### PR TITLE
[FIRRTL] Preserve cached analysis when nothing changes a few passes

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1710,8 +1710,11 @@ void InferWidthsPass::runOnOperation() {
     signalPassFailure();
     return;
   }
-  if (mapping.areAllModulesSkipped())
+  if (mapping.areAllModulesSkipped()) {
+    markAllAnalysesPreserved();
     return; // fast path if no inferrable widths are around
+  }
+
   LLVM_DEBUG({
     llvm::dbgs() << "Constraints:\n";
     solver.dumpConstraints(llvm::dbgs());


### PR DESCRIPTION
This checks if anything in the IR changed, and call
`markAllAnalysisPreserved()` if nothing changes.  This covers:

 - BlackBoxMemory
 - BlackBoxReader
 - InferWidths