### PR TITLE
[RTL] Improving support for rtl::ArrayType

### DIFF
--- a/include/circt/Dialect/RTL/RTLCombinatorial.td
+++ b/include/circt/Dialect/RTL/RTLCombinatorial.td
@@ -200,14 +200,19 @@ def ConcatOp : VariadicRTLOp<"concat"> {
   ];
 }
 
+def Extractable
+  : Type<CPred<"$_self.isa<IntegerType>() ||"
+               "$_self.isa<ArrayType>()">,
+         "a type which can be sliced">;
+
 // Extract a range of bits from the specified input.
 def ExtractOp : RTLOp<"extract", [NoSideEffect]> {
   let summary = "Extract a range of bits into a smaller value, lowBit "
                 "specifies the lowest bit included.";
 
-  let arguments = (ins AnySignlessInteger:$input,
+  let arguments = (ins Extractable:$input,
                    I32Attr:$lowBit);
-  let results = (outs AnySignlessInteger:$result);
+  let results = (outs Extractable:$result);
 
   let assemblyFormat = [{
     $input `from` $lowBit attr-dict `:` functional-type($input, $result)
@@ -266,4 +271,14 @@ def MuxOp : RTLOp<"mux",
                    cond, trueValue, falseValue);
     }]>
   ];
+}
+
+def ReinterpretCast : RTLOp<"reinterpret_cast", [NoSideEffect]> {
+  let summary = "Change types without any conversion";
+
+  let arguments = (ins AnyType:$arg);
+  let results = (outs AnyType:$out);
+  let assemblyFormat = [{
+    $arg attr-dict `:` `(` type($arg) `)` `->` type($out)
+  }];
 }

--- a/include/circt/Dialect/RTL/RTLCombinatorial.td
+++ b/include/circt/Dialect/RTL/RTLCombinatorial.td
@@ -273,7 +273,7 @@ def MuxOp : RTLOp<"mux",
   ];
 }
 
-def ReinterpretCast : RTLOp<"reinterpret_cast", [NoSideEffect]> {
+def ReinterpretCastOp : RTLOp<"reinterpret_cast", [NoSideEffect]> {
   let summary = "Change types without any conversion";
 
   let arguments = (ins AnyType:$arg);

--- a/include/circt/Dialect/RTL/RTLVisitors.h
+++ b/include/circt/Dialect/RTL/RTLVisitors.h
@@ -27,7 +27,7 @@ public:
   ResultType dispatchCombinatorialVisitor(Operation *op, ExtraArgs... args) {
     auto *thisCast = static_cast<ConcreteType *>(this);
     return TypeSwitch<Operation *, ResultType>(op)
-        .template Case<ConstantOp,
+        .template Case<ConstantOp, ReinterpretCastOp,
                        // Arithmetic and Logical Binary Operations.
                        AddOp, SubOp, MulOp, DivUOp, DivSOp, ModUOp, ModSOp,
                        ShlOp, ShrUOp, ShrSOp,
@@ -82,6 +82,7 @@ public:
 
   // Basic nodes.
   HANDLE(ConstantOp, Unhandled);
+  HANDLE(ReinterpretCastOp, Unhandled);
 
   // Arithmetic and Logical Binary Operations.
   HANDLE(AddOp, Binary);

--- a/test/Dialect/RTL/basic.mlir
+++ b/test/Dialect/RTL/basic.mlir
@@ -86,6 +86,12 @@ func @test1(%arg0: i3, %arg1: i1) -> i50 {
   // CHECK-NEXT: = rtl.mux %arg1, [[RES2]], [[RES3]] : i7
   %mux = rtl.mux %arg1, %d, %e : i7
 
+  // CHECK-NEXT: [[RES24:%[0-9]+]] = rtl.reinterpret_cast %c42_i12 : (i12) -> !rtl.array<12xi1>
+  %array = rtl.reinterpret_cast %a : (i12) -> !rtl.array<12xi1>
+
+  // CHECK-NEXT: rtl.extract [[RES24]] from 2 : (!rtl.array<12xi1>) -> !rtl.array<4xi1>
+  %arraySlice = rtl.extract %array from 2 : (!rtl.array<12xi1>) -> !rtl.array<4xi1>
+
   // CHECK-NEXT:    return [[RES8]] : i50
   return %result : i50
 }

--- a/test/Dialect/RTL/errors.mlir
+++ b/test/Dialect/RTL/errors.mlir
@@ -30,6 +30,20 @@ func private @test_extract(%arg0: i4) {
 
 // -----
 
+func private @test_extract(%arg0: i4) {
+  // expected-error @+1 {{'rtl.extract' op argument and result types must match}}
+  %b = rtl.extract %arg0 from 2 : (i4) -> !rtl.array<12xi4>
+}
+
+// -----
+
+func private @test_extract(%arg0: !rtl.array<32xi4>) {
+  // expected-error @+1 {{'rtl.extract' op argument and result array types must have same element type}}
+  %b = rtl.extract %arg0 from 2 : (!rtl.array<32xi4>) -> !rtl.array<12xi1>
+}
+
+// -----
+
 func private @test_and() {
   // expected-error @+1 {{'rtl.and' op expected 1 or more operands}}
   %b = rtl.and : i111

--- a/test/ExportVerilog/rtl-dialect.mlir
+++ b/test/ExportVerilog/rtl-dialect.mlir
@@ -15,7 +15,9 @@ module {
     %r17: i1, %r18: i1, %r19: i1, %r20: i1,
     %r21: i1, %r22: i1, %r23: i1, %r24: i1,
     %r25: i1, %r26: i1, %r27: i1, %r28: i1,
-    %r29: i12, %r30: i2, %r31: i9, %r32: i9, %r33: i4, %r34: i4
+    %r29: i12, %r30: i2, %r31: i9, %r32: i9,
+    %r33: i4, %r34: i4, %r36: !rtl.array<3xi2>
+
     ) {
     
     %0 = rtl.add %a, %b : i4
@@ -53,21 +55,27 @@ module {
     %allone = rtl.constant (15 : i4) : i4
     %34 = rtl.xor %a, %allone : i4
 
-    rtl.output %0, %2, %4, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34:
+    %aab = rtl.concat %a, %a, %b : (i4, i4, i4) -> i12
+    %35 = rtl.reinterpret_cast %aab : (i12) -> !rtl.array<6xi2>
+    %36 = rtl.extract %35 from 0 : (!rtl.array<6xi2>) -> !rtl.array<3xi2>
+
+    rtl.output %0, %2, %4, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %36:
      i4,i4, i4,i4,i4,i4,i4, i4,i4,i4,i4,i4,
      i4,i1,i1,i1,i1, i1,i1,i1,i1,i1, i1,i1,i1,i1,
-     i12, i2,i9,i9,i4, i4
+     i12, i2,i9,i9,i4,i4,!rtl.array<3xi2>
   }
   // CHECK-LABEL: module TESTSIMPLE(
-  // CHECK-NEXT:   input  [3:0]  a, b
-  // CHECK-NEXT:   input         cond,
-  // CHECK-NEXT:   output [3:0]  r0, r2, r4, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15
-  // CHECK-NEXT:   output        r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28
-  // CHECK-NEXT:   output [11:0] r29,
-  // CHECK-NEXT:   output [1:0]  r30,
-  // CHECK-NEXT:   output [8:0]  r31, r32,
-  // CHECK-NEXT:   output [3:0]  r33, r34);
+  // CHECK-NEXT:   input  [3:0]      a, b
+  // CHECK-NEXT:   input             cond,
+  // CHECK-NEXT:   output [3:0]      r0, r2, r4, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15
+  // CHECK-NEXT:   output            r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28
+  // CHECK-NEXT:   output [11:0]     r29,
+  // CHECK-NEXT:   output [1:0]      r30,
+  // CHECK-NEXT:   output [8:0]      r31, r32,
+  // CHECK-NEXT:   output [3:0]      r33, r34
+  // CHECK-NEXT:   output [1:0][2:0] r36);
   // CHECK-EMPTY:
+  // CHECK-NEXT:   wire [1:0][5:0] _T = {a, a, b};
   // CHECK-NEXT:   assign r0 = a + b;
   // CHECK-NEXT:   assign r2 = a - b;
   // CHECK-NEXT:   assign r4 = a * b;
@@ -100,6 +108,7 @@ module {
   // CHECK-NEXT:   assign r32 = {{[{}][{}]}}5'd0}, a};
   // CHECK-NEXT:   assign r33 = cond ? a : b;
   // CHECK-NEXT:   assign r34 = ~a;
+  // CHECK-NEXT:   assign r36 = _T[2:0];
   // CHECK-NEXT: endmodule
 
   rtl.module @B(%a: i1) -> (%b: i1, %c: i1) {
@@ -271,4 +280,3 @@ module {
     rtl.output %wireout, %memout : i4, i8
   }
 }
-


### PR DESCRIPTION
- Teach ExtractOp about arrays.
- Add a `ReinterpretCast`.
- Refactoring ExportVerilog type output width calculation to improve support for array outputs.

This was a real down-the-rabbit-hole. I only intended to add the first two...