### PR TITLE
[FIRRTL][ExpandWhens] Split the module body processing

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -1,5 +1,4 @@
 //===- ExpandWhens.cpp - Expand WhenOps into muxed operations ---*- C++ -*-===//
-//
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -22,6 +21,10 @@
 using namespace circt;
 using namespace firrtl;
 
+/// This is a determistic mapping of a FieldRef to the last operation which set
+/// a value to it.
+using ScopeMap = llvm::MapVector<FieldRef, Operation *>;
+
 /// Move all operations from a source block in to a destination block. Leaves
 /// the source block empty.
 static void mergeBlock(Block &destination, Block::iterator insertPoint,
@@ -29,82 +32,60 @@ static void mergeBlock(Block &destination, Block::iterator insertPoint,
   destination.getOperations().splice(insertPoint, source.getOperations());
 }
 
+//===----------------------------------------------------------------------===//
+// Last Connect Visitor
+//===----------------------------------------------------------------------===//
+
 namespace {
 
-class ExpandWhensVisitor : public FIRRTLVisitor<ExpandWhensVisitor> {
+/// This visitor visits process a block resolving last connect semantics
+/// and expanding WhenOps.
+template <typename ConcreteT>
+class LastConnectResolver : public FIRRTLVisitor<ConcreteT> {
+protected:
+  /// Tracks if anything in the IR has changed.
+  bool changed = false;
+
+  /// Map of destinations and the operation which is driving a value to it in
+  /// the current scope. This is used for resolving last connect semantics, and
+  /// for retrieving the responsible connect operation.
+  ScopeMap &scope;
+
 public:
-  ExpandWhensVisitor(llvm::MapVector<FieldRef, Operation *> &scope,
-                     Value condition)
-      : scope(scope), condition(condition) {}
+  LastConnectResolver(ScopeMap &scope) : scope(scope) {}
 
-  /// Run expand whens on the Module.  This will emit an error for each
-  /// incomplete initialization found. If an initialiazation error was detected,
-  /// this will return failure and leave the IR in an inconsistent state.
-  static LogicalResult run(FModuleOp op);
-
-  using FIRRTLVisitor<ExpandWhensVisitor>::visitExpr;
-  using FIRRTLVisitor<ExpandWhensVisitor>::visitDecl;
-  using FIRRTLVisitor<ExpandWhensVisitor>::visitStmt;
-
-  void visitDecl(FModuleOp op);
-  void visitDecl(InstanceOp op);
-  void visitDecl(MemOp op);
-  void visitDecl(RegOp op);
-  void visitDecl(RegResetOp op);
-  void visitDecl(WireOp op);
-  void visitInvalidOp(Operation *op) {}
-  void visitStmt(AssertOp op);
-  void visitStmt(AssumeOp op);
-  void visitStmt(ConnectOp op);
-  void visitStmt(CoverOp op);
-  void visitStmt(ModuleOp op);
-  void visitStmt(PartialConnectOp op);
-  void visitStmt(PrintFOp op);
-  void visitStmt(StopOp op);
-  void visitStmt(WhenOp op);
-  void visitUnhandledOp(Operation *op) {}
-
-private:
-  /// Process a block, recording each declaration, and expanding all whens.
-  void process(Block &block);
+  using FIRRTLVisitor<ConcreteT>::visitExpr;
+  using FIRRTLVisitor<ConcreteT>::visitDecl;
+  using FIRRTLVisitor<ConcreteT>::visitStmt;
 
   /// Records a connection to a destination. This will delete a previous
   /// connection to a destination if there was one.
-  void setLastConnect(FieldRef dest, Operation *connection) {
+  bool setLastConnect(FieldRef dest, Operation *connection) {
     // Try to insert, if it doesn't insert, replace the previous value.
     auto itAndInserted = scope.insert({dest, connection});
     if (!std::get<1>(itAndInserted)) {
       auto iterator = std::get<0>(itAndInserted);
       // Delete the old connection if it exists. Null connections are inserted
       // on declarations.
-      if (auto *oldConnect = iterator->second)
+      if (auto *oldConnect = iterator->second) {
         oldConnect->erase();
+      }
       iterator->second = connection;
+      return true;
     }
+    return false;
   }
 
   /// Get the destination value from a connection.  This supports any operation
   /// which is capable of driving a value.
   static Value getDestinationValue(Operation *op) {
-    return TypeSwitch<Operation *, Value>(op)
-        .Case<ConnectOp>([](auto op) { return op.dest(); })
-        .Case<PartialConnectOp>([](auto op) { return op.dest(); })
-        .Default([](Operation *op) {
-          llvm_unreachable("unknown operation");
-          return nullptr;
-        });
+    return cast<ConnectOp>(op).dest();
   }
 
   /// Get the source value from a connection. This supports any operation which
   /// is capable of driving a value.
   static Value getConnectedValue(Operation *op) {
-    return TypeSwitch<Operation *, Value>(op)
-        .Case<ConnectOp>([](auto op) { return op.src(); })
-        .Case<PartialConnectOp>([](auto op) { return op.src(); })
-        .Default([](Operation *op) {
-          llvm_unreachable("unknown operation");
-          return nullptr;
-        });
+    return cast<ConnectOp>(op).src();
   }
 
   /// For every leaf field in the sink, record that it exists and should be
@@ -141,21 +122,11 @@ private:
     declare(type, flow);
   }
 
-  /// And a 1-bit value with the current condition.  If we are in the outer
-  /// scope, i.e. not in a WhenOp region, then there is no condition.
-  Value andWithCondition(Operation *op, Value value) {
-    // If there is no condition, it means we are not inside any WhenOp.
-    if (!condition)
-      return value;
-    // 'and' the value with the current condition.
-    return OpBuilder(op).createOrFold<AndPrimOp>(
-        condition.getLoc(), condition.getType(), condition, value);
-  }
-
   /// If a value has an outer flip, convert the value to passive.
   Value convertToPassive(OpBuilder &builder, Location loc, Value input) {
     auto inType = input.getType().cast<FIRRTLType>();
-    return builder.createOrFold<AsPassivePrimOp>(loc, inType.getPassiveType(), input);
+    return builder.createOrFold<AsPassivePrimOp>(loc, inType.getPassiveType(),
+                                                 input);
   }
 
   /// Take two connection operations and merge them in to a new connect under a
@@ -173,20 +144,280 @@ private:
     return newConnect;
   }
 
-private:
-  /// Map of destinations and the operation which is driving a value to it in
-  /// the current scope. This is used for resolving last connect semantics, and
-  /// for retrieving the responsible connect operation.
-  llvm::MapVector<FieldRef, Operation *> &scope;
+  void visitDecl(WireOp op) { declareSinks(op.result(), Flow::Duplex); }
 
+  void visitDecl(RegOp op) {
+    // Registers are initialized to themselves.
+    // TODO: register of bundle type are not supported.
+    assert(!op.result().getType().isa<BundleType>() &&
+           "registers can't be bundle type");
+    auto connect = OpBuilder(op->getBlock(), ++Block::iterator(op))
+                       .create<ConnectOp>(op.getLoc(), op, op);
+    scope[getFieldRefFromValue(op.result())] = connect;
+  }
+
+  void visitDecl(RegResetOp op) {
+    // Registers are initialized to themselves.
+    // TODO: register of bundle type are not supported.
+    assert(!op.result().getType().isa<BundleType>() &&
+           "registers can't be bundle type");
+    auto connect = OpBuilder(op->getBlock(), ++Block::iterator(op))
+                       .create<ConnectOp>(op.getLoc(), op, op);
+    scope[getFieldRefFromValue(op.result())] = connect;
+  }
+
+  void visitDecl(InstanceOp op) {
+    // Track any instance inputs which need to be connected to for init
+    // coverage.
+    for (auto result : op.results()) {
+      declareSinks(result, Flow::Source);
+    }
+  }
+
+  void visitDecl(MemOp op) {
+    // Track any memory inputs which require connections.
+    for (auto result : op.results()) {
+      declareSinks(result, Flow::Source);
+    }
+  }
+
+  void visitStmt(PartialConnectOp op) {
+    llvm_unreachable("Partial Connects should have been removed.");
+  }
+
+  void visitStmt(ConnectOp op) {
+    changed |= setLastConnect(getFieldRefFromValue(op.dest()), op);
+  }
+
+  /// Combine the connect statements from each side of the block. There are 5
+  /// cases to consider. If all are set, last connect semantics dictate that it
+  /// is actually the third case.
+  ///
+  /// Prev | Then | Else | Outcome
+  /// -----|------|------|-------
+  ///      |  set |      | then
+  ///      |      |  set | else
+  ///      |  set |  set | mux(p, then, else)
+  ///  set |  set |      | mux(p, then, prev)
+  ///  set |      |  set | mux(p, prev, else)
+  ///
+  /// If the value was declared in the block, then it does not need to have been
+  /// assigned a previous value.  If the value was declared before the block,
+  /// then there is an incomplete initialization error.
+  void mergeScopes(ScopeMap &thenScope, ScopeMap &elseScope,
+                   Value thenCondition) {
+
+    // Process all connects in the `then` block.
+    for (auto &destAndConnect : thenScope) {
+      auto dest = std::get<0>(destAndConnect);
+      auto thenConnect = std::get<1>(destAndConnect);
+
+      // `dest` is set in `then` only.
+      auto itAndInserted = scope.insert({dest, thenConnect});
+      if (std::get<1>(itAndInserted))
+        continue;
+      auto outerIt = std::get<0>(itAndInserted);
+
+      // `dest` is set in `then` and `else`.
+      auto elseIt = elseScope.find(dest);
+      if (elseIt != elseScope.end()) {
+        auto &elseConnect = std::get<1>(*elseIt);
+        // Create a new connect with `mux(p, then, else)`.
+        OpBuilder connectBuilder(elseConnect);
+        auto newConnect = flattenConditionalConnections(
+            connectBuilder, elseConnect->getLoc(),
+            getDestinationValue(thenConnect), thenCondition, thenConnect,
+            elseConnect);
+        setLastConnect(dest, newConnect);
+        // Do not process connect in the else scope.
+        elseScope.erase(dest);
+        continue;
+      }
+
+      // `dest` is null in the outer scope.
+      auto &outerConnect = std::get<1>(*outerIt);
+      if (!outerConnect) {
+        thenConnect->erase();
+        continue;
+      }
+
+      // `dest` is set in the outer scope.
+      // Create a new connect with mux(p, then, outer)
+      OpBuilder connectBuilder(thenConnect);
+      auto newConnect = flattenConditionalConnections(
+          connectBuilder, thenConnect->getLoc(),
+          getDestinationValue(thenConnect), thenCondition, thenConnect,
+          outerConnect);
+      outerIt->second = newConnect;
+    }
+
+    // Process all connects in the `else` block.
+    for (auto &destAndConnect : elseScope) {
+      auto dest = std::get<0>(destAndConnect);
+      auto elseConnect = std::get<1>(destAndConnect);
+
+      // `dest` is set in `then` only.
+      auto itAndInserted = scope.insert({dest, elseConnect});
+      if (std::get<1>(itAndInserted))
+        continue;
+
+      // `dest` is null in the outer scope.
+      auto outerIt = std::get<0>(itAndInserted);
+      auto &outerConnect = std::get<1>(*outerIt);
+      if (!outerConnect) {
+        elseConnect->erase();
+        continue;
+      }
+
+      // `dest` is set in the outer scope.
+      // Create a new connect with mux(p, outer, else).
+      OpBuilder connectBuilder(elseConnect);
+      auto newConnect = flattenConditionalConnections(
+          connectBuilder, elseConnect->getLoc(),
+          getDestinationValue(outerConnect), thenCondition, outerConnect,
+          elseConnect);
+      outerIt->second = newConnect;
+    }
+  }
+};
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// WhenOpVisitor
+//===----------------------------------------------------------------------===//
+
+/// This extends the ModuleVisitor with additional funcationality that is only
+/// required in side a WhenOp.  This visitor handles all Simulation constructs.
+namespace {
+class WhenOpVisitor : public LastConnectResolver<WhenOpVisitor> {
+
+public:
+  WhenOpVisitor(ScopeMap &scope, Value condition)
+      : LastConnectResolver<WhenOpVisitor>(scope), condition(condition) {}
+
+  using LastConnectResolver<WhenOpVisitor>::visitExpr;
+  using LastConnectResolver<WhenOpVisitor>::visitDecl;
+  using LastConnectResolver<WhenOpVisitor>::visitStmt;
+
+  /// Process a block, recording each declaration, and expanding all whens.
+  void process(Block &block);
+
+  /// Simulation Constructs.
+  void visitStmt(AssertOp op);
+  void visitStmt(AssumeOp op);
+  void visitStmt(CoverOp op);
+  void visitStmt(ModuleOp op);
+  void visitStmt(PrintFOp op);
+  void visitStmt(StopOp op);
+  void visitStmt(WhenOp op);
+
+private:
+  /// And a 1-bit value with the current condition.  If we are in the outer
+  /// scope, i.e. not in a WhenOp region, then there is no condition.
+  Value andWithCondition(Operation *op, Value value) {
+    // 'and' the value with the current condition.
+    return OpBuilder(op).createOrFold<AndPrimOp>(
+        condition.getLoc(), condition.getType(), condition, value);
+  }
+
+private:
   /// The current wrapping condition. If null, we are in the outer scope.
   Value condition;
 };
 } // namespace
 
-LogicalResult ExpandWhensVisitor::run(FModuleOp module) {
-  llvm::MapVector<FieldRef, Operation *> outerScope;
-  ExpandWhensVisitor(outerScope, nullptr).visitDecl(module);
+void WhenOpVisitor::process(Block &block) {
+
+  for (auto &op : llvm::make_early_inc_range(block)) {
+    dispatchVisitor(&op);
+  }
+}
+
+void WhenOpVisitor::visitStmt(PrintFOp op) {
+  op.condMutable().assign(andWithCondition(op, op.cond()));
+}
+
+void WhenOpVisitor::visitStmt(StopOp op) {
+  op.condMutable().assign(andWithCondition(op, op.cond()));
+}
+
+void WhenOpVisitor::visitStmt(AssertOp op) {
+  op.enableMutable().assign(andWithCondition(op, op.enable()));
+}
+
+void WhenOpVisitor::visitStmt(AssumeOp op) {
+  op.enableMutable().assign(andWithCondition(op, op.enable()));
+}
+
+void WhenOpVisitor::visitStmt(CoverOp op) {
+  op.enableMutable().assign(andWithCondition(op, op.enable()));
+}
+
+void WhenOpVisitor::visitStmt(WhenOp whenOp) {
+  OpBuilder b(whenOp);
+  Block *parentBlock = whenOp->getBlock();
+  auto condition = whenOp.condition();
+
+  // Process both sides of the the WhenOp, fixing up all simulation
+  // contructs, and resolving last connect semantics in each block. This process
+  // returns the set of connects in each side of the when op.
+
+  // Process the `then` block.
+  ScopeMap thenScope;
+  auto thenCondition = andWithCondition(whenOp, condition);
+  auto &thenBlock = whenOp.getThenBlock();
+  WhenOpVisitor(thenScope, thenCondition).process(thenBlock);
+  mergeBlock(*parentBlock, Block::iterator(whenOp), thenBlock);
+
+  // Process the `else` block.
+  ScopeMap elseScope;
+  if (whenOp.hasElseRegion()) {
+    auto notOp = b.createOrFold<NotPrimOp>(whenOp.getLoc(), condition.getType(),
+                                           condition);
+    Value elseCondition = andWithCondition(whenOp, notOp);
+    auto &elseBlock = whenOp.getElseBlock();
+    WhenOpVisitor(elseScope, elseCondition).process(elseBlock);
+    mergeBlock(*parentBlock, Block::iterator(whenOp), elseBlock);
+  }
+
+  mergeScopes(thenScope, elseScope, thenCondition);
+
+  // Delete the now empty WhenOp.
+  whenOp.erase();
+}
+
+//===----------------------------------------------------------------------===//
+// ModuleOpVisitor
+//===----------------------------------------------------------------------===//
+
+namespace {
+class ModuleVisitor : public LastConnectResolver<ModuleVisitor> {
+public:
+  ModuleVisitor(ScopeMap &scope) : LastConnectResolver<ModuleVisitor>(scope) {}
+
+  // Unshadow the overloads.
+  using LastConnectResolver<ModuleVisitor>::visitExpr;
+  using LastConnectResolver<ModuleVisitor>::visitDecl;
+  using LastConnectResolver<ModuleVisitor>::visitStmt;
+
+  // Visit a module and return true if anything changed.
+  bool visitDecl(FModuleOp op);
+  void visitStmt(WhenOp whenOp);
+
+  /// Run expand whens on the Module.  This will emit an error for each
+  /// incomplete initialization found. If an initialiazation error was detected,
+  /// this will return failure and leave the IR in an inconsistent state.  If
+  /// the pass was a success, returns true if nothing changed.
+  static mlir::FailureOr<bool> run(FModuleOp op);
+
+private:
+};
+} // namespace
+
+mlir::FailureOr<bool> ModuleVisitor::run(FModuleOp module) {
+  ScopeMap outerScope;
+  ModuleVisitor visitor(outerScope);
+  auto changed = visitor.visitDecl(module);
 
   // Check for any incomplete initialization.
   LogicalResult result = success();
@@ -205,16 +436,48 @@ LogicalResult ExpandWhensVisitor::run(FModuleOp module) {
                                     "\" not fully initialized");
   }
 
+  // Return Failed or Changed.
+  if (succeeded(result)) {
+    return mlir::FailureOr<bool>(changed);
+  }
   return result;
 }
 
-void ExpandWhensVisitor::process(Block &block) {
-  for (auto &op : llvm::make_early_inc_range(block)) {
-    dispatchVisitor(&op);
+void ModuleVisitor::visitStmt(WhenOp whenOp) {
+  Block *parentBlock = whenOp->getBlock();
+  auto condition = whenOp.condition();
+
+  // Process both sides of the the WhenOp, fixing up all simulation
+  // contructs, and resolving last connect semantics in each block. This process
+  // returns the set of connects in each side of the when op.
+
+  // Process the `then` block.
+  ScopeMap thenScope;
+  auto &thenBlock = whenOp.getThenBlock();
+  WhenOpVisitor(thenScope, condition).process(thenBlock);
+  mergeBlock(*parentBlock, Block::iterator(whenOp), thenBlock);
+
+  // Process the `else` block.
+  ScopeMap elseScope;
+  if (whenOp.hasElseRegion()) {
+    OpBuilder b(whenOp);
+    auto notCondition = b.createOrFold<NotPrimOp>(
+        whenOp.getLoc(), condition.getType(), condition);
+    auto &elseBlock = whenOp.getElseBlock();
+    WhenOpVisitor(elseScope, notCondition).process(elseBlock);
+    mergeBlock(*parentBlock, Block::iterator(whenOp), elseBlock);
   }
+
+  mergeScopes(thenScope, elseScope, condition);
+
+  // If we are deleting a WhenOp something definitely changed.
+  changed = true;
+
+  // Delete the now empty WhenOp.
+  whenOp.erase();
 }
 
-void ExpandWhensVisitor::visitDecl(FModuleOp op) {
+bool ModuleVisitor::visitDecl(FModuleOp op) {
   // Track any results (flipped arguments) of the module for init coverage.
   for (auto it : llvm::enumerate(op.getArguments())) {
     auto flow = getModulePortDirection(op, it.index()) == Direction::Input
@@ -223,191 +486,10 @@ void ExpandWhensVisitor::visitDecl(FModuleOp op) {
     declareSinks(it.value(), flow);
   }
 
-  process(*op.getBodyBlock());
-}
-
-void ExpandWhensVisitor::visitDecl(WireOp op) {
-  declareSinks(op.result(), Flow::Duplex);
-}
-
-void ExpandWhensVisitor::visitDecl(RegOp op) {
-  // Registers are initialized to themselves.
-  // TODO: register of bundle type are not supported.
-  assert(!op.result().getType().isa<BundleType>() &&
-         "registers can't be bundle type");
-  auto connect = OpBuilder(op->getBlock(), ++Block::iterator(op))
-                     .create<ConnectOp>(op.getLoc(), op, op);
-  scope[getFieldRefFromValue(op.result())] = connect;
-}
-
-void ExpandWhensVisitor::visitDecl(RegResetOp op) {
-  // Registers are initialized to themselves.
-  // TODO: register of bundle type are not supported.
-  assert(!op.result().getType().isa<BundleType>() &&
-         "registers can't be bundle type");
-  auto connect = OpBuilder(op->getBlock(), ++Block::iterator(op))
-                     .create<ConnectOp>(op.getLoc(), op, op);
-  scope[getFieldRefFromValue(op.result())] = connect;
-}
-
-void ExpandWhensVisitor::visitDecl(InstanceOp op) {
-  // Track any instance inputs which need to be connected to for init coverage.
-  for (auto result : op.results()) {
-    declareSinks(result, Flow::Source);
+  for (auto &op : llvm::make_early_inc_range(*op.getBodyBlock())) {
+    dispatchVisitor(&op);
   }
-}
-
-void ExpandWhensVisitor::visitDecl(MemOp op) {
-  // Track any memory inputs which require connections.
-  for (auto result : op.results()) {
-    declareSinks(result, Flow::Source);
-  }
-}
-
-void ExpandWhensVisitor::visitStmt(PartialConnectOp op) {
-  setLastConnect(getFieldRefFromValue(op.dest()), op);
-}
-
-void ExpandWhensVisitor::visitStmt(ConnectOp op) {
-  setLastConnect(getFieldRefFromValue(op.dest()), op);
-}
-
-void ExpandWhensVisitor::visitStmt(PrintFOp op) {
-  op.condMutable().assign(andWithCondition(op, op.cond()));
-}
-
-void ExpandWhensVisitor::visitStmt(StopOp op) {
-  op.condMutable().assign(andWithCondition(op, op.cond()));
-}
-
-void ExpandWhensVisitor::visitStmt(AssertOp op) {
-  op.enableMutable().assign(andWithCondition(op, op.enable()));
-}
-
-void ExpandWhensVisitor::visitStmt(AssumeOp op) {
-  op.enableMutable().assign(andWithCondition(op, op.enable()));
-}
-
-void ExpandWhensVisitor::visitStmt(CoverOp op) {
-  op.enableMutable().assign(andWithCondition(op, op.enable()));
-}
-
-void ExpandWhensVisitor::visitStmt(WhenOp whenOp) {
-  OpBuilder b(whenOp);
-  Block *parentBlock = whenOp->getBlock();
-
-  // Process both sides of the the WhenOp, fixing up all simulation
-  // contructs, and resolving last connect semantics in each block. This process
-  // returns the set of connects in each side of the when op.
-
-  // Process the `then` block.
-  llvm::MapVector<FieldRef, Operation *> thenScope;
-  auto thenCondition = andWithCondition(whenOp, whenOp.condition());
-  auto &thenBlock = whenOp.getThenBlock();
-  ExpandWhensVisitor(thenScope, thenCondition).process(thenBlock);
-  mergeBlock(*parentBlock, Block::iterator(whenOp), thenBlock);
-
-  // Process the `else` block.
-  llvm::MapVector<FieldRef, Operation *> elseScope;
-  if (whenOp.hasElseRegion()) {
-    auto condition = whenOp.condition();
-    auto notOp = b.createOrFold<NotPrimOp>(whenOp.getLoc(), condition.getType(),
-                                           condition);
-    Value elseCondition = andWithCondition(whenOp, notOp);
-    auto &elseBlock = whenOp.getElseBlock();
-    ExpandWhensVisitor(elseScope, elseCondition).process(elseBlock);
-    mergeBlock(*parentBlock, Block::iterator(whenOp), elseBlock);
-  }
-
-  // Combine the connect statements from each side of the block. There are 5
-  // cases to consider. If all are set, last connect semantics dictate that it
-  // is actually the third case.
-  //
-  // Prev | Then | Else | Outcome
-  // -----|------|------|-------
-  //      |  set |      | then
-  //      |      |  set | else
-  //      |  set |  set | mux(p, then, else)
-  //  set |  set |      | mux(p, then, prev)
-  //  set |      |  set | mux(p, prev, else)
-  //
-  // If the value was declared in the block, then it does not need to have been
-  // assigned a previous value.  If the value was declared before the block,
-  // then there is an incomplete initialization error.
-
-  // Process all connects in the `then` block.
-  for (auto &destAndConnect : thenScope) {
-    auto dest = std::get<0>(destAndConnect);
-    auto thenConnect = std::get<1>(destAndConnect);
-
-    // `dest` is set in `then` only.
-    auto itAndInserted = scope.insert({dest, thenConnect});
-    if (std::get<1>(itAndInserted))
-      continue;
-    auto outerIt = std::get<0>(itAndInserted);
-
-    // `dest` is set in `then` and `else`.
-    auto elseIt = elseScope.find(dest);
-    if (elseIt != elseScope.end()) {
-      auto &elseConnect = std::get<1>(*elseIt);
-      // Create a new connect with `mux(p, then, else)`.
-      OpBuilder connectBuilder(elseConnect);
-      auto newConnect = flattenConditionalConnections(
-          connectBuilder, elseConnect->getLoc(),
-          getDestinationValue(thenConnect), thenCondition, thenConnect,
-          elseConnect);
-      setLastConnect(dest, newConnect);
-      // Do not process connect in the else scope.
-      elseScope.erase(dest);
-      continue;
-    }
-
-    // `dest` is null in the outer scope.
-    auto &outerConnect = std::get<1>(*outerIt);
-    if (!outerConnect) {
-      thenConnect->erase();
-      continue;
-    }
-
-    // `dest` is set in the outer scope.
-    // Create a new connect with mux(p, then, outer)
-    OpBuilder connectBuilder(thenConnect);
-    auto newConnect = flattenConditionalConnections(
-        connectBuilder, thenConnect->getLoc(), getDestinationValue(thenConnect),
-        thenCondition, thenConnect, outerConnect);
-    outerIt->second = newConnect;
-  }
-
-  // Process all connects in the `else` block.
-  for (auto &destAndConnect : elseScope) {
-    auto dest = std::get<0>(destAndConnect);
-    auto elseConnect = std::get<1>(destAndConnect);
-
-    // `dest` is set in `then` only.
-    auto itAndInserted = scope.insert({dest, elseConnect});
-    if (std::get<1>(itAndInserted))
-      continue;
-
-    // `dest` is null in the outer scope.
-    auto outerIt = std::get<0>(itAndInserted);
-    auto &outerConnect = std::get<1>(*outerIt);
-    if (!outerConnect) {
-      elseConnect->erase();
-      continue;
-    }
-
-    // `dest` is set in the outer scope.
-    // Create a new connect with mux(p, outer, else).
-    OpBuilder connectBuilder(elseConnect);
-    auto newConnect =
-        flattenConditionalConnections(connectBuilder, elseConnect->getLoc(),
-                                      getDestinationValue(outerConnect),
-                                      thenCondition, outerConnect, elseConnect);
-    outerIt->second = newConnect;
-  }
-
-  // Delete the now empty WhenOp.
-  whenOp.erase();
+  return changed;
 }
 
 //===----------------------------------------------------------------------===//
@@ -419,8 +501,14 @@ class ExpandWhensPass : public ExpandWhensBase<ExpandWhensPass> {
 };
 
 void ExpandWhensPass::runOnOperation() {
-  if (failed(ExpandWhensVisitor::run(getOperation())))
+  // Pass returns failure if something went wrong, or a bool indicating whether
+  // something changed.
+  auto failureOrChanged = ModuleVisitor::run(getOperation());
+  if (failed(failureOrChanged)) {
     signalPassFailure();
+  } else if (!*failureOrChanged) {
+    markAllAnalysesPreserved();
+  }
 }
 
 std::unique_ptr<mlir::Pass> circt::firrtl::createExpandWhensPass() {

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -16,20 +16,6 @@ firrtl.module @shadow_connects(out %out : !firrtl.uint<1>) {
 // CHECK-NEXT: }
 
 
-// Test that last connect semantics are resolved for partial connects.
-firrtl.module @shadow_partialconnects(out %out : !firrtl.uint<1>) {
-  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-  %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-  firrtl.partialconnect %out, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-  firrtl.partialconnect %out, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-}
-// CHECK-LABEL: firrtl.module @shadow_partialconnects(out %out: !firrtl.uint<1>) {
-// CHECK-NEXT:   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-// CHECK-NEXT:   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-// CHECK-NEXT:   firrtl.partialconnect %out, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK-NEXT: }
-
-
 // Test that last connect semantics are resolved in a WhenOp
 firrtl.module @shadow_when(in %p : !firrtl.uint<1>) {
   %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>


### PR DESCRIPTION
This change splits the way module bodies are processed from the way
WhenOp regions are processed.  There was unneeded work in the module
body to process simulation constructs, which is now skipped.

This creates two different visitor classes, one for the Module and one
for the WhenOp, and moves the common code to a new parent class.

This change also checks if any changes have been made to the module and
will `markAnalysisPreserved` if no changes have been made.