### PR TITLE
[FIRRTL] Return multiple results from memories, Lower Memories in LowerTypes

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -77,6 +77,9 @@ def MemOp : FIRRTLOp<"mem", [/*MemAlloc*/]> {
     static BundleType getTypeForPortList(uint64_t depth, FIRRTLType dataType,
                               ArrayRef<std::pair<Identifier, PortKind>> ports);
 
+    static BundleType getTypeForPort(uint64_t depth, FIRRTLType dataType,
+                              PortKind portKind);
+
     /// Return the name and kind of ports supported by this memory.
     void getPorts(SmallVectorImpl<std::pair<Identifier, PortKind>> &result);
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -78,8 +78,9 @@ def MemOp : FIRRTLOp<"mem", [/*MemAlloc*/]> {
     static BundleType getTypeForPortList(uint64_t depth, FIRRTLType dataType,
                               ArrayRef<std::pair<Identifier, PortKind>> ports);
 
+    /// Return the type of a port given the memory depth, type, and kind
     static BundleType getTypeForPort(uint64_t depth, FIRRTLType dataType,
-                              PortKind portKind);
+                                     PortKind portKind);
 
     /// Return the name and kind of ports supported by this memory.
     void getPorts(SmallVectorImpl<std::pair<Identifier, PortKind>> &result);

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -64,10 +64,11 @@ def MemOp : FIRRTLOp<"mem", [/*MemAlloc*/]> {
   let arguments = (ins I32Attr:$readLatency,
                        Confined<I32Attr, [IntMinValue<1>]>:$writeLatency,
                        Confined<I64Attr, [IntMinValue<1>]>:$depth, RUWAttr:$ruw,
+                       StrArrayAttr:$portNames,
                        OptionalAttr<StrAttr>:$name);
-  let results = (outs BundleType:$result);
+  let results = (outs Variadic<FIRRTLType>:$results);
 
-  let assemblyFormat = "$ruw attr-dict `:` type($result)";
+  let assemblyFormat = "$ruw attr-dict (`:` type($results)^ )?";
 
   let extraClassDeclaration = [{
     enum class PortKind { Read, Write, ReadWrite };
@@ -89,6 +90,19 @@ def MemOp : FIRRTLOp<"mem", [/*MemAlloc*/]> {
     /// Return the data-type field of the memory, the type of each element.  If
     /// the Mem has no read/write ports, this will return null.
     FIRRTLType getDataTypeOrNull();
+
+    /// Return the port name for the specified result number.
+    StringAttr getPortName(size_t resultNo);
+    StringRef getPortNameStr(size_t resultNo) {
+      return getPortName(resultNo).getValue();
+    }
+
+    // Return the result for this instance that corresponds to the specified
+    // port name.
+    Value getPortNamed(StringRef name) {
+      return getPortNamed(StringAttr::get(name, getContext()));
+    }
+    Value getPortNamed(StringAttr name);
   }];
 }
 

--- a/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
+++ b/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
@@ -1422,23 +1422,16 @@ LogicalResult FIRRTLLowering::visitDecl(MemOp op) {
   // Keep track of whether this mem is an even power of two or not.
   bool isPowerOfTwo = llvm::isPowerOf2_64(depth);
 
-  // Lower all of the read/write ports.  Each read-write port has a subfield.
-  // While it is possible for there to be more than one subfield per port, they
-  // should be CSE'd away, and generating redundant logic for them isn't a
-  // correctness problem, so we just keep things simple.
-  while (!op->use_empty()) {
-    // Work through the users of the mem, dropping their reference to null as we
-    // go.  This allows SubfieldOp lowering to know that the subfields have been
-    // correctly processed.
-    auto port = cast<SubfieldOp>(*op->user_begin());
-    port->dropAllReferences();
+  // Lower all of the read/write ports.  Each port is a separate
+  // return value of the memory.
+  auto namesArray = op.portNames();
+  for (size_t i = 0, e = namesArray.size(); i != e; ++i) {
 
+    auto portName = namesArray[i].cast<StringAttr>().getValue();
+    auto port = op.getPortNamed(portName);
     auto portBundleType =
         port.getType().cast<FIRRTLType>().getPassiveType().cast<BundleType>();
 
-    // A port has a bunch of subfields hanging off of it, which are the various
-    // parts of the port.  Emit a wire for each of the pieces so users of the
-    // subfield have something to use.
     SmallVector<std::pair<Identifier, Value>> portWires;
     for (BundleType::BundleElement elt : portBundleType.getElements()) {
       auto fieldType = lowerType(elt.type);
@@ -1451,8 +1444,7 @@ LogicalResult FIRRTLLowering::visitDecl(MemOp op) {
         continue;
       }
       auto name =
-          (Twine(memName) + "_" + port.fieldname() + "_" + elt.name.str())
-              .str();
+          (Twine(memName) + "_" + portName + "_" + elt.name.str()).str();
       auto fieldWire = builder->create<rtl::WireOp>(fieldType, name);
       portWires.push_back({elt.name, fieldWire});
     }
@@ -1468,8 +1460,8 @@ LogicalResult FIRRTLLowering::visitDecl(MemOp op) {
 
     // Now that we have the wires for each element, rewrite any subfields to use
     // them instead of the subfields.
-    while (!port->use_empty()) {
-      auto portField = cast<SubfieldOp>(*port->user_begin());
+    while (!port.use_empty()) {
+      auto portField = cast<SubfieldOp>(*port.user_begin());
       portField->dropAllReferences();
       setLowering(portField, getPortFieldWire(portField.fieldname()));
     }
@@ -1479,7 +1471,7 @@ LogicalResult FIRRTLLowering::visitDecl(MemOp op) {
       return builder->create<rtl::ReadInOutOp>(getPortFieldWire(portName));
     };
 
-    switch (op.getPortKind(port.fieldname()).getValue()) {
+    switch (op.getPortKind(portName).getValue()) {
     case MemOp::PortKind::ReadWrite:
       op.emitOpError("readwrite ports should be lowered into separate read and "
                      "write ports by previous passes");

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -1481,17 +1481,13 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
     ports.push_back({portName, portKind});
   }
 
-  // Create the special type to represent this memory.
-  BundleType memType = MemOp::getTypeForPortList(depth, dataType, ports);
-
   llvm::SmallVector<Type> resultTypes;
   llvm::SmallVector<Attribute> resultNames;
-  for (auto element : memType.getElements()) {
-    resultTypes.push_back(element.type);
-    resultNames.push_back(rewriter.getStringAttr(element.name.str()));
+  for (auto p : ports) {
+    resultTypes.push_back(FlipType::get(MemOp::getTypeForPort(depth, dataType, p.second)));
+    resultNames.push_back(rewriter.getStringAttr(p.first));
   }
 
-  // Create the actual mem op.
   auto memOp = rewriter.create<MemOp>(insertLoc, resultTypes, readLatency,
                                       writeLatency, depth, ruw,
                                       rewriter.getArrayAttr(resultNames), name);

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -1482,14 +1482,21 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
   }
 
   // Create the special type to represent this memory.
-  FIRRTLType memType = MemOp::getTypeForPortList(depth, dataType, ports);
+  BundleType memType = MemOp::getTypeForPortList(depth, dataType, ports);
+
+  llvm::SmallVector<Type> resultTypes;
+  llvm::SmallVector<Attribute> resultNames;
+  for (auto element : memType.getElements()) {
+    resultTypes.push_back(element.type);
+    resultNames.push_back(rewriter.getStringAttr(element.name.str()));
+  }
 
   // Create the actual mem op.
-  auto memOp = rewriter.create<MemOp>(insertLoc, memType, readLatency,
-                                      writeLatency, depth, ruw, name);
+  auto memOp = rewriter.create<MemOp>(insertLoc, resultTypes, readLatency,
+                                      writeLatency, depth, ruw,
+                                      rewriter.getArrayAttr(resultNames), name);
 
   // Prepare to create each load and store port logic.
-  BundleType resultType = memOp.getType().cast<BundleType>();
   auto bitType = UIntType::get(rewriter.getContext(), 1);
   auto numPorts = portList.size();
   auto clock = portList[numPorts - 2][0];
@@ -1514,9 +1521,8 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
 
     // Create a subfield op to access this port in the memory.
     auto fieldName = loadIdentifier(i);
-    auto bundleType = resultType.getElementType(fieldName).cast<BundleType>();
-    auto memBundle =
-        rewriter.create<SubfieldOp>(insertLoc, bundleType, memOp, fieldName);
+    auto memBundle = memOp.getPortNamed(fieldName);
+    auto bundleType = memBundle.getType().cast<BundleType>();
 
     // Get the clock out of the bundle and connect it.
     auto memClockType = bundleType.getElementType("clk");
@@ -1585,12 +1591,15 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
     // Unpack store control.
     auto storeControlValid = storeControl[0];
 
-    // Create a subfield op to access this port in the memory.
     auto fieldName = storeIdentifier(i);
-    auto subfieldType = resultType.getElementType(fieldName).cast<FlipType>();
-    auto bundleType = subfieldType.getElementType().cast<BundleType>();
-    auto memBundle =
-        rewriter.create<SubfieldOp>(insertLoc, subfieldType, memOp, fieldName);
+    auto memBundle = memOp.getPortNamed(fieldName);
+    // If this is a write port, then it will be flipped. Strip that.
+    BundleType bundleType = memBundle.getType().dyn_cast<BundleType>();
+    if (!bundleType)
+      bundleType = memBundle.getType()
+                       .cast<FlipType>()
+                       .getElementType()
+                       .cast<BundleType>();
 
     // Get the clock out of the bundle and connect it.
     auto memClockType = FlipType::get(bundleType.getElementType("clk"));

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -1593,13 +1593,10 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
 
     auto fieldName = storeIdentifier(i);
     auto memBundle = memOp.getPortNamed(fieldName);
-    // If this is a write port, then it will be flipped. Strip that.
-    BundleType bundleType = memBundle.getType().dyn_cast<BundleType>();
-    if (!bundleType)
-      bundleType = memBundle.getType()
-                       .cast<FlipType>()
-                       .getElementType()
-                       .cast<BundleType>();
+    BundleType bundleType = memBundle.getType()
+                                .cast<FIRRTLType>()
+                                .getPassiveType()
+                                .cast<BundleType>();
 
     // Get the clock out of the bundle and connect it.
     auto memClockType = FlipType::get(bundleType.getElementType("clk"));

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -1484,7 +1484,8 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
   llvm::SmallVector<Type> resultTypes;
   llvm::SmallVector<Attribute> resultNames;
   for (auto p : ports) {
-    resultTypes.push_back(FlipType::get(MemOp::getTypeForPort(depth, dataType, p.second)));
+    resultTypes.push_back(
+        FlipType::get(MemOp::getTypeForPort(depth, dataType, p.second)));
     resultNames.push_back(rewriter.getStringAttr(p.first));
   }
 

--- a/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
@@ -62,6 +62,20 @@ struct FIRRTLOpAsmDialectInterface : public OpAsmDialectInterface {
       return;
     }
 
+    if (auto memory = dyn_cast<MemOp>(op)) {
+      StringRef base;
+      if (auto nameAttr = op->getAttrOfType<StringAttr>("name"))
+        base = nameAttr.getValue();
+      if (base.empty())
+        base = "mem";
+
+      for (size_t i = 0, e = op->getNumResults(); i != e; ++i) {
+        setNameFn(memory.getResult(i),
+                  (base + "_" + memory.getPortNameStr(i)).str());
+      }
+      return;
+    }
+
     // Many firrtl dialect operations have an optional 'name' attribute.  If
     // present, use it.
     if (op->getNumResults() == 1)

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -768,31 +768,53 @@ static Optional<MemOp::PortKind> getMemPortKindFromType(FIRRTLType type) {
 void MemOp::getPorts(
     SmallVectorImpl<std::pair<Identifier, MemOp::PortKind>> &result) {
   // Each entry in the bundle is a port.
-  for (auto elt : getType().getElements()) {
+  for (size_t i = 0, e = getNumResults(); i != e; ++i) {
+    auto elt = getResult(i);
     // Each port is a bundle.
-    auto kind = getMemPortKindFromType(elt.type);
+    auto kind = getMemPortKindFromType(elt.getType().cast<FIRRTLType>());
     assert(kind.hasValue() && "unknown port type!");
-    result.push_back({elt.name, kind.getValue()});
+    result.push_back({Identifier::get(getPortNameStr(i), elt.getContext()),
+                      kind.getValue()});
   }
 }
 
 /// Return the kind of the specified port or None if the name is invalid.
 Optional<MemOp::PortKind> MemOp::getPortKind(StringRef portName) {
-  auto eltType = getType().getElementType(portName);
-  if (!eltType)
+  auto elt = getPortNamed(portName);
+  if (!elt)
     return None;
-  return getMemPortKindFromType(eltType);
+  return getMemPortKindFromType(elt.getType().cast<FIRRTLType>());
 }
 
 /// Return the data-type field of the memory, the type of each element.
 FIRRTLType MemOp::getDataTypeOrNull() {
   // Mems with no read/write ports are legal.
-  if (getType().getElements().empty())
+  if (getNumResults() == 0)
     return {};
 
-  auto firstPort = getType().getElements()[0];
-  auto firstPortType = firstPort.type.getPassiveType().cast<BundleType>();
-  return firstPortType.getElementType("data");
+  auto firstPortType = getResult(0).getType().cast<FIRRTLType>();
+
+  StringRef dataFieldName = "data";
+  if (getMemPortKindFromType(firstPortType).getValue() == PortKind::ReadWrite)
+    dataFieldName = "rdata";
+
+  return firstPortType.getPassiveType().cast<BundleType>().getElementType(
+      dataFieldName);
+}
+
+StringAttr MemOp::getPortName(size_t resultNo) {
+  return portNames()[resultNo].cast<StringAttr>();
+}
+
+Value MemOp::getPortNamed(StringAttr name) {
+  auto namesArray = portNames();
+  for (size_t i = 0, e = namesArray.size(); i != e; ++i) {
+    if (namesArray[i] == name) {
+      assert(i < getNumResults() && " names array out of sync with results");
+      return getResult(i);
+    }
+  }
+  return Value();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -20,10 +20,10 @@
 #include "mlir/IR/Verifier.h"
 #include "mlir/Translation.h"
 #include "llvm/ADT/PointerEmbeddedInt.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/ScopedHashTable.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/StringExtras.h"
-#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -2081,12 +2081,14 @@ ParseResult FIRStmtParser::parseMem(unsigned memIndent) {
     StringRef portName;
     if (parseId(portName, "expected port name"))
       return failure();
-    ports.push_back({builder.getStringAttr(portName), MemOp::getTypeForPort(depth, type, portKind)});
+    ports.push_back({builder.getStringAttr(portName),
+                     MemOp::getTypeForPort(depth, type, portKind)});
 
     while (!getIndentation().hasValue()) {
       if (parseId(portName, "expected port name"))
         return failure();
-      ports.push_back({builder.getStringAttr(portName), MemOp::getTypeForPort(depth, type, portKind)});
+      ports.push_back({builder.getStringAttr(portName),
+                       MemOp::getTypeForPort(depth, type, portKind)});
     }
   }
 
@@ -2100,12 +2102,12 @@ ParseResult FIRStmtParser::parseMem(unsigned memIndent) {
 
   // Canonicalize the ports into alphabetical order.
   // TODO: Move this into MemOp construction/canonicalization.
-  llvm::array_pod_sort(
-      ports.begin(), ports.end(),
-      [](const std::pair<StringAttr, BundleType> *lhs,
-         const std::pair<StringAttr, BundleType> *rhs) -> int {
-        return lhs->first.getValue().compare(rhs->first.getValue());
-      });
+  llvm::array_pod_sort(ports.begin(), ports.end(),
+                       [](const std::pair<StringAttr, BundleType> *lhs,
+                          const std::pair<StringAttr, BundleType> *rhs) -> int {
+                         return lhs->first.getValue().compare(
+                             rhs->first.getValue());
+                       });
 
   // Require that all port names are unique.
   // TODO: Move this into MemOp verification.

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2103,16 +2103,31 @@ ParseResult FIRStmtParser::parseMem(unsigned memIndent) {
     return failure();
   }
 
-  auto result =
-      builder.create<MemOp>(info.getLoc(), memType, readLatency, writeLatency,
-                            depth, ruw, filterUselessName(id));
+  SmallVector<Type, 4> resultTypes;
+  SmallVector<Attribute, 4> resultNames;
+  for (auto element : memType.getElements()) {
+    resultTypes.push_back(element.type);
+    resultNames.push_back(StringAttr::get(element.name.str(), getContext()));
+  }
+
+  auto result = builder.create<MemOp>(
+      info.getLoc(), resultTypes, readLatency, writeLatency, depth, ruw,
+      builder.getArrayAttr(resultNames), filterUselessName(id));
+
+  UnbundledValueEntry unbundledValueEntry;
+  unbundledValueEntry.reserve(memType.getNumElements());
+  for (size_t i = 0, e = memType.getNumElements(); i != e; ++i) {
+    unbundledValueEntry.push_back({resultNames[i], result.getResult(i)});
+  }
+  unbundledValues.push_back(std::move(unbundledValueEntry));
+  auto entryID = UnbundledID(unbundledValues.size());
 
   // Remember that this memory is in this symbol table scope.
   // TODO(chisel bug): This should be removed along with memoryScopeTable.
   memoryScopeTable.insert(Identifier::get(id.getValue(), getContext()),
                           {symbolTable.getCurScope(), result.getOperation()});
 
-  return addSymbolEntry(id.getValue(), result, info.getFIRLoc());
+  return addSymbolEntry(id.getValue(), entryID, info.getFIRLoc());
 }
 
 /// node ::= 'node' id '=' exp info?

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -15,6 +15,7 @@
 #include "circt/Dialect/FIRRTL/FIRRTLVisitors.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Support/ImplicitLocOpBuilder.h"
+#include "llvm/ADT/StringSwitch.h"
 
 using namespace circt;
 using namespace firrtl;
@@ -94,6 +95,7 @@ struct FIRRTLTypesLowering : public LowerFIRRTLTypesBase<FIRRTLTypesLowering>,
 
   // Lowering operations.
   void visitDecl(InstanceOp op);
+  void visitDecl(MemOp op);
   void visitExpr(SubfieldOp op);
   void visitStmt(ConnectOp op);
 
@@ -249,6 +251,109 @@ void FIRRTLTypesLowering::visitDecl(InstanceOp op) {
   }
 
   // Remember to remove the original op.
+  opsToRemove.push_back(op);
+}
+
+/// Lower memory operations. A new memory is created for every leaf
+/// element in a memory's data type.
+void FIRRTLTypesLowering::visitDecl(MemOp op) {
+
+  auto type = op.getDataTypeOrNull();
+
+  // Bail out if the memory is empty
+  if (!type)
+    return;
+
+  SmallVector<FlatBundleFieldEntry, 8> fieldTypes;
+  flattenBundleTypes(type, "", false, fieldTypes);
+
+  // Mutable store of the types of the ports of a new memory. This is
+  // cleared and re-used.
+  SmallVector<Type, 4> resultPortTypes;
+
+  // Store any new wires created during lowering. This ensures that
+  // wires are re-used if they already exist.
+  DenseMap<StringRef, Value> newWires;
+
+  // Loop over the leaf aggregates.
+  for (auto field : fieldTypes) {
+
+    // Determine the new port type for this memory. New ports are
+    // constructed by checking the kind of the memory.
+    resultPortTypes.clear();
+    for (size_t i = 0, e = op.getNumResults(); i != e; ++i) {
+      auto kind = op.getPortKind(op.getPortName(i).getValue()).getValue();
+      auto flattenedPortType =
+          FlipType::get(op.getTypeForPort(op.depth(), field.type, kind));
+
+      resultPortTypes.push_back(flattenedPortType);
+    }
+
+    // Construct the new memory for this flattened field.
+    auto newName = op.name().getValue().str() + field.suffix;
+    auto newMem = builder->create<MemOp>(
+        resultPortTypes, op.readLatency(), op.writeLatency(), op.depth(),
+        op.ruw(), op.portNames(), builder->getStringAttr(newName));
+
+    // Setup the lowering to the new memory.
+    for (size_t i = 0, e = newMem.getNumResults(); i != e; ++i) {
+
+      BundleType underlying = newMem.getResult(i)
+                                  .getType()
+                                  .cast<FIRRTLType>()
+                                  .getPassiveType()
+                                  .cast<BundleType>();
+
+      auto kind =
+          newMem.getPortKind(newMem.getPortName(i).getValue()).getValue();
+
+      for (auto elt : underlying.getElements()) {
+
+        // These ports require special handling. When these are
+        // lowered, they result in multiple new connections. E.g., an
+        // assignment to a clock needs to be split into an assignment
+        // to all clocks. This is handled by creating a dummy wire,
+        // setting the dummy wire as the lowering target, and then
+        // connecting every new port subfield to that.
+        if (elt.name == "clk" | elt.name == "en" | elt.name == "addr" |
+            elt.name == "wmode") {
+          Type theType = FlipType::get(elt.type);
+
+          // Construct a new wire if needed.
+          auto wire =
+              newWires[op.getPortName(i).getValue().str() + elt.name.str()];
+          if (!wire) {
+            wire = builder->create<WireOp>(
+                theType, op.name().getValue().str() + "_" +
+                             op.getPortName(i).getValue().str() + "_" +
+                             elt.name.str());
+            newWires[op.getPortName(i).getValue().str() + elt.name.str()] =
+                wire;
+            setBundleLowering(op.getResult(i), elt.name.str(), wire);
+          }
+
+          builder->create<ConnectOp>(
+              builder->create<SubfieldOp>(theType, newMem.getResult(i),
+                                          elt.name),
+              wire);
+          continue;
+        }
+
+        // Data ports ("data", "rdata", "wdata", "mask", "wmask") are
+        // trivially lowered because each data leaf winds up in a new,
+        // separate memory. No wire creation is needed.
+        FIRRTLType theType = elt.type;
+        if (kind == MemOp::PortKind::Write || elt.name == "wdata" ||
+            elt.name == "wmask")
+          theType = FlipType::get(theType);
+
+        setBundleLowering(op.getResult(i), elt.name.str() + field.suffix,
+                          builder->create<SubfieldOp>(
+                              theType, newMem.getResult(i), elt.name));
+      }
+    }
+  }
+
   opsToRemove.push_back(op);
 }
 

--- a/lib/Translation/ExportVerilog/ExportVerilogFIRRTL.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilogFIRRTL.cpp
@@ -1546,7 +1546,7 @@ void ModuleEmitter::emitDecl(MemOp op) {
   SmallPtrSet<Operation *, 8> ops;
   ops.insert(op);
 
-  auto memName = getName(op.getResult());
+  auto memName = op.name().getValue().str();
   uint64_t depth = op.depth();
   auto locInfo = getLocationInfoAsString(ops);
 
@@ -1571,20 +1571,22 @@ void ModuleEmitter::emitDecl(MemOp op) {
   // is set.
   if (depth == 1) { // Don't emit a for loop for one element.
     for (const auto &elt : fieldTypes) {
-      std::string action = memName.str() + elt.suffix + "[0] = `RANDOM;";
+      std::string action = memName + elt.suffix + "[0] = `RANDOM;";
       addInitial(action, locInfo, /*ppCond*/ "RANDOMIZE_MEM_INIT",
                  /*cond*/ "", /*partialOrder: After initVar decl*/ 11);
     }
 
   } else if (!fieldTypes.empty()) {
-    std::string action = "for (initvar = 0; initvar < " + llvm::utostr(depth) +
-                         "; initvar = initvar+1)";
+    auto initvar = memName + "_initvar";
+    std::string action = "for (" + initvar + " = 0; " + initvar + " < " +
+                         llvm::utostr(depth) + "; " + initvar + " = " +
+                         initvar + "+1)";
 
     if (fieldTypes.size() > 1)
       action += " begin";
 
     for (const auto &elt : fieldTypes)
-      action += "\n  " + memName.str() + elt.suffix + "[initvar] = `RANDOM;";
+      action += "\n  " + memName + elt.suffix + "[" + initvar + "] = `RANDOM;";
 
     if (fieldTypes.size() > 1)
       action += "\nend";
@@ -1608,7 +1610,7 @@ void ModuleEmitter::emitDecl(MemOp op) {
     // of subfield's.
     // TODO(verilog dialect): eliminate subfields.
     auto getPortName = [&](StringRef fieldName) -> std::string {
-      return getName(op).str() + "_" + portName.str() + "_" + fieldName.str();
+      return memName + "_" + portName.str() + "_" + fieldName.str();
     };
 
     switch (port.second) {
@@ -1628,8 +1630,7 @@ void ModuleEmitter::emitDecl(MemOp op) {
 
       for (const auto &elt : fieldTypes) {
         indent() << "assign " << getPortName("data") << elt.suffix << " = "
-                 << getName(op) << elt.suffix << '[' << getPortName("addr")
-                 << "];";
+                 << memName << elt.suffix << '[' << getPortName("addr") << "];";
         emitLocationInfoAndNewLine(ops);
       }
 
@@ -1641,7 +1642,7 @@ void ModuleEmitter::emitDecl(MemOp op) {
         for (const auto &elt : fieldTypes) {
           indent() << "assign " << getPortName("data") << elt.suffix << " = ";
           os << getPortName("addr") << " < " << depth << " ? ";
-          os << getName(op) << elt.suffix << '[' << getPortName("addr") << "]";
+          os << memName << elt.suffix << '[' << getPortName("addr") << "]";
           os << " : `RANDOM;";
           emitLocationInfoAndNewLine(ops);
         }
@@ -1663,8 +1664,7 @@ void ModuleEmitter::emitDecl(MemOp op) {
       auto condition = getPortName("en") + " & " + getPortName("mask");
 
       for (const auto &elt : fieldTypes) {
-        std::string action = getName(op).str() + elt.suffix + '[' +
-                             getPortName("addr") +
+        std::string action = memName + elt.suffix + '[' + getPortName("addr") +
                              "] <= " + getPortName("data") + elt.suffix + ";";
 
         addAtPosEdge(action, locStr, clockExpr,
@@ -1799,6 +1799,13 @@ void ModuleEmitter::collectNamesEmitDecls(Block &block) {
                           .str();
           addName(result, name);
         }
+      } else if (auto memory = dyn_cast<MemOp>(&op)) {
+        if (nameAttr) {
+          auto name = (nameAttr.getValue() + "_" +
+                       memory.getPortNameStr(result.getResultNumber()))
+                          .str();
+          addName(result, name);
+        }
       } else {
         addName(result, nameAttr);
       }
@@ -1849,6 +1856,7 @@ void ModuleEmitter::collectNamesEmitDecls(Block &block) {
   }
 
   SmallPtrSet<Operation *, 8> ops;
+  SmallPtrSet<Operation *, 8> visitedDecls;
 
   // Okay, now that we have measured the things to emit, emit the things.
   for (auto value : valuesToEmit) {
@@ -1856,6 +1864,9 @@ void ModuleEmitter::collectNamesEmitDecls(Block &block) {
 
     auto *decl = value.getDefiningOp();
     ops.insert(decl);
+
+    // True if this is an op we haven't seen before
+    auto unvisitedOp = std::get<1>(visitedDecls.insert(decl));
 
     auto word = getVerilogDeclWord(decl);
 
@@ -1873,26 +1884,30 @@ void ModuleEmitter::collectNamesEmitDecls(Block &block) {
       emitTypePaddedToWidth(elementType, maxTypeWidth, decl);
 
       os << getName(value) << elt.suffix << ';';
-      if (isFirst)
+      if (isFirst) {
         emitLocationInfoAndNewLine(ops);
-      else
+      } else
         os << '\n';
     }
 
     // Handle the reg declaration for a memory specially because we need to
     // handle aggregate types and depths.
     if (auto memOp = dyn_cast<MemOp>(decl)) {
+      auto memName = memOp.name().getValue().str();
       fieldTypes.clear();
       if (auto dataType = memOp.getDataTypeOrNull())
         flattenBundleTypes(dataType, "", false, fieldTypes);
 
-      uint64_t depth = memOp.depth();
-      for (const auto &elt : fieldTypes) {
-        indent() << "reg";
-        os.indent(maxDeclNameWidth - 3 + 1);
-        emitTypePaddedToWidth(elt.type, maxTypeWidth, decl);
-        os << getName(decl->getResult(0)) << elt.suffix;
-        os << '[' << (depth - 1) << ":0];\n";
+      if (unvisitedOp) {
+        uint64_t depth = memOp.depth();
+        for (auto fieldType : fieldTypes) {
+          indent() << "reg";
+          os.indent(maxDeclNameWidth - 3 + 1);
+          emitTypePaddedToWidth(fieldType.type, maxTypeWidth, decl);
+          os << memName + fieldType.suffix;
+          os << '[' << (depth - 1) << ":0];";
+          emitLocationInfoAndNewLine(ops);
+        }
       }
     }
   }

--- a/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
+++ b/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
@@ -613,7 +613,7 @@ module attributes {firrtl.mainModule = "Simple"} {
     %c0_ui3 = firrtl.constant(0 : ui3) : !firrtl.uint<3>
 
     // CHECK:  %_M = sv.reg : !rtl.inout<uarray<12xi42>>
-    %_M = firrtl.mem Undefined {depth = 12 : i64, name = "_M", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<read: bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>, write: flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>>
+    %_M_read, %_M_write = firrtl.mem Undefined {depth = 12 : i64, name = "_M", portNames = ["read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>
 
     // CHECK-NEXT: sv.ifdef "!SYNTHESIS"  {
     // CHECK-NEXT:   sv.initial  {
@@ -625,25 +625,6 @@ module attributes {firrtl.mainModule = "Simple"} {
     // CHECK-NEXT: }
 
     // Write port.
-
-    // CHECK:      %_M_write_addr = rtl.wire : !rtl.inout<i4>
-    // CHECK-NEXT: %_M_write_en = rtl.wire : !rtl.inout<i1>
-    // CHECK-NEXT: %_M_write_clk = rtl.wire : !rtl.inout<i1>
-    // CHECK-NEXT: %_M_write_data = rtl.wire : !rtl.inout<i42>
-    // CHECK-NEXT: %_M_write_mask = rtl.wire : !rtl.inout<i1>
-
-    // CHECK-NEXT: %0 = rtl.read_inout %_M_write_clk
-    // CHECK-NEXT: sv.always posedge %0  {
-    // CHECK-NEXT:     %2 = rtl.read_inout %_M_write_en : !rtl.inout<i1>
-    // CHECK-NEXT:     %3 = rtl.read_inout %_M_write_mask : !rtl.inout<i1>
-    // CHECK-NEXT:     %4 = rtl.and %2, %3 : i1
-    // CHECK-NEXT:     sv.if %4  {
-    // CHECK-NEXT:       %5 = rtl.read_inout %_M_write_data : !rtl.inout<i42>
-    // CHECK-NEXT:       %6 = rtl.read_inout %_M_write_addr : !rtl.inout<i4>
-    // CHECK-NEXT:       %7 = rtl.arrayindex %_M[%6]
-    // CHECK-NEXT:       sv.bpassign %7, %5 : i42
-    // CHECK-NEXT:     }
-    // CHECK-NEXT:   }
 
     // Read port.
     // CHECK-NEXT: %_M_read_addr = rtl.wire : !rtl.inout<i4>
@@ -666,28 +647,45 @@ module attributes {firrtl.mainModule = "Simple"} {
     // CHECK-NEXT:   rtl.connect %_M_read_data, %7 : i42
     // CHECK-NEXT: }
 
-    %4 = firrtl.subfield %_M("read") : (!firrtl.bundle<read: bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>, write: flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>>) -> !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>
-    %5 = firrtl.subfield %4("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.sint<42>
-    %6 = firrtl.subfield %4("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<4>>
+    // CHECK:      %_M_write_addr = rtl.wire : !rtl.inout<i4>
+    // CHECK-NEXT: %_M_write_en = rtl.wire : !rtl.inout<i1>
+    // CHECK-NEXT: %_M_write_clk = rtl.wire : !rtl.inout<i1>
+    // CHECK-NEXT: %_M_write_data = rtl.wire : !rtl.inout<i42>
+    // CHECK-NEXT: %_M_write_mask = rtl.wire : !rtl.inout<i1>
+
+    // CHECK-NEXT: %0 = rtl.read_inout %_M_write_clk
+    // CHECK-NEXT: sv.always posedge %0  {
+    // CHECK-NEXT:     %2 = rtl.read_inout %_M_write_en : !rtl.inout<i1>
+    // CHECK-NEXT:     %3 = rtl.read_inout %_M_write_mask : !rtl.inout<i1>
+    // CHECK-NEXT:     %4 = rtl.and %2, %3 : i1
+    // CHECK-NEXT:     sv.if %4  {
+    // CHECK-NEXT:       %5 = rtl.read_inout %_M_write_data : !rtl.inout<i42>
+    // CHECK-NEXT:       %6 = rtl.read_inout %_M_write_addr : !rtl.inout<i4>
+    // CHECK-NEXT:       %7 = rtl.arrayindex %_M[%6]
+    // CHECK-NEXT:       sv.bpassign %7, %5 : i42
+    // CHECK-NEXT:     }
+    // CHECK-NEXT:   }
+
+    %5 = firrtl.subfield %_M_read("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.sint<42>
+    %6 = firrtl.subfield %_M_read("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<4>>
     firrtl.connect %6, %c0_ui1 : !firrtl.flip<uint<4>>, !firrtl.uint<1>
-    %7 = firrtl.subfield %4("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<1>>
+    %7 = firrtl.subfield %_M_read("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<1>>
     firrtl.connect %7, %c1_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-    %8 = firrtl.subfield %4("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<clock>
+    %8 = firrtl.subfield %_M_read("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<clock>
     firrtl.connect %8, %0 : !firrtl.flip<clock>, !firrtl.clock
 
-    %9 = firrtl.subfield %_M("write") : (!firrtl.bundle<read: bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>, write: flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>>) -> !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>
-    %10 = firrtl.subfield %9("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<4>>
+    %10 = firrtl.subfield %_M_write("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<4>>
     %11 = firrtl.validif %2, %c0_ui3 : (!firrtl.uint<1>, !firrtl.uint<3>) -> !firrtl.uint<3>
     firrtl.connect %10, %11 : !firrtl.flip<uint<4>>, !firrtl.uint<3>
-    %12 = firrtl.subfield %9("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+    %12 = firrtl.subfield %_M_write("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
     firrtl.connect %12, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-    %13 = firrtl.subfield %9("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<clock>
+    %13 = firrtl.subfield %_M_write("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<clock>
     %14 = firrtl.validif %2, %1 : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.clock
     firrtl.connect %13, %14 : !firrtl.flip<clock>, !firrtl.clock
-    %15 = firrtl.subfield %9("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<sint<42>>
+    %15 = firrtl.subfield %_M_write("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<sint<42>>
     %16 = firrtl.validif %2, %3 : (!firrtl.uint<1>, !firrtl.sint<42>) -> !firrtl.sint<42>
     firrtl.connect %15, %16 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
-    %17 = firrtl.subfield %9("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+    %17 = firrtl.subfield %_M_write("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
     %18 = firrtl.validif %2, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.connect %17, %18 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
     %19 = firrtl.stdIntCast %5 : (!firrtl.sint<42>) -> i42
@@ -718,12 +716,12 @@ module attributes {firrtl.mainModule = "Simple"} {
   // CHECK-NEXT:      }
   // CHECK-NEXT:    }
   // CHECK-NEXT:  }
-  // CHECK-NEXT:  rtl.output
+  // CHECK:  rtl.output
   // CHECK-NEXT:}
   rtl.module @MemAggregate(%clock1: i1, %clock2: i1) {
       %0 = firrtl.stdIntCast %clock1 : (i1) -> !firrtl.clock
       %1 = firrtl.stdIntCast %clock2 : (i1) -> !firrtl.clock
-      %_M = firrtl.mem Undefined {depth = 20 : i64, name = "_M", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<read: bundle<addr: flip<uint<5>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<id: analog<4>, other: sint<8>>>, write: flip<bundle<addr: uint<5>, en: uint<1>, clk: clock, data: bundle<id: analog<4>, other: sint<8>>, mask: bundle<id: uint<1>, other: uint<1>>>>>
+      %_M_read, %_M_write = firrtl.mem Undefined {depth = 20 : i64, name = "_M", portNames = ["read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<5>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<id: analog<4>, other: sint<8>>>, !firrtl.flip<bundle<addr: uint<5>, en: uint<1>, clk: clock, data: bundle<id: analog<4>, other: sint<8>>, mask: bundle<id: uint<1>, other: uint<1>>>>
       rtl.output
     }
 
@@ -746,7 +744,7 @@ module attributes {firrtl.mainModule = "Simple"} {
   // CHECK-NEXT:   rtl.output
   // CHECK-NEXT: }
   rtl.module @MemEmpty() {
-    %Empty = firrtl.mem Undefined {depth = 16 : i64, name = "Empty", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<>
+    firrtl.mem Undefined {depth = 16 : i64, name = "Empty", portNames = [], readLatency = 0 : i32, writeLatency = 1 : i32}
     rtl.output
   }
 
@@ -778,10 +776,10 @@ module attributes {firrtl.mainModule = "Simple"} {
   // CHECK-NEXT:       }
   // CHECK-NEXT:     }
   // CHECK-NEXT:   }
-  // CHECK-NEXT:   rtl.output
+  // CHECK:   rtl.output
   // CHECK-NEXT: }
   rtl.module @MemOne() {
-    %_M = firrtl.mem Undefined {depth = 1 : i64, name = "_M", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<read: bundle<addr: flip<uint<1>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<id: analog<4>, other: sint<8>>>, write: flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<id: analog<4>, other: sint<8>>, mask: bundle<id: uint<1>, other: uint<1>>>>>
+    %_M_read, %_M_write = firrtl.mem Undefined {depth = 1 : i64, name = "_M", portNames=["read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<1>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<id: analog<4>, other: sint<8>>>, !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<id: analog<4>, other: sint<8>>, mask: bundle<id: uint<1>, other: uint<1>>>>
     rtl.output
   }
 
@@ -793,19 +791,18 @@ module attributes {firrtl.mainModule = "Simple"} {
     %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
 
     // CHECK:  %_M = sv.reg : !rtl.inout<uarray<12xi42>>
-    %_M = firrtl.mem Undefined {depth = 12 : i64, name = "_M", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<read: bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>>
+    %_M_read = firrtl.mem Undefined {depth = 12 : i64, name = "_M", portNames = ["read"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>
     // Read port.
     // CHECK: %_M_read_addr = rtl.wire : !rtl.inout<i4>
     // CHECK-NEXT: %_M_read_en = rtl.wire : !rtl.inout<i1>
     // CHECK-NEXT: %_M_read_clk = rtl.wire : !rtl.inout<i1>
     // CHECK-NEXT: %_M_read_data = rtl.wire : !rtl.inout<i42>
     // CHECK-NEXT: sv.ifdef "!RANDOMIZE_GARBAGE_ASSIGN"  {
-    %4 = firrtl.subfield %_M("read") : (!firrtl.bundle<read: bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>>) -> !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>
-    %6 = firrtl.subfield %4("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<4>>
+    %6 = firrtl.subfield %_M_read("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<4>>
     firrtl.connect %6, %c0_ui1 : !firrtl.flip<uint<4>>, !firrtl.uint<1>
-    %7 = firrtl.subfield %4("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<1>>
+    %7 = firrtl.subfield %_M_read("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<1>>
     firrtl.connect %7, %c1_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-    %8 = firrtl.subfield %4("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<clock>
+    %8 = firrtl.subfield %_M_read("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<clock>
     firrtl.connect %8, %0 : !firrtl.flip<clock>, !firrtl.clock
     rtl.output
   }

--- a/test/Conversion/HandshakeToFIRRTL/test_memory.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_memory.mlir
@@ -19,10 +19,7 @@
 // CHECK: %[[LD_CONTROL_READY:.+]] = firrtl.subfield %arg5("ready")
 
 // Construct the memory.
-// CHECK: %[[MEM:.+]] = firrtl.mem Old {depth = 10 : i64, name = "mem0", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<load0: bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<8>>, store0: flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>>>
-
-// Get the load0 port.
-// CHECK: %[[MEM_LOAD:.+]] = firrtl.subfield %[[MEM]]("load0") : {{.*}} -> !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<8>>
+// CHECK: %[[MEM_LOAD:.+]], %[[MEM_STORE:.+]] = firrtl.mem Old {depth = 10 : i64, name = "mem0", portNames = ["load0", "store0"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<8>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>>
 
 // Connect the store clock.
 // CHECK: %[[MEM_LOAD_CLK:.+]] = firrtl.subfield %[[MEM_LOAD]]("clk") : {{.*}} -> !firrtl.flip<clock>
@@ -50,9 +47,6 @@
 // CHECK-DAG: firrtl.{{.+}} %[[LD_DATA_READY]]
 // CHECK-DAG: firrtl.connect %[[LD_CONTROL_VALID]]
 // CHECK-DAG: firrtl.{{.+}} %[[LD_CONTROL_READY]]
-
-// Get the store0 port.
-// CHECK: %[[MEM_STORE:.+]] = firrtl.subfield %[[MEM]]("store0") : {{.*}} -> !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>>
 
 // Connect the store clock.
 // CHECK: %[[MEM_STORE_CLK:.+]] = firrtl.subfield %[[MEM_STORE]]("clk") : {{.*}} -> !firrtl.flip<clock>

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -46,7 +46,7 @@ firrtl.circuit "TopLevel" {
     %sourceV, %sinkV = firrtl.instance @Simple {name = "", portNames = ["source", "sink"]} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
 
     // CHECK-NEXT: firrtl.connect %inst_source_valid, %source_valid
-    // CHECK-NEXT: firrtl.connect %source_ready, %inst_source_ready 
+    // CHECK-NEXT: firrtl.connect %source_ready, %inst_source_ready
     // CHECK-NEXT: firrtl.connect %inst_source_data, %source_data
     // CHECK-NEXT: firrtl.connect %sink_valid, %inst_sink_valid
     // CHECK-NEXT: firrtl.connect %inst_sink_ready, %sink_ready
@@ -118,5 +118,132 @@ firrtl.circuit "Foo" {
   firrtl.module @Foo(%a: !firrtl.bundle<b: bundle<c: uint<1>>>, %b: !firrtl.flip<bundle<b: bundle<c: uint<1>>>>) {
     // CHECK: firrtl.connect %[[FLAT_ARG_OUTPUT_NAME]], %[[FLAT_ARG_INPUT_NAME]] : [[FLAT_ARG_OUTPUT_TYPE]], [[FLAT_ARG_INPUT_TYPE]]
     firrtl.connect %b, %a : !firrtl.flip<bundle<b: bundle<c: uint<1>>>>, !firrtl.bundle<b: bundle<c: uint<1>>>
+  }
+}
+
+// -----
+
+// COM: Test lower of a 1-read 1-write aggregate memory
+//
+// COM: circuit Foo :
+// COM:   module Foo :
+// COM:     input clock: Clock
+// COM:     input rAddr: UInt<4>
+// COM:     input rEn: UInt<1>
+// COM:     output rData: {a: UInt<8>, b: UInt<8>}
+// COM:     input wAddr: UInt<4>
+// COM:     input wEn: UInt<1>
+// COM:     input wMask: {a: UInt<1>, b: UInt<1>}
+// COM:     input wData: {a: UInt<8>, b: UInt<8>}
+// COM:
+// COM:     mem memory:
+// COM:       data-type => {a: UInt<8>, b: UInt<8>}
+// COM:       depth => 16
+// COM:       reader => r
+// COM:       writer => w
+// COM:       read-latency => 0
+// COM:       write-latency => 1
+// COM:       read-under-write => undefined
+// COM:
+// COM:     memory.r.clk <= clock
+// COM:     memory.r.en <= rEn
+// COM:     memory.r.addr <= rAddr
+// COM:     rData <= memory.r.data
+// COM:
+// COM:     memory.w.clk <= clock
+// COM:     memory.w.en <= wEn
+// COM:     memory.w.addr <= wAddr
+// COM:     memory.w.mask <= wMask
+// COM:     memory.w.data <= wData
+
+firrtl.circuit "Foo" {
+
+  // CHECK-LABEL: firrtl.module @Foo
+  firrtl.module @Foo(%clock: !firrtl.clock, %rAddr: !firrtl.uint<4>, %rEn: !firrtl.uint<1>, %rData: !firrtl.flip<bundle<a: uint<8>, b: uint<8>>>, %wAddr: !firrtl.uint<4>, %wEn: !firrtl.uint<1>, %wMask: !firrtl.bundle<a: uint<1>, b: uint<1>>, %wData: !firrtl.bundle<a: uint<8>, b: uint<8>>) {
+    %memory_r, %memory_w = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r", "w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<a: uint<8>, b: uint<8>>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>>
+    %0 = firrtl.subfield %memory_r("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<a: uint<8>, b: uint<8>>>) -> !firrtl.flip<clock>
+    firrtl.connect %0, %clock : !firrtl.flip<clock>, !firrtl.clock
+    %1 = firrtl.subfield %memory_r("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<a: uint<8>, b: uint<8>>>) -> !firrtl.flip<uint<1>>
+    firrtl.connect %1, %rEn : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+    %2 = firrtl.subfield %memory_r("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<a: uint<8>, b: uint<8>>>) -> !firrtl.flip<uint<4>>
+    firrtl.connect %2, %rAddr : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+    %3 = firrtl.subfield %memory_r("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<a: uint<8>, b: uint<8>>>) -> !firrtl.bundle<a: uint<8>, b: uint<8>>
+    firrtl.connect %rData, %3 : !firrtl.flip<bundle<a: uint<8>, b: uint<8>>>, !firrtl.bundle<a: uint<8>, b: uint<8>>
+    %4 = firrtl.subfield %memory_w("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>>) -> !firrtl.flip<clock>
+    firrtl.connect %4, %clock : !firrtl.flip<clock>, !firrtl.clock
+    %5 = firrtl.subfield %memory_w("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>>) -> !firrtl.flip<uint<1>>
+    firrtl.connect %5, %wEn : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+    %6 = firrtl.subfield %memory_w("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>>) -> !firrtl.flip<uint<4>>
+    firrtl.connect %6, %wAddr : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+    %7 = firrtl.subfield %memory_w("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>>) -> !firrtl.flip<bundle<a: uint<1>, b: uint<1>>>
+    firrtl.connect %7, %wMask : !firrtl.flip<bundle<a: uint<1>, b: uint<1>>>, !firrtl.bundle<a: uint<1>, b: uint<1>>
+    %8 = firrtl.subfield %memory_w("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>>) -> !firrtl.flip<bundle<a: uint<8>, b: uint<8>>>
+    firrtl.connect %8, %wData : !firrtl.flip<bundle<a: uint<8>, b: uint<8>>>, !firrtl.bundle<a: uint<8>, b: uint<8>>
+
+    // COM: ---------------------------------------------------------------------------------
+    // COM: Split memory "a" should exist
+    // CHECK: %[[MEMORY_A_R:.+]], %[[MEMORY_A_W:.+]] = firrtl.mem {{.+}} data: uint<8>, mask: uint<1>
+    // COM: ---------------------------------------------------------------------------------
+    // COM: Read port
+    // CHECK-DAG: %[[MEMORY_A_R_ADDR:.+]] = firrtl.subfield %[[MEMORY_A_R]]("addr")
+    // CHECK-DAG: %[[MEMORY_R_ADDR:.+]] = firrtl.wire
+    // CHECK: firrtl.connect %[[MEMORY_A_R_ADDR]], %[[MEMORY_R_ADDR]]
+    // CHECK-DAG: %[[MEMORY_A_R_EN:.+]] = firrtl.subfield %[[MEMORY_A_R]]("en")
+    // CHECK-DAG: %[[MEMORY_R_EN:.+]] = firrtl.wire
+    // CHECK: firrtl.connect %[[MEMORY_A_R_EN]], %[[MEMORY_R_EN]]
+    // CHECK-DAG: %[[MEMORY_A_R_CLK:.+]] = firrtl.subfield %[[MEMORY_A_R]]("clk")
+    // CHECK-DAG: %[[MEMORY_R_CLK:.+]] = firrtl.wire
+    // CHECK: firrtl.connect %[[MEMORY_A_R_CLK]], %[[MEMORY_R_CLK]]
+    // CHECK: %[[MEMORY_A_R_DATA:.+]] = firrtl.subfield %[[MEMORY_A_R]]("data")
+    // COM: ---------------------------------------------------------------------------------
+    // COM: Write Port
+    // CHECK-DAG: %[[MEMORY_A_W_ADDR:.+]] = firrtl.subfield %[[MEMORY_A_W]]("addr")
+    // CHECK-DAG: %[[MEMORY_W_ADDR:.+]] = firrtl.wire
+    // CHECK: firrtl.connect %[[MEMORY_A_W_ADDR]], %[[MEMORY_W_ADDR]]
+    // CHECK-DAG: %[[MEMORY_A_W_EN:.+]] = firrtl.subfield %[[MEMORY_A_W]]("en")
+    // CHECK-DAG: %[[MEMORY_W_EN:.+]] = firrtl.wire
+    // CHECK: firrtl.connect %[[MEMORY_A_W_EN]], %[[MEMORY_W_EN]]
+    // CHECK-DAG: %[[MEMORY_A_W_CLK:.+]] = firrtl.subfield %[[MEMORY_A_W]]("clk")
+    // CHECK-DAG: %[[MEMORY_W_CLK:.+]] = firrtl.wire
+    // CHECK: firrtl.connect %[[MEMORY_A_W_CLK]], %[[MEMORY_W_CLK]]
+    // CHECK: %[[MEMORY_A_W_DATA:.+]] = firrtl.subfield %[[MEMORY_A_W]]("data")
+    // CHECK: %[[MEMORY_A_W_MASK:.+]] = firrtl.subfield %[[MEMORY_A_W]]("mask")
+    // COM: ---------------------------------------------------------------------------------
+    // COM: Split memory "b" should exist
+    // CHECK: %[[MEMORY_B_R:.+]], %[[MEMORY_B_W:.+]] = firrtl.mem {{.+}} data: uint<8>, mask: uint<1>
+    // COM: ---------------------------------------------------------------------------------
+    // COM: Read port
+    // CHECK: %[[MEMORY_B_R_ADDR:.+]] = firrtl.subfield %[[MEMORY_B_R]]("addr")
+    // CHECK: firrtl.connect %[[MEMORY_B_R_ADDR]], %[[MEMORY_R_ADDR]]
+    // CHECK: %[[MEMORY_B_R_EN:.+]] = firrtl.subfield %[[MEMORY_B_R]]("en")
+    // CHECK: firrtl.connect %[[MEMORY_B_R_EN]], %[[MEMORY_R_EN]]
+    // CHECK: %[[MEMORY_B_R_CLK:.+]] = firrtl.subfield %[[MEMORY_B_R]]("clk")
+    // CHECK: firrtl.connect %[[MEMORY_B_R_CLK]], %[[MEMORY_R_CLK]]
+    // CHECK: %[[MEMORY_B_R_DATA:.+]] = firrtl.subfield %[[MEMORY_B_R]]("data")
+    // COM: ---------------------------------------------------------------------------------
+    // COM: Write port
+    // CHECK: %[[MEMORY_B_W_ADDR:.+]] = firrtl.subfield %[[MEMORY_B_W]]("addr")
+    // CHECK: firrtl.connect %[[MEMORY_B_W_ADDR]], %[[MEMORY_W_ADDR]]
+    // CHECK: %[[MEMORY_B_W_EN:.+]] = firrtl.subfield %[[MEMORY_B_W]]("en")
+    // CHECK: firrtl.connect %[[MEMORY_B_W_EN]], %[[MEMORY_W_EN]]
+    // CHECK: %[[MEMORY_B_W_CLK:.+]] = firrtl.subfield %[[MEMORY_B_W]]("clk")
+    // CHECK: firrtl.connect %[[MEMORY_B_W_CLK]], %[[MEMORY_W_CLK]]
+    // CHECK: %[[MEMORY_B_W_DATA:.+]] = firrtl.subfield %[[MEMORY_B_W]]("data")
+    // CHECK: %[[MEMORY_B_W_MASK:.+]] = firrtl.subfield %[[MEMORY_B_W]]("mask")
+    // COM: ---------------------------------------------------------------------------------
+    // COM: Connections to module ports
+    // CHECK: firrtl.connect %[[MEMORY_R_CLK]], %clock
+    // CHECK: firrtl.connect %[[MEMORY_R_EN]], %rEn
+    // CHECK: firrtl.connect %[[MEMORY_R_ADDR]], %rAddr
+    // CHECK: firrtl.connect %rData_a, %[[MEMORY_A_R_DATA]]
+    // CHECK: firrtl.connect %rData_b, %[[MEMORY_B_R_DATA]]
+    // CHECK: firrtl.connect %[[MEMORY_W_CLK]], %clock
+    // CHECK: firrtl.connect %[[MEMORY_W_EN]], %wEn
+    // CHECK: firrtl.connect %[[MEMORY_W_ADDR]], %wAddr
+    // CHECK: firrtl.connect %[[MEMORY_A_W_MASK]], %wMask_a
+    // CHECK: firrtl.connect %[[MEMORY_B_W_MASK]], %wMask_b
+    // CHECK: firrtl.connect %[[MEMORY_A_W_DATA]], %wData_a
+    // CHECK: firrtl.connect %[[MEMORY_B_W_DATA]], %wData_b
+
   }
 }

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -333,11 +333,11 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     node n13 = not(auto)
 
 
-    ; CHECK: %_M = firrtl.mem Undefined {depth = 8 : i64, name = "_M",
-    ; CHECK:   readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<
-    ; CHECK:       _T_10: bundle<addr: flip<uint<3>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<id: analog<4>>, mask: flip<bundle<id: uint<1>>>>
-    ; CHECK:       _T_11: bundle<addr: flip<uint<3>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<id: analog<4>>, mask: flip<bundle<id: uint<1>>>>
-    ; CHECK:       _T_18: bundle<addr: flip<uint<3>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<id: analog<4>>>
+    ; CHECK: %_M__T_10, %_M__T_11, %_M__T_18 = firrtl.mem Undefined {depth = 8 : i64, name = "_M", portNames = ["_T_10", "_T_11", "_T_18"]
+    ; CHECK:   readLatency = 0 : i32, writeLatency = 1 : i32} :
+    ; CHECK:       !firrtl.bundle<addr: flip<uint<3>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<id: analog<4>>, mask: flip<bundle<id: uint<1>>>>,
+    ; CHECK:       !firrtl.bundle<addr: flip<uint<3>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<id: analog<4>>, mask: flip<bundle<id: uint<1>>>>,
+    ; CHECK:       !firrtl.bundle<addr: flip<uint<3>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<id: analog<4>>
     mem _M : @[Decoupled.scala 209:24]
         data-type => { id : Analog<4> }
         depth => 8
@@ -514,7 +514,9 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       reader => io_deq_bits_MPORT
       writer => MPORT
       read-under-write => undefined
-      ; CHECK:         %bar = firrtl.mem Undefined {depth = 1 : i64, name = "bar", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<MPORT: flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<3>, mask: uint<1>>>, io_deq_bits_MPORT: bundle<addr: flip<uint<1>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<3>>>
+      ; CHECK: %bar_MPORT, %bar_io_deq_bits_MPORT = firrtl.mem Undefined {depth = 1 : i64, name = "bar", portNames = ["MPORT", "io_deq_bits_MPORT"], readLatency = 0 : i32, writeLatency = 1 : i32} :
+      ; CHECK: !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<3>, mask: uint<1>>>,
+      ; CHECK: !firrtl.bundle<addr: flip<uint<1>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<3>>
 
   ; CHECK-LABEL: firrtl.module @issue354(%tmp5: !firrtl.flip<sint<19>>) {
   module issue354 :

--- a/test/ExportVerilog/verilog-basic.fir
+++ b/test/ExportVerilog/verilog-basic.fir
@@ -6,7 +6,7 @@
 ; RUN: circt-translate -import-firrtl --mlir-print-debuginfo %s | circt-translate -export-firrtl-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
 
 ; Some day this should filecheck:
-; RUN: circt-translate -import-firrtl --mlir-print-debuginfo %s | circt-opt -lower-firrtl-to-rtl-module -lower-firrtl-to-rtl | circt-translate -export-verilog -verify-diagnostics
+; RUN: circt-translate -import-firrtl --mlir-print-debuginfo %s | circt-opt -pass-pipeline='firrtl.circuit(firrtl.module(firrtl-lower-types))' -lower-firrtl-to-rtl-module -lower-firrtl-to-rtl | circt-translate -export-verilog -verify-diagnostics
 
 circuit inputs_only :
 
@@ -273,7 +273,7 @@ circuit inputs_only :
     output out: UInt<1>
     defname = FooExtModule
 
-  extmodule MyParameterizedExtModule : 
+  extmodule MyParameterizedExtModule :
     input in: UInt<8>
     output out: UInt<1>
     parameter FORMAT = "xyz_timeout=%d\n"
@@ -483,12 +483,12 @@ circuit inputs_only :
     ; CHECK:  wire        _M_read_en;
     ; CHECK:  wire        _M_read_clk;
     ; CHECK:  wire [41:0] _M_read_data;
+    ; CHECK:  reg  [41:0] _M[7:0];
     ; CHECK:  wire [2:0]  _M_write_addr;
     ; CHECK:  wire        _M_write_en;
     ; CHECK:  wire        _M_write_clk;
     ; CHECK:  wire [41:0] _M_write_data;
     ; CHECK:  wire        _M_write_mask;
-    ; CHECK:  reg  [41:0] _M[7:0];
     mem _M : @[Decoupled.scala 209:27]
           data-type => SInt<42>
           depth => 8
@@ -524,8 +524,8 @@ circuit inputs_only :
 ; CHECK-NEXT:    `INIT_RANDOM_PROLOG_
 ; CHECK-NEXT:    `ifdef RANDOMIZE_MEM_INIT
 ; CHECK-NEXT:      integer initvar;
-; CHECK-NEXT:      for (initvar = 0; initvar < 8; initvar = initvar+1)
-; CHECK-NEXT:        _M[initvar] = `RANDOM;{{.*}}// Decoupled.scala:209:27
+; CHECK-NEXT:      for (_M_initvar = 0; _M_initvar < 8; _M_initvar = _M_initvar+1)
+; CHECK-NEXT:        _M[_M_initvar] = `RANDOM;{{.*}}// Decoupled.scala:209:27
 ; CHECK-NEXT:    `endif // RANDOMIZE_MEM_INIT
 ; CHECK-NEXT:  end // initial
 ; CHECK-NEXT:  `endif // SYNTHESIS
@@ -541,8 +541,11 @@ circuit inputs_only :
     input clock1 : Clock
     input clock2 : Clock
 
-    ; CHECK:        reg  [3:0] _M_id[19:0];
-    ; CHECK-NEXT:   reg  [7:0] _M_other[19:0];
+    ; CHECK:        reg  [3:0] _M_id[19:0];{{.+}}// Decoupled.scala:209:24
+    ; CHECK-NEXT:   reg  [7:0] _M_other[19:0];{{.+}}// Decoupled.scala:209:24
+    ; COM: Ensure that the flattened memories only show up once
+    ; CHECK-NOT:    reg  [3:0] _M_id[19:0];
+    ; CHECK-NOT:    reg  [3:0] _M_other[19:0];
     mem _M : @[Decoupled.scala 209:24]
           data-type => { id : Analog<4>, other: SInt<8> }
           depth => 20
@@ -565,9 +568,9 @@ circuit inputs_only :
 ; CHECK-NEXT:      `INIT_RANDOM_PROLOG_
 ; CHECK-NEXT:      `ifdef RANDOMIZE_MEM_INIT
 ; CHECK-NEXT:        integer initvar;
-; CHECK-NEXT:        for (initvar = 0; initvar < 20; initvar = initvar+1) begin
-; CHECK-NEXT:          _M_id[initvar] = `RANDOM;
-; CHECK-NEXT:          _M_other[initvar] = `RANDOM;
+; CHECK-NEXT:        for (_M_initvar = 0; _M_initvar < 20; _M_initvar = _M_initvar+1) begin
+; CHECK-NEXT:          _M_id[_M_initvar] = `RANDOM;
+; CHECK-NEXT:          _M_other[_M_initvar] = `RANDOM;
 ; CHECK-NEXT:        end	// Decoupled.scala:209:24
 ; CHECK-NEXT:      `endif // RANDOMIZE_MEM_INIT
 ; CHECK-NEXT:    end // initial


### PR DESCRIPTION
Fixes #479, #478.

Return one result per port for a FIRRTL memory instead of a single
bundle.

Lowers memories during FIRRTL type lowering.

### Status

This is still work-in-progress and there's a lot of cargo culting from ded5bd2e396a84cc9e277573ce8e83d06b699bd4 and 938ad62122167d7498abef03d058e8d99a281c89. This also has some very ugly code in LowerTypes that I'll cleanup before promoting to non-draft.