### PR TITLE
[FIRRTL] Add location to getResultType for better error reporting 

### DIFF
--- a/include/circt/Dialect/FIRRTL/OpExpressions.td
+++ b/include/circt/Dialect/FIRRTL/OpExpressions.td
@@ -50,7 +50,8 @@ def SubfieldOp : FIRRTLOp<"subfield", [NoSideEffect]> {
     /// Compute the result of a Subfield operation on a value of the specified
     /// type and extracting the specified field name.  If the request is
     /// invalid, then a null type is returned.
-    static FIRRTLType getResultType(FIRRTLType inType, StringRef fieldName, Location loc);
+    static FIRRTLType getResultType(FIRRTLType inType, StringRef fieldName,
+                                    Location loc);
   }];
 }
 
@@ -77,7 +78,8 @@ def SubindexOp : FIRRTLOp<"subindex", [NoSideEffect]> {
   let extraClassDeclaration = [{
     /// Compute the result of a Subindex operation on a value of the specified
     /// type.  If the request is invalid, then a null type is returned.
-    static FIRRTLType getResultType(FIRRTLType inType, unsigned fieldIdx, Location loc);
+    static FIRRTLType getResultType(FIRRTLType inType, unsigned fieldIdx,
+                                    Location loc);
   }];
 }
 
@@ -103,7 +105,8 @@ def SubaccessOp : FIRRTLOp<"subaccess", [NoSideEffect]> {
   let extraClassDeclaration = [{
     /// Compute the result of a Subaccess operation on a value of the specified
     /// type.  If the request is invalid, then a null type is returned.
-    static FIRRTLType getResultType(FIRRTLType baseType, FIRRTLType indexType, Location loc);
+    static FIRRTLType getResultType(FIRRTLType baseType, FIRRTLType indexType,
+                                    Location loc);
   }];
 }
 //===----------------------------------------------------------------------===//
@@ -133,7 +136,8 @@ class BinaryPrimOp<string mnemonic, string resultTypeFunction,
   let extraClassDeclaration = !cast<code>(!strconcat(!cast<string>([{
     /// Return the result for inputs with the specified type, returning a null
     /// type if the input types are invalid.
-    static FIRRTLType getResultType(FIRRTLType lhs, FIRRTLType rhs, Location loc) {
+    static FIRRTLType getResultType(FIRRTLType lhs, FIRRTLType rhs,
+                                    Location loc) {
       return }]), resultTypeFunction, !cast<string>([{(lhs, rhs);
     }
     static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
@@ -277,7 +281,8 @@ def HeadPrimOp : PrimOp<"head"> {
   let extraClassDeclaration = [{
     /// Return the result for inputs with the specified type, returning a null
     /// type if the input types are invalid.
-    static FIRRTLType getResultType(FIRRTLType input, int32_t amount, Location loc);
+    static FIRRTLType getResultType(FIRRTLType input, int32_t amount,
+                                    Location loc);
     static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
                                     ArrayRef<int32_t> integers, Location loc) {
       if (inputs.size() != 1 || integers.size() != 1)
@@ -330,7 +335,8 @@ def PadPrimOp : PrimOp<"pad"> {
   let extraClassDeclaration = [{
     /// Return the result for inputs with the specified type, returning a null
     /// type if the input types are invalid.
-    static FIRRTLType getResultType(FIRRTLType input, int32_t amount, Location loc);
+    static FIRRTLType getResultType(FIRRTLType input, int32_t amount,
+                                    Location loc);
     static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
                                     ArrayRef<int32_t> integers, Location loc) {
       if (inputs.size() != 1 || integers.size() != 1)
@@ -351,7 +357,8 @@ class ShiftPrimOp<string mnemonic> : PrimOp<mnemonic> {
   let extraClassDeclaration = [{
     /// Return the result for inputs with the specified type, returning a null
     /// type if the input types are invalid.
-    static FIRRTLType getResultType(FIRRTLType input, int32_t amount, Location loc);
+    static FIRRTLType getResultType(FIRRTLType input, int32_t amount,
+                                    Location loc);
     static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
                                     ArrayRef<int32_t> integers, Location loc) {
       if (inputs.size() != 1 || integers.size() != 1)
@@ -385,7 +392,8 @@ def TailPrimOp : PrimOp<"tail"> {
   let extraClassDeclaration = [{
     /// Return the result for inputs with the specified type, returning a null
     /// type if the input types are invalid.
-    static FIRRTLType getResultType(FIRRTLType input, int32_t amount, Location loc);
+    static FIRRTLType getResultType(FIRRTLType input, int32_t amount,
+                                    Location loc);
     static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
                                     ArrayRef<int32_t> integers, Location loc) {
       if (inputs.size() != 1 || integers.size() != 1)

--- a/include/circt/Dialect/FIRRTL/OpExpressions.td
+++ b/include/circt/Dialect/FIRRTL/OpExpressions.td
@@ -50,7 +50,7 @@ def SubfieldOp : FIRRTLOp<"subfield", [NoSideEffect]> {
     /// Compute the result of a Subfield operation on a value of the specified
     /// type and extracting the specified field name.  If the request is
     /// invalid, then a null type is returned.
-    static FIRRTLType getResultType(FIRRTLType inType, StringRef fieldName);
+    static FIRRTLType getResultType(FIRRTLType inType, StringRef fieldName, Location loc);
   }];
 }
 
@@ -77,7 +77,7 @@ def SubindexOp : FIRRTLOp<"subindex", [NoSideEffect]> {
   let extraClassDeclaration = [{
     /// Compute the result of a Subindex operation on a value of the specified
     /// type.  If the request is invalid, then a null type is returned.
-    static FIRRTLType getResultType(FIRRTLType inType, unsigned fieldIdx);
+    static FIRRTLType getResultType(FIRRTLType inType, unsigned fieldIdx, Location loc);
   }];
 }
 
@@ -103,7 +103,7 @@ def SubaccessOp : FIRRTLOp<"subaccess", [NoSideEffect]> {
   let extraClassDeclaration = [{
     /// Compute the result of a Subaccess operation on a value of the specified
     /// type.  If the request is invalid, then a null type is returned.
-    static FIRRTLType getResultType(FIRRTLType baseType, FIRRTLType indexType);
+    static FIRRTLType getResultType(FIRRTLType baseType, FIRRTLType indexType, Location loc);
   }];
 }
 //===----------------------------------------------------------------------===//
@@ -133,14 +133,14 @@ class BinaryPrimOp<string mnemonic, string resultTypeFunction,
   let extraClassDeclaration = !cast<code>(!strconcat(!cast<string>([{
     /// Return the result for inputs with the specified type, returning a null
     /// type if the input types are invalid.
-    static FIRRTLType getResultType(FIRRTLType lhs, FIRRTLType rhs) {
+    static FIRRTLType getResultType(FIRRTLType lhs, FIRRTLType rhs, Location loc) {
       return }]), resultTypeFunction, !cast<string>([{(lhs, rhs);
     }
     static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
-                                    ArrayRef<int32_t> integers) {
+                                    ArrayRef<int32_t> integers, Location loc) {
       if (inputs.size() != 2 || !integers.empty())
         return {};
-      return getResultType(inputs[0], inputs[1]);
+      return getResultType(inputs[0], inputs[1], loc);
     }
   }])));
 }
@@ -197,14 +197,14 @@ class UnaryPrimOp<string mnemonic, string resultTypeFunction,
   let extraClassDeclaration = !cast<code>(!strconcat(!cast<string>([{
     /// Return the result for inputs with the specified type, returning a null
     /// type if the input types are invalid.
-    static FIRRTLType getResultType(FIRRTLType input) {
+    static FIRRTLType getResultType(FIRRTLType input, Location loc) {
       return }]), resultTypeFunction, !cast<string>([{(input);
     }
     static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
-                                    ArrayRef<int32_t> integers) {
+                                    ArrayRef<int32_t> integers, Location loc) {
       if (inputs.size() != 1 || !integers.empty())
         return {};
-      return getResultType(inputs[0]);
+      return getResultType(inputs[0], loc);
     }
   }])));
 }
@@ -252,12 +252,12 @@ def BitsPrimOp : PrimOp<"bits"> {
     /// Return the result for inputs with the specified type, returning a null
     /// type if the input types are invalid.
     static FIRRTLType getResultType(FIRRTLType input, int32_t high,
-                                    int32_t low);
+                                    int32_t low, Location loc);
     static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
-                                    ArrayRef<int32_t> integers) {
+                                    ArrayRef<int32_t> integers, Location loc) {
       if (inputs.size() != 1 || integers.size() != 2)
         return {};
-      return getResultType(inputs[0], integers[0], integers[1]);
+      return getResultType(inputs[0], integers[0], integers[1], loc);
     }
   }];
 
@@ -277,12 +277,12 @@ def HeadPrimOp : PrimOp<"head"> {
   let extraClassDeclaration = [{
     /// Return the result for inputs with the specified type, returning a null
     /// type if the input types are invalid.
-    static FIRRTLType getResultType(FIRRTLType input, int32_t amount);
+    static FIRRTLType getResultType(FIRRTLType input, int32_t amount, Location loc);
     static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
-                                    ArrayRef<int32_t> integers) {
+                                    ArrayRef<int32_t> integers, Location loc) {
       if (inputs.size() != 1 || integers.size() != 1)
         return {};
-      return getResultType(inputs[0], integers[0]);
+      return getResultType(inputs[0], integers[0], loc);
     }
   }];
 }
@@ -301,12 +301,12 @@ def MuxPrimOp : PrimOp<"mux"> {
     /// Return the result for inputs with the specified type, returning a null
     /// type if the input types are invalid.
     static FIRRTLType getResultType(FIRRTLType sel, FIRRTLType high,
-                                    FIRRTLType low);
+                                    FIRRTLType low, Location loc);
     static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
-                                    ArrayRef<int32_t> integers) {
+                                    ArrayRef<int32_t> integers, Location loc) {
       if (inputs.size() != 3 || integers.size() != 0)
         return {};
-      return getResultType(inputs[0], inputs[1], inputs[2]);
+      return getResultType(inputs[0], inputs[1], inputs[2], loc);
     }
   }];
 }
@@ -330,12 +330,12 @@ def PadPrimOp : PrimOp<"pad"> {
   let extraClassDeclaration = [{
     /// Return the result for inputs with the specified type, returning a null
     /// type if the input types are invalid.
-    static FIRRTLType getResultType(FIRRTLType input, int32_t amount);
+    static FIRRTLType getResultType(FIRRTLType input, int32_t amount, Location loc);
     static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
-                                    ArrayRef<int32_t> integers) {
+                                    ArrayRef<int32_t> integers, Location loc) {
       if (inputs.size() != 1 || integers.size() != 1)
         return {};
-      return getResultType(inputs[0], integers[0]);
+      return getResultType(inputs[0], integers[0], loc);
     }
   }];
 }
@@ -351,12 +351,12 @@ class ShiftPrimOp<string mnemonic> : PrimOp<mnemonic> {
   let extraClassDeclaration = [{
     /// Return the result for inputs with the specified type, returning a null
     /// type if the input types are invalid.
-    static FIRRTLType getResultType(FIRRTLType input, int32_t amount);
+    static FIRRTLType getResultType(FIRRTLType input, int32_t amount, Location loc);
     static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
-                                    ArrayRef<int32_t> integers) {
+                                    ArrayRef<int32_t> integers, Location loc) {
       if (inputs.size() != 1 || integers.size() != 1)
         return {};
-      return getResultType(inputs[0], integers[0]);
+      return getResultType(inputs[0], integers[0], loc);
     }
   }];
 }
@@ -385,12 +385,12 @@ def TailPrimOp : PrimOp<"tail"> {
   let extraClassDeclaration = [{
     /// Return the result for inputs with the specified type, returning a null
     /// type if the input types are invalid.
-    static FIRRTLType getResultType(FIRRTLType input, int32_t amount);
+    static FIRRTLType getResultType(FIRRTLType input, int32_t amount, Location loc);
     static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
-                                    ArrayRef<int32_t> integers) {
+                                    ArrayRef<int32_t> integers, Location loc) {
       if (inputs.size() != 1 || integers.size() != 1)
         return {};
-      return getResultType(inputs[0], integers[0]);
+      return getResultType(inputs[0], integers[0], loc);
     }
   }];
 }

--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -1087,11 +1087,13 @@ static LogicalResult verifyBitsPrimOp(BitsPrimOp bits) {
 
   int32_t resultWidth =
       bits.result().getType().cast<IntType>().getBitWidthOrSentinel();
+  int32_t expectedWidth = expectedType.cast<IntType>().getBitWidthOrSentinel();
+
   if (resultWidth != -1 &&
-      expectedType.cast<IntType>().getBitWidthOrSentinel() != resultWidth) {
+       expectedWidth != resultWidth) {
     bits.emitError() << "width of the result type must be equal to (high - low "
                         "+ 1), expected "
-                     << hi - lo + 1 << " but got " << resultWidth;
+                     << expectedWidth  << " but got " << resultWidth;
     return failure();
   }
 

--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -1089,11 +1089,10 @@ static LogicalResult verifyBitsPrimOp(BitsPrimOp bits) {
       bits.result().getType().cast<IntType>().getBitWidthOrSentinel();
   int32_t expectedWidth = expectedType.cast<IntType>().getBitWidthOrSentinel();
 
-  if (resultWidth != -1 &&
-       expectedWidth != resultWidth) {
+  if (resultWidth != -1 && expectedWidth != resultWidth) {
     bits.emitError() << "width of the result type must be equal to (high - low "
                         "+ 1), expected "
-                     << expectedWidth  << " but got " << resultWidth;
+                     << expectedWidth << " but got " << resultWidth;
     return failure();
   }
 

--- a/lib/FIRParser/FIRParser.cpp
+++ b/lib/FIRParser/FIRParser.cpp
@@ -902,7 +902,8 @@ ParseResult FIRStmtParser::parsePostFixFieldId(Value &result,
   // Make sure the field name matches up with the input value's type and
   // compute the result type for the expression.
   auto resultType = result.getType().cast<FIRRTLType>();
-  resultType = SubfieldOp::getResultType(resultType, fieldName);
+  resultType =
+      SubfieldOp::getResultType(resultType, fieldName, translateLocation(loc));
   if (!resultType) {
     // TODO(QoI): This error would be nicer with a .fir pretty print of the
     // type.
@@ -938,7 +939,8 @@ ParseResult FIRStmtParser::parsePostFixIntSubscript(Value &result,
   // Make sure the index expression is valid and compute the result type for the
   // expression.
   auto resultType = result.getType().cast<FIRRTLType>();
-  resultType = SubindexOp::getResultType(resultType, indexNo);
+  resultType = SubindexOp::getResultType(resultType, indexNo,
+                                         translateLocation(indexLoc));
   if (!resultType) {
     // TODO(QoI): This error would be nicer with a .fir pretty print of the
     // type.
@@ -979,7 +981,8 @@ ParseResult FIRStmtParser::parsePostFixDynamicSubscript(Value &result,
   // Make sure the index expression is valid and compute the result type for the
   // expression.
   auto resultType = result.getType().cast<FIRRTLType>();
-  resultType = SubaccessOp::getResultType(resultType, indexType);
+  resultType = SubaccessOp::getResultType(resultType, indexType,
+                                          translateLocation(indexLoc));
   if (!resultType) {
     // TODO(QoI): This error would be nicer with a .fir pretty print of the
     // type.
@@ -1086,7 +1089,8 @@ ParseResult FIRStmtParser::parsePrimExp(Value &result, SubOpVector &subOps) {
 
 #define TOK_LPKEYWORD_PRIM(SPELLING, CLASS)                                    \
   case FIRToken::lp_##SPELLING: {                                              \
-    auto resultTy = CLASS::getResultType(opTypes, integers);                   \
+    auto resultTy =                                                            \
+        CLASS::getResultType(opTypes, integers, translateLocation(loc));       \
     if (!resultTy)                                                             \
       return typeError(#SPELLING);                                             \
     result = builder.create<CLASS>(translateLocation(loc), resultTy,           \

--- a/test/FIRParser/errors.fir
+++ b/test/FIRParser/errors.fir
@@ -112,3 +112,13 @@ circuit test :
   module invalid_name :
     input bf: { flip int_1 : UInt<1>, int_out : UInt<2>}
     node n4 = add(bf, bf)  ; expected-error {{invalid input types for 'add'}}
+
+;// -----
+
+circuit test :
+  module invalid_bits:
+     input a: UInt<8>
+     output b: UInt<4>
+     ; expected-error@+2 {{high must be equal or greater than low, but got high = 4, low = 7}};
+     ; expected-error@+1 {{invalid input types for 'bits': '!firrtl.uint<8>'}}
+     b <= bits(a, 4, 7)


### PR DESCRIPTION
This is the next PR to #199. This PR adds `Location` to `getResultType` to emit an error when the precondition doesn't satisfy the spec. As an example, I modified bits op to use `Location` as an example, which leads to better error reporting in firrtl parser as well.

```Foo.fir
circuit Foo:
  module Foo:
    input a: UInt<8>
    output b: UInt<4>
    b <= bits(a, 4, 7)
```
``` firtool Foo.fir                                                                                                                
Foo.fir:5:11: error: high must be equal or greater than low, but got high = 4, low = 7
     b <= bits(a, 4, 7)
          ^
Foo.fir:5:11: error: invalid input types for 'bits': '!firrtl.uint<8>'
     b <= bits(a, 4, 7)
`