### PR TITLE
[ExportVerilog] Add file list output

### DIFF
--- a/include/circt/Translation/ExportVerilog.h
+++ b/include/circt/Translation/ExportVerilog.h
@@ -34,12 +34,9 @@ mlir::LogicalResult exportVerilog(mlir::ModuleOp module, llvm::raw_ostream &os);
 /// Export a module containing RTL, and SV dialect code, as one file per SV
 /// module. Requires that the SV dialect is loaded in to the context.
 ///
-/// Files are created in the directory indicated by \p dirname. The function
-/// \p emittedFile is called for every emitted file, in the order appropriate
-/// given the input MLIR module.
-mlir::LogicalResult
-exportSplitVerilog(mlir::ModuleOp module, llvm::StringRef dirname,
-                   std::function<void(llvm::StringRef)> emittedFile);
+/// Files are created in the directory indicated by \p dirname.
+mlir::LogicalResult exportSplitVerilog(mlir::ModuleOp module,
+                                       llvm::StringRef dirname);
 
 /// Register a translation for exporting RTL, Comb and SV to SystemVerilog.
 void registerToVerilogTranslation();

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -2899,18 +2899,17 @@ void SplitEmitter::emitMLIRModule() {
   // separate output files, and the remaining top-level verbatim SV/ifdef
   // business that needs to go into each file.
   for (auto &op : *rootOp.getBody()) {
-    if (isa<RTLModuleOp>(op) || isa<InterfaceOp>(op)) {
-      moduleOps.push_back({&op, perFileOps.size(), /*filename=*/{}});
-    } else if (isa<VerbatimOp>(op) || isa<IfDefProceduralOp>(op)) {
-      perFileOps.push_back(&op);
-    } else if (isa<RTLGeneratorSchemaOp>(op)) {
-      /* Empty */
-    } else if (isa<RTLModuleExternOp>(op)) {
-      // ignore extern modules for split Verilog emission
-    } else {
-      op.emitError("unknown operation");
-      encounteredError = true;
-    }
+    TypeSwitch<Operation *>(&op)
+        .Case<RTLModuleOp, InterfaceOp>([&](auto &) {
+          moduleOps.push_back({&op, perFileOps.size()});
+        })
+        .Case<VerbatimOp, IfDefProceduralOp>(
+            [&](auto &) { perFileOps.push_back(&op); })
+        .Case<RTLGeneratorSchemaOp, RTLModuleExternOp>([&](auto &) {})
+        .Default([&](auto *) {
+          op.emitError("unknown operation");
+          encounteredError = true;
+        });
   }
 
   // In parallel, emit each module into its separate file, embedded within the
@@ -2984,16 +2983,26 @@ LogicalResult circt::exportVerilog(ModuleOp module, llvm::raw_ostream &os) {
   return failure(emitter.encounteredError);
 }
 
-LogicalResult
-circt::exportSplitVerilog(ModuleOp module, StringRef dirname,
-                          std::function<void(llvm::StringRef)> emittedFile) {
+LogicalResult circt::exportSplitVerilog(ModuleOp module, StringRef dirname) {
   SplitEmitter emitter(dirname, module);
   emitter.emitMLIRModule();
-  if (emittedFile) {
-    for (auto mod : std::move(emitter.moduleOps)) {
-      emittedFile(mod.filename);
-    }
+
+  // Write the file list.
+  SmallString<128> filelistPath(dirname);
+  llvm::sys::path::append(filelistPath, "filelist.f");
+
+  std::string errorMessage;
+  auto output = mlir::openOutputFile(filelistPath, &errorMessage);
+  if (!output) {
+    module->emitError(errorMessage);
+    return failure();
   }
+
+  for (auto mod : std::move(emitter.moduleOps)) {
+    output->os() << mod.filename << "\n";
+  }
+  output->keep();
+
   return failure(emitter.encounteredError);
 }
 

--- a/test/firtool/split-verilog.mlir
+++ b/test/firtool/split-verilog.mlir
@@ -1,9 +1,11 @@
 // RUN: firtool %s --format=mlir -verilog | FileCheck %s --check-prefix=VERILOG
-// RUN: firtool %s --format=mlir -split-verilog -o=%t | FileCheck %s --check-prefix=FIRTOOL
-// RUN: FileCheck %s --check-prefix=VERILOG-FOO < %t/foo.v
-// RUN: FileCheck %s --check-prefix=VERILOG-BAR < %t/bar.v
-// RUN: FileCheck %s --check-prefix=VERILOG-USB < %t/usb.v
-// RUN: FileCheck %s --check-prefix=VERILOG-INOUT-3 < %t/inout_3.v
+// RUN: rm -rf %t
+// RUN: firtool %s --format=mlir -split-verilog -o=%t
+// RUN: FileCheck %s --check-prefix=VERILOG-FOO < %t/foo.sv
+// RUN: FileCheck %s --check-prefix=VERILOG-BAR < %t/bar.sv
+// RUN: FileCheck %s --check-prefix=VERILOG-USB < %t/usb.sv
+// RUN: FileCheck %s --check-prefix=VERILOG-INOUT-3 < %t/inout_3.sv
+// RUN: FileCheck %s --check-prefix=LIST < %t/filelist.f
 
 sv.verbatim "// I'm everywhere"
 sv.ifdef.procedural "VERILATOR" {
@@ -35,10 +37,10 @@ rtl.module.extern @inout_0 () -> ()
 rtl.module.extern @inout_1 () -> ()
 rtl.module.extern @inout_2 () -> ()
 
-// FIRTOOL:      foo.v
-// FIRTOOL-NEXT: bar.v
-// FIRTOOL-NEXT: usb.v
-// FIRTOOL-NEXT: inout_3.v
+// LIST:      foo.sv
+// LIST-NEXT: bar.sv
+// LIST-NEXT: usb.sv
+// LIST-NEXT: inout_3.sv
 
 // VERILOG-FOO:       // I'm everywhere
 // VERILOG-FOO-NEXT:  `ifdef VERILATOR

--- a/test/firtool/split-verilog.mlir
+++ b/test/firtool/split-verilog.mlir
@@ -1,13 +1,9 @@
 // RUN: firtool %s --format=mlir -verilog | FileCheck %s --check-prefix=VERILOG
 // RUN: firtool %s --format=mlir -split-verilog -o=%t | FileCheck %s --check-prefix=FIRTOOL
-// RUN: FileCheck %s --check-prefix=VERILOG-FOO < %t/foo.sv
-// RUN: FileCheck %s --check-prefix=VERILOG-BAR < %t/bar.sv
-// RUN: FileCheck %s --check-prefix=VERILOG-USB < %t/usb.sv
-// RUN: FileCheck %s --check-prefix=VERILOG-PLL < %t/pll.sv
-// RUN: FileCheck %s --check-prefix=VERILOG-INOUT-3 < %t/inout_3.sv
-// RUN: FileCheck %s --check-prefix=VERILOG-INOUT-0 < %t/inout_0.sv
-// RUN: FileCheck %s --check-prefix=VERILOG-INOUT-1 < %t/inout_1.sv
-// RUN: FileCheck %s --check-prefix=VERILOG-INOUT-2 < %t/inout_2.sv
+// RUN: FileCheck %s --check-prefix=VERILOG-FOO < %t/foo.v
+// RUN: FileCheck %s --check-prefix=VERILOG-BAR < %t/bar.v
+// RUN: FileCheck %s --check-prefix=VERILOG-USB < %t/usb.v
+// RUN: FileCheck %s --check-prefix=VERILOG-INOUT-3 < %t/inout_3.v
 
 sv.verbatim "// I'm everywhere"
 sv.ifdef.procedural "VERILATOR" {
@@ -39,14 +35,10 @@ rtl.module.extern @inout_0 () -> ()
 rtl.module.extern @inout_1 () -> ()
 rtl.module.extern @inout_2 () -> ()
 
-// FIRTOOL:      foo.sv
-// FIRTOOL-NEXT: bar.sv
-// FIRTOOL-NEXT: usb.sv
-// FIRTOOL-NEXT: pll.sv
-// FIRTOOL-NEXT: inout_3.sv
-// FIRTOOL-NEXT: inout_0.sv
-// FIRTOOL-NEXT: inout_1.sv
-// FIRTOOL-NEXT: inout_2.sv
+// FIRTOOL:      foo.v
+// FIRTOOL-NEXT: bar.v
+// FIRTOOL-NEXT: usb.v
+// FIRTOOL-NEXT: inout_3.v
 
 // VERILOG-FOO:       // I'm everywhere
 // VERILOG-FOO-NEXT:  `ifdef VERILATOR
@@ -75,14 +67,6 @@ rtl.module.extern @inout_2 () -> ()
 // VERILOG-USB-LABEL: interface usb;
 // VERILOG-USB:       endinterface
 
-// VERILOG-PLL:        // I'm everywhere
-// VERILOG-PLL-NEXT:   `ifdef VERILATOR
-// VERILOG-PLL-NEXT:     // Hello
-// VERILOG-PLL-NEXT:   `else
-// VERILOG-PLL-NEXT:     // World
-// VERILOG-PLL-NEXT:   `endif
-// VERILOG-PLL:        // external module pll
-
 // VERILOG-INOUT-3:       // I'm everywhere
 // VERILOG-INOUT-3-NEXT:  `ifdef VERILATOR
 // VERILOG-INOUT-3-NEXT:    // Hello
@@ -91,11 +75,6 @@ rtl.module.extern @inout_2 () -> ()
 // VERILOG-INOUT-3-NEXT:  `endif
 // VERILOG-INOUT-3-LABEL: module inout_3(
 // VERILOG-INOUT-3:       endmodule
-
-// VERILOG-INOUT-0:    // external module inout_0
-// VERILOG-INOUT-1:    // external module inout_1
-// VERILOG-INOUT-2:    // external module inout_2
-
 
 // VERILOG:       // I'm everywhere
 // VERILOG-NEXT:  `ifdef VERILATOR

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -268,9 +268,7 @@ processBufferIntoMultipleFiles(std::unique_ptr<llvm::MemoryBuffer> ownedBuffer,
         case OutputVerilog:
           llvm_unreachable("single-stream format must be handled elsewhere");
         case OutputSplitVerilog:
-          return exportSplitVerilog(
-              module.get(), outputDirectory,
-              [](StringRef filename) { llvm::outs() << filename << "\n"; });
+          return exportSplitVerilog(module.get(), outputDirectory);
         }
         llvm_unreachable("unknown output format");
       });


### PR DESCRIPTION
This PR does the following:

* Rather than printing the list of emitted files to standard output, generate a dedicated `filelist.f` file for split Verilog output with one line for each emitted file.
* Stop generating stub files for external modules when split Verilog output is enabled. This collides with black box annotations supplying the actual files to be included for external modules.

Factored out of #918.