### PR TITLE
[FIRRTL] Properly apply annotations to entities with temp names

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -76,6 +76,20 @@ def SMemOp : FIRRTLOp<"smem", [/*MemAlloc*/]> {
     "$ruw custom<MemOp>(attr-dict) `:` type($result)";
 }
 
+def MemoryPortOp : FIRRTLOp<"memoryport"> {
+  let summary = "Access a memory";
+
+  let arguments = (ins FIRRTLType:$memory, IntType:$index, ClockType:$clock,
+                    MemDirAttr:$direction, OptionalAttr<StrAttr>:$name,
+                    DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations);
+  let results = (outs FIRRTLType:$result);
+
+  let assemblyFormat = [{
+    $direction $memory `,` $index `,` $clock attr-dict `:`
+       functional-type(operands, $result)
+  }];
+}
+
 def MemOp : FIRRTLOp<"mem", [/*MemAlloc*/]> {
   let summary = "Define a new mem";
   let arguments = (

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -10,19 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-def MemoryPortOp : FIRRTLOp<"memoryport"> {
-  let summary = "Access a memory";
-
-  let arguments = (ins FIRRTLType:$memory, IntType:$index, ClockType:$clock,
-                       MemDirAttr:$direction, OptionalAttr<StrAttr>:$name);
-  let results = (outs FIRRTLType:$result);
-
-  let assemblyFormat = [{
-    $direction $memory `,` $index `,` $clock attr-dict `:`
-       functional-type(operands, $result)
-  }];
-}
-
 def AttachOp : FIRRTLOp<"attach"> {
   let summary = "Analog Attach Statement";
 

--- a/lib/Dialect/FIRRTL/Import/FIRLexer.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRLexer.cpp
@@ -314,10 +314,6 @@ FIRToken FIRLexer::lexInlineAnnotation(const char *tokStart) {
     case 0:
       if (curPtr - 1 != curBuffer.end())
         break;
-      LLVM_FALLTHROUGH;
-    case '\n': // Vertical whitespace isn't allowed in inline annotations.
-    case '\v':
-    case '\f':
       return emitError(tokStart, "unterminated inline annotation");
     default:
       break;

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -63,6 +63,19 @@ static StringRef filterUselessName(StringRef name) {
   return isUselessName(name) ? "" : name;
 }
 
+/// Get an annotation with a class name field.
+static DictionaryAttr getAnnotationOfClass(MLIRContext *context,
+                                           StringRef classString) {
+  auto id = NamedAttribute(Identifier::get("class", context),
+                           StringAttr::get(context, classString));
+  return DictionaryAttr::getWithSorted(context, {id});
+}
+
+/// Checks the annotations array for a matching annotation.
+static bool hasAnnotation(ArrayAttr annotations, DictionaryAttr annotation) {
+  return llvm::is_contained(annotations, annotation);
+}
+
 //===----------------------------------------------------------------------===//
 // GlobalFIRParserState
 //===----------------------------------------------------------------------===//
@@ -76,7 +89,10 @@ struct GlobalFIRParserState {
                        FIRParserOptions options,
                        const llvm::MemoryBuffer *annotationsBuf)
       : context(context), options(options), lex(sourceMgr, context),
-        curToken(lex.lexToken()), annotationsBuf(annotationsBuf) {}
+        curToken(lex.lexToken()), annotationsBuf(annotationsBuf) {
+    dontTouchAnnotation =
+        getAnnotationOfClass(context, "firrtl.transforms.DontTouchAnnotation");
+  }
 
   /// The context we're parsing into.
   MLIRContext *const context;
@@ -102,6 +118,9 @@ struct GlobalFIRParserState {
 
   /// A mutable reference to the current ModuleTarget.
   StringRef moduleTarget;
+
+  // Cached annotation for DontTouch.
+  DictionaryAttr dontTouchAnnotation;
 
   class BacktraceState {
   public:
@@ -265,6 +284,13 @@ struct FIRParser {
   /// Populate a vector of annotations for a given Target.  If the annotations
   /// parameter is non-empty, then this will be appended to.
   void getAnnotations(Twine target, ArrayAttr &annotations);
+
+  /// Returns true if the annotation list contains the DontTouchAnnotation. This
+  /// method is slightly more efficient than other lookup methods, because it
+  /// uses a stashed copy of the annotation for lookup.
+  bool hasDontTouch(ArrayAttr annotations) {
+    return hasAnnotation(annotations, state.dontTouchAnnotation);
+  }
 
 private:
   FIRParser(const FIRParser &) = delete;
@@ -2163,9 +2189,10 @@ ParseResult FIRStmtParser::parseInstance() {
     resultTypes.push_back(FlipType::get(port.type));
     resultNames.push_back(port.name);
   }
-  auto name = filterUselessName(id);
   ArrayAttr annotations = builder.getArrayAttr({});
-  getAnnotations(getModuleTarget() + ">" + name, annotations);
+  getAnnotations(getModuleTarget() + ">" + id, annotations);
+  auto name = hasDontTouch(annotations) ? id : filterUselessName(id);
+
   auto result = builder.create<InstanceOp>(
       info.getLoc(), resultTypes, moduleName, builder.getArrayAttr(resultNames),
       name, annotations);
@@ -2203,9 +2230,9 @@ ParseResult FIRStmtParser::parseCMem() {
       parseType(type, "expected cmem type") || parseOptionalInfo(info))
     return failure();
 
-  auto name = filterUselessName(id);
   ArrayAttr annotations = builder.getArrayAttr({});
-  getAnnotations(getModuleTarget() + ">" + name, annotations);
+  getAnnotations(getModuleTarget() + ">" + id, annotations);
+  auto name = hasDontTouch(annotations) ? id : filterUselessName(id);
 
   auto result = builder.create<CMemOp>(info.getLoc(), type, name, annotations);
 
@@ -2238,9 +2265,9 @@ ParseResult FIRStmtParser::parseSMem() {
       parseOptionalInfo(info))
     return failure();
 
-  auto name = filterUselessName(id);
   ArrayAttr annotations = builder.getArrayAttr({});
-  getAnnotations(getModuleTarget() + ">" + name, annotations);
+  getAnnotations(getModuleTarget() + ">" + id, annotations);
+  auto name = hasDontTouch(annotations) ? id : filterUselessName(id);
 
   auto result =
       builder.create<SMemOp>(info.getLoc(), type, ruw, name, annotations);
@@ -2372,9 +2399,9 @@ ParseResult FIRStmtParser::parseMem(unsigned memIndent) {
     resultTypes.push_back(FlipType::get(p.second));
   }
 
-  auto name = filterUselessName(id);
   ArrayAttr annotations = builder.getArrayAttr({});
-  getAnnotations(getModuleTarget() + ">" + name, annotations);
+  getAnnotations(getModuleTarget() + ">" + id, annotations);
+  auto name = hasDontTouch(annotations) ? id : filterUselessName(id);
 
   auto result = builder.create<MemOp>(
       info.getLoc(), resultTypes, readLatency, writeLatency, depth, ruw,
@@ -2441,19 +2468,18 @@ ParseResult FIRStmtParser::parseNode() {
   // passive.
   initializer = convertToPassive(initializer, initializer.getLoc());
 
+  ArrayAttr annotations = builder.getArrayAttr({});
+  getAnnotations(getModuleTarget() + ">" + id, annotations);
+
   // Ignore useless names like _T.
-  auto actualName = filterUselessName(id);
+  auto name = hasDontTouch(annotations) ? id : filterUselessName(id);
 
   // The entire point of a node declaration is to carry a name.  If it got
   // dropped, then we don't even need to create a result.
-  //
-  // TODO: This optimization doesn't respect annotated, temporary nodes.
   Value result;
-  if (!actualName.empty()) {
-    ArrayAttr annotations = builder.getArrayAttr({});
-    getAnnotations(getModuleTarget() + ">" + actualName, annotations);
+  if (!name.empty()) {
     result = builder.create<NodeOp>(info.getLoc(), initializer.getType(),
-                                    initializer, actualName, annotations);
+                                    initializer, name, annotations);
   } else
     result = initializer;
   return addSymbolEntry(id, result, info.getFIRLoc());
@@ -2478,9 +2504,9 @@ ParseResult FIRStmtParser::parseWire() {
 
   ArrayAttr annotations = builder.getArrayAttr({});
   getAnnotations(getModuleTarget() + ">" + id, annotations);
+  auto name = hasDontTouch(annotations) ? id : filterUselessName(id);
 
-  auto result = builder.create<WireOp>(info.getLoc(), type,
-                                       filterUselessName(id), annotations);
+  auto result = builder.create<WireOp>(info.getLoc(), type, name, annotations);
   return addSymbolEntry(id, result, info.getFIRLoc());
 }
 
@@ -2572,9 +2598,9 @@ ParseResult FIRStmtParser::parseRegister(unsigned regIndent) {
   if (parseOptionalInfo(info, subOps))
     return failure();
 
-  auto name = filterUselessName(id);
   ArrayAttr annotations = builder.getArrayAttr({});
-  getAnnotations(getModuleTarget() + ">" + name, annotations);
+  getAnnotations(getModuleTarget() + ">" + id, annotations);
+  auto name = hasDontTouch(annotations) ? id : filterUselessName(id);
 
   Value result;
   if (resetSignal)

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1775,13 +1775,13 @@ ParseResult FIRStmtParser::parseMemPort(MemDirAttr direction) {
   if (auto isExpr = parseExpWithLeadingKeyword(spelling, info))
     return isExpr.getValue();
 
-  StringRef resultValue;
+  StringRef id;
   StringRef memName;
   SymbolValueEntry memorySym;
   Value memory, indexExp, clock;
   SmallVector<Operation *, 8> subOps;
   if (parseToken(FIRToken::kw_mport, "expected 'mport' in memory port") ||
-      parseId(resultValue, "expected result name") ||
+      parseId(id, "expected result name") ||
       parseToken(FIRToken::equal, "expected '=' in memory port") ||
       parseId(memName, "expected memory name") ||
       lookupSymbolEntry(memorySym, memName, info.getFIRLoc()) ||
@@ -1798,9 +1798,13 @@ ParseResult FIRStmtParser::parseMemPort(MemDirAttr direction) {
     return emitError(info.getFIRLoc(), "memory should have vector type");
   auto resultType = memVType.getElementType();
 
-  auto name = builder.getStringAttr(filterUselessName(resultValue));
-  auto result = builder.create<MemoryPortOp>(info.getLoc(), resultType, memory,
-                                             indexExp, clock, direction, name);
+  ArrayAttr annotations = builder.getArrayAttr({});
+  getAnnotations(getModuleTarget() + ">" + id, annotations);
+  auto name = hasDontTouch(annotations) ? id : filterUselessName(id);
+
+  auto result = builder.create<MemoryPortOp>(
+      info.getLoc(), resultType, memory, indexExp, clock, direction,
+      builder.getStringAttr(name), annotations);
 
   // TODO(firrtl scala bug): If the next operation is a skip, just eat it if it
   // is at the same indent level as us.  This is a horrible hack on top of the
@@ -1839,7 +1843,7 @@ ParseResult FIRStmtParser::parseMemPort(MemDirAttr direction) {
     }
 
     // If we need to inject this name into a parent scope, then we have to do
-    // some IR hackery.  Create a wire for the resultValue name right before
+    // some IR hackery.  Create a wire for the id name right before
     // the mem in question, inject its name into that scope, then connect
     // the output of the mport to it.
     if (scopeAndOperation.first != symbolTable.getCurScope()) {
@@ -1851,13 +1855,13 @@ ParseResult FIRStmtParser::parseMemPort(MemDirAttr direction) {
 
       // Inject this the wire's name into the same scope as the memory.
       symbolTable.insertIntoScope(
-          scopeAndOperation.first, Identifier::get(resultValue, getContext()),
+          scopeAndOperation.first, Identifier::get(id, getContext()),
           {info.getFIRLoc(), SymbolValueEntry(wireHack)});
       return success();
     }
   }
 
-  return addSymbolEntry(resultValue, result, info.getFIRLoc());
+  return addSymbolEntry(id, result, info.getFIRLoc());
 }
 
 /// printf ::= 'printf(' exp exp StringLit exp* ')' info?

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -202,7 +202,8 @@ circuit Foo: %[[{"target": "Foo|Foo>_T_0", "a": "a"},
                 {"target": "Foo|Foo>_T_4", "a": "a"},
                 {"target": "Foo|Foo>_T_5", "a": "a"},
                 {"target": "Foo|Foo>_T_6", "a": "a"},
-                {"target": "Foo|Foo>_T_7", "a": "a"}]]
+                {"target": "Foo|Foo>_T_7", "a": "a"},
+                {"target": "Foo|Foo>_T_8", "a": "a"}]]
   module Bar:
     skip
   module Foo:
@@ -222,10 +223,12 @@ circuit Foo: %[[{"target": "Foo|Foo>_T_0", "a": "a"},
     smem _T_4 : UInt<1>[9] [256]
     ; CHECK: %4 = firrtl.cmem  {annotations = [{a = "a"}], name = ""}
     cmem _T_5 : UInt<1>[9] [256]
+    ; CHECK: %5 = firrtl.memoryport Infer %4, %reset, %clock {annotations = [{a = "a"}], name = ""}
+    infer mport _T_6 = _T_5[reset], clock
     ; CHECK: firrtl.instance @Bar  {annotations = [{a = "a"}], name = "", portNames = []}
-    inst _T_6 of Bar
+    inst _T_7 of Bar
     ; CHECK: firrtl.mem Undefined  {annotations = [{a = "a"}], depth = 8 : i64, name = "", portNames = ["w"], readLatency = 0 : i32, writeLatency = 1 : i32}
-    mem _T_7 :
+    mem _T_8 :
         data-type => UInt<4>
         depth => 8
         writer => w
@@ -243,7 +246,8 @@ circuit Foo: %[[{"target": "Foo|Foo>_T_0", "class": "firrtl.transforms.DontTouch
                 {"target": "Foo|Foo>_T_4", "class": "firrtl.transforms.DontTouchAnnotation"},
                 {"target": "Foo|Foo>_T_5", "class": "firrtl.transforms.DontTouchAnnotation"},
                 {"target": "Foo|Foo>_T_6", "class": "firrtl.transforms.DontTouchAnnotation"},
-                {"target": "Foo|Foo>_T_7", "class": "firrtl.transforms.DontTouchAnnotation"}]]
+                {"target": "Foo|Foo>_T_7", "class": "firrtl.transforms.DontTouchAnnotation"},
+                {"target": "Foo|Foo>_T_8", "class": "firrtl.transforms.DontTouchAnnotation"}]]
   module Bar:
     skip
   module Foo:
@@ -263,10 +267,12 @@ circuit Foo: %[[{"target": "Foo|Foo>_T_0", "class": "firrtl.transforms.DontTouch
     smem _T_4 : UInt<1>[9] [256]
     ; CHECK: %_T_5 = firrtl.cmem  {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}], name = "_T_5"}
     cmem _T_5 : UInt<1>[9] [256]
-    ; CHECK: firrtl.instance @Bar  {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}], name = "_T_6", portNames = []}
-    inst _T_6 of Bar
-    ; CHECK: firrtl.mem Undefined  {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}], depth = 8 : i64, name = "_T_7", portNames = ["w"], readLatency = 0 : i32, writeLatency = 1 : i32}
-    mem _T_7 :
+    ; CHECK: %_T_6 = firrtl.memoryport Infer %_T_5, %reset, %clock {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}], name = "_T_6"}
+    infer mport _T_6 = _T_5[reset], clock
+    ; CHECK: firrtl.instance @Bar  {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}], name = "_T_7", portNames = []}
+    inst _T_7 of Bar
+    ; CHECK: firrtl.mem Undefined  {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}], depth = 8 : i64, name = "_T_8", portNames = ["w"], readLatency = 0 : i32, writeLatency = 1 : i32}
+    mem _T_8 :
         data-type => UInt<4>
         depth => 8
         writer => w

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -190,3 +190,86 @@ circuit Foo: %[[{"\"":"}]]"}]]
 
     ; CHECK-LABEL: module {
     ; CHECK: firrtl.circuit "Foo" attributes {annotations =
+
+
+; // -----
+
+; COM: Annotations should apply even when the target's name is dropped.
+circuit Foo: %[[{"target": "Foo|Foo>_T_0", "a": "a"},
+                {"target": "Foo|Foo>_T_1", "a": "a"},
+                {"target": "Foo|Foo>_T_2", "a": "a"},
+                {"target": "Foo|Foo>_T_3", "a": "a"},
+                {"target": "Foo|Foo>_T_4", "a": "a"},
+                {"target": "Foo|Foo>_T_5", "a": "a"},
+                {"target": "Foo|Foo>_T_6", "a": "a"},
+                {"target": "Foo|Foo>_T_7", "a": "a"}]]
+  module Bar:
+    skip
+  module Foo:
+    input reset : UInt<1>
+    input clock : Clock
+
+    ; CHECK: %0 = firrtl.wire  {annotations = [{a = "a"}]}
+    wire _T_0 : UInt<1>
+    ; CHECK-NOT: firrtl.node
+    node _T_1 = _T_0
+    ; CHECK: %1 = firrtl.reg %clock  {annotations = [{a = "a"}]}
+    reg _T_2 : UInt<1>, clock
+    ; CHECK: %2 = firrtl.regreset %clock, %reset, %c0_ui4  {annotations = [{a = "a"}]}
+    reg _T_3 : UInt<4>, clock with :
+      reset => (reset, UInt<4>("h0"))
+    ; CHECK: %3 = firrtl.smem Undefined  {annotations = [{a = "a"}], name = ""}
+    smem _T_4 : UInt<1>[9] [256]
+    ; CHECK: %4 = firrtl.cmem  {annotations = [{a = "a"}], name = ""}
+    cmem _T_5 : UInt<1>[9] [256]
+    ; CHECK: firrtl.instance @Bar  {annotations = [{a = "a"}], name = "", portNames = []}
+    inst _T_6 of Bar
+    ; CHECK: firrtl.mem Undefined  {annotations = [{a = "a"}], depth = 8 : i64, name = "", portNames = ["w"], readLatency = 0 : i32, writeLatency = 1 : i32}
+    mem _T_7 :
+        data-type => UInt<4>
+        depth => 8
+        writer => w
+        read-latency => 0
+        write-latency => 1
+        read-under-write => undefined
+
+; // -----
+
+; COM: DontTouch annotation preserves temporary names
+circuit Foo: %[[{"target": "Foo|Foo>_T_0", "class": "firrtl.transforms.DontTouchAnnotation"},
+                {"target": "Foo|Foo>_T_1", "class": "firrtl.transforms.DontTouchAnnotation"},
+                {"target": "Foo|Foo>_T_2", "class": "firrtl.transforms.DontTouchAnnotation"},
+                {"target": "Foo|Foo>_T_3", "class": "firrtl.transforms.DontTouchAnnotation"},
+                {"target": "Foo|Foo>_T_4", "class": "firrtl.transforms.DontTouchAnnotation"},
+                {"target": "Foo|Foo>_T_5", "class": "firrtl.transforms.DontTouchAnnotation"},
+                {"target": "Foo|Foo>_T_6", "class": "firrtl.transforms.DontTouchAnnotation"},
+                {"target": "Foo|Foo>_T_7", "class": "firrtl.transforms.DontTouchAnnotation"}]]
+  module Bar:
+    skip
+  module Foo:
+    input reset : UInt<1>
+    input clock : Clock
+
+    ; CHECK: %_T_0 = firrtl.wire  {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]}
+    wire _T_0 : UInt<1>
+    ; CHECK: %_T_1 = firrtl.node %_T_0  {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]}
+    node _T_1 = _T_0
+    ; CHECK: %_T_2 = firrtl.reg %clock  {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]}
+    reg _T_2 : UInt<1>, clock
+    ; CHECK: %_T_3 = firrtl.regreset %clock, %reset, %c0_ui4  {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]}
+    reg _T_3 : UInt<4>, clock with :
+      reset => (reset, UInt<4>("h0"))
+    ; CHECK: %_T_4 = firrtl.smem Undefined  {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}], name = "_T_4"}
+    smem _T_4 : UInt<1>[9] [256]
+    ; CHECK: %_T_5 = firrtl.cmem  {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}], name = "_T_5"}
+    cmem _T_5 : UInt<1>[9] [256]
+    ; CHECK: firrtl.instance @Bar  {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}], name = "_T_6", portNames = []}
+    inst _T_6 of Bar
+    ; CHECK: firrtl.mem Undefined  {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}], depth = 8 : i64, name = "_T_7", portNames = ["w"], readLatency = 0 : i32, writeLatency = 1 : i32}
+    mem _T_7 :
+        data-type => UInt<4>
+        depth => 8
+        writer => w
+        read-latency => 0
+        write-latency => 1
+        read-under-write => undefined

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -307,7 +307,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %myMem = firrtl.cmem {name = "myMem"} : !firrtl.vector<bundle<id: uint<4>, resp: uint<2>>, 8>
     cmem myMem : { id : UInt<4>, resp : UInt<2>} [8] @[Decoupled.scala 209:24]
 
-    ; CHECK: %memValue = firrtl.memoryport Infer %myMem, %i8, %clock {name = "memValue"} : (!firrtl.vector<bundle<id: uint<4>, resp: uint<2>>, 8>, !firrtl.uint<8>, !firrtl.clock) -> !firrtl.bundle<id: uint<4>, resp: uint<2>>
+    ; CHECK: %memValue = firrtl.memoryport Infer %myMem, %i8, %clock  {annotations = [], name = "memValue"} : (!firrtl.vector<bundle<id: uint<4>, resp: uint<2>>, 8>, !firrtl.uint<8>, !firrtl.clock) -> !firrtl.bundle<id: uint<4>, resp: uint<2>>
     infer mport memValue = myMem[i8], clock
     auto11 <= memValue.id
 
@@ -316,7 +316,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %base_table_1 = firrtl.smem Old {name = "base_table_1"} : !firrtl.vector<vector<uint<1>, 9>, 256>
     smem base_table_1 : UInt<1>[9] [256] old
 
-    ; CHECK: %tableValue = firrtl.memoryport Read %base_table_0, %i8, %clock {name = "tableValue"} : (!firrtl.vector<vector<uint<1>, 9>, 256>, !firrtl.uint<8>, !firrtl.clock) -> !firrtl.vector<uint<1>, 9>
+    ; CHECK: %tableValue = firrtl.memoryport Read %base_table_0, %i8, %clock {annotations = [], name = "tableValue"} : (!firrtl.vector<vector<uint<1>, 9>, 256>, !firrtl.uint<8>, !firrtl.clock) -> !firrtl.vector<uint<1>, 9>
     read mport tableValue = base_table_0[i8], clock
 
     ; CHECK: firrtl.pad %i8, 10 : (!firrtl.uint<8>) -> !firrtl.uint<10>


### PR DESCRIPTION
There is a problem where entities with dropped temporary names (such as
"_T_0") can't have annotations properly attached. This change looks up
the annotations of an entity before removing the name, which allows
annotations to apply as intended.

In addition to this, entities with the DontTouch attribute will not have
their name dropped by the parser.