### PR TITLE
[HandshakeToFIRRTL] update sub-module naming rule

### DIFF
--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -110,15 +110,32 @@ static Value createConstantOp(FIRRTLType opType, APInt value,
   return Value();
 }
 
-/// Construct a name for creating FIRRTL sub-module. The returned string
-/// contains the following information: 1) standard or handshake operation
-/// name; 2) number of inputs; 3) number of outputs; 4) constant value (if
-/// applied); 5) constant type (if applied); 6) comparison operation type (if
-/// applied); 7) whether the component is for the control path (if applied).
+static Type getHandshakeDataType(Operation *op) {
+  if (auto memOp = dyn_cast<MemoryOp>(op))
+    return memOp.getMemRefType().getElementType();
+
+  else if (auto sinkOp = dyn_cast<SinkOp>(op)) {
+    // As SinkOp only has one argument, which at this stage is already converted
+    // to a bundled FIRRTLType, here we convert it back to a normal data type.
+    // Is there a better way to do this?
+    auto type = sinkOp.getOperand().getType().cast<BundleType>();
+
+    if (auto dataType = type.getElementType("data")) {
+      auto intType = dataType.cast<firrtl::IntType>();
+      return IntegerType::get(type.getContext(), intType.getWidthOrSentinel(),
+                              intType.isSigned() ? IntegerType::Signed
+                                                 : IntegerType::Unsigned);
+    } else
+      return NoneType::get(type.getContext());
+  } else
+    return op->getResult(0).getType();
+}
+
+/// Construct a name for creating FIRRTL sub-module.
 static std::string getSubModuleName(Operation *oldOp) {
-  /// The dialect name is separated from the operation name by '.', which is not
-  /// valid in SystemVerilog module names. In case this name is used in
-  /// SystemVerilog output, replace '.' with '_'.
+  // The dialect name is separated from the operation name by '.', which is not
+  // valid in SystemVerilog module names. In case this name is used in
+  // SystemVerilog output, replace '.' with '_'.
   std::string prefix = oldOp->getName().getStringRef().str();
   std::replace(prefix.begin(), prefix.end(), '.', '_');
 
@@ -126,47 +143,56 @@ static std::string getSubModuleName(Operation *oldOp) {
                               std::to_string(oldOp->getNumOperands()) + "ins_" +
                               std::to_string(oldOp->getNumResults()) + "outs";
 
+  // Add value of the constant operation.
   if (auto constOp = dyn_cast<handshake::ConstantOp>(oldOp)) {
-    // Currently we only support integer or index types. Here, the emitted type
-    // aligns with getFIRRTLType() method. Thus all integers other than signed
-    // integers will be emitted as unsigned.
     if (auto intAttr = constOp.getValue().dyn_cast<IntegerAttr>()) {
       auto intType = intAttr.getType();
 
-      if (auto indexType = intType.dyn_cast<IndexType>()) {
-        // Handle index type.
-        subModuleName +=
-            "_c" + std::to_string((uint64_t)intAttr.getInt()) + "_ui";
-        subModuleName += std::to_string(indexType.kInternalStorageBitWidth);
-
-      } else {
-        // Handle integer types.
-        if (intType.isSignedInteger())
-          subModuleName += "_c" + std::to_string(intAttr.getSInt()) + "_si";
-        else if (intType.isUnsignedInteger())
-          subModuleName += "_c" + std::to_string(intAttr.getUInt()) + "_ui";
-        else
-          subModuleName +=
-              "_c" + std::to_string((uint64_t)intAttr.getInt()) + "_ui";
-
-        subModuleName += std::to_string(intType.getIntOrFloatBitWidth());
-      }
+      if (intType.isSignedInteger())
+        subModuleName += "_c" + std::to_string(intAttr.getSInt());
+      else if (intType.isUnsignedInteger())
+        subModuleName += "_c" + std::to_string(intAttr.getUInt());
+      else
+        subModuleName += "_c" + std::to_string((uint64_t)intAttr.getInt());
     } else
-      oldOp->emitError("unsupported constant value type");
+      oldOp->emitError("unsupported constant type");
   }
 
+  // Add operation data type. Currently we only support integer or index types.
+  // The emitted type aligns with the getFIRRTLType() method. Thus all integers
+  // other than signed integers will be emitted as unsigned.
+  auto type = getHandshakeDataType(oldOp);
+  if (type.isIntOrIndex()) {
+    if (auto indexType = type.dyn_cast<IndexType>())
+      subModuleName +=
+          "_ui" + std::to_string(indexType.kInternalStorageBitWidth);
+    else if (type.isSignedInteger())
+      subModuleName += "_si" + std::to_string(type.getIntOrFloatBitWidth());
+    else
+      subModuleName += "_ui" + std::to_string(type.getIntOrFloatBitWidth());
+
+  } else if (type.isa<NoneType>()) {
+    auto ctrlAttr = oldOp->getAttrOfType<BoolAttr>("control");
+    if (ctrlAttr.getValue())
+      subModuleName += "_ctrl";
+    else
+      oldOp->emitError("non-control component has invalid data type");
+  } else
+    oldOp->emitError("unsupported data type");
+
+  // Add memory ID.
+  if (auto memOp = dyn_cast<handshake::MemoryOp>(oldOp))
+    subModuleName += "_id" + std::to_string(memOp.id());
+
+  // Add compare kind.
   if (auto comOp = dyn_cast<mlir::CmpIOp>(oldOp))
     subModuleName += "_" + stringifyEnum(comOp.getPredicate()).str();
 
+  // Add buffer information.
   if (auto bufferOp = dyn_cast<handshake::BufferOp>(oldOp)) {
     subModuleName += "_" + bufferOp.getNumSlots().toString(10, false) + "slots";
     if (bufferOp.isSequential())
       subModuleName += "_seq";
-  }
-
-  if (auto ctrlAttr = oldOp->getAttr("control")) {
-    if (ctrlAttr.cast<BoolAttr>().getValue())
-      subModuleName += "_ctrl";
   }
 
   return subModuleName;

--- a/test/Conversion/HandshakeToFIRRTL/simple_addi.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/simple_addi.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
 
-// CHECK-LABEL: firrtl.module @std_addi_2ins_1outs(
+// CHECK-LABEL: firrtl.module @std_addi_2ins_1outs_ui64(
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) {
 // CHECK:   %0 = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %1 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.flip<uint<1>>
@@ -25,7 +25,7 @@
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg4: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
 handshake.func @simple_addi(%arg0: index, %arg1: index, %arg2: none, ...) -> (index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @std_addi_2ins_1outs {name = "", portNames = ["arg0", "arg1", "arg2"]} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @std_addi_2ins_1outs_ui64 {name = "", portNames = ["arg0", "arg1", "arg2"]} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
   // CHECK: firrtl.connect %inst_arg0, %arg0 : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
   // CHECK: firrtl.connect %inst_arg1, %arg1 : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
   %0 = addi %arg0, %arg1 : index

--- a/test/Conversion/HandshakeToFIRRTL/test_branch.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_branch.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
 
-// CHECK-LABEL: firrtl.module @handshake_branch_1ins_1outs(
+// CHECK-LABEL: firrtl.module @handshake_branch_1ins_1outs_ui64(
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) {
 // CHECK:   %0 = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %1 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.flip<uint<1>>
@@ -17,7 +17,7 @@
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
 handshake.func @test_branch(%arg0: index, %arg1: none, ...) -> (index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1 = firrtl.instance @handshake_branch_1ins_1outs {name = "", portNames = ["arg0", "arg1"]} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+  // CHECK: %inst_arg0, %inst_arg1 = firrtl.instance @handshake_branch_1ins_1outs_ui64 {name = "", portNames = ["arg0", "arg1"]} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
   %0 = "handshake.branch"(%arg0) {control = false}: (index) -> index
   handshake.return %0, %arg1 : index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
@@ -1,13 +1,13 @@
 // RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
 
-// CHECK-LABEL: firrtl.module @handshake_buffer_1ins_1outs_2slots_seq(
+// CHECK-LABEL: firrtl.module @handshake_buffer_1ins_1outs_ui64_2slots_seq(
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
 
 // CHECK-LABEL: firrtl.module @test_buffer(
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
 handshake.func @test_buffer(%arg0: index, %arg1: none, ...) -> (index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_clock, %inst_reset = firrtl.instance @handshake_buffer_1ins_1outs_2slots_seq {name = "", portNames = ["arg0", "arg1", "clock", "reset"]} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.flip<clock>, !firrtl.flip<uint<1>>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_clock, %inst_reset = firrtl.instance @handshake_buffer_1ins_1outs_ui64_2slots_seq {name = "", portNames = ["arg0", "arg1", "clock", "reset"]} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.flip<clock>, !firrtl.flip<uint<1>>
   // CHECK: firrtl.connect %inst_clock, %clock : !firrtl.flip<clock>, !firrtl.clock
   // CHECK: firrtl.connect %inst_reset, %reset : !firrtl.flip<uint<1>>, !firrtl.uint<1>  
   %0 = "handshake.buffer"(%arg0) {control = false, sequential = true, slots = 2 : i32} : (index) -> index

--- a/test/Conversion/HandshakeToFIRRTL/test_conditional_branch.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_conditional_branch.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
 
-// CHECK-LABEL: firrtl.module @handshake_conditional_branch_2ins_2outs(
+// CHECK-LABEL: firrtl.module @handshake_conditional_branch_2ins_2outs_ui64(
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<1>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) {
 // CHECK:   %0 = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<1>>) -> !firrtl.uint<1>
 // CHECK:   %1 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<1>>) -> !firrtl.flip<uint<1>>
@@ -32,7 +32,7 @@
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<1>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg4: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg5: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
 handshake.func @test_conditional_branch(%arg0: i1, %arg1: index, %arg2: none, ...) -> (index, index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_arg3 = firrtl.instance @handshake_conditional_branch_2ins_2outs {name = "", portNames = ["arg0", "arg1", "arg2", "arg3"]} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<1>>>, !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_arg3 = firrtl.instance @handshake_conditional_branch_2ins_2outs_ui64 {name = "", portNames = ["arg0", "arg1", "arg2", "arg3"]} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<1>>>, !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
   %0:2 = "handshake.conditional_branch"(%arg0, %arg1) {control = false}: (i1, index) -> (index, index)
   handshake.return %0#0, %0#1, %arg2 : index, index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_constant.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_constant.mlir
@@ -1,40 +1,44 @@
 // RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
 
-// CHECK-LABEL: firrtl.module @handshake_lazy_fork_1ins_2outs_ctrl(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>) {
-// CHECK:   %0 = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
-// CHECK:   %1 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %2 = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %3 = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>) -> !firrtl.uint<1>
-// CHECK:   %4 = firrtl.subfield %arg2("valid") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %5 = firrtl.subfield %arg2("ready") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>) -> !firrtl.uint<1>
-// CHECK:   %6 = firrtl.and %5, %3 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %1, %6 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// CHECK:   %7 = firrtl.and %0, %6 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %2, %7 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// CHECK:   firrtl.connect %4, %7 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// Submodule for the index and i64 ConstantOps as they have the same value and converted type.
+// CHECK-LABEL: firrtl.module @handshake_constant_1ins_1outs_c42_ui64(
+// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) {
+// CHECK:   %[[ARG0_VALID:.+]] = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
+// CHECK:   %[[ARG0_READY:.+]] = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.flip<uint<1>>
+// CHECK:   %[[ARG1_VALID:.+]] = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<1>>
+// CHECK:   %[[ARG1_READY:.+]] = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.uint<1>
+// CHECK:   %[[ARG1_DATA:.+]] = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
+// CHECK:   firrtl.connect %[[ARG1_VALID:.+]], %[[ARG0_VALID:.+]] : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// CHECK:   firrtl.connect %[[ARG0_READY:.+]], %[[ARG1_READY:.+]] : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// CHECK:   %c42_ui64 = firrtl.constant(42 : ui64) : !firrtl.uint<64>
+// CHECK:   firrtl.connect %[[ARG1_DATA:.+]], %c42_ui64 : !firrtl.flip<uint<64>>, !firrtl.uint<64>
 // CHECK: }
 
-// CHECK: firrtl.module @handshake_constant_1ins_1outs(%arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) {
-// CHECK:   %0 = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
-// CHECK:   %1 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %2 = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %3 = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %4 = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
-// CHECK:   firrtl.connect %2, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// CHECK:   firrtl.connect %1, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// CHECK:   %c42_ui64 = firrtl.constant(42 : ui64) : !firrtl.uint<64>
-// CHECK:   firrtl.connect %4, %c42_ui64 : !firrtl.flip<uint<64>>, !firrtl.uint<64>
-// CHECK: }
+// Submodule for the ui32 ConstantOp.
+// CHECK-LABEL: firrtl.module @handshake_constant_1ins_1outs_c42_ui32(
+// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<32>>>) {
+// CHECK:   %c42_ui32 = firrtl.constant(42 : ui32) : !firrtl.uint<32>
+
+// Submodule for the si32 ConstantOp.
+// CHECK-LABEL: firrtl.module @"handshake_constant_1ins_1outs_c-11_si32"(
+// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<sint<32>>>) {
+// CHECK:   %c-11_si32 = firrtl.constant(-11 : si32) : !firrtl.sint<32>
 
 // CHECK-LABEL: firrtl.module @test_constant(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
-handshake.func @test_constant(%arg0: none, ...) -> (index, none) {
-
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @handshake_lazy_fork_1ins_2outs_ctrl {name = "", portNames = ["arg0", "arg1", "arg2"]} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>
-  %0:2 = "handshake.lazy_fork"(%arg0) {control = true} : (none) -> (none, none)
+// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<32>>>, %arg4: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<sint<32>>>, %arg5: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+handshake.func @test_constant(%arg0: none, ...) -> (index, i64, ui32, si32, none) {
+  %0:5 = "handshake.fork"(%arg0) {control = true} : (none) -> (none, none, none, none, none)
   
-  // CHECK: %inst_arg0_0, %inst_arg1_1 = firrtl.instance @handshake_constant_1ins_1outs {name = "", portNames = ["arg0", "arg1"]} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+  // CHECK: %inst_arg0_0, %inst_arg1_1 = firrtl.instance @handshake_constant_1ins_1outs_c42_ui64 {name = "", portNames = ["arg0", "arg1"]} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
   %1 = "handshake.constant"(%0#0) {value = 42 : index}: (none) -> index
-  handshake.return %1, %0#1 : index, none
+
+  // CHECK: %inst_arg0_2, %inst_arg1_3 = firrtl.instance @handshake_constant_1ins_1outs_c42_ui64 {name = "", portNames = ["arg0", "arg1"]} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+  %2 = "handshake.constant"(%0#1) {value = 42 : i64}: (none) -> i64
+
+  // CHECK: %inst_arg0_4, %inst_arg1_5 = firrtl.instance @handshake_constant_1ins_1outs_c42_ui32 {name = "", portNames = ["arg0", "arg1"]} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<32>>
+  %3 = "handshake.constant"(%0#2) {value = 42 : ui32}: (none) -> ui32
+
+  // CHECK: %inst_arg0_6, %inst_arg1_7 = firrtl.instance @"handshake_constant_1ins_1outs_c-11_si32" {name = "", portNames = ["arg0", "arg1"]} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: sint<32>>
+  %4 = "handshake.constant"(%0#3) {value = -11 : si32}: (none) -> si32
+  handshake.return %1, %2, %3, %4, %0#4 : index, i64, ui32, si32, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_fork.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_fork.mlir
@@ -71,7 +71,7 @@ handshake.func @test_fork(%arg0: none, %arg1: none, ...) -> (none, none, none) {
 
 // -----
 
-// CHECK-LABEL: firrtl.module @handshake_fork_1ins_2outs(
+// CHECK-LABEL: firrtl.module @handshake_fork_1ins_2outs_ui64(
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
 // CHECK:   %[[ARG_DATA:.+]] = firrtl.subfield %arg0("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
 // CHECK:   %[[RES0_DATA:.+]] = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
@@ -84,7 +84,7 @@ handshake.func @test_fork(%arg0: none, %arg1: none, ...) -> (none, none, none) {
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg4: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
 handshake.func @test_fork_data(%arg0: index, %arg1: none, ...) -> (index, index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_clock, %inst_reset = firrtl.instance @handshake_fork_1ins_2outs {name = "", portNames = ["arg0", "arg1", "arg2", "clock", "reset"]} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.flip<clock>, !firrtl.flip<uint<1>>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_clock, %inst_reset = firrtl.instance @handshake_fork_1ins_2outs_ui64 {name = "", portNames = ["arg0", "arg1", "arg2", "clock", "reset"]} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.flip<clock>, !firrtl.flip<uint<1>>
   %0:2 = "handshake.fork"(%arg0) {control = false} : (index) -> (index, index)
   handshake.return %0#0, %0#1, %arg1 : index, index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_lazy_fork.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_lazy_fork.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
 
-// CHECK-LABEL: firrtl.module @handshake_lazy_fork_1ins_2outs(
+// CHECK-LABEL: firrtl.module @handshake_lazy_fork_1ins_2outs_ui64(
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) {
 // CHECK:   %0 = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %1 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.flip<uint<1>>
@@ -24,7 +24,7 @@
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg4: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
 handshake.func @test_lazy_fork(%arg0: index, %arg1: none, ...) -> (index, index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @handshake_lazy_fork_1ins_2outs {name = "", portNames = ["arg0", "arg1", "arg2"]} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @handshake_lazy_fork_1ins_2outs_ui64 {name = "", portNames = ["arg0", "arg1", "arg2"]} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
   %0:2 = "handshake.lazy_fork"(%arg0) {control = false} : (index) -> (index, index)
   handshake.return %0#0, %0#1, %arg1 : index, index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_load.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_load.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt -lower-handshake-to-firrtl -split-input-file -verify-diagnostics %s
 
-// CHECK-LABEL: firrtl.module @handshake_load_3ins_2outs(
+// CHECK-LABEL: firrtl.module @handshake_load_3ins_2outs_ui8(
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<8>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<8>>>, %arg4: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) {
 // CHECK:   %[[IADDR_VALID:.+]] = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %[[IADDR_READY:.+]] = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.flip<uint<1>>
@@ -37,7 +37,7 @@ handshake.func @main(%arg0: index, %arg1: none, ...) -> none {
   %1:2 = "handshake.fork"(%arg1) {control = true} : (none) -> (none, none)
   %2 = "handshake.join"(%1#1, %0#1) {control = true} : (none, none) -> none
 
-  // CHECK: %16 = firrtl.instance @handshake_load_3ins_2outs {name = ""} : !firrtl.bundle<arg0: bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, arg1: bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<8>>>, arg2: bundle<valid: flip<uint<1>>, ready: uint<1>>, arg3: bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<8>>, arg4: bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>
+  // CHECK: %16 = firrtl.instance @handshake_load_3ins_2outs_ui8 {name = ""} : !firrtl.bundle<arg0: bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, arg1: bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<8>>>, arg2: bundle<valid: flip<uint<1>>, ready: uint<1>>, arg3: bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<8>>, arg4: bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>
   %3, %addressResults = "handshake.load"(%arg0, %0#0, %1#0) : (index, i8, none) -> (i8, index)
   "handshake.sink"(%3) : (i8) -> ()
   handshake.return %2 : none

--- a/test/Conversion/HandshakeToFIRRTL/test_memory.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_memory.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt -lower-handshake-to-firrtl -split-input-file %s | FileCheck %s
 
-// CHECK-LABEL: firrtl.module @handshake_memory_3ins_3outs
+// CHECK-LABEL: firrtl.module @handshake_memory_3ins_3outs_ui8
 // CHECK: %[[ST_DATA_VALID:.+]] = firrtl.subfield %arg0("valid")
 // CHECK: %[[ST_DATA_READY:.+]] = firrtl.subfield %arg0("ready")
 // CHECK: %[[ST_DATA_DATA:.+]] = firrtl.subfield %arg0("data")
@@ -103,7 +103,7 @@
 // CHECK-LABEL: firrtl.module @main
 handshake.func @main(%arg0: i8, %arg1: index, %arg2: index, ...) -> (i8, none, none) {
   // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_arg3, %inst_arg4, %inst_arg5, %inst_clock, %inst_reset
-  // CHECK: = firrtl.instance @handshake_memory_3ins_3outs
+  // CHECK: = firrtl.instance @handshake_memory_3ins_3outs_ui8
   %0:3 = "handshake.memory"(%arg0, %arg1, %arg2) {id = 0 : i32, ld_count = 1 : i32, lsq = false, st_count = 1 : i32, type = memref<10xi8>} : (i8, index, index) -> (i8, none, none)
 
   handshake.return %0#0, %0#1, %0#2: i8, none, none

--- a/test/Conversion/HandshakeToFIRRTL/test_merge.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_merge.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
 
-// CHECK-LABEL: firrtl.module @handshake_merge_2ins_1outs(
+// CHECK-LABEL: firrtl.module @handshake_merge_2ins_1outs_ui64(
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) {
 // CHECK:   %[[ARG0_VALID:.+]] = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %[[ARG0_READY:.+]] = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.flip<uint<1>>
@@ -55,7 +55,7 @@
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg4: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
 handshake.func @test_merge(%arg0: index, %arg1: index, %arg2: none, ...) -> (index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @handshake_merge_2ins_1outs {name = "", portNames = ["arg0", "arg1", "arg2"]} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @handshake_merge_2ins_1outs_ui64 {name = "", portNames = ["arg0", "arg1", "arg2"]} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
   %0 = "handshake.merge"(%arg0, %arg1) : (index, index) -> index
   handshake.return %0, %arg2 : index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_mux.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_mux.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt -lower-handshake-to-firrtl -split-input-file %s | FileCheck %s
 
-// CHECK-LABEL: firrtl.module @handshake_mux_3ins_1outs(
+// CHECK-LABEL: firrtl.module @handshake_mux_3ins_1outs_ui64(
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) {
 // CHECK:   %0 = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %1 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.flip<uint<1>>
@@ -37,7 +37,7 @@
 // CHECK: firrtl.module @test_mux(%arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg3: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg4: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg5: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
 handshake.func @test_mux(%arg0: index, %arg1: index, %arg2: index, %arg3: none, ...) -> (index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_arg3 = firrtl.instance @handshake_mux_3ins_1outs {name = "", portNames = ["arg0", "arg1", "arg2", "arg3"]} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_arg3 = firrtl.instance @handshake_mux_3ins_1outs_ui64 {name = "", portNames = ["arg0", "arg1", "arg2", "arg3"]} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
   %0 = "handshake.mux"(%arg0, %arg1, %arg2): (index, index, index) -> index
   handshake.return %0, %arg3 : index, none
 }
@@ -46,7 +46,7 @@ handshake.func @test_mux(%arg0: index, %arg1: index, %arg2: index, %arg3: none, 
 
 // Test a mux tree with an odd number of inputs.
 
-// CHECK-LABEL: firrtl.module @handshake_mux_4ins_1outs
+// CHECK-LABEL: firrtl.module @handshake_mux_4ins_1outs_ui64
 // CHECK: %[[DATA1:.+]] = firrtl.subfield %arg1("data")
 // CHECK: %[[DATA2:.+]] = firrtl.subfield %arg2("data")
 // CHECK: %[[DATA3:.+]] = firrtl.subfield %arg3("data")
@@ -63,7 +63,7 @@ handshake.func @test_mux_3way(%arg0: index, %arg1: index, %arg2: index, %arg3: i
 
 // Test a mux tree with multiple full layers.
 
-// CHECK-LABEL: firrtl.module @handshake_mux_9ins_1outs
+// CHECK-LABEL: firrtl.module @handshake_mux_9ins_1outs_ui64
 // CHECK: %[[DATA1:.+]] = firrtl.subfield %arg1("data")
 // CHECK: %[[DATA2:.+]] = firrtl.subfield %arg2("data")
 // CHECK: %[[DATA3:.+]] = firrtl.subfield %arg3("data")
@@ -90,7 +90,7 @@ handshake.func @test_mux_8way(%arg0: index, %arg1: index, %arg2: index, %arg3: i
 
 // Test a mux tree with multiple layers and a partial first layer (odd).
 
-// CHECK-LABEL: firrtl.module @handshake_mux_6ins_1outs
+// CHECK-LABEL: firrtl.module @handshake_mux_6ins_1outs_ui64
 // CHECK: %[[DATA1:.+]] = firrtl.subfield %arg1("data")
 // CHECK: %[[DATA2:.+]] = firrtl.subfield %arg2("data")
 // CHECK: %[[DATA3:.+]] = firrtl.subfield %arg3("data")
@@ -111,7 +111,7 @@ handshake.func @test_mux_5way(%arg0: index, %arg1: index, %arg2: index, %arg3: i
 
 // Test a mux tree with multiple layers and a partial first layer (even).
 
-// CHECK-LABEL: firrtl.module @handshake_mux_7ins_1outs
+// CHECK-LABEL: firrtl.module @handshake_mux_7ins_1outs_ui64
 // CHECK: %[[DATA1:.+]] = firrtl.subfield %arg1("data")
 // CHECK: %[[DATA2:.+]] = firrtl.subfield %arg2("data")
 // CHECK: %[[DATA3:.+]] = firrtl.subfield %arg3("data")

--- a/test/Conversion/HandshakeToFIRRTL/test_sink.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_sink.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
 
-// CHECK-LABEL: firrtl.module @handshake_sink_1ins_0outs(
+// CHECK-LABEL: firrtl.module @handshake_sink_1ins_0outs_ui64(
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) {
 // CHECK:   %0 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.flip<uint<1>>
 // CHECK:   %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
@@ -11,7 +11,7 @@
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
 handshake.func @test_sink(%arg0: index, %arg2: none, ...) -> (none) {
 
-  // CHECK: %inst_arg0 = firrtl.instance @handshake_sink_1ins_0outs {name = "", portNames = ["arg0"]} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>
+  // CHECK: %inst_arg0 = firrtl.instance @handshake_sink_1ins_0outs_ui64 {name = "", portNames = ["arg0"]} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>
   // CHECK: firrtl.connect %inst_arg0, %arg0 : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
   "handshake.sink"(%arg0) : (index) -> ()
 

--- a/test/Conversion/HandshakeToFIRRTL/test_store.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_store.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt -lower-handshake-to-firrtl -split-input-file %s | FileCheck %s
 
-// CHECK-LABEL: firrtl.module @handshake_store_3ins_2outs
+// CHECK-LABEL: firrtl.module @handshake_store_3ins_2outs_ui8
 // CHECK: %[[IN_DATA_VALID:.+]] = firrtl.subfield %arg0("valid")
 // CHECK: %[[IN_DATA_READY:.+]] = firrtl.subfield %arg0("ready")
 // CHECK: %[[IN_DATA_DATA:.+]] = firrtl.subfield %arg0("data")
@@ -39,7 +39,7 @@
 
 // CHECK-LABEL: firrtl.module @main
 handshake.func @main(%arg0: i8, %arg1: index, %arg2: none, ...) -> (i8, index, none) {
-  // CHECK: {{.+}} = firrtl.instance @handshake_store_3ins_2outs
+  // CHECK: {{.+}} = firrtl.instance @handshake_store_3ins_2outs_ui8
   %0:2 = "handshake.store"(%arg0, %arg1, %arg2) : (i8, index, none) -> (i8, index)
 
   handshake.return %0#0, %0#1, %arg2 : i8, index, none


### PR DESCRIPTION
This patch resolves the issue proposed in #337. The previous sub-module naming rule doesn't distinguish dataflow components with different data types or constant values, which causes the data type mismatch on sub-module interfaces in the generated FIRRTL circuit. @JuanEsco063 The test case you provided works now, please let me know whether the current output has the correct functionality :D