### PR TITLE
[RTL] Use 'name' attributes for their SSA names 

### DIFF
--- a/lib/Dialect/RTL/Dialect.cpp
+++ b/lib/Dialect/RTL/Dialect.cpp
@@ -37,7 +37,7 @@ struct RTLOpAsmDialectInterface : public OpAsmDialectInterface {
 
 RTLDialect::RTLDialect(MLIRContext *context)
     : Dialect(getDialectNamespace(), context,
-              ::mlir::TypeID::get<RTLDialect>()) {
+    ::mlir::TypeID::get<RTLDialect>()) {
 
   // Register operations.
   addOperations<

--- a/lib/Dialect/RTL/Dialect.cpp
+++ b/lib/Dialect/RTL/Dialect.cpp
@@ -27,7 +27,7 @@ struct RTLOpAsmDialectInterface : public OpAsmDialectInterface {
   void getAsmResultNames(Operation *op,
                          OpAsmSetValueNameFn setNameFn) const override {
     // If an operation have an optional 'name' attribute, use it.
-    if (op->getNumResults() > 0)
+    if (isa<WireOp>(op) && op->getNumResults() > 0)
       if (auto nameAttr = op->getAttrOfType<StringAttr>("name"))
         setNameFn(op->getResult(0), nameAttr.getValue());
   }

--- a/lib/Dialect/RTL/Dialect.cpp
+++ b/lib/Dialect/RTL/Dialect.cpp
@@ -18,8 +18,7 @@ using namespace rtl;
 namespace {
 
 // We implement the OpAsmDialectInterface so that RTL dialect operations
-// automatically interpret the name attribute on function arguments and
-// on operations as their SSA name.
+// automatically interpret the name attribute on operations as their SSA name.
 struct RTLOpAsmDialectInterface : public OpAsmDialectInterface {
   using OpAsmDialectInterface::OpAsmDialectInterface;
 

--- a/lib/Dialect/RTL/Dialect.cpp
+++ b/lib/Dialect/RTL/Dialect.cpp
@@ -15,15 +15,38 @@ using namespace rtl;
 // Dialect specification.
 //===----------------------------------------------------------------------===//
 
+namespace {
+
+// We implement the OpAsmDialectInterface so that RTL dialect operations
+// automatically interpret the name attribute on function arguments and
+// on operations as their SSA name.
+struct RTLOpAsmDialectInterface : public OpAsmDialectInterface {
+  using OpAsmDialectInterface::OpAsmDialectInterface;
+
+  /// Get a special name to use when printing the given operation. See
+  /// OpAsmInterface.td#getAsmResultNames for usage details and documentation.
+  void getAsmResultNames(Operation *op,
+                         OpAsmSetValueNameFn setNameFn) const override {
+    // If an operation have an optional 'name' attribute, use it.
+    if (op->getNumResults() > 0)
+      if (auto nameAttr = op->getAttrOfType<StringAttr>("name"))
+        setNameFn(op->getResult(0), nameAttr.getValue());
+  }
+};
+} // end anonymous namespace
+
 RTLDialect::RTLDialect(MLIRContext *context)
     : Dialect(getDialectNamespace(), context,
-    ::mlir::TypeID::get<RTLDialect>()) {
+              ::mlir::TypeID::get<RTLDialect>()) {
 
   // Register operations.
   addOperations<
 #define GET_OP_LIST
 #include "circt/Dialect/RTL/RTL.cpp.inc"
       >();
+
+  // Register interface implementations.
+  addInterfaces<RTLOpAsmDialectInterface>();
 }
 
 RTLDialect::~RTLDialect() {}

--- a/test/rtl/basic.mlir
+++ b/test/rtl/basic.mlir
@@ -36,8 +36,11 @@ func @test1(%arg0: i3, %arg1: i1) -> i50 {
   // CHECK-NEXT: rtl.add [[RES9]], [[RES10]] : i19
   %add = rtl.add %small1, %small2 : i19
 
-  // CHECK-NEXT:  = rtl.wire : i4
-  %w = rtl.wire : i4
+  // CHECK-NEXT: %rtl.wire : i4
+  %w1 = rtl.wire : i4
+
+  // CHECK-NEXT: %renamed = rtl.wire { name = "renamed" } : i4
+  %w2 = rtl.wire { name = "renamed" } : i4
 
   // CHECK-NEXT: = rtl.mux %arg1, [[RES2]], [[RES3]] : i7
   %mux = rtl.mux %arg1, %d, %e : i7

--- a/test/rtl/basic.mlir
+++ b/test/rtl/basic.mlir
@@ -36,11 +36,11 @@ func @test1(%arg0: i3, %arg1: i1) -> i50 {
   // CHECK-NEXT: rtl.add [[RES9]], [[RES10]] : i19
   %add = rtl.add %small1, %small2 : i19
 
-  // CHECK-NEXT: %rtl.wire : i4
-  %w1 = rtl.wire : i4
+  // CHECK-NEXT: rtl.wire : i4
+  %w = rtl.wire : i4
 
-  // CHECK-NEXT: %renamed = rtl.wire { name = "renamed" } : i4
-  %w2 = rtl.wire { name = "renamed" } : i4
+  // CHECK-NEXT: %after = rtl.wire {name = "after"} : i4
+  %before = rtl.wire { name = "after" } : i4
 
   // CHECK-NEXT: = rtl.mux %arg1, [[RES2]], [[RES3]] : i7
   %mux = rtl.mux %arg1, %d, %e : i7

--- a/test/rtl/basic.mlir
+++ b/test/rtl/basic.mlir
@@ -36,7 +36,7 @@ func @test1(%arg0: i3, %arg1: i1) -> i50 {
   // CHECK-NEXT: rtl.add [[RES9]], [[RES10]] : i19
   %add = rtl.add %small1, %small2 : i19
 
-  // CHECK-NEXT: = rtl.wire : i4
+  // CHECK-NEXT:  = rtl.wire : i4
   %w = rtl.wire : i4
 
   // CHECK-NEXT: %after = rtl.wire {name = "after"} : i4

--- a/test/rtl/basic.mlir
+++ b/test/rtl/basic.mlir
@@ -36,7 +36,7 @@ func @test1(%arg0: i3, %arg1: i1) -> i50 {
   // CHECK-NEXT: rtl.add [[RES9]], [[RES10]] : i19
   %add = rtl.add %small1, %small2 : i19
 
-  // CHECK-NEXT: rtl.wire : i4
+  // CHECK-NEXT: = rtl.wire : i4
   %w = rtl.wire : i4
 
   // CHECK-NEXT: %after = rtl.wire {name = "after"} : i4


### PR DESCRIPTION
For #90, this PR enables to use of values of `name` attributes as their SSA names by adding `OpAsmDialectInterfaces` to `RTLDialect`.

```
 %before = rtl.wire { name = "after" } : i4
```
will be converted into
```
 %after = rtl.wire { name = "after" } : i4
```

I'll create another PRs which hides `name` attribute, and set `name` attribute from their SSA name (as noted in #90)