### PR TITLE
[FIRRTL] Add Circuit Op Verification

### DIFF
--- a/include/circt/Dialect/FIRRTL/OpStructure.td
+++ b/include/circt/Dialect/FIRRTL/OpStructure.td
@@ -35,6 +35,8 @@ def CircuitOp : FIRRTLOp<"circuit",
   
   let printer = [{ return ::print(p, *this); }];
   let parser = [{ return ::parse$cppClass(parser, result); }];
+
+  let verifier = [{ return ::verifyCircuitOp(*this); }];
 }
 
 def FModuleOp : FIRRTLOp<"module",

--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -58,6 +58,25 @@ static ParseResult parseCircuitOp(OpAsmParser &parser, OperationState &result) {
   return success();
 }
 
+static LogicalResult verifyCircuitOp(CircuitOp &circuit) {
+  StringRef main = circuit.name();
+
+  // Check that the circuit has a non-empty name.
+  if (main.empty()) {
+    circuit.emitOpError("must have a non-empty name");
+    return failure();
+  }
+
+  // Check that a module matching the "main" module exists in the circuit.
+  if (!circuit.lookupSymbol(main)) {
+    circuit.emitOpError("must contain one module that matches main name '" +
+                        main + "'");
+    return failure();
+  }
+
+  return success();
+}
+
 Region &CircuitOp::getBodyRegion() { return getOperation()->getRegion(0); }
 Block *CircuitOp::getBody() { return &getBodyRegion().front(); }
 

--- a/test/EmitVerilog/rtl-dialect.mlir
+++ b/test/EmitVerilog/rtl-dialect.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-translate %s -emit-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
 
-firrtl.circuit "Circuit" {
+firrtl.circuit "M1" {
   firrtl.module @M1(%x : !firrtl.uint<8>,
                     %y : !firrtl.flip<uint<8>>,
                     %z : i8) {

--- a/test/EmitVerilog/sv-dialect.mlir
+++ b/test/EmitVerilog/sv-dialect.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-translate %s -emit-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
 
-firrtl.circuit "Circuit" {
+firrtl.circuit "M1" {
   // CHECK-LABEL: module M1(
   firrtl.module @M1(%clock : i1, %cond : i1, %val : i8) {
 

--- a/test/EmitVerilog/verilog-basic.fir
+++ b/test/EmitVerilog/verilog-basic.fir
@@ -3,7 +3,7 @@
 ; Some day this should filecheck:
 ; RUN: circt-translate -parse-fir --mlir-print-debuginfo %s | circt-opt -pass-pipeline='firrtl.circuit(lower-firrtl-to-rtl)' | circt-translate -emit-verilog -verify-diagnostics
 
-circuit Xorr :
+circuit inputs_only :
 
   module inputs_only :
     input a: UInt<1>

--- a/test/EmitVerilog/verilog-weird.mlir
+++ b/test/EmitVerilog/verilog-weird.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-translate %s -emit-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
 
-firrtl.circuit "Circuit" {
+firrtl.circuit "M1" {
   firrtl.module @M1(%x : !firrtl.uint<8> { firrtl.name = "y"},
                     %y : !firrtl.flip<uint<8>>) {
     firrtl.connect %y, %x : !firrtl.flip<uint<8>>, !firrtl.uint<8>

--- a/test/FIRParser/basic.fir
+++ b/test/FIRParser/basic.fir
@@ -1,6 +1,6 @@
 ; RUN: circt-translate -parse-fir -verify-diagnostics %s | circt-opt | FileCheck %s
 
-circuit basic :     ; CHECK: firrtl.circuit "basic" {
+circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
   ; CHECK-LABEL: firrtl.module @MyModule(%in: !firrtl.uint, %out: !firrtl.flip<uint<8>>) {
   module MyModule :   @[FooBar.scala 369:27]

--- a/test/FIRParser/locations.fir
+++ b/test/FIRParser/locations.fir
@@ -1,6 +1,6 @@
 ; RUN: circt-translate -parse-fir --mlir-print-debuginfo -verify-diagnostics %s | FileCheck %s
 
-circuit basic :  @[CIRCUIT.scala 127]
+circuit MyModule :  @[CIRCUIT.scala 127]
 
   ; CHECK-LABEL: firrtl.module @MyModule(%in: !firrtl.uint, %out: !firrtl.flip<uint<8>>) {
   module MyModule :   @[FooBar.scala 369:27]

--- a/test/firrtl/canonicalization.mlir
+++ b/test/firrtl/canonicalization.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt -canonicalize %s | FileCheck %s
 
-firrtl.circuit "Circuit" {
+firrtl.circuit "And" {
 
 // CHECK-LABEL: firrtl.module @And
 firrtl.module @And(%in: !firrtl.uint<4>,

--- a/test/firrtl/cse.mlir
+++ b/test/firrtl/cse.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt -cse %s | FileCheck %s
 
-firrtl.circuit "Circuit" {
+firrtl.circuit "And" {
 
 // CHECK-LABEL: firrtl.module @And
 firrtl.module @And(%in1: !firrtl.uint<4>, %in2: !firrtl.uint<4>,

--- a/test/firrtl/errors.mlir
+++ b/test/firrtl/errors.mlir
@@ -35,9 +35,9 @@ firrtl.circuit "MyModule" {
 
 // -----
 
+// expected-error @+1 {{'firrtl.circuit' op must contain one module that matches main name ('MyCircuit')}}
 firrtl.circuit "MyCircuit" {
 
-// expected-error @+1 {{'firrtl.module' op requires string attribute 'sym_name'}}
 "firrtl.module"() ( {
   "firrtl.done"() : () -> ()
 }) { type = () -> ()} : () -> ()

--- a/test/firrtl/errors.mlir
+++ b/test/firrtl/errors.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt %s -split-input-file -verify-diagnostics
 
-firrtl.circuit "Circuit" {
+firrtl.circuit "X" {
 
 firrtl.module @X(%b : !firrtl.unknowntype) {
   // expected-error @-1 {{unknown firrtl type}}
@@ -10,7 +10,7 @@ firrtl.module @X(%b : !firrtl.unknowntype) {
 
 // -----
 
-firrtl.circuit "Circuit" {
+firrtl.circuit "X" {
 
 firrtl.module @X(%b : !firrtl.uint<32>, %d : !firrtl.uint<16>, %out : !firrtl.uint) {
   // expected-error @+1 {{'firrtl.add' op expected 2 operands, but found 3}}
@@ -21,7 +21,7 @@ firrtl.module @X(%b : !firrtl.uint<32>, %d : !firrtl.uint<16>, %out : !firrtl.ui
 
 // -----
 
-firrtl.circuit "Circuit" {
+firrtl.circuit "MyModule" {
 
 // expected-error @+2 {{'firrtl.module' op expects regions to end with 'firrtl.done'}}
 // expected-note @+1 {{implies 'firrtl.done'}}
@@ -35,7 +35,7 @@ firrtl.circuit "Circuit" {
 
 // -----
 
-firrtl.circuit "Circuit" {
+firrtl.circuit "MyCircuit" {
 
 // expected-error @+1 {{'firrtl.module' op requires string attribute 'sym_name'}}
 "firrtl.module"() ( {

--- a/test/firrtl/errors.mlir
+++ b/test/firrtl/errors.mlir
@@ -35,7 +35,7 @@ firrtl.circuit "MyModule" {
 
 // -----
 
-// expected-error @+1 {{'firrtl.circuit' op must contain one module that matches main name ('MyCircuit')}}
+// expected-error @+1 {{'firrtl.circuit' op must contain one module that matches main name 'MyCircuit'}}
 firrtl.circuit "MyCircuit" {
 
 "firrtl.module"() ( {
@@ -49,3 +49,18 @@ firrtl.circuit "MyCircuit" {
 
 // expected-error @+1 {{'firrtl.module' op should be embedded into a firrtl.circuit}}
 firrtl.module @X() {}
+
+// -----
+
+// expected-error @+1 {{'firrtl.circuit' op must contain one module that matches main name 'Foo'}}
+firrtl.circuit "Foo" {
+
+firrtl.module @Bar() {}
+
+}
+
+// -----
+
+// expected-error @+1 {{'firrtl.circuit' op must have a non-empty name}}
+firrtl.circuit "" {
+}

--- a/test/firrtl/lower-to-rtl.mlir
+++ b/test/firrtl/lower-to-rtl.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt -pass-pipeline='firrtl.circuit(lower-firrtl-to-rtl)' %s | FileCheck %s
 
- firrtl.circuit "Circuit" {
+ firrtl.circuit "Simple" {
 
   // CHECK-LABEL: firrtl.module @Simple
   firrtl.module @Simple(%in1: !firrtl.uint<4>,

--- a/test/firrtl/test.mlir
+++ b/test/firrtl/test.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt %s | FileCheck %s
 
-firrtl.circuit "Circuit" {
+firrtl.circuit "MyModule" {
 
 //module MyModule :
 //  input in: UInt<8>

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -2,13 +2,13 @@
 ; RUN: firtool %s --format=fir -verilog |           FileCheck %s --check-prefix=VERILOG
 ; RUN: firtool %s --format=fir -mlir -lower-to-rtl | circt-opt | FileCheck %s --check-prefix=MLIRLOWER
 
-circuit fir_test :
+circuit test_mod :
   module test_mod :
     input a: UInt<1>
     output b: UInt<1>
     b <= a
 
-; MLIR: firrtl.circuit "fir_test" {
+; MLIR: firrtl.circuit "test_mod" {
 
 ; MLIR-LABEL: firrtl.module @test_mod(%a: !firrtl.uint<1>, %b: !firrtl.flip<uint<1>>) {
 ; MLIR-NEXT:    firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.uint<1>
@@ -20,7 +20,7 @@ circuit fir_test :
 ; VERILOG-NEXT :   assign b = a;
 ; VERILOG-NEXT : endmodule
 
-; MLIRLOWER: firrtl.circuit "fir_test" {
+; MLIRLOWER: firrtl.circuit "test_mod" {
 ; MLIRLOWER:   firrtl.module @test_mod(%a: !firrtl.uint<1>, %b: !firrtl.flip<uint<1>>) {
 ; MLIRLOWER:     %0 = firrtl.stdIntCast %b : (!firrtl.flip<uint<1>>) -> i1
 ; MLIRLOWER:     %1 = firrtl.stdIntCast %a : (!firrtl.uint<1>) -> i1

--- a/test/firtool/firtool.mlir
+++ b/test/firtool/firtool.mlir
@@ -2,17 +2,17 @@
 // RUN: firtool %s --format=mlir -verilog |           FileCheck %s --check-prefix=VERILOG
 
 firrtl.circuit "Top" {
-  firrtl.module @MyModule(%in : !firrtl.uint<8>,
+  firrtl.module @Top(%in : !firrtl.uint<8>,
                           %out : !firrtl.flip<uint<8>>) {
     firrtl.connect %out, %in : !firrtl.flip<uint<8>>, !firrtl.uint<8>
   }
 }
 
-// MLIR-LABEL: firrtl.module @MyModule(%in: !firrtl.uint<8>, %out: !firrtl.flip<uint<8>>) {
+// MLIR-LABEL: firrtl.module @Top(%in: !firrtl.uint<8>, %out: !firrtl.flip<uint<8>>) {
 // MLIR-NEXT:    firrtl.connect %out, %in : !firrtl.flip<uint<8>>, !firrtl.uint<8>
 // MLIR-NEXT:  }
 
-// VERILOG-LABEL: module MyModule(
+// VERILOG-LABEL: module Top(
 // VERILOG-NEXT :   input  [7:0] in,
 // VERILOG-NEXT :   output [7:0] out);
 // VERILOG-NEXT :   assign out = in;

--- a/test/firtool/optimizations.fir
+++ b/test/firtool/optimizations.fir
@@ -1,7 +1,7 @@
 ; RUN: firtool %s --format=fir              | circt-opt | FileCheck %s --check-prefix=OPT
 ; RUN: firtool %s --format=fir -disable-opt | circt-opt | FileCheck %s --check-prefix=NOOPT
 
-circuit optimizations :
+circuit test_cse :
   module test_cse :
     input a: UInt<4>
     output b: UInt<4>


### PR DESCRIPTION
This adds some simple verification of the FIRRTL dialect circuit op. Namely, it requires that a circuit name exists (which is nonsensical for FIRRTL IR) and that the circuit name matches a module in the circuit. 

The latter condition disallows circuits like the following which is illegal FIRRTL IR:

```
circuit Foo:
  module Bar:
    skip
```

A number of test cases were written like the illegal example. The first commit in this patch series corrects these tests. The second commit adds and uses the circuit verifier. The third commit adds a test that the example circuit (above) in MLIR dialect is rejected.