### PR TITLE
[Python] Update all create methods to accept keyword arguments.

### DIFF
--- a/integration_test/Bindings/Python/DesignEntry/connect_errors.py
+++ b/integration_test/Bindings/Python/DesignEntry/connect_errors.py
@@ -26,7 +26,7 @@ class Test:
   def construct(self, mod):
     const = hw.ConstantOp.create(types.i32, 0)
     dummy = Dummy()
-    inst = dummy.module.create("d", {"x": const.result})
+    inst = dummy.module.create("d", x=const.result)
     try:
       # CHECK: cannot connect from source of type
       connect(inst.y, None)

--- a/integration_test/Bindings/Python/dialects/comb.py
+++ b/integration_test/Bindings/Python/dialects/comb.py
@@ -20,135 +20,135 @@ with Context() as ctx, Location.unknown():
       const = hw.ConstantOp(i32, IntegerAttr.get(i32, 1))
 
       # CHECK: comb.extract %[[CONST]] from 14
-      comb.ExtractOp.create(14, i32, {"input": const.result})
+      comb.ExtractOp.create(14, i32, input=const.result)
       # CHECK: comb.extract %[[CONST]] from 14
       extract = comb.ExtractOp.create(14, i32)
       connect(extract.input, const.result)
 
       # CHECK: comb.parity %[[CONST]]
-      comb.ParityOp.create(i32, {"input": const.result})
+      comb.ParityOp.create(i32, input=const.result)
       # CHECK: comb.parity %[[CONST]]
       parity = comb.ParityOp.create(i32)
       connect(parity.input, const.result)
 
       # CHECK: comb.sext %[[CONST]]
-      comb.SExtOp.create(i32, {"input": const.result})
+      comb.SExtOp.create(i32, input=const.result)
       # CHECK: comb.sext %[[CONST]]
       sext = comb.SExtOp.create(i32)
       connect(sext.input, const.result)
 
       # CHECK: comb.divs %[[CONST]], %[[CONST]]
-      comb.DivSOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      comb.DivSOp.create(i32, lhs=const.result, rhs=const.result)
       # CHECK: comb.divs %[[CONST]], %[[CONST]]
       divs = comb.DivSOp.create(i32)
       connect(divs.lhs, const.result)
       connect(divs.rhs, const.result)
 
       # CHECK: comb.divu %[[CONST]], %[[CONST]]
-      comb.DivUOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      comb.DivUOp.create(i32, lhs=const.result, rhs=const.result)
       # CHECK: comb.divu %[[CONST]], %[[CONST]]
       divu = comb.DivUOp.create(i32)
       connect(divu.lhs, const.result)
       connect(divu.rhs, const.result)
 
       # CHECK: comb.mods %[[CONST]], %[[CONST]]
-      comb.ModSOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      comb.ModSOp.create(i32, lhs=const.result, rhs=const.result)
       # CHECK: comb.mods %[[CONST]], %[[CONST]]
       mods = comb.ModSOp.create(i32)
       connect(mods.lhs, const.result)
       connect(mods.rhs, const.result)
 
       # CHECK: comb.modu %[[CONST]], %[[CONST]]
-      comb.ModUOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      comb.ModUOp.create(i32, lhs=const.result, rhs=const.result)
       # CHECK: comb.modu %[[CONST]], %[[CONST]]
       modu = comb.ModUOp.create(i32)
       connect(modu.lhs, const.result)
       connect(modu.rhs, const.result)
 
       # CHECK: comb.shl %[[CONST]], %[[CONST]]
-      comb.ShlOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      comb.ShlOp.create(i32, lhs=const.result, rhs=const.result)
       # CHECK: comb.shl %[[CONST]], %[[CONST]]
       shl = comb.ShlOp.create(i32)
       connect(shl.lhs, const.result)
       connect(shl.rhs, const.result)
 
       # CHECK: comb.shrs %[[CONST]], %[[CONST]]
-      comb.ShrSOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      comb.ShrSOp.create(i32, lhs=const.result, rhs=const.result)
       # CHECK: comb.shrs %[[CONST]], %[[CONST]]
       shrs = comb.ShrSOp.create(i32)
       connect(shrs.lhs, const.result)
       connect(shrs.rhs, const.result)
 
       # CHECK: comb.shru %[[CONST]], %[[CONST]]
-      comb.ShrUOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      comb.ShrUOp.create(i32, lhs=const.result, rhs=const.result)
       # CHECK: comb.shru %[[CONST]], %[[CONST]]
       shru = comb.ShrUOp.create(i32)
       connect(shru.lhs, const.result)
       connect(shru.rhs, const.result)
 
       # CHECK: comb.sub %[[CONST]], %[[CONST]]
-      comb.SubOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      comb.SubOp.create(i32, lhs=const.result, rhs=const.result)
       # CHECK: comb.sub %[[CONST]], %[[CONST]]
       sub = comb.SubOp.create(i32)
       connect(sub.lhs, const.result)
       connect(sub.rhs, const.result)
 
       # CHECK: comb.icmp eq %[[CONST]], %[[CONST]]
-      comb.EqOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      comb.EqOp.create(i32, lhs=const.result, rhs=const.result)
       eq = comb.EqOp.create(i32)
       connect(eq.lhs, const.result)
       connect(eq.rhs, const.result)
 
       # CHECK: comb.icmp ne %[[CONST]], %[[CONST]]
-      comb.NeOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      comb.NeOp.create(i32, lhs=const.result, rhs=const.result)
       ne = comb.NeOp.create(i32)
       connect(ne.lhs, const.result)
       connect(ne.rhs, const.result)
 
       # CHECK: comb.icmp slt %[[CONST]], %[[CONST]]
-      comb.LtSOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      comb.LtSOp.create(i32, lhs=const.result, rhs=const.result)
       lts = comb.LtSOp.create(i32)
       connect(lts.lhs, const.result)
       connect(lts.rhs, const.result)
 
       # CHECK: comb.icmp sle %[[CONST]], %[[CONST]]
-      comb.LeSOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      comb.LeSOp.create(i32, lhs=const.result, rhs=const.result)
       les = comb.LeSOp.create(i32)
       connect(les.lhs, const.result)
       connect(les.rhs, const.result)
 
       # CHECK: comb.icmp sgt %[[CONST]], %[[CONST]]
-      comb.GtSOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      comb.GtSOp.create(i32, lhs=const.result, rhs=const.result)
       gts = comb.GtSOp.create(i32)
       connect(gts.lhs, const.result)
       connect(gts.rhs, const.result)
 
       # CHECK: comb.icmp sge %[[CONST]], %[[CONST]]
-      comb.GeSOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      comb.GeSOp.create(i32, lhs=const.result, rhs=const.result)
       ges = comb.GeSOp.create(i32)
       connect(ges.lhs, const.result)
       connect(ges.rhs, const.result)
 
       # CHECK: comb.icmp ult %[[CONST]], %[[CONST]]
-      comb.LtUOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      comb.LtUOp.create(i32, lhs=const.result, rhs=const.result)
       ltu = comb.LtUOp.create(i32)
       connect(ltu.lhs, const.result)
       connect(ltu.rhs, const.result)
 
       # CHECK: comb.icmp ule %[[CONST]], %[[CONST]]
-      comb.LeUOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      comb.LeUOp.create(i32, lhs=const.result, rhs=const.result)
       leu = comb.LeUOp.create(i32)
       connect(leu.lhs, const.result)
       connect(leu.rhs, const.result)
 
       # CHECK: comb.icmp ugt %[[CONST]], %[[CONST]]
-      comb.GtUOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      comb.GtUOp.create(i32, lhs=const.result, rhs=const.result)
       gtu = comb.GtUOp.create(i32)
       connect(gtu.lhs, const.result)
       connect(gtu.rhs, const.result)
 
       # CHECK: comb.icmp uge %[[CONST]], %[[CONST]]
-      comb.GeUOp.create(i32, {"lhs": const.result, "rhs": const.result})
+      comb.GeUOp.create(i32, lhs=const.result, rhs=const.result)
       geu = comb.GeUOp.create(i32)
       connect(geu.lhs, const.result)
       connect(geu.rhs, const.result)

--- a/integration_test/Bindings/Python/dialects/msft.py
+++ b/integration_test/Bindings/Python/dialects/msft.py
@@ -27,7 +27,7 @@ with Context() as ctx, Location.unknown():
                         body_builder=lambda module: hw.OutputOp([]))
 
   with InsertionPoint.at_block_terminator(top.body.blocks[0]):
-    inst = op.create("inst1", {})
+    inst = op.create("inst1")
     msft.locate(inst.operation, "mem", devtype=msft.M20K, x=50, y=100, num=1)
     # CHECK: hw.instance "inst1" @MyWidget() {"loc:mem" = #msft.physloc<M20K, 50, 100, 1>, parameters = {}} : () -> ()
 

--- a/integration_test/Bindings/Python/dialects/rtl.py
+++ b/integration_test/Bindings/Python/dialects/rtl.py
@@ -95,10 +95,10 @@ with Context() as ctx, Location.unknown():
       inst1 = one_output.create("inst1")
 
       # CHECK: hw.instance "inst2" @one_input(%[[INST1_RESULT]])
-      inst2 = one_input.create("inst2", {"a": inst1.a})
+      inst2 = one_input.create("inst2", a=inst1.a)
 
       # CHECK: hw.instance "inst4" @two_inputs(%[[INST1_RESULT]], %[[INST1_RESULT]])
-      inst4 = two_inputs.create("inst4", {"a": inst1.a})
+      inst4 = two_inputs.create("inst4", a=inst1.a)
       connect(inst4.b, inst1.a)
 
       # CHECK: %[[INST5_RESULT:.+]] = hw.instance "inst5" @MyWidget(%[[INST5_RESULT]])
@@ -106,7 +106,7 @@ with Context() as ctx, Location.unknown():
       connect(inst5.my_input, inst5.my_output)
 
       # CHECK: hw.instance "inst6" {{.*}} {BANKS = 2 : i64}
-      one_input.create("inst6", {"a": inst1.a}, parameters={"BANKS": 2})
+      one_input.create("inst6", a=inst1.a, parameters={"BANKS": 2})
 
     instance_builder_tests = hw.HWModuleOp(name="instance_builder_tests",
                                            body_builder=instance_builder_body)

--- a/integration_test/Bindings/Python/dialects/rtl_errors.py
+++ b/integration_test/Bindings/Python/dialects/rtl_errors.py
@@ -40,7 +40,7 @@ with Context() as ctx, Location.unknown():
 
       # CHECK: unknown port name b
       try:
-        inst2 = one_input.create("inst2", {"a": constant_value})
+        inst2 = one_input.create("inst2", a=constant_value)
         connect(inst2.b, constant_value)
       except AttributeError as e:
         print(e)

--- a/integration_test/Bindings/Python/dialects/seq.py
+++ b/integration_test/Bindings/Python/dialects/seq.py
@@ -48,7 +48,7 @@ with Context() as ctx, Location.unknown():
       seq.reg(reg_input, module.clk, name="FuBar")
 
       # CHECK: seq.compreg %[[INPUT_VAL]], %clk {name = "reg1"}
-      reg1 = seq.CompRegOp.create(i32, {"clk": module.clk}, name="reg1")
+      reg1 = seq.CompRegOp.create(i32, clk=module.clk, name="reg1")
       connect(reg1.input, reg_input)
 
       # CHECK: seq.compreg %[[INPUT_VAL]], %clk {name = "reg2"}

--- a/lib/Bindings/Python/circt/dialects/_comb_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_comb_ops_ext.py
@@ -19,8 +19,8 @@ def UnaryOp(base):
   class _Class(base):
 
     @classmethod
-    def create(cls, *args, **kwargs):
-      return UnaryOpBuilder(cls, *args, **kwargs)
+    def create(cls, result_type, **kwargs):
+      return UnaryOpBuilder(cls, result_type, kwargs)
 
   return _Class
 
@@ -47,8 +47,8 @@ def BinaryOp(base):
   class _Class(base):
 
     @classmethod
-    def create(cls, *args, **kwargs):
-      return BinaryOpBuilder(cls, *args, **kwargs)
+    def create(cls, result_type, **kwargs):
+      return BinaryOpBuilder(cls, result_type, kwargs)
 
   return _Class
 
@@ -57,8 +57,8 @@ def BinaryOp(base):
 class ExtractOp:
 
   @staticmethod
-  def create(low_bit, *args, **kwargs):
-    return ExtractOpBuilder(low_bit, *args, **kwargs)
+  def create(low_bit, result_type, **kwargs):
+    return ExtractOpBuilder(low_bit, result_type, kwargs)
 
 
 @UnaryOp

--- a/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
@@ -139,13 +139,13 @@ class ModuleLike:
 
   def create(self,
              name: str,
-             input_port_mapping: Dict[str, Value] = {},
              parameters: Dict[str, object] = {},
              loc=None,
-             ip=None):
+             ip=None,
+             **kwargs):
     return InstanceBuilder(self,
                            name,
-                           input_port_mapping,
+                           kwargs,
                            parameters=parameters,
                            loc=loc,
                            ip=ip)

--- a/lib/Bindings/Python/circt/dialects/_seq_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_seq_ops_ext.py
@@ -56,5 +56,15 @@ class CompRegOp:
     )
 
   @classmethod
-  def create(cls, *args, **kwargs):
-    return CompRegBuilder(cls, *args, **kwargs)
+  def create(cls,
+             result_type,
+             reset=None,
+             reset_value=None,
+             name=None,
+             **kwargs):
+    return CompRegBuilder(cls,
+                          result_type,
+                          kwargs,
+                          reset=reset,
+                          reset_value=reset_value,
+                          name=name)

--- a/lib/Bindings/Python/circt/dialects/comb.py
+++ b/lib/Bindings/Python/circt/dialects/comb.py
@@ -32,8 +32,8 @@ def CompareOp(predicate):
     class _Class(cls):
 
       @staticmethod
-      def create(*args, **kwargs):
-        return ICmpOpBuilder(predicate, *args, **kwargs)
+      def create(result_type, **kwargs):
+        return ICmpOpBuilder(predicate, result_type, kwargs)
 
     return _Class
 

--- a/lib/Bindings/Python/circt/dialects/seq.py
+++ b/lib/Bindings/Python/circt/dialects/seq.py
@@ -5,6 +5,8 @@
 # Generated tablegen dialects end up in the mlir.dialects package for now.
 from mlir.dialects._seq_ops_gen import *
 
+from .seq import CompRegOp
+
 
 # Create a computational register whose input is the given value, and is clocked
 # by the given clock. If a reset is provided, the register will be reset by that
@@ -19,11 +21,12 @@ def reg(value, clock, reset=None, reset_value=None, name=None):
     if not reset_value:
       zero = IntegerAttr.get(value_type, 0)
       reset_value = hw.ConstantOp(value_type, zero).result
-    return CompRegOp(value_type,
-                     value,
-                     clock,
-                     reset=reset,
-                     reset_value=reset_value,
-                     name=name).result
+    return CompRegOp.create(value_type,
+                            input=value,
+                            clk=clock,
+                            reset=reset,
+                            reset_value=reset_value,
+                            name=name).data.value
   else:
-    return CompRegOp(value_type, value, clock, name=name).result
+    return CompRegOp.create(value_type, input=value, clk=clock,
+                            name=name).data.value


### PR DESCRIPTION
This makes the API more natural compared to an explicit dictionary of
input ports to set by name.