### PR TITLE
Fix the lint steps in the GH workflow to compare against the target branch

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -81,19 +81,25 @@ jobs:
     - name: choose-commit
       if: ${{ always() }}
       env:
-        PR_BASE: ${{ github.event.pull_request.base.sha }}
+        PR_BASE: ${{ github.base_ref }}
       run: |
         # Run clang-format
         if [[ -z "$PR_BASE" ]]; then
-          DIFF_COMMIT="HEAD^"
+          DIFF_COMMIT_NAME="HEAD^"
         else
-          DIFF_COMMIT="$PR_BASE"
+          DIFF_COMMIT_NAME="$PR_BASE"
         fi
-        echo "DIFF_COMMIT=$DIFF_COMMIT" >> $GITHUB_ENV
+        echo "DIFF_COMMIT_NAME=$DIFF_COMMIT_NAME" >> $GITHUB_ENV
     - name: git fetch base commit
       continue-on-error: true
       run: |
-        [[ ! "$DIFF_COMMIT" == *"HEAD"* ]] && git fetch origin $DIFF_COMMIT
+        if [[ ! "$DIFF_COMMIT_NAME" == *"HEAD"* ]]; then
+          git fetch --recurse-submodules=no origin $DIFF_COMMIT_NAME
+          DIFF_COMMIT_SHA=$( git rev-parse origin/$DIFF_COMMIT_NAME )
+        else
+          DIFF_COMMIT_SHA=$( git rev-parse $DIFF_COMMIT_NAME )
+        fi
+        echo "DIFF_COMMIT=$DIFF_COMMIT_SHA" >> $GITHUB_ENV
     - name: clang-format
       if: ${{ always() }}
       run: |

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -3,152 +3,259 @@ name: Build and Test
 on: [push, pull_request]
 
 jobs:
+  # Build the LLVM submodule then cache it. Do not rebuild if hit in the
+  # cache.
   build-llvm:
     name: Build LLVM
     runs-on: ubuntu-latest
     steps:
-    - name: Configure Environment
-      run: echo "::add-path::$GITHUB_WORKSPACE/llvm/install/bin"
-    - name: Get CIRCT
-      uses: actions/checkout@v2
-      with:
-        submodules: 'true'
-    - name: Get LLVM Hash
-      id: get-llvm-hash
-      run: echo "::set-output name=hash::$(git rev-parse @:./llvm)"
-      shell: bash
-    - name: Cache LLVM
-      id: cache-llvm
-      uses: actions/cache@v2
-      with:
-        path: llvm
-        key: ${{ runner.os }}-llvm-install-${{ steps.get-llvm-hash.outputs.hash }}
-    - name: Rebuild and Install LLVM
-      if: steps.cache-llvm.outputs.cache-hit != 'true'
-      run: |
-        mkdir llvm/build
-        mkdir llvm/install
-        cd llvm/build
-        cmake ../llvm -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_TARGETS_TO_BUILD="host" -DCMAKE_INSTALL_PREFIX=../install -DLLVM_ENABLE_PROJECTS='mlir' -DLLVM_OPTIMIZED_TABLEGEN=ON -DLLVM_ENABLE_OCAMLDOC=OFF -DLLVM_ENABLE_BINDINGS=OFF -DLLVM_INSTALL_UTILS=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLLVM_ENABLE_LLD=ON -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON
-        cmake --build . --target install -- -j$(nproc)
-  build:
+      - name: Configure Environment
+        run: echo "::add-path::$GITHUB_WORKSPACE/llvm/install/bin"
+
+      # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
+      # time.
+      - name: Get CIRCT
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+          submodules: "true"
+
+      # Extract the LLVM submodule hash for use in the cache key.
+      - name: Get LLVM Hash
+        id: get-llvm-hash
+        run: echo "::set-output name=hash::$(git rev-parse @:./llvm)"
+        shell: bash
+
+      # Try to fetch LLVM from the cache.
+      - name: Cache LLVM
+        id: cache-llvm
+        uses: actions/cache@v2
+        with:
+          path: llvm
+          key: ${{ runner.os }}-llvm-install-${{ steps.get-llvm-hash.outputs.hash }}
+
+      # Build LLVM if we didn't hit in the cache.
+      - name: Rebuild and Install LLVM
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        run: |
+          mkdir llvm/build
+          mkdir llvm/install
+          cd llvm/build
+          cmake ../llvm \
+            -DLLVM_BUILD_EXAMPLES=OFF \
+            -DLLVM_TARGETS_TO_BUILD="host" \
+            -DCMAKE_INSTALL_PREFIX=../install \
+            -DLLVM_ENABLE_PROJECTS='mlir' \
+            -DLLVM_OPTIMIZED_TABLEGEN=ON \
+            -DLLVM_ENABLE_OCAMLDOC=OFF \
+            -DLLVM_ENABLE_BINDINGS=OFF \
+            -DLLVM_INSTALL_UTILS=ON \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DLLVM_ENABLE_LLD=ON \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DLLVM_ENABLE_ASSERTIONS=ON
+          cmake --build . --target install -- -j$(nproc)
+
+    # Installing the results into the cache is an action which is automatically
+    # added by the cache action above.
+
+  # --- end of build-llvm job.
+
+  # Build CIRCT and run its tests.
+  build-circt:
     name: Build and Test
     needs: build-llvm
     runs-on: ubuntu-latest
     steps:
-    - name: Configure Environment
-      run: echo "::add-path::$GITHUB_WORKSPACE/llvm/install/bin"
-    - name: Get CIRCT
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 2
-        submodules: 'true'
-    - name: Install clang-tidy
-      run: |
-          sudo apt-get install -y clang-tidy-9
-          sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-9 100
-    - name: Get LLVM Hash
-      id: get-llvm-hash
-      run: echo "::set-output name=hash::$(git rev-parse @:./llvm)"
-      shell: bash
-    - name: Cache LLVM
-      id: cache-llvm
-      uses: actions/cache@v2
-      with:
-        path: llvm
-        key: ${{ runner.os }}-llvm-install-${{ steps.get-llvm-hash.outputs.hash }}
-    - name: Rebuild and Install LLVM
-      if: steps.cache-llvm.outputs.cache-hit != 'true'
-      run: |
-        mkdir llvm/build
-        mkdir llvm/install
-        cd llvm/build
-        cmake ../llvm -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_TARGETS_TO_BUILD="host" -DCMAKE_INSTALL_PREFIX=../install -DLLVM_ENABLE_PROJECTS='mlir' -DLLVM_OPTIMIZED_TABLEGEN=ON -DLLVM_ENABLE_OCAMLDOC=OFF -DLLVM_ENABLE_BINDINGS=OFF -DLLVM_INSTALL_UTILS=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLLVM_ENABLE_LLD=ON -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON
-        cmake --build . --target install -- -j$(nproc)
-    - name: Build and Test CIRCT (Assert)
-      run: |
-        mkdir build_assert
-        cd build_assert
-        cmake .. -DCMAKE_BUILD_TYPE=Debug -DLLVM_ENABLE_ASSERTIONS=ON -DMLIR_DIR=../llvm/install/lib/cmake/mlir/ -DLLVM_DIR=../llvm/install/lib/cmake/llvm/ -DCMAKE_LINKER=lld -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLLVM_EXTERNAL_LIT=`pwd`/../llvm/build/bin/llvm-lit -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-        make check-circt -j$(nproc)
-    - name: Build and Test CIRCT (Release)
-      run: |
-        mkdir build_release
-        cd build_release
-        cmake .. -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=OFF -DMLIR_DIR=../llvm/install/lib/cmake/mlir/ -DLLVM_DIR=../llvm/install/lib/cmake/llvm/ -DCMAKE_LINKER=lld -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLLVM_EXTERNAL_LIT=`pwd`/../llvm/build/bin/llvm-lit
-        make check-circt -j$(nproc)
+      - name: Configure Environment
+        run: echo "::add-path::$GITHUB_WORKSPACE/llvm/install/bin"
 
-    - name: choose-commit
-      if: ${{ always() }}
-      env:
-        PR_BASE: ${{ github.base_ref }}
-      run: |
-        # Run clang-format
-        if [[ -z "$PR_BASE" ]]; then
-          DIFF_COMMIT_NAME="HEAD^"
-        else
-          DIFF_COMMIT_NAME="$PR_BASE"
-        fi
-        echo "DIFF_COMMIT_NAME=$DIFF_COMMIT_NAME" >> $GITHUB_ENV
-    - name: git fetch base commit
-      continue-on-error: true
-      run: |
-        if [[ ! "$DIFF_COMMIT_NAME" == *"HEAD"* ]]; then
-          git fetch --recurse-submodules=no origin $DIFF_COMMIT_NAME
-          DIFF_COMMIT_SHA=$( git rev-parse origin/$DIFF_COMMIT_NAME )
-        else
-          DIFF_COMMIT_SHA=$( git rev-parse $DIFF_COMMIT_NAME )
-        fi
-        echo "DIFF_COMMIT=$DIFF_COMMIT_SHA" >> $GITHUB_ENV
-    - name: clang-format
-      if: ${{ always() }}
-      run: |
-        # Run clang-format
-        git clang-format-9 $DIFF_COMMIT
-        git diff --ignore-submodules > clang-format.patch
-        if [ -s clang-format.patch ]; then
-          echo "Clang-format found formatting problems in the following files. See diff in the clang-format.patch artifact."
-          git diff --ignore-submodules --name-only
-          git checkout .
-          exit 1
-        fi
-        echo "Clang-format found no formatting problems"
-        exit 0
-    - name: clang-tidy
-      if: ${{ always() }}
-      run: |
-        git diff -U0 $DIFF_COMMIT | clang-tidy-diff-9.py -path build_assert -p1 -fix
-        git diff --ignore-submodules > clang-tidy.patch
-        if [ -s clang-tidy.patch ]; then
-          echo "Clang-tidy problems in the following files. See diff in the clang-tidy.patch artifact."
-          git diff --ignore-submodules --name-only
-          git checkout .
-          exit 1
-        fi
-        echo "Clang-tidy found no problems"
-        exit 0
-    - name: Upload format and tidy patches
-      uses: actions/upload-artifact@v2
-      continue-on-error: true
-      if: ${{ failure() }}
-      with:
-        name: clang-format-tidy-patches
-        path: clang-*.patch
-    # Unfortunately, artifact uploads are always zips so display the diff as well
-    - name: clang format and tidy patches display
-      if: ${{ failure() }}
-      continue-on-error: true
-      run: |
-        # Display patches
-        if [ ! -z clang-format.patch ]; then
-          echo "Clang-format patch"
-          echo "================"
-          cat clang-format.patch
-          echo "================"
-        end
-        if [ ! -z clang-tidy.patch ]; then
-          echo "Clang-tidy patch"
-          echo "================"
-          cat clang-tidy.patch
-          echo "================"
-        end
+      # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
+      # time.
+      - name: Get CIRCT
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+          submodules: "true"
+
+      # We'll be running clang-tidy later in this flow.
+      - name: Install clang-tidy
+        run: |
+          sudo apt-get install -y clang-tidy-9
+          sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy \
+            /usr/bin/clang-tidy-9 100
+
+      # Extract the LLVM submodule hash for use in the cache key.
+      - name: Get LLVM Hash
+        id: get-llvm-hash
+        run: echo "::set-output name=hash::$(git rev-parse @:./llvm)"
+        shell: bash
+
+      # Try to fetch LLVM from the cache.
+      - name: Cache LLVM
+        id: cache-llvm
+        uses: actions/cache@v2
+        with:
+          path: llvm
+          key: ${{ runner.os }}-llvm-install-${{ steps.get-llvm-hash.outputs.hash }}
+
+      # Build LLVM if we didn't hit in the cache. Even though we build it in
+      # the previous job, there is a low chance that it'll have been evicted by
+      # the time we get here.
+      - name: Rebuild and Install LLVM
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        run: |
+          mkdir llvm/build
+          mkdir llvm/install
+          cd llvm/build
+          cmake ../llvm \
+            -DLLVM_BUILD_EXAMPLES=OFF \
+            -DLLVM_TARGETS_TO_BUILD="host" \
+            -DCMAKE_INSTALL_PREFIX=../install \
+            -DLLVM_ENABLE_PROJECTS='mlir' \
+            -DLLVM_OPTIMIZED_TABLEGEN=ON \
+            -DLLVM_ENABLE_OCAMLDOC=OFF \
+            -DLLVM_ENABLE_BINDINGS=OFF \
+            -DLLVM_INSTALL_UTILS=ON \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DLLVM_ENABLE_LLD=ON \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DLLVM_ENABLE_ASSERTIONS=ON
+          cmake --build . --target install -- -j$(nproc)
+
+      # Build the CIRCT test target in debug mode to build and test.
+      - name: Build and Test CIRCT (Assert)
+        run: |
+          mkdir build_assert
+          cd build_assert
+          cmake .. \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DLLVM_ENABLE_ASSERTIONS=ON \
+            -DMLIR_DIR=../llvm/install/lib/cmake/mlir/ \
+            -DLLVM_DIR=../llvm/install/lib/cmake/llvm/ \
+            -DCMAKE_LINKER=lld \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DLLVM_EXTERNAL_LIT=`pwd`/../llvm/build/bin/llvm-lit \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          make check-circt -j$(nproc)
+
+      # Build the CIRCT test target in release mode to build and test.
+      - name: Build and Test CIRCT (Release)
+        run: |
+          mkdir build_release
+          cd build_release
+          cmake .. \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DLLVM_ENABLE_ASSERTIONS=OFF \
+            -DMLIR_DIR=../llvm/install/lib/cmake/mlir/ \
+            -DLLVM_DIR=../llvm/install/lib/cmake/llvm/ \
+            -DCMAKE_LINKER=lld \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ 
+            -DLLVM_EXTERNAL_LIT=`pwd`/../llvm/build/bin/llvm-lit
+          make check-circt -j$(nproc)
+
+      # Choose the git commit to diff against for the purposes of linting.
+      # Since this workflow is triggered on both pushes and pull requests, we
+      # have to determine if the pull request target branch is set (which it
+      # will only be on the PR triggered flow). If it's not, then compare
+      # against the last commit.
+      - name: choose-commit
+        if: ${{ always() }}
+        env:
+          # Base ref is the target branch, in text form (not hash)
+          PR_BASE: ${{ github.base_ref }}
+        run: |
+          # Run clang-format
+          if [[ -z "$PR_BASE" ]]; then
+            DIFF_COMMIT_NAME="HEAD^"
+          else
+            DIFF_COMMIT_NAME="$PR_BASE"
+          fi
+          echo "DIFF_COMMIT_NAME=$DIFF_COMMIT_NAME" >> $GITHUB_ENV
+
+      # Since we did a shallow fetch for this repo, we must fetch the commit
+      # upon which we be diff'ing. The last step set the ref name in the
+      # $DIFF_COMMIT_NAME environment variable. When running the fetch, resolve
+      # it to the commit hash and pass that hash along to subsequent steps.
+      - name: git fetch base commit
+        continue-on-error: true
+        run: |
+          if [[ ! "$DIFF_COMMIT_NAME" == *"HEAD"* ]]; then
+            git fetch --recurse-submodules=no origin $DIFF_COMMIT_NAME
+            DIFF_COMMIT_SHA=$( git rev-parse origin/$DIFF_COMMIT_NAME )
+          else
+            DIFF_COMMIT_SHA=$( git rev-parse $DIFF_COMMIT_NAME )
+          fi
+          echo "DIFF_COMMIT=$DIFF_COMMIT_SHA" >> $GITHUB_ENV
+
+      # Run 'git clang-format', comparing against the target commit hash. If
+      # clang-format fixed anything, fail and output a patch.
+      - name: clang-format
+        if: ${{ always() }}
+        run: |
+          # Run clang-format
+          git clang-format-9 $DIFF_COMMIT
+          git diff --ignore-submodules > clang-format.patch
+          if [ -s clang-format.patch ]; then
+            echo "Clang-format found formatting problems in the following " \
+              "files. See diff in the clang-format.patch artifact."
+            git diff --ignore-submodules --name-only
+            git checkout .
+            exit 1
+          fi
+          echo "Clang-format found no formatting problems"
+          exit 0
+
+      # Run clang-tidy against only the changes. The 'clang-tidy-diff' script
+      # does this if supplied with the diff.
+      - name: clang-tidy
+        if: ${{ always() }}
+        run: |
+          git diff -U0 $DIFF_COMMIT | \
+            clang-tidy-diff-9.py -path build_assert -p1 -fix
+          git diff --ignore-submodules > clang-tidy.patch
+          if [ -s clang-tidy.patch ]; then
+            echo "Clang-tidy problems in the following files. " \
+              "See diff in the clang-tidy.patch artifact."
+            git diff --ignore-submodules --name-only
+            git checkout .
+            exit 1
+          fi
+          echo "Clang-tidy found no problems"
+          exit 0
+
+      # Upload the format and tidy patches to an artifact (zip'd) associated
+      # with the workflow run. Only run this on a failure.
+      - name: Upload format and tidy patches
+        uses: actions/upload-artifact@v2
+        continue-on-error: true
+        if: ${{ failure() }}
+        with:
+          name: clang-format-tidy-patches
+          path: clang-*.patch
+
+      # Unfortunately, artifact uploads are always zips so display the diff as
+      # well to provide feedback at a glance.
+      - name: clang format and tidy patches display
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: |
+          # Display patches
+          if [ ! -z clang-format.patch ]; then
+            echo "Clang-format patch"
+            echo "================"
+            cat clang-format.patch
+            echo "================"
+          end
+          if [ ! -z clang-tidy.patch ]; then
+            echo "Clang-tidy patch"
+            echo "================"
+            cat clang-tidy.patch
+            echo "================"
+          end
+
+    # --- end of build-circt job.

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -154,7 +154,7 @@ jobs:
             -DLLVM_DIR=../llvm/install/lib/cmake/llvm/ \
             -DCMAKE_LINKER=lld \
             -DCMAKE_C_COMPILER=clang \
-            -DCMAKE_CXX_COMPILER=clang++ 
+            -DCMAKE_CXX_COMPILER=clang++ \
             -DLLVM_EXTERNAL_LIT=`pwd`/../llvm/build/bin/llvm-lit
           make check-circt -j$(nproc)
 


### PR DESCRIPTION
It was apparently comparing against the fork point. (Two different
meanings of the word 'base' I think.) As a result, it would pick up
differences in the target branch since the fork point! Users would have
to merge before the PR to avoid this.