### PR TITLE
[CAPI] Guard esi::exportCosimSchema by CAPNP ifdef

### DIFF
--- a/lib/CAPI/Dialect/ESI.cpp
+++ b/lib/CAPI/Dialect/ESI.cpp
@@ -18,8 +18,12 @@ void registerESIPasses() { circt::esi::registerESIPasses(); }
 MlirLogicalResult circtESIExportCosimSchema(MlirModule module,
                                             MlirStringCallback callback,
                                             void *userData) {
+#ifdef CAPNP
   mlir::detail::CallbackOstream stream(callback, userData);
   return wrap(circt::esi::exportCosimSchema(unwrap(module), stream));
+#else
+  return wrap(mlir::failure());
+#endif
 }
 
 bool circtESITypeIsAChannelType(MlirType type) {


### PR DESCRIPTION
C API fails to link on builds that have CAPNP disabled, since some of the symbols in the C++ API get dropped. Make the corresponding uses in the C API conditional on the presence of the same ifdef, so things link again.