### PR TITLE
[Comb] Collapse extract(n, extract(m, x)) into extract(n+m, x)

### DIFF
--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -149,6 +149,17 @@ LogicalResult ExtractOp::canonicalize(ExtractOp op, PatternRewriter &rewriter) {
       return success();
     }
   }
+
+  // extract(olo, extract(ilo, x)) = extract(olo + ilo, x)
+  if (auto innerExtract = dyn_cast_or_null<ExtractOp>(op.input().getDefiningOp())) {
+    rewriter.replaceOpWithNewOp<ExtractOp>(
+        op,
+        op.getType(),
+        innerExtract.input(),
+        innerExtract.lowBit() + op.lowBit());
+    return success();
+  }
+
   return failure();
 }
 

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -66,3 +66,14 @@ hw.module @andDedupLong(%arg0: i7, %arg1: i7, %arg2: i7) -> (i7) {
   %0 = comb.and %arg0, %arg1, %arg2, %arg0: i7
   hw.output %0 : i7
 }
+
+// CHECK-LABEL: @extractNested
+hw.module @extractNested(%0: i5) -> (%o1 : i1) {
+// Multiple layers of nested extract is a weak evidence that the cannonicalization
+// operates recursively.
+// CHECK-NEXT: %0 = comb.extract %arg0 from 4 : (i5) -> i1
+  %1 = comb.extract %0 from 1 : (i5) -> i4
+  %2 = comb.extract %1 from 2 : (i4) -> i2
+  %3 = comb.extract %2 from 1 : (i2) -> i1
+  hw.output %3 : i1
+}


### PR DESCRIPTION
Tackles https://github.com/llvm/circt/issues/1326 in the Combs pass.