### PR TITLE
[Python] Use resources from MLIR python headers

### DIFF
--- a/lib/Bindings/Python/CIRCTModule.cpp
+++ b/lib/Bindings/Python/CIRCTModule.cpp
@@ -19,6 +19,7 @@
 
 #include "llvm-c/ErrorHandling.h"
 
+#include "CirctPybindUtils.h"
 #include "PybindUtils.h"
 #include <pybind11/pybind11.h>
 namespace py = pybind11;
@@ -61,7 +62,7 @@ PYBIND11_MODULE(_circt, m) {
       "Register CIRCT dialects on a PyMlirContext.");
 
   m.def("export_verilog", [](MlirModule mod, py::object fileObject) {
-    circt::python::PyFileAccumulator accum(fileObject, false);
+    mlir::PyFileAccumulator accum(fileObject, false);
     py::gil_scoped_release();
     mlirExportVerilog(mod, accum.getCallback(), accum.getUserData());
   });

--- a/lib/Bindings/Python/CMakeLists.txt
+++ b/lib/Bindings/Python/CMakeLists.txt
@@ -24,6 +24,7 @@ add_mlir_python_extension(CIRCTBindingsPythonExtension _circt
     CIRCTCAPISV
     CIRCTCAPIExportVerilog
 )
+target_include_directories(CIRCTBindingsPythonExtension PRIVATE "${MLIR_MAIN_SRC_DIR}/lib/Bindings/Python")
 add_dependencies(CIRCTBindingsPython CIRCTBindingsPythonExtension)
 
 ################################################################################

--- a/lib/Bindings/Python/CirctPybindUtils.h
+++ b/lib/Bindings/Python/CirctPybindUtils.h
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef CIRCT_BINDINGS_PYTHON_PYBINDUTILS_H
-#define CIRCT_BINDINGS_PYTHON_PYBINDUTILS_H
+#ifndef CIRCT_BINDINGS_PYTHON_CIRCTPYBINDUTILS_H
+#define CIRCT_BINDINGS_PYTHON_CIRCTPYBINDUTILS_H
 
 #include <string>
 
@@ -26,47 +26,8 @@
 
 namespace py = pybind11;
 
-namespace circt {
-namespace python {
-
-/// Taken from PybindUtils.h in MLIR.
-/// Accumulates into a python file-like object, either writing text (default)
-/// or binary.
-class PyFileAccumulator {
-public:
-  PyFileAccumulator(pybind11::object fileObject, bool binary)
-      : pyWriteFunction(fileObject.attr("write")), binary(binary) {}
-
-  void *getUserData() { return this; }
-
-  MlirStringCallback getCallback() {
-    return [](MlirStringRef part, void *userData) {
-      pybind11::gil_scoped_acquire();
-      PyFileAccumulator *accum = static_cast<PyFileAccumulator *>(userData);
-      if (accum->binary) {
-        // Note: Still has to copy and not avoidable with this API.
-        pybind11::bytes pyBytes(part.data, part.length);
-        accum->pyWriteFunction(pyBytes);
-      } else {
-        pybind11::str pyStr(part.data,
-                            part.length); // Decodes as UTF-8 by default.
-        accum->pyWriteFunction(pyStr);
-      }
-    };
-  }
-
-private:
-  pybind11::object pyWriteFunction;
-  bool binary;
-};
-} // namespace python
-} // namespace circt
-
 namespace pybind11 {
 namespace detail {
-
-template <typename T>
-struct type_caster<llvm::Optional<T>> : optional_caster<llvm::Optional<T>> {};
 
 /// Helper to convert a presumed MLIR API object to a capsule, accepting either
 /// an explicit Capsule (which can happen when two C APIs are communicating
@@ -257,4 +218,4 @@ inline pybind11::error_already_set raiseValueError(const std::string &message) {
 
 } // namespace pybind11
 
-#endif // CIRCT_BINDINGS_PYTHON_PYBINDUTILS_H
+#endif // CIRCT_BINDINGS_PYTHON_CIRCTPYBINDUTILS_H

--- a/lib/Bindings/Python/ESIModule.cpp
+++ b/lib/Bindings/Python/ESIModule.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "DialectModules.h"
+#include "IRModule.h"
 
 #include "circt-c/Dialect/ESI.h"
 #include "circt/Dialect/ESI/ESIDialect.h"
@@ -22,7 +23,7 @@
 
 #include "llvm/ADT/SmallVector.h"
 
-#include "PybindUtils.h"
+#include "CirctPybindUtils.h"
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 namespace py = pybind11;

--- a/lib/Bindings/Python/MSFTModule.cpp
+++ b/lib/Bindings/Python/MSFTModule.cpp
@@ -15,6 +15,7 @@
 #include "mlir/CAPI/IR.h"
 #include "mlir/CAPI/Support.h"
 
+#include "CirctPybindUtils.h"
 #include "PybindUtils.h"
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -53,7 +54,7 @@ void circt::python::populateDialectMSFTSubmodule(py::module &m) {
       .export_values();
 
   m.def("export_tcl", [](MlirModule mod, py::object fileObject) {
-    circt::python::PyFileAccumulator accum(fileObject, false);
+    mlir::PyFileAccumulator accum(fileObject, false);
     py::gil_scoped_release();
     mlirMSFTExportTcl(mod, accum.getCallback(), accum.getUserData());
   });


### PR DESCRIPTION
This is awkward but by adding the python binding lib dir to the include path
for our pybind code, we can #include MLIR headers. I did this so we can take
advantage of numerous widgets in those headers. This PR cleans up some
duplicate code.

This PR will probably fail clang-tidy.