### PR TITLE
[Handshake] Add canonicalization to remove sunk constants.

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -490,6 +490,7 @@ def ConstantOp : Handshake_Op<"constant", [
   // let skipDefaultBuilders = 1;
   let builders = [OpBuilder<(ins "Attribute":$value, "Value":$operand)>];
 
+  let hasCanonicalizer = 1;
   let extraClassDeclaration = [{
     Attribute getValue() { return (*this)->getAttr("value"); }
   }];
@@ -659,5 +660,9 @@ def EliminateSimpleForksPattern : Pat<(ForkOp
                                        : $op $a, $attr),
                                       (replaceWithValue $a), [(HasOneResult
                                                                : $op)]>;
+
+def EliminateSunkConstantsPattern
+    : Pat<(SinkOp:$sink (ConstantOp $control, $value)),
+          (replaceWithValue $sink)>;
 
 #endif // HANDSHAKE_OPS

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -438,9 +438,8 @@ def ConditionalBranchOp : Handshake_Op<"conditional_branch", [
   }];
 }
 
-def SinkOp : Handshake_Op<"sink", [
-  NoSideEffect, DeclareOpInterfaceMethods<ExecutableOpInterface>
-]> {
+def SinkOp
+    : Handshake_Op<"sink", [DeclareOpInterfaceMethods<ExecutableOpInterface>]> {
   let summary = "sink operation";
   let description = [{
     The "handshake.sink" operation discards any data that arrives at its

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -565,6 +565,11 @@ bool handshake::ConstantOp::tryExecute(
   return tryToExecute(getOperation(), valueMap, timeMap, scheduleList, 0);
 }
 
+void handshake::ConstantOp::getCanonicalizationPatterns(
+    RewritePatternSet &results, MLIRContext *context) {
+  results.insert<circt::handshake::EliminateSunkConstantsPattern>(context);
+}
+
 void handshake::TerminatorOp::build(OpBuilder &builder, OperationState &result,
                                     ArrayRef<Block *> successors) {
   // Add all the successor blocks of the block which contains this terminator

--- a/test/Conversion/StandardToHandshake/test_canonicalize.mlir
+++ b/test/Conversion/StandardToHandshake/test_canonicalize.mlir
@@ -6,7 +6,7 @@ module {
   // CHECK-SAME:                         %[[VAL_0:.*]]: none, ...) -> none {
   handshake.func @simple(%arg0: none, ...) -> none {
 
-    // CHECK-NOT: "handshake.constant"(%arg0)
+    // CHECK: %[[VAL_1:.*]] = "handshake.constant"(%[[VAL_0:.*]]) {value = 1 : index} : (none) -> index
     %0 = "handshake.constant"(%arg0) {value = 1 : index} : (none) -> index
     
     // CHECK-NOT: %[[TMP_0:.*]] = "handshake.branch"(%[[VAL_0:.*]]) {control = true} : (none) -> none

--- a/test/Conversion/StandardToHandshake/test_canonicalize.mlir
+++ b/test/Conversion/StandardToHandshake/test_canonicalize.mlir
@@ -52,4 +52,13 @@ module {
     %result, %index = "handshake.control_merge"(%arg0, %arg1) {control = true} : (none, none) -> (none, index)
     handshake.return %result, %arg2 : none, none
   }
+
+  // CHECK-LABEL: sunk_constant
+  handshake.func @sunk_constant(%arg0: none) -> (none) {
+    // CHECK-NOT: handshake.constant
+    // CHECK-NOT: handshake.sink
+    %0 = "handshake.constant"(%arg0) { value = 24 : i8 } : (none) -> i8
+    "handshake.sink"(%0) : (i8) -> ()
+    handshake.return %arg0: none
+  }
 }


### PR DESCRIPTION
The previous change, which this PR reverts, intended to allow removing constants that ended up in sinks, but it ultimately led to sinks being removed in situations where we really don't want that. Specifically, a sunk output of a ConditionalBranchOp would be removed. In hardware, this would ultimately result in dangling ready wires, which Verilator finds:

```
%Warning-UNDRIVEN: build/tools/circt/integration_test/Dialect/Handshake/%matmul-export.sv:4924:15: Signal is not driven: '_arg3_ready_wire'
%Warning-UNDRIVEN: build/tools/circt/integration_test/Dialect/Handshake/%matmul-export.sv:4931:15: Signal is not driven: '_arg3_ready_wire_40'
%Warning-UNDRIVEN: build/tools/circt/integration_test/Dialect/Handshake/%matmul-export.sv:4972:15: Signal is not driven: '_arg3_ready_wire_48'
...
```

That's definitely not what we want! Besides reverting the previous change, the new addition in this PR addresses the sunk constant situation by adding a canonicalization for this specific case.