### PR TITLE
[FIRRTL] Add support for binds to Grand Central

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -19,7 +19,8 @@ def InstanceOp : FIRRTLOp<"instance"> {
 
   let arguments = (ins FlatSymbolRefAttr:$moduleName, StrAttr:$name,
                        AnnotationArrayAttr:$annotations,
-                       PortAnnotationsAttr:$portAnnotations);
+                       PortAnnotationsAttr:$portAnnotations,
+                       BoolAttr:$lowerToBind);
   let results = (outs Variadic<FIRRTLType>:$results);
 
   let assemblyFormat =
@@ -32,7 +33,8 @@ def InstanceOp : FIRRTLOp<"instance"> {
                    "::mlir::StringRef":$moduleName,
                    CArg<"StringRef", "{}">:$name,
                    CArg<"ArrayRef<Attribute>", "{}">:$annotations,
-                   CArg<"ArrayRef<Attribute>", "{}">:$portAnnotations)>,
+                   CArg<"ArrayRef<Attribute>", "{}">:$portAnnotations,
+                   CArg<"bool","false">:$lowerToBind)>,
 
     /// Constructor that creates a version of the specified instance, but that
     /// erases some number of results from it.

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -841,10 +841,11 @@ Operation *InstanceOp::getReferencedModule() {
 void InstanceOp::build(OpBuilder &builder, OperationState &result,
                        TypeRange resultTypes, StringRef moduleName,
                        StringRef name, ArrayRef<Attribute> annotations,
-                       ArrayRef<Attribute> portAnnotations) {
+                       ArrayRef<Attribute> portAnnotations, bool lowerToBind) {
   result.addAttribute("moduleName", builder.getSymbolRefAttr(moduleName));
   result.addAttribute("name", builder.getStringAttr(name));
   result.addAttribute("annotations", builder.getArrayAttr(annotations));
+  result.addAttribute("lowerToBind", builder.getBoolAttr(lowerToBind));
   result.addTypes(resultTypes);
 
   if (portAnnotations.empty()) {
@@ -2339,14 +2340,25 @@ static void printImplicitSSAName(OpAsmPrinter &p, Operation *op,
 
 static ParseResult parseInstanceOp(OpAsmParser &parser,
                                    NamedAttrList &resultAttrs) {
-  return parseElidePortAnnotations(parser, resultAttrs);
+  auto result = parseElidePortAnnotations(parser, resultAttrs);
+
+  if (!resultAttrs.get("lowerToBind")) {
+    resultAttrs.append("lowerToBind", parser.getBuilder().getBoolAttr(false));
+  }
+
+  return result;
 }
 
 /// Always elide "moduleName" and elide "annotations" if it exists or
 /// if it is empty.
 static void printInstanceOp(OpAsmPrinter &p, Operation *op,
                             DictionaryAttr attr) {
-  printElidePortAnnotations(p, op, attr, {"moduleName"});
+  SmallVector<StringRef, 2> elides = {"moduleName"};
+  if (auto lowerToBind = op->getAttrOfType<BoolAttr>("lowerToBind"))
+    if (!lowerToBind.getValue())
+      elides.push_back("lowerToBind");
+
+  printElidePortAnnotations(p, op, attr, elides);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2349,8 +2349,8 @@ static ParseResult parseInstanceOp(OpAsmParser &parser,
   return result;
 }
 
-/// Always elide "moduleName" and elide "annotations" if it exists or
-/// if it is empty.
+/// Always elide "moduleName", elide "lowerToBind" if false, and elide
+/// "annotations" if it exists or if it is empty.
 static void printInstanceOp(OpAsmPrinter &p, Operation *op,
                             DictionaryAttr attr) {
   SmallVector<StringRef, 2> elides = {"moduleName"};

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2662,8 +2662,9 @@ ParseResult FIRStmtParser::parseInstance() {
                    });
   auto name = dontTouch ? id : filterUselessName(id);
 
-  auto result = builder.create<InstanceOp>(
-      resultTypes, moduleName, name, annotations.first, annotations.second);
+  auto result =
+      builder.create<InstanceOp>(resultTypes, moduleName, name,
+                                 annotations.first, annotations.second, false);
 
   // Since we are implicitly unbundling the instance results, we need to keep
   // track of the mapping from bundle fields to results in the unbundledValues

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2662,9 +2662,9 @@ ParseResult FIRStmtParser::parseInstance() {
                    });
   auto name = dontTouch ? id : filterUselessName(id);
 
-  auto result =
-      builder.create<InstanceOp>(resultTypes, moduleName, name,
-                                 annotations.first, annotations.second, false);
+  auto result = builder.create<InstanceOp>(resultTypes, moduleName, name,
+                                           annotations.first.getValue(),
+                                           annotations.second.getValue());
 
   // Since we are implicitly unbundling the instance results, we need to keep
   // track of the mapping from bundle fields to results in the unbundledValues

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -214,6 +214,7 @@ public:
   void visitDecl(RegResetOp op) { handleRef(op); }
   void visitDecl(WireOp op) { handleRef(op); }
   void visitDecl(NodeOp op) { handleRef(op); }
+  void visitDecl(InstanceOp op);
 
   /// Process all other ops.  Error if any of these ops contain annotations that
   /// indicate it as being part of an interface.
@@ -349,6 +350,29 @@ void GrandCentralVisitor::handlePorts(Operation *op) {
   mlir::function_like_impl::setAllArgAttrDicts(op, newArgAttrs);
 }
 
+void GrandCentralVisitor::visitDecl(InstanceOp op) {
+
+  // If this instance's underlying module has a "companion" annotation, then
+  // move this onto the actual instance op.
+  AnnotationSet annotations(op.getReferencedModule());
+  if (auto anno = annotations.getAnnotation(
+          "sifive.enterprise.grandcentral.GrandCentralView$"
+          "SerializedViewAnnotation")) {
+    auto tpe = anno.getAs<StringAttr>("type");
+    if (!tpe) {
+      op.getReferencedModule()->emitOpError(
+          "contains a GrandcCentralView$SerializedViewAnnotation that does not "
+          "contain a \"type\" field");
+      failed = true;
+      return;
+    }
+    if (tpe.getValue() == "companion")
+      op->setAttr("lowerToBind", BoolAttr::get(op.getContext(), true));
+  }
+
+  visitUnhandledDecl(op);
+}
+
 void GrandCentralPass::runOnOperation() {
   CircuitOp circuitOp = getOperation();
 
@@ -412,13 +436,21 @@ void GrandCentralPass::runOnOperation() {
   circuitOp->setAttr("annotations", annotations.getArrayAttr());
 
   // Walk through the circuit to collect additional information.  If this fails,
-  // signal pass failure.
-  for (auto &op : circuitOp.getBody()->getOperations()) {
+  // signal pass failure.  Walk in reverse order so that annotations can be
+  // removed from modules after all referring instances have consumed their
+  // annotations.
+  for (auto &op : llvm::reverse(circuitOp.getBody()->getOperations())) {
     if (isa<FModuleOp, FExtModuleOp>(op)) {
       GrandCentralVisitor visitor(interfaceMap);
       visitor.visitModule(&op);
       if (visitor.hasFailed())
         return signalPassFailure();
+      AnnotationSet annotations(&op);
+      annotations.removeAnnotations([](auto anno) {
+        return anno.isClass("sifive.enterprise.grandcentral.GrandCentralView$"
+                            "SerializedViewAnnotation");
+      });
+      annotations.applyToOperation(&op);
     }
   }
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerBundleVectorTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerBundleVectorTypes.cpp
@@ -897,7 +897,7 @@ void TypeLoweringVisitor::visitDecl(InstanceOp op) {
   // FIXME: annotation update
   auto newInstance = builder->create<InstanceOp>(
       resultTypes, op.moduleNameAttr(), op.nameAttr(), op.annotations(),
-      builder->getArrayAttr(newPortAnno), builder->getBoolAttr(false));
+      builder->getArrayAttr(newPortAnno), op.lowerToBindAttr());
 
   SmallVector<Value> lowered;
   for (size_t aggIndex = 0, eAgg = op.getNumResults(); aggIndex != eAgg;

--- a/lib/Dialect/FIRRTL/Transforms/LowerBundleVectorTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerBundleVectorTypes.cpp
@@ -897,7 +897,7 @@ void TypeLoweringVisitor::visitDecl(InstanceOp op) {
   // FIXME: annotation update
   auto newInstance = builder->create<InstanceOp>(
       resultTypes, op.moduleNameAttr(), op.nameAttr(), op.annotations(),
-      builder->getArrayAttr(newPortAnno));
+      builder->getArrayAttr(newPortAnno), builder->getBoolAttr(false));
 
   SmallVector<Value> lowered;
   for (size_t aggIndex = 0, eAgg = op.getNumResults(); aggIndex != eAgg;

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -430,7 +430,7 @@ void TypeLoweringVisitor::visitDecl(InstanceOp op) {
 
   auto newInstance = builder->create<InstanceOp>(
       resultTypes, op.moduleNameAttr(), op.nameAttr(), op.annotations(),
-      builder->getArrayAttr(lowerPortAnnotations));
+      builder->getArrayAttr(lowerPortAnnotations), op.lowerToBindAttr());
 
   // Record the mapping of each old result to each new result.
   size_t nextResult = 0;

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -2655,7 +2655,8 @@ void ModuleEmitter::emitBind(BindOp bind) {
   auto instance = bind.getReferencedInstance();
   auto instantiator = instance->getParentOfType<hw::HWModuleOp>().getName();
   auto instanceName = instance.instanceName();
-  os << "bind " << instantiator << " " << instanceName << " " << instanceName << " (.*);\n\n";
+  os << "bind " << instantiator << " " << instanceName << " " << instanceName
+     << " (.*);\n\n";
 }
 
 // Check if the value is from read of a wire or reg or is a port.

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -2651,7 +2651,12 @@ void ModuleEmitter::emitHWGeneratedModule(HWModuleGeneratedOp module) {
   os << "// external generated module " << verilogName.getValue() << "\n\n";
 }
 
-void ModuleEmitter::emitBind(BindOp bind) { os << "// bind\n\n"; }
+void ModuleEmitter::emitBind(BindOp bind) {
+  auto instance = bind.getReferencedInstance();
+  auto instantiator = instance->getParentOfType<hw::HWModuleOp>().getName();
+  auto instanceName = instance.instanceName();
+  os << "bind " << instantiator << " " << instanceName << " " << instanceName << " (.*);\n\n";
+}
 
 // Check if the value is from read of a wire or reg or is a port.
 static bool isSimpleReadOrPort(Value v) {

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -392,6 +392,13 @@ firrtl.circuit "Simple" {
     %1455 = firrtl.asPassive %hits_1_7 : !firrtl.uint<1>
   }
 
+  // CHECK: sv.bind @[[bazSymbol:.+]] {output_file
+  // CHECK-NEXT: hw.module @bindTest()
+  firrtl.module @bindTest() {
+    // CHECK: hw.instance "baz" sym @[[bazSymbol]] @bar
+    %baz = firrtl.instance @bar {lowerToBind = true, name = "baz"} : !firrtl.uint<1>
+  }
+
   // https://github.com/llvm/circt/issues/314
   // CHECK-LABEL: hw.module @issue314
   firrtl.module @issue314(in %inp_2: !firrtl.uint<27>, in %inpi: !firrtl.uint<65>) {

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -137,3 +137,24 @@ firrtl.circuit "UnsupportedTypes" attributes {annotations = [{a}, {class = "sifi
 // CHECK-NEXT: sv.verbatim "// boolean = <unsupported boolean type>;"
 // CHECK-NEXT: sv.verbatim "// integer = <unsupported integer type>;"
 // CHECK-NEXT: sv.verbatim "// double = <unsupported double type>;"
+
+// -----
+
+firrtl.circuit "BindTest" attributes {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedBundleType", defName = "Foo", elements = []}]} {
+  firrtl.module @Companion() attributes {annotations = [{class = "sifive.enterprise.grandcentral.GrandCentralView$SerializedViewAnnotation", id = 42 : i64, type = "companion"}]} {}
+  firrtl.module @BindTest() {
+    firrtl.instance @Companion { name = "companion1" }
+    firrtl.instance @Companion { name = "companion2" }
+  }
+}
+
+// CHECK-LABEL: firrtl.circuit "BindTest"
+
+// Annotations are remove from the companion module declaration.
+// CHECK: firrtl.module @Companion()
+// CHECK-NOT: annotations
+// CHECK-SAME: {
+
+// Each companion instance has "lowerToBind" set.
+// CHECK: firrtl.module @BindTest
+// CHECK-COUNT-2: firrtl.instance @Companion {lowerToBind = true

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -125,4 +125,11 @@ firrtl.module @VerbatimExpr() {
   %2 = firrtl.add %0, %1 : (!firrtl.uint<42>, !firrtl.uint<32>) -> !firrtl.uint<43>
 }
 
+// CHECK-LABL: @LowerToBind
+// CHECK: firrtl.instance @InstanceLowerToBind {lowerToBind = true, name = "foo"}
+firrtl.module @InstanceLowerToBind() {}
+firrtl.module @LowerToBind() {
+  firrtl.instance @InstanceLowerToBind {lowerToBind = true, name = "foo"}
+}
+
 }

--- a/test/ExportVerilog/verilog-basic.mlir
+++ b/test/ExportVerilog/verilog-basic.mlir
@@ -377,3 +377,18 @@ hw.module @UnaryParensIssue755(%a: i8) -> (%b: i1) {
   %1 = comb.icmp ne %0, %c0_i8 : i8
   hw.output %1 : i1
 }
+
+sv.bind @__BindEmissionInstance__ {output_file = {directory = "BindTest", exclude_from_filelist = true, exclude_replicated_ops = true, name = "BindEmissionInstance.sv"}}
+// CHECK-LABL: module BindEmissionInstance()
+hw.module @BindEmissionInstance() {
+  hw.output
+}
+// CHECK-LABEL: module BindEmission()
+hw.module @BindEmission() -> () {
+  // CHECK-NEXT: // BindEmissionInstance BindEmissionInstance ();
+  hw.instance "BindEmissionInstance" sym @__BindEmissionInstance__ @BindEmissionInstance() {doNotPrint = true} : () -> ()
+  hw.output
+}
+
+// CHECK-LABEL: FILE "BindTest/BindEmissionInstance.sv"
+// CHECK: bind BindEmission BindEmissionInstance BindEmissionInstance (.*);


### PR DESCRIPTION
Lower the companion defined in a Grand Central view to a SystemVerilog `bind`.  This adds a new `BoolAttr` for FIRRTL dialect's `InstanceOp` called `lowerToBind`.  If this is true, then the destiny of an instance is to become a bind.

The first commit in this patch set turns on _actual_ bind emission (as opposed to emitting a chicken-switch comment).  Note: this is the minimal implementation necessary for bind emission. It doesn't handle the situation of binds needing to keep wires around.  Grand Central views are relying on io-less companion modules that are bound in.  Therefore, such a simplistic approach will work for the needs of Grand Central.

This PR is really four logical commits and it may be easier to review them individually.