### PR TITLE
[ExportVerilog] Special case register of struct or array of struct.

### DIFF
--- a/integration_test/EmitVerilog/lint.mlir
+++ b/integration_test/EmitVerilog/lint.mlir
@@ -6,6 +6,7 @@
 // RUN: verilator --lint-only --top-module TESTSIMPLE %t1.sv
 // RUN: verilator --lint-only --top-module casts %t1.sv
 // RUN: verilator --lint-only --top-module exprInlineTestIssue439 %t1.sv
+// RUN: verilator --lint-only --top-module StructDecls %t1.sv
 
 hw.module @B(%a: i1) -> (%b: i1, %c: i1) {
   %0 = comb.or %a, %a : i1
@@ -106,4 +107,9 @@ hw.module @casts(%in1: i64) -> (%r1: !hw.array<5xi8>) {
   %midBits = hw.array_slice %bits at %idx : (!hw.array<64xi1>) -> !hw.array<40xi1>
   %r1 = hw.bitcast %midBits : (!hw.array<40xi1>) -> !hw.array<5xi8>
   hw.output %r1 : !hw.array<5xi8>
+}
+
+hw.module @StructDecls() {
+  %reg1 = sv.reg : !hw.inout<struct<a: i1, b: i1>>
+  %reg2 = sv.reg : !hw.inout<array<8xstruct<a: i1, b: i1>>>
 }

--- a/integration_test/EmitVerilog/sv-structs.mlir
+++ b/integration_test/EmitVerilog/sv-structs.mlir
@@ -1,0 +1,26 @@
+// REQUIRES: verilator
+// RUN: circt-translate %s -export-verilog -verify-diagnostics > %t1.sv
+// RUN: circt-rtl-sim.py %t1.sv --cycles 1 2>&1 | FileCheck %s
+
+hw.module @top(%clk: i1, %rstn: i1) {
+  %reg1 = sv.reg : !hw.inout<struct<a: i1, b: i1>>
+  %reg2 = sv.reg : !hw.inout<array<2xstruct<a: i1, b: i1>>>
+
+  %a = hw.constant 0 : i1
+  %b = hw.constant 1 : i1
+  %cst1 = hw.struct_create(%a, %b) : !hw.struct<a: i1, b: i1>
+  %cst2 = hw.array_create %cst1, %cst1 : !hw.struct<a: i1, b: i1>
+
+  sv.always posedge %clk {
+    sv.passign %reg1, %cst1 : !hw.struct<a: i1, b: i1>
+    sv.passign %reg2, %cst2 : !hw.array<2xstruct<a: i1, b: i1>>
+    sv.fwrite "reg1: %b\n" (%reg1) : !hw.inout<struct<a: i1, b: i1>>
+    sv.fwrite "reg2: %b\n" (%reg2) : !hw.inout<array<2xstruct<a: i1, b: i1>>>
+  }
+
+  // CHECK: [driver] Starting simulation
+  // CHECK-NEXT: reg1: 00
+  // CHECK-NEXT: reg2: 0000
+  // CHECK-NEXT: reg1: 01
+  // CHECK-NEXT: reg2: 0101
+}

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -295,9 +295,12 @@ static StringRef getVerilogDeclWord(Operation *op) {
         op->getResult(0).getType().cast<InOutType>().getElementType();
     if (elementType.isa<StructType>())
       return "";
-    if (auto innerType = elementType.dyn_cast<ArrayType>())
+    if (auto innerType = elementType.dyn_cast<ArrayType>()) {
+      while (innerType.getElementType().isa<ArrayType>())
+        innerType = innerType.getElementType().cast<ArrayType>();
       if (innerType.getElementType().isa<StructType>())
         return "";
+    }
 
     return "reg";
   }

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -287,8 +287,16 @@ static void printUnpackedTypePostfix(Type type, raw_ostream &os) {
 
 /// Return the word (e.g. "reg") in Verilog to declare the specified thing.
 static StringRef getVerilogDeclWord(Operation *op) {
-  if (isa<RegOp>(op))
+  if (isa<RegOp>(op)) {
+    auto elementType =
+        op->getResult(0).getType().cast<InOutType>().getElementType();
+    if (elementType.isa<StructType>())
+      return "";
+    if (auto innerType = elementType.dyn_cast<ArrayType>())
+      if (innerType.getElementType().isa<StructType>())
+        return "";
     return "reg";
+  }
   if (isa<WireOp>(op))
     return "wire";
   if (isa<ConstantOp>(op))

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -288,6 +288,9 @@ static void printUnpackedTypePostfix(Type type, raw_ostream &os) {
 /// Return the word (e.g. "reg") in Verilog to declare the specified thing.
 static StringRef getVerilogDeclWord(Operation *op) {
   if (isa<RegOp>(op)) {
+    // Check if the type stored in this register is a struct or array of
+    // structs. In this case, according to spec section 6.8, the "reg" prefix
+    // should be left off.
     auto elementType =
         op->getResult(0).getType().cast<InOutType>().getElementType();
     if (elementType.isa<StructType>())
@@ -295,6 +298,7 @@ static StringRef getVerilogDeclWord(Operation *op) {
     if (auto innerType = elementType.dyn_cast<ArrayType>())
       if (innerType.getElementType().isa<StructType>())
         return "";
+
     return "reg";
   }
   if (isa<WireOp>(op))
@@ -1629,7 +1633,10 @@ public:
   /// return false. If the operation *is* a constant, also emit the initializer
   /// and semicolon, e.g. `localparam K = 1'h0`, and return true.
   bool emitDeclarationForTemporary(Operation *op) {
-    indent() << getVerilogDeclWord(op) << " ";
+    StringRef declWord = getVerilogDeclWord(op);
+    indent() << declWord;
+    if (!declWord.empty())
+      os << ' ';
     if (printPackedType(stripUnpackedTypes(op->getResult(0).getType()), os, op))
       os << ' ';
     os << names.getName(op->getResult(0));
@@ -2515,7 +2522,8 @@ void StmtEmitter::collectNamesEmitDecls(Block &block) {
     auto word = getVerilogDeclWord(decl);
     if (!isZeroBitType(type)) {
       indent() << word;
-      os.indent(maxDeclNameWidth - word.size() + 1);
+      auto extraIndent = word.empty() ? 0 : 1;
+      os.indent(maxDeclNameWidth - word.size() + extraIndent);
     } else {
       indent() << "// Zero width: " << word << ' ';
     }

--- a/test/ExportVerilog/sv-dialect.mlir
+++ b/test/ExportVerilog/sv-dialect.mlir
@@ -738,10 +738,14 @@ hw.module @ConstantEmissionAtTopOfBlock() {
 // CHECK-LABEL: module RegisterOfStructOrArrayOfStruct
 hw.module @RegisterOfStructOrArrayOfStruct() {
   // CHECK-NOT: reg
-  // CHECK: struct packed {logic a; logic b; }      reg1
+  // CHECK: struct packed {logic a; logic b; }           reg1
   %reg1 = sv.reg : !hw.inout<struct<a: i1, b: i1>>
 
   // CHECK-NOT: reg
-  // CHECK: struct packed {logic a; logic b; }[7:0] reg2
+  // CHECK: struct packed {logic a; logic b; }[7:0]      reg2
   %reg2 = sv.reg : !hw.inout<array<8xstruct<a: i1, b: i1>>>
+
+  // CHECK-NOT: reg
+  // CHECK: struct packed {logic a; logic b; }[3:0][7:0] reg3
+  %reg3 = sv.reg : !hw.inout<array<4xarray<8xstruct<a: i1, b: i1>>>>
 }

--- a/test/ExportVerilog/sv-dialect.mlir
+++ b/test/ExportVerilog/sv-dialect.mlir
@@ -733,3 +733,15 @@ hw.module @ConstantEmissionAtTopOfBlock() {
     }
   }
 }
+
+// See https://github.com/llvm/circt/issues/1356
+// CHECK-LABEL: module RegisterOfStructOrArrayOfStruct
+hw.module @RegisterOfStructOrArrayOfStruct() {
+  // CHECK-NOT: reg
+  // CHECK: struct packed {logic a; logic b; }      reg1
+  %reg1 = sv.reg : !hw.inout<struct<a: i1, b: i1>>
+
+  // CHECK-NOT: reg
+  // CHECK: struct packed {logic a; logic b; }[7:0] reg2
+  %reg2 = sv.reg : !hw.inout<array<8xstruct<a: i1, b: i1>>>
+}


### PR DESCRIPTION
Don't print `reg` if the reg holds a struct or array of struct. See
the spec, section 6.8 for the syntax of variable declarations.