### PR TITLE
[FIRRTL]  Add Port Direction

### DIFF
--- a/lib/Conversion/FIRRTLToLLHD/FIRRTLToLLHD.cpp
+++ b/lib/Conversion/FIRRTLToLLHD/FIRRTLToLLHD.cpp
@@ -119,12 +119,8 @@ void FIRRTLToLLHDPass::convertModule(firrtl::FModuleOp &module) {
 
     // For now, let's do a simple approach where we only support flip at the top
     // of a port's aggregate type.
-    bool isFlip = false;
+    bool isFlip = port.direction == circt::firrtl::Direction::Output;
     firrtl::FIRRTLType type = port.type;
-    if (auto flipType = type.dyn_cast<firrtl::FlipType>()) {
-      isFlip = true;
-      type = flipType.getElementType();
-    }
 
     // Convert the type. We keep things simple for the time being.
     auto width = type.getBitWidthOrSentinel();

--- a/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
+++ b/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
@@ -804,7 +804,7 @@ void FIRRTLModuleLowering::lowerModuleBody(
     // Outputs need a temporary wire so they can be connect'd to, which we
     // then return.
     Value newArg = bodyBuilder.create<WireOp>(
-        FlipType::get(port.type), "." + port.getName().str() + ".output");
+        port.type, "." + port.getName().str() + ".output");
     // Switch all uses of the old operands to the new ones.
     oldArg.replaceAllUsesWith(newArg);
 

--- a/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
@@ -26,6 +26,10 @@ ArrayAttr firrtl::getModulePortNames(Operation *module) {
   return module->getAttrOfType<ArrayAttr>("portNames");
 }
 
+// If the specified module contains the portDirections attribute, return it.
+mlir::IntegerAttr firrtl::getModulePortDirections(Operation *module) {
+  return module->getAttrOfType<mlir::IntegerAttr>(direction::attrKey);
+}
 namespace {
 
 // We implement the OpAsmDialectInterface so that FIRRTL dialect operations

--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -193,11 +193,10 @@ void ExpandWhensVisitor::process(Block &block) {
 
 void ExpandWhensVisitor::visitDecl(FModuleOp op) {
   // Track any results (flipped arguments) of the module for init coverage.
-  for (auto arg : op.getArguments()) {
-    auto type = arg.getType().cast<FIRRTLType>();
-    if (!type.isPassive())
+  size_t i = 0;
+  for (auto arg : op.getArguments())
+    if (getModulePortDirection(op, i++) == Direction::Output)
       scope[arg] = nullptr;
-  }
 
   process(*op.getBodyBlock());
 }

--- a/test/Conversion/FIRRTLToRTL/errors.mlir
+++ b/test/Conversion/FIRRTLToRTL/errors.mlir
@@ -16,7 +16,7 @@ firrtl.circuit "Div" {
   //          read-under-write => undefined
   // COM: This is a memory with aggregates which is currently not
   // supported.
-  firrtl.module @Div(%clock1: !firrtl.clock, %clock2: !firrtl.clock) {
+  firrtl.module @Div(in %clock1: !firrtl.clock, in %clock2: !firrtl.clock) {
   // expected-error @+2 {{'firrtl.mem' should have simple type and known width}}
   // expected-error @+1 {{'firrtl.mem' op should have already been lowered from a ground type to an aggregate type using the LowerTypes pass}}
     %_M_read, %_M_write = firrtl.mem Undefined {depth = 20 : i64, name = "_M", portNames = ["read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<5>, en: uint<1>, clk: clock, data: flip<bundle<id: uint<4>, other: sint<8>>>>>, !firrtl.flip<bundle<addr: uint<5>, en: uint<1>, clk: clock, data: bundle<id: uint<4>, other: sint<8>>, mask: bundle<id: uint<1>, other: uint<1>>>>
@@ -40,10 +40,10 @@ firrtl.circuit "Div" {
 
   // COM: Unknown widths are unsupported
   // expected-error @+1 {{cannot lower this port type to RTL}}
-  firrtl.module @UnknownWidth(%a: !firrtl.uint) {}
+  firrtl.module @UnknownWidth(in %a: !firrtl.uint) {}
 
   // https://github.com/llvm/circt/issues/778
-  firrtl.module @zero_width_mem(%clock: !firrtl.clock, %reset: !firrtl.uint<1>, %r0en: !firrtl.uint<1>) {
+  firrtl.module @zero_width_mem(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %r0en: !firrtl.uint<1>) {
     %c0_ui4 = firrtl.constant(0 : i4) : !firrtl.uint<4>
     %c0_ui1 = firrtl.constant(false) : !firrtl.uint<1>
     %c0_ui25 = firrtl.constant(0 : i25) : !firrtl.uint<25>

--- a/test/Conversion/FIRRTLToRTL/lower-to-rtl-module.mlir
+++ b/test/Conversion/FIRRTLToRTL/lower-to-rtl-module.mlir
@@ -13,20 +13,18 @@ firrtl.circuit "Simple" {
 
    // CHECK-LABEL: rtl.module.extern @MyParameterizedExtModule(%in: i1) -> (%out: i8)
    // CHECK: attributes {verilogName = "name_thing"}
-   firrtl.extmodule @MyParameterizedExtModule(!firrtl.uint<1> , !firrtl.flip<uint<8>> )
+   firrtl.extmodule @MyParameterizedExtModule(in %in: !firrtl.uint<1>, out %out: !firrtl.uint<8>)
       attributes {defname = "name_thing",
                   parameters = {DEFAULT = 0 : i64,
                                 DEPTH = 3.242000e+01 : f64,
                                 FORMAT = "xyz_timeout=%d\0A",
-                                WIDTH = 32 : i8},
-                  portNames = ["in", "out"]
-                                }
+                                WIDTH = 32 : i8}}
 
    // CHECK-LABEL: rtl.module @Simple(%in1: i4, %in2: i2, %in3: i8) -> (%out4: i4) {
-   firrtl.module @Simple(%in1: !firrtl.uint<4>,
-                        %in2: !firrtl.uint<2>,
-                        %in3: !firrtl.sint<8>,
-                        %out4: !firrtl.flip<uint<4>>) {
+   firrtl.module @Simple(in %in1: !firrtl.uint<4>,
+                         in %in2: !firrtl.uint<2>,
+                         in %in3: !firrtl.sint<8>,
+                         out %out4: !firrtl.uint<4>) {
 
     %1 = firrtl.asUInt %in1 : (!firrtl.uint<4>) -> !firrtl.uint<4>
 
@@ -43,14 +41,14 @@ firrtl.circuit "Simple" {
     // CHECK: [[RESULT:%.+]] = comb.xor
     %5 = firrtl.xor %in2, %4 : (!firrtl.uint<2>, !firrtl.uint<4>) -> !firrtl.uint<4>
 
-    firrtl.connect %out4, %5 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+    firrtl.connect %out4, %5 : !firrtl.uint<4>, !firrtl.uint<4>
     // CHECK-NEXT: rtl.output [[RESULT]] : i4
   }
 
   // CHECK-LABEL: rtl.module @TestInstance(
-  firrtl.module @TestInstance(%u2: !firrtl.uint<2>, %s8: !firrtl.sint<8>,
-                              %clock: !firrtl.clock,
-                              %reset: !firrtl.uint<1>) {
+  firrtl.module @TestInstance(in %u2: !firrtl.uint<2>, in %s8: !firrtl.sint<8>,
+                              in %clock: !firrtl.clock,
+                              in %reset: !firrtl.uint<1>) {
     // CHECK-NEXT: %c0_i2 = rtl.constant
     // CHECK-NEXT: %xyz.out4 = rtl.instance "xyz" @Simple([[ARG1:%.+]], %u2, %s8) : (i4, i2, i8) -> i4
     %xyz:4 = firrtl.instance @Simple {name = "xyz", portNames=["in1", "in2", "in3", "out4"]}
@@ -82,10 +80,10 @@ firrtl.circuit "Simple" {
   }
 
   // CHECK-LABEL: rtl.module @OutputFirst(%in1: i1, %in4: i4) -> (%out4: i4) {
-  firrtl.module @OutputFirst(%out4: !firrtl.flip<uint<4>>,
-                             %in1: !firrtl.uint<1>,
-                             %in4: !firrtl.uint<4>) {
-    firrtl.connect %out4, %in4 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.module @OutputFirst(out %out4: !firrtl.uint<4>,
+                             in %in1: !firrtl.uint<1>,
+                             in %in4: !firrtl.uint<4>) {
+    firrtl.connect %out4, %in4 : !firrtl.uint<4>, !firrtl.uint<4>
 
     // CHECK-NEXT: rtl.output %in4 : i4
   }
@@ -93,32 +91,30 @@ firrtl.circuit "Simple" {
   // CHECK-LABEL: rtl.module @PortMadness(
   // CHECK: %inA: i4, %inB: i4, %inC: i4, %inE: i3)
   // CHECK: -> (%outA: i4, %outB: i4, %outC: i4, %outD: i4, %outE: i4) {
-  firrtl.module @PortMadness(%inA: !firrtl.uint<4>,
-                             %inB: !firrtl.uint<4>,
-                             %inC: !firrtl.uint<4>,
-                             %outA: !firrtl.flip<uint<4>>,
-                             %outB: !firrtl.flip<uint<4>>,
-                             %outC: !firrtl.flip<uint<4>>,
-                             %outD: !firrtl.flip<uint<4>>,
-                             %inE: !firrtl.uint<3>,
-                             %outE: !firrtl.flip<uint<4>>) {
+  firrtl.module @PortMadness(in %inA: !firrtl.uint<4>,
+                             in %inB: !firrtl.uint<4>,
+                             in %inC: !firrtl.uint<4>,
+                             out %outA: !firrtl.uint<4>,
+                             out %outB: !firrtl.uint<4>,
+                             out %outC: !firrtl.uint<4>,
+                             out %outD: !firrtl.uint<4>,
+                             in %inE: !firrtl.uint<3>,
+                             out %outE: !firrtl.uint<4>) {
     // CHECK: [[OUTC:%.+]] = sv.wire : !rtl.inout<i4>
     // CHECK: [[OUTD:%.+]] = sv.wire : !rtl.inout<i4>
 
     // Normal
-    firrtl.connect %outA, %inA : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+    firrtl.connect %outA, %inA : !firrtl.uint<4>, !firrtl.uint<4>
 
     // Multi connect
-    firrtl.connect %outB, %inA : !firrtl.flip<uint<4>>, !firrtl.uint<4>
-    firrtl.connect %outB, %inB : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+    firrtl.connect %outB, %inA : !firrtl.uint<4>, !firrtl.uint<4>
+    firrtl.connect %outB, %inB : !firrtl.uint<4>, !firrtl.uint<4>
 
-    // Use of output as an input.
-    %tmp = firrtl.asPassive %outC : !firrtl.flip<uint<4>>
-    %0 = firrtl.sub %inA, %tmp : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
+    %0 = firrtl.sub %inA, %outC : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
 
     // No connections to outD.
 
-    firrtl.connect %outE, %inE : !firrtl.flip<uint<4>>, !firrtl.uint<3>
+    firrtl.connect %outE, %inE : !firrtl.uint<4>, !firrtl.uint<3>
 
     // CHECK: [[OUTBY:%.+]] = comb.merge %inB, %inA : i4
     // CHECK: [[OUTCR:%.+]] = sv.read_inout %.outC.output
@@ -132,18 +128,18 @@ firrtl.circuit "Simple" {
   // CHECK-LABEL: rtl.module @Analog(%a1: !rtl.inout<i1>) -> (%outClock: i1) {
   // CHECK-NEXT:    %0 = sv.read_inout %a1 : !rtl.inout<i1>
   // CHECK-NEXT:    rtl.output %0 : i1
-  firrtl.module @Analog(%a1: !firrtl.analog<1>,
-                        %outClock: !firrtl.flip<clock>) {
+  firrtl.module @Analog(in %a1: !firrtl.analog<1>,
+                        out %outClock: !firrtl.clock) {
 
     %clock = firrtl.asClock %a1 : (!firrtl.analog<1>) -> !firrtl.clock
-    firrtl.connect %outClock, %clock : !firrtl.flip<clock>, !firrtl.clock
+    firrtl.connect %outClock, %clock : !firrtl.clock, !firrtl.clock
   }
 
   // Issue #373: https://github.com/llvm/circt/issues/373
   // CHECK-LABEL: rtl.module @instance_ooo
-  firrtl.module @instance_ooo(%arg0: !firrtl.uint<2>, %arg1: !firrtl.uint<2>,
-                              %arg2: !firrtl.uint<3>,
-                              %out0: !firrtl.flip<uint<8>>) {
+  firrtl.module @instance_ooo(in %arg0: !firrtl.uint<2>, in %arg1: !firrtl.uint<2>,
+                              in %arg2: !firrtl.uint<3>,
+                              out %out0: !firrtl.uint<8>) {
     // CHECK: %false = rtl.constant false
 
     // CHECK-NEXT: rtl.instance "myext" @MyParameterizedExtModule([[ARG:%.+]]) {parameters
@@ -161,13 +157,13 @@ firrtl.circuit "Simple" {
     // CHECK-NEXT: [[ARG]] = comb.icmp eq [[ADD]], %arg2 : i3
     firrtl.connect %myext#0, %a : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 
-    firrtl.connect %out0, %myext#1 : !firrtl.flip<uint<8>>, !firrtl.uint<8>
+    firrtl.connect %out0, %myext#1 : !firrtl.uint<8>, !firrtl.uint<8>
 
     // CHECK-NEXT: rtl.output %myext.out
   }
 
   // CHECK-LABEL: rtl.module @instance_cyclic
-  firrtl.module @instance_cyclic(%arg0: !firrtl.uint<2>, %arg1: !firrtl.uint<2>) {
+  firrtl.module @instance_cyclic(in %arg0: !firrtl.uint<2>, in %arg1: !firrtl.uint<2>) {
     // CHECK: %myext.out = rtl.instance "myext" @MyParameterizedExtModule(%0)
     %myext:2 = firrtl.instance @MyParameterizedExtModule {name = "myext", portNames=["in", "out"]}
       : !firrtl.flip<uint<1>>, !firrtl.uint<8>
@@ -180,16 +176,16 @@ firrtl.circuit "Simple" {
   }
 
   // CHECK-LABEL: rtl.module @ZeroWidthPorts(%inA: i4) -> (%outa: i4) {
-  firrtl.module @ZeroWidthPorts(%inA: !firrtl.uint<4>,
-                                %inB: !firrtl.uint<0>,
-                                %inC: !firrtl.analog<0>,
-                                %outa: !firrtl.flip<uint<4>>,
-                                %outb: !firrtl.flip<uint<0>>) {
+  firrtl.module @ZeroWidthPorts(in %inA: !firrtl.uint<4>,
+                                in %inB: !firrtl.uint<0>,
+                                in %inC: !firrtl.analog<0>,
+                                out %outa: !firrtl.uint<4>,
+                                out %outb: !firrtl.uint<0>) {
      %0 = firrtl.mul %inA, %inB : (!firrtl.uint<4>, !firrtl.uint<0>) -> !firrtl.uint<4>
-    firrtl.connect %outa, %0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+    firrtl.connect %outa, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 
     %1 = firrtl.mul %inB, %inB : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
-    firrtl.connect %outb, %1 : !firrtl.flip<uint<0>>, !firrtl.uint<0>
+    firrtl.connect %outb, %1 : !firrtl.uint<0>, !firrtl.uint<0>
 
     firrtl.attach %inC, %inC : !firrtl.analog<0>, !firrtl.analog<0>
 
@@ -198,11 +194,11 @@ firrtl.circuit "Simple" {
   }
 
   // CHECK-LABEL: rtl.module @ZeroWidthInstance
-  firrtl.module @ZeroWidthInstance(%iA: !firrtl.uint<4>,
-                                   %iB: !firrtl.uint<0>,
-                                   %iC: !firrtl.analog<0>,
-                                   %oA: !firrtl.flip<uint<4>>,
-                                   %oB: !firrtl.flip<uint<0>>) {
+  firrtl.module @ZeroWidthInstance(in %iA: !firrtl.uint<4>,
+                                   in %iB: !firrtl.uint<0>,
+                                   in %iC: !firrtl.analog<0>,
+                                   out %oA: !firrtl.uint<4>,
+                                   out %oB: !firrtl.uint<0>) {
 
     // CHECK: %myinst.outa = rtl.instance "myinst" @ZeroWidthPorts(%iA) : (i4) -> i4
     %myinst:5 = firrtl.instance @ZeroWidthPorts {name = "myinst", portNames=["inA", "inB", "inC", "outa", "outb"]}
@@ -212,22 +208,22 @@ firrtl.circuit "Simple" {
     firrtl.connect %myinst#0, %iA : !firrtl.flip<uint<4>>, !firrtl.uint<4>
     firrtl.connect %myinst#1, %iB : !firrtl.flip<uint<0>>, !firrtl.uint<0>
     firrtl.attach %myinst#2, %iC : !firrtl.analog<0>, !firrtl.analog<0>
-    firrtl.connect %oA, %myinst#3 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
-    firrtl.connect %oB, %myinst#4 : !firrtl.flip<uint<0>>, !firrtl.uint<0>
+    firrtl.connect %oA, %myinst#3 : !firrtl.uint<4>, !firrtl.uint<4>
+    firrtl.connect %oB, %myinst#4 : !firrtl.uint<0>, !firrtl.uint<0>
 
     // CHECK: rtl.output %myinst.outa
   }
 
   // CHECK-LABEL: rtl.module @SimpleStruct(%source: !rtl.struct<valid: i1, ready: i1, data: i64>) -> (%sink: !rtl.struct<valid: i1, ready: i1, data: i64>) {
   // CHECK-NEXT:    rtl.output %source : !rtl.struct<valid: i1, ready: i1, data: i64>
-  firrtl.module @SimpleStruct(%source: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>,
-                              %sink: !firrtl.flip<bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>>) {
-    firrtl.connect %sink, %source : !firrtl.flip<bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
+  firrtl.module @SimpleStruct(in %source: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>,
+                              out %sink: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>) {
+    firrtl.connect %sink, %source : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
   }
 
   // https://github.com/llvm/circt/issues/690
   // CHECK-LABEL: rtl.module @bar690(%led_0: !rtl.inout<i1>) {
-  firrtl.module @bar690(%led_0: !firrtl.analog<1>) {
+  firrtl.module @bar690(in %led_0: !firrtl.analog<1>) {
   }
   // CHECK-LABEL: rtl.module @foo690()
   firrtl.module @foo690() {
@@ -236,7 +232,7 @@ firrtl.circuit "Simple" {
     %result = firrtl.instance @bar690 {name = "fpga", portNames = ["led_0"]} : !firrtl.analog<1>
   }
   // CHECK-LABEL: rtl.module @foo690a(%a: !rtl.inout<i1>) {
-  firrtl.module @foo690a(%a: !firrtl.analog<1>) {
+  firrtl.module @foo690a(in %a: !firrtl.analog<1>) {
     %result = firrtl.instance @bar690 {name = "fpga", portNames = ["led_0"]} : !firrtl.analog<1>
     firrtl.attach %result, %a: !firrtl.analog<1>, !firrtl.analog<1>
   }
@@ -245,8 +241,8 @@ firrtl.circuit "Simple" {
   // CHECK-LABEL: rtl.module @foo740(%led_0: !rtl.inout<i1>) {
   // CHECK:  %.led_0.wire = sv.wire
   // CHECK-NEXT:  rtl.instance "fpga" @bar740(%.led_0.wire)
-  firrtl.extmodule @bar740(%led_0: !firrtl.analog<1>)
-  firrtl.module @foo740(%led_0: !firrtl.analog<1>) {
+  firrtl.extmodule @bar740(in %led_0: !firrtl.analog<1>)
+  firrtl.module @foo740(in %led_0: !firrtl.analog<1>) {
     %result = firrtl.instance @bar740 {name = "fpga", portNames = ["led_0"]} : !firrtl.analog<1>
     firrtl.attach %result, %led_0 : !firrtl.analog<1>, !firrtl.analog<1>
   }

--- a/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
+++ b/test/Conversion/FIRRTLToRTL/lower-to-rtl.mlir
@@ -3,13 +3,13 @@
 firrtl.circuit "Simple" {
 
   // CHECK-LABEL: rtl.module @Simple
-  firrtl.module @Simple(%in1: !firrtl.uint<4>,
-                        %in2: !firrtl.uint<2>,
-                        %in3: !firrtl.sint<8>,
-                        %in4: !firrtl.uint<0>,
-                        %in5: !firrtl.sint<0>,
-                        %out1: !firrtl.flip<sint<1>>,
-                        %out2: !firrtl.flip<sint<1>>  ) {
+  firrtl.module @Simple(in %in1: !firrtl.uint<4>,
+                        in %in2: !firrtl.uint<2>,
+                        in %in3: !firrtl.sint<8>,
+                        in %in4: !firrtl.uint<0>,
+                        in %in5: !firrtl.sint<0>,
+                        out %out1: !firrtl.sint<1>,
+                        out %out2: !firrtl.sint<1>  ) {
     // Issue #364: https://github.com/llvm/circt/issues/364
     // CHECK: = rtl.constant -1175 : i12
     // CHECK-DAG: rtl.constant -4 : i4
@@ -226,9 +226,9 @@ firrtl.circuit "Simple" {
     // CHECK: = comb.sub %c0_i9, [[SEXT]] : i9
     %54 = firrtl.neg %in3 : (!firrtl.sint<8>) -> !firrtl.sint<9>
     // CHECK: rtl.output %false, %false : i1, i1
-    firrtl.connect %out1, %53 : !firrtl.flip<sint<1>>, !firrtl.sint<1>
+    firrtl.connect %out1, %53 : !firrtl.sint<1>, !firrtl.sint<1>
     %55 = firrtl.neg %in5 : (!firrtl.sint<0>) -> !firrtl.sint<1>
-    firrtl.connect %out2, %55 : !firrtl.flip<sint<1>>, !firrtl.sint<1>
+    firrtl.connect %out2, %55 : !firrtl.sint<1>, !firrtl.sint<1>
   }
 
 //   module Print :
@@ -240,8 +240,8 @@ firrtl.circuit "Simple" {
 //    printf(clock, reset, "Hi %x %x\n", add(a, a), b)
 
   // CHECK-LABEL: rtl.module @Print
-  firrtl.module @Print(%clock: !firrtl.clock, %reset: !firrtl.uint<1>,
-                       %a: !firrtl.uint<4>, %b: !firrtl.uint<4>) {
+  firrtl.module @Print(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>,
+                       in %a: !firrtl.uint<4>, in %b: !firrtl.uint<4>) {
 
     // CHECK: sv.always posedge %clock {
     // CHECK-NEXT:   sv.ifdef.procedural "SYNTHESIS" {
@@ -280,7 +280,7 @@ firrtl.circuit "Simple" {
 //    stop(clock2, reset, 0)
 
   // CHECK-LABEL: rtl.module @Stop
-  firrtl.module @Stop(%clock1: !firrtl.clock, %clock2: !firrtl.clock, %reset: !firrtl.uint<1>) {
+  firrtl.module @Stop(in %clock1: !firrtl.clock, in %clock2: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 
     // CHECK-NEXT: sv.always posedge %clock1 {
     // CHECK-NEXT:   sv.ifdef.procedural "SYNTHESIS" {
@@ -321,9 +321,9 @@ firrtl.circuit "Simple" {
 //     cover(clock,  cCond, cEn, "cover0")
 
   // CHECK-LABEL: rtl.module @Verification
-  firrtl.module @Verification(%clock: !firrtl.clock, %aCond: !firrtl.uint<1>,
-   %aEn: !firrtl.uint<1>, %bCond: !firrtl.uint<1>, %bEn: !firrtl.uint<1>,
-    %cCond: !firrtl.uint<1>, %cEn: !firrtl.uint<1>) {
+  firrtl.module @Verification(in %clock: !firrtl.clock, in %aCond: !firrtl.uint<1>,
+   in %aEn: !firrtl.uint<1>, in %bCond: !firrtl.uint<1>, in %bEn: !firrtl.uint<1>,
+   in %cCond: !firrtl.uint<1>, in %cEn: !firrtl.uint<1>) {
 
     // CHECK-NEXT: sv.always posedge %clock {
     // CHECK-NEXT:   sv.if %aEn {
@@ -342,7 +342,7 @@ firrtl.circuit "Simple" {
     // CHECK-NEXT: rtl.output
   }
 
-  firrtl.module @bar(%io_cpu_flush: !firrtl.uint<1>) {
+  firrtl.module @bar(in %io_cpu_flush: !firrtl.uint<1>) {
   }
 
   // CHECK-LABEL: rtl.module @foo
@@ -363,7 +363,7 @@ firrtl.circuit "Simple" {
 
   // https://github.com/llvm/circt/issues/314
   // CHECK-LABEL: rtl.module @issue314
-  firrtl.module @issue314(%inp_2: !firrtl.uint<27>, %inpi: !firrtl.uint<65>) {
+  firrtl.module @issue314(in %inp_2: !firrtl.uint<27>, in %inpi: !firrtl.uint<65>) {
     // CHECK: %c0_i38 = rtl.constant 0 : i38
     // CHECK: %tmp48 = sv.wire : !rtl.inout<i27>
     %tmp48 = firrtl.wire : !firrtl.uint<27>
@@ -380,10 +380,10 @@ firrtl.circuit "Simple" {
   // CHECK-LABEL: rtl.module @test_rem
   // CHECK-NEXT:     %0 = comb.modu
   // CHECK-NEXT:     rtl.output %0
-  firrtl.module @test_rem(%tmp85: !firrtl.uint<1>, %tmp79: !firrtl.uint<1>,
-       %out: !firrtl.flip<uint<1>>) {
+  firrtl.module @test_rem(in %tmp85: !firrtl.uint<1>, in %tmp79: !firrtl.uint<1>,
+       out %out: !firrtl.uint<1>) {
     %2 = firrtl.rem %tmp79, %tmp85 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.connect %out, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+    firrtl.connect %out, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 
   // CHECK-LABEL: rtl.module @Analog(%a1: !rtl.inout<i1>, %b1: !rtl.inout<i1>,
@@ -407,12 +407,12 @@ firrtl.circuit "Simple" {
   // CHECK-NEXT:    }
   // CHECK-NEXT:    %0 = sv.read_inout %a1 : !rtl.inout<i1>
   // CHECK-NEXT:    rtl.output %0 : i1
-  firrtl.module @Analog(%a1: !firrtl.analog<1>, %b1: !firrtl.analog<1>,
-                        %c1: !firrtl.analog<1>, %outClock: !firrtl.flip<clock>) {
+  firrtl.module @Analog(in %a1: !firrtl.analog<1>, in %b1: !firrtl.analog<1>,
+                        in %c1: !firrtl.analog<1>, out %outClock: !firrtl.clock) {
     firrtl.attach %a1, %b1, %c1 : !firrtl.analog<1>, !firrtl.analog<1>, !firrtl.analog<1>
 
     %1 = firrtl.asClock %a1 : (!firrtl.analog<1>) -> !firrtl.clock
-    firrtl.connect %outClock, %1 : !firrtl.flip<clock>, !firrtl.clock
+    firrtl.connect %outClock, %1 : !firrtl.clock, !firrtl.clock
   }
 
 
@@ -429,8 +429,8 @@ firrtl.circuit "Simple" {
 
   // CHECK-LABEL: rtl.module @UninitReg1(%clock: i1, %reset: i1, %cond: i1, %value: i2) {
 
-  firrtl.module @UninitReg1(%clock: !firrtl.clock, %reset: !firrtl.uint<1>,
-                            %cond: !firrtl.uint<1>, %value: !firrtl.uint<2>) {
+  firrtl.module @UninitReg1(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>,
+                            in %cond: !firrtl.uint<1>, in %value: !firrtl.uint<2>) {
     // CHECK-NEXT: %c0_i2 = rtl.constant 0 : i2
     %c0_ui2 = firrtl.constant(0 : ui2) : !firrtl.uint<2>
     // CHECK-NEXT: %count = sv.reg : !rtl.inout<i2>
@@ -475,9 +475,9 @@ firrtl.circuit "Simple" {
   //     reg <= mux(io_en, io_d, reg)
 
   // CHECK-LABEL: rtl.module @InitReg1(
-  firrtl.module @InitReg1(%clock: !firrtl.clock, %reset: !firrtl.uint<1>,
-                          %io_d: !firrtl.uint<32>, %io_en: !firrtl.uint<1>,
-                          %io_q: !firrtl.flip<uint<32>>) {
+  firrtl.module @InitReg1(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>,
+                          in %io_d: !firrtl.uint<32>, in %io_en: !firrtl.uint<1>,
+                          out %io_q: !firrtl.uint<32>) {
     // CHECK: %c0_i32 = rtl.constant 0 : i32
     %c0_ui32 = firrtl.constant(0 : ui32) : !firrtl.uint<32>
 
@@ -524,7 +524,7 @@ firrtl.circuit "Simple" {
     %5 = firrtl.mux(%io_en, %io_d, %shorten) : (!firrtl.uint<1>, !firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>
 
     firrtl.connect %reg, %5 : !firrtl.uint<32>, !firrtl.uint<32>
-    firrtl.connect %io_q, %reg: !firrtl.flip<uint<32>>, !firrtl.uint<32>
+    firrtl.connect %io_q, %reg: !firrtl.uint<32>, !firrtl.uint<32>
 
     // CHECK-NEXT: %7 = sv.read_inout %reg : !rtl.inout<i32>
     // CHECK-NEXT: rtl.output %7 : i32
@@ -566,10 +566,10 @@ firrtl.circuit "Simple" {
   //     _M.write.mask <= validif(inpred, UInt<1>("h1"))
 
   // CHECK-LABEL: rtl.module @MemSimple(
-  firrtl.module @MemSimple(%clock1: !firrtl.clock, %clock2: !firrtl.clock,
-                           %inpred: !firrtl.uint<1>, %indata: !firrtl.sint<42>,
-                           %result: !firrtl.flip<sint<42>>,
-                           %result2: !firrtl.flip<sint<42>>) {
+  firrtl.module @MemSimple(in %clock1: !firrtl.clock, in %clock2: !firrtl.clock,
+                           in %inpred: !firrtl.uint<1>, in %indata: !firrtl.sint<42>,
+                           out %result: !firrtl.sint<42>,
+                           out %result2: !firrtl.sint<42>) {
     %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
     %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
     %c0_ui3 = firrtl.constant(0 : ui3) : !firrtl.uint<3>
@@ -578,9 +578,9 @@ firrtl.circuit "Simple" {
   // CHECK: rtl.output %_M.ro_data_0, %_M.rw_rdata_0 : i42, i42
 
       %0 = firrtl.subfield %_M_read("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>) -> !firrtl.sint<42>
-      firrtl.connect %result, %0 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
+      firrtl.connect %result, %0 : !firrtl.sint<42>, !firrtl.sint<42>
       %1 = firrtl.subfield %_M_rw("rdata") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, wmode: uint<1>, rdata: flip<sint<42>>, wdata: sint<42>, wmask: uint<1>>>) -> !firrtl.sint<42>
-      firrtl.connect %result2, %1 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
+      firrtl.connect %result2, %1 : !firrtl.sint<42>, !firrtl.sint<42>
       %2 = firrtl.subfield %_M_read("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>) -> !firrtl.uint<4>
       firrtl.connect %2, %c0_ui1 : !firrtl.uint<4>, !firrtl.uint<1>
       %3 = firrtl.subfield %_M_read("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>) -> !firrtl.uint<1>
@@ -613,7 +613,7 @@ firrtl.circuit "Simple" {
 
   // CHECK-LABEL: rtl.module @IncompleteRead(
   // The read port has no use of the data field.
-  firrtl.module @IncompleteRead(%clock1: !firrtl.clock) {
+  firrtl.module @IncompleteRead(in %clock1: !firrtl.clock) {
     %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
     %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
 
@@ -633,19 +633,19 @@ firrtl.circuit "Simple" {
   // CHECK-NEXT:    %c42_i23 = rtl.constant 42 : i23
   // CHECK-NEXT:    rtl.output %c0_i23 : i23
   // CHECK-NEXT:  }
-  firrtl.module @top_mod(%tmp27: !firrtl.flip<uint<23>>) {
+  firrtl.module @top_mod(out %tmp27: !firrtl.uint<23>) {
     %0 = firrtl.wire : !firrtl.uint<0>
     %c42_ui23 = firrtl.constant(42 : ui23) : !firrtl.uint<23>
     %1 = firrtl.tail %c42_ui23, 23 : (!firrtl.uint<23>) -> !firrtl.uint<0>
     firrtl.connect %0, %1 : !firrtl.uint<0>, !firrtl.uint<0>
     %2 = firrtl.head %c42_ui23, 0 : (!firrtl.uint<23>) -> !firrtl.uint<0>
     %3 = firrtl.pad %2, 23 : (!firrtl.uint<0>) -> !firrtl.uint<23>
-    firrtl.connect %tmp27, %3 : !firrtl.flip<uint<23>>, !firrtl.uint<23>
+    firrtl.connect %tmp27, %3 : !firrtl.uint<23>, !firrtl.uint<23>
   }
 
   //CHECK-LABEL: rtl.module @test_partialconnect(%clock: i1) {
   //CHECK: sv.alwaysff(posedge %clock)
-  firrtl.module @test_partialconnect(%clock : !firrtl.clock) {
+  firrtl.module @test_partialconnect(in %clock : !firrtl.clock) {
     %b = firrtl.reg %clock {name = "pcon"} : (!firrtl.clock) -> !firrtl.uint<1>
     %a = firrtl.constant(0 : ui2) : !firrtl.uint<2>
     firrtl.partialconnect %b, %a : !firrtl.uint<1>, !firrtl.uint<2>
@@ -655,15 +655,15 @@ firrtl.circuit "Simple" {
   // CHECK-NEXT:    %0 = rtl.struct_extract %source["data"] : !rtl.struct<valid: i1, ready: i1, data: i64>
   // CHECK-NEXT:    rtl.output %0 : i64
   // CHECK-NEXT:  }
-  firrtl.module @SimpleStruct(%source: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>,
-                              %fldout: !firrtl.flip<uint<64>>) {
+  firrtl.module @SimpleStruct(in %source: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>,
+                              out %fldout: !firrtl.uint<64>) {
     %2 = firrtl.subfield %source ("data") : (!firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
-    firrtl.connect %fldout, %2 : !firrtl.flip<uint<64>>, !firrtl.uint<64>
+    firrtl.connect %fldout, %2 : !firrtl.uint<64>, !firrtl.uint<64>
   }
 
   // CHECK-LABEL: IsInvalidIssue572
   // https://github.com/llvm/circt/issues/572
-  firrtl.module @IsInvalidIssue572(%a: !firrtl.analog<1>) {
+  firrtl.module @IsInvalidIssue572(in %a: !firrtl.analog<1>) {
 
     // CHECK-NEXT: %.invalid_analog = sv.wire : !rtl.inout<i1>
     %0 = firrtl.invalidvalue : !firrtl.analog<1>
@@ -693,7 +693,7 @@ firrtl.circuit "Simple" {
 
   // CHECK-LABEL: ASQ
   // https://github.com/llvm/circt/issues/699
-  firrtl.module @ASQ(%clock: !firrtl.clock, %reset: !firrtl.asyncreset) {
+  firrtl.module @ASQ(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset) {
     %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
     %widx_widx_bin = firrtl.regreset %clock, %reset, %c0_ui1 {name = "widx_widx_bin"} : (!firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>) -> !firrtl.uint<4>
   }
@@ -701,13 +701,13 @@ firrtl.circuit "Simple" {
   // CHECK-LABEL: rtl.module @Struct0bits(%source: !rtl.struct<valid: i1, ready: i1, data: i0>) {
   // CHECK-NEXT:    rtl.output
   // CHECK-NEXT:  }
-  firrtl.module @Struct0bits(%source: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<0>>) {
+  firrtl.module @Struct0bits(in %source: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<0>>) {
     %2 = firrtl.subfield %source ("data") : (!firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<0>>) -> !firrtl.uint<0>
   }
 
   // CHECK-LABEL: rtl.module @MemDepth1
-  firrtl.module @MemDepth1(%clock: !firrtl.clock, %en: !firrtl.uint<1>,
-                         %addr: !firrtl.uint<1>, %data: !firrtl.flip<uint<32>>) {
+  firrtl.module @MemDepth1(in %clock: !firrtl.clock, in %en: !firrtl.uint<1>,
+                           in %addr: !firrtl.uint<1>, out %data: !firrtl.uint<32>) {
     // CHECK: %mem0.ro_data_0 = rtl.instance "mem0" @FIRRTLMem_1_0_0_32_1_0_1_1(%clock, %en, %addr) : (i1, i1, i1) -> i32
     // CHECK: rtl.output %mem0.ro_data_0 : i32
     %mem0_load0 = firrtl.mem Old {depth = 1 : i64, name = "mem0", portNames = ["load0"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: flip<uint<32>>>>
@@ -716,7 +716,7 @@ firrtl.circuit "Simple" {
     %1 = firrtl.subfield %mem0_load0("addr") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: flip<uint<32>>>>) -> !firrtl.uint<1>
     firrtl.connect %1, %addr : !firrtl.uint<1>, !firrtl.uint<1>
     %2 = firrtl.subfield %mem0_load0("data") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: flip<uint<32>>>>) -> !firrtl.uint<32>
-    firrtl.connect %data, %2 : !firrtl.flip<uint<32>>, !firrtl.uint<32>
+    firrtl.connect %data, %2 : !firrtl.uint<32>, !firrtl.uint<32>
     %3 = firrtl.subfield %mem0_load0("en") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: flip<uint<32>>>>) -> !firrtl.uint<1>
     firrtl.connect %3, %en : !firrtl.uint<1>, !firrtl.uint<1>
 }

--- a/test/Conversion/FIRRTLToRTL/zero-width.mlir
+++ b/test/Conversion/FIRRTLToRTL/zero-width.mlir
@@ -2,16 +2,16 @@
 
 firrtl.circuit "Arithmetic" {
   // CHECK-LABEL: rtl.module @Arithmetic
-  firrtl.module @Arithmetic(%uin3c: !firrtl.uint<3>,
-                            %out0: !firrtl.flip<uint<3>>,
-                            %out1: !firrtl.flip<uint<4>>,
-                            %out2: !firrtl.flip<uint<4>>,
-                            %out3: !firrtl.flip<uint<1>>) {
+  firrtl.module @Arithmetic(in %uin3c: !firrtl.uint<3>,
+                            out %out0: !firrtl.uint<3>,
+                            out %out1: !firrtl.uint<4>,
+                            out %out2: !firrtl.uint<4>,
+                            out %out3: !firrtl.uint<1>) {
   %uin0c = firrtl.wire : !firrtl.uint<0>
 
     // CHECK-DAG: [[MULZERO:%.+]] = rtl.constant 0 : i3
     %0 = firrtl.mul %uin0c, %uin3c : (!firrtl.uint<0>, !firrtl.uint<3>) -> !firrtl.uint<3>
-    firrtl.connect %out0, %0 : !firrtl.flip<uint<3>>, !firrtl.uint<3>
+    firrtl.connect %out0, %0 : !firrtl.uint<3>, !firrtl.uint<3>
 
     // Lowers to nothing.
     %m0 = firrtl.mul %uin0c, %uin0c : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
@@ -27,22 +27,22 @@ firrtl.circuit "Arithmetic" {
     // CHECK-NEXT: [[UIN3EXT:%.+]] = comb.concat %false, %uin3c : (i1, i3) -> i4
     // CHECK-NEXT: [[ADDRES:%.+]] = comb.add %c0_i4, [[UIN3EXT]] : i4
     %1 = firrtl.add %uin0c, %uin3c : (!firrtl.uint<0>, !firrtl.uint<3>) -> !firrtl.uint<4>
-    firrtl.connect %out1, %1 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+    firrtl.connect %out1, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 
     %2 = firrtl.shl %node, 4 : (!firrtl.uint<0>) -> !firrtl.uint<4>
-    firrtl.connect %out2, %2 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+    firrtl.connect %out2, %2 : !firrtl.uint<4>, !firrtl.uint<4>
 
     // Issue #436
     %3 = firrtl.eq %uin0c, %uin0c : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
-    firrtl.connect %out3, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+    firrtl.connect %out3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
 
     // CHECK: rtl.output %c0_i3, [[ADDRES]], %c0_i4, %true
   }
 
   // CHECK-LABEL: rtl.module @Exotic
-  firrtl.module @Exotic(%uin3c: !firrtl.uint<3>,
-                        %out0: !firrtl.flip<uint<3>>,
-                        %out1: !firrtl.flip<uint<3>>) {
+  firrtl.module @Exotic(in %uin3c: !firrtl.uint<3>,
+                        out %out0: !firrtl.uint<3>,
+                        out %out1: !firrtl.uint<3>) {
     %uin0c = firrtl.wire : !firrtl.uint<0>
 
     // CHECK-DAG: = rtl.constant true
@@ -55,11 +55,11 @@ firrtl.circuit "Arithmetic" {
 
     // Lowers to the uin3 value.
     %3 = firrtl.cat %uin0c, %uin3c : (!firrtl.uint<0>, !firrtl.uint<3>) -> !firrtl.uint<3>
-    firrtl.connect %out0, %3 : !firrtl.flip<uint<3>>, !firrtl.uint<3>
+    firrtl.connect %out0, %3 : !firrtl.uint<3>, !firrtl.uint<3>
 
     // Lowers to the uin3 value.
     %4 = firrtl.cat %uin3c, %uin0c : (!firrtl.uint<3>, !firrtl.uint<0>) -> !firrtl.uint<3>
-    firrtl.connect %out1, %4 : !firrtl.flip<uint<3>>, !firrtl.uint<3>
+    firrtl.connect %out1, %4 : !firrtl.uint<3>, !firrtl.uint<3>
 
     // Lowers to nothing.
     %5 = firrtl.cat %uin0c, %uin0c : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
@@ -68,7 +68,7 @@ firrtl.circuit "Arithmetic" {
   }
 
   // CHECK-LABEL: rtl.module @Decls
-  firrtl.module @Decls(%uin3c: !firrtl.uint<3>) {
+  firrtl.module @Decls(in %uin3c: !firrtl.uint<3>) {
     %sin0c = firrtl.wire : !firrtl.sint<0>
     %uin0c = firrtl.wire : !firrtl.uint<0>
 

--- a/test/Conversion/HandshakeToFIRRTL/simple_addi.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/simple_addi.mlir
@@ -1,16 +1,16 @@
 // RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
 
 // CHECK-LABEL: firrtl.module @std_addi_2ins_1outs_ui64(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) {
+// CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, out %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) {
 // CHECK:   %0 = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %1 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %2 = firrtl.subfield %arg0("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
 // CHECK:   %3 = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %4 = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %5 = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %6 = firrtl.subfield %arg2("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %7 = firrtl.subfield %arg2("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %8 = firrtl.subfield %arg2("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
+// CHECK:   %6 = firrtl.subfield %arg2("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
+// CHECK:   %7 = firrtl.subfield %arg2("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
+// CHECK:   %8 = firrtl.subfield %arg2("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
 // CHECK:   %9 = firrtl.add %2, %5 : (!firrtl.uint<64>, !firrtl.uint<64>) -> !firrtl.uint<65>
 // CHECK:   %10 = firrtl.bits %9 63 to 0 : (!firrtl.uint<65>) -> !firrtl.uint<64>
 // CHECK:   firrtl.connect %8, %10 : !firrtl.uint<64>, !firrtl.uint<64>
@@ -22,7 +22,7 @@
 // CHECK: }
 
 // CHECK-LABEL: firrtl.module @simple_addi(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg3: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg4: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, in %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, out %arg4: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @simple_addi(%arg0: index, %arg1: index, %arg2: none, ...) -> (index, none) {
 
   // CHECK:%inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @std_addi_2ins_1outs_ui64  {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
@@ -30,7 +30,7 @@ handshake.func @simple_addi(%arg0: index, %arg1: index, %arg2: none, ...) -> (in
   // CHECK: firrtl.connect %inst_arg1, %arg1 : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
   %0 = addi %arg0, %arg1 : index
 
-  // CHECK: firrtl.connect %arg3, %inst_arg2 : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
-  // CHECK: firrtl.connect %arg4, %arg2 : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>
+  // CHECK: firrtl.connect %arg3, %inst_arg2 : !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+  // CHECK: firrtl.connect %arg4, %arg2 : !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>
   handshake.return %0, %arg2 : index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_branch.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_branch.mlir
@@ -1,20 +1,20 @@
 // RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
 
 // CHECK-LABEL: firrtl.module @handshake_branch_1ins_1outs_ui64(
-// CHECK-SAME: %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) {
+// CHECK-SAME: in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, out %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) {
 // CHECK:   %0 = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %1 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %2 = firrtl.subfield %arg0("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %3 = firrtl.subfield %arg1("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %4 = firrtl.subfield %arg1("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %5 = firrtl.subfield %arg1("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
+// CHECK:   %3 = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
+// CHECK:   %4 = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
+// CHECK:   %5 = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
 // CHECK:   firrtl.connect %3, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:   firrtl.connect %1, %4 : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:   firrtl.connect %5, %2 : !firrtl.uint<64>, !firrtl.uint<64>
 // CHECK: }
 
 // CHECK-LABEL: firrtl.module @test_branch(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg3: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, out %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_branch(%arg0: index, %arg1: none, ...) -> (index, none) {
 
   // CHECK: %inst_arg0, %inst_arg1 = firrtl.instance @handshake_branch_1ins_1outs_ui64  {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>

--- a/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
@@ -1,11 +1,11 @@
 // RUN: circt-opt -lower-handshake-to-firrtl -split-input-file %s | FileCheck %s
 
 // CHECK-LABEL: firrtl.module @handshake_buffer_1ins_1outs_ctrl_3slots_seq(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, out %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 // CHECK:   %[[IN_VALID:.+]] = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
 // CHECK:   %[[IN_READY:.+]] = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
-// CHECK:   %[[OUT_VALID:.+]] = firrtl.subfield %arg1("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>) -> !firrtl.uint<1>
-// CHECK:   %[[OUT_READY:.+]] = firrtl.subfield %arg1("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>) -> !firrtl.uint<1>
+// CHECK:   %[[OUT_VALID:.+]] = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
+// CHECK:   %[[OUT_READY:.+]] = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
 // CHECK:   %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
 
 // Stage 0 ready wire and valid register.
@@ -75,7 +75,7 @@
 // CHECK: }
 
 // CHECK-LABEL: firrtl.module @test_buffer(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %arg3: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, out %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_buffer(%arg0: none, %arg1: none, ...) -> (none, none) {
 
   // CHECK: %inst_arg0, %inst_arg1, %inst_clock, %inst_reset = firrtl.instance @handshake_buffer_1ins_1outs_ctrl_3slots_seq {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, !firrtl.flip<clock>, !firrtl.flip<uint<1>>
@@ -86,9 +86,9 @@ handshake.func @test_buffer(%arg0: none, %arg1: none, ...) -> (none, none) {
 // -----
 
 // CHECK-LABEL: firrtl.module @handshake_buffer_1ins_1outs_ui64_2slots_seq(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, out %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 // CHECK:   %[[IN_DATA:.+]] = firrtl.subfield %arg0("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %[[OUT_DATA:.+]] = firrtl.subfield %arg1("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
+// CHECK:   %[[OUT_DATA:.+]] = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
 // CHECK:   %c0_ui64 = firrtl.constant(0 : ui64) : !firrtl.uint<64>
 
 // CHECK:   %dataReg0 = firrtl.regreset %clock, %reset, %c0_ui64 : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<64>) -> !firrtl.uint<64>
@@ -114,12 +114,12 @@ handshake.func @test_buffer(%arg0: none, %arg1: none, ...) -> (none, none) {
 // CHECK: }
 
 // CHECK-LABEL: firrtl.module @test_buffer_data(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg3: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, out %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_buffer_data(%arg0: index, %arg1: none, ...) -> (index, none) {
 
   // CHECK: %inst_arg0, %inst_arg1, %inst_clock, %inst_reset = firrtl.instance @handshake_buffer_1ins_1outs_ui64_2slots_seq {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.flip<clock>, !firrtl.flip<uint<1>>
   // CHECK: firrtl.connect %inst_clock, %clock : !firrtl.flip<clock>, !firrtl.clock
-  // CHECK: firrtl.connect %inst_reset, %reset : !firrtl.flip<uint<1>>, !firrtl.uint<1>  
+  // CHECK: firrtl.connect %inst_reset, %reset : !firrtl.flip<uint<1>>, !firrtl.uint<1>
   %0 = "handshake.buffer"(%arg0) {control = false, sequential = true, slots = 2 : i32} : (index) -> index
   handshake.return %0, %arg1 : index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_cmerge.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_cmerge.mlir
@@ -3,16 +3,16 @@
 // Test a control merge that is control only.
 
 // CHECK-LABEL: firrtl.module @handshake_control_merge_2ins_2outs_ctrl(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %arg3: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>,  %[[CLOCK:.+]]: !firrtl.clock, %[[RESET:.+]]: !firrtl.uint<1>) {
+// CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, out %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, in %[[CLOCK:.+]]: !firrtl.clock, in %[[RESET:.+]]: !firrtl.uint<1>) {
 // CHECK:   %[[ARG0_VALID:.+]] = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
 // CHECK:   %[[ARG0_READY:.+]] = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
 // CHECK:   %[[ARG1_VALID:.+]] = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
 // CHECK:   %[[ARG1_READY:.+]] = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG2_VALID:.+]] = firrtl.subfield %arg2("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG2_READY:.+]] = firrtl.subfield %arg2("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG3_VALID:.+]] = firrtl.subfield %arg3("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG3_READY:.+]] = firrtl.subfield %arg3("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG3_DATA:.+]] = firrtl.subfield %arg3("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
+// CHECK:   %[[ARG2_VALID:.+]] = firrtl.subfield %arg2("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
+// CHECK:   %[[ARG2_READY:.+]] = firrtl.subfield %arg2("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
+// CHECK:   %[[ARG3_VALID:.+]] = firrtl.subfield %arg3("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
+// CHECK:   %[[ARG3_READY:.+]] = firrtl.subfield %arg3("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
+// CHECK:   %[[ARG3_DATA:.+]] = firrtl.subfield %arg3("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
 
 // Common definitions.
 // CHECK:   %[[NO_WINNER:.+]] = firrtl.constant(0 : ui2) : !firrtl.uint<2>
@@ -88,7 +88,7 @@
 // CHECK:   firrtl.connect %[[ARG1_READY]], %[[ARG1_READY0]]
 
 // CHECK-LABEL: firrtl.module @test_cmerge(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg3: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %arg4: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg5: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, in %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, out %arg4: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, out %arg5: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_cmerge(%arg0: none, %arg1: none, %arg2: none, ...) -> (none, index, none) {
 
   // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_arg3, %inst_clock, %inst_reset = firrtl.instance @handshake_control_merge_2ins_2outs_ctrl {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.flip<clock>, !firrtl.flip<uint<1>>
@@ -103,7 +103,7 @@ handshake.func @test_cmerge(%arg0: none, %arg1: none, %arg2: none, ...) -> (none
 // CHECK-LABEL: firrtl.module @handshake_control_merge_2ins_2outs
 // CHECK: %[[ARG0_DATA:.+]] = firrtl.subfield %arg0("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
 // CHECK: %[[ARG1_DATA:.+]] = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK: %[[ARG2_DATA:.+]] = firrtl.subfield %arg2("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
+// CHECK: %[[ARG2_DATA:.+]] = firrtl.subfield %arg2("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
 // ...
 // CHECK:   %win = firrtl.wire : !firrtl.uint<2>
 // ...

--- a/test/Conversion/HandshakeToFIRRTL/test_conditional_branch.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_conditional_branch.mlir
@@ -1,19 +1,19 @@
 // RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
 
 // CHECK-LABEL: firrtl.module @handshake_conditional_branch_2ins_2outs_ui64(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<1>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg3: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) {
+// CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<1>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, out %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) {
 // CHECK:   %0 = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<1>>) -> !firrtl.uint<1>
 // CHECK:   %1 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<1>>) -> !firrtl.uint<1>
 // CHECK:   %2 = firrtl.subfield %arg0("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<1>>) -> !firrtl.uint<1>
 // CHECK:   %3 = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %4 = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %5 = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %6 = firrtl.subfield %arg2("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %7 = firrtl.subfield %arg2("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %8 = firrtl.subfield %arg2("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
-// CHECK:   %9 = firrtl.subfield %arg3("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %10 = firrtl.subfield %arg3("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %11 = firrtl.subfield %arg3("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
+// CHECK:   %6 = firrtl.subfield %arg2("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
+// CHECK:   %7 = firrtl.subfield %arg2("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
+// CHECK:   %8 = firrtl.subfield %arg2("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
+// CHECK:   %9 = firrtl.subfield %arg3("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
+// CHECK:   %10 = firrtl.subfield %arg3("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
+// CHECK:   %11 = firrtl.subfield %arg3("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
 // CHECK:   %12 = firrtl.and %0, %3 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   %13 = firrtl.not %2 : (!firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   %14 = firrtl.and %2, %12 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
@@ -29,7 +29,7 @@
 // CHECK: }
 
 // CHECK-LABEL: firrtl.module @test_conditional_branch(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<1>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg3: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg4: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg5: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<1>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, in %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, out %arg4: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, out %arg5: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_conditional_branch(%arg0: i1, %arg1: index, %arg2: none, ...) -> (index, index, none) {
 
   // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_arg3 = firrtl.instance @handshake_conditional_branch_2ins_2outs_ui64  {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<1>>>, !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>

--- a/test/Conversion/HandshakeToFIRRTL/test_constant.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_constant.mlir
@@ -2,12 +2,12 @@
 
 // Submodule for the index and i64 ConstantOps as they have the same value and converted type.
 // CHECK-LABEL: firrtl.module @handshake_constant_1ins_1outs_c42_ui64(
-// CHECK-SAME: %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) {
+// CHECK-SAME: in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, out %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) {
 // CHECK:   %[[ARG0_VALID:.+]] = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
 // CHECK:   %[[ARG0_READY:.+]] = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG1_VALID:.+]] = firrtl.subfield %arg1("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG1_READY:.+]] = firrtl.subfield %arg1("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG1_DATA:.+]] = firrtl.subfield %arg1("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
+// CHECK:   %[[ARG1_VALID:.+]] = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
+// CHECK:   %[[ARG1_READY:.+]] = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
+// CHECK:   %[[ARG1_DATA:.+]] = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
 // CHECK:   firrtl.connect %[[ARG1_VALID:.+]], %[[ARG0_VALID:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:   firrtl.connect %[[ARG0_READY:.+]], %[[ARG1_READY:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:   %c42_ui64 = firrtl.constant(42 : ui64) : !firrtl.uint<64>
@@ -16,19 +16,19 @@
 
 // Submodule for the ui32 ConstantOp.
 // CHECK-LABEL: firrtl.module @handshake_constant_1ins_1outs_c42_ui32(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<32>>>) {
+// CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, out %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<32>>) {
 // CHECK:   %c42_ui32 = firrtl.constant(42 : ui32) : !firrtl.uint<32>
 
 // Submodule for the si32 ConstantOp.
 // CHECK-LABEL: firrtl.module @"handshake_constant_1ins_1outs_c-11_si32"(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: sint<32>>>) {
+// CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, out %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: sint<32>>) {
 // CHECK:   %c-11_si32 = firrtl.constant(-11 : si32) : !firrtl.sint<32>
 
 // CHECK-LABEL: firrtl.module @test_constant(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg3: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<32>>>, %arg4: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: sint<32>>>, %arg5: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, out %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, out %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<32>>, out %arg4: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: sint<32>>, out %arg5: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_constant(%arg0: none, ...) -> (index, i64, ui32, si32, none) {
   %0:5 = "handshake.fork"(%arg0) {control = true} : (none) -> (none, none, none, none, none)
-  
+
   // CHECK: %inst_arg0_0, %inst_arg1_1 = firrtl.instance @handshake_constant_1ins_1outs_c42_ui64  {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
   %1 = "handshake.constant"(%0#0) {value = 42 : index}: (none) -> index
 

--- a/test/Conversion/HandshakeToFIRRTL/test_fork.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_fork.mlir
@@ -1,13 +1,13 @@
 // RUN: circt-opt -lower-handshake-to-firrtl -split-input-file %s | FileCheck %s
 
 // CHECK-LABEL: firrtl.module @handshake_fork_1ins_2outs_ctrl(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>
+// CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, out %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, out %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>
 // CHECK:   %[[ARG_VALID:.+]] = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
 // CHECK:   %[[ARG_READY:.+]] = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
-// CHECK:   %[[RES0_VALID:.+]] = firrtl.subfield %arg1("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>) -> !firrtl.uint<1>
-// CHECK:   %[[RES0_READY:.+]] = firrtl.subfield %arg1("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>) -> !firrtl.uint<1>
-// CHECK:   %[[RES1_VALID:.+]] = firrtl.subfield %arg2("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>) -> !firrtl.uint<1>
-// CHECK:   %[[RES1_READY:.+]] = firrtl.subfield %arg2("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>) -> !firrtl.uint<1>
+// CHECK:   %[[RES0_VALID:.+]] = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
+// CHECK:   %[[RES0_READY:.+]] = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
+// CHECK:   %[[RES1_VALID:.+]] = firrtl.subfield %arg2("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
+// CHECK:   %[[RES1_READY:.+]] = firrtl.subfield %arg2("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
 
 // Done logic.
 // CHECK:   %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
@@ -61,7 +61,7 @@
 // CHECK: }
 
 // CHECK-LABEL: firrtl.module @test_fork(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %arg3: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %arg4: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, out %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, out %arg4: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_fork(%arg0: none, %arg1: none, ...) -> (none, none, none) {
 
   // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_clock, %inst_reset = firrtl.instance @handshake_fork_1ins_2outs_ctrl {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, !firrtl.flip<clock>, !firrtl.flip<uint<1>>
@@ -72,16 +72,16 @@ handshake.func @test_fork(%arg0: none, %arg1: none, ...) -> (none, none, none) {
 // -----
 
 // CHECK-LABEL: firrtl.module @handshake_fork_1ins_2outs_ui64(
-// CHECK-SAME: %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME: in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, out %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, out %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 // CHECK:   %[[ARG_DATA:.+]] = firrtl.subfield %arg0("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %[[RES0_DATA:.+]] = firrtl.subfield %arg1("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
-// CHECK:   %[[RES1_DATA:.+]] = firrtl.subfield %arg2("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
+// CHECK:   %[[RES0_DATA:.+]] = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
+// CHECK:   %[[RES1_DATA:.+]] = firrtl.subfield %arg2("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
 
 // CHECK:   firrtl.connect %[[RES0_DATA:.+]], %[[ARG_DATA:.+]] : !firrtl.uint<64>, !firrtl.uint<64>
 // CHECK:   firrtl.connect %[[RES1_DATA:.+]], %[[ARG_DATA:.+]] : !firrtl.uint<64>, !firrtl.uint<64>
 
 // CHECK-LABEL: firrtl.module @test_fork_data(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg3: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg4: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, out %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, out %arg4: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_fork_data(%arg0: index, %arg1: none, ...) -> (index, index, none) {
 
   // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_clock, %inst_reset = firrtl.instance @handshake_fork_1ins_2outs_ui64 {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.flip<clock>, !firrtl.flip<uint<1>>

--- a/test/Conversion/HandshakeToFIRRTL/test_join.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_join.mlir
@@ -1,13 +1,13 @@
 // RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
 
 // CHECK-LABEL: firrtl.module @handshake_join_2ins_1outs_ctrl(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>) {
+// CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, out %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) {
  // CHECK:   %0 = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
  // CHECK:   %1 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
  // CHECK:   %2 = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
  // CHECK:   %3 = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
- // CHECK:   %4 = firrtl.subfield %arg2("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>) -> !firrtl.uint<1>
- // CHECK:   %5 = firrtl.subfield %arg2("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>) -> !firrtl.uint<1>
+ // CHECK:   %4 = firrtl.subfield %arg2("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
+ // CHECK:   %5 = firrtl.subfield %arg2("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>) -> !firrtl.uint<1>
  // CHECK:   %6 = firrtl.and %2, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
  // CHECK:   firrtl.connect %4, %6 : !firrtl.uint<1>, !firrtl.uint<1>
  // CHECK:   %7 = firrtl.and %5, %6 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
@@ -16,7 +16,7 @@
  // CHECK: }
 
 // CHECK-LABEL: firrtl.module @test_join(
-// CHECK-SAME: %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg3: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %arg4: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME: in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, in %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, out %arg4: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_join(%arg0: none, %arg1: none, %arg2: none, ...) -> (none, none) {
 
   // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @handshake_join_2ins_1outs_ctrl  {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>

--- a/test/Conversion/HandshakeToFIRRTL/test_lazy_fork.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_lazy_fork.mlir
@@ -1,16 +1,16 @@
 // RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
 
 // CHECK-LABEL: firrtl.module @handshake_lazy_fork_1ins_2outs_ui64(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) {
+// CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, out %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, out %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) {
 // CHECK:   %0 = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %1 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %2 = firrtl.subfield %arg0("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %3 = firrtl.subfield %arg1("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %4 = firrtl.subfield %arg1("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %5 = firrtl.subfield %arg1("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
-// CHECK:   %6 = firrtl.subfield %arg2("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %7 = firrtl.subfield %arg2("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %8 = firrtl.subfield %arg2("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
+// CHECK:   %3 = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
+// CHECK:   %4 = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
+// CHECK:   %5 = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
+// CHECK:   %6 = firrtl.subfield %arg2("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
+// CHECK:   %7 = firrtl.subfield %arg2("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
+// CHECK:   %8 = firrtl.subfield %arg2("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
 // CHECK:   %9 = firrtl.and %7, %4 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:   firrtl.connect %1, %9 : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:   %10 = firrtl.and %0, %9 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
@@ -21,7 +21,7 @@
 // CHECK: }
 
 // CHECK-LABEL: firrtl.module @test_lazy_fork(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg3: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg4: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, out %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, out %arg4: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_lazy_fork(%arg0: index, %arg1: none, ...) -> (index, index, none) {
 
   // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @handshake_lazy_fork_1ins_2outs_ui64  {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>

--- a/test/Conversion/HandshakeToFIRRTL/test_merge.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_merge.mlir
@@ -1,16 +1,16 @@
 // RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
 
 // CHECK-LABEL: firrtl.module @handshake_merge_2ins_1outs_ui64(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) {
+// CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, out %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) {
 // CHECK:   %[[ARG0_VALID:.+]] = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %[[ARG0_READY:.+]] = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %[[ARG0_DATA:.+]] = firrtl.subfield %arg0("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
 // CHECK:   %[[ARG1_VALID:.+]] = firrtl.subfield %arg1("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %[[ARG1_READY:.+]] = firrtl.subfield %arg1("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %[[ARG1_DATA:.+]] = firrtl.subfield %arg1("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %[[ARG2_VALID:.+]] = firrtl.subfield %arg2("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG2_READY:.+]] = firrtl.subfield %arg2("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %[[ARG2_DATA:.+]] = firrtl.subfield %arg2("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
+// CHECK:   %[[ARG2_VALID:.+]] = firrtl.subfield %arg2("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
+// CHECK:   %[[ARG2_READY:.+]] = firrtl.subfield %arg2("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
+// CHECK:   %[[ARG2_DATA:.+]] = firrtl.subfield %arg2("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
 
 // Common definitions.
 // CHECK:   %[[NO_WINNER:.+]] = firrtl.constant(0 : ui2) : !firrtl.uint<2>
@@ -52,7 +52,7 @@
 // CHECK:   firrtl.connect %[[ARG1_READY]], %[[ARG1_READY0]]
 
 // CHECK-LABEL: firrtl.module @test_merge(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg3: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg4: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, in %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, out %arg4: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_merge(%arg0: index, %arg1: index, %arg2: none, ...) -> (index, none) {
 
   // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @handshake_merge_2ins_1outs_ui64 {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>

--- a/test/Conversion/HandshakeToFIRRTL/test_mux.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_mux.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt -lower-handshake-to-firrtl -split-input-file %s | FileCheck %s
 
 // CHECK-LABEL: firrtl.module @handshake_mux_3ins_1outs_ui64(
-// CHECK-SAME:  %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg3: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) {
+// CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, in %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) {
 // CHECK:   %0 = firrtl.subfield %arg0("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %1 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %2 = firrtl.subfield %arg0("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
@@ -11,9 +11,9 @@
 // CHECK:   %6 = firrtl.subfield %arg2("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %7 = firrtl.subfield %arg2("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %8 = firrtl.subfield %arg2("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
-// CHECK:   %9 = firrtl.subfield %arg3("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %10 = firrtl.subfield %arg3("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
-// CHECK:   %11 = firrtl.subfield %arg3("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
+// CHECK:   %9 = firrtl.subfield %arg3("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
+// CHECK:   %10 = firrtl.subfield %arg3("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
+// CHECK:   %11 = firrtl.subfield %arg3("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
 // CHECK:   %12 = firrtl.bits %2 0 to 0 : (!firrtl.uint<64>) -> !firrtl.uint<1>
 // CHECK:   %13 = firrtl.mux(%12, %8, %5) : (!firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>) -> !firrtl.uint<64>
 // CHECK:   firrtl.connect %11, %13 : !firrtl.uint<64>, !firrtl.uint<64>
@@ -34,7 +34,7 @@
 // CHECK:   firrtl.connect %7, %23 : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK: }
 
-// CHECK: firrtl.module @test_mux(%arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg3: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg4: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, %arg5: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK: firrtl.module @test_mux(in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, in %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, in %arg3: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, out %arg4: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, out %arg5: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_mux(%arg0: index, %arg1: index, %arg2: index, %arg3: none, ...) -> (index, none) {
 
   // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_arg3 = firrtl.instance @handshake_mux_3ins_1outs_ui64  {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
@@ -129,4 +129,3 @@ handshake.func @test_mux_6way(%arg0: index, %arg1: index, %arg2: index, %arg3: i
   %0 = "handshake.mux"(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6): (index, index, index, index, index, index, index) -> index
   handshake.return %0, %arg7 : index, none
 }
-

--- a/test/Conversion/HandshakeToFIRRTL/test_sink.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_sink.mlir
@@ -1,20 +1,20 @@
 // RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
 
 // CHECK-LABEL: firrtl.module @handshake_sink_1ins_0outs_ui64(
-// CHECK-SAME:   %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) {
+// CHECK-SAME:   in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) {
 // CHECK:   %0 = firrtl.subfield %arg0("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
 // CHECK:   %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
 // CHECK:   firrtl.connect %0, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK: }
 
 // CHECK-LABEL: firrtl.module @test_sink(
-// CHECK-SAME: %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, %arg2: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, %clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+// CHECK-SAME: in %arg0: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, out %arg2: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_sink(%arg0: index, %arg2: none, ...) -> (none) {
 
   // CHECK: %inst_arg0 = firrtl.instance @handshake_sink_1ins_0outs_ui64  {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>
   // CHECK: firrtl.connect %inst_arg0, %arg0 : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
   "handshake.sink"(%arg0) : (index) -> ()
 
-  // CHECK: firrtl.connect %arg2, %arg1 : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>
+  // CHECK: firrtl.connect %arg2, %arg1 : !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>>
   handshake.return %arg2 : none
 }

--- a/test/Dialect/FIRRTL/blackbox-memory.mlir
+++ b/test/Dialect/FIRRTL/blackbox-memory.mlir
@@ -18,8 +18,8 @@ firrtl.circuit "Read" {
 }
 
 // WRAPPER-LABEL: firrtl.circuit "Read" {
-// WRAPPER-NEXT:   firrtl.extmodule @ReadMemory_ext(%R0_addr: !firrtl.uint<4>, %R0_en: !firrtl.uint<1>, %R0_clk: !firrtl.clock, %R0_data: !firrtl.flip<sint<8>>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
-// WRAPPER-NEXT:   firrtl.module @ReadMemory(%read0: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) {
+// WRAPPER-NEXT:   firrtl.extmodule @ReadMemory_ext(in %R0_addr: !firrtl.uint<4>, in %R0_en: !firrtl.uint<1>, in %R0_clk: !firrtl.clock, out %R0_data: !firrtl.sint<8>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// WRAPPER-NEXT:   firrtl.module @ReadMemory(in %read0: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) {
 // WRAPPER-NEXT:     %ReadMemory_R0_addr, %ReadMemory_R0_en, %ReadMemory_R0_clk, %ReadMemory_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory"} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
 // WRAPPER-NEXT:     %0 = firrtl.subfield %read0("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.uint<4>
 // WRAPPER-NEXT:     firrtl.connect %ReadMemory_R0_addr, %0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
@@ -44,7 +44,7 @@ firrtl.circuit "Read" {
 // WRAPPER-NEXT: }
 
 // INLINE-LABEL: firrtl.circuit "Read" {
-// INLINE-NEXT:   firrtl.extmodule @ReadMemory_ext(%R0_addr: !firrtl.uint<4>, %R0_en: !firrtl.uint<1>, %R0_clk: !firrtl.clock, %R0_data: !firrtl.flip<sint<8>>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// INLINE-NEXT:   firrtl.extmodule @ReadMemory_ext(in %R0_addr: !firrtl.uint<4>, in %R0_en: !firrtl.uint<1>, in %R0_clk: !firrtl.clock, out %R0_data: !firrtl.sint<8>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // INLINE-NEXT:   firrtl.module @Read() {
 // INLINE-NEXT:     %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
 // INLINE-NEXT:     %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
@@ -74,8 +74,8 @@ firrtl.circuit "Write" {
 }
 
 // WRAPPER-LABEL: firrtl.circuit "Write" {
-// WRAPPER-NEXT:   firrtl.extmodule @WriteMemory_ext(%W0_addr: !firrtl.uint<1>, %W0_en: !firrtl.uint<1>, %W0_clk: !firrtl.clock, %W0_data: !firrtl.sint<8>, %W0_mask: !firrtl.uint<1>) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
-// WRAPPER-NEXT:   firrtl.module @WriteMemory(%write0: !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) {
+// WRAPPER-NEXT:   firrtl.extmodule @WriteMemory_ext(in %W0_addr: !firrtl.uint<1>, in %W0_en: !firrtl.uint<1>, in %W0_clk: !firrtl.clock, in %W0_data: !firrtl.sint<8>, in %W0_mask: !firrtl.uint<1>) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// WRAPPER-NEXT:   firrtl.module @WriteMemory(in %write0: !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) {
 // WRAPPER-NEXT:     %WriteMemory_W0_addr, %WriteMemory_W0_en, %WriteMemory_W0_clk, %WriteMemory_W0_data, %WriteMemory_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory"} : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.flip<sint<8>>, !firrtl.flip<uint<1>>
 // WRAPPER-NEXT:     %0 = firrtl.subfield %write0("addr") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
 // WRAPPER-NEXT:     firrtl.connect %WriteMemory_W0_addr, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
@@ -94,7 +94,7 @@ firrtl.circuit "Write" {
 // WRAPPER-NEXT: }
 
 // INLINE-LABEL: firrtl.circuit "Write" {
-// INLINE-NEXT:   firrtl.extmodule @WriteMemory_ext(%W0_addr: !firrtl.uint<1>, %W0_en: !firrtl.uint<1>, %W0_clk: !firrtl.clock, %W0_data: !firrtl.sint<8>, %W0_mask: !firrtl.uint<1>) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// INLINE-NEXT:   firrtl.extmodule @WriteMemory_ext(in %W0_addr: !firrtl.uint<1>, in %W0_en: !firrtl.uint<1>, in %W0_clk: !firrtl.clock, in %W0_data: !firrtl.sint<8>, in %W0_mask: !firrtl.uint<1>) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // INLINE-NEXT:   firrtl.module @Write() {
 // INLINE-NEXT:     %WriteMemory_W0_addr, %WriteMemory_W0_en, %WriteMemory_W0_clk, %WriteMemory_W0_data, %WriteMemory_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory"} : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.flip<sint<8>>, !firrtl.flip<uint<1>>
 // INLINE-NEXT:     %0 = firrtl.wire  : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
@@ -141,13 +141,13 @@ firrtl.circuit "Write" {
 //        _M.write.mask <= validif(inpred, UInt<1>("h1"))
 
 firrtl.circuit "MemSimple" {
-  firrtl.module @MemSimple(%clock1: !firrtl.clock, %clock2: !firrtl.clock, %inpred: !firrtl.uint<1>, %indata: !firrtl.sint<42>, %result: !firrtl.flip<sint<42>>) {
+  firrtl.module @MemSimple(in %clock1: !firrtl.clock, in %clock2: !firrtl.clock, in %inpred: !firrtl.uint<1>, in %indata: !firrtl.sint<42>, out %result: !firrtl.sint<42>) {
     %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
     %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
     %c0_ui3 = firrtl.constant(0 : ui3) : !firrtl.uint<3>
     %_M_read, %_M_write = firrtl.mem Undefined {depth = 12 : i64, name = "_M", portNames = ["read", "write"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>
     %0 = firrtl.subfield %_M_read("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>) -> !firrtl.sint<42>
-    firrtl.connect %result, %0 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
+    firrtl.connect %result, %0 : !firrtl.sint<42>, !firrtl.sint<42>
     %1 = firrtl.subfield %_M_read("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>) -> !firrtl.uint<4>
     firrtl.connect %1, %c0_ui1 : !firrtl.uint<4>, !firrtl.uint<1>
     %2 = firrtl.subfield %_M_read("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>) -> !firrtl.uint<1>
@@ -177,8 +177,8 @@ firrtl.circuit "MemSimple" {
 }
 
 // WRAPPER-LABEL: firrtl.circuit "MemSimple" {
-// WRAPPER-NEXT:   firrtl.extmodule @_M_ext(%R0_addr: !firrtl.uint<4>, %R0_en: !firrtl.uint<1>, %R0_clk: !firrtl.clock, %R0_data: !firrtl.flip<sint<42>>, %W0_addr: !firrtl.uint<4>, %W0_en: !firrtl.uint<1>, %W0_clk: !firrtl.clock, %W0_data: !firrtl.sint<42>, %W0_mask: !firrtl.uint<1>) attributes {depth = 12 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
-// WRAPPER-NEXT:   firrtl.module @_M(%read: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>, %write: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) {
+// WRAPPER-NEXT:   firrtl.extmodule @_M_ext(in %R0_addr: !firrtl.uint<4>, in %R0_en: !firrtl.uint<1>, in %R0_clk: !firrtl.clock, out %R0_data: !firrtl.sint<42>, in %W0_addr: !firrtl.uint<4>, in %W0_en: !firrtl.uint<1>, in %W0_clk: !firrtl.clock, in %W0_data: !firrtl.sint<42>, in %W0_mask: !firrtl.uint<1>) attributes {depth = 12 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// WRAPPER-NEXT:   firrtl.module @_M(in %read: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>, in %write: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) {
 // WRAPPER-NEXT:     %_M_R0_addr, %_M_R0_en, %_M_R0_clk, %_M_R0_data, %_M_W0_addr, %_M_W0_en, %_M_W0_clk, %_M_W0_data, %_M_W0_mask = firrtl.instance @_M_ext {name = "_M"} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<42>, !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.flip<sint<42>>, !firrtl.flip<uint<1>>
 // WRAPPER-NEXT:     %0 = firrtl.subfield %read("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>) -> !firrtl.uint<4>
 // WRAPPER-NEXT:     firrtl.connect %_M_R0_addr, %0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
@@ -199,13 +199,13 @@ firrtl.circuit "MemSimple" {
 // WRAPPER-NEXT:     %8 = firrtl.subfield %write("mask") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.uint<1>
 // WRAPPER-NEXT:     firrtl.connect %_M_W0_mask, %8 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // WRAPPER-NEXT:   }
-// WRAPPER-NEXT:   firrtl.module @MemSimple(%clock1: !firrtl.clock, %clock2: !firrtl.clock, %inpred: !firrtl.uint<1>, %indata: !firrtl.sint<42>, %result: !firrtl.flip<sint<42>>) {
+// WRAPPER-NEXT:   firrtl.module @MemSimple(in %clock1: !firrtl.clock, in %clock2: !firrtl.clock, in %inpred: !firrtl.uint<1>, in %indata: !firrtl.sint<42>, out %result: !firrtl.sint<42>) {
 // WRAPPER-NEXT:     %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
 // WRAPPER-NEXT:     %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
 // WRAPPER-NEXT:     %c0_ui3 = firrtl.constant(0 : ui3) : !firrtl.uint<3>
 // WRAPPER-NEXT:     %_M_read, %_M_write = firrtl.instance @_M {name = "_M"} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>>
 // WRAPPER-NEXT:     %0 = firrtl.subfield %_M_read("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>) -> !firrtl.sint<42>
-// WRAPPER-NEXT:     firrtl.connect %result, %0 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
+// WRAPPER-NEXT:     firrtl.connect %result, %0 : !firrtl.sint<42>, !firrtl.sint<42>
 // WRAPPER-NEXT:     %1 = firrtl.subfield %_M_read("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>) -> !firrtl.uint<4>
 // WRAPPER-NEXT:     firrtl.connect %1, %c0_ui1 : !firrtl.uint<4>, !firrtl.uint<1>
 // WRAPPER-NEXT:     %2 = firrtl.subfield %_M_read("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>>) -> !firrtl.uint<1>
@@ -235,8 +235,8 @@ firrtl.circuit "MemSimple" {
 // WRAPPER-NEXT: }
 
 // INLINE-LABEL: firrtl.circuit "MemSimple" {
-// INLINE-NEXT:   firrtl.extmodule @_M_ext(%R0_addr: !firrtl.uint<4>, %R0_en: !firrtl.uint<1>, %R0_clk: !firrtl.clock, %R0_data: !firrtl.flip<sint<42>>, %W0_addr: !firrtl.uint<4>, %W0_en: !firrtl.uint<1>, %W0_clk: !firrtl.clock, %W0_data: !firrtl.sint<42>, %W0_mask: !firrtl.uint<1>) attributes {depth = 12 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
-// INLINE-NEXT:   firrtl.module @MemSimple(%clock1: !firrtl.clock, %clock2: !firrtl.clock, %inpred: !firrtl.uint<1>, %indata: !firrtl.sint<42>, %result: !firrtl.flip<sint<42>>) {
+// INLINE-NEXT:   firrtl.extmodule @_M_ext(in %R0_addr: !firrtl.uint<4>, in %R0_en: !firrtl.uint<1>, in %R0_clk: !firrtl.clock, out %R0_data: !firrtl.sint<42>, in %W0_addr: !firrtl.uint<4>, in %W0_en: !firrtl.uint<1>, in %W0_clk: !firrtl.clock, in %W0_data: !firrtl.sint<42>, in %W0_mask: !firrtl.uint<1>) attributes {depth = 12 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// INLINE-NEXT:   firrtl.module @MemSimple(in %clock1: !firrtl.clock, in %clock2: !firrtl.clock, in %inpred: !firrtl.uint<1>, in %indata: !firrtl.sint<42>, out %result: !firrtl.sint<42>) {
 // INLINE-NEXT:     %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
 // INLINE-NEXT:     %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
 // INLINE-NEXT:     %c0_ui3 = firrtl.constant(0 : ui3) : !firrtl.uint<3>
@@ -262,7 +262,7 @@ firrtl.circuit "MemSimple" {
 // INLINE-NEXT:     %10 = firrtl.subfield %5("mask") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) -> !firrtl.uint<1>
 // INLINE-NEXT:     firrtl.connect %_M_W0_mask, %10 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // INLINE-NEXT:     %11 = firrtl.subfield %0("data") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>) -> !firrtl.sint<42>
-// INLINE-NEXT:     firrtl.connect %result, %11 : !firrtl.flip<sint<42>>, !firrtl.sint<42>
+// INLINE-NEXT:     firrtl.connect %result, %11 : !firrtl.sint<42>, !firrtl.sint<42>
 // INLINE-NEXT:     %12 = firrtl.subfield %0("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>) -> !firrtl.uint<4>
 // INLINE-NEXT:     firrtl.connect %12, %c0_ui1 : !firrtl.uint<4>, !firrtl.uint<1>
 // INLINE-NEXT:     %13 = firrtl.subfield %0("en") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<42>>>) -> !firrtl.uint<1>
@@ -302,8 +302,8 @@ firrtl.circuit "NameCollision" {
 }
 
 // WRAPPER-LABEL: firrtl.circuit "NameCollision" {
-// WRAPPER-NEXT:   firrtl.extmodule @NameCollisionMemory_ext_1(%W0_addr: !firrtl.uint<4>, %W0_en: !firrtl.uint<1>, %W0_clk: !firrtl.clock, %W0_data: !firrtl.sint<8>, %W0_mask: !firrtl.uint<1>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
-// WRAPPER-NEXT:   firrtl.module @NameCollisionMemory_0(%write0: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) {
+// WRAPPER-NEXT:   firrtl.extmodule @NameCollisionMemory_ext_1(in %W0_addr: !firrtl.uint<4>, in %W0_en: !firrtl.uint<1>, in %W0_clk: !firrtl.clock, in %W0_data: !firrtl.sint<8>, in %W0_mask: !firrtl.uint<1>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// WRAPPER-NEXT:   firrtl.module @NameCollisionMemory_0(in %write0: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) {
 // WRAPPER-NEXT:     %NameCollisionMemory_W0_addr, %NameCollisionMemory_W0_en, %NameCollisionMemory_W0_clk, %NameCollisionMemory_W0_data, %NameCollisionMemory_W0_mask = firrtl.instance @NameCollisionMemory_ext_1 {name = "NameCollisionMemory"} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.flip<sint<8>>, !firrtl.flip<uint<1>>
 // WRAPPER-NEXT:     %0 = firrtl.subfield %write0("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<4>
 // WRAPPER-NEXT:     firrtl.connect %NameCollisionMemory_W0_addr, %0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
@@ -316,8 +316,8 @@ firrtl.circuit "NameCollision" {
 // WRAPPER-NEXT:     %4 = firrtl.subfield %write0("mask") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
 // WRAPPER-NEXT:     firrtl.connect %NameCollisionMemory_W0_mask, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // WRAPPER-NEXT:   }
-// WRAPPER-NEXT:   firrtl.extmodule @NameCollisionMemory_ext_0(%R0_addr: !firrtl.uint<4>, %R0_en: !firrtl.uint<1>, %R0_clk: !firrtl.clock, %R0_data: !firrtl.flip<sint<8>>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
-// WRAPPER-NEXT:   firrtl.module @NameCollisionMemory(%read0: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) {
+// WRAPPER-NEXT:   firrtl.extmodule @NameCollisionMemory_ext_0(in %R0_addr: !firrtl.uint<4>, in %R0_en: !firrtl.uint<1>, in %R0_clk: !firrtl.clock, out %R0_data: !firrtl.sint<8>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// WRAPPER-NEXT:   firrtl.module @NameCollisionMemory(in %read0: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) {
 // WRAPPER-NEXT:     %NameCollisionMemory_R0_addr, %NameCollisionMemory_R0_en, %NameCollisionMemory_R0_clk, %NameCollisionMemory_R0_data = firrtl.instance @NameCollisionMemory_ext_0 {name = "NameCollisionMemory"} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
 // WRAPPER-NEXT:     %0 = firrtl.subfield %read0("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.uint<4>
 // WRAPPER-NEXT:     firrtl.connect %NameCollisionMemory_R0_addr, %0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
@@ -337,8 +337,8 @@ firrtl.circuit "NameCollision" {
 // WRAPPER-NEXT: }
 
 // INLINE-LABEL: firrtl.circuit "NameCollision" {
-// INLINE-NEXT:   firrtl.extmodule @NameCollisionMemory_ext_1(%W0_addr: !firrtl.uint<4>, %W0_en: !firrtl.uint<1>, %W0_clk: !firrtl.clock, %W0_data: !firrtl.sint<8>, %W0_mask: !firrtl.uint<1>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
-// INLINE-NEXT:   firrtl.extmodule @NameCollisionMemory_ext_0(%R0_addr: !firrtl.uint<4>, %R0_en: !firrtl.uint<1>, %R0_clk: !firrtl.clock, %R0_data: !firrtl.flip<sint<8>>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// INLINE-NEXT:   firrtl.extmodule @NameCollisionMemory_ext_1(in %W0_addr: !firrtl.uint<4>, in %W0_en: !firrtl.uint<1>, in %W0_clk: !firrtl.clock, in %W0_data: !firrtl.sint<8>, in %W0_mask: !firrtl.uint<1>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// INLINE-NEXT:   firrtl.extmodule @NameCollisionMemory_ext_0(in %R0_addr: !firrtl.uint<4>, in %R0_en: !firrtl.uint<1>, in %R0_clk: !firrtl.clock, out %R0_data: !firrtl.sint<8>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // INLINE-NEXT:   firrtl.module @NameCollisionMemory_ext() {
 // INLINE-NEXT:     %NameCollisionMemory_R0_addr, %NameCollisionMemory_R0_en, %NameCollisionMemory_R0_clk, %NameCollisionMemory_R0_data = firrtl.instance @NameCollisionMemory_ext_0 {name = "NameCollisionMemory"} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
 // INLINE-NEXT:     %0 = firrtl.wire  : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>
@@ -379,8 +379,8 @@ firrtl.circuit "Duplicate" {
 }
 
 // WRAPPER-LABEL: firrtl.circuit "Duplicate" {
-// WRAPPER-NEXT:   firrtl.extmodule @WriteMemory_ext(%W0_addr: !firrtl.uint<1>, %W0_en: !firrtl.uint<1>, %W0_clk: !firrtl.clock, %W0_data: !firrtl.sint<8>, %W0_mask: !firrtl.uint<1>) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
-// WRAPPER-NEXT:   firrtl.module @WriteMemory(%write0: !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) {
+// WRAPPER-NEXT:   firrtl.extmodule @WriteMemory_ext(in %W0_addr: !firrtl.uint<1>, in %W0_en: !firrtl.uint<1>, in %W0_clk: !firrtl.clock, in %W0_data: !firrtl.sint<8>, in %W0_mask: !firrtl.uint<1>) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// WRAPPER-NEXT:   firrtl.module @WriteMemory(in %write0: !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) {
 // WRAPPER-NEXT:     %WriteMemory_W0_addr, %WriteMemory_W0_en, %WriteMemory_W0_clk, %WriteMemory_W0_data, %WriteMemory_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory"} : !firrtl.flip<uint<1>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.flip<sint<8>>, !firrtl.flip<uint<1>>
 // WRAPPER-NEXT:     %0 = firrtl.subfield %write0("addr") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
 // WRAPPER-NEXT:     firrtl.connect %WriteMemory_W0_addr, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
@@ -393,8 +393,8 @@ firrtl.circuit "Duplicate" {
 // WRAPPER-NEXT:     %4 = firrtl.subfield %write0("mask") : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
 // WRAPPER-NEXT:     firrtl.connect %WriteMemory_W0_mask, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
 // WRAPPER-NEXT:   }
-// WRAPPER-NEXT:   firrtl.extmodule @ReadMemory_ext(%R0_addr: !firrtl.uint<4>, %R0_en: !firrtl.uint<1>, %R0_clk: !firrtl.clock, %R0_data: !firrtl.flip<sint<8>>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
-// WRAPPER-NEXT:   firrtl.module @ReadMemory(%read0: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) {
+// WRAPPER-NEXT:   firrtl.extmodule @ReadMemory_ext(in %R0_addr: !firrtl.uint<4>, in %R0_en: !firrtl.uint<1>, in %R0_clk: !firrtl.clock, out %R0_data: !firrtl.sint<8>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// WRAPPER-NEXT:   firrtl.module @ReadMemory(in %read0: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) {
 // WRAPPER-NEXT:     %ReadMemory_R0_addr, %ReadMemory_R0_en, %ReadMemory_R0_clk, %ReadMemory_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory"} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
 // WRAPPER-NEXT:     %0 = firrtl.subfield %read0("addr") : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>) -> !firrtl.uint<4>
 // WRAPPER-NEXT:     firrtl.connect %ReadMemory_R0_addr, %0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
@@ -416,8 +416,8 @@ firrtl.circuit "Duplicate" {
 // WRAPPER-NEXT: }
 
 // INLINE-LABEL: firrtl.circuit "Duplicate" {
-// INLINE-NEXT:   firrtl.extmodule @WriteMemory_ext(%W0_addr: !firrtl.uint<1>, %W0_en: !firrtl.uint<1>, %W0_clk: !firrtl.clock, %W0_data: !firrtl.sint<8>, %W0_mask: !firrtl.uint<1>) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
-// INLINE-NEXT:   firrtl.extmodule @ReadMemory_ext(%R0_addr: !firrtl.uint<4>, %R0_en: !firrtl.uint<1>, %R0_clk: !firrtl.clock, %R0_data: !firrtl.flip<sint<8>>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// INLINE-NEXT:   firrtl.extmodule @WriteMemory_ext(in %W0_addr: !firrtl.uint<1>, in %W0_en: !firrtl.uint<1>, in %W0_clk: !firrtl.clock, in %W0_data: !firrtl.sint<8>, in %W0_mask: !firrtl.uint<1>) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
+// INLINE-NEXT:   firrtl.extmodule @ReadMemory_ext(in %R0_addr: !firrtl.uint<4>, in %R0_en: !firrtl.uint<1>, in %R0_clk: !firrtl.clock, out %R0_data: !firrtl.sint<8>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // INLINE-NEXT:   firrtl.module @Duplicate() {
 // INLINE-NEXT:     %ReadMemory_R0_addr, %ReadMemory_R0_en, %ReadMemory_R0_clk, %ReadMemory_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory"} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.flip<clock>, !firrtl.sint<8>
 // INLINE-NEXT:     %0 = firrtl.wire  : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<sint<8>>>

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -3,14 +3,14 @@
 firrtl.circuit "And" {
 
 // CHECK-LABEL: firrtl.module @Div
-firrtl.module @Div(%a: !firrtl.uint<4>,
-                  %b: !firrtl.flip<uint<4>>,
-                  %c: !firrtl.sint<4>,
-                  %d: !firrtl.flip<sint<5>>,
-                  %e: !firrtl.uint,
-                  %f: !firrtl.flip<uint>,
-                  %g: !firrtl.sint,
-                  %h: !firrtl.flip<sint>) {
+firrtl.module @Div(in %a: !firrtl.uint<4>,
+                   out %b: !firrtl.uint<4>,
+                   in %c: !firrtl.sint<4>,
+                   out %d: !firrtl.sint<5>,
+                   in %e: !firrtl.uint,
+                   out %f: !firrtl.uint,
+                   in %g: !firrtl.sint,
+                   out %h: !firrtl.sint) {
 
   // CHECK-DAG: [[ONE_i4:%.+]] = firrtl.constant(1 : i4) : !firrtl.uint<4>
   // CHECK-DAG: [[ONE_s5:%.+]] = firrtl.constant(1 : i5) : !firrtl.sint<5>
@@ -20,54 +20,54 @@ firrtl.module @Div(%a: !firrtl.uint<4>,
   // COM: Check that 'div(a, a) -> 1' works for known UInt widths
   // CHECK: firrtl.connect %b, [[ONE_i4]]
   %0 = firrtl.div %a, %a : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  firrtl.connect %b, %0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %b, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // COM: Check that 'div(c, c) -> 1' works for known SInt widths
-  // CHECK: firrtl.connect %d, [[ONE_s5]] : !firrtl.flip<sint<5>>, !firrtl.sint<5>
+  // CHECK: firrtl.connect %d, [[ONE_s5]] : !firrtl.sint<5>, !firrtl.sint<5>
   %1 = firrtl.div %c, %c : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.sint<5>
-  firrtl.connect %d, %1 : !firrtl.flip<sint<5>>, !firrtl.sint<5>
+  firrtl.connect %d, %1 : !firrtl.sint<5>, !firrtl.sint<5>
 
   // COM: Check that 'div(e, e) -> 1' works for unknown UInt widths
   // CHECK: firrtl.connect %f, [[ONE_i2]]
   %2 = firrtl.div %e, %e : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
-  firrtl.connect %f, %2 : !firrtl.flip<uint>, !firrtl.uint
+  firrtl.connect %f, %2 : !firrtl.uint, !firrtl.uint
 
   // COM: Check that 'div(g, g) -> 1' works for unknown SInt widths
   // CHECK: firrtl.connect %h, [[ONE_s2]]
   %3 = firrtl.div %g, %g : (!firrtl.sint, !firrtl.sint) -> !firrtl.sint
-  firrtl.connect %h, %3 : !firrtl.flip<sint>, !firrtl.sint
+  firrtl.connect %h, %3 : !firrtl.sint, !firrtl.sint
 
   // COM: Check that 'div(a, 1) -> a' for known UInt widths
   // CHECK: firrtl.connect %b, %a
   %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
   %4 = firrtl.div %a, %c1_ui2 : (!firrtl.uint<4>, !firrtl.uint<2>) -> !firrtl.uint<4>
-  firrtl.connect %b, %4 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %b, %4 : !firrtl.uint<4>, !firrtl.uint<4>
 
 }
 
 // CHECK-LABEL: firrtl.module @And
-firrtl.module @And(%in: !firrtl.uint<4>,
-                   %sin: !firrtl.sint<4>,
-                   %out: !firrtl.flip<uint<4>>) {
+firrtl.module @And(in %in: !firrtl.uint<4>,
+                   in %sin: !firrtl.sint<4>,
+                   out %out: !firrtl.uint<4>) {
   // CHECK: firrtl.connect %out, %c1_ui4
   %c1_ui4 = firrtl.constant(1 : ui4) : !firrtl.uint<4>
   %c3_ui4 = firrtl.constant(3 : ui4) : !firrtl.uint<4>
   %0 = firrtl.and %c3_ui4, %c1_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  firrtl.connect %out, %0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.connect %out, %in
   %c15_ui4 = firrtl.constant(15 : ui4) : !firrtl.uint<4>
   %1 = firrtl.and %in, %c15_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  firrtl.connect %out, %1 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.connect %out, %c0_ui4
   %c1_ui0 = firrtl.constant(0 : ui4) : !firrtl.uint<4>
   %2 = firrtl.and %in, %c1_ui0 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  firrtl.connect %out, %2 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out, %2 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.connect %out, %in
   %3 = firrtl.and %in, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  firrtl.connect %out, %3 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out, %3 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // Mixed type inputs - the constant is zero extended, not sign extended, so it
   // cannot be folded!
@@ -76,366 +76,366 @@ firrtl.module @And(%in: !firrtl.uint<4>,
   // CHECK-NEXT: firrtl.connect %out,
   %c3_ui2 = firrtl.constant(3 : ui2) : !firrtl.uint<2>
   %4 = firrtl.and %in, %c3_ui2 : (!firrtl.uint<4>, !firrtl.uint<2>) -> !firrtl.uint<4>
-  firrtl.connect %out, %4 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out, %4 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // Mixed type input and outputs.
 
   // CHECK: firrtl.connect %out, %c1_ui4
   %c1_si4 = firrtl.constant(1 : si4) : !firrtl.sint<4>
   %5 = firrtl.and %c1_si4, %c1_si4 : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.uint<4>
-  firrtl.connect %out, %5 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out, %5 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: [[AND:%.+]] = firrtl.and %sin, %sin
   // CHECK-NEXT: firrtl.connect %out, [[AND]]
   %6 = firrtl.and %sin, %sin : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.uint<4>
-  firrtl.connect %out, %6 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out, %6 : !firrtl.uint<4>, !firrtl.uint<4>
 }
 
 // CHECK-LABEL: firrtl.module @Or
-firrtl.module @Or(%in: !firrtl.uint<4>,
-                  %sin: !firrtl.sint<4>,
-                  %out: !firrtl.flip<uint<4>>) {
+firrtl.module @Or(in %in: !firrtl.uint<4>,
+                  in %sin: !firrtl.sint<4>,
+                  out %out: !firrtl.uint<4>) {
   // CHECK: firrtl.connect %out, %c7_ui4
   %c4_ui4 = firrtl.constant(4 : ui4) : !firrtl.uint<4>
   %c3_ui4 = firrtl.constant(3 : ui4) : !firrtl.uint<4>
   %0 = firrtl.or %c3_ui4, %c4_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  firrtl.connect %out, %0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.connect %out, %c15_ui4
   %c1_ui15 = firrtl.constant(15 : ui4) : !firrtl.uint<4>
   %1 = firrtl.or %in, %c1_ui15 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  firrtl.connect %out, %1 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.connect %out, %in
   %c1_ui0 = firrtl.constant(0 : ui4) : !firrtl.uint<4>
   %2 = firrtl.or %in, %c1_ui0 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  firrtl.connect %out, %2 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out, %2 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.connect %out, %in
   %3 = firrtl.or %in, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  firrtl.connect %out, %3 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out, %3 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // Mixed type input and outputs.
 
   // CHECK: firrtl.connect %out, %c1_ui4
   %c1_si4 = firrtl.constant(1 : si4) : !firrtl.sint<4>
   %5 = firrtl.or %c1_si4, %c1_si4 : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.uint<4>
-  firrtl.connect %out, %5 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out, %5 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: [[OR:%.+]] = firrtl.or %sin, %sin
   // CHECK-NEXT: firrtl.connect %out, [[OR]]
   %6 = firrtl.or %sin, %sin : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.uint<4>
-  firrtl.connect %out, %6 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out, %6 : !firrtl.uint<4>, !firrtl.uint<4>
 }
 
 // CHECK-LABEL: firrtl.module @Xor
-firrtl.module @Xor(%in: !firrtl.uint<4>,
-                   %sin: !firrtl.sint<4>,
-                   %out: !firrtl.flip<uint<4>>) {
+firrtl.module @Xor(in %in: !firrtl.uint<4>,
+                   in %sin: !firrtl.sint<4>,
+                   out %out: !firrtl.uint<4>) {
   // CHECK: firrtl.connect %out, %c2_ui4
   %c1_ui4 = firrtl.constant(1 : ui4) : !firrtl.uint<4>
   %c3_ui4 = firrtl.constant(3 : ui4) : !firrtl.uint<4>
   %0 = firrtl.xor %c3_ui4, %c1_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  firrtl.connect %out, %0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.connect %out, %in
   %c1_ui0 = firrtl.constant(0 : ui4) : !firrtl.uint<4>
   %2 = firrtl.xor %in, %c1_ui0 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  firrtl.connect %out, %2 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out, %2 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.connect %out, %c0_ui4
   %3 = firrtl.xor %in, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  firrtl.connect %out, %3 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out, %3 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // Mixed type input and outputs.
 
   // CHECK: firrtl.connect %out, %c0_ui4
   %6 = firrtl.xor %sin, %sin : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.uint<4>
-  firrtl.connect %out, %6 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out, %6 : !firrtl.uint<4>, !firrtl.uint<4>
 }
 
 // CHECK-LABEL: firrtl.module @EQ
-firrtl.module @EQ(%in: !firrtl.uint<1>,
-                   %out: !firrtl.flip<uint<1>>) {
+firrtl.module @EQ(in %in: !firrtl.uint<1>,
+                  out %out: !firrtl.uint<1>) {
   // CHECK: firrtl.connect %out, %in
   %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
   %0 = firrtl.eq %in, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-  firrtl.connect %out, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // Issue #368: https://github.com/llvm/circt/issues/368
   %c3_ui2 = firrtl.constant(3 : ui2) : !firrtl.uint<2>
   %1 = firrtl.eq %in, %c3_ui2 : (!firrtl.uint<1>, !firrtl.uint<2>) -> !firrtl.uint<1>
-  firrtl.connect %out, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %out, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: firrtl.eq %in, %c3_ui2
   // CHECK: firrtl.connect
 }
 
 // CHECK-LABEL: firrtl.module @NEQ
-firrtl.module @NEQ(%in: !firrtl.uint<1>,
-                   %out: !firrtl.flip<uint<1>>) {
+firrtl.module @NEQ(in %in: !firrtl.uint<1>,
+                   out %out: !firrtl.uint<1>) {
   // CHECK: firrtl.connect %out, %in
   %c1_ui0 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
   %0 = firrtl.neq %in, %c1_ui0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-  firrtl.connect %out, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
 // CHECK-LABEL: firrtl.module @Cat
-firrtl.module @Cat(%in4: !firrtl.uint<4>,
-                   %out4: !firrtl.flip<uint<4>>) {
+firrtl.module @Cat(in %in4: !firrtl.uint<4>,
+                   out %out4: !firrtl.uint<4>) {
 
   // CHECK: firrtl.connect %out4, %in4
   %0 = firrtl.bits %in4 3 to 2 : (!firrtl.uint<4>) -> !firrtl.uint<2>
   %1 = firrtl.bits %in4 1 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<2>
   %2 = firrtl.cat %0, %1 : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<4>
-  firrtl.connect %out4, %2 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out4, %2 : !firrtl.uint<4>, !firrtl.uint<4>
 }
 
 // CHECK-LABEL: firrtl.module @Bits
-firrtl.module @Bits(%in1: !firrtl.uint<1>,
-                    %in4: !firrtl.uint<4>,
-                    %out1: !firrtl.flip<uint<1>>,
-                    %out2: !firrtl.flip<uint<2>>,
-                    %out4: !firrtl.flip<uint<4>>) {
+firrtl.module @Bits(in %in1: !firrtl.uint<1>,
+                    in %in4: !firrtl.uint<4>,
+                    out %out1: !firrtl.uint<1>,
+                    out %out2: !firrtl.uint<2>,
+                    out %out4: !firrtl.uint<4>) {
   // CHECK: firrtl.connect %out1, %in1
   %0 = firrtl.bits %in1 0 to 0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-  firrtl.connect %out1, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %out1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: firrtl.connect %out4, %in4
   %1 = firrtl.bits %in4 3 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<4>
-  firrtl.connect %out4, %1 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out4, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.connect %out2, %c1_ui2
   %c7_ui4 = firrtl.constant(10 : ui4) : !firrtl.uint<4>
   %2 = firrtl.bits %c7_ui4 2 to 1 : (!firrtl.uint<4>) -> !firrtl.uint<2>
-  firrtl.connect %out2, %2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+  firrtl.connect %out2, %2 : !firrtl.uint<2>, !firrtl.uint<2>
 
 
   // CHECK: firrtl.bits %in4 2 to 2 : (!firrtl.uint<4>) -> !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %out1, %
   %3 = firrtl.bits %in4 3 to 1 : (!firrtl.uint<4>) -> !firrtl.uint<3>
   %4 = firrtl.bits %3 1 to 1 : (!firrtl.uint<3>) -> !firrtl.uint<1>
-  firrtl.connect %out1, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %out1, %4 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: firrtl.connect %out1, %in1
   %5 = firrtl.bits %in1 0 to 0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-  firrtl.connect %out1, %5 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %out1, %5 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
 // CHECK-LABEL: firrtl.module @Head
-firrtl.module @Head(%in4u: !firrtl.uint<4>,
-                   %out1u: !firrtl.flip<uint<1>>,
-                   %out3u: !firrtl.flip<uint<3>>) {
+firrtl.module @Head(in %in4u: !firrtl.uint<4>,
+                    out %out1u: !firrtl.uint<1>,
+                    out %out3u: !firrtl.uint<3>) {
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4u 3 to 3
   // CHECK-NEXT: firrtl.connect %out1u, [[BITS]]
   %0 = firrtl.head %in4u, 1 : (!firrtl.uint<4>) -> !firrtl.uint<1>
-  firrtl.connect %out1u, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %out1u, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4u 3 to 1
   // CHECK-NEXT: firrtl.connect %out3u, [[BITS]]
   %1 = firrtl.head %in4u, 3 : (!firrtl.uint<4>) -> !firrtl.uint<3>
-  firrtl.connect %out3u, %1 : !firrtl.flip<uint<3>>, !firrtl.uint<3>
+  firrtl.connect %out3u, %1 : !firrtl.uint<3>, !firrtl.uint<3>
 }
 
 // CHECK-LABEL: firrtl.module @Mux
-firrtl.module @Mux(%in: !firrtl.uint<4>,
-                   %cond: !firrtl.uint<1>,
-                   %out: !firrtl.flip<uint<4>>,
-                   %out1: !firrtl.flip<uint<1>>) {
+firrtl.module @Mux(in %in: !firrtl.uint<4>,
+                   in %cond: !firrtl.uint<1>,
+                   out %out: !firrtl.uint<4>,
+                   out %out1: !firrtl.uint<1>) {
   // CHECK: firrtl.connect %out, %in
   %0 = firrtl.mux (%cond, %in, %in) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  firrtl.connect %out, %0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.connect %out, %c7_ui4
   %c7_ui4 = firrtl.constant(7 : ui4) : !firrtl.uint<4>
   %c1_ui0 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
   %2 = firrtl.mux (%c1_ui0, %in, %c7_ui4) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  firrtl.connect %out, %2 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out, %2 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.connect %out1, %cond
   %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
   %3 = firrtl.mux (%cond, %c1_ui1, %c1_ui0) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-  firrtl.connect %out1, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %out1, %3 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
 // CHECK-LABEL: firrtl.module @Pad
-firrtl.module @Pad(%in1u: !firrtl.uint<1>,
-                   %out1u: !firrtl.flip<uint<1>>,
-                   %outu: !firrtl.flip<uint<4>>,
-                   %outs: !firrtl.flip<sint<4>>) {
+firrtl.module @Pad(in %in1u: !firrtl.uint<1>,
+                   out %out1u: !firrtl.uint<1>,
+                   out %outu: !firrtl.uint<4>,
+                   out %outs: !firrtl.sint<4>) {
   // CHECK: firrtl.connect %out1u, %in1u
   %0 = firrtl.pad %in1u, 1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-  firrtl.connect %out1u, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %out1u, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: firrtl.connect %outu, %c1_ui4
   %c1_ui0 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
   %1 = firrtl.pad %c1_ui0, 4 : (!firrtl.uint<1>) -> !firrtl.uint<4>
-  firrtl.connect %outu, %1 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %outu, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.connect %outs, %c-1_si4
   %c1_si1 = firrtl.constant(-1 : si1) : !firrtl.sint<1>
   %2 = firrtl.pad %c1_si1, 4 : (!firrtl.sint<1>) -> !firrtl.sint<4>
-  firrtl.connect %outs, %2 : !firrtl.flip<sint<4>>, !firrtl.sint<4>
+  firrtl.connect %outs, %2 : !firrtl.sint<4>, !firrtl.sint<4>
 }
 
 // CHECK-LABEL: firrtl.module @Shl
-firrtl.module @Shl(%in1u: !firrtl.uint<1>,
-                   %out1u: !firrtl.flip<uint<1>>,
-                   %outu: !firrtl.flip<uint<4>>) {
+firrtl.module @Shl(in %in1u: !firrtl.uint<1>,
+                   out %out1u: !firrtl.uint<1>,
+                   out %outu: !firrtl.uint<4>) {
   // CHECK: firrtl.connect %out1u, %in1u
   %0 = firrtl.shl %in1u, 0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-  firrtl.connect %out1u, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %out1u, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: firrtl.connect %outu, %c8_ui4
   %c1_ui0 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
   %1 = firrtl.shl %c1_ui0, 3 : (!firrtl.uint<1>) -> !firrtl.uint<4>
-  firrtl.connect %outu, %1 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %outu, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 }
 
 // CHECK-LABEL: firrtl.module @Shr
-firrtl.module @Shr(%in1u: !firrtl.uint<1>,
-                   %in4u: !firrtl.uint<4>,
-                   %in1s: !firrtl.sint<1>,
-                   %in4s: !firrtl.sint<4>,
-                   %out1s: !firrtl.flip<sint<1>>,
-                   %out1u: !firrtl.flip<uint<1>>,
-                   %outu: !firrtl.flip<uint<4>>) {
+firrtl.module @Shr(in %in1u: !firrtl.uint<1>,
+                   in %in4u: !firrtl.uint<4>,
+                   in %in1s: !firrtl.sint<1>,
+                   in %in4s: !firrtl.sint<4>,
+                   out %out1s: !firrtl.sint<1>,
+                   out %out1u: !firrtl.uint<1>,
+                   out %outu: !firrtl.uint<4>) {
   // CHECK: firrtl.connect %out1u, %in1u
   %0 = firrtl.shr %in1u, 0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-  firrtl.connect %out1u, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %out1u, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: firrtl.connect %out1u, %c0_ui1
   %1 = firrtl.shr %in4u, 4 : (!firrtl.uint<4>) -> !firrtl.uint<1>
-  firrtl.connect %out1u, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %out1u, %1 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: firrtl.connect %out1u, %c0_ui1
   %2 = firrtl.shr %in4u, 5 : (!firrtl.uint<4>) -> !firrtl.uint<1>
-  firrtl.connect %out1u, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %out1u, %2 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4s 3 to 3
   // CHECK-NEXT: [[CAST:%.+]] = firrtl.asSInt [[BITS]]
   // CHECK-NEXT: firrtl.connect %out1s, [[CAST]]
   %3 = firrtl.shr %in4s, 3 : (!firrtl.sint<4>) -> !firrtl.sint<1>
-  firrtl.connect %out1s, %3 : !firrtl.flip<sint<1>>, !firrtl.sint<1>
+  firrtl.connect %out1s, %3 : !firrtl.sint<1>, !firrtl.sint<1>
 
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4s 3 to 3
   // CHECK-NEXT: [[CAST:%.+]] = firrtl.asSInt [[BITS]]
   // CHECK-NEXT: firrtl.connect %out1s, [[CAST]]
   %4 = firrtl.shr %in4s, 4 : (!firrtl.sint<4>) -> !firrtl.sint<1>
-  firrtl.connect %out1s, %4 : !firrtl.flip<sint<1>>, !firrtl.sint<1>
+  firrtl.connect %out1s, %4 : !firrtl.sint<1>, !firrtl.sint<1>
 
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4s 3 to 3
   // CHECK-NEXT: [[CAST:%.+]] = firrtl.asSInt [[BITS]]
   // CHECK-NEXT: firrtl.connect %out1s, [[CAST]]
   %5 = firrtl.shr %in4s, 5 : (!firrtl.sint<4>) -> !firrtl.sint<1>
-  firrtl.connect %out1s, %5 : !firrtl.flip<sint<1>>, !firrtl.sint<1>
+  firrtl.connect %out1s, %5 : !firrtl.sint<1>, !firrtl.sint<1>
 
   // CHECK: firrtl.connect %out1u, %c1_ui1
   %c12_ui4 = firrtl.constant(12 : ui4) : !firrtl.uint<4>
   %6 = firrtl.shr %c12_ui4, 3 : (!firrtl.uint<4>) -> !firrtl.uint<1>
-  firrtl.connect %out1u, %6 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %out1u, %6 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4u 3 to 3
   // CHECK-NEXT: firrtl.connect %out1u, [[BITS]]
   %7 = firrtl.shr %in4u, 3 : (!firrtl.uint<4>) -> !firrtl.uint<1>
-  firrtl.connect %out1u, %7 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %out1u, %7 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // Issue #313: https://github.com/llvm/circt/issues/313
-  // CHECK: firrtl.connect %out1s, %in1s : !firrtl.flip<sint<1>>, !firrtl.sint<1>
+  // CHECK: firrtl.connect %out1s, %in1s : !firrtl.sint<1>, !firrtl.sint<1>
   %8 = firrtl.shr %in1s, 42 : (!firrtl.sint<1>) -> !firrtl.sint<1>
-  firrtl.connect %out1s, %8 : !firrtl.flip<sint<1>>, !firrtl.sint<1>
+  firrtl.connect %out1s, %8 : !firrtl.sint<1>, !firrtl.sint<1>
 }
 
 // CHECK-LABEL: firrtl.module @Tail
-firrtl.module @Tail(%in4u: !firrtl.uint<4>,
-                   %out1u: !firrtl.flip<uint<1>>,
-                   %out3u: !firrtl.flip<uint<3>>) {
+firrtl.module @Tail(in %in4u: !firrtl.uint<4>,
+                    out %out1u: !firrtl.uint<1>,
+                    out %out3u: !firrtl.uint<3>) {
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4u 0 to 0
   // CHECK-NEXT: firrtl.connect %out1u, [[BITS]]
   %0 = firrtl.tail %in4u, 3 : (!firrtl.uint<4>) -> !firrtl.uint<1>
-  firrtl.connect %out1u, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %out1u, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4u 2 to 0
   // CHECK-NEXT: firrtl.connect %out3u, [[BITS]]
   %1 = firrtl.tail %in4u, 1 : (!firrtl.uint<4>) -> !firrtl.uint<3>
-  firrtl.connect %out3u, %1 : !firrtl.flip<uint<3>>, !firrtl.uint<3>
+  firrtl.connect %out3u, %1 : !firrtl.uint<3>, !firrtl.uint<3>
 }
 
 // CHECK-LABEL: firrtl.module @issue326
-firrtl.module @issue326(%tmp57: !firrtl.flip<sint<1>>) {
+firrtl.module @issue326(out %tmp57: !firrtl.sint<1>) {
   %c29_si7 = firrtl.constant(29 : si7) : !firrtl.sint<7>
   %0 = firrtl.shr %c29_si7, 47 : (!firrtl.sint<7>) -> !firrtl.sint<1>
    // CHECK: c0_si1 = firrtl.constant(false) : !firrtl.sint<1>
-   firrtl.connect %tmp57, %0 : !firrtl.flip<sint<1>>, !firrtl.sint<1>
+   firrtl.connect %tmp57, %0 : !firrtl.sint<1>, !firrtl.sint<1>
 }
 
 // CHECK-LABEL: firrtl.module @issue331
-firrtl.module @issue331(%tmp81: !firrtl.flip<sint<1>>) {
+firrtl.module @issue331(out %tmp81: !firrtl.sint<1>) {
   // CHECK: %c-1_si1 = firrtl.constant(true) : !firrtl.sint<1>
   %c-1_si1 = firrtl.constant(-1 : si1) : !firrtl.sint<1>
   %0 = firrtl.shr %c-1_si1, 3 : (!firrtl.sint<1>) -> !firrtl.sint<1>
-  firrtl.connect %tmp81, %0 : !firrtl.flip<sint<1>>, !firrtl.sint<1>
+  firrtl.connect %tmp81, %0 : !firrtl.sint<1>, !firrtl.sint<1>
 }
 
 // CHECK-LABEL: firrtl.module @issue432
-firrtl.module @issue432(%tmp8: !firrtl.flip<uint<10>>) {
+firrtl.module @issue432(out %tmp8: !firrtl.uint<10>) {
   %c130_si10 = firrtl.constant(130 : si10) : !firrtl.sint<10>
   %0 = firrtl.tail %c130_si10, 0 : (!firrtl.sint<10>) -> !firrtl.uint<10>
-  firrtl.connect %tmp8, %0 : !firrtl.flip<uint<10>>, !firrtl.uint<10>
+  firrtl.connect %tmp8, %0 : !firrtl.uint<10>, !firrtl.uint<10>
   // CHECK-NEXT: %c130_ui10 = firrtl.constant(130 : i10) : !firrtl.uint<10>
   // CHECK-NEXT: firrtl.connect %tmp8, %c130_ui10
 }
 
 // CHECK-LABEL: firrtl.module @issue437
-firrtl.module @issue437(%tmp19: !firrtl.flip<uint<1>>) {
+firrtl.module @issue437(out %tmp19: !firrtl.uint<1>) {
   // CHECK-NEXT: %c1_ui1 = firrtl.constant(true) : !firrtl.uint<1>
   %c-1_si1 = firrtl.constant(-1 : si1) : !firrtl.sint<1>
   %0 = firrtl.bits %c-1_si1 0 to 0 : (!firrtl.sint<1>) -> !firrtl.uint<1>
-  firrtl.connect %tmp19, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %tmp19, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
 // CHECK-LABEL: firrtl.module @issue446
 // CHECK-NEXT: firrtl.xor %inp_1, %inp_1
-firrtl.module @issue446(%inp_1: !firrtl.sint<0>, %tmp10: !firrtl.flip<uint<1>>) {
+firrtl.module @issue446(in %inp_1: !firrtl.sint<0>, out %tmp10: !firrtl.uint<1>) {
   %0 = firrtl.xor %inp_1, %inp_1 : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.uint<0>
-  firrtl.connect %tmp10, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<0>
+  firrtl.connect %tmp10, %0 : !firrtl.uint<1>, !firrtl.uint<0>
 }
 
 // CHECK-LABEL: firrtl.module @xorUnsized
 // CHECK-NEXT: %c0_ui = firrtl.constant(false) : !firrtl.uint
-firrtl.module @xorUnsized(%inp_1: !firrtl.sint, %tmp10: !firrtl.flip<uint>) {
+firrtl.module @xorUnsized(in %inp_1: !firrtl.sint, out %tmp10: !firrtl.uint) {
   %0 = firrtl.xor %inp_1, %inp_1 : (!firrtl.sint, !firrtl.sint) -> !firrtl.uint
-  firrtl.connect %tmp10, %0 : !firrtl.flip<uint>, !firrtl.uint
+  firrtl.connect %tmp10, %0 : !firrtl.uint, !firrtl.uint
 }
 
 // https://github.com/llvm/circt/issues/516
 // CHECK-LABEL: @issue516
 // CHECK-NEXT: firrtl.div
-firrtl.module @issue516(%inp_0: !firrtl.uint<0>, %tmp3: !firrtl.flip<uint<0>>) {
+firrtl.module @issue516(in %inp_0: !firrtl.uint<0>, out %tmp3: !firrtl.uint<0>) {
   %0 = firrtl.div %inp_0, %inp_0 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
-  firrtl.connect %tmp3, %0 : !firrtl.flip<uint<0>>, !firrtl.uint<0>
+  firrtl.connect %tmp3, %0 : !firrtl.uint<0>, !firrtl.uint<0>
 }
 
 // https://github.com/llvm/circt/issues/591
 // CHECK-LABEL: @reg_cst_prop1
 // CHECK-NEXT:   %c5_ui8 = firrtl.constant(5 : ui8) : !firrtl.uint<8>
-// CHECK-NEXT:   firrtl.connect %out_b, %c5_ui8 : !firrtl.flip<uint<8>>, !firrtl.uint<8>
+// CHECK-NEXT:   firrtl.connect %out_b, %c5_ui8 : !firrtl.uint<8>, !firrtl.uint<8>
 // CHECK-NEXT:  }
-firrtl.module @reg_cst_prop1(%clock: !firrtl.clock, %out_b: !firrtl.flip<uint<8>>) {
+firrtl.module @reg_cst_prop1(in %clock: !firrtl.clock, out %out_b: !firrtl.uint<8>) {
   %c5_ui8 = firrtl.constant(5 : ui8) : !firrtl.uint<8>
   %tmp_a = firrtl.reg %clock {name = "tmp_a"} : (!firrtl.clock) -> !firrtl.uint<8>
   %tmp_b = firrtl.reg %clock {name = "tmp_b"} : (!firrtl.clock) -> !firrtl.uint<8>
   firrtl.connect %tmp_a, %c5_ui8 : !firrtl.uint<8>, !firrtl.uint<8>
   firrtl.connect %tmp_b, %tmp_a : !firrtl.uint<8>, !firrtl.uint<8>
-  firrtl.connect %out_b, %tmp_b : !firrtl.flip<uint<8>>, !firrtl.uint<8>
+  firrtl.connect %out_b, %tmp_b : !firrtl.uint<8>, !firrtl.uint<8>
 }
 
 // CHECK-LABEL: @reg_cst_prop2
 // CHECK-NEXT:   %c5_ui8 = firrtl.constant(5 : ui8) : !firrtl.uint<8>
-// CHECK-NEXT:   firrtl.connect %out_b, %c5_ui8 : !firrtl.flip<uint<8>>, !firrtl.uint<8>
+// CHECK-NEXT:   firrtl.connect %out_b, %c5_ui8 : !firrtl.uint<8>, !firrtl.uint<8>
 // CHECK-NEXT:  }
-firrtl.module @reg_cst_prop2(%clock: !firrtl.clock, %out_b: !firrtl.flip<uint<8>>) {
+firrtl.module @reg_cst_prop2(in %clock: !firrtl.clock, out %out_b: !firrtl.uint<8>) {
   %tmp_b = firrtl.reg %clock {name = "tmp_b"} : (!firrtl.clock) -> !firrtl.uint<8>
-  firrtl.connect %out_b, %tmp_b : !firrtl.flip<uint<8>>, !firrtl.uint<8>
+  firrtl.connect %out_b, %tmp_b : !firrtl.uint<8>, !firrtl.uint<8>
 
   %tmp_a = firrtl.reg %clock {name = "tmp_a"} : (!firrtl.clock) -> !firrtl.uint<8>
   %c5_ui8 = firrtl.constant(5 : ui8) : !firrtl.uint<8>
@@ -445,30 +445,30 @@ firrtl.module @reg_cst_prop2(%clock: !firrtl.clock, %out_b: !firrtl.flip<uint<8>
 
 // CHECK-LABEL: @reg_cst_prop3
 // CHECK-NEXT:   %c0_ui8 = firrtl.constant(0 : i8) : !firrtl.uint<8>
-// CHECK-NEXT:   firrtl.connect %out_b, %c0_ui8 : !firrtl.flip<uint<8>>, !firrtl.uint<8>
+// CHECK-NEXT:   firrtl.connect %out_b, %c0_ui8 : !firrtl.uint<8>, !firrtl.uint<8>
 // CHECK-NEXT:  }
-firrtl.module @reg_cst_prop3(%clock: !firrtl.clock, %out_b: !firrtl.flip<uint<8>>) {
+firrtl.module @reg_cst_prop3(in %clock: !firrtl.clock, out %out_b: !firrtl.uint<8>) {
   %tmp_a = firrtl.reg %clock {name = "tmp_a"} : (!firrtl.clock) -> !firrtl.uint<8>
   %c5_ui8 = firrtl.constant(5 : ui8) : !firrtl.uint<8>
   firrtl.connect %tmp_a, %c5_ui8 : !firrtl.uint<8>, !firrtl.uint<8>
 
   %xor = firrtl.xor %tmp_a, %c5_ui8 : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
-  firrtl.connect %out_b, %xor : !firrtl.flip<uint<8>>, !firrtl.uint<8>
+  firrtl.connect %out_b, %xor : !firrtl.uint<8>, !firrtl.uint<8>
 }
 
 // CHECK-LABEL: @pcon
 // CHECK-NEXT:   %0 = firrtl.bits %in 4 to 0 : (!firrtl.uint<9>) -> !firrtl.uint<5>
-// CHECK-NEXT:   firrtl.connect %out, %0 : !firrtl.flip<uint<5>>, !firrtl.uint<5>
+// CHECK-NEXT:   firrtl.connect %out, %0 : !firrtl.uint<5>, !firrtl.uint<5>
 // CHECK-NEXT:  }
-firrtl.module @pcon(%in: !firrtl.uint<9>, %out: !firrtl.flip<uint<5>>) {
-  firrtl.partialconnect %out, %in : !firrtl.flip<uint<5>>, !firrtl.uint<9>
+firrtl.module @pcon(in %in: !firrtl.uint<9>, out %out: !firrtl.uint<5>) {
+  firrtl.partialconnect %out, %in : !firrtl.uint<5>, !firrtl.uint<9>
 }
 
 // https://github.com/llvm/circt/issues/788
 
 // CHECK-LABEL: @AttachMerge
-firrtl.module @AttachMerge(%a: !firrtl.analog<1>, %b: !firrtl.analog<1>,
-                           %c: !firrtl.analog<1>) {
+firrtl.module @AttachMerge(in %a: !firrtl.analog<1>, in %b: !firrtl.analog<1>,
+                           in %c: !firrtl.analog<1>) {
   // CHECK-NEXT: firrtl.attach %c, %b, %a :
   // CHECK-NEXT: }
   firrtl.attach %b, %a : !firrtl.analog<1>, !firrtl.analog<1>
@@ -476,7 +476,7 @@ firrtl.module @AttachMerge(%a: !firrtl.analog<1>, %b: !firrtl.analog<1>,
 }
 
 // CHECK-LABEL: @AttachDeadWire
-firrtl.module @AttachDeadWire(%a: !firrtl.analog<1>, %b: !firrtl.analog<1>) {
+firrtl.module @AttachDeadWire(in %a: !firrtl.analog<1>, in %b: !firrtl.analog<1>) {
   // CHECK-NEXT: firrtl.attach %a, %b :
   // CHECK-NEXT: }
   %c = firrtl.wire  : !firrtl.analog<1>
@@ -484,7 +484,7 @@ firrtl.module @AttachDeadWire(%a: !firrtl.analog<1>, %b: !firrtl.analog<1>) {
 }
 
 // CHECK-LABEL: @AttachOpts
-firrtl.module @AttachOpts(%a: !firrtl.analog<1>) {
+firrtl.module @AttachOpts(in %a: !firrtl.analog<1>) {
   // CHECK-NEXT: }
   %b = firrtl.wire  : !firrtl.analog<1>
   firrtl.attach %b, %a : !firrtl.analog<1>, !firrtl.analog<1>
@@ -492,111 +492,111 @@ firrtl.module @AttachOpts(%a: !firrtl.analog<1>) {
 
 // CHECK-LABEL: @wire_cst_prop1
 // CHECK-NEXT:   %c10_ui9 = firrtl.constant(10 : i9) : !firrtl.uint<9>
-// CHECK-NEXT:   firrtl.connect %out_b, %c10_ui9 : !firrtl.flip<uint<9>>, !firrtl.uint<9>
+// CHECK-NEXT:   firrtl.connect %out_b, %c10_ui9 : !firrtl.uint<9>, !firrtl.uint<9>
 // CHECK-NEXT:  }
-firrtl.module @wire_cst_prop1(%out_b: !firrtl.flip<uint<9>>) {
+firrtl.module @wire_cst_prop1(out %out_b: !firrtl.uint<9>) {
   %tmp_a = firrtl.wire : !firrtl.uint<8>
   %c5_ui8 = firrtl.constant(5 : ui8) : !firrtl.uint<8>
   firrtl.connect %tmp_a, %c5_ui8 : !firrtl.uint<8>, !firrtl.uint<8>
 
   %xor = firrtl.add %tmp_a, %c5_ui8 : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<9>
-  firrtl.connect %out_b, %xor : !firrtl.flip<uint<9>>, !firrtl.uint<9>
+  firrtl.connect %out_b, %xor : !firrtl.uint<9>, !firrtl.uint<9>
 }
 
 // CHECK-LABEL: @wire_port_prop1
-// CHECK-NEXT:   firrtl.connect %out_b, %in_a : !firrtl.flip<uint<9>>, !firrtl.uint<9>
+// CHECK-NEXT:   firrtl.connect %out_b, %in_a : !firrtl.uint<9>, !firrtl.uint<9>
 // CHECK-NEXT:  }
-firrtl.module @wire_port_prop1(%in_a: !firrtl.uint<9>, %out_b: !firrtl.flip<uint<9>>) {
+firrtl.module @wire_port_prop1(in %in_a: !firrtl.uint<9>, out %out_b: !firrtl.uint<9>) {
   %tmp = firrtl.wire : !firrtl.uint<9>
   firrtl.connect %tmp, %in_a : !firrtl.uint<9>, !firrtl.uint<9>
 
-  firrtl.connect %out_b, %tmp : !firrtl.flip<uint<9>>, !firrtl.uint<9>
+  firrtl.connect %out_b, %tmp : !firrtl.uint<9>, !firrtl.uint<9>
 }
 
 // CHECK-LABEL: @LEQWithConstLHS
 // CHECK-NEXT: %c42_ui = firrtl.constant
 // CHECK-NEXT: %0 = firrtl.geq %a, %c42_ui
-firrtl.module @LEQWithConstLHS(%a: !firrtl.uint, %b: !firrtl.flip<uint<1>>) {
+firrtl.module @LEQWithConstLHS(in %a: !firrtl.uint, out %b: !firrtl.uint<1>) {
   %0 = firrtl.constant(42) : !firrtl.uint
   %1 = firrtl.leq %0, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
-  firrtl.connect %b, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %b, %1 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
 // CHECK-LABEL: @LTWithConstLHS
 // CHECK-NEXT: %c42_ui = firrtl.constant
 // CHECK-NEXT: %0 = firrtl.gt %a, %c42_ui
-firrtl.module @LTWithConstLHS(%a: !firrtl.uint, %b: !firrtl.flip<uint<1>>) {
+firrtl.module @LTWithConstLHS(in %a: !firrtl.uint, out %b: !firrtl.uint<1>) {
   %0 = firrtl.constant(42) : !firrtl.uint
   %1 = firrtl.lt %0, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
-  firrtl.connect %b, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %b, %1 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
 // CHECK-LABEL: @GEQWithConstLHS
 // CHECK-NEXT: %c42_ui = firrtl.constant
 // CHECK-NEXT: %0 = firrtl.leq %a, %c42_ui
-firrtl.module @GEQWithConstLHS(%a: !firrtl.uint, %b: !firrtl.flip<uint<1>>) {
+firrtl.module @GEQWithConstLHS(in %a: !firrtl.uint, out %b: !firrtl.uint<1>) {
   %0 = firrtl.constant(42) : !firrtl.uint
   %1 = firrtl.geq %0, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
-  firrtl.connect %b, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %b, %1 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
 // CHECK-LABEL: @GTWithConstLHS
 // CHECK-NEXT: %c42_ui = firrtl.constant
 // CHECK-NEXT: %0 = firrtl.lt %a, %c42_ui
-firrtl.module @GTWithConstLHS(%a: !firrtl.uint, %b: !firrtl.flip<uint<1>>) {
+firrtl.module @GTWithConstLHS(in %a: !firrtl.uint, out %b: !firrtl.uint<1>) {
   %0 = firrtl.constant(42) : !firrtl.uint
   %1 = firrtl.gt %0, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
-  firrtl.connect %b, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %b, %1 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
 // CHECK-LABEL: @CompareWithSelf
 firrtl.module @CompareWithSelf(
-  %a: !firrtl.uint,
-  %y0: !firrtl.flip<uint<1>>,
-  %y1: !firrtl.flip<uint<1>>,
-  %y2: !firrtl.flip<uint<1>>,
-  %y3: !firrtl.flip<uint<1>>,
-  %y4: !firrtl.flip<uint<1>>,
-  %y5: !firrtl.flip<uint<1>>
+  in %a: !firrtl.uint,
+  out %y0: !firrtl.uint<1>,
+  out %y1: !firrtl.uint<1>,
+  out %y2: !firrtl.uint<1>,
+  out %y3: !firrtl.uint<1>,
+  out %y4: !firrtl.uint<1>,
+  out %y5: !firrtl.uint<1>
 ) {
   // CHECK-NEXT: [[_:.+]] = firrtl.constant
   // CHECK-NEXT: [[_:.+]] = firrtl.constant
 
   %0 = firrtl.leq %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
-  firrtl.connect %y0, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %y0, %c1_ui1
 
   %1 = firrtl.lt %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
-  firrtl.connect %y1, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %y1, %c0_ui1
 
   %2 = firrtl.geq %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
-  firrtl.connect %y2, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y2, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %y2, %c1_ui1
 
   %3 = firrtl.gt %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
-  firrtl.connect %y3, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %y3, %c0_ui1
 
   %4 = firrtl.eq %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
-  firrtl.connect %y4, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y4, %4 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %y4, %c1_ui1
 
   %5 = firrtl.neq %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
-  firrtl.connect %y5, %5 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y5, %5 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %y5, %c0_ui1
 }
 
 // CHECK-LABEL: @LEQOutsideBounds
 firrtl.module @LEQOutsideBounds(
-  %a: !firrtl.uint<3>,
-  %b: !firrtl.sint<3>,
-  %y0: !firrtl.flip<uint<1>>,
-  %y1: !firrtl.flip<uint<1>>,
-  %y2: !firrtl.flip<uint<1>>,
-  %y3: !firrtl.flip<uint<1>>,
-  %y4: !firrtl.flip<uint<1>>,
-  %y5: !firrtl.flip<uint<1>>
+  in %a: !firrtl.uint<3>,
+  in %b: !firrtl.sint<3>,
+  out %y0: !firrtl.uint<1>,
+  out %y1: !firrtl.uint<1>,
+  out %y2: !firrtl.uint<1>,
+  out %y3: !firrtl.uint<1>,
+  out %y4: !firrtl.uint<1>,
+  out %y5: !firrtl.uint<1>
 ) {
   // CHECK-NEXT: [[_:.+]] = firrtl.constant
   // CHECK-NEXT: [[_:.+]] = firrtl.constant
@@ -611,8 +611,8 @@ firrtl.module @LEQOutsideBounds(
   // a <= 8 -> 1
   %0 = firrtl.leq %a, %c7_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
   %1 = firrtl.leq %a, %c8_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
-  firrtl.connect %y0, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y1, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %y0, %c1_ui1
   // CHECK-NEXT: firrtl.connect %y1, %c1_ui1
 
@@ -620,8 +620,8 @@ firrtl.module @LEQOutsideBounds(
   // b <= 4 -> 1
   %2 = firrtl.leq %b, %c3_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
   %3 = firrtl.leq %b, %c4_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
-  firrtl.connect %y2, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y3, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y2, %2 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %y2, %c1_ui1
   // CHECK-NEXT: firrtl.connect %y3, %c1_ui1
 
@@ -629,22 +629,22 @@ firrtl.module @LEQOutsideBounds(
   // b <= -6 -> 0
   %4 = firrtl.leq %b, %cm5_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
   %5 = firrtl.leq %b, %cm6_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
-  firrtl.connect %y4, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y5, %5 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y4, %4 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y5, %5 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %y4, %c0_ui1
   // CHECK-NEXT: firrtl.connect %y5, %c0_ui1
 }
 
 // CHECK-LABEL: @LTOutsideBounds
 firrtl.module @LTOutsideBounds(
-  %a: !firrtl.uint<3>,
-  %b: !firrtl.sint<3>,
-  %y0: !firrtl.flip<uint<1>>,
-  %y1: !firrtl.flip<uint<1>>,
-  %y2: !firrtl.flip<uint<1>>,
-  %y3: !firrtl.flip<uint<1>>,
-  %y4: !firrtl.flip<uint<1>>,
-  %y5: !firrtl.flip<uint<1>>
+  in %a: !firrtl.uint<3>,
+  in %b: !firrtl.sint<3>,
+  out %y0: !firrtl.uint<1>,
+  out %y1: !firrtl.uint<1>,
+  out %y2: !firrtl.uint<1>,
+  out %y3: !firrtl.uint<1>,
+  out %y4: !firrtl.uint<1>,
+  out %y5: !firrtl.uint<1>
 ) {
   // CHECK-NEXT: [[_:.+]] = firrtl.constant
   // CHECK-NEXT: [[_:.+]] = firrtl.constant
@@ -659,8 +659,8 @@ firrtl.module @LTOutsideBounds(
   // a < 9 -> 1
   %0 = firrtl.lt %a, %c8_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
   %1 = firrtl.lt %a, %c9_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
-  firrtl.connect %y0, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y1, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %y0, %c1_ui1
   // CHECK-NEXT: firrtl.connect %y1, %c1_ui1
 
@@ -668,8 +668,8 @@ firrtl.module @LTOutsideBounds(
   // b < 5 -> 1
   %2 = firrtl.lt %b, %c4_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
   %3 = firrtl.lt %b, %c5_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
-  firrtl.connect %y2, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y3, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y2, %2 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %y2, %c1_ui1
   // CHECK-NEXT: firrtl.connect %y3, %c1_ui1
 
@@ -677,22 +677,22 @@ firrtl.module @LTOutsideBounds(
   // b < -5 -> 0
   %4 = firrtl.lt %b, %cm4_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
   %5 = firrtl.lt %b, %cm5_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
-  firrtl.connect %y4, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y5, %5 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y4, %4 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y5, %5 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %y4, %c0_ui1
   // CHECK-NEXT: firrtl.connect %y5, %c0_ui1
 }
 
 // CHECK-LABEL: @GEQOutsideBounds
 firrtl.module @GEQOutsideBounds(
-  %a: !firrtl.uint<3>,
-  %b: !firrtl.sint<3>,
-  %y0: !firrtl.flip<uint<1>>,
-  %y1: !firrtl.flip<uint<1>>,
-  %y2: !firrtl.flip<uint<1>>,
-  %y3: !firrtl.flip<uint<1>>,
-  %y4: !firrtl.flip<uint<1>>,
-  %y5: !firrtl.flip<uint<1>>
+  in %a: !firrtl.uint<3>,
+  in %b: !firrtl.sint<3>,
+  out %y0: !firrtl.uint<1>,
+  out %y1: !firrtl.uint<1>,
+  out %y2: !firrtl.uint<1>,
+  out %y3: !firrtl.uint<1>,
+  out %y4: !firrtl.uint<1>,
+  out %y5: !firrtl.uint<1>
 ) {
   // CHECK-NEXT: [[_:.+]] = firrtl.constant
   // CHECK-NEXT: [[_:.+]] = firrtl.constant
@@ -707,8 +707,8 @@ firrtl.module @GEQOutsideBounds(
   // a >= 9 -> 0
   %0 = firrtl.geq %a, %c8_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
   %1 = firrtl.geq %a, %c9_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
-  firrtl.connect %y0, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y1, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %y0, %c0_ui1
   // CHECK-NEXT: firrtl.connect %y1, %c0_ui1
 
@@ -716,8 +716,8 @@ firrtl.module @GEQOutsideBounds(
   // b >= 5 -> 0
   %2 = firrtl.geq %b, %c4_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
   %3 = firrtl.geq %b, %c5_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
-  firrtl.connect %y2, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y3, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y2, %2 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %y2, %c0_ui1
   // CHECK-NEXT: firrtl.connect %y3, %c0_ui1
 
@@ -725,22 +725,22 @@ firrtl.module @GEQOutsideBounds(
   // b >= -5 -> 1
   %4 = firrtl.geq %b, %cm4_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
   %5 = firrtl.geq %b, %cm5_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
-  firrtl.connect %y4, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y5, %5 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y4, %4 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y5, %5 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %y4, %c1_ui1
   // CHECK-NEXT: firrtl.connect %y5, %c1_ui1
 }
 
 // CHECK-LABEL: @GTOutsideBounds
 firrtl.module @GTOutsideBounds(
-  %a: !firrtl.uint<3>,
-  %b: !firrtl.sint<3>,
-  %y0: !firrtl.flip<uint<1>>,
-  %y1: !firrtl.flip<uint<1>>,
-  %y2: !firrtl.flip<uint<1>>,
-  %y3: !firrtl.flip<uint<1>>,
-  %y4: !firrtl.flip<uint<1>>,
-  %y5: !firrtl.flip<uint<1>>
+  in %a: !firrtl.uint<3>,
+  in %b: !firrtl.sint<3>,
+  out %y0: !firrtl.uint<1>,
+  out %y1: !firrtl.uint<1>,
+  out %y2: !firrtl.uint<1>,
+  out %y3: !firrtl.uint<1>,
+  out %y4: !firrtl.uint<1>,
+  out %y5: !firrtl.uint<1>
 ) {
   // CHECK-NEXT: [[_:.+]] = firrtl.constant
   // CHECK-NEXT: [[_:.+]] = firrtl.constant
@@ -755,8 +755,8 @@ firrtl.module @GTOutsideBounds(
   // a > 8 -> 0
   %0 = firrtl.gt %a, %c7_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
   %1 = firrtl.gt %a, %c8_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
-  firrtl.connect %y0, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y1, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %y0, %c0_ui1
   // CHECK-NEXT: firrtl.connect %y1, %c0_ui1
 
@@ -764,8 +764,8 @@ firrtl.module @GTOutsideBounds(
   // b > 4 -> 0
   %2 = firrtl.gt %b, %c3_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
   %3 = firrtl.gt %b, %c4_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
-  firrtl.connect %y2, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y3, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y2, %2 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %y2, %c0_ui1
   // CHECK-NEXT: firrtl.connect %y3, %c0_ui1
 
@@ -773,26 +773,26 @@ firrtl.module @GTOutsideBounds(
   // b > -6 -> 1
   %4 = firrtl.gt %b, %cm5_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
   %5 = firrtl.gt %b, %cm6_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
-  firrtl.connect %y4, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y5, %5 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y4, %4 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y5, %5 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %y4, %c1_ui1
   // CHECK-NEXT: firrtl.connect %y5, %c1_ui1
 }
 
 // CHECK-LABEL: @ComparisonOfDifferentWidths
 firrtl.module @ComparisonOfDifferentWidths(
-  %y0: !firrtl.flip<uint<1>>,
-  %y1: !firrtl.flip<uint<1>>,
-  %y2: !firrtl.flip<uint<1>>,
-  %y3: !firrtl.flip<uint<1>>,
-  %y4: !firrtl.flip<uint<1>>,
-  %y5: !firrtl.flip<uint<1>>,
-  %y6: !firrtl.flip<uint<1>>,
-  %y7: !firrtl.flip<uint<1>>,
-  %y8: !firrtl.flip<uint<1>>,
-  %y9: !firrtl.flip<uint<1>>,
-  %y10: !firrtl.flip<uint<1>>,
-  %y11: !firrtl.flip<uint<1>>
+  out %y0: !firrtl.uint<1>,
+  out %y1: !firrtl.uint<1>,
+  out %y2: !firrtl.uint<1>,
+  out %y3: !firrtl.uint<1>,
+  out %y4: !firrtl.uint<1>,
+  out %y5: !firrtl.uint<1>,
+  out %y6: !firrtl.uint<1>,
+  out %y7: !firrtl.uint<1>,
+  out %y8: !firrtl.uint<1>,
+  out %y9: !firrtl.uint<1>,
+  out %y10: !firrtl.uint<1>,
+  out %y11: !firrtl.uint<1>
 ) {
   // CHECK-NEXT: [[_:.+]] = firrtl.constant
   // CHECK-NEXT: [[_:.+]] = firrtl.constant
@@ -814,18 +814,18 @@ firrtl.module @ComparisonOfDifferentWidths(
   %10 = firrtl.neq %c3_ui2, %c4_ui3 : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<1>
   %11 = firrtl.neq %c3_si3, %c4_si4 : (!firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.uint<1>
 
-  firrtl.connect %y0, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y1, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y2, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y3, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y4, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y5, %5 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y6, %6 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y7, %7 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y8, %8 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y9, %9 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y10, %10 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y11, %11 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y2, %2 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y4, %4 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y5, %5 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y6, %6 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y7, %7 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y8, %8 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y9, %9 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y10, %10 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y11, %11 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %y0, %c1_ui1
   // CHECK-NEXT: firrtl.connect %y1, %c1_ui1
   // CHECK-NEXT: firrtl.connect %y2, %c1_ui1
@@ -842,18 +842,18 @@ firrtl.module @ComparisonOfDifferentWidths(
 
 // CHECK-LABEL: @ComparisonOfUnsizedAndSized
 firrtl.module @ComparisonOfUnsizedAndSized(
-  %y0: !firrtl.flip<uint<1>>,
-  %y1: !firrtl.flip<uint<1>>,
-  %y2: !firrtl.flip<uint<1>>,
-  %y3: !firrtl.flip<uint<1>>,
-  %y4: !firrtl.flip<uint<1>>,
-  %y5: !firrtl.flip<uint<1>>,
-  %y6: !firrtl.flip<uint<1>>,
-  %y7: !firrtl.flip<uint<1>>,
-  %y8: !firrtl.flip<uint<1>>,
-  %y9: !firrtl.flip<uint<1>>,
-  %y10: !firrtl.flip<uint<1>>,
-  %y11: !firrtl.flip<uint<1>>
+  out %y0: !firrtl.uint<1>,
+  out %y1: !firrtl.uint<1>,
+  out %y2: !firrtl.uint<1>,
+  out %y3: !firrtl.uint<1>,
+  out %y4: !firrtl.uint<1>,
+  out %y5: !firrtl.uint<1>,
+  out %y6: !firrtl.uint<1>,
+  out %y7: !firrtl.uint<1>,
+  out %y8: !firrtl.uint<1>,
+  out %y9: !firrtl.uint<1>,
+  out %y10: !firrtl.uint<1>,
+  out %y11: !firrtl.uint<1>
 ) {
   // CHECK-NEXT: [[_:.+]] = firrtl.constant
   // CHECK-NEXT: [[_:.+]] = firrtl.constant
@@ -875,18 +875,18 @@ firrtl.module @ComparisonOfUnsizedAndSized(
   %10 = firrtl.neq %c3_ui, %c4_ui3 : (!firrtl.uint, !firrtl.uint<3>) -> !firrtl.uint<1>
   %11 = firrtl.neq %c3_si, %c4_si4 : (!firrtl.sint, !firrtl.sint<4>) -> !firrtl.uint<1>
 
-  firrtl.connect %y0, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y1, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y2, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y3, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y4, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y5, %5 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y6, %6 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y7, %7 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y8, %8 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y9, %9 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y10, %10 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y11, %11 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y2, %2 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y4, %4 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y5, %5 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y6, %6 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y7, %7 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y8, %8 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y9, %9 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y10, %10 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y11, %11 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %y0, %c1_ui1
   // CHECK-NEXT: firrtl.connect %y1, %c1_ui1
   // CHECK-NEXT: firrtl.connect %y2, %c1_ui1
@@ -903,18 +903,18 @@ firrtl.module @ComparisonOfUnsizedAndSized(
 
 // CHECK-LABEL: @ComparisonOfUnsized
 firrtl.module @ComparisonOfUnsized(
-  %y0: !firrtl.flip<uint<1>>,
-  %y1: !firrtl.flip<uint<1>>,
-  %y2: !firrtl.flip<uint<1>>,
-  %y3: !firrtl.flip<uint<1>>,
-  %y4: !firrtl.flip<uint<1>>,
-  %y5: !firrtl.flip<uint<1>>,
-  %y6: !firrtl.flip<uint<1>>,
-  %y7: !firrtl.flip<uint<1>>,
-  %y8: !firrtl.flip<uint<1>>,
-  %y9: !firrtl.flip<uint<1>>,
-  %y10: !firrtl.flip<uint<1>>,
-  %y11: !firrtl.flip<uint<1>>
+  out %y0: !firrtl.uint<1>,
+  out %y1: !firrtl.uint<1>,
+  out %y2: !firrtl.uint<1>,
+  out %y3: !firrtl.uint<1>,
+  out %y4: !firrtl.uint<1>,
+  out %y5: !firrtl.uint<1>,
+  out %y6: !firrtl.uint<1>,
+  out %y7: !firrtl.uint<1>,
+  out %y8: !firrtl.uint<1>,
+  out %y9: !firrtl.uint<1>,
+  out %y10: !firrtl.uint<1>,
+  out %y11: !firrtl.uint<1>
 ) {
   // CHECK-NEXT: [[_:.+]] = firrtl.constant
   // CHECK-NEXT: [[_:.+]] = firrtl.constant
@@ -936,18 +936,18 @@ firrtl.module @ComparisonOfUnsized(
   %10 = firrtl.neq %c0_ui, %c4_ui : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
   %11 = firrtl.neq %c0_si, %c4_si : (!firrtl.sint, !firrtl.sint) -> !firrtl.uint<1>
 
-  firrtl.connect %y0, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y1, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y2, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y3, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y4, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y5, %5 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y6, %6 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y7, %7 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y8, %8 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y9, %9 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y10, %10 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y11, %11 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y2, %2 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y4, %4 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y5, %5 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y6, %6 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y7, %7 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y8, %8 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y9, %9 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y10, %10 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y11, %11 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %y0, %c1_ui1
   // CHECK-NEXT: firrtl.connect %y1, %c1_ui1
   // CHECK-NEXT: firrtl.connect %y2, %c1_ui1
@@ -964,32 +964,32 @@ firrtl.module @ComparisonOfUnsized(
 
 // CHECK-LABEL: @ComparisonOfZeroAndNonzeroWidths
 firrtl.module @ComparisonOfZeroAndNonzeroWidths(
-  %xu: !firrtl.uint<0>,
-  %xs: !firrtl.sint<0>,
-  %y0: !firrtl.flip<uint<1>>,
-  %y1: !firrtl.flip<uint<1>>,
-  %y2: !firrtl.flip<uint<1>>,
-  %y3: !firrtl.flip<uint<1>>,
-  %y4: !firrtl.flip<uint<1>>,
-  %y5: !firrtl.flip<uint<1>>,
-  %y6: !firrtl.flip<uint<1>>,
-  %y7: !firrtl.flip<uint<1>>,
-  %y8: !firrtl.flip<uint<1>>,
-  %y9: !firrtl.flip<uint<1>>,
-  %y10: !firrtl.flip<uint<1>>,
-  %y11: !firrtl.flip<uint<1>>,
-  %y12: !firrtl.flip<uint<1>>,
-  %y13: !firrtl.flip<uint<1>>,
-  %y14: !firrtl.flip<uint<1>>,
-  %y15: !firrtl.flip<uint<1>>,
-  %y16: !firrtl.flip<uint<1>>,
-  %y17: !firrtl.flip<uint<1>>,
-  %y18: !firrtl.flip<uint<1>>,
-  %y19: !firrtl.flip<uint<1>>,
-  %y20: !firrtl.flip<uint<1>>,
-  %y21: !firrtl.flip<uint<1>>,
-  %y22: !firrtl.flip<uint<1>>,
-  %y23: !firrtl.flip<uint<1>>
+  in %xu: !firrtl.uint<0>,
+  in %xs: !firrtl.sint<0>,
+  out %y0: !firrtl.uint<1>,
+  out %y1: !firrtl.uint<1>,
+  out %y2: !firrtl.uint<1>,
+  out %y3: !firrtl.uint<1>,
+  out %y4: !firrtl.uint<1>,
+  out %y5: !firrtl.uint<1>,
+  out %y6: !firrtl.uint<1>,
+  out %y7: !firrtl.uint<1>,
+  out %y8: !firrtl.uint<1>,
+  out %y9: !firrtl.uint<1>,
+  out %y10: !firrtl.uint<1>,
+  out %y11: !firrtl.uint<1>,
+  out %y12: !firrtl.uint<1>,
+  out %y13: !firrtl.uint<1>,
+  out %y14: !firrtl.uint<1>,
+  out %y15: !firrtl.uint<1>,
+  out %y16: !firrtl.uint<1>,
+  out %y17: !firrtl.uint<1>,
+  out %y18: !firrtl.uint<1>,
+  out %y19: !firrtl.uint<1>,
+  out %y20: !firrtl.uint<1>,
+  out %y21: !firrtl.uint<1>,
+  out %y22: !firrtl.uint<1>,
+  out %y23: !firrtl.uint<1>
 ) {
   // CHECK-NEXT: [[_:.+]] = firrtl.constant
   // CHECK-NEXT: [[_:.+]] = firrtl.constant
@@ -1023,30 +1023,30 @@ firrtl.module @ComparisonOfZeroAndNonzeroWidths(
   %22 = firrtl.neq %xs, %c0_si4 : (!firrtl.sint<0>, !firrtl.sint<4>) -> !firrtl.uint<1>
   %23 = firrtl.neq %xs, %c4_si4 : (!firrtl.sint<0>, !firrtl.sint<4>) -> !firrtl.uint<1>
 
-  firrtl.connect %y0, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y1, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y2, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y3, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y4, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y5, %5 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y6, %6 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y7, %7 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y8, %8 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y9, %9 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y10, %10 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y11, %11 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y12, %12 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y13, %13 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y14, %14 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y15, %15 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y16, %16 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y17, %17 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y18, %18 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y19, %19 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y20, %20 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y21, %21 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y22, %22 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y23, %23 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y2, %2 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y4, %4 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y5, %5 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y6, %6 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y7, %7 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y8, %8 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y9, %9 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y10, %10 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y11, %11 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y12, %12 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y13, %13 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y14, %14 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y15, %15 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y16, %16 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y17, %17 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y18, %18 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y19, %19 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y20, %20 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y21, %21 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y22, %22 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y23, %23 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %y0, %c1_ui1
   // CHECK-NEXT: firrtl.connect %y1, %c1_ui1
   // CHECK-NEXT: firrtl.connect %y2, %c1_ui1
@@ -1075,34 +1075,34 @@ firrtl.module @ComparisonOfZeroAndNonzeroWidths(
 
 // CHECK-LABEL: @ComparisonOfZeroWidths
 firrtl.module @ComparisonOfZeroWidths(
-  %xu0: !firrtl.uint<0>,
-  %xu1: !firrtl.uint<0>,
-  %xs0: !firrtl.sint<0>,
-  %xs1: !firrtl.sint<0>,
-  %y0: !firrtl.flip<uint<1>>,
-  %y1: !firrtl.flip<uint<1>>,
-  %y2: !firrtl.flip<uint<1>>,
-  %y3: !firrtl.flip<uint<1>>,
-  %y4: !firrtl.flip<uint<1>>,
-  %y5: !firrtl.flip<uint<1>>,
-  %y6: !firrtl.flip<uint<1>>,
-  %y7: !firrtl.flip<uint<1>>,
-  %y8: !firrtl.flip<uint<1>>,
-  %y9: !firrtl.flip<uint<1>>,
-  %y10: !firrtl.flip<uint<1>>,
-  %y11: !firrtl.flip<uint<1>>,
-  %y12: !firrtl.flip<uint<1>>,
-  %y13: !firrtl.flip<uint<1>>,
-  %y14: !firrtl.flip<uint<1>>,
-  %y15: !firrtl.flip<uint<1>>,
-  %y16: !firrtl.flip<uint<1>>,
-  %y17: !firrtl.flip<uint<1>>,
-  %y18: !firrtl.flip<uint<1>>,
-  %y19: !firrtl.flip<uint<1>>,
-  %y20: !firrtl.flip<uint<1>>,
-  %y21: !firrtl.flip<uint<1>>,
-  %y22: !firrtl.flip<uint<1>>,
-  %y23: !firrtl.flip<uint<1>>
+  in %xu0: !firrtl.uint<0>,
+  in %xu1: !firrtl.uint<0>,
+  in %xs0: !firrtl.sint<0>,
+  in %xs1: !firrtl.sint<0>,
+  out %y0: !firrtl.uint<1>,
+  out %y1: !firrtl.uint<1>,
+  out %y2: !firrtl.uint<1>,
+  out %y3: !firrtl.uint<1>,
+  out %y4: !firrtl.uint<1>,
+  out %y5: !firrtl.uint<1>,
+  out %y6: !firrtl.uint<1>,
+  out %y7: !firrtl.uint<1>,
+  out %y8: !firrtl.uint<1>,
+  out %y9: !firrtl.uint<1>,
+  out %y10: !firrtl.uint<1>,
+  out %y11: !firrtl.uint<1>,
+  out %y12: !firrtl.uint<1>,
+  out %y13: !firrtl.uint<1>,
+  out %y14: !firrtl.uint<1>,
+  out %y15: !firrtl.uint<1>,
+  out %y16: !firrtl.uint<1>,
+  out %y17: !firrtl.uint<1>,
+  out %y18: !firrtl.uint<1>,
+  out %y19: !firrtl.uint<1>,
+  out %y20: !firrtl.uint<1>,
+  out %y21: !firrtl.uint<1>,
+  out %y22: !firrtl.uint<1>,
+  out %y23: !firrtl.uint<1>
 ) {
   // CHECK-NEXT: [[_:.+]] = firrtl.constant
   // CHECK-NEXT: [[_:.+]] = firrtl.constant
@@ -1120,18 +1120,18 @@ firrtl.module @ComparisonOfZeroWidths(
   %10 = firrtl.neq %xu0, %xu1 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
   %11 = firrtl.neq %xs0, %xs1 : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.uint<1>
 
-  firrtl.connect %y0, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y1, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y2, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y3, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y4, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y5, %5 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y6, %6 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y7, %7 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y8, %8 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y9, %9 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y10, %10 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y11, %11 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y2, %2 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y4, %4 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y5, %5 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y6, %6 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y7, %7 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y8, %8 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y9, %9 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y10, %10 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y11, %11 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %y0, %c1_ui1
   // CHECK-NEXT: firrtl.connect %y1, %c1_ui1
   // CHECK-NEXT: firrtl.connect %y2, %c0_ui1
@@ -1148,30 +1148,30 @@ firrtl.module @ComparisonOfZeroWidths(
 
 // CHECK-LABEL: @ComparisonOfConsts
 firrtl.module @ComparisonOfConsts(
-  %y0: !firrtl.flip<uint<1>>,
-  %y1: !firrtl.flip<uint<1>>,
-  %y2: !firrtl.flip<uint<1>>,
-  %y3: !firrtl.flip<uint<1>>,
-  %y4: !firrtl.flip<uint<1>>,
-  %y5: !firrtl.flip<uint<1>>,
-  %y6: !firrtl.flip<uint<1>>,
-  %y7: !firrtl.flip<uint<1>>,
-  %y8: !firrtl.flip<uint<1>>,
-  %y9: !firrtl.flip<uint<1>>,
-  %y10: !firrtl.flip<uint<1>>,
-  %y11: !firrtl.flip<uint<1>>,
-  %y12: !firrtl.flip<uint<1>>,
-  %y13: !firrtl.flip<uint<1>>,
-  %y14: !firrtl.flip<uint<1>>,
-  %y15: !firrtl.flip<uint<1>>,
-  %y16: !firrtl.flip<uint<1>>,
-  %y17: !firrtl.flip<uint<1>>,
-  %y18: !firrtl.flip<uint<1>>,
-  %y19: !firrtl.flip<uint<1>>,
-  %y20: !firrtl.flip<uint<1>>,
-  %y21: !firrtl.flip<uint<1>>,
-  %y22: !firrtl.flip<uint<1>>,
-  %y23: !firrtl.flip<uint<1>>
+  out %y0: !firrtl.uint<1>,
+  out %y1: !firrtl.uint<1>,
+  out %y2: !firrtl.uint<1>,
+  out %y3: !firrtl.uint<1>,
+  out %y4: !firrtl.uint<1>,
+  out %y5: !firrtl.uint<1>,
+  out %y6: !firrtl.uint<1>,
+  out %y7: !firrtl.uint<1>,
+  out %y8: !firrtl.uint<1>,
+  out %y9: !firrtl.uint<1>,
+  out %y10: !firrtl.uint<1>,
+  out %y11: !firrtl.uint<1>,
+  out %y12: !firrtl.uint<1>,
+  out %y13: !firrtl.uint<1>,
+  out %y14: !firrtl.uint<1>,
+  out %y15: !firrtl.uint<1>,
+  out %y16: !firrtl.uint<1>,
+  out %y17: !firrtl.uint<1>,
+  out %y18: !firrtl.uint<1>,
+  out %y19: !firrtl.uint<1>,
+  out %y20: !firrtl.uint<1>,
+  out %y21: !firrtl.uint<1>,
+  out %y22: !firrtl.uint<1>,
+  out %y23: !firrtl.uint<1>
 ) {
   %c2_si4 = firrtl.constant(2 : i4) : !firrtl.sint<4>
   %c-3_si3 = firrtl.constant(-3 : i3) : !firrtl.sint<3>
@@ -1198,22 +1198,22 @@ firrtl.module @ComparisonOfConsts(
   %14 = firrtl.gt %c2_ui4, %c5_ui3 : (!firrtl.uint<4>, !firrtl.uint<3>) -> !firrtl.uint<1>
   %15 = firrtl.gt %c5_ui3, %c2_ui4 : (!firrtl.uint<3>, !firrtl.uint<4>) -> !firrtl.uint<1>
 
-  firrtl.connect %y0, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y1, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y2, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y3, %3 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y4, %4 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y5, %5 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y6, %6 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y7, %7 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y8, %8 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y9, %9 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y10, %10 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y11, %11 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y12, %12 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y13, %13 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y14, %14 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %y15, %15 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y2, %2 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y4, %4 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y5, %5 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y6, %6 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y7, %7 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y8, %8 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y9, %9 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y10, %10 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y11, %11 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y12, %12 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y13, %13 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y14, %14 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y15, %15 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %y0, %c0_ui1
   // CHECK-NEXT: firrtl.connect %y1, %c1_ui1
   // CHECK-NEXT: firrtl.connect %y2, %c1_ui1
@@ -1234,150 +1234,150 @@ firrtl.module @ComparisonOfConsts(
 
 // CHECK-LABEL: @add_cst_prop1
 // CHECK-NEXT:   %c11_ui9 = firrtl.constant(11 : i9) : !firrtl.uint<9>
-// CHECK-NEXT:   firrtl.connect %out_b, %c11_ui9 : !firrtl.flip<uint<9>>, !firrtl.uint<9>
+// CHECK-NEXT:   firrtl.connect %out_b, %c11_ui9 : !firrtl.uint<9>, !firrtl.uint<9>
 // CHECK-NEXT:  }
-firrtl.module @add_cst_prop1(%out_b: !firrtl.flip<uint<9>>) {
+firrtl.module @add_cst_prop1(out %out_b: !firrtl.uint<9>) {
   %c6_ui7 = firrtl.constant(6 : ui7) : !firrtl.uint<7>
   %tmp_a = firrtl.wire : !firrtl.uint<7>
   %c5_ui8 = firrtl.constant(5 : ui8) : !firrtl.uint<8>
   firrtl.connect %tmp_a, %c6_ui7 : !firrtl.uint<7>, !firrtl.uint<7>
   %add = firrtl.add %tmp_a, %c5_ui8 : (!firrtl.uint<7>, !firrtl.uint<8>) -> !firrtl.uint<9>
-  firrtl.connect %out_b, %add : !firrtl.flip<uint<9>>, !firrtl.uint<9>
+  firrtl.connect %out_b, %add : !firrtl.uint<9>, !firrtl.uint<9>
 }
 
 // CHECK-LABEL: @add_cst_prop2
 // CHECK-NEXT:   %c-1_si9 = firrtl.constant(-1 : i9) : !firrtl.sint<9>
-// CHECK-NEXT:   firrtl.connect %out_b, %c-1_si9 : !firrtl.flip<sint<9>>, !firrtl.sint<9>
+// CHECK-NEXT:   firrtl.connect %out_b, %c-1_si9 : !firrtl.sint<9>, !firrtl.sint<9>
 // CHECK-NEXT:  }
-firrtl.module @add_cst_prop2(%out_b: !firrtl.flip<sint<9>>) {
+firrtl.module @add_cst_prop2(out %out_b: !firrtl.sint<9>) {
   %c6_ui7 = firrtl.constant(-6 : i7) : !firrtl.sint<7>
   %tmp_a = firrtl.wire : !firrtl.sint<7>
   %c5_ui8 = firrtl.constant(5 : i8) : !firrtl.sint<8>
   firrtl.connect %tmp_a, %c6_ui7 : !firrtl.sint<7>, !firrtl.sint<7>
   %add = firrtl.add %tmp_a, %c5_ui8 : (!firrtl.sint<7>, !firrtl.sint<8>) -> !firrtl.sint<9>
-  firrtl.connect %out_b, %add : !firrtl.flip<sint<9>>, !firrtl.sint<9>
+  firrtl.connect %out_b, %add : !firrtl.sint<9>, !firrtl.sint<9>
 }
 
 // CHECK-LABEL: @add_cst_prop3
 // CHECK-NEXT:   %c-2_si4 = firrtl.constant(-2 : i4) : !firrtl.sint<4>
-// CHECK-NEXT:   firrtl.connect %out_b, %c-2_si4 : !firrtl.flip<sint<4>>, !firrtl.sint<4>
+// CHECK-NEXT:   firrtl.connect %out_b, %c-2_si4 : !firrtl.sint<4>, !firrtl.sint<4>
 // CHECK-NEXT:  }
-firrtl.module @add_cst_prop3(%out_b: !firrtl.flip<sint<4>>) {
+firrtl.module @add_cst_prop3(out %out_b: !firrtl.sint<4>) {
   %c1_si2 = firrtl.constant(-1 : i2) : !firrtl.sint<2>
   %tmp_a = firrtl.wire : !firrtl.sint<2>
   %c1_si3 = firrtl.constant(-1 : i3) : !firrtl.sint<3>
   firrtl.connect %tmp_a, %c1_si2 : !firrtl.sint<2>, !firrtl.sint<2>
   %add = firrtl.add %tmp_a, %c1_si3 : (!firrtl.sint<2>, !firrtl.sint<3>) -> !firrtl.sint<4>
-  firrtl.connect %out_b, %add : !firrtl.flip<sint<4>>, !firrtl.sint<4>
+  firrtl.connect %out_b, %add : !firrtl.sint<4>, !firrtl.sint<4>
 }
 
 // CHECK-LABEL: @sub_cst_prop1
 // CHECK-NEXT:      %c1_ui9 = firrtl.constant(1 : i9) : !firrtl.uint<9>
-// CHECK-NEXT:      firrtl.connect %out_b, %c1_ui9 : !firrtl.flip<uint<9>>, !firrtl.uint<9>
+// CHECK-NEXT:      firrtl.connect %out_b, %c1_ui9 : !firrtl.uint<9>, !firrtl.uint<9>
 // CHECK-NEXT:  }
-firrtl.module @sub_cst_prop1(%out_b: !firrtl.flip<uint<9>>) {
+firrtl.module @sub_cst_prop1(out %out_b: !firrtl.uint<9>) {
   %c6_ui7 = firrtl.constant(6 : ui7) : !firrtl.uint<7>
   %tmp_a = firrtl.wire : !firrtl.uint<7>
   %c5_ui8 = firrtl.constant(5 : ui8) : !firrtl.uint<8>
   firrtl.connect %tmp_a, %c6_ui7 : !firrtl.uint<7>, !firrtl.uint<7>
   %add = firrtl.sub %tmp_a, %c5_ui8 : (!firrtl.uint<7>, !firrtl.uint<8>) -> !firrtl.uint<9>
-  firrtl.connect %out_b, %add : !firrtl.flip<uint<9>>, !firrtl.uint<9>
+  firrtl.connect %out_b, %add : !firrtl.uint<9>, !firrtl.uint<9>
 }
 
 // CHECK-LABEL: @sub_cst_prop2
 // CHECK-NEXT:      %c-11_si9 = firrtl.constant(-11 : i9) : !firrtl.sint<9>
-// CHECK-NEXT:      firrtl.connect %out_b, %c-11_si9 : !firrtl.flip<sint<9>>, !firrtl.sint<9>
+// CHECK-NEXT:      firrtl.connect %out_b, %c-11_si9 : !firrtl.sint<9>, !firrtl.sint<9>
 // CHECK-NEXT:  }
-firrtl.module @sub_cst_prop2(%out_b: !firrtl.flip<sint<9>>) {
+firrtl.module @sub_cst_prop2(out %out_b: !firrtl.sint<9>) {
   %c6_ui7 = firrtl.constant(-6 : i7) : !firrtl.sint<7>
   %tmp_a = firrtl.wire : !firrtl.sint<7>
   %c5_ui8 = firrtl.constant(5 : i8) : !firrtl.sint<8>
   firrtl.connect %tmp_a, %c6_ui7 : !firrtl.sint<7>, !firrtl.sint<7>
   %add = firrtl.sub %tmp_a, %c5_ui8 : (!firrtl.sint<7>, !firrtl.sint<8>) -> !firrtl.sint<9>
-  firrtl.connect %out_b, %add : !firrtl.flip<sint<9>>, !firrtl.sint<9>
+  firrtl.connect %out_b, %add : !firrtl.sint<9>, !firrtl.sint<9>
 }
 
 // CHECK-LABEL: @mul_cst_prop1
 // CHECK-NEXT:      %c30_ui15 = firrtl.constant(30 : i15) : !firrtl.uint<15>
-// CHECK-NEXT:      firrtl.connect %out_b, %c30_ui15 : !firrtl.flip<uint<15>>, !firrtl.uint<15>
+// CHECK-NEXT:      firrtl.connect %out_b, %c30_ui15 : !firrtl.uint<15>, !firrtl.uint<15>
 // CHECK-NEXT:  }
-firrtl.module @mul_cst_prop1(%out_b: !firrtl.flip<uint<15>>) {
+firrtl.module @mul_cst_prop1(out %out_b: !firrtl.uint<15>) {
   %c6_ui7 = firrtl.constant(6 : ui7) : !firrtl.uint<7>
   %tmp_a = firrtl.wire : !firrtl.uint<7>
   %c5_ui8 = firrtl.constant(5 : ui8) : !firrtl.uint<8>
   firrtl.connect %tmp_a, %c6_ui7 : !firrtl.uint<7>, !firrtl.uint<7>
   %add = firrtl.mul %tmp_a, %c5_ui8 : (!firrtl.uint<7>, !firrtl.uint<8>) -> !firrtl.uint<15>
-  firrtl.connect %out_b, %add : !firrtl.flip<uint<15>>, !firrtl.uint<15>
+  firrtl.connect %out_b, %add : !firrtl.uint<15>, !firrtl.uint<15>
 }
 
 // CHECK-LABEL: @mul_cst_prop2
 // CHECK-NEXT:      %c-30_si15 = firrtl.constant(-30 : i15) : !firrtl.sint<15>
-// CHECK-NEXT:      firrtl.connect %out_b, %c-30_si15 : !firrtl.flip<sint<15>>, !firrtl.sint<15>
+// CHECK-NEXT:      firrtl.connect %out_b, %c-30_si15 : !firrtl.sint<15>, !firrtl.sint<15>
 // CHECK-NEXT:  }
-firrtl.module @mul_cst_prop2(%out_b: !firrtl.flip<sint<15>>) {
+firrtl.module @mul_cst_prop2(out %out_b: !firrtl.sint<15>) {
   %c6_ui7 = firrtl.constant(-6 : i7) : !firrtl.sint<7>
   %tmp_a = firrtl.wire : !firrtl.sint<7>
   %c5_ui8 = firrtl.constant(5 : i8) : !firrtl.sint<8>
   firrtl.connect %tmp_a, %c6_ui7 : !firrtl.sint<7>, !firrtl.sint<7>
   %add = firrtl.mul %tmp_a, %c5_ui8 : (!firrtl.sint<7>, !firrtl.sint<8>) -> !firrtl.sint<15>
-  firrtl.connect %out_b, %add : !firrtl.flip<sint<15>>, !firrtl.sint<15>
+  firrtl.connect %out_b, %add : !firrtl.sint<15>, !firrtl.sint<15>
 }
 
 // CHECK-LABEL: @mul_cst_prop3
 // CHECK-NEXT:      %c30_si15 = firrtl.constant(30 : i15) : !firrtl.sint<15>
-// CHECK-NEXT:      firrtl.connect %out_b, %c30_si15 : !firrtl.flip<sint<15>>, !firrtl.sint<15>
+// CHECK-NEXT:      firrtl.connect %out_b, %c30_si15 : !firrtl.sint<15>, !firrtl.sint<15>
 // CHECK-NEXT:  }
-firrtl.module @mul_cst_prop3(%out_b: !firrtl.flip<sint<15>>) {
+firrtl.module @mul_cst_prop3(out %out_b: !firrtl.sint<15>) {
   %c6_ui7 = firrtl.constant(-6 : i7) : !firrtl.sint<7>
   %tmp_a = firrtl.wire : !firrtl.sint<7>
   %c5_ui8 = firrtl.constant(-5 : i8) : !firrtl.sint<8>
   firrtl.connect %tmp_a, %c6_ui7 : !firrtl.sint<7>, !firrtl.sint<7>
   %add = firrtl.mul %tmp_a, %c5_ui8 : (!firrtl.sint<7>, !firrtl.sint<8>) -> !firrtl.sint<15>
-  firrtl.connect %out_b, %add : !firrtl.flip<sint<15>>, !firrtl.sint<15>
+  firrtl.connect %out_b, %add : !firrtl.sint<15>, !firrtl.sint<15>
 }
 
 // CHECK-LABEL: firrtl.module @MuxInvalidOpt
-firrtl.module @MuxInvalidOpt(%cond: !firrtl.uint<1>, %data: !firrtl.uint<4>, %out1: !firrtl.flip<uint<4>>, %out2: !firrtl.flip<uint<4>>, %out3: !firrtl.flip<uint<4>>, %out4: !firrtl.flip<uint<4>>) {
+firrtl.module @MuxInvalidOpt(in %cond: !firrtl.uint<1>, in %data: !firrtl.uint<4>, out %out1: !firrtl.uint<4>, out %out2: !firrtl.uint<4>, out %out3: !firrtl.uint<4>, out %out4: !firrtl.uint<4>) {
 
   // We can optimize out these mux's since the invalid value can take on any input.
   %tmp1 = firrtl.invalidvalue : !firrtl.uint<4>
   %a = firrtl.mux(%cond, %data, %tmp1) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   // CHECK:         firrtl.connect %out1, %data
-  firrtl.connect %out1, %a : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out1, %a : !firrtl.uint<4>, !firrtl.uint<4>
 
   %b = firrtl.mux(%cond, %tmp1, %data) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   // CHECK:         firrtl.connect %out2, %data
-  firrtl.connect %out2, %b : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out2, %b : !firrtl.uint<4>, !firrtl.uint<4>
 
   %false = firrtl.constant(false) : !firrtl.uint<1>
   %c = firrtl.mux(%false, %data, %tmp1) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   // CHECK:         firrtl.connect %out3, %data
-  firrtl.connect %out3, %c : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out3, %c : !firrtl.uint<4>, !firrtl.uint<4>
 
   %true = firrtl.constant(true) : !firrtl.uint<1>
   %d = firrtl.mux(%false, %tmp1, %data) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   // CHECK:         firrtl.connect %out4, %data
-  firrtl.connect %out4, %d : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out4, %d : !firrtl.uint<4>, !firrtl.uint<4>
 }
 
 // CHECK-LABEL: firrtl.module @MuxCanon
-firrtl.module @MuxCanon(%c1: !firrtl.uint<1>, %c2: !firrtl.uint<1>, %d1: !firrtl.uint<5>, %d2: !firrtl.uint<5>, %d3: !firrtl.uint<5>, %foo: !firrtl.flip<uint<5>>, %foo2: !firrtl.flip<uint<5>>) {
+firrtl.module @MuxCanon(in %c1: !firrtl.uint<1>, in %c2: !firrtl.uint<1>, in %d1: !firrtl.uint<5>, in %d2: !firrtl.uint<5>, in %d3: !firrtl.uint<5>, out %foo: !firrtl.uint<5>, out %foo2: !firrtl.uint<5>) {
   %0 = firrtl.mux(%c1, %d2, %d3) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
   %1 = firrtl.mux(%c1, %d1, %0) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
   %2 = firrtl.mux(%c1, %0, %d1) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
-  firrtl.connect %foo, %1 : !firrtl.flip<uint<5>>, !firrtl.uint<5>
-  firrtl.connect %foo2, %2 : !firrtl.flip<uint<5>>, !firrtl.uint<5>
-  // CHECK: firrtl.mux(%c1, %d1, %d3) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5> 
-  // CHECK: firrtl.mux(%c1, %d2, %d1) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5> 
+  firrtl.connect %foo, %1 : !firrtl.uint<5>, !firrtl.uint<5>
+  firrtl.connect %foo2, %2 : !firrtl.uint<5>, !firrtl.uint<5>
+  // CHECK: firrtl.mux(%c1, %d1, %d3) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
+  // CHECK: firrtl.mux(%c1, %d2, %d1) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
 }
 
 // CHECK-LABEL: firrtl.module @EmptyNode
-firrtl.module @EmptyNode(%d1: !firrtl.uint<5>, %foo: !firrtl.flip<uint<5>>, %foo2: !firrtl.flip<uint<5>>) {
+firrtl.module @EmptyNode(in %d1: !firrtl.uint<5>, out %foo: !firrtl.uint<5>, out %foo2: !firrtl.uint<5>) {
   %bar0 = firrtl.node %d1 : !firrtl.uint<5>
   %bar1 = firrtl.node %d1 : !firrtl.uint<5>
   %bar2 = firrtl.node %d1 {annotations = [{extrastuff = "n1"}]} : !firrtl.uint<5>
-  firrtl.connect %foo, %bar1 : !firrtl.flip<uint<5>>, !firrtl.uint<5>
-  firrtl.connect %foo2, %bar2 : !firrtl.flip<uint<5>>, !firrtl.uint<5>
+  firrtl.connect %foo, %bar1 : !firrtl.uint<5>, !firrtl.uint<5>
+  firrtl.connect %foo2, %bar2 : !firrtl.uint<5>, !firrtl.uint<5>
 }
 // CHECK-NEXT: %bar2 = firrtl.node %d1 {annotations = [{extrastuff = "n1"}]}
 // CHECK-NEXT: firrtl.connect %foo, %d1
@@ -1385,13 +1385,13 @@ firrtl.module @EmptyNode(%d1: !firrtl.uint<5>, %foo: !firrtl.flip<uint<5>>, %foo
 
 // COM: https://github.com/llvm/circt/issues/929
 // CHECK-LABEL: firrtl.module @MuxInvalidTypeOpt
-firrtl.module @MuxInvalidTypeOpt(%in : !firrtl.uint<1>, %out : !firrtl.flip<uint<4>>) {
+firrtl.module @MuxInvalidTypeOpt(in %in : !firrtl.uint<1>, out %out : !firrtl.uint<4>) {
   %c7_ui4 = firrtl.constant(7 : ui4) : !firrtl.uint<4>
   %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
   %c0_ui2 = firrtl.constant(0 : ui2) : !firrtl.uint<2>
   %0 = firrtl.mux (%in, %c7_ui4, %c0_ui2) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<2>) -> !firrtl.uint<4>
   %1 = firrtl.mux (%in, %c1_ui2, %0) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  firrtl.connect %out, %1 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 }
 // CHECK: firrtl.mux(%in, %c7_ui4, %c0_ui2) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<2>) -> !firrtl.uint<4>
 // CHECK: firrtl.mux(%in, %c1_ui2, %0) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<4>) -> !firrtl.uint<4>

--- a/test/Dialect/FIRRTL/check-widths-errors.mlir
+++ b/test/Dialect/FIRRTL/check-widths-errors.mlir
@@ -3,7 +3,7 @@
 firrtl.circuit "Foo" {
   // expected-error @+2 {{uninferred width: type '!firrtl.uint'}}
   // expected-note @+1 {{in port `a` of module `Foo`}}
-  firrtl.module @Foo (%a: !firrtl.uint) {
+  firrtl.module @Foo (in %a: !firrtl.uint) {
   }
 }
 
@@ -69,6 +69,6 @@ firrtl.circuit "Foo" {
 firrtl.circuit "Foo" {
   // expected-error @+2 {{uninferred width: type '!firrtl.uint'}}
   // expected-note @+1 {{in port `a` of module `Foo`}}
-  firrtl.module @Foo (%a: !firrtl.uint, %b: !firrtl.sint) {
+  firrtl.module @Foo (in %a: !firrtl.uint, in %b: !firrtl.sint) {
   }
 }

--- a/test/Dialect/FIRRTL/connect-errors.mlir
+++ b/test/Dialect/FIRRTL/connect-errors.mlir
@@ -3,9 +3,9 @@
 
 firrtl.circuit "test" {
 // expected-note @+1 {{the left-hand-side was defined here}}
-firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<uint<1>>) {
+firrtl.module @test(in %a : !firrtl.uint<1>, out %b : !firrtl.uint<1>) {
   // expected-error @+1 {{has invalid flow: the left-hand-side has source flow}}
-  firrtl.connect %a, %b : !firrtl.uint<1>, !firrtl.flip<uint<1>>
+  firrtl.connect %a, %b : !firrtl.uint<1>, !firrtl.uint<1>
 }
 }
 
@@ -14,27 +14,27 @@ firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<uint<1>>) {
 // -----
 
 firrtl.circuit "test" {
-firrtl.module @test(%a : !firrtl.analog, %b : !firrtl.flip<analog>) {
+firrtl.module @test(in %a : !firrtl.analog, out %b : !firrtl.analog) {
   // expected-error @+1 {{analog types may not be connected}}
-  firrtl.connect %b, %a : !firrtl.flip<analog>, !firrtl.analog
+  firrtl.connect %b, %a : !firrtl.analog, !firrtl.analog
 }
 }
 
 // -----
 
 firrtl.circuit "test" {
-firrtl.module @test(%a : !firrtl.analog, %b : !firrtl.flip<uint<1>>) {
+firrtl.module @test(in %a : !firrtl.analog, out %b : !firrtl.uint<1>) {
   // expected-error @+1 {{analog types may not be connected}}
-  firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.analog
+  firrtl.connect %b, %a : !firrtl.uint<1>, !firrtl.analog
 }
 }
 
 // -----
 
 firrtl.circuit "test" {
-firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<analog>) {
+firrtl.module @test(in %a : !firrtl.uint<1>, out %b : !firrtl.analog) {
   // expected-error @+1 {{analog types may not be connected}}
-  firrtl.connect %b, %a : !firrtl.flip<analog>, !firrtl.uint<1>
+  firrtl.connect %b, %a : !firrtl.analog, !firrtl.uint<1>
 }
 }
 
@@ -45,18 +45,18 @@ firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<analog>) {
 // -----
 
 firrtl.circuit "test" {
-firrtl.module @test(%a : !firrtl.reset, %b : !firrtl.flip<uint<2>>) {
+firrtl.module @test(in %a : !firrtl.reset, out %b : !firrtl.uint<2>) {
   // expected-error @+1 {{type mismatch between destination '!firrtl.uint<2>' and source '!firrtl.reset'}}
-  firrtl.connect %b, %a : !firrtl.flip<uint<2>>, !firrtl.reset
+  firrtl.connect %b, %a : !firrtl.uint<2>, !firrtl.reset
 }
 }
 
 // -----
 
 firrtl.circuit "test" {
-firrtl.module @test(%a : !firrtl.reset, %b : !firrtl.flip<sint<1>>) {
+firrtl.module @test(in %a : !firrtl.reset, out %b : !firrtl.sint<1>) {
   // expected-error @+1 {{type mismatch between destination '!firrtl.sint<1>' and source '!firrtl.reset'}}
-  firrtl.connect %b, %a : !firrtl.flip<sint<1>>, !firrtl.reset
+  firrtl.connect %b, %a : !firrtl.sint<1>, !firrtl.reset
 }
 }
 
@@ -65,18 +65,18 @@ firrtl.module @test(%a : !firrtl.reset, %b : !firrtl.flip<sint<1>>) {
 // -----
 
 firrtl.circuit "test" {
-firrtl.module @test(%a : !firrtl.uint<2>, %b : !firrtl.flip<reset>) {
+firrtl.module @test(in %a : !firrtl.uint<2>, out %b : !firrtl.reset) {
   // expected-error @+1 {{type mismatch between destination '!firrtl.reset' and source '!firrtl.uint<2>'}}
-  firrtl.connect %b, %a : !firrtl.flip<reset>, !firrtl.uint<2>
+  firrtl.connect %b, %a : !firrtl.reset, !firrtl.uint<2>
 }
 }
 
 // -----
 
 firrtl.circuit "test" {
-firrtl.module @test(%a : !firrtl.sint<1>, %b : !firrtl.flip<reset>) {
+firrtl.module @test(in %a : !firrtl.sint<1>, out %b : !firrtl.reset) {
   // expected-error @+1 {{type mismatch between destination '!firrtl.reset' and source '!firrtl.sint<1>'}}
-  firrtl.connect %b, %a : !firrtl.flip<reset>, !firrtl.sint<1>
+  firrtl.connect %b, %a : !firrtl.reset, !firrtl.sint<1>
 }
 }
 
@@ -87,9 +87,9 @@ firrtl.module @test(%a : !firrtl.sint<1>, %b : !firrtl.flip<reset>) {
 // -----
 
 firrtl.circuit "test" {
-firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<sint<1>>) {
+firrtl.module @test(in %a : !firrtl.uint<1>, out %b : !firrtl.sint<1>) {
   // expected-error @+1 {{type mismatch between destination '!firrtl.sint<1>' and source '!firrtl.uint<1>'}}
-  firrtl.connect %b, %a : !firrtl.flip<sint<1>>, !firrtl.uint<1>
+  firrtl.connect %b, %a : !firrtl.sint<1>, !firrtl.uint<1>
 }
 }
 
@@ -97,9 +97,9 @@ firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<sint<1>>) {
 
 firrtl.circuit "test" {
 
-firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<clock>) {
+firrtl.module @test(in %a : !firrtl.uint<1>, out %b : !firrtl.clock) {
   // expected-error @+1 {{type mismatch between destination '!firrtl.clock' and source '!firrtl.uint<1>'}}
-  firrtl.connect %b, %a : !firrtl.flip<clock>, !firrtl.uint<1>
+  firrtl.connect %b, %a : !firrtl.clock, !firrtl.uint<1>
 }
 
 }
@@ -107,9 +107,9 @@ firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<clock>) {
 // -----
 
 firrtl.circuit "test" {
-firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<asyncreset>) {
+firrtl.module @test(in %a : !firrtl.uint<1>, out %b : !firrtl.asyncreset) {
   // expected-error @+1 {{type mismatch between destination '!firrtl.asyncreset' and source '!firrtl.uint<1>'}}
-  firrtl.connect %b, %a : !firrtl.flip<asyncreset>, !firrtl.uint<1>
+  firrtl.connect %b, %a : !firrtl.asyncreset, !firrtl.uint<1>
 }
 }
 
@@ -118,27 +118,27 @@ firrtl.module @test(%a : !firrtl.uint<1>, %b : !firrtl.flip<asyncreset>) {
 // -----
 
 firrtl.circuit "test" {
-firrtl.module @test(%a : !firrtl.sint<1>, %b : !firrtl.flip<uint<1>>) {
+firrtl.module @test(in %a : !firrtl.sint<1>, out %b : !firrtl.uint<1>) {
   // expected-error @+1 {{type mismatch between destination '!firrtl.uint<1>' and source '!firrtl.sint<1>'}}
-  firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.sint<1>
+  firrtl.connect %b, %a : !firrtl.uint<1>, !firrtl.sint<1>
 }
 }
 
 // -----
 
 firrtl.circuit "test" {
-firrtl.module @test(%a : !firrtl.sint<1>, %b : !firrtl.flip<clock>) {
+firrtl.module @test(in %a : !firrtl.sint<1>, out %b : !firrtl.clock) {
   // expected-error @+1 {{type mismatch between destination '!firrtl.clock' and source '!firrtl.sint<1>'}}
-  firrtl.connect %b, %a : !firrtl.flip<clock>, !firrtl.sint<1>
+  firrtl.connect %b, %a : !firrtl.clock, !firrtl.sint<1>
 }
 }
 
 // -----
 
 firrtl.circuit "test" {
-firrtl.module @test(%a : !firrtl.sint<1>, %b : !firrtl.flip<asyncreset>) {
+firrtl.module @test(in %a : !firrtl.sint<1>, out %b : !firrtl.asyncreset) {
   // expected-error @+1 {{type mismatch between destination '!firrtl.asyncreset' and source '!firrtl.sint<1>'}}
-  firrtl.connect %b, %a : !firrtl.flip<asyncreset>, !firrtl.sint<1>
+  firrtl.connect %b, %a : !firrtl.asyncreset, !firrtl.sint<1>
 }
 }
 
@@ -147,27 +147,27 @@ firrtl.module @test(%a : !firrtl.sint<1>, %b : !firrtl.flip<asyncreset>) {
 // -----
 
 firrtl.circuit "test" {
-firrtl.module @test(%a : !firrtl.clock, %b : !firrtl.flip<uint<1>>) {
+firrtl.module @test(in %a : !firrtl.clock, out %b : !firrtl.uint<1>) {
   // expected-error @+1 {{type mismatch between destination '!firrtl.uint<1>' and source '!firrtl.clock'}}
-  firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.clock
+  firrtl.connect %b, %a : !firrtl.uint<1>, !firrtl.clock
 }
 }
 
 // -----
 
 firrtl.circuit "test" {
-firrtl.module @test(%a : !firrtl.clock, %b : !firrtl.flip<sint<1>>) {
+firrtl.module @test(in %a : !firrtl.clock, out %b : !firrtl.sint<1>) {
   // expected-error @+1 {{type mismatch between destination '!firrtl.sint<1>' and source '!firrtl.clock'}}
-  firrtl.connect %b, %a : !firrtl.flip<sint<1>>, !firrtl.clock
+  firrtl.connect %b, %a : !firrtl.sint<1>, !firrtl.clock
 }
 }
 
 // -----
 
 firrtl.circuit "test" {
-firrtl.module @test(%a : !firrtl.clock, %b : !firrtl.flip<asyncreset>) {
+firrtl.module @test(in %a : !firrtl.clock, out %b : !firrtl.asyncreset) {
   // expected-error @+1 {{type mismatch between destination '!firrtl.asyncreset' and source '!firrtl.clock'}}
-  firrtl.connect %b, %a : !firrtl.flip<asyncreset>, !firrtl.clock
+  firrtl.connect %b, %a : !firrtl.asyncreset, !firrtl.clock
 }
 }
 
@@ -176,27 +176,27 @@ firrtl.module @test(%a : !firrtl.clock, %b : !firrtl.flip<asyncreset>) {
 // -----
 
 firrtl.circuit "test" {
-firrtl.module @test(%a : !firrtl.asyncreset, %b : !firrtl.flip<uint<1>>) {
+firrtl.module @test(in %a : !firrtl.asyncreset, out %b : !firrtl.uint<1>) {
   // expected-error @+1 {{type mismatch between destination '!firrtl.uint<1>' and source '!firrtl.asyncreset'}}
-  firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.asyncreset
+  firrtl.connect %b, %a : !firrtl.uint<1>, !firrtl.asyncreset
 }
 }
 
 // -----
 
 firrtl.circuit "test" {
-firrtl.module @test(%a : !firrtl.asyncreset, %b : !firrtl.flip<sint<1>>) {
+firrtl.module @test(in %a : !firrtl.asyncreset, out %b : !firrtl.sint<1>) {
   // expected-error @+1 {{type mismatch between destination '!firrtl.sint<1>' and source '!firrtl.asyncreset'}}
-  firrtl.connect %b, %a : !firrtl.flip<sint<1>>, !firrtl.asyncreset
+  firrtl.connect %b, %a : !firrtl.sint<1>, !firrtl.asyncreset
 }
 }
 
 // -----
 
 firrtl.circuit "test" {
-firrtl.module @test(%a : !firrtl.asyncreset, %b : !firrtl.flip<clock>) {
+firrtl.module @test(in %a : !firrtl.asyncreset, out %b : !firrtl.clock) {
   // expected-error @+1 {{type mismatch between destination '!firrtl.clock' and source '!firrtl.asyncreset'}}
-  firrtl.connect %b, %a : !firrtl.flip<clock>, !firrtl.asyncreset
+  firrtl.connect %b, %a : !firrtl.clock, !firrtl.asyncreset
 }
 }
 
@@ -205,18 +205,18 @@ firrtl.module @test(%a : !firrtl.asyncreset, %b : !firrtl.flip<clock>) {
 // -----
 
 firrtl.circuit "test" {
-firrtl.module @test(%a : !firrtl.vector<uint<1>, 3>, %b : !firrtl.flip<vector<uint<1>, 2>>) {
+firrtl.module @test(in %a : !firrtl.vector<uint<1>, 3>, out %b : !firrtl.vector<uint<1>, 2>) {
   // expected-error @+1 {{type mismatch between destination '!firrtl.vector<uint<1>, 2>' and source '!firrtl.vector<uint<1>, 3>'}}
-  firrtl.connect %b, %a : !firrtl.flip<vector<uint<1>, 2>>, !firrtl.vector<uint<1>, 3>
+  firrtl.connect %b, %a : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 3>
 }
 }
 
 // -----
 
 firrtl.circuit "test" {
-firrtl.module @test(%a : !firrtl.vector<uint<1>, 3>, %b : !firrtl.flip<vector<sint<1>, 3>>) {
+firrtl.module @test(in %a : !firrtl.vector<uint<1>, 3>, out %b : !firrtl.vector<sint<1>, 3>) {
   // expected-error @+1 {{type mismatch between destination '!firrtl.vector<sint<1>, 3>' and source '!firrtl.vector<uint<1>, 3>'}}
-  firrtl.connect %b, %a : !firrtl.flip<vector<sint<1>, 3>>, !firrtl.vector<uint<1>, 3>
+  firrtl.connect %b, %a : !firrtl.vector<sint<1>, 3>, !firrtl.vector<uint<1>, 3>
 }
 }
 
@@ -226,7 +226,7 @@ firrtl.module @test(%a : !firrtl.vector<uint<1>, 3>, %b : !firrtl.flip<vector<si
 // -----
 
 firrtl.circuit "test" {
-firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>>, %b : !firrtl.bundle<f1: flip<uint<1>>, f2: sint<1>>) {
+firrtl.module @test(in %a : !firrtl.bundle<f1: uint<1>>, in %b : !firrtl.bundle<f1: flip<uint<1>>, f2: sint<1>>) {
   // expected-error @+1 {{type mismatch between destination '!firrtl.bundle<f1: flip<uint<1>>, f2: sint<1>>' and source '!firrtl.bundle<f1: uint<1>>'}}
   firrtl.connect %b, %a : !firrtl.bundle<f1: flip<uint<1>>, f2: sint<1>>, !firrtl.bundle<f1: uint<1>>
 }
@@ -235,7 +235,7 @@ firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>>, %b : !firrtl.bundle<f1: fl
 // -----
 
 firrtl.circuit "test" {
-firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>>, %b : !firrtl.bundle<f2: flip<uint<1>>>) {
+firrtl.module @test(in %a : !firrtl.bundle<f1: uint<1>>, in %b : !firrtl.bundle<f2: flip<uint<1>>>) {
   // expected-error @+1 {{type mismatch between destination '!firrtl.bundle<f2: flip<uint<1>>>' and source '!firrtl.bundle<f1: uint<1>>'}}
   firrtl.connect %b, %a : !firrtl.bundle<f2: flip<uint<1>>>, !firrtl.bundle<f1: uint<1>>
 }
@@ -244,7 +244,7 @@ firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>>, %b : !firrtl.bundle<f2: fl
 // -----
 
 firrtl.circuit "test" {
-firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>>, %b : !firrtl.bundle<f1: flip<sint<1>>>) {
+firrtl.module @test(in %a : !firrtl.bundle<f1: uint<1>>, in %b : !firrtl.bundle<f1: flip<sint<1>>>) {
   // expected-error @+1 {{type mismatch between destination '!firrtl.bundle<f1: flip<sint<1>>>' and source '!firrtl.bundle<f1: uint<1>>'}}
   firrtl.connect %b, %a : !firrtl.bundle<f1: flip<sint<1>>>, !firrtl.bundle<f1: uint<1>>
 }
@@ -253,10 +253,10 @@ firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>>, %b : !firrtl.bundle<f1: fl
 // -----
 
 firrtl.circuit "test" {
-firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>>, %b : !firrtl.flip<bundle<f1: uint<1>>>) {
+firrtl.module @test(in %a : !firrtl.bundle<f1: uint<1>>, out %b : !firrtl.bundle<f1: uint<1>>) {
   // expected-note @+1 {{the left-hand-side was defined here}}
   %0 = firrtl.subfield %a("f1") : (!firrtl.bundle<f1: uint<1>>) -> !firrtl.uint<1>
-  %1 = firrtl.subfield %b("f1") : (!firrtl.flip<bundle<f1: uint<1>>>) -> !firrtl.uint<1>
+  %1 = firrtl.subfield %b("f1") : (!firrtl.bundle<f1: uint<1>>) -> !firrtl.uint<1>
   // expected-error @+1 {{op has invalid flow: the left-hand-side has source flow}}
   firrtl.connect %0, %1 : !firrtl.uint<1>, !firrtl.uint<1>
 }
@@ -267,9 +267,9 @@ firrtl.module @test(%a : !firrtl.bundle<f1: uint<1>>, %b : !firrtl.flip<bundle<f
 // -----
 
 firrtl.circuit "test" {
-firrtl.module @test(%a : !firrtl.uint<2>, %b : !firrtl.flip<uint<1>>) {
+firrtl.module @test(in %a : !firrtl.uint<2>, out %b : !firrtl.uint<1>) {
   // expected-error @+1 {{destination width 1 is not greater than or equal to source width 2}}
-  firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.uint<2>
+  firrtl.connect %b, %a : !firrtl.uint<1>, !firrtl.uint<2>
 }
 }
 
@@ -282,9 +282,9 @@ firrtl.module @test(%a : !firrtl.uint<2>, %b : !firrtl.flip<uint<1>>) {
 ///     a.a.a <= ax.a.a
 
 firrtl.circuit "test"  {
-firrtl.module @test(%a: !firrtl.flip<bundle<a: bundle<a: flip<uint<1>>>>>) {
+firrtl.module @test(out %a: !firrtl.bundle<a: bundle<a: flip<uint<1>>>>) {
   %ax = firrtl.wire  : !firrtl.bundle<a: bundle<a: flip<uint<1>>>>
-  %a_a = firrtl.subfield %a("a") : (!firrtl.flip<bundle<a: bundle<a: flip<uint<1>>>>>) -> !firrtl.bundle<a: flip<uint<1>>>
+  %a_a = firrtl.subfield %a("a") : (!firrtl.bundle<a: bundle<a: flip<uint<1>>>>) -> !firrtl.bundle<a: flip<uint<1>>>
   // expected-note @+1 {{the left-hand-side was defined here}}
   %a_a_a = firrtl.subfield %a_a("a") : (!firrtl.bundle<a: flip<uint<1>>>) -> !firrtl.uint<1>
   %ax_a = firrtl.subfield %ax("a") : (!firrtl.bundle<a: bundle<a: flip<uint<1>>>>) -> !firrtl.bundle<a: flip<uint<1>>>
@@ -303,10 +303,10 @@ firrtl.module @test(%a: !firrtl.flip<bundle<a: bundle<a: flip<uint<1>>>>>) {
 ///     a.a <= ax.a
 
 firrtl.circuit "test"  {
-firrtl.module @test(%a: !firrtl.flip<bundle<a: flip<bundle<a: uint<1>>>>>) {
+firrtl.module @test(out %a: !firrtl.bundle<a: flip<bundle<a: uint<1>>>>) {
   %ax = firrtl.wire  : !firrtl.bundle<a: flip<bundle<a: uint<1>>>>
   // expected-note @+1 {{the left-hand-side was defined here}}
-  %a_a = firrtl.subfield %a("a") : (!firrtl.flip<bundle<a: flip<bundle<a: uint<1>>>>>) -> !firrtl.bundle<a: uint<1>>
+  %a_a = firrtl.subfield %a("a") : (!firrtl.bundle<a: flip<bundle<a: uint<1>>>>) -> !firrtl.bundle<a: uint<1>>
   %ax_a = firrtl.subfield %ax("a") : (!firrtl.bundle<a: flip<bundle<a: uint<1>>>>) -> !firrtl.bundle<a: uint<1>>
   // expected-error @+1 {{invalid flow: the left-hand-side has source flow}}
   firrtl.connect %a_a, %ax_a : !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>
@@ -322,9 +322,9 @@ firrtl.module @test(%a: !firrtl.flip<bundle<a: flip<bundle<a: uint<1>>>>>) {
 ///     a.a.a <= ax.a.a
 
 firrtl.circuit "test"  {
-firrtl.module @test(%a: !firrtl.flip<bundle<a: flip<bundle<a: uint<1>>>>>) {
+firrtl.module @test(out %a: !firrtl.bundle<a: flip<bundle<a: uint<1>>>>) {
   %ax = firrtl.wire  : !firrtl.bundle<a: flip<bundle<a: uint<1>>>>
-  %a_a = firrtl.subfield %a("a") : (!firrtl.flip<bundle<a: flip<bundle<a: uint<1>>>>>) -> !firrtl.bundle<a: uint<1>>
+  %a_a = firrtl.subfield %a("a") : (!firrtl.bundle<a: flip<bundle<a: uint<1>>>>) -> !firrtl.bundle<a: uint<1>>
   // expected-note @+1 {{the left-hand-side was defined here}}
   %a_a_a = firrtl.subfield %a_a("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
   %ax_a = firrtl.subfield %ax("a") : (!firrtl.bundle<a: flip<bundle<a: uint<1>>>>) -> !firrtl.bundle<a: uint<1>>
@@ -343,10 +343,10 @@ firrtl.module @test(%a: !firrtl.flip<bundle<a: flip<bundle<a: uint<1>>>>>) {
 ///     a.a <= ax.a
 
 firrtl.circuit "test"  {
-firrtl.module @test(%a: !firrtl.flip<bundle<a: flip<bundle<a: flip<uint<1>>>>>>) {
+firrtl.module @test(out %a: !firrtl.bundle<a: flip<bundle<a: flip<uint<1>>>>>) {
   %ax = firrtl.wire  : !firrtl.bundle<a: flip<bundle<a: flip<uint<1>>>>>
   // expected-note @+1 {{the left-hand-side was defined here}}
-  %a_a = firrtl.subfield %a("a") : (!firrtl.flip<bundle<a: flip<bundle<a: flip<uint<1>>>>>>) -> !firrtl.bundle<a: flip<uint<1>>>
+  %a_a = firrtl.subfield %a("a") : (!firrtl.bundle<a: flip<bundle<a: flip<uint<1>>>>>) -> !firrtl.bundle<a: flip<uint<1>>>
   %ax_a = firrtl.subfield %ax("a") : (!firrtl.bundle<a: flip<bundle<a: flip<uint<1>>>>>) -> !firrtl.bundle<a: flip<uint<1>>>
   // expected-error @+1 {{invalid flow: the left-hand-side has source flow}}
   firrtl.connect %a_a, %ax_a : !firrtl.bundle<a: flip<uint<1>>>, !firrtl.bundle<a: flip<uint<1>>>
@@ -372,11 +372,11 @@ firrtl.module @test(%a: !firrtl.flip<bundle<a: flip<bundle<a: flip<uint<1>>>>>>)
 ///     a <= memory.r.en
 
 firrtl.circuit "test" {
-firrtl.module @test(%a: !firrtl.flip<uint<1>>) {
+firrtl.module @test(out %a: !firrtl.uint<1>) {
   %memory_r = firrtl.mem Undefined  {depth = 2 : i64, name = "memory", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: flip<uint<1>>>>
   // expected-note @+1 {{the right-hand-side was defined here}}
   %memory_r_en = firrtl.subfield %memory_r("en") : (!firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: flip<uint<1>>>>) -> !firrtl.uint<1>
   // expected-error @+1 {{invalid flow: the right-hand-side has sink flow}}
-  firrtl.connect %a, %memory_r_en : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %a, %memory_r_en : !firrtl.uint<1>, !firrtl.uint<1>
 }
 }

--- a/test/Dialect/FIRRTL/connect.mlir
+++ b/test/Dialect/FIRRTL/connect.mlir
@@ -4,109 +4,109 @@
 firrtl.circuit "reset0" {
 
 // Reset destination.
-firrtl.module @reset0(%a : !firrtl.uint<1>, %b : !firrtl.flip<reset>) {
+firrtl.module @reset0(in %a : !firrtl.uint<1>, out %b : !firrtl.reset) {
   // CHECK: firrtl.connect %b, %a
-  firrtl.connect %b, %a : !firrtl.flip<reset>, !firrtl.uint<1>
+  firrtl.connect %b, %a : !firrtl.reset, !firrtl.uint<1>
 }
 
-firrtl.module @reset1(%a : !firrtl.asyncreset, %b : !firrtl.flip<reset>) {
+firrtl.module @reset1(in %a : !firrtl.asyncreset, out %b : !firrtl.reset) {
   // CHECK: firrtl.connect %b, %a
-  firrtl.connect %b, %a : !firrtl.flip<reset>, !firrtl.asyncreset
+  firrtl.connect %b, %a : !firrtl.reset, !firrtl.asyncreset
 }
 
 /// Reset types can be connected to Reset, UInt<1>, or AsyncReset types.
 
 // Reset source.
-firrtl.module @reset2(%a : !firrtl.reset, %b : !firrtl.flip<reset>) {
+firrtl.module @reset2(in %a : !firrtl.reset, out %b : !firrtl.reset) {
   // CHECK: firrtl.connect %b, %a
-  firrtl.connect %b, %a : !firrtl.flip<reset>, !firrtl.reset
+  firrtl.connect %b, %a : !firrtl.reset, !firrtl.reset
 }
 
-firrtl.module @reset3(%a : !firrtl.reset, %b : !firrtl.flip<uint<1>>) {
+firrtl.module @reset3(in %a : !firrtl.reset, out %b : !firrtl.uint<1>) {
   // CHECK: firrtl.connect %b, %a
-  firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.reset
+  firrtl.connect %b, %a : !firrtl.uint<1>, !firrtl.reset
 }
 
-firrtl.module @reset4(%a : !firrtl.reset, %b : !firrtl.flip<asyncreset>) {
-  // CHECK: firrtl.connect %b, %a
-  firrtl.connect %b, %a : !firrtl.flip<asyncreset>, !firrtl.reset
+firrtl.module @reset4(in %a : !firrtl.reset, out %b : !firrtl.asyncreset) {
+  // CHECK firrtl.connect %b, %a
+  firrtl.connect %b, %a : !firrtl.asyncreset, !firrtl.reset
 }
 
 // AsyncReset source.
-firrtl.module @asyncreset0(%a : !firrtl.asyncreset, %b : !firrtl.flip<asyncreset>) {
+firrtl.module @asyncreset0(in %a : !firrtl.asyncreset, out %b : !firrtl.asyncreset) {
   // CHECK: firrtl.connect %b, %a
-  firrtl.connect %b, %a : !firrtl.flip<asyncreset>, !firrtl.asyncreset
+  firrtl.connect %b, %a : !firrtl.asyncreset, !firrtl.asyncreset
 }
 
 // Clock source.
-firrtl.module @clock0(%a : !firrtl.clock, %b : !firrtl.flip<clock>) {
+firrtl.module @clock0(in %a : !firrtl.clock, out %b : !firrtl.clock) {
   // CHECK: firrtl.connect %b, %a
-  firrtl.connect %b, %a : !firrtl.flip<clock>, !firrtl.clock
+  firrtl.connect %b, %a : !firrtl.clock, !firrtl.clock
 }
 
 /// Ground types can be connected if they are the same ground type.
 
 // SInt<> source.
-firrtl.module @sint0(%a : !firrtl.sint<1>, %b : !firrtl.flip<sint<1>>) {
+firrtl.module @sint0(in %a : !firrtl.sint<1>, out %b : !firrtl.sint<1>) {
   // CHECK: firrtl.connect %b, %a
-  firrtl.connect %b, %a : !firrtl.flip<sint<1>>, !firrtl.sint<1>
+  firrtl.connect %b, %a : !firrtl.sint<1>, !firrtl.sint<1>
 }
 
 // UInt<> source.
-firrtl.module @uint0(%a : !firrtl.uint<1>, %b : !firrtl.flip<uint<1>>) {
+firrtl.module @uint0(in %a : !firrtl.uint<1>, out %b : !firrtl.uint<1>) {
   // CHECK: firrtl.connect %b, %a
-  firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %b, %a : !firrtl.uint<1>, !firrtl.uint<1>
 }
-firrtl.module @uint1(%a : !firrtl.uint<1>, %b : !firrtl.flip<uint<2>>) {
+firrtl.module @uint1(in %a : !firrtl.uint<1>, out %b : !firrtl.uint<2>) {
   // CHECK: firrtl.connect %b, %a
-  firrtl.connect %b, %a : !firrtl.flip<uint<2>>, !firrtl.uint<1>
+  firrtl.connect %b, %a : !firrtl.uint<2>, !firrtl.uint<1>
 }
 
 /// Vector types can be connected if they have the same size and element type.
-firrtl.module @vect0(%a : !firrtl.vector<uint<1>, 3>, %b : !firrtl.flip<vector<uint<1>, 3>>) {
+firrtl.module @vect0(in %a : !firrtl.vector<uint<1>, 3>, out %b : !firrtl.vector<uint<1>, 3>) {
   // CHECK: firrtl.connect %b, %a
-  firrtl.connect %b, %a : !firrtl.flip<vector<uint<1>, 3>>, !firrtl.vector<uint<1>, 3>
+  firrtl.connect %b, %a : !firrtl.vector<uint<1>, 3>, !firrtl.vector<uint<1>, 3>
 }
 
 /// Bundle types can be connected if they have the same size, element names, and
 /// element types.
 
-firrtl.module @bundle0(%a : !firrtl.bundle<f1: uint<1>, f2: flip<sint<1>>>, %b : !firrtl.flip<bundle<f1: uint<1>, f2: flip<sint<1>>>>) {
+firrtl.module @bundle0(in %a : !firrtl.bundle<f1: uint<1>, f2: flip<sint<1>>>, out %b : !firrtl.bundle<f1: uint<1>, f2: flip<sint<1>>>) {
   // CHECK: firrtl.connect %b, %a
-  firrtl.connect %b, %a : !firrtl.flip<bundle<f1: uint<1>, f2: flip<sint<1>>>>, !firrtl.bundle<f1: uint<1>, f2: flip<sint<1>>>
+  firrtl.connect %b, %a : !firrtl.bundle<f1: uint<1>, f2: flip<sint<1>>>, !firrtl.bundle<f1: uint<1>, f2: flip<sint<1>>>
 }
 
-firrtl.module @bundle1(%a : !firrtl.bundle<f1: uint<1>, f2: flip<sint<2>>>, %b : !firrtl.flip<bundle<f1: uint<2>, f2: flip<sint<1>>>>) {
+firrtl.module @bundle1(in %a : !firrtl.bundle<f1: uint<1>, f2: flip<sint<2>>>, out %b : !firrtl.bundle<f1: uint<2>, f2: flip<sint<1>>>) {
   // CHECK: firrtl.connect %b, %a
-  firrtl.connect %b, %a : !firrtl.flip<bundle<f1: uint<2>, f2: flip<sint<1>>>>, !firrtl.bundle<f1: uint<1>, f2: flip<sint<2>>>
+  firrtl.connect %b, %a : !firrtl.bundle<f1: uint<2>, f2: flip<sint<1>>>, !firrtl.bundle<f1: uint<1>, f2: flip<sint<2>>>
 }
 
 /// Destination bitwidth must be greater than or equal to source bitwidth.
-firrtl.module @bitwidth(%a : !firrtl.uint<1>, %b : !firrtl.flip<uint<2>>) {
+firrtl.module @bitwidth(in %a : !firrtl.uint<1>, out %b : !firrtl.uint<2>) {
   // CHECK: firrtl.connect %b, %a
-  firrtl.connect %b, %a : !firrtl.flip<uint<2>>, !firrtl.uint<1>
+  firrtl.connect %b, %a : !firrtl.uint<2>, !firrtl.uint<1>
 }
 
 /// Partial connects may truncate.
-firrtl.module @partial_bitwidth(%a : !firrtl.uint<2>, %b : !firrtl.flip<uint<1>>) {
+firrtl.module @partial_bitwidth(in %a : !firrtl.uint<2>, out %b : !firrtl.uint<1>) {
   // CHECK: firrtl.partialconnect %b, %a
-  firrtl.partialconnect %b, %a : !firrtl.flip<uint<1>>, !firrtl.uint<2>
+  firrtl.partialconnect %b, %a : !firrtl.uint<1>, !firrtl.uint<2>
 }
 
-firrtl.module @wires0(%in : !firrtl.uint<1>, %out : !firrtl.flip<uint<1>>) {
+firrtl.module @wires0(in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
   %w = firrtl.wire : !firrtl.uint<1>
   // CHECK: firrtl.connect %w, %in : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.connect %out, %w : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK: firrtl.connect %out, %w : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %w, %in : !firrtl.uint<1>, !firrtl.uint<1>
-  firrtl.connect %out, %w : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %out, %w : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
-firrtl.module @wires1(%in : !firrtl.uint<1>, %out : !firrtl.flip<uint<1>>) {
+firrtl.module @wires1(in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
   %wf = firrtl.wire : !firrtl.uint<1>
   // CHECK: firrtl.connect %wf, %in : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.connect %out, %wf : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK: firrtl.connect %out, %wf : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %wf, %in : !firrtl.uint<1>, !firrtl.uint<1>
-  firrtl.connect %out, %wf : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %out, %wf : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
 firrtl.module @wires2() {
@@ -116,31 +116,31 @@ firrtl.module @wires2() {
   firrtl.connect %w0, %w1 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
-firrtl.module @wires3(%out : !firrtl.flip<uint<1>>) {
+firrtl.module @wires3(out %out : !firrtl.uint<1>) {
   %wf = firrtl.wire : !firrtl.uint<1>
   // check that we can read from an output port
   // CHECK: firrtl.connect %wf, %out
-  firrtl.connect %wf, %out : !firrtl.uint<1>, !firrtl.flip<uint<1>>
+  firrtl.connect %wf, %out : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
-firrtl.module @wires4(%in : !firrtl.uint<1>, %out : !firrtl.flip<uint<1>>) {
+firrtl.module @wires4(in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
   %w = firrtl.wire : !firrtl.bundle<a: uint<1>>
   %0 = firrtl.subfield %w("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
   // CHECK: firrtl.connect %0, %in : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.connect %out, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK: firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %0, %in : !firrtl.uint<1>, !firrtl.uint<1>
-  firrtl.connect %out, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
-firrtl.module @registers0(%clock : !firrtl.clock, %in : !firrtl.uint<1>, %out : !firrtl.flip<uint<1>>) {
+firrtl.module @registers0(in %clock : !firrtl.clock, in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
   %0 = firrtl.reg %clock : (!firrtl.clock) -> !firrtl.uint<1>
   // CHECK: firrtl.connect %0, %in : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.connect %out, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK: firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %0, %in : !firrtl.uint<1>, !firrtl.uint<1>
-  firrtl.connect %out, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
-firrtl.module @registers1(%clock : !firrtl.clock) {
+firrtl.module @registers1(in %clock : !firrtl.clock) {
   %0 = firrtl.reg %clock : (!firrtl.clock) -> !firrtl.uint<1>
   %1 = firrtl.reg %clock : (!firrtl.clock) -> !firrtl.uint<1>
   // CHECK: firrtl.connect %0, %1

--- a/test/Dialect/FIRRTL/const-prop-single-module.mlir
+++ b/test/Dialect/FIRRTL/const-prop-single-module.mlir
@@ -10,10 +10,10 @@ firrtl.module @ConstantPropagationSingleModule() {}
 
 
 // The rule x >= 0 should always be true if x is a UInt
-firrtl.module @Top01(%x: !firrtl.uint<5>, %y: !firrtl.flip<uint<1>>) {
+firrtl.module @Top01(in %x: !firrtl.uint<5>, out %y: !firrtl.uint<1>) {
   %c0_ui = firrtl.constant(0 : ui64) : !firrtl.uint
   %0 = firrtl.geq %x, %c0_ui : (!firrtl.uint<5>, !firrtl.uint) -> !firrtl.uint<1>
-  firrtl.connect %y, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top01
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant(true)
@@ -21,10 +21,10 @@ firrtl.module @Top01(%x: !firrtl.uint<5>, %y: !firrtl.flip<uint<1>>) {
 
 
 // The rule x < 0 should never be true if x is a UInt
-firrtl.module @Top02(%x: !firrtl.uint<5>, %y: !firrtl.flip<uint<1>>) {
+firrtl.module @Top02(in %x: !firrtl.uint<5>, out %y: !firrtl.uint<1>) {
   %c0_ui = firrtl.constant(0 : ui64) : !firrtl.uint
   %0 = firrtl.lt %x, %c0_ui : (!firrtl.uint<5>, !firrtl.uint) -> !firrtl.uint<1>
-  firrtl.connect %y, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top02
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant(false)
@@ -32,10 +32,10 @@ firrtl.module @Top02(%x: !firrtl.uint<5>, %y: !firrtl.flip<uint<1>>) {
 
 
 // The rule 0 <= x should always be true if x is a UInt
-firrtl.module @Top03(%x: !firrtl.uint<5>, %y: !firrtl.flip<uint<1>>) {
+firrtl.module @Top03(in %x: !firrtl.uint<5>, out %y: !firrtl.uint<1>) {
   %c0_ui = firrtl.constant(0 : ui64) : !firrtl.uint
   %0 = firrtl.leq %c0_ui, %x : (!firrtl.uint, !firrtl.uint<5>) -> !firrtl.uint<1>
-  firrtl.connect %y, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top03
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant(true)
@@ -43,10 +43,10 @@ firrtl.module @Top03(%x: !firrtl.uint<5>, %y: !firrtl.flip<uint<1>>) {
 
 
 // The rule 0 > x should never be true if x is a UInt
-firrtl.module @Top04(%x: !firrtl.uint<5>, %y: !firrtl.flip<uint<1>>) {
+firrtl.module @Top04(in %x: !firrtl.uint<5>, out %y: !firrtl.uint<1>) {
   %c0_ui = firrtl.constant(0 : ui64) : !firrtl.uint
   %0 = firrtl.gt %c0_ui, %x : (!firrtl.uint, !firrtl.uint<5>) -> !firrtl.uint<1>
-  firrtl.connect %y, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top04
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant(false)
@@ -54,11 +54,11 @@ firrtl.module @Top04(%x: !firrtl.uint<5>, %y: !firrtl.flip<uint<1>>) {
 
 
 // The rule 1 < 3 should always be true
-firrtl.module @Top05(%y: !firrtl.flip<uint<1>>) {
+firrtl.module @Top05(out %y: !firrtl.uint<1>) {
   %c1_ui = firrtl.constant(1 : ui4) : !firrtl.uint
   %c3_ui = firrtl.constant(3 : ui4) : !firrtl.uint
   %0 = firrtl.lt %c1_ui, %c3_ui : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
-  firrtl.connect %y, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top05
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant(true)
@@ -66,10 +66,10 @@ firrtl.module @Top05(%y: !firrtl.flip<uint<1>>) {
 
 
 // The rule x < 8 should always be true if x only has 3 bits
-firrtl.module @Top06(%x: !firrtl.uint<3>, %y: !firrtl.flip<uint<1>>) {
+firrtl.module @Top06(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
   %c8_ui = firrtl.constant(8 : ui5) : !firrtl.uint
   %0 = firrtl.lt %x, %c8_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
-  firrtl.connect %y, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top06
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant(true)
@@ -77,10 +77,10 @@ firrtl.module @Top06(%x: !firrtl.uint<3>, %y: !firrtl.flip<uint<1>>) {
 
 
 // The rule x <= 7 should always be true if x only has 3 bits
-firrtl.module @Top07(%x: !firrtl.uint<3>, %y: !firrtl.flip<uint<1>>) {
+firrtl.module @Top07(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
   %c7_ui = firrtl.constant(7 : ui4) : !firrtl.uint
   %0 = firrtl.leq %x, %c7_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
-  firrtl.connect %y, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top07
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant(true)
@@ -88,10 +88,10 @@ firrtl.module @Top07(%x: !firrtl.uint<3>, %y: !firrtl.flip<uint<1>>) {
 
 
 // The rule 8 > x should always be true if x only has 3 bits
-firrtl.module @Top08(%x: !firrtl.uint<3>, %y: !firrtl.flip<uint<1>>) {
+firrtl.module @Top08(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
   %c8_ui = firrtl.constant(8 : ui5) : !firrtl.uint
   %0 = firrtl.gt %c8_ui, %x : (!firrtl.uint, !firrtl.uint<3>) -> !firrtl.uint<1>
-  firrtl.connect %y, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top08
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant(true)
@@ -99,10 +99,10 @@ firrtl.module @Top08(%x: !firrtl.uint<3>, %y: !firrtl.flip<uint<1>>) {
 
 
 // The rule 7 >= x should always be true if x only has 3 bits
-firrtl.module @Top09(%x: !firrtl.uint<3>, %y: !firrtl.flip<uint<1>>) {
+firrtl.module @Top09(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
   %c7_ui = firrtl.constant(7 : ui4) : !firrtl.uint
   %0 = firrtl.geq %c7_ui, %x : (!firrtl.uint, !firrtl.uint<3>) -> !firrtl.uint<1>
-  firrtl.connect %y, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top09
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant(true)
@@ -110,10 +110,10 @@ firrtl.module @Top09(%x: !firrtl.uint<3>, %y: !firrtl.flip<uint<1>>) {
 
 
 // The rule 10 == 10 should always be true
-firrtl.module @Top10(%y: !firrtl.flip<uint<1>>) {
+firrtl.module @Top10(out %y: !firrtl.uint<1>) {
   %c10_ui = firrtl.constant(10 : ui8) : !firrtl.uint
   %0 = firrtl.eq %c10_ui, %c10_ui : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
-  firrtl.connect %y, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top10
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant(true)
@@ -121,9 +121,9 @@ firrtl.module @Top10(%y: !firrtl.flip<uint<1>>) {
 
 
 // The rule x == z should not be true even if they have the same number of bits
-firrtl.module @Top11(%x: !firrtl.uint<3>, %z: !firrtl.uint<3>, %y: !firrtl.flip<uint<1>>) {
+firrtl.module @Top11(in %x: !firrtl.uint<3>, in %z: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
   %0 = firrtl.eq %x, %z : (!firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<1>
-  firrtl.connect %y, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top11
 // CHECK-NEXT: %[[K:.+]] = firrtl.eq %x, %z
@@ -131,10 +131,10 @@ firrtl.module @Top11(%x: !firrtl.uint<3>, %z: !firrtl.uint<3>, %y: !firrtl.flip<
 
 
 // The rule 10 != 10 should always be false
-firrtl.module @Top12(%y: !firrtl.flip<uint<1>>) {
+firrtl.module @Top12(out %y: !firrtl.uint<1>) {
   %c10_ui = firrtl.constant(10 : ui8) : !firrtl.uint
   %0 = firrtl.neq %c10_ui, %c10_ui : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
-  firrtl.connect %y, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top12
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant(false)
@@ -142,11 +142,11 @@ firrtl.module @Top12(%y: !firrtl.flip<uint<1>>) {
 
 
 // The rule 1 >= 3 should always be false
-firrtl.module @Top13(%y: !firrtl.flip<uint<1>>) {
+firrtl.module @Top13(out %y: !firrtl.uint<1>) {
   %c1_ui = firrtl.constant(1 : ui4) : !firrtl.uint
   %c3_ui = firrtl.constant(3 : ui4) : !firrtl.uint
   %0 = firrtl.geq %c1_ui, %c3_ui : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
-  firrtl.connect %y, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top13
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant(false)
@@ -154,10 +154,10 @@ firrtl.module @Top13(%y: !firrtl.flip<uint<1>>) {
 
 
 // The rule x >= 8 should never be true if x only has 3 bits
-firrtl.module @Top14(%x: !firrtl.uint<3>, %y: !firrtl.flip<uint<1>>) {
+firrtl.module @Top14(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
   %c8_ui = firrtl.constant(8 : ui5) : !firrtl.uint
   %0 = firrtl.geq %x, %c8_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
-  firrtl.connect %y, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top14
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant(false)
@@ -165,10 +165,10 @@ firrtl.module @Top14(%x: !firrtl.uint<3>, %y: !firrtl.flip<uint<1>>) {
 
 
 // The rule x > 7 should never be true if x only has 3 bits
-firrtl.module @Top15(%x: !firrtl.uint<3>, %y: !firrtl.flip<uint<1>>) {
+firrtl.module @Top15(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
   %c7_ui = firrtl.constant(7 : ui4) : !firrtl.uint
   %0 = firrtl.gt %x, %c7_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
-  firrtl.connect %y, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top15
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant(false)
@@ -176,10 +176,10 @@ firrtl.module @Top15(%x: !firrtl.uint<3>, %y: !firrtl.flip<uint<1>>) {
 
 
 // The rule 8 <= x should never be true if x only has 3 bits
-firrtl.module @Top16(%x: !firrtl.uint<3>, %y: !firrtl.flip<uint<1>>) {
+firrtl.module @Top16(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
   %c8_ui = firrtl.constant(8 : ui5) : !firrtl.uint
   %0 = firrtl.leq %c8_ui, %x : (!firrtl.uint, !firrtl.uint<3>) -> !firrtl.uint<1>
-  firrtl.connect %y, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top16
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant(false)
@@ -187,10 +187,10 @@ firrtl.module @Top16(%x: !firrtl.uint<3>, %y: !firrtl.flip<uint<1>>) {
 
 
 // The rule 7 < x should never be true if x only has 3 bits
-firrtl.module @Top17(%x: !firrtl.uint<3>, %y: !firrtl.flip<uint<1>>) {
+firrtl.module @Top17(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
   %c7_ui = firrtl.constant(7 : ui4) : !firrtl.uint
   %0 = firrtl.lt %c7_ui, %x : (!firrtl.uint, !firrtl.uint<3>) -> !firrtl.uint<1>
-  firrtl.connect %y, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top17
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant(false)

--- a/test/Dialect/FIRRTL/cse.mlir
+++ b/test/Dialect/FIRRTL/cse.mlir
@@ -3,19 +3,19 @@
 firrtl.circuit "And" {
 
 // CHECK-LABEL: firrtl.module @And
-firrtl.module @And(%in1: !firrtl.uint<4>, %in2: !firrtl.uint<4>,
-                   %out1: !firrtl.flip<uint<4>>,
-                   %out2: !firrtl.flip<uint<4>>) {
+firrtl.module @And(in %in1: !firrtl.uint<4>, in %in2: !firrtl.uint<4>,
+                   out %out1: !firrtl.uint<4>,
+                   out %out2: !firrtl.uint<4>) {
   // And operations should get CSE'd.
 
   // CHECK: %0 = firrtl.and %in1, %in2
   %0 = firrtl.and %in1, %in2 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   // CHECK-NEXT: firrtl.connect %out1, %0
-  firrtl.connect %out1, %0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out1, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK-NEXT: firrtl.connect %out2, %0
   %1 = firrtl.and %in1, %in2 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  firrtl.connect %out2, %1 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out2, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 }
 
 // CHECK-LABEL: firrtl.module @Wire

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -2,7 +2,7 @@
 
 firrtl.circuit "X" {
 
-firrtl.module @X(%b : !firrtl.unknowntype) {
+firrtl.module @X(in %b : !firrtl.unknowntype) {
   // expected-error @-1 {{unknown firrtl type}}
 }
 
@@ -12,7 +12,7 @@ firrtl.module @X(%b : !firrtl.unknowntype) {
 
 firrtl.circuit "X" {
 
-firrtl.module @X(%b : !firrtl.uint<32>, %d : !firrtl.uint<16>, %out : !firrtl.uint) {
+firrtl.module @X(in %b : !firrtl.uint<32>, in %d : !firrtl.uint<16>, in %out : !firrtl.uint) {
   // expected-error @+1 {{'firrtl.add' op expected 2 operands, but found 3}}
   %3 = "firrtl.add"(%b, %d, %out) : (!firrtl.uint<32>, !firrtl.uint<16>, !firrtl.uint) -> !firrtl.uint<32>
 }
@@ -53,7 +53,7 @@ firrtl.circuit "" {
 // -----
 
 firrtl.circuit "Foo" {
-  firrtl.module @Foo(%clk: !firrtl.uint<1>, %reset: !firrtl.uint<1>) {
+  firrtl.module @Foo(in %clk: !firrtl.uint<1>, in %reset: !firrtl.uint<1>) {
     // expected-error @+1 {{'firrtl.reg' op operand #0 must be clock, but got '!firrtl.uint<1>'}}
     %a = firrtl.reg %clk {name = "a"} : (!firrtl.uint<1>) -> !firrtl.uint<1>
   }
@@ -62,7 +62,7 @@ firrtl.circuit "Foo" {
 // -----
 
 firrtl.circuit "Foo" {
-  firrtl.module @Foo(%clk: !firrtl.uint<1>, %reset: !firrtl.uint<1>) {
+  firrtl.module @Foo(in %clk: !firrtl.uint<1>, in %reset: !firrtl.uint<1>) {
     %zero = firrtl.constant(0 : ui1) : !firrtl.uint<1>
     // expected-error @+1 {{'firrtl.regreset' op operand #0 must be clock, but got '!firrtl.uint<1>'}}
     %a = firrtl.regreset %clk, %reset, %zero {name = "a"} : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
@@ -72,7 +72,7 @@ firrtl.circuit "Foo" {
 // -----
 
 firrtl.circuit "Foo" {
-  firrtl.module @Foo(%clk: !firrtl.clock, %reset: !firrtl.uint<2>) {
+  firrtl.module @Foo(in %clk: !firrtl.clock, in %reset: !firrtl.uint<2>) {
     %zero = firrtl.constant(0 : ui1) : !firrtl.uint<1>
     // expected-error @+1 {{'firrtl.regreset' op operand #1 must be Reset, but got '!firrtl.uint<2>'}}
     %a = firrtl.regreset %clk, %reset, %zero {name = "a"} : (!firrtl.clock, !firrtl.uint<2>, !firrtl.uint<1>) -> !firrtl.uint<1>
@@ -92,7 +92,7 @@ firrtl.circuit "Foo" {
 // -----
 
 firrtl.circuit "Foo" {
-  firrtl.module @Foo(%clk: !firrtl.clock) {
+  firrtl.module @Foo(in %clk: !firrtl.clock) {
     // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive type (contain no flips)}}
     %a = firrtl.reg %clk {name = "a"} : (!firrtl.clock) -> !firrtl.flip<uint<1>>
   }
@@ -101,7 +101,7 @@ firrtl.circuit "Foo" {
 // -----
 
 firrtl.circuit "Foo" {
-  firrtl.module @Foo(%clk: !firrtl.clock, %reset: !firrtl.uint<1>) {
+  firrtl.module @Foo(in %clk: !firrtl.clock, in %reset: !firrtl.uint<1>) {
     %zero = firrtl.constant(0 : ui1) : !firrtl.uint<1>
     // expected-error @+1 {{'firrtl.regreset' op result #0 must be a passive type (contain no flips)}}
     %a = firrtl.regreset %clk, %reset, %zero {name = "a"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.flip<uint<1>>
@@ -126,7 +126,7 @@ firrtl.circuit "Foo" {
 firrtl.circuit "Foo" {
 
   // expected-note @+1 {{previous extmodule definition occurred here}}
-  firrtl.extmodule @Foo(%a : !firrtl.uint<1>) attributes { defname = "Foo" }
+  firrtl.extmodule @Foo(in %a : !firrtl.uint<1>) attributes { defname = "Foo" }
   // expected-error @+1 {{'firrtl.extmodule' op with 'defname' attribute "Foo" has 0 ports which is different from a previously defined extmodule with the same 'defname' which has 1 ports}}
   firrtl.extmodule @Bar() attributes { defname = "Foo" }
 
@@ -137,9 +137,9 @@ firrtl.circuit "Foo" {
 firrtl.circuit "Foo" {
 
   // expected-note @+1 {{previous extmodule definition occurred here}}
-  firrtl.extmodule @Foo(%a : !firrtl.uint<1>) attributes { defname = "Foo" }
+  firrtl.extmodule @Foo(in %a : !firrtl.uint<1>) attributes { defname = "Foo" }
   // expected-error @+1 {{'firrtl.extmodule' op with 'defname' attribute "Foo" has a port with name "b" which does not match the name of the port in the same position of a previously defined extmodule with the same 'defname', expected port to have name "a"}}
-  firrtl.extmodule @Foo_(%b : !firrtl.uint<1>) attributes { defname = "Foo" }
+  firrtl.extmodule @Foo_(in %b : !firrtl.uint<1>) attributes { defname = "Foo" }
 
 }
 
@@ -147,11 +147,11 @@ firrtl.circuit "Foo" {
 
 firrtl.circuit "Foo" {
 
-  firrtl.extmodule @Foo(%a : !firrtl.uint<2>) attributes { defname = "Foo", parameters = { width = 2 : i32 } }
+  firrtl.extmodule @Foo(in %a : !firrtl.uint<2>) attributes { defname = "Foo", parameters = { width = 2 : i32 } }
   // expected-note @+1 {{previous extmodule definition occurred here}}
-  firrtl.extmodule @Bar(%a : !firrtl.uint<1>) attributes { defname = "Foo" }
+  firrtl.extmodule @Bar(in %a : !firrtl.uint<1>) attributes { defname = "Foo" }
   // expected-error @+1 {{'firrtl.extmodule' op with 'defname' attribute "Foo" has a port with name "a" which has a different type '!firrtl.uint<2>' which does not match the type of the port in the same position of a previously defined extmodule with the same 'defname', expected port to have type '!firrtl.uint<1>'}}
-  firrtl.extmodule @Baz(%a : !firrtl.uint<2>) attributes { defname = "Foo" }
+  firrtl.extmodule @Baz(in %a : !firrtl.uint<2>) attributes { defname = "Foo" }
 
 }
 
@@ -160,9 +160,9 @@ firrtl.circuit "Foo" {
 firrtl.circuit "Foo" {
 
   // expected-note @+1 {{previous extmodule definition occurred here}}
-  firrtl.extmodule @Foo(%a : !firrtl.uint<1>) attributes { defname = "Foo" }
+  firrtl.extmodule @Foo(in %a : !firrtl.uint<1>) attributes { defname = "Foo" }
   // expected-error @+1 {{'firrtl.extmodule' op with 'defname' attribute "Foo" has a port with name "a" which has a different type '!firrtl.sint<1>' which does not match the type of the port in the same position of a previously defined extmodule with the same 'defname', expected port to have type '!firrtl.uint<1>'}}
-  firrtl.extmodule @Foo_(%a : !firrtl.sint<1>) attributes { defname = "Foo" }
+  firrtl.extmodule @Foo_(in %a : !firrtl.sint<1>) attributes { defname = "Foo" }
 
 }
 
@@ -171,9 +171,9 @@ firrtl.circuit "Foo" {
 firrtl.circuit "Foo" {
 
   // expected-note @+1 {{previous extmodule definition occurred here}}
-  firrtl.extmodule @Foo(%a : !firrtl.uint<2>) attributes { defname = "Foo", parameters = { width = 2 : i32 } }
+  firrtl.extmodule @Foo(in %a : !firrtl.uint<2>) attributes { defname = "Foo", parameters = { width = 2 : i32 } }
   // expected-error @+1 {{'firrtl.extmodule' op with 'defname' attribute "Foo" has a port with name "a" which has a different type '!firrtl.sint' which does not match the type of the port in the same position of a previously defined extmodule with the same 'defname', expected port to have type '!firrtl.uint'}}
-  firrtl.extmodule @Bar(%a : !firrtl.sint<1>) attributes { defname = "Foo" }
+  firrtl.extmodule @Bar(in %a : !firrtl.sint<1>) attributes { defname = "Foo" }
 
 }
 
@@ -182,7 +182,7 @@ firrtl.circuit "Foo" {
 firrtl.circuit "Foo" {
 
   // expected-error @+1 {{has unknown extmodule parameter value 'width' = @Foo}}
-  firrtl.extmodule @Foo(%a : !firrtl.uint<2>) attributes { defname = "Foo", parameters = { width = @Foo } }
+  firrtl.extmodule @Foo(in %a : !firrtl.uint<2>) attributes { defname = "Foo", parameters = { width = @Foo } }
 
 }
 
@@ -213,7 +213,7 @@ firrtl.circuit "Foo" {
 firrtl.circuit "Foo" {
 
   // expected-note @+1 {{original module declared here}}
-  firrtl.module @Callee(%arg0: !firrtl.uint<1>) { }
+  firrtl.module @Callee(in %arg0: !firrtl.uint<1>) { }
   firrtl.module @Foo() {
     // expected-error @+1 {{'firrtl.instance' op result type for "arg0" must be '!firrtl.flip<uint<1>>', but got '!firrtl.uint<2>'}}
     %a = firrtl.instance @Callee {name = ""} : !firrtl.uint<2>
@@ -225,7 +225,7 @@ firrtl.circuit "Foo" {
 firrtl.circuit "Foo" {
 
   // expected-note @+1 {{original module declared here}}
-  firrtl.module @Callee(%arg0: !firrtl.uint<1> ) { }
+  firrtl.module @Callee(in %arg0: !firrtl.uint<1> ) { }
   firrtl.module @Foo() {
     // expected-error @+1 {{'firrtl.instance' op has a wrong number of results; expected 1 but got 0}}
     firrtl.instance @Callee {name = ""}
@@ -237,7 +237,7 @@ firrtl.circuit "Foo" {
 firrtl.circuit "Foo" {
 
   // expected-note @+1 {{original module declared here}}
-  firrtl.module @Callee(%arg0: !firrtl.uint<1>, %arg1: !firrtl.bundle<valid: uint<1>>) { }
+  firrtl.module @Callee(in %arg0: !firrtl.uint<1>, in %arg1: !firrtl.bundle<valid: uint<1>>) { }
   firrtl.module @Foo() {
     // expected-error @+1 {{'firrtl.instance' op result type for "arg0" must be '!firrtl.flip<uint<1>>', but got '!firrtl.uint<1>'}}
     %a:2 = firrtl.instance @Callee {name = ""}
@@ -249,7 +249,7 @@ firrtl.circuit "Foo" {
 
 firrtl.circuit "X" {
 
-firrtl.module @X(%a : !firrtl.uint<4>) {
+firrtl.module @X(in %a : !firrtl.uint<4>) {
   // expected-error @+1 {{high must be equal or greater than low, but got high = 3, low = 4}}
   %0 = firrtl.bits %a 3 to 4 : (!firrtl.uint<4>) -> !firrtl.uint<2>
 }
@@ -260,7 +260,7 @@ firrtl.module @X(%a : !firrtl.uint<4>) {
 
 firrtl.circuit "X" {
 
-firrtl.module @X(%a : !firrtl.uint<4>) {
+firrtl.module @X(in %a : !firrtl.uint<4>) {
   // expected-error @+1 {{high must be smaller than the width of input, but got high = 4, width = 4}}
   %0 = firrtl.bits %a 4 to 3 : (!firrtl.uint<4>) -> !firrtl.uint<2>
 }
@@ -271,7 +271,7 @@ firrtl.module @X(%a : !firrtl.uint<4>) {
 
 firrtl.circuit "X" {
 
-firrtl.module @X(%a : !firrtl.uint<4>) {
+firrtl.module @X(in %a : !firrtl.uint<4>) {
   // expected-error @+1 {{'firrtl.bits' op result type should be '!firrtl.uint<3>'}}
   %0 = firrtl.bits %a 3 to 1 : (!firrtl.uint<4>) -> !firrtl.uint<2>
 }
@@ -282,14 +282,14 @@ firrtl.module @X(%a : !firrtl.uint<4>) {
 
 firrtl.circuit "BadPort" {
   // expected-error @+1 {{'firrtl.module' op all module ports must be firrtl types}}
-  firrtl.module @BadPort(%in1 : i1) {
+  firrtl.module @BadPort(in %in1 : i1) {
   }
 }
 
 // -----
 
 firrtl.circuit "BadPort" {
-  firrtl.module @BadPort(%a : !firrtl.uint<1>) {
+  firrtl.module @BadPort(in %a : !firrtl.uint<1>) {
     // expected-error @+1 {{'firrtl.attach' op operand #0 must be analog type, but got '!firrtl.uint<1>'}}
     firrtl.attach %a, %a : !firrtl.uint<1>, !firrtl.uint<1>
   }
@@ -298,7 +298,7 @@ firrtl.circuit "BadPort" {
 // -----
 
 firrtl.circuit "BadAdd" {
-  firrtl.module @BadAdd(%a : !firrtl.uint<1>) {
+  firrtl.module @BadAdd(in %a : !firrtl.uint<1>) {
     // expected-error @+1 {{'firrtl.add' op result type should be '!firrtl.uint<2>'}}
     firrtl.add %a, %a : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   }
@@ -307,7 +307,9 @@ firrtl.circuit "BadAdd" {
 // -----
 
 firrtl.circuit "NodeMustBePassive" {
-  firrtl.module @NodeMustBePassive(%a: !firrtl.flip<uint<1>>) {
+  firrtl.module @Sub(in %a: !firrtl.uint<1>) {}
+  firrtl.module @NodeMustBePassive() {
+    %a = firrtl.instance @Sub {name = "sub"} : !firrtl.flip<uint<1>>
     // expected-error @+1 {{'firrtl.node' op operand #0 must be a passive type}}
     %b = firrtl.node %a  : !firrtl.flip<uint<1>>
   }
@@ -346,7 +348,7 @@ firrtl.circuit "StructCast3" {
 // -----
 
 firrtl.circuit "OutOfOrder" {
-  firrtl.module @OutOfOrder(%a: !firrtl.uint<32>) {
+  firrtl.module @OutOfOrder(in %a: !firrtl.uint<32>) {
     // expected-error @+1 {{operand #0 does not dominate this use}}
     %0 = firrtl.add %1, %1 : (!firrtl.uint<33>, !firrtl.uint<33>) -> !firrtl.uint<34>
     // expected-note @+1 {{operand defined here}}

--- a/test/Dialect/FIRRTL/expand-whens-errors.mlir
+++ b/test/Dialect/FIRRTL/expand-whens-errors.mlir
@@ -2,14 +2,14 @@
 
 firrtl.circuit "simple" {
 
-firrtl.module @simple(%in : !firrtl.uint<1>, %out : !firrtl.flip<uint<1>>) {
-    firrtl.connect %out, %in : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+firrtl.module @simple(in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
+    firrtl.connect %out, %in : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
 // This test is checking each kind of declaration to ensure that it is caught
 // by the initialization coverage check. This is also testing that we can emit
 // all errors in a module at once.
-firrtl.module @CheckInitialization(%clock : !firrtl.clock, %en : !firrtl.uint<1>, %p : !firrtl.uint<1>, %out : !firrtl.flip<uint<2>>) {
+firrtl.module @CheckInitialization(in %clock : !firrtl.clock, in %en : !firrtl.uint<1>, in %p : !firrtl.uint<1>, out %out : !firrtl.uint<2>) {
   // expected-error @-1 {{module port "out" not fully initialized}}
   // expected-error @+1 {{sink not fully initialized}}
   %w = firrtl.wire : !firrtl.uint<2>
@@ -22,7 +22,7 @@ firrtl.module @CheckInitialization(%clock : !firrtl.clock, %en : !firrtl.uint<1>
 
 firrtl.circuit "declaration_in_when" {
 // Check that wires declared inside of a when are detected as uninitialized.
-firrtl.module @declaration_in_when(%p : !firrtl.uint<1>) {
+firrtl.module @declaration_in_when(in %p : !firrtl.uint<1>) {
   firrtl.when %p {
     // expected-error @+1 {{sink not fully initialized}}
     %w_then = firrtl.wire : !firrtl.uint<2>
@@ -38,7 +38,7 @@ firrtl.module @declaration_in_when(%p : !firrtl.uint<1>) {
 firrtl.circuit "complex" {
 // Test that a wire set across separate when statements is detected as not
 // completely initialized.
-firrtl.module @complex(%p : !firrtl.uint<1>, %q : !firrtl.uint<1>) {
+firrtl.module @complex(in %p : !firrtl.uint<1>, in %q : !firrtl.uint<1>) {
   // expected-error @+1 {{sink not fully initialized}}
   %w = firrtl.wire : !firrtl.uint<2>
 
@@ -55,4 +55,3 @@ firrtl.module @complex(%p : !firrtl.uint<1>, %q : !firrtl.uint<1>) {
 }
 
 }
-

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -3,35 +3,35 @@ firrtl.circuit "ExpandWhens" {
 firrtl.module @ExpandWhens () {}
 
 // Test that last connect semantics are resolved for connects.
-firrtl.module @shadow_connects(%out : !firrtl.flip<uint<1>>) {
+firrtl.module @shadow_connects(out %out : !firrtl.uint<1>) {
   %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
   %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
-  firrtl.connect %out, %c0_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.connect %out, %c1_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.connect %out, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %out, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
 }
-// CHECK-LABEL: firrtl.module @shadow_connects(%out: !firrtl.flip<uint<1>>) {
+// CHECK-LABEL: firrtl.module @shadow_connects(out %out: !firrtl.uint<1>) {
 // CHECK-NEXT:   %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
 // CHECK-NEXT:   %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
-// CHECK-NEXT:   firrtl.connect %out, %c1_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// CHECK-NEXT:   firrtl.connect %out, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT: }
 
 
 // Test that last connect semantics are resolved for partial connects.
-firrtl.module @shadow_partialconnects(%out : !firrtl.flip<uint<1>>) {
+firrtl.module @shadow_partialconnects(out %out : !firrtl.uint<1>) {
   %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
   %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
-  firrtl.partialconnect %out, %c0_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  firrtl.partialconnect %out, %c1_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  firrtl.partialconnect %out, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.partialconnect %out, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
 }
-// CHECK-LABEL: firrtl.module @shadow_partialconnects(%out: !firrtl.flip<uint<1>>) {
+// CHECK-LABEL: firrtl.module @shadow_partialconnects(out %out: !firrtl.uint<1>) {
 // CHECK-NEXT:   %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
 // CHECK-NEXT:   %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
-// CHECK-NEXT:   firrtl.partialconnect %out, %c1_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+// CHECK-NEXT:   firrtl.partialconnect %out, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT: }
 
 
 // Test that last connect semantics are resolved in a WhenOp
-firrtl.module @shadow_when(%p : !firrtl.uint<1>) {
+firrtl.module @shadow_when(in %p : !firrtl.uint<1>) {
   %c0_ui2 = firrtl.constant(0 : ui2) : !firrtl.uint<2>
   %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
   firrtl.when %p {
@@ -40,7 +40,7 @@ firrtl.module @shadow_when(%p : !firrtl.uint<1>) {
     firrtl.connect %w, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   }
 }
-// CHECK-LABEL: firrtl.module @shadow_when(%p: !firrtl.uint<1>) {
+// CHECK-LABEL: firrtl.module @shadow_when(in %p: !firrtl.uint<1>) {
 // CHECK-NEXT:   %c0_ui2 = firrtl.constant(0 : ui2) : !firrtl.uint<2>
 // CHECK-NEXT:   %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
 // CHECK-NEXT:   %w = firrtl.wire  : !firrtl.uint<2>
@@ -49,7 +49,7 @@ firrtl.module @shadow_when(%p : !firrtl.uint<1>) {
 
 
 // Test all simulation constructs
-firrtl.module @simulation(%clock : !firrtl.clock, %p : !firrtl.uint<1>, %enable : !firrtl.uint<1>, %reset : !firrtl.uint<1>) {
+firrtl.module @simulation(in %clock : !firrtl.clock, in %p : !firrtl.uint<1>, in %enable : !firrtl.uint<1>, in %reset : !firrtl.uint<1>) {
   firrtl.when %p {
     firrtl.printf %clock, %enable, "CIRCT Rocks!"
     firrtl.stop %clock, %enable, 0
@@ -64,7 +64,7 @@ firrtl.module @simulation(%clock : !firrtl.clock, %p : !firrtl.uint<1>, %enable 
     firrtl.cover %clock, %p, %enable, ""
   }
 }
-// CHECK-LABEL: firrtl.module @simulation(%clock: !firrtl.clock, %p: !firrtl.uint<1>, %enable: !firrtl.uint<1>, %reset: !firrtl.uint<1>) {
+// CHECK-LABEL: firrtl.module @simulation(in %clock: !firrtl.clock, in %p: !firrtl.uint<1>, in %enable: !firrtl.uint<1>, in %reset: !firrtl.uint<1>) {
 // CHECK-NEXT:   %0 = firrtl.and %p, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:   firrtl.printf %clock, %0, "CIRCT Rocks!"
 // CHECK-NEXT:   %1 = firrtl.and %p, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
@@ -90,14 +90,14 @@ firrtl.module @simulation(%clock : !firrtl.clock, %p : !firrtl.uint<1>, %enable 
 
 
 // Test nested when operations work correctly.
-firrtl.module @nested_whens(%clock : !firrtl.clock, %p0 : !firrtl.uint<1>, %p1 : !firrtl.uint<1>, %enable : !firrtl.uint<1>, %reset : !firrtl.uint<1>) {
+firrtl.module @nested_whens(in %clock : !firrtl.clock, in %p0 : !firrtl.uint<1>, in %p1 : !firrtl.uint<1>, in %enable : !firrtl.uint<1>, in %reset : !firrtl.uint<1>) {
   firrtl.when %p0 {
     firrtl.when %p1 {
       firrtl.printf %clock, %enable, "CIRCT Rocks!"
     }
   }
 }
-// CHECK-LABEL: firrtl.module @nested_whens(%clock: !firrtl.clock, %p0: !firrtl.uint<1>, %p1: !firrtl.uint<1>, %enable: !firrtl.uint<1>, %reset: !firrtl.uint<1>) {
+// CHECK-LABEL: firrtl.module @nested_whens(in %clock: !firrtl.clock, in %p0: !firrtl.uint<1>, in %p1: !firrtl.uint<1>, in %enable: !firrtl.uint<1>, in %reset: !firrtl.uint<1>) {
 // CHECK-NEXT:   %0 = firrtl.and %p0, %p1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:   %1 = firrtl.and %0, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:   firrtl.printf %clock, %1, "CIRCT Rocks!"
@@ -106,163 +106,163 @@ firrtl.module @nested_whens(%clock : !firrtl.clock, %p0 : !firrtl.uint<1>, %p1 :
 
 // Test that a parameter set in both sides of the connect is resolved. The value
 // used is local to each region.
-firrtl.module @set_in_both(%clock : !firrtl.clock, %p : !firrtl.uint<1>, %out : !firrtl.flip<uint<2>>) {
+firrtl.module @set_in_both(in %clock : !firrtl.clock, in %p : !firrtl.uint<1>, out %out : !firrtl.uint<2>) {
   firrtl.when %p {
     %c0_ui2 = firrtl.constant(0 : ui2) : !firrtl.uint<2>
-    firrtl.connect %out, %c0_ui2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+    firrtl.connect %out, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   } else {
     %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
-    firrtl.connect %out, %c1_ui2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+    firrtl.connect %out, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   }
 }
-// CHECK-LABEL: firrtl.module @set_in_both(%clock: !firrtl.clock, %p: !firrtl.uint<1>, %out: !firrtl.flip<uint<2>>) {
+// CHECK-LABEL: firrtl.module @set_in_both(in %clock: !firrtl.clock, in %p: !firrtl.uint<1>, out %out: !firrtl.uint<2>) {
 // CHECK-NEXT:   %c0_ui2 = firrtl.constant(0 : ui2) : !firrtl.uint<2>
 // CHECK-NEXT:   %0 = firrtl.not %p : (!firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:   %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
 // CHECK-NEXT:   %1 = firrtl.mux(%p, %c0_ui2, %c1_ui2) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
-// CHECK-NEXT:   firrtl.connect %out, %1 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+// CHECK-NEXT:   firrtl.connect %out, %1 : !firrtl.uint<2>, !firrtl.uint<2>
 // CHECK-NEXT: }
 
 
 // Test that a parameter set before a WhenOp, and then in both sides of the
 // WhenOp is resolved.
-firrtl.module @set_before_and_in_both(%clock : !firrtl.clock, %p : !firrtl.uint<1>, %out : !firrtl.flip<uint<2>>) {
+firrtl.module @set_before_and_in_both(in %clock : !firrtl.clock, in %p : !firrtl.uint<1>, out %out : !firrtl.uint<2>) {
   %c0_ui2 = firrtl.constant(0 : ui2) : !firrtl.uint<2>
   %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
   %c2_ui2 = firrtl.constant(2 : ui2) : !firrtl.uint<2>
-  firrtl.connect %out, %c2_ui2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+  firrtl.connect %out, %c2_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   firrtl.when %p {
-    firrtl.connect %out, %c0_ui2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+    firrtl.connect %out, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   } else {
-     firrtl.connect %out, %c1_ui2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+     firrtl.connect %out, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   }
 }
-// CHECK-LABEL: firrtl.module @set_before_and_in_both(%clock: !firrtl.clock, %p: !firrtl.uint<1>, %out: !firrtl.flip<uint<2>>) {
+// CHECK-LABEL: firrtl.module @set_before_and_in_both(in %clock: !firrtl.clock, in %p: !firrtl.uint<1>, out %out: !firrtl.uint<2>) {
 // CHECK-NEXT:   %c0_ui2 = firrtl.constant(0 : ui2) : !firrtl.uint<2>
 // CHECK-NEXT:   %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
 // CHECK-NEXT:   %c2_ui2 = firrtl.constant(2 : ui2) : !firrtl.uint<2>
 // CHECK-NEXT:   %0 = firrtl.not %p : (!firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:   %1 = firrtl.mux(%p, %c0_ui2, %c1_ui2) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
-// CHECK-NEXT:   firrtl.connect %out, %1 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
-// CHECK-NEXT: } 
+// CHECK-NEXT:   firrtl.connect %out, %1 : !firrtl.uint<2>, !firrtl.uint<2>
+// CHECK-NEXT: }
 
 
 // Test that a parameter set in a WhenOp is not the last connect.
-firrtl.module @set_after(%clock : !firrtl.clock, %p : !firrtl.uint<1>, %out : !firrtl.flip<uint<2>>) {
+firrtl.module @set_after(in %clock : !firrtl.clock, in %p : !firrtl.uint<1>, out %out : !firrtl.uint<2>) {
   %c0_ui2 = firrtl.constant(0 : ui2) : !firrtl.uint<2>
   %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
   %c2_ui2 = firrtl.constant(2 : ui2) : !firrtl.uint<2>
   firrtl.when %p {
-    firrtl.connect %out, %c0_ui2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+    firrtl.connect %out, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   } else {
-    firrtl.connect %out, %c1_ui2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+    firrtl.connect %out, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   }
-  firrtl.connect %out, %c2_ui2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+  firrtl.connect %out, %c2_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
 }
-// CHECK-LABEL: firrtl.module @set_after(%clock: !firrtl.clock, %p: !firrtl.uint<1>, %out: !firrtl.flip<uint<2>>) {
+// CHECK-LABEL: firrtl.module @set_after(in %clock: !firrtl.clock, in %p: !firrtl.uint<1>, out %out: !firrtl.uint<2>) {
 // CHECK-NEXT:   %c0_ui2 = firrtl.constant(0 : ui2) : !firrtl.uint<2>
 // CHECK-NEXT:   %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
 // CHECK-NEXT:   %c2_ui2 = firrtl.constant(2 : ui2) : !firrtl.uint<2>
 // CHECK-NEXT:   %0 = firrtl.not %p : (!firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:   %1 = firrtl.mux(%p, %c0_ui2, %c1_ui2) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
-// CHECK-NEXT:   firrtl.connect %out, %c2_ui2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+// CHECK-NEXT:   firrtl.connect %out, %c2_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
 // CHECK-NEXT: }
 
 
 // Test that wire written to in only the thenblock is resolved.
-firrtl.module @set_in_then0(%clock : !firrtl.clock, %p : !firrtl.uint<1>, %out : !firrtl.flip<uint<2>>) {
+firrtl.module @set_in_then0(in %clock : !firrtl.clock, in %p : !firrtl.uint<1>, out %out : !firrtl.uint<2>) {
   %c0_ui2 = firrtl.constant(0 : ui2) : !firrtl.uint<2>
   %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
-  firrtl.connect %out, %c0_ui2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+  firrtl.connect %out, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   firrtl.when %p {
-    firrtl.connect %out, %c1_ui2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+    firrtl.connect %out, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   }
 }
-// CHECK-LABEL: firrtl.module @set_in_then0(%clock: !firrtl.clock, %p: !firrtl.uint<1>, %out: !firrtl.flip<uint<2>>) {
+// CHECK-LABEL: firrtl.module @set_in_then0(in %clock: !firrtl.clock, in %p: !firrtl.uint<1>, out %out: !firrtl.uint<2>) {
 // CHECK-NEXT:   %c0_ui2 = firrtl.constant(0 : ui2) : !firrtl.uint<2>
 // CHECK-NEXT:   %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
 // CHECK-NEXT:   %0 = firrtl.mux(%p, %c1_ui2, %c0_ui2) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
-// CHECK-NEXT:   firrtl.connect %out, %0 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+// CHECK-NEXT:   firrtl.connect %out, %0 : !firrtl.uint<2>, !firrtl.uint<2>
 // CHECK-NEXT: }
 
 
 // Test that wire written to in only the then block is resolved.
-firrtl.module @set_in_then1(%clock : !firrtl.clock, %p : !firrtl.uint<1>, %out : !firrtl.flip<uint<2>>) {
+firrtl.module @set_in_then1(in %clock : !firrtl.clock, in %p : !firrtl.uint<1>, out %out : !firrtl.uint<2>) {
   %c0_ui2 = firrtl.constant(0 : ui2) : !firrtl.uint<2>
   %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
   firrtl.when %p {
-    firrtl.connect %out, %c1_ui2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+    firrtl.connect %out, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   }
-  firrtl.connect %out, %c0_ui2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+  firrtl.connect %out, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
 }
-// CHECK-LABEL: firrtl.module @set_in_then1(%clock: !firrtl.clock, %p: !firrtl.uint<1>, %out: !firrtl.flip<uint<2>>) {
+// CHECK-LABEL: firrtl.module @set_in_then1(in %clock: !firrtl.clock, in %p: !firrtl.uint<1>, out %out: !firrtl.uint<2>) {
 // CHECK-NEXT:   %c0_ui2 = firrtl.constant(0 : ui2) : !firrtl.uint<2>
 // CHECK-NEXT:   %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
-// CHECK-NEXT:   firrtl.connect %out, %c0_ui2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+// CHECK-NEXT:   firrtl.connect %out, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
 // CHECK-NEXT: }
 
 
 // Test that wire written to in only the else is resolved.
-firrtl.module @set_in_else0(%p : !firrtl.uint<1>, %out : !firrtl.flip<uint<2>>) {
+firrtl.module @set_in_else0(in %p : !firrtl.uint<1>, out %out : !firrtl.uint<2>) {
   %c0_ui2 = firrtl.constant(0 : ui2) : !firrtl.uint<2>
   %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
-  firrtl.connect %out, %c0_ui2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+  firrtl.connect %out, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   firrtl.when %p {
   } else {
-    firrtl.connect %out, %c1_ui2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+    firrtl.connect %out, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   }
 }
-// CHECK-LABEL: firrtl.module @set_in_else0(%p: !firrtl.uint<1>, %out: !firrtl.flip<uint<2>>) {
+// CHECK-LABEL: firrtl.module @set_in_else0(in %p: !firrtl.uint<1>, out %out: !firrtl.uint<2>) {
 // CHECK-NEXT:   %c0_ui2 = firrtl.constant(0 : ui2) : !firrtl.uint<2>
 // CHECK-NEXT:   %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
 // CHECK-NEXT:   %0 = firrtl.not %p : (!firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:   %1 = firrtl.mux(%p, %c0_ui2, %c1_ui2) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
-// CHECK-NEXT:   firrtl.connect %out, %1 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+// CHECK-NEXT:   firrtl.connect %out, %1 : !firrtl.uint<2>, !firrtl.uint<2>
 // CHECK-NEXT: }
 
 
 // Test that wire written to in only the else block is resolved.
-firrtl.module @set_in_else1(%clock : !firrtl.clock, %p : !firrtl.uint<1>, %out : !firrtl.flip<uint<2>>) {
+firrtl.module @set_in_else1(in %clock : !firrtl.clock, in %p : !firrtl.uint<1>, out %out : !firrtl.uint<2>) {
   %c0_ui2 = firrtl.constant(0 : ui2) : !firrtl.uint<2>
   %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
   firrtl.when %p {
   } else {
-    firrtl.connect %out, %c1_ui2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+    firrtl.connect %out, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   }
-  firrtl.connect %out, %c0_ui2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+  firrtl.connect %out, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
 }
-// CHECK-LABEL: firrtl.module @set_in_else1(%clock: !firrtl.clock, %p: !firrtl.uint<1>, %out: !firrtl.flip<uint<2>>) {
+// CHECK-LABEL: firrtl.module @set_in_else1(in %clock: !firrtl.clock, in %p: !firrtl.uint<1>, out %out: !firrtl.uint<2>) {
 // CHECK-NEXT:   %c0_ui2 = firrtl.constant(0 : ui2) : !firrtl.uint<2>
 // CHECK-NEXT:   %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
 // CHECK-NEXT:   %0 = firrtl.not %p : (!firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:   firrtl.connect %out, %c0_ui2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+// CHECK-NEXT:   firrtl.connect %out, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
 // CHECK-NEXT: }
 
 // Check that nested WhenOps work.
-firrtl.module @nested(%clock : !firrtl.clock, %p0 : !firrtl.uint<1>, %p1 : !firrtl.uint<1>, %out : !firrtl.flip<uint<2>>) {
+firrtl.module @nested(in %clock : !firrtl.clock, in %p0 : !firrtl.uint<1>, in %p1 : !firrtl.uint<1>, out %out : !firrtl.uint<2>) {
   %c0_ui2 = firrtl.constant(0 : ui2) : !firrtl.uint<2>
   %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
   %c2_ui2 = firrtl.constant(2 : ui2) : !firrtl.uint<2>
 
-  firrtl.connect %out, %c0_ui2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+  firrtl.connect %out, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   firrtl.when %p0 {
     firrtl.when %p1 {
-      firrtl.connect %out, %c1_ui2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+      firrtl.connect %out, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
     }
   }
 }
-// CHECK-LABEL: firrtl.module @nested(%clock: !firrtl.clock, %p0: !firrtl.uint<1>, %p1: !firrtl.uint<1>, %out: !firrtl.flip<uint<2>>) {
+// CHECK-LABEL: firrtl.module @nested(in %clock: !firrtl.clock, in %p0: !firrtl.uint<1>, in %p1: !firrtl.uint<1>, out %out: !firrtl.uint<2>) {
 // CHECK-NEXT:   %c0_ui2 = firrtl.constant(0 : ui2) : !firrtl.uint<2>
 // CHECK-NEXT:   %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
 // CHECK-NEXT:   %c2_ui2 = firrtl.constant(2 : ui2) : !firrtl.uint<2>
 // CHECK-NEXT:   %0 = firrtl.and %p0, %p1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:   %1 = firrtl.mux(%p0, %c1_ui2, %c0_ui2) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
-// CHECK-NEXT:   firrtl.connect %out, %1 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+// CHECK-NEXT:   firrtl.connect %out, %1 : !firrtl.uint<2>, !firrtl.uint<2>
 // CHECK-NEXT: }
 
 
 // Check that nested WhenOps work.
-firrtl.module @nested2(%clock : !firrtl.clock, %p0 : !firrtl.uint<1>, %p1 : !firrtl.uint<1>, %out : !firrtl.flip<uint<2>>) {
+firrtl.module @nested2(in %clock : !firrtl.clock, in %p0 : !firrtl.uint<1>, in %p1 : !firrtl.uint<1>, out %out : !firrtl.uint<2>) {
   %c0_ui2 = firrtl.constant(0 : ui2) : !firrtl.uint<2>
   %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
   %c2_ui2 = firrtl.constant(2 : ui2) : !firrtl.uint<2>
@@ -270,19 +270,19 @@ firrtl.module @nested2(%clock : !firrtl.clock, %p0 : !firrtl.uint<1>, %p1 : !fir
 
   firrtl.when %p0 {
     firrtl.when %p1 {
-      firrtl.connect %out, %c0_ui2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+      firrtl.connect %out, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
     } else {
-      firrtl.connect %out, %c1_ui2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+      firrtl.connect %out, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
     }
   } else {
     firrtl.when %p1 {
-      firrtl.connect %out, %c2_ui2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+      firrtl.connect %out, %c2_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
     } else {
-      firrtl.connect %out, %c3_ui2 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+      firrtl.connect %out, %c3_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
     }
   }
 }
-//CHECK-LABEL: firrtl.module @nested2(%clock: !firrtl.clock, %p0: !firrtl.uint<1>, %p1: !firrtl.uint<1>, %out: !firrtl.flip<uint<2>>) {
+//CHECK-LABEL: firrtl.module @nested2(in %clock: !firrtl.clock, in %p0: !firrtl.uint<1>, in %p1: !firrtl.uint<1>, out %out: !firrtl.uint<2>) {
 //CHECK-NEXT:   %c0_ui2 = firrtl.constant(0 : ui2) : !firrtl.uint<2>
 //CHECK-NEXT:   %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
 //CHECK-NEXT:   %c2_ui2 = firrtl.constant(2 : ui2) : !firrtl.uint<2>
@@ -297,11 +297,11 @@ firrtl.module @nested2(%clock : !firrtl.clock, %p0 : !firrtl.uint<1>, %p1 : !fir
 //CHECK-NEXT:   %7 = firrtl.and %4, %6 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 //CHECK-NEXT:   %8 = firrtl.mux(%5, %c2_ui2, %c3_ui2) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
 //CHECK-NEXT:   %9 = firrtl.mux(%p0, %3, %8) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
-//CHECK-NEXT:   firrtl.connect %out, %9 : !firrtl.flip<uint<2>>, !firrtl.uint<2>
+//CHECK-NEXT:   firrtl.connect %out, %9 : !firrtl.uint<2>, !firrtl.uint<2>
 //CHECK-NEXT: }
 
 // Test that registers are multiplexed with themselves.
-firrtl.module @register_mux(%p : !firrtl.uint<1>, %clock: !firrtl.clock) {
+firrtl.module @register_mux(in %p : !firrtl.uint<1>, in %clock: !firrtl.clock) {
   %c0_ui2 = firrtl.constant(0 : ui2) : !firrtl.uint<2>
   %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
 
@@ -314,14 +314,14 @@ firrtl.module @register_mux(%p : !firrtl.uint<1>, %clock: !firrtl.clock) {
   %reg1 = firrtl.reg %clock : (!firrtl.clock) -> !firrtl.uint<2>
   firrtl.connect %reg1, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
 
-  // CHECK: %reg2 = firrtl.reg %clock 
+  // CHECK: %reg2 = firrtl.reg %clock
   // CHECK: [[MUX:%.+]] = firrtl.mux(%p, %c0_ui2, %reg2)
   // CHECK: firrtl.connect %reg2, [[MUX]]
   %reg2 = firrtl.reg %clock : (!firrtl.clock) -> !firrtl.uint<2>
   firrtl.when %p {
     firrtl.connect %reg2, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   }
-  
+
   // CHECK: %reg3 = firrtl.reg %clock
   // CHECK: [[MUX:%.+]] = firrtl.mux(%p, %c0_ui2, %c1_ui2)
   // CHECK: firrtl.connect %reg3, [[MUX]]

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -3,22 +3,22 @@
 firrtl.circuit "Test" {
 
   // CHECK-LABEL: @PassThrough
-  // CHECK: (%source: !firrtl.uint<1>, %dest: !firrtl.flip<uint<1>>) 
-  firrtl.module @PassThrough(%source: !firrtl.uint<1>, %dest: !firrtl.flip<uint<1>>) {
+  // CHECK: (in %source: !firrtl.uint<1>, out %dest: !firrtl.uint<1>)
+  firrtl.module @PassThrough(in %source: !firrtl.uint<1>, out %dest: !firrtl.uint<1>) {
     // CHECK-NEXT: %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
     // CHECK-NEXT: firrtl.connect %dest, %c0_ui1
-    firrtl.connect %dest, %source : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+    firrtl.connect %dest, %source : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK-NEXT: }
   }
 
   // CHECK-LABEL: @Test
-  firrtl.module @Test(%clock: !firrtl.clock, %reset: !firrtl.uint<1>,
-                      %result1: !firrtl.flip<uint<1>>,
-                      %result2: !firrtl.flip<uint<1>>,
-                      %result3: !firrtl.flip<uint<1>>,
-                      %result4: !firrtl.flip<uint<2>>,
-                      %result5: !firrtl.flip<uint<2>>,
-                      %result6: !firrtl.flip<uint<4>>) {
+  firrtl.module @Test(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>,
+                      out %result1: !firrtl.uint<1>,
+                      out %result2: !firrtl.uint<1>,
+                      out %result3: !firrtl.uint<1>,
+                      out %result4: !firrtl.uint<2>,
+                      out %result5: !firrtl.uint<2>,
+                      out %result6: !firrtl.uint<4>) {
     %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
     %c1_ui1 = firrtl.constant(1 : ui1) : !firrtl.uint<1>
 
@@ -28,7 +28,7 @@ firrtl.circuit "Test" {
 
     // CHECK-NOT: firrtl.wire
     // CHECK: firrtl.connect %result1, %c0_ui1_0
-    firrtl.connect %result1, %someWire : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+    firrtl.connect %result1, %someWire : !firrtl.uint<1>, !firrtl.uint<1>
 
     // Not a constant.
     %nonconstWire = firrtl.wire : !firrtl.uint<1>
@@ -36,7 +36,7 @@ firrtl.circuit "Test" {
     firrtl.connect %nonconstWire, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
 
     // CHECK: firrtl.connect %result2, %nonconstWire
-    firrtl.connect %result2, %nonconstWire : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+    firrtl.connect %result2, %nonconstWire : !firrtl.uint<1>, !firrtl.uint<1>
 
 
     // Constant propagation through instance.
@@ -45,7 +45,7 @@ firrtl.circuit "Test" {
     // CHECK: firrtl.connect %inst_source, %c0_ui1
     firrtl.connect %source, %c0_ui1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
     // CHECK: firrtl.connect %result3, %c0_ui1_1
-    firrtl.connect %result3, %dest : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+    firrtl.connect %result3, %dest : !firrtl.uint<1>, !firrtl.uint<1>
 
     // Check connect extensions.
     %extWire = firrtl.wire : !firrtl.uint<2>
@@ -56,7 +56,7 @@ firrtl.circuit "Test" {
     firrtl.connect %extWire, %invalid : !firrtl.uint<2>, !firrtl.uint<2>
 
     // CHECK: firrtl.connect %result4, %c0_ui2
-    firrtl.connect %result4, %extWire: !firrtl.flip<uint<2>>, !firrtl.uint<2>
+    firrtl.connect %result4, %extWire: !firrtl.uint<2>, !firrtl.uint<2>
 
     // regreset
     %c0_ui20 = firrtl.constant(0 : ui20) : !firrtl.uint<20>
@@ -66,23 +66,22 @@ firrtl.circuit "Test" {
     firrtl.connect %regreset, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
 
     // CHECK: firrtl.connect %result5, %c0_ui2
-    firrtl.connect %result5, %regreset: !firrtl.flip<uint<2>>, !firrtl.uint<2>
+    firrtl.connect %result5, %regreset: !firrtl.uint<2>, !firrtl.uint<2>
 
     // reg
     %reg = firrtl.reg %clock  : (!firrtl.clock) -> !firrtl.uint<4>
     firrtl.connect %reg, %c0_ui2 : !firrtl.uint<4>, !firrtl.uint<2>
 
     // CHECK: firrtl.connect %result6, %c0_ui4
-    firrtl.connect %result6, %reg: !firrtl.flip<uint<4>>, !firrtl.uint<4>
+    firrtl.connect %result6, %reg: !firrtl.uint<4>, !firrtl.uint<4>
 
   }
 
   // Unused modules should be completely dropped.
 
-  // CHECK-LABEL: @UnusedModule(%source: !firrtl.uint<1>, %dest: !firrtl.flip<uint<1>>)
-  firrtl.module @UnusedModule(%source: !firrtl.uint<1>, %dest: !firrtl.flip<uint<1>>) {
-    firrtl.connect %dest, %source : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK-LABEL: @UnusedModule(in %source: !firrtl.uint<1>, out %dest: !firrtl.uint<1>)
+  firrtl.module @UnusedModule(in %source: !firrtl.uint<1>, out %dest: !firrtl.uint<1>) {
+    firrtl.connect %dest, %source : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK-NEXT: }
   }
 }
-

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -2,19 +2,19 @@
 
 firrtl.circuit "Foo" {
   // CHECK-LABEL: @InferConstant
-  // CHECK-SAME: %out0: !firrtl.flip<uint<42>>
-  // CHECK-SAME: %out1: !firrtl.flip<sint<42>>
-  firrtl.module @InferConstant(%out0: !firrtl.flip<uint>, %out1: !firrtl.flip<sint>) {
+  // CHECK-SAME: out %out0: !firrtl.uint<42>
+  // CHECK-SAME: out %out1: !firrtl.sint<42>
+  firrtl.module @InferConstant(out %out0: !firrtl.uint, out %out1: !firrtl.sint) {
     %0 = firrtl.constant(1 : ui42) : !firrtl.uint
     %1 = firrtl.constant(2 : si42) : !firrtl.sint
-    firrtl.connect %out0, %0 : !firrtl.flip<uint>, !firrtl.uint
-    firrtl.connect %out1, %1 : !firrtl.flip<sint>, !firrtl.sint
+    firrtl.connect %out0, %0 : !firrtl.uint, !firrtl.uint
+    firrtl.connect %out1, %1 : !firrtl.sint, !firrtl.sint
   }
 
   // CHECK-LABEL: @InferOutput
-  // CHECK-SAME: %out: !firrtl.flip<uint<2>>
-  firrtl.module @InferOutput(%in: !firrtl.uint<2>, %out: !firrtl.flip<uint>) {
-    firrtl.connect %out, %in : !firrtl.flip<uint>, !firrtl.uint<2>
+  // CHECK-SAME: out %out: !firrtl.uint<2>
+  firrtl.module @InferOutput(in %in: !firrtl.uint<2>, out %out: !firrtl.uint) {
+    firrtl.connect %out, %in : !firrtl.uint, !firrtl.uint<2>
   }
 
   // CHECK-LABEL: @AddSubOp
@@ -80,7 +80,7 @@ firrtl.circuit "Foo" {
   }
 
   // CHECK-LABEL: @ComparisonOp
-  firrtl.module @ComparisonOp(%a: !firrtl.uint<2>, %b: !firrtl.uint<3>) {
+  firrtl.module @ComparisonOp(in %a: !firrtl.uint<2>, in %b: !firrtl.uint<3>) {
     // CHECK: %6 = firrtl.wire : !firrtl.uint<1>
     // CHECK: %7 = firrtl.wire : !firrtl.uint<1>
     // CHECK: %8 = firrtl.wire : !firrtl.uint<1>
@@ -108,7 +108,7 @@ firrtl.circuit "Foo" {
   }
 
   // CHECK-LABEL: @MuxOp
-  firrtl.module @MuxOp(%a: !firrtl.uint<1>) {
+  firrtl.module @MuxOp(in %a: !firrtl.uint<1>) {
     // CHECK: %0 = firrtl.wire : !firrtl.uint<2>
     // CHECK: %1 = firrtl.wire : !firrtl.uint<3>
     // CHECK: %2 = firrtl.mux{{.*}} -> !firrtl.uint<3>

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -83,14 +83,14 @@ firrtl.module @compose() {
   firrtl.instance @test2 {name = "test2"}
   firrtl.instance @test3 {name = "test3"}
 }
-firrtl.module @test1() attributes {annotations = 
+firrtl.module @test1() attributes {annotations =
         [{class = "firrtl.transforms.FlattenAnnotation"},
          {class = "firrtl.passes.InlineAnnotation"}]} {
   %test_wire = firrtl.wire : !firrtl.uint<2>
   firrtl.instance @test2 {name = "test2"}
   firrtl.instance @test3 {name = "test3"}
 }
-firrtl.module @test2() attributes {annotations = 
+firrtl.module @test2() attributes {annotations =
         [{class = "firrtl.passes.InlineAnnotation"}]} {
   %test_wire = firrtl.wire : !firrtl.uint<2>
   firrtl.instance @test3 {name = "test3"}
@@ -118,35 +118,35 @@ firrtl.module @test3() {
 // This is testing that connects are properly replaced when inlining. This is
 // also testing that the deep clone and remapping values is working correctly.
 firrtl.circuit "TestConnections" {
-firrtl.module @InlineMe0(%in0: !firrtl.uint<4>, %in1: !firrtl.uint<4>,
-                        %out0: !firrtl.flip<uint<4>>, %out1: !firrtl.flip<uint<4>>) 
+firrtl.module @InlineMe0(in %in0: !firrtl.uint<4>, in %in1: !firrtl.uint<4>,
+                         out %out0: !firrtl.uint<4>, out %out1: !firrtl.uint<4>)
         attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
   %0 = firrtl.and %in0, %in1 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  firrtl.connect %out0, %0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out0, %0 : !firrtl.uint<4>, !firrtl.uint<4>
   %1 = firrtl.and %in0, %in1 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  firrtl.connect %out1, %1 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out1, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 }
-firrtl.module @InlineMe1(%in0: !firrtl.uint<4>, %in1: !firrtl.uint<4>,
-                   %out0: !firrtl.flip<uint<4>>,
-                   %out1: !firrtl.flip<uint<4>>)
+firrtl.module @InlineMe1(in %in0: !firrtl.uint<4>, in %in1: !firrtl.uint<4>,
+                   out %out0: !firrtl.uint<4>,
+                   out %out1: !firrtl.uint<4>)
         attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
   %a_in0, %a_in1, %a_out0, %a_out1 = firrtl.instance @InlineMe0 {name = "a"} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>, !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %a_in0, %in0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
   firrtl.connect %a_in1, %in1 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
-  firrtl.connect %out0, %a_out0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
-  firrtl.connect %out1, %a_out1 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out0, %a_out0 : !firrtl.uint<4>, !firrtl.uint<4>
+  firrtl.connect %out1, %a_out1 : !firrtl.uint<4>, !firrtl.uint<4>
 }
-firrtl.module @TestConnections(%in0: !firrtl.uint<4>, %in1: !firrtl.uint<4>,
-                   %out0: !firrtl.flip<uint<4>>,
-                   %out1: !firrtl.flip<uint<4>>) {
+firrtl.module @TestConnections(in %in0: !firrtl.uint<4>, in %in1: !firrtl.uint<4>,
+                   out %out0: !firrtl.uint<4>,
+                   out %out1: !firrtl.uint<4>) {
   %b_in0, %b_in1, %b_out0, %b_out1 = firrtl.instance @InlineMe1 {name = "b"} : !firrtl.flip<uint<4>>, !firrtl.flip<uint<4>>, !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %b_in0, %in0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
   firrtl.connect %b_in1, %in1 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
-  firrtl.connect %out0, %b_out0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
-  firrtl.connect %out1, %b_out1 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+  firrtl.connect %out0, %b_out0 : !firrtl.uint<4>, !firrtl.uint<4>
+  firrtl.connect %out1, %b_out1 : !firrtl.uint<4>, !firrtl.uint<4>
 }
 }
-// CHECK-LABEL: firrtl.module @TestConnections(%in0: !firrtl.uint<4>, %in1: !firrtl.uint<4>, %out0: !firrtl.flip<uint<4>>, %out1: !firrtl.flip<uint<4>>) {
+// CHECK-LABEL: firrtl.module @TestConnections(in %in0: !firrtl.uint<4>, in %in1: !firrtl.uint<4>, out %out0: !firrtl.uint<4>, out %out1: !firrtl.uint<4>) {
 // CHECK-NEXT:   %b_in0 = firrtl.wire  : !firrtl.uint<4>
 // CHECK-NEXT:   %b_in1 = firrtl.wire  : !firrtl.uint<4>
 // CHECK-NEXT:   %b_out0 = firrtl.wire  : !firrtl.uint<4>
@@ -165,28 +165,28 @@ firrtl.module @TestConnections(%in0: !firrtl.uint<4>, %in1: !firrtl.uint<4>,
 // CHECK-NEXT:   firrtl.connect %b_out1, %b_a_out1 : !firrtl.uint<4>, !firrtl.uint<4>
 // CHECK-NEXT:   firrtl.connect %b_in0, %in0 : !firrtl.uint<4>, !firrtl.uint<4>
 // CHECK-NEXT:   firrtl.connect %b_in1, %in1 : !firrtl.uint<4>, !firrtl.uint<4>
-// CHECK-NEXT:   firrtl.connect %out0, %b_out0 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
-// CHECK-NEXT:   firrtl.connect %out1, %b_out1 : !firrtl.flip<uint<4>>, !firrtl.uint<4>
+// CHECK-NEXT:   firrtl.connect %out0, %b_out0 : !firrtl.uint<4>, !firrtl.uint<4>
+// CHECK-NEXT:   firrtl.connect %out1, %b_out1 : !firrtl.uint<4>, !firrtl.uint<4>
 // CHECK-NEXT: }
 
 
 // This is testing that bundles with flip types are handled properly by the inliner.
 firrtl.circuit "TestBulkConnections" {
-firrtl.module @InlineMe0(%in0: !firrtl.bundle<a: uint<4>, b: flip<uint<4>>>,
-                         %out0: !firrtl.flip<bundle<a: uint<4>, b: flip<uint<4>>>>) 
+firrtl.module @InlineMe0(in %in0: !firrtl.bundle<a: uint<4>, b: flip<uint<4>>>,
+                         out %out0: !firrtl.bundle<a: uint<4>, b: flip<uint<4>>>)
         attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
-  firrtl.connect %out0, %in0 : !firrtl.flip<bundle<a: uint<4>, b: flip<uint<4>>>>, !firrtl.bundle<a: uint<4>, b: flip<uint<4>>>
+  firrtl.connect %out0, %in0 : !firrtl.bundle<a: uint<4>, b: flip<uint<4>>>, !firrtl.bundle<a: uint<4>, b: flip<uint<4>>>
 }
-firrtl.module @TestBulkConnections(%in0: !firrtl.bundle<a: uint<4>, b: flip<uint<4>>>,
-                                   %out0: !firrtl.flip<bundle<a: uint<4>, b: flip<uint<4>>>>) {
+firrtl.module @TestBulkConnections(in %in0: !firrtl.bundle<a: uint<4>, b: flip<uint<4>>>,
+                                   out %out0: !firrtl.bundle<a: uint<4>, b: flip<uint<4>>>) {
   %i_in0, %i_out0 = firrtl.instance @InlineMe0 {name = "i"} : !firrtl.flip<bundle<a: uint<4>, b: flip<uint<4>>>>, !firrtl.bundle<a: uint<4>, b: flip<uint<4>>>
   firrtl.connect %i_in0, %in0 : !firrtl.flip<bundle<a: uint<4>, b: flip<uint<4>>>>, !firrtl.bundle<a: uint<4>, b: flip<uint<4>>>
-  firrtl.connect %out0, %i_out0 : !firrtl.flip<bundle<a: uint<4>, b: flip<uint<4>>>>, !firrtl.bundle<a: uint<4>, b: flip<uint<4>>>
+  firrtl.connect %out0, %i_out0 : !firrtl.bundle<a: uint<4>, b: flip<uint<4>>>, !firrtl.bundle<a: uint<4>, b: flip<uint<4>>>
 // CHECK: %i_in0 = firrtl.wire  : !firrtl.bundle<a: uint<4>, b: flip<uint<4>>>
 // CHECK: %i_out0 = firrtl.wire  : !firrtl.bundle<a: uint<4>, b: flip<uint<4>>>
 // CHECK: firrtl.connect %i_out0, %i_in0 : !firrtl.bundle<a: uint<4>, b: flip<uint<4>>>, !firrtl.bundle<a: uint<4>, b: flip<uint<4>>>
 // CHECK: firrtl.connect %i_in0, %in0 : !firrtl.bundle<a: uint<4>, b: flip<uint<4>>>, !firrtl.bundle<a: uint<4>, b: flip<uint<4>>>
-// CHECK: firrtl.connect %out0, %i_out0 : !firrtl.flip<bundle<a: uint<4>, b: flip<uint<4>>>>, !firrtl.bundle<a: uint<4>, b: flip<uint<4>>>
+// CHECK: firrtl.connect %out0, %i_out0 : !firrtl.bundle<a: uint<4>, b: flip<uint<4>>>, !firrtl.bundle<a: uint<4>, b: flip<uint<4>>>
 }
 }
 
@@ -196,7 +196,7 @@ firrtl.circuit "renaming" {
 firrtl.module @renaming() {
   %0, %1, %2 = firrtl.instance @declarations {name = "myinst"} : !firrtl.flip<clock>, !firrtl.flip<uint<8>>, !firrtl.flip<asyncreset>
 }
-firrtl.module @declarations(%clock : !firrtl.clock, %u8 : !firrtl.uint<8>, %reset : !firrtl.asyncreset) attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
+firrtl.module @declarations(in %clock : !firrtl.clock, in %u8 : !firrtl.uint<8>, in %reset : !firrtl.asyncreset) attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
   // CHECK: %myinst_cmem = firrtl.cmem  {name = "myinst_cmem"} : !firrtl.uint<8>
   %cmem = firrtl.cmem {name = "cmem"} : !firrtl.uint<8>
   // CHECK: %myinst_mem_read = firrtl.mem Undefined {depth = 1 : i64, name = "myinst_mem", portNames = ["read"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<1>, en: uint<1>, clk: clock, data: flip<sint<42>>>>

--- a/test/Dialect/FIRRTL/lower-types-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-types-errors.mlir
@@ -2,10 +2,10 @@
 
 module  {
   firrtl.circuit "top_mod" {
-    firrtl.module @top_mod(%result: !firrtl.flip<uint<8>>, %addr: !firrtl.uint<8>, %vec0: !firrtl.vector<uint<8>, 4>) {
+    firrtl.module @top_mod(out %result: !firrtl.uint<8>, in %addr: !firrtl.uint<8>, in %vec0: !firrtl.vector<uint<8>, 4>) {
       %0 = firrtl.subaccess %vec0[%addr] : !firrtl.vector<uint<8>, 4>, !firrtl.uint<8>
       // expected-error @-1 {{SubaccessOp not handled.}}
-      firrtl.connect %result, %0 :!firrtl.flip<uint<8>>, !firrtl.uint<8>
+      firrtl.connect %result, %0 :!firrtl.uint<8>, !firrtl.uint<8>
     }
   }
 }

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -3,14 +3,14 @@
 firrtl.circuit "TopLevel" {
 
   // CHECK-LABEL: firrtl.module @Simple
-  // CHECK-SAME: %[[SOURCE_VALID_NAME:source_valid]]: [[SOURCE_VALID_TYPE:!firrtl.uint<1>]]
-  // CHECK-SAME: %[[SOURCE_READY_NAME:source_ready]]: [[SOURCE_READY_TYPE:!firrtl.flip<uint<1>>]]
-  // CHECK-SAME: %[[SOURCE_DATA_NAME:source_data]]: [[SOURCE_DATA_TYPE:!firrtl.uint<64>]]
-  // CHECK-SAME: %[[SINK_VALID_NAME:sink_valid]]: [[SINK_VALID_TYPE:!firrtl.flip<uint<1>>]]
-  // CHECK-SAME: %[[SINK_READY_NAME:sink_ready]]: [[SINK_READY_TYPE:!firrtl.uint<1>]]
-  // CHECK-SAME: %[[SINK_DATA_NAME:sink_data]]: [[SINK_DATA_TYPE:!firrtl.flip<uint<64>>]]
-  firrtl.module @Simple(%source: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>,
-                        %sink: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) {
+  // CHECK-SAME: in %[[SOURCE_VALID_NAME:source_valid]]: [[SOURCE_VALID_TYPE:!firrtl.uint<1>]]
+  // CHECK-SAME: out %[[SOURCE_READY_NAME:source_ready]]: [[SOURCE_READY_TYPE:!firrtl.uint<1>]]
+  // CHECK-SAME: in %[[SOURCE_DATA_NAME:source_data]]: [[SOURCE_DATA_TYPE:!firrtl.uint<64>]]
+  // CHECK-SAME: out %[[SINK_VALID_NAME:sink_valid]]: [[SINK_VALID_TYPE:!firrtl.uint<1>]]
+  // CHECK-SAME: in %[[SINK_READY_NAME:sink_ready]]: [[SINK_READY_TYPE:!firrtl.uint<1>]]
+  // CHECK-SAME: out %[[SINK_DATA_NAME:sink_data]]: [[SINK_DATA_TYPE:!firrtl.uint<64>]]
+  firrtl.module @Simple(in %source: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>,
+                        out %sink: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) {
 
     // CHECK-NEXT: firrtl.when %[[SOURCE_VALID_NAME]]
     // CHECK-NEXT:   firrtl.connect %[[SINK_DATA_NAME]], %[[SOURCE_DATA_NAME]] : [[SINK_DATA_TYPE]], [[SOURCE_DATA_TYPE]]
@@ -20,9 +20,9 @@ firrtl.circuit "TopLevel" {
     %0 = firrtl.subfield %source("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
     %1 = firrtl.subfield %source("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
     %2 = firrtl.subfield %source("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
-    %3 = firrtl.subfield %sink("valid") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
-    %4 = firrtl.subfield %sink("ready") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<1>
-    %5 = firrtl.subfield %sink("data") : (!firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) -> !firrtl.uint<64>
+    %3 = firrtl.subfield %sink("valid") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
+    %4 = firrtl.subfield %sink("ready") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<1>
+    %5 = firrtl.subfield %sink("data") : (!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) -> !firrtl.uint<64>
     firrtl.when %0 {
       firrtl.connect %5, %2 : !firrtl.uint<64>, !firrtl.uint<64>
       firrtl.connect %3, %0 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -31,14 +31,14 @@ firrtl.circuit "TopLevel" {
   }
 
   // CHECK-LABEL: firrtl.module @TopLevel
-  // CHECK-SAME: %source_valid: [[SOURCE_VALID_TYPE:!firrtl.uint<1>]]
-  // CHECK-SAME: %source_ready: [[SOURCE_READY_TYPE:!firrtl.flip<uint<1>>]]
-  // CHECK-SAME: %source_data: [[SOURCE_DATA_TYPE:!firrtl.uint<64>]]
-  // CHECK-SAME: %sink_valid: [[SINK_VALID_TYPE:!firrtl.flip<uint<1>>]]
-  // CHECK-SAME: %sink_ready: [[SINK_READY_TYPE:!firrtl.uint<1>]]
-  // CHECK-SAME: %sink_data: [[SINK_DATA_TYPE:!firrtl.flip<uint<64>>]]
-  firrtl.module @TopLevel(%source: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>,
-                          %sink: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) {
+  // CHECK-SAME: in %source_valid: [[SOURCE_VALID_TYPE:!firrtl.uint<1>]]
+  // CHECK-SAME: out %source_ready: [[SOURCE_READY_TYPE:!firrtl.uint<1>]]
+  // CHECK-SAME: in %source_data: [[SOURCE_DATA_TYPE:!firrtl.uint<64>]]
+  // CHECK-SAME: out %sink_valid: [[SINK_VALID_TYPE:!firrtl.uint<1>]]
+  // CHECK-SAME: in %sink_ready: [[SINK_READY_TYPE:!firrtl.uint<1>]]
+  // CHECK-SAME: out %sink_data: [[SINK_DATA_TYPE:!firrtl.uint<64>]]
+  firrtl.module @TopLevel(in %source: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>,
+                          out %sink: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) {
 
     // CHECK-NEXT: %inst_source_valid, %inst_source_ready, %inst_source_data, %inst_sink_valid, %inst_sink_ready, %inst_sink_data
     // CHECK-SAME: = firrtl.instance @Simple {name = ""} :
@@ -53,7 +53,7 @@ firrtl.circuit "TopLevel" {
     // CHECK-NEXT: firrtl.connect %sink_data, %inst_sink_data
     firrtl.connect %sourceV, %source : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
 
-    firrtl.connect %sink, %sinkV : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+    firrtl.connect %sink, %sinkV : !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
   }
 }
 
@@ -62,12 +62,12 @@ firrtl.circuit "TopLevel" {
 firrtl.circuit "Recursive" {
 
   // CHECK-LABEL: firrtl.module @Recursive
-  // CHECK-SAME: %[[FLAT_ARG_1_NAME:arg_foo_bar_baz]]: [[FLAT_ARG_1_TYPE:!firrtl.uint<1>]]
-  // CHECK-SAME: %[[FLAT_ARG_2_NAME:arg_foo_qux]]: [[FLAT_ARG_2_TYPE:!firrtl.sint<64>]]
-  // CHECK-SAME: %[[OUT_1_NAME:out1]]: [[OUT_1_TYPE:!firrtl.flip<uint<1>>]]
-  // CHECK-SAME: %[[OUT_2_NAME:out2]]: [[OUT_2_TYPE:!firrtl.flip<sint<64>>]]
-  firrtl.module @Recursive(%arg: !firrtl.bundle<foo: bundle<bar: bundle<baz: uint<1>>, qux: sint<64>>>,
-                           %out1: !firrtl.flip<uint<1>>, %out2: !firrtl.flip<sint<64>>) {
+  // CHECK-SAME: in %[[FLAT_ARG_1_NAME:arg_foo_bar_baz]]: [[FLAT_ARG_1_TYPE:!firrtl.uint<1>]]
+  // CHECK-SAME: in %[[FLAT_ARG_2_NAME:arg_foo_qux]]: [[FLAT_ARG_2_TYPE:!firrtl.sint<64>]]
+  // CHECK-SAME: out %[[OUT_1_NAME:out1]]: [[OUT_1_TYPE:!firrtl.uint<1>]]
+  // CHECK-SAME: out %[[OUT_2_NAME:out2]]: [[OUT_2_TYPE:!firrtl.sint<64>]]
+  firrtl.module @Recursive(in %arg: !firrtl.bundle<foo: bundle<bar: bundle<baz: uint<1>>, qux: sint<64>>>,
+                           out %out1: !firrtl.uint<1>, out %out2: !firrtl.sint<64>) {
 
     // CHECK-NEXT: firrtl.connect %[[OUT_1_NAME]], %[[FLAT_ARG_1_NAME]] : [[OUT_1_TYPE]], [[FLAT_ARG_1_TYPE]]
     // CHECK-NEXT: firrtl.connect %[[OUT_2_NAME]], %[[FLAT_ARG_2_NAME]] : [[OUT_2_TYPE]], [[FLAT_ARG_2_TYPE]]
@@ -76,8 +76,8 @@ firrtl.circuit "Recursive" {
     %1 = firrtl.subfield %0("bar") : (!firrtl.bundle<bar: bundle<baz: uint<1>>, qux: sint<64>>) -> !firrtl.bundle<baz: uint<1>>
     %2 = firrtl.subfield %1("baz") : (!firrtl.bundle<baz: uint<1>>) -> !firrtl.uint<1>
     %3 = firrtl.subfield %0("qux") : (!firrtl.bundle<bar: bundle<baz: uint<1>>, qux: sint<64>>) -> !firrtl.sint<64>
-    firrtl.connect %out1, %2 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-    firrtl.connect %out2, %3 : !firrtl.flip<sint<64>>, !firrtl.sint<64>
+    firrtl.connect %out1, %2 : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %out2, %3 : !firrtl.sint<64>, !firrtl.sint<64>
   }
 
 }
@@ -87,11 +87,11 @@ firrtl.circuit "Recursive" {
 firrtl.circuit "Uniquification" {
 
   // CHECK-LABEL: firrtl.module @Uniquification
-  // CHECK-SAME: %[[FLATTENED_ARG:a_b]]: [[FLATTENED_TYPE:!firrtl.uint<1>]],
+  // CHECK-SAME: in %[[FLATTENED_ARG:a_b]]: [[FLATTENED_TYPE:!firrtl.uint<1>]],
   // CHECK-NOT: %[[FLATTENED_ARG]]
-  // CHECK-SAME: %[[RENAMED_ARG:a_b.+]]: [[RENAMED_TYPE:!firrtl.uint<1>]]
+  // CHECK-SAME: in %[[RENAMED_ARG:a_b.+]]: [[RENAMED_TYPE:!firrtl.uint<1>]]
   // CHECK-SAME: {portNames = ["a_b", "a_b"]}
-  firrtl.module @Uniquification(%a: !firrtl.bundle<b: uint<1>>, %a_b: !firrtl.uint<1>) {
+  firrtl.module @Uniquification(in %a: !firrtl.bundle<b: uint<1>>, in %a_b: !firrtl.uint<1>) {
   }
 
 }
@@ -101,11 +101,11 @@ firrtl.circuit "Uniquification" {
 firrtl.circuit "Top" {
 
   // CHECK-LABEL: firrtl.module @Top
-  firrtl.module @Top(%in : !firrtl.bundle<a: uint<1>, b: uint<1>>,
-                     %out : !firrtl.flip<bundle<a: uint<1>, b: uint<1>>>) {
-    // CHECK: firrtl.connect %out_a, %in_a : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-    // CHECK: firrtl.connect %out_b, %in_b : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-    firrtl.connect %out, %in : !firrtl.flip<bundle<a: uint<1>, b: uint<1>>>, !firrtl.bundle<a: uint<1>, b: uint<1>>
+  firrtl.module @Top(in %in : !firrtl.bundle<a: uint<1>, b: uint<1>>,
+                     out %out : !firrtl.bundle<a: uint<1>, b: uint<1>>) {
+    // CHECK: firrtl.connect %out_a, %in_a : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK: firrtl.connect %out_b, %in_b : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %out, %in : !firrtl.bundle<a: uint<1>, b: uint<1>>, !firrtl.bundle<a: uint<1>, b: uint<1>>
   }
 
 }
@@ -114,11 +114,11 @@ firrtl.circuit "Top" {
 
 firrtl.circuit "Foo" {
   // CHECK-LABEL: firrtl.module @Foo
-  // CHECK-SAME: %[[FLAT_ARG_INPUT_NAME:a_b_c]]: [[FLAT_ARG_INPUT_TYPE:!firrtl.uint<1>]]
-  // CHECK-SAME: %[[FLAT_ARG_OUTPUT_NAME:b_b_c]]: [[FLAT_ARG_OUTPUT_TYPE:!firrtl.flip<uint<1>>]]
-  firrtl.module @Foo(%a: !firrtl.bundle<b: bundle<c: uint<1>>>, %b: !firrtl.flip<bundle<b: bundle<c: uint<1>>>>) {
+  // CHECK-SAME: in %[[FLAT_ARG_INPUT_NAME:a_b_c]]: [[FLAT_ARG_INPUT_TYPE:!firrtl.uint<1>]]
+  // CHECK-SAME: out %[[FLAT_ARG_OUTPUT_NAME:b_b_c]]: [[FLAT_ARG_OUTPUT_TYPE:!firrtl.uint<1>]]
+  firrtl.module @Foo(in %a: !firrtl.bundle<b: bundle<c: uint<1>>>, out %b: !firrtl.bundle<b: bundle<c: uint<1>>>) {
     // CHECK: firrtl.connect %[[FLAT_ARG_OUTPUT_NAME]], %[[FLAT_ARG_INPUT_NAME]] : [[FLAT_ARG_OUTPUT_TYPE]], [[FLAT_ARG_INPUT_TYPE]]
-    firrtl.connect %b, %a : !firrtl.flip<bundle<b: bundle<c: uint<1>>>>, !firrtl.bundle<b: bundle<c: uint<1>>>
+    firrtl.connect %b, %a : !firrtl.bundle<b: bundle<c: uint<1>>>, !firrtl.bundle<b: bundle<c: uint<1>>>
   }
 }
 
@@ -160,7 +160,7 @@ firrtl.circuit "Foo" {
 firrtl.circuit "Foo" {
 
   // CHECK-LABEL: firrtl.module @Foo
-  firrtl.module @Foo(%clock: !firrtl.clock, %rAddr: !firrtl.uint<4>, %rEn: !firrtl.uint<1>, %rData: !firrtl.flip<bundle<a: uint<8>, b: uint<8>>>, %wAddr: !firrtl.uint<4>, %wEn: !firrtl.uint<1>, %wMask: !firrtl.bundle<a: uint<1>, b: uint<1>>, %wData: !firrtl.bundle<a: uint<8>, b: uint<8>>) {
+  firrtl.module @Foo(in %clock: !firrtl.clock, in %rAddr: !firrtl.uint<4>, in %rEn: !firrtl.uint<1>, out %rData: !firrtl.bundle<a: uint<8>, b: uint<8>>, in %wAddr: !firrtl.uint<4>, in %wEn: !firrtl.uint<1>, in %wMask: !firrtl.bundle<a: uint<1>, b: uint<1>>, in %wData: !firrtl.bundle<a: uint<8>, b: uint<8>>) {
     %memory_r, %memory_w = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r", "w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<bundle<a: uint<8>, b: uint<8>>>>>, !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>>
     %0 = firrtl.subfield %memory_r("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<bundle<a: uint<8>, b: uint<8>>>>>) -> !firrtl.clock
     firrtl.connect %0, %clock : !firrtl.clock, !firrtl.clock
@@ -169,7 +169,7 @@ firrtl.circuit "Foo" {
     %2 = firrtl.subfield %memory_r("addr") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<bundle<a: uint<8>, b: uint<8>>>>>) -> !firrtl.uint<4>
     firrtl.connect %2, %rAddr : !firrtl.uint<4>, !firrtl.uint<4>
     %3 = firrtl.subfield %memory_r("data") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<bundle<a: uint<8>, b: uint<8>>>>>) -> !firrtl.bundle<a: uint<8>, b: uint<8>>
-    firrtl.connect %rData, %3 : !firrtl.flip<bundle<a: uint<8>, b: uint<8>>>, !firrtl.bundle<a: uint<8>, b: uint<8>>
+    firrtl.connect %rData, %3 : !firrtl.bundle<a: uint<8>, b: uint<8>>, !firrtl.bundle<a: uint<8>, b: uint<8>>
     %4 = firrtl.subfield %memory_w("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>>) -> !firrtl.clock
     firrtl.connect %4, %clock : !firrtl.clock, !firrtl.clock
     %5 = firrtl.subfield %memory_w("en") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>>) -> !firrtl.uint<1>
@@ -280,7 +280,7 @@ firrtl.circuit "Foo" {
 //    rwDataOut <= memory.rw.rdata
 
 firrtl.circuit "MemoryRWSplit" {
-  firrtl.module @MemoryRWSplit(%clock: !firrtl.clock, %rwEn: !firrtl.uint<1>, %rwMode: !firrtl.uint<1>, %rwAddr: !firrtl.uint<4>, %rwMask: !firrtl.uint<1>, %rwDataIn: !firrtl.uint<8>, %rwDataOut: !firrtl.flip<uint<8>>) {
+  firrtl.module @MemoryRWSplit(in %clock: !firrtl.clock, in %rwEn: !firrtl.uint<1>, in %rwMode: !firrtl.uint<1>, in %rwAddr: !firrtl.uint<4>, in %rwMask: !firrtl.uint<1>, in %rwDataIn: !firrtl.uint<8>, out %rwDataOut: !firrtl.uint<8>) {
     %memory_rw = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["rw"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, wmode: uint<1>, rdata: flip<uint<8>>, wdata: uint<8>, wmask: uint<1>>>
     %0 = firrtl.subfield %memory_rw("clk") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, wmode: uint<1>, rdata: flip<uint<8>>, wdata: uint<8>, wmask: uint<1>>>) -> !firrtl.clock
     firrtl.connect %0, %clock : !firrtl.clock, !firrtl.clock
@@ -295,7 +295,7 @@ firrtl.circuit "MemoryRWSplit" {
     %5 = firrtl.subfield %memory_rw("wdata") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, wmode: uint<1>, rdata: flip<uint<8>>, wdata: uint<8>, wmask: uint<1>>>) -> !firrtl.uint<8>
     firrtl.connect %5, %rwDataIn : !firrtl.uint<8>, !firrtl.uint<8>
     %6 = firrtl.subfield %memory_rw("rdata") : (!firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, wmode: uint<1>, rdata: flip<uint<8>>, wdata: uint<8>, wmask: uint<1>>>) -> !firrtl.uint<8>
-    firrtl.connect %rwDataOut, %6 : !firrtl.flip<uint<8>>, !firrtl.uint<8>
+    firrtl.connect %rwDataOut, %6 : !firrtl.uint<8>, !firrtl.uint<8>
   }
 
   // CHECK-LABEL: firrtl.module @MemoryRWSplit
@@ -371,9 +371,9 @@ firrtl.circuit "MemoryRWSplitUnique" {
 
 module  {
   firrtl.circuit "top_mod" {
-    firrtl.module @mod_2(%clock: !firrtl.clock, %inp_a: !firrtl.bundle<inp_d: uint<14>>) {
+    firrtl.module @mod_2(in %clock: !firrtl.clock, in %inp_a: !firrtl.bundle<inp_d: uint<14>>) {
     }
-    firrtl.module @top_mod(%clock: !firrtl.clock) {
+    firrtl.module @top_mod(in %clock: !firrtl.clock) {
       %U0_clock, %U0_inp_a = firrtl.instance @mod_2 {name = "U0"} : !firrtl.flip<clock>, !firrtl.flip<bundle<inp_d: uint<14>>>
       %0 = firrtl.invalidvalue : !firrtl.clock
       firrtl.connect %U0_clock, %0 : !firrtl.flip<clock>, !firrtl.clock
@@ -385,9 +385,9 @@ module  {
 
 //CHECK-LABEL: module  {
 //CHECK-NEXT:   firrtl.circuit "top_mod" {
-//CHECK-NEXT:     firrtl.module @mod_2(%clock: !firrtl.clock, %inp_a_inp_d: !firrtl.uint<14>) {
+//CHECK-NEXT:     firrtl.module @mod_2(in %clock: !firrtl.clock, in %inp_a_inp_d: !firrtl.uint<14>) {
 //CHECK-NEXT:     }
-//CHECK-NEXT:    firrtl.module @top_mod(%clock: !firrtl.clock) {
+//CHECK-NEXT:    firrtl.module @top_mod(in %clock: !firrtl.clock) {
 //CHECK-NEXT:      %U0_clock, %U0_inp_a_inp_d = firrtl.instance @mod_2 {name = "U0"} : !firrtl.flip<clock>, !firrtl.flip<uint<14>>
 //CHECK-NEXT:      %0 = firrtl.invalidvalue : !firrtl.clock
 //CHECK-NEXT:      firrtl.connect %U0_clock, %0 : !firrtl.flip<clock>, !firrtl.clock
@@ -404,7 +404,7 @@ module  {
 module  {
   firrtl.circuit "Issue661" {
     // CHECK-LABEL: firrtl.module @Issue661
-    firrtl.module @Issue661(%clock: !firrtl.clock) {
+    firrtl.module @Issue661(in %clock: !firrtl.clock) {
       %head_MPORT_2, %head_MPORT_6 = firrtl.mem Undefined {depth = 20 : i64, name = "head", portNames = ["MPORT_2", "MPORT_6"], readLatency = 0 : i32, writeLatency = 1 : i32}
       : !firrtl.flip<bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<5>, mask: uint<1>>>,
         !firrtl.flip<bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<5>, mask: uint<1>>>
@@ -414,16 +414,16 @@ module  {
 }
 
 firrtl.circuit "RegBundle" {
-    // CHECK-LABEL: firrtl.module @RegBundle(%a_a: !firrtl.uint<1>, %clk: !firrtl.clock, %b_a: !firrtl.flip<uint<1>>) {
-    firrtl.module @RegBundle(%a: !firrtl.bundle<a: uint<1>>, %clk: !firrtl.clock, %b: !firrtl.flip<bundle<a: uint<1>>>) {
+    // CHECK-LABEL: firrtl.module @RegBundle(in %a_a: !firrtl.uint<1>, in %clk: !firrtl.clock, out %b_a: !firrtl.uint<1>) {
+    firrtl.module @RegBundle(in %a: !firrtl.bundle<a: uint<1>>, in %clk: !firrtl.clock, out %b: !firrtl.bundle<a: uint<1>>) {
       // CHECK-NEXT: %x_a = firrtl.reg %clk : (!firrtl.clock) -> !firrtl.uint<1>
       // CHECK-NEXT: firrtl.connect %x_a, %a_a : !firrtl.uint<1>, !firrtl.uint<1>
-      // CHECK-NEXT: firrtl.connect %b_a, %x_a : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+      // CHECK-NEXT: firrtl.connect %b_a, %x_a : !firrtl.uint<1>, !firrtl.uint<1>
       %x = firrtl.reg %clk {name = "x"} : (!firrtl.clock) -> !firrtl.bundle<a: uint<1>>
       %0 = firrtl.subfield %x("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
       %1 = firrtl.subfield %a("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
       firrtl.connect %0, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-      %2 = firrtl.subfield %b("a") : (!firrtl.flip<bundle<a: uint<1>>>) -> !firrtl.uint<1>
+      %2 = firrtl.subfield %b("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
       %3 = firrtl.subfield %x("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
       firrtl.connect %2, %3 : !firrtl.uint<1>, !firrtl.uint<1>
     }
@@ -432,30 +432,30 @@ firrtl.circuit "RegBundle" {
 // -----
 
 firrtl.circuit "RegBundleWithBulkConnect" {
-    // CHECK-LABEL: firrtl.module @RegBundleWithBulkConnect(%a_a: !firrtl.uint<1>, %clk: !firrtl.clock, %b_a: !firrtl.flip<uint<1>>) {
-    firrtl.module @RegBundleWithBulkConnect(%a: !firrtl.bundle<a: uint<1>>, %clk: !firrtl.clock, %b: !firrtl.flip<bundle<a: uint<1>>>) {
+    // CHECK-LABEL: firrtl.module @RegBundleWithBulkConnect(in %a_a: !firrtl.uint<1>, in %clk: !firrtl.clock, out %b_a: !firrtl.uint<1>) {
+    firrtl.module @RegBundleWithBulkConnect(in %a: !firrtl.bundle<a: uint<1>>, in %clk: !firrtl.clock, out %b: !firrtl.bundle<a: uint<1>>) {
       // CHECK-NEXT: %x_a = firrtl.reg %clk : (!firrtl.clock) -> !firrtl.uint<1>
       // CHECK-NEXT: firrtl.connect %x_a, %a_a : !firrtl.uint<1>, !firrtl.uint<1>
-      // CHECK-NEXT: firrtl.connect %b_a, %x_a : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+      // CHECK-NEXT: firrtl.connect %b_a, %x_a : !firrtl.uint<1>, !firrtl.uint<1>
       %x = firrtl.reg %clk {name = "x"} : (!firrtl.clock) -> !firrtl.bundle<a: uint<1>>
       firrtl.connect %x, %a : !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>
-      firrtl.connect %b, %x : !firrtl.flip<bundle<a: uint<1>>>, !firrtl.bundle<a: uint<1>>
+      firrtl.connect %b, %x : !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>
     }
 }
 
 // -----
 
 firrtl.circuit "WireBundle" {
-    // CHECK-LABEL: firrtl.module @WireBundle(%a_a: !firrtl.uint<1>,  %b_a: !firrtl.flip<uint<1>>) {
-    firrtl.module @WireBundle(%a: !firrtl.bundle<a: uint<1>>,  %b: !firrtl.flip<bundle<a: uint<1>>>) {
+    // CHECK-LABEL: firrtl.module @WireBundle(in %a_a: !firrtl.uint<1>,  out %b_a: !firrtl.uint<1>) {
+    firrtl.module @WireBundle(in %a: !firrtl.bundle<a: uint<1>>,  out %b: !firrtl.bundle<a: uint<1>>) {
       // CHECK-NEXT: %x_a = firrtl.wire  : !firrtl.uint<1>
       // CHECK-NEXT: firrtl.connect %x_a, %a_a : !firrtl.uint<1>, !firrtl.uint<1>
-      // CHECK-NEXT: firrtl.connect %b_a, %x_a : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+      // CHECK-NEXT: firrtl.connect %b_a, %x_a : !firrtl.uint<1>, !firrtl.uint<1>
       %x = firrtl.wire : !firrtl.bundle<a: uint<1>>
       %0 = firrtl.subfield %x("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
       %1 = firrtl.subfield %a("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
       firrtl.connect %0, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-      %2 = firrtl.subfield %b("a") : (!firrtl.flip<bundle<a: uint<1>>>) -> !firrtl.uint<1>
+      %2 = firrtl.subfield %b("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
       %3 = firrtl.subfield %x("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
       firrtl.connect %2, %3 : !firrtl.uint<1>, !firrtl.uint<1>
     }
@@ -465,30 +465,30 @@ firrtl.circuit "WireBundle" {
 
 firrtl.circuit "WireBundlesWithBulkConnect" {
   // CHECK-LABEL: firrtl.module @WireBundlesWithBulkConnect
-  firrtl.module @WireBundlesWithBulkConnect(%source: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>,
-                             %sink: !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>) {
+  firrtl.module @WireBundlesWithBulkConnect(in %source: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>,
+                             out %sink: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>) {
     // CHECK: %w_valid = firrtl.wire  : !firrtl.uint<1>
     // CHECK: %w_ready = firrtl.wire  : !firrtl.uint<1>
     // CHECK: %w_data = firrtl.wire  : !firrtl.uint<64>
     %w = firrtl.wire : !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
     // CHECK: firrtl.connect %w_valid, %source_valid : !firrtl.uint<1>, !firrtl.uint<1>
-    // CHECK: firrtl.connect %source_ready, %w_ready : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+    // CHECK: firrtl.connect %source_ready, %w_ready : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: firrtl.connect %w_data, %source_data : !firrtl.uint<64>, !firrtl.uint<64>
     firrtl.connect %w, %source : !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
-    // CHECK: firrtl.connect %sink_valid, %w_valid : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+    // CHECK: firrtl.connect %sink_valid, %w_valid : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: firrtl.connect %w_ready, %sink_ready : !firrtl.uint<1>, !firrtl.uint<1>
-    // CHECK: firrtl.connect %sink_data, %w_data : !firrtl.flip<uint<64>>, !firrtl.uint<64>
-    firrtl.connect %sink, %w : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
+    // CHECK: firrtl.connect %sink_data, %w_data : !firrtl.uint<64>, !firrtl.uint<64>
+    firrtl.connect %sink, %w : !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>
   }
 }
 
 // -----
 // COM: Test vector lowering
 firrtl.circuit "LowerVectors" {
-  firrtl.module @LowerVectors(%a: !firrtl.vector<uint<1>, 2>, %b: !firrtl.flip<vector<uint<1>, 2>>) {
-    firrtl.connect %b, %a: !firrtl.flip<vector<uint<1>, 2>>, !firrtl.vector<uint<1>, 2>
+  firrtl.module @LowerVectors(in %a: !firrtl.vector<uint<1>, 2>, out %b: !firrtl.vector<uint<1>, 2>) {
+    firrtl.connect %b, %a: !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
   }
-  // CHECK-LABEL: firrtl.module @LowerVectors(%a_0: !firrtl.uint<1>, %a_1: !firrtl.uint<1>, %b_0: !firrtl.flip<uint<1>>, %b_1: !firrtl.flip<uint<1>>)
+  // CHECK-LABEL: firrtl.module @LowerVectors(in %a_0: !firrtl.uint<1>, in %a_1: !firrtl.uint<1>, out %b_0: !firrtl.uint<1>, out %b_1: !firrtl.uint<1>)
   // CHECK: firrtl.connect %b_0, %a_0
   // CHECK: firrtl.connect %b_1, %a_1
 }
@@ -497,21 +497,21 @@ firrtl.circuit "LowerVectors" {
 
 // COM: Test vector of bundles lowering
 firrtl.circuit "LowerVectorsOfBundles" {
-  // CHECK-LABEL: firrtl.module @LowerVectorsOfBundles(%in_0_a: !firrtl.uint<1>, %in_0_b: !firrtl.flip<uint<1>>, %in_1_a: !firrtl.uint<1>, %in_1_b: !firrtl.flip<uint<1>>, %out_0_a: !firrtl.flip<uint<1>>, %out_0_b: !firrtl.uint<1>, %out_1_a: !firrtl.flip<uint<1>>, %out_1_b: !firrtl.uint<1>) {
-  firrtl.module @LowerVectorsOfBundles(%in: !firrtl.vector<bundle<a : uint<1>, b : flip<uint<1>>>, 2>,
-                                       %out: !firrtl.flip<vector<bundle<a : uint<1>, b : flip<uint<1>>>, 2>>) {
-    // CHECK: firrtl.connect %out_0_a, %in_0_a : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-    // CHECK: firrtl.connect %in_0_b, %out_0_b : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-    // CHECK: firrtl.connect %out_1_a, %in_1_a : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-    // CHECK: firrtl.connect %in_1_b, %out_1_b : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-    firrtl.connect %out, %in: !firrtl.flip<vector<bundle<a : uint<1>, b : flip<uint<1>>>, 2>>, !firrtl.vector<bundle<a : uint<1>, b : flip<uint<1>>>, 2>
+  // CHECK-LABEL: firrtl.module @LowerVectorsOfBundles(in %in_0_a: !firrtl.uint<1>, out %in_0_b: !firrtl.uint<1>, in %in_1_a: !firrtl.uint<1>, out %in_1_b: !firrtl.uint<1>, out %out_0_a: !firrtl.uint<1>, in %out_0_b: !firrtl.uint<1>, out %out_1_a: !firrtl.uint<1>, in %out_1_b: !firrtl.uint<1>) {
+  firrtl.module @LowerVectorsOfBundles(in %in: !firrtl.vector<bundle<a : uint<1>, b : flip<uint<1>>>, 2>,
+                                       out %out: !firrtl.vector<bundle<a : uint<1>, b : flip<uint<1>>>, 2>) {
+    // CHECK: firrtl.connect %out_0_a, %in_0_a : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK: firrtl.connect %in_0_b, %out_0_b : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK: firrtl.connect %out_1_a, %in_1_a : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK: firrtl.connect %in_1_b, %out_1_b : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %out, %in: !firrtl.vector<bundle<a : uint<1>, b : flip<uint<1>>>, 2>, !firrtl.vector<bundle<a : uint<1>, b : flip<uint<1>>>, 2>
   }
 }
 
 // -----
 firrtl.circuit "ExternalModule" {
-  // CHECK-LABEL: firrtl.extmodule @ExternalModule(%source_valid: !firrtl.uint<1>, %source_ready: !firrtl.flip<uint<1>>, %source_data: !firrtl.uint<64>)
-  firrtl.extmodule @ExternalModule(!firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>> ) attributes {portNames = ["source"]}
+  // CHECK-LABEL: firrtl.extmodule @ExternalModule(in %source_valid: !firrtl.uint<1>, out %source_ready: !firrtl.uint<1>, in %source_data: !firrtl.uint<64>)
+  firrtl.extmodule @ExternalModule(in %source: !firrtl.bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>> )
   firrtl.module @Test() {
     // CHECK:  %inst_source_valid, %inst_source_ready, %inst_source_data = firrtl.instance @ExternalModule  {name = ""} : !firrtl.flip<uint<1>>, !firrtl.uint<1>, !firrtl.flip<uint<64>>
     %inst_source = firrtl.instance @ExternalModule {name = ""} : !firrtl.flip<bundle<valid: uint<1>, ready: flip<uint<1>>, data: uint<64>>>
@@ -523,7 +523,7 @@ firrtl.circuit "ExternalModule" {
 // Test RegResetOp lowering
 firrtl.circuit "LowerRegResetOp" {
   // CHECK-LABEL: firrtl.module @LowerRegResetOp
-  firrtl.module @LowerRegResetOp(%clock: !firrtl.clock, %reset: !firrtl.uint<1>, %a_d: !firrtl.vector<uint<1>, 2>, %a_q: !firrtl.flip<vector<uint<1>, 2>>) {
+  firrtl.module @LowerRegResetOp(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %a_d: !firrtl.vector<uint<1>, 2>, out %a_q: !firrtl.vector<uint<1>, 2>) {
     %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
     %init = firrtl.wire  : !firrtl.vector<uint<1>, 2>
     %0 = firrtl.subindex %init[0] : !firrtl.vector<uint<1>, 2>
@@ -532,7 +532,7 @@ firrtl.circuit "LowerRegResetOp" {
     firrtl.connect %1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     %r = firrtl.regreset %clock, %reset, %init {name = "r"} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<1>, 2>) -> !firrtl.vector<uint<1>, 2>
     firrtl.connect %r, %a_d : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
-    firrtl.connect %a_q, %r : !firrtl.flip<vector<uint<1>, 2>>, !firrtl.vector<uint<1>, 2>
+    firrtl.connect %a_q, %r : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
   }
   // CHECK:   %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
   // CHECK:   %init_0 = firrtl.wire  : !firrtl.uint<1>
@@ -543,8 +543,8 @@ firrtl.circuit "LowerRegResetOp" {
   // CHECK:   %r_1 = firrtl.regreset %clock, %reset, %init_1 : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   // CHECK:   firrtl.connect %r_0, %a_d_0 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:   firrtl.connect %r_1, %a_d_1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK:   firrtl.connect %a_q_0, %r_0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  // CHECK:   firrtl.connect %a_q_1, %r_1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK:   firrtl.connect %a_q_0, %r_0 : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK:   firrtl.connect %a_q_1, %r_1 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
 // -----
@@ -553,7 +553,7 @@ firrtl.circuit "LowerRegResetOp" {
 // https://github.com/llvm/circt/issues/795
 firrtl.circuit "LowerRegResetOpNoName" {
   // CHECK-LABEL: firrtl.module @LowerRegResetOpNoName
-  firrtl.module @LowerRegResetOpNoName(%clock: !firrtl.clock, %reset: !firrtl.uint<1>, %a_d: !firrtl.vector<uint<1>, 2>, %a_q: !firrtl.flip<vector<uint<1>, 2>>) {
+  firrtl.module @LowerRegResetOpNoName(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %a_d: !firrtl.vector<uint<1>, 2>, out %a_q: !firrtl.vector<uint<1>, 2>) {
     %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
     %init = firrtl.wire  : !firrtl.vector<uint<1>, 2>
     %0 = firrtl.subindex %init[0] : !firrtl.vector<uint<1>, 2>
@@ -562,7 +562,7 @@ firrtl.circuit "LowerRegResetOpNoName" {
     firrtl.connect %1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     %r = firrtl.regreset %clock, %reset, %init {name = ""} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<1>, 2>) -> !firrtl.vector<uint<1>, 2>
     firrtl.connect %r, %a_d : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
-    firrtl.connect %a_q, %r : !firrtl.flip<vector<uint<1>, 2>>, !firrtl.vector<uint<1>, 2>
+    firrtl.connect %a_q, %r : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
   }
   // CHECK:   %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
   // CHECK:   %init_0 = firrtl.wire  : !firrtl.uint<1>
@@ -573,8 +573,8 @@ firrtl.circuit "LowerRegResetOpNoName" {
   // CHECK:   %1 = firrtl.regreset %clock, %reset, %init_1 : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   // CHECK:   firrtl.connect %0, %a_d_0 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:   firrtl.connect %1, %a_d_1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK:   firrtl.connect %a_q_0, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-  // CHECK:   firrtl.connect %a_q_1, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+  // CHECK:   firrtl.connect %a_q_0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK:   firrtl.connect %a_q_1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
 // -----
@@ -583,17 +583,17 @@ firrtl.circuit "LowerRegResetOpNoName" {
 // https://github.com/llvm/circt/issues/795
 firrtl.circuit "lowerRegOpNoName" {
   // CHECK-LABEL: firrtl.module @lowerRegOpNoName
-  firrtl.module @lowerRegOpNoName(%clock: !firrtl.clock, %a_d: !firrtl.vector<uint<1>, 2>, %a_q: !firrtl.flip<vector<uint<1>, 2>>) {
+  firrtl.module @lowerRegOpNoName(in %clock: !firrtl.clock, in %a_d: !firrtl.vector<uint<1>, 2>, out %a_q: !firrtl.vector<uint<1>, 2>) {
     %r = firrtl.reg %clock {name = ""} : (!firrtl.clock) -> !firrtl.vector<uint<1>, 2>
       firrtl.connect %r, %a_d : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
-      firrtl.connect %a_q, %r : !firrtl.flip<vector<uint<1>, 2>>, !firrtl.vector<uint<1>, 2>
+      firrtl.connect %a_q, %r : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
   }
  // CHECK:    %0 = firrtl.reg %clock : (!firrtl.clock) -> !firrtl.uint<1>
  // CHECK:    %1 = firrtl.reg %clock : (!firrtl.clock) -> !firrtl.uint<1>
  // CHECK:    firrtl.connect %0, %a_d_0 : !firrtl.uint<1>, !firrtl.uint<1>
  // CHECK:    firrtl.connect %1, %a_d_1 : !firrtl.uint<1>, !firrtl.uint<1>
- // CHECK:    firrtl.connect %a_q_0, %0 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
- // CHECK:    firrtl.connect %a_q_1, %1 : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+ // CHECK:    firrtl.connect %a_q_0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+ // CHECK:    firrtl.connect %a_q_1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
 // -----
@@ -601,9 +601,9 @@ firrtl.circuit "lowerRegOpNoName" {
 // Test that InstanceOp Annotations are copied to the new instance.
 // CHECK-LABEL: firrtl.circuit "AnnotationsInstanceOp"
 firrtl.circuit "AnnotationsInstanceOp" {
-  firrtl.module @Bar(%a: !firrtl.flip<vector<uint<1>, 2>>) {
+  firrtl.module @Bar(out %a: !firrtl.vector<uint<1>, 2>) {
     %0 = firrtl.invalidvalue : !firrtl.vector<uint<1>, 2>
-    firrtl.connect %a, %0 : !firrtl.flip<vector<uint<1>, 2>>, !firrtl.vector<uint<1>, 2>
+    firrtl.connect %a, %0 : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
   }
   firrtl.module @AnnotationsInstanceOp() {
     %bar_a = firrtl.instance @Bar  {annotations = [{a = "a"}], name = "bar"} : !firrtl.vector<uint<1>, 2>
@@ -645,7 +645,7 @@ firrtl.circuit "AnnotationsWireOp" {
 // Test that Reg/RegResetOp Annotations are copied to lowered registers.
 firrtl.circuit "AnnotationsRegOp" {
   // CHECK-LABEL: firrtl.module @AnnotationsRegOp
-  firrtl.module @AnnotationsRegOp(%clock: !firrtl.clock, %reset: !firrtl.uint<1>) {
+  firrtl.module @AnnotationsRegOp(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
     %bazInit = firrtl.wire  : !firrtl.vector<uint<1>, 2>
     %0 = firrtl.subindex %bazInit[0] : !firrtl.vector<uint<1>, 2>
     %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
@@ -669,25 +669,25 @@ firrtl.circuit "AnnotationsRegOp" {
 
 // Test that WhenOp with regions has its regions lowered.
 firrtl.circuit "WhenOp" {
-  firrtl.module @WhenOp (%p: !firrtl.uint<1>,
-                         %in : !firrtl.bundle<a: uint<1>, b: uint<1>>,
-                         %out : !firrtl.flip<bundle<a: uint<1>, b: uint<1>>>) {
+  firrtl.module @WhenOp (in %p: !firrtl.uint<1>,
+                         in %in : !firrtl.bundle<a: uint<1>, b: uint<1>>,
+                         out %out : !firrtl.bundle<a: uint<1>, b: uint<1>>) {
     // No else region.
     firrtl.when %p {
-      // CHECK: firrtl.connect %out_a, %in_a : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-      // CHECK: firrtl.connect %out_b, %in_b : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-      firrtl.connect %out, %in : !firrtl.flip<bundle<a: uint<1>, b: uint<1>>>, !firrtl.bundle<a: uint<1>, b: uint<1>>
+      // CHECK: firrtl.connect %out_a, %in_a : !firrtl.uint<1>, !firrtl.uint<1>
+      // CHECK: firrtl.connect %out_b, %in_b : !firrtl.uint<1>, !firrtl.uint<1>
+      firrtl.connect %out, %in : !firrtl.bundle<a: uint<1>, b: uint<1>>, !firrtl.bundle<a: uint<1>, b: uint<1>>
     }
 
     // Else region.
     firrtl.when %p {
-      // CHECK: firrtl.connect %out_a, %in_a : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-      // CHECK: firrtl.connect %out_b, %in_b : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-      firrtl.connect %out, %in : !firrtl.flip<bundle<a: uint<1>, b: uint<1>>>, !firrtl.bundle<a: uint<1>, b: uint<1>>
+      // CHECK: firrtl.connect %out_a, %in_a : !firrtl.uint<1>, !firrtl.uint<1>
+      // CHECK: firrtl.connect %out_b, %in_b : !firrtl.uint<1>, !firrtl.uint<1>
+      firrtl.connect %out, %in : !firrtl.bundle<a: uint<1>, b: uint<1>>, !firrtl.bundle<a: uint<1>, b: uint<1>>
     } else {
-      // CHECK: firrtl.connect %out_a, %in_a : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-      // CHECK: firrtl.connect %out_b, %in_b : !firrtl.flip<uint<1>>, !firrtl.uint<1>
-      firrtl.connect %out, %in : !firrtl.flip<bundle<a: uint<1>, b: uint<1>>>, !firrtl.bundle<a: uint<1>, b: uint<1>>
+      // CHECK: firrtl.connect %out_a, %in_a : !firrtl.uint<1>, !firrtl.uint<1>
+      // CHECK: firrtl.connect %out_b, %in_b : !firrtl.uint<1>, !firrtl.uint<1>
+      firrtl.connect %out, %in : !firrtl.bundle<a: uint<1>, b: uint<1>>, !firrtl.bundle<a: uint<1>, b: uint<1>>
     }
   }
 }
@@ -710,7 +710,7 @@ firrtl.circuit "AnnotationsBundle" {
 
 // Test that subfield annotations on reg are lowred to appropriate instance based on target.
 firrtl.circuit "AnnotationsBundle2" {
-  firrtl.module @AnnotationsBundle2(%clock: !firrtl.clock) {
+  firrtl.module @AnnotationsBundle2(in %clock: !firrtl.clock) {
     %bar = firrtl.reg %clock  {annotations = [{one, target = [".qux"]}, {target = ["[1]", ".baz"], two}]} : (!firrtl.clock) -> !firrtl.vector<bundle<baz: uint<1>, qux: uint<1>>, 2>
 
     // CHECK: %bar_0_baz = firrtl.reg %clock  : (!firrtl.clock) -> !firrtl.uint<1>
@@ -726,7 +726,7 @@ firrtl.circuit "AnnotationsBundle2" {
 // circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar[0].qux[0]"},{"two":null,"target":"~Foo|Foo>bar[1].baz"},{"three":null,"target":"~Foo|Foo>bar[0].yes"} ]]
 
 firrtl.circuit "AnnotationsBundle3" {
-  firrtl.module @AnnotationsBundle3(%clock: !firrtl.clock) {
+  firrtl.module @AnnotationsBundle3(in %clock: !firrtl.clock) {
     %bar = firrtl.reg %clock  {annotations = [{one, target = ["[0]", ".qux", "[0]"]}, {target = ["[1]", ".baz"], two}, {target = ["[0]", ".yes"], three}]} : (!firrtl.clock) -> !firrtl.vector<bundle<baz: vector<uint<1>, 2>, qux: vector<uint<1>, 2>, yes: bundle<a: uint<1>, b: uint<1>>>, 2>
 
     // CHECK: %bar_0_baz_0 = firrtl.reg %clock  : (!firrtl.clock) -> !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -2,24 +2,24 @@
 
 circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
-  ; CHECK-LABEL: firrtl.module @MyModule(%in: !firrtl.uint, %out: !firrtl.flip<uint<8>>) {
+  ; CHECK-LABEL: firrtl.module @MyModule(in %in: !firrtl.uint, out %out: !firrtl.uint<8>) {
   module MyModule :   @[FooBar.scala 369:27]
     input in: UInt
     output out: UInt<8>
 
-    ; CHECK: firrtl.connect %out, %in : !firrtl.flip<uint<8>>, !firrtl.uint
+    ; CHECK: firrtl.connect %out, %in : !firrtl.uint<8>, !firrtl.uint
     out <= in
 
   ; CHECK: }
 
 
-  ; CHECK-LABEL: firrtl.module @circuit(%in: !firrtl.uint<80>) {
+  ; CHECK-LABEL: firrtl.module @circuit(in %in: !firrtl.uint<80>) {
   module circuit :    ; Module with a keyword id.
     input in: UInt<80>
 
   ; CHECK: }
 
-  ; CHECK-LABEL: firrtl.extmodule @MyExtModule(%in: !firrtl.uint, %out: !firrtl.flip<uint<8>>)
+  ; CHECK-LABEL: firrtl.extmodule @MyExtModule(in %in: !firrtl.uint, out %out: !firrtl.uint<8>)
   ; CHECK: attributes {defname = "myextmodule"}
   ; CHECK-NOT: {
   extmodule MyExtModule :
@@ -27,7 +27,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     output ,,, out ,,: ,, UInt,<,8,>  ; Commas are whitespace
     defname = myextmodule
 
-  ; CHECK-LABEL: firrtl.extmodule @MyParameterizedExtModule(%in: !firrtl.uint, %out: !firrtl.flip<uint<8>>)
+  ; CHECK-LABEL: firrtl.extmodule @MyParameterizedExtModule(in %in: !firrtl.uint, out %out: !firrtl.uint<8>)
   ; CHECK: attributes {defname = "name_thing",
   ; CHECK: parameters = {DEFAULT = 0 : i64,
   ; CHECK:               DEPTH = 3.242000e+01 : f64,
@@ -63,18 +63,18 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
   ; CHECK-LABEL: firrtl.module @stmts(
   module stmts :
-    input reset : UInt<1>         ; CHECK: %reset: !firrtl.uint<1>,
-    input reset_async: AsyncReset ; CHECK: %reset_async: !firrtl.asyncreset,
-    input reset_abstract: Reset   ; CHECK: %reset_abstract: !firrtl.reset,
-    input clock : Clock           ; CHECK: %clock: !firrtl.clock,
-    output auto : UInt<1>         ; CHECK: %auto: !firrtl.flip<uint<1>>,
-    output auto11 : UInt<11>      ; CHECK: %auto11: !firrtl.flip<uint<11>>,
-    output sauto : SInt<9>        ; CHECK: %sauto: !firrtl.flip<sint<9>>,
-    input i8 : UInt<8>            ; CHECK: %i8: !firrtl.uint<8>,
-    input s1 : SInt<1>            ; CHECK: %s1: !firrtl.sint<1>,
-    input s8 : SInt<8>            ; CHECK: %s8: !firrtl.sint<8>,
-    input a1 : Analog<1>          ; CHECK: %a1: !firrtl.analog<1>,
-    input a8 : Analog<8>          ; CHECK: %a8: !firrtl.analog<8>)
+    input reset : UInt<1>         ; CHECK: in %reset: !firrtl.uint<1>,
+    input reset_async: AsyncReset ; CHECK: in %reset_async: !firrtl.asyncreset,
+    input reset_abstract: Reset   ; CHECK: in %reset_abstract: !firrtl.reset,
+    input clock : Clock           ; CHECK: in %clock: !firrtl.clock,
+    output auto : UInt<1>         ; CHECK: out %auto: !firrtl.uint<1>,
+    output auto11 : UInt<11>      ; CHECK: out %auto11: !firrtl.uint<11>,
+    output sauto : SInt<9>        ; CHECK: out %sauto: !firrtl.sint<9>,
+    input i8 : UInt<8>            ; CHECK: in %i8: !firrtl.uint<8>,
+    input s1 : SInt<1>            ; CHECK: in %s1: !firrtl.sint<1>,
+    input s8 : SInt<8>            ; CHECK: in %s8: !firrtl.sint<8>,
+    input a1 : Analog<1>          ; CHECK: in %a1: !firrtl.analog<1>,
+    input a8 : Analog<8>          ; CHECK: in %a8: !firrtl.analog<8>)
 
     ; CHECK: %_t = firrtl.wire : !firrtl.vector<uint<1>, 12>
     wire _t : UInt<1>[12] @[Nodes.scala 370:76]
@@ -92,7 +92,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     _t <- _t_2
 
     ; CHECK: [[INV:%.+]]  = firrtl.invalidvalue : !firrtl.uint<1>
-    ; CHECK-NEXT: firrtl.connect %auto, [[INV]] : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+    ; CHECK-NEXT: firrtl.connect %auto, [[INV]] : !firrtl.uint<1>, !firrtl.uint<1>
     auto is invalid
 
     ; CHECK-NOT: firrtl.attach %a1
@@ -102,7 +102,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     skip  @[SKipLoc.scala 42:24]
 
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue : !firrtl.uint<1>
-    ; CHECK-NEXT: firrtl.connect %auto, [[INV]] : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+    ; CHECK-NEXT: firrtl.connect %auto, [[INV]] : !firrtl.uint<1>, !firrtl.uint<1>
     auto is invalid
 
     ; CHECK-NOT: firrtl.connect %reset
@@ -111,7 +111,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: [[A:%.+]] = firrtl.subfield %out_0("member") : (!firrtl.bundle<member: bundle<0: bundle<clock: clock, reset: uint<1>>>>) -> !firrtl.bundle<0: bundle<clock: clock, reset: uint<1>>>
     ; CHECK: [[B:%.+]] = firrtl.subfield [[A]]("0") : (!firrtl.bundle<0: bundle<clock: clock, reset: uint<1>>>) -> !firrtl.bundle<clock: clock, reset: uint<1>>
     ; CHECK: [[C:%.+]] = firrtl.subfield [[B]]("reset") : (!firrtl.bundle<clock: clock, reset: uint<1>>) -> !firrtl.uint<1>
-    ; CHECK: firrtl.partialconnect %auto, [[C]] : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+    ; CHECK: firrtl.partialconnect %auto, [[C]] : !firrtl.uint<1>, !firrtl.uint<1>
     auto <- out_0.member.0.reset @[Field 173:49]
 
     ; CHECK: [[A:%.+]] = firrtl.subindex %_t_2[0] : !firrtl.vector<uint<1>, 12>
@@ -180,8 +180,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.asClock %reset_async : (!firrtl.asyncreset) -> !firrtl.clock
     node check_c5 = asClock(reset_async)
 
-    ; CHECK: [[PASSIVE:%.*]] = firrtl.asPassive %auto : !firrtl.flip<uint<1>>
-    ; CHECK: firrtl.node [[PASSIVE]]  : !firrtl.uint<1>
+    ; CHECK: firrtl.node %auto  : !firrtl.uint<1>
     node check_output = auto
 
     ; CHECK: %c42_ui10 = firrtl.constant(42 : ui10) : !firrtl.uint<10>
@@ -327,8 +326,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.subaccess %_t[%i8] : !firrtl.vector<uint<1>, 12>, !firrtl.uint<8>
     auto <= _t[i8]
 
-    ; CHECK: [[autoP:%.+]] = firrtl.asPassive %auto : !firrtl.flip<uint<1>>
-    ; CHECK: firrtl.subaccess %_t{{\[}}[[autoP]]] : !firrtl.vector<uint<1>, 12>, !firrtl.uint<1>
+    ; CHECK: firrtl.subaccess %_t{{\[}}%auto] : !firrtl.vector<uint<1>, 12>, !firrtl.uint<1>
     auto <= _t[auto]
 
     ; CHECK: %myMem = firrtl.cmem {name = "myMem"} : !firrtl.vector<bundle<id: uint<4>, resp: uint<2>>, 8>
@@ -363,8 +361,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.andr %n12
     node value = andr(_GEN_43)    ;; Uses n12 directly.
 
-    ; CHECK: [[autoP:%.+]] = firrtl.asPassive %auto : !firrtl.flip<uint<1>>
-    ; CHECK-NEXT: = firrtl.not [[autoP]] : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    ; CHECK: = firrtl.not %auto : (!firrtl.uint<1>) -> !firrtl.uint<1>
     node n13 = not(auto)
 
 
@@ -570,12 +567,12 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       write-latency => 1
       read-under-write => undefined
 
-  ; CHECK-LABEL: firrtl.module @issue354(%tmp5: !firrtl.flip<sint<19>>) {
+  ; CHECK-LABEL: firrtl.module @issue354(out %tmp5: !firrtl.sint<19>) {
   module issue354 :
     output tmp5: SInt<19>
     tmp5 <= SInt<19>(8)
      ; CHECK: %c8_si19 = firrtl.constant(8 : si19) : !firrtl.sint<19>
-     ; CHECK: firrtl.connect %tmp5, %c8_si19 : !firrtl.flip<sint<19>>, !firrtl.sint<19>
+     ; CHECK: firrtl.connect %tmp5, %c8_si19 : !firrtl.sint<19>, !firrtl.sint<19>
 
    ; CHECK-LABEL: firrtl.module @issue347
   module issue347 :
@@ -601,8 +598,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input clkIn: Clock
     output clkOut: Clock
     clkOut <= clkIn
-    ; CHECK: [[clkOut_passive:%.+]] = firrtl.asPassive %clkOut
-    ; CHECK: firrtl.reg [[clkOut_passive]]
+    ; CHECK: firrtl.reg %clkOut
     reg r: UInt<1>, clkOut
 
   ; COM: Check that a register reset sink is converted to passive
@@ -611,8 +607,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input clk: Clock
     output rst: UInt<1>
     rst is invalid
-    ; CHECK: [[rst_passive:%.+]] = firrtl.asPassive %rst
-    ; CHECK: firrtl.regreset %clk, [[rst_passive]]
+    ; CHECK: firrtl.regreset %clk, %rst
     reg r: UInt<1>, clk with : (reset => (rst, UInt<1>(0)))
 
   ; COM: Check that a register init sink is converted to passive
@@ -622,8 +617,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input rst: UInt<1>
     output init: UInt<1>
     init is invalid
-    ; CHECK: [[init_passive:%.+]] = firrtl.asPassive %init
-    ; CHECK: firrtl.regreset %clk, %rst, [[init_passive]]
+    ; CHECK: firrtl.regreset %clk, %rst, %init
     reg r: UInt<1>, clk with : (reset => (rst, init))
 
   ; https://github.com/llvm/circt/issues/492
@@ -760,7 +754,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
   ; CHECK-LABEL: firrtl.module @mutableSubIndex606
   module mutableSubIndex606 :
     output io : UInt<1>[8]
-    ; CHECK:  %0 = firrtl.subindex %io[0] : !firrtl.flip<vector<uint<1>, 8>>
+    ; CHECK:  %0 = firrtl.subindex %io[0] : !firrtl.vector<uint<1>, 8>
     ; CHECK: firrtl.connect %0, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     io[0] <= UInt<1>("h00")
 

--- a/test/Dialect/FIRRTL/parse-locations.fir
+++ b/test/Dialect/FIRRTL/parse-locations.fir
@@ -2,7 +2,7 @@
 
 circuit MyModule :  @[CIRCUIT.scala 127]
 
-  ; CHECK-LABEL: firrtl.module @MyModule(%in: !firrtl.uint, %out: !firrtl.flip<uint<8>>) {
+  ; CHECK-LABEL: firrtl.module @MyModule(in %in: !firrtl.uint, out %out: !firrtl.uint<8>) {
   module MyModule :   @[FooBar.scala 369:27]
     input in: UInt
     output out: UInt<8>

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -6,13 +6,13 @@ firrtl.circuit "MyModule" {
 //  input in: UInt<8>
 //  output out: UInt<8>
 //  out <= in
-firrtl.module @MyModule(%in : !firrtl.uint<8>,
-                        %out : !firrtl.flip<uint<8>>) {
-  firrtl.connect %out, %in : !firrtl.flip<uint<8>>, !firrtl.uint<8>
+firrtl.module @MyModule(in %in : !firrtl.uint<8>,
+                        out %out : !firrtl.uint<8>) {
+  firrtl.connect %out, %in : !firrtl.uint<8>, !firrtl.uint<8>
 }
 
-// CHECK-LABEL: firrtl.module @MyModule(%in: !firrtl.uint<8>, %out: !firrtl.flip<uint<8>>) 
-// CHECK-NEXT:    firrtl.connect %out, %in : !firrtl.flip<uint<8>>, !firrtl.uint<8>
+// CHECK-LABEL: firrtl.module @MyModule(in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>)
+// CHECK-NEXT:    firrtl.connect %out, %in : !firrtl.uint<8>, !firrtl.uint<8>
 // CHECK-NEXT:  }
 
 
@@ -25,41 +25,41 @@ firrtl.module @MyModule(%in : !firrtl.uint<8>,
 //    out <= add(b,d)
 
 firrtl.circuit "Top" {
-  firrtl.module @Top(%out: !firrtl.flip<uint>,
-                     %b: !firrtl.uint<32>,
-                     %c: !firrtl.analog<13>,
-                     %d: !firrtl.uint<16>) {
+  firrtl.module @Top(out %out: !firrtl.uint,
+                     in %b: !firrtl.uint<32>,
+                     in %c: !firrtl.analog<13>,
+                     in %d: !firrtl.uint<16>) {
     %3 = firrtl.add %b, %d : (!firrtl.uint<32>, !firrtl.uint<16>) -> !firrtl.uint<33>
 
     %4 = firrtl.invalidvalue : !firrtl.analog<13>
     firrtl.attach %c, %4 : !firrtl.analog<13>, !firrtl.analog<13>
     %5 = firrtl.add %3, %d : (!firrtl.uint<33>, !firrtl.uint<16>) -> !firrtl.uint<34>
 
-    firrtl.connect %out, %5 : !firrtl.flip<uint>, !firrtl.uint<34>
+    firrtl.connect %out, %5 : !firrtl.uint, !firrtl.uint<34>
   }
 }
 
 // CHECK-LABEL: firrtl.circuit "Top" {
-// CHECK-NEXT:    firrtl.module @Top(%out: !firrtl.flip<uint>,
-// CHECK:                            %b: !firrtl.uint<32>, %c: !firrtl.analog<13>, %d: !firrtl.uint<16>) {
+// CHECK-NEXT:    firrtl.module @Top(out %out: !firrtl.uint,
+// CHECK:                            in %b: !firrtl.uint<32>, in %c: !firrtl.analog<13>, in %d: !firrtl.uint<16>) {
 // CHECK-NEXT:      %0 = firrtl.add %b, %d : (!firrtl.uint<32>, !firrtl.uint<16>) -> !firrtl.uint<33>
 // CHECK-NEXT:      %1 = firrtl.invalidvalue : !firrtl.analog<13>
 // CHECK-NEXT:      firrtl.attach %c, %1 : !firrtl.analog<13>, !firrtl.analog<13>
 // CHECK-NEXT:      %2 = firrtl.add %0, %d : (!firrtl.uint<33>, !firrtl.uint<16>) -> !firrtl.uint<34>
-// CHECK-NEXT:      firrtl.connect %out, %2 : !firrtl.flip<uint>, !firrtl.uint<34>
+// CHECK-NEXT:      firrtl.connect %out, %2 : !firrtl.uint, !firrtl.uint<34>
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
 
 
 // Test some hard cases of name handling.
-firrtl.module @Mod2(%in : !firrtl.uint<8>,
-                    %out : !firrtl.flip<uint<8>>) attributes {portNames = ["some_name", "out"]}{
-  firrtl.connect %out, %in : !firrtl.flip<uint<8>>, !firrtl.uint<8>
+firrtl.module @Mod2(in %in : !firrtl.uint<8>,
+                    out %out : !firrtl.uint<8>) attributes {portNames = ["some_name", "out"]}{
+  firrtl.connect %out, %in : !firrtl.uint<8>, !firrtl.uint<8>
 }
 
-// CHECK-LABEL: firrtl.module @Mod2(%some_name: !firrtl.uint<8>,
-// CHECK:                           %out: !firrtl.flip<uint<8>>) 
-// CHECK-NEXT:    firrtl.connect %out, %some_name : !firrtl.flip<uint<8>>, !firrtl.uint<8>
+// CHECK-LABEL: firrtl.module @Mod2(in %some_name: !firrtl.uint<8>,
+// CHECK:                           out %out: !firrtl.uint<8>)
+// CHECK-NEXT:    firrtl.connect %out, %some_name : !firrtl.uint<8>, !firrtl.uint<8>
 // CHECK-NEXT:  }
 
 
@@ -70,7 +70,7 @@ firrtl.module @no_ports() {
 
 // stdIntCast can work with clock inputs/outputs too.
 // CHECK-LABEL: @ClockCast
-firrtl.module @ClockCast(%clock: !firrtl.clock) {
+firrtl.module @ClockCast(in %clock: !firrtl.clock) {
   // CHECK: %0 = firrtl.stdIntCast %clock : (!firrtl.clock) -> i1
   %0 = firrtl.stdIntCast %clock : (!firrtl.clock) -> i1
 
@@ -80,7 +80,7 @@ firrtl.module @ClockCast(%clock: !firrtl.clock) {
 
 
 // CHECK-LABEL: @TestDshRL
-firrtl.module @TestDshRL(%in1 : !firrtl.uint<2>, %in2: !firrtl.uint<3>) {
+firrtl.module @TestDshRL(in %in1 : !firrtl.uint<2>, in %in2: !firrtl.uint<3>) {
   // CHECK: %0 = firrtl.dshl %in1, %in2 : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<9>
   %0 = firrtl.dshl %in1, %in2 : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<9>
 
@@ -92,7 +92,7 @@ firrtl.module @TestDshRL(%in1 : !firrtl.uint<2>, %in2: !firrtl.uint<3>) {
 }
 
 // CHECK-LABEL: @TestNodeName
-firrtl.module @TestNodeName(%in1 : !firrtl.uint<8>) {
+firrtl.module @TestNodeName(in %in1 : !firrtl.uint<8>) {
   // CHECK: %n1 = firrtl.node %in1 : !firrtl.uint<8>
   %n1 = firrtl.node %in1 : !firrtl.uint<8>
 

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -18,8 +18,8 @@ circuit test_mod : %[[{"a": "a"}]]
 
 ; MLIR: firrtl.circuit "test_mod"
 
-; MLIR-LABEL: firrtl.module @test_mod(%a: !firrtl.uint<1>, %b: !firrtl.flip<uint<1>>)
-; MLIR-NEXT:    firrtl.connect %b, %a : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+; MLIR-LABEL: firrtl.module @test_mod(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>)
+; MLIR-NEXT:    firrtl.connect %b, %a : !firrtl.uint<1>, !firrtl.uint<1>
 ; MLIR-NEXT:  }
 
 ; ANNOTATIONS-LABEL: firrtl.circuit "test_mod"

--- a/test/firtool/firtool.mlir
+++ b/test/firtool/firtool.mlir
@@ -2,14 +2,14 @@
 // RUN: firtool %s --format=mlir -verilog |           FileCheck %s --check-prefix=VERILOG
 
 firrtl.circuit "Top" {
-  firrtl.module @Top(%in : !firrtl.uint<8>,
-                          %out : !firrtl.flip<uint<8>>) {
-    firrtl.connect %out, %in : !firrtl.flip<uint<8>>, !firrtl.uint<8>
+  firrtl.module @Top(in %in : !firrtl.uint<8>,
+                     out %out : !firrtl.uint<8>) {
+    firrtl.connect %out, %in : !firrtl.uint<8>, !firrtl.uint<8>
   }
 }
 
-// MLIR-LABEL: firrtl.module @Top(%in: !firrtl.uint<8>, %out: !firrtl.flip<uint<8>>) {
-// MLIR-NEXT:    firrtl.connect %out, %in : !firrtl.flip<uint<8>>, !firrtl.uint<8>
+// MLIR-LABEL: firrtl.module @Top(in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>) {
+// MLIR-NEXT:    firrtl.connect %out, %in : !firrtl.uint<8>, !firrtl.uint<8>
 // MLIR-NEXT:  }
 
 // VERILOG-LABEL: module Top(

--- a/test/firtool/phase-ordering.fir
+++ b/test/firtool/phase-ordering.fir
@@ -3,7 +3,7 @@
 ; Temporary wires should not be introduced by type lowering, and if they are,
 ; they should be cleaned up by canonicalize.
 
-; CHECK-LABEL: firrtl.module @Issue794(%clock: !firrtl.clock,
+; CHECK-LABEL: firrtl.module @Issue794(in %clock: !firrtl.clock,
 ; CHECK-NOT: firrtl.wire
 ; CHECK: }
 circuit Issue794:


### PR DESCRIPTION
Add port direction information to the FIRRTL Dialect. Stop using an outer `FlipType` to mark a module output port. All modules now include an `IntegerAttribute` with key `"portDirections"` which densely stores the direction of each port as a bit. Block argument zero is in bit zero, arg one is in bit one, etc.

This is printed/parsed in a special format which has inputs looking like `input %a: uint<1>` and outputs looking like `output %b: uint<1>`. This is extremely close to the existing FIRRTL syntax. 

@lattner suggested to remove `input` (an input isn't specially marked) and just use `output` to mark outputs. @jackkoenig and @azidar were in favor of keeping the `input` and `output`. Having both is closer to the spirit of FIRRTL IR, so I went with the latter approach.

After this PR, the only place a flip can show up is: 
1. Inside a bundle
2. On an instance or memory port

(2) is kind of weird, but technically correct since FIRRTL IR treats the "type" of a memory or instance as a bundle. We, instead, split this up into its constituent first-level subfields. An even cleaner representation would be to either revert to a bundle representation or to strip these flips and store directionality somewhere else (in the parent module, in a `portDirections` attribute on an instance, or, for memories, just make it implicit).

### Example

The following FIRRTL text:

```scala
circuit Foo:
  module Bar:
    input a: {a: UInt<1>, flip b: UInt<1>}
    a.b <= a.a
  module Foo:
    input a: {a: UInt<1>, flip b: UInt<1>}

    inst bar of Bar
    bar.a <= a
```

Is parsed into:

```mlir
module  {
  firrtl.circuit "Foo"  {
    firrtl.module @Bar(input %a: !firrtl.bundle<a: uint<1>, b: flip<uint<1>>>) {
      %0 = firrtl.subfield %a("b") : (!firrtl.bundle<a: uint<1>, b: flip<uint<1>>>) -> !firrtl.uint<1>
      %1 = firrtl.subfield %a("a") : (!firrtl.bundle<a: uint<1>, b: flip<uint<1>>>) -> !firrtl.uint<1>
      firrtl.connect %0, %1 : !firrtl.uint<1>, !firrtl.uint<1>
    }
    firrtl.module @Foo(input %a: !firrtl.bundle<a: uint<1>, b: flip<uint<1>>>) {
      %bar_a = firrtl.instance @Bar  {name = "bar"} : !firrtl.flip<bundle<a: uint<1>, b: flip<uint<1>>>>
      firrtl.connect %bar_a, %a : !firrtl.flip<bundle<a: uint<1>, b: flip<uint<1>>>>, !firrtl.bundle<a: uint<1>, b: flip<uint<1>>>
    }
  }
}
```

After lowering, the ports get split up into separate input and output ports:

```mlir
module  {
  firrtl.circuit "Foo"  {
    firrtl.module @Bar(input %a_a: !firrtl.uint<1>, output %a_b: !firrtl.uint<1>) {
      firrtl.connect %a_b, %a_a : !firrtl.uint<1>, !firrtl.uint<1>
    }
    firrtl.module @Foo(input %a_a: !firrtl.uint<1>, output %a_b: !firrtl.uint<1>) {
      %bar_a_a, %bar_a_b = firrtl.instance @Bar  {name = "bar"} : !firrtl.flip<uint<1>>, !firrtl.uint<1>
      firrtl.connect %bar_a_a, %a_a : !firrtl.flip<uint<1>>, !firrtl.uint<1>
      firrtl.connect %a_b, %bar_a_b : !firrtl.uint<1>, !firrtl.uint<1>
    }
  }
}
```

For the above, the port encoding can be inspected using the default printer. Both modules have port directions of `0b10`:

```mlir
"module"() ( {
  "firrtl.circuit"() ( {
    "firrtl.module"() ( {
    ^bb0(%a_a: !firrtl.uint<1>, %a_b: !firrtl.uint<1>):  // no predecessors
      "firrtl.connect"(%a_b, %a_a) : (!firrtl.uint<1>, !firrtl.uint<1>) -> ()
    }) {portDirections = 2 : ui2, portNames = ["a_a", "a_b"], sym_name = "Bar", type = (!firrtl.uint<1>, !firrtl.uint<1>) -> ()} : () -> ()
    "firrtl.module"() ( {
    ^bb0(%a_a: !firrtl.uint<1>, %a_b: !firrtl.uint<1>):  // no predecessors
      %bar_a_a, %bar_a_b = "firrtl.instance"() {annotations = [], moduleName = @Bar, name = "bar"} : () -> (!firrtl.flip<uint<1>>, !firrtl.uint<1>)
      "firrtl.connect"(%bar_a_a, %a_a) : (!firrtl.flip<uint<1>>, !firrtl.uint<1>) -> ()
      "firrtl.connect"(%a_b, %bar_a_b) : (!firrtl.uint<1>, !firrtl.uint<1>) -> ()
    }) {portDirections = 2 : ui2, portNames = ["a_a", "a_b"], sym_name = "Foo", type = (!firrtl.uint<1>, !firrtl.uint<1>) -> ()} : () -> ()
  }) {name = "Foo"} : () -> ()
}) : () -> ()
```

### Metadata

Fixes #989.