### PR TITLE
[FIRRTL] Add InstanceOp Verification

### DIFF
--- a/include/circt/Dialect/FIRRTL/OpDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/OpDeclarations.td
@@ -18,6 +18,8 @@ def InstanceOp : FIRRTLOp<"instance"> {
   let assemblyFormat = [{
      $moduleName attr-dict `:` type($result)
   }];
+
+  let verifier = [{ return ::verifyInstanceOp(*this); }];
 }
 
 def CMemOp : FIRRTLOp<"cmem", [/*MemAlloc*/]> {

--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -485,10 +485,11 @@ static LogicalResult verifyInstanceOp(InstanceOp &instance) {
   // inside a module.
   auto circuit = instance.getParentOfType<CircuitOp>();
 
-  // Check that this instance doesn't recursively instantiate its wrapping module.
+  // Check that this instance doesn't recursively instantiate its wrapping
+  // module.
   if (circuit.lookupSymbol(instance.moduleName()) == module) {
     auto diag = instance.emitOpError()
-      << "is a recursive instantiation of its containing module";
+                << "is a recursive instantiation of its containing module";
     diag.attachNote(module.getLoc()) << "containing module declared here";
     return failure();
   }

--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -455,10 +455,10 @@ static ParseResult parseFExtModuleOp(OpAsmParser &parser,
   return parseFModuleOp(parser, result, /*isExtModule:*/ true);
 }
 
-static LogicalResult verifyFModuleOp(FModuleOp module) {
+static LogicalResult verifyFModuleOp(FModuleOp &module) {
   // The parent op must be a circuit op.
-  auto *parentOp = module.getParentOp();
-  if (!parentOp || !isa<CircuitOp>(parentOp)) {
+  auto parentOp = dyn_cast<CircuitOp>(module.getParentOp());
+  if (!parentOp) {
     module.emitOpError("should be embedded into a firrtl.circuit");
     return failure();
   }

--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -459,7 +459,7 @@ static LogicalResult verifyFModuleOp(FModuleOp &module) {
   // The parent op must be a circuit op.
   auto parentOp = dyn_cast<CircuitOp>(module.getParentOp());
   if (!parentOp) {
-    module.emitOpError("should be embedded into a firrtl.circuit");
+    module.emitOpError("should be embedded into a 'firrtl.circuit'");
     return failure();
   }
 

--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -457,7 +457,7 @@ static ParseResult parseFExtModuleOp(OpAsmParser &parser,
 
 static LogicalResult verifyFModuleOp(FModuleOp &module) {
   // The parent op must be a circuit op.
-  auto parentOp = dyn_cast<CircuitOp>(module.getParentOp());
+  auto parentOp = dyn_cast_or_null<CircuitOp>(module.getParentOp());
   if (!parentOp) {
     module.emitOpError("should be embedded into a 'firrtl.circuit'");
     return failure();

--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -470,7 +470,7 @@ static LogicalResult verifyFModuleOp(FModuleOp &module) {
 // Declarations
 //===----------------------------------------------------------------------===//
 
-/// Verify the correctness of an InstanceOp
+/// Verify the correctness of an InstanceOp.
 static LogicalResult verifyInstanceOp(InstanceOp &instance) {
 
   // Check that this instance is inside a module.

--- a/test/firrtl/errors.mlir
+++ b/test/firrtl/errors.mlir
@@ -191,3 +191,25 @@ firrtl.circuit "Foo" {
   firrtl.extmodule @Bar(%a : !firrtl.sint<1>) attributes { defname = "Foo" }
 
 }
+
+// -----
+
+firrtl.circuit "Foo" {
+
+  firrtl.module @Foo()
+  // expected-error @+1 {{'firrtl.instance' op should be embedded in a 'firrtl.module'}}
+  %a = firrtl.instance @Foo : !firrtl.bundle<>
+
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+
+  // expected-note @+1 {{containing module declared here}}
+  firrtl.module @Foo() {
+    // expected-error @+1 {{'firrtl.instance' op is a recursive instantiation of its containing module}}
+    %a = firrtl.instance @Foo : !firrtl.bundle<>
+  }
+
+}

--- a/test/firrtl/errors.mlir
+++ b/test/firrtl/errors.mlir
@@ -47,7 +47,7 @@ firrtl.circuit "MyCircuit" {
 // -----
 
 
-// expected-error @+1 {{'firrtl.module' op should be embedded into a firrtl.circuit}}
+// expected-error @+1 {{'firrtl.module' op should be embedded into a 'firrtl.circuit'}}
 firrtl.module @X() {}
 
 // -----


### PR DESCRIPTION
This adds verification of FIRRTL Dialect `InstanceOp`s. Specifically, two things are checked:

- An instance must be inside a module
- An instance cannot recursively instantiate its outer module

Also, this simplifies the existing checking logic inside module verification.

Towards #80.