### PR TITLE
Remove Type Canonicalization

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -228,7 +228,7 @@ def WireOp : FIRRTLOp<"wire", []> {
   let arguments = (
     ins StrAttr:$name,
         DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations);
-  let results = (outs FIRRTLType:$result);
+  let results = (outs UnflippedType:$result);
 
   let builders = [
     OpBuilder<(ins "::mlir::Type":$elementType,

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -61,6 +61,9 @@ def SubfieldOp : FIRRTLOp<"subfield", [NoSideEffect]> {
     /// invalid, then a null type is returned.
     static FIRRTLType getResultType(Type inType, StringAttr fieldName,
                                     Location loc);
+
+    /// Return true if the specified field is flipped.
+    bool isFieldFlipped();
   }];
 
   let verifier = [{

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -72,7 +72,7 @@ bool isBundleType(Type type);
 bool isDuplexValue(Value val);
 
 namespace flow {
-  enum Flow { Source, Sink, Duplex };
+enum Flow { Source, Sink, Duplex };
 }
 
 /// Compute the flow for a Value, \p val, as determined by the FIRRTL
@@ -87,6 +87,12 @@ namespace flow {
 /// should normally \a not have to change this from its default of \p
 /// flow::Source.
 flow::Flow foldFlow(Value val, flow::Flow accumulatedFlow = flow::Source);
+
+namespace kind {
+enum Kind { Port, Instance, Other };
+}
+
+kind::Kind getDeclarationKind(Value val);
 
 } // namespace firrtl
 } // namespace circt

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -71,6 +71,23 @@ bool isBundleType(Type type);
 /// connect.
 bool isDuplexValue(Value val);
 
+namespace flow {
+  enum Flow { Source, Sink, Duplex };
+}
+
+/// Compute the flow for a Value, \p val, as determined by the FIRRTL
+/// specification.  This recursively walks backwards from \p val to the
+/// declaration.  The resulting flow is a combination of the declaration flow
+/// (output ports and instance inputs are sinks, registers and wires are duplex,
+/// anything else is a source) and the number of intermediary flips.  An even
+/// number of flips will result in the same flow as the declaration.  An odd
+/// number of flips will result in reversed flow being returned.  The reverse of
+/// source is sink.  The reverse of sink is source.  The reverse of duplex is
+/// duplex.  The \p accumulatedFlow parameter sets the initial flow.  A user
+/// should normally \a not have to change this from its default of \p
+/// flow::Source.
+flow::Flow foldFlow(Value val, flow::Flow accumulatedFlow = flow::Source);
+
 } // namespace firrtl
 } // namespace circt
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -52,6 +52,10 @@ def PassiveType : DialectType<FIRRTLDialect,
   CPred<"$_self.isa<FIRRTLType>() && $_self.cast<FIRRTLType>().isPassive()">,
   "a passive type (contain no flips)", "::circt::firrtl::FIRRTLType">;
 
+def UnflippedType : DialectType<FIRRTLDialect,
+  CPred<"$_self.isa<FIRRTLType>() && !$_self.isa<FlipType>()">,
+  "a type that does not contain an outer flip", "::circt::firrtl::FIRRTLType">;
+
 //===----------------------------------------------------------------------===//
 // FIRRTL Types Predicates
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
+++ b/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
@@ -787,11 +787,8 @@ void FIRRTLModuleLowering::lowerModuleBody(
     // We lower zero width inout and outputs to a wire that isn't connected to
     // anything outside the module.  Inputs are lowered to zero.
     if (isZeroWidth && port.isInput()) {
-      Value newArg = bodyBuilder.create<WireOp>(FlipType::get(port.type),
-                                                "." + port.getName().str() +
-                                                    ".0width_input");
-
-      newArg = bodyBuilder.create<AsPassivePrimOp>(newArg);
+      Value newArg = bodyBuilder.create<WireOp>(
+          port.type, "." + port.getName().str() + ".0width_input");
       oldArg.replaceAllUsesWith(newArg);
       continue;
     }
@@ -807,7 +804,7 @@ void FIRRTLModuleLowering::lowerModuleBody(
     // Outputs need a temporary wire so they can be connect'd to, which we
     // then return.
     Value newArg = bodyBuilder.create<WireOp>(
-        port.type, "." + port.getName().str() + ".output");
+        FlipType::get(port.type), "." + port.getName().str() + ".output");
     // Switch all uses of the old operands to the new ones.
     oldArg.replaceAllUsesWith(newArg);
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -646,7 +646,7 @@ static LogicalResult verifyMemOp(MemOp mem) {
     {
       auto dataTypeOption = portBundleType.getElement("data");
       if (!dataTypeOption && portKind == MemOp::PortKind::ReadWrite)
-        dataTypeOption = portBundleType.getElement("rdata");
+        dataTypeOption = portBundleType.getElement("wdata");
       if (!dataTypeOption) {
         mem.emitOpError() << "has no data field on port " << portName
                           << " (expected to see \"data\" for a read or write "
@@ -654,6 +654,9 @@ static LogicalResult verifyMemOp(MemOp mem) {
         return failure();
       }
       dataType = dataTypeOption.getValue().type;
+      // Read data is expected to have an outer flip, so strip that.
+      if (portKind == MemOp::PortKind::Read)
+        dataType = FlipType::get(dataType);
     }
 
     // Error if the data type isn't passive.
@@ -970,8 +973,14 @@ FIRRTLType SubfieldOp::getResultType(Type inType, StringAttr fieldName,
                                      Location loc) {
   if (auto bundleType = inType.dyn_cast<BundleType>()) {
     for (auto &elt : bundleType.getElements()) {
-      if (elt.name == fieldName)
+      if (elt.name == fieldName) {
+        // FIRRTL puts flips on element fields, not on the underlying
+        // types.  The result type of a subfield should strip a flip
+        // if one exists.
+        if (auto flipped = elt.type.dyn_cast<FlipType>())
+          return flipped.getElementType().cast<FIRRTLType>();
         return elt.type;
+      }
     }
     mlir::emitError(loc, "unknown field '")
         << fieldName.getValue() << "' in bundle type " << inType;
@@ -980,7 +989,7 @@ FIRRTLType SubfieldOp::getResultType(Type inType, StringAttr fieldName,
 
   if (auto flipType = inType.dyn_cast<FlipType>())
     if (auto subType = getResultType(flipType.getElementType(), fieldName, loc))
-      return FlipType::get(subType);
+      return subType;
 
   mlir::emitError(loc, "subfield requires bundle operand");
   return {};
@@ -998,7 +1007,7 @@ FIRRTLType SubindexOp::getResultType(FIRRTLType inType, unsigned fieldIdx,
 
   if (auto flipType = inType.dyn_cast<FlipType>())
     if (auto subType = getResultType(flipType.getElementType(), fieldIdx, loc))
-      return FlipType::get(subType);
+      return subType;
 
   mlir::emitError(loc, "subindex requires vector operand");
   return {};
@@ -1017,7 +1026,7 @@ FIRRTLType SubaccessOp::getResultType(FIRRTLType inType, FIRRTLType indexType,
 
   if (auto flipType = inType.dyn_cast<FlipType>())
     if (auto subType = getResultType(flipType.getElementType(), indexType, loc))
-      return FlipType::get(subType);
+      return subType;
 
   mlir::emitError(loc, "subaccess requires vector operand, not ") << inType;
   return {};

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -343,18 +343,11 @@ static bool areBundleElementsEquivalent(BundleType::BundleElement destElement,
   return areTypesEquivalent(destElement.type, srcElement.type);
 }
 
-/// Returns whether the two types are equivalent. See the FIRRTL spec for the
-/// full definition of type equivalence. This predicate differs from the spec in
-/// that it only compares passive types. Because of how the FIRRTL dialect uses
-/// flip types in module ports and aggregates, this definition, unlike the spec,
-/// ignores flips.
+/// Returns whether the two types are equivalent.  This implements the exact
+/// definition of type equivalence in the FIRRTL spec.  If the types being
+/// compared have any outer flips that encode FIRRTL module directions (input or
+/// output), these should be stripped before using this method.
 bool firrtl::areTypesEquivalent(FIRRTLType destType, FIRRTLType srcType) {
-  // Ensure we are comparing passive types.
-  if (!destType.isPassive())
-    destType = destType.getPassiveType();
-  if (!srcType.isPassive())
-    srcType = srcType.getPassiveType();
-
   // Reset types can be driven by UInt<1>, AsyncReset, or Reset types.
   if (destType.isa<ResetType>())
     return srcType.isResetType();

--- a/test/Conversion/FIRRTLToRTL/errors.mlir
+++ b/test/Conversion/FIRRTLToRTL/errors.mlir
@@ -19,7 +19,7 @@ firrtl.circuit "Div" {
   firrtl.module @Div(%clock1: !firrtl.clock, %clock2: !firrtl.clock) {
   // expected-error @+2 {{'firrtl.mem' should have simple type and known width}}
   // expected-error @+1 {{'firrtl.mem' op should have already been lowered from a ground type to an aggregate type using the LowerTypes pass}}
-    %_M_read, %_M_write = firrtl.mem Undefined {depth = 20 : i64, name = "_M", portNames = ["read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<5>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<id: uint<4>, other: sint<8>>>, !firrtl.flip<bundle<addr: uint<5>, en: uint<1>, clk: clock, data: bundle<id: uint<4>, other: sint<8>>, mask: bundle<id: uint<1>, other: uint<1>>>>
+    %_M_read, %_M_write = firrtl.mem Undefined {depth = 20 : i64, name = "_M", portNames = ["read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<5>, en: uint<1>, clk: clock, data: flip<bundle<id: uint<4>, other: sint<8>>>>>, !firrtl.flip<bundle<addr: uint<5>, en: uint<1>, clk: clock, data: bundle<id: uint<4>, other: sint<8>>, mask: bundle<id: uint<1>, other: uint<1>>>>
   }
 
   // module MemOne :
@@ -35,7 +35,7 @@ firrtl.circuit "Div" {
   firrtl.module @MemOne() {
   // expected-error @+2 {{'firrtl.mem' should have simple type and known width}}
   // expected-error @+1 {{'firrtl.mem' op should have already been lowered from a ground type to an aggregate type using the LowerTypes pass}}
-    %_M_read, %_M_write = firrtl.mem Undefined {depth = 1 : i64, name = "_M", portNames=["read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<1>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<id: uint<4>, other: sint<8>>>, !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<id: uint<4>, other: sint<8>>, mask: bundle<id: uint<1>, other: uint<1>>>>
+    %_M_read, %_M_write = firrtl.mem Undefined {depth = 1 : i64, name = "_M", portNames=["read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: flip<bundle<id: uint<4>, other: sint<8>>>>>, !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<id: uint<4>, other: sint<8>>, mask: bundle<id: uint<1>, other: uint<1>>>>
   }
 
   // COM: Unknown widths are unsupported
@@ -48,22 +48,22 @@ firrtl.circuit "Div" {
     %c0_ui1 = firrtl.constant(false) : !firrtl.uint<1>
     %c0_ui25 = firrtl.constant(0 : i25) : !firrtl.uint<25>
   // expected-error @+1 {{'firrtl.mem' should have simple type and known width}}
-    %tmp41_r0, %tmp41_w0 = firrtl.mem Undefined {depth = 10 : i64, name = "tmp41", portNames = ["r0", "w0"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<0>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>>
-    %0 = firrtl.subfield %tmp41_r0("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<0>>) -> !firrtl.flip<clock>
-    firrtl.connect %0, %clock : !firrtl.flip<clock>, !firrtl.clock
-    %1 = firrtl.subfield %tmp41_r0("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<0>>) -> !firrtl.flip<uint<1>>
-    firrtl.connect %1, %r0en : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-    %2 = firrtl.subfield %tmp41_r0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<0>>) -> !firrtl.flip<uint<4>>
-    firrtl.connect %2, %c0_ui4 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
-    %3 = firrtl.subfield %tmp41_w0("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>>) -> !firrtl.flip<clock>
-    firrtl.connect %3, %clock : !firrtl.flip<clock>, !firrtl.clock
-    %4 = firrtl.subfield %tmp41_w0("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-    firrtl.connect %4, %r0en : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-    %5 = firrtl.subfield %tmp41_w0("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>>) -> !firrtl.flip<uint<4>>
-    firrtl.connect %5, %c0_ui4 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
-    %6 = firrtl.subfield %tmp41_w0("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-    firrtl.connect %6, %c0_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-    %7 = firrtl.subfield %tmp41_w0("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>>) -> !firrtl.flip<uint<0>>
-    firrtl.partialconnect %7, %c0_ui25 : !firrtl.flip<uint<0>>, !firrtl.uint<25>
+    %tmp41_r0, %tmp41_w0 = firrtl.mem Undefined {depth = 10 : i64, name = "tmp41", portNames = ["r0", "w0"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<uint<0>>>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>>
+    %0 = firrtl.subfield %tmp41_r0("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<uint<0>>>>) -> !firrtl.clock
+    firrtl.connect %0, %clock : !firrtl.clock, !firrtl.clock
+    %1 = firrtl.subfield %tmp41_r0("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<uint<0>>>>) -> !firrtl.uint<1>
+    firrtl.connect %1, %r0en : !firrtl.uint<1>, !firrtl.uint<1>
+    %2 = firrtl.subfield %tmp41_r0("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<uint<0>>>>) -> !firrtl.uint<4>
+    firrtl.connect %2, %c0_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
+    %3 = firrtl.subfield %tmp41_w0("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>>) -> !firrtl.clock
+    firrtl.connect %3, %clock : !firrtl.clock, !firrtl.clock
+    %4 = firrtl.subfield %tmp41_w0("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>>) -> !firrtl.uint<1>
+    firrtl.connect %4, %r0en : !firrtl.uint<1>, !firrtl.uint<1>
+    %5 = firrtl.subfield %tmp41_w0("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>>) -> !firrtl.uint<4>
+    firrtl.connect %5, %c0_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
+    %6 = firrtl.subfield %tmp41_w0("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>>) -> !firrtl.uint<1>
+    firrtl.connect %6, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    %7 = firrtl.subfield %tmp41_w0("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>>) -> !firrtl.uint<0>
+    firrtl.partialconnect %7, %c0_ui25 : !firrtl.uint<0>, !firrtl.uint<25>
   }
 }

--- a/test/Conversion/FIRRTLToRTL/lower-to-rtl-module.mlir
+++ b/test/Conversion/FIRRTLToRTL/lower-to-rtl-module.mlir
@@ -31,7 +31,7 @@ firrtl.circuit "Simple" {
     %1 = firrtl.asUInt %in1 : (!firrtl.uint<4>) -> !firrtl.uint<4>
 
     // CHECK: comb.concat %false, %in1
-    // CHECK: comb.concat %false, %in1 
+    // CHECK: comb.concat %false, %in1
 
     // CHECK: comb.sub
     %2 = firrtl.sub %1, %1 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
@@ -66,7 +66,7 @@ firrtl.circuit "Simple" {
 
     // CHECK: sv.fwrite "%x"(%xyz.out4) : i4
     firrtl.printf %clock, %reset, "%x"(%xyz#3) : !firrtl.uint<4>
- 
+
     // CHECK: sv.fwrite "Something interesting! %x"(%myext.out) : i8
 
     // Parameterized module reference.
@@ -102,14 +102,8 @@ firrtl.circuit "Simple" {
                              %outD: !firrtl.flip<uint<4>>,
                              %inE: !firrtl.uint<3>,
                              %outE: !firrtl.flip<uint<4>>) {
-    // CHECK: %0 = firrtl.stdIntCast %inA : (i4) -> !firrtl.uint<4>
-    // CHECK-NEXT: %1 = firrtl.stdIntCast %inB : (i4) -> !firrtl.uint<4>
-    // CHECK-NEXT: %2 = firrtl.stdIntCast %inC : (i4) -> !firrtl.uint<4>
-
-    // CHECK: [[OUTC:%.+]] = firrtl.wire {{.*}} : !firrtl.flip<uint<4>>
-    // CHECK: [[OUTD:%.+]] = firrtl.wire {{.*}} : !firrtl.flip<uint<4>>
-
-    // CHECK: [[INE:%.+]] = firrtl.stdIntCast %inE : (i3) -> !firrtl.uint<3>
+    // CHECK: [[OUTC:%.+]] = sv.wire : !rtl.inout<i4>
+    // CHECK: [[OUTD:%.+]] = sv.wire : !rtl.inout<i4>
 
     // Normal
     firrtl.connect %outA, %inA : !firrtl.flip<uint<4>>, !firrtl.uint<4>
@@ -121,15 +115,6 @@ firrtl.circuit "Simple" {
     // Use of output as an input.
     %tmp = firrtl.asPassive %outC : !firrtl.flip<uint<4>>
     %0 = firrtl.sub %inA, %tmp : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
-
-    // Use of an input as an output.
-    // NOTE: This isn't valid but needs to be accepted until the verifier
-    // rejects it.
-    %tmp2 = firrtl.asNonPassive %inC : !firrtl.flip<uint<4>>
-
-    // expected-error @+2 {{'firrtl.connect' op LowerToRTL couldn't handle this operation}}
-    // expected-error @+1 {{destination isn't an inout type}}
-    firrtl.connect %tmp2, %inA : !firrtl.flip<uint<4>>, !firrtl.uint<4>
 
     // No connections to outD.
 

--- a/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
+++ b/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
@@ -6,8 +6,8 @@ firrtl.circuit "Simple" {
   firrtl.module @Simple(%in1: !firrtl.uint<4>,
                         %in2: !firrtl.uint<2>,
                         %in3: !firrtl.sint<8>,
-                        %in4: !firrtl.uint<0>, 
-                        %in5: !firrtl.sint<0>, 
+                        %in4: !firrtl.uint<0>,
+                        %in5: !firrtl.sint<0>,
                         %out1: !firrtl.flip<sint<1>>,
                         %out2: !firrtl.flip<sint<1>>  ) {
     // Issue #364: https://github.com/llvm/circt/issues/364
@@ -568,47 +568,47 @@ firrtl.circuit "Simple" {
   // CHECK-LABEL: rtl.module @MemSimple(
   firrtl.module @MemSimple(%clock1: !firrtl.clock, %clock2: !firrtl.clock,
                            %inpred: !firrtl.uint<1>, %indata: !firrtl.sint<42>,
-                           %result: !firrtl.flip<sint<42>>, 
+                           %result: !firrtl.flip<sint<42>>,
                            %result2: !firrtl.flip<sint<42>>) {
     %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
     %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
     %c0_ui3 = firrtl.constant(0 : ui3) : !firrtl.uint<3>
-    %_M_read, %_M_rw, %_M_write = firrtl.mem Undefined {depth = 12 : i64, name = "_M", portNames = ["read", "rw", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>, !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, wmode: flip<uint<1>>, rdata: sint<42>, wdata: flip<sint<42>>, wmask: flip<uint<1>>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>
+    %_M_read, %_M_rw, %_M_write = firrtl.mem Undefined {depth = 12 : i64, name = "_M", portNames = ["read", "rw", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, wmode: uint<1>, rdata: flip<sint<42>>, wdata: sint<42>, wmask: uint<1>>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>
   // CHECK:      %_M.ro_data_0, %_M.rw_rdata_0 = rtl.instance "_M" @FIRRTLMem_1_1_1_42_12_0_1_0(%clock1, %true, %c0_i4, %clock1, %true, %c0_i4_0, %true, %true, %0, %clock2, %inpred, %c0_i4_1, %[[mask:.+]], %[[data:.+]]) : (i1, i1, i4, i1, i1, i4, i1, i1, i42, i1, i1, i4, i1, i42) -> (i42, i42)
   // CHECK: rtl.output %_M.ro_data_0, %_M.rw_rdata_0 : i42, i42
 
-      %0 = firrtl.subfield %_M_read("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.sint<42>
+      %0 = firrtl.subfield %_M_read("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>) -> !firrtl.sint<42>
       firrtl.connect %result, %0 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
-      %1 = firrtl.subfield %_M_rw("rdata") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, wmode: flip<uint<1>>, rdata: sint<42>, wdata: flip<sint<42>>, wmask: flip<uint<1>>>) -> !firrtl.sint<42>
+      %1 = firrtl.subfield %_M_rw("rdata") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, wmode: uint<1>, rdata: flip<sint<42>>, wdata: sint<42>, wmask: uint<1>>>) -> !firrtl.sint<42>
       firrtl.connect %result2, %1 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
-      %2 = firrtl.subfield %_M_read("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<4>>
-      firrtl.connect %2, %c0_ui1 : !firrtl.flip<uint<4>>, !firrtl.uint<1>
-      %3 = firrtl.subfield %_M_read("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<1>>
-      firrtl.connect %3, %c1_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-      %4 = firrtl.subfield %_M_read("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<clock>
-      firrtl.connect %4, %clock1 : !firrtl.flip<clock>, !firrtl.clock
+      %2 = firrtl.subfield %_M_read("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>) -> !firrtl.uint<4>
+      firrtl.connect %2, %c0_ui1 : !firrtl.uint<4>, !firrtl.uint<1>
+      %3 = firrtl.subfield %_M_read("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>) -> !firrtl.uint<1>
+      firrtl.connect %3, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+      %4 = firrtl.subfield %_M_read("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>) -> !firrtl.clock
+      firrtl.connect %4, %clock1 : !firrtl.clock, !firrtl.clock
 
-      %5 = firrtl.subfield %_M_rw("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, wmode: flip<uint<1>>, rdata: sint<42>, wdata: flip<sint<42>>, wmask: flip<uint<1>>>) -> !firrtl.flip<uint<4>>
-      firrtl.connect %5, %c0_ui1 : !firrtl.flip<uint<4>>, !firrtl.uint<1>
-      %6 = firrtl.subfield %_M_rw("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, wmode: flip<uint<1>>, rdata: sint<42>, wdata: flip<sint<42>>, wmask: flip<uint<1>>>) -> !firrtl.flip<uint<1>>
-      firrtl.connect %6, %c1_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-      %7 = firrtl.subfield %_M_rw("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, wmode: flip<uint<1>>, rdata: sint<42>, wdata: flip<sint<42>>, wmask: flip<uint<1>>>) -> !firrtl.flip<clock>
-      firrtl.connect %7, %clock1 : !firrtl.flip<clock>, !firrtl.clock
-      %8 = firrtl.subfield %_M_rw("wmask") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, wmode: flip<uint<1>>, rdata: sint<42>, wdata: flip<sint<42>>, wmask: flip<uint<1>>>) -> !firrtl.flip<uint<1>>
-      firrtl.connect %8, %c1_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-      %9 = firrtl.subfield %_M_rw("wmode") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, wmode: flip<uint<1>>, rdata: sint<42>, wdata: flip<sint<42>>, wmask: flip<uint<1>>>) -> !firrtl.flip<uint<1>>
-      firrtl.connect %9, %c1_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+      %5 = firrtl.subfield %_M_rw("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, wmode: uint<1>, rdata: flip<sint<42>>, wdata: sint<42>, wmask: uint<1>>>) -> !firrtl.uint<4>
+      firrtl.connect %5, %c0_ui1 : !firrtl.uint<4>, !firrtl.uint<1>
+      %6 = firrtl.subfield %_M_rw("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, wmode: uint<1>, rdata: flip<sint<42>>, wdata: sint<42>, wmask: uint<1>>>) -> !firrtl.uint<1>
+      firrtl.connect %6, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+      %7 = firrtl.subfield %_M_rw("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, wmode: uint<1>, rdata: flip<sint<42>>, wdata: sint<42>, wmask: uint<1>>>) -> !firrtl.clock
+      firrtl.connect %7, %clock1 : !firrtl.clock, !firrtl.clock
+      %8 = firrtl.subfield %_M_rw("wmask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, wmode: uint<1>, rdata: flip<sint<42>>, wdata: sint<42>, wmask: uint<1>>>) -> !firrtl.uint<1>
+      firrtl.connect %8, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+      %9 = firrtl.subfield %_M_rw("wmode") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, wmode: uint<1>, rdata: flip<sint<42>>, wdata: sint<42>, wmask: uint<1>>>) -> !firrtl.uint<1>
+      firrtl.connect %9, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
 
-      %10 = firrtl.subfield %_M_write("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<4>>
-      firrtl.connect %10, %c0_ui3 : !firrtl.flip<uint<4>>, !firrtl.uint<3>
-      %11 = firrtl.subfield %_M_write("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-      firrtl.connect %11, %inpred : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-      %12 = firrtl.subfield %_M_write("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<clock>
-      firrtl.connect %12, %clock2 : !firrtl.flip<clock>, !firrtl.clock
-      %13 = firrtl.subfield %_M_write("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<sint<42>>
-      firrtl.connect %13, %indata : !firrtl.flip<sint<42>>, !firrtl.sint<42>
-      %14 = firrtl.subfield %_M_write("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-      firrtl.connect %14, %c1_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+      %10 = firrtl.subfield %_M_write("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.uint<4>
+      firrtl.connect %10, %c0_ui3 : !firrtl.uint<4>, !firrtl.uint<3>
+      %11 = firrtl.subfield %_M_write("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.uint<1>
+      firrtl.connect %11, %inpred : !firrtl.uint<1>, !firrtl.uint<1>
+      %12 = firrtl.subfield %_M_write("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.clock
+      firrtl.connect %12, %clock2 : !firrtl.clock, !firrtl.clock
+      %13 = firrtl.subfield %_M_write("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.sint<42>
+      firrtl.connect %13, %indata : !firrtl.sint<42>, !firrtl.sint<42>
+      %14 = firrtl.subfield %_M_write("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.uint<1>
+      firrtl.connect %14, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 
   // CHECK-LABEL: rtl.module @IncompleteRead(
@@ -618,14 +618,14 @@ firrtl.circuit "Simple" {
     %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
 
     // CHECK:  %_M.ro_data_0 = rtl.instance "_M" @FIRRTLMem_1_0_0_42_12_0_1_0(%clock1, %true, %c0_i4) : (i1, i1, i4) -> i42
-    %_M_read = firrtl.mem Undefined {depth = 12 : i64, name = "_M", portNames = ["read"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>
+    %_M_read = firrtl.mem Undefined {depth = 12 : i64, name = "_M", portNames = ["read"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>
     // Read port.
-    %6 = firrtl.subfield %_M_read("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<4>>
-    firrtl.connect %6, %c0_ui1 : !firrtl.flip<uint<4>>, !firrtl.uint<1>
-    %7 = firrtl.subfield %_M_read("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<1>>
-    firrtl.connect %7, %c1_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-    %8 = firrtl.subfield %_M_read("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<clock>
-    firrtl.connect %8, %clock1 : !firrtl.flip<clock>, !firrtl.clock
+    %6 = firrtl.subfield %_M_read("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>) -> !firrtl.uint<4>
+    firrtl.connect %6, %c0_ui1 : !firrtl.uint<4>, !firrtl.uint<1>
+    %7 = firrtl.subfield %_M_read("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>) -> !firrtl.uint<1>
+    firrtl.connect %7, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    %8 = firrtl.subfield %_M_read("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>) -> !firrtl.clock
+    firrtl.connect %8, %clock1 : !firrtl.clock, !firrtl.clock
   }
 
   // CHECK-LABEL: rtl.module @top_mod() -> (%tmp27: i23) {
@@ -634,10 +634,10 @@ firrtl.circuit "Simple" {
   // CHECK-NEXT:    rtl.output %c0_i23 : i23
   // CHECK-NEXT:  }
   firrtl.module @top_mod(%tmp27: !firrtl.flip<uint<23>>) {
-    %0 = firrtl.wire : !firrtl.flip<uint<0>>
+    %0 = firrtl.wire : !firrtl.uint<0>
     %c42_ui23 = firrtl.constant(42 : ui23) : !firrtl.uint<23>
     %1 = firrtl.tail %c42_ui23, 23 : (!firrtl.uint<23>) -> !firrtl.uint<0>
-    firrtl.connect %0, %1 : !firrtl.flip<uint<0>>, !firrtl.uint<0>
+    firrtl.connect %0, %1 : !firrtl.uint<0>, !firrtl.uint<0>
     %2 = firrtl.head %c42_ui23, 0 : (!firrtl.uint<23>) -> !firrtl.uint<0>
     %3 = firrtl.pad %2, 23 : (!firrtl.uint<0>) -> !firrtl.uint<23>
     firrtl.connect %tmp27, %3 : !firrtl.flip<uint<23>>, !firrtl.uint<23>
@@ -664,7 +664,7 @@ firrtl.circuit "Simple" {
   // CHECK-LABEL: IsInvalidIssue572
   // https://github.com/llvm/circt/issues/572
   firrtl.module @IsInvalidIssue572(%a: !firrtl.analog<1>) {
-    
+
     // CHECK-NEXT: %.invalid_analog = sv.wire : !rtl.inout<i1>
     %0 = firrtl.invalidvalue : !firrtl.analog<1>
 
@@ -686,9 +686,9 @@ firrtl.circuit "Simple" {
   // CHECK-LABEL: IsInvalidIssue654
   // https://github.com/llvm/circt/issues/654
   firrtl.module @IsInvalidIssue654() {
-    %w = firrtl.wire : !firrtl.flip<uint<0>>
+    %w = firrtl.wire : !firrtl.uint<0>
     %0 = firrtl.invalidvalue : !firrtl.uint<0>
-    firrtl.connect %w, %0 : !firrtl.flip<uint<0>>, !firrtl.uint<0>
+    firrtl.connect %w, %0 : !firrtl.uint<0>, !firrtl.uint<0>
   }
 
   // CHECK-LABEL: ASQ
@@ -699,7 +699,7 @@ firrtl.circuit "Simple" {
   }
 
   // CHECK-LABEL: rtl.module @Struct0bits(%source: !rtl.struct<valid: i1, ready: i1, data: i0>) {
-  // CHECK-NEXT:    rtl.output 
+  // CHECK-NEXT:    rtl.output
   // CHECK-NEXT:  }
   firrtl.module @Struct0bits(%source: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<0>>) {
     %2 = firrtl.subfield %source ("data") : (!firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<0>>) -> !firrtl.uint<0>
@@ -710,15 +710,15 @@ firrtl.circuit "Simple" {
                          %addr: !firrtl.uint<1>, %data: !firrtl.flip<uint<32>>) {
     // CHECK: %mem0.ro_data_0 = rtl.instance "mem0" @FIRRTLMem_1_0_0_32_1_0_1_1(%clock, %en, %addr) : (i1, i1, i1) -> i32
     // CHECK: rtl.output %mem0.ro_data_0 : i32
-    %mem0_load0 = firrtl.mem Old {depth = 1 : i64, name = "mem0", portNames = ["load0"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<1>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<32>>
-    %0 = firrtl.subfield %mem0_load0("clk") : (!firrtl.bundle<addr: flip<uint<1>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<32>>) -> !firrtl.flip<clock>
-    firrtl.connect %0, %clock : !firrtl.flip<clock>, !firrtl.clock
-    %1 = firrtl.subfield %mem0_load0("addr") : (!firrtl.bundle<addr: flip<uint<1>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<32>>) -> !firrtl.flip<uint<1>>
-    firrtl.connect %1, %addr : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-    %2 = firrtl.subfield %mem0_load0("data") : (!firrtl.bundle<addr: flip<uint<1>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<32>>) -> !firrtl.uint<32>
+    %mem0_load0 = firrtl.mem Old {depth = 1 : i64, name = "mem0", portNames = ["load0"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: flip<uint<32>>>>
+    %0 = firrtl.subfield %mem0_load0("clk") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: flip<uint<32>>>>) -> !firrtl.clock
+    firrtl.connect %0, %clock : !firrtl.clock, !firrtl.clock
+    %1 = firrtl.subfield %mem0_load0("addr") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: flip<uint<32>>>>) -> !firrtl.uint<1>
+    firrtl.connect %1, %addr : !firrtl.uint<1>, !firrtl.uint<1>
+    %2 = firrtl.subfield %mem0_load0("data") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: flip<uint<32>>>>) -> !firrtl.uint<32>
     firrtl.connect %data, %2 : !firrtl.flip<uint<32>>, !firrtl.uint<32>
-    %3 = firrtl.subfield %mem0_load0("en") : (!firrtl.bundle<addr: flip<uint<1>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<32>>) -> !firrtl.flip<uint<1>>
-    firrtl.connect %3, %en : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+    %3 = firrtl.subfield %mem0_load0("en") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: flip<uint<32>>>>) -> !firrtl.uint<1>
+    firrtl.connect %3, %en : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
 }

--- a/test/Conversion/FIRRTLToRTL/zero-width.mlir
+++ b/test/Conversion/FIRRTLToRTL/zero-width.mlir
@@ -8,7 +8,7 @@ firrtl.circuit "Arithmetic" {
                             %out2: !firrtl.flip<uint<4>>,
                             %out3: !firrtl.flip<uint<1>>) {
   %uin0c = firrtl.wire : !firrtl.uint<0>
-  
+
     // CHECK-DAG: [[MULZERO:%.+]] = rtl.constant 0 : i3
     %0 = firrtl.mul %uin0c, %uin3c : (!firrtl.uint<0>, !firrtl.uint<3>) -> !firrtl.uint<3>
     firrtl.connect %out0, %0 : !firrtl.flip<uint<3>>, !firrtl.uint<3>
@@ -44,7 +44,7 @@ firrtl.circuit "Arithmetic" {
                         %out0: !firrtl.flip<uint<3>>,
                         %out1: !firrtl.flip<uint<3>>) {
     %uin0c = firrtl.wire : !firrtl.uint<0>
-  
+
     // CHECK-DAG: = rtl.constant true
     %0 = firrtl.andr %uin0c : (!firrtl.uint<0>) -> !firrtl.uint<1>
 
@@ -73,8 +73,8 @@ firrtl.circuit "Arithmetic" {
     %uin0c = firrtl.wire : !firrtl.uint<0>
 
     // Lowers to nothing.
-    %wire = firrtl.wire : !firrtl.flip<sint<0>>
-    firrtl.connect %wire, %sin0c : !firrtl.flip<sint<0>>, !firrtl.sint<0>
+    %wire = firrtl.wire : !firrtl.sint<0>
+    firrtl.connect %wire, %sin0c : !firrtl.sint<0>, !firrtl.sint<0>
 
     // CHECK-NEXT: rtl.output
   }

--- a/test/Conversion/HandshakeToFIRRTL/simple_addi.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/simple_addi.mlir
@@ -1,36 +1,36 @@
 // RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
 
 // CHECK-LABEL: firrtl.module @std_addi_2ins_1outs_ui64(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) {
+// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) {
 // CHECK:   %0 = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %1 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.flip<uint<1>>
+// CHECK:   %1 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %2 = firrtl.subfield %arg0("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
 // CHECK:   %3 = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %4 = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.flip<uint<1>>
+// CHECK:   %4 = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %5 = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %6 = firrtl.subfield %arg2("valid") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %7 = firrtl.subfield %arg2("ready") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %8 = firrtl.subfield %arg2("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
+// CHECK:   %6 = firrtl.subfield %arg2("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
+// CHECK:   %7 = firrtl.subfield %arg2("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
+// CHECK:   %8 = firrtl.subfield %arg2("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
 // CHECK:   %9 = firrtl.add %2, %5 : (!firrtl.uint<64>, !firrtl.uint<64>) -> !firrtl.uint<65>
 // CHECK:   %10 = firrtl.bits %9 63 to 0 : (!firrtl.uint<65>) -> !firrtl.uint<64>
-// CHECK:   firrtl.connect %8, %10 : !firrtl.flip<uint<64>>, !firrtl.uint<64>
+// CHECK:   firrtl.connect %8, %10 : !firrtl.uint<64>, !firrtl.uint<64>
 // CHECK:   %11 = firrtl.and %0, %3 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %6, %11 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// CHECK:   firrtl.connect %6, %11 : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:   %12 = firrtl.and %7, %11 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %1, %12 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// CHECK:   firrtl.connect %4, %12 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// CHECK:   firrtl.connect %1, %12 : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   firrtl.connect %4, %12 : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK: }
 
 // CHECK-LABEL: firrtl.module @simple_addi(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg4: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg3: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg4: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
 handshake.func @simple_addi(%arg0: index, %arg1: index, %arg2: none, ...) -> (index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @std_addi_2ins_1outs_ui64 {name = ""} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
-  // CHECK: firrtl.connect %inst_arg0, %arg0 : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
-  // CHECK: firrtl.connect %inst_arg1, %arg1 : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+  // CHECK:%inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @std_addi_2ins_1outs_ui64  {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+  // CHECK: firrtl.connect %inst_arg0, %arg0 : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+  // CHECK: firrtl.connect %inst_arg1, %arg1 : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
   %0 = addi %arg0, %arg1 : index
 
-  // CHECK: firrtl.connect %arg3, %inst_arg2 : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
-  // CHECK: firrtl.connect %arg4, %arg2 : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>
+  // CHECK: firrtl.connect %arg3, %inst_arg2 : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+  // CHECK: firrtl.connect %arg4, %arg2 : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>
   handshake.return %0, %arg2 : index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_branch.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_branch.mlir
@@ -1,23 +1,23 @@
 // RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
 
 // CHECK-LABEL: firrtl.module @handshake_branch_1ins_1outs_ui64(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) {
+// CHECK-SAME: %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) {
 // CHECK:   %0 = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %1 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.flip<uint<1>>
+// CHECK:   %1 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %2 = firrtl.subfield %arg0("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %3 = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %4 = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %5 = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
-// CHECK:   firrtl.connect %3, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// CHECK:   firrtl.connect %1, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// CHECK:   firrtl.connect %5, %2 : !firrtl.flip<uint<64>>, !firrtl.uint<64>
+// CHECK:   %3 = firrtl.subfield %arg1("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
+// CHECK:   %4 = firrtl.subfield %arg1("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
+// CHECK:   %5 = firrtl.subfield %arg1("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
+// CHECK:   firrtl.connect %3, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   firrtl.connect %1, %4 : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   firrtl.connect %5, %2 : !firrtl.uint<64>, !firrtl.uint<64>
 // CHECK: }
 
 // CHECK-LABEL: firrtl.module @test_branch(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg3: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
 handshake.func @test_branch(%arg0: index, %arg1: none, ...) -> (index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1 = firrtl.instance @handshake_branch_1ins_1outs_ui64 {name = ""} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+  // CHECK: %inst_arg0, %inst_arg1 = firrtl.instance @handshake_branch_1ins_1outs_ui64  {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
   %0 = "handshake.branch"(%arg0) {control = false}: (index) -> index
   handshake.return %0, %arg1 : index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_cmerge.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_cmerge.mlir
@@ -3,16 +3,16 @@
 // Test a control merge that is control only.
 
 // CHECK-LABEL: firrtl.module @handshake_control_merge_2ins_2outs_ctrl(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %[[CLOCK:.+]]: !firrtl.clock, %[[RESET:.+]]: !firrtl.uint<1>) {
+// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %arg3: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>,  %[[CLOCK:.+]]: !firrtl.clock, %[[RESET:.+]]: !firrtl.uint<1>) {
 // CHECK:   %[[ARG0_VALID:.+]] = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG0_READY:.+]] = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.flip<uint<1>>
+// CHECK:   %[[ARG0_READY:.+]] = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
 // CHECK:   %[[ARG1_VALID:.+]] = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG1_READY:.+]] = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %[[ARG2_VALID:.+]] = firrtl.subfield %arg2("valid") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %[[ARG2_READY:.+]] = firrtl.subfield %arg2("ready") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG3_VALID:.+]] = firrtl.subfield %arg3("valid") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %[[ARG3_READY:.+]] = firrtl.subfield %arg3("ready") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG3_DATA:.+]] = firrtl.subfield %arg3("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
+// CHECK:   %[[ARG1_READY:.+]] = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
+// CHECK:   %[[ARG2_VALID:.+]] = firrtl.subfield %arg2("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>) -> !firrtl.uint<1>
+// CHECK:   %[[ARG2_READY:.+]] = firrtl.subfield %arg2("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>) -> !firrtl.uint<1>
+// CHECK:   %[[ARG3_VALID:.+]] = firrtl.subfield %arg3("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
+// CHECK:   %[[ARG3_READY:.+]] = firrtl.subfield %arg3("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
+// CHECK:   %[[ARG3_DATA:.+]] = firrtl.subfield %arg3("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
 
 // Common definitions.
 // CHECK:   %[[NO_WINNER:.+]] = firrtl.constant(0 : ui2) : !firrtl.uint<2>
@@ -88,10 +88,10 @@
 // CHECK:   firrtl.connect %[[ARG1_READY]], %[[ARG1_READY0]]
 
 // CHECK-LABEL: firrtl.module @test_cmerge(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %arg4: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg5: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg3: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %arg4: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg5: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
 handshake.func @test_cmerge(%arg0: none, %arg1: none, %arg2: none, ...) -> (none, index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_arg3, %inst_clock, %inst_reset = firrtl.instance @handshake_control_merge_2ins_2outs_ctrl {name = ""} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.flip<clock>, !firrtl.flip<uint<1>>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_arg3, %inst_clock, %inst_reset = firrtl.instance @handshake_control_merge_2ins_2outs_ctrl {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.flip<clock>, !firrtl.flip<uint<1>>
   %0:2 = "handshake.control_merge"(%arg0, %arg1) {control = true} : (none, none) -> (none, index)
   handshake.return %0#0, %0#1, %arg2 : none, index, none
 }
@@ -103,7 +103,7 @@ handshake.func @test_cmerge(%arg0: none, %arg1: none, %arg2: none, ...) -> (none
 // CHECK-LABEL: firrtl.module @handshake_control_merge_2ins_2outs
 // CHECK: %[[ARG0_DATA:.+]] = firrtl.subfield %arg0("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
 // CHECK: %[[ARG1_DATA:.+]] = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK: %[[ARG2_DATA:.+]] = firrtl.subfield %arg2("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
+// CHECK: %[[ARG2_DATA:.+]] = firrtl.subfield %arg2("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
 // ...
 // CHECK:   %win = firrtl.wire : !firrtl.uint<2>
 // ...

--- a/test/Conversion/HandshakeToFIRRTL/test_conditional_branch.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_conditional_branch.mlir
@@ -1,38 +1,38 @@
 // RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
 
 // CHECK-LABEL: firrtl.module @handshake_conditional_branch_2ins_2outs_ui64(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<1>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) {
+// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<1>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg3: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) {
 // CHECK:   %0 = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<1>>) -> !firrtl.uint<1>
-// CHECK:   %1 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<1>>) -> !firrtl.flip<uint<1>>
+// CHECK:   %1 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<1>>) -> !firrtl.uint<1>
 // CHECK:   %2 = firrtl.subfield %arg0("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<1>>) -> !firrtl.uint<1>
 // CHECK:   %3 = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %4 = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.flip<uint<1>>
+// CHECK:   %4 = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %5 = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %6 = firrtl.subfield %arg2("valid") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %7 = firrtl.subfield %arg2("ready") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %8 = firrtl.subfield %arg2("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
-// CHECK:   %9 = firrtl.subfield %arg3("valid") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %10 = firrtl.subfield %arg3("ready") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %11 = firrtl.subfield %arg3("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
+// CHECK:   %6 = firrtl.subfield %arg2("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
+// CHECK:   %7 = firrtl.subfield %arg2("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
+// CHECK:   %8 = firrtl.subfield %arg2("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
+// CHECK:   %9 = firrtl.subfield %arg3("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
+// CHECK:   %10 = firrtl.subfield %arg3("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
+// CHECK:   %11 = firrtl.subfield %arg3("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
 // CHECK:   %12 = firrtl.and %0, %3 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   %13 = firrtl.not %2 : (!firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   %14 = firrtl.and %2, %12 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %6, %14 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// CHECK:   firrtl.connect %6, %14 : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:   %15 = firrtl.and %13, %12 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %9, %15 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// CHECK:   firrtl.connect %8, %5 : !firrtl.flip<uint<64>>, !firrtl.uint<64>
-// CHECK:   firrtl.connect %11, %5 : !firrtl.flip<uint<64>>, !firrtl.uint<64>
+// CHECK:   firrtl.connect %9, %15 : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   firrtl.connect %8, %5 : !firrtl.uint<64>, !firrtl.uint<64>
+// CHECK:   firrtl.connect %11, %5 : !firrtl.uint<64>, !firrtl.uint<64>
 // CHECK:   %16 = firrtl.mux(%2, %7, %10) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   %17 = firrtl.and %16, %12 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %4, %17 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// CHECK:   firrtl.connect %1, %17 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// CHECK:   firrtl.connect %4, %17 : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   firrtl.connect %1, %17 : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK: }
 
 // CHECK-LABEL: firrtl.module @test_conditional_branch(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<1>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg4: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg5: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<1>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg3: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg4: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg5: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
 handshake.func @test_conditional_branch(%arg0: i1, %arg1: index, %arg2: none, ...) -> (index, index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_arg3 = firrtl.instance @handshake_conditional_branch_2ins_2outs_ui64 {name = ""} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<1>>>, !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_arg3 = firrtl.instance @handshake_conditional_branch_2ins_2outs_ui64  {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<1>>>, !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
   %0:2 = "handshake.conditional_branch"(%arg0, %arg1) {control = false}: (i1, index) -> (index, index)
   handshake.return %0#0, %0#1, %arg2 : index, index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_constant.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_constant.mlir
@@ -2,43 +2,43 @@
 
 // Submodule for the index and i64 ConstantOps as they have the same value and converted type.
 // CHECK-LABEL: firrtl.module @handshake_constant_1ins_1outs_c42_ui64(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) {
+// CHECK-SAME: %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) {
 // CHECK:   %[[ARG0_VALID:.+]] = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG0_READY:.+]] = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %[[ARG1_VALID:.+]] = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %[[ARG1_READY:.+]] = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG1_DATA:.+]] = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
-// CHECK:   firrtl.connect %[[ARG1_VALID:.+]], %[[ARG0_VALID:.+]] : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// CHECK:   firrtl.connect %[[ARG0_READY:.+]], %[[ARG1_READY:.+]] : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// CHECK:   %[[ARG0_READY:.+]] = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
+// CHECK:   %[[ARG1_VALID:.+]] = firrtl.subfield %arg1("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
+// CHECK:   %[[ARG1_READY:.+]] = firrtl.subfield %arg1("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
+// CHECK:   %[[ARG1_DATA:.+]] = firrtl.subfield %arg1("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
+// CHECK:   firrtl.connect %[[ARG1_VALID:.+]], %[[ARG0_VALID:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   firrtl.connect %[[ARG0_READY:.+]], %[[ARG1_READY:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:   %c42_ui64 = firrtl.constant(42 : ui64) : !firrtl.uint<64>
-// CHECK:   firrtl.connect %[[ARG1_DATA:.+]], %c42_ui64 : !firrtl.flip<uint<64>>, !firrtl.uint<64>
+// CHECK:   firrtl.connect %[[ARG1_DATA:.+]], %c42_ui64 : !firrtl.uint<64>, !firrtl.uint<64>
 // CHECK: }
 
 // Submodule for the ui32 ConstantOp.
 // CHECK-LABEL: firrtl.module @handshake_constant_1ins_1outs_c42_ui32(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<32>>>) {
+// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<32>>>) {
 // CHECK:   %c42_ui32 = firrtl.constant(42 : ui32) : !firrtl.uint<32>
 
 // Submodule for the si32 ConstantOp.
 // CHECK-LABEL: firrtl.module @"handshake_constant_1ins_1outs_c-11_si32"(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<sint<32>>>) {
+// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: sint<32>>>) {
 // CHECK:   %c-11_si32 = firrtl.constant(-11 : si32) : !firrtl.sint<32>
 
 // CHECK-LABEL: firrtl.module @test_constant(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<32>>>, %arg4: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<sint<32>>>, %arg5: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg3: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<32>>>, %arg4: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: sint<32>>>, %arg5: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
 handshake.func @test_constant(%arg0: none, ...) -> (index, i64, ui32, si32, none) {
   %0:5 = "handshake.fork"(%arg0) {control = true} : (none) -> (none, none, none, none, none)
   
-  // CHECK: %inst_arg0_0, %inst_arg1_1 = firrtl.instance @handshake_constant_1ins_1outs_c42_ui64 {name = ""} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+  // CHECK: %inst_arg0_0, %inst_arg1_1 = firrtl.instance @handshake_constant_1ins_1outs_c42_ui64  {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
   %1 = "handshake.constant"(%0#0) {value = 42 : index}: (none) -> index
 
-  // CHECK: %inst_arg0_2, %inst_arg1_3 = firrtl.instance @handshake_constant_1ins_1outs_c42_ui64 {name = ""} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+  // CHECK: %inst_arg0_2, %inst_arg1_3 = firrtl.instance @handshake_constant_1ins_1outs_c42_ui64  {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
   %2 = "handshake.constant"(%0#1) {value = 42 : i64}: (none) -> i64
 
-  // CHECK: %inst_arg0_4, %inst_arg1_5 = firrtl.instance @handshake_constant_1ins_1outs_c42_ui32 {name = ""} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<32>>
+  // CHECK: %inst_arg0_4, %inst_arg1_5 = firrtl.instance @handshake_constant_1ins_1outs_c42_ui32  {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<32>>
   %3 = "handshake.constant"(%0#2) {value = 42 : ui32}: (none) -> ui32
 
-  // CHECK: %inst_arg0_6, %inst_arg1_7 = firrtl.instance @"handshake_constant_1ins_1outs_c-11_si32" {name = ""} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: sint<32>>
+  // CHECK: %inst_arg0_6, %inst_arg1_7 = firrtl.instance @"handshake_constant_1ins_1outs_c-11_si32"  {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: sint<32>>
   %4 = "handshake.constant"(%0#3) {value = -11 : si32}: (none) -> si32
   handshake.return %1, %2, %3, %4, %0#4 : index, i64, ui32, si32, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_fork.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_fork.mlir
@@ -1,13 +1,13 @@
 // RUN: circt-opt -lower-handshake-to-firrtl -split-input-file %s | FileCheck %s
 
 // CHECK-LABEL: firrtl.module @handshake_fork_1ins_2outs_ctrl(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>
 // CHECK:   %[[ARG_VALID:.+]] = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG_READY:.+]] = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %[[RES0_VALID:.+]] = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %[[RES0_READY:.+]] = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>) -> !firrtl.uint<1>
-// CHECK:   %[[RES1_VALID:.+]] = firrtl.subfield %arg2("valid") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %[[RES1_READY:.+]] = firrtl.subfield %arg2("ready") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>) -> !firrtl.uint<1>
+// CHECK:   %[[ARG_READY:.+]] = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
+// CHECK:   %[[RES0_VALID:.+]] = firrtl.subfield %arg1("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>) -> !firrtl.uint<1>
+// CHECK:   %[[RES0_READY:.+]] = firrtl.subfield %arg1("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>) -> !firrtl.uint<1>
+// CHECK:   %[[RES1_VALID:.+]] = firrtl.subfield %arg2("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>) -> !firrtl.uint<1>
+// CHECK:   %[[RES1_READY:.+]] = firrtl.subfield %arg2("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>) -> !firrtl.uint<1>
 
 // Done logic.
 // CHECK:   %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
@@ -17,7 +17,7 @@
 // CHECK:   %allDone = firrtl.wire : !firrtl.uint<1>
 // CHECK:   %6 = firrtl.and %done1, %done0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   firrtl.connect %allDone, %6 : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:   firrtl.connect %[[ARG_READY:.+]], %allDone : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// CHECK:   firrtl.connect %[[ARG_READY:.+]], %allDone : !firrtl.uint<1>, !firrtl.uint<1>
 
 // CHECK:   %notAllDone = firrtl.wire : !firrtl.uint<1>
 // CHECK:   %7 = firrtl.not %allDone : (!firrtl.uint<1>) -> !firrtl.uint<1>
@@ -33,7 +33,7 @@
 // CHECK:   firrtl.connect %notEmtd0, %9 : !firrtl.uint<1>, !firrtl.uint<1>
 
 // CHECK:   %10 = firrtl.and %notEmtd0, %[[ARG_VALID:.+]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %[[RES0_VALID:.+]], %10 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// CHECK:   firrtl.connect %[[RES0_VALID:.+]], %10 : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:   %validReady0 = firrtl.wire : !firrtl.uint<1>
 // CHECK:   %11 = firrtl.and %[[RES0_READY:.+]], %10 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   firrtl.connect %validReady0, %11 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -51,7 +51,7 @@
 // CHECK:   firrtl.connect %notEmtd1, %14 : !firrtl.uint<1>, !firrtl.uint<1>
 
 // CHECK:   %15 = firrtl.and %notEmtd1, %[[ARG0_VALID:.+]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %[[RES1_VALID:.+]], %15 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// CHECK:   firrtl.connect %[[RES1_VALID:.+]], %15 : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:   %validReady1 = firrtl.wire : !firrtl.uint<1>
 // CHECK:   %16 = firrtl.and %[[RES1_READY:.+]], %15 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   firrtl.connect %validReady1, %16 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -61,10 +61,10 @@
 // CHECK: }
 
 // CHECK-LABEL: firrtl.module @test_fork(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %arg4: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %arg3: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %arg4: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
 handshake.func @test_fork(%arg0: none, %arg1: none, ...) -> (none, none, none) {
 
-  // CHECK:  %inst_arg0, %inst_arg1, %inst_arg2, %inst_clock, %inst_reset = firrtl.instance @handshake_fork_1ins_2outs_ctrl {name = ""} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, !firrtl.flip<clock>, !firrtl.flip<uint<1>>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_clock, %inst_reset = firrtl.instance @handshake_fork_1ins_2outs_ctrl {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, !firrtl.flip<clock>, !firrtl.flip<uint<1>>
   %0:2 = "handshake.fork"(%arg0) {control = true} : (none) -> (none, none)
   handshake.return %0#0, %0#1, %arg1 : none, none, none
 }
@@ -72,19 +72,19 @@ handshake.func @test_fork(%arg0: none, %arg1: none, ...) -> (none, none, none) {
 // -----
 
 // CHECK-LABEL: firrtl.module @handshake_fork_1ins_2outs_ui64(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME: %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
 // CHECK:   %[[ARG_DATA:.+]] = firrtl.subfield %arg0("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %[[RES0_DATA:.+]] = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
-// CHECK:   %[[RES1_DATA:.+]] = firrtl.subfield %arg2("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
+// CHECK:   %[[RES0_DATA:.+]] = firrtl.subfield %arg1("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
+// CHECK:   %[[RES1_DATA:.+]] = firrtl.subfield %arg2("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
 
-// CHECK:   firrtl.connect %[[RES0_DATA:.+]], %[[ARG_DATA:.+]] : !firrtl.flip<uint<64>>, !firrtl.uint<64>
-// CHECK:   firrtl.connect %[[RES1_DATA:.+]], %[[ARG_DATA:.+]] : !firrtl.flip<uint<64>>, !firrtl.uint<64>
+// CHECK:   firrtl.connect %[[RES0_DATA:.+]], %[[ARG_DATA:.+]] : !firrtl.uint<64>, !firrtl.uint<64>
+// CHECK:   firrtl.connect %[[RES1_DATA:.+]], %[[ARG_DATA:.+]] : !firrtl.uint<64>, !firrtl.uint<64>
 
 // CHECK-LABEL: firrtl.module @test_fork_data(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg4: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg3: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg4: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
 handshake.func @test_fork_data(%arg0: index, %arg1: none, ...) -> (index, index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_clock, %inst_reset = firrtl.instance @handshake_fork_1ins_2outs_ui64 {name = ""} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.flip<clock>, !firrtl.flip<uint<1>>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_clock, %inst_reset = firrtl.instance @handshake_fork_1ins_2outs_ui64 {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.flip<clock>, !firrtl.flip<uint<1>>
   %0:2 = "handshake.fork"(%arg0) {control = false} : (index) -> (index, index)
   handshake.return %0#0, %0#1, %arg1 : index, index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_join.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_join.mlir
@@ -1,25 +1,25 @@
 // RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
 
 // CHECK-LABEL: firrtl.module @handshake_join_2ins_1outs_ctrl(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>) {
-// CHECK:   %0 = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
-// CHECK:   %1 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %2 = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
-// CHECK:   %3 = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %4 = firrtl.subfield %arg2("valid") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %5 = firrtl.subfield %arg2("ready") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>) -> !firrtl.uint<1>
-// CHECK:   %6 = firrtl.and %2, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %4, %6 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// CHECK:   %7 = firrtl.and %5, %6 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %1, %7 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// CHECK:   firrtl.connect %3, %7 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// CHECK: }
+// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>) {
+ // CHECK:   %0 = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
+ // CHECK:   %1 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
+ // CHECK:   %2 = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
+ // CHECK:   %3 = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
+ // CHECK:   %4 = firrtl.subfield %arg2("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>) -> !firrtl.uint<1>
+ // CHECK:   %5 = firrtl.subfield %arg2("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>) -> !firrtl.uint<1>
+ // CHECK:   %6 = firrtl.and %2, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+ // CHECK:   firrtl.connect %4, %6 : !firrtl.uint<1>, !firrtl.uint<1>
+ // CHECK:   %7 = firrtl.and %5, %6 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+ // CHECK:   firrtl.connect %1, %7 : !firrtl.uint<1>, !firrtl.uint<1>
+ // CHECK:   firrtl.connect %3, %7 : !firrtl.uint<1>, !firrtl.uint<1>
+ // CHECK: }
 
 // CHECK-LABEL: firrtl.module @test_join(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %arg4: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME: %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg3: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %arg4: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
 handshake.func @test_join(%arg0: none, %arg1: none, %arg2: none, ...) -> (none, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @handshake_join_2ins_1outs_ctrl {name = ""} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @handshake_join_2ins_1outs_ctrl  {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>
   %0 = "handshake.join"(%arg0, %arg1) {control = true}: (none, none) -> none
   handshake.return %0, %arg2 : none, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_lazy_fork.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_lazy_fork.mlir
@@ -1,30 +1,30 @@
 // RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
 
 // CHECK-LABEL: firrtl.module @handshake_lazy_fork_1ins_2outs_ui64(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) {
+// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) {
 // CHECK:   %0 = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %1 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.flip<uint<1>>
+// CHECK:   %1 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %2 = firrtl.subfield %arg0("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %3 = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %4 = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %5 = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
-// CHECK:   %6 = firrtl.subfield %arg2("valid") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %7 = firrtl.subfield %arg2("ready") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %8 = firrtl.subfield %arg2("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
+// CHECK:   %3 = firrtl.subfield %arg1("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
+// CHECK:   %4 = firrtl.subfield %arg1("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
+// CHECK:   %5 = firrtl.subfield %arg1("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
+// CHECK:   %6 = firrtl.subfield %arg2("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
+// CHECK:   %7 = firrtl.subfield %arg2("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
+// CHECK:   %8 = firrtl.subfield %arg2("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
 // CHECK:   %9 = firrtl.and %7, %4 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %1, %9 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// CHECK:   firrtl.connect %1, %9 : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:   %10 = firrtl.and %0, %9 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %3, %10 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// CHECK:   firrtl.connect %5, %2 : !firrtl.flip<uint<64>>, !firrtl.uint<64>
-// CHECK:   firrtl.connect %6, %10 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// CHECK:   firrtl.connect %8, %2 : !firrtl.flip<uint<64>>, !firrtl.uint<64>
+// CHECK:   firrtl.connect %3, %10 : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   firrtl.connect %5, %2 : !firrtl.uint<64>, !firrtl.uint<64>
+// CHECK:   firrtl.connect %6, %10 : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:   firrtl.connect %8, %2 : !firrtl.uint<64>, !firrtl.uint<64>
 // CHECK: }
 
 // CHECK-LABEL: firrtl.module @test_lazy_fork(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg4: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg3: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg4: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
 handshake.func @test_lazy_fork(%arg0: index, %arg1: none, ...) -> (index, index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @handshake_lazy_fork_1ins_2outs_ui64 {name = ""} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @handshake_lazy_fork_1ins_2outs_ui64  {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
   %0:2 = "handshake.lazy_fork"(%arg0) {control = false} : (index) -> (index, index)
   handshake.return %0#0, %0#1, %arg1 : index, index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_memory.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_memory.mlir
@@ -19,14 +19,15 @@
 // CHECK: %[[LD_CONTROL_READY:.+]] = firrtl.subfield %arg5("ready")
 
 // Construct the memory.
-// CHECK: %[[MEM_LOAD:.+]], %[[MEM_STORE:.+]] = firrtl.mem Old {depth = 10 : i64, name = "mem0", portNames = ["load0", "store0"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<8>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>>
+// CHECK: %[[MEM_LOAD:.+]], %[[MEM_STORE:.+]] = firrtl.mem Old {depth = 10 : i64, name = "mem0", portNames = ["load0", "store0"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<uint<8>>>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>>
+ 
 
 // Connect the store clock.
-// CHECK: %[[MEM_LOAD_CLK:.+]] = firrtl.subfield %[[MEM_LOAD]]("clk") : {{.*}} -> !firrtl.flip<clock>
+// CHECK: %[[MEM_LOAD_CLK:.+]] = firrtl.subfield %[[MEM_LOAD]]("clk") : {{.*}} -> !firrtl.clock
 // CHECK: firrtl.connect %[[MEM_LOAD_CLK]], %clock
 
 // Connect the load address, truncating if necessary.
-// CHECK: %[[MEM_LOAD_ADDR:.+]] = firrtl.subfield %[[MEM_LOAD]]("addr") : {{.*}} -> !firrtl.flip<uint<4>>
+// CHECK: %[[MEM_LOAD_ADDR:.+]] = firrtl.subfield %[[MEM_LOAD]]("addr") : {{.*}} -> !firrtl.uint<4>
 // CHECK: %[[LD_ADDR_DATA_TAIL:.+]] = firrtl.tail %[[LD_ADDR_DATA]], 60 : (!firrtl.uint<64>) -> !firrtl.uint<4>
 // CHECK: firrtl.connect %[[MEM_LOAD_ADDR]], %[[LD_ADDR_DATA_TAIL]]
 
@@ -35,7 +36,7 @@
 // CHECK: firrtl.connect %[[LD_DATA_DATA]], %[[MEM_LOAD_DATA]]
 
 // Connect the load address valid to the load enable.
-// CHECK: %[[MEM_LOAD_EN:.+]] = firrtl.subfield %[[MEM_LOAD]]("en") : {{.*}} -> !firrtl.flip<uint<1>>
+// CHECK: %[[MEM_LOAD_EN:.+]] = firrtl.subfield %[[MEM_LOAD]]("en") : {{.*}} -> !firrtl.uint<1>
 // CHECK: firrtl.connect %[[MEM_LOAD_EN]], %[[LD_ADDR_VALID]]
 
 // Create control-only fork for the load address valid and ready signal to the
@@ -49,16 +50,16 @@
 // CHECK-DAG: firrtl.{{.+}} %[[LD_CONTROL_READY]]
 
 // Connect the store clock.
-// CHECK: %[[MEM_STORE_CLK:.+]] = firrtl.subfield %[[MEM_STORE]]("clk") : {{.*}} -> !firrtl.flip<clock>
+// CHECK: %[[MEM_STORE_CLK:.+]] = firrtl.subfield %[[MEM_STORE]]("clk") : {{.*}} -> !firrtl.clock
 // CHECK: firrtl.connect %[[MEM_STORE_CLK]], %clock
 
 // Connect the store address, truncating if necessary.
-// CHECK: %[[MEM_STORE_ADDR:.+]] = firrtl.subfield %[[MEM_STORE]]("addr") : {{.*}} -> !firrtl.flip<uint<4>>
+// CHECK: %[[MEM_STORE_ADDR:.+]] = firrtl.subfield %[[MEM_STORE]]("addr") : {{.*}} -> !firrtl.uint<4>
 // CHECK: %[[ST_ADDR_DATA_TAIL:.+]] = firrtl.tail %[[ST_ADDR_DATA]], 60 : (!firrtl.uint<64>) -> !firrtl.uint<4>
 // CHECK: firrtl.connect %[[MEM_STORE_ADDR]], %[[ST_ADDR_DATA_TAIL]]
 
 // Connect the store data.
-// CHECK: %[[MEM_STORE_DATA:.+]] = firrtl.subfield %[[MEM_STORE]]("data") : {{.*}} -> !firrtl.flip<uint<8>>
+// CHECK: %[[MEM_STORE_DATA:.+]] = firrtl.subfield %[[MEM_STORE]]("data") : {{.*}} -> !firrtl.uint<8>
 // CHECK: firrtl.connect %[[MEM_STORE_DATA]], %[[ST_DATA_DATA]]
 
 // Create the write valid buffer.
@@ -87,11 +88,11 @@
 // CHECK: firrtl.connect %[[WRITE_VALID_BUFFER]], %[[WRITE_VALID_BUFFER_MUX]]
 
 // Connect the write valid signal to the memory enable
-// CHECK: %[[MEM_STORE_EN:.+]] = firrtl.subfield %[[MEM_STORE]]("en") : {{.*}} -> !firrtl.flip<uint<1>>
+// CHECK: %[[MEM_STORE_EN:.+]] = firrtl.subfield %[[MEM_STORE]]("en") : {{.*}} -> !firrtl.uint<1>
 // CHECK: firrtl.connect %[[MEM_STORE_EN]], %[[WRITE_VALID]]
 
 // Connect the write valid signal to the memory mask.
-// CHECK: %[[MEM_STORE_MASK:.+]] = firrtl.subfield %[[MEM_STORE]]("mask") : {{.*}} -> !firrtl.flip<uint<1>>
+// CHECK: %[[MEM_STORE_MASK:.+]] = firrtl.subfield %[[MEM_STORE]]("mask") : {{.*}} -> !firrtl.uint<1>
 // CHECK: firrtl.connect %[[MEM_STORE_MASK]], %[[WRITE_VALID]]
 
 // CHECK-LABEL: firrtl.module @main

--- a/test/Conversion/HandshakeToFIRRTL/test_merge.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_merge.mlir
@@ -1,16 +1,16 @@
 // RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
 
 // CHECK-LABEL: firrtl.module @handshake_merge_2ins_1outs_ui64(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) {
+// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) {
 // CHECK:   %[[ARG0_VALID:.+]] = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG0_READY:.+]] = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.flip<uint<1>>
+// CHECK:   %[[ARG0_READY:.+]] = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %[[ARG0_DATA:.+]] = firrtl.subfield %arg0("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
 // CHECK:   %[[ARG1_VALID:.+]] = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG1_READY:.+]] = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.flip<uint<1>>
+// CHECK:   %[[ARG1_READY:.+]] = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %[[ARG1_DATA:.+]] = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %[[ARG2_VALID:.+]] = firrtl.subfield %arg2("valid") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %[[ARG2_READY:.+]] = firrtl.subfield %arg2("ready") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG2_DATA:.+]] = firrtl.subfield %arg2("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
+// CHECK:   %[[ARG2_VALID:.+]] = firrtl.subfield %arg2("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
+// CHECK:   %[[ARG2_READY:.+]] = firrtl.subfield %arg2("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
+// CHECK:   %[[ARG2_DATA:.+]] = firrtl.subfield %arg2("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
 
 // Common definitions.
 // CHECK:   %[[NO_WINNER:.+]] = firrtl.constant(0 : ui2) : !firrtl.uint<2>
@@ -52,10 +52,10 @@
 // CHECK:   firrtl.connect %[[ARG1_READY]], %[[ARG1_READY0]]
 
 // CHECK-LABEL: firrtl.module @test_merge(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg4: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg3: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg4: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
 handshake.func @test_merge(%arg0: index, %arg1: index, %arg2: none, ...) -> (index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @handshake_merge_2ins_1outs_ui64 {name = ""} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @handshake_merge_2ins_1outs_ui64 {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
   %0 = "handshake.merge"(%arg0, %arg1) : (index, index) -> index
   handshake.return %0, %arg2 : index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_mux.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_mux.mlir
@@ -1,43 +1,43 @@
 // RUN: circt-opt -lower-handshake-to-firrtl -split-input-file %s | FileCheck %s
 
 // CHECK-LABEL: firrtl.module @handshake_mux_3ins_1outs_ui64(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg3: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) {
+// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg3: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) {
 // CHECK:   %0 = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %1 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.flip<uint<1>>
+// CHECK:   %1 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %2 = firrtl.subfield %arg0("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
 // CHECK:   %3 = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %4 = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.flip<uint<1>>
+// CHECK:   %4 = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %5 = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
 // CHECK:   %6 = firrtl.subfield %arg2("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
-// CHECK:   %7 = firrtl.subfield %arg2("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.flip<uint<1>>
+// CHECK:   %7 = firrtl.subfield %arg2("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %8 = firrtl.subfield %arg2("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %9 = firrtl.subfield %arg3("valid") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<1>>
-// CHECK:   %10 = firrtl.subfield %arg3("ready") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %11 = firrtl.subfield %arg3("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
+// CHECK:   %9 = firrtl.subfield %arg3("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
+// CHECK:   %10 = firrtl.subfield %arg3("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
+// CHECK:   %11 = firrtl.subfield %arg3("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
 // CHECK:   %12 = firrtl.bits %2 0 to 0 : (!firrtl.uint<64>) -> !firrtl.uint<1>
 // CHECK:   %13 = firrtl.mux(%12, %8, %5) : (!firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>) -> !firrtl.uint<64>
-// CHECK:   firrtl.connect %11, %13 : !firrtl.flip<uint<64>>, !firrtl.uint<64>
+// CHECK:   firrtl.connect %11, %13 : !firrtl.uint<64>, !firrtl.uint<64>
 // CHECK:   %14 = firrtl.bits %2 0 to 0 : (!firrtl.uint<64>) -> !firrtl.uint<1>
 // CHECK:   %15 = firrtl.mux(%14, %6, %3) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   %16 = firrtl.and %15, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %9, %16 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// CHECK:   firrtl.connect %9, %16 : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:   %17 = firrtl.and %16, %10 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %1, %17 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// CHECK:   firrtl.connect %1, %17 : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:   %18 = firrtl.tail %2, 63 : (!firrtl.uint<64>) -> !firrtl.uint<1>
 // CHECK:   %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
 // CHECK:   %19 = firrtl.dshl %c1_ui1, %18 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
 // CHECK:   %20 = firrtl.bits %19 0 to 0 : (!firrtl.uint<2>) -> !firrtl.uint<1>
 // CHECK:   %21 = firrtl.and %20, %17 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %4, %21 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// CHECK:   firrtl.connect %4, %21 : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:   %22 = firrtl.bits %19 1 to 1 : (!firrtl.uint<2>) -> !firrtl.uint<1>
 // CHECK:   %23 = firrtl.and %22, %17 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:   firrtl.connect %7, %23 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// CHECK:   firrtl.connect %7, %23 : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK: }
 
-// CHECK: firrtl.module @test_mux(%arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg3: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg4: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, %arg5: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK: firrtl.module @test_mux(%arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg3: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg4: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg5: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
 handshake.func @test_mux(%arg0: index, %arg1: index, %arg2: index, %arg3: none, ...) -> (index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_arg3 = firrtl.instance @handshake_mux_3ins_1outs_ui64 {name = ""} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_arg3 = firrtl.instance @handshake_mux_3ins_1outs_ui64  {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
   %0 = "handshake.mux"(%arg0, %arg1, %arg2): (index, index, index) -> index
   handshake.return %0, %arg3 : index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_sink.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_sink.mlir
@@ -1,20 +1,20 @@
 // RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
 
 // CHECK-LABEL: firrtl.module @handshake_sink_1ins_0outs_ui64(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) {
-// CHECK:   %0 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.flip<uint<1>>
+// CHECK-SAME:   %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) {
+// CHECK:   %0 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
-// CHECK:   firrtl.connect %0, %c1_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// CHECK:   firrtl.connect %0, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK: }
 
 // CHECK-LABEL: firrtl.module @test_sink(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME: %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
 handshake.func @test_sink(%arg0: index, %arg2: none, ...) -> (none) {
 
-  // CHECK: %inst_arg0 = firrtl.instance @handshake_sink_1ins_0outs_ui64 {name = ""} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>
-  // CHECK: firrtl.connect %inst_arg0, %arg0 : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+  // CHECK: %inst_arg0 = firrtl.instance @handshake_sink_1ins_0outs_ui64  {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>
+  // CHECK: firrtl.connect %inst_arg0, %arg0 : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
   "handshake.sink"(%arg0) : (index) -> ()
 
-  // CHECK: firrtl.connect %arg2, %arg1 : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>
+  // CHECK: firrtl.connect %arg2, %arg1 : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>
   handshake.return %arg2 : none
 }

--- a/test/Dialect/FIRRTL/blackbox-memory.mlir
+++ b/test/Dialect/FIRRTL/blackbox-memory.mlir
@@ -6,14 +6,14 @@ firrtl.circuit "Read" {
     %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
     %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
 
-    %0 = firrtl.mem Undefined {depth = 16 : i64, name = "ReadMemory", portNames = ["read0"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+    %0 = firrtl.mem Undefined {depth = 16 : i64, name = "ReadMemory", portNames = ["read0"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>>
 
-    %1 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.sint<8>
-    %2 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
-    firrtl.connect %2, %c0_ui1 : !firrtl.flip<uint<4>>, !firrtl.uint<1>
-    %3 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<1>>
-    firrtl.connect %3, %c1_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-    %4 = firrtl.subfield %0("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<clock>
+    %1 = firrtl.subfield %0("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>>) -> !firrtl.sint<8>
+    %2 = firrtl.subfield %0("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>>) -> !firrtl.uint<4>
+    firrtl.connect %2, %c0_ui1 : !firrtl.uint<4>, !firrtl.uint<1>
+    %3 = firrtl.subfield %0("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>>) -> !firrtl.uint<1>
+    firrtl.connect %3, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    %4 = firrtl.subfield %0("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>>) -> !firrtl.clock
   }
 }
 
@@ -27,19 +27,19 @@ firrtl.circuit "Read" {
 // WRAPPER-NEXT:     firrtl.connect %ReadMemory_R0_en, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // WRAPPER-NEXT:     %2 = firrtl.subfield %read0("clk") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.clock
 // WRAPPER-NEXT:     firrtl.connect %ReadMemory_R0_clk, %2 : !firrtl.flip<clock>, !firrtl.clock
-// WRAPPER-NEXT:     %3 = firrtl.subfield %read0("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.flip<sint<8>>
-// WRAPPER-NEXT:     firrtl.connect %3, %ReadMemory_R0_data : !firrtl.flip<sint<8>>, !firrtl.sint<8>
+// WRAPPER-NEXT:     %3 = firrtl.subfield %read0("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.sint<8>
+// WRAPPER-NEXT:     firrtl.connect %3, %ReadMemory_R0_data : !firrtl.sint<8>, !firrtl.sint<8>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT:   firrtl.module @Read() {
 // WRAPPER-NEXT:     %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
 // WRAPPER-NEXT:     %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
-// WRAPPER-NEXT:     %ReadMemory_read0 = firrtl.instance @ReadMemory {name = "ReadMemory"} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
-// WRAPPER-NEXT:     %0 = firrtl.subfield %ReadMemory_read0("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.sint<8>
-// WRAPPER-NEXT:     %1 = firrtl.subfield %ReadMemory_read0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
-// WRAPPER-NEXT:     firrtl.connect %1, %c0_ui1 : !firrtl.flip<uint<4>>, !firrtl.uint<1>
-// WRAPPER-NEXT:     %2 = firrtl.subfield %ReadMemory_read0("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<1>>
-// WRAPPER-NEXT:     firrtl.connect %2, %c1_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// WRAPPER-NEXT:     %3 = firrtl.subfield %ReadMemory_read0("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<clock>
+// WRAPPER-NEXT:     %ReadMemory_read0 = firrtl.instance @ReadMemory {name = "ReadMemory"} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>>
+// WRAPPER-NEXT:     %0 = firrtl.subfield %ReadMemory_read0("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>>) -> !firrtl.sint<8>
+// WRAPPER-NEXT:     %1 = firrtl.subfield %ReadMemory_read0("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>>) -> !firrtl.uint<4>
+// WRAPPER-NEXT:     firrtl.connect %1, %c0_ui1 : !firrtl.uint<4>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %2 = firrtl.subfield %ReadMemory_read0("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>>) -> !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %2, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %3 = firrtl.subfield %ReadMemory_read0("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>>) -> !firrtl.clock
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT: }
 
@@ -49,21 +49,21 @@ firrtl.circuit "Read" {
 // INLINE-NEXT:     %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
 // INLINE-NEXT:     %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
 // INLINE-NEXT:     %ReadMemory_R0_addr, %ReadMemory_R0_en, %ReadMemory_R0_clk, %ReadMemory_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory"} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
-// INLINE-NEXT:     %0 = firrtl.wire : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
-// INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
-// INLINE-NEXT:     firrtl.connect %ReadMemory_R0_addr, %1 : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
-// INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %ReadMemory_R0_en, %2 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %3 = firrtl.subfield %0("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<clock>
-// INLINE-NEXT:     firrtl.connect %ReadMemory_R0_clk, %3 : !firrtl.flip<clock>, !firrtl.flip<clock>
-// INLINE-NEXT:     %4 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.sint<8>
+// INLINE-NEXT:     %0 = firrtl.wire : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>
+// INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.uint<4>
+// INLINE-NEXT:     firrtl.connect %ReadMemory_R0_addr, %1 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+// INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %ReadMemory_R0_en, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %3 = firrtl.subfield %0("clk") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.clock
+// INLINE-NEXT:     firrtl.connect %ReadMemory_R0_clk, %3 : !firrtl.flip<clock>, !firrtl.clock
+// INLINE-NEXT:     %4 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.sint<8>
 // INLINE-NEXT:     firrtl.connect %4, %ReadMemory_R0_data : !firrtl.sint<8>, !firrtl.sint<8>
-// INLINE-NEXT:     %5 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.sint<8>
-// INLINE-NEXT:     %6 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
-// INLINE-NEXT:     firrtl.connect %6, %c0_ui1 : !firrtl.flip<uint<4>>, !firrtl.uint<1>
-// INLINE-NEXT:     %7 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %7, %c1_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// INLINE-NEXT:     %8 = firrtl.subfield %0("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<clock>
+// INLINE-NEXT:     %5 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.sint<8>
+// INLINE-NEXT:     %6 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.uint<4>
+// INLINE-NEXT:     firrtl.connect %6, %c0_ui1 : !firrtl.uint<4>, !firrtl.uint<1>
+// INLINE-NEXT:     %7 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %7, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+// INLINE-NEXT:     %8 = firrtl.subfield %0("clk") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.clock
 // INLINE-NEXT:   }
 // INLINE-NEXT: }
 
@@ -97,17 +97,17 @@ firrtl.circuit "Write" {
 // INLINE-NEXT:   firrtl.extmodule @WriteMemory_ext(%W0_addr: !firrtl.uint<1>, %W0_en: !firrtl.uint<1>, %W0_clk: !firrtl.clock, %W0_data: !firrtl.sint<8>, %W0_mask: !firrtl.uint<1>) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // INLINE-NEXT:   firrtl.module @Write() {
 // INLINE-NEXT:     %WriteMemory_W0_addr, %WriteMemory_W0_en, %WriteMemory_W0_clk, %WriteMemory_W0_data, %WriteMemory_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory"} : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.flip<sint<8>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %0 = firrtl.wire  : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
-// INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %WriteMemory_W0_addr, %1 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %WriteMemory_W0_en, %2 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %3 = firrtl.subfield %0("clk") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<clock>
-// INLINE-NEXT:     firrtl.connect %WriteMemory_W0_clk, %3 : !firrtl.flip<clock>, !firrtl.flip<clock>
-// INLINE-NEXT:     %4 = firrtl.subfield %0("data") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<sint<8>>
-// INLINE-NEXT:     firrtl.connect %WriteMemory_W0_data, %4 : !firrtl.flip<sint<8>>, !firrtl.flip<sint<8>>
-// INLINE-NEXT:     %5 = firrtl.subfield %0("mask") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %WriteMemory_W0_mask, %5 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
+// INLINE-NEXT:     %0 = firrtl.wire  : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
+// INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %WriteMemory_W0_addr, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %WriteMemory_W0_en, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %3 = firrtl.subfield %0("clk") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.clock
+// INLINE-NEXT:     firrtl.connect %WriteMemory_W0_clk, %3 : !firrtl.flip<clock>, !firrtl.clock
+// INLINE-NEXT:     %4 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.sint<8>
+// INLINE-NEXT:     firrtl.connect %WriteMemory_W0_data, %4 : !firrtl.flip<sint<8>>, !firrtl.sint<8>
+// INLINE-NEXT:     %5 = firrtl.subfield %0("mask") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %WriteMemory_W0_mask, %5 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // INLINE-NEXT:   }
 // INLINE-NEXT: }
 
@@ -119,7 +119,7 @@ firrtl.circuit "Write" {
 //        input inpred  : UInt<1>
 //        input indata  : SInt<42>
 //        output result : SInt<42>
-// 
+//
 //        mem _M : @[Decoupled.scala 209:27]
 //              data-type => SInt<42>
 //              depth => 12
@@ -128,9 +128,9 @@ firrtl.circuit "Write" {
 //              reader => read
 //              writer => write
 //              read-under-write => undefined
-// 
+//
 //        result <= _M.read.data
-// 
+//
 //        _M.read.addr <= UInt<1>("h0")
 //        _M.read.en <= UInt<1>("h1")
 //        _M.read.clk <= clock1
@@ -145,34 +145,34 @@ firrtl.circuit "MemSimple" {
     %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
     %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
     %c0_ui3 = firrtl.constant(0 : ui3) : !firrtl.uint<3>
-    %_M_read, %_M_write = firrtl.mem Undefined {depth = 12 : i64, name = "_M", portNames = ["read", "write"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>
-    %0 = firrtl.subfield %_M_read("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.sint<42>
+    %_M_read, %_M_write = firrtl.mem Undefined {depth = 12 : i64, name = "_M", portNames = ["read", "write"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>
+    %0 = firrtl.subfield %_M_read("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>) -> !firrtl.sint<42>
     firrtl.connect %result, %0 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
-    %1 = firrtl.subfield %_M_read("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<4>>
-    firrtl.connect %1, %c0_ui1 : !firrtl.flip<uint<4>>, !firrtl.uint<1>
-    %2 = firrtl.subfield %_M_read("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<1>>
-    firrtl.connect %2, %c1_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-    %3 = firrtl.subfield %_M_read("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<clock>
-    firrtl.connect %3, %clock1 : !firrtl.flip<clock>, !firrtl.clock
-    %4 = firrtl.subfield %_M_write("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<4>>
+    %1 = firrtl.subfield %_M_read("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>) -> !firrtl.uint<4>
+    firrtl.connect %1, %c0_ui1 : !firrtl.uint<4>, !firrtl.uint<1>
+    %2 = firrtl.subfield %_M_read("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>) -> !firrtl.uint<1>
+    firrtl.connect %2, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    %3 = firrtl.subfield %_M_read("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>) -> !firrtl.clock
+    firrtl.connect %3, %clock1 : !firrtl.clock, !firrtl.clock
+    %4 = firrtl.subfield %_M_write("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.uint<4>
     %5 = firrtl.invalidvalue : !firrtl.uint<3>
     %6 = firrtl.mux(%inpred, %c0_ui3, %5) : (!firrtl.uint<1>, !firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
-    firrtl.connect %4, %6 : !firrtl.flip<uint<4>>, !firrtl.uint<3>
-    %7 = firrtl.subfield %_M_write("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+    firrtl.connect %4, %6 : !firrtl.uint<4>, !firrtl.uint<3>
+    %7 = firrtl.subfield %_M_write("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.uint<1>
     %8 = firrtl.mux(%inpred, %c1_ui1, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.connect %7, %8 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-    %9 = firrtl.subfield %_M_write("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<clock>
+    firrtl.connect %7, %8 : !firrtl.uint<1>, !firrtl.uint<1>
+    %9 = firrtl.subfield %_M_write("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.clock
     %10 = firrtl.invalidvalue : !firrtl.clock
     %11 = firrtl.mux(%inpred, %clock2, %10) : (!firrtl.uint<1>, !firrtl.clock, !firrtl.clock) -> !firrtl.clock
-    firrtl.connect %9, %11 : !firrtl.flip<clock>, !firrtl.clock
-    %12 = firrtl.subfield %_M_write("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<sint<42>>
+    firrtl.connect %9, %11 : !firrtl.clock, !firrtl.clock
+    %12 = firrtl.subfield %_M_write("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.sint<42>
     %13 = firrtl.invalidvalue : !firrtl.sint<42>
     %14 = firrtl.mux(%inpred, %indata, %13) : (!firrtl.uint<1>, !firrtl.sint<42>, !firrtl.sint<42>) -> !firrtl.sint<42>
-    firrtl.connect %12, %14 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
-    %15 = firrtl.subfield %_M_write("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+    firrtl.connect %12, %14 : !firrtl.sint<42>, !firrtl.sint<42>
+    %15 = firrtl.subfield %_M_write("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.uint<1>
     %16 = firrtl.invalidvalue : !firrtl.uint<1>
     %17 = firrtl.mux(%inpred, %c1_ui1, %16) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.connect %15, %17 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+    firrtl.connect %15, %17 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
 
@@ -186,8 +186,8 @@ firrtl.circuit "MemSimple" {
 // WRAPPER-NEXT:     firrtl.connect %_M_R0_en, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // WRAPPER-NEXT:     %2 = firrtl.subfield %read("clk") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>) -> !firrtl.clock
 // WRAPPER-NEXT:     firrtl.connect %_M_R0_clk, %2 : !firrtl.flip<clock>, !firrtl.clock
-// WRAPPER-NEXT:     %3 = firrtl.subfield %read("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>) -> !firrtl.flip<sint<42>>
-// WRAPPER-NEXT:     firrtl.connect %3, %_M_R0_data : !firrtl.flip<sint<42>>, !firrtl.sint<42>
+// WRAPPER-NEXT:     %3 = firrtl.subfield %read("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>) -> !firrtl.sint<42>
+// WRAPPER-NEXT:     firrtl.connect %3, %_M_R0_data : !firrtl.sint<42>, !firrtl.sint<42>
 // WRAPPER-NEXT:     %4 = firrtl.subfield %write("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.uint<4>
 // WRAPPER-NEXT:     firrtl.connect %_M_W0_addr, %4 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
 // WRAPPER-NEXT:     %5 = firrtl.subfield %write("en") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.uint<1>
@@ -203,34 +203,34 @@ firrtl.circuit "MemSimple" {
 // WRAPPER-NEXT:     %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
 // WRAPPER-NEXT:     %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
 // WRAPPER-NEXT:     %c0_ui3 = firrtl.constant(0 : ui3) : !firrtl.uint<3>
-// WRAPPER-NEXT:     %_M_read, %_M_write = firrtl.instance @_M {name = "_M"} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>
-// WRAPPER-NEXT:     %0 = firrtl.subfield %_M_read("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.sint<42>
+// WRAPPER-NEXT:     %_M_read, %_M_write = firrtl.instance @_M {name = "_M"} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>
+// WRAPPER-NEXT:     %0 = firrtl.subfield %_M_read("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>) -> !firrtl.sint<42>
 // WRAPPER-NEXT:     firrtl.connect %result, %0 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
-// WRAPPER-NEXT:     %1 = firrtl.subfield %_M_read("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<4>>
-// WRAPPER-NEXT:     firrtl.connect %1, %c0_ui1 : !firrtl.flip<uint<4>>, !firrtl.uint<1>
-// WRAPPER-NEXT:     %2 = firrtl.subfield %_M_read("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<1>>
-// WRAPPER-NEXT:     firrtl.connect %2, %c1_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// WRAPPER-NEXT:     %3 = firrtl.subfield %_M_read("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<clock>
-// WRAPPER-NEXT:     firrtl.connect %3, %clock1 : !firrtl.flip<clock>, !firrtl.clock
-// WRAPPER-NEXT:     %4 = firrtl.subfield %_M_write("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<4>>
+// WRAPPER-NEXT:     %1 = firrtl.subfield %_M_read("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>) -> !firrtl.uint<4>
+// WRAPPER-NEXT:     firrtl.connect %1, %c0_ui1 : !firrtl.uint<4>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %2 = firrtl.subfield %_M_read("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>) -> !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %2, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %3 = firrtl.subfield %_M_read("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>) -> !firrtl.clock
+// WRAPPER-NEXT:     firrtl.connect %3, %clock1 : !firrtl.clock, !firrtl.clock
+// WRAPPER-NEXT:     %4 = firrtl.subfield %_M_write("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.uint<4>
 // WRAPPER-NEXT:     %5 = firrtl.invalidvalue : !firrtl.uint<3>
 // WRAPPER-NEXT:     %6 = firrtl.mux(%inpred, %c0_ui3, %5) : (!firrtl.uint<1>, !firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
-// WRAPPER-NEXT:     firrtl.connect %4, %6 : !firrtl.flip<uint<4>>, !firrtl.uint<3>
-// WRAPPER-NEXT:     %7 = firrtl.subfield %_M_write("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// WRAPPER-NEXT:     firrtl.connect %4, %6 : !firrtl.uint<4>, !firrtl.uint<3>
+// WRAPPER-NEXT:     %7 = firrtl.subfield %_M_write("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.uint<1>
 // WRAPPER-NEXT:     %8 = firrtl.mux(%inpred, %c1_ui1, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// WRAPPER-NEXT:     firrtl.connect %7, %8 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// WRAPPER-NEXT:     %9 = firrtl.subfield %_M_write("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<clock>
+// WRAPPER-NEXT:     firrtl.connect %7, %8 : !firrtl.uint<1>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %9 = firrtl.subfield %_M_write("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.clock
 // WRAPPER-NEXT:     %10 = firrtl.invalidvalue : !firrtl.clock
 // WRAPPER-NEXT:     %11 = firrtl.mux(%inpred, %clock2, %10) : (!firrtl.uint<1>, !firrtl.clock, !firrtl.clock) -> !firrtl.clock
-// WRAPPER-NEXT:     firrtl.connect %9, %11 : !firrtl.flip<clock>, !firrtl.clock
-// WRAPPER-NEXT:     %12 = firrtl.subfield %_M_write("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<sint<42>>
+// WRAPPER-NEXT:     firrtl.connect %9, %11 : !firrtl.clock, !firrtl.clock
+// WRAPPER-NEXT:     %12 = firrtl.subfield %_M_write("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.sint<42>
 // WRAPPER-NEXT:     %13 = firrtl.invalidvalue : !firrtl.sint<42>
 // WRAPPER-NEXT:     %14 = firrtl.mux(%inpred, %indata, %13) : (!firrtl.uint<1>, !firrtl.sint<42>, !firrtl.sint<42>) -> !firrtl.sint<42>
-// WRAPPER-NEXT:     firrtl.connect %12, %14 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
-// WRAPPER-NEXT:     %15 = firrtl.subfield %_M_write("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// WRAPPER-NEXT:     firrtl.connect %12, %14 : !firrtl.sint<42>, !firrtl.sint<42>
+// WRAPPER-NEXT:     %15 = firrtl.subfield %_M_write("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.uint<1>
 // WRAPPER-NEXT:     %16 = firrtl.invalidvalue : !firrtl.uint<1>
 // WRAPPER-NEXT:     %17 = firrtl.mux(%inpred, %c1_ui1, %16) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// WRAPPER-NEXT:     firrtl.connect %15, %17 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// WRAPPER-NEXT:     firrtl.connect %15, %17 : !firrtl.uint<1>, !firrtl.uint<1>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT: }
 
@@ -241,60 +241,60 @@ firrtl.circuit "MemSimple" {
 // INLINE-NEXT:     %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
 // INLINE-NEXT:     %c0_ui3 = firrtl.constant(0 : ui3) : !firrtl.uint<3>
 // INLINE-NEXT:     %_M_R0_addr, %_M_R0_en, %_M_R0_clk, %_M_R0_data, %_M_W0_addr, %_M_W0_en, %_M_W0_clk, %_M_W0_data, %_M_W0_mask = firrtl.instance @_M_ext {name = "_M"} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<42>, !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.flip<sint<42>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %0 = firrtl.wire  : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>
-// INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<4>>
-// INLINE-NEXT:     firrtl.connect %_M_R0_addr, %1 : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
-// INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %_M_R0_en, %2 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %3 = firrtl.subfield %0("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<clock>
-// INLINE-NEXT:     firrtl.connect %_M_R0_clk, %3 : !firrtl.flip<clock>, !firrtl.flip<clock>
-// INLINE-NEXT:     %4 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.sint<42>
+// INLINE-NEXT:     %0 = firrtl.wire  : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>
+// INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>) -> !firrtl.uint<4>
+// INLINE-NEXT:     firrtl.connect %_M_R0_addr, %1 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+// INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>) -> !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %_M_R0_en, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %3 = firrtl.subfield %0("clk") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>) -> !firrtl.clock
+// INLINE-NEXT:     firrtl.connect %_M_R0_clk, %3 : !firrtl.flip<clock>, !firrtl.clock
+// INLINE-NEXT:     %4 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>) -> !firrtl.sint<42>
 // INLINE-NEXT:     firrtl.connect %4, %_M_R0_data : !firrtl.sint<42>, !firrtl.sint<42>
-// INLINE-NEXT:     %5 = firrtl.wire  : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>
-// INLINE-NEXT:     %6 = firrtl.subfield %5("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<4>>
-// INLINE-NEXT:     firrtl.connect %_M_W0_addr, %6 : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
-// INLINE-NEXT:     %7 = firrtl.subfield %5("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %_M_W0_en, %7 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %8 = firrtl.subfield %5("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<clock>
-// INLINE-NEXT:     firrtl.connect %_M_W0_clk, %8 : !firrtl.flip<clock>, !firrtl.flip<clock>
-// INLINE-NEXT:     %9 = firrtl.subfield %5("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<sint<42>>
-// INLINE-NEXT:     firrtl.connect %_M_W0_data, %9 : !firrtl.flip<sint<42>>, !firrtl.flip<sint<42>>
-// INLINE-NEXT:     %10 = firrtl.subfield %5("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %_M_W0_mask, %10 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %11 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.sint<42>
+// INLINE-NEXT:     %5 = firrtl.wire  : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>
+// INLINE-NEXT:     %6 = firrtl.subfield %5("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.uint<4>
+// INLINE-NEXT:     firrtl.connect %_M_W0_addr, %6 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+// INLINE-NEXT:     %7 = firrtl.subfield %5("en") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %_M_W0_en, %7 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %8 = firrtl.subfield %5("clk") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.clock
+// INLINE-NEXT:     firrtl.connect %_M_W0_clk, %8 : !firrtl.flip<clock>, !firrtl.clock
+// INLINE-NEXT:     %9 = firrtl.subfield %5("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.sint<42>
+// INLINE-NEXT:     firrtl.connect %_M_W0_data, %9 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
+// INLINE-NEXT:     %10 = firrtl.subfield %5("mask") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %_M_W0_mask, %10 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %11 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>) -> !firrtl.sint<42>
 // INLINE-NEXT:     firrtl.connect %result, %11 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
-// INLINE-NEXT:     %12 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<4>>
-// INLINE-NEXT:     firrtl.connect %12, %c0_ui1 : !firrtl.flip<uint<4>>, !firrtl.uint<1>
-// INLINE-NEXT:     %13 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %13, %c1_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// INLINE-NEXT:     %14 = firrtl.subfield %0("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<42>>) -> !firrtl.flip<clock>
-// INLINE-NEXT:     firrtl.connect %14, %clock1 : !firrtl.flip<clock>, !firrtl.clock
-// INLINE-NEXT:     %15 = firrtl.subfield %5("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<4>>
+// INLINE-NEXT:     %12 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>) -> !firrtl.uint<4>
+// INLINE-NEXT:     firrtl.connect %12, %c0_ui1 : !firrtl.uint<4>, !firrtl.uint<1>
+// INLINE-NEXT:     %13 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>) -> !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %13, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+// INLINE-NEXT:     %14 = firrtl.subfield %0("clk") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>) -> !firrtl.clock
+// INLINE-NEXT:     firrtl.connect %14, %clock1 : !firrtl.clock, !firrtl.clock
+// INLINE-NEXT:     %15 = firrtl.subfield %5("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.uint<4>
 // INLINE-NEXT:     %16 = firrtl.invalidvalue : !firrtl.uint<3>
 // INLINE-NEXT:     %17 = firrtl.mux(%inpred, %c0_ui3, %16) : (!firrtl.uint<1>, !firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
-// INLINE-NEXT:     firrtl.connect %15, %17 : !firrtl.flip<uint<4>>, !firrtl.uint<3>
-// INLINE-NEXT:     %18 = firrtl.subfield %5("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %15, %17 : !firrtl.uint<4>, !firrtl.uint<3>
+// INLINE-NEXT:     %18 = firrtl.subfield %5("en") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.uint<1>
 // INLINE-NEXT:     %19 = firrtl.mux(%inpred, %c1_ui1, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// INLINE-NEXT:     firrtl.connect %18, %19 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-// INLINE-NEXT:     %20 = firrtl.subfield %5("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<clock>
+// INLINE-NEXT:     firrtl.connect %18, %19 : !firrtl.uint<1>, !firrtl.uint<1>
+// INLINE-NEXT:     %20 = firrtl.subfield %5("clk") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.clock
 // INLINE-NEXT:     %21 = firrtl.invalidvalue : !firrtl.clock
 // INLINE-NEXT:     %22 = firrtl.mux(%inpred, %clock2, %21) : (!firrtl.uint<1>, !firrtl.clock, !firrtl.clock) -> !firrtl.clock
-// INLINE-NEXT:     firrtl.connect %20, %22 : !firrtl.flip<clock>, !firrtl.clock
-// INLINE-NEXT:     %23 = firrtl.subfield %5("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<sint<42>>
+// INLINE-NEXT:     firrtl.connect %20, %22 : !firrtl.clock, !firrtl.clock
+// INLINE-NEXT:     %23 = firrtl.subfield %5("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.sint<42>
 // INLINE-NEXT:     %24 = firrtl.invalidvalue : !firrtl.sint<42>
 // INLINE-NEXT:     %25 = firrtl.mux(%inpred, %indata, %24) : (!firrtl.uint<1>, !firrtl.sint<42>, !firrtl.sint<42>) -> !firrtl.sint<42>
-// INLINE-NEXT:     firrtl.connect %23, %25 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
-// INLINE-NEXT:     %26 = firrtl.subfield %5("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
+// INLINE-NEXT:     firrtl.connect %23, %25 : !firrtl.sint<42>, !firrtl.sint<42>
+// INLINE-NEXT:     %26 = firrtl.subfield %5("mask") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.uint<1>
 // INLINE-NEXT:     %27 = firrtl.invalidvalue : !firrtl.uint<1>
 // INLINE-NEXT:     %28 = firrtl.mux(%inpred, %c1_ui1, %27) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// INLINE-NEXT:     firrtl.connect %26, %28 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %26, %28 : !firrtl.uint<1>, !firrtl.uint<1>
 // INLINE-NEXT:   }
 // INLINE-NEXT: }
 
 firrtl.circuit "NameCollision" {
   // Check for name NameCollision with a generated module
   firrtl.module @NameCollisionMemory_ext() {
-    %0 = firrtl.mem Undefined {depth = 16 : i64, name = "NameCollisionMemory", portNames = ["read0"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+    %0 = firrtl.mem Undefined {depth = 16 : i64, name = "NameCollisionMemory", portNames = ["read0"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>>
   }
   firrtl.module @NameCollision() {
     %0 = firrtl.mem Undefined {depth = 16 : i64, name = "NameCollisionMemory", portNames = ["write0"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
@@ -325,11 +325,11 @@ firrtl.circuit "NameCollision" {
 // WRAPPER-NEXT:     firrtl.connect %NameCollisionMemory_R0_en, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // WRAPPER-NEXT:     %2 = firrtl.subfield %read0("clk") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.clock
 // WRAPPER-NEXT:     firrtl.connect %NameCollisionMemory_R0_clk, %2 : !firrtl.flip<clock>, !firrtl.clock
-// WRAPPER-NEXT:     %3 = firrtl.subfield %read0("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.flip<sint<8>>
-// WRAPPER-NEXT:     firrtl.connect %3, %NameCollisionMemory_R0_data : !firrtl.flip<sint<8>>, !firrtl.sint<8>
+// WRAPPER-NEXT:     %3 = firrtl.subfield %read0("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.sint<8>
+// WRAPPER-NEXT:     firrtl.connect %3, %NameCollisionMemory_R0_data : !firrtl.sint<8>, !firrtl.sint<8>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT:   firrtl.module @NameCollisionMemory_ext() {
-// WRAPPER-NEXT:     %NameCollisionMemory_read0 = firrtl.instance @NameCollisionMemory {name = "NameCollisionMemory"} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+// WRAPPER-NEXT:     %NameCollisionMemory_read0 = firrtl.instance @NameCollisionMemory {name = "NameCollisionMemory"} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT:   firrtl.module @NameCollision() {
 // WRAPPER-NEXT:     %NameCollisionMemory_write0 = firrtl.instance @NameCollisionMemory_0 {name = "NameCollisionMemory"} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
@@ -341,39 +341,39 @@ firrtl.circuit "NameCollision" {
 // INLINE-NEXT:   firrtl.extmodule @NameCollisionMemory_ext_0(%R0_addr: !firrtl.uint<4>, %R0_en: !firrtl.uint<1>, %R0_clk: !firrtl.clock, %R0_data: !firrtl.flip<sint<8>>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // INLINE-NEXT:   firrtl.module @NameCollisionMemory_ext() {
 // INLINE-NEXT:     %NameCollisionMemory_R0_addr, %NameCollisionMemory_R0_en, %NameCollisionMemory_R0_clk, %NameCollisionMemory_R0_data = firrtl.instance @NameCollisionMemory_ext_0 {name = "NameCollisionMemory"} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
-// INLINE-NEXT:     %0 = firrtl.wire  : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
-// INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
-// INLINE-NEXT:     firrtl.connect %NameCollisionMemory_R0_addr, %1 : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
-// INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %NameCollisionMemory_R0_en, %2 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %3 = firrtl.subfield %0("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<clock>
-// INLINE-NEXT:     firrtl.connect %NameCollisionMemory_R0_clk, %3 : !firrtl.flip<clock>, !firrtl.flip<clock>
-// INLINE-NEXT:     %4 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.sint<8>
+// INLINE-NEXT:     %0 = firrtl.wire  : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>
+// INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.uint<4>
+// INLINE-NEXT:     firrtl.connect %NameCollisionMemory_R0_addr, %1 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+// INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %NameCollisionMemory_R0_en, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %3 = firrtl.subfield %0("clk") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.clock
+// INLINE-NEXT:     firrtl.connect %NameCollisionMemory_R0_clk, %3 : !firrtl.flip<clock>, !firrtl.clock
+// INLINE-NEXT:     %4 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.sint<8>
 // INLINE-NEXT:     firrtl.connect %4, %NameCollisionMemory_R0_data : !firrtl.sint<8>, !firrtl.sint<8>
 // INLINE-NEXT:   }
 // INLINE-NEXT:   firrtl.module @NameCollision() {
 // INLINE-NEXT:     %NameCollisionMemory_W0_addr, %NameCollisionMemory_W0_en, %NameCollisionMemory_W0_clk, %NameCollisionMemory_W0_data, %NameCollisionMemory_W0_mask = firrtl.instance @NameCollisionMemory_ext_1 {name = "NameCollisionMemory"} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.flip<sint<8>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %0 = firrtl.wire  : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
-// INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<4>>
-// INLINE-NEXT:     firrtl.connect %NameCollisionMemory_W0_addr, %1 : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
-// INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %NameCollisionMemory_W0_en, %2 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %3 = firrtl.subfield %0("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<clock>
-// INLINE-NEXT:     firrtl.connect %NameCollisionMemory_W0_clk, %3 : !firrtl.flip<clock>, !firrtl.flip<clock>
-// INLINE-NEXT:     %4 = firrtl.subfield %0("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<sint<8>>
-// INLINE-NEXT:     firrtl.connect %NameCollisionMemory_W0_data, %4 : !firrtl.flip<sint<8>>, !firrtl.flip<sint<8>>
-// INLINE-NEXT:     %5 = firrtl.subfield %0("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %NameCollisionMemory_W0_mask, %5 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
+// INLINE-NEXT:     %0 = firrtl.wire  : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
+// INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<4>
+// INLINE-NEXT:     firrtl.connect %NameCollisionMemory_W0_addr, %1 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+// INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %NameCollisionMemory_W0_en, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %3 = firrtl.subfield %0("clk") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.clock
+// INLINE-NEXT:     firrtl.connect %NameCollisionMemory_W0_clk, %3 : !firrtl.flip<clock>, !firrtl.clock
+// INLINE-NEXT:     %4 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.sint<8>
+// INLINE-NEXT:     firrtl.connect %NameCollisionMemory_W0_data, %4 : !firrtl.flip<sint<8>>, !firrtl.sint<8>
+// INLINE-NEXT:     %5 = firrtl.subfield %0("mask") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %NameCollisionMemory_W0_mask, %5 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // INLINE-NEXT:   }
 // INLINE-NEXT: }
 
 firrtl.circuit "Duplicate" {
   firrtl.module @Duplicate() {
-    %r0 = firrtl.mem Undefined {depth = 16 : i64, name = "ReadMemory", portNames = ["read0"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+    %r0 = firrtl.mem Undefined {depth = 16 : i64, name = "ReadMemory", portNames = ["read0"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>>
     %w0 = firrtl.mem Undefined {depth = 1 : i64, name = "WriteMemory", portNames = ["write0"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
-    %r1 = firrtl.mem Undefined {depth = 16 : i64, name = "ReadMemory1", portNames = ["read1"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+    %r1 = firrtl.mem Undefined {depth = 16 : i64, name = "ReadMemory1", portNames = ["read1"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>>
     %w1 = firrtl.mem Undefined {depth = 1 : i64, name = "WriteMemory1", portNames = ["write1"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
-    %r2 = firrtl.mem Undefined {depth = 16 : i64, name = "ReadMemory2", portNames = ["read2"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+    %r2 = firrtl.mem Undefined {depth = 16 : i64, name = "ReadMemory2", portNames = ["read2"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>>
     %w2 = firrtl.mem Undefined {depth = 1 : i64, name = "WriteMemory2", portNames = ["write2"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
   }
 }
@@ -402,15 +402,15 @@ firrtl.circuit "Duplicate" {
 // WRAPPER-NEXT:     firrtl.connect %ReadMemory_R0_en, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // WRAPPER-NEXT:     %2 = firrtl.subfield %read0("clk") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.clock
 // WRAPPER-NEXT:     firrtl.connect %ReadMemory_R0_clk, %2 : !firrtl.flip<clock>, !firrtl.clock
-// WRAPPER-NEXT:     %3 = firrtl.subfield %read0("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.flip<sint<8>>
-// WRAPPER-NEXT:     firrtl.connect %3, %ReadMemory_R0_data : !firrtl.flip<sint<8>>, !firrtl.sint<8>
+// WRAPPER-NEXT:     %3 = firrtl.subfield %read0("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.sint<8>
+// WRAPPER-NEXT:     firrtl.connect %3, %ReadMemory_R0_data : !firrtl.sint<8>, !firrtl.sint<8>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT:   firrtl.module @Duplicate() {
-// WRAPPER-NEXT:     %ReadMemory_read0 = firrtl.instance @ReadMemory {name = "ReadMemory"} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+// WRAPPER-NEXT:     %ReadMemory_read0 = firrtl.instance @ReadMemory {name = "ReadMemory"} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>>
 // WRAPPER-NEXT:     %WriteMemory_write0 = firrtl.instance @WriteMemory {name = "WriteMemory"} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
-// WRAPPER-NEXT:     %ReadMemory1_read0 = firrtl.instance @ReadMemory {name = "ReadMemory1"} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+// WRAPPER-NEXT:     %ReadMemory1_read0 = firrtl.instance @ReadMemory {name = "ReadMemory1"} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>>
 // WRAPPER-NEXT:     %WriteMemory1_write0 = firrtl.instance @WriteMemory {name = "WriteMemory1"} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
-// WRAPPER-NEXT:     %ReadMemory2_read0 = firrtl.instance @ReadMemory {name = "ReadMemory2"} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+// WRAPPER-NEXT:     %ReadMemory2_read0 = firrtl.instance @ReadMemory {name = "ReadMemory2"} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>>
 // WRAPPER-NEXT:     %WriteMemory2_write0 = firrtl.instance @WriteMemory {name = "WriteMemory2"} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT: }
@@ -420,70 +420,70 @@ firrtl.circuit "Duplicate" {
 // INLINE-NEXT:   firrtl.extmodule @ReadMemory_ext(%R0_addr: !firrtl.uint<4>, %R0_en: !firrtl.uint<1>, %R0_clk: !firrtl.clock, %R0_data: !firrtl.flip<sint<8>>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // INLINE-NEXT:   firrtl.module @Duplicate() {
 // INLINE-NEXT:     %ReadMemory_R0_addr, %ReadMemory_R0_en, %ReadMemory_R0_clk, %ReadMemory_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory"} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
-// INLINE-NEXT:     %0 = firrtl.wire  : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
-// INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
-// INLINE-NEXT:     firrtl.connect %ReadMemory_R0_addr, %1 : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
-// INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %ReadMemory_R0_en, %2 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %3 = firrtl.subfield %0("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<clock>
-// INLINE-NEXT:     firrtl.connect %ReadMemory_R0_clk, %3 : !firrtl.flip<clock>, !firrtl.flip<clock>
-// INLINE-NEXT:     %4 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.sint<8>
+// INLINE-NEXT:     %0 = firrtl.wire  : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>
+// INLINE-NEXT:     %1 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.uint<4>
+// INLINE-NEXT:     firrtl.connect %ReadMemory_R0_addr, %1 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+// INLINE-NEXT:     %2 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %ReadMemory_R0_en, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %3 = firrtl.subfield %0("clk") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.clock
+// INLINE-NEXT:     firrtl.connect %ReadMemory_R0_clk, %3 : !firrtl.flip<clock>, !firrtl.clock
+// INLINE-NEXT:     %4 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.sint<8>
 // INLINE-NEXT:     firrtl.connect %4, %ReadMemory_R0_data : !firrtl.sint<8>, !firrtl.sint<8>
 // INLINE-NEXT:     %WriteMemory_W0_addr, %WriteMemory_W0_en, %WriteMemory_W0_clk, %WriteMemory_W0_data, %WriteMemory_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory"} : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.flip<sint<8>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %5 = firrtl.wire  : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
-// INLINE-NEXT:     %6 = firrtl.subfield %5("addr") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %WriteMemory_W0_addr, %6 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %7 = firrtl.subfield %5("en") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %WriteMemory_W0_en, %7 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %8 = firrtl.subfield %5("clk") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<clock>
-// INLINE-NEXT:     firrtl.connect %WriteMemory_W0_clk, %8 : !firrtl.flip<clock>, !firrtl.flip<clock>
-// INLINE-NEXT:     %9 = firrtl.subfield %5("data") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<sint<8>>
-// INLINE-NEXT:     firrtl.connect %WriteMemory_W0_data, %9 : !firrtl.flip<sint<8>>, !firrtl.flip<sint<8>>
-// INLINE-NEXT:     %10 = firrtl.subfield %5("mask") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %WriteMemory_W0_mask, %10 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
+// INLINE-NEXT:     %5 = firrtl.wire  : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
+// INLINE-NEXT:     %6 = firrtl.subfield %5("addr") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %WriteMemory_W0_addr, %6 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %7 = firrtl.subfield %5("en") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %WriteMemory_W0_en, %7 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %8 = firrtl.subfield %5("clk") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.clock
+// INLINE-NEXT:     firrtl.connect %WriteMemory_W0_clk, %8 : !firrtl.flip<clock>, !firrtl.clock
+// INLINE-NEXT:     %9 = firrtl.subfield %5("data") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.sint<8>
+// INLINE-NEXT:     firrtl.connect %WriteMemory_W0_data, %9 : !firrtl.flip<sint<8>>, !firrtl.sint<8>
+// INLINE-NEXT:     %10 = firrtl.subfield %5("mask") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %WriteMemory_W0_mask, %10 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // INLINE-NEXT:     %ReadMemory1_R0_addr, %ReadMemory1_R0_en, %ReadMemory1_R0_clk, %ReadMemory1_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory1"} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
-// INLINE-NEXT:     %11 = firrtl.wire  : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
-// INLINE-NEXT:     %12 = firrtl.subfield %11("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
-// INLINE-NEXT:     firrtl.connect %ReadMemory1_R0_addr, %12 : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
-// INLINE-NEXT:     %13 = firrtl.subfield %11("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %ReadMemory1_R0_en, %13 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %14 = firrtl.subfield %11("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<clock>
-// INLINE-NEXT:     firrtl.connect %ReadMemory1_R0_clk, %14 : !firrtl.flip<clock>, !firrtl.flip<clock>
-// INLINE-NEXT:     %15 = firrtl.subfield %11("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.sint<8>
+// INLINE-NEXT:     %11 = firrtl.wire  : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>
+// INLINE-NEXT:     %12 = firrtl.subfield %11("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.uint<4>
+// INLINE-NEXT:     firrtl.connect %ReadMemory1_R0_addr, %12 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+// INLINE-NEXT:     %13 = firrtl.subfield %11("en") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %ReadMemory1_R0_en, %13 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %14 = firrtl.subfield %11("clk") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.clock
+// INLINE-NEXT:     firrtl.connect %ReadMemory1_R0_clk, %14 : !firrtl.flip<clock>, !firrtl.clock
+// INLINE-NEXT:     %15 = firrtl.subfield %11("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.sint<8>
 // INLINE-NEXT:     firrtl.connect %15, %ReadMemory1_R0_data : !firrtl.sint<8>, !firrtl.sint<8>
 // INLINE-NEXT:     %WriteMemory1_W0_addr, %WriteMemory1_W0_en, %WriteMemory1_W0_clk, %WriteMemory1_W0_data, %WriteMemory1_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory1"} : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.flip<sint<8>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %16 = firrtl.wire  : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
-// INLINE-NEXT:     %17 = firrtl.subfield %16("addr") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %WriteMemory1_W0_addr, %17 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %18 = firrtl.subfield %16("en") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %WriteMemory1_W0_en, %18 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %19 = firrtl.subfield %16("clk") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<clock>
-// INLINE-NEXT:     firrtl.connect %WriteMemory1_W0_clk, %19 : !firrtl.flip<clock>, !firrtl.flip<clock>
-// INLINE-NEXT:     %20 = firrtl.subfield %16("data") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<sint<8>>
-// INLINE-NEXT:     firrtl.connect %WriteMemory1_W0_data, %20 : !firrtl.flip<sint<8>>, !firrtl.flip<sint<8>>
-// INLINE-NEXT:     %21 = firrtl.subfield %16("mask") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %WriteMemory1_W0_mask, %21 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
+// INLINE-NEXT:     %16 = firrtl.wire  : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
+// INLINE-NEXT:     %17 = firrtl.subfield %16("addr") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %WriteMemory1_W0_addr, %17 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %18 = firrtl.subfield %16("en") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %WriteMemory1_W0_en, %18 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %19 = firrtl.subfield %16("clk") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.clock
+// INLINE-NEXT:     firrtl.connect %WriteMemory1_W0_clk, %19 : !firrtl.flip<clock>, !firrtl.clock
+// INLINE-NEXT:     %20 = firrtl.subfield %16("data") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.sint<8>
+// INLINE-NEXT:     firrtl.connect %WriteMemory1_W0_data, %20 : !firrtl.flip<sint<8>>, !firrtl.sint<8>
+// INLINE-NEXT:     %21 = firrtl.subfield %16("mask") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %WriteMemory1_W0_mask, %21 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // INLINE-NEXT:     %ReadMemory2_R0_addr, %ReadMemory2_R0_en, %ReadMemory2_R0_clk, %ReadMemory2_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory2"} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
-// INLINE-NEXT:     %22 = firrtl.wire  : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
-// INLINE-NEXT:     %23 = firrtl.subfield %22("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<4>>
-// INLINE-NEXT:     firrtl.connect %ReadMemory2_R0_addr, %23 : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>
-// INLINE-NEXT:     %24 = firrtl.subfield %22("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %ReadMemory2_R0_en, %24 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %25 = firrtl.subfield %22("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.flip<clock>
-// INLINE-NEXT:     firrtl.connect %ReadMemory2_R0_clk, %25 : !firrtl.flip<clock>, !firrtl.flip<clock>
-// INLINE-NEXT:     %26 = firrtl.subfield %22("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>) -> !firrtl.sint<8>
+// INLINE-NEXT:     %22 = firrtl.wire  : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>
+// INLINE-NEXT:     %23 = firrtl.subfield %22("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.uint<4>
+// INLINE-NEXT:     firrtl.connect %ReadMemory2_R0_addr, %23 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+// INLINE-NEXT:     %24 = firrtl.subfield %22("en") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %ReadMemory2_R0_en, %24 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %25 = firrtl.subfield %22("clk") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.clock
+// INLINE-NEXT:     firrtl.connect %ReadMemory2_R0_clk, %25 : !firrtl.flip<clock>, !firrtl.clock
+// INLINE-NEXT:     %26 = firrtl.subfield %22("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.sint<8>
 // INLINE-NEXT:     firrtl.connect %26, %ReadMemory2_R0_data : !firrtl.sint<8>, !firrtl.sint<8>
 // INLINE-NEXT:     %WriteMemory2_W0_addr, %WriteMemory2_W0_en, %WriteMemory2_W0_clk, %WriteMemory2_W0_data, %WriteMemory2_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory2"} : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.flip<sint<8>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %27 = firrtl.wire  : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>
-// INLINE-NEXT:     %28 = firrtl.subfield %27("addr") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %WriteMemory2_W0_addr, %28 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %29 = firrtl.subfield %27("en") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %WriteMemory2_W0_en, %29 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
-// INLINE-NEXT:     %30 = firrtl.subfield %27("clk") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<clock>
-// INLINE-NEXT:     firrtl.connect %WriteMemory2_W0_clk, %30 : !firrtl.flip<clock>, !firrtl.flip<clock>
-// INLINE-NEXT:     %31 = firrtl.subfield %27("data") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<sint<8>>
-// INLINE-NEXT:     firrtl.connect %WriteMemory2_W0_data, %31 : !firrtl.flip<sint<8>>, !firrtl.flip<sint<8>>
-// INLINE-NEXT:     %32 = firrtl.subfield %27("mask") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>>) -> !firrtl.flip<uint<1>>
-// INLINE-NEXT:     firrtl.connect %WriteMemory2_W0_mask, %32 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
+// INLINE-NEXT:     %27 = firrtl.wire  : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
+// INLINE-NEXT:     %28 = firrtl.subfield %27("addr") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %WriteMemory2_W0_addr, %28 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %29 = firrtl.subfield %27("en") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %WriteMemory2_W0_en, %29 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// INLINE-NEXT:     %30 = firrtl.subfield %27("clk") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.clock
+// INLINE-NEXT:     firrtl.connect %WriteMemory2_W0_clk, %30 : !firrtl.flip<clock>, !firrtl.clock
+// INLINE-NEXT:     %31 = firrtl.subfield %27("data") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.sint<8>
+// INLINE-NEXT:     firrtl.connect %WriteMemory2_W0_data, %31 : !firrtl.flip<sint<8>>, !firrtl.sint<8>
+// INLINE-NEXT:     %32 = firrtl.subfield %27("mask") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+// INLINE-NEXT:     firrtl.connect %WriteMemory2_W0_mask, %32 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // INLINE-NEXT:   }
 // INLINE-NEXT: }

--- a/test/Dialect/FIRRTL/connect.mlir
+++ b/test/Dialect/FIRRTL/connect.mlir
@@ -71,14 +71,14 @@ firrtl.module @vect0(%a : !firrtl.vector<uint<1>, 3>, %b : !firrtl.flip<vector<u
 /// Bundle types can be connected if they have the same size, element names, and
 /// element types.
 
-firrtl.module @bundle0(%a : !firrtl.bundle<f1: uint<1>, f2: flip<sint<1>>>, %b : !firrtl.bundle<f1: flip<uint<1>>, f2: sint<1>>) {
+firrtl.module @bundle0(%a : !firrtl.bundle<f1: uint<1>, f2: flip<sint<1>>>, %b : !firrtl.flip<bundle<f1: uint<1>, f2: flip<sint<1>>>>) {
   // CHECK: firrtl.connect %b, %a
-  firrtl.connect %b, %a : !firrtl.bundle<f1: flip<uint<1>>, f2: sint<1>>, !firrtl.bundle<f1: uint<1>, f2: flip<sint<1>>>
+  firrtl.connect %b, %a : !firrtl.flip<bundle<f1: uint<1>, f2: flip<sint<1>>>>, !firrtl.bundle<f1: uint<1>, f2: flip<sint<1>>>
 }
 
-firrtl.module @bundle1(%a : !firrtl.bundle<f1: uint<1>, f2: flip<sint<2>>>, %b : !firrtl.bundle<f1: flip<uint<2>>, f2: sint<1>>) {
+firrtl.module @bundle1(%a : !firrtl.bundle<f1: uint<1>, f2: flip<sint<2>>>, %b : !firrtl.flip<bundle<f1: uint<2>, f2: flip<sint<1>>>>) {
   // CHECK: firrtl.connect %b, %a
-  firrtl.connect %b, %a : !firrtl.bundle<f1: flip<uint<2>>, f2: sint<1>>, !firrtl.bundle<f1: uint<1>, f2: flip<sint<2>>>
+  firrtl.connect %b, %a : !firrtl.flip<bundle<f1: uint<2>, f2: flip<sint<1>>>>, !firrtl.bundle<f1: uint<1>, f2: flip<sint<2>>>
 }
 
 /// Destination bitwidth must be greater than or equal to source bitwidth.
@@ -102,11 +102,11 @@ firrtl.module @wires0(%in : !firrtl.uint<1>, %out : !firrtl.flip<uint<1>>) {
 }
 
 firrtl.module @wires1(%in : !firrtl.uint<1>, %out : !firrtl.flip<uint<1>>) {
-  %wf = firrtl.wire : !firrtl.flip<uint<1>>
-  // CHECK: firrtl.connect %wf, %in : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  // CHECK: firrtl.connect %out, %wf : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
-  firrtl.connect %wf, %in : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %out, %wf : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
+  %wf = firrtl.wire : !firrtl.uint<1>
+  // CHECK: firrtl.connect %wf, %in : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK: firrtl.connect %out, %wf : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %wf, %in : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %out, %wf : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 }
 
 firrtl.module @wires2() {
@@ -116,21 +116,14 @@ firrtl.module @wires2() {
   firrtl.connect %w0, %w1 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
-firrtl.module @wires3() {
-  // CHECK: firrtl.connect %wf0, %wf1
-  %wf0 = firrtl.wire : !firrtl.flip<uint<1>>
-  %wf1 = firrtl.wire : !firrtl.flip<uint<1>>
-  firrtl.connect %wf0, %wf1 : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
-}
-
-firrtl.module @wires4(%out : !firrtl.flip<uint<1>>) {
-  %wf = firrtl.wire : !firrtl.flip<uint<1>>
+firrtl.module @wires3(%out : !firrtl.flip<uint<1>>) {
+  %wf = firrtl.wire : !firrtl.uint<1>
   // check that we can read from an output port
   // CHECK: firrtl.connect %wf, %out
-  firrtl.connect %wf, %out : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
+  firrtl.connect %wf, %out : !firrtl.uint<1>, !firrtl.flip<uint<1>>
 }
 
-firrtl.module @wires5(%in : !firrtl.uint<1>, %out : !firrtl.flip<uint<1>>) {
+firrtl.module @wires4(%in : !firrtl.uint<1>, %out : !firrtl.flip<uint<1>>) {
   %w = firrtl.wire : !firrtl.bundle<a: uint<1>>
   %0 = firrtl.subfield %w("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
   // CHECK: firrtl.connect %0, %in : !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -307,10 +307,9 @@ firrtl.circuit "BadAdd" {
 // -----
 
 firrtl.circuit "NodeMustBePassive" {
-  firrtl.module @NodeMustBePassive() {
-    %a = firrtl.wire : !firrtl.flip<uint<1>>
+  firrtl.module @NodeMustBePassive(%a: !firrtl.flip<uint<1>>) {
     // expected-error @+1 {{'firrtl.node' op operand #0 must be a passive type}}
-    %b = firrtl.node %a : !firrtl.flip<uint<1>>
+    %b = firrtl.node %a  : !firrtl.flip<uint<1>>
   }
 }
 
@@ -360,7 +359,7 @@ firrtl.circuit "OutOfOrder" {
 firrtl.circuit "MemoryNegativeReadLatency" {
   firrtl.module @MemoryNegativeReadLatency() {
     // expected-error @+1 {{'firrtl.mem' op attribute 'readLatency' failed to satisfy constraint}}
-    %memory_r = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r", "rw", "w"], readLatency = -1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<8>>
+    %memory_r = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r", "rw", "w"], readLatency = -1 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<uint<8>>>>
   }
 }
 
@@ -369,7 +368,7 @@ firrtl.circuit "MemoryNegativeReadLatency" {
 firrtl.circuit "MemoryZeroWriteLatency" {
   firrtl.module @MemoryZeroWriteLatency() {
     // expected-error @+1 {{'firrtl.mem' op attribute 'writeLatency' failed to satisfy constraint}}
-    %memory_r = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r", "rw", "w"], readLatency = 0 : i32, writeLatency = 0 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<8>>
+    %memory_r = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r", "rw", "w"], readLatency = 0 : i32, writeLatency = 0 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<uint<8>>>>
   }
 }
 
@@ -378,7 +377,7 @@ firrtl.circuit "MemoryZeroWriteLatency" {
 firrtl.circuit "MemoryZeroDepth" {
   firrtl.module @MemoryZeroDepth() {
     // expected-error @+1 {{'firrtl.mem' op attribute 'depth' failed to satisfy constraint}}
-    %memory_r = firrtl.mem Undefined {depth = 0 : i64, name = "memory", portNames = ["r", "rw", "w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<8>>
+    %memory_r = firrtl.mem Undefined {depth = 0 : i64, name = "memory", portNames = ["r", "rw", "w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<uint<8>>>>
   }
 }
 
@@ -396,7 +395,7 @@ firrtl.circuit "MemoryBadPortType" {
 firrtl.circuit "MemoryPortNamesCollide" {
   firrtl.module @MemoryPortNamesCollide() {
     // expected-error @+1 {{'firrtl.mem' op has non-unique port name "r"}}
-    %memory_r, %memory_r_0 = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r", "r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<8>>, !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<8>>
+    %memory_r, %memory_r_0 = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r", "r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<uint<8>>>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<uint<8>>>>
   }
 }
 
@@ -414,7 +413,7 @@ firrtl.circuit "MemoryUnexpectedNumberOfFields" {
 firrtl.circuit "MemoryMissingDataField" {
   firrtl.module @MemoryMissingDataField() {
     // expected-error @+1 {{'firrtl.mem' op has no data field on port "r" (expected to see "data" for a read or write port or "rdata" for a read/write port)}}
-    %memory_r = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, rdata: uint<8>>
+    %memory_r = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata: flip<uint<8>>>>
   }
 }
 
@@ -423,7 +422,7 @@ firrtl.circuit "MemoryMissingDataField" {
 firrtl.circuit "MemoryMissingDataField2" {
   firrtl.module @MemoryMissingDataField2() {
     // expected-error @+1 {{'firrtl.mem' op has no data field on port "rw" (expected to see "data" for a read or write port or "rdata" for a read/write port)}}
-    %memory_rw = firrtl.mem Undefined {depth = 16 : i64, name = "memory2", portNames = ["rw"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, wmode: flip<uint<1>>, readdata: uint<8>, wdata: flip<uint<8>>, wmask: flip<uint<1>>>
+    %memory_rw = firrtl.mem Undefined {depth = 16 : i64, name = "memory2", portNames = ["rw"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, wmode: uint<1>, rdata: flip<uint<8>>, writedata: uint<8>, wmask: uint<1>>>
   }
 }
 
@@ -432,7 +431,7 @@ firrtl.circuit "MemoryMissingDataField2" {
 firrtl.circuit "MemoryDataNotPassive" {
   firrtl.module @MemoryDataNotPassive() {
     // expected-error @+1 {{'firrtl.mem' op has non-passive data type on port "r" (memory types must be passive)}}
-    %memory_r = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<a: uint<8>, b: flip<uint<8>>>>
+    %memory_r = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<bundle<a: flip<uint<8>>, b: uint<8>>>>>
   }
 }
 
@@ -441,7 +440,7 @@ firrtl.circuit "MemoryDataNotPassive" {
 firrtl.circuit "MemoryDataContainsAnalog" {
   firrtl.module @MemoryDataContainsAnalog() {
     // expected-error @+1 {{'firrtl.mem' op has a data type that contains an analog type on port "r" (memory types cannot contain analog types)}}
-    %memory_r = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<a: uint<8>, b: analog<8>>>
+    %memory_r = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<bundle<a: uint<8>, b: analog<8>>>>>
   }
 }
 
@@ -449,8 +448,8 @@ firrtl.circuit "MemoryDataContainsAnalog" {
 
 firrtl.circuit "MemoryPortInvalidReadKind" {
   firrtl.module @MemoryPortInvalidReadKind() {
-    // expected-error @+1 {{'firrtl.mem' op has an invalid type for port "r" of determined kind "read" (expected '!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<8>>', but got '!firrtl.bundle<BAD: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<8>>')}}
-    %memory_r= firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<BAD: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<8>>
+    // expected-error @+1 {{'firrtl.mem' op has an invalid type for port "r" of determined kind "read" (expected '!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<uint<8>>>>', but got '!firrtl.flip<bundle<BAD: uint<4>, en: uint<1>, clk: clock, data: flip<uint<8>>>>')}}
+    %memory_r= firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<BAD: uint<4>, en: uint<1>, clk: clock, data: flip<uint<8>>>>
   }
 }
 
@@ -467,8 +466,8 @@ firrtl.circuit "MemoryPortInvalidWriteKind" {
 
 firrtl.circuit "MemoryPortInvalidReadWriteKind" {
   firrtl.module @MemoryPortInvalidReadWriteKind() {
-    // expected-error @+1 {{'firrtl.mem' op has an invalid type for port "rw" of determined kind "readwrite" (expected '!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, wmode: flip<uint<1>>, rdata: uint<8>, wdata: flip<uint<8>>, wmask: flip<uint<1>>>', but got '!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, wmode: flip<uint<1>>, rdata: uint<8>, wdata: flip<uint<8>>, BAD: flip<uint<1>>>')}}
-    %memory_r= firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["rw"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, wmode: flip<uint<1>>, rdata: uint<8>, wdata: flip<uint<8>>, BAD: flip<uint<1>>>
+    // expected-error @+1 {{'firrtl.mem' op has an invalid type for port "rw" of determined kind "readwrite" (expected '!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, wmode: uint<1>, rdata: flip<uint<8>>, wdata: uint<8>, wmask: uint<1>>>', but got '!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, wmode: uint<1>, rdata: flip<uint<8>>, wdata: uint<8>, BAD: uint<1>>>')}}
+    %memory_r= firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["rw"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, wmode: uint<1>, rdata: flip<uint<8>>, wdata: uint<8>, BAD: uint<1>>>
   }
 }
 
@@ -477,6 +476,6 @@ firrtl.circuit "MemoryPortInvalidReadWriteKind" {
 firrtl.circuit "MemoryPortsWithDifferentTypes" {
   firrtl.module @MemoryPortsWithDifferentTypes() {
     // expected-error @+1 {{'firrtl.mem' op port "r1" has a different type than port "r0" (expected '!firrtl.uint<8>', but got '!firrtl.sint<8>')}}
-    %memory_r0, %memory_r1 = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r0", "r1"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<8>>, !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: sint<8>>
+    %memory_r0, %memory_r1 = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r0", "r1"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<uint<8>>>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>>
   }
 }

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -35,16 +35,16 @@ firrtl.module @shadow_when(%p : !firrtl.uint<1>) {
   %c0_ui2 = firrtl.constant(0 : ui2) : !firrtl.uint<2>
   %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
   firrtl.when %p {
-    %w = firrtl.wire : !firrtl.flip<uint<2>>
-    firrtl.connect %w, %c0_ui2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
-    firrtl.connect %w, %c1_ui2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+    %w = firrtl.wire : !firrtl.uint<2>
+    firrtl.connect %w, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
+    firrtl.connect %w, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   }
 }
 // CHECK-LABEL: firrtl.module @shadow_when(%p: !firrtl.uint<1>) {
 // CHECK-NEXT:   %c0_ui2 = firrtl.constant(0 : ui2) : !firrtl.uint<2>
 // CHECK-NEXT:   %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
-// CHECK-NEXT:   %w = firrtl.wire  : !firrtl.flip<uint<2>>
-// CHECK-NEXT:   firrtl.connect %w, %c1_ui2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+// CHECK-NEXT:   %w = firrtl.wire  : !firrtl.uint<2>
+// CHECK-NEXT:   firrtl.connect %w, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
 // CHECK-NEXT: }
 
 

--- a/test/Dialect/FIRRTL/lower-types.fir
+++ b/test/Dialect/FIRRTL/lower-types.fir
@@ -21,13 +21,6 @@ circuit TypeCanonicalizationConsideredHarmful:
     ; CHECK-NEXT: firrtl.partialconnect %a_a_a, %ax_a_a
     ; CHECK-NEXT: firrtl.partialconnect %a_a_a, %ax_a_a
 
-    a <= ax
-    a.a <= ax.a
-    a.a.a <= ax.a.a
-    ; CHECK:      firrtl.connect %a_a_a, %ax_a_a
-    ; CHECK-NEXT: firrtl.connect %a_a_a, %ax_a_a
-    ; CHECK-NEXT: firrtl.connect %a_a_a, %ax_a_a
-
     wire b:  { a: {flip a: UInt<1>}}
     wire bx: { a: {flip a: UInt<1>}}
 
@@ -37,13 +30,6 @@ circuit TypeCanonicalizationConsideredHarmful:
     ; CHECK:      firrtl.partialconnect %bx_a_a, %b_a_a
     ; CHECK-NEXT: firrtl.partialconnect %bx_a_a, %b_a_a
     ; CHECK-NEXT: firrtl.partialconnect %b_a_a,  %bx_a_a
-
-    b <= bx
-    b.a <= bx.a
-    b.a.a <= bx.a.a
-    ; CHECK:      firrtl.connect %bx_a_a, %b_a_a
-    ; CHECK-NEXT: firrtl.connect %bx_a_a, %b_a_a
-    ; CHECK-NEXT: firrtl.connect %b_a_a,  %bx_a_a
 
     wire c:  {flip a: { a: UInt<1>}}
     wire cx: {flip a: { a: UInt<1>}}
@@ -55,13 +41,6 @@ circuit TypeCanonicalizationConsideredHarmful:
     ; CHECK-NEXT: firrtl.partialconnect %c_a_a,  %cx_a_a
     ; CHECK-NEXT: firrtl.partialconnect %c_a_a,  %cx_a_a
 
-    c <= cx
-    c.a <= cx.a
-    c.a.a <= cx.a.a
-    ; CHECK:      firrtl.connect %cx_a_a, %c_a_a
-    ; CHECK-NEXT: firrtl.connect %c_a_a,  %cx_a_a
-    ; CHECK-NEXT: firrtl.connect %c_a_a,  %cx_a_a
-
     wire d:  {flip a: {flip a: UInt<1>}}
     wire dx: {flip a: {flip a: UInt<1>}}
 
@@ -71,13 +50,6 @@ circuit TypeCanonicalizationConsideredHarmful:
     ; CHECK:      firrtl.partialconnect %d_a_a,  %dx_a_a
     ; CHECK-NEXT: firrtl.partialconnect %dx_a_a, %d_a_a
     ; CHECK-NEXT: firrtl.partialconnect %d_a_a,  %dx_a_a
-
-    d <= dx
-    d.a <= dx.a
-    d.a.a <= dx.a.a
-    ; CHECK:      firrtl.connect %d_a_a,  %dx_a_a
-    ; CHECK-NEXT: firrtl.connect %dx_a_a, %d_a_a
-    ; CHECK-NEXT: firrtl.connect %d_a_a,  %dx_a_a
 
   module TypeCanonicalizationStillConsideredHarmful:
 

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -10,7 +10,7 @@ firrtl.circuit "TopLevel" {
   // CHECK-SAME: %[[SINK_READY_NAME:sink_ready]]: [[SINK_READY_TYPE:!firrtl.uint<1>]]
   // CHECK-SAME: %[[SINK_DATA_NAME:sink_data]]: [[SINK_DATA_TYPE:!firrtl.flip<uint<64>>]]
   firrtl.module @Simple(%source: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>,
-                        %sink: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) {
+                        %sink: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) {
 
     // CHECK-NEXT: firrtl.when %[[SOURCE_VALID_NAME]]
     // CHECK-NEXT:   firrtl.connect %[[SINK_DATA_NAME]], %[[SOURCE_DATA_NAME]] : [[SINK_DATA_TYPE]], [[SOURCE_DATA_TYPE]]
@@ -18,15 +18,15 @@ firrtl.circuit "TopLevel" {
     // CHECK-NEXT:   firrtl.connect %[[SOURCE_READY_NAME]], %[[SINK_READY_NAME]] : [[SOURCE_READY_TYPE]], [[SINK_READY_TYPE]]
 
     %0 = firrtl.subfield %source("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
-    %1 = firrtl.subfield %source("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.flip<uint<1>>
+    %1 = firrtl.subfield %source("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
     %2 = firrtl.subfield %source("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
-    %3 = firrtl.subfield %sink("valid") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<1>>
-    %4 = firrtl.subfield %sink("ready") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.uint<1>
-    %5 = firrtl.subfield %sink("data") : (!firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) -> !firrtl.flip<uint<64>>
+    %3 = firrtl.subfield %sink("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
+    %4 = firrtl.subfield %sink("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
+    %5 = firrtl.subfield %sink("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
     firrtl.when %0 {
-      firrtl.connect %5, %2 : !firrtl.flip<uint<64>>, !firrtl.uint<64>
-      firrtl.connect %3, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-      firrtl.connect %1, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+      firrtl.connect %5, %2 : !firrtl.uint<64>, !firrtl.uint<64>
+      firrtl.connect %3, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+      firrtl.connect %1, %4 : !firrtl.uint<1>, !firrtl.uint<1>
     }
   }
 
@@ -38,12 +38,12 @@ firrtl.circuit "TopLevel" {
   // CHECK-SAME: %sink_ready: [[SINK_READY_TYPE:!firrtl.uint<1>]]
   // CHECK-SAME: %sink_data: [[SINK_DATA_TYPE:!firrtl.flip<uint<64>>]]
   firrtl.module @TopLevel(%source: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>,
-                          %sink: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) {
+                          %sink: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) {
 
     // CHECK-NEXT: %inst_source_valid, %inst_source_ready, %inst_source_data, %inst_sink_valid, %inst_sink_ready, %inst_sink_data
     // CHECK-SAME: = firrtl.instance @Simple {name = ""} :
     // CHECK-SAME: !firrtl.flip<uint<1>>, !firrtl.uint<1>, !firrtl.flip<uint<64>>, !firrtl.uint<1>, !firrtl.flip<uint<1>>, !firrtl.uint<64>
-    %sourceV, %sinkV = firrtl.instance @Simple {name = ""} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+    %sourceV, %sinkV = firrtl.instance @Simple {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
 
     // CHECK-NEXT: firrtl.connect %inst_source_valid, %source_valid
     // CHECK-NEXT: firrtl.connect %source_ready, %inst_source_ready
@@ -51,9 +51,9 @@ firrtl.circuit "TopLevel" {
     // CHECK-NEXT: firrtl.connect %sink_valid, %inst_sink_valid
     // CHECK-NEXT: firrtl.connect %inst_sink_ready, %sink_ready
     // CHECK-NEXT: firrtl.connect %sink_data, %inst_sink_data
-    firrtl.connect %sourceV, %source : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+    firrtl.connect %sourceV, %source : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
 
-    firrtl.connect %sink, %sinkV : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+    firrtl.connect %sink, %sinkV : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
   }
 }
 
@@ -89,7 +89,7 @@ firrtl.circuit "Uniquification" {
   // CHECK-LABEL: firrtl.module @Uniquification
   // CHECK-SAME: %[[FLATTENED_ARG:a_b]]: [[FLATTENED_TYPE:!firrtl.uint<1>]],
   // CHECK-NOT: %[[FLATTENED_ARG]]
-  // CHECK-SAME: %[[RENAMED_ARG:a_b.+]]: [[RENAMED_TYPE:!firrtl.uint<1>]] 
+  // CHECK-SAME: %[[RENAMED_ARG:a_b.+]]: [[RENAMED_TYPE:!firrtl.uint<1>]]
   // CHECK-SAME: {portNames = ["a_b", "a_b"]}
   firrtl.module @Uniquification(%a: !firrtl.bundle<b: uint<1>>, %a_b: !firrtl.uint<1>) {
   }
@@ -161,25 +161,25 @@ firrtl.circuit "Foo" {
 
   // CHECK-LABEL: firrtl.module @Foo
   firrtl.module @Foo(%clock: !firrtl.clock, %rAddr: !firrtl.uint<4>, %rEn: !firrtl.uint<1>, %rData: !firrtl.flip<bundle<a: uint<8>, b: uint<8>>>, %wAddr: !firrtl.uint<4>, %wEn: !firrtl.uint<1>, %wMask: !firrtl.bundle<a: uint<1>, b: uint<1>>, %wData: !firrtl.bundle<a: uint<8>, b: uint<8>>) {
-    %memory_r, %memory_w = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r", "w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<a: uint<8>, b: uint<8>>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>>
-    %0 = firrtl.subfield %memory_r("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<a: uint<8>, b: uint<8>>>) -> !firrtl.flip<clock>
-    firrtl.connect %0, %clock : !firrtl.flip<clock>, !firrtl.clock
-    %1 = firrtl.subfield %memory_r("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<a: uint<8>, b: uint<8>>>) -> !firrtl.flip<uint<1>>
-    firrtl.connect %1, %rEn : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-    %2 = firrtl.subfield %memory_r("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<a: uint<8>, b: uint<8>>>) -> !firrtl.flip<uint<4>>
-    firrtl.connect %2, %rAddr : !firrtl.flip<uint<4>>, !firrtl.uint<4>
-    %3 = firrtl.subfield %memory_r("data") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<a: uint<8>, b: uint<8>>>) -> !firrtl.bundle<a: uint<8>, b: uint<8>>
+    %memory_r, %memory_w = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r", "w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<bundle<a: uint<8>, b: uint<8>>>>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>>
+    %0 = firrtl.subfield %memory_r("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<bundle<a: uint<8>, b: uint<8>>>>>) -> !firrtl.clock
+    firrtl.connect %0, %clock : !firrtl.clock, !firrtl.clock
+    %1 = firrtl.subfield %memory_r("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<bundle<a: uint<8>, b: uint<8>>>>>) -> !firrtl.uint<1>
+    firrtl.connect %1, %rEn : !firrtl.uint<1>, !firrtl.uint<1>
+    %2 = firrtl.subfield %memory_r("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<bundle<a: uint<8>, b: uint<8>>>>>) -> !firrtl.uint<4>
+    firrtl.connect %2, %rAddr : !firrtl.uint<4>, !firrtl.uint<4>
+    %3 = firrtl.subfield %memory_r("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<bundle<a: uint<8>, b: uint<8>>>>>) -> !firrtl.bundle<a: uint<8>, b: uint<8>>
     firrtl.connect %rData, %3 : !firrtl.flip<bundle<a: uint<8>, b: uint<8>>>, !firrtl.bundle<a: uint<8>, b: uint<8>>
-    %4 = firrtl.subfield %memory_w("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>>) -> !firrtl.flip<clock>
-    firrtl.connect %4, %clock : !firrtl.flip<clock>, !firrtl.clock
-    %5 = firrtl.subfield %memory_w("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>>) -> !firrtl.flip<uint<1>>
-    firrtl.connect %5, %wEn : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-    %6 = firrtl.subfield %memory_w("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>>) -> !firrtl.flip<uint<4>>
-    firrtl.connect %6, %wAddr : !firrtl.flip<uint<4>>, !firrtl.uint<4>
-    %7 = firrtl.subfield %memory_w("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>>) -> !firrtl.flip<bundle<a: uint<1>, b: uint<1>>>
-    firrtl.connect %7, %wMask : !firrtl.flip<bundle<a: uint<1>, b: uint<1>>>, !firrtl.bundle<a: uint<1>, b: uint<1>>
-    %8 = firrtl.subfield %memory_w("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>>) -> !firrtl.flip<bundle<a: uint<8>, b: uint<8>>>
-    firrtl.connect %8, %wData : !firrtl.flip<bundle<a: uint<8>, b: uint<8>>>, !firrtl.bundle<a: uint<8>, b: uint<8>>
+    %4 = firrtl.subfield %memory_w("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>>) -> !firrtl.clock
+    firrtl.connect %4, %clock : !firrtl.clock, !firrtl.clock
+    %5 = firrtl.subfield %memory_w("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>>) -> !firrtl.uint<1>
+    firrtl.connect %5, %wEn : !firrtl.uint<1>, !firrtl.uint<1>
+    %6 = firrtl.subfield %memory_w("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>>) -> !firrtl.uint<4>
+    firrtl.connect %6, %wAddr : !firrtl.uint<4>, !firrtl.uint<4>
+    %7 = firrtl.subfield %memory_w("mask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>>) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
+    firrtl.connect %7, %wMask : !firrtl.bundle<a: uint<1>, b: uint<1>>, !firrtl.bundle<a: uint<1>, b: uint<1>>
+    %8 = firrtl.subfield %memory_w("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>>) -> !firrtl.bundle<a: uint<8>, b: uint<8>>
+    firrtl.connect %8, %wData : !firrtl.bundle<a: uint<8>, b: uint<8>>, !firrtl.bundle<a: uint<8>, b: uint<8>>
 
     // COM: ---------------------------------------------------------------------------------
     // COM: Split memory "a" should exist
@@ -281,20 +281,20 @@ firrtl.circuit "Foo" {
 
 firrtl.circuit "MemoryRWSplit" {
   firrtl.module @MemoryRWSplit(%clock: !firrtl.clock, %rwEn: !firrtl.uint<1>, %rwMode: !firrtl.uint<1>, %rwAddr: !firrtl.uint<4>, %rwMask: !firrtl.uint<1>, %rwDataIn: !firrtl.uint<8>, %rwDataOut: !firrtl.flip<uint<8>>) {
-    %memory_rw = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["rw"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, wmode: flip<uint<1>>, rdata: uint<8>, wdata: flip<uint<8>>, wmask: flip<uint<1>>>
-    %0 = firrtl.subfield %memory_rw("clk") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, wmode: flip<uint<1>>, rdata: uint<8>, wdata: flip<uint<8>>, wmask: flip<uint<1>>>) -> !firrtl.flip<clock>
-    firrtl.connect %0, %clock : !firrtl.flip<clock>, !firrtl.clock
-    %1 = firrtl.subfield %memory_rw("en") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, wmode: flip<uint<1>>, rdata: uint<8>, wdata: flip<uint<8>>, wmask: flip<uint<1>>>) -> !firrtl.flip<uint<1>>
-    firrtl.connect %1, %rwEn : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-    %2 = firrtl.subfield %memory_rw("addr") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, wmode: flip<uint<1>>, rdata: uint<8>, wdata: flip<uint<8>>, wmask: flip<uint<1>>>) -> !firrtl.flip<uint<4>>
-    firrtl.connect %2, %rwAddr : !firrtl.flip<uint<4>>, !firrtl.uint<4>
-    %3 = firrtl.subfield %memory_rw("wmode") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, wmode: flip<uint<1>>, rdata: uint<8>, wdata: flip<uint<8>>, wmask: flip<uint<1>>>) -> !firrtl.flip<uint<1>>
-    firrtl.connect %3, %rwMode : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-    %4 = firrtl.subfield %memory_rw("wmask") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, wmode: flip<uint<1>>, rdata: uint<8>, wdata: flip<uint<8>>, wmask: flip<uint<1>>>) -> !firrtl.flip<uint<1>>
-    firrtl.connect %4, %rwMask : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-    %5 = firrtl.subfield %memory_rw("wdata") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, wmode: flip<uint<1>>, rdata: uint<8>, wdata: flip<uint<8>>, wmask: flip<uint<1>>>) -> !firrtl.flip<uint<8>>
-    firrtl.connect %5, %rwDataIn : !firrtl.flip<uint<8>>, !firrtl.uint<8>
-    %6 = firrtl.subfield %memory_rw("rdata") : (!firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, wmode: flip<uint<1>>, rdata: uint<8>, wdata: flip<uint<8>>, wmask: flip<uint<1>>>) -> !firrtl.uint<8>
+    %memory_rw = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["rw"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, wmode: uint<1>, rdata: flip<uint<8>>, wdata: uint<8>, wmask: uint<1>>>
+    %0 = firrtl.subfield %memory_rw("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, wmode: uint<1>, rdata: flip<uint<8>>, wdata: uint<8>, wmask: uint<1>>>) -> !firrtl.clock
+    firrtl.connect %0, %clock : !firrtl.clock, !firrtl.clock
+    %1 = firrtl.subfield %memory_rw("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, wmode: uint<1>, rdata: flip<uint<8>>, wdata: uint<8>, wmask: uint<1>>>) -> !firrtl.uint<1>
+    firrtl.connect %1, %rwEn : !firrtl.uint<1>, !firrtl.uint<1>
+    %2 = firrtl.subfield %memory_rw("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, wmode: uint<1>, rdata: flip<uint<8>>, wdata: uint<8>, wmask: uint<1>>>) -> !firrtl.uint<4>
+    firrtl.connect %2, %rwAddr : !firrtl.uint<4>, !firrtl.uint<4>
+    %3 = firrtl.subfield %memory_rw("wmode") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, wmode: uint<1>, rdata: flip<uint<8>>, wdata: uint<8>, wmask: uint<1>>>) -> !firrtl.uint<1>
+    firrtl.connect %3, %rwMode : !firrtl.uint<1>, !firrtl.uint<1>
+    %4 = firrtl.subfield %memory_rw("wmask") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, wmode: uint<1>, rdata: flip<uint<8>>, wdata: uint<8>, wmask: uint<1>>>) -> !firrtl.uint<1>
+    firrtl.connect %4, %rwMask : !firrtl.uint<1>, !firrtl.uint<1>
+    %5 = firrtl.subfield %memory_rw("wdata") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, wmode: uint<1>, rdata: flip<uint<8>>, wdata: uint<8>, wmask: uint<1>>>) -> !firrtl.uint<8>
+    firrtl.connect %5, %rwDataIn : !firrtl.uint<8>, !firrtl.uint<8>
+    %6 = firrtl.subfield %memory_rw("rdata") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, wmode: uint<1>, rdata: flip<uint<8>>, wdata: uint<8>, wmask: uint<1>>>) -> !firrtl.uint<8>
     firrtl.connect %rwDataOut, %6 : !firrtl.flip<uint<8>>, !firrtl.uint<8>
   }
 
@@ -305,7 +305,7 @@ firrtl.circuit "MemoryRWSplit" {
   // COM:   - port names are updated correctly
   // CHECK-SAME: portNames = ["rw_r", "rw_w"]
   // COM:   - the types are correct for read and write ports
-  // CHECK-SAME: !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<8>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>>
+  // CHECK-SAME: !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<uint<8>>>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>>
   // COM: ---------------------------------------------------------------------------------
   // COM: Read port is hooked up correctly
   // COM:   - address is "rw_addr"
@@ -356,7 +356,7 @@ firrtl.circuit "MemoryRWSplit" {
 
 firrtl.circuit "MemoryRWSplitUnique" {
   firrtl.module @MemoryRWSplitUnique() {
-    %memory_rw, %memory_rw_r, %memory_rw_w = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["rw", "rw_r", "rw_w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, wmode: flip<uint<1>>, rdata: uint<8>, wdata: flip<uint<8>>, wmask: flip<uint<1>>>, !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<8>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>>
+    %memory_rw, %memory_rw_r, %memory_rw_w = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["rw", "rw_r", "rw_w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, wmode: uint<1>, rdata: flip<uint<8>>, wdata: uint<8>, wmask: uint<1>>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<uint<8>>>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>>
   }
 
   // CHECK-LABEL: firrtl.module @MemoryRWSplitUnique
@@ -408,7 +408,7 @@ module  {
       %head_MPORT_2, %head_MPORT_6 = firrtl.mem Undefined {depth = 20 : i64, name = "head", portNames = ["MPORT_2", "MPORT_6"], readLatency = 0 : i32, writeLatency = 1 : i32}
       : !firrtl.flip<bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<5>, mask: uint<1>>>,
         !firrtl.flip<bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<5>, mask: uint<1>>>
-      %127 = firrtl.subfield %head_MPORT_6("clk") : (!firrtl.flip<bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<5>, mask: uint<1>>>) -> !firrtl.flip<clock>
+      %127 = firrtl.subfield %head_MPORT_6("clk") : (!firrtl.flip<bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<5>, mask: uint<1>>>) -> !firrtl.clock
     }
   }
 }
@@ -423,9 +423,9 @@ firrtl.circuit "RegBundle" {
       %0 = firrtl.subfield %x("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
       %1 = firrtl.subfield %a("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
       firrtl.connect %0, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-      %2 = firrtl.subfield %b("a") : (!firrtl.flip<bundle<a: uint<1>>>) -> !firrtl.flip<uint<1>>
+      %2 = firrtl.subfield %b("a") : (!firrtl.flip<bundle<a: uint<1>>>) -> !firrtl.uint<1>
       %3 = firrtl.subfield %x("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
-      firrtl.connect %2, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+      firrtl.connect %2, %3 : !firrtl.uint<1>, !firrtl.uint<1>
     }
 }
 
@@ -455,9 +455,9 @@ firrtl.circuit "WireBundle" {
       %0 = firrtl.subfield %x("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
       %1 = firrtl.subfield %a("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
       firrtl.connect %0, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-      %2 = firrtl.subfield %b("a") : (!firrtl.flip<bundle<a: uint<1>>>) -> !firrtl.flip<uint<1>>
+      %2 = firrtl.subfield %b("a") : (!firrtl.flip<bundle<a: uint<1>>>) -> !firrtl.uint<1>
       %3 = firrtl.subfield %x("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
-      firrtl.connect %2, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+      firrtl.connect %2, %3 : !firrtl.uint<1>, !firrtl.uint<1>
     }
 }
 
@@ -466,19 +466,19 @@ firrtl.circuit "WireBundle" {
 firrtl.circuit "WireBundlesWithBulkConnect" {
   // CHECK-LABEL: firrtl.module @WireBundlesWithBulkConnect
   firrtl.module @WireBundlesWithBulkConnect(%source: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>,
-                             %sink: !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>) {
+                             %sink: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) {
     // CHECK: %w_valid = firrtl.wire  : !firrtl.uint<1>
-    // CHECK: %w_ready = firrtl.wire  : !firrtl.flip<uint<1>>
+    // CHECK: %w_ready = firrtl.wire  : !firrtl.uint<1>
     // CHECK: %w_data = firrtl.wire  : !firrtl.uint<64>
     %w = firrtl.wire : !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
     // CHECK: firrtl.connect %w_valid, %source_valid : !firrtl.uint<1>, !firrtl.uint<1>
-    // CHECK: firrtl.connect %source_ready, %w_ready : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>
+    // CHECK: firrtl.connect %source_ready, %w_ready : !firrtl.flip<uint<1>>, !firrtl.uint<1>
     // CHECK: firrtl.connect %w_data, %source_data : !firrtl.uint<64>, !firrtl.uint<64>
     firrtl.connect %w, %source : !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
     // CHECK: firrtl.connect %sink_valid, %w_valid : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-    // CHECK: firrtl.connect %w_ready, %sink_ready : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+    // CHECK: firrtl.connect %w_ready, %sink_ready : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: firrtl.connect %sink_data, %w_data : !firrtl.flip<uint<64>>, !firrtl.uint<64>
-    firrtl.connect %sink, %w : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+    firrtl.connect %sink, %w : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
   }
 }
 
@@ -514,7 +514,7 @@ firrtl.circuit "ExternalModule" {
   firrtl.extmodule @ExternalModule(!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>> ) attributes {portNames = ["source"]}
   firrtl.module @Test() {
     // CHECK:  %inst_source_valid, %inst_source_ready, %inst_source_data = firrtl.instance @ExternalModule  {name = ""} : !firrtl.flip<uint<1>>, !firrtl.uint<1>, !firrtl.flip<uint<64>>
-    %inst_source = firrtl.instance @ExternalModule {name = ""} : !firrtl.bundle<valid: flip<uint<1>>, ready: uint<1>, data: flip<uint<64>>>
+    %inst_source = firrtl.instance @ExternalModule {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>
   }
 }
 
@@ -618,7 +618,7 @@ firrtl.circuit "AnnotationsInstanceOp" {
 firrtl.circuit "AnnotationsMemOp" {
   // CHECK-LABEL: firrtl.module @AnnotationsMemOp
   firrtl.module @AnnotationsMemOp() {
-    %bar_r, %bar_w = firrtl.mem Undefined  {annotations = [{a = "a"}], depth = 16 : i64, name = "bar", portNames = ["r", "w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: vector<uint<8>, 2>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: vector<uint<8>, 2>, mask: vector<uint<1>, 2>>>
+    %bar_r, %bar_w = firrtl.mem Undefined  {annotations = [{a = "a"}], depth = 16 : i64, name = "bar", portNames = ["r", "w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<vector<uint<8>, 2>>>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: vector<uint<8>, 2>, mask: vector<uint<1>, 2>>>
   }
   // CHECK: firrtl.mem
   // CHECK-SAME: annotations = [{a = "a"}]
@@ -689,5 +689,82 @@ firrtl.circuit "WhenOp" {
       // CHECK: firrtl.connect %out_b, %in_b : !firrtl.flip<uint<1>>, !firrtl.uint<1>
       firrtl.connect %out, %in : !firrtl.flip<bundle<a: uint<1>, b: uint<1>>>, !firrtl.bundle<a: uint<1>, b: uint<1>>
     }
+  }
+}
+
+// -----
+
+// Test wire connection semantics.  Based on the flippedness of the destination
+// type, the connection may be reversed.
+firrtl.circuit "WireSemantics"  {
+  firrtl.module @WireSemantics() {
+    %a = firrtl.wire  : !firrtl.bundle<a: bundle<a: uint<1>>>
+    %ax = firrtl.wire  : !firrtl.bundle<a: bundle<a: uint<1>>>
+    firrtl.connect %a, %ax : !firrtl.bundle<a: bundle<a: uint<1>>>, !firrtl.bundle<a: bundle<a: uint<1>>>
+    // COM: a <= ax
+    // CHECK: firrtl.connect %a_a_a, %ax_a_a
+    %0 = firrtl.subfield %a("a") : (!firrtl.bundle<a: bundle<a: uint<1>>>) -> !firrtl.bundle<a: uint<1>>
+    %1 = firrtl.subfield %ax("a") : (!firrtl.bundle<a: bundle<a: uint<1>>>) -> !firrtl.bundle<a: uint<1>>
+    firrtl.connect %0, %1 : !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>
+    // COM: a.a <= ax.a
+    // CHECK: firrtl.connect %a_a_a, %ax_a_a
+    %2 = firrtl.subfield %a("a") : (!firrtl.bundle<a: bundle<a: uint<1>>>) -> !firrtl.bundle<a: uint<1>>
+    %3 = firrtl.subfield %2("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+    %4 = firrtl.subfield %ax("a") : (!firrtl.bundle<a: bundle<a: uint<1>>>) -> !firrtl.bundle<a: uint<1>>
+    %5 = firrtl.subfield %4("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+    firrtl.connect %3, %5 : !firrtl.uint<1>, !firrtl.uint<1>
+    // COM: a.a.a <= ax.a.a
+    // CHECK: firrtl.connect %a_a_a, %ax_a_a
+    %b = firrtl.wire  : !firrtl.bundle<a: bundle<a: flip<uint<1>>>>
+    %bx = firrtl.wire  : !firrtl.bundle<a: bundle<a: flip<uint<1>>>>
+    firrtl.connect %b, %bx : !firrtl.bundle<a: bundle<a: flip<uint<1>>>>, !firrtl.bundle<a: bundle<a: flip<uint<1>>>>
+    // COM: b <= bx
+    // CHECK: firrtl.connect %bx_a_a, %b_a_a
+    %6 = firrtl.subfield %b("a") : (!firrtl.bundle<a: bundle<a: flip<uint<1>>>>) -> !firrtl.bundle<a: flip<uint<1>>>
+    %7 = firrtl.subfield %bx("a") : (!firrtl.bundle<a: bundle<a: flip<uint<1>>>>) -> !firrtl.bundle<a: flip<uint<1>>>
+    firrtl.connect %6, %7 : !firrtl.bundle<a: flip<uint<1>>>, !firrtl.bundle<a: flip<uint<1>>>
+    // COM: b.a <= bx.a
+    // CHECK: firrtl.connect %bx_a_a, %b_a_a
+    %8 = firrtl.subfield %b("a") : (!firrtl.bundle<a: bundle<a: flip<uint<1>>>>) -> !firrtl.bundle<a: flip<uint<1>>>
+    %9 = firrtl.subfield %8("a") : (!firrtl.bundle<a: flip<uint<1>>>) -> !firrtl.uint<1>
+    %10 = firrtl.subfield %bx("a") : (!firrtl.bundle<a: bundle<a: flip<uint<1>>>>) -> !firrtl.bundle<a: flip<uint<1>>>
+    %11 = firrtl.subfield %10("a") : (!firrtl.bundle<a: flip<uint<1>>>) -> !firrtl.uint<1>
+    firrtl.connect %9, %11 : !firrtl.uint<1>, !firrtl.uint<1>
+    // COM: b.a.a <= bx.a.a
+    // CHECK: firrtl.connect %b_a_a, %bx_a_a
+    %c = firrtl.wire  : !firrtl.bundle<a: flip<bundle<a: uint<1>>>>
+    %cx = firrtl.wire  : !firrtl.bundle<a: flip<bundle<a: uint<1>>>>
+    firrtl.connect %c, %cx : !firrtl.bundle<a: flip<bundle<a: uint<1>>>>, !firrtl.bundle<a: flip<bundle<a: uint<1>>>>
+    // COM: c <= cx
+    // CHECK: firrtl.connect %cx_a_a, %c_a_a
+    %12 = firrtl.subfield %c("a") : (!firrtl.bundle<a: flip<bundle<a: uint<1>>>>) -> !firrtl.bundle<a: uint<1>>
+    %13 = firrtl.subfield %cx("a") : (!firrtl.bundle<a: flip<bundle<a: uint<1>>>>) -> !firrtl.bundle<a: uint<1>>
+    firrtl.connect %12, %13 : !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>
+    // COM: c.a <= cx.a
+    // CHECK: firrtl.connect %c_a_a, %cx_a_a
+    %14 = firrtl.subfield %c("a") : (!firrtl.bundle<a: flip<bundle<a: uint<1>>>>) -> !firrtl.bundle<a: uint<1>>
+    %15 = firrtl.subfield %14("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+    %16 = firrtl.subfield %cx("a") : (!firrtl.bundle<a: flip<bundle<a: uint<1>>>>) -> !firrtl.bundle<a: uint<1>>
+    %17 = firrtl.subfield %16("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+    firrtl.connect %15, %17 : !firrtl.uint<1>, !firrtl.uint<1>
+    // COM: c.a.a <= cx.a.a
+    // CHECK: firrtl.connect %c_a_a, %cx_a_a
+    %d = firrtl.wire  : !firrtl.bundle<a: flip<bundle<a: flip<uint<1>>>>>
+    %dx = firrtl.wire  : !firrtl.bundle<a: flip<bundle<a: flip<uint<1>>>>>
+    firrtl.connect %d, %dx : !firrtl.bundle<a: flip<bundle<a: flip<uint<1>>>>>, !firrtl.bundle<a: flip<bundle<a: flip<uint<1>>>>>
+    // COM: d <= dx
+    // CHECK: firrtl.connect %d_a_a, %dx_a_a
+    %18 = firrtl.subfield %d("a") : (!firrtl.bundle<a: flip<bundle<a: flip<uint<1>>>>>) -> !firrtl.bundle<a: flip<uint<1>>>
+    %19 = firrtl.subfield %dx("a") : (!firrtl.bundle<a: flip<bundle<a: flip<uint<1>>>>>) -> !firrtl.bundle<a: flip<uint<1>>>
+    firrtl.connect %18, %19 : !firrtl.bundle<a: flip<uint<1>>>, !firrtl.bundle<a: flip<uint<1>>>
+    // COM: d.a <= dx.a
+    // CHECK: firrtl.connect %dx_a_a, %d_a_a
+    %20 = firrtl.subfield %d("a") : (!firrtl.bundle<a: flip<bundle<a: flip<uint<1>>>>>) -> !firrtl.bundle<a: flip<uint<1>>>
+    %21 = firrtl.subfield %20("a") : (!firrtl.bundle<a: flip<uint<1>>>) -> !firrtl.uint<1>
+    %22 = firrtl.subfield %dx("a") : (!firrtl.bundle<a: flip<bundle<a: flip<uint<1>>>>>) -> !firrtl.bundle<a: flip<uint<1>>>
+    %23 = firrtl.subfield %22("a") : (!firrtl.bundle<a: flip<uint<1>>>) -> !firrtl.uint<1>
+    firrtl.connect %21, %23 : !firrtl.uint<1>, !firrtl.uint<1>
+    // COM: d.a.a <= dx.a.a
+    // CHECK: firrtl.connect %d_a_a, %dx_a_a
   }
 }

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -369,10 +369,10 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
 
     ; CHECK: %_M__T_10, %_M__T_11, %_M__T_18 = firrtl.mem Undefined {depth = 8 : i64, name = "_M", portNames = ["_T_10", "_T_11", "_T_18"]
-    ; CHECK:   readLatency = 0 : i32, writeLatency = 1 : i32} :
-    ; CHECK:       !firrtl.flip<bundle<addr: uint<3>, en: uint<1>, clk: clock, data: bundle<id: uint<4>>, mask: bundle<id: uint<1>>>>,
-    ; CHECK:       !firrtl.flip<bundle<addr: uint<3>, en: uint<1>, clk: clock, data: bundle<id: uint<4>>, mask: bundle<id: uint<1>>>>,
-    ; CHECK:       !firrtl.bundle<addr: flip<uint<3>>, en: flip<uint<1>>, clk: flip<clock>, data: bundle<id: uint<4>>
+    ; CHECK-SAME: readLatency = 0 : i32, writeLatency = 1 : i32} :
+    ; CHECK-SAME: !firrtl.flip<bundle<addr: uint<3>, en: uint<1>, clk: clock, data: bundle<id: uint<4>>, mask: bundle<id: uint<1>>>>,
+    ; CHECK-SAME: !firrtl.flip<bundle<addr: uint<3>, en: uint<1>, clk: clock, data: bundle<id: uint<4>>, mask: bundle<id: uint<1>>>>,
+    ; CHECK-SAME: !firrtl.flip<bundle<addr: uint<3>, en: uint<1>, clk: clock, data: flip<bundle<id: uint<4>>>>
     mem _M : @[Decoupled.scala 209:24]
         data-type => { id : UInt<4> }
         depth => 8
@@ -409,13 +409,13 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     wire _t_6 : { flip b : { bits : { source : UInt<7> } } }
     node _t_8 = bits(_t_6.b.bits.source, 5, 0)
 
-    ; CHECK: %flip1 = firrtl.wire : !firrtl.bundle<x: bundle<a: uint>>
+    ; CHECK: %flip1 = firrtl.wire : !firrtl.bundle<x: flip<bundle<a: flip<uint>>>>
     wire flip1 : { flip x : { flip a : UInt } }
-    ; CHECK: %flip2 = firrtl.wire : !firrtl.bundle<x: bundle<a: uint, b: analog>>
+    ; CHECK: %flip2 = firrtl.wire : !firrtl.bundle<x: flip<bundle<a: flip<uint>, b: analog>>>
     wire flip2 : { flip x : { flip a : UInt, b: Analog } }
-    ; CHECK: %flip3 = firrtl.wire : !firrtl.bundle<x: bundle<a: uint, b: analog>>
+    ; CHECK: %flip3 = firrtl.wire : !firrtl.bundle<x: flip<bundle<a: flip<uint>, b: analog>>>
     wire flip3 : { flip x : { flip a : UInt, flip b: Analog } }
-    ; CHECK: %flip4 = firrtl.wire : !firrtl.bundle<x: vector<bundle<a: uint>, 4>>
+    ; CHECK: %flip4 = firrtl.wire : !firrtl.bundle<x: flip<vector<bundle<a: flip<uint>>, 4>>>
     wire flip4 : { flip x : { flip a : UInt }[4] }
 
 
@@ -539,8 +539,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input bf: { flip int_1 : UInt<1>, int_out : UInt<2>}
     ; CHECK: %0 = firrtl.subfield %bf("int_1")
     node _T = bf.int_1
-    ; CHECK: %1 = firrtl.asPassive %0 : !firrtl.flip<uint<1>>
-    when _T :  ; CHECK: firrtl.when %1 {
+    when _T :  ; CHECK: firrtl.when %0 {
       skip
 
   ; CHECK-LABEL: firrtl.module @mem_depth_1
@@ -558,7 +557,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       read-under-write => undefined
       ; CHECK: %bar_MPORT, %bar_io_deq_bits_MPORT = firrtl.mem Undefined {depth = 1 : i64, name = "bar", portNames = ["MPORT", "io_deq_bits_MPORT"], readLatency = 0 : i32, writeLatency = 1 : i32} :
       ; CHECK: !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<3>, mask: uint<1>>>,
-      ; CHECK: !firrtl.bundle<addr: flip<uint<1>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<3>>
+      ; CHECK: !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: flip<uint<3>>>>
 
   ; CHECK-LABEL: firrtl.module @mem_no_ports() {
   ; CHECK-NEXT: }
@@ -700,8 +699,12 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.connect %out0, [[INV]]
     out0 is invalid
 
+    ; CHECK: [[OUT1_A:%.+]] = firrtl.subfield %out1("a")
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
-    ; CHECK: firrtl.connect %out1, [[INV]]
+    ; CHECK: firrtl.connect [[OUT1_A]], [[INV]]
+    ; CHECK: [[OUT1_B:%.+]] = firrtl.subfield %out1("b")
+    ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
+    ; CHECK: firrtl.connect [[OUT1_B]], [[INV]]
     out1 is invalid
 
     ; CHECK: [[OUT2_A:%.+]] = firrtl.subfield %out2("a")
@@ -748,17 +751,18 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
     ; CHECK: firrtl.connect %U0_in0, [[INV]]
+    ; CHECK: [[U0_IN1_A:%.+]] = firrtl.subfield %U0_in1("a")
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
-    ; CHECK: firrtl.connect %U0_in1, [[INV]]
+    ; CHECK: firrtl.connect [[U0_IN1_A]], [[INV]]
     U0 is invalid
 
   ; https://github.com/llvm/circt/issues/606
   ; CHECK-LABEL: firrtl.module @mutableSubIndex606
-  module mutableSubIndex606 : 
+  module mutableSubIndex606 :
     output io : UInt<1>[8]
     ; CHECK:  %0 = firrtl.subindex %io[0] : !firrtl.flip<vector<uint<1>, 8>>
-    ; CHECK: firrtl.connect %0, %c0_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-    io[0] <= UInt<1>("h00") 
+    ; CHECK: firrtl.connect %0, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    io[0] <= UInt<1>("h00")
 
 
   ; https://github.com/llvm/circt/issues/782
@@ -769,7 +773,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input rEn: UInt<1>
     output rData: UInt<8>
 
-    ; CHECK: %mem_r = firrtl.mem Undefined {depth = 16 : i64, name = "mem", portNames = ["r"], readLatency = 2 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: flip<uint<4>>, en: flip<uint<1>>, clk: flip<clock>, data: uint<8>> 
+    ; CHECK: %mem_r = firrtl.mem Undefined {depth = 16 : i64, name = "mem", portNames = ["r"], readLatency = 2 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<uint<8>>>>
     mem mem:
       data-type => UInt<8>
       depth => 16


### PR DESCRIPTION
This removes type canonicalization. Type canonicalization is unable to fully represented FIRRTL semantics of bulk connects and bulk partial connects. (See #919 for more info.)

Roughly this does a number of things:

- [x] Remove type canonicalization.
- [x] Change the bundles used for memory ports.
- [x] Strip flips from `SubfieldOp`.
- [x] Add utilities for computing flow.
- [x] Switch to flow-based verification of `ConnectOp`.
- [x] Disallow outer flips on wires. (Adds a new `UnflippedType`.)
- [x] Switch to flow-based connect lowering in `LowerTypes`.
- [x] Lower `is invalid` to a blown-out connect.
- [x] Fix all the tests that this will break. 😬 
  - [x] Handshake
  - [x] Parsing due to invalidation
- [x] Fix all dependent dialects. 😬 
  - [x] Handshake

I am trying to keep this patch series extremely well organized so that smaller pieces can be pulled out and landed as needed. During review it is fine to ask that this is split up further.