### PR TITLE
[ESI] Start of system assembly API: System.load_mlir

### DIFF
--- a/integration_test/Bindings/Python/dialects/esi.py
+++ b/integration_test/Bindings/Python/dialects/esi.py
@@ -15,6 +15,7 @@ with Context() as ctxt, Location.unknown():
     circt.register_dialects(ctxt)
     sys = esi.System(ctxt)
     sys.load_mlir(path.join(thisDir, "esi_load1.mlir"))
+    sys.load_mlir(path.join(thisDir, "esi_load2.mlir"))
     m = sys.get()
 
     i1 = IntegerType.get_signless(1)
@@ -39,7 +40,13 @@ with Context() as ctxt, Location.unknown():
     # CHECK-NEXT:     rtl.output %foo_valid : i1
 
     prod = sys.lookup("IntProducer")
-    if prod is not None:
-        prod.print()
-        print()  # Newline.
-        # CHECK: rtl.module.extern @IntProducer(%clk: i1) -> (%ints: !esi.channel<i32>)
+    assert (prod is not None)
+    prod.print()
+    print()  # Newline.
+    # CHECK: rtl.module.extern @IntProducer(%clk: i1) -> (%ints: !esi.channel<i32>)
+
+    acc = sys.lookup("IntAccumulator")
+    assert (acc is not None)
+    acc.print()
+    print()  # Newline.
+    # CHECK: rtl.module.extern @IntAccumulator(%clk: i1, %ints: i32, %ints_valid: i1) -> (%ints_ready: i1, %sum: i32)

--- a/integration_test/Bindings/Python/dialects/esi.py
+++ b/integration_test/Bindings/Python/dialects/esi.py
@@ -8,14 +8,19 @@ from circt.dialects import rtl
 from mlir.ir import *
 from mlir.dialects import builtin
 
-with Context() as ctx, Location.unknown():
-    circt.register_dialects(ctx)
-    m = builtin.ModuleOp()
+from os import path
+thisDir = path.dirname(__file__)
+
+with Context() as ctxt, Location.unknown():
+    circt.register_dialects(ctxt)
+    sys = esi.System(ctxt)
+    sys.load_mlir(path.join(thisDir, "esi_load1.mlir"))
+    m = sys.get()
 
     i1 = IntegerType.get_signless(1)
     i32 = IntegerType.get_signless(32)
 
-    with InsertionPoint(m.body):
+    with InsertionPoint(m.regions[0].blocks[0]):
         op = rtl.RTLModuleOp(
             name='MyWidget',
             input_ports=[('foo', i32), ('foo_valid', i1)],
@@ -32,3 +37,9 @@ with Context() as ctx, Location.unknown():
     # CHECK-NEXT:     rtl.output
     # CHECK-LABEL:  rtl.module @MyWidget(%foo: i32, %foo_valid: i1) -> (%foo_ready: i1) {
     # CHECK-NEXT:     rtl.output %foo_valid : i1
+
+    prod = sys.lookup("IntProducer")
+    if prod is not None:
+        prod.print()
+        print()  # Newline.
+        # CHECK: rtl.module.extern @IntProducer(%clk: i1) -> (%ints: !esi.channel<i32>)

--- a/integration_test/Bindings/Python/dialects/esi_load1.mlir
+++ b/integration_test/Bindings/Python/dialects/esi_load1.mlir
@@ -1,0 +1,1 @@
+rtl.module.extern @IntProducer(%clk: i1) -> (%ints: !esi.channel<i32>)

--- a/integration_test/Bindings/Python/dialects/esi_load2.mlir
+++ b/integration_test/Bindings/Python/dialects/esi_load2.mlir
@@ -1,0 +1,1 @@
+rtl.module.extern @IntAccumulator(%clk: i1, %ints: i32, %ints_valid: i1) -> (%ints_ready: i1, %sum: i32)

--- a/integration_test/Bindings/Python/dialects/lit.local.cfg
+++ b/integration_test/Bindings/Python/dialects/lit.local.cfg
@@ -1,0 +1,2 @@
+# Only run python in this dir
+config.suffixes = ['.py']

--- a/lib/Bindings/Python/ESIModule.cpp
+++ b/lib/Bindings/Python/ESIModule.cpp
@@ -16,6 +16,8 @@
 #include "mlir/CAPI/IR.h"
 #include "mlir/CAPI/Support.h"
 #include "mlir/IR/Builders.h"
+#include "mlir/Parser.h"
+#include "mlir/Support/FileUtilities.h"
 
 #include "llvm/ADT/SmallVector.h"
 
@@ -44,11 +46,48 @@ static MlirOperation pyWrapModule(MlirOperation cModOp,
   return wrap(wrapper);
 }
 
+//===----------------------------------------------------------------------===//
+// The main entry point into the ESI API.
+//===----------------------------------------------------------------------===//
+
+class System {
+public:
+  System(MlirContext cCtxt) : ctxt(unwrap(cCtxt)) {
+    module = OwningModuleRef(ModuleOp::create(UnknownLoc::get(ctxt)));
+  }
+
+  void loadMlir(std::string filename) {
+    auto loadedMod = mlir::parseSourceFile(filename, ctxt);
+    Block *loadedBlock = loadedMod->getBody();
+    auto &ops = module->getBody()->getOperations();
+    ops.splice(ops.end(), loadedBlock->getOperations());
+  }
+
+  MlirOperation get() { return wrap((Operation *)module.get()); }
+  MlirOperation lookup(std::string symbol) {
+    Operation *found =
+        SymbolTable::lookupSymbolIn((Operation *)module.get(), symbol);
+    return wrap(found);
+  }
+
+private:
+  MLIRContext *ctxt;
+  OwningModuleRef module;
+};
+
 void circt::python::populateDialectESISubmodule(py::module &m) {
   m.doc() = "ESI Python Native Extension";
 
   m.def("buildWrapper", &pyWrapModule,
         "Construct an ESI wrapper around RTL module 'op' given a list of "
-        "latency-insensitive ports",
+        "latency-insensitive ports.",
         py::arg("op"), py::arg("name_list"));
+
+  py::class_<System>(m, "System")
+      .def(py::init<MlirContext>())
+      .def("load_mlir", &System::loadMlir,
+           "Load an MLIR assembly file.")
+      .def("get", &System::get, "Get the top level module op.")
+      .def("lookup", &System::lookup,
+           "Lookup an RTL module and return it.");
 }

--- a/lib/Bindings/Python/ESIModule.cpp
+++ b/lib/Bindings/Python/ESIModule.cpp
@@ -85,9 +85,7 @@ void circt::python::populateDialectESISubmodule(py::module &m) {
 
   py::class_<System>(m, "System")
       .def(py::init<MlirContext>())
-      .def("load_mlir", &System::loadMlir,
-           "Load an MLIR assembly file.")
+      .def("load_mlir", &System::loadMlir, "Load an MLIR assembly file.")
       .def("get", &System::get, "Get the top level module op.")
-      .def("lookup", &System::lookup,
-           "Lookup an RTL module and return it.");
+      .def("lookup", &System::lookup, "Lookup an RTL module and return it.");
 }

--- a/lib/Bindings/Python/PybindUtils.h
+++ b/lib/Bindings/Python/PybindUtils.h
@@ -121,6 +121,14 @@ struct type_caster<MlirModule> {
     }
     return true;
   }
+  static handle cast(MlirModule v, return_value_policy, handle) {
+    auto capsule =
+        py::reinterpret_steal<py::object>(mlirPythonModuleToCapsule(v));
+    return py::module::import("mlir.ir")
+        .attr("Module")
+        .attr(MLIR_PYTHON_CAPI_FACTORY_ATTR)(capsule)
+        .release();
+  };
 };
 
 /// Casts object <-> MlirOperation.
@@ -136,6 +144,8 @@ struct type_caster<MlirOperation> {
     return true;
   }
   static handle cast(MlirOperation v, return_value_policy, handle) {
+    if (v.ptr == nullptr)
+      return py::none();
     auto capsule =
         py::reinterpret_steal<py::object>(mlirPythonOperationToCapsule(v));
     return py::module::import("mlir.ir")


### PR DESCRIPTION
Start the system assembly API with a method to load an MLIR assembly file and append it to the System module.