### PR TITLE
[RTL] Add type declaration ops.

### DIFF
--- a/include/circt/Dialect/RTL/RTL.td
+++ b/include/circt/Dialect/RTL/RTL.td
@@ -45,5 +45,6 @@ class RTLOp<string mnemonic, list<OpTrait> traits = []> :
 
 include "circt/Dialect/RTL/RTLAggregates.td"
 include "circt/Dialect/RTL/RTLStructure.td"
+include "circt/Dialect/RTL/RTLTypeDecls.td"
 
 #endif // RTL_TD

--- a/include/circt/Dialect/RTL/RTLTypeDecls.td
+++ b/include/circt/Dialect/RTL/RTLTypeDecls.td
@@ -14,7 +14,7 @@
 // Declaration operations
 //===----------------------------------------------------------------------===//
 
-def TypedeclScopeOp : RTLOp<"typedecl_scope",
+def TypeScopeOp : RTLOp<"type_scope",
       [Symbol, SymbolTable, SingleBlock, NoTerminator, NoRegionArguments,
       HasParent<"mlir::ModuleOp">]> {
   let summary = "Type declaration wrapper.";
@@ -35,11 +35,15 @@ def TypedeclScopeOp : RTLOp<"typedecl_scope",
   }];
 }
 
-def TypedeclOp : RTLOp<"typedecl", [Symbol, HasParent<"TypedeclScopeOp">]> {
+def TypedeclOp : RTLOp<"typedecl", [Symbol, HasParent<"TypeScopeOp">]> {
   let summary = "Type declaration.";
   let description = "Associate a symbolic name with a type.";
 
-  let arguments = (ins SymbolNameAttr:$sym_name, TypeAttr:$type);
+  let arguments = (ins
+    SymbolNameAttr:$sym_name,
+    TypeAttr:$type,
+    OptionalAttr<StrAttr>:$verilogName
+  );
 
-  let assemblyFormat = "$sym_name `:` $type attr-dict";
+  let assemblyFormat = "$sym_name (`,` $verilogName^)? `:` $type attr-dict";
 }

--- a/include/circt/Dialect/RTL/RTLTypeDecls.td
+++ b/include/circt/Dialect/RTL/RTLTypeDecls.td
@@ -14,7 +14,7 @@
 // Declaration operations
 //===----------------------------------------------------------------------===//
 
-def TypedeclScope : RTLOp<"typedecl_scope",
+def TypedeclScopeOp : RTLOp<"typedecl_scope",
       [Symbol, SymbolTable, SingleBlock, NoTerminator, NoRegionArguments,
       HasParent<"mlir::ModuleOp">]> {
   let summary = "Type declaration wrapper.";
@@ -35,7 +35,7 @@ def TypedeclScope : RTLOp<"typedecl_scope",
   }];
 }
 
-def Typedecl : RTLOp<"typedecl", [Symbol, HasParent<"TypedeclScope">]> {
+def TypedeclOp : RTLOp<"typedecl", [Symbol, HasParent<"TypedeclScopeOp">]> {
   let summary = "Type declaration.";
   let description = "Associate a symbolic name with a type.";
 

--- a/include/circt/Dialect/RTL/RTLTypeDecls.td
+++ b/include/circt/Dialect/RTL/RTLTypeDecls.td
@@ -29,9 +29,13 @@ def TypedeclScope : RTLOp<"typedecl_scope",
   let arguments = (ins SymbolNameAttr:$sym_name);
 
   let assemblyFormat = "$sym_name $body attr-dict";
+
+  let extraClassDeclaration = [{
+    Block *getBodyBlock() { return &body().front(); }
+  }];
 }
 
-def Typedecl : RTLOp<"typedecl", [Symbol]> {
+def Typedecl : RTLOp<"typedecl", [Symbol, HasParent<"TypedeclScope">]> {
   let summary = "Type declaration.";
   let description = "Associate a symbolic name with a type.";
 

--- a/include/circt/Dialect/RTL/RTLTypeDecls.td
+++ b/include/circt/Dialect/RTL/RTLTypeDecls.td
@@ -1,0 +1,41 @@
+//===- RTLTypeDecls.td - RTL data type declaration ops and types ----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Support for type declarations in the RTL type system.
+//
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// Declaration operations
+//===----------------------------------------------------------------------===//
+
+def TypedeclScope : RTLOp<"typedecl_scope",
+      [Symbol, SymbolTable, SingleBlock, NoTerminator, NoRegionArguments,
+      HasParent<"mlir::ModuleOp">]> {
+  let summary = "Type declaration wrapper.";
+  let description = [{
+    An operation whose one body block contains type declarations. This op
+    provides a scope for type declarations at the top level of an MLIR module.
+    It is a symbol that may be looked up within the module, as well as a symbol
+    table itself, so type declarations may be looked up.
+  }];
+
+  let regions = (region SizedRegion<1>:$body);
+  let arguments = (ins SymbolNameAttr:$sym_name);
+
+  let assemblyFormat = "$sym_name $body attr-dict";
+}
+
+def Typedecl : RTLOp<"typedecl", [Symbol]> {
+  let summary = "Type declaration.";
+  let description = "Associate a symbolic name with a type.";
+
+  let arguments = (ins SymbolNameAttr:$sym_name, TypeAttr:$type);
+
+  let assemblyFormat = "$sym_name `:` $type attr-dict";
+}

--- a/test/Dialect/RTL/typedecls.mlir
+++ b/test/Dialect/RTL/typedecls.mlir
@@ -1,9 +1,11 @@
 // RUN: circt-opt %s | circt-opt | FileCheck %s
 
-// CHECK-LABEL: rtl.typedecl_scope @__rtl_typedecls {
-rtl.typedecl_scope @__rtl_typedecls {
+// CHECK-LABEL: rtl.type_scope @__rtl_typedecls {
+rtl.type_scope @__rtl_typedecls {
   // CHECK: rtl.typedecl @foo : i1
   rtl.typedecl @foo : i1
   // CHECK: rtl.typedecl @bar : !rtl.struct<a: i1, b: i1>
   rtl.typedecl @bar : !rtl.struct<a: i1, b: i1>
+  // CHECK: rtl.typedecl @baz, "MY_NAMESPACE_baz" : i8
+  rtl.typedecl @baz, "MY_NAMESPACE_baz" : i8
 }

--- a/test/Dialect/RTL/typedecls.mlir
+++ b/test/Dialect/RTL/typedecls.mlir
@@ -1,0 +1,9 @@
+// RUN: circt-opt %s | circt-opt | FileCheck %s
+
+// CHECK-LABEL: rtl.typedecl_scope @__rtl_typedecls {
+rtl.typedecl_scope @__rtl_typedecls {
+  // CHECK: rtl.typedecl @foo : i1
+  rtl.typedecl @foo : i1
+  // CHECK: rtl.typedecl @bar : !rtl.struct<a: i1, b: i1>
+  rtl.typedecl @bar : !rtl.struct<a: i1, b: i1>
+}


### PR DESCRIPTION
This includes the ODS to define a wrapper operation for a typedecl
scope. Within its body, typedecl ops may associate a symbolic name to
a type.