### PR TITLE
Ignore broken clang-tidy rule in header file

### DIFF
--- a/lib/Conversion/PassDetail.h
+++ b/lib/Conversion/PassDetail.h
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// NOLINTNEXTLINE(llvm-header-guard)
 #ifndef CONVERSION_PASSDETAIL_H
 #define CONVERSION_PASSDETAIL_H
 


### PR DESCRIPTION
Our CI is incorrectly reporting this header file as having the wrong
header guard. Until the check is fixed, we are ignoring the linting rule
for this header file.
