### PR TITLE
[Python] Use classmethod instead of staticmethod for Type getters.

### DIFF
--- a/integration_test/Bindings/Python/dialects/rtl.py
+++ b/integration_test/Bindings/Python/dialects/rtl.py
@@ -17,6 +17,8 @@ with Context() as ctx, Location.unknown():
   # CHECK: !hw.array<5xi32>
   array_i32 = hw.ArrayType.get(i32, 5)
   print(array_i32)
+  # CHECK: i32
+  print(array_i32.element_type)
 
   # CHECK: !hw.struct<foo: i32, bar: !hw.array<5xi32>>
   struct = hw.StructType.get([("foo", i32), ("bar", array_i32)])

--- a/lib/Bindings/Python/ESIModule.cpp
+++ b/lib/Bindings/Python/ESIModule.cpp
@@ -120,10 +120,10 @@ void circt::python::populateDialectESISubmodule(py::module &m) {
            "Print the cosim RPC schema");
 
   mlir_type_subclass(m, "ChannelType", circtESITypeIsAChannelType)
-      .def_staticmethod("get",
-                        [](MlirType inner) {
-                          return py::cast(circtESIChannelTypeGet(inner));
-                        })
+      .def_classmethod("get",
+                       [](py::object cls, MlirType inner) {
+                         return cls(circtESIChannelTypeGet(inner));
+                       })
       .def_property_readonly(
           "inner", [](MlirType self) { return circtESIChannelGetInner(self); });
 }

--- a/lib/Bindings/Python/HWModule.cpp
+++ b/lib/Bindings/Python/HWModule.cpp
@@ -29,12 +29,16 @@ void circt::python::populateDialectHWSubmodule(py::module &m) {
   m.doc() = "HW dialect Python native extension";
 
   mlir_type_subclass(m, "ArrayType", hwTypeIsAArrayType)
-      .def_staticmethod("get", [](MlirType elementType, intptr_t size) {
-        return py::cast(hwArrayTypeGet(elementType, size));
+      .def_classmethod("get",
+                       [](py::object cls, MlirType elementType, intptr_t size) {
+                         return cls(hwArrayTypeGet(elementType, size));
+                       })
+      .def_property_readonly("element_type", [](MlirType self) {
+        return hwArrayTypeGetElementType(self);
       });
 
   mlir_type_subclass(m, "StructType", hwTypeIsAStructType)
-      .def_staticmethod("get", [](py::list pyFieldInfos) {
+      .def_classmethod("get", [](py::object cls, py::list pyFieldInfos) {
         llvm::SmallVector<HWStructFieldInfo> mlirFieldInfos;
         MlirContext ctx;
 
@@ -50,7 +54,7 @@ void circt::python::populateDialectHWSubmodule(py::module &m) {
               mlirStringRefCreate(names[i].data(), names[i].size()),
               mlirTypeAttrGet(type)});
         }
-        return py::cast(
+        return cls(
             hwStructTypeGet(ctx, mlirFieldInfos.size(), mlirFieldInfos.data()));
       });
 }


### PR DESCRIPTION
This allows us to directly return a Python object of the class being
instantiated, rather than an object of the base _mlir.ir.Type
class. This allows the readonly properties to work correctly.