### PR TITLE
Update LLVM to 4dfddf715b94857998601aa79c25e4f327d44dfa.

### DIFF
--- a/include/circt/Dialect/MSFT/MSFT.td
+++ b/include/circt/Dialect/MSFT/MSFT.td
@@ -44,8 +44,9 @@ def DeviceType : I32EnumAttr<"DeviceType",
     I32EnumAttrCase<"DSP", 2>,
   ]>;
 
-class MSFT_Attr<string name, string baseCppClass = "::mlir::Attribute">
-    : AttrDef<MSFTDialect, name, baseCppClass> {
+class MSFT_Attr<string name, list<Trait> traits = [],
+                string baseCppClass = "::mlir::Attribute">
+    : AttrDef<MSFTDialect, name, traits, baseCppClass> {
   let mnemonic = ?;
 }
 

--- a/lib/Dialect/ESI/ESIPasses.cpp
+++ b/lib/Dialect/ESI/ESIPasses.cpp
@@ -23,6 +23,7 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 
 #include <memory>

--- a/lib/Dialect/ESI/ESITranslations.cpp
+++ b/lib/Dialect/ESI/ESITranslations.cpp
@@ -14,6 +14,7 @@
 #include "mlir/IR/BuiltinDialect.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Translation.h"
+#include "llvm/Support/Format.h"
 
 #include <algorithm>
 

--- a/lib/Dialect/SV/Transforms/GeneratorCallout.cpp
+++ b/lib/Dialect/SV/Transforms/GeneratorCallout.cpp
@@ -14,6 +14,7 @@
 #include "SVPassDetail.h"
 #include "circt/Dialect/SV/SVPasses.h"
 #include "circt/Support/ImplicitLocOpBuilder.h"
+#include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Process.h"
 
 using namespace circt;

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -28,6 +28,7 @@
 #include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Parallel.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Support/SaveAndRestore.h"
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Support/raw_ostream.h"

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -34,6 +34,7 @@
 #include "mlir/Transforms/Passes.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/ToolOutputFile.h"
 
 using namespace llvm;

--- a/tools/handshake-runner/Simulation.cpp
+++ b/tools/handshake-runner/Simulation.cpp
@@ -18,6 +18,7 @@
 #include "circt/Dialect/Handshake/HandshakeOps.h"
 #include "circt/Dialect/Handshake/Simulation.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "llvm/Support/Debug.h"
 
 #define DEBUG_TYPE "runner"
 

--- a/tools/handshake-runner/handshake-runner.cpp
+++ b/tools/handshake-runner/handshake-runner.cpp
@@ -18,6 +18,7 @@
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Parser.h"
 #include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/SourceMgr.h"
 
 #include "circt/Dialect/Handshake/HandshakeOps.h"
 #include "circt/Dialect/Handshake/Simulation.h"

--- a/tools/llhd-sim/llhd-sim.cpp
+++ b/tools/llhd-sim/llhd-sim.cpp
@@ -25,6 +25,7 @@
 #include "mlir/Transforms/Passes.h"
 
 #include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/ToolOutputFile.h"
 
 using namespace llvm;


### PR DESCRIPTION
This includes a couple breaking changes:
* AttrDef has a new argument for attribure traits.
* Several includes we depended on appear to have been moved to forward
declarations, so add the explicit includes we needed.