### PR TITLE
[FIRRTL] Add new operation `BundleOp`

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -127,6 +127,35 @@ def InvalidValueOp : FIRRTLOp<"invalidvalue", [NoSideEffect]> {
   let assemblyFormat = "attr-dict `:` type($result)";
 }
 
+def BundleOp : FIRRTLOp<"bundle", [NoSideEffect]> {
+  let summary = "Create a bundle from constituent parts.";
+  let description = [{
+    This operation takes several values and combines them into a single
+    bundle value.
+
+    ```
+      %0 = firrtl.bundle %0, %1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
+    ```
+
+    Each operand must appear in the output bundle, and the type of each element
+    in the output bundle must match the type of operand. The name of each
+    bundle element is up to the user.
+
+    The result of the `firrtl.bundle` operation is always considered to have
+    source flow.  This means that the result can only appear on the right hand
+    side of a connect operation.
+
+    If an operand has Sink flow, it must be flipped in the output bundle.  If
+    an operand has Source flow, it must not be flipped in the output bundle. If
+    the operand has Duplex flow, then it can be either.
+  }];
+  let arguments = (ins Variadic<FIRRTLType>:$inputs);
+  let results = (outs BundleType:$result);
+  let assemblyFormat =
+    "$inputs attr-dict `:` functional-type($inputs, $result)";
+  let verifier = "return ::verifyBundleOp(*this);";
+}
+
 def SubfieldOp : FIRRTLExprOp<"subfield"> {
   let summary = "Extract a subfield of another value";
   let description = [{

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -30,6 +30,7 @@ public:
         // Basic Expressions
         .template Case<
             ConstantOp, InvalidValueOp, SubfieldOp, SubindexOp, SubaccessOp,
+            BundleOp,
             // Arithmetic and Logical Binary Primitives.
             AddPrimOp, SubPrimOp, MulPrimOp, DivPrimOp, RemPrimOp, AndPrimOp,
             OrPrimOp, XorPrimOp,
@@ -89,6 +90,7 @@ public:
   HANDLE(SubfieldOp, Unhandled);
   HANDLE(SubindexOp, Unhandled);
   HANDLE(SubaccessOp, Unhandled);
+  HANDLE(BundleOp, Unhandled);
 
   // Arithmetic and Logical Binary Primitives.
   HANDLE(AddPrimOp, Binary);

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -306,6 +306,42 @@ firrtl.circuit "BadAdd" {
 
 // -----
 
+firrtl.circuit "BadBundle" {
+  firrtl.module @BadBundle(in %x : !firrtl.uint<8>) {
+    // expected-error @+1 {{expected 1 operands, but got 0}}
+    %0 = firrtl.bundle : () -> !firrtl.bundle<a: flip<uint<8>>>
+  }
+}
+
+// -----
+
+firrtl.circuit "BadBundle" {
+  firrtl.module @BadBundle(in %x : !firrtl.uint<8>) {
+    // expected-error @+1 {{result element "a" should not be flipped}}
+    %0 = firrtl.bundle %x : (!firrtl.uint<8>) -> !firrtl.bundle<a: flip<uint<8>>>
+  }
+}
+
+// -----
+
+firrtl.circuit "BadBundle" {
+  firrtl.module @BadBundle(out %x : !firrtl.uint<8>) {
+    // expected-error @+1 {{result element "a" should be flipped}}
+    %0 = firrtl.bundle %x : (!firrtl.uint<8>) -> !firrtl.bundle<a: uint<8>>
+  }
+}
+
+// -----
+
+firrtl.circuit "BadBundle" {
+  firrtl.module @BadBundle(out %x : !firrtl.sint<42>) {
+    // expected-error @+1 {{result element "a" has a different type than than the operand}}
+    %0 = firrtl.bundle %x : (!firrtl.sint<42>) -> !firrtl.bundle<a: flip<uint<8>>>
+  }
+}
+
+// -----
+
 firrtl.circuit "NodeMustBePassive" {
   firrtl.module @Sub(in %a: !firrtl.uint<1>) {}
   firrtl.module @NodeMustBePassive() {

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -560,6 +560,19 @@ firrtl.circuit "ExternalModule" {
 }
 
 // -----
+firrtl.circuit "bundleop" {
+  firrtl.module @bundleop(in %x : !firrtl.bundle<a: flip<uint<8>>>, in %y : !firrtl.uint<8>) {
+    // check: %w_a_a = firrtl.wire  : !firrtl.uint<8>
+    // check: %w_b = firrtl.wire  : !firrtl.uint<8>
+    // check: firrtl.connect %x_a, %w_a_a : !firrtl.uint<8>, !firrtl.uint<8>
+    // check: firrtl.connect %w_b, %y : !firrtl.uint<8>, !firrtl.uint<8>
+    %w = firrtl.wire : !firrtl.bundle<a: bundle<a: flip<uint<8>>>, b: uint<8>>
+    %0 = firrtl.bundle %x, %y : (!firrtl.bundle<a: flip<uint<8>>>, !firrtl.uint<8>) -> !firrtl.bundle<a: bundle<a: flip<uint<8>>>, b: uint<8>>
+    firrtl.connect %w, %0 : !firrtl.bundle<a: bundle<a: flip<uint<8>>>, b: uint<8>>, !firrtl.bundle<a: bundle<a: flip<uint<8>>>, b: uint<8>>
+  }
+}
+
+// -----
 
 // Test RegResetOp lowering
 firrtl.circuit "LowerRegResetOp" {

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -307,6 +307,12 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.connect %xyz_in, %i8 : !firrtl.flip<uint<80>>, !firrtl.uint<8>
     xyz.in <= i8
 
+    ; CHECK: %tmp_w = firrtl.wire  : !firrtl.bundle<in: flip<uint<80>>>
+    wire tmp_w : {flip in: UInt<80> }
+    ; CHECK: [[BUNDLE:%.*]] = firrtl.bundle %xyz_in : (!firrtl.flip<uint<80>>) -> !firrtl.bundle<in: flip<uint<80>>>
+    ; CHECK: firrtl.connect %tmp_w, [[BUNDLE]] : !firrtl.bundle<in: flip<uint<80>>>, !firrtl.bundle<in: flip<uint<80>>>
+    tmp_w <= xyz
+
     ; CHECK: %myext_in, %myext_out = firrtl.instance @MyExtModule
     ; CHECK: {name = "myext"} :
     ; CHECK: !firrtl.flip<uint>, !firrtl.uint<8>
@@ -752,10 +758,13 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %U0_in0, %U0_in1, %U0_out0, %U0_out1 = firrtl.instance @mod_0_563
     inst U0 of mod_0_563
 
-    ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
-    ; CHECK: firrtl.connect %U0_in0, [[INV]]
-    ; CHECK: [[U0_IN1_A:%.+]] = firrtl.subfield %U0_in1("a")
-    ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
+    ; CHECK: [[BUNDLE:%.+]] = firrtl.bundle %U0_in0, %U0_in1, %U0_out0, %U0_out1
+    ; CHECK: [[U0_IN0:%.+]] = firrtl.subfield [[BUNDLE]]("in0")
+    ; CHECK: [[INV:%.+]] = firrtl.invalidvalue : !firrtl.uint<5>
+    ; CHECK: firrtl.connect [[U0_IN0]], [[INV]]
+    ; CHECK: [[U0_IN1:%.+]] = firrtl.subfield [[BUNDLE]]("in1")
+    ; CHECK: [[U0_IN1_A:%.+]] = firrtl.subfield [[U0_IN1]]("a")
+    ; CHECK: [[INV:%.+]] = firrtl.invalidvalue : !firrtl.uint<5>
     ; CHECK: firrtl.connect [[U0_IN1_A]], [[INV]]
     U0 is invalid
 

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -201,15 +201,6 @@ circuit circuit:
   module circuit :
     input in: UInt<80>
     inst xyz of circuit
-    node n = xyz
-    node m = n     ; expected-error {{expected '.' in field reference}}
-
-;// -----
-
-circuit circuit:
-  module circuit :
-    input in: UInt<80>
-    inst xyz of circuit
     node n = xyz.foo   ; expected-error {{use of invalid field name 'foo' on bundle value}}
 
 ;// -----


### PR DESCRIPTION
BundleOp is a new FIRRTL operation that takes several values and
combines them in to a single bundle.  This is primarily used to take the
multiple return values from an InstanceOp, and combine them in to a
single value which can be connected to or invalidated.

A follow on commit to this will simplify the handling of
emitInvalidate() in the FIRRTL parser.