### PR TITLE
RTL TypeRefType to reference a declared type.

### DIFF
--- a/include/circt/Dialect/RTL/RTLTypes.h
+++ b/include/circt/Dialect/RTL/RTLTypes.h
@@ -14,6 +14,7 @@
 #ifndef CIRCT_DIALECT_RTL_TYPES_H
 #define CIRCT_DIALECT_RTL_TYPES_H
 
+#include "circt/Support/LLVM.h"
 #include "mlir/IR/Types.h"
 
 namespace circt {

--- a/include/circt/Dialect/RTL/RTLTypes.td
+++ b/include/circt/Dialect/RTL/RTLTypes.td
@@ -162,5 +162,6 @@ def TypeRefType : RTLType<"TypeRef"> {
   let extraClassDeclaration = [{
     static TypeRefType get(SymbolRefAttr ref);
     mlir::SymbolRefAttr getRef() const;
+    Optional<mlir::StringRef> getName(Operation *op);
   }];
 }

--- a/include/circt/Dialect/RTL/RTLTypes.td
+++ b/include/circt/Dialect/RTL/RTLTypes.td
@@ -137,3 +137,30 @@ def UnionType : RTLType<"Union"> {
     mlir::Type getFieldType(mlir::StringRef fieldName);
   }];
 }
+
+def TypeRefType : RTLType<"TypeRef"> {
+  let summary = "An symbolic reference to a type declaration";
+  let description = [{
+    A TypeRef is parameterized by a SymbolRefAttr, which points to the
+    declaration of this type. Upon construction, a TypeRef verifies the
+    referent exists and stores the inner type. It also canonicalizes the inner
+    type, resolving any nested TypeRefs. If different, the canonical type is
+    also stored.
+  }];
+
+  let mnemonic = "typeref";
+
+  let parameters = (ins
+    "mlir::SymbolRefAttr":$ref,
+    "mlir::Type":$canonicalType,
+    "mlir::StringAttr":$name
+  );
+
+  let genStorageClass = 0;
+  let genAccessors = 0;
+
+  let extraClassDeclaration = [{
+    static TypeRefType get(SymbolRefAttr ref);
+    mlir::SymbolRefAttr getRef() const;
+  }];
+}

--- a/include/circt/Dialect/RTL/RTLTypes.td
+++ b/include/circt/Dialect/RTL/RTLTypes.td
@@ -142,10 +142,12 @@ def TypeRefType : RTLType<"TypeRef"> {
   let summary = "An symbolic reference to a type declaration";
   let description = [{
     A TypeRef is parameterized by a SymbolRefAttr, which points to the
-    declaration of this type. Upon construction, a TypeRef verifies the
-    referent exists and stores the inner type. It also canonicalizes the inner
-    type, resolving any nested TypeRefs. If different, the canonical type is
-    also stored.
+    declaration of this type. Upon construction, a TypeRef simply stores the
+    symbol reference, leaving the canonical type and name null. Accessors for
+    the canonical type and name are provided, which lazily look up the
+    reference. If it doesn't exist, an error is logged and None is returned. The
+    accessors cache the referred canonical type and name in storage to avoid
+    future lookups.
   }];
 
   let mnemonic = "typeref";

--- a/lib/Dialect/RTL/RTLTypes.cpp
+++ b/lib/Dialect/RTL/RTLTypes.cpp
@@ -420,8 +420,10 @@ Optional<StringRef> TypeRefType::getName(Operation *op) {
   auto typedecl =
       SymbolTable::lookupNearestSymbolFrom<TypedeclOp>(op, getRef());
 
-  if (!typedecl)
+  if (!typedecl) {
+    op->emitError("unable to resolve name for type reference ") << *this;
     return None;
+  }
 
   // Use the verilogName if set, otherwise default to the symbol name.
   StringRef name = typedecl.verilogName().getValueOr(typedecl.sym_name());

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -254,6 +254,16 @@ static bool printPackedTypeImpl(Type type, raw_ostream &os, Operation *op,
         op->emitError("Unexpected unpacked array in packed type ") << arrayType;
         return true;
       })
+      .Case<TypeRefType>([&](TypeRefType typeRef) {
+        auto name = typeRef.getName(op);
+        if (!name.hasValue()) {
+          op->emitError("unable to resolve name for type reference ")
+              << typeRef;
+          return false;
+        }
+        os << name.getValue();
+        return true;
+      })
       .Default([&](Type type) {
         os << "<<invalid type>>";
         op->emitError("value has an unsupported verilog type ") << type;

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -1531,7 +1531,7 @@ LogicalResult TypeScopeEmitter::visitTypeScope(TypedeclOp op) {
   indent() << "typedef ";
   printPackedType(stripUnpackedTypes(op.type()), os, op, false);
   printUnpackedTypePostfix(op.type(), os);
-  os << ' ' << op.sym_name();
+  os << ' ' << op.verilogName().getValueOr(op.sym_name());
   os << ";\n";
   return success();
 }

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -256,11 +256,8 @@ static bool printPackedTypeImpl(Type type, raw_ostream &os, Operation *op,
       })
       .Case<TypeRefType>([&](TypeRefType typeRef) {
         auto name = typeRef.getName(op);
-        if (!name.hasValue()) {
-          op->emitError("unable to resolve name for type reference ")
-              << typeRef;
+        if (!name.hasValue())
           return false;
-        }
         os << name.getValue();
         return true;
       })

--- a/test/Dialect/RTL/types.mlir
+++ b/test/Dialect/RTL/types.mlir
@@ -44,7 +44,9 @@ module {
   }
 
   // CHECK-LABEL: typeref
-  func @typeref(%arg0: !rtl.typeref<@__rtl_types::@foo>) {
+  func @typeref(
+    // CHECK: %arg0: !rtl.typeref<@__rtl_typedecls::@foo>
+    %arg0: !rtl.typeref<@__rtl_typedecls::@foo>) {
     return
   }
 }

--- a/test/Dialect/RTL/types.mlir
+++ b/test/Dialect/RTL/types.mlir
@@ -42,4 +42,9 @@ module {
     %arg4: !rtl.inout<uarray<2xarray<42xi8>>>) {
     return
   }
+
+  // CHECK-LABEL: typeref
+  func @typeref(%arg0: !rtl.typeref<@__rtl_types::@foo>) {
+    return
+  }
 }

--- a/test/ExportVerilog/rtl-typedecls-errors.mlir
+++ b/test/ExportVerilog/rtl-typedecls-errors.mlir
@@ -1,0 +1,6 @@
+// RUN: circt-translate %s -export-verilog -verify-diagnostics
+
+// expected-error @+1 {{unable to resolve name for type reference}}
+rtl.module @testTypeRef(
+  %arg0: !rtl.typeref<@__rtl_typedecls::@foo>) {
+}

--- a/test/ExportVerilog/rtl-typedecls.mlir
+++ b/test/ExportVerilog/rtl-typedecls.mlir
@@ -1,13 +1,16 @@
 // RUN: circt-translate %s -export-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
 
 rtl.type_scope @__rtl_typedecls {
-  // CHECK: typedef logic foo;
+  // CHECK-LABEL: typedef logic foo;
   rtl.typedecl @foo : i1
-  // CHECK: typedef struct packed {logic a; logic b; } bar;
+  // CHECK-LABEL: typedef struct packed {logic a; logic b; } bar;
   rtl.typedecl @bar : !rtl.struct<a: i1, b: i1>
-  // CHECK: typedef logic [7:0][0:15] baz;
+  // CHECK-LABEL: typedef logic [7:0][0:15] baz;
   rtl.typedecl @baz : !rtl.uarray<16xi8>
 }
 
-rtl.module @testTypeRef(%arg0: !rtl.typeref<@__rtl_typedecls::@foo>) {
+// CHECK-LABEL: module testTypeRef
+rtl.module @testTypeRef(
+  // CHECK: input foo arg0
+  %arg0: !rtl.typeref<@__rtl_typedecls::@foo>) {
 }

--- a/test/ExportVerilog/rtl-typedecls.mlir
+++ b/test/ExportVerilog/rtl-typedecls.mlir
@@ -8,3 +8,6 @@ rtl.type_scope @__rtl_typedecls {
   // CHECK: typedef logic [7:0][0:15] baz;
   rtl.typedecl @baz : !rtl.uarray<16xi8>
 }
+
+rtl.module @testTypeRef(%arg0: !rtl.typeref<@__rtl_typedecls::@foo>) {
+}

--- a/test/ExportVerilog/rtl-typedecls.mlir
+++ b/test/ExportVerilog/rtl-typedecls.mlir
@@ -7,10 +7,14 @@ rtl.type_scope @__rtl_typedecls {
   rtl.typedecl @bar : !rtl.struct<a: i1, b: i1>
   // CHECK-LABEL: typedef logic [7:0][0:15] baz;
   rtl.typedecl @baz : !rtl.uarray<16xi8>
+  // CHECK-LABEL: typedef logic [31:0] customName;
+  rtl.typedecl @qux, "customName" : i32
 }
 
 // CHECK-LABEL: module testTypeRef
 rtl.module @testTypeRef(
-  // CHECK: input foo arg0
-  %arg0: !rtl.typeref<@__rtl_typedecls::@foo>) {
+  // CHECK: input foo        arg0
+  %arg0: !rtl.typeref<@__rtl_typedecls::@foo>,
+  // CHECK: input customName arg1
+  %arg1: !rtl.typeref<@__rtl_typedecls::@qux>) {
 }


### PR DESCRIPTION
This adds support for symbolically referencing a type declared with an RTL type declaration.

Ideally, we would verify the reference exists upon construction, and cache the name and canonical type in the type's storage. However, the current API for parsing and verifying types exists in a vacuum--there doesn't appear to be any way to lookup a symbolic reference. I.e., there is no hook to get a pointer to the outer ModuleOp, or something like that. During parsing, the reference may not have even been parsed yet.

I'm not sure if there is a better way to do this, but what I've implemented here resolves the symbolic reference to look up the name/canonical type lazily. The printer/parser just work with the symbolic name, and initialize the storage with no name or canonical type set. Then, there is a helper method (for example `getName`), which provides access to the underlying name. It first checks for the name in type storage, and returns it if present. Otherwise, it uses the Operation pointer to perform a symbol lookup, and either caches the result and returns it, or fails with an error. I haven't implemented it yet, but getting the underlying canonical type would work the same way.

This is why I opened #1050, you can see where I would use the Operation on ExportVerilog L258.

It makes me uneasy that it will be possible to create invalid types, and we won't get an error until they are actually used. But given how type parsing and verification works, I'm not sure if there is a better way. Thoughts?