### PR TITLE
[SV] Use function for InterfaceOp builder body

### DIFF
--- a/include/circt/Dialect/SV/SVTypeDecl.td
+++ b/include/circt/Dialect/SV/SVTypeDecl.td
@@ -42,6 +42,12 @@ def InterfaceOp : SVOp<"interface",
 
   let assemblyFormat = "attr-dict $sym_name $body";
 
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins "StringRef":$sym_name,
+               CArg<"std::function<void()>", "{}">:$body)>
+  ];
+
   let extraClassDeclaration = [{
     Block *getBodyBlock() { return &body().front(); }
 

--- a/lib/Dialect/ESI/ESIPasses.cpp
+++ b/lib/Dialect/ESI/ESIPasses.cpp
@@ -225,22 +225,18 @@ InterfaceOp ESIHWBuilder::getOrConstructInterface(ChannelPort t) {
 }
 
 InterfaceOp ESIHWBuilder::constructInterface(ChannelPort chan) {
-  InterfaceOp iface = create<InterfaceOp>(constructInterfaceName(chan));
-  ImplicitLocOpBuilder ib(getLoc(), iface.getRegion());
-  ib.createBlock(&iface.getRegion());
-
-  InterfaceSignalOp s;
-  ib.create<InterfaceSignalOp>(validStr, getI1Type());
-  ib.create<InterfaceSignalOp>(readyStr, getI1Type());
-  ib.create<InterfaceSignalOp>(dataStr, chan.getInner());
-  ib.create<InterfaceModportOp>(
-      sinkStr, /*inputs=*/ArrayRef<StringRef>{readyStr},
-      /*outputs=*/ArrayRef<StringRef>{validStr, dataStr});
-  ib.create<InterfaceModportOp>(
-      sourceStr,
-      /*inputs=*/ArrayRef<StringRef>{validStr, dataStr},
-      /*outputs=*/ArrayRef<StringRef>{readyStr});
-  return iface;
+  return create<InterfaceOp>(constructInterfaceName(chan).getValue(), [&]() {
+    create<InterfaceSignalOp>(validStr, getI1Type());
+    create<InterfaceSignalOp>(readyStr, getI1Type());
+    create<InterfaceSignalOp>(dataStr, chan.getInner());
+    create<InterfaceModportOp>(
+        sinkStr, /*inputs=*/ArrayRef<StringRef>{readyStr},
+        /*outputs=*/ArrayRef<StringRef>{validStr, dataStr});
+    create<InterfaceModportOp>(
+        sourceStr,
+        /*inputs=*/ArrayRef<StringRef>{validStr, dataStr},
+        /*outputs=*/ArrayRef<StringRef>{readyStr});
+  });
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -648,6 +648,16 @@ static LogicalResult verifyCaseZOp(CaseZOp op) {
 // TypeDecl operations
 //===----------------------------------------------------------------------===//
 
+void InterfaceOp::build(OpBuilder &builder, OperationState &result,
+                        StringRef sym_name, std::function<void()> body) {
+  OpBuilder::InsertionGuard guard(builder);
+
+  result.addAttribute("sym_name", builder.getStringAttr(sym_name));
+  builder.createBlock(result.addRegion());
+  if (body)
+    body();
+}
+
 ModportType InterfaceOp::getModportType(StringRef modportName) {
   assert(lookupSymbol<InterfaceModportOp>(modportName) &&
          "Modport symbol not found.");


### PR DESCRIPTION
Remove the default builders for sv::InterfaceOp and add a lone builder
that users a std::function<void()> to construct the body.  (This is
modeled off of how the always blocks work.)  This dramatically
simplifies the construction of interfaces and avoids boilerplate
whenever you want to place operations inside the interface.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>