### PR TITLE
[FIRRTL] Add MemOp Verification

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -61,7 +61,7 @@ def SMemOp : FIRRTLOp<"smem", [/*MemAlloc*/]> {
 
 def MemOp : FIRRTLOp<"mem", [/*MemAlloc*/]> {
   let summary = "Define a new mem";
-  let arguments = (ins I32Attr:$readLatency,
+  let arguments = (ins Confined<I32Attr, [IntMinValue<0>]>:$readLatency,
                        Confined<I32Attr, [IntMinValue<1>]>:$writeLatency,
                        Confined<I64Attr, [IntMinValue<1>]>:$depth, RUWAttr:$ruw,
                        StrArrayAttr:$portNames,
@@ -69,6 +69,8 @@ def MemOp : FIRRTLOp<"mem", [/*MemAlloc*/]> {
   let results = (outs Variadic<FIRRTLType>:$results);
 
   let assemblyFormat = "$ruw attr-dict `:` type($results)";
+
+  let verifier = "return ::verifyMemOp(*this);";
 
   let extraClassDeclaration = [{
     enum class PortKind { Read, Write, ReadWrite };

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1160,6 +1160,7 @@ FIRRTLType XorPrimOp::getResultType(FIRRTLType lhs, FIRRTLType rhs,
                                     Location loc) {
   return getBitwiseBinaryResult(lhs, rhs, loc);
 }
+
 static FIRRTLType getCompareResult(FIRRTLType lhs, FIRRTLType rhs,
                                    Location loc) {
   int32_t lhsWidth, rhsWidth;

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -19,6 +19,10 @@
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/FunctionImplementation.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallSet.h"
+#include "llvm/ADT/StringSet.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 using namespace circt;
 using namespace firrtl;
@@ -634,6 +638,135 @@ static LogicalResult verifyInstanceOp(InstanceOp instance) {
   return success();
 }
 
+/// Verify the correctness of a MemOp.
+static LogicalResult verifyMemOp(MemOp mem) {
+
+  // Store the port names as we find them. This lets us check quickly
+  // for uniqueneess.
+  StringSet<> portNamesSet;
+
+  // Store the previous data type. This lets us check that the data
+  // type is consistent across all ports.
+  FIRRTLType oldDataType;
+
+  for (size_t i = 0, e = mem.getNumResults(); i != e; ++i) {
+    auto portName = mem.getPortName(i);
+
+    // Get a bundle type representing this port, stripping an outer
+    // flip if it exists.  If this is not a bundle<> or
+    // flip<bundle<>>, then this is an error.
+    BundleType portBundleType =
+        TypeSwitch<FIRRTLType, BundleType>(
+            mem.getResult(i).getType().cast<FIRRTLType>())
+            .Case<BundleType>([](BundleType a) { return a; })
+            .Case<FlipType>([](FlipType a) {
+              return a.getElementType().dyn_cast<BundleType>();
+            })
+            .Default([](auto) { return nullptr; });
+    if (!portBundleType) {
+      mem.emitOpError() << "has an invalid type on port " << portName
+                        << " (expected either '!firrtl.bundle<...>' or "
+                           "'!firrtl.flip<bundle<...>>')";
+      return failure();
+    }
+
+    // Require that all port names are unique.
+    if (!std::get<1>(portNamesSet.insert(portName.getValue()))) {
+      mem.emitOpError() << "has non-unique port name " << portName;
+      return failure();
+    }
+
+    // Determine the kind of the memory.  If the kind cannot be
+    // determined, then it's indicative of the wrong number of fields
+    // in the type (but we don't know any more just yet).
+    MemOp::PortKind portKind;
+    {
+      auto portKindOption =
+          mem.getPortKind(mem.getPortName(i).getValue().str());
+      if (!portKindOption.hasValue()) {
+        mem.emitOpError()
+            << "has an invalid number of fields on port " << portName
+            << " (expected 4 for read, 5 for write, or 7 for read/write)";
+        return failure();
+      }
+      portKind = portKindOption.getValue();
+    }
+
+    // Safely search for the "data" field, erroring if it can't be
+    // found.
+    FIRRTLType dataType;
+    {
+      auto dataTypeOption = portBundleType.getElement("data");
+      if (!dataTypeOption && portKind == MemOp::PortKind::ReadWrite)
+        dataTypeOption = portBundleType.getElement("rdata");
+      if (!dataTypeOption) {
+        mem.emitOpError() << "has no data field on port " << portName
+                          << " (expected to see \"data\" for a read or write "
+                             "port or \"rdata\" for a read/write port)";
+        return failure();
+      }
+      dataType = dataTypeOption.getValue().type;
+    }
+
+    // Error if the data type isn't passive.
+    if (!dataType.isPassive()) {
+      mem.emitOpError() << "has non-passive data type on port " << portName
+                        << " (memory types must be passive)";
+      return failure();
+    }
+
+    // Error if the data type contains analog types.
+    if (dataType.containsAnalog()) {
+      mem.emitOpError()
+          << "has a data type that contains an analog type on port " << portName
+          << " (memory types cannot contain analog types)";
+      return failure();
+    }
+
+    // Check that the port type matches the kind that we determined
+    // for this port.  This catches situations of extraneous port
+    // fields beind included or the fields being named incorrectly.
+    FIRRTLType expectedType =
+        FlipType::get(mem.getTypeForPort(mem.depth(), dataType, portKind));
+    // Compute the original port type as portBundleType may have
+    // stripped outer flip information.
+    auto originalType = mem.getResult(i).getType();
+    if (originalType != expectedType) {
+      StringRef portKindName;
+      switch (portKind) {
+      case MemOp::PortKind::Read:
+        portKindName = "read";
+        break;
+      case MemOp::PortKind::Write:
+        portKindName = "write";
+        break;
+      case MemOp::PortKind::ReadWrite:
+        portKindName = "readwrite";
+        break;
+      }
+      mem.emitOpError() << "has an invalid type for port " << portName
+                        << " of determined kind \"" << portKindName
+                        << "\" (expected " << expectedType << ", but got "
+                        << originalType << ")";
+      return failure();
+    }
+
+    // Error if the type of the current port was not the same as the
+    // last port, but skip checking the first port.
+    if (oldDataType && (oldDataType != dataType)) {
+      mem.emitOpError() << "port " << mem.getPortName(i)
+                        << " has a different type than port "
+                        << mem.getPortName(i - 1) << " (expected "
+                        << oldDataType << ", but got " << dataType << ")";
+      return failure();
+    }
+
+    oldDataType = dataType;
+  }
+
+  return success();
+}
+
 BundleType MemOp::getTypeForPort(uint64_t depth, FIRRTLType dataType,
                                  PortKind portKind) {
 
@@ -1027,7 +1160,6 @@ FIRRTLType XorPrimOp::getResultType(FIRRTLType lhs, FIRRTLType rhs,
                                     Location loc) {
   return getBitwiseBinaryResult(lhs, rhs, loc);
 }
-
 static FIRRTLType getCompareResult(FIRRTLType lhs, FIRRTLType rhs,
                                    Location loc) {
   int32_t lhsWidth, rhsWidth;
@@ -1083,7 +1215,8 @@ FIRRTLType DShlPrimOp::getResultType(FIRRTLType lhs, FIRRTLType rhs,
     return {};
   }
 
-  // If the left or right has unknown result type, then the operation does too.
+  // If the left or right has unknown result type, then the operation does
+  // too.
   auto width = lhsi.getWidthOrSentinel();
   if (width == -1 || !rhsui.getWidth().hasValue())
     width = -1;
@@ -1312,9 +1445,9 @@ FIRRTLType MuxPrimOp::getResultType(FIRRTLType sel, FIRRTLType high,
   }
 
   if (low.isa<IntType>()) {
-    // Two different Int types can be compatible.  If either has unknown width,
-    // then return it.  If both are known but different width, then return the
-    // larger one.
+    // Two different Int types can be compatible.  If either has unknown
+    // width, then return it.  If both are known but different width, then
+    // return the larger one.
     int32_t highWidth = high.getBitWidthOrSentinel();
     int32_t lowWidth = low.getBitWidthOrSentinel();
     if (lowWidth == -1)

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2118,14 +2118,6 @@ ParseResult FIRStmtParser::parseMem(unsigned memIndent) {
     }
   }
 
-  if (!type.isPassive()) {
-    emitError(info.getFIRLoc(), "'mem' data-type must be a passive type");
-    return failure();
-  }
-
-  if (readLatency < 0 || writeLatency < 0)
-    return emitError(info.getFIRLoc(), "invalid latency");
-
   // The FIRRTL dialect requires mems to have at least one port.  Since portless
   // mems can never be referenced, it is always safe to drop them.
   if (ports.empty())
@@ -2139,12 +2131,6 @@ ParseResult FIRStmtParser::parseMem(unsigned memIndent) {
                          return lhs->first.getValue().compare(
                              rhs->first.getValue());
                        });
-
-  // Require that all port names are unique.
-  // TODO: Move this into MemOp verification.
-  for (size_t i = 1, e = ports.size(); i < e; ++i)
-    if (ports[i - 1].first == ports[i].first)
-      return {};
 
   SmallVector<Attribute, 4> resultNames;
   SmallVector<Type, 4> resultTypes;

--- a/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
+++ b/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
@@ -696,7 +696,7 @@ module attributes {firrtl.mainModule = "Simple"} {
   //    input clock2 : Clock
   //
   //    mem _M : @[Decoupled.scala 209:24]
-  //          data-type => { id : Analog<4>, other: SInt<8> }
+  //          data-type => { id : UInt<4>, other: SInt<8> }
   //          depth => 20
   //          read-latency => 0
   //          write-latency => 1
@@ -720,13 +720,13 @@ module attributes {firrtl.mainModule = "Simple"} {
   rtl.module @MemAggregate(%clock1: i1, %clock2: i1) {
       %0 = firrtl.stdIntCast %clock1 : (i1) -> !firrtl.clock
       %1 = firrtl.stdIntCast %clock2 : (i1) -> !firrtl.clock
-      %_M_read, %_M_write = firrtl.mem Undefined {depth = 20 : i64, name = "_M", portNames = ["read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<5>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<id: analog<4>, other: sint<8>>>, !firrtl.flip<bundle<addr: uint<5>, en: uint<1>, clk: clock, data: bundle<id: analog<4>, other: sint<8>>, mask: bundle<id: uint<1>, other: uint<1>>>>
+      %_M_read, %_M_write = firrtl.mem Undefined {depth = 20 : i64, name = "_M", portNames = ["read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<5>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<id: uint<4>, other: sint<8>>>, !firrtl.flip<bundle<addr: uint<5>, en: uint<1>, clk: clock, data: bundle<id: uint<4>, other: sint<8>>, mask: bundle<id: uint<1>, other: uint<1>>>>
       rtl.output
     }
 
   // module MemOne :
   //   mem _M : @[Decoupled.scala 209:24]
-  //         data-type => { id : Analog<4>, other: SInt<8> }
+  //         data-type => { id : UInt<4>, other: SInt<8> }
   //         depth => 1
   //         read-latency => 0
   //         write-latency => 1
@@ -755,7 +755,7 @@ module attributes {firrtl.mainModule = "Simple"} {
   // CHECK:   rtl.output
   // CHECK-NEXT: }
   rtl.module @MemOne() {
-    %_M_read, %_M_write = firrtl.mem Undefined {depth = 1 : i64, name = "_M", portNames=["read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<1>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<id: analog<4>, other: sint<8>>>, !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<id: analog<4>, other: sint<8>>, mask: bundle<id: uint<1>, other: uint<1>>>>
+    %_M_read, %_M_write = firrtl.mem Undefined {depth = 1 : i64, name = "_M", portNames=["read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<1>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<id: uint<4>, other: sint<8>>>, !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<id: uint<4>, other: sint<8>>, mask: bundle<id: uint<1>, other: uint<1>>>>
     rtl.output
   }
 

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -335,11 +335,11 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     ; CHECK: %_M__T_10, %_M__T_11, %_M__T_18 = firrtl.mem Undefined {depth = 8 : i64, name = "_M", portNames = ["_T_10", "_T_11", "_T_18"]
     ; CHECK:   readLatency = 0 : i32, writeLatency = 1 : i32} :
-    ; CHECK:       !firrtl.bundle<addr: flip<uint<3>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<id: analog<4>>, mask: flip<bundle<id: uint<1>>>>,
-    ; CHECK:       !firrtl.bundle<addr: flip<uint<3>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<id: analog<4>>, mask: flip<bundle<id: uint<1>>>>,
-    ; CHECK:       !firrtl.bundle<addr: flip<uint<3>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<id: analog<4>>
+    ; CHECK:       !firrtl.flip<bundle<addr: uint<3>, en: uint<1>, clk: clock, data: bundle<id: uint<4>>, mask: bundle<id: uint<1>>>>,
+    ; CHECK:       !firrtl.flip<bundle<addr: uint<3>, en: uint<1>, clk: clock, data: bundle<id: uint<4>>, mask: bundle<id: uint<1>>>>,
+    ; CHECK:       !firrtl.bundle<addr: flip<uint<3>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<id: uint<4>>
     mem _M : @[Decoupled.scala 209:24]
-        data-type => { id : Analog<4> }
+        data-type => { id : UInt<4> }
         depth => 8
         read-latency => 0
         write-latency => 1
@@ -614,4 +614,3 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     memory.w.addr <= wAddr
     memory.w.mask <= wMask
     memory.w.data <= wData
-

--- a/test/ExportVerilog/verilog-basic.fir
+++ b/test/ExportVerilog/verilog-basic.fir
@@ -547,7 +547,7 @@ circuit inputs_only :
     ; CHECK-NOT:    reg  [3:0] _M_id[19:0];
     ; CHECK-NOT:    reg  [3:0] _M_other[19:0];
     mem _M : @[Decoupled.scala 209:24]
-          data-type => { id : Analog<4>, other: SInt<8> }
+          data-type => { id : UInt<4>, other: SInt<8> }
           depth => 20
           read-latency => 0
           write-latency => 1
@@ -595,7 +595,7 @@ circuit inputs_only :
  ; CHECK-LABEL: module MemOne();
   module MemOne :
     mem _M : @[Decoupled.scala 209:24]
-          data-type => { id : Analog<4>, other: SInt<8> }
+          data-type => { id : UInt<4>, other: SInt<8> }
           depth => 1
           read-latency => 0
           write-latency => 1


### PR DESCRIPTION
Add verifiers for FIRRTL dialect memory ops. Specifically, this adds the following verification checks:

  1. All ports have valid types (must be bundle or flip<bundle>).
  2. All port names are unique.
  3. All ports have the correct number of fields (kinds can be
     determined).
  4. A "data" field (for read or write kind ) or "rdata" field (for
     readwrite kind) is present in each port.
  5. All ports have passive data type.
  6. All ports contain no analogs.
  7. Each port has the correct type for its determined kind.
  8. All port data types are the same.
  9. The read latency is non-negative.

Additionally, any tests that violated point `6` are fixed.

Fixes #519.