### PR TITLE
[Calyx] Remove CellsOp. Add GroupOp, AssignOp, DoneOp.

### DIFF
--- a/include/circt/Dialect/Calyx/Calyx.td
+++ b/include/circt/Dialect/Calyx/Calyx.td
@@ -13,9 +13,9 @@
 #ifndef CALYX_TD
 #define CALYX_TD
 
-include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
-include "mlir/IR/OpAsmInterface.td"
+include "mlir/IR/OpBase.td"
+include "mlir/IR/RegionKindInterface.td"
 include "mlir/IR/SymbolInterfaces.td"
 
 def CalyxDialect : Dialect {

--- a/include/circt/Dialect/Calyx/Calyx.td
+++ b/include/circt/Dialect/Calyx/Calyx.td
@@ -13,7 +13,6 @@
 #ifndef CALYX_TD
 #define CALYX_TD
 
-include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpBase.td"
 include "mlir/IR/RegionKindInterface.td"
 include "mlir/IR/SymbolInterfaces.td"

--- a/include/circt/Dialect/Calyx/CalyxOps.h
+++ b/include/circt/Dialect/Calyx/CalyxOps.h
@@ -14,7 +14,6 @@
 #define CIRCT_DIALECT_CALYX_OPS_H
 
 #include "circt/Dialect/Calyx/CalyxDialect.h"
-#include "mlir/IR/Builders.h"
 #include "mlir/IR/FunctionSupport.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/RegionKindInterface.h"

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -38,7 +38,8 @@ def ComponentOp : CalyxOp<"component", [
     IsolatedFromAbove,
     // TODO(Calyx): Need to eventually expose the output ports.
     NoTerminator,
-    SingleBlock
+    SingleBlock,
+    SymbolTable
   ]> {
   let summary = "Calyx Component";
   let description = [{
@@ -94,12 +95,12 @@ def CellsOp : CalyxContainer<"cells", [
   let description = [{
     The "calyx.cells" operation represents a container for
     the sub-components that are used within the parent
-    component.
+    component. This may only contain `calyx.cell` ops.
 
     ```mlir
       calyx.cells {
-       // TODO(Calyx): Add `cell` examples once
-       // CellOps are added.
+        %in0 = calyx.cell "a0" @A : i64
+        %in1, %out0 = calyx.cell "b0" @B : i132, i8
       }
     ```
   }];
@@ -118,8 +119,7 @@ def WiresOp : CalyxContainer<"wires", [
 
     ```mlir
       calyx.wires {
-        // TODO(Calyx): Add `group` examples once
-        // GroupOps are added.
+        calyx.group @A { ... }
       }
     ```
   }];
@@ -181,4 +181,43 @@ def CellOp : CalyxOp<"cell", [
     $instanceName $componentName attr-dict (`:` type($results)^)?
   }];
   let verifier = "return ::verify$cppClass(*this);";
+}
+
+def GroupOp : CalyxOp<"group", [
+    HasParent<"WiresOp">,
+    RegionKindInterface,
+    // TODO(Calyx): When assignments are added:
+    // SingleBlockImplicitTerminator<>
+    SingleBlock,
+    NoTerminator,
+    Symbol
+  ]> {
+  let summary = "Calyx Group";
+  let description = [{
+    Represents a Calyx group, which is a collection
+    of assignments that are only active when the group
+    is run from the control execution schedule. A group
+    signifies its termination with a special port named
+    a "done" port.
+
+    ```mlir
+      calyx.group @MyGroup {
+        // TODO(Calyx): Add assignments when
+        // they are in the Calyx dialect.
+      }
+    ```
+  }];
+
+  let arguments = (ins SymbolNameAttr: $sym_name);
+
+  let extraClassDeclaration = [{
+    // Implement RegionKindInterface.
+    static RegionKind getRegionKind(unsigned index) { return RegionKind::Graph; }
+
+    /// Returns the body of a Calyx group.
+    Block *getBody() { return &getOperation()->getRegion(0).front(); }
+  }];
+
+  let regions = (region SizedRegion<1>:$body);
+  let assemblyFormat = "$sym_name $body attr-dict";
 }

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -36,10 +36,8 @@ def ComponentOp : CalyxOp<"component", [
     Symbol,
     FunctionLike,
     IsolatedFromAbove,
-    // TODO(Calyx): Need to eventually expose the output ports.
-    NoTerminator,
     SingleBlock,
-    SymbolTable
+    NoTerminator
   ]> {
   let summary = "Calyx Component";
   let description = [{
@@ -50,7 +48,8 @@ def ComponentOp : CalyxOp<"component", [
     (2) The cells, wires, and control schedule.
     ```mlir
       calyx.component @MyComponent(%in1: i32) -> (%out1: i8) {
-        calyx.cells { ... }
+        %in, %out = "c0" @SomeComponent : i32, i32
+
         calyx.wires { ... }
         calyx.control { ... }
       }
@@ -87,29 +86,9 @@ def ComponentOp : CalyxOp<"component", [
   let parser = "return ::parse$cppClass(parser, result);";
 }
 
-def CellsOp : CalyxContainer<"cells", [
-    HasParent<"ComponentOp">,
-    IsolatedFromAbove
-  ]> {
-  let summary = "Calyx Cells";
-  let description = [{
-    The "calyx.cells" operation represents a container for
-    the sub-components that are used within the parent
-    component. This may only contain `calyx.cell` ops.
-
-    ```mlir
-      calyx.cells {
-        %in0 = calyx.cell "a0" @A : i64
-        %in1, %out0 = calyx.cell "b0" @B : i132, i8
-      }
-    ```
-  }];
-
-  let verifier = "return ::verify$cppClass(*this);";
-}
-
 def WiresOp : CalyxContainer<"wires", [
-    HasParent<"ComponentOp">
+    HasParent<"ComponentOp">,
+    SymbolTable
   ]> {
   let summary = "Calyx Wires";
   let description = [{
@@ -152,7 +131,7 @@ def ControlOp : CalyxContainer<"control", [
 }
 
 def CellOp : CalyxOp<"cell", [
-    HasParent<"CellsOp">
+    // HasParent<"ComponentOp">
   ]> {
   let summary = "Calyx Cell";
   let description = [{
@@ -187,11 +166,9 @@ def CellOp : CalyxOp<"cell", [
 
 def GroupOp : CalyxOp<"group", [
     HasParent<"WiresOp">,
+    NoRegionArguments,
     RegionKindInterface,
-    // TODO(Calyx): When assignments are added:
-    // SingleBlockImplicitTerminator<>
     SingleBlock,
-    NoTerminator,
     Symbol
   ]> {
   let summary = "Calyx Group";
@@ -204,8 +181,8 @@ def GroupOp : CalyxOp<"group", [
 
     ```mlir
       calyx.group @MyGroup {
-        // TODO(Calyx): Add assignments when
-        // they are in the Calyx dialect.
+        calyx.assign %1, %2 : i32
+        calyx.done %3 : i1
       }
     ```
   }];
@@ -222,4 +199,34 @@ def GroupOp : CalyxOp<"group", [
 
   let regions = (region SizedRegion<1>:$body);
   let assemblyFormat = "$sym_name $body attr-dict";
+}
+
+// TODO(Calyx): Add optional guard to AssignOp and DoneOp.
+def AssignOp : CalyxOp<"assign", [
+    SameTypeOperands
+  ]> {
+  let summary = "Calyx Assignment";
+  let description = [{
+    The "calyx.assign" operation represents a non-blocking
+    assignment. An assignment may optionally be
+    guarded. This operation should only be instantiated in the
+    "calyx.wires" section or a "calyx.group".
+  }];
+  let arguments = (ins AnyType:$dest, AnyType:$src);
+  let assemblyFormat = "$dest `=` $src attr-dict `:` type($src)";
+  let verifier = "return ::verify$cppClass(*this);";
+}
+
+def DoneOp : CalyxOp<"done", [
+    HasParent<"GroupOp">,
+    Terminator
+  ]> {
+    let summary = "Calyx Done Port";
+    let description = [{
+      The "calyx.done" operation represents a port on a
+      Calyx group that signifies when the group is finished.
+    }];
+
+    let arguments = (ins AnyType:$src);
+    let assemblyFormat = "$src attr-dict `:` type($src)";
 }

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -120,6 +120,8 @@ def WiresOp : CalyxContainer<"wires", [
     ```mlir
       calyx.wires {
         calyx.group @A { ... }
+        // TODO(Calyx): Add example of assignment
+        // outside of a Calyx GroupOp.
       }
     ```
   }];

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -99,8 +99,7 @@ def WiresOp : CalyxContainer<"wires", [
     ```mlir
       calyx.wires {
         calyx.group @A { ... }
-        // TODO(Calyx): Add example of assignment
-        // outside of a Calyx GroupOp.
+        calyx.assign %1, %2
       }
     ```
   }];
@@ -192,9 +191,6 @@ def GroupOp : CalyxOp<"group", [
   let extraClassDeclaration = [{
     // Implement RegionKindInterface.
     static RegionKind getRegionKind(unsigned index) { return RegionKind::Graph; }
-
-    /// Returns the body of a Calyx group.
-    Block *getBody() { return &getOperation()->getRegion(0).front(); }
   }];
 
   let regions = (region SizedRegion<1>:$body);

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -99,7 +99,7 @@ def WiresOp : CalyxContainer<"wires", [
     ```mlir
       calyx.wires {
         calyx.group @A { ... }
-        calyx.assign %1, %2
+        calyx.assign %1 = %2 : i16
       }
     ```
   }];
@@ -180,7 +180,7 @@ def GroupOp : CalyxOp<"group", [
 
     ```mlir
       calyx.group @MyGroup {
-        calyx.assign %1, %2 : i32
+        calyx.assign %1 = %2 : i32
         calyx.done %3 : i1
       }
     ```
@@ -207,6 +207,10 @@ def AssignOp : CalyxOp<"assign", [
     assignment. An assignment may optionally be
     guarded. This operation should only be instantiated in the
     "calyx.wires" section or a "calyx.group".
+
+    ```mlir
+      calyx.assign %1 = %2 : i16
+    ```
   }];
   let arguments = (ins AnyType:$dest, AnyType:$src);
   let assemblyFormat = "$dest `=` $src attr-dict `:` type($src)";
@@ -221,6 +225,10 @@ def DoneOp : CalyxOp<"done", [
     let description = [{
       The "calyx.done" operation represents a port on a
       Calyx group that signifies when the group is finished.
+
+      ```mlir
+        calyx.done %0 : i1
+      ```
     }];
 
     let arguments = (ins AnyType:$src);

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -131,7 +131,7 @@ def ControlOp : CalyxContainer<"control", [
 }
 
 def CellOp : CalyxOp<"cell", [
-    // HasParent<"ComponentOp">
+    HasParent<"ComponentOp">
   ]> {
   let summary = "Calyx Cell";
   let description = [{

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -271,7 +271,8 @@ static LogicalResult verifyCellOp(CellOp cell) {
 // AssignOp
 //===----------------------------------------------------------------------===//
 static LogicalResult verifyAssignOp(AssignOp assign) {
-  if (assign->getParentOfType<GroupOp>() || assign->getParentOfType<WiresOp>())
+  auto parent = assign->getParentOp();
+  if (isa<GroupOp>(parent) || isa<WiresOp>(parent))
     return success();
   return assign.emitOpError(
       "should only be contained in \"calyx.wires\" or \"calyx.group\"");

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -275,7 +275,7 @@ static LogicalResult verifyAssignOp(AssignOp assign) {
   if (isa<GroupOp>(parent) || isa<WiresOp>(parent))
     return success();
   return assign.emitOpError(
-      "should only be contained in \"calyx.wires\" or \"calyx.group\"");
+      "should only be contained in 'calyx.wires' or 'calyx.group'");
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/Calyx/CalyxOps.h"
-#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/DialectImplementation.h"
@@ -199,31 +198,19 @@ static ParseResult parseComponentOp(OpAsmParser &parser,
 
 static LogicalResult verifyComponentOp(ComponentOp op) {
   // Verify there is exactly one of each section:
-  // calyx.cells, calyx.wires, and calyx.control.
-  uint32_t numCells = 0, numWires = 0, numControl = 0;
+  // calyx.wires, and calyx.control.
+  uint32_t numWires = 0, numControl = 0;
   for (auto &bodyOp : *op.getBody()) {
-    if (isa<CellsOp>(bodyOp))
-      ++numCells;
-    else if (isa<WiresOp>(bodyOp))
+    if (isa<WiresOp>(bodyOp))
       ++numWires;
     else if (isa<ControlOp>(bodyOp))
       ++numControl;
   }
-  if (numCells == 1 && numWires == 1 && numControl == 1)
+  if (numWires == 1 && numControl == 1)
     return success();
 
   return op.emitOpError() << "requires exactly one of each: "
-                             "'calyx.cells', 'calyx.wires', 'calyx.control'.";
-}
-
-//===----------------------------------------------------------------------===//
-// CellsOp
-//===----------------------------------------------------------------------===//
-static LogicalResult verifyCellsOp(CellsOp cells) {
-  if (!llvm::all_of(*cells.getBody(), [](auto &op) { return isa<CellOp>(op); }))
-    return cells.emitOpError("should only contain 'calyx.cell' ops.");
-
-  return success();
+                             "'calyx.wires', 'calyx.control'.";
 }
 
 //===----------------------------------------------------------------------===//
@@ -252,8 +239,7 @@ static LogicalResult verifyCellOp(CellOp cell) {
            << ", which does not exist.";
 
   // Verify the referenced component is not instantiating itself.
-  auto cells = cell->getParentOfType<CellsOp>();
-  auto parentComponent = cells->getParentOfType<ComponentOp>();
+  auto parentComponent = cell->getParentOfType<ComponentOp>();
   if (parentComponent == referencedComponent)
     return cell.emitOpError()
            << "is a recursive instantiation of its parent component: "
@@ -279,6 +265,16 @@ static LogicalResult verifyCellOp(CellOp cell) {
            << expectedType << ", but got " << resultType;
   }
   return success();
+}
+
+//===----------------------------------------------------------------------===//
+// AssignOp
+//===----------------------------------------------------------------------===//
+static LogicalResult verifyAssignOp(AssignOp assign) {
+  if (assign->getParentOfType<GroupOp>() || assign->getParentOfType<WiresOp>())
+    return success();
+  return assign.emitOpError(
+      "should only be contained in \"calyx.wires\" or \"calyx.group\"");
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -6,9 +6,8 @@ calyx.program {}
 // -----
 
 calyx.program {
-  // expected-error @+1 {{'calyx.component' op requires exactly one of each: 'calyx.cells', 'calyx.wires', 'calyx.control'.}}
+  // expected-error @+1 {{'calyx.component' op requires exactly one of each: 'calyx.wires', 'calyx.control'.}}
   calyx.component @main() -> () {
-    calyx.wires {}
     calyx.control {}
   }
 }
@@ -17,10 +16,9 @@ calyx.program {
 
 calyx.program {
   calyx.component @main() -> () {
-    calyx.cells {
-      // expected-error @+1 {{'calyx.cell' op is referencing component: A, which does not exist.}}
-      calyx.cell "a0" @A
-    }
+    // expected-error @+1 {{'calyx.cell' op is referencing component: A, which does not exist.}}
+    calyx.cell "a0" @A
+
     calyx.wires {}
     calyx.control {}
   }
@@ -30,15 +28,12 @@ calyx.program {
 
 calyx.program {
   calyx.component @A(%in: i16) -> () {
-    calyx.cells {}
     calyx.wires {}
     calyx.control {}
   }
   calyx.component @main() -> () {
-    calyx.cells {
-      // expected-error @+1 {{'calyx.cell' op has a wrong number of results; expected: 1 but got 0}}
-      calyx.cell "a0" @A
-    }
+    // expected-error @+1 {{'calyx.cell' op has a wrong number of results; expected: 1 but got 0}}
+    calyx.cell "a0" @A
     calyx.wires {}
     calyx.control {}
   }
@@ -48,15 +43,13 @@ calyx.program {
 
 calyx.program {
   calyx.component @B(%in: i16) -> () {
-    calyx.cells {}
     calyx.wires {}
     calyx.control {}
   }
   calyx.component @main() -> () {
-    calyx.cells {
-      // expected-error @+1 {{'calyx.cell' op result type for "%in" must be 'i16', but got 'i1'}}
-      %0 = calyx.cell "b0" @B : i1
-    }
+    // expected-error @+1 {{'calyx.cell' op result type for "%in" must be 'i16', but got 'i1'}}
+    %0 = calyx.cell "b0" @B : i1
+
     calyx.wires {}
     calyx.control {}
   }

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -54,3 +54,25 @@ calyx.program {
     calyx.control {}
   }
 }
+
+// -----
+
+calyx.program {
+  calyx.component @A() -> (%out: i16) {
+    calyx.wires {}
+    calyx.control {}
+  }
+  calyx.component @B(%in: i16) -> () {
+    calyx.wires {}
+    calyx.control {}
+  }
+  calyx.component @main() -> () {
+    %0 = calyx.cell "a0" @A : i16
+    %1 = calyx.cell "b0" @B : i16
+    // expected-error @+1 {{'calyx.assign' op should only be contained in 'calyx.wires' or 'calyx.group'}}
+    calyx.assign %1 = %0 : i16
+
+    calyx.wires {}
+    calyx.control {}
+  }
+}

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -3,49 +3,51 @@
 // CHECK: calyx.program {
 calyx.program {
 
-  // CHECK-LABEL:  calyx.component @ComponentWithInAndOutPorts(%in1: i64, %in2: i16) -> (%out1: i32, %out2: i8) {
-  calyx.component @ComponentWithInAndOutPorts(%in1: i64, %in2: i16) -> (%out1: i32, %out2: i8) {
-    // CHECK:        calyx.cells {
+  // CHECK-LABEL:  calyx.component @ComponentWithInAndOutPorts(%in1: i32, %in2: i16) -> (%out1: i32, %out2: i8) {
+  calyx.component @ComponentWithInAndOutPorts(%in1: i32, %in2: i16) -> (%out1: i32, %out2: i8) {
     // CHECK:        calyx.wires {
     // CHECK:        calyx.control {
-    calyx.cells {}
     calyx.wires {}
     calyx.control {}
   }
 
   // CHECK-LABEL: calyx.component @ComponentWithInPort(%x: i64) -> () {
   calyx.component @ComponentWithInPort(%x: i64) -> () {
-    calyx.cells {}
     calyx.wires {}
     calyx.control {}
   }
 
   // CHECK-LABEL: calyx.component @ComponentWithOutPort() -> (%y: i64) {
   calyx.component @ComponentWithOutPort() -> (%y: i64) {
-    calyx.cells {}
     calyx.wires {}
     calyx.control {}
   }
 
   // CHECK-LABEL: calyx.component @ComponentWithNoPorts() -> () {
   calyx.component @ComponentWithNoPorts() -> () {
-    calyx.cells {}
+    calyx.wires {}
+    calyx.control {}
+  }
+
+  calyx.component @A(%in: i8) -> (%out: i8) {
     calyx.wires {}
     calyx.control {}
   }
 
   calyx.component @main() -> () {
-    calyx.cells {
-      // CHECK: %0:4 = calyx.cell "c0" @ComponentWithInAndOutPorts : i64, i16, i32, i8
-      // CHECK-NEXT: calyx.cell "c1" @ComponentWithNoPorts
-      %in1, %in2, %out1, %out2 = calyx.cell "c0" @ComponentWithInAndOutPorts : i64, i16, i32, i8
-      calyx.cell "c1" @ComponentWithNoPorts
-    }
+    %in1, %out1 = calyx.cell "c0" @A : i8, i8
+    %in2, %out2 =  calyx.cell "c1" @A : i8, i8
+    %c1_i1 = constant 1 : i1
+
     calyx.wires {
       // CHECK: calyx.group @SomeGroup {
-      calyx.group @SomeGroup {}
+      calyx.group @SomeGroup {
+        // CHECK: calyx.assign %1#0 = %0#1 : i8
+        // CHECK-NEXT: calyx.done %true : i1
+        calyx.assign %in2 = %out1 : i8
+        calyx.done %c1_i1 : i1
+      }
     }
     calyx.control {}
   }
-
 }

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -41,7 +41,10 @@ calyx.program {
       %in1, %in2, %out1, %out2 = calyx.cell "c0" @ComponentWithInAndOutPorts : i64, i16, i32, i8
       calyx.cell "c1" @ComponentWithNoPorts
     }
-    calyx.wires {}
+    calyx.wires {
+      // CHECK: calyx.group @SomeGroup {
+      calyx.group @SomeGroup {}
+    }
     calyx.control {}
   }
 

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -36,7 +36,7 @@ calyx.program {
 
   calyx.component @main() -> () {
     %in1, %out1 = calyx.cell "c0" @A : i8, i8
-    %in2, %out2 =  calyx.cell "c1" @A : i8, i8
+    %in2, %out2 = calyx.cell "c1" @A : i8, i8
     %c1_i1 = constant 1 : i1
 
     calyx.wires {


### PR DESCRIPTION
- Adds `calyx.assign`, `calyx.group`, `calyx.done` (example in Calyx language provided [here](https://capra.cs.cornell.edu/docs/calyx/tutorial/language-tut.html#add-control)).
- Removes the `calyx.cells` region*.

*After discussing with @rachitnigam  and @sampsyo, trying to contain the IR in an (essentially) no-op region is not necessary. In future PRs, `calyx.wires` and `calyx.control` *may* be removed as well, in a separate PR since this has enough nonsense in it already.