### PR TITLE
[Comb] Allow operand and result of SExtOp to have the same width and add folder

### DIFF
--- a/include/circt/Dialect/Comb/Combinational.td
+++ b/include/circt/Dialect/Comb/Combinational.td
@@ -182,7 +182,7 @@ def ExtractOp : CombOp<"extract", [NoSideEffect]> {
 }
 
 def SExtOp : CombOp<"sext", [NoSideEffect]> {
-  let summary = "Sign extend an integer to a larger integer";
+  let summary = "Sign extend an integer to an equal or larger integer";
 
   let arguments = (ins CombIntegerType:$input);
   let results = (outs CombIntegerType:$result);

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -88,6 +88,9 @@ OpFoldResult SExtOp::fold(ArrayRef<Attribute> constants) {
     return getIntAttr(input.getValue().sext(destWidth), getContext());
   }
 
+  if (getType().getWidth() == input().getType().cast<IntegerType>().getWidth())
+    return input();
+
   return {};
 }
 

--- a/lib/Dialect/Comb/CombOps.cpp
+++ b/lib/Dialect/Comb/CombOps.cpp
@@ -65,8 +65,8 @@ ICmpPredicate ICmpOp::getFlippedPredicate(ICmpPredicate predicate) {
 //===----------------------------------------------------------------------===//
 
 static LogicalResult verifySExtOp(SExtOp op) {
-  // The source must be equal or smaller than the dest type.  Both are already known to
-  // be signless integers.
+  // The source must be equal or smaller than the dest type.  Both are already
+  // known to be signless integers.
   auto srcType = op.getOperand().getType().cast<IntegerType>();
   if (srcType.getWidth() > op.getType().getWidth()) {
     op.emitOpError("extension must increase bitwidth of operand");

--- a/lib/Dialect/Comb/CombOps.cpp
+++ b/lib/Dialect/Comb/CombOps.cpp
@@ -65,7 +65,7 @@ ICmpPredicate ICmpOp::getFlippedPredicate(ICmpPredicate predicate) {
 //===----------------------------------------------------------------------===//
 
 static LogicalResult verifySExtOp(SExtOp op) {
-  // The source must be smaller than the dest type.  Both are already known to
+  // The source must be equal or smaller than the dest type.  Both are already known to
   // be signless integers.
   auto srcType = op.getOperand().getType().cast<IntegerType>();
   if (srcType.getWidth() > op.getType().getWidth()) {

--- a/lib/Dialect/Comb/CombOps.cpp
+++ b/lib/Dialect/Comb/CombOps.cpp
@@ -68,7 +68,7 @@ static LogicalResult verifySExtOp(SExtOp op) {
   // The source must be smaller than the dest type.  Both are already known to
   // be signless integers.
   auto srcType = op.getOperand().getType().cast<IntegerType>();
-  if (srcType.getWidth() >= op.getType().getWidth()) {
+  if (srcType.getWidth() > op.getType().getWidth()) {
     op.emitOpError("extension must increase bitwidth of operand");
     return failure();
   }

--- a/test/Dialect/RTL/canonicalization.mlir
+++ b/test/Dialect/RTL/canonicalization.mlir
@@ -818,3 +818,10 @@ rtl.module @icmp_fold_1bit_eq1(%arg: i1) -> (i1, i1, i1, i1) {
   %3 = comb.icmp ne   %one, %arg : i1
   rtl.output %0, %1, %2, %3 : i1, i1, i1, i1
 }
+
+// CHECK-LABEL: rtl.module @sext_identical(%a: i1) -> (i1) {
+// CHECK-NEXT:   rtl.output %a : i1
+rtl.module @sext_identical(%a: i1) -> (i1) {
+  %0 = comb.sext %a : (i1) -> (i1)
+  rtl.output %0 : i1
+}

--- a/test/Dialect/RTL/errors.mlir
+++ b/test/Dialect/RTL/errors.mlir
@@ -1,9 +1,9 @@
 // RUN: circt-opt %s -split-input-file -verify-diagnostics
 
-func private @test_extend(%arg0: i4) -> i4 {
+func private @test_extend(%arg0: i4) -> i3 {
   // expected-error @+1 {{extension must increase bitwidth of operand}}
-  %a = comb.sext %arg0 : (i4) -> i4
-  return %a : i4
+  %a = comb.sext %arg0 : (i4) -> i3
+  return %a : i3
 }
 
 // -----


### PR DESCRIPTION
Will close #692 
This patch also adds a folder for sext op