### PR TITLE
Fix gcc build issue with namespace

### DIFF
--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -2159,7 +2159,7 @@ struct HandshakeFuncOpLowering : public OpConversionPattern<handshake::FuncOp> {
       // be instantiated in the top-module.
       else if (op.getDialect()->getNamespace() != "firrtl") {
         FModuleOp subModuleOp = checkSubModuleOp(topModuleOp, &op);
-        bool hasClock = op.hasTrait<OpTrait::HasClock>();
+        bool hasClock = op.hasTrait<mlir::OpTrait::HasClock>();
 
         // Check if the sub-module already exists.
         if (!subModuleOp) {

--- a/lib/Dialect/ESI/ESIPasses.cpp
+++ b/lib/Dialect/ESI/ESIPasses.cpp
@@ -118,7 +118,7 @@ ESIRTLBuilder::ESIRTLBuilder(Operation *top)
 
 StringAttr ESIRTLBuilder::constructInterfaceName(ChannelPort port) {
   Operation *tableOp =
-      getInsertionPoint()->getParentWithTrait<OpTrait::SymbolTable>();
+      getInsertionPoint()->getParentWithTrait<mlir::OpTrait::SymbolTable>();
 
   // Get a name based on the type.
   std::string portTypeName;


### PR DESCRIPTION
Temporary fix for build failure on ubuntu with gcc. 
Getting the following error on main branch, with **gcc (Ubuntu 7.4.0-1ubuntu1~18.04.1) 7.4.0**

```
../lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp: In member function �virtual mlir::LogicalResult HandshakeFuncOpLowering::matchAndRewrite(circt::handshake::FuncOp, llvm::ArrayRef<mlir::Value>, mlir::ConversionPatternRewriter&) const�:                                                                                                                                                                              ../lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp:2162:28: error: parse error in template argument list                                                                                                           bool hasClock = op.hasTrait<OpTrait::HasClock>();                                                                                                                                                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                                          ../lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp:2162:56: error: no matching function for call to �mlir::Operation::hasTrait<<expression error> >()�                                                             bool hasClock = op.hasTrait<OpTrait::HasClock>();                                                                                                                                                                                                               ^                                                                                                                                                        In file included from ../llvm/mlir/include/mlir/IR/OpDefinition.h:22:0,                                                                                                                                                           from ../llvm/mlir/include/mlir/IR/FunctionSupport.h:18,
                 from ../llvm/mlir/include/mlir/IR/BuiltinOps.h:16,
                 from ../llvm/mlir/include/mlir/Pass/Pass.h:12,
                 from ../lib/Conversion/HandshakeToFIRRTL/../PassDetail.h:13,
                 from ../lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp:14:
../llvm/mlir/include/mlir/IR/Operation.h:467:53: note: candidate: template<template<class T> class Trait> bool mlir::Operation::hasTrait()
   template <template <typename T> class Trait> bool hasTrait() {
                                                     ^~~~~~~~
../llvm/mlir/include/mlir/IR/Operation.h:467:53: note:   template argument deduction/substitution failed:
../lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp:2162:56: error: template argument 1 is invalid
         bool hasClock = op.hasTrait<OpTrait::HasClock>();
                                                        ^
```