### PR TITLE
[CI] Replace Clang PR build with GCC build

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -128,15 +128,19 @@ jobs:
       # Build and test CIRCT in both debug and release mode.
       # --------
 
-      # Build the CIRCT test target in debug mode to build and test.
-      - name: Build and Test CIRCT (Assert)
+      # Our PR builds are trying to test the two corners of the build matrix:
+      # clang + release + noassert + shared
+      # gcc   + debug   + assert   + static 
+
+      # Build the CIRCT test target in release mode with assertions using Clang.
+      - name: Build and Test CIRCT (Clang release)
         run: |
-          mkdir build_assert
-          cd build_assert
+          mkdir build_clang
+          cd build_clang
           cmake .. \
             -DBUILD_SHARED_LIBS=ON \
-            -DCMAKE_BUILD_TYPE=Debug \
-            -DLLVM_ENABLE_ASSERTIONS=ON \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DLLVM_ENABLE_ASSERTIONS=OFF \
             -DMLIR_DIR=../llvm/install/lib/cmake/mlir/ \
             -DLLVM_DIR=../llvm/install/lib/cmake/llvm/ \
             -DCMAKE_LINKER=lld \
@@ -147,20 +151,19 @@ jobs:
           make check-circt -j$(nproc)
           make circt-doc
 
-      # Build the CIRCT test target in release mode to build and test.
-      - name: Build and Test CIRCT (Release)
+      # Build the CIRCT test target in debug mode with assertions using GCC.
+      - name: Build and Test CIRCT (GCC debug)
         run: |
-          mkdir build_release
-          cd build_release
+          mkdir build_gcc
+          cd build_gcc
           cmake .. \
-            -DBUILD_SHARED_LIBS=ON \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DLLVM_ENABLE_ASSERTIONS=OFF \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DLLVM_ENABLE_ASSERTIONS=ON \
             -DMLIR_DIR=../llvm/install/lib/cmake/mlir/ \
             -DLLVM_DIR=../llvm/install/lib/cmake/llvm/ \
             -DCMAKE_LINKER=lld \
-            -DCMAKE_C_COMPILER=clang \
-            -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_C_COMPILER=gcc \
+            -DCMAKE_CXX_COMPILER=g++ \
             -DLLVM_EXTERNAL_LIT=`pwd`/../llvm/build/bin/llvm-lit
           make check-circt -j$(nproc)
           make circt-doc


### PR DESCRIPTION
This change adds a GCC build to the buildAndTest job which is run on
every PR.  This step takes about 1m 30s to complete.

This also combines the two clang builds, in release and debug mode, into
a single build, release+asserts.  Normally, a cmake release build adds
-DNDEBUG to all command line options.  The LLVM cmake system has a flag
to override this, LLVM_ENABLE_ASSERTIONS.  Building in release mode with
assertions should give us the best of both worlds for error checking.

The GCC builds will be running in the same release+assert build
configuration.