### PR TITLE
[ExportVerilog] [SV Interfaces] Support for read and assign signal ops

### DIFF
--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -37,6 +37,7 @@ public:
                        // Type declarations.
                        InterfaceOp, InterfaceSignalOp, InterfaceModportOp,
                        InterfaceInstanceOp, GetModportOp,
+                       AssignInterfaceSignalOp, ReadInterfaceSignalOp,
                        // Verification statements.
                        AssertOp, AssumeOp, CoverOp>(
             [&](auto expr) -> ResultType {
@@ -92,6 +93,8 @@ public:
   HANDLE(InterfaceSignalOp, Unhandled);
   HANDLE(InterfaceModportOp, Unhandled);
   HANDLE(GetModportOp, Unhandled);
+  HANDLE(AssignInterfaceSignalOp, Unhandled);
+  HANDLE(ReadInterfaceSignalOp, Unhandled);
 
   // Verification statements.
   HANDLE(AssertOp, Unhandled);

--- a/integration_test/EmitVerilog/sv-interfaces.mlir
+++ b/integration_test/EmitVerilog/sv-interfaces.mlir
@@ -1,14 +1,9 @@
-// RUN: circt-translate %s -emit-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
+// REQUIRES: rtl-sim
+// RUN: circt-translate %s -emit-verilog -verify-diagnostics > %t1.sv
+// RUN: verilator --lint-only --top-module top %t1.sv
+// RUN: circt-rtl-sim.py %t1.sv --cycles 2 2>&1 | FileCheck %s
 
 module {
-  // CHECK-LABEL: interface data_vr;
-  // CHECK:         logic [31:0] data;
-  // CHECK:         logic valid;
-  // CHECK:         logic ready;
-  // CHECK:         modport data_in(input data, input valid, output ready);
-  // CHECK:         modport data_out(output data, output valid, input ready);
-  // CHECK:       endinterface
-  // CHECK-EMPTY:
   sv.interface @data_vr {
     sv.interface.signal @data : i32
     sv.interface.signal @valid : i1
@@ -17,35 +12,33 @@ module {
     sv.interface.modport @data_out ("output" @data, "output" @valid, "input" @ready)
   }
 
+  // TODO: This ugly bit is because we don't yet have ExportVerilog support
+  // for modports as module port declarations.
   rtl.externmodule @Rcvr (%m: !sv.modport<@data_vr::@data_in>)
+  sv.verbatim "module Rcvr (data_vr.data_in m);\nendmodule"
 
-  // CHECK-LABEL: module Top
-  rtl.module @Top (%clk: i1) {
-    // CHECK: data_vr [[IFACE:.+]]();{{.*}}//{{.+}}
+  rtl.module @top (%clk: i1, %rstn: i1) {
     %iface = sv.interface.instance : !sv.interface<@data_vr>
 
-    // CHECK-EMPTY:
     %ifaceInPort = sv.modport.get %iface @data_in :
       !sv.interface<@data_vr> -> !sv.modport<@data_vr::@data_in>
 
-    // CHECK: Rcvr rcvr1 ({{.*}}//{{.+}}
-    // CHECK:   .m ([[IFACE]].data_in){{.*}}//{{.+}}
-    // CHECK: );
     rtl.instance "rcvr1" @Rcvr(%ifaceInPort) : (!sv.modport<@data_vr::@data_in>) -> ()
 
-    // CHECK: Rcvr rcvr2 ({{.*}}//{{.+}}
-    // CHECK:   .m ([[IFACE]].data_in){{.*}}//{{.+}}
-    // CHECK: );
     rtl.instance "rcvr2" @Rcvr(%ifaceInPort) : (!sv.modport<@data_vr::@data_in>) -> ()
 
     %c1 = rtl.constant (1 : i1) : i1
-    // CHECK: assign _T.valid = 1'h1;
     sv.interface.signal.assign %iface(@data_vr::@valid) = %c1 : i1
 
     sv.always posedge %clk {
       %validValue = sv.interface.signal.read %iface(@data_vr::@valid) : i1
-      // CHECK: $fwrite(32'h80000002, "valid: %d\n", _T.valid);
       sv.fwrite "valid: %d\n" (%validValue) : i1
     }
+    // CHECK: valid: 1
+    // CHECK: valid: 1
+    // CHECK: valid: 1
+    // CHECK: valid: 1
+    // CHECK: valid: 1
+    // CHECK: valid: 1
   }
 }

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -21,7 +21,8 @@ using namespace sv;
 
 /// Return true if the specified operation is an expression.
 bool sv::isExpression(Operation *op) {
-  return isa<sv::TextualValueOp>(op) || isa<sv::GetModportOp>(op);
+  return isa<sv::TextualValueOp>(op) || isa<sv::GetModportOp>(op) ||
+         isa<sv::ReadInterfaceSignalOp>(op);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -327,6 +327,7 @@ public:
   LogicalResult visitSV(InterfaceOp op);
   LogicalResult visitSV(InterfaceSignalOp op);
   LogicalResult visitSV(InterfaceModportOp op);
+  LogicalResult visitSV(AssignInterfaceSignalOp op);
   void emitOperation(Operation *op);
 
   void collectNamesEmitDecls(Block &block);
@@ -636,6 +637,7 @@ private:
   }
 
   SubExprInfo visitSV(GetModportOp op);
+  SubExprInfo visitSV(ReadInterfaceSignalOp op);
   SubExprInfo visitSV(TextualValueOp op);
 
   // Noop cast operators.
@@ -940,6 +942,11 @@ SubExprInfo ExprEmitter::emitBitSelect(Value operand, unsigned hiBit,
 
 SubExprInfo ExprEmitter::visitSV(GetModportOp op) {
   os << emitter.getName(op.iface()) + "." + op.field();
+  return {Unary, IsUnsigned};
+}
+
+SubExprInfo ExprEmitter::visitSV(ReadInterfaceSignalOp op) {
+  os << emitter.getName(op.iface()) + "." + op.signalName();
   return {Unary, IsUnsigned};
 }
 
@@ -1545,6 +1552,15 @@ LogicalResult ModuleEmitter::visitSV(InterfaceModportOp op) {
   return success();
 }
 
+LogicalResult ModuleEmitter::visitSV(AssignInterfaceSignalOp op) {
+  SmallPtrSet<Operation *, 8> emitted;
+  indent() << "assign ";
+  emitExpression(op.iface(), emitted, /*forceRootExpr=*/true);
+  os << "." << op.signalName() << " = ";
+  emitExpression(op.rhs(), emitted, /*forceRootExpr=*/true);
+  os << ";\n";
+  return success();
+}
 //===----------------------------------------------------------------------===//
 // Module Driver
 //===----------------------------------------------------------------------===//

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -1613,7 +1613,7 @@ static bool isExpressionAlwaysInline(Operation *op) {
     return true;
 
   // An SV interface modport is a symbolic name that is always inlined.
-  if (isa<GetModportOp>(op))
+  if (isa<GetModportOp>(op) || isa<ReadInterfaceSignalOp>(op))
     return true;
 
   // If this is a noop cast and the operand is always inlined, then the noop

--- a/test/ExportVerilog/sv-interfaces.mlir
+++ b/test/ExportVerilog/sv-interfaces.mlir
@@ -46,6 +46,8 @@ module {
       %validValue = sv.interface.signal.read %iface(@data_vr::@valid) : i1
       // CHECK: $fwrite(32'h80000002, "valid: %d\n", _T.valid);
       sv.fwrite "valid: %d\n" (%validValue) : i1
+      // CHECK: assert(_T.valid);
+      sv.assert %validValue : i1
     }
   }
 }


### PR DESCRIPTION
Adds support for SystemVerilog output for the ReadInterfaceSignalOp and AssignInterfaceSignalOp. Updates the test and adds an integration test.