### PR TITLE
Disable C API tests on Windows

### DIFF
--- a/test/CAPI/ir.c
+++ b/test/CAPI/ir.c
@@ -23,6 +23,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if defined(_WIN32) || defined(__CYGWIN__)
+/// The C API is currently not supported on Windows (https://github.com/llvm/circt/issues/578)
+int main() { return 0; }
+#else
 int registerOnlyRTL() {
   MlirContext ctx = mlirContextCreate();
   // The built-in dialect is always loaded.
@@ -67,3 +71,4 @@ int main() {
 
   return 0;
 }
+#endif


### PR DESCRIPTION
I believe I'm the only person who is using the C API currently, and it would be better to have the CI working so I suggest disabling this test until https://github.com/llvm/circt/issues/578 is fixed.