### PR TITLE
[RTL] Support typedecls in ExportVerilog.

### DIFF
--- a/include/circt/Dialect/RTL/RTLVisitors.h
+++ b/include/circt/Dialect/RTL/RTLVisitors.h
@@ -79,10 +79,9 @@ public:
   ResultType dispatchStmtVisitor(Operation *op, ExtraArgs... args) {
     auto *thisCast = static_cast<ConcreteType *>(this);
     return TypeSwitch<Operation *, ResultType>(op)
-        .template Case<OutputOp, InstanceOp, TypedeclOp>(
-            [&](auto expr) -> ResultType {
-              return thisCast->visitStmt(expr, args...);
-            })
+        .template Case<OutputOp, InstanceOp>([&](auto expr) -> ResultType {
+          return thisCast->visitStmt(expr, args...);
+        })
         .Default([&](auto expr) -> ResultType {
           return thisCast->visitInvalidStmt(op, args...);
         });
@@ -119,6 +118,43 @@ public:
   // Basic nodes.
   HANDLE(OutputOp, Unhandled);
   HANDLE(InstanceOp, Unhandled);
+#undef HANDLE
+};
+
+/// This helps visit TypeScopeOp child nodes.
+template <typename ConcreteType, typename ResultType = void,
+          typename... ExtraArgs>
+class TypeScopeVisitor {
+public:
+  ResultType dispatchTypeScopeVisitor(Operation *op, ExtraArgs... args) {
+    auto *thisCast = static_cast<ConcreteType *>(this);
+    return TypeSwitch<Operation *, ResultType>(op)
+        .template Case<TypedeclOp>([&](auto expr) -> ResultType {
+          return thisCast->visitTypeScope(expr, args...);
+        })
+        .Default([&](auto expr) -> ResultType {
+          return thisCast->visitInvalidTypeScope(op, args...);
+        });
+  }
+
+  /// This callback is invoked on any non-type scope operations.
+  ResultType visitInvalidTypeScope(Operation *op, ExtraArgs... args) {
+    op->emitOpError("unknown RTL type scope node");
+    abort();
+  }
+
+  /// This callback is invoked on any type scope operations that are not
+  /// handled by the concrete visitor.
+  ResultType visitUnhandledTypeScope(Operation *op, ExtraArgs... args) {
+    return ResultType();
+  }
+
+#define HANDLE(OPTYPE, OPKIND)                                                 \
+  ResultType visitTypeScope(OPTYPE op, ExtraArgs... args) {                    \
+    return static_cast<ConcreteType *>(this)->visit##OPKIND##TypeScope(        \
+        op, args...);                                                          \
+  }
+
   HANDLE(TypedeclOp, Unhandled);
 #undef HANDLE
 };

--- a/include/circt/Dialect/RTL/RTLVisitors.h
+++ b/include/circt/Dialect/RTL/RTLVisitors.h
@@ -79,9 +79,10 @@ public:
   ResultType dispatchStmtVisitor(Operation *op, ExtraArgs... args) {
     auto *thisCast = static_cast<ConcreteType *>(this);
     return TypeSwitch<Operation *, ResultType>(op)
-        .template Case<OutputOp, InstanceOp>([&](auto expr) -> ResultType {
-          return thisCast->visitStmt(expr, args...);
-        })
+        .template Case<OutputOp, InstanceOp, TypedeclOp>(
+            [&](auto expr) -> ResultType {
+              return thisCast->visitStmt(expr, args...);
+            })
         .Default([&](auto expr) -> ResultType {
           return thisCast->visitInvalidStmt(op, args...);
         });
@@ -118,6 +119,7 @@ public:
   // Basic nodes.
   HANDLE(OutputOp, Unhandled);
   HANDLE(InstanceOp, Unhandled);
+  HANDLE(TypedeclOp, Unhandled);
 #undef HANDLE
 };
 

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -1510,16 +1510,12 @@ private:
 } // end anonymous namespace
 
 void TypeScopeEmitter::emitTypeScopeBlock(Block &body) {
-  addIndent();
-
   for (auto &op : body) {
     if (failed(dispatchTypeScopeVisitor(&op))) {
       op.emitOpError("cannot emit this type scope op to Verilog");
       os << "<<unsupported op: " << op.getName().getStringRef() << ">>\n";
     }
   }
-
-  reduceIndent();
 }
 
 LogicalResult TypeScopeEmitter::visitTypeScope(TypedeclOp op) {

--- a/test/ExportVerilog/rtl-typedecls.mlir
+++ b/test/ExportVerilog/rtl-typedecls.mlir
@@ -1,0 +1,10 @@
+// RUN: circt-translate %s -export-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
+
+rtl.type_scope @__rtl_typedecls {
+  // CHECK: typedef logic foo;
+  rtl.typedecl @foo : i1
+  // CHECK: typedef struct packed {logic a; logic b; } bar;
+  rtl.typedecl @bar : !rtl.struct<a: i1, b: i1>
+  // CHECK: typedef logic [7:0][0:15] baz;
+  rtl.typedecl @baz : !rtl.uarray<16xi8>
+}

--- a/test/firtool/split-verilog.mlir
+++ b/test/firtool/split-verilog.mlir
@@ -15,6 +15,10 @@ sv.ifdef.procedural "VERILATOR" {
 }
 sv.verbatim ""
 
+rtl.type_scope @__rtl_typedecls {
+  rtl.typedecl @foo : i1
+}
+
 rtl.module @foo(%a: i1) -> (%b: i1) {
   rtl.output %a : i1
 }
@@ -48,6 +52,7 @@ rtl.module.extern @inout_2 () -> ()
 // VERILOG-FOO-NEXT:  `else
 // VERILOG-FOO-NEXT:    // World
 // VERILOG-FOO-NEXT:  `endif
+// VERILOG-FOO:       typedef logic foo;
 // VERILOG-FOO-LABEL: module foo(
 // VERILOG-FOO:       endmodule
 
@@ -57,6 +62,7 @@ rtl.module.extern @inout_2 () -> ()
 // VERILOG-BAR-NEXT:  `else
 // VERILOG-BAR-NEXT:    // World
 // VERILOG-BAR-NEXT:  `endif
+// VERILOG-BAR:       typedef logic foo;
 // VERILOG-BAR-LABEL: module bar
 // VERILOG-BAR:       endmodule
 
@@ -66,6 +72,7 @@ rtl.module.extern @inout_2 () -> ()
 // VERILOG-USB-NEXT:  `else
 // VERILOG-USB-NEXT:    // World
 // VERILOG-USB-NEXT:  `endif
+// VERILOG-USB:       typedef logic foo;
 // VERILOG-USB-LABEL: interface usb;
 // VERILOG-USB:       endinterface
 
@@ -75,6 +82,7 @@ rtl.module.extern @inout_2 () -> ()
 // VERILOG-INOUT-3-NEXT:  `else
 // VERILOG-INOUT-3-NEXT:    // World
 // VERILOG-INOUT-3-NEXT:  `endif
+// VERILOG-INOUT-3:       typedef logic foo;
 // VERILOG-INOUT-3-LABEL: module inout_3(
 // VERILOG-INOUT-3:       endmodule
 
@@ -84,6 +92,7 @@ rtl.module.extern @inout_2 () -> ()
 // VERILOG-NEXT:  `else
 // VERILOG-NEXT:    // World
 // VERILOG-NEXT:  `endif
+// VERILOG:       typedef logic foo;
 // VERILOG-LABEL: module foo(
 // VERILOG:       endmodule
 // VERILOG-LABEL: module bar


### PR DESCRIPTION
The typedecl scope has its whole body exported at the top level of the
output. If split output, typedecls are included in each file.