### PR TITLE
Remove unused functions in FIRParser and ExportVerilog

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -190,11 +190,6 @@ struct FIRParser {
     consumeToken();
   }
 
-  /// Capture the current token's location into the specified value.  This
-  /// always succeeds.
-  ParseResult parseGetLocation(SMLoc &loc);
-  ParseResult parseGetLocation(Location &loc);
-
   /// Capture the current token's spelling into the specified value.  This
   /// always succeeds.
   ParseResult parseGetSpelling(StringRef &spelling) {
@@ -257,18 +252,6 @@ InFlightDiagnostic FIRParser::emitError(SMLoc loc, const Twine &message) {
 //===----------------------------------------------------------------------===//
 // Token Parsing
 //===----------------------------------------------------------------------===//
-
-/// Capture the current token's location into the specified value.  This
-/// always succeeds.
-ParseResult FIRParser::parseGetLocation(SMLoc &loc) {
-  loc = getToken().getLoc();
-  return success();
-}
-
-ParseResult FIRParser::parseGetLocation(Location &loc) {
-  loc = translateLocation(getToken().getLoc());
-  return success();
-}
 
 /// Consume the specified token if present and return success.  On failure,
 /// output a diagnostic and return failure.

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -1601,8 +1601,6 @@ private:
   LogicalResult visitUnhandledSV(Operation *op) { return failure(); }
   LogicalResult visitInvalidSV(Operation *op) { return failure(); }
 
-  void emitMergeOp(MergeOp op);
-
   LogicalResult emitNoop() {
     --numStatementsEmitted;
     return success();
@@ -1745,25 +1743,6 @@ void StmtEmitter::emitStatementExpression(Operation *op) {
   emitExpression(op->getResult(0), emittedExprs, ForceEmitMultiUse);
   os << ';';
   emitLocationInfoAndNewLine(emittedExprs);
-}
-
-void StmtEmitter::emitMergeOp(MergeOp op) {
-  SmallPtrSet<Operation *, 8> ops;
-  --numStatementsEmitted; // We manually count our statements.
-
-  // Emit "a = rtl.merge x, y, z" as:
-  //   assign a = x;
-  //   assign a = y;
-  //   assign a = z;
-  for (auto operand : op.getOperands()) {
-    ops.insert(op);
-    indent() << "assign " << emitter.getName(op) << " = ";
-    emitExpression(operand, ops);
-    os << ';';
-    emitLocationInfoAndNewLine(ops);
-    ops.clear();
-    ++numStatementsEmitted;
-  }
 }
 
 LogicalResult StmtEmitter::visitSV(ConnectOp op) {


### PR DESCRIPTION
Remove a few unused functions from the FIRParser and the ExportVerilog pass to make the compiler happy. See #709.