### PR TITLE
[FIRRTL] Handle registers and recursion during width inference

### DIFF
--- a/test/Dialect/FIRRTL/infer-widths-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-widths-errors.mlir
@@ -1,10 +1,24 @@
 // RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-infer-widths)' --verify-diagnostics --split-input-file %s
 
 firrtl.circuit "Foo" {
-  firrtl.module @Foo(in %clock : !firrtl.clock) {
-    // expected-error @+1 {{'firrtl.reg' op not supported in width inference}}
-    %0 = firrtl.reg %clock : (!firrtl.clock) -> !firrtl.uint<4>
+  firrtl.module @Foo(in %0: !firrtl.uint<4>) {
     %1 = firrtl.wire : !firrtl.uint
-    firrtl.connect %1, %0 : !firrtl.uint, !firrtl.uint<4>
+    // expected-error @+1 {{'firrtl.partialconnect' op not supported in width inference}}
+    firrtl.partialconnect %1, %0 : !firrtl.uint, !firrtl.uint<4>
+  }
+}
+
+// -----
+firrtl.circuit "Foo" {
+  firrtl.module @Foo(in %clk: !firrtl.clock, in %x: !firrtl.uint<6>) {
+    // expected-error @+1 {{'firrtl.reg' op is constrained to be wider than itself}}
+    %0 = firrtl.reg %clk : (!firrtl.clock) -> !firrtl.uint
+    // expected-note @+1 {{constrained width W >= W+3 here}}
+    %1 = firrtl.shl %0, 3 : (!firrtl.uint) -> !firrtl.uint
+    // expected-note @+1 {{constrained width W >= W+4 here}}
+    %2 = firrtl.shl %1, 1 : (!firrtl.uint) -> !firrtl.uint
+    // expected-note @+1 {{constrained width W >= 2W+4 here}}
+    %3 = firrtl.mul %0, %2 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    firrtl.connect %0, %3 : !firrtl.uint, !firrtl.uint
   }
 }

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -393,5 +393,46 @@ firrtl.circuit "Foo" {
     firrtl.connect %x, %0 : !firrtl.sint, !firrtl.sint
   }
 
+  // CHECK-LABEL: @RegSimple
+  firrtl.module @RegSimple(in %clk: !firrtl.clock, in %x: !firrtl.uint<6>) {
+    // CHECK: %0 = firrtl.reg %clk : (!firrtl.clock) -> !firrtl.uint<6>
+    // CHECK: %1 = firrtl.reg %clk : (!firrtl.clock) -> !firrtl.uint<6>
+    %0 = firrtl.reg %clk : (!firrtl.clock) -> !firrtl.uint
+    %1 = firrtl.reg %clk : (!firrtl.clock) -> !firrtl.uint
+    %2 = firrtl.wire : !firrtl.uint
+    %3 = firrtl.xor %1, %2 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    firrtl.connect %0, %x : !firrtl.uint, !firrtl.uint<6>
+    firrtl.connect %1, %3 : !firrtl.uint, !firrtl.uint
+    firrtl.connect %2, %x : !firrtl.uint, !firrtl.uint<6>
+  }
+
+  // CHECK-LABEL: @RegShr
+  firrtl.module @RegShr(in %clk: !firrtl.clock, in %x: !firrtl.uint<6>) {
+    // CHECK: %0 = firrtl.reg %clk : (!firrtl.clock) -> !firrtl.uint<6>
+    // CHECK: %1 = firrtl.reg %clk : (!firrtl.clock) -> !firrtl.uint<6>
+    %0 = firrtl.reg %clk : (!firrtl.clock) -> !firrtl.uint
+    %1 = firrtl.reg %clk : (!firrtl.clock) -> !firrtl.uint
+    %2 = firrtl.shr %0, 0 : (!firrtl.uint) -> !firrtl.uint
+    %3 = firrtl.shr %1, 3 : (!firrtl.uint) -> !firrtl.uint
+    firrtl.connect %0, %x : !firrtl.uint, !firrtl.uint<6>
+    firrtl.connect %1, %x : !firrtl.uint, !firrtl.uint<6>
+    firrtl.connect %0, %2 : !firrtl.uint, !firrtl.uint
+    firrtl.connect %1, %3 : !firrtl.uint, !firrtl.uint
+  }
+
+  // CHECK-LABEL: @RegShl
+  firrtl.module @RegShl(in %clk: !firrtl.clock, in %x: !firrtl.uint<6>) {
+    // CHECK: %0 = firrtl.reg %clk : (!firrtl.clock) -> !firrtl.uint<6>
+    %0 = firrtl.reg %clk : (!firrtl.clock) -> !firrtl.uint
+    %1 = firrtl.reg %clk : (!firrtl.clock) -> !firrtl.uint
+    %2 = firrtl.shl %0, 0 : (!firrtl.uint) -> !firrtl.uint
+    %3 = firrtl.shl %1, 3 : (!firrtl.uint) -> !firrtl.uint
+    %4 = firrtl.shr %3, 3 : (!firrtl.uint) -> !firrtl.uint
+    firrtl.connect %0, %x : !firrtl.uint, !firrtl.uint<6>
+    firrtl.connect %1, %x : !firrtl.uint, !firrtl.uint<6>
+    firrtl.connect %0, %2 : !firrtl.uint, !firrtl.uint
+    firrtl.connect %1, %4 : !firrtl.uint, !firrtl.uint
+  }
+
   firrtl.module @Foo() {}
 }


### PR DESCRIPTION
* Extend the `InferWidths` pass to properly support recursive constraints. This is actually pretty straightforward, because the recursion either leaves the constraint unaffected (e.g. x >= x-1), or it renderes the constraint unsatisfiable (e.g. x >= x+1). Thus, to compute an actual value for a width, recursions can just be ignored.

* Add a separate pass over the constraint expressions that analyses the recursions for unsatisfiability. This is the tricky part of the entire width inference process. This adds a `LinIneq` struct to represent a canonicalized linear inequality that may be recursive in a single variable. A depth-first pass over the constraint expressions recursively maps them to this canonicalized form, which mainly tracks three distinct aspects of an inequality: a recursive linear term, a non-recursive linear term, and trivial unsatisfiability. The various constraint expressions build different forms of this inequality, and operations such as `add`, `max`, and `min` can further combine them. The result is a single simplified expression for each free variable which indicates the constraints imposed on it that are dependent and independent of the variable itself. The constraint is unsatisfiable if the dependent part has a specific adverse structure. Otherwise it is satisfiable.

* An interesting side-effect that @lattner already suspected is that the information gathered as part of the unsatisfiability analysis (the `LinIneq` structure) may be sufficient to already determine the value to assign to a given free variable. The analysis currently runs on the generated constraint expression graph, but may at a later stage very well use the IR ops and use-def lists directly. Using the IR would render construction of a separate expression graph unnecessary and would make width inference simpler. There is more work required to make this possible, especially to bring width inference to par with the Scala implementation, and to more precisely track operations such as `min` in `LinIneq` -- it's currently just upper-bounded as `max`.

* While this commit specifically removes the bail-out on register ops, the actual implementation should be able to handle any kind of cyclic constraints, including wires and contra-connected modules.