### PR TITLE
[FIRRTL] Improve RegOp/RegInitOp Verification

### DIFF
--- a/include/circt/Dialect/FIRRTL/OpDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/OpDeclarations.td
@@ -101,7 +101,7 @@ def RegOp : FIRRTLOp<"reg", [/*MemAlloc*/]> {
     ```
     }];
 
-  let arguments = (ins AnyType:$clockVal, OptionalAttr<StrAttr>:$name);
+  let arguments = (ins ClockType:$clockVal, OptionalAttr<StrAttr>:$name);
   let results = (outs AnyType:$result);
   
   let assemblyFormat = [{
@@ -118,7 +118,7 @@ def RegInitOp : FIRRTLOp<"reginit", [/*MemAlloc*/]> {
     ```
     }];
 
-  let arguments = (ins AnyType:$clockVal, AnyType:$resetSignal, 
+  let arguments = (ins ClockType:$clockVal, AnyType:$resetSignal,
                        AnyType:$resetValue, OptionalAttr<StrAttr>:$name);
   let results = (outs AnyType:$result);
   

--- a/include/circt/Dialect/FIRRTL/OpDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/OpDeclarations.td
@@ -118,7 +118,7 @@ def RegInitOp : FIRRTLOp<"reginit", [/*MemAlloc*/]> {
     ```
     }];
 
-  let arguments = (ins ClockType:$clockVal, AnyType:$resetSignal,
+  let arguments = (ins ClockType:$clockVal, ResetType:$resetSignal,
                        AnyType:$resetValue, OptionalAttr<StrAttr>:$name);
   let results = (outs AnyType:$result);
   

--- a/include/circt/Dialect/FIRRTL/OpDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/OpDeclarations.td
@@ -114,7 +114,7 @@ def RegInitOp : FIRRTLOp<"reginit", [/*MemAlloc*/]> {
   let description = [{
     Declare a new register:
     ```
-      %name = firrtl.reg %clockVal, %resetSignal, %resetValue : t1
+      %name = firrtl.reginit %clockVal, %resetSignal, %resetValue : t1
     ```
     }];
 

--- a/include/circt/Dialect/FIRRTL/Types.h
+++ b/include/circt/Dialect/FIRRTL/Types.h
@@ -58,6 +58,9 @@ public:
                     AnalogType, FlipType, BundleType, FVectorType>();
   }
 
+  /// Return true if this is a valid "reset" type.
+  bool isResetType();
+
 protected:
   using Type::Type;
 };

--- a/include/circt/Dialect/FIRRTL/Types.td
+++ b/include/circt/Dialect/FIRRTL/Types.td
@@ -19,6 +19,7 @@ def UInt1Type : Type<CPred<"$_self.isa<UIntType>() && "
                            "$_self.cast<UIntType>().getWidth() == 1">,
                            "UInt<1>">,
                 BuildableType<"UIntType::get($_builder.getContext(), 1)">;
+def ResetType : Type<CPred<"$_self.cast<FIRRTLType>().isResetType()">, "Reset, AsyncReset, or UInt<1>">;
 
 //===----------------------------------------------------------------------===//
 // FIRRTL Enum Definitions

--- a/lib/Dialect/FIRRTL/Types.cpp
+++ b/lib/Dialect/FIRRTL/Types.cpp
@@ -264,6 +264,22 @@ int32_t FIRRTLType::getBitWidthOrSentinel() {
       });
 }
 
+/// Return true if this is a type usable as a reset. This must be
+/// either an abstract reset, a concrete 1-bit UInt, or an
+/// asynchronous reset.
+bool FIRRTLType::isResetType() {
+  return TypeSwitch<FIRRTLType, bool>(*this)
+    .Case<ResetType, AsyncResetType>([](Type) {
+      return true;
+    })
+    .Case<UIntType>([](UIntType a) {
+      return a.getWidth() == 1;
+    })
+    .Default([](Type) {
+      return false;
+    });
+}
+
 //===----------------------------------------------------------------------===//
 // IntType
 //===----------------------------------------------------------------------===//

--- a/test/firrtl/errors.mlir
+++ b/test/firrtl/errors.mlir
@@ -64,3 +64,22 @@ firrtl.module @Bar() {}
 // expected-error @+1 {{'firrtl.circuit' op must have a non-empty name}}
 firrtl.circuit "" {
 }
+
+// -----
+
+firrtl.circuit "Foo" {
+  firrtl.module @Foo(%clk: !firrtl.uint<1>, %reset: !firrtl.uint<1>) {
+    // expected-error @+1 {{'firrtl.reg' op operand #0 must be clock, but got '!firrtl.uint<1>'}}
+    %a = firrtl.reg %clk {name = "a"} : (!firrtl.uint<1>) -> !firrtl.uint<1>
+  }
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+  firrtl.module @Foo(%clk: !firrtl.uint<1>, %reset: !firrtl.uint<1>) {
+    %zero = firrtl.constant(0 : ui1) : !firrtl.uint<1>
+    // expected-error @+1 {{'firrtl.reginit' op operand #0 must be clock, but got '!firrtl.uint<1>'}}
+    %a = firrtl.reginit %clk, %reset, %zero {name = "a"} : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  }
+}

--- a/test/firrtl/errors.mlir
+++ b/test/firrtl/errors.mlir
@@ -83,3 +83,13 @@ firrtl.circuit "Foo" {
     %a = firrtl.reginit %clk, %reset, %zero {name = "a"} : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   }
 }
+
+// -----
+
+firrtl.circuit "Foo" {
+  firrtl.module @Foo(%clk: !firrtl.clock, %reset: !firrtl.uint<2>) {
+    %zero = firrtl.constant(0 : ui1) : !firrtl.uint<1>
+    // expected-error @+1 {{'firrtl.reginit' op operand #1 must be Reset, AsyncReset, or UInt<1>, but got '!firrtl.uint<2>'}}
+    %a = firrtl.reginit %clk, %reset, %zero {name = "a"} : (!firrtl.clock, !firrtl.uint<2>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  }
+}


### PR DESCRIPTION
Restricts the type of connections to the clock and register inputs of `RegOp` and `RegInitOp`. Previously these were any type. This PR adds the following checks:

- The clock connection must be a `ClockType`
- The reset connection must be a `ResetType`

A constraint is added to `ResetType` to facilitate the second check. Specifically, a `ResetType` must now be one of: an abstract reset type, a concrete 1-bit UInt, or a concrete asynchronous reset.

Adds tests to check the clock type guarantee for `RegOp` and `RegInitOp`. Adds a test that a 2-bit UInt reset connection for `RegInitOp` is rejected.

This PR includes a miscellaneous documentation fix that corrects the `RegInitOp` description.

This PR works towards #80.