### PR TITLE
[ExportVerilog] Ensure stable names

### DIFF
--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -665,7 +665,7 @@ StringRef ModuleEmitter::addName(ValueOrOp valueOrOp, StringRef name) {
 }
 
 /// Add the specified name to the name table, returning if the name
-/// empty or is changed by uniqing. 
+/// empty or is changed by uniqing.
 bool ModuleEmitter::addLegalName(ValueOrOp valueOrOp, StringRef name) {
   auto updatedName = addName(valueOrOp, name);
   if (name.empty() || updatedName != name)
@@ -2676,14 +2676,14 @@ void ModuleEmitter::prepareHWModule(Block &block) {
     // them now ensures any temporary generated will not use one of the names
     // previously declared.
     if (auto instance = dyn_cast<InstanceOp>(op))
-      if (!addLegalName(ValueOrOp(instance), instance.instanceName()))
+      if (!addLegalName(ValueOrOp(&op), instance.instanceName()))
         emitOpError(instance, "Instance name changed durring emission.");
     if (auto wire = dyn_cast<WireOp>(op))
-      if (!addLegalName(ValueOrOp(wire), wire.name()))
-      emitOpError(wire, "Wire name changed durring emission");
-      if (auto regOp = dyn_cast<RegOp>(op))
-      if(!addLegalName(ValueOrOp(regOp), regOp.name()))
-      emitOpError(regOp, "Register name changed durring emission");
+      if (!addLegalName(ValueOrOp(op.getResult(0)), wire.name()))
+        emitOpError(wire, "Wire name changed durring emission");
+    if (auto regOp = dyn_cast<RegOp>(op))
+      if (!addLegalName(ValueOrOp(op.getResult(0)), regOp.name()))
+        emitOpError(regOp, "Register name changed durring emission");
   }
 
   // Now that all the basic ops are settled, check for any use-before def issues

--- a/test/Dialect/SV/hw-legalize-names.mlir
+++ b/test/Dialect/SV/hw-legalize-names.mlir
@@ -57,6 +57,14 @@ hw.module @inout_inst(%a: i1) -> () {
   %0 = hw.instance "foo" @inout (%a) : (i1) -> (i1)
 }
 
+// https://github.com/llvm/circt/issues/525
+// CHECK-LABEL: hw.module @issue525(%struct_0: i2, %else_1: i2) -> (%casex_2: i2)
+// CHECK-NEXT: %0 = comb.add %struct_0, %else_1 : i2
+hw.module @issue525(%struct: i2, %else: i2) -> (%casex: i2) {
+  %2 = comb.add %struct, %else : i2
+  hw.output %2 : i2
+}
+
 // https://github.com/llvm/circt/issues/855
 // CHECK-LABEL: hw.module @nameless_reg
 // CHECK-NEXT: %_T = sv.reg : !hw.inout<i4>
@@ -84,8 +92,6 @@ hw.module @ModuleWithCollision(%reg: i1) -> (%wire: i1) {
 hw.module @InstanceWithCollisions(%a: i1) {
   hw.instance "parameter" @ModuleWithCollision(%a) : (i1) -> (i1)
 }
-
-
 
 // TODO: Renaming the above interface declarations currently does not rename
 // their use in the following types.

--- a/test/ExportVerilog/hw-dialect.mlir
+++ b/test/ExportVerilog/hw-dialect.mlir
@@ -465,44 +465,6 @@ hw.module @TestZeroInstance(%aa: i4, %azeroBit: i0, %aarrZero: !hw.array<3xi0>)
   hw.output %o1, %o2, %o3 : i4, i0, !hw.array<3xi0>
 }
 
-// CHECK-LABEL: TestDupInstanceName
-hw.module @TestDupInstanceName(%a: i1) {
-  // CHECK: B name (
-  %w1, %y1 = hw.instance "name" @B(%a) : (i1) -> (i1, i1)
-
-  // CHECK: B name_0 (
-  %w2, %y2 = hw.instance "name" @B(%a) : (i1) -> (i1, i1)
-}
-
-// CHECK-LABEL: TestEmptyInstanceName
-hw.module @TestEmptyInstanceName(%a: i1) {
-  // CHECK: B _T (
-  %w1, %y1 = hw.instance "" @B(%a) : (i1) -> (i1, i1)
-
-  // CHECK: B _T_0 (
-  %w2, %y2 = hw.instance "" @B(%a) : (i1) -> (i1, i1)
-}
-
-// CHECK-LABEL: TestInstanceNameValueConflict
-hw.module @TestInstanceNameValueConflict(%a: i1) {
-  // CHECK: wire name
-  %name = sv.wire : !hw.inout<i1>
-
-  // CHECK: B name_0 (
-  %w, %y = hw.instance "name" @B(%a) : (i1) -> (i1, i1)
-}
-
-// https://github.com/llvm/circt/issues/525
-hw.module @issue525(%struct: i2, %else: i2) -> (%casex: i2) {
-  %2 = comb.add %struct, %else : i2
-  hw.output %2 : i2
-}
-// CHECK-LABEL: module issue525(
-// CHECK-NEXT: input  [1:0] struct_0, else_1,
-// CHECK-NEXT: output [1:0] casex_2);
-// CHECK: assign casex_2 = struct_0 + else_1;
-
-
 // https://github.com/llvm/circt/issues/438
 // CHECK-LABEL: module cyclic
 hw.module @cyclic(%a: i1) -> (%b: i1) {

--- a/test/ExportVerilog/verilog-basic.mlir
+++ b/test/ExportVerilog/verilog-basic.mlir
@@ -113,8 +113,8 @@ hw.module @Precedence(%a: i4, %b: i4, %c: i4) -> (%out1: i1, %out: i10) {
   %c0_i5 = hw.constant 0 : i5
   %c0_i3 = hw.constant 0 : i3
   %c0_i6 = hw.constant 0 : i6
-  %.out1.output = sv.wire  : !hw.inout<i1>
-  %.out.output = sv.wire  : !hw.inout<i10>
+  %_out1_output = sv.wire  : !hw.inout<i1>
+  %_out_output = sv.wire  : !hw.inout<i10>
 
   // CHECK: wire [4:0] _T = {1'h0, b};
   // CHECK: wire [4:0] _T_0 = _T + {1'h0, c};
@@ -146,17 +146,17 @@ hw.module @Precedence(%a: i4, %b: i4, %c: i4) -> (%out1: i1, %out: i10) {
   %4 = comb.concat %false, %2 : (i1, i5) -> i6
   %5 = comb.add %3, %4 : i6
   %6 = comb.concat %c0_i4, %5 : (i4, i6) -> i10
-  sv.connect %.out.output, %6 : i10
+  sv.connect %_out_output, %6 : i10
   %7 = comb.concat %false, %a : (i1, i4) -> i5
   %8 = comb.add %7, %0 : i5
   %9 = comb.concat %false, %8 : (i1, i5) -> i6
   %10 = comb.concat %c0_i2, %c : (i2, i4) -> i6
   %11 = comb.sub %9, %10 : i6
   %12 = comb.concat %c0_i4, %11 : (i4, i6) -> i10
-  sv.connect %.out.output, %12 : i10
+  sv.connect %_out_output, %12 : i10
   %13 = comb.sub %3, %4 : i6
   %14 = comb.concat %c0_i4, %13 : (i4, i6) -> i10
-  sv.connect %.out.output, %14 : i10
+  sv.connect %_out_output, %14 : i10
   %15 = comb.concat %c0_i4, %b : (i4, i4) -> i8
   %16 = comb.concat %c0_i4, %c : (i4, i4) -> i8
   %17 = comb.mul %15, %16 : i8
@@ -164,45 +164,45 @@ hw.module @Precedence(%a: i4, %b: i4, %c: i4) -> (%out1: i1, %out: i10) {
   %19 = comb.concat %false, %17 : (i1, i8) -> i9
   %20 = comb.add %18, %19 : i9
   %21 = comb.concat %false, %20 : (i1, i9) -> i10
-  sv.connect %.out.output, %21 : i10
+  sv.connect %_out_output, %21 : i10
   %22 = comb.concat %c0_i4, %a : (i4, i4) -> i8
   %23 = comb.mul %22, %15 : i8
   %24 = comb.concat %false, %23 : (i1, i8) -> i9
   %25 = comb.concat %c0_i5, %c : (i5, i4) -> i9
   %26 = comb.add %24, %25 : i9
   %27 = comb.concat %false, %26 : (i1, i9) -> i10
-  sv.connect %.out.output, %27 : i10
+  sv.connect %_out_output, %27 : i10
   %28 = comb.concat %c0_i4, %8 : (i4, i5) -> i9
   %29 = comb.mul %28, %25 : i9
   %30 = comb.concat %false, %29 : (i1, i9) -> i10
-  sv.connect %.out.output, %30 : i10
+  sv.connect %_out_output, %30 : i10
   %31 = comb.concat %c0_i4, %2 : (i4, i5) -> i9
   %32 = comb.mul %18, %31 : i9
   %33 = comb.concat %false, %32 : (i1, i9) -> i10
-  sv.connect %.out.output, %33 : i10
+  sv.connect %_out_output, %33 : i10
   %34 = comb.concat %c0_i5, %8 : (i5, i5) -> i10
   %35 = comb.concat %c0_i5, %2 : (i5, i5) -> i10
   %36 = comb.mul %34, %35 : i10
-  sv.connect %.out.output, %36 : i10
+  sv.connect %_out_output, %36 : i10
   %37 = comb.parity %2 : i5
-  sv.connect %.out1.output, %37 : i1
+  sv.connect %_out1_output, %37 : i1
   %38 = comb.icmp ult %b, %c : i4
   %39 = comb.icmp ugt %b, %c : i4
   %40 = comb.or %38, %39 : i1
-  sv.connect %.out1.output, %40 : i1
+  sv.connect %_out1_output, %40 : i1
   %41 = comb.xor %b, %c : i4
-  %42 = sv.read_inout %.out1.output : !hw.inout<i1>
+  %42 = sv.read_inout %_out1_output : !hw.inout<i1>
   %43 = comb.concat %c0_i3, %42 : (i3, i1) -> i4
   %44 = comb.and %41, %43 : i4
   %45 = comb.concat %c0_i6, %44 : (i6, i4) -> i10
-  sv.connect %.out.output, %45 : i10
-  %46 = sv.read_inout %.out.output : !hw.inout<i10>
+  sv.connect %_out_output, %45 : i10
+  %46 = sv.read_inout %_out_output : !hw.inout<i10>
   %47 = comb.extract %46 from 2 : (i10) -> i8
   %48 = comb.concat %c0_i2, %47 : (i2, i8) -> i10
-  sv.connect %.out.output, %48 : i10
+  sv.connect %_out_output, %48 : i10
   %49 = comb.concat %c0_i6, %a : (i6, i4) -> i10
   %50 = comb.icmp ult %46, %49 : i10
-  sv.connect %.out1.output, %50 : i1
+  sv.connect %_out1_output, %50 : i1
   hw.output %42, %46 : i1, i10
 }
 

--- a/test/ExportVerilog/verilog-errors.mlir
+++ b/test/ExportVerilog/verilog-errors.mlir
@@ -13,3 +13,11 @@ hw.module @parameter() {
 // expected-error @+2 {{unknown style option 'badOption'}}
 // expected-error @+1 {{unknown style option 'anotherOne'}}
 module attributes {circt.loweringOptions = "badOption,anotherOne"} {}
+
+// -----
+
+// expected-error @+2 {{Port name changed durring emission}}
+// expected-error @+1 {{Output port name changed durring emission}}
+hw.module @namechange(%casex: i4) -> (%if: i4) {
+  hw.output %casex : i4
+}

--- a/test/ExportVerilog/verilog-errors.mlir
+++ b/test/ExportVerilog/verilog-errors.mlir
@@ -16,8 +16,8 @@ module attributes {circt.loweringOptions = "badOption,anotherOne"} {}
 
 // -----
 
-// expected-error @+2 {{Port name changed durring emission}}
-// expected-error @+1 {{Output port name changed durring emission}}
+// expected-error @+2 {{name 'casex' changed during emission}}
+// expected-error @+1 {{name 'if' changed during emission}}
 hw.module @namechange(%casex: i4) -> (%if: i4) {
   hw.output %casex : i4
 }


### PR DESCRIPTION
Name legalization is happening twice, once via a dedicated pass, again in export verilog.  This changes export verilog to not change the name of any port, wire, register, or instance durring emission, depending instead on legalize-names having done so already.  This is done by pre-populating the name table durring the prepare phase with incoming names, so that subsequent temporary names will never displace input names.
