### PR TITLE
[Python] Fix format check by specifying bash as shell.

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -256,6 +256,7 @@ jobs:
       # Run yapf to check Python formatting.
       - name: python-format
         if: ${{ always() }}
+        shell: bash -e {0}
         run: |
           files=$(git diff --name-only $DIFF_COMMIT | grep .py || echo -n)
           if [[ ! -z $files ]]; then


### PR DESCRIPTION
The default shell is `sh -e {0}`, which leads to the error:

`[[: not found`

This uses `bash` instead of `sh`.