### PR TITLE
[FIRRTL] Add black box source helper pass

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -13,6 +13,7 @@
 #ifndef CIRCT_DIALECT_FIRRTL_PASSES_H
 #define CIRCT_DIALECT_FIRRTL_PASSES_H
 
+#include "llvm/ADT/Optional.h"
 #include <memory>
 
 namespace mlir {
@@ -35,6 +36,10 @@ std::unique_ptr<mlir::Pass> createExpandWhensPass();
 std::unique_ptr<mlir::Pass> createCheckWidthsPass();
 
 std::unique_ptr<mlir::Pass> createInferWidthsPass();
+
+std::unique_ptr<mlir::Pass>
+createBlackBoxReaderPass(llvm::Optional<StringRef> inputPrefix = {},
+                         llvm::Optional<StringRef> resourcePrefix = {});
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -111,4 +111,67 @@ def InferWidths : Pass<"firrtl-infer-widths", "firrtl::CircuitOp"> {
   let constructor = "circt::firrtl::createInferWidthsPass()";
 }
 
+def BlackBoxReader : Pass<"firrtl-blackbox-reader", "CircuitOp"> {
+  let summary = "Load source files for black boxes into the IR";
+  let description = [{
+    This pass handles reads the Verilog source files for black boxes and adds
+    them as `sv.verbatim.file` operations into the IR. Later passes can then
+    write these files back to disk to ensure that they can be accessed by other
+    tools down the line in a well-known location. Supports inline, resource, and
+    path annotations for black box source files.
+
+    The supported `firrtl.circuit` annotations are:
+
+    - `{class = "firrtl.transforms.BlackBoxTargetDirAnno", targetDir = "..."}`
+      Overrides the target directory into which black box source files are
+      emitted.
+    - `{class = "firrtl.transforms.BlackBoxResourceFileNameAnno", resourceFileName = "xyz.f"}`
+      Specifies the output file name for the list of black box source files that
+      is generated as a collateral of the pass.
+
+    The supported `firrtl.extmodule` annotations are:
+
+    - ```
+      {
+        class = "firrtl.transforms.BlackBoxInlineAnno",
+        name = "myfile.v",
+        text = "..."
+      }
+      ```
+      Specifies the black box source code (`text`) inline. Generates a file with
+      the given `name` in the target directory.
+    - ```
+      {
+        class = "firrtl.transforms.BlackBoxPathAnno",
+        path = "myfile.v"
+      }
+      ```
+      Specifies the file `path` as source code for the module. Copies the file
+      to the target directory.
+    - ```
+      {
+        class = "firrtl.transforms.BlackBoxResourceAnno",
+        resourceId = "myfile.v"
+      }
+      ```
+      Specifies the file `path` as source code for the module. In contrast to
+      the `BlackBoxPathAnno`, the file is searched for in the black box resource
+      search path. This is a remnant of the Scala origins of FIRRTL. Copies the
+      file to the target directory.
+  }];
+
+  let constructor = "circt::firrtl::createBlackBoxReaderPass()";
+  let options = [
+    Option<"inputPrefix", "input-prefix", "std::string", "",
+      "Prefix for input paths in black box annotations. This should be the "
+      "directory where the input file was located, to allow for annotations "
+      "relative to the input file.">,
+    Option<"resourcePrefix", "resource-prefix", "std::string",
+      "\"src/main/resources\"",
+      "Search path for black box sources specified via the "
+      "`BlackBoxResourceAnno` annotation.">
+  ];
+  let dependentDialects = ["sv::SVDialect"];
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_PASSES_TD

--- a/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
@@ -1,0 +1,292 @@
+//===- BlackBoxReader.cpp - Ingest black box sources ------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//===----------------------------------------------------------------------===//
+//
+// Read Verilog source files for black boxes based on corresponding black box
+// annotations on the circuit and modules. Primarily based on:
+//
+// https://github.com/chipsalliance/firrtl/blob/master/src/main/scala/firrtl/
+// transforms/BlackBoxSourceHelper.scala
+//
+//===----------------------------------------------------------------------===//
+
+#include "./PassDetails.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "circt/Dialect/HW/HWDialect.h"
+#include "circt/Dialect/SV/SVOps.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/Support/FileUtilities.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Path.h"
+
+#define DEBUG_TYPE "firrtl-blackbox-reader"
+
+using namespace circt;
+using namespace firrtl;
+
+using hw::OutputFileAttr;
+using sv::VerbatimOp;
+
+/// Append a path to an existing path, replacing it if the other path is
+/// absolute. This mimicks the behaviour of `foo/bar` and `/foo/bar` being used
+/// in a working directory `/home`, resulting in `/home/foo/bar` and `/foo/bar`,
+/// respectively.
+static void appendPossiblyAbsolutePath(SmallVectorImpl<char> &base,
+                                       const Twine &suffix) {
+  if (llvm::sys::path::is_absolute(suffix)) {
+    base.clear();
+    suffix.toVector(base);
+  } else {
+    llvm::sys::path::append(base, suffix);
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Pass Implementation
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct EmittedFile {
+  VerbatimOp op;
+  StringAttr fileName;
+};
+
+struct BlackBoxReaderPass : public BlackBoxReaderBase<BlackBoxReaderPass> {
+  void runOnOperation() override;
+  void runOnAnnotation(Operation *op, DictionaryAttr anno, OpBuilder &builder);
+  void loadFile(Operation *op, StringRef inputPath, OpBuilder &builder);
+
+  using BlackBoxReaderBase::inputPrefix;
+  using BlackBoxReaderBase::resourcePrefix;
+
+private:
+  /// The generated `sv.verbatim` nodes.
+  SmallVector<EmittedFile, 8> emittedFiles;
+
+  /// The target directory to output black boxes into. Can be changed
+  /// through `firrtl.transforms.BlackBoxTargetDirAnno` annotations.
+  SmallString<128> targetDir;
+
+  /// The file list file name (sic) for black boxes. If set, generates a file
+  /// that lists all non-header source files for black boxes. Can be changed
+  /// through `firrtl.transforms.BlackBoxResourceFileNameAnno` annotations.
+  SmallString<128> resourceFileName;
+
+  // Internalized annotation class names for fast comparison.
+  StringAttr targetDirAnnoClass;
+  StringAttr resourceFileNameAnnoClass;
+  StringAttr inlineAnnoClass;
+  StringAttr pathAnnoClass;
+  StringAttr resourceAnnoClass;
+};
+} // end anonymous namespace
+
+/// Emit the annotated source code for black boxes in a circuit.
+void BlackBoxReaderPass::runOnOperation() {
+  CircuitOp circuitOp = getOperation();
+
+  // Internalize some string attributes for easy reference later.
+  auto cx = &getContext();
+  targetDirAnnoClass =
+      StringAttr::get(cx, "firrtl.transforms.BlackBoxTargetDirAnno");
+  resourceFileNameAnnoClass =
+      StringAttr::get(cx, "firrtl.transforms.BlackBoxResourceFileNameAnno");
+  inlineAnnoClass = StringAttr::get(cx, "firrtl.transforms.BlackBoxInlineAnno");
+  pathAnnoClass = StringAttr::get(cx, "firrtl.transforms.BlackBoxPathAnno");
+  resourceAnnoClass =
+      StringAttr::get(cx, "firrtl.transforms.BlackBoxResourceAnno");
+
+  // Determine the target directory and resource file name from the
+  // annotations present on the circuit operation.
+  targetDir = ".";
+  resourceFileName = "firrtl_black_box_resource_files.f";
+
+  if (auto attrs = circuitOp->getAttrOfType<ArrayAttr>("annotations")) {
+    for (auto attr : attrs) {
+      auto anno = attr.dyn_cast<DictionaryAttr>();
+      if (!anno)
+        continue;
+      auto cls = anno.getAs<StringAttr>("class");
+
+      // Handle target dir annotation.
+      if (cls == targetDirAnnoClass) {
+        auto x = anno.getAs<StringAttr>("targetDir");
+        if (!x) {
+          circuitOp->emitError(targetDirAnnoClass.getValue() +
+                               " annotation missing \"targetDir\" attribute");
+          signalPassFailure();
+          continue;
+        }
+        targetDir = x.getValue();
+        continue;
+      }
+
+      // Handle resource file name annotation.
+      if (cls == resourceFileNameAnnoClass) {
+        auto x = anno.getAs<StringAttr>("resourceFileName");
+        if (!x) {
+          circuitOp->emitError(
+              resourceFileNameAnnoClass.getValue() +
+              " annotation missing \"resourceFileName\" attribute");
+          signalPassFailure();
+          continue;
+        }
+        resourceFileName = x.getValue();
+        continue;
+      }
+    }
+  }
+
+  LLVM_DEBUG(llvm::dbgs() << "Black box target directory: " << targetDir << "\n"
+                          << "Black box resource file name: "
+                          << resourceFileName << "\n");
+
+  // Gather the relevant annotations on all modules in the circuit.
+  OpBuilder builder(&getContext());
+  builder.setInsertionPointToEnd(getOperation()->getBlock());
+
+  for (auto &op : *circuitOp.getBody()) {
+    if (!isa<FModuleOp>(op) && !isa<FExtModuleOp>(op))
+      continue;
+    if (auto attrs = op.getAttrOfType<ArrayAttr>("annotations")) {
+      for (auto attr : attrs) {
+        if (auto anno = attr.dyn_cast<DictionaryAttr>())
+          runOnAnnotation(&op, anno, builder);
+      }
+    }
+  }
+
+  // If we have emitted any files, generate a file list operation that
+  // documents the additional annotation-controlled file listing to be
+  // created.
+  if (!emittedFiles.empty()) {
+    auto trueAttr = BoolAttr::get(cx, true);
+    std::string output;
+    llvm::raw_string_ostream os(output);
+    for (auto &file : emittedFiles) {
+      const auto &fileName = file.fileName.getValue();
+      // Exclude Verilog header files since we expect them to be included
+      // explicitly by compiler directives in other source files.
+      auto ext = llvm::sys::path::extension(fileName);
+      bool exclude = (ext == ".h" || ext == ".vh" || ext == ".svh");
+      file.op->setAttr(
+          "output_file",
+          OutputFileAttr::get(file.fileName, BoolAttr::get(cx, exclude),
+                              /*exclude_replicated_ops=*/trueAttr, cx));
+      if (!exclude)
+        os << fileName << "\n";
+    }
+    auto op =
+        builder.create<VerbatimOp>(circuitOp->getLoc(), std::move(output));
+    op->setAttr("output_file",
+                OutputFileAttr::get(StringAttr::get(cx, resourceFileName),
+                                    /*exclude_from_filelist=*/trueAttr,
+                                    /*exclude_replicated_ops=*/trueAttr, cx));
+  }
+
+  // Clean up.
+  emittedFiles.clear();
+}
+
+/// Run on an operation annotated with a black box annotation.
+void BlackBoxReaderPass::runOnAnnotation(Operation *op, DictionaryAttr anno,
+                                         OpBuilder &builder) {
+  auto cls = anno.getAs<StringAttr>("class");
+
+  // Handle inline annotation.
+  if (cls == inlineAnnoClass) {
+    auto name = anno.getAs<StringAttr>("name");
+    auto text = anno.getAs<StringAttr>("text");
+    if (!name || !text) {
+      op->emitError(inlineAnnoClass.getValue() +
+                    " annotation missing \"name\" or \"text\" attribute");
+      signalPassFailure();
+      return;
+    }
+
+    // Determine output path.
+    SmallString<128> outputPath(targetDir);
+    llvm::sys::path::append(outputPath, name.getValue());
+    LLVM_DEBUG(llvm::dbgs()
+               << "Add black box source `" << outputPath << "` inline\n");
+
+    // Create an IR node to hold the contents.
+    emittedFiles.push_back({builder.create<VerbatimOp>(op->getLoc(), text),
+                            builder.getStringAttr(outputPath)});
+    return;
+  }
+
+  // Handle path annotation.
+  if (cls == pathAnnoClass) {
+    auto path = anno.getAs<StringAttr>("path");
+    if (!path) {
+      op->emitError(pathAnnoClass.getValue() +
+                    " annotation missing \"path\" attribute");
+      signalPassFailure();
+      return;
+    }
+    SmallString<128> inputPath(inputPrefix);
+    appendPossiblyAbsolutePath(inputPath, path.getValue());
+    return loadFile(op, inputPath, builder);
+  }
+
+  // Handle resource annotation.
+  if (cls == resourceAnnoClass) {
+    auto resourceId = anno.getAs<StringAttr>("resourceId");
+    if (!resourceId) {
+      op->emitError(pathAnnoClass.getValue() +
+                    " annotation missing \"resourceId\" attribute");
+      signalPassFailure();
+      return;
+    }
+    SmallString<128> inputPath(inputPrefix);
+    appendPossiblyAbsolutePath(inputPath, resourcePrefix);
+    // Note that we always treat `resourceId` as a relative path, as the
+    // previous Scala implementation tended to emit `/foo.v` as resourceId.
+    llvm::sys::path::append(inputPath, resourceId.getValue());
+    return loadFile(op, inputPath, builder);
+  }
+}
+
+/// Copies a black box source file to the appropriate location in the target
+/// directory.
+void BlackBoxReaderPass::loadFile(Operation *op, StringRef inputPath,
+                                  OpBuilder &builder) {
+  SmallString<128> outputPath(targetDir);
+  llvm::sys::path::append(outputPath, llvm::sys::path::filename(inputPath));
+  LLVM_DEBUG(llvm::dbgs() << "Add black box source `" << outputPath
+                          << "` from `" << inputPath << "`\n");
+
+  // Open and read the input file.
+  std::string errorMessage;
+  auto input = mlir::openInputFile(inputPath, &errorMessage);
+  if (!input) {
+    op->emitError(errorMessage);
+    signalPassFailure();
+    return;
+  }
+
+  // Create an IR node to hold the contents.
+  emittedFiles.push_back(
+      {builder.create<VerbatimOp>(op->getLoc(), input->getBuffer()),
+       builder.getStringAttr(outputPath)});
+}
+
+//===----------------------------------------------------------------------===//
+// Pass Creation
+//===----------------------------------------------------------------------===//
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createBlackBoxReaderPass(
+    llvm::Optional<StringRef> inputPrefix,
+    llvm::Optional<StringRef> resourcePrefix) {
+  auto pass = std::make_unique<BlackBoxReaderPass>();
+  if (inputPrefix)
+    pass->inputPrefix = inputPrefix->str();
+  if (resourcePrefix)
+    pass->resourcePrefix = resourcePrefix->str();
+  return pass;
+}

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_circt_dialect_library(CIRCTFIRRTLTransforms
+  BlackBoxReader.cpp
   BlackboxMemory.cpp
   CheckWidths.cpp
   ExpandWhens.cpp
@@ -12,6 +13,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
 
   LINK_LIBS PUBLIC
   CIRCTFIRRTL
+  CIRCTSV
   MLIRIR
   MLIRPass
   MLIRTransformUtils

--- a/lib/Dialect/FIRRTL/Transforms/PassDetails.h
+++ b/lib/Dialect/FIRRTL/Transforms/PassDetails.h
@@ -17,6 +17,7 @@
 #define DIALECT_FIRRTL_TRANSFORMS_PASSDETAILS_H
 
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/SV/SVDialect.h"
 #include "mlir/Pass/Pass.h"
 
 namespace circt {

--- a/test/firtool/blackbox-path.v
+++ b/test/firtool/blackbox-path.v
@@ -1,0 +1,1 @@
+module ExtPath(); endmodule

--- a/test/firtool/blackbox-resource.v
+++ b/test/firtool/blackbox-resource.v
@@ -1,0 +1,1 @@
+module ExtResource(); endmodule

--- a/test/firtool/blackbox.mlir
+++ b/test/firtool/blackbox.mlir
@@ -1,0 +1,62 @@
+// RUN: firtool %s --format=mlir --split-verilog -o=%t
+// RUN: FileCheck %s --check-prefix=VERILOG-TOP < %t/test_mod.sv
+// RUN: FileCheck %s --check-prefix=VERILOG-FOO < %t/magic/blackbox-inline.v
+// RUN: FileCheck %s --check-prefix=VERILOG-HDR < %t/magic/blackbox-inline.svh
+// RUN: FileCheck %s --check-prefix=VERILOG-BAR < %t/magic/blackbox-resource.v
+// RUN: FileCheck %s --check-prefix=VERILOG-GIB < %t/magic/blackbox-path.v
+// RUN: FileCheck %s --check-prefix=LIST-TOP < %t/filelist.f
+// RUN: FileCheck %s --check-prefix=LIST-BLACK-BOX < %t/magic.f
+
+// LIST-TOP: test_mod.sv
+
+// LIST-BLACK-BOX:      magic/blackbox-inline.v
+// LIST-BLACK-BOX-NEXT: magic/blackbox-resource.v
+// LIST-BLACK-BOX-NEXT: magic/blackbox-path.v
+
+firrtl.circuit "test_mod" attributes {annotations = [
+  // Black box processing should honor only the last annotation.
+  {class = "firrtl.transforms.BlackBoxTargetDirAnno", targetDir = "ignore_me_plz"},
+  {class = "firrtl.transforms.BlackBoxTargetDirAnno", targetDir = "magic"},
+  {class = "firrtl.transforms.BlackBoxResourceFileNameAnno", resourceFileName = "definitely_bad.f"},
+  {class = "firrtl.transforms.BlackBoxResourceFileNameAnno", resourceFileName = "magic.f"}
+]} {
+  // VERILOG-TOP-LABEL: module test_mod
+  // VERILOG-TOP-NEXT:    ExtInline foo
+  // VERILOG-TOP-NEXT:    ExtResource bar
+  // VERILOG-TOP-NEXT:    ExtPath gib
+  // VERILOG-TOP-NEXT:  endmodule
+  firrtl.module @test_mod() {
+    firrtl.instance @ExtInline {name = "foo", portNames = []}
+    firrtl.instance @ExtResource {name = "bar", portNames = []}
+    firrtl.instance @ExtPath {name = "gib", portNames = []}
+  }
+
+  // VERILOG-FOO-LABEL: module ExtInline(); endmodule
+  // VERILOG-HDR-LABEL: `define SOME_MACRO
+  firrtl.extmodule @ExtInline() attributes {annotations = [
+    // Both files shall be emitted, but the Verilog header `*.svh` shall be
+    // excluded from the file list.
+    {
+      class = "firrtl.transforms.BlackBoxInlineAnno",
+      name = "blackbox-inline.v",
+      text = "module ExtInline(); endmodule\n"
+    },
+    {
+      class = "firrtl.transforms.BlackBoxInlineAnno",
+      name = "blackbox-inline.svh",
+      text = "`define SOME_MACRO\n"
+    }
+  ]}
+
+  // VERILOG-BAR-LABEL: module ExtResource(); endmodule
+  firrtl.extmodule @ExtResource() attributes {annotations = [{
+    class = "firrtl.transforms.BlackBoxResourceAnno",
+    resourceId = "blackbox-resource.v"
+  }]}
+
+  // VERILOG-GIB-LABEL: module ExtPath(); endmodule
+  firrtl.extmodule @ExtPath() attributes {annotations = [{
+    class = "firrtl.transforms.BlackBoxPathAnno",
+    path = "blackbox-path.v"
+  }]}
+}

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -35,6 +35,7 @@
 #include "mlir/Transforms/Passes.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/ToolOutputFile.h"
 
@@ -209,6 +210,10 @@ processBuffer(std::unique_ptr<llvm::MemoryBuffer> ownedBuffer,
 
   if (blackboxMemory)
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createBlackBoxMemoryPass());
+
+  // Read black box source files into the IR.
+  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createBlackBoxReaderPass(
+      llvm::sys::path::parent_path(inputFilename), {""}));
 
   // Lower if we are going to verilog or if lowering was specifically requested.
   if (lowerToHW || outputFormat == OutputVerilog ||


### PR DESCRIPTION
This PR does the following:

* Add the `BlackBoxSourceHelper` transformation pass which is modeled after the corresponding Scala implementation. It honors a set of FIRRTL annotations that declare source code for black boxes to be copied to an output directory. This can be done inline, as a separate path, or the rather Java-specific resource mechanism.

I tried to stay faithful to the original Scala implementation. Since the pass interacts with additional files specified by the user in the input source, I added the ability to make it treat input files relative to some path (usually the directory around the input FIR file) and output files relative to some path (usually the output directory for split Verilog). This should remove a lot of confusion by making the operation invariant to the current working directory.

I'm pretty sure my handling of the additional options/arguments to the pass is not very idiomatic LLVM code. The pass specifies an `input-prefix`, `output-prefix`, and `resource-prefix` option. These are generated as part of the pass `...Base`, but I'm not sure how something like `firtool` is supposed to configure these programmatically. I'm aware of the nice `--pass-pipeline=foo{x=y}` syntax that allows the user to configure things, but what if the tool needs to set the options based on some other user input (input and output file names in this case)?

The original Scala implementation is here: https://github.com/chipsalliance/firrtl/blob/master/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala

### Todo
- [x] Incorporate #953
- [x] Incorporate #973