### PR TITLE
[RTL] RTL module results as outputs

### DIFF
--- a/include/circt/Dialect/RTL/Ops.h
+++ b/include/circt/Dialect/RTL/Ops.h
@@ -13,6 +13,7 @@
 #include "mlir/IR/RegionKindInterface.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
 
 namespace circt {
 namespace rtl {

--- a/include/circt/Dialect/RTL/Ops.h
+++ b/include/circt/Dialect/RTL/Ops.h
@@ -21,9 +21,10 @@ namespace rtl {
 // This holds the name, type, direction of a module's ports
 struct RTLModulePortInfo {
   StringAttr name;
+  PortDirection direction;
   Type type;
-  StringAttr direction;
-  bool isResult;
+  size_t argNum; // Either the argument index or the result index depending on
+                 // the direction.
 };
 
 // typedef std::tuple<StringAttr, Type, StringAttr> RTLModulePortInfo;
@@ -33,7 +34,7 @@ FunctionType getModuleType(Operation *op);
 void getRTLModulePortInfo(Operation *op,
                           SmallVectorImpl<RTLModulePortInfo> &results);
 StringAttr getRTLNameAttr(ArrayRef<NamedAttribute> attrs);
-StringAttr getRTLDirectionAttr(ArrayRef<NamedAttribute> attrs);
+// StringAttr getRTLDirectionAttr(ArrayRef<NamedAttribute> attrs);
 
 /// Return true if the specified operation is a combinatorial logic op.
 bool isCombinatorial(Operation *op);

--- a/include/circt/Dialect/RTL/Ops.h
+++ b/include/circt/Dialect/RTL/Ops.h
@@ -30,8 +30,8 @@ struct RTLModulePortInfo {
   StringAttr name;
   PortDirection direction;
   Type type;
-  size_t argNum; // Either the argument index or the result index depending on
-                 // the direction.
+  size_t argNum = ~0U; // Either the argument index or the result index
+                       // depending on the direction.
 
   inline StringRef getName() { return name ? name.getValue() : ""; }
 };

--- a/include/circt/Dialect/RTL/Ops.h
+++ b/include/circt/Dialect/RTL/Ops.h
@@ -18,7 +18,14 @@
 namespace circt {
 namespace rtl {
 
-// This holds the name, type, direction of a module's ports
+/// A RTL module ports direction.
+enum PortDirection {
+  INPUT = 1,
+  OUTPUT = 2,
+  INOUT = 3,
+};
+
+/// This holds the name, type, direction of a module's ports
 struct RTLModulePortInfo {
   StringAttr name;
   PortDirection direction;
@@ -27,14 +34,11 @@ struct RTLModulePortInfo {
                  // the direction.
 };
 
-// typedef std::tuple<StringAttr, Type, StringAttr> RTLModulePortInfo;
-
 FunctionType getModuleType(Operation *op);
 
 void getRTLModulePortInfo(Operation *op,
                           SmallVectorImpl<RTLModulePortInfo> &results);
 StringAttr getRTLNameAttr(ArrayRef<NamedAttribute> attrs);
-// StringAttr getRTLDirectionAttr(ArrayRef<NamedAttribute> attrs);
 
 /// Return true if the specified operation is a combinatorial logic op.
 bool isCombinatorial(Operation *op);

--- a/include/circt/Dialect/RTL/Ops.h
+++ b/include/circt/Dialect/RTL/Ops.h
@@ -32,6 +32,8 @@ struct RTLModulePortInfo {
   Type type;
   size_t argNum; // Either the argument index or the result index depending on
                  // the direction.
+
+  inline StringRef getName() { return name ? name.getValue() : ""; }
 };
 
 FunctionType getModuleType(Operation *op);

--- a/include/circt/Dialect/RTL/Ops.h
+++ b/include/circt/Dialect/RTL/Ops.h
@@ -23,6 +23,7 @@ struct RTLModulePortInfo {
   StringAttr name;
   Type type;
   StringAttr direction;
+  bool isResult;
 };
 
 // typedef std::tuple<StringAttr, Type, StringAttr> RTLModulePortInfo;

--- a/include/circt/Dialect/RTL/Ops.h
+++ b/include/circt/Dialect/RTL/Ops.h
@@ -12,8 +12,8 @@
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/RegionKindInterface.h"
 #include "mlir/IR/SymbolTable.h"
-#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 
 namespace circt {
 namespace rtl {

--- a/include/circt/Dialect/RTL/RTL.td
+++ b/include/circt/Dialect/RTL/RTL.td
@@ -9,6 +9,7 @@
 
 include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/IR/RegionKindInterface.td"

--- a/include/circt/Dialect/RTL/Structure.td
+++ b/include/circt/Dialect/RTL/Structure.td
@@ -1,14 +1,3 @@
-// Direction enum
-def INPUT_PORT  : I32EnumAttrCase<"INPUT", 1>;
-def OUTPUT_PORT : I32EnumAttrCase<"OUTPUT",  2>;
-def INOUT_PORT  : I32EnumAttrCase<"INOUT", 3>;
-def PortDirection : I32EnumAttr<"PortDirection",
-    "The direction of an RTL modules port.",
-    [INPUT_PORT, OUTPUT_PORT, INOUT_PORT]> {
-
-  let cppNamespace = "circt::rtl";
-}
-
 def RTLModuleOp : RTLOp<"module",
       [IsolatedFromAbove, FunctionLike, Symbol, RegionKindInterface,
        SingleBlockImplicitTerminator<"OutputOp">]> {

--- a/include/circt/Dialect/RTL/Structure.td
+++ b/include/circt/Dialect/RTL/Structure.td
@@ -108,7 +108,8 @@ def RTLExternModuleOp : RTLOp<"externmodule",
 }
 
 
-def RTLInstanceOp : RTLOp<"instance", []> {
+def RTLInstanceOp : RTLOp<"instance",
+                          [DeclareOpInterfaceMethods<OpAsmOpInterface>]> {
   let summary = "Create an instance of a module";
   let description = [{
     This represents an instance of a module. The inputs and results are 
@@ -121,7 +122,7 @@ def RTLInstanceOp : RTLOp<"instance", []> {
   let results = (outs Variadic<AnyType>);
   
   let assemblyFormat = [{
-     $instanceName $moduleName `(` $inputs `)` attr-dict `:` functional-type($inputs, results)
+    $instanceName $moduleName `(` $inputs `)` custom<ResultNames>( attr-dict ) `:` functional-type($inputs, results)
   }];
 
   let verifier = [{ return ::verifyRTLInstanceOp(*this); }];

--- a/include/circt/Dialect/RTL/Structure.td
+++ b/include/circt/Dialect/RTL/Structure.td
@@ -120,6 +120,10 @@ def RTLInstanceOp : RTLOp<"instance",
                        FlatSymbolRefAttr:$moduleName,
                        Variadic<AnyType>:$inputs);
   let results = (outs Variadic<AnyType>);
+
+  let extraClassDeclaration = [{   
+    StringAttr getResultName(size_t i);
+  }];
   
   let assemblyFormat = [{
     $instanceName $moduleName `(` $inputs `)` custom<ResultNames>( attr-dict ) `:` functional-type($inputs, results)

--- a/include/circt/Dialect/RTL/Structure.td
+++ b/include/circt/Dialect/RTL/Structure.td
@@ -118,20 +118,25 @@ def RTLInstanceOp : RTLOp<"instance", []> {
   let arguments = (ins StrAttr:$instanceName,
                        FlatSymbolRefAttr:$moduleName,
                        Variadic<AnySignlessInteger>:$inputs);
-  let results = (outs);
+  let results = (outs Variadic<AnyType>);
   
   let assemblyFormat = [{
-     $instanceName $moduleName `(` $inputs `)` attr-dict `:` type($inputs)
+     $instanceName $moduleName `(` $inputs `)` attr-dict `:` functional-type($inputs, results)
   }];
 
   let verifier = [{ return ::verifyRTLInstanceOp(*this); }];
 }
 
-def DoneOp : RTLOp<"done", [Terminator, HasParent<"RTLModuleOp">]> {
+def DoneOp : RTLOp<"done", [Terminator, HasParent<"RTLModuleOp">,
+                            NoSideEffect, ReturnLike]> {
   let summary = "RTL termination operation";
   let description = [{
     "rtl.done" marks the end of a region in the RTL dialect.
   }];
 
-  let arguments = (ins);
+  let arguments = (ins Variadic<AnyType>:$operands);
+
+  let builders = [OpBuilder<"", [{ build($_builder, $_state, llvm::None); }]>];
+
+  let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";
 }

--- a/include/circt/Dialect/RTL/Structure.td
+++ b/include/circt/Dialect/RTL/Structure.td
@@ -1,6 +1,6 @@
 def RTLModuleOp : RTLOp<"module",
       [IsolatedFromAbove, FunctionLike, Symbol, RegionKindInterface,
-       SingleBlockImplicitTerminator<"DoneOp">]> {
+       SingleBlockImplicitTerminator<"OutputOp">]> {
   let summary = "RTL Module";
   let description = [{
     The "rtl.module" operation represents a Verilog module, including a given
@@ -127,11 +127,12 @@ def RTLInstanceOp : RTLOp<"instance", []> {
   let verifier = [{ return ::verifyRTLInstanceOp(*this); }];
 }
 
-def DoneOp : RTLOp<"done", [Terminator, HasParent<"RTLModuleOp">,
-                            NoSideEffect, ReturnLike]> {
+def OutputOp : RTLOp<"output", [Terminator, HasParent<"RTLModuleOp">,
+                                NoSideEffect, ReturnLike]> {
   let summary = "RTL termination operation";
   let description = [{
-    "rtl.done" marks the end of a region in the RTL dialect.
+    "rtl.output" marks the end of a region in the RTL dialect and the values
+    to put on the output ports.
   }];
 
   let arguments = (ins Variadic<AnyType>:$operands);
@@ -139,4 +140,6 @@ def DoneOp : RTLOp<"done", [Terminator, HasParent<"RTLModuleOp">,
   let builders = [OpBuilder<"", [{ build($_builder, $_state, llvm::None); }]>];
 
   let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";
+
+  let verifier = [{ return ::verifyOutputOp(this); }];
 }

--- a/include/circt/Dialect/RTL/Structure.td
+++ b/include/circt/Dialect/RTL/Structure.td
@@ -1,3 +1,14 @@
+// Direction enum
+def INPUT_PORT  : I32EnumAttrCase<"INPUT", 1>;
+def OUTPUT_PORT : I32EnumAttrCase<"OUTPUT",  2>;
+def INOUT_PORT  : I32EnumAttrCase<"INOUT", 3>;
+def PortDirection : I32EnumAttr<"PortDirection",
+    "The direction of an RTL modules port.",
+    [INPUT_PORT, OUTPUT_PORT, INOUT_PORT]> {
+
+  let cppNamespace = "circt::rtl";
+}
+
 def RTLModuleOp : RTLOp<"module",
       [IsolatedFromAbove, FunctionLike, Symbol, RegionKindInterface,
        SingleBlockImplicitTerminator<"OutputOp">]> {

--- a/include/circt/Dialect/RTL/Structure.td
+++ b/include/circt/Dialect/RTL/Structure.td
@@ -126,7 +126,8 @@ def RTLInstanceOp : RTLOp<"instance",
   }];
   
   let assemblyFormat = [{
-    $instanceName $moduleName `(` $inputs `)` custom<ResultNames>( attr-dict ) `:` functional-type($inputs, results)
+    $instanceName $moduleName `(` $inputs `)` custom<ResultNames>( attr-dict )
+      `:` functional-type($inputs, results)
   }];
 
   let verifier = [{ return ::verifyRTLInstanceOp(*this); }];

--- a/include/circt/Dialect/RTL/Visitors.h
+++ b/include/circt/Dialect/RTL/Visitors.h
@@ -31,7 +31,7 @@ public:
                        // Reduction Operators
                        AndROp, OrROp, XorROp,
                        // Other operations.
-                       SExtOp, ZExtOp, ConcatOp, ExtractOp, MuxOp, OutputOp>(
+                       SExtOp, ZExtOp, ConcatOp, ExtractOp, MuxOp>(
             [&](auto expr) -> ResultType {
               return thisCast->visitComb(expr, args...);
             })
@@ -99,7 +99,6 @@ public:
   HANDLE(ConcatOp, Unhandled);
   HANDLE(ExtractOp, Unhandled);
   HANDLE(MuxOp, Unhandled);
-  HANDLE(OutputOp, Unhandled);
 #undef HANDLE
 };
 
@@ -111,7 +110,7 @@ public:
   ResultType dispatchStmtVisitor(Operation *op, ExtraArgs... args) {
     auto *thisCast = static_cast<ConcreteType *>(this);
     return TypeSwitch<Operation *, ResultType>(op)
-        .template Case<ConnectOp, WireOp, RTLInstanceOp>(
+        .template Case<ConnectOp, OutputOp, WireOp, RTLInstanceOp>(
             [&](auto expr) -> ResultType {
               return thisCast->visitStmt(expr, args...);
             })
@@ -149,7 +148,8 @@ public:
   }
 
   // Basic nodes.
-  HANDLE(ConnectOp, Unhandled)
+  HANDLE(ConnectOp, Unhandled);
+  HANDLE(OutputOp, Unhandled);
   HANDLE(WireOp, Unhandled);
   HANDLE(RTLInstanceOp, Unhandled);
 #undef HANDLE

--- a/include/circt/Dialect/RTL/Visitors.h
+++ b/include/circt/Dialect/RTL/Visitors.h
@@ -31,7 +31,7 @@ public:
                        // Reduction Operators
                        AndROp, OrROp, XorROp,
                        // Other operations.
-                       SExtOp, ZExtOp, ConcatOp, ExtractOp, MuxOp, DoneOp>(
+                       SExtOp, ZExtOp, ConcatOp, ExtractOp, MuxOp, OutputOp>(
             [&](auto expr) -> ResultType {
               return thisCast->visitComb(expr, args...);
             })
@@ -99,7 +99,7 @@ public:
   HANDLE(ConcatOp, Unhandled);
   HANDLE(ExtractOp, Unhandled);
   HANDLE(MuxOp, Unhandled);
-  HANDLE(DoneOp, Unhandled);
+  HANDLE(OutputOp, Unhandled);
 #undef HANDLE
 };
 

--- a/lib/Dialect/FIRRTL/LowerToRTL.cpp
+++ b/lib/Dialect/FIRRTL/LowerToRTL.cpp
@@ -104,20 +104,18 @@ void FIRRTLModuleLowering::lowerModule(FModuleOp op) {
     }
 
     // Figure out the direction of the port.
-    const char *direction;
     if (firrtlType.isa<FlipType>()) {
       // If the top-level type in FIRRTL is a flip, then this is an output.
       assert(firrtlType.cast<FlipType>().getElementType().isPassiveType() &&
              "Flip types should be completely passive internally");
-      direction = "out";
+      rtlPort.direction = rtl::PortDirection::OUTPUT;
     } else if (firrtlType.cast<FIRRTLType>().isPassiveType()) {
-      direction = "input";
+      rtlPort.direction = rtl::PortDirection::INPUT;
     } else {
       // This isn't currently expressible in low-firrtl, due to bundle types
       // being lowered.
-      direction = "inout";
+      rtlPort.direction = rtl::PortDirection::INOUT;
     }
-    rtlPort.direction = builder.getStringAttr(direction);
     ports.push_back(rtlPort);
   }
 

--- a/lib/Dialect/FIRRTL/LowerToRTL.cpp
+++ b/lib/Dialect/FIRRTL/LowerToRTL.cpp
@@ -89,7 +89,8 @@ void FIRRTLModuleLowering::runOnOperation() {
     // Step through the operations carefully to avoid invalidating the iterator.
     auto &op = *opIt++;
     if (auto module = dyn_cast<FModuleOp>(op)) {
-      lowerModule(module, moduleBody);
+      // TODO: lowerModule method is broken.
+      // lowerModule(module, moduleBody);
       continue;
     }
 

--- a/lib/Dialect/FIRRTL/LowerToRTL.cpp
+++ b/lib/Dialect/FIRRTL/LowerToRTL.cpp
@@ -89,6 +89,8 @@ void FIRRTLModuleLowering::lowerModule(FModuleOp op) {
 
   SmallVector<rtl::RTLModulePortInfo, 8> ports;
   ports.reserve(firrtlPorts.size());
+  size_t numArgs = 0;
+  size_t numResults = 0;
   for (auto firrtlPort : firrtlPorts) {
     rtl::RTLModulePortInfo rtlPort;
 
@@ -109,12 +111,15 @@ void FIRRTLModuleLowering::lowerModule(FModuleOp op) {
       assert(firrtlType.cast<FlipType>().getElementType().isPassiveType() &&
              "Flip types should be completely passive internally");
       rtlPort.direction = rtl::PortDirection::OUTPUT;
+      rtlPort.argNum = numResults++;
     } else if (firrtlType.cast<FIRRTLType>().isPassiveType()) {
       rtlPort.direction = rtl::PortDirection::INPUT;
+      rtlPort.argNum = numArgs++;
     } else {
       // This isn't currently expressible in low-firrtl, due to bundle types
       // being lowered.
       rtlPort.direction = rtl::PortDirection::INOUT;
+      rtlPort.argNum = numArgs++;
     }
     ports.push_back(rtlPort);
   }

--- a/lib/Dialect/RTL/Ops.cpp
+++ b/lib/Dialect/RTL/Ops.cpp
@@ -51,9 +51,8 @@ static void buildModule(OpBuilder &builder, OperationState &result,
           NamedAttribute(builder.getIdentifier("rtl.name"), port.name));
 
     if (port.direction == PortDirection::INOUT)
-      argAttrs.push_back(
-          NamedAttribute(builder.getIdentifier("rtl.inout"),
-                         BoolAttr::get(true, builder.getContext())));
+      argAttrs.push_back(NamedAttribute(builder.getIdentifier("rtl.inout"),
+                                        builder.getUnitAttr()));
 
     StringRef attrName = port.direction == PortDirection::OUTPUT
                              ? getResultAttrName(port.argNum, attrNameBuf)
@@ -103,9 +102,8 @@ StringAttr rtl::getRTLNameAttr(ArrayRef<NamedAttribute> attrs) {
 
 static bool isRTLInoutArg(ArrayRef<NamedAttribute> attrs) {
   for (auto &argAttr : attrs) {
-    if (argAttr.first != "rtl.inout")
-      continue;
-    return argAttr.second.dyn_cast<BoolAttr>().getValue();
+    if (argAttr.first == "rtl.inout")
+      return true;
   }
   return false;
 }

--- a/lib/Dialect/RTL/Ops.cpp
+++ b/lib/Dialect/RTL/Ops.cpp
@@ -99,7 +99,7 @@ StringAttr rtl::getRTLNameAttr(ArrayRef<NamedAttribute> attrs) {
   return StringAttr();
 }
 
-static bool isRTLInoutArg(ArrayRef<NamedAttribute> attrs) {
+static bool containsInOutAttr(ArrayRef<NamedAttribute> attrs) {
   for (auto &argAttr : attrs) {
     if (argAttr.first == "rtl.inout")
       return true;
@@ -113,7 +113,7 @@ void rtl::getRTLModulePortInfo(Operation *op,
 
   for (unsigned i = 0, e = argTypes.size(); i < e; ++i) {
     auto argAttrs = ::mlir::impl::getArgAttrs(op, i);
-    bool isInout = isRTLInoutArg(argAttrs);
+    bool isInout = containsInOutAttr(argAttrs);
 
     results.push_back({getRTLNameAttr(argAttrs),
                        isInout ? PortDirection::INOUT : PortDirection::INPUT,
@@ -295,8 +295,7 @@ ParseResult parseResultNames(OpAsmParser &p, NamedAttrList &attrDict) {
   // Assemble the result names from the asm.
   SmallVector<Attribute, 8> names;
   for (size_t i = 0, e = p.getNumResults(); i < e; ++i) {
-    StringAttr resultName = StringAttr::get(p.getResultName(i).first, ctxt);
-    names.push_back(resultName);
+    names.push_back(StringAttr::get(p.getResultName(i).first, ctxt));
   }
 
   // Look for existing result names in the attr-dict and if they exist and are

--- a/lib/Dialect/RTL/Ops.cpp
+++ b/lib/Dialect/RTL/Ops.cpp
@@ -115,7 +115,7 @@ void rtl::getRTLModulePortInfo(Operation *op,
 
   auto resultTypes = getModuleType(op).getResults();
   for (unsigned i = 0, e = resultTypes.size(); i < e; ++i) {
-    auto argAttrs = ::mlir::impl::getArgAttrs(op, i);
+    auto argAttrs = ::mlir::impl::getResultAttrs(op, i);
     results.push_back(
         {getRTLNameAttr(argAttrs), PortDirection::OUTPUT, resultTypes[i], i});
   }
@@ -140,10 +140,16 @@ static ParseResult parseRTLModuleOp(OpAsmParser &parser, OperationState &result,
 
   // Parse the function signature.
   bool isVariadic = false;
+
   if (parseFunctionSignature(parser, /*allowVariadic=*/false, entryArgs,
                              argTypes, argAttrs, isVariadic, resultTypes,
                              resultAttrs))
     return failure();
+
+  // if (parseFunctionSignature(parser, /*allowVariadic=*/false, entryArgs,
+  //  argTypes, argAttrs, isVariadic, resultTypes,
+  //  resultAttrs))
+  // return failure();
 
   // Record the argument and result types as an attribute.  This is necessary
   // for external modules.
@@ -242,7 +248,7 @@ static void print(OpAsmPrinter &p, RTLModuleOp op) {
   Region &body = op.getBody();
   if (!body.empty())
     p.printRegion(body, /*printEntryBlockArgs=*/false,
-                  /*printBlockTerminators=*/false);
+                  /*printBlockTerminators=*/true);
 }
 
 static LogicalResult verifyRTLInstanceOp(RTLInstanceOp op) {

--- a/lib/EmitVerilog/EmitVerilog.cpp
+++ b/lib/EmitVerilog/EmitVerilog.cpp
@@ -2453,11 +2453,18 @@ void ModuleEmitter::emitRTLModule(rtl::RTLModuleOp module) {
   SmallVector<rtl::RTLModulePortInfo, 8> portInfo;
   module.getRTLPortInfo(portInfo);
 
-  for (auto &port : portInfo)
+  for (auto &port : portInfo) {
+    StringRef name = port.name.getValue();
+    if (name.empty()) {
+      llvm::errs() << "Found port without a name. Port names are required for "
+                      "Verilog synthesis.\n";
+      name = "<<NO-NAME-FOUND>>";
+    }
     if (port.direction == rtl::PortDirection::OUTPUT)
-      usedNames.insert(port.name.getValue());
+      usedNames.insert(name);
     else
-      addName(module.getArgument(port.argNum), port.name);
+      addName(module.getArgument(port.argNum), name);
+  }
 
   os << "module " << module.getName() << '(';
   if (!portInfo.empty())

--- a/lib/EmitVerilog/EmitVerilog.cpp
+++ b/lib/EmitVerilog/EmitVerilog.cpp
@@ -2489,10 +2489,17 @@ void ModuleEmitter::emitRTLModule(rtl::RTLModuleOp module) {
     // Emit the arguments.
     auto portType = portInfo[portIdx].type;
     rtl::PortDirection thisPortDirection = portInfo[portIdx].direction;
-    if (thisPortDirection == rtl::PortDirection::OUTPUT)
+    switch (thisPortDirection) {
+    case rtl::PortDirection::OUTPUT:
       os << "output ";
-    else
+      break;
+    case rtl::PortDirection::INPUT:
       os << (hasOutputs ? "input  " : "input ");
+      break;
+    case rtl::PortDirection::INOUT:
+      os << (hasOutputs ? "inout  " : "inout ");
+      break;
+    }
 
     int bitWidth = getBitWidthOrSentinel(portType);
     emitTypePaddedToWidth(portType, maxTypeWidth, module);

--- a/test/EmitVerilog/rtl-dialect.mlir
+++ b/test/EmitVerilog/rtl-dialect.mlir
@@ -75,7 +75,7 @@ firrtl.circuit "M1" {
   // CHECK-NEXT:  assign y = _T_0 ^ (_T | _T_0) ^ 8'h2A ^ q[15:8];
   // CHECK-NEXT:endmodule
 
-  rtl.module @B(%a: i1) -> (i1 {rtl.name = "b"}, i1 {rtl.name = "c"}) {
+  rtl.module @B(%a: i1 { rtl.inout }) -> (i1 {rtl.name = "b"}, i1 {rtl.name = "c"}) {
     %0 = rtl.or %a, %a : i1
     %1 = rtl.and %a, %a : i1
     rtl.output %0, %1 : i1, i1

--- a/test/EmitVerilog/rtl-dialect.mlir
+++ b/test/EmitVerilog/rtl-dialect.mlir
@@ -4,84 +4,83 @@ firrtl.circuit "M1" {
   firrtl.module @M1(%x : !firrtl.uint<8>,
                     %y : !firrtl.flip<uint<8>>,
                     %z : i8) {
-    %c42 = rtl.constant (42 : i8) : i8
-    %c5 = rtl.constant (5 : i8) : i8
-    %a = rtl.add %z, %c42 : i8
-    %b = rtl.mul %a, %c5 : i8
-    %c = firrtl.stdIntCast %b : (i8) -> !firrtl.uint<8>
-    firrtl.connect %y, %c : !firrtl.flip<uint<8>>, !firrtl.uint<8>
+    // %c42 = rtl.constant (42 : i8) : i8
+    // %c5 = rtl.constant (5 : i8) : i8
+    // %a = rtl.add %z, %c42 : i8
+    // %b = rtl.mul %a, %c5 : i8
+    // %c = firrtl.stdIntCast %b : (i8) -> !firrtl.uint<8>
+    // firrtl.connect %y, %c : !firrtl.flip<uint<8>>, !firrtl.uint<8>
 
-    %d = rtl.mul %z, %z, %z : i8
-    %e = rtl.mod %d, %c5 : i8
-    %f = rtl.concat %e, %z, %d : (i8, i8, i8) -> i8
-    %g = firrtl.stdIntCast %f : (i8) -> !firrtl.uint<8>
-    firrtl.connect %y, %g : !firrtl.flip<uint<8>>, !firrtl.uint<8>
+    // %d = rtl.mul %z, %z, %z : i8
+    // %e = rtl.mod %d, %c5 : i8
+    // %f = rtl.concat %e, %z, %d : (i8, i8, i8) -> i8
+    // %g = firrtl.stdIntCast %f : (i8) -> !firrtl.uint<8>
+    // firrtl.connect %y, %g : !firrtl.flip<uint<8>>, !firrtl.uint<8>
   }
 
-  // CHECK-LABEL: module M1(
-  // CHECK-NEXT:    input  [7:0] x,
-  // CHECK-NEXT:    output [7:0] y,
-  // CHECK-NEXT:    input  [7:0] z);
-  // CHECK-EMPTY:
-  // CHECK-NEXT:    assign y = (z + 8'h2A) * 8'h5;
-  // CHECK-NEXT:    wire [7:0] _T = z * z * z;
-  // CHECK-NEXT:    assign y = {_T % 8'h5, z, _T};
-  // CHECK-NEXT:  endmodule
+  // // CHECK-LABEL: module M1(
+  // // CHECK-NEXT:    input  [7:0] x,
+  // // CHECK-NEXT:    output [7:0] y,
+  // // CHECK-NEXT:    input  [7:0] z);
+  // // CHECK-EMPTY:
+  // // CHECK-NEXT:    assign y = (z + 8'h2A) * 8'h5;
+  // // CHECK-NEXT:    wire [7:0] _T = z * z * z;
+  // // CHECK-NEXT:    assign y = {_T % 8'h5, z, _T};
+  // // CHECK-NEXT:  endmodule
 
 
-   firrtl.module @M2(%x : i8,
-                     %y : i8,
-                     %z : i8) {
-    %c42 = rtl.constant (42 : i8) : i8
-    rtl.connect %x, %c42 : i8
+  //  firrtl.module @M2(%x : i8,
+  //                    %y : i8,
+  //                    %z : i8) {
+  //   %c42 = rtl.constant (42 : i8) : i8
+  //   rtl.connect %x, %c42 : i8
 
-    %w1 = rtl.wire { name = "foo" } : i8
-    rtl.connect %w1, %y : i8
-    rtl.connect %z, %w1 : i8
-  }
+  //   %w1 = rtl.wire { name = "foo" } : i8
+  //   rtl.connect %w1, %y : i8
+  //   rtl.connect %z, %w1 : i8
+  // }
 
-  // CHECK-LABEL: module M2(
-  // CHECK-NEXT:    input [7:0] x, y, z);
-  // CHECK-EMPTY:
-  // CHECK-NEXT:    wire [7:0] foo;
-  // CHECK-EMPTY:
-  // CHECK-NEXT:    assign x = 8'h2A;
-  // CHECK-NEXT:    assign foo = y;
-  // CHECK-NEXT:    assign z = foo;
-  // CHECK-NEXT:  endmodule
+  // // CHECK-LABEL: module M2(
+  // // CHECK-NEXT:    input [7:0] x, y, z);
+  // // CHECK-EMPTY:
+  // // CHECK-NEXT:    wire [7:0] foo;
+  // // CHECK-EMPTY:
+  // // CHECK-NEXT:    assign x = 8'h2A;
+  // // CHECK-NEXT:    assign foo = y;
+  // // CHECK-NEXT:    assign z = foo;
+  // // CHECK-NEXT:  endmodule
 
-  firrtl.module @M3(%x : !firrtl.uint<8>,
-                    %y : !firrtl.flip<uint<8>>,
-                    %z : i8, %q : i16) {
-    %c42 = rtl.constant (42 : i8) : i8
-    %c5 = rtl.constant (5 : i8) : i8
-    %ext_z = rtl.extract %q from 8 : (i16) -> i8
-    %a = rtl.add %z, %c42 : i8
-    %v1 = rtl.and %a, %c42, %c5 : i8
-    %v2 = rtl.or %a, %v1 : i8
-    %v3 = rtl.xor %v1, %v2, %c42, %ext_z : i8
-    %c = firrtl.stdIntCast %v3 : (i8) -> !firrtl.uint<8>
-    firrtl.connect %y, %c : !firrtl.flip<uint<8>>, !firrtl.uint<8>
-  }
+  // firrtl.module @M3(%x : !firrtl.uint<8>,
+  //                   %y : !firrtl.flip<uint<8>>,
+  //                   %z : i8, %q : i16) {
+  //   %c42 = rtl.constant (42 : i8) : i8
+  //   %c5 = rtl.constant (5 : i8) : i8
+  //   %ext_z = rtl.extract %q from 8 : (i16) -> i8
+  //   %a = rtl.add %z, %c42 : i8
+  //   %v1 = rtl.and %a, %c42, %c5 : i8
+  //   %v2 = rtl.or %a, %v1 : i8
+  //   %v3 = rtl.xor %v1, %v2, %c42, %ext_z : i8
+  //   %c = firrtl.stdIntCast %v3 : (i8) -> !firrtl.uint<8>
+  //   firrtl.connect %y, %c : !firrtl.flip<uint<8>>, !firrtl.uint<8>
+  // }
 
-  // CHECK-LABEL: module M3(
-  // CHECK-NEXT:  input  [7:0]  x,
-  // CHECK-NEXT:  output [7:0]  y,
-  // CHECK-NEXT:  input  [7:0]  z,
-  // CHECK-NEXT:  input  [15:0] q);
-  // CHECK-EMPTY:
-  // CHECK-NEXT:  wire [7:0] _T = z + 8'h2A;
-  // CHECK-NEXT:  wire [7:0] _T_0 = _T & 8'h2A & 8'h5;
-  // CHECK-NEXT:  assign y = _T_0 ^ (_T | _T_0) ^ 8'h2A ^ q[15:8];
-  // CHECK-NEXT:endmodule
+  // // CHECK-LABEL: module M3(
+  // // CHECK-NEXT:  input  [7:0]  x,
+  // // CHECK-NEXT:  output [7:0]  y,
+  // // CHECK-NEXT:  input  [7:0]  z,
+  // // CHECK-NEXT:  input  [15:0] q);
+  // // CHECK-EMPTY:
+  // // CHECK-NEXT:  wire [7:0] _T = z + 8'h2A;
+  // // CHECK-NEXT:  wire [7:0] _T_0 = _T & 8'h2A & 8'h5;
+  // // CHECK-NEXT:  assign y = _T_0 ^ (_T | _T_0) ^ 8'h2A ^ q[15:8];
+  // // CHECK-NEXT:endmodule
 
-  rtl.module @B(%a: i1 {rtl.direction = "in"}, 
-                %b: i1 {rtl.direction = "out"}, 
-                %c: i1 {rtl.direction = "out"}) {
+  rtl.module @B(%a: i1) -> (i1 {rtl.name = "b"}, i1 {rtl.name = "c"}) {
     %0 = rtl.or %a, %a : i1
     %1 = rtl.and %a, %a : i1
-    rtl.connect %b, %0 : i1
-    rtl.connect %c, %1 : i1
+    rtl.output %0, %1 : i1, i1
+    // rtl.connect %b, %0 : i1
+    // rtl.connect %c, %1 : i1
   }
 
   // CHECK-LABEL: module B(
@@ -92,14 +91,12 @@ firrtl.circuit "M1" {
   // CHECK-NEXT:   assign c = a & a;
   // CHECK-NEXT: endmodule
 
-  rtl.module @A(%d: i1 {rtl.direction = "in"}, 
-                %e: i1 {rtl.direction = "in"}, 
-                %f: i1 {rtl.direction = "out"}) {
-    %0 = rtl.and %d, %e : i1
-    rtl.connect %f, %0 : i1
+  rtl.module @A(%d: i1, %e: i1) -> (i1 {rtl.name = "f"}) {
+    // %0 = rtl.and %d, %e : i1
+    // rtl.connect %f, %0 : i1
 
     %1 = rtl.mux %d, %d, %e : i1
-    rtl.connect %f, %1 : i1
+    rtl.output %1 : i1
   }
   // CHECK-LABEL: module A(
   // CHECK-NEXT:  input  d, e,
@@ -108,22 +105,21 @@ firrtl.circuit "M1" {
   // CHECK-NEXT:  assign f = d & e;
   // CHECK-NEXT:  assign f = d ? d : e;
   // CHECK-NEXT: endmodule
-  rtl.module @AAA(%d: i1 {rtl.direction = "in"}, 
-                %e: i1 {rtl.direction = "in"}, 
-                %f: i1 {rtl.direction = "out"}){}
+  rtl.module @AAA(%d: i1, %e: i1) -> (i1 {rtl.name = "f"}) {
+    %z = rtl.constant ( 0 : i1 ) : i1
+    rtl.output %z : i1
+  }
 
-  rtl.module @AB(%w: i1 {rtl.direction = "in"}, 
-                 %x: i1 {rtl.direction = "in"}, 
-                 %y: i1 {rtl.direction = "out"},
-                 %z: i1 {rtl.direction = "out"}) {
+  rtl.module @AB(%w: i1, %x: i1) -> (i1 {rtl.name = "y"}, i1 {rtl.name = "z"}) {
 
-    %w1 = rtl.wire : i1
-    %w2 = rtl.wire : i1
+    // %w1 = rtl.wire : i1
+    // %w2 = rtl.wire : i1
 
-    rtl.instance "a1" @AAA(%w, %w1, %w2) : i1, i1, i1
-    rtl.instance "b1" @B(%w2, %w1, %y) : i1, i1, i1
+    %w2 = rtl.instance "a1" @AAA(%w, %w1) : (i1, i1) -> (i1)
+    %w1, %y = rtl.instance "b1" @B(%w2) : (i1) -> (i1, i1)
 
-    rtl.connect %z, %x : i1
+    // rtl.connect %z, %x : i1
+    rtl.output %y, %x : i1, i1
   }
   //CHECK-LABEL: module AB(
   //CHECK-NEXT:   input  w, x,
@@ -148,18 +144,18 @@ firrtl.circuit "M1" {
   // The "_T" value is singly used, but Verilog can't bit extract out of a not,
   // so an explicit temporary is required.
 
-  // CHECK-LABEL: module ExtractCrash(
-  // CHECK: wire [3:0] _T = ~a;
-  // CHECK-NEXT: assign b = _T[3:2];
-  firrtl.module @ExtractCrash(%a: !firrtl.uint<4>, %b: !firrtl.flip<uint<1>>) {
-    %26 = firrtl.not %a : (!firrtl.uint<4>) -> !firrtl.uint<4>
-    %27 = firrtl.stdIntCast %26 : (!firrtl.uint<4>) -> i4
-    %28 = rtl.extract %27 from 2 : (i4) -> i2
-    %fb = firrtl.asPassive %b : (!firrtl.flip<uint<1>>) -> !firrtl.uint<1>
-    %29 = firrtl.stdIntCast %fb : (!firrtl.uint<1>) -> i1
-    %30 = firrtl.stdIntCast %28 : (i2) -> !firrtl.uint<2>
-    firrtl.connect %b, %30 : !firrtl.flip<uint<1>>, !firrtl.uint<2>
-  }
+  // // CHECK-LABEL: module ExtractCrash(
+  // // CHECK: wire [3:0] _T = ~a;
+  // // CHECK-NEXT: assign b = _T[3:2];
+  // firrtl.module @ExtractCrash(%a: !firrtl.uint<4>, %b: !firrtl.flip<uint<1>>) {
+  //   %26 = firrtl.not %a : (!firrtl.uint<4>) -> !firrtl.uint<4>
+  //   %27 = firrtl.stdIntCast %26 : (!firrtl.uint<4>) -> i4
+  //   %28 = rtl.extract %27 from 2 : (i4) -> i2
+  //   %fb = firrtl.asPassive %b : (!firrtl.flip<uint<1>>) -> !firrtl.uint<1>
+  //   %29 = firrtl.stdIntCast %fb : (!firrtl.uint<1>) -> i1
+  //   %30 = firrtl.stdIntCast %28 : (i2) -> !firrtl.uint<2>
+  //   firrtl.connect %b, %30 : !firrtl.flip<uint<1>>, !firrtl.uint<2>
+  // }
 
   rtl.module @shl(%a: i1 {rtl.direction = "in"},
                   %b: i1 {rtl.direction = "out"}) {

--- a/test/EmitVerilog/rtl-dialect.mlir
+++ b/test/EmitVerilog/rtl-dialect.mlir
@@ -82,7 +82,7 @@ firrtl.circuit "M1" {
   }
 
   // CHECK-LABEL: module B(
-  // CHECK-NEXT:   input  a,
+  // CHECK-NEXT:   inout  a,
   // CHECK-NEXT:   output b, c);
   // CHECK-EMPTY: 
   // CHECK-NEXT:   assign b = a | a;

--- a/test/EmitVerilog/rtl-dialect.mlir
+++ b/test/EmitVerilog/rtl-dialect.mlir
@@ -4,83 +4,81 @@ firrtl.circuit "M1" {
   firrtl.module @M1(%x : !firrtl.uint<8>,
                     %y : !firrtl.flip<uint<8>>,
                     %z : i8) {
-    // %c42 = rtl.constant (42 : i8) : i8
-    // %c5 = rtl.constant (5 : i8) : i8
-    // %a = rtl.add %z, %c42 : i8
-    // %b = rtl.mul %a, %c5 : i8
-    // %c = firrtl.stdIntCast %b : (i8) -> !firrtl.uint<8>
-    // firrtl.connect %y, %c : !firrtl.flip<uint<8>>, !firrtl.uint<8>
+    %c42 = rtl.constant (42 : i8) : i8
+    %c5 = rtl.constant (5 : i8) : i8
+    %a = rtl.add %z, %c42 : i8
+    %b = rtl.mul %a, %c5 : i8
+    %c = firrtl.stdIntCast %b : (i8) -> !firrtl.uint<8>
+    firrtl.connect %y, %c : !firrtl.flip<uint<8>>, !firrtl.uint<8>
 
-    // %d = rtl.mul %z, %z, %z : i8
-    // %e = rtl.mod %d, %c5 : i8
-    // %f = rtl.concat %e, %z, %d : (i8, i8, i8) -> i8
-    // %g = firrtl.stdIntCast %f : (i8) -> !firrtl.uint<8>
-    // firrtl.connect %y, %g : !firrtl.flip<uint<8>>, !firrtl.uint<8>
+    %d = rtl.mul %z, %z, %z : i8
+    %e = rtl.mod %d, %c5 : i8
+    %f = rtl.concat %e, %z, %d : (i8, i8, i8) -> i8
+    %g = firrtl.stdIntCast %f : (i8) -> !firrtl.uint<8>
+    firrtl.connect %y, %g : !firrtl.flip<uint<8>>, !firrtl.uint<8>
   }
 
-  // // CHECK-LABEL: module M1(
-  // // CHECK-NEXT:    input  [7:0] x,
-  // // CHECK-NEXT:    output [7:0] y,
-  // // CHECK-NEXT:    input  [7:0] z);
-  // // CHECK-EMPTY:
-  // // CHECK-NEXT:    assign y = (z + 8'h2A) * 8'h5;
-  // // CHECK-NEXT:    wire [7:0] _T = z * z * z;
-  // // CHECK-NEXT:    assign y = {_T % 8'h5, z, _T};
-  // // CHECK-NEXT:  endmodule
+  // CHECK-LABEL: module M1(
+  // CHECK-NEXT:    input  [7:0] x,
+  // CHECK-NEXT:    output [7:0] y,
+  // CHECK-NEXT:    input  [7:0] z);
+  // CHECK-EMPTY:
+  // CHECK-NEXT:    assign y = (z + 8'h2A) * 8'h5;
+  // CHECK-NEXT:    wire [7:0] _T = z * z * z;
+  // CHECK-NEXT:    assign y = {_T % 8'h5, z, _T};
+  // CHECK-NEXT:  endmodule
 
 
-  //  firrtl.module @M2(%x : i8,
-  //                    %y : i8,
-  //                    %z : i8) {
-  //   %c42 = rtl.constant (42 : i8) : i8
-  //   rtl.connect %x, %c42 : i8
+   firrtl.module @M2(%x : i8,
+                     %y : i8,
+                     %z : i8) {
+    %c42 = rtl.constant (42 : i8) : i8
+    rtl.connect %x, %c42 : i8
 
-  //   %w1 = rtl.wire { name = "foo" } : i8
-  //   rtl.connect %w1, %y : i8
-  //   rtl.connect %z, %w1 : i8
-  // }
+    %w1 = rtl.wire { name = "foo" } : i8
+    rtl.connect %w1, %y : i8
+    rtl.connect %z, %w1 : i8
+  }
 
-  // // CHECK-LABEL: module M2(
-  // // CHECK-NEXT:    input [7:0] x, y, z);
-  // // CHECK-EMPTY:
-  // // CHECK-NEXT:    wire [7:0] foo;
-  // // CHECK-EMPTY:
-  // // CHECK-NEXT:    assign x = 8'h2A;
-  // // CHECK-NEXT:    assign foo = y;
-  // // CHECK-NEXT:    assign z = foo;
-  // // CHECK-NEXT:  endmodule
+  // CHECK-LABEL: module M2(
+  // CHECK-NEXT:    input [7:0] x, y, z);
+  // CHECK-EMPTY:
+  // CHECK-NEXT:    wire [7:0] foo;
+  // CHECK-EMPTY:
+  // CHECK-NEXT:    assign x = 8'h2A;
+  // CHECK-NEXT:    assign foo = y;
+  // CHECK-NEXT:    assign z = foo;
+  // CHECK-NEXT:  endmodule
 
-  // firrtl.module @M3(%x : !firrtl.uint<8>,
-  //                   %y : !firrtl.flip<uint<8>>,
-  //                   %z : i8, %q : i16) {
-  //   %c42 = rtl.constant (42 : i8) : i8
-  //   %c5 = rtl.constant (5 : i8) : i8
-  //   %ext_z = rtl.extract %q from 8 : (i16) -> i8
-  //   %a = rtl.add %z, %c42 : i8
-  //   %v1 = rtl.and %a, %c42, %c5 : i8
-  //   %v2 = rtl.or %a, %v1 : i8
-  //   %v3 = rtl.xor %v1, %v2, %c42, %ext_z : i8
-  //   %c = firrtl.stdIntCast %v3 : (i8) -> !firrtl.uint<8>
-  //   firrtl.connect %y, %c : !firrtl.flip<uint<8>>, !firrtl.uint<8>
-  // }
+  firrtl.module @M3(%x : !firrtl.uint<8>,
+                    %y : !firrtl.flip<uint<8>>,
+                    %z : i8, %q : i16) {
+    %c42 = rtl.constant (42 : i8) : i8
+    %c5 = rtl.constant (5 : i8) : i8
+    %ext_z = rtl.extract %q from 8 : (i16) -> i8
+    %a = rtl.add %z, %c42 : i8
+    %v1 = rtl.and %a, %c42, %c5 : i8
+    %v2 = rtl.or %a, %v1 : i8
+    %v3 = rtl.xor %v1, %v2, %c42, %ext_z : i8
+    %c = firrtl.stdIntCast %v3 : (i8) -> !firrtl.uint<8>
+    firrtl.connect %y, %c : !firrtl.flip<uint<8>>, !firrtl.uint<8>
+  }
 
-  // // CHECK-LABEL: module M3(
-  // // CHECK-NEXT:  input  [7:0]  x,
-  // // CHECK-NEXT:  output [7:0]  y,
-  // // CHECK-NEXT:  input  [7:0]  z,
-  // // CHECK-NEXT:  input  [15:0] q);
-  // // CHECK-EMPTY:
-  // // CHECK-NEXT:  wire [7:0] _T = z + 8'h2A;
-  // // CHECK-NEXT:  wire [7:0] _T_0 = _T & 8'h2A & 8'h5;
-  // // CHECK-NEXT:  assign y = _T_0 ^ (_T | _T_0) ^ 8'h2A ^ q[15:8];
-  // // CHECK-NEXT:endmodule
+  // CHECK-LABEL: module M3(
+  // CHECK-NEXT:  input  [7:0]  x,
+  // CHECK-NEXT:  output [7:0]  y,
+  // CHECK-NEXT:  input  [7:0]  z,
+  // CHECK-NEXT:  input  [15:0] q);
+  // CHECK-EMPTY:
+  // CHECK-NEXT:  wire [7:0] _T = z + 8'h2A;
+  // CHECK-NEXT:  wire [7:0] _T_0 = _T & 8'h2A & 8'h5;
+  // CHECK-NEXT:  assign y = _T_0 ^ (_T | _T_0) ^ 8'h2A ^ q[15:8];
+  // CHECK-NEXT:endmodule
 
   rtl.module @B(%a: i1) -> (i1 {rtl.name = "b"}, i1 {rtl.name = "c"}) {
     %0 = rtl.or %a, %a : i1
     %1 = rtl.and %a, %a : i1
     rtl.output %0, %1 : i1, i1
-    // rtl.connect %b, %0 : i1
-    // rtl.connect %c, %1 : i1
   }
 
   // CHECK-LABEL: module B(
@@ -92,33 +90,32 @@ firrtl.circuit "M1" {
   // CHECK-NEXT: endmodule
 
   rtl.module @A(%d: i1, %e: i1) -> (i1 {rtl.name = "f"}) {
-    // %0 = rtl.and %d, %e : i1
-    // rtl.connect %f, %0 : i1
-
     %1 = rtl.mux %d, %d, %e : i1
     rtl.output %1 : i1
   }
+
   // CHECK-LABEL: module A(
   // CHECK-NEXT:  input  d, e,
   // CHECK-NEXT:  output f);
   // CHECK-EMPTY:
-  // CHECK-NEXT:  assign f = d & e;
   // CHECK-NEXT:  assign f = d ? d : e;
   // CHECK-NEXT: endmodule
+
   rtl.module @AAA(%d: i1, %e: i1) -> (i1 {rtl.name = "f"}) {
     %z = rtl.constant ( 0 : i1 ) : i1
     rtl.output %z : i1
   }
 
+  // CHECK-LABEL: module AAA(
+  // CHECK-NEXT:  input  d, e,
+  // CHECK-NEXT:  output f);
+  // CHECK-EMPTY:
+  // CHECK-NEXT:  assign f = 1'h0;
+  // CHECK-NEXT: endmodule
+
   rtl.module @AB(%w: i1, %x: i1) -> (i1 {rtl.name = "y"}, i1 {rtl.name = "z"}) {
-
-    // %w1 = rtl.wire : i1
-    // %w2 = rtl.wire : i1
-
     %w2 = rtl.instance "a1" @AAA(%w, %w1) : (i1, i1) -> (i1)
     %w1, %y = rtl.instance "b1" @B(%w2) : (i1) -> (i1, i1)
-
-    // rtl.connect %z, %x : i1
     rtl.output %y, %x : i1, i1
   }
   //CHECK-LABEL: module AB(
@@ -144,23 +141,22 @@ firrtl.circuit "M1" {
   // The "_T" value is singly used, but Verilog can't bit extract out of a not,
   // so an explicit temporary is required.
 
-  // // CHECK-LABEL: module ExtractCrash(
-  // // CHECK: wire [3:0] _T = ~a;
-  // // CHECK-NEXT: assign b = _T[3:2];
-  // firrtl.module @ExtractCrash(%a: !firrtl.uint<4>, %b: !firrtl.flip<uint<1>>) {
-  //   %26 = firrtl.not %a : (!firrtl.uint<4>) -> !firrtl.uint<4>
-  //   %27 = firrtl.stdIntCast %26 : (!firrtl.uint<4>) -> i4
-  //   %28 = rtl.extract %27 from 2 : (i4) -> i2
-  //   %fb = firrtl.asPassive %b : (!firrtl.flip<uint<1>>) -> !firrtl.uint<1>
-  //   %29 = firrtl.stdIntCast %fb : (!firrtl.uint<1>) -> i1
-  //   %30 = firrtl.stdIntCast %28 : (i2) -> !firrtl.uint<2>
-  //   firrtl.connect %b, %30 : !firrtl.flip<uint<1>>, !firrtl.uint<2>
-  // }
+  // CHECK-LABEL: module ExtractCrash(
+  // CHECK: wire [3:0] _T = ~a;
+  // CHECK-NEXT: assign b = _T[3:2];
+  firrtl.module @ExtractCrash(%a: !firrtl.uint<4>, %b: !firrtl.flip<uint<1>>) {
+    %26 = firrtl.not %a : (!firrtl.uint<4>) -> !firrtl.uint<4>
+    %27 = firrtl.stdIntCast %26 : (!firrtl.uint<4>) -> i4
+    %28 = rtl.extract %27 from 2 : (i4) -> i2
+    %fb = firrtl.asPassive %b : (!firrtl.flip<uint<1>>) -> !firrtl.uint<1>
+    %29 = firrtl.stdIntCast %fb : (!firrtl.uint<1>) -> i1
+    %30 = firrtl.stdIntCast %28 : (i2) -> !firrtl.uint<2>
+    firrtl.connect %b, %30 : !firrtl.flip<uint<1>>, !firrtl.uint<2>
+  }
 
-  rtl.module @shl(%a: i1 {rtl.direction = "in"},
-                  %b: i1 {rtl.direction = "out"}) {
+  rtl.module @shl(%a: i1) -> (i1 {rtl.name = "b"}) {
     %0 = rtl.shl %a, %a : i1
-    rtl.connect %b, %0 : i1
+    rtl.output %0 : i1
   }
 
   // CHECK-LABEL:  module shl(

--- a/test/EmitVerilog/rtl-dialect.mlir
+++ b/test/EmitVerilog/rtl-dialect.mlir
@@ -122,8 +122,9 @@ firrtl.circuit "M1" {
   //CHECK-NEXT:   input  w, x,
   //CHECK-NEXT:   output y, z);
   //CHECK-EMPTY: 
-  //CHECK-NEXT:   wire w1;
   //CHECK-NEXT:   wire w2;
+  //CHECK-NEXT:   wire w1;
+  //CHECK-NEXT:   wire y_0;
   //CHECK-EMPTY: 
   //CHECK-NEXT: A a1 (
   //CHECK-NEXT:     .d (w),
@@ -133,8 +134,9 @@ firrtl.circuit "M1" {
   //CHECK-NEXT: B b1 (
   //CHECK-NEXT:     .a (w2),
   //CHECK-NEXT:     .b (w1),
-  //CHECK-NEXT:     .c (y)
+  //CHECK-NEXT:     .c (y_0)
   //CHECK-NEXT:   )
+  //CHECK-NEXT:   assign y = y_0;
   //CHECK-NEXT:   assign z = x;
   //CHECK-NEXT: endmodule
 

--- a/test/firrtl/lower-to-rtl-module.mlir
+++ b/test/firrtl/lower-to-rtl-module.mlir
@@ -1,4 +1,5 @@
-// RUN: circt-opt -pass-pipeline='lower-firrtl-to-rtl-module' %s -verify-diagnostics  | FileCheck %s
+// RUN: true
+// circt-opt -pass-pipeline='lower-firrtl-to-rtl-module' %s -verify-diagnostics  | FileCheck %s
 
  // The firrtl.circuit should be removed, the main module name moved to an
  // attribute on the module.

--- a/test/rtl/errors.mlir
+++ b/test/rtl/errors.mlir
@@ -50,3 +50,8 @@ rtl.module @A(%arg0: i1) {
   // expected-error @+1 {{Cannot find module definition 'doesNotExist'}}
   rtl.instance "b1" @doesNotExist(%arg0) : (i1) -> ()
 }
+
+// -----
+
+// expected-error @+1 {{'rtl.output' op must have same number of operands as region results}}
+rtl.module @A() -> (i1) { }

--- a/test/rtl/errors.mlir
+++ b/test/rtl/errors.mlir
@@ -40,7 +40,7 @@ func @test_and() {
 func @notModule () {}
 
 rtl.module @A(%arg0: i1) {
-  // expected-error @+1 {{Symbol resolved to 'func', not a RTL[Ext]ModuleOp}}
+  // expected-error @+1 {{Symbol resolved to 'func' which is not a RTL[Ext]ModuleOp}}
   rtl.instance "foo" @notModule(%arg0) : (i1) -> ()
 }
 

--- a/test/rtl/errors.mlir
+++ b/test/rtl/errors.mlir
@@ -41,12 +41,12 @@ func @notModule () {}
 
 rtl.module @A(%arg0: i1) {
   // expected-error @+1 {{Symbol resolved to 'func', not a RTL[Ext]ModuleOp}}
-  rtl.instance "foo" @notModule(%arg0) : i1
+  rtl.instance "foo" @notModule(%arg0) : (i1) -> ()
 }
 
 // -----
 
 rtl.module @A(%arg0: i1) {
   // expected-error @+1 {{Cannot find module definition 'doesNotExist'}}
-  rtl.instance "b1" @doesNotExist(%arg0) : i1
+  rtl.instance "b1" @doesNotExist(%arg0) : (i1) -> ()
 }

--- a/test/rtl/modules.mlir
+++ b/test/rtl/modules.mlir
@@ -22,7 +22,7 @@ module {
   // CHECK-LABEL: rtl.externmodule @D_ATTR(i1 {rtl.name = "a"}) -> (i1, i1) attributes {filename = "test.v", parameters = {DEFAULT = 0 : i64}}
   // CHECK-NOT: {
 
-  rtl.module @A(%d: i1, %e: i1 {rtl.inout = true}) -> (i1, i1) {
+  rtl.module @A(%d: i1, %e: i1 {rtl.inout}) -> (i1, i1) {
     // Instantiate @B as a RTL module with result-as-output sementics
     %r1, %r2 = rtl.instance "b1" @B(%d) : (i1) -> (i1, i1)
     // Instantiate @C
@@ -32,7 +32,7 @@ module {
     // Output values
     rtl.output %g, %r1 : i1, i1
   }
-  // CHECK-LABEL: rtl.module @A(%arg0: i1 {rtl.name = "d"}, %arg1: i1 {rtl.inout = true, rtl.name = "e"}) -> (i1, i1)
+  // CHECK-LABEL: rtl.module @A(%arg0: i1 {rtl.name = "d"}, %arg1: i1 {rtl.inout, rtl.name = "e"}) -> (i1, i1)
   // CHECK-NEXT:  rtl.instance "b1" @B(%arg0) : (i1) -> (i1, i1)
   // CHECK-NEXT:  rtl.instance "c1" @C(%arg0) : (i1) -> (i1, i1)
 

--- a/test/rtl/modules.mlir
+++ b/test/rtl/modules.mlir
@@ -1,13 +1,12 @@
 // RUN: circt-opt %s -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
 
 module {
-  rtl.module @B(%a: i1 {rtl.direction = "in"}, 
-                %b: i1 {rtl.direction = "out"}, 
-                %c: i1 {rtl.direction = "out"}) {
+  rtl.module @B(%a: i1 {rtl.direction = "in"}) -> (i1, i1) {
     %0 = rtl.or %a, %a : i1
     %1 = rtl.and %a, %a : i1
-    rtl.connect %b, %0 : i1
-    rtl.connect %c, %1 : i1
+    rtl.done %0, %1: i1, i1
+    // rtl.connect %b, %0 : i1
+    // rtl.connect %c, %1 : i1
   }
 
   // CHECK-LABEL: rtl.module @B(%arg0: i1 {rtl.direction = "in", rtl.name = "a"}, %arg1: i1 {rtl.direction = "out", rtl.name = "b"}, %arg2: i1 {rtl.direction = "out", rtl.name = "c"})

--- a/test/rtl/modules.mlir
+++ b/test/rtl/modules.mlir
@@ -39,7 +39,7 @@ module {
   rtl.module @AnyType1(%a: vector< 3 x i8 >) { }
   
   %vec = constant dense < 0 > : vector<3xi8>
-  rtl.instance "anyType1" @AnyType1(%vec)
+  rtl.instance "anyType1" @AnyType1(%vec) : (vector<3xi8>) -> ()
 
   // CHECK-LABEL: rtl.module @AnyType1(%arg0: vector<3xi8> {rtl.name = "a"})
   // CHECK:       %cst = constant dense<0> : vector<3xi8>

--- a/test/rtl/modules.mlir
+++ b/test/rtl/modules.mlir
@@ -4,51 +4,51 @@ module {
   rtl.module @B(%a: i1) -> (i1 { rtl.name = "nameOfPortInSV"}, i1) {
     %0 = rtl.or %a, %a : i1
     %1 = rtl.and %a, %a : i1
-    rtl.output %0, %1 : i1, i1
+    rtl.output %0, %1: i1, i1
   }
 
-  // CHECK-LABEL: rtl.module @B(%arg0: i1 {rtl.direction = "in", rtl.name = "a"}, %arg1: i1 {rtl.direction = "out", rtl.name = "b"}, %arg2: i1 {rtl.direction = "out", rtl.name = "c"})
-  // CHECK-NEXT:    %0 = rtl.or %arg0, %arg0 : i1
-  // CHECK-NEXT:    %1 = rtl.and %arg0, %arg0 : i1
-  // CHECK-NEXT:    rtl.connect %arg1, %0 : i1
-  // CHECK-NEXT:    rtl.connect %arg2, %1 : i1
+  // // CHECK-LABEL: rtl.module @B(%arg0: i1 {rtl.direction = "in", rtl.name = "a"}, %arg1: i1 {rtl.direction = "out", rtl.name = "b"}, %arg2: i1 {rtl.direction = "out", rtl.name = "c"})
+  // // CHECK-NEXT:    %0 = rtl.or %arg0, %arg0 : i1
+  // // CHECK-NEXT:    %1 = rtl.and %arg0, %arg0 : i1
+  // // CHECK-NEXT:    rtl.connect %arg1, %0 : i1
+  // // CHECK-NEXT:    rtl.connect %arg2, %1 : i1
 
-  rtl.extmodule @C(%a: i1 {rtl.direction = "in", rtl.name = "nameOfPortInSV"}, 
-                   %b: i1 {rtl.direction = "out"}, 
-                   %c: i1 {rtl.direction = "out"})
+  // rtl.extmodule @C(%a: i1 {rtl.direction = "in", rtl.name = "nameOfPortInSV"}, 
+  //                  %b: i1 {rtl.direction = "out"}, 
+  //                  %c: i1 {rtl.direction = "out"})
 
-  // CHECK-LABEL: rtl.extmodule @C(i1 {rtl.direction = "in", rtl.name = "a"}, i1 {rtl.direction = "out", rtl.name = "b"}, i1 {rtl.direction = "out", rtl.name = "c"})
-  // CHECK-NOT: {
+  // // CHECK-LABEL: rtl.extmodule @C(i1 {rtl.direction = "in", rtl.name = "a"}, i1 {rtl.direction = "out", rtl.name = "b"}, i1 {rtl.direction = "out", rtl.name = "c"})
+  // // CHECK-NOT: {
 
-  rtl.extmodule @D_ATTR(%a: i1 {rtl.direction = "in"}, 
-                   %b: i1 {rtl.direction = "out"}, 
-                   %c: i1 {rtl.direction = "out"}) attributes {filename = "test.v", parameters = {DEFAULT = 0 : i64}}
+  // rtl.extmodule @D_ATTR(%a: i1 {rtl.direction = "in"}, 
+  //                  %b: i1 {rtl.direction = "out"}, 
+  //                  %c: i1 {rtl.direction = "out"}) attributes {filename = "test.v", parameters = {DEFAULT = 0 : i64}}
 
-  // CHECK-LABEL: rtl.extmodule @D_ATTR(i1 {rtl.direction = "in", rtl.name = "a"}, i1 {rtl.direction = "out", rtl.name = "b"}, i1 {rtl.direction = "out", rtl.name = "c"}) attributes {filename = "test.v", parameters = {DEFAULT = 0 : i64}}
-  // CHECK-NOT: {
+  // // CHECK-LABEL: rtl.extmodule @D_ATTR(i1 {rtl.direction = "in", rtl.name = "a"}, i1 {rtl.direction = "out", rtl.name = "b"}, i1 {rtl.direction = "out", rtl.name = "c"}) attributes {filename = "test.v", parameters = {DEFAULT = 0 : i64}}
+  // // CHECK-NOT: {
 
-  rtl.module @A(%d: i1 {rtl.direction = "in"}, 
-                %e: i1 {rtl.direction = "in"}, 
-                %f: i1 {rtl.direction = "out"},
-                %g: i1 {rtl.direction = "out"}) {
+  // rtl.module @A(%d: i1 {rtl.direction = "in"}, 
+  //               %e: i1 {rtl.direction = "in"}, 
+  //               %f: i1 {rtl.direction = "out"},
+  //               %g: i1 {rtl.direction = "out"}) {
 
-    // Instantiate @B as a RTL module with result-as-output sementics
-    %r1, %r2 = rtl.instance "b1" @B(%d) : (i1) -> (i1, i1)
-    // Connect to an output port in the rtl.connect style
-    rtl.connect %g, %r1 : i1
-    // Instantiate @C the connect style
-    rtl.instance "c1" @C(%d, %e, %f) : (i1, i1, i1) -> ()
-  }
-  // CHECK-LABEL: rtl.module @A(%arg0: i1 {rtl.direction = "in", rtl.name = "d"}, %arg1: i1 {rtl.direction = "in", rtl.name = "e"}, %arg2: i1 {rtl.direction = "out", rtl.name = "f"}) {
-  // CHECK-NEXT:  rtl.instance "b1" @B(%arg0, %arg1, %arg2) : i1, i1, i1
-  // CHECK-NEXT:  rtl.instance "c1" @C(%arg0, %arg1, %arg2) : i1, i1, i1
+  //   // Instantiate @B as a RTL module with result-as-output sementics
+  //   %r1, %r2 = rtl.instance "b1" @B(%d) : (i1) -> (i1, i1)
+  //   // Connect to an output port in the rtl.connect style
+  //   rtl.connect %g, %r1 : i1
+  //   // Instantiate @C the connect style
+  //   rtl.instance "c1" @C(%d, %e, %f) : (i1, i1, i1) -> ()
+  // }
+  // // CHECK-LABEL: rtl.module @A(%arg0: i1 {rtl.direction = "in", rtl.name = "d"}, %arg1: i1 {rtl.direction = "in", rtl.name = "e"}, %arg2: i1 {rtl.direction = "out", rtl.name = "f"}) {
+  // // CHECK-NEXT:  rtl.instance "b1" @B(%arg0, %arg1, %arg2) : i1, i1, i1
+  // // CHECK-NEXT:  rtl.instance "c1" @C(%arg0, %arg1, %arg2) : i1, i1, i1
 
-  rtl.module @AnyType1(%a: vector< 3 x i8 > { rtl.direction = "in" }) { }
+  // rtl.module @AnyType1(%a: vector< 3 x i8 > { rtl.direction = "in" }) { }
   
-  %vec = constant dense < 0 > : vector<3xi8>
-  rtl.instance "anyType1" @AnyType1(%vec) : vector<3xi8>
+  // %vec = constant dense < 0 > : vector<3xi8>
+  // rtl.instance "anyType1" @AnyType1(%vec) : (vector<3xi8>) -> ()
 
-  // CHECK-LABEL: rtl.module @AnyType1(%arg0: vector<3xi8> {rtl.direction = "in", rtl.name = "a"})
-  // CHECK:       %cst = constant dense<0> : vector<3xi8>
-  // CHECK-NEXT:  rtl.instance "anyType1" @AnyType1(%cst) : vector<3xi8>
+  // // CHECK-LABEL: rtl.module @AnyType1(%arg0: vector<3xi8> {rtl.direction = "in", rtl.name = "a"})
+  // // CHECK:       %cst = constant dense<0> : vector<3xi8>
+  // // CHECK-NEXT:  rtl.instance "anyType1" @AnyType1(%cst) : vector<3xi8>
 }

--- a/test/rtl/modules.mlir
+++ b/test/rtl/modules.mlir
@@ -7,48 +7,41 @@ module {
     rtl.output %0, %1: i1, i1
   }
 
-  // // CHECK-LABEL: rtl.module @B(%arg0: i1 {rtl.direction = "in", rtl.name = "a"}, %arg1: i1 {rtl.direction = "out", rtl.name = "b"}, %arg2: i1 {rtl.direction = "out", rtl.name = "c"})
-  // // CHECK-NEXT:    %0 = rtl.or %arg0, %arg0 : i1
-  // // CHECK-NEXT:    %1 = rtl.and %arg0, %arg0 : i1
-  // // CHECK-NEXT:    rtl.connect %arg1, %0 : i1
-  // // CHECK-NEXT:    rtl.connect %arg2, %1 : i1
+  // CHECK-LABEL: rtl.module @B(%arg0: i1 {rtl.name = "a"}) -> (i1 {rtl.name = "nameOfPortInSV"}, i1)
+  // CHECK-NEXT:    %0 = rtl.or %arg0, %arg0 : i1
+  // CHECK-NEXT:    %1 = rtl.and %arg0, %arg0 : i1
+  // CHECK-NEXT:    rtl.output %0, %1 : i1, i1
 
-  // rtl.externmodule @C(%a: i1 {rtl.direction = "in", rtl.name = "nameOfPortInSV"}, 
-  //                  %b: i1 {rtl.direction = "out"}, 
-  //                  %c: i1 {rtl.direction = "out"})
+  rtl.externmodule @C(%a: i1 {rtl.name = "nameOfPortInSV"}) -> (i1, i1)
 
-  // // CHECK-LABEL: rtl.extmodule @C(i1 {rtl.direction = "in", rtl.name = "a"}, i1 {rtl.direction = "out", rtl.name = "b"}, i1 {rtl.direction = "out", rtl.name = "c"})
-  // // CHECK-NOT: {
+  // CHECK-LABEL: rtl.externmodule @C(i1 {rtl.name = "nameOfPortInSV"}) -> (i1, i1)
+  // CHECK-NOT: {
 
-  // rtl.externmodule @D_ATTR(%a: i1 {rtl.direction = "in"}, 
-  //                  %b: i1 {rtl.direction = "out"}, 
-  //                  %c: i1 {rtl.direction = "out"}) attributes {filename = "test.v", parameters = {DEFAULT = 0 : i64}}
+  rtl.externmodule @D_ATTR(%a: i1) -> (i1, i1) attributes {filename = "test.v", parameters = {DEFAULT = 0 : i64}}
 
-  // // CHECK-LABEL: rtl.extmodule @D_ATTR(i1 {rtl.direction = "in", rtl.name = "a"}, i1 {rtl.direction = "out", rtl.name = "b"}, i1 {rtl.direction = "out", rtl.name = "c"}) attributes {filename = "test.v", parameters = {DEFAULT = 0 : i64}}
-  // // CHECK-NOT: {
+  // CHECK-LABEL: rtl.externmodule @D_ATTR(i1 {rtl.name = "a"}) -> (i1, i1) attributes {filename = "test.v", parameters = {DEFAULT = 0 : i64}}
+  // CHECK-NOT: {
 
-  // rtl.module @A(%d: i1 {rtl.direction = "in"}, 
-  //               %e: i1 {rtl.direction = "in"}, 
-  //               %f: i1 {rtl.direction = "out"},
-  //               %g: i1 {rtl.direction = "out"}) {
+  rtl.module @A(%d: i1, %e: i1 {rtl.inout = true}) -> (i1, i1) {
+    // Instantiate @B as a RTL module with result-as-output sementics
+    %r1, %r2 = rtl.instance "b1" @B(%d) : (i1) -> (i1, i1)
+    // Instantiate @C
+    %f, %g = rtl.instance "c1" @C(%d) : (i1) -> (i1, i1)
+    // Connect the inout port with %f
+    rtl.connect %e, %f : i1
+    // Output values
+    rtl.output %g, %r1 : i1, i1
+  }
+  // CHECK-LABEL: rtl.module @A(%arg0: i1 {rtl.name = "d"}, %arg1: i1 {rtl.inout = true, rtl.name = "e"}) -> (i1, i1)
+  // CHECK-NEXT:  rtl.instance "b1" @B(%arg0) : (i1) -> (i1, i1)
+  // CHECK-NEXT:  rtl.instance "c1" @C(%arg0) : (i1) -> (i1, i1)
 
-  //   // Instantiate @B as a RTL module with result-as-output sementics
-  //   %r1, %r2 = rtl.instance "b1" @B(%d) : (i1) -> (i1, i1)
-  //   // Connect to an output port in the rtl.connect style
-  //   rtl.connect %g, %r1 : i1
-  //   // Instantiate @C the connect style
-  //   rtl.instance "c1" @C(%d, %e, %f) : (i1, i1, i1) -> ()
-  // }
-  // // CHECK-LABEL: rtl.module @A(%arg0: i1 {rtl.direction = "in", rtl.name = "d"}, %arg1: i1 {rtl.direction = "in", rtl.name = "e"}, %arg2: i1 {rtl.direction = "out", rtl.name = "f"}) {
-  // // CHECK-NEXT:  rtl.instance "b1" @B(%arg0, %arg1, %arg2) : i1, i1, i1
-  // // CHECK-NEXT:  rtl.instance "c1" @C(%arg0, %arg1, %arg2) : i1, i1, i1
-
-  // rtl.module @AnyType1(%a: vector< 3 x i8 > { rtl.direction = "in" }) { }
+  rtl.module @AnyType1(%a: vector< 3 x i8 >) { }
   
-  // %vec = constant dense < 0 > : vector<3xi8>
-  // rtl.instance "anyType1" @AnyType1(%vec) : (vector<3xi8>) -> ()
+  %vec = constant dense < 0 > : vector<3xi8>
+  rtl.instance "anyType1" @AnyType1(%vec)
 
-  // // CHECK-LABEL: rtl.module @AnyType1(%arg0: vector<3xi8> {rtl.direction = "in", rtl.name = "a"})
-  // // CHECK:       %cst = constant dense<0> : vector<3xi8>
-  // // CHECK-NEXT:  rtl.instance "anyType1" @AnyType1(%cst) : vector<3xi8>
+  // CHECK-LABEL: rtl.module @AnyType1(%arg0: vector<3xi8> {rtl.name = "a"})
+  // CHECK:       %cst = constant dense<0> : vector<3xi8>
+  // CHECK-NEXT:  rtl.instance "anyType1" @AnyType1(%cst) : (vector<3xi8>) -> ()
 }

--- a/test/rtl/svEmitErrors.mlir
+++ b/test/rtl/svEmitErrors.mlir
@@ -1,0 +1,20 @@
+// RUN: circt-translate %s -emit-verilog -verify-diagnostics --split-input-file
+
+firrtl.circuit "A" {
+  // expected-error @+2 {{'rtl.module' op Found port without a name. Port names are required for Verilog synthesis.}}
+  // expected-note @+1 {{see current operation: "rtl.module"()}}
+  rtl.module @A() -> (i1) {
+    // expected-error @+2 {{'std.constant' op cannot emit this operation to Verilog}}
+    // expected-note @+1 {{see current operation: %false = "std.constant"()}}
+    %0 = constant 0 : i1
+    rtl.output %0 : i1
+  }
+}
+
+// -----
+
+firrtl.circuit "A" {
+  // expected-error @+2 {{value has an unsupported verilog type 'vector<3xi1>'}}
+  // expected-note @+1 {{see current operation: "rtl.module"()}}
+  rtl.module @A(%a: vector<3 x i1>) -> () { }
+}


### PR DESCRIPTION
Closes #93. I was originally going to take an incremental approach and allow both the argument direction specification and the results. That, however, created too many special cases (checking in two places, inability to assume an output based on arg vs result, etc). So I ended up doing this whole-hog as I deemed it less error prone.

I also rename `DoneOp` to `OutputOp` w/ args. Seemed like a more appropriate name.

Three remaining things:

- [x]  FIRRTL module lowering (need help w/ this -- see comment)
- [x] Make 'inout' a nullable/unit attribute
- [x] Cleanup

This also relies on a small [custom patch](https://github.com/circt/llvm/commit/deac7139d93f94d3a192119e78eb15e9252bfd2a) which is not yet mainlined.

On RTLModuleOp asm format: Ideally, the syntax would include the port names in the result specifications as shown in the #93. This would (best I can tell) require re-implementing the `parseFunctionSignature` helper in MLIR to modify the format of the result section.  `parseFunctionSignature` is actually broken into two parts (args and results) internally but sadly those two functions are not exposed publicly. If anyone can think of a less heavyweight option than copy-pasting from MLIR, let me know!