### PR TITLE
[RTL] Add name attribute if ssa has an useful name

### DIFF
--- a/include/circt/Dialect/RTL/Statements.td
+++ b/include/circt/Dialect/RTL/Statements.td
@@ -32,8 +32,7 @@ def WireOp : RTLOp<"wire"> {
 
   let arguments = (ins OptionalAttr<StrAttr>:$name);
   let results = (outs AnyType:$result);
-  
-  let assemblyFormat = [{
-     attr-dict `:` type($result)
-  }];
+
+  let printer = [{ printWireOp(p, *this); }];
+  let parser = [{ return parseWireOp(parser, result); }];
 }

--- a/lib/Dialect/RTL/Ops.cpp
+++ b/lib/Dialect/RTL/Ops.cpp
@@ -272,6 +272,65 @@ static inline ConstantIntMatcher m_RConstant(APInt &value) {
 }
 
 //===----------------------------------------------------------------------===//
+// WireOp
+//===----------------------------------------------------------------------===//
+
+static void printWireOp(OpAsmPrinter &p, WireOp &op) {
+  p << op.getOperationName();
+  // Note that we only need to print the "name" attribute if the asmprinter
+  // result name disagrees with it.  This can happen in strange cases, e.g.
+  // when there are conflicts.
+  bool namesDisagree = false;
+
+  SmallString<32> resultNameStr;
+  llvm::raw_svector_ostream tmpStream(resultNameStr);
+  p.printOperand(op.getResult(), tmpStream);
+  auto expectedName = op.nameAttr();
+  if (!expectedName ||
+      tmpStream.str().drop_front() != expectedName.getValue()) {
+    namesDisagree = true;
+  }
+
+  if (namesDisagree)
+    p.printOptionalAttrDict(op.getAttrs());
+  else
+    p.printOptionalAttrDict(op.getAttrs(), {"name"});
+
+  p << " : " << op.getType();
+}
+
+static ParseResult parseWireOp(OpAsmParser &parser, OperationState &result) {
+  Type resultType;
+
+  if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon() ||
+      parser.parseType(resultType))
+    return failure();
+
+  result.addTypes(resultType);
+
+  // If the attribute dictionary contains no 'name' attribute, infer it from
+  // the SSA name (if specified).
+  bool hadName = llvm::any_of(result.attributes, [](NamedAttribute attr) {
+    return attr.first == "name";
+  });
+
+  // If there was no name specified, check to see if there was a useful name
+  // specified in the asm file.
+  if (hadName)
+    return success();
+
+  auto resultName = parser.getResultName(0);
+  if (!resultName.first.empty() && !isdigit(resultName.first[0])){
+    StringRef name = resultName.first;
+    auto *context = result.getContext();
+    auto nameAttr = parser.getBuilder().getStringAttr(name);
+    result.attributes.push_back({Identifier::get("name", context), nameAttr});
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // ConstantOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/RTL/Ops.cpp
+++ b/lib/Dialect/RTL/Ops.cpp
@@ -320,7 +320,7 @@ static ParseResult parseWireOp(OpAsmParser &parser, OperationState &result) {
     return success();
 
   auto resultName = parser.getResultName(0);
-  if (!resultName.first.empty() && !isdigit(resultName.first[0])){
+  if (!resultName.first.empty() && !isdigit(resultName.first[0])) {
     StringRef name = resultName.first;
     auto *context = result.getContext();
     auto nameAttr = parser.getBuilder().getStringAttr(name);

--- a/test/EmitVerilog/rtl-dialect.mlir
+++ b/test/EmitVerilog/rtl-dialect.mlir
@@ -126,17 +126,17 @@ firrtl.circuit "M1" {
   //CHECK-NEXT:   input  w, x,
   //CHECK-NEXT:   output y, z);
   //CHECK-EMPTY: 
-  //CHECK-NEXT:   wire _T;
-  //CHECK-NEXT:   wire _T_0;
+  //CHECK-NEXT:   wire w1;
+  //CHECK-NEXT:   wire w2;
   //CHECK-EMPTY: 
   //CHECK-NEXT: A a1 (
   //CHECK-NEXT:     .d (w),
-  //CHECK-NEXT:     .e (_T),
-  //CHECK-NEXT:     .f (_T_0)
+  //CHECK-NEXT:     .e (w1),
+  //CHECK-NEXT:     .f (w2)
   //CHECK-NEXT:   )
   //CHECK-NEXT: B b1 (
-  //CHECK-NEXT:     .a (_T_0),
-  //CHECK-NEXT:     .b (_T),
+  //CHECK-NEXT:     .a (w2),
+  //CHECK-NEXT:     .b (w1),
   //CHECK-NEXT:     .c (y)
   //CHECK-NEXT:   )
   //CHECK-NEXT:   assign z = x;

--- a/test/firrtl/lower-to-rtl.mlir
+++ b/test/firrtl/lower-to-rtl.mlir
@@ -59,7 +59,7 @@
     // CHECK-NEXT: rtl.connect [[CAST1]], [[ZEXT]] : i4
     firrtl.connect %out4, %in2 : !firrtl.flip<uint<4>>, !firrtl.uint<2>
 
-    // CHECK-NEXT: = rtl.wire {name = "test-name"} : i4
+    // CHECK-NEXT: %test-name = rtl.wire : i4
     firrtl.wire {name = "test-name"} : !firrtl.uint<4>
 
     // CHECK-NEXT: = rtl.wire : i2
@@ -125,7 +125,7 @@
     %21 = firrtl.rem %3, %in3 : (!firrtl.sint<3>, !firrtl.sint<8>) -> !firrtl.sint<3>
 
     // CHECK-NEXT: [[CAST:%.+]] = firrtl.stdIntCast %in2 : (!firrtl.uint<2>) -> i2
-    // CHECK-NEXT: [[WIRE:%.+]] = rtl.wire {name = "n1"} : i2
+    // CHECK-NEXT: [[WIRE:%n1]] = rtl.wire : i2
     // CHECK-NEXT: rtl.connect [[WIRE]], [[CAST]] : i2
     %n1 = firrtl.node %in2  {name = "n1"} : !firrtl.uint<2>
 

--- a/test/rtl/basic.mlir
+++ b/test/rtl/basic.mlir
@@ -66,11 +66,19 @@ func @test1(%arg0: i3, %arg1: i1) -> i50 {
   // CHECK-NEXT: rtl.icmp "uge" [[RES9]], [[RES10]] : i19
   %ugeq = rtl.icmp "uge" %small1, %small2 : i19
 
-  // CHECK-NEXT:  = rtl.wire : i4
+  // CHECK-NEXT:  %w = rtl.wire : i4
   %w = rtl.wire : i4
 
-  // CHECK-NEXT: %after = rtl.wire {name = "after"} : i4
-  %before = rtl.wire { name = "after" } : i4
+  // CHECK-NEXT: %after1 = rtl.wire : i4
+  %before1 = rtl.wire {name = "after1"} : i4
+
+  // CHECK-NEXT: %after2_conflict = rtl.wire : i4
+  // CHECK-NEXT: %after2_conflict_0 = rtl.wire {name = "after2_conflict"} : i4
+  %before2_0 = rtl.wire {name = "after2_conflict"} : i4
+  %before2_1 = rtl.wire {name = "after2_conflict"} : i4
+
+  // CHECK-NEXT: %after3 = rtl.wire {someAttr = "foo"} : i4
+  %before3 = rtl.wire {name = "after3", someAttr = "foo"} : i4
 
   // CHECK-NEXT: = rtl.mux %arg1, [[RES2]], [[RES3]] : i7
   %mux = rtl.mux %arg1, %d, %e : i7

--- a/test/rtl/basic.mlir
+++ b/test/rtl/basic.mlir
@@ -66,7 +66,7 @@ func @test1(%arg0: i3, %arg1: i1) -> i50 {
   // CHECK-NEXT: rtl.icmp "uge" [[RES9]], [[RES10]] : i19
   %ugeq = rtl.icmp "uge" %small1, %small2 : i19
 
-  // CHECK-NEXT:  %w = rtl.wire : i4
+  // CHECK-NEXT: %w = rtl.wire : i4
   %w = rtl.wire : i4
 
   // CHECK-NEXT: %after1 = rtl.wire : i4


### PR DESCRIPTION
For #90, this PR enables the following things:

- Implement own printer and parser
- Recognize the name of SSA value of `WireOp` in parser and set their name to the `name` attribute
- Hide name attribute in the printer if it is used in SSA name

I basically follow the method used for `StringAttrPrettyNameOp` in [mlir/test/lib/Dialect/Test/TestDialect.cpp](https://github.com/llvm/llvm-project/blob/3ea4ccd857c3ab83aff9dcceeb82c33681658a32/mlir/test/lib/Dialect/Test/TestDialect.cpp#L718) (introduced by [D76205](https://reviews.llvm.org/D76205))
