### PR TITLE
[PyCDE] Store design parameters in the 'parameters' attribute

### DIFF
--- a/frontends/PyCDE/src/pycde/module.py
+++ b/frontends/PyCDE/src/pycde/module.py
@@ -69,7 +69,7 @@ def module(cls):
       input_ports: list[Input] = []
       output_ports: list[Output] = []
       parameters: list[Parameter] = []
-      attributes: dict[str: mlir.ir.Attribute] = {}
+      attributes: dict[str:mlir.ir.Attribute] = {}
       # Scan for them.
       for attr_name in dir(self):
         if attr_name in dont_touch:

--- a/frontends/PyCDE/src/pycde/module.py
+++ b/frontends/PyCDE/src/pycde/module.py
@@ -61,13 +61,15 @@ def module(cls):
 
       # The OpView attributes cannot be touched before OpView is constructed.
       # Get a list and don't touch them.
-      dont_touch = set([x for x in dir(mlir.ir.OpView)])
+      dont_touch = set()
+      dont_touch.update([x for x in dir(mlir.ir.OpView)])
+      dont_touch.update(["OPERATION_NAME", "_ODS_REGIONS"])
 
       # After the wrapped class' construct, all the IO should be known.
       input_ports: list[Input] = []
       output_ports: list[Output] = []
       parameters: list[Parameter] = []
-
+      attributes: dict[str: mlir.ir.Attribute] = {}
       # Scan for them.
       for attr_name in dir(self):
         if attr_name in dont_touch:
@@ -76,12 +78,16 @@ def module(cls):
         if isinstance(attr, Input):
           attr.name = attr_name
           input_ports.append(attr)
-        if isinstance(attr, Output):
+        elif isinstance(attr, Output):
           attr.name = attr_name
           output_ports.append(attr)
-        if isinstance(attr, Parameter):
+        elif isinstance(attr, Parameter):
           attr.name = attr_name
           parameters.append(attr)
+        else:
+          mlir_attr = support.var_to_attribute(attr, True)
+          if mlir_attr is not None:
+            attributes[attr_name] = mlir_attr
 
       # Build a list of operand values for the operation we're gonna create.
       input_ports_values: list[mlir.ir.Value] = []
@@ -105,7 +111,8 @@ def module(cls):
           [mlir.ir.StringAttr.get(x.name) for x in output_ports])
 
       # Set up the op attributes.
-      attributes = {p.name: p.attr for p in parameters}
+      parameters = {p.name: p.attr for p in parameters}
+      attributes["parameters"] = mlir.ir.DictAttr.get(parameters)
       attributes["opNames"] = op_names_attr
       attributes["resultNames"] = result_names_attr
 
@@ -183,13 +190,18 @@ class _Generate:
         (n.value, o.type) for (n, o) in zip(result_names, op.results)
     ]
 
-    # Assemble the attributes and present them as parameters.
+    # Assemble the parameters.
     params = {
         nattr.name: nattr.attr
-        for nattr in op.attributes
-        if nattr.name not in ["opNames", "resultNames"]
+        for nattr in mlir.ir.DictAttr(op.attributes["parameters"])
     }
     self.params = type(f"{op.name}_params", (object,), params)
+
+    attrs = {
+        nattr.name: nattr.attr
+        for nattr in op.attributes
+        if nattr.name not in ["opNames", "resultNames", "parameters"]
+    }
 
     # Build the replacement HWModuleOp in the outer module.
     with mlir.ir.InsertionPoint(mod.regions[0].blocks[0]):
@@ -201,7 +213,10 @@ class _Generate:
     # Build a replacement instance at the op to be replaced.
     with mlir.ir.InsertionPoint(op):
       mapping = {name.value: op.operands[i] for i, name in enumerate(op_names)}
-      return mod.create(op.name, **mapping).operation
+      inst = mod.create(op.name, **mapping).operation
+      for (name, attr) in attrs.items():
+        inst.attributes[name] = attr
+      return inst
 
 
 def generator(func):

--- a/frontends/PyCDE/test/polynomial.py
+++ b/frontends/PyCDE/test/polynomial.py
@@ -17,8 +17,9 @@ class PolynomialCompute:
   # Evaluate polynomial for 'x'.
   x = Input(types.i32)
 
-  def __init__(self, coefficients: list[int], **kwargs):
+  def __init__(self, name: str, coefficients: list[int], **kwargs):
     """coefficients is in 'd' -> 'a' order."""
+    self.instanceName = name
     self.coefficients = Parameter(coefficients)
     # Full result.
     self.y = Output(types.i32)
@@ -59,7 +60,8 @@ class Polynomial(pycde.System):
   def build(self, top):
     i32 = types.i32
     x = hw.ConstantOp.create(i32, 23)
-    poly = PolynomialCompute([62, 42, 6], x=x)
+    poly = PolynomialCompute("example", [62, 42, 6], x=x)
+    # PolynomialCompute("example", [62, 42, 6], x=poly.y)
     hw.OutputOp([poly.y])
 
 
@@ -68,7 +70,7 @@ poly = Polynomial()
 poly.print()
 # CHECK:  hw.module @top() -> (%y: i32) {
 # CHECK:    %c23_i32 = hw.constant 23 : i32
-# CHECK:    [[REG0:%.+]] = "pycde.PolynomialCompute"(%c23_i32) {coefficients = [62, 42, 6], opNames = ["x"], resultNames = ["y"]} : (i32) -> i32
+# CHECK:    [[REG0:%.+]] = "pycde.PolynomialCompute"(%c23_i32) {instanceName = "example", opNames = ["x"], parameters = {coefficients = [62, 42, 6]},  resultNames = ["y"]} : (i32) -> i32
 # CHECK:    hw.output [[REG0]] : i32
 
 poly.generate()

--- a/lib/Bindings/Python/circt/support.py
+++ b/lib/Bindings/Python/circt/support.py
@@ -52,7 +52,7 @@ def connect(destination, source):
     destination.builder.backedges[index].erase()
 
 
-def var_to_attribute(obj) -> ir.Attribute:
+def var_to_attribute(obj, none_on_fail: bool = False) -> ir.Attribute:
   """Create an MLIR attribute from a Python object for a few common cases."""
   if isinstance(obj, ir.Attribute):
     return obj
@@ -63,6 +63,8 @@ def var_to_attribute(obj) -> ir.Attribute:
     return ir.StringAttr.get(obj)
   if isinstance(obj, list):
     return ir.ArrayAttr.get([var_to_attribute(x) for x in obj])
+  if none_on_fail:
+    return None
   raise TypeError(f"Cannot convert type '{type(obj)}' to MLIR attribute")
 
 


### PR DESCRIPTION
All other attributes come from object members (which can be converted to
attributes) and get inherited by the instance.