### PR TITLE
Respect Procedural/Non-procedural Regions when Unwinding Inlined, Long Line Expressions

### DIFF
--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -1691,6 +1691,12 @@ void StmtEmitter::emitExpression(Value exp,
       declarationsNeeded.push_back(expr);
   }
 
+  // Remove any out-of-line expressions as they have already been emitted.  If
+  // these are not removed here, then later non-SSA definitions/uses of these
+  // expressions will be erroneously duplicated.
+  for (auto *expr : tooLargeSubExpressions)
+    emitter.outOfLineExpressions.erase(expr);
+
   // Re-add this statement now that all the preceeding ones are out.
   outBuffer.append(thisStmt.begin(), thisStmt.end());
 

--- a/test/ExportVerilog/sv-dialect.mlir
+++ b/test/ExportVerilog/sv-dialect.mlir
@@ -619,3 +619,17 @@ rtl.module @inlineProceduralWiresWithLongNames(%clock: i1, %in: i1) {
     sv.passign %3, %in : i1
   }
 }
+
+// CHECK-LABEL: module notEmitDuplicateWiresThatWereUnInlinedDueToLongNames
+rtl.module @notEmitDuplicateWiresThatWereUnInlinedDueToLongNames(%clock: i1, %x: i1) {
+  // CHECK: wire _tmp = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+  // CHECK-NOT: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+  %0 = comb.and %1, %x : i1
+  sv.alwaysff(posedge %clock)  {
+    sv.if %0  {
+      sv.verbatim "// hello"
+    }
+  }
+  %aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = sv.wire  : !rtl.inout<i1>
+  %1 = sv.read_inout %aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa : !rtl.inout<i1>
+}

--- a/test/ExportVerilog/sv-dialect.mlir
+++ b/test/ExportVerilog/sv-dialect.mlir
@@ -598,3 +598,24 @@ rtl.module @alwayscombTest(%a: i1) -> (%x: i1) {
   %out = sv.read_inout %combWire : !rtl.inout<i1>
   rtl.output %out : i1
 }
+
+// CHECK-LABEL: module inlineProceduralWiresWithLongNames
+rtl.module @inlineProceduralWiresWithLongNames(%clock: i1, %in: i1) {
+  %aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = sv.wire  : !rtl.inout<i1>
+  %0 = sv.read_inout %aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa : !rtl.inout<i1>
+  %bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = sv.wire  : !rtl.inout<i1>
+  %1 = sv.read_inout %bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb : !rtl.inout<i1>
+  %r = sv.reg  : !rtl.inout<uarray<1xi1>>
+  %s = sv.reg  : !rtl.inout<uarray<1xi1>>
+  %2 = sv.array_index_inout %r[%0] : !rtl.inout<uarray<1xi1>>, i1
+  %3 = sv.array_index_inout %s[%1] : !rtl.inout<uarray<1xi1>>, i1
+  // CHECK: always_ff
+  sv.alwaysff(posedge %clock)  {
+    // CHECK:      automatic logic [[x:.+]];
+    // CHECK-NEXT: automatic logic [[y:.+]];
+    // CHECK-NEXT: [[x]] = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+    sv.passign %2, %in : i1
+    // CHECK:      [[y]] = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+    sv.passign %3, %in : i1
+  }
+}


### PR DESCRIPTION
Two fixes:

1) Pass around the current statement when doing Verilog emission of expressions and sub-expressions. This avoids problems where inlining an expression, defined in a non-procedural region, into a procedural region was then unwound due to the emitted Verilog line being too long. The type of region (procedural vs. non-procedural) in which the inlined expression was *defined* was then incorrectly used to generate a temporary. This changes this to compute the region based on the type of the statement.

2) Reset `outOfLineExpressions` pointer set if these have already been emitted. Without doing this, later use/def of something in the pointer set would cause duplicate emission. (I'm much less confident that this modification is sound. I had a difficult time following all the `ExportVerilog` logic and may have missed something.)

Regardless, the test cases are sound and can be re-used if there's a better solution here.

Fixes #838.