### PR TITLE
[SV] Change InterfaceModportType to ModportType.

### DIFF
--- a/include/circt/Dialect/SV/TypeDecl.td
+++ b/include/circt/Dialect/SV/TypeDecl.td
@@ -136,7 +136,7 @@ def InterfaceType : SVType<"Interface"> {
   let parameters = (ins "::mlir::FlatSymbolRefAttr":$interface);
 }
 
-def InterfaceModportType : SVType<"InterfaceModport"> {
+def ModportType : SVType<"Modport"> {
   let summary = "SystemVerilog type pointing to an InterfaceModportOp";
   let description = [{
     A MLIR type for the SV dialect's `InterfaceModportOp` to allow
@@ -189,7 +189,7 @@ def GetModportOp: SVOp<"modport.get", [NoSideEffect]> {
 
   let arguments = (ins InterfaceTypeCond:$iface, FlatSymbolRefAttr:$field);
   let results = (outs
-    Type<CPred<"$_self.isa<::circt::sv::InterfaceModportType>()">,
+    Type<CPred<"$_self.isa<::circt::sv::ModportType>()">,
       "sv.modport">:$result);
 
   let assemblyFormat = [{

--- a/lib/Dialect/SV/Ops.cpp
+++ b/lib/Dialect/SV/Ops.cpp
@@ -137,7 +137,7 @@ static LogicalResult verifyGetModportOp(GetModportOp &op) {
   if (!symtable)
     return op.emitError("sv.interface.instance must exist within a region "
                         "which has a symbol table.");
-  auto ifaceTy = op.getType().cast<InterfaceModportType>();
+  auto ifaceTy = op.getType().cast<ModportType>();
   auto referencedOp =
       SymbolTable::lookupSymbolIn(symtable, ifaceTy.getModport());
   if (!referencedOp)

--- a/lib/Dialect/SV/Types.cpp
+++ b/lib/Dialect/SV/Types.cpp
@@ -25,14 +25,14 @@ void InterfaceType::print(DialectAsmPrinter &p) const {
   p << "interface<" << getInterface() << ">";
 }
 
-Type InterfaceModportType::parse(MLIRContext *ctxt, DialectAsmParser &p) {
+Type ModportType::parse(MLIRContext *ctxt, DialectAsmParser &p) {
   SymbolRefAttr modPort;
   if (p.parseLess() || p.parseAttribute(modPort) || p.parseGreater())
     return Type();
   return get(ctxt, modPort);
 }
 
-void InterfaceModportType::print(DialectAsmPrinter &p) const {
+void ModportType::print(DialectAsmPrinter &p) const {
   p << "modport<" << getModport() << ">";
 }
 


### PR DESCRIPTION
This seems more inline with the assembly name, `sv.modport<...>`.