### PR TITLE
[CAPI] Remove MLIRPublicAPI dependency from C-API test

### DIFF
--- a/test/CAPI/CMakeLists.txt
+++ b/test/CAPI/CMakeLists.txt
@@ -9,7 +9,6 @@ target_link_libraries(circt-capi-ir-test
   ${dialect_libs}
 
   MLIRCAPIRegistration
-  MLIRPublicAPI
   CIRCTCAPIComb
   CIRCTCAPIHW
   CIRCTCAPISeq


### PR DESCRIPTION
This PR attempts to address https://github.com/llvm/circt/issues/880 . According to https://llvm.discourse.group/t/inconsistent-typeid-after-linking-libmlir-so/2122, the typeIDs do not yet properly work with .dylib, so statically linking seems like the right way to go ... for now.

### Justification on Why This Works Follows ### 

I built LLVM and circt with the following flags on a M1 Macbook Air.

```bash
# building llvm
cmake -G Ninja ../llvm \                                   
    -DLLVM_ENABLE_PROJECTS="mlir" \
    -DLLVM_TARGETS_TO_BUILD="host" \
    -DLLVM_ENABLE_ASSERTIONS=ON \
    -DCMAKE_BUILD_TYPE=DEBUG

# building circt
cmake -G Ninja .. \                                       
    -DMLIR_DIR=$PWD/../llvm/build/lib/cmake/mlir \
    -DLLVM_DIR=$PWD/../llvm/build/lib/cmake/llvm \
    -DLLVM_ENABLE_ASSERTIONS=ON \
    -DCMAKE_BUILD_TYPE=DEBUG
```

The invocation from `ninja -v ./bin/circt-capi-ir-test`. Notably, notice that MLIR libraries are both linked statically and dynamically.

```
/Library/Developer/CommandLineTools/usr/bin/c++ -fno-exceptions -fno-rtti -fPIC -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wstring-conversion -Wmisleading-indentation -fdiagnostics-color -g -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk -Wl,-search_paths_first -Wl,-headerpad_max_install_names  test/CAPI/CMakeFiles/circt-capi-ir-test.dir/ir.c.o -o bin/circt-capi-ir-test  -Wl,-rpath,@loader_path/../lib -Wl,-rpath,/Users/fyq14/dev/circt/llvm/build/./lib  ../llvm/build/lib/libMLIRAffine.a  ../llvm/build/lib/libMLIRAffineTransforms.a  ../llvm/build/lib/libMLIRAffineUtils.a  ../llvm/build/lib/libMLIRArmNeon.a  ../llvm/build/lib/libMLIRArmSVE.a  ../llvm/build/lib/libMLIRArmSVETransforms.a  ../llvm/build/lib/libMLIRAsync.a  ../llvm/build/lib/libMLIRAsyncTransforms.a  ../llvm/build/lib/libMLIRAMX.a  ../llvm/build/lib/libMLIRAMXTransforms.a  ../llvm/build/lib/libMLIRComplex.a  ../llvm/build/lib/libMLIRDLTI.a  ../llvm/build/lib/libMLIRGPU.a  ../llvm/build/lib/libMLIRLinalgAnalysis.a  ../llvm/build/lib/libMLIRLinalg.a  ../llvm/build/lib/libMLIRLinalgTransforms.a  ../llvm/build/lib/libMLIRLinalgUtils.a  ../llvm/build/lib/libMLIRLLVMIRTransforms.a  ../llvm/build/lib/libMLIRLLVMIR.a  ../llvm/build/lib/libMLIRNVVMIR.a  ../llvm/build/lib/libMLIRROCDLIR.a  ../llvm/build/lib/libMLIRMath.a  ../llvm/build/lib/libMLIRMathTransforms.a  ../llvm/build/lib/libMLIRMemRef.a  ../llvm/build/lib/libMLIRMemRefTransforms.a  ../llvm/build/lib/libMLIRMemRefUtils.a  ../llvm/build/lib/libMLIROpenACC.a  ../llvm/build/lib/libMLIROpenMP.a  ../llvm/build/lib/libMLIRPDL.a  ../llvm/build/lib/libMLIRPDLInterp.a  ../llvm/build/lib/libMLIRQuant.a  ../llvm/build/lib/libMLIRSCF.a  ../llvm/build/lib/libMLIRSCFTransforms.a  ../llvm/build/lib/libMLIRSDBM.a  ../llvm/build/lib/libMLIRShape.a  ../llvm/build/lib/libMLIRShapeOpsTransforms.a  ../llvm/build/lib/libMLIRSparseTensor.a  ../llvm/build/lib/libMLIRSparseTensorTransforms.a  ../llvm/build/lib/libMLIRSPIRV.a  ../llvm/build/lib/libMLIRSPIRVModuleCombiner.a  ../llvm/build/lib/libMLIRSPIRVConversion.a  ../llvm/build/lib/libMLIRSPIRVTransforms.a  ../llvm/build/lib/libMLIRSPIRVUtils.a  ../llvm/build/lib/libMLIRStandard.a  ../llvm/build/lib/libMLIRStandardOpsTransforms.a  ../llvm/build/lib/libMLIRTensor.a  ../llvm/build/lib/libMLIRTensorTransforms.a  ../llvm/build/lib/libMLIRTosa.a  ../llvm/build/lib/libMLIRTosaTransforms.a  ../llvm/build/lib/libMLIRVector.a  ../llvm/build/lib/libMLIRX86Vector.a  ../llvm/build/lib/libMLIRX86VectorTransforms.a  ../llvm/build/lib/libMLIRTosaTestPasses.a  ../llvm/build/lib/libMLIRCAPIRegistration.a  ../llvm/build/lib/libMLIRPublicAPI.dylib  lib/libCIRCTCAPIComb.a  lib/libCIRCTCAPIHW.a  lib/libCIRCTCAPISeq.a  lib/libCIRCTCAPISV.a  lib/libCIRCTCAPIExportVerilog.a  ../llvm/build/lib/libMLIRAffineTransforms.a  ../llvm/build/lib/libMLIRAsyncTransforms.a  ../llvm/build/lib/libMLIRMathTransforms.a  ../llvm/build/lib/libMLIRMemRefTransforms.a  ../llvm/build/lib/libMLIRSDBM.a  ../llvm/build/lib/libMLIRShapeOpsTransforms.a  ../llvm/build/lib/libMLIRSparseTensorTransforms.a  ../llvm/build/lib/libMLIRLinalgTransforms.a  ../llvm/build/lib/libMLIRLinalgAnalysis.a  ../llvm/build/lib/libMLIRSCFTransforms.a  ../llvm/build/lib/libMLIRSparseTensor.a  ../llvm/build/lib/libMLIRSPIRVModuleCombiner.a  ../llvm/build/lib/libMLIRSPIRVTransforms.a  ../llvm/build/lib/libMLIRTensorTransforms.a  ../llvm/build/lib/libMLIRSPIRVTranslateRegistration.a  ../llvm/build/lib/libMLIRSPIRVDeserialization.a  ../llvm/build/lib/libMLIRToLLVMIRTranslationRegistration.a  ../llvm/build/lib/libMLIRArmNeonToLLVMIRTranslation.a  ../llvm/build/lib/libMLIRArmSVEToLLVMIRTranslation.a  ../llvm/build/lib/libMLIRAMXToLLVMIRTranslation.a  ../llvm/build/lib/libMLIRNVVMToLLVMIRTranslation.a  ../llvm/build/lib/libMLIROpenACCToLLVMIRTranslation.a  ../llvm/build/lib/libMLIROpenMPToLLVMIRTranslation.a  ../llvm/build/lib/libMLIRROCDLToLLVMIRTranslation.a  ../llvm/build/lib/libMLIRX86VectorToLLVMIRTranslation.a  ../llvm/build/lib/libMLIRTargetLLVMIRImport.a  ../llvm/build/lib/libLLVMIRReader.a  ../llvm/build/lib/libMLIRArmNeon2dToIntr.a  ../llvm/build/lib/libMLIRComplexToLLVM.a  ../llvm/build/lib/libMLIRComplexToStandard.a  ../llvm/build/lib/libMLIRGPUToNVVMTransforms.a  ../llvm/build/lib/libMLIRNVVMIR.a  ../llvm/build/lib/libMLIRGPUToROCDLTransforms.a  ../llvm/build/lib/libMLIRGPUToGPURuntimeTransforms.a  ../llvm/build/lib/libMLIRAsyncToLLVM.a  ../llvm/build/lib/libMLIRGPUToSPIRV.a  ../llvm/build/lib/libMLIRGPUToVulkanTransforms.a  ../llvm/build/lib/libMLIRSPIRVSerialization.a  ../llvm/build/lib/libMLIRSPIRVBinaryUtils.a  ../llvm/build/lib/libMLIRLinalgToLLVM.a  ../llvm/build/lib/libMLIRVectorToSCF.a  ../llvm/build/lib/libMLIRLinalgToSPIRV.a  ../llvm/build/lib/libMLIRLinalgToStandard.a  ../llvm/build/lib/libMLIRMathToLibm.a  ../llvm/build/lib/libMLIRStandardOpsTransforms.a  ../llvm/build/lib/libMLIROpenACCToLLVM.a  ../llvm/build/lib/libMLIROpenACCToSCF.a  ../llvm/build/lib/libMLIROpenMPToLLVM.a  ../llvm/build/lib/libMLIRSCFToGPU.a  ../llvm/build/lib/libMLIRComplex.a  ../llvm/build/lib/libMLIRAffineToStandard.a  ../llvm/build/lib/libMLIRSCFToOpenMP.a  ../llvm/build/lib/libMLIRSCFToSPIRV.a  ../llvm/build/lib/libMLIRSCFToStandard.a  ../llvm/build/lib/libMLIRShapeToStandard.a  ../llvm/build/lib/libMLIRShape.a  ../llvm/build/lib/libMLIRSPIRVToLLVM.a  ../llvm/build/lib/libMLIRSPIRVUtils.a  ../llvm/build/lib/libMLIRStandardToSPIRV.a  ../llvm/build/lib/libMLIRTosaToLinalg.a  ../llvm/build/lib/libMLIRLinalgUtils.a  ../llvm/build/lib/libMLIRTosaToSCF.a  ../llvm/build/lib/libMLIRTosaToStandard.a  ../llvm/build/lib/libMLIRTosaTransforms.a  ../llvm/build/lib/libMLIRTosa.a  ../llvm/build/lib/libMLIRQuant.a  ../llvm/build/lib/libMLIRVectorToROCDL.a  ../llvm/build/lib/libMLIRROCDLIR.a  ../llvm/build/lib/libMLIRVectorToLLVM.a  ../llvm/build/lib/libMLIRArmNeon.a  ../llvm/build/lib/libMLIRArmSVETransforms.a  ../llvm/build/lib/libMLIRArmSVE.a  ../llvm/build/lib/libMLIRAMXTransforms.a  ../llvm/build/lib/libMLIRAMX.a  ../llvm/build/lib/libMLIRX86VectorTransforms.a  ../llvm/build/lib/libMLIRX86Vector.a  ../llvm/build/lib/libMLIRStandardToLLVM.a  ../llvm/build/lib/libMLIRMath.a  ../llvm/build/lib/libMLIRVectorToGPU.a  ../llvm/build/lib/libMLIRGPU.a  ../llvm/build/lib/libMLIRAsync.a  ../llvm/build/lib/libMLIRDLTI.a  ../llvm/build/lib/libMLIRLLVMToLLVMIRTranslation.a  ../llvm/build/lib/libMLIRTargetLLVMIRExport.a  ../llvm/build/lib/libMLIRLLVMIRTransforms.a  ../llvm/build/lib/libMLIROpenACC.a  ../llvm/build/lib/libMLIROpenMP.a  ../llvm/build/lib/libLLVMFrontendOpenMP.a  ../llvm/build/lib/libLLVMTransformUtils.a  ../llvm/build/lib/libMLIRLLVMIR.a  ../llvm/build/lib/libLLVMAsmParser.a  ../llvm/build/lib/libLLVMBitWriter.a  ../llvm/build/lib/libLLVMAnalysis.a  ../llvm/build/lib/libLLVMProfileData.a  ../llvm/build/lib/libLLVMObject.a  ../llvm/build/lib/libLLVMBitReader.a  ../llvm/build/lib/libLLVMMCParser.a  ../llvm/build/lib/libLLVMMC.a  ../llvm/build/lib/libLLVMDebugInfoCodeView.a  ../llvm/build/lib/libLLVMTextAPI.a  ../llvm/build/lib/libMLIRVectorToSPIRV.a  ../llvm/build/lib/libMLIRSPIRVConversion.a  ../llvm/build/lib/libMLIRSPIRV.a  lib/libCIRCTSeq.a  ../llvm/build/lib/libMLIRTransforms.a  ../llvm/build/lib/libMLIRVector.a  ../llvm/build/lib/libMLIRAffineUtils.a  ../llvm/build/lib/libMLIRCopyOpInterface.a  lib/libCIRCTSVTransforms.a  ../llvm/build/lib/libMLIRTransformUtils.a  ../llvm/build/lib/libMLIRLoopAnalysis.a  ../llvm/build/lib/libMLIRPresburger.a  ../llvm/build/lib/libMLIRRewrite.a  ../llvm/build/lib/libMLIRPDLToPDLInterp.a  ../llvm/build/lib/libMLIRPDLInterp.a  ../llvm/build/lib/libMLIRPDL.a  ../llvm/build/lib/libMLIRCAPIIR.a  lib/libCIRCTExportVerilog.a  lib/libCIRCTSV.a  lib/libCIRCTComb.a  ../llvm/build/lib/libMLIRTranslation.a  lib/libCIRCTFIRRTL.a  ../llvm/build/lib/libMLIRPass.a  ../llvm/build/lib/libMLIRAnalysis.a  ../llvm/build/lib/libMLIRLinalg.a  ../llvm/build/lib/libMLIRAffine.a  ../llvm/build/lib/libMLIRDialectUtils.a  ../llvm/build/lib/libMLIRParser.a  ../llvm/build/lib/libMLIRSCF.a  ../llvm/build/lib/libMLIRMemRef.a  ../llvm/build/lib/libMLIRMemRefUtils.a  ../llvm/build/lib/libMLIRDialect.a  ../llvm/build/lib/libMLIRStandard.a  ../llvm/build/lib/libMLIRTensor.a  ../llvm/build/lib/libLLVMCore.a  ../llvm/build/lib/libLLVMBinaryFormat.a  ../llvm/build/lib/libLLVMRemarks.a  ../llvm/build/lib/libLLVMBitstreamReader.a  ../llvm/build/lib/libMLIRViewLikeInterface.a  ../llvm/build/lib/libMLIRCastInterfaces.a  ../llvm/build/lib/libMLIRVectorInterfaces.a  ../llvm/build/lib/libMLIRLoopLikeInterface.a  ../llvm/build/lib/libMLIRSideEffectInterfaces.a  ../llvm/build/lib/libMLIRDataLayoutInterfaces.a  ../llvm/build/lib/libMLIRInferTypeOpInterface.a  ../llvm/build/lib/libMLIRCallInterfaces.a  ../llvm/build/lib/libMLIRControlFlowInterfaces.a  lib/libCIRCTHW.a  lib/libCIRCTSupport.a  ../llvm/build/lib/libMLIRIR.a  ../llvm/build/lib/libMLIRSupport.a  ../llvm/build/lib/libLLVMSupport.a  -lm  /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk/usr/lib/libz.tbd  /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk/usr/lib/libcurses.tbd  ../llvm/build/lib/libLLVMDemangle.a
```

I don't have a good theory as to why this works in Release, and not in debug, as mentioned in the issue. But I do suspect that it's due to different methods referencing different TypeIDs. I am purely speculating that depending on whether they inlined the statically linked one, or references the dynamic one. As shown below:

(big caveat: I'm not a C++ expert)

```bash
(lldb) breakpoint set --name InOutType::get
(lldb) run
(lldb) # I manually ran step a few times.
Process 17500 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = step in
    frame #0: 0x0000000100173720 circt-capi-ir-test`circt::hw::isHWValueType(type=Type @ 0x000000016fdff370) at HWTypes.cpp:62:12
   59  	/// hardware but not marker types like InOutType.
   60  	bool circt::hw::isHWValueType(Type type) {
   61  	  // Signless and signed integer types are both valid.
-> 62  	  if (type.isa<IntegerType>())
   63  	    return true;
   64  	
   65  	  if (auto array = type.dyn_cast<ArrayType>())
(lldb) expr (int) type.isSignlessInteger()
(int) $16 = 1
(lldb) expr (int) type.isUnsignedInteger()
(int) $17 = 0  # but why?
```

And as mentioned in the issue, the type ID does not match those of IntegerType.

```
(lldb) expr (uint64_t) mlir::IntegerType::getTypeID().storage
(uint64_t) $18 = 4296646152
(lldb) expr (uint64_t) type.getTypeID().storage
(uint64_t) $20 = 4358510576
```

