### PR TITLE
firrtl memory generator node lowering

### DIFF
--- a/include/circt/Dialect/SV/SVPasses.h
+++ b/include/circt/Dialect/SV/SVPasses.h
@@ -27,6 +27,7 @@ namespace sv {
 std::unique_ptr<mlir::Pass> createRTLCleanupPass();
 std::unique_ptr<mlir::Pass> createRTLStubExternalModulesPass();
 std::unique_ptr<mlir::Pass> createRTLLegalizeNamesPass();
+std::unique_ptr<mlir::Pass> createRTLMemSimImplPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/SV/SVPasses.td
+++ b/include/circt/Dialect/SV/SVPasses.td
@@ -49,4 +49,16 @@ def RTLLegalizeNames : Pass<"rtl-legalize-names", "ModuleOp"> {
   let constructor = "circt::sv::createRTLLegalizeNamesPass()";
 }
 
+def RTLMemSimImpl : Pass<"rtl-memory-sim", "ModuleOp"> {
+  let summary = "Implement FIRRTMMem memories nodes with simulation model";
+  let description = [{
+    This pass replaces generated module nodes of type FIRRTLMem with a model
+    suitable for simulation.
+  }];
+
+  let constructor = "circt::sv::createRTLMemSimImplPass()";
+  let dependentDialects = ["circt::sv::SVDialect"];
+}
+
+
 #endif // CIRCT_DIALECT_SV_SVPASSES

--- a/lib/Dialect/SV/Transforms/CMakeLists.txt
+++ b/lib/Dialect/SV/Transforms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_circt_dialect_library(CIRCTSVTransforms
   RTLCleanup.cpp
   RTLStubExternalModules.cpp
   RTLLegalizeNames.cpp
+  RTLMemSimImpl.cpp
 
   DEPENDS
   CIRCTSVTransformsIncGen

--- a/lib/Dialect/SV/Transforms/RTLMemSimImpl.cpp
+++ b/lib/Dialect/SV/Transforms/RTLMemSimImpl.cpp
@@ -76,8 +76,7 @@ static Value addPipelineStages(ImplicitLocOpBuilder &b, size_t stages,
   return data;
 }
 
-void RTLMemSimImplPass::generateMemory(rtl::RTLModuleOp op,
-                                       FirMemory mem) {
+void RTLMemSimImplPass::generateMemory(rtl::RTLModuleOp op, FirMemory mem) {
   ImplicitLocOpBuilder b(UnknownLoc::get(&getContext()), op.getBody());
 
   // Create a register for the memory.

--- a/lib/Dialect/SV/Transforms/RTLMemSimImpl.cpp
+++ b/lib/Dialect/SV/Transforms/RTLMemSimImpl.cpp
@@ -97,10 +97,11 @@ void RTLMemSimImplPass::generateMemory(rtl::RTLModuleOp op,
     addr = addPipelineStages(b, mem.readLatency, clock, addr);
 
     // Read Logic
-    Value rdata = b.create<comb::MuxOp>(
-        en,
-        b.create<sv::ReadInOutOp>(b.create<sv::ArrayIndexInOutOp>(reg, addr)),
-        b.create<sv::ConstantXOp>(dataType));
+    Value ren =
+        b.create<sv::ReadInOutOp>(b.create<sv::ArrayIndexInOutOp>(reg, addr));
+    Value x = b.create<sv::ConstantXOp>(dataType);
+
+    Value rdata = b.create<comb::MuxOp>(en, ren, x);
     outputs.push_back(rdata);
   }
   for (size_t i = 0; i < mem.numReadWritePorts; ++i) {
@@ -128,8 +129,8 @@ void RTLMemSimImplPass::generateMemory(rtl::RTLModuleOp op,
       auto slot = b.create<sv::ArrayIndexInOutOp>(reg, addr);
       auto rcond = b.createOrFold<comb::AndOp>(
           en, b.createOrFold<comb::ICmpOp>(
-                     ICmpPredicate::eq, wmode,
-                     b.createOrFold<rtl::ConstantOp>(wmode.getType(), 0)));
+                  ICmpPredicate::eq, wmode,
+                  b.createOrFold<rtl::ConstantOp>(wmode.getType(), 0)));
       auto wcond = b.createOrFold<comb::AndOp>(
           en, b.createOrFold<comb::AndOp>(wmask, wmode));
 

--- a/lib/Dialect/SV/Transforms/RTLMemSimImpl.cpp
+++ b/lib/Dialect/SV/Transforms/RTLMemSimImpl.cpp
@@ -1,0 +1,205 @@
+//===- RTLMemSimImpl.cpp - RTL Memory Implementation Pass -----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This transformation pass converts gemerated FIRRTL memory modules to
+// simulation models.
+//
+//===----------------------------------------------------------------------===//
+
+#include "SVPassDetail.h"
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/SV/SVPasses.h"
+#include "circt/Support/ImplicitLocOpBuilder.h"
+
+using namespace circt;
+
+//===----------------------------------------------------------------------===//
+// StubExternalModules Pass
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct RTLMemSimImplPass : public sv::RTLMemSimImplBase<RTLMemSimImplPass> {
+  void runOnOperation() override;
+
+private:
+  void generateMemory(rtl::RTLModuleOp op, rtl::RTLModuleGeneratedOp refOp);
+};
+
+struct FirMemory {
+  size_t numReadPorts;
+  size_t numWritePorts;
+  size_t numReadWritePorts;
+  size_t dataWidth;
+  size_t depth;
+  size_t readLatency;
+  size_t writeLatency;
+  size_t readUnderWrite;
+};
+} // end anonymous namespace
+
+static FirMemory analyzeMemOp(rtl::RTLModuleGeneratedOp op) {
+  FirMemory mem;
+  mem.depth = op->getAttrOfType<IntegerAttr>("depth").getInt();
+  mem.numReadPorts = op->getAttrOfType<IntegerAttr>("numReadPorts").getUInt();
+  mem.numWritePorts = op->getAttrOfType<IntegerAttr>("numWritePorts").getUInt();
+  mem.numReadWritePorts =
+      op->getAttrOfType<IntegerAttr>("numReadWritePorts").getUInt();
+  mem.readLatency = op->getAttrOfType<IntegerAttr>("readLatency").getUInt();
+  mem.writeLatency = op->getAttrOfType<IntegerAttr>("writeLatency").getUInt();
+  mem.dataWidth = op->getAttrOfType<IntegerAttr>("width").getUInt();
+  mem.readUnderWrite =
+      op->getAttrOfType<IntegerAttr>("readUnderWrite").getUInt();
+  return mem;
+};
+
+static Value addPipelineStages(ImplicitLocOpBuilder &b, size_t stages,
+                               Value clock, Value data) {
+  if (!stages)
+    return data;
+
+  while (stages--) {
+    auto reg = b.create<sv::RegOp>(data.getType());
+
+    // pipeline stage
+    b.create<sv::AlwaysFFOp>(sv::EventControl::AtPosEdge, clock,
+                             [&]() { b.create<sv::PAssignOp>(reg, data); });
+    data = b.create<sv::ReadInOutOp>(reg);
+  }
+
+  return data;
+}
+
+void RTLMemSimImplPass::generateMemory(rtl::RTLModuleOp op,
+                                       rtl::RTLModuleGeneratedOp refOp) {
+  ImplicitLocOpBuilder b(UnknownLoc::get(&getContext()), op.getBody());
+  auto mem = analyzeMemOp(refOp);
+
+  // Create a register for the memory.
+  auto dataType = b.getIntegerType(mem.dataWidth);
+  Value reg =
+      b.create<sv::RegOp>(rtl::UnpackedArrayType::get(dataType, mem.depth),
+                          b.getStringAttr("Memory"));
+
+  SmallVector<Value, 4> outputs;
+
+  size_t inArg = 0;
+  for (size_t i = 0; i < mem.numReadPorts; ++i) {
+    Value clock = op.body().getArgument(inArg++);
+    Value en = op.body().getArgument(inArg++);
+    Value addr = op.body().getArgument(inArg++);
+    // Add pipeline stages
+    en = addPipelineStages(b, mem.readLatency, clock, en);
+    addr = addPipelineStages(b, mem.readLatency, clock, addr);
+
+    // Read Logic
+    Value rdata = b.create<comb::MuxOp>(
+        en,
+        b.create<sv::ReadInOutOp>(b.create<sv::ArrayIndexInOutOp>(reg, addr)),
+        b.create<sv::ConstantXOp>(dataType));
+    outputs.push_back(rdata);
+  }
+  for (size_t i = 0; i < mem.numReadWritePorts; ++i) {
+    auto numStages = std::max(mem.readLatency, mem.writeLatency) - 1;
+    Value clock = op.body().getArgument(inArg++);
+    Value en = op.body().getArgument(inArg++);
+    Value addr = op.body().getArgument(inArg++);
+    Value wmode = op.body().getArgument(inArg++);
+    Value wmask = op.body().getArgument(inArg++);
+    Value wdata = op.body().getArgument(inArg++);
+
+    // Add pipeline stages
+    en = addPipelineStages(b, numStages, clock, en);
+    addr = addPipelineStages(b, numStages, clock, addr);
+    wmode = addPipelineStages(b, numStages, clock, wmode);
+    wmask = addPipelineStages(b, numStages, clock, wmask);
+    wdata = addPipelineStages(b, numStages, clock, wdata);
+
+    // wire to store read result
+    auto rWire = b.create<sv::WireOp>(wdata.getType());
+    Value rdata = b.create<sv::ReadInOutOp>(rWire);
+
+    // RW logic
+    b.create<sv::AlwaysFFOp>(sv::EventControl::AtPosEdge, clock, [&]() {
+      auto slot = b.create<sv::ArrayIndexInOutOp>(reg, addr);
+      auto rcond = b.createOrFold<comb::AndOp>(
+          en, b.createOrFold<comb::ICmpOp>(
+                     ICmpPredicate::eq, wmode,
+                     b.createOrFold<rtl::ConstantOp>(wmode.getType(), 0)));
+      auto wcond = b.createOrFold<comb::AndOp>(
+          en, b.createOrFold<comb::AndOp>(wmask, wmode));
+
+      b.create<sv::PAssignOp>(rWire, b.create<sv::ConstantXOp>(dataType));
+      b.create<sv::IfOp>(
+          wcond, [&]() { b.create<sv::PAssignOp>(slot, wdata); },
+          [&]() {
+            b.create<sv::IfOp>(rcond, [&]() {
+              b.create<sv::PAssignOp>(rWire, b.create<sv::ReadInOutOp>(slot));
+            });
+          });
+    });
+    outputs.push_back(rdata);
+  }
+  for (size_t i = 0; i < mem.numWritePorts; ++i) {
+    auto numStages = mem.writeLatency - 1;
+    Value clock = op.body().getArgument(inArg++);
+    Value en = op.body().getArgument(inArg++);
+    Value addr = op.body().getArgument(inArg++);
+    Value wmask = op.body().getArgument(inArg++);
+    Value wdata = op.body().getArgument(inArg++);
+    // Add pipeline stages
+    en = addPipelineStages(b, numStages, clock, en);
+    addr = addPipelineStages(b, numStages, clock, addr);
+    wmask = addPipelineStages(b, numStages, clock, wmask);
+    wdata = addPipelineStages(b, numStages, clock, wdata);
+
+    // Write logic
+    b.create<sv::AlwaysFFOp>(sv::EventControl::AtPosEdge, clock, [&]() {
+      auto wcond = b.createOrFold<comb::AndOp>(en, wmask);
+      b.create<sv::IfOp>(wcond, [&]() {
+        auto slot = b.create<sv::ArrayIndexInOutOp>(reg, addr);
+        b.create<sv::PAssignOp>(slot, wdata);
+      });
+    });
+  }
+
+  auto outputOp = op.getBodyBlock()->getTerminator();
+  outputOp->setOperands(outputs);
+}
+
+void RTLMemSimImplPass::runOnOperation() {
+  auto topModule = getOperation().getBody();
+  OpBuilder builder(topModule->getParentOp()->getContext());
+  builder.setInsertionPointToEnd(topModule);
+
+  SmallVector<rtl::RTLModuleGeneratedOp> toErase;
+
+  for (auto op : topModule->getOps<rtl::RTLModuleGeneratedOp>()) {
+    auto oldModule = cast<rtl::RTLModuleGeneratedOp>(op);
+    oldModule.dump();
+    auto gen = oldModule.generatorKind();
+    auto genOp = cast<rtl::RTLGeneratorSchemaOp>(
+        SymbolTable::lookupSymbolIn(getOperation(), gen));
+    genOp->dump();
+
+    if (genOp.descriptor() == "FIRRTL_Memory") {
+      llvm::errs() << "Found\n";
+      auto nameAttr = builder.getStringAttr(oldModule.getName());
+      auto newModule = builder.create<rtl::RTLModuleOp>(
+          oldModule.getLoc(), nameAttr, oldModule.getPorts());
+      generateMemory(newModule, oldModule);
+      toErase.push_back(oldModule);
+    }
+  }
+
+  for (auto m : toErase)
+    m.erase();
+}
+
+std::unique_ptr<Pass> circt::sv::createRTLMemSimImplPass() {
+  return std::make_unique<RTLMemSimImplPass>();
+}

--- a/lib/Dialect/SV/Transforms/RTLMemSimImpl.cpp
+++ b/lib/Dialect/SV/Transforms/RTLMemSimImpl.cpp
@@ -180,11 +180,9 @@ void RTLMemSimImplPass::runOnOperation() {
 
   for (auto op : topModule->getOps<rtl::RTLModuleGeneratedOp>()) {
     auto oldModule = cast<rtl::RTLModuleGeneratedOp>(op);
-    oldModule.dump();
     auto gen = oldModule.generatorKind();
     auto genOp = cast<rtl::RTLGeneratorSchemaOp>(
         SymbolTable::lookupSymbolIn(getOperation(), gen));
-    genOp->dump();
 
     if (genOp.descriptor() == "FIRRTL_Memory") {
       llvm::errs() << "Found\n";

--- a/lib/Dialect/SV/Transforms/RTLMemSimImpl.cpp
+++ b/lib/Dialect/SV/Transforms/RTLMemSimImpl.cpp
@@ -185,7 +185,6 @@ void RTLMemSimImplPass::runOnOperation() {
         SymbolTable::lookupSymbolIn(getOperation(), gen));
 
     if (genOp.descriptor() == "FIRRTL_Memory") {
-      llvm::errs() << "Found\n";
       auto nameAttr = builder.getStringAttr(oldModule.getName());
       auto newModule = builder.create<rtl::RTLModuleOp>(
           oldModule.getLoc(), nameAttr, oldModule.getPorts());

--- a/test/Dialect/SV/rtl-memsim.mlir
+++ b/test/Dialect/SV/rtl-memsim.mlir
@@ -56,4 +56,25 @@ rtl.module @simple(%clock: i1, %reset: i1, %r0en: i1, %mode: i1, %data0: i16) ->
 //CHECK-NEXT:  rtl.output %[[readres]], %[[rwres]]
 
 //CHECK-LABEL: @FIRRTLMem_1_1_1_16_10_2_4_0
-//CHECK:     %Memory = sv.reg  : !rtl.inout<uarray<10xi16>>
+//COM: This produces a lot of output, we check one field's pipeline
+//CHECK:         %Memory = sv.reg  : !rtl.inout<uarray<10xi16>>
+//CHECK:         sv.alwaysff(posedge %ro_clock_0)  {
+//CHECK-NEXT:      sv.passign %0, %ro_en_0 : i1
+//CHECK-NEXT:    }
+//CHECK-NEXT:    %1 = sv.read_inout %0 : !rtl.inout<i1>
+//CHECK-NEXT:    %2 = sv.reg  : !rtl.inout<i1>
+//CHECK-NEXT:    sv.alwaysff(posedge %ro_clock_0)  {
+//CHECK-NEXT:      sv.passign %2, %1 : i1
+//CHECK-NEXT:    }
+//CHECK-NEXT:    %3 = sv.read_inout %2 : !rtl.inout<i1>
+//CHECK-NEXT:    %4 = sv.reg  : !rtl.inout<i4>
+//CHECK-NEXT:    sv.alwaysff(posedge %ro_clock_0)  {
+//CHECK-NEXT:      sv.passign %4, %ro_addr_0 : i4
+//CHECK-NEXT:    }
+//CHECK-NEXT:    %5 = sv.read_inout %4 : !rtl.inout<i4>
+//CHECK-NEXT:    %6 = sv.reg  : !rtl.inout<i4>
+//CHECK-NEXT:    sv.alwaysff(posedge %ro_clock_0)  {
+//CHECK-NEXT:      sv.passign %6, %5 : i4
+//CHECK-NEXT:    }
+//CHECK-NEXT:    %7 = sv.read_inout %6 : !rtl.inout<i4>
+//CHECK-NEXT:    %8 = sv.array_index_inout %Memory[%7] : !rtl.inout<uarray<10xi16>>, i4

--- a/test/Dialect/SV/rtl-memsim.mlir
+++ b/test/Dialect/SV/rtl-memsim.mlir
@@ -1,0 +1,59 @@
+// RUN: circt-opt -rtl-memory-sim %s | FileCheck %s
+
+rtl.generator.schema @FIRRTLMem, "FIRRTL_Memory", ["depth", "numReadPorts", "numWritePorts", "numReadWritePorts", "readLatency", "writeLatency", "width", "readUnderWrite"]
+rtl.module.generated @FIRRTLMem_1_1_1_16_10_0_1_0, @FIRRTLMem(%ro_clock_0: i1, %ro_en_0: i1, %ro_addr_0: i4, %rw_clock_0: i1, %rw_en_0: i1, %rw_addr_0: i4, %rw_wmode_0: i1, %rw_wmask_0: i1, %rw_wdata_0: i16, %wo_clock_0: i1, %wo_en_0: i1, %wo_addr_0: i4, %wo_mask_0: i1, %wo_data_0: i16) -> (%ro_data_0: i16, %rw_rdata_0: i16) attributes {depth = 10 : i64, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : ui32, width = 16 : ui32, writeLatency = 1 : ui32}
+rtl.module.generated @FIRRTLMem_1_1_1_16_10_2_4_0, @FIRRTLMem(%ro_clock_0: i1, %ro_en_0: i1, %ro_addr_0: i4, %rw_clock_0: i1, %rw_en_0: i1, %rw_addr_0: i4, %rw_wmode_0: i1, %rw_wmask_0: i1, %rw_wdata_0: i16, %wo_clock_0: i1, %wo_en_0: i1, %wo_addr_0: i4, %wo_mask_0: i1, %wo_data_0: i16) -> (%ro_data_0: i16, %rw_rdata_0: i16) attributes {depth = 10 : i64, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 1 : ui32, readLatency = 2 : ui32, readUnderWrite = 0 : ui32, width = 16 : ui32, writeLatency = 4 : ui32}
+
+//CHECK-LABEL: @complex
+rtl.module @complex(%clock: i1, %reset: i1, %r0en: i1, %mode: i1, %data0: i16) -> (%data1: i16, %data2: i16) {
+  %true = rtl.constant true
+  %c0_i4 = rtl.constant 0 : i4
+  %tmp41.ro_data_0, %tmp41.rw_rdata_0 = rtl.instance "tmp41" @FIRRTLMem_1_1_1_16_10_2_4_0(%clock, %r0en, %c0_i4, %clock, %r0en, %c0_i4, %mode, %true, %data0, %clock, %r0en, %c0_i4, %true, %data0) : (i1, i1, i4, i1, i1, i4, i1, i1, i16, i1, i1, i4, i1, i16) -> (i16, i16)
+  rtl.output %tmp41.ro_data_0, %tmp41.rw_rdata_0 : i16, i16
+}
+
+//CHECK-LABEL: @simple
+rtl.module @simple(%clock: i1, %reset: i1, %r0en: i1, %mode: i1, %data0: i16) -> (%data1: i16, %data2: i16) {
+  %true = rtl.constant true
+  %c0_i4 = rtl.constant 0 : i4
+  %tmp41.ro_data_0, %tmp41.rw_rdata_0 = rtl.instance "tmp41" @FIRRTLMem_1_1_1_16_10_0_1_0(%clock, %r0en, %c0_i4, %clock, %r0en, %c0_i4, %mode, %true, %data0, %clock, %r0en, %c0_i4, %true, %data0) : (i1, i1, i4, i1, i1, i4, i1, i1, i16, i1, i1, i4, i1, i16) -> (i16, i16)
+  rtl.output %tmp41.ro_data_0, %tmp41.rw_rdata_0 : i16, i16
+}
+
+//CHECK-LABEL: @FIRRTLMem_1_1_1_16_10_0_1_0
+//CHECK:       %Memory = sv.reg  : !rtl.inout<uarray<10xi16>>
+//CHECK-NEXT:  %[[rslot:.+]] = sv.array_index_inout %Memory[%ro_addr_0]
+//CHECK-NEXT:  %[[read:.+]] = sv.read_inout %[[rslot]]
+//CHECK-NEXT:  %[[x:.+]] = sv.constantX
+//CHECK-NEXT:  %[[readres:.+]] = comb.mux %ro_en_0, %[[read]], %[[x]]
+//CHECK-NEXT:  %[[rwtmp:.+]] = sv.wire
+//CHECK-NEXT:  %[[rwres:.+]] = sv.read_inout %[[rwtmp]]
+//CHECK-NEXT:    sv.alwaysff(posedge %rw_clock_0)  {
+//CHECK-NEXT:      %[[rwslot:.+]] = sv.array_index_inout %Memory[%rw_addr_0] 
+//CHECK-NEXT:      %false = rtl.constant false
+//CHECK-NEXT:      %[[rwrcondpre:.+]] = comb.icmp eq %rw_wmode_0, %false
+//CHECK-NEXT:      %[[rwrcond:.+]] = comb.and %rw_en_0, %[[rwrcondpre]]
+//CHECK-NEXT:      %[[rwwcondpre:.+]] = comb.and %rw_wmask_0, %rw_wmode_0
+//CHECK-NEXT:      %[[rwwcond:.+]] = comb.and %rw_en_0, %[[rwwcondpre]]
+//CHECK-NEXT:      %[[x2:.+]] = sv.constantX
+//CHECK-NEXT:      sv.passign %[[rwtmp]], %[[x2]]
+//CHECK-NEXT:      sv.if %[[rwwcond]]  {
+//CHECK-NEXT:        sv.passign %[[rwslot]], %rw_wdata_0
+//CHECK-NEXT:      } else  {
+//CHECK-NEXT:        sv.if %[[rwrcond]]  {
+//CHECK-NEXT:          %[[rwdata:.+]] = sv.read_inout %[[rwslot]]
+//CHECK-NEXT:          sv.passign %[[rwtmp]], %[[rwdata]]
+//CHECK-NEXT:        }
+//CHECK-NEXT:      }
+//CHECK-NEXT:    }
+//CHECK-NEXT:  sv.alwaysff(posedge %wo_clock_0)  {
+//CHECK-NEXT:    %[[wcond:.+]] = comb.and %wo_en_0, %wo_mask_0
+//CHECK-NEXT:    sv.if %[[wcond]]  {
+//CHECK-NEXT:      %[[wslot:.+]] = sv.array_index_inout %Memory[%wo_addr_0]
+//CHECK-NEXT:      sv.passign %[[wslot]], %wo_data_0
+//CHECK-NEXT:    }
+//CHECK-NEXT:  }
+//CHECK-NEXT:  rtl.output %[[readres]], %[[rwres]]
+
+//CHECK-LABEL: @FIRRTLMem_1_1_1_16_10_2_4_0
+//CHECK:     %Memory = sv.reg  : !rtl.inout<uarray<10xi16>>


### PR DESCRIPTION
Lower firrtl memory generator nodes into a simulation model.  This implements the code in LowerToRTL as a separate pass in preparation for converging lowering to generate generator modules.