### PR TITLE
[Py] Create syntactic sugar for some Array and Struct ops

### DIFF
--- a/include/circt-c/Dialect/HW.h
+++ b/include/circt-c/Dialect/HW.h
@@ -87,6 +87,9 @@ MLIR_CAPI_EXPORTED MlirType
 hwStructTypeGet(MlirContext ctx, intptr_t numElements,
                 struct HWStructFieldInfo const *elements);
 
+MLIR_CAPI_EXPORTED MlirType hwStructTypeGetField(MlirType structType,
+                                                 MlirStringRef fieldName);
+
 #ifdef __cplusplus
 }
 #endif

--- a/integration_test/Bindings/Python/dialects/hw.py
+++ b/integration_test/Bindings/Python/dialects/hw.py
@@ -1,0 +1,40 @@
+# REQUIRES: bindings_python
+# RUN: %PYTHON% %s | FileCheck %s
+
+import circt
+from circt.dialects import hw
+
+from mlir.ir import Context, Location, InsertionPoint, IntegerType, IntegerAttr, Module
+
+with Context() as ctx, Location.unknown():
+  circt.register_dialects(ctx)
+
+  i1 = IntegerType.get_signless(1)
+  i32 = IntegerType.get_signless(32)
+
+  m = Module.create()
+  with InsertionPoint(m.body):
+
+    def build(module):
+      # CHECK: %[[CONST:.+]] = hw.constant 1 : i32
+      constI32 = hw.ConstantOp(i32, IntegerAttr.get(i32, 1))
+      constI1 = hw.ConstantOp.create(i1, 1)
+
+      # CHECK: [[ARRAY1:%.+]] = hw.array_create %c1_i32, %c1_i32, %c1_i32 : i32
+      array1 = hw.ArrayCreateOp.create([constI32, constI32, constI32])
+
+      # CHECK: hw.array_get [[ARRAY1]][%c1_i32] : !hw.array<3xi32>
+      hw.ArrayGetOp.create(array1, constI32)
+      # CHECK: %c-2_i2 = hw.constant -2 : i2
+      # CHECK: hw.array_get [[ARRAY1]][%c-2_i2] : !hw.array<3xi32>
+      hw.ArrayGetOp.create(array1, 2)
+
+      # CHECK: [[STRUCT1:%.+]] = hw.struct_create (%c1_i32, %true) : !hw.struct<a: i32, b: i1>
+      struct1 = hw.StructCreateOp.create([('a', constI32), ('b', constI1)])
+
+      # CHECK: %4 = hw.struct_extract [[STRUCT1]]["a"] : !hw.struct<a: i32, b: i1>
+      hw.StructExtractOp.create(struct1, 'a')
+
+    hw.HWModuleOp(name="test", body_builder=build)
+
+  print(m)

--- a/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
@@ -355,3 +355,61 @@ class ConstantOp:
   @staticmethod
   def create(data_type, value):
     return hw.ConstantOp(data_type, IntegerAttr.get(data_type, value))
+
+
+class ArrayGetOp:
+
+  @staticmethod
+  def create(array_value, idx):
+    array_value = support.get_value(array_value)
+    array_type = hw.ArrayType(array_value.type)
+    if isinstance(idx, int):
+      idx_width = (array_type.size - 1).bit_length()
+      idx_val = ConstantOp.create(IntegerType.get_signless(idx_width),
+                                  idx).result
+    else:
+      idx_val = support.get_value(idx)
+    return hw.ArrayGetOp(array_type.element_type, array_value, idx_val)
+
+
+class ArrayCreateOp:
+
+  @staticmethod
+  def create(elements):
+    if not elements:
+      raise ValueError("Cannot 'create' an array of length zero.")
+    vals = []
+    type = None
+    for arg in elements:
+      arg_val = support.get_value(arg)
+      vals.append(arg_val)
+      if type is None:
+        type = arg_val.type
+      elif type != arg_val.type:
+        raise TypeError(
+            "All arguments must be the same type to create an array")
+    return hw.ArrayCreateOp(hw.ArrayType.get(vals[0].type, len(vals)), vals)
+
+
+class StructCreateOp:
+
+  @staticmethod
+  def create(elements: list[(str, Type)]):
+    elem_name_values = [
+        (name, support.get_value(value)) for (name, value) in elements
+    ]
+    struct_type = hw.StructType.get([
+        (name, value.type) for (name, value) in elem_name_values
+    ])
+    return hw.StructCreateOp(struct_type,
+                             [value for (_, value) in elem_name_values])
+
+
+class StructExtractOp:
+
+  @staticmethod
+  def create(struct_value, field_name: str):
+    struct_value = support.get_value(struct_value)
+    struct_type = hw.StructType(struct_value.type)
+    return hw.StructExtractOp(struct_type, struct_value,
+                              StringAttr.get(field_name))

--- a/lib/CAPI/Dialect/HW.cpp
+++ b/lib/CAPI/Dialect/HW.cpp
@@ -76,3 +76,8 @@ MlirType hwStructTypeGet(MlirContext ctx, intptr_t numElements,
   }
   return wrap(StructType::get(unwrap(ctx), fieldInfos));
 }
+
+MlirType hwStructTypeGetField(MlirType structType, MlirStringRef fieldName) {
+  StructType st = unwrap(structType).cast<StructType>();
+  return wrap(st.getFieldType(unwrap(fieldName)));
+}


### PR DESCRIPTION
Recreating the C++ logic for ArrayCreateOp, ArrayGetOp, StructCreateOp, and StructExtractOp.