### PR TITLE
[ESI] [Python] Create a ChannelPort type

### DIFF
--- a/integration_test/Bindings/Python/dialects/esi.py
+++ b/integration_test/Bindings/Python/dialects/esi.py
@@ -20,6 +20,7 @@ with Context() as ctxt, Location.unknown():
 
     i1 = IntegerType.get_signless(1)
     i32 = IntegerType.get_signless(32)
+    i32_chan = esi.channel_type(i32)
 
     with InsertionPoint(m.regions[0].blocks[0]):
         op = rtl.RTLModuleOp(
@@ -30,6 +31,14 @@ with Context() as ctxt, Location.unknown():
                 [module.entry_block.arguments[1]])
         )
 
+        snoop = rtl.RTLModuleOp(
+            name='I32Snoop',
+            input_ports=[('foo_in', i32_chan)],
+            output_ports=[('foo_out', i32_chan)],
+            body_builder=lambda module: rtl.OutputOp(
+                [module.entry_block.arguments[0]])
+        )
+
     esi.buildWrapper(op.operation, ["foo"])
     m.print()
     # CHECK-LABEL:  rtl.module @MyWidget_esi(%foo: !esi.channel<i32>) {
@@ -38,6 +47,8 @@ with Context() as ctxt, Location.unknown():
     # CHECK-NEXT:     rtl.output
     # CHECK-LABEL:  rtl.module @MyWidget(%foo: i32, %foo_valid: i1) -> (%foo_ready: i1) {
     # CHECK-NEXT:     rtl.output %foo_valid : i1
+    # CHECK-LABEL:  rtl.module @I32Snoop(%foo_in: !esi.channel<i32>) -> (%foo_out: !esi.channel<i32>) {
+    # CHECK-NEXT:     rtl.output %foo_in : !esi.channel<i32>
 
     prod = sys.lookup("IntProducer")
     assert (prod is not None)

--- a/lib/Bindings/Python/ESIModule.cpp
+++ b/lib/Bindings/Python/ESIModule.cpp
@@ -10,6 +10,7 @@
 
 #include "circt-c/Dialect/ESI.h"
 #include "circt/Dialect/ESI/ESIDialect.h"
+#include "circt/Dialect/ESI/ESITypes.h"
 #include "circt/Support/LLVM.h"
 #include "mlir-c/Bindings/Python/Interop.h"
 
@@ -46,8 +47,14 @@ static MlirOperation pyWrapModule(MlirOperation cModOp,
   return wrap(wrapper);
 }
 
+static MlirType channelType(MlirType cElem) {
+  Type elemTy = unwrap(cElem);
+  auto chanTy = ChannelPort::get(elemTy.getContext(), elemTy);
+  return wrap(chanTy);
+}
+
 //===----------------------------------------------------------------------===//
-// The main entry point into the ESI API.
+// The main entry point into the ESI Assembly API.
 //===----------------------------------------------------------------------===//
 
 class System {
@@ -82,6 +89,8 @@ void circt::python::populateDialectESISubmodule(py::module &m) {
         "Construct an ESI wrapper around RTL module 'op' given a list of "
         "latency-insensitive ports.",
         py::arg("op"), py::arg("name_list"));
+  m.def("channel_type", &channelType,
+        "Create an ESI channel type which wraps the argument type");
 
   py::class_<System>(m, "System")
       .def(py::init<MlirContext>())


### PR DESCRIPTION
Function to create channel type wrapping the argument type. This is a temporary way to get a critical ESI type before we get the long-term solution we discussed at the bindings MLIR ODM a while back.