### PR TITLE
[ESI] Fix Windows build

### DIFF
--- a/lib/Dialect/ESI/ESIPasses.cpp
+++ b/lib/Dialect/ESI/ESIPasses.cpp
@@ -55,8 +55,9 @@ public:
   ESIRTLBuilder(Operation *top);
 
   RTLModuleExternOp declareStage();
-  // Will be unused when CAPNP is undefined
-  RTLModuleExternOp declareCosimEndpoint() LLVM_ATTRIBUTE_UNUSED;
+#ifdef CAPNP
+  RTLModuleExternOp declareCosimEndpoint();
+#endif // CAPNP
 
   InterfaceOp getOrConstructInterface(ChannelPort);
   InterfaceOp constructInterface(ChannelPort);
@@ -186,6 +187,7 @@ RTLModuleExternOp ESIRTLBuilder::declareStage() {
   return declaredStage;
 }
 
+#ifdef CAPNP
 /// Write an 'ExternModuleOp' to use a hand-coded SystemVerilog module. Said
 /// module contains a bi-directional Cosimulation DPI interface with valid/ready
 /// semantics.
@@ -209,6 +211,7 @@ RTLModuleExternOp ESIRTLBuilder::declareCosimEndpoint() {
   declaredCosimEndpoint = create<RTLModuleExternOp>(name, ports);
   return declaredCosimEndpoint;
 }
+#endif
 
 /// Return the InterfaceType which corresponds to an ESI port type. If it
 /// doesn't exist in the cache, build the InterfaceOp and the corresponding


### PR DESCRIPTION
Remove the annotation which broke the build. Don't re-introduce warning -- ifdef'ing unused code.