### PR TITLE
[FIRRTL] Fix LowerTypes getAllBundleLowerings for nested aggregates.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -405,8 +405,19 @@ Value FIRRTLTypesLowering::getBundleLowering(Value oldValue,
 // field.
 void FIRRTLTypesLowering::getAllBundleLowerings(
     Value value, SmallVectorImpl<Value> &results) {
+  // Get the original value's bundle type.
   BundleType bundleType = getCanonicalBundleType(value.getType());
   assert(bundleType && "attempted to get bundle lowerings for non-bundle type");
-  for (auto element : bundleType.getElements())
-    results.push_back(getBundleLowering(value, element.name));
+
+  // Flatten the original value's bundle type.
+  SmallVector<FlatBundleFieldEntry, 8> fieldTypes;
+  flattenBundleTypes(bundleType, "", false, fieldTypes);
+
+  for (auto element : fieldTypes) {
+    // Remove the field separator prefix.
+    auto name = StringRef(element.suffix).drop_front(1);
+
+    // Store the resulting lowering for this flat value.
+    results.push_back(getBundleLowering(value, name));
+  }
 }

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -108,3 +108,15 @@ firrtl.circuit "Top" {
   }
 
 }
+
+// -----
+
+firrtl.circuit "Foo" {
+  // CHECK-LABEL: firrtl.module @Foo
+  // CHECK-SAME: %[[FLAT_ARG_INPUT_NAME:a_b_c]]: [[FLAT_ARG_INPUT_TYPE:!firrtl.uint<1>]]
+  // CHECK-SAME: %[[FLAT_ARG_OUTPUT_NAME:b_b_c]]: [[FLAT_ARG_OUTPUT_TYPE:!firrtl.flip<uint<1>>]]
+  firrtl.module @Foo(%a: !firrtl.bundle<b: bundle<c: uint<1>>>, %b: !firrtl.flip<bundle<b: bundle<c: uint<1>>>>) {
+    // CHECK: firrtl.connect %[[FLAT_ARG_OUTPUT_NAME]], %[[FLAT_ARG_INPUT_NAME]] : [[FLAT_ARG_OUTPUT_TYPE]], [[FLAT_ARG_INPUT_TYPE]]
+    firrtl.connect %b, %a : !firrtl.flip<bundle<b: bundle<c: uint<1>>>>, !firrtl.bundle<b: bundle<c: uint<1>>>
+  }
+}


### PR DESCRIPTION
Previously, this would only work for bundles with a single level of
nesting. This update calls the flattenBundleTypes helper, which allows
this function to work with bundles of arbitrary nesting. This fixes
https://github.com/llvm/circt/issues/507.