### PR TITLE
[EmitVerilog] Lint and simulation integration tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ add_subdirectory(lib)
 add_subdirectory(tools)
 #add_subdirectory(unittests)
 add_subdirectory(test)
+add_subdirectory(integration_test)
 
 #option(CIRCT_INCLUDE_DOCS "Generate build targets for the CIRCT docs."
 #  ${LLVM_INCLUDE_DOCS} ${MLIR_INCLUDE_DOCS})

--- a/README.md
+++ b/README.md
@@ -107,8 +107,7 @@ $ cmake -G Ninja .. \
     -DCMAKE_BUILD_TYPE=DEBUG
 $ ninja
 $ ninja check-circt
-$ ninja check-circt-integration # Run the integration tests, which require
-                                # additional software to be present.
+$ ninja check-circt-integration # Run the integration tests.
 ```
 
 The `-DCMAKE_BUILD_TYPE=DEBUG` flag enables debug information, which makes the

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ $ cmake -G Ninja .. \
     -DCMAKE_BUILD_TYPE=DEBUG
 $ ninja
 $ ninja check-circt
+$ ninja check-circt-integration # Run the integration tests, which require
+                                # additional software to be present.
 ```
 
 The `-DCMAKE_BUILD_TYPE=DEBUG` flag enables debug information, which makes the

--- a/integration_test/CMakeLists.txt
+++ b/integration_test/CMakeLists.txt
@@ -1,0 +1,22 @@
+configure_lit_site_cfg(
+  ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
+  ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
+  INTEGRATION_CONFIG
+  ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
+  )
+
+set(CIRCT_INTEGRATION_TEST_DEPENDS
+  FileCheck count not
+  circt-opt
+  circt-translate
+  )
+
+add_lit_testsuite(check-circt-integration "Running the CIRCT integration tests"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS ${CIRCT_INTEGRATION_TEST_DEPENDS}
+  )
+set_target_properties(check-circt-integration PROPERTIES FOLDER "IntegrationTests")
+
+add_lit_testsuites(CIRCT_INTEGRATION ${CMAKE_CURRENT_SOURCE_DIR}
+  DEPENDS ${CIRCT_INTEGRATION_TEST_DEPS}
+)

--- a/integration_test/EmitVerilog/basic.mlir
+++ b/integration_test/EmitVerilog/basic.mlir
@@ -1,0 +1,37 @@
+// REQUIRES: verilator
+// RUN: circt-translate %s -emit-verilog -verify-diagnostics > %t1.sv
+// RUN: verilator --cc --top-module main -sv %t1.sv --build --exe %S/driver.cpp
+// RUN: ./obj_dir/Vmain --cycles 8 2>&1 | FileCheck %s
+
+module {
+  // The RTL dialect doesn't have any sequential constructs yet. So don't do
+  // much.
+  rtl.module @main(%clk: i1, %rstn: i1) {
+    %c1 = rtl.instance "aaa" @AAA () : () -> (i1)
+    %c1Shl = rtl.instance "shl" @shl (%c1) : (i1) -> (i1)
+    sv.alwaysat_posedge %clk {
+      sv.fwrite "tick\n"
+    }
+  }
+
+  rtl.module @AAA() -> (i1 {rtl.name = "f"}) {
+    %z = rtl.constant ( 1 : i1 ) : i1
+    rtl.output %z : i1
+  }
+
+  rtl.module @shl(%a: i1) -> (i1 {rtl.name = "b"}) {
+    %0 = rtl.shl %a, %a : i1
+    rtl.output %0 : i1
+  }
+}
+
+// CHECK:      [driver] Starting simulation
+// CHECK-NEXT: tick
+// CHECK-NEXT: tick
+// CHECK-NEXT: tick
+// CHECK-NEXT: tick
+// CHECK-NEXT: tick
+// CHECK-NEXT: tick
+// CHECK-NEXT: tick
+// CHECK-NEXT: tick
+// CHECK-NEXT: [driver] Ending simulation at tick #17

--- a/integration_test/EmitVerilog/driver.cpp
+++ b/integration_test/EmitVerilog/driver.cpp
@@ -1,0 +1,83 @@
+//===- driver.cpp - Verilator software driver -----------------------------===//
+//
+// A fairly standard, boilerplate Verilator C++ simulation driver. Assumes the
+// top level exposes just two signals: 'clk' and 'rstn'.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Vmain.h"
+
+#ifdef DEBUG
+#include "verilated_vcd_c.h"
+#endif
+
+#include <iostream>
+
+vluint64_t timeStamp;
+
+// Called by $time in Verilog
+double sc_time_stamp() { return timeStamp; }
+
+int main(int argc, char **argv) {
+  Verilated::commandArgs(argc, argv);
+
+  size_t numCyclesToRun = 0;
+  // Search the command line args for those we are sensitive to.
+  for (int i = 1; i < argc; ++i) {
+    if (std::string(argv[i]) == "--cycles") {
+      if (i + 1 < argc) {
+        numCyclesToRun = std::strtoull(argv[++i], nullptr, 10);
+      } else {
+        std::cerr << "--cycles must be followed by number of cycles."
+                  << std::endl;
+        return 1;
+      }
+    }
+  }
+
+  // Construct the simulated module's C++ model.
+  auto &dut = *new Vmain();
+#ifdef DEBUG
+  VerilatedVcdC *tfp = new VerilatedVcdC;
+  Verilated::traceEverOn(true);
+  dut.trace(tfp, 99); // Trace 99 levels of hierarchy
+  tfp->open("main.vcd");
+#endif
+
+  std::cout << "[driver] Starting simulation" << std::endl;
+
+  // Reset.
+  dut.rstn = 0;
+  dut.clk = 0;
+
+  // Run for a few cycles with reset held.
+  for (timeStamp = 0; timeStamp < 10 && !Verilated::gotFinish(); timeStamp++) {
+    dut.eval();
+    dut.clk = !dut.clk;
+#ifdef DEBUG
+    tfp->dump(timeStamp);
+#endif
+  }
+
+  // Take simulation out of reset.
+  dut.rstn = 1;
+
+  // Run for the specified number of cycles out of reset.
+  for (; timeStamp <= (numCyclesToRun * 2) && !Verilated::gotFinish();
+       timeStamp++) {
+    dut.eval();
+    dut.clk = !dut.clk;
+#ifdef DEBUG
+    tfp->dump(timeStamp);
+#endif
+  }
+
+  // Tell the simulator that we're going to exit. This flushes the output(s) and
+  // frees whatever memory may have been allocated.
+  dut.final();
+#ifdef DEBUG
+  tfp->close();
+#endif
+
+  std::cout << "[driver] Ending simulation at tick #" << timeStamp << std::endl;
+}

--- a/integration_test/EmitVerilog/lint.mlir
+++ b/integration_test/EmitVerilog/lint.mlir
@@ -1,0 +1,31 @@
+// REQUIRES: verilator
+// RUN: circt-translate %s -emit-verilog -verify-diagnostics > %t1.sv && verilator --lint-only --top-module AB %t1.sv
+
+module {
+  rtl.module @B(%a: i1 { rtl.inout }) -> (i1 {rtl.name = "b"}, i1 {rtl.name = "c"}) {
+    %0 = rtl.or %a, %a : i1
+    %1 = rtl.and %a, %a : i1
+    rtl.output %0, %1 : i1, i1
+  }
+
+  rtl.module @A(%d: i1, %e: i1) -> (i1 {rtl.name = "f"}) {
+    %1 = rtl.mux %d, %d, %e : i1
+    rtl.output %1 : i1
+  }
+
+  rtl.module @AAA(%d: i1, %e: i1) -> (i1 {rtl.name = "f"}) {
+    %z = rtl.constant ( 0 : i1 ) : i1
+    rtl.output %z : i1
+  }
+
+  rtl.module @AB(%w: i1, %x: i1) -> (i1 {rtl.name = "y"}, i1 {rtl.name = "z"}) {
+    %w2 = rtl.instance "a1" @AAA(%w, %w1) : (i1, i1) -> (i1)
+    %w1, %y = rtl.instance "b1" @B(%w2) : (i1) -> (i1, i1)
+    rtl.output %y, %x : i1, i1
+  }
+
+  rtl.module @shl(%a: i1) -> (i1 {rtl.name = "b"}) {
+    %0 = rtl.shl %a, %a : i1
+    rtl.output %0 : i1
+  }
+}

--- a/integration_test/lit.cfg.py
+++ b/integration_test/lit.cfg.py
@@ -1,0 +1,68 @@
+# -*- Python -*-
+
+import os
+import platform
+import re
+import shutil
+import subprocess
+import tempfile
+
+import lit.formats
+import lit.util
+
+from lit.llvm import llvm_config
+from lit.llvm.subst import ToolSubst
+from lit.llvm.subst import FindTool
+
+# Configuration file for the 'lit' test runner.
+
+# name: The name of this test suite.
+config.name = 'CIRCT'
+
+config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+
+# suffixes: A list of file extensions to treat as test files.
+config.suffixes = ['.td', '.mlir', '.ll', '.fir', '.sv']
+
+# test_source_root: The root path where tests are located.
+config.test_source_root = os.path.dirname(__file__)
+
+# test_exec_root: The root path where tests should be run.
+config.test_exec_root = os.path.join(config.circt_obj_root, 'test')
+
+config.substitutions.append(('%PATH%', config.environment['PATH']))
+config.substitutions.append(('%shlibext', config.llvm_shlib_ext))
+
+llvm_config.with_system_environment(
+    ['HOME', 'INCLUDE', 'LIB', 'TMP', 'TEMP'])
+
+llvm_config.use_default_substitutions()
+
+# excludes: A list of directories to exclude from the testsuite. The 'Inputs'
+# subdirectories contain auxiliary inputs for various tests in their parent
+# directories.
+config.excludes = ['Inputs', 'CMakeLists.txt', 'README.txt', 'LICENSE.txt']
+
+# test_source_root: The root path where tests are located.
+config.test_source_root = os.path.dirname(__file__)
+
+# test_exec_root: The root path where tests should be run.
+config.test_exec_root = os.path.join(config.circt_obj_root, 'integration_test')
+
+# Tweak the PATH to include the tools dir.
+llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)
+
+tool_dirs = [config.circt_tools_dir,
+             config.mlir_tools_dir, config.llvm_tools_dir]
+tools = [
+    'circt-opt',
+    'circt-translate',
+]
+
+# Enable Verilator if it has been detected.
+if config.verilator_path != "":
+  tool_dirs.append(os.path.dirname(config.verilator_path))
+  tools.append('verilator')
+  config.available_features.add('verilator')
+
+llvm_config.add_tool_substitutions(tools, tool_dirs)

--- a/integration_test/lit.site.cfg.py.in
+++ b/integration_test/lit.site.cfg.py.in
@@ -1,0 +1,53 @@
+@LIT_SITE_CFG_IN_HEADER@
+
+import sys
+
+config.host_triple = "@LLVM_HOST_TRIPLE@"
+config.target_triple = "@TARGET_TRIPLE@"
+config.llvm_src_root = "@LLVM_SOURCE_DIR@"
+config.llvm_obj_root = "@LLVM_BINARY_DIR@"
+config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"
+config.llvm_lib_dir = "@LLVM_LIBRARY_DIR@"
+config.llvm_shlib_dir = "@SHLIBDIR@"
+config.llvm_shlib_ext = "@SHLIBEXT@"
+config.llvm_exe_ext = "@EXEEXT@"
+config.lit_tools_dir = "@LLVM_LIT_TOOLS_DIR@"
+config.python_executable = "@PYTHON_EXECUTABLE@"
+config.gold_executable = "@GOLD_EXECUTABLE@"
+config.ld64_executable = "@LD64_EXECUTABLE@"
+config.enable_shared = @ENABLE_SHARED@
+config.enable_assertions = @ENABLE_ASSERTIONS@
+config.targets_to_build = "@TARGETS_TO_BUILD@"
+config.native_target = "@LLVM_NATIVE_ARCH@"
+config.llvm_bindings = "@LLVM_BINDINGS@".split(' ')
+config.host_os = "@HOST_OS@"
+config.host_cc = "@HOST_CC@"
+config.host_cxx = "@HOST_CXX@"
+# Note: ldflags can contain double-quoted paths, so must use single quotes here.
+config.host_ldflags = '@HOST_LDFLAGS@'
+config.llvm_use_sanitizer = "@LLVM_USE_SANITIZER@"
+config.llvm_host_triple = '@LLVM_HOST_TRIPLE@'
+config.host_arch = "@HOST_ARCH@"
+config.mlir_src_root = "@MLIR_SOURCE_DIR@"
+config.mlir_obj_root = "@MLIR_BINARY_DIR@"
+config.mlir_tools_dir = "@MLIR_TOOLS_DIR@"
+config.circt_src_root = "@CIRCT_SOURCE_DIR@"
+config.circt_obj_root = "@CIRCT_BINARY_DIR@"
+config.circt_tools_dir = "@CIRCT_TOOLS_DIR@"
+config.verilator_path = "@VERILATOR_PATH@"
+
+# Support substitution of the tools_dir with user parameters. This is
+# used when we can't determine the tool dir at configuration time.
+try:
+    config.llvm_tools_dir = config.llvm_tools_dir % lit_config.params
+    config.llvm_shlib_dir = config.llvm_shlib_dir % lit_config.params
+except KeyError:
+    e = sys.exc_info()[1]
+    key, = e.args
+    lit_config.fatal("unable to find %r parameter, use '--param=%s=VALUE'" % (key,key))
+
+import lit.llvm
+lit.llvm.initialize(lit_config, config)
+
+# Let the main config do the real work.
+lit_config.load_config(config, "@CIRCT_SOURCE_DIR@/integration_test/lit.cfg.py")

--- a/utils/get-verilator.sh
+++ b/utils/get-verilator.sh
@@ -11,7 +11,7 @@ wget https://github.com/verilator/verilator/archive/v$VERILATOR_VER.tar.gz
 tar -zxf v$VERILATOR_VER.tar.gz
 cd verilator-$VERILATOR_VER
 autoconf
-./configure --prefix=`pwd`/..
+./configure --prefix=$EXT_DIR
 make -j$(nproc)
 make install
 cd ..


### PR DESCRIPTION
- Simple Verilator lint test.
- Simple Verilator simulation test support.
- Simple Verilator simulator test.

The integration tests are run with the `check-circt-integration` target.