### PR TITLE
[FIRRTL] Split connect error tests from regular tests

### DIFF
--- a/test/Dialect/FIRRTL/connect-errors.mlir
+++ b/test/Dialect/FIRRTL/connect-errors.mlir
@@ -1,0 +1,254 @@
+
+// RUN: circt-opt %s -split-input-file -verify-diagnostics
+
+/// Analog types cannot be connected and must be attached.
+
+// -----
+
+firrtl.circuit "test" {
+firrtl.module @test(%a : !firrtl.analog, %b : !firrtl.flip<analog>) {
+  // expected-error @+1 {{analog types may not be connected}}
+  firrtl.connect %b, %a : !firrtl.flip<analog>, !firrtl.analog
+}
+}
+
+// -----
+
+firrtl.circuit "test" {
+firrtl.module @test(%a : !firrtl.analog, %b : !firrtl.flip<uint<1>>) {
+  // expected-error @+1 {{analog types may not be connected}}
+  firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.analog
+}
+}
+
+// -----
+
+firrtl.circuit "test" {
+firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<analog>) {
+  // expected-error @+1 {{analog types may not be connected}}
+  firrtl.connect %b, %a : !firrtl.flip<analog>, !firrtl.uint<1>
+}
+}
+
+/// Reset types can be connected to Reset, UInt<1>, or AsyncReset types.
+
+// Reset source.
+
+// -----
+
+firrtl.circuit "test" {
+firrtl.module @test(%a : !firrtl.reset, %b : !firrtl.flip<uint<2>>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.uint<2>' and source '!firrtl.reset'}}
+  firrtl.connect %b, %a : !firrtl.flip<uint<2>>, !firrtl.reset
+}
+}
+
+// -----
+
+firrtl.circuit "test" {
+firrtl.module @test(%a : !firrtl.reset, %b : !firrtl.flip<sint<1>>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.sint<1>' and source '!firrtl.reset'}}
+  firrtl.connect %b, %a : !firrtl.flip<sint<1>>, !firrtl.reset
+}
+}
+
+// Reset destination.
+
+// -----
+
+firrtl.circuit "test" {
+firrtl.module @test(%a : !firrtl.uint<2>, %b : !firrtl.flip<reset>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.reset' and source '!firrtl.uint<2>'}}
+  firrtl.connect %b, %a : !firrtl.flip<reset>, !firrtl.uint<2>
+}
+}
+
+// -----
+
+firrtl.circuit "test" {
+firrtl.module @test(%a : !firrtl.sint<1>, %b : !firrtl.flip<reset>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.reset' and source '!firrtl.sint<1>'}}
+  firrtl.connect %b, %a : !firrtl.flip<reset>, !firrtl.sint<1>
+}
+}
+
+/// Ground types can be connected if they are the same ground type.
+
+// UInt<> source.
+
+// -----
+
+firrtl.circuit "test" {
+firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<sint<1>>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.sint<1>' and source '!firrtl.uint<1>'}}
+  firrtl.connect %b, %a : !firrtl.flip<sint<1>>, !firrtl.uint<1>
+}
+}
+
+// -----
+
+firrtl.circuit "test" {
+
+firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<clock>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.clock' and source '!firrtl.uint<1>'}}
+  firrtl.connect %b, %a : !firrtl.flip<clock>, !firrtl.uint<1>
+}
+
+}
+
+// -----
+
+firrtl.circuit "test" {
+firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<asyncreset>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.asyncreset' and source '!firrtl.uint<1>'}}
+  firrtl.connect %b, %a : !firrtl.flip<asyncreset>, !firrtl.uint<1>
+}
+}
+
+// SInt<> source.
+
+// -----
+
+firrtl.circuit "test" {
+firrtl.module @test(%a : !firrtl.sint<1>, %b : !firrtl.flip<uint<1>>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.uint<1>' and source '!firrtl.sint<1>'}}
+  firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.sint<1>
+}
+}
+
+// -----
+
+firrtl.circuit "test" {
+firrtl.module @test(%a : !firrtl.sint<1>, %b : !firrtl.flip<clock>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.clock' and source '!firrtl.sint<1>'}}
+  firrtl.connect %b, %a : !firrtl.flip<clock>, !firrtl.sint<1>
+}
+}
+
+// -----
+
+firrtl.circuit "test" {
+firrtl.module @test(%a : !firrtl.sint<1>, %b : !firrtl.flip<asyncreset>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.asyncreset' and source '!firrtl.sint<1>'}}
+  firrtl.connect %b, %a : !firrtl.flip<asyncreset>, !firrtl.sint<1>
+}
+}
+
+// Clock source.
+
+// -----
+
+firrtl.circuit "test" {
+firrtl.module @test(%a : !firrtl.clock, %b : !firrtl.flip<uint<1>>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.uint<1>' and source '!firrtl.clock'}}
+  firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.clock
+}
+}
+
+// -----
+
+firrtl.circuit "test" {
+firrtl.module @test(%a : !firrtl.clock, %b : !firrtl.flip<sint<1>>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.sint<1>' and source '!firrtl.clock'}}
+  firrtl.connect %b, %a : !firrtl.flip<sint<1>>, !firrtl.clock
+}
+}
+
+// -----
+
+firrtl.circuit "test" {
+firrtl.module @test(%a : !firrtl.clock, %b : !firrtl.flip<asyncreset>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.asyncreset' and source '!firrtl.clock'}}
+  firrtl.connect %b, %a : !firrtl.flip<asyncreset>, !firrtl.clock
+}
+}
+
+// AsyncReset source.
+
+// -----
+
+firrtl.circuit "test" {
+firrtl.module @test(%a : !firrtl.asyncreset, %b : !firrtl.flip<uint<1>>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.uint<1>' and source '!firrtl.asyncreset'}}
+  firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.asyncreset
+}
+}
+
+// -----
+
+firrtl.circuit "test" {
+firrtl.module @test(%a : !firrtl.asyncreset, %b : !firrtl.flip<sint<1>>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.sint<1>' and source '!firrtl.asyncreset'}}
+  firrtl.connect %b, %a : !firrtl.flip<sint<1>>, !firrtl.asyncreset
+}
+}
+
+// -----
+
+firrtl.circuit "test" {
+firrtl.module @test(%a : !firrtl.asyncreset, %b : !firrtl.flip<clock>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.clock' and source '!firrtl.asyncreset'}}
+  firrtl.connect %b, %a : !firrtl.flip<clock>, !firrtl.asyncreset
+}
+}
+
+/// Vector types can be connected if they have the same size and element type.
+
+// -----
+
+firrtl.circuit "test" {
+firrtl.module @test(%a : !firrtl.vector<uint<1>, 3>, %b : !firrtl.flip<vector<uint<1>, 2>>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.vector<uint<1>, 2>' and source '!firrtl.vector<uint<1>, 3>'}}
+  firrtl.connect %b, %a : !firrtl.flip<vector<uint<1>, 2>>, !firrtl.vector<uint<1>, 3>
+}
+}
+
+// -----
+
+firrtl.circuit "test" {
+firrtl.module @test(%a : !firrtl.vector<uint<1>, 3>, %b : !firrtl.flip<vector<sint<1>, 3>>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.vector<sint<1>, 3>' and source '!firrtl.vector<uint<1>, 3>'}}
+  firrtl.connect %b, %a : !firrtl.flip<vector<sint<1>, 3>>, !firrtl.vector<uint<1>, 3>
+}
+}
+
+/// Bundle types can be connected if they have the same size, element names, and
+/// element types.
+
+// -----
+
+firrtl.circuit "test" {
+firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>>, %b : !firrtl.bundle<f1: flip<uint<1>>, f2: sint<1>>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.bundle<f1: uint<1>, f2: sint<1>>' and source '!firrtl.bundle<f1: uint<1>>'}}
+  firrtl.connect %b, %a : !firrtl.bundle<f1: flip<uint<1>>, f2: sint<1>>, !firrtl.bundle<f1: uint<1>>
+}
+}
+
+// -----
+
+firrtl.circuit "test" {
+firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>>, %b : !firrtl.bundle<f2: flip<uint<1>>>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.bundle<f2: uint<1>>' and source '!firrtl.bundle<f1: uint<1>>'}}
+  firrtl.connect %b, %a : !firrtl.bundle<f2: flip<uint<1>>>, !firrtl.bundle<f1: uint<1>>
+}
+}
+
+// -----
+
+firrtl.circuit "test" {
+firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>>, %b : !firrtl.bundle<f1: flip<sint<1>>>) {
+  // expected-error @+1 {{type mismatch between destination '!firrtl.bundle<f1: sint<1>>' and source '!firrtl.bundle<f1: uint<1>>'}}
+  firrtl.connect %b, %a : !firrtl.bundle<f1: flip<sint<1>>>, !firrtl.bundle<f1: uint<1>>
+}
+}
+
+/// Destination bitwidth must be greater than or equal to source bitwidth.
+
+// -----
+
+firrtl.circuit "test" {
+firrtl.module @test(%a : !firrtl.uint<2>, %b : !firrtl.flip<uint<1>>) {
+  // expected-error @+1 {{destination width 1 is not greater than or equal to source width 2}}
+  firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.uint<2>
+}
+}

--- a/test/Dialect/FIRRTL/connect.mlir
+++ b/test/Dialect/FIRRTL/connect.mlir
@@ -1,465 +1,94 @@
-// RUN: circt-opt %s -split-input-file -verify-diagnostics
 
-/// Analog types cannot be connected and must be attached.
+// RUN: circt-opt %s | FileCheck %s
 
-// -----
+firrtl.circuit "reset0" {
 
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.analog, %b : !firrtl.flip<analog>) {
-  // expected-error @+1 {{analog types may not be connected}}
-  firrtl.connect %b, %a : !firrtl.flip<analog>, !firrtl.analog
+// Reset destination.
+firrtl.module @reset0(%a : !firrtl.uint<1>, %b : !firrtl.flip<reset>) {
+  // CHECK: firrtl.connect %b, %a
+  firrtl.connect %b, %a : !firrtl.flip<reset>, !firrtl.uint<1>
 }
 
-}
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.analog, %b : !firrtl.flip<uint<1>>) {
-  // expected-error @+1 {{analog types may not be connected}}
-  firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.analog
-}
-
-}
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<analog>) {
-  // expected-error @+1 {{analog types may not be connected}}
-  firrtl.connect %b, %a : !firrtl.flip<analog>, !firrtl.uint<1>
-}
-
+firrtl.module @reset1(%a : !firrtl.asyncreset, %b : !firrtl.flip<reset>) {
+  // CHECK: firrtl.connect %b, %a
+  firrtl.connect %b, %a : !firrtl.flip<reset>, !firrtl.asyncreset
 }
 
 /// Reset types can be connected to Reset, UInt<1>, or AsyncReset types.
 
 // Reset source.
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.reset, %b : !firrtl.flip<reset>) {
+firrtl.module @reset2(%a : !firrtl.reset, %b : !firrtl.flip<reset>) {
   // CHECK: firrtl.connect %b, %a
   firrtl.connect %b, %a : !firrtl.flip<reset>, !firrtl.reset
 }
 
-}
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.reset, %b : !firrtl.flip<uint<1>>) {
+firrtl.module @reset3(%a : !firrtl.reset, %b : !firrtl.flip<uint<1>>) {
   // CHECK: firrtl.connect %b, %a
   firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.reset
 }
 
-}
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.reset, %b : !firrtl.flip<asyncreset>) {
+firrtl.module @reset4(%a : !firrtl.reset, %b : !firrtl.flip<asyncreset>) {
   // CHECK: firrtl.connect %b, %a
   firrtl.connect %b, %a : !firrtl.flip<asyncreset>, !firrtl.reset
 }
 
-}
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.reset, %b : !firrtl.flip<uint<2>>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.uint<2>' and source '!firrtl.reset'}}
-  firrtl.connect %b, %a : !firrtl.flip<uint<2>>, !firrtl.reset
-}
-
-}
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.reset, %b : !firrtl.flip<sint<1>>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.sint<1>' and source '!firrtl.reset'}}
-  firrtl.connect %b, %a : !firrtl.flip<sint<1>>, !firrtl.reset
-}
-
-}
-
-// Reset destination.
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<reset>) {
-  // CHECK: firrtl.connect %b, %a
-  firrtl.connect %b, %a : !firrtl.flip<reset>, !firrtl.uint<1>
-}
-
-}
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.asyncreset, %b : !firrtl.flip<reset>) {
-  // CHECK: firrtl.connect %b, %a
-  firrtl.connect %b, %a : !firrtl.flip<reset>, !firrtl.asyncreset
-}
-
-}
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.uint<2>, %b : !firrtl.flip<reset>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.reset' and source '!firrtl.uint<2>'}}
-  firrtl.connect %b, %a : !firrtl.flip<reset>, !firrtl.uint<2>
-}
-
-}
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.sint<1>, %b : !firrtl.flip<reset>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.reset' and source '!firrtl.sint<1>'}}
-  firrtl.connect %b, %a : !firrtl.flip<reset>, !firrtl.sint<1>
-}
-
-}
-
-/// Ground types can be connected if they are the same ground type.
-
-// UInt<> source.
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<uint<1>>) {
-  // CHECK: firrtl.connect %b, %a
-  firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-}
-
-}
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<uint<2>>) {
-  // CHECK: firrtl.connect %b, %a
-  firrtl.connect %b, %a : !firrtl.flip<uint<2>>, !firrtl.uint<1>
-}
-
-}
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<sint<1>>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.sint<1>' and source '!firrtl.uint<1>'}}
-  firrtl.connect %b, %a : !firrtl.flip<sint<1>>, !firrtl.uint<1>
-}
-
-}
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<clock>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.clock' and source '!firrtl.uint<1>'}}
-  firrtl.connect %b, %a : !firrtl.flip<clock>, !firrtl.uint<1>
-}
-
-}
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<asyncreset>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.asyncreset' and source '!firrtl.uint<1>'}}
-  firrtl.connect %b, %a : !firrtl.flip<asyncreset>, !firrtl.uint<1>
-}
-
-}
-
-// SInt<> source.
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.sint<1>, %b : !firrtl.flip<sint<1>>) {
-  // CHECK: firrtl.connect %b, %a
-  firrtl.connect %b, %a : !firrtl.flip<sint<1>>, !firrtl.sint<1>
-}
-
-}
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.sint<1>, %b : !firrtl.flip<uint<1>>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.uint<1>' and source '!firrtl.sint<1>'}}
-  firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.sint<1>
-}
-
-}
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.sint<1>, %b : !firrtl.flip<clock>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.clock' and source '!firrtl.sint<1>'}}
-  firrtl.connect %b, %a : !firrtl.flip<clock>, !firrtl.sint<1>
-}
-
-}
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.sint<1>, %b : !firrtl.flip<asyncreset>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.asyncreset' and source '!firrtl.sint<1>'}}
-  firrtl.connect %b, %a : !firrtl.flip<asyncreset>, !firrtl.sint<1>
-}
-
-}
-
-// Clock source.
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.clock, %b : !firrtl.flip<clock>) {
-  // CHECK: firrtl.connect %b, %a
-  firrtl.connect %b, %a : !firrtl.flip<clock>, !firrtl.clock
-}
-
-}
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.clock, %b : !firrtl.flip<uint<1>>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.uint<1>' and source '!firrtl.clock'}}
-  firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.clock
-}
-
-}
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.clock, %b : !firrtl.flip<sint<1>>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.sint<1>' and source '!firrtl.clock'}}
-  firrtl.connect %b, %a : !firrtl.flip<sint<1>>, !firrtl.clock
-}
-
-}
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.clock, %b : !firrtl.flip<asyncreset>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.asyncreset' and source '!firrtl.clock'}}
-  firrtl.connect %b, %a : !firrtl.flip<asyncreset>, !firrtl.clock
-}
-
-}
-
 // AsyncReset source.
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.asyncreset, %b : !firrtl.flip<asyncreset>) {
+firrtl.module @asyncreset0(%a : !firrtl.asyncreset, %b : !firrtl.flip<asyncreset>) {
   // CHECK: firrtl.connect %b, %a
   firrtl.connect %b, %a : !firrtl.flip<asyncreset>, !firrtl.asyncreset
 }
 
-}
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.asyncreset, %b : !firrtl.flip<uint<1>>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.uint<1>' and source '!firrtl.asyncreset'}}
-  firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.asyncreset
+// Clock source.
+firrtl.module @clock0(%a : !firrtl.clock, %b : !firrtl.flip<clock>) {
+  // CHECK: firrtl.connect %b, %a
+  firrtl.connect %b, %a : !firrtl.flip<clock>, !firrtl.clock
 }
 
+/// Ground types can be connected if they are the same ground type.
+
+// SInt<> source.
+firrtl.module @sint0(%a : !firrtl.sint<1>, %b : !firrtl.flip<sint<1>>) {
+  // CHECK: firrtl.connect %b, %a
+  firrtl.connect %b, %a : !firrtl.flip<sint<1>>, !firrtl.sint<1>
 }
 
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.asyncreset, %b : !firrtl.flip<sint<1>>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.sint<1>' and source '!firrtl.asyncreset'}}
-  firrtl.connect %b, %a : !firrtl.flip<sint<1>>, !firrtl.asyncreset
+// UInt<> source.
+firrtl.module @uint0(%a : !firrtl.uint<1>, %b : !firrtl.flip<uint<1>>) {
+  // CHECK: firrtl.connect %b, %a
+  firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 }
-
-}
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.asyncreset, %b : !firrtl.flip<clock>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.clock' and source '!firrtl.asyncreset'}}
-  firrtl.connect %b, %a : !firrtl.flip<clock>, !firrtl.asyncreset
-}
-
+firrtl.module @uint1(%a : !firrtl.uint<1>, %b : !firrtl.flip<uint<2>>) {
+  // CHECK: firrtl.connect %b, %a
+  firrtl.connect %b, %a : !firrtl.flip<uint<2>>, !firrtl.uint<1>
 }
 
 /// Vector types can be connected if they have the same size and element type.
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.vector<uint<1>, 3>, %b : !firrtl.flip<vector<uint<1>, 3>>) {
+firrtl.module @vect0(%a : !firrtl.vector<uint<1>, 3>, %b : !firrtl.flip<vector<uint<1>, 3>>) {
   // CHECK: firrtl.connect %b, %a
   firrtl.connect %b, %a : !firrtl.flip<vector<uint<1>, 3>>, !firrtl.vector<uint<1>, 3>
-}
-
-}
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.vector<uint<1>, 3>, %b : !firrtl.flip<vector<uint<1>, 2>>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.vector<uint<1>, 2>' and source '!firrtl.vector<uint<1>, 3>'}}
-  firrtl.connect %b, %a : !firrtl.flip<vector<uint<1>, 2>>, !firrtl.vector<uint<1>, 3>
-}
-
-}
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.vector<uint<1>, 3>, %b : !firrtl.flip<vector<sint<1>, 3>>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.vector<sint<1>, 3>' and source '!firrtl.vector<uint<1>, 3>'}}
-  firrtl.connect %b, %a : !firrtl.flip<vector<sint<1>, 3>>, !firrtl.vector<uint<1>, 3>
-}
-
 }
 
 /// Bundle types can be connected if they have the same size, element names, and
 /// element types.
 
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>, f2: flip<sint<1>>>, %b : !firrtl.bundle<f1: flip<uint<1>>, f2: sint<1>>) {
+firrtl.module @bundle0(%a : !firrtl.bundle<f1: uint<1>, f2: flip<sint<1>>>, %b : !firrtl.bundle<f1: flip<uint<1>>, f2: sint<1>>) {
   // CHECK: firrtl.connect %b, %a
   firrtl.connect %b, %a : !firrtl.bundle<f1: flip<uint<1>>, f2: sint<1>>, !firrtl.bundle<f1: uint<1>, f2: flip<sint<1>>>
 }
 
-}
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>, f2: flip<sint<2>>>, %b : !firrtl.bundle<f1: flip<uint<2>>, f2: sint<1>>) {
+firrtl.module @bundle1(%a : !firrtl.bundle<f1: uint<1>, f2: flip<sint<2>>>, %b : !firrtl.bundle<f1: flip<uint<2>>, f2: sint<1>>) {
   // CHECK: firrtl.connect %b, %a
   firrtl.connect %b, %a : !firrtl.bundle<f1: flip<uint<2>>, f2: sint<1>>, !firrtl.bundle<f1: uint<1>, f2: flip<sint<2>>>
 }
 
-}
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>>, %b : !firrtl.bundle<f1: flip<uint<1>>, f2: sint<1>>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.bundle<f1: uint<1>, f2: sint<1>>' and source '!firrtl.bundle<f1: uint<1>>'}}
-  firrtl.connect %b, %a : !firrtl.bundle<f1: flip<uint<1>>, f2: sint<1>>, !firrtl.bundle<f1: uint<1>>
-}
-
-}
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>>, %b : !firrtl.bundle<f2: flip<uint<1>>>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.bundle<f2: uint<1>>' and source '!firrtl.bundle<f1: uint<1>>'}}
-  firrtl.connect %b, %a : !firrtl.bundle<f2: flip<uint<1>>>, !firrtl.bundle<f1: uint<1>>
-}
-
-}
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>>, %b : !firrtl.bundle<f1: flip<sint<1>>>) {
-  // expected-error @+1 {{type mismatch between destination '!firrtl.bundle<f1: sint<1>>' and source '!firrtl.bundle<f1: uint<1>>'}}
-  firrtl.connect %b, %a : !firrtl.bundle<f1: flip<sint<1>>>, !firrtl.bundle<f1: uint<1>>
-}
-
-}
-
 /// Destination bitwidth must be greater than or equal to source bitwidth.
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<uint<2>>) {
+firrtl.module @bitwidth(%a : !firrtl.uint<1>, %b : !firrtl.flip<uint<2>>) {
   // CHECK: firrtl.connect %b, %a
   firrtl.connect %b, %a : !firrtl.flip<uint<2>>, !firrtl.uint<1>
 }
 
-}
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.uint<2>, %b : !firrtl.flip<uint<1>>) {
-  // expected-error @+1 {{destination width 1 is not greater than or equal to source width 2}}
-  firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.uint<2>
-}
-
-}
-
 /// Partial connects may truncate.
-
-// -----
-
-firrtl.circuit "test" {
-
-firrtl.module @test(%a : !firrtl.uint<2>, %b : !firrtl.flip<uint<1>>) {
+firrtl.module @partial_bitwidth(%a : !firrtl.uint<2>, %b : !firrtl.flip<uint<1>>) {
   // CHECK: firrtl.partialconnect %b, %a
   firrtl.partialconnect %b, %a : !firrtl.flip<uint<1>>, !firrtl.uint<2>
 }


### PR DESCRIPTION
Regular tests cannot be in the same file as error tests, due to the
absence of FileCheck from the diagnostic verification tests.  Before
this change, the positive checks were accidentally not being checked.

The error tests were moved into `connect-errors.mlir`.  The regular tests
are no longer tested using `-split-input-file`, and all modules had to be
renamed to avoid a name collision.