### PR TITLE
[FIR Parsing] Use int64 to parse integers instead of 32

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -165,7 +165,7 @@ class BinaryPrimOp<string mnemonic, Type lhsType, Type rhsType, Type resultType,
     /// type if the input types are invalid.
     static FIRRTLType getResultType(FIRRTLType lhs, FIRRTLType rhs, Location loc);
     static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
-                                    ArrayRef<int32_t> integers, Location loc) {
+                                    ArrayRef<int64_t> integers, Location loc) {
       if (inputs.size() != 2 || !integers.empty()) {
         mlir::emitError(loc,"operation requires two operands and no constants");
         return {};
@@ -250,7 +250,7 @@ class UnaryPrimOp<string mnemonic, Type srcType, Type resultType,
     /// type if the input type is invalid.
     static FIRRTLType getResultType(FIRRTLType input, Location loc);
     static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
-                                    ArrayRef<int32_t> integers, Location loc) {
+                                    ArrayRef<int64_t> integers, Location loc) {
       if (inputs.size() != 1 || !integers.empty()) {
         mlir::emitError(loc, "operation requires one operand and no constants");
         return {};
@@ -330,7 +330,7 @@ def BitsPrimOp : PrimOp<"bits"> {
     static FIRRTLType getResultType(FIRRTLType input, int32_t high,
                                     int32_t low, Location loc);
     static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
-                                    ArrayRef<int32_t> integers, Location loc) {
+                                    ArrayRef<int64_t> integers, Location loc) {
       if (inputs.size() != 1 || integers.size() != 2) {
         mlir::emitError(loc,"operation requires one operand and two constants");
         return {};
@@ -359,7 +359,7 @@ def HeadPrimOp : PrimOp<"head"> {
     static FIRRTLType getResultType(FIRRTLType input, int32_t amount,
                                     Location loc);
     static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
-                                    ArrayRef<int32_t> integers, Location loc) {
+                                    ArrayRef<int64_t> integers, Location loc) {
       if (inputs.size() != 1 || integers.size() != 1) {
         mlir::emitError(loc, "operation requires one operand and one constant");
         return {};
@@ -406,7 +406,7 @@ def MuxPrimOp : PrimOp<"mux"> {
     static FIRRTLType getResultType(FIRRTLType sel, FIRRTLType high,
                                     FIRRTLType low, Location loc);
     static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
-                                    ArrayRef<int32_t> integers, Location loc) {
+                                    ArrayRef<int64_t> integers, Location loc) {
       if (inputs.size() != 3 || !integers.empty()) {
         mlir::emitError(loc,
                         "operation requires three operands and no constants");
@@ -445,7 +445,7 @@ def PadPrimOp : PrimOp<"pad"> {
     static FIRRTLType getResultType(FIRRTLType input, int32_t amount,
                                     Location loc);
     static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
-                                    ArrayRef<int32_t> integers, Location loc) {
+                                    ArrayRef<int64_t> integers, Location loc) {
       if (inputs.size() != 1 || integers.size() != 1) {
         mlir::emitError(loc, "operation requires one operand and one constant");
         return {};
@@ -473,7 +473,7 @@ class ShiftPrimOp<string mnemonic> : PrimOp<mnemonic> {
     static FIRRTLType getResultType(FIRRTLType input, int32_t amount,
                                     Location loc);
     static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
-                                    ArrayRef<int32_t> integers, Location loc) {
+                                    ArrayRef<int64_t> integers, Location loc) {
       if (inputs.size() != 1 || integers.size() != 1) {
         mlir::emitError(loc, "operation requires one operand and one constant");
         return {};
@@ -529,7 +529,7 @@ def TailPrimOp : PrimOp<"tail"> {
     static FIRRTLType getResultType(FIRRTLType input, int32_t amount,
                                     Location loc);
     static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
-                                    ArrayRef<int32_t> integers, Location loc) {
+                                    ArrayRef<int64_t> integers, Location loc) {
       if (inputs.size() != 1 || integers.size() != 1) {
         mlir::emitError(loc, "operation requires one operand and one constant");
         return {};

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -216,10 +216,10 @@ struct FIRParser {
 
   /// Parse 'intLit' into the specified value.
   ParseResult parseIntLit(APInt &result, const Twine &message);
-  ParseResult parseIntLit(int32_t &result, const Twine &message);
+  ParseResult parseIntLit(int64_t &result, const Twine &message);
 
   // Parse ('<' intLit '>')? setting result to -1 if not present.
-  ParseResult parseOptionalWidth(int32_t &result);
+  ParseResult parseOptionalWidth(int64_t &result);
 
   // Parse the 'id' grammar, which is an identifier or an allowed keyword.
   ParseResult parseId(StringRef &result, const Twine &message);
@@ -538,13 +538,13 @@ ParseResult FIRParser::parseIntLit(APInt &result, const Twine &message) {
   }
 }
 
-ParseResult FIRParser::parseIntLit(int32_t &result, const Twine &message) {
+ParseResult FIRParser::parseIntLit(int64_t &result, const Twine &message) {
   APInt value;
   auto loc = getToken().getLoc();
   if (parseIntLit(value, message))
     return failure();
 
-  result = (int32_t)value.getLimitedValue();
+  result = (int64_t)value.getLimitedValue();
   if (result != value)
     return emitError(loc, "value is too big to handle"), failure();
   return success();
@@ -553,7 +553,7 @@ ParseResult FIRParser::parseIntLit(int32_t &result, const Twine &message) {
 // optional-width ::= ('<' intLit '>')?
 //
 // This returns with result equal to -1 if not present.
-ParseResult FIRParser::parseOptionalWidth(int32_t &result) {
+ParseResult FIRParser::parseOptionalWidth(int64_t &result) {
   if (!consumeIf(FIRToken::less))
     return result = -1, success();
 
@@ -659,7 +659,7 @@ ParseResult FIRParser::parseType(FIRRTLType &result, const Twine &message) {
     consumeToken();
 
     // Parse a width specifier if present.
-    int32_t width;
+    int64_t width;
     if (parseOptionalWidth(width))
       return failure();
 
@@ -703,7 +703,7 @@ ParseResult FIRParser::parseType(FIRRTLType &result, const Twine &message) {
   // Handle postfix vector sizes.
   while (consumeIf(FIRToken::l_square)) {
     auto sizeLoc = getToken().getLoc();
-    int32_t size;
+    int64_t size;
     if (parseIntLit(size, "expected width") ||
         parseToken(FIRToken::r_square, "expected ]"))
       return failure();
@@ -1158,7 +1158,7 @@ ParseResult FIRStmtParser::parsePostFixFieldId(Value &result,
 ParseResult FIRStmtParser::parsePostFixIntSubscript(Value &result,
                                                     SubOpVector &subOps) {
   auto indexLoc = getToken().getLoc();
-  int32_t indexNo;
+  int64_t indexNo;
   if (parseIntLit(indexNo, "expected index") ||
       parseToken(FIRToken::r_square, "expected ']'"))
     return failure();
@@ -1224,7 +1224,7 @@ ParseResult FIRStmtParser::parsePrimExp(Value &result, SubOpVector &subOps) {
 
   // Parse the operands and constant integer arguments.
   SmallVector<Value, 4> operands;
-  SmallVector<int32_t, 4> integers;
+  SmallVector<int64_t, 4> integers;
   if (parseListUntil(FIRToken::r_paren, [&]() -> ParseResult {
         // Handle the integer constant case if present.
         if (getToken().isAny(FIRToken::integer, FIRToken::signed_integer,
@@ -1314,7 +1314,7 @@ ParseResult FIRStmtParser::parseIntegerLiteralExp(Value &result,
   consumeToken();
 
   // Parse a width specifier if present.
-  int32_t width;
+  int64_t width;
   APInt value;
   if (parseOptionalWidth(width) ||
       parseToken(FIRToken::l_paren, "expected '(' in integer expression") ||
@@ -1729,7 +1729,7 @@ ParseResult FIRStmtParser::parseStop() {
   SmallVector<Operation *, 8> subOps;
 
   Value clock, condition;
-  int32_t exitCode;
+  int64_t exitCode;
   if (parseExp(clock, subOps, "expected clock expression in 'stop'") ||
       parseExp(condition, subOps, "expected condition in 'stop'") ||
       parseIntLit(exitCode, "expected exit code in 'stop'") ||
@@ -2107,7 +2107,7 @@ ParseResult FIRStmtParser::parseMem(unsigned memIndent) {
     return failure();
 
   FIRRTLType type;
-  int32_t depth = -1, readLatency = -1, writeLatency = -1;
+  int64_t depth = -1, readLatency = -1, writeLatency = -1;
   RUWAttr ruw = RUWAttr::Undefined;
 
   SmallVector<std::pair<StringAttr, BundleType>, 4> ports;

--- a/test/circt-translate/parse_int64.fir
+++ b/test/circt-translate/parse_int64.fir
@@ -1,0 +1,18 @@
+; RUN: circt-translate %s --import-firrtl | FileCheck %s --strict-whitespace
+
+circuit Foo:
+  module Foo:
+    mem memory:
+      data-type => UInt<8>
+      depth => 2147483648
+      reader => r
+      read-latency => 0
+      write-latency => 1
+      read-under-write => undefined
+; CHECK: module  {
+; CHECK:   firrtl.circuit "Foo" {
+; CHECK:     firrtl.module @Foo() {
+; CHECK:       %memory_r = firrtl.mem Undefined {depth = 2147483648 : i64, name = "memory", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<31>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<8>>
+; CHECK:     }
+; CHECK:   }
+; CHECK: }


### PR DESCRIPTION
The FIRParser is currently using an int32_t to parse integers, update it to int64_t.
Fix for https://github.com/llvm/circt/issues/783