### PR TITLE
[cmake] Adding an option to produce a standalone install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,3 +354,21 @@ if (NOT LLVM_ENABLE_IDE)
 endif()
 
 add_subdirectory(cmake/modules)
+
+# Set RPATH to $ORIGIN on all targets.
+function(set_rpath_all_targets dir)
+  get_property(subdirectories DIRECTORY ${dir} PROPERTY SUBDIRECTORIES)
+  foreach(subdir ${subdirectories})
+    set_rpath_all_targets(${subdir})
+  endforeach()
+
+  get_directory_property(LCL_TARGETS DIRECTORY ${dir} BUILDSYSTEM_TARGETS)
+  set_property(TARGET ${LCL_TARGETS} PROPERTY INSTALL_RPATH "$ORIGIN/../lib")
+endfunction()
+
+option(STANDALONE_INSTALL "Create an 'install' for packaging which doesn't \
+         require installation" off)
+if (STANDALONE_INSTALL)
+  message(STATUS "Setting an $ORIGIN-based RPATH on all executables")
+  set_rpath_all_targets(${CMAKE_CURRENT_SOURCE_DIR})
+endif()

--- a/lib/Dialect/ESI/CMakeLists.txt
+++ b/lib/Dialect/ESI/CMakeLists.txt
@@ -36,6 +36,9 @@ endif()
 if (ESI_CAPNP)
   list(APPEND srcs capnp/Schema.cpp)
   list(APPEND ESI_LinkLibs CapnProto::capnp CapnProto::capnpc)
+  install(FILES ${CapnProto_capnp_IMPORTED_LOCATION} DESTINATION lib)
+  install(FILES ${CapnProto_capnpc_IMPORTED_LOCATION} DESTINATION lib)
+  install(FILES ${CapnProto_kj_IMPORTED_LOCATION} DESTINATION lib)
 endif()
 
 add_circt_dialect_library(CIRCTESI


### PR DESCRIPTION
Enables producing binary packages (e.g. tars) which do not require installation into the system. Sets the binaries' RPATHs to point to the 'lib' directory within said package.

There are cmake built-in properties which are supposed to do this sort of thing, but I couldn't get them to work after a _full day_ of trying. This is the the solution I got to work and it doesn't seem too hacky to me. CMake lacks a global list of targets (I don't understand why) so the recurse through the directories is necessary. :(