### PR TITLE
Fix StandardToHandshake dropping the LogicalResult return value from rewriteAffineFor.

### DIFF
--- a/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
+++ b/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
@@ -1451,7 +1451,8 @@ struct FuncOpLowering : public OpConversionPattern<mlir::FuncOp> {
                                 newFuncOp.end());
 
     // Rewrite affine.for operations.
-    rewriteAffineFor(newFuncOp, rewriter);
+    if (failed(rewriteAffineFor(newFuncOp, rewriter)))
+      newFuncOp.emitOpError("failed to rewrite Affine loops");
 
     // Perform dataflow conversion
     MemRefToMemoryAccessOp MemOps = replaceMemoryOps(newFuncOp, rewriter);

--- a/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
+++ b/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
@@ -1405,10 +1405,9 @@ struct HandshakeCanonicalizePattern : public ConversionPattern {
 
 struct FuncOpLowering : public OpConversionPattern<mlir::FuncOp> {
   using OpConversionPattern<mlir::FuncOp>::OpConversionPattern;
-  LogicalResult match(Operation *op) const override { return success(); }
-
-  void rewrite(mlir::FuncOp funcOp, ArrayRef<Value> operands,
-               ConversionPatternRewriter &rewriter) const override {
+  LogicalResult
+  matchAndRewrite(mlir::FuncOp funcOp, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const override {
 
     // Only retain those attributes that are not constructed by build.
     SmallVector<NamedAttribute, 4> attributes;
@@ -1452,7 +1451,7 @@ struct FuncOpLowering : public OpConversionPattern<mlir::FuncOp> {
 
     // Rewrite affine.for operations.
     if (failed(rewriteAffineFor(newFuncOp, rewriter)))
-      newFuncOp.emitOpError("failed to rewrite Affine loops");
+      return newFuncOp.emitOpError("failed to rewrite Affine loops");
 
     // Perform dataflow conversion
     MemRefToMemoryAccessOp MemOps = replaceMemoryOps(newFuncOp, rewriter);
@@ -1489,6 +1488,8 @@ struct FuncOpLowering : public OpConversionPattern<mlir::FuncOp> {
     rewriter.eraseOp(cntrlMg);
 
     rewriter.eraseOp(funcOp);
+
+    return success();
   }
 };
 

--- a/test/Conversion/StandardToHandshake/Affine/errors.mlir
+++ b/test/Conversion/StandardToHandshake/Affine/errors.mlir
@@ -1,0 +1,9 @@
+// RUN: circt-opt %s -create-dataflow -split-input-file -verify-diagnostics
+
+// expected-error @+1 {{'handshake.func' op failed to rewrite Affine loops}}
+func @doubly_nested()->() {
+  affine.for %i = 0 to 10 {
+    affine.for %j = 0 to 10 {}
+  }
+  return
+}


### PR DESCRIPTION
This adds explicit a check for failure of`rewriteAffineFor`.
Fixes #583.