### PR TITLE
Update LLVM to 2e36e0dad52

### DIFF
--- a/lib/Dialect/LLHD/IR/LLHDDialect.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDDialect.cpp
@@ -28,12 +28,12 @@ struct LLHDInlinerInterface : public DialectInlinerInterface {
   //===--------------------------------------------------------------------===//
 
   /// All operations within LLHD can be inlined.
-  bool isLegalToInline(Operation *, Region *,
+  bool isLegalToInline(Operation *, Region *, bool,
                        BlockAndValueMapping &) const final {
     return true;
   }
 
-  bool isLegalToInline(Region *, Region *src,
+  bool isLegalToInline(Region *, Region *src, bool,
                        BlockAndValueMapping &) const final {
     // Don't inline processes and entities
     return !isa<llhd::ProcOp>(src->getParentOp()) &&

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -9,6 +9,7 @@
 #include "circt/Dialect/FIRRTL/Ops.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/RTL/Dialect.h"
+#include "circt/Dialect/RTL/Ops.h"
 #include "circt/Dialect/SV/Dialect.h"
 #include "circt/EmitVerilog.h"
 #include "circt/FIRParser.h"
@@ -102,7 +103,8 @@ processBuffer(std::unique_ptr<llvm::MemoryBuffer> ownedBuffer,
   // If enabled, run the optimizer.
   if (!disableOptimization) {
     // Apply any pass manager command line options.
-    PassManager pm(&context, /*verifyPasses:*/ true);
+    PassManager pm(&context);
+    pm.enableVerifier(true);
     applyPassManagerCLOptions(pm);
 
     pm.addPass(createCSEPass());
@@ -111,7 +113,7 @@ processBuffer(std::unique_ptr<llvm::MemoryBuffer> ownedBuffer,
     // Run the lower-to-rtl pass if requested.
     if (lowerToRTL) {
       pm.addPass(firrtl::createLowerFIRRTLToRTLModulePass());
-      pm.addPass(firrtl::createLowerFIRRTLToRTLPass());
+      pm.nest<rtl::RTLModuleOp>().addPass(firrtl::createLowerFIRRTLToRTLPass());
     }
 
     if (failed(pm.run(module.get())))


### PR DESCRIPTION
This adds some helper methods to `FunctionLike` that I'd like to make use of in https://github.com/llvm/circt/pull/157.