### PR TITLE
Eliminate firrtl.node ops when they carry no annotations

### DIFF
--- a/include/circt/Dialect/FIRRTL/Canonicalization.td
+++ b/include/circt/Dialect/FIRRTL/Canonicalization.td
@@ -19,6 +19,11 @@ include "circt/Dialect/FIRRTL/FIRRTL.td"
 /// const-on-LHS rewriting patterns converge in case both operands are constant.
 def NonConstantOp : Constraint<CPred<"!$0.getDefiningOp<ConstantOp>()">>;
 
+// Constraint that matches empty attribute dictionaries.  Used to ensure that
+// there are no FIRRTL annotation on an operation.
+def EmptyAttrDict : Constraint<CPred<"$0.empty()">>;
+
+
 // leq(const, x) -> geq(x, const)
 def LEQWithConstLHS : Pat<
   (LEQPrimOp (ConstantOp:$lhs $_), $rhs),
@@ -55,5 +60,10 @@ def MuxSameCondHigh : Pat<
   (MuxPrimOp $cond, $y, $x)
   >;
 
+// node(x, name, {}) -> x
+def EmptyNode : Pat<
+  (NodeOp $x, $name, $attrs),
+  (replaceWithValue $x),
+  [(EmptyAttrDict $attrs)]>;
 
 #endif // CIRCT_DIALECT_FIRRTL_CANONICALIZATION_TD

--- a/include/circt/Dialect/FIRRTL/Canonicalization.td
+++ b/include/circt/Dialect/FIRRTL/Canonicalization.td
@@ -43,4 +43,16 @@ def GTWithConstLHS : Pat<
   (LTPrimOp $rhs, $lhs),
   [(NonConstantOp $rhs)]>;
 
+// mux(cond, x, mux(cond, y, z))
+def MuxSameCondLow : Pat<
+  (MuxPrimOp $cond, $x, (MuxPrimOp $cond, $y, $z)),
+  (MuxPrimOp $cond, $x, $z)
+  >;
+
+// mux(cond, x, node(mux(cond, y, z)))
+def MuxSameCondLowNode : Pat<
+  (MuxPrimOp $cond, $x, (NodeOp (MuxPrimOp $cond, $y, $z), $name, $attr)),
+  (MuxPrimOp $cond, $x, $z)
+  >;
+
 #endif // CIRCT_DIALECT_FIRRTL_CANONICALIZATION_TD

--- a/include/circt/Dialect/FIRRTL/Canonicalization.td
+++ b/include/circt/Dialect/FIRRTL/Canonicalization.td
@@ -49,10 +49,11 @@ def MuxSameCondLow : Pat<
   (MuxPrimOp $cond, $x, $z)
   >;
 
-// mux(cond, x, node(mux(cond, y, z)))
-def MuxSameCondLowNode : Pat<
-  (MuxPrimOp $cond, $x, (NodeOp (MuxPrimOp $cond, $y, $z), $name, $attr)),
-  (MuxPrimOp $cond, $x, $z)
+// mux(cond, mux(cond, y, z), x)
+def MuxSameCondHigh : Pat<
+  (MuxPrimOp $cond, (MuxPrimOp $cond, $y, $z), $x),
+  (MuxPrimOp $cond, $y, $x)
   >;
+
 
 #endif // CIRCT_DIALECT_FIRRTL_CANONICALIZATION_TD

--- a/include/circt/Dialect/FIRRTL/Canonicalization.td
+++ b/include/circt/Dialect/FIRRTL/Canonicalization.td
@@ -43,13 +43,13 @@ def GTWithConstLHS : Pat<
   (LTPrimOp $rhs, $lhs),
   [(NonConstantOp $rhs)]>;
 
-// mux(cond, x, mux(cond, y, z))
+// mux(cond, x, mux(cond, y, z)) -> mux(cond, x, z)
 def MuxSameCondLow : Pat<
   (MuxPrimOp $cond, $x, (MuxPrimOp $cond, $y, $z)),
   (MuxPrimOp $cond, $x, $z)
   >;
 
-// mux(cond, mux(cond, y, z), x)
+// mux(cond, mux(cond, y, z), x) -> mux(cond, y, x)
 def MuxSameCondHigh : Pat<
   (MuxPrimOp $cond, (MuxPrimOp $cond, $y, $z), $x),
   (MuxPrimOp $cond, $y, $x)

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -152,6 +152,8 @@ def NodeOp : FIRRTLOp<"node", [NoSideEffect, SameOperandsAndResultType]> {
   let results = (outs FIRRTLType:$result);
 
   let assemblyFormat = "$input custom<ImplicitSSAName>(attr-dict) `:` type($input)";
+
+  let hasCanonicalizer = true;
 }
 
 def RegOp : FIRRTLOp<"reg", [/*MemAlloc*/]> {

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -388,6 +388,7 @@ def MuxPrimOp : PrimOp<"mux"> {
     "`(` operands `)` attr-dict `:` functional-type(operands, $result)";
 
   let hasFolder = 1;
+  let hasCanonicalizer = true;
 
   let extraClassDeclaration = [{
     /// Return the result for inputs with the specified type, returning a null

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -997,3 +997,8 @@ LogicalResult PartialConnectOp::canonicalize(PartialConnectOp op,
   }
   return failure();
 }
+
+void NodeOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                         MLIRContext *context) {
+  results.insert<patterns::EmptyNode>(context);
+}

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -662,6 +662,12 @@ OpFoldResult MuxPrimOp::fold(ArrayRef<Attribute> operands) {
   return {};
 }
 
+void MuxPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                            MLIRContext *context) {
+  results.insert<patterns::MuxSameCondLow>(context);
+  results.insert<patterns::MuxSameCondLowNode>(context);
+}
+
 OpFoldResult PadPrimOp::fold(ArrayRef<Attribute> operands) {
   auto input = this->input();
 

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -665,7 +665,7 @@ OpFoldResult MuxPrimOp::fold(ArrayRef<Attribute> operands) {
 void MuxPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                             MLIRContext *context) {
   results.insert<patterns::MuxSameCondLow>(context);
-  results.insert<patterns::MuxSameCondLowNode>(context);
+  results.insert<patterns::MuxSameCondHigh>(context);
 }
 
 OpFoldResult PadPrimOp::fold(ArrayRef<Attribute> operands) {

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -1266,14 +1266,12 @@ firrtl.module @MuxInvalidOpt(%cond: !firrtl.uint<1>, %data: !firrtl.uint<4>, %ou
 // CHECK-LABEL: firrtl.module @MuxCanon
 firrtl.module @MuxCanon(%c1: !firrtl.uint<1>, %c2: !firrtl.uint<1>, %d1: !firrtl.uint<5>, %d2: !firrtl.uint<5>, %d3: !firrtl.uint<5>, %foo: !firrtl.flip<uint<5>>, %foo2: !firrtl.flip<uint<5>>) {
   %0 = firrtl.mux(%c1, %d2, %d3) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
-  %baz = firrtl.node %0  : !firrtl.uint<5>
-  %1 = firrtl.mux(%c1, %d1, %baz) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
-  %bar = firrtl.node %1  : !firrtl.uint<5>
-  firrtl.connect %foo, %bar : !firrtl.flip<uint<5>>, !firrtl.uint<5>
-  %2 = firrtl.mux(%c1, %d1, %0) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
-  firrtl.connect %foo, %2 : !firrtl.flip<uint<5>>, !firrtl.uint<5>
+  %1 = firrtl.mux(%c1, %d1, %0) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
+  %2 = firrtl.mux(%c1, %0, %d1) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
+  firrtl.connect %foo, %1 : !firrtl.flip<uint<5>>, !firrtl.uint<5>
+  firrtl.connect %foo2, %2 : !firrtl.flip<uint<5>>, !firrtl.uint<5>
   // CHECK: firrtl.mux(%c1, %d1, %d3) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5> 
-  // CHECK: firrtl.mux(%c1, %d1, %d3) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5> 
+  // CHECK: firrtl.mux(%c1, %d2, %d1) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5> 
 }
 
 }

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -1262,4 +1262,18 @@ firrtl.module @MuxInvalidOpt(%cond: !firrtl.uint<1>, %data: !firrtl.uint<4>, %ou
   // CHECK:         firrtl.connect %out2, %data 
   firrtl.connect %out2, %b : !firrtl.flip<uint<4>>, !firrtl.uint<4>
 }
+
+// CHECK-LABEL: firrtl.module @MuxCanon
+firrtl.module @MuxCanon(%c1: !firrtl.uint<1>, %c2: !firrtl.uint<1>, %d1: !firrtl.uint<5>, %d2: !firrtl.uint<5>, %d3: !firrtl.uint<5>, %foo: !firrtl.flip<uint<5>>, %foo2: !firrtl.flip<uint<5>>) {
+  %0 = firrtl.mux(%c1, %d2, %d3) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
+  %baz = firrtl.node %0  : !firrtl.uint<5>
+  %1 = firrtl.mux(%c1, %d1, %baz) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
+  %bar = firrtl.node %1  : !firrtl.uint<5>
+  firrtl.connect %foo, %bar : !firrtl.flip<uint<5>>, !firrtl.uint<5>
+  %2 = firrtl.mux(%c1, %d1, %0) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
+  firrtl.connect %foo, %2 : !firrtl.flip<uint<5>>, !firrtl.uint<5>
+  // CHECK: firrtl.mux(%c1, %d1, %d3) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5> 
+  // CHECK: firrtl.mux(%c1, %d1, %d3) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5> 
+}
+
 }

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -1274,4 +1274,11 @@ firrtl.module @MuxCanon(%c1: !firrtl.uint<1>, %c2: !firrtl.uint<1>, %d1: !firrtl
   // CHECK: firrtl.mux(%c1, %d2, %d1) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5> 
 }
 
+// CHECK-LABEL: firrtl.module @EmptyNode
+firrtl.module @EmptyNode(%d1: !firrtl.uint<5>, %foo: !firrtl.flip<uint<5>>) {
+  %bar = firrtl.node %d1  : !firrtl.uint<5>
+  firrtl.connect %foo, %bar : !firrtl.flip<uint<5>>, !firrtl.uint<5>
+}
+// CHECK: firrtl.connect %foo, %d1
+
 }

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -1275,10 +1275,14 @@ firrtl.module @MuxCanon(%c1: !firrtl.uint<1>, %c2: !firrtl.uint<1>, %d1: !firrtl
 }
 
 // CHECK-LABEL: firrtl.module @EmptyNode
-firrtl.module @EmptyNode(%d1: !firrtl.uint<5>, %foo: !firrtl.flip<uint<5>>) {
+firrtl.module @EmptyNode(%d1: !firrtl.uint<5>, %foo: !firrtl.flip<uint<5>>, %foo2: !firrtl.flip<uint<5>>) {
   %bar = firrtl.node %d1  : !firrtl.uint<5>
+  %bar2 = firrtl.node %d1 {annotations = [{extrastuff = "n1"}]}  : !firrtl.uint<5>
   firrtl.connect %foo, %bar : !firrtl.flip<uint<5>>, !firrtl.uint<5>
+  firrtl.connect %foo2, %bar2 : !firrtl.flip<uint<5>>, !firrtl.uint<5>
 }
-// CHECK: firrtl.connect %foo, %d1
+// CHECK-NEXT: %bar2 = firrtl.node %d1 {annotations = [{extrastuff = "n1"}]}
+// CHECK-NEXT: firrtl.connect %foo, %d1
+// CHECK-NEXT: firrtl.connect %foo2, %bar2
 
 }


### PR DESCRIPTION
Eliminates unused NodeOps.
Partially addresses #299 