### PR TITLE
Update Pass documentation

### DIFF
--- a/docs/Passes.md
+++ b/docs/Passes.md
@@ -4,10 +4,6 @@ This document describes the available CIRCT passes and their contracts.
 
 [TOC]
 
-## Transformations Passes
-
-[include "Transformations.md"]
-
 ## Conversion Passes
 
 [include "FIRRTLToLLHD.md"]
@@ -18,10 +14,18 @@ This document describes the available CIRCT passes and their contracts.
 
 [include "CIRCTConversionPasses.md"]
 
-## `firrtl` Dialect Passes
+## ESI Dialect Passes
+
+[include "ESIPasses.md"]
+
+## FIRRTL Dialect Passes
 
 [include "FIRRTLPasses.md"]
 
-## `sv` Dialect Passes
+## LLHD Dialect Passes
 
-[include "SVPasses.md"] 
+[include "LLHDPasses.md"]
+
+## SV Dialect Passes
+
+[include "SVPasses.md"]

--- a/include/circt/Dialect/ESI/CMakeLists.txt
+++ b/include/circt/Dialect/ESI/CMakeLists.txt
@@ -6,6 +6,8 @@ mlir_tablegen(ESIAttrs.h.inc -gen-struct-attr-decls)
 mlir_tablegen(ESIAttrs.cpp.inc -gen-struct-attr-defs)
 mlir_tablegen(ESIPasses.h.inc -gen-pass-decls)
 
+add_circt_doc(ESI -gen-pass-doc ESIPasses ./)
+
 add_public_tablegen_target(MLIRESIEnumsIncGen)
 
 add_subdirectory(cosim)

--- a/include/circt/Dialect/LLHD/Transforms/CMakeLists.txt
+++ b/include/circt/Dialect/LLHD/Transforms/CMakeLists.txt
@@ -2,4 +2,4 @@ set(LLVM_TARGET_DEFINITIONS Passes.td)
 mlir_tablegen(Passes.h.inc -gen-pass-decls)
 add_public_tablegen_target(CIRCTLLHDTransformsIncGen)
 
-add_circt_doc(Passes -gen-pass-doc Transformations ./)
+add_circt_doc(Passes -gen-pass-doc LLHDPasses ./)


### PR DESCRIPTION
- Rename LLHD pass documentation from "Transformation Passes" to "LLHD
  Passes".
- Stop using backticks around dialect names in titles.  It renders in a
  way which is hard to read.
- Add ESI Passes
- Fix inclusion of SV passes.

Current pass documentation hosted here: https://circt.llvm.org/docs/Passes/
cc @xgupta 