### PR TITLE
Ignore all files beginning with `build` in the top level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-build
+/build*
 /docker_build
 .vscode
 #*


### PR DESCRIPTION
- leading slash matches only in the top level directory
- asterisk allows matching build2, build-sharedlibs, or others

This is useful if you need more than one build directory for testing
with different cmake options.