### PR TITLE
Add CI test with -DBUILD_SHARED_LIBS=ON.

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -128,6 +128,23 @@ jobs:
             -DLLVM_EXTERNAL_LIT=`pwd`/../llvm/build/bin/llvm-lit
           make check-circt -j$(nproc)
 
+      # Build the CIRCT test target in release mode with shared libs enabled.
+      - name: Build and Test CIRCT (Release + Shared Libs)
+        run: |
+          mkdir build_sharedlib
+          cd build_sharedlib
+          cmake .. \
+            -DBUILD_SHARED_LIBS=ON \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DLLVM_ENABLE_ASSERTIONS=OFF \
+            -DMLIR_DIR=../llvm/install/lib/cmake/mlir/ \
+            -DLLVM_DIR=../llvm/install/lib/cmake/llvm/ \
+            -DCMAKE_LINKER=lld \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DLLVM_EXTERNAL_LIT=`pwd`/../llvm/build/bin/llvm-lit
+          make check-circt -j$(nproc)
+
       # --------
       # Lint the CIRCT C++ code.
       # -------

--- a/lib/Dialect/ESI/CMakeLists.txt
+++ b/lib/Dialect/ESI/CMakeLists.txt
@@ -16,6 +16,7 @@ add_circt_dialect_library(MLIRESI
   Support
 
   LINK_LIBS PUBLIC
+  MLIRSV
   MLIREDSC
   MLIRIR
   MLIRTransforms

--- a/lib/Dialect/FIRRTL/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/CMakeLists.txt
@@ -13,9 +13,10 @@ add_circt_dialect_library(MLIRFIRRTL
   Support
 
   LINK_LIBS PUBLIC
+  MLIRRTL
   MLIRIR
   MLIRPass
   )
 
 add_dependencies(circt-headers MLIRFIRRTLIncGen MLIRFIRRTLEnumsIncGen)
- 
+


### PR DESCRIPTION
Is this something that we want to check for in our CI? I have been building this way, and while working on https://github.com/llvm/circt/pull/302 found that some libraries fail to link at the moment.