### PR TITLE
[HW] Add symbol to sv::RegOp if DontTouch annotation present

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1675,7 +1675,11 @@ LogicalResult FIRRTLLowering::visitDecl(RegOp op) {
   if (resultType.isInteger(0))
     return setLowering(op, Value());
 
-  auto regResult = builder.create<sv::RegOp>(resultType, op.nameAttr());
+  // Add symbol if DontTouch annotation present.
+  auto regResult =
+      AnnotationSet(op).hasDontTouch()
+          ? builder.create<sv::RegOp>(resultType, op.nameAttr(), op.nameAttr())
+          : builder.create<sv::RegOp>(resultType, op.nameAttr());
   (void)setLowering(op, regResult);
 
   initializeRegister(regResult, Value());

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -452,8 +452,8 @@ firrtl.circuit "Simple" {
                             in %cond: !firrtl.uint<1>, in %value: !firrtl.uint<2>) {
     // CHECK-NEXT: %c0_i2 = hw.constant 0 : i2
     %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
-    // CHECK-NEXT: %count = sv.reg : !hw.inout<i2>
-    %count = firrtl.reg %clock {name = "count"} : (!firrtl.clock) -> !firrtl.uint<2>
+    // CHECK-NEXT: %count = sv.reg sym @count : !hw.inout<i2>
+    %count = firrtl.reg %clock {name = "count", annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : (!firrtl.clock) -> !firrtl.uint<2>
 
     // CHECK-NEXT: sv.ifdef "SYNTHESIS"  {
     // CHECK-NEXT:   } else {


### PR DESCRIPTION
Add symbol to `sv::RegOp` when lowering from FIRRTL if `DontTouch` annotation is present.
Will create a followup PR to update `canonicalize` to check for symbols.