### PR TITLE
[CAPI][Python] Add support for TypeAliasType in CAPI and Bindings.

### DIFF
--- a/include/circt-c/Dialect/HW.h
+++ b/include/circt-c/Dialect/HW.h
@@ -67,6 +67,9 @@ MLIR_CAPI_EXPORTED bool hwTypeIsAInOut(MlirType type);
 /// If the type is an HW struct.
 MLIR_CAPI_EXPORTED bool hwTypeIsAStructType(MlirType);
 
+/// If the type is an HW type alias.
+MLIR_CAPI_EXPORTED bool hwTypeIsATypeAliasType(MlirType);
+
 /// Creates a fixed-size HW array type in the context associated with element
 MLIR_CAPI_EXPORTED MlirType hwArrayTypeGet(MlirType element, size_t size);
 
@@ -89,6 +92,18 @@ hwStructTypeGet(MlirContext ctx, intptr_t numElements,
 
 MLIR_CAPI_EXPORTED MlirType hwStructTypeGetField(MlirType structType,
                                                  MlirStringRef fieldName);
+
+MLIR_CAPI_EXPORTED MlirType hwTypeAliasTypeGet(MlirStringRef scope,
+                                               MlirStringRef name,
+                                               MlirType innerType);
+
+MLIR_CAPI_EXPORTED MlirType hwTypeAliasTypeGetCanonicalType(MlirType typeAlias);
+
+MLIR_CAPI_EXPORTED MlirType hwTypeAliasTypeGetInnerType(MlirType typeAlias);
+
+MLIR_CAPI_EXPORTED MlirStringRef hwTypeAliasTypeGetName(MlirType typeAlias);
+
+MLIR_CAPI_EXPORTED MlirStringRef hwTypeAliasTypeGetScope(MlirType typeAlias);
 
 #ifdef __cplusplus
 }

--- a/integration_test/Bindings/Python/dialects/hw.py
+++ b/integration_test/Bindings/Python/dialects/hw.py
@@ -51,3 +51,15 @@ with Context() as ctx, Location.unknown():
     hw.HWModuleOp(name="test", body_builder=build)
 
   print(m)
+
+  # CHECK: !hw.typealias<@myscope::@myname, i1>
+  # CHECK: i1
+  # CHECK: i1
+  # CHECK: myscope
+  # CHECK: myname
+  typeAlias = hw.TypeAliasType.get("myscope", "myname", i1)
+  print(typeAlias)
+  print(typeAlias.canonical_type)
+  print(typeAlias.inner_type)
+  print(typeAlias.scope)
+  print(typeAlias.name)

--- a/lib/CAPI/Dialect/HW.cpp
+++ b/lib/CAPI/Dialect/HW.cpp
@@ -81,3 +81,39 @@ MlirType hwStructTypeGetField(MlirType structType, MlirStringRef fieldName) {
   StructType st = unwrap(structType).cast<StructType>();
   return wrap(st.getFieldType(unwrap(fieldName)));
 }
+
+bool hwTypeIsATypeAliasType(MlirType type) {
+  return unwrap(type).isa<TypeAliasType>();
+}
+
+MlirType hwTypeAliasTypeGet(MlirStringRef cScope, MlirStringRef cName,
+                            MlirType cInnerType) {
+  StringRef scope = unwrap(cScope);
+  StringRef name = unwrap(cName);
+  Type innerType = unwrap(cInnerType);
+  FlatSymbolRefAttr nameRef =
+      FlatSymbolRefAttr::get(innerType.getContext(), name);
+  SymbolRefAttr ref =
+      SymbolRefAttr::get(innerType.getContext(), scope, {nameRef});
+  return wrap(TypeAliasType::get(ref, innerType));
+}
+
+MlirType hwTypeAliasTypeGetCanonicalType(MlirType typeAlias) {
+  TypeAliasType type = unwrap(typeAlias).cast<TypeAliasType>();
+  return wrap(type.getCanonicalType());
+}
+
+MlirType hwTypeAliasTypeGetInnerType(MlirType typeAlias) {
+  TypeAliasType type = unwrap(typeAlias).cast<TypeAliasType>();
+  return wrap(type.getInnerType());
+}
+
+MlirStringRef hwTypeAliasTypeGetName(MlirType typeAlias) {
+  TypeAliasType type = unwrap(typeAlias).cast<TypeAliasType>();
+  return wrap(type.getRef().getLeafReference());
+}
+
+MlirStringRef hwTypeAliasTypeGetScope(MlirType typeAlias) {
+  TypeAliasType type = unwrap(typeAlias).cast<TypeAliasType>();
+  return wrap(type.getRef().getRootReference());
+}

--- a/test/CAPI/ir.c
+++ b/test/CAPI/ir.c
@@ -103,6 +103,26 @@ int testHWTypes() {
   if (!hwTypeIsAInOut(io8type))
     return 4;
 
+  MlirStringRef scope = mlirStringRefCreateFromCString("myscope");
+  MlirStringRef name = mlirStringRefCreateFromCString("myname");
+  MlirType typeAliasType = hwTypeAliasTypeGet(scope, name, i8type);
+  if (mlirTypeIsNull(typeAliasType))
+    return 5;
+  if (!hwTypeIsATypeAliasType(typeAliasType))
+    return 6;
+  MlirType canonicalType = hwTypeAliasTypeGetCanonicalType(typeAliasType);
+  if (!mlirTypeEqual(canonicalType, i8type))
+    return 7;
+  MlirType innerType = hwTypeAliasTypeGetInnerType(typeAliasType);
+  if (!mlirTypeEqual(innerType, i8type))
+    return 8;
+  MlirStringRef theScope = hwTypeAliasTypeGetScope(typeAliasType);
+  if (theScope.length != scope.length)
+    return 9;
+  MlirStringRef theName = hwTypeAliasTypeGetName(typeAliasType);
+  if (theName.length != name.length)
+    return 10;
+
   mlirContextDestroy(ctx);
 
   return 0;


### PR DESCRIPTION
This adds straightforward support for the TypeAliasType, as it stands
today, in the CAPI, then layers the Bindings directly on top of that.

Later improvements to the TypeAliasType's builder will of course
require refactoring part of this, but for now, this opens it up for
use in PyCDE.