### PR TITLE
[CLI] Update checks in circt-translate commandline test.

### DIFF
--- a/test/circt-translate/commandline.mlir
+++ b/test/circt-translate/commandline.mlir
@@ -3,7 +3,7 @@
 // CHECK: OVERVIEW: CIRCT Translation Testing Tool
 
 // CHECK: Translation to perform
-// CHECK-NEXT: --export-firrtl-verilog
-// CHECK-NEXT: --export-llhd-verilog
-// CHECK-NEXT: --export-verilog
-// CHECK-NEXT: --import-firrtl
+// CHECK: --export-firrtl-verilog
+// CHECK: --export-llhd-verilog
+// CHECK: --export-verilog
+// CHECK: --import-firrtl


### PR DESCRIPTION
This changes from CHECK-NEXT to CHECK. Not all translations are always
available (notably ESI Cap'n Proto export). This should make the test
more robust to the absence or presence of optional translations.