### PR TITLE
[FIRRTL] Allow firrtl.constant of type Clock, Reset, AsyncReset

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -87,7 +87,7 @@ def ZeroValueAttr : Constraint<CPred<"$0.getAPSInt().getExtValue() == 0">>;
 
 // regreset(clock, constant_zero, resetValue, name, {}) -> reg(clock, name, {})
 def RegresetWithZeroReset : Pat<
-  (RegResetOp $clock, (AsAsyncResetPrimOp (ConstantOp $value)), $resetValue,
+  (RegResetOp $clock, (ConstantOp $value), $resetValue,
    $name, $annotations),
   (RegOp $clock, $name, $annotations),
   [(ZeroValueAttr $value)]>;

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -15,7 +15,7 @@ def APSIntAttr : Attr<CPred<"$_self.isa<::mlir::IntegerAttr>()">,
   let storageType = [{ ::mlir::IntegerAttr }];
   let returnType = [{ ::llvm::APSInt }];
   let constBuilderCall = "IntegerAttr::get($_builder.getContext(), $0)";
-  let convertFromStorage = "APSInt($_self.getValue(), !getType().isSigned())";
+  let convertFromStorage = "APSInt($_self.getValue(), !isSigned())";
 }
 
 def SameOperandsIntTypeKind : NativeOpTrait<"SameOperandsIntTypeKind"> {
@@ -94,7 +94,7 @@ def ConstantOp : FIRRTLOp<"constant", [NoSideEffect, ConstantLike,
     }];
 
   let arguments = (ins APSIntAttr:$value);
-  let results = (outs NonZeroIntType:$result);
+  let results = (outs NonZeroGroundType:$result);
 
   // Need a custom parser/printer to avoid redundant type for the attribute and
   // the op itself.
@@ -107,6 +107,13 @@ def ConstantOp : FIRRTLOp<"constant", [NoSideEffect, ConstantLike,
   ];
   let hasFolder = 1;
   let verifier = "return ::verifyConstantOp(*this);";
+  let extraClassDeclaration = [{
+    bool isSigned() {
+      if (auto intType = getType().dyn_cast<IntType>())
+        return intType.isSigned();
+      return false;
+    }
+  }];
 }
 
 def InvalidValueOp : FIRRTLOp<"invalidvalue", [NoSideEffect, ConstantLike]> {

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -79,6 +79,9 @@ def ResetType : DialectType<FIRRTLDialect,
   CPred<"$_self.isa<FIRRTLType>() && $_self.cast<FIRRTLType>().isResetType()">,
   "Reset", "::circt::firrtl::FIRRTLType">;
 
+def NonZeroGroundType : AnyTypeOf<[NonZeroIntType, ClockType, ResetType,
+    AsyncResetType], "A non-aggregate type with a positive width.">;
+
 def UIntSIntClockType : AnyTypeOf<[SIntType, UIntType, ClockType],
                                   "sint, uint, or clock",
                                   "::circt::firrtl::FIRRTLType">;

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -737,21 +737,25 @@ OpFoldResult AsUIntPrimOp::fold(ArrayRef<Attribute> operands) {
 }
 
 OpFoldResult AsAsyncResetPrimOp::fold(ArrayRef<Attribute> operands) {
-  // TODO: Implement constants of asyncreset type.
-
   // No effect.
   if (input().getType() == getType())
       return input();
+
+  // Constant fold.  The operand must already be 1 bit.
+  if (auto attr = operands[0].dyn_cast_or_null<IntegerAttr>())
+      return attr;
 
   return {};
 }
 
 OpFoldResult AsClockPrimOp::fold(ArrayRef<Attribute> operands) {
-  // TODO: Implement constants of clock type.
-
   // No effect.
   if (input().getType() == getType())
       return input();
+
+  // Constant fold.  The operand must already be 1 bit.
+  if (auto attr = operands[0].dyn_cast_or_null<IntegerAttr>())
+      return attr;
 
   return {};
 }

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1124,7 +1124,7 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
         // If the constant has a known width, use that. Otherwise pick the
         // smallest number of bits necessary to represent the constant.
         Expr *e;
-        if (auto width = op.getType().getWidth())
+        if (auto width = op.getType().template cast<IntType>().getWidth())
           e = solver.known(*width);
         else {
           auto v = op.value();

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -53,6 +53,61 @@ firrtl.circuit "" {
 // -----
 
 firrtl.circuit "Foo" {
+firrtl.module @Foo() {
+  // expected-error @+1 {{invalid return type}}
+  firrtl.constant 100 : !firrtl.bundle<>
+}
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+firrtl.module @Foo() {
+  // expected-error @+1 {{constant too large for result type}}
+  firrtl.constant 100 : !firrtl.uint<4>
+}
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+firrtl.module @Foo() {
+  // expected-error @+1 {{constant too large for result type}}
+  firrtl.constant -100 : !firrtl.sint<4>
+}
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+firrtl.module @Foo() {
+  // expected-error @+1 {{constant too large for result type}}
+  firrtl.constant 2 : !firrtl.clock
+}
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+firrtl.module @Foo() {
+  // expected-error @+1 {{constant too large for result type}}
+  firrtl.constant 2 : !firrtl.reset
+}
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+firrtl.module @Foo() {
+  // expected-error @+1 {{constant too large for result type}}
+  firrtl.constant 2 : !firrtl.asyncreset
+}
+}
+
+
+// -----
+
+firrtl.circuit "Foo" {
   firrtl.module @Foo(in %clk: !firrtl.uint<1>, in %reset: !firrtl.uint<1>) {
     // expected-error @+1 {{'firrtl.reg' op operand #0 must be clock, but got '!firrtl.uint<1>'}}
     %a = firrtl.reg %clk {name = "a"} : (!firrtl.uint<1>) -> !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -78,6 +78,19 @@ firrtl.module @ClockCast(in %clock: !firrtl.clock) {
   %1 = firrtl.stdIntCast %0 : (i1) -> !firrtl.clock
 }
 
+// Constant op supports different return types.
+firrtl.module @Constants() {
+  // CHECK: %c4_ui8 = firrtl.constant 4 : !firrtl.uint<8>
+  firrtl.constant 4 : !firrtl.uint<8>
+  // CHECK: %c-4_si16 = firrtl.constant -4 : !firrtl.sint<16>
+  firrtl.constant -4 : !firrtl.sint<16>
+  // CHECK: %c1_clock = firrtl.constant 1 : !firrtl.clock
+  firrtl.constant 1 : !firrtl.clock
+  // CHECK: %c1_reset = firrtl.constant 1 : !firrtl.reset
+  firrtl.constant 1 : !firrtl.reset
+  // CHECK: %c1_asyncreset = firrtl.constant 1 : !firrtl.asyncreset
+  firrtl.constant 1 : !firrtl.asyncreset
+}
 
 // CHECK-LABEL: @TestDshRL
 firrtl.module @TestDshRL(in %in1 : !firrtl.uint<2>, in %in2: !firrtl.uint<3>) {


### PR DESCRIPTION
This adds the ability to have constant values of type `Clock`, `Reset`,
and `AsyncReset`.

The SSA value format for constant op has been extended to handle the new
return types:
```mlir
%c1_clock = firrtl.constant 1 : !firrtl.clock
%c1_reset = firrtl.constant 1 : !firrtl.reset
%c1_asyncreset = firrtl.constant 1 : !firrtl.asyncreset
```

New folders for `asClock()` and `asAsyncReset()` have been added to
transform `cast(constant) -> constant` and `cast(a : A) : A -> a : A`.

This fixes a bug in IMConstProp, where it was incorrectly attempting to
materialize a constant of type `firrtl.reset` due to an implicit
conversion of a `UInt<1>` from a module instantiation to the module body.