### PR TITLE
[SV] Add NonProceduralOp trait

### DIFF
--- a/include/circt/Dialect/SV/SV.td
+++ b/include/circt/Dialect/SV/SV.td
@@ -42,6 +42,10 @@ def ProceduralOp : NativeOpTrait<"ProceduralOp"> {
   let cppNamespace = "::circt::sv";
 }
 
+def NonProceduralOp : NativeOpTrait<"NonProceduralOp"> {
+  let cppNamespace = "::circt::sv";
+}
+
 include "SVTypes.td"
 include "SVExpressions.td"
 include "SVInOutOps.td"

--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -26,7 +26,8 @@ def ConnectOp : SVOp<"connect", [InOutTypeConstraint<"src", "dest">]> {
 }
 
 // Note that net declarations like 'wire' should not appear in an always block.
-def WireOp : SVOp<"wire", [DeclareOpInterfaceMethods<OpAsmOpInterface>]> {
+def WireOp : SVOp<"wire", [DeclareOpInterfaceMethods<OpAsmOpInterface>,
+                           NonProceduralOp]> {
   let summary = "Define a new wire";
   let description = [{
     Declare a SystemVerilog Net Declaration of 'wire' type.

--- a/include/circt/Dialect/SV/SVOps.h
+++ b/include/circt/Dialect/SV/SVOps.h
@@ -49,7 +49,8 @@ public:
   }
 };
 
-/// This class verifies that the specified op is not located in a procedural region.
+/// This class verifies that the specified op is not located in a procedural
+/// region.
 template <typename ConcreteType>
 class NonProceduralOp
     : public mlir::OpTrait::TraitBase<ConcreteType, NonProceduralOp> {

--- a/include/circt/Dialect/SV/SVOps.h
+++ b/include/circt/Dialect/SV/SVOps.h
@@ -26,6 +26,9 @@ namespace sv {
 bool isExpression(Operation *op);
 /// Return true if the specified operation is in a procedural region.
 LogicalResult verifyInProceduralRegion(Operation *op);
+/// Return true if the specified operation is not in a procedural region.
+LogicalResult verifyInNonProceduralRegion(Operation *op);
+
 
 /// Signals that an operations regions are procedural.
 template <typename ConcreteType>
@@ -43,6 +46,16 @@ class ProceduralOp
 public:
   static LogicalResult verifyTrait(Operation *op) {
     return verifyInProceduralRegion(op);
+  }
+};
+
+/// This class verifies that the specified op is not located in a procedural region.
+template <typename ConcreteType>
+class NonProceduralOp
+    : public mlir::OpTrait::TraitBase<ConcreteType, NonProceduralOp> {
+public:
+  static LogicalResult verifyTrait(Operation *op) {
+    return verifyInNonProceduralRegion(op);
   }
 };
 

--- a/include/circt/Dialect/SV/SVOps.h
+++ b/include/circt/Dialect/SV/SVOps.h
@@ -29,7 +29,6 @@ LogicalResult verifyInProceduralRegion(Operation *op);
 /// Return true if the specified operation is not in a procedural region.
 LogicalResult verifyInNonProceduralRegion(Operation *op);
 
-
 /// Signals that an operations regions are procedural.
 template <typename ConcreteType>
 class ProceduralRegion

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -16,7 +16,8 @@ def HasRegionTerminator : SingleBlockImplicitTerminator<"YieldOp">;
 // Control flow like-operations
 //===----------------------------------------------------------------------===//
 
-def IfDefOp : SVOp<"ifdef", [HasRegionTerminator, NoRegionArguments]> {
+def IfDefOp : SVOp<"ifdef", [HasRegionTerminator, NoRegionArguments,
+                             NonProceduralOp]> {
   let summary = "'ifdef MACRO' block";
 
   let description = [{
@@ -148,7 +149,8 @@ def EventControlAttr : I32EnumAttr<"EventControl", "edge control trigger",
 
 
 def AlwaysOp : SVOp<"always", [HasRegionTerminator, NoRegionArguments,
-                               RecursiveSideEffects, ProceduralRegion]> {
+                               RecursiveSideEffects, ProceduralRegion,
+                               NonProceduralOp]> {
   let summary = "'always @' block";
   let description = "See SV Spec 9.2, and 9.4.2.2.";
   
@@ -190,7 +192,8 @@ def ResetTypeAttr : I32EnumAttr<"ResetType", "reset type",
 
 
 def AlwaysFFOp : SVOp<"alwaysff", [HasRegionTerminator, NoRegionArguments,
-                                   RecursiveSideEffects, ProceduralRegion]> {
+                                   RecursiveSideEffects, ProceduralRegion,
+                                   NonProceduralOp]> {
   let summary = "'alwaysff @' block with optional reset";
   let description = [{ 
     alwaysff blocks represent always_ff verilog nodes, which enforce inference 
@@ -233,7 +236,8 @@ def AlwaysFFOp : SVOp<"alwaysff", [HasRegionTerminator, NoRegionArguments,
 
 
 def InitialOp : SVOp<"initial", [HasRegionTerminator, NoRegionArguments,
-                                 RecursiveSideEffects, ProceduralRegion]> {
+                                 RecursiveSideEffects, ProceduralRegion,
+                                 NonProceduralOp]> {
   let summary = "'initial' block";
   let description = "See SV Spec 9.2.1.";
 

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -35,6 +35,13 @@ LogicalResult sv::verifyInProceduralRegion(Operation *op) {
   return failure();
 }
 
+LogicalResult sv::verifyInNonProceduralRegion(Operation *op) {
+  if (!op->getParentOp()->hasTrait<sv::ProceduralRegion>())
+    return success();
+  op->emitError() << op->getName() << " should be in a non-procedural region";
+  return failure();
+}
+
 //===----------------------------------------------------------------------===//
 // ImplicitSSAName Custom Directive
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/SV/errors.mlir
+++ b/test/Dialect/SV/errors.mlir
@@ -85,3 +85,35 @@ rtl.module @CaseZ(%arg8: i8) {
       sv.yield
     }
 }
+
+// -----
+rtl.module @Initial() {
+  sv.initial {
+    // expected-error @+1 {{sv.initial should be in a non-procedural region}}
+    sv.initial {}
+  }
+}
+
+// -----
+rtl.module @IfDef() {
+  sv.initial {
+    // expected-error @+1 {{sv.ifdef should be in a non-procedural region}}
+    sv.ifdef "SYNTHESIS" {}
+  }
+}
+
+// -----
+rtl.module @Always(%arg0: i1) {
+  sv.initial {
+    // expected-error @+1 {{sv.always should be in a non-procedural region}}
+    sv.always posedge %arg0 {}
+  }
+}
+
+// -----
+rtl.module @AlwaysFF(%arg0: i1) {
+  sv.initial {
+    // expected-error @+1 {{sv.alwaysff should be in a non-procedural region}}
+    sv.alwaysff (posedge %arg0) {}
+  }
+}

--- a/test/Dialect/SV/errors.mlir
+++ b/test/Dialect/SV/errors.mlir
@@ -117,3 +117,11 @@ rtl.module @AlwaysFF(%arg0: i1) {
     sv.alwaysff (posedge %arg0) {}
   }
 }
+
+// -----
+rtl.module @Wire() {
+  sv.initial {
+    // expected-error @+1 {{sv.wire should be in a non-procedural region}}
+    %wire = sv.wire : !rtl.inout<i1>
+  }
+}


### PR DESCRIPTION
Similar to #719, this PR adds `NonProceduralOp` trait which checks operations with this trait must not be in procedural regions.

I added the trait to `wire, ifdef, always, alwaysff, initial`.

