### PR TITLE
[FIRRTL] Add verbatim.expr operation

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTL.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTL.td
@@ -14,6 +14,7 @@
 #define FIRRTL_TD
 
 include "mlir/IR/OpBase.td"
+include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -478,6 +478,41 @@ def TailPrimOp : PrimOp<"tail"> {
 }
 
 //===----------------------------------------------------------------------===//
+// Verbatim
+//===----------------------------------------------------------------------===//
+
+def HasCustomSSAName : DeclareOpInterfaceMethods<OpAsmOpInterface>;
+
+def VerbatimExprOp : FIRRTLOp<"verbatim.expr",
+                              [NoSideEffect, HasCustomSSAName]> {
+  let summary = "Expression that expands to a value given SystemVerilog text";
+  let description = [{
+    This operation produces a typed value expressed by a string of
+    SystemVerilog.  This can be used to access macros and other values that are
+    only sensible as Verilog text.
+
+    The text string is expected to have the highest precedence, so you should
+    include parentheses in the string if it isn't a single token.  This is also
+    assumed to not have side effects (use `sv.verbatim` if you need them).
+
+    `firrtl.verbatim.expr` allows operand substitutions with `{{0}}` syntax.
+  }];
+
+  let arguments = (ins StrAttr:$text, Variadic<AnyType>:$operands);
+  let results = (outs FIRRTLType:$result);
+  let assemblyFormat = [{
+    $text attr-dict (`(` $operands^ `)`)?
+      `:` functional-type($operands, $result)
+  }];
+
+  let builders = [
+    OpBuilder<(ins "Type":$resultType, "StringRef":$text),
+               "build(odsBuilder, odsState, resultType, text, ValueRange{});">
+  ];
+}
+
+
+//===----------------------------------------------------------------------===//
 // Conversions to/from fixed-width signless integer types in standard dialect.
 //===----------------------------------------------------------------------===//
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -17,6 +17,7 @@
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/FunctionSupport.h"
+#include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/RegionKindInterface.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -42,7 +42,7 @@ public:
             CvtPrimOp, NegPrimOp, NotPrimOp, AndRPrimOp, OrRPrimOp, XorRPrimOp,
             // Miscellaneous.
             BitsPrimOp, HeadPrimOp, MuxPrimOp, PadPrimOp, ShlPrimOp, ShrPrimOp,
-            TailPrimOp, AsPassivePrimOp, AsNonPassivePrimOp,
+            TailPrimOp, VerbatimExprOp, AsPassivePrimOp, AsNonPassivePrimOp,
 
             // Conversion from FIRRTL to HW dialect types.
             StdIntCastOp, HWStructCastOp, AnalogInOutCastOp>(
@@ -135,6 +135,7 @@ public:
   HANDLE(ShlPrimOp, Unhandled);
   HANDLE(ShrPrimOp, Unhandled);
   HANDLE(TailPrimOp, Unhandled);
+  HANDLE(VerbatimExprOp, Unhandled);
   HANDLE(AsPassivePrimOp, Unhandled);
   HANDLE(AsNonPassivePrimOp, Unhandled);
 

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1008,6 +1008,7 @@ struct FIRRTLLowering : public FIRRTLVisitor<FIRRTLLowering, LogicalResult> {
   }
   LogicalResult visitExpr(TailPrimOp op);
   LogicalResult visitExpr(MuxPrimOp op);
+  LogicalResult visitExpr(VerbatimExprOp op);
 
   // Statements
   LogicalResult visitStmt(SkipOp op);
@@ -2312,6 +2313,24 @@ LogicalResult FIRRTLLowering::visitExpr(MuxPrimOp op) {
 
   return setLoweringTo<comb::MuxOp>(op, ifTrue.getType(), cond, ifTrue,
                                     ifFalse);
+}
+
+LogicalResult FIRRTLLowering::visitExpr(VerbatimExprOp op) {
+  auto resultTy = lowerType(op.getType());
+  if (!resultTy)
+    return failure();
+
+  SmallVector<Value, 4> operands;
+  operands.reserve(op.operands().size());
+  for (auto operand : op.operands()) {
+    auto lowered = getLoweredValue(operand);
+    if (!lowered)
+      return failure();
+    operands.push_back(lowered);
+  }
+
+  return setLoweringTo<sv::VerbatimExprOp>(op, resultTy, op.textAttr(),
+                                           operands);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -21,6 +21,7 @@
 #include "mlir/IR/PatternMatch.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 
 using mlir::RegionRange;
@@ -2009,6 +2010,25 @@ FIRRTLType TailPrimOp::inferReturnType(ValueRange operands,
   }
 
   return IntType::get(input.getContext(), false, width);
+}
+
+//===----------------------------------------------------------------------===//
+// VerbatimExprOp
+//===----------------------------------------------------------------------===//
+
+void VerbatimExprOp::getAsmResultNames(
+    function_ref<void(Value, StringRef)> setNameFn) {
+  // If the text is macro like, then use a pretty name.  We only take the
+  // text up to a weird character (like a paren) and currently ignore
+  // parenthesized expressions.
+  auto isOkCharacter = [](char c) { return llvm::isAlnum(c) || c == '_'; };
+  auto name = text();
+  // Ignore a leading ` in macro name.
+  if (name.startswith("`"))
+    name = name.drop_front();
+  name = name.take_while(isOkCharacter);
+  if (!name.empty())
+    setNameFn(getResult(), name);
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -203,6 +203,15 @@ firrtl.circuit "Simple" {
     %47 = firrtl.asClock %44 : (!firrtl.uint<1>) -> !firrtl.clock
     %48 = firrtl.asAsyncReset %44 : (!firrtl.uint<1>) -> !firrtl.asyncreset
 
+    // CHECK: [[VERB1:%.+]] = sv.verbatim.expr "MAGIC_CONSTANT" : () -> i42
+    // CHECK: [[VERB2:%.+]] = sv.verbatim.expr "$bits({{[{][{]0[}][}]}})"([[VERB1]]) : (i42) -> i32
+    // CHECK: [[VERB1EXT:%.+]] = comb.concat {{%.+}}, [[VERB1]] : (i1, i42) -> i43
+    // CHECK: [[VERB2EXT:%.+]] = comb.concat {{%.+}}, [[VERB2]] : (i11, i32) -> i43
+    // CHECK: = comb.add [[VERB1EXT]], [[VERB2EXT]] : i43
+    %56 = firrtl.verbatim.expr "MAGIC_CONSTANT" : () -> !firrtl.uint<42>
+    %57 = firrtl.verbatim.expr "$bits({{0}})"(%56) : (!firrtl.uint<42>) -> !firrtl.uint<32>
+    %58 = firrtl.add %56, %57 : (!firrtl.uint<42>, !firrtl.uint<32>) -> !firrtl.uint<43>
+
     // Issue #353
     // CHECK: [[PADRES_EXT:%.+]] = comb.sext [[PADRES]] : (i3) -> i8
     // CHECK: = comb.and %in3, [[PADRES_EXT]] : i8

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -115,4 +115,14 @@ firrtl.module @TestInvalidAttr() {
   }
 }
 
+// CHECK-LABEL: @VerbatimExpr
+firrtl.module @VerbatimExpr() {
+  // CHECK: %[[TMP:.+]] = firrtl.verbatim.expr "FOO" : () -> !firrtl.uint<42>
+  // CHECK: %[[TMP2:.+]] = firrtl.verbatim.expr "$bits({{[{][{]0[}][}]}})"(%[[TMP]]) : (!firrtl.uint<42>) -> !firrtl.uint<32>
+  // CHECK: firrtl.add %[[TMP]], %[[TMP2]] : (!firrtl.uint<42>, !firrtl.uint<32>) -> !firrtl.uint<43>
+  %0 = firrtl.verbatim.expr "FOO" : () -> !firrtl.uint<42>
+  %1 = firrtl.verbatim.expr "$bits({{0}})"(%0) : (!firrtl.uint<42>) -> !firrtl.uint<32>
+  %2 = firrtl.add %0, %1 : (!firrtl.uint<42>, !firrtl.uint<32>) -> !firrtl.uint<43>
+}
+
 }


### PR DESCRIPTION
Add a `verbatim.expr` operation to the FIRRTL dialect which lowers to the corresponding operation in the SV dialect. This allows construction of FIRRTL-typed expressions from a string representation. Based on a suggestion in #1178.