### PR TITLE
[FIRRTL] Infer widths across modules and instances

### DIFF
--- a/test/Dialect/FIRRTL/infer-widths-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-widths-errors.mlir
@@ -22,3 +22,16 @@ firrtl.circuit "Foo" {
     firrtl.connect %0, %3 : !firrtl.uint, !firrtl.uint
   }
 }
+
+// -----
+firrtl.circuit "Foo" {
+  // expected-note @+1 {{Module `Bar` defined here:}}
+  firrtl.extmodule @Bar(in %in: !firrtl.uint, out %out: !firrtl.uint)
+  firrtl.module @Foo(in %in: !firrtl.uint<42>, out %out: !firrtl.uint) {
+    // expected-error @+2 {{extern module `Bar` has ports of uninferred width}}
+    // expected-note @+1 {{Only non-extern FIRRTL modules may contain unspecified widths to be inferred automatically.}}
+    %inst_in, %inst_out = firrtl.instance @Bar {name = "inst"} : !firrtl.flip<uint>, !firrtl.uint
+    firrtl.connect %inst_in, %in : !firrtl.flip<uint>, !firrtl.uint<42>
+    firrtl.connect %out, %inst_out : !firrtl.uint, !firrtl.uint
+  }
+}

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -434,5 +434,44 @@ firrtl.circuit "Foo" {
     firrtl.connect %1, %4 : !firrtl.uint, !firrtl.uint
   }
 
+  // Inter-module width inference for one-to-one module-instance correspondence.
+  // CHECK-LABEL: @InterModuleSimpleFoo
+  // CHECK-SAME: in %in: !firrtl.uint<42>
+  // CHECK-SAME: out %out: !firrtl.uint<43>
+  // CHECK-LABEL: @InterModuleSimpleBar
+  // CHECK-SAME: in %in: !firrtl.uint<42>
+  // CHECK-SAME: out %out: !firrtl.uint<44>
+  firrtl.module @InterModuleSimpleFoo(in %in: !firrtl.uint, out %out: !firrtl.uint) {
+    %0 = firrtl.add %in, %in : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    firrtl.connect %out, %0 : !firrtl.uint, !firrtl.uint
+  }
+  firrtl.module @InterModuleSimpleBar(in %in: !firrtl.uint<42>, out %out: !firrtl.uint) {
+    %inst_in, %inst_out = firrtl.instance @InterModuleSimpleFoo {name = "inst"} : !firrtl.flip<uint>, !firrtl.uint
+    %0 = firrtl.add %inst_out, %inst_out : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    firrtl.connect %inst_in, %in : !firrtl.flip<uint>, !firrtl.uint<42>
+    firrtl.connect %out, %0 : !firrtl.uint, !firrtl.uint
+  }
+
+  // Inter-module width inference for multiple instances per module.
+  // CHECK-LABEL: @InterModuleMultipleFoo
+  // CHECK-SAME: in %in: !firrtl.uint<42>
+  // CHECK-SAME: out %out: !firrtl.uint<43>
+  // CHECK-LABEL: @InterModuleMultipleBar
+  // CHECK-SAME: in %in1: !firrtl.uint<17>
+  // CHECK-SAME: in %in2: !firrtl.uint<42>
+  // CHECK-SAME: out %out: !firrtl.uint<43>
+  firrtl.module @InterModuleMultipleFoo(in %in: !firrtl.uint, out %out: !firrtl.uint) {
+    %0 = firrtl.add %in, %in : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    firrtl.connect %out, %0 : !firrtl.uint, !firrtl.uint
+  }
+  firrtl.module @InterModuleMultipleBar(in %in1: !firrtl.uint<17>, in %in2: !firrtl.uint<42>, out %out: !firrtl.uint) {
+    %inst1_in, %inst1_out = firrtl.instance @InterModuleMultipleFoo {name = "inst1"} : !firrtl.flip<uint>, !firrtl.uint
+    %inst2_in, %inst2_out = firrtl.instance @InterModuleMultipleFoo {name = "inst2"} : !firrtl.flip<uint>, !firrtl.uint
+    %0 = firrtl.xor %inst1_out, %inst2_out : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    firrtl.connect %inst1_in, %in1 : !firrtl.flip<uint>, !firrtl.uint<17>
+    firrtl.connect %inst2_in, %in2 : !firrtl.flip<uint>, !firrtl.uint<42>
+    firrtl.connect %out, %0 : !firrtl.uint, !firrtl.uint
+  }
+
   firrtl.module @Foo() {}
 }


### PR DESCRIPTION
Expand the `InferWidths` pass to handle width inference across modules and their instances. This is done by ensuring that free variables in the constraint problem are created first for all module ports in the IR, before module bodies are processed. This then allows InstanceOp to simply look up the variables for the ports on the instantiated module, and re-use them as the variables for the instance ports. Connecting to the instance port imposes a constraint on the instance port, which shares the same constraint variable as the corresponding module. As a result, the constraints from instance port connects are collectively imposed on the instantiated module.