### PR TITLE
[FIRRTL] Don't fold mux with unknown result width

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -23,8 +23,14 @@ def NonConstantOp : Constraint<CPred<"!$0.getDefiningOp<ConstantOp>()">>;
 // there are no FIRRTL annotation on an operation.
 def EmptyAttrDict : Constraint<CPred<"$0.empty()">>;
 
-// Constraint that enforces equal EqualTypes
+// Constraint that enforces equal types
 def EqualTypes : Constraint<CPred<"$0.getType() == $1.getType()">>;
+
+// Constraint that enforces types of known width
+def KnownWidth : Constraint<CPred<[{
+  $0.getType().isa<FIRRTLType>() &&
+    $0.getType().cast<FIRRTLType>().getBitWidthOrSentinel() >= 0
+  }]>>;
 
 // leq(const, x) -> geq(x, const)
 def LEQWithConstLHS : Pat<
@@ -53,17 +59,16 @@ def GTWithConstLHS : Pat<
 // mux(cond, x, mux(cond, y, z)) -> mux(cond, x, z)
 def MuxSameCondLow : Pat<
   (MuxPrimOp $cond, $x, (MuxPrimOp $cond, $y, $z)),
-  (MuxPrimOp $cond, $x, $z),
-  [(EqualTypes $x, $y),(EqualTypes $x, $z)]
-  >;
+  (MuxPrimOp $cond, $x, $z), [
+    (EqualTypes $x, $y), (EqualTypes $x, $z), (KnownWidth $x)
+  ]>;
 
 // mux(cond, mux(cond, y, z), x) -> mux(cond, y, x)
 def MuxSameCondHigh : Pat<
   (MuxPrimOp $cond, (MuxPrimOp $cond, $y, $z), $x),
-  (MuxPrimOp $cond, $y, $x),
-  [(EqualTypes $x, $y),(EqualTypes $x, $z)]
-
-  >;
+  (MuxPrimOp $cond, $y, $x), [
+    (EqualTypes $x, $y), (EqualTypes $x, $z), (KnownWidth $x)
+  ]>;
 
 // node(x, name, {}) -> x
 def EmptyNode : Pat<


### PR DESCRIPTION
Fix an issue around mux canonicalization where folding a mux to one of its operands can result in invalidation of subsequent IR if the mux result does not have a known width. For example, picking an unsized constant can lead to the constant resolving to a width more narrow than assumed in the remaining IR. This change refuses to fold and canonicalize any multiplexers that have unkown result width.

Fixes #1142.