### PR TITLE
[ExportVerilog] `logic` inside of procedural regions must be 'automatic'

### DIFF
--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -193,7 +193,9 @@ static StringRef getVerilogDeclWord(Operation *op) {
     parent = parent->getParentOp();
     if (isa<RTLModuleOp>(parent))
       return "wire";
-  } while (parent != nullptr && !parent->hasTrait<ProceduralRegion>());
+    if (parent->hasTrait<ProceduralRegion>())
+      return "automatic logic";
+  } while (parent != nullptr);
 
   return "logic";
 };

--- a/test/ExportVerilog/sv-dialect.mlir
+++ b/test/ExportVerilog/sv-dialect.mlir
@@ -215,7 +215,7 @@ rtl.module @exprInlineTestIssue439(%clk: i1) {
 
   // CHECK: always @(posedge clk) begin
   sv.always posedge %clk {
-    // CHECK: logic [15:0] _T_0 = _T[15:0];
+    // CHECK: automatic logic [15:0] _T_0 = _T[15:0];
     %e = comb.extract %c from 0 : (i32) -> i16
     %f = comb.add %e, %e : i16
     sv.fwrite "%d"(%f) : i16


### PR DESCRIPTION
Verilator accepts raw `logic` and does the correct thing, but questa complains and requires it be explicitly marked as 'static' or 'automatic'. My understanding is that automatic is what we want, but someone more knowledgeable about SystemVerilog than I should weight in.

Quartus accepts 'automatic logic'.

This PR adds the "automatic" to `_T_0`s declaration.
```
module exprInlineTestIssue439(
  input clk);

  wire [31:0] _T = 32'h0;	// /home/jodemme/circt/integration_test/EmitVerilog/lint.mlir:96:8
  always @(posedge clk) begin	// /home/jodemme/circt/integration_test/EmitVerilog/lint.mlir:98:3
    automatic logic [15:0] _T_0 = _T[15:0];	// /home/jodemme/circt/integration_test/EmitVerilog/lint.mlir:99:10
    $fwrite(32'h80000002, "%d", _T_0 + _T_0);	// /home/jodemme/circt/integration_test/EmitVerilog/lint.mlir:100:10, :101:5
  end // always @(posedge)
endmodule
```