### PR TITLE
[CAPI] Fix the windows build which #453 broke

### DIFF
--- a/test/CAPI/CMakeLists.txt
+++ b/test/CAPI/CMakeLists.txt
@@ -10,4 +10,5 @@ target_link_libraries(circt-capi-ir-test
   ${dialect_libs}
 
   MLIRCAPIRegistration
+  MLIRPublicAPI
   )


### PR DESCRIPTION
#453 broke the Windows build!

@lattner Does this addition break your tests?