### PR TITLE
[FIRRTL] Fix the handling of DShlwPrimOp

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -251,8 +251,18 @@ def NEQPrimOp : BinaryPrimOp<"neq", IntType, IntType, UInt1Type, [Commutative]>;
 def CatPrimOp   : BinaryPrimOp<"cat", IntType, IntType, UIntType> {
   let hasCanonicalizeMethod = true;
 }
-def DShlPrimOp  : BinaryPrimOp<"dshl", IntType, UIntType, IntType>;
-def DShlwPrimOp : BinaryPrimOp<"dshlw", IntType, UIntType, IntType>;
+def DShlPrimOp  : BinaryPrimOp<"dshl", IntType, UIntType, IntType>  {
+  let description = [{
+    A dynamic shift left operation. The width of `$result` is expanded to
+    `width($lhs) + 1 << width($rhs) - 1`.
+  }];
+}
+def DShlwPrimOp : BinaryPrimOp<"dshlw", IntType, UIntType, IntType> {
+  let description = [{
+    A dynamic shift left operation same as 'dshl' but with different width rule.
+    The width of `$result` is equal to `$lhs`.
+  }];
+}
 def DShrPrimOp  : BinaryPrimOp<"dshr", IntType, UIntType, IntType>;
 
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1002,7 +1002,7 @@ struct FIRRTLLowering : public FIRRTLVisitor<FIRRTLLowering, LogicalResult> {
     return lowerDivLikeOp<comb::ShrSOp, comb::ShrUOp>(op);
   }
   LogicalResult visitExpr(DShlwPrimOp op) {
-    return lowerDivLikeOp<comb::ShrSOp, comb::ShrUOp>(op);
+    return lowerDivLikeOp<comb::ShlOp, comb::ShlOp>(op);
   }
   LogicalResult visitExpr(TailPrimOp op);
   LogicalResult visitExpr(MuxPrimOp op);
@@ -1732,10 +1732,9 @@ LogicalResult FIRRTLLowering::visitDecl(MemOp op) {
     auto portName = op.getPortName(i).getValue();
     auto portKind = op.getPortKind(i);
 
-    auto &portKindNum =
-        portKind == MemOp::PortKind::Read
-            ? readCount
-            : portKind == MemOp::PortKind::Write ? writeCount : readwriteCount;
+    auto &portKindNum = portKind == MemOp::PortKind::Read    ? readCount
+                        : portKind == MemOp::PortKind::Write ? writeCount
+                                                             : readwriteCount;
 
     auto addInput = [&](SmallVectorImpl<Value> &operands, StringRef field,
                         size_t width) {

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1732,9 +1732,10 @@ LogicalResult FIRRTLLowering::visitDecl(MemOp op) {
     auto portName = op.getPortName(i).getValue();
     auto portKind = op.getPortKind(i);
 
-    auto &portKindNum = portKind == MemOp::PortKind::Read    ? readCount
-                        : portKind == MemOp::PortKind::Write ? writeCount
-                                                             : readwriteCount;
+    auto &portKindNum =
+        portKind == MemOp::PortKind::Read
+            ? readCount
+            : portKind == MemOp::PortKind::Write ? writeCount : readwriteCount;
 
     auto addInput = [&](SmallVectorImpl<Value> &operands, StringRef field,
                         size_t width) {

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -259,12 +259,9 @@ OpFoldResult DShlPrimOp::fold(ArrayRef<Attribute> operands) {
 }
 
 OpFoldResult DShlwPrimOp::fold(ArrayRef<Attribute> operands) {
-  // This follows LowerToHW's precedent.
-  // TODO: Verify this: https://github.com/llvm/circt/issues/1062
   return constFoldFIRRTLBinaryOp(
-      *this, operands, BinOpKind::DivideOrShift, [=](APInt a, APInt b) {
-        return getType().isSigned() ? a.ashr(b) : a.lshr(b);
-      });
+      *this, operands, BinOpKind::DivideOrShift,
+      [=](APInt a, APInt b) -> APInt { return a << b; });
 }
 
 OpFoldResult DShrPrimOp::fold(ArrayRef<Attribute> operands) {

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -177,7 +177,7 @@ firrtl.circuit "Simple" {
     // CHECK-NEXT: [[SHIFT:%.+]] = comb.shl {{.*}}, {{.*}} : i15
     %30 = firrtl.dshl %in3, %29 : (!firrtl.sint<8>, !firrtl.uint<3>) -> !firrtl.sint<15>
 
-    // CHECK-NEXT: = comb.shru [[DSHR]], [[DSHR]] : i3
+    // CHECK-NEXT: = comb.shl [[DSHR]], [[DSHR]] : i3
     %dshlw = firrtl.dshlw %29, %29 : (!firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
 
     // Issue #367: https://github.com/llvm/circt/issues/367


### PR DESCRIPTION
A quick fix of issue #1062 - we still parse `dshlw`, and the errors in the lowering and folding are fixed.