### PR TITLE
Update LLVM to c68d2895a1f4019b387c69d1e5eec31b0eb5e7b0

### DIFF
--- a/tools/llhd-sim/llhd-sim.cpp
+++ b/tools/llhd-sim/llhd-sim.cpp
@@ -21,6 +21,7 @@
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/FileUtilities.h"
 #include "mlir/Target/LLVMIR.h"
+#include "mlir/Target/LLVMIR/Export.h"
 #include "mlir/Transforms/Passes.h"
 
 #include "llvm/Support/InitLLVM.h"
@@ -163,6 +164,7 @@ int main(int argc, char **argv) {
   // Load the dialects
   context
       .loadDialect<llhd::LLHDDialect, LLVM::LLVMDialect, StandardOpsDialect>();
+  mlir::registerLLVMDialectTranslation(context);
 
   OwningModuleRef module(parseSourceFile(mgr, &context));
 


### PR DESCRIPTION
* Need to include a new header in LLHD sim for LLVM translations
* Need to explicitly register the LLVM translations