### PR TITLE
[NFC] Re-enable Python format check, and don't fail when no changes.

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -250,10 +250,12 @@ jobs:
 
       # Run yapf to check Python formatting.
       - name: python-format
-        if: ${{ false }}
+        if: ${{ always() }}
         run: |
-          files=$(git diff --name-only $DIFF_COMMIT | grep .py)
-          yapf --diff $files
+          files=$(git diff --name-only $DIFF_COMMIT | grep .py || echo -n)
+          if [[ ! -z $files ]]; then
+            yapf --diff $files
+          fi
 
       # Upload the format and tidy patches to an artifact (zip'd) associated
       # with the workflow run. Only run this on a failure.

--- a/lib/Bindings/Python/circt/__init__.py
+++ b/lib/Bindings/Python/circt/__init__.py
@@ -3,4 +3,4 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # Simply a wrapper around the extension module of the same name.
-from  _circt import *
+from _circt import *

--- a/lib/Bindings/Python/circt/__init__.py
+++ b/lib/Bindings/Python/circt/__init__.py
@@ -3,4 +3,4 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # Simply a wrapper around the extension module of the same name.
-from _circt import *
+from  _circt import *


### PR DESCRIPTION
The intent of the check was to only run yapf on the files that
changed, but if no Python files changed, the grep command returns 1
and fails the check. In that case, return an empty list of files, and
check for that.