### PR TITLE
[LowerToHW] Add symbol to wires only if DontTouch annotation present

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1575,21 +1575,19 @@ LogicalResult FIRRTLLowering::visitDecl(WireOp op) {
 
   if (!AnnotationSet(op).hasDontTouch())
     return setLoweringTo<sv::WireOp>(op, resultType, nameAttr);
-  auto moduleName =
-      cast<hw::HWModuleOp>(op->getParentOp()).getNameAttr().getValue().str();
+  auto moduleName = cast<hw::HWModuleOp>(op->getParentOp()).getName();
   auto symName = op.nameAttr();
   // Prepend the name of the module to make the symbol name unique in the symbol
   // table, it is already unique in the module. Checking if the name is unique
   // in the SymbolTable is non-trivial.
   if (symName && !symName.getValue().empty())
-    symName = builder.getStringAttr("__" + moduleName + "__" +
-                                    symName.getValue().str());
+    symName = builder.getStringAttr(
+        (Twine("__") + moduleName + Twine("__") + symName.getValue()).str());
   else
     // If marked with DontTouch but does not have a name, then add a symbol
-    // name.
-    // TODO: Add an id to make the symbol name unique, what's the best way to
-    // generate the id?
-    symName = builder.getStringAttr("__" + moduleName + "__");
+    // name. Note: Same symbol name for all such wires in the module.
+    symName =
+        builder.getStringAttr((Twine("__") + moduleName + Twine("__")).str());
 
   // This is not a temporary wire created by the compiler, so attach a symbol
   // name.

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
@@ -100,8 +100,8 @@ firrtl.circuit "Simple" {
                              out %outD: !firrtl.uint<4>,
                              in %inE: !firrtl.uint<3>,
                              out %outE: !firrtl.uint<4>) {
-    // CHECK: [[OUTC:%.+]] = sv.wire sym @__PortMadness__.outC.output : !hw.inout<i4>
-    // CHECK: [[OUTD:%.+]] = sv.wire sym @__PortMadness__.outD.output : !hw.inout<i4>
+    // CHECK: [[OUTC:%.+]] = sv.wire : !hw.inout<i4>
+    // CHECK: [[OUTD:%.+]] = sv.wire : !hw.inout<i4>
 
     // Normal
     firrtl.connect %outA, %inA : !firrtl.uint<4>, !firrtl.uint<4>

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -20,9 +20,13 @@ firrtl.circuit "Simple" {
 
 
     // CHECK: %out4 = sv.wire sym @__Simple__out4 : !hw.inout<i4>
-    // CHECK: %out5 = sv.wire sym @__Simple__out5 : !hw.inout<i4>
-    %out4 = firrtl.wire : !firrtl.uint<4>
+    // CHECK: %out5 = sv.wire : !hw.inout<i4>
+    %out4 = firrtl.wire {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<4>
     %out5 = firrtl.wire : !firrtl.uint<4>
+    // CHECK: sv.wire sym @__Simple{{.*}} 
+    // CHECK: sv.wire sym @__Simple{{.*}} 
+    %500 = firrtl.wire {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<4>
+    %501 = firrtl.wire {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<5>
 
     // CHECK: sv.connect %out5, %c0_i4 : i4
     %tmp1 = firrtl.invalidvalue : !firrtl.uint<4>
@@ -74,9 +78,9 @@ firrtl.circuit "Simple" {
     firrtl.connect %out4, %in2 : !firrtl.uint<4>, !firrtl.uint<2>
 
     // CHECK-NEXT: %test-name = sv.wire sym @"__Simple__test-name" : !hw.inout<i4>
-    firrtl.wire {name = "test-name"} : !firrtl.uint<4>
+    firrtl.wire {name = "test-name", annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<4>
 
-    // CHECK-NEXT: = sv.wire sym @__Simple___t_1 : !hw.inout<i2>
+    // CHECK-NEXT: = sv.wire : !hw.inout<i2>
     %_t_1 = firrtl.wire : !firrtl.uint<2>
 
     // CHECK-NEXT: = firrtl.wire : !firrtl.vector<uint<1>, 13>
@@ -357,7 +361,7 @@ firrtl.circuit "Simple" {
   // CHECK-LABEL: hw.module @foo
   firrtl.module @foo() {
     // CHECK-NEXT:  %io_cpu_flush.wire = sv.wire sym @__foo__io_cpu_flush.wire : !hw.inout<i1>
-    %io_cpu_flush.wire = firrtl.wire : !firrtl.uint<1>
+    %io_cpu_flush.wire = firrtl.wire {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<1>
     // CHECK-NEXT: hw.instance "fetch" @bar([[IO:%[0-9]+]])
     %i = firrtl.instance @bar {name = "fetch", portNames=["io_cpu_flush"]} : !firrtl.flip<uint<1>>
     firrtl.connect %i, %io_cpu_flush.wire : !firrtl.flip<uint<1>>, !firrtl.uint<1>
@@ -374,7 +378,7 @@ firrtl.circuit "Simple" {
   // CHECK-LABEL: hw.module @issue314
   firrtl.module @issue314(in %inp_2: !firrtl.uint<27>, in %inpi: !firrtl.uint<65>) {
     // CHECK: %c0_i38 = hw.constant 0 : i38
-    // CHECK: %tmp48 = sv.wire sym @__issue314__tmp48 : !hw.inout<i27>
+    // CHECK: %tmp48 = sv.wire : !hw.inout<i27>
     %tmp48 = firrtl.wire : !firrtl.uint<27>
 
     // CHECK-NEXT: %0 = comb.concat %c0_i38, %inp_2 : (i38, i27) -> i65

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -45,9 +45,8 @@ circuit test_mod : %[[{"a": "a"}]]
 ; Check that we canonicalize the HW output of lowering.
 ;
 ; MLIRLOWER: hw.module @cat(%a: i2, %b: i2, %c: i2) -> (%d: i6) {
-; MLIRLOWER:   %.d.output = sv.wire sym @__cat__.d.output : !hw.inout<i6>
-; MLIRLOWER:   %0 = sv.read_inout %.d.output : !hw.inout<i6>
-; MLIRLOWER:   hw.output %0 : i6
+; MLIRLOWER:   %x_i6 = sv.constantX : i6
+; MLIRLOWER:   hw.output %x_i6 : i6
 ; MLIRLOWER: }
 
   module implicitTrunc :
@@ -116,6 +115,5 @@ circuit test_mod : %[[{"a": "a"}]]
 ; VERILOG-LABEL: module flipFlop(
 ; VERILOG-NEXT:    input clock, a_d,
 ; VERILOG-NEXT:    output a_q);
-; VERILOG:         wire _a_q_output;
-; VERILOG:         assign a_q = _a_q_output;
+; VERILOG:         assign a_q = 1'bx;
 ; VERILOG:       endmodule


### PR DESCRIPTION
Update the `LowerToHW` to add symbol to `WireOp` only if the `DontTouch` annotation is present.
This removes all the temporary wires added during `FIRRTL` transformations.
This should also remove the dependency on wire names, to determine if they are temporary.
Yet to handle, the case when `DontTouch` annotation present, but no name on wire, how to generate a unique name ?
Lit tests confirms this also removes the temporary wires left after `IMConstProp`