### PR TITLE
[ExportVerilog] Parallelize split Verilog output and print file list

### DIFF
--- a/include/circt/Translation/ExportVerilog.h
+++ b/include/circt/Translation/ExportVerilog.h
@@ -13,6 +13,8 @@
 #ifndef CIRCT_TRANSLATION_EXPORTVERILOG_H
 #define CIRCT_TRANSLATION_EXPORTVERILOG_H
 
+#include <functional>
+
 namespace llvm {
 class raw_ostream;
 class StringRef;
@@ -31,9 +33,12 @@ mlir::LogicalResult exportVerilog(mlir::ModuleOp module, llvm::raw_ostream &os);
 /// Export a module containing RTL, and SV dialect code, as one file per SV
 /// module.
 ///
-/// Files are created in the directory indicated by \c dirname.
-mlir::LogicalResult exportSplitVerilog(mlir::ModuleOp module,
-                                       llvm::StringRef dirname);
+/// Files are created in the directory indicated by \p dirname. The function
+/// \p emittedFile is called for every emitted file, in the order appropriate
+/// given the input MLIR module.
+mlir::LogicalResult
+exportSplitVerilog(mlir::ModuleOp module, llvm::StringRef dirname,
+                   std::function<void(llvm::StringRef)> emittedFile);
 
 /// Register a translation for exporting RTL, Comb and SV to SystemVerilog.
 void registerToVerilogTranslation();

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -2925,9 +2925,16 @@ LogicalResult circt::exportVerilog(ModuleOp module, llvm::raw_ostream &os) {
   return failure(state.encounteredError);
 }
 
-LogicalResult circt::exportSplitVerilog(ModuleOp module, StringRef dirname) {
+LogicalResult
+circt::exportSplitVerilog(ModuleOp module, StringRef dirname,
+                          std::function<void(llvm::StringRef)> emittedFile) {
   SplitModuleEmitter emitter(dirname);
   emitter.emitMLIRModule(module);
+  if (emittedFile) {
+    for (auto mod : std::move(emitter.moduleOps)) {
+      emittedFile(mod.filename);
+    }
+  }
   return failure(emitter.encounteredError);
 }
 

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -2569,11 +2569,10 @@ namespace {
 
 class SplitModuleEmitter {
 public:
-  explicit SplitModuleEmitter(StringRef dirname)
-      : encounteredError(false), dirname(dirname) {}
+  explicit SplitModuleEmitter(StringRef dirname) : dirname(dirname) {}
 
   /// Whether any error has been encountered during emission.
-  std::atomic<bool> encounteredError;
+  std::atomic<bool> encounteredError = {};
 
   /// The directory to emit files into.
   StringRef dirname;

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -718,27 +718,6 @@ StringRef ModuleEmitter::addName(ValueOrOp valueOrOp, StringRef name) {
 }
 
 //===----------------------------------------------------------------------===//
-// SplitModuleEmitter
-//===----------------------------------------------------------------------===//
-
-namespace {
-
-class SplitModuleEmitter {
-public:
-  explicit SplitModuleEmitter(StringRef dirname) : dirname(dirname) {}
-
-  bool encounteredError = false;
-  StringRef dirname;
-  SmallVector<Operation *, 8> perFileOps;
-
-  void emitMLIRModule(ModuleOp module);
-  void emitFile(StringRef filename,
-                std::function<void(VerilogEmitterState &)> callback);
-};
-
-} // namespace
-
-//===----------------------------------------------------------------------===//
 // Expression Emission
 //===----------------------------------------------------------------------===//
 
@@ -2584,8 +2563,25 @@ void ModuleEmitter::emitStatementBlock(Block &body) {
 }
 
 //===----------------------------------------------------------------------===//
-// Module Driver
+// SplitModuleEmitter
 //===----------------------------------------------------------------------===//
+
+namespace {
+
+class SplitModuleEmitter {
+public:
+  explicit SplitModuleEmitter(StringRef dirname) : dirname(dirname) {}
+
+  bool encounteredError = false;
+  StringRef dirname;
+  SmallVector<Operation *, 8> perFileOps;
+
+  void emitMLIRModule(ModuleOp module);
+  void emitFile(StringRef filename,
+                std::function<void(VerilogEmitterState &)> callback);
+};
+
+} // namespace
 
 void SplitModuleEmitter::emitMLIRModule(ModuleOp module) {
   for (auto &op : *module.getBody()) {
@@ -2645,6 +2641,10 @@ void SplitModuleEmitter::emitFile(
 
   output->keep();
 }
+
+//===----------------------------------------------------------------------===//
+// Module Driver
+//===----------------------------------------------------------------------===//
 
 void ModuleEmitter::emitMLIRModule(ModuleOp module) {
   for (auto &op : *module.getBody()) {

--- a/test/firtool/split_verilog.mlir
+++ b/test/firtool/split_verilog.mlir
@@ -1,4 +1,4 @@
-// RUN: firtool %s --format=mlir -split-verilog -o=%t
+// RUN: firtool %s --format=mlir -split-verilog -o=%t | FileCheck %s --check-prefix=FIRTOOL
 // RUN: FileCheck %s --check-prefix=VERILOG-FOO < %t/foo.v
 // RUN: FileCheck %s --check-prefix=VERILOG-BAR < %t/bar.v
 // RUN: FileCheck %s --check-prefix=VERILOG-USB < %t/usb.v
@@ -23,6 +23,11 @@ sv.interface @usb {
   sv.interface.signal @ready : i1
 }
 rtl.module.extern @pll ()
+
+// FIRTOOL:      foo.v
+// FIRTOOL-NEXT: bar.v
+// FIRTOOL-NEXT: usb.v
+// FIRTOOL-NEXT: pll.v
 
 // VERILOG-FOO:       // I'm everywhere
 // VERILOG-FOO-NEXT:  `ifdef VERILATOR

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -203,7 +203,9 @@ processBufferIntoMultipleFiles(std::unique_ptr<llvm::MemoryBuffer> ownedBuffer,
     case OutputVerilog:
       llvm_unreachable("single-stream format must be handled elsewhere");
     case OutputSplitVerilog:
-      return exportSplitVerilog(module.get(), outputDirectory);
+      return exportSplitVerilog(
+          module.get(), outputDirectory,
+          [](StringRef filename) { llvm::outs() << filename << "\n"; });
     }
     llvm_unreachable("unknown output format");
   });

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -194,7 +194,7 @@ processBufferIntoSingleStream(std::unique_ptr<llvm::MemoryBuffer> ownedBuffer,
 /// Process a single buffer of the input into multiple output files.
 static LogicalResult
 processBufferIntoMultipleFiles(std::unique_ptr<llvm::MemoryBuffer> ownedBuffer,
-                               const std::string &outputDirectory) {
+                               StringRef outputDirectory) {
   return processBuffer(std::move(ownedBuffer), [&](OwningModuleRef module) {
     // Finally, emit the output.
     switch (outputFormat) {


### PR DESCRIPTION
* Parallelize the emission of multiple Verilog files as discussed in #756.
* Also have `firtool` print the list of generated files in the appropriate order, which is an absolute necessity for split output. Later on we might want to offer more selective ways to print this file list.
* Make the implementation of `getReservedWords` thread-safe as discussed in #770.