### PR TITLE
[FIRRTL] Add firrtl pass to blackbox memories

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -94,6 +94,9 @@ def MemOp : FIRRTLOp<"mem", [/*MemAlloc*/]> {
       return getPortName(resultNo).getValue();
     }
 
+    /// Return the port type for the specified result number.
+    FIRRTLType getPortType(size_t resultNo);
+
     // Return the result for this instance that corresponds to the specified
     // port name.
     Value getPortNamed(StringRef name) {

--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -24,6 +24,8 @@ namespace firrtl {
 
 std::unique_ptr<mlir::Pass> createLowerFIRRTLTypesPass();
 
+std::unique_ptr<mlir::Pass> createBlackBoxMemoryPass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/FIRRTL/Passes.h.inc"

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -23,4 +23,22 @@ def LowerFIRRTLTypes : Pass<"firrtl-lower-types", "firrtl::FModuleOp"> {
   let constructor = "circt::firrtl::createLowerFIRRTLTypesPass()";
 }
 
+def BlackboxMemory : Pass<"firrtl-blackbox-memory", "firrtl::CircuitOp"> {
+  let summary = "Replace all FIRRTL memories with an external module blackbox.";
+  let description = [{
+    This pass replaces all sequential memory operations with an external module
+    blackbox.  For each memory operation, it creates a FModuleOp which
+    replicates the return types of the memory operation, and replaces the
+    MemoryOp with an instance of the module.  Inside the new module, an
+    instance of an FExtModule blackbox is created.  The blackbox module must
+    use the same parameter naming conventions used by the ReplaceSeqMemories
+    pass in the Scala FIRRTL compiler.
+  }];
+  let constructor = "circt::firrtl::createBlackBoxMemoryPass()";
+  let options = [
+    Option<"emitWrapper", "emit-wrapper", "bool", "true",
+           "Create a wrapper module around the blackbox external module.">
+  ];
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_PASSES_TD

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -865,6 +865,10 @@ StringAttr MemOp::getPortName(size_t resultNo) {
   return portNames()[resultNo].cast<StringAttr>();
 }
 
+FIRRTLType MemOp::getPortType(size_t resultNo) {
+  return results()[resultNo].getType().cast<FIRRTLType>();
+}
+
 Value MemOp::getPortNamed(StringAttr name) {
   auto namesArray = portNames();
   for (size_t i = 0, e = namesArray.size(); i != e; ++i) {

--- a/lib/Dialect/FIRRTL/Transforms/BlackboxMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackboxMemory.cpp
@@ -1,0 +1,476 @@
+//===- BlackboxMemory.cpp - Create modules for memory -----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//===----------------------------------------------------------------------===//
+//
+// Transform memory operations in to instances of external modules for memory
+// generators.
+//
+//===----------------------------------------------------------------------===//
+
+#include "./PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "mlir/IR/OperationSupport.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/Twine.h"
+
+using namespace circt;
+using namespace firrtl;
+
+using MemoryPortList = SmallVectorImpl<std::pair<Identifier, MemOp::PortKind>>;
+using ModulePortList = SmallVectorImpl<ModulePortInfo>;
+
+/// Compute a hash code for a MemOp. This specialized hash ignores the naming of
+/// the memory and ports.
+llvm::hash_code computeHash(MemOp op) {
+  // MemOp attributes
+  llvm::hash_code hash =
+      llvm::hash_combine(op.readLatencyAttr(), op.writeLatencyAttr());
+  hash = llvm::hash_combine(hash, op.depthAttr());
+  hash = llvm::hash_combine(hash, op.ruwAttr());
+
+  // Result Types
+  ArrayRef<Type> resultTypes = op->getResultTypes();
+  switch (resultTypes.size()) {
+  case 0:
+    // We don't need to add anything to the hash.
+    break;
+  case 1:
+    // Add in the result type.
+    hash = llvm::hash_combine(hash, resultTypes.front());
+    break;
+  default:
+    // Use the type buffer as the hash, as we can guarantee it is the same for
+    // any given range of result types. This takes advantage of the fact the
+    // result types >1 are stored in a TupleType and uniqued.
+    hash = llvm::hash_combine(hash, resultTypes.data());
+    break;
+  }
+  return hash;
+}
+
+/// Compare memory operations for equivalence.  Only compares the types of the
+/// memory and not the name or the memory, or the ports.
+static bool isEquivalentTo(MemOp lhs, MemOp rhs) {
+  if (lhs == rhs)
+    return true;
+  // Compare attributes.
+  if (lhs.readLatencyAttr() != rhs.readLatencyAttr())
+    return false;
+  if (lhs.writeLatencyAttr() != rhs.writeLatencyAttr())
+    return false;
+  if (lhs.depthAttr() != rhs.depthAttr())
+    return false;
+  if (lhs.ruwAttr() != rhs.ruwAttr())
+    return false;
+  // Compare result types.  Taken from operation equivalence.
+  ArrayRef<Type> lhsResultTypes = lhs->getResultTypes();
+  ArrayRef<Type> rhsResultTypes = rhs->getResultTypes();
+  if (lhsResultTypes.size() != rhsResultTypes.size())
+    return false;
+  switch (lhsResultTypes.size()) {
+  case 0:
+    break;
+  case 1:
+    // Compare the single result type.
+    if (lhsResultTypes.front() != rhsResultTypes.front())
+      return false;
+    break;
+  default:
+    // Use the type buffer for the comparison, as we can guarantee it is the
+    // same for any given range of result types. This takes advantage of the
+    // fact the result types >1 are stored in a TupleType and uniqued.
+    if (lhsResultTypes.data() != rhsResultTypes.data())
+      return false;
+    break;
+  }
+  return true;
+}
+
+namespace {
+struct MemOpInfo : public llvm::DenseMapInfo<MemOp> {
+  static MemOp getEmptyKey() {
+    auto pointer = llvm::DenseMapInfo<void *>::getEmptyKey();
+    return MemOp::getFromOpaquePointer(pointer);
+  }
+  static MemOp getTombstoneKey() {
+    auto pointer = llvm::DenseMapInfo<void *>::getTombstoneKey();
+    return MemOp::getFromOpaquePointer(pointer);
+  }
+  static unsigned getHashValue(MemOp op) { return computeHash(op); }
+  static bool isEqual(MemOp lhs, MemOp rhs) {
+    if (lhs == rhs)
+      return true;
+    if (lhs == getTombstoneKey() || lhs == getEmptyKey() ||
+        rhs == getTombstoneKey() || rhs == getEmptyKey())
+      return false;
+    return isEquivalentTo(lhs, rhs);
+  }
+};
+} // end anonymous namespace
+
+/// Create an instance of a Module using the module name and the port list.
+static InstanceOp createInstance(OpBuilder builder, Location loc,
+                                 StringRef moduleName,
+                                 const ModulePortList &modulePorts) {
+  // Make a bundle of the inputs and outputs of the specified module.
+  SmallVector<Type, 4> resultTypes;
+  SmallVector<Attribute, 4> resultNames;
+  resultTypes.reserve(modulePorts.size());
+  resultNames.reserve(modulePorts.size());
+  for (auto port : modulePorts) {
+    resultTypes.push_back(FlipType::get(port.type));
+    resultNames.push_back(port.name);
+  }
+
+  return builder.create<InstanceOp>(loc, resultTypes, moduleName,
+                                    builder.getArrayAttr(resultNames),
+                                    StringAttr());
+}
+
+/// Get the portlist for an external module representing a blackbox memory. This
+/// external module must be compatible with the modules which are generated for
+/// `vlsi_mem_gen`, which can be found in the rocketchip project.
+static void
+getBlackboxPortsForMemOp(MemOp op, const MemoryPortList &memPorts,
+                         SmallVectorImpl<ModulePortInfo> &extPorts) {
+  OpBuilder builder(op);
+  unsigned readPorts = 0;
+  unsigned writePorts = 0;
+  unsigned readWritePorts = 0;
+  for (unsigned i = 0; i < memPorts.size(); ++i) {
+    // Calculate the naming prefix to use based on the kind of the port.
+    std::string prefix;
+    switch (memPorts[i].second) {
+    case MemOp::PortKind::Read:
+      prefix = (Twine("R") + Twine(readPorts++) + "_").str();
+      break;
+    case MemOp::PortKind::Write:
+      prefix = (Twine("W") + Twine(writePorts++) + "_").str();
+      break;
+    case MemOp::PortKind::ReadWrite:
+      prefix = (Twine("RW") + Twine(readWritePorts++) + "_").str();
+      break;
+    }
+    // Flatten the bundle representing a memory port, name-mangling and adding
+    // every field in the bundle to the exter module's port list.
+    auto type = op.getResult(i).getType().cast<FIRRTLType>();
+    if (type.isa<FlipType>())
+      type = type.cast<FlipType>().getElementType();
+    for (auto bundleElement : type.cast<BundleType>().getElements()) {
+      auto name = builder.getStringAttr(prefix + bundleElement.name.str());
+      auto type = FlipType::get(bundleElement.type);
+      extPorts.push_back({name, type});
+    }
+  }
+}
+
+/// Create an external module blackbox representing the memory operation.
+/// Returns the port list of the external module.
+static FExtModuleOp
+createBlackboxModuleForMem(MemOp op,
+                           const SmallVectorImpl<ModulePortInfo> &extPorts) {
+
+  OpBuilder builder(op->getContext());
+
+  // The module's name is the name of the memory postfixed with "_ext".
+  StringRef memName = "mem";
+  if (op.name().hasValue())
+    memName = op.name().getValue();
+  std::string extName = memName.str() + "_ext";
+
+  // Create the blackbox external module.
+  auto extModuleOp = builder.create<FExtModuleOp>(
+      op.getLoc(), builder.getStringAttr(extName), extPorts);
+
+  // Insert the external module into the circuit.  This will rename the
+  // external module if there is a conflict with another module name.
+  auto circuitOp = op->getParentOfType<CircuitOp>();
+  SymbolTable symbolTable(circuitOp);
+  symbolTable.insert(extModuleOp);
+
+  // Move the external module to the beginning of the circuitOp.  Inserting into
+  // the symbol table may have moved the operation to the end of the circuit.
+  extModuleOp->moveBefore(&circuitOp.front());
+
+  // Add the memory parameters as attributes on the external module.  These will
+  // be used by the generator tools to create memory configuration files, or
+  // create the memory itself.  We use a named attr list to avoid creating lots
+  // of intermediate dictionary attributes.
+  NamedAttrList attrs(extModuleOp->getAttrDictionary());
+  attrs.set("generator", builder.getStringAttr("FIRRTLMemory"));
+  attrs.set("readLatency", op.readLatencyAttr());
+  attrs.set("writeLatency", op.writeLatencyAttr());
+  attrs.set("depth", op.depthAttr());
+  attrs.set("ruw", op.ruwAttr());
+  extModuleOp->setAttrs(attrs.getDictionary(builder.getContext()));
+
+  return extModuleOp;
+}
+
+/// Create a regular module to wrap the external module.  The wrapper module
+/// instantiates the external module, and connects all the inputs and outputs
+/// together. This module will match the bundle return type of the memory op,
+/// and connects to the flattened parameters of the external module. This is
+/// done for compatibility with the Scala FIRRTL compiler and it is unclear if
+/// this will be needed in the long run.
+static FModuleOp
+createWrapperModule(MemOp op, const MemoryPortList &memPorts,
+                    FExtModuleOp extModuleOp,
+                    const SmallVectorImpl<ModulePortInfo> &extPorts,
+                    SmallVectorImpl<ModulePortInfo> &modPorts) {
+  OpBuilder builder(op->getContext());
+
+  // Get the name of the memory.  The wrapper module name matched the external
+  // module, but without the "_ext" name.  In the event of a name collision,
+  // matches the memory name over the blackbox name.
+  StringRef memName = "mem";
+  if (op.name().hasValue())
+    memName = op.name().getValue();
+
+  // Create a wrapper module with the same type as the memory
+  modPorts.reserve(op.getResults().size());
+  for (unsigned i = 0; i < memPorts.size(); ++i) {
+    auto name = op.getPortName(i);
+    auto type = FlipType::get(op.getPortType(i));
+    modPorts.push_back({name, type});
+  }
+  auto moduleOp = builder.create<FModuleOp>(
+      op.getLoc(), builder.getStringAttr(memName), modPorts);
+
+  // Insert the externaml module into the circuit.  This will rename the module
+  // if there is a conflict with another module name.
+  auto circuitOp = op->getParentOfType<CircuitOp>();
+  SymbolTable symbolTable(circuitOp);
+  symbolTable.insert(moduleOp);
+
+  // Move the module right after the external module, for readability purposes.
+  moduleOp->moveAfter(extModuleOp);
+
+  // Create the module
+  builder.setInsertionPointToStart(moduleOp.getBodyBlock());
+  auto instanceOp =
+      createInstance(builder, op.getLoc(), extModuleOp.getName(), extPorts);
+
+  // Connect the ports between the memory module and the instance of the black
+  // box memory module. The outer module has a single bundle representing each
+  // Memory port, while the inner module has a separate field for each memory
+  // port bundle in the memory bundle.
+  auto extResultIt = instanceOp.result_begin();
+  for (auto memPort : moduleOp.getArguments()) {
+    auto memPortType = memPort.getType().cast<FIRRTLType>();
+    for (auto field :
+         memPortType.getPassiveType().cast<BundleType>().getElements()) {
+
+      auto fieldType =
+          SubfieldOp::getResultType(memPortType, field.name, op.getLoc());
+      auto fieldValue = builder.create<SubfieldOp>(
+          op.getLoc(), fieldType, memPort, builder.getStringAttr(field.name));
+      // Create the connection between module arguments and the external module,
+      // making sure that sinks are on the LHS
+      if (fieldValue.getType().cast<FIRRTLType>().isPassive())
+        builder.create<ConnectOp>(op.getLoc(), *extResultIt, fieldValue);
+      else
+        builder.create<ConnectOp>(op.getLoc(), fieldValue, *extResultIt);
+      // advance the external module field iterator
+      ++extResultIt;
+    }
+  }
+
+  return moduleOp;
+}
+
+/// Create a bundle wire for each memory port.  This takes all the individual
+/// fields returned from instantiating the external module, and wraps them in to
+/// bundles to match the memory return type.
+static void
+createWiresForMemoryPorts(OpBuilder builder, Location loc, MemOp op,
+                          InstanceOp instanceOp,
+                          const SmallVectorImpl<ModulePortInfo> &extPorts,
+                          SmallVectorImpl<Value> &results) {
+
+  auto extResultIt = instanceOp.result_begin();
+
+  for (auto memPort : op.getResults()) {
+    // Create  a wire bundle for each memory port
+    auto wireOp = builder.create<WireOp>(loc, memPort.getType());
+    results.push_back(wireOp.getResult());
+
+    // Connect each wire to the corresponding ports in the external module
+    auto wireBundle = memPort.getType().cast<FIRRTLType>();
+    if (wireBundle.isa<FlipType>())
+      wireBundle = wireBundle.cast<FlipType>().getElementType();
+    for (auto field : wireBundle.cast<BundleType>().getElements()) {
+      auto fieldType =
+          SubfieldOp::getResultType(wireOp.getType(), field.name, op.getLoc());
+      auto fieldValue = builder.create<SubfieldOp>(
+          op.getLoc(), fieldType, wireOp, builder.getStringAttr(field.name));
+      // Create the connection between module arguments and the external module,
+      // making sure that sinks are on the LHS
+      if (fieldValue.getType().cast<FIRRTLType>().isPassive())
+        builder.create<ConnectOp>(op.getLoc(), *extResultIt, fieldValue);
+      else
+        builder.create<ConnectOp>(op.getLoc(), fieldValue, *extResultIt);
+      // advance the external module field iterator
+      ++extResultIt;
+    }
+  }
+}
+
+static void
+replaceMemWithWrapperModule(DenseMap<MemOp, FModuleOp, MemOpInfo> &knownMems,
+                            MemOp memOp) {
+
+  // The module we will be replacing the MemOp with.  If we don't have a
+  // suitable memory module already created, a new one representing the memory
+  // will be created.
+  FModuleOp moduleOp;
+  SmallVector<ModulePortInfo, 2> modPorts;
+
+  // Check if we have already created a suitable wrapper module. If we have not
+  // seen a similar memory, create a new wrapper module.
+  auto it = knownMems.find(memOp);
+  auto found = it != knownMems.end();
+  if (found) {
+    // Create an instance of the wrapping module.  We have to retrieve the
+    // module port information back from the module.
+    moduleOp = it->second;
+    getModulePortInfo(moduleOp, modPorts);
+  } else {
+    // Get the memory port descriptors. This gives us the name and kind of each
+    // memory port created by the MemOp.
+    SmallVector<std::pair<Identifier, MemOp::PortKind>, 2> memPorts;
+    memOp.getPorts(memPorts);
+
+    // Get the portlist for a module which represents the blackbox memory.
+    // Typically has 1R + 1W memory port, which has 4+5=9 fields.
+    SmallVector<ModulePortInfo, 9> extPortList;
+    getBlackboxPortsForMemOp(memOp, memPorts, extPortList);
+    auto extModuleOp = createBlackboxModuleForMem(memOp, extPortList);
+    moduleOp = createWrapperModule(memOp, memPorts, extModuleOp, extPortList,
+                                   modPorts);
+    knownMems[memOp] = moduleOp;
+  }
+
+  // Create an instance of the wrapping module
+  auto instanceOp = createInstance(OpBuilder(memOp), memOp.getLoc(),
+                                   moduleOp.getName(), modPorts);
+
+  // Replace the memory operation with the module instance
+  memOp.replaceAllUsesWith(instanceOp.getResults());
+
+  // If we are using the memory operation as a key in the map, we cannot delete
+  // it yet.
+  if (found)
+    memOp->erase();
+}
+
+static void
+replaceMemsWithWrapperModules(CircuitOp circuit,
+                              function_ref<bool(MemOp)> shouldReplace) {
+  /// A set of replaced memory operations.  When two memory operations
+  /// share the same types, they can share the same modules.
+  DenseMap<MemOp, FModuleOp, MemOpInfo> knownMems;
+  for (auto fmodule : circuit.getOps<FModuleOp>()) {
+    for (auto memOp : llvm::make_early_inc_range(fmodule.getOps<MemOp>())) {
+      if (shouldReplace(memOp)) {
+        replaceMemWithWrapperModule(knownMems, memOp);
+      }
+    }
+  }
+  // Erase any of the remaining memory operations.  These were kept around
+  // to check if other memory operations were equivalent.
+  for (auto it : knownMems)
+    it.first.erase();
+}
+
+static void
+replaceMemWithExtModule(DenseMap<MemOp, FExtModuleOp, MemOpInfo> &knownMems,
+                        MemOp memOp) {
+
+  FExtModuleOp extModuleOp;
+  SmallVector<ModulePortInfo, 9> extPortList;
+
+  auto it = knownMems.find(memOp);
+  auto found = it != knownMems.end();
+  if (found) {
+    // Create an instance of the wrapping module.  We have to retrieve the
+    // module port information back from the module.
+    extModuleOp = it->second;
+    getModulePortInfo(extModuleOp, extPortList);
+  } else {
+    // Get the memory port descriptors.  This gives us the name and kind of each
+    // memory port created by the MemOp.
+    SmallVector<std::pair<Identifier, MemOp::PortKind>, 2> memPorts;
+    memOp.getPorts(memPorts);
+
+    // Get the portlist for a module which represents the blackbox memory.
+    // Typically has 1R + 1W memory port, which has 4+5=9 fields.
+    getBlackboxPortsForMemOp(memOp, memPorts, extPortList);
+    extModuleOp = createBlackboxModuleForMem(memOp, extPortList);
+    knownMems[memOp] = extModuleOp;
+  }
+
+  OpBuilder builder(memOp);
+
+  // Create an instance of the black box module
+  auto instanceOp = createInstance(builder, memOp.getLoc(),
+                                   extModuleOp.getName(), extPortList);
+
+  // Create a wire for every memory port
+  SmallVector<Value, 2> results;
+  results.reserve(memOp.getNumResults());
+  createWiresForMemoryPorts(builder, memOp.getLoc(), memOp, instanceOp,
+                            extPortList, results);
+
+  // Replace each memory port with a wire
+  memOp.replaceAllUsesWith(results);
+
+  // If we are using the memory operation as a key in the map, we cannot delete
+  // it yet.
+  if (found)
+    memOp->erase();
+}
+
+static void replaceMemsWithExtModules(CircuitOp circuit,
+                                      function_ref<bool(MemOp)> shouldReplace) {
+  /// A set of replaced memory operations.  When two memory operations
+  /// share the same types, they can share the same modules.
+  DenseMap<MemOp, FExtModuleOp, MemOpInfo> knownMems;
+  for (auto fmodule : circuit.getOps<FModuleOp>()) {
+    for (auto memOp : llvm::make_early_inc_range(fmodule.getOps<MemOp>())) {
+      if (shouldReplace(memOp)) {
+        replaceMemWithExtModule(knownMems, memOp);
+      }
+    }
+  }
+  // Erase any of the remaining memory operations.  These were kept around
+  // to check if other memory operations were equivalent.
+  for (auto op : knownMems)
+    op.first.erase();
+}
+
+namespace {
+struct BlackboxMemoryPass : public BlackboxMemoryBase<BlackboxMemoryPass> {
+  void runOnOperation() override {
+    // A memory must have read and write latencies of 1 in order to be
+    // blackboxed. In the future this will probably be configurable.
+    auto shouldReplace = [](MemOp memOp) -> bool {
+      return memOp.readLatency() == 1 && memOp.writeLatency() == 1;
+    };
+    if (emitWrapper)
+      replaceMemsWithWrapperModules(getOperation(), shouldReplace);
+    else
+      replaceMemsWithExtModules(getOperation(), shouldReplace);
+  }
+};
+} // end anonymous namespace
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createBlackBoxMemoryPass() {
+  return std::make_unique<BlackboxMemoryPass>();
+}

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_circt_dialect_library(CIRCTFIRRTLTransforms
+  BlackboxMemory.cpp
   LowerTypes.cpp
 
   DEPENDS

--- a/test/Dialect/FIRRTL/blackbox-memory.mlir
+++ b/test/Dialect/FIRRTL/blackbox-memory.mlir
@@ -1,0 +1,475 @@
+// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-blackbox-memory{emit-wrapper=true})' %s | FileCheck --check-prefix=WRAPPER %s
+// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-blackbox-memory{emit-wrapper=false})' %s | FileCheck --check-prefix=INLINE %s
+
+firrtl.circuit "Read" {
+  firrtl.module @Read() {
+    %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
+    %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
+
+    %0 = firrtl.mem Undefined {depth = 16 : i64, name = "ReadMemory", portNames = ["read0"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+
+    %1 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.sint<8>
+    %2 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
+    firrtl.connect %2, %c0_ui1 : !firrtl.flip<uint<4>>, !firrtl.uint<1>
+    %3 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<1>>
+    firrtl.connect %3, %c1_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+    %4 = firrtl.subfield %0("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<clock>
+  }
+}
+
+// WRAPPER-LABEL: firrtl.circuit "Read" {
+// WRAPPER-NEXT:   firrtl.extmodule @ReadMemory_ext(!firrtl.uint<4> {firrtl.name = "R0_addr"}, !firrtl.uint<1> {firrtl.name = "R0_en"}, !firrtl.clock {firrtl.name = "R0_clk"}, !firrtl.flip<sint<8>> {firrtl.name = "R0_data"}) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// WRAPPER-NEXT:   firrtl.module @ReadMemory(%read0: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) {
+// WRAPPER-NEXT:     %inst_R0_addr, %inst_R0_en, %inst_R0_clk, %inst_R0_data = firrtl.instance @ReadMemory_ext {portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
+// WRAPPER-NEXT:     %0 = firrtl.subfield %read0("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.uint<4>
+// WRAPPER-NEXT:     firrtl.connect %inst_R0_addr, %0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+// WRAPPER-NEXT:     %1 = firrtl.subfield %read0("en") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %inst_R0_en, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %2 = firrtl.subfield %read0("clk") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.clock
+// WRAPPER-NEXT:     firrtl.connect %inst_R0_clk, %2 : !firrtl.flip<clock>, !firrtl.clock
+// WRAPPER-NEXT:     %3 = firrtl.subfield %read0("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.flip<sint<8>>
+// WRAPPER-NEXT:     firrtl.connect %3, %inst_R0_data : !firrtl.flip<sint<8>>, !firrtl.sint<8>
+// WRAPPER-NEXT:   }
+// WRAPPER-NEXT:   firrtl.module @Read() {
+// WRAPPER-NEXT:     %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
+// WRAPPER-NEXT:     %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
+// WRAPPER-NEXT:     %inst_read0 = firrtl.instance @ReadMemory {portNames = ["read0"]} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+// WRAPPER-NEXT:     %0 = firrtl.subfield %inst_read0("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.sint<8>
+// WRAPPER-NEXT:     %1 = firrtl.subfield %inst_read0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
+// WRAPPER-NEXT:     firrtl.connect %1, %c0_ui1 : !firrtl.flip<uint<4>>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %2 = firrtl.subfield %inst_read0("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<1>>
+// WRAPPER-NEXT:     firrtl.connect %2, %c1_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %3 = firrtl.subfield %inst_read0("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<clock>
+// WRAPPER-NEXT:   }
+// WRAPPER-NEXT: }
+
+// INLINE-LABEL: firrtl.circuit "Read" {
+// INLINE-NEXT:   firrtl.extmodule @ReadMemory_ext(!firrtl.uint<4> {firrtl.name = "R0_addr"}, !firrtl.uint<1> {firrtl.name = "R0_en"}, !firrtl.clock {firrtl.name = "R0_clk"}, !firrtl.flip<sint<8>> {firrtl.name = "R0_data"}) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// INLINE-NEXT:   firrtl.module @Read() {
+// INLINE-NEXT:     %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
+// INLINE-NEXT:     %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
+// INLINE-NEXT:     %inst_R0_addr, %inst_R0_en, %inst_R0_clk, %inst_R0_data = firrtl.instance @ReadMemory_ext {portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
+// INLINE-NEXT:     %0 = firrtl.wire  {name = ""} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+// INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
+// INLINE-NEXT:     firrtl.connect %1, %inst_R0_addr : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
+// INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %2, %inst_R0_en : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
+// INLINE-NEXT:     %3 = firrtl.subfield %0("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<clock>
+// INLINE-NEXT:     firrtl.connect %3, %inst_R0_clk : !firrtl.flip<clock>, !firrtl.flip<clock>
+// INLINE-NEXT:     %4 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.sint<8>
+// INLINE-NEXT:     firrtl.connect %inst_R0_data, %4 : !firrtl.sint<8>, !firrtl.sint<8>
+// INLINE-NEXT:     %5 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.sint<8>
+// INLINE-NEXT:     %6 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
+// INLINE-NEXT:     firrtl.connect %6, %c0_ui1 : !firrtl.flip<uint<4>>, !firrtl.uint<1>
+// INLINE-NEXT:     %7 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %7, %c1_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %8 = firrtl.subfield %0("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<clock>
+// INLINE-NEXT:   }
+// INLINE-NEXT: }
+
+firrtl.circuit "Write" {
+  firrtl.module @Write() {
+    %0 = firrtl.mem Undefined {depth = 1 : i64, name = "WriteMemory", portNames = ["write0"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
+  }
+}
+
+// WRAPPER-LABEL: firrtl.circuit "Write" {
+// WRAPPER-NEXT:   firrtl.extmodule @WriteMemory_ext(!firrtl.flip<uint<1>> {firrtl.name = "W0_addr"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_en"}, !firrtl.flip<clock> {firrtl.name = "W0_clk"}, !firrtl.flip<sint<8>> {firrtl.name = "W0_data"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_mask"}) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// WRAPPER-NEXT:   firrtl.module @WriteMemory(%write0: !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) {
+// WRAPPER-NEXT:     %inst_W0_addr, %inst_W0_en, %inst_W0_clk, %inst_W0_data, %inst_W0_mask = firrtl.instance @WriteMemory_ext {portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %0 = firrtl.subfield %write0("addr") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %inst_W0_addr, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %1 = firrtl.subfield %write0("en") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %inst_W0_en, %1 : !firrtl.uint<1>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %2 = firrtl.subfield %write0("clk") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.clock
+// WRAPPER-NEXT:     firrtl.connect %inst_W0_clk, %2 : !firrtl.clock, !firrtl.clock
+// WRAPPER-NEXT:     %3 = firrtl.subfield %write0("data") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.sint<8>
+// WRAPPER-NEXT:     firrtl.connect %inst_W0_data, %3 : !firrtl.sint<8>, !firrtl.sint<8>
+// WRAPPER-NEXT:     %4 = firrtl.subfield %write0("mask") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %inst_W0_mask, %4 : !firrtl.uint<1>, !firrtl.uint<1>
+// WRAPPER-NEXT:   }
+// WRAPPER-NEXT:   firrtl.module @Write() {
+// WRAPPER-NEXT:     %inst_write0 = firrtl.instance @WriteMemory {portNames = ["write0"]} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
+// WRAPPER-NEXT:   }
+// WRAPPER-NEXT: }
+
+// INLINE-LABEL: firrtl.circuit "Write" {
+// INLINE-NEXT:   firrtl.extmodule @WriteMemory_ext(!firrtl.flip<uint<1>> {firrtl.name = "W0_addr"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_en"}, !firrtl.flip<clock> {firrtl.name = "W0_clk"}, !firrtl.flip<sint<8>> {firrtl.name = "W0_data"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_mask"}) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// INLINE-NEXT:   firrtl.module @Write() {
+// INLINE-NEXT:     %inst_W0_addr, %inst_W0_en, %inst_W0_clk, %inst_W0_data, %inst_W0_mask = firrtl.instance @WriteMemory_ext {portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// INLINE-NEXT:     %0 = firrtl.wire  {name = ""} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
+// INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %1, %inst_W0_addr : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %2, %inst_W0_en : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %3 = firrtl.subfield %0("clk") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<clock>
+// INLINE-NEXT:     firrtl.connect %3, %inst_W0_clk : !firrtl.flip<clock>, !firrtl.clock
+// INLINE-NEXT:     %4 = firrtl.subfield %0("data") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<sint<8>>
+// INLINE-NEXT:     firrtl.connect %4, %inst_W0_data : !firrtl.flip<sint<8>>, !firrtl.sint<8>
+// INLINE-NEXT:     %5 = firrtl.subfield %0("mask") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %5, %inst_W0_mask : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:   }
+// INLINE-NEXT: }
+
+// generated from:
+// circuit MemSimple :
+//     module MemSimple :
+//        input clock1  : Clock
+//        input clock2  : Clock
+//        input inpred  : UInt<1>
+//        input indata  : SInt<42>
+//        output result : SInt<42>
+// 
+//        mem _M : @[Decoupled.scala 209:27]
+//              data-type => SInt<42>
+//              depth => 12
+//              read-latency => 0
+//              write-latency => 1
+//              reader => read
+//              writer => write
+//              read-under-write => undefined
+// 
+//        result <= _M.read.data
+// 
+//        _M.read.addr <= UInt<1>("h0")
+//        _M.read.en <= UInt<1>("h1")
+//        _M.read.clk <= clock1
+//        _M.write.addr <= validif(inpred, UInt<3>("h0"))
+//        _M.write.en <= mux(inpred, UInt<1>("h1"), UInt<1>("h0"))
+//        _M.write.clk <= validif(inpred, clock2)
+//        _M.write.data <= validif(inpred, indata)
+//        _M.write.mask <= validif(inpred, UInt<1>("h1"))
+
+firrtl.circuit "MemSimple" {
+  firrtl.module @MemSimple(%clock1: !firrtl.clock, %clock2: !firrtl.clock, %inpred: !firrtl.uint<1>, %indata: !firrtl.sint<42>, %result: !firrtl.flip<sint<42>>) {
+    %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
+    %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
+    %c0_ui3 = firrtl.constant(0 : ui3) : !firrtl.uint<3>
+    %_M_read, %_M_write = firrtl.mem Undefined {depth = 12 : i64, name = "_M", portNames = ["read", "write"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>
+    %0 = firrtl.subfield %_M_read("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.sint<42>
+    firrtl.connect %result, %0 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
+    %1 = firrtl.subfield %_M_read("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<4>>
+    firrtl.connect %1, %c0_ui1 : !firrtl.flip<uint<4>>, !firrtl.uint<1>
+    %2 = firrtl.subfield %_M_read("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<1>>
+    firrtl.connect %2, %c1_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+    %3 = firrtl.subfield %_M_read("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<clock>
+    firrtl.connect %3, %clock1 : !firrtl.flip<clock>, !firrtl.clock
+    %4 = firrtl.subfield %_M_write("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<4>>
+    %5 = firrtl.validif %inpred, %c0_ui3 : (!firrtl.uint<1>, !firrtl.uint<3>) -> !firrtl.uint<3>
+    firrtl.connect %4, %5 : !firrtl.flip<uint<4>>, !firrtl.uint<3>
+    %6 = firrtl.subfield %_M_write("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+    firrtl.connect %6, %inpred : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+    %7 = firrtl.subfield %_M_write("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<clock>
+    %8 = firrtl.validif %inpred, %clock2 : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.clock
+    firrtl.connect %7, %8 : !firrtl.flip<clock>, !firrtl.clock
+    %9 = firrtl.subfield %_M_write("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<sint<42>>
+    %10 = firrtl.validif %inpred, %indata : (!firrtl.uint<1>, !firrtl.sint<42>) -> !firrtl.sint<42>
+    firrtl.connect %9, %10 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
+    %11 = firrtl.subfield %_M_write("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+    %12 = firrtl.validif %inpred, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    firrtl.connect %11, %12 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  }
+}
+
+// WRAPPER-LABEL: firrtl.circuit "MemSimple" {
+// WRAPPER-NEXT:   firrtl.extmodule @_M_ext(!firrtl.uint<4> {firrtl.name = "R0_addr"}, !firrtl.uint<1> {firrtl.name = "R0_en"}, !firrtl.clock {firrtl.name = "R0_clk"}, !firrtl.flip<sint<42>> {firrtl.name = "R0_data"}, !firrtl.flip<uint<4>> {firrtl.name = "W0_addr"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_en"}, !firrtl.flip<clock> {firrtl.name = "W0_clk"}, !firrtl.flip<sint<42>> {firrtl.name = "W0_data"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_mask"}) attributes {depth = 12 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// WRAPPER-NEXT:   firrtl.module @_M(%read: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>, %write: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) {
+// WRAPPER-NEXT:     %inst_R0_addr, %inst_R0_en, %inst_R0_clk, %inst_R0_data, %inst_W0_addr, %inst_W0_en, %inst_W0_clk, %inst_W0_data, %inst_W0_mask = firrtl.instance @_M_ext {portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data", "W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<42>, !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<42>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %0 = firrtl.subfield %read("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>) -> !firrtl.uint<4>
+// WRAPPER-NEXT:     firrtl.connect %inst_R0_addr, %0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+// WRAPPER-NEXT:     %1 = firrtl.subfield %read("en") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>) -> !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %inst_R0_en, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %2 = firrtl.subfield %read("clk") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>) -> !firrtl.clock
+// WRAPPER-NEXT:     firrtl.connect %inst_R0_clk, %2 : !firrtl.flip<clock>, !firrtl.clock
+// WRAPPER-NEXT:     %3 = firrtl.subfield %read("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>) -> !firrtl.flip<sint<42>>
+// WRAPPER-NEXT:     firrtl.connect %3, %inst_R0_data : !firrtl.flip<sint<42>>, !firrtl.sint<42>
+// WRAPPER-NEXT:     %4 = firrtl.subfield %write("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.uint<4>
+// WRAPPER-NEXT:     firrtl.connect %inst_W0_addr, %4 : !firrtl.uint<4>, !firrtl.uint<4>
+// WRAPPER-NEXT:     %5 = firrtl.subfield %write("en") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %inst_W0_en, %5 : !firrtl.uint<1>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %6 = firrtl.subfield %write("clk") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.clock
+// WRAPPER-NEXT:     firrtl.connect %inst_W0_clk, %6 : !firrtl.clock, !firrtl.clock
+// WRAPPER-NEXT:     %7 = firrtl.subfield %write("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.sint<42>
+// WRAPPER-NEXT:     firrtl.connect %inst_W0_data, %7 : !firrtl.sint<42>, !firrtl.sint<42>
+// WRAPPER-NEXT:     %8 = firrtl.subfield %write("mask") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %inst_W0_mask, %8 : !firrtl.uint<1>, !firrtl.uint<1>
+// WRAPPER-NEXT:   }
+// WRAPPER-NEXT:   firrtl.module @MemSimple(%clock1: !firrtl.clock, %clock2: !firrtl.clock, %inpred: !firrtl.uint<1>, %indata: !firrtl.sint<42>, %result: !firrtl.flip<sint<42>>) {
+// WRAPPER-NEXT:     %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
+// WRAPPER-NEXT:     %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
+// WRAPPER-NEXT:     %c0_ui3 = firrtl.constant(0 : ui3) : !firrtl.uint<3>
+// WRAPPER-NEXT:     %inst_read, %inst_write = firrtl.instance @_M {portNames = ["read", "write"]} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>
+// WRAPPER-NEXT:     %0 = firrtl.subfield %inst_read("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.sint<42>
+// WRAPPER-NEXT:     firrtl.connect %result, %0 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
+// WRAPPER-NEXT:     %1 = firrtl.subfield %inst_read("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<4>>
+// WRAPPER-NEXT:     firrtl.connect %1, %c0_ui1 : !firrtl.flip<uint<4>>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %2 = firrtl.subfield %inst_read("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<1>>
+// WRAPPER-NEXT:     firrtl.connect %2, %c1_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %3 = firrtl.subfield %inst_read("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<clock>
+// WRAPPER-NEXT:     firrtl.connect %3, %clock1 : !firrtl.flip<clock>, !firrtl.clock
+// WRAPPER-NEXT:     %4 = firrtl.subfield %inst_write("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<4>>
+// WRAPPER-NEXT:     %5 = firrtl.validif %inpred, %c0_ui3 : (!firrtl.uint<1>, !firrtl.uint<3>) -> !firrtl.uint<3>
+// WRAPPER-NEXT:     firrtl.connect %4, %5 : !firrtl.flip<uint<4>>, !firrtl.uint<3>
+// WRAPPER-NEXT:     %6 = firrtl.subfield %inst_write("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// WRAPPER-NEXT:     firrtl.connect %6, %inpred : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %7 = firrtl.subfield %inst_write("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<clock>
+// WRAPPER-NEXT:     %8 = firrtl.validif %inpred, %clock2 : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.clock
+// WRAPPER-NEXT:     firrtl.connect %7, %8 : !firrtl.flip<clock>, !firrtl.clock
+// WRAPPER-NEXT:     %9 = firrtl.subfield %inst_write("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<sint<42>>
+// WRAPPER-NEXT:     %10 = firrtl.validif %inpred, %indata : (!firrtl.uint<1>, !firrtl.sint<42>) -> !firrtl.sint<42>
+// WRAPPER-NEXT:     firrtl.connect %9, %10 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
+// WRAPPER-NEXT:     %11 = firrtl.subfield %inst_write("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// WRAPPER-NEXT:     %12 = firrtl.validif %inpred, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %11, %12 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// WRAPPER-NEXT:   }
+// WRAPPER-NEXT: }
+
+// INLINE-LABEL: firrtl.circuit "MemSimple" {
+// INLINE-NEXT:   firrtl.extmodule @_M_ext(!firrtl.uint<4> {firrtl.name = "R0_addr"}, !firrtl.uint<1> {firrtl.name = "R0_en"}, !firrtl.clock {firrtl.name = "R0_clk"}, !firrtl.flip<sint<42>> {firrtl.name = "R0_data"}, !firrtl.flip<uint<4>> {firrtl.name = "W0_addr"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_en"}, !firrtl.flip<clock> {firrtl.name = "W0_clk"}, !firrtl.flip<sint<42>> {firrtl.name = "W0_data"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_mask"}) attributes {depth = 12 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// INLINE-NEXT:   firrtl.module @MemSimple(%clock1: !firrtl.clock, %clock2: !firrtl.clock, %inpred: !firrtl.uint<1>, %indata: !firrtl.sint<42>, %result: !firrtl.flip<sint<42>>) {
+// INLINE-NEXT:     %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
+// INLINE-NEXT:     %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
+// INLINE-NEXT:     %c0_ui3 = firrtl.constant(0 : ui3) : !firrtl.uint<3>
+// INLINE-NEXT:     %inst_R0_addr, %inst_R0_en, %inst_R0_clk, %inst_R0_data, %inst_W0_addr, %inst_W0_en, %inst_W0_clk, %inst_W0_data, %inst_W0_mask = firrtl.instance @_M_ext {portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data", "W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<42>, !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<42>, !firrtl.uint<1>
+// INLINE-NEXT:     %0 = firrtl.wire  {name = ""} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>
+// INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<4>>
+// INLINE-NEXT:     firrtl.connect %1, %inst_R0_addr : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
+// INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %2, %inst_R0_en : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
+// INLINE-NEXT:     %3 = firrtl.subfield %0("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<clock>
+// INLINE-NEXT:     firrtl.connect %3, %inst_R0_clk : !firrtl.flip<clock>, !firrtl.flip<clock>
+// INLINE-NEXT:     %4 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.sint<42>
+// INLINE-NEXT:     firrtl.connect %inst_R0_data, %4 : !firrtl.sint<42>, !firrtl.sint<42>
+// INLINE-NEXT:     %5 = firrtl.wire  {name = ""} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>
+// INLINE-NEXT:     %6 = firrtl.subfield %5("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<4>>
+// INLINE-NEXT:     firrtl.connect %6, %inst_W0_addr : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+// INLINE-NEXT:     %7 = firrtl.subfield %5("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %7, %inst_W0_en : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %8 = firrtl.subfield %5("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<clock>
+// INLINE-NEXT:     firrtl.connect %8, %inst_W0_clk : !firrtl.flip<clock>, !firrtl.clock
+// INLINE-NEXT:     %9 = firrtl.subfield %5("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<sint<42>>
+// INLINE-NEXT:     firrtl.connect %9, %inst_W0_data : !firrtl.flip<sint<42>>, !firrtl.sint<42>
+// INLINE-NEXT:     %10 = firrtl.subfield %5("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %10, %inst_W0_mask : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %11 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.sint<42>
+// INLINE-NEXT:     firrtl.connect %result, %11 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
+// INLINE-NEXT:     %12 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<4>>
+// INLINE-NEXT:     firrtl.connect %12, %c0_ui1 : !firrtl.flip<uint<4>>, !firrtl.uint<1>
+// INLINE-NEXT:     %13 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %13, %c1_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %14 = firrtl.subfield %0("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<clock>
+// INLINE-NEXT:     firrtl.connect %14, %clock1 : !firrtl.flip<clock>, !firrtl.clock
+// INLINE-NEXT:     %15 = firrtl.subfield %5("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<4>>
+// INLINE-NEXT:     %16 = firrtl.validif %inpred, %c0_ui3 : (!firrtl.uint<1>, !firrtl.uint<3>) -> !firrtl.uint<3>
+// INLINE-NEXT:     firrtl.connect %15, %16 : !firrtl.flip<uint<4>>, !firrtl.uint<3>
+// INLINE-NEXT:     %17 = firrtl.subfield %5("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %17, %inpred : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %18 = firrtl.subfield %5("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<clock>
+// INLINE-NEXT:     %19 = firrtl.validif %inpred, %clock2 : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.clock
+// INLINE-NEXT:     firrtl.connect %18, %19 : !firrtl.flip<clock>, !firrtl.clock
+// INLINE-NEXT:     %20 = firrtl.subfield %5("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<sint<42>>
+// INLINE-NEXT:     %21 = firrtl.validif %inpred, %indata : (!firrtl.uint<1>, !firrtl.sint<42>) -> !firrtl.sint<42>
+// INLINE-NEXT:     firrtl.connect %20, %21 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
+// INLINE-NEXT:     %22 = firrtl.subfield %5("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     %23 = firrtl.validif %inpred, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %22, %23 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:   }
+// INLINE-NEXT: }
+
+firrtl.circuit "NameCollision" {
+  // Check for name NameCollision with a generated module
+  firrtl.module @NameCollisionMemory_ext() {
+    %0 = firrtl.mem Undefined {depth = 16 : i64, name = "NameCollisionMemory", portNames = ["read0"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+  }
+  firrtl.module @NameCollision() {
+    %0 = firrtl.mem Undefined {depth = 16 : i64, name = "NameCollisionMemory", portNames = ["write0"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
+  }
+}
+
+// WRAPPER-LABEL: firrtl.circuit "NameCollision" {
+// WRAPPER-NEXT:   firrtl.extmodule @NameCollisionMemory_ext_1(!firrtl.flip<uint<4>> {firrtl.name = "W0_addr"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_en"}, !firrtl.flip<clock> {firrtl.name = "W0_clk"}, !firrtl.flip<sint<8>> {firrtl.name = "W0_data"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_mask"}) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// WRAPPER-NEXT:   firrtl.module @NameCollisionMemory_0(%write0: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) {
+// WRAPPER-NEXT:     %inst_W0_addr, %inst_W0_en, %inst_W0_clk, %inst_W0_data, %inst_W0_mask = firrtl.instance @NameCollisionMemory_ext_1 {portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %0 = firrtl.subfield %write0("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<4>
+// WRAPPER-NEXT:     firrtl.connect %inst_W0_addr, %0 : !firrtl.uint<4>, !firrtl.uint<4>
+// WRAPPER-NEXT:     %1 = firrtl.subfield %write0("en") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %inst_W0_en, %1 : !firrtl.uint<1>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %2 = firrtl.subfield %write0("clk") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.clock
+// WRAPPER-NEXT:     firrtl.connect %inst_W0_clk, %2 : !firrtl.clock, !firrtl.clock
+// WRAPPER-NEXT:     %3 = firrtl.subfield %write0("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.sint<8>
+// WRAPPER-NEXT:     firrtl.connect %inst_W0_data, %3 : !firrtl.sint<8>, !firrtl.sint<8>
+// WRAPPER-NEXT:     %4 = firrtl.subfield %write0("mask") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %inst_W0_mask, %4 : !firrtl.uint<1>, !firrtl.uint<1>
+// WRAPPER-NEXT:   }
+// WRAPPER-NEXT:   firrtl.extmodule @NameCollisionMemory_ext_0(!firrtl.uint<4> {firrtl.name = "R0_addr"}, !firrtl.uint<1> {firrtl.name = "R0_en"}, !firrtl.clock {firrtl.name = "R0_clk"}, !firrtl.flip<sint<8>> {firrtl.name = "R0_data"}) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// WRAPPER-NEXT:   firrtl.module @NameCollisionMemory(%read0: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) {
+// WRAPPER-NEXT:     %inst_R0_addr, %inst_R0_en, %inst_R0_clk, %inst_R0_data = firrtl.instance @NameCollisionMemory_ext_0 {portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
+// WRAPPER-NEXT:     %0 = firrtl.subfield %read0("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.uint<4>
+// WRAPPER-NEXT:     firrtl.connect %inst_R0_addr, %0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+// WRAPPER-NEXT:     %1 = firrtl.subfield %read0("en") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %inst_R0_en, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %2 = firrtl.subfield %read0("clk") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.clock
+// WRAPPER-NEXT:     firrtl.connect %inst_R0_clk, %2 : !firrtl.flip<clock>, !firrtl.clock
+// WRAPPER-NEXT:     %3 = firrtl.subfield %read0("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.flip<sint<8>>
+// WRAPPER-NEXT:     firrtl.connect %3, %inst_R0_data : !firrtl.flip<sint<8>>, !firrtl.sint<8>
+// WRAPPER-NEXT:   }
+// WRAPPER-NEXT:   firrtl.module @NameCollisionMemory_ext() {
+// WRAPPER-NEXT:     %inst_read0 = firrtl.instance @NameCollisionMemory {portNames = ["read0"]} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+// WRAPPER-NEXT:   }
+// WRAPPER-NEXT:   firrtl.module @NameCollision() {
+// WRAPPER-NEXT:     %inst_write0 = firrtl.instance @NameCollisionMemory_0 {portNames = ["write0"]} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
+// WRAPPER-NEXT:   }
+// WRAPPER-NEXT: }
+
+// INLINE-LABEL: firrtl.circuit "NameCollision" {
+// INLINE-NEXT:   firrtl.extmodule @NameCollisionMemory_ext_1(!firrtl.flip<uint<4>> {firrtl.name = "W0_addr"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_en"}, !firrtl.flip<clock> {firrtl.name = "W0_clk"}, !firrtl.flip<sint<8>> {firrtl.name = "W0_data"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_mask"}) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// INLINE-NEXT:   firrtl.extmodule @NameCollisionMemory_ext_0(!firrtl.uint<4> {firrtl.name = "R0_addr"}, !firrtl.uint<1> {firrtl.name = "R0_en"}, !firrtl.clock {firrtl.name = "R0_clk"}, !firrtl.flip<sint<8>> {firrtl.name = "R0_data"}) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// INLINE-NEXT:   firrtl.module @NameCollisionMemory_ext() {
+// INLINE-NEXT:     %inst_R0_addr, %inst_R0_en, %inst_R0_clk, %inst_R0_data = firrtl.instance @NameCollisionMemory_ext_0 {portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
+// INLINE-NEXT:     %0 = firrtl.wire  {name = ""} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+// INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
+// INLINE-NEXT:     firrtl.connect %1, %inst_R0_addr : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
+// INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %2, %inst_R0_en : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
+// INLINE-NEXT:     %3 = firrtl.subfield %0("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<clock>
+// INLINE-NEXT:     firrtl.connect %3, %inst_R0_clk : !firrtl.flip<clock>, !firrtl.flip<clock>
+// INLINE-NEXT:     %4 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.sint<8>
+// INLINE-NEXT:     firrtl.connect %inst_R0_data, %4 : !firrtl.sint<8>, !firrtl.sint<8>
+// INLINE-NEXT:   }
+// INLINE-NEXT:   firrtl.module @NameCollision() {
+// INLINE-NEXT:     %inst_W0_addr, %inst_W0_en, %inst_W0_clk, %inst_W0_data, %inst_W0_mask = firrtl.instance @NameCollisionMemory_ext_1 {portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// INLINE-NEXT:     %0 = firrtl.wire  {name = ""} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
+// INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<4>>
+// INLINE-NEXT:     firrtl.connect %1, %inst_W0_addr : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+// INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %2, %inst_W0_en : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %3 = firrtl.subfield %0("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<clock>
+// INLINE-NEXT:     firrtl.connect %3, %inst_W0_clk : !firrtl.flip<clock>, !firrtl.clock
+// INLINE-NEXT:     %4 = firrtl.subfield %0("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<sint<8>>
+// INLINE-NEXT:     firrtl.connect %4, %inst_W0_data : !firrtl.flip<sint<8>>, !firrtl.sint<8>
+// INLINE-NEXT:     %5 = firrtl.subfield %0("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %5, %inst_W0_mask : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:   }
+// INLINE-NEXT: }
+
+
+firrtl.circuit "Duplicate" {
+  firrtl.module @Duplicate() {
+    %r0 = firrtl.mem Undefined {depth = 16 : i64, name = "ReadMemory", portNames = ["read0"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+    %w0 = firrtl.mem Undefined {depth = 1 : i64, name = "WriteMemory", portNames = ["write0"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
+    %r1 = firrtl.mem Undefined {depth = 16 : i64, name = "ReadMemory1", portNames = ["read1"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+    %w1 = firrtl.mem Undefined {depth = 1 : i64, name = "WriteMemory1", portNames = ["write1"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
+    %r2 = firrtl.mem Undefined {depth = 16 : i64, name = "ReadMemory2", portNames = ["read2"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+    %w2 = firrtl.mem Undefined {depth = 1 : i64, name = "WriteMemory2", portNames = ["write2"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
+  }
+}
+
+// WRAPPER-LABEL: firrtl.circuit "Duplicate" {
+// WRAPPER-NEXT:   firrtl.extmodule @WriteMemory_ext(!firrtl.flip<uint<1>> {firrtl.name = "W0_addr"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_en"}, !firrtl.flip<clock> {firrtl.name = "W0_clk"}, !firrtl.flip<sint<8>> {firrtl.name = "W0_data"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_mask"}) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// WRAPPER-NEXT:   firrtl.module @WriteMemory(%write0: !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) {
+// WRAPPER-NEXT:     %inst_W0_addr, %inst_W0_en, %inst_W0_clk, %inst_W0_data, %inst_W0_mask = firrtl.instance @WriteMemory_ext {portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %0 = firrtl.subfield %write0("addr") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %inst_W0_addr, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %1 = firrtl.subfield %write0("en") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %inst_W0_en, %1 : !firrtl.uint<1>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %2 = firrtl.subfield %write0("clk") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.clock
+// WRAPPER-NEXT:     firrtl.connect %inst_W0_clk, %2 : !firrtl.clock, !firrtl.clock
+// WRAPPER-NEXT:     %3 = firrtl.subfield %write0("data") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.sint<8>
+// WRAPPER-NEXT:     firrtl.connect %inst_W0_data, %3 : !firrtl.sint<8>, !firrtl.sint<8>
+// WRAPPER-NEXT:     %4 = firrtl.subfield %write0("mask") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %inst_W0_mask, %4 : !firrtl.uint<1>, !firrtl.uint<1>
+// WRAPPER-NEXT:   }
+// WRAPPER-NEXT:   firrtl.extmodule @ReadMemory_ext(!firrtl.uint<4> {firrtl.name = "R0_addr"}, !firrtl.uint<1> {firrtl.name = "R0_en"}, !firrtl.clock {firrtl.name = "R0_clk"}, !firrtl.flip<sint<8>> {firrtl.name = "R0_data"}) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// WRAPPER-NEXT:   firrtl.module @ReadMemory(%read0: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) {
+// WRAPPER-NEXT:     %inst_R0_addr, %inst_R0_en, %inst_R0_clk, %inst_R0_data = firrtl.instance @ReadMemory_ext {portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
+// WRAPPER-NEXT:     %0 = firrtl.subfield %read0("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.uint<4>
+// WRAPPER-NEXT:     firrtl.connect %inst_R0_addr, %0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+// WRAPPER-NEXT:     %1 = firrtl.subfield %read0("en") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %inst_R0_en, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %2 = firrtl.subfield %read0("clk") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.clock
+// WRAPPER-NEXT:     firrtl.connect %inst_R0_clk, %2 : !firrtl.flip<clock>, !firrtl.clock
+// WRAPPER-NEXT:     %3 = firrtl.subfield %read0("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.flip<sint<8>>
+// WRAPPER-NEXT:     firrtl.connect %3, %inst_R0_data : !firrtl.flip<sint<8>>, !firrtl.sint<8>
+// WRAPPER-NEXT:   }
+// WRAPPER-NEXT:   firrtl.module @Duplicate() {
+// WRAPPER-NEXT:     %inst_read0 = firrtl.instance @ReadMemory {portNames = ["read0"]} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+// WRAPPER-NEXT:     %inst_write0 = firrtl.instance @WriteMemory {portNames = ["write0"]} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
+// WRAPPER-NEXT:     %inst_read0_0 = firrtl.instance @ReadMemory {portNames = ["read0"]} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+// WRAPPER-NEXT:     %inst_write0_1 = firrtl.instance @WriteMemory {portNames = ["write0"]} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
+// WRAPPER-NEXT:     %inst_read0_2 = firrtl.instance @ReadMemory {portNames = ["read0"]} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+// WRAPPER-NEXT:     %inst_write0_3 = firrtl.instance @WriteMemory {portNames = ["write0"]} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
+// WRAPPER-NEXT:   }
+// WRAPPER-NEXT: }
+
+// INLINE-LABEL: firrtl.circuit "Duplicate" {
+// INLINE-NEXT:   firrtl.extmodule @WriteMemory_ext(!firrtl.flip<uint<1>> {firrtl.name = "W0_addr"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_en"}, !firrtl.flip<clock> {firrtl.name = "W0_clk"}, !firrtl.flip<sint<8>> {firrtl.name = "W0_data"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_mask"}) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// INLINE-NEXT:   firrtl.extmodule @ReadMemory_ext(!firrtl.uint<4> {firrtl.name = "R0_addr"}, !firrtl.uint<1> {firrtl.name = "R0_en"}, !firrtl.clock {firrtl.name = "R0_clk"}, !firrtl.flip<sint<8>> {firrtl.name = "R0_data"}) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// INLINE-NEXT:   firrtl.module @Duplicate() {
+// INLINE-NEXT:     %inst_R0_addr, %inst_R0_en, %inst_R0_clk, %inst_R0_data = firrtl.instance @ReadMemory_ext {portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
+// INLINE-NEXT:     %0 = firrtl.wire  {name = ""} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+// INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
+// INLINE-NEXT:     firrtl.connect %1, %inst_R0_addr : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
+// INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %2, %inst_R0_en : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
+// INLINE-NEXT:     %3 = firrtl.subfield %0("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<clock>
+// INLINE-NEXT:     firrtl.connect %3, %inst_R0_clk : !firrtl.flip<clock>, !firrtl.flip<clock>
+// INLINE-NEXT:     %4 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.sint<8>
+// INLINE-NEXT:     firrtl.connect %inst_R0_data, %4 : !firrtl.sint<8>, !firrtl.sint<8>
+// INLINE-NEXT:     %inst_W0_addr, %inst_W0_en, %inst_W0_clk, %inst_W0_data, %inst_W0_mask = firrtl.instance @WriteMemory_ext {portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// INLINE-NEXT:     %5 = firrtl.wire  {name = ""} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
+// INLINE-NEXT:     %6 = firrtl.subfield %5("addr") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %6, %inst_W0_addr : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %7 = firrtl.subfield %5("en") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %7, %inst_W0_en : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %8 = firrtl.subfield %5("clk") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<clock>
+// INLINE-NEXT:     firrtl.connect %8, %inst_W0_clk : !firrtl.flip<clock>, !firrtl.clock
+// INLINE-NEXT:     %9 = firrtl.subfield %5("data") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<sint<8>>
+// INLINE-NEXT:     firrtl.connect %9, %inst_W0_data : !firrtl.flip<sint<8>>, !firrtl.sint<8>
+// INLINE-NEXT:     %10 = firrtl.subfield %5("mask") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %10, %inst_W0_mask : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %inst_R0_addr_0, %inst_R0_en_1, %inst_R0_clk_2, %inst_R0_data_3 = firrtl.instance @ReadMemory_ext {portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
+// INLINE-NEXT:     %11 = firrtl.wire  {name = ""} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+// INLINE-NEXT:     %12 = firrtl.subfield %11("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
+// INLINE-NEXT:     firrtl.connect %12, %inst_R0_addr_0 : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
+// INLINE-NEXT:     %13 = firrtl.subfield %11("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %13, %inst_R0_en_1 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
+// INLINE-NEXT:     %14 = firrtl.subfield %11("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<clock>
+// INLINE-NEXT:     firrtl.connect %14, %inst_R0_clk_2 : !firrtl.flip<clock>, !firrtl.flip<clock>
+// INLINE-NEXT:     %15 = firrtl.subfield %11("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.sint<8>
+// INLINE-NEXT:     firrtl.connect %inst_R0_data_3, %15 : !firrtl.sint<8>, !firrtl.sint<8>
+// INLINE-NEXT:     %inst_W0_addr_4, %inst_W0_en_5, %inst_W0_clk_6, %inst_W0_data_7, %inst_W0_mask_8 = firrtl.instance @WriteMemory_ext {portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// INLINE-NEXT:     %16 = firrtl.wire  {name = ""} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
+// INLINE-NEXT:     %17 = firrtl.subfield %16("addr") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %17, %inst_W0_addr_4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %18 = firrtl.subfield %16("en") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %18, %inst_W0_en_5 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %19 = firrtl.subfield %16("clk") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<clock>
+// INLINE-NEXT:     firrtl.connect %19, %inst_W0_clk_6 : !firrtl.flip<clock>, !firrtl.clock
+// INLINE-NEXT:     %20 = firrtl.subfield %16("data") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<sint<8>>
+// INLINE-NEXT:     firrtl.connect %20, %inst_W0_data_7 : !firrtl.flip<sint<8>>, !firrtl.sint<8>
+// INLINE-NEXT:     %21 = firrtl.subfield %16("mask") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %21, %inst_W0_mask_8 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %inst_R0_addr_9, %inst_R0_en_10, %inst_R0_clk_11, %inst_R0_data_12 = firrtl.instance @ReadMemory_ext {portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
+// INLINE-NEXT:     %22 = firrtl.wire  {name = ""} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+// INLINE-NEXT:     %23 = firrtl.subfield %22("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
+// INLINE-NEXT:     firrtl.connect %23, %inst_R0_addr_9 : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
+// INLINE-NEXT:     %24 = firrtl.subfield %22("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %24, %inst_R0_en_10 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
+// INLINE-NEXT:     %25 = firrtl.subfield %22("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<clock>
+// INLINE-NEXT:     firrtl.connect %25, %inst_R0_clk_11 : !firrtl.flip<clock>, !firrtl.flip<clock>
+// INLINE-NEXT:     %26 = firrtl.subfield %22("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.sint<8>
+// INLINE-NEXT:     firrtl.connect %inst_R0_data_12, %26 : !firrtl.sint<8>, !firrtl.sint<8>
+// INLINE-NEXT:     %inst_W0_addr_13, %inst_W0_en_14, %inst_W0_clk_15, %inst_W0_data_16, %inst_W0_mask_17 = firrtl.instance @WriteMemory_ext {portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// INLINE-NEXT:     %27 = firrtl.wire  {name = ""} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
+// INLINE-NEXT:     %28 = firrtl.subfield %27("addr") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %28, %inst_W0_addr_13 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %29 = firrtl.subfield %27("en") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %29, %inst_W0_en_14 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %30 = firrtl.subfield %27("clk") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<clock>
+// INLINE-NEXT:     firrtl.connect %30, %inst_W0_clk_15 : !firrtl.flip<clock>, !firrtl.clock
+// INLINE-NEXT:     %31 = firrtl.subfield %27("data") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<sint<8>>
+// INLINE-NEXT:     firrtl.connect %31, %inst_W0_data_16 : !firrtl.flip<sint<8>>, !firrtl.sint<8>
+// INLINE-NEXT:     %32 = firrtl.subfield %27("mask") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %32, %inst_W0_mask_17 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:   }
+// INLINE-NEXT: }

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -69,6 +69,11 @@ static cl::opt<bool>
                      cl::init(false));
 
 static cl::opt<bool>
+    blackboxMemory("blackbox-memory",
+                   cl::desc("Create a blackbox for all memory operations"),
+                   cl::init(false));
+
+static cl::opt<bool>
     ignoreFIRLocations("ignore-fir-locators",
                        cl::desc("ignore the @info locations in the .fir file"),
                        cl::init(false));
@@ -130,6 +135,9 @@ processBuffer(std::unique_ptr<llvm::MemoryBuffer> ownedBuffer,
 
   // Allow optimizations to run multithreaded.
   context.disableMultithreading(false);
+
+  if (blackboxMemory)
+    pm.nest<firrtl::CircuitOp>().addPass(firrtl::createBlackBoxMemoryPass());
 
   // Run the lower-to-rtl pass if requested.
   if (lowerToRTL) {


### PR DESCRIPTION
This is the start of some work to add a pass to automatically create black boxes for FIRRTL memory operations.  This works by replacing a `firrtl.mem` op with an equivalent instance of an external module. This work aims to add a feature to replace the `--repl-seq-mem` option in the SFC.
```
MemLib Options
  -frsq, --repl-seq-mem -c:<circuit>:-i:<file>:-o:<file>
                           Blackbox and emit a configuration file for each sequential memory
```


<details>
  <summary>Some example output from the scala firrtl compiler</summary>

```scala
// firrtl-1.4.0 --repl-seq-mem -c:Foo:-o:test.txt  -i ./test.fir -o test
circuit Foo :
  module Foo :
    input clock : Clock
    input reset : UInt<1>
    input readAddr : UInt<3>
    output dataOut : UInt<8>
    input writeAddr : UInt<3>
    input writeEn : UInt<1>
    input dataIn : UInt<8>
    mem mem : @[main.scala 13:24]
      data-type => UInt<8>
      depth => 8
      read-latency => 1
      write-latency => 1
      reader => MPORT
      writer => MPORT_1
      read-under-write => undefined
    mem.MPORT.addr is invalid @[main.scala 13:24]
    mem.MPORT.clk is invalid @[main.scala 13:24]
    mem.MPORT.en <= UInt<1>("h0") @[main.scala 13:24]
    mem.MPORT_1.addr is invalid @[main.scala 13:24]
    mem.MPORT_1.clk is invalid @[main.scala 13:24]
    mem.MPORT_1.en <= UInt<1>("h0") @[main.scala 13:24]
    mem.MPORT_1.data is invalid @[main.scala 13:24]
    mem.MPORT_1.mask is invalid @[main.scala 13:24]
    mem.MPORT.addr <= readAddr @[main.scala 15:17]
    mem.MPORT.clk <= clock @[main.scala 15:17]
    dataOut <= mem.MPORT.data @[main.scala 15:11]
    when writeEn : @[main.scala 17:18]
      mem.MPORT_1.addr <= writeAddr @[main.scala 18:8]
      mem.MPORT_1.clk <= clock @[main.scala 18:8]
      mem.MPORT_1.en <= UInt<1>("h1") @[main.scala 18:8]
      mem.MPORT_1.mask <= UInt<1>("h0") @[main.scala 18:8]
      mem.MPORT_1.data <= dataIn @[main.scala 18:20]
      mem.MPORT_1.mask <= UInt<1>("h1") @[main.scala 18:20]
```
      
```verilog
module Foo(
  input        clock,
  input        reset,
  input  [2:0] readAddr,
  output [7:0] dataOut,
  input  [2:0] writeAddr,
  input        writeEn,
  input  [7:0] dataIn
);
  wire [2:0] mem_R0_addr; // @[main.scala 13:24]
  wire  mem_R0_clk; // @[main.scala 13:24]
  wire [7:0] mem_R0_data; // @[main.scala 13:24]
  wire [2:0] mem_W0_addr; // @[main.scala 13:24]
  wire  mem_W0_en; // @[main.scala 13:24]
  wire  mem_W0_clk; // @[main.scala 13:24]
  wire [7:0] mem_W0_data; // @[main.scala 13:24]
  mem mem ( // @[main.scala 13:24]
    .R0_addr(mem_R0_addr),
    .R0_clk(mem_R0_clk),
    .R0_data(mem_R0_data),
    .W0_addr(mem_W0_addr),
    .W0_en(mem_W0_en),
    .W0_clk(mem_W0_clk),
    .W0_data(mem_W0_data)
  );
  assign dataOut = mem_R0_data; // @[main.scala 15:11]
  assign mem_R0_addr = readAddr; // @[main.scala 15:17]
  assign mem_R0_clk = clock; // @[main.scala 15:17]
  assign mem_W0_addr = writeAddr; // @[main.scala 17:18 main.scala 18:8]
  assign mem_W0_en = writeEn; // @[main.scala 17:18 main.scala 18:8 main.scala 13:24]
  assign mem_W0_clk = clock; // @[main.scala 17:18 main.scala 18:8]
  assign mem_W0_data = dataIn; // @[main.scala 17:18 main.scala 18:20]
endmodule
module mem(
  input  [2:0] R0_addr,
  input        R0_clk,
  output [7:0] R0_data,
  input  [2:0] W0_addr,
  input        W0_en,
  input        W0_clk,
  input  [7:0] W0_data
);
  wire [2:0] mem_ext_R0_addr;
  wire  mem_ext_R0_en;
  wire  mem_ext_R0_clk;
  wire [7:0] mem_ext_R0_data;
  wire [2:0] mem_ext_W0_addr;
  wire  mem_ext_W0_en;
  wire  mem_ext_W0_clk;
  wire [7:0] mem_ext_W0_data;
  mem_ext mem_ext (
    .R0_addr(mem_ext_R0_addr),
    .R0_en(mem_ext_R0_en),
    .R0_clk(mem_ext_R0_clk),
    .R0_data(mem_ext_R0_data),
    .W0_addr(mem_ext_W0_addr),
    .W0_en(mem_ext_W0_en),
    .W0_clk(mem_ext_W0_clk),
    .W0_data(mem_ext_W0_data)
  );
  assign mem_ext_R0_clk = R0_clk;
  assign mem_ext_R0_en = 1'h0;
  assign mem_ext_R0_addr = R0_addr;
  assign R0_data = mem_ext_R0_data;
  assign mem_ext_W0_clk = W0_clk;
  assign mem_ext_W0_en = W0_en;
  assign mem_ext_W0_addr = W0_addr;
  assign mem_ext_W0_data = W0_data;
endmodule
```
</details>

The SFC generates a configuration file for all black boxed memories, which is used by other tools to generate macro memories. For the example above, the following is generated:
```
name mem_ext depth 8 width 8 ports write,read
```

This new blackboxing pass is storing the memory configuration data as parameters on the generated external module.  Some code was added to preserve the parameters during the lowering to RTL.  The hope is that we can write a pass or tool which can launch a (command line) registered generator to produce whatever artifacts we need.  A larger discussion about how this should work will probably be necessary.