### PR TITLE
[FIRRTL] Allow 0-bit mux cond, fold to false

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -412,7 +412,7 @@ def HeadPrimOp : PrimOp<"head"> {
 }
 
 def MuxPrimOp : PrimOp<"mux"> {
-  let arguments = (ins UInt1Type:$sel, PassiveType:$high, PassiveType:$low);
+  let arguments = (ins UInt01Type:$sel, PassiveType:$high, PassiveType:$low);
   let results = (outs PassiveType:$result);
 
   let assemblyFormat =

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -46,6 +46,14 @@ def UInt1Type : DialectType<FIRRTLDialect,
    "UInt<1> or UInt", "::circt::firrtl::UIntType">,
    BuildableType<"UIntType::get($_builder.getContext(), 1)">;
 
+def UInt01Type : DialectType<FIRRTLDialect,
+  CPred<"$_self.isa<UIntType>() && "
+        "($_self.cast<UIntType>().getWidth() == 0 ||"
+        "$_self.cast<UIntType>().getWidth() == 1 ||"
+        " $_self.cast<UIntType>().getWidth() == None)">,
+   "UInt<0> UInt<1> or UInt", "::circt::firrtl::UIntType">,
+   BuildableType<"UIntType::get($_builder.getContext(), 1)">;
+
 def AsyncResetType : DialectType<FIRRTLDialect,
   CPred<"$_self.isa<AsyncResetType>()">,
   "AsyncReset", "::circt::firrtl::AsyncResetType">;

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -2319,8 +2319,15 @@ LogicalResult FIRRTLLowering::visitExpr(MuxPrimOp op) {
   auto cond = getLoweredValue(op.sel());
   auto ifTrue = getLoweredAndExtendedValue(op.high(), op.getType());
   auto ifFalse = getLoweredAndExtendedValue(op.low(), op.getType());
-  if (!cond || !ifTrue || !ifFalse)
+  if (!ifTrue || !ifFalse)
     return failure();
+
+  // Lower mux(0-bit, x, y) -> y
+  if (!cond) {
+    return handleZeroBit(op.sel(), [&]() {
+      return setLowering(op, ifFalse);
+    });
+  }
 
   return setLoweringTo<comb::MuxOp>(op, ifTrue.getType(), cond, ifTrue,
                                     ifFalse);

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -963,6 +963,11 @@ OpFoldResult MuxPrimOp::fold(ArrayRef<Attribute> operands) {
   if (getType().getBitWidthOrSentinel() < 0)
     return {};
 
+  // // mux(0-bit, x, y) -> y
+  if (sel().getType().cast<FIRRTLType>().getBitWidthOrSentinel() == 0 &&
+      low().getType() == getType())
+    return low();
+
   // mux(0/1, x, y) -> x or y
   if (auto cond = operands[0].dyn_cast_or_null<IntegerAttr>()) {
     if (cond.getValue().isNullValue() && low().getType() == getType())

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1983,15 +1983,6 @@ FIRRTLType MuxPrimOp::inferReturnType(ValueRange operands,
   auto high = operands[1].getType().cast<FIRRTLType>();
   auto low = operands[2].getType().cast<FIRRTLType>();
 
-  // Sel needs to be a one bit uint or an unknown width uint.
-  auto selui = sel.dyn_cast<UIntType>();
-  int32_t selWidth = selui.getBitWidthOrSentinel();
-  if (!selui || selWidth == 0 || selWidth > 1) {
-    if (loc)
-      mlir::emitError(*loc, "selector must be UInt or UInt<1>");
-    return {};
-  }
-
   // TODO: Should use a more general type equivalence operator.
   if (high == low)
     return low;

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -170,6 +170,9 @@ firrtl.circuit "Simple" {
     // CHECK-NEXT: comb.mux {{.*}}, [[CVT4]], [[SUB]] : i4
     %26 = firrtl.mux(%17, %23, %25) : (!firrtl.uint<1>, !firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.sint<4>
 
+    // CHECK-NEXT: [[CVT4:%.+]] = comb.sext [[CVT]] : (i3) -> i4
+    %27 = firrtl.mux(%in4, %23, %25) : (!firrtl.uint<0>, !firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.sint<4>
+
     // CHECK-NEXT: = comb.icmp eq  {{.*}}, %c-1_i14 : i14
     %28 = firrtl.andr %18 : (!firrtl.uint<14>) -> !firrtl.uint<1>
 

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -298,8 +298,10 @@ firrtl.module @Head(in %in4u: !firrtl.uint<4>,
 // CHECK-LABEL: firrtl.module @Mux
 firrtl.module @Mux(in %in: !firrtl.uint<4>,
                    in %cond: !firrtl.uint<1>,
+                   in %condZeroWidth: !firrtl.uint<0>,
                    out %out: !firrtl.uint<4>,
-                   out %out1: !firrtl.uint<1>) {
+                   out %out1: !firrtl.uint<1>,
+                   out %out2: !firrtl.uint<4>) {
   // CHECK: firrtl.connect %out, %in
   %0 = firrtl.mux (%cond, %in, %in) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %0 : !firrtl.uint<4>, !firrtl.uint<4>
@@ -314,6 +316,10 @@ firrtl.module @Mux(in %in: !firrtl.uint<4>,
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   %3 = firrtl.mux (%cond, %c1_ui1, %c1_ui0) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out1, %3 : !firrtl.uint<1>, !firrtl.uint<1>
+
+  // CHECK: firrtl.connect %out2, %c7_ui4
+  %4 = firrtl.mux (%condZeroWidth, %in, %c7_ui4) : (!firrtl.uint<0>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  firrtl.connect %out2, %4 : !firrtl.uint<4>, !firrtl.uint<4>
 }
 
 // CHECK-LABEL: firrtl.module @Pad

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -847,15 +847,19 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     infer mport w = a[wAddr], clock
     w <= wData
 
-  ; Test that a mux with an unknown width select line parses.  This is a check
-  ; of the predicate enforced on UInt1Type.
-  ; CHECK-LABEL: firrtl.module @MuxUnknownWidthSelect_Issue1108
-  module MuxUnknownWidthSelect_Issue1108:
+  ; Test that a mux with unknown width or 0-bit width select line parses.  This
+  ; is a check of the predicate enforced on UInt1Type.
+  ; CHECK-LABEL: firrtl.module @MuxUnknownWidthOrZeroWidthSelect_Issue1108
+  module MuxUnknownWidthOrZeroWidthSelect_Issue1108:
     input a: UInt<1>
     input b: UInt<1>
-    input sel: UInt
-    output c: UInt<8>
-    c <= mux(sel, a, b)
+    input selUnknown: UInt
+    input selZero: UInt<0>
+    output c: UInt<8>[2]
+    ; CHECK: firrtl.mux([[_:.+]]) : (!firrtl.uint, [[_:.+]]) -> !firrtl.uint<1>
+    c[0] <= mux(selUnknown, a, b)
+    ; CHECK: firrtl.mux([[_:.+]]) : (!firrtl.uint<0>, [[_:.+]]) -> !firrtl.uint<1>
+    c[1] <= mux(selZero, a, b)
 
   ; CHECK-LABEL: firrtl.extmodule @RawStringParam
   ; CHECK: parameters = {FORMAT = "xyz_timeout=%d\\n",


### PR DESCRIPTION
    Add a new type, UInt01Type, which is a UInt that has either a 0-bit,
    1-bit, or unspecified width.  Change the mux primop to use this type for
    its select line (since this is what the Scala FIRRTL Compiler allows).
    
    Add a folder that will fold a mux with a 0-bit select line to its false
    value.  This aligns CIRCT with the behavior of the ZeroWidth pass in the
    Scala FIRRTL Compiler (which will replace a 0-bit select with a 1-bit,
    0-valued select) along with its constant propagation behavior.

I found this by doing some data-mining the ZeroWidth pass tests: https://github.com/chipsalliance/firrtl/blob/master/src/test/scala/firrtlTests/ZeroWidthTests.scala#L49.  Note: that this PR goes _further_ than the ZeroWidth pass.  That inserts a 1-bit zero.  This PR just drops the mux and uses its false value.