### PR TITLE
[RTLToLLHD] Rework RTLModuleOp conversion to use upstream pattern.

### DIFF
--- a/test/Conversion/RTLToLLHD/errors.mlir
+++ b/test/Conversion/RTLToLLHD/errors.mlir
@@ -1,7 +1,6 @@
 // RUN: circt-opt -convert-rtl-to-llhd -split-input-file -verify-diagnostics %s
 
 module {
-  // expected-error @+2 {{type converter failed to convert signature}}
   // expected-error @+1 {{failed to legalize operation 'rtl.module'}}
   rtl.module @test(%in: f16) -> (%out: f16) {
     rtl.output %in: f16


### PR DESCRIPTION
The upstream dialect conversion pattern for rewriting a function type
has been updated to support all FunctionLike ops, and we can use it
here. This removes all of the signature and region conversion from the
pattern, and replaces it with a simple check that the conversion
succeeded. Because the upstream conversion doesn't turn outputs into
inputs, we also need to add all of the RTLModuleOp outputs as inputs
to the EntityOp.