### PR TITLE
[ExportVerilog] Use LegalNamesAnalysis to determine module names

### DIFF
--- a/include/circt/Dialect/SV/SVDialect.h
+++ b/include/circt/Dialect/SV/SVDialect.h
@@ -53,6 +53,12 @@ llvm::StringRef resolveKeywordConflict(llvm::StringRef origName,
 StringRef sanitizeName(llvm::StringRef name, llvm::StringSet<> &recordNames,
                        size_t &nextGeneratedNameID);
 
+/// Check if a name is valid for use in SV output by only containing characters
+/// allowed in SV identifiers.
+///
+/// Call \c sanitizeName() to obtain a sanitized version of the name.
+bool isNameValid(llvm::StringRef name);
+
 } // namespace sv
 } // namespace circt
 

--- a/lib/Dialect/SV/SVDialect.cpp
+++ b/lib/Dialect/SV/SVDialect.cpp
@@ -98,6 +98,14 @@ StringRef circt::sv::resolveKeywordConflict(StringRef origName,
   }
 }
 
+static bool isValidVerilogCharacterFirst(char ch) {
+  return isalpha(ch) || ch == '_';
+}
+
+static bool isValidVerilogCharacter(char ch) {
+  return isValidVerilogCharacterFirst(ch) || isdigit(ch);
+}
+
 /// Sanitize the specified name for use in SV output. Auto-uniquifies the name
 /// through \c resolveKeywordConflict if required. If the name is empty, a
 /// unique temp name is created.
@@ -106,10 +114,6 @@ StringRef circt::sv::sanitizeName(StringRef name,
                                   size_t &nextGeneratedNameID) {
   if (name.empty())
     name = "_T";
-
-  auto isValidVerilogCharacter = [](char ch) -> bool {
-    return isalpha(ch) || isdigit(ch) || ch == '_';
-  };
 
   // Check to see if the name consists of all-valid identifiers.  If not, we
   // need to escape them.
@@ -133,7 +137,7 @@ StringRef circt::sv::sanitizeName(StringRef name,
 
   // Check to see if this name is valid.  The first character cannot be a
   // number or some other weird thing.  If it is, start with an underscore.
-  if (!isalpha(name.front()) && name.front() != '_') {
+  if (!isValidVerilogCharacterFirst(name.front())) {
     SmallString<16> tmpName("_");
     tmpName += name;
     return sanitizeName(tmpName, recordNames, nextGeneratedNameID);
@@ -141,4 +145,20 @@ StringRef circt::sv::sanitizeName(StringRef name,
 
   // Make sure the new valid name does not conflict with any existing names.
   return resolveKeywordConflict(name, recordNames, nextGeneratedNameID);
+}
+
+/// Check if a name is valid for use in SV output by only containing characters
+/// allowed in SV identifiers.
+///
+/// Call \c sanitizeName() to obtain a sanitized version of the name.
+bool circt::sv::isNameValid(StringRef name) {
+  if (name.empty())
+    return false;
+  if (!isValidVerilogCharacterFirst(name.front()))
+    return false;
+  for (char ch : name) {
+    if (!isValidVerilogCharacter(ch))
+      return false;
+  }
+  return true;
 }

--- a/lib/Dialect/SV/SVDialect.cpp
+++ b/lib/Dialect/SV/SVDialect.cpp
@@ -99,11 +99,11 @@ StringRef circt::sv::resolveKeywordConflict(StringRef origName,
 }
 
 static bool isValidVerilogCharacterFirst(char ch) {
-  return isalpha(ch) || ch == '_';
+  return llvm::isAlpha(ch) || ch == '_';
 }
 
 static bool isValidVerilogCharacter(char ch) {
-  return isValidVerilogCharacterFirst(ch) || isdigit(ch);
+  return isValidVerilogCharacterFirst(ch) || llvm::isDigit(ch);
 }
 
 /// Sanitize the specified name for use in SV output. Auto-uniquifies the name

--- a/lib/Dialect/SV/SVDialect.cpp
+++ b/lib/Dialect/SV/SVDialect.cpp
@@ -160,5 +160,5 @@ bool circt::sv::isNameValid(StringRef name) {
     if (!isValidVerilogCharacter(ch))
       return false;
   }
-  return true;
+  return reservedWords->count(name) == 0;
 }

--- a/lib/Dialect/SV/Transforms/RTLLegalizeNames.cpp
+++ b/lib/Dialect/SV/Transforms/RTLLegalizeNames.cpp
@@ -67,6 +67,11 @@ void RTLLegalizeNamesPass::runOnOperation() {
       runOnModule(module);
     } else if (auto intf = dyn_cast<InterfaceOp>(op)) {
       runOnInterface(intf, symbolUsers);
+    } else if (auto extMod = dyn_cast<RTLModuleExternOp>(op)) {
+      auto name = extMod.getVerilogModuleName();
+      if (!sv::isNameValid(name)) {
+        extMod->emitOpError("with invalid name \"" + name + "\"");
+      }
     }
   }
 

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -612,8 +612,8 @@ StringRef ModuleEmitter::addName(ValueOrOp valueOrOp, StringRef name) {
 /// contain any illegal characters). If invalid, calls \c emitOpError.
 void ModuleEmitter::verifyModuleName(Operation *op, StringAttr nameAttr) {
   if (!isNameValid(nameAttr.getValue()))
-    emitOpError(op, "Name \"" + nameAttr.getValue() +
-                        "\" is not allowed in Verilog output.\n");
+    emitOpError(op, "name \"" + nameAttr.getValue() +
+                        "\" is not allowed in Verilog output");
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/SV/rtl-legalize-names-errors.mlir
+++ b/test/Dialect/SV/rtl-legalize-names-errors.mlir
@@ -1,0 +1,4 @@
+// RUN: circt-opt -rtl-legalize-names %s
+
+// expected-error @+1 {{'rtl.module.extern' op with invalid name "parameter"}}
+rtl.module.extern @parameter ()

--- a/test/ExportVerilog/rtl-dialect.mlir
+++ b/test/ExportVerilog/rtl-dialect.mlir
@@ -1,4 +1,5 @@
-// RUN: circt-translate %s -export-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
+// RUN: circt-opt %s --rtl-legalize-names --mlir-print-debuginfo > %t
+// RUN: circt-translate %t -export-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
 
 rtl.module.extern @E(%a: i1 {rtl.direction = "in"}, 
               %b: i1 {rtl.direction = "out"}, 

--- a/test/ExportVerilog/rtl-dialect.mlir
+++ b/test/ExportVerilog/rtl-dialect.mlir
@@ -446,12 +446,12 @@ rtl.module @TestZeroInstance(%aa: i4, %azeroBit: i0, %aarrZero: !rtl.array<3xi0>
   -> (%r0: i4, %rZero: i0, %arrZero: !rtl.array<3xi0>) {
 
   // CHECK: TestZero iii (	// {{.*}}rtl-dialect.mlir:{{.*}}:19
-  // CHECK:   .a       (aa),
-  // CHECK: //.zeroBit (azeroBit),
-  // CHECK: //.arrZero (aarrZero),
-  // CHECK:   .r0      (iii_r0)
-  // CHECK: //.rZero   (iii_rZero)
-  // CHECK: //.arrZero (iii_arrZero)
+  // CHECK:   .a         (aa),
+  // CHECK: //.zeroBit   (azeroBit),
+  // CHECK: //.arrZero   (aarrZero),
+  // CHECK:   .r0        (iii_r0)
+  // CHECK: //.rZero     (iii_rZero)
+  // CHECK: //.arrZero_0 (iii_arrZero_0)
   // CHECK: );
 
   %o1, %o2, %o3 = rtl.instance "iii" @TestZero(%aa, %azeroBit, %aarrZero)
@@ -459,7 +459,7 @@ rtl.module @TestZeroInstance(%aa: i4, %azeroBit: i0, %aarrZero: !rtl.array<3xi0>
 
   // CHECK: assign r0 = iii_r0;
   // CHECK: // Zero width: assign rZero = iii_rZero;
-  // CHECK: // Zero width: assign arrZero = iii_arrZero;
+  // CHECK: // Zero width: assign arrZero = iii_arrZero_0;
   rtl.output %o1, %o2, %o3 : i4, i0, !rtl.array<3xi0>
 }
 
@@ -588,7 +588,7 @@ rtl.module @inout(%inout: i1) -> (%b: i1) {
 
 // https://github.com/llvm/circt/issues/681
 // Rename keywords used in variable/module names
-// CHECK-LABEL: module reg_1(
+// CHECK-LABEL: module reg_2(
 // CHECK-NEXT:  input  inout_0,
 // CHECK-NEXT:  output b);
 // CHECK-EMPTY:
@@ -634,4 +634,22 @@ rtl.module @ArrayLHS(%clock: i1) -> () {
   sv.initial  {
     sv.bpassign %3, %false : i1
   }
+}
+
+// Instantiate a module which has had its ports renamed.
+// CHECK-LABEL: module ModuleWithCollision
+// CHECK-NEXT:    input  reg_0,
+// CHECK-NEXT:    output wire_1);
+// CHECK:       endmodule
+rtl.module @ModuleWithCollision(%reg: i1) -> (%wire: i1) {
+  rtl.output %reg : i1
+}
+
+// CHECK-LABEL: module InstanceWithCollisions
+// CHECK:         ModuleWithCollision parameter_0 (
+// CHECK-NEXT:      .reg_0  (
+// CHECK-NEXT:      .wire_1 (
+// CHECK:       endmodule
+rtl.module @InstanceWithCollisions(%a: i1) {
+  rtl.instance "parameter" @ModuleWithCollision(%a) : (i1) -> (i1)
 }

--- a/test/ExportVerilog/sv-dialect.mlir
+++ b/test/ExportVerilog/sv-dialect.mlir
@@ -1,4 +1,5 @@
-// RUN: circt-translate %s -export-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
+// RUN: circt-opt %s --rtl-legalize-names --mlir-print-debuginfo > %t
+// RUN: circt-translate %t -export-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
 
 // CHECK-LABEL: module M1(
 rtl.module @M1(%clock : i1, %cond : i1, %val : i8) {

--- a/test/ExportVerilog/sv-interfaces.mlir
+++ b/test/ExportVerilog/sv-interfaces.mlir
@@ -1,4 +1,5 @@
-// RUN: circt-translate %s -export-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
+// RUN: circt-opt %s --rtl-legalize-names --mlir-print-debuginfo > %t
+// RUN: circt-translate %t -export-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
 
 module {
   // CHECK-LABEL: interface data_vr;

--- a/test/ExportVerilog/sv-interfaces.mlir
+++ b/test/ExportVerilog/sv-interfaces.mlir
@@ -80,7 +80,10 @@ module {
 
 // Next test case is related to:https://github.com/llvm/circt/issues/681
 // Rename keywords used in variable/module names
-  rtl.module.extern @reg (%m: !sv.modport<@data_vr::@data_in>)
+// NOTE(fschuiki): Extern modules should trigger an error diagnostic if they
+// would cause a rename, but since the user supplies the module externally we
+// can't just rename it.
+  rtl.module.extern @regStuff (%m: !sv.modport<@data_vr::@data_in>)
   // CHECK-LABEL: module Top2
   rtl.module @Top2 (%clk: i1) {
     // CHECK: data_vr [[IFACE:.+]]();{{.*}}//{{.+}}
@@ -90,15 +93,15 @@ module {
     %ifaceInPort = sv.modport.get %iface @data_in :
       !sv.interface<@data_vr> -> !sv.modport<@data_vr::@data_in>
 
-    // CHECK: reg_0 rcvr1 ({{.*}}//{{.+}}
+    // CHECK: regStuff rcvr1 ({{.*}}//{{.+}}
     // CHECK:   .m ([[IFACE]].data_in){{.*}}//{{.+}}
     // CHECK: );
-    rtl.instance "rcvr1" @reg(%ifaceInPort) : (!sv.modport<@data_vr::@data_in>) -> ()
+    rtl.instance "rcvr1" @regStuff(%ifaceInPort) : (!sv.modport<@data_vr::@data_in>) -> ()
 
-    // CHECK: reg_0 rcvr2 ({{.*}}//{{.+}}
+    // CHECK: regStuff rcvr2 ({{.*}}//{{.+}}
     // CHECK:   .m ([[IFACE]].data_in){{.*}}//{{.+}}
     // CHECK: );
-    rtl.instance "rcvr2" @reg(%ifaceInPort) : (!sv.modport<@data_vr::@data_in>) -> ()
+    rtl.instance "rcvr2" @regStuff(%ifaceInPort) : (!sv.modport<@data_vr::@data_in>) -> ()
   }
 
   // https://github.com/llvm/circt/issues/724

--- a/test/ExportVerilog/verilog-basic.mlir
+++ b/test/ExportVerilog/verilog-basic.mlir
@@ -1,4 +1,5 @@
-// RUN: circt-translate %s -export-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
+// RUN: circt-opt %s --rtl-legalize-names --mlir-print-debuginfo > %t
+// RUN: circt-translate %t -export-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
 
 // CHECK-LABEL: module inputs_only(
 // CHECK-NEXT: input a, b);

--- a/test/ExportVerilog/verilog-errors.mlir
+++ b/test/ExportVerilog/verilog-errors.mlir
@@ -3,3 +3,8 @@
 // expected-error @+1 {{value has an unsupported verilog type 'f32'}}
 rtl.module @Top(%out: f32) {
 }
+
+// expected-error @+1 {{'rtl.module' op name "parameter" is not allowed in Verilog output}}
+rtl.module @parameter() {
+}
+

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -192,6 +192,11 @@ processBuffer(std::unique_ptr<llvm::MemoryBuffer> ownedBuffer,
     }
   }
 
+  // If we are going to verilog, sanitize the module names.
+  if (outputFormat == OutputVerilog || outputFormat == OutputSplitVerilog) {
+    pm.addPass(sv::createRTLLegalizeNamesPass());
+  }
+
   if (failed(pm.run(module.get())))
     return failure();
 


### PR DESCRIPTION
Update ExportVerilog to use the new `LegalNamesAnalysis` pass to determine module, interface, port, instance, reg, and wire names (basically everything that would be exposed as part of the Verilog hierarchy and we might want to refer to somewhere in a Tcl script or hierarchical module path).

* Refactor the MLIR module level emission in ExportVerilog such that it has a separate but symmetrical `UnifiedEmitter` and `SplitEmitter`. These either emit Verilog into one large file, or one separate file per module and interface. This will also provide a way to inject the results of LegalNamesAnalysis into the emission process.

* Extend ExportVerilog to use the LegalNamesAnalysis pass to determine the names for modules, interfaces, ports, regs, and wires. This removes the need for on-the-fly name uniquification in quite a few cases. Also ensures that names are identical between unified and split Verilog output. Picks up a few additional name collision cases around port and instance names that could previously go unnoticed.
