### PR TITLE
Changing cache key to increase cache-hit rate slightly

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -15,7 +15,7 @@ jobs:
         submodules: 'true'
     - name: Get LLVM Hash
       id: get-llvm-hash
-      run: echo "::set-output name=hash::$(git submodule status)"
+      run: echo "::set-output name=hash::$(git rev-parse @:./llvm)"
       shell: bash
     - name: Cache LLVM
       id: cache-llvm
@@ -44,7 +44,7 @@ jobs:
         submodules: 'true'
     - name: Get LLVM Hash
       id: get-llvm-hash
-      run: echo "::set-output name=hash::$(git submodule status)"
+      run: echo "::set-output name=hash::$(git rev-parse @:./llvm)"
       shell: bash
     - name: Cache LLVM
       id: cache-llvm


### PR DESCRIPTION
Currently the llvm cache key is something like `Linux-llvm-install- 1509eab55b74e19ba20526047f33effdefe561eb llvm (heads/master)`. The heads/master would change in certain contexts even if the commit hash didn't. This PR changes the key to something like `Linux-llvm-install-d14cfe10341681d18edf05ac98da2c5241b0864e` which strictly increases the cache hit rate. (Don't know how much in practice, but IME it makes a big difference.)