### PR TITLE
[RTL] Allow ArrayType to contain anything but InOut types

### DIFF
--- a/lib/Dialect/RTL/RTLTypes.cpp
+++ b/lib/Dialect/RTL/RTLTypes.cpp
@@ -238,8 +238,8 @@ void ArrayType::print(DialectAsmPrinter &p) const {
 LogicalResult ArrayType::verifyConstructionInvariants(Location loc,
                                                       Type innerType,
                                                       size_t size) {
-  if (!isRTLValueType(innerType))
-    return emitError(loc, "invalid element for rtl.array type");
+  if (hasRTLInOutType(innerType))
+    return emitError(loc, "rtl.array cannot contain InOut types");
   return success();
 }
 

--- a/test/Dialect/RTL/types.mlir
+++ b/test/Dialect/RTL/types.mlir
@@ -7,6 +7,11 @@ module {
     return
   }
 
+  // CHECK-LABEL: func @si20x5array(%{{.*}}: !rtl.array<5xsi20>)
+  func @si20x5array(%A: !rtl.array<5 x si20>) {
+    return
+  }
+
   // CHECK-LABEL: func @inoutType(%arg0: !rtl.inout<i42>) {
   func @inoutType(%arg0: !rtl.inout<i42>) {
     return


### PR DESCRIPTION
The RTL dialect is supposed to be an open type system.