### PR TITLE
Update LLVM

### DIFF
--- a/include/circt/Dialect/Comb/CombDialect.h
+++ b/include/circt/Dialect/Comb/CombDialect.h
@@ -13,8 +13,8 @@
 #ifndef CIRCT_DIALECT_COMB_COMBDIALECT_H
 #define CIRCT_DIALECT_COMB_COMBDIALECT_H
 
-#include "mlir/IR/Dialect.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Dialect.h"
 
 namespace circt {
 namespace comb {

--- a/include/circt/Dialect/Comb/CombDialect.h
+++ b/include/circt/Dialect/Comb/CombDialect.h
@@ -14,6 +14,7 @@
 #define CIRCT_DIALECT_COMB_COMBDIALECT_H
 
 #include "mlir/IR/Dialect.h"
+#include "mlir/IR/BuiltinAttributes.h"
 
 namespace circt {
 namespace comb {

--- a/include/circt/Dialect/ESI/ESIDialect.h
+++ b/include/circt/Dialect/ESI/ESIDialect.h
@@ -37,6 +37,10 @@ public:
   /// Print a type registered to this dialect
   void printType(mlir::Type type,
                  mlir::DialectAsmPrinter &printer) const override;
+
+private:
+  /// Register all ESI types.
+  void registerTypes();
 };
 
 void registerESIPasses();

--- a/include/circt/Dialect/FIRRTL/FIRRTLDialect.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDialect.h
@@ -35,6 +35,10 @@ public:
                                  Location loc) override;
 
   static StringRef getDialectNamespace() { return "firrtl"; }
+
+private:
+  /// Register all FIRRTL types.
+  void registerTypes();
 };
 
 /// If the specified attribute list has a firrtl.name attribute, return its

--- a/include/circt/Dialect/RTL/RTLDialect.h
+++ b/include/circt/Dialect/RTL/RTLDialect.h
@@ -34,6 +34,10 @@ public:
 
   Operation *materializeConstant(OpBuilder &builder, Attribute value, Type type,
                                  Location loc) override;
+
+private:
+  /// Register all RTL types.
+  void registerTypes();
 };
 
 } // namespace rtl

--- a/include/circt/Dialect/SV/SVDialect.h
+++ b/include/circt/Dialect/SV/SVDialect.h
@@ -32,6 +32,7 @@ public:
   /// Print a type registered to this dialect
   void printType(mlir::Type type,
                  mlir::DialectAsmPrinter &printer) const override;
+
 private:
   /// Register all SV types.
   void registerTypes();

--- a/include/circt/Dialect/SV/SVDialect.h
+++ b/include/circt/Dialect/SV/SVDialect.h
@@ -32,6 +32,9 @@ public:
   /// Print a type registered to this dialect
   void printType(mlir::Type type,
                  mlir::DialectAsmPrinter &printer) const override;
+private:
+  /// Register all SV types.
+  void registerTypes();
 };
 
 } // namespace sv

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -207,7 +207,8 @@ def AlwaysFFOp : SVOp<"alwaysff", [HasRegionTerminator, NoRegionArguments,
   
   let regions = (region SizedRegion<1>:$bodyBlk, AnyRegion:$resetBlk);
   let arguments = (ins EventControlAttr:$clockEdge, I1:$clock, 
-                       DefaultValuedAttr<ResetTypeAttr, "0">:$resetStyle,
+                       DefaultValuedAttr<ResetTypeAttr, 
+                                         "ResetType::NoReset">:$resetStyle,
                        OptionalAttr<EventControlAttr>:$resetEdge, 
                        Optional<I1>:$reset);
   let results = (outs);

--- a/lib/Dialect/ESI/ESIDialect.cpp
+++ b/lib/Dialect/ESI/ESIDialect.cpp
@@ -22,10 +22,8 @@ namespace esi {
 
 ESIDialect::ESIDialect(MLIRContext *context)
     : Dialect("esi", context, TypeID::get<ESIDialect>()) {
-  addTypes<
-#define GET_TYPEDEF_LIST
-#include "circt/Dialect/ESI/ESITypes.cpp.inc"
-      >();
+
+  registerTypes();
 
   addOperations<
 #define GET_OP_LIST

--- a/lib/Dialect/ESI/ESITypes.cpp
+++ b/lib/Dialect/ESI/ESITypes.cpp
@@ -92,3 +92,10 @@ void ESIDialect::printType(Type type, DialectAsmPrinter &printer) const {
     return;
   llvm_unreachable("unexpected 'esi' type kind");
 }
+
+void ESIDialect::registerTypes() {
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "circt/Dialect/ESI/ESITypes.cpp.inc"
+      >();
+}

--- a/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
@@ -126,10 +126,7 @@ FIRRTLDialect::FIRRTLDialect(MLIRContext *context)
     : Dialect(getDialectNamespace(), context,
               ::mlir::TypeID::get<FIRRTLDialect>()) {
 
-  // Register types.
-  addTypes<SIntType, UIntType, ClockType, ResetType, AsyncResetType, AnalogType,
-           // Derived Types
-           FlipType, BundleType, FVectorType>();
+  registerTypes();
 
   // Register operations.
   addOperations<

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -779,3 +779,9 @@ FIRRTLType FVectorType::getPassiveType() {
   impl->passiveContainsAnalogTypeInfo.setPointer(passiveType);
   return passiveType;
 }
+
+void FIRRTLDialect::registerTypes() {
+  addTypes<SIntType, UIntType, ClockType, ResetType, AsyncResetType, AnalogType,
+           // Derived Types
+           FlipType, BundleType, FVectorType>();
+}

--- a/lib/Dialect/RTL/RTLDialect.cpp
+++ b/lib/Dialect/RTL/RTLDialect.cpp
@@ -57,11 +57,7 @@ RTLDialect::RTLDialect(MLIRContext *context)
     : Dialect(getDialectNamespace(), context,
               ::mlir::TypeID::get<RTLDialect>()) {
 
-  // Register types.
-  addTypes<
-#define GET_TYPEDEF_LIST
-#include "circt/Dialect/RTL/RTLTypes.cpp.inc"
-      >();
+  registerTypes();
 
   // Register operations.
   addOperations<

--- a/lib/Dialect/RTL/RTLTypes.cpp
+++ b/lib/Dialect/RTL/RTLTypes.cpp
@@ -314,3 +314,10 @@ void RTLDialect::printType(Type type, DialectAsmPrinter &printer) const {
     return;
   llvm_unreachable("unexpected 'rtl' type");
 }
+
+void RTLDialect::registerTypes() {
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "circt/Dialect/RTL/RTLTypes.cpp.inc"
+      >();
+}

--- a/lib/Dialect/SV/SVDialect.cpp
+++ b/lib/Dialect/SV/SVDialect.cpp
@@ -27,11 +27,8 @@ SVDialect::SVDialect(MLIRContext *context)
     : Dialect(getDialectNamespace(), context,
               ::mlir::TypeID::get<SVDialect>()) {
   context->loadDialect<circt::comb::CombDialect>();
-  // Register types.
-  addTypes<
-#define GET_TYPEDEF_LIST
-#include "circt/Dialect/SV/SVTypes.cpp.inc"
-      >();
+
+  registerTypes();
 
   // Register operations.
   addOperations<

--- a/lib/Dialect/SV/SVTypes.cpp
+++ b/lib/Dialect/SV/SVTypes.cpp
@@ -98,3 +98,10 @@ void SVDialect::printType(Type type, DialectAsmPrinter &printer) const {
     return;
   llvm_unreachable("unexpected 'rtl' type kind");
 }
+
+void SVDialect::registerTypes() {
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "circt/Dialect/SV/SVTypes.cpp.inc"
+      >();
+}

--- a/test/Conversion/StandardToHandshake/Affine/test-affine-for.mlir
+++ b/test/Conversion/StandardToHandshake/Affine/test-affine-for.mlir
@@ -64,7 +64,7 @@ func @empty_body () -> () {
 // Simple load store pair in the loop body. 
 
 func @load_store () -> () {
-  %A = alloc() : memref<10xf32>
+  %A = memref.alloc() : memref<10xf32>
   affine.for %i = 0 to 10 {
     %0 = affine.load %A[%i] : memref<10xf32>
     affine.store %0, %A[%i] : memref<10xf32>

--- a/test/Conversion/StandardToHandshake/Affine/test-affine-load-store.mlir
+++ b/test/Conversion/StandardToHandshake/Affine/test-affine-load-store.mlir
@@ -6,7 +6,7 @@
 
 func @load_store () -> () {
   %c0 = constant 0 : index
-  %A = alloc() : memref<10xf32>
+  %A = memref.alloc() : memref<10xf32>
   %0 = affine.load %A[%c0] : memref<10xf32>
   affine.store %0, %A[%c0] : memref<10xf32>
   return
@@ -32,7 +32,7 @@ func @load_store () -> () {
 
 func @affine_map_addr () -> () {
   %c5 = constant 5 : index
-  %A = alloc() : memref<10xf32>
+  %A = memref.alloc() : memref<10xf32>
   %0 = affine.load %A[%c5 + 1] : memref<10xf32>
   affine.store %0, %A[%c5 - 1] : memref<10xf32>
   return

--- a/test/Conversion/StandardToHandshake/test10.mlir
+++ b/test/Conversion/StandardToHandshake/test10.mlir
@@ -7,9 +7,9 @@
 // CHECK-SAME:                                     %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> none {
 // CHECK:           %[[VAL_2:.*]] = "handshake.merge"(%[[VAL_0]]) : (index) -> index
 // CHECK:           %[[VAL_3:.*]]:6 = "handshake.fork"(%[[VAL_1]]) {control = true} : (none) -> (none, none, none, none, none, none)
-// CHECK:           %[[VAL_4:.*]] = alloc() : memref<100xf32>
-// CHECK:           %[[VAL_5:.*]] = alloc() : memref<100xf32, 2>
-// CHECK:           %[[VAL_6:.*]] = alloc() : memref<1xi32>
+// CHECK:           %[[VAL_4:.*]] = memref.alloc() : memref<100xf32>
+// CHECK:           %[[VAL_5:.*]] = memref.alloc() : memref<100xf32, 2>
+// CHECK:           %[[VAL_6:.*]] = memref.alloc() : memref<1xi32>
 // CHECK:           %[[VAL_7:.*]] = "handshake.constant"(%[[VAL_3]]#4) {value = 0 : index} : (none) -> index
 // CHECK:           %[[VAL_8:.*]] = "handshake.constant"(%[[VAL_3]]#3) {value = 64 : index} : (none) -> index
 // CHECK:           %[[VAL_9:.*]] = "handshake.constant"(%[[VAL_3]]#2) {value = 0 : index} : (none) -> index
@@ -83,7 +83,7 @@
 // CHECK:           %[[VAL_87:.*]] = addi %[[VAL_68]]#1, %[[VAL_86]] : index
 // CHECK:           %[[VAL_88:.*]] = "handshake.constant"(%[[VAL_85]]#0) {value = 11 : index} : (none) -> index
 // CHECK:           %[[VAL_89:.*]] = addi %[[VAL_70]]#1, %[[VAL_88]] : index
-// CHECK:           dma_start %[[VAL_72]]#1{{\[}}%[[VAL_87]]], %[[VAL_74]]#1{{\[}}%[[VAL_89]]], %[[VAL_76]]#1, %[[VAL_78]]#1{{\[}}%[[VAL_80]]#1] : memref<100xf32>, memref<100xf32, 2>, memref<1xi32>
+// CHECK:           memref.dma_start %[[VAL_72]]#1{{\[}}%[[VAL_87]]], %[[VAL_74]]#1{{\[}}%[[VAL_89]]], %[[VAL_76]]#1, %[[VAL_78]]#1{{\[}}%[[VAL_80]]#1] : memref<100xf32>, memref<100xf32, 2>, memref<1xi32>
 // CHECK:           %[[VAL_90:.*]] = addi %[[VAL_68]]#0, %[[VAL_82]]#1 : index
 // CHECK:           %[[VAL_27]] = "handshake.branch"(%[[VAL_70]]#0) {control = false} : (index) -> index
 // CHECK:           %[[VAL_29]] = "handshake.branch"(%[[VAL_72]]#0) {control = false} : (memref<100xf32>) -> memref<100xf32>
@@ -101,9 +101,9 @@
 // CHECK:         }
 // CHECK:       }
 
-    %0 = alloc() : memref<100xf32>
-    %1 = alloc() : memref<100xf32, 2>
-    %2 = alloc() : memref<1xi32>
+    %0 = memref.alloc() : memref<100xf32>
+    %1 = memref.alloc() : memref<100xf32, 2>
+    %2 = memref.alloc() : memref<1xi32>
     %c0 = constant 0 : index
     %c64 = constant 64 : index
     %c0_0 = constant 0 : index
@@ -118,7 +118,7 @@
     %5 = addi %3, %c7 : index
     %c11 = constant 11 : index
     %6 = addi %arg0, %c11 : index
-    dma_start %0[%5], %1[%6], %c64, %2[%c0] : memref<100xf32>, memref<100xf32, 2>, memref<1xi32>
+    memref.dma_start %0[%5], %1[%6], %c64, %2[%c0] : memref<100xf32>, memref<100xf32, 2>, memref<1xi32>
     %7 = addi %3, %c1 : index
     br ^bb1(%7 : index)
   ^bb3: // pred: ^bb1

--- a/test/Conversion/StandardToHandshake/test14.mlir
+++ b/test/Conversion/StandardToHandshake/test14.mlir
@@ -73,7 +73,7 @@
 // CHECK:         }
 // CHECK:       }
 
-    %0 = alloc() : memref<10xf32>
+    %0 = memref.alloc() : memref<10xf32>
     %cst = constant 1.100000e+01 : f32
     %c0 = constant 0 : index
     %c10 = constant 10 : index
@@ -88,7 +88,7 @@
     %4 = addi %1, %3 : index
     %c7 = constant 7 : index
     %5 = addi %4, %c7 : index
-    store %cst, %0[%5] : memref<10xf32>
+    memref.store %cst, %0[%5] : memref<10xf32>
     %6 = addi %1, %c1 : index
     br ^bb1(%6 : index)
   ^bb3: // pred: ^bb1

--- a/test/Conversion/StandardToHandshake/test15.mlir
+++ b/test/Conversion/StandardToHandshake/test15.mlir
@@ -64,7 +64,7 @@
 // CHECK:         }
 // CHECK:       }
 
-    %0 = alloc() : memref<10xf32>
+    %0 = memref.alloc() : memref<10xf32>
     %c0 = constant 0 : index
     %c10 = constant 10 : index
     %c1 = constant 1 : index
@@ -76,7 +76,7 @@
     %3 = addi %1, %arg0 : index
     %c7 = constant 7 : index
     %4 = addi %3, %c7 : index
-    %5 = load %0[%4] : memref<10xf32>
+    %5 = memref.load %0[%4] : memref<10xf32>
     %6 = addi %1, %c1 : index
     br ^bb1(%6 : index)
   ^bb3: // pred: ^bb1

--- a/test/Conversion/StandardToHandshake/test28.mlir
+++ b/test/Conversion/StandardToHandshake/test28.mlir
@@ -71,8 +71,8 @@
 // CHECK:       }
 
 
-    %0 = alloc() : memref<10xf32>
-    %10 = alloc() : memref<10xf32>
+    %0 = memref.alloc() : memref<10xf32>
+    %10 = memref.alloc() : memref<10xf32>
     %c0 = constant 0 : index
     %c10 = constant 10 : index
     %c1 = constant 1 : index
@@ -84,11 +84,11 @@
     %3 = addi %1, %arg0 : index
     %c7 = constant 7 : index
     %4 = addi %3, %c7 : index
-    %5 = load %0[%4] : memref<10xf32>
+    %5 = memref.load %0[%4] : memref<10xf32>
     %6 = addi %1, %c1 : index
-    %7 = load %10[%4] : memref<10xf32>
+    %7 = memref.load %10[%4] : memref<10xf32>
     %8 = addf %5, %7 : f32
-    store %8, %10[%4] : memref<10xf32>
+    memref.store %8, %10[%4] : memref<10xf32>
     br ^bb1(%6 : index)
   ^bb3: // pred: ^bb1
     return

--- a/test/Conversion/StandardToHandshake/test29.mlir
+++ b/test/Conversion/StandardToHandshake/test29.mlir
@@ -40,7 +40,7 @@ func @load_store(memref<4x4xi32>, index, index) {
 
 ^bb0(%0: memref<4x4xi32>, %1: index, %2: index):
   %c1 = constant 11 : i32
-  store %c1, %0[%1, %2] : memref<4x4xi32>
-  %3 = load %0[%1, %2] : memref<4x4xi32>
+  memref.store %c1, %0[%1, %2] : memref<4x4xi32>
+  %3 = memref.load %0[%1, %2] : memref<4x4xi32>
   return
 }

--- a/test/Conversion/StandardToHandshake/test30.mlir
+++ b/test/Conversion/StandardToHandshake/test30.mlir
@@ -83,10 +83,10 @@
 // CHECK:         }
 // CHECK:       }
 
-    %0 = alloc() : memref<10xf32>
+    %0 = memref.alloc() : memref<10xf32>
     %c0 = constant 0 : index
     %c10 = constant 10 : index
-    %9 = load %0[%c0] : memref<10xf32>
+    %9 = memref.load %0[%c0] : memref<10xf32>
     %c1 = constant 1 : index
     br ^bb1(%c0 : index)
   ^bb1(%1: index):      // 2 preds: ^bb0, ^bb2
@@ -96,12 +96,12 @@
     %3 = addi %1, %arg0 : index
     %c7 = constant 7 : index
     %4 = addi %3, %c7 : index
-    %5 = load %0[%4] : memref<10xf32>
+    %5 = memref.load %0[%4] : memref<10xf32>
     %6 = addi %1, %c1 : index
-    %7 = load %0[%4] : memref<10xf32>
+    %7 = memref.load %0[%4] : memref<10xf32>
     %8 = addf %5, %7 : f32
     %11 = addf %9, %9 : f32
-    store %8, %0[%4] : memref<10xf32>
+    memref.store %8, %0[%4] : memref<10xf32>
     br ^bb1(%6 : index)
   ^bb3: // pred: ^bb1
     return

--- a/test/Conversion/StandardToHandshake/test31.mlir
+++ b/test/Conversion/StandardToHandshake/test31.mlir
@@ -83,11 +83,11 @@
 // CHECK:         }
 // CHECK:       }
 
-    %0 = alloc() : memref<10xf32>
-    %10 = alloc() : memref<10xf32>
+    %0 = memref.alloc() : memref<10xf32>
+    %10 = memref.alloc() : memref<10xf32>
     %c0 = constant 0 : index
     %c10 = constant 10 : index
-    %9 = load %0[%c0] : memref<10xf32>
+    %9 = memref.load %0[%c0] : memref<10xf32>
     %c1 = constant 1 : index
     br ^bb1(%c0 : index)
   ^bb1(%1: index):      // 2 preds: ^bb0, ^bb2
@@ -97,12 +97,12 @@
     %3 = addi %1, %arg0 : index
     %c7 = constant 7 : index
     %4 = addi %3, %c7 : index
-    %5 = load %0[%4] : memref<10xf32>
+    %5 = memref.load %0[%4] : memref<10xf32>
     %6 = addi %1, %c1 : index
-    %7 = load %10[%4] : memref<10xf32>
+    %7 = memref.load %10[%4] : memref<10xf32>
     %8 = addf %5, %7 : f32
     %11 = addf %9, %9 : f32
-    store %8, %10[%4] : memref<10xf32>
+    memref.store %8, %10[%4] : memref<10xf32>
     br ^bb1(%6 : index)
   ^bb3: // pred: ^bb1
     return

--- a/test/Conversion/StandardToHandshake/test32.mlir
+++ b/test/Conversion/StandardToHandshake/test32.mlir
@@ -60,10 +60,10 @@
 // CHECK:         }
 // CHECK:       }
 
-    %10 = alloc() : memref<10xf32>
+    %10 = memref.alloc() : memref<10xf32>
     %c0 = constant 0 : index
     %c10 = constant 10 : index
-    %5 = load %10[%c10] : memref<10xf32>
+    %5 = memref.load %10[%c10] : memref<10xf32>
     br ^bb1(%c0 : index)
   ^bb1(%1: index):      // 2 preds: ^bb0, ^bb2
     %2 = cmpi slt, %1, %c10 : index
@@ -71,9 +71,9 @@
   ^bb2: // pred: ^bb1
     %c1 = constant 1 : index
     %3 = addi %1, %c1 : index
-    %7 = load %10[%3] : memref<10xf32>
+    %7 = memref.load %10[%3] : memref<10xf32>
     %8 = addf %5, %7 : f32
-    store %8, %10[%3] : memref<10xf32>
+    memref.store %8, %10[%3] : memref<10xf32>
     br ^bb1(%3 : index)
   ^bb3: // pred: ^bb1
     return

--- a/test/Conversion/StandardToHandshake/test33.mlir
+++ b/test/Conversion/StandardToHandshake/test33.mlir
@@ -52,7 +52,7 @@
 // CHECK:         }
 // CHECK:       }
 
-    %10 = alloc() : memref<10xf32>
+    %10 = memref.alloc() : memref<10xf32>
     %c0 = constant 0 : index
     %c10 = constant 10 : index
     br ^bb1(%c0 : index)
@@ -61,11 +61,11 @@
     cond_br %2, ^bb2, ^bb3
   ^bb2: // pred: ^bb1
     %c1 = constant 1 : index
-    %5 = load %10[%c1] : memref<10xf32>
+    %5 = memref.load %10[%c1] : memref<10xf32>
     %3 = addi %1, %c1 : index
-    %7 = load %10[%3] : memref<10xf32>
+    %7 = memref.load %10[%3] : memref<10xf32>
     %8 = addf %5, %7 : f32
-    store %8, %10[%3] : memref<10xf32>
+    memref.store %8, %10[%3] : memref<10xf32>
     br ^bb1(%3 : index)
   ^bb3: // pred: ^bb1
     return

--- a/test/Conversion/StandardToHandshake/test34.mlir
+++ b/test/Conversion/StandardToHandshake/test34.mlir
@@ -55,7 +55,7 @@
 // CHECK:         }
 // CHECK:       }
 
-    %10 = alloc() : memref<10xf32>
+    %10 = memref.alloc() : memref<10xf32>
     %c0 = constant 0 : index
     %c10 = constant 10 : index
     br ^bb1(%c0 : index)
@@ -65,10 +65,10 @@
   ^bb2: // pred: ^bb1
     %c1 = constant 1 : index
     %3 = addi %1, %c1 : index
-    %7 = load %10[%3] : memref<10xf32>
+    %7 = memref.load %10[%3] : memref<10xf32>
     %8 = addf %7, %7 : f32
-    store %8, %10[%3] : memref<10xf32>
-    %5 = load %10[%c1] : memref<10xf32>
+    memref.store %8, %10[%3] : memref<10xf32>
+    %5 = memref.load %10[%c1] : memref<10xf32>
     br ^bb1(%3 : index)
   ^bb3: // pred: ^bb1
     return

--- a/test/Conversion/StandardToHandshake/test35.mlir
+++ b/test/Conversion/StandardToHandshake/test35.mlir
@@ -61,12 +61,12 @@
 // CHECK:         }
 // CHECK:       }
 
-    %10 = alloc() : memref<10xf32>
-    %11 = alloc() : memref<10xf32>
+    %10 = memref.alloc() : memref<10xf32>
+    %11 = memref.alloc() : memref<10xf32>
     %c0 = constant 0 : index
     %c10 = constant 10 : index
-    %5 = load %10[%c10] : memref<10xf32>
-    store %5, %11[%c10] : memref<10xf32>
+    %5 = memref.load %10[%c10] : memref<10xf32>
+    memref.store %5, %11[%c10] : memref<10xf32>
     br ^bb1(%c0 : index)
   ^bb1(%1: index):      // 2 preds: ^bb0, ^bb2
     %2 = cmpi slt, %1, %c10 : index
@@ -74,9 +74,9 @@
   ^bb2: // pred: ^bb1
     %c1 = constant 1 : index
     %3 = addi %1, %c1 : index
-    %7 = load %11[%3] : memref<10xf32>
+    %7 = memref.load %11[%3] : memref<10xf32>
     %8 = addf %5, %7 : f32
-    store %8, %10[%3] : memref<10xf32>
+    memref.store %8, %10[%3] : memref<10xf32>
     br ^bb1(%3 : index)
   ^bb3: // pred: ^bb1
     return

--- a/test/Conversion/StandardToHandshake/test9.mlir
+++ b/test/Conversion/StandardToHandshake/test9.mlir
@@ -7,7 +7,7 @@ func @affine_dma_wait(%arg0: index) {
 // CHECK-SAME:                                    %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> none {
 // CHECK:           %[[VAL_2:.*]] = "handshake.merge"(%[[VAL_0]]) : (index) -> index
 // CHECK:           %[[VAL_3:.*]]:5 = "handshake.fork"(%[[VAL_1]]) {control = true} : (none) -> (none, none, none, none, none)
-// CHECK:           %[[VAL_4:.*]] = alloc() : memref<1xi32>
+// CHECK:           %[[VAL_4:.*]] = memref.alloc() : memref<1xi32>
 // CHECK:           %[[VAL_5:.*]] = "handshake.constant"(%[[VAL_3]]#3) {value = 64 : index} : (none) -> index
 // CHECK:           %[[VAL_6:.*]] = "handshake.constant"(%[[VAL_3]]#2) {value = 0 : index} : (none) -> index
 // CHECK:           %[[VAL_7:.*]] = "handshake.constant"(%[[VAL_3]]#1) {value = 10 : index} : (none) -> index
@@ -61,7 +61,7 @@ func @affine_dma_wait(%arg0: index) {
 // CHECK:           %[[VAL_62:.*]] = addi %[[VAL_50]]#1, %[[VAL_52]]#1 : index
 // CHECK:           %[[VAL_63:.*]] = "handshake.constant"(%[[VAL_61]]#0) {value = 17 : index} : (none) -> index
 // CHECK:           %[[VAL_64:.*]] = addi %[[VAL_62]], %[[VAL_63]] : index
-// CHECK:           dma_wait %[[VAL_54]]#1{{\[}}%[[VAL_64]]], %[[VAL_56]]#1 : memref<1xi32>
+// CHECK:           memref.dma_wait %[[VAL_54]]#1{{\[}}%[[VAL_64]]], %[[VAL_56]]#1 : memref<1xi32>
 // CHECK:           %[[VAL_65:.*]] = addi %[[VAL_50]]#0, %[[VAL_58]]#1 : index
 // CHECK:           %[[VAL_21]] = "handshake.branch"(%[[VAL_52]]#0) {control = false} : (index) -> index
 // CHECK:           %[[VAL_23]] = "handshake.branch"(%[[VAL_54]]#0) {control = false} : (memref<1xi32>) -> memref<1xi32>
@@ -76,7 +76,7 @@ func @affine_dma_wait(%arg0: index) {
 // CHECK:         }
 // CHECK:       }
 
-    %0 = alloc() : memref<1xi32>
+    %0 = memref.alloc() : memref<1xi32>
     %c64 = constant 64 : index
     %c0 = constant 0 : index
     %c10 = constant 10 : index
@@ -89,7 +89,7 @@ func @affine_dma_wait(%arg0: index) {
     %3 = addi %1, %arg0 : index
     %c17 = constant 17 : index
     %4 = addi %3, %c17 : index
-    dma_wait %0[%4], %c64 : memref<1xi32>
+    memref.dma_wait %0[%4], %c64 : memref<1xi32>
     %5 = addi %1, %c1 : index
     br ^bb1(%5 : index)
   ^bb3: // pred: ^bb1

--- a/test/circt-opt/commandline.mlir
+++ b/test/circt-opt/commandline.mlir
@@ -11,6 +11,7 @@
 // DIALECT-NEXT: handshake
 // DIALECT-NEXT: llhd
 // DIALECT-NEXT: llvm
+// DIALECT-NEXT: memref
 // DIALECT-NEXT: rtl
 // DIALECT-NEXT: staticlogic
 // DIALECT-NEXT: std

--- a/test/handshake-runner/cdiv-old-std.mlir
+++ b/test/handshake-runner/cdiv-old-std.mlir
@@ -20,35 +20,35 @@ module {
     %12 = cmpi slt, %11, %c4 : index
     cond_br %12, ^bb2, ^bb6
   ^bb2:	// pred: ^bb1
-    %13 = load %0[%11] : memref<4xi32>
-    %14 = load %2[%11] : memref<4xi32>
-    %15 = load %0[%11] : memref<4xi32>
-    %16 = load %2[%11] : memref<4xi32>
-    %17 = load %10[%11] : memref<4xi1>
+    %13 = memref.load %0[%11] : memref<4xi32>
+    %14 = memref.load %2[%11] : memref<4xi32>
+    %15 = memref.load %0[%11] : memref<4xi32>
+    %16 = memref.load %2[%11] : memref<4xi32>
+    %17 = memref.load %10[%11] : memref<4xi1>
     cond_br %17, ^bb3, ^bb4
   ^bb3:	// pred: ^bb2
-    %18 = load %6[%11] : memref<4xi32>
-    %19 = load %9[%11] : memref<4xi32>
+    %18 = memref.load %6[%11] : memref<4xi32>
+    %19 = memref.load %9[%11] : memref<4xi32>
     %20 = muli %13, %18 : i32
     %21 = muli %15, %18 : i32
     %22 = addi %20, %15 : i32
     %23 = subi %13, %21 : i32
     %24 = divi_unsigned %22, %19 : i32
     %25 = divi_unsigned %23, %19 : i32
-    store %24, %5[%11] : memref<4xi32>
-    store %25, %4[%11] : memref<4xi32>
+    memref.store %24, %5[%11] : memref<4xi32>
+    memref.store %25, %4[%11] : memref<4xi32>
     br ^bb5
   ^bb4:	// pred: ^bb2
-    %26 = load %7[%11] : memref<4xi32>
-    %27 = load %8[%11] : memref<4xi32>
+    %26 = memref.load %7[%11] : memref<4xi32>
+    %27 = memref.load %8[%11] : memref<4xi32>
     %28 = muli %13, %26 : i32
     %29 = muli %15, %26 : i32
     %30 = addi %29, %13 : i32
     %31 = subi %28, %15 : i32
     %32 = divi_unsigned %30, %27 : i32
     %33 = divi_unsigned %31, %27 : i32
-    store %32, %5[%11] : memref<4xi32>
-    store %33, %4[%11] : memref<4xi32>
+    memref.store %32, %5[%11] : memref<4xi32>
+    memref.store %33, %4[%11] : memref<4xi32>
     br ^bb5
   ^bb5:	// 2 preds: ^bb3, ^bb4
     %34 = addi %11, %c1 : index

--- a/test/handshake-runner/cdiv-std.mlir
+++ b/test/handshake-runner/cdiv-std.mlir
@@ -7,51 +7,51 @@ module {
     %c0 = constant 0 : index
     %c1 = constant 1 : index
     %c10 = constant 10 : index
-    %0 = alloc() : memref<100xi32>
-    %1 = alloc() : memref<100xi32>
-    %2 = alloc() : memref<100xi32>
-    %3 = alloc() : memref<100xi32>
-    %4 = alloc() : memref<100xi32>
-    %5 = alloc() : memref<100xi32>
-    %6 = alloc() : memref<100xi32>
-    %7 = alloc() : memref<100xi32>
-    %8 = alloc() : memref<100xi32>
-    %9 = alloc() : memref<100xi32>
-    %10 = alloc() : memref<100xi1>
+    %0 = memref.alloc() : memref<100xi32>
+    %1 = memref.alloc() : memref<100xi32>
+    %2 = memref.alloc() : memref<100xi32>
+    %3 = memref.alloc() : memref<100xi32>
+    %4 = memref.alloc() : memref<100xi32>
+    %5 = memref.alloc() : memref<100xi32>
+    %6 = memref.alloc() : memref<100xi32>
+    %7 = memref.alloc() : memref<100xi32>
+    %8 = memref.alloc() : memref<100xi32>
+    %9 = memref.alloc() : memref<100xi32>
+    %10 = memref.alloc() : memref<100xi1>
     br ^bb1(%c0 : index)
   ^bb1(%11: index):	// 2 preds: ^bb0, ^bb5
     %12 = cmpi slt, %11, %c10 : index
     cond_br %12, ^bb2, ^bb6
   ^bb2:	// pred: ^bb1
-    %13 = load %0[%11] : memref<100xi32>
-    %14 = load %2[%11] : memref<100xi32>
-    %15 = load %0[%11] : memref<100xi32>
-    %16 = load %2[%11] : memref<100xi32>
-    %17 = load %10[%11] : memref<100xi1>
+    %13 = memref.load %0[%11] : memref<100xi32>
+    %14 = memref.load %2[%11] : memref<100xi32>
+    %15 = memref.load %0[%11] : memref<100xi32>
+    %16 = memref.load %2[%11] : memref<100xi32>
+    %17 = memref.load %10[%11] : memref<100xi1>
     cond_br %17, ^bb3, ^bb4
   ^bb3:	// pred: ^bb2
-    %18 = load %6[%11] : memref<100xi32>
-    %19 = load %9[%11] : memref<100xi32>
+    %18 = memref.load %6[%11] : memref<100xi32>
+    %19 = memref.load %9[%11] : memref<100xi32>
     %20 = muli %13, %18 : i32
     %21 = muli %15, %18 : i32
     %22 = addi %20, %15 : i32
     %23 = subi %13, %21 : i32
     %24 = muli %22, %19 : i32
     %25 = muli %23, %19 : i32
-    store %24, %5[%11] : memref<100xi32>
-    store %25, %4[%11] : memref<100xi32>
+    memref.store %24, %5[%11] : memref<100xi32>
+    memref.store %25, %4[%11] : memref<100xi32>
     br ^bb5
   ^bb4:	// pred: ^bb2
-    %26 = load %7[%11] : memref<100xi32>
-    %27 = load %8[%11] : memref<100xi32>
+    %26 = memref.load %7[%11] : memref<100xi32>
+    %27 = memref.load %8[%11] : memref<100xi32>
     %28 = muli %13, %26 : i32
     %29 = muli %15, %26 : i32
     %30 = addi %29, %13 : i32
     %31 = subi %28, %15 : i32
     %32 = muli %30, %27 : i32
     %33 = muli %31, %27 : i32
-    store %32, %5[%11] : memref<100xi32>
-    store %33, %4[%11] : memref<100xi32>
+    memref.store %32, %5[%11] : memref<100xi32>
+    memref.store %33, %4[%11] : memref<100xi32>
     br ^bb5
   ^bb5:	// 2 preds: ^bb3, ^bb4
     %34 = addi %11, %c1 : index

--- a/test/handshake-runner/floydwarshall-std.mlir
+++ b/test/handshake-runner/floydwarshall-std.mlir
@@ -7,7 +7,7 @@ module {
     %c0 = constant 0 : index
     %c1 = constant 1 : index
     %c4 = constant 4 : index
-    %0 = alloc() : memref<256xi32>
+    %0 = memref.alloc() : memref<256xi32>
     br ^bb1(%c0 : index)
   ^bb1(%1: index):	// 2 preds: ^bb0, ^bb11
     %2 = cmpi slt, %1, %c4 : index
@@ -28,17 +28,17 @@ module {
     %9 = addi %7, %5 : index
     %10 = addi %7, %1 : index
     %11 = addi %8, %5 : index
-    %12 = load %0[%9] : memref<256xi32>
-    %13 = load %0[%10] : memref<256xi32>
-    %14 = load %0[%11] : memref<256xi32>
+    %12 = memref.load %0[%9] : memref<256xi32>
+    %13 = memref.load %0[%10] : memref<256xi32>
+    %14 = memref.load %0[%11] : memref<256xi32>
     %15 = addi %13, %14 : i32
     %16 = cmpi ult, %12, %15 : i32
     cond_br %16, ^bb7, ^bb8
   ^bb7:	// pred: ^bb6
-    store %12, %0[%9] : memref<256xi32>
+    memref.store %12, %0[%9] : memref<256xi32>
     br ^bb9
   ^bb8:	// pred: ^bb6
-    store %15, %0[%9] : memref<256xi32>
+    memref.store %15, %0[%9] : memref<256xi32>
     br ^bb9
   ^bb9:	// 2 preds: ^bb7, ^bb8
     %17 = addi %5, %c1 : index

--- a/test/handshake-runner/histogram-std.mlir
+++ b/test/handshake-runner/histogram-std.mlir
@@ -7,20 +7,20 @@ module {
     %c0 = constant 0 : index
     %c1 = constant 1 : index
     %c10 = constant 10 : index
-    %0 = alloc() : memref<100xi32>
-    %1 = alloc() : memref<100xi32>
-    %2 = alloc() : memref<100xi32>
+    %0 = memref.alloc() : memref<100xi32>
+    %1 = memref.alloc() : memref<100xi32>
+    %2 = memref.alloc() : memref<100xi32>
     br ^bb1(%c0 : index)
   ^bb1(%3: index):	// 2 preds: ^bb0, ^bb2
     %4 = cmpi slt, %3, %c10 : index
     cond_br %4, ^bb2, ^bb3
   ^bb2:	// pred: ^bb1
-    %5 = load %0[%3] : memref<100xi32>
-    %6 = load %1[%3] : memref<100xi32>
+    %5 = memref.load %0[%3] : memref<100xi32>
+    %6 = memref.load %1[%3] : memref<100xi32>
     %7 = index_cast %5 : i32 to index
-    %8 = load %2[%7] : memref<100xi32>
+    %8 = memref.load %2[%7] : memref<100xi32>
     %9 = addi %8, %6 : i32
-    store %9, %2[%7] : memref<100xi32>
+    memref.store %9, %2[%7] : memref<100xi32>
     %10 = addi %3, %c1 : index
     br ^bb1(%10 : index)
   ^bb3:	// pred: ^bb1

--- a/test/handshake-runner/loadstore.mlir
+++ b/test/handshake-runner/loadstore.mlir
@@ -4,10 +4,10 @@
 
 module {
   func @main(%arg0: index) -> (i8) {
-    %0 = alloc() : memref<10xi8>
+    %0 = memref.alloc() : memref<10xi8>
     %c1 = constant 1 : i8
-	 store %c1, %0[%arg0] : memref<10xi8>
-	 %1 = load %0[%arg0] : memref<10xi8>
+	 memref.store %c1, %0[%arg0] : memref<10xi8>
+	 %1 = memref.load %0[%arg0] : memref<10xi8>
 	 return %1 : i8
   }
 }

--- a/test/handshake-runner/loop-check-1-std.mlir
+++ b/test/handshake-runner/loop-check-1-std.mlir
@@ -8,14 +8,14 @@ module {
     %c1 = constant 1 : index
     %c4 = constant 4 : index
     %c5_i32 = constant 5 : i32
-    %0 = alloc() : memref<64xi32>
-    %1 = alloc() : memref<64xi32>
+    %0 = memref.alloc() : memref<64xi32>
+    %1 = memref.alloc() : memref<64xi32>
     br ^bb1(%c0 : index)
   ^bb1(%2: index):  // 2 preds: ^bb0, ^bb2
     %3 = cmpi slt, %2, %c4 : index
     cond_br %3, ^bb2, ^bb3
   ^bb2: // pred: ^bb1
-    store %c5_i32, %0[%2] : memref<64xi32>
+    memref.store %c5_i32, %0[%2] : memref<64xi32>
     %4 = addi %2, %c1 : index
     br ^bb1(%4 : index)
   ^bb3: // pred: ^bb1
@@ -24,13 +24,13 @@ module {
     %6 = cmpi slt, %5, %c4 : index
     cond_br %6, ^bb5, ^bb6
   ^bb5: // pred: ^bb4
-    %7 = load %0[%5] : memref<64xi32>
+    %7 = memref.load %0[%5] : memref<64xi32>
     %8 = addi %7, %7 : i32
-    store %8, %1[%5] : memref<64xi32>
+    memref.store %8, %1[%5] : memref<64xi32>
     %9 = addi %5, %c1 : index
     br ^bb4(%9 : index)
   ^bb6: // pred: ^bb4
-    %10 = load %1[%c0] : memref<64xi32>
+    %10 = memref.load %1[%c0] : memref<64xi32>
     return %10 : i32
   }
 }

--- a/test/handshake-runner/loop-check-2-std.mlir
+++ b/test/handshake-runner/loop-check-2-std.mlir
@@ -9,14 +9,14 @@ module {
     %c3 = constant 3 : index
     %c4 = constant 4 : index
     %c5_i32 = constant 5 : i32
-    %0 = alloc() : memref<64xi32>
-    %1 = alloc() : memref<64xi32>
+    %0 = memref.alloc() : memref<64xi32>
+    %1 = memref.alloc() : memref<64xi32>
     br ^bb1(%c0 : index)
   ^bb1(%2: index):  // 2 preds: ^bb0, ^bb2
     %3 = cmpi slt, %2, %c4 : index
     cond_br %3, ^bb2, ^bb3
   ^bb2: // pred: ^bb1
-    store %c5_i32, %0[%2] : memref<64xi32>
+    memref.store %c5_i32, %0[%2] : memref<64xi32>
     %4 = addi %2, %c1 : index
     br ^bb1(%4 : index)
   ^bb3: // pred: ^bb1
@@ -25,13 +25,13 @@ module {
     %6 = cmpi slt, %5, %c4 : index
     cond_br %6, ^bb5, ^bb6
   ^bb5: // pred: ^bb4
-    %7 = load %0[%5] : memref<64xi32>
+    %7 = memref.load %0[%5] : memref<64xi32>
     %8 = addi %7, %7 : i32
-    store %8, %1[%5] : memref<64xi32>
+    memref.store %8, %1[%5] : memref<64xi32>
     %9 = addi %5, %c1 : index
     br ^bb4(%9 : index)
   ^bb6: // pred: ^bb4
-    %10 = load %1[%c3] : memref<64xi32>
+    %10 = memref.load %1[%c3] : memref<64xi32>
     return %10 : i32
   }
 }

--- a/test/handshake-runner/matmul-check-std.mlir
+++ b/test/handshake-runner/matmul-check-std.mlir
@@ -13,17 +13,17 @@ module {
     %c64 = constant 64 : index
     %c0_i32 = constant 0 : i32
     %c5_i32 = constant 5 : i32
-    %0 = alloc() : memref<64xi32>
-    %1 = alloc() : memref<64xi32>
-    %2 = alloc() : memref<64xi32>
-    %3 = alloc() : memref<1xi32>
+    %0 = memref.alloc() : memref<64xi32>
+    %1 = memref.alloc() : memref<64xi32>
+    %2 = memref.alloc() : memref<64xi32>
+    %3 = memref.alloc() : memref<1xi32>
     br ^bb1(%c0 : index)
   ^bb1(%4: index):  // 2 preds: ^bb0, ^bb2
     %5 = cmpi slt, %4, %c64 : index
     cond_br %5, ^bb2, ^bb3
   ^bb2: // pred: ^bb1
-    store %c5_i32, %0[%4] : memref<64xi32>
-    store %c5_i32, %1[%4] : memref<64xi32>
+    memref.store %c5_i32, %0[%4] : memref<64xi32>
+    memref.store %c5_i32, %1[%4] : memref<64xi32>
     %6 = addi %4, %c1 : index
     br ^bb1(%6 : index)
   ^bb3: // pred: ^bb1
@@ -37,7 +37,7 @@ module {
     %10 = cmpi slt, %9, %c8 : index
     cond_br %10, ^bb7, ^bb11
   ^bb7: // pred: ^bb6
-    store %c0_i32, %3[%c0] : memref<1xi32>
+    memref.store %c0_i32, %3[%c0] : memref<1xi32>
     %11 = muli %7, %c8 : index
     br ^bb8(%c0 : index)
   ^bb8(%12: index): // 2 preds: ^bb7, ^bb9
@@ -45,27 +45,27 @@ module {
     cond_br %13, ^bb9, ^bb10
   ^bb9: // pred: ^bb8
     %14 = addi %11, %12 : index
-    %15 = load %0[%14] : memref<64xi32>
+    %15 = memref.load %0[%14] : memref<64xi32>
     %16 = muli %12, %c8 : index
     %17 = addi %16, %9 : index
-    %18 = load %1[%17] : memref<64xi32>
-    %19 = load %3[%c0] : memref<1xi32>
+    %18 = memref.load %1[%17] : memref<64xi32>
+    %19 = memref.load %3[%c0] : memref<1xi32>
     %20 = muli %15, %18 : i32
     %21 = addi %19, %20 : i32
-    store %21, %3[%c0] : memref<1xi32>
+    memref.store %21, %3[%c0] : memref<1xi32>
     %22 = addi %12, %c1 : index
     br ^bb8(%22 : index)
   ^bb10:  // pred: ^bb8
     %23 = addi %11, %9 : index
-    %24 = load %3[%c0] : memref<1xi32>
-    store %24, %2[%23] : memref<64xi32>
+    %24 = memref.load %3[%c0] : memref<1xi32>
+    memref.store %24, %2[%23] : memref<64xi32>
     %25 = addi %9, %c1 : index
     br ^bb6(%25 : index)
   ^bb11:  // pred: ^bb6
     %26 = addi %7, %c1 : index
     br ^bb4(%26 : index)
   ^bb12:  // pred: ^bb4
-    %27 = load %2[%c63] : memref<64xi32>
+    %27 = memref.load %2[%c63] : memref<64xi32>
     return %27 : i32
   }
 }

--- a/test/handshake-runner/matmul-std.mlir
+++ b/test/handshake-runner/matmul-std.mlir
@@ -8,10 +8,10 @@ module {
     %c1 = constant 1 : index
     %c4 = constant 4 : index
     %c0_i32 = constant 0 : i32
-    %0 = alloc() : memref<256xi32>
-    %1 = alloc() : memref<256xi32>
-    %2 = alloc() : memref<256xi32>
-    %3 = alloc() : memref<1xi32>
+    %0 = memref.alloc() : memref<256xi32>
+    %1 = memref.alloc() : memref<256xi32>
+    %2 = memref.alloc() : memref<256xi32>
+    %3 = memref.alloc() : memref<1xi32>
     br ^bb1(%c0 : index)
   ^bb1(%4: index):	// 2 preds: ^bb0, ^bb8
     %5 = cmpi slt, %4, %c4 : index
@@ -22,7 +22,7 @@ module {
     %7 = cmpi slt, %6, %c4 : index
     cond_br %7, ^bb4, ^bb8
   ^bb4:	// pred: ^bb3
-    store %c0_i32, %3[%c0] : memref<1xi32>
+    memref.store %c0_i32, %3[%c0] : memref<1xi32>
     %8 = muli %4, %c4 : index
     br ^bb5(%c0 : index)
   ^bb5(%9: index):	// 2 preds: ^bb4, ^bb6
@@ -32,18 +32,18 @@ module {
     %11 = muli %9, %c4 : index
     %12 = addi %8, %9 : index
     %13 = addi %11, %6 : index
-    %14 = load %0[%12] : memref<256xi32>
-    %15 = load %1[%13] : memref<256xi32>
-    %16 = load %3[%c0] : memref<1xi32>
+    %14 = memref.load %0[%12] : memref<256xi32>
+    %15 = memref.load %1[%13] : memref<256xi32>
+    %16 = memref.load %3[%c0] : memref<1xi32>
     %17 = muli %14, %15 : i32
     %18 = addi %16, %17 : i32
-    store %18, %3[%c0] : memref<1xi32>
+    memref.store %18, %3[%c0] : memref<1xi32>
     %19 = addi %9, %c1 : index
     br ^bb5(%19 : index)
   ^bb7:	// pred: ^bb5
     %20 = addi %8, %6 : index
-    %21 = load %3[%c0] : memref<1xi32>
-    store %21, %2[%20] : memref<256xi32>
+    %21 = memref.load %3[%c0] : memref<1xi32>
+    memref.store %21, %2[%20] : memref<256xi32>
     %22 = addi %6, %c1 : index
     br ^bb3(%22 : index)
   ^bb8:	// pred: ^bb3

--- a/test/handshake-runner/memory_simple_2_std.mlir
+++ b/test/handshake-runner/memory_simple_2_std.mlir
@@ -6,7 +6,7 @@ module {
   func @main(%0: memref<4xi32>) -> i32{
     %c0 = constant 0 : index
     %c5 = constant 5 : i32
-    store %c5, %0[%c0] : memref<4xi32>
+    memref.store %c5, %0[%c0] : memref<4xi32>
     return %c5 : i32
     }
 

--- a/test/handshake-runner/memory_simple_std.mlir
+++ b/test/handshake-runner/memory_simple_std.mlir
@@ -5,7 +5,7 @@
 module {
   func @main(%0 : memref<4xi32>) -> i32{
     %c0 = constant 0 : index
-    %1 = load %0[%c0] : memref<4xi32>
+    %1 = memref.load %0[%c0] : memref<4xi32>
     return %1 : i32
     }
 

--- a/tools/circt-opt/circt-opt.cpp
+++ b/tools/circt-opt/circt-opt.cpp
@@ -15,6 +15,7 @@
 #include "circt/InitAllPasses.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/Pass/PassRegistry.h"
 #include "mlir/Support/MlirOptMain.h"
@@ -24,9 +25,10 @@ int main(int argc, char **argv) {
   mlir::DialectRegistry registry;
 
   // Register MLIR stuff
-  registry.insert<mlir::StandardOpsDialect>();
-  registry.insert<mlir::LLVM::LLVMDialect>();
   registry.insert<mlir::AffineDialect>();
+  registry.insert<mlir::LLVM::LLVMDialect>();
+  registry.insert<mlir::memref::MemRefDialect>();
+  registry.insert<mlir::StandardOpsDialect>();
 
   circt::registerAllDialects(registry);
   circt::registerAllPasses();

--- a/tools/handshake-runner/handshake-runner.cpp
+++ b/tools/handshake-runner/handshake-runner.cpp
@@ -13,6 +13,7 @@
 
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Parser.h"
@@ -62,7 +63,8 @@ int main(int argc, char **argv) {
 
   // Load the MLIR module.
   mlir::MLIRContext context;
-  context.loadDialect<StandardOpsDialect, handshake::HandshakeOpsDialect>();
+  context.loadDialect<StandardOpsDialect, memref::MemRefDialect,
+                      handshake::HandshakeOpsDialect>();
   SourceMgr source_mgr;
   source_mgr.AddNewSourceBuffer(std::move(*file_or_err), SMLoc());
   mlir::OwningModuleRef module(mlir::parseSourceFile(source_mgr, &context));


### PR DESCRIPTION
This is needed to fix a crash in DCE for graph regions. [0]

- alloc and store operations have been moved to a new MemRef dialect
- custom dialect types now need to be registered in the same compilation
  unit as the type's storage.  Any dialect that registers types have had
  the logic moved to DialectTypes.cpp.
- Small change to the ResetTypeAttr default value declaration.

[0] https://reviews.llvm.org/D98919