### PR TITLE
[FIRRTL] Add ExtModule Verification

### DIFF
--- a/include/circt/Dialect/FIRRTL/Types.h
+++ b/include/circt/Dialect/FIRRTL/Types.h
@@ -47,6 +47,11 @@ public:
   /// used for `mem` operations.
   FIRRTLType getMaskType();
 
+  /// Return this type with widths of all ground types removed. This
+  /// enables two types to be compared by structure and name ignoring
+  /// widths.
+  FIRRTLType getWidthlessType();
+
   /// If this is an IntType, AnalogType, or sugar type for a single bit (Clock,
   /// Reset, etc) then return the bitwidth.  Return -1 if the is one of these
   /// types but without a specified bitwidth.  Return -2 if this isn't a simple

--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -150,8 +150,7 @@ static LogicalResult verifyCircuitOp(CircuitOp &circuit) {
     for (auto p : llvm::zip(ports, collidingPorts)) {
       StringAttr aName, bName;
       FIRRTLType aType, bType;
-      std::forward_as_tuple(std::tie(aName, aType),
-                            std::tie(bName, bType)) = p;
+      std::forward_as_tuple(std::tie(aName, aType), std::tie(bName, bType)) = p;
       if (extModule.parameters() || collidingExtModule.parameters()) {
         aType = aType.getWidthlessType();
         bType = bType.getWidthlessType();

--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -110,21 +110,16 @@ static LogicalResult verifyCircuitOp(CircuitOp &circuit) {
     // extmodule verification as checking against a parameterless
     // module is stricter.
     FExtModuleOp collidingExtModule;
-    {
-      auto &value = defnameMap[defname];
-      if (value) {
-        collidingExtModule = value;
-        if (value.parameters() && !extModule.parameters())
-          value = extModule;
-      } else {
+    if (auto &value = defnameMap[defname]) {
+      collidingExtModule = value;
+      if (value.parameters() && !extModule.parameters())
         value = extModule;
-      }
-    }
-
-    // Go to next extmodule if no extmodule with the same defname
-    // was found.
-    if (!collidingExtModule)
+    } else {
+      value = extModule;
+      // Go to the next extmodule if no extmodule with the same
+      // defname was found.
       continue;
+    }
 
     // Check that the number of ports is exactly the same.
     SmallVector<std::pair<StringAttr, FIRRTLType>, 8> ports;

--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -7,6 +7,7 @@
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/FunctionImplementation.h"
 #include "mlir/IR/StandardTypes.h"
+#include "llvm/ADT/StringMap.h"
 
 using namespace circt;
 using namespace firrtl;
@@ -72,6 +73,118 @@ static LogicalResult verifyCircuitOp(CircuitOp &circuit) {
     circuit.emitOpError("must contain one module that matches main name '" +
                         main + "'");
     return failure();
+  }
+
+  // Store a mapping of defname strings to the first external module
+  // that defines it.
+  llvm::StringMap<FExtModuleOp> defnameMap;
+
+  // Verify external modules.
+  for (auto &op : *circuit.getBody()) {
+    if (auto extModule = dyn_cast<FExtModuleOp>(op)) {
+      if (auto defname = extModule.defnameAttr()) {
+        // Check that this extmodule's defname does not conflict with
+        // the symbol name of any module.
+        auto collidingModule = circuit.lookupSymbol(defname.getValue());
+        if (isa_and_nonnull<FModuleOp>(collidingModule)) {
+          auto diag =
+              op.emitOpError()
+              << "attribute 'defname' with value " << defname
+              << " conflicts with the name of another module in the circuit";
+          diag.attachNote(collidingModule->getLoc())
+              << "previous module declared here";
+          return failure();
+        }
+
+        // Find an optional extmodule with a defname collision. Update
+        // the defnameMap if this is the first extmodule with that
+        // defname or if the current extmodule takes no parameters and
+        // the collision does. The latter condition improves later
+        // extmodule verification as checking against a parameterless
+        // module is stricter.
+        auto collidingExtModuleOpt =
+            Optional<FExtModuleOp>(llvm::NoneType::None);
+        {
+          auto value = defnameMap.find(defname.getValue());
+          if (value != defnameMap.end()) {
+            collidingExtModuleOpt = Optional<FExtModuleOp>(value->getValue());
+            if (value->getValue().parameters() && !extModule.parameters())
+              defnameMap.insert_or_assign(defname.getValue(), extModule);
+          } else {
+            defnameMap.insert_or_assign(defname.getValue(), extModule);
+          }
+        }
+
+        // Go to next extmodule if no extmodule with the same defname
+        // was found.
+        if (!collidingExtModuleOpt)
+          continue;
+
+        auto collidingExtModule = collidingExtModuleOpt.getValue();
+
+        // Check that the number of ports is exactly the same.
+        auto ports = new SmallVector<std::pair<StringAttr, FIRRTLType>, 8>;
+        auto collidingPorts =
+            new SmallVector<std::pair<StringAttr, FIRRTLType>, 8>;
+        extModule.getPortInfo(*ports);
+        collidingExtModule.getPortInfo(*collidingPorts);
+        if (ports->size() != collidingPorts->size()) {
+          auto diag = op.emitOpError()
+                      << "with 'defname' attribute " << defname << " has "
+                      << ports->size()
+                      << " ports which is different from a previously defined "
+                         "extmodule with the same 'defname' which has "
+                      << collidingPorts->size() << " ports";
+          diag.attachNote(collidingExtModule.getLoc())
+              << "previous extmodule definition occurred here";
+          return failure();
+        }
+
+        // Check that ports match for name and type. Since parameters
+        // *might* affect widths, ignore widths if either module has
+        // parameters. Note that this allows for misdetections, but
+        // has zero false positives.
+        for (auto p : llvm::zip(*ports, *collidingPorts)) {
+          auto a_name = std::get<0>(std::get<0>(p));
+          auto b_name = std::get<0>(std::get<1>(p));
+          FIRRTLType a_type, b_type;
+          if (extModule.parameters() || collidingExtModule.parameters()) {
+            a_type = std::get<1>(std::get<0>(p)).getWidthlessType();
+            b_type = std::get<1>(std::get<1>(p)).getWidthlessType();
+          } else {
+            a_type = std::get<1>(std::get<0>(p));
+            b_type = std::get<1>(std::get<1>(p));
+          }
+          if (a_name != b_name) {
+            auto diag = op.emitOpError()
+                        << "with 'defname' attribute " << defname
+                        << " has a port with name " << a_name
+                        << " which does not match the name of the port "
+                        << "in the same position of a previously defined "
+                        << "extmodule with the same 'defname', expected port "
+                           "to have name "
+                        << b_name;
+            diag.attachNote(collidingExtModule.getLoc())
+                << "previous extmodule definition occurred here";
+            return failure();
+          }
+          if (a_type != b_type) {
+            auto diag = op.emitOpError()
+                        << "with 'defname' attribute " << defname
+                        << " has a port with name " << a_name
+                        << " which has a different type " << a_type
+                        << " which does not match the type of the port in "
+                           "the same position of a previously defined "
+                           "extmodule with the same 'defname', expected port "
+                           "to have type "
+                        << b_type;
+            diag.attachNote(collidingExtModule.getLoc())
+                << "previous extmodule definition occurred here";
+            return failure();
+          }
+        }
+      }
+    }
   }
 
   return success();

--- a/test/firrtl/errors.mlir
+++ b/test/firrtl/errors.mlir
@@ -122,3 +122,72 @@ firrtl.circuit "Foo" {
     %a = firrtl.reginit %clk, %reset, %zero {name = "a"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.flip<uint<1>>
   }
 }
+
+// -----
+
+firrtl.circuit "Foo" {
+
+  // expected-error @+1 {{'firrtl.extmodule' op attribute 'defname' with value "Bar" conflicts with the name of another module in the circuit}}
+  firrtl.extmodule @Foo() attributes { defname = "Bar" }
+  // expected-note @+1 {{previous module declared here}}
+  firrtl.module @Bar() {}
+  // Allow an extmodule to conflict with its own symbol name
+  firrtl.extmodule @Baz() attributes { defname = "Baz" }
+
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+
+  // expected-note @+1 {{previous extmodule definition occurred here}}
+  firrtl.extmodule @Foo(%a : !firrtl.uint<1>) attributes { defname = "Foo" }
+  // expected-error @+1 {{'firrtl.extmodule' op with 'defname' attribute "Foo" has 0 ports which is different from a previously defined extmodule with the same 'defname' which has 1 ports}}
+  firrtl.extmodule @Bar() attributes { defname = "Foo" }
+
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+
+  // expected-note @+1 {{previous extmodule definition occurred here}}
+  firrtl.extmodule @Foo(%a : !firrtl.uint<1>) attributes { defname = "Foo" }
+  // expected-error @+1 {{'firrtl.extmodule' op with 'defname' attribute "Foo" has a port with name "b" which does not match the name of the port in the same position of a previously defined extmodule with the same 'defname', expected port to have name "a"}}
+  firrtl.extmodule @Foo_(%b : !firrtl.uint<1>) attributes { defname = "Foo" }
+
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+
+  firrtl.extmodule @Foo(%a : !firrtl.uint<2>) attributes { defname = "Foo", parameters = { width = 2 : i32 } }
+  // expected-note @+1 {{previous extmodule definition occurred here}}
+  firrtl.extmodule @Bar(%a : !firrtl.uint<1>) attributes { defname = "Foo" }
+  // expected-error @+1 {{'firrtl.extmodule' op with 'defname' attribute "Foo" has a port with name "a" which has a different type '!firrtl.uint<2>' which does not match the type of the port in the same position of a previously defined extmodule with the same 'defname', expected port to have type '!firrtl.uint<1>'}}
+  firrtl.extmodule @Baz(%a : !firrtl.uint<2>) attributes { defname = "Foo" }
+
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+
+  // expected-note @+1 {{previous extmodule definition occurred here}}
+  firrtl.extmodule @Foo(%a : !firrtl.uint<1>) attributes { defname = "Foo" }
+  // expected-error @+1 {{'firrtl.extmodule' op with 'defname' attribute "Foo" has a port with name "a" which has a different type '!firrtl.sint<1>' which does not match the type of the port in the same position of a previously defined extmodule with the same 'defname', expected port to have type '!firrtl.uint<1>'}}
+  firrtl.extmodule @Foo_(%a : !firrtl.sint<1>) attributes { defname = "Foo" }
+
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+
+  // expected-note @+1 {{previous extmodule definition occurred here}}
+  firrtl.extmodule @Foo(%a : !firrtl.uint<2>) attributes { defname = "Foo", parameters = { width = 2 : i32 } }
+  // expected-error @+1 {{'firrtl.extmodule' op with 'defname' attribute "Foo" has a port with name "a" which has a different type '!firrtl.sint' which does not match the type of the port in the same position of a previously defined extmodule with the same 'defname', expected port to have type '!firrtl.uint'}}
+  firrtl.extmodule @Bar(%a : !firrtl.sint<1>) attributes { defname = "Foo" }
+
+}


### PR DESCRIPTION
Adds checking of FIRRTL extmodule (`FExtModuleOp`) that brings the FIRRTL Dialect verification in line with the examples that I extracted from the Scala FIRRTL Compiler tests. A FIRRTL circuit is now verified such that the following properties hold:

1. External module defnames will not conflict with module names
2. External modules with the same defname must have the same port names with the same port types
3. (2) is relaxed for external modules which have parameters in that they do not have to match on width

To help with this, this PR adds a method, `getWidthlessType` to `FIRRTLType` that sets all the widths to unknown to facilitate a check like this.

Towards #80.