### PR TITLE
[FIRRTL] Add support for new Verification statements (assert, assume, cover)

### DIFF
--- a/include/circt/Dialect/FIRRTL/OpStatements.td
+++ b/include/circt/Dialect/FIRRTL/OpStatements.td
@@ -128,7 +128,8 @@ def StopOp : FIRRTLOp<"stop", []> {
 def AssertOp : FIRRTLOp<"assert", []> {
   let summary = "Assert Verification Statement";
 
-  let arguments = (ins ClockType:$clock, UInt1Type:$predicate, UInt1Type:$enable, StrAttr:$message);
+  let arguments = (ins ClockType:$clock, UInt1Type:$predicate, UInt1Type:$enable,
+    StrAttr:$message);
   let results = (outs);
 
   let assemblyFormat = [{
@@ -139,7 +140,8 @@ def AssertOp : FIRRTLOp<"assert", []> {
 def AssumeOp : FIRRTLOp<"assume", []> {
   let summary = "Assume Verification Statement";
 
-  let arguments = (ins ClockType:$clock, UInt1Type:$predicate, UInt1Type:$enable, StrAttr:$message);
+  let arguments = (ins ClockType:$clock, UInt1Type:$predicate, UInt1Type:$enable,
+    StrAttr:$message);
   let results = (outs);
 
   let assemblyFormat = [{
@@ -150,7 +152,8 @@ def AssumeOp : FIRRTLOp<"assume", []> {
 def CoverOp : FIRRTLOp<"cover", []> {
   let summary = "Cover Verification Statement";
 
-  let arguments = (ins ClockType:$clock, UInt1Type:$predicate, UInt1Type:$enable, StrAttr:$message);
+  let arguments = (ins ClockType:$clock, UInt1Type:$predicate, UInt1Type:$enable,
+    StrAttr:$message);
   let results = (outs);
 
   let assemblyFormat = [{

--- a/include/circt/Dialect/FIRRTL/OpStatements.td
+++ b/include/circt/Dialect/FIRRTL/OpStatements.td
@@ -147,6 +147,17 @@ def AssumeOp : FIRRTLOp<"assume", []> {
   }];
 }
 
+def CoverOp : FIRRTLOp<"cover", []> {
+  let summary = "Cover Verification Statement";
+
+  let arguments = (ins ClockType:$clock, UInt1Type:$predicate, UInt1Type:$enable, StrAttr:$message);
+  let results = (outs);
+
+  let assemblyFormat = [{
+    $clock `,` $predicate `,` $enable `,` $message attr-dict
+  }];
+}
+
 def WhenOp : FIRRTLOp<"when", [SingleBlockImplicitTerminator<"DoneOp">]> {
   let summary = "When Statement";
   let description = [{

--- a/include/circt/Dialect/FIRRTL/OpStatements.td
+++ b/include/circt/Dialect/FIRRTL/OpStatements.td
@@ -136,6 +136,17 @@ def AssertOp : FIRRTLOp<"assert", []> {
   }];
 }
 
+def AssumeOp : FIRRTLOp<"assume", []> {
+  let summary = "Assume Verification Statement";
+
+  let arguments = (ins ClockType:$clock, UInt1Type:$predicate, UInt1Type:$enable, StrAttr:$message);
+  let results = (outs);
+
+  let assemblyFormat = [{
+    $clock `,` $predicate `,` $enable `,` $message attr-dict
+  }];
+}
+
 def WhenOp : FIRRTLOp<"when", [SingleBlockImplicitTerminator<"DoneOp">]> {
   let summary = "When Statement";
   let description = [{

--- a/include/circt/Dialect/FIRRTL/OpStatements.td
+++ b/include/circt/Dialect/FIRRTL/OpStatements.td
@@ -125,6 +125,17 @@ def StopOp : FIRRTLOp<"stop", []> {
   }];
 }
 
+def AssertOp : FIRRTLOp<"assert", []> {
+  let summary = "Assert Verification Statement";
+
+  let arguments = (ins ClockType:$clock, UInt1Type:$predicate, UInt1Type:$enable, StrAttr:$message);
+  let results = (outs);
+
+  let assemblyFormat = [{
+    $clock `,` $predicate `,` $enable `,` $message attr-dict
+  }];
+}
+
 def WhenOp : FIRRTLOp<"when", [SingleBlockImplicitTerminator<"DoneOp">]> {
   let summary = "When Statement";
   let description = [{

--- a/lib/FIRParser/FIRTokenKinds.def
+++ b/lib/FIRParser/FIRTokenKinds.def
@@ -115,6 +115,7 @@ TOK_KEYWORD(write)
 TOK_LPKEYWORD(printf)
 TOK_LPKEYWORD(stop)
 TOK_LPKEYWORD(assert)
+TOK_LPKEYWORD(assume)
 
 // These are for LPKEYWORD cases that correspond to a primitive operation.
 TOK_LPKEYWORD_PRIM(add, AddPrimOp)

--- a/lib/FIRParser/FIRTokenKinds.def
+++ b/lib/FIRParser/FIRTokenKinds.def
@@ -116,6 +116,7 @@ TOK_LPKEYWORD(printf)
 TOK_LPKEYWORD(stop)
 TOK_LPKEYWORD(assert)
 TOK_LPKEYWORD(assume)
+TOK_LPKEYWORD(cover)
 
 // These are for LPKEYWORD cases that correspond to a primitive operation.
 TOK_LPKEYWORD_PRIM(add, AddPrimOp)

--- a/lib/FIRParser/FIRTokenKinds.def
+++ b/lib/FIRParser/FIRTokenKinds.def
@@ -114,6 +114,7 @@ TOK_KEYWORD(write)
 // FIRToken::lp_foo enums.
 TOK_LPKEYWORD(printf)
 TOK_LPKEYWORD(stop)
+TOK_LPKEYWORD(assert)
 
 // These are for LPKEYWORD cases that correspond to a primitive operation.
 TOK_LPKEYWORD_PRIM(add, AddPrimOp)

--- a/test/FIRParser/basic.fir
+++ b/test/FIRParser/basic.fir
@@ -285,6 +285,13 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.attach(%a8, %a8, %a8) :
     attach (a8, a8, a8)
 
+    wire pred: UInt <1>
+    wire en: UInt <1>
+    pred <= eq(i8, i8)
+    en <= not(reset)
+    ; CHECK: firrtl.assert %clock, %pred, %en, "X equals Y when Z is valid"
+    assert(clock, pred, en, "X equals Y when Z is valid")
+
   ; CHECK-LABEL: firrtl.module @type_handling(
   module type_handling :
     wire _t_6 : { flip b : { bits : { source : UInt<7> } } }

--- a/test/FIRParser/basic.fir
+++ b/test/FIRParser/basic.fir
@@ -293,6 +293,8 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     assert(clock, pred, en, "X equals Y when Z is valid")
     ; CHECK: firrtl.assume %clock, %pred, %en, "X equals Y when Z is valid"
     assume(clock, pred, en, "X equals Y when Z is valid")
+    ; CHECK: firrtl.cover %clock, %pred, %en, "X equals Y when Z is valid"
+    cover(clock, pred, en, "X equals Y when Z is valid")
 
   ; CHECK-LABEL: firrtl.module @type_handling(
   module type_handling :

--- a/test/FIRParser/basic.fir
+++ b/test/FIRParser/basic.fir
@@ -291,6 +291,8 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     en <= not(reset)
     ; CHECK: firrtl.assert %clock, %pred, %en, "X equals Y when Z is valid"
     assert(clock, pred, en, "X equals Y when Z is valid")
+    ; CHECK: firrtl.assume %clock, %pred, %en, "X equals Y when Z is valid"
+    assume(clock, pred, en, "X equals Y when Z is valid")
 
   ; CHECK-LABEL: firrtl.module @type_handling(
   module type_handling :


### PR DESCRIPTION
Adds support for parsing and internal representation of new FIRRTL (version 1.4.0, Chisel 3.4.0) verification statements: `assert`, `assume`, and `cover`. This PR includes, narrowly, tests that these are parsed correctly.

This does not add support for any emission of these statements.

Fixes #97.