### PR TITLE
[CMAKE] Add circt library declaration helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,6 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
   
   list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
   list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
-  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
   
   include(TableGen)
   include(AddLLVM)
@@ -75,6 +74,10 @@ set(CIRCT_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/include ) # --includedir
 set(CIRCT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(CIRCT_BINARY_DIR ${CMAKE_BINARY_DIR}/bin)
 set(CIRCT_TOOLS_DIR ${CMAKE_BINARY_DIR}/bin)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
+
+include(AddCIRCT)
 
 # Installing the headers and docs needs to depend on generating any public
 # tablegen'd targets.

--- a/cmake/modules/AddCIRCT.cmake
+++ b/cmake/modules/AddCIRCT.cmake
@@ -1,0 +1,43 @@
+include_guard()
+
+function(add_circt_dialect dialect dialect_namespace)
+  add_mlir_dialect(${ARGV})
+  add_dependencies(circt-headers MLIR${dialect}IncGen)
+endfunction()
+
+function(add_circt_interface interface)
+  add_mlir_interface(${ARGV})
+  add_dependencies(circt-headers MLIR${dialect}IncGen)
+endfunction()
+
+function(add_circt_doc doc_filename command output_file output_directory)
+  add_mlir_doc(${ARGV})
+  add_dependencies(circt-doc ${output_file}DocGen)
+endfunction()
+
+function(add_circt_library name)
+  add_mlir_library(${ARGV})
+  add_circt_library_install(${name})
+endfunction()
+
+# Adds a CIRCT library target for installation.  This should normally only be
+# called from add_circt_library().
+function(add_circt_library_install name)
+  set_property(GLOBAL APPEND PROPERTY CIRCT_ALL_LIBS ${name})
+  set_property(GLOBAL APPEND PROPERTY CIRCT_EXPORTS ${name})
+endfunction()
+
+function(add_circt_dialect_library name)
+  set_property(GLOBAL APPEND PROPERTY CIRCT_DIALECT_LIBS ${name})
+  add_circt_library(${ARGV} DEPENDS circt-headers)
+endfunction()
+
+function(add_circt_conversion_library name)
+  set_property(GLOBAL APPEND PROPERTY CIRCT_CONVERSION_LIBS ${name})
+  add_circt_library(${ARGV} DEPENDS circt-headers)
+endfunction()
+
+function(add_circt_translation_library name)
+  set_property(GLOBAL APPEND PROPERTY CIRCT_TRANSLATION_LIBS ${name})
+  add_circt_library(${ARGV} DEPENDS circt-headers)
+endfunction()

--- a/include/circt/Conversion/CMakeLists.txt
+++ b/include/circt/Conversion/CMakeLists.txt
@@ -5,4 +5,4 @@ set(LLVM_TARGET_DEFINITIONS Passes.td)
 mlir_tablegen(Passes.h.inc -gen-pass-decls -name Conversion)
 add_public_tablegen_target(CIRCTConversionPassIncGen)
 
-add_mlir_doc(Passes -gen-pass-doc CIRCTConversionPasses ./)
+add_circt_doc(Passes -gen-pass-doc CIRCTConversionPasses ./)

--- a/include/circt/Conversion/FIRRTLToLLHD/CMakeLists.txt
+++ b/include/circt/Conversion/FIRRTLToLLHD/CMakeLists.txt
@@ -2,4 +2,4 @@ set(LLVM_TARGET_DEFINITIONS Passes.td)
 mlir_tablegen(Passes.h.inc -gen-pass-decls)
 add_public_tablegen_target(MLIRFIRRTLToLLHDConversionPassIncGen)
 
-add_mlir_doc(Passes -gen-pass-doc FIRRTLToLLHD Passes/)
+add_circt_doc(Passes -gen-pass-doc FIRRTLToLLHD Passes/)

--- a/include/circt/Conversion/LLHDToLLVM/CMakeLists.txt
+++ b/include/circt/Conversion/LLHDToLLVM/CMakeLists.txt
@@ -2,4 +2,4 @@ set(LLVM_TARGET_DEFINITIONS Passes.td)
 mlir_tablegen(Passes.h.inc -gen-pass-decls)
 add_public_tablegen_target(MLIRLLHDConversionPassIncGen)
 
-add_mlir_doc(Passes -gen-pass-doc LLHDToLLVM Passes/)
+add_circt_doc(Passes -gen-pass-doc LLHDToLLVM Passes/)

--- a/include/circt/Dialect/ESI/CMakeLists.txt
+++ b/include/circt/Dialect/ESI/CMakeLists.txt
@@ -1,5 +1,5 @@
-add_mlir_dialect(ESI esi)
-add_mlir_doc(ESI -gen-op-doc esi Dialect/)
+add_circt_dialect(ESI esi)
+add_circt_doc(ESI -gen-op-doc esi Dialect/)
 
 set(LLVM_TARGET_DEFINITIONS ESI.td)
 mlir_tablegen(ESIAttrs.h.inc -gen-struct-attr-decls)

--- a/include/circt/Dialect/FIRRTL/CMakeLists.txt
+++ b/include/circt/Dialect/FIRRTL/CMakeLists.txt
@@ -1,10 +1,8 @@
-add_mlir_dialect(FIRRTL firrtl FIRRTL)
-add_mlir_doc(FIRRTL -gen-op-doc firrtl Dialect/)
+add_circt_dialect(FIRRTL firrtl FIRRTL)
+add_circt_doc(FIRRTL -gen-op-doc firrtl Dialect/)
 
 set(LLVM_TARGET_DEFINITIONS FIRRTL.td)
 mlir_tablegen(FIRRTLEnums.h.inc -gen-enum-decls)
 mlir_tablegen(FIRRTLEnums.cpp.inc -gen-enum-defs)
 mlir_tablegen(FIRRTLPasses.h.inc -gen-pass-decls)
 add_public_tablegen_target(MLIRFIRRTLEnumsIncGen)
-
-

--- a/include/circt/Dialect/Handshake/CMakeLists.txt
+++ b/include/circt/Dialect/Handshake/CMakeLists.txt
@@ -1,5 +1,5 @@
-add_mlir_dialect(HandshakeOps handshake)
-add_mlir_doc(HandshakeOps -gen-op-doc handshake Dialect/)
+add_circt_dialect(HandshakeOps handshake)
+add_circt_doc(HandshakeOps -gen-op-doc handshake Dialect/)
 
 set(LLVM_TARGET_DEFINITIONS HandshakeOps.td)
 mlir_tablegen(HandshakeOps.inc -gen-rewriters)

--- a/include/circt/Dialect/LLHD/IR/CMakeLists.txt
+++ b/include/circt/Dialect/LLHD/IR/CMakeLists.txt
@@ -1,5 +1,5 @@
-add_mlir_dialect(LLHD llhd)
-add_mlir_doc(LLHD -gen-op-doc llhd Dialect/)
+add_circt_dialect(LLHD llhd)
+add_circt_doc(LLHD -gen-op-doc llhd Dialect/)
 
 set(LLVM_TARGET_DEFINITIONS LLHD.td)
 mlir_tablegen(LLHDEnums.h.inc -gen-enum-decls)

--- a/include/circt/Dialect/LLHD/Transforms/CMakeLists.txt
+++ b/include/circt/Dialect/LLHD/Transforms/CMakeLists.txt
@@ -2,4 +2,4 @@ set(LLVM_TARGET_DEFINITIONS Passes.td)
 mlir_tablegen(Passes.h.inc -gen-pass-decls)
 add_public_tablegen_target(MLIRLLHDTransformsIncGen)
 
-add_mlir_doc(Passes -gen-pass-doc Transformations Passes/)
+add_circt_doc(Passes -gen-pass-doc Transformations Passes/)

--- a/include/circt/Dialect/RTL/CMakeLists.txt
+++ b/include/circt/Dialect/RTL/CMakeLists.txt
@@ -1,5 +1,5 @@
-add_mlir_dialect(RTL rtl)
-add_mlir_doc(RTL -gen-op-doc rtl Dialect/)
+add_circt_dialect(RTL rtl)
+add_circt_doc(RTL -gen-op-doc rtl Dialect/)
 
 set(LLVM_TARGET_DEFINITIONS RTL.td)
 mlir_tablegen(RTLEnums.h.inc -gen-enum-decls)

--- a/include/circt/Dialect/SV/CMakeLists.txt
+++ b/include/circt/Dialect/SV/CMakeLists.txt
@@ -1,14 +1,14 @@
-add_mlir_dialect(SV sv)
-add_mlir_doc(SV -gen-op-doc sv Dialect/)
+add_circt_dialect(SV sv)
+add_circt_doc(SV -gen-op-doc sv Dialect/)
 
 set(LLVM_TARGET_DEFINITIONS SV.td)
 
 mlir_tablegen(SVEnums.h.inc -gen-enum-decls)
 mlir_tablegen(SVEnums.cpp.inc -gen-enum-defs)
 add_public_tablegen_target(MLIRSVEnumsIncGen)
-add_dependencies(mlir-headers MLIRSVEnumsIncGen)
+add_dependencies(circt-headers MLIRSVEnumsIncGen)
 
 mlir_tablegen(SVStructs.h.inc -gen-struct-attr-decls)
 mlir_tablegen(SVStructs.cpp.inc -gen-struct-attr-defs)
 add_public_tablegen_target(MLIRSVStructsIncGen)
-add_dependencies(mlir-headers MLIRSVStructsIncGen)
+add_dependencies(circt-headers MLIRSVStructsIncGen)

--- a/include/circt/Dialect/StaticLogic/CMakeLists.txt
+++ b/include/circt/Dialect/StaticLogic/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_mlir_dialect(StaticLogic staticlogic)
-add_mlir_doc(StaticLogic -gen-op-doc staticlogic Dialect/)
+add_circt_dialect(StaticLogic staticlogic)
+add_circt_doc(StaticLogic -gen-op-doc staticlogic Dialect/)
 
 set(LLVM_TARGET_DEFINITIONS StaticLogic.td)

--- a/lib/CAPI/RTL/CMakeLists.txt
+++ b/lib/CAPI/RTL/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_mlir_library(MLIRCAPIRTL
+add_circt_library(MLIRCAPIRTL
 
   RTLDialect.cpp
 

--- a/lib/Conversion/FIRRTLToLLHD/CMakeLists.txt
+++ b/lib/Conversion/FIRRTLToLLHD/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_mlir_conversion_library(MLIRFIRRTLToLLHD
+add_circt_conversion_library(MLIRFIRRTLToLLHD
   FIRRTLToLLHD.cpp
 
   DEPENDS

--- a/lib/Conversion/FIRRTLToRTL/CMakeLists.txt
+++ b/lib/Conversion/FIRRTLToRTL/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_mlir_conversion_library(MLIRFIRRTLToRTL
+add_circt_conversion_library(MLIRFIRRTLToRTL
   LowerToRTL.cpp
 
   DEPENDS

--- a/lib/Conversion/HandshakeToFIRRTL/CMakeLists.txt
+++ b/lib/Conversion/HandshakeToFIRRTL/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_mlir_library(MLIRHandshakeToFIRRTL
+add_circt_library(MLIRHandshakeToFIRRTL
   HandshakeToFIRRTL.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/Conversion/LLHDToLLVM/CMakeLists.txt
+++ b/lib/Conversion/LLHDToLLVM/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_mlir_conversion_library(MLIRLLHDToLLVM
+add_circt_conversion_library(MLIRLLHDToLLVM
   LLHDToLLVM.cpp
 
   DEPENDS

--- a/lib/Conversion/StandardToHandshake/CMakeLists.txt
+++ b/lib/Conversion/StandardToHandshake/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_mlir_library(MLIRStandardToHandshake
+add_circt_library(MLIRStandardToHandshake
   StandardToHandshake.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/Conversion/StandardToStaticLogic/CMakeLists.txt
+++ b/lib/Conversion/StandardToStaticLogic/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_mlir_library(MLIRStandardToStaticLogic
+add_circt_library(MLIRStandardToStaticLogic
   StandardToStaticLogic.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/Dialect/ESI/CMakeLists.txt
+++ b/lib/Dialect/ESI/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_mlir_dialect_library(MLIRESI
+add_circt_dialect_library(MLIRESI
   ESIDialect.cpp
   ESIOps.cpp
   ESIPasses.cpp
@@ -22,6 +22,6 @@ add_mlir_dialect_library(MLIRESI
   )
 
 
-add_dependencies(mlir-headers MLIRESIIncGen)
+add_dependencies(circt-headers MLIRESIIncGen)
 
 add_subdirectory(cosim)

--- a/lib/Dialect/FIRRTL/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/CMakeLists.txt
@@ -1,5 +1,5 @@
 file(GLOB globbed *.cpp)
-add_mlir_dialect_library(MLIRFIRRTL
+add_circt_dialect_library(MLIRFIRRTL
   ${globbed}
 
   ADDITIONAL_HEADER_DIRS
@@ -17,4 +17,5 @@ add_mlir_dialect_library(MLIRFIRRTL
   MLIRPass
   )
 
-add_dependencies(mlir-headers MLIRFIRRTLIncGen MLIRFIRRTLEnumsIncGen)
+add_dependencies(circt-headers MLIRFIRRTLIncGen MLIRFIRRTLEnumsIncGen)
+ 

--- a/lib/Dialect/Handshake/CMakeLists.txt
+++ b/lib/Dialect/Handshake/CMakeLists.txt
@@ -4,7 +4,7 @@ set(LLVM_OPTIONAL_SOURCES
   mlir_std_runner.cpp
   )
 
-add_mlir_dialect_library(MLIRHandshakeOps
+add_circt_dialect_library(MLIRHandshakeOps
   HandshakeOps.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/Dialect/LLHD/IR/CMakeLists.txt
+++ b/lib/Dialect/LLHD/IR/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_mlir_dialect_library(MLIRLLHD
+add_circt_dialect_library(MLIRLLHD
   LLHDDialect.cpp
   LLHDOps.cpp
   LLHDCanonicalization.cpp

--- a/lib/Dialect/LLHD/Simulator/CMakeLists.txt
+++ b/lib/Dialect/LLHD/Simulator/CMakeLists.txt
@@ -5,25 +5,25 @@ set(LLVM_OPTIONAL_SOURCES
     Trace.cpp
 )
 
-add_mlir_library(CIRCTLLHDSimState
+add_circt_library(CIRCTLLHDSimState
     State.cpp
 )
 
-add_mlir_library(CIRCTLLHDSimTrace
+add_circt_library(CIRCTLLHDSimTrace
     Trace.cpp
 
     LINK_LIBS PUBLIC
     CIRCTLLHDSimState
 )
 
-add_mlir_library(circt-llhd-signals-runtime-wrappers SHARED
+add_circt_library(circt-llhd-signals-runtime-wrappers SHARED
     signals-runtime-wrappers.cpp
 
     LINK_LIBS PUBLIC
     CIRCTLLHDSimState
 )
 
-add_mlir_library(CIRCTLLHDSimEngine
+add_circt_library(CIRCTLLHDSimEngine
     Engine.cpp
 
     LINK_LIBS PUBLIC

--- a/lib/Dialect/LLHD/Transforms/CMakeLists.txt
+++ b/lib/Dialect/LLHD/Transforms/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_mlir_dialect_library(MLIRLLHDTransforms
+add_circt_dialect_library(MLIRLLHDTransforms
   TemporalRegions.cpp
   PassRegistration.cpp
   ProcessLoweringPass.cpp

--- a/lib/Dialect/RTL/CMakeLists.txt
+++ b/lib/Dialect/RTL/CMakeLists.txt
@@ -1,5 +1,5 @@
 file(GLOB globbed *.cpp)
-add_mlir_dialect_library(MLIRRTL
+add_circt_dialect_library(MLIRRTL
   ${globbed}
 
   ADDITIONAL_HEADER_DIRS
@@ -16,4 +16,4 @@ add_mlir_dialect_library(MLIRRTL
   MLIRIR
    )
 
-add_dependencies(mlir-headers MLIRRTLIncGen MLIRRTLEnumsIncGen)
+add_dependencies(circt-headers MLIRRTLIncGen MLIRRTLEnumsIncGen)

--- a/lib/Dialect/SV/CMakeLists.txt
+++ b/lib/Dialect/SV/CMakeLists.txt
@@ -1,5 +1,5 @@
 file(GLOB globbed *.cpp)
-add_mlir_dialect_library(MLIRSV
+add_circt_dialect_library(MLIRSV
   ${globbed}
 
   ADDITIONAL_HEADER_DIRS
@@ -15,4 +15,4 @@ add_mlir_dialect_library(MLIRSV
   MLIRIR
    )
 
-add_dependencies(mlir-headers MLIRSVIncGen)
+add_dependencies(circt-headers MLIRSVIncGen)

--- a/lib/Dialect/StaticLogic/CMakeLists.txt
+++ b/lib/Dialect/StaticLogic/CMakeLists.txt
@@ -4,7 +4,7 @@ set(LLVM_OPTIONAL_SOURCES
   Ops.cpp
   )
 
-add_mlir_dialect_library(MLIRStaticLogicOps
+add_circt_dialect_library(MLIRStaticLogicOps
   Ops.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/EmitVerilog/CMakeLists.txt
+++ b/lib/EmitVerilog/CMakeLists.txt
@@ -1,6 +1,6 @@
 file(GLOB globbed *.cpp)
 
-add_mlir_library(CIRCTEmitVerilog
+add_circt_library(CIRCTEmitVerilog
   ${globbed}
   
   ADDITIONAL_HEADER_DIRS

--- a/lib/FIRParser/CMakeLists.txt
+++ b/lib/FIRParser/CMakeLists.txt
@@ -1,6 +1,6 @@
 file(GLOB globbed *.cpp)
 
-add_mlir_library(CIRCTFIRParser
+add_circt_library(CIRCTFIRParser
   ${globbed}
   
   ADDITIONAL_HEADER_DIRS

--- a/lib/Target/Verilog/CMakeLists.txt
+++ b/lib/Target/Verilog/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_mlir_library(MLIRLLHDTargetVerilog
+add_circt_library(MLIRLLHDTargetVerilog
   TranslateToVerilog.cpp
 
   ADDITIONAL_HEADER_DIRS


### PR DESCRIPTION
This change adds many cmake helpers to declare circuit libraries, for
example:

`cmake
add_circt_dialect(RTL rtl)
add_circt_library(RTL ...)
`

These new functions are implemented by thinly wrapping the MLIR version
of these calls, doing some CIRCT specific logic in the process.

The intention is that eventually these functions will be replaced with
an implementation that does not wrap `add_mlir_library()`. If CIRCT
migrates in to the LLVM main repo, these will have to be properly
implemented without hijacking the MLIR cmake logic.

It seems that the functionality implemented by these functions is
required by any new MLIR based project.  In the future we should look
into refactoring them into common project helpers.  If a re-usable
framework of core utilities is created in LLVM, we will switch to using
those.