### PR TITLE
[FIRRTL] Make Circuit, FModule and When noterminator ops

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -142,8 +142,8 @@ def CoverOp : FIRRTLOp<"cover"> {
     "$clock `,` $predicate `,` $enable `,` $message attr-dict";
 }
 
-def WhenOp : FIRRTLOp<"when", [SingleBlockImplicitTerminator<"DoneOp">,
-                               NoRegionArguments, RecursiveSideEffects]> {
+def WhenOp : FIRRTLOp<"when", [SingleBlock, NoTerminator, NoRegionArguments,
+                               RecursiveSideEffects]> {
   let summary = "When Statement";
   let description = [{
     The "firrtl.when" operation represents a conditional.  Connections within
@@ -174,7 +174,7 @@ def WhenOp : FIRRTLOp<"when", [SingleBlockImplicitTerminator<"DoneOp">,
 
     OpBuilder getThenBodyBuilder() {
       Block &body = getThenBlock();
-      return OpBuilder(&body, std::prev(body.end()));
+      return OpBuilder::atBlockEnd(&body);
     }
 
     bool hasElseRegion() {
@@ -190,7 +190,7 @@ def WhenOp : FIRRTLOp<"when", [SingleBlockImplicitTerminator<"DoneOp">,
 
     OpBuilder getElseBodyBuilder() {
       Block &body = getElseBlock();
-      return OpBuilder(&body, std::prev(body.end()));
+      return OpBuilder::atBlockEnd(&body);
     }
   }];
 }

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 def CircuitOp : FIRRTLOp<"circuit",
-      [IsolatedFromAbove, SymbolTable,
-       SingleBlockImplicitTerminator<"DoneOp">]> {
+      [IsolatedFromAbove, SymbolTable, SingleBlock, NoTerminator,
+       NoRegionArguments]> {
   let summary = "FIRRTL Circuit";
   let description = [{
     The "firrtl.circuit" operation represents an overall Verilog circuit,
@@ -33,7 +33,7 @@ def CircuitOp : FIRRTLOp<"circuit",
     OpBuilder getBodyBuilder() {
       assert(!body().empty() && "Unexpected empty 'body' region.");
       Block &bodyBlock = body().front();
-      return OpBuilder(&bodyBlock, std::prev(bodyBlock.end()));
+      return OpBuilder::atBlockEnd(&bodyBlock);
     }
 
     /// Return body of this circuit.
@@ -45,14 +45,12 @@ def CircuitOp : FIRRTLOp<"circuit",
     Operation *getMainModule();
   }];
 
-  let printer = "return ::print(p, *this);";
-  let parser = "return ::parse$cppClass(parser, result);";
+  let assemblyFormat = "$name attr-dict-with-keyword $body";
   let verifier = "return ::verifyCircuitOp(*this);";
 }
 
 def FModuleOp : FIRRTLOp<"module",
-      [IsolatedFromAbove, FunctionLike, Symbol,
-       SingleBlockImplicitTerminator<"DoneOp">]> {
+      [IsolatedFromAbove, FunctionLike, Symbol, SingleBlock, NoTerminator]> {
   let summary = "FIRRTL Module";
   let description = [{
     The "firrtl.module" operation represents a Verilog module, including a given
@@ -92,7 +90,7 @@ def FModuleOp : FIRRTLOp<"module",
     OpBuilder getBodyBuilder() {
       assert(!body().empty() && "Unexpected empty 'body' region.");
       Block &bodyBlock = body().front();
-      return OpBuilder(&bodyBlock, std::prev(bodyBlock.end()));
+      return OpBuilder::atBlockEnd(&bodyBlock);
     }
 
   private:
@@ -179,13 +177,4 @@ def FExtModuleOp : FIRRTLOp<"extmodule",
   let printer = "return ::print(p, *this);";
   let parser = "return ::parse$cppClass(parser, result);";
   let verifier = "return ::verifyFExtModuleOp(*this);";
-}
-
-def DoneOp : FIRRTLOp<"done", [Terminator]> {
-  let summary = "FIRRTL termination operation";
-  let description = [{
-    "firrtl.done" marks the end of a region in the FIRRTL dialect.
-  }];
-
-  let arguments = (ins);
 }

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -154,12 +154,11 @@ public:
   ResultType dispatchStmtVisitor(Operation *op, ExtraArgs... args) {
     auto *thisCast = static_cast<ConcreteType *>(this);
     return TypeSwitch<Operation *, ResultType>(op)
-        .template Case<AttachOp, ConnectOp, DoneOp, MemoryPortOp,
-                       PartialConnectOp, PrintFOp, SkipOp, StopOp, WhenOp,
-                       AssertOp, AssumeOp, CoverOp>(
-            [&](auto opNode) -> ResultType {
-              return thisCast->visitStmt(opNode, args...);
-            })
+        .template Case<AttachOp, ConnectOp, MemoryPortOp, PartialConnectOp,
+                       PrintFOp, SkipOp, StopOp, WhenOp, AssertOp, AssumeOp,
+                       CoverOp>([&](auto opNode) -> ResultType {
+          return thisCast->visitStmt(opNode, args...);
+        })
         .Default([&](auto expr) -> ResultType {
           return thisCast->visitInvalidStmt(op, args...);
         });
@@ -184,7 +183,6 @@ public:
 
   HANDLE(AttachOp);
   HANDLE(ConnectOp);
-  HANDLE(DoneOp);
   HANDLE(MemoryPortOp);
   HANDLE(PartialConnectOp);
   HANDLE(PrintFOp);

--- a/lib/Conversion/FIRRTLToLLHD/FIRRTLToLLHD.cpp
+++ b/lib/Conversion/FIRRTLToLLHD/FIRRTLToLLHD.cpp
@@ -42,7 +42,6 @@ struct FIRRTLToLLHDPass
   LogicalResult visitUnhandledOp(Operation *op);
   LogicalResult visitInvalidOp(Operation *op);
 
-  LogicalResult visitStmt(firrtl::DoneOp op) { return success(); }
   LogicalResult visitStmt(firrtl::ConnectOp op);
 
 private:
@@ -89,8 +88,8 @@ void FIRRTLToLLHDPass::convertCircuit(firrtl::CircuitOp &circuit) {
     if (auto module = dyn_cast<firrtl::FModuleOp>(op)) {
       builder->setInsertionPointAfter(circuit);
       convertModule(module);
-    } else if (!isa<firrtl::DoneOp>(op)) {
-      op.emitError("expected `firrtl.module` or `firrtl.done`");
+    } else {
+      op.emitError("expected `firrtl.module`");
       signalPassFailure();
     }
   }

--- a/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
+++ b/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
@@ -205,9 +205,6 @@ void FIRRTLModuleLowering::runOnOperation() {
       continue;
     }
 
-    if (isa<DoneOp>(op))
-      continue;
-
     // Otherwise we don't know what this is.  We are just going to drop it,
     // but emit an error so the client has some chance to know that this is
     // going to happen.
@@ -630,8 +627,7 @@ void FIRRTLModuleLowering::lowerModuleBody(
   auto &oldBlockInstList = oldModule.getBodyBlock()->getOperations();
   auto &newBlockInstList = newModule.getBodyBlock()->getOperations();
   newBlockInstList.splice(Block::iterator(cursor), oldBlockInstList,
-                          oldBlockInstList.begin(),
-                          std::prev(oldBlockInstList.end()));
+                          oldBlockInstList.begin(), oldBlockInstList.end());
 
   // We are done with our cursor op.
   cursor.erase();

--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -25,10 +25,6 @@ using namespace firrtl;
 /// the source block empty.
 static void mergeBlock(Block &destination, Block::iterator insertPoint,
                        Block &source) {
-  // Erase the terminator.
-  assert(isa<DoneOp>(source.back()) &&
-         "Block must be terminated with a DoneOp");
-  source.back().erase();
   destination.getOperations().splice(insertPoint, source.getOperations());
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -439,13 +439,8 @@ void IMConstPropPass::rewriteModuleBody(FModuleOp module) {
   auto *body = module.getBodyBlock();
   // If a module is unreachable, then nuke its body.
   if (!executableBlocks.count(body)) {
-    // TODO: Get rid of DoneOp, we don't need it anymore with recent MLIR
-    // improvements.
-    //     while (!body->empty())
-    //       body->back().erase();
-    auto done = cast<DoneOp>(body->getTerminator());
-    while (&body->front() != done)
-      (--Block::iterator(done))->erase();
+    while (!body->empty())
+      body->back().erase();
     return;
   }
 

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -21,25 +21,10 @@ firrtl.module @X(%b : !firrtl.uint<32>, %d : !firrtl.uint<16>, %out : !firrtl.ui
 
 // -----
 
-firrtl.circuit "MyModule" {
-
-// expected-error @+2 {{'firrtl.module' op expects regions to end with 'firrtl.done'}}
-// expected-note @+1 {{implies 'firrtl.done'}}
-"firrtl.module"() ( {
-^bb0(%a: !firrtl.uint<32>):
-  %0 = firrtl.add %a, %a : (!firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<33>
-
-}) {sym_name = "MyModule", type = (!firrtl.uint<32>) -> ()} : () -> ()
-
-}
-
-// -----
-
 // expected-error @+1 {{'firrtl.circuit' op must contain one module that matches main name 'MyCircuit'}}
 firrtl.circuit "MyCircuit" {
 
 "firrtl.module"() ( {
-  "firrtl.done"() : () -> ()
 }) { type = () -> ()} : () -> ()
 
 }


### PR DESCRIPTION
This change removes the terminator from all FIRRTL operations with
regions.  Since the firrtl.done op is no longer used anywhere, it was
deleted.