### PR TITLE
[HandshakeToFIRRTL] Add MemoryOp lowering.

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -517,7 +517,7 @@ def TerminatorOp : Handshake_Op<"terminator", [Terminator]> {
 }
 
 def MemRefTypeAttr : TypeAttrBase<"MemRefType", "memref type attribute">;
-def MemoryOp : Handshake_Op<"memory"> {
+def MemoryOp : Handshake_Op<"memory", [HasClock]> {
   let summary = "memory";
   let description = [{
     Each MemoryOp represents an independent memory or memory region (BRAM or external memory).

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -1518,7 +1518,7 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
     auto falseConst =
         createConstantOp(bitType, APInt(1, 0), insertLoc, rewriter);
     auto bufferName = rewriter.getStringAttr("writeValidBuffer");
-    auto writeValidBuffer = rewriter.create<RegInitOp>(
+    auto writeValidBuffer = rewriter.create<RegResetOp>(
         insertLoc, bitType, clock, reset, falseConst, bufferName);
 
     // Connect the write valid buffer to the store control valid.

--- a/test/Conversion/HandshakeToFIRRTL/errors.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/errors.mlir
@@ -2,10 +2,10 @@
 
 // expected-error @+1 {{failed to legalize operation 'handshake.func'}}
 handshake.func @main(%arg0: index, %arg1: none, ...) -> none {
-  // expected-error @+1 {{unsupported operation type}}
   %0:2 = "handshake.memory"(%addressResults) {id = 0 : i32, ld_count = 1 : i32, lsq = false, st_count = 0 : i32, type = memref<10xi8>} : (index) -> (i8, none)
   %1:2 = "handshake.fork"(%arg1) {control = true} : (none) -> (none, none)
   %2 = "handshake.join"(%1#1, %0#1) {control = true} : (none, none) -> none
+  // expected-error @+1 {{unsupported operation type}}
   %3, %addressResults = "handshake.load"(%arg0, %0#0, %1#0) : (index, i8, none) -> (i8, index)
   "handshake.sink"(%3) : (i8) -> ()
   handshake.return %2 : none

--- a/test/Conversion/HandshakeToFIRRTL/test_memory.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_memory.mlir
@@ -70,20 +70,6 @@
 // Create the write valid buffer.
 // CHECK: %[[WRITE_VALID_BUFFER:.+]] = firrtl.reginit {{.+}} -> !firrtl.uint<1>
 
-// Create the write valid signal.
-// CHECK: %[[WRITE_VALID:.+]] = firrtl.and %[[ST_ADDR_VALID]], %[[ST_DATA_VALID]]
-
-// Connect the write valid signal to the buffer.
-// CHECK: firrtl.connect %[[WRITE_VALID_BUFFER]], %[[WRITE_VALID]]
-
-// Connect the write valid signal to the memory enable
-// CHECK: %[[MEM_STORE_EN:.+]] = firrtl.subfield %[[MEM_STORE]]("en") : {{.*}} -> !firrtl.flip<uint<1>>
-// CHECK: firrtl.connect %[[MEM_STORE_EN]], %[[WRITE_VALID]]
-
-// Connect the write valid signal to the memory mask.
-// CHECK: %[[MEM_STORE_MASK:.+]] = firrtl.subfield %[[MEM_STORE]]("mask") : {{.*}} -> !firrtl.flip<uint<1>>
-// CHECK: firrtl.connect %[[MEM_STORE_MASK]], %[[WRITE_VALID]]
-
 // Connect the write valid buffer to the store control valid.
 // CHECK: firrtl.connect %[[ST_CONTROL_VALID]], %[[WRITE_VALID_BUFFER]]
 
@@ -92,6 +78,21 @@
 // CHECK: %[[STORE_COMPLETED:.+]] = firrtl.and %[[WRITE_VALID_BUFFER]], %[[ST_CONTROL_READY]]
 // CHECK: firrtl.connect %[[ST_ADDR_READY]], %[[STORE_COMPLETED]]
 // CHECK: firrtl.connect %[[ST_DATA_READY]], %[[STORE_COMPLETED]]
+
+// Create the logic to drive the write valid buffer or keep its output.
+// CHECK: %[[NOT_WRITE_VALID_BUFFER:.+]] = firrtl.not %[[WRITE_VALID_BUFFER]]
+// CHECK: %[[EMPTY_OR_COMPLETE:.+]] = firrtl.or %[[NOT_WRITE_VALID_BUFFER]], %[[STORE_COMPLETED]]
+// CHECK: %[[WRITE_VALID:.+]] = firrtl.and %[[ST_ADDR_VALID]], %[[ST_DATA_VALID]]
+// CHECK: %[[WRITE_VALID_BUFFER_MUX:.+]] = firrtl.mux(%[[EMPTY_OR_COMPLETE]], %[[WRITE_VALID]], %[[WRITE_VALID_BUFFER]])
+// CHECK: firrtl.connect %[[WRITE_VALID_BUFFER]], %[[WRITE_VALID_BUFFER_MUX]]
+
+// Connect the write valid signal to the memory enable
+// CHECK: %[[MEM_STORE_EN:.+]] = firrtl.subfield %[[MEM_STORE]]("en") : {{.*}} -> !firrtl.flip<uint<1>>
+// CHECK: firrtl.connect %[[MEM_STORE_EN]], %[[WRITE_VALID]]
+
+// Connect the write valid signal to the memory mask.
+// CHECK: %[[MEM_STORE_MASK:.+]] = firrtl.subfield %[[MEM_STORE]]("mask") : {{.*}} -> !firrtl.flip<uint<1>>
+// CHECK: firrtl.connect %[[MEM_STORE_MASK]], %[[WRITE_VALID]]
 
 // CHECK-LABEL: firrtl.module @main
 handshake.func @main(%arg0: i8, %arg1: index, %arg2: index, ...) -> (i8, none, none) {

--- a/test/Conversion/HandshakeToFIRRTL/test_memory.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_memory.mlir
@@ -68,7 +68,7 @@
 // CHECK: firrtl.connect %[[MEM_STORE_DATA]], %[[ST_DATA_DATA]]
 
 // Create the write valid buffer.
-// CHECK: %[[WRITE_VALID_BUFFER:.+]] = firrtl.reginit {{.+}} -> !firrtl.uint<1>
+// CHECK: %[[WRITE_VALID_BUFFER:.+]] = firrtl.regreset {{.+}} -> !firrtl.uint<1>
 
 // Connect the write valid buffer to the store control valid.
 // CHECK: firrtl.connect %[[ST_CONTROL_VALID]], %[[WRITE_VALID_BUFFER]]

--- a/test/Conversion/HandshakeToFIRRTL/test_memory.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_memory.mlir
@@ -1,0 +1,52 @@
+// RUN: circt-opt -lower-handshake-to-firrtl -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: firrtl.module @handshake_memory_3ins_3outs
+// CHECK: %[[ST_DATA_VALID:.+]] = firrtl.subfield %arg0("valid")
+// CHECK: %[[ST_DATA_READY:.+]] = firrtl.subfield %arg0("ready")
+// CHECK: %[[ST_DATA_DATA:.+]] = firrtl.subfield %arg0("data")
+// CHECK: %[[ST_ADDR_VALID:.+]] = firrtl.subfield %arg1("valid")
+// CHECK: %[[ST_ADDR_READY:.+]] = firrtl.subfield %arg1("ready")
+// CHECK: %[[ST_ADDR_DATA:.+]] = firrtl.subfield %arg1("data")
+// CHECK: %[[LD_ADDR_VALID:.+]] = firrtl.subfield %arg2("valid")
+// CHECK: %[[LD_ADDR_READY:.+]] = firrtl.subfield %arg2("ready")
+// CHECK: %[[LD_ADDR_DATA:.+]] = firrtl.subfield %arg2("data")
+// CHECK: %[[LD_DATA_VALID:.+]] = firrtl.subfield %arg3("valid")
+// CHECK: %[[LD_DATA_READY:.+]] = firrtl.subfield %arg3("ready")
+// CHECK: %[[LD_DATA_DATA:.+]] = firrtl.subfield %arg3("data")
+// CHECK: %[[ST_CONTROL_VALID:.+]] = firrtl.subfield %arg4("valid")
+// CHECK: %[[ST_CONTROL_READY:.+]] = firrtl.subfield %arg4("ready")
+// CHECK: %[[LD_CONTROL_VALID:.+]] = firrtl.subfield %arg5("valid")
+// CHECK: %[[LD_CONTROL_READY:.+]] = firrtl.subfield %arg5("ready")
+
+// Construct the memory.
+// CHECK: %[[MEM:.+]] = firrtl.mem "Old" {depth = 10 : i64, name = "mem0", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<load0: bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<8>>, store0: flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>>>
+
+// Get the load0 port.
+// CHECK: %[[MEM_LOAD:.+]] = firrtl.subfield %[[MEM]]("load0") : {{.*}} -> !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<8>>
+
+// Connect the load address, truncating if necessary.
+// CHECK: %[[MEM_LOAD_ADDR:.+]] = firrtl.subfield %[[MEM_LOAD]]("addr") : {{.*}} -> !firrtl.flip<uint<4>>
+// CHECK: %[[LD_ADDR_DATA_TAIL:.+]] = firrtl.tail %[[LD_ADDR_DATA]], 60 : (!firrtl.uint<64>) -> !firrtl.uint<4>
+// CHECK: firrtl.connect %[[MEM_LOAD_ADDR]], %[[LD_ADDR_DATA_TAIL]] : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+
+// Connect the load data.
+// CHECK: %[[MEM_LOAD_DATA:.+]] = firrtl.subfield %[[MEM_LOAD]]("data") : {{.*}} -> !firrtl.uint<8>
+// CHECK: firrtl.connect %[[LD_DATA_DATA]], %[[MEM_LOAD_DATA]] : !firrtl.flip<uint<8>>, !firrtl.uint<8>
+
+// Create control-only fork for the load address valid and ready signal to the
+// data and control signals. This re-uses the logic tested in test_fork.mlir, so
+// the checks here are just at the module boundary.
+// CHECK-DAG: firrtl.{{.+}} %[[LD_ADDR_VALID]]
+// CHECK-DAG: firrtl.connect %[[LD_ADDR_READY]]
+// CHECK-DAG: firrtl.connect %[[LD_DATA_VALID]]
+// CHECK-DAG: firrtl.{{.+}} %[[LD_DATA_READY]]
+// CHECK-DAG: firrtl.connect %[[LD_CONTROL_VALID]]
+// CHECK-DAG: firrtl.{{.+}} %[[LD_CONTROL_READY]]
+
+// CHECK-LABEL: firrtl.module @main
+handshake.func @main(%arg0: i8, %arg1: index, %arg2: index, ...) -> (i8, none, none) {
+  // CHECK: %0 = firrtl.instance @handshake_memory_3ins_3outs
+  %0:3 = "handshake.memory"(%arg0, %arg1, %arg2) {id = 0 : i32, ld_count = 1 : i32, lsq = false, st_count = 1 : i32, type = memref<10xi8>} : (i8, index, index) -> (i8, none, none)
+
+  handshake.return %0#0, %0#1, %0#2: i8, none, none
+}


### PR DESCRIPTION
This adds the start of a lowering from MemoryOp. This initial commit
includes support for the load ports of a memory. The appropriate data
signals are connected, and the control signals are built similarly to
the ForkOp. This is part of https://github.com/llvm/circt/issues/337.