### PR TITLE
[HandshakeToFIRRTL] legalize top FIRRTL module to meet the def-before-use requirement

### DIFF
--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -36,7 +36,7 @@ static void legalizeFModule(FModuleOp moduleOp) {
   SmallVector<Operation *, 8> connectOps;
   moduleOp.walk([&](ConnectOp op) { connectOps.push_back(op); });
   for (auto op : connectOps)
-    op->moveBefore(&moduleOp.front().back());
+    op->moveBefore(&moduleOp.getBodyBlock()->back());
 }
 
 /// Get the corresponding FIRRTL type given the built-in data type. Current

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -33,7 +33,7 @@ using ValueVectorList = std::vector<ValueVector>;
 //===----------------------------------------------------------------------===//
 
 static void legalizeFModule(FModuleOp moduleOp) {
-  std::vector<Operation *> connectOps;
+  SmallVector<Operation *, 8> connectOps;
   moduleOp.walk([&](ConnectOp op) { connectOps.push_back(op); });
   for (auto op : connectOps)
     op->moveBefore(&moduleOp.front().back());

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -32,6 +32,13 @@ using ValueVectorList = std::vector<ValueVector>;
 // Utils
 //===----------------------------------------------------------------------===//
 
+static void legalizeFModule(FModuleOp moduleOp) {
+  std::vector<Operation *> connectOps;
+  moduleOp.walk([&](ConnectOp op) { connectOps.push_back(op); });
+  for (auto op : connectOps)
+    op->moveBefore(&moduleOp.front().back());
+}
+
 /// Get the corresponding FIRRTL type given the built-in data type. Current
 /// supported data types are integer (signed, unsigned, and signless), index,
 /// and none.
@@ -1952,6 +1959,8 @@ struct HandshakeFuncOpLowering : public OpConversionPattern<handshake::FuncOp> {
       }
     }
     rewriter.eraseOp(funcOp);
+
+    legalizeFModule(topModuleOp);
 
     return success();
   }

--- a/test/Conversion/HandshakeToFIRRTL/test_load.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_load.mlir
@@ -1,5 +1,4 @@
 // RUN: circt-opt -lower-handshake-to-firrtl -split-input-file -verify-diagnostics %s
-// XFAIL: *
 
 // CHECK-LABEL: firrtl.module @handshake_load_3ins_2outs_ui8(
 // CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<8>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<8>>>, %arg4: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) {


### PR DESCRIPTION
This is a quick fix for issue #534. All ConnectOp in the top FIRRTL module are moved to the end for meeting the def-before-use requirement of FIRRTL dialect.