### PR TITLE
[Comb] Rename XorROp to ParityOp

### DIFF
--- a/include/circt/Dialect/Comb/CombVisitors.h
+++ b/include/circt/Dialect/Comb/CombVisitors.h
@@ -36,7 +36,7 @@ public:
                        // Comparison operations
                        ICmpOp,
                        // Reduction Operators
-                       XorROp,
+                       ParityOp,
                        // Other operations.
                        SExtOp, ConcatOp, ExtractOp, MuxOp,
                        // Cast operation
@@ -99,7 +99,7 @@ public:
   HANDLE(OrOp, Variadic);
   HANDLE(XorOp, Variadic);
 
-  HANDLE(XorROp, Unary);
+  HANDLE(ParityOp, Unary);
 
   HANDLE(ICmpOp, Binary);
 

--- a/include/circt/Dialect/Comb/CombVisitors.h
+++ b/include/circt/Dialect/Comb/CombVisitors.h
@@ -36,7 +36,7 @@ public:
                        // Comparison operations
                        ICmpOp,
                        // Reduction Operators
-                       AndROp, XorROp,
+                       XorROp,
                        // Other operations.
                        SExtOp, ConcatOp, ExtractOp, MuxOp,
                        // Cast operation
@@ -99,7 +99,6 @@ public:
   HANDLE(OrOp, Variadic);
   HANDLE(XorOp, Variadic);
 
-  HANDLE(AndROp, Unary);
   HANDLE(XorROp, Unary);
 
   HANDLE(ICmpOp, Binary);

--- a/include/circt/Dialect/Comb/Combinational.td
+++ b/include/circt/Dialect/Comb/Combinational.td
@@ -199,7 +199,6 @@ class UnaryI1ReductionOp<string mnemonic, list<OpTrait> traits = []> :
   let assemblyFormat = "$input attr-dict `:` type($input)";
 }
 
-def AndROp : UnaryI1ReductionOp<"andr">;
 def XorROp : UnaryI1ReductionOp<"xorr">;
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/Comb/Combinational.td
+++ b/include/circt/Dialect/Comb/Combinational.td
@@ -199,7 +199,7 @@ class UnaryI1ReductionOp<string mnemonic, list<OpTrait> traits = []> :
   let assemblyFormat = "$input attr-dict `:` type($input)";
 }
 
-def XorROp : UnaryI1ReductionOp<"xorr">;
+def ParityOp : UnaryI1ReductionOp<"parity">;
 
 //===----------------------------------------------------------------------===//
 // Integer width modifying operations.

--- a/integration_test/EmitVerilog/lint.mlir
+++ b/integration_test/EmitVerilog/lint.mlir
@@ -70,7 +70,7 @@ rtl.module @TESTSIMPLE(%a: i4, %b: i4, %cond: i1, %array: !rtl.array<10xi4>,
   %20 = comb.icmp ule %a, %b : i4
   %21 = comb.icmp ugt %a, %b : i4
   %22 = comb.icmp uge %a, %b : i4
-  %23 = comb.xorr %a : i4
+  %23 = comb.parity %a : i4
   %24 = comb.concat %a, %a, %b : (i4, i4, i4) -> i12
   %25 = comb.extract %a from 1 : (i4) -> i2
   %26 = comb.sext %a : (i4) -> i9

--- a/integration_test/EmitVerilog/lint.mlir
+++ b/integration_test/EmitVerilog/lint.mlir
@@ -42,9 +42,9 @@ rtl.module @TESTSIMPLE(%a: i4, %b: i4, %cond: i1, %array: !rtl.array<10xi4>,
   %r12: i4, %r13: i1,
   %r14: i1, %r15: i1, %r16: i1, %r17: i1,
   %r18: i1, %r19: i1, %r20: i1, %r21: i1,
-  %r22: i1, %r23: i1, %r24: i1, 
-  %r25: i12, %r26: i2, %r27: i9, %r28: i4, %r29: i4,
-  %r30: !rtl.array<3xi4>
+  %r22: i1, %r23: i1, 
+  %r24: i12, %r25: i2, %r26: i9, %r27: i4, %r28: i4,
+  %r29: !rtl.array<3xi4>
   ) {
 
   %0 = comb.add %a, %b : i4
@@ -70,24 +70,23 @@ rtl.module @TESTSIMPLE(%a: i4, %b: i4, %cond: i1, %array: !rtl.array<10xi4>,
   %20 = comb.icmp ule %a, %b : i4
   %21 = comb.icmp ugt %a, %b : i4
   %22 = comb.icmp uge %a, %b : i4
-  %23 = comb.andr %a : i4
-  %24 = comb.xorr %a : i4
-  %25 = comb.concat %a, %a, %b : (i4, i4, i4) -> i12
-  %26 = comb.extract %a from 1 : (i4) -> i2
-  %27 = comb.sext %a : (i4) -> i9
-  %28 = comb.mux %cond, %a, %b : i4
+  %23 = comb.xorr %a : i4
+  %24 = comb.concat %a, %a, %b : (i4, i4, i4) -> i12
+  %25 = comb.extract %a from 1 : (i4) -> i2
+  %26 = comb.sext %a : (i4) -> i9
+  %27 = comb.mux %cond, %a, %b : i4
 
   %allone = comb.constant 15 : i4
-  %29 = comb.xor %a, %allone : i4
+  %28 = comb.xor %a, %allone : i4
 
   %one = comb.constant 1 : i4
   %aPlusOne = comb.add %a, %one : i4
-  %30 = rtl.array_slice %array at %aPlusOne: (!rtl.array<10xi4>) -> !rtl.array<3xi4>
+  %29 = rtl.array_slice %array at %aPlusOne: (!rtl.array<10xi4>) -> !rtl.array<3xi4>
 
 
-  rtl.output %0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30:
+  rtl.output %0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29:
     i4,i4, i4,i4,i4,i4,i4, i4,i4,i4,i4,i4,
-    i4,i1,i1,i1,i1, i1,i1,i1,i1,i1, i1,i1,i1,
+    i4,i1,i1,i1,i1, i1,i1,i1,i1,i1, i1,i1,
     i12, i2,i9,i4, i4, !rtl.array<3xi4>
 }
 

--- a/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
+++ b/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
@@ -1770,7 +1770,7 @@ LogicalResult FIRRTLLowering::visitExpr(XorRPrimOp op) {
     return failure();
   }
 
-  return setLoweringTo<comb::XorROp>(op, builder->getIntegerType(1), operand);
+  return setLoweringTo<comb::ParityOp>(op, builder->getIntegerType(1), operand);
 }
 
 LogicalResult FIRRTLLowering::visitExpr(AndRPrimOp op) {

--- a/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
+++ b/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
@@ -1781,7 +1781,13 @@ LogicalResult FIRRTLLowering::visitExpr(AndRPrimOp op) {
     });
   }
 
-  return setLoweringTo<comb::AndROp>(op, builder->getIntegerType(1), operand);
+  // Lower AndR to == -1
+  return setLoweringTo<comb::ICmpOp>(
+      op, ICmpPredicate::eq, operand,
+      builder->create<comb::ConstantOp>(
+          APInt(operand.getType().getIntOrFloatBitWidth(), -1)));
+  // return setLoweringTo<comb::AndROp>(op, builder->getIntegerType(1),
+  // operand);
 }
 
 LogicalResult FIRRTLLowering::visitExpr(OrRPrimOp op) {

--- a/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
+++ b/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
@@ -1786,8 +1786,6 @@ LogicalResult FIRRTLLowering::visitExpr(AndRPrimOp op) {
       op, ICmpPredicate::eq, operand,
       builder->create<comb::ConstantOp>(
           APInt(operand.getType().getIntOrFloatBitWidth(), -1)));
-  // return setLoweringTo<comb::AndROp>(op, builder->getIntegerType(1),
-  // operand);
 }
 
 LogicalResult FIRRTLLowering::visitExpr(OrRPrimOp op) {

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -99,15 +99,6 @@ OpFoldResult SExtOp::fold(ArrayRef<Attribute> constants) {
   return {};
 }
 
-OpFoldResult AndROp::fold(ArrayRef<Attribute> constants) {
-  // Constant fold.
-  if (auto input = constants[0].dyn_cast_or_null<IntegerAttr>())
-    return getIntAttr(APInt(1, input.getValue().isAllOnesValue()),
-                      getContext());
-
-  return {};
-}
-
 OpFoldResult XorROp::fold(ArrayRef<Attribute> constants) {
   // Constant fold.
   if (auto input = constants[0].dyn_cast_or_null<IntegerAttr>())

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -99,7 +99,7 @@ OpFoldResult SExtOp::fold(ArrayRef<Attribute> constants) {
   return {};
 }
 
-OpFoldResult XorROp::fold(ArrayRef<Attribute> constants) {
+OpFoldResult ParityOp::fold(ArrayRef<Attribute> constants) {
   // Constant fold.
   if (auto input = constants[0].dyn_cast_or_null<IntegerAttr>())
     return getIntAttr(APInt(1, input.getValue().countPopulation() & 1),

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -851,7 +851,7 @@ private:
 
   // SystemVerilog spec 11.8.1: "Reduction operator results are unsigned,
   // regardless of the operands."
-  SubExprInfo visitComb(XorROp op) { return emitUnary(op, "^", true); }
+  SubExprInfo visitComb(ParityOp op) { return emitUnary(op, "^", true); }
 
   SubExprInfo visitComb(SExtOp op);
   SubExprInfo visitComb(ConcatOp op);

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -851,7 +851,6 @@ private:
 
   // SystemVerilog spec 11.8.1: "Reduction operator results are unsigned,
   // regardless of the operands."
-  SubExprInfo visitComb(AndROp op) { return emitUnary(op, "&", true); }
   SubExprInfo visitComb(XorROp op) { return emitUnary(op, "^", true); }
 
   SubExprInfo visitComb(SExtOp op);
@@ -1080,7 +1079,14 @@ SubExprInfo ExprEmitter::visitComb(ICmpOp op) {
 
   auto pred = static_cast<uint64_t>(op.predicate());
   assert(pred < sizeof(symop) / sizeof(symop[0]));
-  if (pred == 1) {
+  if (pred == 0) {
+    // Lower "== -1" to Reduction And
+    if (auto op1 =
+            dyn_cast_or_null<ConstantOp>(op.getOperand(1).getDefiningOp())) {
+      if (op1.getValue().isAllOnesValue())
+        return emitUnary(op, "&", true);
+    }
+  } else if (pred == 1) {
     // Lower "!= 0" to Reduction Or
     if (auto op1 =
             dyn_cast_or_null<ConstantOp>(op.getOperand(1).getDefiningOp())) {

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -1079,14 +1079,14 @@ SubExprInfo ExprEmitter::visitComb(ICmpOp op) {
 
   auto pred = static_cast<uint64_t>(op.predicate());
   assert(pred < sizeof(symop) / sizeof(symop[0]));
-  if (pred == 0) {
+  if (op.predicate() == ICmpPredicate::eq) {
     // Lower "== -1" to Reduction And
     if (auto op1 =
             dyn_cast_or_null<ConstantOp>(op.getOperand(1).getDefiningOp())) {
       if (op1.getValue().isAllOnesValue())
         return emitUnary(op, "&", true);
     }
-  } else if (pred == 1) {
+  } else if (op.predicate() == ICmpPredicate::ne) {
     // Lower "!= 0" to Reduction Or
     if (auto op1 =
             dyn_cast_or_null<ConstantOp>(op.getOperand(1).getDefiningOp())) {

--- a/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
+++ b/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
@@ -103,7 +103,7 @@ module attributes {firrtl.mainModule = "Simple"} {
     // CHECK-NEXT: = comb.concat [[CONCAT1]], [[ZERO]] : (i8, i3) -> i11
     %14 = firrtl.shl %6, 3 : (!firrtl.uint<8>) -> !firrtl.uint<11>
 
-    // CHECK-NEXT: = comb.xorr [[CONCAT1]] : i8
+    // CHECK-NEXT: = comb.parity [[CONCAT1]] : i8
     %15 = firrtl.xorr %6 : (!firrtl.uint<8>) -> !firrtl.uint<1>
 
     // CHECK-NEXT: = comb.constant -1 : i8

--- a/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
+++ b/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
@@ -106,7 +106,8 @@ module attributes {firrtl.mainModule = "Simple"} {
     // CHECK-NEXT: = comb.xorr [[CONCAT1]] : i8
     %15 = firrtl.xorr %6 : (!firrtl.uint<8>) -> !firrtl.uint<1>
 
-    // CHECK-NEXT: = comb.andr [[CONCAT1]] : i8
+    // CHECK-NEXT: = comb.constant -1 : i8
+    // CHECK-NEXT: = comb.icmp eq  {{.*}}, {{.*}} : i8
     %16 = firrtl.andr %6 : (!firrtl.uint<8>) -> !firrtl.uint<1>
 
     // CHECK-NEXT: = comb.constant
@@ -166,7 +167,8 @@ module attributes {firrtl.mainModule = "Simple"} {
 
     // Noop
     %27 = firrtl.validif %12, %18 : (!firrtl.uint<1>, !firrtl.uint<14>) -> !firrtl.uint<14>
-    // CHECK-NEXT: comb.andr
+    // CHECK-NEXT: = comb.constant -1 : i14
+    // CHECK-NEXT: = comb.icmp eq  {{.*}}, {{.*}} : i14
     %28 = firrtl.andr %27 : (!firrtl.uint<14>) -> !firrtl.uint<1>
 
     // CHECK-NEXT: %c0_i11 = comb.constant 0 : i11

--- a/test/Dialect/RTL/basic.mlir
+++ b/test/Dialect/RTL/basic.mlir
@@ -15,9 +15,7 @@ rtl.module @test1(%arg0: i3, %arg1: i1, %arg2: !rtl.array<1000xi8>) -> (i50) {
   // CHECK-NEXT:    [[RES4:%[0-9]+]] = comb.concat %c42_i12 : (i12) -> i12
   %conc1 = comb.concat %a : (i12) -> i12
 
-  // CHECK-NEXT:    [[RES5:%[0-9]+]] = comb.andr [[RES4]] : i12
   // CHECK-NEXT:    [[RES7:%[0-9]+]] = comb.xorr [[RES4]] : i12
-  %andr1 = comb.andr %conc1 : i12
   %xorr1 = comb.xorr %conc1 : i12
 
   // CHECK-NEXT:    [[RES8:%[0-9]+]] = comb.concat [[RES4]], [[RES0]], [[RES1]], [[RES2]], [[RES2]] : (i12, i12, i12, i7, i7) -> i50

--- a/test/Dialect/RTL/basic.mlir
+++ b/test/Dialect/RTL/basic.mlir
@@ -15,8 +15,8 @@ rtl.module @test1(%arg0: i3, %arg1: i1, %arg2: !rtl.array<1000xi8>) -> (i50) {
   // CHECK-NEXT:    [[RES4:%[0-9]+]] = comb.concat %c42_i12 : (i12) -> i12
   %conc1 = comb.concat %a : (i12) -> i12
 
-  // CHECK-NEXT:    [[RES7:%[0-9]+]] = comb.xorr [[RES4]] : i12
-  %xorr1 = comb.xorr %conc1 : i12
+  // CHECK-NEXT:    [[RES7:%[0-9]+]] = comb.parity [[RES4]] : i12
+  %parity1 = comb.parity %conc1 : i12
 
   // CHECK-NEXT:    [[RES8:%[0-9]+]] = comb.concat [[RES4]], [[RES0]], [[RES1]], [[RES2]], [[RES2]] : (i12, i12, i12, i7, i7) -> i50
   %result = comb.concat %conc1, %b, %c, %d, %d : (i12, i12, i12, i7, i7) -> i50

--- a/test/Dialect/RTL/canonicalization.mlir
+++ b/test/Dialect/RTL/canonicalization.mlir
@@ -462,22 +462,22 @@ rtl.module @sext_constant_folding() -> (i5) {
   rtl.output %0 : i5
 }
 
-// CHECK-LABEL: rtl.module @xorr_constant_folding1() -> (i1) {
+// CHECK-LABEL: rtl.module @parity_constant_folding1() -> (i1) {
 // CHECK-NEXT:  %true = comb.constant true
 // CHECK-NEXT:  rtl.output %true : i1
 
-rtl.module @xorr_constant_folding1() -> (i1) {
+rtl.module @parity_constant_folding1() -> (i1) {
   %c4_i4 = comb.constant 4 : i4
-  %0 = comb.xorr %c4_i4 : i4
+  %0 = comb.parity %c4_i4 : i4
   rtl.output %0 : i1
 }
 
-// CHECK-LABEL: rtl.module @xorr_constant_folding2() -> (i1) {
+// CHECK-LABEL: rtl.module @parity_constant_folding2() -> (i1) {
 // CHECK-NEXT:  %false = comb.constant false
 // CHECK-NEXT:  rtl.output %false : i1
-rtl.module @xorr_constant_folding2() -> (i1) {
+rtl.module @parity_constant_folding2() -> (i1) {
   %c15_i4 = comb.constant 15 : i4
-  %0 = comb.xorr %c15_i4 : i4
+  %0 = comb.parity %c15_i4 : i4
   rtl.output %0 : i1
 }
 

--- a/test/Dialect/RTL/canonicalization.mlir
+++ b/test/Dialect/RTL/canonicalization.mlir
@@ -462,26 +462,6 @@ rtl.module @sext_constant_folding() -> (i5) {
   rtl.output %0 : i5
 }
 
-// CHECK-LABEL: rtl.module @andr_constant_folding1() -> (i1) {
-// CHECK-NEXT:  %false = comb.constant false
-// CHECK-NEXT:  rtl.output %false : i1
-
-rtl.module @andr_constant_folding1() -> (i1) {
-  %c8_i4 = comb.constant 8 : i4
-  %0 = comb.andr %c8_i4 : i4
-  rtl.output %0 : i1
-}
-
-// CHECK-LABEL: rtl.module @andr_constant_folding2() -> (i1) {
-// CHECK-NEXT:  %true = comb.constant true
-// CHECK-NEXT:  rtl.output %true : i1
-
-rtl.module @andr_constant_folding2() -> (i1) {
-  %c15_i4 = comb.constant 15 : i4
-  %0 = comb.andr %c15_i4 : i4
-  rtl.output %0 : i1
-}
-
 // CHECK-LABEL: rtl.module @xorr_constant_folding1() -> (i1) {
 // CHECK-NEXT:  %true = comb.constant true
 // CHECK-NEXT:  rtl.output %true : i1

--- a/test/ExportVerilog/rtl-dialect.mlir
+++ b/test/ExportVerilog/rtl-dialect.mlir
@@ -47,7 +47,8 @@ rtl.module @TESTSIMPLE(%a: i4, %b: i4, %c: i2, %cond: i1,
   %23 = comb.icmp ule %a, %b : i4
   %24 = comb.icmp ugt %a, %b : i4
   %25 = comb.icmp uge %a, %b : i4
-  %26 = comb.andr %a : i4
+  %one4 = comb.constant -1 : i4
+  %26 = comb.icmp eq %a, %one4 : i4
   %zero4 = comb.constant 0 : i4
   %27 = comb.icmp ne %a, %zero4 : i4
   %28 = comb.xorr %a : i4

--- a/test/ExportVerilog/rtl-dialect.mlir
+++ b/test/ExportVerilog/rtl-dialect.mlir
@@ -51,7 +51,7 @@ rtl.module @TESTSIMPLE(%a: i4, %b: i4, %c: i2, %cond: i1,
   %26 = comb.icmp eq %a, %one4 : i4
   %zero4 = comb.constant 0 : i4
   %27 = comb.icmp ne %a, %zero4 : i4
-  %28 = comb.xorr %a : i4
+  %28 = comb.parity %a : i4
   %29 = comb.concat %a, %a, %b : (i4, i4, i4) -> i12
   %30 = comb.extract %a from 1 : (i4) -> i2
   %31 = comb.sext %a : (i4) -> i9

--- a/test/ExportVerilog/sv-dialect.mlir
+++ b/test/ExportVerilog/sv-dialect.mlir
@@ -276,3 +276,19 @@ rtl.module @issue595_variant1(%arr: !rtl.array<128xi1>) {
   %3 = comb.bitcast %2 : (!rtl.array<32xi1>) -> i32
   rtl.output
 }
+
+rtl.module @issue595_variant2_checkRedunctionAnd(%arr: !rtl.array<128xi1>) {
+  // CHECK: wire [63:0] _T;
+  %c0_i32 = comb.constant -1 : i32
+  %c0_i7 = comb.constant 0 : i7
+  %c0_i6 = comb.constant 0 : i6
+  %0 = comb.icmp eq %3, %c0_i32 : i32
+  // CHECK: assert(&_T[6'h0+:32]);
+  sv.assert %0 : i1
+
+  // CHECK: assign _T = arr[7'h0+:64];
+  %1 = rtl.array_slice %arr at %c0_i7 : (!rtl.array<128xi1>) -> !rtl.array<64xi1>
+  %2 = rtl.array_slice %1 at %c0_i6 : (!rtl.array<64xi1>) -> !rtl.array<32xi1>
+  %3 = comb.bitcast %2 : (!rtl.array<32xi1>) -> i32
+  rtl.output
+}


### PR DESCRIPTION
Rename the "reduction Xor" operator to "Parity" in Comb dialect.
Semantics remain exactly same and export Verilog also doesn't change.
Discussed in: https://github.com/llvm/circt/issues/598