### PR TITLE
3 fixes for old GCC

### DIFF
--- a/lib/Dialect/ESI/ESIDialect.cpp
+++ b/lib/Dialect/ESI/ESIDialect.cpp
@@ -15,7 +15,6 @@
 #include "circt/Dialect/ESI/ESITypes.h"
 
 #include "mlir/IR/DialectImplementation.h"
-#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/FormatVariadic.h"
 
 using namespace mlir;

--- a/lib/Dialect/ESI/ESIPasses.cpp
+++ b/lib/Dialect/ESI/ESIPasses.cpp
@@ -17,7 +17,6 @@
 #include "circt/Dialect/SV/SVOps.h"
 #include "circt/Support/BackedgeBuilder.h"
 #include "circt/Support/ImplicitLocOpBuilder.h"
-
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Pass/Pass.h"

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -236,7 +236,8 @@ FIRRTLType FIRRTLType::getPassiveType() {
 FIRRTLType FIRRTLType::getMaskType() {
   return TypeSwitch<FIRRTLType, FIRRTLType>(*this)
       .Case<ClockType, ResetType, AsyncResetType, SIntType, UIntType,
-            AnalogType>([&](Type) { return UIntType::get(getContext(), 1); })
+            AnalogType>(
+          [&](Type) { return UIntType::get(this->getContext(), 1); })
       .Case<FlipType>([](FlipType flipType) {
         return FlipType::get(flipType.getElementType().getMaskType());
       })
@@ -245,7 +246,7 @@ FIRRTLType FIRRTLType::getMaskType() {
         newElements.reserve(bundleType.getElements().size());
         for (auto elt : bundleType.getElements())
           newElements.push_back({elt.name, elt.type.getMaskType()});
-        return BundleType::get(newElements, getContext());
+        return BundleType::get(newElements, this->getContext());
       })
       .Case<FVectorType>([](FVectorType vectorType) {
         return FVectorType::get(vectorType.getElementType().getMaskType(),
@@ -266,13 +267,13 @@ FIRRTLType FIRRTLType::getWidthlessType() {
         return FlipType::get(a.getElementType().getWidthlessType());
       })
       .Case<UIntType, SIntType, AnalogType>(
-          [&](auto a) { return a.get(getContext(), -1); })
+          [&](auto a) { return a.get(this->getContext(), -1); })
       .Case<BundleType>([&](auto a) {
         SmallVector<BundleType::BundleElement, 4> newElements;
         newElements.reserve(a.getElements().size());
         for (auto elt : a.getElements())
           newElements.push_back({elt.name, elt.type.getWidthlessType()});
-        return BundleType::get(newElements, getContext());
+        return BundleType::get(newElements, this->getContext());
       })
       .Case<FVectorType>([](auto a) {
         return FVectorType::get(a.getElementType().getWidthlessType(),

--- a/lib/Dialect/RTL/RTLFolds.cpp
+++ b/lib/Dialect/RTL/RTLFolds.cpp
@@ -203,7 +203,7 @@ OpFoldResult AndOp::fold(ArrayRef<Attribute> constants) {
   }
 
   // and(x, x, x) -> x -- noop
-  if (llvm::all_of(inputs(), [&](auto in) { return in == inputs()[0]; }))
+  if (llvm::all_of(inputs(), [&](auto in) { return in == this->inputs()[0]; }))
     return inputs()[0];
 
   // Constant fold
@@ -274,7 +274,7 @@ OpFoldResult OrOp::fold(ArrayRef<Attribute> constants) {
   }
 
   // or(x, x, x) -> x
-  if (llvm::all_of(inputs(), [&](auto in) { return in == inputs()[0]; }))
+  if (llvm::all_of(inputs(), [&](auto in) { return in == this->inputs()[0]; }))
     return inputs()[0];
 
   // Constant fold
@@ -399,7 +399,7 @@ void XorOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
 
 OpFoldResult MergeOp::fold(ArrayRef<Attribute> constants) {
   // rtl.merge(x, x, x) -> x.
-  if (llvm::all_of(inputs(), [&](auto in) { return in == inputs()[0]; }))
+  if (llvm::all_of(inputs(), [&](auto in) { return in == this->inputs()[0]; }))
     return inputs()[0];
 
   return {};

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -469,11 +469,11 @@ void GetModportOp::build(OpBuilder &builder, OperationState &state, Value value,
   auto ifaceTy = value.getType().dyn_cast<InterfaceType>();
   assert(ifaceTy && "GetModportOp expects an InterfaceType.");
   auto fieldAttr = SymbolRefAttr::get(builder.getContext(), field);
-  auto modportSym = SymbolRefAttr::get(
-      builder.getContext(), ifaceTy.getInterface().getRootReference(),
-      {fieldAttr});
+  auto modportSym =
+      SymbolRefAttr::get(builder.getContext(),
+                         ifaceTy.getInterface().getRootReference(), fieldAttr);
   build(builder, state, {ModportType::get(builder.getContext(), modportSym)},
-        {value}, fieldAttr);
+        value, fieldAttr);
 }
 
 void ReadInterfaceSignalOp::build(OpBuilder &builder, OperationState &state,
@@ -485,8 +485,7 @@ void ReadInterfaceSignalOp::build(OpBuilder &builder, OperationState &state,
       iface.getDefiningOp(), ifaceTy.getInterface());
   assert(ifaceDefOp &&
          "ReadInterfaceSignalOp could not resolve an InterfaceOp.");
-  build(builder, state, {ifaceDefOp.getSignalType(signalName)}, {iface},
-        fieldAttr);
+  build(builder, state, ifaceDefOp.getSignalType(signalName), iface, fieldAttr);
 }
 
 ParseResult parseIfaceTypeAndSignal(OpAsmParser &p, Type &ifaceTy,

--- a/lib/Dialect/SV/Transforms/AlwaysFusion.cpp
+++ b/lib/Dialect/SV/Transforms/AlwaysFusion.cpp
@@ -16,7 +16,6 @@
 #include "circt/Dialect/SV/SVOps.h"
 #include "circt/Dialect/SV/SVPasses.h"
 #include "mlir/IR/Visitors.h"
-#include "llvm/ADT/TypeSwitch.h"
 
 using namespace mlir;
 using namespace circt;

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -1380,15 +1380,15 @@ LogicalResult ModuleEmitter::visitSV(IfDefOp op) {
   emitLocationInfoAndNewLine(ops);
 
   addIndent();
-  for (auto &op : op.getThenBlock()->without_terminator())
-    emitOperation(&op);
+  for (auto &o : op.getThenBlock()->without_terminator())
+    emitOperation(&o);
   reduceIndent();
 
   if (op.hasElse()) {
     indent() << "`else\n";
     addIndent();
-    for (auto &op : op.getElseBlock()->without_terminator())
-      emitOperation(&op);
+    for (auto &o : op.getElseBlock()->without_terminator())
+      emitOperation(&o);
     reduceIndent();
   }
 
@@ -1683,8 +1683,8 @@ LogicalResult ModuleEmitter::visitSV(InterfaceOp op) {
   os << "interface " << op.sym_name() << ";\n";
 
   addIndent();
-  for (auto &op : op.getBodyBlock()->without_terminator())
-    emitOperation(&op);
+  for (auto &o : op.getBodyBlock()->without_terminator())
+    emitOperation(&o);
   reduceIndent();
 
   os << "endinterface\n\n";


### PR DESCRIPTION
I have an older Ubuntu machine which only has GCC 5 installed on it.  MLIR appears to have made similar changes to support this older compiler, and it compiles out of the box. I believe that these are bugs which are fixed in newer versions of GCC.  I don't have a plan for keeping this from happening in the future, I'll just fix problems as they come up.