### PR TITLE
[FIRRTL] Add constant folders and canonicalization for comparison ops

### DIFF
--- a/include/circt/Dialect/FIRRTL/CMakeLists.txt
+++ b/include/circt/Dialect/FIRRTL/CMakeLists.txt
@@ -10,3 +10,7 @@ set(LLVM_TARGET_DEFINITIONS Passes.td)
 mlir_tablegen(Passes.h.inc -gen-pass-decls)
 add_public_tablegen_target(CIRCTFIRRTLTransformsIncGen)
 add_circt_doc(Passes -gen-pass-doc FIRRTLPasses ./)
+
+set(LLVM_TARGET_DEFINITIONS Canonicalization.td)
+mlir_tablegen(Canonicalization.h.inc -gen-rewriters)
+add_public_tablegen_target(CIRCTFIRRTLCanonicalizationIncGen)

--- a/include/circt/Dialect/FIRRTL/Canonicalization.td
+++ b/include/circt/Dialect/FIRRTL/Canonicalization.td
@@ -1,0 +1,46 @@
+//===- Canonicalization.td - FIRRTL canonicalization -------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// The canonicalization patterns for the FIRRTL dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_FIRRTL_CANONICALIZATION_TD
+#define CIRCT_DIALECT_FIRRTL_CANONICALIZATION_TD
+
+include "circt/Dialect/FIRRTL/FIRRTL.td"
+
+/// Constraint that matches non-constant operations. Used to ensure that the
+/// const-on-LHS rewriting patterns converge in case both operands are constant.
+def NonConstantOp : Constraint<CPred<"!$0.getDefiningOp<ConstantOp>()">>;
+
+// leq(const, x) -> geq(x, const)
+def LEQWithConstLHS : Pat<
+  (LEQPrimOp (ConstantOp:$lhs $_), $rhs),
+  (GEQPrimOp $rhs, $lhs),
+  [(NonConstantOp $rhs)]>;
+
+// lt(const, x) -> gt(x, const)
+def LTWithConstLHS : Pat<
+  (LTPrimOp (ConstantOp:$lhs $_), $rhs),
+  (GTPrimOp $rhs, $lhs),
+  [(NonConstantOp $rhs)]>;
+
+// geq(const, x) -> geq(x, const)
+def GEQWithConstLHS : Pat<
+  (GEQPrimOp (ConstantOp:$lhs $_), $rhs),
+  (LEQPrimOp $rhs, $lhs),
+  [(NonConstantOp $rhs)]>;
+
+// gt(const, x) -> lt(x, const)
+def GTWithConstLHS : Pat<
+  (GTPrimOp (ConstantOp:$lhs $_), $rhs),
+  (LTPrimOp $rhs, $lhs),
+  [(NonConstantOp $rhs)]>;
+
+#endif // CIRCT_DIALECT_FIRRTL_CANONICALIZATION_TD

--- a/include/circt/Dialect/FIRRTL/Canonicalization.td
+++ b/include/circt/Dialect/FIRRTL/Canonicalization.td
@@ -31,7 +31,7 @@ def LTWithConstLHS : Pat<
   (GTPrimOp $rhs, $lhs),
   [(NonConstantOp $rhs)]>;
 
-// geq(const, x) -> geq(x, const)
+// geq(const, x) -> leq(x, const)
 def GEQWithConstLHS : Pat<
   (GEQPrimOp (ConstantOp:$lhs $_), $rhs),
   (LEQPrimOp $rhs, $lhs),

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -210,10 +210,18 @@ def XorPrimOp : BinaryPrimOp<"xor", IntType, IntType, UIntType, [Commutative]> {
 }
 
 // Comparison Operations
-def LEQPrimOp : BinaryPrimOp<"leq", IntType, IntType, UInt1Type>;
-def LTPrimOp  : BinaryPrimOp<"lt",  IntType, IntType, UInt1Type>;
-def GEQPrimOp : BinaryPrimOp<"geq", IntType, IntType, UInt1Type>;
-def GTPrimOp  : BinaryPrimOp<"gt",  IntType, IntType, UInt1Type>;
+def LEQPrimOp : BinaryPrimOp<"leq", IntType, IntType, UInt1Type> {
+  let hasCanonicalizer = 1;
+}
+def LTPrimOp  : BinaryPrimOp<"lt",  IntType, IntType, UInt1Type> {
+  let hasCanonicalizer = 1;
+}
+def GEQPrimOp : BinaryPrimOp<"geq", IntType, IntType, UInt1Type> {
+  let hasCanonicalizer = 1;
+}
+def GTPrimOp  : BinaryPrimOp<"gt",  IntType, IntType, UInt1Type> {
+  let hasCanonicalizer = 1;
+}
 def EQPrimOp  : BinaryPrimOp<"eq",  IntType, IntType, UInt1Type, [Commutative]>{
   let hasFolder = 1;
 }

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -212,15 +212,19 @@ def XorPrimOp : BinaryPrimOp<"xor", IntType, IntType, UIntType, [Commutative]> {
 // Comparison Operations
 def LEQPrimOp : BinaryPrimOp<"leq", IntType, IntType, UInt1Type> {
   let hasCanonicalizer = 1;
+  let hasFolder = 1;
 }
 def LTPrimOp  : BinaryPrimOp<"lt",  IntType, IntType, UInt1Type> {
   let hasCanonicalizer = 1;
+  let hasFolder = 1;
 }
 def GEQPrimOp : BinaryPrimOp<"geq", IntType, IntType, UInt1Type> {
   let hasCanonicalizer = 1;
+  let hasFolder = 1;
 }
 def GTPrimOp  : BinaryPrimOp<"gt",  IntType, IntType, UInt1Type> {
   let hasCanonicalizer = 1;
+  let hasFolder = 1;
 }
 def EQPrimOp  : BinaryPrimOp<"eq",  IntType, IntType, UInt1Type, [Commutative]>{
   let hasFolder = 1;

--- a/lib/Dialect/FIRRTL/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/CMakeLists.txt
@@ -8,6 +8,7 @@ add_circt_dialect_library(CIRCTFIRRTL
   DEPENDS
   MLIRFIRRTLIncGen
   MLIRFIRRTLEnumsIncGen
+  CIRCTFIRRTLCanonicalizationIncGen
 
   LINK_COMPONENTS
   Support
@@ -18,7 +19,11 @@ add_circt_dialect_library(CIRCTFIRRTL
   MLIRPass
   )
 
-add_dependencies(circt-headers MLIRFIRRTLIncGen MLIRFIRRTLEnumsIncGen)
+add_dependencies(circt-headers
+  MLIRFIRRTLIncGen
+  MLIRFIRRTLEnumsIncGen
+  CIRCTFIRRTLCanonicalizationIncGen
+  )
 
 add_subdirectory(Import)
 add_subdirectory(Transforms)

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -16,6 +16,15 @@
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
 
+// Declarative canonicalization patterns
+namespace circt {
+namespace firrtl {
+namespace patterns {
+#include "circt/Dialect/FIRRTL/Canonicalization.h.inc"
+} // namespace patterns
+} // namespace firrtl
+} // namespace circt
+
 using namespace circt;
 using namespace firrtl;
 
@@ -180,6 +189,26 @@ OpFoldResult XorPrimOp::fold(ArrayRef<Attribute> operands) {
 
   return constFoldBinaryOp<IntegerAttr>(operands,
                                         [](APInt a, APInt b) { return a ^ b; });
+}
+
+void LEQPrimOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
+                                            MLIRContext *context) {
+  results.insert<patterns::LEQWithConstLHS>(context);
+}
+
+void LTPrimOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
+                                           MLIRContext *context) {
+  results.insert<patterns::LTWithConstLHS>(context);
+}
+
+void GEQPrimOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
+                                            MLIRContext *context) {
+  results.insert<patterns::GEQWithConstLHS>(context);
+}
+
+void GTPrimOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
+                                           MLIRContext *context) {
+  results.insert<patterns::GTWithConstLHS>(context);
 }
 
 OpFoldResult EQPrimOp::fold(ArrayRef<Attribute> operands) {

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -550,4 +550,42 @@ firrtl.module @GTWithConstLHS(%a: !firrtl.uint, %b: !firrtl.flip<uint<1>>) {
   firrtl.connect %b, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 }
 
+// CHECK-LABEL: @CompareWithSelf
+firrtl.module @CompareWithSelf(
+  %a: !firrtl.uint,
+  %y0: !firrtl.flip<uint<1>>,
+  %y1: !firrtl.flip<uint<1>>,
+  %y2: !firrtl.flip<uint<1>>,
+  %y3: !firrtl.flip<uint<1>>,
+  %y4: !firrtl.flip<uint<1>>,
+  %y5: !firrtl.flip<uint<1>>
+) {
+  // CHECK-NEXT: [[_:.+]] = firrtl.constant
+  // CHECK-NEXT: [[_:.+]] = firrtl.constant
+
+  %0 = firrtl.leq %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  firrtl.connect %y0, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.connect %y0, %c1_ui1
+
+  %1 = firrtl.lt %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  firrtl.connect %y1, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.connect %y1, %c0_ui1
+
+  %2 = firrtl.geq %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  firrtl.connect %y2, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.connect %y2, %c1_ui1
+
+  %3 = firrtl.gt %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  firrtl.connect %y3, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.connect %y3, %c0_ui1
+
+  %4 = firrtl.eq %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  firrtl.connect %y4, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.connect %y4, %c1_ui1
+
+  %5 = firrtl.neq %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  firrtl.connect %y5, %5 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.connect %y5, %c0_ui1
+}
+
 }

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -588,4 +588,196 @@ firrtl.module @CompareWithSelf(
   // CHECK-NEXT: firrtl.connect %y5, %c0_ui1
 }
 
+// CHECK-LABEL: @LEQOutsideBounds
+firrtl.module @LEQOutsideBounds(
+  %a: !firrtl.uint<3>,
+  %b: !firrtl.sint<3>,
+  %y0: !firrtl.flip<uint<1>>,
+  %y1: !firrtl.flip<uint<1>>,
+  %y2: !firrtl.flip<uint<1>>,
+  %y3: !firrtl.flip<uint<1>>,
+  %y4: !firrtl.flip<uint<1>>,
+  %y5: !firrtl.flip<uint<1>>
+) {
+  // CHECK-NEXT: [[_:.+]] = firrtl.constant
+  // CHECK-NEXT: [[_:.+]] = firrtl.constant
+  %cm5_si = firrtl.constant(-5) : !firrtl.sint
+  %cm6_si = firrtl.constant(-6) : !firrtl.sint
+  %c3_si = firrtl.constant(3) : !firrtl.sint
+  %c4_si = firrtl.constant(4) : !firrtl.sint
+  %c7_ui = firrtl.constant(7) : !firrtl.uint
+  %c8_ui = firrtl.constant(8) : !firrtl.uint
+
+  // a <= 7 -> 1
+  // a <= 8 -> 1
+  %0 = firrtl.leq %a, %c7_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
+  %1 = firrtl.leq %a, %c8_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
+  firrtl.connect %y0, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y1, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.connect %y0, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y1, %c1_ui1
+
+  // b <= 3 -> 1
+  // b <= 4 -> 1
+  %2 = firrtl.leq %b, %c3_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
+  %3 = firrtl.leq %b, %c4_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
+  firrtl.connect %y2, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y3, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.connect %y2, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y3, %c1_ui1
+
+  // b <= -5 -> 0
+  // b <= -6 -> 0
+  %4 = firrtl.leq %b, %cm5_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
+  %5 = firrtl.leq %b, %cm6_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
+  firrtl.connect %y4, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y5, %5 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.connect %y4, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y5, %c0_ui1
+}
+
+// CHECK-LABEL: @LTOutsideBounds
+firrtl.module @LTOutsideBounds(
+  %a: !firrtl.uint<3>,
+  %b: !firrtl.sint<3>,
+  %y0: !firrtl.flip<uint<1>>,
+  %y1: !firrtl.flip<uint<1>>,
+  %y2: !firrtl.flip<uint<1>>,
+  %y3: !firrtl.flip<uint<1>>,
+  %y4: !firrtl.flip<uint<1>>,
+  %y5: !firrtl.flip<uint<1>>
+) {
+  // CHECK-NEXT: [[_:.+]] = firrtl.constant
+  // CHECK-NEXT: [[_:.+]] = firrtl.constant
+  %cm4_si = firrtl.constant(-4) : !firrtl.sint
+  %cm5_si = firrtl.constant(-5) : !firrtl.sint
+  %c4_si = firrtl.constant(4) : !firrtl.sint
+  %c5_si = firrtl.constant(5) : !firrtl.sint
+  %c8_ui = firrtl.constant(8) : !firrtl.uint
+  %c9_ui = firrtl.constant(9) : !firrtl.uint
+
+  // a < 8 -> 1
+  // a < 9 -> 1
+  %0 = firrtl.lt %a, %c8_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
+  %1 = firrtl.lt %a, %c9_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
+  firrtl.connect %y0, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y1, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.connect %y0, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y1, %c1_ui1
+
+  // b < 4 -> 1
+  // b < 5 -> 1
+  %2 = firrtl.lt %b, %c4_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
+  %3 = firrtl.lt %b, %c5_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
+  firrtl.connect %y2, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y3, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.connect %y2, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y3, %c1_ui1
+
+  // b < -4 -> 0
+  // b < -5 -> 0
+  %4 = firrtl.lt %b, %cm4_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
+  %5 = firrtl.lt %b, %cm5_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
+  firrtl.connect %y4, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y5, %5 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.connect %y4, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y5, %c0_ui1
+}
+
+// CHECK-LABEL: @GEQOutsideBounds
+firrtl.module @GEQOutsideBounds(
+  %a: !firrtl.uint<3>,
+  %b: !firrtl.sint<3>,
+  %y0: !firrtl.flip<uint<1>>,
+  %y1: !firrtl.flip<uint<1>>,
+  %y2: !firrtl.flip<uint<1>>,
+  %y3: !firrtl.flip<uint<1>>,
+  %y4: !firrtl.flip<uint<1>>,
+  %y5: !firrtl.flip<uint<1>>
+) {
+  // CHECK-NEXT: [[_:.+]] = firrtl.constant
+  // CHECK-NEXT: [[_:.+]] = firrtl.constant
+  %cm4_si = firrtl.constant(-4) : !firrtl.sint
+  %cm5_si = firrtl.constant(-5) : !firrtl.sint
+  %c4_si = firrtl.constant(4) : !firrtl.sint
+  %c5_si = firrtl.constant(5) : !firrtl.sint
+  %c8_ui = firrtl.constant(8) : !firrtl.uint
+  %c9_ui = firrtl.constant(9) : !firrtl.uint
+
+  // a >= 8 -> 0
+  // a >= 9 -> 0
+  %0 = firrtl.geq %a, %c8_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
+  %1 = firrtl.geq %a, %c9_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
+  firrtl.connect %y0, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y1, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.connect %y0, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y1, %c0_ui1
+
+  // b >= 4 -> 0
+  // b >= 5 -> 0
+  %2 = firrtl.geq %b, %c4_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
+  %3 = firrtl.geq %b, %c5_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
+  firrtl.connect %y2, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y3, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.connect %y2, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y3, %c0_ui1
+
+  // b >= -4 -> 1
+  // b >= -5 -> 1
+  %4 = firrtl.geq %b, %cm4_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
+  %5 = firrtl.geq %b, %cm5_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
+  firrtl.connect %y4, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y5, %5 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.connect %y4, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y5, %c1_ui1
+}
+
+// CHECK-LABEL: @GTOutsideBounds
+firrtl.module @GTOutsideBounds(
+  %a: !firrtl.uint<3>,
+  %b: !firrtl.sint<3>,
+  %y0: !firrtl.flip<uint<1>>,
+  %y1: !firrtl.flip<uint<1>>,
+  %y2: !firrtl.flip<uint<1>>,
+  %y3: !firrtl.flip<uint<1>>,
+  %y4: !firrtl.flip<uint<1>>,
+  %y5: !firrtl.flip<uint<1>>
+) {
+  // CHECK-NEXT: [[_:.+]] = firrtl.constant
+  // CHECK-NEXT: [[_:.+]] = firrtl.constant
+  %cm5_si = firrtl.constant(-5) : !firrtl.sint
+  %cm6_si = firrtl.constant(-6) : !firrtl.sint
+  %c3_si = firrtl.constant(3) : !firrtl.sint
+  %c4_si = firrtl.constant(4) : !firrtl.sint
+  %c7_ui = firrtl.constant(7) : !firrtl.uint
+  %c8_ui = firrtl.constant(8) : !firrtl.uint
+
+  // a > 7 -> 0
+  // a > 8 -> 0
+  %0 = firrtl.gt %a, %c7_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
+  %1 = firrtl.gt %a, %c8_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
+  firrtl.connect %y0, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y1, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.connect %y0, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y1, %c0_ui1
+
+  // b > 3 -> 0
+  // b > 4 -> 0
+  %2 = firrtl.gt %b, %c3_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
+  %3 = firrtl.gt %b, %c4_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
+  firrtl.connect %y2, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y3, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.connect %y2, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y3, %c0_ui1
+
+  // b > -5 -> 1
+  // b > -6 -> 1
+  %4 = firrtl.gt %b, %cm5_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
+  %5 = firrtl.gt %b, %cm6_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
+  firrtl.connect %y4, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y5, %5 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.connect %y4, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y5, %c1_ui1
+}
+
 }

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -514,4 +514,40 @@ firrtl.module @wire_port_prop1(%in_a: !firrtl.uint<9>, %out_b: !firrtl.flip<uint
   firrtl.connect %out_b, %tmp : !firrtl.flip<uint<9>>, !firrtl.uint<9>
 }
 
+// CHECK-LABEL: @LEQWithConstLHS
+// CHECK-NEXT: %c42_ui = firrtl.constant
+// CHECK-NEXT: %0 = firrtl.geq %a, %c42_ui
+firrtl.module @LEQWithConstLHS(%a: !firrtl.uint, %b: !firrtl.flip<uint<1>>) {
+  %0 = firrtl.constant(42) : !firrtl.uint
+  %1 = firrtl.leq %0, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  firrtl.connect %b, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+}
+
+// CHECK-LABEL: @LTWithConstLHS
+// CHECK-NEXT: %c42_ui = firrtl.constant
+// CHECK-NEXT: %0 = firrtl.gt %a, %c42_ui
+firrtl.module @LTWithConstLHS(%a: !firrtl.uint, %b: !firrtl.flip<uint<1>>) {
+  %0 = firrtl.constant(42) : !firrtl.uint
+  %1 = firrtl.lt %0, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  firrtl.connect %b, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+}
+
+// CHECK-LABEL: @GEQWithConstLHS
+// CHECK-NEXT: %c42_ui = firrtl.constant
+// CHECK-NEXT: %0 = firrtl.leq %a, %c42_ui
+firrtl.module @GEQWithConstLHS(%a: !firrtl.uint, %b: !firrtl.flip<uint<1>>) {
+  %0 = firrtl.constant(42) : !firrtl.uint
+  %1 = firrtl.geq %0, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  firrtl.connect %b, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+}
+
+// CHECK-LABEL: @GTWithConstLHS
+// CHECK-NEXT: %c42_ui = firrtl.constant
+// CHECK-NEXT: %0 = firrtl.lt %a, %c42_ui
+firrtl.module @GTWithConstLHS(%a: !firrtl.uint, %b: !firrtl.flip<uint<1>>) {
+  %0 = firrtl.constant(42) : !firrtl.uint
+  %1 = firrtl.gt %0, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  firrtl.connect %b, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+}
+
 }

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -780,4 +780,187 @@ firrtl.module @GTOutsideBounds(
   // CHECK-NEXT: firrtl.connect %y5, %c1_ui1
 }
 
+// CHECK-LABEL: @ComparisonOfDifferentWidths
+firrtl.module @ComparisonOfDifferentWidths(
+  %y0: !firrtl.flip<uint<1>>,
+  %y1: !firrtl.flip<uint<1>>,
+  %y2: !firrtl.flip<uint<1>>,
+  %y3: !firrtl.flip<uint<1>>,
+  %y4: !firrtl.flip<uint<1>>,
+  %y5: !firrtl.flip<uint<1>>,
+  %y6: !firrtl.flip<uint<1>>,
+  %y7: !firrtl.flip<uint<1>>,
+  %y8: !firrtl.flip<uint<1>>,
+  %y9: !firrtl.flip<uint<1>>,
+  %y10: !firrtl.flip<uint<1>>,
+  %y11: !firrtl.flip<uint<1>>
+) {
+  // CHECK-NEXT: [[_:.+]] = firrtl.constant
+  // CHECK-NEXT: [[_:.+]] = firrtl.constant
+  %c3_si3 = firrtl.constant(3 : i3) : !firrtl.sint<3>
+  %c4_si4 = firrtl.constant(4 : i4) : !firrtl.sint<4>
+  %c3_ui2 = firrtl.constant(3 : i2) : !firrtl.uint<2>
+  %c4_ui3 = firrtl.constant(4 : i3) : !firrtl.uint<3>
+
+  %0 = firrtl.leq %c3_ui2, %c4_ui3 : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<1>
+  %1 = firrtl.leq %c3_si3, %c4_si4 : (!firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.uint<1>
+  %2 = firrtl.lt %c3_ui2, %c4_ui3 : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<1>
+  %3 = firrtl.lt %c3_si3, %c4_si4 : (!firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.uint<1>
+  %4 = firrtl.geq %c3_ui2, %c4_ui3 : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<1>
+  %5 = firrtl.geq %c3_si3, %c4_si4 : (!firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.uint<1>
+  %6 = firrtl.gt %c3_ui2, %c4_ui3 : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<1>
+  %7 = firrtl.gt %c3_si3, %c4_si4 : (!firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.uint<1>
+  %8 = firrtl.eq %c3_ui2, %c4_ui3 : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<1>
+  %9 = firrtl.eq %c3_si3, %c4_si4 : (!firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.uint<1>
+  %10 = firrtl.neq %c3_ui2, %c4_ui3 : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<1>
+  %11 = firrtl.neq %c3_si3, %c4_si4 : (!firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.uint<1>
+
+  firrtl.connect %y0, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y1, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y2, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y3, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y4, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y5, %5 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y6, %6 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y7, %7 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y8, %8 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y9, %9 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y10, %10 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y11, %11 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.connect %y0, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y1, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y2, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y3, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y4, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y5, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y6, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y7, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y8, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y9, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y10, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y11, %c1_ui1
+}
+
+// CHECK-LABEL: @ComparisonOfUnsizedAndSized
+firrtl.module @ComparisonOfUnsizedAndSized(
+  %y0: !firrtl.flip<uint<1>>,
+  %y1: !firrtl.flip<uint<1>>,
+  %y2: !firrtl.flip<uint<1>>,
+  %y3: !firrtl.flip<uint<1>>,
+  %y4: !firrtl.flip<uint<1>>,
+  %y5: !firrtl.flip<uint<1>>,
+  %y6: !firrtl.flip<uint<1>>,
+  %y7: !firrtl.flip<uint<1>>,
+  %y8: !firrtl.flip<uint<1>>,
+  %y9: !firrtl.flip<uint<1>>,
+  %y10: !firrtl.flip<uint<1>>,
+  %y11: !firrtl.flip<uint<1>>
+) {
+  // CHECK-NEXT: [[_:.+]] = firrtl.constant
+  // CHECK-NEXT: [[_:.+]] = firrtl.constant
+  %c3_si = firrtl.constant(3) : !firrtl.sint
+  %c4_si4 = firrtl.constant(4 : i4) : !firrtl.sint<4>
+  %c3_ui = firrtl.constant(3) : !firrtl.uint
+  %c4_ui3 = firrtl.constant(4 : i3) : !firrtl.uint<3>
+
+  %0 = firrtl.leq %c3_ui, %c4_ui3 : (!firrtl.uint, !firrtl.uint<3>) -> !firrtl.uint<1>
+  %1 = firrtl.leq %c3_si, %c4_si4 : (!firrtl.sint, !firrtl.sint<4>) -> !firrtl.uint<1>
+  %2 = firrtl.lt %c3_ui, %c4_ui3 : (!firrtl.uint, !firrtl.uint<3>) -> !firrtl.uint<1>
+  %3 = firrtl.lt %c3_si, %c4_si4 : (!firrtl.sint, !firrtl.sint<4>) -> !firrtl.uint<1>
+  %4 = firrtl.geq %c3_ui, %c4_ui3 : (!firrtl.uint, !firrtl.uint<3>) -> !firrtl.uint<1>
+  %5 = firrtl.geq %c3_si, %c4_si4 : (!firrtl.sint, !firrtl.sint<4>) -> !firrtl.uint<1>
+  %6 = firrtl.gt %c3_ui, %c4_ui3 : (!firrtl.uint, !firrtl.uint<3>) -> !firrtl.uint<1>
+  %7 = firrtl.gt %c3_si, %c4_si4 : (!firrtl.sint, !firrtl.sint<4>) -> !firrtl.uint<1>
+  %8 = firrtl.eq %c3_ui, %c4_ui3 : (!firrtl.uint, !firrtl.uint<3>) -> !firrtl.uint<1>
+  %9 = firrtl.eq %c3_si, %c4_si4 : (!firrtl.sint, !firrtl.sint<4>) -> !firrtl.uint<1>
+  %10 = firrtl.neq %c3_ui, %c4_ui3 : (!firrtl.uint, !firrtl.uint<3>) -> !firrtl.uint<1>
+  %11 = firrtl.neq %c3_si, %c4_si4 : (!firrtl.sint, !firrtl.sint<4>) -> !firrtl.uint<1>
+
+  firrtl.connect %y0, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y1, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y2, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y3, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y4, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y5, %5 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y6, %6 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y7, %7 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y8, %8 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y9, %9 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y10, %10 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y11, %11 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.connect %y0, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y1, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y2, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y3, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y4, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y5, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y6, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y7, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y8, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y9, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y10, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y11, %c1_ui1
+}
+
+// CHECK-LABEL: @ComparisonOfUnsized
+firrtl.module @ComparisonOfUnsized(
+  %y0: !firrtl.flip<uint<1>>,
+  %y1: !firrtl.flip<uint<1>>,
+  %y2: !firrtl.flip<uint<1>>,
+  %y3: !firrtl.flip<uint<1>>,
+  %y4: !firrtl.flip<uint<1>>,
+  %y5: !firrtl.flip<uint<1>>,
+  %y6: !firrtl.flip<uint<1>>,
+  %y7: !firrtl.flip<uint<1>>,
+  %y8: !firrtl.flip<uint<1>>,
+  %y9: !firrtl.flip<uint<1>>,
+  %y10: !firrtl.flip<uint<1>>,
+  %y11: !firrtl.flip<uint<1>>
+) {
+  // CHECK-NEXT: [[_:.+]] = firrtl.constant
+  // CHECK-NEXT: [[_:.+]] = firrtl.constant
+  %c0_si = firrtl.constant(0) : !firrtl.sint
+  %c4_si = firrtl.constant(4) : !firrtl.sint
+  %c0_ui = firrtl.constant(0) : !firrtl.uint
+  %c4_ui = firrtl.constant(4) : !firrtl.uint
+
+  %0 = firrtl.leq %c0_ui, %c4_ui : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  %1 = firrtl.leq %c0_si, %c4_si : (!firrtl.sint, !firrtl.sint) -> !firrtl.uint<1>
+  %2 = firrtl.lt %c0_ui, %c4_ui : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  %3 = firrtl.lt %c0_si, %c4_si : (!firrtl.sint, !firrtl.sint) -> !firrtl.uint<1>
+  %4 = firrtl.geq %c0_ui, %c4_ui : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  %5 = firrtl.geq %c0_si, %c4_si : (!firrtl.sint, !firrtl.sint) -> !firrtl.uint<1>
+  %6 = firrtl.gt %c0_ui, %c4_ui : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  %7 = firrtl.gt %c0_si, %c4_si : (!firrtl.sint, !firrtl.sint) -> !firrtl.uint<1>
+  %8 = firrtl.eq %c0_ui, %c4_ui : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  %9 = firrtl.eq %c0_si, %c4_si : (!firrtl.sint, !firrtl.sint) -> !firrtl.uint<1>
+  %10 = firrtl.neq %c0_ui, %c4_ui : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  %11 = firrtl.neq %c0_si, %c4_si : (!firrtl.sint, !firrtl.sint) -> !firrtl.uint<1>
+
+  firrtl.connect %y0, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y1, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y2, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y3, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y4, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y5, %5 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y6, %6 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y7, %7 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y8, %8 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y9, %9 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y10, %10 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y11, %11 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.connect %y0, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y1, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y2, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y3, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y4, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y5, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y6, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y7, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y8, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y9, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y10, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y11, %c1_ui1
+}
+
 }

--- a/test/Dialect/FIRRTL/const-prop-single-module.fir
+++ b/test/Dialect/FIRRTL/const-prop-single-module.fir
@@ -1,0 +1,94 @@
+; RUN: circt-translate --import-firrtl %s | circt-opt --canonicalize | FileCheck %s
+
+; The following tests are derived from `ConstantPropagationSingleModule` in [1].
+; [1]: https://github.com/chipsalliance/firrtl/blob/master/src/test/scala/firrtlTests/ConstantPropagationTests.scala
+
+circuit ConstantPropagationSingleModule :
+  module ConstantPropagationSingleModule:
+
+
+; The rule x >= 0 should always be true if x is a UInt
+  module Top01 :
+    input x : UInt<5>
+    output y : UInt<1>
+    y <= geq(x, UInt(0))
+; CHECK-LABEL: firrtl.module @Top01
+; CHECK-NEXT: %[[K:.+]] = firrtl.constant(true)
+; CHECK-NEXT: firrtl.connect %y, %[[K]]
+
+
+; The rule x < 0 should never be true if x is a UInt
+  module Top02 :
+    input x : UInt<5>
+    output y : UInt<1>
+    y <= lt(x, UInt(0))
+; CHECK-LABEL: firrtl.module @Top02
+; CHECK-NEXT: %[[K:.+]] = firrtl.constant(false)
+; CHECK-NEXT: firrtl.connect %y, %[[K]]
+
+
+; The rule 0 <= x should always be true if x is a UInt
+  module Top03 :
+    input x : UInt<5>
+    output y : UInt<1>
+    y <= leq(UInt(0), x)
+; CHECK-LABEL: firrtl.module @Top03
+; CHECK-NEXT: %[[K:.+]] = firrtl.constant(true)
+; CHECK-NEXT: firrtl.connect %y, %[[K]]
+
+
+; The rule 0 > x should never be true if x is a UInt
+  module Top04 :
+    input x : UInt<5>
+    output y : UInt<1>
+    y <= gt(UInt(0), x)
+; CHECK-LABEL: firrtl.module @Top04
+; CHECK-NEXT: %[[K:.+]] = firrtl.constant(false)
+; CHECK-NEXT: firrtl.connect %y, %[[K]]
+
+
+; The rule 1 < 3 should always be true
+  module Top05 :
+    output y : UInt<1>
+    y <= lt(UInt(1), UInt(3))
+; CHECK-LABEL: firrtl.module @Top05
+; CHECK-NEXT: %[[K:.+]] = firrtl.constant(true)
+; CHECK-NEXT: firrtl.connect %y, %[[K]]
+
+
+; The rule 10 == 10 should always be true
+  module Top06 :
+    output y : UInt<1>
+    y <= eq(UInt(10), UInt(10))
+; CHECK-LABEL: firrtl.module @Top06
+; CHECK-NEXT: %[[K:.+]] = firrtl.constant(true)
+; CHECK-NEXT: firrtl.connect %y, %[[K]]
+
+
+; The rule x == z should not be true even if they have the same number of bits
+  module Top07 :
+    input x : UInt<3>
+    input z : UInt<3>
+    output y : UInt<1>
+    y <= eq(x,z)
+; CHECK-LABEL: firrtl.module @Top07
+; CHECK-NEXT: %[[K:.+]] = firrtl.eq %x, %z
+; CHECK-NEXT: firrtl.connect %y, %[[K]]
+
+
+; The rule 10 != 10 should always be false
+  module Top08 :
+    output y : UInt<1>
+    y <= neq(UInt(10), UInt(10))
+; CHECK-LABEL: firrtl.module @Top08
+; CHECK-NEXT: %[[K:.+]] = firrtl.constant(false)
+; CHECK-NEXT: firrtl.connect %y, %[[K]]
+
+
+; The rule 1 >= 3 should always be false
+  module Top09 :
+    output y : UInt<1>
+    y <= geq(UInt(1), UInt(3))
+; CHECK-LABEL: firrtl.module @Top09
+; CHECK-NEXT: %[[K:.+]] = firrtl.constant(false)
+; CHECK-NEXT: firrtl.connect %y, %[[K]]

--- a/test/Dialect/FIRRTL/const-prop-single-module.fir
+++ b/test/Dialect/FIRRTL/const-prop-single-module.fir
@@ -56,39 +56,119 @@ circuit ConstantPropagationSingleModule :
 ; CHECK-NEXT: firrtl.connect %y, %[[K]]
 
 
-; The rule 10 == 10 should always be true
+; The rule x < 8 should always be true if x only has 3 bits
   module Top06 :
+    input x : UInt<3>
     output y : UInt<1>
-    y <= eq(UInt(10), UInt(10))
+    y <= lt(x, UInt(8))
 ; CHECK-LABEL: firrtl.module @Top06
 ; CHECK-NEXT: %[[K:.+]] = firrtl.constant(true)
 ; CHECK-NEXT: firrtl.connect %y, %[[K]]
 
 
-; The rule x == z should not be true even if they have the same number of bits
+; The rule x <= 7 should always be true if x only has 3 bits
   module Top07 :
+    input x : UInt<3>
+    output y : UInt<1>
+    y <= leq(x, UInt(7))
+; CHECK-LABEL: firrtl.module @Top07
+; CHECK-NEXT: %[[K:.+]] = firrtl.constant(true)
+; CHECK-NEXT: firrtl.connect %y, %[[K]]
+
+
+; The rule 8 > x should always be true if x only has 3 bits
+  module Top08 :
+    input x : UInt<3>
+    output y : UInt<1>
+    y <= gt(UInt(8), x)
+; CHECK-LABEL: firrtl.module @Top08
+; CHECK-NEXT: %[[K:.+]] = firrtl.constant(true)
+; CHECK-NEXT: firrtl.connect %y, %[[K]]
+
+
+; The rule 7 >= x should always be true if x only has 3 bits
+  module Top09 :
+    input x : UInt<3>
+    output y : UInt<1>
+    y <= geq(UInt(7),x)
+; CHECK-LABEL: firrtl.module @Top09
+; CHECK-NEXT: %[[K:.+]] = firrtl.constant(true)
+; CHECK-NEXT: firrtl.connect %y, %[[K]]
+
+
+; The rule 10 == 10 should always be true
+  module Top10 :
+    output y : UInt<1>
+    y <= eq(UInt(10), UInt(10))
+; CHECK-LABEL: firrtl.module @Top10
+; CHECK-NEXT: %[[K:.+]] = firrtl.constant(true)
+; CHECK-NEXT: firrtl.connect %y, %[[K]]
+
+
+; The rule x == z should not be true even if they have the same number of bits
+  module Top11 :
     input x : UInt<3>
     input z : UInt<3>
     output y : UInt<1>
     y <= eq(x,z)
-; CHECK-LABEL: firrtl.module @Top07
+; CHECK-LABEL: firrtl.module @Top11
 ; CHECK-NEXT: %[[K:.+]] = firrtl.eq %x, %z
 ; CHECK-NEXT: firrtl.connect %y, %[[K]]
 
 
 ; The rule 10 != 10 should always be false
-  module Top08 :
+  module Top12 :
     output y : UInt<1>
     y <= neq(UInt(10), UInt(10))
-; CHECK-LABEL: firrtl.module @Top08
+; CHECK-LABEL: firrtl.module @Top12
 ; CHECK-NEXT: %[[K:.+]] = firrtl.constant(false)
 ; CHECK-NEXT: firrtl.connect %y, %[[K]]
 
 
 ; The rule 1 >= 3 should always be false
-  module Top09 :
+  module Top13 :
     output y : UInt<1>
     y <= geq(UInt(1), UInt(3))
-; CHECK-LABEL: firrtl.module @Top09
+; CHECK-LABEL: firrtl.module @Top13
+; CHECK-NEXT: %[[K:.+]] = firrtl.constant(false)
+; CHECK-NEXT: firrtl.connect %y, %[[K]]
+
+
+; The rule x >= 8 should never be true if x only has 3 bits
+  module Top14 :
+    input x : UInt<3>
+    output y : UInt<1>
+    y <= geq(x, UInt(8))
+; CHECK-LABEL: firrtl.module @Top14
+; CHECK-NEXT: %[[K:.+]] = firrtl.constant(false)
+; CHECK-NEXT: firrtl.connect %y, %[[K]]
+
+
+; The rule x > 7 should never be true if x only has 3 bits
+  module Top15 :
+    input x : UInt<3>
+    output y : UInt<1>
+    y <= gt(x, UInt(7))
+; CHECK-LABEL: firrtl.module @Top15
+; CHECK-NEXT: %[[K:.+]] = firrtl.constant(false)
+; CHECK-NEXT: firrtl.connect %y, %[[K]]
+
+
+; The rule 8 <= x should never be true if x only has 3 bits
+  module Top16 :
+    input x : UInt<3>
+    output y : UInt<1>
+    y <= leq(UInt(8), x)
+; CHECK-LABEL: firrtl.module @Top16
+; CHECK-NEXT: %[[K:.+]] = firrtl.constant(false)
+; CHECK-NEXT: firrtl.connect %y, %[[K]]
+
+
+; The rule 7 < x should never be true if x only has 3 bits
+  module Top17 :
+    input x : UInt<3>
+    output y : UInt<1>
+    y <= lt(UInt(7), x)
+; CHECK-LABEL: firrtl.module @Top17
 ; CHECK-NEXT: %[[K:.+]] = firrtl.constant(false)
 ; CHECK-NEXT: firrtl.connect %y, %[[K]]


### PR DESCRIPTION
Start work towards #804. This PR does the following:

* Define canonicalizations for LEQ, LT, GEQ, GT that pulls constants on the LHS to the RHS by changing to the dual operation
* Perform constant folding for LEQ, LT, GEQ, GT, EQ, NEQ when both operands are constant or both operands are identical
* Handle cases where the RHS is a constant but the comparison is always true/false due to the type bounds of the LHS, for example `x < 8` being always true if x has only 3 bits.
* Handle cases like `x < 0` and `x >= 0` when `x` is unsigned
* Add the first few test cases from `ConstantPropagationTests.scala`