### PR TITLE
[FIRRTL] Convert register clock, reset, and init to passive during parsing

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2129,6 +2129,7 @@ ParseResult FIRStmtParser::parseRegister(unsigned regIndent) {
         parseToken(FIRToken::l_paren, "expected '(' in reset specifier") ||
         parseExp(resetSignal, subOps, "expected expression for reset signal"))
       return failure();
+    resetSignal = convertToPassive(resetSignal, resetSignal.getLoc());
 
     // The Scala implementation of FIRRTL represents registers without resets
     // as a self referential register... and the pretty printer doesn't print

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2103,6 +2103,7 @@ ParseResult FIRStmtParser::parseRegister(unsigned regIndent) {
       parseType(type, "expected reg type") ||
       parseExp(clock, subOps, "expected expression for register clock"))
     return failure();
+  clock = convertToPassive(clock, clock.getLoc());
 
   // Parse the 'with' specifier if present.
   Value resetSignal, resetValue;

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2147,6 +2147,7 @@ ParseResult FIRStmtParser::parseRegister(unsigned regIndent) {
           parseToken(FIRToken::r_paren, "expected ')' in reset specifier") ||
           parseOptionalInfo(info, subOps))
         return failure();
+      resetValue = convertToPassive(resetValue, resetValue.getLoc());
     }
 
     if (hasExtraLParen &&

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -557,3 +557,14 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: [[rst_passive:%.+]] = firrtl.asPassive %rst
     ; CHECK: firrtl.regreset %clk, [[rst_passive]]
     reg r: UInt<1>, clk with : (reset => (rst, UInt<1>(0)))
+
+  ; COM: Check that a register init sink is converted to passive
+  ; CHECK-LABEL: firrtl.module @register_init_passive
+  module register_init_passive:
+    input clk: Clock
+    input rst: UInt<1>
+    output init: UInt<1>
+    init is invalid
+    ; CHECK: [[init_passive:%.+]] = firrtl.asPassive %init
+    ; CHECK: firrtl.regreset %clk, %rst, [[init_passive]]
+    reg r: UInt<1>, clk with : (reset => (rst, init))

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -537,3 +537,13 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input a: { a: UInt<1>, b: Analog<1>}
     ; CHECK: %b = firrtl.node %a {{.+}}: !firrtl.bundle<a: uint<1>, b: analog<1>>
     node b = a
+
+  ; COM: Check that a register clock sink is converted to passive
+  ; CHECK-LABEL: firrtl.module @register_clock_passive
+  module register_clock_passive:
+    input clkIn: Clock
+    output clkOut: Clock
+    clkOut <= clkIn
+    ; CHECK: [[clkOut_passive:%.+]] = firrtl.asPassive %clkOut
+    ; CHECK: firrtl.reg [[clkOut_passive]]
+    reg r: UInt<1>, clkOut

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -547,3 +547,13 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: [[clkOut_passive:%.+]] = firrtl.asPassive %clkOut
     ; CHECK: firrtl.reg [[clkOut_passive]]
     reg r: UInt<1>, clkOut
+
+  ; COM: Check that a register reset sink is converted to passive
+  ; CHECK-LABEL: firrtl.module @register_reset_passive
+  module register_reset_passive:
+    input clk: Clock
+    output rst: UInt<1>
+    rst is invalid
+    ; CHECK: [[rst_passive:%.+]] = firrtl.asPassive %rst
+    ; CHECK: firrtl.regreset %clk, [[rst_passive]]
+    reg r: UInt<1>, clk with : (reset => (rst, UInt<1>(0)))


### PR DESCRIPTION
Align the FIRRTL parser with the Scala FIRRTL Compiler (SFC) so that it accepts circuits where the clock, reset, or initialization are flipped. E.g., they are output ports.

This PR splits out  non-controversial stuff in #381. These circuits, if lowered to RTL, will have the appropriate synthetic wires added. I spot checked the RTL and Verilog output and this looked good.

E.g., the following circuit:

```
circuit Foo:
  module Foo:
    input clkIn: Clock
    output clkOut: Clock
    input a: UInt<1>
    output b: UInt<1>

    clkOut <= clkIn
    reg r: UInt<1>, clkOut

    r <= a
    b <= r
```

Is parsed into the following FIRRTL dialect:

```mlir
module  {
  firrtl.circuit "Foo" {
    firrtl.module @Foo(%clkIn: !firrtl.clock, %clkOut: !firrtl.flip<clock>, %a: !firrtl.uint<1>, %b: !firrtl.flip<uint<1>>) {
      firrtl.connect %clkOut, %clkIn : !firrtl.flip<clock>, !firrtl.clock
      %0 = firrtl.asPassive %clkOut : (!firrtl.flip<clock>) -> !firrtl.clock
      %r = firrtl.reg %0 {name = "r"} : (!firrtl.clock) -> !firrtl.uint<1>
      firrtl.connect %r, %a : !firrtl.uint<1>, !firrtl.uint<1>
      firrtl.connect %b, %r : !firrtl.flip<uint<1>>, !firrtl.uint<1>
    }
  }
}
```

In RTL this becomes (verbatim stuff pruned):

```mlir
module attributes {firrtl.mainModule = "Foo"}  {
  rtl.module @Foo(%clkIn: i1, %a: i1) -> (%clkOut: i1, %b: i1) {
    %0 = rtl.wire : !rtl.inout<i1>
    rtl.connect %0, %clkIn : i1
    %r = sv.reg : !rtl.inout<i1>
    %1 = rtl.read_inout %0 : !rtl.inout<i1>
    sv.always posedge %1  {
      sv.passign %r, %a : i1
    }
    %2 = rtl.read_inout %r : !rtl.inout<i1>
    rtl.output %1, %2 : i1, i1
  }
}
```

And the following Verilog:
```verilog
module Foo(
  input  clkIn, a,
  output clkOut, b);

  wire _T;	// Foo.fir:2:3
  reg  r;	// Foo.fir:9:5

  assign _T = clkIn;	// Foo.fir:8:12
  wire _T_0 = _T;	// Foo.fir:11:7
  always @(posedge _T_0)	// Foo.fir:11:7
    r <= a;	// Foo.fir:11:7
  assign clkOut = _T_0;	// Foo.fir:2:3
  assign b = r;	// Foo.fir:2:3
endmodule
```