### PR TITLE
[Python] Add a helper to create constants given a type and value.

### DIFF
--- a/integration_test/Bindings/Python/DesignEntry/connect.py
+++ b/integration_test/Bindings/Python/DesignEntry/connect.py
@@ -10,7 +10,7 @@ from circt.esi import types
 
 def build(mod, dummy_mod):
   # CHECK: %[[C0:.+]] = hw.constant 0
-  const = hw.ConstantOp(types.i32, mlir.ir.IntegerAttr.get(types.i32, 0))
+  const = hw.ConstantOp.create(types.i32, 0)
   inst = dummy_mod.create("d")
   connect(inst.x, inst.y)
   connect(inst.x, const)

--- a/integration_test/Bindings/Python/DesignEntry/connect_errors.py
+++ b/integration_test/Bindings/Python/DesignEntry/connect_errors.py
@@ -24,7 +24,7 @@ class Dummy:
 class Test:
 
   def construct(self, mod):
-    const = hw.ConstantOp(types.i32, mlir.ir.IntegerAttr.get(types.i32, 0))
+    const = hw.ConstantOp.create(types.i32, 0)
     dummy = Dummy()
     inst = dummy.module.create("d", {"x": const.result})
     try:

--- a/integration_test/Bindings/Python/DesignEntry/polynomial.py
+++ b/integration_test/Bindings/Python/DesignEntry/polynomial.py
@@ -32,8 +32,7 @@ class PolynomialCompute:
     taps: list[mlir.ir.Value] = list()
     runningPower: list[mlir.ir.Value] = list()
     for power, coeff in enumerate(self.__coefficients):
-      coeffVal = hw.ConstantOp(types.i32,
-                               mlir.ir.IntegerAttr.get(types.i32, coeff))
+      coeffVal = hw.ConstantOp.create(types.i32, coeff)
       if power == 0:
         newPartialSum = coeffVal.result
       else:
@@ -60,8 +59,7 @@ class PolynomialCompute:
 
 def build(top):
   i32 = mlir.ir.Type.parse("i32")
-  c23 = mlir.ir.IntegerAttr.get(i32, 23)
-  x = hw.ConstantOp(i32, c23)
+  x = hw.ConstantOp.create(i32, 23)
   poly = PolynomialCompute([62, 42, 6], x=x)
   hw.OutputOp([poly.y])
 

--- a/integration_test/Bindings/Python/dialects/msft.py
+++ b/integration_test/Bindings/Python/dialects/msft.py
@@ -31,8 +31,8 @@ with Context() as ctx, Location.unknown():
     msft.locate(inst.operation, "mem", devtype=msft.M20K, x=50, y=100, num=1)
     # CHECK: hw.instance "inst1" @MyWidget() {"loc:mem" = #msft.physloc<M20K, 50, 100, 1>, parameters = {}} : () -> ()
 
-    val = hw.ConstantOp(i32, IntegerAttr.get(i32, 14)).result
-    clk = hw.ConstantOp(i1, IntegerAttr.get(i1, 0)).result
+    val = hw.ConstantOp.create(i32, 14).result
+    clk = hw.ConstantOp.create(i1, 0).result
     reg = seq.reg(val, clk, name="MyLocatableRegister")
     msft.locate(reg.owner, "mem", devtype=msft.M20K, x=25, y=25, num=1)
     # CHECK: seq.compreg {{.+}} {"loc:mem" = #msft.physloc<M20K, 25, 25, 1>, name = "MyLocatableRegister"}

--- a/integration_test/Bindings/Python/dialects/rtl.py
+++ b/integration_test/Bindings/Python/dialects/rtl.py
@@ -74,7 +74,7 @@ with Context() as ctx, Location.unknown():
         name="one_output",
         output_ports=[("a", i32)],
         body_builder=lambda m: hw.OutputOp(
-            [hw.ConstantOp(i32, IntegerAttr.get(i32, 46)).result]),
+            [hw.ConstantOp.create(i32, 46).result]),
     )
     two_outputs = hw.HWModuleOp(
         name="two_outputs",

--- a/integration_test/Bindings/Python/dialects/rtl_errors.py
+++ b/integration_test/Bindings/Python/dialects/rtl_errors.py
@@ -26,7 +26,7 @@ with Context() as ctx, Location.unknown():
         name="one_output",
         output_ports=[("a", i32)],
         body_builder=lambda m: hw.OutputOp(
-            [hw.ConstantOp(i32, IntegerAttr.get(i32, 46)).result]),
+            [hw.ConstantOp.create(i32, 46).result]),
     )
     input_output = hw.HWModuleOp(
         name="input_output",
@@ -66,7 +66,7 @@ with Context() as ctx, Location.unknown():
       inst1 = one_input.create("inst1")
 
     try:
-      instance_builder_tests = hw.HWModuleOp(
-          name="instance_builder_tests", body_builder=instance_builder_body)
+      instance_builder_tests = hw.HWModuleOp(name="instance_builder_tests",
+                                             body_builder=instance_builder_body)
     except RuntimeError as e:
       print(e)

--- a/integration_test/Bindings/Python/dialects/seq.py
+++ b/integration_test/Bindings/Python/dialects/seq.py
@@ -22,9 +22,9 @@ with Context() as ctx, Location.unknown():
 
     def top(module):
       # CHECK: %[[RESET_VAL:.+]] = hw.constant 0
-      reg_reset = hw.ConstantOp(i32, IntegerAttr.get(i32, 0)).result
+      reg_reset = hw.ConstantOp.create(i32, 0).result
       # CHECK: %[[INPUT_VAL:.+]] = hw.constant 45
-      reg_input = hw.ConstantOp(i32, IntegerAttr.get(i32, 45)).result
+      reg_input = hw.ConstantOp.create(i32, 45).result
       # CHECK: %[[DATA_VAL:.+]] = seq.compreg %[[INPUT_VAL]], %clk, %rstn, %[[RESET_VAL]]
       reg = seq.CompRegOp(i32,
                           reg_input,
@@ -39,7 +39,7 @@ with Context() as ctx, Location.unknown():
       seq.reg(reg_input, module.clk, reset=module.rstn)
       # CHECK: %[[RESET_VALUE:.+]] = hw.constant 123
       # CHECK: seq.compreg %[[INPUT_VAL]], %clk, %rstn, %[[RESET_VALUE]]
-      custom_reset = hw.ConstantOp(i32, IntegerAttr.get(i32, 123)).result
+      custom_reset = hw.ConstantOp.create(i32, 123).result
       seq.reg(reg_input,
               module.clk,
               reset=module.rstn,

--- a/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
@@ -356,3 +356,10 @@ class HWModuleOp(ModuleLike):
 class HWModuleExternOp(ModuleLike):
   """Specialization for the HW module op class."""
   pass
+
+
+class ConstantOp:
+
+  @staticmethod
+  def create(data_type, value):
+    return hw.ConstantOp(data_type, IntegerAttr.get(data_type, value))


### PR DESCRIPTION
This still requires an explicit type from the end user, but it hides
the fact that an Attribute must be constructed under the hood.