### PR TITLE
[NFC] Rename auto-generated Dialect doc folder to Dialects

### DIFF
--- a/include/circt/Dialect/ESI/CMakeLists.txt
+++ b/include/circt/Dialect/ESI/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_circt_dialect(ESI esi)
-add_circt_doc(ESI -gen-op-doc esi Dialect/)
+add_circt_doc(ESI -gen-op-doc esi Dialects/)
 
 set(LLVM_TARGET_DEFINITIONS ESI.td)
 mlir_tablegen(ESIAttrs.h.inc -gen-struct-attr-decls)

--- a/include/circt/Dialect/FIRRTL/CMakeLists.txt
+++ b/include/circt/Dialect/FIRRTL/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_circt_dialect(FIRRTL firrtl FIRRTL)
-add_circt_doc(FIRRTL -gen-op-doc firrtl Dialect/)
+add_circt_doc(FIRRTL -gen-op-doc firrtl Dialects/)
 
 set(LLVM_TARGET_DEFINITIONS FIRRTL.td)
 mlir_tablegen(FIRRTLEnums.h.inc -gen-enum-decls)

--- a/include/circt/Dialect/Handshake/CMakeLists.txt
+++ b/include/circt/Dialect/Handshake/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_circt_dialect(HandshakeOps handshake)
-add_circt_doc(HandshakeOps -gen-op-doc handshake Dialect/)
+add_circt_doc(HandshakeOps -gen-op-doc HandshakeOps Dialects/)
 
 set(LLVM_TARGET_DEFINITIONS HandshakeOps.td)
 mlir_tablegen(HandshakeOps.inc -gen-rewriters)

--- a/include/circt/Dialect/LLHD/IR/CMakeLists.txt
+++ b/include/circt/Dialect/LLHD/IR/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_circt_dialect(LLHD llhd)
-add_circt_doc(LLHD -gen-op-doc llhd Dialect/)
+add_circt_doc(LLHD -gen-op-doc llhd Dialects/)
 
 set(LLVM_TARGET_DEFINITIONS LLHD.td)
 mlir_tablegen(LLHDEnums.h.inc -gen-enum-decls)

--- a/include/circt/Dialect/RTL/CMakeLists.txt
+++ b/include/circt/Dialect/RTL/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_circt_dialect(RTL rtl)
-add_circt_doc(RTL -gen-op-doc rtl Dialect/)
+add_circt_doc(RTL -gen-op-doc rtl Dialects/)
 
 set(LLVM_TARGET_DEFINITIONS RTL.td)
 mlir_tablegen(RTLEnums.h.inc -gen-enum-decls)

--- a/include/circt/Dialect/SV/CMakeLists.txt
+++ b/include/circt/Dialect/SV/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_circt_dialect(SV sv)
-add_circt_doc(SV -gen-op-doc sv Dialect/)
+add_circt_doc(SV -gen-op-doc sv Dialects/)
 
 set(LLVM_TARGET_DEFINITIONS SV.td)
 

--- a/include/circt/Dialect/StaticLogic/CMakeLists.txt
+++ b/include/circt/Dialect/StaticLogic/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_circt_dialect(StaticLogic staticlogic)
-add_circt_doc(StaticLogic -gen-op-doc staticlogic Dialect/)
+add_circt_doc(StaticLogic -gen-op-doc staticlogic Dialects/)
 
 set(LLVM_TARGET_DEFINITIONS StaticLogic.td)


### PR DESCRIPTION
Two minor changes, just to make MLIR consistency in folder naming. Example- [MLIR Affine's CMakeList.txt](https://github.com/llvm/llvm-project/blob/d0fa7a05be92617a0262ec8b622f158971a54c54/mlir/include/mlir/Dialect/Affine/IR/CMakeLists.txt#L1)
* build/docs/Dialect --> build/docs/Dialects
* build/docs/Dialect/handshake.md --> build/docs/Dialect/HandshakeOps.md
