### PR TITLE
[LLVM] Update LLVM submodule and the way it's cached

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -34,8 +34,10 @@ jobs:
         id: cache-llvm
         uses: actions/cache@v2
         with:
-          path: llvm
-          key: ${{ runner.os }}-llvm-sharedlibs-${{ steps.get-llvm-hash.outputs.hash }}
+          path: |
+            llvm/build
+            llvm/install
+          key: ${{ runner.os }}-llvm-nocode-sharedlibs-${{ steps.get-llvm-hash.outputs.hash }}
 
       # Build LLVM if we didn't hit in the cache.
       - name: Rebuild and Install LLVM
@@ -114,8 +116,10 @@ jobs:
         id: cache-llvm
         uses: actions/cache@v2
         with:
-          path: llvm
-          key: ${{ runner.os }}-llvm-sharedlibs-${{ steps.get-llvm-hash.outputs.hash }}
+          path: |
+            llvm/build
+            llvm/install
+          key: ${{ runner.os }}-llvm-nocode-sharedlibs-${{ steps.get-llvm-hash.outputs.hash }}
 
       # Build LLVM if we didn't hit in the cache. Even though we build it in
       # the previous job, there is a low chance that it'll have been evicted by


### PR DESCRIPTION
Bumping LLVM to get https://github.com/llvm/llvm-project/commit/0126e906483c50c47db0687195e4b0216479846e. Updating the workflow since there's no reason to cache the LLVM source code. Doing both simultaneously to save compilation resources.