### PR TITLE
[Calyx] Add Cell, Program ops.

### DIFF
--- a/include/circt/Dialect/Calyx/Calyx.td
+++ b/include/circt/Dialect/Calyx/Calyx.td
@@ -43,7 +43,7 @@ class CalyxOp<string mnemonic, list<OpTrait> traits = []> :
 /// Base class for Calyx containers.
 class CalyxContainer<string mnemonic, list<OpTrait> traits = []> :
   Op<CalyxDialect, mnemonic, !listconcat(traits, [
-      HasParent<"ComponentOp">,
+      NoRegionArguments,
       NoTerminator,
       SingleBlock
   ])> {
@@ -51,7 +51,7 @@ class CalyxContainer<string mnemonic, list<OpTrait> traits = []> :
   let regions = (region SizedRegion<1>: $body);
 
   let extraClassDeclaration = [{
-    /// Returns the body of a Calyx component.
+    /// Returns the body of a Calyx container.
     Block *getBody() { return &getOperation()->getRegion(0).front(); }
   }];
 }

--- a/include/circt/Dialect/Calyx/Calyx.td
+++ b/include/circt/Dialect/Calyx/Calyx.td
@@ -38,7 +38,18 @@ def CalyxDialect : Dialect {
 
 /// Base class for the operation in this dialect.
 class CalyxOp<string mnemonic, list<OpTrait> traits = []> :
-    Op<CalyxDialect, mnemonic, traits>;
+  Op<CalyxDialect, mnemonic, traits>;
+
+/// Base class for Calyx containers.
+class CalyxContainer<string mnemonic, list<OpTrait> traits = []> :
+  Op<CalyxDialect, mnemonic, !listconcat(traits, [
+      HasParent<"ComponentOp">,
+      NoTerminator,
+      SingleBlock
+  ])> {
+  let assemblyFormat = "$body attr-dict";
+  let regions = (region SizedRegion<1>: $body);
+}
 
 include "circt/Dialect/Calyx/CalyxStructure.td"
 

--- a/include/circt/Dialect/Calyx/Calyx.td
+++ b/include/circt/Dialect/Calyx/Calyx.td
@@ -49,6 +49,11 @@ class CalyxContainer<string mnemonic, list<OpTrait> traits = []> :
   ])> {
   let assemblyFormat = "$body attr-dict";
   let regions = (region SizedRegion<1>: $body);
+
+  let extraClassDeclaration = [{
+    /// Returns the body of a Calyx component.
+    Block *getBody() { return &getOperation()->getRegion(0).front(); }
+  }];
 }
 
 include "circt/Dialect/Calyx/CalyxStructure.td"

--- a/include/circt/Dialect/Calyx/CalyxOps.h
+++ b/include/circt/Dialect/Calyx/CalyxOps.h
@@ -22,6 +22,25 @@
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
+namespace circt {
+namespace calyx {
+
+/// The direction of a Calyx port.
+enum PortDirection { INPUT = 0, OUTPUT = 1 };
+
+/// This holds the name and type that describes the component's ports.
+struct ComponentPortInfo {
+  StringAttr name;
+  Type type;
+  PortDirection direction;
+};
+
+/// Returns port information about a given component.
+SmallVector<ComponentPortInfo> getComponentPortInfo(Operation *op);
+
+} // namespace calyx
+} // namespace circt
+
 #define GET_OP_CLASSES
 #include "circt/Dialect/Calyx/Calyx.h.inc"
 

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -79,6 +79,11 @@ def ComponentOp : CalyxOp<"component", [
     public:
       /// Returns the body of a Calyx component.
       Block *getBody() { return &getOperation()->getRegion(0).front(); }
+
+      // Returns information about the input and output ports for the component.
+      SmallVector<ComponentPortInfo> getPorts() {
+        return getComponentPortInfo(*this);
+      }
   }];
 
   let verifier = "return ::verify$cppClass(*this);";
@@ -159,7 +164,7 @@ def CellOp : CalyxOp<"cell", [
     optionally have parameters.
 
     ```mlir
-      %out1 = calyx.cell "foo" @MyComponent(%in0) : i32 -> i64
+      %in1, %out1 = calyx.cell "name" @MyComponent : i64, i16
     ```
   }];
 
@@ -169,18 +174,16 @@ def CellOp : CalyxOp<"cell", [
     Operation *getReferencedComponent();
   }];
 
-  // TODO(Calyx): Add parameters attribute for
+  // TODO(Calyx): Add `parameters` attribute for
   // SystemVerilog-wrapped primitives.
   let arguments = (ins
     StrAttr:$instanceName,
-    FlatSymbolRefAttr:$componentName,
-    Variadic<AnyType>:$inputs
+    FlatSymbolRefAttr:$componentName
   );
-  let results = (outs Variadic<AnyType>);
+  let results = (outs Variadic<AnyType>:$results);
 
   let assemblyFormat = [{
-    $instanceName $componentName `(` $inputs `)`
-    attr-dict `:` functional-type($inputs, results)
+    $instanceName $componentName attr-dict (`:` type($results)^)?
   }];
   let verifier = "return ::verify$cppClass(*this);";
 }

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -9,3 +9,111 @@
 // This describes the Calyx structures.
 //
 //===----------------------------------------------------------------------===//
+
+def ComponentOp : CalyxOp<"component", [
+    Symbol,
+    FunctionLike,
+    IsolatedFromAbove,
+    // TODO(Calyx): Need to eventually expose the output ports.
+    NoTerminator,
+    SingleBlock
+  ]> {
+  let summary = "Calyx Component";
+  let description = [{
+    The "calyx.component" operation represents an overall
+    Calyx component containing:
+    (1) In- and output port definitions
+        that define the interface.
+    (2) The cells, wires, and control schedule.
+    ```mlir
+      calyx.component @MyComponent(%in1: i32) -> (%out1: i8) {
+        calyx.cells { ... }
+        calyx.wires { ... }
+        calyx.control { ... }
+      }
+    ```
+  }];
+
+  // TODO(Calyx): Allow explicit port naming?
+  let arguments = (ins
+    ArrayAttr:$inPortNames,
+    ArrayAttr:$outPortNames
+  );
+  let results = (outs);
+
+  let regions = (region SizedRegion<1>: $body);
+
+  let extraClassDeclaration = [{
+    // Necessary to avoid name clashing with `front`.
+    using FunctionLike::front;
+
+    private:
+      // This trait needs access to the hooks defined below.
+      friend class OpTrait::FunctionLike<ComponentOp>;
+
+      /// Hooks for the input/output type enumeration in FunctionLike.
+      unsigned getNumFuncArguments() { return getType().getNumInputs(); }
+      unsigned getNumFuncResults() { return getType().getNumResults(); }
+    public:
+      /// Returns the body of a Calyx component.
+      Block *getBody() { return &getOperation()->getRegion(0).front(); }
+  }];
+
+  let verifier = "return ::verify$cppClass(*this);";
+  let printer = "return ::print$cppClass(p, *this);";
+  let parser = "return ::parse$cppClass(parser, result);";
+}
+
+def CellsOp : CalyxContainer<"cells", [IsolatedFromAbove]> {
+  let summary = "Calyx Cells";
+  let description = [{
+    The "calyx.cells" operation represents a container for
+    the sub-components that are used within the parent
+    component.
+
+    ```mlir
+      calyx.cells {
+       // TODO(Calyx): Add `cell` examples once
+       // CellOps are added.
+      }
+    ```
+  }];
+}
+
+def WiresOp : CalyxContainer<"wires", []> {
+  let summary = "Calyx Wires";
+  let description = [{
+    The "calyx.wires" operation represents a set of
+    guarded connections between component instances,
+    which may be placed within groups.
+
+    ```mlir
+      calyx.wires {
+        // TODO(Calyx): Add `group` examples once
+        // GroupOps are added.
+      }
+    ```
+  }];
+}
+
+// TODO1(Calyx): The terminator for the control flow
+// schedule should define that of the component.
+// TODO2(Calyx): While it currently carries the
+// SingleBlock trait, this may change depending
+// on how we decide to represent Groups in the
+// dialect.
+def ControlOp : CalyxContainer<"control", []> {
+  let summary = "Calyx Control";
+  let description = [{
+    The "calyx.control" operation represents the
+    execution schedule defined for the given
+    component, i.e. when each group executes.
+
+    ```mlir
+      calyx.control {
+        // TODO(Calyx): Add `control` examples
+        // once control flow ops are added.
+      }
+    ```
+  }];
+}

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -79,11 +79,6 @@ def ComponentOp : CalyxOp<"component", [
     public:
       /// Returns the body of a Calyx component.
       Block *getBody() { return &getOperation()->getRegion(0).front(); }
-
-      // Returns information about the input and output ports for the component.
-      SmallVector<ComponentPortInfo> getPorts() {
-        return getComponentPortInfo(*this);
-      }
   }];
 
   let verifier = "return ::verify$cppClass(*this);";
@@ -160,8 +155,8 @@ def CellOp : CalyxOp<"cell", [
   let summary = "Calyx Cell";
   let description = [{
     Represents a cell (or instance) of a Calyx component or
-    primitive, which may include state. Some instances may
-    optionally have parameters.
+    primitive, which may include state. Some cells may
+    optionally have parameters attributed to them.
 
     ```mlir
       %in1, %out1 = calyx.cell "name" @MyComponent : i64, i16

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -10,7 +10,35 @@
 //
 //===----------------------------------------------------------------------===//
 
+def ProgramOp : CalyxOp<"program", [
+    IsolatedFromAbove,
+    NoRegionArguments,
+    NoTerminator,
+    SymbolTable,
+    SingleBlock
+  ]> {
+  let summary = "Calyx Program";
+  let description = [{
+    The "calyx.program" operation represents an overall Calyx program,
+    containing a list of Calyx components. This must include a "main"
+    component, the entry point of the program.
+  }];
+  let arguments = (ins);
+
+  let extraClassDeclaration = [{
+    /// Returns the main component, representing the
+    /// entry point of the Calyx program.
+    Operation *getMainComponent() { return lookupSymbol("main"); }
+  }];
+
+  let regions = (region SizedRegion<1>:$body);
+  let assemblyFormat = "$body attr-dict";
+  let verifier = "return ::verify$cppClass(*this);";
+}
+
+
 def ComponentOp : CalyxOp<"component", [
+    HasParent<"ProgramOp">,
     Symbol,
     FunctionLike,
     IsolatedFromAbove,
@@ -78,6 +106,8 @@ def CellsOp : CalyxContainer<"cells", [IsolatedFromAbove]> {
       }
     ```
   }];
+
+  let verifier = "return ::verify$cppClass(*this);";
 }
 
 def WiresOp : CalyxContainer<"wires", []> {
@@ -116,4 +146,39 @@ def ControlOp : CalyxContainer<"control", []> {
       }
     ```
   }];
+}
+
+def CellOp : CalyxOp<"cell", [
+    HasParent<"CellsOp">
+  ]> {
+  let summary = "Instantiates an instance of a component or primitive.";
+  let description = [{
+    Represents an instance of a Calyx component or primitive, which may
+    include state. Some instances may optionally have parameters.
+
+    ```mlir
+      %out1 = calyx.cell "foo" @MyComponent(%in0) : i32 -> i64
+    ```
+  }];
+
+  let extraClassDeclaration = [{
+    /// Lookup the component for the symbol. This returns null on
+    /// invalid IR.
+    Operation *getReferencedComponent();
+  }];
+
+  // TODO(Calyx): Add parameters attribute for
+  // SystemVerilog-wrapped primitives.
+  let arguments = (ins
+    StrAttr:$instanceName,
+    FlatSymbolRefAttr:$componentName,
+    Variadic<AnyType>:$inputs
+  );
+  let results = (outs Variadic<AnyType>);
+
+  let assemblyFormat = [{
+    $instanceName $componentName `(` $inputs `)`
+    attr-dict `:` functional-type($inputs, results)
+  }];
+  let verifier = "return ::verify$cppClass(*this);";
 }

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -152,10 +152,11 @@ def ControlOp : CalyxContainer<"control", [
 def CellOp : CalyxOp<"cell", [
     HasParent<"CellsOp">
   ]> {
-  let summary = "Instantiates an instance of a component or primitive.";
+  let summary = "Calyx Cell";
   let description = [{
-    Represents an instance of a Calyx component or primitive, which may
-    include state. Some instances may optionally have parameters.
+    Represents a cell (or instance) of a Calyx component or
+    primitive, which may include state. Some instances may
+    optionally have parameters.
 
     ```mlir
       %out1 = calyx.cell "foo" @MyComponent(%in0) : i32 -> i64

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -25,7 +25,7 @@ def ProgramOp : CalyxContainer<"program", [
   let extraClassDeclaration = [{
     /// Returns the main component, representing the
     /// entry point of the Calyx program.
-    Operation *getMainComponent() { return lookupSymbol("main"); }
+    ComponentOp getMainComponent() { return lookupSymbol<ComponentOp>("main"); }
   }];
   let verifier = "return ::verify$cppClass(*this);";
 }
@@ -166,7 +166,7 @@ def CellOp : CalyxOp<"cell", [
   let extraClassDeclaration = [{
     /// Lookup the component for the symbol. This returns null on
     /// invalid IR.
-    Operation *getReferencedComponent();
+    ComponentOp getReferencedComponent();
   }];
 
   // TODO(Calyx): Add `parameters` attribute for

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -10,12 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-def ProgramOp : CalyxOp<"program", [
+def ProgramOp : CalyxContainer<"program", [
     IsolatedFromAbove,
-    NoRegionArguments,
-    NoTerminator,
-    SymbolTable,
-    SingleBlock
+    SymbolTable
   ]> {
   let summary = "Calyx Program";
   let description = [{
@@ -30,9 +27,6 @@ def ProgramOp : CalyxOp<"program", [
     /// entry point of the Calyx program.
     Operation *getMainComponent() { return lookupSymbol("main"); }
   }];
-
-  let regions = (region SizedRegion<1>:$body);
-  let assemblyFormat = "$body attr-dict";
   let verifier = "return ::verify$cppClass(*this);";
 }
 
@@ -92,7 +86,10 @@ def ComponentOp : CalyxOp<"component", [
   let parser = "return ::parse$cppClass(parser, result);";
 }
 
-def CellsOp : CalyxContainer<"cells", [IsolatedFromAbove]> {
+def CellsOp : CalyxContainer<"cells", [
+    HasParent<"ComponentOp">,
+    IsolatedFromAbove
+  ]> {
   let summary = "Calyx Cells";
   let description = [{
     The "calyx.cells" operation represents a container for
@@ -110,7 +107,9 @@ def CellsOp : CalyxContainer<"cells", [IsolatedFromAbove]> {
   let verifier = "return ::verify$cppClass(*this);";
 }
 
-def WiresOp : CalyxContainer<"wires", []> {
+def WiresOp : CalyxContainer<"wires", [
+    HasParent<"ComponentOp">
+  ]> {
   let summary = "Calyx Wires";
   let description = [{
     The "calyx.wires" operation represents a set of
@@ -132,7 +131,9 @@ def WiresOp : CalyxContainer<"wires", []> {
 // SingleBlock trait, this may change depending
 // on how we decide to represent Groups in the
 // dialect.
-def ControlOp : CalyxContainer<"control", []> {
+def ControlOp : CalyxContainer<"control", [
+    HasParent<"ComponentOp">
+  ]> {
   let summary = "Calyx Control";
   let description = [{
     The "calyx.control" operation represents the

--- a/lib/Dialect/Calyx/CMakeLists.txt
+++ b/lib/Dialect/Calyx/CMakeLists.txt
@@ -25,8 +25,6 @@ set(Calyx_Deps
   MLIRCalyxAttrsIncGen
   )
 
-
-
 add_circt_dialect_library(CIRCTCalyx
   ${srcs}
 

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -192,10 +192,9 @@ static LogicalResult verifyCellsOp(CellsOp cells) {
   if (!component)
     return cells.emitOpError("Should be embedded in 'calyx.component'.");
 
-  for (auto &op : *cells.getBody()) {
-    if (!isa<CellOp>(op))
-      return cells.emitOpError("Should only contain 'calyx.cell' instances.");
-  }
+  if (!llvm::all_of(*cells.getBody(), [](auto &op) { return isa<CellOp>(op); }))
+    return cells.emitOpError("Should only contain 'calyx.cell' instances.");
+
   return success();
 }
 

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -26,6 +26,148 @@ using namespace circt;
 using namespace circt::calyx;
 using namespace mlir;
 
+//===----------------------------------------------------------------------===//
+// ComponentOp
+//===----------------------------------------------------------------------===//
+
+/// Prints the port definitions of a Calyx component signature.
+static void printPortDefList(OpAsmPrinter &p, ArrayRef<Type> portDefTypes,
+                             ArrayAttr portDefNames) {
+  p << '(';
+  llvm::interleaveComma(
+      llvm::zip(portDefNames, portDefTypes), p, [&](auto nameAndType) {
+        if (auto name =
+                std::get<0>(nameAndType).template dyn_cast<StringAttr>()) {
+          p << name.getValue() << ": ";
+        }
+        p << std::get<1>(nameAndType);
+      });
+  p << ')';
+}
+
+static void printComponentOp(OpAsmPrinter &p, ComponentOp &op) {
+  auto componentName =
+      op->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName())
+          .getValue();
+  p << "calyx.component ";
+  p.printSymbolName(componentName);
+
+  auto typeAttr = op->getAttrOfType<TypeAttr>(ComponentOp::getTypeAttrName());
+  auto functionType = typeAttr.getValue().cast<FunctionType>();
+
+  auto inputPortTypes = functionType.getInputs();
+  auto inputPortNames = op->getAttrOfType<ArrayAttr>("inPortNames");
+  printPortDefList(p, inputPortTypes, inputPortNames);
+  p << " -> ";
+  auto outputPortTypes = functionType.getResults();
+  auto outputPortNames = op->getAttrOfType<ArrayAttr>("outPortNames");
+  printPortDefList(p, outputPortTypes, outputPortNames);
+
+  p.printRegion(op.body(), /*printBlockTerminators=*/false,
+                /*printEmptyBlock=*/false);
+}
+
+/// Parses the ports of a Calyx component signature, and adds the corresponding
+/// port names to `attrName`.
+static ParseResult
+parsePortDefList(OpAsmParser &parser, MLIRContext *context,
+                 OperationState &result,
+                 SmallVectorImpl<OpAsmParser::OperandType> &ports,
+                 SmallVectorImpl<Type> &portTypes, StringRef attrName) {
+  if (parser.parseLParen())
+    return failure();
+
+  do {
+    OpAsmParser::OperandType port;
+    Type portType;
+    if (failed(parser.parseOptionalRegionArgument(port)) ||
+        failed(parser.parseOptionalColon()) ||
+        failed(parser.parseType(portType)))
+      continue;
+    ports.push_back(port);
+    portTypes.push_back(portType);
+  } while (succeeded(parser.parseOptionalComma()));
+
+  // Add attribute for port names; these are currently
+  // just inferred from the arguments of the component.
+  SmallVector<Attribute> portNames(ports.size());
+  llvm::transform(ports, portNames.begin(), [&](auto port) -> StringAttr {
+    return StringAttr::get(context, port.name);
+  });
+  result.addAttribute(attrName, ArrayAttr::get(context, portNames));
+
+  return (parser.parseRParen());
+}
+
+/// Parses the signature of a Calyx component.
+static ParseResult
+parseComponentSignature(OpAsmParser &parser, OperationState &result,
+                        SmallVectorImpl<OpAsmParser::OperandType> &inPorts,
+                        SmallVectorImpl<Type> &inPortTypes,
+                        SmallVectorImpl<OpAsmParser::OperandType> &outPorts,
+                        SmallVectorImpl<Type> &outPortTypes) {
+  auto *context = parser.getBuilder().getContext();
+  if (parsePortDefList(parser, context, result, inPorts, inPortTypes,
+                       "inPortNames") ||
+      parser.parseArrow() ||
+      parsePortDefList(parser, context, result, outPorts, outPortTypes,
+                       "outPortNames"))
+    return failure();
+
+  return success();
+}
+
+static ParseResult parseComponentOp(OpAsmParser &parser,
+                                    OperationState &result) {
+  using namespace mlir::function_like_impl;
+
+  StringAttr componentName;
+  if (parser.parseSymbolName(componentName, SymbolTable::getSymbolAttrName(),
+                             result.attributes))
+    return failure();
+
+  SmallVector<OpAsmParser::OperandType> inPorts, outPorts;
+  SmallVector<Type> inPortTypes, outPortTypes;
+  if (parseComponentSignature(parser, result, inPorts, inPortTypes, outPorts,
+                              outPortTypes))
+    return failure();
+
+  // Build the component's type for FunctionLike trait.
+  auto &builder = parser.getBuilder();
+  auto type = builder.getFunctionType(inPortTypes, outPortTypes);
+  result.addAttribute(ComponentOp::getTypeAttrName(), TypeAttr::get(type));
+
+  // The entry block needs to have same number of
+  // input port definitions as the component.
+  auto *body = result.addRegion();
+  if (parser.parseRegion(*body, inPorts, inPortTypes))
+    return failure();
+
+  if (body->empty())
+    body->push_back(new Block());
+
+  return success();
+}
+
+static LogicalResult verifyComponentOp(ComponentOp op) {
+  // Verify there is exactly one of each section:
+  // calyx.cells, calyx.wires, and calyx.control.
+  uint32_t numCells = 0, numWires = 0, numControl = 0;
+  for (auto &bodyOp : *op.getBody()) {
+    if (isa<CellsOp>(bodyOp))
+      ++numCells;
+    else if (isa<WiresOp>(bodyOp))
+      ++numWires;
+    else if (isa<ControlOp>(bodyOp))
+      ++numControl;
+  }
+  if (numCells == 1 && numWires == 1 && numControl == 1)
+    return success();
+
+  return op.emitOpError()
+         << "Requires exactly one of each: "
+            "\"calyx.cells\", \"calyx.wires\", \"calyx.control\".";
+}
 
 //===----------------------------------------------------------------------===//
 // TableGen generated logic.

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -230,7 +230,7 @@ static LogicalResult verifyCellsOp(CellsOp cells) {
     return cells.emitOpError("should be embedded in 'calyx.component'.");
 
   if (!llvm::all_of(*cells.getBody(), [](auto &op) { return isa<CellOp>(op); }))
-    return cells.emitOpError("should only contain 'calyx.cell' instances.");
+    return cells.emitOpError("should only contain 'calyx.cell' ops.");
 
   return success();
 }

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -1,0 +1,63 @@
+// RUN: circt-opt %s -split-input-file -verify-diagnostics
+
+// expected-error @+1 {{'calyx.program' op must contain one component named "main" as the entry point.}}
+calyx.program {}
+
+// -----
+
+calyx.program {
+  // expected-error @+1 {{'calyx.component' op requires exactly one of each: 'calyx.cells', 'calyx.wires', 'calyx.control'.}}
+  calyx.component @main() -> () {
+    calyx.wires {}
+    calyx.control {}
+  }
+}
+
+// -----
+
+calyx.program {
+  calyx.component @main() -> () {
+    calyx.cells {
+      // expected-error @+1 {{'calyx.cell' op is referencing component: A, which does not exist.}}
+      calyx.cell "a0" @A
+    }
+    calyx.wires {}
+    calyx.control {}
+  }
+}
+
+// -----
+
+calyx.program {
+  calyx.component @A(%in: i16) -> () {
+    calyx.cells {}
+    calyx.wires {}
+    calyx.control {}
+  }
+  calyx.component @main() -> () {
+    calyx.cells {
+      // expected-error @+1 {{'calyx.cell' op has a wrong number of results; expected: 1 but got 0}}
+      calyx.cell "a0" @A
+    }
+    calyx.wires {}
+    calyx.control {}
+  }
+}
+
+// -----
+
+calyx.program {
+  calyx.component @B(%in: i16) -> () {
+    calyx.cells {}
+    calyx.wires {}
+    calyx.control {}
+  }
+  calyx.component @main() -> () {
+    calyx.cells {
+      // expected-error @+1 {{'calyx.cell' op result type for "%in" must be 'i16', but got 'i1'}}
+      %0 = calyx.cell "b0" @B : i1
+    }
+    calyx.wires {}
+    calyx.control {}
+  }
+}

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -1,5 +1,6 @@
 // RUN: circt-opt %s -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
 
+// CHECK: calyx.program {
 calyx.program {
 
   // CHECK-LABEL:  calyx.component @ComponentWithInAndOutPorts(%in1: i64, %in2: i16) -> (%out1: i32, %out2: i8) {

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s -verify-diagnostics | FileCheck %s
+// RUN: circt-opt %s -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
 
 // CHECK: calyx.program {
 calyx.program {

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -27,6 +27,7 @@ calyx.program {
     calyx.control {}
   }
 
+  // CHECK-LABEL: calyx.component @ComponentWithNoPorts() -> () {
   calyx.component @ComponentWithNoPorts() -> () {
     calyx.cells {}
     calyx.wires {}

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -1,39 +1,43 @@
 // RUN: circt-opt %s -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
 
-// CHECK-LABEL:  calyx.component @ComponentWithInAndOutPorts(%in1: i64, %in2: i16) -> (%out1: i32, %out2: i8) {
-calyx.component @ComponentWithInAndOutPorts(%in1: i64, %in2: i16) -> (%out1: i32, %out2: i8) {
+calyx.program {
 
-  // CHECK:        calyx.cells {
-  calyx.cells {}
-  // CHECK:        calyx.wires {
-  calyx.wires {}
-  // CHECK:        calyx.control {
-  calyx.control {}
-}
+  // CHECK-LABEL:  calyx.component @ComponentWithInAndOutPorts(%in1: i64, %in2: i16) -> (%out1: i32, %out2: i8) {
+  calyx.component @ComponentWithInAndOutPorts(%in1: i64, %in2: i16) -> (%out1: i32, %out2: i8) {
 
-// CHECK-LABEL: calyx.component @ComponentWithInPort(%x: i64) -> () {
-calyx.component @ComponentWithInPort(%x: i64) -> () {
+    // CHECK:        calyx.cells {
+    calyx.cells {}
+    // CHECK:        calyx.wires {
+    calyx.wires {}
+    // CHECK:        calyx.control {
+    calyx.control {}
+  }
 
-  calyx.cells {}
-  calyx.wires {}
-  calyx.control {}
+  // CHECK-LABEL: calyx.component @ComponentWithInPort(%x: i64) -> () {
+  calyx.component @ComponentWithInPort(%x: i64) -> () {
 
-}
+    calyx.cells {}
+    calyx.wires {}
+    calyx.control {}
 
-// CHECK-LABEL: calyx.component @ComponentWithOutPort() -> (%y: i64) {
-calyx.component @ComponentWithOutPort() -> (%y: i64) {
+  }
 
-  calyx.cells {}
-  calyx.wires {}
-  calyx.control {}
+  // CHECK-LABEL: calyx.component @ComponentWithOutPort() -> (%y: i64) {
+  calyx.component @ComponentWithOutPort() -> (%y: i64) {
 
-}
+    calyx.cells {}
+    calyx.wires {}
+    calyx.control {}
 
-// CHECK-LABEL: calyx.component @ComponentWithNoPorts() -> () {
-calyx.component @ComponentWithNoPorts() -> () {
+  }
 
-  calyx.cells {}
-  calyx.wires {}
-  calyx.control {}
+  calyx.component @main() -> () {
+    calyx.cells {
+      // CHECK: %0 = calyx.cell "c0" @ComponentWithOutPort() : () -> i64
+      %0 = calyx.cell "c0" @ComponentWithOutPort() : () -> i64
+    }
+    calyx.wires {}
+    calyx.control {}
+  }
 
 }

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -1,0 +1,39 @@
+// RUN: circt-opt %s -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
+
+// CHECK-LABEL:  calyx.component @ComponentWithInAndOutPorts(%in1: i64, %in2: i16) -> (%out1: i32, %out2: i8) {
+calyx.component @ComponentWithInAndOutPorts(%in1: i64, %in2: i16) -> (%out1: i32, %out2: i8) {
+
+  // CHECK:        calyx.cells {
+  calyx.cells {}
+  // CHECK:        calyx.wires {
+  calyx.wires {}
+  // CHECK:        calyx.control {
+  calyx.control {}
+}
+
+// CHECK-LABEL: calyx.component @ComponentWithInPort(%x: i64) -> () {
+calyx.component @ComponentWithInPort(%x: i64) -> () {
+
+  calyx.cells {}
+  calyx.wires {}
+  calyx.control {}
+
+}
+
+// CHECK-LABEL: calyx.component @ComponentWithOutPort() -> (%y: i64) {
+calyx.component @ComponentWithOutPort() -> (%y: i64) {
+
+  calyx.cells {}
+  calyx.wires {}
+  calyx.control {}
+
+}
+
+// CHECK-LABEL: calyx.component @ComponentWithNoPorts() -> () {
+calyx.component @ComponentWithNoPorts() -> () {
+
+  calyx.cells {}
+  calyx.wires {}
+  calyx.control {}
+
+}

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -1,39 +1,45 @@
-// RUN: circt-opt %s -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
+// RUN: circt-opt %s -verify-diagnostics | FileCheck %s
 
 // CHECK: calyx.program {
 calyx.program {
 
   // CHECK-LABEL:  calyx.component @ComponentWithInAndOutPorts(%in1: i64, %in2: i16) -> (%out1: i32, %out2: i8) {
   calyx.component @ComponentWithInAndOutPorts(%in1: i64, %in2: i16) -> (%out1: i32, %out2: i8) {
-
     // CHECK:        calyx.cells {
-    calyx.cells {}
     // CHECK:        calyx.wires {
-    calyx.wires {}
     // CHECK:        calyx.control {
+    calyx.cells {}
+    calyx.wires {}
     calyx.control {}
   }
 
   // CHECK-LABEL: calyx.component @ComponentWithInPort(%x: i64) -> () {
   calyx.component @ComponentWithInPort(%x: i64) -> () {
-
     calyx.cells {}
     calyx.wires {}
     calyx.control {}
-
   }
 
   // CHECK-LABEL: calyx.component @ComponentWithOutPort() -> (%y: i64) {
   calyx.component @ComponentWithOutPort() -> (%y: i64) {
-
     calyx.cells {}
     calyx.wires {}
     calyx.control {}
+  }
 
+  calyx.component @ComponentWithNoPorts() -> () {
+    calyx.cells {}
+    calyx.wires {}
+    calyx.control {}
   }
 
   calyx.component @main() -> () {
-    calyx.cells {}
+    calyx.cells {
+      // CHECK: %0:4 = calyx.cell "c0" @ComponentWithInAndOutPorts : i64, i16, i32, i8
+      // CHECK-NEXT: calyx.cell "c1" @ComponentWithNoPorts
+      %in1, %in2, %out1, %out2 = calyx.cell "c0" @ComponentWithInAndOutPorts : i64, i16, i32, i8
+      calyx.cell "c1" @ComponentWithNoPorts
+    }
     calyx.wires {}
     calyx.control {}
   }

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -33,10 +33,7 @@ calyx.program {
   }
 
   calyx.component @main() -> () {
-    calyx.cells {
-      // CHECK: %0 = calyx.cell "c0" @ComponentWithOutPort() : () -> i64
-      %0 = calyx.cell "c0" @ComponentWithOutPort() : () -> i64
-    }
+    calyx.cells {}
     calyx.wires {}
     calyx.control {}
   }


### PR DESCRIPTION
- Add new ops for `calyx.cell` (used to create instances of components and primitives) and `calyx.program` (encompasses a Calyx program).
- Verifier for `calyx.cells` (every op within the body should be a `calyx.cell`).
- Functions to get a component's port information. Eerily similar to both `FIRRTL` and `HW`'s implementations, but with some key differences (e.g. `HW` has `InOut` port direction, which Calyx currently doesn't support, `FIRRTL` uses `FIRRTLType`).
- Closes #1321. Using instances in this manner allows for Calyx component's to maintain the FunctionLike trait, and keep the separation of structure and control.