### PR TITLE
[FIRRTL] Remove validif operation

### DIFF
--- a/docs/RationaleFIRRTL.md
+++ b/docs/RationaleFIRRTL.md
@@ -229,10 +229,10 @@ by the .fir file parser.
 
 ### More things are represented as primitives
 
-We describe the `mux` and `validif` expressions as "primitives", whereas the IR
-spec and grammar implement them as special kinds of expressions.
+We describe the `mux` expression as "primitive", whereas the IR
+spec and grammar implement it as a special kind of expression.
 
-We do this to simplify the implementation: These expression
+We do this to simplify the implementation: These expressions
 have the same structure as primitives, and modeling them as such allows reuse
 of the parsing logic instead of duplication of grammar rules.
 

--- a/docs/RationaleFIRRTL.md
+++ b/docs/RationaleFIRRTL.md
@@ -250,3 +250,28 @@ and returns an invalid value, and a standard `firrtl.connect` operation that
 connects the invalid value to the destination (or a `firrtl.attach` for analog
 values).  This has the same expressive power as the standard FIRRTL
 representation but is easier to work with.
+
+### `validif` represented as a multiplexer
+
+The FIRRTL spec describes a `validIf(en, x)` operation that is used during lowering from high to low FIRRTL. Consider the following example:
+
+```
+c <= invalid
+when a:
+  c <= b
+```
+
+Lowering will introduce the following intermediate representation in low FIRRTL:
+
+```
+c <= validIf(a, b)
+```
+
+Since there is no precedence of this `validIf` being used anywhere in the Chisel/FIRRTL ecosystem thus far and instead is always replaced by its right-hand operand `b`, the FIRRTL MLIR dialect does not provide such an operation at all. Rather it directly replaces any `validIf` in FIRRTL input with the following equivalent operations:
+
+```mlir
+%0 = firrtl.invalidvalue : !firrtl.uint<42>
+%c = firrtl.mux(%a, %b, %0) : (!firrtl.uint<1>, !firrtl.uint<42>, !firrtl.uint<42>) -> !firrtl.uint<42>
+```
+
+A canonicalization then folds this combination of `firrtl.invalidvalue` and `firrtl.mux` to the "high" operand of the multiplexer to facilitate downstream transformation passes.

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -220,9 +220,6 @@ def DShlPrimOp  : BinaryPrimOp<"dshl", IntType, UIntType, IntType>;
 def DShlwPrimOp : BinaryPrimOp<"dshlw", IntType, UIntType, IntType>;
 def DShrPrimOp  : BinaryPrimOp<"dshr", IntType, UIntType, IntType>;
 
-def ValidIfPrimOp
-  : BinaryPrimOp<"validif", UInt1Type, PassiveType, PassiveType>;
-
 //===----------------------------------------------------------------------===//
 // Unary Operations
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -36,7 +36,7 @@ public:
             // Comparisons.
             LEQPrimOp, LTPrimOp, GEQPrimOp, GTPrimOp, EQPrimOp, NEQPrimOp,
             // Misc Binary Primitives.
-            CatPrimOp, DShlPrimOp, DShlwPrimOp, DShrPrimOp, ValidIfPrimOp,
+            CatPrimOp, DShlPrimOp, DShlwPrimOp, DShrPrimOp,
             // Unary operators.
             AsSIntPrimOp, AsUIntPrimOp, AsAsyncResetPrimOp, AsClockPrimOp,
             CvtPrimOp, NegPrimOp, NotPrimOp, AndRPrimOp, OrRPrimOp, XorRPrimOp,
@@ -114,7 +114,6 @@ public:
   HANDLE(DShlPrimOp, Binary);
   HANDLE(DShlwPrimOp, Binary);
   HANDLE(DShrPrimOp, Binary);
-  HANDLE(ValidIfPrimOp, Binary);
 
   // Unary operators.
   HANDLE(AsSIntPrimOp, Unary);

--- a/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
+++ b/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
@@ -813,7 +813,6 @@ struct FIRRTLLowering : public FIRRTLVisitor<FIRRTLLowering, LogicalResult> {
   }
   LogicalResult visitExpr(TailPrimOp op);
   LogicalResult visitExpr(MuxPrimOp op);
-  LogicalResult visitExpr(ValidIfPrimOp op);
 
   // Statements
   LogicalResult visitStmt(SkipOp op);
@@ -2291,16 +2290,6 @@ LogicalResult FIRRTLLowering::visitExpr(MuxPrimOp op) {
 
   return setLoweringTo<comb::MuxOp>(op, ifTrue.getType(), cond, ifTrue,
                                     ifFalse);
-}
-
-LogicalResult FIRRTLLowering::visitExpr(ValidIfPrimOp op) {
-  // It isn't clear to me why it it is ok to ignore the binding condition,
-  // but this is what the existing FIRRTL verilog emitter does.
-  auto val = getLoweredValue(op.rhs());
-  if (!val)
-    return failure();
-
-  return setLowering(op, val);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -520,12 +520,6 @@ OpFoldResult DShlwPrimOp::fold(ArrayRef<Attribute> operands) { return {}; }
 
 OpFoldResult DShrPrimOp::fold(ArrayRef<Attribute> operands) { return {}; }
 
-OpFoldResult ValidIfPrimOp::fold(ArrayRef<Attribute> operands) {
-  // Fold all validIf(x, y) -> y for now. This replicates what the Scala FIRRTL
-  // compiler does in all relevant cases.
-  return rhs();
-}
-
 //===----------------------------------------------------------------------===//
 // Unary Operators
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1323,21 +1323,6 @@ FIRRTLType DShrPrimOp::getResultType(FIRRTLType lhs, FIRRTLType rhs,
   return lhs;
 }
 
-FIRRTLType ValidIfPrimOp::getResultType(FIRRTLType lhs, FIRRTLType rhs,
-                                        Location loc) {
-  auto lhsUInt = lhs.dyn_cast<UIntType>();
-  if (!lhsUInt) {
-    mlir::emitError(loc, "first operand should have UInt type");
-    return {};
-  }
-  auto lhsWidth = lhsUInt.getWidthOrSentinel();
-  if (lhsWidth != -1 && lhsWidth != 1) {
-    mlir::emitError(loc, "first operand should have 'uint<1>' type");
-    return {};
-  }
-  return rhs;
-}
-
 //===----------------------------------------------------------------------===//
 // Unary Primitives
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1415,6 +1415,30 @@ ParseResult FIRStmtParser::parsePrimExp(Value &result, SubOpVector &subOps) {
     break;                                                                     \
   }
 #include "FIRTokenKinds.def"
+
+  case FIRToken::lp_validif: {
+    auto tloc = translateLocation(loc);
+
+    if (opTypes.size() != 2 || !integers.empty()) {
+      mlir::emitError(tloc, "operation requires two operands and no constants");
+      return failure();
+    }
+    auto lhsUInt = opTypes[0].dyn_cast<UIntType>();
+    if (!lhsUInt) {
+      mlir::emitError(tloc, "first operand should have UInt type");
+      return failure();
+    }
+    auto lhsWidth = lhsUInt.getWidthOrSentinel();
+    if (lhsWidth != -1 && lhsWidth != 1) {
+      mlir::emitError(tloc, "first operand should have 'uint<1>' type");
+      return failure();
+    }
+
+    auto inv = builder.create<InvalidValuePrimOp>(tloc, opTypes[1]);
+    result = builder.create<MuxPrimOp>(
+        tloc, opTypes[1], ValueRange({operands[0], operands[1], inv}), attrs);
+    break;
+  }
   }
 
   subOps.push_back(result.getDefiningOp());

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1416,6 +1416,9 @@ ParseResult FIRStmtParser::parsePrimExp(Value &result, SubOpVector &subOps) {
   }
 #include "FIRTokenKinds.def"
 
+  // Expand `validif(a, b)` expressions to `mux(a, b, invalidvalue)`, since we
+  // do not provide an operation for `validif`. See docs/RationaleFIRRTL.md for
+  // more details on this.
   case FIRToken::lp_validif: {
     auto tloc = translateLocation(loc);
 

--- a/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
+++ b/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
@@ -125,6 +125,7 @@ TOK_LPKEYWORD(stop)
 TOK_LPKEYWORD(assert)
 TOK_LPKEYWORD(assume)
 TOK_LPKEYWORD(cover)
+TOK_LPKEYWORD(validif)
 
 // These are for LPKEYWORD cases that correspond to a primitive operation.
 TOK_LPKEYWORD_PRIM(add, AddPrimOp)
@@ -160,7 +161,6 @@ TOK_LPKEYWORD_PRIM(shl, ShlPrimOp)
 TOK_LPKEYWORD_PRIM(shr, ShrPrimOp)
 TOK_LPKEYWORD_PRIM(sub, SubPrimOp)
 TOK_LPKEYWORD_PRIM(tail, TailPrimOp)
-TOK_LPKEYWORD_PRIM(validif, ValidIfPrimOp)
 TOK_LPKEYWORD_PRIM(xor, XorPrimOp)
 TOK_LPKEYWORD_PRIM(xorr, XorRPrimOp)
 

--- a/test/Dialect/FIRRTL/blackbox-memory.mlir
+++ b/test/Dialect/FIRRTL/blackbox-memory.mlir
@@ -155,19 +155,24 @@ firrtl.circuit "MemSimple" {
     %3 = firrtl.subfield %_M_read("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<clock>
     firrtl.connect %3, %clock1 : !firrtl.flip<clock>, !firrtl.clock
     %4 = firrtl.subfield %_M_write("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<4>>
-    %5 = firrtl.validif %inpred, %c0_ui3 : (!firrtl.uint<1>, !firrtl.uint<3>) -> !firrtl.uint<3>
-    firrtl.connect %4, %5 : !firrtl.flip<uint<4>>, !firrtl.uint<3>
-    %6 = firrtl.subfield %_M_write("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-    firrtl.connect %6, %inpred : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-    %7 = firrtl.subfield %_M_write("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<clock>
-    %8 = firrtl.validif %inpred, %clock2 : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.clock
-    firrtl.connect %7, %8 : !firrtl.flip<clock>, !firrtl.clock
-    %9 = firrtl.subfield %_M_write("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<sint<42>>
-    %10 = firrtl.validif %inpred, %indata : (!firrtl.uint<1>, !firrtl.sint<42>) -> !firrtl.sint<42>
-    firrtl.connect %9, %10 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
-    %11 = firrtl.subfield %_M_write("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-    %12 = firrtl.validif %inpred, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.connect %11, %12 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+    %5 = firrtl.invalidvalue : !firrtl.uint<3>
+    %6 = firrtl.mux(%inpred, %c0_ui3, %5) : (!firrtl.uint<1>, !firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
+    firrtl.connect %4, %6 : !firrtl.flip<uint<4>>, !firrtl.uint<3>
+    %7 = firrtl.subfield %_M_write("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+    %8 = firrtl.mux(%inpred, %c1_ui1, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    firrtl.connect %7, %8 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+    %9 = firrtl.subfield %_M_write("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<clock>
+    %10 = firrtl.invalidvalue : !firrtl.clock
+    %11 = firrtl.mux(%inpred, %clock2, %10) : (!firrtl.uint<1>, !firrtl.clock, !firrtl.clock) -> !firrtl.clock
+    firrtl.connect %9, %11 : !firrtl.flip<clock>, !firrtl.clock
+    %12 = firrtl.subfield %_M_write("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<sint<42>>
+    %13 = firrtl.invalidvalue : !firrtl.sint<42>
+    %14 = firrtl.mux(%inpred, %indata, %13) : (!firrtl.uint<1>, !firrtl.sint<42>, !firrtl.sint<42>) -> !firrtl.sint<42>
+    firrtl.connect %12, %14 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
+    %15 = firrtl.subfield %_M_write("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+    %16 = firrtl.invalidvalue : !firrtl.uint<1>
+    %17 = firrtl.mux(%inpred, %c1_ui1, %16) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    firrtl.connect %15, %17 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
   }
 }
 
@@ -208,19 +213,24 @@ firrtl.circuit "MemSimple" {
 // WRAPPER-NEXT:     %3 = firrtl.subfield %_M_read("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<clock>
 // WRAPPER-NEXT:     firrtl.connect %3, %clock1 : !firrtl.flip<clock>, !firrtl.clock
 // WRAPPER-NEXT:     %4 = firrtl.subfield %_M_write("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<4>>
-// WRAPPER-NEXT:     %5 = firrtl.validif %inpred, %c0_ui3 : (!firrtl.uint<1>, !firrtl.uint<3>) -> !firrtl.uint<3>
-// WRAPPER-NEXT:     firrtl.connect %4, %5 : !firrtl.flip<uint<4>>, !firrtl.uint<3>
-// WRAPPER-NEXT:     %6 = firrtl.subfield %_M_write("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// WRAPPER-NEXT:     firrtl.connect %6, %inpred : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// WRAPPER-NEXT:     %7 = firrtl.subfield %_M_write("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<clock>
-// WRAPPER-NEXT:     %8 = firrtl.validif %inpred, %clock2 : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.clock
-// WRAPPER-NEXT:     firrtl.connect %7, %8 : !firrtl.flip<clock>, !firrtl.clock
-// WRAPPER-NEXT:     %9 = firrtl.subfield %_M_write("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<sint<42>>
-// WRAPPER-NEXT:     %10 = firrtl.validif %inpred, %indata : (!firrtl.uint<1>, !firrtl.sint<42>) -> !firrtl.sint<42>
-// WRAPPER-NEXT:     firrtl.connect %9, %10 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
-// WRAPPER-NEXT:     %11 = firrtl.subfield %_M_write("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// WRAPPER-NEXT:     %12 = firrtl.validif %inpred, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// WRAPPER-NEXT:     firrtl.connect %11, %12 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %5 = firrtl.invalidvalue : !firrtl.uint<3>
+// WRAPPER-NEXT:     %6 = firrtl.mux(%inpred, %c0_ui3, %5) : (!firrtl.uint<1>, !firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
+// WRAPPER-NEXT:     firrtl.connect %4, %6 : !firrtl.flip<uint<4>>, !firrtl.uint<3>
+// WRAPPER-NEXT:     %7 = firrtl.subfield %_M_write("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// WRAPPER-NEXT:     %8 = firrtl.mux(%inpred, %c1_ui1, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %7, %8 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %9 = firrtl.subfield %_M_write("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<clock>
+// WRAPPER-NEXT:     %10 = firrtl.invalidvalue : !firrtl.clock
+// WRAPPER-NEXT:     %11 = firrtl.mux(%inpred, %clock2, %10) : (!firrtl.uint<1>, !firrtl.clock, !firrtl.clock) -> !firrtl.clock
+// WRAPPER-NEXT:     firrtl.connect %9, %11 : !firrtl.flip<clock>, !firrtl.clock
+// WRAPPER-NEXT:     %12 = firrtl.subfield %_M_write("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<sint<42>>
+// WRAPPER-NEXT:     %13 = firrtl.invalidvalue : !firrtl.sint<42>
+// WRAPPER-NEXT:     %14 = firrtl.mux(%inpred, %indata, %13) : (!firrtl.uint<1>, !firrtl.sint<42>, !firrtl.sint<42>) -> !firrtl.sint<42>
+// WRAPPER-NEXT:     firrtl.connect %12, %14 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
+// WRAPPER-NEXT:     %15 = firrtl.subfield %_M_write("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// WRAPPER-NEXT:     %16 = firrtl.invalidvalue : !firrtl.uint<1>
+// WRAPPER-NEXT:     %17 = firrtl.mux(%inpred, %c1_ui1, %16) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %15, %17 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT: }
 
@@ -260,19 +270,24 @@ firrtl.circuit "MemSimple" {
 // INLINE-NEXT:     %14 = firrtl.subfield %0("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<clock>
 // INLINE-NEXT:     firrtl.connect %14, %clock1 : !firrtl.flip<clock>, !firrtl.clock
 // INLINE-NEXT:     %15 = firrtl.subfield %5("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<4>>
-// INLINE-NEXT:     %16 = firrtl.validif %inpred, %c0_ui3 : (!firrtl.uint<1>, !firrtl.uint<3>) -> !firrtl.uint<3>
-// INLINE-NEXT:     firrtl.connect %15, %16 : !firrtl.flip<uint<4>>, !firrtl.uint<3>
-// INLINE-NEXT:     %17 = firrtl.subfield %5("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %17, %inpred : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// INLINE-NEXT:     %18 = firrtl.subfield %5("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<clock>
-// INLINE-NEXT:     %19 = firrtl.validif %inpred, %clock2 : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.clock
-// INLINE-NEXT:     firrtl.connect %18, %19 : !firrtl.flip<clock>, !firrtl.clock
-// INLINE-NEXT:     %20 = firrtl.subfield %5("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<sint<42>>
-// INLINE-NEXT:     %21 = firrtl.validif %inpred, %indata : (!firrtl.uint<1>, !firrtl.sint<42>) -> !firrtl.sint<42>
-// INLINE-NEXT:     firrtl.connect %20, %21 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
-// INLINE-NEXT:     %22 = firrtl.subfield %5("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %23 = firrtl.validif %inpred, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// INLINE-NEXT:     firrtl.connect %22, %23 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %16 = firrtl.invalidvalue : !firrtl.uint<3>
+// INLINE-NEXT:     %17 = firrtl.mux(%inpred, %c0_ui3, %16) : (!firrtl.uint<1>, !firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
+// INLINE-NEXT:     firrtl.connect %15, %17 : !firrtl.flip<uint<4>>, !firrtl.uint<3>
+// INLINE-NEXT:     %18 = firrtl.subfield %5("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     %19 = firrtl.mux(%inpred, %c1_ui1, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %18, %19 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %20 = firrtl.subfield %5("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<clock>
+// INLINE-NEXT:     %21 = firrtl.invalidvalue : !firrtl.clock
+// INLINE-NEXT:     %22 = firrtl.mux(%inpred, %clock2, %21) : (!firrtl.uint<1>, !firrtl.clock, !firrtl.clock) -> !firrtl.clock
+// INLINE-NEXT:     firrtl.connect %20, %22 : !firrtl.flip<clock>, !firrtl.clock
+// INLINE-NEXT:     %23 = firrtl.subfield %5("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<sint<42>>
+// INLINE-NEXT:     %24 = firrtl.invalidvalue : !firrtl.sint<42>
+// INLINE-NEXT:     %25 = firrtl.mux(%inpred, %indata, %24) : (!firrtl.uint<1>, !firrtl.sint<42>, !firrtl.sint<42>) -> !firrtl.sint<42>
+// INLINE-NEXT:     firrtl.connect %23, %25 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
+// INLINE-NEXT:     %26 = firrtl.subfield %5("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     %27 = firrtl.invalidvalue : !firrtl.uint<1>
+// INLINE-NEXT:     %28 = firrtl.mux(%inpred, %c1_ui1, %27) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %26, %28 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // INLINE-NEXT:   }
 // INLINE-NEXT: }
 

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -1249,18 +1249,6 @@ firrtl.module @mul_cst_prop3(%out_b: !firrtl.flip<sint<15>>) {
   firrtl.connect %out_b, %add : !firrtl.flip<sint<15>>, !firrtl.sint<15>
 }
 
-// We fold `validif` operations to their RHS, regardless of the LHS.
-// See https://github.com/llvm/circt/issues/839.
-// CHECK-LABEL: @elide_validif
-// CHECK-NEXT:      firrtl.connect %out, %clock : !firrtl.flip<clock>, !firrtl.clock
-// CHECK-NEXT:  }
-firrtl.module @elide_validif(%clock: !firrtl.clock, %valid: !firrtl.uint<1>, %out: !firrtl.flip<clock>) {
-  %x = firrtl.wire  : !firrtl.clock
-  %0 = firrtl.validif %valid, %clock : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.clock
-  firrtl.connect %x, %0 : !firrtl.clock, !firrtl.clock
-  firrtl.connect %out, %x : !firrtl.flip<clock>, !firrtl.clock
-}
-
 // CHECK-LABEL: firrtl.module @MuxInvalidOpt
 firrtl.module @MuxInvalidOpt(%cond: !firrtl.uint<1>, %data: !firrtl.uint<4>, %out1: !firrtl.flip<uint<4>>, %out2: !firrtl.flip<uint<4>>) {
 

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -682,15 +682,11 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input in1: Clock
     input in2: UInt<42>
     input en: UInt<1>
-    output out1: Clock
-    output out2: UInt<42>
 
-    ; CHECK-NEXT: %0 = firrtl.invalidvalue : !firrtl.clock
+    ; CHECK:      %0 = firrtl.invalidvalue : !firrtl.clock
     ; CHECK-NEXT: %1 = firrtl.mux(%en, %in1, %0) : (!firrtl.uint<1>, !firrtl.clock, !firrtl.clock) -> !firrtl.clock
-    ; CHECK-NEXT: firrtl.connect
-    out1 <= validif(en, in1)
+    node out1 = validif(en, in1)
 
-    ; CHECK-NEXT: %2 = firrtl.invalidvalue : !firrtl.uint<42>
+    ; CHECK:      %2 = firrtl.invalidvalue : !firrtl.uint<42>
     ; CHECK-NEXT: %3 = firrtl.mux(%en, %in2, %2) : (!firrtl.uint<1>, !firrtl.uint<42>, !firrtl.uint<42>) -> !firrtl.uint<42>
-    ; CHECK-NEXT: firrtl.connect
-    out2 <= validif(en, in2)
+    node out2 = validif(en, in2)

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -675,3 +675,22 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     mem.r.en <= rEn
     mem.r.addr <= rAddr
     rData <= mem.r.data
+
+  ; https://github.com/llvm/circt/issues/886
+  ; CHECK-LABEL: ParseValidifAsMux
+  module ParseValidifAsMux:
+    input in1: Clock
+    input in2: UInt<42>
+    input en: UInt<1>
+    output out1: Clock
+    output out2: UInt<42>
+
+    ; CHECK-NEXT: %0 = firrtl.invalidvalue : !firrtl.clock
+    ; CHECK-NEXT: %1 = firrtl.mux(%en, %in1, %0) : (!firrtl.uint<1>, !firrtl.clock, !firrtl.clock) -> !firrtl.clock
+    ; CHECK-NEXT: firrtl.connect
+    out1 <= validif(en, in1)
+
+    ; CHECK-NEXT: %2 = firrtl.invalidvalue : !firrtl.uint<42>
+    ; CHECK-NEXT: %3 = firrtl.mux(%en, %in2, %2) : (!firrtl.uint<1>, !firrtl.uint<42>, !firrtl.uint<42>) -> !firrtl.uint<42>
+    ; CHECK-NEXT: firrtl.connect
+    out2 <= validif(en, in2)

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -195,7 +195,6 @@ circuit Issue426:
     ; expected-error @+1 {{initializer too wide for declared width}}
     a <= SInt<1>(-2)
 
-
 ;// -----
 
 circuit circuit:
@@ -212,3 +211,27 @@ circuit circuit:
     input in: UInt<80>
     inst xyz of circuit
     node n = xyz.foo   ; expected-error {{use of invalid field name 'foo' on bundle value}}
+
+;// -----
+
+circuit Issue886:
+  module Issue886 :
+    input a: SInt<1>
+    input b: UInt<42>
+    node n = validif(a, b)  ; expected-error {{first operand should have UInt type}}
+
+;// -----
+
+circuit Issue886:
+  module Issue886 :
+    input a: UInt<2>
+    input b: UInt<42>
+    node n = validif(a, b)  ; expected-error {{first operand should have 'uint<1>' type}}
+
+;// -----
+
+circuit Issue886:
+  module Issue886 :
+    input a: UInt<1>
+    input b: UInt<42>
+    node n = validif(a, b, b)  ; expected-error {{operation requires two operands and no constants}}


### PR DESCRIPTION
* Remove the `validif` operation from the IR and replace any occurrences during parsing with an equivalent `invalidvalue` and `mux` operation. Fixes #886.

* Adjust a few of the test cases, especially around memories, which do not run canonicalization and thus no longer see the removal of validif happen automatically.

@darthscsi: Are the memory tests still okay like this? I had to remove a few occurrences of `validif` since the tests run without any canonicalization.