### PR TITLE
[RTL] Move to unsigned indexes for array ops

### DIFF
--- a/include/circt/Dialect/RTL/RTLAggregates.td
+++ b/include/circt/Dialect/RTL/RTLAggregates.td
@@ -101,7 +101,7 @@ def ArraySliceOp : RTLOp<"array_slice", [NoSideEffect]> {
     behavior.
   }];
 
-  let arguments = (ins ArrayType:$input, RTLIntegerType:$lowIndex);
+  let arguments = (ins ArrayType:$input, AnyUnsignedInteger:$lowIndex);
   let results = (outs ArrayType:$dst);
   let verifier = [{
     unsigned inputSize = input().getType().cast<ArrayType>().getSize();
@@ -140,7 +140,7 @@ def ArrayGetOp : RTLOp<"array_get",
     [NoSideEffect, IndexBitWidthConstraint<"index", "input">,
      ArrayElementTypeConstraint<"result", "input">]> {
   let summary = "Get the value in an array at the specified index";
-  let arguments = (ins ArrayType:$input, RTLIntegerType:$index);
+  let arguments = (ins ArrayType:$input, AnyUnsignedInteger:$index);
   let results = (outs RTLNonInOutType:$result);
 
   let assemblyFormat = [{

--- a/include/circt/Dialect/RTL/RTLTypes.td
+++ b/include/circt/Dialect/RTL/RTLTypes.td
@@ -19,12 +19,6 @@ class RTLType<string name> : TypeDef<RTLDialect, name> { }
 
 // Type constraint that indicates that an operand/result may only be a valid,
 // known, non-directional type.
-def RTLIntegerType : Type<CPred<"isRTLIntegerType($_self)">,
-                          "an integer bitvector of one or more bits",
-                          "::mlir::IntegerType">;
-
-// Type constraint that indicates that an operand/result may only be a valid,
-// known, non-directional type.
 def RTLValueType : Type<CPred<"isRTLValueType($_self)">,
                         "a known primitive element">;
 


### PR DESCRIPTION
@lattner What do you think of making indexes in array ops `AnyUnsignedInteger`? These are ops which care about signs. This would also allow zero-width indexes, which implies zero-length arrays should be valid. Not sure how I feel about this, but it may be useful to allow zero-length arrays as temporaries to be optimized away... Would like your thoughts before I make this work. I don't have a strong opinion either way.