### PR TITLE
[FIRRTL] Add InferResets pass

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -193,4 +193,30 @@ public:
 #define GET_OP_CLASSES
 #include "circt/Dialect/FIRRTL/FIRRTL.h.inc"
 
+//===----------------------------------------------------------------------===//
+// Traits
+//===----------------------------------------------------------------------===//
+
+namespace llvm {
+template <>
+struct DenseMapInfo<circt::firrtl::FModuleOp> {
+  using Operation = mlir::Operation;
+  using FModuleOp = circt::firrtl::FModuleOp;
+  static inline FModuleOp getEmptyKey() {
+    return FModuleOp::getFromOpaquePointer(
+        DenseMapInfo<Operation *>::getEmptyKey());
+  }
+  static inline FModuleOp getTombstoneKey() {
+    return FModuleOp::getFromOpaquePointer(
+        DenseMapInfo<Operation *>::getTombstoneKey());
+  }
+  static unsigned getHashValue(const FModuleOp &val) {
+    return DenseMapInfo<Operation *>::getHashValue(val);
+  }
+  static bool isEqual(const FModuleOp &lhs, const FModuleOp &rhs) {
+    return lhs == rhs;
+  }
+};
+} // end namespace llvm
+
 #endif // CIRCT_DIALECT_FIRRTL_OPS_H

--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -37,6 +37,8 @@ std::unique_ptr<mlir::Pass> createExpandWhensPass();
 
 std::unique_ptr<mlir::Pass> createInferWidthsPass();
 
+std::unique_ptr<mlir::Pass> createInferResetsPass();
+
 std::unique_ptr<mlir::Pass> createPrintInstanceGraphPass();
 
 std::unique_ptr<mlir::Pass>

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -109,6 +109,19 @@ def InferWidths : Pass<"firrtl-infer-widths", "firrtl::CircuitOp"> {
   let constructor = "circt::firrtl::createInferWidthsPass()";
 }
 
+def InferResets : Pass<"firrtl-infer-resets", "firrtl::CircuitOp"> {
+  let summary = "Infer reset synchronicity and add implicit resets";
+  let description = [{
+    This pass infers whether resets are synchronous or asynchronous, and extends
+    reset-less registers with an asynchronous reset based on the following
+    annotations:
+
+    - `sifive.enterprise.firrtl.FullAsyncResetAnnotation`
+    - `sifive.enterprise.firrtl.IgnoreFullAsyncResetAnnotation`
+  }];
+  let constructor = "circt::firrtl::createInferResetsPass()";
+}
+
 def BlackBoxReader : Pass<"firrtl-blackbox-reader", "CircuitOp"> {
   let summary = "Load source files for black boxes into the IR";
   let description = [{

--- a/include/circt/Support/FieldRef.h
+++ b/include/circt/Support/FieldRef.h
@@ -52,6 +52,14 @@ public:
     return value == other.value && id == other.id;
   }
 
+  bool operator<(const FieldRef &other) const {
+    if (value.getImpl() < other.value.getImpl())
+      return true;
+    if (value.getImpl() > other.value.getImpl())
+      return false;
+    return id < other.id;
+  }
+
   operator bool() const { return bool(value); }
 
 private:

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -6,6 +6,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   GrandCentralTaps.cpp
   IMConstProp.cpp
   InferWidths.cpp
+  InferResets.cpp
   LowerTypes.cpp
   ModuleInliner.cpp
   PrintInstanceGraph.cpp

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -1,0 +1,1457 @@
+//===- InferResets.cpp - Infer resets and add async reset -------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the InferResets pass.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
+#include "circt/Dialect/FIRRTL/InstanceGraph.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "circt/Support/FieldRef.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "llvm/ADT/EquivalenceClasses.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/TinyPtrVector.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "infer-resets"
+
+using llvm::BumpPtrAllocator;
+using llvm::MapVector;
+using llvm::SmallDenseSet;
+using llvm::SmallSetVector;
+using mlir::FailureOr;
+using mlir::InferTypeOpInterface;
+using mlir::WalkOrder;
+
+using namespace circt;
+using namespace firrtl;
+
+//===----------------------------------------------------------------------===//
+// Utilities
+//===----------------------------------------------------------------------===//
+
+/// An absolute instance path.
+using InstancePathRef = ArrayRef<InstanceOp>;
+using InstancePath = SmallVector<InstanceOp>;
+
+template <typename T>
+static T &operator<<(T &os, InstancePathRef path) {
+  os << "$root";
+  for (InstanceOp inst : path)
+    os << "/" << inst.name() << ":" << inst.moduleName();
+  return os;
+}
+
+static StringRef getTail(InstancePathRef path) {
+  if (path.empty())
+    return "$root";
+  auto last = path.back();
+  return last.name();
+}
+
+namespace {
+/// A reset domain.
+struct ResetDomain {
+  /// Whether this is the root of the reset domain.
+  bool isTop = false;
+  /// The reset signal for this domain. A null value indicates that this domain
+  /// explicitly has no reset.
+  Value reset;
+
+  // Implementation details for this domain.
+  Value existingValue;
+  Optional<unsigned> existingPort;
+  StringAttr newPortName;
+
+  ResetDomain(Value reset) : reset(reset) {}
+};
+} // namespace
+
+inline bool operator==(const ResetDomain &a, const ResetDomain &b) {
+  return (a.isTop == b.isTop && a.reset == b.reset);
+}
+inline bool operator!=(const ResetDomain &a, const ResetDomain &b) {
+  return !(a == b);
+}
+
+/// Return the name and parent module of a reset. The reset value must either be
+/// a module port or a wire/node operation.
+static std::pair<StringAttr, FModuleOp> getResetNameAndModule(Value reset) {
+  if (auto arg = reset.dyn_cast<BlockArgument>()) {
+    auto module = cast<FModuleOp>(arg.getParentRegion()->getParentOp());
+    return {getModulePortName(module, arg.getArgNumber()), module};
+  } else {
+    auto op = reset.getDefiningOp();
+    return {op->getAttrOfType<StringAttr>("name"),
+            op->getParentOfType<FModuleOp>()};
+  }
+}
+
+/// Return the name of a reset. The reset value must either be a module port or
+/// a wire/node operation.
+static inline StringAttr getResetName(Value reset) {
+  return getResetNameAndModule(reset).first;
+}
+
+/// Construct a zero value of the given type using the given builder.
+static Value createZeroValue(ImplicitLocOpBuilder &builder, FIRRTLType type,
+                             SmallDenseMap<FIRRTLType, Value> &cache) {
+  auto it = cache.find(type);
+  if (it != cache.end())
+    return it->second;
+  auto nullBit = [&]() {
+    return createZeroValue(builder, UIntType::get(builder.getContext(), 1),
+                           cache);
+  };
+  auto value =
+      TypeSwitch<FIRRTLType, Value>(type)
+          .Case<ClockType>([&](auto type) {
+            return builder.create<AsClockPrimOp>(nullBit());
+          })
+          .Case<AsyncResetType>([&](auto type) {
+            return builder.create<AsAsyncResetPrimOp>(nullBit());
+          })
+          .Case<SIntType, UIntType>([&](auto type) {
+            return builder.create<ConstantOp>(
+                type, APInt::getNullValue(type.getWidth().getValueOr(1)));
+          })
+          .Case<BundleType>([&](auto type) {
+            auto wireOp = builder.create<WireOp>(type);
+            for (auto &field : llvm::enumerate(type.getElements())) {
+              auto zero = createZeroValue(builder, field.value().type, cache);
+              auto acc = builder.create<SubfieldOp>(field.value().type, wireOp,
+                                                    field.index());
+              builder.create<ConnectOp>(acc, zero);
+            }
+            return wireOp;
+          })
+          .Case<FVectorType>([&](auto type) {
+            auto wireOp = builder.create<WireOp>(type);
+            auto zero = createZeroValue(builder, type.getElementType(), cache);
+            for (unsigned i = 0, e = type.getNumElements(); i < e; ++i) {
+              auto acc = builder.create<SubindexOp>(zero.getType(), wireOp, i);
+              builder.create<ConnectOp>(acc, zero);
+            }
+            return wireOp;
+          })
+          .Case<ResetType, AnalogType>(
+              [&](auto type) { return builder.create<InvalidValueOp>(type); })
+          .Default([](auto) {
+            llvm_unreachable("switch handles all types");
+            return Value{};
+          });
+  cache.insert({type, value});
+  return value;
+}
+
+/// Construct a null value of the given type using the given builder.
+static Value createZeroValue(ImplicitLocOpBuilder &builder, FIRRTLType type) {
+  SmallDenseMap<FIRRTLType, Value> cache;
+  return createZeroValue(builder, type, cache);
+}
+
+/// Helper function that inserts reset multiplexer into all `ConnectOp`s and
+/// `PartialConnectOp`s with the given target. Looks through `SubfieldOp`,
+/// `SubindexOp`, and `SubaccessOp`, and inserts multiplexers into connects to
+/// these subaccesses as well. Modifies the insertion location of the builder.
+/// Returns true if the `resetValue` was used in any way, false otherwise.
+static bool insertResetMux(ImplicitLocOpBuilder &builder, Value target,
+                           Value reset, Value resetValue) {
+  // Indicates whether the `resetValue` was assigned to in some way. We use this
+  // to erase unused subfield/subindex/subaccess ops on the reset value if they
+  // end up unused.
+  bool resetValueUsed = false;
+
+  for (auto &use : target.getUses()) {
+    Operation *useOp = use.getOwner();
+    builder.setInsertionPoint(useOp);
+    TypeSwitch<Operation *>(useOp)
+        // Insert a mux on the value connected to the target:
+        // connect(dst, src) -> connect(dst, mux(reset, resetValue, src))
+        .Case<ConnectOp, PartialConnectOp>([&](auto op) {
+          if (op.dest() != target)
+            return;
+          LLVM_DEBUG(llvm::dbgs() << "  - Insert mux into " << op << "\n");
+          auto muxOp = builder.create<MuxPrimOp>(reset, resetValue, op.src());
+          op.srcMutable().assign(muxOp);
+          resetValueUsed = true;
+        })
+        // Look through subfields.
+        .Case<SubfieldOp>([&](auto op) {
+          auto resetSubValue =
+              builder.create<SubfieldOp>(resetValue, op.fieldIndexAttr());
+          if (insertResetMux(builder, op, reset, resetSubValue))
+            resetValueUsed = true;
+          else
+            resetSubValue.erase();
+        })
+        // Look through subindices.
+        .Case<SubindexOp>([&](auto op) {
+          auto resetSubValue =
+              builder.create<SubindexOp>(resetValue, op.indexAttr());
+          if (insertResetMux(builder, op, reset, resetSubValue))
+            resetValueUsed = true;
+          else
+            resetSubValue.erase();
+        })
+        // Look through subaccesses.
+        .Case<SubaccessOp>([&](auto op) {
+          auto resetSubValue =
+              builder.create<SubaccessOp>(resetValue, op.index());
+          if (insertResetMux(builder, op, reset, resetSubValue))
+            resetValueUsed = true;
+          else
+            resetSubValue.erase();
+        });
+  }
+  return resetValueUsed;
+}
+
+//===----------------------------------------------------------------------===//
+// Reset Network
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// A reset signal.
+///
+/// This essentially combines the exact `FieldRef` of the signal in question
+/// with a type to be used for error reporting and inferring the reset kind.
+struct ResetSignal {
+  ResetSignal(FieldRef field, FIRRTLType type) : field(field), type(type) {}
+  bool operator<(const ResetSignal &other) const { return field < other.field; }
+  bool operator==(const ResetSignal &other) const {
+    return field == other.field;
+  }
+  bool operator!=(const ResetSignal &other) const { return !(*this == other); }
+
+  FieldRef field;
+  FIRRTLType type;
+};
+
+/// A connection made to or from a reset network.
+///
+/// These drives are tracked for each reset network, and are used for error
+/// reporting to the user.
+struct ResetDrive {
+  /// What's being driven.
+  ResetSignal dst;
+  /// What's driving.
+  ResetSignal src;
+  /// The location to use for diagnostics.
+  Location loc;
+};
+
+/// A list of connections to a reset network.
+using ResetDrives = SmallVector<ResetDrive, 1>;
+
+/// All signals connected together into a reset network.
+using ResetNetwork = llvm::iterator_range<
+    llvm::EquivalenceClasses<ResetSignal>::member_iterator>;
+
+/// Whether a reset is sync or async.
+enum class ResetKind { Async, Sync };
+
+} // namespace
+
+namespace llvm {
+template <>
+struct DenseMapInfo<ResetSignal> {
+  static inline ResetSignal getEmptyKey() {
+    return ResetSignal{DenseMapInfo<FieldRef>::getEmptyKey(), {}};
+  }
+  static inline ResetSignal getTombstoneKey() {
+    return ResetSignal{DenseMapInfo<FieldRef>::getTombstoneKey(), {}};
+  }
+  static unsigned getHashValue(const ResetSignal &x) {
+    return circt::hash_value(x.field);
+  }
+  static bool isEqual(const ResetSignal &lhs, const ResetSignal &rhs) {
+    return lhs == rhs;
+  }
+};
+} // namespace llvm
+
+template <typename T>
+static T &operator<<(T &os, const ResetKind &kind) {
+  switch (kind) {
+  case ResetKind::Async:
+    return os << "async";
+  case ResetKind::Sync:
+    return os << "sync";
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Pass Infrastructure
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// Infer concrete reset types and insert full async reset.
+///
+/// This pass replaces `reset` types in the IR with a concrete `asyncreset` or
+/// `uint<1>` depending on how the reset is used, and adds async resets to
+/// registers in modules marked with the corresponding
+/// `FullAsyncResetAnnotation`.
+///
+/// On a high level, the first stage of the pass that deals with reset inference
+/// operates as follows:
+///
+/// 1. Build a global graph of the resets in the design by tracing reset signals
+///    through instances. This uses the `ResetNetwork` utilities and boils down
+///    to finding  groups of values in the IR that are part of the same reset
+///    network (i.e., somehow attached together through ports, wires, instances,
+///    and connects). We use LLVM's `EquivalenceClasses` data structure to do
+///    this efficiently.
+///
+/// 2. Infer the type of each reset network found in step 1 by looking at the
+///    type of values connected to the network. This results in the network
+///    being declared a sync (`uint<1>`) or async (`asyncreset`) network. If the
+///    reset is never driven by a concrete type, an error is emitted.
+///
+/// 3. Walk the IR and update the type of wires and ports with the reset types
+///    found in step 2. This will replace all `reset` types in the IR with
+///    a concrete type.
+///
+/// The second stage that deals with the addition of async resets operates as
+/// follows:
+///
+/// 4. Visit every module in the design and determine if it has an explicit
+///    reset annotated. Ports of and wires in the module can have a
+///    `FullAsyncResetAnnotation`, which marks that port or wire as the async
+///    reset for the module. A module may also carry a
+///    `IgnoreFullAsyncResetAnnotation`, which marks it as being explicitly not
+///    in a reset domain. These annotations are sparse; it is very much possible
+///    that just the top-level module in the design has a full async reset
+///    annotation. A module can only ever carry one of these annotations, which
+///    puts it into one of three categories from an async reset inference
+///    perspective:
+///
+///      a. unambiguously marks a port or wire as the module's async reset
+///      b. explicitly marks it as not to have any async resets added
+///      c. inherit reset
+///
+/// 5. For every module in the design, determine the full async reset domain it
+///    is in. Note that this very narrowly deals with the inference of a
+///    "default" async reset, which bascially goes through the IR and attaches
+///    all non-reset registers to a default async reset signal. If a module
+///    carries one of the annotations mentioned in (4), the annotated port or
+///    wire is used as its reset domain. Otherwise, it inherits the reset domain
+///    from parent modules. This conceptually involves looking at all the places
+///    where a module is instantiated, and recursively determining the reset
+///    domain at the instantiation site. A module can only ever be in one reset
+///    domain. In case it is inferred to lie in multiple ones, e.g., if it is
+///    instantiated in different reset domains, an error is emitted. If
+///    successful, every module is associated with a reset signal, either one of
+///    its local ports or wires, or a port or wire within one of its parent
+///    modules.
+///
+/// 6. For every module in the design, determine how async resets shall be
+///    implemented. This step handles the following distinct cases:
+///
+///      a. Skip a module because it is marked as having no reset domain.
+///      b. Use a port or wire in the module itself as reset. This is possible
+///         if the module is at the "top" of its reset domain, which means that
+///         it itself carried a reset annotation, and the reset value is either
+///         a port or wire of the module itself.
+///      c. Route a parent module's reset through a module port and use that
+///         port as the reset. This happens if the module is *not* at the "top"
+///         of its reset domain, but rather refers to a value in a parent module
+///         as its reset.
+///
+///    As a result, a module's reset domain is annotated with the existing local
+///    value to reuse (port or wire), the index of an existing port to reuse,
+///    and the name of an additional port to insert into its port list.
+///
+/// 7. For every module in the design, async resets are implemented. This
+///    determines the local value to use as the reset signal and updates the
+///    `reg` and `regreset` operations in the design. If the register already
+///    has an async reset, it is left unchanged. If it has a sync reset, the
+///    sync reset is moved into a `mux` operation on all `connect`s to the
+///    register (which the Scala code base called the `RemoveResets` pass).
+///    Finally the register is replaced with a `regreset` operation, with the
+///    reset signal determined earlier, and a "zero" value constructed for the
+///    register's type.
+///
+///    Determining the local reset value is trivial if step 6 found a module to
+///    be of case a or b. Case c is the non-trivial one, because it requires
+///    modifying the port list of the module. This is done by first determining
+///    the name of the reset signal in the parent module, which is either the
+///    name of the port or wire declaration. We then look for an existing
+///    `asyncreset` port in the port list and reuse that as reset. If no port
+///    with that name was found, or the existing port is of the wrong type, a
+///    new port is inserted into the port list.
+///
+///    TODO: This logic is *very* brittle and error-prone. It may make sense to
+///    just add an additional port for the inferred async reset in any case,
+///    with an optimization to use an existing `asyncreset` port if all of the
+///    module's instantiations have that port connected to the desired signal
+///    already.
+///
+struct InferResetsPass : public InferResetsBase<InferResetsPass> {
+  void runOnOperation() override;
+  void runOnOperationInner();
+
+  // Copy creates a new empty pass (because ResetMap has no copy constructor).
+  using InferResetsBase::InferResetsBase;
+  InferResetsPass(const InferResetsPass &) {}
+
+  //===--------------------------------------------------------------------===//
+  // Reset type inference
+
+  void traceResets(CircuitOp circuit);
+  void traceResets(InstanceOp inst);
+  void traceResets(Value dst, Value src, Location loc);
+  void traceResets(Value value);
+  void traceResets(FIRRTLType dstType, Value dst, unsigned dstID,
+                   FIRRTLType srcType, Value src, unsigned srcID, Location loc);
+
+  LogicalResult inferAndUpdateResets();
+  FailureOr<ResetKind> inferReset(ResetNetwork net);
+  LogicalResult updateReset(ResetNetwork net, ResetKind kind);
+  bool updateReset(FieldRef field, FIRRTLType resetType);
+
+  //===--------------------------------------------------------------------===//
+  // Async reset implementation
+
+  LogicalResult collectAnnos(CircuitOp circuit);
+  LogicalResult collectAnnos(FModuleOp module);
+
+  LogicalResult buildDomains(CircuitOp circuit);
+  void buildDomains(FModuleOp module, const InstancePath &instPath,
+                    Value parentReset, InstanceGraph &instGraph,
+                    unsigned indent = 0);
+
+  void determineImpl();
+  void determineImpl(FModuleOp module, ResetDomain &domain);
+
+  LogicalResult implementAsyncReset();
+  LogicalResult implementAsyncReset(FModuleOp module, ResetDomain &domain);
+  void implementAsyncReset(Operation *op, FModuleOp module, Value actualReset);
+
+  //===--------------------------------------------------------------------===//
+  // Utilities
+
+  /// Get the reset network a signal belongs to.
+  ResetNetwork getResetNetwork(ResetSignal signal) {
+    return llvm::make_range(resetClasses.findLeader(signal),
+                            resetClasses.member_end());
+  }
+
+  /// Get the drives of a reset network.
+  ResetDrives &getResetDrives(ResetNetwork net) {
+    return resetDrives[*net.begin()];
+  }
+
+  /// Guess the root node of a reset network, such that we have something for
+  /// the user to make sense of.
+  ResetSignal guessRoot(ResetNetwork net);
+  ResetSignal guessRoot(ResetSignal signal) {
+    return guessRoot(getResetNetwork(signal));
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Analysis data
+
+  /// A map of all traced reset networks in the circuit.
+  llvm::EquivalenceClasses<ResetSignal> resetClasses;
+
+  /// A map of all connects to and from a reset.
+  DenseMap<ResetSignal, ResetDrives> resetDrives;
+
+  /// The annotated reset for a module. A null value indicates that the module
+  /// is explicitly annotated with `ignore`. Otherwise the port/wire/node
+  /// annotated as reset within the module is stored.
+  DenseMap<Operation *, Value> annotatedResets;
+
+  /// The reset domain for a module. In case of conflicting domain membership,
+  /// the vector for a module contains multiple elements.
+  MapVector<FModuleOp, SmallVector<std::pair<ResetDomain, InstancePath>, 1>>
+      domains;
+};
+} // namespace
+
+void InferResetsPass::runOnOperation() {
+  runOnOperationInner();
+  resetClasses = llvm::EquivalenceClasses<ResetSignal>();
+  resetDrives.clear();
+  annotatedResets.clear();
+  domains.clear();
+}
+
+void InferResetsPass::runOnOperationInner() {
+  // Trace the uninferred reset networks throughout the design.
+  traceResets(getOperation());
+
+  // Infer the type of the traced resets and update the IR.
+  if (failed(inferAndUpdateResets()))
+    return signalPassFailure();
+
+  // Gather the reset annotations throughout the modules.
+  if (failed(collectAnnos(getOperation())))
+    return signalPassFailure();
+
+  // Build the reset domains in the design.
+  if (failed(buildDomains(getOperation())))
+    return signalPassFailure();
+
+  // Determine how each reset shall be implemented.
+  determineImpl();
+
+  // Implement the async resets.
+  if (failed(implementAsyncReset()))
+    return signalPassFailure();
+}
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createInferResetsPass() {
+  return std::make_unique<InferResetsPass>();
+}
+
+ResetSignal InferResetsPass::guessRoot(ResetNetwork net) {
+  ResetDrives &drives = getResetDrives(net);
+  ResetSignal bestSignal = *net.begin();
+  unsigned bestNumDrives = -1;
+
+  for (auto signal : net) {
+    // Don't consider `invalidvalue` for reporting as a root.
+    if (isa_and_nonnull<InvalidValueOp>(
+            signal.field.getValue().getDefiningOp()))
+      continue;
+
+    // Count the number of times this particular signal in the reset network is
+    // assigned to.
+    unsigned numDrives = 0;
+    for (auto &drive : drives)
+      if (drive.dst == signal)
+        ++numDrives;
+
+    // Keep track of the signal with the lowest number of assigns. These tend to
+    // be the signals further up the reset tree. This will usually resolve to
+    // the root of the reset tree far up in the design hierarchy.
+    if (numDrives < bestNumDrives) {
+      bestNumDrives = numDrives;
+      bestSignal = signal;
+    }
+  }
+  return bestSignal;
+}
+
+//===----------------------------------------------------------------------===//
+// Reset Tracing
+//===----------------------------------------------------------------------===//
+
+/// Iterate over a circuit and follow all signals with `ResetType`, aggregating
+/// them into reset nets. After this function returns, the `resetMap` is
+/// populated with the reset networks in the circuit, alongside information on
+/// drivers and their types that contribute to the reset.
+void InferResetsPass::traceResets(CircuitOp circuit) {
+  LLVM_DEBUG(
+      llvm::dbgs() << "\n===----- Tracing uninferred resets -----===\n\n");
+  circuit.walk([&](Operation *op) {
+    TypeSwitch<Operation *>(op)
+        .Case<ConnectOp, PartialConnectOp>(
+            [&](auto op) { traceResets(op.dest(), op.src(), op.getLoc()); })
+        .Case<InstanceOp>([&](auto op) { traceResets(op); });
+  });
+}
+
+/// Trace reset signals through an instance. This essentially associates the
+/// instance's port values with the target module's port values.
+void InferResetsPass::traceResets(InstanceOp inst) {
+  // Lookup the referenced module. Nothing to do if its an extmodule.
+  auto module = dyn_cast<FModuleOp>(inst.getReferencedModule());
+  if (!module)
+    return;
+  LLVM_DEBUG(llvm::dbgs() << "Visiting instance " << inst.name() << "\n");
+
+  // Establish a connection between the instance ports and module ports.
+  auto dirs = getModulePortDirections(module);
+  for (auto it : llvm::enumerate(inst.getResults())) {
+    auto dir = direction::get(dirs.getValue()[it.index()]);
+    Value dstPort = module.getArgument(it.index());
+    Value srcPort = it.value();
+    if (dir == Direction::Output)
+      std::swap(dstPort, srcPort);
+    traceResets(dstPort, srcPort, it.value().getLoc());
+  }
+}
+
+/// Analyze a connect or partial connect of one (possibly aggregate) value to
+/// another. Each drive involving a `ResetType` is recorded.
+void InferResetsPass::traceResets(Value dst, Value src, Location loc) {
+  // Trace through any subfield/subindex/subaccess ops on both sides of the
+  // connect.
+  traceResets(dst);
+  traceResets(src);
+
+  // Analyze the actual connection.
+  auto dstType = dst.getType().cast<FIRRTLType>();
+  auto srcType = src.getType().cast<FIRRTLType>();
+  traceResets(dstType, dst, 0, srcType, src, 0, loc);
+}
+
+/// Trace a value through a possible subfield/subindex/subaccess op. This is
+/// used when analyzing connects and partial connects, to ensure we actually
+/// track down which subfields of larger aggregate values these drives refer to.
+void InferResetsPass::traceResets(Value value) {
+  auto op = value.getDefiningOp();
+  if (!op)
+    return;
+  TypeSwitch<Operation *>(op)
+      .Case<SubfieldOp>([&](auto op) {
+        auto bundleType = op.input().getType().template cast<BundleType>();
+        auto index = op.fieldIndex();
+        traceResets(op.getType(), op.getResult(), 0,
+                    bundleType.getElements()[index].type, op.input(),
+                    bundleType.getFieldID(index), value.getLoc());
+      })
+      .Case<SubindexOp, SubaccessOp>([&](auto op) {
+        // Collapse all elements in vectors into one shared element which will
+        // ensure that reset inference provides a uniform result for all
+        // elements.
+        //
+        // CAVEAT: This may infer reset networks that are too big, since
+        // unrelated resets in the same vector end up looking as if they were
+        // connected. However for the sake of type inference, this is
+        // indistinguishable from them having to share the same type (namely the
+        // vector element type).
+        auto vectorType = op.input().getType().template cast<FVectorType>();
+        traceResets(op.getType(), op.getResult(), 0,
+                    vectorType.getElementType(), op.input(),
+                    vectorType.getFieldID(0), value.getLoc());
+      });
+}
+
+/// Analyze a connect or partial connect of one (possibly aggregate) value to
+/// another. Each drive involving a `ResetType` is recorded.
+void InferResetsPass::traceResets(FIRRTLType dstType, Value dst, unsigned dstID,
+                                  FIRRTLType srcType, Value src, unsigned srcID,
+                                  Location loc) {
+  if (auto dstBundle = dstType.dyn_cast<BundleType>()) {
+    auto srcBundle = srcType.cast<BundleType>();
+    for (unsigned dstIdx = 0, e = dstBundle.getNumElements(); dstIdx < e;
+         ++dstIdx) {
+      auto dstField = dstBundle.getElements()[dstIdx].name.getValue();
+      auto srcIdx = srcBundle.getElementIndex(dstField);
+      if (!srcIdx)
+        continue;
+      auto &dstElt = dstBundle.getElements()[dstIdx];
+      auto &srcElt = srcBundle.getElements()[*srcIdx];
+      if (dstElt.isFlip) {
+        traceResets(srcElt.type, src, srcID + srcBundle.getFieldID(*srcIdx),
+                    dstElt.type, dst, dstID + dstBundle.getFieldID(dstIdx),
+                    loc);
+      } else {
+        traceResets(dstElt.type, dst, dstID + dstBundle.getFieldID(dstIdx),
+                    srcElt.type, src, srcID + srcBundle.getFieldID(*srcIdx),
+                    loc);
+      }
+    }
+    return;
+  }
+
+  if (auto dstVector = dstType.dyn_cast<FVectorType>()) {
+    auto srcVector = srcType.cast<FVectorType>();
+    auto srcElType = srcVector.getElementType();
+    auto dstElType = dstVector.getElementType();
+    // Collapse all elements into one shared element. See comment in traceResets
+    // above for some context.
+    traceResets(dstElType, dst, dstID + dstVector.getFieldID(0), srcElType, src,
+                srcID + srcVector.getFieldID(0), loc);
+    return;
+  }
+
+  if (dstType.isGround()) {
+    if (dstType.isa<ResetType>() || srcType.isa<ResetType>()) {
+      FieldRef dstField(dst, dstID);
+      FieldRef srcField(src, srcID);
+      LLVM_DEBUG(llvm::dbgs() << "Visiting driver '" << getFieldName(dstField)
+                              << "' = '" << getFieldName(srcField) << "' ("
+                              << dstType << " = " << srcType << ")\n");
+
+      // Determine the leaders for the dst and src reset networks before we make
+      // the connection. This will allow us to later detect if dst got merged
+      // into src, or src into dst.
+      ResetSignal dstLeader =
+          *resetClasses.findLeader(resetClasses.insert({dstField, dstType}));
+      ResetSignal srcLeader =
+          *resetClasses.findLeader(resetClasses.insert({srcField, srcType}));
+
+      // Unify the two reset networks.
+      ResetSignal unionLeader = *resetClasses.unionSets(dstLeader, srcLeader);
+      assert(unionLeader == dstLeader || unionLeader == srcLeader);
+
+      // If dst got merged into src, append dst's drives to src's, or vice
+      // versa.
+      auto &unionDrives = resetDrives[unionLeader];
+      if (dstLeader != srcLeader) {
+        if (unionLeader == dstLeader)
+          unionDrives.append(std::move(resetDrives[srcLeader]));
+        else
+          unionDrives.append(std::move(resetDrives[dstLeader]));
+      }
+
+      // Keep note of this drive so we can point the user at the right location
+      // in case something goes wrong.
+      unionDrives.push_back({{dstField, dstType}, {srcField, srcType}, loc});
+    }
+    return;
+  }
+
+  llvm_unreachable("unknown type");
+}
+
+//===----------------------------------------------------------------------===//
+// Reset Inference
+//===----------------------------------------------------------------------===//
+
+LogicalResult InferResetsPass::inferAndUpdateResets() {
+  LLVM_DEBUG(llvm::dbgs() << "\n===----- Infer reset types -----===\n\n");
+  for (auto it = resetClasses.begin(), end = resetClasses.end(); it != end;
+       ++it) {
+    if (!it->isLeader())
+      continue;
+    ResetNetwork net = llvm::make_range(resetClasses.member_begin(it),
+                                        resetClasses.member_end());
+
+    // Infer whether this should be a sync or async reset.
+    auto kind = inferReset(net);
+    if (failed(kind))
+      return failure();
+
+    // Update the types in the IR to match the inferred kind.
+    if (failed(updateReset(net, *kind)))
+      return failure();
+  }
+  return success();
+}
+
+FailureOr<ResetKind> InferResetsPass::inferReset(ResetNetwork net) {
+  LLVM_DEBUG(llvm::dbgs() << "Inferring reset network with "
+                          << std::distance(net.begin(), net.end())
+                          << " nodes\n");
+
+  // Go through the nodes and track the involved types.
+  unsigned asyncDrives = 0;
+  unsigned syncDrives = 0;
+  unsigned invalidDrives = 0;
+  for (ResetSignal signal : net) {
+    // Keep track of whether this signal contributes a vote for async or sync.
+    if (signal.type.isa<AsyncResetType>())
+      ++asyncDrives;
+    else if (signal.type.isa<UIntType>())
+      ++syncDrives;
+    else if (isa_and_nonnull<InvalidValueOp>(
+                 signal.field.getValue().getDefiningOp()))
+      ++invalidDrives;
+  }
+  LLVM_DEBUG(llvm::dbgs() << "- Found " << asyncDrives << " async, "
+                          << syncDrives << " sync, " << invalidDrives
+                          << " invalid drives\n");
+
+  // Handle the case where we have no votes for either kind.
+  if (asyncDrives == 0 && syncDrives == 0 && invalidDrives == 0) {
+    ResetSignal root = guessRoot(net);
+    mlir::emitError(root.field.getValue().getLoc())
+        << "reset network never driven with concrete type";
+    return failure();
+  }
+
+  // Handle the case where we have votes for both kinds.
+  if (asyncDrives > 0 && syncDrives > 0) {
+    ResetSignal root = guessRoot(net);
+    bool majorityAsync = asyncDrives >= syncDrives;
+    auto diag =
+        mlir::emitError(root.field.getValue().getLoc())
+        << "reset network simultaneously connected to async and sync resets";
+    diag.attachNote(root.field.getValue().getLoc())
+        << "did you intend for the reset to be "
+        << (majorityAsync ? "async?" : "sync?");
+    for (auto &drive : getResetDrives(net)) {
+      if ((drive.dst.type.isa<AsyncResetType>() && !majorityAsync) ||
+          (drive.src.type.isa<AsyncResetType>() && !majorityAsync) ||
+          (drive.dst.type.isa<UIntType>() && majorityAsync) ||
+          (drive.src.type.isa<UIntType>() && majorityAsync))
+        diag.attachNote(drive.loc)
+            << "offending " << (majorityAsync ? "sync" : "async")
+            << " drive here:";
+    }
+    return failure();
+  }
+
+  // At this point we know that the type of the reset is unambiguous. If there
+  // are any votes for async, we make the reset async. Otherwise we make it
+  // sync.
+  auto kind = (asyncDrives ? ResetKind::Async : ResetKind::Sync);
+  LLVM_DEBUG(llvm::dbgs() << "- Inferred as " << kind << "\n");
+  return kind;
+}
+
+//===----------------------------------------------------------------------===//
+// Reset Updating
+//===----------------------------------------------------------------------===//
+
+LogicalResult InferResetsPass::updateReset(ResetNetwork net, ResetKind kind) {
+  LLVM_DEBUG(llvm::dbgs() << "Updating reset network with "
+                          << std::distance(net.begin(), net.end())
+                          << " nodes to " << kind << "\n");
+
+  // Determine the final type the reset should have.
+  FIRRTLType resetType;
+  if (kind == ResetKind::Async)
+    resetType = AsyncResetType::get(&getContext());
+  else
+    resetType = UIntType::get(&getContext(), 1);
+
+  // Update all those values in the network that cannot be inferred from
+  // operands. If we change the type of a module port (i.e. BlockArgument), add
+  // the module to a module worklist since we need to update its function type.
+  SmallSetVector<Operation *, 16> worklist;
+  SmallDenseSet<Operation *> moduleWorklist;
+  for (auto signal : net) {
+    Value value = signal.field.getValue();
+    if (!value.isa<BlockArgument>() &&
+        !isa_and_nonnull<WireOp, RegOp, RegResetOp, InstanceOp, InvalidValueOp>(
+            value.getDefiningOp()))
+      continue;
+    if (updateReset(signal.field, resetType)) {
+      for (auto user : value.getUsers())
+        worklist.insert(user);
+      if (auto blockArg = value.dyn_cast<BlockArgument>())
+        moduleWorklist.insert(blockArg.getOwner()->getParentOp());
+    }
+  }
+
+  // Process the owrklist of operations that have their type changed, pushing
+  // types down the SSA dataflow graph. This is important because we change the
+  // reset types in aggregates, and then need all the subindex, subfield, and
+  // subaccess operations to be updated as appropriate.
+  while (!worklist.empty()) {
+    auto op = dyn_cast_or_null<InferTypeOpInterface>(worklist.pop_back_val());
+    if (!op)
+      continue;
+
+    // Determine the new result types.
+    SmallVector<Type, 2> types;
+    if (failed(op.inferReturnTypes(op->getContext(), op->getLoc(),
+                                   op->getOperands(), op->getAttrDictionary(),
+                                   op->getRegions(), types)))
+      return failure();
+    assert(types.size() == op->getNumResults());
+
+    // Update the results and add the changed ones to the worklist.
+    for (auto it : llvm::zip(op->getResults(), types)) {
+      auto newType = std::get<1>(it);
+      if (std::get<0>(it).getType() == newType)
+        continue;
+      std::get<0>(it).setType(newType);
+      for (auto user : std::get<0>(it).getUsers())
+        worklist.insert(user);
+    }
+
+    LLVM_DEBUG(llvm::dbgs() << "- Inferred " << *op << "\n");
+  }
+
+  // Update module types based on the type of the block arguments.
+  for (auto *op : moduleWorklist) {
+    auto module = dyn_cast<FModuleOp>(op);
+    if (!module)
+      continue;
+
+    SmallVector<Type> argTypes;
+    argTypes.reserve(module.getArguments().size());
+    for (auto arg : module.getArguments())
+      argTypes.push_back(arg.getType());
+
+    auto type =
+        FunctionType::get(op->getContext(), argTypes, /*resultTypes*/ {});
+    module->setAttr(FModuleOp::getTypeAttrName(), TypeAttr::get(type));
+    LLVM_DEBUG(llvm::dbgs()
+               << "- Updated type of module '" << module.getName() << "'\n");
+  }
+
+  return success();
+}
+
+/// Update the type of a single field within a type.
+static FIRRTLType updateType(FIRRTLType oldType, unsigned fieldID,
+                             FIRRTLType fieldType) {
+  // If this is a ground type, simply replace it.
+  if (oldType.isGround()) {
+    assert(fieldID == 0);
+    return fieldType;
+  }
+
+  // If this is a bundle type, update the corresponding field.
+  if (auto bundleType = oldType.dyn_cast<BundleType>()) {
+    unsigned index = bundleType.getIndexForFieldID(fieldID);
+    SmallVector<BundleType::BundleElement> fields(
+        bundleType.getElements().begin(), bundleType.getElements().end());
+    fields[index].type = updateType(
+        fields[index].type, fieldID - bundleType.getFieldID(index), fieldType);
+    return BundleType::get(fields, oldType.getContext());
+  }
+
+  // If this is a vector type, update the element type.
+  if (auto vectorType = oldType.dyn_cast<FVectorType>()) {
+    unsigned index = vectorType.getIndexForFieldID(fieldID);
+    auto newType =
+        updateType(vectorType.getElementType(),
+                   fieldID - vectorType.getFieldID(index), fieldType);
+    return FVectorType::get(newType, vectorType.getNumElements());
+  }
+
+  llvm_unreachable("unknown aggregate type");
+  return oldType;
+}
+
+/// Update the reset type of a specific field.
+bool InferResetsPass::updateReset(FieldRef field, FIRRTLType resetType) {
+  // Compute the updated type.
+  auto oldType = field.getValue().getType().cast<FIRRTLType>();
+  auto newType = updateType(oldType, field.getFieldID(), resetType);
+
+  // Update the type if necessary.
+  if (oldType == newType)
+    return false;
+  LLVM_DEBUG(llvm::dbgs() << "- Updating '" << getFieldName(field) << "' from "
+                          << oldType << " to " << newType << "\n");
+  field.getValue().setType(newType);
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
+// Reset Annotations
+//===----------------------------------------------------------------------===//
+
+/// Annotation that marks a reset (port or wire) and domain.
+static constexpr const char *resetAnno =
+    "sifive.enterprise.firrtl.FullAsyncResetAnnotation";
+
+/// Annotation that marks a module as not belonging to any reset domain.
+static constexpr const char *ignoreAnno =
+    "sifive.enterprise.firrtl.IgnoreFullAsyncResetAnnotation";
+
+LogicalResult InferResetsPass::collectAnnos(CircuitOp circuit) {
+  LLVM_DEBUG(
+      llvm::dbgs() << "\n===----- Gather async reset annotations -----===\n\n");
+  circuit.walk<WalkOrder::PreOrder>([&](FModuleOp module) {
+    if (failed(collectAnnos(module)))
+      return WalkResult::interrupt();
+    return WalkResult::skip();
+  });
+  return success();
+}
+
+LogicalResult InferResetsPass::collectAnnos(FModuleOp module) {
+  bool anyFailed = false;
+  SmallSetVector<std::pair<Annotation, Location>, 4> conflictingAnnos;
+
+  // Consume a possible "ignore" annotation on the module itself, which
+  // explicitly assigns it no reset domain.
+  bool ignore = false;
+  AnnotationSet moduleAnnos(module);
+  if (!moduleAnnos.empty()) {
+    moduleAnnos.removeAnnotations([&](Annotation anno) {
+      if (anno.isClass(ignoreAnno)) {
+        ignore = true;
+        conflictingAnnos.insert({anno, module.getLoc()});
+        return true;
+      }
+      if (anno.isClass(resetAnno)) {
+        anyFailed = true;
+        module.emitError("'FullAsyncResetAnnotation' cannot target module; "
+                         "must target port or wire/node instead");
+        return true;
+      }
+      return false;
+    });
+    moduleAnnos.applyToOperation(module);
+  }
+  if (anyFailed)
+    return failure();
+
+  // Consume any reset annotations on module ports.
+  Value reset;
+  AnnotationSet::removePortAnnotations(module, [&](unsigned argNum,
+                                                   Annotation anno) {
+    Value arg = module.getArgument(argNum);
+    if (anno.isClass(resetAnno)) {
+      reset = arg;
+      conflictingAnnos.insert({anno, reset.getLoc()});
+      return true;
+    }
+    if (anno.isClass(ignoreAnno)) {
+      anyFailed = true;
+      mlir::emitError(arg.getLoc(),
+                      "'IgnoreFullAsyncResetAnnotation' cannot target port; "
+                      "must target module instead");
+      return true;
+    }
+    return false;
+  });
+  if (anyFailed)
+    return failure();
+
+  // Consume any reset annotations on wires in the module body.
+  module.walk([&](Operation *op) {
+    AnnotationSet::removeAnnotations(op, [&](Annotation anno) {
+      // Reset annotations must target wire/node ops.
+      if (!isa<WireOp, NodeOp>(op)) {
+        if (anno.isClass(resetAnno, ignoreAnno)) {
+          anyFailed = true;
+          op->emitError(
+              "reset annotations must target module, port, or wire/node");
+          return true;
+        }
+        return false;
+      }
+
+      // At this point we know that we have a WireOp/NodeOp. Process the reset
+      // annotations.
+      if (anno.isClass(resetAnno)) {
+        reset = op->getResult(0);
+        conflictingAnnos.insert({anno, reset.getLoc()});
+        return true;
+      }
+      if (anno.isClass(ignoreAnno)) {
+        anyFailed = true;
+        op->emitError(
+            "'IgnoreFullAsyncResetAnnotation' cannot target wire/node; must "
+            "target module instead");
+        return true;
+      }
+      return false;
+    });
+  });
+  if (anyFailed)
+    return failure();
+
+  // If we have found no annotations, there is nothing to do. We just leave this
+  // module unannotated, which will cause it to inherit a reset domain from its
+  // instantiation sites.
+  if (!ignore && !reset) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "No reset annotation for " << module.getName() << "\n");
+    return success();
+  }
+
+  // If we have found multiple annotations, emit an error and abort.
+  if (conflictingAnnos.size() > 1) {
+    auto diag = module.emitError("multiple reset annotations on module '")
+                << module.getName() << "'";
+    for (auto &annoAndLoc : conflictingAnnos)
+      diag.attachNote(annoAndLoc.second)
+          << "conflicting " << annoAndLoc.first.getClassAttr() << ":";
+    return failure();
+  }
+
+  // Dump some information in debug builds.
+  LLVM_DEBUG({
+    llvm::dbgs() << "Annotated reset for " << module.getName() << ": ";
+    if (ignore)
+      llvm::dbgs() << "no domain\n";
+    else if (auto arg = reset.dyn_cast<BlockArgument>())
+      llvm::dbgs() << "port " << getModulePortName(module, arg.getArgNumber())
+                   << "\n";
+    else
+      llvm::dbgs() << "wire "
+                   << reset.getDefiningOp()->getAttrOfType<StringAttr>("name")
+                   << "\n";
+  });
+
+  // Store the annotated reset for this module.
+  assert(ignore || reset);
+  annotatedResets.insert({module, reset});
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// Domain Construction
+//===----------------------------------------------------------------------===//
+
+/// Gather the reset domains present in a circuit. This traverses the instance
+/// hierarchy of the design, making instances either live in a new reset domain
+/// if so annotated, or inherit their parent's domain. This can go wrong in some
+/// cases, mainly when a module is instantiated multiple times within different
+/// reset domains.
+LogicalResult InferResetsPass::buildDomains(CircuitOp circuit) {
+  LLVM_DEBUG(
+      llvm::dbgs() << "\n===----- Build async reset domains -----===\n\n");
+
+  // Gather the domains.
+  auto instGraph = getAnalysis<InstanceGraph>();
+  auto module = dyn_cast<FModuleOp>(instGraph.getTopLevelNode()->getModule());
+  if (!module) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "Skipping circuit because main module is no `firrtl.module`");
+    return success();
+  }
+  buildDomains(module, InstancePath{}, Value{}, instGraph);
+
+  // Report any domain conflicts among the modules.
+  bool anyFailed = false;
+  for (auto &it : domains) {
+    auto module = cast<FModuleOp>(it.first);
+    auto &domainConflicts = it.second;
+    if (domainConflicts.size() <= 1)
+      continue;
+
+    anyFailed = true;
+    SmallDenseSet<Value> printedDomainResets;
+    auto diag = module.emitError("module '")
+                << module.getName()
+                << "' instantiated in different reset domains";
+    for (auto &it : domainConflicts) {
+      ResetDomain &domain = it.first;
+      InstancePathRef path = it.second;
+      auto inst = path.back();
+      auto loc = path.empty() ? module.getLoc() : inst.getLoc();
+      auto &note = diag.attachNote(loc);
+
+      // Describe the instance itself.
+      if (path.empty())
+        note << "root instance";
+      else {
+        note << "instance '";
+        llvm::interleave(
+            path, [&](InstanceOp inst) { note << inst.name(); },
+            [&]() { note << "/"; });
+        note << "'";
+      }
+
+      // Describe the reset domain the instance is in.
+      note << " is in";
+      if (domain.reset) {
+        auto nameAndModule = getResetNameAndModule(domain.reset);
+        note << " reset domain rooted at '" << nameAndModule.first.getValue()
+             << "' of module '" << nameAndModule.second.getName() << "'";
+
+        // Show where the domain reset is declared (once per reset).
+        if (printedDomainResets.insert(domain.reset).second) {
+          diag.attachNote(domain.reset.getLoc())
+              << "reset domain '" << nameAndModule.first.getValue()
+              << "' of module '" << nameAndModule.second.getName()
+              << "' declared here:";
+        }
+      } else
+        note << " no reset domain";
+    }
+  }
+  return failure(anyFailed);
+}
+
+void InferResetsPass::buildDomains(FModuleOp module,
+                                   const InstancePath &instPath,
+                                   Value parentReset, InstanceGraph &instGraph,
+                                   unsigned indent) {
+  LLVM_DEBUG(llvm::dbgs().indent(indent * 2)
+             << "Visiting " << getTail(instPath) << " (" << module.getName()
+             << ")\n");
+
+  // Assemble the domain for this module.
+  ResetDomain domain(parentReset);
+  auto it = annotatedResets.find(module);
+  if (it != annotatedResets.end()) {
+    domain.isTop = true;
+    domain.reset = it->second;
+  }
+
+  // Associate the domain with this module. If the module already has an
+  // associated domain, it must be identical. Otherwise we'll have to report the
+  // conflicting domains to the user.
+  auto &entries = domains[module];
+  if (llvm::all_of(entries,
+                   [&](const auto &entry) { return entry.first != domain; }))
+    entries.push_back({domain, instPath});
+
+  // Traverse the child instances.
+  InstancePath childPath = instPath;
+  for (auto record : instGraph[module]->instances()) {
+    auto submodule = dyn_cast<FModuleOp>(record->getTarget()->getModule());
+    if (!submodule)
+      continue;
+    childPath.push_back(record->getInstance());
+    buildDomains(submodule, childPath, domain.reset, instGraph, indent + 1);
+    childPath.pop_back();
+  }
+}
+
+/// Determine how the reset for each module shall be implemented.
+void InferResetsPass::determineImpl() {
+  LLVM_DEBUG(
+      llvm::dbgs() << "\n===----- Determine implementation -----===\n\n");
+  for (auto &it : domains) {
+    auto module = cast<FModuleOp>(it.first);
+    auto &domain = it.second.back().first;
+    determineImpl(module, domain);
+  }
+}
+
+/// Determine how the reset for a module shall be implemented. This function
+/// fills in the `existingValue`, `existingPort`, and `newPortName` fields of
+/// the given reset domain.
+///
+/// Generally it does the following:
+/// - If the domain has explicitly no reset ("ignore"), leaves everything empty.
+/// - If the domain is the place where the reset is defined ("top"), fills in
+///   the existing port/wire/node as reset.
+/// - If the module already has a port with the reset's name:
+///   - If the type is `asyncreset`, reuses that port.
+///   - Otherwise appends a `_N` suffix with increasing N to create a yet-unused
+///     port name, and marks that as to be created.
+/// - Otherwise indicates that a port with the reset's name should be created.
+///
+void InferResetsPass::determineImpl(FModuleOp module, ResetDomain &domain) {
+  if (!domain.reset)
+    return; // nothing to do if the module needs no reset
+  LLVM_DEBUG(llvm::dbgs() << "Planning reset for " << module.getName() << "\n");
+
+  // If this is the root of a reset domain, we don't need to add any ports
+  // and can just simply reuse the existing values.
+  if (domain.isTop) {
+    LLVM_DEBUG(llvm::dbgs() << "- Rooting at local value "
+                            << getResetName(domain.reset) << "\n");
+    domain.existingValue = domain.reset;
+    if (auto blockArg = domain.reset.dyn_cast<BlockArgument>())
+      domain.existingPort = blockArg.getArgNumber();
+    return;
+  }
+
+  // Otherwise, check if a port with this name and type already exists and
+  // reuse that where possible.
+  auto neededName = getResetName(domain.reset);
+  auto neededType = domain.reset.getType();
+  LLVM_DEBUG(llvm::dbgs() << "- Looking for existing port " << neededName
+                          << "\n");
+  auto portNames = getModulePortNames(module);
+  auto ports = llvm::zip(portNames, module.getArguments());
+  auto portIt = llvm::find_if(
+      ports, [&](auto port) { return std::get<0>(port) == neededName; });
+  if (portIt != ports.end() && std::get<1>(*portIt).getType() == neededType) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "- Reusing existing port " << neededName << "\n");
+    domain.existingValue = std::get<1>(*portIt);
+    domain.existingPort = std::distance(ports.begin(), portIt);
+    return;
+  }
+
+  // If we have found a port but the types don't match, pick a new name for
+  // the reset port.
+  //
+  // CAVEAT: The Scala FIRRTL compiler just throws an error in this case. This
+  // seems unnecessary though, since the compiler can just insert a new reset
+  // signal as needed.
+  if (portIt != ports.end()) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "- Existing " << neededName << " has incompatible type "
+               << std::get<1>(*portIt).getType() << "\n");
+    StringAttr newName;
+    unsigned suffix = 0;
+    do {
+      newName =
+          StringAttr::get(&getContext(), Twine(neededName.getValue()) +
+                                             Twine("_") + Twine(suffix++));
+    } while (llvm::is_contained(portNames, newName));
+    LLVM_DEBUG(llvm::dbgs()
+               << "- Creating uniquified port " << newName << "\n");
+    domain.newPortName = newName;
+    return;
+  }
+
+  // At this point we know that there is no such port, and we can safely
+  // create one as needed.
+  LLVM_DEBUG(llvm::dbgs() << "- Creating new port " << neededName << "\n");
+  domain.newPortName = neededName;
+}
+
+//===----------------------------------------------------------------------===//
+// Async Reset Implementation
+//===----------------------------------------------------------------------===//
+
+/// Implement the async resets gathered in the pass' `domains` map.
+LogicalResult InferResetsPass::implementAsyncReset() {
+  LLVM_DEBUG(llvm::dbgs() << "\n===----- Implement async resets -----===\n\n");
+  for (auto &it : domains)
+    if (failed(implementAsyncReset(cast<FModuleOp>(it.first),
+                                   it.second.back().first)))
+      return failure();
+  return success();
+}
+
+/// Implement the async resets for a specific module.
+///
+/// This will add ports to the module as appropriate, update the register ops in
+/// the module, and update any instantiated submodules with their corresponding
+/// reset implementation details.
+LogicalResult InferResetsPass::implementAsyncReset(FModuleOp module,
+                                                   ResetDomain &domain) {
+  LLVM_DEBUG(llvm::dbgs() << "Implementing async reset for " << module.getName()
+                          << "\n");
+
+  // Nothing to do if the module was marked explicitly with no reset domain.
+  if (!domain.reset) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "- Skipping because module explicitly has no domain\n");
+    return success();
+  }
+
+  // If needed, add a reset port to the module.
+  Value actualReset = domain.existingValue;
+  if (domain.newPortName) {
+    ModulePortInfo portInfo{.name = domain.newPortName,
+                            .type = AsyncResetType::get(&getContext()),
+                            .direction = Direction::Input,
+                            .loc = domain.reset.getLoc()};
+    module.insertPorts({{0, portInfo}});
+    actualReset = module.getArgument(0);
+    LLVM_DEBUG(llvm::dbgs()
+               << "- Inserted port " << domain.newPortName << "\n");
+  }
+  assert(actualReset);
+  LLVM_DEBUG({
+    llvm::dbgs() << "- Using ";
+    if (auto blockArg = actualReset.dyn_cast<BlockArgument>())
+      llvm::dbgs() << "port #" << blockArg.getArgNumber() << " ";
+    else
+      llvm::dbgs() << "wire/node ";
+    llvm::dbgs() << getResetName(actualReset) << "\n";
+  });
+
+  // Gather a list of operations in the module that need to be updated with the
+  // new reset.
+  SmallVector<Operation *> opsToUpdate;
+  module.walk([&](Operation *op) {
+    if (isa<InstanceOp, RegOp, RegResetOp>(op))
+      opsToUpdate.push_back(op);
+  });
+
+  // Update the operations.
+  for (auto *op : opsToUpdate)
+    implementAsyncReset(op, module, actualReset);
+
+  return success();
+}
+
+/// Modify an operation in a module to implement an async reset for that module.
+void InferResetsPass::implementAsyncReset(Operation *op, FModuleOp module,
+                                          Value actualReset) {
+  ImplicitLocOpBuilder builder(op->getLoc(), op);
+
+  // Handle instances.
+  if (auto instOp = dyn_cast<InstanceOp>(op)) {
+    // Lookup the reset domain of the instantiated module. If there is no reset
+    // domain associated with that module, or the module is explicitly marked as
+    // being in no domain, simply skip.
+    auto refModule = dyn_cast<FModuleOp>(instOp.getReferencedModule());
+    if (!refModule)
+      return;
+    auto domainIt = domains.find(refModule);
+    if (domainIt == domains.end())
+      return;
+    auto &domain = domainIt->second.back().first;
+    if (!domain.reset)
+      return;
+    LLVM_DEBUG(llvm::dbgs() << "- Update instance '" << instOp.name() << "'\n");
+
+    // If needed, add a reset port to the instance.
+    Value instReset;
+    if (domain.newPortName) {
+      LLVM_DEBUG(llvm::dbgs() << "  - Adding new result as reset\n");
+
+      // Determine the new result types.
+      SmallVector<Type> resultTypes;
+      resultTypes.reserve(instOp.getNumResults() + 1);
+      resultTypes.push_back(actualReset.getType());
+      resultTypes.append(instOp.getResultTypes().begin(),
+                         instOp.getResultTypes().end());
+
+      // Create a new list of port annotations.
+      SmallVector<Attribute> newPortAnnos;
+      if (auto oldPortAnnos = instOp.portAnnotations()) {
+        newPortAnnos.reserve(oldPortAnnos.size() + 1);
+        newPortAnnos.push_back(builder.getArrayAttr({}));
+        newPortAnnos.append(oldPortAnnos.begin(), oldPortAnnos.end());
+      }
+      LLVM_DEBUG(llvm::dbgs()
+                 << "  - Result types: " << resultTypes.size() << "\n");
+      LLVM_DEBUG(llvm::dbgs()
+                 << "  - Port annos: " << newPortAnnos.size() << "\n");
+
+      // Create a new instance op with the reset inserted.
+      auto newInstOp = builder.create<InstanceOp>(
+          resultTypes, instOp.moduleName(), instOp.name(),
+          instOp.annotations().getValue(), newPortAnnos);
+      instReset = newInstOp.getResult(0);
+
+      // Update the uses over to the new instance and drop the old instance.
+      instOp.replaceAllUsesWith(newInstOp.getResults().drop_front());
+      instOp->erase();
+      instOp = newInstOp;
+    } else if (domain.existingPort.hasValue()) {
+      auto idx = domain.existingPort.getValue();
+      instReset = instOp.getResult(idx);
+      LLVM_DEBUG(llvm::dbgs() << "  - Using result #" << idx << " as reset\n");
+    }
+
+    // If there's no reset port on the instance to connect, we're done. This can
+    // happen if the instantiated module has a reset domain, but that domain is
+    // e.g. rooted at an internal wire.
+    if (!instReset)
+      return;
+
+    // Connect the instance's reset to the actual reset.
+    assert(instReset && actualReset);
+    builder.setInsertionPointAfter(instOp);
+    builder.create<ConnectOp>(instReset, actualReset);
+    return;
+  }
+
+  // Handle reset-less registers.
+  if (auto regOp = dyn_cast<RegOp>(op)) {
+    LLVM_DEBUG(llvm::dbgs() << "- Adding async reset to " << regOp << "\n");
+    auto zero = createZeroValue(builder, regOp.getType());
+    auto newRegOp = builder.create<RegResetOp>(
+        regOp.getType(), regOp.clockVal(), actualReset, zero, regOp.nameAttr(),
+        regOp.annotations());
+    regOp.getResult().replaceAllUsesWith(newRegOp);
+    regOp->erase();
+    return;
+  }
+
+  // Handle registers with reset.
+  if (auto regOp = dyn_cast<RegResetOp>(op)) {
+    // If the register already has an async reset, leave it untouched.
+    if (regOp.resetSignal().getType().isa<AsyncResetType>()) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "- Skipping (has async reset) " << regOp << "\n");
+      // The following performs the logic of `CheckResets` in the original Scala
+      // source code.
+      if (failed(regOp.verify()))
+        signalPassFailure();
+      return;
+    }
+    LLVM_DEBUG(llvm::dbgs() << "- Updating reset of " << regOp << "\n");
+
+    // If we arrive here, the register has a sync reset. In order to add an
+    // async reset, we have to move the sync reset into a mux in front of the
+    // register.
+    insertResetMux(builder, regOp, regOp.resetSignal(), regOp.resetValue());
+    builder.setInsertionPoint(regOp);
+
+    // Replace the existing reset with the async reset.
+    auto zero = createZeroValue(builder, regOp.getType());
+    regOp.resetSignalMutable().assign(actualReset);
+    regOp.resetValueMutable().assign(zero);
+  }
+}

--- a/test/Dialect/FIRRTL/infer-resets-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-resets-errors.mlir
@@ -1,0 +1,225 @@
+// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-infer-resets)' --verify-diagnostics --split-input-file %s
+
+// Tests extracted from:
+// - github.com/chipsalliance/firrtl:
+//   - test/scala/firrtlTests/InferResetsSpec.scala
+// - github.com/sifive/$internal:
+//   - test/scala/firrtl/FullAsyncResetTransform.scala
+
+
+//===----------------------------------------------------------------------===//
+// Reset Inference
+//===----------------------------------------------------------------------===//
+
+
+// Should NOT allow last connect semantics to pick the right type for Reset
+firrtl.circuit "top" {
+  // expected-error @+2 {{reset network simultaneously connected to async and sync resets}}
+  // expected-note @+1 {{did you intend for the reset to be async?}}
+  firrtl.module @top(in %reset0: !firrtl.asyncreset, in %reset1: !firrtl.uint<1>, out %out: !firrtl.reset) {
+    %w0 = firrtl.wire : !firrtl.reset
+    %w1 = firrtl.wire : !firrtl.reset
+    firrtl.connect %w0, %reset0 : !firrtl.reset, !firrtl.asyncreset
+    // expected-note @+1 {{offending sync drive here:}}
+    firrtl.connect %w1, %reset1 : !firrtl.reset, !firrtl.uint<1>
+    firrtl.connect %out, %w0 : !firrtl.reset, !firrtl.reset
+    firrtl.connect %out, %w1 : !firrtl.reset, !firrtl.reset
+  }
+}
+
+// -----
+// Should NOT support last connect semantics across whens
+firrtl.circuit "top" {
+  // expected-error @+2 {{reset network simultaneously connected to async and sync resets}}
+  // expected-note @+1 {{did you intend for the reset to be async?}}
+  firrtl.module @top(in %reset0: !firrtl.asyncreset, in %reset1: !firrtl.asyncreset, in %reset2: !firrtl.uint<1>, in %en: !firrtl.uint<1>, out %out: !firrtl.reset) {
+    %w0 = firrtl.wire : !firrtl.reset
+    %w1 = firrtl.wire : !firrtl.reset
+    %w2 = firrtl.wire : !firrtl.reset
+    firrtl.connect %w0, %reset0 : !firrtl.reset, !firrtl.asyncreset
+    firrtl.connect %w1, %reset1 : !firrtl.reset, !firrtl.asyncreset
+    // expected-note @+1 {{offending sync drive here:}}
+    firrtl.connect %w2, %reset2 : !firrtl.reset, !firrtl.uint<1>
+    firrtl.connect %out, %w2 : !firrtl.reset, !firrtl.reset
+    firrtl.when %en  {
+      firrtl.connect %out, %w0 : !firrtl.reset, !firrtl.reset
+    } else  {
+      firrtl.connect %out, %w1 : !firrtl.reset, !firrtl.reset
+    }
+  }
+}
+
+// -----
+// Should not allow different Reset Types to drive a single Reset
+firrtl.circuit "top" {
+  // expected-error @+2 {{reset network simultaneously connected to async and sync resets}}
+  // expected-note @+1 {{did you intend for the reset to be async?}}
+  firrtl.module @top(in %reset0: !firrtl.asyncreset, in %reset1: !firrtl.uint<1>, in %en: !firrtl.uint<1>, out %out: !firrtl.reset) {
+    %w1 = firrtl.wire : !firrtl.reset
+    %w2 = firrtl.wire : !firrtl.reset
+    firrtl.connect %w1, %reset0 : !firrtl.reset, !firrtl.asyncreset
+    // expected-note @+1 {{offending sync drive here:}}
+    firrtl.connect %w2, %reset1 : !firrtl.reset, !firrtl.uint<1>
+    firrtl.connect %out, %w1 : !firrtl.reset, !firrtl.reset
+    firrtl.when %en  {
+      firrtl.connect %out, %w2 : !firrtl.reset, !firrtl.reset
+    }
+  }
+}
+
+// -----
+// Should error if a ResetType driving UInt<1> infers to AsyncReset
+firrtl.circuit "top" {
+  // expected-error @+2 {{reset network simultaneously connected to async and sync resets}}
+  // expected-note @+1 {{did you intend for the reset to be async?}}
+  firrtl.module @top(in %in: !firrtl.asyncreset, out %out: !firrtl.uint<1>) {
+    %w = firrtl.wire  : !firrtl.reset
+    firrtl.connect %w, %in : !firrtl.reset, !firrtl.asyncreset
+    // expected-note @+1 {{offending sync drive here:}}
+    firrtl.connect %out, %w : !firrtl.uint<1>, !firrtl.reset
+  }
+}
+
+// -----
+// Should error if a ResetType driving AsyncReset infers to UInt<1>
+firrtl.circuit "top"   {
+  // expected-error @+2 {{reset network simultaneously connected to async and sync resets}}
+  // expected-note @+1 {{did you intend for the reset to be async?}}
+  firrtl.module @top(in %in: !firrtl.uint<1>, out %out: !firrtl.asyncreset) {
+    %w = firrtl.wire  : !firrtl.reset
+    // expected-note @+1 {{offending sync drive here:}}
+    firrtl.connect %w, %in : !firrtl.reset, !firrtl.uint<1>
+    firrtl.connect %out, %w : !firrtl.asyncreset, !firrtl.reset
+  }
+}
+
+// -----
+// Should not allow ResetType as an Input
+firrtl.circuit "top" {
+  // expected-error @+1 {{reset network never driven with concrete type}}
+  firrtl.module @top(in %in: !firrtl.bundle<foo: reset>, out %out: !firrtl.reset) {
+    %0 = firrtl.subfield %in(0) : (!firrtl.bundle<foo: reset>) -> !firrtl.reset
+    firrtl.connect %out, %0 : !firrtl.reset, !firrtl.reset
+  }
+}
+
+// -----
+// Should not allow ResetType as an ExtModule output
+firrtl.circuit "top" {
+  firrtl.extmodule @ext(out %out: !firrtl.bundle<foo: reset>)
+  firrtl.module @top(out %out: !firrtl.reset) {
+    // expected-error @+1 {{reset network never driven with concrete type}}
+    %e_out = firrtl.instance @ext  {name = "e"} : !firrtl.bundle<foo: reset>
+    %0 = firrtl.subfield %e_out(0) : (!firrtl.bundle<foo: reset>) -> !firrtl.reset
+    firrtl.connect %out, %0 : !firrtl.reset, !firrtl.reset
+  }
+}
+
+// -----
+// Should not allow Vecs to infer different Reset Types
+firrtl.circuit "top" {
+  // expected-error @+2 {{reset network simultaneously connected to async and sync resets}}
+  // expected-note @+1 {{did you intend for the reset to be async?}}
+  firrtl.module @top(in %reset0: !firrtl.asyncreset, in %reset1: !firrtl.uint<1>, out %out: !firrtl.vector<reset, 2>) {
+    %0 = firrtl.subindex %out[0] : !firrtl.vector<reset, 2>
+    %1 = firrtl.subindex %out[1] : !firrtl.vector<reset, 2>
+    firrtl.connect %0, %reset0 : !firrtl.reset, !firrtl.asyncreset
+    // expected-note @+1 {{offending sync drive here:}}
+    firrtl.connect %1, %reset1 : !firrtl.reset, !firrtl.uint<1>
+  }
+}
+
+// -----
+// Should not allow an invalidated Wire to drive both a UInt<1> and an AsyncReset
+firrtl.circuit "top" {
+  // expected-error @+2 {{reset network simultaneously connected to async and sync resets}}
+  // expected-note @+1 {{did you intend for the reset to be async?}}
+  firrtl.module @top(in %in0: !firrtl.asyncreset, in %in1: !firrtl.uint<1>, out %out0: !firrtl.reset, out %out1: !firrtl.reset) {
+    %w = firrtl.wire  : !firrtl.reset
+    %invalid_reset = firrtl.invalidvalue : !firrtl.reset
+    firrtl.connect %w, %invalid_reset : !firrtl.reset, !firrtl.reset
+    firrtl.connect %out0, %w : !firrtl.reset, !firrtl.reset
+    firrtl.connect %out1, %w : !firrtl.reset, !firrtl.reset
+    firrtl.connect %out0, %in0 : !firrtl.reset, !firrtl.asyncreset
+    // expected-note @+1 {{offending sync drive here:}}
+    firrtl.connect %out1, %in1 : !firrtl.reset, !firrtl.uint<1>
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Full Async Reset
+//===----------------------------------------------------------------------===//
+
+// -----
+// Reset annotation cannot target module
+firrtl.circuit "top" {
+  // expected-error @+1 {{FullAsyncResetAnnotation' cannot target module; must target port or wire/node instead}}
+  firrtl.module @top() attributes {annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]} {
+  }
+}
+
+// -----
+// Ignore reset annotation cannot target port
+firrtl.circuit "top" {
+  // expected-error @+1 {{IgnoreFullAsyncResetAnnotation' cannot target port; must target module instead}}
+  firrtl.module @top(in %reset: !firrtl.asyncreset {firrtl.annotations = [{class = "sifive.enterprise.firrtl.IgnoreFullAsyncResetAnnotation"}]}) {
+  }
+}
+
+// -----
+// Ignore reset annotation cannot target wire/node
+firrtl.circuit "top" {
+  firrtl.module @top() {
+    // expected-error @+1 {{IgnoreFullAsyncResetAnnotation' cannot target wire/node; must target module instead}}
+    %0 = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.IgnoreFullAsyncResetAnnotation"}]} : !firrtl.asyncreset
+    // expected-error @+1 {{IgnoreFullAsyncResetAnnotation' cannot target wire/node; must target module instead}}
+    %1 = firrtl.node %0 {annotations = [{class = "sifive.enterprise.firrtl.IgnoreFullAsyncResetAnnotation"}]} : !firrtl.asyncreset
+    // expected-error @+1 {{reset annotations must target module, port, or wire/node}}
+    %2 = firrtl.asUInt %0 {annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]} : (!firrtl.asyncreset) -> !firrtl.uint<1>
+    // expected-error @+1 {{reset annotations must target module, port, or wire/node}}
+    %3 = firrtl.asUInt %0 {annotations = [{class = "sifive.enterprise.firrtl.IgnoreFullAsyncResetAnnotation"}]} : (!firrtl.asyncreset) -> !firrtl.uint<1>
+  }
+}
+
+// -----
+// Cannot have multiple reset annotations on a module
+firrtl.circuit "top" {
+  // expected-error @+2 {{multiple reset annotations on module 'top'}}
+  // expected-note @+1 {{conflicting "sifive.enterprise.firrtl.FullAsyncResetAnnotation":}}
+  firrtl.module @top(in %outerReset: !firrtl.asyncreset {firrtl.annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]}) {
+    // expected-note @+1 {{conflicting "sifive.enterprise.firrtl.FullAsyncResetAnnotation":}}
+    %innerReset = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]} : !firrtl.asyncreset
+    // expected-note @+1 {{conflicting "sifive.enterprise.firrtl.FullAsyncResetAnnotation":}}
+    %anotherReset = firrtl.node %innerReset {annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]} : !firrtl.asyncreset
+  }
+}
+
+// -----
+// Multiple instances of same module cannot live in different reset domains
+firrtl.circuit "Top" {
+  // expected-error @+1 {{module 'Foo' instantiated in different reset domains}}
+  firrtl.module @Foo(in %clock: !firrtl.clock) {
+    %reg = firrtl.reg %clock : !firrtl.uint<8>
+  }
+  // expected-note @+1 {{reset domain 'otherReset' of module 'Child' declared here:}}
+  firrtl.module @Child(in %clock: !firrtl.clock, in %otherReset: !firrtl.asyncreset {firrtl.annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]}) {
+    // expected-note @+1 {{instance 'child/inst' is in reset domain rooted at 'otherReset' of module 'Child'}}
+    %inst_clock = firrtl.instance @Foo {name = "inst"} : !firrtl.clock
+    firrtl.connect %inst_clock, %clock : !firrtl.clock, !firrtl.clock
+  }
+  firrtl.module @Other(in %clock: !firrtl.clock) attributes {annotations = [{class = "sifive.enterprise.firrtl.IgnoreFullAsyncResetAnnotation"}]} {
+    // expected-note @+1 {{instance 'other/inst' is in no reset domain}}
+    %inst_clock = firrtl.instance @Foo {name = "inst"} : !firrtl.clock
+    firrtl.connect %inst_clock, %clock : !firrtl.clock, !firrtl.clock
+  }
+  // expected-note @+1 {{reset domain 'reset' of module 'Top' declared here:}}
+  firrtl.module @Top(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset {firrtl.annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]}) {
+    %child_clock, %child_otherReset = firrtl.instance @Child {name = "child"} : !firrtl.clock, !firrtl.asyncreset
+    %other_clock = firrtl.instance @Other {name = "other"} : !firrtl.clock
+    // expected-note @+1 {{instance 'foo' is in reset domain rooted at 'reset' of module 'Top'}}
+    %foo_clock = firrtl.instance @Foo {name = "foo"} : !firrtl.clock
+    firrtl.connect %child_clock, %clock : !firrtl.clock, !firrtl.clock
+    firrtl.connect %other_clock, %clock : !firrtl.clock, !firrtl.clock
+    firrtl.connect %foo_clock, %clock : !firrtl.clock, !firrtl.clock
+  }
+}

--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -1,0 +1,508 @@
+// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-infer-resets)' --verify-diagnostics --split-input-file %s | FileCheck %s
+
+// Tests extracted from:
+// - github.com/chipsalliance/firrtl:
+//   - test/scala/firrtlTests/InferResetsSpec.scala
+// - github.com/sifive/$internal:
+//   - test/scala/firrtl/FullAsyncResetTransform.scala
+
+firrtl.circuit "Foo" {
+firrtl.module @Foo() {}
+
+
+//===----------------------------------------------------------------------===//
+// Reset Inference
+//===----------------------------------------------------------------------===//
+
+// Provoke two existing reset networks being merged.
+// CHECK-LABEL: firrtl.module @MergeNetsChild1
+// CHECK-SAME: in %reset: !firrtl.asyncreset
+firrtl.module @MergeNetsChild1(in %reset: !firrtl.reset) {
+  // CHECK: %localReset = firrtl.wire : !firrtl.asyncreset
+  %localReset = firrtl.wire : !firrtl.reset
+  firrtl.connect %localReset, %reset : !firrtl.reset, !firrtl.reset
+}
+// CHECK-LABEL: firrtl.module @MergeNetsChild2
+// CHECK-SAME: in %reset: !firrtl.asyncreset
+firrtl.module @MergeNetsChild2(in %reset: !firrtl.reset) {
+  // CHECK: %localReset = firrtl.wire : !firrtl.asyncreset
+  %localReset = firrtl.wire : !firrtl.reset
+  firrtl.connect %localReset, %reset : !firrtl.reset, !firrtl.reset
+}
+// CHECK-LABEL: firrtl.module @MergeNetsTop
+firrtl.module @MergeNetsTop(in %reset: !firrtl.asyncreset) {
+  // CHECK: %localReset = firrtl.wire : !firrtl.asyncreset
+  %localReset = firrtl.wire : !firrtl.reset
+  firrtl.connect %localReset, %reset : !firrtl.reset, !firrtl.asyncreset
+  // CHECK: %c1_reset = firrtl.instance @MergeNetsChild1 {{.*}} : !firrtl.asyncreset
+  // CHECK: %c2_reset = firrtl.instance @MergeNetsChild2 {{.*}} : !firrtl.asyncreset
+  %c1_reset = firrtl.instance @MergeNetsChild1  {name = "c1"} : !firrtl.reset
+  %c2_reset = firrtl.instance @MergeNetsChild2  {name = "c2"} : !firrtl.reset
+  firrtl.connect %c1_reset, %localReset : !firrtl.reset, !firrtl.reset
+  firrtl.connect %c2_reset, %localReset : !firrtl.reset, !firrtl.reset
+}
+
+// Should support casting to other types
+// CHECK-LABEL: firrtl.module @CastingToOtherTypes
+firrtl.module @CastingToOtherTypes(in %a: !firrtl.uint<1>, out %v: !firrtl.uint<1>, out %w: !firrtl.sint<1>, out %x: !firrtl.clock, out %y: !firrtl.asyncreset) {
+  // CHECK: %r = firrtl.wire : !firrtl.uint<1>
+  %r = firrtl.wire : !firrtl.reset
+  %0 = firrtl.asUInt %r : (!firrtl.reset) -> !firrtl.uint<1>
+  %1 = firrtl.asSInt %r : (!firrtl.reset) -> !firrtl.sint<1>
+  %2 = firrtl.asClock %r : (!firrtl.reset) -> !firrtl.clock
+  %3 = firrtl.asAsyncReset %r : (!firrtl.reset) -> !firrtl.asyncreset
+  firrtl.connect %r, %a : !firrtl.reset, !firrtl.uint<1>
+  firrtl.connect %v, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %w, %1 : !firrtl.sint<1>, !firrtl.sint<1>
+  firrtl.connect %x, %2 : !firrtl.clock, !firrtl.clock
+  firrtl.connect %y, %3 : !firrtl.asyncreset, !firrtl.asyncreset
+}
+
+// Should work across Module boundaries
+// CHECK-LABEL: firrtl.module @ModuleBoundariesChild
+// CHECK-SAME: in %childReset: !firrtl.uint<1>
+firrtl.module @ModuleBoundariesChild(in %clock: !firrtl.clock, in %childReset: !firrtl.reset, in %x: !firrtl.uint<8>, out %z: !firrtl.uint<8>) {
+  %c123_ui = firrtl.constant 123 : !firrtl.uint
+  // CHECK: %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.uint<1>, !firrtl.uint, !firrtl.uint<8>
+  %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.reset, !firrtl.uint, !firrtl.uint<8>
+  firrtl.connect %r, %x : !firrtl.uint<8>, !firrtl.uint<8>
+  firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
+}
+// CHECK-LABEL: firrtl.module @ModuleBoundariesTop
+firrtl.module @ModuleBoundariesTop(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %x: !firrtl.uint<8>, out %z: !firrtl.uint<8>) {
+  // CHECK: {{.*}} = firrtl.instance @ModuleBoundariesChild {{.*}} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+  %c_clock, %c_childReset, %c_x, %c_z = firrtl.instance @ModuleBoundariesChild {name = "c"} : !firrtl.clock, !firrtl.reset, !firrtl.uint<8>, !firrtl.uint<8>
+  firrtl.connect %c_clock, %clock : !firrtl.clock, !firrtl.clock
+  firrtl.connect %c_childReset, %reset : !firrtl.reset, !firrtl.uint<1>
+  firrtl.connect %c_x, %x : !firrtl.uint<8>, !firrtl.uint<8>
+  firrtl.connect %z, %c_z : !firrtl.uint<8>, !firrtl.uint<8>
+}
+
+// Should work across multiple Module boundaries
+// CHECK-LABEL: firrtl.module @MultipleModuleBoundariesChild
+// CHECK-SAME: in %resetIn: !firrtl.uint<1>
+// CHECK-SAME: out %resetOut: !firrtl.uint<1>
+firrtl.module @MultipleModuleBoundariesChild(in %resetIn: !firrtl.reset, out %resetOut: !firrtl.reset) {
+  firrtl.connect %resetOut, %resetIn : !firrtl.reset, !firrtl.reset
+}
+// CHECK-LABEL: firrtl.module @MultipleModuleBoundariesTop
+firrtl.module @MultipleModuleBoundariesTop(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %x: !firrtl.uint<8>, out %z: !firrtl.uint<8>) {
+  // CHECK: {{.*}} = firrtl.instance @MultipleModuleBoundariesChild {{.*}} : !firrtl.uint<1>, !firrtl.uint<1>
+  %c_resetIn, %c_resetOut = firrtl.instance @MultipleModuleBoundariesChild  {name = "c"} : !firrtl.reset, !firrtl.reset
+  firrtl.connect %c_resetIn, %reset : !firrtl.reset, !firrtl.uint<1>
+  %c123_ui = firrtl.constant 123 : !firrtl.uint
+  // CHECK: %r = firrtl.regreset %clock, %c_resetOut, %c123_ui : !firrtl.uint<1>, !firrtl.uint, !firrtl.uint<8>
+  %r = firrtl.regreset %clock, %c_resetOut, %c123_ui : !firrtl.reset, !firrtl.uint, !firrtl.uint<8>
+  firrtl.connect %r, %x : !firrtl.uint<8>, !firrtl.uint<8>
+  firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
+}
+
+// Should work in nested and flipped aggregates with regular and partial connect
+// CHECK-LABEL: firrtl.module @NestedAggregates
+// CHECK-SAME: out %buzz: !firrtl.bundle<foo flip: vector<bundle<a: asyncreset, c: uint<1>, b flip: asyncreset>, 2>, bar: vector<bundle<a: asyncreset, b flip: asyncreset, c: uint<8>>, 2>>
+firrtl.module @NestedAggregates(out %buzz: !firrtl.bundle<foo flip: vector<bundle<a: asyncreset, c: uint<1>, b flip: reset>, 2>, bar: vector<bundle<a: reset, b flip: asyncreset, c: uint<8>>, 2>>) {
+  %0 = firrtl.subfield %buzz(1) : (!firrtl.bundle<foo flip: vector<bundle<a: asyncreset, c: uint<1>, b flip: reset>, 2>, bar: vector<bundle<a: reset, b flip: asyncreset, c: uint<8>>, 2>>) -> !firrtl.vector<bundle<a: reset, b flip: asyncreset, c: uint<8>>, 2>
+  %1 = firrtl.subfield %buzz(0) : (!firrtl.bundle<foo flip: vector<bundle<a: asyncreset, c: uint<1>, b flip: reset>, 2>, bar: vector<bundle<a: reset, b flip: asyncreset, c: uint<8>>, 2>>) -> !firrtl.vector<bundle<a: asyncreset, c: uint<1>, b flip: reset>, 2>
+  // TODO: Enable the following once #1302 is fixed.
+  // firrtl.connect %0, %1 : !firrtl.vector<bundle<a: reset, b flip: asyncreset, c: uint<8>>, 2>, !firrtl.vector<bundle<a: asyncreset, c: uint<1>, b flip: reset>, 2>
+  firrtl.partialconnect %0, %1 : !firrtl.vector<bundle<a: reset, b flip: asyncreset, c: uint<8>>, 2>, !firrtl.vector<bundle<a: asyncreset, c: uint<1>, b flip: reset>, 2>
+}
+
+// Should not crash if a ResetType has no drivers
+// CHECK-LABEL: firrtl.module @DontCrashIfNoDrivers
+// CHECK-SAME: out %out: !firrtl.uint<1>
+firrtl.module @DontCrashIfNoDrivers(out %out: !firrtl.reset) {
+  %c1_ui = firrtl.constant 1 : !firrtl.uint
+  %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+  // CHECK: %w = firrtl.wire : !firrtl.uint<1>
+  %w = firrtl.wire : !firrtl.reset
+  firrtl.connect %out, %w : !firrtl.reset, !firrtl.reset
+  // TODO: Enable the following once #1303 is fixed.
+  // firrtl.connect %out, %c1_ui : !firrtl.reset, !firrtl.uint
+  firrtl.connect %out, %c1_ui1 : !firrtl.reset, !firrtl.uint<1>
+}
+
+// Should allow concrete reset types to overrule invalidation
+// CHECK-LABEL: firrtl.module @ConcreteResetOverruleInvalid
+// CHECK-SAME: out %out: !firrtl.asyncreset
+firrtl.module @ConcreteResetOverruleInvalid(in %in: !firrtl.asyncreset, out %out: !firrtl.reset) {
+  // CHECK: %invalid_asyncreset = firrtl.invalidvalue : !firrtl.asyncreset
+  %invalid_reset = firrtl.invalidvalue : !firrtl.reset
+  firrtl.connect %out, %invalid_reset : !firrtl.reset, !firrtl.reset
+  firrtl.connect %out, %in : !firrtl.reset, !firrtl.asyncreset
+}
+
+// Should default to BoolType for Resets that are only invalidated
+// CHECK-LABEL: firrtl.module @DefaultToBool
+// CHECK-SAME: out %out: !firrtl.uint<1>
+firrtl.module @DefaultToBool(out %out: !firrtl.reset) {
+  // CHECK: %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
+  %invalid_reset = firrtl.invalidvalue : !firrtl.reset
+  firrtl.connect %out, %invalid_reset : !firrtl.reset, !firrtl.reset
+}
+
+// Should not error if component of ResetType is invalidated and connected to an AsyncResetType
+// CHECK-LABEL: firrtl.module @OverrideInvalidWithDifferentResetType
+// CHECK-SAME: out %out: !firrtl.asyncreset
+firrtl.module @OverrideInvalidWithDifferentResetType(in %cond: !firrtl.uint<1>, in %in: !firrtl.asyncreset, out %out: !firrtl.reset) {
+  // CHECK: %invalid_asyncreset = firrtl.invalidvalue : !firrtl.asyncreset
+  %invalid_reset = firrtl.invalidvalue : !firrtl.reset
+  firrtl.connect %out, %invalid_reset : !firrtl.reset, !firrtl.reset
+  firrtl.when %cond  {
+    firrtl.connect %out, %in : !firrtl.reset, !firrtl.asyncreset
+  }
+}
+
+// Should allow ResetType to drive AsyncResets or UInt<1>
+// CHECK-LABEL: firrtl.module @ResetDrivesAsyncResetOrBool1
+firrtl.module @ResetDrivesAsyncResetOrBool1(in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
+  // CHECK: %w = firrtl.wire : !firrtl.uint<1>
+  %w = firrtl.wire : !firrtl.reset
+  firrtl.connect %w, %in : !firrtl.reset, !firrtl.uint<1>
+  firrtl.connect %out, %w : !firrtl.uint<1>, !firrtl.reset
+}
+// CHECK-LABEL: firrtl.module @ResetDrivesAsyncResetOrBool2
+firrtl.module @ResetDrivesAsyncResetOrBool2(out %foo: !firrtl.bundle<a flip: uint<1>>, in %bar: !firrtl.bundle<a flip: uint<1>>) {
+  // CHECK: %w = firrtl.wire : !firrtl.bundle<a flip: uint<1>>
+  %w = firrtl.wire : !firrtl.bundle<a flip: reset>
+  // TODO: Replace partialconnect with connect once #1302 is fixed.
+  firrtl.partialconnect %foo, %w : !firrtl.bundle<a flip: uint<1>>, !firrtl.bundle<a flip: reset>
+  firrtl.partialconnect %w, %bar : !firrtl.bundle<a flip: reset>, !firrtl.bundle<a flip: uint<1>>
+}
+// CHECK-LABEL: firrtl.module @ResetDrivesAsyncResetOrBool3
+firrtl.module @ResetDrivesAsyncResetOrBool3(in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
+  // CHECK: %w = firrtl.wire : !firrtl.uint<1>
+  %w = firrtl.wire : !firrtl.reset
+  firrtl.partialconnect %w, %in : !firrtl.reset, !firrtl.uint<1>
+  firrtl.partialconnect %out, %w : !firrtl.uint<1>, !firrtl.reset
+}
+
+// Should support inferring modules that would dedup differently
+// CHECK-LABEL: firrtl.module @DedupDifferentlyChild1
+// CHECK-SAME: in %childReset: !firrtl.uint<1>
+firrtl.module @DedupDifferentlyChild1(in %clock: !firrtl.clock, in %childReset: !firrtl.reset, in %x: !firrtl.uint<8>, out %z: !firrtl.uint<8>) {
+  %c123_ui = firrtl.constant 123 : !firrtl.uint
+  // CHECK: %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.uint<1>, !firrtl.uint, !firrtl.uint<8>
+  %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.reset, !firrtl.uint, !firrtl.uint<8>
+  firrtl.connect %r, %x : !firrtl.uint<8>, !firrtl.uint<8>
+  firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
+}
+// CHECK-LABEL: firrtl.module @DedupDifferentlyChild2
+// CHECK-SAME: in %childReset: !firrtl.asyncreset
+firrtl.module @DedupDifferentlyChild2(in %clock: !firrtl.clock, in %childReset: !firrtl.reset, in %x: !firrtl.uint<8>, out %z: !firrtl.uint<8>) {
+  %c123_ui = firrtl.constant 123 : !firrtl.uint
+  // CHECK: %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.asyncreset, !firrtl.uint, !firrtl.uint<8>
+  %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.reset, !firrtl.uint, !firrtl.uint<8>
+  firrtl.connect %r, %x : !firrtl.uint<8>, !firrtl.uint<8>
+  firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
+}
+// CHECK-LABEL: firrtl.module @DedupDifferentlyTop
+firrtl.module @DedupDifferentlyTop(in %clock: !firrtl.clock, in %reset1: !firrtl.uint<1>, in %reset2: !firrtl.asyncreset, in %x: !firrtl.vector<uint<8>, 2>, out %z: !firrtl.vector<uint<8>, 2>) {
+  // CHECK: {{.*}} = firrtl.instance @DedupDifferentlyChild1 {{.*}} : !firrtl.clock, !firrtl.uint<1>
+  %c1_clock, %c1_childReset, %c1_x, %c1_z = firrtl.instance @DedupDifferentlyChild1  {name = "c1"} : !firrtl.clock, !firrtl.reset, !firrtl.uint<8>, !firrtl.uint<8>
+  firrtl.connect %c1_clock, %clock : !firrtl.clock, !firrtl.clock
+  firrtl.connect %c1_childReset, %reset1 : !firrtl.reset, !firrtl.uint<1>
+  %0 = firrtl.subindex %x[0] : !firrtl.vector<uint<8>, 2>
+  firrtl.connect %c1_x, %0 : !firrtl.uint<8>, !firrtl.uint<8>
+  %1 = firrtl.subindex %z[0] : !firrtl.vector<uint<8>, 2>
+  firrtl.connect %1, %c1_z : !firrtl.uint<8>, !firrtl.uint<8>
+  // CHECK: {{.*}} = firrtl.instance @DedupDifferentlyChild2 {{.*}} : !firrtl.clock, !firrtl.asyncreset
+  %c2_clock, %c2_childReset, %c2_x, %c2_z = firrtl.instance @DedupDifferentlyChild2  {name = "c2"} : !firrtl.clock, !firrtl.reset, !firrtl.uint<8>, !firrtl.uint<8>
+  firrtl.connect %c2_clock, %clock : !firrtl.clock, !firrtl.clock
+  firrtl.connect %c2_childReset, %reset2 : !firrtl.reset, !firrtl.asyncreset
+  %2 = firrtl.subindex %x[1] : !firrtl.vector<uint<8>, 2>
+  firrtl.connect %c2_x, %2 : !firrtl.uint<8>, !firrtl.uint<8>
+  %3 = firrtl.subindex %z[1] : !firrtl.vector<uint<8>, 2>
+  firrtl.connect %3, %c2_z : !firrtl.uint<8>, !firrtl.uint<8>
+}
+
+// Should infer based on what a component *drives* not just what drives it
+// CHECK-LABEL: firrtl.module @InferBasedOnDriven
+// CHECK-SAME: out %out: !firrtl.asyncreset
+firrtl.module @InferBasedOnDriven(in %in: !firrtl.asyncreset, out %out: !firrtl.reset) {
+  // CHECK: %w = firrtl.wire : !firrtl.asyncreset
+  // CHECK: %invalid_asyncreset = firrtl.invalidvalue : !firrtl.asyncreset
+  %w = firrtl.wire : !firrtl.reset
+  %invalid_reset = firrtl.invalidvalue : !firrtl.reset
+  firrtl.connect %w, %invalid_reset : !firrtl.reset, !firrtl.reset
+  firrtl.connect %out, %w : !firrtl.reset, !firrtl.reset
+  firrtl.connect %out, %in : !firrtl.reset, !firrtl.asyncreset
+}
+
+// Should infer from connections, ignoring the fact that the invalidation wins
+// CHECK-LABEL: firrtl.module @InferIgnoreInvalidation
+// CHECK-SAME: out %out: !firrtl.asyncreset
+firrtl.module @InferIgnoreInvalidation(in %in: !firrtl.asyncreset, out %out: !firrtl.reset) {
+  // CHECK: %invalid_asyncreset = firrtl.invalidvalue : !firrtl.asyncreset
+  %invalid_reset = firrtl.invalidvalue : !firrtl.reset
+  firrtl.connect %out, %in : !firrtl.reset, !firrtl.asyncreset
+  firrtl.connect %out, %invalid_reset : !firrtl.reset, !firrtl.reset
+}
+
+// Should not propagate type info from downstream across a cast
+// CHECK-LABEL: firrtl.module @DontPropagateUpstreamAcrossCast
+// CHECK-SAME: out %out0: !firrtl.asyncreset
+// CHECK-SAME: out %out1: !firrtl.uint<1>
+firrtl.module @DontPropagateUpstreamAcrossCast(in %in0: !firrtl.asyncreset, in %in1: !firrtl.uint<1>, out %out0: !firrtl.reset, out %out1: !firrtl.reset) {
+  // CHECK: %w = firrtl.wire : !firrtl.uint<1>
+  %w = firrtl.wire : !firrtl.reset
+  %invalid_reset = firrtl.invalidvalue : !firrtl.reset
+  firrtl.connect %w, %invalid_reset : !firrtl.reset, !firrtl.reset
+  %0 = firrtl.asAsyncReset %w : (!firrtl.reset) -> !firrtl.asyncreset
+  firrtl.connect %out0, %0 : !firrtl.reset, !firrtl.asyncreset
+  firrtl.connect %out1, %w : !firrtl.reset, !firrtl.reset
+  firrtl.connect %out0, %in0 : !firrtl.reset, !firrtl.asyncreset
+  firrtl.connect %out1, %in1 : !firrtl.reset, !firrtl.uint<1>
+}
+
+// Should take into account both internal and external constraints on Module port types
+// CHECK-LABEL: firrtl.module @InternalAndExternalChild
+// CHECK-SAME: out %o: !firrtl.asyncreset
+firrtl.module @InternalAndExternalChild(in %i: !firrtl.asyncreset, out %o: !firrtl.reset) {
+  firrtl.connect %o, %i : !firrtl.reset, !firrtl.asyncreset
+}
+// CHECK-LABEL: firrtl.module @InternalAndExternalTop
+firrtl.module @InternalAndExternalTop(in %in: !firrtl.asyncreset, out %out: !firrtl.asyncreset) {
+  // CHECK: {{.*}} = firrtl.instance @InternalAndExternalChild {{.*}} : !firrtl.asyncreset, !firrtl.asyncreset
+  %c_i, %c_o = firrtl.instance @InternalAndExternalChild  {name = "c"} : !firrtl.asyncreset, !firrtl.reset
+  firrtl.connect %c_i, %in : !firrtl.asyncreset, !firrtl.asyncreset
+  firrtl.connect %out, %c_o : !firrtl.asyncreset, !firrtl.reset
+}
+
+// Should not crash on combinational loops
+// CHECK-LABEL: firrtl.module @NoCrashOnCombLoop
+// CHECK-SAME: out %out: !firrtl.asyncreset
+firrtl.module @NoCrashOnCombLoop(in %in: !firrtl.asyncreset, out %out: !firrtl.reset) {
+  %w0 = firrtl.wire : !firrtl.reset
+  %w1 = firrtl.wire : !firrtl.reset
+  firrtl.connect %w0, %in : !firrtl.reset, !firrtl.asyncreset
+  firrtl.connect %w0, %w1 : !firrtl.reset, !firrtl.reset
+  firrtl.connect %w1, %w0 : !firrtl.reset, !firrtl.reset
+  firrtl.connect %out, %in : !firrtl.reset, !firrtl.asyncreset
+}
+
+
+//===----------------------------------------------------------------------===//
+// Full Async Reset
+//===----------------------------------------------------------------------===//
+
+
+// CHECK-LABEL: firrtl.module @ConsumeIgnoreAnno
+// CHECK-NOT: IgnoreFullAsyncResetAnnotation
+firrtl.module @ConsumeIgnoreAnno() attributes {annotations = [{class = "sifive.enterprise.firrtl.IgnoreFullAsyncResetAnnotation"}]} {
+}
+
+// CHECK-LABEL: firrtl.module @ConsumeResetAnnoPort
+// CHECK-NOT: FullAsyncResetAnnotation
+firrtl.module @ConsumeResetAnnoPort(in %outerReset: !firrtl.asyncreset {firrtl.annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]}) {
+}
+
+// CHECK-LABEL: firrtl.module @ConsumeResetAnnoWire
+firrtl.module @ConsumeResetAnnoWire(in %outerReset: !firrtl.asyncreset) {
+  // CHECK: %innerReset = firrtl.wire
+  // CHECK-NOT: FullAsyncResetAnnotation
+  %innerReset = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]} : !firrtl.asyncreset
+}
+
+} // firrtl.circuit
+
+// -----
+// Reset-less registers should inherit the annotated async reset signal.
+firrtl.circuit "Top" {
+  // CHECK-LABEL: firrtl.module @Top
+  firrtl.module @Top(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %init: !firrtl.uint<1>, in %in: !firrtl.uint<8>, in %extraReset: !firrtl.asyncreset {firrtl.annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}, {class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]}) {
+    %c1_ui8 = firrtl.constant 1 : !firrtl.uint<8>
+    // CHECK: %reg1 = firrtl.regreset %clock, %extraReset, %c0_ui8
+    %reg1 = firrtl.reg %clock : !firrtl.uint<8>
+    firrtl.connect %reg1, %in : !firrtl.uint<8>, !firrtl.uint<8>
+
+    // Existing async reset remains untouched.
+    // CHECK: %reg2 = firrtl.regreset %clock, %reset, %c1_ui8
+    %reg2 = firrtl.regreset %clock, %reset, %c1_ui8 : !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
+    firrtl.connect %reg2, %in : !firrtl.uint<8>, !firrtl.uint<8>
+
+    // Existing sync reset is moved to mux.
+    // CHECK: %reg3 = firrtl.regreset %clock, %extraReset, %c0_ui8
+    // CHECK: %0 = firrtl.mux(%init, %c1_ui8, %in)
+    // CHECK: firrtl.connect %reg3, %0
+    %reg3 = firrtl.regreset %clock, %init, %c1_ui8 : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+    firrtl.connect %reg3, %in : !firrtl.uint<8>, !firrtl.uint<8>
+
+    // Factoring of sync reset into mux works through subfield op.
+    // CHECK: %reg4 = firrtl.regreset %clock, %extraReset, %1
+    // CHECK: %3 = firrtl.subfield %reset4(0)
+    // CHECK: %4 = firrtl.subfield %reg4(0)
+    // CHECK: %5 = firrtl.mux(%init, %3, %in)
+    // CHECK: firrtl.connect %4, %5
+    %reset4 = firrtl.wire : !firrtl.bundle<a: uint<8>>
+    %reg4 = firrtl.regreset %clock, %init, %reset4 : !firrtl.uint<1>, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>
+    %0 = firrtl.subfield %reg4(0) : (!firrtl.bundle<a: uint<8>>) -> !firrtl.uint<8>
+    firrtl.connect %0, %in : !firrtl.uint<8>, !firrtl.uint<8>
+
+    // Factoring of sync reset into mux works through subindex op.
+    // CHECK: %reg5 = firrtl.regreset %clock, %extraReset, %6
+    // CHECK: %8 = firrtl.subindex %reset5[0]
+    // CHECK: %9 = firrtl.subindex %reg5[0]
+    // CHECK: %10 = firrtl.mux(%init, %8, %in)
+    // CHECK: firrtl.connect %9, %10
+    %reset5 = firrtl.wire : !firrtl.vector<uint<8>, 1>
+    %reg5 = firrtl.regreset %clock, %init, %reset5 : !firrtl.uint<1>, !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
+    %1 = firrtl.subindex %reg5[0] : !firrtl.vector<uint<8>, 1>
+    firrtl.connect %1, %in : !firrtl.uint<8>, !firrtl.uint<8>
+
+    // Factoring of sync reset into mux works through subaccess op.
+    // CHECK: %reg6 = firrtl.regreset %clock, %extraReset, %11
+    // CHECK: %13 = firrtl.subaccess %reset6[%in]
+    // CHECK: %14 = firrtl.subaccess %reg6[%in]
+    // CHECK: %15 = firrtl.mux(%init, %13, %in)
+    // CHECK: firrtl.connect %14, %15
+    %reset6 = firrtl.wire : !firrtl.vector<uint<8>, 1>
+    %reg6 = firrtl.regreset %clock, %init, %reset6 : !firrtl.uint<1>, !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
+    %2 = firrtl.subaccess %reg6[%in] : !firrtl.vector<uint<8>, 1>, !firrtl.uint<8>
+    firrtl.connect %2, %in : !firrtl.uint<8>, !firrtl.uint<8>
+
+    // Subfields that are never assigned to should not leave unused reset
+    // subfields behind.
+    // CHECK-NOT: %16 = firrtl.subfield %reset4(0)
+    // CHECK: %16 = firrtl.subfield %reg4(0)
+    %3 = firrtl.subfield %reg4(0) : (!firrtl.bundle<a: uint<8>>) -> !firrtl.uint<8>
+  }
+}
+
+// -----
+// Async reset inference should be able to construct reset values for aggregate
+// types.
+firrtl.circuit "Top" {
+  // CHECK-LABEL: firrtl.module @Top
+  firrtl.module @Top(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset {firrtl.annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]}) {
+    // CHECK: %c0_ui = firrtl.constant 0 : !firrtl.uint
+    // CHECK: %reg_uint = firrtl.regreset %clock, %reset, %c0_ui
+    %reg_uint = firrtl.reg %clock : !firrtl.uint
+    // CHECK: %c0_si = firrtl.constant 0 : !firrtl.sint
+    // CHECK: %reg_sint = firrtl.regreset %clock, %reset, %c0_si
+    %reg_sint = firrtl.reg %clock : !firrtl.sint
+    // CHECK: %0 = firrtl.wire : !firrtl.bundle<a: uint<8>, b: bundle<x: uint<8>, y: uint<8>>>
+    // CHECK: %c0_ui8 = firrtl.constant 0 : !firrtl.uint<8>
+    // CHECK: %1 = firrtl.subfield %0(0)
+    // CHECK: firrtl.connect %1, %c0_ui8
+    // CHECK: %2 = firrtl.wire : !firrtl.bundle<x: uint<8>, y: uint<8>>
+    // CHECK: %3 = firrtl.subfield %2(0)
+    // CHECK: firrtl.connect %3, %c0_ui8
+    // CHECK: %4 = firrtl.subfield %2(1)
+    // CHECK: firrtl.connect %4, %c0_ui8
+    // CHECK: %5 = firrtl.subfield %0(1)
+    // CHECK: firrtl.connect %5, %2
+    // CHECK: %reg_bundle = firrtl.regreset %clock, %reset, %0
+    %reg_bundle = firrtl.reg %clock : !firrtl.bundle<a: uint<8>, b: bundle<x: uint<8>, y: uint<8>>>
+    // CHECK: %6 = firrtl.wire : !firrtl.vector<uint<8>, 4>
+    // CHECK: %c0_ui8_0 = firrtl.constant 0 : !firrtl.uint<8>
+    // CHECK: %7 = firrtl.subindex %6[0]
+    // CHECK: firrtl.connect %7, %c0_ui8_0
+    // CHECK: %8 = firrtl.subindex %6[1]
+    // CHECK: firrtl.connect %8, %c0_ui8_0
+    // CHECK: %9 = firrtl.subindex %6[2]
+    // CHECK: firrtl.connect %9, %c0_ui8_0
+    // CHECK: %10 = firrtl.subindex %6[3]
+    // CHECK: firrtl.connect %10, %c0_ui8_0
+    // CHECK: %reg_vector = firrtl.regreset %clock, %reset, %6
+    %reg_vector = firrtl.reg %clock : !firrtl.vector<uint<8>, 4>
+  }
+}
+
+// -----
+// Reset should reuse ports if name and type matches.
+firrtl.circuit "ReusePorts" {
+  // CHECK-LABEL: firrtl.module @Child
+  // CHECK-SAME: in %clock: !firrtl.clock
+  // CHECK-SAME: in %reset: !firrtl.asyncreset
+  // CHECK: %reg = firrtl.regreset %clock, %reset, %c0_ui8
+  firrtl.module @Child(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset) {
+    %reg = firrtl.reg %clock : !firrtl.uint<8>
+  }
+  // CHECK-LABEL: firrtl.module @BadName
+  // CHECK-SAME: in %reset: !firrtl.asyncreset,
+  // CHECK-SAME: in %clock: !firrtl.clock
+  // CHECK-SAME: in %existingReset: !firrtl.asyncreset
+  // CHECK: %reg = firrtl.regreset %clock, %reset, %c0_ui8
+  firrtl.module @BadName(in %clock: !firrtl.clock, in %existingReset: !firrtl.asyncreset) {
+    %reg = firrtl.reg %clock : !firrtl.uint<8>
+  }
+  // CHECK-LABEL: firrtl.module @BadType
+  // CHECK-SAME: in %reset_0: !firrtl.asyncreset,
+  // CHECK-SAME: in %clock: !firrtl.clock
+  // CHECK-SAME: in %reset: !firrtl.uint<1>
+  // CHECK: %reg = firrtl.regreset %clock, %reset_0, %c0_ui8
+  firrtl.module @BadType(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
+    %reg = firrtl.reg %clock : !firrtl.uint<8>
+  }
+  // CHECK-LABEL: firrtl.module @ReusePorts
+  firrtl.module @ReusePorts(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset {firrtl.annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]}) {
+    // CHECK: %child_clock, %child_reset = firrtl.instance @Child
+    // CHECK: firrtl.connect %child_reset, %reset
+    // CHECK: %badName_reset, %badName_clock, %badName_existingReset = firrtl.instance @BadName
+    // CHECK: firrtl.connect %badName_reset, %reset
+    // CHECK: %badType_reset_0, %badType_clock, %badType_reset = firrtl.instance @BadType
+    // CHECK: firrtl.connect %badType_reset_0, %reset
+    %child_clock, %child_reset = firrtl.instance @Child {name = "child"} : !firrtl.clock, !firrtl.asyncreset
+    %badName_clock, %badName_existingReset = firrtl.instance @BadName {name = "badName"} : !firrtl.clock, !firrtl.asyncreset
+    %badType_clock, %badType_reset = firrtl.instance @BadType {name = "badType"} : !firrtl.clock, !firrtl.uint<1>
+  }
+}
+
+// -----
+// Infer async reset: nested
+firrtl.circuit "FullAsyncNested" {
+  // CHECK-LABEL: firrtl.module @FullAsyncNestedDeeper
+  firrtl.module @FullAsyncNestedDeeper(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %io_in: !firrtl.uint<8>, out %io_out: !firrtl.uint<8>) {
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    // CHECK: %io_out_REG = firrtl.regreset %clock, %reset, %c1_ui1
+    %io_out_REG = firrtl.regreset %clock, %reset, %c1_ui1 : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<8>
+    firrtl.connect %io_out_REG, %io_in : !firrtl.uint<8>, !firrtl.uint<8>
+    firrtl.connect %io_out, %io_out_REG : !firrtl.uint<8>, !firrtl.uint<8>
+  }
+  // CHECK-LABEL: firrtl.module @FullAsyncNestedChild
+  firrtl.module @FullAsyncNestedChild(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %io_in: !firrtl.uint<8>, out %io_out: !firrtl.uint<8>) {
+    %inst_clock, %inst_reset, %inst_io_in, %inst_io_out = firrtl.instance @FullAsyncNestedDeeper  {name = "inst"} : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
+    firrtl.connect %inst_clock, %clock : !firrtl.clock, !firrtl.clock
+    firrtl.connect %inst_reset, %reset : !firrtl.asyncreset, !firrtl.asyncreset
+    firrtl.connect %inst_io_in, %io_in : !firrtl.uint<8>, !firrtl.uint<8>
+    // CHECK: %io_out_REG = firrtl.regreset %clock, %reset, %c0_ui8
+    %io_out_REG = firrtl.reg %clock : !firrtl.uint<8>
+    firrtl.connect %io_out_REG, %io_in : !firrtl.uint<8>, !firrtl.uint<8>
+    %0 = firrtl.add %io_out_REG, %inst_io_out : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<9>
+    %1 = firrtl.bits %0 7 to 0 : (!firrtl.uint<9>) -> !firrtl.uint<8>
+    firrtl.connect %io_out, %1 : !firrtl.uint<8>, !firrtl.uint<8>
+  }
+  // CHECK-LABEL: firrtl.module @FullAsyncNested
+  firrtl.module @FullAsyncNested(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset {firrtl.annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}, {class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]}, in %io_in: !firrtl.uint<8>, out %io_out: !firrtl.uint<8>) {
+    %inst_clock, %inst_reset, %inst_io_in, %inst_io_out = firrtl.instance @FullAsyncNestedChild  {name = "inst"} : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
+    firrtl.connect %inst_clock, %clock : !firrtl.clock, !firrtl.clock
+    firrtl.connect %inst_reset, %reset : !firrtl.asyncreset, !firrtl.asyncreset
+    firrtl.connect %io_out, %inst_io_out : !firrtl.uint<8>, !firrtl.uint<8>
+    firrtl.connect %inst_io_in, %io_in : !firrtl.uint<8>, !firrtl.uint<8>
+  }
+}
+
+
+// -----
+// Infer async reset: excluded
+// TODO: Check that no extraReset port present
+firrtl.circuit "FullAsyncExcluded" {
+  // CHECK-LABEL: firrtl.module @FullAsyncExcludedChild
+  // CHECK-SAME: (in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %io_in: !firrtl.uint<8>, out %io_out: !firrtl.uint<8>)
+  firrtl.module @FullAsyncExcludedChild(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %io_in: !firrtl.uint<8>, out %io_out: !firrtl.uint<8>) attributes {annotations = [{class = "sifive.enterprise.firrtl.IgnoreFullAsyncResetAnnotation"}]} {
+    // CHECK: %io_out_REG = firrtl.reg %clock
+    %io_out_REG = firrtl.reg %clock : !firrtl.uint<8>
+    firrtl.connect %io_out_REG, %io_in : !firrtl.uint<8>, !firrtl.uint<8>
+    firrtl.connect %io_out, %io_out_REG : !firrtl.uint<8>, !firrtl.uint<8>
+  }
+  // CHECK-LABEL: firrtl.module @FullAsyncExcluded
+  firrtl.module @FullAsyncExcluded(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %io_in: !firrtl.uint<8>, out %io_out: !firrtl.uint<8>, in %extraReset: !firrtl.asyncreset {firrtl.annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}, {class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]}) {
+    // CHECK: %inst_clock, %inst_reset, %inst_io_in, %inst_io_out = firrtl.instance @FullAsyncExcludedChild
+    %inst_clock, %inst_reset, %inst_io_in, %inst_io_out = firrtl.instance @FullAsyncExcludedChild  {name = "inst"} : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
+    firrtl.connect %inst_clock, %clock : !firrtl.clock, !firrtl.clock
+    firrtl.connect %inst_reset, %reset : !firrtl.asyncreset, !firrtl.asyncreset
+    firrtl.connect %io_out, %inst_io_out : !firrtl.uint<8>, !firrtl.uint<8>
+    firrtl.connect %inst_io_in, %io_in : !firrtl.uint<8>, !firrtl.uint<8>
+  }
+}

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -122,6 +122,11 @@ static cl::opt<bool>
                 cl::desc("run the width inference pass on firrtl"),
                 cl::init(true));
 
+static cl::opt<bool>
+    inferResets("infer-resets",
+                cl::desc("run the reset inference pass on firrtl"),
+                cl::init(true));
+
 static cl::opt<bool> extractTestCode("extract-test-code",
                                      cl::desc("run the extract test code pass"),
                                      cl::init(false));
@@ -228,6 +233,9 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
   // Width inference creates canonicalization opportunities.
   if (inferWidths)
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInferWidthsPass());
+
+  if (inferResets)
+    pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInferResetsPass());
 
   // The input mlir file could be firrtl dialect so we might need to clean
   // things up.


### PR DESCRIPTION
Add the `InferResets` transformation pass to the FIRRTL dialect, which assigns asynchronous resets to registers without reset, and replaces `reset` types with either `uint<1>` or `asyncreset`, as appropriate.

This combines the operation of the following Scala FIRRTL compiler passes:
- `InferResets`
- `RemoveReset`
- `CheckResets`
- `FullAsyncResetTransform`

More precisely, this does the following:

* Extract reset-related test cases from the existing Scala FIRRTL compiler code; specifically from `InferResets`, `CheckResets`, `RemoveReset`, and `FullAsyncResetTransform`.

* Add the `InferResets` transformation pass to the FIRRTL dialect, which assigns asynchronous resets to registers without reset, and replaces `reset` types with either `uint<1>` or `asyncreset`, as appropriate.

* Add the `--infer-resets` option to firtool, off by default for now.

### Todo
- [x] Add comment that explains what the stages of the pass are doing
- [x] Merge `CheckResets` into this pass (from the verifier, where it might not run)
- [x] Land #1357 
- [x] Use `llvm/ADT/EquivalenceClasses.h` instead of `ResetMap`