### PR TITLE
Remove `using namespace mlir` from header files

### DIFF
--- a/include/circt/Conversion/FIRRTLToLLHD/FIRRTLToLLHD.h
+++ b/include/circt/Conversion/FIRRTLToLLHD/FIRRTLToLLHD.h
@@ -23,7 +23,6 @@ class OperationPass;
 } // namespace mlir
 
 namespace circt {
-using namespace mlir;
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
 createConvertFIRRTLToLLHDPass();
 } // namespace circt

--- a/include/circt/Conversion/LLHDToLLVM/LLHDToLLVM.h
+++ b/include/circt/Conversion/LLHDToLLVM/LLHDToLLVM.h
@@ -14,21 +14,17 @@
 #ifndef CIRCT_CONVERSION_LLHDTOLLVM_LLHDTOLLVM_H
 #define CIRCT_CONVERSION_LLHDTOLLVM_LLHDTOLLVM_H
 
+#include "circt/Support/LLVM.h"
 #include <memory>
 
 namespace mlir {
-class ModuleOp;
 class LLVMTypeConverter;
-class OwningRewritePatternList;
-template <typename T>
-class OperationPass;
 } // namespace mlir
 
 namespace circt {
-using namespace mlir;
 
 /// Get the LLHD to LLVM conversion patterns.
-void populateLLHDToLLVMConversionPatterns(LLVMTypeConverter &converter,
+void populateLLHDToLLVMConversionPatterns(mlir::LLVMTypeConverter &converter,
                                           OwningRewritePatternList &patterns,
                                           size_t &sigCounter,
                                           size_t &regCounter);

--- a/include/circt/Dialect/FIRRTL/FIRRTLDialect.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDialect.h
@@ -13,12 +13,13 @@
 #ifndef CIRCT_DIALECT_FIRRTL_DIALECT_H
 #define CIRCT_DIALECT_FIRRTL_DIALECT_H
 
+#include "circt/Support/LLVM.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Dialect.h"
 
 namespace circt {
 namespace firrtl {
-using namespace mlir;
+
 class FIRRTLType;
 
 class FIRRTLDialect : public Dialect {

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -14,6 +14,7 @@
 #define CIRCT_DIALECT_FIRRTL_TYPES_H
 
 #include "circt/Dialect/FIRRTL/FIRRTLDialect.h"
+#include "circt/Support/LLVM.h"
 #include "mlir/IR/Types.h"
 
 namespace circt {
@@ -24,8 +25,6 @@ struct FlipTypeStorage;
 struct BundleTypeStorage;
 struct VectorTypeStorage;
 } // namespace detail.
-
-using namespace mlir;
 
 class ClockType;
 class ResetType;

--- a/include/circt/Dialect/Handshake/HandshakeOps.h
+++ b/include/circt/Dialect/Handshake/HandshakeOps.h
@@ -13,6 +13,7 @@
 #ifndef CIRCT_HANDSHAKEOPS_OPS_H_
 #define CIRCT_HANDSHAKEOPS_OPS_H_
 
+#include "circt/Support/LLVM.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -31,7 +32,6 @@
 namespace circt {
 namespace handshake {
 
-using namespace mlir;
 class TerminatorOp;
 
 class HandshakeOpsDialect : public Dialect {

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -141,18 +141,18 @@ def FuncOp : Op<Handshake_Dialect, "func", [
   }];
   let printer = [{
     FunctionType fnType = getType();
-    impl::printFunctionLikeOp(p, *this, fnType.getInputs(), /*isVariadic=*/true,
-                              fnType.getResults());
+    mlir::impl::printFunctionLikeOp(p, *this, fnType.getInputs(),
+        /*isVariadic=*/true, fnType.getResults());
   }];
   let parser = [{
     auto buildFuncType =
         [](Builder & builder, ArrayRef<Type> argTypes, ArrayRef<Type> results,
-           impl::VariadicFlag, std::string &) {
+           mlir::impl::VariadicFlag, std::string &) {
       return builder.getFunctionType(argTypes, results);
     };
 
-    return impl::parseFunctionLikeOp(parser, result, /*allowVariadic=*/true,
-                                     buildFuncType);
+    return mlir::impl::parseFunctionLikeOp(parser, result,
+        /*allowVariadic=*/true, buildFuncType);
   }];
 }
 

--- a/include/circt/Dialect/LLHD/IR/LLHD.td
+++ b/include/circt/Dialect/LLHD/IR/LLHD.td
@@ -102,11 +102,11 @@ class LLHD_ArithmeticOrBitwiseOp<string mnemonic, list<OpTrait> traits = []>
   let results = (outs AnySignlessInteger);
 
   let parser = [{
-      return impl::parseOneResultSameOperandTypeOp(parser, result);
+      return mlir::impl::parseOneResultSameOperandTypeOp(parser, result);
   }];
 
   let printer = [{
-      impl::printOneResultOp(this->getOperation(), p);
+      mlir::impl::printOneResultOp(this->getOperation(), p);
   }];
 }
 

--- a/include/circt/Dialect/LLHD/IR/LLHDDialect.h
+++ b/include/circt/Dialect/LLHD/IR/LLHDDialect.h
@@ -13,12 +13,12 @@
 #ifndef CIRCT_DIALECT_LLHD_IR_LLHDDIALECT_H
 #define CIRCT_DIALECT_LLHD_IR_LLHDDIALECT_H
 
+#include "circt/Support/LLVM.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Dialect.h"
 
 namespace circt {
 namespace llhd {
-using namespace mlir;
 
 namespace detail {
 struct SigTypeStorage;

--- a/include/circt/Dialect/LLHD/IR/LLHDOps.h
+++ b/include/circt/Dialect/LLHD/IR/LLHDOps.h
@@ -15,6 +15,7 @@
 
 #include "circt/Dialect/LLHD/IR/LLHDDialect.h"
 #include "circt/Dialect/LLHD/IR/LLHDEnums.h.inc"
+#include "circt/Support/LLVM.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"

--- a/include/circt/Dialect/LLHD/Simulator/Engine.h
+++ b/include/circt/Dialect/LLHD/Simulator/Engine.h
@@ -14,7 +14,6 @@
 #define CIRCT_DIALECT_LLHD_SIMULATOR_ENGINE_H
 
 #include "circt/Dialect/LLHD/IR/LLHDOps.h"
-
 #include "mlir/IR/BuiltinOps.h"
 
 namespace mlir {
@@ -71,7 +70,7 @@ private:
   llvm::raw_ostream &out;
   std::string root;
   std::unique_ptr<State> state;
-  std::unique_ptr<ExecutionEngine> engine;
+  std::unique_ptr<mlir::ExecutionEngine> engine;
   ModuleOp module;
   int traceMode;
 };

--- a/include/circt/Dialect/LLHD/Transforms/Passes.h
+++ b/include/circt/Dialect/LLHD/Transforms/Passes.h
@@ -13,17 +13,11 @@
 #ifndef CIRCT_DIALECT_LLHD_TRANSFORMS_PASSES_H
 #define CIRCT_DIALECT_LLHD_TRANSFORMS_PASSES_H
 
+#include "circt/Support/LLVM.h"
 #include <memory>
-
-namespace mlir {
-class ModuleOp;
-template <typename T>
-class OperationPass;
-} // namespace mlir
 
 namespace circt {
 namespace llhd {
-using namespace mlir;
 
 class ProcOp;
 

--- a/include/circt/Dialect/RTL/RTLDialect.h
+++ b/include/circt/Dialect/RTL/RTLDialect.h
@@ -13,11 +13,11 @@
 #ifndef CIRCT_DIALECT_RTL_RTLDIALECT_H
 #define CIRCT_DIALECT_RTL_RTLDIALECT_H
 
+#include "circt/Support/LLVM.h"
 #include "mlir/IR/Dialect.h"
 
 namespace circt {
 namespace rtl {
-using namespace mlir;
 
 class RTLDialect : public Dialect {
 public:

--- a/include/circt/Dialect/SV/SVDialect.h
+++ b/include/circt/Dialect/SV/SVDialect.h
@@ -13,11 +13,11 @@
 #ifndef CIRCT_DIALECT_SV_DIALECT_H
 #define CIRCT_DIALECT_SV_DIALECT_H
 
+#include "circt/Support/LLVM.h"
 #include "mlir/IR/Dialect.h"
 
 namespace circt {
 namespace sv {
-using namespace mlir;
 
 class SVDialect : public Dialect {
 public:

--- a/include/circt/Dialect/StaticLogic/StaticLogic.h
+++ b/include/circt/Dialect/StaticLogic/StaticLogic.h
@@ -13,6 +13,7 @@
 #ifndef CIRCT_STATICLOGIC_OPS_H_
 #define CIRCT_STATICLOGIC_OPS_H_
 
+#include "circt/Support/LLVM.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -29,8 +30,6 @@
 
 namespace circt {
 namespace staticlogic {
-
-using namespace mlir;
 
 class StaticLogicDialect : public Dialect {
 public:

--- a/include/circt/Support/LLVM.h
+++ b/include/circt/Support/LLVM.h
@@ -21,46 +21,226 @@
 // MLIR includes a lot of forward declarations of LLVM types, use them.
 #include "mlir/Support/LLVM.h"
 
+// Can not forward declare inline functions with default arguments, so we
+// include the header directly.
+#include "mlir/Support/LogicalResult.h"
+
+// Import classes from the `mlir` namespace into the `circt` namespace.  All of
+// the following classes have been already forward declared and imported from
+// `llvm` in to the `mlir` namespace. For classes with default template
+// arguments, MLIR does not import the type directly, it creates a templated
+// using statement. This is due to the limitiation that only one declaration of
+// a type can have default arguments. For those types, it is important to import
+// the MLIR version, and not the LLVM version. To keep things simple, all
+// classes here should be imported from the `mlir` namespace, not the `llvm`
+// namespace.
+namespace circt {
+using mlir::APFloat;
+using mlir::APInt;
+using mlir::ArrayRef;
+using mlir::cast;
+using mlir::cast_or_null;
+using mlir::DenseMap;
+using mlir::DenseMapInfo;
+using mlir::DenseSet;
+using mlir::dyn_cast;
+using mlir::dyn_cast_or_null;
+using mlir::function_ref;
+using mlir::isa;
+using mlir::isa_and_nonnull;
+using mlir::iterator_range;
+using mlir::MutableArrayRef;
+using mlir::None;
+using mlir::Optional;
+using mlir::PointerUnion;
+using mlir::raw_ostream;
+using mlir::SmallPtrSet;
+using mlir::SmallPtrSetImpl;
+using mlir::SmallString;
+using mlir::SmallVector;
+using mlir::SmallVectorImpl;
+using mlir::StringLiteral;
+using mlir::StringRef;
+using mlir::StringSet;
+using mlir::TinyPtrVector;
+using mlir::Twine;
+using mlir::TypeSwitch;
+} // namespace circt
+
+// Forward declarations of classes to be imported in to the circt namespace.
+namespace mlir {
+class ArrayAttr;
+class Attribute;
+class Block;
+class BlockAndValueMapping;
+class BlockArgument;
+class BoolAttr;
+class Builder;
+class NamedAttrList;
+class ConversionPattern;
+class ConversionPatternRewriter;
+class ConversionTarget;
+class DenseElementsAttr;
+class Diagnostic;
+class Dialect;
+class DialectAsmParser;
+class DialectAsmPrinter;
+class DictionaryAttr;
+class ElementsAttr;
+class FileLineColLoc;
+class FlatSymbolRefAttr;
+class FloatAttr;
+class FunctionType;
+class FusedLoc;
+class Identifier;
+class IndexType;
+class InFlightDiagnostic;
+class IntegerAttr;
+class IntegerType;
+class Location;
+class MemRefType;
+class MLIRContext;
+class ModuleOp;
+class ModuleTerminatorOp;
+class MutableOperandRange;
+class NamedAttrList;
+class NoneType;
+class OpAsmDialectInterface;
+class OpAsmParser;
+class OpAsmPrinter;
+class OpBuilder;
+class OperandRange;
+class Operation;
+class OpFoldResult;
+class OpOperand;
+class OwningModuleRef;
+class OwningRewritePatternList;
+class ParseResult;
+class Pass;
+class PatternRewriter;
+class Region;
+class ShapedType;
+class SplatElementsAttr;
+class StringAttr;
+class SymbolRefAttr;
+class SymbolTable;
+class TupleType;
+class Type;
+class TypeAttr;
+class TypeConverter;
+class TypeID;
+class TypeRange;
+class TypeStorage;
+class UnknownLoc;
+class Value;
+class ValueRange;
+class VectorType;
+class WalkResult;
+enum class RegionKind;
+struct CallInterfaceCallable;
+struct LogicalResult;
+struct MemRefAccess;
+struct OperationState;
+
+template <typename SourceOp>
+struct OpConversionPattern;
+template <typename T>
+class OperationPass;
+template <typename SourceOp>
+struct OpRewritePattern;
+
+using DefaultTypeStorage = TypeStorage;
+using OpAsmSetValueNameFn = function_ref<void(Value, StringRef)>;
+using NamedAttribute = std::pair<Identifier, Attribute>;
+
+namespace OpTrait {}
+
+} // namespace mlir
+
 // Import things we want into our namespace.
 namespace circt {
-// Casting operators.
-using llvm::cast;
-using llvm::cast_or_null;
-using llvm::dyn_cast;
-using llvm::dyn_cast_or_null;
-using llvm::isa;
-using llvm::isa_and_nonnull;
-
-// Containers.
-using llvm::ArrayRef;
-using llvm::DenseMapInfo;
-template <typename KeyT, typename ValueT,
-          typename KeyInfoT = DenseMapInfo<KeyT>,
-          typename BucketT = llvm::detail::DenseMapPair<KeyT, ValueT>>
-using DenseMap = llvm::DenseMap<KeyT, ValueT, KeyInfoT, BucketT>;
-template <typename ValueT, typename ValueInfoT = DenseMapInfo<ValueT>>
-using DenseSet = llvm::DenseSet<ValueT, ValueInfoT>;
-template <typename Fn>
-using function_ref = llvm::function_ref<Fn>;
-using llvm::iterator_range;
-using llvm::MutableArrayRef;
-using llvm::None;
-using llvm::Optional;
-using llvm::PointerUnion;
-using llvm::SmallPtrSet;
-using llvm::SmallPtrSetImpl;
-using llvm::SmallString;
-using llvm::SmallVector;
-using llvm::SmallVectorImpl;
-using llvm::StringLiteral;
-using llvm::StringRef;
-using llvm::TinyPtrVector;
-using llvm::Twine;
-
-// Other common classes.
-using llvm::APFloat;
-using llvm::APInt;
-using llvm::raw_ostream;
+using mlir::ArrayAttr;
+using mlir::Attribute;
+using mlir::Block;
+using mlir::BlockAndValueMapping;
+using mlir::BlockArgument;
+using mlir::BoolAttr;
+using mlir::Builder;
+using mlir::CallInterfaceCallable;
+using mlir::ConversionPattern;
+using mlir::ConversionPatternRewriter;
+using mlir::ConversionTarget;
+using mlir::DefaultTypeStorage;
+using mlir::DenseElementsAttr;
+using mlir::Diagnostic;
+using mlir::Dialect;
+using mlir::DialectAsmParser;
+using mlir::DialectAsmPrinter;
+using mlir::DictionaryAttr;
+using mlir::ElementsAttr;
+using mlir::failed;
+using mlir::failure;
+using mlir::FileLineColLoc;
+using mlir::FlatSymbolRefAttr;
+using mlir::FloatAttr;
+using mlir::FunctionType;
+using mlir::FusedLoc;
+using mlir::Identifier;
+using mlir::IndexType;
+using mlir::InFlightDiagnostic;
+using mlir::IntegerAttr;
+using mlir::IntegerType;
+using mlir::Location;
+using mlir::LogicalResult;
+using mlir::MemRefAccess;
+using mlir::MemRefType;
+using mlir::MLIRContext;
+using mlir::ModuleOp;
+using mlir::ModuleTerminatorOp;
+using mlir::MutableOperandRange;
+using mlir::NamedAttribute;
+using mlir::NamedAttrList;
+using mlir::NoneType;
+using mlir::OpAsmDialectInterface;
+using mlir::OpAsmParser;
+using mlir::OpAsmPrinter;
+using mlir::OpAsmSetValueNameFn;
+using mlir::OpBuilder;
+using mlir::OpConversionPattern;
+using mlir::OperandRange;
+using mlir::Operation;
+using mlir::OperationPass;
+using mlir::OperationState;
+using mlir::OpFoldResult;
+using mlir::OpOperand;
+using mlir::OpRewritePattern;
+using mlir::OwningModuleRef;
+using mlir::OwningRewritePatternList;
+using mlir::ParseResult;
+using mlir::Pass;
+using mlir::PatternRewriter;
+using mlir::Region;
+using mlir::RegionKind;
+using mlir::ShapedType;
+using mlir::SplatElementsAttr;
+using mlir::StringAttr;
+using mlir::succeeded;
+using mlir::success;
+using mlir::SymbolRefAttr;
+using mlir::SymbolTable;
+using mlir::TupleType;
+using mlir::Type;
+using mlir::TypeAttr;
+using mlir::TypeConverter;
+using mlir::TypeID;
+using mlir::TypeRange;
+using mlir::TypeStorage;
+using mlir::UnknownLoc;
+using mlir::Value;
+using mlir::ValueRange;
+using mlir::VectorType;
+using mlir::WalkResult;
+namespace OpTrait = mlir::OpTrait;
 } // namespace circt
 
 #endif // CIRCT_SUPPORT_LLVM_H

--- a/lib/CAPI/ExportVerilog/ExportVerilog.cpp
+++ b/lib/CAPI/ExportVerilog/ExportVerilog.cpp
@@ -12,12 +12,11 @@
 #include "mlir/CAPI/Utils.h"
 #include "llvm/Support/raw_ostream.h"
 
-using namespace mlir;
 using namespace circt;
 
 MlirLogicalResult mlirExportVerilog(MlirModule module,
                                     MlirStringCallback callback,
                                     void *userData) {
-  detail::CallbackOstream stream(callback, userData);
+  mlir::detail::CallbackOstream stream(callback, userData);
   return wrap(exportVerilog(unwrap(module), stream));
 }

--- a/lib/Conversion/FIRRTLToLLHD/FIRRTLToLLHD.cpp
+++ b/lib/Conversion/FIRRTLToLLHD/FIRRTLToLLHD.cpp
@@ -23,7 +23,6 @@
 
 #define DEBUG_TYPE "firrtl-to-llhd"
 
-using namespace mlir;
 using namespace circt;
 using namespace circt::llhd;
 

--- a/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
+++ b/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
@@ -14,6 +14,7 @@
 #include "../PassDetail.h"
 #include "circt/Dialect/LLHD/IR/LLHDDialect.h"
 #include "circt/Dialect/LLHD/IR/LLHDOps.h"
+#include "circt/Support/LLVM.h"
 #include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVM.h"
 #include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVMPass.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"

--- a/lib/Conversion/RTLToLLHD/RTLToLLHD.cpp
+++ b/lib/Conversion/RTLToLLHD/RTLToLLHD.cpp
@@ -41,8 +41,7 @@ struct RTLToLLHDTypeConverter : public TypeConverter {
 } // namespace
 
 /// Create a RTL to LLHD conversion pass.
-std::unique_ptr<OperationPass<mlir::ModuleOp>>
-circt::createConvertRTLToLLHDPass() {
+std::unique_ptr<OperationPass<ModuleOp>> circt::createConvertRTLToLLHDPass() {
   return std::make_unique<RTLToLLHDPass>();
 }
 
@@ -62,8 +61,8 @@ void RTLToLLHDPass::runOnOperation() {
 
   RTLToLLHDTypeConverter typeConverter;
   OwningRewritePatternList patterns;
-  populateFunctionLikeTypeConversionPattern<RTLModuleOp>(patterns, &context,
-                                                         typeConverter);
+  mlir::populateFunctionLikeTypeConversionPattern<RTLModuleOp>(
+      patterns, &context, typeConverter);
   patterns.insert<ConvertRTLModule>(typeConverter, &context);
   patterns.insert<ConvertOutput>(typeConverter, &context);
   patterns.insert<ConvertInstance>(typeConverter, &context);

--- a/lib/Conversion/StandardToStaticLogic/StandardToStaticLogic.cpp
+++ b/lib/Conversion/StandardToStaticLogic/StandardToStaticLogic.cpp
@@ -15,7 +15,6 @@
 #include "circt/Dialect/StaticLogic/StaticLogic.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 
-using namespace mlir;
 using namespace circt;
 using namespace staticlogic;
 using namespace std;

--- a/lib/Dialect/ESI/ESIDialect.cpp
+++ b/lib/Dialect/ESI/ESIDialect.cpp
@@ -13,11 +13,9 @@
 #include "circt/Dialect/ESI/ESIDialect.h"
 #include "circt/Dialect/ESI/ESIOps.h"
 #include "circt/Dialect/ESI/ESITypes.h"
-
+#include "circt/Support/LLVM.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "llvm/Support/FormatVariadic.h"
-
-using namespace mlir;
 
 namespace circt {
 namespace esi {

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -14,12 +14,12 @@
 #include "circt/Dialect/RTL/RTLTypes.h"
 #include "circt/Dialect/SV/SVOps.h"
 #include "circt/Dialect/SV/SVTypes.h"
-
+#include "circt/Support/LLVM.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/SymbolTable.h"
 
-using namespace mlir;
+using namespace circt;
 using namespace circt::esi;
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/ESI/ESIPasses.cpp
+++ b/lib/Dialect/ESI/ESIPasses.cpp
@@ -17,6 +17,7 @@
 #include "circt/Dialect/SV/SVOps.h"
 #include "circt/Support/BackedgeBuilder.h"
 #include "circt/Support/ImplicitLocOpBuilder.h"
+#include "circt/Support/LLVM.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Pass/Pass.h"
@@ -36,7 +37,7 @@ namespace esi {
 } // namespace esi
 } // namespace circt
 
-using namespace mlir;
+using namespace circt;
 using namespace circt::esi;
 using namespace circt::rtl;
 using namespace circt::sv;

--- a/lib/Dialect/ESI/ESITranslations.cpp
+++ b/lib/Dialect/ESI/ESITranslations.cpp
@@ -22,7 +22,6 @@
 #include "circt/Dialect/ESI/CosimSchema.h"
 #endif
 
-using namespace mlir;
 using namespace circt::esi;
 
 //===----------------------------------------------------------------------===//
@@ -167,8 +166,9 @@ static LogicalResult exportCosimSchema(ModuleOp module, llvm::raw_ostream &os) {
 
 void circt::esi::registerESITranslations() {
 #ifdef CAPNP
-  TranslateFromMLIRRegistration cosimToCapnp(
-      "export-esi-capnp", exportCosimSchema, [](DialectRegistry &registry) {
+  mlir::TranslateFromMLIRRegistration cosimToCapnp(
+      "export-esi-capnp", exportCosimSchema,
+      [](mlir::DialectRegistry &registry) {
         registry
             .insert<ESIDialect, circt::rtl::RTLDialect, circt::sv::SVDialect,
                     mlir::StandardOpsDialect, mlir::BuiltinDialect>();

--- a/lib/Dialect/ESI/ESITypes.cpp
+++ b/lib/Dialect/ESI/ESITypes.cpp
@@ -12,22 +12,23 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/ESI/ESITypes.h"
+#include "circt/Support/LLVM.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/TypeSwitch.h"
 
-using namespace mlir;
+using namespace circt;
 using namespace circt::esi;
 
-Type ChannelPort::parse(mlir::MLIRContext *ctxt, mlir::DialectAsmParser &p) {
+Type ChannelPort::parse(MLIRContext *ctxt, DialectAsmParser &p) {
   Type inner;
   if (p.parseLess() || p.parseType(inner) || p.parseGreater())
     return Type();
   return get(ctxt, inner);
 }
 
-void ChannelPort::print(mlir::DialectAsmPrinter &p) const {
+void ChannelPort::print(DialectAsmPrinter &p) const {
   p << "channel<";
   p.printType(getInner());
   p << ">";

--- a/lib/Dialect/ESI/capnp/Schema.cpp
+++ b/lib/Dialect/ESI/capnp/Schema.cpp
@@ -27,7 +27,6 @@
 #include <initializer_list>
 #include <string>
 
-using namespace mlir;
 using namespace circt::esi::capnp::detail;
 using namespace circt;
 

--- a/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
@@ -115,7 +115,7 @@ struct FIRRTLOpAsmDialectInterface : public OpAsmDialectInterface {
 
     for (size_t i = 0, e = block->getNumArguments(); i != e; ++i) {
       // Scan for a 'firrtl.name' attribute.
-      if (auto str = getFIRRTLNameAttr(impl::getArgAttrs(parentOp, i)))
+      if (auto str = getFIRRTLNameAttr(mlir::impl::getArgAttrs(parentOp, i)))
         setNameFn(block->getArgument(i), str.getValue());
     }
   }

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -11,12 +11,15 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Support/LLVM.h"
 #include "mlir/Dialect/CommonFolders.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
 
 using namespace circt;
 using namespace firrtl;
+
+using mlir::constFoldBinaryOp;
 
 static Attribute getIntAttr(const APInt &value, MLIRContext *context) {
   return IntegerAttr::get(IntegerType::get(context, value.getBitWidth()),

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -20,6 +20,8 @@
 using namespace circt;
 using namespace firrtl;
 
+using mlir::TypeStorageAllocator;
+
 //===----------------------------------------------------------------------===//
 // Type Printing
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/Import/FIRLexer.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRLexer.cpp
@@ -18,7 +18,6 @@
 
 using namespace circt;
 using namespace firrtl;
-using namespace mlir;
 using llvm::SMLoc;
 using llvm::SMRange;
 using llvm::SourceMgr;

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -14,6 +14,7 @@
 
 #include "FIRLexer.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Support/LLVM.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Diagnostics.h"
@@ -29,7 +30,7 @@
 
 using namespace circt;
 using namespace firrtl;
-using namespace mlir;
+
 using llvm::SMLoc;
 using llvm::SourceMgr;
 
@@ -2735,7 +2736,7 @@ OwningModuleRef circt::firrtl::importFIRRTL(SourceMgr &sourceMgr,
 }
 
 void circt::firrtl::registerFromFIRRTLTranslation() {
-  static TranslateToMLIRRegistration fromFIR(
+  static mlir::TranslateToMLIRRegistration fromFIR(
       "import-firrtl", [](llvm::SourceMgr &sourceMgr, MLIRContext *context) {
         return importFIRRTL(sourceMgr, context);
       });

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -11,28 +11,26 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/Handshake/HandshakeOps.h"
-
+#include "circt/Support/LLVM.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/FunctionImplementation.h"
+#include "mlir/IR/IntegerSet.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OpImplementation.h"
-#include "mlir/IR/Value.h"
-
-using namespace mlir;
-using namespace circt;
-using namespace circt::handshake;
-
-#include "mlir/IR/IntegerSet.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Value.h"
 #include "mlir/Transforms/InliningUtils.h"
 #include "llvm/ADT/Any.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/Support/Debug.h"
+
+using namespace circt;
+using namespace circt::handshake;
 
 #define INDEX_WIDTH 32
 

--- a/lib/Dialect/LLHD/IR/LLHDCanonicalization.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDCanonicalization.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/LLHD/IR/LLHDOps.h"
+#include "circt/Support/LLVM.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/PatternMatch.h"
 

--- a/lib/Dialect/LLHD/IR/LLHDDialect.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDDialect.cpp
@@ -18,9 +18,10 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 
-using namespace mlir;
 using namespace circt;
 using namespace circt::llhd;
+
+using mlir::TypeStorageAllocator;
 
 //===----------------------------------------------------------------------===//
 // LLHDDialect Interfaces
@@ -28,8 +29,8 @@ using namespace circt::llhd;
 
 namespace {
 /// This class defines the interface for handling inlining with LLHD operations.
-struct LLHDInlinerInterface : public DialectInlinerInterface {
-  using DialectInlinerInterface::DialectInlinerInterface;
+struct LLHDInlinerInterface : public mlir::DialectInlinerInterface {
+  using mlir::DialectInlinerInterface::DialectInlinerInterface;
 
   //===--------------------------------------------------------------------===//
   // Analysis Hooks
@@ -55,8 +56,7 @@ struct LLHDInlinerInterface : public DialectInlinerInterface {
 //===----------------------------------------------------------------------===//
 
 LLHDDialect::LLHDDialect(mlir::MLIRContext *context)
-    : Dialect(getDialectNamespace(), context,
-    ::mlir::TypeID::get<LLHDDialect>()) {
+    : Dialect(getDialectNamespace(), context, TypeID::get<LLHDDialect>()) {
   addTypes<SigType, TimeType, ArrayType, PtrType>();
   addAttributes<TimeAttr>();
   addOperations<

--- a/lib/Dialect/LLHD/IR/LLHDOps.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDOps.cpp
@@ -27,8 +27,8 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 
-using namespace mlir;
 using namespace circt;
+using namespace mlir;
 
 template <class AttrElementT,
           class ElementValueT = typename AttrElementT::ValueType,

--- a/lib/Dialect/LLHD/Simulator/Engine.cpp
+++ b/lib/Dialect/LLHD/Simulator/Engine.cpp
@@ -21,7 +21,6 @@
 
 #include "llvm/Support/TargetSelect.h"
 
-using namespace mlir;
 using namespace circt::llhd::sim;
 
 Engine::Engine(

--- a/lib/Dialect/LLHD/Transforms/EarlyCodeMotionPass.cpp
+++ b/lib/Dialect/LLHD/Transforms/EarlyCodeMotionPass.cpp
@@ -13,9 +13,9 @@
 #include "PassDetails.h"
 #include "TemporalRegions.h"
 #include "circt/Dialect/LLHD/Transforms/Passes.h"
+#include "circt/Support/LLVM.h"
 #include "mlir/IR/Dominance.h"
 
-using namespace mlir;
 using namespace circt;
 
 namespace {
@@ -40,7 +40,7 @@ static SmallVector<Block *, 8> intersection(SmallVectorImpl<Block *> &v1,
 void EarlyCodeMotionPass::runOnOperation() {
   llhd::ProcOp proc = getOperation();
   llhd::TemporalRegionAnalysis trAnalysis = llhd::TemporalRegionAnalysis(proc);
-  DominanceInfo dom(proc);
+  mlir::DominanceInfo dom(proc);
 
   DenseMap<Block *, unsigned> entryDistance;
   SmallPtrSet<Block *, 32> workDone;
@@ -59,7 +59,7 @@ void EarlyCodeMotionPass::runOnOperation() {
          iter != block->getOperations().end(); ++iter) {
       Operation &op = *iter;
       if (!isa<llhd::PrbOp>(op) &&
-          (!MemoryEffectOpInterface::hasNoEffect(&op) ||
+          (!mlir::MemoryEffectOpInterface::hasNoEffect(&op) ||
            op.hasTrait<OpTrait::IsTerminator>()))
         continue;
 

--- a/lib/Dialect/LLHD/Transforms/FunctionEliminationPass.cpp
+++ b/lib/Dialect/LLHD/Transforms/FunctionEliminationPass.cpp
@@ -16,7 +16,6 @@
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/Visitors.h"
 
-using namespace mlir;
 using namespace circt;
 
 namespace {
@@ -29,7 +28,7 @@ struct FunctionEliminationPass
 void FunctionEliminationPass::runOnOperation() {
   ModuleOp module = getOperation();
 
-  WalkResult result = module.walk([](CallOp op) -> WalkResult {
+  WalkResult result = module.walk([](mlir::CallOp op) -> WalkResult {
     if (isa<llhd::ProcOp>(op->getParentOp()) ||
         isa<llhd::EntityOp>(op->getParentOp())) {
       return emitError(
@@ -45,7 +44,7 @@ void FunctionEliminationPass::runOnOperation() {
     return;
   }
 
-  module.walk([](FuncOp op) { op.erase(); });
+  module.walk([](mlir::FuncOp op) { op.erase(); });
 }
 } // namespace
 

--- a/lib/Dialect/LLHD/Transforms/MemoryToBlockArgumentPass.cpp
+++ b/lib/Dialect/LLHD/Transforms/MemoryToBlockArgumentPass.cpp
@@ -16,7 +16,6 @@
 #include "mlir/IR/Dominance.h"
 #include <set>
 
-using namespace mlir;
 using namespace circt;
 
 namespace {
@@ -31,7 +30,7 @@ struct MemoryToBlockArgumentPass
 /// Add the dominance fontier blocks of 'frontierOf' to the 'df' set
 static void getDominanceFrontier(Block *frontierOf, Operation *op,
                                  std::set<Block *> &df) {
-  DominanceInfo dom(op);
+  mlir::DominanceInfo dom(op);
   for (Block &block : op->getRegion(0).getBlocks()) {
     for (Block *pred : block.getPredecessors()) {
       if (dom.dominates(frontierOf, pred) &&
@@ -66,9 +65,9 @@ static void addBlockOperandToTerminator(Operation *terminator,
                                         Block *successsor, Value toAppend) {
   if (auto wait = dyn_cast<llhd::WaitOp>(terminator)) {
     wait.destOpsMutable().append(toAppend);
-  } else if (auto br = dyn_cast<BranchOp>(terminator)) {
+  } else if (auto br = dyn_cast<mlir::BranchOp>(terminator)) {
     br.destOperandsMutable().append(toAppend);
-  } else if (auto condBr = dyn_cast<CondBranchOp>(terminator)) {
+  } else if (auto condBr = dyn_cast<mlir::CondBranchOp>(terminator)) {
     if (condBr.falseDest() == successsor) {
       condBr.falseDestOperandsMutable().append(toAppend);
     } else {

--- a/lib/Dialect/LLHD/Transforms/ProcessLoweringPass.cpp
+++ b/lib/Dialect/LLHD/Transforms/ProcessLoweringPass.cpp
@@ -16,7 +16,6 @@
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/Visitors.h"
 
-using namespace mlir;
 using namespace circt;
 
 namespace {
@@ -45,7 +44,7 @@ void ProcessLoweringPass::runOnOperation() {
             "Process-lowering: The second block (containing the "
             "llhd.wait) is not allowed to have arguments.");
       }
-      if (!isa<BranchOp>(first.getTerminator())) {
+      if (!isa<mlir::BranchOp>(first.getTerminator())) {
         return op.emitOpError(
             "Process-lowering: The first block has to be terminated "
             "by a BranchOp from the standard dialect.");

--- a/lib/Dialect/LLHD/Transforms/TemporalRegions.cpp
+++ b/lib/Dialect/LLHD/Transforms/TemporalRegions.cpp
@@ -15,7 +15,6 @@
 #include "circt/Dialect/LLHD/IR/LLHDOps.h"
 #include "llvm/ADT/SmallPtrSet.h"
 
-using namespace mlir;
 using namespace circt;
 
 static void addBlockToTR(Block *block, int tr, DenseMap<Block *, int> &blockMap,

--- a/lib/Dialect/LLHD/Transforms/TemporalRegions.h
+++ b/lib/Dialect/LLHD/Transforms/TemporalRegions.h
@@ -14,11 +14,11 @@
 #ifndef DIALECT_LLHD_TRANSFORMS_TEMPORALREGIONS_H
 #define DIALECT_LLHD_TRANSFORMS_TEMPORALREGIONS_H
 
+#include "circt/Support/LLVM.h"
 #include "mlir/IR/Operation.h"
 
 namespace circt {
 namespace llhd {
-using namespace mlir;
 
 struct TemporalRegionAnalysis {
   using BlockMapT = DenseMap<Block *, int>;

--- a/lib/Dialect/RTL/RTLDialect.cpp
+++ b/lib/Dialect/RTL/RTLDialect.cpp
@@ -46,7 +46,7 @@ struct RTLOpAsmDialectInterface : public OpAsmDialectInterface {
 
     for (size_t i = 0, e = block->getNumArguments(); i != e; ++i) {
       // Scan for a 'rtl.name' attribute.
-      if (auto str = getRTLNameAttr(impl::getArgAttrs(parentOp, i)))
+      if (auto str = getRTLNameAttr(mlir::impl::getArgAttrs(parentOp, i)))
         setNameFn(block->getArgument(i), str.getValue());
     }
   }

--- a/lib/Dialect/RTL/RTLFolds.cpp
+++ b/lib/Dialect/RTL/RTLFolds.cpp
@@ -18,6 +18,8 @@
 using namespace circt;
 using namespace rtl;
 
+using mlir::constFoldBinaryOp;
+
 static Attribute getIntAttr(const APInt &value, MLIRContext *context) {
   return IntegerAttr::get(IntegerType::get(context, value.getBitWidth()),
                           value);

--- a/lib/Dialect/RTL/RTLOps.cpp
+++ b/lib/Dialect/RTL/RTLOps.cpp
@@ -191,9 +191,10 @@ static ParseResult parseModuleFunctionSignature(
     SmallVectorImpl<Type> &argTypes, SmallVectorImpl<NamedAttrList> &argAttrs,
     bool &isVariadic, SmallVectorImpl<Type> &resultTypes,
     SmallVectorImpl<NamedAttrList> &resultAttrs) {
+  using namespace mlir::impl;
   bool allowArgAttrs = true;
-  if (impl::parseFunctionArgumentList(parser, allowArgAttrs, allowVariadic,
-                                      argNames, argTypes, argAttrs, isVariadic))
+  if (parseFunctionArgumentList(parser, allowArgAttrs, allowVariadic, argNames,
+                                argTypes, argAttrs, isVariadic))
     return failure();
   if (succeeded(parser.parseOptionalArrow()))
     return parseFunctionResultList(parser, resultTypes, resultAttrs);

--- a/lib/Dialect/RTL/RTLTypes.cpp
+++ b/lib/Dialect/RTL/RTLTypes.cpp
@@ -12,6 +12,7 @@
 
 #include "circt/Dialect/RTL/RTLTypes.h"
 #include "circt/Dialect/RTL/RTLDialect.h"
+#include "circt/Support/LLVM.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/DialectImplementation.h"
@@ -19,7 +20,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 
-using namespace mlir;
+using namespace circt;
 using namespace circt::rtl;
 
 #define GET_TYPEDEF_CLASSES

--- a/lib/Dialect/SV/SVDialect.cpp
+++ b/lib/Dialect/SV/SVDialect.cpp
@@ -17,7 +17,6 @@
 #include "mlir/IR/DialectImplementation.h"
 
 using namespace circt::sv;
-using namespace mlir;
 
 //===----------------------------------------------------------------------===//
 // Dialect specification.

--- a/lib/Dialect/SV/SVTypes.cpp
+++ b/lib/Dialect/SV/SVTypes.cpp
@@ -17,8 +17,8 @@
 #include "mlir/IR/DialectImplementation.h"
 #include "llvm/ADT/TypeSwitch.h"
 
+using namespace circt;
 using namespace circt::sv;
-using namespace mlir;
 
 /// Return the element type of an ArrayType or UnpackedArrayType, or null if the
 /// operand isn't an array.

--- a/lib/Dialect/SV/Transforms/AlwaysFusion.cpp
+++ b/lib/Dialect/SV/Transforms/AlwaysFusion.cpp
@@ -17,7 +17,6 @@
 #include "circt/Dialect/SV/SVPasses.h"
 #include "mlir/IR/Visitors.h"
 
-using namespace mlir;
 using namespace circt;
 using namespace sv;
 
@@ -28,7 +27,8 @@ namespace {
 /// each op.
 struct SimpleOperationInfo : public llvm::DenseMapInfo<Operation *> {
   static unsigned getHashValue(const Operation *opC) {
-    return OperationEquivalence::computeHash(const_cast<Operation *>(opC));
+    return mlir::OperationEquivalence::computeHash(
+        const_cast<Operation *>(opC));
   }
   static bool isEqual(const Operation *lhsC, const Operation *rhsC) {
     auto *lhs = const_cast<Operation *>(lhsC);
@@ -38,7 +38,7 @@ struct SimpleOperationInfo : public llvm::DenseMapInfo<Operation *> {
     if (lhs == getTombstoneKey() || lhs == getEmptyKey() ||
         rhs == getTombstoneKey() || rhs == getEmptyKey())
       return false;
-    return OperationEquivalence::isEquivalentTo(lhs, rhs);
+    return mlir::OperationEquivalence::isEquivalentTo(lhs, rhs);
   }
 };
 

--- a/lib/Dialect/StaticLogic/StaticLogicOps.cpp
+++ b/lib/Dialect/StaticLogic/StaticLogicOps.cpp
@@ -13,7 +13,6 @@
 #include "circt/Dialect/StaticLogic/StaticLogic.h"
 #include "mlir/IR/FunctionImplementation.h"
 
-using namespace mlir;
 using namespace circt;
 using namespace circt::staticlogic;
 

--- a/lib/Support/BackedgeBuilder.cpp
+++ b/lib/Support/BackedgeBuilder.cpp
@@ -11,11 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Support/BackedgeBuilder.h"
-
+#include "circt/Support/LLVM.h"
 #include "mlir/IR/PatternMatch.h"
 
 using namespace circt;
-using namespace mlir;
 
 Backedge::Backedge(mlir::Operation *op) : value(op->getResult(0)) {}
 

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -25,7 +25,7 @@
 #include "llvm/Support/raw_ostream.h"
 
 using namespace circt;
-using namespace mlir;
+
 using namespace rtl;
 using namespace sv;
 
@@ -2213,8 +2213,8 @@ LogicalResult circt::exportVerilog(ModuleOp module, llvm::raw_ostream &os) {
 }
 
 void circt::registerToVerilogTranslation() {
-  TranslateFromMLIRRegistration toVerilog(
-      "export-verilog", exportVerilog, [](DialectRegistry &registry) {
+  mlir::TranslateFromMLIRRegistration toVerilog(
+      "export-verilog", exportVerilog, [](mlir::DialectRegistry &registry) {
         registry.insert<RTLDialect, SVDialect>();
       });
 }

--- a/lib/Translation/ExportVerilog/ExportVerilogFIRRTL.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilogFIRRTL.cpp
@@ -23,7 +23,6 @@
 
 using namespace circt;
 using namespace firrtl;
-using namespace mlir;
 
 /// Should we emit wire decls in a block at the top of a module, or inline?
 static constexpr bool emitInlineWireDecls = true;
@@ -2329,9 +2328,9 @@ LogicalResult circt::exportFIRRTLToVerilog(ModuleOp module,
 }
 
 void circt::registerFIRRTLToVerilogTranslation() {
-  TranslateFromMLIRRegistration toVerilog(
+  mlir::TranslateFromMLIRRegistration toVerilog(
       "export-firrtl-verilog", exportFIRRTLToVerilog,
-      [](DialectRegistry &registry) {
+      [](mlir::DialectRegistry &registry) {
         registry.insert<firrtl::FIRRTLDialect>();
       });
 }

--- a/tools/handshake-runner/Simulation.cpp
+++ b/tools/handshake-runner/Simulation.cpp
@@ -23,7 +23,7 @@
 #define INDEX_WIDTH 32
 
 using namespace llvm;
-using namespace mlir;
+
 using namespace circt;
 
 STATISTIC(instructionsExecuted, "Instructions Executed");


### PR DESCRIPTION
This change aims to remove all instances of `using namespace mlir` from
our header files.  Many types have been manually imported into the
`circt` namespace in `circt/Support/LLVM.h`.  These types include all
core MLIR functionality types (IR, Diagnostic), utility types, rewrite
patterns and conversions, builtin IR types and attrs, and the module op.

Not imported were any operations (other than ModuleOp), matcher (e.g.
m_Zero), anything in the `impl` namespace, and interfaces.  There are
some problems with interface code generation from ODS, so some
interfaces were imported.

~~Due to certain templates being exported by both MLIR and CIRCT (e.g.
SmallVector), there was an issue with ambiguous types when both MLIR and
CIRCT namespaces are used. To fix these situations, I just removed the
MLIR using declaration.  This lead to me removing `using namespace mlir`
from almost the entire code base.~~

Some further cleanup would be useful to remove the `mlir::` namespace
qualifier where we no longer need it.