### PR TITLE
[FIRRTL][Annotation] Fix a bug in parsing annotation target

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
@@ -116,20 +116,23 @@ static llvm::Optional<std::string> canonicalizeTarget(StringRef target) {
   //   3. ComponentName => ReferenceTarget, e.g., A.B.C -> ~A|B>C
   std::string newTarget = "~";
   llvm::raw_string_ostream s(newTarget);
-  bool isModule = true;
+  unsigned tokenIdx = 0;
   for (auto a : target) {
-    switch (a) {
-    case '.':
-      if (isModule) {
+    if (a == '.') {
+      switch (tokenIdx) {
+      case 0:
         s << "|";
-        isModule = false;
+        break;
+      case 1:
+        s << ">";
+        break;
+      default:
+        s << ".";
         break;
       }
-      s << ">";
-      break;
-    default:
+      ++tokenIdx;
+    } else
       s << a;
-    }
   }
   return llvm::Optional<std::string>(newTarget);
 }

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -90,16 +90,18 @@ circuit Foo: %[[
 ; COM: Test result annotations of InstanceOp.
 circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar.a"},
                 {"two":null,"target":"~Foo|Foo>bar.b.baz"},
-                {"three":null,"target":"~Foo|Foo/bar:Bar>b.qux"}]]
+                {"three":null,"target":"~Foo|Foo/bar:Bar>b.qux"},
+                {"four":null,"target":"Foo.Foo.bar.c"}]]
   module Bar:
     input a: UInt<1>
     output b: {baz: UInt<1>, qux: UInt<1>}
+    output c: UInt<1>
   module Foo:
     inst bar of Bar
 
     ; CHECK-LABEL: module {
-    ; CHECK: %bar_a, %bar_b = firrtl.instance @Bar
-    ; CHECK-SAME: [{one}], [#firrtl.subAnno<fieldID = [1, 1], {two}>, #firrtl.subAnno<fieldID = [2, 2], {three}>]
+    ; CHECK: %bar_a, %bar_b, %bar_c = firrtl.instance @Bar
+    ; CHECK-SAME: [{one}], [#firrtl.subAnno<fieldID = [1, 1], {two}>, #firrtl.subAnno<fieldID = [2, 2], {three}>], [{four}]
 
 ; // -----
 


### PR DESCRIPTION
Previously, an annotation target like `Foo.Foo.bar.baz` is canonicalized to `~Foo|Foo>bar>baz`, which is incorrect. This patch resolves this issue by canonicalizing it to `~Foo|Foo>bar.baz`.