### PR TITLE
[llhd-sim] Move trace generation to a dedicated class

### DIFF
--- a/include/circt/Dialect/LLHD/Simulator/Engine.h
+++ b/include/circt/Dialect/LLHD/Simulator/Engine.h
@@ -27,7 +27,7 @@ public:
   /// Initialize an LLHD simulation engine. This initializes the state, as well
   /// as the mlir::ExecutionEngine with the given module.
   Engine(llvm::raw_ostream &out, ModuleOp module, MLIRContext &context,
-         std::string root);
+         std::string root, int mode);
 
   /// Default destructor
   ~Engine();
@@ -58,6 +58,7 @@ private:
   std::unique_ptr<State> state;
   std::unique_ptr<ExecutionEngine> engine;
   ModuleOp module;
+  int traceMode;
 };
 
 } // namespace sim

--- a/include/circt/Dialect/LLHD/Simulator/Engine.h
+++ b/include/circt/Dialect/LLHD/Simulator/Engine.h
@@ -33,7 +33,7 @@ public:
   ~Engine();
 
   /// Run simulation up to n steps. Pass n=0 to run indefinitely.
-  int simulate(int n);
+  int simulate(int n, uint64_t maxTime);
 
   /// Build the instance layout of the design.
   void buildLayout(ModuleOp module);

--- a/include/circt/Dialect/LLHD/Simulator/Engine.h
+++ b/include/circt/Dialect/LLHD/Simulator/Engine.h
@@ -27,12 +27,13 @@ public:
   /// Initialize an LLHD simulation engine. This initializes the state, as well
   /// as the mlir::ExecutionEngine with the given module.
   Engine(llvm::raw_ostream &out, ModuleOp module, MLIRContext &context,
-         std::string root, int mode);
+         std::string root, int traceMode);
 
   /// Default destructor
   ~Engine();
 
-  /// Run simulation up to n steps. Pass n=0 to run indefinitely.
+  /// Run simulation up to n steps or maxTime picoseconds of simulation time.
+  /// n=0 and T=0 make the simulation run indefinitely.
   int simulate(int n, uint64_t maxTime);
 
   /// Build the instance layout of the design.

--- a/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
+++ b/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
@@ -1124,7 +1124,24 @@ struct InstOpConversion : public ConvertToLLVMPattern {
     auto sigFunc = getOrInsertFunction(module, rewriter, op->getLoc(),
                                        "allocSignal", allocSigFuncTy);
 
-    // Get or insert allocProc library call definition.
+    // Add information about the elements of an array stored in a signal.
+    // Signature: (i8* state, i32 signalIndex, i32 size, i32 numElements) ->
+    // void
+    auto addSigArrElemFuncTy = LLVM::LLVMType::getFunctionTy(
+        voidTy, {i8PtrTy, i32Ty, i32Ty, i32Ty}, /*isVarArg=*/false);
+    auto addSigElemFunc =
+        getOrInsertFunction(module, rewriter, op->getLoc(),
+                            "add_sig_array_elements", addSigArrElemFuncTy);
+
+    // Add information about one element of a struct stored in a signal.
+    // Signature: (i8* state, i32 signalIndex, i32 offset, i32 size) -> void
+    auto addSigStructElemFuncTy = LLVM::LLVMType::getFunctionTy(
+        voidTy, {i8PtrTy, i32Ty, i32Ty, i32Ty}, /*isVarArg=*/false);
+    auto addSigStructFunc =
+        getOrInsertFunction(module, rewriter, op->getLoc(),
+                            "add_sig_struct_element", addSigStructElemFuncTy);
+
+    // Get or insert Alloc_proc library call definition.
     auto allocProcFuncTy = LLVM::LLVMType::getFunctionTy(
         voidTy, {i8PtrTy, i8PtrTy, i8PtrTy}, /*isVarArg=*/false);
     auto allocProcFunc = getOrInsertFunction(module, rewriter, op->getLoc(),
@@ -1265,8 +1282,73 @@ struct InstOpConversion : public ConvertToLLVMPattern {
 
         std::array<Value, 5> args(
             {initStatePtr, indexConst, owner, mall, passSize});
-        initBuilder.create<LLVM::CallOp>(
+        auto index = initBuilder.create<LLVM::CallOp>(
             op.getLoc(), i32Ty, rewriter.getSymbolRefAttr(sigFunc), args);
+
+        // Add structured underlying type information.
+        if (underlyingTy.isArrayTy()) {
+          auto zeroC = initBuilder.create<LLVM::ConstantOp>(
+              op.getLoc(), i32Ty, rewriter.getI32IntegerAttr(0));
+
+          auto numElements = initBuilder.create<LLVM::ConstantOp>(
+              op.getLoc(), i32Ty,
+              rewriter.getI32IntegerAttr(underlyingTy.getArrayNumElements()));
+
+          // Get element size.
+          auto null = initBuilder.create<LLVM::NullOp>(
+              op.getLoc(), underlyingTy.getPointerTo());
+          auto gepFirst = initBuilder.create<LLVM::GEPOp>(
+              op.getLoc(), underlyingTy.getArrayElementType().getPointerTo(),
+              null, ArrayRef<Value>({zeroC, oneC}));
+          auto toInt = initBuilder.create<LLVM::PtrToIntOp>(op.getLoc(), i32Ty,
+                                                            gepFirst);
+
+          // Add information to the state.
+          initBuilder.create<LLVM::CallOp>(
+              op.getLoc(), llvm::None,
+              rewriter.getSymbolRefAttr(addSigElemFunc),
+              ArrayRef<Value>(
+                  {initStatePtr, index.getResult(0), toInt, numElements}));
+        } else if (underlyingTy.isStructTy()) {
+          auto zeroC = initBuilder.create<LLVM::ConstantOp>(
+              op.getLoc(), i32Ty, rewriter.getI32IntegerAttr(0));
+
+          auto null = initBuilder.create<LLVM::NullOp>(
+              op.getLoc(), underlyingTy.getPointerTo());
+          for (size_t i = 0, e = underlyingTy.getStructNumElements(); i < e;
+               ++i) {
+            auto oneC = initBuilder.create<LLVM::ConstantOp>(
+                op.getLoc(), i32Ty, rewriter.getI32IntegerAttr(1));
+            auto indexC = initBuilder.create<LLVM::ConstantOp>(
+                op.getLoc(), i32Ty, rewriter.getI32IntegerAttr(i));
+
+            // Get pointer offset.
+            auto gepElem = initBuilder.create<LLVM::GEPOp>(
+                op.getLoc(),
+                underlyingTy.getStructElementType(i).getPointerTo(), null,
+                ArrayRef<Value>({zeroC, indexC}));
+            auto elemToInt = initBuilder.create<LLVM::PtrToIntOp>(
+                op.getLoc(), i32Ty, gepElem);
+
+            // Get element size.
+            auto elemNull = initBuilder.create<LLVM::NullOp>(
+                op.getLoc(),
+                underlyingTy.getStructElementType(i).getPointerTo());
+            auto gepElemSize = initBuilder.create<LLVM::GEPOp>(
+                op.getLoc(),
+                underlyingTy.getStructElementType(i).getPointerTo(), elemNull,
+                ArrayRef<Value>({oneC}));
+            auto elemSizeToInt = initBuilder.create<LLVM::PtrToIntOp>(
+                op.getLoc(), i32Ty, gepElemSize);
+
+            // Add information to the state.
+            initBuilder.create<LLVM::CallOp>(
+                op.getLoc(), llvm::None,
+                rewriter.getSymbolRefAttr(addSigStructFunc),
+                ArrayRef<Value>({initStatePtr, index.getResult(0), elemToInt,
+                                 elemSizeToInt}));
+          }
+        }
       });
     } else if (auto proc = module.lookupSymbol<ProcOp>(instOp.callee())) {
       // Handle process instantiation.

--- a/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
+++ b/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
@@ -1131,7 +1131,7 @@ struct InstOpConversion : public ConvertToLLVMPattern {
         voidTy, {i8PtrTy, i32Ty, i32Ty, i32Ty}, /*isVarArg=*/false);
     auto addSigElemFunc =
         getOrInsertFunction(module, rewriter, op->getLoc(),
-                            "add_sig_array_elements", addSigArrElemFuncTy);
+                            "addSigArrayElements", addSigArrElemFuncTy);
 
     // Add information about one element of a struct stored in a signal.
     // Signature: (i8* state, i32 signalIndex, i32 offset, i32 size) -> void
@@ -1139,7 +1139,7 @@ struct InstOpConversion : public ConvertToLLVMPattern {
         voidTy, {i8PtrTy, i32Ty, i32Ty, i32Ty}, /*isVarArg=*/false);
     auto addSigStructFunc =
         getOrInsertFunction(module, rewriter, op->getLoc(),
-                            "add_sig_struct_element", addSigStructElemFuncTy);
+                            "addSigStructElement", addSigStructElemFuncTy);
 
     // Get or insert Alloc_proc library call definition.
     auto allocProcFuncTy = LLVM::LLVMType::getFunctionTy(

--- a/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
+++ b/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
@@ -1141,7 +1141,7 @@ struct InstOpConversion : public ConvertToLLVMPattern {
         getOrInsertFunction(module, rewriter, op->getLoc(),
                             "addSigStructElement", addSigStructElemFuncTy);
 
-    // Get or insert Alloc_proc library call definition.
+    // Get or insert allocProc library call definition.
     auto allocProcFuncTy = LLVM::LLVMType::getFunctionTy(
         voidTy, {i8PtrTy, i8PtrTy, i8PtrTy}, /*isVarArg=*/false);
     auto allocProcFunc = getOrInsertFunction(module, rewriter, op->getLoc(),

--- a/lib/Dialect/LLHD/Simulator/CMakeLists.txt
+++ b/lib/Dialect/LLHD/Simulator/CMakeLists.txt
@@ -2,10 +2,18 @@ set(LLVM_OPTIONAL_SOURCES
     State.cpp
     Engine.cpp
     signals-runtime-wrappers.cpp
+    Trace.cpp
 )
 
 add_mlir_library(CIRCTLLHDSimState
     State.cpp
+)
+
+add_mlir_library(CIRCTLLHDSimTrace
+    Trace.cpp
+
+    LINK_LIBS PUBLIC
+    CIRCTLLHDSimState
 )
 
 add_mlir_library(circt-llhd-signals-runtime-wrappers SHARED
@@ -24,4 +32,5 @@ add_mlir_library(CIRCTLLHDSimEngine
     CIRCTLLHDSimState
     circt-llhd-signals-runtime-wrappers
     MLIRExecutionEngine
+    CIRCTLLHDSimTrace
     )

--- a/lib/Dialect/LLHD/Simulator/Engine.cpp
+++ b/lib/Dialect/LLHD/Simulator/Engine.cpp
@@ -198,7 +198,8 @@ int Engine::simulate(int n, uint64_t maxTime) {
     trace.flush(/*force=*/true);
   }
 
-  llvm::errs() << "Finished after " << i << " steps.\n";
+  llvm::errs() << "Finished at " << state->time.dump() << " (" << i
+               << " cycles)\n";
   return 0;
 }
 

--- a/lib/Dialect/LLHD/Simulator/Engine.cpp
+++ b/lib/Dialect/LLHD/Simulator/Engine.cpp
@@ -210,7 +210,7 @@ void Engine::buildLayout(ModuleOp module) {
 
   // Build root instance, the parent and instance names are the same for the
   // root.
-  Instance rootInst(root, root);
+  Instance rootInst(state->root, state->root);
   rootInst.unit = root;
   rootInst.path = root;
 
@@ -220,7 +220,7 @@ void Engine::buildLayout(ModuleOp module) {
   // The root is always an instance.
   rootInst.isEntity = true;
   // Store the root instance.
-  state->instances[rootInst.unit + "." + rootInst.name] = std::move(rootInst);
+  state->instances[rootInst.name] = std::move(rootInst);
 
   // Add triggers to signals.
   for (auto &inst : state->instances) {

--- a/lib/Dialect/LLHD/Simulator/Engine.cpp
+++ b/lib/Dialect/LLHD/Simulator/Engine.cpp
@@ -210,7 +210,7 @@ void Engine::buildLayout(ModuleOp module) {
 
   // Build root instance, the parent and instance names are the same for the
   // root.
-  Instance rootInst(state->root, state->root);
+  Instance rootInst(root, root);
   rootInst.unit = root;
   rootInst.path = root;
 
@@ -220,10 +220,10 @@ void Engine::buildLayout(ModuleOp module) {
   // The root is always an instance.
   rootInst.isEntity = true;
   // Store the root instance.
-  state->instances[rootInst.unit + "." + rootInst.name] = std::move(rootInst)
+  state->instances[rootInst.unit + "." + rootInst.name] = std::move(rootInst);
 
-      // Add triggers to signals.
-      for (auto &inst : state->instances) {
+  // Add triggers to signals.
+  for (auto &inst : state->instances) {
     for (auto trigger : inst.getValue().sensitivityList) {
       state->signals[trigger.globalIndex].triggers.push_back(
           inst.getKey().str());

--- a/lib/Dialect/LLHD/Simulator/Engine.cpp
+++ b/lib/Dialect/LLHD/Simulator/Engine.cpp
@@ -21,8 +21,8 @@ using namespace mlir;
 using namespace circt::llhd::sim;
 
 Engine::Engine(llvm::raw_ostream &out, ModuleOp module, MLIRContext &context,
-               std::string root, int mode)
-    : out(out), root(root), traceMode(mode) {
+               std::string root, int traceMode)
+    : out(out), root(root), traceMode(traceMode) {
   state = std::make_unique<State>();
   state->root = root + '.' + root;
 
@@ -78,7 +78,7 @@ int Engine::simulate(int n, uint64_t maxTime) {
   }
 
   if (traceMode >= 0) {
-    // Dump the signals' initial values.
+    // Add changes for all the signals' initial values.
     for (size_t i = 0, e = state->signals.size(); i < e; ++i) {
       trace.addChange(i);
     }

--- a/lib/Dialect/LLHD/Simulator/Engine.cpp
+++ b/lib/Dialect/LLHD/Simulator/Engine.cpp
@@ -5,6 +5,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "State.h"
+#include "Trace.h"
 
 #include "circt/Conversion/LLHDToLLVM/LLHDToLLVM.h"
 #include "circt/Dialect/LLHD/Simulator/Engine.h"
@@ -21,9 +22,10 @@ using namespace mlir;
 using namespace circt::llhd::sim;
 
 Engine::Engine(llvm::raw_ostream &out, ModuleOp module, MLIRContext &context,
-               std::string root)
-    : out(out), root(root) {
+               std::string root, int mode)
+    : out(out), root(root), traceMode(mode) {
   state = std::make_unique<State>();
+  state->root = root + '.' + root;
 
   buildLayout(module);
 
@@ -65,6 +67,9 @@ int Engine::simulate(int n) {
   assert(engine && "engine not found");
   assert(state && "state not found");
 
+  auto tm = static_cast<TraceMode>(traceMode);
+  Trace trace(state, out, tm);
+
   SmallVector<void *, 1> arg({&state});
   // Initialize tbe simulation state.
   auto invocationResult = engine->invoke("llhd_init", arg);
@@ -73,9 +78,11 @@ int Engine::simulate(int n) {
     return -1;
   }
 
-  // Dump the signals' initial values.
-  for (size_t i = 0, e = state->signals.size(); i < e; ++i) {
-    state->dumpSignal(out, i);
+  if (traceMode >= 0) {
+    // Dump the signals' initial values.
+    for (size_t i = 0, e = state->signals.size(); i < e; ++i) {
+      trace.addChange(i);
+    }
   }
 
   int i = 0;
@@ -93,8 +100,10 @@ int Engine::simulate(int n) {
     auto pop = state->popQueue();
 
     // Update the simulation time.
-    assert(state->time < pop.time || pop.time.time == 0);
     state->time = pop.time;
+
+    if (traceMode >= 0)
+      trace.flush();
 
     // Apply the signal changes and dump the signals that actually changed
     // value.
@@ -143,7 +152,8 @@ int Engine::simulate(int n) {
       }
 
       // Dump the updated signal.
-      state->dumpSignal(out, change.first);
+      if (traceMode >= 0)
+        trace.addChange(change.first);
     }
 
     // Add scheduled process resumes to the wakeup queue.
@@ -178,6 +188,12 @@ int Engine::simulate(int n) {
     wakeupQueue.clear();
     i++;
   }
+
+  if (traceMode >= 0) {
+    // Flush any remainign changes
+    trace.flush(/*force=*/true);
+  }
+
   llvm::errs() << "Finished after " << i << " steps.\n";
   return 0;
 }
@@ -189,7 +205,7 @@ void Engine::buildLayout(ModuleOp module) {
 
   // Build root instance, the parent and instance names are the same for the
   // root.
-  Instance rootInst(root, root);
+  Instance rootInst(state->root, state->root);
   rootInst.unit = root;
   rootInst.path = root;
 
@@ -199,10 +215,10 @@ void Engine::buildLayout(ModuleOp module) {
   // The root is always an instance.
   rootInst.isEntity = true;
   // Store the root instance.
-  state->instances[rootInst.unit + "." + rootInst.name] = std::move(rootInst);
+  state->instances[rootInst.unit + "." + rootInst.name] = std::move(rootInst)
 
-  // Add triggers to signals.
-  for (auto &inst : state->instances) {
+      // Add triggers to signals.
+      for (auto &inst : state->instances) {
     for (auto trigger : inst.getValue().sensitivityList) {
       state->signals[trigger.globalIndex].triggers.push_back(
           inst.getKey().str());

--- a/lib/Dialect/LLHD/Simulator/Engine.cpp
+++ b/lib/Dialect/LLHD/Simulator/Engine.cpp
@@ -63,7 +63,7 @@ void Engine::dumpStateLayout() { state->dumpLayout(); }
 
 void Engine::dumpStateSignalTriggers() { state->dumpSignalTriggers(); }
 
-int Engine::simulate(int n) {
+int Engine::simulate(int n, uint64_t maxTime) {
   assert(engine && "engine not found");
   assert(state && "state not found");
 
@@ -94,10 +94,11 @@ int Engine::simulate(int n) {
     wakeupQueue.insert(k.str());
 
   while (!state->queue.empty()) {
-    if (n > 0 && i >= n) {
+    auto pop = state->popQueue();
+
+    if ((n > 0 && i >= n) || (maxTime > 0 && pop.time.time > maxTime)) {
       break;
     }
-    auto pop = state->popQueue();
 
     // Update the simulation time.
     state->time = pop.time;

--- a/lib/Dialect/LLHD/Simulator/State.cpp
+++ b/lib/Dialect/LLHD/Simulator/State.cpp
@@ -81,6 +81,18 @@ std::string Signal::dump() {
   return ss.str();
 }
 
+std::string Signal::dump(unsigned elemIndex) {
+  assert(elements.size() > 0 && "the signal type has to be tuple or array!");
+  auto elemSize = elements[elemIndex].second;
+  auto ptr = value + elements[elemIndex].first;
+  std::string ret;
+  raw_string_ostream ss(ret);
+  ss << "0x";
+  for (int i = elemSize - 1; i >= 0; --i) {
+    ss << format_hex_no_prefix(static_cast<int>(ptr[i]), 2);
+  }
+  return ret;
+}
 //===----------------------------------------------------------------------===//
 // Slot
 //===----------------------------------------------------------------------===//
@@ -187,6 +199,10 @@ int State::addSignalData(int index, std::string owner, uint8_t *value,
     }
   }
   return globalIdx;
+}
+
+void State::addSignalElement(unsigned index, unsigned offset, unsigned size) {
+  signals[index].elements.push_back(std::make_pair(offset, size));
 }
 
 void State::dumpSignal(llvm::raw_ostream &out, int index) {

--- a/lib/Dialect/LLHD/Simulator/State.cpp
+++ b/lib/Dialect/LLHD/Simulator/State.cpp
@@ -84,7 +84,7 @@ std::string Signal::dump() {
 std::string Signal::dump(unsigned elemIndex) {
   assert(elements.size() > 0 && "the signal type has to be tuple or array!");
   auto elemSize = elements[elemIndex].second;
-  auto ptr = value + elements[elemIndex].first;
+  auto ptr = value.get() + elements[elemIndex].first;
   std::string ret;
   raw_string_ostream ss(ret);
   ss << "0x";
@@ -181,6 +181,7 @@ void State::addProcPtr(std::string name, ProcState *procStatePtr) {
 
 int State::addSignalData(int index, std::string owner, uint8_t *value,
                          uint64_t size) {
+  llvm::outs() << owner << "\n";
   auto &inst = instances[owner];
   uint64_t globalIdx = inst.sensitivityList[index + inst.nArgs].globalIndex;
   auto &sig = signals[globalIdx];

--- a/lib/Dialect/LLHD/Simulator/State.cpp
+++ b/lib/Dialect/LLHD/Simulator/State.cpp
@@ -181,7 +181,6 @@ void State::addProcPtr(std::string name, ProcState *procStatePtr) {
 
 int State::addSignalData(int index, std::string owner, uint8_t *value,
                          uint64_t size) {
-  llvm::outs() << owner << "\n";
   auto &inst = instances[owner];
   uint64_t globalIdx = inst.sensitivityList[index + inst.nArgs].globalIndex;
   auto &sig = signals[globalIdx];

--- a/lib/Dialect/LLHD/Simulator/State.h
+++ b/lib/Dialect/LLHD/Simulator/State.h
@@ -79,12 +79,11 @@ struct Signal {
   /// owner.
   bool operator<(const Signal &rhs) const;
 
-  /// Return the signal value in dumpable format: "0x<value>".
+  /// Return the value of the signal in hexadecimal string format.
   std::string dump();
 
-  /// Return the value of the i-th element of the signal in dumpable format. If
-  /// the signal is not of tuple or array type (i.e. has no sub-elements), an
-  /// assertion is thrown.
+  /// Return the value of the i-th element of the signal in hexadecimal string
+  /// format.
   std::string dump(unsigned);
 
   std::string name;

--- a/lib/Dialect/LLHD/Simulator/State.h
+++ b/lib/Dialect/LLHD/Simulator/State.h
@@ -82,6 +82,11 @@ struct Signal {
   /// Return the signal value in dumpable format: "0x<value>".
   std::string dump();
 
+  /// Return the value of the i-th element of the signal in dumpable format. If
+  /// the signal is not of tuple or array type (i.e. has no sub-elements), an
+  /// assertion is thrown.
+  std::string dump(unsigned);
+
   std::string name;
   std::string owner;
   // The list of instances this signal triggers.
@@ -89,6 +94,7 @@ struct Signal {
   int origin = -1;
   uint64_t size;
   std::unique_ptr<uint8_t> value;
+  std::vector<std::pair<unsigned, unsigned>> elements;
 };
 
 /// The simulator's internal representation of one queue slot.
@@ -189,6 +195,8 @@ struct State {
 
   int addSignalData(int index, std::string owner, uint8_t *value,
                     uint64_t size);
+
+  void addSignalElement(unsigned, unsigned, unsigned);
 
   /// Add a pointer to the process persistence state to a process instance.
   void addProcPtr(std::string name, ProcState *procStatePtr);

--- a/lib/Dialect/LLHD/Simulator/State.h
+++ b/lib/Dialect/LLHD/Simulator/State.h
@@ -91,7 +91,6 @@ struct Signal {
   std::string owner;
   // The list of instances this signal triggers.
   std::vector<std::string> triggers;
-  int origin = -1;
   uint64_t size;
   std::unique_ptr<uint8_t> value;
   std::vector<std::pair<unsigned, unsigned>> elements;

--- a/lib/Dialect/LLHD/Simulator/Trace.cpp
+++ b/lib/Dialect/LLHD/Simulator/Trace.cpp
@@ -54,7 +54,7 @@ void Trace::addChangeReduced(unsigned sigIndex) {
       // Add a change for the whole signal.
       auto valueDump = sig.dump();
       auto path = state->instances[root].path + '/' + sig.name;
-      changes.push_back(std::make_tuple(path, valueDump));
+      changes.push_back(std::make_pair(path, valueDump));
     }
   }
 }

--- a/lib/Dialect/LLHD/Simulator/Trace.cpp
+++ b/lib/Dialect/LLHD/Simulator/Trace.cpp
@@ -1,0 +1,154 @@
+#include "Trace.h"
+
+#include "llvm/Support/raw_ostream.h"
+
+using namespace mlir::llhd::sim;
+
+void Trace::addChange(unsigned sigIndex) {
+  currentTime = state->time;
+  if (mode == full)
+    addChangeFull(sigIndex);
+  else if (mode == reduced)
+    addChangeReduced(sigIndex);
+  else if (mode == merged || mode == mergedReduce)
+    addChangeMerged(sigIndex);
+}
+
+void Trace::addChangeFull(unsigned sigIndex) {
+  auto sig = state->signals[sigIndex];
+  // Add a change for all signal elements.
+  if (sig.elements.size() > 0) {
+    for (size_t i = 0, e = sig.elements.size(); i < e; ++i) {
+      auto valueDump = sig.dump(i);
+      for (auto inst : sig.triggers) {
+        std::string path;
+        llvm::raw_string_ostream ss(path);
+        ss << state->instances[inst].path << '/' << sig.name << '[' << i << ']';
+        changes.push_back(std::make_pair(path, valueDump));
+      }
+    }
+  } else {
+    // Add a change for the whole signal.
+    auto valueDump = sig.dump();
+    for (auto inst : sig.triggers) {
+      auto path = state->instances[inst].path + '/' + sig.name;
+      changes.push_back(std::make_pair(path, valueDump));
+    }
+  }
+}
+
+void Trace::addChangeReduced(unsigned sigIndex) {
+  auto sig = state->signals[sigIndex];
+  auto root = state->root;
+  if (sig.owner == root) {
+    // Add a change for all signal sub-elements.
+    if (sig.elements.size() > 0) {
+      for (size_t i = 0, e = sig.elements.size(); i < e; ++i) {
+        auto valueDump = sig.dump(i);
+        std::string path;
+        llvm::raw_string_ostream ss(path);
+        ss << state->instances[root].path << '/' << sig.name << '[' << i << ']';
+        changes.push_back(std::make_pair(path, valueDump));
+      }
+    } else {
+      // Add a change for the whole signal.
+      auto valueDump = sig.dump();
+      auto path = state->instances[root].path + '/' + sig.name;
+      changes.push_back(std::make_tuple(path, valueDump));
+    }
+  }
+}
+
+void Trace::addChangeMerged(unsigned sigIndex) {
+  auto sig = state->signals[sigIndex];
+  auto time = state->time;
+  // Add a change for all sub-elements
+  if (sig.elements.size() > 0) {
+    for (size_t i = 0, e = sig.elements.size(); i < e; ++i) {
+      auto valueDump = sig.dump(i);
+      mergedChanges[std::make_pair(sigIndex, i)] =
+          std::make_pair(time, valueDump);
+    }
+  } else {
+    // Add one change for the whole signal.
+    auto valueDump = sig.dump();
+    mergedChanges[std::make_pair(sigIndex, 0)] =
+        std::make_pair(time, valueDump);
+  }
+}
+
+void Trace::flush(bool force) {
+  if (changes.size() > 0 || mergedChanges.size() > 0) {
+    if (mode == TraceMode::full || mode == TraceMode::reduced)
+      flushFull();
+    else if (mode == TraceMode::merged || mode == TraceMode::mergedReduce)
+      if (state->time.time > currentTime.time || force)
+        flushMerged();
+  }
+}
+
+void Trace::flushFull() {
+  std::sort(changes.begin(), changes.end(),
+            [](std::pair<std::string, std::string> &lhs,
+               std::pair<std::string, std::string> &rhs) -> bool {
+              return lhs.first < rhs.first;
+            });
+  auto timeDump = currentTime.dump();
+  for (auto change : changes) {
+    out << timeDump << "  " << change.first << "  " << change.second << "\n";
+  }
+  changes.clear();
+}
+
+void Trace::flushMerged() {
+  // Move the merged changes to the changes vector for dumping.
+  for (auto elem : mergedChanges) {
+    auto sigIndex = elem.first.first;
+    auto sig = state->signals[sigIndex];
+    auto change = elem.second;
+    // Add the changes for all signals.
+    if (mode == merged) {
+      for (auto inst : sig.triggers) {
+        if (sig.elements.size() > 0) {
+          std::string path;
+          llvm::raw_string_ostream ss(path);
+          ss << state->instances[inst].path << '/' << sig.name << '['
+             << elem.first.second << ']';
+          changes.push_back(std::make_pair(path, change.second));
+        } else {
+          auto path = state->instances[inst].path + '/' + sig.name;
+          changes.push_back(std::make_pair(path, change.second));
+        }
+      }
+    } else if (mode == mergedReduce) {
+      // Add the changes for the top-level signals only.
+      auto sigIndex = elem.first.first;
+      auto sig = state->signals[sigIndex];
+      auto root = state->root;
+      if (sig.owner == root) {
+        if (sig.elements.size() > 0) {
+          std::string path;
+          llvm::raw_string_ostream ss(path);
+          ss << state->instances[root].path << '/' << sig.name << '['
+             << elem.first.second << ']';
+          changes.push_back(std::make_pair(path, change.second));
+        } else {
+          auto path = state->instances[root].path + '/' + sig.name;
+          changes.push_back(std::make_pair(path, change.second));
+        }
+      }
+    }
+  }
+
+  std::sort(changes.begin(), changes.end(),
+            [](std::pair<std::string, std::string> &lhs,
+               std::pair<std::string, std::string> &rhs) -> bool {
+              return lhs.first < rhs.first;
+            });
+  out << currentTime.time << "ps\n";
+  for (auto change : changes) {
+    out << "  " << change.first << "  " << change.second << "\n";
+  }
+  mergedChanges.clear();
+  changes.clear();
+}

--- a/lib/Dialect/LLHD/Simulator/Trace.cpp
+++ b/lib/Dialect/LLHD/Simulator/Trace.cpp
@@ -132,7 +132,7 @@ void Trace::flushMerged() {
         if (sig.owner == root &&
             (mode == mergedReduce ||
              (mode == namedOnly && sig.owner == root &&
-              !std::regex_match(sig.name, std::regex("sig[0-9]*"))))) {
+              !std::regex_match(sig.name, std::regex("(sig)?[0-9]*"))))) {
           if (sig.elements.size() > 0) {
             std::string path;
             llvm::raw_string_ostream ss(path);

--- a/lib/Dialect/LLHD/Simulator/Trace.cpp
+++ b/lib/Dialect/LLHD/Simulator/Trace.cpp
@@ -63,19 +63,16 @@ void Trace::addChangeReduced(unsigned sigIndex) {
 
 void Trace::addChangeMerged(unsigned sigIndex) {
   auto &sig = state->signals[sigIndex];
-  auto time = state->time;
   if (sig.elements.size() > 0) {
     // Add a change for all sub-elements
     for (size_t i = 0, e = sig.elements.size(); i < e; ++i) {
       auto valueDump = sig.dump(i);
-      mergedChanges[std::make_pair(sigIndex, i)] =
-          std::make_pair(time, valueDump);
+      mergedChanges[std::make_pair(sigIndex, i)] = valueDump;
     }
   } else {
     // Add one change for the whole signal.
     auto valueDump = sig.dump();
-    mergedChanges[std::make_pair(sigIndex, 0)] =
-        std::make_pair(time, valueDump);
+    mergedChanges[std::make_pair(sigIndex, 0)] = valueDump;
   }
 }
 
@@ -109,7 +106,7 @@ void Trace::flushMerged() {
     auto &sig = state->signals[sigIndex];
     auto change = elem.second;
     // Filter out changes that do not actually introduce changes
-    if (lastValue[elem.first] != change.second) {
+    if (lastValue[elem.first] != change) {
       // Add the changes for all signals.
       if (mode == merged) {
         for (auto inst : sig.triggers) {
@@ -118,10 +115,10 @@ void Trace::flushMerged() {
             llvm::raw_string_ostream ss(path);
             ss << state->instances[inst].path << '/' << sig.name << '['
                << elem.first.second << ']';
-            changes.push_back(std::make_pair(path, change.second));
+            changes.push_back(std::make_pair(path, change));
           } else {
             auto path = state->instances[inst].path + '/' + sig.name;
-            changes.push_back(std::make_pair(path, change.second));
+            changes.push_back(std::make_pair(path, change));
           }
         }
       } else if (mode == mergedReduce || mode == namedOnly) {
@@ -138,14 +135,14 @@ void Trace::flushMerged() {
             llvm::raw_string_ostream ss(path);
             ss << state->instances[root].path << '/' << sig.name << '['
                << elem.first.second << ']';
-            changes.push_back(std::make_pair(path, change.second));
+            changes.push_back(std::make_pair(path, change));
           } else {
             auto path = state->instances[root].path + '/' + sig.name;
-            changes.push_back(std::make_pair(path, change.second));
+            changes.push_back(std::make_pair(path, change));
           }
         }
       }
-      lastValue[elem.first] = change.second;
+      lastValue[elem.first] = change;
     }
   }
 

--- a/lib/Dialect/LLHD/Simulator/Trace.cpp
+++ b/lib/Dialect/LLHD/Simulator/Trace.cpp
@@ -1,3 +1,10 @@
+//===- Trace.cpp - Simulation trace implementation ------------------------===//
+//
+// This file implements the Trace class, used to handle the signal trace
+// generation for the llhd-sim tool.
+//
+//===----------------------------------------------------------------------===//
+
 #include "Trace.h"
 
 #include "llvm/Support/raw_ostream.h"

--- a/lib/Dialect/LLHD/Simulator/Trace.cpp
+++ b/lib/Dialect/LLHD/Simulator/Trace.cpp
@@ -29,6 +29,10 @@ Trace::Trace(std::unique_ptr<State> const &state, llvm::raw_ostream &out,
   }
 }
 
+//===----------------------------------------------------------------------===//
+// Changes gathering methods
+//===----------------------------------------------------------------------===//
+
 void Trace::pushChange(std::string inst, unsigned sigIndex, int elem = -1) {
   auto &sig = state->signals[sigIndex];
   std::string valueDump;
@@ -99,6 +103,10 @@ void Trace::addChangeMerged(unsigned sigIndex) {
     mergedChanges[std::make_pair(sigIndex, -1)] = valueDump;
   }
 }
+
+//===----------------------------------------------------------------------===//
+// Flush methods
+//===----------------------------------------------------------------------===//
 
 void Trace::sortChanges() {
   std::sort(changes.begin(), changes.end(),

--- a/lib/Dialect/LLHD/Simulator/Trace.cpp
+++ b/lib/Dialect/LLHD/Simulator/Trace.cpp
@@ -38,7 +38,6 @@ void Trace::pushChange(std::string inst, unsigned sigIndex, int elem = -1) {
   std::string valueDump;
   std::string path;
   llvm::raw_string_ostream ss(path);
-  auto lastValKey = std::make_tuple(inst, sigIndex, elem);
 
   ss << state->instances[inst].path << '/' << sig.name;
 
@@ -53,6 +52,7 @@ void Trace::pushChange(std::string inst, unsigned sigIndex, int elem = -1) {
   }
 
   // Check wheter we have an actual change from last value.
+  auto lastValKey = std::make_pair(path, elem);
   if (valueDump != lastValue[lastValKey]) {
     changes.push_back(std::make_pair(path, valueDump));
     lastValue[lastValKey] = valueDump;

--- a/lib/Dialect/LLHD/Simulator/Trace.cpp
+++ b/lib/Dialect/LLHD/Simulator/Trace.cpp
@@ -109,23 +109,23 @@ void Trace::sortChanges() {
 }
 
 void Trace::flush(bool force) {
-  if (changes.size() > 0 || mergedChanges.size() > 0) {
-    if (mode == full || mode == reduced)
-      flushFull();
-    else if (mode == merged || mode == mergedReduce || mode == namedOnly)
-      if (state->time.time > currentTime.time || force)
-        flushMerged();
-  }
+  if (mode == full || mode == reduced)
+    flushFull();
+  else if (mode == merged || mode == mergedReduce || mode == namedOnly)
+    if (state->time.time > currentTime.time || force)
+      flushMerged();
 }
 
 void Trace::flushFull() {
-  sortChanges();
+  if (changes.size() > 0) {
+    sortChanges();
 
-  auto timeDump = currentTime.dump();
-  for (auto change : changes) {
-    out << timeDump << "  " << change.first << "  " << change.second << "\n";
+    auto timeDump = currentTime.dump();
+    for (auto change : changes) {
+      out << timeDump << "  " << change.first << "  " << change.second << "\n";
+    }
+    changes.clear();
   }
-  changes.clear();
 }
 
 void Trace::flushMerged() {
@@ -147,13 +147,15 @@ void Trace::flushMerged() {
     }
   }
 
-  sortChanges();
+  if (changes.size() > 0) {
+    sortChanges();
 
-  // Flush the changes to output stream.
-  out << currentTime.time << "ps\n";
-  for (auto change : changes) {
-    out << "  " << change.first << "  " << change.second << "\n";
+    // Flush the changes to output stream.
+    out << currentTime.time << "ps\n";
+    for (auto change : changes) {
+      out << "  " << change.first << "  " << change.second << "\n";
+    }
+    mergedChanges.clear();
+    changes.clear();
   }
-  mergedChanges.clear();
-  changes.clear();
 }

--- a/lib/Dialect/LLHD/Simulator/Trace.cpp
+++ b/lib/Dialect/LLHD/Simulator/Trace.cpp
@@ -4,7 +4,7 @@
 
 #include <regex>
 
-using namespace mlir::llhd::sim;
+using namespace circt::llhd::sim;
 
 void Trace::addChange(unsigned sigIndex) {
   currentTime = state->time;
@@ -17,7 +17,7 @@ void Trace::addChange(unsigned sigIndex) {
 }
 
 void Trace::addChangeFull(unsigned sigIndex) {
-  auto sig = state->signals[sigIndex];
+  auto &sig = state->signals[sigIndex];
   // Add a change for all signal elements.
   if (sig.elements.size() > 0) {
     for (size_t i = 0, e = sig.elements.size(); i < e; ++i) {
@@ -40,7 +40,7 @@ void Trace::addChangeFull(unsigned sigIndex) {
 }
 
 void Trace::addChangeReduced(unsigned sigIndex) {
-  auto sig = state->signals[sigIndex];
+  auto &sig = state->signals[sigIndex];
   auto root = state->root;
   if (sig.owner == root) {
     // Add a change for all signal sub-elements.
@@ -62,7 +62,7 @@ void Trace::addChangeReduced(unsigned sigIndex) {
 }
 
 void Trace::addChangeMerged(unsigned sigIndex) {
-  auto sig = state->signals[sigIndex];
+  auto &sig = state->signals[sigIndex];
   auto time = state->time;
   // Add a change for all sub-elements
   if (sig.elements.size() > 0) {
@@ -106,7 +106,7 @@ void Trace::flushMerged() {
   // Move the merged changes to the changes vector for dumping.
   for (auto elem : mergedChanges) {
     auto sigIndex = elem.first.first;
-    auto sig = state->signals[sigIndex];
+    auto &sig = state->signals[sigIndex];
     auto change = elem.second;
     // Filter out changes that do not actually introduce changes
     if (lastValue[elem.first] != change.second) {
@@ -127,7 +127,7 @@ void Trace::flushMerged() {
       } else if (mode == mergedReduce || mode == namedOnly) {
         // Add the changes for the top-level signals only.
         auto sigIndex = elem.first.first;
-        auto sig = state->signals[sigIndex];
+        auto &sig = state->signals[sigIndex];
         auto root = state->root;
         if (sig.owner == root &&
             (mode == mergedReduce ||

--- a/lib/Dialect/LLHD/Simulator/Trace.cpp
+++ b/lib/Dialect/LLHD/Simulator/Trace.cpp
@@ -93,6 +93,14 @@ void Trace::addChangeMerged(unsigned sigIndex) {
   }
 }
 
+void Trace::sortChanges() {
+  std::sort(changes.begin(), changes.end(),
+            [](std::pair<std::string, std::string> &lhs,
+               std::pair<std::string, std::string> &rhs) -> bool {
+              return lhs.first < rhs.first;
+            });
+}
+
 void Trace::flush(bool force) {
   if (changes.size() > 0 || mergedChanges.size() > 0) {
     if (mode == full || mode == reduced)
@@ -104,11 +112,8 @@ void Trace::flush(bool force) {
 }
 
 void Trace::flushFull() {
-  std::sort(changes.begin(), changes.end(),
-            [](std::pair<std::string, std::string> &lhs,
-               std::pair<std::string, std::string> &rhs) -> bool {
-              return lhs.first < rhs.first;
-            });
+  sortChanges();
+
   auto timeDump = currentTime.dump();
   for (auto change : changes) {
     out << timeDump << "  " << change.first << "  " << change.second << "\n";
@@ -135,11 +140,7 @@ void Trace::flushMerged() {
     }
   }
 
-  std::sort(changes.begin(), changes.end(),
-            [](std::pair<std::string, std::string> &lhs,
-               std::pair<std::string, std::string> &rhs) -> bool {
-              return lhs.first < rhs.first;
-            });
+  sortChanges();
 
   // Flush the changes to output stream.
   out << currentTime.time << "ps\n";

--- a/lib/Dialect/LLHD/Simulator/Trace.h
+++ b/lib/Dialect/LLHD/Simulator/Trace.h
@@ -1,0 +1,64 @@
+#ifndef CIRCT_DIALECT_LLHD_SIMULATOR_TRACE_H
+#define CIRCT_DIALECT_LLHD_SIMULATOR_TRACE_H
+
+#include "State.h"
+
+#include <map>
+#include <vector>
+
+namespace llvm {
+class raw_ostream;
+}
+
+namespace mlir {
+namespace llhd {
+namespace sim {
+
+enum TraceMode { full, reduced, merged, mergedReduce };
+
+/// Class for generating a signal change trace.
+/// This offers various trace formats:
+/// - full: a human-readable and diff-friendly trace which lists all the signal
+/// changes for all time steps of the simulation. The changes inside a time step
+/// are ordered by the signal paths.
+/// - reduced: same as full, but only the signals of the top-level entity are
+/// dumped.
+/// - merged: a human-readable format that merges all the delta step and epsilon
+/// step changes into their real-time step. This makes visual inspection against
+/// other traces format easier, whenever they don't have infinitesimal sub-steps
+/// (e.g. VCD).
+/// - merged-reduce: same as merged, but only the signals of the top-level
+/// entity are dumped.
+class Trace {
+  llvm::raw_ostream &out;
+  std::unique_ptr<State> const &state;
+  TraceMode mode;
+  Time currentTime;
+  std::vector<std::pair<std::string, std::string>> changes;
+  std::map<std::pair<unsigned, unsigned>, std::pair<Time, std::string>>
+      mergedChanges;
+
+  void addChangeFull(unsigned);
+  void addChangeReduced(unsigned);
+  void addChangeMerged(unsigned);
+  void addChangeMergedReduce(unsigned);
+
+  void flushFull();
+  void flushMerged();
+
+public:
+  Trace(std::unique_ptr<State> const &state, llvm::raw_ostream &out,
+        TraceMode mode)
+      : out(out), state(state), mode(mode) {}
+
+  /// Add a value change.
+  void addChange(unsigned);
+
+  /// Flush the changes to the output stream.
+  void flush(bool force = false);
+};
+} // namespace sim
+} // namespace llhd
+} // namespace mlir
+
+#endif // CIRCT_DIALECT_LLHD_SIMULATOR_TRACE_H

--- a/lib/Dialect/LLHD/Simulator/Trace.h
+++ b/lib/Dialect/LLHD/Simulator/Trace.h
@@ -15,7 +15,7 @@
 
 namespace llvm {
 class raw_ostream;
-}
+} // namespace llvm
 
 namespace circt {
 namespace llhd {

--- a/lib/Dialect/LLHD/Simulator/Trace.h
+++ b/lib/Dialect/LLHD/Simulator/Trace.h
@@ -35,8 +35,7 @@ class Trace {
   TraceMode mode;
   Time currentTime;
   std::vector<std::pair<std::string, std::string>> changes;
-  std::map<std::pair<unsigned, unsigned>, std::pair<Time, std::string>>
-      mergedChanges;
+  std::map<std::pair<unsigned, unsigned>, std::string> mergedChanges;
   std::map<std::pair<unsigned, unsigned>, std::string> lastValue;
 
   void pushChange(std::string inst, Signal &sig, int elem);

--- a/lib/Dialect/LLHD/Simulator/Trace.h
+++ b/lib/Dialect/LLHD/Simulator/Trace.h
@@ -35,8 +35,8 @@ class Trace {
   TraceMode mode;
   Time currentTime;
   std::vector<std::pair<std::string, std::string>> changes;
-  std::map<std::pair<unsigned, unsigned>, std::string> mergedChanges;
-  std::map<std::pair<unsigned, unsigned>, std::string> lastValue;
+  std::map<std::pair<unsigned, int>, std::string> mergedChanges;
+  std::map<std::pair<unsigned, int>, std::string> lastValue;
 
   void pushChange(std::string inst, Signal &sig, int elem);
   void pushAllChanges(std::string inst, Signal &sig);

--- a/lib/Dialect/LLHD/Simulator/Trace.h
+++ b/lib/Dialect/LLHD/Simulator/Trace.h
@@ -44,6 +44,8 @@ class Trace {
 
   void addChangeMerged(unsigned);
 
+  void sortChanges();
+
   void flushFull();
   void flushMerged();
 

--- a/lib/Dialect/LLHD/Simulator/Trace.h
+++ b/lib/Dialect/LLHD/Simulator/Trace.h
@@ -35,7 +35,7 @@ class Trace {
   // Buffer of changes for the merged formats.
   std::map<std::pair<unsigned, int>, std::string> mergedChanges;
   // Buffer of last dumped change for each signal.
-  std::map<std::tuple<std::string, unsigned, int>, std::string> lastValue;
+  std::map<std::pair<std::string, int>, std::string> lastValue;
 
   /// Push one change to the changes vector.
   void pushChange(std::string inst, unsigned sigIndex, int elem);

--- a/lib/Dialect/LLHD/Simulator/Trace.h
+++ b/lib/Dialect/LLHD/Simulator/Trace.h
@@ -39,6 +39,9 @@ class Trace {
       mergedChanges;
   std::map<std::pair<unsigned, unsigned>, std::string> lastValue;
 
+  void pushChange(std::string inst, Signal &sig, int elem);
+  void pushAllChanges(std::string inst, Signal &sig);
+
   void addChangeFull(unsigned);
   void addChangeReduced(unsigned);
   void addChangeMerged(unsigned);

--- a/lib/Dialect/LLHD/Simulator/Trace.h
+++ b/lib/Dialect/LLHD/Simulator/Trace.h
@@ -34,6 +34,7 @@ class Trace {
   std::unique_ptr<State> const &state;
   TraceMode mode;
   Time currentTime;
+  std::vector<bool> isTraced;
   std::vector<std::pair<std::string, std::string>> changes;
   std::map<std::pair<unsigned, int>, std::string> mergedChanges;
   std::map<std::pair<unsigned, int>, std::string> lastValue;
@@ -51,8 +52,7 @@ class Trace {
 
 public:
   Trace(std::unique_ptr<State> const &state, llvm::raw_ostream &out,
-        TraceMode mode)
-      : out(out), state(state), mode(mode) {}
+        TraceMode mode);
 
   /// Add a value change.
   void addChange(unsigned);

--- a/lib/Dialect/LLHD/Simulator/Trace.h
+++ b/lib/Dialect/LLHD/Simulator/Trace.h
@@ -60,6 +60,6 @@ public:
 };
 } // namespace sim
 } // namespace llhd
-} // namespace mlir
+} // namespace circt
 
 #endif // CIRCT_DIALECT_LLHD_SIMULATOR_TRACE_H

--- a/lib/Dialect/LLHD/Simulator/Trace.h
+++ b/lib/Dialect/LLHD/Simulator/Trace.h
@@ -14,7 +14,7 @@ namespace mlir {
 namespace llhd {
 namespace sim {
 
-enum TraceMode { full, reduced, merged, mergedReduce };
+enum TraceMode { full, reduced, merged, mergedReduce, namedOnly };
 
 /// Class for generating a signal change trace.
 /// This offers various trace formats:
@@ -37,6 +37,7 @@ class Trace {
   std::vector<std::pair<std::string, std::string>> changes;
   std::map<std::pair<unsigned, unsigned>, std::pair<Time, std::string>>
       mergedChanges;
+  std::map<std::pair<unsigned, unsigned>, std::string> lastValue;
 
   void addChangeFull(unsigned);
   void addChangeReduced(unsigned);

--- a/lib/Dialect/LLHD/Simulator/Trace.h
+++ b/lib/Dialect/LLHD/Simulator/Trace.h
@@ -10,7 +10,7 @@ namespace llvm {
 class raw_ostream;
 }
 
-namespace mlir {
+namespace circt {
 namespace llhd {
 namespace sim {
 

--- a/lib/Dialect/LLHD/Simulator/Trace.h
+++ b/lib/Dialect/LLHD/Simulator/Trace.h
@@ -37,15 +37,12 @@ class Trace {
   std::vector<bool> isTraced;
   std::vector<std::pair<std::string, std::string>> changes;
   std::map<std::pair<unsigned, int>, std::string> mergedChanges;
-  std::map<std::pair<unsigned, int>, std::string> lastValue;
+  std::map<std::tuple<std::string, unsigned, int>, std::string> lastValue;
 
-  void pushChange(std::string inst, Signal &sig, int elem);
-  void pushAllChanges(std::string inst, Signal &sig);
+  void pushChange(std::string inst, unsigned sigIndex, int elem);
+  void pushAllChanges(std::string inst, unsigned sigIndex);
 
-  void addChangeFull(unsigned);
-  void addChangeReduced(unsigned);
   void addChangeMerged(unsigned);
-  void addChangeMergedReduce(unsigned);
 
   void flushFull();
   void flushMerged();

--- a/lib/Dialect/LLHD/Simulator/Trace.h
+++ b/lib/Dialect/LLHD/Simulator/Trace.h
@@ -1,3 +1,10 @@
+//===- Trace.h - Simulation trace definition --------------------*- C++ -*-===//
+//
+// This file defines the Trace class, used to handle the signal trace generation
+// for the llhd-sim tool.
+//
+//===----------------------------------------------------------------------===//
+
 #ifndef CIRCT_DIALECT_LLHD_SIMULATOR_TRACE_H
 #define CIRCT_DIALECT_LLHD_SIMULATOR_TRACE_H
 

--- a/lib/Dialect/LLHD/Simulator/Trace.h
+++ b/lib/Dialect/LLHD/Simulator/Trace.h
@@ -5,6 +5,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// clang-tidy seems to expect the absolute path in the header guard on some
+// systems, so just disable it.
+// NOLINTNEXTLINE(llvm-header-guard)
 #ifndef CIRCT_DIALECT_LLHD_SIMULATOR_TRACE_H
 #define CIRCT_DIALECT_LLHD_SIMULATOR_TRACE_H
 

--- a/lib/Dialect/LLHD/Simulator/signals-runtime-wrappers.cpp
+++ b/lib/Dialect/LLHD/Simulator/signals-runtime-wrappers.cpp
@@ -24,13 +24,13 @@ int allocSignal(State *state, int index, char *owner, uint8_t *value,
 }
 
 void addSigArrayElements(State *state, unsigned index, unsigned size,
-                            unsigned numElements) {
+                         unsigned numElements) {
   for (size_t i = 0; i < numElements; ++i)
     state->addSignalElement(index, size * i, size);
 }
 
 void addSigStructElement(State *state, unsigned index, unsigned offset,
-                            unsigned size) {
+                         unsigned size) {
   state->addSignalElement(index, offset, size);
 }
 

--- a/lib/Dialect/LLHD/Simulator/signals-runtime-wrappers.cpp
+++ b/lib/Dialect/LLHD/Simulator/signals-runtime-wrappers.cpp
@@ -23,7 +23,18 @@ int allocSignal(State *state, int index, char *owner, uint8_t *value,
   return state->addSignalData(index, sOwner, value, size);
 }
 
-void allocProc(State *state, char *owner, ProcState *procState) {
+void add_sig_array_elements(State *state, unsigned index, unsigned size,
+                            unsigned numElements) {
+  for (size_t i = 0; i < numElements; ++i)
+    state->addSignalElement(index, size * i, size);
+}
+
+void add_sig_struct_element(State *state, unsigned index, unsigned offset,
+                            unsigned size) {
+  state->addSignalElement(index, offset, size);
+}
+
+void alloc_proc(State *state, char *owner, ProcState *procState) {
   assert(state && "alloc_proc: state not found");
   std::string sOwner(owner);
   state->addProcPtr(sOwner, procState);

--- a/lib/Dialect/LLHD/Simulator/signals-runtime-wrappers.cpp
+++ b/lib/Dialect/LLHD/Simulator/signals-runtime-wrappers.cpp
@@ -23,18 +23,18 @@ int allocSignal(State *state, int index, char *owner, uint8_t *value,
   return state->addSignalData(index, sOwner, value, size);
 }
 
-void add_sig_array_elements(State *state, unsigned index, unsigned size,
+void addSigArrayElements(State *state, unsigned index, unsigned size,
                             unsigned numElements) {
   for (size_t i = 0; i < numElements; ++i)
     state->addSignalElement(index, size * i, size);
 }
 
-void add_sig_struct_element(State *state, unsigned index, unsigned offset,
+void addSigStructElement(State *state, unsigned index, unsigned offset,
                             unsigned size) {
   state->addSignalElement(index, offset, size);
 }
 
-void alloc_proc(State *state, char *owner, ProcState *procState) {
+void allocProc(State *state, char *owner, ProcState *procState) {
   assert(state && "alloc_proc: state not found");
   std::string sOwner(owner);
   state->addProcPtr(sOwner, procState);

--- a/lib/Dialect/LLHD/Simulator/signals-runtime-wrappers.h
+++ b/lib/Dialect/LLHD/Simulator/signals-runtime-wrappers.h
@@ -20,6 +20,16 @@ extern "C" {
 int allocSignal(circt::llhd::sim::State *state, int index, char *owner,
                 uint8_t *value, int64_t size);
 
+/// Add offset and size information for the elements of an array signal.
+void add_sig_array_elements(mlir::llhd::sim::State *state, unsigned index,
+                            unsigned size, unsigned numElements);
+
+/// Add offset and size information for one element of a struct signal. Elements
+/// are assumed to be added (by calling this function) in sequential order, from
+/// first to last.
+void add_sig_struct_element(mlir::llhd::sim::State *state, unsigned index,
+                            unsigned offset, unsigned size);
+
 /// Add allocated constructs to a process instance.
 void allocProc(circt::llhd::sim::State *state, char *owner,
                circt::llhd::sim::ProcState *procState);

--- a/lib/Dialect/LLHD/Simulator/signals-runtime-wrappers.h
+++ b/lib/Dialect/LLHD/Simulator/signals-runtime-wrappers.h
@@ -27,7 +27,7 @@ void addSigArrayElements(circt::llhd::sim::State *state, unsigned index,
 /// Add offset and size information for one element of a struct signal. Elements
 /// are assumed to be added (by calling this function) in sequential order, from
 /// first to last.
-void addSigStructSlement(circt::llhd::sim::State *state, unsigned index,
+void addSigStructElement(circt::llhd::sim::State *state, unsigned index,
                          unsigned offset, unsigned size);
 
 /// Add allocated constructs to a process instance.

--- a/lib/Dialect/LLHD/Simulator/signals-runtime-wrappers.h
+++ b/lib/Dialect/LLHD/Simulator/signals-runtime-wrappers.h
@@ -21,14 +21,14 @@ int allocSignal(circt::llhd::sim::State *state, int index, char *owner,
                 uint8_t *value, int64_t size);
 
 /// Add offset and size information for the elements of an array signal.
-void add_sig_array_elements(mlir::llhd::sim::State *state, unsigned index,
-                            unsigned size, unsigned numElements);
+void addSigArrayElements(circt::llhd::sim::State *state, unsigned index,
+                         unsigned size, unsigned numElements);
 
 /// Add offset and size information for one element of a struct signal. Elements
 /// are assumed to be added (by calling this function) in sequential order, from
 /// first to last.
-void add_sig_struct_element(mlir::llhd::sim::State *state, unsigned index,
-                            unsigned offset, unsigned size);
+void addSigStructSlement(circt::llhd::sim::State *state, unsigned index,
+                         unsigned offset, unsigned size);
 
 /// Add allocated constructs to a process instance.
 void allocProc(circt::llhd::sim::State *state, char *owner,

--- a/test/Dialect/LLHD/Simulator/sim_array_boundary_check.mlir
+++ b/test/Dialect/LLHD/Simulator/sim_array_boundary_check.mlir
@@ -2,7 +2,6 @@
 
 // CHECK: 0ps 0d 0e  root/sig[0]  0xffff
 // CHECK-NEXT: 0ps 0d 0e  root/sig[1]  0xffff
-// CHECK-NEXT: 0ps 0d 1e  root/sig[0]  0xffff
 // CHECK-NEXT: 0ps 0d 1e  root/sig[1]  0x0000
 llhd.entity @root () -> () {
     %0 = llhd.const -1 : i8

--- a/test/Dialect/LLHD/Simulator/sim_array_boundary_check.mlir
+++ b/test/Dialect/LLHD/Simulator/sim_array_boundary_check.mlir
@@ -1,7 +1,9 @@
 // RUN: llhd-sim %s | FileCheck %s
 
-// CHECK: 0ps 0d 0e  root/sig  0xffffffff
-// CHECK-NEXT: 0ps 0d 1e  root/sig  0x0000ffff
+// CHECK: 0ps 0d 0e  root/sig[0]  0xffff
+// CHECK-NEXT: 0ps 0d 0e  root/sig[1]  0xffff
+// CHECK-NEXT: 0ps 0d 1e  root/sig[0]  0xffff
+// CHECK-NEXT: 0ps 0d 1e  root/sig[1]  0x0000
 llhd.entity @root () -> () {
     %0 = llhd.const -1 : i8
     %1 = llhd.array_uniform %0 : !llhd.array<2 x i8>

--- a/test/Dialect/LLHD/Simulator/sim_bit_precision_drives.mlir
+++ b/test/Dialect/LLHD/Simulator/sim_bit_precision_drives.mlir
@@ -1,11 +1,11 @@
 // RUN: llhd-sim %s | FileCheck %s
 
-// CHECK: 0ps 0d 0e  root/twoBytes  0x12345678
+// CHECK: 0ps 0d 0e  root/sameByte  0xffffffff
 // CHECK-NEXT: 0ps 0d 0e  root/spanBytes  0xffffffff
-// CHECK-NEXT: 0ps 0d 0e  root/sameByte  0xffffffff
-// CHECK-NEXT: 1000ps 0d 0e  root/twoBytes  0x1234ffff
-// CHECK-NEXT: 1000ps 0d 0e  root/spanBytes  0xfffff00f
+// CHECK-NEXT: 0ps 0d 0e  root/twoBytes  0x12345678
 // CHECK-NEXT: 1000ps 0d 0e  root/sameByte  0xfffffffc
+// CHECK-NEXT: 1000ps 0d 0e  root/spanBytes  0xfffff00f
+// CHECK-NEXT: 1000ps 0d 0e  root/twoBytes  0x1234ffff
 llhd.entity @root () -> () {
   %0 = llhd.const 0x12345678 : i32
   %1 = llhd.const 0xffffffff : i32

--- a/test/Dialect/LLHD/Simulator/sim_formats.mlir
+++ b/test/Dialect/LLHD/Simulator/sim_formats.mlir
@@ -1,0 +1,115 @@
+// RUN: llhd-sim %s -T 5000 --trace-format=full | FileCheck %s --check-prefix=FULL
+// RUN: llhd-sim %s -T 5000 --trace-format=reduced | FileCheck %s --check-prefix=REDUCED
+// RUN: llhd-sim %s -T 5000 --trace-format=merged | FileCheck %s --check-prefix=MERGED
+// RUN: llhd-sim %s -T 5000 --trace-format=merged-reduce | FileCheck %s --check-prefix=MERGEDRED
+// RUN: llhd-sim %s -T 5000 --trace-format=named-only | FileCheck %s --check-prefix=NAMED
+
+// FULL: 0ps 0d 0e  root/1  0x01
+// FULL: 0ps 0d 0e  root/foo/s  0x01
+// FULL: 0ps 0d 0e  root/s  0x01
+// FULL: 0ps 0d 1e  root/foo/s  0x02
+// FULL: 0ps 0d 1e  root/s  0x02
+// FULL: 0ps 0d 2e  root/foo/s  0x03
+// FULL: 0ps 0d 2e  root/s  0x03
+// FULL: 1000ps 0d 1e  root/foo/s  0x06
+// FULL: 1000ps 0d 1e  root/s  0x06
+// FULL: 1000ps 0d 2e  root/foo/s  0x09
+// FULL: 1000ps 0d 2e  root/s  0x09
+// FULL: 2000ps 0d 1e  root/foo/s  0x12
+// FULL: 2000ps 0d 1e  root/s  0x12
+// FULL: 2000ps 0d 2e  root/foo/s  0x1b
+// FULL: 2000ps 0d 2e  root/s  0x1b
+// FULL: 3000ps 0d 1e  root/foo/s  0x36
+// FULL: 3000ps 0d 1e  root/s  0x36
+// FULL: 3000ps 0d 2e  root/foo/s  0x51
+// FULL: 3000ps 0d 2e  root/s  0x51
+// FULL: 4000ps 0d 1e  root/foo/s  0xa2
+// FULL: 4000ps 0d 1e  root/s  0xa2
+// FULL: 4000ps 0d 2e  root/foo/s  0xf3
+// FULL: 4000ps 0d 2e  root/s  0xf3
+// FULL: 5000ps 0d 1e  root/foo/s  0xe6
+// FULL: 5000ps 0d 1e  root/s  0xe6
+// FULL: 5000ps 0d 2e  root/foo/s  0xd9
+// FULL: 5000ps 0d 2e  root/s  0xd9
+
+// REDUCED: 0ps 0d 0e  root/1  0x01
+// REDUCED: 0ps 0d 0e  root/s  0x01
+// REDUCED: 0ps 0d 1e  root/s  0x02
+// REDUCED: 0ps 0d 2e  root/s  0x03
+// REDUCED: 1000ps 0d 1e  root/s  0x06
+// REDUCED: 1000ps 0d 2e  root/s  0x09
+// REDUCED: 2000ps 0d 1e  root/s  0x12
+// REDUCED: 2000ps 0d 2e  root/s  0x1b
+// REDUCED: 3000ps 0d 1e  root/s  0x36
+// REDUCED: 3000ps 0d 2e  root/s  0x51
+// REDUCED: 4000ps 0d 1e  root/s  0xa2
+// REDUCED: 4000ps 0d 2e  root/s  0xf3
+// REDUCED: 5000ps 0d 1e  root/s  0xe6
+// REDUCED: 5000ps 0d 2e  root/s  0xd9
+
+// MERGED: 0ps
+// MERGED:   root/1  0x01
+// MERGED:   root/foo/s  0x03
+// MERGED:   root/s  0x03
+// MERGED: 1000ps
+// MERGED:   root/foo/s  0x09
+// MERGED:   root/s  0x09
+// MERGED: 2000ps
+// MERGED:   root/foo/s  0x1b
+// MERGED:   root/s  0x1b
+// MERGED: 3000ps
+// MERGED:   root/foo/s  0x51
+// MERGED:   root/s  0x51
+// MERGED: 4000ps
+// MERGED:   root/foo/s  0xf3
+// MERGED:   root/s  0xf3
+// MERGED: 5000ps
+// MERGED:   root/foo/s  0xd9
+// MERGED:   root/s  0xd9
+
+// MERGEDRED: 0ps
+// MERGEDRED:   root/1  0x01
+// MERGEDRED:   root/s  0x03
+// MERGEDRED: 1000ps
+// MERGEDRED:   root/s  0x09
+// MERGEDRED: 2000ps
+// MERGEDRED:   root/s  0x1b
+// MERGEDRED: 3000ps
+// MERGEDRED:   root/s  0x51
+// MERGEDRED: 4000ps
+// MERGEDRED:   root/s  0xf3
+// MERGEDRED: 5000ps
+// MERGEDRED:   root/s  0xd9
+
+// NAMED: 0ps
+// NAMED:   root/s  0x03
+// NAMED: 1000ps
+// NAMED:   root/s  0x09
+// NAMED: 2000ps
+// NAMED:   root/s  0x1b
+// NAMED: 3000ps
+// NAMED:   root/s  0x51
+// NAMED: 4000ps
+// NAMED:   root/s  0xf3
+// NAMED: 5000ps
+// NAMED:   root/s  0xd9
+llhd.entity @root () -> () {
+  %0 = llhd.const 1 : i8
+  %s = llhd.sig "s" %0 : i8
+  %1 = llhd.sig "1" %0 : i8
+  llhd.inst "foo" @foo () -> (%s) : () -> (!llhd.sig<i8>)
+}
+
+llhd.proc @foo () -> (%s : !llhd.sig<i8>) {
+  br ^entry
+^entry:
+  %1 = llhd.prb %s : !llhd.sig<i8>
+  %2 = addi %1, %1 : i8
+  %t0 = llhd.const #llhd.time<0ns, 0d, 1e> : !llhd.time
+  llhd.drv %s, %2 after %t0 : !llhd.sig<i8>
+  %3 = addi %2, %1 : i8
+  %t1 = llhd.const #llhd.time<0ns, 0d, 2e> : !llhd.time
+  llhd.drv %s, %3 after %t1 : !llhd.sig<i8>
+  %t2= llhd.const #llhd.time<1ns, 0d, 0e> : !llhd.time
+  llhd.wait for %t2, ^entry
+}

--- a/test/Dialect/LLHD/Simulator/sim_reg.mlir
+++ b/test/Dialect/LLHD/Simulator/sim_reg.mlir
@@ -1,22 +1,22 @@
 // RUN: llhd-sim %s -n 10 | FileCheck %s
 
-// CHECK: 0ps 0d 0e  root/sig1  0x00000000
+// CHECK: 0ps 0d 0e  root/clock  0x00
+// CHECK-NEXT: 0ps 0d 0e  root/sig1  0x00000000
 // CHECK-NEXT: 0ps 0d 0e  root/sig2  0x00000000
-// CHECK-NEXT: 0ps 0d 0e  root/clock  0x00
 // CHECK-NEXT: 1000ps 0d 0e  root/sig1  0x00000002
 // CHECK-NEXT: 2000ps 0d 0e  root/clock  0x01
 // CHECK-NEXT: 3000ps 0d 0e  root/sig1  0x00000001
 // CHECK-NEXT: 3000ps 0d 0e  root/sig2  0xffffffff
-// CHECK-NEXT: 4000ps 0d 0e  root/sig1  0x00000003
 // CHECK-NEXT: 4000ps 0d 0e  root/clock  0x00
+// CHECK-NEXT: 4000ps 0d 0e  root/sig1  0x00000003
 // CHECK-NEXT: 5000ps 0d 0e  root/sig1  0x00000000
 // CHECK-NEXT: 5000ps 0d 0e  root/sig2  0x00000000
-// CHECK-NEXT: 6000ps 0d 0e  root/sig1  0x00000002
 // CHECK-NEXT: 6000ps 0d 0e  root/clock  0x01
+// CHECK-NEXT: 6000ps 0d 0e  root/sig1  0x00000002
 // CHECK-NEXT: 7000ps 0d 0e  root/sig1  0x00000001
 // CHECK-NEXT: 7000ps 0d 0e  root/sig2  0xffffffff
-// CHECK-NEXT: 8000ps 0d 0e  root/sig1  0x00000003
 // CHECK-NEXT: 8000ps 0d 0e  root/clock  0x00
+// CHECK-NEXT: 8000ps 0d 0e  root/sig1  0x00000003
 // CHECK-NEXT: 9000ps 0d 0e  root/sig1  0x00000000
 // CHECK-NEXT: 9000ps 0d 0e  root/sig2  0x00000000
 llhd.entity @root () -> () {

--- a/test/Dialect/LLHD/Simulator/sim_shifts.mlir
+++ b/test/Dialect/LLHD/Simulator/sim_shifts.mlir
@@ -1,13 +1,13 @@
 // RUN: llhd-sim %s | FileCheck %s
 
-// CHECK: 0ps 0d 0e  root/shr  0x08
-// CHECK-NEXT: 0ps 0d 0e  root/shl  0x01
-// CHECK-NEXT: 1000ps 0d 0e  root/shr  0x0c
+// CHECK: 0ps 0d 0e  root/shl  0x01
+// CHECK-NEXT: 0ps 0d 0e  root/shr  0x08
 // CHECK-NEXT: 1000ps 0d 0e  root/shl  0x02
-// CHECK-NEXT: 2000ps 0d 0e  root/shr  0x0e
+// CHECK-NEXT: 1000ps 0d 0e  root/shr  0x0c
 // CHECK-NEXT: 2000ps 0d 0e  root/shl  0x04
-// CHECK-NEXT: 3000ps 0d 0e  root/shr  0x0f
+// CHECK-NEXT: 2000ps 0d 0e  root/shr  0x0e
 // CHECK-NEXT: 3000ps 0d 0e  root/shl  0x08
+// CHECK-NEXT: 3000ps 0d 0e  root/shr  0x0f
 // CHECK-NEXT: 4000ps 0d 0e  root/shl  0x00
 
 llhd.entity @root () -> () {

--- a/test/Dialect/LLHD/Simulator/sim_wait.mlir
+++ b/test/Dialect/LLHD/Simulator/sim_wait.mlir
@@ -1,8 +1,8 @@
 // RUN: llhd-sim %s | FileCheck %s
 
 // CHECK: 0ps 0d 0e  root/proc/s1  0x00000000
-// CHECK-NEXT: 0ps 0d 0e  root/s1  0x00000000
 // CHECK-NEXT: 0ps 0d 0e  root/proc/s2  0x00000000
+// CHECK-NEXT: 0ps 0d 0e  root/s1  0x00000000
 // CHECK-NEXT: 0ps 0d 0e  root/s2  0x00000000
 // CHECK-NEXT: 0ps 0d 2e  root/proc/s1  0x00000001
 // CHECK-NEXT: 0ps 0d 2e  root/s1  0x00000001

--- a/tools/llhd-sim/llhd-sim.cpp
+++ b/tools/llhd-sim/llhd-sim.cpp
@@ -32,6 +32,12 @@ static cl::opt<std::string> outputFilename("o", cl::desc("Output filename"),
 static cl::opt<int> nSteps("n", cl::desc("Set the maximum number of steps"),
                            cl::value_desc("max-steps"));
 
+static cl::opt<uint64_t> maxTime(
+    "T",
+    cl::desc("Stop the simulation after the given amount of picoseconds, "
+             "inclusive (including all sub-steps for that real-time step). "),
+    cl::value_desc("max-steps"));
+
 static cl::opt<bool>
     dumpLLVMDialect("dump-llvm-dialect",
                     cl::desc("Dump the LLVM IR dialect module"));
@@ -138,7 +144,7 @@ int main(int argc, char **argv) {
     return 0;
   }
 
-  engine.simulate(nSteps);
+  engine.simulate(nSteps, maxTime);
 
   output->keep();
   return 0;

--- a/tools/llhd-sim/llhd-sim.cpp
+++ b/tools/llhd-sim/llhd-sim.cpp
@@ -51,6 +51,24 @@ static cl::opt<std::string> root(
     cl::value_desc("root_name"), cl::init("root"));
 static cl::alias rootA("r", cl::desc("Alias for -root"), cl::aliasopt(root));
 
+enum TraceFormat { full, reduced, merged, mergedReduce, noTrace = -1 };
+
+static cl::opt<TraceFormat> traceMode(
+    "trace-format", cl::desc("Choose the dump format:"), cl::init(full),
+    cl::values(
+        clEnumVal(full, "A human readable and diff-friendly dump of all the "
+                        "signal changes, default"),
+        clEnumVal(reduced,
+                  "A human readable dump of only the root-level signals"),
+        clEnumVal(merged, "A human readable dump of all signal changes, where "
+                          "all delta steps and epsilon steps are merged into "
+                          "their real-time steps"),
+        clEnumValN(mergedReduce, "merged-reduce",
+                   "A human readable dump of only the root level signals, "
+                   "where all delta steps and epsilon steps are merged into "
+                   "their real-time steps"),
+        clEnumValN(noTrace, "no-trace", "Don't dump the signal trace")));
+
 static int parseMLIR(MLIRContext &context, OwningModuleRef &module) {
   module = parseSourceFile(inputFilename, &context);
   if (!module)
@@ -115,7 +133,7 @@ int main(int argc, char **argv) {
     return 0;
   }
 
-  llhd::sim::Engine engine(output->os(), *module, context, root);
+  llhd::sim::Engine engine(output->os(), *module, context, root, traceMode);
 
   if (dumpLLVMDialect || dumpLLVMIR) {
     return dumpLLVM(engine.getModule(), context);

--- a/tools/llhd-sim/llhd-sim.cpp
+++ b/tools/llhd-sim/llhd-sim.cpp
@@ -70,18 +70,18 @@ static cl::opt<TraceFormat> traceMode(
     "trace-format", cl::desc("Choose the dump format:"), cl::init(full),
     cl::values(
         clEnumVal(full, "Dump signal changes for every time step and sub-step, "
-                        "for each signal and connected instance"),
+                        "for all instances"),
         clEnumVal(reduced, "Dump signal changes for every time-step and "
-                           "sub-step, only for the top-level signals"),
+                           "sub-step, only for the top-level instance"),
         clEnumVal(merged,
-                  "Only dump changes for real-time steps, for all signals and "
-                  "connected instances"),
+                  "Only dump changes for real-time steps, for all instances"),
         clEnumValN(mergedReduce, "merged-reduce",
                    "Only dump changes for real-time steps, only for the "
-                   "top-level signals"),
-        clEnumValN(namedOnly, "named-only",
-                   "Only dump changes for real-time steps, only for top-level "
-                   "signals not having a default name (i.e. '(sig)?[0-9]*')"),
+                   "top-level instance"),
+        clEnumValN(
+            namedOnly, "named-only",
+            "Only dump changes for real-time steps, only for top-level "
+            "instance and signals not having the default name '(sig)?[0-9]*'"),
         clEnumValN(noTrace, "no-trace", "Don't dump a signal trace")));
 
 static int dumpLLVM(ModuleOp module, MLIRContext &context) {

--- a/tools/llhd-sim/llhd-sim.cpp
+++ b/tools/llhd-sim/llhd-sim.cpp
@@ -57,7 +57,14 @@ static cl::opt<std::string> root(
     cl::value_desc("root_name"), cl::init("root"));
 static cl::alias rootA("r", cl::desc("Alias for -root"), cl::aliasopt(root));
 
-enum TraceFormat { full, reduced, merged, mergedReduce, noTrace = -1 };
+enum TraceFormat {
+  full,
+  reduced,
+  merged,
+  mergedReduce,
+  namedOnly,
+  noTrace = -1
+};
 
 static cl::opt<TraceFormat> traceMode(
     "trace-format", cl::desc("Choose the dump format:"), cl::init(full),
@@ -73,6 +80,11 @@ static cl::opt<TraceFormat> traceMode(
                    "A human readable dump of only the root level signals, "
                    "where all delta steps and epsilon steps are merged into "
                    "their real-time steps"),
+        clEnumValN(namedOnly, "named-only",
+                   "A human readable dump of only the root level signals, "
+                   "where all delta steps and epsilon steps are merged into "
+                   "their real-time steps, and default-named signals (i.e. "
+                   "with name 'sig[0-9]*') are filtered out."),
         clEnumValN(noTrace, "no-trace", "Don't dump the signal trace")));
 
 static int dumpLLVM(ModuleOp module, MLIRContext &context) {

--- a/tools/llhd-sim/llhd-sim.cpp
+++ b/tools/llhd-sim/llhd-sim.cpp
@@ -34,9 +34,9 @@ static cl::opt<int> nSteps("n", cl::desc("Set the maximum number of steps"),
 
 static cl::opt<uint64_t> maxTime(
     "T",
-    cl::desc("Stop the simulation after the given amount of picoseconds, "
-             "inclusive (including all sub-steps for that real-time step). "),
-    cl::value_desc("max-steps"));
+    cl::desc("Stop the simulation after the given amount of simulation time in "
+             "picoseconds, including all sub-steps for that real-time step"),
+    cl::value_desc("max-time"));
 
 static cl::opt<bool>
     dumpLLVMDialect("dump-llvm-dialect",
@@ -69,23 +69,20 @@ enum TraceFormat {
 static cl::opt<TraceFormat> traceMode(
     "trace-format", cl::desc("Choose the dump format:"), cl::init(full),
     cl::values(
-        clEnumVal(full, "A human readable and diff-friendly dump of all the "
-                        "signal changes, default"),
-        clEnumVal(reduced,
-                  "A human readable dump of only the root-level signals"),
-        clEnumVal(merged, "A human readable dump of all signal changes, where "
-                          "all delta steps and epsilon steps are merged into "
-                          "their real-time steps"),
+        clEnumVal(full, "Dump signal changes for every time step and sub-step, "
+                        "for each signal and connected instance"),
+        clEnumVal(reduced, "Dump signal changes for every time-step and "
+                           "sub-step, only for the top-level signals"),
+        clEnumVal(merged,
+                  "Only dump changes for real-time steps, for all signals and "
+                  "connected instances"),
         clEnumValN(mergedReduce, "merged-reduce",
-                   "A human readable dump of only the root level signals, "
-                   "where all delta steps and epsilon steps are merged into "
-                   "their real-time steps"),
+                   "Only dump changes for real-time steps, only for the "
+                   "top-level signals"),
         clEnumValN(namedOnly, "named-only",
-                   "A human readable dump of only the root level signals, "
-                   "where all delta steps and epsilon steps are merged into "
-                   "their real-time steps, and default-named signals (i.e. "
-                   "with name 'sig[0-9]*') are filtered out."),
-        clEnumValN(noTrace, "no-trace", "Don't dump the signal trace")));
+                   "Only dump changes for real-time steps, only for top-level "
+                   "signals not having a default name (i.e. '(sig)?[0-9]*')"),
+        clEnumValN(noTrace, "no-trace", "Don't dump a signal trace")));
 
 static int dumpLLVM(ModuleOp module, MLIRContext &context) {
   if (dumpLLVMDialect) {


### PR DESCRIPTION
This patch introduces a new class to control the trace generation of `llhd-sim`, allowing to handle the output more dynamically, as well as defining multiple trace formats. This also "completes" the textual dump format we currently use for `llhd-sim` by separating array and struct signal entries by element (instead of printing them as an integer signal) and sorting the entries of a time step by their hierarchical paths.

Also, a couple of variations of the textual format are present. In particular, the `named-only` format should contain the same information as a top-level VCD trace, allowing to compare the `llhd-sim` trace against a VCD trace, by translating the latter to this format (e.g. through a [simple python script](https://github.com/rodonisi/llhd-extras/blob/master/convert_vcd/convert_vcd.py)). Adding VCD as an output format should also be quite close from here if desirable.

This also includes a couple minor quality-of-life changes:
* allow to directly pipe the input design to `llhd-sim` (e.g. from `circt-opt`) 
* allow to stop the simulation after a desired amount of simulation time has passed