### PR TITLE
[FIRRTL] Verify that NodeOp is passive

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -99,7 +99,7 @@ def NodeOp : FIRRTLOp<"node", [NoSideEffect, SameOperandsAndResultType]> {
     ```
     }];
 
-  let arguments = (ins FIRRTLType:$input, OptionalAttr<StrAttr>:$name);
+  let arguments = (ins PassiveType:$input, OptionalAttr<StrAttr>:$name);
   let results = (outs FIRRTLType:$result);
 
   let assemblyFormat = [{

--- a/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
+++ b/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
@@ -365,12 +365,11 @@ module attributes {firrtl.mainModule = "Simple"} {
     // CHECK-NEXT: rtl.instance "fetch"
     rtl.instance "fetch" @bar(%io_cpu_flush.wireV)  : (i1) -> ()
     %0 = firrtl.stdIntCast %io_cpu_flush.wireV : (i1) -> !firrtl.uint<1>
-    %1454 = firrtl.asNonPassive %0 : (!firrtl.uint<1>) -> !firrtl.flip<uint<1>>
 
-    %hits_1_7 = firrtl.node %1454 {name = "hits_1_7"} : !firrtl.flip<uint<1>>
+    %hits_1_7 = firrtl.node %0 {name = "hits_1_7"} : !firrtl.uint<1>
     // CHECK-NEXT:  %hits_1_7 = rtl.wire : !rtl.inout<i1>
     // CHECK-NEXT:  rtl.connect %hits_1_7, [[IO]] : i1
-    %1455 = firrtl.asPassive %hits_1_7 : (!firrtl.flip<uint<1>>) -> !firrtl.uint<1>
+    %1455 = firrtl.asPassive %hits_1_7 : (!firrtl.uint<1>) -> !firrtl.uint<1>
   }
 
   // https://github.com/llvm/circt/issues/314

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -346,3 +346,13 @@ firrtl.circuit "BadAdd" {
     firrtl.add %a, %a : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   }
 }
+
+// -----
+
+firrtl.circuit "NodeMustBePassive" {
+  firrtl.module @NodeMustBePassive() {
+    %a = firrtl.wire : !firrtl.flip<uint<1>>
+    // expected-error @+1 {{'firrtl.node' op operand #0 must be a passive type}}
+    %b = firrtl.node %a : !firrtl.flip<uint<1>>
+  }
+}

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -118,8 +118,8 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.connect [[A]], [[B]]
     _t_2[0] <= _t[0] @[Xbar.scala 21:44]
 
-    ; CHECK: %n1 = firrtl.node %auto {name = "n1"} : !firrtl.flip<uint<1>>
-    node n1 = auto
+    ; CHECK: %n1 = firrtl.node %i8 {name = "n1"} : !firrtl.uint<8>
+    node n1 = i8
 
     ; CHECK: firrtl.add %reset, %reset : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
     node n2 = add(reset, reset)

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -530,3 +530,10 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
   ; CHECK: attributes {parameters = {A = -1 : i4}}
   extmodule issue183:
      parameter A = -1
+
+  ; COM: The Scala FIRRTL Compiler allows this for an aggregate node with an internal analog.
+  ; CHECK-LABEL: firrtl.module @analog_in_aggregate_node
+  module analog_in_aggregate_node:
+    input a: { a: UInt<1>, b: Analog<1>}
+    ; CHECK: %b = firrtl.node %a {{.+}}: !firrtl.bundle<a: uint<1>, b: analog<1>>
+    node b = a

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -134,3 +134,21 @@ circuit test :
    input in1 : SInt
    input in2 : UInt
    node n = add(in1, in2)  ; expected-error {{operand signedness must match}}
+
+;// -----
+
+circuit invalid_node_not_passive :
+  module invalid_node_not_passive :
+    input a : { a: UInt, flip b: UInt}
+    output b : { a: UInt, flip b: UInt}
+    ; expected-error @+1 {{Node cannot be analog and must be passive or passive under a flip}}
+    node n = a
+
+;// -----
+
+circuit invalid_node_analog :
+  module invalid_node_analog :
+    input a : Analog<1>
+    output b : Analog<1>
+    ; expected-error @+1 {{Node cannot be analog and must be passive or passive under a flip}}
+    node n = a


### PR DESCRIPTION
Add a NodeOp verifier that asserts that a node is passive. One
testcase is added and one testcase is changed that did not respect
this invariant.

- Fixes #395.
- Fixes #388.