### PR TITLE
Enabling submodule clone over HTTPS as well as SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "llvm"]
 	path = llvm
-	url = git@github.com:circt/llvm.git
+	url = ../../circt/llvm.git
 	shallow = true


### PR DESCRIPTION
... by using a relative path in the submodule definition. See discussion [here](https://github.com/llvm/circt/pull/188#issuecomment-723270471)

@stephenneuendorffer it wouldn't allow me to reopen the other PR, so I created a new one.