### PR TITLE
Rename RTLInstanceOp verifier to verifyRTLInstanceOp

### DIFF
--- a/include/circt/Dialect/RTL/Structure.td
+++ b/include/circt/Dialect/RTL/Structure.td
@@ -77,7 +77,7 @@ def RTLInstanceOp : RTLOp<"instance", []> {
      $instanceName $moduleName `(` $inputs `)` attr-dict `:` type($inputs)
   }];
 
-  let verifier = [{ return ::verifyFModuleOp(*this); }];
+  let verifier = [{ return ::verifyRTLInstanceOp(*this); }];
 }
 
 def DoneOp : RTLOp<"done", [Terminator, HasParent<"RTLModuleOp">]> {


### PR DESCRIPTION
This renames a previously misnamed verifier in RTL's Structure.td that was causing build issues. 