### PR TITLE
[rtl] Add basic dead wire elimination

### DIFF
--- a/include/circt/Dialect/RTL/RTLStatements.td
+++ b/include/circt/Dialect/RTL/RTLStatements.td
@@ -21,7 +21,7 @@ def ConnectOp : RTLOp<"connect", [InOutTypeConstraint<"src", "dest">]> {
 
   let arguments = (ins InOutType:$dest, RTLValueType:$src);
   let results = (outs);
-    let assemblyFormat = "$dest `,` $src  attr-dict `:` type($src)";
+  let assemblyFormat = "$dest `,` $src  attr-dict `:` type($src)";
 }
 
 def WireOp : RTLOp<"wire", [DeclareOpInterfaceMethods<OpAsmOpInterface>]> {
@@ -49,6 +49,7 @@ def WireOp : RTLOp<"wire", [DeclareOpInterfaceMethods<OpAsmOpInterface>]> {
   // We handle the name in a custom way, so we use a customer parser/printer.
   let printer = "printWireOp(p, *this);";
   let parser = "return parseWireOp(parser, result);";
+  let hasCanonicalizer = true;
 }
 
 // Expressions used for working with inout types.

--- a/test/Dialect/RTL/canonicalization.mlir
+++ b/test/Dialect/RTL/canonicalization.mlir
@@ -588,3 +588,51 @@ func @concat_fold6(%arg0: i5, %arg1: i3) -> (i4) {
   %2 = rtl.concat %0, %1 : (i2, i2) -> i4
   return %2 : i4
 }
+
+// CHECK-LABEL: func @wire0()
+// CHECK-NEXT:    return
+func @wire0() {
+  %w = rtl.wire : !rtl.inout<i1>
+  return
+}
+
+// CHECK-LABEL: func @wire1()
+// CHECK-NEXT:    return
+func @wire1() {
+  %w = rtl.wire : !rtl.inout<i1>
+  %0 = rtl.read_inout %w : !rtl.inout<i1>
+  return
+}
+
+// CHECK-LABEL: func @wire2()
+// CHECK-NEXT:    return
+func @wire2() {
+  %c = rtl.constant(1 : i1) : i1
+  %w = rtl.wire : !rtl.inout<i1>
+  rtl.connect %w, %c : i1
+  return
+}
+
+// CHECK-LABEL: func @wire3()
+// CHECK-NEXT:    return
+func @wire3() {
+  %c = rtl.constant(1 : i1) : i1
+  %w = rtl.wire : !rtl.inout<i1>
+  %0 = rtl.read_inout %w : !rtl.inout<i1>
+  rtl.connect %w, %c :i1
+  return
+}
+
+// CHECK-LABEL: func @wire4() -> i1
+// CHECK-NEXT:    %true = rtl.constant(true) : i1
+// CHECK-NEXT:    %w = rtl.wire : !rtl.inout<i1>
+// CHECK-NEXT:    %0 = rtl.read_inout %w : !rtl.inout<i1>
+// CHECK-NEXT:    rtl.connect %w, %true : i1
+// CHECK-NEXT:    return %0
+func @wire4() -> i1 {
+  %true = rtl.constant(true) : i1
+  %w = rtl.wire : !rtl.inout<i1>
+  %0 = rtl.read_inout %w : !rtl.inout<i1>
+  rtl.connect %w, %true : i1
+  return %0 : i1
+}


### PR DESCRIPTION
A wire is considered dead when its value is never used.  This approach
to eliminating wires relies on canonicalization.

1. If a value is read from a wire and never used, the read is removed.
2. If a value is never read from a wire, the wire and all connects are
   removed.
   

### Old commit message:


A wire is considered dead when its value is never used.  This approach
to eliminating wires relies on canonicalization.

1. If a value is read from a wire and never used, the read is removed.
2. If a value is never read from a wire, the wire and all connects are
   removed.

This relies on the `MemoryEffects` operation interface to eliminate dead
operations.  Using this interface, unused reads and unused wires are
removed. The MemoryEffect interface does not eliminate any dead stores
to wires, and a separate canonicalization pattern was added To handle
this case.

cc @darthscsi @seldridge @lattner