### PR TITLE
[ESI] Ditch `esi.struct` type

### DIFF
--- a/include/circt/Dialect/ESI/ESITypes.td
+++ b/include/circt/Dialect/ESI/ESITypes.td
@@ -13,17 +13,3 @@
 //===----------------------------------------------------------------------===//
 
 class ESI_Type<string name> : TypeDef<ESI_Dialect, name> { }
-
-def Struct : ESI_Type<"Struct"> {
-  let summary = "A HW struct with a name";
-  let mnemonic = "struct";
-  let parameters = (ins
-    StringRefParameter<"struct name">:$name,
-    "::circt::hw::StructType":$inner);
-
-  let extraClassDeclaration = [{
-    ArrayRef<::circt::hw::StructType::FieldInfo> getElements() const {
-      return getInner().getElements();
-    }
-  }];
-}

--- a/lib/Dialect/ESI/ESITypes.cpp
+++ b/lib/Dialect/ESI/ESITypes.cpp
@@ -34,40 +34,6 @@ void ChannelPort::print(DialectAsmPrinter &p) const {
   p << ">";
 }
 
-Type StructType::parse(MLIRContext *ctxt, DialectAsmParser &p) {
-  if (p.parseLess())
-    return Type();
-  StringRef structName;
-  if (p.parseKeyword(&structName) || p.parseComma())
-    return Type();
-
-  llvm::SmallVector<hw::StructType::FieldInfo, 4> fields;
-  StringRef fieldName;
-  while (mlir::succeeded(p.parseOptionalKeyword(&fieldName))) {
-    Type type;
-    if (p.parseColon() || p.parseType(type))
-      return Type();
-    fields.push_back(hw::StructType::FieldInfo{fieldName, type});
-    if (p.parseOptionalComma())
-      break;
-  }
-  if (p.parseGreater())
-    return Type();
-
-  auto inner = hw::StructType::get(ctxt, fields);
-  return get(ctxt, structName, inner);
-}
-
-void StructType::print(DialectAsmPrinter &p) const {
-  p << "struct<";
-  p << getName() << ", ";
-  llvm::interleaveComma(getInner().getElements(), p,
-                        [&](const hw::StructType::FieldInfo &field) {
-                          p << field.name << ": " << field.type;
-                        });
-  p << ">";
-}
-
 #define GET_TYPEDEF_CLASSES
 #include "circt/Dialect/ESI/ESITypes.cpp.inc"
 

--- a/test/Dialect/ESI/connectivity.mlir
+++ b/test/Dialect/ESI/connectivity.mlir
@@ -11,7 +11,7 @@ hw.module @Reciever(%a: !esi.channel<i1>) {
   // Recieve bits.
   %data, %valid = esi.unwrap.vr %a, %rdy : i1
 }
-!FooStruct = type !esi.struct<FooStruct, a: si4, b: !hw.array<3 x ui4>>
+!FooStruct = type !hw.struct<a: si4, b: !hw.array<3 x ui4>>
 hw.module @StructRcvr(%a: !esi.channel<!FooStruct>) {
   %rdy = constant 1 : i1
   // Recieve bits.
@@ -22,7 +22,7 @@ hw.module @StructRcvr(%a: !esi.channel<!FooStruct>) {
 // CHECK:        %chanOutput, %ready = esi.wrap.vr %false, %false : i1
 // CHECK-LABEL: hw.module @Reciever(%a: !esi.channel<i1>) {
 // CHECK:        %rawOutput, %valid = esi.unwrap.vr %a, %true : i1
-// CHECK-LABEL: hw.module @StructRcvr(%a: !esi.channel<!esi.struct<FooStruct, a: si4, b: !hw.array<3xui4>>>)
+// CHECK-LABEL: hw.module @StructRcvr(%a: !esi.channel<!hw.struct<a: si4, b: !hw.array<3xui4>>>)
 
 hw.module @test(%clk: i1, %rstn: i1) {
   %esiChan = hw.instance "sender" @Sender () : () -> (!esi.channel<i1>)


### PR DESCRIPTION
Will be replaced with whatever goes in the `hw` dialect.