### PR TITLE
[integration_test] Update golden verilog

### DIFF
--- a/integration_test/EmitVerilog/verilog_equiv.fir
+++ b/integration_test/EmitVerilog/verilog_equiv.fir
@@ -131,8 +131,8 @@ module test_unary(
   assign out_head_s = sin4[3:2];
   assign out_tail_u = uin4[1:0];
   assign out_tail_s = sin4[1:0];
-  assign out_neg_u = -$signed(uin4);
-  assign out_neg_s = -$signed(sin4);
+  assign out_neg_s = 4'sh0 - $signed(sin4); 
+  assign out_neg_u = 4'h0 - uin4;
 endmodule
 
 ;--- test_prim.fir


### PR DESCRIPTION
* Update the golden verilog with the latest firrtl
* firrtl output for neg, for signed and unsigned operand must respect the sign.
* This should fix the yosys integration_test failure https://github.com/llvm/circt/issues/842
* The firrtl bug fix that updates the golden: https://github.com/chipsalliance/firrtl/commit/49b823244732e8d3a4b0fe91d0f10625fea34eec