### PR TITLE
[FIRRTL][ExpandWhens] Properly handle registers

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -204,10 +204,18 @@ void ExpandWhensVisitor::visitDecl(FModuleOp op) {
 
 void ExpandWhensVisitor::visitDecl(WireOp op) { scope[op.result()] = nullptr; }
 
-void ExpandWhensVisitor::visitDecl(RegOp op) { scope[op.result()] = nullptr; }
+void ExpandWhensVisitor::visitDecl(RegOp op) {
+  // Registers are initialized to themselves.
+  auto connect = OpBuilder(op->getBlock(), ++Block::iterator(op))
+                     .create<ConnectOp>(op.getLoc(), op, op);
+  scope[op.result()] = connect;
+}
 
 void ExpandWhensVisitor::visitDecl(RegResetOp op) {
-  scope[op.result()] = nullptr;
+  // Registers are initialized to themselves.
+  auto connect = OpBuilder(op->getBlock(), ++Block::iterator(op))
+                     .create<ConnectOp>(op.getLoc(), op, op);
+  scope[op.result()] = connect;
 }
 
 void ExpandWhensVisitor::visitDecl(InstanceOp op) {

--- a/test/Dialect/FIRRTL/expand-whens-errors.mlir
+++ b/test/Dialect/FIRRTL/expand-whens-errors.mlir
@@ -13,10 +13,6 @@ firrtl.module @CheckInitialization(%clock : !firrtl.clock, %en : !firrtl.uint<1>
   // expected-error @-1 {{module port "out" not fully initialized}}
   // expected-error @+1 {{sink not fully initialized}}
   %w = firrtl.wire : !firrtl.uint<2>
-  // expected-error @+1 {{sink not fully initialized}}
-  %r = firrtl.reg %clock : (!firrtl.clock) -> !firrtl.uint<2>
-  // expected-error @+1 {{sink not fully initialized}}
-  %rr = firrtl.regreset %clock, %en, %w : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<2>) -> !firrtl.uint<2>
   // expected-error @+1 {{instance port "in" not fully initialized}}
   %simple_out, %simple_in = firrtl.instance @simple {name = "test", portNames=["in", "out"]}: !firrtl.flip<uint<1>>, !firrtl.uint<1>
 }

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -300,4 +300,37 @@ firrtl.module @nested2(%clock : !firrtl.clock, %p0 : !firrtl.uint<1>, %p1 : !fir
 //CHECK-NEXT:   firrtl.connect %out, %9 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
 //CHECK-NEXT: }
 
+// Test that registers are multiplexed with themselves.
+firrtl.module @register_mux(%p : !firrtl.uint<1>, %clock: !firrtl.clock) {
+  %c0_ui2 = firrtl.constant(0 : ui2) : !firrtl.uint<2>
+  %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
+
+  // CHECK: %reg0 = firrtl.reg %clock
+  // CHECK: firrtl.connect %reg0, %reg0
+  %reg0 = firrtl.reg %clock : (!firrtl.clock) -> !firrtl.uint<2>
+
+  // CHECK: %reg1 = firrtl.reg %clock
+  // CHECK: firrtl.connect %reg1, %c0_ui2
+  %reg1 = firrtl.reg %clock : (!firrtl.clock) -> !firrtl.uint<2>
+  firrtl.connect %reg1, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
+
+  // CHECK: %reg2 = firrtl.reg %clock 
+  // CHECK: [[MUX:%.+]] = firrtl.mux(%p, %c0_ui2, %reg2)
+  // CHECK: firrtl.connect %reg2, [[MUX]]
+  %reg2 = firrtl.reg %clock : (!firrtl.clock) -> !firrtl.uint<2>
+  firrtl.when %p {
+    firrtl.connect %reg2, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
+  }
+  
+  // CHECK: %reg3 = firrtl.reg %clock
+  // CHECK: [[MUX:%.+]] = firrtl.mux(%p, %c0_ui2, %c1_ui2)
+  // CHECK: firrtl.connect %reg3, [[MUX]]
+  %reg3 = firrtl.reg %clock : (!firrtl.clock) -> !firrtl.uint<2>
+  firrtl.when %p {
+    firrtl.connect %reg3, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
+  } else {
+    firrtl.connect %reg3, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
+  }
+}
+
 }


### PR DESCRIPTION
Register in FIRRTL are initialized to their own value. This affects how
they behave when connected to in WhenOp statements, and prevents them
from being uninitialized. Before this change, they were treated
identically to wires. The following example works for registers, but
would be considered uninitialized if it was a wire:

```scala
reg r: UInt<4>, clock
when p:
  r <= UInt<4>(0)
```
lowers to:

```scala
reg r: UInt<4>, clock
r <= mux(p, UInt<4>(0), r)
```