### PR TITLE
[WIP] [FIRRTL] Fix sign emission for firrtl

### DIFF
--- a/lib/EmitVerilog/EmitVerilog.cpp
+++ b/lib/EmitVerilog/EmitVerilog.cpp
@@ -752,14 +752,14 @@ private:
                          const char *syntax, bool opSigned = false);
 
   SubExprInfo emitFIRRTLBinary(Operation *op, VerilogPrecedence prec,
-                         const char *syntax);
+                               const char *syntax);
 
   SubExprInfo emitVariadic(Operation *op, VerilogPrecedence prec,
                            const char *syntax, bool hasStrictSign = false);
 
   SubExprInfo emitFIRRTLVariadic(Operation *op, VerilogPrecedence prec,
-                           const char *syntax);
-  
+                                 const char *syntax);
+
   SubExprInfo emitUnary(Operation *op, const char *syntax, bool forceUnsigned);
 
   SubExprInfo emitFIRRTLUnary(Operation *op, const char *syntax);
@@ -773,33 +773,55 @@ private:
   SubExprInfo visitExpr(AddPrimOp op) {
     return emitFIRRTLVariadic(op, Addition, "+");
   }
-  SubExprInfo visitExpr(SubPrimOp op) { return emitFIRRTLBinary(op, Addition, "-"); }
+  SubExprInfo visitExpr(SubPrimOp op) {
+    return emitFIRRTLBinary(op, Addition, "-");
+  }
   SubExprInfo visitExpr(MulPrimOp op) {
     return emitFIRRTLVariadic(op, Multiply, "*");
   }
-  SubExprInfo visitExpr(DivPrimOp op) { return emitFIRRTLBinary(op, Multiply, "/"); }
+  SubExprInfo visitExpr(DivPrimOp op) {
+    return emitFIRRTLBinary(op, Multiply, "/");
+  }
   SubExprInfo visitExpr(RemPrimOp op) {
     return emitFIRRTLBinary(op, Multiply, "%");
   }
 
-  SubExprInfo visitExpr(AndPrimOp op) { return emitFIRRTLVariadic(op, And, "&"); }
+  SubExprInfo visitExpr(AndPrimOp op) {
+    return emitFIRRTLVariadic(op, And, "&");
+  }
   SubExprInfo visitExpr(OrPrimOp op) { return emitFIRRTLVariadic(op, Or, "|"); }
-  SubExprInfo visitExpr(XorPrimOp op) { return emitFIRRTLVariadic(op, Xor, "^"); }
+  SubExprInfo visitExpr(XorPrimOp op) {
+    return emitFIRRTLVariadic(op, Xor, "^");
+  }
 
   // FIRRTL Comparison Operations
   SubExprInfo visitExpr(LEQPrimOp op) {
     return emitFIRRTLBinary(op, Comparison, "<=");
   }
-  SubExprInfo visitExpr(LTPrimOp op) { return emitFIRRTLBinary(op, Comparison, "<"); }
+  SubExprInfo visitExpr(LTPrimOp op) {
+    return emitFIRRTLBinary(op, Comparison, "<");
+  }
   SubExprInfo visitExpr(GEQPrimOp op) {
     return emitFIRRTLBinary(op, Comparison, ">=");
   }
-  SubExprInfo visitExpr(GTPrimOp op) { return emitFIRRTLBinary(op, Comparison, ">"); }
-  SubExprInfo visitExpr(EQPrimOp op) { return emitFIRRTLBinary(op, Equality, "=="); }
-  SubExprInfo visitExpr(NEQPrimOp op) { return emitFIRRTLBinary(op, Equality, "!="); }
-  SubExprInfo visitExpr(DShlPrimOp op) { return emitFIRRTLBinary(op, Shift, "<<"); }
-  SubExprInfo visitExpr(DShlwPrimOp op) { return emitFIRRTLBinary(op, Shift, "<<"); }
-  SubExprInfo visitExpr(DShrPrimOp op) { return emitFIRRTLBinary(op, Shift, ">>>"); }
+  SubExprInfo visitExpr(GTPrimOp op) {
+    return emitFIRRTLBinary(op, Comparison, ">");
+  }
+  SubExprInfo visitExpr(EQPrimOp op) {
+    return emitFIRRTLBinary(op, Equality, "==");
+  }
+  SubExprInfo visitExpr(NEQPrimOp op) {
+    return emitFIRRTLBinary(op, Equality, "!=");
+  }
+  SubExprInfo visitExpr(DShlPrimOp op) {
+    return emitFIRRTLBinary(op, Shift, "<<");
+  }
+  SubExprInfo visitExpr(DShlwPrimOp op) {
+    return emitFIRRTLBinary(op, Shift, "<<");
+  }
+  SubExprInfo visitExpr(DShrPrimOp op) {
+    return emitFIRRTLBinary(op, Shift, ">>>");
+  }
 
   // Unary Prefix operators.
   SubExprInfo visitExpr(AndRPrimOp op) { return emitFIRRTLUnary(op, "&"); }
@@ -963,7 +985,7 @@ SubExprInfo ExprEmitter::emitBinary(Operation *op, VerilogPrecedence prec,
 }
 
 SubExprInfo ExprEmitter::emitFIRRTLBinary(Operation *op, VerilogPrecedence prec,
-                                    const char *syntax) {
+                                          const char *syntax) {
   auto retWidth = getBitWidthOrSentinel(op->getResult(0).getType());
   auto op0Width = getBitWidthOrSentinel(op->getOperand(0).getType());
   auto op1Width = getBitWidthOrSentinel(op->getOperand(1).getType());
@@ -977,7 +999,8 @@ SubExprInfo ExprEmitter::emitFIRRTLBinary(Operation *op, VerilogPrecedence prec,
     else
       os << "{{" << (retWidth - op0Width) << "'d0}, ";
   }
-  emitSubExpr(op->getOperand(0), (op0Width >= retWidth) ? prec : LowestPrecedence, true);
+  emitSubExpr(op->getOperand(0),
+              (op0Width >= retWidth) ? prec : LowestPrecedence, true);
   if (op0Width < retWidth) {
     if (!op0Signed && retSigned) {
       os << '[' << (op0Width - 1) << "]}}, ";
@@ -1021,7 +1044,7 @@ SubExprInfo ExprEmitter::emitFIRRTLBinary(Operation *op, VerilogPrecedence prec,
   // Otherwise, the result is signed if both operands are signed.
   SubExprSignedness signedness;
   if ((op0Signed && op1Signed) ||
-           getSignednessOf(op->getResult(0).getType()) == IsSigned)
+      getSignednessOf(op->getResult(0).getType()) == IsSigned)
     signedness = IsSigned;
   else
     signedness = IsUnsigned;
@@ -1029,37 +1052,33 @@ SubExprInfo ExprEmitter::emitFIRRTLBinary(Operation *op, VerilogPrecedence prec,
   return {prec, signedness};
 }
 
-  SubExprInfo ExprEmitter::emitUnary(Operation *op, const char *syntax, bool forceUnsigned) {
-    os << syntax;
-    auto signedness = emitSubExpr(op->getOperand(0),
-                                  Unary)
-                          .signedness;
-    return {Unary, forceUnsigned ? IsUnsigned : signedness};
-  }
+SubExprInfo ExprEmitter::emitUnary(Operation *op, const char *syntax,
+                                   bool forceUnsigned) {
+  os << syntax;
+  auto signedness = emitSubExpr(op->getOperand(0), Unary).signedness;
+  return {Unary, forceUnsigned ? IsUnsigned : signedness};
+}
 
 SubExprInfo ExprEmitter::emitFIRRTLUnary(Operation *op, const char *syntax) {
-    auto width = getBitWidthOrSentinel(op->getResult(0).getType());
-    auto opWidth = getBitWidthOrSentinel(op->getOperand(0).getType());
-    auto opSigned = IsSigned == getSignednessOf(op->getOperand(0).getType());
+  auto width = getBitWidthOrSentinel(op->getResult(0).getType());
+  auto opWidth = getBitWidthOrSentinel(op->getOperand(0).getType());
+  auto opSigned = IsSigned == getSignednessOf(op->getOperand(0).getType());
 
   os << syntax;
   if (opWidth < width) {
-    emitSubExpr(op->getOperand(0),ForceEmitMultiUse, true);
+    emitSubExpr(op->getOperand(0), ForceEmitMultiUse, true);
     if (opSigned)
-      os << syntax << "{{" << (width - opWidth) << '{' 
-         << emitter.getName(op->getOperand(0))
-         << '[' << (opWidth - 1) << "]}}, "
-         << emitter.getName(op->getOperand(0))
-         << "})";
+      os << syntax << "{{" << (width - opWidth) << '{'
+         << emitter.getName(op->getOperand(0)) << '[' << (opWidth - 1)
+         << "]}}, " << emitter.getName(op->getOperand(0)) << "})";
     else
       os << syntax << "{{" << (width - opWidth) << "'d0}, "
-         << emitter.getName(op->getOperand(0))
-         << "})";
-    } else {
-      emitSubExpr(op->getOperand(0), Unary, true);
-    }
-  return {Unary, opSigned ? IsSigned : IsUnsigned};
+         << emitter.getName(op->getOperand(0)) << "})";
+  } else {
+    emitSubExpr(op->getOperand(0), Unary, true);
   }
+  return {Unary, opSigned ? IsSigned : IsUnsigned};
+}
 
 SubExprInfo ExprEmitter::emitVariadic(Operation *op, VerilogPrecedence prec,
                                       const char *syntax, bool hasStrictSign) {
@@ -1071,8 +1090,9 @@ SubExprInfo ExprEmitter::emitVariadic(Operation *op, VerilogPrecedence prec,
   return {prec, IsUnsigned};
 }
 
-SubExprInfo ExprEmitter::emitFIRRTLVariadic(Operation *op, VerilogPrecedence prec,
-                                      const char *syntax) {
+SubExprInfo ExprEmitter::emitFIRRTLVariadic(Operation *op,
+                                            VerilogPrecedence prec,
+                                            const char *syntax) {
   auto width = getBitWidthOrSentinel(op->getResult(0).getType());
   bool opSigned = IsSigned == getSignednessOf(op->getResult(0).getType());
   interleave(
@@ -1088,8 +1108,7 @@ SubExprInfo ExprEmitter::emitFIRRTLVariadic(Operation *op, VerilogPrecedence pre
           else
             os << "{{" << (width - op0Width) << "'d0}, ";
         }
-        emitSubExpr(v1, op0Width >= width ? prec : LowestPrecedence,
-                    opSigned);
+        emitSubExpr(v1, op0Width >= width ? prec : LowestPrecedence, opSigned);
         if (op0Width < width) {
           if (op0Signed) {
             os << '[' << (op0Width - 1) << "]}}, ";

--- a/test/EmitVerilog/verilog-basic.fir
+++ b/test/EmitVerilog/verilog-basic.fir
@@ -99,7 +99,7 @@ circuit inputs_only :
 ; CHECK-NEXT:     assign x8 = clock ? 4'h1 : clock ? 4'h2 : 4'h3;
 ; CHECK-NEXT:     assign x9 = in4[3:2] | in4[1:0];
 ; CHECK-NEXT:     assign x10 = in4;
-; CHECK-NEXT:     assign x11 = {{\{\{}}2'd0}, in4} ^ {{\{\{}}2{in4[3]}}, in4} ^ {6{clock}};
+; CHECK-NEXT:     assign x11 = {{\{\{}}2'd0}, in4} ^ $signed({{\{\{}}2{in4[3]}}, in4}) ^ $signed({6{clock}});
 ; CHECK-NEXT:     assign x12 = in4;
 ; CHECK-NEXT:     assign x13 = in4 << in4;
 ; CHECK-NEXT:  endmodule
@@ -638,6 +638,9 @@ circuit inputs_only :
 
   ; CHECK-LABEL: module IsInvalid(
   ; CHECK-NEXT:    output a);
+  ; CHECK-EMPTY:
+  ; CHECK-NEXT:    assign a = '0;
+  ; CHECK-NEXT:  endmodule
   module IsInvalid :
     output a: Analog<1>
     a is invalid  @[Place.scala 101]

--- a/test/EmitVerilog/verilog-basic.fir
+++ b/test/EmitVerilog/verilog-basic.fir
@@ -130,18 +130,17 @@ circuit inputs_only :
 ; CHECK-NEXT:     output       out1,
 ; CHECK-NEXT:     output [3:0] out);
 ; CHECK-EMPTY:
-
-; CHECK-NEXT:     assign out = a + b + c;
-; CHECK-NEXT:     assign out = a + b - c;
-; CHECK-NEXT:     assign out = a - (b + c);
-; CHECK-NEXT:     assign out = a + b * c;
-; CHECK-NEXT:     assign out = a * b + c;
-; CHECK-NEXT:     assign out = (a + b) * c;
-; CHECK-NEXT:     assign out = a * (b + c);
-; CHECK-NEXT:     assign out = (a + b) * (b + c);
-; CHECK-NEXT:     assign out1 = ^(b + c);
+; CHECK-NEXT:     assign out = {{\{\{}}2'd0}, a} + {{\{\{}}1'd0}, {{\{\{}}1'd0}, b} + {{\{\{}}1'd0}, c}};
+; CHECK-NEXT:     assign out = {{\{\{}}1'd0}, {{\{\{}}1'd0}, a} + {{\{\{}}1'd0}, b}} - {{\{\{}}2'd0}, c};
+; CHECK-NEXT:     assign out = {{\{\{}}2'd0}, a} - {{\{\{}}1'd0}, {{\{\{}}1'd0}, b} + {{\{\{}}1'd0}, c}};
+; CHECK-NEXT:     assign out = {{\{\{}}5'd0}, a} + {{\{\{}}1'd0}, {{\{\{}}4'd0}, b} * {{\{\{}}4'd0}, c}};
+; CHECK-NEXT:     assign out = {{\{\{}}1'd0}, {{\{\{}}4'd0}, a} * {{\{\{}}4'd0}, b}} + {{\{\{}}5'd0}, c};
+; CHECK-NEXT:     assign out = {{\{\{}}4'd0}, {{\{\{}}1'd0}, a} + {{\{\{}}1'd0}, b}} * {{\{\{}}5'd0}, c};
+; CHECK-NEXT:     assign out = {{\{\{}}5'd0}, a} * {{\{\{}}4'd0}, {{\{\{}}1'd0}, b} + {{\{\{}}1'd0}, c}};
+; CHECK-NEXT:     assign out = {{\{\{}}5'd0}, {{\{\{}}1'd0}, a} + {{\{\{}}1'd0}, b}} * {{\{\{}}5'd0}, {{\{\{}}1'd0}, b} + {{\{\{}}1'd0}, c}};
+; CHECK-NEXT:     assign out1 = ^({{\{\{}}1'd0}, b} + {{\{\{}}1'd0}, c});
 ; CHECK-NEXT:     assign out1 = b < c | b > c;
-; CHECK-NEXT:     assign out1 = (b ^ c) & (out1 | out1);
+; CHECK-NEXT:     assign out1 = (b ^ c) & {{\{\{}}3'd0}, out1 | out1};
 ; CHECK-NEXT:     assign out1 = out[3:2];
 ; CHECK-NEXT:     assign out1 = out < a;
 ; CHECK-NEXT:  endmodule
@@ -190,11 +189,11 @@ circuit inputs_only :
 ; CHECK-NEXT:     assign out = $signed(c) >= $signed(d);
 ; CHECK-NEXT:     assign out = $signed(a) >= $signed(b);
 ; CHECK-NEXT:     assign out = a == b;
-; CHECK-NEXT:     assign out = c == d;
-; CHECK-NEXT:     assign out = a == b;
+; CHECK-NEXT:     assign out = $signed(c) == $signed(d);
+; CHECK-NEXT:     assign out = $signed(a) == $signed(b);
 ; CHECK-NEXT:     assign out = a != b;
-; CHECK-NEXT:     assign out = c != d;
-; CHECK-NEXT:     assign out = a != b
+; CHECK-NEXT:     assign out = $signed(c) != $signed(d);
+; CHECK-NEXT:     assign out = $signed(a) != $signed(b)
 ; CHECK-NEXT:  endmodule
 
 
@@ -234,9 +233,9 @@ circuit inputs_only :
 ; CHECK-NEXT:     assign out = a >= b;
 ; CHECK-NEXT:     assign out = $signed(c) >= $signed(d);
 ; CHECK-NEXT:     assign out = a == b;
-; CHECK-NEXT:     assign out = c == d;
+; CHECK-NEXT:     assign out = $signed(c) == $signed(d);
 ; CHECK-NEXT:     assign out = a != b;
-; CHECK-NEXT:     assign out = c != d;
+; CHECK-NEXT:     assign out = $signed(c) != $signed(d);
 ; CHECK-NEXT:  endmodule
 
 
@@ -253,7 +252,7 @@ circuit inputs_only :
     ;; emitter needs to reintroduce it as an 'assign' to a local.
 
     node _T_42 = andr(xorr(a)) ; CHECK-NEXT:    wire _T = &^a;
-    node _T_99 = add(a, a)     ; CHECK-NEXT:    wire [4:0] _T_0 = a + a;
+    node _T_99 = add(a, a)     ; CHECK-NEXT:    wire [4:0] _T_0 = {{\{\{}}1'd0}, a} + {{\{\{}}1'd0}, a};
 
     b <= andr(_T_42)           ; CHECK-NEXT:    assign b = &_T;
     b <= xorr(_T_42)           ; CHECK-NEXT:    assign b = ^_T;
@@ -387,7 +386,7 @@ circuit inputs_only :
   ; CHECK-EMPTY:
   ; CHECK-NEXT:    always @(posedge clock) begin
   ; CHECK-NEXT:      `ifndef SYNTHESIS
-  ; CHECK-NEXT:        if (`PRINTF_COND_ && reset) $fwrite(32'h80000002, "Hi %x %x\n", a + a, b);
+  ; CHECK-NEXT:        if (`PRINTF_COND_ && reset) $fwrite(32'h80000002, "Hi %x %x\n", {{\{\{}}1'd0}, a} + {{\{\{}}1'd0}, a}, b);
   ; CHECK-NEXT:      `endif
   ; CHECK-NEXT:    end // always @(posedge)
   ; CHECK-NEXT:  endmodule
@@ -657,8 +656,8 @@ circuit inputs_only :
     b <= xor(_T_4, UInt<4>("h10"))        @[A.scala 101:15]
 
 
-; CHECK: assign b = a + a + 4'h3 ^ 4'h1;
+; CHECK: assign b = {{\{\{}}1'd0}, {{\{\{}}1'd0}, a} + {{\{\{}}1'd0}, a}} + {{\{\{}}2'd0}, 4'h3} ^ {{\{\{}}2'd0}, 4'h1};
 ; CHECK: // Other.scala:51:15, Place.scala:101:{13,15}
 
-; CHECK: assign b = a * a * 4'h2 ^ 4'h0;
+; CHECK: assign b = {{\{\{}}4'd0}, {{\{\{}}4'd0}, a} * {{\{\{}}4'd0}, a}} * {{\{\{}}8'd0}, 4'h2} ^ {{\{\{}}8'd0}, 4'h0};
 ; CHECK: // A.scala:11:13, :51:15, :101:15


### PR DESCRIPTION
Use the firrtl types to determine signness and force operations to be interpreted that way.
Use the firrtl op sizes to determine operation width. Verilog has complex rules to determine operation width which are context-sensitive (expressions with an assignment have different inferred width (and thus extension behavior) than expressions which are subexpressions.

To deal with this, use the firrtl operation width and always output the sign/zero extension of the operands. This way when walking an expression tree, we can build the output in a context-independent way.

This adds to the locations where we are duplicating expression trees rather than promoting sub-expressions to wires. I believe this is (extremely) ugly, but correct and shouldn't hurt synthesized output of the code. I strongly lean towards fixing this be a separate cleanup. Likewise, some of the $signed casts are unnecessary, this conservatively adds them unconditionally based on firrtl type.

The semantics of the firrtl verilog output was checked with formal equivalence checks against the scala firrtl compiler.

