### PR TITLE
[Py] [PyCDE] Use `bitcast` to convert structs to TypeAliasTypes and take advantage of aliases

### DIFF
--- a/frontends/PyCDE/src/pycde/module.py
+++ b/frontends/PyCDE/src/pycde/module.py
@@ -380,11 +380,25 @@ class _Generate:
         inst.attributes[name] = attr
       return inst
 
+  @staticmethod
+  def create_type_string(ty):
+    ty = support.type_to_pytype(ty)
+    if isinstance(ty, hw.TypeAliasType):
+      return ty.name
+    if isinstance(ty, hw.ArrayType):
+      return f"{ty.size}x" + _Generate.create_type_string(ty.element_type)
+    return str(ty)
+
   def create_module_name(self, op):
+    def val_str(val):
+      if isinstance(val, mlir.ir.Type):
+        return self.create_type_string(val)
+      return str(val)
+
     name = op.name
     if len(self.params) > 0:
       name += "_" + "_".join(
-          str(value) for (_, value) in
+          val_str(value) for (_, value) in
           sorted(self.params.items()))
 
     return name

--- a/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
@@ -178,7 +178,8 @@ def _create_output_op(cls_name, output_ports, entry_block, bb_ret):
       # If it does, the return from body_builder must be None.
       if bb_ret is not None and bb_ret != last_op:
         raise support.ConnectionError(
-            "Cannot return value from body_builder and create hw.OutputOp")
+            f"In {cls_name}, cannot return value from body_builder and "
+            "create hw.OutputOp")
       return
 
   # If builder didn't create an output op and didn't return anything, this op
@@ -187,7 +188,8 @@ def _create_output_op(cls_name, output_ports, entry_block, bb_ret):
     if len(output_ports) == 0:
       hw.OutputOp([])
       return
-    raise support.ConnectionError("Must return module output values")
+    raise support.ConnectionError(
+        f"In {cls_name}, must return module output values")
 
   # Now create the output op depending on the object type returned
   outputs: list[Value] = list()
@@ -195,7 +197,8 @@ def _create_output_op(cls_name, output_ports, entry_block, bb_ret):
   # Only acceptable return is a dict of port, value mappings.
   if not isinstance(bb_ret, dict):
     raise support.ConnectionError(
-        "Can only return a dict of port, value mappings from body_builder.")
+        "In {cls_name}, can only return a dict of port, value mappings "
+        "from body_builder.")
 
   # A dict of `OutputPortName` -> ValueLike must be converted to a list in port
   # order.
@@ -209,11 +212,16 @@ def _create_output_op(cls_name, output_ports, entry_block, bb_ret):
       if val is None:
         field_type = type(bb_ret[name])
         raise TypeError(
-            f"body_builder return doesn't support type '{field_type}'")
+            f"In {cls_name}, body_builder return doesn't support type "
+            f"'{field_type}'")
       if val.type != port_type:
-        raise TypeError(
-            f"Output port '{name}' type ({val.type}) doesn't match declared"
-            f" type ({port_type})")
+        if isinstance(port_type, hw.TypeAliasType) and \
+           port_type.inner_type == val.type:
+          val = hw.BitcastOp(port_type, val).result
+        else:
+          raise TypeError(
+              f"In {cls_name}, output port '{name}' type ({val.type}) doesn't "
+              f"match declared type ({port_type})")
       outputs.append(val)
       bb_ret.pop(name)
   if len(unconnected_ports) > 0:

--- a/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
@@ -428,26 +428,26 @@ class StructCreateOp:
         (name, support.get_value(value)) for (name, value) in elements
     ]
     struct_fields = [(name, value.type) for (name, value) in elem_name_values]
-    if result_type is None:
-      result_type = hw.StructType.get(struct_fields)
-    else:
-      result_type_inner = support.get_self_or_inner(result_type)
-      if not isinstance(result_type_inner, hw.StructType):
-        raise TypeError("result_type must be cast-able to struct type")
-      result_fields = result_type_inner.get_fields()
-      if len(struct_fields) != len(result_fields):
-        raise TypeError("Number of fields in result_type must match elements")
-      for (ex_name, ex_type), (res_name,
-                               res_type) in zip(struct_fields, result_fields):
-        if ex_name != res_name:
-          raise TypeError(
-              f"Field names must match ('{ex_name}' vs '{res_name}'")
-        if support.type_to_pytype(ex_type) != support.type_to_pytype(res_type):
-          raise TypeError(
-              f"Field types must match ('{ex_type}' vs '{res_type}'")
+    struct_type = hw.StructType.get(struct_fields)
 
-    return hw.StructCreateOp(result_type,
-                             [value for (_, value) in elem_name_values])
+    struct_val = hw.StructCreateOp(struct_type,
+                                   [value for (_, value) in elem_name_values])
+    if result_type is None:
+      return struct_val
+
+    result_type_inner = support.get_self_or_inner(result_type)
+    if not isinstance(result_type_inner, hw.StructType):
+      raise TypeError("result_type must be cast-able to struct type")
+    result_fields = result_type_inner.get_fields()
+    if len(struct_fields) != len(result_fields):
+      raise TypeError("Number of fields in result_type must match elements")
+    for (ex_name, ex_type), (res_name, res_type) in zip(struct_fields,
+                                                        result_fields):
+      if ex_name != res_name:
+        raise TypeError(f"Field names must match ('{ex_name}' vs '{res_name}'")
+      if support.type_to_pytype(ex_type) != support.type_to_pytype(res_type):
+        raise TypeError(f"Field types must match ('{ex_type}' vs '{res_type}'")
+    return hw.BitcastOp(result_type, struct_val.result)
 
 
 class StructExtractOp:

--- a/lib/Bindings/Python/circt/support.py
+++ b/lib/Bindings/Python/circt/support.py
@@ -103,6 +103,10 @@ def type_to_pytype(t):
 # long one. This is a way that works for now.
 def attribute_to_var(attr):
   import mlir.ir as ir
+
+  if not isinstance(attr, ir.Attribute):
+    raise TypeError("attribute_to_var only accepts MLIR Attributes")
+
   try:
     return ir.BoolAttr(attr).value
   except ValueError:

--- a/lib/Bindings/Python/circt/support.py
+++ b/lib/Bindings/Python/circt/support.py
@@ -238,6 +238,10 @@ class OpOperand:
     self.value = value
     self.backedge_owner = backedge_owner
 
+  @property
+  def type(self):
+    return self.value.type
+
 
 class NamedValueOpView:
   """Helper class to incrementally construct an instance of an operation that


### PR DESCRIPTION
This is a hack to unblock us pending a group discussion.

- Use a `bitcast` in `StructCreateOp.create()` if the `result_type` is specified.
- Take advantage of type aliases in naming.
- In creating `OutputOps`, automatically convert to an alias if the port is just a type aliased version of the value being returned.
- (Unrelated) add class name in `_create_output_op` messages.