### PR TITLE
[HandshakeToFIRRTL] Fix decoder one-hot vector width.

### DIFF
--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -312,7 +312,7 @@ static Value createOneHotMuxTree(ArrayRef<Value> inputs, Value select,
 
 /// Construct a decoder by dynamically shifting 1 bit by the input amount.
 /// See http://www.imm.dtu.dk/~masca/chisel-book.pdf Section 5.2.
-static Value createDecoder(Value input, unsigned width, Location insertLoc,
+static Value createDecoder(Value input, Location insertLoc,
                            ConversionPatternRewriter &rewriter) {
   auto *context = rewriter.getContext();
 
@@ -881,8 +881,7 @@ bool HandshakeBuilder::visitHandshake(MuxOp op) {
   // Since addresses coming from Handshake are IndexType and have a hardcoded
   // 64-bit width in this pass, we may need to truncate down to the actual
   // width used to index into the decoder.
-  uint64_t decodeWidth = argData.size();
-  size_t bitsNeeded = getNumIndexBits(decodeWidth);
+  size_t bitsNeeded = getNumIndexBits(argData.size());
   size_t selectBits =
       selectData.getType().cast<FIRRTLType>().getBitWidthOrSentinel();
 
@@ -894,8 +893,7 @@ bool HandshakeBuilder::visitHandshake(MuxOp op) {
   }
 
   // Create a decoder for the select data.
-  auto decodedSelect =
-      createDecoder(selectData, decodeWidth, insertLoc, rewriter);
+  auto decodedSelect = createDecoder(selectData, insertLoc, rewriter);
 
   // Walk through each arg data.
   for (unsigned i = 0, e = argData.size(); i != e; ++i) {

--- a/test/Conversion/HandshakeToFIRRTL/test_mux.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_mux.mlir
@@ -23,9 +23,9 @@
 // CHECK:   firrtl.connect %9, %16 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // CHECK:   %17 = firrtl.and %16, %10 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   firrtl.connect %1, %17 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// CHECK:   %18 = firrtl.tail %2, 63 : (!firrtl.uint<64>) -> !firrtl.uint<1>
 // CHECK:   %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
-// CHECK:   %18 = firrtl.dshl %c1_ui1, %2 : (!firrtl.uint<1>, !firrtl.uint<64>) -> !firrtl.uint<1>
-// CHECK:   %19 = firrtl.pad %18, 2 : (!firrtl.uint<1>) -> !firrtl.uint<2>
+// CHECK:   %19 = firrtl.dshl %c1_ui1, %18 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
 // CHECK:   %20 = firrtl.bits %19 0 to 0 : (!firrtl.uint<2>) -> !firrtl.uint<1>
 // CHECK:   %21 = firrtl.and %20, %17 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   firrtl.connect %4, %21 : !firrtl.flip<uint<1>>, !firrtl.uint<1>


### PR DESCRIPTION
The previous calculation was done using the width of the entire 64-bit
index to dynamically shift a bit into a one-hot vector. This adds a
tail operation to only select the bits needed from the index. This
updates the decoder implementation to just compute the correct result
width of the dshl operation, and drops the unneeded pad.
This came up while testing #543.