### PR TITLE
[Calyx] Add guard for assignments and done operations.

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -217,6 +217,7 @@ def AssignOp : CalyxOp<"assign", []> {
     Optional<I1>:$guard
   );
   let verifier = "return ::verify$cppClass(*this);";
+
   // TODO1(Calyx): Calyx IR typically represents a
   // guarded assignments as `%dest = %guard ? %src`
   // TODO2(Calyx): Only need type of `src` or `dest`.

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -217,8 +217,9 @@ def AssignOp : CalyxOp<"assign", []> {
     Optional<I1>:$guard
   );
   let verifier = "return ::verify$cppClass(*this);";
-  // TODO(Calyx): Calyx IR typically represents a
+  // TODO1(Calyx): Calyx IR typically represents a
   // guarded assignments as `%dest = %guard ? %src`
+  // TODO2(Calyx): Only need type of `src` or `dest`.
   let assemblyFormat = [{
     $dest `=` $src (`,` $guard^ `?`)?
     attr-dict `:` type($dest) `,` type($src)

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -197,7 +197,13 @@ def GroupOp : CalyxOp<"group", [
   let assemblyFormat = "$sym_name $body attr-dict";
 }
 
-def AssignOp : CalyxOp<"assign", []> {
+class SameTypeConstraint<string lhs, string rhs>
+ : TypesMatchWith<"lhs and rhs types should be equivalent",
+                   lhs, rhs, [{ $_self }]>;
+
+def AssignOp : CalyxOp<"assign", [
+    SameTypeConstraint<"dest", "src">
+  ]> {
   let summary = "Calyx Assignment";
   let description = [{
     The "calyx.assign" operation represents a non-blocking
@@ -207,8 +213,8 @@ def AssignOp : CalyxOp<"assign", []> {
     "calyx.wires" section or a "calyx.group".
 
     ```mlir
-      calyx.assign %1 = %2 : i16, i16
-      calyx.assign %1 = %2, %guard ? : i16, i16
+      calyx.assign %1 = %2 : i16
+      calyx.assign %1 = %2, %guard ? : i16
     ```
   }];
   let arguments = (ins
@@ -218,12 +224,10 @@ def AssignOp : CalyxOp<"assign", []> {
   );
   let verifier = "return ::verify$cppClass(*this);";
 
-  // TODO1(Calyx): Calyx IR typically represents a
+  // TODO(Calyx): Calyx IR typically represents a
   // guarded assignments as `%dest = %guard ? %src`
-  // TODO2(Calyx): Only need type of `src` or `dest`.
   let assemblyFormat = [{
-    $dest `=` $src (`,` $guard^ `?`)?
-    attr-dict `:` type($dest) `,` type($src)
+    $dest `=` $src (`,` $guard^ `?`)? attr-dict `:` type($dest)
   }];
 }
 

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -217,6 +217,8 @@ def AssignOp : CalyxOp<"assign", []> {
     Optional<I1>:$guard
   );
   let verifier = "return ::verify$cppClass(*this);";
+  // TODO(Calyx): Calyx IR typically represents a
+  // guarded assignments as `%dest = %guard ? %src`
   let assemblyFormat = [{
     $dest `=` $src (`,` $guard^ `?`)?
     attr-dict `:` type($dest) `,` type($src)

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -197,36 +197,30 @@ def GroupOp : CalyxOp<"group", [
   let assemblyFormat = "$sym_name $body attr-dict";
 }
 
-def GuardOp : CalyxOp<"guard", [
-  ]> {
-  let summary = "Calyx Guard";
-  let description = [{
-    todo
-
-    ```mlir
-      calyx.guard comb.and %0, %1 : i1
-    ```
-  }];
-  let arguments = (ins Variadic<AnyType>:$inputs);
-}
-
-def AssignOp : CalyxOp<"assign", [
-    SameTypeOperands
-  ]> {
+def AssignOp : CalyxOp<"assign", []> {
   let summary = "Calyx Assignment";
   let description = [{
     The "calyx.assign" operation represents a non-blocking
-    assignment. An assignment may optionally be
-    guarded. This operation should only be instantiated in the
+    assignment. An assignment may optionally be guarded,
+    which controls when the assignment should be active.
+    This operation should only be instantiated in the
     "calyx.wires" section or a "calyx.group".
 
     ```mlir
-      calyx.assign %1 = %2 : i16
+      calyx.assign %1 = %2 : i16, i16
+      calyx.assign %1 = %2, %guard ? : i16, i16
     ```
   }];
-  let arguments = (ins AnyType:$dest, AnyType:$src);
-  let assemblyFormat = "$dest `=` $src attr-dict `:` type($src)";
+  let arguments = (ins
+    AnyType:$dest,
+    AnyType:$src,
+    Optional<I1>:$guard
+  );
   let verifier = "return ::verify$cppClass(*this);";
+  let assemblyFormat = [{
+    $dest `=` $src (`,` $guard^ `?`)?
+    attr-dict `:` type($dest) `,` type($src)
+  }];
 }
 
 def DoneOp : CalyxOp<"done", [
@@ -237,12 +231,18 @@ def DoneOp : CalyxOp<"done", [
     let description = [{
       The "calyx.done" operation represents a port on a
       Calyx group that signifies when the group is finished.
+      A done operation may optionally be guarded, which controls
+      when the group's done operation should be active.
 
       ```mlir
         calyx.done %0 : i1
+        calyx.done %0, %guard ? : i1
       ```
     }];
 
-    let arguments = (ins AnyType:$src);
-    let assemblyFormat = "$src attr-dict `:` type($src)";
+    let arguments = (ins
+      AnyType:$src,
+      Optional<I1>:$guard
+    );
+    let assemblyFormat = "$src (`,` $guard^ `?`)? attr-dict `:` type($src)";
 }

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -197,7 +197,19 @@ def GroupOp : CalyxOp<"group", [
   let assemblyFormat = "$sym_name $body attr-dict";
 }
 
-// TODO(Calyx): Add optional guard to AssignOp and DoneOp.
+def GuardOp : CalyxOp<"guard", [
+  ]> {
+  let summary = "Calyx Guard";
+  let description = [{
+    todo
+
+    ```mlir
+      calyx.guard comb.and %0, %1 : i1
+    ```
+  }];
+  let arguments = (ins Variadic<AnyType>:$inputs);
+}
+
 def AssignOp : CalyxOp<"assign", [
     SameTypeOperands
   ]> {

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -276,13 +276,6 @@ static LogicalResult verifyAssignOp(AssignOp assign) {
     return assign.emitOpError(
         "should only be contained in 'calyx.wires' or 'calyx.group'");
 
-  auto srcType = assign.src().getType();
-  auto destType = assign.dest().getType();
-  if (srcType != destType)
-    return assign.emitOpError()
-           << "expected srcType: " << srcType
-           << " to be equivalent to destType: " << destType;
-
   return success();
 }
 

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -272,10 +272,18 @@ static LogicalResult verifyCellOp(CellOp cell) {
 //===----------------------------------------------------------------------===//
 static LogicalResult verifyAssignOp(AssignOp assign) {
   auto parent = assign->getParentOp();
-  if (isa<GroupOp>(parent) || isa<WiresOp>(parent))
-    return success();
-  return assign.emitOpError(
-      "should only be contained in 'calyx.wires' or 'calyx.group'");
+  if (!(isa<GroupOp>(parent) || isa<WiresOp>(parent)))
+    return assign.emitOpError(
+        "should only be contained in 'calyx.wires' or 'calyx.group'");
+
+  auto srcType = assign.src().getType();
+  auto destType = assign.dest().getType();
+  if (srcType != destType)
+    return assign.emitOpError()
+           << "expected srcType: " << srcType
+           << " to be equivalent to destType: " << destType;
+
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -70,28 +70,9 @@ calyx.program {
     %0 = calyx.cell "a0" @A : i16
     %1 = calyx.cell "b0" @B : i16
     // expected-error @+1 {{'calyx.assign' op should only be contained in 'calyx.wires' or 'calyx.group'}}
-    calyx.assign %1 = %0 : i16, i16
+    calyx.assign %1 = %0 : i16
 
     calyx.wires {}
-    calyx.control {}
-  }
-}
-
-// -----
-
-calyx.program {
-  calyx.component @A(%in: i8) -> () {
-    calyx.wires {}
-    calyx.control {}
-  }
-  calyx.component @main() -> () {
-    %in = calyx.cell "c0" @A : i8
-    %c1_i1 = constant 1 : i1
-
-    calyx.wires {
-      // expected-error @+1 {{'calyx.assign' op expected srcType: 'i1' to be equivalent to destType: 'i8'}}
-      calyx.assign %in = %c1_i1 : i8, i1
-    }
     calyx.control {}
   }
 }

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -70,9 +70,28 @@ calyx.program {
     %0 = calyx.cell "a0" @A : i16
     %1 = calyx.cell "b0" @B : i16
     // expected-error @+1 {{'calyx.assign' op should only be contained in 'calyx.wires' or 'calyx.group'}}
-    calyx.assign %1 = %0 : i16
+    calyx.assign %1 = %0 : i16, i16
 
     calyx.wires {}
+    calyx.control {}
+  }
+}
+
+// -----
+
+calyx.program {
+  calyx.component @A(%in: i8) -> (%out: i8) {
+    calyx.wires {}
+    calyx.control {}
+  }
+  calyx.component @main() -> () {
+    %in, %out = calyx.cell "c0" @A : i8, i8
+    %c1_i1 = constant 1 : i1
+
+    calyx.wires {
+      // expected-error @+1 {{'calyx.assign' op expected srcType: 'i1' to be equivalent to destType: 'i8'}}
+      calyx.assign %in = %c1_i1 : i8, i1
+    }
     calyx.control {}
   }
 }

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -80,12 +80,12 @@ calyx.program {
 // -----
 
 calyx.program {
-  calyx.component @A(%in: i8) -> (%out: i8) {
+  calyx.component @A(%in: i8) -> () {
     calyx.wires {}
     calyx.control {}
   }
   calyx.component @main() -> () {
-    %in, %out = calyx.cell "c0" @A : i8, i8
+    %in = calyx.cell "c0" @A : i8
     %c1_i1 = constant 1 : i1
 
     calyx.wires {

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -48,14 +48,14 @@ calyx.program {
     calyx.wires {
       // CHECK: calyx.group @Group1 {
       calyx.group @Group1 {
-        // CHECK: calyx.assign %1#0 = %0#1 : i8, i8
+        // CHECK: calyx.assign %1#0 = %0#1 : i8
         // CHECK-NEXT: calyx.done %true : i1
-        calyx.assign %in2 = %out1 : i8, i8
+        calyx.assign %in2 = %out1 : i8
         calyx.done %c1_i1 : i1
       }
       calyx.group @Group2 {
-        // CHECK:  calyx.assign %1#0 = %0#1, %2 ? : i8, i8
-        calyx.assign %in2 = %out1, %out3 ?  : i8, i8
+        // CHECK:  calyx.assign %1#0 = %0#1, %2 ? : i8
+        calyx.assign %in2 = %out1, %out3 ?  : i8
 
         // CHECK: calyx.done %true, %3 ? : i1
         %guard = comb.and %c1_i1, %out3 : i1

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -48,9 +48,9 @@ calyx.program {
     calyx.wires {
       // CHECK: calyx.group @Group1 {
       calyx.group @Group1 {
-        // CHECK: calyx.assign %0#0 = %1#1 : i8, i8
+        // CHECK: calyx.assign %1#0 = %0#1 : i8, i8
         // CHECK-NEXT: calyx.done %true : i1
-        calyx.assign %in1 = %out2 : i8, i8
+        calyx.assign %in2 = %out1 : i8, i8
         calyx.done %c1_i1 : i1
       }
       calyx.group @Group2 {

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -34,18 +34,32 @@ calyx.program {
     calyx.control {}
   }
 
+  calyx.component @B () -> (%out: i1) {
+    calyx.wires {}
+    calyx.control {}
+  }
+
   calyx.component @main() -> () {
     %in1, %out1 = calyx.cell "c0" @A : i8, i8
     %in2, %out2 = calyx.cell "c1" @A : i8, i8
+    %out3 = calyx.cell "c2" @B : i1
     %c1_i1 = constant 1 : i1
 
     calyx.wires {
-      // CHECK: calyx.group @SomeGroup {
-      calyx.group @SomeGroup {
-        // CHECK: calyx.assign %1#0 = %0#1 : i8
+      // CHECK: calyx.group @Group1 {
+      calyx.group @Group1 {
+        // CHECK: calyx.assign %0#0 = %1#1 : i8, i8
         // CHECK-NEXT: calyx.done %true : i1
-        calyx.assign %in2 = %out1 : i8
+        calyx.assign %in1 = %out2 : i8, i8
         calyx.done %c1_i1 : i1
+      }
+      calyx.group @Group2 {
+        // CHECK:  calyx.assign %1#0 = %0#1, %2 ? : i8, i8
+        calyx.assign %in2 = %out1, %out3 ?  : i8, i8
+
+        // CHECK: calyx.done %true, %3 ? : i1
+        %guard = comb.and %c1_i1, %out3 : i1
+        calyx.done %c1_i1, %guard ? : i1
       }
     }
     calyx.control {}


### PR DESCRIPTION
Adds `guard`s to assignments and done operations. A `guard` is a boolean expression that determines when the given assignment should be active. 

A few notes:

First, Calyx IR represents them in the following manner:
```
dest = guard ? src
```

In the dialect, it takes a slightly different form:
```
dest = src, guard ?
```
The reasoning for this is that I can just use the assemblyFormat for printing and parsing. If I were to try using the Calyx IR, the guard would be mistakenly parsed as the source. A TODO is left to match the Calyx IR parsing and printing.

Second, the `AssignOp` prints the type of both the source and destination, though they should always be the same. I've added a check in the verifier, but eventually we want to print one type for an AssignOp. I had to remove `SameTypeOperands` with the introduction of a 1-bit `guard`. Perhaps there is some ODS-way to verify that 2 of 3 operands have equivalent types, but currently unsure how to do this.