### PR TITLE
Update LLVM to 33f908c42881fa02963f0c64f8be5088717664cc

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -141,17 +141,17 @@ def FuncOp : Op<HandshakeOps_Dialect, "func", [
   }];
   let printer = [{
     FunctionType fnType = getType();
-    mlir::impl::printFunctionLikeOp(p, *this, fnType.getInputs(),
+    mlir::function_like_impl::printFunctionLikeOp(p, *this, fnType.getInputs(),
         /*isVariadic=*/true, fnType.getResults());
   }];
   let parser = [{
     auto buildFuncType =
         [](Builder & builder, ArrayRef<Type> argTypes, ArrayRef<Type> results,
-           mlir::impl::VariadicFlag, std::string &) {
+           mlir::function_like_impl::VariadicFlag, std::string &) {
       return builder.getFunctionType(argTypes, results);
     };
 
-    return mlir::impl::parseFunctionLikeOp(parser, result,
+    return mlir::function_like_impl::parseFunctionLikeOp(parser, result,
         /*allowVariadic=*/true, buildFuncType);
   }];
 }
@@ -246,12 +246,12 @@ def BufferOp : Handshake_Op<"buffer", [NoSideEffect, HasClock]> {
 
   let description = [{
     The "handshake.buffer" operation represents a buffer operation. $slots
-    must be an unsigned integer larger than 0. $sequantial=True indicates a 
-    nontransparent buffer, while $sequantial=False indicates a transparent 
+    must be an unsigned integer larger than 0. $sequantial=True indicates a
+    nontransparent buffer, while $sequantial=False indicates a transparent
     buffer.
   }];
 
-  let arguments = (ins AnyType, BoolAttr:$sequential, BoolAttr:$control, 
+  let arguments = (ins AnyType, BoolAttr:$sequential, BoolAttr:$control,
                    Confined<I32Attr, [IntMinValue<1>]>:$slots);
   let results = (outs AnyType);
 

--- a/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
+++ b/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
@@ -1427,7 +1427,7 @@ struct FuncOpLowering : public OpConversionPattern<mlir::FuncOp> {
     SmallVector<NamedAttribute, 4> attributes;
     for (const auto &attr : funcOp->getAttrs()) {
       if (attr.first == SymbolTable::getSymbolAttrName() ||
-          attr.first == impl::getTypeAttrName())
+          attr.first == function_like_impl::getTypeAttrName())
         continue;
       attributes.push_back(attr);
     }

--- a/lib/Dialect/LLHD/IR/LLHDOps.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDOps.cpp
@@ -877,7 +877,7 @@ static void printProcArguments(OpAsmPrinter &p, Operation *op,
   auto printList = [&](unsigned i, unsigned max) -> void {
     for (; i < max; ++i) {
       p << body.front().getArgument(i) << " : " << types[i];
-      p.printOptionalAttrDict(::mlir::impl::getArgAttrs(op, i));
+      p.printOptionalAttrDict(::mlir::function_like_impl::getArgAttrs(op, i));
 
       if (i < max - 1)
         p << ", ";

--- a/lib/Dialect/RTL/RTLOps.cpp
+++ b/lib/Dialect/RTL/RTLOps.cpp
@@ -166,7 +166,7 @@ enum ExternModKind { PlainMod, ExternMod, GenMod };
 static void buildModule(OpBuilder &builder, OperationState &result,
                         StringAttr name, ArrayRef<ModulePortInfo> ports,
                         ArrayRef<NamedAttribute> attributes) {
-  using namespace mlir::impl;
+  using namespace mlir::function_like_impl;
 
   // Add an attribute for the name.
   result.addAttribute(::mlir::SymbolTable::getSymbolAttrName(), name);
@@ -356,7 +356,7 @@ static ParseResult parseModuleFunctionSignature(
     SmallVectorImpl<NamedAttrList> &resultAttrs,
     SmallVectorImpl<Attribute> &resultNames) {
 
-  using namespace mlir::impl;
+  using namespace mlir::function_like_impl;
   bool allowArgAttrs = true;
   bool allowVariadic = false;
   if (parseFunctionArgumentList(parser, allowArgAttrs, allowVariadic, argNames,
@@ -378,7 +378,7 @@ static bool hasAttribute(StringRef name, ArrayRef<NamedAttribute> attrs) {
 
 static ParseResult parseRTLModuleOp(OpAsmParser &parser, OperationState &result,
                                     ExternModKind modKind = PlainMod) {
-  using namespace mlir::impl;
+  using namespace mlir::function_like_impl;
 
   SmallVector<OpAsmParser::OperandType, 4> entryArgs;
   SmallVector<NamedAttrList, 4> argAttrs;
@@ -501,7 +501,7 @@ static void printModuleSignature(OpAsmPrinter &p, Operation *op,
     }
 
     p.printType(argTypes[i]);
-    p.printOptionalAttrDict(::mlir::impl::getArgAttrs(op, i));
+    p.printOptionalAttrDict(::mlir::function_like_impl::getArgAttrs(op, i));
   }
 
   if (isVariadic) {
@@ -523,9 +523,9 @@ static void printModuleSignature(OpAsmPrinter &p, Operation *op,
       if (!name.empty())
         os << '%' << name << ": ";
 
-      auto resultAttrs = ::mlir::impl::getResultAttrs(op, i);
       p.printType(resultTypes[i]);
-      p.printOptionalAttrDict(resultAttrs);
+      p.printOptionalAttrDict(
+          ::mlir::function_like_impl::getResultAttrs(op, i));
     }
     os << ')';
   }
@@ -533,7 +533,7 @@ static void printModuleSignature(OpAsmPrinter &p, Operation *op,
 
 static void printModuleOp(OpAsmPrinter &p, Operation *op,
                           ExternModKind modKind) {
-  using namespace mlir::impl;
+  using namespace mlir::function_like_impl;
 
   FunctionType fnType = getRTLModuleOpType(op);
   auto argTypes = fnType.getInputs();


### PR DESCRIPTION
Picks up the new `TimingManager` that will allow us to time code paths outside the pass manager. Required some fixes since the argument/result attribute storage has been reworked conceptionally from `{arg0: A, arg1: B, ...}` to `{args: [A, B, ...]}`.