### PR TITLE
[firtool] Add option to emit one file per Verilog module

### DIFF
--- a/include/circt/Translation/ExportVerilog.h
+++ b/include/circt/Translation/ExportVerilog.h
@@ -15,6 +15,7 @@
 
 namespace llvm {
 class raw_ostream;
+class StringRef;
 } // namespace llvm
 
 namespace mlir {
@@ -26,6 +27,13 @@ namespace circt {
 
 /// Export a module containing RTL, and SV dialect code.
 mlir::LogicalResult exportVerilog(mlir::ModuleOp module, llvm::raw_ostream &os);
+
+/// Export a module containing RTL, and SV dialect code, as one file per SV
+/// module.
+///
+/// Files are created in the directory indicated by \c dirname.
+mlir::LogicalResult exportSplitVerilog(mlir::ModuleOp module,
+                                       llvm::StringRef dirname);
 
 /// Register a translation for exporting RTL, Comb and SV to SystemVerilog.
 void registerToVerilogTranslation();

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -2587,9 +2587,9 @@ void ModuleEmitter::emitStatementBlock(Block &body) {
 void SplitModuleEmitter::emitMLIRModule(ModuleOp module) {
   for (auto &op : *module.getBody()) {
     // TODO: Module uniquification happens in ModuleEmitter, but a new instance
-    // of ModuleEmitter is created for each operation in the body. We could add
-    // uniquification across all operations by moving the renaming table into a
-    // separate state object that is passed around, like a VerilogEmitterState.
+    // of ModuleEmitter is created for each operation in the body. This should
+    // be a prepass on the IR such that renaming is consistent regardless of
+    // what subset of the file the emitter is looking at (see #756).
     if (auto module = dyn_cast<RTLModuleOp>(op))
       emitFile(module.getNameAttr().getValue(),
                [&](VerilogEmitterState &state) {

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -2585,7 +2585,6 @@ void ModuleEmitter::emitStatementBlock(Block &body) {
 //===----------------------------------------------------------------------===//
 
 void SplitModuleEmitter::emitMLIRModule(ModuleOp module) {
-  llvm::errs() << "writing into " << dirname << "\n";
   for (auto &op : *module.getBody()) {
     // TODO: Module uniquification happens in ModuleEmitter, but a new instance
     // of ModuleEmitter is created for each operation in the body. We could add
@@ -2607,7 +2606,6 @@ void SplitModuleEmitter::emitMLIRModule(ModuleOp module) {
       });
     else if (isa<VerbatimOp>(op) || isa<IfDefProceduralOp>(op))
       perFileOps.push_back(&op);
-    // ModuleEmitter(state).emitStatement(&op);
     else if (!isa<ModuleTerminatorOp>(op)) {
       op.emitError("unknown operation");
       encounteredError = true;
@@ -2622,7 +2620,6 @@ void SplitModuleEmitter::emitFile(
   SmallString<128> outputFilename(dirname);
   llvm::sys::path::append(outputFilename, fileStem);
   outputFilename.append(".v");
-  llvm::errs() << "creating output file " << outputFilename << "\n";
 
   std::string errorMessage;
   auto output = openOutputFile(outputFilename, &errorMessage);

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -20,11 +20,13 @@
 #include "circt/Dialect/SV/SVVisitors.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/Support/FileUtilities.h"
 #include "mlir/Translation.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/SaveAndRestore.h"
+#include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace circt;
@@ -718,6 +720,27 @@ StringRef ModuleEmitter::addName(ValueOrOp valueOrOp, StringRef name) {
     nameTable[valueOrOp] = updatedName;
   return updatedName;
 }
+
+//===----------------------------------------------------------------------===//
+// SplitModuleEmitter
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+class SplitModuleEmitter {
+public:
+  explicit SplitModuleEmitter(StringRef dirname) : dirname(dirname) {}
+
+  bool encounteredError = false;
+  StringRef dirname;
+  SmallVector<Operation *, 8> perFileOps;
+
+  void emitMLIRModule(ModuleOp module);
+  void emitFile(StringRef filename,
+                std::function<void(VerilogEmitterState &)> callback);
+};
+
+} // namespace
 
 //===----------------------------------------------------------------------===//
 // Expression Emission
@@ -2561,6 +2584,68 @@ void ModuleEmitter::emitStatementBlock(Block &body) {
 // Module Driver
 //===----------------------------------------------------------------------===//
 
+void SplitModuleEmitter::emitMLIRModule(ModuleOp module) {
+  llvm::errs() << "writing into " << dirname << "\n";
+  for (auto &op : *module.getBody()) {
+    // TODO: Module uniquification happens in ModuleEmitter, but a new instance
+    // of ModuleEmitter is created for each operation in the body. We could add
+    // uniquification across all operations by moving the renaming table into a
+    // separate state object that is passed around, like a VerilogEmitterState.
+    if (auto module = dyn_cast<RTLModuleOp>(op))
+      emitFile(module.getNameAttr().getValue(),
+               [&](VerilogEmitterState &state) {
+                 ModuleEmitter(state).emitRTLModule(module);
+               });
+    else if (auto module = dyn_cast<RTLModuleExternOp>(op))
+      emitFile(module.getVerilogModuleNameAttr().getValue(),
+               [&](VerilogEmitterState &state) {
+                 ModuleEmitter(state).emitRTLExternModule(module);
+               });
+    else if (auto intfOp = dyn_cast<InterfaceOp>(op))
+      emitFile(intfOp.sym_name(), [&](VerilogEmitterState &state) {
+        ModuleEmitter(state).emitStatement(&op);
+      });
+    else if (isa<VerbatimOp>(op) || isa<IfDefProceduralOp>(op))
+      perFileOps.push_back(&op);
+    // ModuleEmitter(state).emitStatement(&op);
+    else if (!isa<ModuleTerminatorOp>(op)) {
+      op.emitError("unknown operation");
+      encounteredError = true;
+    }
+  }
+}
+
+void SplitModuleEmitter::emitFile(
+    StringRef fileStem, std::function<void(VerilogEmitterState &)> callback) {
+
+  // Determine the output file name and create it.
+  SmallString<128> outputFilename(dirname);
+  llvm::sys::path::append(outputFilename, fileStem);
+  outputFilename.append(".v");
+  llvm::errs() << "creating output file " << outputFilename << "\n";
+
+  std::string errorMessage;
+  auto output = openOutputFile(outputFilename, &errorMessage);
+  if (!output) {
+    encounteredError = true;
+    llvm::errs() << errorMessage << "\n";
+    return;
+  }
+
+  VerilogEmitterState state(output->os());
+
+  // Emit accumulated per-file operations and whatever the callback does.
+  for (auto op : perFileOps) {
+    ModuleEmitter(state).emitStatement(op);
+  }
+
+  callback(state);
+  if (state.encounteredError)
+    encounteredError = true;
+
+  output->keep();
+}
+
 void ModuleEmitter::emitMLIRModule(ModuleOp module) {
   for (auto &op : *module.getBody()) {
     if (auto module = dyn_cast<RTLModuleOp>(op))
@@ -2776,6 +2861,12 @@ LogicalResult circt::exportVerilog(ModuleOp module, llvm::raw_ostream &os) {
   VerilogEmitterState state(os);
   ModuleEmitter(state).emitMLIRModule(module);
   return failure(state.encounteredError);
+}
+
+LogicalResult circt::exportSplitVerilog(ModuleOp module, StringRef dirname) {
+  SplitModuleEmitter emitter(dirname);
+  emitter.emitMLIRModule(module);
+  return failure(emitter.encounteredError);
 }
 
 void circt::registerToVerilogTranslation() {

--- a/test/firtool/split_verilog.mlir
+++ b/test/firtool/split_verilog.mlir
@@ -1,0 +1,60 @@
+// RUN: firtool %s --format=mlir -split-verilog -o=%t
+// RUN: FileCheck %s --check-prefix=VERILOG-FOO < %t/foo.v
+// RUN: FileCheck %s --check-prefix=VERILOG-BAR < %t/bar.v
+// RUN: FileCheck %s --check-prefix=VERILOG-USB < %t/usb.v
+// RUN: FileCheck %s --check-prefix=VERILOG-PLL < %t/pll.v
+
+sv.verbatim "// I'm everywhere"
+sv.ifdef.procedural "VERILATOR" {
+  sv.verbatim "// Hello"
+} else {
+  sv.verbatim "// World"
+}
+sv.verbatim ""
+
+rtl.module @foo(%a: i1) -> (%b: i1) {
+  rtl.output %a : i1
+}
+rtl.module @bar(%x: i1) -> (%y: i1) {
+  rtl.output %x : i1
+}
+sv.interface @usb {
+  sv.interface.signal @valid : i1
+  sv.interface.signal @ready : i1
+}
+rtl.module.extern @pll ()
+
+// VERILOG-FOO:       // I'm everywhere
+// VERILOG-FOO-NEXT:  `ifdef VERILATOR
+// VERILOG-FOO-NEXT:    // Hello
+// VERILOG-FOO-NEXT:  `else
+// VERILOG-FOO-NEXT:    // World
+// VERILOG-FOO-NEXT:  `endif
+// VERILOG-FOO-LABEL: module foo(
+// VERILOG-FOO:       endmodule
+
+// VERILOG-BAR:       // I'm everywhere
+// VERILOG-BAR-NEXT:  `ifdef VERILATOR
+// VERILOG-BAR-NEXT:    // Hello
+// VERILOG-BAR-NEXT:  `else
+// VERILOG-BAR-NEXT:    // World
+// VERILOG-BAR-NEXT:  `endif
+// VERILOG-BAR-LABEL: module bar
+// VERILOG-BAR:       endmodule
+
+// VERILOG-USB:       // I'm everywhere
+// VERILOG-USB-NEXT:  `ifdef VERILATOR
+// VERILOG-USB-NEXT:    // Hello
+// VERILOG-USB-NEXT:  `else
+// VERILOG-USB-NEXT:    // World
+// VERILOG-USB-NEXT:  `endif
+// VERILOG-USB-LABEL: interface usb;
+// VERILOG-USB:       endinterface
+
+// VERILOG-PLL:        // I'm everywhere
+// VERILOG-PLL-NEXT:   `ifdef VERILATOR
+// VERILOG-PLL-NEXT:     // Hello
+// VERILOG-PLL-NEXT:   `else
+// VERILOG-PLL-NEXT:     // World
+// VERILOG-PLL-NEXT:   `endif
+// VERILOG-PLL:        // external module pll


### PR DESCRIPTION
Add a `-split-verilog` option to `firtool` that will emit a separate file for each and every module in the IR. Requires the user to specify an output directory path via the existing `-o=<dir>` option.

The current single-file Verilog emitter supports `RTLModuleOp`, `RTLModuleExternOp`, `InterfaceOp`, `VerbatimOp`, and `IfDefProceduralOp`. The first three have compilation-unit scope in SV, so they are put into separate files. The main concern are the `sv.verbatim` and `sv.ifdef.procedural` operations where we can't really reason about whether they contain file-scope business (e.g., preprocessor macros) or compilation-unit scope (e.g., a module/interface as inline verilog). The current implementation assumes these to be preprocessor directives (or generally anything that follows a declare-before-use paradigm and must be re-emitted into each file). That should cover the current path from FIRRTL to Verilog, but can go horribly wrong in any kinds of ways if the RTL/SV IR comes from a different source (user input for example).

Longer term I see a couple of options to deal with this:
1. Move separation into individual files into the FIRRTL-to-RTL lowering, where the preprocessor directives (`RANDOM`, etc.) are also injected. That lowering could then emit the directives multiple times as needed.
2. Add a `sv.file` operation that can be used to group modules into different files and add associated preprocessor directives and other verbatim SV business. This would give the IR the abilty to express which things go together into files. I remember doing SV code generation in Python, and the ability to be very explicit about what goes together into which files was pretty useful.
3. Add a `sv.compilation_unit` or `sv.per_file` operation that can be used to indicate which operations are to be re-emitted into each file. (Seems kinda hacky to me though.)

## Todo

- [x] Add a couple of test cases for this