### PR TITLE
[ExportVerilog] Use 'wire' if in an RTL module, `logic' elsewhere

### DIFF
--- a/include/circt/Dialect/SV/SV.td
+++ b/include/circt/Dialect/SV/SV.td
@@ -34,6 +34,10 @@ def SVDialect : Dialect {
 class SVOp<string mnemonic, list<OpTrait> traits = []> :
     Op<SVDialect, mnemonic, traits>;
 
+def ProceduralRegion : NativeOpTrait<"ProceduralRegion"> {
+  let cppNamespace = "::circt::sv";
+}
+
 include "SVTypes.td"
 include "SVExpressions.td"
 include "SVInOutOps.td"

--- a/include/circt/Dialect/SV/SVOps.h
+++ b/include/circt/Dialect/SV/SVOps.h
@@ -25,7 +25,7 @@ namespace sv {
 /// Return true if the specified operation is an expression.
 bool isExpression(Operation *op);
 
-/// Signals that an ops regions are procedural.
+/// Signals that an operations regions are procedural.
 template <typename ConcreteType>
 class ProceduralRegion
     : public mlir::OpTrait::TraitBase<ConcreteType, ProceduralRegion> {

--- a/include/circt/Dialect/SV/SVOps.h
+++ b/include/circt/Dialect/SV/SVOps.h
@@ -19,19 +19,28 @@
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
-#define GET_OP_CLASSES
-#include "circt/Dialect/SV/SVEnums.h.inc"
-// Clang format shouldn't reorder these headers.
-#include "circt/Dialect/SV/SV.h.inc"
-#include "circt/Dialect/SV/SVStructs.h.inc"
-
 namespace circt {
 namespace sv {
 
 /// Return true if the specified operation is an expression.
 bool isExpression(Operation *op);
 
+/// Signals that an ops regions are procedural.
+template <typename ConcreteType>
+class ProceduralRegion
+    : public mlir::OpTrait::TraitBase<ConcreteType, ProceduralRegion> {
+  static LogicalResult verifyTrait(Operation *op) {
+    return mlir::OpTrait::impl::verifyAtLeastNRegions(op, 1);
+  }
+};
+
 } // namespace sv
 } // namespace circt
+
+#define GET_OP_CLASSES
+#include "circt/Dialect/SV/SVEnums.h.inc"
+// Clang format shouldn't reorder these headers.
+#include "circt/Dialect/SV/SV.h.inc"
+#include "circt/Dialect/SV/SVStructs.h.inc"
 
 #endif // CIRCT_DIALECT_SV_OPS_H

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -105,7 +105,7 @@ def EventControlAttr : I32EnumAttr<"EventControl", "edge control trigger",
 
 
 def AlwaysOp : SVOp<"always", [HasRegionTerminator, NoRegionArguments,
-                               RecursiveSideEffects]> {
+                               RecursiveSideEffects, ProceduralRegion]> {
   let summary = "'always @' block";
   let description = "See SV Spec 9.2, and 9.4.2.2.";
   
@@ -147,7 +147,7 @@ def ResetTypeAttr : I32EnumAttr<"ResetType", "reset type",
 
 
 def AlwaysFFOp : SVOp<"alwaysff", [HasRegionTerminator, NoRegionArguments,
-                               RecursiveSideEffects]> {
+                               RecursiveSideEffects, ProceduralRegion]> {
   let summary = "'alwaysff @' block with optional reset";
   let description = [{ 
     alwaysff blocks represent always_ff verilog nodes, which enforce inference 
@@ -190,7 +190,7 @@ def AlwaysFFOp : SVOp<"alwaysff", [HasRegionTerminator, NoRegionArguments,
 
 
 def InitialOp : SVOp<"initial", [HasRegionTerminator, NoRegionArguments,
-                                 RecursiveSideEffects]> {
+                                 RecursiveSideEffects, ProceduralRegion]> {
   let summary = "'initial' block";
   let description = "See SV Spec 9.2.1.";
 

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -172,6 +172,22 @@ static bool isNoopCast(Operation *op) {
   return false;
 }
 
+/// Return the word (e.g. "reg") in Verilog to declare the specified thing.
+static StringRef getVerilogDeclWord(Operation *op) {
+  if (isa<RegOp>(op))
+    return "reg";
+  if (isa<WireOp>(op) || isa<MergeOp>(op))
+    return "wire";
+
+  // Interfaces instances use the name of the declared interface.
+  if (auto interface = dyn_cast<InterfaceInstanceOp>(op))
+    return interface.getInterfaceType().getInterface().getValue();
+
+  if (isa<RTLModuleOp>(op->getParentOp()))
+    return "wire";
+  return "logic";
+};
+
 namespace {
 /// This enum keeps track of the precedence level of various binary operators,
 /// where a lower number binds tighter.
@@ -1116,7 +1132,7 @@ void ModuleEmitter::emitStatementExpression(Operation *op) {
   } else if (isZeroBitType(op->getResult(0).getType())) {
     indent() << "// Zero width: ";
   } else if (emitInlineLogicDecls && !outOfLineExpresssionDecls.count(op)) {
-    indent() << "logic ";
+    indent() << getVerilogDeclWord(op) << " ";
     emitTypeDimWithSpaceIfNeeded(op->getResult(0).getType(), op->getLoc(), os);
     os << getName(op->getResult(0)) << " = ";
   } else {
@@ -1852,20 +1868,6 @@ public:
     return valuesToEmit;
   }
 
-  // Return the word (e.g. "reg") in Verilog to declare the specified thing.
-  static StringRef getVerilogDeclWord(Operation *op) {
-    if (isa<RegOp>(op))
-      return "reg";
-    if (isa<WireOp>(op) || isa<MergeOp>(op))
-      return "wire";
-
-    // Interfaces instances use the name of the declared interface.
-    if (auto interface = dyn_cast<InterfaceInstanceOp>(op))
-      return interface.getInterfaceType().getInterface().getValue();
-
-    return "logic";
-  };
-
 private:
   size_t maxDeclNameWidth = 0, maxTypeWidth = 0;
   SmallVector<ValuesToEmitRecord, 16> valuesToEmit;
@@ -1989,7 +1991,7 @@ void ModuleEmitter::collectNamesEmitDecls(Block &block) {
 
     // Emit the leading word, like 'wire' or 'reg'.
     auto type = record.value.getType();
-    auto word = NameCollector::getVerilogDeclWord(decl);
+    auto word = getVerilogDeclWord(decl);
     if (!isZeroBitType(type)) {
       indent() << word;
       os.indent(maxDeclNameWidth - word.size() + 1);

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -183,8 +183,13 @@ static StringRef getVerilogDeclWord(Operation *op) {
   if (auto interface = dyn_cast<InterfaceInstanceOp>(op))
     return interface.getInterfaceType().getInterface().getValue();
 
-  if (isa<RTLModuleOp>(op->getParentOp()))
-    return "wire";
+  Operation *parent = op;
+  do {
+    parent = parent->getParentOp();
+    if (isa<RTLModuleOp>(parent))
+      return "wire";
+  } while (parent != nullptr && !parent->hasTrait<ProceduralRegion>());
+
   return "logic";
 };
 

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -183,6 +183,8 @@ static StringRef getVerilogDeclWord(Operation *op) {
   if (auto interface = dyn_cast<InterfaceInstanceOp>(op))
     return interface.getInterfaceType().getInterface().getValue();
 
+  // If 'op' is in a module, output 'wire'. If 'op' is in a procedural block,
+  // fall through to default.
   Operation *parent = op;
   do {
     parent = parent->getParentOp();

--- a/test/ExportVerilog/rtl-dialect.mlir
+++ b/test/ExportVerilog/rtl-dialect.mlir
@@ -92,8 +92,8 @@ rtl.module @TESTSIMPLE(%a: i4, %b: i4, %cond: i1,
 // CHECK-NEXT:   output [3:0]            r37,
 // CHECK-NEXT:   output [5:0][3:0]       r38);
 // CHECK-EMPTY:
-// CHECK-NEXT:   logic [8:0][3:0] [[WIRE0:.+]] = {{[{}][{}]}}4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}};
-// CHECK-NEXT:   logic [2:0][3:0] [[WIRE1:.+]] = {{[{}][{}]}}4'hF}, {a + b}, {4'hF}};
+// CHECK-NEXT:   wire [8:0][3:0] [[WIRE0:.+]] = {{[{}][{}]}}4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}};
+// CHECK-NEXT:   wire [2:0][3:0] [[WIRE1:.+]] = {{[{}][{}]}}4'hF}, {a + b}, {4'hF}};
 // CHECK-NEXT:   assign r0 = a + b;
 // CHECK-NEXT:   assign r2 = a - b;
 // CHECK-NEXT:   assign r4 = a * b;
@@ -190,11 +190,11 @@ rtl.module @AB(%w: i1, %x: i1, %i2: i2, %i3: i0) -> (%y: i1, %z: i1, %p: i1, %p2
 // CHECK-NEXT: // input  /*Zero Width*/ i3,
 // CHECK-NEXT:    output                y, z, p, p2);
 // CHECK-EMPTY:
-// CHECK-NEXT:    logic a1_f;
-// CHECK-NEXT:    logic b1_b;
-// CHECK-NEXT:    logic b1_c;
-// CHECK-NEXT:    logic paramd_out;
-// CHECK-NEXT:    logic paramd2_out;
+// CHECK-NEXT:    wire a1_f;
+// CHECK-NEXT:    wire b1_b;
+// CHECK-NEXT:    wire b1_c;
+// CHECK-NEXT:    wire paramd_out;
+// CHECK-NEXT:    wire paramd2_out;
 // CHECK-EMPTY:
 // CHECK-NEXT:    A a1 (
 // CHECK-NEXT:      .d (w),
@@ -275,7 +275,7 @@ rtl.module @literal_extract(%inp_1: i349) -> (%tmp6: i349) {
   rtl.output %0 : i349
 }
 // CHECK-LABEL: module literal_extract
-// CHECK: logic [16:0] _T = 17'h11A2C;
+// CHECK: wire [16:0] _T = 17'h11A2C;
 // CHECK: assign tmp6 = {{[{][{]}}332{_T[16]}}, _T};
 
 rtl.module @wires(%in4: i4, %in8: i8) -> (%a: i4, %b: i8, %c: i8) {
@@ -393,7 +393,7 @@ rtl.module @casts(%in1: i7, %in2: !rtl.array<8xi4>) -> (%r1: !rtl.array<7xi1>, %
   %r1 = rtl.bitcast %in1 : (i7) -> !rtl.array<7xi1>
   %r2 = rtl.bitcast %in2 : (!rtl.array<8xi4>) -> i32
 
-  // CHECK-NEXT: logic [31:0] {{.+}} = /*cast(bit[31:0])*/in2;
+  // CHECK-NEXT: wire [31:0] {{.+}} = /*cast(bit[31:0])*/in2;
   // CHECK-NEXT: assign r1 = in1;
   rtl.output %r1, %r2 : !rtl.array<7xi1>, i32
 }
@@ -461,7 +461,7 @@ rtl.module @TestEmptyInstanceName(%a: i1) {
 
 // CHECK-LABEL: TestInstanceNameValueConflict
 rtl.module @TestInstanceNameValueConflict(%a: i1) {
-  // CHECK: wire  name
+  // CHECK: wire name
   %name = sv.wire : !rtl.inout<i1>
 
   // CHECK: B name_0 (
@@ -482,9 +482,9 @@ rtl.module @issue525(%struct: i2, %else: i2) -> (%casex: i2) {
 // https://github.com/llvm/circt/issues/438
 // CHECK-LABEL: module cyclic
 rtl.module @cyclic(%a: i1) -> (i1 {rtl.name = "b"}) {
-  // CHECK: logic _T_0;
+  // CHECK: wire _T_0;
 
-  // CHECK: logic _T = _T_0 + _T_0;
+  // CHECK: wire _T = _T_0 + _T_0;
   %1 = rtl.add %0, %0 : i1
   // CHECK: assign _T_0 = a << a;
   %0 = rtl.shl %a, %a : i1

--- a/test/ExportVerilog/sv-dialect.mlir
+++ b/test/ExportVerilog/sv-dialect.mlir
@@ -176,7 +176,7 @@ rtl.module @reg(%in4: i4, %in8: i8) -> (%a: i8, %b: i8) {
 // CHECK-LABEL: issue508
 // https://github.com/llvm/circt/issues/508
 rtl.module @issue508(%in1: i1, %in2: i1) {
-  // CHECK: logic _T = in1 | in2;
+  // CHECK: wire _T = in1 | in2;
   %clock = rtl.or %in1, %in2 : i1 
 
   // CHECK-NEXT: always @(posedge _T)
@@ -187,7 +187,7 @@ rtl.module @issue508(%in1: i1, %in2: i1) {
 // CHECK-LABEL: exprInlineTestIssue439
 // https://github.com/llvm/circt/issues/439
 rtl.module @exprInlineTestIssue439(%clk: i1) {
-  // CHECK: logic [31:0] _T = 32'h0;
+  // CHECK: wire [31:0] _T = 32'h0;
   %c = rtl.constant (0:i32) : i32
 
   // CHECK: always @(posedge clk) begin
@@ -205,7 +205,7 @@ rtl.module @exprInlineTestIssue439(%clk: i1) {
 // https://github.com/llvm/circt/issues/439
 rtl.module @issue439(%in1: i1, %in2: i1) {
   // CHECK: wire _T_0;
-  // CHECK: logic _T = in1 | in2;
+  // CHECK: wire _T = in1 | in2;
   %clock = rtl.or %in1, %in2 : i1
 
   // CHECK-NEXT: always @(posedge _T)
@@ -217,4 +217,3 @@ rtl.module @issue439(%in1: i1, %in2: i1) {
     sv.fwrite "Bye %x\n"(%merged) : i1
   }
 }
-

--- a/test/ExportVerilog/sv-dialect.mlir
+++ b/test/ExportVerilog/sv-dialect.mlir
@@ -117,6 +117,18 @@ rtl.module @M1(%clock : i1, %cond : i1, %val : i8) {
     %thing = sv.textual_value "THING" : i42
     // CHECK-NEXT: wire42 = _T;
     sv.bpassign %wire42, %thing : i42
+
+    sv.ifdef "FOO" {
+      // CHECK-NEXT: `ifdef FOO
+      %c1 = sv.textual_value "\"THING\"" : i1
+      // CHECK-NEXT: logic {{.+}} = "THING";
+      sv.fwrite "%d" (%c1) : i1
+      // CHECK-NEXT: fwrite(32'h80000002, "%d", {{.+}});
+      sv.fwrite "%d" (%c1) : i1
+      // CHECK-NEXT: fwrite(32'h80000002, "%d", {{.+}});
+      // CHECK-NEXT: `endif
+    }
+
     // CHECK-NEXT: wire42 <= _T;
     sv.passign %wire42, %thing : i42
   }// CHECK-NEXT:   {{end // initial$}}
@@ -131,6 +143,17 @@ rtl.module @M1(%clock : i1, %cond : i1, %val : i8) {
 
   // CHECK-NEXT: `define STUFF "wire42 (val + val)"
   sv.verbatim "`define STUFF \"{{0}} ({{1}})\"" (%wire42, %add) : !rtl.inout<i42>, i8
+
+  sv.ifdef "FOO" {
+    // CHECK-NEXT: `ifdef FOO
+    %c1 = sv.textual_value "\"THING\"" : i1
+    // CHECK-NEXT: wire {{.+}} = "THING";
+    sv.fwrite "%d" (%c1) : i1
+    // CHECK-NEXT: fwrite(32'h80000002, "%d", {{.+}});
+    sv.fwrite "%d" (%c1) : i1
+    // CHECK-NEXT: fwrite(32'h80000002, "%d", {{.+}});
+    // CHECK-NEXT: `endif
+  }
 }
 
 // CHECK-LABEL: module Aliasing(


### PR DESCRIPTION
https://github.com/llvm/circt/issues/439#issuecomment-779001339

I think this is correct... It fixes the integration tests we broke in e043814d2c1fcf418070a5f977c96ba75451bee5.