### PR TITLE
Add cmake export information so that out-of-tree projects can properl…

### DIFF
--- a/cmake/modules/CIRCTConfig.cmake.in
+++ b/cmake/modules/CIRCTConfig.cmake.in
@@ -1,0 +1,43 @@
+# This file allows users to call find_package(CIRCT) and pick up our targets.
+
+@CIRCT_CONFIG_CODE@
+
+# Hint some locations for LLVM and MLIR.
+# Note: this currently seems to be broken
+#find_package(LLVM REQUIRED CONFIG
+#             HINTS "@CIRCT_CONFIG_LLVM_CMAKE_DIR@")
+#find_package(MLIR REQUIRED CONFIG
+#             HINTS "@CIRCT_CONFIG_MLIR_CMAKE_DIR@")
+
+set(CIRCT_EXPORTED_TARGETS "@CIRCT_EXPORTS@")
+set(CIRCT_CMAKE_DIR "@CIRCT_CONFIG_CMAKE_DIR@")
+set(CIRCT_INCLUDE_DIRS "@CIRCT_CONFIG_INCLUDE_DIRS@")
+#set(CIRCT_TABLEGEN_EXE "@CIRCT_TABLEGEN_EXE@")
+
+# For circt_tablegen()
+set(CIRCT_INCLUDE_DIR "@CIRCT_INCLUDE_DIR@")
+set(CIRCT_MAIN_SRC_DIR "@CIRCT_MAIN_SRC_DIR@")
+
+#set_property(GLOBAL PROPERTY CIRCT_ALL_LIBS "@CIRCT_ALL_LIBS@")
+#set_property(GLOBAL PROPERTY CIRCT_DIALECT_LIBS "@CIRCT_DIALECT_LIBS@")
+#set_property(GLOBAL PROPERTY CIRCT_CONVERSION_LIBS "@CIRCT_CONVERSION_LIBS@")
+#set_property(GLOBAL PROPERTY CIRCT_TRANSLATION_LIBS "@CIRCT_TRANSLATION_LIBS@")
+
+# Provide all our library targets to users.
+include("@CIRCT_CONFIG_EXPORTS_FILE@")
+
+# By creating these targets here, subprojects that depend on CIRCT's
+# tablegen-generated headers can always depend on these targets whether building
+# in-tree with CIRCT or not.
+if(NOT TARGET circt-tablegen-targets)
+  add_custom_target(circt-tablegen-targets)
+endif()
+if(NOT TARGET circt-headers)
+  add_custom_target(circt-headers)
+endif()
+if(NOT TARGET circt-generic-headers)
+  add_custom_target(circt-generic-headers)
+endif()
+if(NOT TARGET circt-doc)
+  add_custom_target(circt-doc)
+endif()

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -1,23 +1,37 @@
-# Generate a list of CMake library targets so that other CMake projects can
-# link against them. LLVM calls its version of this file LLVMExports.cmake, but
-# the usual CMake convention seems to be ${Project}Targets.cmake.
 set(CIRCT_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm)
 set(circt_cmake_builddir "${CMAKE_BINARY_DIR}/${CIRCT_INSTALL_PACKAGE_DIR}")
 
+# Keep this in sync with mlir/cmake/CMakeLists.txt!
+set(MLIR_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/mlir)
+set(mlir_cmake_builddir "${MLIR_BINARY_DIR}/${MLIR_INSTALL_PACKAGE_DIR}")
+
+# Keep this in sync with llvm/cmake/CMakeLists.txt!
+set(LLVM_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm)
+set(llvm_cmake_builddir "${LLVM_BINARY_DIR}/${LLVM_INSTALL_PACKAGE_DIR}")
+
+# Generate a list of CMake library targets so that other CMake projects can
+# link against them. LLVM calls its version of this file LLVMExports.cmake, but
+# the usual CMake convention seems to be ${Project}Targets.cmake.
 get_property(CIRCT_EXPORTS GLOBAL PROPERTY CIRCT_EXPORTS)
 export(TARGETS ${CIRCT_EXPORTS} FILE ${circt_cmake_builddir}/CIRCTTargets.cmake)
 
 # Generate CIRCTConfig.cmake for the build tree.
 set(CIRCT_CONFIG_CMAKE_DIR "${circt_cmake_builddir}")
 set(CIRCT_CONFIG_LLVM_CMAKE_DIR "${llvm_cmake_builddir}")
+set(CIRCT_CONFIG_MLIR_CMAKE_DIR "${mlir_cmake_builddir}")
 set(CIRCT_CONFIG_EXPORTS_FILE "${circt_cmake_builddir}/CIRCTTargets.cmake")
 set(CIRCT_CONFIG_INCLUDE_DIRS
   "${CIRCT_SOURCE_DIR}/include"
   "${CIRCT_BINARY_DIR}/include"
   )
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/CIRCTConfig.cmake.in
+  ${circt_cmake_builddir}/CIRCTConfig.cmake
+  @ONLY)
 set(CIRCT_CONFIG_CMAKE_DIR)
 set(CIRCT_CONFIG_LLVM_CMAKE_DIR)
 set(CIRCT_CONFIG_EXPORTS_FILE)
+set(CIRCT_CONFIG_INCLUDE_DIRS)
 
 # Generate CIRCTConfig.cmake for the install tree.
 set(CIRCT_CONFIG_CODE "
@@ -36,9 +50,14 @@ set(CIRCT_CONFIG_EXPORTS_FILE "\${CIRCT_CMAKE_DIR}/CIRCTTargets.cmake")
 set(CIRCT_CONFIG_INCLUDE_DIRS
   "\${CIRCT_INSTALL_PREFIX}/include"
   )
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/CIRCTConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/CIRCTConfig.cmake
+    @ONLY)
 set(CIRCT_CONFIG_CODE)
 set(CIRCT_CONFIG_CMAKE_DIR)
 set(CIRCT_CONFIG_EXPORTS_FILE)
+set(CIRCT_CONFIG_INCLUDE_DIRS)
 
 if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
   # Not TOOLCHAIN ONLY, so install the CIRCT parts as well


### PR DESCRIPTION
…y call "find_package(CIRCT)"

Generally speaking, this should allow

cake -DCIRCT_DIR="<something>/lib/cmake/circt" myprojectdirectory, where <something> is
either a build or install area.  Then in your project cmake file you can have:
find_package(CIRCT REQUIRED CONFIG)

Closes #237 