### PR TITLE
[FIRRTL] Make names non-optional and use names as SSA values

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -18,7 +18,7 @@ def InstanceOp : FIRRTLOp<"instance"> {
   }];
 
   let arguments = (ins FlatSymbolRefAttr:$moduleName,
-                       StrArrayAttr:$portNames, OptionalAttr<StrAttr>:$name,
+                       StrArrayAttr:$portNames, StrAttr:$name,
                        DefaultValuedAttr<AnnotationArrayAttr,
                                          "{}">:$annotations);
   let results = (outs Variadic<FIRRTLType>:$results);
@@ -34,8 +34,7 @@ def InstanceOp : FIRRTLOp<"instance"> {
                       "::mlir::ArrayAttr":$portNames,
                       CArg<"StringRef", "{}">:$name,
                       CArg<"ArrayRef<Attribute>", "{}">:$annotations), [{
-      return build($_builder, $_state, elementType, moduleName, portNames,
-                   $_builder.getStringAttr(name),
+      return build($_builder, $_state, elementType, moduleName, portNames, name,
                    $_builder.getArrayAttr(annotations));
     }]>
   ];
@@ -60,8 +59,7 @@ def InstanceOp : FIRRTLOp<"instance"> {
 
 def CMemOp : FIRRTLOp<"cmem", [/*MemAlloc*/]> {
   let summary = "Define a new cmem";
-  let arguments = (
-    ins OptionalAttr<StrAttr>:$name,
+  let arguments = (ins StrAttr:$name,
         DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations);
   let results = (outs FIRRTLType:$result);
 
@@ -70,9 +68,7 @@ def CMemOp : FIRRTLOp<"cmem", [/*MemAlloc*/]> {
 
 def SMemOp : FIRRTLOp<"smem", [/*MemAlloc*/]> {
   let summary = "Define a new smem";
-  let arguments = (
-    ins RUWAttr:$ruw,
-        OptionalAttr<StrAttr>:$name,
+  let arguments = (ins RUWAttr:$ruw, StrAttr:$name,
         DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations);
   let results = (outs FIRRTLType:$result);
 
@@ -86,8 +82,7 @@ def MemOp : FIRRTLOp<"mem", [/*MemAlloc*/]> {
     ins Confined<I32Attr, [IntMinValue<0>]>:$readLatency,
         Confined<I32Attr, [IntMinValue<1>]>:$writeLatency,
         Confined<I64Attr, [IntMinValue<1>]>:$depth, RUWAttr:$ruw,
-        StrArrayAttr:$portNames,
-        OptionalAttr<StrAttr>:$name,
+        StrArrayAttr:$portNames, StrAttr:$name,
         DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations);
   let results = (outs Variadic<FIRRTLType>:$results);
 
@@ -146,8 +141,7 @@ def NodeOp : FIRRTLOp<"node", [NoSideEffect, SameOperandsAndResultType]> {
     }];
 
   let arguments = (
-    ins PassiveType:$input,
-        OptionalAttr<StrAttr>:$name,
+    ins PassiveType:$input, StrAttr:$name,
         DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations);
   let results = (outs FIRRTLType:$result);
 
@@ -166,8 +160,7 @@ def RegOp : FIRRTLOp<"reg", [/*MemAlloc*/]> {
     }];
 
   let arguments = (
-    ins ClockType:$clockVal,
-      OptionalAttr<StrAttr>:$name,
+    ins ClockType:$clockVal, StrAttr:$name,
       DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations);
   let results = (outs PassiveType:$result);
 
@@ -175,14 +168,13 @@ def RegOp : FIRRTLOp<"reg", [/*MemAlloc*/]> {
     OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$clockVal,
                    CArg<"StringRef", "{}">:$name,
                    CArg<"ArrayRef<Attribute>","{}">:$annotations), [{
-      return build($_builder, $_state, elementType, clockVal,
-                   $_builder.getStringAttr(name),
+      return build($_builder, $_state, elementType, clockVal, name,
                    $_builder.getArrayAttr(annotations));
     }]>
   ];
 
   let assemblyFormat =
-    "operands custom<ElideAnnotations>(attr-dict) `:` functional-type(operands, $result)";
+    "operands custom<ImplicitSSAName>(attr-dict) `:` functional-type(operands, $result)";
 }
 
 def RegResetOp : FIRRTLOp<"regreset", [/*MemAlloc*/]> {
@@ -196,7 +188,7 @@ def RegResetOp : FIRRTLOp<"regreset", [/*MemAlloc*/]> {
 
   let arguments = (
     ins ClockType:$clockVal, ResetType:$resetSignal,
-        PassiveType:$resetValue, OptionalAttr<StrAttr>:$name,
+        PassiveType:$resetValue, StrAttr:$name,
         DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations);
   let results = (outs PassiveType:$result);
 
@@ -206,13 +198,13 @@ def RegResetOp : FIRRTLOp<"regreset", [/*MemAlloc*/]> {
                    CArg<"StringRef", "{}">:$name,
                    CArg<"ArrayRef<Attribute>","{}">:$annotations), [{
       return build($_builder, $_state, elementType, clockVal, resetSignal,
-                   resetValue, $_builder.getStringAttr(name),
+                   resetValue, name,
                    $_builder.getArrayAttr(annotations));
     }]>
   ];
 
   let assemblyFormat =
-     "operands custom<ElideAnnotations>(attr-dict) `:` functional-type(operands, $result)";
+     "operands custom<ImplicitSSAName>(attr-dict) `:` functional-type(operands, $result)";
 }
 
 def WireOp : FIRRTLOp<"wire", []> {
@@ -225,7 +217,7 @@ def WireOp : FIRRTLOp<"wire", []> {
     }];
 
   let arguments = (
-    ins OptionalAttr<StrAttr>:$name,
+    ins StrAttr:$name,
         DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations);
   let results = (outs FIRRTLType:$result);
 
@@ -233,8 +225,7 @@ def WireOp : FIRRTLOp<"wire", []> {
     OpBuilder<(ins "::mlir::Type":$elementType,
                       CArg<"StringRef", "{}">:$name,
                       CArg<"ArrayRef<Attribute>","{}">:$annotations), [{
-      return build($_builder, $_state, elementType,
-                   $_builder.getStringAttr(name),
+      return build($_builder, $_state, elementType, name,
                    $_builder.getArrayAttr(annotations));
     }]>
   ];

--- a/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
+++ b/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
@@ -1701,9 +1701,9 @@ LogicalResult FIRRTLLowering::visitDecl(RegResetOp op) {
 }
 
 LogicalResult FIRRTLLowering::visitDecl(MemOp op) {
-  StringRef memName = "mem";
-  if (op.name().hasValue())
-    memName = op.name().getValue();
+  auto memName = op.name();
+  if (memName.empty())
+    memName = "mem";
 
   // TODO: Remove this restriction and preserve aggregates in
   // memories.
@@ -1890,12 +1890,8 @@ LogicalResult FIRRTLLowering::visitDecl(InstanceOp oldInstance) {
   FlatSymbolRefAttr symbolAttr = builder.getSymbolRefAttr(newModule);
 
   // Create the new rtl.instance operation.
-  StringAttr instanceName;
-  if (oldInstance.name().hasValue())
-    instanceName = oldInstance.nameAttr();
-
   auto newInstance = builder.create<rtl::InstanceOp>(
-      resultTypes, instanceName, symbolAttr, operands, parameters);
+      resultTypes, oldInstance.nameAttr(), symbolAttr, operands, parameters);
 
   // Now that we have the new rtl.instance, we need to remap all of the users
   // of the outputs/results to the values returned by the instance.

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -1659,7 +1659,7 @@ bool HandshakeBuilder::visitHandshake(MemoryOp op) {
   RUWAttr ruw = RUWAttr::Old;
   uint64_t depth = type.getNumElements();
   FIRRTLType dataType = getFIRRTLType(elementType);
-  StringAttr name = rewriter.getStringAttr("mem" + std::to_string(op.id()));
+  auto name = "mem" + std::to_string(op.id());
 
   // Helpers to get port identifiers.
   auto loadIdentifier = [&](size_t i) {

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -58,9 +58,9 @@ static bool isUselessName(StringRef name) {
 }
 
 /// If the specified name is a useless temporary name produced by FIRRTL, return
-/// an empty attribute to ignore it.  Otherwise, return the argument unmodified.
-static StringAttr filterUselessName(StringAttr name) {
-  return isUselessName(name.getValue()) ? StringAttr() : name;
+/// an empty string to ignore it.  Otherwise, return the argument unmodified.
+static StringRef filterUselessName(StringRef name) {
+  return isUselessName(name) ? "" : name;
 }
 
 //===----------------------------------------------------------------------===//
@@ -1749,7 +1749,7 @@ ParseResult FIRStmtParser::parseMemPort(MemDirAttr direction) {
   if (auto isExpr = parseExpWithLeadingKeyword(spelling, info))
     return isExpr.getValue();
 
-  StringAttr resultValue;
+  StringRef resultValue;
   StringRef memName;
   SymbolValueEntry memorySym;
   Value memory, indexExp, clock;
@@ -1772,9 +1772,9 @@ ParseResult FIRStmtParser::parseMemPort(MemDirAttr direction) {
     return emitError(info.getFIRLoc(), "memory should have vector type");
   auto resultType = memVType.getElementType();
 
+  auto name = builder.getStringAttr(filterUselessName(resultValue));
   auto result = builder.create<MemoryPortOp>(info.getLoc(), resultType, memory,
-                                             indexExp, clock, direction,
-                                             filterUselessName(resultValue));
+                                             indexExp, clock, direction, name);
 
   // TODO(firrtl scala bug): If the next operation is a skip, just eat it if it
   // is at the same indent level as us.  This is a horrible hack on top of the
@@ -1820,19 +1820,18 @@ ParseResult FIRStmtParser::parseMemPort(MemDirAttr direction) {
       OpBuilder memOpBuilder(scopeAndOperation.second);
 
       auto wireHack = memOpBuilder.create<WireOp>(
-          info.getLoc(), result.getType(), StringAttr(), ArrayAttr());
+          info.getLoc(), result.getType(), "", ArrayAttr());
       builder.create<ConnectOp>(info.getLoc(), wireHack, result);
 
       // Inject this the wire's name into the same scope as the memory.
       symbolTable.insertIntoScope(
-          scopeAndOperation.first,
-          Identifier::get(resultValue.getValue(), getContext()),
+          scopeAndOperation.first, Identifier::get(resultValue, getContext()),
           {info.getFIRLoc(), SymbolValueEntry(wireHack)});
       return success();
     }
   }
 
-  return addSymbolEntry(resultValue.getValue(), result, info.getFIRLoc());
+  return addSymbolEntry(resultValue, result, info.getFIRLoc());
 }
 
 /// printf ::= 'printf(' exp exp StringLit exp* ')' info?
@@ -2134,7 +2133,7 @@ ParseResult FIRStmtParser::parseInstance() {
   if (auto isExpr = parseExpWithLeadingKeyword("inst", info))
     return isExpr.getValue();
 
-  StringAttr id;
+  StringRef id;
   StringRef moduleName;
   if (parseId(id, "expected instance name") ||
       parseToken(FIRToken::kw_of, "expected 'of' in instance") ||
@@ -2166,10 +2165,10 @@ ParseResult FIRStmtParser::parseInstance() {
   }
   auto name = filterUselessName(id);
   ArrayAttr annotations = builder.getArrayAttr({});
-  getAnnotations(getModuleTarget() + ">" + name.getValue(), annotations);
+  getAnnotations(getModuleTarget() + ">" + name, annotations);
   auto result = builder.create<InstanceOp>(
-      info.getLoc(), resultTypes, builder.getSymbolRefAttr(moduleName),
-      builder.getArrayAttr(resultNames), name, annotations);
+      info.getLoc(), resultTypes, moduleName, builder.getArrayAttr(resultNames),
+      name, annotations);
 
   // Since we are implicitly unbundling the instance results, we need to keep
   // track of the mapping from bundle fields to results in the unbundledValues
@@ -2183,7 +2182,7 @@ ParseResult FIRStmtParser::parseInstance() {
   // it.
   unbundledValues.push_back(std::move(unbundledValueEntry));
   auto entryId = UnbundledID(unbundledValues.size());
-  return addSymbolEntry(id.getValue(), entryId, info.getFIRLoc());
+  return addSymbolEntry(id, entryId, info.getFIRLoc());
 }
 
 /// cmem ::= 'cmem' id ':' type info?
@@ -2197,7 +2196,7 @@ ParseResult FIRStmtParser::parseCMem() {
   if (auto isExpr = parseExpWithLeadingKeyword("cmem", info))
     return isExpr.getValue();
 
-  StringAttr id;
+  StringRef id;
   FIRRTLType type;
   if (parseId(id, "expected cmem name") ||
       parseToken(FIRToken::colon, "expected ':' in cmem") ||
@@ -2206,16 +2205,16 @@ ParseResult FIRStmtParser::parseCMem() {
 
   auto name = filterUselessName(id);
   ArrayAttr annotations = builder.getArrayAttr({});
-  getAnnotations(getModuleTarget() + ">" + name.getValue(), annotations);
+  getAnnotations(getModuleTarget() + ">" + name, annotations);
 
   auto result = builder.create<CMemOp>(info.getLoc(), type, name, annotations);
 
   // Remember that this memory is in this symbol table scope.
   // TODO(chisel bug): This should be removed along with memoryScopeTable.
-  memoryScopeTable.insert(Identifier::get(id.getValue(), getContext()),
+  memoryScopeTable.insert(Identifier::get(id, getContext()),
                           {symbolTable.getCurScope(), result.getOperation()});
 
-  return addSymbolEntry(id.getValue(), result, info.getFIRLoc());
+  return addSymbolEntry(id, result, info.getFIRLoc());
 }
 
 /// smem ::= 'smem' id ':' type ruw? info?
@@ -2229,7 +2228,7 @@ ParseResult FIRStmtParser::parseSMem() {
   if (auto isExpr = parseExpWithLeadingKeyword("smem", info))
     return isExpr.getValue();
 
-  StringAttr id;
+  StringRef id;
   FIRRTLType type;
   RUWAttr ruw = RUWAttr::Undefined;
 
@@ -2241,17 +2240,17 @@ ParseResult FIRStmtParser::parseSMem() {
 
   auto name = filterUselessName(id);
   ArrayAttr annotations = builder.getArrayAttr({});
-  getAnnotations(getModuleTarget() + ">" + name.getValue(), annotations);
+  getAnnotations(getModuleTarget() + ">" + name, annotations);
 
   auto result =
       builder.create<SMemOp>(info.getLoc(), type, ruw, name, annotations);
 
   // Remember that this memory is in this symbol table scope.
   // TODO(chisel bug): This should be removed along with memoryScopeTable.
-  memoryScopeTable.insert(Identifier::get(id.getValue(), getContext()),
+  memoryScopeTable.insert(Identifier::get(id, getContext()),
                           {symbolTable.getCurScope(), result.getOperation()});
 
-  return addSymbolEntry(id.getValue(), result, info.getFIRLoc());
+  return addSymbolEntry(id, result, info.getFIRLoc());
 }
 
 /// mem ::= 'mem' id ':' info? INDENT memField* DEDENT
@@ -2272,7 +2271,7 @@ ParseResult FIRStmtParser::parseMem(unsigned memIndent) {
   if (auto isExpr = parseExpWithLeadingKeyword("mem", info))
     return isExpr.getValue();
 
-  StringAttr id;
+  StringRef id;
   if (parseId(id, "expected mem name") ||
       parseToken(FIRToken::colon, "expected ':' in mem") ||
       parseOptionalInfo(info))
@@ -2375,11 +2374,11 @@ ParseResult FIRStmtParser::parseMem(unsigned memIndent) {
 
   auto name = filterUselessName(id);
   ArrayAttr annotations = builder.getArrayAttr({});
-  getAnnotations(getModuleTarget() + ">" + name.getValue(), annotations);
+  getAnnotations(getModuleTarget() + ">" + name, annotations);
 
   auto result = builder.create<MemOp>(
       info.getLoc(), resultTypes, readLatency, writeLatency, depth, ruw,
-      builder.getArrayAttr(resultNames), filterUselessName(id), annotations);
+      builder.getArrayAttr(resultNames), name, annotations);
 
   UnbundledValueEntry unbundledValueEntry;
   unbundledValueEntry.reserve(result.getNumResults());
@@ -2391,10 +2390,10 @@ ParseResult FIRStmtParser::parseMem(unsigned memIndent) {
 
   // Remember that this memory is in this symbol table scope.
   // TODO(chisel bug): This should be removed along with memoryScopeTable.
-  memoryScopeTable.insert(Identifier::get(id.getValue(), getContext()),
+  memoryScopeTable.insert(Identifier::get(id, getContext()),
                           {symbolTable.getCurScope(), result.getOperation()});
 
-  return addSymbolEntry(id.getValue(), entryID, info.getFIRLoc());
+  return addSymbolEntry(id, entryID, info.getFIRLoc());
 }
 
 /// node ::= 'node' id '=' exp info?
@@ -2408,7 +2407,7 @@ ParseResult FIRStmtParser::parseNode() {
   if (auto isExpr = parseExpWithLeadingKeyword("node", info))
     return isExpr.getValue();
 
-  StringAttr id;
+  StringRef id;
   Value initializer;
   SmallVector<Operation *, 8> subOps;
   if (parseId(id, "expected node name") ||
@@ -2450,15 +2449,14 @@ ParseResult FIRStmtParser::parseNode() {
   //
   // TODO: This optimization doesn't respect annotated, temporary nodes.
   Value result;
-  if (actualName) {
+  if (!actualName.empty()) {
     ArrayAttr annotations = builder.getArrayAttr({});
-    getAnnotations(getModuleTarget() + ">" + actualName.getValue(),
-                   annotations);
-    result = builder.create<NodeOp>(info.getLoc(), initializer, actualName,
-                                    annotations);
+    getAnnotations(getModuleTarget() + ">" + actualName, annotations);
+    result = builder.create<NodeOp>(info.getLoc(), initializerType, initializer,
+                                    actualName, annotations);
   } else
     result = initializer;
-  return addSymbolEntry(id.getValue(), result, info.getFIRLoc());
+  return addSymbolEntry(id, result, info.getFIRLoc());
 }
 
 /// wire ::= 'wire' id ':' type info?
@@ -2471,7 +2469,7 @@ ParseResult FIRStmtParser::parseWire() {
   if (auto isExpr = parseExpWithLeadingKeyword("wire", info))
     return isExpr.getValue();
 
-  StringAttr id;
+  StringRef id;
   FIRRTLType type;
   if (parseId(id, "expected wire name") ||
       parseToken(FIRToken::colon, "expected ':' in wire") ||
@@ -2479,11 +2477,11 @@ ParseResult FIRStmtParser::parseWire() {
     return failure();
 
   ArrayAttr annotations = builder.getArrayAttr({});
-  getAnnotations(getModuleTarget() + ">" + id.getValue(), annotations);
+  getAnnotations(getModuleTarget() + ">" + id, annotations);
 
   auto result = builder.create<WireOp>(info.getLoc(), type,
                                        filterUselessName(id), annotations);
-  return addSymbolEntry(id.getValue(), result, info.getFIRLoc());
+  return addSymbolEntry(id, result, info.getFIRLoc());
 }
 
 /// register    ::= 'reg' id ':' type exp ('with' ':' reset_block)? info?
@@ -2505,7 +2503,7 @@ ParseResult FIRStmtParser::parseRegister(unsigned regIndent) {
   if (auto isExpr = parseExpWithLeadingKeyword("reg", info))
     return isExpr.getValue();
 
-  StringAttr id;
+  StringRef id;
   FIRRTLType type;
   Value clock;
   SmallVector<Operation *, 8> subOps;
@@ -2550,7 +2548,7 @@ ParseResult FIRStmtParser::parseRegister(unsigned regIndent) {
     // the right form. Recognize that this is happening and treat it as a
     // register without a reset for compatibility.
     // TODO(firrtl scala impl): pretty print registers without resets right.
-    if (getTokenSpelling() == id.getValue()) {
+    if (getTokenSpelling() == id) {
       consumeToken();
       if (parseToken(FIRToken::r_paren, "expected ')' in reset specifier") ||
           parseOptionalInfo(info, subOps))
@@ -2576,7 +2574,7 @@ ParseResult FIRStmtParser::parseRegister(unsigned regIndent) {
 
   auto name = filterUselessName(id);
   ArrayAttr annotations = builder.getArrayAttr({});
-  getAnnotations(getModuleTarget() + ">" + name.getValue(), annotations);
+  getAnnotations(getModuleTarget() + ">" + name, annotations);
 
   Value result;
   if (resetSignal)
@@ -2586,7 +2584,7 @@ ParseResult FIRStmtParser::parseRegister(unsigned regIndent) {
     result =
         builder.create<RegOp>(info.getLoc(), type, clock, name, annotations);
 
-  return addSymbolEntry(id.getValue(), result, info.getFIRLoc());
+  return addSymbolEntry(id, result, info.getFIRLoc());
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/Transforms/BlackboxMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackboxMemory.cpp
@@ -154,10 +154,10 @@ createBlackboxModuleForMem(MemOp op,
   OpBuilder builder(op->getContext());
 
   // The module's name is the name of the memory postfixed with "_ext".
-  StringRef memName = "mem";
-  if (op.name().hasValue())
-    memName = op.name().getValue();
-  std::string extName = memName.str() + "_ext";
+  auto memName = op.name().str();
+  if (memName.empty())
+    memName = "mem";
+  std::string extName = memName + "_ext";
 
   // Create the blackbox external module.
   auto extModuleOp = builder.create<FExtModuleOp>(
@@ -201,12 +201,10 @@ createWrapperModule(MemOp op, const MemoryPortList &memPorts,
                     SmallVectorImpl<ModulePortInfo> &modPorts) {
   OpBuilder builder(op->getContext());
 
-  // Get the name of the memory.  The wrapper module name matched the external
-  // module, but without the "_ext" name.  In the event of a name collision,
-  // matches the memory name over the blackbox name.
-  StringRef memName = "mem";
-  if (op.name().hasValue())
-    memName = op.name().getValue();
+  // The wrapper module's name is the name of the memory.
+  auto memName = op.name();
+  if (memName.empty())
+    memName = "mem";
 
   // Create a wrapper module with the same type as the memory
   modPorts.reserve(op.getResults().size());

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -407,9 +407,10 @@ void TypeLoweringVisitor::visitDecl(MemOp op) {
     // TODO: Annotations are just copied to the lowered memory.
     // Change this to copy all global annotations and only those which
     // target specific ports.
-    auto newName = op.name().getValue().str() + field.suffix;
+    auto newName = op.name().str() + field.suffix;
     auto newMem = builder->create<MemOp>(
-        resultPortTypes, op.readLatency(), op.writeLatency(), depth, op.ruw(),
+        resultPortTypes, op.readLatencyAttr(), op.writeLatencyAttr(),
+        op.depthAttr(), op.ruwAttr(),
         builder->getArrayAttr(resultPortNames.getArrayRef()),
         builder->getStringAttr(newName), op.annotations());
 
@@ -452,9 +453,8 @@ void TypeLoweringVisitor::visitDecl(MemOp op) {
                            const std::string &wireName) -> Value {
           auto wire = newWires[wireName];
           if (!wire) {
-            wire = builder->create<WireOp>(type.getPassiveType(),
-                                           newMem.name().getValue().str() +
-                                               "_" + wireName);
+            wire = builder->create<WireOp>(
+                type.getPassiveType(), newMem.name().str() + "_" + wireName);
             newWires[wireName] = wire;
           }
           return wire;
@@ -538,16 +538,12 @@ void TypeLoweringVisitor::visitDecl(WireOp op) {
   SmallVector<FlatBundleFieldEntry, 8> fieldTypes;
   flattenType(resultType, "", false, fieldTypes);
 
-  // Create the prefix of the lowered name
-  StringRef wireName = "";
-  if (op.name().hasValue())
-    wireName = op.name().getValue();
-
   // Loop over the leaf aggregates.
-  SmallString<16> loweredName(wireName);
+  auto name = op.name().str();
   for (auto field : fieldTypes) {
-    loweredName.resize(wireName.size());
-    loweredName += field.suffix;
+    std::string loweredName = "";
+    if (!name.empty())
+      loweredName = name + field.suffix;
     auto wire = builder->create<WireOp>(field.getPortType(),
                                         builder->getStringAttr(loweredName),
                                         op.annotations());
@@ -574,12 +570,11 @@ void TypeLoweringVisitor::visitDecl(RegOp op) {
   flattenType(resultType, "", false, fieldTypes);
 
   // Loop over the leaf aggregates.
+  auto name = op.name().str();
   for (auto field : fieldTypes) {
-    StringAttr loweredName;
-    if (auto nameAttr = op.nameAttr())
-      loweredName =
-          builder->getStringAttr(nameAttr.getValue().str() + field.suffix);
-
+    std::string loweredName = "";
+    if (!name.empty())
+      loweredName = name + field.suffix;
     setBundleLowering(result, StringRef(field.suffix).drop_front(1),
                       builder->create<RegOp>(field.getPortType(), op.clockVal(),
                                              loweredName, op.annotations()));
@@ -605,11 +600,11 @@ void TypeLoweringVisitor::visitDecl(RegResetOp op) {
   flattenType(resultType, "", false, fieldTypes);
 
   // Loop over the leaf aggregates.
+  auto name = op.name().str();
   for (auto field : fieldTypes) {
-    StringAttr loweredName;
-    if (auto nameAttr = op.nameAttr())
-      loweredName =
-          builder->getStringAttr(nameAttr.getValue().str() + field.suffix);
+    std::string loweredName = "";
+    if (!name.empty())
+      loweredName = name + field.suffix;
     auto suffix = StringRef(field.suffix).drop_front(1);
     auto resetValLowered = getBundleLowering(op.resetValue(), suffix);
     setBundleLowering(result, suffix,

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -85,11 +85,11 @@ static void printImplicitSSAName(OpAsmPrinter &p, Operation *op,
   SmallString<32> resultNameStr;
   llvm::raw_svector_ostream tmpStream(resultNameStr);
   p.printOperand(op->getResult(0), tmpStream);
-  auto expectedName = op->getAttrOfType<StringAttr>("name");
+  auto expectedName = op->getAttrOfType<StringAttr>("name").getValue();
   auto actualName = tmpStream.str().drop_front();
-  if (actualName != expectedName.getValue()) {
+  if (actualName != expectedName) {
     // Anonymous names are printed as digits, which is fine.
-    if (!expectedName.getValue().empty() || !isdigit(actualName[0]))
+    if (!expectedName.empty() || !isdigit(actualName[0]))
       namesDisagree = true;
   }
 

--- a/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
+++ b/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
@@ -77,7 +77,7 @@ firrtl.circuit "Simple" {
     firrtl.wire {name = "test-name"} : !firrtl.uint<4>
 
     // CHECK-NEXT: = sv.wire : !rtl.inout<i2>
-    firrtl.wire : !firrtl.uint<2>
+    %_t_1 = firrtl.wire : !firrtl.uint<2>
 
     // CHECK-NEXT: = firrtl.wire : !firrtl.vector<uint<1>, 13>
     %_t_2 = firrtl.wire : !firrtl.vector<uint<1>, 13>
@@ -139,7 +139,7 @@ firrtl.circuit "Simple" {
     %n1 = firrtl.node %in2  {name = "n1"} : !firrtl.uint<2>
 
     // Nodes with no names are just dropped.
-    %22 = firrtl.node %n1 : !firrtl.uint<2>
+    %22 = firrtl.node %n1 {name = ""} : !firrtl.uint<2>
 
     // CHECK-NEXT: [[CVT:%.+]] = comb.concat %false, %in2 : (i1, i2) -> i3
     %23 = firrtl.cvt %22 : (!firrtl.uint<2>) -> !firrtl.sint<3>
@@ -218,12 +218,12 @@ firrtl.circuit "Simple" {
     %c1175_ui11 = firrtl.constant(1175 : ui11) : !firrtl.uint<11>
     %51 = firrtl.neg %c1175_ui11 : (!firrtl.uint<11>) -> !firrtl.sint<12>
     // https://github.com/llvm/circt/issues/821
-    // CHECK:  = comb.concat %false, %in1 : (i1, i4) -> i5
-    // CHECK:  = comb.sub %c0_i5, %65 : i5
+    // CHECK: [[CONCAT:%.+]] = comb.concat %false, %in1 : (i1, i4) -> i5
+    // CHECK:  = comb.sub %c0_i5, [[CONCAT]] : i5
     %52 = firrtl.neg %in1 : (!firrtl.uint<4>) -> !firrtl.sint<5>
     %53 = firrtl.neg %in4 : (!firrtl.uint<0>) -> !firrtl.sint<1>
-    // CHECK: = comb.sext %in3 : (i8) -> i9
-    // CHECK: = comb.sub %c0_i9, %67 : i9
+    // CHECK: [[SEXT:%.+]] = comb.sext %in3 : (i8) -> i9
+    // CHECK: = comb.sub %c0_i9, [[SEXT]] : i9
     %54 = firrtl.neg %in3 : (!firrtl.sint<8>) -> !firrtl.sint<9>
     // CHECK: rtl.output %false, %false : i1, i1
     firrtl.connect %out1, %53 : !firrtl.flip<sint<1>>, !firrtl.sint<1>

--- a/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
@@ -10,48 +10,48 @@
 
 // Stage 0 ready wire and valid register.
 // CHECK:   %readyWire0 = firrtl.wire : !firrtl.uint<1>
-// CHECK:   %[[VALID_REG0:.+]] = firrtl.regreset %clock, %reset, %c0_ui1 {name = "validReg0"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   %validReg0 = firrtl.regreset %clock, %reset, %c0_ui1 : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   %ctrlValidWire0 = firrtl.wire : !firrtl.uint<1>
 // CHECK:   %ctrlReadyWire0 = firrtl.wire : !firrtl.uint<1>
 
 // pred_ready = !reg_valid || succ_ready.
-// CHECK:   %[[VAL_4:.+]] = firrtl.not %[[VALID_REG0]] : (!firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   %[[VAL_4:.+]] = firrtl.not %validReg0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   %[[VAL_5:.+]] = firrtl.or %[[VAL_4:.+]], %readyWire0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   firrtl.connect %[[IN_READY:.+]], %[[VAL_5:.+]] : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 
 // Drive valid register.
-// CHECK:   %[[VAL_6:.+]] = firrtl.mux(%[[VAL_5:.+]], %[[IN_VALID:.+]], %[[VALID_REG0]]) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %[[VALID_REG0]], %[[VAL_6:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   %[[VAL_6:.+]] = firrtl.mux(%[[VAL_5:.+]], %[[IN_VALID:.+]], %validReg0) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   firrtl.connect %validReg0, %[[VAL_6:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
 
 // Stage 0 ready register.
-// CHECK:   %[[READY_REG0:.+]] = firrtl.regreset %clock, %reset, %c0_ui1_0 {name = "readyReg"}
+// CHECK:   %readyReg = firrtl.regreset %clock, %reset, %c0_ui1_0
 
 // succ_valid = readyReg ? readyReg : pred_valid
-// CHECK:   %[[SUCC_VALID0:.+]] = firrtl.mux(%[[READY_REG0]], %[[READY_REG0]], %[[VALID_REG0]])
+// CHECK:   %[[SUCC_VALID0:.+]] = firrtl.mux(%readyReg, %readyReg, %validReg0)
 // CHECK:   firrtl.connect %ctrlValidWire0, %[[SUCC_VALID0]]
 
 // pred_ready = !readyReg
-// CHECK:   %[[NOT_READY0:.+]] = firrtl.not %[[READY_REG0]]
+// CHECK:   %[[NOT_READY0:.+]] = firrtl.not %readyReg
 // CHECK:   firrtl.connect %readyWire0, %[[NOT_READY0]]
 
 // Stage 1 logics.
 // CHECK:   %readyWire1 = firrtl.wire : !firrtl.uint<1>
-// CHECK:   %[[VALID_REG1:.+]] = firrtl.regreset %clock, %reset, %c0_ui1 {name = "[[VALID_REG1]]"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   %validReg1 = firrtl.regreset %clock, %reset, %c0_ui1 : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   %ctrlValidWire1 = firrtl.wire : !firrtl.uint<1>
 // CHECK:   %ctrlReadyWire1 = firrtl.wire : !firrtl.uint<1>
 
-// CHECK:   %[[VAL_7:.+]] = firrtl.not %[[VALID_REG1]] : (!firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   %[[VAL_7:.+]] = firrtl.not %validReg1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   %[[VAL_8:.+]] = firrtl.or %[[VAL_7:.+]], %readyWire1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   firrtl.connect %ctrlReadyWire0, %[[VAL_8:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
 
-// CHECK:   %[[VAL_9:.+]] = firrtl.mux(%[[VAL_8:.+]], %ctrlValidWire0, %[[VALID_REG1]]) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %[[VALID_REG1]], %[[VAL_9:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   %[[VAL_9:.+]] = firrtl.mux(%[[VAL_8:.+]], %ctrlValidWire0, %validReg1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   firrtl.connect %validReg1, %[[VAL_9:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
 
 // Stage 1 ready register.
 // CHECK:   %[[READY_REG1:.+]] = firrtl.regreset %clock, %reset, %c0_ui1_1 {name = "readyReg"}
 
 // succ_valid = readyReg ? readyReg : pred_valid
-// CHECK:   %[[SUCC_VALID1:.+]] = firrtl.mux(%[[READY_REG1]], %[[READY_REG1]], %[[VALID_REG1]])
+// CHECK:   %[[SUCC_VALID1:.+]] = firrtl.mux(%[[READY_REG1]], %[[READY_REG1]], %validReg1)
 // CHECK:   firrtl.connect %ctrlValidWire1, %[[SUCC_VALID1]]
 
 // pred_ready = !readyReg
@@ -60,7 +60,7 @@
 
 // Stage 2 logics.
 // CHECK:   %readyWire2 = firrtl.wire : !firrtl.uint<1>
-// CHECK:   %validReg2 = firrtl.regreset %clock, %reset, %c0_ui1 {name = "validReg2"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   %validReg2 = firrtl.regreset %clock, %reset, %c0_ui1 : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 
 // CHECK:   %[[VAL_10:.+]] = firrtl.not %validReg2 : (!firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   %[[VAL_11:.+]] = firrtl.or %[[VAL_10:.+]], %readyWire2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
@@ -91,22 +91,22 @@ handshake.func @test_buffer(%arg0: none, %arg1: none, ...) -> (none, none) {
 // CHECK:   %[[OUT_DATA:.+]] = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
 // CHECK:   %c0_ui64 = firrtl.constant(0 : ui64) : !firrtl.uint<64>
 
-// CHECK:   %[[DATA_REG0:.+]] = firrtl.regreset %clock, %reset, %c0_ui64 {name = "dataReg0"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<64>) -> !firrtl.uint<64>
+// CHECK:   %dataReg0 = firrtl.regreset %clock, %reset, %c0_ui64 : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<64>) -> !firrtl.uint<64>
 
-// CHECK:   %[[VAL_9:.+]] = firrtl.mux(%[[VAL_7:.+]], %[[IN_DATA:.+]], %[[DATA_REG0]]) : (!firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>) -> !firrtl.uint<64>
-// CHECK:   firrtl.connect %[[DATA_REG0]], %[[VAL_9:.+]] : !firrtl.uint<64>, !firrtl.uint<64>
+// CHECK:   %[[VAL_9:.+]] = firrtl.mux(%[[VAL_7:.+]], %[[IN_DATA:.+]], %dataReg0) : (!firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>) -> !firrtl.uint<64>
+// CHECK:   firrtl.connect %dataReg0, %[[VAL_9:.+]] : !firrtl.uint<64>, !firrtl.uint<64>
 
-// CHECK:   %[[CTRL_DATA_REG0:.+]] = firrtl.regreset %clock, %reset, %c0_ui64_1 {name = "ctrlDataReg"}
-// CHECK:   %[[SUCC_DATA0:.+]] = firrtl.mux(%readyReg{{.*}}, %[[CTRL_DATA_REG0]], %[[DATA_REG0]])
+// CHECK:   %ctrlDataReg = firrtl.regreset %clock, %reset, %c0_ui64_1
+// CHECK:   %[[SUCC_DATA0:.+]] = firrtl.mux(%readyReg{{.*}}, %ctrlDataReg, %dataReg0)
 // CHECK:   firrtl.connect %ctrlDataWire0, %[[SUCC_DATA0]]
 
-// CHECK:   %[[DATA_REG1:.+]] = firrtl.regreset %clock, %reset, %c0_ui64 {name = "dataReg1"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<64>) -> !firrtl.uint<64>
+// CHECK:   %dataReg1 = firrtl.regreset %clock, %reset, %c0_ui64 : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<64>) -> !firrtl.uint<64>
 
 // CHECK:   %[[CTRL_DATA_REG1:.+]] = firrtl.regreset %clock, %reset, %c0_ui64_6 {name = "ctrlDataReg"}
-// CHECK:   %[[SUCC_DATA1:.+]] = firrtl.mux(%readyReg{{.*}}, %[[CTRL_DATA_REG1]], %[[DATA_REG1]])
+// CHECK:   %[[SUCC_DATA1:.+]] = firrtl.mux(%readyReg{{.*}}, %[[CTRL_DATA_REG1]], %dataReg1)
 // CHECK:   firrtl.connect %ctrlDataWire1, %[[SUCC_DATA1]]
 
-// CHECK:   %[[VAL_13:.+]] = firrtl.mux(%[[VAL_11:.+]], %[[DATA_REG1]], %[[CTRL_DATA_REG1]]) : (!firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>) -> !firrtl.uint<64>
+// CHECK:   %[[VAL_13:.+]] = firrtl.mux(%[[VAL_11:.+]], %dataReg1, %[[CTRL_DATA_REG1]]) : (!firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>) -> !firrtl.uint<64>
 // CHECK:   firrtl.connect %ctrlDataRegWire{{.*}}, %[[VAL_13:.+]] : !firrtl.uint<64>, !firrtl.uint<64>
 
 

--- a/test/Conversion/HandshakeToFIRRTL/test_fork.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_fork.mlir
@@ -24,7 +24,7 @@
 // CHECK:   firrtl.connect %notAllDone, %7 : !firrtl.uint<1>, !firrtl.uint<1>
 
 // Result 0 logic.
-// CHECK:   %emtd0 = firrtl.regreset %clock, %reset, %c0_ui1 {name = "emtd0"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   %emtd0 = firrtl.regreset %clock, %reset, %c0_ui1 : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   %8 = firrtl.and %done0, %notAllDone : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   firrtl.connect %emtd0, %8 : !firrtl.uint<1>, !firrtl.uint<1>
 
@@ -42,7 +42,7 @@
 // CHECK:   firrtl.connect %done0, %12 : !firrtl.uint<1>, !firrtl.uint<1>
 
 // Result1 logic.
-// CHECK:   %emtd1 = firrtl.regreset %clock, %reset, %c0_ui1 {name = "emtd1"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   %emtd1 = firrtl.regreset %clock, %reset, %c0_ui1 : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   %13 = firrtl.and %done1, %notAllDone : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   firrtl.connect %emtd1, %13 : !firrtl.uint<1>, !firrtl.uint<1>
 

--- a/test/Dialect/FIRRTL/blackbox-memory.mlir
+++ b/test/Dialect/FIRRTL/blackbox-memory.mlir
@@ -49,7 +49,7 @@ firrtl.circuit "Read" {
 // INLINE-NEXT:     %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
 // INLINE-NEXT:     %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
 // INLINE-NEXT:     %ReadMemory_R0_addr, %ReadMemory_R0_en, %ReadMemory_R0_clk, %ReadMemory_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory", portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
-// INLINE-NEXT:     %0 = firrtl.wire  {name = ""} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+// INLINE-NEXT:     %0 = firrtl.wire : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
 // INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
 // INLINE-NEXT:     firrtl.connect %ReadMemory_R0_addr, %1 : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
 // INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<1>>
@@ -97,7 +97,7 @@ firrtl.circuit "Write" {
 // INLINE-NEXT:   firrtl.extmodule @WriteMemory_ext(!firrtl.uint<1> {firrtl.name = "W0_addr"}, !firrtl.uint<1> {firrtl.name = "W0_en"}, !firrtl.clock {firrtl.name = "W0_clk"}, !firrtl.sint<8> {firrtl.name = "W0_data"}, !firrtl.uint<1> {firrtl.name = "W0_mask"}) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // INLINE-NEXT:   firrtl.module @Write() {
 // INLINE-NEXT:     %WriteMemory_W0_addr, %WriteMemory_W0_en, %WriteMemory_W0_clk, %WriteMemory_W0_data, %WriteMemory_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory", portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.flip<sint<8>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %0 = firrtl.wire  {name = ""} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
+// INLINE-NEXT:     %0 = firrtl.wire  : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
 // INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
 // INLINE-NEXT:     firrtl.connect %WriteMemory_W0_addr, %1 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
@@ -241,7 +241,7 @@ firrtl.circuit "MemSimple" {
 // INLINE-NEXT:     %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
 // INLINE-NEXT:     %c0_ui3 = firrtl.constant(0 : ui3) : !firrtl.uint<3>
 // INLINE-NEXT:     %_M_R0_addr, %_M_R0_en, %_M_R0_clk, %_M_R0_data, %_M_W0_addr, %_M_W0_en, %_M_W0_clk, %_M_W0_data, %_M_W0_mask = firrtl.instance @_M_ext {name = "_M", portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data", "W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<42>, !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.flip<sint<42>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %0 = firrtl.wire  {name = ""} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>
+// INLINE-NEXT:     %0 = firrtl.wire  : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>
 // INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<4>>
 // INLINE-NEXT:     firrtl.connect %_M_R0_addr, %1 : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
 // INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<1>>
@@ -250,7 +250,7 @@ firrtl.circuit "MemSimple" {
 // INLINE-NEXT:     firrtl.connect %_M_R0_clk, %3 : !firrtl.flip<clock>, !firrtl.flip<clock>
 // INLINE-NEXT:     %4 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.sint<42>
 // INLINE-NEXT:     firrtl.connect %4, %_M_R0_data : !firrtl.sint<42>, !firrtl.sint<42>
-// INLINE-NEXT:     %5 = firrtl.wire  {name = ""} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>
+// INLINE-NEXT:     %5 = firrtl.wire  : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>
 // INLINE-NEXT:     %6 = firrtl.subfield %5("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<4>>
 // INLINE-NEXT:     firrtl.connect %_M_W0_addr, %6 : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
 // INLINE-NEXT:     %7 = firrtl.subfield %5("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
@@ -341,7 +341,7 @@ firrtl.circuit "NameCollision" {
 // INLINE-NEXT:   firrtl.extmodule @NameCollisionMemory_ext_0(!firrtl.uint<4> {firrtl.name = "R0_addr"}, !firrtl.uint<1> {firrtl.name = "R0_en"}, !firrtl.clock {firrtl.name = "R0_clk"}, !firrtl.flip<sint<8>> {firrtl.name = "R0_data"}) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // INLINE-NEXT:   firrtl.module @NameCollisionMemory_ext() {
 // INLINE-NEXT:     %NameCollisionMemory_R0_addr, %NameCollisionMemory_R0_en, %NameCollisionMemory_R0_clk, %NameCollisionMemory_R0_data = firrtl.instance @NameCollisionMemory_ext_0 {name = "NameCollisionMemory", portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
-// INLINE-NEXT:     %0 = firrtl.wire  {name = ""} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+// INLINE-NEXT:     %0 = firrtl.wire  : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
 // INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
 // INLINE-NEXT:     firrtl.connect %NameCollisionMemory_R0_addr, %1 : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
 // INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<1>>
@@ -353,7 +353,7 @@ firrtl.circuit "NameCollision" {
 // INLINE-NEXT:   }
 // INLINE-NEXT:   firrtl.module @NameCollision() {
 // INLINE-NEXT:     %NameCollisionMemory_W0_addr, %NameCollisionMemory_W0_en, %NameCollisionMemory_W0_clk, %NameCollisionMemory_W0_data, %NameCollisionMemory_W0_mask = firrtl.instance @NameCollisionMemory_ext_1 {name = "NameCollisionMemory", portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.flip<sint<8>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %0 = firrtl.wire  {name = ""} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
+// INLINE-NEXT:     %0 = firrtl.wire  : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
 // INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<4>>
 // INLINE-NEXT:     firrtl.connect %NameCollisionMemory_W0_addr, %1 : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
 // INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
@@ -420,7 +420,7 @@ firrtl.circuit "Duplicate" {
 // INLINE-NEXT:   firrtl.extmodule @ReadMemory_ext(!firrtl.uint<4> {firrtl.name = "R0_addr"}, !firrtl.uint<1> {firrtl.name = "R0_en"}, !firrtl.clock {firrtl.name = "R0_clk"}, !firrtl.flip<sint<8>> {firrtl.name = "R0_data"}) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // INLINE-NEXT:   firrtl.module @Duplicate() {
 // INLINE-NEXT:     %ReadMemory_R0_addr, %ReadMemory_R0_en, %ReadMemory_R0_clk, %ReadMemory_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory", portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
-// INLINE-NEXT:     %0 = firrtl.wire  {name = ""} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+// INLINE-NEXT:     %0 = firrtl.wire  : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
 // INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
 // INLINE-NEXT:     firrtl.connect %ReadMemory_R0_addr, %1 : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
 // INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<1>>
@@ -430,7 +430,7 @@ firrtl.circuit "Duplicate" {
 // INLINE-NEXT:     %4 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.sint<8>
 // INLINE-NEXT:     firrtl.connect %4, %ReadMemory_R0_data : !firrtl.sint<8>, !firrtl.sint<8>
 // INLINE-NEXT:     %WriteMemory_W0_addr, %WriteMemory_W0_en, %WriteMemory_W0_clk, %WriteMemory_W0_data, %WriteMemory_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory", portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.flip<sint<8>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %5 = firrtl.wire  {name = ""} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
+// INLINE-NEXT:     %5 = firrtl.wire  : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
 // INLINE-NEXT:     %6 = firrtl.subfield %5("addr") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
 // INLINE-NEXT:     firrtl.connect %WriteMemory_W0_addr, %6 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %7 = firrtl.subfield %5("en") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
@@ -442,7 +442,7 @@ firrtl.circuit "Duplicate" {
 // INLINE-NEXT:     %10 = firrtl.subfield %5("mask") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
 // INLINE-NEXT:     firrtl.connect %WriteMemory_W0_mask, %10 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %ReadMemory1_R0_addr, %ReadMemory1_R0_en, %ReadMemory1_R0_clk, %ReadMemory1_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory1", portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
-// INLINE-NEXT:     %11 = firrtl.wire  {name = ""} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+// INLINE-NEXT:     %11 = firrtl.wire  : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
 // INLINE-NEXT:     %12 = firrtl.subfield %11("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
 // INLINE-NEXT:     firrtl.connect %ReadMemory1_R0_addr, %12 : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
 // INLINE-NEXT:     %13 = firrtl.subfield %11("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<1>>
@@ -452,7 +452,7 @@ firrtl.circuit "Duplicate" {
 // INLINE-NEXT:     %15 = firrtl.subfield %11("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.sint<8>
 // INLINE-NEXT:     firrtl.connect %15, %ReadMemory1_R0_data : !firrtl.sint<8>, !firrtl.sint<8>
 // INLINE-NEXT:     %WriteMemory1_W0_addr, %WriteMemory1_W0_en, %WriteMemory1_W0_clk, %WriteMemory1_W0_data, %WriteMemory1_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory1", portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.flip<sint<8>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %16 = firrtl.wire  {name = ""} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
+// INLINE-NEXT:     %16 = firrtl.wire  : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
 // INLINE-NEXT:     %17 = firrtl.subfield %16("addr") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
 // INLINE-NEXT:     firrtl.connect %WriteMemory1_W0_addr, %17 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %18 = firrtl.subfield %16("en") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
@@ -464,7 +464,7 @@ firrtl.circuit "Duplicate" {
 // INLINE-NEXT:     %21 = firrtl.subfield %16("mask") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
 // INLINE-NEXT:     firrtl.connect %WriteMemory1_W0_mask, %21 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %ReadMemory2_R0_addr, %ReadMemory2_R0_en, %ReadMemory2_R0_clk, %ReadMemory2_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory2", portNames = ["R0_addr", "R0_en", "R0_clk", "R0_data"]} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
-// INLINE-NEXT:     %22 = firrtl.wire  {name = ""} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+// INLINE-NEXT:     %22 = firrtl.wire  : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
 // INLINE-NEXT:     %23 = firrtl.subfield %22("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
 // INLINE-NEXT:     firrtl.connect %ReadMemory2_R0_addr, %23 : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
 // INLINE-NEXT:     %24 = firrtl.subfield %22("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<1>>
@@ -474,7 +474,7 @@ firrtl.circuit "Duplicate" {
 // INLINE-NEXT:     %26 = firrtl.subfield %22("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.sint<8>
 // INLINE-NEXT:     firrtl.connect %26, %ReadMemory2_R0_data : !firrtl.sint<8>, !firrtl.sint<8>
 // INLINE-NEXT:     %WriteMemory2_W0_addr, %WriteMemory2_W0_en, %WriteMemory2_W0_clk, %WriteMemory2_W0_data, %WriteMemory2_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory2", portNames = ["W0_addr", "W0_en", "W0_clk", "W0_data", "W0_mask"]} : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.flip<sint<8>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %27 = firrtl.wire  {name = ""} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
+// INLINE-NEXT:     %27 = firrtl.wire  : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
 // INLINE-NEXT:     %28 = firrtl.subfield %27("addr") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
 // INLINE-NEXT:     firrtl.connect %WriteMemory2_W0_addr, %28 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %29 = firrtl.subfield %27("en") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -192,7 +192,7 @@ firrtl.circuit "Foo" {
 
   firrtl.extmodule @Foo()
   // expected-error @+1 {{'firrtl.instance' op should be embedded in a 'firrtl.module'}}
-  firrtl.instance @Foo {portNames = []}
+  firrtl.instance @Foo {name = "", portNames = []}
 
 }
 
@@ -203,7 +203,7 @@ firrtl.circuit "Foo" {
   // expected-note @+1 {{containing module declared here}}
   firrtl.module @Foo() {
     // expected-error @+1 {{'firrtl.instance' op is a recursive instantiation of its containing module}}
-    firrtl.instance @Foo {portNames = []}
+    firrtl.instance @Foo {name = "", portNames = []}
   }
 
 }
@@ -216,7 +216,7 @@ firrtl.circuit "Foo" {
   firrtl.module @Callee(%arg0: !firrtl.uint<1>) { }
   firrtl.module @Foo() {
     // expected-error @+1 {{'firrtl.instance' op result type for "arg0" must be '!firrtl.flip<uint<1>>', but got '!firrtl.uint<2>'}}
-    %a = firrtl.instance @Callee {portNames = ["arg0"]} : !firrtl.uint<2>
+    %a = firrtl.instance @Callee {name = "", portNames = ["arg0"]} : !firrtl.uint<2>
   }
 }
 
@@ -228,7 +228,7 @@ firrtl.circuit "Foo" {
   firrtl.module @Callee(%arg0: !firrtl.uint<1> ) { }
   firrtl.module @Foo() {
     // expected-error @+1 {{'firrtl.instance' op has a wrong number of results; expected 1 but got 0}}
-    firrtl.instance @Callee {portNames = []}
+    firrtl.instance @Callee {name = "", portNames = []}
   }
 }
 
@@ -240,7 +240,7 @@ firrtl.circuit "Foo" {
   firrtl.module @Callee(%arg0: !firrtl.uint<1>, %arg1: !firrtl.bundle<valid: uint<1>>) { }
   firrtl.module @Foo() {
     // expected-error @+1 {{'firrtl.instance' op result type for "arg0" must be '!firrtl.flip<uint<1>>', but got '!firrtl.uint<1>'}}
-    %a:2 = firrtl.instance @Callee {portNames = ["arg0", "arg1"]}
+    %a:2 = firrtl.instance @Callee {name = "", portNames = ["arg0", "arg1"]}
     : !firrtl.uint<1>, !firrtl.bundle<valid: uint<2>>
   }
 }
@@ -288,7 +288,7 @@ firrtl.module @SubModule(%a : !firrtl.uint<1>) {
 
 firrtl.module @TopModule() {
   // expected-error @+1 {{'firrtl.instance' op is missing a port named '"a"' expected by referenced module}}
-  %0 = firrtl.instance @SubModule {portNames = ["arg0"]}: !firrtl.sint<1>
+  %0 = firrtl.instance @SubModule {name = "", portNames = ["arg0"]}: !firrtl.sint<1>
 }
 
 }

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -415,7 +415,7 @@ module  {
 firrtl.circuit "RegBundle" {
     // CHECK-LABEL: firrtl.module @RegBundle(%a_a: !firrtl.uint<1>, %clk: !firrtl.clock, %b_a: !firrtl.flip<uint<1>>) {
     firrtl.module @RegBundle(%a: !firrtl.bundle<a: uint<1>>, %clk: !firrtl.clock, %b: !firrtl.flip<bundle<a: uint<1>>>) {
-      // CHECK-NEXT: %x_a = firrtl.reg %clk {name = "x_a"} : (!firrtl.clock) -> !firrtl.uint<1>
+      // CHECK-NEXT: %x_a = firrtl.reg %clk : (!firrtl.clock) -> !firrtl.uint<1>
       // CHECK-NEXT: firrtl.connect %x_a, %a_a : !firrtl.uint<1>, !firrtl.uint<1>
       // CHECK-NEXT: firrtl.connect %b_a, %x_a : !firrtl.flip<uint<1>>, !firrtl.uint<1>
       %x = firrtl.reg %clk {name = "x"} : (!firrtl.clock) -> !firrtl.bundle<a: uint<1>>
@@ -433,7 +433,7 @@ firrtl.circuit "RegBundle" {
 firrtl.circuit "RegBundleWithBulkConnect" {
     // CHECK-LABEL: firrtl.module @RegBundleWithBulkConnect(%a_a: !firrtl.uint<1>, %clk: !firrtl.clock, %b_a: !firrtl.flip<uint<1>>) {
     firrtl.module @RegBundleWithBulkConnect(%a: !firrtl.bundle<a: uint<1>>, %clk: !firrtl.clock, %b: !firrtl.flip<bundle<a: uint<1>>>) {
-      // CHECK-NEXT: %x_a = firrtl.reg %clk {name = "x_a"} : (!firrtl.clock) -> !firrtl.uint<1>
+      // CHECK-NEXT: %x_a = firrtl.reg %clk : (!firrtl.clock) -> !firrtl.uint<1>
       // CHECK-NEXT: firrtl.connect %x_a, %a_a : !firrtl.uint<1>, !firrtl.uint<1>
       // CHECK-NEXT: firrtl.connect %b_a, %x_a : !firrtl.flip<uint<1>>, !firrtl.uint<1>
       %x = firrtl.reg %clk {name = "x"} : (!firrtl.clock) -> !firrtl.bundle<a: uint<1>>
@@ -538,8 +538,8 @@ firrtl.circuit "LowerRegResetOp" {
   // CHECK:   %init_1 = firrtl.wire  : !firrtl.uint<1>
   // CHECK:   firrtl.connect %init_0, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:   firrtl.connect %init_1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK:   %r_0 = firrtl.regreset %clock, %reset, %init_0 {name = "r_0"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-  // CHECK:   %r_1 = firrtl.regreset %clock, %reset, %init_1 {name = "r_1"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  // CHECK:   %r_0 = firrtl.regreset %clock, %reset, %init_0 : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  // CHECK:   %r_1 = firrtl.regreset %clock, %reset, %init_1 : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   // CHECK:   firrtl.connect %r_0, %a_d_0 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:   firrtl.connect %r_1, %a_d_1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:   firrtl.connect %a_q_0, %r_0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
@@ -559,7 +559,7 @@ firrtl.circuit "LowerRegResetOpNoName" {
     firrtl.connect %0, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     %1 = firrtl.subindex %init[1] : !firrtl.vector<uint<1>, 2>
     firrtl.connect %1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-    %r = firrtl.regreset %clock, %reset, %init : (!firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<1>, 2>) -> !firrtl.vector<uint<1>, 2>
+    %r = firrtl.regreset %clock, %reset, %init {name = ""} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<1>, 2>) -> !firrtl.vector<uint<1>, 2>
     firrtl.connect %r, %a_d : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
     firrtl.connect %a_q, %r : !firrtl.flip<vector<uint<1>, 2>>, !firrtl.vector<uint<1>, 2>
   }
@@ -568,8 +568,8 @@ firrtl.circuit "LowerRegResetOpNoName" {
   // CHECK:   %init_1 = firrtl.wire  : !firrtl.uint<1>
   // CHECK:   firrtl.connect %init_0, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:   firrtl.connect %init_1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK:   0 = firrtl.regreset %clock, %reset, %init_0 : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-  // CHECK:   1 = firrtl.regreset %clock, %reset, %init_1 : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  // CHECK:   %0 = firrtl.regreset %clock, %reset, %init_0 : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  // CHECK:   %1 = firrtl.regreset %clock, %reset, %init_1 : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   // CHECK:   firrtl.connect %0, %a_d_0 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:   firrtl.connect %1, %a_d_1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:   firrtl.connect %a_q_0, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
@@ -583,7 +583,7 @@ firrtl.circuit "LowerRegResetOpNoName" {
 firrtl.circuit "lowerRegOpNoName" {
   // CHECK-LABEL: firrtl.module @lowerRegOpNoName
   firrtl.module @lowerRegOpNoName(%clock: !firrtl.clock, %a_d: !firrtl.vector<uint<1>, 2>, %a_q: !firrtl.flip<vector<uint<1>, 2>>) {
-    %r = firrtl.reg %clock : (!firrtl.clock) -> !firrtl.vector<uint<1>, 2>
+    %r = firrtl.reg %clock {name = ""} : (!firrtl.clock) -> !firrtl.vector<uint<1>, 2>
       firrtl.connect %r, %a_d : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
       firrtl.connect %a_q, %r : !firrtl.flip<vector<uint<1>, 2>>, !firrtl.vector<uint<1>, 2>
   }

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -246,11 +246,11 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.mux(%reset, %i8, %{{.*}}) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint) -> !firrtl.uint
     node n8 = mux(reset, i8, UInt(4))
 
-    ; CHECK: firrtl.regreset %clock, %reset, %{{.*}} {name = "_t_2621"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>) -> !firrtl.uint<4>
+    ; CHECK: %_t_2621 = firrtl.regreset %clock, %reset, %{{.*}} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>) -> !firrtl.uint<4>
     reg _t_2621 : UInt<4>, clock with :
       reset => (reset, UInt<4>("h0")) @[Edges.scala 230:27]
 
-    ; CHECK: firrtl.regreset %clock, %reset, %{{.*}} {name = "_t_1601"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<2>) -> !firrtl.uint<2>
+    ; CHECK: %_t_1601 = firrtl.regreset %clock, %reset, %{{.*}} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<2>) -> !firrtl.uint<2>
     reg _t_1601 : UInt<2>, clock with :
       (reset => (reset, UInt<2>("h00"))) @[Edges.scala 230:27]
 
@@ -268,7 +268,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; The Scala implementation of FIRRTL prints registers without a reset value
     ; using the register name as the reset.  Make sure we handle this for
     ; compatibility.
-    ; CHECK: firrtl.reg %clock {name = "_t_2622"} : (!firrtl.clock) -> !firrtl.uint<4>
+    ; CHECK: %_t_2622 = firrtl.reg %clock : (!firrtl.clock) -> !firrtl.uint<4>
     reg _t_2622 : UInt<4>, clock with :
       reset => (UInt<1>("h0"), _t_2622)
 


### PR DESCRIPTION
The first part of this change makes names on FIRRTL operations
non-optional StringAttr attributes.  Empty names are still allowed, but
are now represented by an empty string "", instead of a non-existent
attribute.  This change affects the builders generated for each op, and
they now have a builder capable of taking a StringRef for the name.

The second part of this change modifies the SSA printer for registers to
use the same ImplicitSSAName as WireOps.  Since registers now require
an explicit name attribute, making this change now helped keep down the number of
test line changes.

There is a small improvement to the printer to not print empty
name strings.