### PR TITLE
Add DontTouch annotation when scattering DataTapsAnnotation

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
@@ -673,8 +673,13 @@ bool circt::firrtl::scatterCustomAnnotations(
       auto target = canonicalizeTarget(blackBoxAttr.getValue());
       if (!target)
         return false;
+      NamedAttrList dontTouchAnn;
+      dontTouchAnn.append("class",
+          StringAttr::get(context, "firrtl.transforms.DontTouchAnnotation"));
       newAnnotations[target.getValue()].push_back(
           DictionaryAttr::getWithSorted(context, attrs));
+      newAnnotations[target.getValue()].push_back(
+          DictionaryAttr::getWithSorted(context, dontTouchAnn));
 
       // Process all the taps.
       auto keyAttr = tryGetAs<ArrayAttr>(dict, dict, "keys", loc, clazz);
@@ -717,9 +722,13 @@ bool circt::firrtl::scatterCustomAnnotations(
             return false;
           newAnnotations[sourceTarget.getValue()].push_back(
               DictionaryAttr::getWithSorted(context, source));
+          newAnnotations[sourceTarget.getValue()].push_back(
+              DictionaryAttr::getWithSorted(context, dontTouchAnn));
           port.append("portID", portID);
           newAnnotations[portTarget.getValue()].push_back(
               DictionaryAttr::getWithSorted(context, port));
+          newAnnotations[portTarget.getValue()].push_back(
+              DictionaryAttr::getWithSorted(context, dontTouchAnn));
           continue;
         }
 
@@ -740,8 +749,12 @@ bool circt::firrtl::scatterCustomAnnotations(
             return false;
           newAnnotations[moduleTarget.getValue()].push_back(
               DictionaryAttr::getWithSorted(context, module));
+          newAnnotations[moduleTarget.getValue()].push_back(
+              DictionaryAttr::getWithSorted(context, dontTouchAnn));
           newAnnotations[portTarget.getValue()].push_back(
               DictionaryAttr::getWithSorted(context, port));
+          newAnnotations[portTarget.getValue()].push_back(
+              DictionaryAttr::getWithSorted(context, dontTouchAnn));
           continue;
         }
 
@@ -749,6 +762,8 @@ bool circt::firrtl::scatterCustomAnnotations(
             "sifive.enterprise.grandcentral.DeletedDataTapKey") {
           newAnnotations[portTarget.getValue()].push_back(
               DictionaryAttr::getWithSorted(context, port));
+          newAnnotations[portTarget.getValue()].push_back(
+              DictionaryAttr::getWithSorted(context, dontTouchAnn));
           continue;
         }
 
@@ -768,6 +783,8 @@ bool circt::firrtl::scatterCustomAnnotations(
             return false;
           newAnnotations[portNameTarget.getValue()].push_back(
               DictionaryAttr::getWithSorted(context, literal));
+          newAnnotations[portNameTarget.getValue()].push_back(
+              DictionaryAttr::getWithSorted(context, dontTouchAnn));
           continue;
         }
 

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -430,18 +430,18 @@ circuit GCTDataTap : %[
     ; CHECK-LABEL: firrtl.circuit "GCTDataTap"
     ; CHECK-SAME: annotations = [{unrelatedAnnotation}]
     ; CHECK: firrtl.extmodule @DataTap
-    ; CHECK-SAME: %_0: {{.+}} {firrtl.annotations = [{class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = [[ID:[0-9]+]] : i64, portID = [[PORT_ID:[0-9]+]] : i64}]},
-    ; CHECK-SAME: %_1: {{.+}} {firrtl.annotations = [{class = "sifive.enterprise.grandcentral.DataTapModuleSignalKey", id = [[ID]] : i64}]},
-    ; CHECK-SAME: %_2: {{.+}} {firrtl.annotations = [{class = "sifive.enterprise.grandcentral.DeletedDataTapKey", id = [[ID]] : i64}]},
-    ; CHECK-SAME: %_3: {{.+}} {firrtl.annotations = [{class = "sifive.enterprise.grandcentral.LiteralDataTapKey", literal = "UInt<16>(\22h2a\22)"}]}
-    ; CHECK-SAME: annotations = [{class = "sifive.enterprise.grandcentral.DataTapsAnnotation"}]
+    ; CHECK-SAME: %_0: {{.+}} {firrtl.annotations = [{class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = [[ID:[0-9]+]] : i64, portID = [[PORT_ID:[0-9]+]] : i64}, {class = "firrtl.transforms.DontTouchAnnotation"}]},
+    ; CHECK-SAME: %_1: {{.+}} {firrtl.annotations = [{class = "sifive.enterprise.grandcentral.DataTapModuleSignalKey", id = [[ID]] : i64}, {class = "firrtl.transforms.DontTouchAnnotation"}]},
+    ; CHECK-SAME: %_2: {{.+}} {firrtl.annotations = [{class = "sifive.enterprise.grandcentral.DeletedDataTapKey", id = [[ID]] : i64}, {class = "firrtl.transforms.DontTouchAnnotation"}]},
+    ; CHECK-SAME: %_3: {{.+}} {firrtl.annotations = [{class = "sifive.enterprise.grandcentral.LiteralDataTapKey", literal = "UInt<16>(\22h2a\22)"}, {class = "firrtl.transforms.DontTouchAnnotation"}]}
+    ; CHECK-SAME: annotations = [{class = "sifive.enterprise.grandcentral.DataTapsAnnotation"}, {class = "firrtl.transforms.DontTouchAnnotation"}]
 
     ; CHECK: firrtl.extmodule @BlackBox
-    ; CHECK-SAME: annotations = [{class = "sifive.enterprise.grandcentral.DataTapModuleSignalKey", id = [[ID]] : i64, internalPath = "baz.qux"}]
+    ; CHECK-SAME: annotations = [{class = "sifive.enterprise.grandcentral.DataTapModuleSignalKey", id = [[ID]] : i64, internalPath = "baz.qux"}, {class = "firrtl.transforms.DontTouchAnnotation"}]
 
     ; CHECK: firrtl.module @GCTDataTap
     ; CHECK: firrtl.reg
-    ; CHECk-SAME: annotations = [{class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = [[ID]] : i64, portID = [[PORT_ID]] : i64}]
+    ; CHECk-SAME: annotations = [{class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = [[ID]] : i64, portID = [[PORT_ID]] : i64}, {class = "firrtl.transforms.DontTouchAnnotation"}]
 
 ; // -----
 


### PR DESCRIPTION
This PR adds the `DontTouch` annotation when scattering the `DataTapsAnnotation` . Any annotation like the `DataTapsAnnotation` that implements the trait `HasDontTouches` should be treated as `DontTouch`. 
https://www.chisel-lang.org/api/firrtl/1.4.3/firrtl/transforms/HasDontTouches.html