### PR TITLE
[ExportVerilog][SV] C API

### DIFF
--- a/include/circt-c/ExportVerilog.h
+++ b/include/circt-c/ExportVerilog.h
@@ -1,0 +1,26 @@
+//===-- circt-c/SVDialect.h - C API for emitting Verilog ----------*- C -*-===//
+//
+// This header declares the C interface for emitting Verilog from a CIRCT MLIR
+// module.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_C_EXPORTVERILOG_H
+#define CIRCT_C_EXPORTVERILOG_H
+
+#include "mlir-c/IR.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Emits verilog for the specified module using the provided callback and user
+/// data
+MlirLogicalResult mlirExportVerilog(MlirModule, MlirStringCallback,
+                                    void *userData);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CIRCT_C_EXPORTVERILOG_H

--- a/include/circt-c/SVDialect.h
+++ b/include/circt-c/SVDialect.h
@@ -1,0 +1,35 @@
+//===-- circt-c/SVDialect.h - C API for SV dialect ----------------*- C -*-===//
+//
+// This header declares the C interface for registering and accessing the
+// SV dialect. A dialect should be registered with a context to make it
+// available to users of the context. These users must load the dialect
+// before using any of its attributes, operations or types. Parser and pass
+// manager can load registered dialects automatically.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_C_SVDIALECT_H
+#define CIRCT_C_SVDIALECT_H
+
+#include "mlir-c/IR.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Registers the SV dialect with the given context. This allows the dialect to
+/// be loaded dynamically if needed when parsing.
+void mlirContextRegisterSVDialect(MlirContext context);
+
+/// Loads the SV dialect into the given context. The dialect does _not_ have to
+/// be registered in advance.
+MlirDialect mlirContextLoadSVDialect(MlirContext context);
+
+/// Returns the namespace of the SV dialect, suitable for loading it.
+MlirStringRef mlirSVDialectGetNamespace();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CIRCT_C_SVDIALECT_H

--- a/lib/CAPI/CMakeLists.txt
+++ b/lib/CAPI/CMakeLists.txt
@@ -1,1 +1,3 @@
+add_subdirectory(ExportVerilog)
 add_subdirectory(RTL)
+add_subdirectory(SV)

--- a/lib/CAPI/ExportVerilog/CMakeLists.txt
+++ b/lib/CAPI/ExportVerilog/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_circt_library(CIRCTCAPIExportVerilog
+
+  ExportVerilog.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${MLIR_MAIN_INCLUDE_DIR}/mlir-c
+
+  LINK_LIBS PUBLIC
+  MLIRCAPIIR
+  CIRCTExportVerilog
+  )

--- a/lib/CAPI/ExportVerilog/ExportVerilog.cpp
+++ b/lib/CAPI/ExportVerilog/ExportVerilog.cpp
@@ -1,0 +1,23 @@
+//===- RTLDialect.cpp - C Interface EmitVerilog ---------------------------===//
+//
+//  Implements a C Interface for emitVerilog
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt-c/ExportVerilog.h"
+
+#include "circt/Translation/ExportVerilog.h"
+#include "mlir/CAPI/IR.h"
+#include "mlir/CAPI/Support.h"
+#include "mlir/CAPI/Utils.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace mlir;
+using namespace circt;
+
+MlirLogicalResult mlirExportVerilog(MlirModule module,
+                                    MlirStringCallback callback,
+                                    void *userData) {
+  detail::CallbackOstream stream(callback, userData);
+  return wrap(exportVerilog(unwrap(module), stream));
+}

--- a/lib/CAPI/SV/CMakeLists.txt
+++ b/lib/CAPI/SV/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_circt_library(CIRCTCAPISV
+
+  SVDialect.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${MLIR_MAIN_INCLUDE_DIR}/mlir-c
+
+  LINK_LIBS PUBLIC
+  MLIRCAPIIR
+  CIRCTSV
+  )

--- a/lib/CAPI/SV/SVDialect.cpp
+++ b/lib/CAPI/SV/SVDialect.cpp
@@ -1,0 +1,23 @@
+//===- SVDialect.cpp - C Interface for the SV Dialect -------------------===//
+//
+//  Implements a C Interface for the SV Dialect
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt-c/SVDialect.h"
+#include "circt/Dialect/SV/SVDialect.h"
+#include "mlir-c/IR.h"
+#include "mlir/CAPI/IR.h"
+#include "mlir/CAPI/Support.h"
+
+void mlirContextRegisterSVDialect(MlirContext context) {
+  unwrap(context)->getDialectRegistry().insert<circt::sv::SVDialect>();
+}
+
+MlirDialect mlirContextLoadSVDialect(MlirContext context) {
+  return wrap(unwrap(context)->getOrLoadDialect<circt::sv::SVDialect>());
+}
+
+MlirStringRef mlirSVDialectGetNamespace() {
+  return wrap(circt::sv::SVDialect::getDialectNamespace());
+}

--- a/test/CAPI/CMakeLists.txt
+++ b/test/CAPI/CMakeLists.txt
@@ -11,4 +11,6 @@ target_link_libraries(circt-capi-ir-test
 
   MLIRCAPIRegistration
   MLIRPublicAPI
+  CIRCTCAPISV
+  CIRCTCAPIExportVerilog
   )


### PR DESCRIPTION
This add simple pass-through C API for ExportVerilog and the SV dialect.