### PR TITLE
[SV] Do not remove dead wires

### DIFF
--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -48,7 +48,6 @@ def WireOp : SVOp<"wire", [DeclareOpInterfaceMethods<OpAsmOpInterface>,
   ];
 
   let assemblyFormat = "custom<ImplicitSSAName>(attr-dict) `:` type($result)";
-  let hasCanonicalizeMethod = true;
 
   let extraClassDeclaration = [{
     Type getElementType() {

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -812,23 +812,6 @@ void WireOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
     setNameFn(getResult(), nameAttr.getValue());
 }
 
-// If this wire is only written to, delete the wire and all writers.
-LogicalResult WireOp::canonicalize(WireOp op, PatternRewriter &rewriter) {
-  // Check that all operations on the wire are sv.connects. All other wire
-  // operations will have been handled by other canonicalization.
-  for (auto &use : op.getResult().getUses())
-    if (!isa<ConnectOp>(use.getOwner()))
-      return failure();
-
-  // Remove all uses of the wire.
-  for (auto &use : make_early_inc_range(op.getResult().getUses()))
-    rewriter.eraseOp(use.getOwner());
-
-  // Remove the wire.
-  rewriter.eraseOp(op);
-  return success();
-}
-
 /// Ensure that the symbol being instantiated exists and is an InterfaceOp.
 static LogicalResult verifyWireOp(WireOp op) {
   if (!isa<rtl::RTLModuleOp>(op->getParentOp()))

--- a/test/Dialect/RTL/canonicalization.mlir
+++ b/test/Dialect/RTL/canonicalization.mlir
@@ -549,54 +549,6 @@ rtl.module @concat_fold6(%arg0: i5, %arg1: i3) -> (i4) {
   rtl.output %2 : i4
 }
 
-// CHECK-LABEL: rtl.module @wire0()
-// CHECK-NEXT:    rtl.output
-rtl.module @wire0() {
-  %w = sv.wire : !rtl.inout<i1>
-  rtl.output
-}
-
-// CHECK-LABEL: rtl.module @wire1()
-// CHECK-NEXT:    rtl.output
-rtl.module @wire1() {
-  %w = sv.wire : !rtl.inout<i1>
-  %0 = sv.read_inout %w : !rtl.inout<i1>
-  rtl.output
-}
-
-// CHECK-LABEL: rtl.module @wire2()
-// CHECK-NEXT:    rtl.output
-rtl.module @wire2() {
-  %c = rtl.constant 1 : i1
-  %w = sv.wire : !rtl.inout<i1>
-  sv.connect %w, %c : i1
-  rtl.output
-}
-
-// CHECK-LABEL: rtl.module @wire3()
-// CHECK-NEXT:    rtl.output
-rtl.module @wire3() {
-  %c = rtl.constant 1 : i1
-  %w = sv.wire : !rtl.inout<i1>
-  %0 = sv.read_inout %w : !rtl.inout<i1>
-  sv.connect %w, %c :i1
-  rtl.output
-}
-
-// CHECK-LABEL: rtl.module @wire4() -> (i1)
-// CHECK-NEXT:    %true = rtl.constant true
-// CHECK-NEXT:    %w = sv.wire : !rtl.inout<i1>
-// CHECK-NEXT:    %0 = sv.read_inout %w : !rtl.inout<i1>
-// CHECK-NEXT:    sv.connect %w, %true : i1
-// CHECK-NEXT:    rtl.output %0
-rtl.module @wire4() -> (i1) {
-  %true = rtl.constant true
-  %w = sv.wire : !rtl.inout<i1>
-  %0 = sv.read_inout %w : !rtl.inout<i1>
-  sv.connect %w, %true : i1
-  rtl.output %0 : i1
-}
-
 // CHECK-LABEL: rtl.module @mux_fold0(%arg0: i3, %arg1: i3)
 // CHECK-NEXT:    rtl.output %arg0 : i3
 rtl.module @mux_fold0(%arg0: i3, %arg1: i3) -> (i3) {


### PR DESCRIPTION
We have a canonicalization which removes SV wires without any readers.
This is not a legal optimization as wires are considered public and
other tooling may be expecting these wires in the final output.  This
change removes the canonicalization responsible for removing the wire.
This is a useful idea, and we will be revisiting this optimization when
there is a concept of public vs private wires in the RTL dialect.