### PR TITLE
[Py] Prototype @module annotation for design entry

### DIFF
--- a/integration_test/Bindings/Python/DesignEntry/polynomial.py
+++ b/integration_test/Bindings/Python/DesignEntry/polynomial.py
@@ -1,0 +1,77 @@
+# RUN: %PYTHON% %s | FileCheck %s
+
+import mlir
+import circt
+
+from circt import Input, Output
+from circt import esi
+from circt.esi import types
+from circt.dialects import comb, hw
+
+
+@circt.module
+class PolynomialCompute:
+  """Module to compute ax^3 + bx^2 + cx + d for design-time coefficients"""
+
+  def __init__(self, coefficients: list[int]):
+    """coefficients is in 'd' -> 'a' order."""
+    self.__coefficients = coefficients
+
+    # Evaluate polynomial for 'x'.
+    self.x = Input(types.i32)
+    # Full result.
+    self.y = Output(types.i32)
+
+  def construct(self, x: mlir.ir.Value):
+    """Implement this module for input 'x'."""
+
+    taps: list[mlir.ir.Value] = list()
+    runningPower: list[mlir.ir.Value] = list()
+    for power, coeff in enumerate(self.__coefficients):
+      coeffVal = hw.ConstantOp(types.i32,
+                               mlir.ir.IntegerAttr.get(types.i32, coeff))
+      if power == 0:
+        newPartialSum = coeffVal.result
+      else:
+        partialSum = taps[-1]
+        if power == 1:
+          currPow = x
+        else:
+          x_power = [x for i in range(power - 1)]
+          currPow = comb.MulOp(types.i32, x_power + [runningPower[-1]]).result
+        newPartialSum = comb.AddOp(
+            types.i32,
+            [
+                partialSum,
+                comb.MulOp(types.i32, [coeffVal.result, currPow]).result
+            ]).result
+
+        runningPower.append(currPow)
+
+      taps.append(newPartialSum)
+
+    # Final output
+    self.y.set(taps[-1])
+
+
+class ExampleSystem(esi.System):
+  def top_module(self):
+    return PolynomialCompute([62, 42, 6])
+
+
+exsys = ExampleSystem()
+exsys.print()
+# CHECK:  hw.module @PolynomialCompute(%x: i32) -> (%y: i32) {
+# CHECK:    [[REG0:%.+]] = comb.mul %{{.+}}, %x : i32
+# CHECK:    %1 = comb.add %c62_i32, [[REG0]] : i32
+# CHECK:    hw.output %{{.+}} : i32
+
+print("\n\n=== Verilog ===")
+# CHECK-LABEL: === Verilog ===
+
+exsys.print_verilog()
+
+# CHECK:  module PolynomialCompute(
+# CHECK:    input  [31:0] x,
+# CHECK:    output [31:0] y);
+# CHECK:    assign y = 32'h3E + 32'h2A * x + 32'h6 * x * x;

--- a/integration_test/Bindings/Python/DesignEntry/polynomial.py
+++ b/integration_test/Bindings/Python/DesignEntry/polynomial.py
@@ -8,6 +8,7 @@ from circt import esi
 from circt.esi import types
 from circt.dialects import comb, hw
 
+import sys
 
 @circt.module
 class PolynomialCompute:
@@ -54,24 +55,25 @@ class PolynomialCompute:
     self.y.set(taps[-1])
 
 
-class ExampleSystem(esi.System):
-  def top_module(self):
-    return PolynomialCompute([62, 42, 6])
+with mlir.ir.Context() as ctxt, mlir.ir.Location.unknown():
+  circt.register_dialects(ctxt)
+  mod = mlir.ir.Module.create()
+  with mlir.ir.InsertionPoint(mod.body):
+    PolynomialCompute([62, 42, 6])
 
+  mod.operation.print()
+  # CHECK:  hw.module @PolynomialCompute(%x: i32) -> (%y: i32) {
+  # CHECK:    [[REG0:%.+]] = comb.mul %{{.+}}, %x : i32
+  # CHECK:    %1 = comb.add %c62_i32, [[REG0]] : i32
+  # CHECK:    hw.output %{{.+}} : i32
 
-exsys = ExampleSystem()
-exsys.print()
-# CHECK:  hw.module @PolynomialCompute(%x: i32) -> (%y: i32) {
-# CHECK:    [[REG0:%.+]] = comb.mul %{{.+}}, %x : i32
-# CHECK:    %1 = comb.add %c62_i32, [[REG0]] : i32
-# CHECK:    hw.output %{{.+}} : i32
+  print("\n\n=== Verilog ===")
+  # CHECK-LABEL: === Verilog ===
 
-print("\n\n=== Verilog ===")
-# CHECK-LABEL: === Verilog ===
-
-exsys.print_verilog()
-
-# CHECK:  module PolynomialCompute(
-# CHECK:    input  [31:0] x,
-# CHECK:    output [31:0] y);
-# CHECK:    assign y = 32'h3E + 32'h2A * x + 32'h6 * x * x;
+  pm = mlir.passmanager.PassManager.parse("hw-legalize-names,hw.module(hw-cleanup)")
+  pm.run(mod)
+  circt.export_verilog(mod, sys.stdout)
+  # CHECK:  module PolynomialCompute(
+  # CHECK:    input  [31:0] x,
+  # CHECK:    output [31:0] y);
+  # CHECK:    assign y = 32'h3E + 32'h2A * x + 32'h6 * x * x;

--- a/lib/Bindings/Python/circt/__init__.py
+++ b/lib/Bindings/Python/circt/__init__.py
@@ -4,3 +4,4 @@
 
 # Simply a wrapper around the extension module of the same name.
 from _circt import *
+from .design_entry import *

--- a/lib/Bindings/Python/circt/design_entry.py
+++ b/lib/Bindings/Python/circt/design_entry.py
@@ -1,0 +1,78 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from circt.dialects import hw
+
+import mlir.ir
+
+
+class Output:
+  __slots__ = [
+      "type",
+      "value"
+  ]
+
+  def __init__(self, type: mlir.ir.Type):
+    self.type = type
+    self.value = None
+
+  def set(self, val):
+    if type(val) is mlir.ir.OpResult:
+      self.value = val
+    else:
+      self.value = val.result
+
+
+class Input:
+  __slots__ = [
+      "type"
+  ]
+
+  def __init__(self, type: mlir.ir.Type):
+    self.type = type
+
+
+class UnconnectedOutputError(Exception):
+  def __init__(self, module: str, port_name: str):
+    super().__init__(f"Port {port_name} unconnected in design module {module}.")
+
+
+def module(cls):
+  class Module(cls):
+    def __init__(self, *args, **kwargs):
+      super().__init__(*args, **kwargs)
+
+      input_ports = []
+      output_ports = []
+      for attr_name in dir(self):
+        attr = self.__getattribute__(attr_name)
+        if type(attr) is Input:
+          input_ports.append((attr_name, attr))
+        if type(attr) is Output:
+          output_ports.append((attr_name, attr))
+
+      def body_build(mod):
+        inputs = dict()
+        for index, (name, _) in enumerate(input_ports):
+          inputs[name] = mod.entry_block.arguments[index]
+
+        self.construct(**inputs)
+
+        outputs = []
+        for (name, output) in output_ports:
+          if output.value is None:
+            raise UnconnectedOutputError(cls.__name__, name)
+          outputs.append(output.value)
+        hw.OutputOp(outputs)
+
+      self.module = hw.HWModuleOp(
+          name=cls.__name__,
+          input_ports=[(name, port.type) for (name, port) in input_ports],
+          output_ports=[(name, port.type) for (name, port) in output_ports],
+          body_builder=body_build)
+
+    def __setattr__(self, name: str, value) -> None:
+        return super().__setattr__(name, value)
+
+  return Module

--- a/lib/Bindings/Python/circt/esi.py
+++ b/lib/Bindings/Python/circt/esi.py
@@ -33,13 +33,16 @@ class System(CppSystem):
 
       with mlir.ir.InsertionPoint(self.body):
         self.declare_externs()
-        hw.HWModuleOp(name='top',
-                      input_ports=[('clk', self.i1), ('rstn', self.i1)],
-                      output_ports=[],
-                      body_builder=self.build_top)
+        self.top_module()
 
   def declare_externs(self):
     pass
+
+  def top_module(self):
+    return hw.HWModuleOp(name='top',
+                         input_ports=[('clk', self.i1), ('rstn', self.i1)],
+                         output_ports=[],
+                         body_builder=self.build_top)
 
   def build_top(self, topMod):
     self.build(topMod)
@@ -90,7 +93,7 @@ class Types:
 
   @staticmethod
   def array(inner: mlir.ir.Type, size: int) -> hw.ArrayType:
-    return hw.ArrayType(inner, size)
+    return hw.ArrayType.get(inner, size)
 
   @staticmethod
   def chan(inner: mlir.ir.Type) -> mlir.ir.Type:

--- a/lib/Bindings/Python/circt/support.py
+++ b/lib/Bindings/Python/circt/support.py
@@ -5,6 +5,12 @@
 from contextlib import AbstractContextManager
 
 
+class UnconnectedSignalError(RuntimeError):
+  def __init__(self, module: str, port_names: list[str]):
+    super().__init__(
+        f"Ports {port_names} unconnected in design module {module}.")
+
+
 class BackedgeBuilder(AbstractContextManager):
 
   def __init__(self):
@@ -40,6 +46,7 @@ class BackedgeBuilder(AbstractContextManager):
 
       assert port_name, "Could not look up port name for backedge"
 
+      # TODO: Make this use `UnconnectedSignalError`.
       msg = "Port:     " + port_name + "\n"
       msg += "Module:   " + str(module).split(" {")[0] + "\n"
       msg += "Instance: " + str(instance)


### PR DESCRIPTION
Fastest thing I could think of: uses HWModuleOp and calls construct immediately. Lots of ugliness in `construct`.