### PR TITLE
Bind support

### DIFF
--- a/include/circt/Dialect/RTL/RTLStructure.td
+++ b/include/circt/Dialect/RTL/RTLStructure.td
@@ -279,7 +279,7 @@ def RTLModuleGeneratedOp : RTLOp<"module.generated",
 
 def InstanceOp : RTLOp<"instance",
                        [DeclareOpInterfaceMethods<OpAsmOpInterface>,
-                        Symbol]> {
+                       HasParent<"RTLModuleOp">, Symbol]> {
   let summary = "Create an instance of a module";
   let description = [{
     This represents an instance of a module. The inputs and results are 

--- a/include/circt/Dialect/SV/SVOps.h
+++ b/include/circt/Dialect/SV/SVOps.h
@@ -20,6 +20,9 @@
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 namespace circt {
+namespace rtl {
+  class InstanceOp;
+}
 namespace sv {
 
 /// Return true if the specified operation is an expression.

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -10,6 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+/// Ensure symbol is one of the rtl module.* types
+def isModuleSymbol : AttrConstraint<
+  CPred<
+    "rtl::isAnyModule(::mlir::SymbolTable::lookupNearestSymbolFrom("
+      "&$_op, $_self.cast<::mlir::FlatSymbolRefAttr>().getValue()))"
+  >, "is module like">;
+
 //===----------------------------------------------------------------------===//
 // Control flow like-operations
 //===----------------------------------------------------------------------===//
@@ -473,4 +480,54 @@ def CoverOp : SVOp<"cover", [ProceduralOp]> {
   let arguments = (ins AnyType:$property);
   let results = (outs);
   let assemblyFormat = "attr-dict $property `:` type($property)";
+}
+
+def BindExplicitOp : SVOp<"bind.explicit", []> {
+  let summary = "indirect instantiation statement";
+  let description = [{
+    Indirectly instantiate a module in the context of another module.
+      This operation pairs with rtl.instance which tracks all information except
+      the emission point for the bind. Use this flavor of bind when the
+      instantiation location can be explicitly tracked.
+    See 23.11 of SV 2017 spec.
+  }];
+
+  let arguments = (ins FlatSymbolRefAttr:$bind);
+  let results = (outs);
+
+  let assemblyFormat = [{ $bind attr-dict }];
+
+  let extraClassDeclaration = [{
+    /// Lookup the instance for the bind.  This returns null on
+    /// invalid IR.
+    rtl::InstanceOp getReferencedInstance();
+  }];
+}
+
+
+def BindOp : SVOp<"bind", []> {
+  let summary = "indirect instantiation statement";
+  let description = [{
+    Indirectly instantiate a module in the context of another module.  This
+    implements all-instance module binding in system verilog.  This will
+    generate ".*" name binding, but not validate names.
+    See 23.11 of SV 2017 spec.
+  }];
+
+  let arguments = (ins StrAttr:$instanceName, 
+                       Confined<FlatSymbolRefAttr, [isModuleSymbol]>:$base, 
+                       Confined<FlatSymbolRefAttr, [isModuleSymbol]>:$child);
+  let results = (outs);
+
+  let assemblyFormat = [{$instanceName $base $child attr-dict}];
+
+  let extraClassDeclaration = [{
+    /// Lookup the module or extmodule for the src symbol.  This returns null on
+    /// invalid IR.
+    Operation *getReferencedModuleBase();
+
+    /// Lookup the module or extmodule for the dest symbol.  This returns null on
+    /// invalid IR.
+    Operation *getReferencedModuleChild();
+  }];
 }

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -44,6 +44,8 @@ public:
             ReadInterfaceSignalOp,
             // Verification statements.
             AssertOp, AssumeOp, CoverOp,
+            // Bind Statements
+            BindExplicitOp, BindOp,
             // Terminators.
             TypeDeclTerminatorOp>([&](auto expr) -> ResultType {
           return thisCast->visitSV(expr, args...);
@@ -114,6 +116,10 @@ public:
   HANDLE(AssertOp, Unhandled);
   HANDLE(AssumeOp, Unhandled);
   HANDLE(CoverOp, Unhandled);
+
+  // Bind statements.
+  HANDLE(BindExplicitOp, Unhandled);
+  HANDLE(BindOp, Unhandled);
 
   // Terminators.
   HANDLE(TypeDeclTerminatorOp, Unhandled);

--- a/lib/Dialect/RTL/RTLOps.cpp
+++ b/lib/Dialect/RTL/RTLOps.cpp
@@ -718,13 +718,6 @@ static LogicalResult verifyInstanceOpTypes(InstanceOp op,
 }
 
 static LogicalResult verifyInstanceOp(InstanceOp op) {
-  // Check that this instance is inside a module.
-  auto module = dyn_cast<RTLModuleOp>(op->getParentOp());
-  if (!module) {
-    op.emitOpError("should be embedded in an 'rtl.module'");
-    return failure();
-  }
-
   auto referencedModule = op.getReferencedModule();
   if (referencedModule == nullptr)
     return op.emitError("Cannot find module definition '")
@@ -746,7 +739,7 @@ static LogicalResult verifyInstanceOp(InstanceOp op) {
       return failure();
   }
 
-  // If the referenced moudle is internal, check that input and result types are
+  // If the referenced module is internal, check that input and result types are
   // consistent with the referenced module.
   if (!isa<RTLModuleOp>(referencedModule))
     return success();

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -44,6 +44,30 @@ LogicalResult sv::verifyInNonProceduralRegion(Operation *op) {
   return failure();
 }
 
+/// Returns the operation registered with the given symbol name with the regions
+/// of 'symbolTableOp'. recurse through nested regions which don't contain the
+/// symboltable trait. Returns nullptr if no valid symbol was found.
+static Operation* lookupSymbolInEx(Operation* symbolTableOp, StringRef symbol) {
+  Region &region = symbolTableOp->getRegion(0);
+  if (region.empty())
+    return nullptr;
+
+  // Look for a symbol with the given name.
+  Identifier symbolNameId = Identifier::get(SymbolTable::getSymbolAttrName(),
+                                            symbolTableOp->getContext());
+  for (Block &block : region)
+    for (Operation &nestedOp : block) {
+      auto nameAttr = nestedOp.getAttrOfType<StringAttr>(symbolNameId);
+      if (nameAttr && nameAttr.getValue() == symbol)
+        return &nestedOp;
+  if (!nestedOp.hasTrait<OpTrait::SymbolTable>() && nestedOp.getNumRegions()) {
+    if (auto* nop = lookupSymbolInEx(&nestedOp, symbol))
+    return nop;
+  }
+  }
+  return nullptr;
+}
+
 //===----------------------------------------------------------------------===//
 // ImplicitSSAName Custom Directive
 //===----------------------------------------------------------------------===//
@@ -932,6 +956,41 @@ LogicalResult PAssignOp::canonicalize(PAssignOp op, PatternRewriter &rewriter) {
   // Remove the wire.
   rewriter.eraseOp(op);
   return success();
+}
+
+//===----------------------------------------------------------------------===//
+// BindOp
+//===----------------------------------------------------------------------===//
+
+/// Lookup the module or extmodule for the symbol.  This returns null on
+/// invalid IR.
+Operation *BindOp::getReferencedModuleBase() {
+  auto topLevelModuleOp = (*this)->getParentOfType<ModuleOp>();
+  if (!topLevelModuleOp)
+    return nullptr;
+
+  return topLevelModuleOp.lookupSymbol(base());
+}
+
+/// Lookup the module or extmodule for the symbol.  This returns null on
+/// invalid IR.
+Operation *BindOp::getReferencedModuleChild() {
+  auto topLevelModuleOp = (*this)->getParentOfType<ModuleOp>();
+  if (!topLevelModuleOp)
+    return nullptr;
+
+  return topLevelModuleOp.lookupSymbol(child());
+}
+
+rtl::InstanceOp BindExplicitOp::getReferencedInstance() {
+  auto topLevelModuleOp = (*this)->getParentOfType<ModuleOp>();
+  if (!topLevelModuleOp)
+    return nullptr;
+
+  /// Lookup the instance for the symbol.  This returns null on
+  /// invalid IR.
+  auto inst = lookupSymbolInEx(topLevelModuleOp, bind());
+  return dyn_cast_or_null<rtl::InstanceOp>(inst);
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -160,3 +160,22 @@ rtl.module @test1(%arg0: i1, %arg1: i1, %arg8: i8) {
   // CHECK-NEXT: rtl.output
   rtl.output
 }
+
+//CHECK-LABEL: sv.bind "testinst" @test1 @test2
+//CHECK-NEXT: rtl.module.extern @test2
+sv.bind "testinst" @test1 @test2
+rtl.module.extern @test2(%arg0: i1, %arg1: i1, %arg8: i8)
+
+
+rtl.module.extern @ExternDestMod(%a: i1, %b: i2)
+rtl.module.extern @InternalDestMod(%a: i1, %b: i2)
+
+rtl.module @AB(%a: i1, %b: i2) -> () {
+  rtl.instance "whatever" sym @a1 @ExternDestMod(%a, %b) {doNotPrint=1}: (i1, i2) -> ()
+  rtl.instance "yo" sym @b1 @InternalDestMod(%a, %b) {doNotPrint=1} : (i1, i2) -> ()
+  rtl.output
+}
+
+sv.bind.explicit @a1
+sv.bind.explicit @b1
+sv.bind "instname" @AB @ExternDestMod

--- a/test/Dialect/SV/errors.mlir
+++ b/test/Dialect/SV/errors.mlir
@@ -141,3 +141,9 @@ rtl.module @Cover(%arg0: i1) {
   // expected-error @+1 {{sv.cover should be in a procedural region}}
   sv.cover %arg0: i1
 }
+
+// -----
+rtl.module.extern @test1(%arg0: i1, %arg1: i1, %arg8: i8)
+func @test2(%arg0: i1, %arg1: i1, %arg8: i8) { return }
+// expected-error @+1 {{'sv.bind' op attribute 'child' failed to satisfy constraint: flat symbol reference attribute is module like}}
+sv.bind "testinst" @test1 @test2


### PR DESCRIPTION
binds are remote instantiations of a module in another module.  This is modeled with bind.explicit, which takes the symbol of an instance.  The instance is marked with an attribute which prevents its verilog emission.  Where arguments to the instance are expressions, rather than things with names, temporary wires are created to give verilog-namable things to bind to.