### PR TITLE
[FIRRTL][Annotation] Use FieldID instead of strings to reference sub-target

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -105,8 +105,30 @@ def MemDirAttr: I32EnumAttr<"MemDirAttr", "Memory Direction Enum",
 // FIRRTL Annotations Definition
 //===----------------------------------------------------------------------===//
 
-def AnnotationArrayAttr : TypedArrayAttrBase<DictionaryAttr,
-                                             "An array of FIRRTL Annotations">;
+def AnnotationArrayAttr: ArrayAttrBase<
+    And<[
+      // Guarantee this is an ArrayAttr first
+      CPred<"$_self.isa<::mlir::ArrayAttr>()">,
+      // Guarantee all elements are DictionaryAttr or SubAnnotationAttr
+      CPred<"::llvm::all_of($_self.cast<::mlir::ArrayAttr>(), "
+            "[&](::mlir::Attribute attr) { return attr.isa<"
+            "::mlir::DictionaryAttr,"
+            "::circt::firrtl::SubAnnotationAttr>();})">]>,
+    ""> {
+  let constBuilderCall = "$_builder.getArrayAttr($0)";
+}
+
+def SubAnnotationAttr
+  : AttrDef<FIRRTLDialect, "SubAnnotation", [], "::mlir::Attribute"> {
+  let summary = "An Annotation that targets part of what it's attached to";
+  let description = [{
+    An Annotation that is only applicable to part of what it is attached to.
+    This uses a range of field IDs to indicate to which fields it is applicable.
+  }];
+  let mnemonic = "subAnno";
+  let parameters = (ins "int64_t":$minFieldID, "int64_t":$maxFieldID,
+                        "DictionaryAttr":$annotations);
+}
 
 def PortAnnotationsAttr : TypedArrayAttrBase<AnnotationArrayAttr,
                                              "FIRRTL port annotations">;

--- a/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
@@ -50,6 +50,33 @@ void FIRRTLDialect::printAttribute(Attribute attr, DialectAsmPrinter &p) const {
   llvm_unreachable("Unexpected attribute");
 }
 
+//===----------------------------------------------------------------------===//
+// SubAnnotationAttr
+//===----------------------------------------------------------------------===//
+
+Attribute SubAnnotationAttr::parse(MLIRContext *ctxt, DialectAsmParser &p,
+                                   Type type) {
+  int64_t minFieldID, maxFieldID;
+  DictionaryAttr annotations;
+  StringRef fieldIDKeyword;
+
+  if (p.parseLess() || p.parseKeyword(&fieldIDKeyword) || p.parseEqual() ||
+      p.parseLSquare() || p.parseInteger(minFieldID) || p.parseComma() ||
+      p.parseInteger(maxFieldID) || p.parseRSquare() || p.parseComma() ||
+      p.parseAttribute<DictionaryAttr>(annotations) || p.parseGreater())
+    return Attribute();
+
+  if (fieldIDKeyword != "fieldID")
+    return Attribute();
+
+  return SubAnnotationAttr::get(ctxt, minFieldID, maxFieldID, annotations);
+}
+
+void SubAnnotationAttr::print(DialectAsmPrinter &p) const {
+  p << getMnemonic() << "<fieldID = [" << getMinFieldID() << ", "
+    << getMaxFieldID() << "], " << getAnnotations() << ">";
+}
+
 void FIRRTLDialect::registerAttributes() {
   addAttributes<
 #define GET_ATTRDEF_LIST

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -12,6 +12,7 @@
 
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Dialect/FIRRTL/FIRRTLAnnotations.h"
+#include "circt/Dialect/FIRRTL/FIRRTLAttributes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLVisitors.h"
 #include "circt/Dialect/HW/HWTypes.h"

--- a/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
@@ -67,17 +67,29 @@ static StringRef parseSubFieldSubIndexAnnotations(StringRef target,
   target = target.substr(fieldBegin);
   SmallVector<Attribute> annotationVec;
   SmallString<16> temp;
-  temp.push_back(target[0]);
-  for (size_t i = 1, s = target.size(); i < s; ++i) {
-    if (target[i] == '[' || target[i] == '.') {
-      // Create a StringAttr with the previous token.
-      annotationVec.push_back(StringAttr::get(context, temp));
+  for (auto c : target.drop_front()) {
+    if (c == ']') {
+      // Create a IntegerAttr with the previous sub-index token.
+      APInt subIndex;
+      if (!temp.str().getAsInteger(10, subIndex))
+        annotationVec.push_back(IntegerAttr::get(IntegerType::get(context, 64),
+                                                 subIndex.getSExtValue()));
+      else
+        // We don't have a good way to emit error here. This will be reported as
+        // an error in the FIRRTL parser.
+        annotationVec.push_back(StringAttr::get(context, temp));
       temp.clear();
-    }
-    temp.push_back(target[i]);
+    } else if (c == '[' || c == '.') {
+      // Create a StringAttr with the previous token.
+      if (!temp.empty())
+        annotationVec.push_back(StringAttr::get(context, temp));
+      temp.clear();
+    } else
+      temp.push_back(c);
   }
   // Save the last token.
-  annotationVec.push_back(StringAttr::get(context, temp));
+  if (!temp.empty())
+    annotationVec.push_back(StringAttr::get(context, temp));
   annotations = ArrayAttr::get(context, annotationVec);
 
   return targetBase;
@@ -410,8 +422,7 @@ static bool parseAugmentedType(
         assert(classAttr.getValue() == "firrtl.annotations.TargetToken$Field" &&
                "A StringAttr target token must be found with a subfield target "
                "token.");
-        componentAttrs.push_back(
-            StringAttr::get(context, Twine(".") + field.getValue()));
+        componentAttrs.push_back(field);
         continue;
       }
 
@@ -420,8 +431,7 @@ static bool parseAugmentedType(
         assert(classAttr.getValue() == "firrtl.annotations.TargetToken$Index" &&
                "An IntegerAttr target token must be found with a subindex "
                "target token.");
-        componentAttrs.push_back(StringAttr::get(
-            context, "[" + Twine(index.getValue().getZExtValue()) + "]"));
+        componentAttrs.push_back(index);
         continue;
       }
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLAttributes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLVisitors.h"
@@ -108,53 +109,17 @@ static FIRRTLType getCanonicalAggregateType(Type originalType) {
 /// with "target" key, that do not match the field suffix.
 static void filterAnnotations(ArrayAttr annotations,
                               SmallVector<Attribute> &loweredAttrs,
-                              StringRef suffix) {
+                              unsigned targetFieldID) {
   if (!annotations || annotations.empty())
     return;
 
   for (auto opAttr : annotations) {
-    auto di = opAttr.dyn_cast<DictionaryAttr>();
-    if (!di) {
+    if (auto subAnno = opAttr.dyn_cast<SubAnnotationAttr>()) {
+      if (targetFieldID >= subAnno.getMinFieldID() &&
+          targetFieldID <= subAnno.getMaxFieldID())
+        loweredAttrs.push_back(subAnno.getAnnotations());
+    } else
       loweredAttrs.push_back(opAttr);
-      continue;
-    }
-    auto targetAttr = di.get("target");
-    if (!targetAttr) {
-      loweredAttrs.push_back(opAttr);
-      continue;
-    }
-
-    ArrayAttr subFieldTarget = targetAttr.cast<ArrayAttr>();
-    SmallString<16> targetStr;
-    for (auto fName : subFieldTarget) {
-      std::string fNameStr = fName.cast<StringAttr>().getValue().str();
-      // The fNameStr will begin with either '[' or '.', replace it with an
-      // '_' to construct the suffix.
-      fNameStr[0] = '_';
-      // If it ends with ']', then just remove it.
-      if (fNameStr.back() == ']')
-        fNameStr.erase(fNameStr.size() - 1);
-
-      targetStr += fNameStr;
-    }
-    // If no subfield attribute, then copy the annotation.
-    if (targetStr.empty()) {
-      loweredAttrs.push_back(opAttr);
-      continue;
-    }
-    // If the subfield suffix doesn't match, then ignore the annotation.
-    if (suffix.find(targetStr.str().str()) != 0)
-      continue;
-
-    NamedAttrList modAttr;
-    for (auto attr : di.getValue()) {
-      // Ignore the actual target annotation, but copy the rest of annotations.
-      if (attr.first.str() == "target")
-        continue;
-      modAttr.push_back(attr);
-    }
-    loweredAttrs.push_back(
-        DictionaryAttr::get(annotations.getContext(), modAttr));
   }
 }
 
@@ -162,11 +127,11 @@ static void filterAnnotations(ArrayAttr annotations,
 /// This removes annotations with "target" key that does not match the field
 /// suffix.
 static AnnotationSet filterAnnotations(AnnotationSet annotations,
-                                       StringRef suffix) {
+                                       unsigned targetFieldID) {
   if (annotations.empty())
     return annotations;
   SmallVector<Attribute> loweredAttrs;
-  filterAnnotations(annotations.getArrayAttr(), loweredAttrs, suffix);
+  filterAnnotations(annotations.getArrayAttr(), loweredAttrs, targetFieldID);
   return AnnotationSet(ArrayAttr::get(annotations.getContext(), loweredAttrs));
 }
 
@@ -210,7 +175,8 @@ private:
 
   // Helpers to manage state.
   Value addArg(FModuleOp module, Type type, unsigned oldArgNumber,
-               Direction direction, StringRef nameSuffix = "");
+               Direction direction, unsigned targetFieldID,
+               StringRef nameSuffix = "");
 
   void setBundleLowering(FieldRef fieldRef, Value newValue);
   Value getBundleLowering(FieldRef fieldRef);
@@ -336,9 +302,11 @@ void TypeLoweringVisitor::lowerArg(FModuleOp module, BlockArgument arg,
     // Create new block arguments.
     auto type = field.type;
     // Flip the direction if the field is an output.
-    auto direction = (Direction)(
-        (unsigned)getModulePortDirection(module, argNumber) ^ field.isOutput);
-    auto newValue = addArg(module, type, argNumber, direction, field.suffix);
+    auto direction =
+        (Direction)((unsigned)getModulePortDirection(module, argNumber) ^
+                    field.isOutput);
+    auto newValue =
+        addArg(module, type, argNumber, direction, field.fieldID, field.suffix);
 
     // If this field was flattened from a bundle.
     if (!field.suffix.empty()) {
@@ -387,14 +355,14 @@ void TypeLoweringVisitor::visitDecl(FExtModuleOp extModule) {
         pName = builder.getStringAttr("");
       portNames.push_back(pName);
       // Flip the direction if the field is an output.
-      portDirections.push_back((Direction)(
-          (unsigned)getModulePortDirection(extModule, oldArgNumber) ^
-          field.isOutput));
+      portDirections.push_back((
+          Direction)((unsigned)getModulePortDirection(extModule, oldArgNumber) ^
+                     field.isOutput));
 
       // Populate newAnnotations with the old annotations filtered to those
       // associated with just this field.
       AnnotationSet newAnnotations =
-          filterAnnotations(oldAnnotations, field.suffix);
+          filterAnnotations(oldAnnotations, field.fieldID);
 
       // Populate the new arg attributes.
       argAttrDicts.push_back(newAnnotations.getArgumentAttrDict(argAttrs));
@@ -455,7 +423,7 @@ void TypeLoweringVisitor::visitDecl(InstanceOp op) {
       resultFieldIDs.push_back(field.fieldID);
 
       SmallVector<Attribute> loweredAttrs;
-      filterAnnotations(annotations, loweredAttrs, field.suffix);
+      filterAnnotations(annotations, loweredAttrs, field.fieldID);
       lowerPortAnnotations.push_back(builder->getArrayAttr(loweredAttrs));
     }
     numFieldsPerResult.push_back(fieldTypes.size());
@@ -695,7 +663,7 @@ void TypeLoweringVisitor::visitDecl(NodeOp op) {
     // For all annotations on the parent op, filter them based on the target
     // attribute.
     SmallVector<Attribute> loweredAttrs;
-    filterAnnotations(op.annotations(), loweredAttrs, field.suffix);
+    filterAnnotations(op.annotations(), loweredAttrs, field.fieldID);
     auto initializer = getBundleLowering(FieldRef(op.input(), field.fieldID));
     auto node = builder->create<NodeOp>(field.type, initializer, loweredName,
                                         loweredAttrs);
@@ -730,7 +698,7 @@ void TypeLoweringVisitor::visitDecl(WireOp op) {
     SmallVector<Attribute> loweredAttrs;
     // For all annotations on the parent op, filter them based on the target
     // attribute.
-    filterAnnotations(op.annotations(), loweredAttrs, field.suffix);
+    filterAnnotations(op.annotations(), loweredAttrs, field.fieldID);
     auto wire = builder->create<WireOp>(field.type, loweredName, loweredAttrs);
     setBundleLowering(FieldRef(result, field.fieldID), wire);
   }
@@ -763,7 +731,7 @@ void TypeLoweringVisitor::visitDecl(RegOp op) {
     SmallVector<Attribute> loweredAttrs;
     // For all annotations on the parent op, filter them based on the target
     // attribute.
-    filterAnnotations(op.annotations(), loweredAttrs, field.suffix);
+    filterAnnotations(op.annotations(), loweredAttrs, field.fieldID);
     setBundleLowering(FieldRef(result, field.fieldID),
                       builder->create<RegOp>(field.getPortType(), op.clockVal(),
                                              loweredName, loweredAttrs));
@@ -1157,6 +1125,7 @@ void TypeLoweringVisitor::visitStmt(WhenOp op) {
 // possibly with a new suffix appended.
 Value TypeLoweringVisitor::addArg(FModuleOp module, Type type,
                                   unsigned oldArgNumber, Direction direction,
+                                  unsigned targetFieldID,
                                   StringRef nameSuffix) {
   Block *body = module.getBodyBlock();
 
@@ -1174,7 +1143,7 @@ Value TypeLoweringVisitor::addArg(FModuleOp module, Type type,
   SmallVector<NamedAttribute> attributes;
   auto annotations = AnnotationSet::forPort(module, oldArgNumber, attributes);
 
-  AnnotationSet newAnnotations = filterAnnotations(annotations, nameSuffix);
+  AnnotationSet newAnnotations = filterAnnotations(annotations, targetFieldID);
 
   // Populate the new arg attributes.
   newArgAttrs.push_back(newAnnotations.getArgumentAttrDict(attributes));

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -302,9 +302,8 @@ void TypeLoweringVisitor::lowerArg(FModuleOp module, BlockArgument arg,
     // Create new block arguments.
     auto type = field.type;
     // Flip the direction if the field is an output.
-    auto direction =
-        (Direction)((unsigned)getModulePortDirection(module, argNumber) ^
-                    field.isOutput);
+    auto direction = (Direction)(
+        (unsigned)getModulePortDirection(module, argNumber) ^ field.isOutput);
     auto newValue =
         addArg(module, type, argNumber, direction, field.fieldID, field.suffix);
 
@@ -355,9 +354,9 @@ void TypeLoweringVisitor::visitDecl(FExtModuleOp extModule) {
         pName = builder.getStringAttr("");
       portNames.push_back(pName);
       // Flip the direction if the field is an output.
-      portDirections.push_back((
-          Direction)((unsigned)getModulePortDirection(extModule, oldArgNumber) ^
-                     field.isOutput));
+      portDirections.push_back((Direction)(
+          (unsigned)getModulePortDirection(extModule, oldArgNumber) ^
+          field.isOutput));
 
       // Populate newAnnotations with the old annotations filtered to those
       // associated with just this field.

--- a/test/Dialect/FIRRTL/annotations-errors.fir
+++ b/test/Dialect/FIRRTL/annotations-errors.fir
@@ -81,5 +81,36 @@ circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar[1]"}]]
   module Bar:
     input a: UInt<1>
   module Foo:
-    ; expected-error @+1 {{unexpected annotation target [1]}}
+    ; expected-error @+1 {{the first token is invalid}}
     inst bar of Bar
+
+; // -----
+
+; COM: Invalid sub-target annotation should report an error
+
+circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar[a].baz"}, {"two":null,"target":"~Foo|Foo>bar[2].baz"}]]
+  module Foo:
+; expected-error @+2 {{expect an integer for the 1-th token of .a.baz}}
+; expected-error @+1 {{the 1-th token of [2].baz is out of range in the vector}}
+    wire bar: {baz: UInt<1>, qux: UInt<1>}[2]
+
+; // -----
+
+; COM: Invalid sub-target annotation should report an error
+
+circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar[1][0]"},{"two":null,"target":"~Foo|Foo>bar[1].qnx"}]]
+  module Foo:
+    input clock: Clock
+; expected-error @+2 {{expect a string for the 2-th token of [1][0]}}
+; expected-error @+1 {{the 2-th token of [1].qnx is not found in the bundle}}
+    reg bar: {baz: UInt<1>, qux: UInt<1>}[2], clock
+
+; // -----
+
+; COM: Invalid sub-target annotation should report an error
+
+circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar[1].baz[0]"}]]
+  module Foo:
+    input clock: Clock
+; expected-error @+1 {{the 3-th token of [1].baz[0] expects an aggregate type}}
+    reg bar: {baz: UInt<1>, qux: UInt<1>}[2], clock

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -99,7 +99,7 @@ circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar.a"},
 
     ; CHECK-LABEL: module {
     ; CHECK: %bar_a, %bar_b = firrtl.instance @Bar
-    ; CHECK-SAME: [{one}], [#firrtl.subAnno<fieldID = [1, 1], {two}>], [#firrtl.subAnno<fieldID = [2, 2], {three}>]
+    ; CHECK-SAME: [{one}], [#firrtl.subAnno<fieldID = [1, 1], {two}>, #firrtl.subAnno<fieldID = [2, 2], {three}>]
 
 ; // -----
 

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -99,7 +99,7 @@ circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar.a"},
 
     ; CHECK-LABEL: module {
     ; CHECK: %bar_a, %bar_b = firrtl.instance @Bar
-    ; CHECK-SAME: [{one}], [{target = [".baz"], two}, {target = [".qux"], three}]
+    ; CHECK-SAME: [{one}], [#firrtl.subAnno<fieldID = [1, 1], {two}>], [#firrtl.subAnno<fieldID = [2, 2], {three}>]
 
 ; // -----
 
@@ -241,24 +241,24 @@ circuit Foo: %[[{"a":"{\"b\":null}"}]]
 ; // -----
 
 ; COM: Subfield/Subindex annotations should be parsed correctly on wires
-circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar.qux"},{"two":null,"target":"~Foo|Foo>bar[1].baz"} ]]
+circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar[0]"},{"two":null,"target":"~Foo|Foo>bar[1].baz"} ]]
   module Foo:
     wire bar: {baz: UInt<1>, qux: UInt<1>}[2]
 
     ; CHECK-LABEL: module {
-    ; CHECK: %bar = firrtl.wire  {annotations = [{one, target = [".qux"]}, {target = ["[1]", ".baz"], two}]} : !firrtl.vector<bundle<baz: uint<1>, qux: uint<1>>, 2>
+    ; CHECK: %bar = firrtl.wire  {annotations = [#firrtl.subAnno<fieldID = [1, 3], {one}>, #firrtl.subAnno<fieldID = [5, 5], {two}>]} : !firrtl.vector<bundle<baz: uint<1>, qux: uint<1>>, 2>
 
 
 ; // -----
 
 ; COM: Subfield/Subindex annotations should be parsed correctly on registers
-circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar.qux"},{"two":null,"target":"~Foo|Foo>bar[1].baz"} ]]
+circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar[0]"},{"two":null,"target":"~Foo|Foo>bar[1].baz"} ]]
   module Foo:
     input clock: Clock
     reg bar: {baz: UInt<1>, qux: UInt<1>}[2], clock
 
     ; CHECK-LABEL: module {
-    ; CHECK: %bar = firrtl.reg %clock  {annotations = [{one, target = [".qux"]}, {target = ["[1]", ".baz"], two}]} : (!firrtl.clock) -> !firrtl.vector<bundle<baz: uint<1>, qux: uint<1>>, 2>
+    ; CHECK: %bar = firrtl.reg %clock  {annotations = [#firrtl.subAnno<fieldID = [1, 3], {one}>, #firrtl.subAnno<fieldID = [5, 5], {two}>]} : (!firrtl.clock) -> !firrtl.vector<bundle<baz: uint<1>, qux: uint<1>>, 2>
 
 ; // -----
 
@@ -477,7 +477,7 @@ circuit GCTMemTap : %[
     ; CHECK-LABEL: firrtl.circuit "GCTMemTap"
     ; CHECK-SAME: annotations = [{unrelatedAnnotation}]
     ; CHECK: firrtl.extmodule @MemTap
-    ; CHECK-SAME: %mem: [[A:.+]] {firrtl.annotations = [{class = "sifive.enterprise.grandcentral.MemTapAnnotation", id = [[ID:.+]] : i64, target = ["[0]"]}, {class = "sifive.enterprise.grandcentral.MemTapAnnotation", id = [[ID]] : i64, target = ["[1]"]}]
+    ; CHECK-SAME: %mem: [[A:.+]] {firrtl.annotations = [#firrtl.subAnno<fieldID = [1, 1], {class = "sifive.enterprise.grandcentral.MemTapAnnotation", id = 0 : i64}>, #firrtl.subAnno<fieldID = [2, 2], {class = "sifive.enterprise.grandcentral.MemTapAnnotation", id = 0 : i64}>]
     ; CHECK: firrtl.module @GCTMemTap
     ; CHECK: %mem = firrtl.cmem
     ; CHECK-SAME: annotations = [{class = "sifive.enterprise.grandcentral.MemTapAnnotation", id = [[ID]] : i64}]
@@ -528,14 +528,14 @@ circuit GCTInterface : %[
     ; members of the interface inside the parent.  Both port "a" and register
     ; "r" should be annotated.
     ; CHECK: firrtl.module @GCTInterface
-    ; CHECK-SAME: %a: [[TYPE:.+]] {firrtl.annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "ViewName", name = "port", target = []}]}
+    ; CHECK-SAME: %a: [[TYPE:.+]] {firrtl.annotations = [#firrtl.subAnno<fieldID = [0, 0], {class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "ViewName", name = "port"}>]}
     ; CHECK-SAME: annotations = [{class = "sifive.enterprise.grandcentral.GrandCentralView$SerializedViewAnnotation", id = [[ID]] : i64, type = "parent"}]
     ; CHECK: firrtl.reg
     ; CHECK-SAME: annotations
-    ; CHECK-SAME: {class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "register", name = "_2", target = ["._2", "[0]"]}
-    ; CHECK-SAME: {class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "register", name = "_2", target = ["._2", "[1]"]}
-    ; CHECK-SAME: {class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "_0", name = "_1", target = ["._0", "._1"]}
-    ; CHECK-SAME: {class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "_0", name = "_0", target = ["._0", "._0"]}]}
+    ; CHECK-SAME: #firrtl.subAnno<fieldID = [5, 5], {class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "register", name = "_2"}>
+    ; CHECK-SAME: #firrtl.subAnno<fieldID = [6, 6], {class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "register", name = "_2"}>
+    ; CHECK-SAME: #firrtl.subAnno<fieldID = [3, 3], {class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "_0", name = "_1"}>
+    ; CHECK-SAME: #firrtl.subAnno<fieldID = [2, 2], {class = "sifive.enterprise.grandcentral.AugmentedGroundType", defName = "_0", name = "_0"}>
 
 ; // -----
 


### PR DESCRIPTION
Currently, we are using an array of string to reference sub-target in annotations:
```
%bar = firrtl.reg %clock {annotations = [{target = ["[0]", ".baz"], one}]} : 
    (!firrtl.clock) -> !firrtl.vector<bundle<baz: vector<uint<1>, 2>>, 2>
```
In this patch, we replace the strings with `FieldID` introduced in #1045. The annotations above will look like:
```
%bar = firrtl.reg %clock {annotations = [{fieldID = 2 : i64, fieldIDRange = 2 : i64, one}]} : 
    (!firrtl.clock) -> !firrtl.vector<bundle<baz: vector<uint<1>, 2>>, 2>
```
Note that when the sub-target points to aggregate types (in the example above, `vector<uint<1>, 2>`), we introduce a `fieldIDRange` attribute to indicate the range of IDs of the aggregate type. Such that in the `-lower-types`, as long as a flattened field's ID is in the range of `[fieldID, fieldID + fieldIDRange]`, it should be annotated.

Meanwhile, this patch also adds the second verification mentioned in #1013.