### PR TITLE
[RTL] Add bitwise negation and logical negation to RTL dialect.

### DIFF
--- a/include/circt/Dialect/RTL/RTLCombinatorial.td
+++ b/include/circt/Dialect/RTL/RTLCombinatorial.td
@@ -206,6 +206,18 @@ def AndROp : UnaryI1ReductionRTLOp<"andr">;
 def OrROp  : UnaryI1ReductionRTLOp<"orr">;
 def XorROp : UnaryI1ReductionRTLOp<"xorr">;
 
+// Base class for non-reduction unary operations.
+class UnaryRTLOp<string mnemonic, list<OpTrait> traits = []> :
+      RTLOp<mnemonic, traits # [SameOperandsAndResultType]> {
+  let arguments = (ins RTLIntegerType:$input);
+  let results = (outs RTLIntegerType:$result);
+
+  let assemblyFormat = "$input attr-dict `:` type($result)";
+}
+
+def BitNegOp : UnaryRTLOp<"neg">;
+def LogNegOp : UnaryRTLOp<"not">;
+
 //===----------------------------------------------------------------------===//
 // Integer width modifying operations.
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/RTL/RTLVisitors.h
+++ b/include/circt/Dialect/RTL/RTLVisitors.h
@@ -37,6 +37,8 @@ public:
                        ICmpOp,
                        // Reduction Operators
                        AndROp, OrROp, XorROp,
+                       // Non-reduction unary ops
+                       BitNegOp, LogNegOp,
                        // Other operations.
                        SExtOp, ConcatOp, ExtractOp, MuxOp,
                        // Cast operation
@@ -105,6 +107,10 @@ public:
   HANDLE(AndROp, Unary);
   HANDLE(OrROp, Unary);
   HANDLE(XorROp, Unary);
+
+  // Unary but not reductions
+  HANDLE(BitNegOp, Unary);
+  HANDLE(LogNegOp, Unary);
 
   HANDLE(ICmpOp, Binary);
 

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -709,6 +709,8 @@ private:
   SubExprInfo visitComb(AndROp op) { return emitUnary(op, "&", true); }
   SubExprInfo visitComb(OrROp op) { return emitUnary(op, "|", true); }
   SubExprInfo visitComb(XorROp op) { return emitUnary(op, "^", true); }
+  SubExprInfo visitComb(BitNegOp op) { return emitUnary(op, "~"); }
+  SubExprInfo visitComb(LogNegOp op) { return emitUnary(op, "!"); }
 
   SubExprInfo visitComb(SExtOp op);
   SubExprInfo visitComb(ConcatOp op);


### PR DESCRIPTION
This creates a non-reduction unary base class for bitwise (~) and logical (!) negation in the RTL dialect and updates ExportVerilog. 