### PR TITLE
[SV] Add pass to merge AlwaysFF operations

### DIFF
--- a/include/circt/Dialect/SV/CMakeLists.txt
+++ b/include/circt/Dialect/SV/CMakeLists.txt
@@ -12,3 +12,8 @@ mlir_tablegen(SVStructs.h.inc -gen-struct-attr-decls)
 mlir_tablegen(SVStructs.cpp.inc -gen-struct-attr-defs)
 add_public_tablegen_target(MLIRSVStructsIncGen)
 add_dependencies(circt-headers MLIRSVStructsIncGen)
+
+set(LLVM_TARGET_DEFINITIONS SVPasses.td)
+mlir_tablegen(SVPasses.h.inc -gen-pass-decls)
+add_public_tablegen_target(CIRCTSVTransformsIncGen)
+add_circt_doc(Passes -gen-pass-doc SVPasses ./)

--- a/include/circt/Dialect/SV/SVPasses.h
+++ b/include/circt/Dialect/SV/SVPasses.h
@@ -1,0 +1,36 @@
+//===- SVPasses.h - SV pass entry points ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This header file defines prototypes that expose pass constructors.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_SV_SVPASSES_H
+#define CIRCT_DIALECT_SV_SVPASSES_H
+
+#include <memory>
+
+namespace mlir {
+class ModuleOp;
+template <typename T>
+class OperationPass;
+} // namespace mlir
+
+namespace circt {
+namespace sv {
+
+std::unique_ptr<mlir::Pass> createAlwaysFusionPass();
+
+/// Generate the code for registering passes.
+#define GEN_PASS_REGISTRATION
+#include "circt/Dialect/SV/SVPasses.h.inc"
+
+} // namespace sv
+} // namespace circt
+
+#endif // CIRCT_DIALECT_SV_SVPASSES_H

--- a/include/circt/Dialect/SV/SVPasses.td
+++ b/include/circt/Dialect/SV/SVPasses.td
@@ -1,0 +1,47 @@
+//===-- SVPasses.td - SV pass definition file --------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains definitions for passes that work on the SV dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_SV_SVPASSES
+#define CIRCT_DIALECT_SV_SVPASSES
+
+include "mlir/Pass/PassBase.td"
+
+def AlwaysFusion : Pass<"sv-always-fusion"> {
+  let summary = "Combine AlwaysFF blocks with the same predicate";
+  let description = [{
+      This pass finds all AlwaysFF operations with the same condition, and
+      combines them in to a single operation. For example:
+      ```mlir
+      // Input
+      rtl.module() {
+        sv.alwaysff(posedge %clock)  {
+          sv.passign %counter, %1 : i8
+        }
+        sv.alwaysff(posedge %clock)  {
+          sv.passign %param, %2 : i16
+        }
+      }
+  
+      // Output
+      rtl.module() {
+        sv.alwaysff(posedge %clock)  {
+          sv.passign %counter, %1 : i8
+          sv.passign %param, %2 : i16
+        }
+      }
+      ```
+  }];
+
+  let constructor = "circt::sv::createAlwaysFusionPass()";
+}
+
+#endif // CIRCT_DIALECT_SV_SVPASSES

--- a/include/circt/InitAllPasses.h
+++ b/include/circt/InitAllPasses.h
@@ -24,6 +24,7 @@
 #include "circt/Dialect/ESI/ESIDialect.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/LLHD/Transforms/Passes.h"
+#include "circt/Dialect/SV/SVPasses.h"
 
 namespace circt {
 
@@ -45,6 +46,7 @@ inline void registerAllPasses() {
   esi::registerESIPasses();
   firrtl::registerPasses();
   llhd::initLLHDTransformationPasses();
+  sv::registerPasses();
 }
 
 } // namespace circt

--- a/lib/Dialect/SV/CMakeLists.txt
+++ b/lib/Dialect/SV/CMakeLists.txt
@@ -17,3 +17,5 @@ add_circt_dialect_library(CIRCTSV
    )
 
 add_dependencies(circt-headers MLIRSVIncGen)
+
+add_subdirectory(Transforms)

--- a/lib/Dialect/SV/Transforms/AlwaysFusion.cpp
+++ b/lib/Dialect/SV/Transforms/AlwaysFusion.cpp
@@ -1,0 +1,134 @@
+//===- AlwaysFusion.cpp - Always Fusion Pass ------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This transformation pass performs simple fusion of always_ff in the same
+// region.
+//
+//===----------------------------------------------------------------------===//
+
+#include "SVPassDetail.h"
+#include "circt/Dialect/SV/SVDialect.h"
+#include "circt/Dialect/SV/SVOps.h"
+#include "circt/Dialect/SV/SVPasses.h"
+#include "mlir/IR/Visitors.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace mlir;
+using namespace circt;
+using namespace sv;
+
+namespace {
+
+/// Check the equivalence of operations by doing a deep comparison of operands
+/// and attributes, but does not compare the content of any regions attached to
+/// each op.
+struct SimpleOperationInfo : public llvm::DenseMapInfo<Operation *> {
+  static unsigned getHashValue(const Operation *opC) {
+    return OperationEquivalence::computeHash(const_cast<Operation *>(opC));
+  }
+  static bool isEqual(const Operation *lhsC, const Operation *rhsC) {
+    auto *lhs = const_cast<Operation *>(lhsC);
+    auto *rhs = const_cast<Operation *>(rhsC);
+    if (lhs == rhs)
+      return true;
+    if (lhs == getTombstoneKey() || lhs == getEmptyKey() ||
+        rhs == getTombstoneKey() || rhs == getEmptyKey())
+      return false;
+    return OperationEquivalence::isEquivalentTo(const_cast<Operation *>(lhsC),
+                                                const_cast<Operation *>(rhsC));
+  }
+};
+
+// Merge two regions together. These regions must only have a one block.
+static void mergeRegions(Region *region1, Region *region2) {
+  assert(region1->getBlocks().size() <= 1 && region2->getBlocks().size() <= 1 &&
+         "Can only merge regions with a single block");
+  if (region1->empty()) {
+    // If both regions are empty, move on to the next pair of regions
+    if (region2->empty())
+      return;
+    // If the first region has no block, move the second region's block over.
+    region1->getBlocks().splice(region1->end(), region2->getBlocks());
+    return;
+  }
+  // If the second region is not empty, splice its block into the end of the
+  // first region.
+  if (!region2->empty()) {
+    auto &block1 = region1->front();
+    auto &block2 = region2->front();
+    // Remove the terminator from the first block before merging.
+    assert(isa<YieldOp>(block1.back()) &&
+           "Block should be terminated by an sv.yield operation");
+    block1.back().erase();
+    block1.getOperations().splice(block1.end(), block2.getOperations());
+  }
+}
+
+/// Inline all regions from the second operation into the first.
+static void mergeOperations(Operation *op1, Operation *op2) {
+  assert(op1 != op2 && "Cannot merge an op into itself");
+  for (unsigned i = 0; i < op1->getNumRegions(); ++i)
+    mergeRegions(&op1->getRegion(i), &op2->getRegion(i));
+}
+
+struct AlwaysFusionPass : public AlwaysFusionBase<AlwaysFusionPass> {
+  void runOnOperation() override {
+    auto *op = getOperation();
+
+    // Keeps track if anything changed during this pass, used to determine if
+    // the analyses were preserved.
+    bool graphChanged = false;
+
+    auto kindInterface = dyn_cast<mlir::RegionKindInterface>(op);
+    for (unsigned i = 0; i < op->getNumRegions(); ++i) {
+      // If the operation does not implement the region kind interface, all of
+      // its regions are implicitly regular SSACFG region. Since we are blindly
+      // combining alwaysff blocks, make sure they are in a graph region.
+      if (!kindInterface ||
+          kindInterface.getRegionKind(i) == RegionKind::SSACFG)
+        continue;
+
+      if (op->getRegion(i).empty())
+        continue;
+
+      // Graph regions only have 1 block.
+      auto &block = op->getRegion(i).front();
+
+      // A set of operations in the current block which are mergable. Any
+      // operation in this set is a candidate for another similar operation to
+      // merge in to.
+      DenseSet<Operation *, SimpleOperationInfo> foundOps;
+      for (sv::AlwaysFFOp alwaysOp :
+           llvm::make_early_inc_range(block.getOps<sv::AlwaysFFOp>())) {
+        // check if we have encountered an equivalent operation already.  If we
+        // have, merge them together and delete the old operation.
+        auto it = foundOps.find(alwaysOp);
+        if (it == foundOps.end()) {
+          // Record new mergable ops as a candidate for merging
+          foundOps.insert(alwaysOp);
+        } else {
+          // Merge with a similar alwaysff
+          mergeOperations(*it, alwaysOp);
+          alwaysOp.erase();
+          graphChanged = true;
+        }
+      }
+    }
+
+    // If we did not change anything in the graph mark all analysis as
+    // preserved.
+    if (!graphChanged)
+      markAllAnalysesPreserved();
+  }
+};
+
+} // end anonymous namespace
+
+std::unique_ptr<Pass> circt::sv::createAlwaysFusionPass() {
+  return std::make_unique<AlwaysFusionPass>();
+}

--- a/lib/Dialect/SV/Transforms/CMakeLists.txt
+++ b/lib/Dialect/SV/Transforms/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_circt_dialect_library(CIRCTSVTransforms
+  AlwaysFusion.cpp
+
+  DEPENDS
+  CIRCTSVTransformsIncGen
+
+  LINK_LIBS PUBLIC
+  CIRCTSV
+  MLIRIR
+  MLIRPass
+  MLIRTransformUtils
+)

--- a/lib/Dialect/SV/Transforms/SVPassDetail.h
+++ b/lib/Dialect/SV/Transforms/SVPassDetail.h
@@ -1,0 +1,27 @@
+//===- PassDetail.h - SV pass class details ---------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// clang-tidy seems to expect the absolute path in the header guard on some
+// systems, so just disable it.
+// NOLINTNEXTLINE(llvm-header-guard)
+#ifndef DIALECT_SV_TRANSFORMS_SVPASSDETAIL_H
+#define DIALECT_SV_TRANSFORMS_SVPASSDETAIL_H
+
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "mlir/Pass/Pass.h"
+
+namespace circt {
+namespace sv {
+
+#define GEN_PASS_CLASSES
+#include "circt/Dialect/SV/SVPasses.h.inc"
+
+} // namespace sv
+} // namespace circt
+
+#endif // DIALECT_FIRRTL_TRANSFORMS_SVPASSDETAIL_H

--- a/test/Dialect/SV/always-fusion.mlir
+++ b/test/Dialect/SV/always-fusion.mlir
@@ -1,0 +1,99 @@
+// RUN: circt-opt -pass-pipeline='rtl.module(sv-always-fusion)' %s | FileCheck %s
+
+//CHECK-LABEL: rtl.module @alwaysff_basic(%arg0: i1, %arg1: i1) {
+//CHECK-NEXT:   sv.alwaysff(posedge %arg0)  {
+//CHECK-NEXT:     sv.fwrite "A1"
+//CHECK-NEXT:     sv.fwrite "A2"
+//CHECK-NEXT:   }
+//CHECK-NEXT:   sv.alwaysff(posedge %arg1)  {
+//CHECK-NEXT:     sv.fwrite "B1"
+//CHECK-NEXT:     sv.fwrite "B2"
+//CHECK-NEXT:   }
+//CHECK-NEXT:   sv.fwrite "Middle\0A"
+//CHECK-NEXT:   rtl.output
+//CHECK-NEXT: }
+
+rtl.module @alwaysff_basic(%arg0: i1, %arg1: i1) {
+  sv.alwaysff(posedge %arg0) {
+    sv.fwrite "A1"
+  }
+  sv.alwaysff(posedge %arg1) {
+    sv.fwrite "B1"
+  }
+  sv.fwrite "Middle\n"
+  sv.alwaysff(posedge %arg0) {
+    sv.fwrite "A2"
+  }
+  sv.alwaysff(posedge %arg1) {
+    sv.fwrite "B2"
+  }
+  rtl.output
+}
+
+// CHECK-LABEL: rtl.module @alwaysff_basic_reset(%arg0: i1, %arg1: i1) {
+// CHECK-NEXT:   sv.alwaysff(posedge %arg0)  {
+// CHECK-NEXT:     sv.fwrite "A1"
+// CHECK-NEXT:     sv.fwrite "A2"
+// CHECK-NEXT:   }(asyncreset : negedge %arg1)  {
+// CHECK-NEXT:     sv.fwrite "B1"
+// CHECK-NEXT:     sv.fwrite "B2"
+// CHECK-NEXT:   }
+// CHECK-NEXT:   rtl.output
+// CHECK-NEXT: }
+
+rtl.module @alwaysff_basic_reset(%arg0: i1, %arg1: i1) {
+  sv.alwaysff (posedge %arg0) {
+    sv.fwrite "A1"
+  } ( asyncreset : negedge %arg1) {
+    sv.fwrite "B1"
+  }
+  sv.alwaysff (posedge %arg0) {
+    sv.fwrite "A2"
+  } ( asyncreset : negedge %arg1) {
+    sv.fwrite "B2"
+  }
+  rtl.output
+}
+
+
+// CHECK-LABEL: rtl.module @alwaysff_different_reset(%arg0: i1, %arg1: i1) {
+// CHECK-NEXT:   sv.alwaysff(posedge %arg0)  {
+// CHECK-NEXT:     sv.fwrite "A1"
+// CHECK-NEXT:     sv.fwrite "A2"
+// CHECK-NEXT:   }(asyncreset : negedge %arg1)  {
+// CHECK-NEXT:     sv.fwrite "B1"
+// CHECK-NEXT:     sv.fwrite "B2"
+// CHECK-NEXT:   }
+// CHECK-NEXT:   sv.alwaysff(posedge %arg0)  {
+// CHECK-NEXT:     sv.fwrite "C1"
+// CHECK-NEXT:     sv.fwrite "C2"
+// CHECK-NEXT:   }(asyncreset : posedge %arg1)  {
+// CHECK-NEXT:     sv.fwrite "D1"
+// CHECK-NEXT:     sv.fwrite "D2"
+// CHECK-NEXT:   }
+// CHECK-NEXT:   rtl.output
+// CHECK-NEXT: }
+
+rtl.module @alwaysff_different_reset(%arg0: i1, %arg1: i1) {
+  sv.alwaysff (posedge %arg0) {
+    sv.fwrite "A1"
+  } ( asyncreset : negedge %arg1) {
+    sv.fwrite "B1"
+  }
+  sv.alwaysff (posedge %arg0) {
+    sv.fwrite "C1"
+  } ( asyncreset : posedge %arg1) {
+    sv.fwrite "D1"
+  }
+  sv.alwaysff (posedge %arg0) {
+    sv.fwrite "A2"
+  } ( asyncreset : negedge %arg1) {
+    sv.fwrite "B2"
+  }
+  sv.alwaysff (posedge %arg0) {
+    sv.fwrite "C2"
+  } ( asyncreset : posedge %arg1) {
+    sv.fwrite "D2"
+  }
+  rtl.output
+}

--- a/tools/circt-opt/CMakeLists.txt
+++ b/tools/circt-opt/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(circt-opt
   CIRCTStandardToStaticLogic
   CIRCTStaticLogicOps
   CIRCTSV
+  CIRCTSVTransforms
 
   MLIRParser
   MLIRSupport

--- a/tools/firtool/CMakeLists.txt
+++ b/tools/firtool/CMakeLists.txt
@@ -11,6 +11,7 @@ target_link_libraries(firtool PRIVATE
   CIRCTImportFIRRTL
   CIRCTFIRRTLToRTL
   CIRCTFIRRTLTransforms
+  CIRCTSVTransforms
 
   MLIRParser
   MLIRSupport

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -19,6 +19,7 @@
 #include "circt/Dialect/RTL/RTLDialect.h"
 #include "circt/Dialect/RTL/RTLOps.h"
 #include "circt/Dialect/SV/SVDialect.h"
+#include "circt/Dialect/SV/SVPasses.h"
 #include "circt/Translation/ExportVerilog.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -133,6 +134,7 @@ processBuffer(std::unique_ptr<llvm::MemoryBuffer> ownedBuffer,
 
     // If enabled, run the optimizer.
     if (!disableOptimization) {
+      pm.addNestedPass<rtl::RTLModuleOp>(sv::createAlwaysFusionPass());
       pm.addPass(createCSEPass());
       pm.addPass(createCanonicalizerPass());
     }


### PR DESCRIPTION
This adds a pass to merge `sv.alwaysff` operations with identical
conditions.  Due to the design of this operation it is trivial to check
if we meet the conditions for merging this operation.  This pass is
structured to not depend on the RTL dialect, and does not assume that
the `sv.alwaysff` operations are in an RTL module.  They do, however,
need to be in a graph region to work.

Although `sv.alwaysff` regions are not graph regions, they are limited
to having a single block.  This pass takes advantage of this to quickly
splice blocks together when merging operations.

cc @darthscsi @seldridge 