### PR TITLE
[FIRParser] Don't optimize validif in the parser

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1705,17 +1705,7 @@ ParseResult FIRStmtParser::parsePrimExp(Value &result) {
     }
 
     // We always skip emitting the validif mux because it always folds to the
-    // non-invalid operand.  However, if we know the validif would always return
-    // invalid, then fold to invalid instead.
-    if (auto cst = operands[0].getDefiningOp<ConstantOp>()) {
-      // validif(0, x) -> always invalid.
-      if (cst.value().isNullValue()) {
-        result = builder.create<InvalidValueOp>(opTypes[1]);
-        return success();
-      }
-    }
-
-    // Otherwise, fold to the non-invalid value.
+    // non-invalid operand. 
     result = operands[1];
     return success();
   }

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -1417,25 +1417,27 @@ firrtl.module @mul_cst_prop3(out %out_b: !firrtl.sint<15>) {
 
 // CHECK-LABEL: firrtl.module @MuxInvalidOpt
 firrtl.module @MuxInvalidOpt(in %cond: !firrtl.uint<1>, in %data: !firrtl.uint<4>, out %out1: !firrtl.uint<4>, out %out2: !firrtl.uint<4>, out %out3: !firrtl.uint<4>, out %out4: !firrtl.uint<4>) {
+  %invalid = firrtl.invalidvalue : !firrtl.uint<4>
 
   // We can optimize out these mux's since the invalid value can take on any input.
-  %tmp1 = firrtl.invalidvalue : !firrtl.uint<4>
-  %a = firrtl.mux(%cond, %data, %tmp1) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  // CHECK:         firrtl.connect %out1, %data
+  %a = firrtl.mux(%cond, %data, %invalid) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  // CHECK: firrtl.connect %out1, %data
   firrtl.connect %out1, %a : !firrtl.uint<4>, !firrtl.uint<4>
 
-  %b = firrtl.mux(%cond, %tmp1, %data) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  // CHECK:         firrtl.connect %out2, %data
+  %b = firrtl.mux(%cond, %invalid, %data) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  // CHECK: firrtl.connect %out2, %data
   firrtl.connect %out2, %b : !firrtl.uint<4>, !firrtl.uint<4>
 
+  // This fold is required to return %data for SFC compatibility.
   %false = firrtl.constant 0 : !firrtl.uint<1>
-  %c = firrtl.mux(%false, %data, %tmp1) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  // CHECK:         firrtl.connect %out3, %data
+  %c = firrtl.mux(%false, %data, %invalid) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  // CHECK: firrtl.connect %out3, %data
   firrtl.connect %out3, %c : !firrtl.uint<4>, !firrtl.uint<4>
 
+  // This fold is required to return %data for SFC compatibility.
   %true = firrtl.constant 1 : !firrtl.uint<1>
-  %d = firrtl.mux(%false, %tmp1, %data) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  // CHECK:         firrtl.connect %out4, %data
+  %d = firrtl.mux(%true, %invalid, %data) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  // CHECK: firrtl.connect %out4, %data
   firrtl.connect %out4, %d : !firrtl.uint<4>, !firrtl.uint<4>
 }
 

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -803,6 +803,11 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %out2 = firrtl.node %in2 
     node out2 = validif(en, in2)
 
+    ; This is required for SFC compatibility. 
+    ; https://github.com/llvm/circt/issues/1186
+    ; CHECK: %out3 = firrtl.node %in1
+    node out3 = validif(UInt<1>(0), in1)
+
   ; Test that behavioral memory reads and writes both work and that flow checks
   ; don't fail here.  (A memory port should have duplex flow.)
   ; See: https://github.com/llvm/circt/issues/1058
@@ -836,17 +841,3 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     output c: UInt<8>
     c <= mux(sel, a, b)
 
-  ; CHECK-LABEL: firrtl.module @InvalidIfFolding
-  module InvalidIfFolding:
-    input value: UInt<1>
-
-    node thing1 = validif(UInt<1>("h1"), UInt<1>("h0"))
-    ; CHECK-NOT: firrtl.invalidvalue
-    ; CHECK: %thing1 = firrtl.node %c0_ui1
- 
-    node thing2 = validif(UInt<1>("h0"), UInt<1>("h0"))
-    ; CHECK: %invalid_ui1 = firrtl.invalidvalue
-    ; CHECK: %thing2 = firrtl.node %invalid_ui1
-
-    node thing3 = validif(value, value) @[Locator.scala 229:17]
-    ; CHECK: %thing3 = firrtl.node %value


### PR DESCRIPTION
This pattern is already handled by the FIRRTL folders.  As a side effect
of this change, we are now aligning with how the Scala FIRRTL compiler
handles validif with a constant condition:

`validif(0, invalid, value)`:
 - old: condition always false, return invalid.
 - new: mux with an invalid operand, return the other operand.

This fixes #1186.