### PR TITLE
[Handshake] Update func lowering to exit early for unsupported ops.

### DIFF
--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -1341,10 +1341,9 @@ static void convertReturnOp(Operation *oldOp, FModuleOp topModuleOp,
 struct HandshakeFuncOpLowering : public OpConversionPattern<handshake::FuncOp> {
   using OpConversionPattern<handshake::FuncOp>::OpConversionPattern;
 
-  LogicalResult match(Operation *op) const override { return success(); }
-
-  void rewrite(handshake::FuncOp funcOp, ArrayRef<Value> operands,
-               ConversionPatternRewriter &rewriter) const override {
+  LogicalResult
+  matchAndRewrite(handshake::FuncOp funcOp, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const override {
     // Create FIRRTL circuit and top-module operation.
     auto circuitOp = rewriter.create<CircuitOp>(
         funcOp.getLoc(), rewriter.getStringAttr(funcOp.getName()));
@@ -1378,7 +1377,7 @@ struct HandshakeFuncOpLowering : public OpConversionPattern<handshake::FuncOp> {
           } else if (StdExprBuilder(portList, insertLoc, rewriter)
                          .dispatchStdExprVisitor(&op)) {
           } else
-            op.emitError("Usupported operation type");
+            return op.emitError("unsupported operation type");
         }
 
         // Instantiate the new created sub-module.
@@ -1387,6 +1386,8 @@ struct HandshakeFuncOpLowering : public OpConversionPattern<handshake::FuncOp> {
       }
     }
     rewriter.eraseOp(funcOp);
+
+    return success();
   }
 };
 

--- a/test/Conversion/HandshakeToFIRRTL/errors.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/errors.mlir
@@ -1,0 +1,12 @@
+// RUN: circt-opt -lower-handshake-to-firrtl -split-input-file -verify-diagnostics %s
+
+// expected-error @+1 {{failed to legalize operation 'handshake.func'}}
+handshake.func @main(%arg0: index, %arg1: none, ...) -> none {
+  // expected-error @+1 {{unsupported operation type}}
+  %0:2 = "handshake.memory"(%addressResults) {id = 0 : i32, ld_count = 1 : i32, lsq = false, st_count = 0 : i32, type = memref<10xi8>} : (index) -> (i8, none)
+  %1:2 = "handshake.fork"(%arg1) {control = true} : (none) -> (none, none)
+  %2 = "handshake.join"(%1#1, %0#1) {control = true} : (none, none) -> none
+  %3, %addressResults = "handshake.load"(%arg0, %0#0, %1#0) : (index, i8, none) -> (i8, index)
+  "handshake.sink"(%3) : (i8) -> ()
+  handshake.return %2 : none
+}


### PR DESCRIPTION
The conversion will ultimately crash due to some failed assertions if
the op is unsupported. This lets the conversion exit early with the
intended error message in such situations, rather than crashing with
an assertion and in-flight diagnostic messages later on.