### PR TITLE
[FIRRTL] Make MemoryPort name non-optional

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -75,7 +75,7 @@ def MemoryPortOp : FIRRTLOp<"memoryport"> {
   let summary = "Access a memory";
 
   let arguments = (ins FIRRTLType:$memory, IntType:$index, ClockType:$clock,
-                    MemDirAttr:$direction, OptionalAttr<StrAttr>:$name,
+                    MemDirAttr:$direction, StrAttr:$name,
                     DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations);
   let results = (outs FIRRTLType:$result);
 

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1826,9 +1826,9 @@ ParseResult FIRStmtParser::parseMemPort(MemDirAttr direction) {
   getAnnotations(getModuleTarget() + ">" + id, annotations);
   auto name = hasDontTouch(annotations) ? id : filterUselessName(id);
 
-  auto result = builder.create<MemoryPortOp>(
-      info.getLoc(), resultType, memory, indexExp, clock, direction,
-      builder.getStringAttr(name), annotations);
+  auto result =
+      builder.create<MemoryPortOp>(info.getLoc(), resultType, memory, indexExp,
+                                   clock, direction, name, annotations);
 
   // TODO(firrtl scala bug): If the next operation is a skip, just eat it if it
   // is at the same indent level as us.  This is a horrible hack on top of the


### PR DESCRIPTION
This follows the current convention of representing non-existent names
as an empty string instead of an optional attribute.  This makes
MemoryPort easier to work with and generates better builders.