### PR TITLE
Generate docs for dialects

### DIFF
--- a/include/circt/Dialect/FIRRTL/CMakeLists.txt
+++ b/include/circt/Dialect/FIRRTL/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_dialect(FIRRTL firrtl FIRRTL)
+add_mlir_doc(FIRRTL -gen-op-doc firrtl Dialect/)
 
 set(LLVM_TARGET_DEFINITIONS FIRRTL.td)
 mlir_tablegen(FIRRTLEnums.h.inc -gen-enum-decls)

--- a/include/circt/Dialect/Handshake/CMakeLists.txt
+++ b/include/circt/Dialect/Handshake/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_dialect(HandshakeOps handshake)
+add_mlir_doc(HandshakeOps -gen-op-doc handshake Dialect/)
 
 set(LLVM_TARGET_DEFINITIONS HandshakeOps.td)
 mlir_tablegen(HandshakeOps.inc -gen-rewriters)

--- a/include/circt/Dialect/RTL/CMakeLists.txt
+++ b/include/circt/Dialect/RTL/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_dialect(RTL rtl)
+add_mlir_doc(RTL -gen-op-doc rtl Dialect/)
 
 set(LLVM_TARGET_DEFINITIONS RTL.td)
 

--- a/include/circt/Dialect/SV/CMakeLists.txt
+++ b/include/circt/Dialect/SV/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_dialect(SV sv)
+add_mlir_doc(SV -gen-op-doc sv Dialect/)
 
 set(LLVM_TARGET_DEFINITIONS SV.td)
 

--- a/include/circt/Dialect/StaticLogic/CMakeLists.txt
+++ b/include/circt/Dialect/StaticLogic/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_mlir_dialect(StaticLogic staticlogic)
+add_mlir_doc(StaticLogic -gen-op-doc staticlogic Dialect/)
 
 set(LLVM_TARGET_DEFINITIONS StaticLogic.td)


### PR DESCRIPTION
* Add `add_mlir_doc` to the dialect `CMakeLists.txt` files in order to have them generate documentation as part of the `mlir-doc` target