### PR TITLE
[Python][Seq] Fix integration test

### DIFF
--- a/frontends/PyCDE/test/compreg.py
+++ b/frontends/PyCDE/test/compreg.py
@@ -19,5 +19,5 @@ mod = CompReg()
 mod.print_verilog()
 
 # CHECK: reg [7:0] [[NAME:.+]];
-# CHECK: always_ff @(posedge clk)
+# CHECK: always @(posedge clk)
 # CHECK: [[NAME]] <= {{.+}}

--- a/integration_test/Bindings/Python/dialects/seq.py
+++ b/integration_test/Bindings/Python/dialects/seq.py
@@ -72,6 +72,6 @@ with Context() as ctx, Location.unknown():
 
   pm = PassManager.parse("lower-seq-to-sv")
   pm.run(m)
-  # CHECK: always_ff @(posedge clk)
+  # CHECK: always @(posedge clk)
   # CHECK: my_reg <= {{.+}}
   circt.export_verilog(m, sys.stdout)


### PR DESCRIPTION
Verilog emission is now defaulting to print `always` instead of
`always_ff`.  These tests don't run in a PR and were missed during
the change.