### PR TITLE
[SV] Add SystemVerilog force,release statement to SV dialect.

### DIFF
--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -379,6 +379,24 @@ def PAssignOp : SVOp<"passign", [InOutTypeConstraint<"src", "dest">,
   let assemblyFormat = "$dest `,` $src  attr-dict `:` type($src)";
 }
 
+def ForcePAssignOp : SVOp<"force", [InOutTypeConstraint<"src", "dest">,
+                                   ProceduralOp]> {
+  let summary = "Force procedural statement";
+  let description = [{
+    A SystemVerilog force procedural statement 'force x = y;'.  These
+    occur in initial, always, task, and function blocks.  
+    A force statement shall override a procedural assignment until
+    a release statement is executed on the variable. 
+    The left-hand side of the assignment can be avariable, a net,
+    a constant bit-select of a vector net, a part-select of a vector 
+    net or a concatenation. It cannot be a memory word or a bit-select 
+    or part-select of a vector variable. See SV Spec 9.3.2.
+  }];
+  let arguments = (ins InOutType:$dest, InOutElementType:$src);
+  let results = (outs);
+  let assemblyFormat = "$dest `,` $src  attr-dict `:` type($src)";
+}
+
 def AliasOp : SVOp<"alias"> {
   let summary = "SystemVerilog 'alias' statement";
   let description = [{

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -397,6 +397,23 @@ def ForcePAssignOp : SVOp<"force", [InOutTypeConstraint<"src", "dest">,
   let assemblyFormat = "$dest `,` $src  attr-dict `:` type($src)";
 }
 
+def ReleaseOp : SVOp<"release", [ProceduralOp]> {
+  let summary = "Release procedural statement";
+  let description = [{
+    Release is used in conjunction with force. When released,
+    then if the variable does not currently have an active assign 
+    procedural continuous assignment, the variable shall not immediately 
+    change value. The variable shall maintain its current value until 
+    the next procedural assignment or procedural continuous assignment 
+    to the variable. Releasing a variable that currently has an
+    active assign procedural continuous assignment shall immediately 
+    reestablish that assignment. See SV Spec 9.3.2.
+  }];
+  let arguments = (ins InOutType:$dest);
+  let results = (outs);
+  let assemblyFormat = "$dest attr-dict `:` type($dest)";
+}
+
 def AliasOp : SVOp<"alias"> {
   let summary = "SystemVerilog 'alias' statement";
   let description = [{

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -379,7 +379,7 @@ def PAssignOp : SVOp<"passign", [InOutTypeConstraint<"src", "dest">,
   let assemblyFormat = "$dest `,` $src  attr-dict `:` type($src)";
 }
 
-def ForcePAssignOp : SVOp<"force", [InOutTypeConstraint<"src", "dest">,
+def ForceOp : SVOp<"force", [InOutTypeConstraint<"src", "dest">,
                                    ProceduralOp]> {
   let summary = "Force procedural statement";
   let description = [{

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -36,8 +36,8 @@ public:
             IfDefOp, IfDefProceduralOp, IfOp, AlwaysOp, AlwaysCombOp,
             AlwaysFFOp, InitialOp, CaseZOp,
             // Other Statements.
-            ConnectOp, BPAssignOp, PAssignOp, AliasOp, FWriteOp, FatalOp,
-            FinishOp, VerbatimOp,
+            ConnectOp, BPAssignOp, PAssignOp, ForcePAssignOp, AliasOp, FWriteOp,
+            FatalOp, FinishOp, VerbatimOp,
             // Type declarations.
             InterfaceOp, InterfaceSignalOp, InterfaceModportOp,
             InterfaceInstanceOp, GetModportOp, AssignInterfaceSignalOp,
@@ -95,6 +95,7 @@ public:
   HANDLE(ConnectOp, Unhandled);
   HANDLE(BPAssignOp, Unhandled);
   HANDLE(PAssignOp, Unhandled);
+  HANDLE(ForcePAssignOp, Unhandled);
   HANDLE(AliasOp, Unhandled);
   HANDLE(FWriteOp, Unhandled);
   HANDLE(FatalOp, Unhandled);

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -36,8 +36,8 @@ public:
             IfDefOp, IfDefProceduralOp, IfOp, AlwaysOp, AlwaysCombOp,
             AlwaysFFOp, InitialOp, CaseZOp,
             // Other Statements.
-            ConnectOp, BPAssignOp, PAssignOp, ForcePAssignOp, AliasOp, FWriteOp,
-            FatalOp, FinishOp, VerbatimOp,
+            ConnectOp, BPAssignOp, PAssignOp, ForcePAssignOp, ReleaseOp,
+            AliasOp, FWriteOp, FatalOp, FinishOp, VerbatimOp,
             // Type declarations.
             InterfaceOp, InterfaceSignalOp, InterfaceModportOp,
             InterfaceInstanceOp, GetModportOp, AssignInterfaceSignalOp,
@@ -96,6 +96,7 @@ public:
   HANDLE(BPAssignOp, Unhandled);
   HANDLE(PAssignOp, Unhandled);
   HANDLE(ForcePAssignOp, Unhandled);
+  HANDLE(ReleaseOp, Unhandled);
   HANDLE(AliasOp, Unhandled);
   HANDLE(FWriteOp, Unhandled);
   HANDLE(FatalOp, Unhandled);

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -36,7 +36,7 @@ public:
             IfDefOp, IfDefProceduralOp, IfOp, AlwaysOp, AlwaysCombOp,
             AlwaysFFOp, InitialOp, CaseZOp,
             // Other Statements.
-            ConnectOp, BPAssignOp, PAssignOp, ForcePAssignOp, ReleaseOp,
+            ConnectOp, BPAssignOp, PAssignOp, ForceOp, ReleaseOp,
             AliasOp, FWriteOp, FatalOp, FinishOp, VerbatimOp,
             // Type declarations.
             InterfaceOp, InterfaceSignalOp, InterfaceModportOp,
@@ -95,7 +95,7 @@ public:
   HANDLE(ConnectOp, Unhandled);
   HANDLE(BPAssignOp, Unhandled);
   HANDLE(PAssignOp, Unhandled);
-  HANDLE(ForcePAssignOp, Unhandled);
+  HANDLE(ForceOp, Unhandled);
   HANDLE(ReleaseOp, Unhandled);
   HANDLE(AliasOp, Unhandled);
   HANDLE(FWriteOp, Unhandled);

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -41,7 +41,7 @@ static void getBackwardSliceSimple(Operation *rootOp,
     Operation *op = worklist.back();
     worklist.pop_back();
 
-    if (!op || op->hasTrait<OpTrait::IsIsolatedFromAbove>())
+    if (!op) //|| op->hasTrait<OpTrait::IsIsolatedFromAbove>())
       continue;
 
     // Evaluate whether we should keep this def.

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -41,7 +41,7 @@ static void getBackwardSliceSimple(Operation *rootOp,
     Operation *op = worklist.back();
     worklist.pop_back();
 
-    if (!op) //|| op->hasTrait<OpTrait::IsIsolatedFromAbove>())
+    if (!op || op->hasTrait<OpTrait::IsIsolatedFromAbove>())
       continue;
 
     // Evaluate whether we should keep this def.

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -1820,7 +1820,7 @@ LogicalResult StmtEmitter::visitSV(ReleaseOp op) {
   SmallPtrSet<Operation *, 8> ops;
   ops.insert(op);
 
-  indent() << "release";
+  indent() << "release ";
   emitExpression(op.dest(), ops);
   os << ';';
   emitLocationInfoAndNewLine(ops);

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -1624,6 +1624,7 @@ private:
   LogicalResult visitSV(ConnectOp op);
   LogicalResult visitSV(BPAssignOp op);
   LogicalResult visitSV(PAssignOp op);
+  LogicalResult visitSV(ForcePAssignOp op);
   LogicalResult visitSV(AliasOp op);
   LogicalResult visitStmt(OutputOp op);
   LogicalResult visitStmt(InstanceOp op);
@@ -1795,6 +1796,19 @@ LogicalResult StmtEmitter::visitSV(PAssignOp op) {
   indent();
   emitExpression(op.dest(), ops);
   os << " <= ";
+  emitExpression(op.src(), ops);
+  os << ';';
+  emitLocationInfoAndNewLine(ops);
+  return success();
+}
+
+LogicalResult StmtEmitter::visitSV(ForcePAssignOp op) {
+  SmallPtrSet<Operation *, 8> ops;
+  ops.insert(op);
+
+  indent() << "force ";
+  emitExpression(op.dest(), ops);
+  os << " = ";
   emitExpression(op.src(), ops);
   os << ';';
   emitLocationInfoAndNewLine(ops);

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -1625,6 +1625,7 @@ private:
   LogicalResult visitSV(BPAssignOp op);
   LogicalResult visitSV(PAssignOp op);
   LogicalResult visitSV(ForcePAssignOp op);
+  LogicalResult visitSV(ReleaseOp op);
   LogicalResult visitSV(AliasOp op);
   LogicalResult visitStmt(OutputOp op);
   LogicalResult visitStmt(InstanceOp op);
@@ -1810,6 +1811,17 @@ LogicalResult StmtEmitter::visitSV(ForcePAssignOp op) {
   emitExpression(op.dest(), ops);
   os << " = ";
   emitExpression(op.src(), ops);
+  os << ';';
+  emitLocationInfoAndNewLine(ops);
+  return success();
+}
+
+LogicalResult StmtEmitter::visitSV(ReleaseOp op) {
+  SmallPtrSet<Operation *, 8> ops;
+  ops.insert(op);
+
+  indent() << "release";
+  emitExpression(op.dest(), ops);
   os << ';';
   emitLocationInfoAndNewLine(ops);
   return success();

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -1624,7 +1624,7 @@ private:
   LogicalResult visitSV(ConnectOp op);
   LogicalResult visitSV(BPAssignOp op);
   LogicalResult visitSV(PAssignOp op);
-  LogicalResult visitSV(ForcePAssignOp op);
+  LogicalResult visitSV(ForceOp op);
   LogicalResult visitSV(ReleaseOp op);
   LogicalResult visitSV(AliasOp op);
   LogicalResult visitStmt(OutputOp op);
@@ -1803,7 +1803,7 @@ LogicalResult StmtEmitter::visitSV(PAssignOp op) {
   return success();
 }
 
-LogicalResult StmtEmitter::visitSV(ForcePAssignOp op) {
+LogicalResult StmtEmitter::visitSV(ForceOp op) {
   SmallPtrSet<Operation *, 8> ops;
   ops.insert(op);
 

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -139,12 +139,16 @@ hw.module @test1(%arg0: i1, %arg1: i1, %arg8: i8) {
 
   // CHECK-NEXT: %combWire = sv.wire : !hw.inout<i1> 
   %combWire = sv.wire : !hw.inout<i1>
+  // CHECK-NEXT: %combWire2 = sv.wire : !hw.inout<i1> 
+  %combWire2 = sv.wire : !hw.inout<i1>
   // CHECK-NEXT: sv.alwayscomb {
   sv.alwayscomb {
     // CHECK-NEXT: %x_i1 = sv.constantX : i1
     %tmpx = sv.constantX : i1
     // CHECK-NEXT: sv.passign %combWire, %x_i1 : i1
     sv.passign %combWire, %tmpx : i1
+    // CHECK-NEXT: sv.force %combWire2, %x_i1 : i1
+    sv.force %combWire2, %tmpx : i1
     // CHECK-NEXT: }
   }
 

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -141,6 +141,8 @@ hw.module @test1(%arg0: i1, %arg1: i1, %arg8: i8) {
   %combWire = sv.wire : !hw.inout<i1>
   // CHECK-NEXT: %combWire2 = sv.wire : !hw.inout<i1> 
   %combWire2 = sv.wire : !hw.inout<i1>
+  // CHECK-NEXT: %regForce = sv.reg : !hw.inout<i1>
+  %regForce = sv.reg  : !hw.inout<i1>
   // CHECK-NEXT: sv.alwayscomb {
   sv.alwayscomb {
     // CHECK-NEXT: %x_i1 = sv.constantX : i1
@@ -149,6 +151,12 @@ hw.module @test1(%arg0: i1, %arg1: i1, %arg8: i8) {
     sv.passign %combWire, %tmpx : i1
     // CHECK-NEXT: sv.force %combWire2, %x_i1 : i1
     sv.force %combWire2, %tmpx : i1
+    // CHECK-NEXT: sv.force %regForce, %x_i1 : i1
+    sv.force %regForce, %tmpx : i1
+    sv.release %combWire2 : !hw.inout<i1>
+    sv.release %regForce : !hw.inout<i1>
+    // CHECK-NEXT: sv.release %combWire2 : !hw.inout<i1>
+    // CHECK-NEXT: sv.release %regForce : !hw.inout<i1>
     // CHECK-NEXT: }
   }
 

--- a/test/Dialect/SV/errors.mlir
+++ b/test/Dialect/SV/errors.mlir
@@ -53,6 +53,13 @@ hw.module @Passign(%arg0: i1) {
 }
 
 // -----
+hw.module @Passign(%arg0: i1) {
+  %reg = sv.reg : !hw.inout<i1>
+  // expected-error @+1 {{sv.force should be in a procedural region}}
+  sv.force %reg, %arg0 : i1
+}
+
+// -----
 hw.module @IfOp(%arg0: i1) {
   // expected-error @+1 {{sv.if should be in a procedural region}}
   sv.if %arg0 {

--- a/test/Dialect/SV/errors.mlir
+++ b/test/Dialect/SV/errors.mlir
@@ -53,10 +53,17 @@ hw.module @Passign(%arg0: i1) {
 }
 
 // -----
-hw.module @Passign(%arg0: i1) {
+hw.module @ForcePassign(%arg0: i1) {
   %reg = sv.reg : !hw.inout<i1>
   // expected-error @+1 {{sv.force should be in a procedural region}}
   sv.force %reg, %arg0 : i1
+}
+
+// -----
+hw.module @ReleasePassign(%arg0: i1) {
+  %reg = sv.reg : !hw.inout<i1>
+  // expected-error @+1 {{sv.release should be in a procedural region}}
+  sv.release %reg : !hw.inout<i1>
 }
 
 // -----

--- a/test/ExportVerilog/sv-dialect.mlir
+++ b/test/ExportVerilog/sv-dialect.mlir
@@ -3,10 +3,13 @@
 // CHECK-LABEL: module M1(
 hw.module @M1(%clock : i1, %cond : i1, %val : i8) {
   %wire42 = sv.wire : !hw.inout<i42>
+  %forceWire = sv.wire : !hw.inout<i1>
 
   // CHECK:      always @(posedge clock) begin
-  // CHECK-NEXT:   `ifndef SYNTHESIS
   sv.always posedge %clock {
+    // CHECK-NEXT: force forceWire = cond;
+    sv.force %forceWire, %cond : i1
+  // CHECK-NEXT:   `ifndef SYNTHESIS
     sv.ifdef.procedural "SYNTHESIS" {
     } else {
   // CHECK-NEXT:     if (PRINTF_COND_ & 1'bx & 1'bz & 1'bz & cond)
@@ -26,6 +29,8 @@ hw.module @M1(%clock : i1, %cond : i1, %val : i8) {
       } else {
         sv.fwrite "Bye\n"
       }
+  // CHECK-NEXT: release forceWire;
+    sv.release %forceWire : !hw.inout<i1>
   // CHECK-NEXT:   `endif
   // CHECK-NEXT: end // always @(posedge)
     }


### PR DESCRIPTION
Add the `force` statement to SV dialect. `force` is a procedural continuous assignment statements. 
A force can be applied to nets as well as to variables. 

From the spec ::
A force statement to a variable shall override a procedural assignment or an assign procedural continuous
assignment to the variable until a release procedural statement is executed on the variable. When released,
then if the variable does not currently have an active assign procedural continuous assignment, the variable
shall not immediately change value. The variable shall maintain its current value until the next procedural
assignment or procedural continuous assignment to the variable. Releasing a variable that currently has an
active assign procedural continuous assignment shall immediately reestablish that assignment.


Constraints :
The left-hand side of the assignment can be a variable, a net, a constant bit-select of a vector net, a part-select of a vector net, or a concatenation. It cannot be a memory word (array reference)
or a bit-select or a part-select of a vector variable.