### PR TITLE
[FIRRTL] Fold away validif operations

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -556,7 +556,12 @@ OpFoldResult DShlwPrimOp::fold(ArrayRef<Attribute> operands) { return {}; }
 
 OpFoldResult DShrPrimOp::fold(ArrayRef<Attribute> operands) { return {}; }
 
-OpFoldResult ValidIfPrimOp::fold(ArrayRef<Attribute> operands) { return {}; }
+OpFoldResult ValidIfPrimOp::fold(ArrayRef<Attribute> operands) {
+  // Fold all validIf(x, y) -> y for now. This replicates what the Scala FIRRTL
+  // compiler does in all relevant cases.
+  return rhs();
+}
+
 //===----------------------------------------------------------------------===//
 // Unary Operators
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -1252,18 +1252,13 @@ firrtl.module @mul_cst_prop3(%out_b: !firrtl.flip<sint<15>>) {
 // We fold `validif` operations to their RHS, regardless of the LHS.
 // See https://github.com/llvm/circt/issues/839.
 // CHECK-LABEL: @elide_validif
-// CHECK-NEXT:      firrtl.connect %out0, %clock : !firrtl.flip<clock>, !firrtl.clock
-// CHECK-NEXT:      firrtl.connect %out1, %clock : !firrtl.flip<clock>, !firrtl.clock
+// CHECK-NEXT:      firrtl.connect %out, %clock : !firrtl.flip<clock>, !firrtl.clock
 // CHECK-NEXT:  }
-firrtl.module @elide_validif(%clock: !firrtl.clock, %valid: !firrtl.uint<1>, %out0: !firrtl.flip<clock>, %out1: !firrtl.flip<clock>) {
+firrtl.module @elide_validif(%clock: !firrtl.clock, %valid: !firrtl.uint<1>, %out: !firrtl.flip<clock>) {
   %x = firrtl.wire  : !firrtl.clock
-  %y = firrtl.wire  : !firrtl.clock
   %0 = firrtl.validif %valid, %clock : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.clock
-  %1 = firrtl.validif %valid, %clock : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.clock
   firrtl.connect %x, %0 : !firrtl.clock, !firrtl.clock
-  firrtl.connect %y, %1 : !firrtl.clock, !firrtl.clock
-  firrtl.connect %out0, %x : !firrtl.flip<clock>, !firrtl.clock
-  firrtl.connect %out1, %y : !firrtl.flip<clock>, !firrtl.clock
+  firrtl.connect %out, %x : !firrtl.flip<clock>, !firrtl.clock
 }
 
 }

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -1249,4 +1249,21 @@ firrtl.module @mul_cst_prop3(%out_b: !firrtl.flip<sint<15>>) {
   firrtl.connect %out_b, %add : !firrtl.flip<sint<15>>, !firrtl.sint<15>
 }
 
+// We fold `validif` operations to their RHS, regardless of the LHS.
+// See https://github.com/llvm/circt/issues/839.
+// CHECK-LABEL: @elide_validif
+// CHECK-NEXT:      firrtl.connect %out0, %clock : !firrtl.flip<clock>, !firrtl.clock
+// CHECK-NEXT:      firrtl.connect %out1, %clock : !firrtl.flip<clock>, !firrtl.clock
+// CHECK-NEXT:  }
+firrtl.module @elide_validif(%clock: !firrtl.clock, %valid: !firrtl.uint<1>, %out0: !firrtl.flip<clock>, %out1: !firrtl.flip<clock>) {
+  %x = firrtl.wire  : !firrtl.clock
+  %y = firrtl.wire  : !firrtl.clock
+  %0 = firrtl.validif %valid, %clock : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.clock
+  %1 = firrtl.validif %valid, %clock : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.clock
+  firrtl.connect %x, %0 : !firrtl.clock, !firrtl.clock
+  firrtl.connect %y, %1 : !firrtl.clock, !firrtl.clock
+  firrtl.connect %out0, %x : !firrtl.flip<clock>, !firrtl.clock
+  firrtl.connect %out1, %y : !firrtl.flip<clock>, !firrtl.clock
+}
+
 }


### PR DESCRIPTION
Add a trivial folder for `firrtl.validif` operations that will always replace the operation by its second operand, which is the value being gated. This is not perfect but replicates the behaviour of the Scala FIRRTL compiler in all cases that we are interested in for now. Also fixes #839 and makes reasoning about the clock signal easier in some places. We'll want to revisit this at a later stage.