### PR TITLE
[FIRRTL] Add instance graph

### DIFF
--- a/include/circt/Dialect/FIRRTL/InstanceGraph.h
+++ b/include/circt/Dialect/FIRRTL/InstanceGraph.h
@@ -1,0 +1,261 @@
+//===- InstanceGraph.h - Instance graph -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the FIRRTL InstanceGraph, which is similar to a CallGraph.
+//
+//===----------------------------------------------------------------------===//
+#ifndef CIRCT_DIALECT_FIRRTL_INSTANCEGRAPH_H
+#define CIRCT_DIALECT_FIRRTL_INSTANCEGRAPH_H
+
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Support/LLVM.h"
+#include "llvm/ADT/GraphTraits.h"
+#include "llvm/ADT/iterator.h"
+
+namespace circt {
+namespace firrtl {
+
+class InstanceGraphNode;
+
+/// This is an edge in the InstanceGraph. This tracks a specific instantiation
+/// of a module.
+class InstanceRecord {
+public:
+  /// Get the InstanceOp that this is tracking.
+  InstanceOp getInstance() const { return instance; }
+
+  /// Get the module where the InstanceOp lives.
+  InstanceGraphNode *getParent() const { return parent; }
+
+  /// Get the module which the InstanceOp is instantiating.
+  InstanceGraphNode *getTarget() const { return target; }
+
+private:
+  InstanceRecord(InstanceOp instance, InstanceGraphNode *parent,
+                 InstanceGraphNode *target)
+      : instance(instance), parent(parent), target(target) {}
+
+  /// The InstanceOp that this is tracking.
+  InstanceOp instance;
+
+  /// This is the module where the InstanceOp lives.
+  InstanceGraphNode *parent;
+
+  /// This is the module which the InstanceOp is instantiating.
+  InstanceGraphNode *target;
+
+  // Provide access to the constructor.
+  friend class InstanceGraphNode;
+};
+
+/// This is a Node in the InstanceGraph.  Each node represents a Module in a
+/// Circuit.  Both external modules and regular modules can be represented by
+/// this class. It is possible to efficiently iterate all modules instantiated
+/// by this module, as well as all instantiations of this module.
+class InstanceGraphNode {
+  using EdgeVec = std::vector<std::unique_ptr<InstanceRecord>>;
+  using UseVec = std::vector<InstanceRecord *>;
+
+  class InstanceIterator final
+      : public llvm::mapped_iterator<
+            EdgeVec::const_iterator,
+            InstanceRecord *(*)(const EdgeVec::value_type &)> {
+    static InstanceRecord *unwrap(const EdgeVec::value_type &value) {
+      return value.get();
+    }
+
+  public:
+    /// Initializes the result type iterator to the specified result iterator.
+    InstanceIterator(EdgeVec::const_iterator it)
+        : llvm::mapped_iterator<
+              EdgeVec::const_iterator,
+              InstanceRecord *(*)(const EdgeVec::value_type &)>(it, &unwrap) {}
+  };
+
+public:
+  /// Get the module that this node is tracking.
+  Operation *getModule() const { return module; }
+
+  /// Iterate the instance records in this module.
+  using iterator = InstanceIterator;
+  iterator begin() { return iterator(moduleInstances.begin()); }
+  iterator end() { return iterator(moduleInstances.end()); }
+  llvm::iterator_range<iterator> instances() {
+    return llvm::make_range(begin(), end());
+  }
+
+  /// Iterate the instance records which instantiate this module.
+  using use_iterator = UseVec::const_iterator;
+  use_iterator uses_begin() { return moduleUses.begin(); }
+  use_iterator uses_end() { return moduleUses.end(); }
+  llvm::iterator_range<use_iterator> uses() {
+    return llvm::make_range(uses_begin(), uses_end());
+  }
+
+private:
+  InstanceGraphNode() : module(nullptr) {}
+
+  /// Record a new instance op in the body of this module. Returns a newly
+  /// allocated InstanceRecord which will be owned by this node.
+  InstanceRecord *recordInstance(InstanceOp instance,
+                                 InstanceGraphNode *target);
+
+  /// Record that a module instantiates this module.
+  void recordUse(InstanceRecord *record);
+
+  /// The module.
+  Operation *module;
+
+  /// List of instance operations in this module.  This member owns the
+  /// InstanceRecords, which may be pointed to by other InstanceGraohNode's use
+  /// lists.
+  EdgeVec moduleInstances;
+
+  /// List of instances which instantiate this module.
+  UseVec moduleUses;
+
+  // Provide access to the constructor.
+  friend class InstanceGraph;
+};
+
+/// This graph tracks modules and where they are instantiated. This is intended
+/// to be used as a cached analysis on FIRRTL circuits.  This class can be used
+/// to walk the modules efficiently in a bottom-up or top-down order.
+///
+/// To use this class, retrieve a cached copy from the analysis manager:
+///   auto &instanceGraph = getAnalysis<InstanceGraph>(getOperation());
+class InstanceGraph {
+
+  /// Storage for InstanceGraphNodes.
+  using NodeVec = std::vector<std::unique_ptr<InstanceGraphNode>>;
+
+  /// Iterator that unwraps a unique_ptr to return a regular pointer.
+  static InstanceGraphNode *unwrap(const NodeVec::value_type &value) {
+    return value.get();
+  }
+  struct NodeIterator final
+      : public llvm::mapped_iterator<NodeVec::const_iterator,
+                                     decltype(&unwrap)> {
+    /// Initializes the result type iterator to the specified result iterator.
+    NodeIterator(NodeVec::const_iterator it)
+        : llvm::mapped_iterator<NodeVec::const_iterator, decltype(&unwrap)>(
+              it, &unwrap) {}
+  };
+
+public:
+  /// Create a new module graph of a circuit.  This must be called on a FIRRTL
+  /// CircuitOp.
+  explicit InstanceGraph(Operation *operation);
+
+  /// Get the node corresponding to the top-level module of a circuit.
+  InstanceGraphNode *getTopLevelNode() const;
+
+  /// Look up an InstanceGraphNode for a module. Operation must be an FModuleOp
+  /// or an FExtModuleOp.
+  InstanceGraphNode *lookup(Operation *op) const;
+
+  /// Lookup an InstanceGraphNode for a module. Operation must be an FModuleOp
+  /// or an FExtModuleOp.
+  InstanceGraphNode *operator[](Operation *op) const { return lookup(op); }
+
+  /// Look up the referenced module from an InstanceOp. This will use a
+  /// hashtable lookup to find the module, where
+  /// InstanceOp.getReferencedModule() will be a linear search through the IR.
+  Operation *getReferencedModule(InstanceOp op) const;
+
+  /// Iterate through all modules.
+  using iterator = NodeIterator;
+  iterator begin() const { return nodes.begin(); }
+  iterator end() const { return nodes.end(); }
+
+private:
+  /// Get the node corresponding to the module.  If the node has does not exist
+  /// yet, it will be created.
+  InstanceGraphNode *getOrAddNode(StringRef name);
+
+  /// Lookup an module by name.
+  InstanceGraphNode *lookup(StringRef name) const;
+
+  /// The storage for graph nodes, with deterministic iteration.
+  NodeVec nodes;
+
+  /// This maps each operation to its graph node.
+  llvm::StringMap<unsigned> nodeMap;
+};
+
+} // namespace firrtl
+} // namespace circt
+
+namespace llvm {
+template <>
+struct GraphTraits<circt::firrtl::InstanceGraphNode> {
+  using NodeType = circt::firrtl::InstanceGraphNode;
+  using NodeRef = NodeType *;
+
+  // Helper for getting the module referenced by the instance op.
+  static NodeRef getChild(const circt::firrtl::InstanceRecord *record) {
+    return record->getTarget();
+  }
+
+  using ChildIteratorType =
+      llvm::mapped_iterator<NodeType::iterator, decltype(&getChild)>;
+
+  static NodeRef getEntryNode(NodeRef node) { return node; }
+  static ChildIteratorType child_begin(NodeRef node) {
+    return {node->begin(), &getChild};
+  }
+  static ChildIteratorType child_end(NodeRef node) {
+    return {node->end(), &getChild};
+  }
+};
+
+template <>
+struct GraphTraits<circt::firrtl::InstanceGraph *>
+    : public GraphTraits<circt::firrtl::InstanceGraphNode> {
+  using nodes_iterator = circt::firrtl::InstanceGraph::iterator;
+
+  static NodeRef
+  getEntryNode(circt::firrtl::InstanceGraph *instanceGraph) {
+    return instanceGraph->getTopLevelNode();
+  }
+  static nodes_iterator
+  nodes_begin(circt::firrtl::InstanceGraph *instanceGraph) {
+    return instanceGraph->begin();
+  }
+  static nodes_iterator nodes_end(circt::firrtl::InstanceGraph *instanceGraph) {
+    return instanceGraph->end();
+  }
+};
+
+// Provide graph traits for iterating the modules in inverse order.
+template <>
+struct GraphTraits<Inverse<circt::firrtl::InstanceGraphNode *>> {
+  using NodeType = circt::firrtl::InstanceGraphNode;
+  using NodeRef = NodeType *;
+
+  // Helper for getting the module containing the instance op.
+  static NodeRef getParent(const circt::firrtl::InstanceRecord *record) {
+    return record->getParent();
+  }
+
+  using ChildIteratorType =
+      llvm::mapped_iterator<NodeType::use_iterator, decltype(&getParent)>;
+
+  static NodeRef getEntryNode(Inverse<NodeRef> inverse) {
+    return inverse.Graph;
+  }
+  static ChildIteratorType child_begin(NodeRef node) {
+    return {node->uses_begin(), &getParent};
+  }
+  static ChildIteratorType child_end(NodeRef node) {
+    return {node->uses_end(), &getParent};
+  }
+};
+
+} // end namespace llvm
+#endif // CIRCT_DIALECT_FIRRTL_INSTANCEGRAPH_H

--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -37,6 +37,8 @@ std::unique_ptr<mlir::Pass> createCheckWidthsPass();
 
 std::unique_ptr<mlir::Pass> createInferWidthsPass();
 
+std::unique_ptr<mlir::Pass> createPrintInstanceGraphPass();
+
 std::unique_ptr<mlir::Pass>
 createBlackBoxReaderPass(llvm::Optional<StringRef> inputPrefix = {},
                          llvm::Optional<StringRef> resourcePrefix = {});

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -174,4 +174,10 @@ def BlackBoxReader : Pass<"firrtl-blackbox-reader", "CircuitOp"> {
   let dependentDialects = ["sv::SVDialect"];
 }
 
+def PrintInstanceGraph
+    : Pass<"firrtl-print-instance-graph", "firrtl::CircuitOp"> {
+  let summary = "Print a DOT graph of the module hierarchy.";
+  let constructor =  "circt::firrtl::createPrintInstanceGraphPass()";
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_PASSES_TD

--- a/lib/Dialect/FIRRTL/InstanceGraph.cpp
+++ b/lib/Dialect/FIRRTL/InstanceGraph.cpp
@@ -1,0 +1,93 @@
+//===- InstanceGraph.cpp - Instance Graph -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/FIRRTL/InstanceGraph.h"
+
+using namespace circt;
+using namespace firrtl;
+
+InstanceRecord *InstanceGraphNode::recordInstance(InstanceOp instance,
+                                                  InstanceGraphNode *target) {
+  auto *record = new InstanceRecord(instance, this, target);
+  moduleInstances.emplace_back(record);
+  return record;
+}
+
+void InstanceGraphNode::recordUse(InstanceRecord *record) {
+  moduleUses.push_back(record);
+}
+
+InstanceGraph::InstanceGraph(Operation *operation) {
+  auto circuitOp = cast<CircuitOp>(operation);
+
+  // We insert the top level module first in to the node map.  Getting the node
+  // here is enough to ensure that it is the first one added.
+  getOrAddNode(circuitOp.name());
+
+  for (auto &op : *circuitOp.getBody()) {
+    if (auto extModule = dyn_cast<FExtModuleOp>(op)) {
+      auto *currentNode = getOrAddNode(extModule.getName());
+      currentNode->module = extModule;
+    }
+    if (auto module = dyn_cast<FModuleOp>(op)) {
+      auto *currentNode = getOrAddNode(module.getName());
+      currentNode->module = module;
+      // Find all instance operations in the module body.
+      module.body().walk([&](InstanceOp instanceOp) {
+        // Add an edge to indicate that this module instantiates the target.
+        auto *targetNode = getOrAddNode(instanceOp.moduleName());
+        auto *instanceRecord =
+            currentNode->recordInstance(instanceOp, targetNode);
+        targetNode->recordUse(instanceRecord);
+      });
+    }
+  }
+}
+
+InstanceGraphNode *InstanceGraph::getTopLevelNode() const {
+  // The graph always puts the top level module in the array first.
+  if (!nodes.size())
+    return nullptr;
+  return nodes[0].get();
+}
+
+InstanceGraphNode *InstanceGraph::lookup(StringRef name) const {
+  auto it = nodeMap.find(name);
+  assert(it != nodeMap.end() && "Module not in InstanceGraph!");
+  return nodes[it->second].get();
+}
+
+InstanceGraphNode *InstanceGraph::lookup(Operation *op) const {
+  if (auto extModule = dyn_cast<FExtModuleOp>(op)) {
+    return lookup(extModule.getName());
+  }
+  if (auto module = dyn_cast<FModuleOp>(op)) {
+    return lookup(module.getName());
+  }
+  llvm_unreachable("Can only look up module operations.");
+}
+
+InstanceGraphNode *InstanceGraph::getOrAddNode(StringRef name) {
+  // Try to insert an InstanceGraphNode. If its not inserted, it returns
+  // an iterator pointing to the node.
+  auto itAndInserted = nodeMap.try_emplace(name, 0);
+  auto &index = itAndInserted.first->second;
+  if (itAndInserted.second) {
+    // This is a new node, we have to add an element to the NodeVec.
+    auto *node = new InstanceGraphNode();
+    nodes.emplace_back(node);
+    // Store the node storage index in to the map.
+    index = nodes.size() - 1;
+    return node;
+  }
+  return nodes[index].get();
+}
+
+Operation *InstanceGraph::getReferencedModule(InstanceOp op) const {
+  return lookup(op.moduleName())->getModule();
+}

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -7,6 +7,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   IMConstProp.cpp
   InferWidths.cpp
   LowerTypes.cpp
+  PrintInstanceGraph.cpp
 
   DEPENDS
   CIRCTFIRRTLTransformsIncGen

--- a/lib/Dialect/FIRRTL/Transforms/PrintInstanceGraph.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/PrintInstanceGraph.cpp
@@ -1,0 +1,64 @@
+//===- PrintInstanceGraph.cpp - Print the instance graph --------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//===----------------------------------------------------------------------===//
+//
+// Print the module hierarchy.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/InstanceGraph.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "llvm/Support/DOTGraphTraits.h"
+#include "llvm/Support/GraphWriter.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace circt;
+using namespace firrtl;
+
+template <>
+struct llvm::DOTGraphTraits<InstanceGraph *>
+    : public llvm::DefaultDOTGraphTraits {
+  using DefaultDOTGraphTraits::DefaultDOTGraphTraits;
+
+  static std::string getNodeLabel(InstanceGraphNode *node, InstanceGraph *) {
+    // The name of the graph node is the module name.
+    auto *op = node->getModule();
+    if (auto module = dyn_cast<FModuleOp>(op)) {
+      return module.getName().str();
+    }
+    if (auto extModule = dyn_cast<FExtModuleOp>(op)) {
+      return extModule.getName().str();
+    }
+    return "<<unknown>>";
+  }
+  template <typename Iterator>
+  static std::string getEdgeAttributes(const InstanceGraphNode *node,
+                                       Iterator it, InstanceGraph *) {
+    // Set an edge label that is the name of the instance.
+    auto *instanceRecord = *it.getCurrent();
+    auto instanceOp = instanceRecord->getInstance();
+    return ("label=" + instanceOp.name()).str();
+  }
+};
+
+namespace {
+struct PrintInstanceGraphPass
+    : public PrintInstanceGraphBase<PrintInstanceGraphPass> {
+  PrintInstanceGraphPass(raw_ostream &os) : os(os) {}
+  void runOnOperation() override {
+    auto circuitOp = getOperation();
+    auto &instanceGraph = getAnalysis<InstanceGraph>();
+    llvm::WriteGraph(os, &instanceGraph, /*ShortNames=*/false,
+                     circuitOp.name());
+  }
+  raw_ostream &os;
+};
+} // end anonymous namespace
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createPrintInstanceGraphPass() {
+  return std::make_unique<PrintInstanceGraphPass>(llvm::errs());
+}

--- a/test/Dialect/FIRRTL/print-instance-graph.mlir
+++ b/test/Dialect/FIRRTL/print-instance-graph.mlir
@@ -1,0 +1,32 @@
+// RUN: circt-opt -firrtl-print-instance-graph %s -o %t 2>&1 | FileCheck %s
+
+// CHECK: digraph "Top"
+// CHECK:   label="Top";
+// CHECK:   [[TOP:.*]] [shape=record,label="{Top}"];
+// CHECK:   [[TOP]] -> [[ALLIGATOR:.*]][label=alligator];
+// CHECK:   [[TOP]] -> [[CAT:.*]][label=cat];
+// CHECK:   [[ALLIGATOR]] [shape=record,label="{Alligator}"];
+// CHECK:   [[ALLIGATOR]] -> [[BEAR:.*]][label=bear];
+// CHECK:   [[CAT]] [shape=record,label="{Cat}"];
+// CHECK:   [[BEAR]] [shape=record,label="{Bear}"];
+// CHECK:   [[BEAR]] -> [[CAT]][label=cat];
+
+firrtl.circuit "Top" {
+
+firrtl.module @Top() {
+  firrtl.instance @Alligator {name = "alligator" }
+  firrtl.instance @Cat {name = "cat"}
+}
+
+firrtl.module @Alligator() {
+  firrtl.instance @Bear {name = "bear"}
+}
+
+firrtl.module @Bear() {
+  firrtl.instance @Cat {name = "cat" }
+}
+
+firrtl.module @Cat() { }
+
+}
+


### PR DESCRIPTION
This adds an instance graph analysis which tracks modules and where they are instantiated.  This includes a simple pass to print the graph in dot format, which is also used to test the instance graph.

This code was separated from the PrefixModulePass PR.