### PR TITLE
[FIRRTL] Lower registers in LowerTypes

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -370,20 +370,23 @@ void FIRRTLTypesLowering::visitDecl(RegOp op) {
 
   // Attempt to get the bundle types, potentially unwrapping an outer flip type
   // that wraps the whole bundle.
-  BundleType resultType = getCanonicalBundleType(result.getType());
+  FIRRTLType resultType = getCanonicalAggregateType(result.getType());
 
   // If the reg is not a bundle, there is nothing to do.
   if (!resultType)
     return;
 
   SmallVector<FlatBundleFieldEntry, 8> fieldTypes;
-  flattenBundleTypes(resultType, "", false, fieldTypes);
+  flattenType(resultType, "", false, fieldTypes);
 
   // Loop over the leaf aggregates.
   for (auto field : fieldTypes) {
+    SmallString<16> loweredName(op.nameAttr().getValue());
+    loweredName += field.suffix;
     setBundleLowering(
         result, StringRef(field.suffix).drop_front(1),
-        builder->create<RegOp>(field.getPortType(), op.clockVal()));
+        builder->create<RegOp>(field.getPortType(), op.clockVal(),
+                               builder->getStringAttr(loweredName)));
   }
 
   // Remember to remove the original op.

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -97,6 +97,7 @@ struct FIRRTLTypesLowering : public LowerFIRRTLTypesBase<FIRRTLTypesLowering>,
   void visitDecl(InstanceOp op);
   void visitDecl(MemOp op);
   void visitExpr(SubfieldOp op);
+  void visitDecl(RegOp op);
   void visitStmt(ConnectOp op);
   void visitExpr(InvalidValuePrimOp op);
 
@@ -354,10 +355,37 @@ void FIRRTLTypesLowering::visitDecl(MemOp op) {
   opsToRemove.push_back(op);
 }
 
+/// Lower a reg op with a bundle to multiple non-bundled regs.
+void FIRRTLTypesLowering::visitDecl(RegOp op) {
+  Value result = op.result();
+
+  // Attempt to get the bundle types, potentially unwrapping an outer flip type
+  // that wraps the whole bundle.
+  BundleType resultType = getCanonicalBundleType(result.getType());
+
+  // If the reg is not a bundle, there is nothing to do.
+  if (!resultType)
+    return;
+
+  SmallVector<FlatBundleFieldEntry, 8> fieldTypes;
+  flattenBundleTypes(resultType, "", false, fieldTypes);
+
+  // Loop over the leaf aggregates.
+  for (auto field : fieldTypes) {
+    setBundleLowering(
+        result, StringRef(field.suffix).drop_front(1),
+        builder->create<RegOp>(field.getPortType(), op.clockVal()));
+  }
+
+  // Remember to remove the original op.
+  opsToRemove.push_back(op);
+}
+
 // Lowering subfield operations has to deal with three different cases:
 //   a) the input value is from a module block argument
 //   b) the input value is from another subfield operation's result
 //   c) the input value is from an instance
+//   d) the input value is from a register
 //
 // This is accomplished by storing value and suffix mappings that point to the
 // flattened value. If the subfield op is accessing the leaf field of a bundle,

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -294,3 +294,20 @@ module  {
     }
   }
 }
+
+  firrtl.circuit "RegBundle" {
+//CHECK-LABEL: firrtl.module @RegBundle(%a_a: !firrtl.uint<1>, %clk: !firrtl.clock, %b_a: !firrtl.flip<uint<1>>) {
+//CHECK-NEXT: %0 = firrtl.reg %clk : (!firrtl.clock) -> !firrtl.uint<1>
+//CHECK-NEXT: firrtl.connect %0, %a_a : !firrtl.uint<1>, !firrtl.uint<1>
+//CHECK-NEXT: firrtl.connect %b_a, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+    firrtl.module @RegBundle(%a: !firrtl.bundle<a: uint<1>>, %clk: !firrtl.clock, %b: !firrtl.flip<bundle<a: uint<1>>>) {
+      %x = firrtl.reg %clk {name = "x"} : (!firrtl.clock) -> !firrtl.bundle<a: uint<1>>
+      %0 = firrtl.subfield %x("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+      %1 = firrtl.subfield %a("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+      firrtl.connect %0, %1 : !firrtl.uint<1>, !firrtl.uint<1>
+      %2 = firrtl.subfield %b("a") : (!firrtl.flip<bundle<a: uint<1>>>) -> !firrtl.flip<uint<1>>
+      %3 = firrtl.subfield %x("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+      firrtl.connect %2, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+    }
+  
+}

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -297,9 +297,9 @@ module  {
 
   firrtl.circuit "RegBundle" {
 //CHECK-LABEL: firrtl.module @RegBundle(%a_a: !firrtl.uint<1>, %clk: !firrtl.clock, %b_a: !firrtl.flip<uint<1>>) {
-//CHECK-NEXT: %0 = firrtl.reg %clk : (!firrtl.clock) -> !firrtl.uint<1>
-//CHECK-NEXT: firrtl.connect %0, %a_a : !firrtl.uint<1>, !firrtl.uint<1>
-//CHECK-NEXT: firrtl.connect %b_a, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+//CHECK-NEXT: %x_a = firrtl.reg %clk {name = "x_a"} : (!firrtl.clock) -> !firrtl.uint<1>
+//CHECK-NEXT: firrtl.connect %x_a, %a_a : !firrtl.uint<1>, !firrtl.uint<1>
+//CHECK-NEXT: firrtl.connect %b_a, %x_a : !firrtl.flip<uint<1>>, !firrtl.uint<1>
     firrtl.module @RegBundle(%a: !firrtl.bundle<a: uint<1>>, %clk: !firrtl.clock, %b: !firrtl.flip<bundle<a: uint<1>>>) {
       %x = firrtl.reg %clk {name = "x"} : (!firrtl.clock) -> !firrtl.bundle<a: uint<1>>
       %0 = firrtl.subfield %x("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
@@ -309,6 +309,7 @@ module  {
       %3 = firrtl.subfield %x("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
       firrtl.connect %2, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
     }
+}
   
 // -----
 // COM: Test vector lowering


### PR DESCRIPTION
Add support for lowering aggregate registers in FIRRTL dialect's type lowering pass.
Just adding the visitor for registers was required.
Fix for https://github.com/llvm/circt/issues/682