### PR TITLE
[FIRRTL] Fix node parsing when there is an implicit asPassive.

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2452,8 +2452,8 @@ ParseResult FIRStmtParser::parseNode() {
   if (!actualName.empty()) {
     ArrayAttr annotations = builder.getArrayAttr({});
     getAnnotations(getModuleTarget() + ">" + actualName, annotations);
-    result = builder.create<NodeOp>(info.getLoc(), initializerType, initializer,
-                                    actualName, annotations);
+    result = builder.create<NodeOp>(info.getLoc(), initializer.getType(),
+                                    initializer, actualName, annotations);
   } else
     result = initializer;
   return addSymbolEntry(id, result, info.getFIRLoc());

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -183,6 +183,10 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.asClock %reset_async : (!firrtl.asyncreset) -> !firrtl.clock
     node check_c5 = asClock(reset_async)
 
+    ; CHECK: [[PASSIVE:%.*]] = firrtl.asPassive %auto : !firrtl.flip<uint<1>>
+    ; CHECK: firrtl.node [[PASSIVE]]  : !firrtl.uint<1>
+    node check_output = auto
+
     ; CHECK: %c42_ui10 = firrtl.constant(42 : ui10) : !firrtl.uint<10>
     ; CHECK: %c171_ui8 = firrtl.constant(171 : ui8) : !firrtl.uint<8>
     ; CHECK: firrtl.add %c42_ui10, %c171_ui8


### PR DESCRIPTION
Bug introduced in 2803801a06 accidentally started using the wrong type
for the created Node operation.  This fixes the type of the node and
provides a test case for it.