### PR TITLE
[ExpandWhens] Strip flip types off of bundles before casting

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
@@ -41,7 +41,11 @@ FieldRef circt::firrtl::getFieldRefFromValue(Value value) {
     // TODO: implement subindex op.
     if (auto subfieldOp = dyn_cast<SubfieldOp>(op)) {
       value = subfieldOp.input();
-      auto bundleType = value.getType().template cast<BundleType>();
+      // Strip any flip wrapping the bundle type.
+      auto type = value.getType();
+      if (auto flipType = type.dyn_cast<FlipType>())
+          type = flipType.getElementType();
+      auto bundleType = type.cast<BundleType>();
       auto index =
           bundleType.getElementIndex(subfieldOp.fieldname()).getValue();
       // Rebase the current index on the parent field's index.

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -364,5 +364,14 @@ firrtl.module @bundle_types(in %p : !firrtl.uint<1>, in %clock: !firrtl.clock) {
   }
 }
 
+// This is exercising a bug in field reference creation when the bundle is
+// wrapped in an outer flip. See https://github.com/llvm/circt/issues/1172.
+firrtl.module @simple(in %in : !firrtl.bundle<a: uint<1>>) { }
+firrtl.module @bundle_ports() {
+  %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+  %simple_in = firrtl.instance @simple {name = "test0"}: !firrtl.flip<bundle<a: uint<1>>>
+  %0 = firrtl.subfield %simple_in("a") : (!firrtl.flip<bundle<a: uint<1>>>) -> !firrtl.uint<1>
+  firrtl.connect %0, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+}
 
 }


### PR DESCRIPTION
This code was erroneously assuming that the operand of subfield op was
always a bundle type.  BundleType can be wrapped in a FlipType if it is
an `in` port of an InstanceOp.  This change strips the flip type from
the bundle type when it is there.