### PR TITLE
[FIRRTL] Add result type verification for firrtl instance op

### DIFF
--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -519,7 +519,7 @@ static LogicalResult verifyInstanceOp(InstanceOp &instance) {
       return failure();
     }
 
-    for (size_t i = 0, e = bundleElements.size(); i != e; i++) {
+    for (size_t i = 0; i != e; i++) {
       auto expectedType = referencedFModule.getArgument(i)
                               .getType()
                               .cast<FIRRTLType>()

--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -526,10 +526,13 @@ static LogicalResult verifyInstanceOp(InstanceOp &instance) {
                               .cast<FIRRTLType>()
                               .getPassiveType();
       if (bundleElements[i].second != expectedType) {
-        instance.emitOpError("output bundle type must match module. In "
-                             "element ")
+        auto diag = instance.emitOpError() << 
+        "output bundle type must match module. In "
+                             "element "
             << i << ", expected " << expectedType << ", but got "
-            << bundleElements[i].second;
+            << bundleElements[i].second << ".";
+        
+        diag.attachNote(referencedFModule.getLoc()) << "original module declared here";
         return failure();
       }
     }

--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -513,9 +513,10 @@ static LogicalResult verifyInstanceOp(InstanceOp &instance) {
     size_t e = bundleElements.size();
 
     if (e != referencedFModule.getNumArguments()) {
-      instance.emitOpError()
+      auto diag = instance.emitOpError()
           << "has a wrong size of bundle type, expected size is "
           << referencedFModule.getNumArguments() << " but got " << e;
+      diag.attachNote(referencedFModule.getLoc()) << "original module declared here";
       return failure();
     }
 

--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -526,13 +526,14 @@ static LogicalResult verifyInstanceOp(InstanceOp &instance) {
                               .cast<FIRRTLType>()
                               .getPassiveType();
       if (bundleElements[i].second != expectedType) {
-        auto diag = instance.emitOpError() << 
-        "output bundle type must match module. In "
-                             "element "
-            << i << ", expected " << expectedType << ", but got "
-            << bundleElements[i].second << ".";
-        
-        diag.attachNote(referencedFModule.getLoc()) << "original module declared here";
+        auto diag = instance.emitOpError()
+                    << "output bundle type must match module. In "
+                       "element "
+                    << i << ", expected " << expectedType << ", but got "
+                    << bundleElements[i].second << ".";
+
+        diag.attachNote(referencedFModule.getLoc())
+            << "original module declared here";
         return failure();
       }
     }

--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -514,9 +514,10 @@ static LogicalResult verifyInstanceOp(InstanceOp &instance) {
 
     if (e != referencedFModule.getNumArguments()) {
       auto diag = instance.emitOpError()
-          << "has a wrong size of bundle type, expected size is "
-          << referencedFModule.getNumArguments() << " but got " << e;
-      diag.attachNote(referencedFModule.getLoc()) << "original module declared here";
+                  << "has a wrong size of bundle type, expected size is "
+                  << referencedFModule.getNumArguments() << " but got " << e;
+      diag.attachNote(referencedFModule.getLoc())
+          << "original module declared here";
       return failure();
     }
 

--- a/test/firrtl/errors.mlir
+++ b/test/firrtl/errors.mlir
@@ -213,3 +213,15 @@ firrtl.circuit "Foo" {
   }
 
 }
+
+// -----
+
+firrtl.circuit "Foo" {
+  firrtl.module @Bar(%arg0: !firrtl.bundle<valid: uint<1>>) { }
+
+  firrtl.module @Foo() {
+    // expected-error @+1 {{'firrtl.instance' op is a recursive instantiation of its containing module}}
+    %a = firrtl.instance @Bar : !firrtl.bundle<valid: uint<2>>
+  }
+
+}

--- a/test/firrtl/errors.mlir
+++ b/test/firrtl/errors.mlir
@@ -221,7 +221,7 @@ firrtl.circuit "Foo" {
   // expected-note @+1 {{original module declared here}}
   firrtl.module @Callee(%arg0: !firrtl.uint<1>) { }
   firrtl.module @Foo() {
-    // expected-error @+1 {{'firrtl.instance' op output bundle type must match module. In element 0, expected '!firrtl.uint<1>', but got '!firrtl.uint<2>'}}
+    // expected-error @+1 {{'firrtl.instance' op output bundle type must match module. In element 0, expected '!firrtl.uint<1>', but got '!firrtl.uint<2>'.}}
     %a = firrtl.instance @Callee : !firrtl.bundle<arg0: uint<2>>
   }
 }
@@ -245,7 +245,7 @@ firrtl.circuit "Foo" {
   // expected-note @+1 {{original module declared here}}
   firrtl.module @Callee(%arg0: !firrtl.uint<1>, %arg1: !firrtl.bundle<valid: uint<1>>) { }
   firrtl.module @Foo() {
-    // expected-error @+1 {{'firrtl.instance' op output bundle type must match module. In element 1, expected '!firrtl.bundle<valid: uint<1>>', but got '!firrtl.bundle<valid: uint<2>>'}}
+    // expected-error @+1 {{'firrtl.instance' op output bundle type must match module. In element 1, expected '!firrtl.bundle<valid: uint<1>>', but got '!firrtl.bundle<valid: uint<2>>'.}}
     %a = firrtl.instance @Callee : !firrtl.bundle<arg0: uint<1>, arg1: bundle<valid: uint<2>>>
   }
 }

--- a/test/firrtl/errors.mlir
+++ b/test/firrtl/errors.mlir
@@ -239,10 +239,10 @@ firrtl.circuit "Foo" {
 // -----
 
 firrtl.circuit "Foo" {
-  firrtl.module @Callee(%arg0: !firrtl.uint<0>, %arg1: !firrtl.bundle<valid: uint<1>>) { }
+  firrtl.module @Callee(%arg0: !firrtl.uint<1>, %arg1: !firrtl.bundle<valid: uint<1>>) { }
 
   firrtl.module @Foo() {
     // expected-error @+1 {{'firrtl.instance' op output bundle type must match module. In element 1, expected '!firrtl.bundle<valid: uint<1>>', but got '!firrtl.bundle<valid: uint<2>>'}}
-    %b = firrtl.instance @Callee : !firrtl.bundle<arg0: uint<0>, arg1: bundle<valid: uint<2>>>
+    %a = firrtl.instance @Callee : !firrtl.bundle<arg0: uint<1>, arg1: bundle<valid: uint<2>>>
   }
 }

--- a/test/firrtl/errors.mlir
+++ b/test/firrtl/errors.mlir
@@ -217,11 +217,32 @@ firrtl.circuit "Foo" {
 // -----
 
 firrtl.circuit "Foo" {
-  firrtl.module @Bar(%arg0: !firrtl.bundle<valid: uint<1>>) { }
+  firrtl.module @Callee(%arg0: !firrtl.uint<1>) { }
 
   firrtl.module @Foo() {
-    // expected-error @+1 {{'firrtl.instance' op is a recursive instantiation of its containing module}}
-    %a = firrtl.instance @Bar : !firrtl.bundle<valid: uint<2>>
+    // expected-error @+1 {{'firrtl.instance' op output bundle type must match module. In element 0, expected '!firrtl.uint<1>', but got '!firrtl.uint<2>'}}
+    %a = firrtl.instance @Callee : !firrtl.bundle<arg0: uint<2>>
   }
+}
 
+// -----
+
+firrtl.circuit "Foo" {
+  firrtl.module @Callee(%arg0: !firrtl.uint<1> ) { }
+
+  firrtl.module @Foo() {
+    // expected-error @+1 {{'firrtl.instance' op has a wrong size of bundle type, expected size is 1 but got 0}}
+    %a = firrtl.instance @Callee : !firrtl.bundle<>
+  }
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+  firrtl.module @Callee(%arg0: !firrtl.uint<0>, %arg1: !firrtl.bundle<valid: uint<1>>) { }
+
+  firrtl.module @Foo() {
+    // expected-error @+1 {{'firrtl.instance' op output bundle type must match module. In element 1, expected '!firrtl.bundle<valid: uint<1>>', but got '!firrtl.bundle<valid: uint<2>>'}}
+    %b = firrtl.instance @Callee : !firrtl.bundle<arg0: uint<0>, arg1: bundle<valid: uint<2>>>
+  }
 }

--- a/test/firrtl/errors.mlir
+++ b/test/firrtl/errors.mlir
@@ -217,8 +217,9 @@ firrtl.circuit "Foo" {
 // -----
 
 firrtl.circuit "Foo" {
-  firrtl.module @Callee(%arg0: !firrtl.uint<1>) { }
 
+  // expected-note @+1 {{original module declared here}}
+  firrtl.module @Callee(%arg0: !firrtl.uint<1>) { }
   firrtl.module @Foo() {
     // expected-error @+1 {{'firrtl.instance' op output bundle type must match module. In element 0, expected '!firrtl.uint<1>', but got '!firrtl.uint<2>'}}
     %a = firrtl.instance @Callee : !firrtl.bundle<arg0: uint<2>>
@@ -228,8 +229,9 @@ firrtl.circuit "Foo" {
 // -----
 
 firrtl.circuit "Foo" {
-  firrtl.module @Callee(%arg0: !firrtl.uint<1> ) { }
 
+  // expected-note @+1 {{original module declared here}}
+  firrtl.module @Callee(%arg0: !firrtl.uint<1> ) { }
   firrtl.module @Foo() {
     // expected-error @+1 {{'firrtl.instance' op has a wrong size of bundle type, expected size is 1 but got 0}}
     %a = firrtl.instance @Callee : !firrtl.bundle<>
@@ -239,8 +241,9 @@ firrtl.circuit "Foo" {
 // -----
 
 firrtl.circuit "Foo" {
-  firrtl.module @Callee(%arg0: !firrtl.uint<1>, %arg1: !firrtl.bundle<valid: uint<1>>) { }
 
+  // expected-note @+1 {{original module declared here}}
+  firrtl.module @Callee(%arg0: !firrtl.uint<1>, %arg1: !firrtl.bundle<valid: uint<1>>) { }
   firrtl.module @Foo() {
     // expected-error @+1 {{'firrtl.instance' op output bundle type must match module. In element 1, expected '!firrtl.bundle<valid: uint<1>>', but got '!firrtl.bundle<valid: uint<2>>'}}
     %a = firrtl.instance @Callee : !firrtl.bundle<arg0: uint<1>, arg1: bundle<valid: uint<2>>>


### PR DESCRIPTION
Towards #191, this PR adds verification whether the result types match the referenced module by looking at the length and elements of the bundle type.