### PR TITLE
[Handshake] Simplify ForkOp isControl logic.

### DIFF
--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -63,13 +63,9 @@ void ForkOp::build(OpBuilder &builder, OperationState &result, Value operand,
   // Single operand
   result.addOperands(operand);
 
-  // Fork is control-only if it is the no-data output of a ControlMerge or a
-  // StartOp
-  auto *op = operand.getDefiningOp();
-  bool isControl = ((dyn_cast<ControlMergeOp>(op) || dyn_cast<StartOp>(op)) &&
-                    operand == op->getResult(0))
-                       ? true
-                       : false;
+  // Fork is control-only if it has NoneType. This includes the no-data output
+  // of a ControlMerge or a StartOp, as well as control values from MemoryOps.
+  bool isControl = operand.getType().isa<NoneType>() ? true : false;
   result.addAttribute("control", builder.getBoolAttr(isControl));
 }
 void handshake::ForkOp::getCanonicalizationPatterns(

--- a/test/Conversion/StandardToHandshake/Affine/test-affine-for.mlir
+++ b/test/Conversion/StandardToHandshake/Affine/test-affine-for.mlir
@@ -74,7 +74,7 @@ func @load_store () -> () {
 
 // CHECK: handshake.func @load_store(%arg0: none, ...) -> none {
 // CHECK:   %0:3 = "handshake.memory"(%28#0, %28#1, %addressResults) {id = 0 : i32, ld_count = 1 : i32, lsq = false, st_count = 1 : i32, type = memref<10xf32>} : (f32, index, index) -> (f32, none, none)
-// CHECK:   %1:2 = "handshake.fork"(%0#2) {control = false} : (none) -> (none, none)
+// CHECK:   %1:2 = "handshake.fork"(%0#2) {control = true} : (none) -> (none, none)
 // CHECK:   %2:4 = "handshake.fork"(%arg0) {control = true} : (none) -> (none, none, none, none)
 // CHECK:   %3 = "handshake.constant"(%2#2) {value = 0 : index} : (none) -> index
 // CHECK:   %4 = "handshake.constant"(%2#1) {value = 10 : index} : (none) -> index

--- a/test/Conversion/StandardToHandshake/Affine/test-affine-load-store.mlir
+++ b/test/Conversion/StandardToHandshake/Affine/test-affine-load-store.mlir
@@ -14,7 +14,7 @@ func @load_store () -> () {
 
 // CHECK: handshake.func @load_store(%[[ARG0:.*]]: none, ...) -> none {
 // CHECK:   %[[VAL0:.*]]:3 = "handshake.memory"(%[[VAL9:.*]]#0, %[[VAL9]]#1, %[[ADDR:.*]]) {id = 0 : i32, ld_count = 1 : i32, lsq = false, st_count = 1 : i32, type = memref<10xf32>} : (f32, index, index) -> (f32, none, none)
-// CHECK:   %[[VAL1:.*]]:2 = "handshake.fork"(%[[VAL0]]#2) {control = false} : (none) -> (none, none)
+// CHECK:   %[[VAL1:.*]]:2 = "handshake.fork"(%[[VAL0]]#2) {control = true} : (none) -> (none, none)
 // CHECK:   %[[VAL2:.*]]:3 = "handshake.fork"(%[[ARG0]]) {control = true} : (none) -> (none, none, none)
 // CHECK:   %[[VAL3:.*]]:2 = "handshake.fork"(%[[VAL2]]#2) {control = true} : (none) -> (none, none)
 // CHECK:   %[[VAL4:.*]] = "handshake.join"(%[[VAL3]]#1, %[[VAL1]]#1, %[[VAL0]]#1) {control = true} : (none, none, none) -> none
@@ -40,7 +40,7 @@ func @affine_map_addr () -> () {
 
 // CHECK:      handshake.func @affine_map_addr(%[[ARG0:.*]]: none, ...) -> none {
 // CHECK-NEXT:   %[[VAL0:.*]]:3 = "handshake.memory"(%[[VAL13:.*]]#0, %[[VAL13]]#1, %[[ADDR:.*]]) {id = 0 : i32, ld_count = 1 : i32, lsq = false, st_count = 1 : i32, type = memref<10xf32>} : (f32, index, index) -> (f32, none, none)
-// CHECK-NEXT:   %[[VAL1:.*]]:2 = "handshake.fork"(%[[VAL0]]#2) {control = false} : (none) -> (none, none)
+// CHECK-NEXT:   %[[VAL1:.*]]:2 = "handshake.fork"(%[[VAL0]]#2) {control = true} : (none) -> (none, none)
 // CHECK-NEXT:   %[[VAL2:.*]]:3 = "handshake.fork"(%[[ARG0]]) {control = true} : (none) -> (none, none, none)
 // CHECK-NEXT:   %[[VAL3:.*]]:4 = "handshake.fork"(%[[VAL2]]#2) {control = true} : (none) -> (none, none, none, none)
 // CHECK-NEXT:   %[[VAL4:.*]] = "handshake.join"(%[[VAL3]]#3, %[[VAL1]]#1, %[[VAL0]]#1) {control = true} : (none, none, none) -> none

--- a/test/Conversion/StandardToHandshake/test28.mlir
+++ b/test/Conversion/StandardToHandshake/test28.mlir
@@ -6,7 +6,7 @@
 // CHECK-LABEL:   handshake.func @affine_load(
 // CHECK-SAME:                                %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> none {
 // CHECK:           %[[VAL_2:.*]]:3 = "handshake.memory"(%[[VAL_3:.*]]#0, %[[VAL_3]]#1, %[[VAL_4:.*]]) {id = 1 : i32, ld_count = 1 : i32, lsq = false, st_count = 1 : i32, type = memref<10xf32>} : (f32, index, index) -> (f32, none, none)
-// CHECK:           %[[VAL_5:.*]]:2 = "handshake.fork"(%[[VAL_2]]#2) {control = false} : (none) -> (none, none)
+// CHECK:           %[[VAL_5:.*]]:2 = "handshake.fork"(%[[VAL_2]]#2) {control = true} : (none) -> (none, none)
 // CHECK:           %[[VAL_6:.*]]:2 = "handshake.memory"(%[[VAL_7:.*]]) {id = 0 : i32, ld_count = 1 : i32, lsq = false, st_count = 0 : i32, type = memref<10xf32>} : (index) -> (f32, none)
 // CHECK:           %[[VAL_8:.*]] = "handshake.merge"(%[[VAL_0]]) : (index) -> index
 // CHECK:           %[[VAL_9:.*]]:4 = "handshake.fork"(%[[VAL_1]]) {control = true} : (none) -> (none, none, none, none)

--- a/test/Conversion/StandardToHandshake/test30.mlir
+++ b/test/Conversion/StandardToHandshake/test30.mlir
@@ -6,8 +6,8 @@
 // CHECK-LABEL:   handshake.func @affine_load(
 // CHECK-SAME:                                %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> none {
 // CHECK:           %[[VAL_2:.*]]:7 = "handshake.memory"(%[[VAL_3:.*]]#0, %[[VAL_3]]#1, %[[VAL_4:.*]], %[[VAL_5:.*]], %[[VAL_6:.*]]) {id = 0 : i32, ld_count = 3 : i32, lsq = false, st_count = 1 : i32, type = memref<10xf32>} : (f32, index, index, index, index) -> (f32, f32, f32, none, none, none, none)
-// CHECK:           %[[VAL_7:.*]]:2 = "handshake.fork"(%[[VAL_2]]#6) {control = false} : (none) -> (none, none)
-// CHECK:           %[[VAL_8:.*]]:2 = "handshake.fork"(%[[VAL_2]]#5) {control = false} : (none) -> (none, none)
+// CHECK:           %[[VAL_7:.*]]:2 = "handshake.fork"(%[[VAL_2]]#6) {control = true} : (none) -> (none, none)
+// CHECK:           %[[VAL_8:.*]]:2 = "handshake.fork"(%[[VAL_2]]#5) {control = true} : (none) -> (none, none)
 // CHECK:           %[[VAL_9:.*]] = "handshake.merge"(%[[VAL_0]]) : (index) -> index
 // CHECK:           %[[VAL_10:.*]]:2 = "handshake.fork"(%[[VAL_1]]) {control = true} : (none) -> (none, none)
 // CHECK:           %[[VAL_11:.*]]:4 = "handshake.fork"(%[[VAL_10]]#1) {control = true} : (none) -> (none, none, none, none)

--- a/test/Conversion/StandardToHandshake/test31.mlir
+++ b/test/Conversion/StandardToHandshake/test31.mlir
@@ -6,7 +6,7 @@
 // CHECK-LABEL:   handshake.func @affine_load(
 // CHECK-SAME:                                %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> none {
 // CHECK:           %[[VAL_2:.*]]:3 = "handshake.memory"(%[[VAL_3:.*]]#0, %[[VAL_3]]#1, %[[VAL_4:.*]]) {id = 1 : i32, ld_count = 1 : i32, lsq = false, st_count = 1 : i32, type = memref<10xf32>} : (f32, index, index) -> (f32, none, none)
-// CHECK:           %[[VAL_5:.*]]:2 = "handshake.fork"(%[[VAL_2]]#2) {control = false} : (none) -> (none, none)
+// CHECK:           %[[VAL_5:.*]]:2 = "handshake.fork"(%[[VAL_2]]#2) {control = true} : (none) -> (none, none)
 // CHECK:           %[[VAL_6:.*]]:4 = "handshake.memory"(%[[VAL_7:.*]], %[[VAL_8:.*]]) {id = 0 : i32, ld_count = 2 : i32, lsq = false, st_count = 0 : i32, type = memref<10xf32>} : (index, index) -> (f32, f32, none, none)
 // CHECK:           %[[VAL_9:.*]] = "handshake.merge"(%[[VAL_0]]) : (index) -> index
 // CHECK:           %[[VAL_10:.*]]:2 = "handshake.fork"(%[[VAL_1]]) {control = true} : (none) -> (none, none)

--- a/test/Conversion/StandardToHandshake/test32.mlir
+++ b/test/Conversion/StandardToHandshake/test32.mlir
@@ -6,7 +6,7 @@
 // CHECK-LABEL:   handshake.func @test(
 // CHECK-SAME:                         %[[VAL_0:.*]]: none, ...) -> none {
 // CHECK:           %[[VAL_1:.*]]:5 = "handshake.memory"(%[[VAL_2:.*]]#0, %[[VAL_2]]#1, %[[VAL_3:.*]], %[[VAL_4:.*]]) {id = 0 : i32, ld_count = 2 : i32, lsq = false, st_count = 1 : i32, type = memref<10xf32>} : (f32, index, index, index) -> (f32, f32, none, none, none)
-// CHECK:           %[[VAL_5:.*]]:2 = "handshake.fork"(%[[VAL_1]]#4) {control = false} : (none) -> (none, none)
+// CHECK:           %[[VAL_5:.*]]:2 = "handshake.fork"(%[[VAL_1]]#4) {control = true} : (none) -> (none, none)
 // CHECK:           %[[VAL_6:.*]]:2 = "handshake.fork"(%[[VAL_0]]) {control = true} : (none) -> (none, none)
 // CHECK:           %[[VAL_7:.*]]:3 = "handshake.fork"(%[[VAL_6]]#1) {control = true} : (none) -> (none, none, none)
 // CHECK:           %[[VAL_8:.*]] = "handshake.join"(%[[VAL_7]]#2, %[[VAL_1]]#3) {control = true} : (none, none) -> none

--- a/test/Conversion/StandardToHandshake/test33.mlir
+++ b/test/Conversion/StandardToHandshake/test33.mlir
@@ -6,8 +6,8 @@
 // CHECK-LABEL:   handshake.func @test(
 // CHECK-SAME:                         %[[VAL_0:.*]]: none, ...) -> none {
 // CHECK:           %[[VAL_1:.*]]:5 = "handshake.memory"(%[[VAL_2:.*]]#0, %[[VAL_2]]#1, %[[VAL_3:.*]], %[[VAL_4:.*]]) {id = 0 : i32, ld_count = 2 : i32, lsq = false, st_count = 1 : i32, type = memref<10xf32>} : (f32, index, index, index) -> (f32, f32, none, none, none)
-// CHECK:           %[[VAL_5:.*]]:2 = "handshake.fork"(%[[VAL_1]]#4) {control = false} : (none) -> (none, none)
-// CHECK:           %[[VAL_6:.*]]:2 = "handshake.fork"(%[[VAL_1]]#3) {control = false} : (none) -> (none, none)
+// CHECK:           %[[VAL_5:.*]]:2 = "handshake.fork"(%[[VAL_1]]#4) {control = true} : (none) -> (none, none)
+// CHECK:           %[[VAL_6:.*]]:2 = "handshake.fork"(%[[VAL_1]]#3) {control = true} : (none) -> (none, none)
 // CHECK:           %[[VAL_7:.*]]:3 = "handshake.fork"(%[[VAL_0]]) {control = true} : (none) -> (none, none, none)
 // CHECK:           %[[VAL_8:.*]] = "handshake.constant"(%[[VAL_7]]#1) {value = 0 : index} : (none) -> index
 // CHECK:           %[[VAL_9:.*]] = "handshake.constant"(%[[VAL_7]]#0) {value = 10 : index} : (none) -> index

--- a/test/Conversion/StandardToHandshake/test34.mlir
+++ b/test/Conversion/StandardToHandshake/test34.mlir
@@ -6,8 +6,8 @@
 // CHECK-LABEL:   handshake.func @test(
 // CHECK-SAME:                         %[[VAL_0:.*]]: none, ...) -> none {
 // CHECK:           %[[VAL_1:.*]]:5 = "handshake.memory"(%[[VAL_2:.*]]#0, %[[VAL_2]]#1, %[[VAL_3:.*]], %[[VAL_4:.*]]) {id = 0 : i32, ld_count = 2 : i32, lsq = false, st_count = 1 : i32, type = memref<10xf32>} : (f32, index, index, index) -> (f32, f32, none, none, none)
-// CHECK:           %[[VAL_5:.*]]:2 = "handshake.fork"(%[[VAL_1]]#3) {control = false} : (none) -> (none, none)
-// CHECK:           %[[VAL_6:.*]]:2 = "handshake.fork"(%[[VAL_1]]#2) {control = false} : (none) -> (none, none)
+// CHECK:           %[[VAL_5:.*]]:2 = "handshake.fork"(%[[VAL_1]]#3) {control = true} : (none) -> (none, none)
+// CHECK:           %[[VAL_6:.*]]:2 = "handshake.fork"(%[[VAL_1]]#2) {control = true} : (none) -> (none, none)
 // CHECK:           %[[VAL_7:.*]]:3 = "handshake.fork"(%[[VAL_0]]) {control = true} : (none) -> (none, none, none)
 // CHECK:           %[[VAL_8:.*]] = "handshake.constant"(%[[VAL_7]]#1) {value = 0 : index} : (none) -> index
 // CHECK:           %[[VAL_9:.*]] = "handshake.constant"(%[[VAL_7]]#0) {value = 10 : index} : (none) -> index


### PR DESCRIPTION
This logic didn't seem correct for the control results of memories. Rather than adding more special casing, it seemed like we can reliably determine if a ForkOp is control-only by checking if the input is a NoneType. Does that make sense?