### PR TITLE
Up Verilator requirement to v4.110, $urandom_range

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,9 +140,9 @@ else()
       OUTPUT_VARIABLE VERILATOR_VERSION)
     string(REGEX MATCH "Verilator (([0-9]+)\.([0-9]+)) \.*"
       MATCH ${VERILATOR_VERSION})
-    # It's gotta be at least v4.034.
-    if (${CMAKE_MATCH_1} LESS 4.034)
-      message(FATAL_ERROR "CIRCT only supports Verilator version 4.034 and up. \
+    # It's gotta be at least v4.110.
+    if (${CMAKE_MATCH_1} LESS 4.110)
+      message(FATAL_ERROR "CIRCT only supports Verilator version 4.110 and up. \
                            Found version: ${CMAKE_MATCH_1}. You can disable \
                            the Verilator tests with '-DVERILATOR_DISABLE=ON'.")
       set(VERILATOR_PATH "")


### PR DESCRIPTION
Change the Verilator requirement in cmake from 4.034 to 4.100 since
the integration tests use `$urandom_range` which was added to
Verilator in 4.100.

See: Verilator release notes for 4.100: https://github.com/verilator/verilator/blob/master/Changes#verilator-4100-2020-09-07.

`$urandom_range` usage here: https://github.com/llvm/circt/blob/461f0eaff2b3af92af0e754e065ff619bd50ae86/integration_test/ESI/supplements/integers.sv#L37