### PR TITLE
[FIRRTL][ExpandWhens] Print one init error per run

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -440,22 +440,13 @@ mlir::FailureOr<bool> ModuleVisitor::run(FModuleOp module) {
     auto *connect = std::get<1>(destAndConnect);
     if (connect)
       continue;
-
-    // There is an incompletely initialized sink and this pass has failed.
-    result = failure();
-
-    // Get the op which defines the sink.
+    // Get the op which defines the sink, and emit an error.
     auto dest = std::get<0>(destAndConnect);
     dest.getDefiningOp()->emitError("sink \"" + getFieldName(dest) +
                                     "\" not fully initialized");
+    return failure();
   }
-
-  // Return Failed or Changed.
-  if (succeeded(result)) {
-    return mlir::FailureOr<bool>(anythingChanged);
-  }
-
-  return result;
+  return mlir::FailureOr<bool>(anythingChanged);
 }
 
 void ModuleVisitor::visitStmt(ConnectOp op) {

--- a/test/Dialect/FIRRTL/expand-whens-errors.mlir
+++ b/test/Dialect/FIRRTL/expand-whens-errors.mlir
@@ -1,28 +1,40 @@
 // RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl.module(firrtl-expand-whens))' -verify-diagnostics --split-input-file %s
 
-firrtl.circuit "simple" {
-
-firrtl.module @simple(in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
-    firrtl.connect %out, %in : !firrtl.uint<1>, !firrtl.uint<1>
-}
-
 // This test is checking each kind of declaration to ensure that it is caught
 // by the initialization coverage check. This is also testing that we can emit
 // all errors in a module at once.
+firrtl.circuit "CheckInitialization" {
 firrtl.module @CheckInitialization(in %clock : !firrtl.clock, in %en : !firrtl.uint<1>, in %p : !firrtl.uint<1>, in %in0 : !firrtl.bundle<a  flip: uint<1>>, out %out0 : !firrtl.uint<2>, out %out1 : !firrtl.bundle<a flip: uint<1>>) {
   // expected-error @-1 {{sink "in0.a" not fully initialized}}
-  // expected-error @-2 {{sink "out0" not fully initialized}}
+}
+}
 
-  // expected-error @+2 {{sink "w.a" not fully initialized}}
-  // expected-error @+1 {{sink "w.b" not fully initialized}}
+// -----
+
+firrtl.circuit "CheckInitialization" {
+firrtl.module @CheckInitialization() {
+  // expected-error @+1 {{sink "w.a" not fully initialized}}
   %w = firrtl.wire : !firrtl.bundle<a : uint<1>, b  flip: uint<1>>
+}
+}
 
+// -----
+
+firrtl.circuit "CheckInitialization" {
+firrtl.module @simple(in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
+    firrtl.connect %out, %in : !firrtl.uint<1>, !firrtl.uint<1>
+}
+firrtl.module @CheckInitialization() {
   // expected-error @+1 {{sink "test.in" not fully initialized}}
   %simple_out, %simple_in = firrtl.instance @simple {name = "test", portNames=["in", "out"]}: !firrtl.uint<1>, !firrtl.uint<1>
+}
+}
 
-  // expected-error @+3 {{sink "memory.r.addr" not fully initialized}}
-  // expected-error @+2 {{sink "memory.r.en" not fully initialized}}
-  // expected-error @+1 {{sink "memory.r.clk" not fully initialized}}
+// -----
+
+firrtl.circuit "CheckInitialization" {
+firrtl.module @CheckInitialization() {
+  // expected-error @+1 {{sink "memory.r.addr" not fully initialized}}
   %memory_r = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
 }
 }
@@ -35,6 +47,16 @@ firrtl.module @declaration_in_when(in %p : !firrtl.uint<1>) {
   firrtl.when %p {
     // expected-error @+1 {{sink "w_then" not fully initialized}}
     %w_then = firrtl.wire : !firrtl.uint<2>
+  }
+}
+}
+
+// -----
+
+firrtl.circuit "declaration_in_when" {
+// Check that wires declared inside of a when are detected as uninitialized.
+firrtl.module @declaration_in_when(in %p : !firrtl.uint<1>) {
+  firrtl.when %p {
   } else {
     // expected-error @+1 {{sink "w_else" not fully initialized}}
     %w_else = firrtl.wire : !firrtl.uint<2>


### PR DESCRIPTION
When an array is not initialized, the expand whens pass will print an
error for every element in the array.  This could print far too many
errors on huge arrays which may be missing a single bulk connect.  Since
ExpandWhens is running after lower-types there doesn't seem to be a good
way to reduce the number of errors printed, for example printing 1 error
per sink in the original source.

This changes the pass to quit after finding the first initialization
error.