### PR TITLE
[HandshakeToFIRRTL] lowering of BufferOp

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -252,7 +252,7 @@ def BufferOp : Handshake_Op<"buffer", [NoSideEffect, HasClock]> {
   }];
 
   let arguments = (ins AnyType, BoolAttr:$sequential, BoolAttr:$control, 
-                   Confined<I32Attr, [IntMinValue<0>]>:$slots);
+                   Confined<I32Attr, [IntMinValue<1>]>:$slots);
   let results = (outs AnyType);
 
   let extraClassDeclaration = [{

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -720,9 +720,9 @@ public:
   void buildAllReadyLogic(SmallVector<ValueVector *, 4> inputs,
                           ValueVector *output, Value condition);
 
-  void buildOneStageSeqBufferLogic(Value predValid, Value succValidReg,
+  void buildOneStageSeqBufferLogic(Value predValid, Value validReg,
                                    Value predReady, Value succReady,
-                                   Value predData, Value succDataReg);
+                                   Value predData, Value dataReg);
   bool buildSeqBufferLogic(int64_t numStage, ValueVector *input,
                            ValueVector *output, Value clock, Value reset,
                            bool isControl);
@@ -1508,11 +1508,12 @@ bool HandshakeBuilder::buildSeqBufferLogic(int64_t numStage, ValueVector *input,
         insertLoc, bitType, clock, reset, falseConst, validRegName);
 
     // Create registers for data signal.
-    auto dataRegName = rewriter.getStringAttr("dataReg" + std::to_string(i));
     Value dataReg = nullptr;
-    if (!isControl)
+    if (!isControl) {
+      auto dataRegName = rewriter.getStringAttr("dataReg" + std::to_string(i));
       dataReg = rewriter.create<RegResetOp>(insertLoc, dataType, clock, reset,
                                             zeroDataConst, dataRegName);
+    }
 
     // Build the current stage of the buffer.
     buildOneStageSeqBufferLogic(currentValid, validReg, currentReady, readyWire,

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -720,6 +720,13 @@ public:
   void buildAllReadyLogic(SmallVector<ValueVector *, 4> inputs,
                           ValueVector *output, Value condition);
 
+  void buildOneStageSeqBufferLogic(Value predValid, Value succValidReg,
+                                   Value predReady, Value succReady,
+                                   Value predData, Value succDataReg);
+  bool buildSeqBufferLogic(int64_t numStage, ValueVector *input,
+                           ValueVector *output, Value clock, Value reset,
+                           bool isControl);
+
 private:
   ValueVectorList portList;
   Location insertLoc;
@@ -1416,27 +1423,131 @@ bool HandshakeBuilder::visitHandshake(handshake::ConstantOp op) {
   return true;
 }
 
-bool HandshakeBuilder::visitHandshake(BufferOp op) {
-  ValueVector inputSubfields = portList[0];
-  Value inputValid = inputSubfields[0];
-  Value inputReady = inputSubfields[1];
+void HandshakeBuilder::buildOneStageSeqBufferLogic(
+    Value predValid, Value validReg, Value predReady, Value succReady,
+    Value predData = nullptr, Value dataReg = nullptr) {
+  auto bitType = UIntType::get(rewriter.getContext(), 1);
 
-  ValueVector outputSubfields = portList[1];
-  Value outputValid = outputSubfields[0];
-  Value outputReady = outputSubfields[1];
+  // Create a signal for when the valid register is empty or the successor is
+  // ready to accept new token.
+  auto notValidReg = rewriter.create<NotPrimOp>(insertLoc, bitType, validReg);
+  auto emptyOrReady =
+      rewriter.create<OrPrimOp>(insertLoc, bitType, notValidReg, succReady);
+
+  rewriter.create<ConnectOp>(insertLoc, predReady, emptyOrReady);
+
+  // Create a mux that drives the register input. If the emptyOrReady signal
+  // is asserted, the mux selects the predValid signal. Otherwise, it selects
+  // the register output, keeping the output registered unchanged.
+  auto validRegMux = rewriter.create<MuxPrimOp>(
+      insertLoc, bitType, emptyOrReady, predValid, validReg);
+
+  // Now we can drive the valid register.
+  rewriter.create<ConnectOp>(insertLoc, validReg, validRegMux);
+
+  // If data is not nullptr, create data logic.
+  if (predData && dataReg) {
+    auto dataType = predData.getType().cast<FIRRTLType>();
+
+    // Create a mux that drives the date register.
+    auto dataRegMux = rewriter.create<MuxPrimOp>(
+        insertLoc, dataType, emptyOrReady, predData, dataReg);
+    rewriter.create<ConnectOp>(insertLoc, dataReg, dataRegMux);
+  }
+}
+
+bool HandshakeBuilder::buildSeqBufferLogic(int64_t numStage, ValueVector *input,
+                                           ValueVector *output, Value clock,
+                                           Value reset, bool isControl) {
+  if (input == nullptr || output == nullptr)
+    return false;
+
+  auto inputSubfields = *input;
+  auto inputValid = inputSubfields[0];
+  auto inputReady = inputSubfields[1];
+
+  auto outputSubfields = *output;
+  auto outputValid = outputSubfields[0];
+  auto outputReady = outputSubfields[1];
+
+  // Create useful value and type for valid/ready signal.
+  auto bitType = UIntType::get(rewriter.getContext(), 1);
+  auto falseConst = createConstantOp(bitType, APInt(1, 0), insertLoc, rewriter);
+
+  // Create useful value and type for data signal.
+  FIRRTLType dataType = nullptr;
+  Value zeroDataConst = nullptr;
+
+  // Temporary values for storing the valid, ready, and data signals in the
+  // procedure of constructing the multi-stages buffer.
+  Value currentValid = inputValid;
+  Value currentReady = inputReady;
+  Value currentData = nullptr;
+
+  // If is not a control buffer, fill in corresponding values and type.
+  if (!isControl) {
+    auto inputData = inputSubfields[2];
+
+    dataType = inputData.getType().cast<FIRRTLType>();
+    zeroDataConst =
+        createConstantOp(dataType, APInt(dataType.getBitWidthOrSentinel(), 0),
+                         insertLoc, rewriter);
+    currentData = inputData;
+  }
+
+  // Create multiple stages buffer logic.
+  for (unsigned i = 0; i < numStage; ++i) {
+    // Create wires for ready signal from the success buffer stage.
+    auto readyWireName =
+        rewriter.getStringAttr("readyWire" + std::to_string(i));
+    auto readyWire = rewriter.create<WireOp>(insertLoc, bitType, readyWireName);
+
+    // Create a register for valid signal.
+    auto validRegName = rewriter.getStringAttr("validReg" + std::to_string(i));
+    auto validReg = rewriter.create<RegResetOp>(
+        insertLoc, bitType, clock, reset, falseConst, validRegName);
+
+    // Create registers for data signal.
+    auto dataRegName = rewriter.getStringAttr("dataReg" + std::to_string(i));
+    Value dataReg = nullptr;
+    if (!isControl)
+      dataReg = rewriter.create<RegResetOp>(insertLoc, dataType, clock, reset,
+                                            zeroDataConst, dataRegName);
+
+    // Build the current stage of the buffer.
+    buildOneStageSeqBufferLogic(currentValid, validReg, currentReady, readyWire,
+                                currentData, dataReg);
+
+    // Update the current valid, ready, and data.
+    currentValid = validReg;
+    currentReady = readyWire;
+    currentData = dataReg;
+  }
+
+  // Connect to the output ports.
+  rewriter.create<ConnectOp>(insertLoc, outputValid, currentValid);
+  rewriter.create<ConnectOp>(insertLoc, currentReady, outputReady);
+  if (!isControl) {
+    auto outputData = outputSubfields[2];
+    rewriter.create<ConnectOp>(insertLoc, outputData, currentData);
+  }
+
+  return true;
+}
+
+bool HandshakeBuilder::visitHandshake(BufferOp op) {
+  ValueVector input = portList[0];
+  ValueVector output = portList[1];
 
   Value clock = portList[2][0];
   Value reset = portList[3][0];
 
-  // FIXME: This looks unimplemented?
-  (void)outputReady;
-  (void)outputValid;
-  (void)reset;
-  (void)clock;
-  (void)inputValid;
-  (void)inputReady;
-
-  return true;
+  // For now, we only support sequential buffers.
+  if (op.sequential())
+    return buildSeqBufferLogic(op.slots(), &input, &output, clock, reset,
+                               op.control());
+  else
+    return false;
 }
 
 bool HandshakeBuilder::visitHandshake(MemoryOp op) {

--- a/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt -lower-handshake-to-firrtl -split-input-file %s | FileCheck %s
 
-// CHECK-LABEL: firrtl.module @handshake_buffer_1ins_1outs_3slots_seq_ctrl(
+// CHECK-LABEL: firrtl.module @handshake_buffer_1ins_1outs_ctrl_3slots_seq(
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
 // CHECK:   %[[IN_VALID:.+]] = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
 // CHECK:   %[[IN_READY:.+]] = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.flip<uint<1>>
@@ -52,7 +52,7 @@
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
 handshake.func @test_buffer(%arg0: none, %arg1: none, ...) -> (none, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_clock, %inst_reset = firrtl.instance @handshake_buffer_1ins_1outs_3slots_seq_ctrl {name = "", portNames = ["arg0", "arg1", "clock", "reset"]} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, !firrtl.flip<clock>, !firrtl.flip<uint<1>>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_clock, %inst_reset = firrtl.instance @handshake_buffer_1ins_1outs_ctrl_3slots_seq {name = "", portNames = ["arg0", "arg1", "clock", "reset"]} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, !firrtl.flip<clock>, !firrtl.flip<uint<1>>
   %0 = "handshake.buffer"(%arg0) {control = true, sequential = true, slots = 3 : i32} : (none) -> none
   handshake.return %0, %arg1 : none, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
@@ -13,35 +13,35 @@
 // CHECK:   %validReg0 = firrtl.regreset %clock, %reset, %c0_ui1 {name = "validReg0"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 
 // pred_ready = !reg_valid || succ_ready.
-// CHECK:   %4 = firrtl.not %validReg0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   %5 = firrtl.or %4, %readyWire0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %[[IN_READY:.+]], %5 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// CHECK:   %[[VAL_4:.+]] = firrtl.not %validReg0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   %[[VAL_5:.+]] = firrtl.or %[[VAL_4:.+]], %readyWire0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   firrtl.connect %[[IN_READY:.+]], %[[VAL_5:.+]] : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 
 // Drive valid register.
-// CHECK:   %6 = firrtl.mux(%5, %[[IN_VALID:.+]], %validReg0) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %validReg0, %6 : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   %[[VAL_6:.+]] = firrtl.mux(%[[VAL_5:.+]], %[[IN_VALID:.+]], %validReg0) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   firrtl.connect %validReg0, %[[VAL_6:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
 
 // Stage 1 logics.
 // CHECK:   %readyWire1 = firrtl.wire : !firrtl.uint<1>
 // CHECK:   %validReg1 = firrtl.regreset %clock, %reset, %c0_ui1 {name = "validReg1"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 
-// CHECK:   %7 = firrtl.not %validReg1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   %8 = firrtl.or %7, %readyWire1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %readyWire0, %8 : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   %[[VAL_7:.+]] = firrtl.not %validReg1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   %[[VAL_8:.+]] = firrtl.or %[[VAL_7:.+]], %readyWire1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   firrtl.connect %readyWire0, %[[VAL_8:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
 
-// CHECK:   %9 = firrtl.mux(%8, %validReg0, %validReg1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %validReg1, %9 : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   %[[VAL_9:.+]] = firrtl.mux(%[[VAL_8:.+]], %validReg0, %validReg1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   firrtl.connect %validReg1, %[[VAL_9:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
 
 // Stage 2 logics.
 // CHECK:   %readyWire2 = firrtl.wire : !firrtl.uint<1>
 // CHECK:   %validReg2 = firrtl.regreset %clock, %reset, %c0_ui1 {name = "validReg2"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 
-// CHECK:   %10 = firrtl.not %validReg2 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   %11 = firrtl.or %10, %readyWire2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %readyWire1, %11 : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   %[[VAL_10:.+]] = firrtl.not %validReg2 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   %[[VAL_11:.+]] = firrtl.or %[[VAL_10:.+]], %readyWire2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   firrtl.connect %readyWire1, %[[VAL_11:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
 
-// CHECK:   %12 = firrtl.mux(%11, %validReg1, %validReg2) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %validReg2, %12 : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   %[[VAL_12:.+]] = firrtl.mux(%[[VAL_11:.+]], %validReg1, %validReg2) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   firrtl.connect %validReg2, %[[VAL_12:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
 
 // Connet to output ports.
 // CHECK:   firrtl.connect %[[OUT_VALID:.+]], %validReg2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
@@ -66,12 +66,12 @@ handshake.func @test_buffer(%arg0: none, %arg1: none, ...) -> (none, none) {
 // CHECK:   %c0_ui64 = firrtl.constant(0 : ui64) : !firrtl.uint<64>
 
 // CHECK:   %dataReg0 = firrtl.regreset %clock, %reset, %c0_ui64 {name = "dataReg0"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<64>) -> !firrtl.uint<64>
-// CHECK:   %9 = firrtl.mux(%7, %[[IN_DATA:.+]], %dataReg0) : (!firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>) -> !firrtl.uint<64>
-// CHECK:   firrtl.connect %dataReg0, %9 : !firrtl.uint<64>, !firrtl.uint<64>
+// CHECK:   %[[VAL_9:.+]] = firrtl.mux(%[[VAL_7:.+]], %[[IN_DATA:.+]], %dataReg0) : (!firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>) -> !firrtl.uint<64>
+// CHECK:   firrtl.connect %dataReg0, %[[VAL_9:.+]] : !firrtl.uint<64>, !firrtl.uint<64>
 
 // CHECK:   %dataReg1 = firrtl.regreset %clock, %reset, %c0_ui64 {name = "dataReg1"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<64>) -> !firrtl.uint<64>
-// CHECK:   %13 = firrtl.mux(%11, %dataReg0, %dataReg1) : (!firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>) -> !firrtl.uint<64>
-// CHECK:   firrtl.connect %dataReg1, %13 : !firrtl.uint<64>, !firrtl.uint<64>
+// CHECK:   %[[VAL_13:.+]] = firrtl.mux(%[[VAL_11:.+]], %dataReg0, %dataReg1) : (!firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>) -> !firrtl.uint<64>
+// CHECK:   firrtl.connect %dataReg1, %[[VAL_13:.+]] : !firrtl.uint<64>, !firrtl.uint<64>
 
 // CHECK:   firrtl.connect %[[OUT_DATA:.+]], %dataReg1 : !firrtl.flip<uint<64>>, !firrtl.uint<64>
 // CHECK: }


### PR DESCRIPTION
Implement the lowering of BufferOp. For now, this only supports non-transparent buffers. A buildSeqBufferLogic() method is created for other builders to make use of.