### PR TITLE
[Comb] Move ICmpPredicate into comb namespace

### DIFF
--- a/include/circt/Dialect/Comb/Combinational.td
+++ b/include/circt/Dialect/Comb/Combinational.td
@@ -112,6 +112,7 @@ def ICmpPredicateULT : I64EnumAttrCase<"ult", 6>;
 def ICmpPredicateULE : I64EnumAttrCase<"ule", 7>;
 def ICmpPredicateUGT : I64EnumAttrCase<"ugt", 8>;
 def ICmpPredicateUGE : I64EnumAttrCase<"uge", 9>;
+let cppNamespace = "circt::comb" in
 def ICmpPredicate : I64EnumAttr<
     "ICmpPredicate",
     "hw.icmp comparison predicate",

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -29,6 +29,7 @@
 
 using namespace circt;
 using namespace firrtl;
+using circt::comb::ICmpPredicate;
 
 /// Given a FIRRTL type, return the corresponding type for the HW dialect.
 /// This returns a null type if it cannot be lowered.

--- a/lib/Dialect/SV/Transforms/HWMemSimImpl.cpp
+++ b/lib/Dialect/SV/Transforms/HWMemSimImpl.cpp
@@ -131,7 +131,7 @@ void HWMemSimImplPass::generateMemory(hw::HWModuleOp op, FirMemory mem) {
       auto slot = b.create<sv::ArrayIndexInOutOp>(reg, addr);
       auto rcond = b.createOrFold<comb::AndOp>(
           en, b.createOrFold<comb::ICmpOp>(
-                  ICmpPredicate::eq, wmode,
+                  comb::ICmpPredicate::eq, wmode,
                   b.createOrFold<hw::ConstantOp>(wmode.getType(), 0)));
       auto wcond = b.createOrFold<comb::AndOp>(
           en, b.createOrFold<comb::AndOp>(wmask, wmode));


### PR DESCRIPTION
The `I64EnumAttr` requires to have its `cppNamespace` explicitly set in order not to pollute the global namespace.