### PR TITLE
[ExportVerilog] Explicitly load the SV dialect

### DIFF
--- a/include/circt/Translation/ExportVerilog.h
+++ b/include/circt/Translation/ExportVerilog.h
@@ -27,11 +27,12 @@ class ModuleOp;
 
 namespace circt {
 
-/// Export a module containing RTL, and SV dialect code.
+/// Export a module containing RTL, and SV dialect code. Requires that the SV
+/// dialect is loaded in to the context.
 mlir::LogicalResult exportVerilog(mlir::ModuleOp module, llvm::raw_ostream &os);
 
 /// Export a module containing RTL, and SV dialect code, as one file per SV
-/// module.
+/// module. Requires that the SV dialect is loaded in to the context.
 ///
 /// Files are created in the directory indicated by \p dirname. The function
 /// \p emittedFile is called for every emitted file, in the order appropriate

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -2958,6 +2958,10 @@ void circt::registerToVerilogTranslation() {
   mlir::TranslateFromMLIRRegistration toVerilog(
       "export-verilog",
       [](ModuleOp module, llvm::raw_ostream &os) {
+        // ExportVerilog requires that the SV dialect be loaded in order to
+        // create WireOps. It may not have been  loaded by the MLIR parser,
+        // which can happen if the input IR has no SV operations.
+        module->getContext()->loadDialect<sv::SVDialect>();
         applyLoweringCLOptions(module);
         return exportVerilog(module, os);
       },

--- a/test/ExportVerilog/load-dialect.mlir
+++ b/test/ExportVerilog/load-dialect.mlir
@@ -1,0 +1,21 @@
+// RUN: circt-translate %s -export-verilog | FileCheck %s
+// https://github.com/llvm/circt/issues/854
+// This is testing that dependent dialects are explicitly loaded. ExportVerilog
+// must explicitly load any dialect that it creates operations for. For this
+// test to work as intended:
+//   1. the IR must not have any operations from the SV dialect
+//   2. the IR must trigger ExportVerilog to create a sv.wire
+
+
+rtl.module @cyclic(%a: i1) -> (%b: i1) {
+  // Check that a wire temporary is created by export verilog. This wire is
+  // for holding the value of %0.  If this wire is not emitted then this test
+  // should either be deleted or find a different way to force IR generation.
+
+  // CHECK: wire _T;
+
+  %1 = comb.add %0, %0 : i1
+  %0 = comb.shl %a, %a : i1
+  %2 = comb.add %1, %1 : i1
+  rtl.output %2 : i1
+}


### PR DESCRIPTION
Dialects are lazily loaded by the MLIR parser.  When IR read in to
circt-translate does not contain ops from a dialect, the dialect is
never loaded.  Since ExportVerilog creates sv.wire operations, it must
ensure that this dialect has been loaded instead of hoping it has been
loaded by the parser.

Fixes https://github.com/llvm/circt/issues/854