### PR TITLE
[FIRRTL] Cast sink operands to passive

### DIFF
--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -361,7 +361,8 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.andr %n12
     node value = andr(_GEN_43)    ;; Uses n12 directly.
 
-    ; CHECK: = firrtl.not %auto : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    ; CHECK: %[[PASSIVE_AUTO:.+]] = firrtl.asPassive %auto
+    ; CHECK-NEXT: = firrtl.not %[[PASSIVE_AUTO]] : (!firrtl.uint<1>) -> !firrtl.uint<1>
     node n13 = not(auto)
 
 

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -842,3 +842,23 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     output c: UInt<8>
     c <= mux(sel, a, b)
 
+
+  ; Test that operands that are sinks are cast to passive.  This avoids
+  ; downstream issues where LowerTypes wants to lower these expressions blindly,
+  ; but doesn't have sufficient context to know that it needs an asPassive cast.
+  ;
+  ; See: https://github.com/llvm/circt/issues/1181
+  ;
+  ; CHECK-LABEL: firrtl.module @SinkFlowInOperand_Issue1181
+  module SinkFlowInOperandSub_Issue1181:
+    output a: { flip a: UInt<1> }
+    input b: UInt<1>
+  module SinkFlowInOperand_Issue1181:
+    ; CHECK: %[[sub_a:.+]], %[[sub_b:.+]] = firrtl.instance
+    inst sub of SinkFlowInOperandSub_Issue1181
+
+    ; CHECK: %[[sub_a_a:.+]] = firrtl.subfield %[[sub_a]]("a")
+    ; CHECK: %[[sub_a_a_P:.+]] = firrtl.asPassive %[[sub_a_a]]
+    ; CHECK: %[[sub_b_P:.+]] = firrtl.asPassive %[[sub_b]]
+    ; CHECK: firrtl.and %[[sub_a_a_P]], %[[sub_b_P]]
+    node x = and(sub.a.a, sub.b)

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -116,7 +116,7 @@ circuit test :
 circuit test :
   module invalid_name :
     input bf: { flip int_1 : UInt<1>, int_out : UInt<2>}
-    node n4 = add(bf, bf)  ; expected-error {{operands must be integer types, not '!firrtl.bundle<int_1: uint<1>, int_out: uint<2>>' and '!firrtl.bundle<int_1: uint<1>, int_out: uint<2>>'}}
+    node n4 = add(bf, bf)  ; expected-error {{operands must be integer types, not '!firrtl.bundle<int_1: flip<uint<1>>, int_out: uint<2>>' and '!firrtl.bundle<int_1: flip<uint<1>>, int_out: uint<2>>'}}
 
 ;// -----
 


### PR DESCRIPTION
Cast all sink operands to passive during parsing.  Previously, this would only
cast flipped operands.  Since the type canonicalization refactor, it is
insufficient to simply check for flippedness.
    
Fixes #1181.

More details of what is going on are on #1181.