### PR TITLE
[Comb] Add mux canonicalization

### DIFF
--- a/include/circt/Dialect/Comb/Combinational.td
+++ b/include/circt/Dialect/Comb/Combinational.td
@@ -273,6 +273,7 @@ def MuxOp : CombOp<"mux",
     "$cond `,` $trueValue `,` $falseValue attr-dict `:` type($result)";
   
   let hasFolder = true;
+  let hasCanonicalizer = true;
 
   let builders = [
     OpBuilderDAG<(ins "Value":$cond, "Value":$trueValue, "Value":$falseValue),

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -134,6 +134,7 @@ def RegOp : FIRRTLOp<"reg", [/*MemAlloc*/]> {
   let arguments = (ins ClockType:$clockVal, OptionalAttr<StrAttr>:$name);
   let results = (outs PassiveType:$result);
 
+  let hasCanonicalizer = 1;
   let assemblyFormat =
     "operands attr-dict `:` functional-type(operands, $result)";
 }

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -134,7 +134,6 @@ def RegOp : FIRRTLOp<"reg", [/*MemAlloc*/]> {
   let arguments = (ins ClockType:$clockVal, OptionalAttr<StrAttr>:$name);
   let results = (outs PassiveType:$result);
 
-  let hasCanonicalizer = 1;
   let assemblyFormat =
     "operands attr-dict `:` functional-type(operands, $result)";
 }

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -756,9 +756,10 @@ void MuxOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
       // mux(a, 11...1, b) -> or(a, b)
       if (matchPattern(op.trueValue(), m_RConstant(value))) {
         if (value.isAllOnesValue()) {
-          auto cond = width == 1 ? op.cond()
-                                 : rewriter.createOrFold<SExtOp>(
-                                       op.getLoc(), op.getType(), op.cond());
+          auto cond = op.cond();
+          if (width > 1)
+            cond = rewriter.createOrFold<SExtOp>(op.getLoc(), op.getType(),
+                                                 op.cond());
           Value newOperands[] = {cond, op.falseValue()};
           rewriter.replaceOpWithNewOp<OrOp>(op, op.getType(), newOperands);
           return success();
@@ -768,9 +769,10 @@ void MuxOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
       // mux(a, b, 0) -> and(a, b)
       if (matchPattern(op.falseValue(), m_RConstant(value))) {
         if (value.isNullValue()) {
-          auto cond = width == 1 ? op.cond()
-                                 : rewriter.createOrFold<SExtOp>(
-                                       op.getLoc(), op.getType(), op.cond());
+          auto cond = op.cond();
+          if (width > 1)
+            cond = rewriter.createOrFold<SExtOp>(op.getLoc(), op.getType(),
+                                                 op.cond());
           Value newOperands[] = {cond, op.trueValue()};
           rewriter.replaceOpWithNewOp<AndOp>(op, op.getType(), newOperands);
           return success();

--- a/test/Dialect/RTL/canonicalization.mlir
+++ b/test/Dialect/RTL/canonicalization.mlir
@@ -803,3 +803,23 @@ rtl.module @mux_canonicalize1(%a: i1, %b: i1) -> (i1) {
   %0 = comb.mux %a, %b, %false : i1
   rtl.output %0 : i1
 }
+
+// CHECK-LABEL: rtl.module @mux_canonicalize2(%a: i1, %b: i4) -> (i4) {
+// CHECK-NEXT:   %0 = comb.sext %a : (i1) -> i4
+// CHECK-NEXT:   %1 = comb.or %0, %b : i4
+// CHECK-NEXT: rtl.output %1 : i4
+rtl.module @mux_canonicalize2(%a: i1, %b: i4) -> (i4) {
+  %c-1_i4 = comb.constant -1 : i4
+  %0 = comb.mux %a, %c-1_i4, %b : i4
+  rtl.output %0 : i4
+}
+
+// CHECK-LABEL: rtl.module @mux_canonicalize3(%a: i1, %b: i4) -> (i4) {
+// CHECK-NEXT:   %0 = comb.sext %a : (i1) -> i4
+// CHECK-NEXT:   %1 = comb.and %0, %b : i4
+// CHECK-NEXT: rtl.output %1 : i4
+rtl.module @mux_canonicalize3(%a: i1, %b: i4) -> (i4) {
+  %c0_i4 = comb.constant 0 : i4
+  %0 = comb.mux %a, %b, %c0_i4 : i4
+  rtl.output %0 : i4
+}

--- a/test/Dialect/RTL/canonicalization.mlir
+++ b/test/Dialect/RTL/canonicalization.mlir
@@ -785,3 +785,21 @@ rtl.module @shrs_fold2() -> (i12) {
   %0 = comb.shrs %c-5_i12, %c10_i12 : i12
   rtl.output %0 : i12
 }
+
+// CHECK-LABEL: rtl.module @mux_canonicalize0(%a: i1, %b: i1) -> (i1) {
+// CHECK-NEXT:   %0 = comb.or %a, %b : i1
+// CHECK-NEXT: rtl.output %0 : i1
+rtl.module @mux_canonicalize0(%a: i1, %b: i1) -> (i1) {
+  %true = comb.constant true
+  %0 = comb.mux %a, %true, %b : i1
+  rtl.output %0 : i1
+}
+
+// CHECK-LABEL: rtl.module @mux_canonicalize1(%a: i1, %b: i1) -> (i1) {
+// CHECK-NEXT:   %0 = comb.and %a, %b : i1
+// CHECK-NEXT: rtl.output %0 : i1
+rtl.module @mux_canonicalize1(%a: i1, %b: i1) -> (i1) {
+  %false = comb.constant false
+  %0 = comb.mux %a, %b, %false : i1
+  rtl.output %0 : i1
+}


### PR DESCRIPTION
This PR adds the following mux canonicalization
```
mux(a, true, b) -> or(a, b)
mux(a, b, false) -> and(a, b)
```
Part of #635
 