### PR TITLE
[PyCDE] Naming fixes and style changes

### DIFF
--- a/frontends/PyCDE/src/pycde/module.py
+++ b/frontends/PyCDE/src/pycde/module.py
@@ -311,9 +311,7 @@ class _Generate:
   """Represents a generator. Stores the generate function and wraps it with the
   necessary logic to build an HWModule."""
 
-  # Track generated modules so we don't create unnecessary duplicates of
-  # modules that are structurally equivalent.
-  generated_modules = {}
+
 
   def __init__(self, gen_func):
     self.gen_func = gen_func
@@ -355,21 +353,31 @@ class _Generate:
       module_name = self.params["module_name"]
     else:
       module_name = self.create_module_name(mod, op)
+      self.params["module_name"] = module_name
+    module_name = self.sanitize(module_name)
 
-    if module_name not in _Generate.generated_modules:
+    # Track generated modules so we don't create unnecessary duplicates of
+    # modules that are structurally equivalent. If the module name exists in the
+    # top level MLIR module, assume that we've already generated it.
+    existing_module_names = [
+       o for o in mod.regions[0].blocks[0].operations
+       if mlir.ir.StringAttr(o.name).value == module_name]
+
+    if not existing_module_names:
       with mlir.ir.InsertionPoint(mod.regions[0].blocks[0]):
-        gen_mod = ModuleDefinition(self.modcls,
-                                   module_name,
-                                   input_ports=input_ports,
-                                   output_ports=output_ports,
-                                   body_builder=self.gen_func)
-        _Generate.generated_modules[module_name] = gen_mod
+        mod = ModuleDefinition(self.modcls,
+                               module_name,
+                               input_ports=input_ports,
+                               output_ports=output_ports,
+                               body_builder=self.gen_func)
+    else:
+      assert(len(existing_module_names) == 1)
+      mod = existing_module_names[0]
 
     # Build a replacement instance at the op to be replaced.
     with mlir.ir.InsertionPoint(op):
       mapping = {name.value: op.operands[i] for i, name in enumerate(op_names)}
-      inst = _Generate.generated_modules[module_name].create(
-          op.name, **mapping).operation
+      inst = mod.create(op.name, **mapping).operation
       for (name, attr) in attrs.items():
         inst.attributes[name] = attr
       return inst
@@ -378,7 +386,8 @@ class _Generate:
     name = op.name
     if len(self.params) > 0:
       name += "_" + "_".join(
-          sorted(self.sanitize(param) for param in self.params.values()))
+          str(value) for (_, value) in
+          sorted(self.params.items()))
 
     return name
 

--- a/frontends/PyCDE/test/module_naming.py
+++ b/frontends/PyCDE/test/module_naming.py
@@ -42,14 +42,12 @@ class Test(pycde.System):
     UnParameterized(x=c1)
 
 
-# CHECK: hw.module @Module
-# CHECK-NOT: hw.module @Module
-# CHECK: hw.module @Module_1
-# CHECK-NOT: hw.module @Module_1
-# CHECK: hw.module @Module_2
-# CHECK-NOT: hw.module @Module_2
-# CHECK: hw.module @UnParameterized
-# CHECK-NOT: hw.module @UnParameterized
+# CHECK: hw.module @pycde.Module_1
+# CHECK-NOT: hw.module @pycde.Module_1
+# CHECK: hw.module @pycde.Module_2
+# CHECK-NOT: hw.module @pycde.Module_2
+# CHECK: hw.module @pycde.UnParameterized
+# CHECK-NOT: hw.module @pycde.UnParameterized
 t = Test()
 t.generate(["construct"])
 t.print()

--- a/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
@@ -92,24 +92,20 @@ class ModuleLike:
 
     input_types = []
     input_names = []
-    self.input_indices = {}
     input_ports = list(input_ports)
     for i in range(len(input_ports)):
       port_name, port_type = input_ports[i]
       input_types.append(port_type)
       input_names.append(StringAttr.get(str(port_name)))
-      self.input_indices[port_name] = i
     attributes["argNames"] = ArrayAttr.get(input_names)
 
     output_types = []
     output_names = []
     output_ports = list(output_ports)
-    self.output_indices = {}
     for i in range(len(output_ports)):
       port_name, port_type = output_ports[i]
       output_types.append(port_type)
       output_names.append(StringAttr.get(str(port_name)))
-      self.output_indices[port_name] = i
     attributes["resultNames"] = ArrayAttr.get(output_names)
 
     attributes["type"] = TypeAttr.get(
@@ -226,6 +222,15 @@ class HWModuleOp(ModuleLike):
   @property
   def entry_block(self):
     return self.regions[0].blocks[0]
+
+  @property
+  def input_indices(self):
+    indices: dict[int, str] = {}
+    op_names = ArrayAttr(self.attributes["argNames"])
+    for idx, name in enumerate(op_names):
+      str_name = StringAttr(name).value
+      indices[str_name] = idx
+    return indices
 
   # Support attribute access to block arguments by name
   def __getattr__(self, name):


### PR DESCRIPTION
Three changes:
- Fixes a duplicate definition bug: in the case of parameterized modules, multiple generators (per parameterization call) are created so we cannot store the `generated_modules` map in the instance. Instead, we look it up in the IR.
- If the module has parameters, append them regardless of potential conflicts. This makes for less confusing code in the common case of multiple parameterizations since the first parameterization doesn't get a special name.
- Add the "pycde." prefix so we don't create modules which have name conflicts with existing RTL modules.