### PR TITLE
[FIRRTL] Remove unused variable.

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1979,7 +1979,6 @@ LogicalResult MuxPrimOp::validateArguments(ValueRange operands,
 FIRRTLType MuxPrimOp::inferReturnType(ValueRange operands,
                                       ArrayRef<NamedAttribute> attrs,
                                       Optional<Location> loc) {
-  auto sel = operands[0].getType();
   auto high = operands[1].getType().cast<FIRRTLType>();
   auto low = operands[2].getType().cast<FIRRTLType>();
 


### PR DESCRIPTION
When building FIRRTLOps:
```
[1/6] Building CXX object lib/Dialect/FIRRTL/CMakeFiles/obj.CIRCTFIRRTL.dir/FIRRTLOps.cpp.o
  auto sel = operands[0].getType();
       ^
1 warning generated
```