### PR TITLE
[FIRRTL] Allow shr to shift by more than input width

### DIFF
--- a/include/circt/Dialect/FIRRTL/OpExpressions.td
+++ b/include/circt/Dialect/FIRRTL/OpExpressions.td
@@ -246,6 +246,13 @@ def BitsPrimOp : PrimOp<"bits"> {
     $input $hi `to` $lo attr-dict `:` functional-type($input, $result)
   }];
 
+  let description = [{
+    The `bits` operation extracts the bits between `hi` (inclusive) and `lo`
+    (inclusive) from `input`.  `hi` must be greater than or equal to `lo`. Both
+    `hi` and `lo` must be non-negative and less than the bit width of `input`.
+    The result is `hi - lo + 1` bits wide.
+  }];
+
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 
@@ -369,10 +376,26 @@ class ShiftPrimOp<string mnemonic> : PrimOp<mnemonic> {
   }];
 }
 
-let hasFolder = 1 in
-def ShlPrimOp : ShiftPrimOp<"shl">;
-let hasFolder = 1, hasCanonicalizer = 1 in
-def ShrPrimOp : ShiftPrimOp<"shr">;
+def ShlPrimOp : ShiftPrimOp<"shl"> {
+  let description = [{
+    The `shl` operation concatenates `amount` zero bits to the least significant
+    end of `input`. `amount` must be non-negative.
+  }];
+
+  let hasFolder = 1;
+}
+
+def ShrPrimOp : ShiftPrimOp<"shr"> {
+  let description = [{
+    The `shr` operation truncates least significant `amount` bits from `input`.
+    If `amount` is greater than of equal to `width(input)`, the value will be
+    zero for unsigned types and the sign bit for signed types. `amount` must be
+    non-negative.
+  }];
+
+  let hasFolder = 1;
+  let hasCanonicalizer = 1;
+}
 
 def TailPrimOp : PrimOp<"tail"> {
   let arguments = (ins IntType:$input, I32Attr:$amount);

--- a/test/firrtl/canonicalization.mlir
+++ b/test/firrtl/canonicalization.mlir
@@ -219,21 +219,37 @@ firrtl.module @Shr(%in1u: !firrtl.uint<1>,
   %1 = firrtl.shr %in4u, 4 : (!firrtl.uint<4>) -> !firrtl.uint<1>
   firrtl.connect %out1u, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 
+  // CHECK: firrtl.connect %out1u, %c0_ui1
+  %2 = firrtl.shr %in4u, 5 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  firrtl.connect %out1u, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+
+  // CHECK: [[BITS:%.+]] = firrtl.bits %in4s 3 to 3
+  // CHECK-NEXT: [[CAST:%.+]] = firrtl.asSInt [[BITS]]
+  // CHECK-NEXT: firrtl.connect %out1s, [[CAST]]
+  %3 = firrtl.shr %in4s, 3 : (!firrtl.sint<4>) -> !firrtl.sint<1>
+  firrtl.connect %out1s, %3 : !firrtl.flip<sint<1>>, !firrtl.sint<1>
+
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4s 3 to 3
   // CHECK-NEXT: [[CAST:%.+]] = firrtl.asSInt [[BITS]]
   // CHECK-NEXT: firrtl.connect %out1s, [[CAST]]
   %4 = firrtl.shr %in4s, 4 : (!firrtl.sint<4>) -> !firrtl.sint<1>
   firrtl.connect %out1s, %4 : !firrtl.flip<sint<1>>, !firrtl.sint<1>
 
+  // CHECK: [[BITS:%.+]] = firrtl.bits %in4s 3 to 3
+  // CHECK-NEXT: [[CAST:%.+]] = firrtl.asSInt [[BITS]]
+  // CHECK-NEXT: firrtl.connect %out1s, [[CAST]]
+  %5 = firrtl.shr %in4s, 5 : (!firrtl.sint<4>) -> !firrtl.sint<1>
+  firrtl.connect %out1s, %5 : !firrtl.flip<sint<1>>, !firrtl.sint<1>
+
   // CHECK: firrtl.connect %out1u, %c1_ui1
   %c12_ui4 = firrtl.constant(12 : ui4) : !firrtl.uint<4>
-  %2 = firrtl.shr %c12_ui4, 3 : (!firrtl.uint<4>) -> !firrtl.uint<1>
-  firrtl.connect %out1u, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  %6 = firrtl.shr %c12_ui4, 3 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  firrtl.connect %out1u, %6 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4u 3 to 3
   // CHECK-NEXT: firrtl.connect %out1u, [[BITS]]
-  %3 = firrtl.shr %in4u, 3 : (!firrtl.uint<4>) -> !firrtl.uint<1>
-  firrtl.connect %out1u, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  %7 = firrtl.shr %in4u, 3 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  firrtl.connect %out1u, %7 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 }
 
 // CHECK-LABEL: firrtl.module @Tail


### PR DESCRIPTION
When the shift amount is greater than the input width, the signed bit is
returned for signed integers, and zero is returned for unsigned
integers.