### PR TITLE
[FIRRTL] Lower vectors, SubindexOp in LowerTypes

### DIFF
--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -294,3 +294,15 @@ module  {
     }
   }
 }
+
+// -----
+// COM: Test vector lowering
+firrtl.circuit "LowerVectors" {
+  firrtl.module @LowerVectors(%a: !firrtl.vector<uint<1>, 2>, %b: !firrtl.flip<vector<uint<1>, 2>>) {
+    firrtl.connect %b, %a: !firrtl.flip<vector<uint<1>, 2>>, !firrtl.vector<uint<1>, 2>
+  }
+
+  // CHECK: firrtl.module @LowerVectors(%a_0: !firrtl.uint<1>, %a_1: !firrtl.uint<1>, %b_0: !firrtl.flip<uint<1>>, %b_1: !firrtl.flip<uint<1>>)
+  // CHECK: firrtl.connect %b_0, %a_0
+  // CHECK: firrtl.connect %b_1, %a_1
+}


### PR DESCRIPTION
Add vector lowering and lowering of subindex in the LowerTypes pass.

Add one test that vectors are lowered correctly.

Fixes #558. 

This does not fix subaccess lowering. To do that in this PR would be substantially more invasive as that requires flattening the subaccess into a bunch of subaccess and a mux chain. I'll look at this in a follow-up PR.

I'm really unhappy about the amount of code copied between SubindexOp and SubfieldOp handling, but I was having some difficulty factoring this. I'd plan to clean this up in a later commit as long as that's acceptable.