### PR TITLE
[FIRRTL] Nodes shouldn't be no side effect.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -67,8 +67,8 @@ def MuxSameCondHigh : Pat<
 
 // node(x, name, {}) -> x
 def EmptyNode : Pat<
-  (NodeOp $x, $name, $attrs),
+  (NodeOp $x, $name, $annotations),
   (replaceWithValue $x),
-  [(EmptyAttrDict $attrs)]>;
+  [(EmptyAttrDict $annotations)]>;
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLCANONICALIZATION_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -127,7 +127,7 @@ def MemOp : FIRRTLOp<"mem", [/*MemAlloc*/]> {
   }];
 }
 
-def NodeOp : FIRRTLOp<"node", [NoSideEffect, SameOperandsAndResultType]> {
+def NodeOp : FIRRTLOp<"node", [SameOperandsAndResultType]> {
   let summary = "No-op to name a value";
   let description = [{
     A node is simply a named intermediate value in a circuit. The node must

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -1373,9 +1373,10 @@ firrtl.module @MuxCanon(%c1: !firrtl.uint<1>, %c2: !firrtl.uint<1>, %d1: !firrtl
 
 // CHECK-LABEL: firrtl.module @EmptyNode
 firrtl.module @EmptyNode(%d1: !firrtl.uint<5>, %foo: !firrtl.flip<uint<5>>, %foo2: !firrtl.flip<uint<5>>) {
-  %bar = firrtl.node %d1  : !firrtl.uint<5>
-  %bar2 = firrtl.node %d1 {annotations = [{extrastuff = "n1"}]}  : !firrtl.uint<5>
-  firrtl.connect %foo, %bar : !firrtl.flip<uint<5>>, !firrtl.uint<5>
+  %bar0 = firrtl.node %d1 : !firrtl.uint<5>
+  %bar1 = firrtl.node %d1 : !firrtl.uint<5>
+  %bar2 = firrtl.node %d1 {annotations = [{extrastuff = "n1"}]} : !firrtl.uint<5>
+  firrtl.connect %foo, %bar1 : !firrtl.flip<uint<5>>, !firrtl.uint<5>
   firrtl.connect %foo2, %bar2 : !firrtl.flip<uint<5>>, !firrtl.uint<5>
 }
 // CHECK-NEXT: %bar2 = firrtl.node %d1 {annotations = [{extrastuff = "n1"}]}


### PR DESCRIPTION
Nodes, especially those marked with DontTouch, can't be removed by dead
code elimination.  Some tools will expect them in the final output.
There is already a canonicalization to remove a node if it has an empty
annotation list, and it should be able to handle this case as well.

This change removes the NoSideEffect trait from the node operation.