### PR TITLE
[FIRRTL][BlackBoxReader] Stop emitting duplicate blackboxes 

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
@@ -20,6 +20,7 @@
 #include "circt/Dialect/SV/SVOps.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/Support/FileUtilities.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
@@ -51,40 +52,41 @@ static void appendPossiblyAbsolutePath(SmallVectorImpl<char> &base,
 //===----------------------------------------------------------------------===//
 
 namespace {
-struct EmittedFile {
-  VerbatimOp op;
-  StringAttr fileName;
-};
-
 struct BlackBoxReaderPass : public BlackBoxReaderBase<BlackBoxReaderPass> {
   void runOnOperation() override;
   bool runOnAnnotation(Operation *op, Annotation anno, OpBuilder &builder);
   void loadFile(Operation *op, StringRef inputPath, OpBuilder &builder);
+  void setOutputFile(VerbatimOp op, StringAttr fileNameAttr);
 
   using BlackBoxReaderBase::inputPrefix;
   using BlackBoxReaderBase::resourcePrefix;
 
 private:
-  /// The generated `sv.verbatim` nodes.
-  SmallVector<EmittedFile, 8> emittedFiles;
+  /// A set of the files encountered so far.  This is used to prevent two
+  /// annotations from generating the same file.
+  SmallPtrSet<Attribute, 8> emittedFiles;
+
+  /// A list of all files which will be included in the file list.  This is
+  /// subset of all fileNames.
+  SmallVector<StringRef> fileListFiles;
 
   /// The target directory to output black boxes into. Can be changed
   /// through `firrtl.transforms.BlackBoxTargetDirAnno` annotations.
-  SmallString<128> targetDir;
+  StringRef targetDir;
 
   /// The file list file name (sic) for black boxes. If set, generates a file
   /// that lists all non-header source files for black boxes. Can be changed
   /// through `firrtl.transforms.BlackBoxResourceFileNameAnno` annotations.
-  SmallString<128> resourceFileName;
+  StringRef resourceFileName;
 };
 } // end anonymous namespace
 
 /// Emit the annotated source code for black boxes in a circuit.
 void BlackBoxReaderPass::runOnOperation() {
   CircuitOp circuitOp = getOperation();
+  auto context = &getContext();
 
   // Internalize some string attributes for easy reference later.
-  auto cx = &getContext();
   StringRef targetDirAnnoClass = "firrtl.transforms.BlackBoxTargetDirAnno";
   StringRef resourceFileNameAnnoClass =
       "firrtl.transforms.BlackBoxResourceFileNameAnno";
@@ -94,6 +96,8 @@ void BlackBoxReaderPass::runOnOperation() {
   targetDir = ".";
   resourceFileName = "firrtl_black_box_resource_files.f";
 
+  // Process black box annotations on the circuit.  Some of these annotations
+  // will affect how the rest of the annotations are resolved.
   AnnotationSet circuitAnnos(circuitOp);
   SmallVector<Attribute, 4> filteredAnnos;
   for (auto annot : circuitAnnos) {
@@ -122,6 +126,7 @@ void BlackBoxReaderPass::runOnOperation() {
       continue;
     }
 
+    // If it is not a black box annotation, it will be reattached to the op.
     filteredAnnos.push_back(annot.getDict());
   }
 
@@ -129,16 +134,16 @@ void BlackBoxReaderPass::runOnOperation() {
   if (filteredAnnos.empty())
     circuitOp->removeAttr("annotations");
   else
-    circuitOp->setAttr("annotations", ArrayAttr::get(cx, filteredAnnos));
+    circuitOp->setAttr("annotations", ArrayAttr::get(context, filteredAnnos));
 
   LLVM_DEBUG(llvm::dbgs() << "Black box target directory: " << targetDir << "\n"
                           << "Black box resource file name: "
                           << resourceFileName << "\n");
 
-  // Gather the relevant annotations on all modules in the circuit.
-  OpBuilder builder(&getContext());
-  builder.setInsertionPointToEnd(getOperation()->getBlock());
+  // Newly generated IR will be placed at the end of the circuit.
+  auto builder = OpBuilder::atBlockEnd(circuitOp->getBlock());
 
+  // Gather the relevant annotations on all modules in the circuit.
   for (auto &op : *circuitOp.getBody()) {
     if (!isa<FModuleOp>(op) && !isa<FExtModuleOp>(op))
       continue;
@@ -153,44 +158,46 @@ void BlackBoxReaderPass::runOnOperation() {
     if (filteredAnnos.empty())
       op.removeAttr("annotations");
     else
-      op.setAttr("annotations", ArrayAttr::get(cx, filteredAnnos));
+      op.setAttr("annotations", ArrayAttr::get(context, filteredAnnos));
   }
 
   // If we have emitted any files, generate a file list operation that
   // documents the additional annotation-controlled file listing to be
   // created.
-  if (!emittedFiles.empty()) {
-    auto trueAttr = BoolAttr::get(cx, true);
+  if (!fileListFiles.empty()) {
+    // Output the file list in sorted order.
+    llvm::sort(fileListFiles.begin(), fileListFiles.end());
+
+    // Create the file list contents by putting each file on its own line.
+    // Append the targetDir to the filename for the file list.
     std::string output;
     llvm::raw_string_ostream os(output);
-    for (auto &file : emittedFiles) {
-      const auto &fileName = file.fileName.getValue();
-      // Exclude Verilog header files since we expect them to be included
-      // explicitly by compiler directives in other source files.
-      auto ext = llvm::sys::path::extension(fileName);
-      bool exclude = (ext == ".h" || ext == ".vh" || ext == ".svh");
-      file.op->setAttr(
-          "output_file",
-          OutputFileAttr::get(StringAttr::get(cx, targetDir), file.fileName,
-                              BoolAttr::get(cx, exclude),
-                              /*exclude_replicated_ops=*/trueAttr, cx));
+    llvm::interleave(
+        fileListFiles, os,
+        [&](StringRef fileName) {
+          SmallString<32> filePath(targetDir);
+          llvm::sys::path::append(filePath, fileName);
+          os << filePath;
+        },
+        "\n");
 
-      SmallString<32> filePath(targetDir);
-      llvm::sys::path::append(filePath, fileName);
-      if (!exclude)
-        os << filePath << "\n";
-    }
+    // Put the file list in to a verbatim op.
     auto op =
         builder.create<VerbatimOp>(circuitOp->getLoc(), std::move(output));
+
+    // Attach the output file information to the verbatim op.
+    auto trueAttr = BoolAttr::get(context, true);
     op->setAttr("output_file",
-                OutputFileAttr::get(StringAttr::get(cx, ""),
-                                    StringAttr::get(cx, resourceFileName),
+                OutputFileAttr::get(StringAttr::get(context, ""),
+                                    StringAttr::get(context, resourceFileName),
                                     /*exclude_from_filelist=*/trueAttr,
-                                    /*exclude_replicated_ops=*/trueAttr, cx));
+                                    /*exclude_replicated_ops=*/trueAttr,
+                                    context));
   }
 
   // Clean up.
   emittedFiles.clear();
+  fileListFiles.clear();
 }
 
 /// Run on an operation-annotation pair. The annotation need not be a black box
@@ -206,6 +213,7 @@ bool BlackBoxReaderPass::runOnAnnotation(Operation *op, Annotation anno,
   if (anno.isClass(inlineAnnoClass)) {
     auto name = anno.getMember<StringAttr>("name");
     auto text = anno.getMember<StringAttr>("text");
+
     if (!name || !text) {
       op->emitError(inlineAnnoClass)
           << " annotation missing \"name\" or \"text\" attribute";
@@ -216,9 +224,13 @@ bool BlackBoxReaderPass::runOnAnnotation(Operation *op, Annotation anno,
     LLVM_DEBUG(llvm::dbgs()
                << "Add black box source `" << name.getValue() << "` inline\n");
 
+    // Skip this inline annotation if the target is already generated.
+    if (emittedFiles.count(name))
+      return true;
+
     // Create an IR node to hold the contents.
-    emittedFiles.push_back({builder.create<VerbatimOp>(op->getLoc(), text),
-                            builder.getStringAttr(name.getValue())});
+    auto verbatim = builder.create<VerbatimOp>(op->getLoc(), text);
+    setOutputFile(verbatim, name);
     return true;
   }
 
@@ -249,6 +261,7 @@ bool BlackBoxReaderPass::runOnAnnotation(Operation *op, Annotation anno,
     // Note that we always treat `resourceId` as a relative path, as the
     // previous Scala implementation tended to emit `/foo.v` as resourceId.
     llvm::sys::path::append(inputPath, resourceId.getValue());
+
     loadFile(op, inputPath, builder);
     return true;
   }
@@ -274,10 +287,44 @@ void BlackBoxReaderPass::loadFile(Operation *op, StringRef inputPath,
     return;
   }
 
+  // Skip this annotation if the target is already loaded.
+  auto fileNameAttr = builder.getStringAttr(fileName);
+  if (emittedFiles.count(fileNameAttr))
+    return;
+
   // Create an IR node to hold the contents.
-  emittedFiles.push_back(
-      {builder.create<VerbatimOp>(op->getLoc(), input->getBuffer()),
-       builder.getStringAttr(fileName)});
+  auto verbatimOp =
+      builder.create<VerbatimOp>(op->getLoc(), input->getBuffer());
+  setOutputFile(verbatimOp, fileNameAttr);
+}
+
+/// This function is called for every file generated.  It does the following
+/// things:
+///  1. Attaches the output file attribute to the VerbatimOp.
+///  2. Record that the file has been generated.
+///  3. Add each file name to the generated "file list" file.
+void BlackBoxReaderPass::setOutputFile(VerbatimOp op, StringAttr fileNameAttr) {
+  auto *context = &getContext();
+  auto fileName = fileNameAttr.getValue();
+  // Exclude Verilog header files since we expect them to be included
+  // explicitly by compiler directives in other source files.
+  auto ext = llvm::sys::path::extension(fileName);
+  bool exclude = (ext == ".h" || ext == ".vh" || ext == ".svh");
+  auto trueAttr = BoolAttr::get(context, true);
+  op->setAttr("output_file",
+              OutputFileAttr::get(
+                  StringAttr::get(context, targetDir), fileNameAttr,
+                  /*exclude_from_filelist=*/BoolAttr::get(context, exclude),
+                  /*exclude_replicated_ops=*/trueAttr, context));
+
+  // Record this file as generated.
+  assert(!emittedFiles.count(fileNameAttr) &&
+         "Can't generate the same file twice.");
+  emittedFiles.insert(fileNameAttr);
+
+  // Append this file to the file list if its not excluded.
+  if (!exclude)
+    fileListFiles.push_back(fileName);
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/firtool/blackbox.mlir
+++ b/test/firtool/blackbox.mlir
@@ -11,8 +11,8 @@
 // LIST-TOP: test_mod.sv
 
 // LIST-BLACK-BOX:      magic/blackbox-inline.v
-// LIST-BLACK-BOX-NEXT: magic/blackbox-resource.v
 // LIST-BLACK-BOX-NEXT: magic/blackbox-path.v
+// LIST-BLACK-BOX-NEXT: magic/blackbox-resource.v
 
 firrtl.circuit "test_mod" attributes {annotations = [
   // Black box processing should honor only the last annotation.
@@ -37,13 +37,19 @@ firrtl.circuit "test_mod" attributes {annotations = [
   // VERILOG-HDR-LABEL: `define SOME_MACRO
   // VERILOG-HDR-NOT:   `define SOME_MACRO
   firrtl.extmodule @ExtInline() attributes {annotations = [
-    // Both files shall be emitted, but the Verilog header `*.svh` shall be
-    // excluded from the file list.
+    // Inline file shall be emitted.
     {
       class = "firrtl.transforms.BlackBoxInlineAnno",
       name = "blackbox-inline.v",
       text = "module ExtInline(); endmodule\n"
     },
+    // Duplicate inline annotations will not be emitted.
+    {
+      class = "firrtl.transforms.BlackBoxInlineAnno",
+      name = "blackbox-inline.v",
+      text = "module ExtInline(); endmodule\n"
+    },
+    // Verilog header `*.svh` shall be excluded from the file list.
     {
       class = "firrtl.transforms.BlackBoxInlineAnno",
       name = "blackbox-inline.svh",
@@ -54,6 +60,13 @@ firrtl.circuit "test_mod" attributes {annotations = [
   // VERILOG-BAR-LABEL: module ExtResource(); endmodule
   // VERILOG-BAR-NOT:   module ExtResource(); endmodule
   firrtl.extmodule @ExtResource() attributes {annotations = [{
+    class = "firrtl.transforms.BlackBoxResourceAnno",
+    resourceId = "firtool/blackbox-resource.v"
+  }]}
+
+  // Duplicate resources will not be copied.
+  // VERILOG-BAR-NOT:   module ExtResource(); endmodule
+  firrtl.extmodule @DuplicateExtResource() attributes {annotations = [{
     class = "firrtl.transforms.BlackBoxResourceAnno",
     resourceId = "firtool/blackbox-resource.v"
   }]}


### PR DESCRIPTION
Before this change, BlackBoxReader will append multiple BlackBox
annotations with the same filename to the same output file. This is
different than the SFC behaviour, which will emit only one of the
existing blackbox annotations to the output file.

This is causing problems when there is the a duplicate BlackBox
annotation in the IR, which is resulting in multiple definitions of
modules in the output. Duplicate blackbox resource annotations are
fairly common, for example `plusarg_reader` is included from many
places.

The current firtool behaviour is a result of how these annotations are
lowered: each BlackBoxAnnotation becomes an `sv.verbatim` node, which
each append their contents to the destination file. This change updates
the BlackBox reader to only keep and lower the last annotation seen per
file.

There is no checking that BlackBoxAnnotations targeting the same file
are identical in contents. This is the SFC behaviour, although we might
consider revisiting this.