### PR TITLE
[FIRRTL] Verify ConnectOp destination and source bitwidth

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -784,11 +784,19 @@ static LogicalResult verifyConnectOp(ConnectOp connect) {
   if (destType.isa<AnalogType>() || srcType.isa<AnalogType>())
     return connect.emitError("analog types may not be connected");
 
+  // Destination and source types must be equivalent.
   if (!areTypesEquivalent(destType, srcType))
     return connect.emitError("type mismatch between destination ")
            << destType << " and source " << srcType;
 
-  // TODO(mikeurbach): verify source bitwidth is >= destination bitwidth.
+  // Destination bitwidth must be greater than or equal to source bitwidth.
+  int32_t destWidth = destType.getBitWidthOrSentinel();
+  int32_t srcWidth = srcType.getBitWidthOrSentinel();
+  if (destWidth > -1 && srcWidth > -1 && destWidth < srcWidth)
+    return connect.emitError("destination width ")
+           << destWidth << " is not greater than or equal to source width "
+           << srcWidth;
+
   // TODO(mikeurbach): verify destination flow is sink or duplex.
   // TODO(mikeurbach): verify source flow is source or duplex.
   return success();

--- a/test/Conversion/FIRRTLToRTL/lower-to-rtl-module.mlir
+++ b/test/Conversion/FIRRTLToRTL/lower-to-rtl-module.mlir
@@ -152,8 +152,8 @@
   }
 
   // CHECK-LABEL: rtl.module @PortMadness(
-  // CHECK: %inA: i4, %inB: i4, %inC: i4, %inE: i3, %inF: i5)
-  // CHECK: -> (%outA: i4, %outB: i4, %outC: i4, %outD: i4, %outE: i4, %outF: i4) {
+  // CHECK: %inA: i4, %inB: i4, %inC: i4, %inE: i3)
+  // CHECK: -> (%outA: i4, %outB: i4, %outC: i4, %outD: i4, %outE: i4) {
   firrtl.module @PortMadness(%inA: !firrtl.uint<4>,
                              %inB: !firrtl.uint<4>,
                              %inC: !firrtl.uint<4>,
@@ -162,9 +162,7 @@
                              %outC: !firrtl.flip<uint<4>>,
                              %outD: !firrtl.flip<uint<4>>,
                              %inE: !firrtl.uint<3>,
-                             %outE: !firrtl.flip<uint<4>>,
-                             %inF: !firrtl.uint<5>,
-                             %outF: !firrtl.flip<uint<4>>) {
+                             %outE: !firrtl.flip<uint<4>>) {
     // CHECK-NEXT: %0 = firrtl.stdIntCast %inA : (i4) -> !firrtl.uint<4>
     // CHECK-NEXT: %1 = firrtl.stdIntCast %inB : (i4) -> !firrtl.uint<4>
     // CHECK-NEXT: %2 = firrtl.stdIntCast %inC : (i4) -> !firrtl.uint<4>
@@ -173,7 +171,6 @@
     // CHECK: [[OUTD:%.+]] = firrtl.wire : !firrtl.flip<uint<4>>
 
     // CHECK: [[INE:%.+]] = firrtl.stdIntCast %inE : (i3) -> !firrtl.uint<3>
-    // CHECK: [[INF:%.+]] = firrtl.stdIntCast %inF : (i5) -> !firrtl.uint<5>
 
     // Normal
     firrtl.connect %outA, %inA : !firrtl.flip<uint<4>>, !firrtl.uint<4>
@@ -196,10 +193,6 @@
     // CHECK: [[OUTE:%.+]] = firrtl.pad [[INE]], 4 : (!firrtl.uint<3>) -> !firrtl.uint<4>
     firrtl.connect %outE, %inE : !firrtl.flip<uint<4>>, !firrtl.uint<3>
 
-    // Truncation for inF
-    // CHECK: [[OUTF:%.+]] = firrtl.tail [[INF]], 4 : (!firrtl.uint<5>) -> !firrtl.uint<4>
-    firrtl.connect %outF, %inF : !firrtl.flip<uint<4>>, !firrtl.uint<5>
-
     // CHECK: [[OUTBY:%.+]] = rtl.merge %inB, %inA : i4
 
     // CHECK: [[OUTCX:%.+]] = firrtl.asPassive [[OUTC]]
@@ -208,8 +201,7 @@
     // CHECK: [[OUTDY:%.+]] = firrtl.stdIntCast [[OUTDX]]
 
     // CHECK: [[OUTE_CAST:%.+]] = firrtl.stdIntCast [[OUTE]]
-    // CHECK: [[OUTF_CAST:%.+]] = firrtl.stdIntCast [[OUTF]]
-    // CHECK: rtl.output %inA, [[OUTBY]], [[OUTCY]], [[OUTDY]], [[OUTE_CAST]], [[OUTF_CAST]]
+    // CHECK: rtl.output %inA, [[OUTBY]], [[OUTCY]], [[OUTDY]], [[OUTE_CAST]]
   }
 
   // CHECK-LABEL: rtl.module @Analog(%a1: !rtl.inout<i1>) -> (%outClock: i1) {

--- a/test/Dialect/FIRRTL/connect.mlir
+++ b/test/Dialect/FIRRTL/connect.mlir
@@ -428,3 +428,27 @@ firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>>, %b : !firrtl.bundle<f1: fl
 }
 
 }
+
+/// Destination bitwidth must be greater than or equal to source bitwidth.
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<uint<2>>) {
+  // CHECK: firrtl.connect %b, %a
+  firrtl.connect %b, %a : !firrtl.flip<uint<2>>, !firrtl.uint<1>
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.uint<2>, %b : !firrtl.flip<uint<1>>) {
+  // expected-error @+1 {{destination width 1 is not greater than or equal to source width 2}}
+  firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.uint<2>
+}
+
+}

--- a/test/Dialect/FIRRTL/connect.mlir
+++ b/test/Dialect/FIRRTL/connect.mlir
@@ -452,3 +452,16 @@ firrtl.module @test(%a : !firrtl.uint<2>, %b : !firrtl.flip<uint<1>>) {
 }
 
 }
+
+/// Partial connects may truncate.
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.uint<2>, %b : !firrtl.flip<uint<1>>) {
+  // CHECK: firrtl.partialconnect %b, %a
+  firrtl.partialconnect %b, %a : !firrtl.flip<uint<1>>, !firrtl.uint<2>
+}
+
+}

--- a/test/Dialect/FIRRTL/import-basic.fir
+++ b/test/Dialect/FIRRTL/import-basic.fir
@@ -69,7 +69,8 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input reset_abstract: Reset   ; CHECK: %reset_abstract: !firrtl.reset,
     input clock : Clock           ; CHECK: %clock: !firrtl.clock,
     output auto : UInt<1>         ; CHECK: %auto: !firrtl.flip<uint<1>>,
-    output sauto : SInt<1>        ; CHECK: %sauto: !firrtl.flip<sint<1>>,
+    output auto11 : UInt<11>      ; CHECK: %auto11: !firrtl.flip<uint<11>>,
+    output sauto : SInt<9>        ; CHECK: %sauto: !firrtl.flip<sint<9>>,
     input i8 : UInt<8>            ; CHECK: %i8: !firrtl.uint<8>,
     input s1 : SInt<1>            ; CHECK: %s1: !firrtl.sint<1>,
     input s8 : SInt<8>            ; CHECK: %s8: !firrtl.sint<8>,
@@ -176,7 +177,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %c171_ui8 = firrtl.constant(171 : ui8) : !firrtl.uint<8>
     ; CHECK: firrtl.add %c42_ui10, %c171_ui8
     ; CHECK: firrtl.connect %auto
-    auto <= add(UInt<10>(42), UInt<8>("hAB"))
+    auto11 <= add(UInt<10>(42), UInt<8>("hAB"))
 
     ; CHECK: %c-85_si8 = firrtl.constant(-85 : si8) : !firrtl.sint<8>
     sauto <= add(s8, SInt<8>("hAB"))
@@ -291,7 +292,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     ; CHECK: %memValue = firrtl.memoryport "Infer" %myMem, %i8, %clock {name = "memValue"} : (!firrtl.vector<bundle<id: uint<4>, resp: uint<2>>, 8>, !firrtl.uint<8>, !firrtl.clock) -> !firrtl.bundle<id: uint<4>, resp: uint<2>>
     infer mport memValue = myMem[i8], clock
-    auto <= memValue.id
+    auto11 <= memValue.id
 
     ; CHECK: %base_table_0 = firrtl.smem "Undefined" {name = "base_table_0"} : !firrtl.vector<vector<uint<1>, 9>, 256>
     smem base_table_0 : UInt<1>[9] [256]

--- a/test/ExportVerilog/firrtl-dialect.mlir
+++ b/test/ExportVerilog/firrtl-dialect.mlir
@@ -64,14 +64,14 @@ firrtl.circuit "M1" {
   // CHECK-LABEL: module ExtractCrash(
   // CHECK: wire [3:0] _T = ~a;
   // CHECK-NEXT: assign b = _T[3:2];
-  firrtl.module @ExtractCrash(%a: !firrtl.uint<4>, %b: !firrtl.flip<uint<1>>) {
+  firrtl.module @ExtractCrash(%a: !firrtl.uint<4>, %b: !firrtl.flip<uint<2>>) {
     %26 = firrtl.not %a : (!firrtl.uint<4>) -> !firrtl.uint<4>
     %27 = firrtl.stdIntCast %26 : (!firrtl.uint<4>) -> i4
     %28 = rtl.extract %27 from 2 : (i4) -> i2
-    %fb = firrtl.asPassive %b : (!firrtl.flip<uint<1>>) -> !firrtl.uint<1>
-    %29 = firrtl.stdIntCast %fb : (!firrtl.uint<1>) -> i1
+    %fb = firrtl.asPassive %b : (!firrtl.flip<uint<2>>) -> !firrtl.uint<2>
+    %29 = firrtl.stdIntCast %fb : (!firrtl.uint<2>) -> i2
     %30 = firrtl.stdIntCast %28 : (i2) -> !firrtl.uint<2>
-    firrtl.connect %b, %30 : !firrtl.flip<uint<1>>, !firrtl.uint<2>
+    firrtl.connect %b, %30 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
   }
 
 }

--- a/test/ExportVerilog/verilog-basic.fir
+++ b/test/ExportVerilog/verilog-basic.fir
@@ -113,7 +113,7 @@ circuit inputs_only :
     input b: UInt<4>
     input c: UInt<4>
     output out1: UInt<1>
-    output out: UInt<4>
+    output out: UInt<10>
     out <= add(a, add(b, c))
     out <= sub(add(a, b), c)
     out <= sub(a, add(b, c))
@@ -124,14 +124,14 @@ circuit inputs_only :
     out <= mul(add(a, b), add(b, c))
     out1 <= xorr(add(b, c))
     out1 <= or(lt(b, c), gt(b, c))
-    out1 <= and(xor(b, c), or(out1, out1))
-    out1 <= shr(out, 2)
+    out <= and(xor(b, c), or(out1, out1))
+    out <= shr(out, 2)
     out1 <= lt(out, a)
 
 ; CHECK-LABEL: module Precedence(
 ; CHECK-NEXT:     input  [3:0] a, b, c,
 ; CHECK-NEXT:     output       out1,
-; CHECK-NEXT:     output [3:0] out);
+; CHECK-NEXT:     output [9:0] out);
 ; CHECK-EMPTY:
 
 ; CHECK-NEXT:     assign out = a + b + c;
@@ -144,8 +144,8 @@ circuit inputs_only :
 ; CHECK-NEXT:     assign out = (a + b) * (b + c);
 ; CHECK-NEXT:     assign out1 = ^(b + c);
 ; CHECK-NEXT:     assign out1 = b < c | b > c;
-; CHECK-NEXT:     assign out1 = (b ^ c) & (out1 | out1);
-; CHECK-NEXT:     assign out1 = out[3:2];
+; CHECK-NEXT:     assign out = (b ^ c) & (out1 | out1);
+; CHECK-NEXT:     assign out = out[9:2];
 ; CHECK-NEXT:     assign out1 = out < a;
 ; CHECK-NEXT:  endmodule
 

--- a/test/firtool/optimizations.fir
+++ b/test/firtool/optimizations.fir
@@ -4,7 +4,7 @@
 circuit test_cse :
   module test_cse :
     input a: UInt<4>
-    output b: UInt<4>
+    output b: UInt<5>
     b <= add(a, a)
     b <= add(a, a)
     b <= and(a, UInt<4>(0))


### PR DESCRIPTION
This is part of https://github.com/llvm/circt/issues/232. This ensures
that the destination bitwidth is greater than or equal to
the source bitwidth.