### PR TITLE
[SV] Cleanup of Includes/Dependencies for Passes, NFC

### DIFF
--- a/lib/Dialect/SV/Transforms/CMakeLists.txt
+++ b/lib/Dialect/SV/Transforms/CMakeLists.txt
@@ -11,6 +11,8 @@ add_circt_dialect_library(CIRCTSVTransforms
   CIRCTSVTransformsIncGen
 
   LINK_LIBS PUBLIC
+  CIRCTComb
+  CIRCTHW
   CIRCTSV
   MLIRIR
   MLIRPass

--- a/lib/Dialect/SV/Transforms/GeneratorCallout.cpp
+++ b/lib/Dialect/SV/Transforms/GeneratorCallout.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "SVPassDetail.h"
+#include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVPasses.h"
 #include "mlir/IR/Builders.h"
 #include "llvm/Support/FileSystem.h"

--- a/lib/Dialect/SV/Transforms/GeneratorCallout.cpp
+++ b/lib/Dialect/SV/Transforms/GeneratorCallout.cpp
@@ -15,7 +15,6 @@
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVPasses.h"
 #include "mlir/IR/Builders.h"
-#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"

--- a/lib/Dialect/SV/Transforms/GeneratorCallout.cpp
+++ b/lib/Dialect/SV/Transforms/GeneratorCallout.cpp
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "SVPassDetail.h"
+#include "PassDetail.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVPasses.h"
 #include "mlir/IR/Builders.h"

--- a/lib/Dialect/SV/Transforms/HWCleanup.cpp
+++ b/lib/Dialect/SV/Transforms/HWCleanup.cpp
@@ -13,7 +13,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "SVPassDetail.h"
+#include "PassDetail.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVPasses.h"
 

--- a/lib/Dialect/SV/Transforms/HWCleanup.cpp
+++ b/lib/Dialect/SV/Transforms/HWCleanup.cpp
@@ -14,6 +14,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "SVPassDetail.h"
+#include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVPasses.h"
 
 using namespace circt;

--- a/lib/Dialect/SV/Transforms/HWLegalizeNames.cpp
+++ b/lib/Dialect/SV/Transforms/HWLegalizeNames.cpp
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "SVPassDetail.h"
+#include "PassDetail.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVPasses.h"
 

--- a/lib/Dialect/SV/Transforms/HWLegalizeNames.cpp
+++ b/lib/Dialect/SV/Transforms/HWLegalizeNames.cpp
@@ -12,7 +12,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "SVPassDetail.h"
-#include "circt/Dialect/SV/SVOps.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVPasses.h"
 

--- a/lib/Dialect/SV/Transforms/HWLegalizeNames.cpp
+++ b/lib/Dialect/SV/Transforms/HWLegalizeNames.cpp
@@ -13,6 +13,7 @@
 
 #include "SVPassDetail.h"
 #include "circt/Dialect/SV/SVOps.h"
+#include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVPasses.h"
 
 using namespace circt;

--- a/lib/Dialect/SV/Transforms/HWMemSimImpl.cpp
+++ b/lib/Dialect/SV/Transforms/HWMemSimImpl.cpp
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "SVPassDetail.h"
+#include "PassDetail.h"
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVPasses.h"

--- a/lib/Dialect/SV/Transforms/HWMemSimImpl.cpp
+++ b/lib/Dialect/SV/Transforms/HWMemSimImpl.cpp
@@ -13,6 +13,7 @@
 
 #include "SVPassDetail.h"
 #include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVPasses.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 

--- a/lib/Dialect/SV/Transforms/HWStubExternalModules.cpp
+++ b/lib/Dialect/SV/Transforms/HWStubExternalModules.cpp
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "SVPassDetail.h"
+#include "PassDetail.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVPasses.h"
 #include "mlir/IR/Builders.h"

--- a/lib/Dialect/SV/Transforms/HWStubExternalModules.cpp
+++ b/lib/Dialect/SV/Transforms/HWStubExternalModules.cpp
@@ -13,7 +13,7 @@
 #include "SVPassDetail.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVPasses.h"
-#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/Builders.h"
 
 using namespace circt;
 

--- a/lib/Dialect/SV/Transforms/HWStubExternalModules.cpp
+++ b/lib/Dialect/SV/Transforms/HWStubExternalModules.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "SVPassDetail.h"
+#include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVPasses.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 

--- a/lib/Dialect/SV/Transforms/PassDetail.h
+++ b/lib/Dialect/SV/Transforms/PassDetail.h
@@ -9,8 +9,8 @@
 // clang-tidy seems to expect the absolute path in the header guard on some
 // systems, so just disable it.
 // NOLINTNEXTLINE(llvm-header-guard)
-#ifndef DIALECT_SV_TRANSFORMS_SVPASSDETAIL_H
-#define DIALECT_SV_TRANSFORMS_SVPASSDETAIL_H
+#ifndef DIALECT_SV_TRANSFORMS_PASSDETAIL_H
+#define DIALECT_SV_TRANSFORMS_PASSDETAIL_H
 
 #include "circt/Dialect/SV/SVOps.h"
 #include "mlir/Pass/Pass.h"
@@ -34,4 +34,4 @@ namespace sv {
 } // namespace sv
 } // namespace circt
 
-#endif // DIALECT_FIRRTL_TRANSFORMS_SVPASSDETAIL_H
+#endif // DIALECT_FIRRTL_TRANSFORMS_PASSDETAIL_H

--- a/lib/Dialect/SV/Transforms/PrettifyVerilog.cpp
+++ b/lib/Dialect/SV/Transforms/PrettifyVerilog.cpp
@@ -16,6 +16,7 @@
 
 #include "SVPassDetail.h"
 #include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVPasses.h"
 
 using namespace circt;

--- a/lib/Dialect/SV/Transforms/PrettifyVerilog.cpp
+++ b/lib/Dialect/SV/Transforms/PrettifyVerilog.cpp
@@ -14,7 +14,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "SVPassDetail.h"
+#include "PassDetail.h"
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVPasses.h"

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -15,6 +15,7 @@
 
 #include "SVPassDetail.h"
 #include "circt/Dialect/SV/SVOps.h"
+#include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVPasses.h"
 #include "circt/Dialect/SV/SVVisitors.h"
 #include "mlir/IR/BlockAndValueMapping.h"

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -13,7 +13,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "SVPassDetail.h"
+#include "PassDetail.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVPasses.h"
 #include "mlir/IR/BlockAndValueMapping.h"

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -14,10 +14,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "SVPassDetail.h"
-#include "circt/Dialect/SV/SVOps.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVPasses.h"
-#include "circt/Dialect/SV/SVVisitors.h"
 #include "mlir/IR/BlockAndValueMapping.h"
 #include "mlir/IR/Builders.h"
 

--- a/lib/Dialect/SV/Transforms/SVPassDetail.h
+++ b/lib/Dialect/SV/Transforms/SVPassDetail.h
@@ -12,11 +12,20 @@
 #ifndef DIALECT_SV_TRANSFORMS_SVPASSDETAIL_H
 #define DIALECT_SV_TRANSFORMS_SVPASSDETAIL_H
 
-#include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVOps.h"
 #include "mlir/Pass/Pass.h"
 
 namespace circt {
+
+namespace comb {
+class CombDialect;
+}
+
+namespace hw {
+class HWDialect;
+class HWModuleOp;
+} // namespace hw
+
 namespace sv {
 
 #define GEN_PASS_CLASSES


### PR DESCRIPTION
This cleans up the SV Dialect to better align with how MLIR does things for passes. This is a doing a number of disparate things which are all presented as separate commits in the patch set:

- The blind inclusion of `HWOps` is changed to a forward declare
- ~All `dependentDialects` are properly defined for SV passes~ (dropping this as I forgot that dependent dialects are those where the pass can _produce_ those ops)
- HW and Comb are added to CMakeLists.txt
- Unnecessary headers are pruned
- `SVPassDetail.h` is renamed to `PassDetail.h`