### PR TITLE
[firtool] Change command line options for passes

### DIFF
--- a/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
+++ b/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
@@ -1516,7 +1516,7 @@ LogicalResult FIRRTLLowering::visitDecl(MemOp op) {
     return op.emitOpError(
         "should have already been lowered from a ground type to an aggregate "
         "type using the LowerTypes pass. Use "
-        "'firtool --enable-lower-types' or 'circt-opt "
+        "'firtool --lower-types' or 'circt-opt "
         "--pass-pipeline='firrtl.circuit(firrtl-lower-types)' "
         "to run this.");
 

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -106,7 +106,7 @@ struct LoweringOptionsParser : public llvm::cl::parser<LoweringOptions> {
 /// the command line arguments in multiple tools.
 struct LoweringCLOptions {
   llvm::cl::opt<LoweringOptions, false, LoweringOptionsParser> loweringOptions{
-      "circt-lowering-options", llvm::cl::desc("Style options"),
+      "lowering-options", llvm::cl::desc("Style options"),
       llvm::cl::value_desc("option")};
 };
 } // namespace

--- a/test/ExportVerilog/line-length.mlir
+++ b/test/ExportVerilog/line-length.mlir
@@ -1,6 +1,6 @@
-// RUN: circt-translate --circt-lowering-options=emittedLineLength=40 --export-verilog %s | FileCheck %s --check-prefix=SHORT
+// RUN: circt-translate --lowering-options=emittedLineLength=40 --export-verilog %s | FileCheck %s --check-prefix=SHORT
 // RUN: circt-translate  --export-verilog %s | FileCheck %s --check-prefix=DEFAULT
-// RUN: circt-translate --circt-lowering-options=emittedLineLength=180 --export-verilog %s | FileCheck %s --check-prefix=LONG
+// RUN: circt-translate --lowering-options=emittedLineLength=180 --export-verilog %s | FileCheck %s --check-prefix=LONG
 
 rtl.module @longvariadic(%a: i8) -> (%b: i8) {
   %1 = comb.add %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a,

--- a/test/ExportVerilog/sv-alwaysff.mlir
+++ b/test/ExportVerilog/sv-alwaysff.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-translate --split-input-file --export-verilog %s | FileCheck %s --check-prefix=DEFAULT
-// RUN: circt-translate --circt-lowering-options= --split-input-file --export-verilog %s | FileCheck %s --check-prefix=CLEAR
-// RUN: circt-translate --circt-lowering-options=noAlwaysFF --split-input-file --export-verilog %s | FileCheck %s --check-prefix=NOALWAYSFF
+// RUN: circt-translate --lowering-options= --split-input-file --export-verilog %s | FileCheck %s --check-prefix=CLEAR
+// RUN: circt-translate --lowering-options=noAlwaysFF --split-input-file --export-verilog %s | FileCheck %s --check-prefix=NOALWAYSFF
 
 rtl.module @test(%clock : i1, %cond : i1) {
   sv.alwaysff(posedge %clock) {

--- a/test/circt-translate/commandline.mlir
+++ b/test/circt-translate/commandline.mlir
@@ -2,9 +2,9 @@
 
 // CHECK: OVERVIEW: CIRCT Translation Testing Tool
 
-// CHECK: --circt-lowering-options=<value>
-
 // CHECK: Translation to perform
 // CHECK: --export-llhd-verilog
 // CHECK: --export-verilog
 // CHECK: --import-firrtl
+
+// CHECK: --lowering-options=<value>

--- a/test/firtool/commandline.mlir
+++ b/test/firtool/commandline.mlir
@@ -1,4 +1,4 @@
 // RUN: firtool --help | FileCheck %s
 //
 // CHECK: OVERVIEW: circt modular optimizer drive
-// CHECK: --circt-lowering-options=
+// CHECK: --lowering-options=

--- a/test/firtool/phase-ordering.fir
+++ b/test/firtool/phase-ordering.fir
@@ -1,4 +1,4 @@
-; RUN: firtool %s --format=fir -enable-lower-types | FileCheck %s
+; RUN: firtool %s --format=fir -lower-types | FileCheck %s
 
 ; Temporary wires should not be introduced by type lowering, and if they are,
 ; they should be cleaned up by canonicalize.

--- a/test/firtool/style.fir
+++ b/test/firtool/style.fir
@@ -1,10 +1,10 @@
 ; RUN: firtool %s | FileCheck %s --check-prefix=DEFAULT
-; RUN: not firtool --circt-lowering-options=bad-option %s 2>&1 | FileCheck %s --check-prefix=BADOPTION
-; RUN: firtool --circt-lowering-options=noAlwaysFF %s | FileCheck %s --check-prefix=NOALWAYSFF
+; RUN: not firtool --lowering-options=bad-option %s 2>&1 | FileCheck %s --check-prefix=BADOPTION
+; RUN: firtool --lowering-options=noAlwaysFF %s | FileCheck %s --check-prefix=NOALWAYSFF
 
 circuit test :
   module test :
 
 ; DEFAULT: module {
-; BADOPTION: circt-lowering-options option: unknown style option 'bad-option'
+; BADOPTION: lowering-options option: unknown style option 'bad-option'
 ; NOALWAYSFF: module attributes {circt.loweringOptions = "noAlwaysFF"} {

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -72,7 +72,7 @@ static cl::opt<bool> imconstprop(
     cl::init(false));
 
 static cl::opt<bool>
-    enableLowerTypes("enable-lower-types",
+    enableLowerTypes("lower-types",
                      cl::desc("run the lower-types pass within lower-to-rtl"),
                      cl::init(false));
 


### PR DESCRIPTION
This changes the `--enable-lower-types` flag to `--lower-types` and it
changes `--circt-lowering-options` to `--lowering-options`.