### PR TITLE
[ExportVerilog] Make alwaysff emit as always by default

### DIFF
--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -56,7 +56,7 @@ struct LoweringOptions {
 
   // If true, ExportVerilog emits AlwaysFFOp as Verilog always_ff statements.
   // Otherwise, it will print them as always statements
-  bool useAlwaysFF = true;
+  bool useAlwaysFF = false;
 
   /// This is the target width of lines in an emitted verilog source file in
   /// columns.

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -39,8 +39,8 @@ void LoweringOptions::parse(StringRef text, ErrorHandlerT errorHandler) {
     text = split.second;
     if (option == "") {
       // Empty options are fine.
-    } else if (option == "noAlwaysFF") {
-      useAlwaysFF = false;
+    } else if (option == "alwaysFF") {
+      useAlwaysFF = true;
     } else if (option.startswith("emittedLineLength=")) {
       option = option.drop_front(strlen("emittedLineLength="));
       if (option.getAsInteger(10, emittedLineLength)) {
@@ -57,8 +57,8 @@ void LoweringOptions::parse(StringRef text, ErrorHandlerT errorHandler) {
 std::string LoweringOptions::toString() const {
   std::string options = "";
   // All options should add a trailing comma to simplify the code.
-  if (!useAlwaysFF)
-    options += "noAlwaysFF,";
+  if (useAlwaysFF)
+    options += "alwaysFF,";
   if (emittedLineLength != 90)
     options += "emittedLineLength=" + std::to_string(emittedLineLength) + ',';
 

--- a/test/ExportVerilog/hw-dialect.mlir
+++ b/test/ExportVerilog/hw-dialect.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-translate %s -export-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
+// RUN: circt-translate %s -export-verilog -verify-diagnostics --lowering-options=alwaysFF | FileCheck %s --strict-whitespace
 
 // CHECK-LABEL: // external module E
 hw.module.extern @E(%a: i1, %b: i1, %c: i1)

--- a/test/ExportVerilog/sv-alwaysff.mlir
+++ b/test/ExportVerilog/sv-alwaysff.mlir
@@ -1,35 +1,35 @@
 // RUN: circt-translate --split-input-file --export-verilog %s | FileCheck %s --check-prefix=DEFAULT
 // RUN: circt-translate --lowering-options= --split-input-file --export-verilog %s | FileCheck %s --check-prefix=CLEAR
-// RUN: circt-translate --lowering-options=noAlwaysFF --split-input-file --export-verilog %s | FileCheck %s --check-prefix=NOALWAYSFF
+// RUN: circt-translate --lowering-options=alwaysFF --split-input-file --export-verilog %s | FileCheck %s --check-prefix=ALWAYSFF
 
 hw.module @test(%clock : i1, %cond : i1) {
   sv.alwaysff(posedge %clock) {
   }
-}
-
-// DEFAULT: always_ff @(posedge clock) begin
-// DEFAULT: end // always_ff @(posedge)
-
-// CLEAR: always_ff @(posedge clock) begin
-// CLEAR: end // always_ff @(posedge)
-
-// NOALWAYSFF: always @(posedge clock) begin
-// NOALWAYSFF: end // always @(posedge)
-
-// -----
-
-module attributes {circt.loweringOptions = "noAlwaysFF"} {
-hw.module @test(%clock : i1, %cond : i1) {
-  sv.alwaysff(posedge %clock) {
-  }
-}
 }
 
 // DEFAULT: always @(posedge clock) begin
 // DEFAULT: end // always @(posedge)
 
-// CLEAR: always_ff @(posedge clock) begin
-// CLEAR: end // always_ff @(posedge)
+// CLEAR: always @(posedge clock) begin
+// CLEAR: end // always @(posedge)
 
-// NOALWAYSFF: always @(posedge clock) begin
-// NOALWAYSFF: end // always @(posedge)
+// ALWAYSFF: always_ff @(posedge clock) begin
+// ALWAYSFF: end // always_ff @(posedge)
+
+// -----
+
+module attributes {circt.loweringOptions = "alwaysFF"} {
+hw.module @test(%clock : i1, %cond : i1) {
+  sv.alwaysff(posedge %clock) {
+  }
+}
+}
+
+// DEFAULT: always_ff @(posedge clock) begin
+// DEFAULT: end // always_ff @(posedge)
+
+// CLEAR: always @(posedge clock) begin
+// CLEAR: end // always @(posedge)
+
+// ALWAYSFF: always_ff @(posedge clock) begin
+// ALWAYSFF: end // always_ff @(posedge)

--- a/test/ExportVerilog/sv-dialect.mlir
+++ b/test/ExportVerilog/sv-dialect.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-translate %s -export-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
+// RUN: circt-translate %s -export-verilog -verify-diagnostics --lowering-options=alwaysFF | FileCheck %s --strict-whitespace
 
 // CHECK-LABEL: module M1(
 hw.module @M1(%clock : i1, %cond : i1, %val : i8) {

--- a/test/ExportVerilog/verilog-basic.mlir
+++ b/test/ExportVerilog/verilog-basic.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-translate %s -export-verilog -verify-diagnostics | FileCheck %s --strict-whitespace
+// RUN: circt-translate %s -export-verilog -verify-diagnostics --lowering-options=alwaysFF | FileCheck %s --strict-whitespace
 
 // CHECK-LABEL: module inputs_only(
 // CHECK-NEXT: input a, b);

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -115,7 +115,7 @@ circuit test_mod : %[[{"a": "a"}]]
 ; VERILOG-LABEL: module flipFlop(
 ; VERILOG-NEXT:    input clock, a_d,
 ; VERILOG-NEXT:    output a_q);
-; VERILOG:         always_ff @(posedge clock)
+; VERILOG:         always @(posedge clock)
 ; VERILOG-NEXT:      r <= a_d;
 ; VERILOG-NEXT:    assign a_q = r;
 ; VERILOG:       endmodule

--- a/test/firtool/style.fir
+++ b/test/firtool/style.fir
@@ -1,10 +1,10 @@
 ; RUN: firtool %s | FileCheck %s --check-prefix=DEFAULT
 ; RUN: not firtool --lowering-options=bad-option %s 2>&1 | FileCheck %s --check-prefix=BADOPTION
-; RUN: firtool --lowering-options=noAlwaysFF %s | FileCheck %s --check-prefix=NOALWAYSFF
+; RUN: firtool --lowering-options=alwaysFF %s | FileCheck %s --check-prefix=ALWAYSFF
 
 circuit test :
   module test :
 
 ; DEFAULT: module {
 ; BADOPTION: lowering-options option: unknown style option 'bad-option'
-; NOALWAYSFF: module attributes {circt.loweringOptions = "noAlwaysFF"} {
+; ALWAYSFF: module attributes {circt.loweringOptions = "alwaysFF"} {


### PR DESCRIPTION
Some of our tools disallow driving a value from both an `always_ff`
block and an `initial` block. The Verilog spec in section `9.2.2.4`
specifies that variables set in an `always_ff` cannot be be set by any
other process. If the initial block is considered a process, then our
verilog emission for this case is incorrect.

This commit changes the default lowering options to not emit
`always_ff`, which increases our tool compatability.  Down the road we
may change how we initialize variables, which could allow us to legally
emit `always_ff`.