### PR TITLE
[Comb] Constant folding hook for comb.sub

### DIFF
--- a/include/circt/Dialect/Comb/Combinational.td
+++ b/include/circt/Dialect/Comb/Combinational.td
@@ -61,7 +61,6 @@ class UTVariadicOp<string mnemonic, list<OpTrait> traits = []> :
 
 // Arithmetic and Logical Operations.
 def AddOp : UTVariadicOp<"add", [Commutative]>;
-def SubOp : UTBinOp<"sub">;
 def MulOp : UTVariadicOp<"mul", [Commutative]>;
 def DivUOp : UTBinOp<"divu">;
 def DivSOp : UTBinOp<"divs">;
@@ -71,6 +70,7 @@ let hasFolder = true in {
   def ShlOp : UTBinOp<"shl">;
   def ShrUOp : UTBinOp<"shru">;
   def ShrSOp : UTBinOp<"shrs">;
+  def SubOp : UTBinOp<"sub">;
 }
 
 def AndOp : UTVariadicOp<"and", [Commutative]>;

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -404,6 +404,22 @@ OpFoldResult MergeOp::fold(ArrayRef<Attribute> constants) {
   return {};
 }
 
+OpFoldResult SubOp::fold(ArrayRef<Attribute> constants) {
+  APInt value;
+  // sub(x - 0) -> x
+  if (matchPattern(rhs(), m_RConstant(value)) && value.isNullValue())
+    return lhs();
+
+  // sub(x - x) -> 0
+  if (rhs() == lhs())
+    return getIntAttr(APInt(lhs().getType().getIntOrFloatBitWidth(), 0),
+                      getContext());
+
+  // Constant fold
+  return constFoldBinaryOp<IntegerAttr>(
+      constants, [](APInt a, APInt b) { return a -= b; });
+}
+
 OpFoldResult AddOp::fold(ArrayRef<Attribute> constants) {
   auto size = inputs().size();
 

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -416,8 +416,8 @@ OpFoldResult SubOp::fold(ArrayRef<Attribute> constants) {
                       getContext());
 
   // Constant fold
-  return constFoldBinaryOp<IntegerAttr>(
-      constants, [](APInt a, APInt b) { return a -= b; });
+  return constFoldBinaryOp<IntegerAttr>(constants,
+                                        [](APInt a, APInt b) { return a - b; });
 }
 
 OpFoldResult AddOp::fold(ArrayRef<Attribute> constants) {

--- a/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
+++ b/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
@@ -213,7 +213,7 @@ firrtl.circuit "Simple" {
     %50 = firrtl.div %c104_ui8, %c306_ui10 : (!firrtl.uint<8>, !firrtl.uint<10>) -> !firrtl.uint<8>
 
     // Issue #364: https://github.com/llvm/circt/issues/364
-    // CHECK: = comb.sub %c0_i12, %c-873_i12 : i12
+    // CHECK: = rtl.constant -873 : i12
     %c1175_ui11 = firrtl.constant(1175 : ui11) : !firrtl.uint<11>
     %51 = firrtl.neg %c1175_ui11 : (!firrtl.uint<11>) -> !firrtl.sint<12>
   }

--- a/test/Dialect/RTL/canonicalization.mlir
+++ b/test/Dialect/RTL/canonicalization.mlir
@@ -855,3 +855,29 @@ rtl.module @sext_identical(%a: i1) -> (i1) {
   %0 = comb.sext %a : (i1) -> (i1)
   rtl.output %0 : i1
 }
+
+// CHECK-LABEL:  rtl.module @sub_fold1(%arg0: i7) -> (i7) {
+// CHECK-NEXT:    %c-1_i7 = rtl.constant -1 : i7
+// CHECK-NEXT:    rtl.output %c-1_i7 : i7
+rtl.module @sub_fold1(%arg0: i7) -> (i7) {
+  %c11_i7 = rtl.constant 11 : i7
+  %c5_i7 = rtl.constant 12: i7
+  %0 = comb.sub %c11_i7, %c5_i7 : i7
+  rtl.output %0 : i7
+}
+
+// CHECK-LABEL: rtl.module @sub_fold2(%arg0: i7) -> (i7) {
+// CHECK-NEXT:    rtl.output %arg0 : i7
+rtl.module @sub_fold2(%arg0: i7) -> (i7) {
+  %c0_i7 = rtl.constant 0 : i7
+  %0 = comb.sub %arg0, %c0_i7 : i7
+  rtl.output %0 : i7
+}
+
+// CHECK-LABEL:  rtl.module @sub_fold3(%arg0: i7) -> (i7) {
+// CHECK-NEXT:     %c0_i7 = rtl.constant 0 : i7
+// CHECK-NEXT:     rtl.output %c0_i7 : i7
+rtl.module @sub_fold3(%arg0: i7) -> (i7) {
+  %0 = comb.sub %arg0, %arg0 : i7
+  rtl.output %0 : i7
+}


### PR DESCRIPTION
Add the fold hook for comb.sub to handle the following cases
1. x - 0
2. x - x
3. const1 - const2


Fix for https://github.com/llvm/circt/issues/769