### PR TITLE
[ESI] [Cosim DPI] Integration test framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build
 #*
 *~
 .DS_Store
+__pycache__
 
 # External software
 /ext

--- a/integration_test/CMakeLists.txt
+++ b/integration_test/CMakeLists.txt
@@ -1,15 +1,21 @@
+set(CIRCT_INTEGRATION_TEST_DEPENDS
+  FileCheck count not
+  circt-opt
+  circt-translate)
+
+# If ESI Cosim is available to build then enable its tests.
+if (TARGET EsiCosimDpiServer)
+  list(APPEND CIRCT_INTEGRATION_TEST_DEPENDS EsiCosimDpiServer)
+  get_property(ESI_COSIM_LIB_DIR TARGET EsiCosimDpiServer PROPERTY LIBRARY_OUTPUT_DIRECTORY)
+  set(ESI_COSIM_PATH ${ESI_COSIM_LIB_DIR}/libEsiCosimDpiServer.so)
+endif()
+
 configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
   INTEGRATION_CONFIG
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
-  )
-
-set(CIRCT_INTEGRATION_TEST_DEPENDS
-  FileCheck count not
-  circt-opt
-  circt-translate
-  )
+)
 
 add_lit_testsuite(check-circt-integration "Running the CIRCT integration tests"
   ${CMAKE_CURRENT_BINARY_DIR}

--- a/integration_test/ESI/formats.py
+++ b/integration_test/ESI/formats.py
@@ -136,7 +136,7 @@ class CosimTestRunner:
             vars["srcfile"] = self.file
             # 'rpcSchemaPath' points to the CapnProto schema for RPC and is the
             # one that nearly all scripts are going to need.
-            vars["rpcSchemaPath"] = os.path.join(
+            vars["rpcschemapath"] = os.path.join(
                 cfg.circt_include_dir, "circt", "Dialect", "ESI", "cosim",
                 "CosimDpi.capnp")
             script.writelines(f"{name} = \"{value}\"\n" for (

--- a/integration_test/ESI/formats.py
+++ b/integration_test/ESI/formats.py
@@ -1,0 +1,242 @@
+import lit.Test as Test
+import lit.formats
+
+import os
+import re
+import signal
+import socket
+import subprocess
+import sys
+import time
+
+
+class CosimTest(lit.formats.FileBasedTest):
+    """A lit test format (adapter) for running cosimulation-based tests."""
+
+    def execute(self, test, litConfig):
+        # All cosim tests require esi-cosim to have been built.
+        if 'esi-cosim' not in test.config.available_features:
+            return Test.Result(Test.UNSUPPORTED, "ESI-Cosim feature not present")
+        # This format is specialized to Verilator at the moment.
+        if 'verilator' not in test.config.available_features:
+            return Test.Result(Test.UNSUPPORTED, "Verilator not present")
+
+        # Parse, compile, and run the test.
+        testRun = CosimTestRunner(test, litConfig)
+        parsed = testRun.parse()
+        if parsed.code != Test.PASS:
+            return parsed
+        compiled = testRun.compile()
+        if compiled.code != Test.PASS:
+            return compiled
+        return testRun.run()
+
+
+class CosimTestRunner:
+    """The main class responsible for running a cosim test. We use a separate
+    class to allow for per-test mutable state variables."""
+
+    def __init__(self, test, litConfig):
+        self.test = test
+        self.litConfig = litConfig
+        self.file = test.getSourcePath()
+        self.srcdir = os.path.dirname(self.file)
+        self.execdir = test.getExecPath()
+        self.runs = list()
+        self.sources = list()
+        self.cppSources = list()
+        self.top = "main"
+
+    def parse(self):
+        """Parse a test file. Look for comments we recognize anywhere in the
+        file."""
+        fileReader = open(self.file, "r")
+        for line in fileReader:
+            # TOP is the top module.
+            if m := re.match(r"^//\s*TOP:(.*)$", line):
+                self.top = m.group(1)
+            # FILES are the additional RTL files (if any). If specified, must
+            # include the current file. These files are either absolute or
+            # relative to the current file.
+            if m := re.match(r"^//\s*FILES:(.*)$", line):
+                self.sources.extend(m.group(1).split())
+            # C++ driver files to feed to Verilator. Defaults to the simple
+            # driver.cpp. Same path rules as FILES.
+            if m := re.match(r"^//\s*CPP:(.*)$", line):
+                self.cppSources.extend(m.group(1).split())
+            # Run this Python line.
+            if m := re.match(r"^//\s*PY:(.*)$", line):
+                self.runs.append(m.group(1).strip())
+        fileReader.close()
+        return Test.Result(Test.PASS, "")
+
+    def compile(self):
+        """Compile the simulation with Verilator. Let Verilator do the whole
+        thing and produce a binary which 'just works'. This is sufficient for
+        simple-ish C++ drivers."""
+
+        # Assemble a list of sources (RTL and C++), applying the defaults and
+        # path rules.
+        if len(self.sources) == 0:
+            sources = [self.file]
+        else:
+            sources = [(src if os.path.isabs(src) else os.path.join(
+                self.srcdir, src)) for src in self.sources]
+        if len(self.cppSources) == 0:
+            cppSources = [os.path.join(
+                os.path.dirname(__file__), "..", "driver.cpp")]
+        else:
+            cppSources = [(src if os.path.isabs(src) else os.path.join(
+                self.srcdir, src)) for src in self.cppSources]
+
+        # Include the cosim DPI SystemVerilog files.
+        cfg = self.test.config
+        cosimInclude = os.path.join(
+            cfg.circt_include_dir, "circt", "Dialect", "ESI", "cosim")
+        sources.insert(0, os.path.join(cosimInclude, "Cosim_DpiPkg.sv"))
+        sources.insert(1, os.path.join(cosimInclude, "Cosim_Endpoint.sv"))
+
+        # Format the list of sources.
+        sources = " ".join(sources + cppSources)
+        os.makedirs(self.execdir, exist_ok=True)
+
+        # Run verilator to produce an executable. Requires a working Verilator
+        # install in the PATH.
+        vrun = subprocess.run(
+            f"{cfg.verilator_path} --cc --top-module {self.top} --build --exe {sources} {cfg.esi_cosim_path} -LDFLAGS '-Wl,-rpath={cfg.circt_shlib_dir}'".split(),
+            capture_output=True,
+            text=True,
+            cwd=self.execdir)
+        output = vrun.stdout + "\n----- STDERR ------\n" + vrun.stderr
+        return Test.Result(Test.PASS if vrun.returncode == 0 else Test.FAIL, output)
+
+    def run(self):
+        """Run the test by creating a Python script, starting the simulation,
+        running the Python script, then stopping the simulation.
+
+        Not perfect since we don't know when the cosim RPC server in the
+        simulation has started accepting connections."""
+
+        # Find available port.
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(('', 0))
+        port = sock.getsockname()[1]
+        sock.close()
+
+        with open(os.path.join(self.execdir, "script.py"), "w") as script:
+            # Include a bunch of config variables at the beginning of the
+            # script for use by the test code.
+            cfg = self.test.config
+            allDicts = list(self.test.config.__dict__.items()) + \
+                list(self.litConfig.__dict__.items())
+            vars = dict([(key, value)
+                         for (key, value) in allDicts if isinstance(value, str)])
+            vars["execdir"] = self.execdir
+            vars["srcdir"] = self.srcdir
+            vars["srcfile"] = self.file
+            # 'rpcSchemaPath' points to the CapnProto schema for RPC and is the
+            # one that nearly all scripts are going to need.
+            vars["rpcSchemaPath"] = os.path.join(
+                cfg.circt_include_dir, "circt", "Dialect", "ESI", "cosim",
+                "CosimDpi.capnp")
+            script.writelines(f"{name} = \"{value}\"\n" for (
+                name, value) in vars.items())
+            script.write("\n\n")
+
+            # Add the test files directory and this files directory to the
+            # pythonpath.
+            script.write(f"import os\n")
+            script.write(f"import sys\n")
+            script.write(
+                f"sys.path.append(\"{os.path.dirname(self.file)}\")\n")
+            script.write(
+                f"sys.path.append(\"{os.path.dirname(__file__)}\")\n")
+            script.write("\n\n")
+            script.write(
+                "simhostport = f'{os.uname()[1]}:" + str(port) + "'\n")
+
+            # Run the lines specified in the test file.
+            script.writelines(
+                f"{x}\n" for x in self.runs)
+
+        timedout = False
+        try:
+            # Run the simulation.
+            simStdout = open(os.path.join(self.execdir, "sim_stdout.log"), "w")
+            simStderr = open(os.path.join(self.execdir, "sim_stderr.log"), "w")
+            simEnv = os.environ.copy()
+            simEnv["COSIM_PORT"] = str(port)
+            simProc = subprocess.Popen(
+                [f"./obj_dir/V{self.top}", "--cycles", "-1"],
+                stdout=simStdout, stderr=simStderr, cwd=self.execdir,
+                env=simEnv)
+            # Wait a set amount of time for the simulation to start accepting
+            # RPC connections.
+            # TODO: Check if the server is up by polling.
+            time.sleep(0.05)
+
+            # Run the test script.
+            testStdout = open(os.path.join(
+                self.execdir, "test_stdout.log"), "w")
+            testStderr = open(os.path.join(
+                self.execdir, "test_stderr.log"), "w")
+            timeout = None
+            if self.litConfig.maxIndividualTestTime > 0:
+                timeout = self.litConfig.maxIndividualTestTime
+            testProc = subprocess.run([sys.executable, "-u", "script.py"],
+                                      stdout=testStdout, stderr=testStderr,
+                                      timeout=timeout, cwd=self.execdir)
+        except subprocess.TimeoutExpired:
+            timedout = True
+        finally:
+            # Make sure to stop the simulation no matter what.
+            if simProc:
+                simProc.send_signal(signal.SIGINT)
+                # Allow the simulation time to flush its outputs.
+                try:
+                    simProc.wait(timeout=1.0)
+                except subprocess.TimeoutExpired:
+                    simProc.kill()
+            simStderr.close()
+            simStdout.close()
+            testStdout.close()
+            testStderr.close()
+
+        # Read the output log files and return the proper result.
+        err, logs = self.readLogs()
+        if timedout:
+            result = Test.TIMEOUT
+        else:
+            logs += f"---- Test process exit code: {testProc.returncode}\n"
+            result = Test.PASS if testProc.returncode == 0 and not err else Test.FAIL
+        return Test.Result(result, logs)
+
+    def readLogs(self):
+        """Read the log files from the simulation and the test script. Only
+        add the stderr logs if they contain something. Also return a flag
+        indicating that one of the stderr logs has content."""
+
+        foundErr = False
+        ret = "----- Simulation stdout -----\n"
+        with open(os.path.join(self.execdir, "sim_stdout.log")) as f:
+            ret += f.read()
+
+        with open(os.path.join(self.execdir, "sim_stderr.log")) as f:
+            stderr = f.read()
+            if stderr != "":
+                ret += "\n----- Simulation stderr -----\n"
+                ret += stderr
+                foundErr = True
+
+        ret += "\n----- Test stdout -----\n"
+        with open(os.path.join(self.execdir, "test_stdout.log")) as f:
+            ret += f.read()
+
+        with open(os.path.join(self.execdir, "test_stderr.log")) as f:
+            stderr = f.read()
+            if stderr != "":
+                ret += "\n----- Test stderr -----\n"
+                ret += stderr
+                foundErr = True
+
+        return (foundErr, ret)

--- a/integration_test/ESI/lit.local.cfg
+++ b/integration_test/ESI/lit.local.cfg
@@ -1,7 +1,12 @@
 import os
 import site
-site.addsitedir(os.path.dirname(__file__))
 
-import formats
+try:
+  # If capnp isn't available, cosim tests aren't supported.
+  import capnp
 
-config.test_format = formats.CosimTest()
+  site.addsitedir(os.path.dirname(__file__))
+  import formats
+  config.test_format = formats.CosimTest()
+except ImportError:
+  config.unsupported = True

--- a/integration_test/ESI/lit.local.cfg
+++ b/integration_test/ESI/lit.local.cfg
@@ -1,0 +1,7 @@
+import os
+import site
+site.addsitedir(os.path.dirname(__file__))
+
+import formats
+
+config.test_format = formats.CosimTest()

--- a/integration_test/EmitVerilog/basic.mlir
+++ b/integration_test/EmitVerilog/basic.mlir
@@ -1,6 +1,6 @@
 // REQUIRES: verilator
 // RUN: circt-translate %s -emit-verilog -verify-diagnostics > %t1.sv
-// RUN: verilator --cc --top-module main -sv %t1.sv --build --exe %S/driver.cpp
+// RUN: verilator --cc --top-module main -sv %t1.sv --build --exe %S/../driver.cpp
 // RUN: ./obj_dir/Vmain --cycles 8 2>&1 | FileCheck %s
 
 module {

--- a/integration_test/lit.cfg.py
+++ b/integration_test/lit.cfg.py
@@ -32,6 +32,8 @@ config.test_exec_root = os.path.join(config.circt_obj_root, 'test')
 
 config.substitutions.append(('%PATH%', config.environment['PATH']))
 config.substitutions.append(('%shlibext', config.llvm_shlib_ext))
+config.substitutions.append(('%shlibdir', config.circt_shlib_dir))
+config.substitutions.append(('%INC%', config.circt_include_dir))
 
 llvm_config.with_system_environment(
     ['HOME', 'INCLUDE', 'LIB', 'TMP', 'TEMP'])
@@ -51,6 +53,7 @@ config.test_exec_root = os.path.join(config.circt_obj_root, 'integration_test')
 
 # Tweak the PATH to include the tools dir.
 llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)
+# Substitute '%l' with the path to the build lib dir.
 
 tool_dirs = [config.circt_tools_dir,
              config.mlir_tools_dir, config.llvm_tools_dir]
@@ -64,5 +67,11 @@ if config.verilator_path != "":
   tool_dirs.append(os.path.dirname(config.verilator_path))
   tools.append('verilator')
   config.available_features.add('verilator')
+
+# Enable ESI cosim tests if they have been built.
+if config.esi_cosim_path != "":
+  config.available_features.add('esi-cosim')
+  config.substitutions.append(('%ESIINC%', f'{config.circt_include_dir}/circt/Dialect/ESI/'))
+  config.substitutions.append(('%ESICOSIM%', f'{config.esi_cosim_path}'))
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)

--- a/integration_test/lit.site.cfg.py.in
+++ b/integration_test/lit.site.cfg.py.in
@@ -34,7 +34,10 @@ config.mlir_tools_dir = "@MLIR_TOOLS_DIR@"
 config.circt_src_root = "@CIRCT_SOURCE_DIR@"
 config.circt_obj_root = "@CIRCT_BINARY_DIR@"
 config.circt_tools_dir = "@CIRCT_TOOLS_DIR@"
+config.circt_include_dir = "@CIRCT_MAIN_SRC_DIR@"
+config.circt_shlib_dir = "@LLVM_LIBRARY_OUTPUT_INTDIR@"
 config.verilator_path = "@VERILATOR_PATH@"
+config.esi_cosim_path = "@ESI_COSIM_PATH@"
 
 # Support substitution of the tools_dir with user parameters. This is
 # used when we can't determine the tool dir at configuration time.

--- a/lib/Dialect/ESI/CMakeLists.txt
+++ b/lib/Dialect/ESI/CMakeLists.txt
@@ -21,3 +21,5 @@ add_mlir_dialect_library(MLIRESI
 
 
 add_dependencies(mlir-headers MLIRESIIncGen)
+
+add_subdirectory(cosim)

--- a/lib/Dialect/ESI/CMakeLists.txt
+++ b/lib/Dialect/ESI/CMakeLists.txt
@@ -21,5 +21,3 @@ add_mlir_dialect_library(MLIRESI
 
 
 add_dependencies(mlir-headers MLIRESIIncGen)
-
-add_subdirectory(cosim)


### PR DESCRIPTION
Number 5 of 7 planned PRs for #213. The focus of this PR is a lit format for Cosim. Cosim integration tests require selecting a TCP port, starting the simulator (which opens a server on that port), then running the test(s). This lit format enables tests written in Python.

This PR might be difficult to understand without the actual test -- which fails since the Cosim DPI plugin has not yet made it into
master. I can add the test after we've PR'd the rest of the cosim DPI code.

Note: the 4 space Python style is what llvm-lit itself uses. I personally dislike it and it is inconsistent with the rest of the code in CIRCT and LLVM. Nonetheless, it is the established python style for LLVM. If CIRCT devs don't like it and think we should switch to 2 spaces, I'm all for it.