### PR TITLE
[RTL/Comb] Move bitcast back to RTL dialect

### DIFF
--- a/include/circt/Dialect/Comb/CombOps.h
+++ b/include/circt/Dialect/Comb/CombOps.h
@@ -14,7 +14,6 @@
 #define CIRCT_DIALECT_COMB_COMBOPS_H
 
 #include "circt/Dialect/Comb/CombDialect.h"
-#include "circt/Dialect/RTL/RTLTypes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/FunctionSupport.h"
 #include "mlir/IR/OpImplementation.h"

--- a/include/circt/Dialect/Comb/CombVisitors.h
+++ b/include/circt/Dialect/Comb/CombVisitors.h
@@ -38,9 +38,7 @@ public:
             // Reduction Operators
             ParityOp,
             // Other operations.
-            SExtOp, ConcatOp, ExtractOp, MuxOp,
-            // Cast operation
-            BitcastOp>([&](auto expr) -> ResultType {
+            SExtOp, ConcatOp, ExtractOp, MuxOp>([&](auto expr) -> ResultType {
           return thisCast->visitComb(expr, args...);
         })
         .Default([&](auto expr) -> ResultType {
@@ -105,7 +103,6 @@ public:
   HANDLE(ConcatOp, Unhandled);
   HANDLE(ExtractOp, Unhandled);
   HANDLE(MuxOp, Unhandled);
-  HANDLE(BitcastOp, Unary);
 #undef HANDLE
 };
 

--- a/include/circt/Dialect/Comb/Combinational.td
+++ b/include/circt/Dialect/Comb/Combinational.td
@@ -245,31 +245,3 @@ def MuxOp : CombOp<"mux",
     }]>
   ];
 }
-
-def KnownBitWidthType : Type<CPred<[{rtl::getBitWidth($_self) != -1}]>,
-  "Type wherein the bitwidth in hardware is known">;
-
-def BitcastOp: CombOp<"bitcast", [NoSideEffect]> {
-  let summary = [{
-    Reinterpret one value to another value of the same size and
-    potentially different type.
-  }];
-
-  let description = [{
-    See the RTL-SV rationale document for a longer description, including an
-    example.
-  }];
-
-  let arguments = (ins KnownBitWidthType:$input);
-  let results = (outs KnownBitWidthType:$result);
-  let verifier = [{
-    if (rtl::getBitWidth(input().getType()) !=
-        rtl::getBitWidth(result().getType()))
-      return this->emitOpError("Bitwidth of input must match result");
-    return success();
-  }];
-
-  let assemblyFormat = [{
-    $input attr-dict `:` functional-type($input, $result)
-  }];
-}

--- a/include/circt/Dialect/RTL/RTLAggregates.td
+++ b/include/circt/Dialect/RTL/RTLAggregates.td
@@ -232,3 +232,31 @@ def ConstantOp
   let hasFolder = true;
   let verifier = "return ::verifyConstantOp(*this);";
 }
+
+def KnownBitWidthType : Type<CPred<[{getBitWidth($_self) != -1}]>,
+  "Type wherein the bitwidth in hardware is known">;
+
+def BitcastOp: RTLOp<"bitcast", [NoSideEffect]> {
+  let summary = [{
+    Reinterpret one value to another value of the same size and
+    potentially different type.
+  }];
+
+  let description = [{
+    See the RTL-SV rationale document for a longer description, including an
+    example.
+  }];
+
+  let arguments = (ins KnownBitWidthType:$input);
+  let results = (outs KnownBitWidthType:$result);
+  let verifier = [{
+    if (getBitWidth(input().getType()) !=
+        getBitWidth(result().getType()))
+      return this->emitOpError("Bitwidth of input must match result");
+    return success();
+  }];
+
+  let assemblyFormat = [{
+    $input attr-dict `:` functional-type($input, $result)
+  }];
+}

--- a/include/circt/Dialect/RTL/RTLVisitors.h
+++ b/include/circt/Dialect/RTL/RTLVisitors.h
@@ -31,10 +31,11 @@ public:
                        // Array operations
                        ArraySliceOp, ArrayCreateOp, ArrayConcatOp, ArrayGetOp,
                        // Struct operations
-                       StructCreateOp, StructExtractOp, StructInjectOp>(
-            [&](auto expr) -> ResultType {
-              return thisCast->visitTypeOp(expr, args...);
-            })
+                       StructCreateOp, StructExtractOp, StructInjectOp,
+                       // Cast operation
+                       BitcastOp>([&](auto expr) -> ResultType {
+          return thisCast->visitTypeOp(expr, args...);
+        })
         .Default([&](auto expr) -> ResultType {
           return thisCast->visitInvalidTypeOp(op, args...);
         });
@@ -59,6 +60,7 @@ public:
   }
 
   HANDLE(ConstantOp, Unhandled);
+  HANDLE(BitcastOp, Unhandled);
   HANDLE(StructCreateOp, Unhandled);
   HANDLE(StructExtractOp, Unhandled);
   HANDLE(StructInjectOp, Unhandled);

--- a/lib/Dialect/Comb/CombDialect.cpp
+++ b/lib/Dialect/Comb/CombDialect.cpp
@@ -13,7 +13,6 @@
 #include "circt/Dialect/Comb/CombDialect.h"
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/RTL/RTLOps.h"
-#include "circt/Dialect/RTL/RTLTypes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/DialectImplementation.h"

--- a/lib/Dialect/Comb/CombOps.cpp
+++ b/lib/Dialect/Comb/CombOps.cpp
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/Comb/CombOps.h"
-#include "circt/Dialect/RTL/RTLTypes.h"
 #include "mlir/IR/Builders.h"
 
 using namespace mlir;

--- a/lib/Dialect/ESI/capnp/Schema.cpp
+++ b/lib/Dialect/ESI/capnp/Schema.cpp
@@ -494,7 +494,7 @@ public:
 
   /// Construct a bitcast.
   GasketComponent cast(Type t) const {
-    auto dst = builder->create<comb::BitcastOp>(loc(), t, s);
+    auto dst = builder->create<rtl::BitcastOp>(loc(), t, s);
     return GasketComponent(*builder, dst);
   }
 
@@ -508,7 +508,7 @@ public:
     assert(s.getType().isa<IntegerType>());
     Value signlessVal = s;
     if (!signlessVal.getType().isSignlessInteger())
-      signlessVal = builder->create<comb::BitcastOp>(
+      signlessVal = builder->create<rtl::BitcastOp>(
           loc(), builder->getIntegerType(s.getType().getIntOrFloatBitWidth()),
           s);
 
@@ -680,7 +680,7 @@ Slice GasketComponent::castBitArray() const {
       rtl::ArrayType::get(builder->getI1Type(), rtl::getBitWidth(s.getType()));
   if (s.getType() == dstTy)
     return Slice(*builder, s);
-  auto dst = builder->create<comb::BitcastOp>(loc(), dstTy, s);
+  auto dst = builder->create<rtl::BitcastOp>(loc(), dstTy, s);
   return Slice(*builder, dst);
 }
 

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -735,6 +735,7 @@ private:
   // Other
   using TypeOpVisitor::visitTypeOp;
   SubExprInfo visitTypeOp(ConstantOp op);
+  SubExprInfo visitTypeOp(BitcastOp op);
   SubExprInfo visitTypeOp(ArraySliceOp op);
   SubExprInfo visitTypeOp(ArrayGetOp op);
   SubExprInfo visitTypeOp(ArrayCreateOp op);
@@ -791,8 +792,6 @@ private:
   SubExprInfo visitComb(ConcatOp op);
   SubExprInfo visitComb(ExtractOp op);
   SubExprInfo visitComb(ICmpOp op);
-
-  SubExprInfo visitComb(BitcastOp op);
 
 private:
   ModuleEmitter &emitter;
@@ -1025,7 +1024,7 @@ SubExprInfo ExprEmitter::visitComb(ConcatOp op) {
   return {Unary, IsUnsigned};
 }
 
-SubExprInfo ExprEmitter::visitComb(BitcastOp op) {
+SubExprInfo ExprEmitter::visitTypeOp(BitcastOp op) {
   // NOTE: Bitcasts are emitted out-of-line with their own wire declaration when
   // their dimensions don't match. SystemVerilog uses the wire declaration to
   // know what type this value is being casted to.

--- a/test/Dialect/RTL/basic.mlir
+++ b/test/Dialect/RTL/basic.mlir
@@ -92,8 +92,8 @@ rtl.module @test1(%arg0: i3, %arg1: i1, %arg2: !rtl.array<1000xi8>) -> (i50) {
   // CHECK-NEXT: :2 = rtl.struct_explode [[STR]] : !rtl.struct<foo: i19, bar: i7>
   %se:2 = rtl.struct_explode %s0 : !rtl.struct<foo: i19, bar: i7>
 
-  // CHECK-NEXT: comb.bitcast [[STR]] : (!rtl.struct<foo: i19, bar: i7>)
-  %structBits = comb.bitcast %s0 : (!rtl.struct<foo: i19, bar: i7>) -> i26
+  // CHECK-NEXT: rtl.bitcast [[STR]] : (!rtl.struct<foo: i19, bar: i7>)
+  %structBits = rtl.bitcast %s0 : (!rtl.struct<foo: i19, bar: i7>) -> i26
 
   // CHECK-NEXT: = constant 13 : i10
   %idx = constant 13 : i10

--- a/test/Dialect/RTL/bitwise.mlir
+++ b/test/Dialect/RTL/bitwise.mlir
@@ -34,9 +34,9 @@ func @shr_op(%a: i7, %b: i7) -> i7 {
 
 // CHECK-LABEL: func @casts(%arg0: i7) -> !rtl.struct<int: i7>
 func @casts(%in1: i7) -> !rtl.struct<int: i7> {
-  // CHECK-NEXT: %0 = comb.bitcast %arg0 : (i7) -> !rtl.array<7xi1>
-  // CHECK-NEXT: %1 = comb.bitcast %0 : (!rtl.array<7xi1>) -> !rtl.struct<int: i7>
-  %bits = comb.bitcast %in1 : (i7) -> !rtl.array<7xi1>
-  %backToInt = comb.bitcast %bits : (!rtl.array<7xi1>) -> !rtl.struct<int: i7>
+  // CHECK-NEXT: %0 = rtl.bitcast %arg0 : (i7) -> !rtl.array<7xi1>
+  // CHECK-NEXT: %1 = rtl.bitcast %0 : (!rtl.array<7xi1>) -> !rtl.struct<int: i7>
+  %bits = rtl.bitcast %in1 : (i7) -> !rtl.array<7xi1>
+  %backToInt = rtl.bitcast %bits : (!rtl.array<7xi1>) -> !rtl.struct<int: i7>
   return %backToInt : !rtl.struct<int: i7>
 }

--- a/test/ExportVerilog/rtl-dialect.mlir
+++ b/test/ExportVerilog/rtl-dialect.mlir
@@ -411,8 +411,8 @@ rtl.module @signs(%in1: i4, %in2: i4, %in3: i4, %in4: i4)  {
 // CHECK-NEXT: output [31:0]     r2);
 rtl.module @casts(%in1: i7, %in2: !rtl.array<8xi4>) -> (%r1: !rtl.array<7xi1>, %r2: i32) {
   // CHECK-EMPTY:
-  %r1 = comb.bitcast %in1 : (i7) -> !rtl.array<7xi1>
-  %r2 = comb.bitcast %in2 : (!rtl.array<8xi4>) -> i32
+  %r1 = rtl.bitcast %in1 : (i7) -> !rtl.array<7xi1>
+  %r2 = rtl.bitcast %in2 : (!rtl.array<8xi4>) -> i32
 
   // CHECK-NEXT: wire [31:0] {{.+}} = /*cast(bit[31:0])*/in2;
   // CHECK-NEXT: assign r1 = in1;

--- a/test/ExportVerilog/sv-dialect.mlir
+++ b/test/ExportVerilog/sv-dialect.mlir
@@ -321,7 +321,7 @@ rtl.module @issue595(%arr: !rtl.array<128xi1>) {
   // CHECK: assign _T = arr[7'h0+:64];
   %1 = rtl.array_slice %arr at %c0_i7 : (!rtl.array<128xi1>) -> !rtl.array<64xi1>
   %2 = rtl.array_slice %1 at %c0_i6 : (!rtl.array<64xi1>) -> !rtl.array<32xi1>
-  %3 = comb.bitcast %2 : (!rtl.array<32xi1>) -> i32
+  %3 = rtl.bitcast %2 : (!rtl.array<32xi1>) -> i32
   rtl.output
 }
 
@@ -338,7 +338,7 @@ rtl.module @issue595_variant1(%arr: !rtl.array<128xi1>) {
   // CHECK: assign _T = arr[7'h0+:64];
   %1 = rtl.array_slice %arr at %c0_i7 : (!rtl.array<128xi1>) -> !rtl.array<64xi1>
   %2 = rtl.array_slice %1 at %c0_i6 : (!rtl.array<64xi1>) -> !rtl.array<32xi1>
-  %3 = comb.bitcast %2 : (!rtl.array<32xi1>) -> i32
+  %3 = rtl.bitcast %2 : (!rtl.array<32xi1>) -> i32
   rtl.output
 }
 
@@ -354,6 +354,6 @@ rtl.module @issue595_variant2_checkRedunctionAnd(%arr: !rtl.array<128xi1>) {
   // CHECK: assign _T = arr[7'h0+:64];
   %1 = rtl.array_slice %arr at %c0_i7 : (!rtl.array<128xi1>) -> !rtl.array<64xi1>
   %2 = rtl.array_slice %1 at %c0_i6 : (!rtl.array<64xi1>) -> !rtl.array<32xi1>
-  %3 = comb.bitcast %2 : (!rtl.array<32xi1>) -> i32
+  %3 = rtl.bitcast %2 : (!rtl.array<32xi1>) -> i32
   rtl.output
 }


### PR DESCRIPTION
Moving bitcast to live with the rest of the of the type operations. Also remove a few unnecessary #includes to the rtl dialect. Unfortunately, this doesn't eliminate the Comb -> RTL dependence since folders and a materialize constant got added which use rtl::ConstantOp. (I haven't been paying attention the last week or two.)

Mechanical refactoring.