### PR TITLE
[LLHD] Add connect operation.

### DIFF
--- a/include/circt/Dialect/LLHD/IR/StructureOps.td
+++ b/include/circt/Dialect/LLHD/IR/StructureOps.td
@@ -138,7 +138,7 @@ def LLHD_ProcOp : LLHD_Op<"proc", [
 }
 
 //===----------------------------------------------------------------------===//
-//=== Process and Entity Instanciation
+//=== Process and Entity Structure
 //===----------------------------------------------------------------------===//
 
 def LLHD_InstOp : LLHD_Op<"inst", [
@@ -199,6 +199,24 @@ def LLHD_InstOp : LLHD_Op<"inst", [
   }];
 
   let verifier = [{ return ::verify(*this); }];
+}
+
+def LLHD_ConnectOp : LLHD_Op<"con", [
+    SameTypeOperands,
+    HasParent<"EntityOp">
+  ]> {
+  let summary = "Connect two signals.";
+  let description = [{
+    The `con` instruction connects two signals such that they essentially become
+    one signal. All driven values on one signal will be reflected on the other.
+  }];
+
+  let arguments = (ins LLHD_AnySigType:$lhs,
+                       LLHD_AnySigType:$rhs);
+
+  let assemblyFormat = [{
+    operands attr-dict `:` type($lhs)
+  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/LLHD/IR/con.mlir
+++ b/test/Dialect/LLHD/IR/con.mlir
@@ -1,0 +1,26 @@
+// RUN: circt-opt %s -split-input-file -verify-diagnostics | FileCheck %s
+
+// CHECK-LABEL: @connect_ports
+// CHECK-SAME: (%[[IN:.+]] : [[TYPE:.+]]) ->
+// CHECK-SAME: (%[[OUT:.+]] : [[TYPE]])
+// CHECK-NEXT: llhd.con %[[IN]], %[[OUT]] : [[TYPE]]
+llhd.entity @connect_ports(%in: !llhd.sig<i32>) -> (%out: !llhd.sig<i32>) {
+  llhd.con %in, %out : !llhd.sig<i32>
+}
+
+// -----
+
+// expected-note @+1 {{prior use here}}
+llhd.entity @connect_different_types(%in: !llhd.sig<i8>) -> (%out: !llhd.sig<i32>) {
+  // expected-error @+1 {{use of value '%out' expects different type}}
+  llhd.con %in, %out : !llhd.sig<i8>
+  // expected-error @+1 {{expected operation}}
+}
+// -----
+
+llhd.entity @connect_non_signals(%in: !llhd.sig<i32>) -> (%out: !llhd.sig<i32>) {
+  %0 = llhd.prb %in : !llhd.sig<i32>
+  %1 = llhd.prb %out : !llhd.sig<i32>
+  // expected-error @+1 {{'llhd.con' op operand #0 must be LLHD sig type}}
+  llhd.con %0, %1 : i32
+}


### PR DESCRIPTION
This operation is unfortunately necessary to model structural
connections between signals. The assembly format is modified from the
LLHD spec to print the type on the right like other LLHD MLIR
operations. The operation name in C++ is ConnectOp to align with other
dialects' choice of name for this concept.