### PR TITLE
[ESI] Build capnp encoders/decoders in their own modules

### DIFF
--- a/lib/Dialect/ESI/capnp/ESICapnp.h
+++ b/lib/Dialect/ESI/capnp/ESICapnp.h
@@ -14,6 +14,8 @@
 #ifndef CIRCT_DIALECT_ESI_CAPNP_ESICAPNP_H
 #define CIRCT_DIALECT_ESI_CAPNP_ESICAPNP_H
 
+#include "circt/Dialect/RTL/RTLOps.h"
+
 #include <memory>
 
 namespace mlir {
@@ -77,6 +79,10 @@ private:
   /// The implementation of this. Separate to hide the details and avoid having
   /// to include the capnp headers in this header.
   std::shared_ptr<detail::TypeSchemaImpl> s;
+
+  /// Cache of the decode/encode modules;
+  static llvm::SmallDenseMap<Type, rtl::RTLModuleOp> decImplMods;
+  static llvm::SmallDenseMap<Type, rtl::RTLModuleOp> encImplMods;
 };
 
 } // namespace capnp

--- a/lib/Dialect/ESI/capnp/Schema.cpp
+++ b/lib/Dialect/ESI/capnp/Schema.cpp
@@ -103,9 +103,9 @@ public:
   bool operator==(const TypeSchemaImpl &) const;
 
   /// Build an RTL/SV dialect capnp encoder for this type.
-  Value buildEncoder(OpBuilder &, Value clk, Value valid, GasketComponent);
+  rtl::RTLModuleOp buildEncoder(Value clk, Value valid, Value);
   /// Build an RTL/SV dialect capnp decoder for this type.
-  Value buildDecoder(OpBuilder &, Value clk, Value valid, Value);
+  rtl::RTLModuleOp buildDecoder(Value clk, Value valid, Value);
 
 private:
   ::capnp::ParsedSchema getSchema() const;
@@ -471,6 +471,7 @@ public:
   Slice padding(uint64_t p) const;
 
   Location loc() const { return *location; }
+  void setLoc(Location loc) { location = loc; }
   OpBuilder &b() const { return *builder; }
   MLIRContext *ctxt() const { return builder->getContext(); }
 
@@ -801,8 +802,8 @@ private:
   /// manage 'memory allocations' (figuring out where to place pointed to
   /// objects) separately from the data contained in those values, some of which
   /// are pointers themselves.
-  llvm::IntervalMap<uint64_t, GasketComponent, 16>::Allocator allocator;
-  llvm::IntervalMap<uint64_t, GasketComponent, 16> segmentValues;
+  llvm::IntervalMap<uint64_t, GasketComponent, 2048>::Allocator allocator;
+  llvm::IntervalMap<uint64_t, GasketComponent, 2048> segmentValues;
 
   /// Track the allocated message size. Increase to 'alloc' more.
   uint64_t messageSize;
@@ -916,11 +917,39 @@ CapnpSegmentBuilder::build(::capnp::schema::Node::Struct::Reader cStruct,
 
 /// Build an RTL/SV dialect capnp encoder for this type. Inputs need to be
 /// packed on unpadded.
-Value TypeSchemaImpl::buildEncoder(OpBuilder &b, Value clk, Value valid,
-                                   GasketComponent operand) {
+rtl::RTLModuleOp TypeSchemaImpl::buildEncoder(Value clk, Value valid,
+                                              Value operandVal) {
+  auto loc = operandVal.getDefiningOp()->getLoc();
+  auto topMod = operandVal.getDefiningOp()->getParentOfType<ModuleOp>();
+  OpBuilder b = OpBuilder::atBlockEnd(topMod.getBody());
+
+  SmallString<64> modName;
+  modName.append("encode");
+  modName.append(name());
+  SmallVector<rtl::ModulePortInfo, 4> ports;
+  ports.push_back(rtl::ModulePortInfo{
+      b.getStringAttr("clk"), rtl::PortDirection::INPUT, clk.getType(), 0});
+  ports.push_back(rtl::ModulePortInfo{
+      b.getStringAttr("valid"), rtl::PortDirection::INPUT, valid.getType(), 1});
+  ports.push_back(rtl::ModulePortInfo{b.getStringAttr("unencodedInput"),
+                                      rtl::PortDirection::INPUT,
+                                      operandVal.getType(), 2});
+  rtl::ArrayType modOutputType = rtl::ArrayType::get(b.getI1Type(), size());
+  ports.push_back(rtl::ModulePortInfo{b.getStringAttr("encoded"),
+                                      rtl::PortDirection::OUTPUT, modOutputType,
+                                      0});
+  rtl::RTLModuleOp retMod = b.create<rtl::RTLModuleOp>(
+      operandVal.getLoc(), b.getStringAttr(modName), ports);
+
+  Block *innerBlock = retMod.getBodyBlock();
+  b.setInsertionPointToStart(innerBlock);
+  clk = innerBlock->getArgument(0);
+  valid = innerBlock->getArgument(1);
+  GasketComponent operand(b, innerBlock->getArgument(2));
+  operand.setLoc(loc);
+
   ::capnp::schema::Node::Reader rootProto = getTypeSchema().getProto();
   auto st = rootProto.getStruct();
-  Location loc = operand.loc();
   CapnpSegmentBuilder seg(b, loc, size());
 
   // The values in the struct we are encoding.
@@ -934,7 +963,12 @@ Value TypeSchemaImpl::buildEncoder(OpBuilder &b, Value clk, Value valid,
   } else {
     fieldValues.push_back(GasketComponent(b, operand));
   }
-  return seg.build(st, fieldValues);
+  auto ret = seg.build(st, fieldValues);
+
+  innerBlock->getTerminator()->erase();
+  b.setInsertionPointToEnd(innerBlock);
+  b.create<rtl::OutputOp>(loc, ValueRange{ret});
+  return retMod;
 }
 
 //===----------------------------------------------------------------------===//
@@ -1055,8 +1089,34 @@ static GasketComponent decodeField(Type type,
 
 /// Build an RTL/SV dialect capnp decoder for this type. Outputs packed and
 /// unpadded data.
-Value TypeSchemaImpl::buildDecoder(OpBuilder &b, Value clk, Value valid,
-                                   Value operandVal) {
+rtl::RTLModuleOp TypeSchemaImpl::buildDecoder(Value clk, Value valid,
+                                              Value operandVal) {
+  auto loc = operandVal.getDefiningOp()->getLoc();
+  auto topMod = operandVal.getDefiningOp()->getParentOfType<ModuleOp>();
+  OpBuilder b = OpBuilder::atBlockEnd(topMod.getBody());
+
+  SmallString<64> modName;
+  modName.append("decode");
+  modName.append(name());
+  SmallVector<rtl::ModulePortInfo, 4> ports;
+  ports.push_back(rtl::ModulePortInfo{
+      b.getStringAttr("clk"), rtl::PortDirection::INPUT, clk.getType(), 0});
+  ports.push_back(rtl::ModulePortInfo{
+      b.getStringAttr("valid"), rtl::PortDirection::INPUT, valid.getType(), 1});
+  ports.push_back(rtl::ModulePortInfo{b.getStringAttr("encodedInput"),
+                                      rtl::PortDirection::INPUT,
+                                      operandVal.getType(), 2});
+  ports.push_back(rtl::ModulePortInfo{
+      b.getStringAttr("decoded"), rtl::PortDirection::OUTPUT, getType(), 0});
+  rtl::RTLModuleOp retMod = b.create<rtl::RTLModuleOp>(
+      operandVal.getLoc(), b.getStringAttr(modName), ports);
+
+  Block *innerBlock = retMod.getBodyBlock();
+  b.setInsertionPointToStart(innerBlock);
+  clk = innerBlock->getArgument(0);
+  valid = innerBlock->getArgument(1);
+  operandVal = innerBlock->getArgument(2);
+
   // Various useful integer types.
   auto i16 = b.getIntegerType(16);
 
@@ -1066,7 +1126,7 @@ Value TypeSchemaImpl::buildDecoder(OpBuilder &b, Value clk, Value valid,
          "Operand type and length must match the type's capnp size.");
 
   Slice operand(b, operandVal);
-  auto loc = operand.loc();
+  operand.setLoc(loc);
 
   auto alwaysAt = b.create<sv::AlwaysOp>(loc, sv::EventControl::AtPosEdge, clk);
   auto ifValid =
@@ -1116,7 +1176,7 @@ Value TypeSchemaImpl::buildDecoder(OpBuilder &b, Value clk, Value valid,
 
   // What to return depends on the type. (e.g. structs have to be constructed
   // from the field values.)
-  GasketComponent ret =
+  GasketComponent retGC =
       TypeSwitch<Type, GasketComponent>(type)
           .Case([&fieldValues](IntegerType) { return fieldValues[0]; })
           .Case([&fieldValues](rtl::ArrayType) { return fieldValues[0]; })
@@ -1126,12 +1186,21 @@ Value TypeSchemaImpl::buildDecoder(OpBuilder &b, Value clk, Value valid,
             return GasketComponent(
                 b, b.create<rtl::StructCreateOp>(loc, type, rawValues));
           });
-  return ret;
+
+  innerBlock->getTerminator()->erase();
+  b.setInsertionPointToEnd(innerBlock);
+  b.create<rtl::OutputOp>(loc, ValueRange{retGC.getValue()});
+  return retMod;
 }
 
 //===----------------------------------------------------------------------===//
 // TypeSchema wrapper.
 //===----------------------------------------------------------------------===//
+
+llvm::SmallDenseMap<Type, rtl::RTLModuleOp>
+    circt::esi::capnp::TypeSchema::decImplMods;
+llvm::SmallDenseMap<Type, rtl::RTLModuleOp>
+    circt::esi::capnp::TypeSchema::encImplMods;
 
 circt::esi::capnp::TypeSchema::TypeSchema(Type type) {
   circt::esi::ChannelPort chan = type.dyn_cast<circt::esi::ChannelPort>();
@@ -1161,11 +1230,45 @@ bool circt::esi::capnp::TypeSchema::operator==(const TypeSchema &that) const {
 Value circt::esi::capnp::TypeSchema::buildEncoder(OpBuilder &builder, Value clk,
                                                   Value valid,
                                                   Value operand) const {
-  return s->buildEncoder(builder, clk, valid,
-                         GasketComponent(builder, operand));
+  rtl::RTLModuleOp encImplMod;
+  auto encImplIT = encImplMods.find(getType());
+  if (encImplIT == encImplMods.end()) {
+    encImplMod = s->buildEncoder(clk, valid, operand);
+    encImplMods[getType()] = encImplMod;
+  } else {
+    encImplMod = encImplIT->second;
+  }
+
+  SmallString<64> instName;
+  instName.append("encode");
+  instName.append(name());
+  instName.append("Inst");
+  auto resTypes = rtl::getModuleType(encImplMod).getResults();
+  auto encodeInst = builder.create<rtl::InstanceOp>(
+      operand.getLoc(), resTypes, instName, encImplMod.getName(),
+      ValueRange{clk, valid, operand}, DictionaryAttr());
+  return encodeInst.getResult(0);
 }
+
 Value circt::esi::capnp::TypeSchema::buildDecoder(OpBuilder &builder, Value clk,
                                                   Value valid,
                                                   Value operand) const {
-  return s->buildDecoder(builder, clk, valid, operand);
+  rtl::RTLModuleOp decImplMod;
+  auto decImplIT = decImplMods.find(getType());
+  if (decImplIT == decImplMods.end()) {
+    decImplMod = s->buildDecoder(clk, valid, operand);
+    decImplMods[getType()] = decImplMod;
+  } else {
+    decImplMod = decImplIT->second;
+  }
+
+  SmallString<64> instName;
+  instName.append("decode");
+  instName.append(name());
+  instName.append("Inst");
+  auto resTypes = rtl::getModuleType(decImplMod).getResults();
+  auto decodeInst = builder.create<rtl::InstanceOp>(
+      operand.getLoc(), resTypes, instName, decImplMod.getName(),
+      ValueRange{clk, valid, operand}, DictionaryAttr());
+  return decodeInst.getResult(0);
 }

--- a/lib/Dialect/ESI/capnp/Schema.cpp
+++ b/lib/Dialect/ESI/capnp/Schema.cpp
@@ -915,12 +915,12 @@ CapnpSegmentBuilder::build(::capnp::schema::Node::Struct::Reader cStruct,
   return compile();
 }
 
-/// Build an RTL/SV dialect capnp encoder for this type. Inputs need to be
-/// packed on unpadded.
+/// Build an RTL/SV dialect capnp encoder module for this type. Inputs need to
+/// be packed and unpadded.
 rtl::RTLModuleOp TypeSchemaImpl::buildEncoder(Value clk, Value valid,
                                               Value operandVal) {
-  auto loc = operandVal.getDefiningOp()->getLoc();
-  auto topMod = operandVal.getDefiningOp()->getParentOfType<ModuleOp>();
+  Location loc = operandVal.getDefiningOp()->getLoc();
+  ModuleOp topMod = operandVal.getDefiningOp()->getParentOfType<ModuleOp>();
   OpBuilder b = OpBuilder::atBlockEnd(topMod.getBody());
 
   SmallString<64> modName;
@@ -963,7 +963,7 @@ rtl::RTLModuleOp TypeSchemaImpl::buildEncoder(Value clk, Value valid,
   } else {
     fieldValues.push_back(GasketComponent(b, operand));
   }
-  auto ret = seg.build(st, fieldValues);
+  GasketComponent ret = seg.build(st, fieldValues);
 
   innerBlock->getTerminator()->erase();
   b.setInsertionPointToEnd(innerBlock);
@@ -1087,8 +1087,8 @@ static GasketComponent decodeField(Type type,
   return esiValue;
 }
 
-/// Build an RTL/SV dialect capnp decoder for this type. Outputs packed and
-/// unpadded data.
+/// Build an RTL/SV dialect capnp decoder module for this type. Outputs packed
+/// and unpadded data.
 rtl::RTLModuleOp TypeSchemaImpl::buildDecoder(Value clk, Value valid,
                                               Value operandVal) {
   auto loc = operandVal.getDefiningOp()->getLoc();

--- a/test/Dialect/ESI/cosim_structs.mlir
+++ b/test/Dialect/ESI/cosim_structs.mlir
@@ -1,7 +1,6 @@
 // REQUIRES: capnp
 // RUN: circt-translate %s -export-esi-capnp -verify-diagnostics | FileCheck --check-prefix=CAPNP %s
 // RUN: circt-opt %s --lower-esi-ports --lower-esi-to-rtl -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck --check-prefix=COSIM %s
-// RUN: circt-opt %s --lower-esi-ports --lower-esi-to-rtl | circt-translate --export-verilog | FileCheck --check-prefix=SV %s
 
 !DataPkt = type !rtl.struct<encrypted: i1, compressionLevel: ui4, blob: !rtl.array<32 x i8>>
 !pktChan = type !esi.channel<!DataPkt>
@@ -13,13 +12,11 @@ rtl.module @top(%clk:i1, %rstn:i1) -> () {
   %inputData = esi.cosim %clk, %rstn, %compressedData, 1 {name="Compressor"} : !pktChan -> !esi.channel<i1>
 }
 
-// CAPNP:      struct Struct13922113893393513056
+// CAPNP:      struct Struct{{.+}}
 // CAPNP-NEXT:   encrypted        @0 :Bool;
 // CAPNP-NEXT:   compressionLevel @1 :UInt8;
 // CAPNP-NEXT:   blob             @2 :List(UInt8);
 
+// COSIM: rtl.instance "encodeStruct{{.+}}Inst" @encodeStruct{{.+}}(%clk, %6, %7) : (i1, i1, !rtl.struct<encrypted: i1, compressionLevel: ui4, blob: !rtl.array<32xi8>>) -> !rtl.array<448xi1>
 // COSIM: rtl.instance "Compressor" @Cosim_Endpoint(%clk, %rstn, %{{.+}}, %{{.+}}, %{{.+}}) {parameters = {ENDPOINT_ID = 1 : i32, RECV_TYPE_ID = {{[0-9]+}} : ui64, RECV_TYPE_SIZE_BITS = 128 : i32, SEND_TYPE_ID = {{[0-9]+}} : ui64, SEND_TYPE_SIZE_BITS = 448 : i32}}
-
-// Test only a single, critical line in the systemverilog output. Anything else would be too fragile.
-// SV: wire [31:0][7:0] [[BLOB:.+]] = [[IF1:.+]].data.blob;
-// SV: .DataIn       ({[[BLOB]][5'h0], [[BLOB]][5'h1], [[BLOB]][5'h2], [[BLOB]][5'h3], [[BLOB]][5'h4], [[BLOB]][5'h5], [[BLOB]][5'h6], [[BLOB]][5'h7], [[BLOB]][5'h8], [[BLOB]][5'h9], [[BLOB]][5'hA], [[BLOB]][5'hB], [[BLOB]][5'hC], [[BLOB]][5'hD], [[BLOB]][5'hE], [[BLOB]][5'hF], [[BLOB]][5'h10], [[BLOB]][5'h11], [[BLOB]][5'h12], [[BLOB]][5'h13], [[BLOB]][5'h14], [[BLOB]][5'h15], [[BLOB]][5'h16], [[BLOB]][5'h17], [[BLOB]][5'h18], [[BLOB]][5'h19], [[BLOB]][5'h1A], [[BLOB]][5'h1B], [[BLOB]][5'h1C], [[BLOB]][5'h1D], [[BLOB]][5'h1E], [[BLOB]][5'h1F], {29'h20, 3'h2, 30'h0, 2'h1}, 52'h0, [[IF1]].data.compressionLevel, 7'h0, [[IF1]].data.encrypted, {16'h1, 16'h1, 30'h0, 2'h0}})
+// COSIM: rtl.module @encode{{.+}}(%clk: i1, %valid: i1, %unencodedInput: !rtl.struct<encrypted: i1, compressionLevel: ui4, blob: !rtl.array<32xi8>>) -> (%encoded: !rtl.array<448xi1>)

--- a/test/Dialect/ESI/lowering.mlir
+++ b/test/Dialect/ESI/lowering.mlir
@@ -40,13 +40,13 @@ rtl.module @test(%clk:i1, %rstn:i1) {
   // CHECK-NEXT:  rtl.instance "recv2" @Reciever(%3, %clk)  : (!esi.channel<i4>, i1) -> ()
 
   // IFACE-LABEL: rtl.module @test(%clk: i1, %rstn: i1) {
-  // IFACE-NEXT:    %0 = sv.interface.instance : !sv.interface<@IValidReady_i4>
+  // IFACE-NEXT:    %0 = sv.interface.instance {name = "i4FromSender2"} : !sv.interface<@IValidReady_i4>
   // IFACE-NEXT:    %1 = sv.modport.get %0 @source : !sv.interface<@IValidReady_i4> -> !sv.modport<@IValidReady_i4::@source>
   // IFACE-NEXT:    %2 = esi.wrap.iface %1 : !sv.modport<@IValidReady_i4::@source> -> !esi.channel<i4>
   // IFACE-NEXT:    %3 = sv.modport.get %0 @sink : !sv.interface<@IValidReady_i4> -> !sv.modport<@IValidReady_i4::@sink>
   // IFACE-NEXT:    %sender2.y = rtl.instance "sender2" @Sender(%clk, %3) : (i1, !sv.modport<@IValidReady_i4::@sink>) -> i8
   // IFACE-NEXT:    %4 = esi.buffer %clk, %rstn, %2 {stages = 4 : i64} : i4
-  // IFACE-NEXT:    %5 = sv.interface.instance : !sv.interface<@IValidReady_i4>
+  // IFACE-NEXT:    %5 = sv.interface.instance {name = "i4ToRecv2"} : !sv.interface<@IValidReady_i4>
   // IFACE-NEXT:    %6 = sv.modport.get %5 @sink : !sv.interface<@IValidReady_i4> -> !sv.modport<@IValidReady_i4::@sink>
   // IFACE-NEXT:    esi.unwrap.iface %4 into %6 : (!esi.channel<i4>, !sv.modport<@IValidReady_i4::@sink>)
   // IFACE-NEXT:    %7 = sv.modport.get %5 @source : !sv.interface<@IValidReady_i4> -> !sv.modport<@IValidReady_i4::@source>


### PR DESCRIPTION
- Builds capnp gaskets in their own modules.
- Creates "reasonable" names for SV interface instances and gasket modules/instances.