### PR TITLE
[FIRRTL] Add InferWidths pass

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -34,6 +34,8 @@ std::unique_ptr<mlir::Pass> createExpandWhensPass();
 
 std::unique_ptr<mlir::Pass> createCheckWidthsPass();
 
+std::unique_ptr<mlir::Pass> createInferWidthsPass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/FIRRTL/Passes.h.inc"

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -103,4 +103,12 @@ def CheckWidths : Pass<"firrtl-check-widths", "firrtl::FModuleOp"> {
   let constructor = "circt::firrtl::createCheckWidthsPass()";
 }
 
+def InferWidths : Pass<"firrtl-infer-widths", "firrtl::CircuitOp"> {
+  let summary = "Infer the width of types";
+  let description = [{
+    This pass infers the widths of all types throughout a FIRRTL module.
+  }];
+  let constructor = "circt::firrtl::createInferWidthsPass()";
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_PASSES_TD

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -4,6 +4,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   ExpandWhens.cpp
   ModuleInliner.cpp
   IMConstProp.cpp
+  InferWidths.cpp
   LowerTypes.cpp
 
   DEPENDS

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1,0 +1,763 @@
+//===- InferWidths.cpp - Infer width of types -------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the InferWidths pass.
+//
+//===----------------------------------------------------------------------===//
+
+#include "./PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
+#include "circt/Dialect/FIRRTL/FIRRTLVisitors.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/GraphTraits.h"
+#include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/PostOrderIterator.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "infer-widths"
+
+using namespace circt;
+using namespace firrtl;
+
+//===----------------------------------------------------------------------===//
+// Constraint Expressions
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct Expr;
+} // namespace
+
+/// Allow rvalue refs to `Expr` and subclasses to be printed to streams.
+template <typename T, typename std::enable_if<std::is_base_of<Expr, T>::value,
+                                              int>::type = 0>
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const T &e) {
+  e.print(os);
+  return os;
+}
+
+// Allow expression subclasses to be hashed.
+namespace mlir {
+template <typename T, typename std::enable_if<std::is_base_of<Expr, T>::value,
+                                              int>::type = 0>
+inline llvm::hash_code hash_value(const T &e) {
+  return e.hash_value();
+}
+} // namespace mlir
+
+namespace {
+
+/// An expression on the right-hand side of a constraint.
+struct Expr {
+  enum Kind {
+    KindRoot,
+    KindVar,
+    KindKnown,
+    KindAdd,
+    KindMax,
+    KindMin,
+  };
+  llvm::Optional<int32_t> solution = {};
+  Kind kind;
+
+  /// Print a human-readable representation of this expr.
+  void print(llvm::raw_ostream &os) const;
+
+  // Iterators over the child expressions.
+  typedef Expr *const *iterator;
+  iterator begin() const;
+  iterator end() const;
+
+protected:
+  Expr(Kind kind) : kind(kind) {}
+  llvm::hash_code hash_value() const { return llvm::hash_value(kind); }
+};
+
+/// Helper class to CRTP-derive common functions.
+template <class DerivedT, Expr::Kind DerivedKind>
+struct ExprBase : public Expr {
+  ExprBase() : Expr(DerivedKind) {}
+  static bool classof(const Expr *e) { return e->kind == DerivedKind; }
+  bool operator==(const Expr &other) const {
+    if (auto otherSame = dyn_cast<DerivedT>(other))
+      return *static_cast<DerivedT *>(this) == otherSame;
+    return false;
+  }
+  iterator begin() const { return nullptr; }
+  iterator end() const { return nullptr; }
+};
+
+/// A free variable.
+struct RootExpr : public ExprBase<RootExpr, Expr::KindRoot> {
+  RootExpr(std::vector<Expr *> &exprs) : exprs(exprs) {}
+  void print(llvm::raw_ostream &os) const { os << "root"; }
+  iterator begin() const { return &exprs[0]; }
+  iterator end() const { return &exprs[0] + exprs.size(); }
+  std::vector<Expr *> &exprs;
+};
+
+/// A free variable.
+struct VarExpr : public ExprBase<VarExpr, Expr::KindVar> {
+  void print(llvm::raw_ostream &os) const {
+    // Hash the `this` pointer into something somewhat human readable. Since
+    // this is just for debug dumping, we wrap around at 4096 variables.
+    os << "var" << ((size_t)this / llvm::PowerOf2Ceil(sizeof(*this)) & 0xFFF);
+  }
+};
+
+/// A known constant value.
+struct KnownExpr : public ExprBase<KnownExpr, Expr::KindKnown> {
+  KnownExpr(int32_t value) : ExprBase() { solution = value; }
+  void print(llvm::raw_ostream &os) const { os << solution.getValue(); }
+  bool operator==(const KnownExpr &other) const {
+    return solution.getValue() == other.solution.getValue();
+  }
+  llvm::hash_code hash_value() const {
+    return llvm::hash_combine(Expr::hash_value(), solution.getValue());
+  }
+};
+
+/// A binary expression. Contains the actual data. Concrete subclasses are
+/// merely there for show and ease of use.
+struct BinaryExpr : public Expr {
+  bool operator==(const BinaryExpr &other) const {
+    return kind == other.kind && lhs() == other.lhs() && rhs() == other.rhs();
+  }
+  llvm::hash_code hash_value() const {
+    return llvm::hash_combine(Expr::hash_value(), *args);
+  }
+  Expr *lhs() const { return args[0]; }
+  Expr *rhs() const { return args[1]; }
+  iterator begin() const { return args; }
+  iterator end() const { return args + 2; }
+
+  /// The child expressions.
+  Expr *const args[2];
+
+protected:
+  BinaryExpr(Kind kind, Expr *lhs, Expr *rhs) : Expr(kind), args{lhs, rhs} {}
+};
+
+/// Helper class to CRTP-derive common functions.
+template <class DerivedT, Expr::Kind DerivedKind>
+struct BinaryExprBase : public BinaryExpr {
+  template <typename... Args>
+  BinaryExprBase(Args &&... args)
+      : BinaryExpr(DerivedKind, std::forward<Args>(args)...) {}
+  static bool classof(const Expr *e) { return e->kind == DerivedKind; }
+};
+
+/// An addition.
+struct AddExpr : public BinaryExprBase<AddExpr, Expr::KindAdd> {
+  using BinaryExprBase::BinaryExprBase;
+  void print(llvm::raw_ostream &os) const {
+    os << "(" << *lhs() << " + " << *rhs() << ")";
+  }
+};
+
+/// The maximum of two expressions.
+struct MaxExpr : public BinaryExprBase<MaxExpr, Expr::KindMax> {
+  using BinaryExprBase::BinaryExprBase;
+  void print(llvm::raw_ostream &os) const {
+    os << "max(" << *lhs() << ", " << *rhs() << ")";
+  }
+};
+
+/// The minimum of two expressions.
+struct MinExpr : public BinaryExprBase<MinExpr, Expr::KindMin> {
+  using BinaryExprBase::BinaryExprBase;
+  void print(llvm::raw_ostream &os) const {
+    os << "min(" << *lhs() << ", " << *rhs() << ")";
+  }
+};
+
+void Expr::print(llvm::raw_ostream &os) const {
+  TypeSwitch<const Expr *>(this)
+      .Case<RootExpr, VarExpr, KnownExpr, AddExpr, MaxExpr, MinExpr>(
+          [&](auto *e) { e->print(os); });
+}
+
+Expr::iterator Expr::begin() const {
+  return TypeSwitch<const Expr *, Expr::iterator>(this)
+      .Case<RootExpr, VarExpr, KnownExpr, AddExpr, MaxExpr, MinExpr>(
+          [&](auto *e) { return e->begin(); });
+}
+
+Expr::iterator Expr::end() const {
+  return TypeSwitch<const Expr *, Expr::iterator>(this)
+      .Case<RootExpr, VarExpr, KnownExpr, AddExpr, MaxExpr, MinExpr>(
+          [&](auto *e) { return e->end(); });
+}
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// GraphTraits on constraint expressions
+//===----------------------------------------------------------------------===//
+
+namespace llvm {
+template <>
+struct GraphTraits<Expr *> {
+  using ChildIteratorType = Expr::iterator;
+  using NodeRef = Expr *;
+
+  static NodeRef getEntryNode(NodeRef node) { return node; }
+  static inline ChildIteratorType child_begin(NodeRef node) {
+    return node->begin();
+  }
+  static inline ChildIteratorType child_end(NodeRef node) {
+    return node->end();
+  }
+};
+} // namespace llvm
+
+//===----------------------------------------------------------------------===//
+// Fast bump allocator with optional interning
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// An allocation slot in the `InternedAllocator`.
+template <typename T>
+struct InternedSlot {
+  T *ptr;
+  InternedSlot(T *ptr) : ptr(ptr) {}
+};
+
+/// A simple bump allocator that ensures only ever one copy per object exists.
+/// The allocated objects must not have a destructor.
+template <typename T, typename std::enable_if_t<
+                          std::is_trivially_destructible<T>::value, int> = 0>
+class InternedAllocator {
+  using Slot = InternedSlot<T>;
+  llvm::DenseSet<Slot> interned;
+  llvm::BumpPtrAllocator &allocator;
+
+public:
+  InternedAllocator(llvm::BumpPtrAllocator &allocator) : allocator(allocator) {}
+
+  /// Allocate a new object if it does not yet exist, or return a pointer to the
+  /// existing one. `R` is the type of the object to be allocated. `R` must be
+  /// derived from or be the type `T`.
+  template <typename R = T, typename... Args>
+  std::pair<R *, bool> alloc(Args &&... args) {
+    auto stack_value = R(std::forward<Args>(args)...);
+    auto stack_slot = Slot(&stack_value);
+    auto it = interned.find(stack_slot);
+    if (it != interned.end())
+      return std::make_pair(static_cast<R *>(it->ptr), false);
+    auto heap_value = new (allocator) R(std::move(stack_value));
+    interned.insert(Slot(heap_value));
+    return std::make_pair(heap_value, true);
+  }
+};
+
+/// A simple bump allocator. The allocated objects must not have a destructor.
+/// This allocator is mainly there for symmetry with the `InternedAllocator`.
+class VarAllocator {
+  llvm::BumpPtrAllocator &allocator;
+  using T = VarExpr;
+
+public:
+  VarAllocator(llvm::BumpPtrAllocator &allocator) : allocator(allocator) {}
+
+  /// Allocate a new object. `R` is the type of the object to be allocated. `R`
+  /// must be derived from or be the type `T`.
+  template <typename R = T, typename... Args>
+  R *alloc(Args &&... args) {
+    return new (allocator) R(std::forward<Args>(args)...);
+  }
+};
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// Constraint Solver
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// A simple solver for width constraints.
+class ConstraintSolver {
+public:
+  ConstraintSolver() = default;
+
+  VarExpr *var() {
+    auto v = vars.alloc();
+    exprs.push_back(v);
+    return v;
+  }
+  KnownExpr *known(int32_t value) { return alloc<KnownExpr>(knowns, value); }
+  AddExpr *add(Expr *lhs, Expr *rhs) { return alloc<AddExpr>(bins, lhs, rhs); }
+  MaxExpr *max(Expr *lhs, Expr *rhs) { return alloc<MaxExpr>(bins, lhs, rhs); }
+  MinExpr *min(Expr *lhs, Expr *rhs) { return alloc<MinExpr>(bins, lhs, rhs); }
+
+  /// Add a constraint `lhs >= rhs`.
+  Expr *addGeqConstraint(VarExpr *lhs, Expr *rhs) {
+    auto &con = constraints[lhs];
+    con = con ? max(con, rhs) : rhs;
+    return con;
+  }
+
+  void dumpConstraints(llvm::raw_ostream &os);
+  void solve();
+  void gatherDepthFirstExprs(Expr *expr, llvm::SetVector<Expr *> &dfs,
+                             llvm::DenseSet<Expr *> &cycleBreaker);
+
+private:
+  // Allocator for constraint expressions.
+  llvm::BumpPtrAllocator allocator;
+  VarAllocator vars = {allocator};
+  InternedAllocator<KnownExpr> knowns = {allocator};
+  InternedAllocator<BinaryExpr> bins = {allocator};
+
+  /// A list of expressions in the order they were created.
+  std::vector<Expr *> exprs;
+  RootExpr root = {exprs};
+
+  /// Add an allocated expression to the list above.
+  template <typename R, typename T, typename... Args>
+  R *alloc(InternedAllocator<T> &allocator, Args &&... args) {
+    auto it = allocator.template alloc<R>(std::forward<Args>(args)...);
+    if (it.second)
+      exprs.push_back(it.first);
+    return it.first;
+  }
+
+  /// The constraint imposed on each variable. Multiple constraints on the same
+  /// variable are coalesced into a `max(a, b)` expr.
+  llvm::MapVector<VarExpr *, Expr *> constraints;
+
+  // Forbid copyign or moving the solver, which would invalidate the refs to
+  // allocator held by the allocators.
+  ConstraintSolver(ConstraintSolver &&) = delete;
+  ConstraintSolver(const ConstraintSolver &) = delete;
+  ConstraintSolver &operator=(ConstraintSolver &&) = delete;
+  ConstraintSolver &operator=(const ConstraintSolver &) = delete;
+};
+
+} // namespace
+
+/// Print all constraints in the solver to an output stream.
+void ConstraintSolver::dumpConstraints(llvm::raw_ostream &os) {
+  for (const auto &c : constraints) {
+    os << *c.first << " >= " << *c.second << "\n";
+  }
+}
+
+// Helper function to compute binary expressions if both operands have a
+// solution.
+static void solveBinary(BinaryExpr *expr,
+                        std::function<int32_t(int32_t, int32_t)> f) {
+  if (expr->lhs()->solution.hasValue() && expr->rhs()->solution.hasValue())
+    expr->solution =
+        f(expr->lhs()->solution.getValue(), expr->rhs()->solution.getValue());
+}
+
+/// Solve the constraint problem. This is a very simple implementation that
+/// does not fully solve the problem if there are weird dependency cycles
+/// present.
+void ConstraintSolver::solve() {
+  // Iterate over the expressions in depth-first order and start substituting in
+  // solutions.
+  for (auto *expr : llvm::post_order(static_cast<Expr *>(&root))) {
+    if (expr->solution.hasValue())
+      continue;
+    TypeSwitch<Expr *>(expr)
+        .Case<VarExpr>([&](auto *var) {
+          auto it = constraints.find(var);
+          if (it != constraints.end())
+            var->solution = it->second->solution;
+        })
+        .Case<AddExpr>([&](auto *expr) {
+          solveBinary(expr, [](int32_t lhs, int32_t rhs) { return lhs + rhs; });
+        })
+        .Case<MaxExpr>([&](auto *expr) {
+          solveBinary(expr, [](int32_t lhs, int32_t rhs) {
+            return std::max(lhs, rhs);
+          });
+        })
+        .Case<MinExpr>([&](auto *expr) {
+          solveBinary(expr, [](int32_t lhs, int32_t rhs) {
+            return std::min(lhs, rhs);
+          });
+        });
+    LLVM_DEBUG({
+      if (expr->solution.hasValue())
+        llvm::dbgs() << "Setting " << *expr << " = "
+                     << expr->solution.getValue() << "\n";
+      else
+        llvm::dbgs() << "Leaving " << *expr << " unsolved\n";
+    });
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Inference Constraint Problem Mapping
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// A helper class which maps the types and operations in a design to a set of
+/// variables and constraints to be solved later.
+class InferenceMapping {
+public:
+  InferenceMapping(ConstraintSolver &solver) : solver(solver) {}
+
+  void map(CircuitOp op);
+  void map(FModuleOp op);
+  void mapOperation(Operation *op);
+
+  Expr *declareVars(Value value);
+  Expr *declareVars(Type type);
+  Expr *declareVars(FIRRTLType type);
+
+  void constrainTypes(Expr *larger, Expr *smaller);
+
+  Expr *getExpr(Value value);
+  Expr *getExprOrNull(Value value);
+  void setExpr(Value value, Expr *expr);
+
+private:
+  /// The constraint solver into which we emit variables and constraints.
+  ConstraintSolver &solver;
+
+  /// The constraint exprs for each result type of an operation.
+  // TODO: This should actually not map to `Expr *` directly, but rather a
+  // view class that can represent aggregate exprs for bundles/arrays as well.
+  DenseMap<Value, Expr *> opExprs;
+};
+
+} // namespace
+
+void InferenceMapping::map(CircuitOp op) {
+  for (auto &op : *op.getBody()) {
+    if (auto module = dyn_cast<FModuleOp>(&op))
+      map(module);
+  }
+}
+
+void InferenceMapping::map(FModuleOp module) {
+  // Ensure we have constraint variables for the module ports.
+  for (auto arg : module.getArguments())
+    declareVars(arg);
+
+  // Go through operations, creating type variables for results, and generating
+  // constraints.
+  module.walk([&](Operation *op) { mapOperation(op); });
+}
+
+void InferenceMapping::mapOperation(Operation *op) {
+  TypeSwitch<Operation *>(op)
+      .Case<ConstantOp>([&](auto op) {
+        // Constants just use the bit width of the APInt. This is guaranteed to
+        // match the width of the type if the latter has a width assigned.
+        auto e = solver.known(op.value().getBitWidth());
+        setExpr(op.getResult(), e);
+      })
+      .Case<WireOp>([&](auto op) { declareVars(op.getResult()); })
+      .Case<AddPrimOp, SubPrimOp>([&](auto op) {
+        auto lhs = getExpr(op.lhs());
+        auto rhs = getExpr(op.rhs());
+        auto e = solver.add(solver.max(lhs, rhs), solver.known(1));
+        setExpr(op.getResult(), e);
+      })
+      .Case<MulPrimOp>([&](auto op) {
+        auto lhs = getExpr(op.lhs());
+        auto rhs = getExpr(op.rhs());
+        auto e = solver.add(lhs, rhs);
+        setExpr(op.getResult(), e);
+      })
+      .Case<DivPrimOp>([&](auto op) {
+        auto lhs = getExpr(op.lhs());
+        Expr *e;
+        if (op.getType().isSigned()) {
+          e = solver.add(lhs, solver.known(1));
+        } else {
+          e = lhs;
+        }
+        setExpr(op.getResult(), e);
+      })
+      .Case<RemPrimOp>([&](auto op) {
+        auto lhs = getExpr(op.lhs());
+        auto rhs = getExpr(op.rhs());
+        auto *e = solver.min(lhs, rhs);
+        setExpr(op.getResult(), e);
+      })
+      .Case<AndPrimOp, OrPrimOp, XorPrimOp>([&](auto op) {
+        auto lhs = getExpr(op.lhs());
+        auto rhs = getExpr(op.rhs());
+        auto e = solver.max(lhs, rhs);
+        setExpr(op.getResult(), e);
+      })
+      .Case<LEQPrimOp, LTPrimOp, GEQPrimOp, GTPrimOp, EQPrimOp, NEQPrimOp>(
+          [&](auto op) {
+            auto e = solver.known(1);
+            setExpr(op.getResult(), e);
+          })
+      .Case<MuxPrimOp>([&](auto op) {
+        // Caveat: The Scala implementation imposes a constraint on the select
+        // signal to be at least 1 bit wide. The FIRRTL MLIR dialect requries
+        // the select signal to be exactly `uint<1>` anyway, so this constraint
+        // is not needed here.
+        auto high = getExpr(op.high());
+        auto low = getExpr(op.low());
+        auto e = solver.max(high, low);
+        setExpr(op.getResult(), e);
+      })
+      // Handle the various connect statements that imply a type constraint.
+      .Case<ConnectOp>([&](auto op) {
+        auto dest = getExpr(op.dest());
+        auto src = getExpr(op.src());
+        constrainTypes(dest, src);
+      });
+  // TODO: Handle PartialConnect
+  // TODO: Handle DefRegister
+  // TODO: Handle Attach
+  // TODO: Handle Conditionally
+}
+
+/// Declare free variables for the type of a value, and associate the resulting
+/// set of variables with that value.
+Expr *InferenceMapping::declareVars(Value value) {
+  Expr *e = declareVars(value.getType());
+  setExpr(value, e);
+  return e;
+}
+
+/// Declare free variables for a type.
+Expr *InferenceMapping::declareVars(Type type) {
+  if (auto ftype = type.dyn_cast<FIRRTLType>())
+    return declareVars(ftype);
+  // TODO: Once we support compound types, non-FIRRTL types will just map to an
+  // empty list of expressions in the solver. At that point we'll have something
+  // proper to return here.
+  llvm_unreachable("non-FIRRTL ops not supported");
+}
+
+/// Declare free variables for a FIRRTL type.
+Expr *InferenceMapping::declareVars(FIRRTLType type) {
+  // TODO: Support aggregate and compound types as well.
+  auto width = type.getBitWidthOrSentinel();
+  if (width >= 0) {
+    return solver.known(width);
+  } else if (width == -1) {
+    return solver.var();
+  } else if (auto inner = type.dyn_cast<FlipType>()) {
+    return declareVars(inner.getElementType());
+  } else {
+    // TODO: Once we support compound types, non-FIRRTL types will just map to
+    // an empty list of expressions in the solver. At that point we'll have
+    // something proper to return here.
+    llvm_unreachable("non-FIRRTL ops not supported");
+  }
+}
+
+/// Establishes constraints to ensure the sizes in the `larger` type are greater
+/// than or equal to the sizes in the `smaller` type.
+void InferenceMapping::constrainTypes(Expr *larger, Expr *smaller) {
+  // Mimic the Scala implementation here by simply doing nothing if the larger
+  // expr is not a free variable. Apparently there are many cases where useless
+  // constraints can be added, e.g. on multiple well-known values. As long as we
+  // don't want to do type checking itself here, but only width inference, we
+  // should be fine ignoring expr we cannot constraint anyway.
+  if (auto largerVar = dyn_cast<VarExpr>(larger)) {
+    auto c = solver.addGeqConstraint(largerVar, smaller);
+    LLVM_DEBUG(llvm::dbgs()
+               << "Constrained " << *largerVar << " >= " << *c << "\n");
+  }
+}
+
+/// Get the constraint expression for a value.
+Expr *InferenceMapping::getExpr(Value value) {
+  auto expr = getExprOrNull(value);
+  assert(expr && "constraint expr should have been constructed for value");
+  return expr;
+}
+
+/// Get the constraint expression for a value, or null if no expression exists
+/// for the value.
+Expr *InferenceMapping::getExprOrNull(Value value) {
+  auto it = opExprs.find(value);
+  return it != opExprs.end() ? it->second : nullptr;
+}
+
+/// Associate a constraint expression with a value.
+void InferenceMapping::setExpr(Value value, Expr *expr) {
+  LLVM_DEBUG(llvm::dbgs() << "Expr " << *expr << " for " << value << "\n");
+  opExprs.insert(std::make_pair(value, expr));
+}
+
+//===----------------------------------------------------------------------===//
+// Inference Result Application
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// A helper class which maps the types and operations in a design to a set of
+/// variables and constraints to be solved later.
+class InferenceTypeUpdate {
+public:
+  InferenceTypeUpdate(InferenceMapping &mapping) : mapping(mapping) {}
+
+  void update(CircuitOp op);
+  bool updateOperation(Operation *op);
+  bool updateValue(Value value);
+  FIRRTLType updateType(FIRRTLType type, uint32_t solution);
+
+private:
+  InferenceMapping &mapping;
+};
+
+} // namespace
+
+/// Update the types throughout a circuit.
+void InferenceTypeUpdate::update(CircuitOp op) {
+  op.walk([&](Operation *op) { updateOperation(op); });
+}
+
+/// Update the result types of an operation.
+bool InferenceTypeUpdate::updateOperation(Operation *op) {
+  bool anyChanged = false;
+  for (Value v : op->getResults()) {
+    anyChanged |= updateValue(v);
+  }
+
+  // If this is a module, update its ports.
+  if (auto module = dyn_cast<FModuleOp>(op)) {
+    // Update the block argument types.
+    bool argsChanged = false;
+    std::vector<Type> argTypes;
+    argTypes.reserve(module.getArguments().size());
+    for (auto arg : module.getArguments()) {
+      argsChanged |= updateValue(arg);
+      argTypes.push_back(arg.getType());
+    }
+
+    // Update the module function type if needed.
+    if (argsChanged) {
+      auto type =
+          FunctionType::get(op->getContext(), argTypes, /*resultTypes*/ {});
+      module->setAttr(FModuleOp::getTypeAttrName(), TypeAttr::get(type));
+      anyChanged = true;
+    }
+  }
+  return anyChanged;
+}
+
+/// Resize a `uint`, `sint`, or `analog` type to a specific width.
+static FIRRTLType resizeType(FIRRTLType type, uint32_t newWidth) {
+  auto *context = type.getContext();
+  return TypeSwitch<FIRRTLType, FIRRTLType>(type)
+      .Case<UIntType>(
+          [&](auto type) { return UIntType::get(context, newWidth); })
+      .Case<SIntType>(
+          [&](auto type) { return SIntType::get(context, newWidth); })
+      .Case<AnalogType>(
+          [&](auto type) { return AnalogType::get(context, newWidth); })
+      .Default([&](auto type) { return type; });
+}
+
+/// Update the type of a value.
+bool InferenceTypeUpdate::updateValue(Value value) {
+  // Check if the value has a type which we can update.
+  auto type = value.getType().dyn_cast<FIRRTLType>();
+  if (!type)
+    return false;
+
+  // Get the inferred width.
+  Expr *expr = mapping.getExprOrNull(value);
+  if (!expr || !expr->solution.hasValue())
+    return false;
+  int32_t solution = expr->solution.getValue();
+  if (solution <= 0)
+    return false;
+
+  // Update the type.
+  auto newType = updateType(type, solution);
+  LLVM_DEBUG(llvm::dbgs() << "Update " << value << " to " << newType << "\n");
+  value.setType(newType);
+
+  return newType != type;
+}
+
+/// Update a type.
+FIRRTLType InferenceTypeUpdate::updateType(FIRRTLType type, uint32_t solution) {
+  // TODO: This should actually take an aggregate bunch of constraint
+  // expressions such that aggregate types can pick them apart appropriately.
+  if (auto flip = type.dyn_cast<FlipType>()) {
+    return FlipType::get(updateType(flip.getElementType(), solution));
+  } else if (type.getBitWidthOrSentinel() == -1) {
+    return resizeType(type, solution);
+  } else {
+    return type;
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Hashing
+//===----------------------------------------------------------------------===//
+
+// Hash slots in the interned allocator as if they were the pointed-to value
+// itself.
+namespace llvm {
+template <typename T>
+struct DenseMapInfo<InternedSlot<T>> {
+  using Slot = InternedSlot<T>;
+  static Slot getEmptyKey() {
+    auto pointer = llvm::DenseMapInfo<void *>::getEmptyKey();
+    return Slot(static_cast<T *>(pointer));
+  }
+  static Slot getTombstoneKey() {
+    auto pointer = llvm::DenseMapInfo<void *>::getTombstoneKey();
+    return Slot(static_cast<T *>(pointer));
+  }
+  static unsigned getHashValue(Slot val) { return mlir::hash_value(*val.ptr); }
+  static bool isEqual(Slot LHS, Slot RHS) {
+    auto empty = getEmptyKey().ptr;
+    auto tombstone = getTombstoneKey().ptr;
+    if (LHS.ptr == empty || RHS.ptr == empty || LHS.ptr == tombstone ||
+        RHS.ptr == tombstone)
+      return LHS.ptr == RHS.ptr;
+    return *LHS.ptr == *RHS.ptr;
+  }
+};
+} // namespace llvm
+
+//===----------------------------------------------------------------------===//
+// Pass Infrastructure
+//===----------------------------------------------------------------------===//
+
+namespace {
+class InferWidthsPass : public InferWidthsBase<InferWidthsPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+void InferWidthsPass::runOnOperation() {
+  // Collect variables and constraints
+  ConstraintSolver solver;
+  InferenceMapping mapping(solver);
+  mapping.map(getOperation());
+  LLVM_DEBUG({
+    llvm::dbgs() << "Constraints:\n";
+    solver.dumpConstraints(llvm::dbgs());
+  });
+
+  // Solve the constraints.
+  solver.solve();
+
+  // Update the types with the inferred widths.
+  InferenceTypeUpdate(mapping).update(getOperation());
+}
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createInferWidthsPass() {
+  return std::make_unique<InferWidthsPass>();
+}

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -1,0 +1,125 @@
+// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-infer-widths)' --verify-diagnostics %s | FileCheck %s
+
+firrtl.circuit "Foo" {
+  // CHECK-LABEL: @InferConstant
+  // CHECK-SAME: %out0: !firrtl.flip<uint<42>>
+  // CHECK-SAME: %out1: !firrtl.flip<sint<42>>
+  firrtl.module @InferConstant(%out0: !firrtl.flip<uint>, %out1: !firrtl.flip<sint>) {
+    %0 = firrtl.constant(1 : ui42) : !firrtl.uint
+    %1 = firrtl.constant(2 : si42) : !firrtl.sint
+    firrtl.connect %out0, %0 : !firrtl.flip<uint>, !firrtl.uint
+    firrtl.connect %out1, %1 : !firrtl.flip<sint>, !firrtl.sint
+  }
+
+  // CHECK-LABEL: @InferOutput
+  // CHECK-SAME: %out: !firrtl.flip<uint<2>>
+  firrtl.module @InferOutput(%in: !firrtl.uint<2>, %out: !firrtl.flip<uint>) {
+    firrtl.connect %out, %in : !firrtl.flip<uint>, !firrtl.uint<2>
+  }
+
+  // CHECK-LABEL: @AddSubOp
+  firrtl.module @AddSubOp() {
+    // CHECK: %0 = firrtl.wire : !firrtl.uint<2>
+    // CHECK: %1 = firrtl.wire : !firrtl.uint<3>
+    // CHECK: %2 = firrtl.add {{.*}} -> !firrtl.uint<4>
+    // CHECK: %3 = firrtl.sub {{.*}} -> !firrtl.uint<5>
+    %0 = firrtl.wire : !firrtl.uint
+    %1 = firrtl.wire : !firrtl.uint
+    %2 = firrtl.add %0, %1 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %3 = firrtl.sub %0, %2 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
+    %c2_ui3 = firrtl.constant(2 : ui3) : !firrtl.uint<3>
+    firrtl.connect %0, %c1_ui2 : !firrtl.uint, !firrtl.uint<2>
+    firrtl.connect %1, %c2_ui3 : !firrtl.uint, !firrtl.uint<3>
+  }
+
+  // CHECK-LABEL: @MulDivRemOp
+  firrtl.module @MulDivRemOp() {
+    // CHECK: %0 = firrtl.wire : !firrtl.uint<2>
+    // CHECK: %1 = firrtl.wire : !firrtl.uint<3>
+    // CHECK: %2 = firrtl.wire : !firrtl.sint<2>
+    // CHECK: %3 = firrtl.wire : !firrtl.sint<3>
+    // CHECK: %4 = firrtl.mul {{.*}} -> !firrtl.uint<5>
+    // CHECK: %5 = firrtl.div {{.*}} -> !firrtl.uint<3>
+    // CHECK: %6 = firrtl.div {{.*}} -> !firrtl.sint<4>
+    // CHECK: %7 = firrtl.rem {{.*}} -> !firrtl.uint<2>
+    %0 = firrtl.wire : !firrtl.uint
+    %1 = firrtl.wire : !firrtl.uint
+    %2 = firrtl.wire : !firrtl.sint
+    %3 = firrtl.wire : !firrtl.sint
+    %4 = firrtl.mul %1, %0 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %5 = firrtl.div %1, %0 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %6 = firrtl.div %3, %2 : (!firrtl.sint, !firrtl.sint) -> !firrtl.sint
+    %7 = firrtl.rem %1, %0 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
+    %c2_ui3 = firrtl.constant(2 : ui3) : !firrtl.uint<3>
+    %c1_si2 = firrtl.constant(1 : si2) : !firrtl.sint<2>
+    %c2_si3 = firrtl.constant(2 : si3) : !firrtl.sint<3>
+    firrtl.connect %0, %c1_ui2 : !firrtl.uint, !firrtl.uint<2>
+    firrtl.connect %1, %c2_ui3 : !firrtl.uint, !firrtl.uint<3>
+    firrtl.connect %2, %c1_si2 : !firrtl.sint, !firrtl.sint<2>
+    firrtl.connect %3, %c2_si3 : !firrtl.sint, !firrtl.sint<3>
+  }
+
+  // CHECK-LABEL: @AndOrXorOp
+  firrtl.module @AndOrXorOp() {
+    // CHECK: %0 = firrtl.wire : !firrtl.uint<2>
+    // CHECK: %1 = firrtl.wire : !firrtl.uint<3>
+    // CHECK: %2 = firrtl.and {{.*}} -> !firrtl.uint<3>
+    // CHECK: %3 = firrtl.or {{.*}} -> !firrtl.uint<3>
+    // CHECK: %4 = firrtl.xor {{.*}} -> !firrtl.uint<3>
+    %0 = firrtl.wire : !firrtl.uint
+    %1 = firrtl.wire : !firrtl.uint
+    %2 = firrtl.and %0, %1 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %3 = firrtl.or %0, %1 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %4 = firrtl.xor %0, %1 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
+    %c2_ui3 = firrtl.constant(2 : ui3) : !firrtl.uint<3>
+    firrtl.connect %0, %c1_ui2 : !firrtl.uint, !firrtl.uint<2>
+    firrtl.connect %1, %c2_ui3 : !firrtl.uint, !firrtl.uint<3>
+  }
+
+  // CHECK-LABEL: @ComparisonOp
+  firrtl.module @ComparisonOp(%a: !firrtl.uint<2>, %b: !firrtl.uint<3>) {
+    // CHECK: %6 = firrtl.wire : !firrtl.uint<1>
+    // CHECK: %7 = firrtl.wire : !firrtl.uint<1>
+    // CHECK: %8 = firrtl.wire : !firrtl.uint<1>
+    // CHECK: %9 = firrtl.wire : !firrtl.uint<1>
+    // CHECK: %10 = firrtl.wire : !firrtl.uint<1>
+    // CHECK: %11 = firrtl.wire : !firrtl.uint<1>
+    %0 = firrtl.leq %a, %b : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<1>
+    %1 = firrtl.lt %a, %b : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<1>
+    %2 = firrtl.geq %a, %b : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<1>
+    %3 = firrtl.gt %a, %b : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<1>
+    %4 = firrtl.eq %a, %b : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<1>
+    %5 = firrtl.neq %a, %b : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<1>
+    %6 = firrtl.wire : !firrtl.uint
+    %7 = firrtl.wire : !firrtl.uint
+    %8 = firrtl.wire : !firrtl.uint
+    %9 = firrtl.wire : !firrtl.uint
+    %10 = firrtl.wire : !firrtl.uint
+    %11 = firrtl.wire : !firrtl.uint
+    firrtl.connect %6, %0 : !firrtl.uint, !firrtl.uint<1>
+    firrtl.connect %7, %1 : !firrtl.uint, !firrtl.uint<1>
+    firrtl.connect %8, %2 : !firrtl.uint, !firrtl.uint<1>
+    firrtl.connect %9, %3 : !firrtl.uint, !firrtl.uint<1>
+    firrtl.connect %10, %4 : !firrtl.uint, !firrtl.uint<1>
+    firrtl.connect %11, %5 : !firrtl.uint, !firrtl.uint<1>
+  }
+
+  // CHECK-LABEL: @MuxOp
+  firrtl.module @MuxOp(%a: !firrtl.uint<1>) {
+    // CHECK: %0 = firrtl.wire : !firrtl.uint<2>
+    // CHECK: %1 = firrtl.wire : !firrtl.uint<3>
+    // CHECK: %2 = firrtl.mux{{.*}} -> !firrtl.uint<3>
+    %0 = firrtl.wire : !firrtl.uint
+    %1 = firrtl.wire : !firrtl.uint
+    %2 = firrtl.mux(%a, %0, %1) : (!firrtl.uint<1>, !firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
+    %c2_ui3 = firrtl.constant(2 : ui3) : !firrtl.uint<3>
+    firrtl.connect %0, %c1_ui2 : !firrtl.uint, !firrtl.uint<2>
+    firrtl.connect %1, %c2_ui3 : !firrtl.uint, !firrtl.uint<3>
+  }
+
+  firrtl.module @Foo() {}
+}


### PR DESCRIPTION
Add a first basic implementation of an `InferWidths` pass modeled after the corresponding Scala pass. The pass goes through the IR and constructs a constraint problem where the type width of wires and module ports are represented as free variables, and connects impose constraints on those variables depending on their right-hand side.

This first implementation is purposefully kept simple and only deals with non-aggregate types and simple connects to wires. Constraints between modules are not modeled yet either. I'll add issues to track expanding this pass to cover more ground, which should be fairly straightforward after iterating on this first implementation a bit.

Currently supported are the following operations:
- `ConstantOp`
- `WireOp`
- `AddPrimOp`
- `SubPrimOp`
- `MulPrimOp`
- `DivPrimOp`
- `RemPrimOp`
- `AndPrimOp`
- `OrPrimOp`
- `XorPrimOp`
- `LEQPrimOp`
- `LTPrimOp`
- `GEQPrimOp`
- `GTPrimOp`
- `EQPrimOp`
- `NEQPrimOp`
- `MuxPrimOp`
- `ConnectOp`

### Example
As a concrete example, the pass can transform this IR:
```
firrtl.module @Foo(%a: !firrtl.uint<2>, %b: !firrtl.uint<3>) {
  %0 = firrtl.wire : !firrtl.uint
  %1 = firrtl.wire : !firrtl.uint
  %2 = firrtl.add %0, %1 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
  %3 = firrtl.sub %0, %2 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
  firrtl.connect %0, %a : !firrtl.uint, !firrtl.uint<2>
  firrtl.connect %1, %b : !firrtl.uint, !firrtl.uint<3>
}
```
To the following IR:
```
firrtl.module @Foo(...) {
  %0 = firrtl.wire : !firrtl.uint<2>
  %1 = firrtl.wire : !firrtl.uint<3>
  %2 = firrtl.add %0, %1 : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<4>
  %3 = firrtl.sub %0, %2 : (!firrtl.uint<2>, !firrtl.uint<4>) -> !firrtl.uint<5>
  [...]
}
```

### Implementation
The general idea is to infer widths in three steps: (1) walk over the IR and assemble a constraint problem from the operations, (2) solve the constraint problem, and (3) update the types in the IR with the solution.

The `InferenceMapping` class keeps track of how the type of an operation/port maps to a constraint expression. For example, a wire with type `uint` will map to a free variable for width of the `uint` in the constraint problem. Aggregate types generate multiple variables/constraint expressions. For example, a wire with type `bundle<a: uint, b: uint>` will have to map to two free variables, one for each `uint`. Currently the pass only supports non-aggregate types. Adding support for aggregate types will require extending `InferenceMapping` such that it can track multiple constraint expressions for a type (currently it assumes a 1:1 mapping suitable for non-aggregates).

A handful of operations in FIRRTL impose constraints: connect, partial connect, registers, attach, and "conditionally". Currently only connect is supported as a proof of concept. The imposed constraint is for the LHS to be greater than or equal than the RHS. This is a sort of type unification step, where constraining an aggregate type translates into multiple constraints on the inner types (e.g. element-wise for bundles). That also involves flipping the order of the constraint in for flip types.

The `ConstraintSolver` class keeps track of the expressions and constraints, and has `solve()` method. The current implementation is very primitive. It tries to establish a depth-first order among the constraints and then fill in the solution in one go. Cyclic dependencies are detected and broken, but are likely to lead to uninferred widths remaining in the IR. This is actually not that far from the Scala FIRRTL compiler, which relies heavily on aggressive reshaping of the constraint expressions to then fill in results in a forward and backward pass. Both implementations are not complete in the sense that there are constraint problems that have a solution but for which neither implementation will find one. A follow-up task of this PR will be to carefully look into what kind of cycles among the constraints are actually generated by Chisel, what exact shape of problems the Scala impl can find a solution to, and how this can be translated to this MLIR implementation (maybe with less memory allocs).

Finally the `InferenceTypeUpdate` class provides some context and facilities to walk the IR and substitute types with the inferred widths. This is trivial now since we don't support aggregate types. Later on, this will require dissecting aggregate types, getting the solution from the constraint solver, and zipping the new types together into new aggregates.