### PR TITLE
[FIRRTL] Require MemOp write latency >= 1

### DIFF
--- a/include/circt/Dialect/FIRRTL/OpDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/OpDeclarations.td
@@ -42,7 +42,7 @@ def SMemOp : FIRRTLOp<"smem", [/*MemAlloc*/]> {
 
 def MemOp : FIRRTLOp<"mem", [/*MemAlloc*/]> {
   let summary = "Define a new mem";
-  let arguments = (ins I32Attr:$readLatency, I32Attr:$writeLatency,
+  let arguments = (ins I32Attr:$readLatency, Confined<I32Attr, [IntMinValue<1>]>:$writeLatency,
                        I64Attr:$depth, RUWAttr:$ruw,
                        OptionalAttr<StrAttr>:$name);
   let results = (outs AnyType:$result);

--- a/test/firrtl/errors.mlir
+++ b/test/firrtl/errors.mlir
@@ -93,3 +93,12 @@ firrtl.circuit "Foo" {
     %a = firrtl.reginit %clk, %reset, %zero {name = "a"} : (!firrtl.clock, !firrtl.uint<2>, !firrtl.uint<1>) -> !firrtl.uint<1>
   }
 }
+
+// -----
+
+firrtl.circuit "Foo" {
+  firrtl.module @Foo() {
+  // expected-error @+1 {{'firrtl.mem' op attribute 'writeLatency' failed to satisfy constraint: 32-bit signless integer attribute whose minimum value is 1}}
+    %m = firrtl.mem "Undefined" {depth = 32 : i64, name = "m", readLatency = 0 : i32, writeLatency = 0 : i32} : !firrtl.bundle<>
+  }
+}


### PR DESCRIPTION
Add a constraint to the FIRRTL dialect's MemOp write latency attribute to require that this is greater than zero. This brings this in line with the Scala FIRRTL compiler in this regard.

Scala FIRRTL compiler:

```
# firrtl -i memories-with-zero-write-latency-should-throw-an-exception.fir 
Exception in thread "main" firrtl.passes.CheckHighFormLike$IllegalMemLatencyException: : [module Unit] Memory m must have non-negative read latency and positive write latency.
```

`firtool` with this PR:

```
# firtool memories-with-zero-write-latency-should-throw-an-exception.fir  
memories-with-zero-write-latency-should-throw-an-exception.fir:3:5: error: 'firrtl.mem' op attribute 'writeLatency' failed to satisfy constraint: 32-bit signless integer attribute whose minimum value is 1
    mem m :
    ^
```

Towards #80.