### PR TITLE
[ESI] Add NullSourceOp to model source which never produces messages

### DIFF
--- a/include/circt/Dialect/ESI/ESIOps.td
+++ b/include/circt/Dialect/ESI/ESIOps.td
@@ -120,3 +120,12 @@ def CapnpEncode : ESI_Physical_Op<"encode.capnp", [NoSideEffect]> {
     $clk $valid $dataToEncode attr-dict `:` type($dataToEncode) `->` type($capnpBits)
   }];
 }
+
+def NullSourceOp : ESI_Physical_Op<"null", [NoSideEffect]> {
+  let summary = "An op which never produces messages.";
+
+  let arguments = (ins);
+  let results = (outs ChannelType:$out);
+
+  let assemblyFormat = [{ attr-dict `:` type($out) }];
+}

--- a/test/Dialect/ESI/connectivity.mlir
+++ b/test/Dialect/ESI/connectivity.mlir
@@ -40,6 +40,11 @@ rtl.module @test(%clk: i1, %rstn: i1) {
   // CHECK-NEXT:  %sender.x_0 = rtl.instance "sender" @Sender()  : () -> !esi.channel<i1>
   // CHECK-NEXT:  %1 = esi.buffer %clk, %rstn, %sender.x_0 {stages = 4 : i64} : i1
   // CHECK-NEXT:  rtl.instance "recv" @Reciever(%1)  : (!esi.channel<i1>) -> ()
+
+  %nullBit = esi.null : !esi.channel<i1>
+  rtl.instance "nullRcvr" @Reciever(%nullBit) : (!esi.channel<i1>) -> ()
+  // CHECK-NEXT:  [[NULLI1:%.+]] = esi.null : !esi.channel<i1>
+  // CHECK-NEXT:  rtl.instance "nullRcvr" @Reciever([[NULLI1]]) : (!esi.channel<i1>) -> ()
 }
 
 rtl.module.extern @IFaceSender(!sv.modport<@IData::@Source>) -> ()

--- a/test/Dialect/ESI/lowering.mlir
+++ b/test/Dialect/ESI/lowering.mlir
@@ -64,7 +64,7 @@ rtl.module @add11(%clk: i1, %ints: !esi.channel<i32>) -> (%mutatedInts: !esi.cha
   %c4 = rtl.constant 0 : i4
   rtl.output %mutInts, %c4 : !esi.channel<i32>, i4
 }
-// RTL: rtl.module @add11(%clk: i1, %ints: i32, %ints_valid: i1, %mutatedInts_ready: i1) -> (%mutatedInts: i32, %mutatedInts_valid: i1, %c4: i4, %ints_ready: i1) {
+// RTL-LABEL: rtl.module @add11(%clk: i1, %ints: i32, %ints_valid: i1, %mutatedInts_ready: i1) -> (%mutatedInts: i32, %mutatedInts_valid: i1, %c4: i4, %ints_ready: i1) {
 // RTL:   %{{.+}} = rtl.constant 11 : i32
 // RTL:   [[RES0:%.+]] = comb.add %{{.+}}, %ints : i32
 // RTL:   %{{.+}} = rtl.constant 0 : i4
@@ -74,15 +74,28 @@ rtl.module @InternRcvr(%in: !esi.channel<!rtl.array<4xi8>>) -> () {}
 
 rtl.module @test2(%clk:i1, %rstn:i1) {
   %ints, %c4 = rtl.instance "adder" @add11(%clk, %ints) : (i1, !esi.channel<i32>) -> (!esi.channel<i32>, i4)
+
+  %nullBit = esi.null : !esi.channel<i4>
+  rtl.instance "nullRcvr" @Reciever(%nullBit, %clk) : (!esi.channel<i4>, i1) -> ()
+
+  %nullArray = esi.null : !esi.channel<!rtl.array<4xi8>>
+  rtl.instance "nullInternRcvr" @InternRcvr(%nullArray) : (!esi.channel<!rtl.array<4xi8>>) -> ()
 }
-// RTL: rtl.module @test2(%clk: i1, %rstn: i1) {
+// RTL-LABEL: rtl.module @test2(%clk: i1, %rstn: i1) {
 // RTL:   %adder.mutatedInts, %adder.mutatedInts_valid, %adder.c4, %adder.ints_ready = rtl.instance "adder" @add11(%clk, %adder.mutatedInts, %adder.mutatedInts_valid, %adder.ints_ready)
+// RTL:   [[ZERO:%.+]] = rtl.bitcast %c0_i4 : (i4) -> i4
+// RTL:   sv.interface.signal.assign %1(@IValidReady_i4::@data) = [[ZERO]] : i4
+// RTL:   [[ZM:%.+]] = sv.modport.get %{{.+}} @source : !sv.interface<@IValidReady_i4> -> !sv.modport<@IValidReady_i4::@source>
+// RTL:   rtl.instance "nullRcvr" @Reciever([[ZM]], %clk) : (!sv.modport<@IValidReady_i4::@source>, i1) -> ()
+// RTL:   %c0_i32 = rtl.constant 0 : i32
+// RTL:   [[ZA:%.+]] = rtl.bitcast %c0_i32 : (i32) -> !rtl.array<4xi8>
+// RTL:   %nullInternRcvr.in_ready = rtl.instance "nullInternRcvr" @InternRcvr([[ZA]], %false_0) : (!rtl.array<4xi8>, i1) -> i1
 
 rtl.module @twoChannelArgs(%clk: i1, %ints: !esi.channel<i32>, %foo: !esi.channel<i7>) -> () {
   %rdy = rtl.constant 1 : i1
   %i, %i_valid = esi.unwrap.vr %ints, %rdy : i32
   %i2, %i2_valid = esi.unwrap.vr %foo, %rdy : i7
 }
-// RTL: rtl.module @twoChannelArgs(%clk: i1, %ints: i32, %ints_valid: i1, %foo: i7, %foo_valid: i1) -> (%ints_ready: i1, %foo_ready: i1)
+// RTL-LABEL: rtl.module @twoChannelArgs(%clk: i1, %ints: i32, %ints_valid: i1, %foo: i7, %foo_valid: i1) -> (%ints_ready: i1, %foo_ready: i1)
 // RTL:   %true = rtl.constant true
 // RTL:   rtl.output %true, %true : i1, i1


### PR DESCRIPTION
Useful in cases where a module has an input port which you don't want to use.
This PR also fixes a bug in the RemoveWrapUnwrap conversion I found while
debugging.