### PR TITLE
Uncommented the TOK_LITERAL(raw_string)

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
+++ b/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
@@ -52,7 +52,7 @@ TOK_LITERAL(integer)          // 42
 TOK_LITERAL(signed_integer)   // -42 and +42
 TOK_LITERAL(floatingpoint)    // 42.0
 TOK_LITERAL(string)           // "foo"
-// TOK_LITERAL(raw_string)    // 'foo'
+TOK_LITERAL(raw_string)    // 'foo'
 
 TOK_LITERAL(fileinfo)
 TOK_LITERAL(inlineannotation) // %[{"foo":"bar"}]


### PR DESCRIPTION
Resolved #781 . The Scala FIRRTL Compiler supports passing "raw string" parameters to blackboxes. These have single quotes as opposed to double quotes.
So I've Unommented // TOK_LITERAL(raw_string) to handle FIRToken::raw_string.