### PR TITLE
Use a shallow clone of LLVM

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "llvm"]
 	path = llvm
 	url = git@github.com:circt/llvm.git
+	shallow = true

--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ $ git submodule init
 $ git submodule update
 ```
 
+*Note:* The repository is set up so that `git submodule update` performs a shallow clone, meaning it downloads just enough of the LLVM repository to check out the currently specified commit. If you wish to work with the full history of the LLVM repository, you can manually "unshallow" the the submodule:
+
+```
+$ cd llvm
+$ git fetch --unshallow
+```
+
 3) **Build and test LLVM/MLIR:**
 
 ```


### PR DESCRIPTION
Currently when we clone the llvm submodule, we clone all of the history of LLVM, which often isn't needed for day-to-day circt development. A shallow clone only clones enough git objects to represent the state of the submodule at the specified commit. On my machine, the full checkout is about 1GB, whereas the shallow clone is 158MB (making `git submodule --init` much faster). This should not affect existing checkouts and new checkouts can pull down the full llvm history by calling `git fetch --unshallow` inside the submodule.

Please let me know if this has been discussed before or if there is a better way to propose this change.