### PR TITLE
[FIRRTL][InferWidths] Add support for PartialConnectOp

### DIFF
--- a/test/Dialect/FIRRTL/infer-widths-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-widths-errors.mlir
@@ -1,15 +1,6 @@
 // RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-infer-widths)' --verify-diagnostics --split-input-file %s
 
 firrtl.circuit "Foo" {
-  firrtl.module @Foo(in %0: !firrtl.uint<4>) {
-    %1 = firrtl.wire : !firrtl.uint
-    // expected-error @+1 {{'firrtl.partialconnect' op not supported in width inference}}
-    firrtl.partialconnect %1, %0 : !firrtl.uint, !firrtl.uint<4>
-  }
-}
-
-// -----
-firrtl.circuit "Foo" {
   firrtl.module @Foo(in %clk: !firrtl.clock, in %x: !firrtl.uint<6>) {
     // expected-error @+1 {{'firrtl.reg' op is constrained to be wider than itself}}
     %0 = firrtl.reg %clk : (!firrtl.clock) -> !firrtl.uint


### PR DESCRIPTION
Add support for the `PartialConnectOp` to the `InferWidths` pass. The implementation is very much inspired by `LowerTypes`, where we co-iterate the fields of the two value types to be connected. Only fields present on both sides are considered, and vectors get special treatment. The case in width inference is slightly simpler than in `LowerTypes`. The implementation is handled by a dedicated `partiallyConstrainTypes` function, which is analogous to the existing `constrainTypes`.