### PR TITLE
[FIRRTL] Make MemOp accessors less pessimistic

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -100,11 +100,11 @@ def MemOp : FIRRTLOp<"mem", [/*MemAlloc*/]> {
     /// Return the name and kind of ports supported by this memory.
     SmallVector<std::pair<Identifier, PortKind>> getPorts();
 
-    /// Return the kind of the specified port or None if the name is invalid.
-    Optional<PortKind> getPortKind(StringRef portName);
+    /// Return the kind of the specified port.
+    PortKind getPortKind(StringRef portName);
 
-    /// Return the kind of the specified port number
-    Optional<PortKind> getPortKind(size_t resultNo);
+    /// Return the kind of the specified port number.
+    PortKind getPortKind(size_t resultNo);
 
     /// Return the data-type field of the memory, the type of each element.
     FIRRTLType getDataType();

--- a/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
+++ b/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
@@ -156,7 +156,7 @@ static FirMemory analyzeMemOp(MemOp op) {
   size_t numReadWritePorts = 0;
 
   for (size_t i = 0, e = op.getNumResults(); i != e; ++i) {
-    auto portKind = *op.getPortKind(i);
+    auto portKind = op.getPortKind(i);
     if (portKind == MemOp::PortKind::Read)
       ++numReadPorts;
     else if (portKind == MemOp::PortKind::Write)
@@ -1732,7 +1732,7 @@ LogicalResult FIRRTLLowering::visitDecl(MemOp op) {
   // two layers of type to split appart.
   for (size_t i = 0, e = op.getNumResults(); i != e; ++i) {
     auto portName = op.getPortName(i).getValue();
-    auto portKind = *op.getPortKind(i);
+    auto portKind = op.getPortKind(i);
 
     auto &portKindNum =
         portKind == MemOp::PortKind::Read

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -695,15 +695,33 @@ static LogicalResult verifyMemOp(MemOp mem) {
     // in the type (but we don't know any more just yet).
     MemOp::PortKind portKind;
     {
-      auto portKindOption =
-          mem.getPortKind(mem.getPortName(i).getValue().str());
-      if (!portKindOption.hasValue()) {
+      auto elt = mem.getPortNamed(portName);
+      if (!elt) {
+        mem.emitOpError() << "could not get port with name " << portName;
+        return failure();
+      }
+      auto firrtlType = elt.getType().cast<FIRRTLType>();
+      auto portType = firrtlType.dyn_cast<BundleType>();
+      if (!portType) {
+        if (auto flipType = firrtlType.dyn_cast<FlipType>())
+          portType = flipType.getElementType().dyn_cast<BundleType>();
+      }
+      switch (portType.getNumElements()) {
+      case 4:
+        portKind = MemOp::PortKind::Read;
+        break;
+      case 5:
+        portKind = MemOp::PortKind::Write;
+        break;
+      case 7:
+        portKind = MemOp::PortKind::ReadWrite;
+        break;
+      default:
         mem.emitOpError()
             << "has an invalid number of fields on port " << portName
             << " (expected 4 for read, 5 for write, or 7 for read/write)";
         return failure();
       }
-      portKind = portKindOption.getValue();
     }
 
     // Safely search for the "data" field, erroring if it can't be
@@ -821,22 +839,18 @@ BundleType MemOp::getTypeForPort(uint64_t depth, FIRRTLType dataType,
 }
 
 /// Return the kind of port this is given the port type from a 'mem' decl.
-static Optional<MemOp::PortKind> getMemPortKindFromType(FIRRTLType type) {
+static MemOp::PortKind getMemPortKindFromType(FIRRTLType type) {
   auto portType = type.dyn_cast<BundleType>();
   if (!portType) {
     if (auto flipType = type.dyn_cast<FlipType>())
       portType = flipType.getElementType().dyn_cast<BundleType>();
-    if (!portType)
-      return None;
   }
   switch (portType.getNumElements()) {
-  default:
-    return None;
   case 4:
     return MemOp::PortKind::Read;
   case 5:
     return MemOp::PortKind::Write;
-  case 7:
+  default:
     return MemOp::PortKind::ReadWrite;
   }
 }
@@ -848,24 +862,21 @@ SmallVector<std::pair<Identifier, MemOp::PortKind>> MemOp::getPorts() {
   for (size_t i = 0, e = getNumResults(); i != e; ++i) {
     auto elt = getResult(i);
     // Each port is a bundle.
-    auto kind = getMemPortKindFromType(elt.getType().cast<FIRRTLType>());
-    assert(kind.hasValue() && "unknown port type!");
-    result.push_back({Identifier::get(getPortNameStr(i), elt.getContext()),
-                      kind.getValue()});
+    result.push_back(
+        {Identifier::get(getPortNameStr(i), elt.getContext()),
+         getMemPortKindFromType(elt.getType().cast<FIRRTLType>())});
   }
   return result;
 }
 
-/// Return the kind of the specified port or None if the name is invalid.
-Optional<MemOp::PortKind> MemOp::getPortKind(StringRef portName) {
-  auto elt = getPortNamed(portName);
-  if (!elt)
-    return None;
-  return getMemPortKindFromType(elt.getType().cast<FIRRTLType>());
+/// Return the kind of the specified port.
+MemOp::PortKind MemOp::getPortKind(StringRef portName) {
+  return getMemPortKindFromType(
+      getPortNamed(portName).getType().cast<FIRRTLType>());
 }
 
 /// Return the kind of the specified port number.
-Optional<MemOp::PortKind> MemOp::getPortKind(size_t resultNo) {
+MemOp::PortKind MemOp::getPortKind(size_t resultNo) {
   return getMemPortKindFromType(
       getResult(resultNo).getType().cast<FIRRTLType>());
 }
@@ -877,7 +888,7 @@ FIRRTLType MemOp::getDataType() {
   auto firstPortType = getResult(0).getType().cast<FIRRTLType>();
 
   StringRef dataFieldName = "data";
-  if (getMemPortKindFromType(firstPortType).getValue() == PortKind::ReadWrite)
+  if (getMemPortKindFromType(firstPortType) == PortKind::ReadWrite)
     dataFieldName = "rdata";
 
   return firstPortType.getPassiveType().cast<BundleType>().getElementType(

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -380,7 +380,7 @@ void TypeLoweringVisitor::visitDecl(MemOp op) {
     resultPortTypes.clear();
     resultPortNames.clear();
     for (size_t i = 0, e = op.getNumResults(); i != e; ++i) {
-      auto kind = op.getPortKind(i).getValue();
+      auto kind = op.getPortKind(i);
       auto name = op.getPortName(i);
 
       // Any read or write ports are just added.
@@ -426,9 +426,8 @@ void TypeLoweringVisitor::visitDecl(MemOp op) {
                                   .getPassiveType()
                                   .cast<BundleType>();
 
-      auto kind =
-          newMem.getPortKind(newMem.getPortName(i).getValue()).getValue();
-      auto oldKind = op.getPortKind(op.getPortName(j).getValue()).getValue();
+      auto kind = newMem.getPortKind(newMem.getPortName(i).getValue());
+      auto oldKind = op.getPortKind(op.getPortName(j).getValue());
 
       auto skip = kind == MemOp::PortKind::Write &&
                   oldKind == MemOp::PortKind::ReadWrite;


### PR DESCRIPTION
Removes a variety of asserts and Optional returns in MemOp accessors as
data is already checked during validation.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #664 