### PR TITLE
[Python] Register passes, export_verilog, and stack traces

### DIFF
--- a/include/circt-c/Dialect/ESI.h
+++ b/include/circt-c/Dialect/ESI.h
@@ -18,7 +18,7 @@ extern "C" {
 #endif
 
 MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(ESI, esi);
-void registerESIPasses();
+MLIR_CAPI_EXPORTED void registerESIPasses();
 
 #ifdef __cplusplus
 }

--- a/include/circt-c/Dialect/ESI.h
+++ b/include/circt-c/Dialect/ESI.h
@@ -18,6 +18,7 @@ extern "C" {
 #endif
 
 MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(ESI, esi);
+void registerESIPasses();
 
 #ifdef __cplusplus
 }

--- a/include/circt-c/Dialect/SV.h
+++ b/include/circt-c/Dialect/SV.h
@@ -18,6 +18,7 @@ extern "C" {
 #endif
 
 MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(SystemVerilog, sv);
+MLIR_CAPI_EXPORTED void registerSVPasses();
 
 #ifdef __cplusplus
 }

--- a/include/circt/Dialect/SV/SVPasses.h
+++ b/include/circt/Dialect/SV/SVPasses.h
@@ -13,6 +13,8 @@
 #ifndef CIRCT_DIALECT_SV_SVPASSES_H
 #define CIRCT_DIALECT_SV_SVPASSES_H
 
+#include "mlir/Pass/Pass.h"
+
 #include <memory>
 
 namespace mlir {

--- a/integration_test/Bindings/Python/dialects/rtl.py
+++ b/integration_test/Bindings/Python/dialects/rtl.py
@@ -7,12 +7,14 @@ from circt.dialects import rtl
 from mlir.ir import *
 from mlir.dialects import builtin
 
+import sys
+
 with Context() as ctx, Location.unknown():
     circt.register_dialects(ctx)
 
     i32 = IntegerType.get_signless(32)
 
-    m = builtin.ModuleOp()
+    m = Module.create()
     with InsertionPoint(m.body):
         # CHECK: rtl.module @MyWidget(%my_input: i32) -> (%my_output: i32)
         # CHECK:   rtl.output %my_input : i32
@@ -40,4 +42,10 @@ with Context() as ctx, Location.unknown():
             a, b = swap(a, b)
             return a, b
 
-    m.print()
+    m.operation.print()
+
+    print("=== Verilog ===")
+    # CHECK: module MyWidget
+    # CHECK: module swap
+    # CHECK: module top
+    circt.export_verilog(m, sys.stdout)

--- a/integration_test/Bindings/Python/dialects/rtl.py
+++ b/integration_test/Bindings/Python/dialects/rtl.py
@@ -5,7 +5,7 @@ import circt
 from circt.dialects import rtl
 
 from mlir.ir import *
-from mlir.dialects import builtin
+from mlir.passmanager import PassManager
 
 import sys
 
@@ -44,7 +44,11 @@ with Context() as ctx, Location.unknown():
 
     m.operation.print()
 
+    # CHECK-LABEL: === Verilog ===
     print("=== Verilog ===")
+
+    pm = PassManager.parse("rtl-legalize-names,rtl.module(rtl-cleanup)")
+    pm.run(m)
     # CHECK: module MyWidget
     # CHECK: module swap
     # CHECK: module top

--- a/lib/Bindings/Python/CIRCTModule.cpp
+++ b/lib/Bindings/Python/CIRCTModule.cpp
@@ -12,14 +12,53 @@
 #include "circt-c/Dialect/ESI.h"
 #include "circt-c/Dialect/RTL.h"
 #include "circt-c/Dialect/SV.h"
+#include "circt-c/ExportVerilog.h"
 #include "mlir-c/Bindings/Python/Interop.h"
 #include "mlir-c/Registration.h"
 
+#include "llvm-c/ErrorHandling.h"
+
+#include "PybindUtils.h"
 #include <pybind11/pybind11.h>
 namespace py = pybind11;
 
+static void registerPasses() { registerSVPasses(); }
+
+/// Taken from PybindUtils.h in MLIR
+/// Accumulates into a python file-like object, either writing text (default)
+/// or binary.
+class PyFileAccumulator {
+public:
+  PyFileAccumulator(pybind11::object fileObject, bool binary)
+      : pyWriteFunction(fileObject.attr("write")), binary(binary) {}
+
+  void *getUserData() { return this; }
+
+  MlirStringCallback getCallback() {
+    return [](MlirStringRef part, void *userData) {
+      pybind11::gil_scoped_acquire();
+      PyFileAccumulator *accum = static_cast<PyFileAccumulator *>(userData);
+      if (accum->binary) {
+        // Note: Still has to copy and not avoidable with this API.
+        pybind11::bytes pyBytes(part.data, part.length);
+        accum->pyWriteFunction(pyBytes);
+      } else {
+        pybind11::str pyStr(part.data,
+                            part.length); // Decodes as UTF-8 by default.
+        accum->pyWriteFunction(pyStr);
+      }
+    };
+  }
+
+private:
+  pybind11::object pyWriteFunction;
+  bool binary;
+};
+
 PYBIND11_MODULE(_circt, m) {
   m.doc() = "CIRCT Python Native Extension";
+  registerPasses();
+  LLVMEnablePrettyStackTrace();
 
   m.def(
       "register_dialects",
@@ -46,6 +85,12 @@ PYBIND11_MODULE(_circt, m) {
         mlirDialectHandleLoadDialect(sv, context);
       },
       "Register CIRCT dialects on a PyMlirContext.");
+
+  m.def("export_verilog", [](MlirModule mod, py::object fileObject) {
+    PyFileAccumulator accum(fileObject, false);
+    py::gil_scoped_release();
+    mlirExportVerilog(mod, accum.getCallback(), accum.getUserData());
+  });
 
   py::module esi = m.def_submodule("esi", "ESI API");
   circt::python::populateDialectESISubmodule(esi);

--- a/lib/Bindings/Python/CMakeLists.txt
+++ b/lib/Bindings/Python/CMakeLists.txt
@@ -20,6 +20,7 @@ add_mlir_python_extension(CIRCTBindingsPythonExtension _circt
     CIRCTCAPIESI
     CIRCTCAPIRTL
     CIRCTCAPISV
+    CIRCTCAPIExportVerilog
 )
 add_dependencies(CIRCTBindingsPython CIRCTBindingsPythonExtension)
 

--- a/lib/CAPI/Dialect/CMakeLists.txt
+++ b/lib/CAPI/Dialect/CMakeLists.txt
@@ -52,4 +52,5 @@ add_circt_library(CIRCTCAPISV
   LINK_LIBS PUBLIC
   MLIRCAPIIR
   CIRCTSV
+  CIRCTSVTransforms
   )

--- a/lib/CAPI/Dialect/ESI.cpp
+++ b/lib/CAPI/Dialect/ESI.cpp
@@ -9,3 +9,5 @@
 #include "mlir/CAPI/Support.h"
 
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(ESI, esi, circt::esi::ESIDialect)
+
+void registerESIPasses() { circt::esi::registerESIPasses(); }

--- a/lib/CAPI/Dialect/SV.cpp
+++ b/lib/CAPI/Dialect/SV.cpp
@@ -10,7 +10,6 @@
 #include "mlir/CAPI/IR.h"
 #include "mlir/CAPI/Registration.h"
 #include "mlir/CAPI/Support.h"
-#include "mlir/Pass/PassRegistry.h"
 
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(SystemVerilog, sv, circt::sv::SVDialect)
 

--- a/lib/CAPI/Dialect/SV.cpp
+++ b/lib/CAPI/Dialect/SV.cpp
@@ -6,8 +6,12 @@
 
 #include "circt-c/Dialect/SV.h"
 #include "circt/Dialect/SV/SVDialect.h"
+#include "circt/Dialect/SV/SVPasses.h"
 #include "mlir/CAPI/IR.h"
 #include "mlir/CAPI/Registration.h"
 #include "mlir/CAPI/Support.h"
+#include "mlir/Pass/PassRegistry.h"
 
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(SystemVerilog, sv, circt::sv::SVDialect)
+
+void registerSVPasses() { circt::sv::registerPasses(); }


### PR DESCRIPTION
- Registers the SV passes when the 'circt' Python module is imported and the ESI passes when 'circt.esi' is imported.
- Adds a Python 'export_verilog' call.
- Enables LLVM 'pretty' stack traces for easier debugging. Makes assertion messages appear in Python instead of just crashing with no output.