### PR TITLE
Do not construct unnecessary intermediate object

### DIFF
--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -472,7 +472,7 @@ void GetModportOp::build(OpBuilder &builder, OperationState &state, Value value,
   auto modportSym =
       SymbolRefAttr::get(builder.getContext(),
                          ifaceTy.getInterface().getRootReference(), fieldAttr);
-  build(builder, state, {ModportType::get(builder.getContext(), modportSym)},
+  build(builder, state, ModportType::get(builder.getContext(), modportSym),
         value, fieldAttr);
 }
 


### PR DESCRIPTION
The brace initializer is not needed.  Keeping it here trips up the
function deduction in older version of GCC.  This was missed in the
first cleanup.