### PR TITLE
[ESI] Fix ESI integration tests

### DIFF
--- a/lib/CAPI/Dialect/ESI.cpp
+++ b/lib/CAPI/Dialect/ESI.cpp
@@ -18,12 +18,8 @@ void registerESIPasses() { circt::esi::registerESIPasses(); }
 MlirLogicalResult circtESIExportCosimSchema(MlirModule module,
                                             MlirStringCallback callback,
                                             void *userData) {
-#ifdef CAPNP
   mlir::detail::CallbackOstream stream(callback, userData);
   return wrap(circt::esi::exportCosimSchema(unwrap(module), stream));
-#else
-  return wrap(mlir::failure());
-#endif
 }
 
 bool circtESITypeIsAChannelType(MlirType type) {

--- a/lib/Dialect/ESI/ESITranslations.cpp
+++ b/lib/Dialect/ESI/ESITranslations.cpp
@@ -167,6 +167,13 @@ LogicalResult circt::esi::exportCosimSchema(ModuleOp module,
   return schema.emit();
 }
 
+#else // Not CAPNP
+
+LogicalResult circt::esi::exportCosimSchema(ModuleOp module,
+                                            llvm::raw_ostream &os) {
+  return failure();
+}
+
 #endif
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Moving the export translation CAPNP define selection to a C++ file which actually has the CAPNP macro defined.