### PR TITLE
[RTLToLLHD] Add conversion for modules and instances with comb ops

### DIFF
--- a/test/Conversion/RTLToLLHD/errors.mlir
+++ b/test/Conversion/RTLToLLHD/errors.mlir
@@ -1,8 +1,14 @@
 // RUN: circt-opt -convert-rtl-to-llhd -split-input-file -verify-diagnostics %s
 
 module {
-  // expected-error @+1 {{failed to legalize operation 'rtl.module'}}
-  rtl.module @test(%in: f16) -> (%out: f16) {
+  // Since RTL-to-LLHD needs to construct a zero value for temporary signals,
+  // we don't support non-IntegerType arguments to instances.
+  rtl.module @sub(%in: f16) -> (%out: f16) {
     rtl.output %in: f16
+  }
+  rtl.module @test(%in: f16) -> (%out: f16) {
+    // expected-error @+1 {{failed to legalize operation 'rtl.instance'}}
+    %0 = rtl.instance "sub1" @sub (%in) : (f16) -> (f16)
+    rtl.output %0: f16
   }
 }

--- a/test/Conversion/RTLToLLHD/structure.mlir
+++ b/test/Conversion/RTLToLLHD/structure.mlir
@@ -1,18 +1,25 @@
-// RUN: circt-opt -convert-rtl-to-llhd -split-input-file -verify-diagnostics %s | FileCheck %s
+// RUN: circt-opt --convert-rtl-to-llhd --verify-diagnostics %s | FileCheck %s
 
 module {
-  // CHECK-LABEL: llhd.entity @test
+  // CHECK-LABEL: llhd.entity @FeedThrough
   // CHECK-SAME: (%[[IN:.+]] : !llhd.sig<i1>) ->
   // CHECK-SAME: (%[[OUT:.+]] : !llhd.sig<i1>)
-  rtl.module @test(%in: i1) -> (%out: i1) {
+  rtl.module @FeedThrough(%in: i1) -> (%out: i1) {
     // CHECK: llhd.con %[[OUT]], %[[IN]]
     rtl.output %in: i1
   }
-}
 
-// -----
+  // CHECK-LABEL: llhd.entity @CombOp
+  // CHECK-SAME: (%[[IN:.+]] : !llhd.sig<i1>) ->
+  // CHECK-SAME: (%[[OUT:.+]] : !llhd.sig<i1>)
+  rtl.module @CombOp(%in: i1) -> (%out: i1) {
+    // CHECK: %[[PRB:.+]] = llhd.prb %[[IN]]
+    // CHECK: %[[ADD:.+]] = comb.add %[[PRB]], %[[PRB]]
+    // CHECK: llhd.drv %[[OUT]], %[[ADD]]
+    %0 = comb.add %in, %in : i1
+    rtl.output %0: i1
+  }
 
-module {
   // CHECK-LABEL: llhd.entity @sub
   // CHECK-SAME: ({{.+}} : !llhd.sig<i1>) ->
   // CHECK-SAME: ({{.+}} : !llhd.sig<i1>)
@@ -20,12 +27,57 @@ module {
     rtl.output %in : i1
   }
 
-  // CHECK-LABEL: llhd.entity @top
+  // CHECK-LABEL: llhd.entity @SimpleInstance
   // CHECK-SAME: (%[[IN:.+]] : !llhd.sig<i1>) ->
   // CHECK-SAME: (%[[OUT:.+]] : !llhd.sig<i1>)
-  rtl.module @top(%in: i1) -> (%out: i1) {
+  rtl.module @SimpleInstance(%in: i1) -> (%out: i1) {
     // CHECK: llhd.inst "sub1" @sub(%[[IN]]) -> (%[[OUT]]) : (!llhd.sig<i1>) -> !llhd.sig<i1>
     %0 = rtl.instance "sub1" @sub (%in) : (i1) -> i1
     rtl.output %0 : i1
+  }
+
+  // CHECK-LABEL: llhd.entity @InstanceWithLocalOps
+  // CHECK-SAME: (%[[IN:.+]] : !llhd.sig<i1>) ->
+  // CHECK-SAME: (%[[OUT:.+]] : !llhd.sig<i1>)
+  rtl.module @InstanceWithLocalOps(%in: i1) -> (%out: i1) {
+    // CHECK: %[[PRB:.+]] = llhd.prb %[[IN]]
+    // CHECK: %[[ADD1:.+]] = comb.add %[[PRB]], %[[PRB]]
+    // CHECK: llhd.drv %[[ARG_SIG:.+]], %[[ADD1]]
+    // CHECK: %[[RES_SIG:.+]] = llhd.sig
+    // CHECK: %[[RES:.+]] = llhd.prb %[[RES_SIG]]
+    // CHECK: llhd.inst "sub1" @sub(%[[ARG_SIG]]) -> (%[[RES_SIG]]) : (!llhd.sig<i1>) -> !llhd.sig<i1>
+    // CHECK: %[[ADD2:.+]] = comb.add %[[RES]], %[[RES]]
+    // CHECK: llhd.drv %[[OUT:.+]], %[[ADD2]]
+    %0 = comb.add %in, %in : i1
+    %1 = rtl.instance "sub1" @sub (%0) : (i1) -> i1
+    %2 = comb.add %1, %1 : i1
+    rtl.output %2 : i1
+  }
+
+  // CHECK-LABEL: llhd.entity @InstanceDirectlyDrivingMultipleOutputs
+  // CHECK-SAME: (%[[IN:.+]] : !llhd.sig<i1>) -> (
+  // CHECK-SAME: %[[OUT1:.+]] : !llhd.sig<i1>,
+  // CHECK-SAME: %[[OUT2:.+]] : !llhd.sig<i1>)
+  rtl.module @InstanceDirectlyDrivingMultipleOutputs(%in: i1) -> (%out1: i1, %out2: i1) {
+    // CHECK: llhd.inst "sub1" @sub(%[[IN]]) -> (%[[OUT2]]) : (!llhd.sig<i1>) -> !llhd.sig<i1>
+    // CHECK: llhd.con %[[OUT1]], %[[OUT2]]
+    %0 = rtl.instance "sub1" @sub (%in) : (i1) -> i1
+    rtl.output %0, %0 : i1, i1
+  }
+
+  // CHECK-LABEL: llhd.entity @InstanceIndirectlyDrivingMultipleOutputs
+  // CHECK-SAME: (%[[IN:.+]] : !llhd.sig<i1>) -> (
+  // CHECK-SAME: %[[OUT1:.+]] : !llhd.sig<i1>,
+  // CHECK-SAME: %[[OUT2:.+]] : !llhd.sig<i1>)
+  rtl.module @InstanceIndirectlyDrivingMultipleOutputs(%in: i1) -> (%out1: i1, %out2: i1) {
+    // CHECK: %[[RES_SIG:.+]] = llhd.sig
+    // CHECK: %[[RES:.+]] = llhd.prb %[[RES_SIG]]
+    // CHECK: llhd.inst "sub1" @sub(%[[IN]]) -> (%[[RES_SIG]]) : (!llhd.sig<i1>) -> !llhd.sig<i1>
+    // CHECK: %[[ADD:.+]] = comb.add %[[RES]], %[[RES]]
+    // CHECK: llhd.drv %[[OUT1:.+]], %[[ADD]]
+    // CHECK: llhd.drv %[[OUT2:.+]], %[[ADD]]
+    %0 = rtl.instance "sub1" @sub (%in) : (i1) -> i1
+    %1 = comb.add %0, %0 : i1
+    rtl.output %1, %1 : i1, i1
   }
 }


### PR DESCRIPTION
Extend the RTLToLLHD conversion pass to add support for modules that have combinational (or actually any other) operations in the body. These changes will properly insert temporary signals to connect to LLHD instances, but also provide the necessary probe operations to feed the value through the combinational operations. This is a first step towards supporting RTL simulation through the event loop modeled in LLHD.

Fixes #985.