### PR TITLE
Inferred memory port type doesn't match firrtl spec

### DIFF
--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -633,7 +633,7 @@ MemOp::getTypeForPortList(uint64_t depth, FIRRTLType dataType,
       break;
     }
 
-    memFields.push_back({port.first, BundleType::get(portFields, context)});
+    memFields.push_back({port.first, FlipType::get(BundleType::get(portFields, context))});
   }
 
   return BundleType::get(memFields, context);

--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -643,13 +643,11 @@ MemOp::getTypeForPortList(uint64_t depth, FIRRTLType dataType,
 static Optional<MemOp::PortKind> getMemPortKindFromType(FIRRTLType type) {
   auto portType = type.dyn_cast<BundleType>();
   if (!portType) {
-    auto flipType = type.dyn_cast<FlipType>();
-    if (flipType)
+    if(auto flipType = type.dyn_cast<FlipType>())
       portType = flipType.getElementType().dyn_cast<BundleType>();
+    if (!portType)
+      return None;
   }
-  if (!portType)
-    return None;
-  
   switch (portType.getNumElements()) {
   default:
     return None;

--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -642,9 +642,14 @@ MemOp::getTypeForPortList(uint64_t depth, FIRRTLType dataType,
 /// Return the kind of port this is given the port type from a 'mem' decl.
 static Optional<MemOp::PortKind> getMemPortKindFromType(FIRRTLType type) {
   auto portType = type.dyn_cast<BundleType>();
+  if (!portType) {
+    auto flipType = type.dyn_cast<FlipType>();
+    if (flipType)
+      portType = flipType.getElementType().dyn_cast<BundleType>();
+  }
   if (!portType)
     return None;
-
+  
   switch (portType.getNumElements()) {
   default:
     return None;

--- a/lib/Dialect/FIRRTL/Ops.cpp
+++ b/lib/Dialect/FIRRTL/Ops.cpp
@@ -633,7 +633,8 @@ MemOp::getTypeForPortList(uint64_t depth, FIRRTLType dataType,
       break;
     }
 
-    memFields.push_back({port.first, FlipType::get(BundleType::get(portFields, context))});
+    memFields.push_back(
+        {port.first, FlipType::get(BundleType::get(portFields, context))});
   }
 
   return BundleType::get(memFields, context);
@@ -643,7 +644,7 @@ MemOp::getTypeForPortList(uint64_t depth, FIRRTLType dataType,
 static Optional<MemOp::PortKind> getMemPortKindFromType(FIRRTLType type) {
   auto portType = type.dyn_cast<BundleType>();
   if (!portType) {
-    if(auto flipType = type.dyn_cast<FlipType>())
+    if (auto flipType = type.dyn_cast<FlipType>())
       portType = flipType.getElementType().dyn_cast<BundleType>();
     if (!portType)
       return None;

--- a/test/FIRParser/basic.fir
+++ b/test/FIRParser/basic.fir
@@ -325,9 +325,9 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     ; CHECK: %_M = firrtl.mem "Undefined" {depth = 8 : i64, name = "_M",
     ; CHECK:   readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<
-    ; CHECK:       _T_10: bundle<addr: uint<3>, en: uint<1>, clk: clock, data: bundle<id: analog<4>>, mask: bundle<id: uint<1>>>,
-    ; CHECK:       _T_11: bundle<addr: uint<3>, en: uint<1>, clk: clock, data: bundle<id: analog<4>>, mask: bundle<id: uint<1>>>,
-    ; CHECK:       _T_18: bundle<addr: uint<3>, en: uint<1>, clk: clock, data: flip<bundle<id: analog<4>>>>>
+    ; CHECK:       _T_10: flip<bundle<addr: uint<3>, en: uint<1>, clk: clock, data: bundle<id: analog<4>>, mask: bundle<id: uint<1>>>>,
+    ; CHECK:       _T_11: flip<bundle<addr: uint<3>, en: uint<1>, clk: clock, data: bundle<id: analog<4>>, mask: bundle<id: uint<1>>>>,
+    ; CHECK:       _T_18: bundle<addr: flip<uint<3>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<id: analog<4>>>>
     mem _M : @[Decoupled.scala 209:24]
         data-type => { id : Analog<4> }
         depth => 8
@@ -504,7 +504,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       reader => io_deq_bits_MPORT
       writer => MPORT
       read-under-write => undefined
-      ; CHECK:         %bar = firrtl.mem "Undefined" {depth = 1 : i64, name = "bar", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<MPORT: bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<3>, mask: uint<1>>, io_deq_bits_MPORT: bundle<addr: uint<1>, en: uint<1>, clk: clock, data: flip<uint<3>>>>
+      ; CHECK:         %bar = firrtl.mem "Undefined" {depth = 1 : i64, name = "bar", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<MPORT: flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<3>, mask: uint<1>>>, io_deq_bits_MPORT: bundle<addr: flip<uint<1>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<3>>>
 
  
 


### PR DESCRIPTION
5.11 of the firrtl spec says the type of a memory is a bundle of flipped types (each a bundle).  We weren't doing this flipping, which led to bugs when connecting memories to module ports (mem read data to output port), namely connect flip<> flip<>, when it should have been connect flip<>, straight.

The update of getMemPortKindFromType is needed since the flip<bundle> normalization which pushes the flip into the bundle doesn't trigger for a passive bundle (which a write port is).