### PR TITLE
[ESI] Fixing up build dependencies for BUILD_SHARED_LIBS

### DIFF
--- a/include/circt/Dialect/ESI/cosim/CMakeLists.txt
+++ b/include/circt/Dialect/ESI/cosim/CMakeLists.txt
@@ -18,5 +18,8 @@ if(CapnProto_FOUND)
     ${COSIM_CAPNP_HDRS}
     ${COSIM_CAPNP_SRCS}
     CosimSchema.h)
-  target_link_libraries(EsiCosimCapnp PRIVATE CapnProto::capnp)
+  target_link_libraries(EsiCosimCapnp
+    PRIVATE
+    CapnProto::capnp
+    CapnProto::capnp-rpc)
 endif()

--- a/lib/Dialect/ESI/CMakeLists.txt
+++ b/lib/Dialect/ESI/CMakeLists.txt
@@ -21,6 +21,7 @@ set(ESI_LinkLibs
   MLIREDSC
   MLIRIR
   MLIRTransforms
+  MLIRTranslation
 )
 
 set(ESI_Deps


### PR DESCRIPTION
On my OSX machine, using Capnp installed through homebrew, these dependencies are needed when building with shared libraries (`BUILD_SHARED_LIBS`).
