### PR TITLE
[firtool] Enable width inference by default

### DIFF
--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -102,7 +102,7 @@ static cl::opt<bool>
 static cl::opt<bool>
     inferWidths("infer-widths",
                 cl::desc("run the width inference pass on firrtl"),
-                cl::init(false));
+                cl::init(true));
 
 static cl::opt<bool> extractTestCode("extract-test-code",
                                      cl::desc("run the extract test code pass"),


### PR DESCRIPTION
Width inference should now be resilient enough to be enabled by default -- mostly since it just leaves inputs alone that require no widths to be inferred. Worked on our test1/test2/test3 regression test in circt/perf, and one of SiFive's cores. We can also hold off with this merge until @drom had the chance to run a couple of cycles worth of fuzzing with width inference enabled (especially for test cases that aren't exercising width inference -- these should all still pass).

* Switch the `--infer-widths` option to run by default. The user can still disable the pass through `--infer-widths=false`.