### PR TITLE
[FIRRTL] Fix `is invalid` on duplex types and bundles

### DIFF
--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -107,7 +107,6 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK-NEXT: firrtl.connect %auto, [[INV]] : !firrtl.flip<uint<1>>, !firrtl.uint<1>
     auto is invalid
 
-    ; CHECK: [[INV:%.+]] = firrtl.invalidvalue : !firrtl.uint<1>
     ; CHECK-NOT: firrtl.connect %reset
     reset is invalid
 
@@ -633,20 +632,97 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
 
 
-  ; https://github.com/llvm/circt/issues/563
   module mod_0_563 :
-    input tmp1: UInt<5>
-    output tmp2: UInt<5>
-    tmp2 <= tmp1
+    input in0: UInt<5>
+    input in1: { a : UInt<5> }
+    output out0: UInt<5>
+    output out1: { a : UInt<5> }
+    out0 <= in0
+    out1 <= in1
 
-  ; CHECK-LABEL: firrtl.module @invalidate_entire_instance_563
-  module invalidate_entire_instance_563 :
-    ; CHECK:  %U0_tmp1, %U0_tmp2 = firrtl.instance @mod_0_563
+  ; CHECK-LABEL: firrtl.module @CheckInvalids
+  module CheckInvalids :
+    input in0 : UInt<1>
+    input in1 : { a : UInt<1>, b : UInt<1> }
+    input in2 : { a : UInt<1>, flip b : UInt<1>}
+    input in3 : {a : { b : UInt<1>, flip c : UInt<1>}}
+    output out0 : UInt<1>
+    output out1 : { a : UInt<1>, b : UInt<1> }
+    output out2 : { a : UInt<1>, flip b : UInt<1>}
+    output out3 : {a : { b : UInt<1>, flip c : UInt<1>}}
+
+    ; CHECK-NOT: firrtl.connect %in0
+    in0 is invalid
+
+    ; CHECK-NOT: firrtl.connect %in1
+    in1 is invalid
+
+    ; CHECK: [[IN2_B:%.+]] = firrtl.subfield %in2("b")
+    ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
+    ; CHECK: firrtl.connect [[IN2_B]], [[INV]]
+    in2 is invalid
+
+    ; CHECK: [[IN3_A:%.+]] = firrtl.subfield %in3("a")
+    ; CHECK: [[IN3_A_C:%.+]] = firrtl.subfield [[IN3_A]]("c")
+    ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
+    ; CHECK: firrtl.connect [[IN3_A_C]], [[INV]]
+    in3 is invalid
+
+    ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
+    ; CHECK: firrtl.connect %out0, [[INV]]
+    out0 is invalid
+
+    ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
+    ; CHECK: firrtl.connect %out1, [[INV]]
+    out1 is invalid
+
+    ; CHECK: [[OUT2_A:%.+]] = firrtl.subfield %out2("a")
+    ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
+    ; CHECK: firrtl.connect [[OUT2_A]], [[INV]]
+    out2 is invalid
+
+    ; CHECK: [[OUT3_A:%.+]] = firrtl.subfield %out3("a")
+    ; CHECK: [[OUT3_A_B:%.+]] = firrtl.subfield [[OUT3_A]]("b")
+    ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
+    ; CHECK: firrtl.connect [[OUT3_A_B]], [[INV]]
+    out3 is invalid
+
+    ; CHECK: %wire0 = firrtl.wire
+    ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
+    ; CHECK: firrtl.connect %wire0, [[INV]]
+    wire wire0 : UInt<1>
+    wire0 is invalid
+
+    ; CHECK: %wire1 = firrtl.wire
+    ; CHECK: [[WIRE1_A:%.+]] = firrtl.subfield %wire1("a")
+    ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
+    ; CHECK: firrtl.connect [[WIRE1_A]], [[INV]]
+    ; CHECK: [[WIRE1_B:%.+]] = firrtl.subfield %wire1("b")
+    ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
+    ; CHECK: firrtl.connect [[WIRE1_B]], [[INV]]
+    wire wire1 : {a : UInt<1>, flip b : UInt<1> }
+    wire1 is invalid
+
+    ; An analog in the leaf of a wire should be attached not connected.
+    ; CHECK: %wire2 = firrtl.wire
+    ; CHECK: [[WIRE2_X:%.+]] = firrtl.subfield %wire2("x")
+    ; CHECK: [[WIRE2_X_A:%.+]] = firrtl.subfield [[WIRE2_X]]("a")
+    ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
+    ; CHECK: firrtl.connect [[WIRE2_X_A]], [[INV]]
+    ; CHECK: [[WIRE2_X_B:%.+]] = firrtl.subfield [[WIRE2_X]]("b")
+    ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
+    ; CHECK: firrtl.attach [[WIRE2_X_B]], [[INV]]
+    wire wire2 : {x : {flip a : UInt<1>, flip b: Analog<1> } }
+    wire2 is invalid
+
+    ; https://github.com/llvm/circt/issues/563
+    ; CHECK: %U0_in0, %U0_in1, %U0_out0, %U0_out1 = firrtl.instance @mod_0_563
     inst U0 of mod_0_563
 
-    ; CHECK: %0 = firrtl.invalidvalue : !firrtl.uint<5>
-    ; CHECK: firrtl.connect %U0_tmp1, %0 : !firrtl.flip<uint<5>>, !firrtl.uint<5>
-    ; CHECK: %1 = firrtl.invalidvalue : !firrtl.uint<5>
+    ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
+    ; CHECK: firrtl.connect %U0_in0, [[INV]]
+    ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
+    ; CHECK: firrtl.connect %U0_in1, [[INV]]
     U0 is invalid
 
   ; https://github.com/llvm/circt/issues/606

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -96,8 +96,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK-NEXT: firrtl.connect %auto, [[INV]] : !firrtl.flip<uint<1>>, !firrtl.uint<1>
     auto is invalid
 
-    ; CHECK: [[INV:%.+]] = firrtl.invalidvalue : !firrtl.analog<1>
-    ; CHECK-NEXT: firrtl.attach %a1, [[INV]] : !firrtl.analog<1>, !firrtl.analog<1>
+    ; CHECK-NOT: firrtl.attach %a1
     a1 is invalid
 
     ; CHECK: firrtl.skip
@@ -710,8 +709,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
     ; CHECK: firrtl.connect [[WIRE2_X_A]], [[INV]]
     ; CHECK: [[WIRE2_X_B:%.+]] = firrtl.subfield [[WIRE2_X]]("b")
-    ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
-    ; CHECK: firrtl.attach [[WIRE2_X_B]], [[INV]]
+    ; CHECK-NOT: firrtl.attach [[WIRE2_X_B]], [[INV]]
     wire wire2 : {x : {flip a : UInt<1>, flip b: Analog<1> } }
     wire2 is invalid
 


### PR DESCRIPTION
When attached to bundle values, `is invalid` recurses through the bundle
and connects invalid to any flipped field.  When the bundle value is a
register or wire, it should connect invalid to every field, regardless
of the flippedness of that field.  Invalid was not properly recursing or
handling wire types, and this change fixes that.

Due to the way `is invalid` treats wires differently than other values,
we cannot simply bulk connect a bundle typed `invalid`, and let expand
connects handle this later.