### PR TITLE
[FIRRTL] Add division folds

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -172,6 +172,20 @@ class BinaryPrimOp<string mnemonic, Type lhsType, Type rhsType, Type resultType,
 def AddPrimOp : BinaryPrimOp<"add", IntType, IntType, IntType, [Commutative]>;
 def SubPrimOp : BinaryPrimOp<"sub", IntType, IntType, IntType>;
 def MulPrimOp : BinaryPrimOp<"mul", IntType, IntType, IntType, [Commutative]>;
+let hasFolder = 1 in
+let description = [{
+
+  Divides the first argument (the numerator) by the second argument
+  (the denominator) truncating the result (rounding towards zero).
+
+  **If the denominator is zero, the result is undefined.**
+
+  The compiler may optimize this undefined behavior in any way it
+  wants. Notably `div(a, a)` will be optimized to `1`. This may cause
+  erroneous formal equivalence mismatches between unoptimized and
+  optimized FIRRTL dialects that are separately converted to Verilog.
+
+}] in
 def DivPrimOp : BinaryPrimOp<"div", IntType, IntType, IntType>;
 def RemPrimOp : BinaryPrimOp<"rem", IntType, IntType, IntType>;
 

--- a/lib/Dialect/FIRRTL/OpFolds.cpp
+++ b/lib/Dialect/FIRRTL/OpFolds.cpp
@@ -50,6 +50,32 @@ OpFoldResult ConstantOp::fold(ArrayRef<Attribute> operands) {
   return valueAttr();
 }
 
+OpFoldResult DivPrimOp::fold(ArrayRef<Attribute> operands) {
+  APInt value;
+
+  /// div(x, x) -> 1
+  ///
+  /// Division by zero is undefined in the FIRRTL specification. This
+  /// fold exploits that fact to optimize self division to one.
+  if (lhs() == rhs()) {
+    auto width = getType().cast<IntType>().getWidthOrSentinel();
+    if (width == -1)
+      width = 2;
+    return IntegerAttr::get(IntegerType::get(getContext(), width), 1);
+  }
+
+  /// div(x, 1) -> x : (uint, uint) -> uint
+  ///
+  /// UInt division by one returns the numerator. SInt division can't
+  /// be folded here because it increases the return type bitwidth by
+  /// one and requires sign extension (a new op).
+  if (matchPattern(rhs(), m_FConstant(value)) && value.isOneValue() &&
+      lhs().getType() == getType())
+    return lhs();
+
+  return {};
+}
+
 // TODO: Move to DRR.
 OpFoldResult AndPrimOp::fold(ArrayRef<Attribute> operands) {
   APInt value;

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2,6 +2,49 @@
 
 firrtl.circuit "And" {
 
+// CHECK-LABEL: firrtl.module @Div
+firrtl.module @Div(%a: !firrtl.uint<4>,
+                  %b: !firrtl.flip<uint<4>>,
+                  %c: !firrtl.sint<4>,
+                  %d: !firrtl.flip<sint<5>>,
+                  %e: !firrtl.uint,
+                  %f: !firrtl.flip<uint>,
+                  %g: !firrtl.sint,
+                  %h: !firrtl.flip<sint>) {
+
+  // CHECK-DAG: [[ONE_i4:%.+]] = firrtl.constant(1 : i4) : !firrtl.uint<4>
+  // CHECK-DAG: [[ONE_s5:%.+]] = firrtl.constant(1 : i5) : !firrtl.sint<5>
+  // CHECK-DAG: [[ONE_i2:%.+]] = firrtl.constant(1 : i2) : !firrtl.uint
+  // CHECK-DAG: [[ONE_s2:%.+]] = firrtl.constant(1 : i2) : !firrtl.sint
+
+  // COM: Check that 'div(a, a) -> 1' works for known UInt widths
+  // CHECK: firrtl.connect %b, [[ONE_i4]]
+  %0 = firrtl.div %a, %a : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  firrtl.connect %b, %0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+
+  // COM: Check that 'div(c, c) -> 1' works for known SInt widths
+  // CHECK: firrtl.connect %d, [[ONE_s5]] : !firrtl.flip<sint<5>>, !firrtl.sint<5>
+  %1 = firrtl.div %c, %c : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.sint<5>
+  firrtl.connect %d, %1 : !firrtl.flip<sint<5>>, !firrtl.sint<5>
+
+  // COM: Check that 'div(e, e) -> 1' works for unknown UInt widths
+  // CHECK: firrtl.connect %f, [[ONE_i2]]
+  %2 = firrtl.div %e, %e : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+  firrtl.connect %f, %2 : !firrtl.flip<uint>, !firrtl.uint
+
+  // COM: Check that 'div(g, g) -> 1' works for unknown SInt widths
+  // CHECK: firrtl.connect %h, [[ONE_s2]]
+  %3 = firrtl.div %g, %g : (!firrtl.sint, !firrtl.sint) -> !firrtl.sint
+  firrtl.connect %h, %3 : !firrtl.flip<sint>, !firrtl.sint
+
+  // COM: Check that 'div(a, 1) -> a' for known UInt widths
+  // CHECK: firrtl.connect %b, %a
+  %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
+  %4 = firrtl.div %a, %c1_ui2 : (!firrtl.uint<4>, !firrtl.uint<2>) -> !firrtl.uint<4>
+  firrtl.connect %b, %4 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+
+}
+
 // CHECK-LABEL: firrtl.module @And
 firrtl.module @And(%in: !firrtl.uint<4>,
                    %sin: !firrtl.sint<4>,


### PR DESCRIPTION
This adds folding to the FIRRTL dialect division operand. Two folds
are implemented:

  - div(a, a) -> 1
  - div(a, 1) -> a

The former exploits the fact that the FIRRTL specification allows
division by zero to be undefined. This is then used to treat division
by zero as 1 (which is the same as any division by self) and produce a
constant. The latter is straightforward.

Tests and an updated description are included.

See discussion on #363 and chipsalliance/firrtl#2029.