### PR TITLE
[HW]Use port number instead of name

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1923,7 +1923,7 @@ LogicalResult FIRRTLLowering::visitDecl(InstanceOp oldInstance) {
 
     Value resultVal = newInstance.getResult(resultNo);
 
-    auto oldPortResult = oldInstance.getResult(portIndicesByName[port.name]);
+    auto oldPortResult = oldInstance.getResult(portIndex);
     (void)setLowering(oldPortResult, resultVal);
     ++resultNo;
   }

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1886,7 +1886,7 @@ LogicalResult FIRRTLLowering::visitDecl(InstanceOp oldInstance) {
 
     // If we can find the connects to this port, then we can directly
     // materialize it.
-    auto portResult = oldInstance.getResult(portIndicesByName[port.name]);
+    auto portResult = oldInstance.getResult(portIndex);
     assert(portResult && "invalid IR, couldn't find port");
 
     // Create a wire for each input/inout operand, so there is

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
@@ -192,7 +192,11 @@ firrtl.circuit "Simple" {
     // CHECK: [[OUTAC:%.+]] = hw.constant 0 : i4
     // CHECK-NEXT: hw.output [[OUTAC]] : i4
   }
-
+  firrtl.extmodule @SameNamePorts(in %inA: !firrtl.uint<4>,
+                                in %inA: !firrtl.uint<1>,
+                                in %inA: !firrtl.analog<1>,
+                                out %outa: !firrtl.uint<4>,
+                                out %outa: !firrtl.uint<1>)
   // CHECK-LABEL: hw.module @ZeroWidthInstance
   firrtl.module @ZeroWidthInstance(in %iA: !firrtl.uint<4>,
                                    in %iB: !firrtl.uint<0>,
@@ -203,6 +207,9 @@ firrtl.circuit "Simple" {
     // CHECK: %myinst.outa = hw.instance "myinst" @ZeroWidthPorts(%iA) : (i4) -> i4
     %myinst:5 = firrtl.instance @ZeroWidthPorts {name = "myinst", portNames=["inA", "inB", "inC", "outa", "outb"]}
       : !firrtl.flip<uint<4>>, !firrtl.flip<uint<0>>, !firrtl.analog<0>, !firrtl.uint<4>, !firrtl.uint<0>
+    // CHECK: = hw.instance "myinst" @SameNamePorts({{.+}}, {{.+}} {{.+}}) : (i4, i1, !hw.inout<i1>) -> (i4, i1)
+    %myinst_sameName:5 = firrtl.instance @SameNamePorts {name = "myinst"}
+      : !firrtl.flip<uint<4>>, !firrtl.flip<uint<1>>, !firrtl.analog<1>, !firrtl.uint<4>, !firrtl.uint<1>
 
     // Output of the instance is fed into the input!
     firrtl.connect %myinst#0, %iA : !firrtl.flip<uint<4>>, !firrtl.uint<4>


### PR DESCRIPTION
`LowerToHW` crashes if two ports have same name, use the port number instead of name.