### PR TITLE
Firrtl fold simplify known widths

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -110,13 +110,12 @@ static IntegerAttr elideZeroWidthFoldOperand(Value operand,
 /// Check if the operands and results of \p op are of integer type and with
 /// known bitwidth. Can be used to determine if any fold is legal.
 static bool hasKnownWidths(Operation *op) {
-  for (auto resTy : op->getResultTypes()) {
-    auto ty = resTy.cast<FIRRTLType>();
-    // The result must be of integer type and the bitwidth must be knowkn and
-    // non-zero. Unkown bitwidths are handled after width inference.
-    if (!ty.isa<IntType>() || ty.getBitWidthOrSentinel() <= 0)
-      return false;
-  }
+  auto resTy = op->getResultTypes().front().cast<FIRRTLType>();
+  // The result must be of integer type and the bitwidth must be knowkn and
+  // non-zero. Unkown bitwidths are handled after width inference.
+  if (!resTy.isa<IntType>() || resTy.getBitWidthOrSentinel() <= 0)
+    return false;
+
   for (auto opTy : op->getOperandTypes()) {
     auto ty = opTy.cast<FIRRTLType>();
     // Operand bitwidth must be known. Unkown bitwidths are handled after width

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -111,7 +111,7 @@ static IntegerAttr elideZeroWidthFoldOperand(Value operand,
 /// known bitwidth. Can be used to determine if any fold is legal.
 static bool hasKnownWidths(Operation *op) {
   auto resTy = op->getResultTypes().front().cast<FIRRTLType>();
-  // The result must be of integer type and the bitwidth must be knowkn and
+  // The result must be of integer type and the bitwidth must be known and
   // non-zero. Unkown bitwidths are handled after width inference.
   if (!resTy.isa<IntType>() || resTy.getBitWidthOrSentinel() <= 0)
     return false;


### PR DESCRIPTION
Remove the loop for ``getResultTypes()`` in ``hasKnownWidths``, since a FIRRTL ``BinaryPrimOp`` operation always has a single result, 
Related to commit: https://github.com/llvm/circt/commit/74f99727c6ca9ec353a0a54a68d45f6e7fce49de