### PR TITLE
[Handshake] Update MergeOp lowering to use primitive FIRRTL ops.

### DIFF
--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -807,9 +807,9 @@ bool HandshakeBuilder::visitHandshake(MergeOp op) {
   auto resultDataMux = createOneHotMuxTree(argData, win, insertLoc, rewriter);
   rewriter.create<ConnectOp>(insertLoc, resultData, resultDataMux);
 
-  // Create the logic to set the done wires for the result. For both outputs,
-  // the done wire is asserted when the output is valid and ready, or the
-  // emitted register for that output is set.
+  // Create the logic to set the done wires for the result. The done wire is
+  // asserted when the output is valid and ready, or the emitted register is
+  // set.
   auto resultValidAndReady = rewriter.create<AndPrimOp>(
       insertLoc, bitType, hasWinnerCondition, resultReady);
 

--- a/test/Conversion/HandshakeToFIRRTL/simple_addi.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/simple_addi.mlir
@@ -2,18 +2,31 @@
 
 // CHECK-LABEL: firrtl.module @handshake_merge_1ins_1outs(
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) {
-// CHECK:   %0 = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %1 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %2 = firrtl.subfield %arg0("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %3 = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %4 = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %5 = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
-// CHECK:   firrtl.when %0 {
-// CHECK:     firrtl.connect %5, %2 : !firrtl.flip<uint<64>>, !firrtl.uint<64>
-// CHECK:     firrtl.connect %3, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// CHECK:     firrtl.connect %1, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// CHECK:   }
-// CHECK: }
+// CHECK:   %[[ARG0_VALID:.+]] = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
+// CHECK:   %[[ARG0_READY:.+]] = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.flip<uint<1>>
+// CHECK:   %[[ARG0_DATA:.+]] = firrtl.subfield %arg0("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
+// CHECK:   %[[ARG1_VALID:.+]] = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<1>>
+// CHECK:   %[[ARG1_READY:.+]] = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.uint<1>
+// CHECK:   %[[ARG1_DATA:.+]] = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
+// CHECK:   %[[NO_WINNER:.+]] = firrtl.constant(-1 : si2) : !firrtl.sint<2>
+// CHECK:   %[[WIN:win]] = firrtl.wire {{.*}} : !firrtl.sint<2>
+// CHECK:   %[[RESULT_DONE:resultDone]] = firrtl.wire {{.*}} : !firrtl.uint<1>
+// CHECK:   %[[HAS_WINNER:.+]] = firrtl.neq %[[WIN]], %[[NO_WINNER]]
+// CHECK:   %[[INDEX0:.+]] = firrtl.constant(0 : si2)
+// CHECK:   %[[ARB0:.+]] = firrtl.mux(%[[ARG0_VALID]], %[[INDEX0]], %[[NO_WINNER]])
+// CHECK:   firrtl.connect %[[WIN]], %[[ARB0]]
+// CHECK:   %[[WIN_BITS:.+]] = firrtl.bits %[[WIN]] {{.+}} to 0 {{.+}} -> !firrtl.uint
+// CHECK:   %[[WIN_UNSIGNED:.+]] = firrtl.asUInt %[[WIN_BITS]]
+// CHECK:   %[[BITS0:.+]] = firrtl.bits %[[WIN_UNSIGNED]] 0 to 0
+// CHECK:   %[[RESULT_VALID:.+]] = firrtl.and %[[ARG0_VALID]], %[[HAS_WINNER]]
+// CHECK:   firrtl.connect %[[ARG1_VALID]], %[[RESULT_VALID]]
+// CHECK:   %[[BITS1:.+]] = firrtl.bits %[[WIN_UNSIGNED]] 0 to 0
+// CHECK:   firrtl.connect %[[ARG1_DATA]], %[[ARG0_DATA]]
+// CHECK:   %[[RESULT_DONE0:.+]] = firrtl.and %[[RESULT_VALID]], %[[ARG1_READY]]
+// CHECK:   firrtl.connect %[[RESULT_DONE]], %[[RESULT_DONE0]]
+// CHECK:   %[[ARG0_READY0:.+]] = firrtl.eq %[[WIN]], %[[INDEX0]]
+// CHECK:   %[[ARG0_READY1:.+]] = firrtl.and %[[ARG0_READY0]], %[[RESULT_DONE]]
+// CHECK:   firrtl.connect %[[ARG0_READY]], %[[ARG0_READY1]]
 
 // CHECK-LABEL: firrtl.module @std_addi_2ins_1outs(
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) {

--- a/test/Conversion/HandshakeToFIRRTL/simple_addi.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/simple_addi.mlir
@@ -1,33 +1,5 @@
 // RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
 
-// CHECK-LABEL: firrtl.module @handshake_merge_1ins_1outs(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) {
-// CHECK:   %[[ARG0_VALID:.+]] = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG0_READY:.+]] = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %[[ARG0_DATA:.+]] = firrtl.subfield %arg0("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %[[ARG1_VALID:.+]] = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %[[ARG1_READY:.+]] = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG1_DATA:.+]] = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
-// CHECK:   %[[NO_WINNER:.+]] = firrtl.constant(-1 : si2) : !firrtl.sint<2>
-// CHECK:   %[[WIN:win]] = firrtl.wire {{.*}} : !firrtl.sint<2>
-// CHECK:   %[[RESULT_DONE:resultDone]] = firrtl.wire {{.*}} : !firrtl.uint<1>
-// CHECK:   %[[HAS_WINNER:.+]] = firrtl.neq %[[WIN]], %[[NO_WINNER]]
-// CHECK:   %[[INDEX0:.+]] = firrtl.constant(0 : si2)
-// CHECK:   %[[ARB0:.+]] = firrtl.mux(%[[ARG0_VALID]], %[[INDEX0]], %[[NO_WINNER]])
-// CHECK:   firrtl.connect %[[WIN]], %[[ARB0]]
-// CHECK:   %[[WIN_BITS:.+]] = firrtl.bits %[[WIN]] {{.+}} to 0 {{.+}} -> !firrtl.uint
-// CHECK:   %[[WIN_UNSIGNED:.+]] = firrtl.asUInt %[[WIN_BITS]]
-// CHECK:   %[[BITS0:.+]] = firrtl.bits %[[WIN_UNSIGNED]] 0 to 0
-// CHECK:   %[[RESULT_VALID:.+]] = firrtl.and %[[ARG0_VALID]], %[[HAS_WINNER]]
-// CHECK:   firrtl.connect %[[ARG1_VALID]], %[[RESULT_VALID]]
-// CHECK:   %[[BITS1:.+]] = firrtl.bits %[[WIN_UNSIGNED]] 0 to 0
-// CHECK:   firrtl.connect %[[ARG1_DATA]], %[[ARG0_DATA]]
-// CHECK:   %[[RESULT_DONE0:.+]] = firrtl.and %[[RESULT_VALID]], %[[ARG1_READY]]
-// CHECK:   firrtl.connect %[[RESULT_DONE]], %[[RESULT_DONE0]]
-// CHECK:   %[[ARG0_READY0:.+]] = firrtl.eq %[[WIN]], %[[INDEX0]]
-// CHECK:   %[[ARG0_READY1:.+]] = firrtl.and %[[ARG0_READY0]], %[[RESULT_DONE]]
-// CHECK:   firrtl.connect %[[ARG0_READY]], %[[ARG0_READY1]]
-
 // CHECK-LABEL: firrtl.module @std_addi_2ins_1outs(
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) {
 // CHECK:   %0 = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
@@ -52,27 +24,15 @@
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg4: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
 handshake.func @simple_addi(%arg0: index, %arg1: index, %arg2: none, ...) -> (index, none) {
 
-  // CHECK: %0 = firrtl.instance @handshake_merge_1ins_1outs {name = ""} : !firrtl.bundle<arg0: bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, arg1: bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>
-  // CHECK: %1 = firrtl.subfield %0("arg0") : (!firrtl.bundle<arg0: bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, arg1: bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>
+  // CHECK: %0 = firrtl.instance @std_addi_2ins_1outs {name = ""} : !firrtl.bundle<arg0: bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, arg1: bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, arg2: bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>
+  // CHECK: %1 = firrtl.subfield %0("arg0") : (!firrtl.bundle<arg0: bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, arg1: bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, arg2: bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>
   // CHECK: firrtl.connect %1, %arg0 : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
-  // CHECK: %2 = firrtl.subfield %0("arg1") : (!firrtl.bundle<arg0: bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, arg1: bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
-  %0 = "handshake.merge"(%arg0) : (index) -> index
-  
-  // CHECK: %3 = firrtl.instance @handshake_merge_1ins_1outs {name = ""} : !firrtl.bundle<arg0: bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, arg1: bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>
-  // CHECK: %4 = firrtl.subfield %3("arg0") : (!firrtl.bundle<arg0: bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, arg1: bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>
-  // CHECK: firrtl.connect %4, %arg1 : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
-  // CHECK: %5 = firrtl.subfield %3("arg1") : (!firrtl.bundle<arg0: bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, arg1: bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
-  %1 = "handshake.merge"(%arg1) : (index) -> index
-  
-  // CHECK: %6 = firrtl.instance @std_addi_2ins_1outs {name = ""} : !firrtl.bundle<arg0: bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, arg1: bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, arg2: bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>
-  // CHECK: %7 = firrtl.subfield %6("arg0") : (!firrtl.bundle<arg0: bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, arg1: bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, arg2: bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>
-  // CHECK: firrtl.connect %7, %2 : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
-  // CHECK: %8 = firrtl.subfield %6("arg1") : (!firrtl.bundle<arg0: bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, arg1: bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, arg2: bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>
-  // CHECK: firrtl.connect %8, %5 : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
-  // CHECK: %9 = firrtl.subfield %6("arg2") : (!firrtl.bundle<arg0: bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, arg1: bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, arg2: bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
-  %2 = addi %0, %1 : index
+  // CHECK: %2 = firrtl.subfield %0("arg1") : (!firrtl.bundle<arg0: bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, arg1: bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, arg2: bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>
+  // CHECK: firrtl.connect %2, %arg1 : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+  // CHECK: %3 = firrtl.subfield %0("arg2") : (!firrtl.bundle<arg0: bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, arg1: bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, arg2: bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+  %0 = addi %arg0, %arg1 : index
 
-  // CHECK: firrtl.connect %arg3, %9 : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+  // CHECK: firrtl.connect %arg3, %3 : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
   // CHECK: firrtl.connect %arg4, %arg2 : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>
-  handshake.return %2, %arg2 : index, none
+  handshake.return %0, %arg2 : index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_cmerge.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_cmerge.mlir
@@ -78,12 +78,11 @@
 // CHECK:   firrtl.connect %[[CONTROL_EMITTED]], %[[CONTROL_EMITTED0]]
 
 // Logic to assign arg ready outputs.
-// CHECK:   %[[ARG0_READY0:.+]] = firrtl.eq %[[WIN]], %[[INDEX0]]
-// CHECK:   %[[ARG0_READY1:.+]] = firrtl.and %[[ARG0_READY0]], %[[FIRED]]
-// CHECK:   firrtl.connect %[[ARG0_READY]], %[[ARG0_READY1]]
-// CHECK:   %[[ARG1_READY0:.+]] = firrtl.eq %[[WIN]], %[[INDEX1]]
-// CHECK:   %[[ARG1_READY1:.+]] = firrtl.and %[[ARG1_READY0]], %[[FIRED]]
-// CHECK:   firrtl.connect %[[ARG1_READY]], %[[ARG1_READY1]]
+// CHECK:   %[[WIN_OR_DEFAULT:.+]] = firrtl.mux(%[[FIRED]], %[[WIN]], %[[NO_WINNER]])
+// CHECK:   %[[ARG0_READY0:.+]] = firrtl.eq %[[WIN_OR_DEFAULT]], %[[INDEX0]]
+// CHECK:   firrtl.connect %[[ARG0_READY]], %[[ARG0_READY0]]
+// CHECK:   %[[ARG1_READY0:.+]] = firrtl.eq %[[WIN_OR_DEFAULT]], %[[INDEX1]]
+// CHECK:   firrtl.connect %[[ARG1_READY]], %[[ARG1_READY0]]
 
 // CHECK-LABEL: firrtl.module @test_cmerge(
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %arg4: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg5: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {

--- a/test/Conversion/HandshakeToFIRRTL/test_cmerge.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_cmerge.mlir
@@ -15,12 +15,12 @@
 // CHECK:   %[[ARG3_DATA:.+]] = firrtl.subfield %arg3("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
 
 // Common definitions.
-// CHECK:   %[[NO_WINNER:.+]] = firrtl.constant(-1 : si2) : !firrtl.sint<2>
+// CHECK:   %[[NO_WINNER:.+]] = firrtl.constant(0 : ui2) : !firrtl.uint<2>
 // CHECK:   %[[FALSE_CONST:.+]] = firrtl.constant(0 : ui1) : !firrtl.uint<1>
 
 // Won register and win wire.
-// CHECK:   %[[WON:won]] = firrtl.reginit %[[CLOCK]], %[[RESET]], %[[NO_WINNER]] {{.+}} -> !firrtl.sint<2>
-// CHECK:   %[[WIN:win]] = firrtl.wire {{.*}} : !firrtl.sint<2>
+// CHECK:   %[[WON:won]] = firrtl.reginit %[[CLOCK]], %[[RESET]], %[[NO_WINNER]] {{.+}} -> !firrtl.uint<2>
+// CHECK:   %[[WIN:win]] = firrtl.wire {{.*}} : !firrtl.uint<2>
 
 // Fired wire, emitted registers, and done wires.
 // CHECK:   %[[FIRED:fired]] = firrtl.wire {{.*}} : !firrtl.uint<1>
@@ -30,37 +30,46 @@
 // CHECK:   %[[CONTROL_DONE:controlDone]] = firrtl.wire {{.*}} : !firrtl.uint<1>
 
 // Common conditions.
-// CHECK:   %[[HAS_WINNER:.+]] = firrtl.neq %[[WIN]], %[[NO_WINNER]]
-// CHECK:   %[[HAD_WINNER:.+]] = firrtl.neq %[[WON]], %[[NO_WINNER]]
+// CHECK:   %[[HAS_WINNER:.+]] = firrtl.orr %[[WIN]]
+// CHECK:   %[[HAD_WINNER:.+]] = firrtl.orr %[[WON]]
 
 // Arbiter logic to assign win wire.
-// CHECK:   %[[INDEX1:.+]] = firrtl.constant(1 : si2)
+// CHECK:   %[[INDEX1:.+]] = firrtl.constant(2 : ui2)
 // CHECK:   %[[ARB1:.+]] = firrtl.mux(%[[ARG1_VALID]], %[[INDEX1]], %[[NO_WINNER]])
-// CHECK:   %[[INDEX0:.+]] = firrtl.constant(0 : si2)
+// CHECK:   %[[INDEX0:.+]] = firrtl.constant(1 : ui2)
 // CHECK:   %[[ARB0:.+]] = firrtl.mux(%[[ARG0_VALID]], %[[INDEX0]], %[[ARB1]])
 // CHECK:   %[[ARB_RESULT:.+]] = firrtl.mux(%[[HAD_WINNER]], %[[WON]], %[[ARB0]])
 // CHECK:   firrtl.connect %[[WIN]], %[[ARB_RESULT]]
 
 // Logic to assign result and control outputs.
-// CHECK:   %[[WIN_BITS:.+]] = firrtl.bits %[[WIN]] {{.+}} to 0 {{.+}} -> !firrtl.uint
-// CHECK:   %[[WIN_UNSIGNED:.+]] = firrtl.asUInt %[[WIN_BITS]]
 // CHECK:   %[[RESULT_NOT_EMITTED:.+]] = firrtl.not %[[RESULT_EMITTED]]
-// CHECK:   %[[BITS0:.+]] = firrtl.bits %[[WIN_UNSIGNED]] 0 to 0
-// CHECK:   %[[RESULT_VALID0:.+]] = firrtl.mux(%[[BITS0]], %[[ARG1_VALID]], %[[ARG0_VALID]])
-// CHECK:   %[[RESULT_VALID1:.+]] = firrtl.and %[[RESULT_VALID0]], %[[HAS_WINNER]]
-// CHECK:   %[[RESULT_VALID2:.+]] = firrtl.and %[[RESULT_VALID1]], %[[RESULT_NOT_EMITTED]]
-// CHECK:   firrtl.connect %[[ARG2_VALID]], %[[RESULT_VALID2]]
+// CHECK:   %[[DEFAULT0:.+]] = firrtl.constant(0 : ui1)
+// CHECK:   %[[BITS0:.+]] = firrtl.bits %[[WIN]] 1 to 1
+// CHECK:   %[[RESULT_VALID0:.+]] = firrtl.mux(%[[BITS0]], %[[ARG1_VALID]], %[[DEFAULT0]])
+// CHECK:   %[[BITS1:.+]] = firrtl.bits %[[WIN]] 0 to 0
+// CHECK:   %[[RESULT_VALID1:.+]] = firrtl.mux(%[[BITS1]], %[[ARG0_VALID]], %[[RESULT_VALID0]])
+// CHECK:   %[[RESULT_VALID2:.+]] = firrtl.and %[[RESULT_VALID1]], %[[HAS_WINNER]]
+// CHECK:   %[[RESULT_VALID3:.+]] = firrtl.and %[[RESULT_VALID2]], %[[RESULT_NOT_EMITTED]]
+// CHECK:   firrtl.connect %[[ARG2_VALID]], %[[RESULT_VALID3]]
 // CHECK:   %[[CONTROL_NOT_EMITTED:.+]] = firrtl.not %[[CONTROL_EMITTED]]
 // CHECK:   %[[CONTROL_VALID0:.+]] = firrtl.and %[[HAS_WINNER]], %[[CONTROL_NOT_EMITTED]]
 // CHECK:   firrtl.connect %[[ARG3_VALID]], %[[CONTROL_VALID0]]
-// CHECK:   firrtl.connect %[[ARG3_DATA]], %[[WIN_UNSIGNED]]
+
+// CHECK:   %[[C0:.+]] = firrtl.constant(0 : ui1)
+// CHECK:   %[[C1:.+]] = firrtl.constant(1 : ui1)
+// CHECK:   %[[DEFAULT1:.+]] = firrtl.constant(0 : ui1)
+// CHECK:   %[[BITS2:.+]] = firrtl.bits %[[WIN]] 1 to 1
+// CHECK:   %[[CONNECT_VALID0:.+]] = firrtl.mux(%[[BITS2]], %[[C1]], %[[DEFAULT1]])
+// CHECK:   %[[BITS3:.+]] = firrtl.bits %[[WIN]] 0 to 0
+// CHECK:   %[[CONNECT_VALID1:.+]] = firrtl.mux(%[[BITS3]], %[[C0]], %[[CONNECT_VALID0]])
+// CHECK:   firrtl.connect %[[ARG3_DATA]], %[[CONNECT_VALID1]]
 
 // Logic to assign won register.
 // CHECK:   %[[WON_RESULT:.+]] = firrtl.mux(%[[FIRED]], %[[NO_WINNER]], %[[WIN]])
 // CHECK:   firrtl.connect %[[WON]], %[[WON_RESULT]]
 
 // Logic to assign done wires.
-// CHECK:   %[[RESULT_DONE0:.+]] = firrtl.and %[[RESULT_VALID2]], %[[ARG2_READY]]
+// CHECK:   %[[RESULT_DONE0:.+]] = firrtl.and %[[RESULT_VALID3]], %[[ARG2_READY]]
 // CHECK:   %[[RESULT_DONE1:.+]] = firrtl.or %[[RESULT_EMITTED]], %[[RESULT_DONE0]]
 // CHECK:   firrtl.connect %[[RESULT_DONE]], %[[RESULT_DONE1]]
 // CHECK:   %[[CONTROL_DONE0:.+]] = firrtl.and %[[CONTROL_VALID0]], %[[ARG3_READY]]
@@ -102,15 +111,14 @@ handshake.func @test_cmerge(%arg0: none, %arg1: none, %arg2: none, ...) -> (none
 // CHECK: %[[ARG1_DATA:.+]] = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
 // CHECK: %[[ARG2_DATA:.+]] = firrtl.subfield %arg2("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
 // ...
-// CHECK:   %[[WIN:win]] = firrtl.wire {{.*}} : !firrtl.sint<2>
+// CHECK:   %[[WIN:win]] = firrtl.wire {{.*}} : !firrtl.uint<2>
 // ...
-// CHECK:   %[[WIN_BITS:.+]] = firrtl.bits %[[WIN]] {{.+}} to 0 {{.+}} -> !firrtl.uint
-// CHECK:   %[[WIN_UNSIGNED:.+]] = firrtl.asUInt %[[WIN_BITS]]
-// CHECK:   %[[BITS0:.+]] = firrtl.bits %[[WIN_UNSIGNED]] 0 to 0
-// ...
-// CHECK:   %[[BITS1:.+]] = firrtl.bits %[[WIN_UNSIGNED]] 0 to 0
-// CHECK:   %[[RESULT_DATA:.+]] = firrtl.mux(%[[BITS1]], %[[ARG1_DATA]], %[[ARG0_DATA]])
-// CHECK:   firrtl.connect %[[ARG2_DATA]], %[[RESULT_DATA]]
+// CHECK:   %[[DEFAULT0:.+]] = firrtl.constant(0 : ui64)
+// CHECK:   %[[BITS0:.+]] = firrtl.bits %[[WIN]] 1 to 1
+// CHECK:   %[[RESULT_DATA0:.+]] = firrtl.mux(%[[BITS0]], %[[ARG1_DATA]], %[[DEFAULT0]])
+// CHECK:   %[[BITS1:.+]] = firrtl.bits %[[WIN]] 0 to 0
+// CHECK:   %[[RESULT_DATA1:.+]] = firrtl.mux(%[[BITS1]], %[[ARG0_DATA]], %[[RESULT_DATA0]])
+// CHECK:   firrtl.connect %[[ARG2_DATA]], %[[RESULT_DATA1]]
 
 handshake.func @test_cmerge_data(%arg0: index, %arg1: index, %arg2: none, ...) -> (index, index, none) {
   %0:2 = "handshake.control_merge"(%arg0, %arg1) {control = false} : (index, index) -> (index, index)

--- a/test/Conversion/HandshakeToFIRRTL/test_cmerge.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_cmerge.mlir
@@ -43,14 +43,8 @@
 
 // Logic to assign result and control outputs.
 // CHECK:   %[[RESULT_NOT_EMITTED:.+]] = firrtl.not %[[RESULT_EMITTED]]
-// CHECK:   %[[DEFAULT0:.+]] = firrtl.constant(0 : ui1)
-// CHECK:   %[[BITS0:.+]] = firrtl.bits %[[WIN]] 1 to 1
-// CHECK:   %[[RESULT_VALID0:.+]] = firrtl.mux(%[[BITS0]], %[[ARG1_VALID]], %[[DEFAULT0]])
-// CHECK:   %[[BITS1:.+]] = firrtl.bits %[[WIN]] 0 to 0
-// CHECK:   %[[RESULT_VALID1:.+]] = firrtl.mux(%[[BITS1]], %[[ARG0_VALID]], %[[RESULT_VALID0]])
-// CHECK:   %[[RESULT_VALID2:.+]] = firrtl.and %[[RESULT_VALID1]], %[[HAS_WINNER]]
-// CHECK:   %[[RESULT_VALID3:.+]] = firrtl.and %[[RESULT_VALID2]], %[[RESULT_NOT_EMITTED]]
-// CHECK:   firrtl.connect %[[ARG2_VALID]], %[[RESULT_VALID3]]
+// CHECK:   %[[RESULT_VALID0:.+]] = firrtl.and %[[HAS_WINNER]], %[[RESULT_NOT_EMITTED]]
+// CHECK:   firrtl.connect %[[ARG2_VALID]], %[[RESULT_VALID0]]
 // CHECK:   %[[CONTROL_NOT_EMITTED:.+]] = firrtl.not %[[CONTROL_EMITTED]]
 // CHECK:   %[[CONTROL_VALID0:.+]] = firrtl.and %[[HAS_WINNER]], %[[CONTROL_NOT_EMITTED]]
 // CHECK:   firrtl.connect %[[ARG3_VALID]], %[[CONTROL_VALID0]]
@@ -69,7 +63,7 @@
 // CHECK:   firrtl.connect %[[WON]], %[[WON_RESULT]]
 
 // Logic to assign done wires.
-// CHECK:   %[[RESULT_DONE0:.+]] = firrtl.and %[[RESULT_VALID3]], %[[ARG2_READY]]
+// CHECK:   %[[RESULT_DONE0:.+]] = firrtl.and %[[RESULT_VALID0]], %[[ARG2_READY]]
 // CHECK:   %[[RESULT_DONE1:.+]] = firrtl.or %[[RESULT_EMITTED]], %[[RESULT_DONE0]]
 // CHECK:   firrtl.connect %[[RESULT_DONE]], %[[RESULT_DONE1]]
 // CHECK:   %[[CONTROL_DONE0:.+]] = firrtl.and %[[CONTROL_VALID0]], %[[ARG3_READY]]

--- a/test/Conversion/HandshakeToFIRRTL/test_merge.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_merge.mlir
@@ -13,37 +13,41 @@
 // CHECK:   %[[ARG2_DATA:.+]] = firrtl.subfield %arg2("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
 
 // Common definitions.
-// CHECK:   %[[NO_WINNER:.+]] = firrtl.constant(-1 : si2) : !firrtl.sint<2>
+// CHECK:   %[[NO_WINNER:.+]] = firrtl.constant(0 : ui2) : !firrtl.uint<2>
 
 // Win wire.
-// CHECK:   %[[WIN:win]] = firrtl.wire {{.*}} : !firrtl.sint<2>
+// CHECK:   %[[WIN:win]] = firrtl.wire {{.*}} : !firrtl.uint<2>
 
 // Result done wire.
 // CHECK:   %[[RESULT_DONE:resultDone]] = firrtl.wire {{.*}} : !firrtl.uint<1>
 
 // Common conditions.
-// CHECK:   %[[HAS_WINNER:.+]] = firrtl.neq %[[WIN]], %[[NO_WINNER]]
+// CHECK:   %[[HAS_WINNER:.+]] = firrtl.orr %[[WIN]]
 
 // Arbiter logic to assign win wire.
-// CHECK:   %[[INDEX1:.+]] = firrtl.constant(1 : si2)
+// CHECK:   %[[INDEX1:.+]] = firrtl.constant(2 : ui2)
 // CHECK:   %[[ARB1:.+]] = firrtl.mux(%[[ARG1_VALID]], %[[INDEX1]], %[[NO_WINNER]])
-// CHECK:   %[[INDEX0:.+]] = firrtl.constant(0 : si2)
+// CHECK:   %[[INDEX0:.+]] = firrtl.constant(1 : ui2)
 // CHECK:   %[[ARB0:.+]] = firrtl.mux(%[[ARG0_VALID]], %[[INDEX0]], %[[ARB1]])
 // CHECK:   firrtl.connect %[[WIN]], %[[ARB0]]
 
-// Logic to assign result and control outputs.
-// CHECK:   %[[WIN_BITS:.+]] = firrtl.bits %[[WIN]] {{.+}} to 0 {{.+}} -> !firrtl.uint
-// CHECK:   %[[WIN_UNSIGNED:.+]] = firrtl.asUInt %[[WIN_BITS]]
-// CHECK:   %[[BITS0:.+]] = firrtl.bits %[[WIN_UNSIGNED]] 0 to 0
-// CHECK:   %[[RESULT_VALID0:.+]] = firrtl.mux(%[[BITS0]], %[[ARG1_VALID]], %[[ARG0_VALID]])
-// CHECK:   %[[RESULT_VALID1:.+]] = firrtl.and %[[RESULT_VALID0]], %[[HAS_WINNER]]
-// CHECK:   firrtl.connect %[[ARG2_VALID]], %[[RESULT_VALID1]]
-// CHECK:   %[[BITS1:.+]] = firrtl.bits %[[WIN_UNSIGNED]] 0 to 0
-// CHECK:   %[[RESULT_DATA:.+]] = firrtl.mux(%[[BITS1]], %[[ARG1_DATA]], %[[ARG0_DATA]])
+// Logic to assign result outputs.
+// CHECK:   %[[DEFAULT0:.+]] = firrtl.constant(0 : ui1)
+// CHECK:   %[[BITS0:.+]] = firrtl.bits %[[WIN]] 1 to 1
+// CHECK:   %[[RESULT_VALID0:.+]] = firrtl.mux(%[[BITS0]], %[[ARG1_VALID]], %[[DEFAULT0]])
+// CHECK:   %[[BITS1:.+]] = firrtl.bits %[[WIN]] 0 to 0
+// CHECK:   %[[RESULT_VALID1:.+]] = firrtl.mux(%[[BITS1]], %[[ARG0_VALID]], %[[RESULT_VALID0]])
+// CHECK:   %[[RESULT_VALID2:.+]] = firrtl.and %[[RESULT_VALID1]], %[[HAS_WINNER]]
+// CHECK:   firrtl.connect %[[ARG2_VALID]], %[[RESULT_VALID2]]
+// CHECK:   %[[DEFAULT1:.+]] = firrtl.constant(0 : ui64)
+// CHECK:   %[[BITS2:.+]] = firrtl.bits %[[WIN]] 1 to 1
+// CHECK:   %[[RESULT_DATA0:.+]] = firrtl.mux(%[[BITS2]], %[[ARG1_DATA]], %[[DEFAULT1]])
+// CHECK:   %[[BITS3:.+]] = firrtl.bits %[[WIN]] 0 to 0
+// CHECK:   %[[RESULT_DATA:.+]] = firrtl.mux(%[[BITS3]], %[[ARG0_DATA]], %[[RESULT_DATA0]])
 // CHECK:   firrtl.connect %[[ARG2_DATA]], %[[RESULT_DATA]]
 
 // Logic to assign result done wire.
-// CHECK:   %[[RESULT_DONE0:.+]] = firrtl.and %[[RESULT_VALID1]], %[[ARG2_READY]]
+// CHECK:   %[[RESULT_DONE0:.+]] = firrtl.and %[[RESULT_VALID2]], %[[ARG2_READY]]
 // CHECK:   firrtl.connect %[[RESULT_DONE]], %[[RESULT_DONE0]]
 
 // Logic to assign arg ready outputs.

--- a/test/Conversion/HandshakeToFIRRTL/test_merge.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_merge.mlir
@@ -2,27 +2,57 @@
 
 // CHECK-LABEL: firrtl.module @handshake_merge_2ins_1outs(
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) {
-// CHECK:   %0 = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %1 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %2 = firrtl.subfield %arg0("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %3 = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %4 = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %5 = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %6 = firrtl.subfield %arg2("valid") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %7 = firrtl.subfield %arg2("ready") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %8 = firrtl.subfield %arg2("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
-// CHECK:   firrtl.when %0 {
-// CHECK:     firrtl.connect %8, %2 : !firrtl.flip<uint<64>>, !firrtl.uint<64>
-// CHECK:     firrtl.connect %6, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// CHECK:     firrtl.connect %1, %7 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// CHECK:   } else {
-// CHECK:     firrtl.when %3 {
-// CHECK:       firrtl.connect %8, %5 : !firrtl.flip<uint<64>>, !firrtl.uint<64>
-// CHECK:       firrtl.connect %6, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// CHECK:       firrtl.connect %4, %7 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// CHECK:     }
-// CHECK:   }
-// CHECK: }
+// CHECK:   %[[ARG0_VALID:.+]] = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
+// CHECK:   %[[ARG0_READY:.+]] = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.flip<uint<1>>
+// CHECK:   %[[ARG0_DATA:.+]] = firrtl.subfield %arg0("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
+// CHECK:   %[[ARG1_VALID:.+]] = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
+// CHECK:   %[[ARG1_READY:.+]] = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.flip<uint<1>>
+// CHECK:   %[[ARG1_DATA:.+]] = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
+// CHECK:   %[[ARG2_VALID:.+]] = firrtl.subfield %arg2("valid") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<1>>
+// CHECK:   %[[ARG2_READY:.+]] = firrtl.subfield %arg2("ready") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.uint<1>
+// CHECK:   %[[ARG2_DATA:.+]] = firrtl.subfield %arg2("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
+
+// Common definitions.
+// CHECK:   %[[NO_WINNER:.+]] = firrtl.constant(-1 : si2) : !firrtl.sint<2>
+
+// Win wire.
+// CHECK:   %[[WIN:win]] = firrtl.wire {{.*}} : !firrtl.sint<2>
+
+// Result done wire.
+// CHECK:   %[[RESULT_DONE:resultDone]] = firrtl.wire {{.*}} : !firrtl.uint<1>
+
+// Common conditions.
+// CHECK:   %[[HAS_WINNER:.+]] = firrtl.neq %[[WIN]], %[[NO_WINNER]]
+
+// Arbiter logic to assign win wire.
+// CHECK:   %[[INDEX1:.+]] = firrtl.constant(1 : si2)
+// CHECK:   %[[ARB1:.+]] = firrtl.mux(%[[ARG1_VALID]], %[[INDEX1]], %[[NO_WINNER]])
+// CHECK:   %[[INDEX0:.+]] = firrtl.constant(0 : si2)
+// CHECK:   %[[ARB0:.+]] = firrtl.mux(%[[ARG0_VALID]], %[[INDEX0]], %[[ARB1]])
+// CHECK:   firrtl.connect %[[WIN]], %[[ARB0]]
+
+// Logic to assign result and control outputs.
+// CHECK:   %[[WIN_BITS:.+]] = firrtl.bits %[[WIN]] {{.+}} to 0 {{.+}} -> !firrtl.uint
+// CHECK:   %[[WIN_UNSIGNED:.+]] = firrtl.asUInt %[[WIN_BITS]]
+// CHECK:   %[[BITS0:.+]] = firrtl.bits %[[WIN_UNSIGNED]] 0 to 0
+// CHECK:   %[[RESULT_VALID0:.+]] = firrtl.mux(%[[BITS0]], %[[ARG1_VALID]], %[[ARG0_VALID]])
+// CHECK:   %[[RESULT_VALID1:.+]] = firrtl.and %[[RESULT_VALID0]], %[[HAS_WINNER]]
+// CHECK:   firrtl.connect %[[ARG2_VALID]], %[[RESULT_VALID1]]
+// CHECK:   %[[BITS1:.+]] = firrtl.bits %[[WIN_UNSIGNED]] 0 to 0
+// CHECK:   %[[RESULT_DATA:.+]] = firrtl.mux(%[[BITS1]], %[[ARG1_DATA]], %[[ARG0_DATA]])
+// CHECK:   firrtl.connect %[[ARG2_DATA]], %[[RESULT_DATA]]
+
+// Logic to assign result done wire.
+// CHECK:   %[[RESULT_DONE0:.+]] = firrtl.and %[[RESULT_VALID1]], %[[ARG2_READY]]
+// CHECK:   firrtl.connect %[[RESULT_DONE]], %[[RESULT_DONE0]]
+
+// Logic to assign arg ready outputs.
+// CHECK:   %[[ARG0_READY0:.+]] = firrtl.eq %[[WIN]], %[[INDEX0]]
+// CHECK:   %[[ARG0_READY1:.+]] = firrtl.and %[[ARG0_READY0]], %[[RESULT_DONE]]
+// CHECK:   firrtl.connect %[[ARG0_READY]], %[[ARG0_READY1]]
+// CHECK:   %[[ARG1_READY0:.+]] = firrtl.eq %[[WIN]], %[[INDEX1]]
+// CHECK:   %[[ARG1_READY1:.+]] = firrtl.and %[[ARG1_READY0]], %[[RESULT_DONE]]
+// CHECK:   firrtl.connect %[[ARG1_READY]], %[[ARG1_READY1]]
 
 // CHECK-LABEL: firrtl.module @test_merge(
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg4: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {

--- a/test/Conversion/HandshakeToFIRRTL/test_merge.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_merge.mlir
@@ -47,12 +47,11 @@
 // CHECK:   firrtl.connect %[[RESULT_DONE]], %[[RESULT_DONE0]]
 
 // Logic to assign arg ready outputs.
-// CHECK:   %[[ARG0_READY0:.+]] = firrtl.eq %[[WIN]], %[[INDEX0]]
-// CHECK:   %[[ARG0_READY1:.+]] = firrtl.and %[[ARG0_READY0]], %[[RESULT_DONE]]
-// CHECK:   firrtl.connect %[[ARG0_READY]], %[[ARG0_READY1]]
-// CHECK:   %[[ARG1_READY0:.+]] = firrtl.eq %[[WIN]], %[[INDEX1]]
-// CHECK:   %[[ARG1_READY1:.+]] = firrtl.and %[[ARG1_READY0]], %[[RESULT_DONE]]
-// CHECK:   firrtl.connect %[[ARG1_READY]], %[[ARG1_READY1]]
+// CHECK:   %[[WIN_OR_DEFAULT:.+]] = firrtl.mux(%[[RESULT_DONE]], %[[WIN]], %[[NO_WINNER]])
+// CHECK:   %[[ARG0_READY0:.+]] = firrtl.eq %[[WIN_OR_DEFAULT]], %[[INDEX0]]
+// CHECK:   firrtl.connect %[[ARG0_READY]], %[[ARG0_READY0]]
+// CHECK:   %[[ARG1_READY0:.+]] = firrtl.eq %[[WIN_OR_DEFAULT]], %[[INDEX1]]
+// CHECK:   firrtl.connect %[[ARG1_READY]], %[[ARG1_READY0]]
 
 // CHECK-LABEL: firrtl.module @test_merge(
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg4: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {

--- a/test/Conversion/HandshakeToFIRRTL/test_merge.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_merge.mlir
@@ -32,13 +32,7 @@
 // CHECK:   firrtl.connect %[[WIN]], %[[ARB0]]
 
 // Logic to assign result outputs.
-// CHECK:   %[[DEFAULT0:.+]] = firrtl.constant(0 : ui1)
-// CHECK:   %[[BITS0:.+]] = firrtl.bits %[[WIN]] 1 to 1
-// CHECK:   %[[RESULT_VALID0:.+]] = firrtl.mux(%[[BITS0]], %[[ARG1_VALID]], %[[DEFAULT0]])
-// CHECK:   %[[BITS1:.+]] = firrtl.bits %[[WIN]] 0 to 0
-// CHECK:   %[[RESULT_VALID1:.+]] = firrtl.mux(%[[BITS1]], %[[ARG0_VALID]], %[[RESULT_VALID0]])
-// CHECK:   %[[RESULT_VALID2:.+]] = firrtl.and %[[RESULT_VALID1]], %[[HAS_WINNER]]
-// CHECK:   firrtl.connect %[[ARG2_VALID]], %[[RESULT_VALID2]]
+// CHECK:   firrtl.connect %[[ARG2_VALID]], %[[HAS_WINNER]]
 // CHECK:   %[[DEFAULT1:.+]] = firrtl.constant(0 : ui64)
 // CHECK:   %[[BITS2:.+]] = firrtl.bits %[[WIN]] 1 to 1
 // CHECK:   %[[RESULT_DATA0:.+]] = firrtl.mux(%[[BITS2]], %[[ARG1_DATA]], %[[DEFAULT1]])
@@ -47,7 +41,7 @@
 // CHECK:   firrtl.connect %[[ARG2_DATA]], %[[RESULT_DATA]]
 
 // Logic to assign result done wire.
-// CHECK:   %[[RESULT_DONE0:.+]] = firrtl.and %[[RESULT_VALID2]], %[[ARG2_READY]]
+// CHECK:   %[[RESULT_DONE0:.+]] = firrtl.and %[[HAS_WINNER]], %[[ARG2_READY]]
 // CHECK:   firrtl.connect %[[RESULT_DONE]], %[[RESULT_DONE0]]
 
 // Logic to assign arg ready outputs.


### PR DESCRIPTION
This is part of https://github.com/llvm/circt/pull/254. It draws heavily from
the implementation of ControlMergeOp, but can be simplified since it does not
need to wait for more than one output to be ready.