### PR TITLE
[PyCDE] De-duplicate modules that are structurally equivalent.

### DIFF
--- a/frontends/PyCDE/test/polynomial.py
+++ b/frontends/PyCDE/test/polynomial.py
@@ -61,7 +61,7 @@ class Polynomial(pycde.System):
     i32 = types.i32
     x = hw.ConstantOp.create(i32, 23)
     poly = PolynomialCompute("example", [62, 42, 6], x=x)
-    # PolynomialCompute("example", [62, 42, 6], x=poly.y)
+    PolynomialCompute("example", [62, 42, 6], x=poly.y)
     hw.OutputOp([poly.y])
 
 
@@ -75,6 +75,11 @@ poly.print()
 
 poly.generate()
 poly.print()
+# CHECK: hw.module @top
+# CHECK: hw.instance "example" @pycde.PolynomialCompute
+# CHECK: hw.instance "example" @pycde.PolynomialCompute
+# CHECK: hw.module @pycde.PolynomialCompute
+# CHECK-NOT: hw.module @pycde.PolynomialCompute
 
 print("\n\n=== Verilog ===")
 # CHECK-LABEL: === Verilog ===

--- a/frontends/PyCDE/test/polynomial.py
+++ b/frontends/PyCDE/test/polynomial.py
@@ -61,7 +61,7 @@ class Polynomial(pycde.System):
     i32 = types.i32
     x = hw.ConstantOp.create(i32, 23)
     poly = PolynomialCompute("example", [62, 42, 6], x=x)
-    PolynomialCompute("example", [62, 42, 6], x=poly.y)
+    PolynomialCompute("example2", [62, 42, 6], x=poly.y)
     hw.OutputOp([poly.y])
 
 
@@ -77,7 +77,7 @@ poly.generate()
 poly.print()
 # CHECK: hw.module @top
 # CHECK: hw.instance "example" @pycde.PolynomialCompute
-# CHECK: hw.instance "example" @pycde.PolynomialCompute
+# CHECK: hw.instance "example2" @pycde.PolynomialCompute
 # CHECK: hw.module @pycde.PolynomialCompute
 # CHECK-NOT: hw.module @pycde.PolynomialCompute
 


### PR DESCRIPTION
This de-duplicates modules by the following properties:
  * The Operation name being generated
  * The Operation's Input types
  * The Operation's Output types
  * The Operation's Parameters

This allows the same PyCDE operation to be instantiated multiple
times, without trying to define the module multiple times.