### PR TITLE
[Handshake] Add NoSideEffect to SinkOp to participate in CSE.

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -437,8 +437,9 @@ def ConditionalBranchOp : Handshake_Op<"conditional_branch", [
   }];
 }
 
-def SinkOp
-    : Handshake_Op<"sink", [DeclareOpInterfaceMethods<ExecutableOpInterface>]> {
+def SinkOp : Handshake_Op<"sink", [
+  NoSideEffect, DeclareOpInterfaceMethods<ExecutableOpInterface>
+]> {
   let summary = "sink operation";
   let description = [{
     The "handshake.sink" operation discards any data that arrives at its

--- a/test/Conversion/StandardToHandshake/test_canonicalize.mlir
+++ b/test/Conversion/StandardToHandshake/test_canonicalize.mlir
@@ -6,7 +6,7 @@ module {
   // CHECK-SAME:                         %[[VAL_0:.*]]: none, ...) -> none {
   handshake.func @simple(%arg0: none, ...) -> none {
 
-    // CHECK: %[[VAL_1:.*]] = "handshake.constant"(%[[VAL_0:.*]]) {value = 1 : index} : (none) -> index
+    // CHECK-NOT: "handshake.constant"(%arg0)
     %0 = "handshake.constant"(%arg0) {value = 1 : index} : (none) -> index
     
     // CHECK-NOT: %[[TMP_0:.*]] = "handshake.branch"(%[[VAL_0:.*]]) {control = true} : (none) -> none


### PR DESCRIPTION
This allows unused constants and anything else that ends up in a
SinkOp to be removed by CSE and canonicalization.