### PR TITLE
[FIRRTL] Expand AnnotationSet mutation API

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
@@ -23,15 +23,28 @@ namespace firrtl {
 class Annotation;
 class AnnotationSetIterator;
 
+/// Return the name of the attribute used for annotations on FIRRTL ops.
+inline StringRef getAnnotationAttrName() { return "annotations"; }
+
+/// Return the name of the dialect-prefixed attribute used for annotations.
+inline StringRef getDialectAnnotationAttrName() { return "firrtl.annotations"; }
+
 /// This class provides a read-only projection over the MLIR attributes that
 /// represent a set of annotations.  It is intended to make this work less
 /// stringly typed and fiddly for clients.
 ///
 class AnnotationSet {
 public:
-  /// Form an annotation set with a non-null ArrayAttr.
+  /// Form an empty annotation set.
   explicit AnnotationSet(MLIRContext *context)
       : annotations(ArrayAttr::get(context, {})) {}
+
+  /// Form an annotation set from an array of annotation attributes.
+  explicit AnnotationSet(ArrayRef<Attribute> annotations, MLIRContext *context);
+
+  /// Form an annotation set from an array of annotations.
+  explicit AnnotationSet(ArrayRef<Annotation> annotations,
+                         MLIRContext *context);
 
   /// Form an annotation set with a non-null ArrayAttr.
   explicit AnnotationSet(ArrayAttr annotations) : annotations(annotations) {
@@ -62,6 +75,59 @@ public:
   /// Return this annotation set as an argument attribute dictionary for a port.
   DictionaryAttr
   getArgumentAttrDict(ArrayRef<NamedAttribute> otherPortAttrs = {}) const;
+
+  /// Store the annotations in this set in an operation's `annotations`
+  /// attribute, overwriting any existing annotations. Removes the `annotations`
+  /// attribute if the set is empty. Returns true if the operation was modified,
+  /// false otherwise.
+  bool applyToOperation(Operation *op) const;
+
+  /// Store the annotations in this set in a `NamedAttrList` as an array
+  /// attribute with the name `annotations`. Overwrites existing annotations.
+  /// Removes the `annotations` attribute if the set is empty. Returns true if
+  /// the list was modified, false otherwise.
+  ///
+  /// This function is useful if you are in the process of modifying an
+  /// operation's attributes as a `NamedAttrList`, or you are preparing the
+  /// attributes of a operation yet to be created. In that case
+  /// `applyToAttrList` allows you to set the `annotations` attribute in that
+  /// list to the contents of this set.
+  bool applyToAttrList(NamedAttrList &attrs) const;
+
+  /// Store the annotations in this set in a `NamedAttrList` as an array
+  /// attribute with the name `firrtl.annotations`. Overwrites existing
+  /// annotations. Removes the `firrtl.annotations` attribute if the set is
+  /// empty. Returns true if the list was modified, false otherwise.
+  ///
+  /// This function is useful if you are in the process of modifying a port's
+  /// attributes as a `NamedAttrList`, or you are preparing the attributes of a
+  /// port yet to be created as part of an operation. In that case
+  /// `applyToPortAttrList` allows you to set the `firrtl.annotations` attribute
+  /// in that list to the contents of this set.
+  bool applyToPortAttrList(NamedAttrList &attrs) const;
+
+  /// Insert this annotation set into a `DictionaryAttr` under the `annotations`
+  /// key. Overwrites any existing attribute stored under `annotations`. Removes
+  /// the `annotations` attribute in the dictionary if the set is empty. Returns
+  /// the updated dictionary.
+  ///
+  /// This function is useful if you hold an operation's attributes dictionary
+  /// and want to set the `annotations` key in the dictionary to the contents of
+  /// this set.
+  DictionaryAttr applyToDictionaryAttr(DictionaryAttr attrs) const;
+  DictionaryAttr applyToDictionaryAttr(ArrayRef<NamedAttribute> attrs) const;
+
+  /// Insert this annotation set into a `DictionaryAttr` under the
+  /// `firrtl.annotations` key. Overwrites any existing attribute stored under
+  /// `firrtl.annotations`. Removes the `firrtl.annotations` attribute in the
+  /// dictionary if the set is empty. Returns the updated dictionary.
+  ///
+  /// This function is useful if you hold a port's attributes dictionary and
+  /// want to set the `firrtl.annotations` key in the dictionary to the contents
+  /// of this set.
+  DictionaryAttr applyToPortDictionaryAttr(DictionaryAttr attrs) const;
+  DictionaryAttr
+  applyToPortDictionaryAttr(ArrayRef<NamedAttribute> attrs) const;
 
   /// Return true if we have an annotation with the specified class name.
   bool hasAnnotation(StringRef className) const {
@@ -107,8 +173,27 @@ public:
 
   size_t size() const { return annotations.size(); }
 
-  /// Add more annotations to this AttributeSet.
+  /// Add more annotations to this annotation set.
+  void addAnnotations(ArrayRef<Annotation> annotations);
+  void addAnnotations(ArrayRef<Attribute> annotations);
   void addAnnotations(ArrayAttr annotations);
+
+  /// Remove an annotation from this annotation set. Returns true if any were
+  /// removed, false otherwise.
+  bool removeAnnotation(Annotation anno);
+  bool removeAnnotation(Attribute anno);
+
+  /// Remove all annotations from this annotation set for which `predicate`
+  /// returns true. The predicate is guaranteed to be called on every
+  /// annotation, such that this method can be used to partition the set by
+  /// extracting and removing annotations at the same time. Returns true if any
+  /// annotations were removed, false otherwise.
+  bool removeAnnotations(llvm::function_ref<bool(Annotation)> predicate);
+
+  /// Remove all annotations with one of the given classes from this annotation
+  /// set.
+  template <typename... Args>
+  bool removeAnnotationsWithClass(Args... names);
 
 private:
   bool hasAnnotationImpl(StringAttr className) const;
@@ -152,6 +237,11 @@ public:
     return const_cast<DictionaryAttr &>(attrDict).getAs<AttrClass>(name);
   }
 
+  bool operator==(const Annotation &other) const {
+    return attrDict == other.attrDict;
+  }
+  bool operator!=(const Annotation &other) const { return !(*this == other); }
+
 private:
   DictionaryAttr attrDict;
 
@@ -170,6 +260,13 @@ private:
     bool compare(StringRef name) const { return cls && cls.getValue() == name; }
   };
 };
+
+// Out-of-line impl since we need `Annotation` to be fully defined.
+template <typename... Args>
+bool AnnotationSet::removeAnnotationsWithClass(Args... names) {
+  return removeAnnotations(
+      [&](Annotation anno) { return anno.isClass(names...); });
+}
 
 // Iteration over the annotation set.
 class AnnotationSetIterator

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
@@ -17,10 +17,31 @@ using namespace circt;
 using namespace firrtl;
 
 static ArrayAttr getAnnotationsFrom(Operation *op) {
-  if (auto annots = op->getAttrOfType<ArrayAttr>("annotations"))
+  if (auto annots = op->getAttrOfType<ArrayAttr>(getAnnotationAttrName()))
     return annots;
   return ArrayAttr::get(op->getContext(), {});
 }
+
+static ArrayAttr getAnnotationsFrom(ArrayRef<Annotation> annotations,
+                                    MLIRContext *context) {
+  if (annotations.empty())
+    return ArrayAttr::get(context, {});
+  SmallVector<Attribute> attrs;
+  attrs.reserve(annotations.size());
+  for (auto anno : annotations)
+    attrs.push_back(anno.getDict());
+  return ArrayAttr::get(context, attrs);
+}
+
+/// Form an annotation set from an array of annotation attributes.
+AnnotationSet::AnnotationSet(ArrayRef<Attribute> annotations,
+                             MLIRContext *context)
+    : annotations(ArrayAttr::get(context, annotations)) {}
+
+/// Form an annotation set from an array of annotations.
+AnnotationSet::AnnotationSet(ArrayRef<Annotation> annotations,
+                             MLIRContext *context)
+    : annotations(getAnnotationsFrom(annotations, context)) {}
 
 /// Form an annotation set with a possibly-null ArrayAttr.
 AnnotationSet::AnnotationSet(ArrayAttr annotations, MLIRContext *context)
@@ -33,7 +54,7 @@ AnnotationSet::AnnotationSet(Operation *op)
 /// Get an annotation set for the specified module port.
 AnnotationSet AnnotationSet::forPort(Operation *module, size_t portNo) {
   for (auto a : mlir::function_like_impl::getArgAttrs(module, portNo)) {
-    if (a.first == "firrtl.annotations")
+    if (a.first == getDialectAnnotationAttrName())
       return AnnotationSet(a.second.cast<ArrayAttr>());
   }
   return AnnotationSet(ArrayAttr::get(module->getContext(), {}));
@@ -46,7 +67,7 @@ AnnotationSet::forPort(Operation *module, size_t portNo,
                        SmallVectorImpl<NamedAttribute> &otherAttributes) {
   ArrayAttr annotations;
   for (auto a : mlir::function_like_impl::getArgAttrs(module, portNo)) {
-    if (a.first == "firrtl.annotations")
+    if (a.first == getDialectAnnotationAttrName())
       annotations = a.second.cast<ArrayAttr>();
     else
       otherAttributes.push_back(a);
@@ -65,8 +86,111 @@ DictionaryAttr AnnotationSet::getArgumentAttrDict(
                                            otherPortAttrs.end());
   // Annotations are stored as under the "firrtl.annotations" key.
   allPortAttrs.push_back(
-      {Identifier::get("firrtl.annotations", context), getArrayAttr()});
+      {Identifier::get(getDialectAnnotationAttrName(), context),
+       getArrayAttr()});
   return DictionaryAttr::get(context, allPortAttrs);
+}
+
+/// Store the annotations in this set in an operation's `annotations` attribute,
+/// overwriting any existing annotations.
+bool AnnotationSet::applyToOperation(Operation *op) const {
+  if (empty())
+    return bool(op->removeAttr(getAnnotationAttrName()));
+  else {
+    auto before = op->getAttrDictionary();
+    op->setAttr(getAnnotationAttrName(), getArrayAttr());
+    return op->getAttrDictionary() != before;
+  }
+}
+
+static bool applyToAttrListImpl(const AnnotationSet &annoSet, StringRef key,
+                                NamedAttrList &attrs) {
+  if (annoSet.empty())
+    return bool(attrs.erase(key));
+  else {
+    auto attr = annoSet.getArrayAttr();
+    return attrs.set(key, attr) != attr;
+  }
+}
+
+/// Store the annotations in this set in a `NamedAttrList` as an array attribute
+/// with the name `annotations`.
+bool AnnotationSet::applyToAttrList(NamedAttrList &attrs) const {
+  return applyToAttrListImpl(*this, getAnnotationAttrName(), attrs);
+}
+
+/// Store the annotations in this set in a `NamedAttrList` as an array attribute
+/// with the name `firrtl.annotations`.
+bool AnnotationSet::applyToPortAttrList(NamedAttrList &attrs) const {
+  return applyToAttrListImpl(*this, getDialectAnnotationAttrName(), attrs);
+}
+
+static DictionaryAttr applyToDictionaryAttrImpl(const AnnotationSet &annoSet,
+                                                StringRef key,
+                                                ArrayRef<NamedAttribute> attrs,
+                                                bool sorted,
+                                                DictionaryAttr originalDict) {
+  // Find the location in the dictionary where the entry would go.
+  ArrayRef<NamedAttribute>::iterator it;
+  if (sorted) {
+    it = llvm::lower_bound(attrs, key);
+    if (it != attrs.end() && it->first != key)
+      it = attrs.end();
+  } else {
+    it = llvm::find_if(
+        attrs, [key](NamedAttribute attr) { return attr.first == key; });
+  }
+
+  // Fast path in case there are no annotations in the dictionary and we are not
+  // supposed to add any.
+  if (it == attrs.end() && annoSet.empty())
+    return originalDict;
+
+  // Fast path in case there already is an entry in the dictionary, it matches
+  // the set, and, in the case we're supposed to remove empty sets, we're not
+  // leaving an empty entry in the dictionary.
+  if (it != attrs.end() && it->second == annoSet.getArrayAttr() &&
+      !annoSet.empty())
+    return originalDict;
+
+  // If we arrive here, we are supposed to assemble a new dictionary.
+  SmallVector<NamedAttribute> newAttrs;
+  newAttrs.reserve(attrs.size() + 1);
+  newAttrs.append(attrs.begin(), it);
+  if (!annoSet.empty())
+    newAttrs.push_back(
+        {Identifier::get(key, annoSet.getContext()), annoSet.getArrayAttr()});
+  if (it != attrs.end())
+    newAttrs.append(it + 1, attrs.end());
+  return sorted ? DictionaryAttr::getWithSorted(annoSet.getContext(), newAttrs)
+                : DictionaryAttr::get(annoSet.getContext(), newAttrs);
+}
+
+/// Update the attribute dictionary of an operation to contain this annotation
+/// set.
+DictionaryAttr
+AnnotationSet::applyToDictionaryAttr(DictionaryAttr attrs) const {
+  return applyToDictionaryAttrImpl(*this, getAnnotationAttrName(),
+                                   attrs.getValue(), true, attrs);
+}
+
+DictionaryAttr
+AnnotationSet::applyToDictionaryAttr(ArrayRef<NamedAttribute> attrs) const {
+  return applyToDictionaryAttrImpl(*this, getAnnotationAttrName(), attrs, false,
+                                   {});
+}
+
+/// Update the attribute dictionary of a port to contain this annotation set.
+DictionaryAttr
+AnnotationSet::applyToPortDictionaryAttr(DictionaryAttr attrs) const {
+  return applyToDictionaryAttrImpl(*this, getDialectAnnotationAttrName(),
+                                   attrs.getValue(), true, attrs);
+}
+
+DictionaryAttr
+AnnotationSet::applyToPortDictionaryAttr(ArrayRef<NamedAttribute> attrs) const {
+  return applyToDictionaryAttrImpl(*this, getDialectAnnotationAttrName(), attrs,
+                                   false, {});
 }
 
 DictionaryAttr AnnotationSet::getAnnotationImpl(StringAttr className) const {
@@ -103,6 +227,34 @@ bool AnnotationSet::hasDontTouch() const {
 }
 
 /// Add more annotations to this AttributeSet.
+void AnnotationSet::addAnnotations(ArrayRef<Annotation> newAnnotations) {
+  if (newAnnotations.empty())
+    return;
+
+  SmallVector<Attribute> annotationVec;
+  annotationVec.reserve(annotations.size() + newAnnotations.size());
+  annotationVec.append(annotations.begin(), annotations.end());
+  for (auto anno : newAnnotations)
+    annotationVec.push_back(anno.getDict());
+  annotations = ArrayAttr::get(getContext(), annotationVec);
+}
+
+void AnnotationSet::addAnnotations(ArrayRef<Attribute> newAnnotations) {
+  if (newAnnotations.empty())
+    return;
+
+  if (empty()) {
+    annotations = ArrayAttr::get(getContext(), newAnnotations);
+    return;
+  }
+
+  SmallVector<Attribute> annotationVec;
+  annotationVec.reserve(annotations.size() + newAnnotations.size());
+  annotationVec.append(annotations.begin(), annotations.end());
+  annotationVec.append(newAnnotations.begin(), newAnnotations.end());
+  annotations = ArrayAttr::get(getContext(), annotationVec);
+}
+
 void AnnotationSet::addAnnotations(ArrayAttr newAnnotations) {
   if (!newAnnotations)
     return;
@@ -117,6 +269,53 @@ void AnnotationSet::addAnnotations(ArrayAttr newAnnotations) {
   annotationVec.append(annotations.begin(), annotations.end());
   annotationVec.append(newAnnotations.begin(), newAnnotations.end());
   annotations = ArrayAttr::get(getContext(), annotationVec);
+}
+
+/// Remove an annotation from this annotation set. Returns true if any were
+/// removed, false otherwise.
+bool AnnotationSet::removeAnnotation(Annotation anno) {
+  return removeAnnotations([&](Annotation other) { return other == anno; });
+}
+
+/// Remove an annotation from this annotation set. Returns true if any were
+/// removed, false otherwise.
+bool AnnotationSet::removeAnnotation(Attribute anno) {
+  return removeAnnotations(
+      [&](Annotation other) { return other.getDict() == anno; });
+}
+
+/// Remove all annotations from this annotation set for which `predicate`
+/// returns true.
+bool AnnotationSet::removeAnnotations(
+    llvm::function_ref<bool(Annotation)> predicate) {
+  // Fast path for empty sets.
+  auto attr = getArrayAttr();
+  if (!attr)
+    return false;
+
+  // Search for the first match.
+  ArrayRef<Attribute> annos = getArrayAttr().getValue();
+  auto it = annos.begin();
+  while (it != annos.end() &&
+         !predicate(Annotation(it->cast<DictionaryAttr>())))
+    ++it;
+
+  // Fast path for sets where the predicate never matched.
+  if (it == annos.end())
+    return false;
+
+  // Build a filtered list of annotations.
+  SmallVector<Attribute> filteredAnnos;
+  filteredAnnos.reserve(annos.size());
+  filteredAnnos.append(annos.begin(), it);
+  ++it;
+  while (it != annos.end()) {
+    if (!predicate(Annotation(it->cast<DictionaryAttr>())))
+      filteredAnnos.push_back(*it);
+    ++it;
+  }
+  annotations = ArrayAttr::get(getContext(), filteredAnnos);
+  return true;
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
* Add constructors for `AnnotationSet` directly from arrays of `Attribute` and `Annotation`. This can come in handy in certain
  situations where a user might have already filtered a bunch of attributes.

* Add a bunch of methods to apply the annotations recorded in an `AnnotationSet` to the attributes of an operation or port through various intermediate forms (directly on the op, updating a `DictionaryAttr`, modifying a `NamedAttrList`).

* Add a bunch of methods to add and remove annotations in a set. This is a convenient way for performing single-shot modifications of an op's or port's annotations (but may become inefficient if a lot of incremental changes are performed).

* Add a `removeAnnotations` method that takes a predicate function that gets applied to every annotation and can indicate whether the annotation should be retained in the set or not. This is guaranteed to be called on every annotation, and thus lends itself handily to extract the annotations consumed in a transformation.

* Make `Annotation` comparable through `==` and `!=`.