### PR TITLE
[RTL] Add result type verification of instance op

### DIFF
--- a/lib/Dialect/RTL/RTLOps.cpp
+++ b/lib/Dialect/RTL/RTLOps.cpp
@@ -459,32 +459,63 @@ static LogicalResult verifyInstanceOp(InstanceOp op) {
       return failure();
   }
 
-  // Check that result types are consistent with the referenced module.
-  auto expectedTypes = getModuleType(referencedModule).getResults();
-  auto numResults = op->getNumResults();
+  // If the referenced moudle is internal, check that input and result types are
+  // consistent with the referenced module.
+  if (isa<RTLModuleOp>(referencedModule)) {
+    // Check operand types first.
+    auto numOperands = op->getNumOperands();
+    auto expectedOperandTypes = getModuleType(referencedModule).getInputs();
 
-  if (expectedTypes.size() != numResults) {
-    auto diag = op.emitOpError()
-                << "has a wrong number of results; expected "
-                << expectedTypes.size() << " but got " << numResults;
-    diag.attachNote(referencedModule->getLoc())
-        << "original module declared here";
-
-    return failure();
-  }
-
-  for (size_t i = 0; i != numResults; i++) {
-    auto expectedType = expectedTypes[i];
-    auto resultType = op.getResultTypes()[i];
-    if (resultType != expectedType && !resultType.isa<NoneType>() &&
-        !expectedType.isa<NoneType>()) {
+    if (expectedOperandTypes.size() != numOperands) {
       auto diag = op.emitOpError()
-                  << "#" << i << " result type must be " << expectedType
-                  << ", but got " << resultType;
-
+                  << "has a wrong number of operands; expected "
+                  << expectedOperandTypes.size() << " but got " << numOperands;
       diag.attachNote(referencedModule->getLoc())
           << "original module declared here";
+
       return failure();
+    }
+
+    for (size_t i = 0; i != numOperands; ++i) {
+      auto expectedType = expectedOperandTypes[i];
+      auto operandType = op.getOperand(i).getType();
+      if (operandType != expectedType) {
+        auto diag = op.emitOpError()
+                    << "#" << i << " operand type must be " << expectedType
+                    << ", but got " << operandType;
+
+        diag.attachNote(referencedModule->getLoc())
+            << "original module declared here";
+        return failure();
+      }
+    }
+
+    // Checke result types.
+    auto numResults = op->getNumResults();
+    auto expectedResultTypes = getModuleType(referencedModule).getResults();
+
+    if (expectedResultTypes.size() != numResults) {
+      auto diag = op.emitOpError()
+                  << "has a wrong number of results; expected "
+                  << expectedResultTypes.size() << " but got " << numResults;
+      diag.attachNote(referencedModule->getLoc())
+          << "original module declared here";
+
+      return failure();
+    }
+
+    for (size_t i = 0; i != numResults; ++i) {
+      auto expectedType = expectedResultTypes[i];
+      auto resultType = op.getResult(i).getType();
+      if (resultType != expectedType) {
+        auto diag = op.emitOpError()
+                    << "#" << i << " result type must be " << expectedType
+                    << ", but got " << resultType;
+
+        diag.attachNote(referencedModule->getLoc())
+            << "original module declared here";
+        return failure();
+      }
     }
   }
 

--- a/lib/Dialect/RTL/RTLOps.cpp
+++ b/lib/Dialect/RTL/RTLOps.cpp
@@ -424,6 +424,70 @@ Operation *InstanceOp::getReferencedModule() {
   return topLevelModuleOp.lookupSymbol(moduleName());
 }
 
+// Helper function to verify instance op types
+static LogicalResult verifyInstanceOpTypes(InstanceOp op) {
+  auto referencedModule = op.getReferencedModule();
+  assert(referencedModule && "referenced module must not be null");
+
+  // Check operand types first.
+  auto numOperands = op->getNumOperands();
+  auto expectedOperandTypes = getModuleType(referencedModule).getInputs();
+
+  if (expectedOperandTypes.size() != numOperands) {
+    auto diag = op.emitOpError()
+                << "has a wrong number of operands; expected "
+                << expectedOperandTypes.size() << " but got " << numOperands;
+    diag.attachNote(referencedModule->getLoc())
+        << "original module declared here";
+
+    return failure();
+  }
+
+  for (size_t i = 0; i != numOperands; ++i) {
+    auto expectedType = expectedOperandTypes[i];
+    auto operandType = op.getOperand(i).getType();
+    if (operandType != expectedType) {
+      auto diag = op.emitOpError()
+                  << "#" << i << " operand type must be " << expectedType
+                  << ", but got " << operandType;
+
+      diag.attachNote(referencedModule->getLoc())
+          << "original module declared here";
+      return failure();
+    }
+  }
+
+  // Checke result types.
+  auto numResults = op->getNumResults();
+  auto expectedResultTypes = getModuleType(referencedModule).getResults();
+
+  if (expectedResultTypes.size() != numResults) {
+    auto diag = op.emitOpError()
+                << "has a wrong number of results; expected "
+                << expectedResultTypes.size() << " but got " << numResults;
+    diag.attachNote(referencedModule->getLoc())
+        << "original module declared here";
+
+    return failure();
+  }
+
+  for (size_t i = 0; i != numResults; ++i) {
+    auto expectedType = expectedResultTypes[i];
+    auto resultType = op.getResult(i).getType();
+    if (resultType != expectedType) {
+      auto diag = op.emitOpError()
+                  << "#" << i << " result type must be " << expectedType
+                  << ", but got " << resultType;
+
+      diag.attachNote(referencedModule->getLoc())
+          << "original module declared here";
+      return failure();
+    }
+  }
+
+  return success();
+}
+
 static LogicalResult verifyInstanceOp(InstanceOp op) {
   // Check that this instance is inside a module.
   auto module = dyn_cast<RTLModuleOp>(op->getParentOp());
@@ -461,65 +525,10 @@ static LogicalResult verifyInstanceOp(InstanceOp op) {
 
   // If the referenced moudle is internal, check that input and result types are
   // consistent with the referenced module.
-  if (isa<RTLModuleOp>(referencedModule)) {
-    // Check operand types first.
-    auto numOperands = op->getNumOperands();
-    auto expectedOperandTypes = getModuleType(referencedModule).getInputs();
+  if (!isa<RTLModuleOp>(referencedModule))
+    return success();
 
-    if (expectedOperandTypes.size() != numOperands) {
-      auto diag = op.emitOpError()
-                  << "has a wrong number of operands; expected "
-                  << expectedOperandTypes.size() << " but got " << numOperands;
-      diag.attachNote(referencedModule->getLoc())
-          << "original module declared here";
-
-      return failure();
-    }
-
-    for (size_t i = 0; i != numOperands; ++i) {
-      auto expectedType = expectedOperandTypes[i];
-      auto operandType = op.getOperand(i).getType();
-      if (operandType != expectedType) {
-        auto diag = op.emitOpError()
-                    << "#" << i << " operand type must be " << expectedType
-                    << ", but got " << operandType;
-
-        diag.attachNote(referencedModule->getLoc())
-            << "original module declared here";
-        return failure();
-      }
-    }
-
-    // Checke result types.
-    auto numResults = op->getNumResults();
-    auto expectedResultTypes = getModuleType(referencedModule).getResults();
-
-    if (expectedResultTypes.size() != numResults) {
-      auto diag = op.emitOpError()
-                  << "has a wrong number of results; expected "
-                  << expectedResultTypes.size() << " but got " << numResults;
-      diag.attachNote(referencedModule->getLoc())
-          << "original module declared here";
-
-      return failure();
-    }
-
-    for (size_t i = 0; i != numResults; ++i) {
-      auto expectedType = expectedResultTypes[i];
-      auto resultType = op.getResult(i).getType();
-      if (resultType != expectedType) {
-        auto diag = op.emitOpError()
-                    << "#" << i << " result type must be " << expectedType
-                    << ", but got " << resultType;
-
-        diag.attachNote(referencedModule->getLoc())
-            << "original module declared here";
-        return failure();
-      }
-    }
-  }
-
-  return success();
+  return verifyInstanceOpTypes(op);
 }
 
 StringAttr InstanceOp::getResultName(size_t idx) {

--- a/test/Dialect/RTL/errors.mlir
+++ b/test/Dialect/RTL/errors.mlir
@@ -166,3 +166,29 @@ rtl.module @test() -> () {
   %0 = rtl.instance "test" @f() : () -> (i1)
   rtl.output
 }
+
+// -----
+
+// expected-note @+1 {{original module declared here}}
+rtl.module @empty() -> () {
+  rtl.output
+}
+
+rtl.module @test(%a: i1) -> () {
+  // expected-error @+1 {{'rtl.instance' op has a wrong number of operands; expected 0 but got 1}}
+  rtl.instance "test" @empty(%a) : (i1) -> ()
+  rtl.output
+}
+
+// -----
+
+// expected-note @+1 {{original module declared here}}
+rtl.module @f(%a: i1) -> () {
+  rtl.output
+}
+
+rtl.module @test(%a: i2) -> () {
+  // expected-error @+1 {{'rtl.instance' op #0 operand type must be 'i1', but got 'i2'}}
+  rtl.instance "test" @f(%a) : (i2) -> ()
+  rtl.output
+}

--- a/test/Dialect/RTL/errors.mlir
+++ b/test/Dialect/RTL/errors.mlir
@@ -139,3 +139,30 @@ rtl.module @invalid_add(%a: i0) {  // i0 ports are ok.
   // expected-error @+1 {{'comb.add' op operand #0 must be an integer bitvector of one or more bits, but got 'i0'}}
   %b = comb.add %a, %a: i0
 }
+
+// -----
+
+// expected-note @+1 {{original module declared here}}
+rtl.module @empty() -> () {
+  rtl.output
+}
+
+rtl.module @test() -> () {
+  // expected-error @+1 {{'rtl.instance' op has a wrong number of results; expected 0 but got 3}}
+  %0, %1, %3 = rtl.instance "test" @empty() : () -> (i2, i2, i2)
+  rtl.output
+}
+
+// -----
+
+// expected-note @+1 {{original module declared here}}
+rtl.module @f() -> (i2) {
+  %a = comb.constant(1 : i2) : i2
+  rtl.output %a : i2
+}
+
+rtl.module @test() -> () {
+  // expected-error @+1 {{'rtl.instance' op #0 result type must be 'i2', but got 'i1'}}
+  %0 = rtl.instance "test" @f() : () -> (i1)
+  rtl.output
+}


### PR DESCRIPTION
This PR adds the following verification for instance op result types. 

* The numbers of results are the same
* Result types are the same (except for none type)

Will close #617 