### PR TITLE
[LLHD] Add canonicalizer for SigOp(PrbOp(SigOp)) -> SigOp.

### DIFF
--- a/include/circt/Dialect/LLHD/IR/LLHDCanonicalization.td
+++ b/include/circt/Dialect/LLHD/IR/LLHDCanonicalization.td
@@ -82,4 +82,12 @@ def DynExtractElementWithConstantOpIndex : Pat<
   (LLHD_DynExtractElementOp $target, (ConstantOp $index)),
   (LLHD_ExtractElementOp $target, (IndexAttrFromSignlessInteger $index))>;
 
+//===----------------------------------------------------------------------===//
+// SigOp(PrbOp(SigOp)) -> SigOp
+//===----------------------------------------------------------------------===//
+
+def SigOpProbingSigOp : Pat<
+  (LLHD_SigOp StrAttr, (LLHD_PrbOp (LLHD_SigOp:$result StrAttr, AnyType))),
+  (replaceWithValue $result)>;
+
 #endif // CIRCT_DIALECT_LLHD_IR_CANONICALIZATION_TD

--- a/include/circt/Dialect/LLHD/IR/SignalOps.td
+++ b/include/circt/Dialect/LLHD/IR/SignalOps.td
@@ -49,6 +49,8 @@ def LLHD_SigOp : LLHD_Op<"sig", [
   let results = (outs LLHD_AnySigType: $result);
 
   let assemblyFormat = "$name $init attr-dict `:` type($init)";
+
+  let hasCanonicalizer = 1;
 }
 
 def LLHD_PrbOp : LLHD_Op<"prb", [

--- a/lib/Dialect/LLHD/IR/LLHDCanonicalization.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDCanonicalization.cpp
@@ -53,3 +53,8 @@ void llhd::DynExtractElementOp::getCanonicalizationPatterns(
   results.insert<DynExtractElementWithConstantOpIndex,
                  DynExtractElementWithLLHDConstOpIndex>(context);
 }
+
+void llhd::SigOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
+                                              MLIRContext *context) {
+  results.insert<SigOpProbingSigOp>(context);
+}

--- a/test/Dialect/LLHD/Canonicalization/signalOps.mlir
+++ b/test/Dialect/LLHD/Canonicalization/signalOps.mlir
@@ -20,3 +20,13 @@ func @drv_folding(%sig: !llhd.sig<i32>, %val: i32, %time: !llhd.time, %cond: i1)
   // CHECK-NEXT: return
   return
 }
+
+// CHECK-LABEL: @sig_folding
+llhd.entity @sig_folding() -> () {
+  %false = llhd.const 0 : i1
+  // CHECK: llhd.sig "sig1"
+  // CHECK-NOT: llhd.sig
+  %0 = llhd.sig "sig1" %false : i1
+  %1 = llhd.prb %0 : !llhd.sig<i1>
+  %2 = llhd.sig "sig2" %1 : i1
+}


### PR DESCRIPTION
This pattern comes up when generating LLHD, and this lets the
canonicalizer take care of simplifying it.