### PR TITLE
Fixing the workflow which GH broke

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure Environment
-        run: echo "::add-path::$GITHUB_WORKSPACE/llvm/install/bin"
+        run: echo "$GITHUB_WORKSPACE/llvm/install/bin" >> $GITHUB_PATH
 
       # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
       # time.


### PR DESCRIPTION
We've been warned for a while, but they finally broke us: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/