### PR TITLE
[RTL] More Module cases

### DIFF
--- a/lib/EmitVerilog/EmitVerilog.cpp
+++ b/lib/EmitVerilog/EmitVerilog.cpp
@@ -277,12 +277,14 @@ void VerilogEmitterBase::emitTypePaddedToWidth(Type type, size_t padToWidth,
 namespace {
 
 class ModuleEmitter : public VerilogEmitterBase {
+
 public:
   explicit ModuleEmitter(VerilogEmitterState &state)
       : VerilogEmitterBase(state) {}
 
   void emitFModule(FModuleOp module);
   void emitRTLModule(rtl::RTLModuleOp module);
+  void emitRTLExternModule(rtl::RTLExternModuleOp module);
   void emitExpression(Value exp, SmallPtrSet<Operation *, 8> &emittedExprs,
                       bool forceRootExpr = false);
 
@@ -1629,16 +1631,31 @@ void ModuleEmitter::emitStatement(rtl::RTLInstanceOp op) {
 
   auto opArgs = op.inputs();
 
-  auto moduleIR = op.getParentOfType<firrtl::CircuitOp>();
-  auto referencedModule =
-      cast<rtl::RTLModuleOp>(moduleIR.lookupSymbol(defName));
-  assert(referencedModule && "invalid rtl.instance op");
+  SmallVector<rtl::RTLModulePortInfo, 8> portInfo;
+  if (auto moduleIR = op.getParentOfType<firrtl::CircuitOp>()) {
+    auto moduleOp = moduleIR.lookupSymbol(defName);
+    if (auto m = cast<rtl::RTLModuleOp>(moduleOp)) {
+        m.getRTLPortInfo(portInfo);
+    } else if (auto m = cast<rtl::RTLExternModuleOp>(moduleOp)) {
+        m.getRTLPortInfo(portInfo);    
+    } else {
+      assert(0 && "invalid rtl.instance op");
+    }
+  } else if (auto moduleIR = op.getParentOfType<mlir::ModuleOp>()) {
+    auto moduleOp = moduleIR.lookupSymbol(defName);
+    if (isa<rtl::RTLModuleOp>(moduleOp)) {
+      cast<rtl::RTLModuleOp>(moduleOp).getRTLPortInfo(portInfo);
+    } else if (isa<rtl::RTLExternModuleOp>(moduleOp)) {
+      cast<rtl::RTLExternModuleOp>(moduleOp).getRTLPortInfo(portInfo);    
+    } else {
+      assert(0 && "invalid rtl.instance op");
+    }
+  } else {
+    assert(0 && "unknown parent module type");
+  }
 
   os << ' ' << defName << ' ' << instanceName << " (";
   emitLocationInfoAndNewLine(ops);
-
-  SmallVector<rtl::RTLModulePortInfo, 8> portInfo;
-  referencedModule.getRTLPortInfo(portInfo);
 
   for (size_t i = 0, e = portInfo.size(); i != e; ++i) {
     rtl::RTLModulePortInfo &elt = portInfo[i];
@@ -1646,7 +1663,7 @@ void ModuleEmitter::emitStatement(rtl::RTLInstanceOp op) {
     indent() << "  ." << StringRef(elt.name.getValue()) << " ("
              << getName(opArgs[i]) << (isLast ? ")\n" : "),\n");
   }
-  indent() << ")\n";
+  indent() << ");\n";
 }
 
 void ModuleEmitter::emitDecl(RegOp op) {
@@ -2397,6 +2414,14 @@ void ModuleEmitter::emitFModule(FModuleOp module) {
   os << "endmodule\n\n";
 }
 
+void ModuleEmitter::emitRTLExternModule(rtl::RTLExternModuleOp module) {
+  // Add all the ports to the name table.
+  SmallVector<rtl::RTLModulePortInfo, 8> portInfo;
+  module.getRTLPortInfo(portInfo);
+
+  os << "// external module " << module.getName() << "\n\n";
+}
+
 void ModuleEmitter::emitRTLModule(rtl::RTLModuleOp module) {
   // Add all the ports to the name table.
   SmallVector<rtl::RTLModulePortInfo, 8> portInfo;
@@ -2586,6 +2611,9 @@ void CircuitEmitter::emitCircuit(CircuitOp circuit) {
     } else if (auto module = dyn_cast<rtl::RTLModuleOp>(op)) {
       ModuleEmitter(state).emitRTLModule(module);
       continue;
+    } else if (auto module = dyn_cast<rtl::RTLExternModuleOp>(op)) {
+      ModuleEmitter(state).emitRTLExternModule(module);
+      continue;
     }
 
     // Ignore the done terminator at the end of the circuit.
@@ -2602,6 +2630,10 @@ void CircuitEmitter::emitMLIRModule(ModuleOp module) {
   for (auto &op : *module.getBody()) {
     if (auto circuit = dyn_cast<CircuitOp>(op))
       emitCircuit(circuit);
+    else if (auto module = dyn_cast<rtl::RTLModuleOp>(op))
+      ModuleEmitter(state).emitRTLModule(module);
+    else if (auto module = dyn_cast<rtl::RTLExternModuleOp>(op))
+      ModuleEmitter(state).emitRTLExternModule(module);
     else if (!isa<ModuleTerminatorOp>(op))
       op.emitError("unknown operation");
   }

--- a/lib/EmitVerilog/EmitVerilog.cpp
+++ b/lib/EmitVerilog/EmitVerilog.cpp
@@ -1635,9 +1635,9 @@ void ModuleEmitter::emitStatement(rtl::RTLInstanceOp op) {
   if (auto moduleIR = op.getParentOfType<firrtl::CircuitOp>()) {
     auto moduleOp = moduleIR.lookupSymbol(defName);
     if (auto m = cast<rtl::RTLModuleOp>(moduleOp)) {
-        m.getRTLPortInfo(portInfo);
+      m.getRTLPortInfo(portInfo);
     } else if (auto m = cast<rtl::RTLExternModuleOp>(moduleOp)) {
-        m.getRTLPortInfo(portInfo);    
+      m.getRTLPortInfo(portInfo);
     } else {
       assert(0 && "invalid rtl.instance op");
     }
@@ -1646,7 +1646,7 @@ void ModuleEmitter::emitStatement(rtl::RTLInstanceOp op) {
     if (isa<rtl::RTLModuleOp>(moduleOp)) {
       cast<rtl::RTLModuleOp>(moduleOp).getRTLPortInfo(portInfo);
     } else if (isa<rtl::RTLExternModuleOp>(moduleOp)) {
-      cast<rtl::RTLExternModuleOp>(moduleOp).getRTLPortInfo(portInfo);    
+      cast<rtl::RTLExternModuleOp>(moduleOp).getRTLPortInfo(portInfo);
     } else {
       assert(0 && "invalid rtl.instance op");
     }

--- a/lib/EmitVerilog/EmitVerilog.cpp
+++ b/lib/EmitVerilog/EmitVerilog.cpp
@@ -2415,10 +2415,6 @@ void ModuleEmitter::emitFModule(FModuleOp module) {
 }
 
 void ModuleEmitter::emitRTLExternModule(rtl::RTLExternModuleOp module) {
-  // Add all the ports to the name table.
-  SmallVector<rtl::RTLModulePortInfo, 8> portInfo;
-  module.getRTLPortInfo(portInfo);
-
   os << "// external module " << module.getName() << "\n\n";
 }
 

--- a/test/EmitVerilog/firrtl-dialect.mlir
+++ b/test/EmitVerilog/firrtl-dialect.mlir
@@ -75,73 +75,61 @@ firrtl.circuit "M1" {
   // CHECK-NEXT:  assign y = _T_0 ^ (_T | _T_0) ^ 8'h2A ^ q[15:8];
   // CHECK-NEXT:endmodule
 
-  rtl.module @B(%a: i1 {rtl.direction = "in"}, 
-                %b: i1 {rtl.direction = "out"}, 
-                %c: i1 {rtl.direction = "out"}) {
+  rtl.module @B(%a: i1 { rtl.inout }) -> (i1 {rtl.name = "b"}, i1 {rtl.name = "c"}) {
     %0 = rtl.or %a, %a : i1
     %1 = rtl.and %a, %a : i1
-    rtl.connect %b, %0 : i1
-    rtl.connect %c, %1 : i1
+    rtl.output %0, %1 : i1, i1
   }
 
   // CHECK-LABEL: module B(
-  // CHECK-NEXT:   input  a,
+  // CHECK-NEXT:   inout  a,
   // CHECK-NEXT:   output b, c);
   // CHECK-EMPTY: 
   // CHECK-NEXT:   assign b = a | a;
   // CHECK-NEXT:   assign c = a & a;
   // CHECK-NEXT: endmodule
 
-  rtl.module @A(%d: i1 {rtl.direction = "in"}, 
-                %e: i1 {rtl.direction = "in"}, 
-                %f: i1 {rtl.direction = "out"}) {
-    %0 = rtl.and %d, %e : i1
-    rtl.connect %f, %0 : i1
-
+  rtl.module @A(%d: i1, %e: i1) -> (i1 {rtl.name = "f"}) {
     %1 = rtl.mux %d, %d, %e : i1
-    rtl.connect %f, %1 : i1
+    rtl.output %1 : i1
   }
+
   // CHECK-LABEL: module A(
   // CHECK-NEXT:  input  d, e,
   // CHECK-NEXT:  output f);
   // CHECK-EMPTY:
-  // CHECK-NEXT:  assign f = d & e;
   // CHECK-NEXT:  assign f = d ? d : e;
   // CHECK-NEXT: endmodule
-  rtl.module @AAA(%d: i1 {rtl.direction = "in"}, 
-                %e: i1 {rtl.direction = "in"}, 
-                %f: i1 {rtl.direction = "out"}){}
-
-  rtl.module @AB(%w: i1 {rtl.direction = "in"}, 
-                 %x: i1 {rtl.direction = "in"}, 
-                 %y: i1 {rtl.direction = "out"},
-                 %z: i1 {rtl.direction = "out"}) {
-
-    %w1 = rtl.wire : i1
-    %w2 = rtl.wire : i1
-
-    rtl.instance "a1" @AAA(%w, %w1, %w2) : i1, i1, i1
-    rtl.instance "b1" @B(%w2, %w1, %y) : i1, i1, i1
-
-    rtl.connect %z, %x : i1
+  rtl.module @AAA(%d: i1, %e: i1) -> (i1 {rtl.name = "f"}) {
+    %z = rtl.constant ( 0 : i1 ) : i1
+    rtl.output %z : i1
   }
+
+  rtl.module @AB(%w: i1, %x: i1) -> (i1 {rtl.name = "y"}, i1 {rtl.name = "z"}) {
+    %w2 = rtl.instance "a1" @AAA(%w, %w1) : (i1, i1) -> (i1)
+    %w1, %y = rtl.instance "b1" @B(%w2) : (i1) -> (i1, i1)
+    rtl.output %y, %x : i1, i1
+  }
+
   //CHECK-LABEL: module AB(
   //CHECK-NEXT:   input  w, x,
   //CHECK-NEXT:   output y, z);
   //CHECK-EMPTY: 
-  //CHECK-NEXT:   wire w1;
   //CHECK-NEXT:   wire w2;
+  //CHECK-NEXT:   wire w1;
+  //CHECK-NEXT:   wire y_0;
   //CHECK-EMPTY: 
-  //CHECK-NEXT: A a1 (
+  //CHECK-NEXT: AAA a1 (
   //CHECK-NEXT:     .d (w),
   //CHECK-NEXT:     .e (w1),
   //CHECK-NEXT:     .f (w2)
-  //CHECK-NEXT:   )
+  //CHECK-NEXT:   );
   //CHECK-NEXT: B b1 (
   //CHECK-NEXT:     .a (w2),
   //CHECK-NEXT:     .b (w1),
-  //CHECK-NEXT:     .c (y)
-  //CHECK-NEXT:   )
+  //CHECK-NEXT:     .c (y_0)
+  //CHECK-NEXT:   );
+  //CHECK-NEXT:   assign y = y_0;
   //CHECK-NEXT:   assign z = x;
   //CHECK-NEXT: endmodule
 
@@ -161,10 +149,9 @@ firrtl.circuit "M1" {
     firrtl.connect %b, %30 : !firrtl.flip<uint<1>>, !firrtl.uint<2>
   }
 
-  rtl.module @shl(%a: i1 {rtl.direction = "in"},
-                  %b: i1 {rtl.direction = "out"}) {
+  rtl.module @shl(%a: i1) -> (i1 {rtl.name = "b"}) {
     %0 = rtl.shl %a, %a : i1
-    rtl.connect %b, %0 : i1
+    rtl.output %0 : i1
   }
 
   // CHECK-LABEL:  module shl(

--- a/test/EmitVerilog/firrtl-dialect.mlir
+++ b/test/EmitVerilog/firrtl-dialect.mlir
@@ -1,0 +1,177 @@
+// RUN: circt-translate %s -emit-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
+
+firrtl.circuit "M1" {
+  firrtl.module @M1(%x : !firrtl.uint<8>,
+                    %y : !firrtl.flip<uint<8>>,
+                    %z : i8) {
+    %c42 = rtl.constant (42 : i8) : i8
+    %c5 = rtl.constant (5 : i8) : i8
+    %a = rtl.add %z, %c42 : i8
+    %b = rtl.mul %a, %c5 : i8
+    %c = firrtl.stdIntCast %b : (i8) -> !firrtl.uint<8>
+    firrtl.connect %y, %c : !firrtl.flip<uint<8>>, !firrtl.uint<8>
+
+    %d = rtl.mul %z, %z, %z : i8
+    %e = rtl.mod %d, %c5 : i8
+    %f = rtl.concat %e, %z, %d : (i8, i8, i8) -> i8
+    %g = firrtl.stdIntCast %f : (i8) -> !firrtl.uint<8>
+    firrtl.connect %y, %g : !firrtl.flip<uint<8>>, !firrtl.uint<8>
+  }
+
+  // CHECK-LABEL: module M1(
+  // CHECK-NEXT:    input  [7:0] x,
+  // CHECK-NEXT:    output [7:0] y,
+  // CHECK-NEXT:    input  [7:0] z);
+  // CHECK-EMPTY:
+  // CHECK-NEXT:    assign y = (z + 8'h2A) * 8'h5;
+  // CHECK-NEXT:    wire [7:0] _T = z * z * z;
+  // CHECK-NEXT:    assign y = {_T % 8'h5, z, _T};
+  // CHECK-NEXT:  endmodule
+
+
+   firrtl.module @M2(%x : i8,
+                     %y : i8,
+                     %z : i8) {
+    %c42 = rtl.constant (42 : i8) : i8
+    rtl.connect %x, %c42 : i8
+
+    %w1 = rtl.wire { name = "foo" } : i8
+    rtl.connect %w1, %y : i8
+    rtl.connect %z, %w1 : i8
+  }
+
+  // CHECK-LABEL: module M2(
+  // CHECK-NEXT:    input [7:0] x, y, z);
+  // CHECK-EMPTY:
+  // CHECK-NEXT:    wire [7:0] foo;
+  // CHECK-EMPTY:
+  // CHECK-NEXT:    assign x = 8'h2A;
+  // CHECK-NEXT:    assign foo = y;
+  // CHECK-NEXT:    assign z = foo;
+  // CHECK-NEXT:  endmodule
+
+  firrtl.module @M3(%x : !firrtl.uint<8>,
+                    %y : !firrtl.flip<uint<8>>,
+                    %z : i8, %q : i16) {
+    %c42 = rtl.constant (42 : i8) : i8
+    %c5 = rtl.constant (5 : i8) : i8
+    %ext_z = rtl.extract %q from 8 : (i16) -> i8
+    %a = rtl.add %z, %c42 : i8
+    %v1 = rtl.and %a, %c42, %c5 : i8
+    %v2 = rtl.or %a, %v1 : i8
+    %v3 = rtl.xor %v1, %v2, %c42, %ext_z : i8
+    %c = firrtl.stdIntCast %v3 : (i8) -> !firrtl.uint<8>
+    firrtl.connect %y, %c : !firrtl.flip<uint<8>>, !firrtl.uint<8>
+  }
+
+  // CHECK-LABEL: module M3(
+  // CHECK-NEXT:  input  [7:0]  x,
+  // CHECK-NEXT:  output [7:0]  y,
+  // CHECK-NEXT:  input  [7:0]  z,
+  // CHECK-NEXT:  input  [15:0] q);
+  // CHECK-EMPTY:
+  // CHECK-NEXT:  wire [7:0] _T = z + 8'h2A;
+  // CHECK-NEXT:  wire [7:0] _T_0 = _T & 8'h2A & 8'h5;
+  // CHECK-NEXT:  assign y = _T_0 ^ (_T | _T_0) ^ 8'h2A ^ q[15:8];
+  // CHECK-NEXT:endmodule
+
+  rtl.module @B(%a: i1 {rtl.direction = "in"}, 
+                %b: i1 {rtl.direction = "out"}, 
+                %c: i1 {rtl.direction = "out"}) {
+    %0 = rtl.or %a, %a : i1
+    %1 = rtl.and %a, %a : i1
+    rtl.connect %b, %0 : i1
+    rtl.connect %c, %1 : i1
+  }
+
+  // CHECK-LABEL: module B(
+  // CHECK-NEXT:   input  a,
+  // CHECK-NEXT:   output b, c);
+  // CHECK-EMPTY: 
+  // CHECK-NEXT:   assign b = a | a;
+  // CHECK-NEXT:   assign c = a & a;
+  // CHECK-NEXT: endmodule
+
+  rtl.module @A(%d: i1 {rtl.direction = "in"}, 
+                %e: i1 {rtl.direction = "in"}, 
+                %f: i1 {rtl.direction = "out"}) {
+    %0 = rtl.and %d, %e : i1
+    rtl.connect %f, %0 : i1
+
+    %1 = rtl.mux %d, %d, %e : i1
+    rtl.connect %f, %1 : i1
+  }
+  // CHECK-LABEL: module A(
+  // CHECK-NEXT:  input  d, e,
+  // CHECK-NEXT:  output f);
+  // CHECK-EMPTY:
+  // CHECK-NEXT:  assign f = d & e;
+  // CHECK-NEXT:  assign f = d ? d : e;
+  // CHECK-NEXT: endmodule
+  rtl.module @AAA(%d: i1 {rtl.direction = "in"}, 
+                %e: i1 {rtl.direction = "in"}, 
+                %f: i1 {rtl.direction = "out"}){}
+
+  rtl.module @AB(%w: i1 {rtl.direction = "in"}, 
+                 %x: i1 {rtl.direction = "in"}, 
+                 %y: i1 {rtl.direction = "out"},
+                 %z: i1 {rtl.direction = "out"}) {
+
+    %w1 = rtl.wire : i1
+    %w2 = rtl.wire : i1
+
+    rtl.instance "a1" @AAA(%w, %w1, %w2) : i1, i1, i1
+    rtl.instance "b1" @B(%w2, %w1, %y) : i1, i1, i1
+
+    rtl.connect %z, %x : i1
+  }
+  //CHECK-LABEL: module AB(
+  //CHECK-NEXT:   input  w, x,
+  //CHECK-NEXT:   output y, z);
+  //CHECK-EMPTY: 
+  //CHECK-NEXT:   wire w1;
+  //CHECK-NEXT:   wire w2;
+  //CHECK-EMPTY: 
+  //CHECK-NEXT: A a1 (
+  //CHECK-NEXT:     .d (w),
+  //CHECK-NEXT:     .e (w1),
+  //CHECK-NEXT:     .f (w2)
+  //CHECK-NEXT:   )
+  //CHECK-NEXT: B b1 (
+  //CHECK-NEXT:     .a (w2),
+  //CHECK-NEXT:     .b (w1),
+  //CHECK-NEXT:     .c (y)
+  //CHECK-NEXT:   )
+  //CHECK-NEXT:   assign z = x;
+  //CHECK-NEXT: endmodule
+
+  // The "_T" value is singly used, but Verilog can't bit extract out of a not,
+  // so an explicit temporary is required.
+
+  // CHECK-LABEL: module ExtractCrash(
+  // CHECK: wire [3:0] _T = ~a;
+  // CHECK-NEXT: assign b = _T[3:2];
+  firrtl.module @ExtractCrash(%a: !firrtl.uint<4>, %b: !firrtl.flip<uint<1>>) {
+    %26 = firrtl.not %a : (!firrtl.uint<4>) -> !firrtl.uint<4>
+    %27 = firrtl.stdIntCast %26 : (!firrtl.uint<4>) -> i4
+    %28 = rtl.extract %27 from 2 : (i4) -> i2
+    %fb = firrtl.asPassive %b : (!firrtl.flip<uint<1>>) -> !firrtl.uint<1>
+    %29 = firrtl.stdIntCast %fb : (!firrtl.uint<1>) -> i1
+    %30 = firrtl.stdIntCast %28 : (i2) -> !firrtl.uint<2>
+    firrtl.connect %b, %30 : !firrtl.flip<uint<1>>, !firrtl.uint<2>
+  }
+
+  rtl.module @shl(%a: i1 {rtl.direction = "in"},
+                  %b: i1 {rtl.direction = "out"}) {
+    %0 = rtl.shl %a, %a : i1
+    rtl.connect %b, %0 : i1
+  }
+
+  // CHECK-LABEL:  module shl(
+  // CHECK-NEXT:   input  a,
+  // CHECK-NEXT:   output b);
+  // CHECK-EMPTY:
+  // CHECK-NEXT:   assign b = a << a;
+  // CHECK-NEXT: endmodule
+
+}

--- a/test/EmitVerilog/rtl-dialect.mlir
+++ b/test/EmitVerilog/rtl-dialect.mlir
@@ -1,79 +1,11 @@
 // RUN: circt-translate %s -emit-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
 
-firrtl.circuit "M1" {
-  firrtl.module @M1(%x : !firrtl.uint<8>,
-                    %y : !firrtl.flip<uint<8>>,
-                    %z : i8) {
-    %c42 = rtl.constant (42 : i8) : i8
-    %c5 = rtl.constant (5 : i8) : i8
-    %a = rtl.add %z, %c42 : i8
-    %b = rtl.mul %a, %c5 : i8
-    %c = firrtl.stdIntCast %b : (i8) -> !firrtl.uint<8>
-    firrtl.connect %y, %c : !firrtl.flip<uint<8>>, !firrtl.uint<8>
+module {
+  rtl.externmodule @E(%a: i1 {rtl.direction = "in"}, 
+                %b: i1 {rtl.direction = "out"}, 
+                %c: i1 {rtl.direction = "out"})
 
-    %d = rtl.mul %z, %z, %z : i8
-    %e = rtl.mod %d, %c5 : i8
-    %f = rtl.concat %e, %z, %d : (i8, i8, i8) -> i8
-    %g = firrtl.stdIntCast %f : (i8) -> !firrtl.uint<8>
-    firrtl.connect %y, %g : !firrtl.flip<uint<8>>, !firrtl.uint<8>
-  }
-
-  // CHECK-LABEL: module M1(
-  // CHECK-NEXT:    input  [7:0] x,
-  // CHECK-NEXT:    output [7:0] y,
-  // CHECK-NEXT:    input  [7:0] z);
-  // CHECK-EMPTY:
-  // CHECK-NEXT:    assign y = (z + 8'h2A) * 8'h5;
-  // CHECK-NEXT:    wire [7:0] _T = z * z * z;
-  // CHECK-NEXT:    assign y = {_T % 8'h5, z, _T};
-  // CHECK-NEXT:  endmodule
-
-
-   firrtl.module @M2(%x : i8,
-                     %y : i8,
-                     %z : i8) {
-    %c42 = rtl.constant (42 : i8) : i8
-    rtl.connect %x, %c42 : i8
-
-    %w1 = rtl.wire { name = "foo" } : i8
-    rtl.connect %w1, %y : i8
-    rtl.connect %z, %w1 : i8
-  }
-
-  // CHECK-LABEL: module M2(
-  // CHECK-NEXT:    input [7:0] x, y, z);
-  // CHECK-EMPTY:
-  // CHECK-NEXT:    wire [7:0] foo;
-  // CHECK-EMPTY:
-  // CHECK-NEXT:    assign x = 8'h2A;
-  // CHECK-NEXT:    assign foo = y;
-  // CHECK-NEXT:    assign z = foo;
-  // CHECK-NEXT:  endmodule
-
-  firrtl.module @M3(%x : !firrtl.uint<8>,
-                    %y : !firrtl.flip<uint<8>>,
-                    %z : i8, %q : i16) {
-    %c42 = rtl.constant (42 : i8) : i8
-    %c5 = rtl.constant (5 : i8) : i8
-    %ext_z = rtl.extract %q from 8 : (i16) -> i8
-    %a = rtl.add %z, %c42 : i8
-    %v1 = rtl.and %a, %c42, %c5 : i8
-    %v2 = rtl.or %a, %v1 : i8
-    %v3 = rtl.xor %v1, %v2, %c42, %ext_z : i8
-    %c = firrtl.stdIntCast %v3 : (i8) -> !firrtl.uint<8>
-    firrtl.connect %y, %c : !firrtl.flip<uint<8>>, !firrtl.uint<8>
-  }
-
-  // CHECK-LABEL: module M3(
-  // CHECK-NEXT:  input  [7:0]  x,
-  // CHECK-NEXT:  output [7:0]  y,
-  // CHECK-NEXT:  input  [7:0]  z,
-  // CHECK-NEXT:  input  [15:0] q);
-  // CHECK-EMPTY:
-  // CHECK-NEXT:  wire [7:0] _T = z + 8'h2A;
-  // CHECK-NEXT:  wire [7:0] _T_0 = _T & 8'h2A & 8'h5;
-  // CHECK-NEXT:  assign y = _T_0 ^ (_T | _T_0) ^ 8'h2A ^ q[15:8];
-  // CHECK-NEXT:endmodule
+  // CHECK-LABEL: // external module E
 
   rtl.module @B(%a: i1 {rtl.direction = "in"}, 
                 %b: i1 {rtl.direction = "out"}, 
@@ -144,22 +76,6 @@ firrtl.circuit "M1" {
   //CHECK-NEXT:   )
   //CHECK-NEXT:   assign z = x;
   //CHECK-NEXT: endmodule
-
-  // The "_T" value is singly used, but Verilog can't bit extract out of a not,
-  // so an explicit temporary is required.
-
-  // CHECK-LABEL: module ExtractCrash(
-  // CHECK: wire [3:0] _T = ~a;
-  // CHECK-NEXT: assign b = _T[3:2];
-  firrtl.module @ExtractCrash(%a: !firrtl.uint<4>, %b: !firrtl.flip<uint<1>>) {
-    %26 = firrtl.not %a : (!firrtl.uint<4>) -> !firrtl.uint<4>
-    %27 = firrtl.stdIntCast %26 : (!firrtl.uint<4>) -> i4
-    %28 = rtl.extract %27 from 2 : (i4) -> i2
-    %fb = firrtl.asPassive %b : (!firrtl.flip<uint<1>>) -> !firrtl.uint<1>
-    %29 = firrtl.stdIntCast %fb : (!firrtl.uint<1>) -> i1
-    %30 = firrtl.stdIntCast %28 : (i2) -> !firrtl.uint<2>
-    firrtl.connect %b, %30 : !firrtl.flip<uint<1>>, !firrtl.uint<2>
-  }
 
   rtl.module @shl(%a: i1 {rtl.direction = "in"},
                   %b: i1 {rtl.direction = "out"}) {


### PR DESCRIPTION
Support emission of modules when not wrapped in a firrtl.circuit (e.g. firrtl-free rtl dialect).
Fix missing ';' in instance lowering. 