### PR TITLE
[FIRRTL] Implement initial verifications for ConnectOp.

### DIFF
--- a/include/circt/Dialect/FIRRTL/OpStatements.td
+++ b/include/circt/Dialect/FIRRTL/OpStatements.td
@@ -44,6 +44,8 @@ def ConnectOp : FIRRTLOp<"connect", []> {
   let assemblyFormat = [{
     $dest `,` $src  attr-dict `:` type($dest) `,` type($src)
   }];
+
+  let verifier = [{ return ::verifyConnectOp(*this); }];
 }
 
 def PartialConnectOp : FIRRTLOp<"partialconnect", []> {

--- a/include/circt/Dialect/FIRRTL/Types.h
+++ b/include/circt/Dialect/FIRRTL/Types.h
@@ -71,7 +71,10 @@ protected:
 };
 
 /// Returns whether the two types are equivalent. See the FIRRTL spec for the
-/// full definition of type equivalence.
+/// full definition of type equivalence. This predicate differs from the spec in
+/// that it only compares passive types. Because of how the FIRRTL dialect uses
+/// flip types in module ports and aggregates, this definition, unlike the spec,
+/// ignores flips.
 bool areTypesEquivalent(FIRRTLType destType, FIRRTLType srcType);
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/Types.h
+++ b/include/circt/Dialect/FIRRTL/Types.h
@@ -70,6 +70,10 @@ protected:
   using Type::Type;
 };
 
+/// Returns whether the two types are equivalent. See the FIRRTL spec for the
+/// full definition of type equivalence.
+bool areTypesEquivalent(FIRRTLType destType, FIRRTLType srcType);
+
 //===----------------------------------------------------------------------===//
 // Ground Types Without Parameters
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -711,7 +711,7 @@ static bool areElementsConnectEquivalent(
   FIRRTLType destElementType = std::get<1>(destElement);
   bool destIsFlip = destElementType.isa<FlipType>();
 
-  BundleType::BundleElement srcElement = std::get<0>(tuple);
+  BundleType::BundleElement srcElement = std::get<1>(tuple);
   Identifier srcElementName = std::get<0>(srcElement);
   FIRRTLType srcElementType = std::get<1>(srcElement);
   bool srcIsFlip = srcElementType.isa<FlipType>();

--- a/lib/Dialect/FIRRTL/Types.cpp
+++ b/lib/Dialect/FIRRTL/Types.cpp
@@ -302,6 +302,10 @@ bool FIRRTLType::isResetType() {
 }
 
 /// Helper to implement the equivalence logic for a pair of bundle elements.
+/// Note that the FIRRTL spec requires bundle elements to have the same
+/// orientation, but this only compares their passive types. The FIRRTL dialect
+/// differs from the spec in how it uses flip types for module output ports and
+/// canonicalizes flips in bundles, so only passive types can be compared here.
 static bool areBundleElementsEquivalent(BundleType::BundleElement destElement,
                                         BundleType::BundleElement srcElement) {
   Identifier destElementName = std::get<0>(destElement);
@@ -315,7 +319,10 @@ static bool areBundleElementsEquivalent(BundleType::BundleElement destElement,
 }
 
 /// Returns whether the two types are equivalent. See the FIRRTL spec for the
-/// full definition of type equivalence.
+/// full definition of type equivalence. This predicate differs from the spec in
+/// that it only compares passive types. Because of how the FIRRTL dialect uses
+/// flip types in module ports and aggregates, this definition, unlike the spec,
+/// ignores flips.
 bool firrtl::areTypesEquivalent(FIRRTLType destType, FIRRTLType srcType) {
   // Ensure we are comparing passive types.
   if (!destType.isPassive())

--- a/lib/Dialect/FIRRTL/Types.cpp
+++ b/lib/Dialect/FIRRTL/Types.cpp
@@ -301,6 +301,68 @@ bool FIRRTLType::isResetType() {
       .Default([](Type) { return false; });
 }
 
+/// Helper to implement the equivalence logic for a pair of bundle elements.
+static bool areBundleElementsEquivalent(BundleType::BundleElement destElement,
+                                        BundleType::BundleElement srcElement) {
+  Identifier destElementName = std::get<0>(destElement);
+  Identifier srcElementName = std::get<0>(srcElement);
+  if (destElementName != srcElementName)
+    return false;
+
+  FIRRTLType destElementType = std::get<1>(destElement);
+  FIRRTLType srcElementType = std::get<1>(srcElement);
+  return areTypesEquivalent(destElementType, srcElementType);
+}
+
+/// Returns whether the two types are equivalent. See the FIRRTL spec for the
+/// full definition of type equivalence.
+bool firrtl::areTypesEquivalent(FIRRTLType destType, FIRRTLType srcType) {
+  // Ensure we are comparing passive types.
+  if (!destType.isPassive())
+    destType = destType.getPassiveType();
+  if (!srcType.isPassive())
+    srcType = srcType.getPassiveType();
+
+  // Reset types can be driven by UInt<1>, AsyncReset, or Reset types.
+  if (destType.isa<ResetType>())
+    return srcType.isResetType();
+
+  // Reset types can drive UInt<1>, AsyncReset, or Reset types.
+  if (srcType.isa<ResetType>())
+    return destType.isResetType();
+
+  // Vector types can be connected if they have the same size and element type.
+  auto destVectorType = destType.dyn_cast<FVectorType>();
+  auto srcVectorType = srcType.dyn_cast<FVectorType>();
+  if (destVectorType && srcVectorType)
+    return destVectorType.getNumElements() == srcVectorType.getNumElements() &&
+           areTypesEquivalent(destVectorType.getElementType(),
+                              srcVectorType.getElementType());
+
+  // Bundle types can be connected if they have the same size, element names,
+  // and element types.
+  auto destBundleType = destType.dyn_cast<BundleType>();
+  auto srcBundleType = srcType.dyn_cast<BundleType>();
+  if (destBundleType && srcBundleType) {
+    auto destElements = destBundleType.getElements();
+    auto srcElements = srcBundleType.getElements();
+    size_t numDestElements = destElements.size();
+    if (numDestElements != srcElements.size())
+      return false;
+
+    for (size_t i = 0; i < numDestElements; ++i) {
+      auto destElement = destElements[i];
+      auto srcElement = srcElements[i];
+      if (!areBundleElementsEquivalent(destElement, srcElement))
+        return false;
+    }
+  }
+
+  // Ground types can be connected if their passive, widthless versions
+  // are equal.
+  return destType.getWidthlessType() == srcType.getWidthlessType();
+}
+
 //===----------------------------------------------------------------------===//
 // IntType
 //===----------------------------------------------------------------------===//

--- a/test/FIRParser/basic.fir
+++ b/test/FIRParser/basic.fir
@@ -69,6 +69,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input reset_abstract: Reset   ; CHECK: %reset_abstract: !firrtl.reset,
     input clock : Clock           ; CHECK: %clock: !firrtl.clock,
     output auto : UInt<1>         ; CHECK: %auto: !firrtl.flip<uint<1>>,
+    output sauto : SInt<1>        ; CHECK: %sauto: !firrtl.flip<sint<1>>,
     input i8 : UInt<8>            ; CHECK: %i8: !firrtl.uint<8>,
     input s1 : SInt<1>            ; CHECK: %s1: !firrtl.sint<1>,
     input s8 : SInt<8>            ; CHECK: %s8: !firrtl.sint<8>,
@@ -78,13 +79,13 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %_t = firrtl.wire {name = "_t"} : !firrtl.vector<uint<1>, 12>
     wire _t : UInt<1>[12] @[Nodes.scala 370:76]
 
-    ; CHECK: %_t_2 = firrtl.wire {name = "_t_2"} : !firrtl.vector<uint<1>, 13>
-    wire _t_2 : UInt<1>[13]
+    ; CHECK: %_t_2 = firrtl.wire {name = "_t_2"} : !firrtl.vector<uint<1>, 12>
+    wire _t_2 : UInt<1>[12]
 
     ; CHECK: %out_0 = firrtl.wire {name = "out_0"} : !firrtl.bundle<member: bundle<0: bundle<clock: clock, reset: uint<1>>>>
     wire out_0 : { member : { 0 : { clock : Clock, reset : UInt<1>}}}
 
-    ; CHECK: firrtl.connect %_t, %_t_2 : !firrtl.vector<uint<1>, 12>, !firrtl.vector<uint<1>, 13>
+    ; CHECK: firrtl.connect %_t, %_t_2 : !firrtl.vector<uint<1>, 12>, !firrtl.vector<uint<1>, 12>
     _t <= _t_2
 
     ; CHECK: firrtl.partialconnect %_t, %_t_2
@@ -105,7 +106,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.partialconnect %auto, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
     auto <- out_0.member.0.reset @[Field 173:49]
 
-    ; CHECK: %3 = firrtl.subindex %_t_2[0] : (!firrtl.vector<uint<1>, 13>) -> !firrtl.uint<1>
+    ; CHECK: %3 = firrtl.subindex %_t_2[0] : (!firrtl.vector<uint<1>, 12>) -> !firrtl.uint<1>
     ; CHECK: %4 = firrtl.subindex %_t[0] : (!firrtl.vector<uint<1>, 12>) -> !firrtl.uint<1>
     ; CHECK: firrtl.connect %3, %4
     _t_2[0] <= _t[0] @[Xbar.scala 21:44]
@@ -178,7 +179,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     auto <= add(UInt<10>(42), UInt<8>("hAB"))
 
     ; CHECK: %c-85_si8 = firrtl.constant(-85 : si8) : !firrtl.sint<8>
-    auto <= add(s8, SInt<8>("hAB"))
+    sauto <= add(s8, SInt<8>("hAB"))
 
     ; CHECK: firrtl.when %reset {
     ; CHECK:   firrtl.connect %_t, %_t_2
@@ -210,7 +211,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     when lt(reset, UInt(4)) :   ;; When with no else.
       _t <= _t_2
 
-    ; CHECK: firrtl.printf %clock, %reset, "Something interesting!\0A %x %x"(%_t, %_t_2) : !firrtl.vector<uint<1>, 12>, !firrtl.vector<uint<1>, 13>
+    ; CHECK: firrtl.printf %clock, %reset, "Something interesting!\0A %x %x"(%_t, %_t_2) : !firrtl.vector<uint<1>, 12>, !firrtl.vector<uint<1>, 12>
     printf(clock, reset, "Something interesting!\n %x %x", _t, _t_2)
 
     ; CHECK: firrtl.stop %clock, %reset, 42
@@ -506,4 +507,4 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       ; CHECK:         %bar = firrtl.mem "Undefined" {depth = 1 : i64, name = "bar", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<MPORT: bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<3>, mask: uint<1>>, io_deq_bits_MPORT: bundle<addr: uint<1>, en: uint<1>, clk: clock, data: flip<uint<3>>>>
 
  
- 
+

--- a/test/firrtl/connect.mlir
+++ b/test/firrtl/connect.mlir
@@ -7,7 +7,7 @@
 firrtl.circuit "test" {
 
 firrtl.module @test(%a : !firrtl.analog, %b : !firrtl.flip<analog>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<analog>' and source '!firrtl.analog'}}
+  // expected-error @+1 {{analog types may not be connected}}
   firrtl.connect %b, %a : !firrtl.flip<analog>, !firrtl.analog
 }
 
@@ -18,7 +18,7 @@ firrtl.module @test(%a : !firrtl.analog, %b : !firrtl.flip<analog>) {
 firrtl.circuit "test" {
 
 firrtl.module @test(%a : !firrtl.analog, %b : !firrtl.flip<uint<1>>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<uint<1>>' and source '!firrtl.analog'}}
+  // expected-error @+1 {{analog types may not be connected}}
   firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.analog
 }
 
@@ -29,7 +29,7 @@ firrtl.module @test(%a : !firrtl.analog, %b : !firrtl.flip<uint<1>>) {
 firrtl.circuit "test" {
 
 firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<analog>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<analog>' and source '!firrtl.uint<1>'}}
+  // expected-error @+1 {{analog types may not be connected}}
   firrtl.connect %b, %a : !firrtl.flip<analog>, !firrtl.uint<1>
 }
 
@@ -77,7 +77,7 @@ firrtl.module @test(%a : !firrtl.reset, %b : !firrtl.flip<asyncreset>) {
 firrtl.circuit "test" {
 
 firrtl.module @test(%a : !firrtl.reset, %b : !firrtl.flip<uint<2>>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<uint<2>>' and source '!firrtl.reset'}}
+  // expected-error @+1 {{type mismatch between destination '!firrtl.uint<2>' and source '!firrtl.reset'}}
   firrtl.connect %b, %a : !firrtl.flip<uint<2>>, !firrtl.reset
 }
 
@@ -88,7 +88,7 @@ firrtl.module @test(%a : !firrtl.reset, %b : !firrtl.flip<uint<2>>) {
 firrtl.circuit "test" {
 
 firrtl.module @test(%a : !firrtl.reset, %b : !firrtl.flip<sint<1>>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<sint<1>>' and source '!firrtl.reset'}}
+  // expected-error @+1 {{type mismatch between destination '!firrtl.sint<1>' and source '!firrtl.reset'}}
   firrtl.connect %b, %a : !firrtl.flip<sint<1>>, !firrtl.reset
 }
 
@@ -123,7 +123,7 @@ firrtl.module @test(%a : !firrtl.asyncreset, %b : !firrtl.flip<reset>) {
 firrtl.circuit "test" {
 
 firrtl.module @test(%a : !firrtl.uint<2>, %b : !firrtl.flip<reset>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<reset>' and source '!firrtl.uint<2>'}}
+  // expected-error @+1 {{type mismatch between destination '!firrtl.reset' and source '!firrtl.uint<2>'}}
   firrtl.connect %b, %a : !firrtl.flip<reset>, !firrtl.uint<2>
 }
 
@@ -134,7 +134,7 @@ firrtl.module @test(%a : !firrtl.uint<2>, %b : !firrtl.flip<reset>) {
 firrtl.circuit "test" {
 
 firrtl.module @test(%a : !firrtl.sint<1>, %b : !firrtl.flip<reset>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<reset>' and source '!firrtl.sint<1>'}}
+  // expected-error @+1 {{type mismatch between destination '!firrtl.reset' and source '!firrtl.sint<1>'}}
   firrtl.connect %b, %a : !firrtl.flip<reset>, !firrtl.sint<1>
 }
 
@@ -171,7 +171,7 @@ firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<uint<2>>) {
 firrtl.circuit "test" {
 
 firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<sint<1>>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<sint<1>>' and source '!firrtl.uint<1>'}}
+  // expected-error @+1 {{type mismatch between destination '!firrtl.sint<1>' and source '!firrtl.uint<1>'}}
   firrtl.connect %b, %a : !firrtl.flip<sint<1>>, !firrtl.uint<1>
 }
 
@@ -182,7 +182,7 @@ firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<sint<1>>) {
 firrtl.circuit "test" {
 
 firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<clock>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<clock>' and source '!firrtl.uint<1>'}}
+  // expected-error @+1 {{type mismatch between destination '!firrtl.clock' and source '!firrtl.uint<1>'}}
   firrtl.connect %b, %a : !firrtl.flip<clock>, !firrtl.uint<1>
 }
 
@@ -193,7 +193,7 @@ firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<clock>) {
 firrtl.circuit "test" {
 
 firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<asyncreset>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<asyncreset>' and source '!firrtl.uint<1>'}}
+  // expected-error @+1 {{type mismatch between destination '!firrtl.asyncreset' and source '!firrtl.uint<1>'}}
   firrtl.connect %b, %a : !firrtl.flip<asyncreset>, !firrtl.uint<1>
 }
 
@@ -217,7 +217,7 @@ firrtl.module @test(%a : !firrtl.sint<1>, %b : !firrtl.flip<sint<1>>) {
 firrtl.circuit "test" {
 
 firrtl.module @test(%a : !firrtl.sint<1>, %b : !firrtl.flip<uint<1>>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<uint<1>>' and source '!firrtl.sint<1>'}}
+  // expected-error @+1 {{type mismatch between destination '!firrtl.uint<1>' and source '!firrtl.sint<1>'}}
   firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.sint<1>
 }
 
@@ -228,7 +228,7 @@ firrtl.module @test(%a : !firrtl.sint<1>, %b : !firrtl.flip<uint<1>>) {
 firrtl.circuit "test" {
 
 firrtl.module @test(%a : !firrtl.sint<1>, %b : !firrtl.flip<clock>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<clock>' and source '!firrtl.sint<1>'}}
+  // expected-error @+1 {{type mismatch between destination '!firrtl.clock' and source '!firrtl.sint<1>'}}
   firrtl.connect %b, %a : !firrtl.flip<clock>, !firrtl.sint<1>
 }
 
@@ -239,7 +239,7 @@ firrtl.module @test(%a : !firrtl.sint<1>, %b : !firrtl.flip<clock>) {
 firrtl.circuit "test" {
 
 firrtl.module @test(%a : !firrtl.sint<1>, %b : !firrtl.flip<asyncreset>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<asyncreset>' and source '!firrtl.sint<1>'}}
+  // expected-error @+1 {{type mismatch between destination '!firrtl.asyncreset' and source '!firrtl.sint<1>'}}
   firrtl.connect %b, %a : !firrtl.flip<asyncreset>, !firrtl.sint<1>
 }
 
@@ -263,7 +263,7 @@ firrtl.module @test(%a : !firrtl.clock, %b : !firrtl.flip<clock>) {
 firrtl.circuit "test" {
 
 firrtl.module @test(%a : !firrtl.clock, %b : !firrtl.flip<uint<1>>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<uint<1>>' and source '!firrtl.clock'}}
+  // expected-error @+1 {{type mismatch between destination '!firrtl.uint<1>' and source '!firrtl.clock'}}
   firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.clock
 }
 
@@ -274,7 +274,7 @@ firrtl.module @test(%a : !firrtl.clock, %b : !firrtl.flip<uint<1>>) {
 firrtl.circuit "test" {
 
 firrtl.module @test(%a : !firrtl.clock, %b : !firrtl.flip<sint<1>>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<sint<1>>' and source '!firrtl.clock'}}
+  // expected-error @+1 {{type mismatch between destination '!firrtl.sint<1>' and source '!firrtl.clock'}}
   firrtl.connect %b, %a : !firrtl.flip<sint<1>>, !firrtl.clock
 }
 
@@ -285,7 +285,7 @@ firrtl.module @test(%a : !firrtl.clock, %b : !firrtl.flip<sint<1>>) {
 firrtl.circuit "test" {
 
 firrtl.module @test(%a : !firrtl.clock, %b : !firrtl.flip<asyncreset>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<asyncreset>' and source '!firrtl.clock'}}
+  // expected-error @+1 {{type mismatch between destination '!firrtl.asyncreset' and source '!firrtl.clock'}}
   firrtl.connect %b, %a : !firrtl.flip<asyncreset>, !firrtl.clock
 }
 
@@ -308,7 +308,7 @@ firrtl.module @test(%a : !firrtl.asyncreset, %b : !firrtl.flip<asyncreset>) {
 firrtl.circuit "test" {
 
 firrtl.module @test(%a : !firrtl.asyncreset, %b : !firrtl.flip<uint<1>>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<uint<1>>' and source '!firrtl.asyncreset'}}
+  // expected-error @+1 {{type mismatch between destination '!firrtl.uint<1>' and source '!firrtl.asyncreset'}}
   firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.asyncreset
 }
 
@@ -319,7 +319,7 @@ firrtl.module @test(%a : !firrtl.asyncreset, %b : !firrtl.flip<uint<1>>) {
 firrtl.circuit "test" {
 
 firrtl.module @test(%a : !firrtl.asyncreset, %b : !firrtl.flip<sint<1>>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<sint<1>>' and source '!firrtl.asyncreset'}}
+  // expected-error @+1 {{type mismatch between destination '!firrtl.sint<1>' and source '!firrtl.asyncreset'}}
   firrtl.connect %b, %a : !firrtl.flip<sint<1>>, !firrtl.asyncreset
 }
 
@@ -330,7 +330,7 @@ firrtl.module @test(%a : !firrtl.asyncreset, %b : !firrtl.flip<sint<1>>) {
 firrtl.circuit "test" {
 
 firrtl.module @test(%a : !firrtl.asyncreset, %b : !firrtl.flip<clock>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<clock>' and source '!firrtl.asyncreset'}}
+  // expected-error @+1 {{type mismatch between destination '!firrtl.clock' and source '!firrtl.asyncreset'}}
   firrtl.connect %b, %a : !firrtl.flip<clock>, !firrtl.asyncreset
 }
 
@@ -354,7 +354,7 @@ firrtl.module @test(%a : !firrtl.vector<uint<1>, 3>, %b : !firrtl.flip<vector<ui
 firrtl.circuit "test" {
 
 firrtl.module @test(%a : !firrtl.vector<uint<1>, 3>, %b : !firrtl.flip<vector<uint<1>, 2>>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<vector<uint<1>, 2>>' and source '!firrtl.vector<uint<1>, 3>'}}
+  // expected-error @+1 {{type mismatch between destination '!firrtl.vector<uint<1>, 2>' and source '!firrtl.vector<uint<1>, 3>'}}
   firrtl.connect %b, %a : !firrtl.flip<vector<uint<1>, 2>>, !firrtl.vector<uint<1>, 3>
 }
 
@@ -365,7 +365,7 @@ firrtl.module @test(%a : !firrtl.vector<uint<1>, 3>, %b : !firrtl.flip<vector<ui
 firrtl.circuit "test" {
 
 firrtl.module @test(%a : !firrtl.vector<uint<1>, 3>, %b : !firrtl.flip<vector<sint<1>, 3>>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<vector<sint<1>, 3>>' and source '!firrtl.vector<uint<1>, 3>'}}
+  // expected-error @+1 {{type mismatch between destination '!firrtl.vector<sint<1>, 3>' and source '!firrtl.vector<uint<1>, 3>'}}
   firrtl.connect %b, %a : !firrtl.flip<vector<sint<1>, 3>>, !firrtl.vector<uint<1>, 3>
 }
 
@@ -401,7 +401,7 @@ firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>, f2: flip<sint<2>>>, %b : !f
 firrtl.circuit "test" {
 
 firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>>, %b : !firrtl.bundle<f1: flip<uint<1>>, f2: sint<1>>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.bundle<f1: flip<uint<1>>, f2: sint<1>>' and source '!firrtl.bundle<f1: uint<1>>'}}
+  // expected-error @+1 {{type mismatch between destination '!firrtl.bundle<f1: uint<1>, f2: sint<1>>' and source '!firrtl.bundle<f1: uint<1>>'}}
   firrtl.connect %b, %a : !firrtl.bundle<f1: flip<uint<1>>, f2: sint<1>>, !firrtl.bundle<f1: uint<1>>
 }
 
@@ -412,7 +412,7 @@ firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>>, %b : !firrtl.bundle<f1: fl
 firrtl.circuit "test" {
 
 firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>>, %b : !firrtl.bundle<f2: flip<uint<1>>>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<bundle<f2: uint<1>>>' and source '!firrtl.bundle<f1: uint<1>>'}}
+  // expected-error @+1 {{type mismatch between destination '!firrtl.bundle<f2: uint<1>>' and source '!firrtl.bundle<f1: uint<1>>'}}
   firrtl.connect %b, %a : !firrtl.bundle<f2: flip<uint<1>>>, !firrtl.bundle<f1: uint<1>>
 }
 
@@ -423,7 +423,7 @@ firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>>, %b : !firrtl.bundle<f2: fl
 firrtl.circuit "test" {
 
 firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>>, %b : !firrtl.bundle<f1: flip<sint<1>>>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<bundle<f1: sint<1>>>' and source '!firrtl.bundle<f1: uint<1>>'}}
+  // expected-error @+1 {{type mismatch between destination '!firrtl.bundle<f1: sint<1>>' and source '!firrtl.bundle<f1: uint<1>>'}}
   firrtl.connect %b, %a : !firrtl.bundle<f1: flip<sint<1>>>, !firrtl.bundle<f1: uint<1>>
 }
 

--- a/test/firrtl/connect.mlir
+++ b/test/firrtl/connect.mlir
@@ -1,0 +1,408 @@
+// RUN: circt-opt %s -split-input-file -verify-diagnostics
+
+/// Analog types cannot be connected and must be attached.
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.analog, %b : !firrtl.flip<analog>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<analog>' and source '!firrtl.analog'}}
+  firrtl.connect %b, %a : !firrtl.flip<analog>, !firrtl.analog
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.analog, %b : !firrtl.flip<uint<1>>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<uint<1>>' and source '!firrtl.analog'}}
+  firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.analog
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<analog>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<analog>' and source '!firrtl.uint<1>'}}
+  firrtl.connect %b, %a : !firrtl.flip<analog>, !firrtl.uint<1>
+}
+
+}
+
+/// Reset types can be connected to Reset, UInt<1>, or AsyncReset types.
+
+// Reset source.
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.reset, %b : !firrtl.flip<reset>) {
+  // CHECK: firrtl.connect %b, %a
+  firrtl.connect %b, %a : !firrtl.flip<reset>, !firrtl.reset
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.reset, %b : !firrtl.flip<uint<1>>) {
+  // CHECK: firrtl.connect %b, %a
+  firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.reset
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.reset, %b : !firrtl.flip<asyncreset>) {
+  // CHECK: firrtl.connect %b, %a
+  firrtl.connect %b, %a : !firrtl.flip<asyncreset>, !firrtl.reset
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.reset, %b : !firrtl.flip<uint<2>>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<uint<2>>' and source '!firrtl.reset'}}
+  firrtl.connect %b, %a : !firrtl.flip<uint<2>>, !firrtl.reset
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.reset, %b : !firrtl.flip<sint<1>>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<sint<1>>' and source '!firrtl.reset'}}
+  firrtl.connect %b, %a : !firrtl.flip<sint<1>>, !firrtl.reset
+}
+
+}
+
+// Reset destination.
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<reset>) {
+  // CHECK: firrtl.connect %b, %a
+  firrtl.connect %b, %a : !firrtl.flip<reset>, !firrtl.uint<1>
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.asyncreset, %b : !firrtl.flip<reset>) {
+  // CHECK: firrtl.connect %b, %a
+  firrtl.connect %b, %a : !firrtl.flip<reset>, !firrtl.asyncreset
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.uint<2>, %b : !firrtl.flip<reset>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<reset>' and source '!firrtl.uint<2>'}}
+  firrtl.connect %b, %a : !firrtl.flip<reset>, !firrtl.uint<2>
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.sint<1>, %b : !firrtl.flip<reset>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<reset>' and source '!firrtl.sint<1>'}}
+  firrtl.connect %b, %a : !firrtl.flip<reset>, !firrtl.sint<1>
+}
+
+}
+
+/// Ground types can be connected if they are the same ground type.
+
+// UInt<> source.
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<uint<1>>) {
+  // CHECK: firrtl.connect %b, %a
+  firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<sint<1>>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<sint<1>>' and source '!firrtl.uint<1>'}}
+  firrtl.connect %b, %a : !firrtl.flip<sint<1>>, !firrtl.uint<1>
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<clock>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<clock>' and source '!firrtl.uint<1>'}}
+  firrtl.connect %b, %a : !firrtl.flip<clock>, !firrtl.uint<1>
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<asyncreset>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<asyncreset>' and source '!firrtl.uint<1>'}}
+  firrtl.connect %b, %a : !firrtl.flip<asyncreset>, !firrtl.uint<1>
+}
+
+}
+
+// SInt<> source.
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.sint<1>, %b : !firrtl.flip<sint<1>>) {
+  // CHECK: firrtl.connect %b, %a
+  firrtl.connect %b, %a : !firrtl.flip<sint<1>>, !firrtl.sint<1>
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.sint<1>, %b : !firrtl.flip<uint<1>>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<uint<1>>' and source '!firrtl.sint<1>'}}
+  firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.sint<1>
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.sint<1>, %b : !firrtl.flip<clock>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<clock>' and source '!firrtl.sint<1>'}}
+  firrtl.connect %b, %a : !firrtl.flip<clock>, !firrtl.sint<1>
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.sint<1>, %b : !firrtl.flip<asyncreset>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<asyncreset>' and source '!firrtl.sint<1>'}}
+  firrtl.connect %b, %a : !firrtl.flip<asyncreset>, !firrtl.sint<1>
+}
+
+}
+
+// Clock source.
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.clock, %b : !firrtl.flip<clock>) {
+  // CHECK: firrtl.connect %b, %a
+  firrtl.connect %b, %a : !firrtl.flip<clock>, !firrtl.clock
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.clock, %b : !firrtl.flip<uint<1>>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<uint<1>>' and source '!firrtl.clock'}}
+  firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.clock
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.clock, %b : !firrtl.flip<sint<1>>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<sint<1>>' and source '!firrtl.clock'}}
+  firrtl.connect %b, %a : !firrtl.flip<sint<1>>, !firrtl.clock
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.clock, %b : !firrtl.flip<asyncreset>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<asyncreset>' and source '!firrtl.clock'}}
+  firrtl.connect %b, %a : !firrtl.flip<asyncreset>, !firrtl.clock
+}
+
+}
+
+// AsyncReset source.
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.asyncreset, %b : !firrtl.flip<asyncreset>) {
+  // CHECK: firrtl.connect %b, %a
+  firrtl.connect %b, %a : !firrtl.flip<asyncreset>, !firrtl.asyncreset
+}
+
+}
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.asyncreset, %b : !firrtl.flip<uint<1>>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<uint<1>>' and source '!firrtl.asyncreset'}}
+  firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.asyncreset
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.asyncreset, %b : !firrtl.flip<sint<1>>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<sint<1>>' and source '!firrtl.asyncreset'}}
+  firrtl.connect %b, %a : !firrtl.flip<sint<1>>, !firrtl.asyncreset
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.asyncreset, %b : !firrtl.flip<clock>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<clock>' and source '!firrtl.asyncreset'}}
+  firrtl.connect %b, %a : !firrtl.flip<clock>, !firrtl.asyncreset
+}
+
+}
+
+/// Vector types can be connected if they have the same size and element type.
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.vector<uint<1>, 3>, %b : !firrtl.flip<vector<uint<1>, 3>>) {
+  // CHECK: firrtl.connect %b, %a
+  firrtl.connect %b, %a : !firrtl.flip<vector<uint<1>, 3>>, !firrtl.vector<uint<1>, 3>
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.vector<uint<1>, 3>, %b : !firrtl.flip<vector<uint<1>, 2>>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<vector<uint<1>, 2>>' and source '!firrtl.vector<uint<1>, 3>'}}
+  firrtl.connect %b, %a : !firrtl.flip<vector<uint<1>, 2>>, !firrtl.vector<uint<1>, 3>
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.vector<uint<1>, 3>, %b : !firrtl.flip<vector<sint<1>, 3>>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<vector<sint<1>, 3>>' and source '!firrtl.vector<uint<1>, 3>'}}
+  firrtl.connect %b, %a : !firrtl.flip<vector<sint<1>, 3>>, !firrtl.vector<uint<1>, 3>
+}
+
+}
+
+/// Bundle types can be connected if they have the same size, element names, and
+/// element types.
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>, f2: flip<sint<1>>>, %b : !firrtl.bundle<f1: flip<uint<1>>, f2: sint<1>>) {
+  // CHECK: firrtl.connect %b, %a
+  firrtl.connect %b, %a : !firrtl.bundle<f1: flip<uint<1>>, f2: sint<1>>, !firrtl.bundle<f1: uint<1>, f2: flip<sint<1>>>
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>>, %b : !firrtl.bundle<f1: flip<uint<1>>, f2: sint<1>>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.bundle<f1: flip<uint<1>>, f2: sint<1>>' and source '!firrtl.bundle<f1: uint<1>>'}}
+  firrtl.connect %b, %a : !firrtl.bundle<f1: flip<uint<1>>, f2: sint<1>>, !firrtl.bundle<f1: uint<1>>
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>>, %b : !firrtl.bundle<f2: flip<uint<1>>>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<bundle<f2: uint<1>>>' and source '!firrtl.bundle<f1: uint<1>>'}}
+  firrtl.connect %b, %a : !firrtl.bundle<f2: flip<uint<1>>>, !firrtl.bundle<f1: uint<1>>
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>>, %b : !firrtl.bundle<f1: flip<sint<1>>>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.flip<bundle<f1: sint<1>>>' and source '!firrtl.bundle<f1: uint<1>>'}}
+  firrtl.connect %b, %a : !firrtl.bundle<f1: flip<sint<1>>>, !firrtl.bundle<f1: uint<1>>
+}
+
+}

--- a/test/firrtl/connect.mlir
+++ b/test/firrtl/connect.mlir
@@ -159,6 +159,17 @@ firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<uint<1>>) {
 
 firrtl.circuit "test" {
 
+firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<uint<2>>) {
+  // CHECK: firrtl.connect %b, %a
+  firrtl.connect %b, %a : !firrtl.flip<uint<2>>, !firrtl.uint<1>
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+
 firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<sint<1>>) {
   // expected-error @+1 {{type mismatch between destination '!firrtl.flip<sint<1>>' and source '!firrtl.uint<1>'}}
   firrtl.connect %b, %a : !firrtl.flip<sint<1>>, !firrtl.uint<1>
@@ -370,6 +381,17 @@ firrtl.circuit "test" {
 firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>, f2: flip<sint<1>>>, %b : !firrtl.bundle<f1: flip<uint<1>>, f2: sint<1>>) {
   // CHECK: firrtl.connect %b, %a
   firrtl.connect %b, %a : !firrtl.bundle<f1: flip<uint<1>>, f2: sint<1>>, !firrtl.bundle<f1: uint<1>, f2: flip<sint<1>>>
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>, f2: flip<sint<2>>>, %b : !firrtl.bundle<f1: flip<uint<2>>, f2: sint<1>>) {
+  // CHECK: firrtl.connect %b, %a
+  firrtl.connect %b, %a : !firrtl.bundle<f1: flip<uint<2>>, f2: sint<1>>, !firrtl.bundle<f1: uint<1>, f2: flip<sint<2>>>
 }
 
 }


### PR DESCRIPTION
This is part of https://github.com/llvm/circt/issues/232. This checks
that the connected values have equivalent types, as defined by Section
4.5 of the FIRRTL spec.