### PR TITLE
[PyCDE] Clean up module key and use it as name when necessary.

### DIFF
--- a/frontends/PyCDE/src/pycde/module.py
+++ b/frontends/PyCDE/src/pycde/module.py
@@ -343,7 +343,7 @@ class _Generate:
     if "module_name" in self.params:
       module_name = self.params["module_name"]
     else:
-      module_name = self.create_module_name(op, input_ports, output_ports)
+      module_name = self.create_module_name(mod, op, input_ports, output_ports)
 
     if module_name not in self.generated_modules:
       with mlir.ir.InsertionPoint(mod.regions[0].blocks[0]):
@@ -363,8 +363,14 @@ class _Generate:
         inst.attributes[name] = attr
       return inst
 
-  def create_module_name(self, op, input_ports, output_ports):
+  def create_module_name(self, mod, op, input_ports, output_ports):
     op_name = op.name.replace("pycde.", "")
+    existing_module_names = set(
+        mlir.ir.StringAttr(o.name).value
+        for o in mod.regions[0].blocks[0].operations)
+    if op_name not in existing_module_names:
+      return op_name
+
     input_port_types = "_".join(
         sorted(self.sanitize(type) for (_, type) in input_ports))
     output_port_types = "_".join(

--- a/frontends/PyCDE/src/pycde/module.py
+++ b/frontends/PyCDE/src/pycde/module.py
@@ -343,7 +343,7 @@ class _Generate:
     if "module_name" in self.params:
       module_name = self.params["module_name"]
     else:
-      module_name = self.create_module_name(mod, op, input_ports, output_ports)
+      module_name = self.create_module_name(mod, op)
 
     if module_name not in self.generated_modules:
       with mlir.ir.InsertionPoint(mod.regions[0].blocks[0]):
@@ -363,7 +363,7 @@ class _Generate:
         inst.attributes[name] = attr
       return inst
 
-  def create_module_name(self, mod, op, input_ports, output_ports):
+  def create_module_name(self, mod, op):
     op_name = op.name.replace("pycde.", "")
     existing_module_names = set(
         mlir.ir.StringAttr(o.name).value
@@ -371,14 +371,9 @@ class _Generate:
     if op_name not in existing_module_names:
       return op_name
 
-    input_port_types = "_".join(
-        sorted(self.sanitize(type) for (_, type) in input_ports))
-    output_port_types = "_".join(
-        sorted(self.sanitize(type) for (_, type) in output_ports))
     param_values = "_".join(
         sorted(self.sanitize(param) for param in self.params.values()))
-    return "_".join(
-        [op_name, input_port_types, output_port_types, param_values])
+    return "_".join([op_name, param_values])
 
   def sanitize(self, value):
     sanitized_str = str(value)

--- a/frontends/PyCDE/src/pycde/module.py
+++ b/frontends/PyCDE/src/pycde/module.py
@@ -364,16 +364,18 @@ class _Generate:
       return inst
 
   def create_module_name(self, mod, op):
-    op_name = op.name.replace("pycde.", "")
+    name = op.name.replace("pycde.", "")
     existing_module_names = set(
         mlir.ir.StringAttr(o.name).value
         for o in mod.regions[0].blocks[0].operations)
-    if op_name not in existing_module_names:
-      return op_name
+    if name not in existing_module_names:
+      return name
 
-    param_values = "_".join(
-        sorted(self.sanitize(param) for param in self.params.values()))
-    return "_".join([op_name, param_values])
+    if len(self.params) > 0:
+      name += "_" + "_".join(
+          sorted(self.sanitize(param) for param in self.params.values()))
+
+    return name
 
   def sanitize(self, value):
     sanitized_str = str(value)

--- a/frontends/PyCDE/test/module_naming.py
+++ b/frontends/PyCDE/test/module_naming.py
@@ -30,6 +30,8 @@ class Test(pycde.System):
     Parameterized(2)(x=c1)
 
 
+# CHECK: hw.module @Module
+# CHECK-NOT: hw.module @Module
 # CHECK: hw.module @Module_i1_i1_1
 # CHECK-NOT: hw.module @Module_i1_i1_1
 # CHECK: hw.module @Module_i1_i1_2

--- a/frontends/PyCDE/test/module_naming.py
+++ b/frontends/PyCDE/test/module_naming.py
@@ -32,10 +32,10 @@ class Test(pycde.System):
 
 # CHECK: hw.module @Module
 # CHECK-NOT: hw.module @Module
-# CHECK: hw.module @Module_i1_i1_1
-# CHECK-NOT: hw.module @Module_i1_i1_1
-# CHECK: hw.module @Module_i1_i1_2
-# CHECK-NOT: hw.module @Module_i1_i1_2
+# CHECK: hw.module @Module_1
+# CHECK-NOT: hw.module @Module_1
+# CHECK: hw.module @Module_2
+# CHECK-NOT: hw.module @Module_2
 t = Test()
 t.generate()
 t.print()

--- a/frontends/PyCDE/test/module_naming.py
+++ b/frontends/PyCDE/test/module_naming.py
@@ -1,0 +1,39 @@
+# RUN: %PYTHON% %s 2>&1 | FileCheck %s
+
+import pycde
+import circt.dialects.hw
+
+
+@pycde.module
+def Parameterized(param):
+
+  class Module:
+    x = pycde.Input(pycde.types.i1)
+    y = pycde.Output(pycde.types.i1)
+
+    @pycde.generator
+    def construct(mod):
+      return {"y": mod.x}
+
+  return Module
+
+
+class Test(pycde.System):
+  inputs = []
+  outputs = []
+
+  def build(self, top):
+    c1 = circt.dialects.hw.ConstantOp.create(pycde.types.i1, 1)
+    Parameterized(1)(x=c1)
+    Parameterized(1)(x=c1)
+    Parameterized(2)(x=c1)
+    Parameterized(2)(x=c1)
+
+
+# CHECK: hw.module @Module_i1_i1_1
+# CHECK-NOT: hw.module @Module_i1_i1_1
+# CHECK: hw.module @Module_i1_i1_2
+# CHECK-NOT: hw.module @Module_i1_i1_2
+t = Test()
+t.generate()
+t.print()

--- a/frontends/PyCDE/test/module_naming.py
+++ b/frontends/PyCDE/test/module_naming.py
@@ -18,6 +18,16 @@ def Parameterized(param):
   return Module
 
 
+@pycde.module
+class UnParameterized:
+  x = pycde.Input(pycde.types.i1)
+  y = pycde.Output(pycde.types.i1)
+
+  @pycde.generator
+  def construct(mod):
+    return {"y": mod.x}
+
+
 class Test(pycde.System):
   inputs = []
   outputs = []
@@ -28,6 +38,8 @@ class Test(pycde.System):
     Parameterized(1)(x=c1)
     Parameterized(2)(x=c1)
     Parameterized(2)(x=c1)
+    UnParameterized(x=c1)
+    UnParameterized(x=c1)
 
 
 # CHECK: hw.module @Module
@@ -36,6 +48,8 @@ class Test(pycde.System):
 # CHECK-NOT: hw.module @Module_1
 # CHECK: hw.module @Module_2
 # CHECK-NOT: hw.module @Module_2
+# CHECK: hw.module @UnParameterized
+# CHECK-NOT: hw.module @UnParameterized
 t = Test()
-t.generate()
+t.generate(["construct"])
 t.print()


### PR DESCRIPTION
If the user doesn't specify a get_module_name or otherwise set the
module_name parameter, use the improved module key as the name.