### PR TITLE
[RTL] Add canonicalizers for mux and icmp

### DIFF
--- a/include/circt/Dialect/RTL/RTLCombinatorial.td
+++ b/include/circt/Dialect/RTL/RTLCombinatorial.td
@@ -132,6 +132,10 @@ def MergeOp : UTVariadicRTLOp<"merge", [Commutative]> {
   let hasCanonicalizer = false;
 }
 
+//===----------------------------------------------------------------------===//
+// Comparisons
+//===----------------------------------------------------------------------===//
+
 def ICmpPredicateEQ  : I64EnumAttrCase<"eq", 0>;
 def ICmpPredicateNE  : I64EnumAttrCase<"ne", 1>;
 def ICmpPredicateSLT : I64EnumAttrCase<"slt", 2>;
@@ -149,19 +153,37 @@ def ICmpPredicate : I64EnumAttr<
      ICmpPredicateSGT, ICmpPredicateSGE, ICmpPredicateULT, ICmpPredicateULE,
      ICmpPredicateUGT, ICmpPredicateUGE]>;
 
-// Other integer operations.
 def ICmpOp : RTLOp<"icmp", [NoSideEffect, SameTypeOperands]> {
+  let summary = "Compare two integer values";
+  let description = [{
+    This operation compares two integers using a predicate.  If the predicate is
+    true, returns 1, otherwise returns 0. This operation always returns a one
+    bit wide result.
+
+    ```
+        %r = rtl.icmp eq %a, %b : i4
+    ```
+  }];
+
   let arguments = (ins ICmpPredicate:$predicate, 
                    RTLIntegerType:$lhs, RTLIntegerType:$rhs);
   let results = (outs I1:$result);
 
   let assemblyFormat = "$predicate $lhs `,` $rhs  attr-dict `:` type($lhs)";
+  
+  let hasFolder = true;
+  let hasCanonicalizer = true;
 
   let builders = [
     OpBuilderDAG<(ins "ICmpPredicate":$pred, "Value":$lhs, "Value":$rhs), [{
       return build($_builder, $_state, $_builder.getI1Type(), pred, lhs, rhs);
     }]>
   ];
+  let extraClassDeclaration = [{
+    /// Returns the flipped predicate, reversing the LHS and RHS operands.  The
+    /// lhs and rhs operands should be flipped to match the new predicate.
+    static ICmpPredicate getFlippedPredicate(ICmpPredicate predicate);
+  }];
 }
 
 //===----------------------------------------------------------------------===//
@@ -301,6 +323,11 @@ def ArraySliceOp : RTLOp<"array_slice", [NoSideEffect]> {
 def MuxOp : RTLOp<"mux",
  [NoSideEffect, AllTypesMatch<["trueValue", "falseValue", "result"]>]> {
   let summary = "Return one or the other operand depending on a selector bit";
+  let description = [{
+    ```
+      %0 = mux %pred, %tvalue, %fvalue : i4
+    ```
+  }];
 
   let arguments = (ins I1:$cond, RTLIntegerType:$trueValue,
                        RTLIntegerType:$falseValue);
@@ -308,6 +335,8 @@ def MuxOp : RTLOp<"mux",
 
   let assemblyFormat =
     "$cond `,` $trueValue `,` $falseValue attr-dict `:` type($result)";
+  
+  let hasFolder = true;
 
   let builders = [
     OpBuilderDAG<(ins "Value":$cond, "Value":$trueValue, "Value":$falseValue),

--- a/lib/Dialect/RTL/RTLFolds.cpp
+++ b/lib/Dialect/RTL/RTLFolds.cpp
@@ -732,3 +732,219 @@ void WireOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
   };
   results.insert<DropDeadConnect>(context);
 }
+
+//===----------------------------------------------------------------------===//
+// MuxOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult MuxOp::fold(ArrayRef<Attribute> constants) {
+  // mux (c, b, b) -> b
+  if (trueValue() == falseValue())
+    return trueValue();
+
+  // mux(0, a, b) -> b
+  // mux(1, a, b) -> a
+  if (auto pred = constants[0].dyn_cast_or_null<IntegerAttr>()) {
+    if (pred.getValue().isNullValue())
+      return falseValue();
+    return trueValue();
+  }
+
+  return {};
+}
+
+//===----------------------------------------------------------------------===//
+// ICmpOp
+//===----------------------------------------------------------------------===//
+
+// Calculate the result of a comparison when the LHS and RHS are both
+// constants.
+static bool applyCmpPredicate(ICmpPredicate predicate, const APInt &lhs,
+                              const APInt &rhs) {
+  switch (predicate) {
+  case ICmpPredicate::eq:
+    return lhs.eq(rhs);
+  case ICmpPredicate::ne:
+    return lhs.ne(rhs);
+  case ICmpPredicate::slt:
+    return lhs.slt(rhs);
+  case ICmpPredicate::sle:
+    return lhs.sle(rhs);
+  case ICmpPredicate::sgt:
+    return lhs.sgt(rhs);
+  case ICmpPredicate::sge:
+    return lhs.sge(rhs);
+  case ICmpPredicate::ult:
+    return lhs.ult(rhs);
+  case ICmpPredicate::ule:
+    return lhs.ule(rhs);
+  case ICmpPredicate::ugt:
+    return lhs.ugt(rhs);
+  case ICmpPredicate::uge:
+    return lhs.uge(rhs);
+  }
+  llvm_unreachable("unknown comparison predicate");
+}
+
+// Returns the result of applying the predicate when the LHS and RHS are the
+// exact same value.
+static bool applyCmpPredicateToEqualOperands(ICmpPredicate predicate) {
+  switch (predicate) {
+  case ICmpPredicate::eq:
+  case ICmpPredicate::sle:
+  case ICmpPredicate::sge:
+  case ICmpPredicate::ule:
+  case ICmpPredicate::uge:
+    return true;
+  case ICmpPredicate::ne:
+  case ICmpPredicate::slt:
+  case ICmpPredicate::sgt:
+  case ICmpPredicate::ult:
+  case ICmpPredicate::ugt:
+    return false;
+  }
+  llvm_unreachable("unknown comparison predicate");
+}
+
+OpFoldResult ICmpOp::fold(ArrayRef<Attribute> constants) {
+
+  // gt a, a -> false
+  // gte a, a -> true
+  if (lhs() == rhs()) {
+    auto val = applyCmpPredicateToEqualOperands(predicate());
+    return IntegerAttr::get(getType(), val);
+  }
+
+  auto lhs = constants[0].dyn_cast_or_null<IntegerAttr>();
+  auto rhs = constants[1].dyn_cast_or_null<IntegerAttr>();
+
+  // gt 1, 2 -> false
+  if (lhs && rhs) {
+    auto val = applyCmpPredicate(predicate(), lhs.getValue(), rhs.getValue());
+    return IntegerAttr::get(getType(), val);
+  }
+
+  return {};
+}
+
+namespace {
+// Canonicalizes a ICmp with a single constant
+struct ICmpCanonicalizeConstant final : public OpRewritePattern<ICmpOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(ICmpOp op,
+                                PatternRewriter &rewriter) const override {
+
+    APInt lhs, rhs;
+
+    // icmp 1, x -> icmp x, 1
+    if (matchPattern(op.lhs(), m_RConstant(lhs))) {
+      assert(!matchPattern(op.rhs(), m_RConstant(rhs)) && "Should be folded");
+      rewriter.replaceOpWithNewOp<ICmpOp>(
+          op, ICmpOp::getFlippedPredicate(op.predicate()), op.rhs(), op.lhs());
+      return success();
+    }
+
+    // Canonicalize with RHS constant
+    if (matchPattern(op.rhs(), m_RConstant(rhs))) {
+      ConstantOp constant;
+
+      auto getConstant = [&rewriter, &op](APInt &&constant) -> Value {
+        return rewriter.create<ConstantOp>(op.getLoc(), constant);
+      };
+
+      auto replaceWith = [&rewriter, &op](ICmpPredicate predicate, Value lhs,
+                                          Value rhs) -> LogicalResult {
+        rewriter.replaceOpWithNewOp<ICmpOp>(op, predicate, lhs, rhs);
+        return success();
+      };
+
+      auto replaceWithConstant = [&rewriter,
+                                  &op](bool constant) -> LogicalResult {
+        rewriter.replaceOpWithNewOp<ConstantOp>(op, APInt(1, constant));
+        return success();
+      };
+
+      switch (op.predicate()) {
+      case ICmpPredicate::slt:
+        // x < max -> x != max
+        if (rhs.isMaxSignedValue())
+          return replaceWith(ICmpPredicate::ne, op.lhs(), op.rhs());
+        // x < min -> false
+        if (rhs.isMinSignedValue())
+          return replaceWithConstant(0);
+        // x < min+1 -> x == min
+        if ((rhs - 1).isMinSignedValue())
+          return replaceWith(ICmpPredicate::eq, op.lhs(), getConstant(rhs - 1));
+        break;
+      case ICmpPredicate::sgt:
+        // x > min -> x != min
+        if (rhs.isMinSignedValue())
+          return replaceWith(ICmpPredicate::ne, op.lhs(), op.rhs());
+        // x > max -> false
+        if (rhs.isMaxSignedValue())
+          return replaceWithConstant(0);
+        // x > max-1 -> x == max
+        if ((rhs + 1).isMaxSignedValue())
+          return replaceWith(ICmpPredicate::eq, op.lhs(), getConstant(rhs + 1));
+        break;
+      case ICmpPredicate::ult:
+        // x < max -> x != max
+        if (rhs.isMaxValue())
+          return replaceWith(ICmpPredicate::ne, op.lhs(), op.rhs());
+        // x < min -> false
+        if (rhs.isMinValue())
+          return replaceWithConstant(0);
+        // x < min+1 -> x == min
+        if ((rhs - 1).isMinValue())
+          return replaceWith(ICmpPredicate::eq, op.lhs(), getConstant(rhs - 1));
+        break;
+      case ICmpPredicate::ugt:
+        // x > min -> x != min
+        if (rhs.isMinValue())
+          replaceWith(ICmpPredicate::ne, op.lhs(), op.rhs());
+        // x > max -> false
+        if (rhs.isMaxValue())
+          return replaceWithConstant(0);
+        // x > max-1 -> x == max
+        if ((rhs + 1).isMaxValue())
+          return replaceWith(ICmpPredicate::eq, op.lhs(), getConstant(rhs + 1));
+        break;
+      case ICmpPredicate::sle:
+        // x <= max -> true
+        if (rhs.isMaxSignedValue())
+          return replaceWithConstant(1);
+        // x <= c -> x < (c+1)
+        return replaceWith(ICmpPredicate::slt, op.lhs(), getConstant(rhs + 1));
+      case ICmpPredicate::sge:
+        // x >= min -> true
+        if (rhs.isMinSignedValue())
+          return replaceWithConstant(1);
+        // x >= c -> x > (c-1)
+        return replaceWith(ICmpPredicate::sgt, op.lhs(), getConstant(rhs - 1));
+      case ICmpPredicate::ule:
+        // x <= max -> true
+        if (rhs.isMaxValue())
+          return replaceWithConstant(1);
+        // x <= c -> x < (c+1)
+        return replaceWith(ICmpPredicate::ult, op.lhs(), getConstant(rhs + 1));
+      case ICmpPredicate::uge:
+        // x >= min -> true
+        if (rhs.isMinValue())
+          return replaceWithConstant(1);
+        // x >= c -> x > (c-1)
+        return replaceWith(ICmpPredicate::ugt, op.lhs(), getConstant(rhs - 1));
+      default:
+        break;
+      }
+    }
+
+    return failure();
+  }
+};
+
+} // namespace
+
+void ICmpOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
+                                         MLIRContext *context) {
+  results.insert<ICmpCanonicalizeConstant>(context);
+}

--- a/lib/Dialect/RTL/RTLOps.cpp
+++ b/lib/Dialect/RTL/RTLOps.cpp
@@ -525,6 +525,36 @@ static LogicalResult verifyOutputOp(OutputOp *op) {
 }
 
 //===----------------------------------------------------------------------===//
+// ICmpOp
+//===----------------------------------------------------------------------===//
+
+ICmpPredicate ICmpOp::getFlippedPredicate(ICmpPredicate predicate) {
+  switch (predicate) {
+  case ICmpPredicate::eq:
+    return ICmpPredicate::eq;
+  case ICmpPredicate::ne:
+    return ICmpPredicate::ne;
+  case ICmpPredicate::slt:
+    return ICmpPredicate::sgt;
+  case ICmpPredicate::sle:
+    return ICmpPredicate::sge;
+  case ICmpPredicate::sgt:
+    return ICmpPredicate::slt;
+  case ICmpPredicate::sge:
+    return ICmpPredicate::sle;
+  case ICmpPredicate::ult:
+    return ICmpPredicate::ugt;
+  case ICmpPredicate::ule:
+    return ICmpPredicate::uge;
+  case ICmpPredicate::ugt:
+    return ICmpPredicate::ult;
+  case ICmpPredicate::uge:
+    return ICmpPredicate::ule;
+  }
+  llvm_unreachable("unknown comparison predicate");
+}
+
+//===----------------------------------------------------------------------===//
 // RTL combinational ops
 //===----------------------------------------------------------------------===//
 

--- a/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
+++ b/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
@@ -160,8 +160,8 @@ module attributes {firrtl.mainModule = "Simple"} {
     %25 = firrtl.neg %s24 : (!firrtl.sint<3>) -> !firrtl.sint<4>
 
     // CHECK-NEXT: [[CVT4:%.+]] = rtl.sext [[CVT]] : (i3) -> i4
-    // CHECK-NEXT: rtl.mux %false{{.*}}, [[CVT4]], [[SUB]] : i4
-    %26 = firrtl.mux(%12, %23, %25) : (!firrtl.uint<1>, !firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.sint<4>
+    // CHECK-NEXT: rtl.mux {{.*}}, [[CVT4]], [[SUB]] : i4
+    %26 = firrtl.mux(%17, %23, %25) : (!firrtl.uint<1>, !firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.sint<4>
 
     // Noop
     %27 = firrtl.validif %12, %18 : (!firrtl.uint<1>, !firrtl.uint<14>) -> !firrtl.uint<14>

--- a/test/Conversion/FIRRTLToRTL/zero-width.mlir
+++ b/test/Conversion/FIRRTLToRTL/zero-width.mlir
@@ -33,7 +33,7 @@ module attributes {firrtl.mainModule = "Simple"} {
     %c2 = firrtl.stdIntCast %2 : (!firrtl.uint<4>) -> i4
 
     // Issue #436
-    // CHECK: [[CMP:%.+]] = rtl.icmp eq %false_2, %false_3 : i1
+    // CHECK: [[CMP:%true.*]] = rtl.constant(true) : i1
     %3 = firrtl.eq %uin0c, %uin0c : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
     %c3 = firrtl.stdIntCast %3 : (!firrtl.uint<1>) -> i1
 

--- a/test/Dialect/RTL/canonicalization.mlir
+++ b/test/Dialect/RTL/canonicalization.mlir
@@ -636,3 +636,112 @@ func @wire4() -> i1 {
   rtl.connect %w, %true : i1
   return %0 : i1
 }
+
+// CHECK-LABEL: func @mux_fold0(%arg0: i3, %arg1: i3)
+// CHECK-NEXT:    return %arg0 : i3
+func @mux_fold0(%arg0: i3, %arg1: i3) -> (i3) {
+  %c1_i1 = rtl.constant(1 : i1) : i1
+  %0 = rtl.mux %c1_i1, %arg0, %arg1 : i3
+  return %0 : i3
+}
+
+// CHECK-LABEL: func @mux_fold1(%arg0: i1, %arg1: i3)
+// CHECK-NEXT:    return %arg1 : i3
+func @mux_fold1(%arg0: i1, %arg1: i3) -> (i3) {
+  %0 = rtl.mux %arg0, %arg1, %arg1 : i3
+  return %0 : i3
+}
+
+// CHECK-LABEL: func @icmp_fold_constants() -> i1 {
+// CHECK-NEXT:    %false = rtl.constant(false) : i1
+// CHECK-NEXT:    return %false : i1
+func @icmp_fold_constants() -> (i1) {
+  %c2_i2 = rtl.constant(2 : i2) : i2
+  %c3_i2 = rtl.constant(3 : i2) : i2
+  %0 = rtl.icmp uge %c2_i2, %c3_i2 : i2
+  return %0 : i1
+}
+
+// CHECK-LABEL: func @icmp_fold_same_operands(%arg0: i2) -> i1 {
+// CHECK-NEXT:    %false = rtl.constant(false) : i1
+// CHECK-NEXT:    return %false : i1
+func @icmp_fold_same_operands(%arg0: i2) -> (i1) {
+  %0 = rtl.icmp ugt %arg0, %arg0 : i2
+  return %0 : i1
+}
+
+// CHECK-LABEL: func @icmp_fold_constant_rhs0(%arg0: i2) -> i1 {
+// CHECK-NEXT:    %false = rtl.constant(false) : i1
+// CHECK-NEXT:    return %false : i1
+func @icmp_fold_constant_rhs0(%arg0: i2) -> (i1) {
+  %c3_i2 = rtl.constant(3 : i2) : i2
+  %0 = rtl.icmp ugt %arg0, %c3_i2 : i2
+  return %0 : i1
+}
+
+// CHECK-LABEL: func @icmp_fold_constant_rhs1(%arg0: i2) -> i1 {
+// CHECK-NEXT:    %false = rtl.constant(false) : i1
+// CHECK-NEXT:    return %false : i1
+func @icmp_fold_constant_rhs1(%arg0: i2) -> (i1) {
+  %c-2_i2 = rtl.constant(-2 : i2) : i2
+  %0 = rtl.icmp slt %arg0, %c-2_i2 : i2
+  return %0 : i1
+}
+
+// CHECK-LABEL: func @icmp_fold_constant_lhs0(%arg0: i2) -> i1 {
+// CHECK-NEXT:    %true = rtl.constant(true) : i1
+// CHECK-NEXT:    return %true : i1
+func @icmp_fold_constant_lhs0(%arg0: i2) -> (i1) {
+  %c3_i2 = rtl.constant(3 : i2) : i2
+  %0 = rtl.icmp uge %c3_i2, %arg0 : i2
+  return %0 : i1
+}
+
+// CHECK-LABEL: func @icmp_fold_constant_lhs1(%arg0: i2) -> i1 {
+// CHECK-NEXT:    %true = rtl.constant(true) : i1
+// CHECK-NEXT:    return %true : i1
+func @icmp_fold_constant_lhs1(%arg0: i2) -> (i1) {
+  %c-2_i2 = rtl.constant(-2 : i2) : i2
+  %0 = rtl.icmp sle %c-2_i2, %arg0 : i2
+  return %0 : i1
+}
+
+// CHECK-LABEL: func @icmp_canonicalize0(%arg0: i2) -> i1 {
+// CHECK-NEXT:    %c-1_i2 = rtl.constant(-1 : i2) : i2
+// CHECK-NEXT:    %0 = rtl.icmp sgt %arg0, %c-1_i2 : i2
+// CHECK-NEXT:    return %0 : i1
+func @icmp_canonicalize0(%arg0: i2) -> (i1) {
+  %c-1_i2 = rtl.constant(-1 : i2) : i2
+  %0 = rtl.icmp slt %c-1_i2, %arg0 : i2
+  return %0 : i1
+}
+
+// CHECK-LABEL: func @icmp_canonicalize_ne(%arg0: i2) -> i1 {
+// CHECK-NEXT:    %c-2_i2 = rtl.constant(-2 : i2) : i2
+// CHECK-NEXT:    %0 = rtl.icmp ne %arg0, %c-2_i2 : i2
+// CHECK-NEXT:    return %0 : i1
+func @icmp_canonicalize_ne(%arg0: i2) -> (i1) {
+  %c-2_i2 = rtl.constant(-2 : i2) : i2
+  %0 = rtl.icmp slt %c-2_i2, %arg0 : i2
+  return %0 : i1
+}
+
+// CHECK-LABEL: func @icmp_canonicalize_eq(%arg0: i2) -> i1 {
+// CHECK-NEXT:    %c-2_i2 = rtl.constant(-2 : i2) : i2
+// CHECK-NEXT:    %0 = rtl.icmp eq %arg0, %c-2_i2 : i2
+// CHECK-NEXT:    return %0 : i1
+func @icmp_canonicalize_eq(%arg0: i2) -> (i1) {
+  %c-1_i2 = rtl.constant(-1 : i2) : i2
+  %0 = rtl.icmp slt %arg0, %c-1_i2: i2
+  return %0 : i1
+}
+
+// CHECK-LABEL: func @icmp_canonicalize_sgt(%arg0: i2) -> i1 {
+// CHECK-NEXT:    %c-1_i2 = rtl.constant(-1 : i2) : i2
+// CHECK-NEXT:    %0 = rtl.icmp sgt %arg0, %c-1_i2 : i2
+// CHECK-NEXT:    return %0 : i1
+func @icmp_canonicalize_sgt(%arg0: i2) -> (i1) {
+  %c0_i2 = rtl.constant(0 : i2) : i2
+  %0 = rtl.icmp sle %c0_i2, %arg0 : i2
+  return %0 : i1
+}


### PR DESCRIPTION
For https://github.com/llvm/circt/issues/402

With these changes we are getting closer to reasonable output, but still not there.  We are still not able to optimize out unneeded wires.

```verilog
// before:
module top_mod(
  output tmp28);

  wire tmp11;

  assign tmp11 = 1'h1;
  assign tmp28 = tmp11 < 1'h1; // < changed
endmodule

// after:
module top_mod1(
  output tmp28);

  wire tmp11;

  assign tmp11 = 1'h1;
  assign tmp28 = tmp11 == 1'h0; // < changed
endmodule
```

```verilog
// before
module top_mod(
  input  [10:0] inp_0,
  output        tmp12, tmp2);

  wire        _T;
  wire [27:0] tmp6;

  assign _T = $signed(13'h0) >= $signed({{2{inp_0[10]}}, inp_0});
  assign tmp6 = {{27'd0}, _T} * 28'h1;
  assign tmp12 = 28'h0 > tmp6;  // < changed
  assign tmp2 = _T;
endmodule

// after
module top_mod(
  input  [10:0] inp_0,
  output        tmp12, tmp2);

  wire        _T;
  wire [27:0] tmp6;

  assign _T = $signed({{2{inp_0[10]}}, inp_0}) < 13'sh1;
  wire _T_0 = _T;
  assign tmp6 = {27'h0, _T_0} << 28'h0;
  assign tmp12 = 1'h0; // < changed
  assign tmp2 = _T_0;
endmodule
```
