### PR TITLE
[Py] [PyCDE] More type checking in HWInstances and module instantiation

### DIFF
--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -42,8 +42,8 @@ class System:
   def body(self):
     return self.mod.body
 
-  def print(self):
-    self.mod.operation.print()
+  def print(self, **kwargs):
+    self.mod.operation.print(**kwargs)
 
   def graph(self, short_names=True):
     import mlir.all_passes_registration

--- a/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
@@ -42,7 +42,7 @@ class InstanceBuilder(support.NamedValueOpView):
       }
       for input_name, input_value in input_port_mapping.items():
         if input_name not in input_name_type_lookup:
-          continue  # This error gets caught and raise later.
+          continue  # This error gets caught and raised later.
         mod_input_type = input_name_type_lookup[input_name]
         if support.type_to_pytype(input_value.type) != mod_input_type:
           raise TypeError(f"Input '{input_name}' has type '{input_value.type}' "

--- a/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
@@ -35,6 +35,19 @@ class InstanceBuilder(support.NamedValueOpView):
     if results is None:
       results = module.type.results
 
+    if not isinstance(module, hw.HWModuleExternOp):
+      input_name_type_lookup = {
+          name: support.type_to_pytype(ty)
+          for name, ty in zip(self.operand_names(), module.type.inputs)
+      }
+      for input_name, input_value in input_port_mapping.items():
+        if input_name not in input_name_type_lookup:
+          continue  # This error gets caught and raise later.
+        mod_input_type = input_name_type_lookup[input_name]
+        if support.type_to_pytype(input_value.type) != mod_input_type:
+          raise TypeError(f"Input '{input_name}' has type '{input_value.type}' "
+                          f"but expected '{mod_input_type}'")
+
     super().__init__(hw.InstanceOp,
                      results,
                      input_port_mapping,

--- a/lib/Bindings/Python/circt/support.py
+++ b/lib/Bindings/Python/circt/support.py
@@ -286,13 +286,13 @@ class NamedValueOpView:
 
   def __getattr__(self, name):
     # Check for the attribute in the arg name set.
-    if name in self.operand_indices:
+    if "operand_indices" in dir(self) and name in self.operand_indices:
       index = self.operand_indices[name]
       value = self.opview.operands[index]
       return OpOperand(self.opview.operation, index, value, self)
 
     # Check for the attribute in the result name set.
-    if name in self.result_indices:
+    if "result_indices" in dir(self) and name in self.result_indices:
       index = self.result_indices[name]
       value = self.opview.results[index]
       return OpOperand(self.opview.operation, index, value, self)


### PR DESCRIPTION
- Adds type checking to PyCDE module instantiations.
- Corrects generate to use types defined in class rather than the example op.
- Adds type checking to Python bindings ModuleLike.create()
- Adds a safety check to `ModuleLike.__getattr_()` to avoid infinite recursion.