### PR TITLE
[ESI] Fix integration test issues

### DIFF
--- a/include/circt/Dialect/ESI/cosim/Server.h
+++ b/include/circt/Dialect/ESI/cosim/Server.h
@@ -17,10 +17,7 @@
 #define CIRCT_DIALECT_ESI_COSIM_SERVER_H
 
 #include "circt/Dialect/ESI/cosim/Endpoint.h"
-
-namespace std {
-class thread;
-} // namespace std
+#include <thread>
 
 namespace circt {
 namespace esi {

--- a/lib/Dialect/ESI/ESITranslations.cpp
+++ b/lib/Dialect/ESI/ESITranslations.cpp
@@ -4,12 +4,12 @@
 // - Cap'nProto schema generation
 //
 //===----------------------------------------------------------------------===//
+
 #include "circt/Dialect/ESI/ESIDialect.h"
 #include "circt/Dialect/ESI/ESIOps.h"
-
 #include "circt/Dialect/RTL/RTLDialect.h"
 #include "circt/Dialect/SV/SVDialect.h"
-
+#include "circt/Support/LLVM.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/BuiltinDialect.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -22,6 +22,7 @@
 #include "circt/Dialect/ESI/CosimSchema.h"
 #endif
 
+using namespace circt;
 using namespace circt::esi;
 
 //===----------------------------------------------------------------------===//
@@ -40,7 +41,7 @@ struct ExportCosimSchema {
       : module(module), os(os), diag(module.getContext()->getDiagEngine()),
         unknown(UnknownLoc::get(module.getContext())) {
     diag.registerHandler([this](Diagnostic &diag) -> LogicalResult {
-      if (diag.getSeverity() == DiagnosticSeverity::Error)
+      if (diag.getSeverity() == mlir::DiagnosticSeverity::Error)
         ++errorCount;
       return failure();
     });
@@ -61,7 +62,7 @@ struct ExportCosimSchema {
 private:
   ModuleOp module;
   llvm::raw_ostream &os;
-  DiagnosticEngine &diag;
+  mlir::DiagnosticEngine &diag;
   const Location unknown;
   size_t errorCount = 0;
 

--- a/test/Dialect/ESI/cosim.mlir
+++ b/test/Dialect/ESI/cosim.mlir
@@ -96,9 +96,9 @@ rtl.module @top(%clk:i1, %rstn:i1) -> () {
   // SV:      assert(rootPointer_2[6'h0+:32] == 32'h0);
   // SV:      assert(rootPointer_2[6'h20+:16] == 16'h0);
   // SV:      assert(rootPointer_2[6'h30+:16] == 16'h1);
-  // SV:      assert(i_ptr[6'h0+:2] == 2'h0);
-  // SV:      assert(i_ptr[6'h1F+:3] == 3'h5);
-  // SV:      assert($signed(i_ptr[6'h22+:29]) <= 29'sh0);
+  // SV:      assert(i_ptr[6'h0+:2] == 2'h1);
+  // SV:      assert(i_ptr[6'h20+:3] == 3'h5);
+  // SV:      assert(i_ptr[6'h23+:29] <= 29'h4);
   // SV:    end
   // SV:  end // always @(posedge)
   // SV:  wire [63:0] rootPointer_2 = ArrTestEP_DataOut[9'h0+:64];


### PR DESCRIPTION
I broke the integration testing with a recent PR I merged.  I managed to get these tests working on OSX, just had to install capnp with `brew install --HEAD capnp` :). The changes to cosim.mlir need to be verified, all I did was copy the output of the tool.

- Don't forward declare std::thread.  Does not work on OSX, and in general
  you can't forward declare classes from the `std` namespace.
- Fix namespace issues caused by e1ca6eaaf9.
- Fix cosim test: use logic instead of wire, fix constants