### PR TITLE
[SV] [Interfaces] Allow RTL types on signals

### DIFF
--- a/include/circt/Dialect/SV/SVTypeDecl.td
+++ b/include/circt/Dialect/SV/SVTypeDecl.td
@@ -57,8 +57,13 @@ def InterfaceOp : SVOp<"interface",
   }];
 }
 
-// For now, IntegerType is a placeholder for future SV dialect types
-def SignalTypeAttr : TypeAttrBase<"IntegerType", "Integer type attribute">;
+def SignalTypeAttr : TypeAttrBase<"::mlir::Type", "Any SV/RTL type"> {
+  let predicate = And<[
+      CPred<"$_self.isa<::mlir::TypeAttr>()">,
+      CPred<"::circt::rtl::getBitWidth(" #
+              "$_self.cast<::mlir::TypeAttr>().getValue()) != -1">
+  ]>;
+}
 
 def InterfaceSignalOp : SVOp<"interface.signal",
     [Symbol, HasParent<"InterfaceOp">]> {

--- a/test/ExportVerilog/sv-interfaces.mlir
+++ b/test/ExportVerilog/sv-interfaces.mlir
@@ -13,6 +13,7 @@ module {
     sv.interface.signal @data : i32
     sv.interface.signal @valid : i1
     sv.interface.signal @ready : i1
+    sv.interface.signal @arrayData : !rtl.array<8xi8>
     sv.interface.modport @data_in ("input" @data, "input" @valid, "output" @ready)
     sv.interface.modport @data_out ("output" @data, "output" @valid, "input" @ready)
   }


### PR DESCRIPTION
"RTL" types are defined by the RTL dialect being able to calculate their bitwidth.