### PR TITLE
[FIRRTL][LowerTypes] Report the op when missing a bundle lowering

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -1074,6 +1074,7 @@ Value TypeLoweringVisitor::getBundleLowering(Value oldValue,
                                              StringRef flatField) {
   auto flatFieldId = builder->getIdentifier(flatField);
   auto &entry = loweredBundleValues[ValueIdentifier(oldValue, flatFieldId)];
+#ifndef NDEBUG
   if (!entry) {
     {
       auto diag =
@@ -1083,6 +1084,7 @@ Value TypeLoweringVisitor::getBundleLowering(Value oldValue,
     }
     llvm::report_fatal_error("bundle lowering was not set");
   }
+#endif
   return entry;
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -1074,7 +1074,15 @@ Value TypeLoweringVisitor::getBundleLowering(Value oldValue,
                                              StringRef flatField) {
   auto flatFieldId = builder->getIdentifier(flatField);
   auto &entry = loweredBundleValues[ValueIdentifier(oldValue, flatFieldId)];
-  assert(entry && "bundle lowering was not set");
+  if (!entry) {
+    {
+      auto diag =
+          mlir::emitError(oldValue.getLoc(), "bundle lowering was not set");
+      if (auto op = oldValue.getDefiningOp())
+        diag.attachNote(op->getLoc()) << "see current operation: " << op;
+    }
+    llvm::report_fatal_error("bundle lowering was not set");
+  }
   return entry;
 }
 


### PR DESCRIPTION
This will print an error message when a bundle lowering does not exist. This is usually the result of missing support for a specific operation in the LowerTypes pass.  It is helpful to know what operation support is missing without having to start up the debugger.  In order for the error message to reliably print, multithreading must be disabled with: `--mlir-disable-threading`.

Example output:
```
./fieldtest.fir:6:5: error: bundle lowering was not set
    node n = in0
    ^
./fieldtest.fir:6:5: note: see current operation: %n = firrtl.node %arg0  : !firrtl.bundle<a: uint<1>>
LLVM ERROR: bundle lowering was not set
PLEASE submit a bug report to https://bugs.llvm.org/ and include the crash backtrace.
Stack dump:
0.	Program arguments: ./bin/firtool -mlir-disable-threading ./fieldtest.fir
```