### PR TITLE
Enable cloning llvm submodule over HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "llvm"]
 	path = llvm
-	url = git@github.com:circt/llvm.git
+	url = ../../circt/llvm.git
 	shallow = true


### PR DESCRIPTION
If you clone circt over HTTPS (`git clone https://github.com/llvm/circt`) in an environment that doesn't have your SSH credentials (like a Docker image), `git submodule update --init` will fail. This change makes it so the submodule is checked out using the same mechanism that was used for the parent module (by using a path relative path instead of an absolute SSH url).

Note that the double ".." is needed because while the `circt` project is in the `llvm` organization, the `llvm` submodule is actually a fork that resides in the `circt` organization. This makes me a bit dizzy, but go figure.