### PR TITLE
[SV] Add sym_name argument to sv::WireOp::build

### DIFF
--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -40,7 +40,8 @@ def WireOp : SVOp<"wire", [DeclareOpInterfaceMethods<OpAsmOpInterface>,
   let skipDefaultBuilders = 1;
   let builders = [
     OpBuilder<(ins "::mlir::Type":$elementType,
-                      CArg<"StringAttr", "StringAttr()">:$name)>,
+                      CArg<"StringAttr", "StringAttr()">:$name,
+                      CArg<"StringAttr", "StringAttr()">:$sym_name)>,
     OpBuilder<(ins "::mlir::Type":$elementType, CArg<"StringRef">:$name), [{
       return build($_builder, $_state, elementType,
                    $_builder.getStringAttr(name));

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -797,9 +797,11 @@ LogicalResult verifySignalExists(Value ifaceVal, FlatSymbolRefAttr signalName) {
 //===----------------------------------------------------------------------===//
 
 void WireOp::build(OpBuilder &odsBuilder, OperationState &odsState,
-                   Type elementType, StringAttr name) {
+                   Type elementType, StringAttr name, StringAttr sym_name) {
   if (!name)
     name = odsBuilder.getStringAttr("");
+  if (sym_name)
+    odsState.addAttribute("sym_name", sym_name);
 
   odsState.addAttribute("name", name);
   odsState.addTypes(InOutType::get(elementType));


### PR DESCRIPTION
Added the symbol name argument to `sv::WireOp::build` this is required to attach symbol to `sv::WireOp`. 
Followup to https://github.com/llvm/circt/pull/1044