### PR TITLE
[FIRRTL] Add DataTapAnnotation to DontTouch

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
@@ -233,7 +233,8 @@ bool AnnotationSet::hasAnnotationImpl(StringRef className) const {
 }
 
 bool AnnotationSet::hasDontTouch() const {
-  return hasAnnotation("firrtl.transforms.DontTouchAnnotation");
+  return (hasAnnotation("firrtl.transforms.DontTouchAnnotation") ||
+          hasAnnotation("sifive.enterprise.grandcentral.DataTapsAnnotation"));
 }
 
 /// Add more annotations to this AttributeSet.

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -570,6 +570,25 @@ firrtl.module @reg_cst_prop1_DontTouch(in %clock: !firrtl.clock, out %out_b: !fi
   firrtl.connect %tmp_b, %tmp_a : !firrtl.uint<8>, !firrtl.uint<8>
   firrtl.connect %out_b, %tmp_b : !firrtl.uint<8>, !firrtl.uint<8>
 }
+
+// Check for DontTouch annotation
+// CHECK-LABEL: @reg_cst_prop1_DontTouch2
+// CHECK-NEXT:      %c5_ui8 = firrtl.constant 5 : !firrtl.uint<8>
+// CHECK-NEXT:      %tmp_a = firrtl.reg %clock  {annotations = [{class = "sifive.enterprise.grandcentral.DataTapsAnnotation"}]} : (!firrtl.clock) -> !firrtl.uint<8>
+// CHECK-NEXT:      %tmp_b = firrtl.reg %clock  : (!firrtl.clock) -> !firrtl.uint<8>
+// CHECK-NEXT:      firrtl.connect %tmp_a, %c5_ui8 : !firrtl.uint<8>, !firrtl.uint<8>
+// CHECK-NEXT:      firrtl.connect %tmp_b, %tmp_a : !firrtl.uint<8>, !firrtl.uint<8>
+// CHECK-NEXT:      firrtl.connect %out_b, %tmp_b : !firrtl.uint<8>, !firrtl.uint<8>
+
+firrtl.module @reg_cst_prop1_DontTouch2(in %clock: !firrtl.clock, out %out_b: !firrtl.uint<8>) {
+  %c5_ui8 = firrtl.constant 5 : !firrtl.uint<8>
+  %tmp_a = firrtl.reg %clock {name = "tmp_a", annotations = [{class = "sifive.enterprise.grandcentral.DataTapsAnnotation"}]}  : (!firrtl.clock) -> !firrtl.uint<8>
+  %tmp_b = firrtl.reg %clock {name = "tmp_b"} : (!firrtl.clock) -> !firrtl.uint<8>
+  firrtl.connect %tmp_a, %c5_ui8 : !firrtl.uint<8>, !firrtl.uint<8>
+  firrtl.connect %tmp_b, %tmp_a : !firrtl.uint<8>, !firrtl.uint<8>
+  firrtl.connect %out_b, %tmp_b : !firrtl.uint<8>, !firrtl.uint<8>
+}
+
 // CHECK-LABEL: @reg_cst_prop2
 // CHECK-NEXT:   %c5_ui8 = firrtl.constant 5 : !firrtl.uint<8>
 // CHECK-NEXT:   firrtl.connect %out_b, %c5_ui8 : !firrtl.uint<8>, !firrtl.uint<8>


### PR DESCRIPTION
Consider `DataTaps` annotation as DontTouch to mimic SFC behavior. 
In SFC any annotation that implements the trait `HasDontTouches` is treated as `DontTouch`. 
This PR is a temporary fix, to add the annotations that SFC considers as DontTouch explicitly to `AnnotationSet::hasDontTouch()`