### PR TITLE
[FIRRTL] Replace RHS Sinks used as Sources with Wires

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2129,6 +2129,7 @@ ParseResult FIRStmtParser::parseRegister(unsigned regIndent) {
         parseToken(FIRToken::l_paren, "expected '(' in reset specifier") ||
         parseExp(resetSignal, subOps, "expected expression for reset signal"))
       return failure();
+    resetSignal = convertToPassive(resetSignal, resetSignal.getLoc());
 
     // The Scala implementation of FIRRTL represents registers without resets
     // as a self referential register... and the pretty printer doesn't print

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2103,6 +2103,7 @@ ParseResult FIRStmtParser::parseRegister(unsigned regIndent) {
       parseType(type, "expected reg type") ||
       parseExp(clock, subOps, "expected expression for register clock"))
     return failure();
+  clock = convertToPassive(clock, clock.getLoc());
 
   // Parse the 'with' specifier if present.
   Value resetSignal, resetValue;

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2147,6 +2147,7 @@ ParseResult FIRStmtParser::parseRegister(unsigned regIndent) {
           parseToken(FIRToken::r_paren, "expected ')' in reset specifier") ||
           parseOptionalInfo(info, subOps))
         return failure();
+      resetValue = convertToPassive(resetValue, resetValue.getLoc());
     }
 
     if (hasExtraLParen &&

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -289,10 +289,6 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.subaccess %_t[%i8] : (!firrtl.vector<uint<1>, 12>, !firrtl.uint<8>) -> !firrtl.uint<1>
     auto <= _t[i8]
 
-    ; CHECK: [[autoP:%.+]] = firrtl.asPassive %auto : (!firrtl.flip<uint<1>>) -> !firrtl.uint<1>
-    ; CHECK: firrtl.subaccess %_t{{\[}}[[autoP]]] : (!firrtl.vector<uint<1>, 12>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    auto <= _t[auto]
-
     ; CHECK: %myMem = firrtl.cmem {name = "myMem"} : !firrtl.vector<bundle<id: uint<4>, resp: uint<2>>, 8>
     cmem myMem : { id : UInt<4>, resp : UInt<2>} [8] @[Decoupled.scala 209:24]
 
@@ -324,11 +320,6 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     ; CHECK: firrtl.andr %n12
     node value = andr(_GEN_43)    ;; Uses n12 directly.
-
-    ; CHECK: [[autoP:%.+]] = firrtl.asPassive %auto : (!firrtl.flip<uint<1>>) -> !firrtl.uint<1>
-    ; CHECK-NEXT: = firrtl.not [[autoP]] : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    node n13 = not(auto)
-
 
     ; CHECK: %_M = firrtl.mem "Undefined" {depth = 8 : i64, name = "_M",
     ; CHECK:   readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<
@@ -488,15 +479,6 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK:  %f = firrtl.node [[CST15]]
     node f = UInt<4>(15)
     node g = UInt<4>(7)
-
-  ; CHECK-LABEL: firrtl.module @flip_one
-  module flip_one :
-    input bf: { flip int_1 : UInt<1>, int_out : UInt<2>}
-    ; CHECK: %0 = firrtl.subfield %bf("int_1")
-    node _T = bf.int_1
-    ; CHECK: %1 = firrtl.asPassive %0 : (!firrtl.flip<uint<1>>) -> !firrtl.uint<1>
-    when _T :  ; CHECK: firrtl.when %1 {
-      skip
 
   ; CHECK-LABEL: firrtl.module @mem_depth_1
   module mem_depth_1 :

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -557,3 +557,14 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: [[rst_passive:%.+]] = firrtl.asPassive %rst
     ; CHECK: firrtl.regreset %clk, [[rst_passive]]
     reg r: UInt<1>, clk with : (reset => (rst, UInt<1>(0)))
+
+  ; COM: Check that a register init sink is converted to passive
+  ; CHECK-LABEL: firrtl.module @register_init_passive
+  module register_init_passive:
+    input clk: Clock
+    input rst: UInt<1>
+    output init: UInt<1>
+    init is invalid
+    ; CHECK: [[init_passive:%.+]] = firrtl.asPassive %init
+    ; CHECK: firrtl.regreset %clk, %rst, [[init_passive]]
+    reg r: UInt<1>, clk with : (reset => (rst, init))

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -537,3 +537,13 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input a: { a: UInt<1>, b: Analog<1>}
     ; CHECK: %b = firrtl.node %a {{.+}}: !firrtl.bundle<a: uint<1>, b: analog<1>>
     node b = a
+
+  ; COM: Check that a register clock sink is converted to passive
+  ; CHECK-LABEL: firrtl.module @register_clock_passive
+  module register_clock_passive:
+    input clkIn: Clock
+    output clkOut: Clock
+    clkOut <= clkIn
+    ; CHECK: [[clkOut_passive:%.+]] = firrtl.asPassive %clkOut
+    ; CHECK: firrtl.reg [[clkOut_passive]]
+    reg r: UInt<1>, clkOut

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -547,3 +547,13 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: [[clkOut_passive:%.+]] = firrtl.asPassive %clkOut
     ; CHECK: firrtl.reg [[clkOut_passive]]
     reg r: UInt<1>, clkOut
+
+  ; COM: Check that a register reset sink is converted to passive
+  ; CHECK-LABEL: firrtl.module @register_reset_passive
+  module register_reset_passive:
+    input clk: Clock
+    output rst: UInt<1>
+    rst is invalid
+    ; CHECK: [[rst_passive:%.+]] = firrtl.asPassive %rst
+    ; CHECK: firrtl.regreset %clk, [[rst_passive]]
+    reg r: UInt<1>, clk with : (reset => (rst, UInt<1>(0)))

--- a/test/Dialect/FIRRTL/parse-rhs-sinks.fir
+++ b/test/Dialect/FIRRTL/parse-rhs-sinks.fir
@@ -1,0 +1,537 @@
+; RUN: circt-translate -parse-fir -verify-diagnostics -split-input-file %s | FileCheck %s
+
+circuit Foo :
+  module Foo :
+    output a : UInt<1>
+    output b : UInt<1>
+    a is invalid
+    b <= a
+
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK: [[WIRE:%.+]] = firrtl.wire : !firrtl.flip<uint<1>>
+    ; CHECK: firrtl.connect %a, [[WIRE]]
+    ; CHECK: [[INVALID:%.+]] = firrtl.invalidvalue
+    ; CHECK: firrtl.connect [[WIRE]], [[INVALID]]
+    ; CHECK: firrtl.connect %b, [[WIRE]]
+
+    ; // -----
+
+circuit Foo :
+  module Foo :
+    output a : UInt<1>
+    output b : UInt<1>
+    a <= UInt<1>("h0")
+    b <= a
+
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK: [[WIRE:%.+]] = firrtl.wire : !firrtl.flip<uint<1>>
+    ; CHECK: firrtl.connect %a, [[WIRE]]
+    ; CHECK: [[ZERO:%.+]] = firrtl.constant
+    ; CHECK: firrtl.connect [[WIRE]], [[ZERO]]
+    ; CHECK: firrtl.connect %b, [[WIRE]]
+
+    ; // -----
+
+circuit Foo :
+  module Foo :
+    output a : UInt<1>
+    output b : UInt<1>
+    input c : UInt<1>
+    a <- c
+    b <- a
+
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK: [[WIRE:%.+]] = firrtl.wire : !firrtl.flip<uint<1>>
+    ; CHECK: firrtl.connect %a, [[WIRE]]
+    ; CHECK: firrtl.partialconnect [[WIRE]], %c
+    ; CHECK: firrtl.partialconnect %b, [[WIRE]]
+
+    ; // -----
+
+circuit Foo :
+  module Foo :
+    output a : { b : UInt<1>, c : UInt<1>}
+    output b : UInt<1>
+    a is invalid
+    b <= a.b
+
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK: [[WIRE:%.+]] = firrtl.wire : !firrtl.flip<bundle<b: uint<1>, c: uint<1>>>
+    ; CHECK: firrtl.connect %a, [[WIRE]]
+    ; CHECK: [[INVALID:%.+]] = firrtl.invalidvalue
+    ; CHECK: firrtl.connect [[WIRE]], [[INVALID]]
+    ; CHECK: [[SUBFIELD:%.+]] = firrtl.subfield [[WIRE]]("b")
+    ; CHECK: firrtl.connect %b, [[SUBFIELD]]
+
+    ; // -----
+
+circuit Foo :
+  module Foo :
+    input a : { b : UInt<1>, flip c : UInt<1>}
+    output b : { b : UInt<1>, flip c : UInt<1>}
+    output c : UInt<1>
+    b <= a
+    c <= b.b
+
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK: [[WIRE:%.+]] = firrtl.wire : !firrtl.bundle<b: flip<uint<1>>, c: uint<1>>
+    ; CHECK: firrtl.connect %b, [[WIRE]]
+    ; CHECK; firrtl.connect [[WIRE]], %a
+    ; CHECK: [[SUBFIELD:%.+]] = firrtl.subfield [[WIRE]]("b")
+    ; CHECK: firrtl.connect %c, [[SUBFIELD]]
+
+    ; // -----
+
+circuit Foo :
+  module Foo :
+    input a : { b : UInt<1>, flip c : UInt<1>}
+    output b : { b : UInt<1>, flip c : UInt<1>}
+    output c : UInt<1>
+    b.b <= a.b
+    a.c <= b.c
+    c <= b.b
+
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK: [[WIRE:%.+]] = firrtl.wire : !firrtl.bundle<b: flip<uint<1>>, c: uint<1>>
+    ; CHECK: firrtl.connect %b, [[WIRE]]
+    ; CHECK-DAG: [[WIRE_B:%.+]] = firrtl.subfield [[WIRE]]("b")
+    ; CHECK-DAG: [[A_B:%.+]] = firrtl.subfield %a("b")
+    ; CHECK: firrtl.connect [[WIRE_B]], [[A_B]]
+    ; CHECK-DAG: [[WIRE_C:%.+]] = firrtl.subfield [[WIRE]]("c")
+    ; CHECK-DAG: [[A_C:%.+]] = firrtl.subfield %a("c")
+    ; CHECK: firrtl.connect [[A_C]], [[WIRE_C]]
+    ; CHECK-DAG: [[WIRE_B:%.+]] = firrtl.subfield [[WIRE]]("b")
+    ; CHECK: firrtl.connect %c, [[WIRE_B]]
+
+    ; // -----
+
+circuit Foo :
+  module Foo :
+    output a : { a : UInt<1>, flip b : UInt<1>}
+    output b : { a : UInt<1>}
+    b is invalid
+    a <- b
+
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK: [[WIRE:%.+]] = firrtl.wire : !firrtl.flip<bundle<a: uint<1>>>
+    ; CHECK: [[INVALID:%.+]] = firrtl.invalidvalue
+    ; CHECK: firrtl.connect [[WIRE]], [[INVALID]]
+    ; CHECK: firrtl.partialconnect %a, [[WIRE]]
+
+    ; // -----
+
+circuit Foo :
+  module Foo :
+    input cond : UInt<1>
+    output a : UInt<1>
+    output b : UInt<1>
+    when eq(cond, UInt<1>("h0")) :
+      a <= UInt<1>("h0")
+    else :
+      when eq(cond, UInt<1>("h1")) :
+        a <= UInt<1>("h1")
+      else :
+        a <= UInt<1>("h0")
+    b <= a
+
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK: [[WIRE:%.+]] = firrtl.wire : !firrtl.flip<uint<1>>
+    ; CHECK: firrtl.connect %a, [[WIRE]]
+    ; CHECK-COUNT-3: firrtl.connect [[WIRE]]
+    ; CHECK: firrtl.connect %b, [[WIRE]]
+
+    ; // -----
+
+circuit Foo :
+  module Foo :
+    input a : { flip a: UInt<1> }
+    node b = a.a
+
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK: [[WIRE:%.+]] = firrtl.wire : !firrtl.flip<bundle<a: uint<1>>>
+    ; CHECK: firrtl.connect %a, [[WIRE]]
+    ; CHECK: [[WIRE_a:%.+]] = firrtl.subfield [[WIRE]]("a")
+    ; CHECK: [[WIRE_a_passive:%.+]] = firrtl.asPassive [[WIRE_a]]
+    ; CHECK; firrtl.node [[WIRE_passive]]
+
+    ; // -----
+
+circuit Foo :
+  module Foo :
+    input a : UInt<2>
+    output b : UInt<1>
+    output c : UInt<1>
+    b is invalid
+    c <= not(b)
+
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK: [[WIRE:%.+]] = firrtl.wire : !firrtl.flip<uint<1>>
+    ; CHECK: firrtl.connect %b, [[WIRE]]
+    ; CHECK: [[INVALID:%.+]] = firrtl.invalidvalue
+    ; CHECK: firrtl.connect [[WIRE]], [[INVALID]]
+    ; CHECK: [[A:%.+]] = firrtl.asPassive [[WIRE]]
+    ; CHECK: [[B:%.+]] = firrtl.not [[A]]
+    ; CHECK: firrtl.connect %c, [[B]]
+
+    ; // -----
+
+circuit Foo :
+  module Foo :
+    input a : UInt<1>[2]
+    output b : UInt<1>
+    output c : UInt<1>
+    b is invalid
+    c <= a[b]
+
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK: [[WIRE:%.+]] = firrtl.wire : !firrtl.flip<uint<1>>
+    ; CHECK: firrtl.connect %b, [[WIRE]]
+    ; CHECK: [[INVALID:%.+]] = firrtl.invalidvalue
+    ; CHECK: firrtl.connect [[WIRE]], [[INVALID]]
+    ; CHECK: %1 = firrtl.asPassive [[WIRE]]
+    ; CHECK: firrtl.subaccess %a[%1]
+
+    ; // -----
+
+circuit Foo :
+  module Foo :
+    input decoupled : { flip ready : UInt<1>, valid : UInt<1>}
+    decoupled.ready is invalid
+    node c = and(decoupled.ready, decoupled.valid)
+
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK: [[WIRE:%.+]] = firrtl.wire : !firrtl.bundle<ready: flip<uint<1>>, valid: uint<1>>
+    ; CHECK: firrtl.connect %decoupled, [[WIRE]]
+    ; CHECK: [[WIRE_ready:%.+]] = firrtl.subfield [[WIRE]]("ready")
+    ; CHECK: [[INVALID:%.+]] = firrtl.invalidvalue
+    ; CHECK: firrtl.connect [[WIRE_ready]], [[INVALID]]
+    ; CHECK: [[WIRE_ready:%.+]] = firrtl.subfield [[WIRE]]("ready")
+    ; CHECK: [[WIRE_ready_passive:%.+]] = firrtl.asPassive [[WIRE_ready]]
+    ; CHECK: [[WIRE_valid:%.+]] = firrtl.subfield [[WIRE]]("valid")
+    ; CHECK: [[AND:%.+]] = firrtl.and [[WIRE_ready_passive]], [[WIRE_valid]]
+    ; CHECK: %c = firrtl.node [[AND]]
+
+    ; // -----
+
+circuit Foo :
+  module Foo :
+    output a : { a : UInt<1>}
+    output b : { a : UInt<1>}
+    wire w : { a : UInt<1>}
+    b is invalid
+    w <= b
+    a <= w
+
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK: [[WIRE:%.+]] = firrtl.wire : !firrtl.flip<bundle<a: uint<1>>>
+    ; CHECK: firrtl.connect %b, [[WIRE]]
+    ; CHECK: [[INVALID:%.+]] = firrtl.invalidvalue
+    ; CHECK: firrtl.connect [[WIRE]], [[INVALID]]
+    ; CHECK: firrtl.connect %w, [[WIRE]]
+    ; CHECK: firrtl.connect %a, %w
+
+    ; // -----
+
+circuit Foo :
+  module Foo :
+    output a : { a : UInt<1>}
+    output b : { a : UInt<1>}
+    input clk : Clock
+    reg r : { a : UInt<1>}, clk with :
+      reset => (UInt<1>("h0"), r)
+    b is invalid
+    r <= b
+    a <= r
+
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK: [[WIRE:%.+]] = firrtl.wire : !firrtl.flip<bundle<a: uint<1>>>
+    ; CHECK: firrtl.connect %b, [[WIRE]]
+    ; CHECK: [[INVALID:%.+]] = firrtl.invalidvalue
+    ; CHECK: firrtl.connect [[WIRE]], [[INVALID]]
+    ; CHECK: firrtl.connect %r, [[WIRE]]
+    ; CHECK: firrtl.connect %a, %r
+
+    ; // -----
+
+circuit Foo :
+  module Foo :
+    input clkIn : Clock
+    output clkOut : Clock
+    reg r : UInt<1>, clkOut with :
+      reset => (UInt<1>("h0"), r)
+    clkOut <= clkIn
+
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK: [[WIRE:%.+]] = firrtl.wire : !firrtl.flip<clock>
+    ; CHECK: firrtl.connect %clkOut, [[WIRE]]
+    ; CHECK: [[WIRE_passive:%.+]] = firrtl.asPassive [[WIRE]]
+    ; CHECK: %r = firrtl.reg [[WIRE_passive]]
+
+    ; // -----
+
+circuit Foo :
+  module Foo :
+    output a : AsyncReset
+    input clk : Clock
+    reg r : UInt<1>, clk with :
+      reset => (a, UInt<1>("h0"))
+    a is invalid
+    r is invalid
+
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK: [[WIRE:%.+]] = firrtl.wire : !firrtl.flip<asyncreset>
+    ; CHECK: firrtl.connect %a, [[WIRE]]
+    ; CHECK: [[WIRE_passive:%.+]] = firrtl.asPassive [[WIRE]]
+    ; CHECK: firrtl.regreset %clk, [[WIRE_passive]]
+
+    ; // -----
+
+circuit Foo :
+  module Foo :
+    output a : UInt<1>
+    input clk : Clock
+    input rst : UInt<1>
+    reg r : UInt<1>, clk with :
+      reset => (rst, a)
+    a is invalid
+    r is invalid
+
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK: [[WIRE:%.+]] = firrtl.wire : !firrtl.flip<uint<1>>
+    ; CHECK: firrtl.connect %a, [[WIRE]]
+    ; CHECK: [[WIRE_passive]] = firrtl.asPassive [[WIRE]]
+    ; CHECK: firrtl.regreset %clk, %rst, [[WIRE_passive]]
+
+    ; // -----
+
+circuit Foo :
+  module Foo :
+    input in : { flip ready : UInt<1>, valid : UInt<1>}
+    output out : { flip ready : UInt<1>, valid : UInt<1>}
+    out <= in
+
+    ; COM: This test should not be changed. The connect is bi-directional.
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK-NOT: firrtl.wire
+
+    ; // -----
+
+circuit Foo :
+  module Foo :
+    input a : { a : UInt<1>}
+    output b : { a : UInt<1>}
+    b <= a
+
+    ; COM: This test should not be changed. The connect is legal.
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK-NOT: firrtl.wire
+
+    ; // -----
+
+circuit Foo :
+  module Foo :
+    output a : { flip a : UInt<1>}
+    input b : { flip a : UInt<1>}
+    a <= b
+
+    ; COM: This test should not be changed. The connect is legally backwards.
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK-NOT: firrtl.wire
+
+    ; // -----
+
+circuit Foo :
+  module Foo :
+    input a : { a : UInt<1>}
+    output b : { a : UInt<1>}
+    b <- a
+
+    ; COM: This test should not be changed. The connect is legal.
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK-NOT: firrtl.wire
+
+    ; // -----
+
+circuit Foo :
+  module Foo :
+    output a : { flip a : UInt<1>}
+    input b : { flip a : UInt<1>}
+    a <- b
+
+    ; COM: This test should not be changed. The connect is legally backwards.
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK-NOT: firrtl.wire
+
+    ; // -----
+
+circuit Foo :
+  module Foo :
+    input a : { a : UInt<1>}
+    output b : { a : UInt<1>}
+    wire w: { a: UInt<1>}
+    w <= a
+    b <= w
+
+    ; COM: This test should not be changed. The connect is legal.
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK-NOT: %0 = firrtl.wire
+
+    ; // -----
+
+circuit Foo :
+  module Foo :
+    output a : { flip a : UInt<1>}
+    input b : { flip a : UInt<1>}
+    wire w: { flip a: UInt<1>}
+    a <= w
+    w <= b
+
+    ; COM: This test should not be changed. The connect is legally backwards with an intermediary wire.
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK-NOT: %0 = firrtl.wire
+
+    ; // -----
+
+circuit Foo :
+  module Foo :
+    input a : { a : UInt<1>}
+    output b : { a : UInt<1>}
+    wire w: { a: UInt<1>}
+    w <- a
+    b <- w
+
+    ; COM: This test should not be changed. The connect is legal.
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK-NOT: %0 = firrtl.wire
+
+    ; // -----
+
+circuit Foo :
+  module Foo :
+    output a : { flip a : UInt<1>}
+    input b : { flip a : UInt<1>}
+    wire w: { flip a: UInt<1>}
+    a <- w
+    w <- b
+
+    ; COM: This test should not be changed. The connect is legally backwards with an intermediary wire.
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK-NOT: %0 = firrtl.wire
+
+    ; // -----
+
+circuit Foo :
+  module Foo :
+    input a: { flip a: UInt<1> }
+    a is invalid
+    wire w : { flip a: UInt<1>, b: UInt<1> }
+    w is invalid
+    w <- a
+
+    ; COM: This test should not result in a wire being created.
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK-NOT: %0 = firrtl.wire
+
+    ; // -----
+
+circuit Foo :
+  module Foo :
+    output a: { a: UInt<1> }
+    a is invalid
+    wire w : { a: UInt<1>, flip b: UInt<1> }
+    w is invalid
+    w <- a
+
+    ; COM: This test should result in a wire being created
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK-COUNT-2: firrtl.wire
+
+    ; // -----
+
+circuit Foo :
+  module Bar :
+    input a : UInt<1>
+  module Foo :
+    output a : UInt<1>
+
+    inst bar of Bar
+    bar.a is invalid
+    a <= bar.a
+
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK: [[WIRE:%.+]] = firrtl.wire : !firrtl.flip<uint<1>>
+    ; CHECK-DAG: [[INVALID:%.+]] = firrtl.invalidvalue
+    ; CHECK-DAG: firrtl.connect [[WIRE]], [[INVALID]]
+    ; CHECK-DAG: firrtl.subfield %bar("a")
+    ; CHECK-DAG: [[SUBFIELD:%.+]] = firrtl.subfield %bar("a")
+    ; CHECK-NOT: -------------------- (DAG region separator)
+    ; CHECK-DAG: firrtl.connect %a, [[WIRE]]
+    ; CHECK-DAG: firrtl.connect [[SUBFIELD]], [[WIRE]]
+
+    ; // -----
+
+circuit Foo :
+  module Bar :
+    input a : { flip b : UInt<1>, c : UInt<1>}
+
+    skip
+
+  module Foo :
+    input a : { flip b : UInt<1>, c : UInt<1>}
+
+    inst bar of Bar
+    a <= bar.a
+
+    ; COM: This circuit should be unmodified
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK-NOT: firrtl.wire
+
+    ; // -----
+
+circuit Foo :
+  module Bar :
+    input a : UInt<1>
+
+  module Foo :
+    output a : UInt<1>
+
+    inst bar of Bar
+
+    bar.a is invalid
+    a <= not(bar.a)
+
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK: [[WIRE:%.+]] = firrtl.wire : !firrtl.flip<uint<1>>
+    ; CHECK-DAG: [[INVALID:%.+]] = firrtl.invalidvalue
+    ; CHECK-DAG: firrtl.connect [[WIRE]], [[INVALID]]
+    ; CHECK-DAG: firrtl.subfield %bar("a")
+    ; CHECK-DAG: [[SUBFIELD:%.+]] = firrtl.subfield %bar("a")
+    ; CHECK: firrtl.connect [[SUBFIELD]], [[WIRE]]
+    ; CHECK: [[WIRE_passive:%.+]] = firrtl.asPassive [[WIRE]]
+    ; CHECK: [[NOT:%.+]] = firrtl.not [[WIRE_passive]]
+    ; CHECK-DAG: firrtl.connect %a, [[NOT]]
+
+    ; // -----
+
+circuit Foo :
+  module Bar :
+    input i : UInt<1>
+    output o : UInt<1>
+    o <= i
+  module Foo :
+    input i : UInt<1>
+    output o : UInt<1>
+    inst bar of Bar
+    bar.i <= i
+    node x = and(bar.i, bar.o)
+    o <= x
+
+    ; CHECK-LABEL: firrtl.circuit
+    ; CHECK: [[WIRE:%.+_synthetic]] = firrtl.wire : !firrtl.flip<uint<1>>
+    ; CHECK: firrtl.connect [[WIRE]], %i
+    ; CHECK: [[SUBFIELD_i:%.+]] = firrtl.subfield %bar("i")
+    ; CHECK: firrtl.connect [[SUBFIELD_i]], [[WIRE]]
+    ; CHECK-DAG: [[WIRE_passive:%.+]] = firrtl.asPassive [[WIRE]]
+    ; CHECK-DAG: [[SUBFIELD_o:%.+]] = firrtl.subfield %bar("o")
+    ; CHECK: [[AND:%.+]] = firrtl.and [[WIRE_passive]], [[SUBFIELD_o]]
+    ; CHECK: %x = firrtl.node [[AND]]

--- a/test/ExportVerilog/verilog-basic.fir
+++ b/test/ExportVerilog/verilog-basic.fir
@@ -122,20 +122,25 @@ circuit inputs_only :
 ; CHECK-NEXT:     output       out1,
 ; CHECK-NEXT:     output [9:0] out);
 ; CHECK-EMPTY:
-
-; CHECK-NEXT:     assign out = a + b + c;
-; CHECK-NEXT:     assign out = a + b - c;
-; CHECK-NEXT:     assign out = a - (b + c);
-; CHECK-NEXT:     assign out = a + b * c;
-; CHECK-NEXT:     assign out = a * b + c;
-; CHECK-NEXT:     assign out = (a + b) * c;
-; CHECK-NEXT:     assign out = a * (b + c);
-; CHECK-NEXT:     assign out = (a + b) * (b + c);
-; CHECK-NEXT:     assign out1 = ^(b + c);
-; CHECK-NEXT:     assign out1 = b < c | b > c;
-; CHECK-NEXT:     assign out = (b ^ c) & (out1 | out1);
-; CHECK-NEXT:     assign out = out[9:2];
-; CHECK-NEXT:     assign out1 = out < a;
+; CHECK-NEXT:     wire [9:0] [[WIRE_out:.+]];
+; CHECK-NEXT:     wire       [[WIRE_out1:.+]];
+; CHECK-EMPTY:
+; CHECK-NEXT:     assign out = [[WIRE_out]];
+; CHECK-NEXT:     assign out1 = [[WIRE_out1]];
+; CHECK-NEXT:     assign [[WIRE_out]] = a + b + c;
+; CHECK-NEXT:     assign [[WIRE_out]] = a + b - c;
+; CHECK-NEXT:     assign [[WIRE_out]] = a - (b + c);
+; CHECK-NEXT:     assign [[WIRE_out]] = a + b * c;
+; CHECK-NEXT:     assign [[WIRE_out]] = a * b + c;
+; CHECK-NEXT:     assign [[WIRE_out]] = (a + b) * c;
+; CHECK-NEXT:     assign [[WIRE_out]] = a * (b + c);
+; CHECK-NEXT:     assign [[WIRE_out]] = (a + b) * (b + c);
+; CHECK-NEXT:     assign [[WIRE_out1]] = ^(b + c);
+; CHECK-NEXT:     assign [[WIRE_out1]] = b < c | b > c;
+; CHECK-NEXT:     assign [[WIRE_out]] = (b ^ c) & ([[WIRE_out1]] | [[WIRE_out1]]);
+; CHECK-NEXT:     wire [9:0] [[WIRE_out_copy:_.+]] = [[WIRE_out]];
+; CHECK-NEXT:     assign [[WIRE_out]] = [[WIRE_out_copy]][9:2];
+; CHECK-NEXT:     assign [[WIRE_out1]] = [[WIRE_out]] < a;
 ; CHECK-NEXT:  endmodule
 
 
@@ -273,7 +278,7 @@ circuit inputs_only :
     output out: UInt<1>
     defname = FooExtModule
 
-  extmodule MyParameterizedExtModule : 
+  extmodule MyParameterizedExtModule :
     input in: UInt<8>
     output out: UInt<1>
     parameter FORMAT = "xyz_timeout=%d\n"


### PR DESCRIPTION
Change the FIRRTL parser to remove usages of sinks as _right hand side_ (RHS) expressions (either output ports or instance inputs that show up on the RHS). These are replaced with an intermediary wire and all connections are updated.

Note: this is currently partially handled by casts using `firrtl.asPassive`. However, this PR pushes towards limiting `asPassive` casts to only things which have in-out behavior. Namely, registers and wires. If anything else is used illegally in an in-out way (e.g., a module output port or an instance input port), then it is replaced by a wire and the wire is cast `asPassive` when needed.

There are a lot of examples in the tests, but a simple example is below. Here, port `a` is illegally used as a source.

```
circuit Foo :
  module Foo :
    output a : UInt<1>
    output b : UInt<1>
    a is invalid
    b <= a
```

This is converted to:

```
circuit Foo :
  module Foo :
    output a : UInt<1>
    output b : UInt<1>
    wire a_synthetic : UInt<1>
    a <= a_synthetic
    a_synthetic is invalid
    b <= a_synthetic
```

This PR adds the ability to compute Scala FIRRTL Compiler "flow", but doesn't use it. This is merely a convenience for computing if something needs to have an intermediary wire added.

### Relationship to Chisel3 emitted FIRRTL IR ("CHIRRTL")

Chisel3 allows users to use almost anything as a RHS, including things which are traditionally "sinks". I.e., you can use an L-value as an R-value freely. The two common examples include:

1. Reading from an output port
2. Reading from an instance input port

While weird, this is actually quite useful in two situations:

1. You have no idea how one of these L-values was computed, but you want to read it's value. E.g., the value is being set inside some deep `when`/`.elsewhen`/`.otherwise` structure.
2. You want to "tap" some signal with a monitor or an assertion.

A full example could look like (for an interactive version see: https://scastie.scala-lang.org/DUXfJREnRee7nGA8CkgSgQ):

```scala
class Foo extends MultiIOModule {
  val a = IO(Output(Bool()))
  val sel = IO(Input(Bool()))
  
  a := 0.U
  when (sel) {
    a := 1.U
  }
  
  experimental.verification.assert(a =/= 0.U)
}
```

This produces the following. Note that `a` is used as an R-value when computing the node associated with the assert:

```
circuit Foo :
  module Foo :
    input clock : Clock
    input reset : UInt<1>
    output a : UInt<1>
    input sel : UInt<1>
    a <= UInt<1>("h0")
    when sel :
      a <= UInt<1>("h1")
    node _T = neq(a, UInt<1>("h0"))
    assert(clock, _T, UInt<1>("h1"), "")
```

Problematically, this results in the FIRRTL IR that Chsiel emits (usually called "CHIRRTL") to be illegal FIRRTL IR as defined in the FIRRTL specification. You aren't supposed to be able to use "sinks" as "sources". Because this is used liberally in Chisel code, sinks are allowed to be used as sources and never removed. Consequently, ports almost behave like wires (they have in-out semantics). This PR tries to remove that usage and relegate in-out semantics to only wires and registes.

With this PR, the above code example is immediately cleaned up to add a synthetic wire in place of the problematic `a`. This then relegates "wire"-like behavior to wires and registers and preserves the correct semantics of ports (that they are true R or L-values).