### PR TITLE
[CI] Update to ubuntu-latest, and fix paths to LLVM.

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -8,7 +8,7 @@ jobs:
   # JSON files in codeowners/.
   request_reviewer:
     name: "Request review from code owner"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Get CIRCT
         uses: actions/checkout@v2

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -13,7 +13,7 @@ jobs:
   # cache.
   build-llvm:
     name: Build LLVM
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
       # time.
@@ -51,7 +51,7 @@ jobs:
   # Configure CIRCT using LLVM's build system ("Unified" build). We do not actually build this configuration since it isn't as easy to cache LLVM artifacts in this mode.
   configure-circt-unified:
     name: Configure Unified Build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
       # time.
@@ -79,7 +79,7 @@ jobs:
   build-circt:
     name: Build and Test
     needs: build-llvm
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Configure Environment
         run: echo "$GITHUB_WORKSPACE/llvm/install/bin" >> $GITHUB_PATH
@@ -141,13 +141,11 @@ jobs:
             -DBUILD_SHARED_LIBS=ON \
             -DCMAKE_BUILD_TYPE=Release \
             -DLLVM_ENABLE_ASSERTIONS=OFF \
-            -DMLIR_DIR=../llvm/install/lib/cmake/mlir/ \
-            -DLLVM_DIR=../llvm/install/lib/cmake/llvm/ \
+            -DMLIR_DIR=llvm/install/lib/cmake/mlir/ \
+            -DLLVM_DIR=llvm/install/lib/cmake/llvm/ \
             -DCMAKE_LINKER=lld \
             -DCMAKE_C_COMPILER=clang \
-            -DCMAKE_CXX_COMPILER=clang++ \
-            -DLLVM_EXTERNAL_LIT=`pwd`/../llvm/build/bin/llvm-lit \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+            -DCMAKE_CXX_COMPILER=clang++
           make check-circt -j$(nproc)
           make circt-doc
 
@@ -159,12 +157,11 @@ jobs:
           cmake .. \
             -DCMAKE_BUILD_TYPE=Debug \
             -DLLVM_ENABLE_ASSERTIONS=ON \
-            -DMLIR_DIR=../llvm/install/lib/cmake/mlir/ \
-            -DLLVM_DIR=../llvm/install/lib/cmake/llvm/ \
+            -DMLIR_DIR=llvm/install/lib/cmake/mlir/ \
+            -DLLVM_DIR=llvm/install/lib/cmake/llvm/ \
             -DCMAKE_LINKER=lld \
             -DCMAKE_C_COMPILER=gcc \
-            -DCMAKE_CXX_COMPILER=g++ \
-            -DLLVM_EXTERNAL_LIT=`pwd`/../llvm/build/bin/llvm-lit
+            -DCMAKE_CXX_COMPILER=g++
           make check-circt -j$(nproc)
           make circt-doc
 

--- a/.github/workflows/nightlyIntegrationTests.yml
+++ b/.github/workflows/nightlyIntegrationTests.yml
@@ -47,7 +47,7 @@ jobs:
   build-circt:
     name: Build and Test
     needs: build-llvm
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/circt/images/circt-integration-test:v5
     strategy:
@@ -113,12 +113,12 @@ jobs:
             -DBUILD_SHARED_LIBS=$BUILD_SHARED \
             -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
             -DLLVM_ENABLE_ASSERTIONS=$BUILD_ASSERT \
-            -DMLIR_DIR=../llvm/install/lib/cmake/mlir/ \
-            -DLLVM_DIR=../llvm/install/lib/cmake/llvm/ \
+            -DMLIR_DIR=llvm/install/lib/cmake/mlir/ \
+            -DLLVM_DIR=llvm/install/lib/cmake/llvm/ \
             -DCMAKE_LINKER=lld \
             -DCMAKE_C_COMPILER=$CC \
             -DCMAKE_CXX_COMPILER=$CXX \
-            -DLLVM_EXTERNAL_LIT=`pwd`/../llvm/build/bin/llvm-lit \
+            -DLLVM_EXTERNAL_LIT=llvm/build/bin/llvm-lit \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -DCIRCT_BINDINGS_PYTHON_ENABLED=ON \
             -DPYTHON_EXECUTABLE=/usr/bin/python3


### PR DESCRIPTION
Previously, the broken path to llvm-lit caused builds to fail for
ubuntu-latest, because we were falling back to the binary that came
installed on the OS. By fixing the path, we can update to the latest.