### PR TITLE
Add RegisterOp to StaticLogic dialect

### DIFF
--- a/include/circt/Dialect/StaticLogic/StaticLogic.td
+++ b/include/circt/Dialect/StaticLogic/StaticLogic.td
@@ -41,6 +41,8 @@ def PipelineOp : Op<StaticLogic_Dialect, "pipeline", [NoSideEffect]> {
   let results = (outs Variadic<AnyType>);
   let regions = (region AnyRegion: $body);
 
+  let hasCanonicalizer = 1;
+
   let skipDefaultBuilders = 1;
 
   let builders = [OpBuilderDAG<(ins "ValueRange":$operands, "ValueRange":$results), [{
@@ -62,8 +64,30 @@ def PipelineOp : Op<StaticLogic_Dialect, "pipeline", [NoSideEffect]> {
   }]>];
 }
 
+def RegisterOp : Op<StaticLogic_Dialect, "register", 
+    [NoSideEffect, Terminator]> {
+  let summary = "register operation";
+  let description = [{
+    The "staticlogic.register" operation is the terminator of blocks inside of a
+    pipeline region. In the further lowering, operands of this operation are
+    corresponding to registers between pipeline stages.
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$destOperands);
+  let successors = (successor AnySuccessor:$dest);
+
+  let builders = [OpBuilder<"OperandRange destOperands, Block *dest", [{
+    odsState.addOperands(destOperands);
+    odsState.addSuccessors(dest);
+  }]>];
+
+  let assemblyFormat = [{
+    $dest (`(` $destOperands^ `:` type($destOperands) `)`)? attr-dict
+  }];
+}
+
 def ReturnOp : Op<StaticLogic_Dialect, "return", [Terminator]> {
-  let summary = "StaticLogic dialect return.";
+  let summary = "StaticLogic dialect return";
   let description = [{
     The "staticlogic.return" operation represents a terminator of a statically 
     scheduled module, which is similar to a standard return operation.

--- a/include/circt/Dialect/StaticLogic/StaticLogic.td
+++ b/include/circt/Dialect/StaticLogic/StaticLogic.td
@@ -69,8 +69,8 @@ def RegisterOp : Op<StaticLogic_Dialect, "register",
   let summary = "register operation";
   let description = [{
     The "staticlogic.register" operation is the terminator of blocks inside of a
-    pipeline region. In the further lowering, operands of this operation are
-    corresponding to registers between pipeline stages.
+    pipeline region. In the further lowering, operands of this operation will be
+    lowered to registers between pipeline stages.
   }];
 
   let arguments = (ins Variadic<AnyType>:$destOperands);

--- a/lib/Dialect/StaticLogic/StaticLogicOps.cpp
+++ b/lib/Dialect/StaticLogic/StaticLogicOps.cpp
@@ -12,6 +12,7 @@
 
 #include "circt/Dialect/StaticLogic/StaticLogic.h"
 #include "mlir/IR/FunctionImplementation.h"
+#include "mlir/IR/PatternMatch.h"
 
 using namespace mlir;
 using namespace circt;
@@ -27,4 +28,77 @@ StaticLogicDialect::StaticLogicDialect(MLIRContext *context)
 #define GET_OP_LIST
 #include "circt/Dialect/StaticLogic/StaticLogic.cpp.inc"
       >();
+}
+
+//===----------------------------------------------------------------------===//
+// PipelineOp
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// This canonicalizer will ensure all values passed between pipeline stages are
+/// going through the register operation.
+struct CanonicalizePipeline : public OpRewritePattern<PipelineOp> {
+  using OpRewritePattern<PipelineOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(PipelineOp pipeline,
+                                PatternRewriter &rewriter) const override {
+    for (auto &block : pipeline.getRegion()) {
+      auto registerOp = dyn_cast<RegisterOp>(block.getTerminator());
+      if (!registerOp)
+        continue;
+
+      auto dest = registerOp.dest();
+      SmallVector<Value, 8> registers;
+
+      // Walk through all block arguments. If an argument is used by other
+      // blocks, it needs to be registered.
+      for (auto arg : block.getArguments()) {
+        for (auto &use : arg.getUses()) {
+          if (use.getOwner()->getBlock() != &block) {
+            registers.push_back(arg);
+            break;
+          }
+        }
+      }
+
+      // Walk through all results of all operations in the block. If a result is
+      // used by other blocks, it needs to be regitered.
+      for (auto &op : block) {
+        for (auto result : op.getResults()) {
+          for (auto &use : result.getUses()) {
+            if (use.getOwner()->getBlock() != &block) {
+              // Only push back unique operands.
+              if (std::find(registers.begin(), registers.end(), result) ==
+                  registers.end())
+                registers.push_back(result);
+              break;
+            }
+          }
+        }
+      }
+
+      // Update register operation's operands list and the successor's arguments
+      // list.
+      auto destOperands = registerOp.destOperandsMutable();
+
+      for (auto value : registers) {
+        destOperands.append(value);
+        auto arg = dest->addArgument(value.getType());
+        value.replaceUsesWithIf(arg, [&block](OpOperand &use) {
+          return use.getOwner()->getBlock() != &block;
+        });
+      }
+
+      rewriter.setInsertionPoint(registerOp);
+      rewriter.create<RegisterOp>(registerOp.getLoc(), destOperands, dest);
+      rewriter.eraseOp(registerOp);
+    }
+    return success();
+  }
+};
+} // end anonymous namespace.
+
+void PipelineOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
+                                             MLIRContext *context) {
+  results.insert<CanonicalizePipeline>(context);
 }

--- a/test/Dialect/StaticLogic/test_register.mlir
+++ b/test/Dialect/StaticLogic/test_register.mlir
@@ -1,0 +1,26 @@
+// RUN: circt-opt -canonicalize %s | FileCheck %s
+
+// CHECK: ^bb0(%[[ARG_3:.*]]: index, %[[ARG_4:.*]]: index, %[[ARG_5:.*]]: index):  // no predecessors
+// CHECK:   %[[VAL_1:.*]] = addi %[[ARG_3:.*]], %[[ARG_4:.*]] : index
+// CHECK:   staticlogic.register ^bb1(%[[ARG_5:.*]], %[[VAL_1:.*]] : index, index)
+// CHECK: ^bb1(%[[VAL_2:.*]]: index, %[[VAL_3:.*]]: index):  // pred: ^bb0
+// CHECK:   %[[VAL_4:.*]] = addi %[[VAL_3:.*]], %[[VAL_2:.*]] : index
+// CHECK:   staticlogic.register ^bb2(%[[VAL_3:.*]], %[[VAL_4:.*]] : index, index)
+// CHECK: ^bb2(%[[VAL_5:.*]]: index, %[[VAL_6:.*]]: index):  // pred: ^bb1
+// CHECK:   %[[VAL_7:.*]] = addi %[[VAL_5:.*]], %[[VAL_6:.*]] : index
+// CHECK:   "staticlogic.return"(%[[VAL_7:.*]]) : (index) -> ()
+
+func @ops(%arg0: index, %arg1: index, %arg2: index) -> index {
+  %0 = "staticlogic.pipeline"(%arg0, %arg1, %arg2) ( {
+  ^bb0(%arg3: index, %arg4: index, %arg5: index):  // no predecessors
+    %1 = addi %arg3, %arg4 : index
+    staticlogic.register ^bb1
+  ^bb1:  // pred: ^bb0
+    %2 = addi %1, %arg5 : index
+    staticlogic.register ^bb2
+  ^bb2:  // pred: ^bb1
+    %3 = addi %1, %2 : index
+    "staticlogic.return"(%3) : (index) -> ()
+  }) : (index, index, index) -> index
+  return %0 : index
+}


### PR DESCRIPTION
Resolves #122. This patch also adds a canonicalizer for the Pipeline operation to ensure all live-ins and live-outs of a pipeline stage are passed through register operations.