### PR TITLE
[FIRRTL] Negate bit extension

### DIFF
--- a/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
+++ b/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
@@ -2119,18 +2119,13 @@ LogicalResult FIRRTLLowering::visitExpr(NotPrimOp op) {
 }
 
 LogicalResult FIRRTLLowering::visitExpr(NegPrimOp op) {
-  // FIRRTL negate always adds a bit, and always does a sign extension even if
-  // the input is unsigned.
-  // -x  ---> 0-sext(x)
-  auto operand = getLoweredValue(op.input());
-  if (!operand) {
-    return handleZeroBit(op.getOperand(), [&]() {
-      // Negate of a zero bit value is 1b0.
-      return setLowering(op, getOrCreateIntConstant(1, 0));
-    });
-  }
+  // FIRRTL negate always adds a bit.
+  // -x ---> 0-sext(x) or 0-zext(x)
+  auto operand = getLoweredAndExtendedValue(op.input(), op.getType());
+  if (!operand)
+    return failure();
+
   auto resultType = lowerType(op.getType());
-  operand = builder.createOrFold<comb::SExtOp>(resultType, operand);
 
   auto zero = getOrCreateIntConstant(resultType.getIntOrFloatBitWidth(), 0);
   return setLoweringTo<comb::SubOp>(op, zero, operand);

--- a/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
+++ b/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
@@ -5,7 +5,11 @@ firrtl.circuit "Simple" {
   // CHECK-LABEL: rtl.module @Simple
   firrtl.module @Simple(%in1: !firrtl.uint<4>,
                         %in2: !firrtl.uint<2>,
-                        %in3: !firrtl.sint<8>) {
+                        %in3: !firrtl.sint<8>,
+                        %in4: !firrtl.uint<0>, 
+                        %in5: !firrtl.sint<0>, 
+                        %out1: !firrtl.flip<sint<1>>,
+                        %out2: !firrtl.flip<sint<1>>  ) {
     // Issue #364: https://github.com/llvm/circt/issues/364
     // CHECK: = rtl.constant -1175 : i12
     // CHECK-DAG: rtl.constant -4 : i4
@@ -220,6 +224,14 @@ firrtl.circuit "Simple" {
     // CHECK:  = comb.concat %false, %in1 : (i1, i4) -> i5
     // CHECK:  = comb.sub %c0_i5, %65 : i5
     %52 = firrtl.neg %in1 : (!firrtl.uint<4>) -> !firrtl.sint<5>
+    %53 = firrtl.neg %in4 : (!firrtl.uint<0>) -> !firrtl.sint<1>
+    // CHECK: = comb.sext %in3 : (i8) -> i9
+    // CHECK: = comb.sub %c0_i9, %67 : i9
+    %54 = firrtl.neg %in3 : (!firrtl.sint<8>) -> !firrtl.sint<9>
+    // CHECK: rtl.output %false, %false : i1, i1
+    firrtl.connect %out1, %53 : !firrtl.flip<sint<1>>, !firrtl.sint<1>
+    %55 = firrtl.neg %in5 : (!firrtl.sint<0>) -> !firrtl.sint<1>
+    firrtl.connect %out2, %55 : !firrtl.flip<sint<1>>, !firrtl.sint<1>
   }
 
 //   module Print :

--- a/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
+++ b/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
@@ -6,6 +6,8 @@ firrtl.circuit "Simple" {
   firrtl.module @Simple(%in1: !firrtl.uint<4>,
                         %in2: !firrtl.uint<2>,
                         %in3: !firrtl.sint<8>) {
+    // Issue #364: https://github.com/llvm/circt/issues/364
+    // CHECK: = rtl.constant -1175 : i12
     // CHECK-DAG: rtl.constant -4 : i4
     %c12_ui4 = firrtl.constant(12 : ui4) : !firrtl.uint<4>
 
@@ -212,10 +214,12 @@ firrtl.circuit "Simple" {
     %c306_ui10 = firrtl.constant(306 : ui10) : !firrtl.uint<10>
     %50 = firrtl.div %c104_ui8, %c306_ui10 : (!firrtl.uint<8>, !firrtl.uint<10>) -> !firrtl.uint<8>
 
-    // Issue #364: https://github.com/llvm/circt/issues/364
-    // CHECK: = rtl.constant -873 : i12
     %c1175_ui11 = firrtl.constant(1175 : ui11) : !firrtl.uint<11>
     %51 = firrtl.neg %c1175_ui11 : (!firrtl.uint<11>) -> !firrtl.sint<12>
+    // https://github.com/llvm/circt/issues/821
+    // CHECK:  = comb.concat %false, %in1 : (i1, i4) -> i5
+    // CHECK:  = comb.sub %c0_i5, %65 : i5
+    %52 = firrtl.neg %in1 : (!firrtl.uint<4>) -> !firrtl.sint<5>
   }
 
 //   module Print :


### PR DESCRIPTION
Signed number should be sign extended, and unsigned should be zero extended.
Fix for: https://github.com/llvm/circt/issues/821