### PR TITLE
[FIRRTL] Memory blackboxing fix for write memories

### DIFF
--- a/test/Dialect/FIRRTL/blackbox-memory.mlir
+++ b/test/Dialect/FIRRTL/blackbox-memory.mlir
@@ -20,26 +20,26 @@ firrtl.circuit "Read" {
 // WRAPPER-LABEL: firrtl.circuit "Read" {
 // WRAPPER-NEXT:   firrtl.extmodule @ReadMemory_ext(!firrtl.uint<4> {firrtl.name = "R0_addr"}, !firrtl.uint<1> {firrtl.name = "R0_en"}, !firrtl.clock {firrtl.name = "R0_clk"}, !firrtl.flip<sint<8>> {firrtl.name = "R0_data"}) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // WRAPPER-NEXT:   firrtl.module @ReadMemory(%read0: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) {
-// WRAPPER-NEXT:     %inst_R0_addr, %inst_R0_en, %inst_R0_clk, %inst_R0_data = firrtl.instance @ReadMemory_ext {portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
+// WRAPPER-NEXT:     %ReadMemory_R0_addr, %ReadMemory_R0_en, %ReadMemory_R0_clk, %ReadMemory_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory", portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
 // WRAPPER-NEXT:     %0 = firrtl.subfield %read0("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.uint<4>
-// WRAPPER-NEXT:     firrtl.connect %inst_R0_addr, %0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+// WRAPPER-NEXT:     firrtl.connect %ReadMemory_R0_addr, %0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
 // WRAPPER-NEXT:     %1 = firrtl.subfield %read0("en") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.uint<1>
-// WRAPPER-NEXT:     firrtl.connect %inst_R0_en, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %ReadMemory_R0_en, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // WRAPPER-NEXT:     %2 = firrtl.subfield %read0("clk") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.clock
-// WRAPPER-NEXT:     firrtl.connect %inst_R0_clk, %2 : !firrtl.flip<clock>, !firrtl.clock
+// WRAPPER-NEXT:     firrtl.connect %ReadMemory_R0_clk, %2 : !firrtl.flip<clock>, !firrtl.clock
 // WRAPPER-NEXT:     %3 = firrtl.subfield %read0("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.flip<sint<8>>
-// WRAPPER-NEXT:     firrtl.connect %3, %inst_R0_data : !firrtl.flip<sint<8>>, !firrtl.sint<8>
+// WRAPPER-NEXT:     firrtl.connect %3, %ReadMemory_R0_data : !firrtl.flip<sint<8>>, !firrtl.sint<8>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT:   firrtl.module @Read() {
 // WRAPPER-NEXT:     %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
 // WRAPPER-NEXT:     %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
-// WRAPPER-NEXT:     %inst_read0 = firrtl.instance @ReadMemory {portNames = ["read0"]} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
-// WRAPPER-NEXT:     %0 = firrtl.subfield %inst_read0("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.sint<8>
-// WRAPPER-NEXT:     %1 = firrtl.subfield %inst_read0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
+// WRAPPER-NEXT:     %ReadMemory_read0 = firrtl.instance @ReadMemory {name = "ReadMemory", portNames = ["read0"]} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+// WRAPPER-NEXT:     %0 = firrtl.subfield %ReadMemory_read0("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.sint<8>
+// WRAPPER-NEXT:     %1 = firrtl.subfield %ReadMemory_read0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
 // WRAPPER-NEXT:     firrtl.connect %1, %c0_ui1 : !firrtl.flip<uint<4>>, !firrtl.uint<1>
-// WRAPPER-NEXT:     %2 = firrtl.subfield %inst_read0("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<1>>
+// WRAPPER-NEXT:     %2 = firrtl.subfield %ReadMemory_read0("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<1>>
 // WRAPPER-NEXT:     firrtl.connect %2, %c1_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// WRAPPER-NEXT:     %3 = firrtl.subfield %inst_read0("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<clock>
+// WRAPPER-NEXT:     %3 = firrtl.subfield %ReadMemory_read0("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<clock>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT: }
 
@@ -48,16 +48,16 @@ firrtl.circuit "Read" {
 // INLINE-NEXT:   firrtl.module @Read() {
 // INLINE-NEXT:     %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
 // INLINE-NEXT:     %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
-// INLINE-NEXT:     %inst_R0_addr, %inst_R0_en, %inst_R0_clk, %inst_R0_data = firrtl.instance @ReadMemory_ext {portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
+// INLINE-NEXT:     %ReadMemory_R0_addr, %ReadMemory_R0_en, %ReadMemory_R0_clk, %ReadMemory_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory", portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
 // INLINE-NEXT:     %0 = firrtl.wire  {name = ""} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
 // INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
-// INLINE-NEXT:     firrtl.connect %1, %inst_R0_addr : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
+// INLINE-NEXT:     firrtl.connect %1, %ReadMemory_R0_addr : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
 // INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %2, %inst_R0_en : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %2, %ReadMemory_R0_en : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %3 = firrtl.subfield %0("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<clock>
-// INLINE-NEXT:     firrtl.connect %3, %inst_R0_clk : !firrtl.flip<clock>, !firrtl.flip<clock>
+// INLINE-NEXT:     firrtl.connect %3, %ReadMemory_R0_clk : !firrtl.flip<clock>, !firrtl.flip<clock>
 // INLINE-NEXT:     %4 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.sint<8>
-// INLINE-NEXT:     firrtl.connect %inst_R0_data, %4 : !firrtl.sint<8>, !firrtl.sint<8>
+// INLINE-NEXT:     firrtl.connect %ReadMemory_R0_data, %4 : !firrtl.sint<8>, !firrtl.sint<8>
 // INLINE-NEXT:     %5 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.sint<8>
 // INLINE-NEXT:     %6 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
 // INLINE-NEXT:     firrtl.connect %6, %c0_ui1 : !firrtl.flip<uint<4>>, !firrtl.uint<1>
@@ -74,40 +74,40 @@ firrtl.circuit "Write" {
 }
 
 // WRAPPER-LABEL: firrtl.circuit "Write" {
-// WRAPPER-NEXT:   firrtl.extmodule @WriteMemory_ext(!firrtl.flip<uint<1>> {firrtl.name = "W0_addr"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_en"}, !firrtl.flip<clock> {firrtl.name = "W0_clk"}, !firrtl.flip<sint<8>> {firrtl.name = "W0_data"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_mask"}) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// WRAPPER-NEXT:   firrtl.extmodule @WriteMemory_ext(!firrtl.uint<1> {firrtl.name = "W0_addr"}, !firrtl.uint<1> {firrtl.name = "W0_en"}, !firrtl.clock {firrtl.name = "W0_clk"}, !firrtl.sint<8> {firrtl.name = "W0_data"}, !firrtl.uint<1> {firrtl.name = "W0_mask"}) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // WRAPPER-NEXT:   firrtl.module @WriteMemory(%write0: !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) {
-// WRAPPER-NEXT:     %inst_W0_addr, %inst_W0_en, %inst_W0_clk, %inst_W0_data, %inst_W0_mask = firrtl.instance @WriteMemory_ext {portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %WriteMemory_W0_addr, %WriteMemory_W0_en, %WriteMemory_W0_clk, %WriteMemory_W0_data, %WriteMemory_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory", portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.flip<sint<8>>, !firrtl.flip<uint<1>>
 // WRAPPER-NEXT:     %0 = firrtl.subfield %write0("addr") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
-// WRAPPER-NEXT:     firrtl.connect %inst_W0_addr, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %WriteMemory_W0_addr, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // WRAPPER-NEXT:     %1 = firrtl.subfield %write0("en") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
-// WRAPPER-NEXT:     firrtl.connect %inst_W0_en, %1 : !firrtl.uint<1>, !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %WriteMemory_W0_en, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // WRAPPER-NEXT:     %2 = firrtl.subfield %write0("clk") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.clock
-// WRAPPER-NEXT:     firrtl.connect %inst_W0_clk, %2 : !firrtl.clock, !firrtl.clock
+// WRAPPER-NEXT:     firrtl.connect %WriteMemory_W0_clk, %2 : !firrtl.flip<clock>, !firrtl.clock
 // WRAPPER-NEXT:     %3 = firrtl.subfield %write0("data") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.sint<8>
-// WRAPPER-NEXT:     firrtl.connect %inst_W0_data, %3 : !firrtl.sint<8>, !firrtl.sint<8>
+// WRAPPER-NEXT:     firrtl.connect %WriteMemory_W0_data, %3 : !firrtl.flip<sint<8>>, !firrtl.sint<8>
 // WRAPPER-NEXT:     %4 = firrtl.subfield %write0("mask") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
-// WRAPPER-NEXT:     firrtl.connect %inst_W0_mask, %4 : !firrtl.uint<1>, !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %WriteMemory_W0_mask, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT:   firrtl.module @Write() {
-// WRAPPER-NEXT:     %inst_write0 = firrtl.instance @WriteMemory {portNames = ["write0"]} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
+// WRAPPER-NEXT:     %WriteMemory_write0 = firrtl.instance @WriteMemory {name = "WriteMemory", portNames = ["write0"]} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT: }
 
 // INLINE-LABEL: firrtl.circuit "Write" {
-// INLINE-NEXT:   firrtl.extmodule @WriteMemory_ext(!firrtl.flip<uint<1>> {firrtl.name = "W0_addr"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_en"}, !firrtl.flip<clock> {firrtl.name = "W0_clk"}, !firrtl.flip<sint<8>> {firrtl.name = "W0_data"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_mask"}) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// INLINE-NEXT:   firrtl.extmodule @WriteMemory_ext(!firrtl.uint<1> {firrtl.name = "W0_addr"}, !firrtl.uint<1> {firrtl.name = "W0_en"}, !firrtl.clock {firrtl.name = "W0_clk"}, !firrtl.sint<8> {firrtl.name = "W0_data"}, !firrtl.uint<1> {firrtl.name = "W0_mask"}) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // INLINE-NEXT:   firrtl.module @Write() {
-// INLINE-NEXT:     %inst_W0_addr, %inst_W0_en, %inst_W0_clk, %inst_W0_data, %inst_W0_mask = firrtl.instance @WriteMemory_ext {portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// INLINE-NEXT:     %WriteMemory_W0_addr, %WriteMemory_W0_en, %WriteMemory_W0_clk, %WriteMemory_W0_data, %WriteMemory_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory", portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.flip<sint<8>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %0 = firrtl.wire  {name = ""} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
 // INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %1, %inst_W0_addr : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %1, %WriteMemory_W0_addr : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %2, %inst_W0_en : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %2, %WriteMemory_W0_en : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %3 = firrtl.subfield %0("clk") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<clock>
-// INLINE-NEXT:     firrtl.connect %3, %inst_W0_clk : !firrtl.flip<clock>, !firrtl.clock
+// INLINE-NEXT:     firrtl.connect %3, %WriteMemory_W0_clk : !firrtl.flip<clock>, !firrtl.flip<clock>
 // INLINE-NEXT:     %4 = firrtl.subfield %0("data") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<sint<8>>
-// INLINE-NEXT:     firrtl.connect %4, %inst_W0_data : !firrtl.flip<sint<8>>, !firrtl.sint<8>
+// INLINE-NEXT:     firrtl.connect %4, %WriteMemory_W0_data : !firrtl.flip<sint<8>>, !firrtl.flip<sint<8>>
 // INLINE-NEXT:     %5 = firrtl.subfield %0("mask") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %5, %inst_W0_mask : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %5, %WriteMemory_W0_mask : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:   }
 // INLINE-NEXT: }
 
@@ -172,85 +172,85 @@ firrtl.circuit "MemSimple" {
 }
 
 // WRAPPER-LABEL: firrtl.circuit "MemSimple" {
-// WRAPPER-NEXT:   firrtl.extmodule @_M_ext(!firrtl.uint<4> {firrtl.name = "R0_addr"}, !firrtl.uint<1> {firrtl.name = "R0_en"}, !firrtl.clock {firrtl.name = "R0_clk"}, !firrtl.flip<sint<42>> {firrtl.name = "R0_data"}, !firrtl.flip<uint<4>> {firrtl.name = "W0_addr"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_en"}, !firrtl.flip<clock> {firrtl.name = "W0_clk"}, !firrtl.flip<sint<42>> {firrtl.name = "W0_data"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_mask"}) attributes {depth = 12 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// WRAPPER-NEXT:   firrtl.extmodule @_M_ext(!firrtl.uint<4> {firrtl.name = "R0_addr"}, !firrtl.uint<1> {firrtl.name = "R0_en"}, !firrtl.clock {firrtl.name = "R0_clk"}, !firrtl.flip<sint<42>> {firrtl.name = "R0_data"}, !firrtl.uint<4> {firrtl.name = "W0_addr"}, !firrtl.uint<1> {firrtl.name = "W0_en"}, !firrtl.clock {firrtl.name = "W0_clk"}, !firrtl.sint<42> {firrtl.name = "W0_data"}, !firrtl.uint<1> {firrtl.name = "W0_mask"}) attributes {depth = 12 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // WRAPPER-NEXT:   firrtl.module @_M(%read: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>, %write: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) {
-// WRAPPER-NEXT:     %inst_R0_addr, %inst_R0_en, %inst_R0_clk, %inst_R0_data, %inst_W0_addr, %inst_W0_en, %inst_W0_clk, %inst_W0_data, %inst_W0_mask = firrtl.instance @_M_ext {portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data", "W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<42>, !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<42>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %_M_R0_addr, %_M_R0_en, %_M_R0_clk, %_M_R0_data, %_M_W0_addr, %_M_W0_en, %_M_W0_clk, %_M_W0_data, %_M_W0_mask = firrtl.instance @_M_ext {name = "_M", portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data", "W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<42>, !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.flip<sint<42>>, !firrtl.flip<uint<1>>
 // WRAPPER-NEXT:     %0 = firrtl.subfield %read("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>) -> !firrtl.uint<4>
-// WRAPPER-NEXT:     firrtl.connect %inst_R0_addr, %0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+// WRAPPER-NEXT:     firrtl.connect %_M_R0_addr, %0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
 // WRAPPER-NEXT:     %1 = firrtl.subfield %read("en") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>) -> !firrtl.uint<1>
-// WRAPPER-NEXT:     firrtl.connect %inst_R0_en, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %_M_R0_en, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // WRAPPER-NEXT:     %2 = firrtl.subfield %read("clk") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>) -> !firrtl.clock
-// WRAPPER-NEXT:     firrtl.connect %inst_R0_clk, %2 : !firrtl.flip<clock>, !firrtl.clock
+// WRAPPER-NEXT:     firrtl.connect %_M_R0_clk, %2 : !firrtl.flip<clock>, !firrtl.clock
 // WRAPPER-NEXT:     %3 = firrtl.subfield %read("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>) -> !firrtl.flip<sint<42>>
-// WRAPPER-NEXT:     firrtl.connect %3, %inst_R0_data : !firrtl.flip<sint<42>>, !firrtl.sint<42>
+// WRAPPER-NEXT:     firrtl.connect %3, %_M_R0_data : !firrtl.flip<sint<42>>, !firrtl.sint<42>
 // WRAPPER-NEXT:     %4 = firrtl.subfield %write("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.uint<4>
-// WRAPPER-NEXT:     firrtl.connect %inst_W0_addr, %4 : !firrtl.uint<4>, !firrtl.uint<4>
+// WRAPPER-NEXT:     firrtl.connect %_M_W0_addr, %4 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
 // WRAPPER-NEXT:     %5 = firrtl.subfield %write("en") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.uint<1>
-// WRAPPER-NEXT:     firrtl.connect %inst_W0_en, %5 : !firrtl.uint<1>, !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %_M_W0_en, %5 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // WRAPPER-NEXT:     %6 = firrtl.subfield %write("clk") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.clock
-// WRAPPER-NEXT:     firrtl.connect %inst_W0_clk, %6 : !firrtl.clock, !firrtl.clock
+// WRAPPER-NEXT:     firrtl.connect %_M_W0_clk, %6 : !firrtl.flip<clock>, !firrtl.clock
 // WRAPPER-NEXT:     %7 = firrtl.subfield %write("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.sint<42>
-// WRAPPER-NEXT:     firrtl.connect %inst_W0_data, %7 : !firrtl.sint<42>, !firrtl.sint<42>
+// WRAPPER-NEXT:     firrtl.connect %_M_W0_data, %7 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
 // WRAPPER-NEXT:     %8 = firrtl.subfield %write("mask") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.uint<1>
-// WRAPPER-NEXT:     firrtl.connect %inst_W0_mask, %8 : !firrtl.uint<1>, !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %_M_W0_mask, %8 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT:   firrtl.module @MemSimple(%clock1: !firrtl.clock, %clock2: !firrtl.clock, %inpred: !firrtl.uint<1>, %indata: !firrtl.sint<42>, %result: !firrtl.flip<sint<42>>) {
 // WRAPPER-NEXT:     %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
 // WRAPPER-NEXT:     %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
 // WRAPPER-NEXT:     %c0_ui3 = firrtl.constant(0 : ui3) : !firrtl.uint<3>
-// WRAPPER-NEXT:     %inst_read, %inst_write = firrtl.instance @_M {portNames = ["read", "write"]} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>
-// WRAPPER-NEXT:     %0 = firrtl.subfield %inst_read("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.sint<42>
+// WRAPPER-NEXT:     %_M_read, %_M_write = firrtl.instance @_M {name = "_M", portNames = ["read", "write"]} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>
+// WRAPPER-NEXT:     %0 = firrtl.subfield %_M_read("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.sint<42>
 // WRAPPER-NEXT:     firrtl.connect %result, %0 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
-// WRAPPER-NEXT:     %1 = firrtl.subfield %inst_read("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<4>>
+// WRAPPER-NEXT:     %1 = firrtl.subfield %_M_read("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<4>>
 // WRAPPER-NEXT:     firrtl.connect %1, %c0_ui1 : !firrtl.flip<uint<4>>, !firrtl.uint<1>
-// WRAPPER-NEXT:     %2 = firrtl.subfield %inst_read("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<1>>
+// WRAPPER-NEXT:     %2 = firrtl.subfield %_M_read("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<1>>
 // WRAPPER-NEXT:     firrtl.connect %2, %c1_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// WRAPPER-NEXT:     %3 = firrtl.subfield %inst_read("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<clock>
+// WRAPPER-NEXT:     %3 = firrtl.subfield %_M_read("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<clock>
 // WRAPPER-NEXT:     firrtl.connect %3, %clock1 : !firrtl.flip<clock>, !firrtl.clock
-// WRAPPER-NEXT:     %4 = firrtl.subfield %inst_write("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<4>>
+// WRAPPER-NEXT:     %4 = firrtl.subfield %_M_write("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<4>>
 // WRAPPER-NEXT:     %5 = firrtl.validif %inpred, %c0_ui3 : (!firrtl.uint<1>, !firrtl.uint<3>) -> !firrtl.uint<3>
 // WRAPPER-NEXT:     firrtl.connect %4, %5 : !firrtl.flip<uint<4>>, !firrtl.uint<3>
-// WRAPPER-NEXT:     %6 = firrtl.subfield %inst_write("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// WRAPPER-NEXT:     %6 = firrtl.subfield %_M_write("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
 // WRAPPER-NEXT:     firrtl.connect %6, %inpred : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// WRAPPER-NEXT:     %7 = firrtl.subfield %inst_write("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<clock>
+// WRAPPER-NEXT:     %7 = firrtl.subfield %_M_write("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<clock>
 // WRAPPER-NEXT:     %8 = firrtl.validif %inpred, %clock2 : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.clock
 // WRAPPER-NEXT:     firrtl.connect %7, %8 : !firrtl.flip<clock>, !firrtl.clock
-// WRAPPER-NEXT:     %9 = firrtl.subfield %inst_write("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<sint<42>>
+// WRAPPER-NEXT:     %9 = firrtl.subfield %_M_write("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<sint<42>>
 // WRAPPER-NEXT:     %10 = firrtl.validif %inpred, %indata : (!firrtl.uint<1>, !firrtl.sint<42>) -> !firrtl.sint<42>
 // WRAPPER-NEXT:     firrtl.connect %9, %10 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
-// WRAPPER-NEXT:     %11 = firrtl.subfield %inst_write("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// WRAPPER-NEXT:     %11 = firrtl.subfield %_M_write("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
 // WRAPPER-NEXT:     %12 = firrtl.validif %inpred, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // WRAPPER-NEXT:     firrtl.connect %11, %12 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT: }
 
 // INLINE-LABEL: firrtl.circuit "MemSimple" {
-// INLINE-NEXT:   firrtl.extmodule @_M_ext(!firrtl.uint<4> {firrtl.name = "R0_addr"}, !firrtl.uint<1> {firrtl.name = "R0_en"}, !firrtl.clock {firrtl.name = "R0_clk"}, !firrtl.flip<sint<42>> {firrtl.name = "R0_data"}, !firrtl.flip<uint<4>> {firrtl.name = "W0_addr"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_en"}, !firrtl.flip<clock> {firrtl.name = "W0_clk"}, !firrtl.flip<sint<42>> {firrtl.name = "W0_data"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_mask"}) attributes {depth = 12 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// INLINE-NEXT:   firrtl.extmodule @_M_ext(!firrtl.uint<4> {firrtl.name = "R0_addr"}, !firrtl.uint<1> {firrtl.name = "R0_en"}, !firrtl.clock {firrtl.name = "R0_clk"}, !firrtl.flip<sint<42>> {firrtl.name = "R0_data"}, !firrtl.uint<4> {firrtl.name = "W0_addr"}, !firrtl.uint<1> {firrtl.name = "W0_en"}, !firrtl.clock {firrtl.name = "W0_clk"}, !firrtl.sint<42> {firrtl.name = "W0_data"}, !firrtl.uint<1> {firrtl.name = "W0_mask"}) attributes {depth = 12 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // INLINE-NEXT:   firrtl.module @MemSimple(%clock1: !firrtl.clock, %clock2: !firrtl.clock, %inpred: !firrtl.uint<1>, %indata: !firrtl.sint<42>, %result: !firrtl.flip<sint<42>>) {
 // INLINE-NEXT:     %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
 // INLINE-NEXT:     %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
 // INLINE-NEXT:     %c0_ui3 = firrtl.constant(0 : ui3) : !firrtl.uint<3>
-// INLINE-NEXT:     %inst_R0_addr, %inst_R0_en, %inst_R0_clk, %inst_R0_data, %inst_W0_addr, %inst_W0_en, %inst_W0_clk, %inst_W0_data, %inst_W0_mask = firrtl.instance @_M_ext {portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data", "W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<42>, !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<42>, !firrtl.uint<1>
+// INLINE-NEXT:     %_M_R0_addr, %_M_R0_en, %_M_R0_clk, %_M_R0_data, %_M_W0_addr, %_M_W0_en, %_M_W0_clk, %_M_W0_data, %_M_W0_mask = firrtl.instance @_M_ext {name = "_M", portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data", "W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<42>, !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.flip<sint<42>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %0 = firrtl.wire  {name = ""} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>
 // INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<4>>
-// INLINE-NEXT:     firrtl.connect %1, %inst_R0_addr : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
+// INLINE-NEXT:     firrtl.connect %1, %_M_R0_addr : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
 // INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %2, %inst_R0_en : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %2, %_M_R0_en : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %3 = firrtl.subfield %0("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<clock>
-// INLINE-NEXT:     firrtl.connect %3, %inst_R0_clk : !firrtl.flip<clock>, !firrtl.flip<clock>
+// INLINE-NEXT:     firrtl.connect %3, %_M_R0_clk : !firrtl.flip<clock>, !firrtl.flip<clock>
 // INLINE-NEXT:     %4 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.sint<42>
-// INLINE-NEXT:     firrtl.connect %inst_R0_data, %4 : !firrtl.sint<42>, !firrtl.sint<42>
+// INLINE-NEXT:     firrtl.connect %_M_R0_data, %4 : !firrtl.sint<42>, !firrtl.sint<42>
 // INLINE-NEXT:     %5 = firrtl.wire  {name = ""} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>
 // INLINE-NEXT:     %6 = firrtl.subfield %5("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<4>>
-// INLINE-NEXT:     firrtl.connect %6, %inst_W0_addr : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+// INLINE-NEXT:     firrtl.connect %6, %_M_W0_addr : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
 // INLINE-NEXT:     %7 = firrtl.subfield %5("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %7, %inst_W0_en : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %7, %_M_W0_en : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %8 = firrtl.subfield %5("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<clock>
-// INLINE-NEXT:     firrtl.connect %8, %inst_W0_clk : !firrtl.flip<clock>, !firrtl.clock
+// INLINE-NEXT:     firrtl.connect %8, %_M_W0_clk : !firrtl.flip<clock>, !firrtl.flip<clock>
 // INLINE-NEXT:     %9 = firrtl.subfield %5("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<sint<42>>
-// INLINE-NEXT:     firrtl.connect %9, %inst_W0_data : !firrtl.flip<sint<42>>, !firrtl.sint<42>
+// INLINE-NEXT:     firrtl.connect %9, %_M_W0_data : !firrtl.flip<sint<42>>, !firrtl.flip<sint<42>>
 // INLINE-NEXT:     %10 = firrtl.subfield %5("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %10, %inst_W0_mask : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %10, %_M_W0_mask : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %11 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.sint<42>
 // INLINE-NEXT:     firrtl.connect %result, %11 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
 // INLINE-NEXT:     %12 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<4>>
@@ -287,68 +287,68 @@ firrtl.circuit "NameCollision" {
 }
 
 // WRAPPER-LABEL: firrtl.circuit "NameCollision" {
-// WRAPPER-NEXT:   firrtl.extmodule @NameCollisionMemory_ext_1(!firrtl.flip<uint<4>> {firrtl.name = "W0_addr"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_en"}, !firrtl.flip<clock> {firrtl.name = "W0_clk"}, !firrtl.flip<sint<8>> {firrtl.name = "W0_data"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_mask"}) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// WRAPPER-NEXT:   firrtl.extmodule @NameCollisionMemory_ext_1(!firrtl.uint<4> {firrtl.name = "W0_addr"}, !firrtl.uint<1> {firrtl.name = "W0_en"}, !firrtl.clock {firrtl.name = "W0_clk"}, !firrtl.sint<8> {firrtl.name = "W0_data"}, !firrtl.uint<1> {firrtl.name = "W0_mask"}) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // WRAPPER-NEXT:   firrtl.module @NameCollisionMemory_0(%write0: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) {
-// WRAPPER-NEXT:     %inst_W0_addr, %inst_W0_en, %inst_W0_clk, %inst_W0_data, %inst_W0_mask = firrtl.instance @NameCollisionMemory_ext_1 {portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %NameCollisionMemory_W0_addr, %NameCollisionMemory_W0_en, %NameCollisionMemory_W0_clk, %NameCollisionMemory_W0_data, %NameCollisionMemory_W0_mask = firrtl.instance @NameCollisionMemory_ext_1 {name = "NameCollisionMemory", portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.flip<sint<8>>, !firrtl.flip<uint<1>>
 // WRAPPER-NEXT:     %0 = firrtl.subfield %write0("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<4>
-// WRAPPER-NEXT:     firrtl.connect %inst_W0_addr, %0 : !firrtl.uint<4>, !firrtl.uint<4>
+// WRAPPER-NEXT:     firrtl.connect %NameCollisionMemory_W0_addr, %0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
 // WRAPPER-NEXT:     %1 = firrtl.subfield %write0("en") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
-// WRAPPER-NEXT:     firrtl.connect %inst_W0_en, %1 : !firrtl.uint<1>, !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %NameCollisionMemory_W0_en, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // WRAPPER-NEXT:     %2 = firrtl.subfield %write0("clk") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.clock
-// WRAPPER-NEXT:     firrtl.connect %inst_W0_clk, %2 : !firrtl.clock, !firrtl.clock
+// WRAPPER-NEXT:     firrtl.connect %NameCollisionMemory_W0_clk, %2 : !firrtl.flip<clock>, !firrtl.clock
 // WRAPPER-NEXT:     %3 = firrtl.subfield %write0("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.sint<8>
-// WRAPPER-NEXT:     firrtl.connect %inst_W0_data, %3 : !firrtl.sint<8>, !firrtl.sint<8>
+// WRAPPER-NEXT:     firrtl.connect %NameCollisionMemory_W0_data, %3 : !firrtl.flip<sint<8>>, !firrtl.sint<8>
 // WRAPPER-NEXT:     %4 = firrtl.subfield %write0("mask") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
-// WRAPPER-NEXT:     firrtl.connect %inst_W0_mask, %4 : !firrtl.uint<1>, !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %NameCollisionMemory_W0_mask, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT:   firrtl.extmodule @NameCollisionMemory_ext_0(!firrtl.uint<4> {firrtl.name = "R0_addr"}, !firrtl.uint<1> {firrtl.name = "R0_en"}, !firrtl.clock {firrtl.name = "R0_clk"}, !firrtl.flip<sint<8>> {firrtl.name = "R0_data"}) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // WRAPPER-NEXT:   firrtl.module @NameCollisionMemory(%read0: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) {
-// WRAPPER-NEXT:     %inst_R0_addr, %inst_R0_en, %inst_R0_clk, %inst_R0_data = firrtl.instance @NameCollisionMemory_ext_0 {portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
+// WRAPPER-NEXT:     %NameCollisionMemory_R0_addr, %NameCollisionMemory_R0_en, %NameCollisionMemory_R0_clk, %NameCollisionMemory_R0_data = firrtl.instance @NameCollisionMemory_ext_0 {name = "NameCollisionMemory", portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
 // WRAPPER-NEXT:     %0 = firrtl.subfield %read0("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.uint<4>
-// WRAPPER-NEXT:     firrtl.connect %inst_R0_addr, %0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+// WRAPPER-NEXT:     firrtl.connect %NameCollisionMemory_R0_addr, %0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
 // WRAPPER-NEXT:     %1 = firrtl.subfield %read0("en") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.uint<1>
-// WRAPPER-NEXT:     firrtl.connect %inst_R0_en, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %NameCollisionMemory_R0_en, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // WRAPPER-NEXT:     %2 = firrtl.subfield %read0("clk") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.clock
-// WRAPPER-NEXT:     firrtl.connect %inst_R0_clk, %2 : !firrtl.flip<clock>, !firrtl.clock
+// WRAPPER-NEXT:     firrtl.connect %NameCollisionMemory_R0_clk, %2 : !firrtl.flip<clock>, !firrtl.clock
 // WRAPPER-NEXT:     %3 = firrtl.subfield %read0("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.flip<sint<8>>
-// WRAPPER-NEXT:     firrtl.connect %3, %inst_R0_data : !firrtl.flip<sint<8>>, !firrtl.sint<8>
+// WRAPPER-NEXT:     firrtl.connect %3, %NameCollisionMemory_R0_data : !firrtl.flip<sint<8>>, !firrtl.sint<8>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT:   firrtl.module @NameCollisionMemory_ext() {
-// WRAPPER-NEXT:     %inst_read0 = firrtl.instance @NameCollisionMemory {portNames = ["read0"]} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+// WRAPPER-NEXT:     %NameCollisionMemory_read0 = firrtl.instance @NameCollisionMemory {name = "NameCollisionMemory", portNames = ["read0"]} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT:   firrtl.module @NameCollision() {
-// WRAPPER-NEXT:     %inst_write0 = firrtl.instance @NameCollisionMemory_0 {portNames = ["write0"]} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
+// WRAPPER-NEXT:     %NameCollisionMemory_write0 = firrtl.instance @NameCollisionMemory_0 {name = "NameCollisionMemory", portNames = ["write0"]} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT: }
 
 // INLINE-LABEL: firrtl.circuit "NameCollision" {
-// INLINE-NEXT:   firrtl.extmodule @NameCollisionMemory_ext_1(!firrtl.flip<uint<4>> {firrtl.name = "W0_addr"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_en"}, !firrtl.flip<clock> {firrtl.name = "W0_clk"}, !firrtl.flip<sint<8>> {firrtl.name = "W0_data"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_mask"}) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// INLINE-NEXT:   firrtl.extmodule @NameCollisionMemory_ext_1(!firrtl.uint<4> {firrtl.name = "W0_addr"}, !firrtl.uint<1> {firrtl.name = "W0_en"}, !firrtl.clock {firrtl.name = "W0_clk"}, !firrtl.sint<8> {firrtl.name = "W0_data"}, !firrtl.uint<1> {firrtl.name = "W0_mask"}) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // INLINE-NEXT:   firrtl.extmodule @NameCollisionMemory_ext_0(!firrtl.uint<4> {firrtl.name = "R0_addr"}, !firrtl.uint<1> {firrtl.name = "R0_en"}, !firrtl.clock {firrtl.name = "R0_clk"}, !firrtl.flip<sint<8>> {firrtl.name = "R0_data"}) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // INLINE-NEXT:   firrtl.module @NameCollisionMemory_ext() {
-// INLINE-NEXT:     %inst_R0_addr, %inst_R0_en, %inst_R0_clk, %inst_R0_data = firrtl.instance @NameCollisionMemory_ext_0 {portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
+// INLINE-NEXT:     %NameCollisionMemory_R0_addr, %NameCollisionMemory_R0_en, %NameCollisionMemory_R0_clk, %NameCollisionMemory_R0_data = firrtl.instance @NameCollisionMemory_ext_0 {name = "NameCollisionMemory", portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
 // INLINE-NEXT:     %0 = firrtl.wire  {name = ""} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
 // INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
-// INLINE-NEXT:     firrtl.connect %1, %inst_R0_addr : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
+// INLINE-NEXT:     firrtl.connect %1, %NameCollisionMemory_R0_addr : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
 // INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %2, %inst_R0_en : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %2, %NameCollisionMemory_R0_en : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %3 = firrtl.subfield %0("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<clock>
-// INLINE-NEXT:     firrtl.connect %3, %inst_R0_clk : !firrtl.flip<clock>, !firrtl.flip<clock>
+// INLINE-NEXT:     firrtl.connect %3, %NameCollisionMemory_R0_clk : !firrtl.flip<clock>, !firrtl.flip<clock>
 // INLINE-NEXT:     %4 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.sint<8>
-// INLINE-NEXT:     firrtl.connect %inst_R0_data, %4 : !firrtl.sint<8>, !firrtl.sint<8>
+// INLINE-NEXT:     firrtl.connect %NameCollisionMemory_R0_data, %4 : !firrtl.sint<8>, !firrtl.sint<8>
 // INLINE-NEXT:   }
 // INLINE-NEXT:   firrtl.module @NameCollision() {
-// INLINE-NEXT:     %inst_W0_addr, %inst_W0_en, %inst_W0_clk, %inst_W0_data, %inst_W0_mask = firrtl.instance @NameCollisionMemory_ext_1 {portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// INLINE-NEXT:     %NameCollisionMemory_W0_addr, %NameCollisionMemory_W0_en, %NameCollisionMemory_W0_clk, %NameCollisionMemory_W0_data, %NameCollisionMemory_W0_mask = firrtl.instance @NameCollisionMemory_ext_1 {name = "NameCollisionMemory", portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.flip<sint<8>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %0 = firrtl.wire  {name = ""} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
 // INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<4>>
-// INLINE-NEXT:     firrtl.connect %1, %inst_W0_addr : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+// INLINE-NEXT:     firrtl.connect %1, %NameCollisionMemory_W0_addr : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
 // INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %2, %inst_W0_en : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %2, %NameCollisionMemory_W0_en : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %3 = firrtl.subfield %0("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<clock>
-// INLINE-NEXT:     firrtl.connect %3, %inst_W0_clk : !firrtl.flip<clock>, !firrtl.clock
+// INLINE-NEXT:     firrtl.connect %3, %NameCollisionMemory_W0_clk : !firrtl.flip<clock>, !firrtl.flip<clock>
 // INLINE-NEXT:     %4 = firrtl.subfield %0("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<sint<8>>
-// INLINE-NEXT:     firrtl.connect %4, %inst_W0_data : !firrtl.flip<sint<8>>, !firrtl.sint<8>
+// INLINE-NEXT:     firrtl.connect %4, %NameCollisionMemory_W0_data : !firrtl.flip<sint<8>>, !firrtl.flip<sint<8>>
 // INLINE-NEXT:     %5 = firrtl.subfield %0("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %5, %inst_W0_mask : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %5, %NameCollisionMemory_W0_mask : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:   }
 // INLINE-NEXT: }
 
@@ -365,111 +365,111 @@ firrtl.circuit "Duplicate" {
 }
 
 // WRAPPER-LABEL: firrtl.circuit "Duplicate" {
-// WRAPPER-NEXT:   firrtl.extmodule @WriteMemory_ext(!firrtl.flip<uint<1>> {firrtl.name = "W0_addr"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_en"}, !firrtl.flip<clock> {firrtl.name = "W0_clk"}, !firrtl.flip<sint<8>> {firrtl.name = "W0_data"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_mask"}) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// WRAPPER-NEXT:   firrtl.extmodule @WriteMemory_ext(!firrtl.uint<1> {firrtl.name = "W0_addr"}, !firrtl.uint<1> {firrtl.name = "W0_en"}, !firrtl.clock {firrtl.name = "W0_clk"}, !firrtl.sint<8> {firrtl.name = "W0_data"}, !firrtl.uint<1> {firrtl.name = "W0_mask"}) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // WRAPPER-NEXT:   firrtl.module @WriteMemory(%write0: !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) {
-// WRAPPER-NEXT:     %inst_W0_addr, %inst_W0_en, %inst_W0_clk, %inst_W0_data, %inst_W0_mask = firrtl.instance @WriteMemory_ext {portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %WriteMemory_W0_addr, %WriteMemory_W0_en, %WriteMemory_W0_clk, %WriteMemory_W0_data, %WriteMemory_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory", portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.flip<sint<8>>, !firrtl.flip<uint<1>>
 // WRAPPER-NEXT:     %0 = firrtl.subfield %write0("addr") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
-// WRAPPER-NEXT:     firrtl.connect %inst_W0_addr, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %WriteMemory_W0_addr, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // WRAPPER-NEXT:     %1 = firrtl.subfield %write0("en") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
-// WRAPPER-NEXT:     firrtl.connect %inst_W0_en, %1 : !firrtl.uint<1>, !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %WriteMemory_W0_en, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // WRAPPER-NEXT:     %2 = firrtl.subfield %write0("clk") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.clock
-// WRAPPER-NEXT:     firrtl.connect %inst_W0_clk, %2 : !firrtl.clock, !firrtl.clock
+// WRAPPER-NEXT:     firrtl.connect %WriteMemory_W0_clk, %2 : !firrtl.flip<clock>, !firrtl.clock
 // WRAPPER-NEXT:     %3 = firrtl.subfield %write0("data") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.sint<8>
-// WRAPPER-NEXT:     firrtl.connect %inst_W0_data, %3 : !firrtl.sint<8>, !firrtl.sint<8>
+// WRAPPER-NEXT:     firrtl.connect %WriteMemory_W0_data, %3 : !firrtl.flip<sint<8>>, !firrtl.sint<8>
 // WRAPPER-NEXT:     %4 = firrtl.subfield %write0("mask") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
-// WRAPPER-NEXT:     firrtl.connect %inst_W0_mask, %4 : !firrtl.uint<1>, !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %WriteMemory_W0_mask, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT:   firrtl.extmodule @ReadMemory_ext(!firrtl.uint<4> {firrtl.name = "R0_addr"}, !firrtl.uint<1> {firrtl.name = "R0_en"}, !firrtl.clock {firrtl.name = "R0_clk"}, !firrtl.flip<sint<8>> {firrtl.name = "R0_data"}) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // WRAPPER-NEXT:   firrtl.module @ReadMemory(%read0: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) {
-// WRAPPER-NEXT:     %inst_R0_addr, %inst_R0_en, %inst_R0_clk, %inst_R0_data = firrtl.instance @ReadMemory_ext {portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
+// WRAPPER-NEXT:     %ReadMemory_R0_addr, %ReadMemory_R0_en, %ReadMemory_R0_clk, %ReadMemory_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory", portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
 // WRAPPER-NEXT:     %0 = firrtl.subfield %read0("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.uint<4>
-// WRAPPER-NEXT:     firrtl.connect %inst_R0_addr, %0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+// WRAPPER-NEXT:     firrtl.connect %ReadMemory_R0_addr, %0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
 // WRAPPER-NEXT:     %1 = firrtl.subfield %read0("en") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.uint<1>
-// WRAPPER-NEXT:     firrtl.connect %inst_R0_en, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %ReadMemory_R0_en, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // WRAPPER-NEXT:     %2 = firrtl.subfield %read0("clk") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.clock
-// WRAPPER-NEXT:     firrtl.connect %inst_R0_clk, %2 : !firrtl.flip<clock>, !firrtl.clock
+// WRAPPER-NEXT:     firrtl.connect %ReadMemory_R0_clk, %2 : !firrtl.flip<clock>, !firrtl.clock
 // WRAPPER-NEXT:     %3 = firrtl.subfield %read0("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.flip<sint<8>>
-// WRAPPER-NEXT:     firrtl.connect %3, %inst_R0_data : !firrtl.flip<sint<8>>, !firrtl.sint<8>
+// WRAPPER-NEXT:     firrtl.connect %3, %ReadMemory_R0_data : !firrtl.flip<sint<8>>, !firrtl.sint<8>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT:   firrtl.module @Duplicate() {
-// WRAPPER-NEXT:     %inst_read0 = firrtl.instance @ReadMemory {portNames = ["read0"]} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
-// WRAPPER-NEXT:     %inst_write0 = firrtl.instance @WriteMemory {portNames = ["write0"]} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
-// WRAPPER-NEXT:     %inst_read0_0 = firrtl.instance @ReadMemory {portNames = ["read0"]} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
-// WRAPPER-NEXT:     %inst_write0_1 = firrtl.instance @WriteMemory {portNames = ["write0"]} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
-// WRAPPER-NEXT:     %inst_read0_2 = firrtl.instance @ReadMemory {portNames = ["read0"]} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
-// WRAPPER-NEXT:     %inst_write0_3 = firrtl.instance @WriteMemory {portNames = ["write0"]} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
+// WRAPPER-NEXT:     %ReadMemory_read0 = firrtl.instance @ReadMemory {name = "ReadMemory", portNames = ["read0"]} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+// WRAPPER-NEXT:     %WriteMemory_write0 = firrtl.instance @WriteMemory {name = "WriteMemory", portNames = ["write0"]} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
+// WRAPPER-NEXT:     %ReadMemory1_read0 = firrtl.instance @ReadMemory {name = "ReadMemory1", portNames = ["read0"]} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+// WRAPPER-NEXT:     %WriteMemory1_write0 = firrtl.instance @WriteMemory {name = "WriteMemory1", portNames = ["write0"]} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
+// WRAPPER-NEXT:     %ReadMemory2_read0 = firrtl.instance @ReadMemory {name = "ReadMemory2", portNames = ["read0"]} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+// WRAPPER-NEXT:     %WriteMemory2_write0 = firrtl.instance @WriteMemory {name = "WriteMemory2", portNames = ["write0"]} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT: }
 
 // INLINE-LABEL: firrtl.circuit "Duplicate" {
-// INLINE-NEXT:   firrtl.extmodule @WriteMemory_ext(!firrtl.flip<uint<1>> {firrtl.name = "W0_addr"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_en"}, !firrtl.flip<clock> {firrtl.name = "W0_clk"}, !firrtl.flip<sint<8>> {firrtl.name = "W0_data"}, !firrtl.flip<uint<1>> {firrtl.name = "W0_mask"}) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// INLINE-NEXT:   firrtl.extmodule @WriteMemory_ext(!firrtl.uint<1> {firrtl.name = "W0_addr"}, !firrtl.uint<1> {firrtl.name = "W0_en"}, !firrtl.clock {firrtl.name = "W0_clk"}, !firrtl.sint<8> {firrtl.name = "W0_data"}, !firrtl.uint<1> {firrtl.name = "W0_mask"}) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // INLINE-NEXT:   firrtl.extmodule @ReadMemory_ext(!firrtl.uint<4> {firrtl.name = "R0_addr"}, !firrtl.uint<1> {firrtl.name = "R0_en"}, !firrtl.clock {firrtl.name = "R0_clk"}, !firrtl.flip<sint<8>> {firrtl.name = "R0_data"}) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // INLINE-NEXT:   firrtl.module @Duplicate() {
-// INLINE-NEXT:     %inst_R0_addr, %inst_R0_en, %inst_R0_clk, %inst_R0_data = firrtl.instance @ReadMemory_ext {portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
+// INLINE-NEXT:     %ReadMemory_R0_addr, %ReadMemory_R0_en, %ReadMemory_R0_clk, %ReadMemory_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory", portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
 // INLINE-NEXT:     %0 = firrtl.wire  {name = ""} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
 // INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
-// INLINE-NEXT:     firrtl.connect %1, %inst_R0_addr : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
+// INLINE-NEXT:     firrtl.connect %1, %ReadMemory_R0_addr : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
 // INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %2, %inst_R0_en : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %2, %ReadMemory_R0_en : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %3 = firrtl.subfield %0("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<clock>
-// INLINE-NEXT:     firrtl.connect %3, %inst_R0_clk : !firrtl.flip<clock>, !firrtl.flip<clock>
+// INLINE-NEXT:     firrtl.connect %3, %ReadMemory_R0_clk : !firrtl.flip<clock>, !firrtl.flip<clock>
 // INLINE-NEXT:     %4 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.sint<8>
-// INLINE-NEXT:     firrtl.connect %inst_R0_data, %4 : !firrtl.sint<8>, !firrtl.sint<8>
-// INLINE-NEXT:     %inst_W0_addr, %inst_W0_en, %inst_W0_clk, %inst_W0_data, %inst_W0_mask = firrtl.instance @WriteMemory_ext {portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %ReadMemory_R0_data, %4 : !firrtl.sint<8>, !firrtl.sint<8>
+// INLINE-NEXT:     %WriteMemory_W0_addr, %WriteMemory_W0_en, %WriteMemory_W0_clk, %WriteMemory_W0_data, %WriteMemory_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory", portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.flip<sint<8>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %5 = firrtl.wire  {name = ""} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
 // INLINE-NEXT:     %6 = firrtl.subfield %5("addr") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %6, %inst_W0_addr : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %6, %WriteMemory_W0_addr : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %7 = firrtl.subfield %5("en") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %7, %inst_W0_en : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %7, %WriteMemory_W0_en : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %8 = firrtl.subfield %5("clk") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<clock>
-// INLINE-NEXT:     firrtl.connect %8, %inst_W0_clk : !firrtl.flip<clock>, !firrtl.clock
+// INLINE-NEXT:     firrtl.connect %8, %WriteMemory_W0_clk : !firrtl.flip<clock>, !firrtl.flip<clock>
 // INLINE-NEXT:     %9 = firrtl.subfield %5("data") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<sint<8>>
-// INLINE-NEXT:     firrtl.connect %9, %inst_W0_data : !firrtl.flip<sint<8>>, !firrtl.sint<8>
+// INLINE-NEXT:     firrtl.connect %9, %WriteMemory_W0_data : !firrtl.flip<sint<8>>, !firrtl.flip<sint<8>>
 // INLINE-NEXT:     %10 = firrtl.subfield %5("mask") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %10, %inst_W0_mask : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// INLINE-NEXT:     %inst_R0_addr_0, %inst_R0_en_1, %inst_R0_clk_2, %inst_R0_data_3 = firrtl.instance @ReadMemory_ext {portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
+// INLINE-NEXT:     firrtl.connect %10, %WriteMemory_W0_mask : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
+// INLINE-NEXT:     %ReadMemory1_R0_addr, %ReadMemory1_R0_en, %ReadMemory1_R0_clk, %ReadMemory1_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory1", portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
 // INLINE-NEXT:     %11 = firrtl.wire  {name = ""} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
 // INLINE-NEXT:     %12 = firrtl.subfield %11("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
-// INLINE-NEXT:     firrtl.connect %12, %inst_R0_addr_0 : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
+// INLINE-NEXT:     firrtl.connect %12, %ReadMemory1_R0_addr : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
 // INLINE-NEXT:     %13 = firrtl.subfield %11("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %13, %inst_R0_en_1 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %13, %ReadMemory1_R0_en : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %14 = firrtl.subfield %11("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<clock>
-// INLINE-NEXT:     firrtl.connect %14, %inst_R0_clk_2 : !firrtl.flip<clock>, !firrtl.flip<clock>
+// INLINE-NEXT:     firrtl.connect %14, %ReadMemory1_R0_clk : !firrtl.flip<clock>, !firrtl.flip<clock>
 // INLINE-NEXT:     %15 = firrtl.subfield %11("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.sint<8>
-// INLINE-NEXT:     firrtl.connect %inst_R0_data_3, %15 : !firrtl.sint<8>, !firrtl.sint<8>
-// INLINE-NEXT:     %inst_W0_addr_4, %inst_W0_en_5, %inst_W0_clk_6, %inst_W0_data_7, %inst_W0_mask_8 = firrtl.instance @WriteMemory_ext {portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %ReadMemory1_R0_data, %15 : !firrtl.sint<8>, !firrtl.sint<8>
+// INLINE-NEXT:     %WriteMemory1_W0_addr, %WriteMemory1_W0_en, %WriteMemory1_W0_clk, %WriteMemory1_W0_data, %WriteMemory1_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory1", portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.flip<sint<8>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %16 = firrtl.wire  {name = ""} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
 // INLINE-NEXT:     %17 = firrtl.subfield %16("addr") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %17, %inst_W0_addr_4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %17, %WriteMemory1_W0_addr : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %18 = firrtl.subfield %16("en") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %18, %inst_W0_en_5 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %18, %WriteMemory1_W0_en : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %19 = firrtl.subfield %16("clk") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<clock>
-// INLINE-NEXT:     firrtl.connect %19, %inst_W0_clk_6 : !firrtl.flip<clock>, !firrtl.clock
+// INLINE-NEXT:     firrtl.connect %19, %WriteMemory1_W0_clk : !firrtl.flip<clock>, !firrtl.flip<clock>
 // INLINE-NEXT:     %20 = firrtl.subfield %16("data") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<sint<8>>
-// INLINE-NEXT:     firrtl.connect %20, %inst_W0_data_7 : !firrtl.flip<sint<8>>, !firrtl.sint<8>
+// INLINE-NEXT:     firrtl.connect %20, %WriteMemory1_W0_data : !firrtl.flip<sint<8>>, !firrtl.flip<sint<8>>
 // INLINE-NEXT:     %21 = firrtl.subfield %16("mask") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %21, %inst_W0_mask_8 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// INLINE-NEXT:     %inst_R0_addr_9, %inst_R0_en_10, %inst_R0_clk_11, %inst_R0_data_12 = firrtl.instance @ReadMemory_ext {portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
+// INLINE-NEXT:     firrtl.connect %21, %WriteMemory1_W0_mask : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
+// INLINE-NEXT:     %ReadMemory2_R0_addr, %ReadMemory2_R0_en, %ReadMemory2_R0_clk, %ReadMemory2_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory2", portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
 // INLINE-NEXT:     %22 = firrtl.wire  {name = ""} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
 // INLINE-NEXT:     %23 = firrtl.subfield %22("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
-// INLINE-NEXT:     firrtl.connect %23, %inst_R0_addr_9 : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
+// INLINE-NEXT:     firrtl.connect %23, %ReadMemory2_R0_addr : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
 // INLINE-NEXT:     %24 = firrtl.subfield %22("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %24, %inst_R0_en_10 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %24, %ReadMemory2_R0_en : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %25 = firrtl.subfield %22("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<clock>
-// INLINE-NEXT:     firrtl.connect %25, %inst_R0_clk_11 : !firrtl.flip<clock>, !firrtl.flip<clock>
+// INLINE-NEXT:     firrtl.connect %25, %ReadMemory2_R0_clk : !firrtl.flip<clock>, !firrtl.flip<clock>
 // INLINE-NEXT:     %26 = firrtl.subfield %22("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.sint<8>
-// INLINE-NEXT:     firrtl.connect %inst_R0_data_12, %26 : !firrtl.sint<8>, !firrtl.sint<8>
-// INLINE-NEXT:     %inst_W0_addr_13, %inst_W0_en_14, %inst_W0_clk_15, %inst_W0_data_16, %inst_W0_mask_17 = firrtl.instance @WriteMemory_ext {portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %ReadMemory2_R0_data, %26 : !firrtl.sint<8>, !firrtl.sint<8>
+// INLINE-NEXT:     %WriteMemory2_W0_addr, %WriteMemory2_W0_en, %WriteMemory2_W0_clk, %WriteMemory2_W0_data, %WriteMemory2_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory2", portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.flip<sint<8>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %27 = firrtl.wire  {name = ""} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
 // INLINE-NEXT:     %28 = firrtl.subfield %27("addr") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %28, %inst_W0_addr_13 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %28, %WriteMemory2_W0_addr : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %29 = firrtl.subfield %27("en") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %29, %inst_W0_en_14 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %29, %WriteMemory2_W0_en : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %30 = firrtl.subfield %27("clk") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<clock>
-// INLINE-NEXT:     firrtl.connect %30, %inst_W0_clk_15 : !firrtl.flip<clock>, !firrtl.clock
+// INLINE-NEXT:     firrtl.connect %30, %WriteMemory2_W0_clk : !firrtl.flip<clock>, !firrtl.flip<clock>
 // INLINE-NEXT:     %31 = firrtl.subfield %27("data") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<sint<8>>
-// INLINE-NEXT:     firrtl.connect %31, %inst_W0_data_16 : !firrtl.flip<sint<8>>, !firrtl.sint<8>
+// INLINE-NEXT:     firrtl.connect %31, %WriteMemory2_W0_data : !firrtl.flip<sint<8>>, !firrtl.flip<sint<8>>
 // INLINE-NEXT:     %32 = firrtl.subfield %27("mask") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %32, %inst_W0_mask_17 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %32, %WriteMemory2_W0_mask : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:   }
 // INLINE-NEXT: }


### PR DESCRIPTION
The memory blackboxing pass was incorrectly flipping the element types
on write memories, which have an outermost flip type.  The old code worked
fine for read memories which canonicalized flips into the bundle
subelements.

This change also adds instance names based on the memory names.  This
will produce better looking verilog, while also getting around a
limitation where RTL instances must have names.