### PR TITLE
[FIRRTL] Add verification for firrtl bits op

### DIFF
--- a/include/circt/Dialect/FIRRTL/OpExpressions.td
+++ b/include/circt/Dialect/FIRRTL/OpExpressions.td
@@ -260,6 +260,8 @@ def BitsPrimOp : PrimOp<"bits"> {
       return getResultType(inputs[0], integers[0], integers[1]);
     }
   }];
+
+  let verifier = [{ return ::verifyBitsPrimOp(*this); }];
 }
 
 def HeadPrimOp : PrimOp<"head"> {

--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -1073,19 +1073,32 @@ FIRRTLType firrtl::getReductionResult(FIRRTLType input) {
 //===----------------------------------------------------------------------===//
 
 static LogicalResult verifyBitsPrimOp(BitsPrimOp bits) {
+  uint32_t hi = bits.hi(), lo = bits.lo();
   // High must be >= low.
-  if (bits.hi() < bits.lo()) {
-    bits.emitError() << "high must be >= low, but got high = " << bits.hi()
-                     << ", low = " << bits.lo();
+  if (hi < lo) {
+    bits.emitError()
+        << "high must be equal or greater than low, but got high = "
+        << bits.hi() << ", low = " << bits.lo();
     return failure();
   }
 
   // Input width must be > high.
   int32_t width =
       bits.input().getType().cast<IntType>().getBitWidthOrSentinel();
-  if (width != -1 && int32_t(bits.hi()) >= width) {
-    bits.emitError() << "high must be < width of input, but got high = "
-                     << bits.hi() << ", width = " << width;
+  if (width != -1 && int32_t(hi) >= width) {
+    bits.emitError()
+        << "high must be smaller than the width of input, but got high = " << hi
+        << ", width = " << width;
+    return failure();
+  }
+
+  // Result type should be int type with (high - low + 1) width.
+  int32_t resultWidth =
+      bits.result().getType().cast<IntType>().getBitWidthOrSentinel();
+  if (resultWidth != -1 && int32_t(hi - lo + 1) != resultWidth) {
+    bits.emitError() << "width of the result type must be equal to (high - low "
+                        "+ 1), expected "
+                     << hi - lo + 1 << " but got = " << resultWidth;
     return failure();
   }
 

--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -1072,6 +1072,26 @@ FIRRTLType firrtl::getReductionResult(FIRRTLType input) {
 // Other Operations
 //===----------------------------------------------------------------------===//
 
+static LogicalResult verifyBitsPrimOp(BitsPrimOp bits) {
+  // High must be >= low.
+  if (bits.hi() < bits.lo()) {
+    bits.emitError() << "high must be >= low, but got high = " << bits.hi()
+                     << ", low = " << bits.lo();
+    return failure();
+  }
+
+  // Input width must be > high.
+  int32_t width =
+      bits.input().getType().cast<IntType>().getBitWidthOrSentinel();
+  if (width != -1 && int32_t(bits.hi()) >= width) {
+    bits.emitError() << "high must be < width of input, but got high = "
+                     << bits.hi() << ", width = " << width;
+    return failure();
+  }
+
+  return success();
+}
+
 FIRRTLType BitsPrimOp::getResultType(FIRRTLType input, int32_t high,
                                      int32_t low) {
   auto inputi = input.dyn_cast<IntType>();

--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -1074,11 +1074,12 @@ FIRRTLType firrtl::getReductionResult(FIRRTLType input) {
 
 static LogicalResult verifyBitsPrimOp(BitsPrimOp bits) {
   uint32_t hi = bits.hi(), lo = bits.lo();
+
   // High must be >= low.
   if (hi < lo) {
     bits.emitError()
-        << "high must be equal or greater than low, but got high = "
-        << bits.hi() << ", low = " << bits.lo();
+        << "high must be equal or greater than low, but got high = " << hi
+        << ", low = " << lo;
     return failure();
   }
 

--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -1099,7 +1099,7 @@ static LogicalResult verifyBitsPrimOp(BitsPrimOp bits) {
   if (resultWidth != -1 && int32_t(hi - lo + 1) != resultWidth) {
     bits.emitError() << "width of the result type must be equal to (high - low "
                         "+ 1), expected "
-                     << hi - lo + 1 << " but got = " << resultWidth;
+                     << hi - lo + 1 << " but got " << resultWidth;
     return failure();
   }
 

--- a/test/firrtl/errors.mlir
+++ b/test/firrtl/errors.mlir
@@ -253,7 +253,7 @@ firrtl.circuit "Foo" {
 firrtl.circuit "X" {
 
 firrtl.module @X(%a : !firrtl.uint<4>) {
-  // expected-error @+1 {{high must be >= low, but got high = 3, low = 4}}
+  // expected-error @+1 {{high must be equal or greater than low, but got high = 3, low = 4}}
   %0 = firrtl.bits %a 3 to 4 : (!firrtl.uint<4>) -> !firrtl.uint<2>
 }
 
@@ -264,8 +264,19 @@ firrtl.module @X(%a : !firrtl.uint<4>) {
 firrtl.circuit "X" {
 
 firrtl.module @X(%a : !firrtl.uint<4>) {
-  // expected-error @+1 {{high must be < width of input, but got high = 4, width = 4}}
-  %0 = firrtl.bits %a 4 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<2>
+  // expected-error @+1 {{high must be smaller than the width of input, but got high = 4, width = 4}}
+  %0 = firrtl.bits %a 4 to 3 : (!firrtl.uint<4>) -> !firrtl.uint<2>
+}
+
+}
+
+// -----
+
+firrtl.circuit "X" {
+
+firrtl.module @X(%a : !firrtl.uint<4>) {
+  // expected-error @+1 {{width of the result type must be equal to (high - low + 1), expected 3 but got = 2}}
+  %0 = firrtl.bits %a 3 to 1 : (!firrtl.uint<4>) -> !firrtl.uint<2>
 }
 
 }

--- a/test/firrtl/errors.mlir
+++ b/test/firrtl/errors.mlir
@@ -236,6 +236,7 @@ firrtl.circuit "Foo" {
     // expected-error @+1 {{'firrtl.instance' op has a wrong size of bundle type, expected size is 1 but got 0}}
     %a = firrtl.instance @Callee : !firrtl.bundle<>
   }
+}
 
 // -----
 
@@ -247,7 +248,7 @@ firrtl.circuit "Foo" {
     // expected-error @+1 {{'firrtl.instance' op output bundle type must match module. In element 1, expected '!firrtl.bundle<valid: uint<1>>', but got '!firrtl.bundle<valid: uint<2>>'.}}
     %a = firrtl.instance @Callee : !firrtl.bundle<arg0: uint<1>, arg1: bundle<valid: uint<2>>>
   }
-
+}
 // ----- 
 
 firrtl.circuit "X" {

--- a/test/firrtl/errors.mlir
+++ b/test/firrtl/errors.mlir
@@ -275,7 +275,7 @@ firrtl.module @X(%a : !firrtl.uint<4>) {
 firrtl.circuit "X" {
 
 firrtl.module @X(%a : !firrtl.uint<4>) {
-  // expected-error @+1 {{width of the result type must be equal to (high - low + 1), expected 3 but got = 2}}
+  // expected-error @+1 {{width of the result type must be equal to (high - low + 1), expected 3 but got 2}}
   %0 = firrtl.bits %a 3 to 1 : (!firrtl.uint<4>) -> !firrtl.uint<2>
 }
 

--- a/test/firrtl/errors.mlir
+++ b/test/firrtl/errors.mlir
@@ -236,7 +236,6 @@ firrtl.circuit "Foo" {
     // expected-error @+1 {{'firrtl.instance' op has a wrong size of bundle type, expected size is 1 but got 0}}
     %a = firrtl.instance @Callee : !firrtl.bundle<>
   }
-}
 
 // -----
 
@@ -248,4 +247,25 @@ firrtl.circuit "Foo" {
     // expected-error @+1 {{'firrtl.instance' op output bundle type must match module. In element 1, expected '!firrtl.bundle<valid: uint<1>>', but got '!firrtl.bundle<valid: uint<2>>'.}}
     %a = firrtl.instance @Callee : !firrtl.bundle<arg0: uint<1>, arg1: bundle<valid: uint<2>>>
   }
+
+// ----- 
+
+firrtl.circuit "X" {
+
+firrtl.module @X(%a : !firrtl.uint<4>) {
+  // expected-error @+1 {{high must be >= low, but got high = 3, low = 4}}
+  %0 = firrtl.bits %a 3 to 4 : (!firrtl.uint<4>) -> !firrtl.uint<2>
+}
+
+}
+
+// -----
+
+firrtl.circuit "X" {
+
+firrtl.module @X(%a : !firrtl.uint<4>) {
+  // expected-error @+1 {{high must be < width of input, but got high = 4, width = 4}}
+  %0 = firrtl.bits %a 4 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<2>
+}
+
 }

--- a/test/firrtl/errors.mlir
+++ b/test/firrtl/errors.mlir
@@ -249,6 +249,7 @@ firrtl.circuit "Foo" {
     %a = firrtl.instance @Callee : !firrtl.bundle<arg0: uint<1>, arg1: bundle<valid: uint<2>>>
   }
 }
+
 // ----- 
 
 firrtl.circuit "X" {


### PR DESCRIPTION
Towards #80, this PR adds the verification of firrtl bits op. This verifies the following things:

- high >= low
- input width > high
- result width == high - low + 1