### PR TITLE
[CI] Compile LLVM in debug mode

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -47,7 +47,7 @@ jobs:
       # Build LLVM if we didn't hit in the cache.
       - name: Rebuild and Install LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
-        run: utils/build-llvm.sh
+        run: utils/build-llvm.sh build install debug
 
 
     # Installing the results into the cache is an action which is automatically
@@ -138,7 +138,7 @@ jobs:
       # the time we get here.
       - name: Rebuild and Install LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
-        run: utils/build-llvm.sh
+        run: utils/build-llvm.sh build install debug
 
       # --------
       # Build and test CIRCT in both debug and release mode.

--- a/lib/Bindings/Python/circt/__init__.py
+++ b/lib/Bindings/Python/circt/__init__.py
@@ -4,3 +4,4 @@
 
 # Simply a wrapper around the extension module of the same name.
 from _circt import *
+from .design_entry import *


### PR DESCRIPTION
```
Failed Tests (25):
  CIRCT :: Conversion/FIRRTLToRTL/errors.mlir
  CIRCT :: Conversion/FIRRTLToRTL/lower-to-rtl-errors.mlir
  CIRCT :: Conversion/FIRRTLToRTL/lower-to-rtl-module.mlir
  CIRCT :: Conversion/FIRRTLToRTL/lower-to-rtl.mlir
  CIRCT :: Conversion/FIRRTLToRTL/zero-width.mlir
  CIRCT :: Dialect/FIRRTL/blackbox-memory.mlir
  CIRCT :: Dialect/FIRRTL/expand-whens-errors.mlir
  CIRCT :: Dialect/FIRRTL/expand-whens.mlir
  CIRCT :: Dialect/FIRRTL/inliner.mlir
  CIRCT :: Dialect/FIRRTL/lower-types.mlir
  CIRCT :: Dialect/LLHD/Simulator/sim_arbitrary_signal_size.mlir
  CIRCT :: Dialect/LLHD/Simulator/sim_array_boundary_check.mlir
  CIRCT :: Dialect/LLHD/Simulator/sim_bit_precision_drives.mlir
  CIRCT :: Dialect/LLHD/Simulator/sim_formats.mlir
  CIRCT :: Dialect/LLHD/Simulator/sim_process.mlir
  CIRCT :: Dialect/LLHD/Simulator/sim_reg.mlir
  CIRCT :: Dialect/LLHD/Simulator/sim_shifts.mlir
  CIRCT :: Dialect/LLHD/Simulator/sim_simple.mlir
  CIRCT :: Dialect/LLHD/Simulator/sim_wait.mlir
  CIRCT :: Dialect/LLHD/Transforms/earlyCodeMotion.mlir
  CIRCT :: Dialect/LLHD/Transforms/memoryToBlockArgument.mlir
  CIRCT :: Dialect/SV/rtl-cleanup.mlir
  CIRCT :: firtool/firtool.fir
  CIRCT :: firtool/firtool.mlir
  CIRCT :: firtool/split-verilog.mlir


Testing Time: 17.41s
  Unsupported:   4
  Passed     : 191
  Failed     :  25
```