### PR TITLE
[FIRRTL LowerTypes] Lower bundle wire connects in lower-types

### DIFF
--- a/docs/RationaleFIRRTL.md
+++ b/docs/RationaleFIRRTL.md
@@ -132,6 +132,21 @@ means about left-hand-side and right-hand-side connections. CIRCT consequently
 accepts all permutations of `a <= b` and types which canonicalize to the same
 representation.
 
+### Flow
+
+The FIRRTL specification describes the concept of "flow" to track whether a
+value is a `sink`, `source`, or `duplex`. In the specification, module inputs
+are `source`, while module outputs are a `sink`. The `duplex` flow type is
+used for values which can be read and written to, such as registers and
+wires. In a connect statement, the LHS must be a `sink` or a `duplex` type,
+while the RHS must be `source` or a `duplex`.
+
+Due to the flip canonicalization in the MLIR implementation, the compiler no
+longer distinguishes between inputs and outputs. As a result, the only
+requirement of a connect statement is that the LHS side is a flip type or a
+`duplex` value. In the new compiler, you can always read from a flip type, so
+there is no verification of the RHS of a connect statement.
+
 ## Operations
 
 ### Multiple result `firrtl.instance` operation

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -58,12 +58,10 @@ void getModulePortInfo(Operation *op, SmallVectorImpl<ModulePortInfo> &results);
 /// Returns true if the type is a bundle or a flip of a bundle.
 bool isBundleType(Type type);
 
-// Returns true if the operation is an expression with duplex flow. Duplex flow
-// has special treatment in bundle connect operations, and affects the
-// determination of the connect algorithm.
-bool isDuplexOp(Operation *op);
-
 /// Returns true if the value results from an expression with duplex flow.
+/// Duplex values have special treatment in bundle connect operations, and their
+/// flip orientation is not used to determine the direction of each pairwise
+/// connect.
 bool isDuplexValue(Value val);
 
 } // namespace firrtl

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -55,6 +55,17 @@ FunctionType getModuleType(Operation *op);
 /// extmodule.
 void getModulePortInfo(Operation *op, SmallVectorImpl<ModulePortInfo> &results);
 
+/// Returns true if the type is a bundle or a flip of a bundle.
+bool isBundleType(Type type);
+
+// Returns true if the operation is an expression with duplex flow. Duplex flow
+// has special treatment in bundle connect operations, and affects the
+// determination of the connect algorithm.
+bool isDuplexOp(Operation *op);
+
+/// Returns true if the value results from an expression with duplex flow.
+bool isDuplexValue(Value val);
+
 } // namespace firrtl
 } // namespace circt
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -25,6 +25,27 @@
 using namespace circt;
 using namespace firrtl;
 
+bool firrtl::isBundleType(Type type) {
+  if (type.isa<FlipType>())
+    return type.cast<FlipType>().getElementType().isa<BundleType>();
+  return type.isa<BundleType>();
+}
+
+bool firrtl::isDuplexOp(Operation *op) {
+  // Using typeswitch is a typesafe way to call input() on three different ops.
+  return TypeSwitch<Operation *, bool>(op)
+      .Case<SubfieldOp, SubindexOp, SubaccessOp>(
+          [](auto op) { return isDuplexValue(op.input()); })
+      .Case<RegOp, RegResetOp, WireOp>([](auto) { return true; })
+      .Default([](auto) { return false; });
+}
+
+bool firrtl::isDuplexValue(Value val) {
+  if (Operation *op = val.getDefiningOp())
+    return isDuplexOp(op);
+  return false;
+}
+
 //===----------------------------------------------------------------------===//
 // VERIFY_RESULT_TYPE / VERIFY_RESULT_TYPE_RET
 //===----------------------------------------------------------------------===//
@@ -891,10 +912,8 @@ Value MemOp::getPortNamed(StringAttr name) {
 //===----------------------------------------------------------------------===//
 
 static LogicalResult verifyConnectOp(ConnectOp connect) {
-  FIRRTLType destType =
-      connect.dest().getType().cast<FIRRTLType>().getPassiveType();
-  FIRRTLType srcType =
-      connect.src().getType().cast<FIRRTLType>().getPassiveType();
+  FIRRTLType destType = connect.dest().getType().cast<FIRRTLType>();
+  FIRRTLType srcType = connect.src().getType().cast<FIRRTLType>();
 
   // Analog types cannot be connected and must be attached.
   if (destType.isa<AnalogType>() || srcType.isa<AnalogType>())
@@ -903,18 +922,37 @@ static LogicalResult verifyConnectOp(ConnectOp connect) {
   // Destination and source types must be equivalent.
   if (!areTypesEquivalent(destType, srcType))
     return connect.emitError("type mismatch between destination ")
-           << destType << " and source " << srcType;
+           << destType.getPassiveType() << " and source "
+           << srcType.getPassiveType();
 
   // Destination bitwidth must be greater than or equal to source bitwidth.
-  int32_t destWidth = destType.getBitWidthOrSentinel();
-  int32_t srcWidth = srcType.getBitWidthOrSentinel();
+  int32_t destWidth = destType.getPassiveType().getBitWidthOrSentinel();
+  int32_t srcWidth = srcType.getPassiveType().getBitWidthOrSentinel();
   if (destWidth > -1 && srcWidth > -1 && destWidth < srcWidth)
     return connect.emitError("destination width ")
            << destWidth << " is not greater than or equal to source width "
            << srcWidth;
 
-  // TODO(mikeurbach): verify destination flow is sink or duplex.
-  // TODO(mikeurbach): verify source flow is source or duplex.
+  // Check that the LHS is a valid sink and RHS is a valid source.
+  if (isBundleType(destType)) {
+    // For bulk connections, we need to make sure that the connection is
+    // unambiguous by making sure that both sides are not duplex types. TODO: we
+    // are not checking that the connections are recursively well formed when
+    // neither is a duplex type.
+    if (isDuplexValue(connect.dest()) && isDuplexValue(connect.src())) {
+      return connect.emitOpError() << "ambiguous bulk connection between two "
+                                   << "duplex values of bundle type";
+    }
+  } else {
+    // This is a mono-connection. Check that the LHS side is a sink or duplex.
+    // Since we can read from a either a passive or flip type, we don't need to
+    // check anything on the RHS.
+    if (destType.isPassive() && !isDuplexValue(connect.dest())) {
+      return connect.emitOpError("connection destination must be a non-passive "
+                                 "type or a duplex value");
+    }
+  }
+
   return success();
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -586,7 +586,7 @@ void TypeLoweringVisitor::visitDecl(RegOp op) {
 //   a) the input value is from a module block argument
 //   b) the input value is from another subfield operation's result
 //   c) the input value is from an instance
-//   d) the input value is from a register
+//   d) the input value is from a duplex op, such as a wire or register
 //
 // This is accomplished by storing value and suffix mappings that point to the
 // flattened value. If the subfield op is accessing the leaf field of a bundle,
@@ -670,6 +670,7 @@ void TypeLoweringVisitor::visitExpr(SubindexOp op) {
 // bundle that was:
 //   a) originally a block argument
 //   b) originally an instance's port
+//   c) originally from a duplex operation, like a wire or register.
 //
 // When two such bundles are connected, none of the subfield visits have a
 // chance to lower them, so we must ensure they have the same number of
@@ -698,13 +699,33 @@ void TypeLoweringVisitor::visitStmt(ConnectOp op) {
   assert(destValues.size() == srcValues.size() &&
          "connected bundles don't match");
 
+  // Determine if the LHS expression is the duplex value.
+  auto isDestDuplex = isDuplexValue(destValues.front());
+
   for (auto tuple : llvm::zip_first(destValues, srcValues)) {
     Value newDest = std::get<0>(tuple);
     Value newSrc = std::get<1>(tuple);
-    if (newDest.getType().isa<FlipType>())
-      builder->create<ConnectOp>(newDest, newSrc);
-    else
-      builder->create<ConnectOp>(newSrc, newDest);
+
+    // When two bundles are bulk connected, the connect operation becomes a
+    // pair-wise connect of each field. The rules for flow state that a value
+    // from a duplex expression can be used as both a source and sink,
+    // regardless of the flip orientation of the type. To make this work, we
+    // find the non-duplex value and make sure that it is the in the correct
+    // position. Two duplex values cannot be connected, since it is unclear
+    // which side is left or right.
+    if (isDestDuplex) {
+      if (newSrc.getType().isa<FlipType>()) {
+        builder->create<ConnectOp>(newSrc, newDest);
+      } else {
+        builder->create<ConnectOp>(newDest, newSrc);
+      }
+    } else {
+      if (!newDest.getType().isa<FlipType>()) {
+        builder->create<ConnectOp>(newSrc, newDest);
+      } else {
+        builder->create<ConnectOp>(newDest, newSrc);
+      }
+    }
   }
 
   // Remember to remove the original op.

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -715,10 +715,10 @@ void TypeLoweringVisitor::visitStmt(ConnectOp op) {
     // which side is left or right.
     if (isDestDuplex ? newSrc.getType().isa<FlipType>()
                      : !newDest.getType().isa<FlipType>()) {
-      builder->create<ConnectOp>(newSrc, newDest);
-    } else {
-      builder->create<ConnectOp>(newDest, newSrc);
+      std::swap(newSrc, newDest);
     }
+
+    builder->create<ConnectOp>(newDest, newSrc);
   }
 
   // Remember to remove the original op.

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -713,18 +713,11 @@ void TypeLoweringVisitor::visitStmt(ConnectOp op) {
     // find the non-duplex value and make sure that it is the in the correct
     // position. Two duplex values cannot be connected, since it is unclear
     // which side is left or right.
-    if (isDestDuplex) {
-      if (newSrc.getType().isa<FlipType>()) {
-        builder->create<ConnectOp>(newSrc, newDest);
-      } else {
-        builder->create<ConnectOp>(newDest, newSrc);
-      }
+    if (isDestDuplex ? newSrc.getType().isa<FlipType>()
+                     : !newDest.getType().isa<FlipType>()) {
+      builder->create<ConnectOp>(newSrc, newDest);
     } else {
-      if (!newDest.getType().isa<FlipType>()) {
-        builder->create<ConnectOp>(newSrc, newDest);
-      } else {
-        builder->create<ConnectOp>(newDest, newSrc);
-      }
+      builder->create<ConnectOp>(newDest, newSrc);
     }
   }
 

--- a/test/Dialect/FIRRTL/connect-errors.mlir
+++ b/test/Dialect/FIRRTL/connect-errors.mlir
@@ -249,6 +249,17 @@ firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>>, %b : !firrtl.bundle<f1: fl
 }
 }
 
+// -----
+
+firrtl.circuit "test" {
+firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>>, %b : !firrtl.flip<bundle<f1: uint<1>>>) {
+  %0 = firrtl.subfield %a("f1") : (!firrtl.bundle<f1: uint<1>>) -> !firrtl.uint<1>
+  %1 = firrtl.subfield %b("f1") : (!firrtl.flip<bundle<f1: uint<1>>>) -> !firrtl.flip<uint<1>>
+  // expected-error @+1 {{connection destination must be a non-passive type or a duplex value}}
+  firrtl.connect %0, %1 : !firrtl.uint<1>, !firrtl.flip<uint<1>>
+}
+}
+
 /// Destination bitwidth must be greater than or equal to source bitwidth.
 
 // -----

--- a/test/Dialect/FIRRTL/connect-errors.mlir
+++ b/test/Dialect/FIRRTL/connect-errors.mlir
@@ -1,6 +1,13 @@
 
 // RUN: circt-opt %s -split-input-file -verify-diagnostics
 
+firrtl.circuit "test" {
+firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<uint<1>>) {
+  // expected-error @+1 {{connection destination must be a non-passive type or a duplex value}}
+  firrtl.connect %a, %b : !firrtl.uint<1>, !firrtl.flip<uint<1>>
+}
+}
+
 /// Analog types cannot be connected and must be attached.
 
 // -----
@@ -250,5 +257,17 @@ firrtl.circuit "test" {
 firrtl.module @test(%a : !firrtl.uint<2>, %b : !firrtl.flip<uint<1>>) {
   // expected-error @+1 {{destination width 1 is not greater than or equal to source width 2}}
   firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.uint<2>
+}
+}
+
+// -----
+
+// Two duplex values with bundle types can not be bulk connected.
+firrtl.circuit "test" {
+firrtl.module @test(%clock : !firrtl.clock) {
+  %w = firrtl.wire : !firrtl.bundle<a : uint<1>>
+  %r = firrtl.reg %clock : (!firrtl.clock) -> !firrtl.bundle<a: uint<1>>
+  // expected-error @+1 {{ambiguous bulk connection between two duplex values of bundle type}}
+  firrtl.connect %r, %w : !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>
 }
 }

--- a/test/Dialect/FIRRTL/connect.mlir
+++ b/test/Dialect/FIRRTL/connect.mlir
@@ -130,6 +130,15 @@ firrtl.module @wires4(%out : !firrtl.flip<uint<1>>) {
   firrtl.connect %wf, %out : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
 }
 
+firrtl.module @wires5(%in : !firrtl.uint<1>, %out : !firrtl.flip<uint<1>>) {
+  %w = firrtl.wire : !firrtl.bundle<a: uint<1>>
+  %0 = firrtl.subfield %w("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+  // CHECK: firrtl.connect %0, %in : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK: firrtl.connect %out, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %0, %in : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %out, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+}
+
 firrtl.module @registers0(%clock : !firrtl.clock, %in : !firrtl.uint<1>, %out : !firrtl.flip<uint<1>>) {
   %0 = firrtl.reg %clock : (!firrtl.clock) -> !firrtl.uint<1>
   // CHECK: firrtl.connect %0, %in : !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/connect.mlir
+++ b/test/Dialect/FIRRTL/connect.mlir
@@ -93,4 +93,56 @@ firrtl.module @partial_bitwidth(%a : !firrtl.uint<2>, %b : !firrtl.flip<uint<1>>
   firrtl.partialconnect %b, %a : !firrtl.flip<uint<1>>, !firrtl.uint<2>
 }
 
+firrtl.module @wires0(%in : !firrtl.uint<1>, %out : !firrtl.flip<uint<1>>) {
+  %w = firrtl.wire : !firrtl.uint<1>
+  // CHECK: firrtl.connect %w, %in : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK: firrtl.connect %out, %w : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %w, %in : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %out, %w : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+}
+
+firrtl.module @wires1(%in : !firrtl.uint<1>, %out : !firrtl.flip<uint<1>>) {
+  %wf = firrtl.wire : !firrtl.flip<uint<1>>
+  // CHECK: firrtl.connect %wf, %in : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK: firrtl.connect %out, %wf : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
+  firrtl.connect %wf, %in : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %out, %wf : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
+}
+
+firrtl.module @wires2() {
+  %w0 = firrtl.wire : !firrtl.uint<1>
+  %w1 = firrtl.wire : !firrtl.uint<1>
+  // CHECK: firrtl.connect %w0, %w1
+  firrtl.connect %w0, %w1 : !firrtl.uint<1>, !firrtl.uint<1>
+}
+
+firrtl.module @wires3() {
+  // CHECK: firrtl.connect %wf0, %wf1
+  %wf0 = firrtl.wire : !firrtl.flip<uint<1>>
+  %wf1 = firrtl.wire : !firrtl.flip<uint<1>>
+  firrtl.connect %wf0, %wf1 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
+}
+
+firrtl.module @wires4(%out : !firrtl.flip<uint<1>>) {
+  %wf = firrtl.wire : !firrtl.flip<uint<1>>
+  // check that we can read from an output port
+  // CHECK: firrtl.connect %wf, %out
+  firrtl.connect %wf, %out : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
+}
+
+firrtl.module @registers0(%clock : !firrtl.clock, %in : !firrtl.uint<1>, %out : !firrtl.flip<uint<1>>) {
+  %0 = firrtl.reg %clock : (!firrtl.clock) -> !firrtl.uint<1>
+  // CHECK: firrtl.connect %0, %in : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK: firrtl.connect %out, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %0, %in : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %out, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+}
+
+firrtl.module @registers1(%clock : !firrtl.clock) {
+  %0 = firrtl.reg %clock : (!firrtl.clock) -> !firrtl.uint<1>
+  %1 = firrtl.reg %clock : (!firrtl.clock) -> !firrtl.uint<1>
+  // CHECK: firrtl.connect %0, %1
+  firrtl.connect %0, %1 : !firrtl.uint<1>, !firrtl.uint<1>
+}
+
 }


### PR DESCRIPTION
~Wires can have a bundle type and need to be handled during the lower
types pass.  For each element in the wire bundle, an new wire needs to
be created.~ (pushed to another PR)

Since wires have a `duplex` type, they can appear on the RHS or LHS of a
connect statement, regardless of whether or not they are a passive type.
When lowering a bulk connect statement involving a wire (i.e.
connecting a bundle type), we need to make sure that the non-duplex type
is used to set the direction of the flow. When doing a bulk connect of
two wires, it is considered an ambiguous flow and an error. To connect
two wires, each field must be connected individually, which is
considered a mono-connection with explicit flow from the RHS to the LHS.

This change adds a function to determine if a value comes from an
expression with duplex flow.  This property is transitive through
subfield accesses.

~The additional checking pointed out a mistake in the flow in the memory
black boxing pass when inlining modules. The type of a newly created
wire was used to determine which value should be on the RHS of the
connection, when it should have considered the non-duplex type involved.~ (pushed to another PR)