### PR TITLE
[nfc] tblegen-generate dialect docs instead of op docs + add Passes.md

### DIFF
--- a/docs/Passes.md
+++ b/docs/Passes.md
@@ -1,0 +1,23 @@
+# Passes
+
+This document describes the available CIRCT passes and their contracts.
+
+[TOC]
+
+## Transformations Passes
+
+[include "Passes/Transformations.md"]
+
+## Conversion Passes
+
+[include "Passes/FIRRTLToLLHD.md"]
+
+[include "Passes/RTLToLLHD.md"]
+
+[include "Passes/LLHDToLLVM.md"]
+
+[include "CIRCTConversionPasses.md"]
+
+## `firrtl` Dialect Passes
+
+[include "FIRRTLPasses.md"]

--- a/include/circt/Dialect/ESI/CMakeLists.txt
+++ b/include/circt/Dialect/ESI/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_circt_dialect(ESI esi)
-add_circt_doc(ESI -gen-op-doc esi Dialects/)
+add_circt_doc(ESI -gen-dialect-doc ESI Dialects/)
 
 set(LLVM_TARGET_DEFINITIONS ESI.td)
 mlir_tablegen(ESIAttrs.h.inc -gen-struct-attr-decls)

--- a/include/circt/Dialect/FIRRTL/CMakeLists.txt
+++ b/include/circt/Dialect/FIRRTL/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_circt_dialect(FIRRTL firrtl FIRRTL)
-add_circt_doc(FIRRTL -gen-op-doc firrtl Dialects/)
+add_circt_doc(FIRRTL -gen-dialect-doc FIRRTL Dialects/)
 
 set(LLVM_TARGET_DEFINITIONS FIRRTL.td)
 mlir_tablegen(FIRRTLEnums.h.inc -gen-enum-decls)

--- a/include/circt/Dialect/LLHD/IR/CMakeLists.txt
+++ b/include/circt/Dialect/LLHD/IR/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_circt_dialect(LLHD llhd)
-add_circt_doc(LLHD -gen-op-doc llhd Dialects/)
+add_circt_doc(LLHD -gen-dialect-doc LLHD Dialects/)
 
 set(LLVM_TARGET_DEFINITIONS LLHD.td)
 mlir_tablegen(LLHDEnums.h.inc -gen-enum-decls)

--- a/include/circt/Dialect/RTL/CMakeLists.txt
+++ b/include/circt/Dialect/RTL/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_circt_dialect(RTL rtl)
-add_circt_doc(RTL -gen-op-doc rtl Dialects/)
+add_circt_doc(RTL -gen-dialect-doc RTL Dialects/)
 
 set(LLVM_TARGET_DEFINITIONS RTL.td)
 mlir_tablegen(RTLEnums.h.inc -gen-enum-decls)

--- a/include/circt/Dialect/SV/CMakeLists.txt
+++ b/include/circt/Dialect/SV/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_circt_dialect(SV sv)
-add_circt_doc(SV -gen-op-doc sv Dialects/)
+add_circt_doc(SV -gen-dialect-doc SV Dialects/)
 
 set(LLVM_TARGET_DEFINITIONS SV.td)
 

--- a/include/circt/Dialect/StaticLogic/CMakeLists.txt
+++ b/include/circt/Dialect/StaticLogic/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_circt_dialect(StaticLogic staticlogic)
-add_circt_doc(StaticLogic -gen-op-doc staticlogic Dialects/)
+add_circt_doc(StaticLogic -gen-dialect-doc StaticLogic Dialects/)
 
 set(LLVM_TARGET_DEFINITIONS StaticLogic.td)


### PR DESCRIPTION
Passes.md file collect autogenerated passes doc from source code. In the second change, op is replaced to dialect for tblegen command. 
