### PR TITLE
[FIRRTL] Add canonicalization for EQ/NEQ PrimOp

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -286,8 +286,10 @@ let inferType = "impl::inferComparisonResult" in {
     def GEQPrimOp : IntBinaryPrimOp<"geq", UInt1Type>;
     def GTPrimOp  : IntBinaryPrimOp<"gt",  UInt1Type>;
   }
-  def EQPrimOp  : IntBinaryPrimOp<"eq",  UInt1Type, [Commutative]>;
-  def NEQPrimOp : IntBinaryPrimOp<"neq", UInt1Type, [Commutative]>;
+  let hasCanonicalizeMethod = true in {
+    def EQPrimOp  : IntBinaryPrimOp<"eq",  UInt1Type, [Commutative]>;
+    def NEQPrimOp : IntBinaryPrimOp<"neq", UInt1Type, [Commutative]>;
+  }
 }
 
 def CatPrimOp : IntBinaryPrimOp<"cat", UIntType> {

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -162,28 +162,68 @@ firrtl.module @Xor(in %in: !firrtl.uint<4>,
 }
 
 // CHECK-LABEL: firrtl.module @EQ
-firrtl.module @EQ(in %in: !firrtl.uint<1>,
+firrtl.module @EQ(in %in1: !firrtl.uint<1>,
+                  in %in4: !firrtl.uint<4>,
                   out %out: !firrtl.uint<1>) {
-  // CHECK: firrtl.connect %out, %in
+  // CHECK: firrtl.connect %out, %in1
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-  %0 = firrtl.eq %in, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %0 = firrtl.eq %in1, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // Issue #368: https://github.com/llvm/circt/issues/368
   %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
-  %1 = firrtl.eq %in, %c3_ui2 : (!firrtl.uint<1>, !firrtl.uint<2>) -> !firrtl.uint<1>
+  %1 = firrtl.eq %in1, %c3_ui2 : (!firrtl.uint<1>, !firrtl.uint<2>) -> !firrtl.uint<1>
   firrtl.connect %out, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.eq %in, %c3_ui2
-  // CHECK: firrtl.connect
+  // CHECK: firrtl.eq %in1, %c3_ui2
+  // CHECK-NEXT: firrtl.connect
+
+  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+  %2 = firrtl.eq %in1, %c0_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  firrtl.connect %out, %2 : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.not %in1
+  // CHECK-NEXT: firrtl.connect
+
+  %c15_ui4 = firrtl.constant 15 : !firrtl.uint<4>
+  %3 = firrtl.eq %in4, %c15_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
+  firrtl.connect %out, %3 : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK: firrtl.andr %in4
+  // CHECK-NEXT: firrtl.connect
+
+  %4 = firrtl.eq %in4, %c0_ui1 : (!firrtl.uint<4>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  firrtl.connect %out, %4 : !firrtl.uint<1>, !firrtl.uint<1>
+
+  // CHECK: [[ORR:%.+]] = firrtl.orr %in4
+  // CHECK-NEXT: firrtl.not [[ORR]]
+  // CHECK-NEXT: firrtl.connect
 }
 
 // CHECK-LABEL: firrtl.module @NEQ
-firrtl.module @NEQ(in %in: !firrtl.uint<1>,
+firrtl.module @NEQ(in %in1: !firrtl.uint<1>,
+                   in %in4: !firrtl.uint<4>,
                    out %out: !firrtl.uint<1>) {
   // CHECK: firrtl.connect %out, %in
-  %c1_ui0 = firrtl.constant 0 : !firrtl.uint<1>
-  %0 = firrtl.neq %in, %c1_ui0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+  %0 = firrtl.neq %in1, %c0_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+
+  %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+  %1 = firrtl.neq %in1, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  firrtl.connect %out, %1 : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.not %in1
+  // CHECK-NEXT: firrtl.connect
+
+  %2 = firrtl.neq %in4, %c0_ui1 : (!firrtl.uint<4>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  firrtl.connect %out, %2 : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK: firrtl.orr %in4
+  // CHECK-NEXT: firrtl.connec
+
+  %c15_ui4 = firrtl.constant 15 : !firrtl.uint<4>
+  %3 = firrtl.neq %in4, %c15_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
+  firrtl.connect %out, %3 : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK: [[ANDR:%.+]] = firrtl.andr %in4
+  // CHECK-NEXT: firrtl.not [[ANDR]]
+  // CHECK-NEXT: firrtl.connect
+
 }
 
 // CHECK-LABEL: firrtl.module @Cat


### PR DESCRIPTION
This PR adds the following canonicalization for EQPrimOp and NEQPrimOp. 

* EQPrimOp
```
 eq(x, 0) ->  not(x) when x is 1 bit
 eq(x, 0) ->  not(orr(x)) when x is 1> bit
 eq(x, ~0) ->  andr(x) when x is 1> bit
```

* NEQPrimOp
```
 neq(x, 1) ->  not(x) when x is 1 bit
 neq(x, 0) ->  orr(x) when x is 1> bit
 neq(x, ~0) ->  not(andr(x)) when x is 1> bit
```