### PR TITLE
[LLHD] parseEntityOp: check if the region was parsed correctly

### DIFF
--- a/lib/Dialect/LLHD/IR/LLHDOps.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDOps.cpp
@@ -623,7 +623,9 @@ static ParseResult parseEntityOp(OpAsmParser &parser, OperationState &result) {
                       TypeAttr::get(type));
 
   auto *body = result.addRegion();
-  parser.parseRegion(*body, args, argTypes);
+  if(parser.parseRegion(*body, args, argTypes))
+    return failure();
+
   llhd::EntityOp::ensureTerminator(*body, parser.getBuilder(), result.location);
   return success();
 }

--- a/test/Dialect/LLHD/IR/connect-errors.mlir
+++ b/test/Dialect/LLHD/IR/connect-errors.mlir
@@ -4,7 +4,6 @@
 llhd.entity @connect_different_types(%in: !llhd.sig<i8>) -> (%out: !llhd.sig<i32>) {
   // expected-error @+1 {{use of value '%out' expects different type}}
   llhd.con %in, %out : !llhd.sig<i8>
-  // expected-error @+1 {{expected operation}}
 }
 
 // -----


### PR DESCRIPTION
When the op is not well-formed, we should not return success.  This
fixes a bug when the region is not added to the op.