### PR TITLE
Fix shell script for displaying clang-format and clang-tidy patches

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -250,12 +250,12 @@ jobs:
             echo "================"
             cat clang-format.patch
             echo "================"
-          end
+          fi
           if [ ! -z clang-tidy.patch ]; then
             echo "Clang-tidy patch"
             echo "================"
             cat clang-tidy.patch
             echo "================"
-          end
+          fi
 
     # --- end of build-circt job.


### PR DESCRIPTION
@teqdruid I noticed this when I had some broken formatting.. I think that's all we need right?