### PR TITLE
[PrettifyVerilog] Sink constants into the block where they are used

### DIFF
--- a/lib/Dialect/SV/Transforms/PrettifyVerilog.cpp
+++ b/lib/Dialect/SV/Transforms/PrettifyVerilog.cpp
@@ -72,11 +72,10 @@ void PrettifyVerilogPass::sinkOpToUses(Operation *op) {
       continue;
     // Find the block local clone of the operation. If there is not one already,
     // the op will be cloned in to the block.
-    auto localValue = blockLocalValues.lookup(localBlock);
+    auto &localValue = blockLocalValues[localBlock];
     if (!localValue) {
       // Clone the operation and insert it to the beginning of the block.
       localValue = OpBuilder::atBlockBegin(localBlock).clone(*op)->getResult(0);
-      blockLocalValues[localBlock] = localValue;
     }
     // Replace the current use, removing it from the use list.
     use.set(localValue);

--- a/lib/Dialect/SV/Transforms/PrettifyVerilog.cpp
+++ b/lib/Dialect/SV/Transforms/PrettifyVerilog.cpp
@@ -59,6 +59,8 @@ static bool isVerilogUnaryOperator(Operation *op) {
 /// operation so it can be sunk into multiple blocks. If there are no more uses
 /// in the current block, the op will be removed.
 void PrettifyVerilogPass::sinkOpToUses(Operation *op) {
+  assert(mlir::MemoryEffectOpInterface::hasNoEffect(op) &&
+         "Op with side effects cannot be sunk to its uses.");
   auto block = op->getBlock();
   for (auto it = op->use_begin(), end = op->use_end(); it != end;) {
     // If the current use is not in the same block as the operation, we are


### PR DESCRIPTION
This change makes the PrettifyVerilog pass duplicate constant ops into
the block where they are used. Sinking constants will allow the verilog
exporter to inline the expression instead of creating a `localparam`.