### PR TITLE
[LLHD] Don't erase ops in the folder for Connect and Drv

### DIFF
--- a/include/circt/Dialect/LLHD/IR/SignalOps.td
+++ b/include/circt/Dialect/LLHD/IR/SignalOps.td
@@ -131,6 +131,7 @@ def LLHD_DrvOp : LLHD_Op<"drv", [
   }];
 
   let hasFolder = 1;
+  let hasCanonicalizeMethod = 1;
 }
 
 def REG_MODE_LOW  : I64EnumAttrCase<"low", 0>;

--- a/include/circt/Dialect/LLHD/IR/StructureOps.td
+++ b/include/circt/Dialect/LLHD/IR/StructureOps.td
@@ -218,7 +218,7 @@ def LLHD_ConnectOp : LLHD_Op<"con", [
     operands attr-dict `:` type($lhs)
   }];
 
-  let hasFolder = 1;
+  let hasCanonicalizeMethod = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/LLHD/IR/LLHDOps.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDOps.cpp
@@ -532,13 +532,21 @@ LogicalResult llhd::DrvOp::fold(ArrayRef<Attribute> operands,
   if (!enable())
     return failure();
 
-  if (matchPattern(enable(), m_Zero())) {
-    erase();
+  if (matchPattern(enable(), m_One())) {
+    enableMutable().clear();
     return success();
   }
 
-  if (matchPattern(enable(), m_One())) {
-    enableMutable().clear();
+  return failure();
+}
+
+LogicalResult llhd::DrvOp::canonicalize(llhd::DrvOp op,
+                                        PatternRewriter &rewriter) {
+  if (!op.enable())
+    return failure();
+
+  if (matchPattern(op.enable(), m_Zero())) {
+    rewriter.eraseOp(op);
     return success();
   }
 
@@ -971,14 +979,11 @@ FunctionType llhd::InstOp::getCalleeType() {
 // ConnectOp
 //===----------------------------------------------------------------------===//
 
-LogicalResult llhd::ConnectOp::fold(ArrayRef<Attribute> operands,
-                                    SmallVectorImpl<OpFoldResult> &results) {
-  if (lhs() == rhs()) {
-    erase();
-    return success();
-  }
-
-  return failure();
+LogicalResult llhd::ConnectOp::canonicalize(llhd::ConnectOp op,
+                                            PatternRewriter &rewriter) {
+  if (op.lhs() == op.rhs())
+    rewriter.eraseOp(op);
+  return success();
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
The folder does not allow an op to be explicitly erased, which was
causing the folder to use-after-free.  There doesn't seem to be a good
way to implement the folding of an op with no results, so this was
re-implemented as a canonicalization.