### PR TITLE
Alwaysff fixes

### DIFF
--- a/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
+++ b/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
@@ -1272,16 +1272,17 @@ LogicalResult FIRRTLLowering::visitDecl(RegResetOp op) {
   setLowering(op, regResult);
 
   auto resetFn = [&]() {
-      builder->create<sv::PAssignOp>(regResult, resetValue);
+    builder->create<sv::PAssignOp>(regResult, resetValue);
   };
 
   if (op.resetSignal().getType().isa<AsyncResetType>()) {
     builder->create<sv::AlwaysFFOp>(
-        EventControl::AtPosEdge, clockVal, ::ResetType::AsyncReset, EventControl::AtPosEdge, resetSignal, std::function<void()>(), resetFn);
+        EventControl::AtPosEdge, clockVal, ::ResetType::AsyncReset,
+        EventControl::AtPosEdge, resetSignal, std::function<void()>(), resetFn);
   } else { // sync reset
-    builder->create<sv::AlwaysFFOp>(EventControl::AtPosEdge, clockVal, 
-                                    ::ResetType::SyncReset, EventControl::AtPosEdge, resetSignal, 
-    std::function<void()>(), resetFn);
+    builder->create<sv::AlwaysFFOp>(
+        EventControl::AtPosEdge, clockVal, ::ResetType::SyncReset,
+        EventControl::AtPosEdge, resetSignal, std::function<void()>(), resetFn);
   }
 
   // Emit the initializer expression for simulation that fills it with random
@@ -2013,7 +2014,7 @@ LogicalResult FIRRTLLowering::visitStmt(ConnectOp op) {
         regResetOp.resetSignal().getType().isa<AsyncResetType>()
             ? ::ResetType::AsyncReset
             : ::ResetType::SyncReset,
-        EventControl::AtPosEdge, resetSignal, 
+        EventControl::AtPosEdge, resetSignal,
         [&]() { builder->create<sv::PAssignOp>(destVal, srcVal); });
     return success();
   }

--- a/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
+++ b/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
@@ -1272,18 +1272,16 @@ LogicalResult FIRRTLLowering::visitDecl(RegResetOp op) {
   setLowering(op, regResult);
 
   auto resetFn = [&]() {
-    builder->create<sv::IfOp>(resetSignal, [&]() {
       builder->create<sv::PAssignOp>(regResult, resetValue);
-    });
   };
 
   if (op.resetSignal().getType().isa<AsyncResetType>()) {
-    builder->create<sv::AlwaysOp>(
-        ArrayRef<EventControl>{EventControl::AtPosEdge,
-                               EventControl::AtPosEdge},
-        ArrayRef<Value>{clockVal, resetSignal}, resetFn);
+    builder->create<sv::AlwaysFFOp>(
+        EventControl::AtPosEdge, clockVal, ::ResetType::AsyncReset, EventControl::AtPosEdge, resetSignal, std::function<void()>(), resetFn);
   } else { // sync reset
-    builder->create<sv::AlwaysOp>(EventControl::AtPosEdge, clockVal, resetFn);
+    builder->create<sv::AlwaysFFOp>(EventControl::AtPosEdge, clockVal, 
+                                    ::ResetType::SyncReset, EventControl::AtPosEdge, resetSignal, 
+    std::function<void()>(), resetFn);
   }
 
   // Emit the initializer expression for simulation that fills it with random
@@ -2015,7 +2013,7 @@ LogicalResult FIRRTLLowering::visitStmt(ConnectOp op) {
         regResetOp.resetSignal().getType().isa<AsyncResetType>()
             ? ::ResetType::AsyncReset
             : ::ResetType::SyncReset,
-        EventControl::AtPosEdge, resetSignal, std::function<void()>(),
+        EventControl::AtPosEdge, resetSignal, 
         [&]() { builder->create<sv::PAssignOp>(destVal, srcVal); });
     return success();
   }

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -276,8 +276,8 @@ void AlwaysFFOp::build(OpBuilder &odsBuilder, OperationState &result,
 void AlwaysFFOp::build(OpBuilder &odsBuilder, OperationState &result,
                        EventControl clockEdge, Value clock,
                        ResetType resetStyle, EventControl resetEdge,
-                       Value reset, std::function<void()> resetCtor,
-                       std::function<void()> bodyCtor) {
+                       Value reset, std::function<void()> bodyCtor,
+                       std::function<void()> resetCtor) {
   result.addAttribute("clockEdge", odsBuilder.getI32IntegerAttr(
                                        static_cast<int32_t>(clockEdge)));
   result.addOperands(clock);
@@ -290,8 +290,8 @@ void AlwaysFFOp::build(OpBuilder &odsBuilder, OperationState &result,
   // Set up the body.
   Region *bodyRegion = result.addRegion();
 
+  AlwaysFFOp::ensureTerminator(*bodyRegion, odsBuilder, result.location);
   if (bodyCtor) {
-    AlwaysFFOp::ensureTerminator(*bodyRegion, odsBuilder, result.location);
     auto oldIP = &*odsBuilder.getInsertionPoint();
     odsBuilder.setInsertionPointToStart(&*bodyRegion->begin());
     bodyCtor();
@@ -301,8 +301,8 @@ void AlwaysFFOp::build(OpBuilder &odsBuilder, OperationState &result,
   // Set up the reset.
   Region *resetRegion = result.addRegion();
 
+  AlwaysFFOp::ensureTerminator(*resetRegion, odsBuilder, result.location);
   if (resetCtor) {
-    AlwaysFFOp::ensureTerminator(*resetRegion, odsBuilder, result.location);
     auto oldIP = &*odsBuilder.getInsertionPoint();
     odsBuilder.setInsertionPointToStart(&*resetRegion->begin());
     resetCtor();

--- a/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
+++ b/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
@@ -513,10 +513,9 @@ module attributes {firrtl.mainModule = "Simple"} {
     %4 = firrtl.asAsyncReset %1 : (!firrtl.uint<1>) -> !firrtl.asyncreset
 
     // CHECK-NEXT: %reg = sv.reg : !rtl.inout<i32>
-    // CHECK-NEXT: sv.always posedge %clock, posedge %reset  {
-    // CHECK-NEXT:   sv.if %reset  {
-    // CHECK-NEXT:     sv.passign %reg, %c0_i32 : i32
-    // CHECK-NEXT:   }
+    // CHECK-NEXT: sv.alwaysff(posedge %clock) {
+    // CHECK-NEXT: }(asyncreset : posedge %reset) {
+    // CHECK-NEXT:   sv.passign %reg, %c0_i32 : i32
     // CHECK-NEXT: }
     // CHECK-NEXT: sv.ifdef "!SYNTHESIS"  {
     // CHECK-NEXT:   sv.initial {
@@ -532,10 +531,9 @@ module attributes {firrtl.mainModule = "Simple"} {
     // CHECK-NEXT:   }
     // CHECK-NEXT: }
     // CHECK-NEXT: %reg2 = sv.reg : !rtl.inout<i32>
-    // CHECK-NEXT: sv.always posedge %clock  {
-    // CHECK-NEXT:   sv.if %reset  {
+    // CHECK-NEXT: sv.alwaysff(posedge %clock) {
+    // CHECK-NEXT: }(syncreset : posedge %reset) {
     // CHECK-NEXT:    sv.passign %reg2, %c0_i32 : i32
-    // CHECK-NEXT:   }
     // CHECK-NEXT: }
     // CHECK-NEXT: sv.ifdef "!SYNTHESIS"  {
     // CHECK-NEXT:   sv.initial  {


### PR DESCRIPTION
registers resets were not being lowered to alwaysff reset blocks.
reset only alwaysff blocks had invalid body blocks.
Fixes #511 