### PR TITLE
[ExportVerilog] Extern module's port types cannot be trusted, use operand types instead

### DIFF
--- a/test/ExportVerilog/hw-dialect.mlir
+++ b/test/ExportVerilog/hw-dialect.mlir
@@ -235,7 +235,7 @@ hw.module @AB(%w: i1, %x: i1, %i2: i2, %i3: i0) -> (%y: i1, %z: i1, %p: i1, %p2:
 // CHECK-NEXT:      .WIDTH(8'd32)
 // CHECK-NEXT:    ) paramd (
 // CHECK-NEXT:      .a   (w),
-// CHECK-NEXT:    //.b   (i3),
+// CHECK-NEXT:      .b   (i3),
 // CHECK-NEXT:      .out (paramd_out)
 // CHECK-NEXT:    );
 // CHECK-NEXT:    FooModule #(


### PR DESCRIPTION
External modules' types are not necessarily the same for every instance due to
SV module parameterization. Thus, we cannot rely on the extern module's port
declaration to determine to print a port or not. We can rely on the instance
operations' operand types in both cases since a verifier ensures that the types
match in the internal module case.