### PR TITLE
[FIRRTL] Accept more types for casting

### DIFF
--- a/include/circt/Dialect/FIRRTL/OpExpressions.td
+++ b/include/circt/Dialect/FIRRTL/OpExpressions.td
@@ -210,14 +210,14 @@ class UnaryPrimOp<string mnemonic, string resultTypeFunction,
 }
 
 def AsSIntPrimOp
-  : UnaryPrimOp<"asSInt", "getAsSIntResult", SIntType, UIntSIntClockType>;
+  : UnaryPrimOp<"asSInt", "getAsSIntResult", SIntType, FIRRTLType>;
 def AsUIntPrimOp
-  : UnaryPrimOp<"asUInt", "getAsUIntResult", UIntType, UIntSIntClockType>;
+  : UnaryPrimOp<"asUInt", "getAsUIntResult", UIntType, FIRRTLType>;
 def AsAsyncResetPrimOp
   : UnaryPrimOp<"asAsyncReset", "getAsAsyncResetResult",
-                ResetType, UIntSIntClockType>;
+                AsyncResetType, OneBitCastableType>;
 def AsClockPrimOp
-  : UnaryPrimOp<"asClock", "getAsClockResult", ClockType, UIntSIntClockType>;
+  : UnaryPrimOp<"asClock", "getAsClockResult", ClockType, OneBitCastableType>;
 def CvtPrimOp : UnaryPrimOp<"cvt", "getCvtResult", SIntType, IntType>;
 def NegPrimOp : UnaryPrimOp<"neg", "getNegResult", SIntType, IntType>;
 def NotPrimOp : UnaryPrimOp<"not", "getNotResult", UIntType, IntType>;

--- a/include/circt/Dialect/FIRRTL/Types.td
+++ b/include/circt/Dialect/FIRRTL/Types.td
@@ -16,11 +16,18 @@ def ClockType : Type<CPred<"$_self.isa<ClockType>()">, "clock">,
 def IntType : Type<CPred<"$_self.isa<IntType>()">, "sint or uint type">;
 def SIntType : Type<CPred<"$_self.isa<SIntType>()">, "sint type">;
 def UIntType : Type<CPred<"$_self.isa<UIntType>()">, "uint type">;
+def AnalogType : Type<CPred<"$_self.isa<AnalogType>()">, "analog type">;
 
 def UInt1Type : Type<CPred<"$_self.isa<UIntType>() && "
                            "$_self.cast<UIntType>().getWidth() == 1">,
                            "UInt<1>">,
                 BuildableType<"UIntType::get($_builder.getContext(), 1)">;
+
+def OneBitType : Type<CPred<"($_self.isa<IntType>() && "
+                            "$_self.cast<IntType>().getWidth() == 1) ||"
+                            "($_self.isa<AnalogType>() && "
+                            "$_self.cast<AnalogType>().getWidth() == 1)">,
+                            "UInt<1>, SInt<1>, or Analog<1>">;
 
 def AsyncResetType : Type<CPred<"$_self.isa<AsyncResetType>()">, "AsyncReset">;
 
@@ -34,6 +41,10 @@ def PassiveType : Type<CPred<"$_self.isa<FIRRTLType>() && "
 
 def UIntSIntClockType : AnyTypeOf<[SIntType, UIntType, ClockType],
                                   "sint, uint, or clock">;
+
+def OneBitCastableType : AnyTypeOf<
+  [OneBitType, ResetType, AsyncResetType, ClockType],
+  "1-bit uint/sint/analog, reset, asyncreset, or clock">;
 
 //===----------------------------------------------------------------------===//
 // FIRRTL Enum Definitions

--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -952,15 +952,11 @@ FIRRTLType firrtl::getValidIfResult(FIRRTLType lhs, FIRRTLType rhs) {
 //===----------------------------------------------------------------------===//
 
 FIRRTLType firrtl::getAsAsyncResetResult(FIRRTLType input) {
-  if (input.isa<UIntType>() || input.isa<SIntType>() || input.isa<ClockType>())
-    return AsyncResetType::get(input.getContext());
-  return {};
+  return AsyncResetType::get(input.getContext());
 }
 
 FIRRTLType firrtl::getAsClockResult(FIRRTLType input) {
-  if (input.isa<UIntType>() || input.isa<SIntType>() || input.isa<ClockType>())
-    return ClockType::get(input.getContext());
-  return {};
+  return ClockType::get(input.getContext());
 }
 
 FIRRTLType firrtl::getAsSIntResult(FIRRTLType input) {
@@ -971,6 +967,8 @@ FIRRTLType firrtl::getAsSIntResult(FIRRTLType input) {
     return input;
   if (auto ui = input.dyn_cast<UIntType>())
     return SIntType::get(input.getContext(), ui.getWidthOrSentinel());
+  if (auto a = input.dyn_cast<AnalogType>())
+    return SIntType::get(input.getContext(), a.getWidthOrSentinel());
   return {};
 }
 
@@ -982,6 +980,8 @@ FIRRTLType firrtl::getAsUIntResult(FIRRTLType input) {
     return input;
   if (auto si = input.dyn_cast<SIntType>())
     return UIntType::get(input.getContext(), si.getWidthOrSentinel());
+  if (auto a = input.dyn_cast<AnalogType>())
+    return UIntType::get(input.getContext(), a.getWidthOrSentinel());
   return {};
 }
 

--- a/lib/Dialect/FIRRTL/Types.cpp
+++ b/lib/Dialect/FIRRTL/Types.cpp
@@ -251,6 +251,9 @@ FIRRTLType FIRRTLType::getMaskType() {
 FIRRTLType FIRRTLType::getWidthlessType() {
   return TypeSwitch<FIRRTLType, FIRRTLType>(*this)
       .Case<ClockType, ResetType, AsyncResetType>([](auto a) { return a; })
+      .Case<FlipType>([](FlipType a) {
+        return FlipType::get(a.getElementType().getWidthlessType());
+      })
       .Case<UIntType, SIntType, AnalogType>(
           [&](auto a) { return a.get(getContext(), -1); })
       .Case<BundleType>([&](auto a) {

--- a/test/FIRParser/basic.fir
+++ b/test/FIRParser/basic.fir
@@ -58,18 +58,22 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input u: UInt          ; CHECK: %u: !firrtl.uint,
     input bf: { flip int_1 : UInt<1>, int_out : UInt<2>}
     ; CHECK: %bf: !firrtl.bundle<int_1: flip<uint<1>>, int_out: uint<2>>
-    
+
     input vec: UInt<1>[4] ; CHECK: %vec: !firrtl.vector<uint<1>, 4>) {
-    
+
 
   ; CHECK-LABEL: firrtl.module @stmts(
   module stmts :
-    input reset : UInt<1>    ; CHECK: %reset: !firrtl.uint<1>,
-    input clock : Clock      ; CHECK: %clock: !firrtl.clock,
-    output auto : UInt<1>    ; CHECK: %auto: !firrtl.flip<uint<1>>,
-    input i8 : UInt<8>       ; CHECK: %i8: !firrtl.uint<8>,
-    input s8 : SInt<8>       ; CHECK: %s8: !firrtl.sint<8>,
-    input a8 : Analog<8>     ; CHECK: %a8: !firrtl.analog<8>)
+    input reset : UInt<1>         ; CHECK: %reset: !firrtl.uint<1>,
+    input reset_async: AsyncReset ; CHECK: %reset_async: !firrtl.asyncreset,
+    input reset_abstract: Reset   ; CHECK: %reset_abstract: !firrtl.reset,
+    input clock : Clock           ; CHECK: %clock: !firrtl.clock,
+    output auto : UInt<1>         ; CHECK: %auto: !firrtl.flip<uint<1>>,
+    input i8 : UInt<8>            ; CHECK: %i8: !firrtl.uint<8>,
+    input s1 : SInt<1>            ; CHECK: %s1: !firrtl.sint<1>,
+    input s8 : SInt<8>            ; CHECK: %s8: !firrtl.sint<8>,
+    input a1 : Analog<1>          ; CHECK: %a1: !firrtl.analog<1>,
+    input a8 : Analog<8>          ; CHECK: %a8: !firrtl.analog<8>)
 
     ; CHECK: %_t = firrtl.wire {name = "_t"} : !firrtl.vector<uint<1>, 12>
     wire _t : UInt<1>[12] @[Nodes.scala 370:76]
@@ -115,8 +119,57 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.asClock %reset : (!firrtl.uint<1>) -> !firrtl.clock
     node n3 = asClock(reset)
 
+    ; CHECK: firrtl.asUInt %clock : (!firrtl.clock) -> !firrtl.uint<1>
+    node check_u0 = asUInt(clock)
+    ; CHECK: firrtl.asUInt %i8 : (!firrtl.uint<8>) -> !firrtl.uint<8>
+    node check_u1 = asUInt(i8)
+    ; CHECK: firrtl.asUInt %s8 : (!firrtl.sint<8>) -> !firrtl.uint<8>
+    node check_u2 = asUInt(s8)
+    ; CHECK: firrtl.asUInt %a8 : (!firrtl.analog<8>) -> !firrtl.uint<8>
+    node check_u3 = asUInt(a8)
+    ; CHECK: firrtl.asUInt %reset_abstract : (!firrtl.reset) -> !firrtl.uint<1>
+    node check_u5 = asUInt(reset_abstract)
+    ; CHECK: firrtl.asUInt %reset_async : (!firrtl.asyncreset) -> !firrtl.uint<1>
+    node check_u6 = asUInt(reset_async)
+
+    ; CHECK: firrtl.asSInt %clock : (!firrtl.clock) -> !firrtl.sint<1>
+    node check_s0 = asSInt(clock)
+    ; CHECK: firrtl.asSInt %i8 : (!firrtl.uint<8>) -> !firrtl.sint<8>
+    node check_s1 = asSInt(i8)
+    ; CHECK: firrtl.asSInt %s8 : (!firrtl.sint<8>) -> !firrtl.sint<8>
+    node check_s2 = asSInt(s8)
+    ; CHECK: firrtl.asSInt %a8 : (!firrtl.analog<8>) -> !firrtl.sint<8>
+    node check_s3 = asSInt(a8)
+    ; CHECK: firrtl.asSInt %reset_abstract : (!firrtl.reset) -> !firrtl.sint<1>
+    node check_s5 = asSInt(reset_abstract)
+    ; CHECK: firrtl.asSInt %reset_async : (!firrtl.asyncreset) -> !firrtl.sint<1>
+    node check_s6 = asSInt(reset_async)
+
+    ; CHECK: firrtl.asAsyncReset %clock : (!firrtl.clock) -> !firrtl.asyncreset
+    node check_ar0 = asAsyncReset(clock)
     ; CHECK: firrtl.asAsyncReset %reset : (!firrtl.uint<1>) -> !firrtl.asyncreset
-    node ar = asAsyncReset(reset)
+    node check_ar1 = asAsyncReset(reset)
+    ; CHECK: firrtl.asAsyncReset %s1 : (!firrtl.sint<1>) -> !firrtl.asyncreset
+    node check_ar2 = asAsyncReset(s1)
+    ; CHECK: firrtl.asAsyncReset %a1 : (!firrtl.analog<1>) -> !firrtl.asyncreset
+    node check_ar3 = asAsyncReset(a1)
+    ; CHECK: firrtl.asAsyncReset %reset_abstract : (!firrtl.reset) -> !firrtl.asyncreset
+    node check_ar4 = asAsyncReset(reset_abstract)
+    ; CHECK: firrtl.asAsyncReset %reset_async : (!firrtl.asyncreset) -> !firrtl.asyncreset
+    node check_ar5 = asAsyncReset(reset_async)
+
+    ; CHECK: firrtl.asClock %clock : (!firrtl.clock) -> !firrtl.clock
+    node check_c0 = asClock(clock)
+    ; CHECK: firrtl.asClock %reset : (!firrtl.uint<1>) -> !firrtl.clock
+    node check_c1 = asClock(reset)
+    ; CHECK: firrtl.asClock %s1 : (!firrtl.sint<1>) -> !firrtl.clock
+    node check_c2 = asClock(s1)
+    ; CHECK: firrtl.asClock %a1 : (!firrtl.analog<1>) -> !firrtl.clock
+    node check_c3 = asClock(a1)
+    ; CHECK: firrtl.asClock %reset_abstract : (!firrtl.reset) -> !firrtl.clock
+    node check_c4 = asClock(reset_abstract)
+    ; CHECK: firrtl.asClock %reset_async : (!firrtl.asyncreset) -> !firrtl.clock
+    node check_c5 = asClock(reset_async)
 
     ; CHECK: %c42_ui10 = firrtl.constant(42 : ui10) : !firrtl.uint<10>
     ; CHECK: %c171_ui8 = firrtl.constant(171 : ui8) : !firrtl.uint<8>


### PR DESCRIPTION
Currently, MLIR FIRRTL will reject a lot of input types on casting operations. However, the Scala FIRRTL compiler will let you cast almost anything. Roughly:

  - `asUInt` and `asSInt` will accept anything
  - `asClock` and `asAsyncReset` will accept anything, but error in `firrtl.passes.CheckTypes` if the input is not one-bit

This PR widens the set of acceptable input types to match the above. 

I'm very open to any suggestions on how to better organize the FIRRTL type hierarchy. It was already cluttered and this PR makes it worse.

This PR also includes a fix to an incomplete match on the method `FIRRTLType::getWidthlessType` which was incorrectly erroring on any flips. (This commit can be trivially broken out into another PR if that makes sense.)

Fixes #181.