### PR TITLE
[PyCDE] Serialize class parameters to attributes

### DIFF
--- a/frontends/PyCDE/src/pycde/support.py
+++ b/frontends/PyCDE/src/pycde/support.py
@@ -1,7 +1,7 @@
 import circt.support as support
 import circt.dialects.hw as hw
 
-import mlir.ir
+import mlir.ir as ir
 
 
 class Value:
@@ -22,3 +22,32 @@ class Value:
 
     raise TypeError(
         "Subscripting only supported on hw.array and hw.struct types")
+
+
+# PyCDE needs a custom version of this to support python classes.
+def var_to_attribute(obj) -> ir.Attribute:
+  """Create an MLIR attribute from a Python object for a few common cases."""
+  if obj is None:
+    return ir.BoolAttr.get(False)
+  if isinstance(obj, ir.Attribute):
+    return obj
+  if isinstance(obj, bool):
+    return ir.BoolAttr.get(obj)
+  if isinstance(obj, int):
+    attrTy = ir.IntegerType.get_signless(64)
+    return ir.IntegerAttr.get(attrTy, obj)
+  if isinstance(obj, str):
+    return ir.StringAttr.get(obj)
+  if isinstance(obj, list) or isinstance(obj, tuple):
+    arr = [var_to_attribute(x) for x in obj]
+    if all(arr):
+      return ir.ArrayAttr.get(arr)
+  if isinstance(obj, dict):
+    attrs = {name: var_to_attribute(value) for name, value in obj.items()}
+    return ir.DictAttr.get(attrs)
+  if hasattr(obj, "__dict__"):
+    attrs = {name: var_to_attribute(value)
+             for name, value in obj.__dict__.items()}
+    return ir.DictAttr.get(attrs)
+  raise TypeError(f"Cannot convert type '{type(obj)}' to MLIR attribute. "
+                  "This is required for parameters.")

--- a/lib/Bindings/Python/circt/support.py
+++ b/lib/Bindings/Python/circt/support.py
@@ -94,6 +94,11 @@ def attribute_to_var(attr):
     return [attribute_to_var(x) for x in arr]
   except ValueError:
     pass
+  try:
+    dict = ir.DictAttr(attr)
+    return {i.name: attribute_to_var(i.attr) for i in dict}
+  except ValueError:
+    pass
 
   raise TypeError(f"Cannot convert {repr(attr)} to python value")
 


### PR DESCRIPTION
Since we want/need to support classes (for sanity's sake in large configuration
spaces), we need to include their data in the MLIR parameters attribute to
avoid duplication.