### PR TITLE
[Handshake] Removed use count check for handshake dialect

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -140,13 +140,6 @@ def FuncOp : Op<Handshake_Dialect, "func", [
                << ") must match the type of the corresponding argument in "
                << "function signature(" << fnInputTypes[i] << ')';
 
-    for (auto &region : this->getOperation()->getRegions())
-      for (auto &block : region)
-        for (auto &nestedOp : block)
-          for (mlir::Value out : nestedOp.getResults())
-            if (!out.hasOneUse())
-              return nestedOp.emitOpError("does not have exactly one use");
-
     return success();
   }];
   let printer = [{


### PR DESCRIPTION
The Handshake Dialect required exactly one use for each op. This patch removes this condition in verification.