### PR TITLE
[Comb] Additional mux canonicalization

### DIFF
--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -744,7 +744,7 @@ static mlir::Value sextToDestTypeAndFlip(mlir::Value op, Type destType,
                                          PatternRewriter &rewriter) {
   op = sextToDestType(op, destType, rewriter);
   Value newOperands[] = {
-      op, rewriter.create<ConstantOp>(op.getLoc(), destType, -1)};
+      op, rewriter.create<rtl::ConstantOp>(op.getLoc(), destType, -1)};
   return rewriter.create<XorOp>(op.getLoc(), destType, newOperands);
 }
 

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -734,38 +734,63 @@ OpFoldResult MuxOp::fold(ArrayRef<Attribute> constants) {
   return {};
 }
 
+static mlir::Value sextToDestType(mlir::Value op, Type destType,
+                                  PatternRewriter &rewriter) {
+  auto width = destType.cast<IntegerType>().getWidth();
+  if (width > 1)
+    op = rewriter.create<SExtOp>(op.getLoc(), destType, op);
+  return op;
+}
+
+static mlir::Value sextToDestTypeAndFlip(mlir::Value op, Type destType,
+                                         PatternRewriter &rewriter) {
+  op = sextToDestType(op, destType, rewriter);
+  Value newOperands[] = {
+      op, rewriter.create<ConstantOp>(op.getLoc(), destType, -1)};
+  return rewriter.create<XorOp>(op.getLoc(), destType, newOperands);
+}
+
 void MuxOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
                                         MLIRContext *context) {
   struct Folder final : public OpRewritePattern<MuxOp> {
     using OpRewritePattern::OpRewritePattern;
     LogicalResult matchAndRewrite(MuxOp op,
                                   PatternRewriter &rewriter) const override {
-      auto width = op.getType().cast<IntegerType>().getWidth();
 
       APInt value;
 
-      // mux(a, 11...1, b) -> or(a, b)
       if (matchPattern(op.trueValue(), m_RConstant(value))) {
+        // mux(a, 11...1, b) -> or(a, b)
         if (value.isAllOnesValue()) {
-          auto cond = op.cond();
-          if (width > 1)
-            cond = rewriter.createOrFold<SExtOp>(op.getLoc(), op.getType(),
-                                                 op.cond());
+          auto cond = sextToDestType(op.cond(), op.getType(), rewriter);
           Value newOperands[] = {cond, op.falseValue()};
           rewriter.replaceOpWithNewOp<OrOp>(op, op.getType(), newOperands);
           return success();
         }
+
+        // mux(a, 0, b) -> and(not(a), b)
+        if (value.isNullValue()) {
+          auto cond = sextToDestTypeAndFlip(op.cond(), op.getType(), rewriter);
+          Value newOperands[] = {cond, op.falseValue()};
+          rewriter.replaceOpWithNewOp<AndOp>(op, op.getType(), newOperands);
+          return success();
+        }
       }
 
-      // mux(a, b, 0) -> and(a, b)
       if (matchPattern(op.falseValue(), m_RConstant(value))) {
+        // mux(a, b, 0) -> and(a, b)
         if (value.isNullValue()) {
-          auto cond = op.cond();
-          if (width > 1)
-            cond = rewriter.createOrFold<SExtOp>(op.getLoc(), op.getType(),
-                                                 op.cond());
+          auto cond = sextToDestType(op.cond(), op.getType(), rewriter);
           Value newOperands[] = {cond, op.trueValue()};
           rewriter.replaceOpWithNewOp<AndOp>(op, op.getType(), newOperands);
+          return success();
+        }
+
+        // mux(a, b, 11...1) -> or(not(a), b)
+        if (value.isAllOnesValue()) {
+          auto cond = sextToDestTypeAndFlip(op.cond(), op.getType(), rewriter);
+          Value newOperands[] = {cond, op.trueValue()};
+          rewriter.replaceOpWithNewOp<OrOp>(op, op.getType(), newOperands);
           return success();
         }
       }

--- a/test/Dialect/RTL/canonicalization.mlir
+++ b/test/Dialect/RTL/canonicalization.mlir
@@ -805,8 +805,8 @@ rtl.module @mux_canonicalize3(%a: i1, %b: i4) -> (i4) {
 }
 
 // CHECK-LABEL: rtl.module @mux_canonicalize4(%a: i1, %b: i1, %c: i4) -> (i1, i1, i4, i4) {
-// CHECK-NEXT:   %true = comb.constant true
-// CHECK-NEXT:   %c-1_i4 = comb.constant -1 : i4
+// CHECK-NEXT:   %true = rtl.constant true
+// CHECK-NEXT:   %c-1_i4 = rtl.constant -1 : i4
 // CHECK-NEXT:   %0 = comb.xor %a, %true : i1
 // CHECK-NEXT:   %1 = comb.and %0, %b : i1
 // CHECK-NEXT:   %2 = comb.xor %a, %true : i1
@@ -819,7 +819,7 @@ rtl.module @mux_canonicalize3(%a: i1, %b: i4) -> (i4) {
 // CHECK-NEXT:   %9 = comb.and %8, %c : i4
 // CHECK-NEXT: rtl.output %1, %3, %6, %9 : i1, i1, i4, i4
 rtl.module @mux_canonicalize4(%a: i1, %b: i1, %c: i4) -> (i1, i1, i4, i4) {
-  %false = comb.constant false
+  %false = rtl.constant false
   %0 = comb.mux %a, %false, %b : i1
 
   %true = comb.constant true

--- a/test/Dialect/RTL/canonicalization.mlir
+++ b/test/Dialect/RTL/canonicalization.mlir
@@ -804,50 +804,33 @@ rtl.module @mux_canonicalize3(%a: i1, %b: i4) -> (i4) {
   rtl.output %0 : i4
 }
 
-// CHECK-LABEL: rtl.module @mux_canonicalize4(%a: i1, %b: i1) -> (i1) {
+// CHECK-LABEL: rtl.module @mux_canonicalize4(%a: i1, %b: i1, %c: i4) -> (i1, i1, i4, i4) {
 // CHECK-NEXT:   %true = comb.constant true
+// CHECK-NEXT:   %c-1_i4 = comb.constant -1 : i4
 // CHECK-NEXT:   %0 = comb.xor %a, %true : i1
 // CHECK-NEXT:   %1 = comb.and %0, %b : i1
-// CHECK-NEXT:  rtl.output %1 : i1
-rtl.module @mux_canonicalize4(%a: i1, %b: i1) -> (i1) {
+// CHECK-NEXT:   %2 = comb.xor %a, %true : i1
+// CHECK-NEXT:   %3 = comb.or %2, %b : i1
+// CHECK-NEXT:   %4 = comb.sext %a : (i1) -> i4
+// CHECK-NEXT:   %5 = comb.xor %4, %c-1_i4 : i4
+// CHECK-NEXT:   %6 = comb.or %5, %c : i4
+// CHECK-NEXT:   %7 = comb.sext %a : (i1) -> i4
+// CHECK-NEXT:   %8 = comb.xor %7, %c-1_i4 : i4
+// CHECK-NEXT:   %9 = comb.and %8, %c : i4
+// CHECK-NEXT: rtl.output %1, %3, %6, %9 : i1, i1, i4, i4
+rtl.module @mux_canonicalize4(%a: i1, %b: i1, %c: i4) -> (i1, i1, i4, i4) {
   %false = comb.constant false
   %0 = comb.mux %a, %false, %b : i1
-  rtl.output %0 : i1
-}
 
-// CHECK-LABEL: rtl.module @mux_canonicalize5(%a: i1, %b: i1) -> (i1) {
-// CHECK-NEXT:   %true = comb.constant true
-// CHECK-NEXT:   %0 = comb.xor %a, %true : i1
-// CHECK-NEXT:   %1 = comb.or %0, %b : i1
-// CHECK-NEXT:  rtl.output %1 : i1
-rtl.module @mux_canonicalize5(%a: i1, %b: i1) -> (i1) {
   %true = comb.constant true
-  %0 = comb.mux %a, %b, %true : i1
-  rtl.output %0 : i1
-}
+  %1 = comb.mux %a, %b, %true : i1
 
-// CHECK-LABEL: rtl.module @mux_canonicalize6(%a: i1, %b: i4) -> (i4) {
-// CHECK-NEXT:   %c-1_i4 = comb.constant -1 : i4
-// CHECK-NEXT:   %0 = comb.sext %a : (i1) -> i4
-// CHECK-NEXT:   %1 = comb.xor %0, %c-1_i4 : i4
-// CHECK-NEXT:   %2 = comb.or %1, %b : i4
-// CHECK-NEXT:  rtl.output %2 : i4
-rtl.module @mux_canonicalize6(%a: i1, %b: i4) -> (i4) {
   %c-1_i4 = comb.constant -1 : i4
-  %0 = comb.mux %a, %b, %c-1_i4 : i4
-  rtl.output %0 : i4
-}
+  %2 = comb.mux %a, %c, %c-1_i4 : i4
 
-// CHECK-LABEL: rtl.module @mux_canonicalize7(%a: i1, %b: i4) -> (i4) {
-// CHECK-NEXT:   %c-1_i4 = comb.constant -1 : i4
-// CHECK-NEXT:   %0 = comb.sext %a : (i1) -> i4
-// CHECK-NEXT:   %1 = comb.xor %0, %c-1_i4 : i4
-// CHECK-NEXT:   %2 = comb.and %1, %b : i4
-// CHECK-NEXT:  rtl.output %2 : i4
-rtl.module @mux_canonicalize7(%a: i1, %b: i4) -> (i4) {
   %c0_i4 = comb.constant 0 : i4
-  %0 = comb.mux %a, %c0_i4, %b : i4
-  rtl.output %0 : i4
+  %3 = comb.mux %a, %c0_i4, %c : i4
+  rtl.output %0, %1, %2, %3 : i1, i1, i4, i4
 }
 
 // CHECK-LABEL: rtl.module @icmp_fold_1bit_eq1(%arg: i1) -> (i1, i1, i1, i1) {

--- a/test/Dialect/RTL/canonicalization.mlir
+++ b/test/Dialect/RTL/canonicalization.mlir
@@ -822,13 +822,13 @@ rtl.module @mux_canonicalize4(%a: i1, %b: i1, %c: i4) -> (i1, i1, i4, i4) {
   %false = rtl.constant false
   %0 = comb.mux %a, %false, %b : i1
 
-  %true = comb.constant true
+  %true = rtl.constant true
   %1 = comb.mux %a, %b, %true : i1
 
-  %c-1_i4 = comb.constant -1 : i4
+  %c-1_i4 = rtl.constant -1 : i4
   %2 = comb.mux %a, %c, %c-1_i4 : i4
 
-  %c0_i4 = comb.constant 0 : i4
+  %c0_i4 = rtl.constant 0 : i4
   %3 = comb.mux %a, %c0_i4, %c : i4
   rtl.output %0, %1, %2, %3 : i1, i1, i4, i4
 }

--- a/test/Dialect/RTL/canonicalization.mlir
+++ b/test/Dialect/RTL/canonicalization.mlir
@@ -804,6 +804,52 @@ rtl.module @mux_canonicalize3(%a: i1, %b: i4) -> (i4) {
   rtl.output %0 : i4
 }
 
+// CHECK-LABEL: rtl.module @mux_canonicalize4(%a: i1, %b: i1) -> (i1) {
+// CHECK-NEXT:   %true = comb.constant true
+// CHECK-NEXT:   %0 = comb.xor %a, %true : i1
+// CHECK-NEXT:   %1 = comb.and %0, %b : i1
+// CHECK-NEXT:  rtl.output %1 : i1
+rtl.module @mux_canonicalize4(%a: i1, %b: i1) -> (i1) {
+  %false = comb.constant false
+  %0 = comb.mux %a, %false, %b : i1
+  rtl.output %0 : i1
+}
+
+// CHECK-LABEL: rtl.module @mux_canonicalize5(%a: i1, %b: i1) -> (i1) {
+// CHECK-NEXT:   %true = comb.constant true
+// CHECK-NEXT:   %0 = comb.xor %a, %true : i1
+// CHECK-NEXT:   %1 = comb.or %0, %b : i1
+// CHECK-NEXT:  rtl.output %1 : i1
+rtl.module @mux_canonicalize5(%a: i1, %b: i1) -> (i1) {
+  %true = comb.constant true
+  %0 = comb.mux %a, %b, %true : i1
+  rtl.output %0 : i1
+}
+
+// CHECK-LABEL: rtl.module @mux_canonicalize6(%a: i1, %b: i4) -> (i4) {
+// CHECK-NEXT:   %c-1_i4 = comb.constant -1 : i4
+// CHECK-NEXT:   %0 = comb.sext %a : (i1) -> i4
+// CHECK-NEXT:   %1 = comb.xor %0, %c-1_i4 : i4
+// CHECK-NEXT:   %2 = comb.or %1, %b : i4
+// CHECK-NEXT:  rtl.output %2 : i4
+rtl.module @mux_canonicalize6(%a: i1, %b: i4) -> (i4) {
+  %c-1_i4 = comb.constant -1 : i4
+  %0 = comb.mux %a, %b, %c-1_i4 : i4
+  rtl.output %0 : i4
+}
+
+// CHECK-LABEL: rtl.module @mux_canonicalize7(%a: i1, %b: i4) -> (i4) {
+// CHECK-NEXT:   %c-1_i4 = comb.constant -1 : i4
+// CHECK-NEXT:   %0 = comb.sext %a : (i1) -> i4
+// CHECK-NEXT:   %1 = comb.xor %0, %c-1_i4 : i4
+// CHECK-NEXT:   %2 = comb.and %1, %b : i4
+// CHECK-NEXT:  rtl.output %2 : i4
+rtl.module @mux_canonicalize7(%a: i1, %b: i4) -> (i4) {
+  %c0_i4 = comb.constant 0 : i4
+  %0 = comb.mux %a, %c0_i4, %b : i4
+  rtl.output %0 : i4
+}
+
 // CHECK-LABEL: rtl.module @icmp_fold_1bit_eq1(%arg: i1) -> (i1, i1, i1, i1) {
 // CHECK-NEXT:   %true = comb.constant true
 // CHECK-NEXT:   %0 = comb.xor %arg, %true : i1


### PR DESCRIPTION
This is the follow-up to #648.
```
mux(a, false, b) => and(not(a), b)
mux(a, b, true) => or(not(a), b)
```
Will close #635.