### PR TITLE
Mlir syntax issue

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
+++ b/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
@@ -52,7 +52,7 @@ TOK_LITERAL(integer)          // 42
 TOK_LITERAL(signed_integer)   // -42 and +42
 TOK_LITERAL(floatingpoint)    // 42.0
 TOK_LITERAL(string)           // "foo"
-// TOK_LITERAL(raw_string)    // 'foo'
+TOK_LITERAL(raw_string)    // 'foo'
 
 TOK_LITERAL(fileinfo)
 TOK_LITERAL(inlineannotation) // %[{"foo":"bar"}]

--- a/test/Dialect/RTL/basic.mlir
+++ b/test/Dialect/RTL/basic.mlir
@@ -117,9 +117,8 @@ rtl.module @signed_arrays(%arg0: si8) -> (%out: !rtl.array<2xsi8>) {
   // CHECK-NEXT:  %wireArray = sv.wire  : !rtl.inout<array<2xsi8>>
   %wireArray = sv.wire : !rtl.inout<!rtl.array<2xsi8>>
 
-  // CHECK-NEXT: %0 = rtl.array_create %arg0, %arg0 : (si8)
-  %0 = rtl.array_create %arg0, %arg0 : (si8)
-
+  // CHECK-NEXT: %0 = rtl.array_create %arg0, %arg0 : si8
+  %0 = rtl.array_create %arg0, %arg0 : si8
   // CHECK-NEXT: sv.connect %wireArray, %0 : !rtl.array<2xsi8>
   sv.connect %wireArray, %0 : !rtl.array<2xsi8>
 


### PR DESCRIPTION
rtl.array_create MLIR syntax has needless parens around element type #866
I removed Parens.