### PR TITLE
[CAPI] Remove unnecessary linkages from test

### DIFF
--- a/test/CAPI/CMakeLists.txt
+++ b/test/CAPI/CMakeLists.txt
@@ -1,8 +1,3 @@
-set(LLVM_LINK_COMPONENTS
-  Core
-  Support
-  )
-
 add_llvm_executable(circt-capi-ir-test
   ir.c
   )
@@ -14,7 +9,5 @@ target_link_libraries(circt-capi-ir-test
   CIRCTCAPIRTL
   ${dialect_libs}
 
-  MLIRCAPIIR
   MLIRCAPIRegistration
-  MLIRPublicAPI
   )


### PR DESCRIPTION
Trying to fix:
    https://github.com/llvm/circt/commit/18b04b2780b86982fa843466b6aa7a7d7b07189c#commitcomment-45910587

I don't really understand how the C API works, but the test links and passes without linking in these libraries.