### PR TITLE
Attach symbols to instances, wires, and regs.

### DIFF
--- a/docs/RationaleRTL-SV.md
+++ b/docs/RationaleRTL-SV.md
@@ -324,6 +324,43 @@ The SV dialect is primarily designed for human consumption, not machines.  As
 such, transformations should aim to reduce redundancy, eliminate useless
 constructs (e.g. eliminate empty ifdef and if blocks), etc.
 
+## Symbols and Visibility
+
+Verilog has a broad notion of what can be named outside the context of its
+declaration.  This is compounded by the many tools which have additional source
+files which refer to verilog names (e.g. tcl files).  However, we do not what to
+require that every wire, register, instance, localparam, port, etc which can be
+named not be touched by passes.  We want only entities marked as public facing
+to impede transformation.
+
+For this reason, wires, registers, and instances may optionally define a symbol.
+When the symbol is defined, the entity is considered part of the visible
+interface and should be preserved in transformation.  Entities without a symbol
+defined are considered private and may be changed by transformation.
+
+### Implementation constraints
+
+Currently, MLIR restricts symbol resolution to looking in and downward though
+any nested symbol tables when resolving symbols.  This assumption has
+implications for verification, the pass manager, and threading.  Until symbol
+references are more general, SV and RTL dialects do not define symbol tables for
+modules.  Therefore, wires, registers, and interfaces exist in the same
+namespace as modules.  It is encouraged that one prefaces the names to avoid
+conflict with modules.  The symbol names on these entities has no bearing on the
+output verilog, each of these entities has a defined way to assign its name (SSA
+value name for wires and regs, a non-optional string for instances).
+
+As MLIR symbol support improves, it is desired to more to per-module symbol
+tables and to unify names with symbol names.
+
+### Ports
+
+Module ports are remotely namable entities in Verilog, but are non easily named
+with symbols.  A suggested workaround is to attach a wire to a port and use it's
+symbol for remote references.
+
+Instance ports have a similar problem.
+
 ## Future Directions
 
 There are many possible future directions that we anticipate tackling, when and

--- a/docs/RationaleRTL-SV.md
+++ b/docs/RationaleRTL-SV.md
@@ -340,7 +340,7 @@ defined are considered private and may be changed by transformation.
 
 ### Implementation constraints
 
-Currently, MLIR restricts symbol resolution to looking in and downward though
+Currently, MLIR restricts symbol resolution to looking in and downward through
 any nested symbol tables when resolving symbols.  This assumption has
 implications for verification, the pass manager, and threading.  Until symbol
 references are more general, SV and RTL dialects do not define symbol tables for
@@ -350,13 +350,13 @@ conflict with modules.  The symbol names on these entities has no bearing on the
 output verilog, each of these entities has a defined way to assign its name (SSA
 value name for wires and regs, a non-optional string for instances).
 
-As MLIR symbol support improves, it is desired to more to per-module symbol
+As MLIR symbol support improves, it is desired to move to per-module symbol
 tables and to unify names with symbol names.
 
 ### Ports
 
-Module ports are remotely namable entities in Verilog, but are non easily named
-with symbols.  A suggested workaround is to attach a wire to a port and use it's
+Module ports are remotely namable entities in Verilog, but are not easily named
+with symbols.  A suggested workaround is to attach a wire to a port and use its
 symbol for remote references.
 
 Instance ports have a similar problem.

--- a/docs/RationaleRTL-SV.md
+++ b/docs/RationaleRTL-SV.md
@@ -328,7 +328,7 @@ constructs (e.g. eliminate empty ifdef and if blocks), etc.
 
 Verilog has a broad notion of what can be named outside the context of its
 declaration.  This is compounded by the many tools which have additional source
-files which refer to verilog names (e.g. tcl files).  However, we do not what to
+files which refer to verilog names (e.g. tcl files).  However, we do not want to
 require that every wire, register, instance, localparam, port, etc which can be
 named not be touched by passes.  We want only entities marked as public facing
 to impede transformation.

--- a/include/circt/Dialect/RTL/RTLStructure.td
+++ b/include/circt/Dialect/RTL/RTLStructure.td
@@ -278,7 +278,8 @@ def RTLModuleGeneratedOp : RTLOp<"module.generated",
 }
 
 def InstanceOp : RTLOp<"instance",
-                       [DeclareOpInterfaceMethods<OpAsmOpInterface>]> {
+                       [DeclareOpInterfaceMethods<OpAsmOpInterface>,
+                        Symbol]> {
   let summary = "Create an instance of a module";
   let description = [{
     This represents an instance of a module. The inputs and results are 
@@ -289,7 +290,8 @@ def InstanceOp : RTLOp<"instance",
   let arguments = (ins StrAttr:$instanceName,
                        Confined<FlatSymbolRefAttr, [isModuleSymbol]>:$moduleName,
                        Variadic<AnyType>:$inputs,
-                       OptionalAttr<DictionaryAttr>:$parameters);
+                       OptionalAttr<DictionaryAttr>:$parameters,
+                       OptionalAttr<SymbolNameAttr>:$sym_name);
   let results = (outs Variadic<AnyType>);
 
   let extraClassDeclaration = [{
@@ -320,10 +322,19 @@ def InstanceOp : RTLOp<"instance",
     void setName(StringRef name) {
       setNameAttr(StringAttr::get(getContext(), name));
     }
+
+    //===------------------------------------------------------------------===//
+    // SymbolOpInterface Methods
+    //===------------------------------------------------------------------===//
+
+    /// An InstanceOp may optionally define a symbol.
+    bool isOptionalSymbol() { return true; }
+
   }];
 
+  /// sym keyword for optional symbol simplifies parsing
   let assemblyFormat = [{
-    $instanceName $moduleName `(` $inputs `)` attr-dict
+    $instanceName (`sym` $sym_name^)? $moduleName `(` $inputs `)` attr-dict
       `:` functional-type($inputs, results)
   }];
 

--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -27,14 +27,14 @@ def ConnectOp : SVOp<"connect", [InOutTypeConstraint<"src", "dest">]> {
 
 // Note that net declarations like 'wire' should not appear in an always block.
 def WireOp : SVOp<"wire", [DeclareOpInterfaceMethods<OpAsmOpInterface>,
-                           NonProceduralOp]> {
+                           NonProceduralOp, Symbol]> {
   let summary = "Define a new wire";
   let description = [{
     Declare a SystemVerilog Net Declaration of 'wire' type.
      See SV Spec 6.7, pp97.
     }];
 
-  let arguments = (ins StrAttr:$name);
+  let arguments = (ins StrAttr:$name, OptionalAttr<SymbolNameAttr>:$sym_name);
   let results = (outs InOutType:$result);
 
   let skipDefaultBuilders = 1;
@@ -47,40 +47,59 @@ def WireOp : SVOp<"wire", [DeclareOpInterfaceMethods<OpAsmOpInterface>,
     }]>
   ];
 
-  let assemblyFormat = "custom<ImplicitSSAName>(attr-dict) `:` type($result)";
+  let assemblyFormat = [{ (`sym` $sym_name^)? custom<ImplicitSSAName>(attr-dict) 
+                          `:` type($result) }];
   let hasCanonicalizeMethod = true;
 
   let extraClassDeclaration = [{
     Type getElementType() {
       return result().getType().cast<InOutType>().getElementType();
     }
+    
+    //===------------------------------------------------------------------===//
+    // SymbolOpInterface Methods
+    //===------------------------------------------------------------------===//
+
+    /// An WireOp may optionally define a symbol.
+    bool isOptionalSymbol() { return true; }
+
   }];
   let verifier = [{ return ::verifyWireOp(*this); }];
 }
 
-def RegOp : SVOp<"reg", [DeclareOpInterfaceMethods<OpAsmOpInterface>]> {
+def RegOp : SVOp<"reg", [DeclareOpInterfaceMethods<OpAsmOpInterface>,
+                         NonProceduralOp, Symbol]> {
   let summary = "Define a new `reg` in SystemVerilog";
    let description = [{
      Declare a SystemVerilog Variable Declaration of 'reg' type.
      See SV Spec 6.8, pp100.
    }];
-  let arguments = (ins StrAttr:$name);
+  let arguments = (ins StrAttr:$name, OptionalAttr<SymbolNameAttr>:$sym_name);
   let results = (outs InOutType:$result);
 
   let skipDefaultBuilders = 1;
   let builders = [
     OpBuilder<(ins "::mlir::Type":$elementType,
-                      CArg<"StringAttr", "StringAttr()">:$name)>
+                      CArg<"StringAttr", "StringAttr()">:$name,
+                      CArg<"StringAttr", "StringAttr()">:$sym_name)>
   ];
 
   // We handle the name in a custom way, so we use a customer parser/printer.
-  let assemblyFormat = "custom<ImplicitSSAName>(attr-dict) `:` type($result)";
+  let assemblyFormat = [{ (`sym` $sym_name^)? custom<ImplicitSSAName>(attr-dict) 
+                          `:` type($result) }];
   let hasCanonicalizeMethod = true;
 
   let extraClassDeclaration = [{
     Type getElementType() {
       return result().getType().cast<InOutType>().getElementType();
     }
+
+    //===------------------------------------------------------------------===//
+    // SymbolOpInterface Methods
+    //===------------------------------------------------------------------===//
+
+    /// An RegOp may optionally define a symbol.
+    bool isOptionalSymbol() { return true; }
   }];
 }
 

--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -68,7 +68,7 @@ def WireOp : SVOp<"wire", [DeclareOpInterfaceMethods<OpAsmOpInterface>,
 }
 
 def RegOp : SVOp<"reg", [DeclareOpInterfaceMethods<OpAsmOpInterface>,
-                         NonProceduralOp, Symbol]> {
+                         Symbol]> {
   let summary = "Define a new `reg` in SystemVerilog";
    let description = [{
      Declare a SystemVerilog Variable Declaration of 'reg' type.

--- a/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
+++ b/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
@@ -1887,7 +1887,8 @@ LogicalResult FIRRTLLowering::visitDecl(InstanceOp oldInstance) {
 
   // Create the new rtl.instance operation.
   auto newInstance = builder.create<rtl::InstanceOp>(
-      resultTypes, oldInstance.nameAttr(), symbolAttr, operands, parameters, StringAttr());
+      resultTypes, oldInstance.nameAttr(), symbolAttr, operands, parameters,
+      StringAttr());
 
   // Now that we have the new rtl.instance, we need to remap all of the users
   // of the outputs/results to the values returned by the instance.

--- a/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
+++ b/lib/Conversion/FIRRTLToRTL/LowerToRTL.cpp
@@ -1805,7 +1805,7 @@ LogicalResult FIRRTLLowering::visitDecl(MemOp op) {
   // Create the instance to replace the memop
   auto inst = builder.create<rtl::InstanceOp>(
       resultTypes, builder.getStringAttr(memName), memModuleAttr, readOperands,
-      DictionaryAttr());
+      DictionaryAttr(), StringAttr());
 
   // Update all users of the result of read ports
   for (auto &ret : returnHolder)
@@ -1887,7 +1887,7 @@ LogicalResult FIRRTLLowering::visitDecl(InstanceOp oldInstance) {
 
   // Create the new rtl.instance operation.
   auto newInstance = builder.create<rtl::InstanceOp>(
-      resultTypes, oldInstance.nameAttr(), symbolAttr, operands, parameters);
+      resultTypes, oldInstance.nameAttr(), symbolAttr, operands, parameters, StringAttr());
 
   // Now that we have the new rtl.instance, we need to remap all of the users
   // of the outputs/results to the values returned by the instance.

--- a/lib/Dialect/ESI/ESIDialect.cpp
+++ b/lib/Dialect/ESI/ESIDialect.cpp
@@ -307,7 +307,7 @@ circt::esi::buildESIWrapper(OpBuilder &b, Operation *pearl,
 
   auto pearlInst = modBuilder.create<rtl::InstanceOp>(
       modType.getResults(), "pearl", SymbolTable::getSymbolName(pearl),
-      pearlOperands, DictionaryAttr());
+      pearlOperands, DictionaryAttr(), StringAttr());
 
   // Hookup all the backedges.
   for (size_t i = 0, e = pearlInst.getNumResults(); i < e; ++i) {

--- a/lib/Dialect/ESI/ESIPasses.cpp
+++ b/lib/Dialect/ESI/ESIPasses.cpp
@@ -861,7 +861,7 @@ LogicalResult PipelineStageLowering::matchAndRewrite(
                         rewriter.getI1Type()};
   auto stageInst = rewriter.create<InstanceOp>(
       loc, resultTypes, pipeStageName, stageModule.getName(), operands,
-      stageParams.getDictionary(rewriter.getContext()));
+      stageParams.getDictionary(rewriter.getContext()), StringAttr());
   auto stageInstResults = stageInst.getResults();
 
   // Set a_ready (from the unwrap) back edge correctly to its output from stage.

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -94,9 +94,9 @@ static void printImplicitSSAName(OpAsmPrinter &p, Operation *op,
   }
 
   if (namesDisagree)
-    p.printOptionalAttrDict(op->getAttrs());
+    p.printOptionalAttrDict(op->getAttrs(), {"sym_name"});
   else
-    p.printOptionalAttrDict(op->getAttrs(), {"name"});
+    p.printOptionalAttrDict(op->getAttrs(), {"name", "sym_name"});
 }
 
 //===----------------------------------------------------------------------===//
@@ -143,10 +143,12 @@ void ConstantZOp::getAsmResultNames(
 //===----------------------------------------------------------------------===//
 
 void RegOp::build(OpBuilder &odsBuilder, OperationState &odsState,
-                  Type elementType, StringAttr name) {
+                  Type elementType, StringAttr name, StringAttr sym_name) {
   if (!name)
     name = odsBuilder.getStringAttr("");
   odsState.addAttribute("name", name);
+  if (sym_name)
+    odsState.addAttribute("sym_name", sym_name);
   odsState.addTypes(rtl::InOutType::get(elementType));
 }
 

--- a/test/Dialect/RTL/modules.mlir
+++ b/test/Dialect/RTL/modules.mlir
@@ -27,8 +27,8 @@ module {
   rtl.module @A(%d: i1, %e: !rtl.inout<i1>) -> (i1, i1) {
     // Instantiate @B as a RTL module with result-as-output sementics
     %r1, %r2 = rtl.instance "b1" @B(%d) : (i1) -> (i1, i1)
-    // Instantiate @C
-    %f, %g = rtl.instance "c1" @C(%d) : (i1) -> (i1, i1)
+    // Instantiate @C with a public symbol on the instance
+    %f, %g = rtl.instance "c1" sym @E @C(%d) : (i1) -> (i1, i1)
     // Connect the inout port with %f
     sv.connect %e, %f : i1
     // Output values
@@ -36,7 +36,7 @@ module {
   }
   // CHECK-LABEL: rtl.module @A(%d: i1, %e: !rtl.inout<i1>) -> (i1, i1)
   // CHECK-NEXT:  %b1.nameOfPortInSV, %b1.1 = rtl.instance "b1" @B(%d) : (i1) -> (i1, i1)
-  // CHECK-NEXT:  %c1.0, %c1.1 = rtl.instance "c1" @C(%d) : (i1) -> (i1, i1)
+  // CHECK-NEXT:  %c1.0, %c1.1 = rtl.instance "c1" sym @E @C(%d) : (i1) -> (i1, i1)
 
   rtl.module @AnyType1(%a: vector< 3 x i8 >) { }
   // CHECK-LABEL: rtl.module @AnyType1(%a: vector<3xi8>)

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -150,8 +150,12 @@ rtl.module @test1(%arg0: i1, %arg1: i1, %arg8: i8) {
 
   // CHECK-NEXT: %reg23 = sv.reg : !rtl.inout<i23>
   // CHECK-NEXT: %regStruct23 = sv.reg : !rtl.inout<struct<foo: i23>>
+  // CHECK-NEXT: %reg24 = sv.reg sym @regSym1 : !rtl.inout<i23>
+  // CHECK-NEXT: %wire25 = sv.wire sym @wireSym1 : !rtl.inout<i23>
   %reg23       = sv.reg  : !rtl.inout<i23>
   %regStruct23 = sv.reg  : !rtl.inout<struct<foo: i23>>
+  %reg24       = sv.reg sym @regSym1 : !rtl.inout<i23>
+  %wire25      = sv.wire sym @wireSym1 : !rtl.inout<i23>
 
   // CHECK-NEXT: rtl.output
   rtl.output


### PR DESCRIPTION
Wires, instances, and registers define externally visible names in verilog.  Model this with optional symbols for those which are public.

Update the rational doc with notes on symbols and visibiligy.