### PR TITLE
[ExportVerilog] Fixed struct printing in interfaces

### DIFF
--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -141,14 +141,6 @@ static bool haveMatchingDims(Type a, Type b, Location loc) {
   return aDims == bDims;
 }
 
-/// Emit the specified type dimensions and print out a trailing space if
-/// anything is printed.
-static void emitTypeDimWithSpaceIfNeeded(Type type, Location loc,
-                                         raw_ostream &os) {
-  if (emitTypeDims(type, loc, os))
-    os << ' ';
-}
-
 /// Return true if this is a zero bit type, e.g. a zero bit integer or array
 /// thereof.
 static bool isZeroBitType(Type type) {
@@ -2036,15 +2028,11 @@ LogicalResult StmtEmitter::visitSV(InterfaceOp op) {
 }
 
 LogicalResult StmtEmitter::visitSV(InterfaceSignalOp op) {
-  if (!isZeroBitType(op.type()))
-    indent() << "logic ";
-  else {
-    ++numStatementsEmitted; // Conservatively require a begin/end.
-    indent() << "// Zero width: logic ";
-  }
-
-  emitTypeDimWithSpaceIfNeeded(op.type(), op.getLoc(), os);
-  os << op.sym_name() << ";\n";
+  indent();
+  printPackedType(op.type(), os, op.getLoc(), false);
+  os << ' ' << op.sym_name();
+  printUnpackedTypePostfix(op.type(), os);
+  os << ";\n";
   return success();
 }
 

--- a/test/ExportVerilog/sv-interfaces.mlir
+++ b/test/ExportVerilog/sv-interfaces.mlir
@@ -18,6 +18,22 @@ module {
     sv.interface.modport @data_out ("output" @data, "output" @valid, "input" @ready)
   }
 
+  // CHECK-LABEL: interface struct_vr;
+  // CHECK:         struct packed {logic [6:0] foo; logic [4:0][15:0] bar; } data;
+  // CHECK:         logic valid;
+  // CHECK:         logic ready;
+  // CHECK:         modport data_in(input data, input valid, output ready);
+  // CHECK:         modport data_out(output data, output valid, input ready);
+  // CHECK:       endinterface
+  // CHECK-EMPTY:
+  sv.interface @struct_vr {
+    sv.interface.signal @data : !rtl.struct<foo: i7, bar: !rtl.array<5 x i16>>
+    sv.interface.signal @valid : i1
+    sv.interface.signal @ready : i1
+    sv.interface.modport @data_in ("input" @data, "input" @valid, "output" @ready)
+    sv.interface.modport @data_out ("output" @data, "output" @valid, "input" @ready)
+  }
+
   rtl.module.extern @Rcvr (%m: !sv.modport<@data_vr::@data_in>)
 
   // CHECK-LABEL: module Top


### PR DESCRIPTION
When structs were present as signals in SV interfaces, `logic` was printed instead of the struct.