### PR TITLE
[FIRRTL LowerTypes] Add FExtModule type lowering

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -15,7 +15,7 @@
 
 include "mlir/Pass/PassBase.td"
 
-def LowerFIRRTLTypes : Pass<"firrtl-lower-types", "firrtl::FModuleOp"> {
+def LowerFIRRTLTypes : Pass<"firrtl-lower-types", "firrtl::CircuitOp"> {
   let summary = "Lower FIRRTL types to ground types";
   let description = [{
     Lower firrtl.module port types to ground types.

--- a/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
+++ b/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
@@ -1527,7 +1527,7 @@ LogicalResult FIRRTLLowering::visitDecl(MemOp op) {
         "should have already been lowered from a ground type to an aggregate "
         "type using the LowerTypes pass. Use "
         "'firtool --enable-lower-types' or 'circt-opt "
-        "--pass-pipeline='firrtl.circuit(firrtl.module(firrtl-lower-types))' "
+        "--pass-pipeline='firrtl.circuit(firrtl-lower-types)' "
         "to run this.");
 
   uint64_t depth = op.depth();

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -20,7 +20,6 @@
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/Parallel.h"
-#include "llvm/Support/Threading.h"
 #include <algorithm>
 #include <vector>
 
@@ -256,7 +255,7 @@ void TypeLoweringVisitor::visitDecl(FExtModuleOp extModule) {
   // Cache the named identifer for argument names.
   auto argNameId = builder.getIdentifier("firrtl.name");
 
-  // Create an array of the result types and results names
+  // Create an array of the result types and results names.
   SmallVector<Type, 8> inputTypes;
   SmallVector<DictionaryAttr, 8> attributes;
 
@@ -264,11 +263,11 @@ void TypeLoweringVisitor::visitDecl(FExtModuleOp extModule) {
   SmallVector<ModulePortInfo, 8> ports;
   extModule.getPortInfo(ports);
   for (auto &port : ports) {
-    // Flatten the port type
+    // Flatten the port type.
     SmallVector<FlatBundleFieldEntry, 8> fieldTypes;
     flattenType(port.type, port.getName(), false, fieldTypes);
 
-    // For each field, add record its name and type
+    // For each field, add record its name and type.
     for (auto field : fieldTypes) {
       inputTypes.push_back(field.getPortType());
       if (port.name) {

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl.module(firrtl-lower-types))' -split-input-file %s | FileCheck %s
+// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-lower-types)' -split-input-file %s | FileCheck %s
 
 firrtl.circuit "TopLevel" {
 
@@ -453,4 +453,15 @@ firrtl.circuit "LowerVectors" {
   // CHECK: firrtl.module @LowerVectors(%a_0: !firrtl.uint<1>, %a_1: !firrtl.uint<1>, %b_0: !firrtl.flip<uint<1>>, %b_1: !firrtl.flip<uint<1>>)
   // CHECK: firrtl.connect %b_0, %a_0
   // CHECK: firrtl.connect %b_1, %a_1
+}
+
+// ----
+
+firrtl.circuit "ExternalModule" {
+  // CHECK: firrtl.extmodule @ExternalModule(!firrtl.uint<1> {firrtl.name = "source_valid"}, !firrtl.flip<uint<1>> {firrtl.name = "source_ready"}, !firrtl.uint<64> {firrtl.name = "source_data"})
+  firrtl.extmodule @ExternalModule(!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>> {firrtl.name = "source"})
+  firrtl.module @Test() {
+    // CHECK:  %inst_source_valid, %inst_source_ready, %inst_source_data = firrtl.instance @ExternalModule {name = "", portNames = ["source_valid", "source_ready", "source_data"]} : !firrtl.flip<uint<1>>, !firrtl.uint<1>, !firrtl.flip<uint<64>>
+    %inst_source = firrtl.instance @ExternalModule {name = "", portNames = ["source"]} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>
+  }
 }

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -142,8 +142,7 @@ processBuffer(std::unique_ptr<llvm::MemoryBuffer> ownedBuffer,
   // Lower if we are going to verilog or if lowering was specifically requested.
   if (lowerToRTL || outputFormat == OutputVerilog) {
     if (enableLowerTypes)
-      pm.nest<firrtl::CircuitOp>().addNestedPass<firrtl::FModuleOp>(
-          firrtl::createLowerFIRRTLTypesPass());
+      pm.addNestedPass<firrtl::CircuitOp>(firrtl::createLowerFIRRTLTypesPass());
     pm.addPass(createLowerFIRRTLToRTLModulePass());
     pm.addNestedPass<rtl::RTLModuleOp>(createLowerFIRRTLToRTLPass());
 


### PR DESCRIPTION
This adds FExtModule lowering support to the lower types pass. This
flattens all types in the parameter list and gives each new operand a
new name.

To process ExtModules in this pass, it had to change from a FModuleOp
pass to a CircuitOp pass. In order to maintain performance, this pass is
now parallelized internally. This parallelization follows a similar
pattern to the PassManager: it creates a worker for each hardware thread
and they compete for the next work unit.