### PR TITLE
[FIRRTL] LowerTypes: fix handing of mux ops

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -890,9 +890,17 @@ void TypeLoweringVisitor::visitExpr(SubindexOp op) {
 }
 
 void TypeLoweringVisitor::visitExpr(MuxPrimOp op) {
+  // Attempt to get the bundle types, potentially unwrapping an outer flip type
+  // that wraps the whole bundle.
+  FIRRTLType resultType = getCanonicalAggregateType(op.getType());
+
+  // If the wire is not a bundle, there is nothing to do.
+  if (!resultType)
+    return;
+
   // Get a string name for each result.
   SmallVector<FlatBundleFieldEntry, 8> fieldTypes;
-  flattenType(op.getType(), "", false, fieldTypes);
+  flattenType(resultType, "", false, fieldTypes);
 
   // Get each lhs value.
   SmallVector<std::pair<Value, bool>, 8> highValues;

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -415,6 +415,20 @@ module  {
 
 // -----
 
+// Check that a non-bundled mux ops are untouched.
+firrtl.circuit "Mux" {
+    // check-label: firrtl.module @Mux
+    firrtl.module @Mux(in %p: !firrtl.uint<1>, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) {
+      // check-next: %0 = firrtl.mux(%p, %a, %b) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+      // check-next: firrtl.connect %c, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+      %0 = firrtl.mux(%p, %a, %b) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+      firrtl.connect %c, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+    }
+}
+
+// -----
+
+
 firrtl.circuit "MuxBundle" {
     // CHECK-LABEL: firrtl.module @MuxBundle
     firrtl.module @MuxBundle(in %p: !firrtl.uint<1>, in %a: !firrtl.bundle<a: uint<1>>, in %b: !firrtl.bundle<a: uint<1>>, out %c: !firrtl.bundle<a: uint<1>>) {


### PR DESCRIPTION
Mux lowering forgot to check when the type was not a bundle, leading to
lots of crashes