### PR TITLE
Extract Test Code to child modules

### DIFF
--- a/include/circt/Dialect/RTL/RTLOps.h
+++ b/include/circt/Dialect/RTL/RTLOps.h
@@ -53,6 +53,9 @@ bool isAnyModule(Operation *module);
 /// Return the signature for the specified module as a function type.
 FunctionType getModuleType(Operation *module);
 
+/// Returns the verilog module name attr of any module-like type
+StringAttr getVerilogModuleNameAttr(Operation *module);
+
 /// Return the port name for the specified argument or result.
 StringAttr getModuleArgumentNameAttr(Operation *module, size_t argNo);
 StringAttr getModuleResultNameAttr(Operation *module, size_t argNo);

--- a/include/circt/Dialect/RTL/RTLStructure.td
+++ b/include/circt/Dialect/RTL/RTLStructure.td
@@ -19,7 +19,8 @@ def RTLModuleOp : RTLOp<"module",
     name, a list of ports, and a body that represents the connections within
     the module.
   }];
-  let arguments = (ins StrArrayAttr:$argNames, StrArrayAttr:$resultNames);
+  let arguments = (ins StrArrayAttr:$argNames, StrArrayAttr:$resultNames, 
+                       OptionalAttr<StrAttr>:$verilogName);
   let results = (outs);
   let regions = (region SizedRegion<1>:$body);
 
@@ -55,6 +56,11 @@ def RTLModuleOp : RTLOp<"module",
     StringRef getName() {
       return getNameAttr().getValue();
     }
+
+    /// Return the name to use for the Verilog module that we're referencing
+    /// here.  This is typically the symbol, but can be overridden with the
+    /// verilogName attribute.
+    StringAttr getVerilogModuleNameAttr();
 
   private:
     // This trait needs access to the hooks defined below.

--- a/include/circt/Dialect/SV/SVOps.h
+++ b/include/circt/Dialect/SV/SVOps.h
@@ -15,6 +15,7 @@
 
 #include "circt/Dialect/SV/SVDialect.h"
 #include "circt/Dialect/SV/SVTypes.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"

--- a/include/circt/Dialect/SV/SVPasses.h
+++ b/include/circt/Dialect/SV/SVPasses.h
@@ -32,6 +32,8 @@ std::unique_ptr<mlir::Pass> createRTLLegalizeNamesPass();
 std::unique_ptr<mlir::Pass> createRTLGeneratorCalloutPass();
 std::unique_ptr<mlir::Pass> createRTLMemSimImplPass();
 
+std::unique_ptr<mlir::Pass> createSVExtractTestCodePass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/SV/SVPasses.h.inc"

--- a/include/circt/Dialect/SV/SVPasses.td
+++ b/include/circt/Dialect/SV/SVPasses.td
@@ -83,5 +83,17 @@ def RTLMemSimImpl : Pass<"rtl-memory-sim", "ModuleOp"> {
   let dependentDialects = ["circt::sv::SVDialect"];
 }
 
+def SVExtractTestCode : Pass<"sv-extract-test-code", "ModuleOp"> {
+  let summary = "Extract simulation only constructs to modules and bind";
+  let description = [{
+    This pass extracts cover, assume, assert operations to a module, along with
+    any ops feeding them only, to modules which are instantiated with a bind
+    statement.
+  }];
+
+  let constructor = "circt::sv::createSVExtractTestCodePass()";
+  let dependentDialects = ["circt::sv::SVDialect"];
+}
+
 
 #endif // CIRCT_DIALECT_SV_SVPASSES

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -10,6 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+/// Ensure symbol is one of the rtl module.* types
+def isModLikeSym : AttrConstraint<
+  CPred<
+    "rtl::isAnyModule(::mlir::SymbolTable::lookupNearestSymbolFrom("
+      "&$_op, $_self.cast<::mlir::FlatSymbolRefAttr>().getValue()))"
+  >, "is module like">;
+
 //===----------------------------------------------------------------------===//
 // Control flow like-operations
 //===----------------------------------------------------------------------===//
@@ -473,4 +480,28 @@ def CoverOp : SVOp<"cover", [ProceduralOp]> {
   let arguments = (ins AnyType:$property);
   let results = (outs);
   let assemblyFormat = "attr-dict $property `:` type($property)";
+}
+
+def BindOp : SVOp<"bind", [IsolatedFromAbove, HasParent<"mlir::ModuleOp">]> {
+  let summary = "indirect instantiation statement";
+  let description = [{
+    Indirectly instantiate a module in the context of another module.  This
+    implements all-instance module binding in system verilog.  This will
+    generate and validate ".*" name binding.
+  }];
+
+  let arguments = (ins StrAttr:$instanceName, Confined<FlatSymbolRefAttr, [isModLikeSym]>:$src, Confined<FlatSymbolRefAttr, [isModLikeSym]>:$dest);
+  let results = (outs);
+
+  let assemblyFormat = [{$instanceName $src $dest attr-dict}];
+
+  let extraClassDeclaration = [{
+    /// Lookup the module or extmodule for the src symbol.  This returns null on
+    /// invalid IR.
+    Operation *getReferencedSrcModule();
+
+    /// Lookup the module or extmodule for the dest symbol.  This returns null on
+    /// invalid IR.
+    Operation *getReferencedDestModule();
+  }];
 }

--- a/lib/Dialect/RTL/RTLOps.cpp
+++ b/lib/Dialect/RTL/RTLOps.cpp
@@ -126,6 +126,18 @@ FunctionType rtl::getModuleType(Operation *module) {
   return typeAttr.getValue().cast<FunctionType>();
 }
 
+/// Return the name to use for the Verilog module that we're referencing
+/// here.  This is typically the symbol, but can be overridden with the
+/// verilogName attribute.
+StringAttr rtl::getVerilogModuleNameAttr(Operation *module) {
+  auto nameAttr = module->getAttrOfType<StringAttr>("verilogName");
+  if (nameAttr)
+    return nameAttr;
+
+  return module->getAttrOfType<StringAttr>(
+      ::mlir::SymbolTable::getSymbolAttrName());
+}
+
 /// Return the port name for the specified argument or result.
 StringAttr rtl::getModuleArgumentNameAttr(Operation *module, size_t argNo) {
   return module->getAttrOfType<ArrayAttr>("argNames")[argNo].cast<StringAttr>();
@@ -517,6 +529,17 @@ static void printModuleSignature(OpAsmPrinter &p, Operation *op,
     }
     os << ')';
   }
+}
+
+/// Return the name to use for the Verilog module that we're referencing
+/// here.  This is typically the symbol, but can be overridden with the
+/// verilogName attribute.
+StringAttr RTLModuleOp::getVerilogModuleNameAttr() {
+  if (auto vName = verilogNameAttr())
+    return vName;
+
+  return (*this)->getAttrOfType<StringAttr>(
+      ::mlir::SymbolTable::getSymbolAttrName());
 }
 
 static void printModuleOp(OpAsmPrinter &p, Operation *op,

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -933,6 +933,26 @@ LogicalResult PAssignOp::canonicalize(PAssignOp op, PatternRewriter &rewriter) {
 }
 
 //===----------------------------------------------------------------------===//
+// BindOp
+//===----------------------------------------------------------------------===//
+
+Operation *BindOp::getReferencedSrcModule() {
+  auto topLevelModuleOp = (*this)->getParentOfType<ModuleOp>();
+  if (!topLevelModuleOp)
+    return nullptr;
+
+  return topLevelModuleOp.lookupSymbol(src());
+}
+
+Operation *BindOp::getReferencedDestModule() {
+  auto topLevelModuleOp = (*this)->getParentOfType<ModuleOp>();
+  if (!topLevelModuleOp)
+    return nullptr;
+
+  return topLevelModuleOp.lookupSymbol(dest());
+}
+
+//===----------------------------------------------------------------------===//
 // TableGen generated logic.
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/SV/Transforms/CMakeLists.txt
+++ b/lib/Dialect/SV/Transforms/CMakeLists.txt
@@ -4,7 +4,8 @@ add_circt_dialect_library(CIRCTSVTransforms
   RTLLegalizeNames.cpp
   GeneratorCallout.cpp
   RTLMemSimImpl.cpp
-
+  SVExtractTestCode.cpp
+  
   DEPENDS
   CIRCTSVTransformsIncGen
 

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -1,0 +1,170 @@
+//===- SVExtractTestCode.cpp - SV Simulation Extraction Pass --------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This transformation pass extracts simulation constructs to submodules.
+//
+//===----------------------------------------------------------------------===//
+
+#include "SVPassDetail.h"
+#include "circt/Dialect/SV/SVOps.h"
+#include "circt/Dialect/SV/SVPasses.h"
+#include "circt/Dialect/SV/SVVisitors.h"
+#include "circt/Support/ImplicitLocOpBuilder.h"
+#include "mlir/IR/BlockAndValueMapping.h"
+
+#include <set>
+
+using namespace circt;
+using namespace sv;
+
+//===----------------------------------------------------------------------===//
+// StubExternalModules Pass
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+struct rootSets {
+  SmallVector<AssertOp> asserts;
+  SmallVector<AssumeOp> assumes;
+  SmallVector<CoverOp> covers;
+};
+
+void findRoots(Operation* op, rootSets& roots) {
+    for (auto& r : op->getRegions())
+    for(auto& b : r.getBlocks())
+    for (auto& o : b.getOperations())
+    if (auto opInterest = dyn_cast<AssertOp>(o)) {
+        roots.asserts.push_back(opInterest);
+    }
+    else if (auto opInterest = dyn_cast<AssumeOp>(o)) {
+      roots.assumes.push_back(opInterest);
+    } else if (auto opInterest = dyn_cast<CoverOp>(o)) {
+      roots.covers.push_back(opInterest);
+    } else if (op->getNumRegions()) {
+        findRoots(&o, roots);
+    }
+}
+
+bool allUsesInSet(Operation* op, SetVector<Operation*> opSet) {
+  for (auto en : llvm::enumerate(op->getResults())) {
+    auto operand = en.value();
+    for (auto use : operand->getUses())
+        if (!opSet.count(use.getDefiningOp()))
+            return false;
+    return true;
+  }
+}
+
+// Aggressively clone operations to the new module.  This leaves maximum
+// flexibility for optimization after removal of the nodes from the old module.
+SetVector<Operation*> computeCloneSet(std::set<Operation*>& roots) {
+  SetVector<Operation*> results;
+  for (auto op : roots) {
+    getBackwardsSlice(op, results, [](Operation *testOp) -> bool {
+      return !isa<ReadWriteOp>() && !isa<InstanceOp>() && !isa<PAssignOp> &&
+             !isa<PBAssignOp>;
+    });
+  }
+  return results;
+}
+
+void expandRegion(SmallVector<Operation*>& roots) {
+
+    SetVector<Operation*> slice;
+    unsigned currentIndex = 0;
+
+    bool changed = true;
+    SmallVector<Operation*> curWL, nextWL;
+    curWL.insert(region.begin(), region.end());
+    while (changed) {
+        changed = false;
+        for (auto op : curWL) {
+        for (auto arg : op->getOperands()) {
+            if (!region.count(arg.getDefiningOp())) {
+                //Outside set, record
+                inputs.insert(arg);
+                op->dump();    
+                arg.dump(); 
+           }
+        }
+    }
+    return inputs;
+}
+
+rtl::RTLModuleOp createModuleForCut(rtl::RTLModuleOp op,
+                                    DenseSet<Value> &inputs, StringRef name,
+                                    BlockAndValueMapping& cutMap) {
+  OpBuilder b(op->getParentOfType<mlir::ModuleOp>()->getContext());
+   SmallVector<rtl::ModulePortInfo> ports;
+  size_t inputNum = 0;
+  for (auto port : inputs) {
+    ports.push_back({b.getStringAttr(""), rtl::INPUT, port.getType(),
+                     inputNum++});
+                     llvm::errs() << inputNum - 1 << ": ";
+                     port.dump();
+                     port.getType().dump();
+                     llvm::errs() << "\n";
+  }
+  std::array<NamedAttribute, 1> bindAttr = {
+      b.getNamedAttr("genAsBind", b.getBoolAttr(true))};
+  auto newMod = b.create<rtl::RTLModuleOp>(op.getLoc(), b.getStringAttr(name), ports, bindAttr);
+  inputNum = 0;
+  for (auto port : inputs) {
+      cutMap.map(port, newMod.body().getArgument(inputNum++));
+  }
+    return newMod;
+  }
+
+  void migrateOps(rtl::RTLModuleOp oldMod, rtl::RTLModuleOp newMod,
+                  std::set<Operation *> &ops, BlockAndValueMapping &cutMap) {
+    OpBuilder b(newMod);
+    for (auto op : ops) {
+//        if (!cutMap.contains(op->getBlock()))
+
+
+        b.clone(*op, cutMap);
+    }
+  }
+
+struct SVExtractTestCodeImplPass : public SVExtractTestCodeBase<SVExtractTestCodeImplPass> {
+  void runOnOperation() override;
+
+private:
+  void doModule(rtl::RTLModuleOp module) {
+    rootSets roots;
+    findRoots(module, roots);
+    std::set<Operation *> allRoots;
+    allRoots.insert(roots.asserts.begin(), roots.asserts.end());
+    allRoots.insert(roots.assumes.begin(), roots.assumes.end());
+    allRoots.insert(roots.covers.begin(), roots.covers.end());
+    if (allRoots.empty())
+      return;
+    auto opsToClone = computeCloneSet(roots);
+    BlockAndValueMapping cutMap;
+    auto inputs = computeCut(osToClone, cutMap);
+    auto bmod = createModuleForCut(
+        module, inputs,
+        (module.getVerilogModuleNameAttr().getValue() + "_bind").str(), cutMap);
+    bmod.dump();
+    migrateOps(module, bmod, allRoots, cutMap);
+  }
+};
+
+} // end anonymous namespace
+
+void SVExtractTestCodeImplPass::runOnOperation() {
+  auto *topLevelModule = getOperation().getBody();
+  for (auto &op : topLevelModule->getOperations())
+      if (auto rtlmod = dyn_cast<rtl::RTLModuleOp>(op))
+            doModule(rtlmod);
+}
+
+    std::unique_ptr<Pass>
+    circt::sv::createSVExtractTestCodePass() {
+  return std::make_unique<SVExtractTestCodeImplPass>();
+}

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -156,3 +156,8 @@ rtl.module @test1(%arg0: i1, %arg1: i1, %arg8: i8) {
   // CHECK-NEXT: rtl.output
   rtl.output
 }
+
+//CHECK-LABEL: sv.bind "testinst" @test1 @test2
+//CHECK-NEXT: rtl.module.extern @test2
+sv.bind "testinst" @test1 @test2
+rtl.module.extern @test2(%arg0: i1, %arg1: i1, %arg8: i8)

--- a/test/Dialect/SV/errors.mlir
+++ b/test/Dialect/SV/errors.mlir
@@ -141,3 +141,9 @@ rtl.module @Cover(%arg0: i1) {
   // expected-error @+1 {{sv.cover should be in a procedural region}}
   sv.cover %arg0: i1
 }
+
+// -----
+rtl.module.extern @test1(%arg0: i1, %arg1: i1, %arg8: i8)
+func @test2(%arg0: i1, %arg1: i1, %arg8: i8) { return }
+// expected-error @+1 {{'sv.bind' op attribute 'dest' failed to satisfy constraint: flat symbol reference attribute is module like}}
+sv.bind "testinst" @test1 @test2

--- a/test/Dialect/SV/sv-extract-test-code.mlir
+++ b/test/Dialect/SV/sv-extract-test-code.mlir
@@ -1,0 +1,54 @@
+// RUN: circt-opt -sv-extract-test-code %s | FileCheck %s
+
+// CHECK-LABEL:  rtl.module @extract_cover(%arg0: i1, %arg1: i1, %arg2: i1) attributes {argNames = ["", "", ""], outputPath = "generated/covers/*  */"} {
+// CHECK-NEXT:    sv.always posedge %arg2  {
+// CHECK-NEXT:      sv.ifdef.procedural "FUN_AND_GAMES"  {
+// CHECK-NEXT:        %0 = comb.and %arg0, %arg1 : i1
+// CHECK-NEXT:        sv.if %0  {
+// CHECK-NEXT:        } else  {
+// CHECK-NEXT:          sv.cover %arg1 : i1
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    rtl.output
+// CHECK-NEXT:  }
+// CHECK-NEXT:  rtl.module @extract_assert(%arg0: i1, %arg1: i1, %arg2: i1, %arg3: i1, %arg4: i1) attributes {argNames = ["", "", "", "", ""], outputPath = "generated/asserts"} {
+// CHECK-NEXT:    sv.always posedge %arg3  {
+// CHECK-NEXT:      sv.ifdef.procedural "FUN_AND_GAMES"  {
+// CHECK-NEXT:        %0 = comb.and %arg0, %arg1 : i1
+// CHECK-NEXT:        sv.if %0  {
+// CHECK-NEXT:          sv.fwrite "this cond is split"
+// CHECK-NEXT:          sv.assert %arg0 : i1
+// CHECK-NEXT:        } else  {
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:      sv.if %arg4  {
+// CHECK-NEXT:        sv.assume %arg2 : i1
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    rtl.output
+// CHECK-NEXT:  }
+// CHECK: rtl.module @extract
+// CHECK:       rtl.instance "InvisibleBind_assert" @extract_assert(%a, %b, %c, %clock, %0) {genAsBind = true} : (i1, i1, i1, i1, i1) -> ()
+// CHECK-NEXT:  rtl.instance "InvisibleBind_cover" @extract_cover(%a, %b, %clock) {genAsBind = true} : (i1, i1, i1) -> ()
+// CHECK-NEXT:  rtl.output
+
+rtl.module @extract(%clock: i1, %a: i1, %b: i1, %c: i1) {
+  %r = sv.reg : !rtl.inout<i1>
+  %d = sv.read_inout %r : !rtl.inout<i1>
+  sv.always posedge %clock  {
+     sv.ifdef.procedural "FUN_AND_GAMES" {
+       %cond = comb.and %a, %b : i1
+       sv.if %cond  {
+         sv.fwrite "this cond is split"
+         sv.assert %a : i1
+       } else {
+           sv.cover %b : i1
+       }
+     }
+     sv.if %d {
+         sv.assume %c : i1
+     }
+  }
+}
+

--- a/test/ExportVerilog/sv-dialect.mlir
+++ b/test/ExportVerilog/sv-dialect.mlir
@@ -714,8 +714,8 @@ rtl.module @ConstantDefAfterUse() {
 
 // Constants defined in a procedural block with users in a different block
 // should be emitted at the top of their defining block.
-// CHECK-LABEL: module ConstantEmissionAtTopOfBlock
-rtl.module @ConstantEmissionAtTopOfBlock() {
+// CHECK-LABEL: module OtherName
+rtl.module @ConstantEmissionAtTopOfBlock() attributes {verilogName = "OtherName"} {
   %myreg = sv.reg : !rtl.inout<i32>
   // CHECK:      always @* begin
   // CHECK-NEXT:   localparam [31:0] _T = 32'h2A;
@@ -728,3 +728,6 @@ rtl.module @ConstantEmissionAtTopOfBlock() {
     }
   }
 }
+
+//CHECK-LABEL: bind ConstantDefAfterUse OtherName foobar_inst (.*)
+sv.bind "foobar_inst" @ConstantDefAfterUse @ConstantEmissionAtTopOfBlock


### PR DESCRIPTION
Extract simulation constructs to child modules which will be instantiated with a bind.

[TODO] Rebase without the bind op PR.
[TODO] Generate a bind statement rather than using an attribute on an instance.