### PR TITLE
[Python] Add NamedValueOpView builders for the Comb dialect.

### DIFF
--- a/integration_test/Bindings/Python/dialects/comb.py
+++ b/integration_test/Bindings/Python/dialects/comb.py
@@ -1,0 +1,31 @@
+# REQUIRES: bindings_python
+# RUN: %PYTHON% %s | FileCheck %s
+
+import circt
+from circt.design_entry import connect
+from circt.dialects import comb, hw
+
+from mlir.ir import Context, Location, InsertionPoint, IntegerType, IntegerAttr, Module
+
+with Context() as ctx, Location.unknown():
+  circt.register_dialects(ctx)
+
+  i32 = IntegerType.get_signless(32)
+
+  m = Module.create()
+  with InsertionPoint(m.body):
+
+    def build(module):
+      # CHECK: %[[CONST:.+]] = hw.constant 1 : i32
+      const = hw.ConstantOp(i32, IntegerAttr.get(i32, 1))
+
+      # CHECK: comb.divs %[[CONST]], %[[CONST]]
+      comb.DivSOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      # CHECK: comb.divs %[[CONST]], %[[CONST]]
+      divs = comb.DivSOp.create(i32)
+      connect(divs.lhs, const.result)
+      connect(divs.rhs, const.result)
+
+    hw.HWModuleOp(name="test", body_builder=build)
+
+  print(m)

--- a/integration_test/Bindings/Python/dialects/comb.py
+++ b/integration_test/Bindings/Python/dialects/comb.py
@@ -26,6 +26,115 @@ with Context() as ctx, Location.unknown():
       connect(divs.lhs, const.result)
       connect(divs.rhs, const.result)
 
+      # CHECK: comb.divu %[[CONST]], %[[CONST]]
+      comb.DivUOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      # CHECK: comb.divu %[[CONST]], %[[CONST]]
+      divu = comb.DivUOp.create(i32)
+      connect(divu.lhs, const.result)
+      connect(divu.rhs, const.result)
+
+      # CHECK: comb.mods %[[CONST]], %[[CONST]]
+      comb.ModSOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      # CHECK: comb.mods %[[CONST]], %[[CONST]]
+      mods = comb.ModSOp.create(i32)
+      connect(mods.lhs, const.result)
+      connect(mods.rhs, const.result)
+
+      # CHECK: comb.modu %[[CONST]], %[[CONST]]
+      comb.ModUOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      # CHECK: comb.modu %[[CONST]], %[[CONST]]
+      modu = comb.ModUOp.create(i32)
+      connect(modu.lhs, const.result)
+      connect(modu.rhs, const.result)
+
+      # CHECK: comb.shl %[[CONST]], %[[CONST]]
+      comb.ShlOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      # CHECK: comb.shl %[[CONST]], %[[CONST]]
+      shl = comb.ShlOp.create(i32)
+      connect(shl.lhs, const.result)
+      connect(shl.rhs, const.result)
+
+      # CHECK: comb.shrs %[[CONST]], %[[CONST]]
+      comb.ShrSOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      # CHECK: comb.shrs %[[CONST]], %[[CONST]]
+      shrs = comb.ShrSOp.create(i32)
+      connect(shrs.lhs, const.result)
+      connect(shrs.rhs, const.result)
+
+      # CHECK: comb.shru %[[CONST]], %[[CONST]]
+      comb.ShrUOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      # CHECK: comb.shru %[[CONST]], %[[CONST]]
+      shru = comb.ShrUOp.create(i32)
+      connect(shru.lhs, const.result)
+      connect(shru.rhs, const.result)
+
+      # CHECK: comb.sub %[[CONST]], %[[CONST]]
+      comb.SubOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      # CHECK: comb.sub %[[CONST]], %[[CONST]]
+      sub = comb.SubOp.create(i32)
+      connect(sub.lhs, const.result)
+      connect(sub.rhs, const.result)
+
+      # CHECK: comb.icmp eq %[[CONST]], %[[CONST]]
+      comb.EqOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      eq = comb.EqOp.create(i32)
+      connect(eq.lhs, const.result)
+      connect(eq.rhs, const.result)
+
+      # CHECK: comb.icmp ne %[[CONST]], %[[CONST]]
+      comb.NeOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      ne = comb.NeOp.create(i32)
+      connect(ne.lhs, const.result)
+      connect(ne.rhs, const.result)
+
+      # CHECK: comb.icmp slt %[[CONST]], %[[CONST]]
+      comb.LtSOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      lts = comb.LtSOp.create(i32)
+      connect(lts.lhs, const.result)
+      connect(lts.rhs, const.result)
+
+      # CHECK: comb.icmp sle %[[CONST]], %[[CONST]]
+      comb.LeSOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      les = comb.LeSOp.create(i32)
+      connect(les.lhs, const.result)
+      connect(les.rhs, const.result)
+
+      # CHECK: comb.icmp sgt %[[CONST]], %[[CONST]]
+      comb.GtSOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      gts = comb.GtSOp.create(i32)
+      connect(gts.lhs, const.result)
+      connect(gts.rhs, const.result)
+
+      # CHECK: comb.icmp sge %[[CONST]], %[[CONST]]
+      comb.GeSOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      ges = comb.GeSOp.create(i32)
+      connect(ges.lhs, const.result)
+      connect(ges.rhs, const.result)
+
+      # CHECK: comb.icmp ult %[[CONST]], %[[CONST]]
+      comb.LtUOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      ltu = comb.LtUOp.create(i32)
+      connect(ltu.lhs, const.result)
+      connect(ltu.rhs, const.result)
+
+      # CHECK: comb.icmp ule %[[CONST]], %[[CONST]]
+      comb.LeUOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      leu = comb.LeUOp.create(i32)
+      connect(leu.lhs, const.result)
+      connect(leu.rhs, const.result)
+
+      # CHECK: comb.icmp ugt %[[CONST]], %[[CONST]]
+      comb.GtUOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      gtu = comb.GtUOp.create(i32)
+      connect(gtu.lhs, const.result)
+      connect(gtu.rhs, const.result)
+
+      # CHECK: comb.icmp uge %[[CONST]], %[[CONST]]
+      comb.GeUOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      geu = comb.GeUOp.create(i32)
+      connect(geu.lhs, const.result)
+      connect(geu.rhs, const.result)
+
     hw.HWModuleOp(name="test", body_builder=build)
 
   print(m)

--- a/integration_test/Bindings/Python/dialects/comb.py
+++ b/integration_test/Bindings/Python/dialects/comb.py
@@ -19,6 +19,24 @@ with Context() as ctx, Location.unknown():
       # CHECK: %[[CONST:.+]] = hw.constant 1 : i32
       const = hw.ConstantOp(i32, IntegerAttr.get(i32, 1))
 
+      # CHECK: comb.extract %[[CONST]] from 14
+      comb.ExtractOp.create(14, i32, {"input": const.result})
+      # CHECK: comb.extract %[[CONST]] from 14
+      extract = comb.ExtractOp.create(14, i32)
+      connect(extract.input, const.result)
+
+      # CHECK: comb.parity %[[CONST]]
+      comb.ParityOp.create(i32, {"input": const.result})
+      # CHECK: comb.parity %[[CONST]]
+      parity = comb.ParityOp.create(i32)
+      connect(parity.input, const.result)
+
+      # CHECK: comb.sext %[[CONST]]
+      comb.SExtOp.create(i32, {"input": const.result})
+      # CHECK: comb.sext %[[CONST]]
+      sext = comb.SExtOp.create(i32)
+      connect(sext.input, const.result)
+
       # CHECK: comb.divs %[[CONST]], %[[CONST]]
       comb.DivSOp.create(i32, {"lhs": const.result, "rhs": const.result})
       # CHECK: comb.divs %[[CONST]], %[[CONST]]

--- a/lib/Bindings/Python/circt/dialects/_comb_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_comb_ops_ext.py
@@ -1,0 +1,17 @@
+from circt.support import NamedValueOpView
+
+
+class BinaryOpBuider(NamedValueOpView):
+
+  def operand_names(self):
+    return ["lhs", "rhs"]
+
+  def result_names(self):
+    return ["result"]
+
+
+class DivSOp:
+
+  @classmethod
+  def create(cls, *args, **kwargs):
+    return BinaryOpBuider(cls, *args, **kwargs)

--- a/lib/Bindings/Python/circt/dialects/_comb_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_comb_ops_ext.py
@@ -1,5 +1,26 @@
 from circt.support import NamedValueOpView
 
+from mlir.ir import IntegerAttr, IntegerType
+
+
+# Builder base classes for non-variadic unary and binary ops.
+class UnaryOpBuilder(NamedValueOpView):
+
+  def operand_names(self):
+    return ["input"]
+
+  def result_names(self):
+    return ["result"]
+
+
+class ExtractOpBuilder(UnaryOpBuilder):
+
+  def __init__(self, low_bit, data_type, input_port_mapping={}, **kwargs):
+    low_bit = IntegerAttr.get(IntegerType.get_signless(32), low_bit)
+    import circt
+    super().__init__(circt.dialects.comb.ExtractOp, data_type,
+                     input_port_mapping, [], [low_bit], **kwargs)
+
 
 class BinaryOpBuilder(NamedValueOpView):
 
@@ -10,6 +31,29 @@ class BinaryOpBuilder(NamedValueOpView):
     return ["result"]
 
 
+# Sugar classes for the various non-variadic unary ops.
+class ExtractOp:
+
+  @staticmethod
+  def create(low_bit, *args, **kwargs):
+    return ExtractOpBuilder(low_bit, *args, **kwargs)
+
+
+class ParityOp:
+
+  @classmethod
+  def create(cls, *args, **kwargs):
+    return UnaryOpBuilder(cls, *args, **kwargs)
+
+
+class SExtOp:
+
+  @classmethod
+  def create(cls, *args, **kwargs):
+    return UnaryOpBuilder(cls, *args, **kwargs)
+
+
+# Sugar classes for the various non-variadic binary ops.
 class DivSOp:
 
   @classmethod

--- a/lib/Bindings/Python/circt/dialects/_comb_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_comb_ops_ext.py
@@ -1,3 +1,4 @@
+from circt.dialects import comb
 from circt.support import NamedValueOpView
 
 from mlir.ir import IntegerAttr, IntegerType
@@ -17,9 +18,8 @@ class ExtractOpBuilder(UnaryOpBuilder):
 
   def __init__(self, low_bit, data_type, input_port_mapping={}, **kwargs):
     low_bit = IntegerAttr.get(IntegerType.get_signless(32), low_bit)
-    import circt
-    super().__init__(circt.dialects.comb.ExtractOp, data_type,
-                     input_port_mapping, [], [low_bit], **kwargs)
+    super().__init__(comb.ExtractOp, data_type, input_port_mapping, [],
+                     [low_bit], **kwargs)
 
 
 class BinaryOpBuilder(NamedValueOpView):

--- a/lib/Bindings/Python/circt/dialects/_comb_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_comb_ops_ext.py
@@ -14,6 +14,17 @@ class UnaryOpBuilder(NamedValueOpView):
     return ["result"]
 
 
+def UnaryOp(base):
+
+  class _Class(base):
+
+    @classmethod
+    def create(cls, *args, **kwargs):
+      return UnaryOpBuilder(cls, *args, **kwargs)
+
+  return _Class
+
+
 class ExtractOpBuilder(UnaryOpBuilder):
 
   def __init__(self, low_bit, data_type, input_port_mapping={}, **kwargs):
@@ -31,6 +42,17 @@ class BinaryOpBuilder(NamedValueOpView):
     return ["result"]
 
 
+def BinaryOp(base):
+
+  class _Class(base):
+
+    @classmethod
+    def create(cls, *args, **kwargs):
+      return BinaryOpBuilder(cls, *args, **kwargs)
+
+  return _Class
+
+
 # Sugar classes for the various non-variadic unary ops.
 class ExtractOp:
 
@@ -39,72 +61,52 @@ class ExtractOp:
     return ExtractOpBuilder(low_bit, *args, **kwargs)
 
 
+@UnaryOp
 class ParityOp:
-
-  @classmethod
-  def create(cls, *args, **kwargs):
-    return UnaryOpBuilder(cls, *args, **kwargs)
+  pass
 
 
+@UnaryOp
 class SExtOp:
-
-  @classmethod
-  def create(cls, *args, **kwargs):
-    return UnaryOpBuilder(cls, *args, **kwargs)
+  pass
 
 
 # Sugar classes for the various non-variadic binary ops.
+@BinaryOp
 class DivSOp:
-
-  @classmethod
-  def create(cls, *args, **kwargs):
-    return BinaryOpBuilder(cls, *args, **kwargs)
+  pass
 
 
+@BinaryOp
 class DivUOp:
-
-  @classmethod
-  def create(cls, *args, **kwargs):
-    return BinaryOpBuilder(cls, *args, **kwargs)
+  pass
 
 
+@BinaryOp
 class ModSOp:
-
-  @classmethod
-  def create(cls, *args, **kwargs):
-    return BinaryOpBuilder(cls, *args, **kwargs)
+  pass
 
 
+@BinaryOp
 class ModUOp:
-
-  @classmethod
-  def create(cls, *args, **kwargs):
-    return BinaryOpBuilder(cls, *args, **kwargs)
+  pass
 
 
+@BinaryOp
 class ShlOp:
-
-  @classmethod
-  def create(cls, *args, **kwargs):
-    return BinaryOpBuilder(cls, *args, **kwargs)
+  pass
 
 
+@BinaryOp
 class ShrSOp:
-
-  @classmethod
-  def create(cls, *args, **kwargs):
-    return BinaryOpBuilder(cls, *args, **kwargs)
+  pass
 
 
+@BinaryOp
 class ShrUOp:
-
-  @classmethod
-  def create(cls, *args, **kwargs):
-    return BinaryOpBuilder(cls, *args, **kwargs)
+  pass
 
 
+@BinaryOp
 class SubOp:
-
-  @classmethod
-  def create(cls, *args, **kwargs):
-    return BinaryOpBuilder(cls, *args, **kwargs)
+  pass

--- a/lib/Bindings/Python/circt/dialects/_comb_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_comb_ops_ext.py
@@ -1,7 +1,7 @@
 from circt.support import NamedValueOpView
 
 
-class BinaryOpBuider(NamedValueOpView):
+class BinaryOpBuilder(NamedValueOpView):
 
   def operand_names(self):
     return ["lhs", "rhs"]
@@ -14,4 +14,53 @@ class DivSOp:
 
   @classmethod
   def create(cls, *args, **kwargs):
-    return BinaryOpBuider(cls, *args, **kwargs)
+    return BinaryOpBuilder(cls, *args, **kwargs)
+
+
+class DivUOp:
+
+  @classmethod
+  def create(cls, *args, **kwargs):
+    return BinaryOpBuilder(cls, *args, **kwargs)
+
+
+class ModSOp:
+
+  @classmethod
+  def create(cls, *args, **kwargs):
+    return BinaryOpBuilder(cls, *args, **kwargs)
+
+
+class ModUOp:
+
+  @classmethod
+  def create(cls, *args, **kwargs):
+    return BinaryOpBuilder(cls, *args, **kwargs)
+
+
+class ShlOp:
+
+  @classmethod
+  def create(cls, *args, **kwargs):
+    return BinaryOpBuilder(cls, *args, **kwargs)
+
+
+class ShrSOp:
+
+  @classmethod
+  def create(cls, *args, **kwargs):
+    return BinaryOpBuilder(cls, *args, **kwargs)
+
+
+class ShrUOp:
+
+  @classmethod
+  def create(cls, *args, **kwargs):
+    return BinaryOpBuilder(cls, *args, **kwargs)
+
+
+class SubOp:
+
+  @classmethod
+  def create(cls, *args, **kwargs):
+    return BinaryOpBuilder(cls, *args, **kwargs)

--- a/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
@@ -12,7 +12,6 @@ class InstanceBuilder(support.NamedValueOpView):
   """Helper class to incrementally construct an instance of a module."""
 
   def __init__(self,
-               cls,
                module,
                name,
                input_port_mapping,
@@ -31,7 +30,7 @@ class InstanceBuilder(support.NamedValueOpView):
     pre_args = [instance_name, module_name]
     post_args = [parameters, sym_name]
 
-    super().__init__(cls,
+    super().__init__(hw.InstanceOp,
                      module.type.results,
                      input_port_mapping,
                      pre_args,
@@ -144,9 +143,7 @@ class ModuleLike:
              parameters: Dict[str, object] = {},
              loc=None,
              ip=None):
-    import circt
-    return InstanceBuilder(circt.dialects.hw.InstanceOp,
-                           self,
+    return InstanceBuilder(self,
                            name,
                            input_port_mapping,
                            parameters=parameters,

--- a/lib/Bindings/Python/circt/dialects/_seq_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_seq_ops_ext.py
@@ -1,53 +1,22 @@
 from circt.support import BackedgeBuilder, NamedValueOpView
 
-from mlir.ir import IntegerType, OpView, StringAttr, Value
+from mlir.ir import IntegerType, OpView, StringAttr
 
 
 class CompRegBuilder(NamedValueOpView):
-  INPUT_PORT_NAMES = ["input", "clk"]
 
-  def __init__(self,
-               data_type,
-               input_port_mapping={},
-               *,
-               reset=None,
-               reset_value=None,
-               name=None,
-               loc=None,
-               ip=None):
-    # Lazily import dependencies to avoid cyclic dependencies.
-    from ._seq_ops_gen import CompRegOp
+  def operand_names(self):
+    return ["input", "clk"]
 
-    backedges = {}
-    operand_indices = {}
-    operand_values = []
-    result_indices = {"data": 0}
-    for i in range(len(self.INPUT_PORT_NAMES)):
-      arg_name = self.INPUT_PORT_NAMES[i]
-      operand_indices[arg_name] = i
-      if arg_name in input_port_mapping:
-        value = input_port_mapping[arg_name]
-        if not isinstance(value, Value):
-          value = input_port_mapping[arg_name].value
-        operand = value
-      else:
-        i1 = IntegerType.get_signless(1)
-        operand_type = data_type if arg_name == "input" else i1
-        backedge = BackedgeBuilder.create(operand_type, arg_name, self)
-        backedges[i] = backedge
-        operand = backedge.result
-      operand_values.append(operand)
+  def result_names(self):
+    return ["data"]
 
-    compreg = CompRegOp(data_type,
-                        operand_values[0],
-                        operand_values[1],
-                        reset=reset,
-                        reset_value=reset_value,
-                        name=name,
-                        loc=loc,
-                        ip=ip)
-
-    super().__init__(compreg, operand_indices, result_indices, backedges)
+  def create_initial_value(self, index, data_type, arg_name):
+    if arg_name == "input":
+      operand_type = data_type
+    else:
+      operand_type = IntegerType.get_signless(1)
+    return BackedgeBuilder.create(operand_type, arg_name, self)
 
 
 class CompRegOp:
@@ -86,6 +55,6 @@ class CompRegOp:
         ),
     )
 
-  @staticmethod
-  def create(*args, **kwargs):
-    return CompRegBuilder(*args, **kwargs)
+  @classmethod
+  def create(cls, *args, **kwargs):
+    return CompRegBuilder(cls, *args, **kwargs)

--- a/lib/Bindings/Python/circt/dialects/comb.py
+++ b/lib/Bindings/Python/circt/dialects/comb.py
@@ -21,9 +21,8 @@ class ICmpOpBuilder(NamedValueOpView):
 
   def __init__(self, predicate, data_type, input_port_mapping={}, **kwargs):
     predicate = IntegerAttr.get(IntegerType.get_signless(64), predicate)
-    import circt
-    super().__init__(circt.dialects.comb.ICmpOp, data_type, input_port_mapping,
-                     [predicate], **kwargs)
+    super().__init__(ICmpOp, data_type, input_port_mapping, [predicate],
+                     **kwargs)
 
 
 class EqOp:

--- a/lib/Bindings/Python/circt/dialects/comb.py
+++ b/lib/Bindings/Python/circt/dialects/comb.py
@@ -25,78 +25,66 @@ class ICmpOpBuilder(NamedValueOpView):
                      **kwargs)
 
 
+def CompareOp(predicate):
+
+  def decorated(cls):
+
+    class _Class(cls):
+
+      @staticmethod
+      def create(*args, **kwargs):
+        return ICmpOpBuilder(predicate, *args, **kwargs)
+
+    return _Class
+
+  return decorated
+
+
+@CompareOp(0)
 class EqOp:
-
-  @staticmethod
-  def create(*args, **kwargs):
-    return ICmpOpBuilder(0, *args, **kwargs)
+  pass
 
 
-class EqOp:
-
-  @staticmethod
-  def create(*args, **kwargs):
-    return ICmpOpBuilder(0, *args, **kwargs)
-
-
+@CompareOp(1)
 class NeOp:
-
-  @staticmethod
-  def create(*args, **kwargs):
-    return ICmpOpBuilder(1, *args, **kwargs)
+  pass
 
 
+@CompareOp(2)
 class LtSOp:
-
-  @staticmethod
-  def create(*args, **kwargs):
-    return ICmpOpBuilder(2, *args, **kwargs)
+  pass
 
 
+@CompareOp(3)
 class LeSOp:
-
-  @staticmethod
-  def create(*args, **kwargs):
-    return ICmpOpBuilder(3, *args, **kwargs)
+  pass
 
 
+@CompareOp(4)
 class GtSOp:
-
-  @staticmethod
-  def create(*args, **kwargs):
-    return ICmpOpBuilder(4, *args, **kwargs)
+  pass
 
 
+@CompareOp(5)
 class GeSOp:
-
-  @staticmethod
-  def create(*args, **kwargs):
-    return ICmpOpBuilder(5, *args, **kwargs)
+  pass
 
 
+@CompareOp(6)
 class LtUOp:
-
-  @staticmethod
-  def create(*args, **kwargs):
-    return ICmpOpBuilder(6, *args, **kwargs)
+  pass
 
 
+@CompareOp(7)
 class LeUOp:
-
-  @staticmethod
-  def create(*args, **kwargs):
-    return ICmpOpBuilder(7, *args, **kwargs)
+  pass
 
 
+@CompareOp(8)
 class GtUOp:
-
-  @staticmethod
-  def create(*args, **kwargs):
-    return ICmpOpBuilder(8, *args, **kwargs)
+  pass
 
 
+@CompareOp(9)
 class GeUOp:
-
-  @staticmethod
-  def create(*args, **kwargs):
-    return ICmpOpBuilder(9, *args, **kwargs)
+  pass

--- a/lib/Bindings/Python/circt/dialects/comb.py
+++ b/lib/Bindings/Python/circt/dialects/comb.py
@@ -4,3 +4,100 @@
 
 # Generated tablegen dialects end up in the mlir.dialects package for now.
 from mlir.dialects._comb_ops_gen import *
+
+from circt.support import NamedValueOpView
+
+from mlir.ir import IntegerAttr, IntegerType
+
+
+# Sugar classes for the various possible verions of ICmpOp.
+class ICmpOpBuilder(NamedValueOpView):
+
+  def operand_names(self):
+    return ["lhs", "rhs"]
+
+  def result_names(self):
+    return ["result"]
+
+  def __init__(self, predicate, data_type, input_port_mapping={}, **kwargs):
+    predicate = IntegerAttr.get(IntegerType.get_signless(64), predicate)
+    import circt
+    super().__init__(circt.dialects.comb.ICmpOp, data_type, input_port_mapping,
+                     [predicate], **kwargs)
+
+
+class EqOp:
+
+  @staticmethod
+  def create(*args, **kwargs):
+    return ICmpOpBuilder(0, *args, **kwargs)
+
+
+class EqOp:
+
+  @staticmethod
+  def create(*args, **kwargs):
+    return ICmpOpBuilder(0, *args, **kwargs)
+
+
+class NeOp:
+
+  @staticmethod
+  def create(*args, **kwargs):
+    return ICmpOpBuilder(1, *args, **kwargs)
+
+
+class LtSOp:
+
+  @staticmethod
+  def create(*args, **kwargs):
+    return ICmpOpBuilder(2, *args, **kwargs)
+
+
+class LeSOp:
+
+  @staticmethod
+  def create(*args, **kwargs):
+    return ICmpOpBuilder(3, *args, **kwargs)
+
+
+class GtSOp:
+
+  @staticmethod
+  def create(*args, **kwargs):
+    return ICmpOpBuilder(4, *args, **kwargs)
+
+
+class GeSOp:
+
+  @staticmethod
+  def create(*args, **kwargs):
+    return ICmpOpBuilder(5, *args, **kwargs)
+
+
+class LtUOp:
+
+  @staticmethod
+  def create(*args, **kwargs):
+    return ICmpOpBuilder(6, *args, **kwargs)
+
+
+class LeUOp:
+
+  @staticmethod
+  def create(*args, **kwargs):
+    return ICmpOpBuilder(7, *args, **kwargs)
+
+
+class GtUOp:
+
+  @staticmethod
+  def create(*args, **kwargs):
+    return ICmpOpBuilder(8, *args, **kwargs)
+
+
+class GeUOp:
+
+  @staticmethod
+  def create(*args, **kwargs):
+    return ICmpOpBuilder(9, *args, **kwargs)


### PR DESCRIPTION
This refactors the NamedValueOpView to push all the complexity into a
shared constructor that works for a variety of ops like InstanceOp,
CompRegOp, and all of the non-variadic Comb ops.

To support this, subclasses must now define two hooks to retrieve the
list of operand names and result names. There is also a third hook to
create a backedge of an appropriate type for a given operand that was
left uninitialized. The default implementation works for ops that have
the same type for all operands.