### PR TITLE
[FIRRTL] Make width inference ready for on-by-default

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -64,14 +64,16 @@ struct ModulePortInfo {
   /// direction of the port, use the \p direction parameter.
   bool isOutput() {
     auto flags = type.getRecursiveTypeProperties();
-    return flags.first && !flags.second && direction == Direction::Output;
+    return flags.isPassive && !flags.containsAnalog &&
+           direction == Direction::Output;
   }
 
   /// Return true if this is a simple input-only port.  If you want the
   /// direction of the port, use the \p direction parameter.
   bool isInput() {
     auto flags = type.getRecursiveTypeProperties();
-    return flags.first && !flags.second && direction == Direction::Input;
+    return flags.isPassive && !flags.containsAnalog &&
+           direction == Direction::Input;
   }
 
   /// Return true if this is an inout port.  This will be true if the port

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -36,6 +36,23 @@ class FlipType;
 class BundleType;
 class FVectorType;
 
+/// A collection of bits indicating the recursive properties of a type.
+struct RecursiveTypeProperties {
+  /// Whether the type only contains passive elements.
+  bool isPassive : 1;
+  /// Whether the type contains an analog type.
+  bool containsAnalog : 1;
+  /// Whether the type has any uninferred bit widths.
+  bool hasUninferredWidth : 1;
+
+  /// The number of bits required to represent a type's recursive properties.
+  static constexpr unsigned numBits = 3;
+  /// Unpack `RecursiveTypeProperties` from a bunch of bits.
+  static RecursiveTypeProperties fromFlags(unsigned bits);
+  /// Pack `RecursiveTypeProperties` as a bunch of bits.
+  unsigned toFlags() const;
+};
+
 // This is a common base class for all FIRRTL types.
 class FIRRTLType : public Type {
 public:
@@ -43,16 +60,22 @@ public:
 
   /// Return true if this is a "passive" type - one that contains no "flip"
   /// types recursively within itself.
-  bool isPassive() { return getRecursiveTypeProperties().first; }
+  bool isPassive() { return getRecursiveTypeProperties().isPassive; }
 
   /// Return true if this is a 'ground' type, aka a non-aggregate type.
   bool isGround();
 
   /// Return true if this is or contains an Analog type.
-  bool containsAnalog() { return getRecursiveTypeProperties().second; }
+  bool containsAnalog() { return getRecursiveTypeProperties().containsAnalog; }
 
-  /// Return a pair with the 'isPassive' and 'containsAnalog' bits.
-  std::pair<bool, bool> getRecursiveTypeProperties();
+  /// Return true if this type contains an uninferred bit width.
+  bool hasUninferredWidth() {
+    return getRecursiveTypeProperties().hasUninferredWidth;
+  }
+
+  /// Return the recursive properties of the type, containing the `isPassive`,
+  /// `containsAnalog`, and `hasUninferredWidth` bits.
+  RecursiveTypeProperties getRecursiveTypeProperties();
 
   /// Return this type with any flip types recursively removed from itself.
   FIRRTLType getPassiveType();
@@ -251,6 +274,9 @@ public:
   unsigned getMaxFieldID();
 
   static FIRRTLType get(FIRRTLType element);
+
+  /// Return the recursive properties of the type.
+  RecursiveTypeProperties getRecursiveTypeProperties();
 };
 
 //===----------------------------------------------------------------------===//
@@ -292,8 +318,8 @@ public:
   /// Look up an element type by name.
   FIRRTLType getElementType(StringRef name);
 
-  /// Return a pair with the 'isPassive' and 'containsAnalog' bits.
-  std::pair<bool, bool> getRecursiveTypeProperties();
+  /// Return the recursive properties of the type.
+  RecursiveTypeProperties getRecursiveTypeProperties();
 
   /// Return this type with any flip types recursively removed from itself.
   FIRRTLType getPassiveType();
@@ -330,8 +356,8 @@ public:
   FIRRTLType getElementType();
   unsigned getNumElements();
 
-  /// Return a pair with the 'isPassive' and 'containsAnalog' bits.
-  std::pair<bool, bool> getRecursiveTypeProperties();
+  /// Return the recursive properties of the type.
+  RecursiveTypeProperties getRecursiveTypeProperties();
 
   /// Return this type with any flip types recursively removed from itself.
   FIRRTLType getPassiveType();

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -192,6 +192,40 @@ Type FIRRTLDialect::parseType(DialectAsmParser &parser) const {
 }
 
 //===----------------------------------------------------------------------===//
+// Recursive Type Properties
+//===----------------------------------------------------------------------===//
+
+enum {
+  /// Bit set if the type only contains passive elements.
+  IsPassiveBitMask = 0x1,
+  /// Bit set if the type contains an analog type.
+  ContainsAnalogBitMask = 0x2,
+  /// Bit set fi the type has any uninferred bit widths.
+  HasUninferredWidthBitMask = 0x4,
+};
+
+/// Unpack `RecursiveTypeProperties` from a bunch of bits.
+RecursiveTypeProperties RecursiveTypeProperties::fromFlags(unsigned flags) {
+  return RecursiveTypeProperties{
+      (flags & IsPassiveBitMask) != 0,
+      (flags & ContainsAnalogBitMask) != 0,
+      (flags & HasUninferredWidthBitMask) != 0,
+  };
+}
+
+/// Pack `RecursiveTypeProperties` as a bunch of bits.
+unsigned RecursiveTypeProperties::toFlags() const {
+  unsigned flags = 0;
+  if (isPassive)
+    flags |= IsPassiveBitMask;
+  if (containsAnalog)
+    flags |= ContainsAnalogBitMask;
+  if (hasUninferredWidth)
+    flags |= HasUninferredWidthBitMask;
+  return flags;
+}
+
+//===----------------------------------------------------------------------===//
 // FIRRTLType Implementation
 //===----------------------------------------------------------------------===//
 
@@ -210,12 +244,20 @@ bool FIRRTLType::isGround() {
 }
 
 /// Return a pair with the 'isPassive' and 'containsAnalog' bits.
-std::pair<bool, bool> FIRRTLType::getRecursiveTypeProperties() {
-  return TypeSwitch<FIRRTLType, std::pair<bool, bool>>(*this)
-      .Case<ClockType, ResetType, AsyncResetType, SIntType, UIntType>(
-          [](Type) { return std::make_pair(true, false); })
-      .Case<AnalogType>([](Type) { return std::make_pair(true, true); })
-      .Case<FlipType>([](Type) { return std::make_pair(false, false); })
+RecursiveTypeProperties FIRRTLType::getRecursiveTypeProperties() {
+  return TypeSwitch<FIRRTLType, RecursiveTypeProperties>(*this)
+      .Case<ClockType, ResetType, AsyncResetType>([](Type) {
+        return RecursiveTypeProperties{true, false, false};
+      })
+      .Case<SIntType, UIntType>([](auto type) {
+        return RecursiveTypeProperties{true, false, !type.hasWidth()};
+      })
+      .Case<AnalogType>([](auto type) {
+        return RecursiveTypeProperties{true, true, !type.hasWidth()};
+      })
+      .Case<FlipType>([](FlipType flipType) {
+        return flipType.getRecursiveTypeProperties();
+      })
       .Case<BundleType>([](BundleType bundleType) {
         return bundleType.getRecursiveTypeProperties();
       })
@@ -224,7 +266,7 @@ std::pair<bool, bool> FIRRTLType::getRecursiveTypeProperties() {
       })
       .Default([](Type) {
         llvm_unreachable("unknown FIRRTL type");
-        return std::make_pair(false, false);
+        return RecursiveTypeProperties{};
       });
 }
 
@@ -590,6 +632,12 @@ FIRRTLType FlipType::getElementType() { return getImpl()->element; }
 
 unsigned FlipType::getMaxFieldID() { return getElementType().getMaxFieldID(); }
 
+/// Return the recursive properties of the type.
+RecursiveTypeProperties FlipType::getRecursiveTypeProperties() {
+  return RecursiveTypeProperties{false, false,
+                                 getImpl()->element.hasUninferredWidth()};
+}
+
 //===----------------------------------------------------------------------===//
 // Bundle Type
 //===----------------------------------------------------------------------===//
@@ -602,13 +650,6 @@ llvm::hash_code hash_value(const BundleType::BundleElement &arg) {
 } // namespace firrtl
 } // namespace circt
 
-enum {
-  /// Bit set if the type only contains passive elements.
-  IsPassiveBitMask = 0x1,
-  /// Bit set if the type contains an analog type.
-  ContainsAnalogBitMask = 0x2,
-};
-
 namespace circt {
 namespace firrtl {
 namespace detail {
@@ -617,26 +658,22 @@ struct BundleTypeStorage : mlir::TypeStorage {
 
   BundleTypeStorage(KeyTy elements)
       : elements(elements.begin(), elements.end()) {
-    bool isPassive = true, containsAnalog = false;
+    RecursiveTypeProperties props{true, false, false};
     unsigned fieldID = 0;
     fieldIDs.reserve(elements.size());
     for (auto &element : elements) {
       auto type = element.type;
       auto eltInfo = type.getRecursiveTypeProperties();
-      isPassive &= eltInfo.first;
-      containsAnalog |= eltInfo.second;
+      props.isPassive &= eltInfo.isPassive;
+      props.containsAnalog |= eltInfo.containsAnalog;
+      props.hasUninferredWidth |= eltInfo.hasUninferredWidth;
       fieldID += 1;
       fieldIDs.push_back(fieldID);
       // Increment the field ID for the next field by the number of subfields.
       fieldID += type.getMaxFieldID();
     }
     maxFieldID = fieldID;
-    unsigned flags = 0;
-    if (isPassive)
-      flags |= IsPassiveBitMask;
-    if (containsAnalog)
-      flags |= ContainsAnalogBitMask;
-    passiveContainsAnalogTypeInfo.setInt(flags);
+    passiveContainsAnalogTypeInfo.setInt(props.toFlags());
   }
 
   bool operator==(const KeyTy &key) const { return key == KeyTy(elements); }
@@ -654,10 +691,10 @@ struct BundleTypeStorage : mlir::TypeStorage {
   SmallVector<unsigned, 4> fieldIDs;
   unsigned maxFieldID;
 
-  /// This holds two bits indicating whether the current type is passive and
-  /// if it contains an analog type, and can hold a pointer to a passive type if
-  /// not.
-  llvm::PointerIntPair<Type, 2, unsigned> passiveContainsAnalogTypeInfo;
+  /// This holds the bits for the type's recursive properties, and can hold a
+  /// pointer to a passive version of the type.
+  llvm::PointerIntPair<Type, RecursiveTypeProperties::numBits, unsigned>
+      passiveContainsAnalogTypeInfo;
 };
 
 } // namespace detail
@@ -674,10 +711,9 @@ auto BundleType::getElements() -> ArrayRef<BundleElement> {
 }
 
 /// Return a pair with the 'isPassive' and 'containsAnalog' bits.
-std::pair<bool, bool> BundleType::getRecursiveTypeProperties() {
+RecursiveTypeProperties BundleType::getRecursiveTypeProperties() {
   auto flags = getImpl()->passiveContainsAnalogTypeInfo.getInt();
-  return std::make_pair((flags & IsPassiveBitMask) != 0,
-                        (flags & ContainsAnalogBitMask) != 0);
+  return RecursiveTypeProperties::fromFlags(flags);
 }
 
 /// Return this type with any flip types recursively removed from itself.
@@ -754,12 +790,7 @@ struct VectorTypeStorage : mlir::TypeStorage {
 
   VectorTypeStorage(KeyTy value) : value(value) {
     auto properties = value.first.getRecursiveTypeProperties();
-    unsigned flags = 0;
-    if (properties.first)
-      flags |= IsPassiveBitMask;
-    if (properties.second)
-      flags |= ContainsAnalogBitMask;
-    passiveContainsAnalogTypeInfo.setInt(flags);
+    passiveContainsAnalogTypeInfo.setInt(properties.toFlags());
   }
 
   bool operator==(const KeyTy &key) const { return key == value; }
@@ -771,10 +802,10 @@ struct VectorTypeStorage : mlir::TypeStorage {
 
   KeyTy value;
 
-  /// This holds two bits indicating whether the current type is passive and
-  /// if it contains an analog type, and can hold a pointer to a passive type if
-  /// not.
-  llvm::PointerIntPair<Type, 2, unsigned> passiveContainsAnalogTypeInfo;
+  /// This holds the bits for the type's recursive properties, and can hold a
+  /// pointer to a passive version of the type.
+  llvm::PointerIntPair<Type, RecursiveTypeProperties::numBits, unsigned>
+      passiveContainsAnalogTypeInfo;
 };
 
 } // namespace detail
@@ -794,11 +825,10 @@ FIRRTLType FVectorType::getElementType() { return getImpl()->value.first; }
 
 unsigned FVectorType::getNumElements() { return getImpl()->value.second; }
 
-/// Return a pair with the 'isPassive' and 'containsAnalog' bits.
-std::pair<bool, bool> FVectorType::getRecursiveTypeProperties() {
+/// Return the recursive properties of the type.
+RecursiveTypeProperties FVectorType::getRecursiveTypeProperties() {
   auto flags = getImpl()->passiveContainsAnalogTypeInfo.getInt();
-  return std::make_pair((flags & IsPassiveBitMask) != 0,
-                        (flags & ContainsAnalogBitMask) != 0);
+  return RecursiveTypeProperties::fromFlags(flags);
 }
 
 /// Return this type with any flip types recursively removed from itself.
@@ -827,7 +857,7 @@ unsigned FVectorType::getFieldID(unsigned index) {
 }
 
 unsigned FVectorType::getIndexForFieldID(unsigned fieldID) {
-  assert(fieldID &&  "fieldID must be at least 1");
+  assert(fieldID && "fieldID must be at least 1");
   // Divide the field ID by the number of fieldID's per element.
   return (fieldID - 1) / (getElementType().getMaxFieldID() + 1);
 }

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -56,7 +56,8 @@ inline llvm::hash_code hash_value(const T &e) {
 } // namespace mlir
 
 namespace {
-#define EXPR_NAMES(x) Root##x, Var##x, Known##x, Add##x, Pow##x, Max##x, Min##x
+#define EXPR_NAMES(x)                                                          \
+  Root##x, Nil##x, Var##x, Known##x, Add##x, Pow##x, Max##x, Min##x
 #define EXPR_KINDS EXPR_NAMES()
 #define EXPR_CLASSES EXPR_NAMES(Expr)
 
@@ -100,6 +101,11 @@ struct RootExpr : public ExprBase<RootExpr, Expr::Kind::Root> {
   iterator begin() const { return &exprs[0]; }
   iterator end() const { return &exprs[0] + exprs.size(); }
   std::vector<Expr *> &exprs;
+};
+
+/// A free variable.
+struct NilExpr : public ExprBase<NilExpr, Expr::Kind::Nil> {
+  void print(llvm::raw_ostream &os) const { os << "nil"; }
 };
 
 /// A free variable.
@@ -328,6 +334,7 @@ class ConstraintSolver {
 public:
   ConstraintSolver() = default;
 
+  NilExpr *nil() { return &singletonNil; }
   VarExpr *var() {
     auto v = vars.alloc();
     exprs.push_back(v);
@@ -358,6 +365,7 @@ public:
 private:
   // Allocator for constraint expressions.
   llvm::BumpPtrAllocator allocator;
+  static NilExpr singletonNil;
   VarAllocator vars = {allocator};
   InternedAllocator<KnownExpr> knowns = {allocator};
   InternedAllocator<UnaryExpr> uns = {allocator};
@@ -392,6 +400,8 @@ private:
 };
 
 } // namespace
+
+NilExpr ConstraintSolver::singletonNil;
 
 /// Print all constraints in the solver to an output stream.
 void ConstraintSolver::dumpConstraints(llvm::raw_ostream &os) {
@@ -586,6 +596,7 @@ static LinIneq checkCycles(VarExpr *var, Expr *expr,
                            InFlightDiagnostic *reportInto = nullptr) {
   auto ineq =
       TypeSwitch<Expr *, LinIneq>(expr)
+          .Case<NilExpr>([](auto) { return LinIneq(0); })
           .Case<KnownExpr>([&](auto *expr) { return LinIneq(*expr->solution); })
           .Case<VarExpr>([&](auto *expr) {
             if (expr == var)
@@ -666,7 +677,7 @@ LogicalResult ConstraintSolver::solve() {
   for (auto *expr : exprs) {
     // Only work on variables.
     auto *var = dyn_cast<VarExpr>(expr);
-    if (!var)
+    if (!var || !var->constraint)
       continue;
     LLVM_DEBUG(llvm::dbgs()
                << "- Checking " << *var << " >= " << *var->constraint << "\n");
@@ -770,9 +781,9 @@ public:
   LogicalResult map(FModuleOp op);
   LogicalResult mapOperation(Operation *op);
 
-  Expr *declareVars(Value value);
-  Expr *declareVars(Type type);
-  Expr *declareVars(FIRRTLType type);
+  Expr *declareVars(Value value, Location loc);
+  Expr *declareVars(Type type, Location loc);
+  Expr *declareVars(FIRRTLType type, Location loc);
 
   void constrainTypes(Expr *larger, Expr *smaller);
 
@@ -792,6 +803,13 @@ private:
 
 } // namespace
 
+/// Check if a type contains any FIRRTL type with uninferred widths.
+static bool hasUninferredWidth(Type type) {
+  if (auto ftype = type.dyn_cast<FIRRTLType>())
+    return ftype.hasUninferredWidth();
+  return false;
+}
+
 LogicalResult InferenceMapping::map(CircuitOp op) {
   for (auto &op : *op.getBody()) {
     if (auto module = dyn_cast<FModuleOp>(&op))
@@ -805,7 +823,7 @@ LogicalResult InferenceMapping::map(FModuleOp module) {
   // Ensure we have constraint variables for the module ports.
   for (auto arg : module.getArguments()) {
     solver.setCurrentContextInfo(arg);
-    declareVars(arg);
+    declareVars(arg, module.getLoc());
   }
 
   // Go through operations, creating type variables for results, and generating
@@ -817,6 +835,22 @@ LogicalResult InferenceMapping::map(FModuleOp module) {
 }
 
 LogicalResult InferenceMapping::mapOperation(Operation *op) {
+  // In case the operation result has a type without uninferred widths, don't
+  // even bother to populate the constraint problem and treat that as a known
+  // size directly. This is done in `declareVars`, which will generate
+  // `KnownExpr` nodes for all known widths -- which are the only ones in this
+  // case.
+  bool allWidthsKnown = true;
+  for (auto result : op->getResults()) {
+    if (!hasUninferredWidth(result.getType()))
+      declareVars(result, op->getLoc());
+    else
+      allWidthsKnown = false;
+  }
+  if (allWidthsKnown && !isa<ConnectOp, PartialConnectOp>(op))
+    return success();
+
+  // Actually generate the necessary constraint expressions.
   bool mappingFailed = false;
   solver.setCurrentContextInfo(op->getNumResults() > 0 ? op->getResults()[0]
                                                        : Value{});
@@ -838,7 +872,7 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
         setExpr(op.getResult(), e);
       })
       .Case<WireOp, InvalidValueOp, RegOp>(
-          [&](auto op) { declareVars(op.getResult()); })
+          [&](auto op) { declareVars(op.getResult(), op.getLoc()); })
 
       // Arithmetic and Logical Binary Primitives
       .Case<AddPrimOp, SubPrimOp>([&](auto op) {
@@ -966,6 +1000,12 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
         auto src = getExpr(op.src());
         constrainTypes(dest, src);
       })
+      .Case<PartialConnectOp>([&](auto op) {
+        if (!hasUninferredWidth(op.dest().getType()))
+          return;
+        op.emitOpError("not supported in width inference");
+        mappingFailed = true;
+      })
 
       // Handle the no-ops that don't interact with width inference.
       .Case<PrintFOp, SkipOp, StopOp, WhenOp, AssertOp, AssumeOp, CoverOp>(
@@ -975,32 +1015,30 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
         op->emitOpError("not supported in width inference");
         mappingFailed = true;
       });
-  // TODO: Handle PartialConnect
-  // TODO: Handle Attach
-  // TODO: Handle Conditionally
+
   return failure(mappingFailed);
 }
 
 /// Declare free variables for the type of a value, and associate the resulting
 /// set of variables with that value.
-Expr *InferenceMapping::declareVars(Value value) {
-  Expr *e = declareVars(value.getType());
+Expr *InferenceMapping::declareVars(Value value, Location loc) {
+  Expr *e = declareVars(value.getType(), loc);
   setExpr(value, e);
   return e;
 }
 
 /// Declare free variables for a type.
-Expr *InferenceMapping::declareVars(Type type) {
+Expr *InferenceMapping::declareVars(Type type, Location loc) {
   if (auto ftype = type.dyn_cast<FIRRTLType>())
-    return declareVars(ftype);
-  // TODO: Once we support compound types, non-FIRRTL types will just map to
-  // an empty list of expressions in the solver. At that point we'll have
-  // something proper to return here.
-  llvm_unreachable("non-FIRRTL types not supported");
+    return declareVars(ftype, loc);
+  // TODO: Non-FIRRTL types should probably map to an empty list of constraint
+  // expressions, rather than `nil`. Update this once this function returns a
+  // list of constraints for compound types.
+  return solver.nil();
 }
 
 /// Declare free variables for a FIRRTL type.
-Expr *InferenceMapping::declareVars(FIRRTLType type) {
+Expr *InferenceMapping::declareVars(FIRRTLType type, Location loc) {
   // TODO: Support aggregate and compound types as well.
   auto width = type.getBitWidthOrSentinel();
   if (width >= 0) {
@@ -1008,10 +1046,10 @@ Expr *InferenceMapping::declareVars(FIRRTLType type) {
   } else if (width == -1) {
     return solver.var();
   } else if (auto inner = type.dyn_cast<FlipType>()) {
-    return declareVars(inner.getElementType());
+    return declareVars(inner.getElementType(), loc);
   } else {
-    // TODO: Once we support compound types, this will go away.
-    llvm_unreachable("compound types not supported");
+    // TODO: Once we support compound types, this will return something useful.
+    return solver.nil();
   }
 }
 
@@ -1156,6 +1194,10 @@ bool InferenceTypeUpdate::updateValue(Value value) {
   if (!type)
     return false;
 
+  // Fast path for types that have fully inferred widths.
+  if (!hasUninferredWidth(type))
+    return false;
+
   // If this is an operation that does not generate any free variables that are
   // determined during width inference, simply update the value type based on
   // the operation arguments.
@@ -1179,11 +1221,28 @@ bool InferenceTypeUpdate::updateValue(Value value) {
 
   // Get the inferred width.
   Expr *expr = mapping.getExprOrNull(value);
-  if (!expr || !expr->solution.hasValue())
+  if (!expr || !expr->solution.hasValue()) {
+    anyFailed = true;
+    // Emit an error that indicates where we have failed to infer a width. Note
+    // that we only get here if the IR contained some operation or FIRRTL type
+    // that is not yet supported by width inference. Errors related to widths
+    // not being inferrable due to contradictory constraints are handled earlier
+    // in the solver, and the pass never proceeds to perform this type update.
+    // TL;DR: This is for compiler hackers.
+    // TODO: Convert this to an assertion once we support all operations and
+    // types for width inference.
+    auto diag = mlir::emitError(value.getLoc(), "failed to infer width");
+    if (auto blockArg = value.dyn_cast<BlockArgument>())
+      diag << " for port #" << blockArg.getArgNumber();
+    else if (auto op = value.getDefiningOp())
+      diag << " for op '" << op->getName() << "'";
+    else
+      diag << " for value";
+    diag << " of type '" << type << "'";
     return false;
+  }
   int32_t solution = expr->solution.getValue();
-  if (solution < 0)
-    return false;
+  assert(solution >= 0); // TODO: This should never happen -- corner cases?
 
   // Update the type.
   auto newType = updateType(type, solution);


### PR DESCRIPTION
This PR makes width inference more robust in the presence of not-yet-supported types and operations, skipping over them whenever they don't require any widths to be inferred (which is easy to check).

`firtool` run with `--infer-widths` and without now produces the exact same output MLIR when run on circt/perf [test1](https://github.com/circt/perf/blob/trunk/regress/test1.fir), [test2](https://github.com/circt/perf/blob/trunk/regress/test2.fir), [test3](https://github.com/circt/perf/blob/trunk/regress/test3.fir), and on one of SiFive's small cores. This despite the fact that these tests contain unsupported aggregate types and operations -- but with no unknown widths.

Once we're happy with this, `--infer-widths` can become the inverse `--disable-infer-widths` with the pass running by default.

### Details

* Add a special `nil` constraint expression that is used as a placeholder for aggregate types and operations that are not yet
  supported. Eventually this expression will go away again, but until everything is implemented we need a way to properly construct a constraint problem in the presence of unsupported types/ops.

* Track locations in `declareVars` to improve error reporting. Uses of the location got dropped by the new `nil` expression, but they will make a comeback later when we have more complex types that might fail to map to constraint variables.

* Add a `hasUninferredWidths` helper that checks whether a type, including aggregate types, contains any uninferred widths.

* Add a fast path that just generates a `KnownExpr` for op results that have no uninferred widths, rather than inspecting the operation itself and trying to come up with a precise expression. This has two benefits:
    1. It speeds up width inference since almost all expressions become "terminal" `KnownExpr` nodes in the graph, rather than building complex nested expressions for them (if they have a known width, that is).
    2. Width inference now succeeds on inputs that contain types/ops not yet supported by width inference, as long as they don't contain any uninferred widths (i.e., width inference becomes better at not touching ops that need no widths to be inferred).

* Add an error message targeted at compiler hackers in case the type update stage encounters a value for which the pass should have inferred a width, but for some reason didn't. This will trigger on structural problems like types/ops not being supported yet, but not on errors triggered by the user by constructing uninferrable constraints. This message will go away in the future as soon as `InferWidths` is comfortable with handling all FIRRTL ops and types. Until then, this should give @drom some hints at what flavors of width inference are yet to be implemented.