### PR TITLE
[FIRRTL][ExpandWhens] Analog types do not need to be initialized

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -128,6 +128,11 @@ private:
         }
         return;
       }
+
+      // If this is an analog type, it does not need to be tracked.
+      if (auto analogType = type.dyn_cast<AnalogType>())
+        return;
+
       // If it is a leaf node with Flow::Sink or Flow::Duplex, it must be
       // initialized.
       if (flow != Flow::Source)

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -374,4 +374,15 @@ firrtl.module @bundle_ports() {
   firrtl.connect %0, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
+// Test that analog types are not tracked by ExpandWhens
+firrtl.module @analog(out %analog : !firrtl.analog<1>) {
+  // Should not complain about the output
+
+  // Should not complain about the embeded analog.
+  %c1 = firrtl.constant 0 : !firrtl.uint<1>
+  %w = firrtl.wire : !firrtl.bundle<a: uint<1>, b: analog<1>>
+  %w_a = firrtl.subfield %w("a") : (!firrtl.bundle<a : uint<1>, b : analog<1>>) -> !firrtl.uint<1>
+  firrtl.connect %w_a, %c1 : !firrtl.uint<1>, !firrtl.uint<1>
+}
+
 }


### PR DESCRIPTION
Analog types are not sinks and do not need to be initialized like one.
This change stops adding analog types to the initialization checker.