### PR TITLE
[FIRRTL, SV] Lower FIRRTL Verification Ops to SystemVerilog 

### DIFF
--- a/include/circt/Dialect/FIRRTL/Visitors.h
+++ b/include/circt/Dialect/FIRRTL/Visitors.h
@@ -144,7 +144,8 @@ public:
     auto *thisCast = static_cast<ConcreteType *>(this);
     return TypeSwitch<Operation *, ResultType>(op)
         .template Case<AttachOp, ConnectOp, DoneOp, InvalidOp, MemoryPortOp,
-                       PartialConnectOp, PrintFOp, SkipOp, StopOp, WhenOp>(
+                       PartialConnectOp, PrintFOp, SkipOp, StopOp, WhenOp,
+                       AssertOp, AssumeOp, CoverOp>(
             [&](auto opNode) -> ResultType {
               return thisCast->visitStmt(opNode, args...);
             })
@@ -180,6 +181,9 @@ public:
   HANDLE(SkipOp);
   HANDLE(StopOp);
   HANDLE(WhenOp);
+  HANDLE(AssertOp);
+  HANDLE(AssumeOp);
+  HANDLE(CoverOp);
 #undef HANDLE
 };
 

--- a/include/circt/Dialect/SV/Statements.td
+++ b/include/circt/Dialect/SV/Statements.td
@@ -143,3 +143,43 @@ def FatalOp : SVOp<"fatal"> {
 
   let assemblyFormat = [{ attr-dict }];
 }
+
+//===----------------------------------------------------------------------===//
+// Verification Statements
+//===----------------------------------------------------------------------===//
+
+def AssertOp : SVOp<"assert"> {
+  let summary = "immediate assertion statement";
+  let description = [{
+    Assert that a specific condition is always true.
+  }];
+
+  let arguments = (ins AnyType:$predicate);
+  let results = (outs);
+
+  let assemblyFormat = [{ attr-dict `(` $predicate `)` `:` type($predicate) }];
+}
+
+def AssumeOp : SVOp<"assume"> {
+  let summary = "assume property statement";
+  let description = [{
+    Assume that a specific property is always true.
+  }];
+
+  let arguments = (ins AnyType:$property);
+  let results = (outs);
+
+  let assemblyFormat = [{ attr-dict `(` $property `)` `:` type($property) }];
+}
+
+def CoverOp : SVOp<"cover"> {
+  let summary = "functional coverage statement";
+  let description = [{
+    Assert that a specific property happens during the course of execution.
+  }];
+
+  let arguments = (ins AnyType:$property);
+  let results = (outs);
+
+  let assemblyFormat = [{ attr-dict `(` $property `)` `:` type($property) }];
+}

--- a/include/circt/Dialect/SV/Statements.td
+++ b/include/circt/Dialect/SV/Statements.td
@@ -157,7 +157,7 @@ def AssertOp : SVOp<"assert"> {
   let arguments = (ins AnyType:$predicate);
   let results = (outs);
 
-  let assemblyFormat = [{ attr-dict `(` $predicate `)` `:` type($predicate) }];
+  let assemblyFormat = [{ attr-dict $predicate `:` type($predicate) }];
 }
 
 def AssumeOp : SVOp<"assume"> {
@@ -169,7 +169,7 @@ def AssumeOp : SVOp<"assume"> {
   let arguments = (ins AnyType:$property);
   let results = (outs);
 
-  let assemblyFormat = [{ attr-dict `(` $property `)` `:` type($property) }];
+  let assemblyFormat = [{ attr-dict $property `:` type($property) }];
 }
 
 def CoverOp : SVOp<"cover"> {
@@ -181,5 +181,5 @@ def CoverOp : SVOp<"cover"> {
   let arguments = (ins AnyType:$property);
   let results = (outs);
 
-  let assemblyFormat = [{ attr-dict `(` $property `)` `:` type($property) }];
+  let assemblyFormat = [{ attr-dict $property `:` type($property) }];
 }

--- a/include/circt/Dialect/SV/Visitors.h
+++ b/include/circt/Dialect/SV/Visitors.h
@@ -24,7 +24,9 @@ public:
                        // Control flow.
                        IfDefOp, IfOp, AlwaysAtPosEdgeOp,
                        // Other Statements.
-                       YieldOp, FWriteOp, FatalOp, FinishOp>(
+                       YieldOp, FWriteOp, FatalOp, FinishOp,
+                       // Verification statements.
+                       AssertOp, AssumeOp, CoverOp>(
             [&](auto expr) -> ResultType {
               return thisCast->visitSV(expr, args...);
             })
@@ -63,6 +65,11 @@ public:
   HANDLE(FWriteOp, Unhandled);
   HANDLE(FatalOp, Unhandled);
   HANDLE(FinishOp, Unhandled);
+
+  // Verification statements.
+  HANDLE(AssertOp, Unhandled);
+  HANDLE(AssumeOp, Unhandled);
+  HANDLE(CoverOp, Unhandled);
 #undef HANDLE
 };
 

--- a/lib/EmitVerilog/EmitVerilog.cpp
+++ b/lib/EmitVerilog/EmitVerilog.cpp
@@ -308,6 +308,9 @@ public:
   void emitStatement(sv::FWriteOp op);
   void emitStatement(sv::FatalOp op);
   void emitStatement(sv::FinishOp op);
+  void emitStatement(sv::AssertOp op);
+  void emitStatement(sv::AssumeOp op);
+  void emitStatement(sv::CoverOp op);
   void emitDecl(NodeOp op);
   void emitDecl(InstanceOp op);
   void emitDecl(RegOp op);
@@ -1491,6 +1494,27 @@ void ModuleEmitter::emitStatement(sv::FinishOp op) {
   emitLocationInfoAndNewLine(ops);
 }
 
+void ModuleEmitter::emitStatement(sv::AssertOp op) {
+  SmallPtrSet<Operation *, 8> ops;
+  ops.insert(op);
+  indent() << "assert(" << emitExpressionToString(op.predicate(), ops) << ");";
+  emitLocationInfoAndNewLine(ops);
+}
+
+void ModuleEmitter::emitStatement(sv::AssumeOp op) {
+  SmallPtrSet<Operation *, 8> ops;
+  ops.insert(op);
+  indent() << "assume(" << emitExpressionToString(op.property(), ops) << ");";
+  emitLocationInfoAndNewLine(ops);
+}
+
+void ModuleEmitter::emitStatement(sv::CoverOp op) {
+  SmallPtrSet<Operation *, 8> ops;
+  ops.insert(op);
+  indent() << "cover(" << emitExpressionToString(op.property(), ops) << ");";
+  emitLocationInfoAndNewLine(ops);
+}
+
 void ModuleEmitter::emitStatement(sv::IfDefOp op) {
   auto cond = op.cond();
 
@@ -1524,7 +1548,8 @@ static void emitBeginEndRegion(Block *block,
     // Verilog statement (for the purposes of if statements).  Just do a simple
     // check here for now.  This can be improved over time.
     return isa<sv::FWriteOp>(op) || isa<sv::FinishOp>(op) ||
-           isa<sv::FatalOp>(op);
+           isa<sv::FatalOp>(op) || isa<sv::AssertOp>(op) ||
+           isa<sv::AssumeOp>(op) || isa<sv::CoverOp>(op);
   };
 
   // Determine if we can omit the begin/end keywords.
@@ -2191,6 +2216,9 @@ void ModuleEmitter::emitOperation(Operation *op) {
     bool visitSV(sv::FWriteOp op) { return emitter.emitStatement(op), true; }
     bool visitSV(sv::FatalOp op) { return emitter.emitStatement(op), true; }
     bool visitSV(sv::FinishOp op) { return emitter.emitStatement(op), true; }
+    bool visitSV(sv::AssertOp op) { return emitter.emitStatement(op), true; }
+    bool visitSV(sv::AssumeOp op) { return emitter.emitStatement(op), true; }
+    bool visitSV(sv::CoverOp op) { return emitter.emitStatement(op), true; }
 
     bool visitUnhandledSV(Operation *op) { return false; }
     bool visitInvalidSV(Operation *op) { return false; }

--- a/test/EmitVerilog/sv-dialect.mlir
+++ b/test/EmitVerilog/sv-dialect.mlir
@@ -27,7 +27,14 @@ firrtl.circuit "M1" {
 
       // CHECK-NEXT:     $fwrite(32'h80000002, "Bye %x\n", val + val);
       %tmp = rtl.add %val, %val : i8
-      sv.fwrite "Bye %x\n"(%tmp) : i8 
+      sv.fwrite "Bye %x\n"(%tmp) : i8
+
+      // CHECK-NEXT:     assert(cond);
+      sv.assert(%cond) : i1
+      // CHECK-NEXT:     assume(cond);
+      sv.assume(%cond) : i1
+      // CHECK-NEXT:     cover(cond);
+      sv.cover(%cond) : i1
 
       // CHECK-NEXT:   $fatal
       sv.fatal

--- a/test/EmitVerilog/sv-dialect.mlir
+++ b/test/EmitVerilog/sv-dialect.mlir
@@ -30,11 +30,11 @@ firrtl.circuit "M1" {
       sv.fwrite "Bye %x\n"(%tmp) : i8
 
       // CHECK-NEXT:     assert(cond);
-      sv.assert(%cond) : i1
+      sv.assert %cond : i1
       // CHECK-NEXT:     assume(cond);
-      sv.assume(%cond) : i1
+      sv.assume %cond : i1
       // CHECK-NEXT:     cover(cond);
-      sv.cover(%cond) : i1
+      sv.cover %cond : i1
 
       // CHECK-NEXT:   $fatal
       sv.fatal

--- a/test/firrtl/lower-to-rtl.mlir
+++ b/test/firrtl/lower-to-rtl.mlir
@@ -224,4 +224,49 @@
     // CHECK-NEXT: }
     firrtl.stop %clock2, %reset, 0
   }
+
+// circuit Verification:
+//   module Verification:
+//     input clock: Clock
+//     input aCond: UInt<8>
+//     input aEn: UInt<8>
+//     input bCond: UInt<1>
+//     input bEn: UInt<1>
+//     input cCond: UInt<1>
+//     input cEn: UInt<1>
+//     assert(clock, bCond, bEn, "assert0")
+//     assume(clock, aCond, aEn, "assume0")
+//     cover(clock,  cCond, cEn, "cover0")
+
+  // CHECK-LABEL: firrtl.module @Verification
+  firrtl.module @Verification(%clock: !firrtl.clock, %aCond: !firrtl.uint<1>, %aEn: !firrtl.uint<1>, %bCond: !firrtl.uint<1>, %bEn: !firrtl.uint<1>, %cCond: !firrtl.uint<1>, %cEn: !firrtl.uint<1>) {
+    // CHECK-NEXT: %0 = firrtl.stdIntCast %clock : (!firrtl.clock) -> i1
+    // CHECK-NEXT: %1 = firrtl.stdIntCast %aEn : (!firrtl.uint<1>) -> i1
+    // CHECK-NEXT: %2 = firrtl.stdIntCast %aCond : (!firrtl.uint<1>) -> i1
+    // CHECK-NEXT: sv.alwaysat_posedge %0 {
+    // CHECK-NEXT:   sv.if %1 {
+    // CHECK-NEXT:     sv.assert(%2) : i1
+    // CHECK-NEXT:   }
+    // CHECK-NEXT: }
+    firrtl.assert %clock, %aCond, %aEn, "assert0"
+    // CHECK-NEXT: %3 = firrtl.stdIntCast %clock : (!firrtl.clock) -> i1
+    // CHECK-NEXT: %4 = firrtl.stdIntCast %bEn : (!firrtl.uint<1>) -> i1
+    // CHECK-NEXT: %5 = firrtl.stdIntCast %bCond : (!firrtl.uint<1>) -> i1
+    // CHECK-NEXT: sv.alwaysat_posedge %3 {
+    // CHECK-NEXT:   sv.if %4 {
+    // CHECK-NEXT:     sv.assume(%5) : i1
+    // CHECK-NEXT:   }
+    // CHECK-NEXT: }
+    firrtl.assume %clock, %bCond, %bEn, "assume0"
+    // CHECK-NEXT: %6 = firrtl.stdIntCast %clock : (!firrtl.clock) -> i1
+    // CHECK-NEXT: %7 = firrtl.stdIntCast %cEn : (!firrtl.uint<1>) -> i1
+    // CHECK-NEXT: %8 = firrtl.stdIntCast %cCond : (!firrtl.uint<1>) -> i1
+    // CHECK-NEXT: sv.alwaysat_posedge %6 {
+    // CHECK-NEXT:   sv.if %7 {
+    // CHECK-NEXT:     sv.cover(%8) : i1
+    // CHECK-NEXT:   }
+    // CHECK-NEXT: }
+    firrtl.cover %clock, %cCond, %cEn, "cover0"
+  }
+
 }

--- a/test/firrtl/lower-to-rtl.mlir
+++ b/test/firrtl/lower-to-rtl.mlir
@@ -245,7 +245,7 @@
     // CHECK-NEXT: %2 = firrtl.stdIntCast %aCond : (!firrtl.uint<1>) -> i1
     // CHECK-NEXT: sv.alwaysat_posedge %0 {
     // CHECK-NEXT:   sv.if %1 {
-    // CHECK-NEXT:     sv.assert(%2) : i1
+    // CHECK-NEXT:     sv.assert %2 : i1
     // CHECK-NEXT:   }
     // CHECK-NEXT: }
     firrtl.assert %clock, %aCond, %aEn, "assert0"
@@ -254,7 +254,7 @@
     // CHECK-NEXT: %5 = firrtl.stdIntCast %bCond : (!firrtl.uint<1>) -> i1
     // CHECK-NEXT: sv.alwaysat_posedge %3 {
     // CHECK-NEXT:   sv.if %4 {
-    // CHECK-NEXT:     sv.assume(%5) : i1
+    // CHECK-NEXT:     sv.assume %5  : i1
     // CHECK-NEXT:   }
     // CHECK-NEXT: }
     firrtl.assume %clock, %bCond, %bEn, "assume0"
@@ -263,7 +263,7 @@
     // CHECK-NEXT: %8 = firrtl.stdIntCast %cCond : (!firrtl.uint<1>) -> i1
     // CHECK-NEXT: sv.alwaysat_posedge %6 {
     // CHECK-NEXT:   sv.if %7 {
-    // CHECK-NEXT:     sv.cover(%8) : i1
+    // CHECK-NEXT:     sv.cover %8 : i1
     // CHECK-NEXT:   }
     // CHECK-NEXT: }
     firrtl.cover %clock, %cCond, %cEn, "cover0"


### PR DESCRIPTION
This enables lowering of the FIRRTL verification ops (`assert`, `assume`, and `cover`) to Verilog through the SystemVerilog dialect. 

This PR adds three new corresponding ops in SystemVerilog (also: `assert`, `assume`, and `cover` though with the normal SystemVerilog semantics here as opposed to FIRRTL). The FIRRTL to RTL path is then augmented to convert FIRRTL verification ops to SystemVerilog verification ops. The `emitVerilog` utility is then extended to know how to serialize the SystemVerilog ops. 