### PR TITLE
Simplify FIRRTLType classof definition

### DIFF
--- a/include/circt/Dialect/FIRRTL/Types.h
+++ b/include/circt/Dialect/FIRRTL/Types.h
@@ -7,6 +7,7 @@
 #ifndef CIRCT_DIALECT_FIRRTL_TYPES_H
 #define CIRCT_DIALECT_FIRRTL_TYPES_H
 
+#include "circt/Dialect/FIRRTL/Dialect.h"
 #include "mlir/IR/Types.h"
 
 namespace circt {
@@ -54,8 +55,7 @@ public:
 
   /// Support method to enable LLVM-style type casting.
   static bool classof(Type type) {
-    return type.isa<ClockType, ResetType, AsyncResetType, SIntType, UIntType,
-                    AnalogType, FlipType, BundleType, FVectorType>();
+    return llvm::isa<FIRRTLDialect>(type.getDialect());
   }
 
   /// Return true if this is a valid "reset" type.


### PR DESCRIPTION
This mechanism wasn't working with the dialect registration before,
but since the fix in https://github.com/llvm/circt/pull/104, this
works as expected.