### PR TITLE
[ESI] C API and Python bindings

### DIFF
--- a/include/circt-c/Dialect/ESI.h
+++ b/include/circt-c/Dialect/ESI.h
@@ -1,4 +1,4 @@
-//===-- circt-c/Dialect/Comb.h - C API for Comb dialect -----------*- C -*-===//
+//===-- circt-c/Dialect/ESI.h - C API for ESI dialect -------------*- C -*-===//
 //
 // This header declares the C interface for registering and accessing the
 // Comb dialect. A dialect should be registered with a context to make it
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef CIRCT_C_DIALECT_COMB_H
-#define CIRCT_C_DIALECT_COMB_H
+#ifndef CIRCT_C_DIALECT_ESI_H
+#define CIRCT_C_DIALECT_ESI_H
 
 #include "mlir-c/Registration.h"
 
@@ -17,10 +17,10 @@
 extern "C" {
 #endif
 
-MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Combinational, comb);
+MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(ESI, esi);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif // CIRCT_C_DIALECT_COMB_H
+#endif // CIRCT_C_DIALECT_ESI_H

--- a/include/circt/Dialect/ESI/ESI.td
+++ b/include/circt/Dialect/ESI/ESI.td
@@ -37,9 +37,9 @@ class ESI_Abstract_Op<string mnemonic, list<OpTrait> traits = []> :
 class ESI_Physical_Op<string mnemonic, list<OpTrait> traits = []> :
     ESI_Op<mnemonic, traits>;
 
-include "ESIPorts.td"
-include "ESITypes.td"
-include "ESIOps.td"
-include "ESIPasses.td"
+include "circt/Dialect/ESI/ESIPorts.td"
+include "circt/Dialect/ESI/ESITypes.td"
+include "circt/Dialect/ESI/ESIOps.td"
+include "circt/Dialect/ESI/ESIPasses.td"
 
 #endif // ESI_TD

--- a/integration_test/Bindings/Python/dialects/esi.py
+++ b/integration_test/Bindings/Python/dialects/esi.py
@@ -1,0 +1,8 @@
+# REQUIRES: bindings_python
+# RUN: %PYTHON% %s
+
+import circt
+from circt.dialects import esi
+
+from mlir.ir import *
+from mlir.dialects import builtin

--- a/integration_test/Bindings/Python/import.py
+++ b/integration_test/Bindings/Python/import.py
@@ -2,4 +2,4 @@
 # RUN: %PYTHON% %s
 
 import circt
-from circt.dialects import comb, rtl, sv
+from circt.dialects import comb, esi, rtl, sv

--- a/lib/Bindings/Python/CIRCTModule.cpp
+++ b/lib/Bindings/Python/CIRCTModule.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt-c/Dialect/Comb.h"
+#include "circt-c/Dialect/ESI.h"
 #include "circt-c/Dialect/RTL.h"
 #include "circt-c/Dialect/SV.h"
 #include "mlir-c/Bindings/Python/Interop.h"
@@ -26,12 +27,18 @@ PYBIND11_MODULE(_circt, m) {
         MlirContext context = mlirPythonCapsuleToContext(wrappedCapsule.ptr());
 
         // Collect CIRCT dialects to register.
-        MlirDialectHandle rtl = mlirGetDialectHandle__rtl__();
-        mlirDialectHandleRegisterDialect(rtl, context);
-        mlirDialectHandleLoadDialect(rtl, context);
         MlirDialectHandle comb = mlirGetDialectHandle__comb__();
         mlirDialectHandleRegisterDialect(comb, context);
         mlirDialectHandleLoadDialect(comb, context);
+
+        MlirDialectHandle esi = mlirGetDialectHandle__esi__();
+        mlirDialectHandleRegisterDialect(esi, context);
+        mlirDialectHandleLoadDialect(esi, context);
+
+        MlirDialectHandle rtl = mlirGetDialectHandle__rtl__();
+        mlirDialectHandleRegisterDialect(rtl, context);
+        mlirDialectHandleLoadDialect(rtl, context);
+
         MlirDialectHandle sv = mlirGetDialectHandle__sv__();
         mlirDialectHandleRegisterDialect(sv, context);
         mlirDialectHandleLoadDialect(sv, context);

--- a/lib/Bindings/Python/CMakeLists.txt
+++ b/lib/Bindings/Python/CMakeLists.txt
@@ -16,6 +16,7 @@ add_mlir_python_extension(CIRCTBindingsPythonExtension _circt
     CIRCTModule.cpp
   LINK_LIBS
     CIRCTCAPIComb
+    CIRCTCAPIESI
     CIRCTCAPIRTL
     CIRCTCAPISV
 )
@@ -72,6 +73,11 @@ add_mlir_dialect_python_bindings(CIRCTBindingsPythonCombOps
   TD_FILE CombOps.td
   DIALECT_NAME comb)
 add_dependencies(CIRCTBindingsPythonSources CIRCTBindingsPythonCombOps)
+
+add_mlir_dialect_python_bindings(CIRCTBindingsPythonESIOps
+  TD_FILE ESIOps.td
+  DIALECT_NAME esi)
+add_dependencies(CIRCTBindingsPythonSources CIRCTBindingsPythonESIOps)
 
 add_mlir_dialect_python_bindings(CIRCTBindingsPythonRTLOps
   TD_FILE RTLOps.td

--- a/lib/Bindings/Python/ESIOps.td
+++ b/lib/Bindings/Python/ESIOps.td
@@ -1,0 +1,15 @@
+//===-- ESIOps.td - Entry point for ESIOps bindings --------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BINDINGS_PYTHON_ESI_OPS
+#define BINDINGS_PYTHON_ESI_OPS
+
+include "mlir/Bindings/Python/Attributes.td"
+include "circt/Dialect/ESI/ESI.td"
+
+#endif

--- a/lib/Bindings/Python/circt/dialects/esi.py
+++ b/lib/Bindings/Python/circt/dialects/esi.py
@@ -1,0 +1,6 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Generated tablegen dialects end up in the mlir.dialects package for now.
+from mlir.dialects._esi_ops_gen import *

--- a/lib/CAPI/Dialect/CMakeLists.txt
+++ b/lib/CAPI/Dialect/CMakeLists.txt
@@ -1,6 +1,7 @@
 # TODO: Make the check source feature optional as an argument on *_add_library.
 set(LLVM_OPTIONAL_SOURCES
   Comb.cpp
+  ESI.cpp
   RTL.cpp
   SV.cpp
 )
@@ -15,6 +16,18 @@ add_circt_library(CIRCTCAPIComb
   LINK_LIBS PUBLIC
   MLIRCAPIIR
   CIRCTComb
+  )
+
+add_circt_library(CIRCTCAPIESI
+
+  ESI.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${MLIR_MAIN_INCLUDE_DIR}/mlir-c
+
+  LINK_LIBS PUBLIC
+  MLIRCAPIIR
+  CIRCTESI
   )
 
 add_circt_library(CIRCTCAPIRTL

--- a/lib/CAPI/Dialect/ESI.cpp
+++ b/lib/CAPI/Dialect/ESI.cpp
@@ -1,0 +1,11 @@
+//===- ESI.cpp - C Interface for the ESI Dialect --------------------------===//
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt-c/Dialect/ESI.h"
+#include "circt/Dialect/ESI/ESIDialect.h"
+#include "mlir/CAPI/IR.h"
+#include "mlir/CAPI/Registration.h"
+#include "mlir/CAPI/Support.h"
+
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(ESI, esi, circt::esi::ESIDialect)


### PR DESCRIPTION
Just the ability to 'import' ESI into Python. All of the ESI ops require `ChannelType`, so I didn't include anything in the integration test other than importing esi.