### PR TITLE
[Python] Add generic connect API that works with builders.

### DIFF
--- a/integration_test/Bindings/Python/DesignEntry/connect.py
+++ b/integration_test/Bindings/Python/DesignEntry/connect.py
@@ -22,19 +22,14 @@ class Dummy:
 class Test:
 
   def construct(self):
+    # CHECK: %[[C0:.+]] = hw.constant 0
     const = hw.ConstantOp(types.i32, mlir.ir.IntegerAttr.get(types.i32, 0))
     dummy = Dummy()
-    inst = dummy.module.create("d", {"x": const.result})
-    try:
-      # CHECK: cannot connect from source of type
-      circt.connect(inst.y, None)
-    except TypeError as e:
-      print(e)
-    try:
-      # CHECK: cannot connect to destination of type
-      circt.connect(None, inst.x)
-    except TypeError as e:
-      print(e)
+    inst = dummy.module.create("d")
+    circt.connect(inst.x, inst.y)
+    circt.connect(inst.x, const)
+    circt.connect(inst.x, const.result)
+    # CHECK: hw.instance "d" @Dummy(%[[C0]])
 
 
 with mlir.ir.Context() as ctxt, mlir.ir.Location.unknown():
@@ -42,3 +37,4 @@ with mlir.ir.Context() as ctxt, mlir.ir.Location.unknown():
   m = mlir.ir.Module.create()
   with mlir.ir.InsertionPoint(m.body):
     Test()
+  print(m)

--- a/integration_test/Bindings/Python/DesignEntry/connect_errors.py
+++ b/integration_test/Bindings/Python/DesignEntry/connect_errors.py
@@ -25,13 +25,21 @@ class Test:
   def construct(self):
     const = hw.ConstantOp(types.i32, mlir.ir.IntegerAttr.get(types.i32, 0))
     dummy = Dummy()
-    dummy.module.create("d", {"x": const.result})
+    inst = dummy.module.create("d", {"x": const.result})
+    try:
+        # CHECK: cannot connect from source of type
+        circt.connect(inst.y, None)
+    except TypeError as e:
+        print(e)
+    try:
+        # CHECK: cannot connect to destination of type
+        circt.connect(None, inst.x)
+    except TypeError as e:
+        print(e)
 
 
 with mlir.ir.Context() as ctxt, mlir.ir.Location.unknown():
   circt.register_dialects(ctxt)
   m = mlir.ir.Module.create()
   with mlir.ir.InsertionPoint(m.body):
-    # CHECK: hw.module
     Test()
-  print(m)

--- a/integration_test/Bindings/Python/DesignEntry/connect_errors.py
+++ b/integration_test/Bindings/Python/DesignEntry/connect_errors.py
@@ -1,0 +1,37 @@
+# RUN: %PYTHON% %s | FileCheck %s
+
+import mlir
+import circt
+
+from circt.dialects import hw
+from circt.esi import types
+from circt.support import BackedgeBuilder
+
+
+@circt.module
+class Dummy:
+
+  def __init__(self):
+    self.x = circt.Input(types.i32)
+    self.y = circt.Output(types.i32)
+
+  def construct(self, x):
+    self.y.set(x)
+
+
+@circt.module
+class Test:
+
+  def construct(self):
+    const = hw.ConstantOp(types.i32, mlir.ir.IntegerAttr.get(types.i32, 0))
+    dummy = Dummy()
+    dummy.module.create("d", {"x": const.result})
+
+
+with mlir.ir.Context() as ctxt, mlir.ir.Location.unknown():
+  circt.register_dialects(ctxt)
+  m = mlir.ir.Module.create()
+  with mlir.ir.InsertionPoint(m.body):
+    # CHECK: hw.module
+    Test()
+  print(m)

--- a/integration_test/Bindings/Python/dialects/rtl.py
+++ b/integration_test/Bindings/Python/dialects/rtl.py
@@ -86,11 +86,11 @@ with Context() as ctx, Location.unknown():
 
       # CHECK: hw.instance "inst4" @two_inputs(%[[INST1_RESULT]], %[[INST1_RESULT]])
       inst4 = two_inputs.create(module, "inst4", {"a": inst1.a})
-      inst4.set_input_port("b", inst1.a)
+      circt.connect(inst4.b, inst1.a)
 
       # CHECK: %[[INST5_RESULT:.+]] = hw.instance "inst5" @MyWidget(%[[INST5_RESULT]])
       inst5 = op.create(module, "inst5")
-      inst5.set_input_port("my_input", inst5.my_output)
+      circt.connect(inst5.my_input, inst5.my_output)
 
       # CHECK: hw.instance "inst6" {{.*}} {BANKS = 2 : i64}
       one_input.create(module, "inst6", {"a": inst1.a}, parameters={"BANKS": 2})

--- a/integration_test/Bindings/Python/dialects/rtl_errors.py
+++ b/integration_test/Bindings/Python/dialects/rtl_errors.py
@@ -37,10 +37,10 @@ with Context() as ctx, Location.unknown():
     def instance_builder_body(module):
       constant_value = one_output.create(module, "inst1").a
 
-      # CHECK: unknown input port name b
+      # CHECK: unknown port name b
       try:
         inst2 = one_input.create(module, "inst2", {"a": constant_value})
-        inst2.set_input_port("b", None)
+        circt.connect(inst2.b, constant_value)
       except AttributeError as e:
         print(e)
 

--- a/lib/Bindings/Python/circt/design_entry.py
+++ b/lib/Bindings/Python/circt/design_entry.py
@@ -86,10 +86,19 @@ def connect(destination, source):
   if not isinstance(destination, BuilderValue):
     raise TypeError(
         f"cannot connect to destination of type {type(destination)}")
-  if not isinstance(source, BuilderValue):
+  if not isinstance(source, BuilderValue) and not isinstance(
+      source, mlir.ir.Value) and not (isinstance(source, mlir.ir.OpView) and
+                                      hasattr(source, "result")):
     raise TypeError(f"cannot connect from source of type {type(source)}")
   builder = destination.builder
   index = destination.index
-  builder.operation.operands[index] = source.value
+  if isinstance(source, BuilderValue):
+    value = source.value
+  elif isinstance(source, mlir.ir.Value):
+    value = source
+  elif isinstance(source, mlir.ir.OpView):
+    value = source.result
+
+  builder.operation.operands[index] = value
   if index in builder.backedges:
     builder.backedges[index].erase()

--- a/lib/Bindings/Python/circt/design_entry.py
+++ b/lib/Bindings/Python/circt/design_entry.py
@@ -83,3 +83,11 @@ def module(cls):
           body_builder=body_build)
 
   return __Module
+
+
+def connect(destination, source):
+  builder = destination.builder
+  index = destination.index
+  builder.operation.operands[index] = source.value
+  if index in builder.backedges:
+    builder.parent_module.remove_backedge(builder.backedges[index])

--- a/lib/Bindings/Python/circt/design_entry.py
+++ b/lib/Bindings/Python/circt/design_entry.py
@@ -6,7 +6,6 @@ from circt.dialects import hw
 from .support import BuilderValue, UnconnectedSignalError
 import circt
 
-
 import mlir.ir
 
 import atexit

--- a/lib/Bindings/Python/circt/support.py
+++ b/lib/Bindings/Python/circt/support.py
@@ -37,8 +37,9 @@ class BackedgeBuilder(AbstractContextManager):
     def erase(self):
       if self.erased:
         return
-      self.creator.edges.remove(self)
-      self.dummy_op.operation.erase()
+      if self in self.creator.edges:
+        self.creator.edges.remove(self)
+        self.dummy_op.operation.erase()
 
   def __init__(self):
     self.edges = set()

--- a/lib/Bindings/Python/circt/support.py
+++ b/lib/Bindings/Python/circt/support.py
@@ -61,3 +61,14 @@ class BackedgeBuilder(AbstractContextManager):
     if errors:
       errors.insert(0, "Uninitialized ports remain in circuit!")
       raise RuntimeError("\n".join(errors))
+
+
+class BuilderValue:
+  """Class that holds a value, as well as builder and index of this value in
+     the operand or result list. This can represent an OpOperand and index into
+     OpOperandList or a OpResult and index into an OpResultList"""
+
+  def __init__(self, value, builder, index):
+    self.value = value
+    self.builder = builder
+    self.index = index


### PR DESCRIPTION
This adds `circt.connect` to "connect" two values. It sets the
destination OpOperand to the new value.

To integrate with the builder approach, this updates the
InstanceBuilder to return a wrapper BuilderValue around any Values
accessed through `__getattr__`. This works with the connect API to
pass around the needed index to ultimately set the Value and erase any
temporary backedges the builder created.

As the builder approach is generalized to other ops, the connect API
should work in exactly the same manner.