### PR TITLE
Remove global dialect registry

### DIFF
--- a/tools/circt-opt/circt-opt.cpp
+++ b/tools/circt-opt/circt-opt.cpp
@@ -69,11 +69,11 @@ static cl::opt<bool> allowUnregisteredDialects(
 int main(int argc, char **argv) {
   InitLLVM y(argc, argv);
 
-  enableGlobalDialectRegistry(true);
+  DialectRegistry registry;
 
   // Register MLIR stuff
-  registerDialect<StandardOpsDialect>();
-  registerDialect<LLVM::LLVMDialect>();
+  registry.insert<StandardOpsDialect>();
+  registry.insert<LLVM::LLVMDialect>();
 
 // Register the standard passes we want.
 #include "mlir/Transforms/Passes.h.inc"
@@ -89,18 +89,18 @@ int main(int argc, char **argv) {
   registerAsmPrinterCLOptions();
 
   // Register our dialects.
-  registerDialect<firrtl::FIRRTLDialect>();
+  registry.insert<firrtl::FIRRTLDialect>();
   firrtl::registerFIRRTLPasses();
 
-  registerDialect<handshake::HandshakeOpsDialect>();
-  registerDialect<staticlogic::StaticLogicDialect>();
+  registry.insert<handshake::HandshakeOpsDialect>();
+  registry.insert<staticlogic::StaticLogicDialect>();
   staticlogic::registerStandardToStaticLogicPasses();
   handshake::registerStandardToHandshakePasses();
   handshake::registerHandshakeToFIRRTLPasses();
 
-  registerDialect<llhd::LLHDDialect>();
-  registerDialect<rtl::RTLDialect>();
-  registerDialect<sv::SVDialect>();
+  registry.insert<llhd::LLHDDialect>();
+  registry.insert<rtl::RTLDialect>();
+  registry.insert<sv::SVDialect>();
 
   llhd::initLLHDTransformationPasses();
   llhd::initLLHDToLLVMPass();
@@ -110,11 +110,10 @@ int main(int argc, char **argv) {
   // Parse pass names in main to ensure static initialization completed.
   cl::ParseCommandLineOptions(argc, argv, "circt modular optimizer driver\n");
 
-  MLIRContext context;
   if (showDialects) {
     llvm::outs() << "Registered Dialects:\n";
-    for (Dialect *dialect : context.getLoadedDialects()) {
-      llvm::outs() << dialect->getNamespace() << "\n";
+    for (const auto &nameAndRegistrationIt : registry) {
+      llvm::outs() << nameAndRegistrationIt.first << "\n";
     }
     return 0;
   }
@@ -134,7 +133,6 @@ int main(int argc, char **argv) {
   }
 
   return failed(MlirOptMain(output->os(), std::move(file), passPipeline,
-                            context.getDialectRegistry(), splitInputFile,
-                            verifyDiagnostics, verifyPasses,
-                            allowUnregisteredDialects));
+                            registry, splitInputFile, verifyDiagnostics,
+                            verifyPasses, allowUnregisteredDialects));
 }

--- a/tools/circt-translate/circt-translate.cpp
+++ b/tools/circt-translate/circt-translate.cpp
@@ -48,24 +48,15 @@ static llvm::cl::opt<bool> verifyDiagnostics(
     llvm::cl::init(false));
 
 int main(int argc, char **argv) {
-  enableGlobalDialectRegistry(true);
-
   // Register MLIR stuff.
   registerAsmPrinterCLOptions();
   registerMLIRContextCLOptions();
-  registerDialect<StandardOpsDialect>();
-
-  // RTL and SV.
-  registerDialect<rtl::RTLDialect>();
-  registerDialect<sv::SVDialect>();
 
   // Register FIRRTL stuff.
-  registerDialect<firrtl::FIRRTLDialect>();
   registerFIRParserTranslation();
   registerVerilogEmitterTranslation();
 
   // LLHD
-  registerDialect<llhd::LLHDDialect>();
   llhd::registerToVerilogTranslation();
 
   llvm::InitLLVM y(argc, argv);
@@ -94,6 +85,10 @@ int main(int argc, char **argv) {
   auto processBuffer = [&](std::unique_ptr<llvm::MemoryBuffer> ownedBuffer,
                            raw_ostream &os) {
     MLIRContext context;
+
+    // Load relevant dialects
+    context.loadDialect<StandardOpsDialect, rtl::RTLDialect, sv::SVDialect,
+                        firrtl::FIRRTLDialect, llhd::LLHDDialect>();
 
     // Nothing here is threaded.  Disable synchronization overhead.
     context.disableMultithreading();

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -73,6 +73,10 @@ static LogicalResult
 processBuffer(std::unique_ptr<llvm::MemoryBuffer> ownedBuffer,
               raw_ostream &os) {
   MLIRContext context;
+
+  // Register our dialects.
+  context.loadDialect<firrtl::FIRRTLDialect, rtl::RTLDialect, sv::SVDialect>();
+
   llvm::SourceMgr sourceMgr;
   sourceMgr.AddNewSourceBuffer(std::move(ownedBuffer), llvm::SMLoc());
   SourceMgrDiagnosticHandler sourceMgrHandler(sourceMgr, &context);
@@ -129,16 +133,9 @@ processBuffer(std::unique_ptr<llvm::MemoryBuffer> ownedBuffer,
 int main(int argc, char **argv) {
   InitLLVM y(argc, argv);
 
-  enableGlobalDialectRegistry(true);
-
   // Register any pass manager command line options.
   registerMLIRContextCLOptions();
   registerPassManagerCLOptions();
-
-  // Register our dialects.
-  registerDialect<firrtl::FIRRTLDialect>();
-  registerDialect<rtl::RTLDialect>();
-  registerDialect<sv::SVDialect>();
 
   // Parse pass names in main to ensure static initialization completed.
   cl::ParseCommandLineOptions(argc, argv, "circt modular optimizer driver\n");

--- a/tools/handshake-runner/handshake-runner.cpp
+++ b/tools/handshake-runner/handshake-runner.cpp
@@ -32,7 +32,6 @@
 #include "mlir/IR/Function.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/Module.h"
-#include "mlir/InitAllDialects.h"
 #include "mlir/Parser.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APInt.h"
@@ -923,9 +922,6 @@ void executeHandshakeFunction(handshake::FuncOp &toplevel,
 }
 
 int main(int argc, char **argv) {
-  enableGlobalDialectRegistry(true);
-  mlir::registerAllDialects();
-  mlir::registerDialect<handshake::HandshakeOpsDialect>();
   InitLLVM y(argc, argv);
   cl::ParseCommandLineOptions(
       argc, argv,
@@ -944,6 +940,7 @@ int main(int argc, char **argv) {
 
   // Load the MLIR module.
   mlir::MLIRContext context;
+  context.loadDialect<StandardOpsDialect, handshake::HandshakeOpsDialect>();
   SourceMgr source_mgr;
   source_mgr.AddNewSourceBuffer(std::move(*file_or_err), SMLoc());
   mlir::OwningModuleRef module(mlir::parseSourceFile(source_mgr, &context));

--- a/tools/llhd-sim/llhd-sim.cpp
+++ b/tools/llhd-sim/llhd-sim.cpp
@@ -77,12 +77,6 @@ static int dumpLLVM(ModuleOp module, MLIRContext &context) {
 }
 
 int main(int argc, char **argv) {
-  enableGlobalDialectRegistry(true);
-
-  registerDialect<llhd::LLHDDialect>();
-  registerDialect<LLVM::LLVMDialect>();
-  registerDialect<StandardOpsDialect>();
-
   llhd::initLLHDToLLVMPass();
 
   InitLLVM y(argc, argv);
@@ -106,6 +100,10 @@ int main(int argc, char **argv) {
   // Parse the input file.
   MLIRContext context;
   OwningModuleRef module;
+
+  // Load the dialects
+  context
+      .loadDialect<llhd::LLHDDialect, LLVM::LLVMDialect, StandardOpsDialect>();
 
   if (parseMLIR(context, module))
     return 1;


### PR DESCRIPTION
This removes uses of the deprecated global dialect registry and
registers dialects explicitly in a DialectRegistry or MLIRContext.