### PR TITLE
[HandshakeToFIRRTL] Add control buffering to BufferOp lowering.

### DIFF
--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -728,9 +728,12 @@ public:
   void buildAllReadyLogic(SmallVector<ValueVector *, 4> inputs,
                           ValueVector *output, Value condition);
 
-  void buildOneStageSeqBufferLogic(Value predValid, Value validReg,
-                                   Value predReady, Value succReady,
-                                   Value predData, Value dataReg);
+  void buildControlBufferLogic(Value predValid, Value predReady,
+                               Value succValid, Value succReady, Value clock,
+                               Value reset, Value predData = nullptr,
+                               Value succData = nullptr);
+  void buildDataBufferLogic(Value predValid, Value validReg, Value predReady,
+                            Value succReady, Value predData, Value dataReg);
   bool buildSeqBufferLogic(int64_t numStage, ValueVector *input,
                            ValueVector *output, Value clock, Value reset,
                            bool isControl);
@@ -1431,9 +1434,83 @@ bool HandshakeBuilder::visitHandshake(handshake::ConstantOp op) {
   return true;
 }
 
-void HandshakeBuilder::buildOneStageSeqBufferLogic(
-    Value predValid, Value validReg, Value predReady, Value succReady,
-    Value predData = nullptr, Value dataReg = nullptr) {
+void HandshakeBuilder::buildControlBufferLogic(Value predValid, Value predReady,
+                                               Value succValid, Value succReady,
+                                               Value clock, Value reset,
+                                               Value predData, Value succData) {
+  auto bitType = UIntType::get(rewriter.getContext(), 1);
+  auto falseConst = createConstantOp(bitType, APInt(1, 0), insertLoc, rewriter);
+
+  // Create a wire and connect it to the register for the ready buffer.
+  auto readyRegWireName = rewriter.getStringAttr("readyRegWire");
+  auto readyRegWire =
+      rewriter.create<WireOp>(insertLoc, bitType, readyRegWireName);
+
+  auto readyRegName = rewriter.getStringAttr("readyReg");
+  auto readyReg = rewriter.create<RegResetOp>(insertLoc, bitType, clock, reset,
+                                              falseConst, readyRegName);
+  rewriter.create<ConnectOp>(insertLoc, readyReg, readyRegWire);
+
+  // Create the logic to drive the successor valid and potentially data.
+  auto validResult = rewriter.create<MuxPrimOp>(insertLoc, bitType, readyReg,
+                                                readyReg, predValid);
+  rewriter.create<ConnectOp>(insertLoc, succValid, validResult);
+
+  // Create the logic to drive the predecessor ready.
+  auto notReady = rewriter.create<NotPrimOp>(insertLoc, bitType, readyReg);
+  rewriter.create<ConnectOp>(insertLoc, predReady, notReady);
+
+  // Create the logic for successor and register are both low.
+  auto succNotReady = rewriter.create<NotPrimOp>(insertLoc, bitType, succReady);
+  auto neitherReady =
+      rewriter.create<AndPrimOp>(insertLoc, bitType, succNotReady, notReady);
+
+  // Create a mux for taking the input when neither ready.
+  auto ctrlNotReadyMux = rewriter.create<MuxPrimOp>(
+      insertLoc, bitType, neitherReady, predValid, readyReg);
+
+  // Create the logic for successor and register are both high.
+  auto bothReady =
+      rewriter.create<AndPrimOp>(insertLoc, bitType, succReady, readyReg);
+
+  // Create a mux for emptying the register when both are ready.
+  auto resetSignal = rewriter.create<MuxPrimOp>(insertLoc, bitType, bothReady,
+                                                falseConst, ctrlNotReadyMux);
+  rewriter.create<ConnectOp>(insertLoc, readyRegWire, resetSignal);
+
+  // Add same logic for the data path if necessary.
+  if (predData) {
+    auto dataType = predData.getType().cast<FIRRTLType>();
+    auto ctrlDataRegWireName = rewriter.getStringAttr("ctrlDataRegWire");
+    auto ctrlDataRegWire =
+        rewriter.create<WireOp>(insertLoc, dataType, ctrlDataRegWireName);
+
+    auto ctrlDataRegName = rewriter.getStringAttr("ctrlDataReg");
+    auto ctrlZeroConst =
+        createConstantOp(dataType, APInt(dataType.getBitWidthOrSentinel(), 0),
+                         insertLoc, rewriter);
+    auto ctrlDataReg = rewriter.create<RegResetOp>(
+        insertLoc, dataType, clock, reset, ctrlZeroConst, ctrlDataRegName);
+
+    rewriter.create<ConnectOp>(insertLoc, ctrlDataReg, ctrlDataRegWire);
+
+    auto dataResult = rewriter.create<MuxPrimOp>(insertLoc, dataType, readyReg,
+                                                 ctrlDataReg, predData);
+    rewriter.create<ConnectOp>(insertLoc, succData, dataResult);
+
+    auto dataNotReadyMux = rewriter.create<MuxPrimOp>(
+        insertLoc, dataType, neitherReady, predData, ctrlDataReg);
+
+    auto dataResetSignal = rewriter.create<MuxPrimOp>(
+        insertLoc, dataType, bothReady, ctrlZeroConst, dataNotReadyMux);
+    rewriter.create<ConnectOp>(insertLoc, ctrlDataRegWire, dataResetSignal);
+  }
+}
+
+void HandshakeBuilder::buildDataBufferLogic(Value predValid, Value validReg,
+                                            Value predReady, Value succReady,
+                                            Value predData = nullptr,
+                                            Value dataReg = nullptr) {
   auto bitType = UIntType::get(rewriter.getContext(), 1);
 
   // Create a signal for when the valid register is empty or the successor is
@@ -1523,14 +1600,37 @@ bool HandshakeBuilder::buildSeqBufferLogic(int64_t numStage, ValueVector *input,
                                             zeroDataConst, dataRegName);
     }
 
+    // Create wires for valid, ready and data signal coming from the control
+    // buffer stage.
+    auto ctrlValidWireName =
+        rewriter.getStringAttr("ctrlValidWire" + std::to_string(i));
+    auto ctrlValidWire =
+        rewriter.create<WireOp>(insertLoc, bitType, ctrlValidWireName);
+
+    auto ctrlReadyWireName =
+        rewriter.getStringAttr("ctrlReadyWire" + std::to_string(i));
+    auto ctrlReadyWire =
+        rewriter.create<WireOp>(insertLoc, bitType, ctrlReadyWireName);
+
+    Value ctrlDataWire;
+    if (!isControl) {
+      auto ctrlDataWireName =
+          rewriter.getStringAttr("ctrlDataWire" + std::to_string(i));
+      ctrlDataWire =
+          rewriter.create<WireOp>(insertLoc, dataType, ctrlDataWireName);
+    }
+
     // Build the current stage of the buffer.
-    buildOneStageSeqBufferLogic(currentValid, validReg, currentReady, readyWire,
-                                currentData, dataReg);
+    buildDataBufferLogic(currentValid, validReg, currentReady, readyWire,
+                         currentData, dataReg);
+
+    buildControlBufferLogic(validReg, readyWire, ctrlValidWire, ctrlReadyWire,
+                            clock, reset, dataReg, ctrlDataWire);
 
     // Update the current valid, ready, and data.
-    currentValid = validReg;
-    currentReady = readyWire;
-    currentData = dataReg;
+    currentValid = ctrlValidWire;
+    currentReady = ctrlReadyWire;
+    currentData = ctrlDataWire;
   }
 
   // Connect to the output ports.

--- a/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
@@ -10,31 +10,53 @@
 
 // Stage 0 ready wire and valid register.
 // CHECK:   %readyWire0 = firrtl.wire : !firrtl.uint<1>
-// CHECK:   %validReg0 = firrtl.regreset %clock, %reset, %c0_ui1 {name = "validReg0"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   %[[VALID_REG0:.+]] = firrtl.regreset %clock, %reset, %c0_ui1 {name = "validReg0"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   %ctrlValidWire0 = firrtl.wire : !firrtl.uint<1>
 // CHECK:   %ctrlReadyWire0 = firrtl.wire : !firrtl.uint<1>
 
 // pred_ready = !reg_valid || succ_ready.
-// CHECK:   %[[VAL_4:.+]] = firrtl.not %validReg0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   %[[VAL_4:.+]] = firrtl.not %[[VALID_REG0]] : (!firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   %[[VAL_5:.+]] = firrtl.or %[[VAL_4:.+]], %readyWire0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   firrtl.connect %[[IN_READY:.+]], %[[VAL_5:.+]] : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 
 // Drive valid register.
-// CHECK:   %[[VAL_6:.+]] = firrtl.mux(%[[VAL_5:.+]], %[[IN_VALID:.+]], %validReg0) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %validReg0, %[[VAL_6:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   %[[VAL_6:.+]] = firrtl.mux(%[[VAL_5:.+]], %[[IN_VALID:.+]], %[[VALID_REG0]]) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   firrtl.connect %[[VALID_REG0]], %[[VAL_6:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
+
+// Stage 0 ready register.
+// CHECK:   %[[READY_REG0:.+]] = firrtl.regreset %clock, %reset, %c0_ui1_0 {name = "readyReg"}
+
+// succ_valid = readyReg ? readyReg : pred_valid
+// CHECK:   %[[SUCC_VALID0:.+]] = firrtl.mux(%[[READY_REG0]], %[[READY_REG0]], %[[VALID_REG0]])
+// CHECK:   firrtl.connect %ctrlValidWire0, %[[SUCC_VALID0]]
+
+// pred_ready = !readyReg
+// CHECK:   %[[NOT_READY0:.+]] = firrtl.not %[[READY_REG0]]
+// CHECK:   firrtl.connect %readyWire0, %[[NOT_READY0]]
 
 // Stage 1 logics.
 // CHECK:   %readyWire1 = firrtl.wire : !firrtl.uint<1>
-// CHECK:   %validReg1 = firrtl.regreset %clock, %reset, %c0_ui1 {name = "validReg1"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   %[[VALID_REG1:.+]] = firrtl.regreset %clock, %reset, %c0_ui1 {name = "[[VALID_REG1]]"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   %ctrlValidWire1 = firrtl.wire : !firrtl.uint<1>
 // CHECK:   %ctrlReadyWire1 = firrtl.wire : !firrtl.uint<1>
 
-// CHECK:   %[[VAL_7:.+]] = firrtl.not %validReg1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   %[[VAL_7:.+]] = firrtl.not %[[VALID_REG1]] : (!firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   %[[VAL_8:.+]] = firrtl.or %[[VAL_7:.+]], %readyWire1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   firrtl.connect %ctrlReadyWire0, %[[VAL_8:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
 
-// CHECK:   %[[VAL_9:.+]] = firrtl.mux(%[[VAL_8:.+]], %ctrlValidWire0, %validReg1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %validReg1, %[[VAL_9:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   %[[VAL_9:.+]] = firrtl.mux(%[[VAL_8:.+]], %ctrlValidWire0, %[[VALID_REG1]]) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   firrtl.connect %[[VALID_REG1]], %[[VAL_9:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
+
+// Stage 1 ready register.
+// CHECK:   %[[READY_REG1:.+]] = firrtl.regreset %clock, %reset, %c0_ui1_1 {name = "readyReg"}
+
+// succ_valid = readyReg ? readyReg : pred_valid
+// CHECK:   %[[SUCC_VALID1:.+]] = firrtl.mux(%[[READY_REG1]], %[[READY_REG1]], %[[VALID_REG1]])
+// CHECK:   firrtl.connect %ctrlValidWire1, %[[SUCC_VALID1]]
+
+// pred_ready = !readyReg
+// CHECK:   %[[NOT_READY1:.+]] = firrtl.not %[[READY_REG1]]
+// CHECK:   firrtl.connect %readyWire1, %[[NOT_READY1]]
 
 // Stage 2 logics.
 // CHECK:   %readyWire2 = firrtl.wire : !firrtl.uint<1>
@@ -69,13 +91,24 @@ handshake.func @test_buffer(%arg0: none, %arg1: none, ...) -> (none, none) {
 // CHECK:   %[[OUT_DATA:.+]] = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
 // CHECK:   %c0_ui64 = firrtl.constant(0 : ui64) : !firrtl.uint<64>
 
-// CHECK:   %dataReg0 = firrtl.regreset %clock, %reset, %c0_ui64 {name = "dataReg0"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<64>) -> !firrtl.uint<64>
-// CHECK:   %[[VAL_9:.+]] = firrtl.mux(%[[VAL_7:.+]], %[[IN_DATA:.+]], %dataReg0) : (!firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>) -> !firrtl.uint<64>
-// CHECK:   firrtl.connect %dataReg0, %[[VAL_9:.+]] : !firrtl.uint<64>, !firrtl.uint<64>
+// CHECK:   %[[DATA_REG0:.+]] = firrtl.regreset %clock, %reset, %c0_ui64 {name = "dataReg0"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<64>) -> !firrtl.uint<64>
 
-// CHECK:   %dataReg1 = firrtl.regreset %clock, %reset, %c0_ui64 {name = "dataReg1"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<64>) -> !firrtl.uint<64>
-// CHECK:   %[[VAL_13:.+]] = firrtl.mux(%[[VAL_11:.+]], %dataReg1, %ctrlDataReg_7) : (!firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>) -> !firrtl.uint<64>
-// CHECK:   firrtl.connect %ctrlDataRegWire_5, %[[VAL_13:.+]] : !firrtl.uint<64>, !firrtl.uint<64>
+// CHECK:   %[[VAL_9:.+]] = firrtl.mux(%[[VAL_7:.+]], %[[IN_DATA:.+]], %[[DATA_REG0]]) : (!firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>) -> !firrtl.uint<64>
+// CHECK:   firrtl.connect %[[DATA_REG0]], %[[VAL_9:.+]] : !firrtl.uint<64>, !firrtl.uint<64>
+
+// CHECK:   %[[CTRL_DATA_REG0:.+]] = firrtl.regreset %clock, %reset, %c0_ui64_1 {name = "ctrlDataReg"}
+// CHECK:   %[[SUCC_DATA0:.+]] = firrtl.mux(%readyReg{{.*}}, %[[CTRL_DATA_REG0]], %[[DATA_REG0]])
+// CHECK:   firrtl.connect %ctrlDataWire0, %[[SUCC_DATA0]]
+
+// CHECK:   %[[DATA_REG1:.+]] = firrtl.regreset %clock, %reset, %c0_ui64 {name = "dataReg1"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<64>) -> !firrtl.uint<64>
+
+// CHECK:   %[[CTRL_DATA_REG1:.+]] = firrtl.regreset %clock, %reset, %c0_ui64_6 {name = "ctrlDataReg"}
+// CHECK:   %[[SUCC_DATA1:.+]] = firrtl.mux(%readyReg{{.*}}, %[[CTRL_DATA_REG1]], %[[DATA_REG1]])
+// CHECK:   firrtl.connect %ctrlDataWire1, %[[SUCC_DATA1]]
+
+// CHECK:   %[[VAL_13:.+]] = firrtl.mux(%[[VAL_11:.+]], %[[DATA_REG1]], %[[CTRL_DATA_REG1]]) : (!firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>) -> !firrtl.uint<64>
+// CHECK:   firrtl.connect %ctrlDataRegWire{{.*}}, %[[VAL_13:.+]] : !firrtl.uint<64>, !firrtl.uint<64>
+
 
 // CHECK:   firrtl.connect %[[OUT_DATA:.+]], %ctrlDataWire1 : !firrtl.flip<uint<64>>, !firrtl.uint<64>
 // CHECK: }

--- a/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
@@ -11,6 +11,8 @@
 // Stage 0 ready wire and valid register.
 // CHECK:   %readyWire0 = firrtl.wire : !firrtl.uint<1>
 // CHECK:   %validReg0 = firrtl.regreset %clock, %reset, %c0_ui1 {name = "validReg0"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   %ctrlValidWire0 = firrtl.wire : !firrtl.uint<1>
+// CHECK:   %ctrlReadyWire0 = firrtl.wire : !firrtl.uint<1>
 
 // pred_ready = !reg_valid || succ_ready.
 // CHECK:   %[[VAL_4:.+]] = firrtl.not %validReg0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
@@ -24,12 +26,14 @@
 // Stage 1 logics.
 // CHECK:   %readyWire1 = firrtl.wire : !firrtl.uint<1>
 // CHECK:   %validReg1 = firrtl.regreset %clock, %reset, %c0_ui1 {name = "validReg1"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   %ctrlValidWire1 = firrtl.wire : !firrtl.uint<1>
+// CHECK:   %ctrlReadyWire1 = firrtl.wire : !firrtl.uint<1>
 
 // CHECK:   %[[VAL_7:.+]] = firrtl.not %validReg1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   %[[VAL_8:.+]] = firrtl.or %[[VAL_7:.+]], %readyWire1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %readyWire0, %[[VAL_8:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   firrtl.connect %ctrlReadyWire0, %[[VAL_8:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
 
-// CHECK:   %[[VAL_9:.+]] = firrtl.mux(%[[VAL_8:.+]], %validReg0, %validReg1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   %[[VAL_9:.+]] = firrtl.mux(%[[VAL_8:.+]], %ctrlValidWire0, %validReg1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   firrtl.connect %validReg1, %[[VAL_9:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
 
 // Stage 2 logics.
@@ -38,14 +42,14 @@
 
 // CHECK:   %[[VAL_10:.+]] = firrtl.not %validReg2 : (!firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   %[[VAL_11:.+]] = firrtl.or %[[VAL_10:.+]], %readyWire2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %readyWire1, %[[VAL_11:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   firrtl.connect %ctrlReadyWire1, %[[VAL_11:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
 
-// CHECK:   %[[VAL_12:.+]] = firrtl.mux(%[[VAL_11:.+]], %validReg1, %validReg2) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   %[[VAL_12:.+]] = firrtl.mux(%[[VAL_11:.+]], %ctrlValidWire1, %validReg2) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   firrtl.connect %validReg2, %[[VAL_12:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
 
 // Connet to output ports.
-// CHECK:   firrtl.connect %[[OUT_VALID:.+]], %validReg2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// CHECK:   firrtl.connect %readyWire2, %[[OUT_READY:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   firrtl.connect %[[OUT_VALID:.+]], %ctrlValidWire2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// CHECK:   firrtl.connect %ctrlReadyWire2, %[[OUT_READY:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK: }
 
 // CHECK-LABEL: firrtl.module @test_buffer(
@@ -70,10 +74,10 @@ handshake.func @test_buffer(%arg0: none, %arg1: none, ...) -> (none, none) {
 // CHECK:   firrtl.connect %dataReg0, %[[VAL_9:.+]] : !firrtl.uint<64>, !firrtl.uint<64>
 
 // CHECK:   %dataReg1 = firrtl.regreset %clock, %reset, %c0_ui64 {name = "dataReg1"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<64>) -> !firrtl.uint<64>
-// CHECK:   %[[VAL_13:.+]] = firrtl.mux(%[[VAL_11:.+]], %dataReg0, %dataReg1) : (!firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>) -> !firrtl.uint<64>
-// CHECK:   firrtl.connect %dataReg1, %[[VAL_13:.+]] : !firrtl.uint<64>, !firrtl.uint<64>
+// CHECK:   %[[VAL_13:.+]] = firrtl.mux(%[[VAL_11:.+]], %dataReg1, %ctrlDataReg_7) : (!firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>) -> !firrtl.uint<64>
+// CHECK:   firrtl.connect %ctrlDataRegWire_5, %[[VAL_13:.+]] : !firrtl.uint<64>, !firrtl.uint<64>
 
-// CHECK:   firrtl.connect %[[OUT_DATA:.+]], %dataReg1 : !firrtl.flip<uint<64>>, !firrtl.uint<64>
+// CHECK:   firrtl.connect %[[OUT_DATA:.+]], %ctrlDataWire1 : !firrtl.flip<uint<64>>, !firrtl.uint<64>
 // CHECK: }
 
 // CHECK-LABEL: firrtl.module @test_buffer_data(


### PR DESCRIPTION
Previously, the lowering would only buffer the data/valid
network. This adds buffering on the ready network.