### PR TITLE
Add comparison operators to the RTL dialect.  

### DIFF
--- a/include/circt/Dialect/RTL/CMakeLists.txt
+++ b/include/circt/Dialect/RTL/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_mlir_dialect(RTL rtl)
 
 set(LLVM_TARGET_DEFINITIONS RTL.td)
-
-
+mlir_tablegen(RTLEnums.h.inc -gen-enum-decls)
+mlir_tablegen(RTLEnums.cpp.inc -gen-enum-defs)
+add_public_tablegen_target(MLIRRTLEnumsIncGen)

--- a/include/circt/Dialect/RTL/Combinatorial.td
+++ b/include/circt/Dialect/RTL/Combinatorial.td
@@ -71,18 +71,6 @@ class UTBinRTLOp<string mnemonic, list<OpTrait> traits = []> :
   }];
 }
 
-// Binary operator with uniform input types and i1 output type.
-class CmpBinRTLOp<string mnemonic, list<OpTrait> traits = []> :
-      BinRTLOp<mnemonic,
-               !listconcat(traits, [SameTypeOperands])> {
-  let arguments = (ins AnySignlessInteger:$lhs, AnySignlessInteger:$rhs);
-  let results = (outs I1:$result);
-
-  let assemblyFormat = [{
-    $lhs `,` $rhs  attr-dict `:` type($lhs)
-  }];
-}
-
 // Base class for variadic operators.
 class VariadicRTLOp<string mnemonic, list<OpTrait> traits = []> :
       RTLOp<mnemonic, !listconcat(traits, [NoSideEffect])> {
@@ -120,12 +108,27 @@ def AndOp : UTVariadicRTLOp<"and", [Commutative]>;
 def OrOp  : UTVariadicRTLOp<"or", [Commutative]>;
 def XorOp : UTVariadicRTLOp<"xor", [Commutative]>;
 
-def EQOp   : CmpBinRTLOp<"eq", [Commutative]>;
-def NEQOp  : CmpBinRTLOp<"neq", [Commutative]>;
-def LTOp   : CmpBinRTLOp<"lt">;
-def ULTOp  : CmpBinRTLOp<"ult">;
-def LEQOp  : CmpBinRTLOp<"leq">;
-def ULEQOp : CmpBinRTLOp<"uleq">;
+def ICmpPredicateEQ  : I64EnumAttrCase<"eq", 0>;
+def ICmpPredicateNE  : I64EnumAttrCase<"ne", 1>;
+def ICmpPredicateSLT : I64EnumAttrCase<"slt", 2>;
+def ICmpPredicateSLE : I64EnumAttrCase<"sle", 3>;
+def ICmpPredicateULT : I64EnumAttrCase<"ult", 4>;
+def ICmpPredicateULE : I64EnumAttrCase<"ule", 5>;
+def ICmpPredicate : I64EnumAttr<
+    "ICmpPredicate",
+    "rtl.icmp comparison predicate",
+    [ICmpPredicateEQ, ICmpPredicateNE,
+     ICmpPredicateSLT, ICmpPredicateSLE,
+     ICmpPredicateULT, ICmpPredicateULE]>;
+
+// Other integer operations.
+def ICmpOp : RTLOp<"icmp", [NoSideEffect, SameTypeOperands]> {
+  let arguments = (ins ICmpPredicate:$predicate, AnySignlessInteger:$lhs, AnySignlessInteger:$rhs);
+  let results = (outs I1:$result);
+
+  let parser = [{ return parseICmpOp(parser, result); }];
+  let printer = [{ printICmpOp(p, *this); }];
+}
 
 //===----------------------------------------------------------------------===//
 // Unary Operations

--- a/include/circt/Dialect/RTL/Combinatorial.td
+++ b/include/circt/Dialect/RTL/Combinatorial.td
@@ -57,7 +57,7 @@ class BinRTLOp<string mnemonic, list<OpTrait> traits = []> :
   let results = (outs AnySignlessInteger:$result);
 
   let assemblyFormat = [{
-    $lhs `,` $rhs  attr-dict `:` functional-type($args, results)
+    $lhs `,` $rhs  attr-dict `:` functional-type($args, $results)
   }];
 }
 
@@ -68,6 +68,18 @@ class UTBinRTLOp<string mnemonic, list<OpTrait> traits = []> :
                            [SameTypeOperands, SameOperandsAndResultType])> {
    let assemblyFormat = [{
     $lhs `,` $rhs  attr-dict `:` type($result)
+  }];
+}
+
+// Binary operator with uniform input types and i1 output type.
+class CmpBinRTLOp<string mnemonic, list<OpTrait> traits = []> :
+      BinRTLOp<mnemonic,
+               !listconcat(traits, [SameTypeOperands])> {
+  let arguments = (ins AnySignlessInteger:$lhs, AnySignlessInteger:$rhs);
+  let results = (outs I1:$result);
+
+  let assemblyFormat = [{
+    $lhs `,` $rhs  attr-dict `:` functional-type(operands, $result)
   }];
 }
 
@@ -107,6 +119,13 @@ def ShlOp : UTBinRTLOp<"shl">;
 def AndOp : UTVariadicRTLOp<"and", [Commutative]>;
 def OrOp  : UTVariadicRTLOp<"or", [Commutative]>;
 def XorOp : UTVariadicRTLOp<"xor", [Commutative]>;
+
+def EQOp   : CmpBinRTLOp<"eq", [Commutative]>;
+def NEQOp  : CmpBinRTLOp<"neq", [Commutative]>;
+def LTOp   : CmpBinRTLOp<"lt">;
+def ULTOp  : CmpBinRTLOp<"ult">;
+def LEQOp  : CmpBinRTLOp<"leq">;
+def ULEQOp : CmpBinRTLOp<"uleq">;
 
 //===----------------------------------------------------------------------===//
 // Unary Operations

--- a/include/circt/Dialect/RTL/Combinatorial.td
+++ b/include/circt/Dialect/RTL/Combinatorial.td
@@ -112,22 +112,27 @@ def ICmpPredicateEQ  : I64EnumAttrCase<"eq", 0>;
 def ICmpPredicateNE  : I64EnumAttrCase<"ne", 1>;
 def ICmpPredicateSLT : I64EnumAttrCase<"slt", 2>;
 def ICmpPredicateSLE : I64EnumAttrCase<"sle", 3>;
-def ICmpPredicateULT : I64EnumAttrCase<"ult", 4>;
-def ICmpPredicateULE : I64EnumAttrCase<"ule", 5>;
+def ICmpPredicateSGT : I64EnumAttrCase<"sgt", 4>;
+def ICmpPredicateSGE : I64EnumAttrCase<"sge", 5>;
+def ICmpPredicateULT : I64EnumAttrCase<"ult", 6>;
+def ICmpPredicateULE : I64EnumAttrCase<"ule", 7>;
+def ICmpPredicateUGT : I64EnumAttrCase<"ugt", 8>;
+def ICmpPredicateUGE : I64EnumAttrCase<"uge", 9>;
 def ICmpPredicate : I64EnumAttr<
     "ICmpPredicate",
     "rtl.icmp comparison predicate",
-    [ICmpPredicateEQ, ICmpPredicateNE,
-     ICmpPredicateSLT, ICmpPredicateSLE,
-     ICmpPredicateULT, ICmpPredicateULE]>;
-
+    [ICmpPredicateEQ, ICmpPredicateNE, ICmpPredicateSLT, ICmpPredicateSLE,
+     ICmpPredicateSGT, ICmpPredicateSGE, ICmpPredicateULT, ICmpPredicateULE,
+     ICmpPredicateUGT, ICmpPredicateUGE]>;
+     
 // Other integer operations.
 def ICmpOp : RTLOp<"icmp", [NoSideEffect, SameTypeOperands]> {
   let arguments = (ins ICmpPredicate:$predicate, AnySignlessInteger:$lhs, AnySignlessInteger:$rhs);
   let results = (outs I1:$result);
 
-  let parser = [{ return parseICmpOp(parser, result); }];
-  let printer = [{ printICmpOp(p, *this); }];
+  let assemblyFormat = [{
+    $predicate $lhs `,` $rhs  attr-dict `:` type($lhs)
+  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/RTL/Combinatorial.td
+++ b/include/circt/Dialect/RTL/Combinatorial.td
@@ -124,10 +124,11 @@ def ICmpPredicate : I64EnumAttr<
     [ICmpPredicateEQ, ICmpPredicateNE, ICmpPredicateSLT, ICmpPredicateSLE,
      ICmpPredicateSGT, ICmpPredicateSGE, ICmpPredicateULT, ICmpPredicateULE,
      ICmpPredicateUGT, ICmpPredicateUGE]>;
-     
+
 // Other integer operations.
 def ICmpOp : RTLOp<"icmp", [NoSideEffect, SameTypeOperands]> {
-  let arguments = (ins ICmpPredicate:$predicate, AnySignlessInteger:$lhs, AnySignlessInteger:$rhs);
+  let arguments = (ins ICmpPredicate:$predicate, 
+                   AnySignlessInteger:$lhs, AnySignlessInteger:$rhs);
   let results = (outs I1:$result);
 
   let assemblyFormat = [{

--- a/include/circt/Dialect/RTL/Combinatorial.td
+++ b/include/circt/Dialect/RTL/Combinatorial.td
@@ -79,7 +79,7 @@ class CmpBinRTLOp<string mnemonic, list<OpTrait> traits = []> :
   let results = (outs I1:$result);
 
   let assemblyFormat = [{
-    $lhs `,` $rhs  attr-dict `:` functional-type(operands, $result)
+    $lhs `,` $rhs  attr-dict `:` type($lhs)
   }];
 }
 

--- a/include/circt/Dialect/RTL/Dialect.h
+++ b/include/circt/Dialect/RTL/Dialect.h
@@ -27,4 +27,7 @@ public:
 } // namespace rtl
 } // namespace circt
 
+// Pull in all enum type definitions and utility function declarations.
+#include "circt/Dialect/RTL/RTLEnums.h.inc"
+
 #endif // CIRCT_DIALECT_RTL_DIALECT_H

--- a/include/circt/Dialect/RTL/Visitors.h
+++ b/include/circt/Dialect/RTL/Visitors.h
@@ -27,7 +27,7 @@ public:
                        // Bitwise operations
                        AndOp, OrOp, XorOp,
                        // Comparison operations
-                       EQOp, NEQOp, LTOp, ULTOp, LEQOp, ULEQOp,
+                       ICmpOp,
                        // Reduction Operators
                        AndROp, OrROp, XorROp,
                        // Other operations.
@@ -91,12 +91,7 @@ public:
   HANDLE(OrROp, Unary);
   HANDLE(XorROp, Unary);
 
-  HANDLE(EQOp, Binary);
-  HANDLE(NEQOp, Binary);
-  HANDLE(LTOp, Binary);
-  HANDLE(ULTOp, Binary);
-  HANDLE(LEQOp, Binary);
-  HANDLE(ULEQOp, Binary);
+  HANDLE(ICmpOp, Binary);
 
   // Other operations.
   HANDLE(SExtOp, Unhandled);

--- a/include/circt/Dialect/RTL/Visitors.h
+++ b/include/circt/Dialect/RTL/Visitors.h
@@ -26,6 +26,8 @@ public:
                        AddOp, SubOp, MulOp, DivOp, ModOp, ShlOp,
                        // Bitwise operations
                        AndOp, OrOp, XorOp,
+                       // Comparison operations
+                       EQOp, NEQOp, LTOp, ULTOp, LEQOp, ULEQOp,
                        // Reduction Operators
                        AndROp, OrROp, XorROp,
                        // Other operations.
@@ -88,6 +90,13 @@ public:
   HANDLE(AndROp, Unary);
   HANDLE(OrROp, Unary);
   HANDLE(XorROp, Unary);
+
+  HANDLE(EQOp, Binary);
+  HANDLE(NEQOp, Binary);
+  HANDLE(LTOp, Binary);
+  HANDLE(ULTOp, Binary);
+  HANDLE(LEQOp, Binary);
+  HANDLE(ULEQOp, Binary);
 
   // Other operations.
   HANDLE(SExtOp, Unhandled);

--- a/lib/Dialect/FIRRTL/LowerToRTL.cpp
+++ b/lib/Dialect/FIRRTL/LowerToRTL.cpp
@@ -87,12 +87,24 @@ struct FIRRTLLowering : public LowerFIRRTLToRTLBase<FIRRTLLowering>,
   LogicalResult visitExpr(AddPrimOp op) {
     return lowerBinOpToVariadic<rtl::AddOp>(op);
   }
-  LogicalResult visitExpr(EQPrimOp op) { return lowerCmpOp<rtl::EQOp, rtl::EQOp>(op); }
-  LogicalResult visitExpr(NEQPrimOp op) { return lowerCmpOp<rtl::NEQOp, rtl::NEQOp>(op); }
-  LogicalResult visitExpr(LTPrimOp op) { return lowerCmpOp<rtl::LTOp, rtl::ULTOp>(op); }
-  LogicalResult visitExpr(LEQPrimOp op) { return lowerCmpOp<rtl::LEQOp, rtl::ULEQOp>(op); }
-  LogicalResult visitExpr(GTPrimOp op) { return lowerCmpOp<rtl::LTOp, rtl::ULTOp>(op, true); }
-  LogicalResult visitExpr(GEQPrimOp op) { return lowerCmpOp<rtl::LEQOp, rtl::ULEQOp>(op, true); }
+  LogicalResult visitExpr(EQPrimOp op) {
+    return lowerCmpOp<rtl::EQOp, rtl::EQOp>(op);
+  }
+  LogicalResult visitExpr(NEQPrimOp op) {
+    return lowerCmpOp<rtl::NEQOp, rtl::NEQOp>(op);
+  }
+  LogicalResult visitExpr(LTPrimOp op) {
+    return lowerCmpOp<rtl::LTOp, rtl::ULTOp>(op);
+  }
+  LogicalResult visitExpr(LEQPrimOp op) {
+    return lowerCmpOp<rtl::LEQOp, rtl::ULEQOp>(op);
+  }
+  LogicalResult visitExpr(GTPrimOp op) {
+    return lowerCmpOp<rtl::LTOp, rtl::ULTOp>(op, true);
+  }
+  LogicalResult visitExpr(GEQPrimOp op) {
+    return lowerCmpOp<rtl::LEQOp, rtl::ULEQOp>(op, true);
+  }
 
   LogicalResult visitExpr(SubPrimOp op) { return lowerBinOp<rtl::SubOp>(op); }
   LogicalResult visitExpr(MulPrimOp op) {
@@ -461,9 +473,10 @@ LogicalResult FIRRTLLowering::lowerCmpOp(Operation *op, bool flip) {
     return failure();
 
   if (flip)
-    std::swap(lhs,rhs);
+    std::swap(lhs, rhs);
 
-  auto srcFIRType = op->getOperand(0).getType().cast<FIRRTLType>().getPassiveType();
+  auto srcFIRType =
+      op->getOperand(0).getType().cast<FIRRTLType>().getPassiveType();
   auto srcIntType = srcFIRType.dyn_cast<IntType>();
   if (!srcIntType || !srcIntType.hasWidth())
     return failure();

--- a/lib/Dialect/FIRRTL/LowerToRTL.cpp
+++ b/lib/Dialect/FIRRTL/LowerToRTL.cpp
@@ -473,11 +473,13 @@ LogicalResult FIRRTLLowering::lowerCmpOp(Operation *op, bool flip) {
   auto rhsFIRType =
       op->getOperand(1).getType().cast<FIRRTLType>().getPassiveType();
   auto rhsIntType = rhsFIRType.dyn_cast<IntType>();
-  
-  if (!lhsIntType || !lhsIntType.hasWidth() || !rhsIntType || !rhsIntType.hasWidth())
+
+  if (!lhsIntType || !lhsIntType.hasWidth() || !rhsIntType ||
+      !rhsIntType.hasWidth())
     return failure();
-  
-  Type cmpType = *lhsIntType.getWidth() < *rhsIntType.getWidth() ? rhsFIRType : lhsFIRType;
+
+  Type cmpType =
+      *lhsIntType.getWidth() < *rhsIntType.getWidth() ? rhsFIRType : lhsFIRType;
 
   auto lhs = getLoweredAndExtendedValue(op->getOperand(0), cmpType);
   auto rhs = getLoweredAndExtendedValue(op->getOperand(1), cmpType);

--- a/lib/Dialect/FIRRTL/LowerToRTL.cpp
+++ b/lib/Dialect/FIRRTL/LowerToRTL.cpp
@@ -70,8 +70,8 @@ struct FIRRTLLowering : public LowerFIRRTLToRTLBase<FIRRTLLowering>,
   LogicalResult lowerBinOp(Operation *op);
   template <typename ResultOpType>
   LogicalResult lowerBinOpToVariadic(Operation *op);
-  LogicalResult lowerCmpOp(Operation *op, ICmpPredicate PredOp,
-                           ICmpPredicate UnSignedOp);
+  LogicalResult lowerCmpOp(Operation *op, ICmpPredicate signedOp,
+                           ICmpPredicate unsignedOp);
 
   LogicalResult visitExpr(CatPrimOp op);
 

--- a/lib/Dialect/FIRRTL/LowerToRTL.cpp
+++ b/lib/Dialect/FIRRTL/LowerToRTL.cpp
@@ -463,8 +463,8 @@ LogicalResult FIRRTLLowering::lowerBinOp(Operation *op) {
 
 /// lowerCmpOp extends each operand to the longest type, then performs the
 /// specified binary operator.
-LogicalResult FIRRTLLowering::lowerCmpOp(Operation *op, ICmpPredicate SignedOp,
-                                         ICmpPredicate UnsignedOp) {
+LogicalResult FIRRTLLowering::lowerCmpOp(Operation *op, ICmpPredicate signedOp,
+                                         ICmpPredicate unsignedOp) {
   // Extend the two operands to match the longest type.
   Type resultType = builder->getIntegerType(1);
   auto lhsFIRType =
@@ -487,10 +487,8 @@ LogicalResult FIRRTLLowering::lowerCmpOp(Operation *op, ICmpPredicate SignedOp,
     return failure();
 
   // Emit the result operation.
-  if (lhsIntType.isSigned())
-    return setLoweringTo<rtl::ICmpOp>(op, resultType, SignedOp, lhs, rhs);
-  else
-    return setLoweringTo<rtl::ICmpOp>(op, resultType, UnsignedOp, lhs, rhs);
+  return setLoweringTo<rtl::ICmpOp>(
+      op, resultType, lhsIntType.isSigned() ? signedOp : unsignedOp, lhs, rhs);
 }
 
 LogicalResult FIRRTLLowering::visitExpr(CatPrimOp op) {

--- a/lib/Dialect/RTL/CMakeLists.txt
+++ b/lib/Dialect/RTL/CMakeLists.txt
@@ -7,11 +7,12 @@ add_mlir_dialect_library(MLIRRTL
 
   DEPENDS
   MLIRRTLIncGen
-
+  MLIRRTLEnumsIncGen
+  
   LINK_COMPONENTS
   Support
 
   LINK_LIBS PUBLIC
    )
 
-add_dependencies(mlir-headers MLIRRTLIncGen)
+add_dependencies(mlir-headers MLIRRTLIncGen MLIRRTLEnumsIncGen)

--- a/lib/Dialect/RTL/Dialect.cpp
+++ b/lib/Dialect/RTL/Dialect.cpp
@@ -44,3 +44,6 @@ Operation *RTLDialect::materializeConstant(OpBuilder &builder, Attribute value,
 
   return nullptr;
 }
+
+// Provide implementations for the enums we use.
+#include "circt/Dialect/RTL/RTLEnums.cpp.inc"

--- a/lib/Dialect/RTL/Ops.cpp
+++ b/lib/Dialect/RTL/Ops.cpp
@@ -744,6 +744,54 @@ void MulOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
 }
 
 //===----------------------------------------------------------------------===//
+// Printing/parsing for RTL::ICmpOp.
+//===----------------------------------------------------------------------===//
+static void printICmpOp(OpAsmPrinter &p, ICmpOp &op) {
+  p << op.getOperationName() << " \"" << stringifyICmpPredicate(op.predicate())
+    << "\" " << op.getOperand(0) << ", " << op.getOperand(1);
+  p.printOptionalAttrDict(op.getAttrs(), {"predicate"});
+  p << " : " << op.lhs().getType();
+}
+
+// <operation> ::= `rtl.icmp` string-literal ssa-use `,` ssa-use
+//                 attribute-dict? `:` type
+static ParseResult parseICmpOp(OpAsmParser &parser, OperationState &result) {
+  Builder &builder = parser.getBuilder();
+
+  StringAttr predicateAttr;
+  OpAsmParser::OperandType lhs, rhs;
+  Type type;
+  llvm::SMLoc predicateLoc, trailingTypeLoc;
+  if (parser.getCurrentLocation(&predicateLoc) ||
+      parser.parseAttribute(predicateAttr, "predicate", result.attributes) ||
+      parser.parseOperand(lhs) || parser.parseComma() ||
+      parser.parseOperand(rhs) ||
+      parser.parseOptionalAttrDict(result.attributes) || parser.parseColon() ||
+      parser.getCurrentLocation(&trailingTypeLoc) || parser.parseType(type) ||
+      parser.resolveOperand(lhs, type, result.operands) ||
+      parser.resolveOperand(rhs, type, result.operands))
+    return failure();
+
+  // Replace the string attribute `predicate` with an integer attribute.
+  int64_t predicateValue = 0;
+    Optional<ICmpPredicate> predicate =
+        symbolizeICmpPredicate(predicateAttr.getValue());
+    if (!predicate)
+      return parser.emitError(predicateLoc)
+             << "'" << predicateAttr.getValue()
+             << "' is an incorrect value of the 'predicate' attribute";
+    predicateValue = static_cast<int64_t>(predicate.getValue());
+
+  result.attributes.set("predicate",
+                        parser.getBuilder().getI64IntegerAttr(predicateValue));
+
+  auto resultType = builder.getIntegerType(1);
+
+  result.addTypes({resultType});
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // TableGen generated logic.
 //===----------------------------------------------------------------------===//
 

--- a/lib/EmitVerilog/EmitVerilog.cpp
+++ b/lib/EmitVerilog/EmitVerilog.cpp
@@ -771,7 +771,7 @@ private:
   SubExprInfo visitExpr(OrPrimOp op) { return emitVariadic(op, Or, "|"); }
   SubExprInfo visitExpr(XorPrimOp op) { return emitVariadic(op, Xor, "^"); }
 
-  // Comparison Operations
+  // FIRRTL Comparison Operations
   SubExprInfo visitExpr(LEQPrimOp op) {
     return emitSignedBinary(op, Comparison, "<=");
   }
@@ -863,6 +863,14 @@ private:
   SubExprInfo visitComb(rtl::ZExtOp op);
   SubExprInfo visitComb(rtl::ConcatOp op);
   SubExprInfo visitComb(rtl::ExtractOp op);
+
+  //RTL Comparison Operations
+  SubExprInfo visitComb(rtl::LTOp op) { return emitSignedBinary(op, Comparison, "<"); }
+  SubExprInfo visitComb(rtl::LEQOp op) { return emitSignedBinary(op, Comparison, "<="); }
+  SubExprInfo visitComb(rtl::ULTOp op) { return emitBinary(op, Comparison, "<"); }
+  SubExprInfo visitComb(rtl::ULEQOp op) { return emitBinary(op, Comparison, "<="); }
+  SubExprInfo visitComb(rtl::EQOp op) { return emitBinary(op, Equality, "=="); }
+  SubExprInfo visitComb(rtl::NEQOp op) { return emitBinary(op, Equality, "!="); }
 
 private:
   SmallPtrSet<Operation *, 8> &emittedExprs;

--- a/lib/EmitVerilog/EmitVerilog.cpp
+++ b/lib/EmitVerilog/EmitVerilog.cpp
@@ -942,9 +942,10 @@ SubExprInfo ExprEmitter::emitBinary(Operation *op, VerilogPrecedence prec,
 
 SubExprInfo ExprEmitter::emitVariadic(Operation *op, VerilogPrecedence prec,
                                       const char *syntax, bool hasStrictSign) {
-  interleave(op->getOperands().begin(), op->getOperands().end(),
-             [&](Value v1) { emitSubExpr(v1, prec, hasStrictSign); },
-             [&] { os << ' ' << syntax << ' '; });
+  interleave(
+      op->getOperands().begin(), op->getOperands().end(),
+      [&](Value v1) { emitSubExpr(v1, prec, hasStrictSign); },
+      [&] { os << ' ' << syntax << ' '; });
 
   return {prec, IsUnsigned};
 }

--- a/lib/EmitVerilog/EmitVerilog.cpp
+++ b/lib/EmitVerilog/EmitVerilog.cpp
@@ -866,7 +866,7 @@ private:
 
   // RTL Comparison Operations
   SubExprInfo visitComb(rtl::ICmpOp op) {
-    std::array<const char *, 6> symop{"==", "!=", "<",  "<=", "<",
+    std::array<const char *, 10> symop{"==", "!=", "<",  "<=", "<",
                                       "<=", ">",  ">=", ">",  ">="};
     return emitSignedBinary(op, Comparison,
                             symop[static_cast<uint64_t>(op.predicate())]);

--- a/lib/EmitVerilog/EmitVerilog.cpp
+++ b/lib/EmitVerilog/EmitVerilog.cpp
@@ -865,21 +865,9 @@ private:
   SubExprInfo visitComb(rtl::ExtractOp op);
 
   // RTL Comparison Operations
-  SubExprInfo visitComb(rtl::LTOp op) {
-    return emitSignedBinary(op, Comparison, "<");
-  }
-  SubExprInfo visitComb(rtl::LEQOp op) {
-    return emitSignedBinary(op, Comparison, "<=");
-  }
-  SubExprInfo visitComb(rtl::ULTOp op) {
-    return emitBinary(op, Comparison, "<");
-  }
-  SubExprInfo visitComb(rtl::ULEQOp op) {
-    return emitBinary(op, Comparison, "<=");
-  }
-  SubExprInfo visitComb(rtl::EQOp op) { return emitBinary(op, Equality, "=="); }
-  SubExprInfo visitComb(rtl::NEQOp op) {
-    return emitBinary(op, Equality, "!=");
+  SubExprInfo visitComb(rtl::ICmpOp op) {
+    std::array<const char*, 6> symop {"==", "!=", "<", "<=", "<", "<="};
+    return emitSignedBinary(op, Comparison, symop[static_cast<uint64_t>(op.predicate())]);
   }
 
 private:

--- a/lib/EmitVerilog/EmitVerilog.cpp
+++ b/lib/EmitVerilog/EmitVerilog.cpp
@@ -867,7 +867,7 @@ private:
   // RTL Comparison Operations
   SubExprInfo visitComb(rtl::ICmpOp op) {
     std::array<const char *, 10> symop{"==", "!=", "<",  "<=", "<",
-                                      "<=", ">",  ">=", ">",  ">="};
+                                       "<=", ">",  ">=", ">",  ">="};
     return emitSignedBinary(op, Comparison,
                             symop[static_cast<uint64_t>(op.predicate())]);
   }

--- a/lib/EmitVerilog/EmitVerilog.cpp
+++ b/lib/EmitVerilog/EmitVerilog.cpp
@@ -866,8 +866,10 @@ private:
 
   // RTL Comparison Operations
   SubExprInfo visitComb(rtl::ICmpOp op) {
-    std::array<const char*, 6> symop {"==", "!=", "<", "<=", "<", "<="};
-    return emitSignedBinary(op, Comparison, symop[static_cast<uint64_t>(op.predicate())]);
+    std::array<const char *, 6> symop{"==", "!=", "<",  "<=", "<",
+                                      "<=", ">",  ">=", ">",  ">="};
+    return emitSignedBinary(op, Comparison,
+                            symop[static_cast<uint64_t>(op.predicate())]);
   }
 
 private:

--- a/lib/EmitVerilog/EmitVerilog.cpp
+++ b/lib/EmitVerilog/EmitVerilog.cpp
@@ -864,13 +864,23 @@ private:
   SubExprInfo visitComb(rtl::ConcatOp op);
   SubExprInfo visitComb(rtl::ExtractOp op);
 
-  //RTL Comparison Operations
-  SubExprInfo visitComb(rtl::LTOp op) { return emitSignedBinary(op, Comparison, "<"); }
-  SubExprInfo visitComb(rtl::LEQOp op) { return emitSignedBinary(op, Comparison, "<="); }
-  SubExprInfo visitComb(rtl::ULTOp op) { return emitBinary(op, Comparison, "<"); }
-  SubExprInfo visitComb(rtl::ULEQOp op) { return emitBinary(op, Comparison, "<="); }
+  // RTL Comparison Operations
+  SubExprInfo visitComb(rtl::LTOp op) {
+    return emitSignedBinary(op, Comparison, "<");
+  }
+  SubExprInfo visitComb(rtl::LEQOp op) {
+    return emitSignedBinary(op, Comparison, "<=");
+  }
+  SubExprInfo visitComb(rtl::ULTOp op) {
+    return emitBinary(op, Comparison, "<");
+  }
+  SubExprInfo visitComb(rtl::ULEQOp op) {
+    return emitBinary(op, Comparison, "<=");
+  }
   SubExprInfo visitComb(rtl::EQOp op) { return emitBinary(op, Equality, "=="); }
-  SubExprInfo visitComb(rtl::NEQOp op) { return emitBinary(op, Equality, "!="); }
+  SubExprInfo visitComb(rtl::NEQOp op) {
+    return emitBinary(op, Equality, "!=");
+  }
 
 private:
   SmallPtrSet<Operation *, 8> &emittedExprs;
@@ -932,10 +942,9 @@ SubExprInfo ExprEmitter::emitBinary(Operation *op, VerilogPrecedence prec,
 
 SubExprInfo ExprEmitter::emitVariadic(Operation *op, VerilogPrecedence prec,
                                       const char *syntax, bool hasStrictSign) {
-  interleave(
-      op->getOperands().begin(), op->getOperands().end(),
-      [&](Value v1) { emitSubExpr(v1, prec, hasStrictSign); },
-      [&] { os << ' ' << syntax << ' '; });
+  interleave(op->getOperands().begin(), op->getOperands().end(),
+             [&](Value v1) { emitSubExpr(v1, prec, hasStrictSign); },
+             [&] { os << ' ' << syntax << ' '; });
 
   return {prec, IsUnsigned};
 }

--- a/test/EmitVerilog/verilog-basic.fir
+++ b/test/EmitVerilog/verilog-basic.fir
@@ -188,6 +188,48 @@ circuit inputs_only :
 ; CHECK-NEXT:  endmodule
 
 
+  module Extend :
+    input a: UInt<4>
+    input b: UInt<6>
+    input c: SInt<3>
+    input d: SInt<5>
+    output out: UInt<1>
+    out <= lt(a, b)
+    out <= lt(c, d)
+    out <= leq(a, b)
+    out <= leq(c, d)
+    out <= gt(a, b)
+    out <= gt(c, d)
+    out <= geq(a, b)
+    out <= geq(c, d)
+    out <= eq(a, b)
+    out <= eq(c, d)
+    out <= neq(a, b)
+    out <= neq(c, d)
+
+
+; CHECK-LABEL: module Extend(
+; CHECK-NEXT:     input  [3:0] a,
+; CHECK-NEXT:     input  [5:0] b,
+; CHECK-NEXT:     input  [2:0] c,
+; CHECK-NEXT:     input  [4:0] d,
+; CHECK-NEXT:     output       out);
+; CHECK-EMPTY:
+; CHECK-NEXT:     assign out = a < b;
+; CHECK-NEXT:     assign out = $signed(c) < $signed(d);
+; CHECK-NEXT:     assign out = a <= b;
+; CHECK-NEXT:     assign out = $signed(c) <= $signed(d);
+; CHECK-NEXT:     assign out = a > b;
+; CHECK-NEXT:     assign out = $signed(c) > $signed(d);
+; CHECK-NEXT:     assign out = a >= b;
+; CHECK-NEXT:     assign out = $signed(c) >= $signed(d);
+; CHECK-NEXT:     assign out = a == b;
+; CHECK-NEXT:     assign out = c == d;
+; CHECK-NEXT:     assign out = a != b;
+; CHECK-NEXT:     assign out = c != d;
+; CHECK-NEXT:  endmodule
+
+
 ; CHECK-LABEL: module MultiUseExpr(
 ; CHECK-NEXT:    input  [3:0] a,
 ; CHECK-NEXT:    output       b);

--- a/test/EmitVerilog/verilog-basic.fir
+++ b/test/EmitVerilog/verilog-basic.fir
@@ -137,7 +137,7 @@ circuit inputs_only :
 ; CHECK-NEXT:  endmodule
 
 
-  module Sign :
+  module CmpSign :
     input a: UInt<4>
     input b: UInt<4>
     input c: SInt<4>
@@ -146,16 +146,45 @@ circuit inputs_only :
     out <= lt(a, b)
     out <= lt(c, d)
     out <= lt(asSInt(a), asSInt(b))
+    out <= leq(a, b)
+    out <= leq(c, d)
+    out <= leq(asSInt(a), asSInt(b))
+    out <= gt(a, b)
+    out <= gt(c, d)
+    out <= gt(asSInt(a), asSInt(b))
+    out <= geq(a, b)
+    out <= geq(c, d)
+    out <= geq(asSInt(a), asSInt(b))
+    out <= eq(a, b)
+    out <= eq(c, d)
     out <= eq(asSInt(a), asSInt(b))
+    out <= neq(a, b)
+    out <= neq(c, d)
+    out <= neq(asSInt(a), asSInt(b))
 
-; CHECK-LABEL: module Sign(
+
+; CHECK-LABEL: module CmpSign(
 ; CHECK-NEXT:     input  [3:0] a, b, c, d,
 ; CHECK-NEXT:     output       out);
 ; CHECK-EMPTY:
 ; CHECK-NEXT:     assign out = a < b;
 ; CHECK-NEXT:     assign out = $signed(c) < $signed(d);
 ; CHECK-NEXT:     assign out = $signed(a) < $signed(b);
+; CHECK-NEXT:     assign out = a <= b;
+; CHECK-NEXT:     assign out = $signed(c) <= $signed(d);
+; CHECK-NEXT:     assign out = $signed(a) <= $signed(b);
+; CHECK-NEXT:     assign out = a > b;
+; CHECK-NEXT:     assign out = $signed(c) > $signed(d);
+; CHECK-NEXT:     assign out = $signed(a) > $signed(b);
+; CHECK-NEXT:     assign out = a >= b;
+; CHECK-NEXT:     assign out = $signed(c) >= $signed(d);
+; CHECK-NEXT:     assign out = $signed(a) >= $signed(b);
 ; CHECK-NEXT:     assign out = a == b;
+; CHECK-NEXT:     assign out = c == d;
+; CHECK-NEXT:     assign out = a == b;
+; CHECK-NEXT:     assign out = a != b;
+; CHECK-NEXT:     assign out = c != d;
+; CHECK-NEXT:     assign out = a != b
 ; CHECK-NEXT:  endmodule
 
 

--- a/test/rtl/basic.mlir
+++ b/test/rtl/basic.mlir
@@ -54,6 +54,18 @@ func @test1(%arg0: i3, %arg1: i1) -> i50 {
   // CHECK-NEXT: rtl.icmp "ule" [[RES9]], [[RES10]] : i19
   %uleq = rtl.icmp "ule" %small1, %small2 : i19
 
+  // CHECK-NEXT: rtl.icmp "sgt" [[RES9]], [[RES10]] : i19
+  %gt = rtl.icmp "sgt" %small1, %small2 : i19
+
+  // CHECK-NEXT: rtl.icmp "ugt" [[RES9]], [[RES10]] : i19
+  %ugt = rtl.icmp "ugt" %small1, %small2 : i19
+
+  // CHECK-NEXT: rtl.icmp "sge" [[RES9]], [[RES10]] : i19
+  %geq = rtl.icmp "sge" %small1, %small2 : i19
+
+  // CHECK-NEXT: rtl.icmp "uge" [[RES9]], [[RES10]] : i19
+  %ugeq = rtl.icmp "uge" %small1, %small2 : i19
+
   // CHECK-NEXT:  = rtl.wire : i4
   %w = rtl.wire : i4
 

--- a/test/rtl/basic.mlir
+++ b/test/rtl/basic.mlir
@@ -36,23 +36,23 @@ func @test1(%arg0: i3, %arg1: i1) -> i50 {
   // CHECK-NEXT: rtl.add [[RES9]], [[RES10]] : i19
   %add = rtl.add %small1, %small2 : i19
 
-  // CHECK-NEXT: rtl.eq [[RES9]], [[RES10]] : (i19, i19) -> i1
-  %eq = rtl.eq %small1, %small2 : (i19, i19) -> i1
+  // CHECK-NEXT: rtl.eq [[RES9]], [[RES10]] : i19
+  %eq = rtl.eq %small1, %small2 : i19
 
-  // CHECK-NEXT: rtl.neq [[RES9]], [[RES10]] : (i19, i19) -> i1
-  %neq = rtl.neq %small1, %small2 : (i19, i19) -> i1
+  // CHECK-NEXT: rtl.neq [[RES9]], [[RES10]] : i19
+  %neq = rtl.neq %small1, %small2 : i19
 
-  // CHECK-NEXT: rtl.lt [[RES9]], [[RES10]] : (i19, i19) -> i1
-  %lt = rtl.lt %small1, %small2 : (i19, i19) -> i1
+  // CHECK-NEXT: rtl.lt [[RES9]], [[RES10]] : i19
+  %lt = rtl.lt %small1, %small2 : i19
 
-  // CHECK-NEXT: rtl.ult [[RES9]], [[RES10]] : (i19, i19) -> i1
-  %ult = rtl.ult %small1, %small2 : (i19, i19) -> i1
+  // CHECK-NEXT: rtl.ult [[RES9]], [[RES10]] : i19
+  %ult = rtl.ult %small1, %small2 : i19
 
-  // CHECK-NEXT: rtl.leq [[RES9]], [[RES10]] : (i19, i19) -> i1
-  %leq = rtl.leq %small1, %small2 : (i19, i19) -> i1
+  // CHECK-NEXT: rtl.leq [[RES9]], [[RES10]] : i19
+  %leq = rtl.leq %small1, %small2 : i19
 
-  // CHECK-NEXT: rtl.uleq [[RES9]], [[RES10]] : (i19, i19) -> i1
-  %uleq = rtl.uleq %small1, %small2 : (i19, i19) -> i1
+  // CHECK-NEXT: rtl.uleq [[RES9]], [[RES10]] : i19
+  %uleq = rtl.uleq %small1, %small2 : i19
 
   // CHECK-NEXT:  = rtl.wire : i4
   %w = rtl.wire : i4

--- a/test/rtl/basic.mlir
+++ b/test/rtl/basic.mlir
@@ -36,6 +36,24 @@ func @test1(%arg0: i3, %arg1: i1) -> i50 {
   // CHECK-NEXT: rtl.add [[RES9]], [[RES10]] : i19
   %add = rtl.add %small1, %small2 : i19
 
+  // CHECK-NEXT: rtl.eq [[RES9]], [[RES10]] : (i19, i19) -> i1
+  %eq = rtl.eq %small1, %small2 : (i19, i19) -> i1
+
+  // CHECK-NEXT: rtl.neq [[RES9]], [[RES10]] : (i19, i19) -> i1
+  %neq = rtl.neq %small1, %small2 : (i19, i19) -> i1
+
+  // CHECK-NEXT: rtl.lt [[RES9]], [[RES10]] : (i19, i19) -> i1
+  %lt = rtl.lt %small1, %small2 : (i19, i19) -> i1
+
+  // CHECK-NEXT: rtl.ult [[RES9]], [[RES10]] : (i19, i19) -> i1
+  %ult = rtl.ult %small1, %small2 : (i19, i19) -> i1
+
+  // CHECK-NEXT: rtl.leq [[RES9]], [[RES10]] : (i19, i19) -> i1
+  %leq = rtl.leq %small1, %small2 : (i19, i19) -> i1
+
+  // CHECK-NEXT: rtl.uleq [[RES9]], [[RES10]] : (i19, i19) -> i1
+  %uleq = rtl.uleq %small1, %small2 : (i19, i19) -> i1
+
   // CHECK-NEXT:  = rtl.wire : i4
   %w = rtl.wire : i4
 

--- a/test/rtl/basic.mlir
+++ b/test/rtl/basic.mlir
@@ -36,23 +36,23 @@ func @test1(%arg0: i3, %arg1: i1) -> i50 {
   // CHECK-NEXT: rtl.add [[RES9]], [[RES10]] : i19
   %add = rtl.add %small1, %small2 : i19
 
-  // CHECK-NEXT: rtl.eq [[RES9]], [[RES10]] : i19
-  %eq = rtl.eq %small1, %small2 : i19
+  // CHECK-NEXT: rtl.icmp "eq" [[RES9]], [[RES10]] : i19
+  %eq = rtl.icmp "eq" %small1, %small2 : i19
 
-  // CHECK-NEXT: rtl.neq [[RES9]], [[RES10]] : i19
-  %neq = rtl.neq %small1, %small2 : i19
+  // CHECK-NEXT: rtl.icmp "ne" [[RES9]], [[RES10]] : i19
+  %neq = rtl.icmp "ne" %small1, %small2 : i19
 
-  // CHECK-NEXT: rtl.lt [[RES9]], [[RES10]] : i19
-  %lt = rtl.lt %small1, %small2 : i19
+  // CHECK-NEXT: rtl.icmp "slt" [[RES9]], [[RES10]] : i19
+  %lt = rtl.icmp "slt" %small1, %small2 : i19
 
-  // CHECK-NEXT: rtl.ult [[RES9]], [[RES10]] : i19
-  %ult = rtl.ult %small1, %small2 : i19
+  // CHECK-NEXT: rtl.icmp "ult" [[RES9]], [[RES10]] : i19
+  %ult = rtl.icmp "ult" %small1, %small2 : i19
 
-  // CHECK-NEXT: rtl.leq [[RES9]], [[RES10]] : i19
-  %leq = rtl.leq %small1, %small2 : i19
+  // CHECK-NEXT: rtl.icmp "sle" [[RES9]], [[RES10]] : i19
+  %leq = rtl.icmp "sle" %small1, %small2 : i19
 
-  // CHECK-NEXT: rtl.uleq [[RES9]], [[RES10]] : i19
-  %uleq = rtl.uleq %small1, %small2 : i19
+  // CHECK-NEXT: rtl.icmp "ule" [[RES9]], [[RES10]] : i19
+  %uleq = rtl.icmp "ule" %small1, %small2 : i19
 
   // CHECK-NEXT:  = rtl.wire : i4
   %w = rtl.wire : i4


### PR DESCRIPTION
Add comparison operators to the RTL dialect.  Include FIRRTL to RTL lowering and RTL to verilog emmision.  Signed RTL operations don't output to verilog correctly, but this is true for div and others, not just comparisons. Implements #82 