### PR TITLE
[FIRRTL] Add AsyncReset Parsing

### DIFF
--- a/include/circt/Dialect/FIRRTL/Types.td
+++ b/include/circt/Dialect/FIRRTL/Types.td
@@ -22,6 +22,8 @@ def UInt1Type : Type<CPred<"$_self.isa<UIntType>() && "
                            "UInt<1>">,
                 BuildableType<"UIntType::get($_builder.getContext(), 1)">;
 
+def AsyncResetType : Type<CPred<"$_self.isa<AsyncResetType>()">, "AsyncReset">;
+
 def ResetType : Type<CPred<"$_self.isa<FIRRTLType>() && "
                            "$_self.cast<FIRRTLType>().isResetType()">,
                     "Reset, AsyncReset, or UInt<1>">;

--- a/lib/FIRParser/FIRParser.cpp
+++ b/lib/FIRParser/FIRParser.cpp
@@ -518,6 +518,7 @@ ParseResult FIRParser::parseFieldId(StringRef &result, const Twine &message) {
 
 /// type ::= 'Clock'
 ///      ::= 'Reset'
+///      ::= 'AsyncReset'
 ///      ::= 'UInt' optional-width
 ///      ::= 'SInt' optional-width
 ///      ::= 'Analog' optional-width
@@ -526,7 +527,6 @@ ParseResult FIRParser::parseFieldId(StringRef &result, const Twine &message) {
 ///
 /// field: 'flip'? fieldId ':' type
 ///
-// FIXME: 'AsyncReset' is also handled by the parser but is not in the spec.
 ParseResult FIRParser::parseType(FIRRTLType &result, const Twine &message) {
   switch (getToken().getKind()) {
   default:
@@ -540,6 +540,11 @@ ParseResult FIRParser::parseType(FIRRTLType &result, const Twine &message) {
   case FIRToken::kw_Reset:
     consumeToken(FIRToken::kw_Reset);
     result = ResetType::get(getContext());
+    break;
+
+  case FIRToken::kw_AsyncReset:
+    consumeToken(FIRToken::kw_AsyncReset);
+    result = AsyncResetType::get(getContext());
     break;
 
   case FIRToken::kw_UInt:

--- a/test/FIRParser/basic.fir
+++ b/test/FIRParser/basic.fir
@@ -50,6 +50,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
   module types :
     input c: Clock         ; CHECK: %c: !firrtl.clock,
     input r: Reset         ; CHECK: %r: !firrtl.reset,
+    input ar: AsyncReset   ; CHECK: %ar: !firrtl.asyncreset,
     input a: Analog        ; CHECK: %a: !firrtl.analog,
     input a8: Analog<8>    ; CHECK: %a8: !firrtl.analog<8>,
     input s: SInt          ; CHECK: %s: !firrtl.sint,


### PR DESCRIPTION
Add support for parsing `AsyncReset` type declarations. Modify an existing test to check that this works.

Note: the `EmitVerilog` path is busted for `AsyncReset` (as well as for actual `Reset` as far as I can tell). This PR doesn't attempt to address this and instead opts to wait for the FIRRTL -> RTL -> Verilog path to become more fleshed out.