### PR TITLE
[SV] Canonicalize sv.if true and sv.if false

### DIFF
--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -101,7 +101,8 @@ def IfOp : SVOp<"if", [HasRegionTerminator, NoRegionArguments,
   let regions = (region SizedRegion<1>:$thenRegion, AnyRegion:$elseRegion);
   let arguments = (ins I1:$cond);
   let results = (outs);
-  
+
+  let hasCanonicalizer = true;
   let assemblyFormat = "$cond $thenRegion (`else` $elseRegion^)? attr-dict";
 
   // TODO: ODS forces using a custom builder just to get the region terminator

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/SV/SVOps.h"
+#include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/RTL/RTLOps.h"
 #include "circt/Dialect/RTL/RTLTypes.h"
 #include "mlir/IR/Builders.h"
@@ -198,6 +199,40 @@ void IfOp::build(OpBuilder &odsBuilder, OperationState &result, Value cond,
   }
 }
 
+/// Replaces the given op with the contents of the given single-block region.
+static void replaceOpWithRegion(PatternRewriter &rewriter, Operation *op,
+                                Region &region) {
+  assert(llvm::hasSingleElement(region) && "expected single-region block");
+  Block *block = &region.front();
+  Operation *terminator = block->getTerminator();
+  rewriter.mergeBlockBefore(block, op);
+  rewriter.eraseOp(op);
+  rewriter.eraseOp(terminator);
+}
+
+void IfOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
+                                       MLIRContext *context) {
+  struct RemoveStaticCondition : public OpRewritePattern<IfOp> {
+    using OpRewritePattern<IfOp>::OpRewritePattern;
+
+    LogicalResult matchAndRewrite(IfOp op,
+                                  PatternRewriter &rewriter) const override {
+      auto constant = op.cond().getDefiningOp<rtl::ConstantOp>();
+      if (!constant)
+        return failure();
+
+      if (constant.getValue().isAllOnesValue())
+        replaceOpWithRegion(rewriter, op, op.thenRegion());
+      else if (!op.elseRegion().empty())
+        replaceOpWithRegion(rewriter, op, op.elseRegion());
+      else
+        rewriter.eraseOp(op);
+
+      return success();
+    }
+  };
+  results.insert<RemoveStaticCondition>(context);
+}
 //===----------------------------------------------------------------------===//
 // AlwaysOp
 

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/SV/SVOps.h"
-#include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/RTL/RTLOps.h"
 #include "circt/Dialect/RTL/RTLTypes.h"
 #include "mlir/IR/Builders.h"

--- a/test/Dialect/SV/canonicalization.mlir
+++ b/test/Dialect/SV/canonicalization.mlir
@@ -1,5 +1,6 @@
 // RUN: circt-opt -canonicalize %s | FileCheck %s
 
+// CHECK-LABEL: func @if_dead_condition(%arg0: i1) {
 // CHECK-NEXT:    sv.always posedge %arg0  {
 // CHECK-NEXT:      sv.fwrite "Reachable1"
 // CHECK-NEXT:      sv.fwrite "Reachable2"

--- a/test/Dialect/SV/canonicalization.mlir
+++ b/test/Dialect/SV/canonicalization.mlir
@@ -1,0 +1,46 @@
+// RUN: circt-opt -canonicalize %s | FileCheck %s
+
+// CHECK-NEXT:    sv.always posedge %arg0  {
+// CHECK-NEXT:      sv.fwrite "Reachable1"
+// CHECK-NEXT:      sv.fwrite "Reachable2"
+// CHECK-NEXT:      sv.fwrite "Reachable3"
+// CHECK-NEXT:      sv.fwrite "Reachable4"
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return 
+// CHECK-NEXT:  }
+
+func @if_dead_condition(%arg0: i1) {
+  sv.always posedge %arg0 {
+    %true = rtl.constant true
+    %false = rtl.constant false
+
+    sv.if %true {}
+
+    sv.if %false {
+        sv.fwrite "Unreachable0"
+    }
+
+    sv.if %true {
+      sv.fwrite "Reachable1"
+    }
+
+    sv.if %true {
+      sv.fwrite "Reachable2"
+    } else {
+      sv.fwrite "Unreachable2"
+    } 
+
+    sv.if %false {
+      sv.fwrite "Unreachable3"
+    } else {
+      sv.fwrite "Reachable3"
+    } 
+
+    sv.if %false {
+      sv.fwrite "Unreachable4"
+    } else {
+      sv.fwrite "Reachable4"
+    } 
+  }
+  return
+}


### PR DESCRIPTION
This PR canonicalizes `sv.if` with a constant condition. 
The logic is ported from SCF dialect canonicalization ([Dialect/SCF/SCF.cpp](https://github.com/llvm/llvm-project/blob/main/mlir/lib/Dialect/SCF/SCF.cpp#L776))

Part of #636.
