### PR TITLE
[PyCDE] Make `pycde.support.Value` get the PyType if not specified

### DIFF
--- a/frontends/PyCDE/src/pycde/support.py
+++ b/frontends/PyCDE/src/pycde/support.py
@@ -38,6 +38,8 @@ def var_to_attribute(obj) -> ir.Attribute:
     return ir.BoolAttr.get(False)
   if isinstance(obj, ir.Attribute):
     return obj
+  if isinstance(obj, ir.Type):
+    return ir.TypeAttr.get(obj)
   if isinstance(obj, bool):
     return ir.BoolAttr.get(obj)
   if isinstance(obj, int):

--- a/frontends/PyCDE/src/pycde/support.py
+++ b/frontends/PyCDE/src/pycde/support.py
@@ -8,9 +8,12 @@ import os
 
 class Value:
 
-  def __init__(self, value, type):
+  def __init__(self, value, type=None):
     self.value = support.get_value(value)
-    self.type = type
+    if type is None:
+      self.type = support.type_to_pytype(self.value.type)
+    else:
+      self.type = type
 
   def __getitem__(self, sub):
     if isinstance(self.type, hw.ArrayType):
@@ -18,11 +21,11 @@ class Value:
       if idx >= self.type.size:
         raise ValueError("Subscript out-of-bounds")
       with get_user_loc():
-        return hw.ArrayGetOp.create(self.value, idx)
+        return Value(hw.ArrayGetOp.create(self.value, idx))
 
     if isinstance(self.type, hw.StructType):
       with get_user_loc():
-        return hw.StructExtractOp.create(self.value, sub)
+        return Value(hw.StructExtractOp.create(self.value, sub))
 
     raise TypeError(
         "Subscripting only supported on hw.array and hw.struct types")

--- a/lib/Bindings/Python/circt/support.py
+++ b/lib/Bindings/Python/circt/support.py
@@ -112,6 +112,10 @@ def attribute_to_var(attr):
   except ValueError:
     pass
   try:
+    return ir.TypeAttr(attr).value
+  except ValueError:
+    pass
+  try:
     arr = ir.ArrayAttr(attr)
     return [attribute_to_var(x) for x in arr]
   except ValueError:

--- a/lib/Bindings/Python/circt/support.py
+++ b/lib/Bindings/Python/circt/support.py
@@ -72,6 +72,28 @@ def var_to_attribute(obj, none_on_fail: bool = False) -> ir.Attribute:
   raise TypeError(f"Cannot convert type '{type(obj)}' to MLIR attribute")
 
 
+# There is currently no support in MLIR for querying type types. The
+# conversation regarding how to achieve this is ongoing and I expect it to be a
+# long one. This is a way that works for now.
+def type_to_pytype(t):
+  from circt.dialects import hw
+  import mlir.ir as ir
+  try:
+    return ir.IntegerType(t)
+  except ValueError:
+    pass
+  try:
+    return hw.ArrayType(t)
+  except ValueError:
+    pass
+  try:
+    return hw.StructType(t)
+  except ValueError:
+    pass
+
+  raise TypeError(f"Cannot convert {repr(t)} to python type")
+
+
 # There is currently no support in MLIR for querying attribute types. The
 # conversation regarding how to achieve this is ongoing and I expect it to be a
 # long one. This is a way that works for now.


### PR DESCRIPTION
This involves a hack similar to the Attribute hack.