### PR TITLE
[ExportVerilog] Add option to control alwaysff printing

### DIFF
--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -1,0 +1,70 @@
+//===- LoweringOptions.h - CIRCT Lowering Options ---------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Options for controlling the lowering process and verilog exporting.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_SUPPORT_LOWERINGOPTIONS_H
+#define CIRCT_SUPPORT_LOWERINGOPTIONS_H
+
+#include "circt/Support/LLVM.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace mlir {
+class ModuleOp;
+}
+
+namespace circt {
+
+/// Options which control the emission from CIRCT to Verilog.
+struct LoweringOptions {
+  /// Error callback type used to indicate errors parsing the options string.
+  using ErrorHandlerT = function_ref<void(llvm::Twine)>;
+
+  /// Create a LoweringOptions with the default values.
+  LoweringOptions() = default;
+
+  /// Create a LoweringOptions and read in options from a string,
+  /// overriding only the set options in the string.
+  LoweringOptions(StringRef options, ErrorHandlerT errorHandler);
+
+  /// Create a LoweringOptions with values loaded from an MLIR ModuleOp. This
+  /// loads a string attribute with the key `circt.loweringOptions`. If there is
+  /// an error parsing the attribute this will print an error using the
+  /// ModuleOp.
+  LoweringOptions(mlir::ModuleOp module);
+
+  /// Read in options from a string, overriding only the set options in the
+  /// string.
+  void parse(StringRef options, ErrorHandlerT callback);
+
+  /// Returns a string representation of the options.
+  std::string toString() const;
+
+  /// Write the verilog emitter options to a module's attributes.
+  void setAsAttribute(mlir::ModuleOp module);
+
+  // Load any emitter options from the module. If there is an error validating
+  // the attribute, this will print an error using the ModuleOp.
+  void parseFromAttribute(mlir::ModuleOp module);
+
+  // If true, ExportVerilog emits AlwaysFFOp as Verilog always_ff statements.
+  // Otherwise, it will print them as always statements
+  bool useAlwaysFF = true;
+};
+
+/// Register commandline options for the verilog emitter.
+void registerLoweringCLOptions();
+
+/// Apply any command line specified style options to the mlir module.
+void applyLoweringCLOptions(ModuleOp module);
+
+} // namespace circt
+
+#endif // CIRCT_SUPPORT_LOWERINGOPTIONS_H

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -1,0 +1,115 @@
+//===- LoweringOptions.cpp - CIRCT Lowering Options -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Options for controlling the lowering process. Contains command line
+// option definitions and support.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Support/LoweringOptions.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/ManagedStatic.h"
+
+using namespace circt;
+
+//===----------------------------------------------------------------------===//
+// LoweringOptions
+//===----------------------------------------------------------------------===//
+
+LoweringOptions::LoweringOptions(StringRef options, ErrorHandlerT errorHandler)
+    : LoweringOptions() {
+  parse(options, errorHandler);
+}
+
+LoweringOptions::LoweringOptions(mlir::ModuleOp module) : LoweringOptions() {
+  parseFromAttribute(module);
+}
+
+void LoweringOptions::parse(StringRef text, ErrorHandlerT errorHandler) {
+  while (!text.empty()) {
+    // Remove the first option from the text.
+    auto split = text.split(",");
+    auto option = split.first.trim();
+    text = split.second;
+    if (option == "") {
+      // Empty options are fine.
+    } else if (option == "noAlwaysFF") {
+      useAlwaysFF = false;
+    } else {
+      errorHandler(llvm::Twine("unknown style option \'") + option + "\'");
+      // We continue parsing options after a failure.
+    }
+  }
+}
+
+std::string LoweringOptions::toString() const {
+  std::string options = "";
+  if (!useAlwaysFF)
+    options += "noAlwaysFF";
+  return options;
+}
+
+void LoweringOptions::setAsAttribute(ModuleOp module) {
+  module->setAttr("circt.loweringOptions",
+                  StringAttr::get(module.getContext(), toString()));
+}
+
+void LoweringOptions::parseFromAttribute(ModuleOp module) {
+  if (auto styleAttr =
+          module->getAttrOfType<StringAttr>("circt.loweringOptions")) {
+    parse(styleAttr.getValue(), [&](Twine error) { module.emitError(error); });
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Command Line Option Processing
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// Commandline parser for LoweringOptions.  Delegates to the parser
+/// defined by LoweringOptions.
+struct LoweringOptionsParser : public llvm::cl::parser<LoweringOptions> {
+
+  LoweringOptionsParser(llvm::cl::Option &option)
+      : llvm::cl::parser<LoweringOptions>(option) {}
+
+  bool parse(llvm::cl::Option &option, StringRef argName, StringRef argValue,
+             LoweringOptions &value) {
+    bool failed = false;
+    value.parse(argValue, [&](Twine error) { failed = option.error(error); });
+    return failed;
+  }
+};
+
+/// Commandline arguments for verilog emission.  Used to dynamically register
+/// the command line arguments in multiple tools.
+struct LoweringCLOptions {
+  llvm::cl::opt<LoweringOptions, false, LoweringOptionsParser> loweringOptions{
+      "circt-lowering-options", llvm::cl::desc("Style options"),
+      llvm::cl::value_desc("option")};
+};
+} // namespace
+
+/// The staticly initialized command line options.
+static llvm::ManagedStatic<LoweringCLOptions> clOptions;
+
+void circt::registerLoweringCLOptions() { *clOptions; }
+
+void circt::applyLoweringCLOptions(ModuleOp module) {
+  // If the command line options were not registered in the first place, there
+  // is nothing to parse.
+  if (!clOptions.isConstructed())
+    return;
+
+  // If an output style is applied on the command line, all previous options are
+  // discarded.
+  if (clOptions->loweringOptions.getNumOccurrences()) {
+    clOptions->loweringOptions.setAsAttribute(module);
+  }
+}

--- a/lib/Translation/ExportVerilog/CMakeLists.txt
+++ b/lib/Translation/ExportVerilog/CMakeLists.txt
@@ -9,6 +9,7 @@ add_circt_translation_library(CIRCTExportVerilog
   CIRCTFIRRTL
   CIRCTComb
   CIRCTRTL
+  CIRCTSupport
   CIRCTSV
   MLIRTranslation
   )

--- a/test/ExportVerilog/sv-alwaysff.mlir
+++ b/test/ExportVerilog/sv-alwaysff.mlir
@@ -1,0 +1,35 @@
+// RUN: circt-translate --split-input-file --export-verilog %s | FileCheck %s --check-prefix=DEFAULT
+// RUN: circt-translate --circt-lowering-options= --split-input-file --export-verilog %s | FileCheck %s --check-prefix=CLEAR
+// RUN: circt-translate --circt-lowering-options=noAlwaysFF --split-input-file --export-verilog %s | FileCheck %s --check-prefix=NOALWAYSFF
+
+rtl.module @test(%clock : i1, %cond : i1) {
+  sv.alwaysff(posedge %clock) {
+  }
+}
+
+// DEFAULT: always_ff @(posedge clock) begin
+// DEFAULT: end // always_ff @(posedge)
+
+// CLEAR: always_ff @(posedge clock) begin
+// CLEAR: end // always_ff @(posedge)
+
+// NOALWAYSFF: always @(posedge clock) begin
+// NOALWAYSFF: end // always @(posedge)
+
+// -----
+
+module attributes {circt.loweringOptions = "noAlwaysFF"} {
+rtl.module @test(%clock : i1, %cond : i1) {
+  sv.alwaysff(posedge %clock) {
+  }
+}
+}
+
+// DEFAULT: always @(posedge clock) begin
+// DEFAULT: end // always @(posedge)
+
+// CLEAR: always_ff @(posedge clock) begin
+// CLEAR: end // always_ff @(posedge)
+
+// NOALWAYSFF: always @(posedge clock) begin
+// NOALWAYSFF: end // always @(posedge)

--- a/test/ExportVerilog/verilog-errors.mlir
+++ b/test/ExportVerilog/verilog-errors.mlir
@@ -8,3 +8,8 @@ rtl.module @Top(%out: f32) {
 rtl.module @parameter() {
 }
 
+// -----
+
+// expected-error @+2 {{unknown style option 'badOption'}}
+// expected-error @+1 {{unknown style option 'anotherOne'}}
+module attributes {circt.loweringOptions = "badOption,anotherOne"} {}

--- a/test/circt-translate/commandline.mlir
+++ b/test/circt-translate/commandline.mlir
@@ -2,6 +2,8 @@
 
 // CHECK: OVERVIEW: CIRCT Translation Testing Tool
 
+// CHECK: --circt-lowering-options=<value>
+
 // CHECK: Translation to perform
 // CHECK: --export-llhd-verilog
 // CHECK: --export-verilog

--- a/test/firtool/commandline.mlir
+++ b/test/firtool/commandline.mlir
@@ -1,3 +1,4 @@
 // RUN: firtool --help | FileCheck %s
 //
 // CHECK: OVERVIEW: circt modular optimizer drive
+// CHECK: --circt-lowering-options=

--- a/test/firtool/style.fir
+++ b/test/firtool/style.fir
@@ -1,0 +1,10 @@
+; RUN: firtool %s | FileCheck %s --check-prefix=DEFAULT
+; RUN: not firtool --circt-lowering-options=bad-option %s 2>&1 | FileCheck %s --check-prefix=BADOPTION
+; RUN: firtool --circt-lowering-options=noAlwaysFF %s | FileCheck %s --check-prefix=NOALWAYSFF
+
+circuit test :
+  module test :
+
+; DEFAULT: module {
+; BADOPTION: circt-lowering-options option: unknown style option 'bad-option'
+; NOALWAYSFF: module attributes {circt.loweringOptions = "noAlwaysFF"} {

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -21,6 +21,7 @@
 #include "circt/Dialect/RTL/RTLOps.h"
 #include "circt/Dialect/SV/SVDialect.h"
 #include "circt/Dialect/SV/SVPasses.h"
+#include "circt/Support/LoweringOptions.h"
 #include "circt/Translation/ExportVerilog.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/AsmState.h"
@@ -211,6 +212,10 @@ processBuffer(std::unique_ptr<llvm::MemoryBuffer> ownedBuffer,
     pm.addPass(sv::createRTLLegalizeNamesPass());
   }
 
+  // Load the emitter options from the command line. Command line options if
+  // specified will override any module options.
+  applyLoweringCLOptions(module.get());
+
   if (failed(pm.run(module.get())))
     return failure();
 
@@ -237,7 +242,7 @@ processBufferIntoSingleStream(std::unique_ptr<llvm::MemoryBuffer> ownedBuffer,
         }
         llvm_unreachable("unknown output format");
       });
-};
+}
 
 /// Process a single buffer of the input into multiple output files.
 static LogicalResult
@@ -268,6 +273,7 @@ int main(int argc, char **argv) {
   registerMLIRContextCLOptions();
   registerPassManagerCLOptions();
   registerAsmPrinterCLOptions();
+  registerLoweringCLOptions();
 
   // Parse pass names in main to ensure static initialization completed.
   cl::ParseCommandLineOptions(argc, argv, "circt modular optimizer driver\n");


### PR DESCRIPTION
This change adds the ability to control the verilog emitter using a set
of options, starting with one option to control the printing of the
`sv.alwaysff` operation.  This allows `sv.alwaysff`  to print as either
an always_ff or always block.

There are several configuration points for this option:

`exportVerilog()` now takes a `VerilogEmitterOptions` struct, with a field
`emitAlwaysFFAsAlways`.  This struct is stored in the
VerilogEmitterState object, and accessed by the different emitters to
customize their output.  This field defaults to false.

`circt-translate` now has a command line option
`--verilog-emit-alwaysff-as-always` under a new option group called
"Verilog Export". This defaults to off.

`firtool` now has a command line option `--emit-alwaysff-as-always` to
control the output.  It has also received the option
`--style={compatible,fancy}`, which is meant to be a simple way to
quickly toggle more than one flag. This flag defaults to compatibility
mode, which defaults -emit-alwaysff-as-always to true.  This the
opposite default setting to circt-translate.