### PR TITLE
[Python][RTL] Support parameters on instances.

### DIFF
--- a/integration_test/Bindings/Python/dialects/rtl.py
+++ b/integration_test/Bindings/Python/dialects/rtl.py
@@ -90,6 +90,9 @@ with Context() as ctx, Location.unknown():
       inst5 = op.create(module, "inst5")
       inst5.set_input_port("my_input", inst5.my_output)
 
+      # CHECK: rtl.instance "inst6" {{.*}} {BANKS = 2 : i64}
+      one_input.create(module, "inst6", {"a": inst1.a}, parameters={"BANKS": 2})
+
       rtl.OutputOp([])
 
     instance_builder_tests = rtl.RTLModuleOp(name="instance_builder_tests",

--- a/lib/Bindings/Python/circt/dialects/_rtl_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_rtl_ops_ext.py
@@ -51,6 +51,7 @@ class InstanceBuilder:
     # Actually build the InstanceOp.
     instance_name = StringAttr.get(name)
     module_name = FlatSymbolRefAttr.get(StringAttr(self.mod.name).value)
+    parameters = {k: Attribute.parse(str(v)) for (k, v) in parameters.items()}
     parameters = DictAttr.get(parameters)
     self.instance = InstanceOp(
         self.mod.type.results,
@@ -175,12 +176,14 @@ class ModuleLike:
              module,
              name: str,
              input_port_mapping: Dict[str, Value] = {},
+             parameters: Dict[str, object] = {},
              loc=None,
              ip=None):
     return InstanceBuilder(module,
                            self,
                            name,
                            input_port_mapping,
+                           parameters=parameters,
                            loc=loc,
                            ip=ip)
 


### PR DESCRIPTION
This adds a parameters dict to the instance create API and
InstanceBuilder class. The attributes are parsed and passed to the
InstanceOp being built.