### PR TITLE
[HandshakeToFIRRTL] update lowering logic of MemoryOp

### DIFF
--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -1529,10 +1529,6 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
     auto storeCompleted = rewriter.create<AndPrimOp>(
         insertLoc, bitType, writeValidBuffer, storeControlReady);
 
-    // Connect the gate to both the store address ready and store data ready.
-    rewriter.create<ConnectOp>(insertLoc, storeAddrReady, storeCompleted);
-    rewriter.create<ConnectOp>(insertLoc, storeDataReady, storeCompleted);
-
     // Create a signal for when the write valid buffer is empty or the output is
     // ready.
     auto notWriteValidBuffer =
@@ -1540,6 +1536,10 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
 
     auto emptyOrComplete = rewriter.create<OrPrimOp>(
         insertLoc, bitType, notWriteValidBuffer, storeCompleted);
+
+    // Connect the gate to both the store address ready and store data ready.
+    rewriter.create<ConnectOp>(insertLoc, storeAddrReady, emptyOrComplete);
+    rewriter.create<ConnectOp>(insertLoc, storeDataReady, emptyOrComplete);
 
     // Create a gate for when both the store address and data are valid.
     auto writeValid = rewriter.create<AndPrimOp>(

--- a/test/Conversion/HandshakeToFIRRTL/test_memory.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_memory.mlir
@@ -73,15 +73,17 @@
 // Connect the write valid buffer to the store control valid.
 // CHECK: firrtl.connect %[[ST_CONTROL_VALID]], %[[WRITE_VALID_BUFFER]]
 
-// Create the store completed signal and connect it to the store data and
-// address ports.
+// Create the store completed signal.
 // CHECK: %[[STORE_COMPLETED:.+]] = firrtl.and %[[WRITE_VALID_BUFFER]], %[[ST_CONTROL_READY]]
-// CHECK: firrtl.connect %[[ST_ADDR_READY]], %[[STORE_COMPLETED]]
-// CHECK: firrtl.connect %[[ST_DATA_READY]], %[[STORE_COMPLETED]]
 
 // Create the logic to drive the write valid buffer or keep its output.
 // CHECK: %[[NOT_WRITE_VALID_BUFFER:.+]] = firrtl.not %[[WRITE_VALID_BUFFER]]
 // CHECK: %[[EMPTY_OR_COMPLETE:.+]] = firrtl.or %[[NOT_WRITE_VALID_BUFFER]], %[[STORE_COMPLETED]]
+
+// Connect the store data and address ports.
+// CHECK: firrtl.connect %[[ST_ADDR_READY]], %[[EMPTY_OR_COMPLETE]]
+// CHECK: firrtl.connect %[[ST_DATA_READY]], %[[EMPTY_OR_COMPLETE]]
+
 // CHECK: %[[WRITE_VALID:.+]] = firrtl.and %[[ST_ADDR_VALID]], %[[ST_DATA_VALID]]
 // CHECK: %[[WRITE_VALID_BUFFER_MUX:.+]] = firrtl.mux(%[[EMPTY_OR_COMPLETE]], %[[WRITE_VALID]], %[[WRITE_VALID_BUFFER]])
 // CHECK: firrtl.connect %[[WRITE_VALID_BUFFER]], %[[WRITE_VALID_BUFFER_MUX]]


### PR DESCRIPTION
Just found the logic of driving `storeAddrReady` and `storeDataReady` are not update. Does this make sense?