### PR TITLE
[ESI] Makes wrap/unwrap expose control signals

### DIFF
--- a/include/circt/Dialect/ESI/ESIOps.h
+++ b/include/circt/Dialect/ESI/ESIOps.h
@@ -10,6 +10,7 @@
 #include "circt/Dialect/ESI/ESIDialect.h"
 #include "circt/Dialect/ESI/ESITypes.h"
 
+#include "mlir/IR/DialectImplementation.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 #define GET_OP_CLASSES

--- a/include/circt/Dialect/ESI/ESIOps.h
+++ b/include/circt/Dialect/ESI/ESIOps.h
@@ -10,7 +10,7 @@
 #include "circt/Dialect/ESI/ESIDialect.h"
 #include "circt/Dialect/ESI/ESITypes.h"
 
-#include "mlir/IR/DialectImplementation.h"
+#include "mlir/IR/OpImplementation.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 #define GET_OP_CLASSES

--- a/include/circt/Dialect/ESI/ESIPorts.td
+++ b/include/circt/Dialect/ESI/ESIPorts.td
@@ -41,8 +41,9 @@ def ChannelType :
 def WrapValidReady : ESI_Op<"wrapvr", [NoSideEffect]> {
   let summary = "Wrap a value into an ESI port";
   let description = [{
-    Wrapping a value into an ESI port type allows modules to send values
-    down an ESI port. Assumes valid/ready semantics.
+    Wrapping a value into an ESI port type allows modules to send values down
+    an ESI port. Wrap data with valid bit, result is the ESI channel and the
+    ready signal from the other end of the channel.
   }];
 
   let arguments = (ins AnyType:$data, I1:$valid);
@@ -55,7 +56,9 @@ def WrapValidReady : ESI_Op<"wrapvr", [NoSideEffect]> {
 def UnwrapValidReady : ESI_Op<"unwrapvr", [NoSideEffect]> {
   let summary = "Unwrap a value from an ESI port";
   let description = [{
-    Unwrapping a value allows operations on the contained value.
+    Unwrapping a value allows operations on the contained value. Unwrap the
+    channel along with a ready signal that you generate. Result is the data
+    along with a valid signal.
   }];
 
   let arguments = (ins ChannelType:$input, I1:$ready);

--- a/include/circt/Dialect/ESI/ESIPorts.td
+++ b/include/circt/Dialect/ESI/ESIPorts.td
@@ -35,31 +35,31 @@ def ChannelType :
   Type<CPred<"$_self.isa<::circt::esi::ChannelPort>()">, "">;
 
 
-def Wrap : ESI_Op<"wrap", [NoSideEffect]> {
+def WrapValidReady : ESI_Op<"wrapvr", [NoSideEffect]> {
   let summary = "Wrap a value into an ESI port";
   let description = [{
     Wrapping a value into an ESI port type allows modules to send values
-    down an ESI port.
+    down an ESI port. Assumes valid/ready semantics.
   }];
 
-  let arguments = (ins AnyType:$input);
-  let results = (outs ChannelType:$output);
+  let arguments = (ins AnyType:$data, I1:$valid);
+  let results = (outs ChannelType:$output, I1:$ready);
 
   let assemblyFormat = [{
-    $input attr-dict `:` type($input) `->` type($output)
+    $data `,` $valid attr-dict `:` type($data) `->` type($output)
   }];
 }
 
-def Unwrap : ESI_Op<"unwrap", [NoSideEffect]> {
+def UnwrapValidReady : ESI_Op<"unwrapvr", [NoSideEffect]> {
   let summary = "Unwrap a value from an ESI port";
   let description = [{
     Unwrapping a value allows operations on the contained value.
   }];
 
-  let arguments = (ins ChannelType:$input);
-  let results = (outs AnyType:$output);
+  let arguments = (ins ChannelType:$input, I1:$ready);
+  let results = (outs AnyType:$output, I1:$valid);
 
   let assemblyFormat = [{
-    $input attr-dict `:` type($input) `->` type($output)
+    $input `,` $ready attr-dict `:` type($input) `->` type($output)
   }];
 }

--- a/include/circt/Dialect/ESI/ESIPorts.td
+++ b/include/circt/Dialect/ESI/ESIPorts.td
@@ -35,6 +35,9 @@ def ChannelType :
   Type<CPred<"$_self.isa<::circt::esi::ChannelPort>()">, "">;
 
 
+//=========
+// Operations on ports.
+
 def WrapValidReady : ESI_Op<"wrapvr", [NoSideEffect]> {
   let summary = "Wrap a value into an ESI port";
   let description = [{
@@ -45,9 +48,8 @@ def WrapValidReady : ESI_Op<"wrapvr", [NoSideEffect]> {
   let arguments = (ins AnyType:$data, I1:$valid);
   let results = (outs ChannelType:$output, I1:$ready);
 
-  let assemblyFormat = [{
-    $data `,` $valid attr-dict `:` type($data) `->` type($output)
-  }];
+  let printer = [{ return ::print(p, *this); }];
+  let parser = [{ return ::parse$cppClass(parser, result); }];
 }
 
 def UnwrapValidReady : ESI_Op<"unwrapvr", [NoSideEffect]> {
@@ -59,7 +61,6 @@ def UnwrapValidReady : ESI_Op<"unwrapvr", [NoSideEffect]> {
   let arguments = (ins ChannelType:$input, I1:$ready);
   let results = (outs AnyType:$output, I1:$valid);
 
-  let assemblyFormat = [{
-    $input `,` $ready attr-dict `:` type($input) `->` type($output)
-  }];
+  let printer = [{ return ::print(p, *this); }];
+  let parser = [{ return ::parse$cppClass(parser, result); }];
 }

--- a/include/circt/Dialect/ESI/ESIPorts.td
+++ b/include/circt/Dialect/ESI/ESIPorts.td
@@ -38,7 +38,7 @@ def ChannelType :
 //=========
 // Operations on ports.
 
-def WrapValidReady : ESI_Op<"wrapvr", [NoSideEffect]> {
+def WrapValidReady : ESI_Op<"wrap.vr", [NoSideEffect]> {
   let summary = "Wrap a value into an ESI port";
   let description = [{
     Wrapping a value into an ESI port type allows modules to send values down
@@ -53,7 +53,7 @@ def WrapValidReady : ESI_Op<"wrapvr", [NoSideEffect]> {
   let parser = [{ return ::parse$cppClass(parser, result); }];
 }
 
-def UnwrapValidReady : ESI_Op<"unwrapvr", [NoSideEffect]> {
+def UnwrapValidReady : ESI_Op<"unwrap.vr", [NoSideEffect]> {
   let summary = "Unwrap a value from an ESI port";
   let description = [{
     Unwrapping a value allows operations on the contained value. Unwrap the

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -71,8 +71,7 @@ ParseResult parseWrapValidReady(OpAsmParser &parser, OperationState &result) {
   if (parser.parseType(innerOutputType))
     return failure();
 
-  auto boolType = IntegerType::get(
-      1, IntegerType::SignednessSemantics::Signless, result.getContext());
+  auto boolType = parser.getBuilder().getI1Type();
   auto outputType =
       ChannelPort::get(parser.getBuilder().getContext(), innerOutputType);
   result.addTypes({outputType, boolType});
@@ -107,8 +106,7 @@ ParseResult parseUnwrapValidReady(OpAsmParser &parser, OperationState &result) {
   auto inputType =
       ChannelPort::get(parser.getBuilder().getContext(), outputType);
 
-  auto boolType = IntegerType::get(
-      1, IntegerType::SignednessSemantics::Signless, result.getContext());
+  auto boolType = parser.getBuilder().getI1Type();
 
   result.addTypes({inputType.getInner(), boolType});
   if (parser.resolveOperands(opList, {inputType, boolType}, inputOperandsLoc,

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -83,7 +83,7 @@ ParseResult parseWrapValidReady(OpAsmParser &parser, OperationState &result) {
 }
 
 void print(OpAsmPrinter &p, WrapValidReady &op) {
-  p << "esi.wrapvr " << op.data() << ", " << op.valid();
+  p << "esi.wrap.vr " << op.data() << ", " << op.valid();
   p.printOptionalAttrDict(op.getAttrs());
   p << " : " << op.output().getType().cast<ChannelPort>().getInner();
 }
@@ -118,7 +118,7 @@ ParseResult parseUnwrapValidReady(OpAsmParser &parser, OperationState &result) {
 }
 
 void print(OpAsmPrinter &p, UnwrapValidReady &op) {
-  p << "esi.unwrapvr " << op.input() << ", " << op.ready();
+  p << "esi.unwrap.vr " << op.input() << ", " << op.ready();
   p.printOptionalAttrDict(op.getAttrs());
   p << " : " << op.output().getType();
 }

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -7,7 +7,6 @@
 #include "circt/Dialect/ESI/ESIOps.h"
 
 #include "mlir/IR/Builders.h"
-#include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/StandardTypes.h"
 
 using namespace mlir;

--- a/test/esi/connectivity.mlir
+++ b/test/esi/connectivity.mlir
@@ -4,19 +4,19 @@ module {
   rtl.module @Sender() -> (%x: !esi.channel<i1>) {
     %0 = constant 0 : i1
     // Don't transmit any data.
-    %ch, %rcvrRdy = esi.wrapvr %0, %0 : i1 -> !esi.channel<i1>
+    %ch, %rcvrRdy = esi.wrapvr %0, %0 : i1
     rtl.output %ch : !esi.channel<i1>
   }
   rtl.module @Reciever(%a: !esi.channel<i1>) {
     %rdy = constant 1 : i1
     // Recieve bits.
-    %data, %valid = esi.unwrapvr %a, %rdy : !esi.channel<i1> -> i1
+    %data, %valid = esi.unwrapvr %a, %rdy : i1
   }
 
   // CHECK-LABEL: rtl.module @Sender() -> (%x: !esi.channel<i1>) {
-  // CHECK:        %output, %ready = esi.wrapvr %false, %false : i1 -> !esi.channel<i1>
+  // CHECK:        %output, %ready = esi.wrapvr %false, %false : i1
   // CHECK-LABEL: rtl.module @Reciever(%a: !esi.channel<i1>) {
-  // CHECK:        %output, %valid = esi.unwrapvr %a, %true : !esi.channel<i1> -> i1
+  // CHECK:        %output, %valid = esi.unwrapvr %a, %true : i1
 
   rtl.module @test() {
     %esiChan = rtl.instance "sender" @Sender () : () -> (!esi.channel<i1>)

--- a/test/esi/connectivity.mlir
+++ b/test/esi/connectivity.mlir
@@ -4,19 +4,19 @@ module {
   rtl.module @Sender() -> (%x: !esi.channel<i1>) {
     %0 = constant 0 : i1
     // Don't transmit any data.
-    %ch, %rcvrRdy = esi.wrapvr %0, %0 : i1
+    %ch, %rcvrRdy = esi.wrap.vr %0, %0 : i1
     rtl.output %ch : !esi.channel<i1>
   }
   rtl.module @Reciever(%a: !esi.channel<i1>) {
     %rdy = constant 1 : i1
     // Recieve bits.
-    %data, %valid = esi.unwrapvr %a, %rdy : i1
+    %data, %valid = esi.unwrap.vr %a, %rdy : i1
   }
 
   // CHECK-LABEL: rtl.module @Sender() -> (%x: !esi.channel<i1>) {
-  // CHECK:        %output, %ready = esi.wrapvr %false, %false : i1
+  // CHECK:        %output, %ready = esi.wrap.vr %false, %false : i1
   // CHECK-LABEL: rtl.module @Reciever(%a: !esi.channel<i1>) {
-  // CHECK:        %output, %valid = esi.unwrapvr %a, %true : i1
+  // CHECK:        %output, %valid = esi.unwrap.vr %a, %true : i1
 
   rtl.module @test() {
     %esiChan = rtl.instance "sender" @Sender () : () -> (!esi.channel<i1>)

--- a/test/esi/connectivity.mlir
+++ b/test/esi/connectivity.mlir
@@ -3,17 +3,20 @@
 module {
   rtl.module @Sender() -> (%x: !esi.channel<i1>) {
     %0 = constant 0 : i1
-    %1 = esi.wrap %0 : i1 -> !esi.channel<i1>
-    rtl.output %1 : !esi.channel<i1>
+    // Don't transmit any data.
+    %ch, %rcvrRdy = esi.wrapvr %0, %0 : i1 -> !esi.channel<i1>
+    rtl.output %ch : !esi.channel<i1>
   }
   rtl.module @Reciever(%a: !esi.channel<i1>) {
-    %0 = esi.unwrap %a : !esi.channel<i1> -> i1
+    %rdy = constant 1 : i1
+    // Recieve bits.
+    %data, %valid = esi.unwrapvr %a, %rdy : !esi.channel<i1> -> i1
   }
 
   // CHECK-LABEL: rtl.module @Sender() -> (%x: !esi.channel<i1>) {
-  // CHECK:         %0 = esi.wrap %false : i1 -> !esi.channel<i1>
+  // CHECK:        %output, %ready = esi.wrapvr %false, %false : i1 -> !esi.channel<i1>
   // CHECK-LABEL: rtl.module @Reciever(%a: !esi.channel<i1>) {
-  // CHECK:         %0 = esi.unwrap %a : !esi.channel<i1> -> i1
+  // CHECK:        %output, %valid = esi.unwrapvr %a, %true : !esi.channel<i1> -> i1
 
   rtl.module @test() {
     %esiChan = rtl.instance "sender" @Sender () : () -> (!esi.channel<i1>)

--- a/test/esi/cosim.mlir
+++ b/test/esi/cosim.mlir
@@ -4,12 +4,12 @@ module {
   rtl.module @Sender() -> ( !esi.channel<i1> { rtl.name = "x"}) {
     %0 = constant 0 : i1
     // Don't transmit.
-    %1, %rcvrRdy = esi.wrapvr %0, %0 : i1 -> !esi.channel<i1>
+    %1, %rcvrRdy = esi.wrapvr %0, %0 : i1
     rtl.output %1 : !esi.channel<i1>
   }
   rtl.module @Reciever(%a: !esi.channel<i1>) {
     %false = constant 0 : i1
-    %0, %valid = esi.unwrapvr %a, %false : !esi.channel<i1> -> i1
+    %0, %valid = esi.unwrapvr %a, %false : i1
   }
 
   // CHECK-LABEL: rtl.module @Sender() -> (%x: !esi.channel<i1>)

--- a/test/esi/cosim.mlir
+++ b/test/esi/cosim.mlir
@@ -3,11 +3,13 @@
 module {
   rtl.module @Sender() -> ( !esi.channel<i1> { rtl.name = "x"}) {
     %0 = constant 0 : i1
-    %1 = esi.wrap %0 : i1 -> !esi.channel<i1>
+    // Don't transmit.
+    %1, %rcvrRdy = esi.wrapvr %0, %0 : i1 -> !esi.channel<i1>
     rtl.output %1 : !esi.channel<i1>
   }
   rtl.module @Reciever(%a: !esi.channel<i1>) {
-    %0 = esi.unwrap %a : !esi.channel<i1> -> i1
+    %false = constant 0 : i1
+    %0, %valid = esi.unwrapvr %a, %false : !esi.channel<i1> -> i1
   }
 
   // CHECK-LABEL: rtl.module @Sender() -> (%x: !esi.channel<i1>)

--- a/test/esi/cosim.mlir
+++ b/test/esi/cosim.mlir
@@ -4,12 +4,12 @@ module {
   rtl.module @Sender() -> ( !esi.channel<i1> { rtl.name = "x"}) {
     %0 = constant 0 : i1
     // Don't transmit.
-    %1, %rcvrRdy = esi.wrapvr %0, %0 : i1
+    %1, %rcvrRdy = esi.wrap.vr %0, %0 : i1
     rtl.output %1 : !esi.channel<i1>
   }
   rtl.module @Reciever(%a: !esi.channel<i1>) {
     %false = constant 0 : i1
-    %0, %valid = esi.unwrapvr %a, %false : i1
+    %0, %valid = esi.unwrap.vr %a, %false : i1
   }
 
   // CHECK-LABEL: rtl.module @Sender() -> (%x: !esi.channel<i1>)


### PR DESCRIPTION
- Wrap and unwrap to an RTL level interface with valid/ready signaling semantics.
- Improves the asm syntax.
- Renames ops to reflect valid/ready signaling.