### PR TITLE
[FIRRTL][InferWidths] Add support for aggregate types

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -146,7 +146,8 @@ def MemOp : FIRRTLOp<"mem", [/*MemAlloc*/]> {
   }];
 }
 
-def NodeOp : FIRRTLOp<"node", [SameOperandsAndResultType]> {
+def NodeOp : FIRRTLOp<"node",
+                      [SameOperandsAndResultType, InferTypeOpInterface]> {
   let summary = "No-op to name a value";
   let description = [{
     A node is simply a named intermediate value in a circuit. The node must
@@ -177,6 +178,16 @@ def NodeOp : FIRRTLOp<"node", [SameOperandsAndResultType]> {
   let assemblyFormat = "$input custom<ImplicitSSAName>(attr-dict) `:` type($input)";
 
   let hasCanonicalizer = true;
+
+  let extraClassDeclaration = [{
+    /// Infer the return types of this operation.
+    static LogicalResult inferReturnTypes(MLIRContext *context,
+                                          Optional<Location> loc,
+                                          ValueRange operands,
+                                          DictionaryAttr attrs,
+                                          mlir::RegionRange regions,
+                                          SmallVectorImpl<Type> &results);
+  }];
 }
 
 def RegOp : FIRRTLOp<"reg", [/*MemAlloc*/]> {

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1122,6 +1122,17 @@ Value MemOp::getPortNamed(StringAttr name) {
   return Value();
 }
 
+/// Infer the return types of this operation.
+LogicalResult NodeOp::inferReturnTypes(MLIRContext *context,
+                                       Optional<Location> loc,
+                                       ValueRange operands,
+                                       DictionaryAttr attrs,
+                                       mlir::RegionRange regions,
+                                       SmallVectorImpl<Type> &results) {
+  results.push_back(operands[0].getType());
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // Statements
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -931,8 +931,7 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
       })
       .Case<NodeOp>([&](auto op) {
         // Nodes have the same type as their input.
-        declareVars(op.getResult(), op.getLoc());
-        unifyTypes(FieldRef(op.getResult(), 0), op.input());
+        unifyTypes(FieldRef(op.input(), 0), op.getResult());
       })
 
       // Aggregate Values

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -102,8 +102,8 @@ struct ExprBase : public Expr {
 struct RootExpr : public ExprBase<RootExpr, Expr::Kind::Root> {
   RootExpr(std::vector<Expr *> &exprs) : exprs(exprs) {}
   void print(llvm::raw_ostream &os) const { os << "root"; }
-  iterator begin() const { return &exprs[0]; }
-  iterator end() const { return &exprs[0] + exprs.size(); }
+  iterator begin() const { return exprs.data(); }
+  iterator end() const { return exprs.data() + exprs.size(); }
   std::vector<Expr *> &exprs;
 };
 

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -517,5 +517,47 @@ firrtl.circuit "Foo" {
     firrtl.connect %out, %0 : !firrtl.uint, !firrtl.uint
   }
 
+  // CHECK-LABEL: @InferBundle
+  firrtl.module @InferBundle(in %in : !firrtl.uint<3>) {
+    // CHECK: firrtl.wire : !firrtl.bundle<a: uint<3>>
+    %w = firrtl.wire : !firrtl.bundle<a: uint>
+    %w_a = firrtl.subfield %w("a") : (!firrtl.bundle<a: uint>) -> !firrtl.uint
+    firrtl.connect %w_a, %in : !firrtl.uint, !firrtl.uint<3>
+  }
+
+  // CHECK-LABEL: @InferBundlePort
+  firrtl.module @InferBundlePort(in %in: !firrtl.bundle<a: uint<2>, b: uint<3>>, out %out: !firrtl.bundle<a: uint, b: uint>) {
+    // CHECK: firrtl.connect %out, %in : !firrtl.bundle<a: uint<2>, b: uint<3>>, !firrtl.bundle<a: uint<2>, b: uint<3>>
+    firrtl.connect %out, %in : !firrtl.bundle<a: uint, b: uint>, !firrtl.bundle<a: uint<2>, b: uint<3>>
+  }
+
+  // CHECK-LABEL: @InferVector
+  firrtl.module @InferVector(in %in : !firrtl.uint<4>) {
+    // CHECK: firrtl.wire : !firrtl.vector<uint<4>, 10>
+    %w = firrtl.wire : !firrtl.vector<uint, 10>
+    %w_5 = firrtl.subindex %w[5] : !firrtl.vector<uint, 10>
+    firrtl.connect %w_5, %in : !firrtl.uint, !firrtl.uint<4>
+  }
+
+  // CHECK-LABEL: @InferVectorPort
+  firrtl.module @InferVectorPort(in %in: !firrtl.vector<uint<4>, 2>, out %out: !firrtl.vector<uint, 2>) {
+    // CHECK: firrtl.connect %out, %in : !firrtl.vector<uint<4>, 2>, !firrtl.vector<uint<4>, 2>
+    firrtl.connect %out, %in : !firrtl.vector<uint, 2>, !firrtl.vector<uint<4>, 2>
+  }
+
+  firrtl.module @InferVectorFancy(in %in : !firrtl.uint<4>) {
+    // CHECK: firrtl.wire : !firrtl.vector<uint<4>, 10>
+    %wv = firrtl.wire : !firrtl.vector<uint, 10>
+    %wv_5 = firrtl.subindex %wv[5] : !firrtl.vector<uint, 10>
+    firrtl.connect %wv_5, %in : !firrtl.uint, !firrtl.uint<4>
+
+    // CHECK: firrtl.wire : !firrtl.bundle<a: uint<4>>
+    %wb = firrtl.wire : !firrtl.bundle<a: uint>
+    %wb_a = firrtl.subfield %wb("a") : (!firrtl.bundle<a: uint>) -> !firrtl.uint
+
+    %wv_2 = firrtl.subindex %wv[2] : !firrtl.vector<uint, 10>
+    firrtl.connect %wb_a, %wv_2 : !firrtl.uint, !firrtl.uint
+  }
+
   firrtl.module @Foo() {}
 }

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -35,6 +35,17 @@ firrtl.circuit "Foo" {
     %node = firrtl.node %w : !firrtl.uint
   }
 
+  firrtl.module @InferNode2() {
+    %c2_ui3 = firrtl.constant 2 : !firrtl.uint<3>
+    %w = firrtl.wire : !firrtl.uint
+    firrtl.connect %w, %c2_ui3 : !firrtl.uint, !firrtl.uint<3>
+
+    %node2 = firrtl.node %w : !firrtl.uint
+
+    %w1 = firrtl.wire : !firrtl.uint
+    firrtl.connect %w1, %node2 : !firrtl.uint, !firrtl.uint
+  }
+
   // CHECK-LABEL: @AddSubOp
   firrtl.module @AddSubOp() {
     // CHECK: %0 = firrtl.wire : !firrtl.uint<2>


### PR DESCRIPTION
This only adds support for aggregate types in wires and ports. Adding
support to other operations may not be that hard. Registers with resets
will require a larger fix.