### PR TITLE
[FIRRTL] Type lowering of operations with no name

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -571,17 +571,14 @@ void TypeLoweringVisitor::visitDecl(RegOp op) {
 
   // Loop over the leaf aggregates.
   for (auto field : fieldTypes) {
-    SmallString<16> loweredName("");
-    if (auto nameAttr = op.nameAttr()) {
-      loweredName = nameAttr.getValue();
-      loweredName += field.suffix;
-    }
-    setBundleLowering(
-        result, StringRef(field.suffix).drop_front(1),
-        builder->create<RegOp>(field.getPortType(), op.clockVal(),
-                               loweredName.empty()
-                                   ? nullptr
-                                   : builder->getStringAttr(loweredName)));
+    StringAttr loweredName;
+    if (auto nameAttr = op.nameAttr())
+      loweredName =
+          builder->getStringAttr(nameAttr.getValue().str() + field.suffix);
+
+    setBundleLowering(result, StringRef(field.suffix).drop_front(1),
+                      builder->create<RegOp>(field.getPortType(), op.clockVal(),
+                                             loweredName));
   }
 
   // Remember to remove the original op.
@@ -605,20 +602,16 @@ void TypeLoweringVisitor::visitDecl(RegResetOp op) {
 
   // Loop over the leaf aggregates.
   for (auto field : fieldTypes) {
-    SmallString<16> loweredName("");
-    if (auto nameAttr = op.nameAttr()) {
-      loweredName = nameAttr.getValue();
-      loweredName += field.suffix;
-    }
+    StringAttr loweredName;
+    if (auto nameAttr = op.nameAttr())
+      loweredName =
+          builder->getStringAttr(nameAttr.getValue().str() + field.suffix);
     auto suffix = StringRef(field.suffix).drop_front(1);
     auto resetValLowered = getBundleLowering(op.resetValue(), suffix);
-    setBundleLowering(
-        result, suffix,
-        builder->create<RegResetOp>(field.getPortType(), op.clockVal(),
-                                    op.resetSignal(), resetValLowered,
-                                    loweredName.empty()
-                                        ? nullptr
-                                        : builder->getStringAttr(loweredName)));
+    setBundleLowering(result, suffix,
+                      builder->create<RegResetOp>(
+                          field.getPortType(), op.clockVal(), op.resetSignal(),
+                          resetValLowered, loweredName));
   }
 
   // Remember to remove the original op.

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -571,12 +571,17 @@ void TypeLoweringVisitor::visitDecl(RegOp op) {
 
   // Loop over the leaf aggregates.
   for (auto field : fieldTypes) {
-    SmallString<16> loweredName(op.nameAttr().getValue());
-    loweredName += field.suffix;
+    SmallString<16> loweredName("");
+    if (auto nameAttr = op.nameAttr()) {
+      loweredName = nameAttr.getValue();
+      loweredName += field.suffix;
+    }
     setBundleLowering(
         result, StringRef(field.suffix).drop_front(1),
         builder->create<RegOp>(field.getPortType(), op.clockVal(),
-                               builder->getStringAttr(loweredName)));
+                               loweredName.empty()
+                                   ? nullptr
+                                   : builder->getStringAttr(loweredName)));
   }
 
   // Remember to remove the original op.
@@ -600,15 +605,20 @@ void TypeLoweringVisitor::visitDecl(RegResetOp op) {
 
   // Loop over the leaf aggregates.
   for (auto field : fieldTypes) {
-    SmallString<16> loweredName(op.nameAttr().getValue());
-    loweredName += field.suffix;
+    SmallString<16> loweredName("");
+    if (auto nameAttr = op.nameAttr()) {
+      loweredName = nameAttr.getValue();
+      loweredName += field.suffix;
+    }
     auto suffix = StringRef(field.suffix).drop_front(1);
     auto resetValLowered = getBundleLowering(op.resetValue(), suffix);
     setBundleLowering(
         result, suffix,
         builder->create<RegResetOp>(field.getPortType(), op.clockVal(),
                                     op.resetSignal(), resetValLowered,
-                                    builder->getStringAttr(loweredName)));
+                                    loweredName.empty()
+                                        ? nullptr
+                                        : builder->getStringAttr(loweredName)));
   }
 
   // Remember to remove the original op.

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -542,3 +542,50 @@ firrtl.circuit "LowereRegResetOp" {
   // CHECK:   firrtl.connect %a_q_0, %r_0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
   // CHECK:   firrtl.connect %a_q_1, %r_1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 }
+
+// -----
+
+// Test RegResetOp lowering without name attribute
+// https://github.com/llvm/circt/issues/795
+firrtl.circuit "LowereRegResetOpNoName" {
+  firrtl.module @LowereRegResetOpNoName(%clock: !firrtl.clock, %reset: !firrtl.uint<1>, %a_d: !firrtl.vector<uint<1>, 2>, %a_q: !firrtl.flip<vector<uint<1>, 2>>) {
+    %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
+    %init = firrtl.wire  : !firrtl.vector<uint<1>, 2>
+    %0 = firrtl.subindex %init[0] : !firrtl.vector<uint<1>, 2>
+    firrtl.connect %0, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    %1 = firrtl.subindex %init[1] : !firrtl.vector<uint<1>, 2>
+    firrtl.connect %1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    %r = firrtl.regreset %clock, %reset, %init : (!firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<1>, 2>) -> !firrtl.vector<uint<1>, 2>
+    firrtl.connect %r, %a_d : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
+    firrtl.connect %a_q, %r : !firrtl.flip<vector<uint<1>, 2>>, !firrtl.vector<uint<1>, 2>
+  }
+  // CHECK:   %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
+  // CHECK:   %init_0 = firrtl.wire  : !firrtl.uint<1>
+  // CHECK:   %init_1 = firrtl.wire  : !firrtl.uint<1>
+  // CHECK:   firrtl.connect %init_0, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK:   firrtl.connect %init_1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK:   0 = firrtl.regreset %clock, %reset, %init_0 : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  // CHECK:   1 = firrtl.regreset %clock, %reset, %init_1 : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  // CHECK:   firrtl.connect %0, %a_d_0 : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK:   firrtl.connect %1, %a_d_1 : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK:   firrtl.connect %a_q_0, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK:   firrtl.connect %a_q_1, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+}
+
+// -----
+
+// Test RegOp lowering without name attribute
+// https://github.com/llvm/circt/issues/795
+firrtl.circuit "lowerRegOpNoName" {
+  firrtl.module @lowerRegOpNoName(%clock: !firrtl.clock, %a_d: !firrtl.vector<uint<1>, 2>, %a_q: !firrtl.flip<vector<uint<1>, 2>>) {
+    %r = firrtl.reg %clock : (!firrtl.clock) -> !firrtl.vector<uint<1>, 2>
+      firrtl.connect %r, %a_d : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
+      firrtl.connect %a_q, %r : !firrtl.flip<vector<uint<1>, 2>>, !firrtl.vector<uint<1>, 2>
+  }
+ // CHECK:    %0 = firrtl.reg %clock : (!firrtl.clock) -> !firrtl.uint<1>
+ // CHECK:    %1 = firrtl.reg %clock : (!firrtl.clock) -> !firrtl.uint<1>
+ // CHECK:    firrtl.connect %0, %a_d_0 : !firrtl.uint<1>, !firrtl.uint<1>
+ // CHECK:    firrtl.connect %1, %a_d_1 : !firrtl.uint<1>, !firrtl.uint<1>
+ // CHECK:    firrtl.connect %a_q_0, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+ // CHECK:    firrtl.connect %a_q_1, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+}


### PR DESCRIPTION
Check if name attribute exists, before accessing it while lowering register and registerReset op.
If no name exists in aggregate operation, then no name should be added after lowering. 
Fix for: https://github.com/llvm/circt/issues/795. 

With name attribute, 
``` mlir 
%r = firrtl.regreset %clock, %reset, %init {name = "r"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<1>, 2>) -> !firrtl.vector<uint<1>, 2>
``` 
is lowered to: 
   ``` mlir
%r_0 = firrtl.regreset %clock, %reset, %init_0 {name = "r_0"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
%r_1 = firrtl.regreset %clock, %reset, %init_1 {name = "r_1"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
```

Without name attribute 
``` mlir    
 %r = firrtl.reg %clock : (!firrtl.clock) -> !firrtl.vector<uint<1>, 2> 
``` 
is lowered to 
``` mlir
%0 = firrtl.reg %clock : (!firrtl.clock) -> !firrtl.uint<1>
%1 = firrtl.reg %clock : (!firrtl.clock) -> !firrtl.uint<1>
```