### PR TITLE
Fix Inappropriate Use of StringRef in LowerTypes

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -319,15 +319,13 @@ void FIRRTLTypesLowering::visitDecl(MemOp op) {
           Type theType = FlipType::get(elt.type);
 
           // Construct a new wire if needed.
-          auto wire =
-              newWires[op.getPortName(i).getValue().str() + elt.name.str()];
+          auto wireName =
+              op.getPortName(i).getValue().str() + "_" + elt.name.str();
+          auto wire = newWires[wireName];
           if (!wire) {
-            wire = builder->create<WireOp>(
-                theType, op.name().getValue().str() + "_" +
-                             op.getPortName(i).getValue().str() + "_" +
-                             elt.name.str());
-            newWires[op.getPortName(i).getValue().str() + elt.name.str()] =
-                wire;
+            wire = builder->create<WireOp>(theType, op.name().getValue().str() +
+                                                        "_" + wireName);
+            newWires[wireName] = wire;
             setBundleLowering(op.getResult(i), elt.name.str(), wire);
           }
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -272,7 +272,7 @@ void FIRRTLTypesLowering::visitDecl(MemOp op) {
 
   // Store any new wires created during lowering. This ensures that
   // wires are re-used if they already exist.
-  DenseMap<StringRef, Value> newWires;
+  llvm::StringMap<Value> newWires;
 
   // Loop over the leaf aggregates.
   for (auto field : fieldTypes) {

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -279,3 +279,18 @@ module  {
 //CHECK-NEXT:    }
 //CHECK-NEXT:  }
 //CHECK-NEXT:}
+
+// -----
+// https://github.com/llvm/circt/issues/661
+
+// COM: This test is just checking that the following doesn't error.
+module  {
+  firrtl.circuit "foo" {
+    firrtl.module @foo(%clock: !firrtl.clock) {
+      %head_MPORT_2, %head_MPORT_6 = firrtl.mem Undefined {depth = 20 : i64, name = "head", portNames = ["MPORT_2", "MPORT_6"], readLatency = 0 : i32, writeLatency = 1 : i32}
+      : !firrtl.flip<bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<5>, mask: uint<1>>>,
+        !firrtl.flip<bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<5>, mask: uint<1>>>
+      %127 = firrtl.subfield %head_MPORT_6("clk") : (!firrtl.flip<bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<5>, mask: uint<1>>>) -> !firrtl.flip<clock>
+    }
+  }
+}


### PR DESCRIPTION
Fixes #661 (I think?).

Inside FIRRTL's LowerTypes transform, when handling MemOps, I was using a `DenseMap<StringRef, Value>` to track new wire creation where new wires are keyed on the name of the wire. However, this is an inappropriate use of a `StringRef` as the names are going in and out of scope. E.g., I'm doing something like:

```c++
DenseMap<StringRef, Value> newWires;
newWires["foo"];
newWires["foo"];
```

I should be using something where the key is permanent and not some transient memory address.

This PR changes this from `DenseMap<StringRef, Value>` to `StringMap<Value>`. The wire name construction is also cleaned up to not be repeated multiple times.