### PR TITLE
[Python] Infer or elide result type from create when unnecessary.

### DIFF
--- a/integration_test/Bindings/Python/dialects/comb.py
+++ b/integration_test/Bindings/Python/dialects/comb.py
@@ -38,118 +38,118 @@ with Context() as ctx, Location.unknown():
       connect(sext.input, const.result)
 
       # CHECK: comb.divs %[[CONST]], %[[CONST]]
-      comb.DivSOp.create(i32, lhs=const.result, rhs=const.result)
+      comb.DivSOp.create(lhs=const.result, rhs=const.result)
       # CHECK: comb.divs %[[CONST]], %[[CONST]]
       divs = comb.DivSOp.create(i32)
       connect(divs.lhs, const.result)
       connect(divs.rhs, const.result)
 
       # CHECK: comb.divu %[[CONST]], %[[CONST]]
-      comb.DivUOp.create(i32, lhs=const.result, rhs=const.result)
+      comb.DivUOp.create(lhs=const.result, rhs=const.result)
       # CHECK: comb.divu %[[CONST]], %[[CONST]]
       divu = comb.DivUOp.create(i32)
       connect(divu.lhs, const.result)
       connect(divu.rhs, const.result)
 
       # CHECK: comb.mods %[[CONST]], %[[CONST]]
-      comb.ModSOp.create(i32, lhs=const.result, rhs=const.result)
+      comb.ModSOp.create(lhs=const.result, rhs=const.result)
       # CHECK: comb.mods %[[CONST]], %[[CONST]]
       mods = comb.ModSOp.create(i32)
       connect(mods.lhs, const.result)
       connect(mods.rhs, const.result)
 
       # CHECK: comb.modu %[[CONST]], %[[CONST]]
-      comb.ModUOp.create(i32, lhs=const.result, rhs=const.result)
+      comb.ModUOp.create(lhs=const.result, rhs=const.result)
       # CHECK: comb.modu %[[CONST]], %[[CONST]]
       modu = comb.ModUOp.create(i32)
       connect(modu.lhs, const.result)
       connect(modu.rhs, const.result)
 
       # CHECK: comb.shl %[[CONST]], %[[CONST]]
-      comb.ShlOp.create(i32, lhs=const.result, rhs=const.result)
+      comb.ShlOp.create(lhs=const.result, rhs=const.result)
       # CHECK: comb.shl %[[CONST]], %[[CONST]]
       shl = comb.ShlOp.create(i32)
       connect(shl.lhs, const.result)
       connect(shl.rhs, const.result)
 
       # CHECK: comb.shrs %[[CONST]], %[[CONST]]
-      comb.ShrSOp.create(i32, lhs=const.result, rhs=const.result)
+      comb.ShrSOp.create(lhs=const.result, rhs=const.result)
       # CHECK: comb.shrs %[[CONST]], %[[CONST]]
       shrs = comb.ShrSOp.create(i32)
       connect(shrs.lhs, const.result)
       connect(shrs.rhs, const.result)
 
       # CHECK: comb.shru %[[CONST]], %[[CONST]]
-      comb.ShrUOp.create(i32, lhs=const.result, rhs=const.result)
+      comb.ShrUOp.create(lhs=const.result, rhs=const.result)
       # CHECK: comb.shru %[[CONST]], %[[CONST]]
       shru = comb.ShrUOp.create(i32)
       connect(shru.lhs, const.result)
       connect(shru.rhs, const.result)
 
       # CHECK: comb.sub %[[CONST]], %[[CONST]]
-      comb.SubOp.create(i32, lhs=const.result, rhs=const.result)
+      comb.SubOp.create(lhs=const.result, rhs=const.result)
       # CHECK: comb.sub %[[CONST]], %[[CONST]]
       sub = comb.SubOp.create(i32)
       connect(sub.lhs, const.result)
       connect(sub.rhs, const.result)
 
       # CHECK: comb.icmp eq %[[CONST]], %[[CONST]]
-      comb.EqOp.create(i32, lhs=const.result, rhs=const.result)
-      eq = comb.EqOp.create(i32)
+      comb.EqOp.create(lhs=const.result, rhs=const.result)
+      eq = comb.EqOp.create()
       connect(eq.lhs, const.result)
       connect(eq.rhs, const.result)
 
       # CHECK: comb.icmp ne %[[CONST]], %[[CONST]]
-      comb.NeOp.create(i32, lhs=const.result, rhs=const.result)
-      ne = comb.NeOp.create(i32)
+      comb.NeOp.create(lhs=const.result, rhs=const.result)
+      ne = comb.NeOp.create()
       connect(ne.lhs, const.result)
       connect(ne.rhs, const.result)
 
       # CHECK: comb.icmp slt %[[CONST]], %[[CONST]]
-      comb.LtSOp.create(i32, lhs=const.result, rhs=const.result)
-      lts = comb.LtSOp.create(i32)
+      comb.LtSOp.create(lhs=const.result, rhs=const.result)
+      lts = comb.LtSOp.create()
       connect(lts.lhs, const.result)
       connect(lts.rhs, const.result)
 
       # CHECK: comb.icmp sle %[[CONST]], %[[CONST]]
-      comb.LeSOp.create(i32, lhs=const.result, rhs=const.result)
-      les = comb.LeSOp.create(i32)
+      comb.LeSOp.create(lhs=const.result, rhs=const.result)
+      les = comb.LeSOp.create()
       connect(les.lhs, const.result)
       connect(les.rhs, const.result)
 
       # CHECK: comb.icmp sgt %[[CONST]], %[[CONST]]
-      comb.GtSOp.create(i32, lhs=const.result, rhs=const.result)
-      gts = comb.GtSOp.create(i32)
+      comb.GtSOp.create(lhs=const.result, rhs=const.result)
+      gts = comb.GtSOp.create()
       connect(gts.lhs, const.result)
       connect(gts.rhs, const.result)
 
       # CHECK: comb.icmp sge %[[CONST]], %[[CONST]]
-      comb.GeSOp.create(i32, lhs=const.result, rhs=const.result)
-      ges = comb.GeSOp.create(i32)
+      comb.GeSOp.create(lhs=const.result, rhs=const.result)
+      ges = comb.GeSOp.create()
       connect(ges.lhs, const.result)
       connect(ges.rhs, const.result)
 
       # CHECK: comb.icmp ult %[[CONST]], %[[CONST]]
-      comb.LtUOp.create(i32, lhs=const.result, rhs=const.result)
-      ltu = comb.LtUOp.create(i32)
+      comb.LtUOp.create(lhs=const.result, rhs=const.result)
+      ltu = comb.LtUOp.create()
       connect(ltu.lhs, const.result)
       connect(ltu.rhs, const.result)
 
       # CHECK: comb.icmp ule %[[CONST]], %[[CONST]]
-      comb.LeUOp.create(i32, lhs=const.result, rhs=const.result)
-      leu = comb.LeUOp.create(i32)
+      comb.LeUOp.create(lhs=const.result, rhs=const.result)
+      leu = comb.LeUOp.create()
       connect(leu.lhs, const.result)
       connect(leu.rhs, const.result)
 
       # CHECK: comb.icmp ugt %[[CONST]], %[[CONST]]
-      comb.GtUOp.create(i32, lhs=const.result, rhs=const.result)
-      gtu = comb.GtUOp.create(i32)
+      comb.GtUOp.create(lhs=const.result, rhs=const.result)
+      gtu = comb.GtUOp.create()
       connect(gtu.lhs, const.result)
       connect(gtu.rhs, const.result)
 
       # CHECK: comb.icmp uge %[[CONST]], %[[CONST]]
-      comb.GeUOp.create(i32, lhs=const.result, rhs=const.result)
-      geu = comb.GeUOp.create(i32)
+      comb.GeUOp.create(lhs=const.result, rhs=const.result)
+      geu = comb.GeUOp.create()
       connect(geu.lhs, const.result)
       connect(geu.rhs, const.result)
 

--- a/integration_test/Bindings/Python/dialects/comb_errors.py
+++ b/integration_test/Bindings/Python/dialects/comb_errors.py
@@ -1,0 +1,35 @@
+# REQUIRES: bindings_python
+# RUN: %PYTHON% %s | FileCheck %s
+
+import circt
+from circt.design_entry import connect
+from circt.dialects import comb, hw
+
+from mlir.ir import Context, Location, InsertionPoint, IntegerType, IntegerAttr, Module
+
+with Context() as ctx, Location.unknown():
+  circt.register_dialects(ctx)
+
+  i32 = IntegerType.get_signless(32)
+  i31 = IntegerType.get_signless(31)
+
+  m = Module.create()
+  with InsertionPoint(m.body):
+
+    def build(module):
+      const1 = hw.ConstantOp(i32, IntegerAttr.get(i32, 1))
+      const2 = hw.ConstantOp(i31, IntegerAttr.get(i31, 1))
+
+      # CHECK: expected same input port types, but received [Type(i32), Type(i31)]
+      try:
+        comb.DivSOp.create(lhs=const1.result, rhs=const2.result)
+      except TypeError as e:
+        print(e)
+
+      # CHECK: result type must be specified
+      try:
+        comb.DivSOp.create()
+      except TypeError as e:
+        print(e)
+
+    hw.HWModuleOp(name="test", body_builder=build)

--- a/lib/Bindings/Python/circt/dialects/_comb_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_comb_ops_ext.py
@@ -3,6 +3,8 @@ from circt.support import NamedValueOpView
 
 from mlir.ir import IntegerAttr, IntegerType
 
+from functools import reduce
+
 
 # Builder base classes for non-variadic unary and binary ops.
 class UnaryOpBuilder(NamedValueOpView):
@@ -47,7 +49,16 @@ def BinaryOp(base):
   class _Class(base):
 
     @classmethod
-    def create(cls, result_type, **kwargs):
+    def create(cls, result_type=None, **kwargs):
+      if not result_type:
+        types = list(map(lambda arg: arg.type, kwargs.values()))
+        if not types:
+          raise TypeError("result type must be specified")
+        all_equal = reduce(lambda t1, t2: t1 == t2, types)
+        if not all_equal:
+          raise TypeError(
+              f"expected same input port types, but received {types}")
+        result_type = types[0]
       return BinaryOpBuilder(cls, result_type, kwargs)
 
   return _Class

--- a/lib/Bindings/Python/circt/dialects/comb.py
+++ b/lib/Bindings/Python/circt/dialects/comb.py
@@ -32,7 +32,8 @@ def CompareOp(predicate):
     class _Class(cls):
 
       @staticmethod
-      def create(result_type, **kwargs):
+      def create(**kwargs):
+        result_type = IntegerType.get_signless(1)
         return ICmpOpBuilder(predicate, result_type, kwargs)
 
     return _Class


### PR DESCRIPTION
The comparators all return an i1, so we simply don't need a result
type there. The binary ops all have the SameOperandsAndResultType
trait, so we can check the operand types and infer the result type.