### PR TITLE
Grand Central Interface Support

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -43,6 +43,8 @@ std::unique_ptr<mlir::Pass>
 createBlackBoxReaderPass(llvm::Optional<StringRef> inputPrefix = {},
                          llvm::Optional<StringRef> resourcePrefix = {});
 
+std::unique_ptr<mlir::Pass> createGrandCentralPass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/FIRRTL/Passes.h.inc"

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -180,4 +180,14 @@ def PrintInstanceGraph
   let constructor =  "circt::firrtl::createPrintInstanceGraphPass()";
 }
 
+def GrandCentral : Pass<"firrtl-grand-central", "CircuitOp"> {
+  let summary = "Remove Grand Central Annotations";
+  let description = [{
+    Processes annotations associated with SiFive's Grand Central utility.
+  }];
+
+  let constructor = "circt::firrtl::createGrandCentralPass()";
+  let dependentDialects = ["circt::sv::SVDialect", "circt::hw::HWDialect"];
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_PASSES_TD

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -3,6 +3,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   BlackBoxReader.cpp
   CheckWidths.cpp
   ExpandWhens.cpp
+  GrandCentral.cpp
   IMConstProp.cpp
   InferWidths.cpp
   LowerTypes.cpp
@@ -14,6 +15,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
 
   LINK_LIBS PUBLIC
   CIRCTFIRRTL
+  CIRCTHW
   CIRCTSV
   CIRCTSupport
   MLIRIR

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -1,0 +1,500 @@
+//===- GrandCentral.cpp - Ingest black box sources --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//===----------------------------------------------------------------------===//
+//
+// Implement SiFive's Grand Central transform.  Currently, this supports
+// SystemVerilog Interface generation.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLAnnotations.h"
+#include "circt/Dialect/FIRRTL/FIRRTLVisitors.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "circt/Dialect/HW/HWDialect.h"
+#include "circt/Dialect/SV/SVOps.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "llvm/ADT/StringSwitch.h"
+
+using namespace circt;
+using namespace firrtl;
+
+//===----------------------------------------------------------------------===//
+// Pass Implementation
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// Mutable store of information about an Element in an interface.  This is
+/// derived from information stored in the "elements" field of an
+/// "AugmentedBundleType".  This is updated as more information is known about
+/// an Element.
+struct ElementInfo {
+  /// Encodes the "tpe" of an element.  This is called "Kind" to avoid
+  /// overloading the meaning of "Type" (which also conflicts with mlir::Type).
+  enum Kind {
+    Error = -1,
+    Ground,
+    Vector,
+    Bundle,
+    String,
+    Boolean,
+    Integer,
+    Double
+  };
+  /// The "tpe" field indicating if this element of the interface is a ground
+  /// type, a vector type, or a bundle type.  Bundle types are nested
+  /// interfaces.
+  Kind tpe;
+  /// A string description that will show up as a comment in the output Verilog.
+  StringRef description;
+  /// The width of this interface.  This is only non-negative for ground or
+  /// vector types.
+  int32_t width = -1;
+  /// The depth of the interface.  This is one for ground types and greater
+  /// than one for vector types.
+  uint32_t depth = 0;
+  /// Indicate if this element was found in the circuit.
+  bool found = false;
+  /// Trakcs location information about what was used to build this element.
+  SmallVector<Location> locations = {};
+  /// True if this is a ground or vector type and it was not (statefully) found.
+  /// This indicates that an interface element, which is composed of ground and
+  /// vector types, found no matching, annotated components in the circuit.
+  bool isMissing() { return !found && (tpe == Ground || tpe == Vector); }
+};
+
+/// Stores a decoded Grand Central AugmentedField
+struct AugmentedField {
+  /// The name of the field.
+  StringRef name;
+  /// An optional descripton that the user provided for the field.  This should
+  /// become a comment in the Verilog.
+  StringRef description;
+  /// The "type" of the field.
+  ElementInfo::Kind tpe;
+};
+
+/// Stores a decoded Grand Central AugmentedBundleType.
+struct AugmentedBundleType {
+  /// The name of the interface.
+  StringRef defName;
+  /// The elements that make up the body of the interface.
+  SmallVector<AugmentedField> elements;
+};
+
+/// Convert an arbitrary attributes into an optional AugmentedField.  Returns
+/// None if the attribute is an invalid AugmentedField.
+static Optional<AugmentedField> decodeField(Attribute maybeField) {
+  auto field = maybeField.dyn_cast_or_null<DictionaryAttr>();
+  if (!field)
+    return {};
+  auto tpeString = field.getAs<StringAttr>("tpe");
+  auto name = field.getAs<StringAttr>("name");
+  if (!name || !tpeString)
+    return {};
+  auto tpe = llvm::StringSwitch<ElementInfo::Kind>(tpeString.getValue())
+                 .Case("sifive.enterprise.grandcentral.AugmentedBundleType",
+                       ElementInfo::Bundle)
+                 .Case("sifive.enterprise.grandcentral.AugmentedVectorType",
+                       ElementInfo::Vector)
+                 .Case("sifive.enterprise.grandcentral.AugmentedGroundType",
+                       ElementInfo::Ground)
+                 .Case("sifive.enterprise.grandcentral.AugmentedStringType",
+                       ElementInfo::String)
+                 .Case("sifive.enterprise.grandcentral.AugmentedBooleanType",
+                       ElementInfo::Boolean)
+                 .Case("sifive.enterprise.grandcentral.AugmentedIntegerType",
+                       ElementInfo::Integer)
+                 .Case("sifive.enterprise.grandcentral.AugmentedDoubleType",
+                       ElementInfo::Double)
+                 .Default(ElementInfo::Error);
+  if (tpe == ElementInfo::Error)
+    return {};
+
+  StringRef description = {};
+  if (auto maybeDescription = field.getAs<StringAttr>("description"))
+    description = maybeDescription.getValue();
+  return Optional<AugmentedField>({name.getValue(), description, tpe});
+};
+
+/// Convert an Annotation into an optional AugmentedBundleType.  Returns None if
+/// the annotation is not an AugmentedBundleType.
+static Optional<AugmentedBundleType> decodeBundleType(Annotation anno) {
+  auto defName = anno.getMember<StringAttr>("defName");
+  auto elements = anno.getMember<ArrayAttr>("elements");
+  if (!defName || !elements)
+    return {};
+  AugmentedBundleType bundle(
+      {defName.getValue(), SmallVector<AugmentedField>()});
+  for (auto element : elements) {
+    auto field = decodeField(element);
+    if (!field)
+      return {};
+    bundle.elements.push_back(field.getValue());
+  }
+  return Optional<AugmentedBundleType>(bundle);
+};
+
+/// Remove Grand Central Annotations associated with SystemVerilog interfaces
+/// that should emitted.  This pass works in three major phases:
+///
+/// 1. The circuit's annotations are examnined to figure out _what_ interfaces
+///    there are.  This includes information about the name of the interface
+///    ("defName") and each of the elements (sv::InterfaceSignalOp) that make up
+///    the interface.  However, no information about the _type_ of the elements
+///    is known.
+///
+/// 2. With this, information, walk through the circuit to find scattered
+///    information about the types of the interface elements.  Annotations are
+///    scattered during FIRRTL parsing to attach all the annotations associated
+///    with elements on the right components.
+///
+/// 3. Add interface ops and populate the elements.
+///
+/// Grand Central supports three "normal" element types and four "weird" element
+/// types.  The normal ones are ground types (SystemVerilog logic), vector types
+/// (SystemVerilog unpacked arrays), and nested interface types (another
+/// SystemVerilog interface).  The Chisel API provides "weird" elements that
+/// include: Boolean, Integer, String, and Double.  The SFC implementation
+/// currently drops these, but this pass emits them as commented out strings.
+struct GrandCentralPass : public GrandCentralBase<GrandCentralPass> {
+  void runOnOperation() override;
+
+  // A map storing mutable information about an element in an interface.  This
+  // is keyed using a (defName, name) tuple where defname is the name of the
+  // interface and name is the name of the element.
+  typedef DenseMap<std::pair<StringRef, StringRef>, ElementInfo> InterfaceMap;
+
+private:
+  // Store a mapping of interface name to InterfaceOp.
+  llvm::StringMap<sv::InterfaceOp> interfaces;
+
+  // Discovered interfaces that need to be constructed.
+  InterfaceMap interfaceMap;
+
+  // Track the order that interfaces should be emitted in.
+  SmallVector<std::pair<StringRef, StringRef>> interfaceKeys;
+};
+
+class GrandCentralVisitor : public FIRRTLVisitor<GrandCentralVisitor> {
+public:
+  GrandCentralVisitor(GrandCentralPass::InterfaceMap &interfaceMap)
+      : interfaceMap(interfaceMap) {}
+
+private:
+  /// Mutable store tracking each element in an interface.  This is indexed by a
+  /// "defName" -> "name" tuple.
+  GrandCentralPass::InterfaceMap &interfaceMap;
+
+  /// Helper to handle wires, registers, and nodes.
+  void handleRef(Operation *op);
+
+  /// A helper used by handleRef that can also be used to process ports.
+  void handleRefLike(Operation *op, AnnotationSet &annotations,
+                     FIRRTLType type);
+
+  // Helper to handle ports of modules that may have Grand Central annotations.
+  void handlePorts(Operation *op);
+
+  // If true, then some error occurred while the visitor was running.  This
+  // indicates that pass failure should occur.
+  bool failed = false;
+
+public:
+  using FIRRTLVisitor<GrandCentralVisitor>::visitDecl;
+
+  /// Visit FModuleOp and FExtModuleOp
+  void visitModule(Operation *op);
+
+  /// Visit ops that can make up an interface element.
+  void visitDecl(RegOp op) { handleRef(op); }
+  void visitDecl(RegResetOp op) { handleRef(op); }
+  void visitDecl(WireOp op) { handleRef(op); }
+  void visitDecl(NodeOp op) { handleRef(op); }
+
+  /// Process all other ops.  Error if any of these ops contain annotations that
+  /// indicate it as being part of an interface.
+  void visitUnhandledDecl(Operation *op);
+
+  /// Returns true if an error condition occurred while visiting ops.
+  bool hasFailed() { return failed; };
+};
+
+} // namespace
+
+void GrandCentralVisitor::visitModule(Operation *op) {
+  handlePorts(op);
+
+  if (isa<FModuleOp>(op))
+    for (auto &stmt : op->getRegion(0).front())
+      dispatchVisitor(&stmt);
+}
+
+/// Process all other operations.  This will throw an error if the operation
+/// contains any annotations that indicates that this should be included in an
+/// interface.  Otherwise, this is a valid nop.
+void GrandCentralVisitor::visitUnhandledDecl(Operation *op) {
+  AnnotationSet annotations(op);
+  auto anno = annotations.getAnnotation(
+      "sifive.enterprise.grandcentral.AugmentedGroundType");
+  if (!anno)
+    return;
+  auto diag =
+      op->emitOpError()
+      << "is marked as a an interface element, but this op or its ports are "
+         "not supposed to be interface elements (Are your annotations "
+         "malformed? Is this a missing feature that should be supported?)";
+  diag.attachNote()
+      << "this annotation marked the op as an interface element: '" << anno
+      << "'";
+  failed = true;
+}
+
+/// Process annotations associated with an operation and having some type.
+/// Return the annotations with the processed annotations removed.  If all
+/// annotations are removed, this returns an empty ArrayAttr.
+void GrandCentralVisitor::handleRefLike(mlir::Operation *op,
+                                        AnnotationSet &annotations,
+                                        FIRRTLType type) {
+  if (annotations.empty())
+    return;
+
+  bool foundAnnotations = false;
+  for (auto anno : annotations) {
+    if (!anno.isClass("sifive.enterprise.grandcentral.AugmentedGroundType"))
+      continue;
+
+    auto defName = anno.getMember<StringAttr>("defName");
+    auto name = anno.getMember<StringAttr>("name");
+    if (!defName || !name) {
+      op->emitOpError(
+            "is marked as part of an interface, but is missing 'defName' or "
+            "'name' fields (did you forget to add these?)")
+              .attachNote()
+          << "the full annotation is: " << anno.getDict();
+      failed = true;
+      continue;
+    }
+
+    // TODO: This is ignoring situations where the leaves of and interface are
+    // not ground types.  This enforces the requirement that this runs after
+    // LowerTypes.  However, this could eventually be relaxed.
+    if (!type.isGround()) {
+      auto diag = op->emitOpError()
+                  << "cannot be added to interface '" << defName.getValue()
+                  << "', component '" << name.getValue()
+                  << "' because it is not a ground type. (Got type '" << type
+                  << "'.) This will be dropped from the interface. (Did you "
+                     "forget to run LowerTypes?)";
+      diag.attachNote()
+          << "The annotation indicating that this should be added was: '"
+          << anno.getDict();
+      failed = true;
+      continue;
+    }
+
+    auto &component = interfaceMap[{defName.getValue(), name.getValue()}];
+    component.found = true;
+
+    switch (component.tpe) {
+    case ElementInfo::Vector:
+      component.width = type.getBitWidthOrSentinel();
+      component.depth++;
+      component.locations.push_back(op->getLoc());
+      break;
+    case ElementInfo::Ground:
+      component.width = type.getBitWidthOrSentinel();
+      component.locations.push_back(op->getLoc());
+      break;
+    case ElementInfo::Bundle:
+    case ElementInfo::String:
+    case ElementInfo::Boolean:
+    case ElementInfo::Integer:
+    case ElementInfo::Double:
+      break;
+    case ElementInfo::Error:
+      llvm_unreachable("Shouldn't be here");
+      break;
+    }
+    annotations.removeAnnotation(anno);
+    foundAnnotations = true;
+  }
+}
+
+/// Combined logic to handle Wires, Registers, and Nodes because these all use
+/// the same approach.
+void GrandCentralVisitor::handleRef(mlir::Operation *op) {
+  auto annotations = AnnotationSet(op);
+  handleRefLike(op, annotations, op->getResult(0).getType().cast<FIRRTLType>());
+  annotations.applyToOperation(op);
+}
+
+/// Remove Grand Central Annotations from ports of modules or external modules.
+/// Return argument attributes with annotations removed.
+void GrandCentralVisitor::handlePorts(Operation *op) {
+
+  SmallVector<Attribute> newArgAttrs;
+  auto ports = getModulePortInfo(op);
+  for (size_t i = 0, e = ports.size(); i != e; ++i) {
+    auto port = ports[i];
+    handleRefLike(op, port.annotations, port.type);
+
+    newArgAttrs.push_back(port.annotations.applyToPortDictionaryAttr(
+        DictionaryAttr::get(op->getContext(), {})));
+  }
+
+  mlir::function_like_impl::setAllArgAttrDicts(op, newArgAttrs);
+}
+
+void GrandCentralPass::runOnOperation() {
+  CircuitOp circuitOp = getOperation();
+
+  AnnotationSet annotations(circuitOp);
+  if (annotations.empty())
+    return;
+
+  auto builder = OpBuilder::atBlockEnd(circuitOp->getBlock());
+
+  // Utility that acts like emitOpError, but does _not_ include a note.  The
+  // note in emitOpError includes the entire op which means the **ENTIRE**
+  // FIRRTL circuit.  This doesn't communicate anything useful to the user other
+  // than flooding their terminal.
+  auto emitCircuitError = [&circuitOp](StringRef message = {}) {
+    return emitError(circuitOp.getLoc(), message);
+  };
+
+  // Examine the Circuit's Annotations doing work to remove Grand Central
+  // Annotations.  Ignore any unprocesssed annotations and rewrite the Circuit's
+  // Annotations with these when done.
+  bool removalError = false;
+  annotations.removeAnnotations([&](auto anno) {
+    if (!anno.isClass("sifive.enterprise.grandcentral.AugmentedBundleType"))
+      return false;
+
+    AugmentedBundleType bundle;
+    if (auto maybeBundle = decodeBundleType(anno))
+      bundle = maybeBundle.getValue();
+    else {
+      emitCircuitError(
+          "'firrtl.circuit' op contained an 'AugmentedBundleType' "
+          "Annotation which did not conform to the expected format")
+              .attachNote()
+          << "the problematic 'AugmentedBundleType' is: '" << anno.getDict()
+          << "'";
+      removalError = true;
+      return false;
+    }
+
+    for (auto elt : bundle.elements) {
+      std::pair<StringRef, StringRef> key = {bundle.defName, elt.name};
+      interfaceMap[key] = {elt.tpe, elt.description};
+      interfaceKeys.push_back(key);
+    }
+
+    // If the interface already exists, don't create it.
+    if (interfaces.count(bundle.defName))
+      return true;
+
+    // Create the interface.  This will be populated later.
+    interfaces[bundle.defName] =
+        builder.create<sv::InterfaceOp>(circuitOp->getLoc(), bundle.defName);
+
+    return true;
+  });
+
+  if (removalError)
+    return signalPassFailure();
+
+  // Remove the processed annotations.
+  circuitOp->setAttr("annotations", annotations.getArrayAttr());
+
+  // Walk through the circuit to collect additional information.  If this fails,
+  // signal pass failure.
+  for (auto &op : circuitOp.getBody()->getOperations()) {
+    if (isa<FModuleOp, FExtModuleOp>(op)) {
+      GrandCentralVisitor visitor(interfaceMap);
+      visitor.visitModule(&op);
+      if (visitor.hasFailed())
+        return signalPassFailure();
+    }
+  }
+
+  // Populate interfaces.
+  for (auto &a : interfaceKeys) {
+    auto defName = a.first;
+    auto name = a.second;
+
+    auto &info = interfaceMap[{defName, name}];
+    if (info.isMissing()) {
+      emitCircuitError()
+          << "'firrtl.circuit' op contained a Grand Central Interface '"
+          << defName << "' that had an element '" << name
+          << "' which did not have a scattered companion annotation (is there "
+             "an invalid target in your annotation file?)";
+      continue;
+    }
+
+    builder.setInsertionPointToEnd(interfaces[defName].getBodyBlock());
+
+    auto loc = builder.getFusedLoc(info.locations);
+    auto description = info.description;
+    if (!description.empty())
+      builder.create<sv::VerbatimOp>(loc, "\n// " + description);
+
+    switch (info.tpe) {
+    case ElementInfo::Bundle:
+      // TODO: Change this to actually use an interface type.  This currently
+      // does not work because: (1) interfaces don't have a defined way to get
+      // their bit width and (2) interfaces have a symbol table that is used to
+      // verify internal ops, but this requires looking arbitrarily far upwards
+      // to find other symbols.
+      builder.create<sv::VerbatimOp>(loc, name + " " + name + "();");
+      break;
+    case ElementInfo::Vector: {
+      auto type = hw::UnpackedArrayType::get(builder.getIntegerType(info.width),
+                                             info.depth);
+      builder.create<sv::InterfaceSignalOp>(loc, name, type);
+      break;
+    }
+    case ElementInfo::Ground: {
+      auto type = builder.getIntegerType(info.width);
+      builder.create<sv::InterfaceSignalOp>(loc, name, type);
+      break;
+    }
+    case ElementInfo::String:
+      builder.create<sv::VerbatimOp>(loc, "// " + name +
+                                              " = <unsupported string type>;");
+      break;
+    case ElementInfo::Boolean:
+      builder.create<sv::VerbatimOp>(loc, "// " + name +
+                                              " = <unsupported boolean type>;");
+      break;
+    case ElementInfo::Integer:
+      builder.create<sv::VerbatimOp>(loc, "// " + name +
+                                              " = <unsupported integer type>;");
+      break;
+    case ElementInfo::Double:
+      builder.create<sv::VerbatimOp>(loc, "// " + name +
+                                              " = <unsupported double type>;");
+      break;
+    case ElementInfo::Error:
+      llvm_unreachable("Shouldn't be here");
+      break;
+    }
+  }
+
+  interfaces.clear();
+  interfaceMap.clear();
+  interfaceKeys.clear();
+}
+
+//===----------------------------------------------------------------------===//
+// Pass Creation
+//===----------------------------------------------------------------------===//
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createGrandCentralPass() {
+  return std::make_unique<GrandCentralPass>();
+}

--- a/lib/Dialect/FIRRTL/Transforms/PassDetails.h
+++ b/lib/Dialect/FIRRTL/Transforms/PassDetails.h
@@ -21,6 +21,10 @@
 
 namespace circt {
 
+namespace hw {
+class HWDialect;
+}
+
 namespace sv {
 class SVDialect;
 }

--- a/test/Dialect/FIRRTL/grand-central-errors.mlir
+++ b/test/Dialect/FIRRTL/grand-central-errors.mlir
@@ -1,0 +1,52 @@
+// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-grand-central)' -split-input-file -verify-diagnostics %s
+
+firrtl.circuit "NonGroundType" attributes {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedBundleType", defName = "Foo", elements = [{name = "foo", tpe = "sifive.enterprise.grandcentral.AugmentedGroundType"}]}]} {
+  firrtl.module @NonGroundType() {
+    // expected-error @+2 {{'firrtl.wire' op cannot be added to interface 'Foo', component 'foo' because it is not a ground type.}}
+    // expected-note @+1 {{"sifive.enterprise.grandcentral.AugmentedGroundType"}}
+    %a = firrtl.wire {annotations = [{a}, {class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "Foo", name = "foo", target = []}]} : !firrtl.vector<uint<2>, 1>
+  }
+}
+
+// -----
+
+// expected-error @+2 {{'firrtl.circuit' op contained an 'AugmentedBundleType' Annotation which did not conform to the expected format}}
+// expected-note @+1 {{the problematic 'AugmentedBundleType' is:}}
+firrtl.circuit "NonGroundType" attributes {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedBundleType"}]} {
+  firrtl.module @NonGroundType() {}
+}
+
+// -----
+
+module  {
+  firrtl.circuit "Foo" attributes {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedBundleType", defName = "View", elements = [{name = "sub_port", tpe = "sifive.enterprise.grandcentral.AugmentedGroundType"}]}]}  {
+    firrtl.module @Bar(in %a: !firrtl.uint<1>) {}
+    firrtl.module @Foo(in %a: !firrtl.uint<1>) attributes {annotations = [{class = "sifive.enterprise.grandcentral.GrandCentralView$SerializedViewAnnotation", id = 0 : i64, type = "parent"}]} {
+      // expected-error @+2 {{'firrtl.instance' op is marked as a an interface element}}
+      // expected-note @+1 {{{class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "View", name = "sub_port", target = [".a"]}}}
+      %bar_a = firrtl.instance @Bar  {annotations = [{a}, {class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "View", name = "sub_port", target = [".a"]}], name = "bar"} : !firrtl.flip<uint<1>>
+      firrtl.connect %bar_a, %a : !firrtl.flip<uint<1>>, !firrtl.uint<1>
+    }
+  }
+}
+
+// -----
+
+module  {
+  firrtl.circuit "Foo" attributes {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedBundleType", defName = "View", elements = [{name = "sub_port", tpe = "sifive.enterprise.grandcentral.AugmentedGroundType"}]}]}  {
+    firrtl.module @Foo(in %a: !firrtl.uint<1>) attributes {annotations = [{class = "sifive.enterprise.grandcentral.GrandCentralView$SerializedViewAnnotation", id = 0 : i64, type = "parent"}]} {
+      // expected-error @+2 {{'firrtl.mem' op is marked as a an interface element}}
+      // expected-note @+1 {{{class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "View", name = "some_mem", target = []}}}
+      %memory_b_r = firrtl.mem Undefined  {annotations = [{a}, {class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "View", name = "some_mem", target = []}], depth = 16 : i64, name = "memory_b", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.flip<bundle<addr: uint<4>, en: uint<1>, clk: clock, data: flip<uint<8>>>>
+    }
+  }
+}
+
+// -----
+
+module {
+  // expected-error @+1 {{'firrtl.circuit' op contained a Grand Central Interface 'Bar' that had an element 'baz' which did not have a scattered companion annotation}}
+  firrtl.circuit "Foo" attributes {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedBundleType", defName = "Bar", elements = [{name = "baz", tpe = "sifive.enterprise.grandcentral.AugmentedGroundType"}]}]}  {
+    firrtl.module @Foo() {}
+  }
+}

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -1,0 +1,139 @@
+// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-grand-central)' -split-input-file %s | FileCheck %s
+
+firrtl.circuit "InterfaceGroundType" attributes {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedBundleType", defName = "Foo", elements = [{description = "description of foo", name = "foo", tpe = "sifive.enterprise.grandcentral.AugmentedGroundType"}, {name = "bar", tpe = "sifive.enterprise.grandcentral.AugmentedGroundType"}]}]} {
+  firrtl.module @InterfaceGroundType() {
+    %a = firrtl.wire {annotations = [{a}, {class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "Foo", name = "foo", target = []}]} : !firrtl.uint<2>
+    %b = firrtl.wire {annotations = [{a}, {class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "Foo", name = "bar", target = []}]} : !firrtl.uint<4>
+  }
+}
+
+// This block is checking that all annotations were removed.
+// CHECK-LABEL: firrtl.circuit "InterfaceGroundType"
+// CHECK-NOT: annotations
+// CHECK-SAME: {
+
+// All Grand Central annotations are removed from the wires.
+// CHECK: firrtl.module @InterfaceGroundType
+// CHECK: %a = firrtl.wire
+// CHECK-SAME: annotations = [{a}]
+// CHECK: %b = firrtl.wire
+// CHECK-SAME: annotations = [{a}]
+
+// CHECK: sv.interface @Foo
+// CHECK-NEXT: sv.verbatim "\0A// description of foo"
+// CHECK-NEXT: sv.interface.signal @foo : i2
+// CHECK-NEXT: sv.interface.signal @bar : i4
+
+// -----
+
+firrtl.circuit "InterfaceVectorType" attributes {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedBundleType", defName = "Foo", elements = [{description = "description of foo", name = "foo", tpe = "sifive.enterprise.grandcentral.AugmentedVectorType"}]}]} {
+  firrtl.module @InterfaceVectorType(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
+    %a_0 = firrtl.reg %clock {annotations = [{a}, {class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "Foo", name = "foo"}]} : (!firrtl.clock) -> !firrtl.uint<1>
+    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    %a_1 = firrtl.regreset %clock, %reset, %c0_ui1 {annotations = [{a}, {class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "Foo", name = "foo"}]} : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  }
+}
+
+// All annotations are removed from the circuit.
+// CHECK-LABEL: firrtl.circuit "InterfaceVectorType"
+// CHECK-NOT: annotations
+// CHECK-SAME: {
+
+// All Grand Central annotations are removed from the registers.
+// CHECK: firrtl.module @InterfaceVectorType
+// CHECK: %a_0 = firrtl.reg
+// CHECK-SAME: annotations = [{a}]
+// CHECK: %a_1 = firrtl.regreset
+// CHECK-SAME: annotations = [{a}]
+
+// CHECK: sv.interface @Foo
+// CHECK-NEXT: sv.verbatim "\0A// description of foo"
+// CHECK-NEXT: sv.interface.signal @foo : !hw.uarray<2xi1>
+
+// -----
+
+firrtl.circuit "InterfaceBundleType" attributes {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedBundleType", defName = "Bar", elements = [{name = "b", tpe = "sifive.enterprise.grandcentral.AugmentedGroundType"}, {name = "a", tpe = "sifive.enterprise.grandcentral.AugmentedGroundType"}]}, {class = "sifive.enterprise.grandcentral.AugmentedBundleType", defName = "Foo", elements = [{description = "descripton of Bar", name = "Bar", tpe = "sifive.enterprise.grandcentral.AugmentedBundleType"}]}]}  {
+  firrtl.module @InterfaceBundleType() {
+    %x = firrtl.wire {annotations = [{a}, {class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "Bar", name = "a"}]} : !firrtl.uint<1>
+    %y = firrtl.wire {annotations = [{a}, {class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "Bar", name = "b"}]} : !firrtl.uint<2>
+  }
+}
+
+// All annotations are removed from the circuit.
+// CHECK-LABEL: firrtl.circuit "InterfaceBundleType"
+// CHECK-NOT: annotations
+// CHECK-SAME: {
+
+// All Grand Central annotations are removed from the wires.
+// CHECK-LABEL: firrtl.module @InterfaceBundleType
+// CHECK: %x = firrtl.wire
+// CHECK-SAME: annotations = [{a}]
+// CHECK: %y = firrtl.wire
+// CHECK-SAME: annotations = [{a}]
+
+// CHECK: sv.interface @Bar
+// CHECK-NEXT: sv.interface.signal @b : i2
+// CHECK-NEXT: sv.interface.signal @a : i1
+
+// CHECK: sv.interface @Foo
+// CHECK-NEXT: sv.verbatim "\0A// descripton of Bar"
+// CHECK-NEXT: Bar Bar();
+
+// -----
+
+firrtl.circuit "InterfaceNode" attributes {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedBundleType", defName = "Foo", elements = [{description = "some expression", name = "foo", tpe = "sifive.enterprise.grandcentral.AugmentedGroundType"}]}]} {
+  firrtl.module @InterfaceNode() {
+    %a = firrtl.wire : !firrtl.uint<2>
+    %notA = firrtl.not %a : (!firrtl.uint<2>) -> !firrtl.uint<2>
+    %b = firrtl.node %notA {annotations = [{a}, {class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "Foo", name = "foo", target = []}]} : !firrtl.uint<2>
+  }
+}
+
+// All annotations are removed from the circuit.
+// CHECK-LABEL: firrtl.circuit "InterfaceNode"
+// CHECK-NOT: annotations
+// CHECK-SAME: {
+
+// The Grand Central annotation is removed from the node.
+// CHECK: firrtl.node
+// CHECK-SAME: annotations = [{a}]
+
+// CHECK: sv.interface @Foo
+// CHECK-NEXT: sv.verbatim "\0A// some expression"
+// CHECK-NEXT: sv.interface.signal @foo : i2
+
+// -----
+
+firrtl.circuit "InterfacePort" attributes {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedBundleType", defName = "Foo", elements = [{description = "description of foo", name = "foo", tpe = "sifive.enterprise.grandcentral.AugmentedGroundType"}]}]} {
+  firrtl.module @InterfacePort(in %a : !firrtl.uint<4> {firrtl.annotations = [{a}, {class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "Foo", name = "foo", target = []}]}) {
+  }
+}
+
+// All annotations are removed from the circuit.
+// CHECK-LABEL: firrtl.circuit "InterfacePort"
+// CHECK-NOT: annotations
+// CHECK-SAME: {
+
+// The Grand Central annotations are removed.
+// CHECK: firrtl.module @InterfacePort
+// CHECK-SAME: firrtl.annotations = [{a}]
+
+// CHECK: sv.interface @Foo
+// CHECK-NEXT: sv.verbatim "\0A// description of foo"
+// CHECK-NEXT: sv.interface.signal @foo : i4
+
+// -----
+
+firrtl.circuit "UnsupportedTypes" attributes {annotations = [{a}, {class = "sifive.enterprise.grandcentral.AugmentedBundleType", defName = "Foo", elements = [{name = "string", tpe = "sifive.enterprise.grandcentral.AugmentedStringType"}, {name = "boolean", tpe = "sifive.enterprise.grandcentral.AugmentedBooleanType"}, {name = "integer", tpe = "sifive.enterprise.grandcentral.AugmentedIntegerType"}, {name = "double", tpe = "sifive.enterprise.grandcentral.AugmentedDoubleType"}]}]} {
+  firrtl.module @UnsupportedTypes() {}
+}
+
+// All Grand Central annotations are removed from the circuit.
+// CHECK-LABEL: firrtl.circuit "UnsupportedTypes"
+// CHECK-SAME: annotations = [{a}]
+
+// CHECK: sv.interface @Foo
+// CHECK-NEXT: sv.verbatim "// string = <unsupported string type>;"
+// CHECK-NEXT: sv.verbatim "// boolean = <unsupported boolean type>;"
+// CHECK-NEXT: sv.verbatim "// integer = <unsupported integer type>;"
+// CHECK-NEXT: sv.verbatim "// double = <unsupported double type>;"

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -107,6 +107,10 @@ static cl::opt<bool>
 static cl::opt<bool> extractTestCode("extract-test-code",
                                      cl::desc("run the extract test code pass"),
                                      cl::init(false));
+static cl::opt<bool> grandCentral(
+    "firrtl-grand-central",
+    cl::desc("create interfaces from SiFive Grand Central Annotations"),
+    cl::init(false));
 
 enum OutputFormatKind {
   OutputMLIR,
@@ -230,6 +234,9 @@ processBuffer(std::unique_ptr<llvm::MemoryBuffer> ownedBuffer,
       blackBoxRoot, blackBoxRootResourcePath.empty()
                         ? blackBoxRoot
                         : blackBoxRootResourcePath));
+
+  if (grandCentral)
+    pm.nest<firrtl::CircuitOp>().addPass(firrtl::createGrandCentralPass());
 
   // Lower if we are going to verilog or if lowering was specifically requested.
   if (lowerToHW || outputFormat == OutputVerilog ||


### PR DESCRIPTION
This adds support for generating interface from scattered Grand Central serialized view annotations. For one Grand Central view (a separate module that can be used to provide an alternative representation of something, e.g., an architectural view of a microarchitectural unit) many interfaces may need to be generated. These are represented in a recursive structure of:

1. Ground types
2. Vector types
3. Bundle types
4. _Other_ types which SFC Grand Central appears to ignore (Strings, Booleans, Integers, Doubles)

An interface is represented by one bundle type. Any ground or vector type elements in that show up as `logic` or unpacked array `logic`, respectively. Sub-bundles show up as sub-interfaces.

This PR takes all of this and generates the necessary interfaces by building `sv::InterfaceOp`s where the types are derived from collecting the scattered interface ground type components.

This PR supports collecting type information from annotations scattered to nodes, wires, registers, and ports. (However, these are expected to be only attached to data/mem taps built in #1178.)

### Example

Given the following MLIR file, which contains both serialized view and `Augmented*Type` annotations: 

```mlir
module  {
  firrtl.circuit "TestHarness" attributes {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedBundleType", defName = "sub_regBundle", elements = [{name = "b"}, {name = "a"}]}, {class = "sifive.enterprise.grandcentral.AugmentedBundleType", defName = "View", elements = [{description = "a wire called \22wire\22 in the submodule", name = "sub_wire"}, {description = "a register with a vector type", name = "sub_regVec"}, {description = "a register with a vector type that is subindexed", name = "sub_regVecSubindex"}, {description = "a register with a bundle type", name = "sub_regBundle"}]}, {class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation", directory = "builds/sandbox/viewOnly/firrtl/gct", filename = "builds/sandbox/viewOnly/firrtl/bindings.sv"}, {class = "firrtl.stage.RunFirrtlTransformAnnotation", transform = "sifive.enterprise.grandcentral.GrandCentralTransform"}]}  {
    firrtl.module @foobar_companion_9() attributes {annotations = [{class = "sifive.enterprise.grandcentral.GrandCentralView$SerializedViewAnnotation", id = 11 : i64, type = "companion"}, {class = "firrtl.transforms.NoDedupAnnotation"}]} {
      %cloneType = firrtl.wire  {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "View", name = "sub_wire", target = []}]} : !firrtl.uint<32>
      %cloneType_1 = firrtl.wire  : !firrtl.clock
      %cloneType_2 = firrtl.wire  : !firrtl.uint<1>
      %cloneType_3_0 = firrtl.wire  {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "View", name = "sub_regVec"}]} : !firrtl.uint<8>
      %cloneType_3_1 = firrtl.wire  {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "View", name = "sub_regVec"}]} : !firrtl.uint<8>
      %cloneType_3_2 = firrtl.wire  {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "View", name = "sub_regVec"}]} : !firrtl.uint<8>
      %cloneType_3_3 = firrtl.wire  {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "View", name = "sub_regVec"}]} : !firrtl.uint<8>
      %cloneType_4 = firrtl.wire  {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "View", name = "sub_regVecSubindex", target = []}]} : !firrtl.uint<8>
      %cloneType_5_a = firrtl.wire  {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "sub_regBundle", name = "a"}]} : !firrtl.uint<16>
      %cloneType_5_b = firrtl.wire  {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "sub_regBundle", name = "b"}]} : !firrtl.uint<16>
      %DataTap_3__5_a, %DataTap_3__5_b, %DataTap_3__4, %DataTap_3__3_0, %DataTap_3__3_1, %DataTap_3__3_2, %DataTap_3__3_3, %DataTap_3__2, %DataTap_3__1, %DataTap_3__0 = firrtl.instance @DataTap_3_5  {name = "DataTap_3"} : !firrtl.uint<16>, !firrtl.uint<16>, !firrtl.uint<8>, !firrtl.uint<8>, !firrtl.uint<8>, !firrtl.uint<8>, !firrtl.uint<8>, !firrtl.uint<1>, !firrtl.clock, !firrtl.uint<32>
      firrtl.connect %cloneType, %DataTap_3__0 : !firrtl.uint<32>, !firrtl.uint<32>
      firrtl.connect %cloneType_1, %DataTap_3__1 : !firrtl.clock, !firrtl.clock
      firrtl.connect %cloneType_2, %DataTap_3__2 : !firrtl.uint<1>, !firrtl.uint<1>
      firrtl.connect %cloneType_3_0, %DataTap_3__3_0 : !firrtl.uint<8>, !firrtl.uint<8>
      firrtl.connect %cloneType_3_1, %DataTap_3__3_1 : !firrtl.uint<8>, !firrtl.uint<8>
      firrtl.connect %cloneType_3_2, %DataTap_3__3_2 : !firrtl.uint<8>, !firrtl.uint<8>
      firrtl.connect %cloneType_3_3, %DataTap_3__3_3 : !firrtl.uint<8>, !firrtl.uint<8>
      firrtl.connect %cloneType_4, %DataTap_3__4 : !firrtl.uint<8>, !firrtl.uint<8>
      firrtl.connect %cloneType_5_b, %DataTap_3__5_b : !firrtl.uint<16>, !firrtl.uint<16>
      firrtl.connect %cloneType_5_a, %DataTap_3__5_a : !firrtl.uint<16>, !firrtl.uint<16>
    }
    firrtl.module @DUT(in %clock: !firrtl.clock, in %reset: !firrtl.reset, in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) attributes {annotations = [{class = "sifive.enterprise.grandcentral.GrandCentralView$SerializedViewAnnotation", id = 11 : i64, type = "parent"}, {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
      firrtl.instance @foobar_companion_9  {name = "foobar_companion_9"}
    }
    firrtl.module @TestHarness(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
      %dut_clock, %dut_reset, %dut_in, %dut_out = firrtl.instance @DUT  {name = "dut"} : !firrtl.flip<clock>, !firrtl.flip<reset>, !firrtl.flip<uint<1>>, !firrtl.uint<1>
    }
  }
}
```

The following interfaces show up in the emitted Verilog if you run with the `-sifive-grand-central` option to `firtool`:
```verilog
interface sub_regBundle;
  logic [15:0] b;
  logic [15:0] a;
endinterface

interface View;
  
  // a wire called "wire" in the submodule
  logic [31:0] sub_wire;
  
  // a register with a vector type
  logic [7:0] sub_regVec[0:3];
  
  // a register with a vector type that is subindexed
  logic [7:0] sub_regVecSubindex;
  
  // a register with a bundle type
  sub_regBundle sub_regBundle();
endinterface
```