### PR TITLE
[RTL] [FIRRTL] Add verification for `parameters` attributes in `rtl.instance` and `firrtl.extmodule` op

### DIFF
--- a/include/circt/Dialect/FIRRTL/OpStructure.td
+++ b/include/circt/Dialect/FIRRTL/OpStructure.td
@@ -156,6 +156,7 @@ def FExtModuleOp : FIRRTLOp<"extmodule",
 
   let printer = [{ return ::print(p, *this); }];
   let parser = [{ return ::parse$cppClass(parser, result); }];
+  let verifier = [{ return ::verifyFExtModuleOp(*this); }];
 }
 
 def DoneOp : FIRRTLOp<"done", [Terminator]> {

--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -465,21 +465,22 @@ static LogicalResult verifyFModuleOp(FModuleOp &module) {
 }
 
 static LogicalResult verifyFExtModuleOp(FExtModuleOp &op) {
-  if (auto paramDictOpt = op.parameters()) {
-    DictionaryAttr paramDict = paramDictOpt.getValue();
-    auto checkParmValue = [&](NamedAttribute elt) -> bool {
-      auto value = elt.second;
-      if (value.isa<IntegerAttr>() || value.isa<StringAttr>() ||
-          value.isa<FloatAttr>())
-        return true;
-      op.emitError() << "has unknown extmodule parameter value '" << elt.first
-                     << "' = " << value;
-      return false;
-    };
+  auto paramDictOpt = op.parameters();
+  if (!paramDictOpt)
+    return success();
+  DictionaryAttr paramDict = paramDictOpt.getValue();
+  auto checkParmValue = [&](NamedAttribute elt) -> bool {
+    auto value = elt.second;
+    if (value.isa<IntegerAttr>() || value.isa<StringAttr>() ||
+        value.isa<FloatAttr>())
+      return true;
+    op.emitError() << "has unknown extmodule parameter value '" << elt.first
+                   << "' = " << value;
+    return false;
+  };
 
-    if (!llvm::all_of(paramDict, checkParmValue))
-      return failure();
-  }
+  if (!llvm::all_of(paramDict, checkParmValue))
+    return failure();
   return success();
 }
 

--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -464,6 +464,25 @@ static LogicalResult verifyFModuleOp(FModuleOp &module) {
   return success();
 }
 
+static LogicalResult verifyFExtModuleOp(FExtModuleOp &op) {
+  if (auto paramDictOpt = op.parameters()) {
+    DictionaryAttr paramDict = paramDictOpt.getValue();
+    auto checkParmValue = [&](NamedAttribute elt) -> bool {
+      auto value = elt.second;
+      if (value.isa<IntegerAttr>() || value.isa<StringAttr>() ||
+          value.isa<FloatAttr>())
+        return true;
+      op.emitError() << "has unknown extmodule parameter value '" << elt.first
+                     << "' = " << value;
+      return false;
+    };
+
+    if (!llvm::all_of(paramDict, checkParmValue))
+      return failure();
+  }
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // Declarations
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/RTL/Ops.cpp
+++ b/lib/Dialect/RTL/Ops.cpp
@@ -299,6 +299,23 @@ static LogicalResult verifyInstanceOp(InstanceOp op) {
         << referencedModule->getName() << "' which is not a RTL[Ext]ModuleOp";
     return failure();
   }
+
+  if (auto paramDictOpt = op.parameters()) {
+    DictionaryAttr paramDict = paramDictOpt.getValue();
+    auto checkParmValue = [&](NamedAttribute elt) -> bool {
+      auto value = elt.second;
+      if (value.isa<IntegerAttr>() || value.isa<StringAttr>() ||
+          value.isa<FloatAttr>())
+        return true;
+      op.emitError() << "has unknown extmodule parameter value '" << elt.first
+                     << "' = " << value;
+      return false;
+    };
+
+    if (!llvm::all_of(paramDict, checkParmValue))
+      return failure();
+  }
+
   return success();
 }
 

--- a/test/firrtl/errors.mlir
+++ b/test/firrtl/errors.mlir
@@ -196,6 +196,15 @@ firrtl.circuit "Foo" {
 
 firrtl.circuit "Foo" {
 
+  // expected-error @+1 {{has unknown extmodule parameter value 'width' = @Foo}}
+  firrtl.extmodule @Foo(%a : !firrtl.uint<2>) attributes { defname = "Foo", parameters = { width = @Foo } }
+
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+
   firrtl.module @Foo()
   // expected-error @+1 {{'firrtl.instance' op should be embedded in a 'firrtl.module'}}
   %a = firrtl.instance @Foo : !firrtl.bundle<>

--- a/test/rtl/errors.mlir
+++ b/test/rtl/errors.mlir
@@ -55,3 +55,12 @@ rtl.module @A(%arg0: i1) {
 
 // expected-error @+1 {{'rtl.output' op must have same number of operands as region results}}
 rtl.module @A() -> (i1) { }
+
+// -----
+
+rtl.module @A () {}
+
+rtl.module @B() {
+  // expected-error @+1 {{has unknown extmodule parameter value 'width' = @Foo}}
+  rtl.instance "foo" @A() { parameters = { width = @Foo } }: () -> ()
+}


### PR DESCRIPTION
This PR will fix #220. This adds verification for `rtl.instance` and `firrtl.extmodule` in the same way as [EmitVerilog](https://github.com/llvm/circt/blob/0b0fe60877819050cdfd44045340f669c09642fd/lib/EmitVerilog/EmitVerilog.cpp#L1626)