### PR TITLE
[Python][Seq] Add a helper for building computational registers.

### DIFF
--- a/integration_test/Bindings/Python/dialects/seq.py
+++ b/integration_test/Bindings/Python/dialects/seq.py
@@ -32,6 +32,18 @@ with Context() as ctx, Location.unknown():
                           reset=rstn,
                           reset_value=reg_reset,
                           name="my_reg")
+
+      # CHECK: seq.compreg %[[INPUT_VAL]], %clk
+      seq.reg(reg_input, clk)
+      # CHECK: seq.compreg %[[INPUT_VAL]], %clk, %rstn, %{{.+}}
+      seq.reg(reg_input, clk, reset=rstn)
+      # CHECK: %[[RESET_VALUE:.+]] = rtl.constant 123
+      # CHECK: seq.compreg %[[INPUT_VAL]], %clk, %rstn, %[[RESET_VALUE]]
+      custom_reset = rtl.ConstantOp(i32, IntegerAttr.get(i32, 123)).result
+      seq.reg(reg_input, clk, reset=rstn, reset_value=custom_reset)
+      # CHECK: seq.compreg {{.+}} {name = "FuBar"}
+      seq.reg(reg_input, clk, name="FuBar")
+
       # CHECK: rtl.output %[[DATA_VAL]]
       return reg.data
 

--- a/lib/Bindings/Python/circt/dialects/seq.py
+++ b/lib/Bindings/Python/circt/dialects/seq.py
@@ -4,3 +4,26 @@
 
 # Generated tablegen dialects end up in the mlir.dialects package for now.
 from mlir.dialects._seq_ops_gen import *
+
+
+# Create a computational register whose input is the given value, and is clocked
+# by the given clock. If a reset is provided, the register will be reset by that
+# signal. If a reset value is provided, the register will reset to that,
+# otherwise it will reset to zero. If name is provided, the register will be
+# named.
+def reg(value, clock, reset=None, reset_value=None, name=None):
+  import circt.dialects.rtl as rtl
+  from mlir.ir import IntegerAttr
+  value_type = value.type
+  if reset:
+    if not reset_value:
+      zero = IntegerAttr.get(value_type, 0)
+      reset_value = rtl.ConstantOp(value_type, zero).result
+    return CompRegOp(value_type,
+                     value,
+                     clock,
+                     reset=reset,
+                     reset_value=reset_value,
+                     name=name).result
+  else:
+    return CompRegOp(value_type, value, clock, name=name).result


### PR DESCRIPTION
This adds a convenience function for construction
CompRegOp. The function requires a value to register and a clock
signal. Optionally, a reset signal, reset value, and name may also be
provided.