### PR TITLE
[PyCDE] Add generator options to select a generator by name.

### DIFF
--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -43,8 +43,9 @@ class System:
   def print(self):
     self.mod.operation.print()
 
-  def generate(self):
-    pm = mlir.passmanager.PassManager.parse("run-generators")
+  def generate(self, generator_names=[]):
+    pm = mlir.passmanager.PassManager.parse("run-generators{generators=" +
+                                            ",".join(generator_names) + "}")
     try:
       pm.run(self.mod)
     except Exception as e:

--- a/frontends/PyCDE/test/generator_options.py
+++ b/frontends/PyCDE/test/generator_options.py
@@ -27,7 +27,7 @@ class Top(System):
 
 # CHECK: hw.constant 1
 top1 = Top()
-top1.generate()
+top1.generate(["generator_a"])
 top1.print()
 
 # CHECK: hw.constant 2
@@ -38,6 +38,20 @@ top2.print()
 # CHECK: generator exception
 top3 = Top()
 try:
-  top3.generate(["generator_a", "generator_b"])
+  top3.generate()
+except RuntimeError:
+  pass
+
+# CHECK: generator exception
+top4 = Top()
+try:
+  top4.generate(["generator_a", "generator_b"])
+except RuntimeError:
+  pass
+
+# CHECK: generator exception
+top5 = Top()
+try:
+  top5.generate(["nonexistant"])
 except RuntimeError:
   pass

--- a/frontends/PyCDE/test/generator_options.py
+++ b/frontends/PyCDE/test/generator_options.py
@@ -1,0 +1,43 @@
+# RUN: %PYTHON% %s | FileCheck %s
+
+from pycde import System, module, generator, types
+
+from circt.dialects import hw
+
+
+@module
+class GeneratorOptions:
+
+  @generator
+  def generator_a(mod):
+    hw.ConstantOp.create(types.i32, 1)
+
+  @generator
+  def generator_b(mod):
+    hw.ConstantOp.create(types.i32, 2)
+
+
+class Top(System):
+  inputs = []
+  outputs = []
+
+  def build(self, top):
+    GeneratorOptions()
+
+
+# CHECK: hw.constant 1
+top1 = Top()
+top1.generate()
+top1.print()
+
+# CHECK: hw.constant 2
+top2 = Top()
+top2.generate(["generator_b"])
+top2.print()
+
+# CHECK: generator exception
+top3 = Top()
+try:
+  top3.generate(["generator_a", "generator_b"])
+except RuntimeError:
+  pass

--- a/include/circt/Dialect/MSFT/MSFT.td
+++ b/include/circt/Dialect/MSFT/MSFT.td
@@ -85,6 +85,11 @@ def RunGenerators: Pass<"run-generators", "mlir::ModuleOp"> {
     implementation of the same logical feature.
   }];
   let constructor = "circt::msft::createRunGeneratorsPass()";
+  let options = [
+    ListOption<"generators", "generators", "std::string",
+               "List of possible generators to run.",
+               "llvm::cl::OneOrMore, llvm::cl::MiscFlags::CommaSeparated">
+  ];
 }
 
 #endif // MSFT_TD


### PR DESCRIPTION
The `generate` call accepts a list of candidate generators to run,
which defaults to empty.

When looking up a generator, the list is consulted. If it is empty,
the first generator is chosen by default. If it is present, the first
generator in the list is selected. If multiple candidates are in the
list, an error is raised.