### PR TITLE
[firtool] Add verify-each option to disable the verifier

### DIFF
--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -82,6 +82,11 @@ static cl::opt<OutputFormatKind> outputFormat(
                           "Do not output anything")),
     cl::init(OutputMLIR));
 
+static cl::opt<bool>
+    verifyPasses("verify-each",
+                 cl::desc("Run the verifier after each transformation pass"),
+                 cl::init(true));
+
 /// Process a single buffer of the input.
 static LogicalResult
 processBuffer(std::unique_ptr<llvm::MemoryBuffer> ownedBuffer,
@@ -100,7 +105,7 @@ processBuffer(std::unique_ptr<llvm::MemoryBuffer> ownedBuffer,
 
   // Apply any pass manager command line options.
   PassManager pm(&context);
-  pm.enableVerifier(true);
+  pm.enableVerifier(verifyPasses);
   applyPassManagerCLOptions(pm);
 
   OwningModuleRef module;


### PR DESCRIPTION
It can be really helpful to disable the verifier in order to dump all of
the IR at a later point.  This option is already supported by circt-opt,
but it can be useful here as well.