### PR TITLE
[CI] Update CMake flag to enable building MLIR Python bindings.

### DIFF
--- a/.github/workflows/nightlyIntegrationTests.yml
+++ b/.github/workflows/nightlyIntegrationTests.yml
@@ -35,12 +35,12 @@ jobs:
         uses: actions/cache@v2
         with:
           path: llvm
-          key: ${{ runner.os }}-llvm-sharedlibs-python-${{ steps.get-llvm-hash.outputs.hash }}
+          key: ${{ runner.os }}-llvm-python-${{ steps.get-llvm-hash.outputs.hash }}
 
       # Build LLVM if we didn't hit in the cache.
       - name: Rebuild and Install LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
-        run: utils/build-llvm.sh build install Release -DMLIR_BINDINGS_PYTHON_ENABLED=ON
+        run: utils/build-llvm.sh build install Release -DMLIR_ENABLE_BINDINGS_PYTHON=ON
 
   # Build CIRCT and run its tests using a Docker container with all the
   # integration testing prerequisite installed.
@@ -92,12 +92,12 @@ jobs:
         uses: actions/cache@v2
         with:
           path: llvm
-          key: ${{ runner.os }}-llvm-sharedlibs-python-${{ steps.get-llvm-hash.outputs.hash }}
+          key: ${{ runner.os }}-llvm-python-${{ steps.get-llvm-hash.outputs.hash }}
 
       # Build LLVM if we didn't hit in the cache.
       - name: Rebuild and Install LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
-        run: utils/build-llvm.sh build install Release -DMLIR_BINDINGS_PYTHON_ENABLED=ON
+        run: utils/build-llvm.sh build install Release -DMLIR_ENABLE_BINDINGS_PYTHON=ON
 
       # --------
       # Build and test CIRCT

--- a/docs/PythonBindings.md
+++ b/docs/PythonBindings.md
@@ -4,7 +4,7 @@ If you are mainly interested in using CIRCT from Python scripts, you need to com
 
 ```
 # in the LLVM/MLIR build directory
-cmake [...] -DMLIR_BINDINGS_PYTHON_ENABLED=ON
+cmake [...] -DMLIR_ENABLE_BINDINGS_PYTHON=ON
 
 # in the CIRCT build directory
 cmake [...] -DCIRCT_BINDINGS_PYTHON_ENABLED=ON


### PR DESCRIPTION
This flag has been renamed upstream.

Fixes https://github.com/llvm/circt/issues/1151.