### PR TITLE
[FIRRTL] Add folders for no-effect casts

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -709,6 +709,10 @@ LogicalResult NEQPrimOp::canonicalize(NEQPrimOp op, PatternRewriter &rewriter) {
 //===----------------------------------------------------------------------===//
 
 OpFoldResult AsSIntPrimOp::fold(ArrayRef<Attribute> operands) {
+  // No effect.
+  if (input().getType() == getType())
+      return input();
+
   // Be careful to only fold the cast into the constant if the size is known.
   // Otherwise width inference may produce differently-sized constants if the
   // sign changes.
@@ -719,6 +723,10 @@ OpFoldResult AsSIntPrimOp::fold(ArrayRef<Attribute> operands) {
 }
 
 OpFoldResult AsUIntPrimOp::fold(ArrayRef<Attribute> operands) {
+  // No effect.
+  if (input().getType() == getType())
+      return input();
+
   // Be careful to only fold the cast into the constant if the size is known.
   // Otherwise width inference may produce differently-sized constants if the
   // sign changes.
@@ -730,11 +738,21 @@ OpFoldResult AsUIntPrimOp::fold(ArrayRef<Attribute> operands) {
 
 OpFoldResult AsAsyncResetPrimOp::fold(ArrayRef<Attribute> operands) {
   // TODO: Implement constants of asyncreset type.
+
+  // No effect.
+  if (input().getType() == getType())
+      return input();
+
   return {};
 }
 
 OpFoldResult AsClockPrimOp::fold(ArrayRef<Attribute> operands) {
   // TODO: Implement constants of clock type.
+
+  // No effect.
+  if (input().getType() == getType())
+      return input();
+
   return {};
 }
 

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -1,6 +1,30 @@
 // RUN: circt-opt -simple-canonicalizer %s | FileCheck %s
 
-firrtl.circuit "And" {
+firrtl.circuit "Casts" {
+
+// CHECK-LABEL: firrtl.module @Casts
+firrtl.module @Casts(in %ui1 : !firrtl.uint<1>, in %si1 : !firrtl.sint<1>,
+    in %clock : !firrtl.clock, in %asyncreset : !firrtl.asyncreset,
+    out %out_ui1 : !firrtl.uint<1>, out %out_si1 : !firrtl.sint<1>,
+    out %out_clock : !firrtl.clock, out %out_asyncreset : !firrtl.asyncreset) {
+
+  %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+  %c1_si1 = firrtl.constant 1 : !firrtl.sint<1>
+
+  /// No effect
+  // CHECK: firrtl.connect %out_ui1, %ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  %0 = firrtl.asUInt %ui1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+  firrtl.connect %out_ui1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK: firrtl.connect %out_si1, %si1 : !firrtl.sint<1>, !firrtl.sint<1>
+  %1 = firrtl.asSInt %si1 : (!firrtl.sint<1>) -> !firrtl.sint<1>
+  firrtl.connect %out_si1, %1 : !firrtl.sint<1>, !firrtl.sint<1>
+  // CHECK: firrtl.connect %out_clock, %clock : !firrtl.clock, !firrtl.clock
+  %2 = firrtl.asClock %clock : (!firrtl.clock) -> !firrtl.clock
+  firrtl.connect %out_clock, %2 : !firrtl.clock, !firrtl.clock
+  // CHECK: firrtl.connect %out_asyncreset, %asyncreset : !firrtl.asyncreset, !firrtl.asyncreset
+  %3 = firrtl.asAsyncReset %asyncreset : (!firrtl.asyncreset) -> !firrtl.asyncreset
+  firrtl.connect %out_asyncreset, %3 : !firrtl.asyncreset, !firrtl.asyncreset
+}
 
 // CHECK-LABEL: firrtl.module @Div
 firrtl.module @Div(in %a: !firrtl.uint<4>,


### PR DESCRIPTION
This adds folders which eliminate casts when the input type matches the
output type, and the cast has no effect.