### PR TITLE
[HandshakeToFIRRTL] Refactor hasClock to use a trait on the op.

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakeInterfaces.td
+++ b/include/circt/Dialect/Handshake/HandshakeInterfaces.td
@@ -53,5 +53,6 @@ def MergeLikeOpInterface : OpInterface<"MergeLikeOpInterface"> {
   }];
 }
 
+def HasClock : NativeOpTrait<"HasClock">;
 
 #endif // HANDSHAKE_INTERFACES

--- a/include/circt/Dialect/Handshake/HandshakeOps.h
+++ b/include/circt/Dialect/Handshake/HandshakeOps.h
@@ -58,6 +58,13 @@ public:
 } // end namespace handshake
 } // end namespace circt
 
+namespace mlir {
+namespace OpTrait {
+template <typename ConcreteType>
+class HasClock : public TraitBase<ConcreteType, HasClock> {};
+} // namespace OpTrait
+} // namespace mlir
+
 #define GET_OP_CLASSES
 #include "circt/Dialect/Handshake/HandshakeOps.h.inc"
 

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -251,7 +251,7 @@ def ReturnOp : Handshake_Op<"return", [Terminator]> {
   let parser = [{ return ::parse$cppClass(parser, result); }];
 }
 
-def BufferOp : Handshake_Op<"buffer", [NoSideEffect]> {
+def BufferOp : Handshake_Op<"buffer", [NoSideEffect, HasClock]> {
   let summary = "buffer operation";
 
   let description = [{
@@ -278,7 +278,7 @@ def BufferOp : Handshake_Op<"buffer", [NoSideEffect]> {
   }];
 }
 
-def ForkOp : Handshake_Op<"fork", [NoSideEffect]> {
+def ForkOp : Handshake_Op<"fork", [NoSideEffect, HasClock]> {
   let summary = "fork operation";
 
   let description = [{
@@ -357,7 +357,7 @@ def MuxOp : Handshake_Op<"mux", [NoSideEffect, MergeLikeOpInterface]> {
 }
 
 def ControlMergeOp : Handshake_Op<"control_merge",
-	 [NoSideEffect, MergeLikeOpInterface]> {
+	 [NoSideEffect, MergeLikeOpInterface, HasClock]> {
   let summary = "control merge operation";
   let description = [{
     The "handshake.control_merge" operation represents a

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -1456,8 +1456,7 @@ struct HandshakeFuncOpLowering : public OpConversionPattern<handshake::FuncOp> {
       // be instantiated in the top-module.
       else if (op.getDialect()->getNamespace() != "firrtl") {
         FModuleOp subModuleOp = checkSubModuleOp(topModuleOp, &op);
-        bool hasClock =
-            isa<handshake::BufferOp, handshake::ControlMergeOp, ForkOp>(op);
+        bool hasClock = op.hasTrait<OpTrait::HasClock>();
 
         // Check if the sub-module already exists.
         if (!subModuleOp) {


### PR DESCRIPTION
As the list of ops with clocks will continue to grow, we discussed
moving this logic to a trait in https://github.com/llvm/circt/pull/403.
This allows the ops themselves to declare that they need a clock,
which can be used in HandshakeToFIRRTL or any other passes.