### PR TITLE
add rtl.extmodule to represent external modules.

### DIFF
--- a/include/circt/Dialect/FIRRTL/OpStructure.td
+++ b/include/circt/Dialect/FIRRTL/OpStructure.td
@@ -112,8 +112,7 @@ def FExtModuleOp : FIRRTLOp<"extmodule",
   let summary = "FIRRTL extmodule";
   let description = [{
     The "firrtl.extmodule" operation represents an external reference to a
-    Verilog module, including a given name, a list of ports, and a body that
-    represents the connections within the module.
+    Verilog module, including a given name and a list of ports.
   }];
   let arguments = (ins OptionalAttr<StrAttr>:$defname,
                        OptionalAttr<DictionaryAttr>:$parameters);

--- a/include/circt/Dialect/RTL/Structure.td
+++ b/include/circt/Dialect/RTL/Structure.td
@@ -60,13 +60,12 @@ def RTLModuleOp : RTLOp<"module",
 
 def RTLExtModuleOp : RTLOp<"extmodule",
       [IsolatedFromAbove, FunctionLike, Symbol]> {
-  let summary = "RTL extModule";
+  let summary = "RTL external Module";
   let description = [{
     The "rtl.extmodule" operation represents an external reference to a Verilog
     module, including a given name and a list of ports.
   }];
-  let arguments = (ins OptionalAttr<StrAttr>:$defname,
-                       OptionalAttr<DictionaryAttr>:$parameters);
+  let arguments = (ins OptionalAttr<DictionaryAttr>:$parameters);
   let results = (outs);
   let regions = (region AnyRegion:$body);
 

--- a/include/circt/Dialect/RTL/Structure.td
+++ b/include/circt/Dialect/RTL/Structure.td
@@ -22,9 +22,6 @@ def RTLModuleOp : RTLOp<"module",
     // Implement RegionKindInterface.
     static RegionKind getRegionKind(unsigned index) { return RegionKind::Graph;}
 
-    void getRTLModulePortInfo(Operation *op,
-                              SmallVectorImpl<RTLModulePortInfo> &results);
-    
     // Decode information about the input and output ports on this module.
     void getRTLPortInfo(SmallVectorImpl<RTLModulePortInfo> &results) {
       getRTLModulePortInfo(*this, results);
@@ -60,6 +57,57 @@ def RTLModuleOp : RTLOp<"module",
   let printer = [{ return ::print(p, *this); }];
   let parser = [{ return ::parse$cppClass(parser, result); }];
 }
+
+def RTLExtModuleOp : RTLOp<"extmodule",
+      [IsolatedFromAbove, FunctionLike, Symbol]> {
+  let summary = "RTL extModule";
+  let description = [{
+    The "rtl.extmodule" operation represents an external reference to a Verilog
+    module, including a given name and a list of ports.
+  }];
+  let arguments = (ins OptionalAttr<StrAttr>:$defname,
+                       OptionalAttr<DictionaryAttr>:$parameters);
+  let results = (outs);
+  let regions = (region AnyRegion:$body);
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<"StringAttr name, ArrayRef<RTLModulePortInfo> ports">
+  ];
+
+  let extraClassDeclaration = [{   
+    // Decode information about the input and output ports on this module.
+    void getRTLPortInfo(SmallVectorImpl<RTLModulePortInfo> &results) {
+      getRTLModulePortInfo(*this, results);
+    }
+
+  private:
+    // This trait needs access to the hooks defined below.
+    friend class OpTrait::FunctionLike<RTLExtModuleOp>;
+
+    /// Returns the number of arguments, implementing OpTrait::FunctionLike.
+    unsigned getNumFuncArguments() { return getType().getInputs().size(); }
+    /// Returns the number of results, implementing OpTrait::FunctionLike.
+    unsigned getNumFuncResults() { return getType().getResults().size(); }
+
+    /// Hook for OpTrait::FunctionLike, called after verifying that the 'type'
+    /// attribute is present and checks if it holds a function type.  Ensures
+    /// getType, getNumFuncArguments, and getNumFuncResults can be called
+    ///  safely.
+    LogicalResult verifyType() {
+      auto type = getTypeAttr().getValue();
+      if (!type.isa<FunctionType>())
+        return emitOpError("requires '" + getTypeAttrName() +
+                           "' attribute of function type");
+      return success();
+    }
+  public:
+  }];
+
+  let printer = [{ return ::print(p, *this); }];
+  let parser = [{ return ::parse$cppClass(parser, result); }];
+}
+
 
 def RTLInstanceOp : RTLOp<"instance", []> {
   let summary = "Create an instance of a module";

--- a/test/EmitVerilog/rtl-dialect.mlir
+++ b/test/EmitVerilog/rtl-dialect.mlir
@@ -108,6 +108,9 @@ firrtl.circuit "M1" {
   // CHECK-NEXT:  assign f = d & e;
   // CHECK-NEXT:  assign f = d ? d : e;
   // CHECK-NEXT: endmodule
+  rtl.module @AAA(%d: i1 {rtl.direction = "in"}, 
+                %e: i1 {rtl.direction = "in"}, 
+                %f: i1 {rtl.direction = "out"}){}
 
   rtl.module @AB(%w: i1 {rtl.direction = "in"}, 
                  %x: i1 {rtl.direction = "in"}, 
@@ -117,7 +120,7 @@ firrtl.circuit "M1" {
     %w1 = rtl.wire : i1
     %w2 = rtl.wire : i1
 
-    rtl.instance "a1" @A(%w, %w1, %w2) : i1, i1, i1
+    rtl.instance "a1" @AAA(%w, %w1, %w2) : i1, i1, i1
     rtl.instance "b1" @B(%w2, %w1, %y) : i1, i1, i1
 
     rtl.connect %z, %x : i1

--- a/test/rtl/errors.mlir
+++ b/test/rtl/errors.mlir
@@ -40,7 +40,7 @@ func @test_and() {
 func @notModule () {}
 
 rtl.module @A(%arg0: i1) {
-  // expected-error @+1 {{Symbol resolved to 'func', not a RTLModuleOp}}
+  // expected-error @+1 {{Symbol resolved to 'func', not a RTL[Ext]ModuleOp}}
   rtl.instance "foo" @notModule(%arg0) : i1
 }
 

--- a/test/rtl/modules.mlir
+++ b/test/rtl/modules.mlir
@@ -16,12 +16,21 @@ module {
   // CHECK-NEXT:    rtl.connect %arg1, %0 : i1
   // CHECK-NEXT:    rtl.connect %arg2, %1 : i1
 
+  rtl.extmodule @C(%a: i1 {rtl.direction = "in"}, 
+                   %b: i1 {rtl.direction = "out"}, 
+                   %c: i1 {rtl.direction = "out"})
+
+  // CHECK-LABEL: rtl.extmodule @C(i1 {rtl.direction = "in", rtl.name = "a"}, i1 {rtl.direction = "out", rtl.name = "b"}, i1 {rtl.direction = "out", rtl.name = "c"})
+
   rtl.module @A(%d: i1 {rtl.direction = "in"}, 
                 %e: i1 {rtl.direction = "in"}, 
                 %f: i1 {rtl.direction = "out"}) {
 
     rtl.instance "b1" @B(%d, %e, %f) : i1, i1, i1
+    rtl.instance "c1" @C(%d, %e, %f) : i1, i1, i1
   }
   // CHECK-LABEL: rtl.module @A(%arg0: i1 {rtl.direction = "in", rtl.name = "d"}, %arg1: i1 {rtl.direction = "in", rtl.name = "e"}, %arg2: i1 {rtl.direction = "out", rtl.name = "f"}) {
   // CHECK-NEXT:  rtl.instance "b1" @B(%arg0, %arg1, %arg2) : i1, i1, i1
+  // CHECK-NEXT:  rtl.instance "c1" @C(%arg0, %arg1, %arg2) : i1, i1, i1
+
 }

--- a/test/rtl/modules.mlir
+++ b/test/rtl/modules.mlir
@@ -21,6 +21,14 @@ module {
                    %c: i1 {rtl.direction = "out"})
 
   // CHECK-LABEL: rtl.extmodule @C(i1 {rtl.direction = "in", rtl.name = "a"}, i1 {rtl.direction = "out", rtl.name = "b"}, i1 {rtl.direction = "out", rtl.name = "c"})
+  // CHECK-NOT: {
+
+  rtl.extmodule @D_ATTR(%a: i1 {rtl.direction = "in"}, 
+                   %b: i1 {rtl.direction = "out"}, 
+                   %c: i1 {rtl.direction = "out"}) attributes {filename = "test.v", parameters = {DEFAULT = 0 : i64}}
+
+  // CHECK-LABEL: rtl.extmodule @D_ATTR(i1 {rtl.direction = "in", rtl.name = "a"}, i1 {rtl.direction = "out", rtl.name = "b"}, i1 {rtl.direction = "out", rtl.name = "c"}) attributes {filename = "test.v", parameters = {DEFAULT = 0 : i64}}
+  // CHECK-NOT: {
 
   rtl.module @A(%d: i1 {rtl.direction = "in"}, 
                 %e: i1 {rtl.direction = "in"}, 


### PR DESCRIPTION
Add rtl.extmodule in the same style as firrtl.extmodule.  rtl.extmodule represents external modules which need to be instantiated but whose code is not in the IR.