### PR TITLE
[FIRRTL] Simpler read port lowering

### DIFF
--- a/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
+++ b/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
@@ -1618,7 +1618,7 @@ LogicalResult FIRRTLLowering::visitDecl(MemOp op) {
           readInOut(builder->create<sv::ArrayIndexInOutOp>(reg, addr));
       // FIRRTL 5.11.1 says undefined behavior on low enable.
       auto undefinedVal =
-          builder->create<sv::TextualValueOp>(value.getType(), "`RANDOM");
+          builder->create<sv::TextualValueOp>(value.getType(), "'x");
       value = builder->create<comb::MuxOp>(en, value, undefinedVal);
 
       // If we're masking, emit "addr < Depth ? mem[addr] : `RANDOM".

--- a/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
+++ b/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
@@ -628,7 +628,7 @@ module attributes {firrtl.mainModule = "Simple"} {
     // CHECK-NEXT: %[[en:.+]] = sv.read_inout %_M_read_en
     // CHECK-NEXT: %[[data_inout:.+]] = sv.array_index_inout %_M[%[[addr]]]
     // CHECK-NEXT: %[[data:.+]] = sv.read_inout %[[data_inout]]
-    // CHECK-NEXT: %[[rnd:.+]] = sv.textual_value "`RANDOM"
+    // CHECK-NEXT: %[[rnd:.+]] = sv.textual_value "'x"
     // CHECK-NEXT: %[[realdata:.+]] = comb.mux %[[en]], %[[data]], %[[rnd]]
     // CHECK-NEXT: sv.ifdef "RANDOMIZE_GARBAGE_ASSIGN"  {
     // CHECK-NEXT:   %c-4_i4 = rtl.constant -4 : i4
@@ -762,7 +762,7 @@ module attributes {firrtl.mainModule = "Simple"} {
     // CHECK-NEXT:     %[[en_1ld:.+]] = sv.read_inout %[[en_1]]
     // CHECK-NEXT:     %[[data_index:.+]] = sv.array_index_inout %memory[%[[addr_1ld]]]
     // CHECK-NEXT:     %[[datareal:.+]] = sv.read_inout %[[data_index]]
-    // CHECK-NEXT:     %[[datarnd:.+]] = sv.textual_value "`RANDOM"
+    // CHECK-NEXT:     %[[datarnd:.+]] = sv.textual_value "'x"
     // CHECK-NEXT:     %[[rddata:.+]] = comb.mux %[[en_1ld]], %[[datareal]], %[[datarnd]]
     // CHECK-NEXT:     sv.connect %memory_r_data, %[[rddata]]
     // COM: --------------------------------------------------------------------


### PR DESCRIPTION
Simpler read port lowering which is still within the spec. Move some logic out of always blocks to improve output code, or at least make all combinatorial logically consistently generated.
