### PR TITLE
Rename all translate command line flags to use import and export

### DIFF
--- a/docs/ESI/cosim.md
+++ b/docs/ESI/cosim.md
@@ -30,7 +30,7 @@ system. Run command below on an MLIR assembly file with `esi.cosim` ops. It
 will find all of the cosim ops and output a capnp schema struct for each
 input and output type.
 
-`circt-translate <esi_system.mlir> -emit-esi-capnp`
+`circt-translate <esi_system.mlir> -export-esi-capnp`
 
 Comments in the generated file indicate the type converted from. In cases
 where the ESI type is smaller than the capnp type (e.g. `i5` vs `UInt8`), the

--- a/integration_test/ESI/cosim/basic.mlir
+++ b/integration_test/ESI/cosim/basic.mlir
@@ -1,6 +1,6 @@
 // REQUIRES: esi-cosim
-// RUN: circt-opt %s --lower-esi-to-physical --lower-esi-ports --lower-esi-to-rtl | circt-translate --emit-verilog > %t1.sv
-// RUN: circt-translate %s -emit-esi-capnp -verify-diagnostics > %t2.capnp
+// RUN: circt-opt %s --lower-esi-to-physical --lower-esi-ports --lower-esi-to-rtl | circt-translate --export-verilog > %t1.sv
+// RUN: circt-translate %s -export-esi-capnp -verify-diagnostics > %t2.capnp
 // RUN: esi-cosim-runner.py --schema %t2.capnp %s %t1.sv %S/../supplements/integers.sv
 // PY: import basic
 // PY: rpc = basic.BasicSystemTester(rpcschemapath, simhostport)

--- a/integration_test/ESI/cosim/loopback.mlir
+++ b/integration_test/ESI/cosim/loopback.mlir
@@ -1,6 +1,6 @@
 // REQUIRES: esi-cosim
-// RUN: circt-opt %s --lower-esi-to-physical --lower-esi-ports --lower-esi-to-rtl | circt-translate --emit-verilog > %t1.sv
-// RUN: circt-translate %s -emit-esi-capnp -verify-diagnostics > %t2.capnp
+// RUN: circt-opt %s --lower-esi-to-physical --lower-esi-ports --lower-esi-to-rtl | circt-translate --export-verilog > %t1.sv
+// RUN: circt-translate %s -export-esi-capnp -verify-diagnostics > %t2.capnp
 // RUN: esi-cosim-runner.py --schema %t2.capnp %s %t1.sv
 // PY: import loopback as test
 // PY: rpc = test.LoopbackTester(rpcschemapath, simhostport)

--- a/integration_test/ESI/system/basic.mlir
+++ b/integration_test/ESI/system/basic.mlir
@@ -1,6 +1,6 @@
 // REQUIRES: rtl-sim
 // RUN: circt-opt %s --lower-esi-to-physical --lower-esi-ports --lower-esi-to-rtl -verify-diagnostics > %t1.mlir
-// RUN: circt-translate %t1.mlir -emit-verilog -verify-diagnostics > %t2.sv
+// RUN: circt-translate %t1.mlir -export-verilog -verify-diagnostics > %t2.sv
 // RUN: circt-rtl-sim.py %t2.sv %INC%/circt/Dialect/ESI/ESIPrimitives.sv %S/../supplements/integers.sv --cycles 150 | FileCheck %s
 
 rtl.externmodule @IntCountProd(%clk: i1, %rstn: i1) -> (%ints: !esi.channel<i32>)

--- a/integration_test/EmitVerilog/basic.mlir
+++ b/integration_test/EmitVerilog/basic.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: verilator
-// RUN: circt-translate %s -emit-verilog -verify-diagnostics > %t1.sv
+// RUN: circt-translate %s -export-verilog -verify-diagnostics > %t1.sv
 // RUN: circt-rtl-sim.py %t1.sv --cycles 8 2>&1 | FileCheck %s
 
 module {

--- a/integration_test/EmitVerilog/lint.mlir
+++ b/integration_test/EmitVerilog/lint.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: verilator
-// RUN: circt-translate %s -emit-verilog -verify-diagnostics > %t1.sv
+// RUN: circt-translate %s -export-verilog -verify-diagnostics > %t1.sv
 // RUN: verilator --lint-only --top-module A %t1.sv
 // RUN: verilator --lint-only --top-module AB %t1.sv
 // RUN: verilator --lint-only --top-module shl %t1.sv

--- a/integration_test/EmitVerilog/sv-interfaces.mlir
+++ b/integration_test/EmitVerilog/sv-interfaces.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: rtl-sim
-// RUN: circt-translate %s -emit-verilog -verify-diagnostics > %t1.sv
+// RUN: circt-translate %s -export-verilog -verify-diagnostics > %t1.sv
 // RUN: verilator --lint-only --top-module top %t1.sv
 // RUN: circt-rtl-sim.py %t1.sv --cycles 2 2>&1 | FileCheck %s
 

--- a/lib/Dialect/ESI/ESITranslations.cpp
+++ b/lib/Dialect/ESI/ESITranslations.cpp
@@ -168,7 +168,7 @@ static LogicalResult exportCosimSchema(ModuleOp module, llvm::raw_ostream &os) {
 void circt::esi::registerESITranslations() {
 #ifdef CAPNP
   TranslateFromMLIRRegistration cosimToCapnp(
-      "emit-esi-capnp", exportCosimSchema, [](DialectRegistry &registry) {
+      "export-esi-capnp", exportCosimSchema, [](DialectRegistry &registry) {
         registry
             .insert<ESIDialect, circt::rtl::RTLDialect, circt::sv::SVDialect,
                     mlir::StandardOpsDialect, mlir::BuiltinDialect>();

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2607,7 +2607,7 @@ OwningModuleRef circt::firrtl::importFIRRTL(SourceMgr &sourceMgr,
 
 void circt::firrtl::registerFromFIRRTLTranslation() {
   static TranslateToMLIRRegistration fromFIR(
-      "parse-fir", [](llvm::SourceMgr &sourceMgr, MLIRContext *context) {
+      "import-firrtl", [](llvm::SourceMgr &sourceMgr, MLIRContext *context) {
         return importFIRRTL(sourceMgr, context);
       });
 }

--- a/lib/Dialect/LLHD/Export/TranslateToVerilog.cpp
+++ b/lib/Dialect/LLHD/Export/TranslateToVerilog.cpp
@@ -421,7 +421,7 @@ LogicalResult circt::llhd::exportVerilog(ModuleOp module, raw_ostream &os) {
 
 void circt::llhd::registerToVerilogTranslation() {
   TranslateFromMLIRRegistration registration(
-      "llhd-to-verilog", exportVerilog, [](DialectRegistry &registry) {
+      "export-llhd-verilog", exportVerilog, [](DialectRegistry &registry) {
         registry.insert<mlir::StandardOpsDialect, llhd::LLHDDialect>();
       });
 }

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -2024,7 +2024,7 @@ LogicalResult circt::exportVerilog(ModuleOp module, llvm::raw_ostream &os) {
 
 void circt::registerToVerilogTranslation() {
   TranslateFromMLIRRegistration toVerilog(
-      "emit-verilog", exportVerilog, [](DialectRegistry &registry) {
+      "export-verilog", exportVerilog, [](DialectRegistry &registry) {
         registry.insert<RTLDialect, SVDialect>();
       });
 }

--- a/lib/Translation/ExportVerilog/ExportVerilogFIRRTL.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilogFIRRTL.cpp
@@ -2277,7 +2277,7 @@ LogicalResult circt::exportFIRRTLToVerilog(ModuleOp module,
 
 void circt::registerFIRRTLToVerilogTranslation() {
   TranslateFromMLIRRegistration toVerilog(
-      "emit-firrtl-verilog", exportFIRRTLToVerilog,
+      "export-firrtl-verilog", exportFIRRTLToVerilog,
       [](DialectRegistry &registry) {
         registry.insert<firrtl::FIRRTLDialect>();
       });

--- a/test/Dialect/ESI/cosim.mlir
+++ b/test/Dialect/ESI/cosim.mlir
@@ -1,8 +1,8 @@
 // REQUIRES: capnp
 // RUN: circt-opt %s -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
 // RUN: circt-opt %s --lower-esi-ports --lower-esi-to-rtl -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck --check-prefix=COSIM %s
-// RUN: circt-opt %s --lower-esi-ports --lower-esi-to-rtl | circt-translate --emit-verilog | FileCheck --check-prefix=SV %s
-// RUN: circt-translate %s -emit-esi-capnp -verify-diagnostics | FileCheck --check-prefix=CAPNP %s
+// RUN: circt-opt %s --lower-esi-ports --lower-esi-to-rtl | circt-translate --export-verilog | FileCheck --check-prefix=SV %s
+// RUN: circt-translate %s -export-esi-capnp -verify-diagnostics | FileCheck --check-prefix=CAPNP %s
 
 rtl.externmodule @Sender() -> ( !esi.channel<si14> { rtl.name = "x"})
 rtl.externmodule @Reciever(%a: !esi.channel<i32>)

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1,4 +1,4 @@
-; RUN: circt-translate -parse-fir -verify-diagnostics %s | circt-opt | FileCheck %s
+; RUN: circt-translate -import-firrtl -verify-diagnostics %s | circt-opt | FileCheck %s
 
 circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -1,4 +1,4 @@
-; RUN: circt-translate -parse-fir -verify-diagnostics --split-input-file %s
+; RUN: circt-translate -import-firrtl -verify-diagnostics --split-input-file %s
 
 circuit test :
   extmodule MyModule :

--- a/test/Dialect/FIRRTL/parse-locations.fir
+++ b/test/Dialect/FIRRTL/parse-locations.fir
@@ -1,4 +1,4 @@
-; RUN: circt-translate -parse-fir --mlir-print-debuginfo -verify-diagnostics -mlir-print-local-scope %s | FileCheck %s
+; RUN: circt-translate -import-firrtl --mlir-print-debuginfo -verify-diagnostics -mlir-print-local-scope %s | FileCheck %s
 
 circuit MyModule :  @[CIRCUIT.scala 127]
 

--- a/test/Dialect/LLHD/Export/verilog_arithmetic.mlir
+++ b/test/Dialect/LLHD/Export/verilog_arithmetic.mlir
@@ -1,4 +1,4 @@
-//RUN: circt-translate --llhd-to-verilog %s | FileCheck %s
+//RUN: circt-translate --export-llhd-verilog %s | FileCheck %s
 
 // CHECK-LABEL: _check_arithmetic
 llhd.entity @check_arithmetic() -> () {

--- a/test/Dialect/LLHD/Export/verilog_bitwise.mlir
+++ b/test/Dialect/LLHD/Export/verilog_bitwise.mlir
@@ -1,4 +1,4 @@
-//RUN: circt-translate --llhd-to-verilog %s | FileCheck %s
+//RUN: circt-translate --export-llhd-verilog %s | FileCheck %s
 
 // CHECK-LABEL: _check_bitwise
 llhd.entity @check_bitwise() -> () {

--- a/test/Dialect/LLHD/Export/verilog_entity.mlir
+++ b/test/Dialect/LLHD/Export/verilog_entity.mlir
@@ -1,4 +1,4 @@
-//RUN: circt-translate --llhd-to-verilog %s | FileCheck %s
+//RUN: circt-translate --export-llhd-verilog %s | FileCheck %s
 
 // CHECK: module _empty;
 llhd.entity @empty () -> () {

--- a/test/Dialect/LLHD/Export/verilog_relations.mlir
+++ b/test/Dialect/LLHD/Export/verilog_relations.mlir
@@ -1,4 +1,4 @@
-//RUN: circt-translate --llhd-to-verilog %s | FileCheck %s
+//RUN: circt-translate --export-llhd-verilog %s | FileCheck %s
 
 // CHECK-LABEL: _check_relations
 llhd.entity @check_relations() -> () {

--- a/test/Dialect/LLHD/Export/verilog_sig.mlir
+++ b/test/Dialect/LLHD/Export/verilog_sig.mlir
@@ -1,4 +1,4 @@
-//RUN: circt-translate --llhd-to-verilog -split-input-file -verify-diagnostics %s | FileCheck %s
+//RUN: circt-translate --export-llhd-verilog -split-input-file -verify-diagnostics %s | FileCheck %s
 
 // CHECK-LABEL: _check_sig
 llhd.entity @check_sig () -> () {

--- a/test/Dialect/RTL/svEmitErrors.mlir
+++ b/test/Dialect/RTL/svEmitErrors.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-translate -emit-verilog -verify-diagnostics --split-input-file %s
+// RUN: circt-translate -export-verilog -verify-diagnostics --split-input-file %s
 
 // expected-error @+1 {{value has an unsupported verilog type 'vector<3xi1>'}}
 rtl.module @A(%a: vector<3 x i1>) -> () { }

--- a/test/ExportVerilog/rtl-dialect.mlir
+++ b/test/ExportVerilog/rtl-dialect.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-translate %s -emit-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
+// RUN: circt-translate %s -export-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
 
 module {
   rtl.externmodule @E(%a: i1 {rtl.direction = "in"}, 

--- a/test/ExportVerilog/sv-dialect.mlir
+++ b/test/ExportVerilog/sv-dialect.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-translate %s -emit-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
+// RUN: circt-translate %s -export-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
 
 // CHECK-LABEL: module M1(
 rtl.module @M1(%clock : i1, %cond : i1, %val : i8) {

--- a/test/ExportVerilog/sv-interfaces.mlir
+++ b/test/ExportVerilog/sv-interfaces.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-translate %s -emit-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
+// RUN: circt-translate %s -export-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
 
 module {
   // CHECK-LABEL: interface data_vr;

--- a/test/ExportVerilog/verilog-basic.fir
+++ b/test/ExportVerilog/verilog-basic.fir
@@ -3,10 +3,10 @@
 ;; firrtl, emitting verilog, and lower-to-rtl) which should be factored into
 ;; those buckets correctly.
 
-; RUN: circt-translate -parse-fir --mlir-print-debuginfo %s | circt-translate -emit-firrtl-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
+; RUN: circt-translate -import-firrtl --mlir-print-debuginfo %s | circt-translate -export-firrtl-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
 
 ; Some day this should filecheck:
-; RUN: circt-translate -parse-fir --mlir-print-debuginfo %s | circt-opt -lower-firrtl-to-rtl-module -lower-firrtl-to-rtl | circt-translate -emit-verilog -verify-diagnostics
+; RUN: circt-translate -import-firrtl --mlir-print-debuginfo %s | circt-opt -lower-firrtl-to-rtl-module -lower-firrtl-to-rtl | circt-translate -export-verilog -verify-diagnostics
 
 circuit inputs_only :
 

--- a/test/ExportVerilog/verilog-errors.mlir
+++ b/test/ExportVerilog/verilog-errors.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-translate -emit-verilog -verify-diagnostics --split-input-file -mlir-print-op-on-diagnostic=false %s
+// RUN: circt-translate -export-verilog -verify-diagnostics --split-input-file -mlir-print-op-on-diagnostic=false %s
 
 // expected-error @+1 {{value has an unsupported verilog type 'f32'}}
 rtl.module @Top(%out: f32) {

--- a/test/ExportVerilog/verilog-weird.mlir
+++ b/test/ExportVerilog/verilog-weird.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-translate %s -emit-firrtl-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
+// RUN: circt-translate %s -export-firrtl-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
 
 firrtl.circuit "M1" {
   firrtl.module @M1(%x : !firrtl.uint<8> { firrtl.name = "y"},

--- a/test/circt-translate/commandline.mlir
+++ b/test/circt-translate/commandline.mlir
@@ -3,7 +3,7 @@
 // CHECK: OVERVIEW: CIRCT Translation Testing Tool
 
 // CHECK: Translation to perform
-// CHECK:     --emit-firrtl-verilog
-// CHECK-NEXT:     --emit-verilog
-// CHECK-NEXT:     --llhd-to-verilog
-// CHECK-NEXT:     --parse-fir
+// CHECK-NEXT: --export-firrtl-verilog
+// CHECK-NEXT: --export-llhd-verilog
+// CHECK-NEXT: --export-verilog
+// CHECK-NEXT: --import-firrtl


### PR DESCRIPTION
This change changes all command line options to use the import and
export nomenclature as described in the MLIR glossary[0].  This is a
a continuation of the renaming work which occured in #341.

[0] https://mlir.llvm.org/getting_started/Glossary/