### PR TITLE
[Comb][RTL] Add rtl.instance inlining support

### DIFF
--- a/include/circt/Dialect/RTL/RTL.td
+++ b/include/circt/Dialect/RTL/RTL.td
@@ -13,12 +13,13 @@
 #ifndef RTL_TD
 #define RTL_TD
 
-include "mlir/IR/OpBase.td"
-include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/Interfaces/CallInterfaces.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpAsmInterface.td"
-include "mlir/IR/SymbolInterfaces.td"
+include "mlir/IR/OpBase.td"
 include "mlir/IR/RegionKindInterface.td"
+include "mlir/IR/SymbolInterfaces.td"
 
 def RTLDialect : Dialect {
   let name = "rtl";

--- a/include/circt/Dialect/RTL/RTLStructure.td
+++ b/include/circt/Dialect/RTL/RTLStructure.td
@@ -12,7 +12,8 @@
 
 def RTLModuleOp : RTLOp<"module",
       [IsolatedFromAbove, FunctionLike, Symbol, RegionKindInterface,
-       SingleBlockImplicitTerminator<"OutputOp">, HasParent<"mlir::ModuleOp">]>{
+       SingleBlockImplicitTerminator<"OutputOp">, HasParent<"mlir::ModuleOp">,
+       CallableOpInterface]>{
   let summary = "RTL Module";
   let description = [{
     The "rtl.module" operation represents a Verilog module, including a given
@@ -48,6 +49,17 @@ def RTLModuleOp : RTLOp<"module",
     StringRef getName() {
       return (*this)->getAttrOfType<StringAttr>(
         ::mlir::SymbolTable::getSymbolAttrName()).getValue();
+    }
+
+    // Returns the callable region of the operation, which is just the module
+    // body.
+    Region *getCallableRegion() {
+      return &getBody();
+    }
+
+    // Returns the result types that the callable region produces when executes.
+    ArrayRef<Type> getCallableResults() {
+      return getType().getResults();
     }
 
   private:
@@ -139,7 +151,7 @@ def RTLModuleExternOp : RTLOp<"module.extern",
 }
 
 def InstanceOp : RTLOp<"instance",
-                       [DeclareOpInterfaceMethods<OpAsmOpInterface>]> {
+      [CallOpInterface, DeclareOpInterfaceMethods<OpAsmOpInterface>]> {
   let summary = "Create an instance of a module";
   let description = [{
     This represents an instance of a module. The inputs and results are 
@@ -154,15 +166,28 @@ def InstanceOp : RTLOp<"instance",
   let results = (outs Variadic<AnyType>);
 
   let extraClassDeclaration = [{
-    // Return the name of the specified result or empty string if it cannot be
-    // determined.
+    /// Return the name of the specified result or empty string if it cannot be
+    /// determined.
     StringAttr getResultName(size_t i);
 
     /// Lookup the module or extmodule for the symbol.  This returns null on
     /// invalid IR.
     Operation *getReferencedModule();
+
+    /// Get the argument operands to the called function.
+    operand_range getArgOperands() {
+      return {arg_operand_begin(), arg_operand_end()};
+    }
+
+    operand_iterator arg_operand_begin() { return operand_begin(); }
+    operand_iterator arg_operand_end() { return operand_end(); }
+
+    /// Return the callee of this operation.
+    CallInterfaceCallable getCallableForCallee() {
+      return (*this)->getAttrOfType<SymbolRefAttr>("moduleName");
+    }
   }];
-  
+
   let assemblyFormat = [{
     $instanceName $moduleName `(` $inputs `)` attr-dict
       `:` functional-type($inputs, results)

--- a/lib/Dialect/Comb/CombDialect.cpp
+++ b/lib/Dialect/Comb/CombDialect.cpp
@@ -16,9 +16,37 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/DialectImplementation.h"
+#include "mlir/Transforms/InliningUtils.h"
 
 using namespace circt;
 using namespace comb;
+
+//===----------------------------------------------------------------------===//
+// Inliner Dialect Interface
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct CombInlinerInterface : public mlir::DialectInlinerInterface {
+  using mlir::DialectInlinerInterface::DialectInlinerInterface;
+
+  /// Returns true if the operation from RTL `op` can be inlined in to the
+  /// destination region `dest`.
+  bool
+  isLegalToInline(Operation *op, Region *dest, bool,
+                  BlockAndValueMapping &valueMapping) const override final {
+    // No operations in Comb prevent inlining.
+    return true;
+  }
+
+  /// Returns true if the given region `src` can be inlined into the region
+  /// `dest`.
+  bool isLegalToInline(Region *dest, Region *src, bool,
+                       BlockAndValueMapping &) const override final {
+    // No operations in Comb prevent inlining.
+    return true;
+  }
+};
+} // end anonymous namespace
 
 //===----------------------------------------------------------------------===//
 // Dialect specification.
@@ -33,6 +61,9 @@ CombDialect::CombDialect(MLIRContext *context)
 #define GET_OP_LIST
 #include "circt/Dialect/Comb/Comb.cpp.inc"
       >();
+
+  // Register interface implementations.
+  addInterfaces<CombInlinerInterface>();
 }
 
 CombDialect::~CombDialect() {}

--- a/test/Dialect/RTL/inlining.mlir
+++ b/test/Dialect/RTL/inlining.mlir
@@ -1,0 +1,31 @@
+// RUN: circt-opt %s -inline | FileCheck %s
+
+rtl.module @empty() -> () {
+  rtl.output
+}
+
+rtl.module @test0() -> () {
+  rtl.instance "inline-me" @empty() {inline} : () -> ()
+  rtl.output
+}
+
+// CHECK-LABEL: rtl.module @test0() {
+// CHECK-NEXT:     rtl.output
+// CHECK-NEXT: }
+
+rtl.module @simple(%a: i2, %b : i2) -> (i2, i2) {
+  %0 = comb.or %a, %b : i2
+  %1 = comb.and %a, %b : i2
+  rtl.output %0, %1: i2, i2
+}
+
+rtl.module @test1(%a: i2, %b : i2) -> (i2, i2) {
+  %0, %1 = rtl.instance "inline-me" @simple(%a, %b) {inline} : (i2, i2) -> (i2, i2)
+  rtl.output %0, %1: i2, i2
+}
+
+// CHECK-LABEL: rtl.module @test1(%a: i2, %b: i2) -> (i2, i2) {
+// CHECK-NEXT:   %0 = comb.or %a, %b : i2
+// CHECK-NEXT:   %1 = comb.and %a, %b : i2
+// CHECK-NEXT:   rtl.output %0, %1 : i2, i2
+// CHECK-NEXT: }


### PR DESCRIPTION
This adds the DialectInlinerInterface to both the Comb and RTL dialects.

In Comb, this interface is used to specify that all Comb operations are
legal to inline. This means that a Comb operation appearing in the body
of a module will not prevent inlining of the module. For the RTL
dialect, all operations are similarly considered safe to inline.  The SV
dialect has not been considered yet, and all operations are by default
not safe to inline.

The Module and Instance operations in the RTL dialect were marked as
Callee-like and Caller-like using operation interfaces.  All InstanceOps
which have the non-dialect singleton attribute `inline` are considered
safe to inline by the inliner.  This use of this attribute in this way
is a quick hack, and in the future we probably want to use something
more robust.