### PR TITLE
Add an integration testing workflow

### DIFF
--- a/.github/workflows/nightlyIntegrationTests.yml
+++ b/.github/workflows/nightlyIntegrationTests.yml
@@ -1,0 +1,116 @@
+name: Nightly integration tests
+
+# Run on request and every day at 12 noon UTC
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 12 * * *
+
+jobs:
+  # We skip the LLVM pre-build-and-cache step since (presumably) it'll be in
+  # the cache already from the PR build.
+
+  # Build CIRCT and run its tests using a Docker container with all the
+  # integration testing prerequisite installed.
+  build-circt:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/circt/images/circt-integration-test:v1
+    steps:
+      - name: Configure Environment
+        run: echo "$GITHUB_WORKSPACE/llvm/install/bin" >> $GITHUB_PATH
+
+      # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
+      # time.
+      - name: Get CIRCT
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+          submodules: true
+
+      # --------
+      # Restore LLVM from cache and build if it's not in there.
+      # --------
+
+      # Extract the LLVM submodule hash for use in the cache key.
+      - name: Get LLVM Hash
+        id: get-llvm-hash
+        run: echo "::set-output name=hash::$(git rev-parse @:./llvm)"
+        shell: bash
+
+      # Try to fetch LLVM from the cache.
+      - name: Cache LLVM
+        id: cache-llvm
+        uses: actions/cache@v2
+        with:
+          path: llvm
+          key: ${{ runner.os }}-llvm-install-${{ steps.get-llvm-hash.outputs.hash }}
+
+      # Build LLVM if we didn't hit in the cache.
+      - name: Rebuild and Install LLVM
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        run: |
+          mkdir llvm/build
+          mkdir llvm/install
+          cd llvm/build
+          cmake ../llvm \
+            -DLLVM_BUILD_EXAMPLES=OFF \
+            -DLLVM_TARGETS_TO_BUILD="host" \
+            -DCMAKE_INSTALL_PREFIX=../install \
+            -DLLVM_ENABLE_PROJECTS='mlir' \
+            -DLLVM_OPTIMIZED_TABLEGEN=ON \
+            -DLLVM_ENABLE_OCAMLDOC=OFF \
+            -DLLVM_ENABLE_BINDINGS=OFF \
+            -DLLVM_INSTALL_UTILS=ON \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DLLVM_ENABLE_LLD=ON \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DLLVM_ENABLE_ASSERTIONS=ON
+          cmake --build . --target install -- -j$(nproc)
+
+      # --------
+      # Build and test CIRCT in both debug and release mode.
+      # --------
+
+      # Build the CIRCT test target in debug mode to build and test.
+      - name: Build and Test CIRCT (Assert)
+        run: |
+          mkdir build_assert
+          cd build_assert
+          cmake .. \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DLLVM_ENABLE_ASSERTIONS=ON \
+            -DMLIR_DIR=../llvm/install/lib/cmake/mlir/ \
+            -DLLVM_DIR=../llvm/install/lib/cmake/llvm/ \
+            -DCMAKE_LINKER=lld \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DLLVM_EXTERNAL_LIT=`pwd`/../llvm/build/bin/llvm-lit \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          make check-circt -j$(nproc)
+      - name: CIRCT integration tests (assert)
+        run: |
+          cd build_assert
+          make check-circt-integration
+
+      # Build the CIRCT test target in release mode to build and test.
+      - name: Build and Test CIRCT (Release)
+        run: |
+          mkdir build_release
+          cd build_release
+          cmake .. \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DLLVM_ENABLE_ASSERTIONS=OFF \
+            -DMLIR_DIR=../llvm/install/lib/cmake/mlir/ \
+            -DLLVM_DIR=../llvm/install/lib/cmake/llvm/ \
+            -DCMAKE_LINKER=lld \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DLLVM_EXTERNAL_LIT=`pwd`/../llvm/build/bin/llvm-lit
+          make check-circt -j$(nproc)
+      - name: CIRCT integration tests (release)
+        run: |
+          cd build_release
+          make check-circt-integration


### PR DESCRIPTION
Runs nightly or by request. Assisted by @stephenneuendorffer.

[Example build](https://github.com/llpm/circt/runs/1410544967):

![image](https://user-images.githubusercontent.com/1498080/99354274-066eed00-285b-11eb-85ad-8df3a972faba.png)
