### PR TITLE
[PyCDE] Add functionality to declare named types.

### DIFF
--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -2,6 +2,8 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from .types import types
+
 import mlir
 import mlir.ir
 import mlir.passmanager
@@ -59,6 +61,7 @@ class System:
       return
     pm = mlir.passmanager.PassManager.parse(",".join(self.passes))
     pm.run(self.mod)
+    types.declare_types(self.mod)
     self.passed = True
 
   def print_verilog(self, out_stream: typing.TextIO = sys.stdout):

--- a/frontends/PyCDE/src/pycde/types.py
+++ b/frontends/PyCDE/src/pycde/types.py
@@ -2,6 +2,8 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from collections import OrderedDict
+
 import mlir.ir
 from circt.dialects import hw
 
@@ -12,7 +14,7 @@ class _Types:
   TYPE_SCOPE = "pycde"
 
   def __init__(self):
-    self.registered_aliases = {}
+    self.registered_aliases = OrderedDict()
     self.declared_aliases = {}
     self.type_scopes = {}
 
@@ -63,9 +65,6 @@ class _Types:
         self.type_scopes[mod] = hw.TypeScopeOp.create(self.TYPE_SCOPE)
         self.declared_aliases[mod] = set([])
 
-    # TODO: at this point, we should ensure that any aliases referring to other
-    # aliases are declared in an order that respects def-before-use, or error on
-    # mutually recursive aliases. For now, emit them in arbitrary order.
     with mlir.ir.InsertionPoint(self.type_scopes[mod].body):
       for (name, type) in self.registered_aliases.items():
         if name in self.declared_aliases[mod]:

--- a/frontends/PyCDE/test/pycde_types.py
+++ b/frontends/PyCDE/test/pycde_types.py
@@ -2,6 +2,8 @@
 
 from pycde import dim, types
 
+from mlir.ir import Module
+
 # CHECK: i6
 array1 = dim(types.i6)
 array1.dump()
@@ -41,3 +43,19 @@ print()
 dim_alias = dim(1, 8, name="myname5")
 dim_alias.dump()
 print()
+
+# CHECK: hw.type_scope @pycde
+# CHECK: hw.typedecl @myname1 : i8
+# CHECK: hw.typedecl @myname2 : i8
+# CHECK: hw.typedecl @myname3 : !hw.array<8xi1>
+# CHECK: hw.typedecl @myname4 : !hw.struct<a: i1, b: i1>
+# CHECK: hw.typedecl @myname5 : !hw.array<8xi1>
+# CHECK-NOT: hw.typedecl @myname1
+# CHECK-NOT: hw.typedecl @myname2
+# CHECK-NOT: hw.typedecl @myname3
+# CHECK-NOT: hw.typedecl @myname4
+# CHECK-NOT: hw.typedecl @myname5
+m = Module.create()
+types.declare_types(m)
+types.declare_types(m)
+print(m)

--- a/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
@@ -430,3 +430,24 @@ class StructExtractOp:
     field_type = struct_type.get_field(field_name)
     return hw.StructExtractOp(field_type, struct_value,
                               StringAttr.get(field_name))
+
+
+class TypedeclOp:
+
+  @staticmethod
+  def create(sym_name: str, type: Type, verilog_name: str = None):
+    return hw.TypedeclOp(StringAttr.get(sym_name), TypeAttr.get(type),
+                         verilog_name)
+
+
+class TypeScopeOp:
+
+  @staticmethod
+  def create(sym_name: str):
+    op = hw.TypeScopeOp(StringAttr.get(sym_name))
+    op.regions[0].blocks.append()
+    return op
+
+  @property
+  def body(self):
+    return self.regions[0].blocks[0]


### PR DESCRIPTION
This builds on the previous support to allow naming types through
PyCDE's types module. A new method will declare the registered type
aliases in a given mlir::ModuleOp. Multiple invocations will only emit
each alias once per module. This method is not intended to be exposed
to an end user, rather it is invoked automatically within a PyCDE
System during the user-facing method run_passes.