### PR TITLE
[PyCDE] Add source location info where we control operation creation

### DIFF
--- a/frontends/PyCDE/src/pycde/support.py
+++ b/frontends/PyCDE/src/pycde/support.py
@@ -3,6 +3,8 @@ import circt.dialects.hw as hw
 
 import mlir.ir as ir
 
+import os
+
 
 class Value:
 
@@ -51,3 +53,17 @@ def var_to_attribute(obj) -> ir.Attribute:
     return ir.DictAttr.get(attrs)
   raise TypeError(f"Cannot convert type '{type(obj)}' to MLIR attribute. "
                   "This is required for parameters.")
+
+
+__dir__ = os.path.dirname(__file__)
+_local_files = set([os.path.join(__dir__, x) for x in os.listdir(__dir__)])
+
+
+def get_user_loc() -> ir.Location:
+  import traceback
+  stack = reversed(traceback.extract_stack())
+  for frame in stack:
+    if frame.filename in _local_files:
+      continue
+    return ir.Location.file(frame.filename, frame.lineno, 0)
+  return ir.Location.unknown()

--- a/lib/Dialect/MSFT/MSFTGenerator.cpp
+++ b/lib/Dialect/MSFT/MSFTGenerator.cpp
@@ -75,6 +75,7 @@ LogicalResult OpGenerator::runOnOperation(mlir::Operation *op,
   Operation *replacement = gen(op);
   if (replacement == nullptr)
     return op->emitError("Failed generator on ") << op->getName();
+  replacement->setLoc(op->getLoc());
   rewriter.replaceOp(op, replacement->getResults());
   return success();
 }


### PR DESCRIPTION
For new module instances, set to the callsite. For misc creation a generator,
use the location of the generator. I think this is the best we can reasonably
do without upstream support.