### PR TITLE
[Python] Factor NamedValueBuilder out of InstanceBuilder, NFC.

### DIFF
--- a/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
@@ -2,7 +2,7 @@ from typing import Dict, Optional, Sequence
 
 import inspect
 
-from circt.support import BackedgeBuilder, BuilderValue, NamedValueBuilder
+from circt.support import BackedgeBuilder, NamedValueBuilder
 
 from mlir.ir import *
 
@@ -69,11 +69,6 @@ class InstanceBuilder(NamedValueBuilder):
     )
 
     super().__init__(instance, operand_indices, result_indices, backedges)
-
-  @property
-  def operation(self):
-    """Get the operation associated with this builder."""
-    return self.opview.operation
 
 
 class ModuleLike:

--- a/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
@@ -2,12 +2,12 @@ from typing import Dict, Optional, Sequence
 
 import inspect
 
-from circt.support import BackedgeBuilder, BuilderValue
+from circt.support import BackedgeBuilder, BuilderValue, NamedValueBuilder
 
 from mlir.ir import *
 
 
-class InstanceBuilder:
+class InstanceBuilder(NamedValueBuilder):
   """Helper class to incrementally construct an instance of a module."""
 
   def __init__(self,
@@ -23,77 +23,57 @@ class InstanceBuilder:
     from ._hw_ops_gen import InstanceOp
 
     # Create mappings from port name to value, index, and potentially backedge.
-    self.mod = module
-    self.operand_indices = {}
-    self.operand_values = []
-    self.result_indices = {}
-    self.backedges = {}
+    operand_indices = {}
+    operand_values = []
+    result_indices = {}
+    backedges = {}
 
     arg_names = ArrayAttr(module.attributes["argNames"])
     for i in range(len(arg_names)):
       arg_name = StringAttr(arg_names[i]).value
-      self.operand_indices[arg_name] = i
+      operand_indices[arg_name] = i
 
       if arg_name in input_port_mapping:
         value = input_port_mapping[arg_name]
         if not isinstance(value, Value):
           value = input_port_mapping[arg_name].value
-        self.operand_values.append(value)
+        operand_values.append(value)
       else:
         type = module.type.inputs[i]
         backedge = BackedgeBuilder.create(
             type, arg_name, self, instance_of=module)
-        self.backedges[i] = backedge
-        self.operand_values.append(backedge.result)
+        backedges[i] = backedge
+        operand_values.append(backedge.result)
 
     result_names = ArrayAttr(module.attributes["resultNames"])
     for i in range(len(result_names)):
       result_name = StringAttr(result_names[i]).value
-      self.result_indices[result_name] = i
+      result_indices[result_name] = i
 
     # Actually build the InstanceOp.
     instance_name = StringAttr.get(name)
-    module_name = FlatSymbolRefAttr.get(StringAttr(self.mod.name).value)
+    module_name = FlatSymbolRefAttr.get(StringAttr(module.name).value)
     parameters = {k: Attribute.parse(str(v)) for (k, v) in parameters.items()}
     parameters = DictAttr.get(parameters)
     if sym_name:
       sym_name = StringAttr.get(sym_name)
-    self.instance = InstanceOp(
-        self.mod.type.results,
+    instance = InstanceOp(
+        module.type.results,
         instance_name,
         module_name,
-        self.operand_values,
+        operand_values,
         parameters,
         sym_name,
         loc=loc,
         ip=ip,
     )
 
-  def __getattr__(self, name):
-    # Check for the attribute in the arg name set.
-    if name in self.operand_indices:
-      index = self.operand_indices[name]
-      value = self.instance.inputs[index]
-      return BuilderValue(value, self, index)
-
-    # Check for the attribute in the result name set.
-    if name in self.result_indices:
-      index = self.result_indices[name]
-      value = self.instance.results[index]
-      return BuilderValue(value, self, index)
-
-    # If we fell through to here, the name isn't a result.
-    raise AttributeError(f"unknown port name {name}")
+    super().__init__(instance, operand_indices, result_indices, backedges)
 
   @property
   def operation(self):
     """Get the operation associated with this builder."""
-    return self.instance.operation
-
-  @property
-  def module(self):
-    """Get the module associated with this builder."""
-    return self.mod.operation
+    return self.opview.operation
 
 
 class ModuleLike:

--- a/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
@@ -2,12 +2,12 @@ from typing import Dict, Optional, Sequence
 
 import inspect
 
-from circt.support import BackedgeBuilder, NamedValueBuilder
+from circt.support import BackedgeBuilder, NamedValueOpView
 
 from mlir.ir import *
 
 
-class InstanceBuilder(NamedValueBuilder):
+class InstanceBuilder(NamedValueOpView):
   """Helper class to incrementally construct an instance of a module."""
 
   def __init__(self,

--- a/lib/Bindings/Python/circt/support.py
+++ b/lib/Bindings/Python/circt/support.py
@@ -97,7 +97,7 @@ class BuilderValue:
     self.index = index
 
 
-class NamedValueBuilder:
+class NamedValueOpView:
   """Helper class to incrementally construct an instance of an operation that
      names its operands and results"""
 

--- a/lib/Bindings/Python/circt/support.py
+++ b/lib/Bindings/Python/circt/support.py
@@ -95,3 +95,30 @@ class BuilderValue:
     self.value = value
     self.builder = builder
     self.index = index
+
+
+class NamedValueBuilder:
+  """Helper class to incrementally construct an instance of an operation that
+     names its operands and results"""
+
+  def __init__(self, opview, operand_indices, result_indices, backedges):
+    self.opview = opview
+    self.operand_indices = operand_indices
+    self.result_indices = result_indices
+    self.backedges = backedges
+
+  def __getattr__(self, name):
+    # Check for the attribute in the arg name set.
+    if name in self.operand_indices:
+      index = self.operand_indices[name]
+      value = self.opview.inputs[index]
+      return BuilderValue(value, self, index)
+
+    # Check for the attribute in the result name set.
+    if name in self.result_indices:
+      index = self.result_indices[name]
+      value = self.opview.results[index]
+      return BuilderValue(value, self, index)
+
+    # If we fell through to here, the name isn't a result.
+    raise AttributeError(f"unknown port name {name}")

--- a/lib/Bindings/Python/circt/support.py
+++ b/lib/Bindings/Python/circt/support.py
@@ -111,7 +111,7 @@ class NamedValueBuilder:
     # Check for the attribute in the arg name set.
     if name in self.operand_indices:
       index = self.operand_indices[name]
-      value = self.opview.inputs[index]
+      value = self.opview.operands[index]
       return BuilderValue(value, self, index)
 
     # Check for the attribute in the result name set.
@@ -122,3 +122,8 @@ class NamedValueBuilder:
 
     # If we fell through to here, the name isn't a result.
     raise AttributeError(f"unknown port name {name}")
+
+  @property
+  def operation(self):
+    """Get the operation associated with this builder."""
+    return self.opview.operation


### PR DESCRIPTION
This adds a new base class to support named access to the operands and
results of an operation being built. Existing support in
InstanceBuilder is maintained and slightly cleaned up.

This sets the stage for other builders for ops that name their
operands and results, like seq.reg and a chunk of the comb dialect.