### PR TITLE
[RTL] add `sext` and `zext` constant folding

### DIFF
--- a/include/circt/Dialect/RTL/Combinatorial.td
+++ b/include/circt/Dialect/RTL/Combinatorial.td
@@ -194,6 +194,7 @@ def SExtOp : RTLOp<"sext", [NoSideEffect]> {
     $input attr-dict `:` functional-type($input, $result)
   }];
 
+  let hasFolder = 1;
   let verifier = [{ return ::verifyExtOp(*this); }];
 }
 
@@ -207,6 +208,7 @@ def ZExtOp : RTLOp<"zext", [NoSideEffect]> {
     $input attr-dict `:` functional-type($input, $result)
   }];
 
+  let hasFolder = 1;
   let verifier = [{ return ::verifyExtOp(*this); }];
 }
 

--- a/lib/Dialect/RTL/Ops.cpp
+++ b/lib/Dialect/RTL/Ops.cpp
@@ -644,6 +644,32 @@ static LogicalResult verifyExtOp(Operation *op) {
   return success();
 }
 
+OpFoldResult ZExtOp::fold(ArrayRef<Attribute> operands) {
+  auto input = this->input();
+
+  // Constant fold
+  APInt value;
+  if (matchPattern(input, m_RConstant(value))) {
+    auto destWidth = getType().cast<IntegerType>().getWidth();
+    return getIntAttr(value.zext(destWidth), getContext());
+  }
+
+  return {};
+}
+
+OpFoldResult SExtOp::fold(ArrayRef<Attribute> operands) {
+  auto input = this->input();
+
+  // Constant fold
+  APInt value;
+  if (matchPattern(input, m_RConstant(value))) {
+    auto destWidth = getType().cast<IntegerType>().getWidth();
+    return getIntAttr(value.sext(destWidth), getContext());
+  }
+
+  return {};
+}
+
 //===----------------------------------------------------------------------===//
 // Other Operations
 //===----------------------------------------------------------------------===//

--- a/test/rtl/canonicalization.mlir
+++ b/test/rtl/canonicalization.mlir
@@ -409,3 +409,23 @@ func @multiply_reduction(%arg0: i11, %arg1: i11) -> i11 {
   %0 = rtl.mul %arg1, %c2_i11 : i11
   return %0 : i11
 }
+
+// CHECK-LABEL: func @zext_constant_folding() -> i5 {
+// CHECK-NEXT:  %c8_i5 = rtl.constant(8 : i5) : i5
+// CHECK-NEXT:  return %c8_i5 : i5
+
+func @zext_constant_folding() -> i5 {
+  %c8_i4 = rtl.constant(8 : i4) : i4
+  %0 = rtl.zext %c8_i4 : (i4) -> i5
+  return %0 : i5
+}
+
+// CHECK-LABEL: func @sext_constant_folding() -> i5 {
+// CHECK-NEXT:  %c-8_i5 = rtl.constant(-8 : i5) : i5
+// CHECK-NEXT:  return %c-8_i5 : i5
+
+func @sext_constant_folding() -> i5 {
+  %c8_i4 = rtl.constant(8 : i4) : i4
+  %0 = rtl.sext %c8_i4 : (i4) -> i5
+  return %0 : i5
+}


### PR DESCRIPTION
Adds some simple constant folding for `sext` and `zext`.  RTL's extension ops require the result width to be larger, so there is no folding of idempotent operations.