### PR TITLE
Update LLVM to 39bbfb77264a4a7a216921c2b70a30ba0f27eb56.

### DIFF
--- a/lib/Bindings/Python/CMakeLists.txt
+++ b/lib/Bindings/Python/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Set up Python binding tools
 ################################################################################
 
-include(AddMLIRPythonExtension)
+include(AddMLIRPython)
 add_custom_target(CIRCTBindingsPython)
 
 ################################################################################


### PR DESCRIPTION
This picks up a couple useful features, but is otherwise NFC:

* Python support for casting constructors on types and attributes
* Special cases added to speed up llvm::parallel_for_each