### PR TITLE
[ESI] [esi-cosim-runner] Convert to polling

### DIFF
--- a/integration_test/ESI/cosim/loopback/loopback.sv
+++ b/integration_test/ESI/cosim/loopback/loopback.sv
@@ -9,19 +9,13 @@
 import Cosim_DpiPkg::*;
 
 module top(
-    `ifdef VERILATOR
     input logic clk,
     input logic rstn
-    `endif
 );
     localparam int TYPE_SIZE_BITS =
         (1 * 64) + // root message
         (1 * 64) + // list header
         (1 * 64);  // list of length 3 bytes, rounded up to multiples of 8 bytes
-    `ifndef VERILATOR
-    logic clk;
-    logic rstn;
-    `endif
 
     wire DataOutValid;
     wire DataOutReady = 1;
@@ -62,26 +56,4 @@ module top(
             DataInValid <= 0;
         end
     end
-
-`ifndef VERILATOR
-    // Clock
-    initial
-    begin
-        clk = 1'b0;
-        while (1)
-        begin
-            #5;
-            clk = !clk;
-        end
-    end
-
-    initial
-    begin
-        rstn = 0;
-        #17
-        // Run!
-        rstn = 1;
-    end
-`endif
-
 endmodule

--- a/tools/esi/esi-cosim-runner.py.in
+++ b/tools/esi/esi-cosim-runner.py.in
@@ -152,10 +152,18 @@ class CosimTestRunner:
                 stdout=simStdout, stderr=simStderr, env=simEnv, preexec_fn=os.setsid)
             simStderr.close()
             simStdout.close()
-            # Wait a set amount of time for the simulation to start accepting
-            # RPC connections.
-            # TODO: Check if the server is up by polling.
-            time.sleep(0.25)
+
+            # Wait for the simulation to start accepting RPC connections.
+            checkCount = 0
+            while not isPortOpen(port):
+              checkCount += 1
+              if checkCount > 200:
+                print("Cosim RPC port never opened")
+                return 1
+              if simProc.poll() != None:
+                print("Simulation exited early")
+                return 1
+              time.sleep(0.05)
 
             # Run the test script.
             testStdout = open("test_stdout.log", "w")
@@ -215,6 +223,11 @@ class CosimTestRunner:
       return (foundErr, ret)
 
 
+def isPortOpen(port):
+  sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+  result = sock.connect_ex(('127.0.0.1', port))
+  sock.close()
+  return True if result == 0 else False
 
 def __main__(args):
     argparser = argparse.ArgumentParser(


### PR DESCRIPTION
Poll for the RPC port open rather than just waiting a fixed amount of
time. Enables using Questa for loopback test (since vsim takes longer
to load).

Make the loopback test compatible with driver.sv for Questa.