### PR TITLE
[FIRRTL] Fix unnecessarily repeated calls to setType in LowerTypes.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -88,7 +88,7 @@ def FModuleOp : FIRRTLOp<"module",
     friend class OpTrait::FunctionLike<FModuleOp>;
 
     /// Returns the number of arguments, implementing OpTrait::FunctionLike.
-    unsigned getNumFuncArguments() { return getType().getInputs().size(); }
+    unsigned getNumFuncArguments() { return getBodyBlock()->getNumArguments(); }
     /// Returns the number of results, implementing OpTrait::FunctionLike.
     unsigned getNumFuncResults() { return getType().getResults().size(); }
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -156,6 +156,9 @@ void FIRRTLTypesLowering::runOnOperation() {
   getOperation().eraseArguments(argsToRemove);
   argsToRemove.clear();
 
+  // Keep the module's type up-to-date.
+  module.setType(builder->getFunctionType(body->getArgumentTypes(), {}));
+
   // Reset lowered state.
   loweredBundleValues.clear();
 }
@@ -467,9 +470,6 @@ Value FIRRTLTypesLowering::addArg(Type type, unsigned oldArgNumber,
 
   // Append the new argument.
   auto newValue = body->addArgument(type);
-
-  // Keep the module's type up-to-date.
-  module.setType(builder->getFunctionType(body->getArgumentTypes(), {}));
 
   // Copy over the name attribute for the new argument.
   StringAttr nameAttr = getFIRRTLNameAttr(module.getArgAttrs(oldArgNumber));


### PR DESCRIPTION
The previous implementation would call setType to update the module's
type attribute after each new argument was added. This constant
updating of the attribute was needed because getNumFuncArguments used
the attribute, and getNumFuncArguments was called by core MLIR logic
throughout this pass.

By updating getNumFuncArguments to just return the current number of
entry block arguments, we are able to update the type attribute once
at the end of the pass.

This is part of https://github.com/llvm/circt/issues/615.