### PR TITLE
[FIRRTL] LowerTypes: Error out on Subaccess op which is not yet supported

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -117,6 +117,7 @@ public:
   void visitDecl(RegResetOp op);
   void visitExpr(InvalidValuePrimOp op);
   void visitExpr(SubfieldOp op);
+  void visitExpr(SubaccessOp op);
   void visitExpr(SubindexOp op);
   void visitStmt(ConnectOp op);
 
@@ -661,6 +662,10 @@ void TypeLoweringVisitor::visitExpr(SubfieldOp op) {
   opsToRemove.push_back(op);
 }
 
+  void TypeLoweringVisitor::visitExpr(SubaccessOp op){
+    op.emitError("Dynamically referring to a vector sub-element is not supported");
+    opsToRemove.push_back(op);
+  }
 // This is currently the same lowering as SubfieldOp, but using a fieldname
 // derived from the fixed index.
 //

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -662,10 +662,11 @@ void TypeLoweringVisitor::visitExpr(SubfieldOp op) {
   opsToRemove.push_back(op);
 }
 
-  void TypeLoweringVisitor::visitExpr(SubaccessOp op){
-    op.emitError("Dynamically referring to a vector sub-element is not supported");
-    opsToRemove.push_back(op);
-  }
+void TypeLoweringVisitor::visitExpr(SubaccessOp op) {
+  op.emitError(
+      "Dynamically referring to a vector sub-element is not supported");
+  opsToRemove.push_back(op);
+}
 // This is currently the same lowering as SubfieldOp, but using a fieldname
 // derived from the fixed index.
 //


### PR DESCRIPTION
Error out instead of crash for subaccess op.
https://github.com/llvm/circt/issues/832