### PR TITLE
[ESI] [Cosim] Include the standard RPC interface in generated schemas

### DIFF
--- a/include/circt/Dialect/ESI/cosim/CMakeLists.txt
+++ b/include/circt/Dialect/ESI/cosim/CMakeLists.txt
@@ -7,8 +7,16 @@
 if(CapnProto_FOUND)
   option(ESI_COSIM "Enable ESI Cosimulation" ON)
   message("-- Enabling ESI cosim")
+
+  file(READ CosimDpi.capnp EsiCosimSchema)
+  configure_file(CosimSchema.h.in
+    ${CIRCT_BINARY_DIR}/include/circt/Dialect/ESI/CosimSchema.h)
+
   add_definitions(${CAPNP_DEFINITIONS})
   capnp_generate_cpp(COSIM_CAPNP_SRCS COSIM_CANPN_HDRS CosimDpi.capnp)
-  add_library(EsiCosimCapnp ${COSIM_CAPNP_HDRS} ${COSIM_CAPNP_SRCS})
+  add_library(EsiCosimCapnp
+    ${COSIM_CAPNP_HDRS}
+    ${COSIM_CAPNP_SRCS}
+    CosimSchema.h)
   target_link_libraries(EsiCosimCapnp PRIVATE CapnProto::capnp)
 endif()

--- a/include/circt/Dialect/ESI/cosim/CosimSchema.h.in
+++ b/include/circt/Dialect/ESI/cosim/CosimSchema.h.in
@@ -1,0 +1,28 @@
+//===- CosimSchema.h.in - template for the ESI cosim schema  ----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// CMake configures this file to fill the Cosim Capnp RPC schema.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_ESI_COSIM_COSIMSCHEMA_H
+#define CIRCT_DIALECT_ESI_COSIM_COSIMSCHEMA_H
+
+namespace circt {
+namespace esi {
+namespace cosim {
+
+constexpr char CosimSchema[] = R"""(
+@EsiCosimSchema@
+)""";
+
+} // namespace cosim
+} // namespace esi
+} // namespace circt
+
+#endif

--- a/lib/Dialect/ESI/ESITranslations.cpp
+++ b/lib/Dialect/ESI/ESITranslations.cpp
@@ -4,8 +4,6 @@
 // - Cap'nProto schema generation
 //
 //===----------------------------------------------------------------------===//
-
-#include "circt/Dialect/ESI/CosimSchema.h"
 #include "circt/Dialect/ESI/ESIDialect.h"
 #include "circt/Dialect/ESI/ESIOps.h"
 
@@ -21,6 +19,7 @@
 
 #ifdef CAPNP
 #include "capnp/ESICapnp.h"
+#include "circt/Dialect/ESI/CosimSchema.h"
 #endif
 
 using namespace mlir;

--- a/test/Dialect/ESI/cosim.mlir
+++ b/test/Dialect/ESI/cosim.mlir
@@ -26,6 +26,10 @@ module {
     // CAPNP:         i @0 :UInt32;
     // CAPNP-LABEL: struct TYsi14 @0x8ee0bd493e80e8a1
     // CAPNP:         i @0 :Int16;
+    // Ensure the standard RPC interface is tacked on.
+    // CAPNP: interface CosimDpiServer
+    // CAPNP: list @0 () -> (ifaces :List(EsiDpiInterfaceDesc));
+    // CAPNP: open @1 [S, T] (iface :EsiDpiInterfaceDesc) -> (iface :EsiDpiEndpoint(S, T));
 
     // COSIM: %rawOutput, %valid = esi.unwrap.vr %send.x, %TestEP.DataInReady : si14
     // COSIM: %0 = esi.encode.capnp %rawOutput : si14 -> !rtl.array<192xi1>


### PR DESCRIPTION
Make running cosim easier by creating an all-inclusive Capnp schema.

- CMake creates a header via `configure_file` with the contents of `CosimDpi.capnp` in a string.
- `emitCosimSchemaBody` prints only the part we want.
