### PR TITLE
[ExportVerilog] Add RTL instance name auto-generation.

### DIFF
--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -334,6 +334,7 @@ public:
     return addName(valueOrOp, nameAttr ? nameAttr.getValue() : "");
   }
 
+  StringRef getName(Value value) { return getName(ValueOrOp(value)); }
   StringRef getName(ValueOrOp valueOrOp) {
     auto *entry = nameTable[valueOrOp];
     assert(entry && "value expected a name but doesn't have one");
@@ -1078,7 +1079,7 @@ void ModuleEmitter::visitMerge(MergeOp op) {
   //   assign a = z;
   for (auto operand : op.getOperands()) {
     ops.insert(op);
-    indent() << "assign " << getName(ValueOrOp(op)) << " = ";
+    indent() << "assign " << getName(op) << " = ";
     emitExpression(operand, ops);
     os << ';';
     emitLocationInfoAndNewLine(ops);

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -326,14 +326,16 @@ public:
   LogicalResult visitSV(AssignInterfaceSignalOp op);
   void emitOperation(Operation *op);
 
+  using ValueOrOp = PointerUnion<Value, Operation *>;
+
   void collectNamesEmitDecls(Block &block);
-  StringRef addName(Value value, StringRef name);
-  StringRef addName(Value value, StringAttr nameAttr) {
-    return addName(value, nameAttr ? nameAttr.getValue() : "");
+  StringRef addName(ValueOrOp valueOrOp, StringRef name);
+  StringRef addName(ValueOrOp valueOrOp, StringAttr nameAttr) {
+    return addName(valueOrOp, nameAttr ? nameAttr.getValue() : "");
   }
 
-  StringRef getName(Value value) {
-    auto *entry = nameTable[value];
+  StringRef getName(ValueOrOp valueOrOp) {
+    auto *entry = nameTable[valueOrOp];
     assert(entry && "value expected a name but doesn't have one");
     return entry->getKey();
   }
@@ -347,7 +349,7 @@ public:
   void emitLocationInfoAndNewLine(const SmallPtrSet<Operation *, 8> &ops);
 
   llvm::StringSet<> usedNames;
-  llvm::DenseMap<Value, llvm::StringMapEntry<llvm::NoneType> *> nameTable;
+  llvm::DenseMap<ValueOrOp, llvm::StringMapEntry<llvm::NoneType> *> nameTable;
   size_t nextGeneratedNameID = 0;
 
   /// This set keeps track of all of the expression nodes that need to be
@@ -360,7 +362,7 @@ public:
 
 /// Add the specified name to the name table, auto-uniquing the name if
 /// required.  If the name is empty, then this creates a unique temp name.
-StringRef ModuleEmitter::addName(Value value, StringRef name) {
+StringRef ModuleEmitter::addName(ValueOrOp valueOrOp, StringRef name) {
   if (name.empty())
     name = "_T";
 
@@ -369,7 +371,7 @@ StringRef ModuleEmitter::addName(Value value, StringRef name) {
   if (!isalpha(name.front()) && name.front() != '_') {
     SmallString<16> tmpName("_");
     tmpName += name;
-    return addName(value, tmpName);
+    return addName(valueOrOp, tmpName);
   }
 
   auto isValidVerilogCharacter = [](char ch) -> bool {
@@ -393,7 +395,7 @@ StringRef ModuleEmitter::addName(Value value, StringRef name) {
         tmpName += llvm::utohexstr((unsigned char)ch);
       }
     }
-    return addName(value, tmpName);
+    return addName(valueOrOp, tmpName);
   }
 
   // Get the list of reserved words we need to avoid.  We could prepopulate this
@@ -405,7 +407,7 @@ StringRef ModuleEmitter::addName(Value value, StringRef name) {
   if (!reservedWords.count(name)) {
     auto insertResult = usedNames.insert(name);
     if (insertResult.second) {
-      nameTable[value] = &*insertResult.first;
+      nameTable[valueOrOp] = &*insertResult.first;
       return insertResult.first->getKey();
     }
   }
@@ -424,7 +426,7 @@ StringRef ModuleEmitter::addName(Value value, StringRef name) {
     if (!reservedWords.count(name)) {
       auto insertResult = usedNames.insert(name);
       if (insertResult.second) {
-        nameTable[value] = &*insertResult.first;
+        nameTable[valueOrOp] = &*insertResult.first;
         return insertResult.first->getKey();
       }
     }
@@ -1076,7 +1078,7 @@ void ModuleEmitter::visitMerge(MergeOp op) {
   //   assign a = z;
   for (auto operand : op.getOperands()) {
     ops.insert(op);
-    indent() << "assign " << getName(op) << " = ";
+    indent() << "assign " << getName(ValueOrOp(op)) << " = ";
     emitExpression(operand, ops);
     os << ';';
     emitLocationInfoAndNewLine(ops);
@@ -1503,7 +1505,7 @@ LogicalResult ModuleEmitter::visitStmt(InstanceOp op) {
     }
   }
 
-  os << ' ' << op.instanceName() << " (";
+  os << ' ' << getName(ValueOrOp(op)) << " (";
 
   SmallVector<ModulePortInfo, 8> portInfo;
   getModulePortInfo(moduleOp, portInfo);
@@ -1746,6 +1748,11 @@ void ModuleEmitter::collectNamesEmitDecls(Block &block) {
   for (auto &op : block) {
     bool isExpr = isVerilogExpression(&op);
 
+    // If the op is an instance, add its name to the name table.
+    auto instance = dyn_cast<InstanceOp>(&op);
+    if (instance)
+      addName(ValueOrOp(instance), instance.instanceName());
+
     for (auto result : op.getResults()) {
       // If this is an expression emitted inline or unused, it doesn't need a
       // name.
@@ -1759,10 +1766,10 @@ void ModuleEmitter::collectNamesEmitDecls(Block &block) {
       }
 
       // Otherwise, it must be an expression or a declaration like a
-      // RegOp/WireOp.  Remember and unique the name for this operation.
-      if (auto instance = dyn_cast<InstanceOp>(&op)) {
+      // RegOp/WireOp.  Remember and unique the name for this result.
+      if (instance) {
         // The name for an instance result is custom.
-        nameTmp = instance.instanceName().str() + "_";
+        nameTmp = getName(ValueOrOp(instance)).str() + "_";
         unsigned resultNumber = result.getResultNumber();
         auto resultName = instance.getResultName(resultNumber);
         if (resultName)

--- a/test/ExportVerilog/rtl-dialect.mlir
+++ b/test/ExportVerilog/rtl-dialect.mlir
@@ -423,4 +423,31 @@ module {
     // CHECK: // Zero width: assign arrZero = iii_arrZero;
     rtl.output %o1, %o2, %o3 : i4, i0, !rtl.array<3xi0>
   }
+
+  // CHECK-LABEL: TestDupInstanceName
+  rtl.module @TestDupInstanceName(%a: i1) {
+    // CHECK: B name (
+    %w1, %y1 = rtl.instance "name" @B(%a) : (i1) -> (i1, i1)
+
+    // CHECK: B name_0 (
+    %w2, %y2 = rtl.instance "name" @B(%a) : (i1) -> (i1, i1)
+  }
+
+  // CHECK-LABEL: TestEmptyInstanceName
+  rtl.module @TestEmptyInstanceName(%a: i1) {
+    // CHECK: B _T (
+    %w1, %y1 = rtl.instance "" @B(%a) : (i1) -> (i1, i1)
+
+    // CHECK: B _T_0 (
+    %w2, %y2 = rtl.instance "" @B(%a) : (i1) -> (i1, i1)
+  }
+
+  // CHECK-LABEL: TestInstanceNameValueConflict
+  rtl.module @TestInstanceNameValueConflict(%a: i1) {
+    // CHECK: wire name
+    %name = rtl.wire : !rtl.inout<i1>
+
+    // CHECK: B name_0 (
+    %w, %y = rtl.instance "name" @B(%a) : (i1) -> (i1, i1)
+  }
 }


### PR DESCRIPTION
Previously, ExportVerilog would just spit out instance names. If
instance names were duplicates or empty, this would cause issues. Now,
every instance is assigned a name in collectNamesEmitDecls, which is
used when naming instance result values and emitting instances
themselves. This fixes https://github.com/llvm/circt/issues/407.