### PR TITLE
[SV] Check IfDefProceduralOp is in a procedural region

### DIFF
--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -61,7 +61,7 @@ def IfDefOp : SVOp<"ifdef", [HasRegionTerminator, NoRegionArguments,
 
 def IfDefProceduralOp
   : SVOp<"ifdef.procedural", [HasRegionTerminator, NoRegionArguments,
-                              ProceduralRegion]> {
+                              ProceduralRegion, ProceduralOp]> {
   let summary = "'ifdef MACRO' block for procedural regions";
 
   let description = [{

--- a/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
+++ b/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
@@ -264,10 +264,10 @@ void FIRRTLModuleLowering::lowerFileHeader(CircuitOp op,
     std::string define = "`define ";
     if (!defineFalse) {
       assert(defineTrue && "didn't define anything");
-      b.create<sv::IfDefProceduralOp>(
+      b.create<sv::IfDefOp>(
           guard, [&]() { emitString(define + defineTrue); });
     } else {
-      b.create<sv::IfDefProceduralOp>(
+      b.create<sv::IfDefOp>(
           guard,
           [&]() {
             if (defineTrue)
@@ -322,7 +322,7 @@ void FIRRTLModuleLowering::lowerFileHeader(CircuitOp op,
     emitGuardedDefine("RANDOMIZE_DELAY", nullptr, "RANDOMIZE_DELAY 0.002");
 
     emitString("\n// Define INIT_RANDOM_PROLOG_ for use in our modules below.");
-    b.create<sv::IfDefProceduralOp>(
+    b.create<sv::IfDefOp>(
         "RANDOMIZE",
         [&]() {
           emitGuardedDefine(
@@ -335,7 +335,7 @@ void FIRRTLModuleLowering::lowerFileHeader(CircuitOp op,
   if (state.used_RANDOMIZE_GARBAGE_ASSIGN) {
     emitString("\n// RANDOMIZE_GARBAGE_ASSIGN enable range checks for mem "
                "assignments.");
-    b.create<sv::IfDefProceduralOp>(
+    b.create<sv::IfDefOp>(
         "RANDOMIZE_GARBAGE_ASSIGN",
         [&]() {
           emitString(

--- a/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
+++ b/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
@@ -264,8 +264,7 @@ void FIRRTLModuleLowering::lowerFileHeader(CircuitOp op,
     std::string define = "`define ";
     if (!defineFalse) {
       assert(defineTrue && "didn't define anything");
-      b.create<sv::IfDefOp>(
-          guard, [&]() { emitString(define + defineTrue); });
+      b.create<sv::IfDefOp>(guard, [&]() { emitString(define + defineTrue); });
     } else {
       b.create<sv::IfDefOp>(
           guard,

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -2604,7 +2604,7 @@ void SplitModuleEmitter::emitMLIRModule(ModuleOp module) {
       emitFile(intfOp.sym_name(), [&](VerilogEmitterState &state) {
         ModuleEmitter(state).emitStatement(&op);
       });
-    else if (isa<VerbatimOp>(op) || isa<IfDefProceduralOp>(op))
+    else if (isa<VerbatimOp>(op) || isa<IfDefOp>(op))
       perFileOps.push_back(&op);
     else if (!isa<ModuleTerminatorOp>(op)) {
       op.emitError("unknown operation");

--- a/test/Conversion/FIRRTLToRTL/lower-to-rtl-module.mlir
+++ b/test/Conversion/FIRRTLToRTL/lower-to-rtl-module.mlir
@@ -6,7 +6,7 @@
 // CHECK-NOT: firrtl.circuit
 
 // We should get a large header boilerplate.
-// CHECK:   sv.ifdef.procedural "PRINTF_COND" {
+// CHECK:   sv.ifdef "PRINTF_COND" {
 // CHECK-NEXT:   sv.verbatim "`define PRINTF_COND_ (`PRINTF_COND)"
 // CHECK-NEXT:  } else  {
 firrtl.circuit "Simple" {

--- a/test/Dialect/SV/errors.mlir
+++ b/test/Dialect/SV/errors.mlir
@@ -143,3 +143,9 @@ rtl.module @Cover(%arg0: i1) {
   // expected-error @+1 {{sv.cover should be in a procedural region}}
   sv.cover %arg0: i1
 }
+
+// -----
+rtl.module @IfDefProcedural() {
+  // expected-error @+1 {{sv.ifdef.procedural should be in a procedural region}}
+  sv.ifdef.procedural "Foo" {}
+}

--- a/test/firtool/split_verilog.mlir
+++ b/test/firtool/split_verilog.mlir
@@ -5,7 +5,7 @@
 // RUN: FileCheck %s --check-prefix=VERILOG-PLL < %t/pll.v
 
 sv.verbatim "// I'm everywhere"
-sv.ifdef.procedural "VERILATOR" {
+sv.ifdef "VERILATOR" {
   sv.verbatim "// Hello"
 } else {
   sv.verbatim "// World"


### PR DESCRIPTION
This PR checks that IfDefProceduralOp is in a procedural region. 
Currently, IfDefProceduralOp is sometimes used  as header in non-procedural region(= top level module). 
So this PR includes the modification of them. 