### PR TITLE
[FIRRTL] Add width inference on most expressions

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -95,7 +95,7 @@ class IndexConstraint<string value, string resultValue>
                    value, resultValue,
                    "firrtl::getVectorElementType($_self)">;
 
-def SubindexOp : FIRRTLOp<"subindex", [NoSideEffect, 
+def SubindexOp : FIRRTLOp<"subindex", [NoSideEffect,
                                        IndexConstraint<"input", "result">]> {
   let summary = "Extract an element of a vector value";
   let description = [{
@@ -127,7 +127,7 @@ def SubindexOp : FIRRTLOp<"subindex", [NoSideEffect,
   }];
 }
 
-def SubaccessOp : FIRRTLOp<"subaccess", [NoSideEffect, 
+def SubaccessOp : FIRRTLOp<"subaccess", [NoSideEffect,
                                          IndexConstraint<"input", "result">]> {
   let summary = "Extract a dynamic element of a vector value";
   let description = [{
@@ -221,7 +221,7 @@ def DivPrimOp : BinaryPrimOp<"div", IntType, IntType, IntType> {
 }
 def RemPrimOp : BinaryPrimOp<"rem", IntType, IntType, IntType>;
 
-def AndPrimOp : BinaryPrimOp<"and", IntType, IntType, UIntType, [Commutative]>; 
+def AndPrimOp : BinaryPrimOp<"and", IntType, IntType, UIntType, [Commutative]>;
 def OrPrimOp  : BinaryPrimOp<"or",  IntType, IntType, UIntType, [Commutative]>;
 def XorPrimOp : BinaryPrimOp<"xor", IntType, IntType, UIntType, [Commutative]>;
 
@@ -593,7 +593,7 @@ class PassiveConstraint<string value, string resultValue>
                    "firrtl::getPassiveType($_self)">;
 
 // Convert a value with non-passive type to a value with passive type.
-def AsPassivePrimOp : FIRRTLOp<"asPassive", [NoSideEffect, 
+def AsPassivePrimOp : FIRRTLOp<"asPassive", [NoSideEffect,
                                PassiveConstraint<"input", "result">]> {
   let arguments = (ins FIRRTLType:$input);
   let results = (outs PassiveType:$result);

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -53,17 +53,13 @@ inline llvm::hash_code hash_value(const T &e) {
 } // namespace mlir
 
 namespace {
+#define EXPR_NAMES(x) Root##x, Var##x, Known##x, Add##x, Pow##x, Max##x, Min##x
+#define EXPR_KINDS EXPR_NAMES()
+#define EXPR_CLASSES EXPR_NAMES(Expr)
 
 /// An expression on the right-hand side of a constraint.
 struct Expr {
-  enum Kind {
-    KindRoot,
-    KindVar,
-    KindKnown,
-    KindAdd,
-    KindMax,
-    KindMin,
-  };
+  enum class Kind { EXPR_KINDS };
   llvm::Optional<int32_t> solution = {};
   Kind kind;
 
@@ -95,7 +91,7 @@ struct ExprBase : public Expr {
 };
 
 /// A free variable.
-struct RootExpr : public ExprBase<RootExpr, Expr::KindRoot> {
+struct RootExpr : public ExprBase<RootExpr, Expr::Kind::Root> {
   RootExpr(std::vector<Expr *> &exprs) : exprs(exprs) {}
   void print(llvm::raw_ostream &os) const { os << "root"; }
   iterator begin() const { return &exprs[0]; }
@@ -104,7 +100,7 @@ struct RootExpr : public ExprBase<RootExpr, Expr::KindRoot> {
 };
 
 /// A free variable.
-struct VarExpr : public ExprBase<VarExpr, Expr::KindVar> {
+struct VarExpr : public ExprBase<VarExpr, Expr::Kind::Var> {
   void print(llvm::raw_ostream &os) const {
     // Hash the `this` pointer into something somewhat human readable. Since
     // this is just for debug dumping, we wrap around at 4096 variables.
@@ -113,7 +109,7 @@ struct VarExpr : public ExprBase<VarExpr, Expr::KindVar> {
 };
 
 /// A known constant value.
-struct KnownExpr : public ExprBase<KnownExpr, Expr::KindKnown> {
+struct KnownExpr : public ExprBase<KnownExpr, Expr::Kind::Known> {
   KnownExpr(int32_t value) : ExprBase() { solution = value; }
   void print(llvm::raw_ostream &os) const { os << solution.getValue(); }
   bool operator==(const KnownExpr &other) const {
@@ -122,6 +118,40 @@ struct KnownExpr : public ExprBase<KnownExpr, Expr::KindKnown> {
   llvm::hash_code hash_value() const {
     return llvm::hash_combine(Expr::hash_value(), solution.getValue());
   }
+};
+
+/// A unary expression. Contains the actual data. Concrete subclasses are merely
+/// there for show and ease of use.
+struct UnaryExpr : public Expr {
+  bool operator==(const UnaryExpr &other) const {
+    return kind == other.kind && arg == other.arg;
+  }
+  llvm::hash_code hash_value() const {
+    return llvm::hash_combine(Expr::hash_value(), arg);
+  }
+  iterator begin() const { return &arg; }
+  iterator end() const { return &arg + 1; }
+
+  /// The child expression.
+  Expr *const arg;
+
+protected:
+  UnaryExpr(Kind kind, Expr *arg) : Expr(kind), arg(arg) {}
+};
+
+/// Helper class to CRTP-derive common functions.
+template <class DerivedT, Expr::Kind DerivedKind>
+struct UnaryExprBase : public UnaryExpr {
+  template <typename... Args>
+  UnaryExprBase(Args &&... args)
+      : UnaryExpr(DerivedKind, std::forward<Args>(args)...) {}
+  static bool classof(const Expr *e) { return e->kind == DerivedKind; }
+};
+
+/// A power of two.
+struct PowExpr : public UnaryExprBase<PowExpr, Expr::Kind::Pow> {
+  using UnaryExprBase::UnaryExprBase;
+  void print(llvm::raw_ostream &os) const { os << "2^" << arg; }
 };
 
 /// A binary expression. Contains the actual data. Concrete subclasses are
@@ -155,7 +185,7 @@ struct BinaryExprBase : public BinaryExpr {
 };
 
 /// An addition.
-struct AddExpr : public BinaryExprBase<AddExpr, Expr::KindAdd> {
+struct AddExpr : public BinaryExprBase<AddExpr, Expr::Kind::Add> {
   using BinaryExprBase::BinaryExprBase;
   void print(llvm::raw_ostream &os) const {
     os << "(" << *lhs() << " + " << *rhs() << ")";
@@ -163,7 +193,7 @@ struct AddExpr : public BinaryExprBase<AddExpr, Expr::KindAdd> {
 };
 
 /// The maximum of two expressions.
-struct MaxExpr : public BinaryExprBase<MaxExpr, Expr::KindMax> {
+struct MaxExpr : public BinaryExprBase<MaxExpr, Expr::Kind::Max> {
   using BinaryExprBase::BinaryExprBase;
   void print(llvm::raw_ostream &os) const {
     os << "max(" << *lhs() << ", " << *rhs() << ")";
@@ -171,7 +201,7 @@ struct MaxExpr : public BinaryExprBase<MaxExpr, Expr::KindMax> {
 };
 
 /// The minimum of two expressions.
-struct MinExpr : public BinaryExprBase<MinExpr, Expr::KindMin> {
+struct MinExpr : public BinaryExprBase<MinExpr, Expr::Kind::Min> {
   using BinaryExprBase::BinaryExprBase;
   void print(llvm::raw_ostream &os) const {
     os << "min(" << *lhs() << ", " << *rhs() << ")";
@@ -179,21 +209,18 @@ struct MinExpr : public BinaryExprBase<MinExpr, Expr::KindMin> {
 };
 
 void Expr::print(llvm::raw_ostream &os) const {
-  TypeSwitch<const Expr *>(this)
-      .Case<RootExpr, VarExpr, KnownExpr, AddExpr, MaxExpr, MinExpr>(
-          [&](auto *e) { e->print(os); });
+  TypeSwitch<const Expr *>(this).Case<EXPR_CLASSES>(
+      [&](auto *e) { e->print(os); });
 }
 
 Expr::iterator Expr::begin() const {
-  return TypeSwitch<const Expr *, Expr::iterator>(this)
-      .Case<RootExpr, VarExpr, KnownExpr, AddExpr, MaxExpr, MinExpr>(
-          [&](auto *e) { return e->begin(); });
+  return TypeSwitch<const Expr *, Expr::iterator>(this).Case<EXPR_CLASSES>(
+      [&](auto *e) { return e->begin(); });
 }
 
 Expr::iterator Expr::end() const {
-  return TypeSwitch<const Expr *, Expr::iterator>(this)
-      .Case<RootExpr, VarExpr, KnownExpr, AddExpr, MaxExpr, MinExpr>(
-          [&](auto *e) { return e->end(); });
+  return TypeSwitch<const Expr *, Expr::iterator>(this).Case<EXPR_CLASSES>(
+      [&](auto *e) { return e->end(); });
 }
 
 } // namespace
@@ -295,6 +322,7 @@ public:
     return v;
   }
   KnownExpr *known(int32_t value) { return alloc<KnownExpr>(knowns, value); }
+  PowExpr *pow(Expr *arg) { return alloc<PowExpr>(uns, arg); }
   AddExpr *add(Expr *lhs, Expr *rhs) { return alloc<AddExpr>(bins, lhs, rhs); }
   MaxExpr *max(Expr *lhs, Expr *rhs) { return alloc<MaxExpr>(bins, lhs, rhs); }
   MinExpr *min(Expr *lhs, Expr *rhs) { return alloc<MinExpr>(bins, lhs, rhs); }
@@ -316,6 +344,7 @@ private:
   llvm::BumpPtrAllocator allocator;
   VarAllocator vars = {allocator};
   InternedAllocator<KnownExpr> knowns = {allocator};
+  InternedAllocator<UnaryExpr> uns = {allocator};
   InternedAllocator<BinaryExpr> bins = {allocator};
 
   /// A list of expressions in the order they were created.
@@ -352,6 +381,12 @@ void ConstraintSolver::dumpConstraints(llvm::raw_ostream &os) {
   }
 }
 
+// Helper function to compute unary expressions if the operand has a solution.
+static void solveUnary(UnaryExpr *expr, std::function<int32_t(int32_t)> f) {
+  if (expr->arg->solution.hasValue())
+    expr->solution = f(expr->arg->solution.getValue());
+}
+
 // Helper function to compute binary expressions if both operands have a
 // solution.
 static void solveBinary(BinaryExpr *expr,
@@ -375,6 +410,12 @@ void ConstraintSolver::solve() {
           auto it = constraints.find(var);
           if (it != constraints.end())
             var->solution = it->second->solution;
+        })
+        .Case<PowExpr>([&](auto *expr) {
+          solveUnary(expr, [](int32_t arg) {
+            assert(arg < 32);
+            return 1 << arg;
+          });
         })
         .Case<AddExpr>([&](auto *expr) {
           solveBinary(expr, [](int32_t lhs, int32_t rhs) { return lhs + rhs; });
@@ -462,7 +503,10 @@ void InferenceMapping::mapOperation(Operation *op) {
         auto e = solver.known(op.value().getBitWidth());
         setExpr(op.getResult(), e);
       })
-      .Case<WireOp>([&](auto op) { declareVars(op.getResult()); })
+      .Case<WireOp, InvalidValueOp>(
+          [&](auto op) { declareVars(op.getResult()); })
+
+      // Arithmetic and Logical Binary Primitives
       .Case<AddPrimOp, SubPrimOp>([&](auto op) {
         auto lhs = getExpr(op.lhs());
         auto rhs = getExpr(op.rhs());
@@ -488,7 +532,7 @@ void InferenceMapping::mapOperation(Operation *op) {
       .Case<RemPrimOp>([&](auto op) {
         auto lhs = getExpr(op.lhs());
         auto rhs = getExpr(op.rhs());
-        auto *e = solver.min(lhs, rhs);
+        auto e = solver.min(lhs, rhs);
         setExpr(op.getResult(), e);
       })
       .Case<AndPrimOp, OrPrimOp, XorPrimOp>([&](auto op) {
@@ -497,11 +541,82 @@ void InferenceMapping::mapOperation(Operation *op) {
         auto e = solver.max(lhs, rhs);
         setExpr(op.getResult(), e);
       })
-      .Case<LEQPrimOp, LTPrimOp, GEQPrimOp, GTPrimOp, EQPrimOp, NEQPrimOp>(
-          [&](auto op) {
-            auto e = solver.known(1);
-            setExpr(op.getResult(), e);
-          })
+
+      // Misc Binary Primitives
+      .Case<CatPrimOp>([&](auto op) {
+        auto lhs = getExpr(op.lhs());
+        auto rhs = getExpr(op.rhs());
+        auto e = solver.add(lhs, rhs);
+        setExpr(op.getResult(), e);
+      })
+      .Case<DShlPrimOp>([&](auto op) {
+        auto lhs = getExpr(op.lhs());
+        auto rhs = getExpr(op.rhs());
+        auto e = solver.add(lhs, solver.add(solver.pow(rhs), solver.known(-1)));
+        setExpr(op.getResult(), e);
+      })
+      .Case<DShlwPrimOp, DShrPrimOp>([&](auto op) {
+        auto e = getExpr(op.lhs());
+        setExpr(op.getResult(), e);
+      })
+
+      // Unary operators
+      .Case<NegPrimOp>([&](auto op) {
+        auto input = getExpr(op.input());
+        auto e = solver.add(input, solver.known(1));
+        setExpr(op.getResult(), e);
+      })
+      .Case<CvtPrimOp>([&](auto op) {
+        auto input = getExpr(op.input());
+        auto e = op.input().getType().template cast<IntType>().isSigned()
+                     ? input
+                     : solver.add(input, solver.known(1));
+        setExpr(op.getResult(), e);
+      })
+
+      // Miscellaneous
+      .Case<BitsPrimOp>([&](auto op) {
+        setExpr(op.getResult(), solver.known(op.hi() - op.lo() + 1));
+      })
+      .Case<HeadPrimOp>(
+          [&](auto op) { setExpr(op.getResult(), solver.known(op.amount())); })
+      .Case<TailPrimOp>([&](auto op) {
+        auto input = getExpr(op.input());
+        auto e = solver.add(input, solver.known(-op.amount()));
+        setExpr(op.getResult(), e);
+      })
+      .Case<PadPrimOp>([&](auto op) {
+        auto input = getExpr(op.input());
+        auto e = solver.max(input, solver.known(op.amount()));
+        setExpr(op.getResult(), e);
+      })
+      .Case<ShlPrimOp>([&](auto op) {
+        auto input = getExpr(op.input());
+        auto e = solver.add(input, solver.known(op.amount()));
+        setExpr(op.getResult(), e);
+      })
+      .Case<ShrPrimOp>([&](auto op) {
+        auto input = getExpr(op.input());
+        auto e = solver.max(solver.add(input, solver.known(-op.amount())),
+                            solver.known(1));
+        setExpr(op.getResult(), e);
+      })
+
+      // Handle operations whose output width matches the input width.
+      .Case<NotPrimOp, AsSIntPrimOp, AsUIntPrimOp, AsPassivePrimOp,
+            AsNonPassivePrimOp>(
+          [&](auto op) { setExpr(op.getResult(), getExpr(op.input())); })
+
+      // Handle operations with a single result type that always has a
+      // well-known width.
+      .Case<LEQPrimOp, LTPrimOp, GEQPrimOp, GTPrimOp, EQPrimOp, NEQPrimOp,
+            AsClockPrimOp, AsAsyncResetPrimOp, AndRPrimOp, OrRPrimOp,
+            XorRPrimOp>([&](auto op) {
+        auto width = op.getType().getBitWidthOrSentinel();
+        assert(width > 0 && "width should have been checked by verifier");
+        setExpr(op.getResult(), solver.known(width));
+      })
+
       .Case<MuxPrimOp>([&](auto op) {
         // Caveat: The Scala implementation imposes a constraint on the select
         // signal to be at least 1 bit wide. The FIRRTL MLIR dialect requries
@@ -536,9 +651,9 @@ Expr *InferenceMapping::declareVars(Value value) {
 Expr *InferenceMapping::declareVars(Type type) {
   if (auto ftype = type.dyn_cast<FIRRTLType>())
     return declareVars(ftype);
-  // TODO: Once we support compound types, non-FIRRTL types will just map to an
-  // empty list of expressions in the solver. At that point we'll have something
-  // proper to return here.
+  // TODO: Once we support compound types, non-FIRRTL types will just map to
+  // an empty list of expressions in the solver. At that point we'll have
+  // something proper to return here.
   llvm_unreachable("non-FIRRTL ops not supported");
 }
 
@@ -564,10 +679,10 @@ Expr *InferenceMapping::declareVars(FIRRTLType type) {
 /// than or equal to the sizes in the `smaller` type.
 void InferenceMapping::constrainTypes(Expr *larger, Expr *smaller) {
   // Mimic the Scala implementation here by simply doing nothing if the larger
-  // expr is not a free variable. Apparently there are many cases where useless
-  // constraints can be added, e.g. on multiple well-known values. As long as we
-  // don't want to do type checking itself here, but only width inference, we
-  // should be fine ignoring expr we cannot constraint anyway.
+  // expr is not a free variable. Apparently there are many cases where
+  // useless constraints can be added, e.g. on multiple well-known values. As
+  // long as we don't want to do type checking itself here, but only width
+  // inference, we should be fine ignoring expr we cannot constraint anyway.
   if (auto largerVar = dyn_cast<VarExpr>(larger)) {
     auto c = solver.addGeqConstraint(largerVar, smaller);
     LLVM_DEBUG(llvm::dbgs()
@@ -600,9 +715,8 @@ void InferenceMapping::setExpr(Value value, Expr *expr) {
 //===----------------------------------------------------------------------===//
 
 namespace {
-
-/// A helper class which maps the types and operations in a design to a set of
-/// variables and constraints to be solved later.
+/// A helper class which maps the types and operations in a design to a set
+/// of variables and constraints to be solved later.
 class InferenceTypeUpdate {
 public:
   InferenceTypeUpdate(InferenceMapping &mapping) : mapping(mapping) {}

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -107,6 +107,174 @@ firrtl.circuit "Foo" {
     firrtl.connect %11, %5 : !firrtl.uint, !firrtl.uint<1>
   }
 
+  // CHECK-LABEL: @CatDynShiftOp
+  firrtl.module @CatDynShiftOp() {
+    // CHECK: %0 = firrtl.wire : !firrtl.uint<2>
+    // CHECK: %1 = firrtl.wire : !firrtl.uint<3>
+    // CHECK: %2 = firrtl.wire : !firrtl.sint<2>
+    // CHECK: %3 = firrtl.wire : !firrtl.sint<3>
+    // CHECK: %4 = firrtl.cat {{.*}} -> !firrtl.uint<5>
+    // CHECK: %5 = firrtl.cat {{.*}} -> !firrtl.uint<5>
+    // CHECK: %6 = firrtl.dshl {{.*}} -> !firrtl.uint<10>
+    // CHECK: %7 = firrtl.dshl {{.*}} -> !firrtl.sint<10>
+    // CHECK: %8 = firrtl.dshlw {{.*}} -> !firrtl.uint<3>
+    // CHECK: %9 = firrtl.dshlw {{.*}} -> !firrtl.sint<3>
+    // CHECK: %10 = firrtl.dshr {{.*}} -> !firrtl.uint<3>
+    // CHECK: %11 = firrtl.dshr {{.*}} -> !firrtl.sint<3>
+    %0 = firrtl.wire : !firrtl.uint
+    %1 = firrtl.wire : !firrtl.uint
+    %2 = firrtl.wire : !firrtl.sint
+    %3 = firrtl.wire : !firrtl.sint
+    %4 = firrtl.cat %0, %1 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %5 = firrtl.cat %2, %3 : (!firrtl.sint, !firrtl.sint) -> !firrtl.uint
+    %6 = firrtl.dshl %1, %1 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %7 = firrtl.dshl %3, %1 : (!firrtl.sint, !firrtl.uint) -> !firrtl.sint
+    %8 = firrtl.dshlw %1, %1 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %9 = firrtl.dshlw %3, %1 : (!firrtl.sint, !firrtl.uint) -> !firrtl.sint
+    %10 = firrtl.dshr %1, %1 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %11 = firrtl.dshr %3, %1 : (!firrtl.sint, !firrtl.uint) -> !firrtl.sint
+    %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
+    %c2_ui3 = firrtl.constant(2 : ui3) : !firrtl.uint<3>
+    %c1_si2 = firrtl.constant(1 : si2) : !firrtl.sint<2>
+    %c2_si3 = firrtl.constant(2 : si3) : !firrtl.sint<3>
+    firrtl.connect %0, %c1_ui2 : !firrtl.uint, !firrtl.uint<2>
+    firrtl.connect %1, %c2_ui3 : !firrtl.uint, !firrtl.uint<3>
+    firrtl.connect %2, %c1_si2 : !firrtl.sint, !firrtl.sint<2>
+    firrtl.connect %3, %c2_si3 : !firrtl.sint, !firrtl.sint<3>
+  }
+
+  // CHECK-LABEL: @CastOp
+  firrtl.module @CastOp() {
+    %c0_ui1 = firrtl.constant(0 : ui1) : !firrtl.uint<1>
+    // CHECK: %0 = firrtl.wire : !firrtl.uint<2>
+    // CHECK: %1 = firrtl.wire : !firrtl.sint<3>
+    // CHECK: %4 = firrtl.asSInt {{.*}} -> !firrtl.sint<2>
+    // CHECK: %5 = firrtl.asUInt {{.*}} -> !firrtl.uint<3>
+    %0 = firrtl.wire : !firrtl.uint
+    %1 = firrtl.wire : !firrtl.sint
+    %2 = firrtl.wire : !firrtl.clock
+    %3 = firrtl.wire : !firrtl.asyncreset
+    %4 = firrtl.asSInt %0 : (!firrtl.uint) -> !firrtl.sint
+    %5 = firrtl.asUInt %1 : (!firrtl.sint) -> !firrtl.uint
+    %6 = firrtl.asUInt %2 : (!firrtl.clock) -> !firrtl.uint<1>
+    %7 = firrtl.asUInt %3 : (!firrtl.asyncreset) -> !firrtl.uint<1>
+    %8 = firrtl.asClock %c0_ui1 : (!firrtl.uint<1>) -> !firrtl.clock
+    %9 = firrtl.asAsyncReset %c0_ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset
+    %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
+    %c2_si3 = firrtl.constant(2 : si3) : !firrtl.sint<3>
+    firrtl.connect %0, %c1_ui2 : !firrtl.uint, !firrtl.uint<2>
+    firrtl.connect %1, %c2_si3 : !firrtl.sint, !firrtl.sint<3>
+  }
+
+  // CHECK-LABEL: @CvtOp
+  firrtl.module @CvtOp() {
+    // CHECK: %0 = firrtl.wire : !firrtl.uint<2>
+    // CHECK: %1 = firrtl.wire : !firrtl.sint<3>
+    // CHECK: %2 = firrtl.cvt {{.*}} -> !firrtl.sint<3>
+    // CHECK: %3 = firrtl.cvt {{.*}} -> !firrtl.sint<3>
+    %0 = firrtl.wire : !firrtl.uint
+    %1 = firrtl.wire : !firrtl.sint
+    %2 = firrtl.cvt %0 : (!firrtl.uint) -> !firrtl.sint
+    %3 = firrtl.cvt %1 : (!firrtl.sint) -> !firrtl.sint
+    %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
+    %c2_si3 = firrtl.constant(2 : si3) : !firrtl.sint<3>
+    firrtl.connect %0, %c1_ui2 : !firrtl.uint, !firrtl.uint<2>
+    firrtl.connect %1, %c2_si3 : !firrtl.sint, !firrtl.sint<3>
+  }
+
+  // CHECK-LABEL: @NegOp
+  firrtl.module @NegOp() {
+    // CHECK: %0 = firrtl.wire : !firrtl.uint<2>
+    // CHECK: %1 = firrtl.wire : !firrtl.sint<3>
+    // CHECK: %2 = firrtl.neg {{.*}} -> !firrtl.sint<3>
+    // CHECK: %3 = firrtl.neg {{.*}} -> !firrtl.sint<4>
+    %0 = firrtl.wire : !firrtl.uint
+    %1 = firrtl.wire : !firrtl.sint
+    %2 = firrtl.neg %0 : (!firrtl.uint) -> !firrtl.sint
+    %3 = firrtl.neg %1 : (!firrtl.sint) -> !firrtl.sint
+    %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
+    %c2_si3 = firrtl.constant(2 : si3) : !firrtl.sint<3>
+    firrtl.connect %0, %c1_ui2 : !firrtl.uint, !firrtl.uint<2>
+    firrtl.connect %1, %c2_si3 : !firrtl.sint, !firrtl.sint<3>
+  }
+
+  // CHECK-LABEL: @NotOp
+  firrtl.module @NotOp() {
+    // CHECK: %0 = firrtl.wire : !firrtl.uint<2>
+    // CHECK: %1 = firrtl.wire : !firrtl.sint<3>
+    // CHECK: %2 = firrtl.not {{.*}} -> !firrtl.uint<2>
+    // CHECK: %3 = firrtl.not {{.*}} -> !firrtl.uint<3>
+    %0 = firrtl.wire : !firrtl.uint
+    %1 = firrtl.wire : !firrtl.sint
+    %2 = firrtl.not %0 : (!firrtl.uint) -> !firrtl.uint
+    %3 = firrtl.not %1 : (!firrtl.sint) -> !firrtl.uint
+    %c1_ui2 = firrtl.constant(1 : ui2) : !firrtl.uint<2>
+    %c2_si3 = firrtl.constant(2 : si3) : !firrtl.sint<3>
+    firrtl.connect %0, %c1_ui2 : !firrtl.uint, !firrtl.uint<2>
+    firrtl.connect %1, %c2_si3 : !firrtl.sint, !firrtl.sint<3>
+  }
+
+  // CHECK-LABEL: @AndOrXorReductionOp
+  firrtl.module @AndOrXorReductionOp() {
+    // CHECK: %0 = firrtl.wire : !firrtl.uint<1>
+    // CHECK: %1 = firrtl.wire : !firrtl.uint<1>
+    // CHECK: %2 = firrtl.wire : !firrtl.uint<1>
+    // CHECK: %3 = firrtl.andr {{.*}} -> !firrtl.uint<1>
+    // CHECK: %4 = firrtl.orr {{.*}} -> !firrtl.uint<1>
+    // CHECK: %5 = firrtl.xorr {{.*}} -> !firrtl.uint<1>
+    %c0_ui16 = firrtl.constant(0 : ui16) : !firrtl.uint<16>
+    %0 = firrtl.wire : !firrtl.uint
+    %1 = firrtl.wire : !firrtl.uint
+    %2 = firrtl.wire : !firrtl.uint
+    %3 = firrtl.andr %c0_ui16 : (!firrtl.uint<16>) -> !firrtl.uint<1>
+    %4 = firrtl.orr %c0_ui16 : (!firrtl.uint<16>) -> !firrtl.uint<1>
+    %5 = firrtl.xorr %c0_ui16 : (!firrtl.uint<16>) -> !firrtl.uint<1>
+    firrtl.connect %0, %3 : !firrtl.uint, !firrtl.uint<1>
+    firrtl.connect %1, %4 : !firrtl.uint, !firrtl.uint<1>
+    firrtl.connect %2, %5 : !firrtl.uint, !firrtl.uint<1>
+  }
+
+  // CHECK-LABEL: @BitsHeadTailPadOp
+  firrtl.module @BitsHeadTailPadOp() {
+    // CHECK: %0 = firrtl.wire : !firrtl.uint<3>
+    // CHECK: %1 = firrtl.wire : !firrtl.uint<3>
+    // CHECK: %2 = firrtl.wire : !firrtl.uint<5>
+    // CHECK: %3 = firrtl.wire : !firrtl.uint<5>
+    // CHECK: %8 = firrtl.tail {{.*}} -> !firrtl.uint<12>
+    // CHECK: %9 = firrtl.tail {{.*}} -> !firrtl.uint<12>
+    // CHECK: %10 = firrtl.pad {{.*}} -> !firrtl.uint<42>
+    // CHECK: %11 = firrtl.pad {{.*}} -> !firrtl.sint<42>
+    // CHECK: %12 = firrtl.pad {{.*}} -> !firrtl.uint<99>
+    // CHECK: %13 = firrtl.pad {{.*}} -> !firrtl.sint<99>
+    %ui = firrtl.wire : !firrtl.uint
+    %si = firrtl.wire : !firrtl.sint
+    %0 = firrtl.wire : !firrtl.uint
+    %1 = firrtl.wire : !firrtl.uint
+    %2 = firrtl.wire : !firrtl.uint
+    %3 = firrtl.wire : !firrtl.uint
+
+    %4 = firrtl.bits %ui 3 to 1 : (!firrtl.uint) -> !firrtl.uint<3>
+    %5 = firrtl.bits %si 3 to 1 : (!firrtl.sint) -> !firrtl.uint<3>
+    %6 = firrtl.head %ui, 5 : (!firrtl.uint) -> !firrtl.uint<5>
+    %7 = firrtl.head %si, 5 : (!firrtl.sint) -> !firrtl.uint<5>
+    %8 = firrtl.tail %ui, 30 : (!firrtl.uint) -> !firrtl.uint
+    %9 = firrtl.tail %si, 30 : (!firrtl.sint) -> !firrtl.uint
+    %10 = firrtl.pad %ui, 13 : (!firrtl.uint) -> !firrtl.uint
+    %11 = firrtl.pad %si, 13 : (!firrtl.sint) -> !firrtl.sint
+    %12 = firrtl.pad %ui, 99 : (!firrtl.uint) -> !firrtl.uint
+    %13 = firrtl.pad %si, 99 : (!firrtl.sint) -> !firrtl.sint
+
+    firrtl.connect %0, %4 : !firrtl.uint, !firrtl.uint<3>
+    firrtl.connect %1, %5 : !firrtl.uint, !firrtl.uint<3>
+    firrtl.connect %2, %6 : !firrtl.uint, !firrtl.uint<5>
+    firrtl.connect %3, %7 : !firrtl.uint, !firrtl.uint<5>
+
+    %c0_ui42 = firrtl.constant(0 : ui42) : !firrtl.uint<42>
+    %c0_si42 = firrtl.constant(0 : si42) : !firrtl.sint<42>
+    firrtl.connect %ui, %c0_ui42 : !firrtl.uint, !firrtl.uint<42>
+    firrtl.connect %si, %c0_si42 : !firrtl.sint, !firrtl.sint<42>
+  }
+
   // CHECK-LABEL: @MuxOp
   firrtl.module @MuxOp(in %a: !firrtl.uint<1>) {
     // CHECK: %0 = firrtl.wire : !firrtl.uint<2>
@@ -119,6 +287,44 @@ firrtl.circuit "Foo" {
     %c2_ui3 = firrtl.constant(2 : ui3) : !firrtl.uint<3>
     firrtl.connect %0, %c1_ui2 : !firrtl.uint, !firrtl.uint<2>
     firrtl.connect %1, %c2_ui3 : !firrtl.uint, !firrtl.uint<3>
+  }
+
+  // CHECK-LABEL: @ShlShrOp
+  firrtl.module @ShlShrOp() {
+    // CHECK: %0 = firrtl.shl {{.*}} -> !firrtl.uint<8>
+    // CHECK: %1 = firrtl.shl {{.*}} -> !firrtl.sint<8>
+    // CHECK: %2 = firrtl.shr {{.*}} -> !firrtl.uint<2>
+    // CHECK: %3 = firrtl.shr {{.*}} -> !firrtl.sint<2>
+    // CHECK: %4 = firrtl.shr {{.*}} -> !firrtl.uint<1>
+    // CHECK: %5 = firrtl.shr {{.*}} -> !firrtl.sint<1>
+    %ui = firrtl.wire : !firrtl.uint
+    %si = firrtl.wire : !firrtl.sint
+
+    %0 = firrtl.shl %ui, 3 : (!firrtl.uint) -> !firrtl.uint
+    %1 = firrtl.shl %si, 3 : (!firrtl.sint) -> !firrtl.sint
+    %2 = firrtl.shr %ui, 3 : (!firrtl.uint) -> !firrtl.uint
+    %3 = firrtl.shr %si, 3 : (!firrtl.sint) -> !firrtl.sint
+    %4 = firrtl.shr %ui, 9 : (!firrtl.uint) -> !firrtl.uint
+    %5 = firrtl.shr %si, 9 : (!firrtl.sint) -> !firrtl.sint
+
+    %c0_ui5 = firrtl.constant(0 : ui5) : !firrtl.uint<5>
+    %c0_si5 = firrtl.constant(0 : si5) : !firrtl.sint<5>
+    firrtl.connect %ui, %c0_ui5 : !firrtl.uint, !firrtl.uint<5>
+    firrtl.connect %si, %c0_si5 : !firrtl.sint, !firrtl.sint<5>
+  }
+
+  // CHECK-LABEL: @PassiveCastOp
+  firrtl.module @PassiveCastOp() {
+    // CHECK: %0 = firrtl.wire : !firrtl.uint<5>
+    // CHECK: %1 = firrtl.asNonPassive {{.*}} : !firrtl.flip<uint<5>>
+    // CHECK: %2 = firrtl.asPassive {{.*}} : !firrtl.flip<uint<5>>
+    %ui = firrtl.wire : !firrtl.uint
+    %0 = firrtl.wire : !firrtl.uint
+    %1 = firrtl.asNonPassive %ui : !firrtl.flip<uint>
+    %2 = firrtl.asPassive %1 : !firrtl.flip<uint>
+    firrtl.connect %0, %2 : !firrtl.uint, !firrtl.uint
+    %c0_ui5 = firrtl.constant(0 : ui5) : !firrtl.uint<5>
+    firrtl.connect %ui, %c0_ui5 : !firrtl.uint, !firrtl.uint<5>
   }
 
   firrtl.module @Foo() {}


### PR DESCRIPTION
Extend the `InferWidths` pass to cover almost all expressions in the FIRRTL dialect. What remains are expressions that interact with aggregate data types, as well as statements and declarations. Contributes to #1014.

This specifically covers the following operations:
- `CatPrimOp`
- `DShlPrimOp`
- `DShlwPrimOp`
- `DShrPrimOp`
- `AsSIntPrimOp`
- `AsUIntPrimOp`
- `AsAsyncResetPrimOp`
- `AsClockPrimOp`
- `CvtPrimOp`
- `NegPrimOp`
- `NotPrimOp`
- `AndRPrimOp`
- `OrRPrimOp`
- `XorRPrimOp`
- `BitsPrimOp`
- `HeadPrimOp`
- `InvalidValuePrimOp`
- `PadPrimOp`
- `ShlPrimOp`
- `ShrPrimOp`
- `TailPrimOp`
- `AsPassivePrimOp`
- `AsNonPassivePrimOp`

### Todo
- [x] Merge #981 and rebase onto that