### PR TITLE
[FIRRTL] Move RTL lowering into a conversion library

### DIFF
--- a/include/circt/Conversion/CMakeLists.txt
+++ b/include/circt/Conversion/CMakeLists.txt
@@ -1,3 +1,8 @@
-add_subdirectory(LLHDToLLVM)
 add_subdirectory(FIRRTLToLLHD)
+add_subdirectory(LLHDToLLVM)
 
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls -name Conversion)
+add_public_tablegen_target(CIRCTConversionPassIncGen)
+
+add_mlir_doc(Passes -gen-pass-doc CIRCTConversionPasses ./)

--- a/include/circt/Conversion/FIRRTLToRTL/FIRRTLToRTL.h
+++ b/include/circt/Conversion/FIRRTLToRTL/FIRRTLToRTL.h
@@ -1,4 +1,4 @@
-//===- Passes.h - FIRRTL pass entry points ----------------------*- C++ -*-===//
+//===- FIRRTLToRTL.h - FIRRTL to RTL conversion pass ------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,12 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This header file defines prototypes that expose pass constructors.
+// This file declares passes which together will lower the FIRRTL dialect to
+// RTL and SV dialects.
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef CIRCT_DIALECT_FIRRTL_PASSES_H
-#define CIRCT_DIALECT_FIRRTL_PASSES_H
+#ifndef CIRCT_CONVERSION_FIRRTLTORTL_FIRRTLTORTL_H
+#define CIRCT_CONVERSION_FIRRTLTORTL_FIRRTLTORTL_H
 
 #include <memory>
 
@@ -22,9 +23,10 @@ class Pass;
 namespace circt {
 namespace firrtl {
 
-std::unique_ptr<mlir::Pass> createLowerFIRRTLTypesPass();
+std::unique_ptr<mlir::Pass> createLowerFIRRTLToRTLModulePass();
+std::unique_ptr<mlir::Pass> createLowerFIRRTLToRTLPass();
 
 } // namespace firrtl
 } // namespace circt
 
-#endif // CIRCT_DIALECT_FIRRTL_PASSES_H
+#endif // CIRCT_CONVERSION_FIRRTLTORTL_FIRRTLTORTL_H

--- a/include/circt/Conversion/Passes.h
+++ b/include/circt/Conversion/Passes.h
@@ -1,0 +1,27 @@
+//===- Passes.h - Conversion Pass Construction and Registration -*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This fle contains the declarations to register conversion passes.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_CONVERSION_PASSES_H
+#define CIRCT_CONVERSION_PASSES_H
+
+#include "circt/Conversion/FIRRTLToRTL/FIRRTLToRTL.h"
+#include "mlir/Pass/PassRegistry.h"
+
+namespace circt {
+
+// Generate the code for registering conversion passes.
+#define GEN_PASS_REGISTRATION
+#include "circt/Conversion/Passes.h.inc"
+
+} // namespace circt
+
+#endif // CIRCT_CONVERSION_PASSES_H

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -1,0 +1,41 @@
+//===-- Passes.td - Conversion pass definitions ------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains definitions for all dialect conversions.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_CONVERSION_PASSES_TD
+#define CIRCT_CONVERSION_PASSES_TD
+
+include "mlir/Pass/PassBase.td"
+
+//===----------------------------------------------------------------------===//
+// FIRRTLToRTL
+//===----------------------------------------------------------------------===//
+
+def LowerFIRRTLToRTLModule
+  : Pass<"lower-firrtl-to-rtl-module", "mlir::ModuleOp"> {
+  let summary = "Lower FIRRTL to RTL Modules";
+  let description = [{
+    Lower firrtl.module's to rtl.module.
+  }];
+  let constructor = "circt::firrtl::createLowerFIRRTLToRTLModulePass()";
+  let dependentDialects = ["rtl::RTLDialect"];
+}
+
+def LowerFIRRTLToRTL : Pass<"lower-firrtl-to-rtl", "rtl::RTLModuleOp"> {
+  let summary = "Lower FIRRTL to RTL";
+  let description = [{
+    Lower the contents of an firrtl.module to the RTL dialect.
+  }];
+  let constructor = "circt::firrtl::createLowerFIRRTLToRTLPass()";
+  let dependentDialects = ["rtl::RTLDialect", "sv::SVDialect"];
+}
+
+#endif // CIRCT_CONVERSION_PASSES_TD

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -9,23 +9,12 @@
 
 include "mlir/Pass/PassBase.td"
 
-/// Lower firrtl.module port types to ground types.
 def LowerFIRRTLTypes : Pass<"lower-firrtl-types", "firrtl::FModuleOp"> {
   let summary = "Lower FIRRTL types to ground types";
+  let description = [{
+    Lower firrtl.module port types to ground types.
+  }];
   let constructor = "circt::firrtl::createLowerFIRRTLTypesPass()";
-}
-
-/// Lower firrtl.module's to rtl.module.
-def LowerFIRRTLToRTLModule
-  : Pass<"lower-firrtl-to-rtl-module", "ModuleOp"> {
-  let summary = "Lower FIRRTL to RTL Modules";
-  let constructor = "circt::firrtl::createLowerFIRRTLToRTLModulePass()";
-}
-
-/// Lower the contents of an firrtl.module to the RTL dialect.
-def LowerFIRRTLToRTL : Pass<"lower-firrtl-to-rtl", "rtl::RTLModuleOp"> {
-  let summary = "Lower FIRRTL to RTL";
-  let constructor = "circt::firrtl::createLowerFIRRTLToRTLPass()";
 }
 
 #endif // CIRCT_DIALECT_FIRRTL_PASSES_TD

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -1,5 +1,6 @@
-add_subdirectory(StandardToHandshake)
+add_subdirectory(FIRRTLToLLHD)
+add_subdirectory(FIRRTLToRTL)
 add_subdirectory(HandshakeToFIRRTL)
 add_subdirectory(LLHDToLLVM)
+add_subdirectory(StandardToHandshake)
 add_subdirectory(StandardToStaticLogic)
-add_subdirectory(FIRRTLToLLHD)

--- a/lib/Conversion/FIRRTLToRTL/CMakeLists.txt
+++ b/lib/Conversion/FIRRTLToRTL/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_mlir_conversion_library(MLIRFIRRTLToRTL
+  LowerToRTL.cpp
+
+  DEPENDS
+  CIRCTConversionPassIncGen
+
+  LINK_COMPONENTS
+  Core
+
+  LINK_LIBS PUBLIC
+  MLIRFIRRTL
+  MLIRRTL
+  MLIRSV
+  MLIRTransforms
+)

--- a/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
+++ b/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
@@ -2,7 +2,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "PassDetails.h"
+#include "../PassDetail.h"
+#include "circt/Conversion/FIRRTLToRTL/FIRRTLToRTL.h"
 #include "circt/Dialect/FIRRTL/Ops.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/FIRRTL/Visitors.h"
@@ -11,6 +12,7 @@
 #include "circt/Support/ImplicitLocOpBuilder.h"
 #include "mlir/IR/StandardTypes.h"
 #include "mlir/Pass/Pass.h"
+
 using namespace circt;
 using namespace firrtl;
 

--- a/lib/Conversion/PassDetail.h
+++ b/lib/Conversion/PassDetail.h
@@ -1,0 +1,36 @@
+//===- PassDetail.h - Conversion Pass class details -------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CONVERSION_PASSDETAIL_H
+#define CONVERSION_PASSDETAIL_H
+
+#include "mlir/Pass/Pass.h"
+
+namespace circt {
+
+namespace firrtl {
+class FIRRTLDialect;
+class FModuleOp;
+} // namespace firrtl
+
+namespace rtl {
+class RTLDialect;
+class RTLModuleOp;
+} // namespace rtl
+
+namespace sv {
+class SVDialect;
+} // namespace sv
+
+// Generate the classes which represent the passes
+#define GEN_PASS_CLASSES
+#include "circt/Conversion/Passes.h.inc"
+
+} // namespace circt
+
+#endif // CONVERSION_PASSDETAIL_H

--- a/lib/Dialect/FIRRTL/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/CMakeLists.txt
@@ -15,8 +15,6 @@ add_mlir_dialect_library(MLIRFIRRTL
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRPass
-  MLIRRTL
-  MLIRSV
-   )
+  )
 
 add_dependencies(mlir-headers MLIRFIRRTLIncGen MLIRFIRRTLEnumsIncGen)

--- a/lib/Dialect/FIRRTL/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/LowerTypes.cpp
@@ -5,12 +5,14 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //===----------------------------------------------------------------------===//
 
-#include "PassDetails.h"
+#include "./PassDetails.h"
+#include "circt/Conversion/FIRRTLToRTL/FIRRTLToRTL.h"
 #include "circt/Dialect/FIRRTL/Ops.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/FIRRTL/Types.h"
 #include "circt/Dialect/FIRRTL/Visitors.h"
 #include "circt/Support/ImplicitLocOpBuilder.h"
+
 using namespace circt;
 using namespace firrtl;
 

--- a/tools/circt-opt/CMakeLists.txt
+++ b/tools/circt-opt/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(circt-opt
   MLIRLLHDTransforms
   MLIRLLHDToLLVM
   MLIRFIRRTLToLLHD
+  MLIRFIRRTLToRTL
 
   MLIRParser
   MLIRSupport

--- a/tools/circt-opt/circt-opt.cpp
+++ b/tools/circt-opt/circt-opt.cpp
@@ -8,6 +8,7 @@
 #include "circt/Conversion/FIRRTLToLLHD/FIRRTLToLLHD.h"
 #include "circt/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.h"
 #include "circt/Conversion/LLHDToLLVM/LLHDToLLVM.h"
+#include "circt/Conversion/Passes.h"
 #include "circt/Conversion/StandardToHandshake/StandardToHandshake.h"
 #include "circt/Conversion/StandardToStaticLogic/StandardToStaticLogic.h"
 #include "circt/Dialect/ESI/ESIDialect.h"
@@ -110,6 +111,8 @@ int main(int argc, char **argv) {
   llhd::initLLHDTransformationPasses();
   llhd::initLLHDToLLVMPass();
   llhd::registerFIRRTLToLLHDPasses();
+
+  registerConversionPasses();
 
   PassPipelineCLParser passPipeline("", "Compiler passes to run");
 

--- a/tools/firtool/CMakeLists.txt
+++ b/tools/firtool/CMakeLists.txt
@@ -9,6 +9,7 @@ llvm_update_compile_flags(firtool)
 target_link_libraries(firtool PRIVATE
   CIRCTEmitVerilog
   CIRCTFIRParser
+  MLIRFIRRTLToRTL
 
   MLIRParser
   MLIRSupport

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -5,6 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "circt/Conversion/Passes.h"
 #include "circt/Dialect/FIRRTL/Dialect.h"
 #include "circt/Dialect/FIRRTL/Ops.h"
 #include "circt/Dialect/FIRRTL/Passes.h"


### PR DESCRIPTION
Move the RTL lowering passes into a FIRRTLToRTL conversion library.
This moves most of the code for lowering from `circt/Dialect/FIRRTL/`
into `circt/Conversion/FIRRTLToRTL/`.

This change creates a new file called `circt/Conversion/Passes.td`,
where all CIRCT conversion passes should be declared.  Any conversion
pass defined in this file can be registered in tools with a single call
`circt::registerConversionPasses()`. This idea is taken from MLIR.