### PR TITLE
Add missing back-tick to RANDOMIZE_GARBAGE_ASSIGN_BOUND_CHECK

### DIFF
--- a/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
+++ b/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
@@ -1899,7 +1899,7 @@ LogicalResult FIRRTLLowering::visitDecl(MemOp op) {
         auto depthCst = getOrCreateIntConstant(addrWidth, depth);
         value = builder.create<sv::VerbatimExprOp>(
             value.getType(),
-            "RANDOMIZE_GARBAGE_ASSIGN_BOUND_CHECK({{0}}, {{1}}, {{2}})",
+            "`RANDOMIZE_GARBAGE_ASSIGN_BOUND_CHECK({{0}}, {{1}}, {{2}})",
             ValueRange{addr, value, depthCst});
         circuitState.used_RANDOMIZE_GARBAGE_ASSIGN = 1;
       }

--- a/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
+++ b/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
@@ -559,7 +559,7 @@ firrtl.circuit "Simple" {
     // COM: --------------------------------------------------------------------
     // CHECK-NEXT: [[data_inout:%.+]] = sv.array_index_inout %_M[%c0_i4]
     // CHECK-NEXT: [[data:%.+]] = sv.read_inout [[data_inout]]
-    // CHECK-NEXT:  = sv.verbatim.expr "RANDOMIZE_GARBAGE_ASSIGN_BOUND_CHECK({{.*}})"(%c0_i4, [[data]], %c-4_i4) : (i4, i42, i4) -> i42
+    // CHECK-NEXT:  = sv.verbatim.expr "`RANDOMIZE_GARBAGE_ASSIGN_BOUND_CHECK({{.*}})"(%c0_i4, [[data]], %c-4_i4) : (i4, i42, i4) -> i42
 
     // COM: Write port.
     // COM: --------------------------------------------------------------------
@@ -730,7 +730,7 @@ firrtl.circuit "Simple" {
     // CHECK:  %_M = sv.reg : !rtl.inout<uarray<12xi42>>
     %_M_read = firrtl.mem Undefined {depth = 12 : i64, name = "_M", portNames = ["read"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>
     // Read port.
-    // CHECK:      sv.verbatim.expr "RANDOMIZE_GARBAGE_ASSIGN_BOUND_CHECK
+    // CHECK:      sv.verbatim.expr "`RANDOMIZE_GARBAGE_ASSIGN_BOUND_CHECK
     %6 = firrtl.subfield %_M_read("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<4>>
     firrtl.connect %6, %c0_ui1 : !firrtl.flip<uint<4>>, !firrtl.uint<1>
     %7 = firrtl.subfield %_M_read("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<1>>


### PR DESCRIPTION
Add the missing back-tick and update lit-tests, as mentioned in, https://github.com/llvm/circt/issues/754#issuecomment-800540665
