### PR TITLE
Make checking for 'end' in tests more robust

### DIFF
--- a/test/EmitVerilog/sv-dialect.mlir
+++ b/test/EmitVerilog/sv-dialect.mlir
@@ -33,7 +33,7 @@ firrtl.circuit "M1" {
       sv.fatal
       // CHECK-NEXT:   $finish
       sv.finish
-      // CHECK-NEXT:   end
+      // CHECK-NEXT:   {{end$}}
     }
   }
 }

--- a/test/EmitVerilog/verilog-basic.fir
+++ b/test/EmitVerilog/verilog-basic.fir
@@ -336,7 +336,7 @@ circuit inputs_only :
   ; CHECK-NEXT:        if (`STOP_COND_ && reset) begin
   ; CHECK-NEXT:          $fatal;
   ; CHECK-NEXT:          $finish;
-  ; CHECK-NEXT:        end
+  ; CHECK-NEXT:        {{end$}}
   ; CHECK-NEXT:      `endif // !SYNTHESIS
   ; CHECK-NEXT:    end // always @(posedge)
   ; CHECK-NEXT:  endmodule
@@ -407,7 +407,7 @@ circuit inputs_only :
   ; CHECK-EMPTY:
   ; CHECK-NEXT:   always @(posedge clock) begin
   ; CHECK-NEXT:     count <= reset ? 2'h0 : cond ? value : count;
-  ; CHECK-NEXT:   end
+  ; CHECK-NEXT:   {{end //}}
   ; CHECK-NEXT: endmodule
   module UninitReg1 :
     input clock: Clock
@@ -443,7 +443,7 @@ circuit inputs_only :
 ; CHECK-EMPTY:
 ; CHECK-NEXT:   always @(posedge clock or posedge reset) begin
 ; CHECK-NEXT:     reg_0 <= io_en ? io_d : reg_0;
-; CHECK-NEXT:   end
+; CHECK-NEXT:   {{end //}}
 ; CHECK-NEXT: endmodule
 
   module InitReg1 :


### PR DESCRIPTION
`; CHECK-NEXT: end` is unfortunately quite fragile, as I noticed when trying to run the tests after compiling with some absolute paths that had the trigram "end" in them. The comment after the preceding lines prints the original source location, and the simple `; CHECK-NEXT: end` would fail because it would locate the match in the comment.

My absolute-path setup is a temporary hack, but this issue would also arise if the relative path happened to have the trigram "end" in it.
