### PR TITLE
Add suuport for system verilog bind statements.

### DIFF
--- a/include/circt/Dialect/RTL/RTLOps.h
+++ b/include/circt/Dialect/RTL/RTLOps.h
@@ -53,6 +53,9 @@ bool isAnyModule(Operation *module);
 /// Return the signature for the specified module as a function type.
 FunctionType getModuleType(Operation *module);
 
+/// Returns the verilog module name attr of any module-like type
+StringAttr getVerilogModuleNameAttr(Operation *module);
+
 /// Return the port name for the specified argument or result.
 StringAttr getModuleArgumentNameAttr(Operation *module, size_t argNo);
 StringAttr getModuleResultNameAttr(Operation *module, size_t argNo);

--- a/include/circt/Dialect/RTL/RTLStructure.td
+++ b/include/circt/Dialect/RTL/RTLStructure.td
@@ -19,7 +19,8 @@ def RTLModuleOp : RTLOp<"module",
     name, a list of ports, and a body that represents the connections within
     the module.
   }];
-  let arguments = (ins StrArrayAttr:$argNames, StrArrayAttr:$resultNames);
+  let arguments = (ins StrArrayAttr:$argNames, StrArrayAttr:$resultNames, 
+                       OptionalAttr<StrAttr>:$verilogName);
   let results = (outs);
   let regions = (region SizedRegion<1>:$body);
 
@@ -55,6 +56,11 @@ def RTLModuleOp : RTLOp<"module",
     StringRef getName() {
       return getNameAttr().getValue();
     }
+
+    /// Return the name to use for the Verilog module that we're referencing
+    /// here.  This is typically the symbol, but can be overridden with the
+    /// verilogName attribute.
+    StringAttr getVerilogModuleNameAttr();
 
   private:
     // This trait needs access to the hooks defined below.

--- a/include/circt/Dialect/SV/SVOps.h
+++ b/include/circt/Dialect/SV/SVOps.h
@@ -15,6 +15,7 @@
 
 #include "circt/Dialect/SV/SVDialect.h"
 #include "circt/Dialect/SV/SVTypes.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -10,6 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+/// Ensure symbol is one of the rtl module.* types
+def isModLikeSym : AttrConstraint<
+  CPred<
+    "rtl::isAnyModule(::mlir::SymbolTable::lookupNearestSymbolFrom("
+      "&$_op, $_self.cast<::mlir::FlatSymbolRefAttr>().getValue()))"
+  >, "is module like">;
+
 //===----------------------------------------------------------------------===//
 // Control flow like-operations
 //===----------------------------------------------------------------------===//
@@ -473,4 +480,28 @@ def CoverOp : SVOp<"cover", [ProceduralOp]> {
   let arguments = (ins AnyType:$property);
   let results = (outs);
   let assemblyFormat = "attr-dict $property `:` type($property)";
+}
+
+def BindOp : SVOp<"bind", [IsolatedFromAbove, HasParent<"mlir::ModuleOp">]> {
+  let summary = "indirect instantiation statement";
+  let description = [{
+    Indirectly instantiate a module in the context of another module.  This
+    implements all-instance module binding in system verilog.  This will
+    generate and validate ".*" name binding.
+  }];
+
+  let arguments = (ins StrAttr:$instanceName, Confined<FlatSymbolRefAttr, [isModLikeSym]>:$src, Confined<FlatSymbolRefAttr, [isModLikeSym]>:$dest);
+  let results = (outs);
+
+  let assemblyFormat = [{$instanceName $src $dest attr-dict}];
+
+  let extraClassDeclaration = [{
+    /// Lookup the module or extmodule for the src symbol.  This returns null on
+    /// invalid IR.
+    Operation *getReferencedSrcModule();
+
+    /// Lookup the module or extmodule for the dest symbol.  This returns null on
+    /// invalid IR.
+    Operation *getReferencedDestModule();
+  }];
 }

--- a/lib/Dialect/RTL/RTLOps.cpp
+++ b/lib/Dialect/RTL/RTLOps.cpp
@@ -126,6 +126,18 @@ FunctionType rtl::getModuleType(Operation *module) {
   return typeAttr.getValue().cast<FunctionType>();
 }
 
+/// Return the name to use for the Verilog module that we're referencing
+/// here.  This is typically the symbol, but can be overridden with the
+/// verilogName attribute.
+StringAttr rtl::getVerilogModuleNameAttr(Operation *module) {
+  auto nameAttr = module->getAttrOfType<StringAttr>("verilogName");
+  if (nameAttr)
+    return nameAttr;
+
+  return module->getAttrOfType<StringAttr>(
+      ::mlir::SymbolTable::getSymbolAttrName());
+}
+
 /// Return the port name for the specified argument or result.
 StringAttr rtl::getModuleArgumentNameAttr(Operation *module, size_t argNo) {
   return module->getAttrOfType<ArrayAttr>("argNames")[argNo].cast<StringAttr>();
@@ -517,6 +529,17 @@ static void printModuleSignature(OpAsmPrinter &p, Operation *op,
     }
     os << ')';
   }
+}
+
+/// Return the name to use for the Verilog module that we're referencing
+/// here.  This is typically the symbol, but can be overridden with the
+/// verilogName attribute.
+StringAttr RTLModuleOp::getVerilogModuleNameAttr() {
+  if (auto vName = verilogNameAttr())
+    return vName;
+
+  return (*this)->getAttrOfType<StringAttr>(
+      ::mlir::SymbolTable::getSymbolAttrName());
 }
 
 static void printModuleOp(OpAsmPrinter &p, Operation *op,

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -933,6 +933,26 @@ LogicalResult PAssignOp::canonicalize(PAssignOp op, PatternRewriter &rewriter) {
 }
 
 //===----------------------------------------------------------------------===//
+// BindOp
+//===----------------------------------------------------------------------===//
+
+Operation *BindOp::getReferencedSrcModule() {
+  auto topLevelModuleOp = (*this)->getParentOfType<ModuleOp>();
+  if (!topLevelModuleOp)
+    return nullptr;
+
+  return topLevelModuleOp.lookupSymbol(src());
+}
+
+Operation *BindOp::getReferencedDestModule() {
+  auto topLevelModuleOp = (*this)->getParentOfType<ModuleOp>();
+  if (!topLevelModuleOp)
+    return nullptr;
+
+  return topLevelModuleOp.lookupSymbol(dest());
+}
+
+//===----------------------------------------------------------------------===//
 // TableGen generated logic.
 //===----------------------------------------------------------------------===//
 

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -156,3 +156,8 @@ rtl.module @test1(%arg0: i1, %arg1: i1, %arg8: i8) {
   // CHECK-NEXT: rtl.output
   rtl.output
 }
+
+//CHECK-LABEL: sv.bind "testinst" @test1 @test2
+//CHECK-NEXT: rtl.module.extern @test2
+sv.bind "testinst" @test1 @test2
+rtl.module.extern @test2(%arg0: i1, %arg1: i1, %arg8: i8)

--- a/test/Dialect/SV/errors.mlir
+++ b/test/Dialect/SV/errors.mlir
@@ -141,3 +141,9 @@ rtl.module @Cover(%arg0: i1) {
   // expected-error @+1 {{sv.cover should be in a procedural region}}
   sv.cover %arg0: i1
 }
+
+// -----
+rtl.module.extern @test1(%arg0: i1, %arg1: i1, %arg8: i8)
+func @test2(%arg0: i1, %arg1: i1, %arg8: i8) { return }
+// expected-error @+1 {{'sv.bind' op attribute 'dest' failed to satisfy constraint: flat symbol reference attribute is module like}}
+sv.bind "testinst" @test1 @test2

--- a/test/ExportVerilog/sv-dialect.mlir
+++ b/test/ExportVerilog/sv-dialect.mlir
@@ -714,8 +714,8 @@ rtl.module @ConstantDefAfterUse() {
 
 // Constants defined in a procedural block with users in a different block
 // should be emitted at the top of their defining block.
-// CHECK-LABEL: module ConstantEmissionAtTopOfBlock
-rtl.module @ConstantEmissionAtTopOfBlock() {
+// CHECK-LABEL: module OtherName
+rtl.module @ConstantEmissionAtTopOfBlock() attributes {verilogName = "OtherName"} {
   %myreg = sv.reg : !rtl.inout<i32>
   // CHECK:      always @* begin
   // CHECK-NEXT:   localparam [31:0] _T = 32'h2A;
@@ -728,3 +728,6 @@ rtl.module @ConstantEmissionAtTopOfBlock() {
     }
   }
 }
+
+//CHECK-LABEL: bind ConstantDefAfterUse OtherName foobar_inst (.*)
+sv.bind "foobar_inst" @ConstantDefAfterUse @ConstantEmissionAtTopOfBlock


### PR DESCRIPTION
Bind statements act as remote instantiation of a module inside another module.  This initially only handles all-module-instances paths (most common), and identical name binding.