### PR TITLE
[HandshakeToFIRRTL] Update MemoryOp to use buildJoinLogic.

### DIFF
--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -1235,13 +1235,9 @@ bool HandshakeBuilder::buildForkLogic(ValueVector *input,
   // Create an AndPrimOp chain for generating the ready signal. Only if all
   // result ports are handshaked (done), the argument port is ready to accept
   // the next token.
-  Value tmpDone = doneWires[0];
-  for (auto doneWire : llvm::drop_begin(doneWires, 1))
-    tmpDone = rewriter.create<AndPrimOp>(insertLoc, bitType, doneWire, tmpDone);
-
-  auto allDoneWire = rewriter.create<WireOp>(insertLoc, bitType,
-                                             rewriter.getStringAttr("allDone"));
-  rewriter.create<ConnectOp>(insertLoc, allDoneWire, tmpDone);
+  Value allDoneWire = rewriter.create<WireOp>(
+      insertLoc, bitType, rewriter.getStringAttr("allDone"));
+  buildReductionTree<AndPrimOp>(doneWires, allDoneWire);
 
   // Connect the allDoneWire to the input ready.
   rewriter.create<ConnectOp>(insertLoc, argReady, allDoneWire);

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -325,8 +325,8 @@ static void createMergeArgReady(ArrayRef<Value> outputs, Value fired,
 
 static void extractValues(ArrayRef<ValueVector *> valueVectors, size_t index,
                           SmallVectorImpl<Value> &result) {
-  for (size_t i = 0; i < valueVectors.size(); ++i)
-    result.push_back((*valueVectors[i])[index]);
+  for (auto *elt : valueVectors)
+    result.push_back((*elt)[index]);
 }
 
 //===----------------------------------------------------------------------===//
@@ -716,8 +716,7 @@ template <typename OpType>
 Value HandshakeBuilder::buildReductionTree(ArrayRef<Value> inputs,
                                            Value output) {
   size_t inputSize = inputs.size();
-  if (!inputSize)
-    return Value();
+  assert(inputSize && "must pass inputs to reduce");
 
   auto tmpValue = inputs[0];
 

--- a/test/Conversion/HandshakeToFIRRTL/test_fork.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_fork.mlir
@@ -14,8 +14,8 @@
 // CHECK:   %done0 = firrtl.wire : !firrtl.uint<1>
 // CHECK:   %done1 = firrtl.wire : !firrtl.uint<1>
 
-// CHECK:   %6 = firrtl.and %done1, %done0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   %allDone = firrtl.wire : !firrtl.uint<1>
+// CHECK:   %6 = firrtl.and %done1, %done0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   firrtl.connect %allDone, %6 : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:   firrtl.connect %[[ARG_READY:.+]], %allDone : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 

--- a/test/Conversion/HandshakeToFIRRTL/test_memory.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_memory.mlir
@@ -74,7 +74,9 @@
 // CHECK: firrtl.connect %[[ST_CONTROL_VALID]], %[[WRITE_VALID_BUFFER]]
 
 // Create the store completed signal.
-// CHECK: %[[STORE_COMPLETED:.+]] = firrtl.and %[[WRITE_VALID_BUFFER]], %[[ST_CONTROL_READY]]
+// CHECK: %[[STORE_COMPLETED:storeCompleted]] = firrtl.wire : !firrtl.uint<1>
+// CHECK: %[[STORE_COMPLETED_GATE:.+]] = firrtl.and %[[ST_CONTROL_READY]], %[[WRITE_VALID_BUFFER]]
+// CHECK: firrtl.connect %[[STORE_COMPLETED]], %[[STORE_COMPLETED_GATE]]
 
 // Create the logic to drive the write valid buffer or keep its output.
 // CHECK: %[[NOT_WRITE_VALID_BUFFER:.+]] = firrtl.not %[[WRITE_VALID_BUFFER]]
@@ -84,7 +86,9 @@
 // CHECK: firrtl.connect %[[ST_ADDR_READY]], %[[EMPTY_OR_COMPLETE]]
 // CHECK: firrtl.connect %[[ST_DATA_READY]], %[[EMPTY_OR_COMPLETE]]
 
-// CHECK: %[[WRITE_VALID:.+]] = firrtl.and %[[ST_ADDR_VALID]], %[[ST_DATA_VALID]]
+// CHECK: %[[WRITE_VALID:writeValid]] = firrtl.wire : !firrtl.uint<1>
+// CHECK: %[[WRITE_VALID_GATE:.+]] = firrtl.and %[[ST_DATA_VALID]], %[[ST_ADDR_VALID]]
+// CHECK: firrtl.connect %[[WRITE_VALID]], %[[WRITE_VALID_GATE]]
 // CHECK: %[[WRITE_VALID_BUFFER_MUX:.+]] = firrtl.mux(%[[EMPTY_OR_COMPLETE]], %[[WRITE_VALID]], %[[WRITE_VALID_BUFFER]])
 // CHECK: firrtl.connect %[[WRITE_VALID_BUFFER]], %[[WRITE_VALID_BUFFER_MUX]]
 


### PR DESCRIPTION
@hanchenye I started to think about using buildJoinLogic, and I remembered this isn't completely straightforward. The problem with the buildJoinLogic implementation for MemoryOp is we can't re-use the `tmpValid` signal between the valid logic and the ready logic.

So, I split buildJoinLogic into two further helpers, which can be used separately in the lowering of MemoryOp. However, to use them, I think I need to introduce a temporary wire to be connected to. In this case, the implementation using the helpers is actually more verbose than the original.

Am I missing a better way to re-factor this? I'm not a huge fan of this change as-is. The existing buildJoinLogic seems to be relevant to the LoadOp at least, so we can just abandon this revision if it's not worth it.