### PR TITLE
[FIRRTL] Don't allow connecting two bundles with internal analog types

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1148,6 +1148,12 @@ static LogicalResult verifyConnectOp(ConnectOp connect) {
   // Analog types cannot be connected and must be attached.
   if (destType.isa<AnalogType>() || srcType.isa<AnalogType>())
     return connect.emitError("analog types may not be connected");
+  if (auto destBundle = destType.dyn_cast<BundleType>())
+    if (destBundle.containsAnalog())
+      return connect.emitError("analog types may not be connected");
+  if (auto srcBundle = srcType.dyn_cast<BundleType>())
+    if (srcBundle.containsAnalog())
+      return connect.emitError("analog types may not be connected");
 
   // Destination and source types must be equivalent.
   if (!areTypesEquivalent(destType, srcType))

--- a/test/Dialect/FIRRTL/connect-errors.mlir
+++ b/test/Dialect/FIRRTL/connect-errors.mlir
@@ -23,6 +23,15 @@ firrtl.module @test(in %a : !firrtl.analog, out %b : !firrtl.analog) {
 // -----
 
 firrtl.circuit "test" {
+firrtl.module @test(in %a : !firrtl.bundle<a: analog>, out %b : !firrtl.bundle<a: analog>) {
+  // expected-error @+1 {{analog types may not be connected}}
+  firrtl.connect %b, %a : !firrtl.bundle<a: analog>, !firrtl.bundle<a: analog>
+}
+}
+
+// -----
+
+firrtl.circuit "test" {
 firrtl.module @test(in %a : !firrtl.analog, out %b : !firrtl.uint<1>) {
   // expected-error @+1 {{analog types may not be connected}}
   firrtl.connect %b, %a : !firrtl.uint<1>, !firrtl.analog


### PR DESCRIPTION
This change extends the ConnectOp verifier to search inside bundles for
analog types. This makes the error show up earlier than after
lower-types. Since the analog check is cached, this is quick.