### PR TITLE
Use ODS generated dialect defintions

### DIFF
--- a/include/circt/Dialect/Comb/Comb.td
+++ b/include/circt/Dialect/Comb/Comb.td
@@ -26,7 +26,7 @@ def CombDialect : Dialect {
     This dialect defines the `comb` dialect, which is intended to be a generic
     representation of combinational logic outside of a particular use-case.
   }];
-
+  let hasConstantMaterializer = 1;
   let cppNamespace = "::circt::comb";
 }
 

--- a/include/circt/Dialect/Comb/CombDialect.h
+++ b/include/circt/Dialect/Comb/CombDialect.h
@@ -18,21 +18,13 @@
 
 namespace circt {
 namespace comb {
+// TODO: remove this
 using namespace mlir;
-
-class CombDialect : public Dialect {
-public:
-  explicit CombDialect(MLIRContext *context);
-  ~CombDialect();
-
-  static StringRef getDialectNamespace() { return "comb"; }
-
-  Operation *materializeConstant(OpBuilder &builder, Attribute value, Type type,
-                                 Location loc) override;
-};
-
 } // namespace comb
 } // namespace circt
+
+// Pull in the Dialect definition.
+#include "circt/Dialect/Comb/CombDialect.h.inc"
 
 // Pull in all enum type definitions and utility function declarations.
 #include "circt/Dialect/Comb/CombEnums.h.inc"

--- a/include/circt/Dialect/Comb/CombOps.h
+++ b/include/circt/Dialect/Comb/CombOps.h
@@ -14,6 +14,7 @@
 #define CIRCT_DIALECT_COMB_COMBOPS_H
 
 #include "circt/Dialect/Comb/CombDialect.h"
+#include "circt/Support/LLVM.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/FunctionSupport.h"
 #include "mlir/IR/OpImplementation.h"

--- a/include/circt/Dialect/ESI/ESI.td
+++ b/include/circt/Dialect/ESI/ESI.td
@@ -20,6 +20,10 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 def ESI_Dialect : Dialect {
   let name = "esi";
   let cppNamespace = "::circt::esi";
+  let extraClassDeclaration = [{
+    /// Register all ESI types.
+    void registerTypes();
+  }];
 }
 
 class ESI_Op<string mnemonic, list<OpTrait> traits = []> :

--- a/include/circt/Dialect/ESI/ESIDialect.h
+++ b/include/circt/Dialect/ESI/ESIDialect.h
@@ -27,25 +27,6 @@
 namespace circt {
 namespace esi {
 
-class ESIDialect : public ::mlir::Dialect {
-public:
-  explicit ESIDialect(mlir::MLIRContext *context);
-
-  /// Returns the prefix used in the textual IR to refer to ESI operations
-  static llvm::StringRef getDialectNamespace() { return "esi"; }
-
-  /// Parses a type registered to this dialect
-  mlir::Type parseType(mlir::DialectAsmParser &parser) const override;
-
-  /// Print a type registered to this dialect
-  void printType(mlir::Type type,
-                 mlir::DialectAsmPrinter &printer) const override;
-
-private:
-  /// Register all ESI types.
-  void registerTypes();
-};
-
 void registerESIPasses();
 void registerESITranslations();
 
@@ -74,5 +55,6 @@ Operation *buildESIWrapper(OpBuilder &b, Operation *mod,
 } // namespace circt
 
 #include "circt/Dialect/ESI/ESIAttrs.h.inc"
+#include "circt/Dialect/ESI/ESIDialect.h.inc"
 
 #endif

--- a/include/circt/Dialect/FIRRTL/FIRRTL.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTL.td
@@ -28,7 +28,12 @@ def FIRRTLDialect : Dialect {
     [FIRRTL GitHub page](https://github.com/freechipsproject/firrtl).
   }];
 
+  let hasConstantMaterializer = 1;
   let cppNamespace = "::circt::firrtl";
+  let extraClassDeclaration = [{
+    /// Register all FIRRTL types.
+    void registerTypes();
+  }];
 }
 
 // Base class for the operation in this dialect.

--- a/include/circt/Dialect/FIRRTL/FIRRTLDialect.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDialect.h
@@ -22,31 +22,15 @@ namespace firrtl {
 
 class FIRRTLType;
 
-class FIRRTLDialect : public Dialect {
-public:
-  /// Create the dialect in the given `context`.
-  explicit FIRRTLDialect(MLIRContext *context);
-  ~FIRRTLDialect();
-
-  Type parseType(DialectAsmParser &parser) const override;
-  void printType(Type, DialectAsmPrinter &) const override;
-
-  Operation *materializeConstant(OpBuilder &builder, Attribute value, Type type,
-                                 Location loc) override;
-
-  static StringRef getDialectNamespace() { return "firrtl"; }
-
-private:
-  /// Register all FIRRTL types.
-  void registerTypes();
-};
-
 /// If the specified attribute list has a firrtl.name attribute, return its
 /// value.
 StringAttr getFIRRTLNameAttr(ArrayRef<NamedAttribute> attrs);
 
 } // namespace firrtl
 } // namespace circt
+
+// Pull in the dialect definition.
+#include "circt/Dialect/FIRRTL/FIRRTLDialect.h.inc"
 
 // Pull in all enum type definitions and utility function declarations.
 #include "circt/Dialect/FIRRTL/FIRRTLEnums.h.inc"

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -14,59 +14,60 @@
 // FIRRTL Types Definitions
 //===----------------------------------------------------------------------===//
 
-def FIRRTLType : Type<CPred<"$_self.isa<FIRRTLType>()">, "FIRRTLType",
-                             "::circt::firrtl::FIRRTLType">;
+def FIRRTLType : DialectType<FIRRTLDialect, CPred<"$_self.isa<FIRRTLType>()">,
+  "FIRRTLType", "::circt::firrtl::FIRRTLType">;
 
-def ClockType : Type<CPred<"$_self.isa<ClockType>()">, "clock",
-                           "::circt::firrtl::ClockType">,
-                BuildableType<"ClockType::get($_builder.getContext())">;
+def ClockType : DialectType<FIRRTLDialect, CPred<"$_self.isa<ClockType>()">,
+ "clock", "::circt::firrtl::ClockType">,
+ BuildableType<"ClockType::get($_builder.getContext())">; 
 
-def IntType : Type<CPred<"$_self.isa<IntType>()">, "sint or uint type",
-                         "::circt::firrtl::IntType">;
-def SIntType : Type<CPred<"$_self.isa<SIntType>()">, "sint type",
-                          "::circt::firrtl::SIntType">;
-def UIntType : Type<CPred<"$_self.isa<UIntType>()">, "uint type",
-                          "::circt::firrtl::UIntType">;
-def AnalogType : Type<CPred<"$_self.isa<AnalogType>()">, "analog type",
-                            "::circt::firrtl::AnalogType">;
+def IntType : DialectType<FIRRTLDialect, CPred<"$_self.isa<IntType>()">,
+ "sint or uint type", "::circt::firrtl::IntType">;
 
-def BundleType : Type<CPred<"$_self.isa<BundleType>()">, "BundleType",
-                            "::circt::firrtl::BundleType">;
+def SIntType : DialectType<FIRRTLDialect, CPred<"$_self.isa<SIntType>()">,
+ "sint type", "::circt::firrtl::SIntType">;
 
-def FVectorType : Type<CPred<"$_self.isa<FVectorType>()">, "FVectorType",
-                                 "::circt::firrtl::FVectorType">;
+def UIntType : DialectType<FIRRTLDialect, CPred<"$_self.isa<UIntType>()">,
+ "uint type", "::circt::firrtl::UIntType">;
 
-def UInt1Type : Type<CPred<"$_self.isa<UIntType>() && "
-                           "$_self.cast<UIntType>().getWidth() == 1">,
-                           "UInt<1>", "::circt::firrtl::UIntType">,
-                BuildableType<"UIntType::get($_builder.getContext(), 1)">;
+def AnalogType : DialectType<FIRRTLDialect, CPred<"$_self.isa<AnalogType>()">,
+ "analog type", "::circt::firrtl::AnalogType">;
 
-def AsyncResetType : Type<CPred<"$_self.isa<AsyncResetType>()">, "AsyncReset",
-                          "::circt::firrtl::AsyncResetType">;
+def BundleType : DialectType<FIRRTLDialect, CPred<"$_self.isa<BundleType>()">,
+ "BundleType", "::circt::firrtl::BundleType">;
 
-def PassiveType : Type<CPred<"$_self.isa<FIRRTLType>() && "
-                             "$_self.cast<FIRRTLType>().isPassive()">,
-                       "a passive type (contain no flips)",
-                       "::circt::firrtl::FIRRTLType">;
+def FVectorType : DialectType<FIRRTLDialect, CPred<"$_self.isa<FVectorType>()">,
+  "FVectorType", "::circt::firrtl::FVectorType">;
+
+def UInt1Type : DialectType<FIRRTLDialect,
+  CPred<"$_self.isa<UIntType>() && $_self.cast<UIntType>().getWidth() == 1">,
+   "UInt<1>", "::circt::firrtl::UIntType">, 
+   BuildableType<"UIntType::get($_builder.getContext(), 1)">;
+
+def AsyncResetType : DialectType<FIRRTLDialect,
+  CPred<"$_self.isa<AsyncResetType>()">,
+  "AsyncReset", "::circt::firrtl::AsyncResetType">;
+
+def PassiveType : DialectType<FIRRTLDialect,
+  CPred<"$_self.isa<FIRRTLType>() && $_self.cast<FIRRTLType>().isPassive()">,
+  "a passive type (contain no flips)", "::circt::firrtl::FIRRTLType">;
 
 //===----------------------------------------------------------------------===//
 // FIRRTL Types Predicates
 //===----------------------------------------------------------------------===//
 
-def OneBitType : Type<CPred<"($_self.isa<IntType>() && "
-                            "$_self.cast<IntType>().getWidth() == 1) ||"
-                            "($_self.isa<AnalogType>() && "
-                            "$_self.cast<AnalogType>().getWidth() == 1)">,
-                            "UInt<1>, SInt<1>, or Analog<1>",
-                            "::circt::firrtl::FIRRTLType">;
+def OneBitType : DialectType<FIRRTLDialect,
+ CPred<"($_self.isa<IntType>() && $_self.cast<IntType>().getWidth() == 1) || "
+   "($_self.isa<AnalogType>() && $_self.cast<AnalogType>().getWidth() == 1)">,
+ "UInt<1>, SInt<1>, or Analog<1>", "::circt::firrtl::FIRRTLType">;
 
-def NonZeroIntType : Type<CPred<"$_self.isa<IntType>() && "
-                          "$_self.cast<IntType>().getWidth() != 0">,
-                          "Int", "::circt::firrtl::IntType">;
+def NonZeroIntType : DialectType<FIRRTLDialect,
+  CPred<"$_self.isa<IntType>() && $_self.cast<IntType>().getWidth() != 0">,
+  "Int", "::circt::firrtl::IntType">;
 
-def ResetType : Type<CPred<"$_self.isa<FIRRTLType>() && "
-                           "$_self.cast<FIRRTLType>().isResetType()">,
-                    "Reset", "::circt::firrtl::FIRRTLType">;
+def ResetType : DialectType<FIRRTLDialect,
+  CPred<"$_self.isa<FIRRTLType>() && $_self.cast<FIRRTLType>().isResetType()">,
+  "Reset", "::circt::firrtl::FIRRTLType">;
 
 def UIntSIntClockType : AnyTypeOf<[SIntType, UIntType, ClockType],
                                   "sint, uint, or clock",

--- a/include/circt/Dialect/Handshake/HandshakeOps.h
+++ b/include/circt/Dialect/Handshake/HandshakeOps.h
@@ -29,16 +29,12 @@
 #include "mlir/Pass/Pass.h"
 #include "llvm/ADT/Any.h"
 
+#include "circt/Dialect/Handshake/HandshakeOpsDialect.h.inc"
+
 namespace circt {
 namespace handshake {
 
 class TerminatorOp;
-
-class HandshakeOpsDialect : public Dialect {
-public:
-  HandshakeOpsDialect(MLIRContext *context);
-  static StringRef getDialectNamespace() { return "handshake"; }
-};
 
 #include "circt/Dialect/Handshake/HandshakeInterfaces.h.inc"
 

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -25,21 +25,21 @@ include "mlir/IR/RegionKindInterface.td"
 include "mlir/Interfaces/CallInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
-def Handshake_Dialect : Dialect {
+def HandshakeOps_Dialect : Dialect {
   let name = "handshake";
   let cppNamespace = "::circt::handshake";
 }
 
 // Base class for Handshake dialect ops.
 class Handshake_Op<string mnemonic, list<OpTrait> traits = []>
-    : Op<Handshake_Dialect, mnemonic,
+    : Op<HandshakeOps_Dialect, mnemonic,
          traits # [HasParent<"handshake::FuncOp">]> {
 }
 
 // This is almost exactly like a standard FuncOp, except that it has some
 // extra verification conditions.  In particular, each Value must
 // only have a single use.  Also, it defines a Dominance-Free Scope
-def FuncOp : Op<Handshake_Dialect, "func", [
+def FuncOp : Op<HandshakeOps_Dialect, "func", [
    NativeOpTrait<"IsIsolatedFromAbove">,
    NativeOpTrait<"FunctionLike">,
    Symbol,

--- a/include/circt/Dialect/LLHD/IR/LLHD.td
+++ b/include/circt/Dialect/LLHD/IR/LLHD.td
@@ -40,11 +40,13 @@ def LLHD_Dialect : Dialect {
 //===----------------------------------------------------------------------===//
 
 // LLHD Time Type
-def LLHD_TimeType : Type<CPred<"$_self.isa<TimeType>()">, "LLHD time type">,
-                    BuildableType<"TimeType::get($_builder.getContext())">;
+def LLHD_TimeType : DialectType<LLHD_Dialect,
+    CPred<"$_self.isa<TimeType>()">, "LLHD time type">,
+    BuildableType<"TimeType::get($_builder.getContext())">;
 
 // LLHD Array Type
-def LLHD_ArrayType : Type<CPred<"$_self.isa<ArrayType>()">, "LLHD array type">;
+def LLHD_ArrayType : DialectType<LLHD_Dialect,
+    CPred<"$_self.isa<ArrayType>()">, "LLHD array type">;
 
 // Legal underlying types for signals and pointers.
 def LLHD_AnyUnderlyingType :
@@ -70,8 +72,8 @@ def LLHD_AnyPtrType : LLHD_PtrType<[LLHD_AnyUnderlyingType]>;
 //===----------------------------------------------------------------------===//
 
 // LLHD time attr
-def LLHD_TimeAttr
-    : Attr<CPred<"$_self.isa<TimeAttr>()">, "LLHD time attribute"> {
+def LLHD_TimeAttr : DialectAttr<LLHD_Dialect,
+    CPred<"$_self.isa<TimeAttr>()">, "LLHD time attribute"> {
   let storageType= [{ TimeAttr }];
   let returnType = [{ llvm::ArrayRef<unsigned> }];
   let valueType = LLHD_TimeType;

--- a/include/circt/Dialect/LLHD/IR/LLHDDialect.h
+++ b/include/circt/Dialect/LLHD/IR/LLHDDialect.h
@@ -17,6 +17,8 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Dialect.h"
 
+#include "circt/Dialect/LLHD/IR/LLHDDialect.h.inc"
+
 namespace circt {
 namespace llhd {
 
@@ -26,30 +28,6 @@ struct TimeAttrStorage;
 struct ArrayTypeStorage;
 struct PtrTypeStorage;
 } // namespace detail
-
-class LLHDDialect : public Dialect {
-public:
-  explicit LLHDDialect(MLIRContext *context);
-
-  /// Returns the prefix used in the textual IR to refer to LLHD operations
-  static StringRef getDialectNamespace() { return "llhd"; }
-
-  /// Parses a type registered to this dialect
-  Type parseType(DialectAsmParser &parser) const override;
-
-  /// Print a type registered to this dialect
-  void printType(Type type, DialectAsmPrinter &printer) const override;
-
-  /// Parse an attribute regustered to this dialect
-  Attribute parseAttribute(DialectAsmParser &parser, Type type) const override;
-
-  /// Print an attribute registered to this dialect
-  void printAttribute(Attribute attr,
-                      DialectAsmPrinter &printer) const override;
-
-  Operation *materializeConstant(OpBuilder &builder, Attribute value, Type type,
-                                 Location loc) override;
-};
 
 //===----------------------------------------------------------------------===//
 // SigType

--- a/include/circt/Dialect/MSFT/MSFT.td
+++ b/include/circt/Dialect/MSFT/MSFT.td
@@ -26,7 +26,12 @@ def MSFTDialect : Dialect {
     a candidate for generalization and re-homing.
   }];
 
+  let hasConstantMaterializer = 1;
   let cppNamespace = "::circt::msft";
+  let extraClassDeclaration = [{
+    /// Register all MSFT attributes.
+    void registerAttributes();
+  }];
 }
 
 // Base class for the operation in this dialect.

--- a/include/circt/Dialect/MSFT/MSFTDialect.h
+++ b/include/circt/Dialect/MSFT/MSFTDialect.h
@@ -17,28 +17,7 @@
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Dialect.h"
 
-namespace circt {
-namespace msft {
-
-class MSFTDialect : public Dialect {
-public:
-  explicit MSFTDialect(MLIRContext *context);
-  ~MSFTDialect();
-
-  static StringRef getDialectNamespace() { return "msft"; }
-
-  Attribute parseAttribute(DialectAsmParser &, Type type) const override;
-  void printAttribute(Attribute, DialectAsmPrinter &) const override;
-
-  Operation *materializeConstant(OpBuilder &builder, Attribute value, Type type,
-                                 Location loc) override;
-
-private:
-  void registerAttributes();
-};
-
-} // namespace msft
-} // namespace circt
+#include "circt/Dialect/MSFT/MSFTDialect.h.inc"
 
 #include "circt/Dialect/MSFT/MSFTEnums.h.inc"
 

--- a/include/circt/Dialect/RTL/RTL.td
+++ b/include/circt/Dialect/RTL/RTL.td
@@ -29,7 +29,12 @@ def RTLDialect : Dialect {
     representation of RTL outside of a particular use-case.
   }];
 
+  let hasConstantMaterializer = 1;
   let cppNamespace = "::circt::rtl";
+  let extraClassDeclaration = [{
+    /// Register all RTL types.
+    void registerTypes();
+  }];
 }
 
 include "circt/Dialect/RTL/RTLTypes.td"

--- a/include/circt/Dialect/RTL/RTLDialect.h
+++ b/include/circt/Dialect/RTL/RTLDialect.h
@@ -19,29 +19,11 @@
 namespace circt {
 namespace rtl {
 
-class RTLDialect : public Dialect {
-public:
-  explicit RTLDialect(MLIRContext *context);
-  ~RTLDialect();
-
-  static StringRef getDialectNamespace() { return "rtl"; }
-
-  /// Parses a type registered to this dialect
-  Type parseType(DialectAsmParser &parser) const override;
-
-  /// Print a type registered to this dialect
-  void printType(Type type, DialectAsmPrinter &printer) const override;
-
-  Operation *materializeConstant(OpBuilder &builder, Attribute value, Type type,
-                                 Location loc) override;
-
-private:
-  /// Register all RTL types.
-  void registerTypes();
-};
-
 } // namespace rtl
 } // namespace circt
+
+// Pull in the dialect definition.
+#include "circt/Dialect/RTL/RTLDialect.h.inc"
 
 // Pull in all enum type definitions and utility function declarations.
 #include "circt/Dialect/RTL/RTLEnums.h.inc"

--- a/include/circt/Dialect/RTL/RTLTypes.td
+++ b/include/circt/Dialect/RTL/RTLTypes.td
@@ -19,19 +19,19 @@ class RTLType<string name> : TypeDef<RTLDialect, name> { }
 
 // Type constraint that indicates that an operand/result may only be a valid,
 // known, non-directional type.
-def RTLIntegerType : Type<CPred<"isRTLIntegerType($_self)">,
-                          "an integer bitvector of one or more bits",
-                          "::mlir::IntegerType">;
+def RTLIntegerType : DialectType<RTLDialect, CPred<"isRTLIntegerType($_self)">,
+                                 "an integer bitvector of one or more bits",
+                                 "::mlir::IntegerType">;
 
 // Type constraint that indicates that an operand/result may only be a valid,
 // known, non-directional type.
-def RTLValueType : Type<CPred<"isRTLValueType($_self)">,
-                        "a known primitive element">;
+def RTLValueType : DialectType<RTLDialect, CPred<"isRTLValueType($_self)">,
+                               "a known primitive element">;
 
 // Type constraint that indicates that an operand/result may only be a valid
 // non-directional type.
-def RTLNonInOutType : Type<CPred<"!hasRTLInOutType($_self)">,
-                           "a type without inout">;
+def RTLNonInOutType : DialectType<RTLDialect, CPred<"!hasRTLInOutType($_self)">,
+                                  "a type without inout">;
 
 //===----------------------------------------------------------------------===//
 // Type declarations

--- a/include/circt/Dialect/SV/SV.td
+++ b/include/circt/Dialect/SV/SV.td
@@ -26,8 +26,12 @@ def SVDialect : Dialect {
     This dialect defines the `sv` dialect, which represents various
     SystemVerilog-specific constructs in an AST-like representation.
   }];
-
+  let dependentDialects = ["circt::comb::CombDialect"];
   let cppNamespace = "::circt::sv";
+  let extraClassDeclaration = [{
+    /// Register all SV types.
+    void registerTypes();
+  }];
 }
 
 // Base class for the operation in this dialect.

--- a/include/circt/Dialect/SV/SVDialect.h
+++ b/include/circt/Dialect/SV/SVDialect.h
@@ -13,31 +13,13 @@
 #ifndef CIRCT_DIALECT_SV_DIALECT_H
 #define CIRCT_DIALECT_SV_DIALECT_H
 
+#include "circt/Dialect/Comb/CombDialect.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/Dialect.h"
 #include "llvm/ADT/StringSet.h"
 
 namespace circt {
 namespace sv {
-
-class SVDialect : public Dialect {
-public:
-  explicit SVDialect(MLIRContext *context);
-  ~SVDialect();
-
-  static StringRef getDialectNamespace() { return "sv"; }
-
-  /// Parses a type registered to this dialect
-  mlir::Type parseType(mlir::DialectAsmParser &parser) const override;
-
-  /// Print a type registered to this dialect
-  void printType(mlir::Type type,
-                 mlir::DialectAsmPrinter &printer) const override;
-
-private:
-  /// Register all SV types.
-  void registerTypes();
-};
 
 /// Given string \p origName, generate a new name if it conflicts with any
 /// keyword or any other name in the set \p recordNames. Use the int \p
@@ -61,5 +43,8 @@ bool isNameValid(llvm::StringRef name);
 
 } // namespace sv
 } // namespace circt
+
+// Pull in the dialect definition.
+#include "circt/Dialect/SV/SVDialect.h.inc"
 
 #endif // CIRCT_DIALECT_SV_DIALECT_H

--- a/include/circt/Dialect/Seq/Seq.td
+++ b/include/circt/Dialect/Seq/Seq.td
@@ -27,6 +27,7 @@ def SeqDialect : Dialect {
     The `seq` dialect is intended to model digital sequential logic.
   }];
 
+  let hasConstantMaterializer = 1;
   let cppNamespace = "::circt::seq";
 }
 

--- a/include/circt/Dialect/Seq/SeqDialect.h
+++ b/include/circt/Dialect/Seq/SeqDialect.h
@@ -19,20 +19,12 @@
 namespace circt {
 namespace seq {
 
-class SeqDialect : public Dialect {
-public:
-  explicit SeqDialect(MLIRContext *context);
-  ~SeqDialect();
-
-  static StringRef getDialectNamespace() { return "seq"; }
-
-  Operation *materializeConstant(OpBuilder &builder, Attribute value, Type type,
-                                 Location loc) override;
-};
-
 void registerSeqPasses();
 
 } // namespace seq
 } // namespace circt
+
+// Pull in the dialect definition.
+#include "circt/Dialect/Seq/SeqDialect.h.inc"
 
 #endif // CIRCT_DIALECT_SEQ_SEQDIALECT_H

--- a/include/circt/Dialect/StaticLogic/StaticLogic.h
+++ b/include/circt/Dialect/StaticLogic/StaticLogic.h
@@ -28,17 +28,7 @@
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Pass/Pass.h"
 
-namespace circt {
-namespace staticlogic {
-
-class StaticLogicDialect : public Dialect {
-public:
-  StaticLogicDialect(MLIRContext *context);
-  static StringRef getDialectNamespace() { return "staticlogic"; }
-};
-
-} // namespace staticlogic
-} // namespace circt
+#include "circt/Dialect/StaticLogic/StaticLogicDialect.h.inc"
 
 #define GET_OP_CLASSES
 #include "circt/Dialect/StaticLogic/StaticLogic.h.inc"

--- a/lib/Dialect/Comb/CombDialect.cpp
+++ b/lib/Dialect/Comb/CombDialect.cpp
@@ -24,18 +24,13 @@ using namespace comb;
 // Dialect specification.
 //===----------------------------------------------------------------------===//
 
-CombDialect::CombDialect(MLIRContext *context)
-    : Dialect(getDialectNamespace(), context,
-              ::mlir::TypeID::get<CombDialect>()) {
-
+void CombDialect::initialize() {
   // Register operations.
   addOperations<
 #define GET_OP_LIST
 #include "circt/Dialect/Comb/Comb.cpp.inc"
       >();
 }
-
-CombDialect::~CombDialect() {}
 
 /// Registered hook to materialize a single constant operation from a given
 /// attribute value with the desired resultant type. This method should use

--- a/lib/Dialect/ESI/ESIDialect.cpp
+++ b/lib/Dialect/ESI/ESIDialect.cpp
@@ -27,11 +27,8 @@
 using namespace circt;
 using namespace circt::esi;
 
-ESIDialect::ESIDialect(MLIRContext *context)
-    : Dialect("esi", context, TypeID::get<ESIDialect>()) {
-
+void ESIDialect::initialize() {
   registerTypes();
-
   addOperations<
 #define GET_OP_LIST
 #include "circt/Dialect/ESI/ESI.cpp.inc"

--- a/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
@@ -122,10 +122,8 @@ struct FIRRTLOpAsmDialectInterface : public OpAsmDialectInterface {
 };
 } // end anonymous namespace
 
-FIRRTLDialect::FIRRTLDialect(MLIRContext *context)
-    : Dialect(getDialectNamespace(), context,
-              ::mlir::TypeID::get<FIRRTLDialect>()) {
-
+void FIRRTLDialect::initialize() {
+  // Register types.
   registerTypes();
 
   // Register operations.
@@ -137,8 +135,6 @@ FIRRTLDialect::FIRRTLDialect(MLIRContext *context)
   // Register interface implementations.
   addInterfaces<FIRRTLOpAsmDialectInterface>();
 }
-
-FIRRTLDialect::~FIRRTLDialect() {}
 
 void FIRRTLDialect::printType(Type type, DialectAsmPrinter &os) const {
   type.cast<FIRRTLType>().print(os.getStream());

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -117,9 +117,7 @@ bool tryToExecute(Operation *op,
 // HandshakeOpsDialect
 //===----------------------------------------------------------------------===//
 
-HandshakeOpsDialect::HandshakeOpsDialect(MLIRContext *context)
-    : Dialect(getDialectNamespace(), context,
-              ::mlir::TypeID::get<HandshakeOpsDialect>()) {
+void HandshakeOpsDialect::initialize() {
   addOperations<
 #define GET_OP_LIST
 #include "circt/Dialect/Handshake/HandshakeOps.cpp.inc"

--- a/lib/Dialect/LLHD/IR/LLHDDialect.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDDialect.cpp
@@ -56,8 +56,7 @@ struct LLHDInlinerInterface : public mlir::DialectInlinerInterface {
 // LLHD Dialect
 //===----------------------------------------------------------------------===//
 
-LLHDDialect::LLHDDialect(mlir::MLIRContext *context)
-    : Dialect(getDialectNamespace(), context, TypeID::get<LLHDDialect>()) {
+void LLHDDialect::initialize() {
   addTypes<SigType, TimeType, ArrayType, PtrType>();
   addAttributes<TimeAttr>();
   addOperations<

--- a/lib/Dialect/MSFT/MSFTDialect.cpp
+++ b/lib/Dialect/MSFT/MSFTDialect.cpp
@@ -23,13 +23,7 @@ using namespace msft;
 // Dialect specification.
 //===----------------------------------------------------------------------===//
 
-MSFTDialect::MSFTDialect(MLIRContext *context)
-    : Dialect(getDialectNamespace(), context,
-              ::mlir::TypeID::get<MSFTDialect>()) {
-  registerAttributes();
-}
-
-MSFTDialect::~MSFTDialect() {}
+void MSFTDialect::initialize() { registerAttributes(); }
 
 /// Registered hook to materialize a single constant operation from a given
 /// attribute value with the desired resultant type. This method should use

--- a/lib/Dialect/RTL/RTLDialect.cpp
+++ b/lib/Dialect/RTL/RTLDialect.cpp
@@ -53,10 +53,8 @@ struct RTLOpAsmDialectInterface : public OpAsmDialectInterface {
 };
 } // end anonymous namespace
 
-RTLDialect::RTLDialect(MLIRContext *context)
-    : Dialect(getDialectNamespace(), context,
-              ::mlir::TypeID::get<RTLDialect>()) {
-
+void RTLDialect::initialize() {
+  // Register types.
   registerTypes();
 
   // Register operations.
@@ -68,8 +66,6 @@ RTLDialect::RTLDialect(MLIRContext *context)
   // Register interface implementations.
   addInterfaces<RTLOpAsmDialectInterface>();
 }
-
-RTLDialect::~RTLDialect() {}
 
 // Registered hook to materialize a single constant operation from a given
 /// attribute value with the desired resultant type. This method should use

--- a/lib/Dialect/SV/SVDialect.cpp
+++ b/lib/Dialect/SV/SVDialect.cpp
@@ -28,11 +28,8 @@ using namespace circt::sv;
 // Dialect specification.
 //===----------------------------------------------------------------------===//
 
-SVDialect::SVDialect(MLIRContext *context)
-    : Dialect(getDialectNamespace(), context,
-              ::mlir::TypeID::get<SVDialect>()) {
-  context->loadDialect<circt::comb::CombDialect>();
-
+void SVDialect::initialize() {
+  // Register types.
   registerTypes();
 
   // Register operations.
@@ -41,8 +38,6 @@ SVDialect::SVDialect(MLIRContext *context)
 #include "circt/Dialect/SV/SV.cpp.inc"
       >();
 }
-
-SVDialect::~SVDialect() {}
 
 //===----------------------------------------------------------------------===//
 // Name conflict resolution

--- a/lib/Dialect/Seq/SeqDialect.cpp
+++ b/lib/Dialect/Seq/SeqDialect.cpp
@@ -24,18 +24,13 @@ using namespace seq;
 // Dialect specification.
 //===----------------------------------------------------------------------===//
 
-SeqDialect::SeqDialect(MLIRContext *context)
-    : Dialect(getDialectNamespace(), context,
-              ::mlir::TypeID::get<SeqDialect>()) {
-
+void SeqDialect::initialize() {
   // Register operations.
   addOperations<
 #define GET_OP_LIST
 #include "circt/Dialect/Seq/Seq.cpp.inc"
       >();
 }
-
-SeqDialect::~SeqDialect() {}
 
 /// Registered hook to materialize a single constant operation from a given
 /// attribute value with the desired resultant type. This method should use

--- a/lib/Dialect/StaticLogic/StaticLogicOps.cpp
+++ b/lib/Dialect/StaticLogic/StaticLogicOps.cpp
@@ -19,9 +19,7 @@ using namespace circt::staticlogic;
 #define GET_OP_CLASSES
 #include "circt/Dialect/StaticLogic/StaticLogic.cpp.inc"
 
-StaticLogicDialect::StaticLogicDialect(MLIRContext *context)
-    : Dialect(getDialectNamespace(), context,
-              ::mlir::TypeID::get<StaticLogicDialect>()) {
+void StaticLogicDialect::initialize() {
   addOperations<
 #define GET_OP_LIST
 #include "circt/Dialect/StaticLogic/StaticLogic.cpp.inc"


### PR DESCRIPTION
In CIRCT there is duplicated declaration of each dialect in ODS and in
C++.  We have been generating the class from ODS, but never including it
anywhere.  This change removes the handwritten dialect classes and uses
the generated version.  In all cases the resulting code is (now)
equivalent.

Some dialects  with constant materializers had to marked as so in ODS
to have the proper function declaration generated.

In order for the dialects to have the functions to parse types or
attributes, they had to have at least one DialectType or DialectAttr.
This change moved some types and attributes to correctly belong to their
dialect in ODS.