### PR TITLE
Fixing the auto request review feature

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -1,7 +1,7 @@
 name: "Request review from code owner"
 on:
   pull_request_target:
-    # branches: [ master ]
+    branches: [ master ]
 
 jobs:
   # Automatically request reviews from the code owner identified in a set of

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -6,8 +6,8 @@ on:
 jobs:
   # Automatically request reviews from the code owner identified in a set of
   # JSON files in codeowners/.
-  assign_reviewer:
-    name: Assign reviews
+  request_reviewer:
+    name: "Request review from code owner"
     runs-on: ubuntu-latest
     steps:
       - name: Get CIRCT

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -1,7 +1,7 @@
-name: "Assign reviewers"
+name: "Request review from code owner"
 on:
-  pull_request:
-    branches: [ master ]
+  pull_request_target:
+    # branches: [ master ]
 
 jobs:
   # Automatically request reviews from the code owner identified in a set of
@@ -10,9 +10,14 @@ jobs:
     name: Assign reviews
     runs-on: ubuntu-latest
     steps:
+      - name: Get CIRCT
+        uses: actions/checkout@v2
+        with:
+          submodules: 'false'
       - name: apply-herald-rules
         id: herald
-        uses: gagoar/use-herald-action@v2.2.0
+        uses: gagoar/use-herald-action@master
+        continue-on-error: true
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           rulesLocation: codeowners/*.json

--- a/codeowners/github.json
+++ b/codeowners/github.json
@@ -2,5 +2,5 @@
   "name": "Add code owner to any github config change",
   "includes": [".github/**"],
   "action": "review",
-  "users": []
+  "users": ["teqdruid"]
 }

--- a/codeowners/github.json
+++ b/codeowners/github.json
@@ -1,6 +1,6 @@
 {
-  "name": "Add John to any github config PR",
+  "name": "Add code owner to any github config change",
   "includes": [".github/**"],
   "action": "review",
-  "users": ["teqdruid"]
+  "users": []
 }


### PR DESCRIPTION
The pull_request trigger's Github token didn't have enough permissions. 'pull_request_target' runs the pipeline in the target branch so it's given the correct perms.

Tested in another branch, though I'm still not 100% sure it'll work.