### PR TITLE
[LLHD] Add for-loop operation

### DIFF
--- a/include/circt/Dialect/LLHD/IR/LLHD.td
+++ b/include/circt/Dialect/LLHD/IR/LLHD.td
@@ -17,6 +17,7 @@ include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/CallInterfaces.td"
+include "mlir/Interfaces/LoopLikeInterface.td"
 include "mlir/IR/SymbolInterfaces.td"
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/LLHD/IR/LLHDOps.h
+++ b/include/circt/Dialect/LLHD/IR/LLHDOps.h
@@ -17,6 +17,7 @@
 #include "circt/Dialect/LLHD/IR/LLHDEnums.h.inc"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 namespace circt {

--- a/include/circt/Dialect/LLHD/IR/StructureOps.td
+++ b/include/circt/Dialect/LLHD/IR/StructureOps.td
@@ -282,3 +282,135 @@ def LLHD_HaltOp : LLHD_Op<"halt", [Terminator, HasParent<"ProcOp">]> {
 
   let assemblyFormat = "attr-dict";
 }
+
+def LLHD_ForOp : LLHD_Op<"for", [
+      DeclareOpInterfaceMethods<LoopLikeOpInterface>,
+      DeclareOpInterfaceMethods<RegionBranchOpInterface>,
+      RecursiveSideEffects,
+      AllTypesMatch<["lowerBound", "upperBound", "step"]>
+  ]> {
+  let summary = "For-loop operation";
+  let description = [{
+    The "llhd.for" operation represents a loop taking 3 SSA values as operands
+    that represent the lower bound, upper bound and step respectively. The
+    operation defines an SSA value for its induction variable. It has one
+    region representing the loop body. The induction variable is represented as
+    an argument of this region.
+    The range of the for-loop includes the lower bound but does not include the
+    upper bound.
+
+    The body region can contain arbitrarily many blocks, but the CGF has to be a
+    DAG, so no backwards edges are allowed. At least one block has to use the
+    "llhd.yield" terminator, but there can also be arbitrarily many of them. The
+    branch (`br`) and conditional branch (`cond_br`) from the standard dialect
+    are the only two other valid block terminators inside the for-loop body
+    region.
+
+    ```mlir
+    llhd.for (%i = %lb : i32) to %ub step %step {
+      // body
+    }
+    ```
+
+    `llhd.for` can also operate on loop-carried variables and returns the final
+    values after loop termination. The initial values of the variables are
+    passed as additional SSA operands to the "llhd.for" following the 3 loop
+    control SSA values mentioned above. The operation region has equivalent
+    arguments for each variable representing the value of the variable at the
+    current iteration.
+
+    All `llhd.yield` terminators must pass all the current iteration variables
+    to the next iteration or the `llhd.for` result.
+
+    ```mlir
+    /// Consider the sequence of even natural numbers. Calculate the partial sum
+    /// of the first %n terms of this sequence.
+    func @partialSum(%n: i32) -> (i32) {
+      %sum_0 = llhd.const 0 : i32
+      %two = llhd.const 2 : i32
+      // iter_args binds initial values to the loop's region arguments.
+      %sum = llhd.for (%i = %two : i32) to %n step %two
+          iter_args(%sum_iter = %sum_0) -> (i32) {
+        %sum_next = addi %sum_iter, %i : i32
+        // Yield current iteration sum to next iteration %sum_iter or to %sum
+        // if final iteration.
+        llhd.yield %sum_next : i32
+      }
+      return %sum : i32
+    }
+    ```
+
+  }];
+  let arguments = (ins AnySignlessInteger:$lowerBound,
+                       AnySignlessInteger:$upperBound,
+                       AnySignlessInteger:$step,
+                       Variadic<AnyType>:$initArgs);
+  let results = (outs Variadic<AnyType>:$results);
+  let regions = (region AnyRegion:$region);
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<"OpBuilder &builder, OperationState &result, "
+              "Value lowerBound, Value upperBound, Value step, "
+              "ValueRange iterArgs = llvm::None">
+  ];
+
+  let extraClassDeclaration = [{
+    Value getInductionVar() { return getLoopBody().front().getArgument(0); }
+    Block::BlockArgListType getRegionIterArgs() {
+      return getLoopBody().front().getArguments().drop_front();
+    }
+    Operation::operand_range getIterOperands() {
+      return getOperands().drop_front(getNumControlOperands());
+    }
+
+    void setLowerBound(Value bound) { getOperation()->setOperand(0, bound); }
+    void setUpperBound(Value bound) { getOperation()->setOperand(1, bound); }
+    void setStep(Value step) { getOperation()->setOperand(2, step); }
+
+    /// Number of region arguments for loop-carried values
+    unsigned getNumRegionIterArgs() {
+      return getLoopBody().front().getNumArguments() - 1;
+    }
+    /// Number of operands controlling the loop: lb, ub, step
+    unsigned getNumControlOperands() { return 3; }
+    /// Does the operation hold operands for loop-carried values
+    bool hasIterOperands() {
+      return getOperation()->getNumOperands() > getNumControlOperands();
+    }
+    /// Get Number of loop-carried values
+    unsigned getNumIterOperands() {
+      return getOperation()->getNumOperands() - getNumControlOperands();
+    }
+  }];
+
+  let verifier = [{ return ::verify(*this); }];
+}
+
+def LLHD_YieldOp : LLHD_Op<"yield", [
+    NoSideEffect,
+    ReturnLike,
+    Terminator,
+    HasParent<"ForOp">
+  ]> {
+  let summary = "Loop yield and termination operation";
+  let description = [{
+    `llhd.yield` yields SSA values from an `llhd.for` operation.
+    The `llhd.yield` operands must match the parent operation's results.
+
+    Example:
+
+    ```mlir
+    llhd.yield
+    llhd.yield %a, %b, %c : i32, !llhd.array<3xi1>, tuple<i1, i2, i3>
+    ```
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$results);
+  let builders = [
+    OpBuilder<"OpBuilder &builder, OperationState &result",
+              [{ /* nothing to do */ }]>
+  ];
+
+  let assemblyFormat = "attr-dict ($results^ `:` type($results))?";
+}

--- a/include/circt/Dialect/LLHD/IR/StructureOps.td
+++ b/include/circt/Dialect/LLHD/IR/StructureOps.td
@@ -299,7 +299,7 @@ def LLHD_ForOp : LLHD_Op<"for", [
     The range of the for-loop includes the lower bound but does not include the
     upper bound.
 
-    The body region can contain arbitrarily many blocks, but the CGF has to be a
+    The body region can contain arbitrarily many blocks, but the CFG has to be a
     DAG, so no backwards edges are allowed. At least one block has to use the
     "llhd.yield" terminator, but there can also be arbitrarily many of them. The
     branch (`br`) and conditional branch (`cond_br`) from the standard dialect
@@ -350,16 +350,17 @@ def LLHD_ForOp : LLHD_Op<"for", [
 
   let skipDefaultBuilders = 1;
   let builders = [
-    OpBuilder<"OpBuilder &builder, OperationState &result, "
-              "Value lowerBound, Value upperBound, Value step, "
-              "ValueRange iterArgs = llvm::None">
+    OpBuilderDAG<(ins "Value":$lowerBound, "Value":$upperBound, "Value":$step,
+      CArg<"ValueRange", "llvm::None">:$iterArgs)>
   ];
 
   let extraClassDeclaration = [{
     Value getInductionVar() { return getLoopBody().front().getArgument(0); }
+
     Block::BlockArgListType getRegionIterArgs() {
       return getLoopBody().front().getArguments().drop_front();
     }
+
     Operation::operand_range getIterOperands() {
       return getOperands().drop_front(getNumControlOperands());
     }
@@ -368,17 +369,20 @@ def LLHD_ForOp : LLHD_Op<"for", [
     void setUpperBound(Value bound) { getOperation()->setOperand(1, bound); }
     void setStep(Value step) { getOperation()->setOperand(2, step); }
 
-    /// Number of region arguments for loop-carried values
+    // Number of region arguments for loop-carried values
     unsigned getNumRegionIterArgs() {
       return getLoopBody().front().getNumArguments() - 1;
     }
-    /// Number of operands controlling the loop: lb, ub, step
+
+    // Number of operands controlling the loop: lb, ub, step
     unsigned getNumControlOperands() { return 3; }
-    /// Does the operation hold operands for loop-carried values
+
+    // Does the operation hold operands for loop-carried values
     bool hasIterOperands() {
       return getOperation()->getNumOperands() > getNumControlOperands();
     }
-    /// Get Number of loop-carried values
+
+    // Get Number of loop-carried values
     unsigned getNumIterOperands() {
       return getOperation()->getNumOperands() - getNumControlOperands();
     }
@@ -407,10 +411,9 @@ def LLHD_YieldOp : LLHD_Op<"yield", [
   }];
 
   let arguments = (ins Variadic<AnyType>:$results);
-  let builders = [
-    OpBuilder<"OpBuilder &builder, OperationState &result",
-              [{ /* nothing to do */ }]>
-  ];
+  let builders = [OpBuilderDAG<(ins), [{ /* nothing to do */ }]>];
 
   let assemblyFormat = "attr-dict ($results^ `:` type($results))?";
+
+  let verifier = [{ return ::verify(*this); }];
 }

--- a/lib/Dialect/LLHD/IR/LLHDOps.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDOps.cpp
@@ -1151,6 +1151,195 @@ static LogicalResult verify(llhd::RegOp op) {
   return success();
 }
 
+//===----------------------------------------------------------------------===//
+// ForOp
+//===----------------------------------------------------------------------===//
+
+void llhd::ForOp::build(OpBuilder &builder, OperationState &result, Value lb,
+                        Value ub, Value step, ValueRange iterArgs) {
+  result.addOperands({lb, ub, step});
+  result.addOperands(iterArgs);
+  for (Value v : iterArgs)
+    result.addTypes(v.getType());
+  Region *bodyRegion = result.addRegion();
+  bodyRegion->push_back(new Block);
+  Block &bodyBlock = bodyRegion->front();
+  bodyBlock.addArgument(lb.getType());
+  for (Value v : iterArgs)
+    bodyBlock.addArgument(v.getType());
+}
+
+static LogicalResult verifyDAG(DenseMap<Block *, bool> &visited, Block *block) {
+  assert(visited.count(block) &&
+         "Visited map has to be initialized for all blocks in the region!");
+
+  if (visited[block])
+    return failure();
+
+  visited[block] = true;
+  for (Block *succ : block->getSuccessors()) {
+    if (failed(verifyDAG(visited, succ)))
+      return failure();
+  }
+  visited[block] = false;
+  return success();
+}
+
+static LogicalResult verify(llhd::ForOp op) {
+  // Check that the body defines as single block argument for the induction
+  // variable.
+  auto &entryBlock = op.getLoopBody().front();
+  if (!entryBlock.getArgument(0).getType().isSignlessInteger())
+    return op.emitOpError(
+        "expected body first argument to be an signless integer argument for "
+        "the induction variable");
+
+  auto opNumResults = op.getNumResults();
+  // If ForOp defines values, check that the number and types of
+  // the defined values match ForOp initial iter operands and backedge
+  // basic block arguments.
+  if (op.getNumIterOperands() != opNumResults)
+    return op.emitOpError(
+        "mismatch in number of loop-carried values and defined values");
+  if (op.getNumRegionIterArgs() != opNumResults)
+    return op.emitOpError(
+        "mismatch in number of basic block args and defined values");
+  auto iterOperands = op.getIterOperands();
+  auto iterArgs = op.getRegionIterArgs();
+  auto opResults = op.getResults();
+  unsigned i = 0;
+  for (auto e : llvm::zip(iterOperands, iterArgs, opResults)) {
+    if (std::get<0>(e).getType() != std::get<2>(e).getType())
+      return op.emitOpError() << "types mismatch between " << i
+                              << "th iter operand and defined value";
+    if (std::get<1>(e).getType() != std::get<2>(e).getType())
+      return op.emitOpError() << "types mismatch between " << i
+                              << "th iter region arg and defined value";
+
+    i++;
+  }
+
+  // Verify that the CFG of the loop body is a DAG
+  DenseMap<Block *, bool> visited;
+  for (Block &block : op.getLoopBody().getBlocks()) {
+    if (block.empty() || block.back().isKnownNonTerminator())
+      return op.emitOpError(
+          "every block in the loop body must have a terminator!");
+
+    visited.insert(std::make_pair(&block, false));
+  }
+  if (failed(verifyDAG(visited, &entryBlock)))
+    return op.emitOpError("CFG of loop body must be a DAG!");
+
+  return success();
+}
+
+static void print(OpAsmPrinter &p, llhd::ForOp op) {
+  p << op.getOperationName() << " (" << op.getInductionVar() << " = "
+    << op.lowerBound() << " : " << op.lowerBound().getType() << ") to "
+    << op.upperBound() << " step " << op.step();
+
+  if (op.hasIterOperands()) {
+    p << " iter_args(";
+    auto regionArgs = op.getRegionIterArgs();
+    auto operands = op.getIterOperands();
+
+    llvm::interleaveComma(llvm::zip(regionArgs, operands), p, [&](auto it) {
+      p << std::get<0>(it) << " = " << std::get<1>(it);
+    });
+    p << ")";
+    p << " -> (" << op.getResultTypes() << ")";
+  }
+  p.printRegion(op.region(),
+                /*printEntryBlockArgs=*/false,
+                /*printBlockTerminators=*/true);
+  p.printOptionalAttrDict(op.getAttrs());
+}
+
+static ParseResult parseForOp(OpAsmParser &parser, OperationState &result) {
+  OpAsmParser::OperandType inductionVariable, lb, ub, step;
+  Type inductionType;
+  // Parse for loop header
+  if (parser.parseLParen() || parser.parseRegionArgument(inductionVariable) ||
+      parser.parseEqual() || parser.parseOperand(lb) ||
+      parser.parseColonType(inductionType) || parser.parseRParen() ||
+      parser.resolveOperand(lb, inductionType, result.operands) ||
+      parser.parseKeyword("to") || parser.parseOperand(ub) ||
+      parser.resolveOperand(ub, inductionType, result.operands) ||
+      parser.parseKeyword("step") || parser.parseOperand(step) ||
+      parser.resolveOperand(step, inductionType, result.operands))
+    return failure();
+
+  // Parse the optional initial iteration arguments.
+  SmallVector<OpAsmParser::OperandType, 4> regionArgs, operands;
+  SmallVector<Type, 4> argTypes;
+  regionArgs.push_back(inductionVariable);
+
+  if (succeeded(parser.parseOptionalKeyword("iter_args"))) {
+    // Parse assignment list and results type list.
+    if (parser.parseAssignmentList(regionArgs, operands) ||
+        parser.parseArrowTypeList(result.types))
+      return failure();
+    // Resolve input operands.
+    for (auto operand_type : llvm::zip(operands, result.types))
+      if (parser.resolveOperand(std::get<0>(operand_type),
+                                std::get<1>(operand_type), result.operands))
+        return failure();
+  }
+  // Induction variable.
+  argTypes.push_back(inductionType);
+  // Loop carried variables
+  argTypes.append(result.types.begin(), result.types.end());
+  // Parse the body region.
+  Region *body = result.addRegion();
+  if (regionArgs.size() != argTypes.size())
+    return parser.emitError(
+        parser.getNameLoc(),
+        "mismatch in number of loop-carried values and defined values");
+
+  if (parser.parseRegion(*body, regionArgs, argTypes))
+    return failure();
+
+  // Parse the optional attribute list.
+  if (parser.parseOptionalAttrDict(result.attributes))
+    return failure();
+
+  return success();
+}
+
+Region &llhd::ForOp::getLoopBody() { return region(); }
+
+bool llhd::ForOp::isDefinedOutsideOfLoop(Value value) {
+  return !region().isAncestor(value.getParentRegion());
+}
+
+LogicalResult llhd::ForOp::moveOutOfLoop(ArrayRef<Operation *> ops) {
+  for (auto op : ops)
+    op->moveBefore(*this);
+  return success();
+}
+
+/// Given the region at `index`, or the parent operation if `index` is None,
+/// return the successor regions. These are the regions that may be selected
+/// during the flow of control. `operands` is a set of optional attributes that
+/// correspond to a constant value for each operand, or null if that operand is
+/// not a constant.
+void llhd::ForOp::getSuccessorRegions(
+    Optional<unsigned> index, ArrayRef<Attribute> operands,
+    SmallVectorImpl<RegionSuccessor> &regions) {
+  // If the predecessor is the ForOp, branch into the body using the iterator
+  // arguments.
+  if (!index.hasValue()) {
+    regions.push_back(RegionSuccessor(&getLoopBody(), getRegionIterArgs()));
+    return;
+  }
+
+  // Otherwise, the loop may branch back to itself or the parent operation.
+  assert(index.getValue() == 0 && "expected loop region");
+  regions.push_back(RegionSuccessor(&getLoopBody(), getRegionIterArgs()));
+  regions.push_back(RegionSuccessor(getResults()));
+}
+
 #include "circt/Dialect/LLHD/IR/LLHDEnums.cpp.inc"
 
 #define GET_OP_CLASSES

--- a/test/Dialect/LLHD/IR/for.mlir
+++ b/test/Dialect/LLHD/IR/for.mlir
@@ -167,3 +167,28 @@ func @illegal_cyclic_for() {
   }
   return
 }
+
+// -----
+
+func @type_mismatch3(%a : i32) {
+  %zero = llhd.const 0 : i32
+  %one = llhd.const 1 : i32
+  %res = llhd.for (%i = %zero : i32) to %one step %one iter_args(%an = %a) -> (i32) {
+    // expected-error @+1 {{number of results do not match number of parent ForOp results}}
+    llhd.yield %an, %an: i32, i32
+  }
+  return
+}
+
+// -----
+
+func @type_mismatch3(%a : i32) {
+  %zero = llhd.const 0 : i32
+  %one = llhd.const 1 : i32
+  %res = llhd.for (%i = %zero : i32) to %one step %one iter_args(%an = %a) -> (i32) {
+    %0 = llhd.const 0 : i8
+    // expected-error @+1 {{result types do not match parent ForOp result types.}}
+    llhd.yield %0: i8
+  }
+  return
+}

--- a/test/Dialect/LLHD/IR/for.mlir
+++ b/test/Dialect/LLHD/IR/for.mlir
@@ -170,7 +170,7 @@ func @illegal_cyclic_for() {
 
 // -----
 
-func @type_mismatch3(%a : i32) {
+func @yield_number_of_results_mismatch(%a : i32) {
   %zero = llhd.const 0 : i32
   %one = llhd.const 1 : i32
   %res = llhd.for (%i = %zero : i32) to %one step %one iter_args(%an = %a) -> (i32) {
@@ -182,7 +182,7 @@ func @type_mismatch3(%a : i32) {
 
 // -----
 
-func @type_mismatch3(%a : i32) {
+func @yield_result_type_mismatch(%a : i32) {
   %zero = llhd.const 0 : i32
   %one = llhd.const 1 : i32
   %res = llhd.for (%i = %zero : i32) to %one step %one iter_args(%an = %a) -> (i32) {

--- a/test/Dialect/LLHD/IR/forOp.mlir
+++ b/test/Dialect/LLHD/IR/forOp.mlir
@@ -1,0 +1,169 @@
+// RUN: circt-opt %s -mlir-print-op-generic -split-input-file -verify-diagnostics | circt-opt | circt-opt | FileCheck %s
+
+// CHECK-LABEL: @check_simple_i32_for
+func @check_simple_i32_for() {
+  // CHECK: %[[VAL_0:.*]] = llhd.const 0 : i32
+  %zero = llhd.const 0 : i32
+  // CHECK: %[[VAL_1:.*]] = llhd.const 1 : i32
+  %one = llhd.const 1 : i32
+  // CHECK-NEXT: llhd.for (%[[VAL_2:.*]] = %[[VAL_0]] : i32) to %[[VAL_1]] step %[[VAL_1]] {
+  // CHECK-NEXT:   llhd.yield
+  // CHECK-NEXT: }
+  llhd.for (%i = %zero : i32) to %one step %one {
+    llhd.yield
+  }
+  return
+}
+
+// CHECK-LABEL: @check_simple_i8_for
+func @check_simple_i8_for() {
+  // CHECK-NEXT: %[[VAL_0:.*]] = llhd.const 0 : i8
+  %zero = llhd.const 0 : i8
+  // CHECK-NEXT: %[[VAL_1:.*]] = llhd.const 1 : i8
+  %one = llhd.const 1 : i8
+  // CHECK-NEXT: llhd.for (%[[VAL_2:.*]] = %[[VAL_0]] : i8) to %[[VAL_1]] step %[[VAL_1]] {
+  // CHECK-NEXT:   llhd.yield
+  // CHECK-NEXT: }
+  llhd.for (%i = %zero : i8) to %one step %one {
+    llhd.yield
+  }
+  return
+}
+
+// CHECK-LABEL: @check_carried_for
+// CHECK-SAME: %[[VAL_0:.*]]: i32,
+// CHECK-SAME: %[[VAL_1:.*]]: !llhd.array<3xi1>,
+// CHECK-SAME: %[[VAL_2:.*]]: tuple<i1, i2, i3>
+func @check_carried_for(%a : i32, %b : !llhd.array<3xi1>, %c : tuple<i1, i2, i3>) {
+  // CHECK-NEXT: %[[VAL_3:.*]] = llhd.const 0 : i32
+  %zero = llhd.const 0 : i32
+  // CHECK-NEXT: %[[VAL_4:.*]] = llhd.const 1 : i32
+  %one = llhd.const 1 : i32
+  // CHECK-NEXT: %{{.*}}:3 = llhd.for (%[[VAL_6:.*]] = %[[VAL_3]] : i32) to %[[VAL_4]] step %[[VAL_4]] iter_args(%[[VAL_7:.*]] = %[[VAL_0]], %[[VAL_8:.*]] = %[[VAL_1]], %[[VAL_9:.*]] = %[[VAL_2]]) -> (i32, !llhd.array<3xi1>, tuple<i1, i2, i3>) {
+  // CHECK-NEXT:   %[[VAL_10:.*]] = llhd.and %[[VAL_7]], %[[VAL_6]] : i32
+  // CHECK-NEXT:   llhd.yield %[[VAL_10]], %[[VAL_8]], %[[VAL_9]] : i32, !llhd.array<3xi1>, tuple<i1, i2, i3>
+  // CHECK-NEXT: }
+  %res:3 = llhd.for (%i = %zero : i32) to %one step %one iter_args(%an = %a, %bn = %b, %cn = %c) -> (i32, !llhd.array<3xi1>, tuple<i1, i2, i3>) {
+    %0 = llhd.and %an, %i : i32
+    llhd.yield %0, %bn, %cn: i32, !llhd.array<3xi1>, tuple<i1, i2, i3>
+  }
+  return
+}
+
+// CHECK-LABEL: @check_bb_for
+func @check_bb_for() {
+  // CHECK-NEXT: %[[VAL_0:.*]] = llhd.const 0 : i8
+  %zero = llhd.const 0 : i8
+  // CHECK-NEXT: %[[VAL_1:.*]] = llhd.const 1 : i8
+  %one = llhd.const 1 : i8
+  // CHECK-NEXT: llhd.for (%[[VAL_2:.*]] = %[[VAL_0]] : i8) to %[[VAL_1]] step %[[VAL_1]] {
+  // CHECK-NEXT:   %[[VAL_3:.*]] = llhd.eq %[[VAL_2]], %[[VAL_0]] : i8
+  // CHECK-NEXT:   cond_br %[[VAL_3]], ^bb1, ^bb2
+  // CHECK-NEXT: ^bb1:
+  // CHECK-NEXT:   llhd.yield
+  // CHECK-NEXT: ^bb2:
+  // CHECK-NEXT:   llhd.yield
+  // CHECK-NEXT: }
+  llhd.for (%i = %zero : i8) to %one step %one {
+    %cond = llhd.eq %i, %zero : i8
+    cond_br %cond, ^bb1, ^bb2
+  ^bb1:
+    llhd.yield
+  ^bb2:
+    llhd.yield
+  }
+  return
+}
+
+// CHECK-LABEL: @check_nested_for
+func @check_nested_for() {
+  // CHECK-NEXT: %[[VAL_0:.*]] = llhd.const 0 : i8
+  %zero = llhd.const 0 : i8
+  // CHECK-NEXT: %[[VAL_1:.*]] = llhd.const 1 : i8
+  %one = llhd.const 1 : i8
+  // CHECK-NEXT: llhd.for (%[[VAL_2:.*]] = %[[VAL_0]] : i8) to %[[VAL_1]] step %[[VAL_1]] {
+  // CHECK-NEXT:   %[[VAL_3:.*]] = llhd.eq %[[VAL_2]], %[[VAL_0]] : i8
+  // CHECK-NEXT:   cond_br %[[VAL_3]], ^bb1, ^bb2
+  // CHECK-NEXT: ^bb1:
+  // CHECK-NEXT:   llhd.for (%[[VAL_4:.*]] = %[[VAL_2]] : i8) to %[[VAL_1]] step %[[VAL_1]] {
+  // CHECK-NEXT:     br ^bb1
+  // CHECK-NEXT:   ^bb1:
+  // CHECK-NEXT:     llhd.yield
+  // CHECK-NEXT:   }
+  // CHECK-NEXT:   llhd.yield
+  // CHECK-NEXT: ^bb2:
+  // CHECK-NEXT:   llhd.yield
+  // CHECK-NEXT: }
+  llhd.for (%i = %zero : i8) to %one step %one {
+    %cond = llhd.eq %i, %zero : i8
+    cond_br %cond, ^bb1, ^bb2
+  ^bb1:
+    llhd.for (%j = %i : i8) to %one step %one {
+      br ^bb1
+    ^bb1:
+      llhd.yield
+    }
+    llhd.yield
+  ^bb2:
+    llhd.yield
+  }
+  return
+}
+
+// -----
+
+func @illegal_wait_for() {
+  %zero = llhd.const 0 : i8
+  %one = llhd.const 1 : i8
+  llhd.for (%i = %zero : i8) to %one step %one {
+    br ^bb1
+  ^bb1:
+    // expected-error @+1 {{'llhd.wait' op expects parent op 'llhd.proc'}}
+    llhd.wait ^bb2
+  ^bb2:
+    llhd.yield
+  }
+  return
+}
+
+// -----
+
+func @illegal_halt_for() {
+  %zero = llhd.const 0 : i8
+  %one = llhd.const 1 : i8
+  llhd.for (%i = %zero : i8) to %one step %one {
+    %cond = llhd.eq %i, %zero : i8
+    cond_br %cond, ^bb1, ^bb2
+  ^bb1:
+    // expected-error @+1 {{'llhd.halt' op expects parent op 'llhd.proc'}}
+    llhd.halt
+  ^bb2:
+    llhd.yield
+  }
+  return
+}
+
+// -----
+
+func @illegal_empty_for() {
+  %zero = llhd.const 0 : i8
+  %one = llhd.const 1 : i8
+  // expected-error @+1 {{every block in the loop body must have a terminator}}
+  llhd.for (%i = %zero : i8) to %one step %one {
+  }
+  return
+}
+
+// -----
+
+func @illegal_cyclic_for() {
+  %zero = llhd.const 0 : i8
+  %one = llhd.const 1 : i8
+  // expected-error @+1 {{CFG of loop body must be a DAG}}
+  llhd.for (%i = %zero : i8) to %one step %one {
+    br ^bb1
+  ^bb1:
+    br ^bb1
+  }
+  return
+}


### PR DESCRIPTION
* This adds a for-loop operation to LLHD which allows multiple basic
  blocks in its body.
* This allows to preserve loops which can be represented as a for-loop
  during the lowering of (System)Verilog to LLHD and thus easier
  loop-unrolling, analysis, etc.
* For now the for-loop operation is restricted to intra-temporal-region
  loops containing no wait or halt operations. This could be lifted in
  the future.