### PR TITLE
[firtool] Move CSE very early

### DIFF
--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -199,6 +199,11 @@ processBuffer(std::unique_ptr<llvm::MemoryBuffer> ownedBuffer,
   // Allow optimizations to run multithreaded.
   context.enableMultithreading(isMultithreaded);
 
+  if (!disableOptimization) {
+    pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
+        createCSEPass());
+  }
+
   // Width inference creates canonicalization opportunities.
   if (inferWidths)
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInferWidthsPass());
@@ -216,7 +221,6 @@ processBuffer(std::unique_ptr<llvm::MemoryBuffer> ownedBuffer,
   // If we parsed a FIRRTL file and have optimizations enabled, clean it up.
   if (!disableOptimization) {
     auto &modulePM = pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>();
-    modulePM.addPass(createCSEPass());
     modulePM.addPass(createSimpleCanonicalizerPass());
   }
 


### PR DESCRIPTION
CSE can work with full efficacy on IR without inferrred widths.
Moving it early improves WidthInferrence and LowerTypes performance.