### PR TITLE
[MSFT] [Python] Physically locate an op

### DIFF
--- a/include/circt-c/Dialect/MSFT.h
+++ b/include/circt-c/Dialect/MSFT.h
@@ -1,0 +1,26 @@
+//===-- circt-c/Dialect/MSFT.h - C API for MSFT dialect -----------*- C -*-===//
+//
+// This header declares the C interface for registering and accessing the
+// MSFT dialect. A dialect should be registered with a context to make it
+// available to users of the context. These users must load the dialect
+// before using any of its attributes, operations or types. Parser and pass
+// manager can load registered dialects automatically.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_C_DIALECT_MSFT_H
+#define CIRCT_C_DIALECT_MSFT_H
+
+#include "mlir-c/Registration.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(MSFT, msft);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CIRCT_C_DIALECT_MSFT_H

--- a/integration_test/Bindings/Python/dialects/msft.py
+++ b/integration_test/Bindings/Python/dialects/msft.py
@@ -1,7 +1,35 @@
 # REQUIRES: bindings_python
 # RUN: %PYTHON% %s | FileCheck %s
 
+import circt
 from circt import msft
+from circt.dialects import rtl
 
-# CHECK: Successfully imported circt.msft
-print("Successfully imported circt.msft")
+from mlir.ir import *
+
+with Context() as ctx, Location.unknown():
+  circt.register_dialects(ctx)
+
+  m = Module.create()
+  with InsertionPoint(m.body):
+    # CHECK: rtl.module @MyWidget()
+    # CHECK:   rtl.output
+    op = rtl.RTLModuleOp(
+        name='MyWidget',
+        input_ports=[],
+        output_ports=[],
+        body_builder=lambda module: rtl.OutputOp([])
+    )
+    top = rtl.RTLModuleOp(
+        name='top',
+        input_ports=[],
+        output_ports=[],
+        body_builder=lambda module: rtl.OutputOp([])
+    )
+
+  with InsertionPoint.at_block_terminator(top.body.blocks[0]):
+    inst = rtl.InstanceOp([], Attribute.parse('"widget"'), Attribute.parse("@MyWidget"), [], Attribute.parse("{}"))
+    msft.locate(inst.operation, "mem", devtype=msft.M20K, x=50, y=100, num=1)
+    # CHECK: rtl.instance "widget" @MyWidget() {"loc:mem" = #msft.physloc<M20K, 50, 100, 1>, parameters = {}} : () -> ()
+
+  m.operation.print()

--- a/lib/Bindings/Python/CIRCTModule.cpp
+++ b/lib/Bindings/Python/CIRCTModule.cpp
@@ -10,6 +10,7 @@
 
 #include "circt-c/Dialect/Comb.h"
 #include "circt-c/Dialect/ESI.h"
+#include "circt-c/Dialect/MSFT.h"
 #include "circt-c/Dialect/RTL.h"
 #include "circt-c/Dialect/SV.h"
 #include "circt-c/ExportVerilog.h"
@@ -44,6 +45,10 @@ PYBIND11_MODULE(_circt, m) {
         MlirDialectHandle esi = mlirGetDialectHandle__esi__();
         mlirDialectHandleRegisterDialect(esi, context);
         mlirDialectHandleLoadDialect(esi, context);
+
+        MlirDialectHandle msft = mlirGetDialectHandle__msft__();
+        mlirDialectHandleRegisterDialect(msft, context);
+        mlirDialectHandleLoadDialect(msft, context);
 
         MlirDialectHandle rtl = mlirGetDialectHandle__rtl__();
         mlirDialectHandleRegisterDialect(rtl, context);

--- a/lib/Bindings/Python/CMakeLists.txt
+++ b/lib/Bindings/Python/CMakeLists.txt
@@ -19,6 +19,7 @@ add_mlir_python_extension(CIRCTBindingsPythonExtension _circt
   LINK_LIBS
     CIRCTCAPIComb
     CIRCTCAPIESI
+    CIRCTCAPIMSFT
     CIRCTCAPIRTL
     CIRCTCAPISV
     CIRCTCAPIExportVerilog

--- a/lib/CAPI/Dialect/CMakeLists.txt
+++ b/lib/CAPI/Dialect/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(LLVM_OPTIONAL_SOURCES
   Comb.cpp
   ESI.cpp
+  MSFT.cpp
   RTL.cpp
   SV.cpp
 )
@@ -28,6 +29,18 @@ add_circt_library(CIRCTCAPIESI
   LINK_LIBS PUBLIC
   MLIRCAPIIR
   CIRCTESI
+  )
+
+add_circt_library(CIRCTCAPIMSFT
+
+  MSFT.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${MLIR_MAIN_INCLUDE_DIR}/mlir-c
+
+  LINK_LIBS PUBLIC
+  MLIRCAPIIR
+  CIRCTMSFT
   )
 
 add_circt_library(CIRCTCAPIRTL

--- a/lib/CAPI/Dialect/MSFT.cpp
+++ b/lib/CAPI/Dialect/MSFT.cpp
@@ -1,0 +1,11 @@
+//===- MSFT.cpp - C Interface for the MSFT Dialect ------------------------===//
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt-c/Dialect/MSFT.h"
+#include "circt/Dialect/MSFT/MSFTDialect.h"
+#include "mlir/CAPI/IR.h"
+#include "mlir/CAPI/Registration.h"
+#include "mlir/CAPI/Support.h"
+
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(MSFT, msft, circt::msft::MSFTDialect)


### PR DESCRIPTION
Adds an API call to physically place an op's sub-entity. Also adds msft dialect CAPI registration.