### PR TITLE
[MSFT] Support name attribute in Quartus TCL exporter.

### DIFF
--- a/integration_test/Bindings/Python/dialects/msft.py
+++ b/integration_test/Bindings/Python/dialects/msft.py
@@ -3,13 +3,15 @@
 
 import circt
 from circt import msft
-from circt.dialects import rtl
+from circt.dialects import rtl, seq
 
 from mlir.ir import *
 import sys
 
 with Context() as ctx, Location.unknown():
   circt.register_dialects(ctx)
+  i32 = IntegerType.get_signless(32)
+  i1 = IntegerType.get_signless(1)
 
   m = Module.create()
   with InsertionPoint(m.body):
@@ -29,6 +31,12 @@ with Context() as ctx, Location.unknown():
     msft.locate(inst.operation, "mem", devtype=msft.M20K, x=50, y=100, num=1)
     # CHECK: rtl.instance "inst1" @MyWidget() {"loc:mem" = #msft.physloc<M20K, 50, 100, 1>, parameters = {}} : () -> ()
 
+    val = rtl.ConstantOp(i32, IntegerAttr.get(i32, 14)).result
+    clk = rtl.ConstantOp(i1, IntegerAttr.get(i1, 0)).result
+    reg = seq.reg(val, clk, name="MyLocatableRegister")
+    msft.locate(reg.owner, "mem", devtype=msft.M20K, x=25, y=25, num=1)
+    # CHECK: seq.compreg {{.+}} {"loc:mem" = #msft.physloc<M20K, 25, 25, 1>, name = "MyLocatableRegister"}
+
   m.operation.print()
 
   # CHECK-LABEL: === tcl ===
@@ -36,4 +44,5 @@ with Context() as ctx, Location.unknown():
 
   # CHECK: proc top_config { parent } {
   # CHECK:   set_location_assignment M20K_X50_Y100_N1 -to $parent|inst1|mem
+  # CHECK:   set_location_assignment M20K_X25_Y25_N1 -to $parent|MyLocatableRegister|mem
   msft.export_tcl(m, sys.stdout)

--- a/lib/Dialect/MSFT/TclExport/ExportQuartusTcl.cpp
+++ b/lib/Dialect/MSFT/TclExport/ExportQuartusTcl.cpp
@@ -126,6 +126,8 @@ LogicalResult Entity::emit(Operation *op, StringRef attrKey, StringRef instName,
   // the child entity patch.
   if (!instName.empty())
     s.os << instName << '|';
+  else if (auto name = op->getAttrOfType<StringAttr>("name"))
+    s.os << name.getValue() << '|';
   s.os << childEntity << '\n';
 
   emittedAttrKeys.insert(attrKey);


### PR DESCRIPTION
Any operation with a "name" attribute can be located and exported with
that name in the TCL output.