### PR TITLE
[FIRRTL] Move result type computation to InferTypeOpInterface

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTL.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTL.td
@@ -16,6 +16,7 @@
 include "mlir/IR/OpBase.td"
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/IR/RegionKindInterface.td"
 
 def FIRRTLDialect : Dialect {

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -18,6 +18,70 @@ def APSIntAttr : Attr<CPred<"$_self.isa<::mlir::IntegerAttr>()">,
   let convertFromStorage = "APSInt($_self.getValue(), !getType().isSigned())";
 }
 
+def SameOperandsIntTypeKind : NativeOpTrait<"SameOperandsIntTypeKind"> {
+  let cppNamespace = "::circt::firrtl";
+}
+
+// A common base class for operations that implement type inference and parsed
+// argument validation.
+class FIRRTLExprOp<string mnemonic, list<OpTrait> traits = []> :
+    FIRRTLOp<mnemonic, traits # [InferTypeOpInterface, NoSideEffect]> {
+
+  // The narrow operation-specific type inference method. Operations can
+  // override this with an inline declaration for the class header, or just
+  // leave it as is and implement the function in a cpp file.
+  code inferTypeDecl = [{
+    /// Infer the return type of this operation.
+    static FIRRTLType inferReturnType(ValueRange operands,
+                                      ArrayRef<NamedAttribute> attrs,
+                                      Optional<Location> loc);
+  }];
+
+  // The operation-specific validator for a parsed list of operands and
+  // constants. Operations can override this with an inline declaration for the
+  // class header, or just leave it as is and implement the function in a cpp
+  // file.
+  code parseValidator = "";
+  code parseValidatorDecl = [{
+    /// Check that the parser has consumed the correct number of operands and
+    /// constants.
+    static LogicalResult validateArguments(ValueRange operands,
+                                           ArrayRef<NamedAttribute> attrs,
+                                           Location loc)
+  }] # !if(!empty(parseValidator), ";", !subst("$_impl", parseValidator, [{ {
+    return $_impl(operands, attrs, loc);
+  } }]));
+
+  // Additional class declarations to emit alongside the type inference.
+  code firrtlExtraClassDeclaration = "";
+
+  let extraClassDeclaration = firrtlExtraClassDeclaration # inferTypeDecl #
+      parseValidatorDecl # [{
+    /// Infer the return types of this operation. This is called by the
+    /// `InferTypeOpInterface`. We simply forward to a narrower
+    /// operation-specific implementation which is sufficient for FIRRTL ops.
+    static LogicalResult inferReturnTypes(MLIRContext *context,
+                                          Optional<Location> loc,
+                                          ValueRange operands,
+                                          DictionaryAttr attrs,
+                                          mlir::RegionRange regions,
+                                          SmallVectorImpl<Type> &results) {
+      return impl::inferReturnTypes(context, loc, operands, attrs, regions,
+        results, &inferReturnType);
+    }
+
+    /// Check that the parser has consumed the correct number of operands and
+    /// constants, and infer the appropriate return type for the operation.
+    static FIRRTLType validateAndInferReturnType(ValueRange operands,
+                                                 ArrayRef<NamedAttribute> attrs,
+                                                 Location loc) {
+      if (failed(validateArguments(operands, attrs, loc)))
+        return {};
+      return inferReturnType(operands, attrs, loc);
+    }
+  }];
+}
+
 def ConstantOp : FIRRTLOp<"constant", [NoSideEffect, ConstantLike,
                                        FirstAttrDerivedResultType]> {
   let summary = "Produce a constant value";
@@ -45,7 +109,6 @@ def ConstantOp : FIRRTLOp<"constant", [NoSideEffect, ConstantLike,
   let verifier = "return ::verifyConstantOp(*this);";
 }
 
-
 def InvalidValueOp : FIRRTLOp<"invalidvalue", [NoSideEffect]> {
   let summary = "InvalidValue primitive";
   let description = [{
@@ -64,7 +127,7 @@ def InvalidValueOp : FIRRTLOp<"invalidvalue", [NoSideEffect]> {
   let assemblyFormat = "attr-dict `:` type($result)";
 }
 
-def SubfieldOp : FIRRTLOp<"subfield", [NoSideEffect]> {
+def SubfieldOp : FIRRTLExprOp<"subfield"> {
   let summary = "Extract a subfield of another value";
   let description = [{
     The subfield expression refers to a subelement of an expression with a
@@ -81,24 +144,9 @@ def SubfieldOp : FIRRTLOp<"subfield", [NoSideEffect]> {
   let assemblyFormat =
     "$input `(` $fieldname `)` attr-dict `:` functional-type($input, $result)";
 
-  let builders = [
-    OpBuilder<(ins "Value":$input, "StringAttr":$fieldName)>,
-    OpBuilder<(ins "Value":$input, "StringRef":$fieldName)>
-  ];
-
-  let extraClassDeclaration = [{
-    /// Compute the result of a Subfield operation on a value of the specified
-    /// type and extracting the specified field name.  If the request is
-    /// invalid, then a null type is returned.
-    static FIRRTLType getResultType(Type inType, StringAttr fieldName,
-                                    Location loc);
-
+  let firrtlExtraClassDeclaration = [{
     /// Return true if the specified field is flipped.
     bool isFieldFlipped();
-  }];
-
-  let verifier = [{
-    VERIFY_RESULT_TYPE_RET(input().getType(), fieldnameAttr());
   }];
 }
 
@@ -107,8 +155,9 @@ class IndexConstraint<string value, string resultValue>
                    value, resultValue,
                    "firrtl::getVectorElementType($_self)">;
 
-def SubindexOp : FIRRTLOp<"subindex", [NoSideEffect,
-                                       IndexConstraint<"input", "result">]> {
+def SubindexOp : FIRRTLExprOp<"subindex", [
+    IndexConstraint<"input", "result">
+  ]> {
   let summary = "Extract an element of a vector value";
   let description = [{
     The subindex expression statically refers, by index, to a subelement
@@ -126,21 +175,11 @@ def SubindexOp : FIRRTLOp<"subindex", [NoSideEffect,
   // TODO: Could drop the result type, inferring it from the source.
   let assemblyFormat =
      "$input `[` $index `]` attr-dict `:` type($input)";
-
-  let extraClassDeclaration = [{
-    /// Compute the result of a Subindex operation on a value of the specified
-    /// type.  If the request is invalid, then a null type is returned.
-    static FIRRTLType getResultType(FIRRTLType inType, unsigned fieldIdx,
-                                    Location loc);
-  }];
-
-  let verifier = [{
-    VERIFY_RESULT_TYPE_RET(input().getType().cast<FIRRTLType>(), index());
-  }];
 }
 
-def SubaccessOp : FIRRTLOp<"subaccess", [NoSideEffect,
-                                         IndexConstraint<"input", "result">]> {
+def SubaccessOp : FIRRTLExprOp<"subaccess", [
+    IndexConstraint<"input", "result">
+  ]> {
   let summary = "Extract a dynamic element of a vector value";
   let description = [{
     The subaccess expression dynamically refers to a subelement of a
@@ -154,31 +193,19 @@ def SubaccessOp : FIRRTLOp<"subaccess", [NoSideEffect,
   let arguments = (ins FIRRTLType:$input, UIntType:$index);
   let results = (outs FIRRTLType:$result);
 
-  // TODO: Could drop the result type, inferring it from the source.
   let assemblyFormat =
      "$input `[` $index `]` attr-dict `:` type($input) `,` type($index)";
 
-  let extraClassDeclaration = [{
-    /// Compute the result of a Subaccess operation on a value of the specified
-    /// type.  If the request is invalid, then a null type is returned.
-    static FIRRTLType getResultType(FIRRTLType baseType, FIRRTLType indexType,
-                                    Location loc);
-  }];
-
-  let verifier = [{
-    VERIFY_RESULT_TYPE_RET(input().getType().cast<FIRRTLType>(),
-                           index().getType().cast<FIRRTLType>());
-  }];
-
   let hasCanonicalizeMethod = true;
 }
+
 //===----------------------------------------------------------------------===//
 // Primitive Operations
 //===----------------------------------------------------------------------===//
 
 /// PrimOp is a FIRRTLOp without side effects.
 class PrimOp<string mnemonic, list<OpTrait> traits = []> :
-    FIRRTLOp<mnemonic, traits # [NoSideEffect]> {
+    FIRRTLExprOp<mnemonic, traits> {
   let hasFolder = 1;
 }
 
@@ -188,8 +215,7 @@ class PrimOp<string mnemonic, list<OpTrait> traits = []> :
 
 // Base class for binary primitive operators.
 class BinaryPrimOp<string mnemonic, Type lhsType, Type rhsType, Type resultType,
-                   list<OpTrait> traits = []> :
-    PrimOp<mnemonic, traits> {
+                   list<OpTrait> traits = []> : PrimOp<mnemonic, traits> {
   let arguments = (ins lhsType:$lhs, rhsType:$rhs);
   let results = (outs resultType:$result);
 
@@ -198,30 +224,40 @@ class BinaryPrimOp<string mnemonic, Type lhsType, Type rhsType, Type resultType,
        `(` type($lhs) `,` type($rhs) `)` `->` type($result)
   }];
 
-  let extraClassDeclaration = [{
-    /// Return the result for inputs with the specified type, returning a null
-    /// type if the input types are invalid.
-    static FIRRTLType getResultType(FIRRTLType lhs, FIRRTLType rhs, Location loc);
-    static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
-                                    ArrayRef<int64_t> integers, Location loc) {
-      if (inputs.size() != 2 || !integers.empty()) {
-        mlir::emitError(loc,"operation requires two operands and no constants");
-        return {};
-      }
-      return getResultType(inputs[0], inputs[1], loc);
+  // Give concrete operations a chance to set a type inference callback. If left
+  // empty, a declaration for `inferBinaryReturnType` will be emitted that the
+  // operation is expected to implement.
+  code inferType = "";
+  let inferTypeDecl = !if(!empty(inferType), [{
+    /// Infer the return type of this binary operation.
+    static FIRRTLType inferBinaryReturnType(FIRRTLType lhs, FIRRTLType rhs,
+                                            Optional<Location> loc);
+    }], "") # !subst("$_infer", !if(!empty(inferType), "inferBinaryReturnType",
+      inferType), [{
+    /// Infer the return type of this operation.
+    static FIRRTLType inferReturnType(ValueRange operands,
+                                      ArrayRef<NamedAttribute> attrs,
+                                      Optional<Location> loc) {
+      return $_infer(operands[0].getType().cast<FIRRTLType>(),
+                     operands[1].getType().cast<FIRRTLType>(),
+                     loc);
     }
-  }];
-
-  let verifier = [{
-    VERIFY_RESULT_TYPE_RET(lhs().getType().cast<FIRRTLType>(),
-                           rhs().getType().cast<FIRRTLType>());
-  }];
+  }]);
+  let parseValidator = "impl::validateBinaryOpArguments";
 }
 
-def AddPrimOp : BinaryPrimOp<"add", IntType, IntType, IntType, [Commutative]>;
-def SubPrimOp : BinaryPrimOp<"sub", IntType, IntType, IntType>;
-def MulPrimOp : BinaryPrimOp<"mul", IntType, IntType, IntType, [Commutative]>;
-def DivPrimOp : BinaryPrimOp<"div", IntType, IntType, IntType> {
+// A binary operation on two integer-typed arguments of the same kind.
+class IntBinaryPrimOp<string mnemonic, Type resultType,
+                      list<OpTrait> traits = []> :
+   BinaryPrimOp<mnemonic, IntType, IntType, resultType,
+                traits # [SameOperandsIntTypeKind]>;
+
+let inferType = "impl::inferAddSubResult" in {
+  def AddPrimOp : IntBinaryPrimOp<"add", IntType, [Commutative]>;
+  def SubPrimOp : IntBinaryPrimOp<"sub", IntType>;
+}
+def MulPrimOp : IntBinaryPrimOp<"mul", IntType, [Commutative]>;
+def DivPrimOp : IntBinaryPrimOp<"div", IntType> {
   let description = [{
     Divides the first argument (the numerator) by the second argument
     (the denominator) truncating the result (rounding towards zero).
@@ -234,23 +270,26 @@ def DivPrimOp : BinaryPrimOp<"div", IntType, IntType, IntType> {
     optimized FIRRTL dialects that are separately converted to Verilog.
   }];
 }
-def RemPrimOp : BinaryPrimOp<"rem", IntType, IntType, IntType>;
-
-def AndPrimOp : BinaryPrimOp<"and", IntType, IntType, UIntType, [Commutative]>;
-def OrPrimOp  : BinaryPrimOp<"or",  IntType, IntType, UIntType, [Commutative]>;
-def XorPrimOp : BinaryPrimOp<"xor", IntType, IntType, UIntType, [Commutative]>;
+def RemPrimOp : IntBinaryPrimOp<"rem", IntType>;
+let inferType = "impl::inferBitwiseResult" in {
+  def AndPrimOp : IntBinaryPrimOp<"and", UIntType, [Commutative]>;
+  def OrPrimOp  : IntBinaryPrimOp<"or",  UIntType, [Commutative]>;
+  def XorPrimOp : IntBinaryPrimOp<"xor", UIntType, [Commutative]>;
+}
 
 // Comparison Operations
-let hasCanonicalizer = true in {
-  def LEQPrimOp : BinaryPrimOp<"leq", IntType, IntType, UInt1Type>;
-  def LTPrimOp  : BinaryPrimOp<"lt",  IntType, IntType, UInt1Type>;
-  def GEQPrimOp : BinaryPrimOp<"geq", IntType, IntType, UInt1Type>;
-  def GTPrimOp  : BinaryPrimOp<"gt",  IntType, IntType, UInt1Type>;
+let inferType = "impl::inferComparisonResult" in {
+  let hasCanonicalizer = true in {
+    def LEQPrimOp : IntBinaryPrimOp<"leq", UInt1Type>;
+    def LTPrimOp  : IntBinaryPrimOp<"lt",  UInt1Type>;
+    def GEQPrimOp : IntBinaryPrimOp<"geq", UInt1Type>;
+    def GTPrimOp  : IntBinaryPrimOp<"gt",  UInt1Type>;
+  }
+  def EQPrimOp  : IntBinaryPrimOp<"eq",  UInt1Type, [Commutative]>;
+  def NEQPrimOp : IntBinaryPrimOp<"neq", UInt1Type, [Commutative]>;
 }
-def EQPrimOp  : BinaryPrimOp<"eq",  IntType, IntType, UInt1Type, [Commutative]>;
-def NEQPrimOp : BinaryPrimOp<"neq", IntType, IntType, UInt1Type, [Commutative]>;
 
-def CatPrimOp   : BinaryPrimOp<"cat", IntType, IntType, UIntType> {
+def CatPrimOp : IntBinaryPrimOp<"cat", UIntType> {
   let hasCanonicalizeMethod = true;
 }
 def DShlPrimOp  : BinaryPrimOp<"dshl", IntType, UIntType, IntType>  {
@@ -273,31 +312,32 @@ def DShrPrimOp  : BinaryPrimOp<"dshr", IntType, UIntType, IntType>;
 
 // Base class for binary primitive operators.
 class UnaryPrimOp<string mnemonic, Type srcType, Type resultType,
-                  list<OpTrait> traits = []> :
-    PrimOp<mnemonic, traits> {
+                  list<OpTrait> traits = []> : PrimOp<mnemonic, traits> {
   let arguments = (ins srcType:$input);
   let results = (outs resultType:$result);
 
   let assemblyFormat =
     "$input attr-dict `:` functional-type($input, $result)";
 
-  let extraClassDeclaration = [{
-    /// Return the result for inputs with the specified type, returning a null
-    /// type if the input type is invalid.
-    static FIRRTLType getResultType(FIRRTLType input, Location loc);
-    static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
-                                    ArrayRef<int64_t> integers, Location loc) {
-      if (inputs.size() != 1 || !integers.empty()) {
-        mlir::emitError(loc, "operation requires one operand and no constants");
-        return {};
-      }
-      return getResultType(inputs[0], loc);
+  // Give concrete operations a chance to set a type inference callback. If left
+  // empty, a declaration for `inferUnaryReturnType` will be emitted that the
+  // operation is expected to implement.
+  code inferType = "";
+  let inferTypeDecl = !if(!empty(inferType), [{
+    /// Infer the return type of this unary operation.
+    static FIRRTLType inferUnaryReturnType(FIRRTLType arg,
+                                           Optional<Location> loc);
+    }], "") # !subst("$_infer", !if(!empty(inferType), "inferUnaryReturnType",
+      inferType), [{
+    /// Infer the return type of this operation.
+    static FIRRTLType inferReturnType(ValueRange operands,
+                                      ArrayRef<NamedAttribute> attrs,
+                                      Optional<Location> loc) {
+      return $_infer(operands[0].getType().cast<FIRRTLType>(), loc);
     }
-  }];
+  }]);
 
-  let verifier = [{
-    VERIFY_RESULT_TYPE_RET(input().getType().cast<FIRRTLType>());
-  }];
+  let parseValidator = "impl::validateUnaryOpArguments";
 }
 
 def AsSIntPrimOp : UnaryPrimOp<"asSInt", FIRRTLType, SIntType>;
@@ -309,26 +349,28 @@ def CvtPrimOp : UnaryPrimOp<"cvt", IntType, SIntType>;
 def NegPrimOp : UnaryPrimOp<"neg", IntType, SIntType>;
 def NotPrimOp : UnaryPrimOp<"not", IntType, UIntType>;
 
-def AndRPrimOp : UnaryPrimOp<"andr", IntType, UIntType> {
-  let description = [{
-    Horizontally reduce a value to one bit, using the 'and' operation to merge
-    bits.  `andr(x)` is equivalent to `concat(x, 1b1) == ~0`.  As such, it
-    returns 1 for zero-bit-wide operands.
-  }];
-}
-def OrRPrimOp : UnaryPrimOp<"orr", IntType, UIntType> {
-  let description = [{
-    Horizontally reduce a value to one bit, using the 'or' operation to merge
-    bits.  `orr(x)` is equivalent to `concat(x, 1b0) != 0`.  As such, it returns
-    0 for zero-bit-wide operands.
-  }];
-}
-def XorRPrimOp : UnaryPrimOp<"xorr", IntType, UIntType> {
-  let description = [{
-    Horizontally reduce a value to one bit, using the 'xor' operation to merge
-    bits.  `xorr(x)` is equivalent to `popcount(concat(x, 1b0)) & 1`.  As such,
-    it returns 0 for zero-bit-wide operands.
-  }];
+let inferType = "impl::inferReductionResult" in {
+  def AndRPrimOp : UnaryPrimOp<"andr", IntType, UInt1Type> {
+    let description = [{
+      Horizontally reduce a value to one bit, using the 'and' operation to merge
+      bits.  `andr(x)` is equivalent to `concat(x, 1b1) == ~0`.  As such, it
+      returns 1 for zero-bit-wide operands.
+    }];
+  }
+  def OrRPrimOp : UnaryPrimOp<"orr", IntType, UInt1Type> {
+    let description = [{
+      Horizontally reduce a value to one bit, using the 'or' operation to merge
+      bits.  `orr(x)` is equivalent to `concat(x, 1b0) != 0`.  As such, it
+      returns 0 for zero-bit-wide operands.
+    }];
+  }
+  def XorRPrimOp : UnaryPrimOp<"xorr", IntType, UInt1Type> {
+    let description = [{
+      Horizontally reduce a value to one bit, using the 'xor' operation to merge
+      bits.  `xorr(x)` is equivalent to `popcount(concat(x, 1b0)) & 1`.  As
+      such, it returns 0 for zero-bit-wide operands.
+    }];
+  }
 }
 
 //===----------------------------------------------------------------------===//
@@ -350,29 +392,6 @@ def BitsPrimOp : PrimOp<"bits"> {
   }];
 
   let hasCanonicalizeMethod = true;
-
-  let builders = [
-    OpBuilder<(ins "Value":$input, "unsigned":$high, "unsigned":$low)>
-  ];
-
-  let extraClassDeclaration = [{
-    /// Return the result for inputs with the specified type, returning a null
-    /// type if the input types are invalid.
-    static FIRRTLType getResultType(FIRRTLType input, int32_t high,
-                                    int32_t low, Location loc);
-    static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
-                                    ArrayRef<int64_t> integers, Location loc) {
-      if (inputs.size() != 1 || integers.size() != 2) {
-        mlir::emitError(loc,"operation requires one operand and two constants");
-        return {};
-      }
-      return getResultType(inputs[0], integers[0], integers[1], loc);
-    }
-  }];
-
-  let verifier = [{
-    VERIFY_RESULT_TYPE_RET(input().getType().cast<FIRRTLType>(), hi(), lo());
-  }];
 }
 
 def HeadPrimOp : PrimOp<"head"> {
@@ -383,25 +402,7 @@ def HeadPrimOp : PrimOp<"head"> {
     "$input `,` $amount attr-dict `:` functional-type($input, $result)";
 
   let hasCanonicalizeMethod = true;
-
-  let extraClassDeclaration = [{
-    /// Return the result for inputs with the specified type, returning a null
-    /// type if the input types are invalid.
-    static FIRRTLType getResultType(FIRRTLType input, int32_t amount,
-                                    Location loc);
-    static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
-                                    ArrayRef<int64_t> integers, Location loc) {
-      if (inputs.size() != 1 || integers.size() != 1) {
-        mlir::emitError(loc, "operation requires one operand and one constant");
-        return {};
-      }
-      return getResultType(inputs[0], integers[0], loc);
-    }
-  }];
-
-  let verifier = [{
-    VERIFY_RESULT_TYPE_RET(input().getType().cast<FIRRTLType>(), amount());
-  }];
+  let parseValidator = "impl::validateOneOperandOneConst";
 }
 
 def MuxPrimOp : PrimOp<"mux"> {
@@ -412,29 +413,6 @@ def MuxPrimOp : PrimOp<"mux"> {
     "`(` operands `)` attr-dict `:` functional-type(operands, $result)";
 
   let hasCanonicalizer = true;
-
-  let extraClassDeclaration = [{
-    /// Return the result for inputs with the specified type, returning a null
-    /// type if the input types are invalid.
-    static FIRRTLType getResultType(FIRRTLType sel, FIRRTLType high,
-                                    FIRRTLType low, Location loc);
-    static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
-                                    ArrayRef<int64_t> integers, Location loc) {
-      if (inputs.size() != 3 || !integers.empty()) {
-        mlir::emitError(loc,
-                        "operation requires three operands and no constants");
-        return {};
-      }
-
-      return getResultType(inputs[0], inputs[1], inputs[2], loc);
-    }
-  }];
-
-  let verifier = [{
-    VERIFY_RESULT_TYPE_RET(sel().getType().cast<FIRRTLType>(),
-                           high().getType().cast<FIRRTLType>(),
-                           low().getType().cast<FIRRTLType>());
-  }];
 }
 
 def PadPrimOp : PrimOp<"pad"> {
@@ -450,25 +428,7 @@ def PadPrimOp : PrimOp<"pad"> {
     width of `input`, then input is unmodified.
   }];
 
-  let extraClassDeclaration = [{
-    /// Return the result for inputs with the specified type, returning a null
-    /// type if the input types are invalid.
-    static FIRRTLType getResultType(FIRRTLType input, int32_t amount,
-                                    Location loc);
-    static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
-                                    ArrayRef<int64_t> integers, Location loc) {
-      if (inputs.size() != 1 || integers.size() != 1) {
-        mlir::emitError(loc, "operation requires one operand and one constant");
-        return {};
-      }
-
-      return getResultType(inputs[0], integers[0], loc);
-    }
-  }];
-
-  let verifier = [{
-    VERIFY_RESULT_TYPE_RET(input().getType().cast<FIRRTLType>(), amount());
-  }];
+  let parseValidator = "impl::validateOneOperandOneConst";
 }
 
 class ShiftPrimOp<string mnemonic> : PrimOp<mnemonic> {
@@ -478,24 +438,7 @@ class ShiftPrimOp<string mnemonic> : PrimOp<mnemonic> {
   let assemblyFormat =
     "$input `,` $amount attr-dict `:` functional-type($input, $result)";
 
-  let extraClassDeclaration = [{
-    /// Return the result for inputs with the specified type, returning a null
-    /// type if the input types are invalid.
-    static FIRRTLType getResultType(FIRRTLType input, int32_t amount,
-                                    Location loc);
-    static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
-                                    ArrayRef<int64_t> integers, Location loc) {
-      if (inputs.size() != 1 || integers.size() != 1) {
-        mlir::emitError(loc, "operation requires one operand and one constant");
-        return {};
-      }
-      return getResultType(inputs[0], integers[0], loc);
-    }
-  }];
-
-  let verifier = [{
-    VERIFY_RESULT_TYPE_RET(input().getType().cast<FIRRTLType>(), amount());
-  }];
+  let parseValidator = "impl::validateOneOperandOneConst";
 }
 
 def ShlPrimOp : ShiftPrimOp<"shl"> {
@@ -530,25 +473,7 @@ def TailPrimOp : PrimOp<"tail"> {
   }];
 
   let hasCanonicalizeMethod = true;
-
-  let extraClassDeclaration = [{
-    /// Return the result for inputs with the specified type, returning a null
-    /// type if the input types are invalid.
-    static FIRRTLType getResultType(FIRRTLType input, int32_t amount,
-                                    Location loc);
-    static FIRRTLType getResultType(ArrayRef<FIRRTLType> inputs,
-                                    ArrayRef<int64_t> integers, Location loc) {
-      if (inputs.size() != 1 || integers.size() != 1) {
-        mlir::emitError(loc, "operation requires one operand and one constant");
-        return {};
-      }
-      return getResultType(inputs[0], integers[0], loc);
-    }
-  }];
-
-  let verifier = [{
-    VERIFY_RESULT_TYPE_RET(input().getType().cast<FIRRTLType>(), amount());
-  }];
+  let parseValidator = "impl::validateOneOperandOneConst";
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -314,11 +314,8 @@ static Value createDecoder(Value input, Location insertLoc,
   auto bit =
       rewriter.create<firrtl::ConstantOp>(insertLoc, bitType, APInt(1, 1));
 
-  auto resultType =
-      DShlPrimOp::getResultType(bit.getType().cast<FIRRTLType>(),
-                                input.getType().cast<FIRRTLType>(), insertLoc);
   // Shift the bit dynamically by the input amount.
-  auto shift = rewriter.create<DShlPrimOp>(insertLoc, resultType, bit, input);
+  auto shift = rewriter.create<DShlPrimOp>(insertLoc, bit, input);
 
   return shift;
 }
@@ -642,12 +639,8 @@ void StdExprBuilder::buildBinaryLogic() {
   Value resultData = resultSubfields[2];
 
   // Carry out the binary operation.
-  auto resultTy =
-      OpType::getResultType(arg0Data.getType().cast<FIRRTLType>(),
-                            arg1Data.getType().cast<FIRRTLType>(), insertLoc);
-  assert(resultTy && "invalid binary operands");
-  Value resultDataOp =
-      rewriter.create<OpType>(insertLoc, resultTy, arg0Data, arg1Data);
+  Value resultDataOp = rewriter.create<OpType>(insertLoc, arg0Data, arg1Data);
+  auto resultTy = resultDataOp.getType().cast<FIRRTLType>();
 
   // Truncate the result type down if needed.
   auto resultWidth = resultData.getType()

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -272,7 +272,7 @@ firrtl.module @X(in %a : !firrtl.uint<4>) {
 firrtl.circuit "X" {
 
 firrtl.module @X(in %a : !firrtl.uint<4>) {
-  // expected-error @+1 {{'firrtl.bits' op result type should be '!firrtl.uint<3>'}}
+  // expected-error @+1 {{'firrtl.bits' op inferred type(s) '!firrtl.uint<3>' are incompatible with return type(s) of operation '!firrtl.uint<2>'}}
   %0 = firrtl.bits %a 3 to 1 : (!firrtl.uint<4>) -> !firrtl.uint<2>
 }
 
@@ -299,7 +299,7 @@ firrtl.circuit "BadPort" {
 
 firrtl.circuit "BadAdd" {
   firrtl.module @BadAdd(in %a : !firrtl.uint<1>) {
-    // expected-error @+1 {{'firrtl.add' op result type should be '!firrtl.uint<2>'}}
+    // expected-error @+1 {{'firrtl.add' op inferred type(s) '!firrtl.uint<2>' are incompatible with return type(s) of operation '!firrtl.uint<1>'}}
     firrtl.add %a, %a : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   }
 }


### PR DESCRIPTION
* Many FIRRTL operations have their result type fully determined by their arguments (operands and attributes). The `InferTypeOpInterface` formalizes this behaviour and provides a unified verification hook as well as a builder which automatically infers the result type of the built operation. The interface also allows passes to treat all ops that can determine their return type uniformly (e.g., the width inference pass).
* Adjust the definition of most FIRRTL expression ops to implement this interface. Some operations which have a well-known return type that is independent of their arguments, such as comparisons or reductions, automatically generate the necessary `inferReturnTypes` function impl.
* The semantics and function signature of `inferReturnTypes` is different from the `getResultType` we have at the moment. This requires a somewhat widespread mechanical change in FIRRTLOps.cpp to update to this new function.
* The FIR parser used a specific flavor of `getResultType` to both check that the parsed operation arguments and constants are of the correct form, and to determine the result type. This is now split into a dedicated `verifyParsedArguments` functions that only performs validation, and the parser is updated to use the `inferReturnTypes` function for the other step. We can't use the builder function with inferred type in the parser, as that aborts/asserts rather than exiting gracefully.
* The `getResultType` implementations performed a certain amount of operation verification alongside type computation. Mainly to check that IntType operands are of the same kind. This is now explicitly formalized in a `SameOperandsIntKind` op trait, which performs the check. Without this change, all the operations with well-known result types (comparisons, reductions) would lose this validation, since the `inferReturnTypes` is auto-generated in their case.
* As a result of this change, a few calls in `HandshakeToFIRRTL` become more streamlined as the result type no longer needs to be explicitly calculated.