### PR TITLE
[rtl] Add flattening for `xor`, `or`, `add`, `mul`.

### DIFF
--- a/lib/Dialect/RTL/Ops.cpp
+++ b/lib/Dialect/RTL/Ops.cpp
@@ -516,7 +516,28 @@ void OrOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
         return success();
       }
 
-      /// TODO: or(x, or(...)) -> or(x, ...) -- flatten
+      // or(x, or(...)) -> or(x, ...) -- flatten
+      for (size_t i = 0; i != size; ++i) {
+        if (!inputs[i].hasOneUse())
+          continue;
+        auto orOp = inputs[i].getDefiningOp<rtl::OrOp>();
+        if (!orOp)
+          continue;
+
+        auto flattenedOrOpInputs = orOp.inputs();
+        SmallVector<Value, 4> newOperands;
+        newOperands.reserve(size + flattenedOrOpInputs.size());
+
+        auto orOpPosition = inputs.begin() + i;
+        newOperands.append(inputs.begin(), orOpPosition);
+        newOperands.append(flattenedOrOpInputs.begin(),
+                           flattenedOrOpInputs.end());
+        newOperands.append(orOpPosition + 1, inputs.end());
+
+        rewriter.replaceOpWithNewOp<OrOp>(op, op.getType(), newOperands);
+        return success();
+      }
+
       /// TODO: or(..., x, not(x)) -> or(..., '1) -- complement
       return failure();
     }
@@ -578,8 +599,29 @@ void XorOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
         return success();
       }
 
+      // xor(x, xor(...)) -> xor(x, ...) -- flatten
+      for (size_t i = 0; i != size; ++i) {
+        if (!inputs[i].hasOneUse())
+          continue;
+        auto xorOp = inputs[i].getDefiningOp<rtl::XorOp>();
+        if (!xorOp)
+          continue;
+
+        auto flattenedXorOpInputs = xorOp.inputs();
+        SmallVector<Value, 4> newOperands;
+        newOperands.reserve(size + flattenedXorOpInputs.size());
+
+        auto xorOpPosition = inputs.begin() + i;
+        newOperands.append(inputs.begin(), xorOpPosition);
+        newOperands.append(flattenedXorOpInputs.begin(),
+                           flattenedXorOpInputs.end());
+        newOperands.append(xorOpPosition + 1, inputs.end());
+
+        rewriter.replaceOpWithNewOp<XorOp>(op, op.getType(), newOperands);
+        return success();
+      }
+
       /// TODO: xor(..., '1) -> not(xor(...))
-      /// TODO: xor(x, xor(...)) -> xor(x, ...) -- flatten
       /// TODO: xor(..., x, not(x)) -> xor(..., '1)
       return failure();
     }
@@ -627,8 +669,30 @@ void AddOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
         return success();
       }
 
+      // add(x, add(...)) -> add(x, ...) -- flatten
+      for (size_t i = 0; i != size; ++i) {
+        if (!inputs[i].hasOneUse())
+          continue;
+        auto addOp = inputs[i].getDefiningOp<rtl::AddOp>();
+        if (!addOp)
+          continue;
+
+        auto flattenedAddOpInputs = addOp.inputs();
+        SmallVector<Value, 4> newOperands;
+        newOperands.reserve(size + flattenedAddOpInputs.size());
+
+        auto addOpPosition = inputs.begin() + i;
+        newOperands.append(inputs.begin(), addOpPosition);
+        newOperands.append(flattenedAddOpInputs.begin(),
+                           flattenedAddOpInputs.end());
+        newOperands.append(addOpPosition + 1, inputs.end());
+
+        rewriter.replaceOpWithNewOp<AddOp>(op, op.getType(), newOperands);
+        return success();
+      }
+
       /// TODO: add(..., x, x) -> add(..., shl(x, 1))
-      /// TODO: add(x, add(...)) -> add(x, ...) -- flatten
+
       return failure();
     }
   };
@@ -680,7 +744,28 @@ void MulOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
         return success();
       }
 
-      /// TODO: mul(a, mul(...)) -> mul(a, ...) -- flatten
+      // mul(a, mul(...)) -> mul(a, ...) -- flatten
+      for (size_t i = 0; i != size; ++i) {
+        if (!inputs[i].hasOneUse())
+          continue;
+        auto mulOp = inputs[i].getDefiningOp<rtl::MulOp>();
+        if (!mulOp)
+          continue;
+
+        auto flattenedMulOpInputs = mulOp.inputs();
+        SmallVector<Value, 4> newOperands;
+        newOperands.reserve(size + flattenedMulOpInputs.size());
+
+        auto mulOpPosition = inputs.begin() + i;
+        newOperands.append(inputs.begin(), mulOpPosition);
+        newOperands.append(flattenedMulOpInputs.begin(),
+                           flattenedMulOpInputs.end());
+        newOperands.append(mulOpPosition + 1, inputs.end());
+
+        rewriter.replaceOpWithNewOp<MulOp>(op, op.getType(), newOperands);
+        return success();
+      }
+
       return failure();
     }
   };

--- a/lib/Dialect/RTL/Ops.cpp
+++ b/lib/Dialect/RTL/Ops.cpp
@@ -300,13 +300,11 @@ void ConstantOp::build(OpBuilder &builder, OperationState &result,
   build(builder, result, APInt(numBits, (uint64_t)value, /*isSigned=*/true));
 }
 
-/// Flattens the Nth index of `inputs` and appends the flattened input to
+/// Flattens `opInputs`, and inserts the flattened inputs to the Nth index of
 /// the original inputs. This is used when flattening in the canonicalization
-/// pattern. It should only be called after `op` is checked to be an operation
-/// wihin `inputs`.
-/// Example: op(1, 2, op(3, 4), 5) -> op(1, 2, 3, 4, 5)
-template <typename Inputs, typename OpInputs>
-auto flattenNthInput(const Inputs &inputs, const OpInputs &opInputs, size_t N) {
+/// pass. Example: op(1, 2, op(3, 4), 5) -> op(1, 2, 3, 4, 5)
+template <typename Inputs>
+auto flattenNthInput(const Inputs &inputs, const Inputs &opInputs, size_t N) {
   assert(N < inputs.size() && "N should be an index less than `inputs` size.");
 
   SmallVector<Value, 4> newOperands;

--- a/lib/Dialect/RTL/Ops.cpp
+++ b/lib/Dialect/RTL/Ops.cpp
@@ -300,17 +300,18 @@ void ConstantOp::build(OpBuilder &builder, OperationState &result,
   build(builder, result, APInt(numBits, (uint64_t)value, /*isSigned=*/true));
 }
 
-/// Flattens `opInputs`, and inserts the flattened inputs to the Nth index of
+/// Flattens `opInputs`, and inserts the flattened inputs to the nth index of
 /// the original inputs. This is used when flattening in the canonicalization
 /// pass. Example: op(1, 2, op(3, 4), 5) -> op(1, 2, 3, 4, 5)
-template <typename Inputs>
-auto flattenNthInput(const Inputs &inputs, const Inputs &opInputs, size_t N) {
-  assert(N < inputs.size() && "N should be an index less than `inputs` size.");
+static auto flattenNthInput(mlir::OperandRange inputs,
+                            mlir::OperandRange opInputs, size_t splitIndex) {
+  assert(splitIndex < inputs.size() &&
+         "splitIndex should be less than `inputs` size.");
 
   SmallVector<Value, 4> newOperands;
   newOperands.reserve(inputs.size() + opInputs.size());
 
-  auto opPosition = inputs.begin() + N;
+  auto opPosition = inputs.begin() + splitIndex;
   newOperands.append(inputs.begin(), opPosition);
   newOperands.append(opInputs.begin(), opInputs.end());
   newOperands.append(opPosition + 1, inputs.end());

--- a/test/rtl/canonicalization.mlir
+++ b/test/rtl/canonicalization.mlir
@@ -122,7 +122,7 @@ func @mul_annulment(%arg0: i11, %arg1: i11, %arg2: i11) -> i11 {
   return %0 : i11
 }
 
-// Flatten
+// Flattening
 
 // CHECK-LABEL: func @and_flatten_in_back(%arg0: i7, %arg1: i7, %arg2: i7) -> i7 {
 // CHECK-NEXT:    [[RES:%[0-9]+]] = rtl.and %arg0, %arg1, %arg2 : i7
@@ -151,6 +151,118 @@ func @and_flatten_in_middle(%arg0: i7, %arg1: i7, %arg2: i7, %arg3: i7) -> i7 {
 func @and_flatten_in_front(%arg0: i7, %arg1: i7, %arg2: i7) -> i7 {
   %and0 = rtl.and %arg0, %arg1 : i7
   %0 = rtl.and %and0, %arg2 : i7
+  return %0 : i7
+}
+
+// CHECK-LABEL: func @or_flatten_in_back(%arg0: i7, %arg1: i7, %arg2: i7) -> i7 {
+// CHECK-NEXT:    [[RES:%[0-9]+]] = rtl.or %arg0, %arg1, %arg2 : i7
+// CHECK-NEXT:    return [[RES]] : i7
+
+func @or_flatten_in_back(%arg0: i7, %arg1: i7, %arg2: i7) -> i7 {
+  %or0 = rtl.or %arg1, %arg2 : i7
+  %0 = rtl.or %arg0, %or0 : i7
+  return %0 : i7
+}
+
+// CHECK-LABEL: func @or_flatten_in_middle(%arg0: i7, %arg1: i7, %arg2: i7, %arg3: i7) -> i7 {
+// CHECK-NEXT:    [[RES:%[0-9]+]] = rtl.or %arg0, %arg1, %arg2, %arg3 : i7
+// CHECK-NEXT:    return [[RES]] : i7
+
+func @or_flatten_in_middle(%arg0: i7, %arg1: i7, %arg2: i7, %arg3: i7) -> i7 {
+  %or0 = rtl.or %arg1, %arg2 : i7
+  %0 = rtl.or %arg0, %or0, %arg3 : i7
+  return %0 : i7
+}
+
+// CHECK-LABEL: func @or_flatten_in_front(%arg0: i7, %arg1: i7, %arg2: i7) -> i7 {
+// CHECK-NEXT:    [[RES:%[0-9]+]] = rtl.or %arg0, %arg1, %arg2 : i7
+// CHECK-NEXT:    return [[RES]] : i7
+
+func @or_flatten_in_front(%arg0: i7, %arg1: i7, %arg2: i7) -> i7 {
+  %or0 = rtl.or %arg0, %arg1 : i7
+  %0 = rtl.or %or0, %arg2 : i7
+  return %0 : i7
+}
+
+// CHECK-LABEL: func @xor_flatten_in_back(%arg0: i7, %arg1: i7, %arg2: i7) -> i7 {
+// CHECK-NEXT:    [[RES:%[0-9]+]] = rtl.xor %arg0, %arg1, %arg2 : i7
+// CHECK-NEXT:    return [[RES]] : i7
+
+func @xor_flatten_in_back(%arg0: i7, %arg1: i7, %arg2: i7) -> i7 {
+  %xor0 = rtl.xor %arg1, %arg2 : i7
+  %0 = rtl.xor %arg0, %xor0 : i7
+  return %0 : i7
+}
+
+// CHECK-LABEL: func @xor_flatten_in_middle(%arg0: i7, %arg1: i7, %arg2: i7, %arg3: i7) -> i7 {
+// CHECK-NEXT:    [[RES:%[0-9]+]] = rtl.xor %arg0, %arg1, %arg2, %arg3 : i7
+// CHECK-NEXT:    return [[RES]] : i7
+
+func @xor_flatten_in_middle(%arg0: i7, %arg1: i7, %arg2: i7, %arg3: i7) -> i7 {
+  %xor0 = rtl.xor %arg1, %arg2 : i7
+  %0 = rtl.xor %arg0, %xor0, %arg3 : i7
+  return %0 : i7
+}
+
+// CHECK-LABEL: func @xor_flatten_in_front(%arg0: i7, %arg1: i7, %arg2: i7) -> i7 {
+// CHECK-NEXT:    [[RES:%[0-9]+]] = rtl.xor %arg0, %arg1, %arg2 : i7
+// CHECK-NEXT:    return [[RES]] : i7
+
+func @xor_flatten_in_front(%arg0: i7, %arg1: i7, %arg2: i7) -> i7 {
+  %xor0 = rtl.xor %arg0, %arg1 : i7
+  %0 = rtl.xor %xor0, %arg2 : i7
+  return %0 : i7
+}
+
+func @add_flatten_in_back(%arg0: i7, %arg1: i7, %arg2: i7) -> i7 {
+  %add0 = rtl.add %arg1, %arg2 : i7
+  %0 = rtl.add %arg0, %add0 : i7
+  return %0 : i7
+}
+
+// CHECK-LABEL: func @add_flatten_in_middle(%arg0: i7, %arg1: i7, %arg2: i7, %arg3: i7) -> i7 {
+// CHECK-NEXT:    [[RES:%[0-9]+]] = rtl.add %arg0, %arg1, %arg2, %arg3 : i7
+// CHECK-NEXT:    return [[RES]] : i7
+
+func @add_flatten_in_middle(%arg0: i7, %arg1: i7, %arg2: i7, %arg3: i7) -> i7 {
+  %add0 = rtl.add %arg1, %arg2 : i7
+  %0 = rtl.add %arg0, %add0, %arg3 : i7
+  return %0 : i7
+}
+
+// CHECK-LABEL: func @add_flatten_in_front(%arg0: i7, %arg1: i7, %arg2: i7) -> i7 {
+// CHECK-NEXT:    [[RES:%[0-9]+]] = rtl.add %arg0, %arg1, %arg2 : i7
+// CHECK-NEXT:    return [[RES]] : i7
+
+func @add_flatten_in_front(%arg0: i7, %arg1: i7, %arg2: i7) -> i7 {
+  %add0 = rtl.add %arg0, %arg1 : i7
+  %0 = rtl.add %add0, %arg2 : i7
+  return %0 : i7
+}
+
+func @mul_flatten_in_back(%arg0: i7, %arg1: i7, %arg2: i7) -> i7 {
+  %mul0 = rtl.mul %arg1, %arg2 : i7
+  %0 = rtl.mul %arg0, %mul0 : i7
+  return %0 : i7
+}
+
+// CHECK-LABEL: func @mul_flatten_in_middle(%arg0: i7, %arg1: i7, %arg2: i7, %arg3: i7) -> i7 {
+// CHECK-NEXT:    [[RES:%[0-9]+]] = rtl.mul %arg0, %arg1, %arg2, %arg3 : i7
+// CHECK-NEXT:    return [[RES]] : i7
+
+func @mul_flatten_in_middle(%arg0: i7, %arg1: i7, %arg2: i7, %arg3: i7) -> i7 {
+  %mul0 = rtl.mul %arg1, %arg2 : i7
+  %0 = rtl.mul %arg0, %mul0, %arg3 : i7
+  return %0 : i7
+}
+
+// CHECK-LABEL: func @mul_flatten_in_front(%arg0: i7, %arg1: i7, %arg2: i7) -> i7 {
+// CHECK-NEXT:    [[RES:%[0-9]+]] = rtl.mul %arg0, %arg1, %arg2 : i7
+// CHECK-NEXT:    return [[RES]] : i7
+
+func @mul_flatten_in_front(%arg0: i7, %arg1: i7, %arg2: i7) -> i7 {
+  %mul0 = rtl.mul %arg0, %arg1 : i7
+  %0 = rtl.mul %mul0, %arg2 : i7
   return %0 : i7
 }
 


### PR DESCRIPTION
One thing to note is the amount of duplication in each case. To reduce this, I could do something like:
```
template <typename Inputs, typename Op>
auto flattenInputs(const Inputs &inputs, Op op,
                   size_t flattenedOpIndex) {
  auto flattenedOpInputs = op.inputs();
  SmallVector<Value, 4> newOperands;
  newOperands.reserve(inputs.size() + flattenedOpInputs.size());

  auto opPosition = inputs.begin() + flattenedOpIndex;
  newOperands.append(inputs.begin(), opPosition);
  newOperands.append(flattenedOpInputs.begin(), flattenedOpInputs.end());
  newOperands.append(opPosition + 1, inputs.end());
  return newOperands;
}

...

      // and(x, and(...)) -> and(x, ...) -- flatten
      for (size_t i = 0; i != size; ++i) {
        if (!inputs[i].hasOneUse())
          continue;
        auto andOp = inputs[i].getDefiningOp<rtl::AndOp>();
        if (!andOp)
          continue;
        rewriter.replaceOpWithNewOp<AndOp>(op, op.getType(),
                                           flattenInputs(inputs, andOp, i));
        return success();
```
I'm not sure if that's worth the extra level of abstraction or not, so looking for input.