### PR TITLE
[HandshakeToFIRRTL] fix the non-default-case warning

### DIFF
--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -564,6 +564,8 @@ bool StdExprBuilder::visitStdExpr(CmpIOp op) {
   case CmpIPredicate::sge:
   case CmpIPredicate::uge:
     return buildBinaryLogic<GEQPrimOp>(), true;
+  default:
+    return false;
   }
 }
 


### PR DESCRIPTION
There is a warning complaining the absence of a default case. This is a quick fix that an unexpected CmpIOp type will cause a visitStdExpr failure.