### PR TITLE
[LowerToRTL] Ensure we maintain the firrtl sequential semantics when lowering procedural statements

### DIFF
--- a/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
+++ b/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
@@ -770,6 +770,8 @@ struct FIRRTLLowering : public LowerFIRRTLToRTLBase<FIRRTLLowering>,
   void emitRandomizePrologIfNeeded();
   void initializeRegister(Value reg, Value resetSignal);
 
+  void addToProceduralBlock(Value clock, std::function<void(void)> fn);
+
   using FIRRTLVisitor<FIRRTLLowering, LogicalResult>::visitExpr;
   using FIRRTLVisitor<FIRRTLLowering, LogicalResult>::visitDecl;
   using FIRRTLVisitor<FIRRTLLowering, LogicalResult>::visitStmt;
@@ -901,6 +903,12 @@ private:
   /// Each value lowered (e.g. operation result) is kept track in this map.  The
   /// key should have a FIRRTL type, the result will have an RTL dialect type.
   DenseMap<Value, Value> valueMapping;
+
+  /// Each value used as a clock to procedural statements has an always block
+  /// associated with it.  FIRRTL has sequential semantics and we must lower
+  /// sequential procedural statements to the same always block to maintain that
+  /// ordering.
+  DenseMap<Value, sv::AlwaysOp> proceduralBlocks;
 
   /// This is true if we've emitted `INIT_RANDOM_PROLOG_ into an initial block
   /// in this module already.
@@ -1146,6 +1154,19 @@ LogicalResult FIRRTLLowering::setLoweringTo(Operation *orig,
                                             CtorArgTypes... args) {
   auto result = builder->createOrFold<ResultOpType>(args...);
   return setLowering(orig->getResult(0), result);
+}
+
+void FIRRTLLowering::addToProceduralBlock(Value clock,
+                                          std::function<void(void)> fn) {
+  auto &blk = proceduralBlocks[clock];
+  if (!blk)
+    blk = builder->create<sv::AlwaysOp>(EventControl::AtPosEdge, clock, fn);
+  else {
+    auto oldIP = builder->saveInsertionPoint();
+    builder->setInsertionPoint(blk.getBodyBlock()->getTerminator());
+    fn();
+    builder->restoreInsertionPoint(oldIP);
+  }
 }
 
 //===----------------------------------------------------------------------===//
@@ -2194,8 +2215,7 @@ LogicalResult FIRRTLLowering::visitStmt(PrintFOp op) {
     }
   }
 
-  // Emit this into an "sv.always posedge" body.
-  builder->create<sv::AlwaysOp>(EventControl::AtPosEdge, clock, [&]() {
+  addToProceduralBlock(clock, [&]() {
     // Emit an "#ifndef SYNTHESIS" guard into the always block.
     builder->create<sv::IfDefProceduralOp>(
         "SYNTHESIS", std::function<void()>(), [&]() {
@@ -2223,7 +2243,7 @@ LogicalResult FIRRTLLowering::visitStmt(StopOp op) {
     return failure();
 
   // Emit this into an "sv.always posedge" body.
-  builder->create<sv::AlwaysOp>(EventControl::AtPosEdge, clock, [&]() {
+  addToProceduralBlock(clock, [&]() {
     // Emit an "#ifndef SYNTHESIS" guard into the always block.
     builder->create<sv::IfDefProceduralOp>(
         "SYNTHESIS", std::function<void()>(), [&]() {
@@ -2268,7 +2288,7 @@ LogicalResult FIRRTLLowering::lowerVerificationStatement(AOpTy op) {
   if (!clock || !enable || !predicate)
     return failure();
 
-  builder->create<sv::AlwaysOp>(EventControl::AtPosEdge, clock, [&]() {
+  addToProceduralBlock(clock, [&]() {
     builder->create<sv::IfOp>(enable, [&]() {
       // Create BOpTy inside the always/if.
       builder->create<BOpTy>(predicate);

--- a/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
+++ b/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
@@ -908,7 +908,7 @@ private:
   /// associated with it.  FIRRTL has sequential semantics and we must lower
   /// sequential procedural statements to the same always block to maintain that
   /// ordering.
-  DenseMap<Value, sv::AlwaysOp> proceduralBlocks;
+  llvm::SmallDenseMap<Value, sv::AlwaysOp> proceduralBlocks;
 
   /// This is true if we've emitted `INIT_RANDOM_PROLOG_ into an initial block
   /// in this module already.

--- a/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
+++ b/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
@@ -264,13 +264,20 @@ module attributes {firrtl.mainModule = "Simple"} {
     // CHECK-NEXT:       sv.fwrite "No operands!\0A"
     // CHECK-NEXT:     }
     // CHECK-NEXT:   }
-    // CHECK-NEXT: }
+    // CHECK-NEXT:   sv.ifdef.procedural "SYNTHESIS"  {
+    // CHECK-NEXT:     } else  {
+    // CHECK-NEXT:       %3 = sv.textual_value "`PRINTF_COND_" : i1
+    // CHECK-NEXT:       %4 = comb.and %3, %reset : i1
+    // CHECK-NEXT:       sv.if %4  {
+    // CHECK-NEXT:         sv.fwrite "Hi %x %x\0A"(%2, %b) : i5, i4
+    // CHECK-NEXT:       }
+    // CHECK-NEXT:     }
+    // CHECK-NEXT:   }
    firrtl.printf %clock1, %reset1, "No operands!\0A"
 
     // CHECK: [[ADD:%.+]] = comb.add
     %0 = firrtl.add %a1, %a1 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
 
-    // CHECK: sv.fwrite "Hi %x %x\0A"({{.*}}) : i5, i4
     firrtl.printf %clock1, %reset1, "Hi %x %x\0A"(%0, %b1) : !firrtl.uint<5>, !firrtl.uint<4>
 
     firrtl.skip
@@ -346,19 +353,15 @@ module attributes {firrtl.mainModule = "Simple"} {
     // CHECK-NEXT:   sv.if %aEn {
     // CHECK-NEXT:     sv.assert %aCond : i1
     // CHECK-NEXT:   }
-    // CHECK-NEXT: }
-    firrtl.assert %clockC, %aCondC, %aEnC, "assert0"
-    // CHECK-NEXT: sv.always posedge %clock {
     // CHECK-NEXT:   sv.if %bEn {
     // CHECK-NEXT:     sv.assume %bCond  : i1
     // CHECK-NEXT:   }
-    // CHECK-NEXT: }
-    firrtl.assume %clockC, %bCondC, %bEnC, "assume0"
-    // CHECK-NEXT: sv.always posedge %clock {
     // CHECK-NEXT:   sv.if %cEn {
     // CHECK-NEXT:     sv.cover %cCond : i1
     // CHECK-NEXT:   }
     // CHECK-NEXT: }
+    firrtl.assert %clockC, %aCondC, %aEnC, "assert0"
+    firrtl.assume %clockC, %bCondC, %bEnC, "assume0"
     firrtl.cover %clockC, %cCondC, %cEnC, "cover0"
     // CHECK-NEXT: rtl.output
     rtl.output


### PR DESCRIPTION
The body of always blocks are not ordered with respect to other always blocks.  FIRRTL semantics say printf (and friends) have sequential semantics in a module, thus they need to be lowered to a common always block.  We can't do this via merging later as that's just best-effort and could result in different orders.

closes #666 
