### PR TITLE
[firtool] Enable expand-whens by default

### DIFF
--- a/test/Conversion/FIRRTLToLLHD/connect.fir
+++ b/test/Conversion/FIRRTLToLLHD/connect.fir
@@ -1,4 +1,4 @@
-; RUN: firtool %s | circt-opt --convert-firrtl-to-llhd | FileCheck %s
+; RUN: circt-translate --import-firrtl %s | circt-opt --convert-firrtl-to-llhd | FileCheck %s
 
 circuit test_mod :
   module test_mod :

--- a/test/Conversion/FIRRTLToLLHD/empty_inouts.fir
+++ b/test/Conversion/FIRRTLToLLHD/empty_inouts.fir
@@ -1,9 +1,10 @@
-; RUN: firtool %s | circt-opt --convert-firrtl-to-llhd | FileCheck %s
+; RUN: circt-translate --import-firrtl %s | circt-opt --convert-firrtl-to-llhd | FileCheck %s
 
 circuit test_mod :
   module test_mod :
     input a: UInt<1>
     output b: UInt<1>
+
 
 ; CHECK-LABEL: llhd.entity @test_mod (
 ; CHECK-SAME: %[[PORT_A:.*]]: !llhd.sig<i1>) -> (

--- a/test/Conversion/FIRRTLToLLHD/empty_ins.fir
+++ b/test/Conversion/FIRRTLToLLHD/empty_ins.fir
@@ -1,4 +1,4 @@
-; RUN: firtool %s | circt-opt --convert-firrtl-to-llhd | FileCheck %s
+; RUN: circt-translate --import-firrtl %s | circt-opt --convert-firrtl-to-llhd | FileCheck %s
 
 circuit test_mod :
   module test_mod :

--- a/test/Conversion/FIRRTLToLLHD/empty_none.fir
+++ b/test/Conversion/FIRRTLToLLHD/empty_none.fir
@@ -1,4 +1,4 @@
-; RUN: firtool %s | circt-opt --convert-firrtl-to-llhd | FileCheck %s
+; RUN: circt-translate --import-firrtl %s | circt-opt --convert-firrtl-to-llhd | FileCheck %s
 
 circuit test_mod :
   module test_mod :

--- a/test/Conversion/FIRRTLToLLHD/empty_outs.fir
+++ b/test/Conversion/FIRRTLToLLHD/empty_outs.fir
@@ -1,4 +1,4 @@
-; RUN: firtool %s | circt-opt --convert-firrtl-to-llhd | FileCheck %s
+; RUN: circt-translate --import-firrtl %s | circt-opt --convert-firrtl-to-llhd | FileCheck %s
 
 circuit test_mod :
   module test_mod :

--- a/test/firtool/optimizations.fir
+++ b/test/firtool/optimizations.fir
@@ -5,10 +5,13 @@ circuit test_cse :
   module test_cse :
     input a: UInt<4>
     output b: UInt<5>
+    output c: UInt<5>
+    output d: UInt<5>
+    output e: UInt<5>
     b <= add(a, a)
-    b <= add(a, a)
-    b <= and(a, UInt<4>(0))
-    b <= and(UInt<4>(3), UInt<4>(1))
+    c <= add(a, a)
+    d <= and(a, UInt<4>(0))
+    e <= and(UInt<4>(3), UInt<4>(1))
 
 ; OPT-DAG: %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
 ; OPT-DAG: %c1_ui4 = firrtl.constant 1 : !firrtl.uint<4>
@@ -16,24 +19,24 @@ circuit test_cse :
 ; Only one add.
 ; OPT: %0 = firrtl.add %a, %a
 ; OPT: firrtl.connect %b, %0
-; OPT: firrtl.connect %b, %0
+; OPT: firrtl.connect %c, %0
 
 ; Connect with zero and one directly.
-; OPT: firrtl.connect %b, %c0_ui4
-; OPT: firrtl.connect %b, %c1_ui4
+; OPT: firrtl.connect %d, %c0_ui4
+; OPT: firrtl.connect %e, %c1_ui4
 
 ; Both adds persist.
 ; NOOPT: %0 = firrtl.add %a, %a
 ; NOOPT: firrtl.connect %b, %0 
 ; NOOPT: %1 = firrtl.add %a, %a
-; NOOPT: firrtl.connect %b, %1 
+; NOOPT: firrtl.connect %c, %1 
 
 ; Ands persist.
 ; NOOPT: %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
 ; NOOPT: firrtl.and %a, %c0_ui4
-; NOOPT: firrtl.connect %b,
+; NOOPT: firrtl.connect %d,
 
 ; NOOPT-DAG: %c3_ui4 = firrtl.constant 3 : !firrtl.uint<4>
 ; NOOPT-DAG: %c1_ui4 = firrtl.constant 1 : !firrtl.uint<4>
 ; NOOPT: firrtl.and %c3_ui4, %c1_ui4
-; NOOPT: firrtl.connect %b,
+; NOOPT: firrtl.connect %e,

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -85,8 +85,9 @@ static cl::opt<bool>
                       cl::init(false));
 
 static cl::opt<bool>
-    expandWhens("expand-whens", cl::desc("run the expand-whens pass on firrtl"),
-                cl::init(false));
+    disableExpandWhens("disable-expand-whens",
+                       cl::desc("disable the expand-whens pass"),
+                       cl::init(false));
 
 static cl::opt<bool>
     blackboxMemory("blackbox-memory",
@@ -198,7 +199,7 @@ processBuffer(std::unique_ptr<llvm::MemoryBuffer> ownedBuffer,
     pm.addNestedPass<firrtl::CircuitOp>(firrtl::createLowerFIRRTLTypesPass());
     auto &modulePM = pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>();
     // Only enable expand whens if lower types is also enabled.
-    if (expandWhens)
+    if (!disableExpandWhens)
       modulePM.addPass(firrtl::createExpandWhensPass());
   }
 


### PR DESCRIPTION
This pass has been subjected to fuzz-testing for quite some time, and it
is surprising (in a negative usability sense) that it is not enabled by
default.

Some FIRRTL-to-LLHD tests were using firtool with uninitialized ports,
and this change switched them to use circt-translate instead.