### PR TITLE
[SV] Invert IfOp if thenBlock is empty

### DIFF
--- a/lib/Dialect/SV/CMakeLists.txt
+++ b/lib/Dialect/SV/CMakeLists.txt
@@ -14,6 +14,7 @@ add_circt_dialect_library(CIRCTSV
   LINK_LIBS PUBLIC
   MLIRIR
   CIRCTRTL
+  CIRCTComb
    )
 
 add_dependencies(circt-headers MLIRSVIncGen)

--- a/lib/Dialect/SV/SVDialect.cpp
+++ b/lib/Dialect/SV/SVDialect.cpp
@@ -13,6 +13,7 @@
 #include "circt/Dialect/SV/SVDialect.h"
 #include "circt/Dialect/SV/SVOps.h"
 #include "circt/Dialect/SV/SVTypes.h"
+#include "circt/Dialect/Comb/CombDialect.h"
 
 #include "mlir/IR/DialectImplementation.h"
 
@@ -25,7 +26,7 @@ using namespace circt::sv;
 SVDialect::SVDialect(MLIRContext *context)
     : Dialect(getDialectNamespace(), context,
               ::mlir::TypeID::get<SVDialect>()) {
-
+  context->loadDialect<circt::comb::CombDialect>();
   // Register types.
   addTypes<
 #define GET_TYPEDEF_LIST

--- a/lib/Dialect/SV/SVDialect.cpp
+++ b/lib/Dialect/SV/SVDialect.cpp
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/SV/SVDialect.h"
+#include "circt/Dialect/Comb/CombDialect.h"
 #include "circt/Dialect/SV/SVOps.h"
 #include "circt/Dialect/SV/SVTypes.h"
-#include "circt/Dialect/Comb/CombDialect.h"
 
 #include "mlir/IR/DialectImplementation.h"
 

--- a/test/Dialect/SV/canonicalization.mlir
+++ b/test/Dialect/SV/canonicalization.mlir
@@ -65,3 +65,23 @@ func @empy_op(%arg0: i1) {
   sv.initial {}
   return
 }
+
+// CHECK-LABEL: func @invert_if(%arg0: i1) {
+// CHECK-NEXT:    %true = rtl.constant true
+// CHECK-NEXT:    sv.initial  {
+// CHECK-NEXT:      %0 = comb.xor %arg0, %true : i1
+// CHECK-NEXT:      sv.if %0  {
+// CHECK-NEXT:        sv.fwrite "Foo"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+func @invert_if(%arg0: i1) {
+  sv.initial {
+    sv.if %arg0 {
+    } else {
+      sv.fwrite "Foo"
+    }
+  }
+  return
+}


### PR DESCRIPTION
This PR adds canonicalization for SVOp. If the then block is empty and else block is not empty, inverts the conditions. 
The dependency from SV dialect to Comb dialect is added to create `comb.xor` within SVDialect.

Will close #721