### PR TITLE
Add helpers to register all dialects, and simplify circt-opt

### DIFF
--- a/include/circt/Conversion/FIRRTLToLLHD/Passes.td
+++ b/include/circt/Conversion/FIRRTLToLLHD/Passes.td
@@ -22,6 +22,7 @@ def ConvertFIRRTLToLLHD : Pass<"convert-firrtl-to-llhd", "ModuleOp"> {
     description.
   }];
   let constructor = "circt::llhd::createConvertFIRRTLToLLHDPass()";
+  let dependentDialects = ["llhd::LLHDDialect"];
 }
 
 #endif // CIRCT_CONVERSION_FIRRTLTOLLHD_PASSES

--- a/include/circt/Conversion/LLHDToLLVM/Passes.td
+++ b/include/circt/Conversion/LLHDToLLVM/Passes.td
@@ -23,6 +23,7 @@ def ConvertLLHDToLLVM : Pass<"convert-llhd-to-llvm", "ModuleOp"> {
     }];
 
     let constructor = "circt::llhd::createConvertLLHDToLLVMPass()";
+    let dependentDialects = ["mlir::LLVM::LLVMDialect"];
 }
 
 #endif // CIRCT_CONVERSION_LLHDTOLLVM_PASSES

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -26,7 +26,7 @@ def LowerFIRRTLToRTLModule
     Lower firrtl.module's to rtl.module.
   }];
   let constructor = "circt::firrtl::createLowerFIRRTLToRTLModulePass()";
-  let dependentDialects = ["rtl::RTLDialect"];
+  let dependentDialects = ["rtl::RTLDialect", "sv::SVDialect"];
 }
 
 def LowerFIRRTLToRTL : Pass<"lower-firrtl-to-rtl", "rtl::RTLModuleOp"> {

--- a/include/circt/Conversion/RTLToLLHD/Passes.td
+++ b/include/circt/Conversion/RTLToLLHD/Passes.td
@@ -22,6 +22,7 @@ def ConvertRTLToLLHD : Pass<"convert-rtl-to-llhd", "mlir::ModuleOp"> {
     description.
   }];
   let constructor = "circt::llhd::createConvertRTLToLLHDPass()";
+  let dependentDialects = ["llhd::LLHDDialect"];
 }
 
 #endif // CIRCT_CONVERSION_RTLTOLLHD_PASSES

--- a/include/circt/InitAllDialects.h
+++ b/include/circt/InitAllDialects.h
@@ -1,0 +1,45 @@
+//===- InitAllDialects.h - CIRCT Dialects Registration ----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines a helper to trigger the registration of all dialects and
+// passes to the system.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_INITALLDIALECTS_H_
+#define CIRCT_INITALLDIALECTS_H_
+
+#include "circt/Dialect/ESI/ESIDialect.h"
+#include "circt/Dialect/FIRRTL/FIRRTLDialect.h"
+#include "circt/Dialect/Handshake/HandshakeOps.h"
+#include "circt/Dialect/LLHD/IR/LLHDDialect.h"
+#include "circt/Dialect/RTL/RTLDialect.h"
+#include "circt/Dialect/SV/SVDialect.h"
+#include "circt/Dialect/StaticLogic/StaticLogic.h"
+#include "mlir/IR/Dialect.h"
+
+namespace circt {
+
+// Add all the MLIR dialects to the provided registry.
+inline void registerAllDialects(mlir::DialectRegistry &registry) {
+  // clang-format off
+  registry.insert<
+    esi::ESIDialect,
+    firrtl::FIRRTLDialect,
+    handshake::HandshakeOpsDialect,
+    llhd::LLHDDialect,
+    rtl::RTLDialect,
+    staticlogic::StaticLogicDialect,
+    sv::SVDialect
+  >();
+  // clang-format on
+}
+
+} // namespace circt
+
+#endif // CIRCT_INITALLDIALECTS_H_

--- a/include/circt/InitAllPasses.h
+++ b/include/circt/InitAllPasses.h
@@ -1,0 +1,52 @@
+//===- InitAllPasses.h - CIRCT Global Pass Registration ---------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines a helper to trigger the registration of all passes to the
+// system.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_INITALLPASSES_H_
+#define CIRCT_INITALLPASSES_H_
+
+#include "circt/Conversion/FIRRTLToLLHD/FIRRTLToLLHD.h"
+#include "circt/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.h"
+#include "circt/Conversion/LLHDToLLVM/LLHDToLLVM.h"
+#include "circt/Conversion/Passes.h"
+#include "circt/Conversion/RTLToLLHD/RTLToLLHD.h"
+#include "circt/Conversion/StandardToHandshake/StandardToHandshake.h"
+#include "circt/Conversion/StandardToStaticLogic/StandardToStaticLogic.h"
+#include "circt/Dialect/ESI/ESIDialect.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "circt/Dialect/LLHD/Transforms/Passes.h"
+
+namespace circt {
+
+inline void registerAllConversionPasses() {
+  registerConversionPasses();
+  handshake::registerHandshakeToFIRRTLPasses();
+  handshake::registerStandardToHandshakePasses();
+  llhd::initLLHDToLLVMPass();
+  llhd::registerFIRRTLToLLHDPasses();
+  llhd::registerRTLToLLHDPasses();
+  staticlogic::registerStandardToStaticLogicPasses();
+}
+
+inline void registerAllPasses() {
+  // Conversion Passes
+  registerAllConversionPasses();
+
+  // Standard Passes
+  esi::registerESIPasses();
+  firrtl::registerPasses();
+  llhd::initLLHDTransformationPasses();
+}
+
+} // namespace circt
+
+#endif // CIRCT_INITALLPASSES_H_

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -1907,6 +1907,10 @@ class HandshakeToFIRRTLPass
     : public mlir::PassWrapper<HandshakeToFIRRTLPass,
                                OperationPass<handshake::FuncOp>> {
 public:
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<firrtl::FIRRTLDialect>();
+  }
+
   void runOnOperation() override {
     auto op = getOperation();
 

--- a/lib/Conversion/StandardToStaticLogic/StandardToStaticLogic.cpp
+++ b/lib/Conversion/StandardToStaticLogic/StandardToStaticLogic.cpp
@@ -110,6 +110,9 @@ namespace {
 
 struct CreatePipelinePass
     : public PassWrapper<CreatePipelinePass, OperationPass<mlir::FuncOp>> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<staticlogic::StaticLogicDialect>();
+  }
   void runOnOperation() override {
     mlir::FuncOp f = getOperation();
     auto builder = OpBuilder(f.getContext());

--- a/test/circt-opt/commandline.mlir
+++ b/test/circt-opt/commandline.mlir
@@ -1,3 +1,16 @@
-// RUN: circt-opt --help | FileCheck %s
-//
-// CHECK: OVERVIEW: circt modular optimizer driver
+// RUN: circt-opt --help | FileCheck %s --check-prefix=HELP
+// RUN: circt-opt --show-dialects | FileCheck %s --check-prefix=DIALECT
+
+// HELP: OVERVIEW: CIRCT modular optimizer driver
+
+// DIALECT: Available Dialects:
+// DIALECT-NEXT: affine
+// DIALECT-NEXT: esi
+// DIALECT-NEXT: firrtl
+// DIALECT-NEXT: handshake
+// DIALECT-NEXT: llhd
+// DIALECT-NEXT: llvm
+// DIALECT-NEXT: rtl
+// DIALECT-NEXT: staticlogic
+// DIALECT-NEXT: std
+// DIALECT-NEXT: sv

--- a/tools/circt-opt/circt-opt.cpp
+++ b/tools/circt-opt/circt-opt.cpp
@@ -11,148 +11,32 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "circt/Conversion/FIRRTLToLLHD/FIRRTLToLLHD.h"
-#include "circt/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.h"
-#include "circt/Conversion/LLHDToLLVM/LLHDToLLVM.h"
-#include "circt/Conversion/Passes.h"
-#include "circt/Conversion/RTLToLLHD/RTLToLLHD.h"
-#include "circt/Conversion/StandardToHandshake/StandardToHandshake.h"
-#include "circt/Conversion/StandardToStaticLogic/StandardToStaticLogic.h"
-#include "circt/Dialect/ESI/ESIDialect.h"
-#include "circt/Dialect/FIRRTL/FIRRTLDialect.h"
-#include "circt/Dialect/FIRRTL/Passes.h"
-#include "circt/Dialect/Handshake/HandshakeOps.h"
-#include "circt/Dialect/LLHD/IR/LLHDDialect.h"
-#include "circt/Dialect/LLHD/Transforms/Passes.h"
-#include "circt/Dialect/RTL/RTLDialect.h"
-#include "circt/Dialect/SV/SVDialect.h"
-#include "circt/Dialect/StaticLogic/StaticLogic.h"
+#include "circt/InitAllDialects.h"
+#include "circt/InitAllPasses.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
-#include "mlir/IR/AsmState.h"
-#include "mlir/Pass/Pass.h"
-#include "mlir/Pass/PassManager.h"
 #include "mlir/Pass/PassRegistry.h"
-#include "mlir/Support/FileUtilities.h"
 #include "mlir/Support/MlirOptMain.h"
 #include "mlir/Transforms/Passes.h"
-#include "llvm/Support/CommandLine.h"
-#include "llvm/Support/InitLLVM.h"
-#include "llvm/Support/ToolOutputFile.h"
-
-using namespace llvm;
-using namespace mlir;
-using namespace circt;
-
-static cl::opt<std::string>
-    inputFilename(cl::Positional, cl::desc("<input file>"), cl::init("-"));
-
-static cl::opt<std::string> outputFilename("o", cl::desc("Output filename"),
-                                           cl::value_desc("filename"),
-                                           cl::init("-"));
-
-static cl::opt<bool>
-    splitInputFile("split-input-file",
-                   cl::desc("Split the input file into pieces and process each "
-                            "chunk independently"),
-                   cl::init(false));
-
-static cl::opt<bool>
-    verifyDiagnostics("verify-diagnostics",
-                      cl::desc("Check that emitted diagnostics match "
-                               "expected-* lines on the corresponding line"),
-                      cl::init(false));
-
-static cl::opt<bool>
-    verifyPasses("verify-each",
-                 cl::desc("Run the verifier after each transformation pass"),
-                 cl::init(true));
-
-static cl::opt<bool>
-    showDialects("show-dialects",
-                 cl::desc("Print the list of registered dialects"),
-                 cl::init(false));
-
-static cl::opt<bool> allowUnregisteredDialects(
-    "allow-unregistered-dialect",
-    cl::desc("Allow operation with no registered dialects"), cl::init(false));
 
 int main(int argc, char **argv) {
-  InitLLVM y(argc, argv);
-
-  DialectRegistry registry;
+  mlir::DialectRegistry registry;
 
   // Register MLIR stuff
-  registry.insert<StandardOpsDialect>();
-  registry.insert<LLVM::LLVMDialect>();
+  registry.insert<mlir::StandardOpsDialect>();
+  registry.insert<mlir::LLVM::LLVMDialect>();
   registry.insert<mlir::AffineDialect>();
 
-// Register the standard passes we want.
-#include "mlir/Transforms/Passes.h.inc"
-  registerCanonicalizerPass();
-  registerCSEPass();
-  registerInlinerPass();
+  circt::registerAllDialects(registry);
+  circt::registerAllPasses();
 
-  // Register any pass manager command line options.
-  registerMLIRContextCLOptions();
-  registerPassManagerCLOptions();
+  // Register the standard passes we want.
+  mlir::registerCanonicalizerPass();
+  mlir::registerCSEPass();
+  mlir::registerInlinerPass();
 
-  // Register printer command line options.
-  registerAsmPrinterCLOptions();
-
-  // Register our dialects.
-  registry.insert<firrtl::FIRRTLDialect>();
-  firrtl::registerPasses();
-
-  registry.insert<handshake::HandshakeOpsDialect>();
-  registry.insert<staticlogic::StaticLogicDialect>();
-  staticlogic::registerStandardToStaticLogicPasses();
-  handshake::registerStandardToHandshakePasses();
-  handshake::registerHandshakeToFIRRTLPasses();
-
-  registry.insert<esi::ESIDialect>();
-  esi::registerESIPasses();
-
-  registry.insert<llhd::LLHDDialect>();
-  registry.insert<rtl::RTLDialect>();
-  registry.insert<sv::SVDialect>();
-
-  llhd::initLLHDTransformationPasses();
-  llhd::initLLHDToLLVMPass();
-  llhd::registerFIRRTLToLLHDPasses();
-  llhd::registerRTLToLLHDPasses();
-
-  registerConversionPasses();
-
-  PassPipelineCLParser passPipeline("", "Compiler passes to run");
-
-  // Parse pass names in main to ensure static initialization completed.
-  cl::ParseCommandLineOptions(argc, argv, "circt modular optimizer driver\n");
-
-  if (showDialects) {
-    llvm::outs() << "Registered Dialects:\n";
-    for (const auto &nameAndRegistrationIt : registry) {
-      llvm::outs() << nameAndRegistrationIt.first << "\n";
-    }
-    return 0;
-  }
-
-  // Set up the input file.
-  std::string errorMessage;
-  auto file = openInputFile(inputFilename, &errorMessage);
-  if (!file) {
-    llvm::errs() << errorMessage << "\n";
-    return 1;
-  }
-
-  auto output = openOutputFile(outputFilename, &errorMessage);
-  if (!output) {
-    llvm::errs() << errorMessage << "\n";
-    exit(1);
-  }
-
-  return failed(MlirOptMain(output->os(), std::move(file), passPipeline,
-                            registry, splitInputFile, verifyDiagnostics,
-                            verifyPasses, allowUnregisteredDialects));
+  return mlir::failed(
+      mlir::MlirOptMain(argc, argv, "CIRCT modular optimizer driver", registry,
+                        /*prelaodDialectsInContext=*/false));
 }


### PR DESCRIPTION
This change cargo-cult imports InitAllDialects.h and InitAllPasses.h
from MLIR.

`circt-opt` has been greatly simplified by using the more powerful
version of `MlirOptMain`, which supersedes all our current
command line options.

Now we're not preloading all dialects, we need to make sure that target
dialects are properly registered in all conversion passes. Source
dialects do not need to be manually loaded.

One thing which is not clear is if `circt::registerAllDialects` should
register any standard MLIR dialects which are used heavily throughout
CIRCT.  This change only registers CIRCT dialects.