### PR TITLE
[FIRRTL][Annotation] Verify circuit target during parsing

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
@@ -183,7 +183,7 @@ static A tryGetAs(DictionaryAttr &dict, DictionaryAttr &root, StringRef key,
 /// represented as a Target-keyed arrays of attributes.  The input JSON value is
 /// checked, at runtime, to be an array of objects.  Returns true if successful,
 /// false if unsuccessful.
-bool circt::firrtl::fromJSON(json::Value &value,
+bool circt::firrtl::fromJSON(json::Value &value, StringRef circuitTarget,
                              llvm::StringMap<ArrayAttr> &annotationMap,
                              json::Path path, MLIRContext *context) {
 
@@ -314,6 +314,14 @@ bool circt::firrtl::fromJSON(json::Value &value,
     if (!optTarget)
       return false;
     StringRef targetStrRef = optTarget.getValue();
+
+    auto circuitFieldEnd = targetStrRef.find_first_of('|');
+    if (circuitFieldEnd != StringRef::npos) {
+      if (circuitTarget != targetStrRef.take_front(circuitFieldEnd)) {
+        p.report("Annotation has invalid circuit name");
+        return false;
+      }
+    }
 
     // Build up the Attribute to represent the Annotation and store it in the
     // global Target -> Attribute mapping.

--- a/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
@@ -318,7 +318,7 @@ bool circt::firrtl::fromJSON(json::Value &value, StringRef circuitTarget,
     auto circuitFieldEnd = targetStrRef.find_first_of('|');
     if (circuitFieldEnd != StringRef::npos) {
       if (circuitTarget != targetStrRef.take_front(circuitFieldEnd)) {
-        p.report("Annotation has invalid circuit name");
+        p.report("annotation has invalid circuit name");
         return false;
       }
     }

--- a/lib/Dialect/FIRRTL/Import/FIRAnnotations.h
+++ b/lib/Dialect/FIRRTL/Import/FIRAnnotations.h
@@ -30,7 +30,7 @@ class ArrayAttr;
 namespace circt {
 namespace firrtl {
 
-bool fromJSON(llvm::json::Value &value,
+bool fromJSON(llvm::json::Value &value, StringRef circuitTarget,
               llvm::StringMap<ArrayAttr> &annotationMap, llvm::json::Path path,
               MLIRContext *context);
 

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3029,7 +3029,7 @@ private:
   /// Add annotations from a string to the internal annotation map.  Report
   /// errors using a provided source manager location and with a provided error
   /// message
-  ParseResult importAnnotations(SMLoc loc, StringRef circuitName,
+  ParseResult importAnnotations(SMLoc loc, StringRef circuitTarget,
                                 StringRef annotationsStr);
 
   ParseResult parseModule(CircuitOp circuit, StringRef circuitTarget,
@@ -3061,7 +3061,7 @@ private:
 } // end anonymous namespace
 
 ParseResult FIRCircuitParser::importAnnotations(SMLoc loc,
-                                                StringRef circuitName,
+                                                StringRef circuitTarget,
                                                 StringRef annotationsStr) {
 
   auto annotations = json::parse(annotationsStr);
@@ -3075,7 +3075,7 @@ ParseResult FIRCircuitParser::importAnnotations(SMLoc loc,
 
   json::Path::Root root;
   llvm::StringMap<ArrayAttr> thisAnnotationMap;
-  if (!fromJSON(annotations.get(), circuitName, thisAnnotationMap, root,
+  if (!fromJSON(annotations.get(), circuitTarget, thisAnnotationMap, root,
                 getContext())) {
     auto diag = emitError(loc, "Invalid/unsupported annotation format");
     std::string jsonErrorMessage =

--- a/test/Dialect/FIRRTL/annotations-errors.fir
+++ b/test/Dialect/FIRRTL/annotations-errors.fir
@@ -3,7 +3,7 @@
 ; COM: Invalid circuit should report an error
 
 ; expected-error @+2 {{Invalid/unsupported annotation format}}
-; expected-note @+1 {{/* error: Annotation has invalid circuit name */}}
+; expected-note @+1 {{/* error: annotation has invalid circuit name */}}
 circuit Foo: %[[{"one":null,"target":"~Fooo|Foo>bar"}]]
   module Foo:
     skip

--- a/test/Dialect/FIRRTL/annotations-errors.fir
+++ b/test/Dialect/FIRRTL/annotations-errors.fir
@@ -1,5 +1,15 @@
 ; RUN: circt-translate -import-firrtl -verify-diagnostics --split-input-file %s
 
+; COM: Invalid circuit should report an error
+
+; expected-error @+2 {{Invalid/unsupported annotation format}}
+; expected-note @+1 {{/* error: Annotation has invalid circuit name */}}
+circuit Foo: %[[{"one":null,"target":"~Fooo|Foo>bar"}]]
+  module Foo:
+    skip
+
+; // -----
+
 ; COM: A non-local Annotation is unsupported.
 
 ; expected-error @+2 {{Invalid/unsupported annotation format}}

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -265,15 +265,15 @@ circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar[0]"},{"two":null,"target":"~F
 ; // -----
 
 ; COM: Annotations should apply even when the target's name is dropped.
-circuit Foo: %[[{"target": "Foo|Foo>_T_0", "a": "a"},
-                {"target": "Foo|Foo>_T_1", "a": "a"},
-                {"target": "Foo|Foo>_T_2", "a": "a"},
-                {"target": "Foo|Foo>_T_3", "a": "a"},
-                {"target": "Foo|Foo>_T_4", "a": "a"},
-                {"target": "Foo|Foo>_T_5", "a": "a"},
-                {"target": "Foo|Foo>_T_6", "a": "a"},
-                {"target": "Foo|Foo>_T_7", "a": "a"},
-                {"target": "Foo|Foo>_T_8", "a": "a"}]]
+circuit Foo: %[[{"target": "~Foo|Foo>_T_0", "a": "a"},
+                {"target": "~Foo|Foo>_T_1", "a": "a"},
+                {"target": "~Foo|Foo>_T_2", "a": "a"},
+                {"target": "~Foo|Foo>_T_3", "a": "a"},
+                {"target": "~Foo|Foo>_T_4", "a": "a"},
+                {"target": "~Foo|Foo>_T_5", "a": "a"},
+                {"target": "~Foo|Foo>_T_6", "a": "a"},
+                {"target": "~Foo|Foo>_T_7", "a": "a"},
+                {"target": "~Foo|Foo>_T_8", "a": "a"}]]
   module Bar:
     skip
   module Foo:
@@ -309,15 +309,15 @@ circuit Foo: %[[{"target": "Foo|Foo>_T_0", "a": "a"},
 ; // -----
 
 ; COM: DontTouch annotation preserves temporary names
-circuit Foo: %[[{"target": "Foo|Foo>_T_0", "class": "firrtl.transforms.DontTouchAnnotation"},
-                {"target": "Foo|Foo>_T_1", "class": "firrtl.transforms.DontTouchAnnotation"},
-                {"target": "Foo|Foo>_T_2", "class": "firrtl.transforms.DontTouchAnnotation"},
-                {"target": "Foo|Foo>_T_3", "class": "firrtl.transforms.DontTouchAnnotation"},
-                {"target": "Foo|Foo>_T_4", "class": "firrtl.transforms.DontTouchAnnotation"},
-                {"target": "Foo|Foo>_T_5", "class": "firrtl.transforms.DontTouchAnnotation"},
-                {"target": "Foo|Foo>_T_6", "class": "firrtl.transforms.DontTouchAnnotation"},
-                {"target": "Foo|Foo>_T_7", "class": "firrtl.transforms.DontTouchAnnotation"},
-                {"target": "Foo|Foo>_T_8", "class": "firrtl.transforms.DontTouchAnnotation"}]]
+circuit Foo: %[[{"target": "~Foo|Foo>_T_0", "class": "firrtl.transforms.DontTouchAnnotation"},
+                {"target": "~Foo|Foo>_T_1", "class": "firrtl.transforms.DontTouchAnnotation"},
+                {"target": "~Foo|Foo>_T_2", "class": "firrtl.transforms.DontTouchAnnotation"},
+                {"target": "~Foo|Foo>_T_3", "class": "firrtl.transforms.DontTouchAnnotation"},
+                {"target": "~Foo|Foo>_T_4", "class": "firrtl.transforms.DontTouchAnnotation"},
+                {"target": "~Foo|Foo>_T_5", "class": "firrtl.transforms.DontTouchAnnotation"},
+                {"target": "~Foo|Foo>_T_6", "class": "firrtl.transforms.DontTouchAnnotation"},
+                {"target": "~Foo|Foo>_T_7", "class": "firrtl.transforms.DontTouchAnnotation"},
+                {"target": "~Foo|Foo>_T_8", "class": "firrtl.transforms.DontTouchAnnotation"}]]
   module Bar:
     skip
   module Foo:


### PR DESCRIPTION
This is a small patch verifying the circuit target of each annotation matches the circuit name during the FIRRTL parsing.