### PR TITLE
[HW] Define TypeAliasType to reference a declared type symbolically.

### DIFF
--- a/include/circt/Dialect/HW/HWTypes.h
+++ b/include/circt/Dialect/HW/HWTypes.h
@@ -14,6 +14,7 @@
 #ifndef CIRCT_DIALECT_HW_TYPES_H
 #define CIRCT_DIALECT_HW_TYPES_H
 
+#include "circt/Support/LLVM.h"
 #include "mlir/IR/Types.h"
 
 namespace circt {

--- a/include/circt/Dialect/HW/HWTypes.td
+++ b/include/circt/Dialect/HW/HWTypes.td
@@ -142,14 +142,14 @@ def TypeAliasType : HWType<"TypeAlias"> {
   let summary = "An symbolic reference to a type declaration";
   let description = [{
     A TypeAlias is parameterized by a SymbolRefAttr, which points to a
-    TypedeclOp. The root referece should refer to a TypeScope within the same
+    TypedeclOp. The root reference should refer to a TypeScope within the same
     outer ModuleOp, and the leaf reference should refer to a type within that
     TypeScope. A TypeAlias is further parameterized by the inner type, which is
     needed to be known at the time the type is parsed.
 
     Upon construction, a TypeAlias stores the symbol reference and type, and
     canonicalizes the type to resolve any nested type aliases. The canonical
-    type is also stored to avoid recomputing it when needed.
+    type is also cached to avoid recomputing it when needed.
   }];
 
   let mnemonic = "typealias";
@@ -160,7 +160,8 @@ def TypeAliasType : HWType<"TypeAlias"> {
     "mlir::Type":$canonicalType
   );
 
-  let extraClassDeclaration = [{
-    static TypeAliasType get(SymbolRefAttr ref, Type type);
-  }];
+  let builders = [
+    TypeBuilderWithInferredContext<(ins
+      "mlir::SymbolRefAttr":$ref, "mlir::Type":$innerType)>
+  ];
 }

--- a/include/circt/Dialect/HW/HWTypes.td
+++ b/include/circt/Dialect/HW/HWTypes.td
@@ -137,3 +137,30 @@ def UnionType : HWType<"Union"> {
     mlir::Type getFieldType(mlir::StringRef fieldName);
   }];
 }
+
+def TypeAliasType : HWType<"TypeAlias"> {
+  let summary = "An symbolic reference to a type declaration";
+  let description = [{
+    A TypeAlias is parameterized by a SymbolRefAttr, which points to a
+    TypedeclOp. The root referece should refer to a TypeScope within the same
+    outer ModuleOp, and the leaf reference should refer to a type within that
+    TypeScope. A TypeAlias is further parameterized by the inner type, which is
+    needed to be known at the time the type is parsed.
+
+    Upon construction, a TypeAlias stores the symbol reference and type, and
+    canonicalizes the type to resolve any nested type aliases. The canonical
+    type is also stored to avoid recomputing it when needed.
+  }];
+
+  let mnemonic = "typealias";
+
+  let parameters = (ins
+    "mlir::SymbolRefAttr":$ref,
+    "mlir::Type":$innerType,
+    "mlir::Type":$canonicalType
+  );
+
+  let extraClassDeclaration = [{
+    static TypeAliasType get(SymbolRefAttr ref, Type type);
+  }];
+}

--- a/lib/Dialect/Comb/CombOps.cpp
+++ b/lib/Dialect/Comb/CombOps.cpp
@@ -21,6 +21,9 @@ using namespace comb;
 /// Return true if the specified type is a signless non-zero width integer type,
 /// the only type which the comb ops operate.
 static bool isCombIntegerType(mlir::Type type) {
+  if (auto typeAlias = type.dyn_cast<hw::TypeAliasType>())
+    type = typeAlias.getCanonicalType();
+
   auto intType = type.dyn_cast<IntegerType>();
   if (!intType || !intType.isSignless())
     return false;

--- a/lib/Dialect/Comb/CombOps.cpp
+++ b/lib/Dialect/Comb/CombOps.cpp
@@ -21,10 +21,13 @@ using namespace comb;
 /// Return true if the specified type is a signless non-zero width integer type,
 /// the only type which the comb ops operate.
 static bool isCombIntegerType(mlir::Type type) {
+  Type canonicalType;
   if (auto typeAlias = type.dyn_cast<hw::TypeAliasType>())
-    type = typeAlias.getCanonicalType();
+    canonicalType = typeAlias.getCanonicalType();
+  else
+    canonicalType = type;
 
-  auto intType = type.dyn_cast<IntegerType>();
+  auto intType = canonicalType.dyn_cast<IntegerType>();
   if (!intType || !intType.isSignless())
     return false;
 

--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -40,10 +40,13 @@ FieldInfo FieldInfo::allocateInto(mlir::TypeStorageAllocator &alloc) const {
 /// Return true if the specified type is a value HW Integer type.  This checks
 /// that it is a signless standard dialect type, that it isn't zero bits.
 bool circt::hw::isHWIntegerType(mlir::Type type) {
+  Type canonicalType;
   if (auto typeAlias = type.dyn_cast<TypeAliasType>())
-    type = typeAlias.getCanonicalType();
+    canonicalType = typeAlias.getCanonicalType();
+  else
+    canonicalType = type;
 
-  auto intType = type.dyn_cast<IntegerType>();
+  auto intType = canonicalType.dyn_cast<IntegerType>();
   if (!intType || !intType.isSignless())
     return false;
 

--- a/test/Dialect/HW/typedecls.mlir
+++ b/test/Dialect/HW/typedecls.mlir
@@ -8,12 +8,16 @@ hw.type_scope @__hw_typedecls {
   hw.typedecl @bar : !hw.struct<a: i1, b: i1>
   // CHECK: hw.typedecl @baz, "MY_NAMESPACE_baz" : i8
   hw.typedecl @baz, "MY_NAMESPACE_baz" : i8
+  // CHECK: hw.typedecl @nested : !hw.struct<a: !hw.typealias<@__hw_typedecls::@foo, i1>, b: i1>
+  hw.typedecl @nested : !hw.struct<a: !hw.typealias<@__hw_typedecls::@foo, i1>, b: i1>
 }
 
 // CHECK-LABEL: hw.module.extern @testTypeAlias
 hw.module.extern @testTypeAlias(
-  // CHECK: hw.typealias<@__hw_typedecls::@foo, i1>
-  %arg0: !hw.typealias<@__hw_typedecls::@foo, i1>
+  // CHECK: !hw.typealias<@__hw_typedecls::@foo, i1>
+  %arg0: !hw.typealias<@__hw_typedecls::@foo, i1>,
+  // CHECK: !hw.typealias<@__hw_typedecls::@nested, !hw.struct<a: !hw.typealias<@__hw_typedecls::@foo, i1>, b: i1>>
+  %arg1: !hw.typealias<@__hw_typedecls::@nested, !hw.struct<a: !hw.typealias<@__hw_typedecls::@foo, i1>, b: i1>>
 )
 
 // CHECK-LABEL: hw.module @testTypeAliasComb

--- a/test/Dialect/HW/typedecls.mlir
+++ b/test/Dialect/HW/typedecls.mlir
@@ -9,3 +9,18 @@ hw.type_scope @__hw_typedecls {
   // CHECK: hw.typedecl @baz, "MY_NAMESPACE_baz" : i8
   hw.typedecl @baz, "MY_NAMESPACE_baz" : i8
 }
+
+// CHECK-LABEL: hw.module.extern @testTypeAlias
+hw.module.extern @testTypeAlias(
+  // CHECK: hw.typealias<@__hw_typedecls::@foo, i1>
+  %arg0: !hw.typealias<@__hw_typedecls::@foo, i1>
+)
+
+// CHECK-LABEL: hw.module @testTypeAliasComb
+hw.module @testTypeAliasComb(
+  %arg0: !hw.typealias<@__hw_typedecls::@foo, i1>,
+  %arg1: !hw.typealias<@__hw_typedecls::@foo, i1>) -> (!hw.typealias<@__hw_typedecls::@foo, i1>) {
+  // CHECK: comb.add %arg0, %arg1 : !hw.typealias<@__hw_typedecls::@foo, i1>
+  %0 = comb.add %arg0, %arg1 : !hw.typealias<@__hw_typedecls::@foo, i1>
+  hw.output %0 : !hw.typealias<@__hw_typedecls::@foo, i1>
+}


### PR DESCRIPTION
The type is created and uniqued based on the symbol reference, inner
type, and canonical type. HW and Comb dialect types are taught to use
the canonical type in their predicates.