### PR TITLE
[HandshakeToFIRRTL] lower fork operation with FIRRTL primitives

### DIFF
--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -1191,7 +1191,6 @@ bool HandshakeBuilder::visitHandshake(ForkOp op) {
       rewriter.create<NotPrimOp>(insertLoc, bitType, allDoneWire));
 
   // Create logic for each result port.
-  SmallVector<Value, 4> emtdRegs;
   unsigned idx = 0;
   for (auto doneWire : doneWires) {
     // Extract valid and ready from the current result port.

--- a/test/Conversion/HandshakeToFIRRTL/test_fork.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_fork.mlir
@@ -1,0 +1,90 @@
+// RUN: circt-opt -lower-handshake-to-firrtl -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: firrtl.module @handshake_fork_1ins_2outs_ctrl(
+// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK:   %[[ARG_VALID:.+]] = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
+// CHECK:   %[[ARG_READY:.+]] = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.flip<uint<1>>
+// CHECK:   %[[RES0_VALID:.+]] = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>) -> !firrtl.flip<uint<1>>
+// CHECK:   %[[RES0_READY:.+]] = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>) -> !firrtl.uint<1>
+// CHECK:   %[[RES1_VALID:.+]] = firrtl.subfield %arg2("valid") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>) -> !firrtl.flip<uint<1>>
+// CHECK:   %[[RES1_READY:.+]] = firrtl.subfield %arg2("ready") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>) -> !firrtl.uint<1>
+
+// Done logic.
+// CHECK:   %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
+// CHECK:   %done0 = firrtl.wire : !firrtl.uint<1>
+// CHECK:   %done1 = firrtl.wire : !firrtl.uint<1>
+
+// CHECK:   %6 = firrtl.and %done1, %done0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   %allDone = firrtl.wire : !firrtl.uint<1>
+// CHECK:   firrtl.connect %allDone, %6 : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   firrtl.connect %[[ARG_READY:.+]], %allDone : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+
+// CHECK:   %notAllDone = firrtl.wire : !firrtl.uint<1>
+// CHECK:   %7 = firrtl.not %allDone : (!firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   firrtl.connect %notAllDone, %7 : !firrtl.uint<1>, !firrtl.uint<1>
+
+// Result 0 logic.
+// CHECK:   %emtd0 = firrtl.reginit %clock, %reset, %c0_ui1 {name = "emtd0"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   %8 = firrtl.and %done0, %notAllDone : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   firrtl.connect %emtd0, %8 : !firrtl.uint<1>, !firrtl.uint<1>
+
+// CHECK:   %notEmtd0 = firrtl.wire : !firrtl.uint<1>
+// CHECK:   %9 = firrtl.not %emtd0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   firrtl.connect %notEmtd0, %9 : !firrtl.uint<1>, !firrtl.uint<1>
+
+// CHECK:   %10 = firrtl.and %notEmtd0, %[[ARG_VALID:.+]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   firrtl.connect %[[RES0_VALID:.+]], %10 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// CHECK:   %validReady0 = firrtl.wire : !firrtl.uint<1>
+// CHECK:   %11 = firrtl.and %[[RES0_READY:.+]], %10 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   firrtl.connect %validReady0, %11 : !firrtl.uint<1>, !firrtl.uint<1>
+
+// CHECK:   %12 = firrtl.or %validReady0, %emtd0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   firrtl.connect %done0, %12 : !firrtl.uint<1>, !firrtl.uint<1>
+
+// Result1 logic.
+// CHECK:   %emtd1 = firrtl.reginit %clock, %reset, %c0_ui1 {name = "emtd1"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   %13 = firrtl.and %done1, %notAllDone : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   firrtl.connect %emtd1, %13 : !firrtl.uint<1>, !firrtl.uint<1>
+
+// CHECK:   %notEmtd1 = firrtl.wire : !firrtl.uint<1>
+// CHECK:   %14 = firrtl.not %emtd1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   firrtl.connect %notEmtd1, %14 : !firrtl.uint<1>, !firrtl.uint<1>
+
+// CHECK:   %15 = firrtl.and %notEmtd1, %[[ARG0_VALID:.+]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   firrtl.connect %[[RES1_VALID:.+]], %15 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// CHECK:   %validReady1 = firrtl.wire : !firrtl.uint<1>
+// CHECK:   %16 = firrtl.and %[[RES1_READY:.+]], %15 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   firrtl.connect %validReady1, %16 : !firrtl.uint<1>, !firrtl.uint<1>
+
+// CHECK:   %17 = firrtl.or %validReady1, %emtd1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   firrtl.connect %done1, %17 : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK: }
+
+// CHECK-LABEL: firrtl.module @test_fork(
+// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %arg4: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+handshake.func @test_fork(%arg0: none, %arg1: none, ...) -> (none, none, none) {
+
+  // CHECK: %0 = firrtl.instance @handshake_fork_1ins_2outs_ctrl {name = ""} : !firrtl.bundle<arg0: bundle<valid: flip<uint<1>>, ready: uint<1>>, arg1: bundle<valid: uint<1>, ready: flip<uint<1>>>, arg2: bundle<valid: uint<1>, ready: flip<uint<1>>>, clock: flip<clock>, reset: flip<uint<1>>>
+  %0:2 = "handshake.fork"(%arg0) {control = true} : (none) -> (none, none)
+  handshake.return %0#0, %0#1, %arg1 : none, none, none
+}
+
+// -----
+
+// CHECK-LABEL: firrtl.module @handshake_fork_1ins_2outs(
+// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK:   %[[ARG_DATA:.+]] = firrtl.subfield %arg0("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
+// CHECK:   %[[RES0_DATA:.+]] = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
+// CHECK:   %[[RES1_DATA:.+]] = firrtl.subfield %arg2("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
+
+// CHECK:   firrtl.connect %[[RES0_DATA:.+]], %[[ARG_DATA:.+]] : !firrtl.flip<uint<64>>, !firrtl.uint<64>
+// CHECK:   firrtl.connect %[[RES1_DATA:.+]], %[[ARG_DATA:.+]] : !firrtl.flip<uint<64>>, !firrtl.uint<64>
+
+// CHECK-LABEL: firrtl.module @test_fork_data(
+// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg4: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+handshake.func @test_fork_data(%arg0: index, %arg1: none, ...) -> (index, index, none) {
+
+  // CHECK: %0 = firrtl.instance @handshake_fork_1ins_2outs {name = ""} : !firrtl.bundle<arg0: bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, arg1: bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, arg2: bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, clock: flip<clock>, reset: flip<uint<1>>>
+  %0:2 = "handshake.fork"(%arg0) {control = false} : (index) -> (index, index)
+  handshake.return %0#0, %0#1, %arg1 : index, index, none
+}


### PR DESCRIPTION
Previously, the ForkOp lowering is implemented with the LazyForkOp's lowering logic. In this patch, the ForkOp lowering is re-implemented using FIRRTL primitives.