### PR TITLE
[LLHD] Update output lowering to just emit connects for signals.

### DIFF
--- a/test/Conversion/RTLToLLHD/structure.mlir
+++ b/test/Conversion/RTLToLLHD/structure.mlir
@@ -5,9 +5,7 @@ module {
   // CHECK-SAME: (%[[IN:.+]] : !llhd.sig<i1>) ->
   // CHECK-SAME: (%[[OUT:.+]] : !llhd.sig<i1>)
   rtl.module @test(%in: i1) -> (%out: i1) {
-    // CHECK: %[[DELTA:.*]] = llhd.const #llhd.time<0ns, 1d, 0e>
-    // CHECK: %[[PRB:.*]] = llhd.prb %[[IN]]
-    // CHECK: llhd.drv %[[OUT]], %[[PRB]] after %[[DELTA]]
+    // CHECK: llhd.con %[[OUT]], %[[IN]]
     rtl.output %in: i1
   }
 }


### PR DESCRIPTION
When the value being output is already a signal, there is no need to
probe it and then immediately drive the result signal. Instead, the
lowering for `rtl.output` just emits a `llhd.con` in this case.