### PR TITLE
[ExportVerilog] Fixing package dimension ordering

### DIFF
--- a/integration_test/EmitVerilog/lint.mlir
+++ b/integration_test/EmitVerilog/lint.mlir
@@ -42,7 +42,8 @@ module {
     %r17: i1, %r18: i1, %r19: i1, %r20: i1,
     %r21: i1, %r22: i1, %r23: i1, %r24: i1,
     %r25: i1, %r26: i1, %r27: i1, %r28: i1,
-    %r29: i12, %r30: i2, %r31: i9, %r32: i9, %r33: i4, %r34: i4
+    %r29: i12, %r30: i2, %r31: i9, %r32: i9, %r33: i4, %r34: i4,
+    %r35: !rtl.array<3xi4>
     ) {
 
     %0 = rtl.add %a, %b : i4
@@ -80,11 +81,13 @@ module {
     %allone = rtl.constant (15 : i4) : i4
     %34 = rtl.xor %a, %allone : i4
 
-    %35 = rtl.array_slice %array at %a : (!rtl.array<10xi4>) -> !rtl.array<3xi4>
+    %one = rtl.constant (1 : i4) : i4
+    %aPlusOne = rtl.add %a, %one : i4
+    %35 = rtl.array_slice %array at %aPlusOne: (!rtl.array<10xi4>) -> !rtl.array<3xi4>
 
-    rtl.output %0, %2, %4, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34:
+    rtl.output %0, %2, %4, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35:
      i4,i4, i4,i4,i4,i4,i4, i4,i4,i4,i4,i4,
      i4,i1,i1,i1,i1, i1,i1,i1,i1,i1, i1,i1,i1,i1,
-     i12, i2,i9,i9,i4, i4
+     i12, i2,i9,i9,i4, i4, !rtl.array<3xi4>
   }
 }

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -104,7 +104,6 @@ static size_t emitTypeDims(Type type, Location loc, raw_ostream &os) {
   size_t emittedWidth = 0;
   int width;
   if (auto arrayType = type.dyn_cast<rtl::ArrayType>()) {
-    emittedWidth += emitTypeDims(arrayType.getElementType(), loc, os);
     width = arrayType.getSize();
   } else {
     width = getBitWidthOrSentinel(type);
@@ -127,6 +126,9 @@ static size_t emitTypeDims(Type type, Location loc, raw_ostream &os) {
     os << '[' << (width - 1) << ":0]";
     emittedWidth += getPrintedIntWidth(width - 1) + 4;
     break;
+  }
+  if (auto arrayType = type.dyn_cast<rtl::ArrayType>()) {
+    emittedWidth += emitTypeDims(arrayType.getElementType(), loc, os);
   }
   return emittedWidth;
 }

--- a/test/ExportVerilog/rtl-dialect.mlir
+++ b/test/ExportVerilog/rtl-dialect.mlir
@@ -69,7 +69,7 @@ module {
   // CHECK-LABEL: module TESTSIMPLE(
   // CHECK-NEXT:   input  [3:0]      a, b
   // CHECK-NEXT:   input             cond,
-  // CHECK-NEXT:   input  [3:0][9:0] array,
+  // CHECK-NEXT:   input  [9:0][3:0] array,
   // CHECK-NEXT:   input  [7:0]      uarray[15:0],
   // CHECK-NEXT:   output [3:0]      r0, r2, r4, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15
   // CHECK-NEXT:   output            r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28
@@ -77,7 +77,7 @@ module {
   // CHECK-NEXT:   output [1:0]      r30,
   // CHECK-NEXT:   output [8:0]      r31, r32,
   // CHECK-NEXT:   output [3:0]      r33, r34,
-  // CHECK-NEXT:   output [3:0][2:0] r35,
+  // CHECK-NEXT:   output [2:0][3:0] r35,
   // CHECK-NEXT:   output [11:0]     r36);
   // CHECK-EMPTY:
   // CHECK-NEXT:   assign r0 = a + b;
@@ -269,9 +269,9 @@ module {
  
     // Packed arrays.
 
-    // CHECK-NEXT: wire [7:0][41:0]      myArray1;
+    // CHECK-NEXT: wire [41:0][7:0]      myArray1;
     %myArray1 = rtl.wire : !rtl.inout<array<42 x i8>>
-    // CHECK-NEXT: wire [3:0][41:0][2:0] myWireArray2;
+    // CHECK-NEXT: wire [2:0][41:0][3:0] myWireArray2;
     %myWireArray2 = rtl.wire : !rtl.inout<array<3 x array<42 x i4>>>
 
     // Unpacked arrays, and unpacked arrays of packed arrays.
@@ -279,7 +279,7 @@ module {
     // CHECK-NEXT: wire [7:0]            myUArray1[41:0];
     %myUArray1 = rtl.wire : !rtl.inout<uarray<42 x i8>>
 
-    // CHECK-NEXT: wire [3:0][41:0]      myWireUArray2[2:0];
+    // CHECK-NEXT: wire [41:0][3:0]      myWireUArray2[2:0];
     %myWireUArray2 = rtl.wire : !rtl.inout<uarray<3 x array<42 x i4>>>
 
     // CHECK-EMPTY:
@@ -361,10 +361,10 @@ module {
   // CHECK-LABEL: module TestZero(
   // CHECK-NEXT:      input  [3:0]               a,
   // CHECK-NEXT:   // input  /*Zero Width*/      zeroBit,
-  // CHECK-NEXT:   // input  /*Zero Width*/[2:0] arrZero,
+  // CHECK-NEXT:   // input  [2:0]/*Zero Width*/ arrZero,
   // CHECK-NEXT:      output [3:0]               r0,
   // CHECK-NEXT:   // output /*Zero Width*/      rZero,
-  // CHECK-NEXT:   // output /*Zero Width*/[2:0] arrZero
+  // CHECK-NEXT:   // output [2:0]/*Zero Width*/ arrZero
   // CHECK-NEXT:    );
   // CHECK-EMPTY:
   rtl.module @TestZero(%a: i4, %zeroBit: i0, %arrZero: !rtl.array<3xi0>)

--- a/test/ExportVerilog/sv-dialect.mlir
+++ b/test/ExportVerilog/sv-dialect.mlir
@@ -123,7 +123,7 @@ rtl.module @reg(%in4: i4, %in8: i8) -> (%a: i8, %b: i8) {
     // CHECK-NEXT: reg [7:0]       myReg;
     %myReg = sv.reg : !rtl.inout<i8>
 
-    // CHECK-NEXT: reg [7:0][41:0] myRegArray1;
+    // CHECK-NEXT: reg [41:0][7:0] myRegArray1;
     %myRegArray1 = sv.reg : !rtl.inout<array<42 x i8>>
 
     // CHECK-EMPTY:


### PR DESCRIPTION
The lint integration test which was supposed to be testing array slicing wasn't being emitted. Fixed that and discovered warnings.

I *think* the packed dimensions were being emitted backwards. Someone please check me on this.