### PR TITLE
[LLHD] Remove redundant negative value check for TimeAttr

### DIFF
--- a/lib/Dialect/LLHD/IR/LLHDDialect.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDDialect.cpp
@@ -477,10 +477,6 @@ TimeAttr::verifyConstructionInvariants(Location loc, Type type,
                              "exactly 3, but got "
                           << timeValues.size();
 
-  // Check the time values are positive or zero integers.
-  if (timeValues[0] < 0 || timeValues[1] < 0 || timeValues[2] < 0)
-    return emitError(loc) << "Received a negative time value.";
-
   return success();
 }
 


### PR DESCRIPTION
* Remove a check for negative values in TimeAttr that can never fail due to the values being unsigned anyway. Contribute towards #709.