### PR TITLE
Support ReferenceTarget Annotations for Operations

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -82,14 +82,16 @@ def SMemOp : FIRRTLOp<"smem", [/*MemAlloc*/]> {
 
 def MemOp : FIRRTLOp<"mem", [/*MemAlloc*/]> {
   let summary = "Define a new mem";
-  let arguments = (ins Confined<I32Attr, [IntMinValue<0>]>:$readLatency,
-                       Confined<I32Attr, [IntMinValue<1>]>:$writeLatency,
-                       Confined<I64Attr, [IntMinValue<1>]>:$depth, RUWAttr:$ruw,
-                       StrArrayAttr:$portNames,
-                       OptionalAttr<StrAttr>:$name);
+  let arguments = (
+    ins Confined<I32Attr, [IntMinValue<0>]>:$readLatency,
+        Confined<I32Attr, [IntMinValue<1>]>:$writeLatency,
+        Confined<I64Attr, [IntMinValue<1>]>:$depth, RUWAttr:$ruw,
+        StrArrayAttr:$portNames,
+        OptionalAttr<StrAttr>:$name,
+        DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations);
   let results = (outs Variadic<FIRRTLType>:$results);
 
-  let assemblyFormat = "$ruw attr-dict `:` type($results)";
+  let assemblyFormat = "$ruw custom<SMemOp>(attr-dict) `:` type($results)";
 
   let verifier = "return ::verifyMemOp(*this);";
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -60,10 +60,12 @@ def InstanceOp : FIRRTLOp<"instance"> {
 
 def CMemOp : FIRRTLOp<"cmem", [/*MemAlloc*/]> {
   let summary = "Define a new cmem";
-  let arguments = (ins OptionalAttr<StrAttr>:$name);
+  let arguments = (
+    ins OptionalAttr<StrAttr>:$name,
+        DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations);
   let results = (outs FIRRTLType:$result);
 
-  let assemblyFormat = "attr-dict `:` type($result)";
+  let assemblyFormat = "custom<ElideAnnotations>(attr-dict) `:` type($result)";
 }
 
 def SMemOp : FIRRTLOp<"smem", [/*MemAlloc*/]> {

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -145,7 +145,10 @@ def NodeOp : FIRRTLOp<"node", [NoSideEffect, SameOperandsAndResultType]> {
     ```
     }];
 
-  let arguments = (ins PassiveType:$input, OptionalAttr<StrAttr>:$name);
+  let arguments = (
+    ins PassiveType:$input,
+        OptionalAttr<StrAttr>:$name,
+        DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations);
   let results = (outs FIRRTLType:$result);
 
   let assemblyFormat = "$input custom<ImplicitSSAName>(attr-dict) `:` type($input)";

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -91,7 +91,7 @@ def MemOp : FIRRTLOp<"mem", [/*MemAlloc*/]> {
         DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations);
   let results = (outs Variadic<FIRRTLType>:$results);
 
-  let assemblyFormat = "$ruw custom<SMemOp>(attr-dict) `:` type($results)";
+  let assemblyFormat = "$ruw custom<MemOp>(attr-dict) `:` type($results)";
 
   let verifier = "return ::verifyMemOp(*this);";
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -163,19 +163,24 @@ def RegOp : FIRRTLOp<"reg", [/*MemAlloc*/]> {
     ```
     }];
 
-  let arguments = (ins ClockType:$clockVal, OptionalAttr<StrAttr>:$name);
+  let arguments = (
+    ins ClockType:$clockVal,
+      OptionalAttr<StrAttr>:$name,
+      DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations);
   let results = (outs PassiveType:$result);
 
   let builders = [
     OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$clockVal,
-                   CArg<"StringRef", "{}">:$name), [{
+                   CArg<"StringRef", "{}">:$name,
+                   CArg<"ArrayRef<Attribute>","{}">:$annotations), [{
       return build($_builder, $_state, elementType, clockVal,
-                   $_builder.getStringAttr(name));
+                   $_builder.getStringAttr(name),
+                   $_builder.getArrayAttr(annotations));
     }]>
   ];
 
   let assemblyFormat =
-    "operands attr-dict `:` functional-type(operands, $result)";
+    "operands custom<ElideAnnotations>(attr-dict) `:` functional-type(operands, $result)";
 }
 
 def RegResetOp : FIRRTLOp<"regreset", [/*MemAlloc*/]> {
@@ -187,21 +192,25 @@ def RegResetOp : FIRRTLOp<"regreset", [/*MemAlloc*/]> {
     ```
     }];
 
-  let arguments = (ins ClockType:$clockVal, ResetType:$resetSignal,
-                       PassiveType:$resetValue, OptionalAttr<StrAttr>:$name);
+  let arguments = (
+    ins ClockType:$clockVal, ResetType:$resetSignal,
+        PassiveType:$resetValue, OptionalAttr<StrAttr>:$name,
+        DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations);
   let results = (outs PassiveType:$result);
 
   let builders = [
     OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$clockVal,
                    "::mlir::Value":$resetSignal, "::mlir::Value":$resetValue,
-                   CArg<"StringRef", "{}">:$name), [{
+                   CArg<"StringRef", "{}">:$name,
+                   CArg<"ArrayRef<Attribute>","{}">:$annotations), [{
       return build($_builder, $_state, elementType, clockVal, resetSignal,
-                   resetValue, $_builder.getStringAttr(name));
+                   resetValue, $_builder.getStringAttr(name),
+                   $_builder.getArrayAttr(annotations));
     }]>
   ];
 
   let assemblyFormat =
-     "operands attr-dict `:` functional-type(operands, $result)";
+     "operands custom<ElideAnnotations>(attr-dict) `:` functional-type(operands, $result)";
 }
 
 def WireOp : FIRRTLOp<"wire", []> {

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -18,10 +18,13 @@ def InstanceOp : FIRRTLOp<"instance"> {
   }];
 
   let arguments = (ins FlatSymbolRefAttr:$moduleName,
-                       StrArrayAttr:$portNames, OptionalAttr<StrAttr>:$name);
+                       StrArrayAttr:$portNames, OptionalAttr<StrAttr>:$name,
+                       DefaultValuedAttr<AnnotationArrayAttr,
+                                         "{}">:$annotations);
   let results = (outs Variadic<FIRRTLType>:$results);
 
-  let assemblyFormat = "$moduleName attr-dict (`:` type($results)^ )?";
+  let assemblyFormat =
+    "$moduleName custom<InstanceOp>(attr-dict) (`:` type($results)^ )?";
 
   let verifier = "return ::verifyInstanceOp(*this);";
 
@@ -29,9 +32,11 @@ def InstanceOp : FIRRTLOp<"instance"> {
     OpBuilder<(ins "::mlir::TypeRange":$elementType,
                       "::mlir::StringRef":$moduleName,
                       "::mlir::ArrayAttr":$portNames,
-                      CArg<"StringRef", "{}">:$name), [{
+                      CArg<"StringRef", "{}">:$name,
+                      CArg<"ArrayRef<Attribute>", "{}">:$annotations), [{
       return build($_builder, $_state, elementType, moduleName, portNames,
-                   $_builder.getStringAttr(name));
+                   $_builder.getStringAttr(name),
+                   $_builder.getArrayAttr(annotations));
     }]>
   ];
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -70,10 +70,14 @@ def CMemOp : FIRRTLOp<"cmem", [/*MemAlloc*/]> {
 
 def SMemOp : FIRRTLOp<"smem", [/*MemAlloc*/]> {
   let summary = "Define a new smem";
-  let arguments = (ins RUWAttr:$ruw, OptionalAttr<StrAttr>:$name);
+  let arguments = (
+    ins RUWAttr:$ruw,
+        OptionalAttr<StrAttr>:$name,
+        DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations);
   let results = (outs FIRRTLType:$result);
 
-  let assemblyFormat = "$ruw attr-dict `:` type($result)";
+  let assemblyFormat =
+    "$ruw custom<MemOp>(attr-dict) `:` type($result)";
 }
 
 def MemOp : FIRRTLOp<"mem", [/*MemAlloc*/]> {

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -213,14 +213,18 @@ def WireOp : FIRRTLOp<"wire", []> {
     ```
     }];
 
-  let arguments = (ins OptionalAttr<StrAttr>:$name);
+  let arguments = (
+    ins OptionalAttr<StrAttr>:$name,
+        DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations);
   let results = (outs FIRRTLType:$result);
 
   let builders = [
     OpBuilder<(ins "::mlir::Type":$elementType,
-                      CArg<"StringRef", "{}">:$name), [{
+                      CArg<"StringRef", "{}">:$name,
+                      CArg<"ArrayRef<Attribute>","{}">:$annotations), [{
       return build($_builder, $_state, elementType,
-                   $_builder.getStringAttr(name));
+                   $_builder.getStringAttr(name),
+                   $_builder.getArrayAttr(annotations));
     }]>
   ];
 

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -1695,9 +1695,9 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
     resultNames.push_back(rewriter.getStringAttr(p.first));
   }
 
-  auto memOp = rewriter.create<MemOp>(insertLoc, resultTypes, readLatency,
-                                      writeLatency, depth, ruw,
-                                      rewriter.getArrayAttr(resultNames), name);
+  auto memOp = rewriter.create<MemOp>(
+      insertLoc, resultTypes, readLatency, writeLatency, depth, ruw,
+      rewriter.getArrayAttr(resultNames), name, rewriter.getArrayAttr({}));
 
   // Prepare to create each load and store port logic.
   auto bitType = UIntType::get(rewriter.getContext(), 1);

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -2033,7 +2033,7 @@ static void createInstOp(Operation *oldOp, FModuleOp subModuleOp,
   // Create a instance operation.
   auto instanceOp = rewriter.create<firrtl::InstanceOp>(
       oldOp->getLoc(), resultTypes, subModuleOp.getName(),
-      rewriter.getArrayAttr(resultNames), rewriter.getStringAttr(""));
+      rewriter.getArrayAttr(resultNames));
 
   // Connect the new created instance with its predecessors and successors in
   // the top-module.

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1762,6 +1762,29 @@ static void printImplicitSSAName(OpAsmPrinter &p, Operation *op,
 }
 
 //===----------------------------------------------------------------------===//
+// Custom attr-dict Directive that Elides Annotations
+//===----------------------------------------------------------------------===//
+
+static ParseResult parseElideAnnotations(OpAsmParser &parser,
+                                         NamedAttrList &resultAttrs) {
+
+  if (parser.parseOptionalAttrDict(resultAttrs))
+    return failure();
+
+  return success();
+}
+
+static void printElideAnnotations(OpAsmPrinter &p, Operation *op,
+                                  DictionaryAttr attr) {
+  // Elide "annotations" if it doesn't exist or if it is empty
+  auto annotationsAttr = op->getAttrOfType<ArrayAttr>("annotations");
+  if (!annotationsAttr || annotationsAttr.empty())
+    return p.printOptionalAttrDict(op->getAttrs(), {"annotations"});
+
+  p.printOptionalAttrDict(op->getAttrs());
+}
+
+//===----------------------------------------------------------------------===//
 // InstanceOp Custom attr-dict Directive
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1816,11 +1816,7 @@ static void printInstanceOp(OpAsmPrinter &p, Operation *op,
 
 /// No change from normal parsing.
 static ParseResult parseMemOp(OpAsmParser &parser, NamedAttrList &resultAttrs) {
-
-  if (parser.parseOptionalAttrDict(resultAttrs))
-    return failure();
-
-  return success();
+  return parser.parseOptionalAttrDict(resultAttrs);
 }
 
 /// Always elide "ruw" and elide "annotations" if it exists or if it is empty.

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1762,6 +1762,32 @@ static void printImplicitSSAName(OpAsmPrinter &p, Operation *op,
 }
 
 //===----------------------------------------------------------------------===//
+// InstanceOp Custom attr-dict Directive
+//===----------------------------------------------------------------------===//
+
+/// No change from normal parsing.
+static ParseResult parseInstanceOp(OpAsmParser &parser,
+                                   NamedAttrList &resultAttrs) {
+  return parser.parseOptionalAttrDict(resultAttrs);
+}
+
+/// Always elide "moduleName" and elide "annotations" if it exists or
+/// if it is empty.
+static void printInstanceOp(OpAsmPrinter &p, Operation *op,
+                            DictionaryAttr attr) {
+
+  // "moduleName" is always elided
+  SmallVector<StringRef, 2> elides = {"moduleName"};
+
+  // Elide "annotations" if it doesn't exist or if it is empty
+  auto annotationsAttr = op->getAttrOfType<ArrayAttr>("annotations");
+  if (!annotationsAttr || annotationsAttr.empty())
+    elides.push_back("annotations");
+
+  p.printOptionalAttrDict(op->getAttrs(), elides);
+}
+
+//===----------------------------------------------------------------------===//
 // TblGen Generated Logic.
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1811,6 +1811,30 @@ static void printInstanceOp(OpAsmPrinter &p, Operation *op,
 }
 
 //===----------------------------------------------------------------------===//
+// MemOp Custom attr-dict Directive
+//===----------------------------------------------------------------------===//
+
+/// No change from normal parsing.
+static ParseResult parseMemOp(OpAsmParser &parser, NamedAttrList &resultAttrs) {
+
+  if (parser.parseOptionalAttrDict(resultAttrs))
+    return failure();
+
+  return success();
+}
+
+/// Always elide "ruw" and elide "annotations" if it exists or if it is empty.
+static void printMemOp(OpAsmPrinter &p, Operation *op, DictionaryAttr attr) {
+  SmallVector<StringRef, 2> elides = {"ruw"};
+
+  auto annotationsAttr = op->getAttrOfType<ArrayAttr>("annotations");
+  if (!annotationsAttr || annotationsAttr.size() == 0)
+    elides.push_back("annotations");
+
+  p.printOptionalAttrDict(op->getAttrs(), elides);
+}
+
+//===----------------------------------------------------------------------===//
 // TblGen Generated Logic.
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1774,11 +1774,7 @@ static void printImplicitSSAName(OpAsmPrinter &p, Operation *op,
 
 static ParseResult parseElideAnnotations(OpAsmParser &parser,
                                          NamedAttrList &resultAttrs) {
-
-  if (parser.parseOptionalAttrDict(resultAttrs))
-    return failure();
-
-  return success();
+  return parser.parseOptionalAttrDict(resultAttrs);
 }
 
 static void printElideAnnotations(OpAsmPrinter &p, Operation *op,

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1755,10 +1755,17 @@ static void printImplicitSSAName(OpAsmPrinter &p, Operation *op,
     namesDisagree = true;
   }
 
-  if (namesDisagree)
-    p.printOptionalAttrDict(op->getAttrs());
-  else
-    p.printOptionalAttrDict(op->getAttrs(), {"name"});
+  SmallVector<StringRef, 2> elides;
+
+  if (!namesDisagree)
+    elides.push_back("name");
+
+  // Elide "annotations" if it doesn't exist or if it is empty
+  auto annotationsAttr = op->getAttrOfType<ArrayAttr>("annotations");
+  if (!annotationsAttr || annotationsAttr.empty())
+    elides.push_back("annotations");
+
+  p.printOptionalAttrDict(op->getAttrs(), elides);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1824,7 +1824,7 @@ static void printMemOp(OpAsmPrinter &p, Operation *op, DictionaryAttr attr) {
   SmallVector<StringRef, 2> elides = {"ruw"};
 
   auto annotationsAttr = op->getAttrOfType<ArrayAttr>("annotations");
-  if (!annotationsAttr || annotationsAttr.size() == 0)
+  if (!annotationsAttr || annotationsAttr.empty())
     elides.push_back("annotations");
 
   p.printOptionalAttrDict(op->getAttrs(), elides);

--- a/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
@@ -78,11 +78,12 @@ bool circt::firrtl::fromJSON(json::Value &value,
     // If the target is something that we know we don't support, then error.
     bool unsupported =
         std::any_of(newTarget.begin(), newTarget.end(), [](char a) {
-          return a == '/' || a == ':' || a == '>' || a == '.' || a == '[';
+          return a == '/' || a == ':' || a == '.' || a == '[';
         });
     if (unsupported) {
       p.field("target").report(
-          "Unsupported target (not a CircuitTarget or ModuleTarget)");
+          "Unsupported target (not a local CircuitTarget, ModuleTarget, or "
+          "ReferenceTarget without subfield or subindex)");
       return {};
     }
 

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -935,6 +935,9 @@ public:
   /// we need to keep track of the scope (in the `symbolTable`) of each memory.
   /// This keeps track of this.
   MemoryScopeTable &memoryScopeTable;
+
+  /// Return the current modulet target, e.g., "~Foo|Bar".
+  StringRef getModuleTarget() { return getState().moduleTarget; }
 };
 } // end anonymous namespace
 

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1820,7 +1820,7 @@ ParseResult FIRStmtParser::parseMemPort(MemDirAttr direction) {
       OpBuilder memOpBuilder(scopeAndOperation.second);
 
       auto wireHack = memOpBuilder.create<WireOp>(
-          info.getLoc(), result.getType(), StringAttr());
+          info.getLoc(), result.getType(), StringAttr(), ArrayAttr());
       builder.create<ConnectOp>(info.getLoc(), wireHack, result);
 
       // Inject this the wire's name into the same scope as the memory.
@@ -2478,8 +2478,11 @@ ParseResult FIRStmtParser::parseWire() {
       parseType(type, "expected wire type") || parseOptionalInfo(info))
     return failure();
 
-  auto result =
-      builder.create<WireOp>(info.getLoc(), type, filterUselessName(id));
+  ArrayAttr annotations = builder.getArrayAttr({});
+  getAnnotations(getModuleTarget() + ">" + id.getValue(), annotations);
+
+  auto result = builder.create<WireOp>(info.getLoc(), type,
+                                       filterUselessName(id), annotations);
   return addSymbolEntry(id.getValue(), result, info.getFIRLoc());
 }
 

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2373,9 +2373,13 @@ ParseResult FIRStmtParser::parseMem(unsigned memIndent) {
     resultTypes.push_back(FlipType::get(p.second));
   }
 
+  auto name = filterUselessName(id);
+  ArrayAttr annotations = builder.getArrayAttr({});
+  getAnnotations(getModuleTarget() + ">" + name.getValue().str(), annotations);
+
   auto result = builder.create<MemOp>(
       info.getLoc(), resultTypes, readLatency, writeLatency, depth, ruw,
-      builder.getArrayAttr(resultNames), filterUselessName(id));
+      builder.getArrayAttr(resultNames), filterUselessName(id), annotations);
 
   UnbundledValueEntry unbundledValueEntry;
   unbundledValueEntry.reserve(result.getNumResults());

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2375,7 +2375,7 @@ ParseResult FIRStmtParser::parseMem(unsigned memIndent) {
 
   auto name = filterUselessName(id);
   ArrayAttr annotations = builder.getArrayAttr({});
-  getAnnotations(getModuleTarget() + ">" + name.getValue().str(), annotations);
+  getAnnotations(getModuleTarget() + ">" + name.getValue(), annotations);
 
   auto result = builder.create<MemOp>(
       info.getLoc(), resultTypes, readLatency, writeLatency, depth, ruw,

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2164,9 +2164,12 @@ ParseResult FIRStmtParser::parseInstance() {
     resultTypes.push_back(FlipType::get(port.type));
     resultNames.push_back(port.name);
   }
+  auto name = filterUselessName(id);
+  ArrayAttr annotations = builder.getArrayAttr({});
+  getAnnotations(getModuleTarget() + ">" + name.getValue(), annotations);
   auto result = builder.create<InstanceOp>(
       info.getLoc(), resultTypes, builder.getSymbolRefAttr(moduleName),
-      builder.getArrayAttr(resultNames), id, builder.getArrayAttr({}));
+      builder.getArrayAttr(resultNames), name, annotations);
 
   // Since we are implicitly unbundling the instance results, we need to keep
   // track of the mapping from bundle fields to results in the unbundledValues

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2447,10 +2447,16 @@ ParseResult FIRStmtParser::parseNode() {
 
   // The entire point of a node declaration is to carry a name.  If it got
   // dropped, then we don't even need to create a result.
+  //
+  // TODO: This optimization doesn't respect annotated, temporary nodes.
   Value result;
-  if (actualName)
-    result = builder.create<NodeOp>(info.getLoc(), initializer, actualName);
-  else
+  if (actualName) {
+    ArrayAttr annotations = builder.getArrayAttr({});
+    getAnnotations(getModuleTarget() + ">" + actualName.getValue(),
+                   annotations);
+    result = builder.create<NodeOp>(info.getLoc(), initializer, actualName,
+                                    annotations);
+  } else
     result = initializer;
   return addSymbolEntry(id.getValue(), result, info.getFIRLoc());
 }

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2163,7 +2163,7 @@ ParseResult FIRStmtParser::parseInstance() {
   }
   auto result = builder.create<InstanceOp>(
       info.getLoc(), resultTypes, builder.getSymbolRefAttr(moduleName),
-      builder.getArrayAttr(resultNames), filterUselessName(id));
+      builder.getArrayAttr(resultNames), id, builder.getArrayAttr({}));
 
   // Since we are implicitly unbundling the instance results, we need to keep
   // track of the mapping from bundle fields to results in the unbundledValues

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2204,8 +2204,11 @@ ParseResult FIRStmtParser::parseCMem() {
       parseType(type, "expected cmem type") || parseOptionalInfo(info))
     return failure();
 
-  auto result =
-      builder.create<CMemOp>(info.getLoc(), type, filterUselessName(id));
+  auto name = filterUselessName(id);
+  ArrayAttr annotations = builder.getArrayAttr({});
+  getAnnotations(getModuleTarget() + ">" + name.getValue(), annotations);
+
+  auto result = builder.create<CMemOp>(info.getLoc(), type, name, annotations);
 
   // Remember that this memory is in this symbol table scope.
   // TODO(chisel bug): This should be removed along with memoryScopeTable.

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2574,13 +2574,17 @@ ParseResult FIRStmtParser::parseRegister(unsigned regIndent) {
   if (parseOptionalInfo(info, subOps))
     return failure();
 
+  auto name = filterUselessName(id);
+  ArrayAttr annotations = builder.getArrayAttr({});
+  getAnnotations(getModuleTarget() + ">" + name.getValue(), annotations);
+
   Value result;
   if (resetSignal)
     result = builder.create<RegResetOp>(info.getLoc(), type, clock, resetSignal,
-                                        resetValue, filterUselessName(id));
+                                        resetValue, name, annotations);
   else
-    result = builder.create<RegOp>(info.getLoc(), type, clock,
-                                   filterUselessName(id));
+    result =
+        builder.create<RegOp>(info.getLoc(), type, clock, name, annotations);
 
   return addSymbolEntry(id.getValue(), result, info.getFIRLoc());
 }

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2239,8 +2239,12 @@ ParseResult FIRStmtParser::parseSMem() {
       parseOptionalInfo(info))
     return failure();
 
+  auto name = filterUselessName(id);
+  ArrayAttr annotations = builder.getArrayAttr({});
+  getAnnotations(getModuleTarget() + ">" + name.getValue(), annotations);
+
   auto result =
-      builder.create<SMemOp>(info.getLoc(), type, ruw, filterUselessName(id));
+      builder.create<SMemOp>(info.getLoc(), type, ruw, name, annotations);
 
   // Remember that this memory is in this symbol table scope.
   // TODO(chisel bug): This should be removed along with memoryScopeTable.

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -403,11 +403,15 @@ void TypeLoweringVisitor::visitDecl(MemOp op) {
     }
 
     // Construct the new memory for this flattened field.
+    //
+    // TODO: Annotations are just copied to the lowered memory.
+    // Change this to copy all global annotations and only those which
+    // target specific ports.
     auto newName = op.name().getValue().str() + field.suffix;
     auto newMem = builder->create<MemOp>(
         resultPortTypes, op.readLatency(), op.writeLatency(), depth, op.ruw(),
         builder->getArrayAttr(resultPortNames.getArrayRef()),
-        builder->getStringAttr(newName));
+        builder->getStringAttr(newName), op.annotations());
 
     // Setup the lowering to the new memory. We need to track both the
     // new memory index ("i") and the old memory index ("j") to deal

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -549,7 +549,8 @@ void TypeLoweringVisitor::visitDecl(WireOp op) {
     loweredName.resize(wireName.size());
     loweredName += field.suffix;
     auto wire = builder->create<WireOp>(field.getPortType(),
-                                        builder->getStringAttr(loweredName));
+                                        builder->getStringAttr(loweredName),
+                                        op.annotations());
     setBundleLowering(result, StringRef(field.suffix).drop_front(1), wire);
   }
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -314,7 +314,7 @@ void TypeLoweringVisitor::visitDecl(InstanceOp op) {
 
   auto newInstance = builder->create<InstanceOp>(
       resultTypes, op.moduleNameAttr(), builder->getArrayAttr(resultNames),
-      op.nameAttr(), builder->getArrayAttr({}));
+      op.nameAttr(), op.annotations());
 
   // Record the mapping of each old result to each new result.
   size_t nextResult = 0;

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -582,7 +582,7 @@ void TypeLoweringVisitor::visitDecl(RegOp op) {
 
     setBundleLowering(result, StringRef(field.suffix).drop_front(1),
                       builder->create<RegOp>(field.getPortType(), op.clockVal(),
-                                             loweredName));
+                                             loweredName, op.annotations()));
   }
 
   // Remember to remove the original op.
@@ -615,7 +615,7 @@ void TypeLoweringVisitor::visitDecl(RegResetOp op) {
     setBundleLowering(result, suffix,
                       builder->create<RegResetOp>(
                           field.getPortType(), op.clockVal(), op.resetSignal(),
-                          resetValLowered, loweredName));
+                          resetValLowered, loweredName, op.annotations()));
   }
 
   // Remember to remove the original op.

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -314,7 +314,7 @@ void TypeLoweringVisitor::visitDecl(InstanceOp op) {
 
   auto newInstance = builder->create<InstanceOp>(
       resultTypes, op.moduleNameAttr(), builder->getArrayAttr(resultNames),
-      op.nameAttr());
+      op.nameAttr(), builder->getArrayAttr({}));
 
   // Record the mapping of each old result to each new result.
   size_t nextResult = 0;

--- a/test/Dialect/FIRRTL/annotations-errors.fir
+++ b/test/Dialect/FIRRTL/annotations-errors.fir
@@ -1,29 +1,9 @@
 ; RUN: circt-translate -import-firrtl -verify-diagnostics --split-input-file %s
 
-; COM: A legacy `firrtl.annotations.ComponentName` is unsupported.
-
-; expected-error @+2 {{Invalid/unsupported annotation format}}
-; expected-note @+1 {{"target": /* error: Unsupported target (not a CircuitTarget or ModuleTarget) */ "Foo.Foo.a"}}
-circuit Foo: %[[{"a":"a","target":"Foo.Foo.a"}]]
-  module Foo:
-    skip
-
-; // -----
-
-; COM: A ReferenceTarget Annotation is unsupported.
-
-; expected-error @+2 {{Invalid/unsupported annotation format}}
-; expected-note @+1 {{"target": /* error: Unsupported target (not a CircuitTarget or ModuleTarget) */ "~Foo|Foo>a"}}
-circuit Foo: %[[{"a":"a","target":"~Foo|Foo>a"}]]
-  module Foo:
-    skip
-
-; // -----
-
 ; COM: A ReferenceTarget Annotation with a subindex is unsupported.
 
 ; expected-error @+2 {{Invalid/unsupported annotation format}}
-; expected-note @+1 {{"target": /* error: Unsupported target (not a CircuitTarget or ModuleTarget) */ "~Foo|Foo>a.b"}}
+; expected-note @+1 {{"target": /* error: Unsupported target (not a local CircuitTarget, ModuleTarget, or ReferenceTarget without subfield or subindex) */ "~Foo|Foo>a.b"}}
 circuit Foo: %[[{"a":"a","target":"~Foo|Foo>a.b"}]]
   module Foo:
     skip
@@ -33,7 +13,7 @@ circuit Foo: %[[{"a":"a","target":"~Foo|Foo>a.b"}]]
 ; COM: A ReferenceTarget Annotation with a subfield is unsupported.
 
 ; expected-error @+2 {{Invalid/unsupported annotation format}}
-; expected-note @+1 {{"target": /* error: Unsupported target (not a CircuitTarget or ModuleTarget) */ "~Foo|Foo>a[0]"}}
+; expected-note @+1 {{"target": /* error: Unsupported target (not a local CircuitTarget, ModuleTarget, or ReferenceTarget without subfield or subindex) */ "~Foo|Foo>a[0]"}}
 circuit Foo: %[[{"a":"a","target":"~Foo|Foo>a[0]"}]]
   module Foo:
     skip
@@ -43,7 +23,7 @@ circuit Foo: %[[{"a":"a","target":"~Foo|Foo>a[0]"}]]
 ; COM: A non-local Annotation is unsupported.
 
 ; expected-error @+2 {{Invalid/unsupported annotation format}}
-; expected-note @+1 {{"target": /* error: Unsupported target (not a CircuitTarget or ModuleTarget) */ "~Foo|Foo/bar:Bar"}}
+; expected-note @+1 {{"target": /* error: Unsupported target (not a local CircuitTarget, ModuleTarget, or ReferenceTarget without subfield or subindex) */ "~Foo|Foo/bar:Bar"}}
 circuit Foo: %[[{"a":"a","target":"~Foo|Foo/bar:Bar"}]]
   module Foo:
     skip

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -82,6 +82,17 @@ circuit Foo: %[[{"a":"a","target":"~Foo|Foo>bar"},{"b":"b","target":"Foo.Foo.bar
 
 ; // -----
 
+; COM: A ReferenceTarget/ComponentName pointing at a CMem should work.
+circuit Foo: %[[{"a":"a","target":"~Foo|Foo>bar"},{"b":"b","target":"Foo.Foo.bar"}]]
+  module Foo:
+    cmem bar: UInt<1>[8]
+
+    ; CHECK-LABEL: module {
+    ; CHECK: firrtl.cmem
+    ; CHECK-SAME: annotations = [{a = "a"}, {b = "b"}]
+
+; // -----
+
 ; COM: All types of JSON values should work
 circuit Foo: %[[{"string":"a","integer":42,"float":3.14,"boolean":true,"null":null,"object":{"foo":"bar"},"array":[1,2,3]}]]
   module Foo:

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -140,6 +140,22 @@ circuit Foo: %[[{"a":"a","target":"~Foo|Foo>bar"},{"b":"b","target":"Foo.Foo.bar
 
 ; // -----
 
+; COM: A ReferenceTarget/ComponentName pointing at a register should work.
+circuit Foo: %[[{"a":"a","target":"~Foo|Foo>bar"},{"b":"b","target":"Foo.Foo.baz"}]]
+  module Foo:
+    input clock: Clock
+    input reset: UInt<1>
+    reg bar: UInt<1>, clock
+    reg baz: UInt<1>, clock with : (reset => (reset, UInt<1>(0)))
+
+    ; CHECK-LABEL: module {
+    ; CHECK: %bar = firrtl.reg
+    ; CHECK-SAME: annotations = [{a = "a"}]
+    ; CHECK: %baz = firrtl.regreset
+    ; CHECK-SAME: annotations = [{b = "b"}]
+
+; // -----
+
 ; COM: A ReferenceTarget/ComponentName pointing at an SMem should work.
 circuit Foo: %[[{"a":"a","target":"~Foo|Foo>bar"},{"b":"b","target":"Foo.Foo.bar"}]]
   module Foo:

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -93,6 +93,24 @@ circuit Foo: %[[{"a":"a","target":"~Foo|Foo>bar"},{"b":"b","target":"Foo.Foo.bar
 
 ; // -----
 
+; COM: A ReferenceTarget/ComponentName pointing at a memory should work.
+circuit Foo: %[[{"a":"a","target":"~Foo|Foo>bar"},{"b":"b","target":"Foo.Foo.bar"}]]
+  module Foo:
+    mem bar:
+      data-type => UInt<8>
+      depth => 16
+      reader => r
+      writer => w
+      read-latency => 0
+      write-latency => 1
+      read-under-write => undefined
+
+    ; CHECK-LABEL: module {
+    ; CHECK: firrtl.mem
+    ; CHECK-SAME: annotations = [{a = "a"}, {b = "b"}]
+
+; // -----
+
 ; COM: A ReferenceTarget/ComponentName pointing at an SMem should work.
 circuit Foo: %[[{"a":"a","target":"~Foo|Foo>bar"},{"b":"b","target":"Foo.Foo.bar"}]]
   module Foo:

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -129,6 +129,17 @@ circuit Foo: %[[{"a":"a","target":"~Foo|Foo>bar"},{"b":"b","target":"Foo.Foo.baz
 
 ; // -----
 
+; COM: A ReferenceTarget/ComponentName pointing at a wire should work.
+circuit Foo: %[[{"a":"a","target":"~Foo|Foo>bar"},{"b":"b","target":"Foo.Foo.bar"}]]
+  module Foo:
+    wire bar: UInt<1>
+
+    ; CHECK-LABEL: module {
+    ; CHECK: %bar = firrtl.wire
+    ; CHECK-SAME: annotations = [{a = "a"}, {b = "b"}]
+
+; // -----
+
 ; COM: A ReferenceTarget/ComponentName pointing at an SMem should work.
 circuit Foo: %[[{"a":"a","target":"~Foo|Foo>bar"},{"b":"b","target":"Foo.Foo.bar"}]]
   module Foo:

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -111,6 +111,24 @@ circuit Foo: %[[{"a":"a","target":"~Foo|Foo>bar"},{"b":"b","target":"Foo.Foo.bar
 
 ; // -----
 
+; COM: A ReferenceTarget/ComponentName pointing at a node should work.
+; COM: This shouldn't crash if the node is in a nested block.
+circuit Foo: %[[{"a":"a","target":"~Foo|Foo>bar"},{"b":"b","target":"Foo.Foo.baz"}]]
+  module Foo:
+    input cond: UInt<1>[2]
+    node bar = UInt<1>(0)
+    when cond[0]:
+      when cond[1]:
+        node baz = UInt<1>(0)
+
+    ; CHECK-LABEL: module {
+    ; CHECK: %bar = firrtl.node
+    ; CHECK-SAME: annotations = [{a = "a"}
+    ; CHECK: %baz = firrtl.node
+    ; CHECK-SAME: annotations = [{b = "b"}]
+
+; // -----
+
 ; COM: A ReferenceTarget/ComponentName pointing at an SMem should work.
 circuit Foo: %[[{"a":"a","target":"~Foo|Foo>bar"},{"b":"b","target":"Foo.Foo.bar"}]]
   module Foo:

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -69,6 +69,19 @@ circuit Foo: %[[{"a":"a","target":"~Foo|Bar"}]]
 
 ; // -----
 
+; COM: A ReferenceTarget/ComponentName pointing at an Instance should work.
+circuit Foo: %[[{"a":"a","target":"~Foo|Foo>bar"},{"b":"b","target":"Foo.Foo.bar"}]]
+  module Bar:
+    skip
+  module Foo:
+    inst bar of Bar
+
+    ; CHECK-LABEL: module {
+    ; CHECK: firrtl.instance @Bar
+    ; CHECK-SAME: annotations = [{a = "a"}, {b = "b"}]
+
+; // -----
+
 ; COM: All types of JSON values should work
 circuit Foo: %[[{"string":"a","integer":42,"float":3.14,"boolean":true,"null":null,"object":{"foo":"bar"},"array":[1,2,3]}]]
   module Foo:

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -93,6 +93,17 @@ circuit Foo: %[[{"a":"a","target":"~Foo|Foo>bar"},{"b":"b","target":"Foo.Foo.bar
 
 ; // -----
 
+; COM: A ReferenceTarget/ComponentName pointing at an SMem should work.
+circuit Foo: %[[{"a":"a","target":"~Foo|Foo>bar"},{"b":"b","target":"Foo.Foo.bar"}]]
+  module Foo:
+    smem bar: UInt<1>[8]
+
+    ; CHECK-LABEL: module {
+    ; CHECK: firrtl.smem
+    ; CHECK-SAME: annotations = [{a = "a"}, {b = "b"}]
+
+; // -----
+
 ; COM: All types of JSON values should work
 circuit Foo: %[[{"string":"a","integer":42,"float":3.14,"boolean":true,"null":null,"object":{"foo":"bar"},"array":[1,2,3]}]]
   module Foo:

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -589,3 +589,18 @@ firrtl.circuit "lowerRegOpNoName" {
  // CHECK:    firrtl.connect %a_q_0, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
  // CHECK:    firrtl.connect %a_q_1, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 }
+
+// -----
+
+// Test that InstanceOp Annotations are copied to the new instance.
+firrtl.circuit "Foo" {
+  firrtl.module @Bar(%a: !firrtl.flip<vector<uint<1>, 2>>) {
+    %0 = firrtl.invalidvalue : !firrtl.vector<uint<1>, 2>
+    firrtl.connect %a, %0 : !firrtl.flip<vector<uint<1>, 2>>, !firrtl.vector<uint<1>, 2>
+  }
+  firrtl.module @Foo() {
+    %bar_a = firrtl.instance @Bar  {annotations = [{a = "a"}], name = "bar", portNames = ["a"]} : !firrtl.vector<uint<1>, 2>
+  }
+  // CHECK: firrtl.instance
+  // CHECK-SAME: annotations = [{a = "a"}]
+}

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -617,3 +617,16 @@ firrtl.circuit "Foo" {
   // CHECK: firrtl.mem
   // CHECK-SAME: annotations = [{a = "a"}]
 }
+
+// -----
+
+// Test that WireOp Annotations are copied to lowered WireOps.
+firrtl.circuit "Wire" {
+  firrtl.module @Wire() {
+    %bar = firrtl.wire  {annotations = [{a = "a"}]} : !firrtl.vector<uint<1>, 2>
+  }
+  // CHECK: firrtl.wire
+  // CHECK-SAME: annotations = [{a = "a"}]
+  // CHECK: firrtl.wire
+  // CHECK-SAME: annotations = [{a = "a"}]
+}

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -604,3 +604,16 @@ firrtl.circuit "Foo" {
   // CHECK: firrtl.instance
   // CHECK-SAME: annotations = [{a = "a"}]
 }
+
+// -----
+
+// Test that MemOp Annotations are copied to lowered MemOps.
+firrtl.circuit "Foo" {
+  firrtl.module @Foo() {
+    %bar_r, %bar_w = firrtl.mem Undefined  {annotations = [{a = "a"}], depth = 16 : i64, name = "bar", portNames = ["r", "w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: vector<uint<8>, 2>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: vector<uint<8>, 2>, mask: vector<uint<1>, 2>>>
+  }
+  // CHECK: firrtl.mem
+  // CHECK-SAME: annotations = [{a = "a"}]
+  // CHECK: firrtl.mem
+  // CHECK-SAME: annotations = [{a = "a"}]
+}

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -630,3 +630,27 @@ firrtl.circuit "Wire" {
   // CHECK: firrtl.wire
   // CHECK-SAME: annotations = [{a = "a"}]
 }
+
+// -----
+
+// Test that Reg/RegResetOp Annotations are copied to lowered registers.
+firrtl.circuit "Reg" {
+  firrtl.module @Reg(%clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+    %bazInit = firrtl.wire  : !firrtl.vector<uint<1>, 2>
+    %0 = firrtl.subindex %bazInit[0] : !firrtl.vector<uint<1>, 2>
+    %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
+    firrtl.connect %0, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    %1 = firrtl.subindex %bazInit[1] : !firrtl.vector<uint<1>, 2>
+    firrtl.connect %1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    %bar = firrtl.reg %clock  {annotations = [{a = "a"}], name = "bar"} : (!firrtl.clock) -> !firrtl.vector<uint<1>, 2>
+    %baz = firrtl.regreset %clock, %reset, %bazInit  {annotations = [{b = "b"}], name = "baz"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<1>, 2>) -> !firrtl.vector<uint<1>, 2>
+  }
+  // CHECK: firrtl.reg
+  // CHECK-SAME: annotations = [{a = "a"}]
+  // CHECK: firrtl.reg
+  // CHECK-SAME: annotations = [{a = "a"}]
+  // CHECK: firrtl.regreset
+  // CHECK-SAME: annotations = [{b = "b"}]
+  // CHECK: firrtl.regreset
+  // CHECK-SAME: annotations = [{b = "b"}]
+}


### PR DESCRIPTION
Add support for parsing Annotations that point at _local_ `ReferenceTarget`s. These are targets of the form:

```
~Circuit|Module>Reference
```

These can point at a variety of things (items checked off are in the PR):

- [x] Instances (using an `InstanceTarget` annotation is better here, but `ReferenceTarget` means the same thing)
- [x] CMem
- [x] SMem
- [x] Wires
- [x] Registers
- [x] Nodes
- [x] Memories

Ports are not supported, due to expected churn related to arg attribute storage being changed in #872. For the time being, port targets sit in another, dependent PR.

The following are not supported as they have optional names that were [added in _to-be-released_ FIRRTL 1.5](https://github.com/chipsalliance/firrtl/pull/2057). This name support is necessary for something to be a valid target:
- Stop
- Print
- Verification Statements

Custom parsers/printers are added to elide the annotations if they are empty. Support is added to `LowerTypes` to copy annotations to operations that are split up.

All operations are handled similarly. Ports are handled differently. The PR is intentionally structured such that the first series of commits are all building the necessary support for reference target annotations, adding support to `CMemOp`, and writing tests for `CMemOp`. Everything after that is (mostly) a series of two commits: (1) adding support to an operation and (2) adding tests for that operation.

### TODO

- [x] Add tests for all cases above.
  - [x] Test that anything lowered in LowerTypes has annotations copied
- [x] Don't print annotations if they are empty (this automatically worked for module/circuit, but not here or not if there are other attributes?).

### Example

The following inline Annotation, targets one instance of module `Bar`:
```scala
circuit Foo: %[[{"class":"firrtl.passes.InlineAnnotation","target":"~Foo|Foo>bar1"}]]
  extmodule Bar:
    input a: UInt<1>
  module Foo:
    input a: UInt<1>
    inst bar1 of Bar
    inst bar2 of Bar
    bar1.a <= a
    bar2.a <= a
```

This is then applied only to the appropriate instance:

```mlir
firrtl.circuit "Foo" {
  firrtl.extmodule @Bar(!firrtl.uint<1> {firrtl.name = "a"})
  firrtl.module @Foo(%a: !firrtl.uint<1>) {
    %bar1_a = firrtl.instance @Bar  {annotations = [{class = "firrtl.passes.InlineAnnotation"}], name = "bar1", portNames = ["a"]} : !firrtl.flip<uint<1>>
    %bar2_a = firrtl.instance @Bar  {name = "bar2", portNames = ["a"]} : !firrtl.flip<uint<1>>
    firrtl.connect %bar1_a, %a : !firrtl.flip<uint<1>>, !firrtl.uint<1>
    firrtl.connect %bar2_a, %a : !firrtl.flip<uint<1>>, !firrtl.uint<1>
  }
}
```