### PR TITLE
[FIRRTL] Use operand type to determine sign for const folding

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -108,6 +108,7 @@ constFoldFIRRTLBinaryOp(Operation *op, ArrayRef<Attribute> operands,
   IntegerAttr rhs = elideZeroWidthFoldOperand(op->getOperand(1), operands[1]);
   if (!lhs || !rhs)
     return {};
+  auto srcType = op->getOperandTypes().front().cast<IntType>();
   auto dstType = op->getResultTypes().front().cast<IntType>();
   auto dstWidth = dstType.getBitWidthOrSentinel();
   auto commonWidth = useDstWidth
@@ -115,7 +116,7 @@ constFoldFIRRTLBinaryOp(Operation *op, ArrayRef<Attribute> operands,
                          : std::max<int32_t>(lhs.getValue().getBitWidth(),
                                              rhs.getValue().getBitWidth());
   auto extOrSelf =
-      dstType.isUnsigned() ? &APInt::zextOrTrunc : &APInt::sextOrTrunc;
+      srcType.isUnsigned() ? &APInt::zextOrTrunc : &APInt::sextOrTrunc;
   return IntegerAttr::get(IntegerType::get(lhs.getContext(), dstWidth),
                           calculate((lhs.getValue().*extOrSelf)(commonWidth),
                                     (rhs.getValue().*extOrSelf)(commonWidth)));

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -1145,6 +1145,93 @@ firrtl.module @ComparisonOfZeroWidths(
   // CHECK-NEXT: firrtl.connect %y10, %c0_ui1
   // CHECK-NEXT: firrtl.connect %y11, %c0_ui1
 }
+
+// CHECK-LABEL: @ComparisonOfConsts
+firrtl.module @ComparisonOfConsts(
+  %y0: !firrtl.flip<uint<1>>,
+  %y1: !firrtl.flip<uint<1>>,
+  %y2: !firrtl.flip<uint<1>>,
+  %y3: !firrtl.flip<uint<1>>,
+  %y4: !firrtl.flip<uint<1>>,
+  %y5: !firrtl.flip<uint<1>>,
+  %y6: !firrtl.flip<uint<1>>,
+  %y7: !firrtl.flip<uint<1>>,
+  %y8: !firrtl.flip<uint<1>>,
+  %y9: !firrtl.flip<uint<1>>,
+  %y10: !firrtl.flip<uint<1>>,
+  %y11: !firrtl.flip<uint<1>>,
+  %y12: !firrtl.flip<uint<1>>,
+  %y13: !firrtl.flip<uint<1>>,
+  %y14: !firrtl.flip<uint<1>>,
+  %y15: !firrtl.flip<uint<1>>,
+  %y16: !firrtl.flip<uint<1>>,
+  %y17: !firrtl.flip<uint<1>>,
+  %y18: !firrtl.flip<uint<1>>,
+  %y19: !firrtl.flip<uint<1>>,
+  %y20: !firrtl.flip<uint<1>>,
+  %y21: !firrtl.flip<uint<1>>,
+  %y22: !firrtl.flip<uint<1>>,
+  %y23: !firrtl.flip<uint<1>>
+) {
+  %c2_si4 = firrtl.constant(2 : i4) : !firrtl.sint<4>
+  %c-3_si3 = firrtl.constant(-3 : i3) : !firrtl.sint<3>
+  %c2_ui4 = firrtl.constant(2 : i4) : !firrtl.uint<4>
+  %c5_ui3 = firrtl.constant(5 : i3) : !firrtl.uint<3>
+
+  // CHECK-NEXT: [[_:.+]] = firrtl.constant
+  // CHECK-NEXT: [[_:.+]] = firrtl.constant
+
+  %0 = firrtl.leq %c2_si4, %c-3_si3 : (!firrtl.sint<4>, !firrtl.sint<3>) -> !firrtl.uint<1>
+  %1 = firrtl.leq %c-3_si3, %c2_si4 : (!firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.uint<1>
+  %2 = firrtl.leq %c2_ui4, %c5_ui3 : (!firrtl.uint<4>, !firrtl.uint<3>) -> !firrtl.uint<1>
+  %3 = firrtl.leq %c5_ui3, %c2_ui4 : (!firrtl.uint<3>, !firrtl.uint<4>) -> !firrtl.uint<1>
+  %4 = firrtl.lt %c2_si4, %c-3_si3 : (!firrtl.sint<4>, !firrtl.sint<3>) -> !firrtl.uint<1>
+  %5 = firrtl.lt %c-3_si3, %c2_si4 : (!firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.uint<1>
+  %6 = firrtl.lt %c2_ui4, %c5_ui3 : (!firrtl.uint<4>, !firrtl.uint<3>) -> !firrtl.uint<1>
+  %7 = firrtl.lt %c5_ui3, %c2_ui4 : (!firrtl.uint<3>, !firrtl.uint<4>) -> !firrtl.uint<1>
+  %8 = firrtl.geq %c2_si4, %c-3_si3 : (!firrtl.sint<4>, !firrtl.sint<3>) -> !firrtl.uint<1>
+  %9 = firrtl.geq %c-3_si3, %c2_si4 : (!firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.uint<1>
+  %10 = firrtl.geq %c2_ui4, %c5_ui3 : (!firrtl.uint<4>, !firrtl.uint<3>) -> !firrtl.uint<1>
+  %11 = firrtl.geq %c5_ui3, %c2_ui4 : (!firrtl.uint<3>, !firrtl.uint<4>) -> !firrtl.uint<1>
+  %12 = firrtl.gt %c2_si4, %c-3_si3 : (!firrtl.sint<4>, !firrtl.sint<3>) -> !firrtl.uint<1>
+  %13 = firrtl.gt %c-3_si3, %c2_si4 : (!firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.uint<1>
+  %14 = firrtl.gt %c2_ui4, %c5_ui3 : (!firrtl.uint<4>, !firrtl.uint<3>) -> !firrtl.uint<1>
+  %15 = firrtl.gt %c5_ui3, %c2_ui4 : (!firrtl.uint<3>, !firrtl.uint<4>) -> !firrtl.uint<1>
+
+  firrtl.connect %y0, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y1, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y2, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y3, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y4, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y5, %5 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y6, %6 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y7, %7 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y8, %8 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y9, %9 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y10, %10 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y11, %11 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y12, %12 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y13, %13 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y14, %14 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y15, %15 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.connect %y0, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y1, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y2, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y3, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y4, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y5, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y6, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y7, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y8, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y9, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y10, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y11, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y12, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y13, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y14, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y15, %c1_ui1
+}
+
 // CHECK-LABEL: @add_cst_prop1
 // CHECK-NEXT:   %c11_ui9 = firrtl.constant(11 : i9) : !firrtl.uint<9>
 // CHECK-NEXT:   firrtl.connect %out_b, %c11_ui9 : !firrtl.flip<uint<9>>, !firrtl.uint<9>


### PR DESCRIPTION
Use the operand types instead of the operation's result type when deciding whether to perform sign or zero extension of constants for folding. This is important for comparison operators, where the result type is always `uint<1>`, yet signed operands should be sign-extended. Fixes #912.