### PR TITLE
Struct output in verilog

### DIFF
--- a/include/circt/Dialect/RTL/RTLVisitors.h
+++ b/include/circt/Dialect/RTL/RTLVisitors.h
@@ -28,10 +28,10 @@ public:
     auto *thisCast = static_cast<ConcreteType *>(this);
     return TypeSwitch<Operation *, ResultType>(op)
         .template Case<
-                       // Array operations
-                       ArraySliceOp, ArrayCreateOp, ArrayConcatOp, ArrayGetOp,
-                       // Struct operations
-                       StructCreateOp, StructExtractOp, StructInjectOp>(
+            // Array operations
+            ArraySliceOp, ArrayCreateOp, ArrayConcatOp, ArrayGetOp,
+            // Struct operations
+            StructCreateOp, StructExtractOp, StructInjectOp>(
             [&](auto expr) -> ResultType {
               return thisCast->visitTypeOp(expr, args...);
             })

--- a/include/circt/Dialect/RTL/RTLVisitors.h
+++ b/include/circt/Dialect/RTL/RTLVisitors.h
@@ -42,7 +42,9 @@ public:
                        // Cast operation
                        BitcastOp,
                        // Array operations
-                       ArraySliceOp, ArrayCreateOp, ArrayConcatOp, ArrayGetOp>(
+                       ArraySliceOp, ArrayCreateOp, ArrayConcatOp, ArrayGetOp,
+                       // Struct operations
+                       StructCreateOp, StructExtractOp, StructInjectOp>(
             [&](auto expr) -> ResultType {
               return thisCast->visitComb(expr, args...);
             })
@@ -113,6 +115,9 @@ public:
   HANDLE(ConcatOp, Unhandled);
   HANDLE(ExtractOp, Unhandled);
   HANDLE(MuxOp, Unhandled);
+  HANDLE(StructCreateOp, Unhandled);
+  HANDLE(StructExtractOp, Unhandled);
+  HANDLE(StructInjectOp, Unhandled);
   HANDLE(BitcastOp, Unary);
   HANDLE(ArraySliceOp, Unhandled);
   HANDLE(ArrayGetOp, Unhandled);

--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -49,6 +49,12 @@ def WireOp : SVOp<"wire", [DeclareOpInterfaceMethods<OpAsmOpInterface>]> {
 
   let assemblyFormat = "custom<ImplicitSSAName>(attr-dict) `:` type($result)";
   let hasCanonicalizer = true;
+
+  let extraClassDeclaration = [{
+    Type getElementType() {
+      return result().getType().cast<InOutType>().getElementType();
+    }
+  }];
 }
 
 def RegOp : SVOp<"reg", [DeclareOpInterfaceMethods<OpAsmOpInterface>]> {
@@ -65,6 +71,12 @@ def RegOp : SVOp<"reg", [DeclareOpInterfaceMethods<OpAsmOpInterface>]> {
   // We handle the name in a custom way, so we use a customer parser/printer.
   let assemblyFormat = "custom<ImplicitSSAName>(attr-dict) `:` type($result)";
   let hasCanonicalizer = true;
+
+  let extraClassDeclaration = [{
+    Type getElementType() {
+      return result().getType().cast<InOutType>().getElementType();
+    }
+  }];
 }
 
 def ReadInOutOp

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -168,6 +168,9 @@ static bool isZeroBitType(Type type) {
   return false;
 }
 
+/// Given a set of known nested types (those supported by this pass), strip off
+/// leading unpacked types.  This strips off portions of the type that are
+/// printed to the right of the name in verilog.
 static Type stripUnpackedTypes(Type type) {
   return TypeSwitch<Type, Type>(type)
       .Case<InOutType>([](InOutType inoutType) {
@@ -180,7 +183,11 @@ static Type stripUnpackedTypes(Type type) {
 }
 
 /// Output the basic type that consists of packed and primitive types.  This is
-/// those to the left of the name in verilog.
+/// those to the left of the name in verilog. implicitIntType controls whether
+/// to print a base type for (logic) for inteters or whether the caller will
+/// have handled this (with logic, wire, reg, etc).  structFieldSep is a
+/// character to be printed between struct fields.  Pretty printed structs will
+/// likely use newline, while inline structs will use spaces
 static void printPackedTypeImpl(Type type, raw_ostream &os, Location loc,
                                 SmallVectorImpl<size_t> &dims,
                                 bool implicitIntType, char structFieldSep) {
@@ -208,7 +215,8 @@ static void printPackedTypeImpl(Type type, raw_ostream &os, Location loc,
         for (auto &element : structType.getElements()) {
           SmallVector<size_t, 8> structDims;
           printPackedTypeImpl(stripUnpackedTypes(element.type), os, loc,
-                              structDims, false, structFieldSep);
+                              structDims, /*implicitIntType=*/false,
+                              structFieldSep);
           os << ' ' << element.name << ';' << structFieldSep;
         }
         os << '}';

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -208,7 +208,7 @@ static bool printPackedTypeImpl(Type type, raw_ostream &os, Location loc,
       })
       .Case<InOutType>([&](InOutType inoutType) {
         return printPackedTypeImpl(inoutType.getElementType(), os, loc, dims,
-                            implicitIntType);
+                                   implicitIntType);
       })
       .Case<StructType>([&](StructType structType) {
         os << "struct packed {";
@@ -224,11 +224,9 @@ static bool printPackedTypeImpl(Type type, raw_ostream &os, Location loc,
       .Case<ArrayType>([&](ArrayType arrayType) {
         dims.push_back(arrayType.getSize());
         return printPackedTypeImpl(arrayType.getElementType(), os, loc, dims,
-                            implicitIntType);
+                                   implicitIntType);
       })
-      .Case<InterfaceType>([](InterfaceType ifaceType) {
-        return false;
-      })
+      .Case<InterfaceType>([](InterfaceType ifaceType) { return false; })
       .Case<UnpackedArrayType>([&](UnpackedArrayType arrayType) {
         os << "<<unexpected unpacked array>>";
         emitError(loc, "Unexpected unpacked array in packed type ")
@@ -1288,7 +1286,8 @@ void ModuleEmitter::emitStatementExpression(Operation *op) {
     indent() << "// Zero width: ";
   } else if (emitInlineLogicDecls && !outOfLineExpresssionDecls.count(op)) {
     indent() << getVerilogDeclWord(op) << " ";
-    if (printPackedType(stripUnpackedTypes(op->getResult(0).getType()), os, op->getLoc()))
+    if (printPackedType(stripUnpackedTypes(op->getResult(0).getType()), os,
+                        op->getLoc()))
       os << ' ';
     os << getName(op->getResult(0)) << " = ";
   } else {
@@ -1926,9 +1925,9 @@ static bool isExpressionUnableToInline(Operation *op) {
                           op->getLoc()))
       // Bitcasts rely on the type being assigned to, so we cannot inline.
       return true;
-  
+
   // StructCreateOp needs to be assigning to a named temporary so that types
-  // are inferred properly by verilog 
+  // are inferred properly by verilog
   if (isa<StructCreateOp>(op))
     return true;
 

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -785,6 +785,9 @@ private:
   SubExprInfo visitTypeOp(ArrayGetOp op);
   SubExprInfo visitTypeOp(ArrayCreateOp op);
   SubExprInfo visitTypeOp(ArrayConcatOp op);
+  SubExprInfo visitTypeOp(StructCreateOp op);
+  SubExprInfo visitTypeOp(StructExtractOp op);
+  SubExprInfo visitTypeOp(StructInjectOp op);
 
   // Comb Dialect Operations
   using CombinationalVisitor::visitComb;
@@ -839,10 +842,6 @@ private:
   SubExprInfo visitComb(ICmpOp op);
 
   SubExprInfo visitComb(BitcastOp op);
-
-  SubExprInfo visitComb(StructCreateOp op);
-  SubExprInfo visitComb(StructExtractOp op);
-  SubExprInfo visitComb(StructInjectOp op);
 
 private:
   /// This is set (before a visit method is called) if emitSubExpr would
@@ -1199,7 +1198,7 @@ SubExprInfo ExprEmitter::visitComb(MuxOp op) {
   return {Conditional, signedness};
 }
 
-SubExprInfo ExprEmitter::visitComb(StructCreateOp op) {
+SubExprInfo ExprEmitter::visitTypeOp(StructCreateOp op) {
   StructType stype = op.getType().cast<StructType>();
   os << "'{";
   size_t i = 0;
@@ -1212,13 +1211,13 @@ SubExprInfo ExprEmitter::visitComb(StructCreateOp op) {
   return {Unary, IsUnsigned};
 }
 
-SubExprInfo ExprEmitter::visitComb(StructExtractOp op) {
+SubExprInfo ExprEmitter::visitTypeOp(StructExtractOp op) {
   emitSubExpr(op.input(), Selection);
   os << '.' << op.field();
   return {Selection, IsUnsigned};
 }
 
-SubExprInfo ExprEmitter::visitComb(StructInjectOp op) {
+SubExprInfo ExprEmitter::visitTypeOp(StructInjectOp op) {
   StructType stype = op.getType().cast<StructType>();
   os << "'{";
   llvm::interleaveComma(stype.getElements(), os,

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -83,6 +83,8 @@ static void getTypeDims(SmallVectorImpl<int64_t> &dims, Type type,
     return getTypeDims(dims, uarray.getElementType(), loc);
   if (type.isa<InterfaceType>())
     return;
+  if (type.isa<StructType>())
+    return;
 
   int width;
   if (auto arrayType = type.dyn_cast<rtl::ArrayType>()) {
@@ -161,6 +163,84 @@ static bool isZeroBitType(Type type) {
 
   // We have an open type system, so assume it is ok.
   return false;
+}
+
+static Type stripUnpackedTypes(Type type) {
+  return TypeSwitch<Type, Type>(type)
+  .Case<InOutType>([](InOutType inoutType) { 
+    return stripUnpackedTypes(inoutType.getElementType());
+  })
+.Case<UnpackedArrayType>([](UnpackedArrayType arrayType) {
+  return stripUnpackedTypes(arrayType.getElementType());
+})
+.Default([](Type type){
+  return type;
+});
+}
+
+/// Output the basic type that consists of packed and primitive types.  This is those to the left of the name in verilog.
+static void printPackedTypeImpl(Type type, raw_ostream& os, Location loc, 
+SmallVectorImpl<size_t>& dims, bool implicitIntType, char structFieldSep) {
+  return TypeSwitch<Type, void>(type)
+      .Case<IntegerType>([&](IntegerType integerType) {
+        if (!implicitIntType)
+          os << "logic";
+        if (integerType.getWidth() != 1)
+          dims.push_back(integerType.getWidth());
+        if (!dims.empty() && !implicitIntType)
+          os << ' ';
+
+        for (auto dim : dims)
+          if (dim)
+            os << '[' << (dim - 1) << ":0]";
+          else
+            os << "/*Zero Width*/";
+          
+    })
+      .Case<InOutType>([&](InOutType inoutType) {
+        printPackedTypeImpl(inoutType.getElementType(), os, loc, dims, implicitIntType, structFieldSep);
+      })
+      .Case<StructType>([&](StructType structType) {
+        os << "struct packed {";
+        for (auto& element : structType.getElements()) {
+          SmallVector<size_t, 8> structDims;
+          printPackedTypeImpl(stripUnpackedTypes(element.type), os, loc, structDims, false, structFieldSep);
+          os << ' ' << element.name << ';' << structFieldSep;
+        }
+        os << '}';
+      })
+      .Case<ArrayType>([&](ArrayType arrayType) {
+        dims.push_back(arrayType.getSize());
+        printPackedTypeImpl(arrayType.getElementType(), os, loc, dims, implicitIntType, structFieldSep);
+      })
+      .Case<InterfaceType>([](InterfaceType ifaceType) {
+        //Noop
+      })
+      .Case<UnpackedArrayType>([&](UnpackedArrayType arrayType) {
+        os << "<<unexpected unpacked array>>";
+        emitError(loc, "Unexpected unpacked array in packed type ") << arrayType;
+      })
+      .Default([&](Type type) {
+        os << "<<invalid type>>";
+        emitError(loc, "value has an unsupported verilog type ") << type;
+      });
+}
+
+static void printPackedType(Type type, raw_ostream& os, Location loc, bool implicitIntType = true, char structFieldSep = ' ') {
+  SmallVector<size_t, 8> packedDimensions;
+  printPackedTypeImpl(type, os, loc, packedDimensions, implicitIntType, structFieldSep);
+}
+
+/// Output the unpacked array dimensions.  This is the part of the type that is to the right of the name.
+static void unpackedTypePrefixToString(Type type, raw_ostream& os, Location loc) {
+  TypeSwitch<Type, void>(type)
+      .Case<InOutType>([&](InOutType inoutType) {
+        unpackedTypePrefixToString(inoutType.getElementType(), os, loc);
+      })
+      .Case<UnpackedArrayType>([&](UnpackedArrayType arrayType) {
+        unpackedTypePrefixToString(arrayType.getElementType(), os, loc);
+        os << '[' << (arrayType.getSize() - 1) << ":0]";
+      });
 }
 
 /// Return true if this is a noop cast that will emit with no syntax.
@@ -718,6 +798,10 @@ private:
 
   SubExprInfo visitComb(BitcastOp op);
 
+  SubExprInfo visitComb(StructCreateOp op);
+  SubExprInfo visitComb(StructExtractOp op);
+  SubExprInfo visitComb(StructInjectOp op);
+
 private:
   /// This is set (before a visit method is called) if emitSubExpr would
   /// prefer to get an output of a specific sign.  This is a hint to cause the
@@ -1071,6 +1155,42 @@ SubExprInfo ExprEmitter::visitComb(MuxOp op) {
     signedness = IsSigned;
 
   return {Conditional, signedness};
+}
+
+SubExprInfo ExprEmitter::visitComb(StructCreateOp op) {
+  StructType stype = op.getType().cast<StructType>();
+  os << "'{";
+  size_t i = 0;
+  llvm::interleaveComma(stype.getElements(), os,
+                        [&](const StructType::FieldInfo &field) {
+                          os << field.name << ": ";
+                          emitSubExpr(op.getOperand(i++), Selection);
+                        });
+  os << '}';
+  return {Unary, IsUnsigned};
+}
+
+SubExprInfo ExprEmitter::visitComb(StructExtractOp op) {
+  emitSubExpr(op.input(), Selection);
+  os << '.' << op.field();
+  return {Selection, IsUnsigned};
+}
+
+SubExprInfo ExprEmitter::visitComb(StructInjectOp op) {
+  StructType stype = op.getType().cast<StructType>();
+  os << "'{";
+  llvm::interleaveComma(stype.getElements(), os,
+                        [&](const StructType::FieldInfo &field) {
+                          os << field.name << ": ";
+                          if (field.name == op.field()) {
+                            emitSubExpr(op.newValue(), Selection);
+                          } else {
+                            emitSubExpr(op.input(), Selection);
+                            os << '.' << field.name;
+                          }
+                        });
+  os << '}';
+  return {Selection, IsUnsigned};
 }
 
 SubExprInfo ExprEmitter::visitUnhandledExpr(Operation *op) {
@@ -1905,12 +2025,14 @@ void ModuleEmitter::collectNamesEmitDecls(Block &block) {
       // Convert the port's type to a string and measure it.
       {
         llvm::raw_svector_ostream stringStream(typeString);
-        emitTypeDimWithSpaceIfNeeded(result.getType(), op.getLoc(),
-                                     stringStream);
+        printPackedType(stripUnpackedTypes(result.getType()), stringStream, op.getLoc());
       }
       maxTypeWidth = std::max(typeString.size(), maxTypeWidth);
     }
   }
+
+  if (maxTypeWidth > 0) // add a space if any type exists
+    maxTypeWidth += 1;
 
   SmallPtrSet<Operation *, 8> ops;
 
@@ -2018,11 +2140,14 @@ void ModuleEmitter::emitRTLModule(RTLModuleOp module) {
     portTypeStrings.push_back({});
     {
       llvm::raw_svector_ostream stringStream(portTypeStrings.back());
-      emitTypeDimWithSpaceIfNeeded(port.type, module.getLoc(), stringStream);
+      printPackedType(stripUnpackedTypes(port.type), stringStream, module.getLoc());
     }
 
     maxTypeWidth = std::max(portTypeStrings.back().size(), maxTypeWidth);
   }
+
+  if (maxTypeWidth > 0) // add a space if any type exists
+    maxTypeWidth += 1;
 
   addIndent();
 
@@ -2071,7 +2196,7 @@ void ModuleEmitter::emitRTLModule(RTLModuleOp module) {
     // If we have any more ports with the same types and the same direction,
     // emit them in a list on the same line.
     while (portIdx != e && portInfo[portIdx].direction == thisPortDirection &&
-           portType == portInfo[portIdx].type) {
+           stripUnpackedTypes(portType) == stripUnpackedTypes(portInfo[portIdx].type)) {
       // Don't exceed our preferred line length.
       StringRef name = getPortName(portIdx);
       if (os.tell() + 2 + name.size() - startOfLinePos >
@@ -2082,7 +2207,7 @@ void ModuleEmitter::emitRTLModule(RTLModuleOp module) {
 
       // Append this to the running port decl.
       os << ", " << name;
-      printArraySubscripts(portType, os);
+      printArraySubscripts(portInfo[portIdx].type, os);
       ++portIdx;
     }
 

--- a/test/ExportVerilog/rtl-dialect.mlir
+++ b/test/ExportVerilog/rtl-dialect.mlir
@@ -20,7 +20,7 @@ rtl.module @TESTSIMPLE(%a: i4, %b: i4, %cond: i1,
   %r25: i1, %r26: i1, %r27: i1, %r28: i1,
   %r29: i12, %r30: i2, %r31: i9, %r33: i4, %r34: i4,
   %r35: !rtl.array<3xi4>, %r36: i12, %r37: i4,
-  %r38: !rtl.array<6xi4>, %r39: i4, %r40: !rtl.struct<foo: i2, bar:i4>
+  %r38: !rtl.array<6xi4>, %r40: !rtl.struct<foo: i2, bar:i4>
   ) {
   
   %0 = comb.add %a, %b : i4
@@ -91,14 +91,14 @@ rtl.module @TESTSIMPLE(%a: i4, %b: i4, %cond: i1,
 // CHECK-NEXT:   output [3:0]                                              r0, r2, r4, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15
 // CHECK-NEXT:   output                                                    r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27,
 // CHECK-NEXT:   output                                                    r28,
-// CHECK-NEXT:   output [11:0]           r29,
-// CHECK-NEXT:   output [1:0]            r30,
-// CHECK-NEXT:   output [8:0]            r31,
-// CHECK-NEXT:   output [3:0]            r33, r34,
-// CHECK-NEXT:   output [2:0][3:0]       r35,
-// CHECK-NEXT:   output [11:0]           r36,
-// CHECK-NEXT:   output [3:0]            r37,
-// CHECK-NEXT:   output [5:0][3:0]       r38);
+// CHECK-NEXT:   output [11:0]                                             r29,
+// CHECK-NEXT:   output [1:0]                                              r30,
+// CHECK-NEXT:   output [8:0]                                              r31,
+// CHECK-NEXT:   output [3:0]                                              r33, r34,
+// CHECK-NEXT:   output [2:0][3:0]                                         r35,
+// CHECK-NEXT:   output [11:0]                                             r36,
+// CHECK-NEXT:   output [3:0]                                              r37,
+// CHECK-NEXT:   output [5:0][3:0]                                         r38,
 // CHECK-NEXT:   output struct packed {logic [1:0] foo; logic [3:0] bar; } r40);
 // CHECK-EMPTY:
 // CHECK-NEXT:   wire [8:0][3:0] [[WIRE0:.+]] = {{[{}][{}]}}4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}};
@@ -138,7 +138,6 @@ rtl.module @TESTSIMPLE(%a: i4, %b: i4, %cond: i1,
 // CHECK-NEXT:   assign r36 = {3{a}};
 // CHECK-NEXT:   assign r37 = array2d[a][b];
 // CHECK-NEXT:   assign r38 = {[[WIRE1]], [[WIRE1]]};
-// CHECK-NEXT:   assign r39 = structA.bar;
 // CHECK-NEXT:   assign r40 = '{foo: structA.foo, bar: a};
 // CHECK-NEXT: endmodule
 

--- a/test/ExportVerilog/rtl-dialect.mlir
+++ b/test/ExportVerilog/rtl-dialect.mlir
@@ -9,7 +9,9 @@ module {
 
   rtl.module @TESTSIMPLE(%a: i4, %b: i4, %cond: i1,
                          %array2d: !rtl.array<12 x array<10xi4>>,
-                         %uarray: !rtl.uarray<16xi8>) -> (
+                         %uarray: !rtl.uarray<16xi8>,
+                         %postUArray: i8,
+                         %structA: !rtl.struct<foo: i2, bar:i4>) -> (
     %r0: i4, %r2: i4, %r4: i4, %r6: i4,
     %r7: i4, %r8: i4, %r9: i4, %r10: i4,
     %r11: i4, %r12: i4, %r13: i4, %r14: i4,
@@ -18,8 +20,7 @@ module {
     %r21: i1, %r22: i1, %r23: i1, %r24: i1,
     %r25: i1, %r26: i1, %r27: i1, %r28: i1,
     %r29: i12, %r30: i2, %r31: i9, %r33: i4, %r34: i4,
-    %r35: !rtl.array<3xi4>, %r36: i12, %r37: i4,
-    %r38: !rtl.array<6xi4>
+    %r38: !rtl.array<6xi4>, %r39: i4, %r40: !rtl.struct<foo: i2, bar:i4>
     ) {
     
     %0 = rtl.add %a, %b : i4
@@ -69,29 +70,45 @@ module {
     %37 = rtl.array_get %elem2d[%b] : !rtl.array<10xi4>
 
     %36 = rtl.concat %a, %a, %a : (i4, i4, i4) -> i12
+    %39 = rtl.struct_extract %structA["bar"] : !rtl.struct<foo: i2, bar: i4>
+    %40 = rtl.struct_inject %structA["bar"], %a : !rtl.struct<foo: i2, bar: i4>
 
-    rtl.output %0, %2, %4, %6, %7, %8, %9, %10, %11, %12, %13, %14,
-               %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27,
-               %28, %29, %30, %31, %33, %34, %35, %36, %37, %38 :
-     i4,i4, i4,i4,i4,i4,i4, i4,i4,i4,i4,i4,
-     i4,i1,i1,i1,i1, i1,i1,i1,i1,i1, i1,i1,i1,i1,
-     i12, i2,i9,i4, i4, !rtl.array<3xi4>, i12, i4, !rtl.array<6xi4>
+
+    rtl.output %0, %2, %4, %6, 
+               %7, %8, %9, %10,
+               %11, %12, %13, %14, 
+               %15, %16, 
+               %17, %18, %19, %20, 
+               %21, %22, %23, %24, 
+               %25, %26, %27, %28, 
+               %29, %30, %31, %33, %34, 
+               %38, %39, %40 :
+     i4, i4, i4, i4,
+     i4, i4, i4, i4,
+     i4, i4, i4, i4,
+     i4, i1,
+     i1, i1, i1, i1,
+     i1, i1, i1, i1, 
+     i1, i1, i1, i1,
+     i12, i2, i9, i4, i4, 
+     !rtl.array<6xi4>, i4, !rtl.struct<foo: i2, bar: i4>
   }
   // CHECK-LABEL: module TESTSIMPLE(
-  // CHECK-NEXT:   input  [3:0]            a, b
-  // CHECK-NEXT:   input                   cond,
-  // CHECK-NEXT:   input  [11:0][9:0][3:0] array2d,
-  // CHECK-NEXT:   input  [7:0]            uarray[15:0],
-  // CHECK-NEXT:   output [3:0]            r0, r2, r4, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15
-  // CHECK-NEXT:   output                  r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27, r28
-  // CHECK-NEXT:   output [11:0]           r29,
-  // CHECK-NEXT:   output [1:0]            r30,
-  // CHECK-NEXT:   output [8:0]            r31,
-  // CHECK-NEXT:   output [3:0]            r33, r34,
-  // CHECK-NEXT:   output [2:0][3:0]       r35,
-  // CHECK-NEXT:   output [11:0]           r36,
-  // CHECK-NEXT:   output [3:0]            r37,
-  // CHECK-NEXT:   output [5:0][3:0]       r38);
+  // CHECK-NEXT:   input  [3:0]                                              a, b
+  // CHECK-NEXT:   input                                                     cond,
+  // CHECK-NEXT:   input  [11:0][9:0][3:0]                                   array2d,
+  // CHECK-NEXT:   input  [7:0]                                              uarray[15:0], postUArray,
+  // CHECK-NEXT:   input  struct packed {logic [1:0] foo; logic [3:0] bar; } structA,
+  // CHECK-NEXT:   output [3:0]                                              r0, r2, r4, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15
+  // CHECK-NEXT:   output                                                    r16, r17, r18, r19, r20, r21, r22, r23, r24, r25, r26, r27,
+  // CHECK-NEXT:   output                                                    r28,
+  // CHECK-NEXT:   output [11:0]                                             r29,
+  // CHECK-NEXT:   output [1:0]                                              r30,
+  // CHECK-NEXT:   output [8:0]                                              r31,
+  // CHECK-NEXT:   output [3:0]                                              r33, r34,
+  // CHECK-NEXT:   output [5:0][3:0]                                         r38,
+  // CHECK-NEXT:   output [3:0]                                              r39,
+  // CHECK-NEXT:   output struct packed {logic [1:0] foo; logic [3:0] bar; } r40);
   // CHECK-EMPTY:
   // CHECK-NEXT:   wire [8:0][3:0] [[WIRE0:.+]] = {{[{}][{}]}}4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}};
   // CHECK-NEXT:   wire [2:0][3:0] [[WIRE1:.+]] = {{[{}][{}]}}4'hF}, {a + b}, {4'hF}};
@@ -126,10 +143,9 @@ module {
   // CHECK-NEXT:   assign r31 = {{[{}][{}]}}5{a[3]}}, a};
   // CHECK-NEXT:   assign r33 = cond ? a : b;
   // CHECK-NEXT:   assign r34 = ~a;
-  // CHECK-NEXT:   assign r35 = cond ? [[WIRE0]][a+:3] : [[WIRE0]][b+:3];
-  // CHECK-NEXT:   assign r36 = {3{a}};
-  // CHECK-NEXT:   assign r37 = array2d[a][b];
   // CHECK-NEXT:   assign r38 = {[[WIRE1]], [[WIRE1]]};
+  // CHECK-NEXT:   assign r39 = structA.bar;
+  // CHECK-NEXT:   assign r40 = '{foo: structA.foo, bar: a};
   // CHECK-NEXT: endmodule
 
   rtl.module @B(%a: i1) -> (%b: i1, %c: i1) {

--- a/test/ExportVerilog/rtl-dialect.mlir
+++ b/test/ExportVerilog/rtl-dialect.mlir
@@ -6,7 +6,7 @@ rtl.module.extern @E(%a: i1 {rtl.direction = "in"},
 
 // CHECK-LABEL: // external module E
 
-rtl.module @TESTSIMPLE(%a: i4, %b: i4, %cond: i1,
+rtl.module @TESTSIMPLE(%a: i4, %b: i4, %c: i2, %cond: i1,
                         %array2d: !rtl.array<12 x array<10xi4>>,
                         %uarray: !rtl.uarray<16xi8>,
                         %postUArray: i8,
@@ -20,7 +20,8 @@ rtl.module @TESTSIMPLE(%a: i4, %b: i4, %cond: i1,
   %r25: i1, %r26: i1, %r27: i1, %r28: i1,
   %r29: i12, %r30: i2, %r31: i9, %r33: i4, %r34: i4,
   %r35: !rtl.array<3xi4>, %r36: i12, %r37: i4,
-  %r38: !rtl.array<6xi4>, %r40: !rtl.struct<foo: i2, bar:i4>
+  %r38: !rtl.array<6xi4>, 
+  %r40: !rtl.struct<foo: i2, bar:i4>, %r41: !rtl.struct<foo: i2, bar: i4>
   ) {
   
   %0 = comb.add %a, %b : i4
@@ -73,17 +74,20 @@ rtl.module @TESTSIMPLE(%a: i4, %b: i4, %cond: i1,
 
   %39 = rtl.struct_extract %structA["bar"] : !rtl.struct<foo: i2, bar: i4>
   %40 = rtl.struct_inject %structA["bar"], %a : !rtl.struct<foo: i2, bar: i4>
-
+  %41 = rtl.struct_create (%c, %a) : !rtl.struct<foo: i2, bar: i4>
+  %42 = rtl.struct_inject %41["bar"], %b : !rtl.struct<foo: i2, bar: i4>
 
   rtl.output %0, %2, %4, %6, %7, %8, %9, %10, %11, %12, %13, %14,
               %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27,
-              %28, %29, %30, %31, %33, %34, %35, %36, %37, %38, %40 :
+              %28, %29, %30, %31, %33, %34, %35, %36, %37, %38, %40, %42 :
     i4,i4, i4,i4,i4,i4,i4, i4,i4,i4,i4,i4,
     i4,i1,i1,i1,i1, i1,i1,i1,i1,i1, i1,i1,i1,i1,
-   i12, i2, i9, i4, i4, !rtl.array<3xi4>, i12, i4, !rtl.array<6xi4>, !rtl.struct<foo: i2, bar: i4>
+   i12, i2, i9, i4, i4, !rtl.array<3xi4>, i12, i4, !rtl.array<6xi4>, 
+   !rtl.struct<foo: i2, bar: i4>, !rtl.struct<foo: i2, bar: i4>
 }
 // CHECK-LABEL: module TESTSIMPLE(
-// CHECK-NEXT:   input  [3:0]                                              a, b
+// CHECK-NEXT:   input  [3:0]                                              a, b,
+// CHECK-NEXT:   input  [1:0]                                              c,
 // CHECK-NEXT:   input                                                     cond,
 // CHECK-NEXT:   input  [11:0][9:0][3:0]                                   array2d,
 // CHECK-NEXT:   input  [7:0]                                              uarray[15:0], postUArray,
@@ -99,10 +103,11 @@ rtl.module @TESTSIMPLE(%a: i4, %b: i4, %cond: i1,
 // CHECK-NEXT:   output [11:0]                                             r36,
 // CHECK-NEXT:   output [3:0]                                              r37,
 // CHECK-NEXT:   output [5:0][3:0]                                         r38,
-// CHECK-NEXT:   output struct packed {logic [1:0] foo; logic [3:0] bar; } r40);
+// CHECK-NEXT:   output struct packed {logic [1:0] foo; logic [3:0] bar; } r40, r41);
 // CHECK-EMPTY:
 // CHECK-NEXT:   wire [8:0][3:0] [[WIRE0:.+]] = {{[{}][{}]}}4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}};
 // CHECK-NEXT:   wire [2:0][3:0] [[WIRE1:.+]] = {{[{}][{}]}}4'hF}, {a + b}, {4'hF}};
+// CHECK-NEXT:   wire struct packed {logic [1:0] foo; logic [3:0] bar; } [[WIRE2:.+]] = '{foo: c, bar: a};
 // CHECK-NEXT:   assign r0 = a + b;
 // CHECK-NEXT:   assign r2 = a - b;
 // CHECK-NEXT:   assign r4 = a * b;
@@ -139,6 +144,7 @@ rtl.module @TESTSIMPLE(%a: i4, %b: i4, %cond: i1,
 // CHECK-NEXT:   assign r37 = array2d[a][b];
 // CHECK-NEXT:   assign r38 = {[[WIRE1]], [[WIRE1]]};
 // CHECK-NEXT:   assign r40 = '{foo: structA.foo, bar: a};
+// CHECK-NEXT:   assign r41 = '{foo: _T_1.foo, bar: b};
 // CHECK-NEXT: endmodule
 
 


### PR DESCRIPTION
Output verilog for structures.
Also support merging declarations with common packed portion but different unpacked version.  eg:
```
input  [7:0]                                              uarray[15:0], postUArray,
```
