### PR TITLE
[SV] Add back dead wire optimization

### DIFF
--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -48,6 +48,7 @@ def WireOp : SVOp<"wire", [DeclareOpInterfaceMethods<OpAsmOpInterface>,
   ];
 
   let assemblyFormat = "custom<ImplicitSSAName>(attr-dict) `:` type($result)";
+  let hasCanonicalizeMethod = true;
 
   let extraClassDeclaration = [{
     Type getElementType() {

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -812,6 +812,27 @@ void WireOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
     setNameFn(getResult(), nameAttr.getValue());
 }
 
+// If this wire is only written to, delete the wire and all writers.
+LogicalResult WireOp::canonicalize(WireOp op, PatternRewriter &rewriter) {
+  // If the wire is named, then we can't delete it.
+  if (!op.name().empty())
+    return failure();
+
+  // Check that all operations on the wire are sv.connects. All other wire
+  // operations will have been handled by other canonicalization.
+  for (auto &use : op.getResult().getUses())
+    if (!isa<ConnectOp>(use.getOwner()))
+      return failure();
+
+  // Remove all uses of the wire.
+  for (auto &use : make_early_inc_range(op.getResult().getUses()))
+    rewriter.eraseOp(use.getOwner());
+
+  // Remove the wire.
+  rewriter.eraseOp(op);
+  return success();
+}
+
 /// Ensure that the symbol being instantiated exists and is an InterfaceOp.
 static LogicalResult verifyWireOp(WireOp op) {
   if (!isa<rtl::RTLModuleOp>(op->getParentOp()))

--- a/test/Dialect/RTL/canonicalization.mlir
+++ b/test/Dialect/RTL/canonicalization.mlir
@@ -871,3 +871,58 @@ rtl.module @sext_and_one_bit(%bit: i1) -> (%a: i65, %b: i8, %c: i8) {
   rtl.output %1, %3, %4 : i65, i8, i8
 }
 
+// CHECK-LABEL: rtl.module @wire0()
+// CHECK-NEXT:    rtl.output
+rtl.module @wire0() {
+  %0 = sv.wire : !rtl.inout<i1>
+  rtl.output
+}
+
+// CHECK-LABEL: rtl.module @wire1()
+// CHECK-NEXT:    rtl.output
+rtl.module @wire1() {
+  %0 = sv.wire : !rtl.inout<i1>
+  %1 = sv.read_inout %0 : !rtl.inout<i1>
+  rtl.output
+}
+
+// CHECK-LABEL: rtl.module @wire2()
+// CHECK-NEXT:    rtl.output
+rtl.module @wire2() {
+  %c = rtl.constant 1 : i1
+  %0 = sv.wire : !rtl.inout<i1>
+  sv.connect %0, %c : i1
+  rtl.output
+}
+
+// CHECK-LABEL: rtl.module @wire3()
+// CHECK-NEXT:    rtl.output
+rtl.module @wire3() {
+  %c = rtl.constant 1 : i1
+  %0 = sv.wire : !rtl.inout<i1>
+  %1 = sv.read_inout %0 : !rtl.inout<i1>
+  sv.connect %0, %c :i1
+  rtl.output
+}
+
+// CHECK-LABEL: rtl.module @wire4() -> (i1)
+// CHECK-NEXT:   %true = rtl.constant true
+// CHECK-NEXT:   %0 = sv.wire  : !rtl.inout<i1>
+// CHECK-NEXT:   %1 = sv.read_inout %0 : !rtl.inout<i1>
+// CHECK-NEXT:   sv.connect %0, %true : i1
+// CHECK-NEXT:   rtl.output %1 : i1
+rtl.module @wire4() -> (i1) {
+  %true = rtl.constant true
+  %0 = sv.wire : !rtl.inout<i1>
+  %1 = sv.read_inout %0 : !rtl.inout<i1>
+  sv.connect %0, %true : i1
+  rtl.output %1 : i1
+}
+
+// CHECK-LABEL: rtl.module @wire5()
+// CHECK-NEXT:   %wire_with_name = sv.wire  : !rtl.inout<i1>
+// CHECK-NEXT:   rtl.output
+rtl.module @wire5() -> () {
+  %wire_with_name = sv.wire : !rtl.inout<i1>
+  rtl.output
+}


### PR DESCRIPTION
This adds back the wire optimization removed in fbe9df0b4 (#950), with
an added constraint that we can't remove a wire if it has a name.