### PR TITLE
[Verilator] Make the error check more flexible

### DIFF
--- a/test/verilator/errors1.sv
+++ b/test/verilator/errors1.sv
@@ -7,7 +7,7 @@
 module main(
   input logic clk,
   input wire rst_n,
-// CHECK: %Warning-UNUSED: {{.*}}:9:14: Signal is not used: 'rst_n'
+// CHECK: %Warning-UNUSED: {{.*}}:9{{.*}} Signal is not used: 'rst_n'
   output logic [15:0] x
 );
 
@@ -16,6 +16,6 @@ module main(
 
   always@(posedge clk) begin
     x_int = x_int + 1;
-// CHECK: %Warning-BLKSEQ: {{.*}}:18:11: Blocking assignments (=) in sequential (flop or latch) block
+// CHECK: %Warning-BLKSEQ: {{.*}}:18{{.*}} Blocking assignments (=) in sequential (flop or latch) block
   end
 endmodule


### PR DESCRIPTION
Verilator changed its error reporting message format since 4.028 to
include the column number. This change is to make the tests backwards
compatible to 4.028 (at least).