### PR TITLE
[FIRRTL] Allow firrtl.instance in the body of firrtl.when

### DIFF
--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -502,7 +502,7 @@ Operation *InstanceOp::getReferencedModule() {
 static LogicalResult verifyInstanceOp(InstanceOp &instance) {
 
   // Check that this instance is inside a module.
-  auto module = dyn_cast<FModuleOp>(instance.getParentOp());
+  auto module = instance.getParentOfType<FModuleOp>();
   if (!module) {
     instance.emitOpError("should be embedded in a 'firrtl.module'");
     return failure();

--- a/test/FIRParser/basic.fir
+++ b/test/FIRParser/basic.fir
@@ -271,6 +271,13 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     myext.in <= i8
     printf(clock, reset, "Something interesting! %x", myext.out)
 
+    ; CHECK: firrtl.when %reset  {
+    when reset :
+      ; CHECK: [[reset_myext:%.+]] = firrtl.instance @MyExtModule {name = "reset_myext"} : !firrtl.bundle<in: flip<uint>, out: uint<8>>
+      inst reset_myext of MyExtModule
+      reset_myext.in <= i8
+    ; CHECK: }
+
     ; CHECK: firrtl.subaccess %_t[%i8] : (!firrtl.vector<uint<1>, 12>, !firrtl.uint<8>) -> !firrtl.uint<1>
     auto <= _t[i8]
 


### PR DESCRIPTION
firrtl.instance must be enclosed by a firrtl.module, but it may not be
the direct parent op. When verifying, using parentOfType will search all
parents of the firrtl.instance op during verification.  This allows a
firrtl.instance op to appear in the body of ops other than a module,
such as firrtl.when.

firrtl.when is still not handled during lowering to RTL.  Any
firrtl.instance occuring in the body will not be properly lower to an
rtl.instance.  This will cause verification to fail.