### PR TITLE
Add a Handshake visitor

### DIFF
--- a/include/circt/Dialect/Handshake/Visitor.h
+++ b/include/circt/Dialect/Handshake/Visitor.h
@@ -22,7 +22,7 @@ template <typename ConcreteType, typename ResultType = void,
           typename... ExtraArgs>
 class HandshakeVisitor {
 public:
-  ResultType dispatchVisitor(Operation *op, ExtraArgs... args) {
+  ResultType dispatchHandshakeVisitor(Operation *op, ExtraArgs... args) {
     auto *thisCast = static_cast<ConcreteType *>(this);
     return TypeSwitch<Operation *, ResultType>(op)
         .template Case<
@@ -31,7 +31,7 @@ public:
             EndOp, ForkOp, FuncOp, InstanceOp, JoinOp, LazyForkOp, LoadOp,
             MemoryOp, MergeOp, MuxOp, ReturnOp, SinkOp, SourceOp, StartOp,
             StoreOp, TerminatorOp>([&](auto opNode) -> ResultType {
-          return thisCast->visitHandshakeOp(opNode, args...);
+          return thisCast->visitHandshake(opNode, args...);
         })
         .Default([&](auto opNode) -> ResultType {
           return thisCast->visitInvalidOp(op, args...);
@@ -51,7 +51,7 @@ public:
   }
 
 #define HANDLE(OPTYPE)                                                         \
-  ResultType visitHandshakeOp(OPTYPE op, ExtraArgs... args) {                  \
+  ResultType visitHandshake(OPTYPE op, ExtraArgs... args) {                    \
     return static_cast<ConcreteType *>(this)->visitUnhandledOp(op, args...);   \
   }
 
@@ -90,7 +90,7 @@ template <typename ConcreteType, typename ResultType = void,
           typename... ExtraArgs>
 class StdExprVisitor {
 public:
-  ResultType dispatchVisitor(Operation *op, ExtraArgs... args) {
+  ResultType dispatchStdExprVisitor(Operation *op, ExtraArgs... args) {
     auto *thisCast = static_cast<ConcreteType *>(this);
     return TypeSwitch<Operation *, ResultType>(op)
         .template Case<

--- a/include/circt/Dialect/Handshake/Visitor.h
+++ b/include/circt/Dialect/Handshake/Visitor.h
@@ -40,7 +40,7 @@ public:
 
   /// This callback is invoked on any invalid operations.
   ResultType visitInvalidOp(Operation *op, ExtraArgs... args) {
-    op->emitOpError("is unsupported operation.");
+    op->emitOpError("is unsupported operation");
     abort();
   }
 
@@ -108,7 +108,7 @@ public:
 
   /// This callback is invoked on any invalid operations.
   ResultType visitInvalidOp(Operation *op, ExtraArgs... args) {
-    op->emitOpError("is unsupported operation.");
+    op->emitOpError("is unsupported operation");
     abort();
   }
 

--- a/include/circt/Dialect/Handshake/Visitor.h
+++ b/include/circt/Dialect/Handshake/Visitor.h
@@ -1,0 +1,146 @@
+//===- Handshake/Visitors.h - Handshake Dialect Visitors --------*- C++ -*-===//
+//
+// Copyright 2020 The CIRCT Authors.
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_HANDSHAKE_VISITORS_H
+#define CIRCT_DIALECT_HANDSHAKE_VISITORS_H
+
+#include "circt/Dialect/Handshake/HandshakeOps.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+namespace circt {
+namespace handshake {
+
+/// HandshakeVisitor is a visitor for handshake nodes.
+template <typename ConcreteType, typename ResultType = void,
+          typename... ExtraArgs>
+class HandshakeVisitor {
+public:
+  ResultType dispatchVisitor(Operation *op, ExtraArgs... args) {
+    auto *thisCast = static_cast<ConcreteType *>(this);
+    return TypeSwitch<Operation *, ResultType>(op)
+        .template Case<
+            // Handshake nodes.
+            BranchOp, BufferOp, ConditionalBranchOp, ConstantOp, ControlMergeOp,
+            EndOp, ForkOp, FuncOp, InstanceOp, JoinOp, LazyForkOp, LoadOp,
+            MemoryOp, MergeOp, MuxOp, ReturnOp, SinkOp, SourceOp, StartOp,
+            StoreOp, TerminatorOp>([&](auto opNode) -> ResultType {
+          return thisCast->visitHandshakeOp(opNode, args...);
+        })
+        .Default([&](auto opNode) -> ResultType {
+          return thisCast->visitInvalidOp(op, args...);
+        });
+  }
+
+  /// This callback is invoked on any invalid operations.
+  ResultType visitInvalidOp(Operation *op, ExtraArgs... args) {
+    op->emitOpError("is unsupported operation.");
+    abort();
+  }
+
+  /// This callback is invoked on any operations that are not handled by the
+  /// concrete visitor.
+  ResultType visitUnhandledOp(Operation *op, ExtraArgs... args) {
+    return ResultType();
+  }
+
+#define HANDLE(OPTYPE)                                                         \
+  ResultType visitHandshakeOp(OPTYPE op, ExtraArgs... args) {                  \
+    return static_cast<ConcreteType *>(this)->visitUnhandledOp(op, args...);   \
+  }
+
+  // Handshake nodes.
+  HANDLE(BranchOp);
+  HANDLE(BufferOp);
+  HANDLE(ConditionalBranchOp);
+  HANDLE(ConstantOp);
+  HANDLE(ControlMergeOp);
+  HANDLE(EndOp);
+  HANDLE(ForkOp);
+  HANDLE(FuncOp);
+  HANDLE(InstanceOp);
+  HANDLE(JoinOp);
+  HANDLE(LazyForkOp);
+  HANDLE(LoadOp);
+  HANDLE(MemoryOp);
+  HANDLE(MergeOp);
+  HANDLE(MuxOp);
+  HANDLE(ReturnOp);
+  HANDLE(SinkOp);
+  HANDLE(SourceOp);
+  HANDLE(StartOp);
+  HANDLE(StoreOp);
+  HANDLE(TerminatorOp);
+#undef HANDLE
+};
+
+} // namespace handshake
+} // namespace circt
+
+namespace mlir {
+
+/// StdExprVisitor is a visitor for standard expression nodes.
+template <typename ConcreteType, typename ResultType = void,
+          typename... ExtraArgs>
+class StdExprVisitor {
+public:
+  ResultType dispatchVisitor(Operation *op, ExtraArgs... args) {
+    auto *thisCast = static_cast<ConcreteType *>(this);
+    return TypeSwitch<Operation *, ResultType>(op)
+        .template Case<
+            // Integer binary expressions.
+            CmpIOp, AddIOp, SubIOp, MulIOp, SignedDivIOp, SignedRemIOp,
+            UnsignedDivIOp, UnsignedRemIOp, XOrOp, AndOp, OrOp, ShiftLeftOp,
+            SignedShiftRightOp, UnsignedShiftRightOp>(
+            [&](auto opNode) -> ResultType {
+              return thisCast->visitStdExpr(opNode, args...);
+            })
+        .Default([&](auto opNode) -> ResultType {
+          return thisCast->visitInvalidOp(op, args...);
+        });
+  }
+
+  /// This callback is invoked on any invalid operations.
+  ResultType visitInvalidOp(Operation *op, ExtraArgs... args) {
+    op->emitOpError("is unsupported operation.");
+    abort();
+  }
+
+  /// This callback is invoked on any operations that are not handled by the
+  /// concrete visitor.
+  ResultType visitUnhandledOp(Operation *op, ExtraArgs... args) {
+    return ResultType();
+  }
+
+#define HANDLE(OPTYPE)                                                         \
+  ResultType visitStdExpr(OPTYPE op, ExtraArgs... args) {                      \
+    return static_cast<ConcreteType *>(this)->visitUnhandledOp(op, args...);   \
+  }
+
+  // Integer binary expressions.
+  HANDLE(CmpIOp);
+  HANDLE(AddIOp);
+  HANDLE(SubIOp);
+  HANDLE(MulIOp);
+  HANDLE(SignedDivIOp);
+  HANDLE(SignedRemIOp);
+  HANDLE(UnsignedDivIOp);
+  HANDLE(UnsignedRemIOp);
+  HANDLE(XOrOp);
+  HANDLE(AndOp);
+  HANDLE(OrOp);
+  HANDLE(ShiftLeftOp);
+  HANDLE(SignedShiftRightOp);
+  HANDLE(UnsignedShiftRightOp);
+#undef HANDLE
+};
+
+} // namespace mlir
+
+#endif // CIRCT_DIALECT_HANDSHAKE_VISITORS_H


### PR DESCRIPTION
This visitor is as same as the FIRRTL visitor. This is for a better experience when doing Handshake to FIRRTL lowering or any other Handshake analysis/lowering.