### PR TITLE
[Py] Make BackedgeBuilder more general and keep a stack

### DIFF
--- a/integration_test/Bindings/Python/dialects/rtl_errors.py
+++ b/integration_test/Bindings/Python/dialects/rtl_errors.py
@@ -59,9 +59,9 @@ with Context() as ctx, Location.unknown():
 
       # Note, the error here is actually caught and printed below.
       # CHECK: Uninitialized ports remain in circuit!
-      # CHECK: Port:     %[[PORT_NAME:.+]]
-      # CHECK: Module:   hw.module @one_input(%[[PORT_NAME]]: i32)
-      # CHECK: Instance: hw.instance "inst1" @one_input({{.+}})
+      # CHECK: Port:       [[PORT_NAME:.+]]
+      # CHECK: InstanceOf: hw.module @one_input(%[[PORT_NAME]]: i32)
+      # CHECK: Instance:   hw.instance "inst1" @one_input({{.+}})
       inst1 = one_input.create(module, "inst1")
 
     try:

--- a/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
@@ -40,7 +40,7 @@ class InstanceBuilder:
         self.operand_values.append(input_port_mapping[arg_name])
       else:
         type = module.type.inputs[i]
-        backedge = BackedgeBuilder.current().create(
+        backedge = BackedgeBuilder.create(
             type, arg_name, self, instance_of=module)
         self.backedges[i] = backedge
         self.operand_values.append(backedge.result)

--- a/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
@@ -40,9 +40,10 @@ class InstanceBuilder:
         self.operand_values.append(input_port_mapping[arg_name])
       else:
         type = module.type.inputs[i]
-        backedge = self.parent_module.create_backedge(type, self)
+        backedge = self.parent_module.create_backedge(
+            type, arg_name, self, instance_of=module)
         self.backedges[i] = backedge
-        self.operand_values.append(backedge)
+        self.operand_values.append(backedge.result)
 
     result_names = ArrayAttr(module.attributes["resultNames"])
     for i in range(len(result_names)):
@@ -66,6 +67,11 @@ class InstanceBuilder:
         loc=loc,
         ip=ip,
     )
+
+  # To look like an OpView.
+  @property
+  def operation():
+    return self.instance
 
   def __getattr__(self, name):
     # Check for the attribute in the arg name set.
@@ -199,9 +205,9 @@ class ModuleLike:
                            loc=loc,
                            ip=ip)
 
-  def create_backedge(self, type, builder):
+  def create_backedge(self, *args, **kwargs):
     assert self.backedge_builder, "No backedge builder initialized."
-    return self.backedge_builder.create(type, builder)
+    return self.backedge_builder.create(*args, **kwargs)
 
   def remove_backedge(self, backedge):
     assert self.backedge_builder, "No backedge builder initialized."

--- a/lib/Bindings/Python/circt/support.py
+++ b/lib/Bindings/Python/circt/support.py
@@ -74,7 +74,7 @@ class BackedgeBuilder(AbstractContextManager):
       if edge.op_view is not None:
         op = edge.op_view.operation
         msg += "Instance:   " + str(op)
-      edge.op_view.operation.erase()
+        op.erase()
       edge.erase()
 
       # Clean up the IR and Python references.

--- a/lib/Bindings/Python/circt/support.py
+++ b/lib/Bindings/Python/circt/support.py
@@ -2,8 +2,14 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import mlir.ir as ir
+
 from contextlib import AbstractContextManager
+from contextvars import ContextVar
 from typing import List
+
+
+_current_backedge_builder = ContextVar("current_bb")
 
 
 class UnconnectedSignalError(RuntimeError):
@@ -14,48 +20,57 @@ class UnconnectedSignalError(RuntimeError):
 
 class BackedgeBuilder(AbstractContextManager):
 
+  class Edge:
+    def __init__(self, type: ir.Type, port_name: str,
+                 op_view, instance_of: ir.Operation):
+      self.dummy_op = ir.Operation.create("TemporaryBackedge", [type])
+      self.instance_of = instance_of
+      self.op_view = op_view
+      self.port_name = port_name
+
+    @property
+    def result(self):
+      return self.dummy_op.result
+
+    def erase(self):
+      self.dummy_op.operation.erase()
+
   def __init__(self):
-    self.edges = []
-    self.builders = {}
+    self.edges = set[BackedgeBuilder.Edge]()
+    self.old_bb_token = _current_backedge_builder.set(self)
 
-  def create(self, type, instance_builder):
-    from mlir.ir import Operation
+  @staticmethod
+  def current():
+    bb = _current_backedge_builder.get(None)
+    if bb is None:
+      raise RuntimeError("No backedge builder found in context!")
+    return bb
 
-    edge = Operation.create("TemporaryBackedge", [type]).result
-    self.edges.append(edge)
-    self.builders[id(edge)] = instance_builder
+  def create(self, type: ir.Type, port_name: str,
+             op_view, instance_of: ir.Operation = None):
+    edge = BackedgeBuilder.Edge(type, port_name, op_view, instance_of)
+    self.edges.add(edge)
     return edge
 
   def remove(self, edge):
     self.edges.remove(edge)
-    self.builders.pop(id(edge))
-    edge.owner.erase()
+    edge.erase()
 
   def __exit__(self, exc_type, exc_value, traceback):
+    _current_backedge_builder.reset(self.old_bb_token)
     errors = []
     for edge in self.edges:
-      # Build a nice error message about the uninitialized port.
-      builder = self.builders[id(edge)]
-      instance = builder.operation
-      module = builder.module
-
-      for i in range(len(instance.operands)):
-        if instance.operands[i] == edge:
-          from mlir.ir import ArrayAttr, StringAttr
-          arg_names = ArrayAttr(module.attributes["argNames"])
-          port_name = "%" + StringAttr(arg_names[i]).value
-
-      assert port_name, "Could not look up port name for backedge"
-
       # TODO: Make this use `UnconnectedSignalError`.
-      msg = "Port:     " + port_name + "\n"
-      msg += "Module:   " + str(module).split(" {")[0] + "\n"
-      msg += "Instance: " + str(instance)
+      msg = "Port:       " + edge.port_name + "\n"
+      if edge.instance_of is not None:
+        msg += "InstanceOf: " + str(edge.instance_of).split(" {")[0] + "\n"
+      if edge.op_view is not None:
+        op = edge.op_view.operation
+        msg += "Instance:   " + str(op)
+      edge.op_view.operation.erase()
+      edge.erase()
 
       # Clean up the IR and Python references.
-      instance.erase()
-      self.remove(edge)
-
       errors.append(msg)
 
     if errors:

--- a/lib/Bindings/Python/circt/support.py
+++ b/lib/Bindings/Python/circt/support.py
@@ -50,8 +50,12 @@ class BackedgeBuilder(AbstractContextManager):
       raise RuntimeError("No backedge builder found in context!")
     return bb
 
-  def create(self, type: ir.Type, port_name: str,
-             op_view, instance_of: ir.Operation = None):
+  @staticmethod
+  def create(*args, **kwargs):
+    return BackedgeBuilder.current()._create(*args, **kwargs)
+
+  def _create(self, type: ir.Type, port_name: str,
+              op_view, instance_of: ir.Operation = None):
     edge = BackedgeBuilder.Edge(self, type, port_name, op_view, instance_of)
     self.edges.add(edge)
     return edge


### PR DESCRIPTION
Divorces the support BackedgeBuilder from InstanceBuilder (so it can be used
elsewhere). Stores some extra information in the edge instead of digging it up
later in an InstanceBuilder-specific way.

Keep a stack of BackedgeBuilders in a contextvar. Provide a static method to
get the top.