### PR TITLE
[FIRRTL] Add CheckWidths pass

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -135,11 +135,19 @@ public:
   using FIRRTLType::TypeBase<ConcreteType, ParentType,
                              detail::WidthTypeStorage>::Base::Base;
 
+  /// Return the bitwidth of this type or None if unknown.
+  Optional<int32_t> getWidth() {
+    return static_cast<ConcreteType *>(this)->getWidth();
+  }
+
   /// Return the width of this type, or -1 if it has none specified.
   int32_t getWidthOrSentinel() {
-    auto width = static_cast<ConcreteType *>(this)->getWidth();
+    auto width = getWidth();
     return width.hasValue() ? width.getValue() : -1;
   }
+
+  /// Return true if this type has a known width.
+  bool hasWidth() { return getWidth().hasValue(); }
 };
 
 class SIntType;

--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -32,6 +32,8 @@ std::unique_ptr<mlir::Pass> createBlackBoxMemoryPass();
 
 std::unique_ptr<mlir::Pass> createExpandWhensPass();
 
+std::unique_ptr<mlir::Pass> createCheckWidthsPass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/FIRRTL/Passes.h.inc"

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -94,4 +94,13 @@ def ExpandWhens : Pass<"firrtl-expand-whens", "firrtl::FModuleOp"> {
   let constructor = "circt::firrtl::createExpandWhensPass()";
 }
 
+def CheckWidths : Pass<"firrtl-check-widths", "firrtl::CircuitOp"> {
+  let summary = "Verify that types have a well-known width";
+  let description = [{
+    This pass checks if the widths of all types throughout a FIRRTL module are
+    well-known.
+  }];
+  let constructor = "circt::firrtl::createCheckWidthsPass()";
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_PASSES_TD

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -94,7 +94,7 @@ def ExpandWhens : Pass<"firrtl-expand-whens", "firrtl::FModuleOp"> {
   let constructor = "circt::firrtl::createExpandWhensPass()";
 }
 
-def CheckWidths : Pass<"firrtl-check-widths", "firrtl::CircuitOp"> {
+def CheckWidths : Pass<"firrtl-check-widths", "firrtl::FModuleOp"> {
   let summary = "Verify that types have a well-known width";
   let description = [{
     This pass checks if the widths of all types throughout a FIRRTL module are

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_circt_dialect_library(CIRCTFIRRTLTransforms
   BlackboxMemory.cpp
+  CheckWidths.cpp
   ExpandWhens.cpp
   ModuleInliner.cpp
   IMConstProp.cpp

--- a/lib/Dialect/FIRRTL/Transforms/CheckWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckWidths.cpp
@@ -1,0 +1,106 @@
+//===- CheckWidths.cpp - Check that width of types are known ----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the CheckWidths pass.
+//
+// Modeled after:
+// https://github.com/chipsalliance/firrtl/blob/master/src/main/scala/firrtl/passes/CheckWidths.scala
+//
+//===----------------------------------------------------------------------===//
+
+#include "./PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
+#include "circt/Dialect/FIRRTL/FIRRTLVisitors.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+
+using namespace circt;
+using namespace firrtl;
+
+namespace {
+/// A simple pass that emits errors for any occurrences of `uint`, `sint`, or
+/// `analog` without a known width.
+class CheckWidthsPass : public CheckWidthsBase<CheckWidthsPass> {
+  void runOnOperation() override;
+  void checkType(Type type, Type reportType, Location loc,
+                 llvm::function_ref<void(InFlightDiagnostic &)> addContext);
+
+  InFlightDiagnostic emitError(Location loc, const Twine &message) {
+    signalPassFailure();
+    return mlir::emitError(loc, message);
+  }
+};
+} // namespace
+
+void CheckWidthsPass::runOnOperation() {
+  getOperation()->walk([&](Operation *op) {
+    TypeSwitch<Operation *>(op)
+        .Case<FModuleOp>([&](auto op) {
+          // Check the port types. Unfortunately we don't have an exact location
+          // of the port name, so we just point at the module with the port name
+          // mentioned in the error.
+          for (auto &port : op.getPorts()) {
+            checkType(port.type, port.type, op.getLoc(),
+                      [&](InFlightDiagnostic &error) {
+                        error.attachNote()
+                            << "in port `" << port.getName() << "` of module `"
+                            << op.getName() << "`";
+                      });
+          }
+        })
+        .Default([&](auto *op) {
+          // Check each result of the operation.
+          for (auto type : op->getResultTypes())
+            checkType(type, type, op->getLoc(), [&](InFlightDiagnostic &error) {
+              error.attachNote() << "in result of `" << op->getName() << "`";
+            });
+        });
+  });
+}
+
+/// Check a type and its children for any occurrences of uninferred widths.
+/// Specifically look for `uint`, `sint`, and `analog` types. The argument
+/// `type` is the one being checked, `reportType` is the one included in any
+/// errors, `loc` is the location to report errors to, and `addContext` gives
+/// the caller the chance to add additional context information to the error.
+void CheckWidthsPass::checkType(
+    Type type, Type reportType, Location loc,
+    llvm::function_ref<void(InFlightDiagnostic &)> addContext) {
+  TypeSwitch<Type>(type)
+      // Primarily complain about integer and analog types not having a proper
+      // width.
+      .template Case<IntType, AnalogType>([&](auto type) {
+        if (!type.hasWidth()) {
+          auto error = emitError(loc, "uninferred width: type ")
+                       << reportType << " has no known width";
+          addContext(error);
+        }
+      })
+      // Look into `flip<...>` and vector types, but report the entire flip or
+      // vector type upon failure. So `flip<uint>` will have the error mention
+      // `flip<uint>` instead of just `uint`.
+      .template Case<FlipType, FVectorType>([&](auto type) {
+        checkType(type.getElementType(), reportType, loc, addContext);
+      })
+      // Look into bundle types. Report only the type of the offending field
+      // upon error, and add a note indicating which field was problematic.
+      .template Case<BundleType>([&](auto type) {
+        for (auto &bundleElement : type.getElements())
+          checkType(bundleElement.type, bundleElement.type, loc,
+                    [&](InFlightDiagnostic &error) {
+                      addContext(error);
+                      error.attachNote()
+                          << "in bundle field `"
+                          << bundleElement.name.getValue() << "`";
+                    });
+      });
+}
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createCheckWidthsPass() {
+  return std::make_unique<CheckWidthsPass>();
+}

--- a/test/Dialect/FIRRTL/check-widths-errors.mlir
+++ b/test/Dialect/FIRRTL/check-widths-errors.mlir
@@ -1,29 +1,43 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-check-widths)' --verify-diagnostics --split-input-file %s
+// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl.module(firrtl-check-widths))' --verify-diagnostics --split-input-file %s
 
 firrtl.circuit "Foo" {
   firrtl.module @Foo () {
     // expected-error @+2 {{uninferred width: type '!firrtl.uint'}}
     // expected-note @+1 {{in result of `firrtl.wire`}}
     %0 = firrtl.wire : !firrtl.uint
+  }
+}
 
-    // expected-error @+2 {{uninferred width: type '!firrtl.flip<uint>'}}
-    // expected-note @+1 {{in result of `firrtl.wire`}}
-    %1 = firrtl.wire : !firrtl.flip<uint>
+// -----
 
+firrtl.circuit "Foo" {
+  firrtl.module @Foo () {
     // expected-error @+2 {{uninferred width: type '!firrtl.vector<uint, 16>'}}
     // expected-note @+1 {{in result of `firrtl.wire`}}
-    %2 = firrtl.wire : !firrtl.vector<uint, 16>
+    %1 = firrtl.wire : !firrtl.vector<uint, 16>
+  }
+}
 
+// -----
+
+firrtl.circuit "Foo" {
+  firrtl.module @Foo () {
     // expected-error @+3 {{uninferred width: type '!firrtl.uint'}}
     // expected-note @+2 {{in result of `firrtl.wire`}}
     // expected-note @+1 {{in bundle field `a`}}
-    %3 = firrtl.wire : !firrtl.bundle<a: uint>
+    %2 = firrtl.wire : !firrtl.bundle<a: uint>
+  }
+}
 
+// -----
+
+firrtl.circuit "Foo" {
+  firrtl.module @Foo () {
     // expected-error @+5 {{uninferred width: type '!firrtl.flip<uint>'}}
     // expected-note @+4 {{in result of `firrtl.wire`}}
     // expected-note @+3 {{in bundle field `a`}}
     // expected-note @+2 {{in bundle field `b`}}
     // expected-note @+1 {{in bundle field `c`}}
-    %4 = firrtl.wire : !firrtl.bundle<a: bundle<b: bundle<c: flip<uint>, d: uint<1>>>>
+    %3 = firrtl.wire : !firrtl.bundle<a: bundle<b: bundle<c: flip<uint>, d: uint<1>>>>
   }
 }

--- a/test/Dialect/FIRRTL/check-widths-errors.mlir
+++ b/test/Dialect/FIRRTL/check-widths-errors.mlir
@@ -1,0 +1,29 @@
+// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-check-widths)' --verify-diagnostics --split-input-file %s
+
+firrtl.circuit "Foo" {
+  firrtl.module @Foo () {
+    // expected-error @+2 {{uninferred width: type '!firrtl.uint'}}
+    // expected-note @+1 {{in result of `firrtl.wire`}}
+    %0 = firrtl.wire : !firrtl.uint
+
+    // expected-error @+2 {{uninferred width: type '!firrtl.flip<uint>'}}
+    // expected-note @+1 {{in result of `firrtl.wire`}}
+    %1 = firrtl.wire : !firrtl.flip<uint>
+
+    // expected-error @+2 {{uninferred width: type '!firrtl.vector<uint, 16>'}}
+    // expected-note @+1 {{in result of `firrtl.wire`}}
+    %2 = firrtl.wire : !firrtl.vector<uint, 16>
+
+    // expected-error @+3 {{uninferred width: type '!firrtl.uint'}}
+    // expected-note @+2 {{in result of `firrtl.wire`}}
+    // expected-note @+1 {{in bundle field `a`}}
+    %3 = firrtl.wire : !firrtl.bundle<a: uint>
+
+    // expected-error @+5 {{uninferred width: type '!firrtl.flip<uint>'}}
+    // expected-note @+4 {{in result of `firrtl.wire`}}
+    // expected-note @+3 {{in bundle field `a`}}
+    // expected-note @+2 {{in bundle field `b`}}
+    // expected-note @+1 {{in bundle field `c`}}
+    %4 = firrtl.wire : !firrtl.bundle<a: bundle<b: bundle<c: flip<uint>, d: uint<1>>>>
+  }
+}

--- a/test/Dialect/FIRRTL/check-widths-errors.mlir
+++ b/test/Dialect/FIRRTL/check-widths-errors.mlir
@@ -1,6 +1,15 @@
 // RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl.module(firrtl-check-widths))' --verify-diagnostics --split-input-file %s
 
 firrtl.circuit "Foo" {
+  // expected-error @+2 {{uninferred width: type '!firrtl.uint'}}
+  // expected-note @+1 {{in port `a` of module `Foo`}}
+  firrtl.module @Foo (%a: !firrtl.uint) {
+  }
+}
+
+// -----
+
+firrtl.circuit "Foo" {
   firrtl.module @Foo () {
     // expected-error @+2 {{uninferred width: type '!firrtl.uint'}}
     // expected-note @+1 {{in result of `firrtl.wire`}}
@@ -14,7 +23,7 @@ firrtl.circuit "Foo" {
   firrtl.module @Foo () {
     // expected-error @+2 {{uninferred width: type '!firrtl.vector<uint, 16>'}}
     // expected-note @+1 {{in result of `firrtl.wire`}}
-    %1 = firrtl.wire : !firrtl.vector<uint, 16>
+    %0 = firrtl.wire : !firrtl.vector<uint, 16>
   }
 }
 
@@ -25,7 +34,7 @@ firrtl.circuit "Foo" {
     // expected-error @+3 {{uninferred width: type '!firrtl.uint'}}
     // expected-note @+2 {{in result of `firrtl.wire`}}
     // expected-note @+1 {{in bundle field `a`}}
-    %2 = firrtl.wire : !firrtl.bundle<a: uint>
+    %0 = firrtl.wire : !firrtl.bundle<a: uint>
   }
 }
 
@@ -38,6 +47,28 @@ firrtl.circuit "Foo" {
     // expected-note @+3 {{in bundle field `a`}}
     // expected-note @+2 {{in bundle field `b`}}
     // expected-note @+1 {{in bundle field `c`}}
-    %3 = firrtl.wire : !firrtl.bundle<a: bundle<b: bundle<c: flip<uint>, d: uint<1>>>>
+    %0 = firrtl.wire : !firrtl.bundle<a: bundle<b: bundle<c: flip<uint>, d: uint<1>>>>
+  }
+}
+
+// -----
+
+// Only first operation with errors should be reported.
+firrtl.circuit "Foo" {
+  firrtl.module @Foo () {
+    // expected-error @+2 {{uninferred width: type '!firrtl.uint'}}
+    // expected-note @+1 {{in result of `firrtl.wire`}}
+    %0 = firrtl.wire : !firrtl.uint
+    %1 = firrtl.wire : !firrtl.sint
+  }
+}
+
+// -----
+
+// Only first error on module ports reported.
+firrtl.circuit "Foo" {
+  // expected-error @+2 {{uninferred width: type '!firrtl.uint'}}
+  // expected-note @+1 {{in port `a` of module `Foo`}}
+  firrtl.module @Foo (%a: !firrtl.uint, %b: !firrtl.sint) {
   }
 }


### PR DESCRIPTION
Add a `CheckWidths` pass modeled after the corresponding Scala pass. The pass emits human-readable errors for any `uint`, `sint`, and `analog` types without known width in the IR. This check will be useful to verify the result of width inference and to ensure that we are in low FIRRTL.

### Example
As a concrete example, this pass will produce errors like:
```
foo.mlir:7:10: error: uninferred width: type '!firrtl.uint' has no known width
    %0 = firrtl.wire : !firrtl.uint
         ^
foo.mlir:7:10: note: in result of `firrtl.wire`
```
```
foo.mlir:27:10: error: uninferred width: type '!firrtl.flip<uint>' has no known width
    %4 = firrtl.wire : !firrtl.bundle<a: bundle<b: bundle<c: flip<uint>, d: uint<1>>>>
         ^
foo.mlir:27:10: note: in result of `firrtl.wire`
foo.mlir:27:10: note: in bundle field `a`
foo.mlir:27:10: note: in bundle field `b`
foo.mlir:27:10: note: in bundle field `c`
```