### PR TITLE
[LLHD] Mark prb as a memory read operation

### DIFF
--- a/include/circt/Dialect/LLHD/IR/SignalOps.td
+++ b/include/circt/Dialect/LLHD/IR/SignalOps.td
@@ -46,7 +46,6 @@ def LLHD_SigOp : LLHD_Op<"sig", [
 }
 
 def LLHD_PrbOp : LLHD_Op<"prb", [
-    NoSideEffect,
     TypesMatchWith<
       "type of 'result' and underlying type of 'signal' have to match.",
       "signal", "result", "$_self.cast<SigType>().getUnderlyingType()">
@@ -72,7 +71,8 @@ def LLHD_PrbOp : LLHD_Op<"prb", [
     ```
   }];
 
-  let arguments = (ins LLHD_AnySigType: $signal);
+  let arguments = (ins Arg<LLHD_AnySigType, "the signal to probe from",
+                           [MemRead]>: $signal);
   let results = (outs LLHD_AnyUnderlyingType: $result);
 
   let assemblyFormat = "$signal attr-dict `:` type($signal)";
@@ -113,7 +113,8 @@ def LLHD_DrvOp : LLHD_Op<"drv", [
     ```
   }];
 
-  let arguments = (ins LLHD_AnySigType: $signal,
+  let arguments = (ins Arg<LLHD_AnySigType, "the signal to drive to",
+                           [MemWrite]>: $signal,
                        LLHD_AnyUnderlyingType: $value,
                        LLHD_TimeType: $time,
                        Optional<I1>: $enable);

--- a/test/Dialect/LLHD/Canonicalization/signals.mlir
+++ b/test/Dialect/LLHD/Canonicalization/signals.mlir
@@ -1,0 +1,14 @@
+// RUN: circt-opt %s -cse | FileCheck %s
+
+// CHECK-LABEL: @check_dce_prb_but_not_cse
+// CHECK-SAME: %[[SIG:.*]]: !llhd.sig<i32>
+func @check_dce_prb_but_not_cse(%sig : !llhd.sig<i32>) -> (i32, i32) {
+  // CHECK-NEXT: %[[P1:.*]] = llhd.prb %[[SIG]] : !llhd.sig<i32>
+  %1 = llhd.prb %sig : !llhd.sig<i32>
+  // CHECK-NEXT: %[[P2:.*]] = llhd.prb %[[SIG]] : !llhd.sig<i32>
+  %2 = llhd.prb %sig : !llhd.sig<i32>
+  %3 = llhd.prb %sig : !llhd.sig<i32>
+
+  // CHECK-NEXT: return %[[P1]], %[[P2]]
+  return %1, %2 : i32, i32
+}


### PR DESCRIPTION
This fixes a bug where prb operations of the same signal were CSEd despite being in different temporal regions