### PR TITLE
Updates for BUILD_SHARED_LIBS=on

### DIFF
--- a/lib/Conversion/FIRRTLToLLHD/CMakeLists.txt
+++ b/lib/Conversion/FIRRTLToLLHD/CMakeLists.txt
@@ -9,5 +9,6 @@ add_mlir_conversion_library(MLIRFIRRTLToLLHD
 
   LINK_LIBS PUBLIC
   MLIRLLHD
+  MLIRFIRRTL
   MLIRTransforms
 )

--- a/lib/Dialect/FIRRTL/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/CMakeLists.txt
@@ -13,6 +13,10 @@ add_mlir_dialect_library(MLIRFIRRTL
   Support
 
   LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRPass
+  MLIRRTL
+  MLIRSV
    )
 
 add_dependencies(mlir-headers MLIRFIRRTLIncGen MLIRFIRRTLEnumsIncGen)

--- a/lib/Dialect/LLHD/IR/CMakeLists.txt
+++ b/lib/Dialect/LLHD/IR/CMakeLists.txt
@@ -17,4 +17,5 @@ add_mlir_dialect_library(MLIRLLHD
   MLIRSideEffectInterfaces
   MLIRControlFlowInterfaces
   MLIRCallInterfaces
+  MLIRStandard
 )

--- a/lib/Dialect/RTL/CMakeLists.txt
+++ b/lib/Dialect/RTL/CMakeLists.txt
@@ -13,6 +13,7 @@ add_mlir_dialect_library(MLIRRTL
   Support
 
   LINK_LIBS PUBLIC
+  MLIRIR
    )
 
 add_dependencies(mlir-headers MLIRRTLIncGen MLIRRTLEnumsIncGen)

--- a/lib/Dialect/SV/CMakeLists.txt
+++ b/lib/Dialect/SV/CMakeLists.txt
@@ -12,6 +12,7 @@ add_mlir_dialect_library(MLIRSV
   Support
 
   LINK_LIBS PUBLIC
+  MLIRIR
    )
 
 add_dependencies(mlir-headers MLIRSVIncGen)

--- a/lib/EmitVerilog/CMakeLists.txt
+++ b/lib/EmitVerilog/CMakeLists.txt
@@ -9,4 +9,5 @@ add_mlir_library(CIRCTEmitVerilog
   MLIRFIRRTL
   MLIRRTL
   MLIRSV
+  MLIRTranslation
   )

--- a/lib/FIRParser/CMakeLists.txt
+++ b/lib/FIRParser/CMakeLists.txt
@@ -7,4 +7,5 @@ add_mlir_library(CIRCTFIRParser
 
   LINK_LIBS PUBLIC
   MLIRFIRRTL
+  MLIRTranslation
   )

--- a/lib/Target/Verilog/CMakeLists.txt
+++ b/lib/Target/Verilog/CMakeLists.txt
@@ -6,4 +6,5 @@ add_mlir_library(MLIRLLHDTargetVerilog
 
   LINK_LIBS PUBLIC
   MLIRLLHD
+  MLIRTranslation
   )


### PR DESCRIPTION
Closes #230 

Generally speaking, building with BUILD_SHARED_LIBS requires more careful description of the dependencies between libraries in cmake, because shared libraries cannot have unresolved symbols.  Generally speaking, this is just a matter of adding the libraries where missing symbols live.