### PR TITLE
[circt-rtl-sim] [Verilator] Compile with trace options when in Debug mode

### DIFF
--- a/tools/circt-rtl-sim/circt-rtl-sim.py.in
+++ b/tools/circt-rtl-sim/circt-rtl-sim.py.in
@@ -20,6 +20,7 @@ import sys
 ThisFileDir = os.path.dirname(__file__)
 DebugBuild = "@CMAKE_BUILD_TYPE@" == "Debug"
 
+
 class Questa:
   """Run and compile funcs for Questasim."""
 

--- a/tools/circt-rtl-sim/circt-rtl-sim.py.in
+++ b/tools/circt-rtl-sim/circt-rtl-sim.py.in
@@ -18,7 +18,7 @@ import subprocess
 import sys
 
 ThisFileDir = os.path.dirname(__file__)
-
+DebugBuild = "@CMAKE_BUILD_TYPE@" == "Debug"
 
 class Questa:
   """Run and compile funcs for Questasim."""
@@ -159,10 +159,13 @@ class Verilator:
     dpiLibs = filter(lambda fn: fn.endswith(".so") or fn.endswith(".dll"),
                      sources)
     self.ldPaths = ":".join([os.path.dirname(x) for x in dpiLibs])
+    debugFlags = []
+    if DebugBuild:
+      debugFlags = ["--trace", "--trace-params", "--trace-structs"]
     return subprocess.run([
         self.verilator, "--cc", "--top-module", self.top, "-sv", "--build",
         "--exe", "--assert"
-    ] + sources)
+    ] + debugFlags + sources)
 
   def run(self, cycles, args):
     exe = os.path.join("obj_dir", "V" + self.top)

--- a/tools/circt-rtl-sim/driver.cpp.in
+++ b/tools/circt-rtl-sim/driver.cpp.in
@@ -13,9 +13,7 @@
 
 #include "Vtop.h"
 
-#ifdef DEBUG
 #include "verilated_vcd_c.h"
-#endif
 
 #include "signal.h"
 #include <iostream>
@@ -53,12 +51,15 @@ int main(int argc, char **argv) {
 
   // Construct the simulated module's C++ model.
   auto &dut = *new Vtop();
-#ifdef DEBUG
-  VerilatedVcdC *tfp = new VerilatedVcdC;
-  Verilated::traceEverOn(true);
-  dut.trace(tfp, 99); // Trace 99 levels of hierarchy
-  tfp->open("main.vcd");
-#endif
+  char *waveformFile = getenv("SAVE_WAVE");
+
+  VerilatedVcdC *tfp = nullptr;
+  if (waveformFile) {
+    tfp = new VerilatedVcdC();
+    Verilated::traceEverOn(true);
+    dut.trace(tfp, 99); // Trace 99 levels of hierarchy
+    tfp->open(waveformFile);
+  }
 
   std::cout << "[driver] Starting simulation" << std::endl;
 
@@ -70,9 +71,8 @@ int main(int argc, char **argv) {
   for (timeStamp = 0; timeStamp < 8 && !Verilated::gotFinish(); timeStamp++) {
     dut.eval();
     dut.clk = !dut.clk;
-#ifdef DEBUG
-    tfp->dump(timeStamp);
-#endif
+    if (tfp)
+      tfp->dump(timeStamp);
   }
 
   // Take simulation out of reset.
@@ -85,17 +85,15 @@ int main(int argc, char **argv) {
        timeStamp++) {
     dut.eval();
     dut.clk = !dut.clk;
-#ifdef DEBUG
-    tfp->dump(timeStamp);
-#endif
+    if (tfp)
+      tfp->dump(timeStamp);
   }
 
   // Tell the simulator that we're going to exit. This flushes the output(s) and
   // frees whatever memory may have been allocated.
   dut.final();
-#ifdef DEBUG
-  tfp->close();
-#endif
+  if (tfp)
+    tfp->close();
 
   std::cout << "[driver] Ending simulation at tick #" << timeStamp << std::endl;
   return 0;


### PR DESCRIPTION
This incurs some cost in the generated simulator. Monitoring and saving the
waveforms to disk incurs yet more overhead, so enable this via an environment
variable.