### PR TITLE
[FIRRTL] LowerTypes + ExpandWhens: fixes for high firrtl

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -160,8 +160,7 @@ private:
                                           Operation *whenFalseConn) {
     auto whenTrue = getConnectedValue(whenTrueConn);
     auto whenFalse = getConnectedValue(whenFalseConn);
-    auto newValue = b.createOrFold<MuxPrimOp>(loc, whenTrue.getType(), cond,
-                                              whenTrue, whenFalse);
+    auto newValue = b.createOrFold<MuxPrimOp>(loc, cond, whenTrue, whenFalse);
     auto newConnect = b.create<ConnectOp>(loc, dest, newValue);
     whenTrueConn->erase();
     whenFalseConn->erase();

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -376,6 +376,7 @@ firrtl.module @bundle_types(in %p : !firrtl.uint<1>, in %clock: !firrtl.clock) {
   }
 }
 
+
 // This is exercising a bug in field reference creation when the bundle is
 // wrapped in an outer flip. See https://github.com/llvm/circt/issues/1172.
 firrtl.module @simple(in %in : !firrtl.bundle<a: uint<1>>) { }
@@ -385,6 +386,27 @@ firrtl.module @bundle_ports() {
   %0 = firrtl.subfield %simple_in("a") : (!firrtl.flip<bundle<a: uint<1>>>) -> !firrtl.uint<1>
   firrtl.connect %0, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
 }
+
+// This that types are converted to passive when they are muxed together.
+firrtl.module @simple2(in %in : !firrtl.uint<3>) { }
+firrtl.module @as_passive(in %p : !firrtl.uint<1>) {
+  %c2_ui3 = firrtl.constant 2 : !firrtl.uint<3>
+  %c3_ui3 = firrtl.constant 3 : !firrtl.uint<3>
+  %simple0_in = firrtl.instance @simple2 {name = "test0"}: !firrtl.flip<uint<3>>
+  firrtl.connect %simple0_in, %c2_ui3 : !firrtl.flip<uint<3>>, !firrtl.uint<3>
+
+  %simple1_in = firrtl.instance @simple2 {name = "test0"}: !firrtl.flip<uint<3>>
+  firrtl.when %p {
+    // This is the tricky part, connect the input ports together.
+    firrtl.connect %simple1_in, %simple0_in : !firrtl.flip<uint<3>>, !firrtl.flip<uint<3>>
+  } else {
+    firrtl.connect %simple1_in, %c3_ui3 : !firrtl.flip<uint<3>>, !firrtl.uint<3>
+  }
+  // CHECK: [[PASSIVE:%.*]] = firrtl.asPassive %test0_in : !firrtl.flip<uint<3>>
+  // CHECK: [[MUX:%.*]] = firrtl.mux(%p, [[PASSIVE]], %c3_ui3) : (!firrtl.uint<1>, !firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
+  // CHECK: firrtl.connect %test0_in_0, [[MUX]] : !firrtl.flip<uint<3>>, !firrtl.uint<3>
+}
+
 
 // Test that analog types are not tracked by ExpandWhens
 firrtl.module @analog(out %analog : !firrtl.analog<1>) {

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -221,6 +221,18 @@ firrtl.module @set_in_else0(in %p : !firrtl.uint<1>, out %out : !firrtl.uint<2>)
 // CHECK-NEXT: }
 
 
+// Test that when there is implicit extension, the mux infers the correct type.
+firrtl.module @check_mux_return_type(in %p : !firrtl.uint<1>, out %out : !firrtl.uint<2>) {
+  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+  %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
+  firrtl.connect %out, %c0_ui1 : !firrtl.uint<2>, !firrtl.uint<1>
+  firrtl.when %p {
+  } else {
+    firrtl.connect %out, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
+  }
+  // CHECK: firrtl.mux(%p, %c0_ui1, %c1_ui2) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<2>) -> !firrtl.uint<2>
+}
+
 // Test that wire written to in only the else block is resolved.
 firrtl.module @set_in_else1(in %clock : !firrtl.clock, in %p : !firrtl.uint<1>, out %out : !firrtl.uint<2>) {
   %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -798,7 +798,7 @@ firrtl.circuit "WireSemantics"  {
     // COM: a <= ax
     // CHECK: firrtl.connect %a_a_a, %ax_a_a
     // COM: a <- ax
-    // CHECK-NEXT: firrtl.partialconnect %a_a_a, %ax_a_a
+    // CHECK-NEXT: firrtl.connect %a_a_a, %ax_a_a
     %0 = firrtl.subfield %a("a") : (!firrtl.bundle<a: bundle<a: uint<1>>>) -> !firrtl.bundle<a: uint<1>>
     %1 = firrtl.subfield %ax("a") : (!firrtl.bundle<a: bundle<a: uint<1>>>) -> !firrtl.bundle<a: uint<1>>
     firrtl.connect %0, %1 : !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>
@@ -806,7 +806,7 @@ firrtl.circuit "WireSemantics"  {
     // COM: a.a <= ax.a
     // CHECK: firrtl.connect %a_a_a, %ax_a_a
     // COM: a.a <- ax.a
-    // CHECK-NEXT: firrtl.partialconnect %a_a_a, %ax_a_a
+    // CHECK-NEXT: firrtl.connect %a_a_a, %ax_a_a
     %2 = firrtl.subfield %a("a") : (!firrtl.bundle<a: bundle<a: uint<1>>>) -> !firrtl.bundle<a: uint<1>>
     %3 = firrtl.subfield %2("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
     %4 = firrtl.subfield %ax("a") : (!firrtl.bundle<a: bundle<a: uint<1>>>) -> !firrtl.bundle<a: uint<1>>
@@ -816,7 +816,7 @@ firrtl.circuit "WireSemantics"  {
     // COM: a.a.a <= ax.a.a
     // CHECK: firrtl.connect %a_a_a, %ax_a_a
     // COM: a.a.a <- ax.a.a
-    // CHECK-NEXT: firrtl.partialconnect %a_a_a, %ax_a_a
+    // CHECK-NEXT: firrtl.connect %a_a_a, %ax_a_a
     %b = firrtl.wire  : !firrtl.bundle<a: bundle<a: flip<uint<1>>>>
     %bx = firrtl.wire  : !firrtl.bundle<a: bundle<a: flip<uint<1>>>>
     firrtl.connect %b, %bx : !firrtl.bundle<a: bundle<a: flip<uint<1>>>>, !firrtl.bundle<a: bundle<a: flip<uint<1>>>>
@@ -824,7 +824,7 @@ firrtl.circuit "WireSemantics"  {
     // COM: b <= bx
     // CHECK: firrtl.connect %bx_a_a, %b_a_a
     // COM: b <- bx
-    // CHECK: firrtl.partialconnect %bx_a_a, %b_a_a
+    // CHECK: firrtl.connect %bx_a_a, %b_a_a
     %6 = firrtl.subfield %b("a") : (!firrtl.bundle<a: bundle<a: flip<uint<1>>>>) -> !firrtl.bundle<a: flip<uint<1>>>
     %7 = firrtl.subfield %bx("a") : (!firrtl.bundle<a: bundle<a: flip<uint<1>>>>) -> !firrtl.bundle<a: flip<uint<1>>>
     firrtl.connect %6, %7 : !firrtl.bundle<a: flip<uint<1>>>, !firrtl.bundle<a: flip<uint<1>>>
@@ -832,7 +832,7 @@ firrtl.circuit "WireSemantics"  {
     // COM: b.a <= bx.a
     // CHECK: firrtl.connect %bx_a_a, %b_a_a
     // COM: b.a <- bx.a
-    // CHECK: firrtl.partialconnect %bx_a_a, %b_a_a
+    // CHECK: firrtl.connect %bx_a_a, %b_a_a
     %8 = firrtl.subfield %b("a") : (!firrtl.bundle<a: bundle<a: flip<uint<1>>>>) -> !firrtl.bundle<a: flip<uint<1>>>
     %9 = firrtl.subfield %8("a") : (!firrtl.bundle<a: flip<uint<1>>>) -> !firrtl.uint<1>
     %10 = firrtl.subfield %bx("a") : (!firrtl.bundle<a: bundle<a: flip<uint<1>>>>) -> !firrtl.bundle<a: flip<uint<1>>>
@@ -842,7 +842,7 @@ firrtl.circuit "WireSemantics"  {
     // COM: b.a.a <= bx.a.a
     // CHECK: firrtl.connect %b_a_a, %bx_a_a
     // COM: b.a.a <- bx.a.a
-    // CHECK: firrtl.partialconnect %b_a_a, %bx_a_a
+    // CHECK: firrtl.connect %b_a_a, %bx_a_a
     %c = firrtl.wire  : !firrtl.bundle<a: flip<bundle<a: uint<1>>>>
     %cx = firrtl.wire  : !firrtl.bundle<a: flip<bundle<a: uint<1>>>>
     firrtl.connect %c, %cx : !firrtl.bundle<a: flip<bundle<a: uint<1>>>>, !firrtl.bundle<a: flip<bundle<a: uint<1>>>>
@@ -850,7 +850,7 @@ firrtl.circuit "WireSemantics"  {
     // COM: c <= cx
     // CHECK: firrtl.connect %cx_a_a, %c_a_a
     // COM: c <- cx
-    // CHECK: firrtl.partialconnect %cx_a_a, %c_a_a
+    // CHECK: firrtl.connect %cx_a_a, %c_a_a
     %12 = firrtl.subfield %c("a") : (!firrtl.bundle<a: flip<bundle<a: uint<1>>>>) -> !firrtl.bundle<a: uint<1>>
     %13 = firrtl.subfield %cx("a") : (!firrtl.bundle<a: flip<bundle<a: uint<1>>>>) -> !firrtl.bundle<a: uint<1>>
     firrtl.connect %12, %13 : !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>
@@ -858,7 +858,7 @@ firrtl.circuit "WireSemantics"  {
     // COM: c.a <= cx.a
     // CHECK: firrtl.connect %c_a_a, %cx_a_a
     // COM: c.a <- cx.a
-    // CHECK: firrtl.partialconnect %c_a_a, %cx_a_a
+    // CHECK: firrtl.connect %c_a_a, %cx_a_a
     %14 = firrtl.subfield %c("a") : (!firrtl.bundle<a: flip<bundle<a: uint<1>>>>) -> !firrtl.bundle<a: uint<1>>
     %15 = firrtl.subfield %14("a") : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
     %16 = firrtl.subfield %cx("a") : (!firrtl.bundle<a: flip<bundle<a: uint<1>>>>) -> !firrtl.bundle<a: uint<1>>
@@ -868,7 +868,7 @@ firrtl.circuit "WireSemantics"  {
     // COM: c.a.a <= cx.a.a
     // CHECK: firrtl.connect %c_a_a, %cx_a_a
     // COM: c.a.a <- cx.a.a
-    // CHECK: firrtl.partialconnect %c_a_a, %cx_a_a
+    // CHECK: firrtl.connect %c_a_a, %cx_a_a
     %d = firrtl.wire  : !firrtl.bundle<a: flip<bundle<a: flip<uint<1>>>>>
     %dx = firrtl.wire  : !firrtl.bundle<a: flip<bundle<a: flip<uint<1>>>>>
     firrtl.connect %d, %dx : !firrtl.bundle<a: flip<bundle<a: flip<uint<1>>>>>, !firrtl.bundle<a: flip<bundle<a: flip<uint<1>>>>>
@@ -876,7 +876,7 @@ firrtl.circuit "WireSemantics"  {
     // COM: d <= dx
     // CHECK: firrtl.connect %d_a_a, %dx_a_a
     // COM: d <- dx
-    // CHECK: firrtl.partialconnect %d_a_a, %dx_a_a
+    // CHECK: firrtl.connect %d_a_a, %dx_a_a
     %18 = firrtl.subfield %d("a") : (!firrtl.bundle<a: flip<bundle<a: flip<uint<1>>>>>) -> !firrtl.bundle<a: flip<uint<1>>>
     %19 = firrtl.subfield %dx("a") : (!firrtl.bundle<a: flip<bundle<a: flip<uint<1>>>>>) -> !firrtl.bundle<a: flip<uint<1>>>
     firrtl.connect %18, %19 : !firrtl.bundle<a: flip<uint<1>>>, !firrtl.bundle<a: flip<uint<1>>>
@@ -884,7 +884,7 @@ firrtl.circuit "WireSemantics"  {
     // COM: d.a <= dx.a
     // CHECK: firrtl.connect %dx_a_a, %d_a_a
     // COM: d.a <- dx.a
-    // CHECK: firrtl.partialconnect %dx_a_a, %d_a_a
+    // CHECK: firrtl.connect %dx_a_a, %d_a_a
     %20 = firrtl.subfield %d("a") : (!firrtl.bundle<a: flip<bundle<a: flip<uint<1>>>>>) -> !firrtl.bundle<a: flip<uint<1>>>
     %21 = firrtl.subfield %20("a") : (!firrtl.bundle<a: flip<uint<1>>>) -> !firrtl.uint<1>
     %22 = firrtl.subfield %dx("a") : (!firrtl.bundle<a: flip<bundle<a: flip<uint<1>>>>>) -> !firrtl.bundle<a: flip<uint<1>>>
@@ -894,7 +894,7 @@ firrtl.circuit "WireSemantics"  {
     // COM: d.a.a <= dx.a.a
     // CHECK: firrtl.connect %d_a_a, %dx_a_a
     // COM: d.a.a <- dx.a.a
-    // CHECK: firrtl.partialconnect %d_a_a, %dx_a_a
+    // CHECK: firrtl.connect %d_a_a, %dx_a_a
   }
 }
 
@@ -907,27 +907,67 @@ firrtl.circuit "PartialConnectEdgeCases" {
     %a = firrtl.wire : !firrtl.bundle<a: uint<1>, b: uint<1>, c: uint<1>>
     %b = firrtl.wire : !firrtl.bundle<a: uint<1>, b: uint<1>>
     firrtl.partialconnect %a, %b : !firrtl.bundle<a: uint<1>, b: uint<1>, c: uint<1>>, !firrtl.bundle<a: uint<1>, b: uint<1>>
-    // CHECK: firrtl.partialconnect %a_a, %b_a
-    // CHECK-NEXT: firrtl.partialconnect %a_b, %b_b
-    // CHECK-NOT: firrtl.partialconnect %a_
+    // CHECK: firrtl.connect %a_a, %b_a
+    // CHECK-NEXT: firrtl.connect %a_b, %b_b
+    // CHECK-NOT: firrtl.connect %a_
 
     firrtl.partialconnect %b, %a : !firrtl.bundle<a: uint<1>, b: uint<1>>, !firrtl.bundle<a: uint<1>, b: uint<1>, c: uint<1>>
-    // CHECK: firrtl.partialconnect %b_a, %a_a
-    // CHECK-NEXT: firrtl.partialconnect %b_b, %a_b
-    // CHECK-NOT: firrtl.partialconnect %b_
+    // CHECK: firrtl.connect %b_a, %a_a
+    // CHECK-NEXT: firrtl.connect %b_b, %a_b
+    // CHECK-NOT: firrtl.connect %b_
 
     // COM: Only the first 'n' elements in a vector are connected.
     %c = firrtl.wire : !firrtl.vector<uint<1>, 2>
     %d = firrtl.wire : !firrtl.vector<uint<1>, 3>
     firrtl.partialconnect %c, %d : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 3>
-    // CHECK: firrtl.partialconnect %c_0, %d_0
-    // CHECK-NEXT: firrtl.partialconnect %c_1, %d_1
-    // CHECK-NOT: firrtl.partialconnect %c_
+    // CHECK: firrtl.connect %c_0, %d_0
+    // CHECK-NEXT: firrtl.connect %c_1, %d_1
+    // CHECK-NOT: firrtl.connect %c_
 
     firrtl.partialconnect %d, %c : !firrtl.vector<uint<1>, 3>, !firrtl.vector<uint<1>, 2>
-    // CHECK: firrtl.partialconnect %d_0, %c_0
-    // CHECK-NEXT: firrtl.partialconnect %d_1, %c_1
-    // CHECK-NOT: firrtl.partialconnect %d_
+    // CHECK: firrtl.connect %d_0, %c_0
+    // CHECK-NEXT: firrtl.connect %d_1, %c_1
+    // CHECK-NOT: firrtl.connect %d_
+  }
+}
+
+// -----
+
+// Test partial connect truncation.
+firrtl.circuit "PartialConnectTruncation" {
+  firrtl.module @PartialConnectTruncation() {
+    // COM: It should not truncate when they are the same
+    %a = firrtl.wire : !firrtl.uint<0>
+    %b = firrtl.wire : !firrtl.uint<0>
+    firrtl.partialconnect %a, %b : !firrtl.uint<0>, !firrtl.uint<0>
+    // CHECK: firrtl.connect %a, %b : !firrtl.uint<0>, !firrtl.uint<0>
+
+    // COM: It should truncate the larger source.
+    %c = firrtl.wire : !firrtl.uint<2>
+    %d = firrtl.wire : !firrtl.uint<3>
+    firrtl.partialconnect %c, %d : !firrtl.uint<2>, !firrtl.uint<3>
+    // CHECK: [[TAIL:%.*]] = firrtl.tail %d, 1 : (!firrtl.uint<3>) -> !firrtl.uint<2>
+    // CHECK: firrtl.connect %c, [[TAIL]] : !firrtl.uint<2>, !firrtl.uint<2>
+
+    // COM: It should truncate and cast the larger source.
+    %e = firrtl.wire : !firrtl.sint<2>
+    %f = firrtl.wire : !firrtl.sint<3>
+    firrtl.partialconnect %e, %f : !firrtl.sint<2>, !firrtl.sint<3>
+    // CHECK: [[TAIL:%.*]] = firrtl.tail %f, 1 : (!firrtl.sint<3>) -> !firrtl.uint<2>
+    // CHECK: [[CAST:%.*]] = firrtl.asSInt [[TAIL]] : (!firrtl.uint<2>) -> !firrtl.sint<2>
+    // CHECK: firrtl.connect %e, [[CAST]] : !firrtl.sint<2>, !firrtl.sint<2>
+  }
+}
+
+// -----
+
+// Test partial connect with analogs are transformed to attaches.
+firrtl.circuit "PartialConnectAnalogs" {
+  firrtl.module @PartialConnectAnalogs() {
+    %a = firrtl.wire : !firrtl.bundle<a: analog<1>>
+    %b = firrtl.wire : !firrtl.bundle<a: analog<1>>
+    firrtl.partialconnect %a, %b : !firrtl.bundle<a: analog<1>>, !firrtl.bundle<a: analog<1>>
+    // CHECK: firrtl.attach %a_a, %b_a : !firrtl.analog<1>, !firrtl.analog<1>
   }
 }
 


### PR DESCRIPTION
There are 4 unrelated changes in this PR that I was too lazy to split apart.

[FIRRTL][LowerTypes] Extend SubaccessOp hack
    
    The subaccess op is not supported yet in the lower-types pass. To get
    around this limitation, there is an incorrect lowering of this
    operation.  The subaccess op is lowered to always return the first index
    of the array.
    
    This change extends the hack to use support full lowering when there is
    a vector of bundles.  It does this by creating a Subindex[0] op, and
    lowering that.
    
    This also change the diagnostic from an `error` to a `warning`.

[FIRRTL][ExpandWhens] Make sure values are passive before muxing
    
    When a sink is used as a the RHS of a connect statement, the expand
    whens pass may create a mux using that value.  The connect op can handle
    operands with flip type, while the mux op cannot.  This checks if the
    type is a flip and emits a the asPassive cast if it is not.

[FIRRTL][ExpandWhens] Fix type of created muxes
    
    The return type of muxes needs to be inferred.  In the case where the
    two operands are not the same type, it should be inferred to be the
    larger of the two.

[FIRRTL][LowerTypes] Convert partialconnects to connects
    
    This modifies the lower tyes pass to canonicalize all partial connects
    as regular connects.  This is something that happens in the SFC duing
    the expand-connects pass, which is a separate earlier pass from
    lower-types.
    
    A partial connect has implicit truncation when the source value is
    larger than the destination. When lower-types converts this to a regular
    connect, it will emit a tail-op to truncate the source first.
    
    Partial connects are partially common because the FIRRTL we are
    consuming has implicit truncations in regular connect statements, which
    we transform in to partial connects.
    
    Removal of partial connects and in particular implicit truncation needs
    to happen before the expand-whens pass runs.  The ExpandWhens pass will
    try to combine multiple connects to a destination into a single connect
    statement by muxing together the sources.  It would be tricky to have
    expand whens properly truncate all source values to create the correct
    mux operation.
 