### PR TITLE
Strength reduce equality comparison with zero

### DIFF
--- a/.arcconfig
+++ b/.arcconfig
@@ -1,3 +1,0 @@
-{
-  "phabricator.uri" : "https://reviews.llvm.org/"
-}

--- a/.arcconfig
+++ b/.arcconfig
@@ -1,0 +1,3 @@
+{
+  "phabricator.uri" : "https://reviews.llvm.org/"
+}

--- a/lib/Dialect/RTL/RTLFolds.cpp
+++ b/lib/Dialect/RTL/RTLFolds.cpp
@@ -856,6 +856,30 @@ struct ICmpCanonicalizeConstant final : public OpRewritePattern<ICmpOp> {
       };
 
       switch (op.predicate()) {
+      case ICmpPredicate::eq:
+        // eq(x, 0) -> not(x) when x is 1 bit.
+        if (rhs.isNullValue() && rhs.getBitWidth() == 1) {
+          SmallVector<Value, 4> notOperands;
+          notOperands.push_back(op.lhs());
+          APInt one = APInt(1, 1);
+          auto constOne = rewriter.create<ConstantOp>(op.getLoc(), one);
+          notOperands.push_back(constOne);
+          rewriter.replaceOpWithNewOp<XorOp>(op, op.getType(), notOperands);
+          return success();
+        }
+        // eq(x, 0) -> not(orr(x)) when x is >1 bit
+        if (rhs.isNullValue() && rhs.getBitWidth() > 1) {
+          auto orR =
+              rewriter.create<OrROp>(op.getLoc(), op.getType(), op.lhs());
+          SmallVector<Value, 4> notOperands;
+          notOperands.push_back(orR);
+          APInt one = APInt(1, 1);
+          auto constOne = rewriter.create<ConstantOp>(op.getLoc(), one);
+          notOperands.push_back(constOne);
+          rewriter.replaceOpWithNewOp<XorOp>(op, op.getType(), notOperands);
+          return success();
+        }
+        break;
       case ICmpPredicate::slt:
         // x < max -> x != max
         if (rhs.isMaxSignedValue())

--- a/test/Dialect/RTL/canonicalization.mlir
+++ b/test/Dialect/RTL/canonicalization.mlir
@@ -805,3 +805,27 @@ func @shrs_fold2() -> (i12) {
   %0 = rtl.shrs %c-5_i12, %c10_i12 : i12
   return %0 : i12
 }
+
+// CHECK-LABEL:  rtl.module @equality_false1(%a: i1) -> (%b: i1) {
+// CHECK-NEXT:    %true = rtl.constant(true) : i1
+// CHECK-NEXT:    %0 = rtl.xor %a, %true : i1
+// CHECK-NEXT:    rtl.output %0 : i1
+
+rtl.module @equality_false1(%a: i1) -> (%b: i1) {
+  %false = rtl.constant(false) : i1
+  %0 = rtl.icmp eq %a, %false : i1
+  rtl.output %0 : i1
+}
+
+
+// CHECK-LABEL:  rtl.module @equality_false2(%a: i2) -> (%b: i1) {
+// CHECK-NEXT:    %true = rtl.constant(true) : i1
+// CHECK-NEXT:    %0 = rtl.orr %a : i2
+// CHECK-NEXT:    %1 = rtl.xor %0, %true : i1
+// CHECK-NEXT:    rtl.output %1 : i1
+
+rtl.module @equality_false2(%a: i2) -> (%b: i1) {
+  %c0_i2 = rtl.constant(0 : i2) : i2
+  %0 = rtl.icmp eq %a, %c0_i2 : i2
+  rtl.output %0 : i1
+}


### PR DESCRIPTION
Add canonicalize patterns for following two cases in the RTL Dialect

Case 1. eq(x, 0), and x is 1 bit -> Replace with not(x) 	
Case 2. eq(x, 0), and x is >1 bit -> Replace with not(orr(x))