### PR TITLE
[FIRRTL] Verify that RegOp/RegInitOp are passive

### DIFF
--- a/include/circt/Dialect/FIRRTL/OpDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/OpDeclarations.td
@@ -102,8 +102,8 @@ def RegOp : FIRRTLOp<"reg", [/*MemAlloc*/]> {
     }];
 
   let arguments = (ins ClockType:$clockVal, OptionalAttr<StrAttr>:$name);
-  let results = (outs AnyType:$result);
-  
+  let results = (outs PassiveType:$result);
+
   let assemblyFormat = [{
      operands attr-dict `:` functional-type(operands, $result)
   }];
@@ -120,8 +120,8 @@ def RegInitOp : FIRRTLOp<"reginit", [/*MemAlloc*/]> {
 
   let arguments = (ins ClockType:$clockVal, ResetType:$resetSignal,
                        AnyType:$resetValue, OptionalAttr<StrAttr>:$name);
-  let results = (outs AnyType:$result);
-  
+  let results = (outs PassiveType:$result);
+
   let assemblyFormat = [{
      operands attr-dict `:` functional-type(operands, $result)
   }];

--- a/include/circt/Dialect/FIRRTL/Types.td
+++ b/include/circt/Dialect/FIRRTL/Types.td
@@ -21,6 +21,9 @@ def UInt1Type : Type<CPred<"$_self.isa<UIntType>() && "
                 BuildableType<"UIntType::get($_builder.getContext(), 1)">;
 def ResetType : Type<CPred<"$_self.cast<FIRRTLType>().isResetType()">, "Reset, AsyncReset, or UInt<1>">;
 
+def PassiveType : Type<CPred<"$_self.cast<FIRRTLType>().isPassiveType()">,
+                       "a passive type (contain no flips)">;
+
 //===----------------------------------------------------------------------===//
 // FIRRTL Enum Definitions
 //===----------------------------------------------------------------------===//

--- a/test/firrtl/errors.mlir
+++ b/test/firrtl/errors.mlir
@@ -102,3 +102,23 @@ firrtl.circuit "Foo" {
     %m = firrtl.mem "Undefined" {depth = 32 : i64, name = "m", readLatency = 0 : i32, writeLatency = 0 : i32} : !firrtl.bundle<>
   }
 }
+
+
+// -----
+
+firrtl.circuit "Foo" {
+  firrtl.module @Foo(%clk: !firrtl.clock) {
+    // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive type (contain no flips)}}
+    %a = firrtl.reg %clk {name = "a"} : (!firrtl.clock) -> !firrtl.flip<uint<1>>
+  }
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+  firrtl.module @Foo(%clk: !firrtl.clock, %reset: !firrtl.uint<1>) {
+    %zero = firrtl.constant(0 : ui1) : !firrtl.uint<1>
+    // expected-error @+1 {{'firrtl.reginit' op result #0 must be a passive type (contain no flips)}}
+    %a = firrtl.reginit %clk, %reset, %zero {name = "a"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.flip<uint<1>>
+  }
+}


### PR DESCRIPTION
Adds and uses functions to verify that RegOp and RegInitOp of the FIRRTL dialect do not have types that contain flips. The PR includes tests of this behavior.

This adds one more check towards #80 that brings the MLIR-based compiler closer to the Scala compiler version.

Concretely, a register with flips is rejected by the Scala implementation of a FIRRTL compiler:

```
# firrtl -i registers-with-flip-in-the-type-should-throw-an-exception.fir
Exception in thread "main" firrtl.passes.CheckHighFormLike$RegWithFlipException: : [module Unit] Register r cannot be a bundle type with flips.
```

The `firtool` utility, with this PR, produces:

```
# firtool registers-with-flip-in-the-type-should-throw-an-exception.fir
registers-with-flip-in-the-type-should-throw-an-exception.fir:6:5: error: 'firrtl.reg' op must be a passive type, but it contains one or more flips
    reg r : {a : UInt<32>, flip b : UInt<32>}, clk
    ^
registers-with-flip-in-the-type-should-throw-an-exception.fir:6:5: note: see current operation: %r = "firrtl.reg"(%clk) {name = "r"} : (!firrtl.clock) -> !firrtl.bundle<a: uint<32>, b: flip<uint<32>>>
```