### PR TITLE
[FIRRTL] Block constant propagation through DontTouchAnnotation

### DIFF
--- a/docs/FIRRTLAnnotations.md
+++ b/docs/FIRRTLAnnotations.md
@@ -309,7 +309,9 @@ Example:
 | target     | string | Reference target                        |
 
 The `DontTouchAnnotation` prevents the removal of elements through
-optimization. This annotation also ensures that the name of the object is
+optimization. This annotation is an optimization barrier, for 
+example, it blocks constant propagation through it.
+This annotation also ensures that the name of the object is
 preserved, and not discarded or modified. 
 
 Example:

--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
@@ -68,6 +68,9 @@ public:
   forPort(Operation *module, size_t portNo,
           SmallVectorImpl<NamedAttribute> &otherAttributes);
 
+  /// Get an annotation set for the specified value.
+  static AnnotationSet getAnnotationSet(Value v);
+
   /// Return all the raw annotations that exist.
   ArrayRef<Attribute> getArray() const { return annotations.getValue(); }
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
@@ -69,7 +69,7 @@ public:
           SmallVectorImpl<NamedAttribute> &otherAttributes);
 
   /// Get an annotation set for the specified value.
-  static AnnotationSet getAnnotationSet(Value v);
+  static AnnotationSet get(Value v);
 
   /// Return all the raw annotations that exist.
   ArrayRef<Attribute> getArray() const { return annotations.getValue(); }

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
@@ -82,7 +82,7 @@ AnnotationSet::forPort(Operation *module, size_t portNo,
 }
 
 /// Get an annotation set for the specified value.
-AnnotationSet AnnotationSet::getAnnotationSet(Value v) {
+AnnotationSet AnnotationSet::get(Value v) {
   if (auto op = v.getDefiningOp())
     return AnnotationSet(op);
   // If its not an Operation, then must be a block argument.

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
@@ -81,6 +81,16 @@ AnnotationSet::forPort(Operation *module, size_t portNo,
   return AnnotationSet(annotations, module->getContext());
 }
 
+/// Get an annotation set for the specified value.
+AnnotationSet AnnotationSet::getAnnotationSet(Value v) {
+  if (auto op = v.getDefiningOp())
+    return AnnotationSet(op);
+  // If its not an Operation, then must be a block argument.
+  auto arg = v.dyn_cast<BlockArgument>();
+  auto module = cast<FModuleOp>(arg.getOwner()->getParentOp());
+  return forPort(module, arg.getArgNumber());
+}
+
 /// Return this annotation set as an argument attribute dictionary for a port.
 DictionaryAttr AnnotationSet::getArgumentAttrDict(
     ArrayRef<NamedAttribute> otherPortAttrs) const {

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -189,6 +189,9 @@ struct IMConstPropPass : public IMConstPropBase<IMConstPropPass> {
   /// revisitation.
   void mergeLatticeValue(Value value, LatticeValue &valueEntry,
                          LatticeValue source) {
+    if (!source.isOverdefined() &&
+        AnnotationSet::getAnnotationSet(value).hasDontTouch())
+      source = LatticeValue::getOverdefined();
     if (valueEntry.mergeIn(source))
       changedLatticeValueWorklist.push_back(value);
   }
@@ -217,6 +220,9 @@ struct IMConstPropPass : public IMConstPropBase<IMConstPropPass> {
     if (source.isUnknown())
       return;
 
+    if (!source.isOverdefined() &&
+        AnnotationSet::getAnnotationSet(value).hasDontTouch())
+      source = LatticeValue::getOverdefined();
     // If we've changed this value then revisit all the users.
     auto &valueEntry = latticeValues[value];
     if (valueEntry != source) {

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -190,7 +190,7 @@ struct IMConstPropPass : public IMConstPropBase<IMConstPropPass> {
   void mergeLatticeValue(Value value, LatticeValue &valueEntry,
                          LatticeValue source) {
     if (!source.isOverdefined() &&
-        AnnotationSet::getAnnotationSet(value).hasDontTouch())
+        AnnotationSet::get(value).hasDontTouch())
       source = LatticeValue::getOverdefined();
     if (valueEntry.mergeIn(source))
       changedLatticeValueWorklist.push_back(value);
@@ -221,7 +221,7 @@ struct IMConstPropPass : public IMConstPropBase<IMConstPropPass> {
       return;
 
     if (!source.isOverdefined() &&
-        AnnotationSet::getAnnotationSet(value).hasDontTouch())
+        AnnotationSet::get(value).hasDontTouch())
       source = LatticeValue::getOverdefined();
     // If we've changed this value then revisit all the users.
     auto &valueEntry = latticeValues[value];

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -189,8 +189,7 @@ struct IMConstPropPass : public IMConstPropBase<IMConstPropPass> {
   /// revisitation.
   void mergeLatticeValue(Value value, LatticeValue &valueEntry,
                          LatticeValue source) {
-    if (!source.isOverdefined() &&
-        AnnotationSet::get(value).hasDontTouch())
+    if (!source.isOverdefined() && AnnotationSet::get(value).hasDontTouch())
       source = LatticeValue::getOverdefined();
     if (valueEntry.mergeIn(source))
       changedLatticeValueWorklist.push_back(value);
@@ -220,8 +219,7 @@ struct IMConstPropPass : public IMConstPropBase<IMConstPropPass> {
     if (source.isUnknown())
       return;
 
-    if (!source.isOverdefined() &&
-        AnnotationSet::get(value).hasDontTouch())
+    if (!source.isOverdefined() && AnnotationSet::get(value).hasDontTouch())
       source = LatticeValue::getOverdefined();
     // If we've changed this value then revisit all the users.
     auto &valueEntry = latticeValues[value];
@@ -501,8 +499,9 @@ void IMConstPropPass::visitConnect(ConnectOp connect) {
   // Driving result ports propagates the value to each instance using the
   // module.
   if (auto blockArg = connect.dest().dyn_cast<BlockArgument>()) {
-    for (auto userOfResultPort : resultPortToInstanceResultMapping[blockArg])
-      mergeLatticeValue(userOfResultPort, srcValue);
+    if (!AnnotationSet::get(blockArg).hasDontTouch())
+      for (auto userOfResultPort : resultPortToInstanceResultMapping[blockArg])
+        mergeLatticeValue(userOfResultPort, srcValue);
     return;
   }
 

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -235,7 +235,7 @@ firrtl.circuit "OutPortTop" {
 firrtl.circuit "InputPortTop"   {
   // CHECK-LABEL: firrtl.module @InputPortChild2
   firrtl.module @InputPortChild2(in %in0: !firrtl.uint<1>, in %in1: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
-    // CHECK: %c1_ui1 = firrtl.constant 1
+    // CHECK: = firrtl.constant 1
     %0 = firrtl.and %in0, %in1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   }


### PR DESCRIPTION
The `DontTouch` annotation should block constant propagation through it, according to the Scala [FIRRTL implementation](https://github.com/chipsalliance/firrtl/blob/master/src/main/scala/firrtl/transforms/ConstantPropagation.scala) 
Mimic this behavior in `IMConstProp` pass.
1. Check if the value has a `DontTouch` annotaiton, whenever updating its lattice value.
2. Mark it as `overdefined`, such that it blocks any constant propagation through it.