### PR TITLE
[ESI] [Capnp schemas] Change naming scheme, adding array support

### DIFF
--- a/integration_test/ESI/cosim/basic.py
+++ b/integration_test/ESI/cosim/basic.py
@@ -8,14 +8,14 @@ class BasicSystemTester(cosim.CosimBase):
     """Provides methods to test the 'basic' simulation."""
 
     def testIntAcc(self, num_msgs):
-        ep = self.openEP(sendType=self.schema.TYi32,
-                         recvType=self.schema.TYi32)
+        ep = self.openEP(sendType=self.schema.I32,
+                         recvType=self.schema.I32)
         sum = 0
         for _ in range(num_msgs):
             i = random.randint(0, 77)
             sum += i
             print(f"Sending {i}")
-            ep.send(self.schema.TYi32.new_message(i=i))
-            result = self.readMsg(ep, self.schema.TYi32)
+            ep.send(self.schema.I32.new_message(i=i))
+            result = self.readMsg(ep, self.schema.I32)
             print(f"Got {result}")
             assert (result.i == sum)

--- a/integration_test/ESI/cosim/loopback.py
+++ b/integration_test/ESI/cosim/loopback.py
@@ -20,13 +20,13 @@ class LoopbackTester(cosim.CosimBase):
         ep.close().wait()
 
     def test_i32(self, num_msgs):
-        ep = self.openEP(sendType=self.schema.TYi32,
-                         recvType=self.schema.TYi32)
+        ep = self.openEP(sendType=self.schema.I32,
+                         recvType=self.schema.I32)
         for _ in range(num_msgs):
             data = random.randint(0, 2**32)
             print(f"Sending {data}")
-            ep.send(self.schema.TYi32.new_message(i=data))
-            result = self.readMsg(ep, self.schema.TYi32)
+            ep.send(self.schema.I32.new_message(i=data))
+            result = self.readMsg(ep, self.schema.I32)
             print(f"Got {result}")
             assert (result.i == data)
 

--- a/lib/Dialect/ESI/capnp/Schema.cpp
+++ b/lib/Dialect/ESI/capnp/Schema.cpp
@@ -180,11 +180,16 @@ uint64_t TypeSchemaImpl::capnpTypeID() const {
 }
 
 /// Returns true if the type is currently supported.
-bool TypeSchemaImpl::isSupported() const {
+static bool isSupported(Type type) {
   return llvm::TypeSwitch<::mlir::Type, bool>(type)
       .Case<IntegerType>([](IntegerType t) { return t.getWidth() <= 64; })
+      .Case<rtl::ArrayType>(
+          [](rtl::ArrayType t) { return isSupported(t.getElementType()); })
       .Default([](Type) { return false; });
 }
+
+/// Returns true if the type is currently supported.
+bool TypeSchemaImpl::isSupported() const { return ::isSupported(type); }
 
 // Compute the expected size of the capnp message in bits.
 size_t TypeSchemaImpl::size() const {
@@ -195,15 +200,73 @@ size_t TypeSchemaImpl::size() const {
           structProto.getDataWordCount() + structProto.getPointerCount());
 }
 
+/// Write a valid Capnp name for 'type'.
+static void emitName(Type type, llvm::raw_ostream &os) {
+  llvm::TypeSwitch<Type>(type)
+      .Case([&os](IntegerType intTy) {
+        std::string intName;
+        llvm::raw_string_ostream(intName) << intTy;
+        // Capnp struct names must start with an uppercase character.
+        intName[0] = toupper(intName[0]);
+        os << intName;
+      })
+      .Case([&os](rtl::ArrayType arrTy) {
+        os << "ArrayOf";
+        emitName(arrTy.getElementType(), os);
+      })
+      .Default([](Type) {
+        assert(false && "Type not supported. Please check support first with "
+                        "isSupported()");
+      });
+}
+
 /// For now, the name is just the type serialized. This works only because we
 /// only support ints.
 StringRef TypeSchemaImpl::name() const {
   if (cachedName == "") {
     llvm::raw_string_ostream os(cachedName);
-    os << "TY" << type;
+    emitName(type, os);
     cachedName = os.str();
   }
   return cachedName;
+}
+
+/// Write a valid Capnp type.
+static void emitCapnpType(Type type, IndentingOStream &os) {
+  llvm::TypeSwitch<Type>(type)
+      .Case([&os](IntegerType intTy) {
+        auto w = intTy.getWidth();
+        if (w == 1) {
+          os.indent() << "Bool";
+        } else {
+          if (intTy.isSigned())
+            os << "Int";
+          else
+            os << "UInt";
+
+          // Round up.
+          if (w <= 8)
+            os << "8";
+          else if (w <= 16)
+            os << "16";
+          else if (w <= 32)
+            os << "32";
+          else if (w <= 64)
+            os << "64";
+          else
+            assert(false && "Type not supported. Integer too wide. Please "
+                            "check support first with isSupported()");
+        }
+      })
+      .Case([&os](rtl::ArrayType arrTy) {
+        os << "List(";
+        emitCapnpType(arrTy.getElementType(), os);
+        os << ')';
+      })
+      .Default([](Type) {
+        assert(false && "Type not supported. Please check support first with "
+                        "isSupported()");
+      });
 }
 
 /// This function is essentially a placeholder which only supports ints. It'll
@@ -218,36 +281,10 @@ LogicalResult TypeSchemaImpl::write(llvm::raw_ostream &rawOS) const {
   os << " {\n";
   os.addIndent();
 
-  auto intTy = type.dyn_cast<IntegerType>();
-  assert(intTy &&
-         "Type not supported. Please check support first with isSupported()");
-
   // Specify the actual type, followed by the capnp field.
   os.indent() << "# Actual type is " << type << ".\n";
   os.indent() << "i @0 :";
-
-  auto w = intTy.getWidth();
-  if (w == 1) {
-    os.indent() << "Bool";
-  } else {
-    if (intTy.isSigned())
-      os << "Int";
-    else
-      os << "UInt";
-
-    // Round up.
-    if (w <= 8)
-      os << "8";
-    else if (w <= 16)
-      os << "16";
-    else if (w <= 32)
-      os << "32";
-    else if (w <= 64)
-      os << "64";
-    else
-      assert(false && "Type not supported. Please check support first with "
-                      "isSupported()");
-  }
+  emitCapnpType(type, os);
   os << ";\n";
 
   os.reduceIndent();

--- a/test/Dialect/ESI/cosim.mlir
+++ b/test/Dialect/ESI/cosim.mlir
@@ -22,9 +22,9 @@ rtl.module @top(%clk:i1, %rstn:i1) -> () {
 
   // Ensure that the file hash is deterministic.
   // CAPNP: 0xc6085f4b7a4688f8;
-  // CAPNP-LABEL: struct TYsi14 @0x9bd5e507cce05cc1
+  // CAPNP-LABEL: struct Si14 @0x9bd5e507cce05cc1
   // CAPNP:         i @0 :Int16;
-  // CAPNP-LABEL: struct TYi32 @0x92cd59dfefaacbdb
+  // CAPNP-LABEL: struct I32 @0x92cd59dfefaacbdb
   // CAPNP:         i @0 :UInt32;
   // Ensure the standard RPC interface is tacked on.
   // CAPNP: interface CosimDpiServer


### PR DESCRIPTION
No tests for arrays since adding arrays to the existing tests breaks the RTL lowering passes. Tests for arrays will be part of the RTL lowering array support PR.