### PR TITLE
[CI] Do not schedule nightly builds on forks

### DIFF
--- a/.github/workflows/buildAndTestWindows.yml
+++ b/.github/workflows/buildAndTestWindows.yml
@@ -11,6 +11,10 @@ jobs:
   build-circt:
     name: Build and Test
     runs-on: windows-latest
+
+    # We only run this job on a schedule if it is the main CIRCT repository.
+    if: (github.event_name == 'schedule' && github.repository == 'llvm/circt') || (github.event_name != 'schedule')
+
     steps:
       - name: Configure Environment
         run: echo "$GITHUB_WORKSPACE/llvm/install/bin" >> $GITHUB_PATH

--- a/.github/workflows/nightlyIntegrationTests.yml
+++ b/.github/workflows/nightlyIntegrationTests.yml
@@ -15,6 +15,10 @@ jobs:
   build-circt:
     name: Build and Test
     runs-on: ubuntu-latest
+
+    # We only run this job on a schedule if it is the main CIRCT repository.
+    if: (github.event_name == 'schedule' && github.repository == 'llvm/circt') || (github.event_name != 'schedule')
+
     container:
       image: ghcr.io/circt/images/circt-integration-test:v3
     steps:


### PR DESCRIPTION
When people fork a repository all of the github-actions are
automatically enabled.  Forked repositorys can manually disable actions
on their fork, but they are by default enabled, and disabling prevents
manually triggering the builds.  If someone needs to run the nightly
build ton their fork this will probably have to be removed.