### PR TITLE
[FIRRTL] Support `else when x:` syntatic shorthand

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2111,10 +2111,14 @@ ParseResult FIRStmtParser::parseWhen(unsigned whenIndent) {
   whenStmt.createElseRegion();
 
   // If we have the ':' form, then handle it.
+
+  // Syntactic shorthand 'else when'. This uses the same indentation level as
+  // the outer 'when'.
   if (getToken().is(FIRToken::kw_when)) {
-    // TODO(completeness): Handle the 'else when' syntactic sugar when we
-    // care.
-    return emitError("'else when' syntax not supported yet"), failure();
+    // We create a sub parser for the else block.
+    FIRStmtParser subParser(whenStmt.getElseBodyBuilder(), *this,
+                            moduleContext);
+    return subParser.parseWhen(whenIndent);
   }
 
   // Parse the 'else' body into the 'else' region.

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -224,6 +224,36 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     when lt(reset, UInt(4)) :   ;; When with no else.
       _t <= _t_2
 
+    ; CHECK: firrtl.when %reset  {
+    ; CHECK:   firrtl.connect %_t, %_t_2
+    ; CHECK: } else  {
+    ; CHECK:   [[COND:%.+]] = firrtl.not %reset
+    ; CHECK:   firrtl.when [[COND]]  {
+    ; CHECK:     firrtl.connect %_t, %_t_2
+    ; CHECK:   }
+    ; CHECK: }
+    when reset :
+      _t <= _t_2
+    else when not(reset) :
+      _t <= _t_2
+
+    ; CHECK: firrtl.when %reset  {
+    ; CHECK:   firrtl.connect %_t, %_t
+    ; CHECK: } else  {
+    ; CHECK:   [[COND:%.+]] = firrtl.not %reset
+    ; CHECK:   firrtl.when [[COND]]  {
+    ; CHECK:     firrtl.connect %_t, %_t_2
+    ; CHECK:   } else  {
+    ; CHECK:     firrtl.connect %_t, %_t_2
+    ; CHECK:   }
+    ; CHECK: }
+    when reset:
+      _t <= _t_2
+    else when not(reset) :
+      _t <= _t_2
+    else :
+      _t <= _t_2
+
     ; CHECK: firrtl.printf %clock, %reset, "Something interesting!\0A %x %x"(%_t, %_t_2) : !firrtl.vector<uint<1>, 12>, !firrtl.vector<uint<1>, 12>
     printf(clock, reset, "Something interesting!\n %x %x", _t, _t_2)
 


### PR DESCRIPTION
This adds support for `when` syntactic shorthand to the parser:
```firrtl
    when reset :
      _t <= _t_2
    else when not(reset) :
      _t <= _t_2
```