### PR TITLE
[FIRRTL]Handle DontTouch annotation with AttachOp

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1365,7 +1365,7 @@ LogicalResult AttachOp::canonicalize(AttachOp op, PatternRewriter &rewriter) {
     // TODO: May need to be sensitive to "don't touch" or other
     // annotations.
     if (auto wire = dyn_cast_or_null<WireOp>(operand.getDefiningOp())) {
-      if (wire->hasOneUse()) {
+      if (!AnnotationSet(wire).hasDontTouch() && wire->hasOneUse()) {
         SmallVector<Value> newOperands;
         for (auto newOperand : op.getOperands())
           if (newOperand != operand) // Don't the add wire.

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -631,6 +631,15 @@ firrtl.module @AttachOpts(in %a: !firrtl.analog<1>) {
   firrtl.attach %b, %a : !firrtl.analog<1>, !firrtl.analog<1>
 }
 
+// CHECK-LABEL: @AttachDeadWireDontTouch
+firrtl.module @AttachDeadWireDontTouch(in %a: !firrtl.analog<1>, in %b: !firrtl.analog<1>) {
+  // CHECK-NEXT: %c = firrtl.wire
+  // CHECK-NEXT: firrtl.attach %a, %b, %c :
+  // CHECK-NEXT: }
+  %c = firrtl.wire  {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]}: !firrtl.analog<1>
+  firrtl.attach %a, %b, %c : !firrtl.analog<1>, !firrtl.analog<1>, !firrtl.analog<1>
+}
+
 // CHECK-LABEL: @wire_cst_prop1
 // CHECK-NEXT:   %c10_ui9 = firrtl.constant 10 : !firrtl.uint<9>
 // CHECK-NEXT:   firrtl.connect %out_b, %c10_ui9 : !firrtl.uint<9>, !firrtl.uint<9>


### PR DESCRIPTION
Handle `DontTouch` annotation during `canonicalize` of `AttachOp`. 