### PR TITLE
[Python] Set a default context (and location) upon import

### DIFF
--- a/lib/Bindings/Python/circt/__init__.py
+++ b/lib/Bindings/Python/circt/__init__.py
@@ -4,4 +4,3 @@
 
 # Simply a wrapper around the extension module of the same name.
 from _circt import *
-from .design_entry import *

--- a/lib/Bindings/Python/circt/design_entry.py
+++ b/lib/Bindings/Python/circt/design_entry.py
@@ -4,8 +4,32 @@
 
 from circt.dialects import hw
 from .support import UnconnectedSignalError
+import circt
 
 import mlir.ir
+
+import atexit
+
+# Push a default context onto the context stack at import time.
+DefaultContext = mlir.ir.Context()
+DefaultContext.__enter__()
+circt.register_dialects(DefaultContext)
+
+
+@atexit.register
+def __exit_ctxt():
+  DefaultContext.__exit__(None, None, None)
+
+
+# Until we get source location based on Python stack traces, default to unknown
+# locations.
+DefaultLocation = mlir.ir.Location.unknown()
+DefaultLocation.__enter__()
+
+
+@atexit.register
+def __exit_loc():
+  DefaultLocation.__exit__(None, None, None)
 
 
 class Output:


### PR DESCRIPTION
The most common use case for the `circt.design_entry` API is that a single
context is used throughout the lifetime of the application. This creates a
default context and default location and installs them into the defaults stack.

Since we don't want this behavior whenever someone imports circt, don't import
`design_entry` into the `circt` namespace.