### PR TITLE
[FIRParser] Force when operands to passive flow

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2298,7 +2298,13 @@ ParseResult FIRStmtParser::parseWhen(unsigned whenIndent) {
     return failure();
 
   locationProcessor.setLoc(startTok.getLoc());
-  condition = convertToPassive(condition);
+
+  // If the operand flow is sink, then forcibly cast this to passive.
+  // This avoids a problem where when this type will be lowered an
+  // asPassive would need to be created.  This is difficult to check at
+  // that point, but trivial here.
+  if (foldFlow(condition) == Flow::Sink)
+    condition = forcePassive(condition);
 
   // Create the IR representation for the when.
   auto whenStmt = builder.create<WhenOp>(condition, /*createElse*/ false);

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -559,7 +559,8 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input bf: { flip int_1 : UInt<1>, int_out : UInt<2>}
     ; CHECK: %0 = firrtl.subfield %bf("int_1")
     node _T = bf.int_1
-    when _T :  ; CHECK: firrtl.when %0 {
+    ; CHECK: %1 = firrtl.asPassive %0
+    when _T :  ; CHECK: firrtl.when %1 {
       skip
 
   ; CHECK-LABEL: firrtl.module @mem_depth_1


### PR DESCRIPTION
This is a similar change we have made a few places: after lower-types
runs these fields will have an outer flip type that must be removed with
isPassive. We must check the flow of the operand to determine if is
necessary to convert to passive.