### PR TITLE
[FIRRTL] Add a CheckCombCycles pass

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -47,6 +47,8 @@ std::unique_ptr<mlir::Pass> createGrandCentralPass();
 
 std::unique_ptr<mlir::Pass> createGrandCentralTapsPass();
 
+std::unique_ptr<mlir::Pass> createCheckCombCyclesPass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/FIRRTL/Passes.h.inc"

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -194,4 +194,12 @@ def GrandCentralTaps : Pass<"firrtl-grand-central-taps", "firrtl::CircuitOp"> {
   let dependentDialects = ["sv::SVDialect"];
 }
 
+def CheckCombCycles : Pass<"firrtl-check-comb-cycles", "firrtl::CircuitOp"> {
+  let summary = "Check combinational cycles and emit errors";
+  let description = [{
+    This pass checks combinational cycles in the IR and emit errors.
+  }];
+  let constructor = "circt::firrtl::createCheckCombCyclesPass()";
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_PASSES_TD

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -9,6 +9,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   LowerTypes.cpp
   ModuleInliner.cpp
   PrintInstanceGraph.cpp
+  CheckCombCycles.cpp
 
   DEPENDS
   CIRCTFIRRTLTransformsIncGen

--- a/lib/Dialect/FIRRTL/Transforms/CheckCombCycles.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckCombCycles.cpp
@@ -22,454 +22,21 @@
 using namespace circt;
 using namespace firrtl;
 
-namespace {
-class CombNodeImpl;
-}
-
-using CombNode = CombNodeImpl *;
-using ValueOrOpType = PointerUnion<Value, Operation *>;
-using CombNodeKeyType = std::pair<ValueOrOpType, unsigned>;
-
-//===----------------------------------------------------------------------===//
-// CombNodeImpl class
-//===----------------------------------------------------------------------===//
-
-namespace {
-/// This is the implementation of a combinational node.
-class CombNodeImpl {
-public:
-  CombNodeImpl(ValueOrOpType valOrOp, unsigned fieldID = 0)
-      : valOrOp(valOrOp), fieldID(fieldID) {}
-
-  bool operator==(const CombNodeImpl &other) const {
-    return valOrOp == other.valOrOp && fieldID == other.fieldID;
-  }
-
-  CombNode *child_begin() { return children.begin(); }
-  CombNode *child_end() { return children.end(); }
-
-  void addChild(CombNode child) { children.emplace_back(child); }
-  void clearChilds() { children.clear(); }
-
-  ValueOrOpType getValOrOp() const { return valOrOp; }
-  unsigned getFieldID() const { return fieldID; }
-
-  llvm::hash_code hash_value() const {
-    return llvm::hash_combine(valOrOp.getOpaqueValue(), fieldID);
-  }
-
-private:
-  /// The underneath value or operation of this node.
-  ValueOrOpType valOrOp;
-
-  /// The field ID this node is referencing to.
-  unsigned fieldID;
-
-  /// Store all children of this node in the graph.
-  SmallVector<CombNode, 4> children;
-};
-} // namespace
-
-//===----------------------------------------------------------------------===//
-// CombGraph class
-//===----------------------------------------------------------------------===//
-
-namespace {
-// This is a combinational graph contains a set of nodes.
-class CombGraph {
-public:
-  ~CombGraph() {
-    for (auto node : nodes)
-      node->~CombNodeImpl();
-  }
-
-  /// Get a node from the graph if it exists. Otherwise, allocate a new node and
-  /// add to the graph.
-  CombNode getOrAddNode(ValueOrOpType valOrOp, unsigned fieldID = 0) {
-    auto it = nodes.find_as<CombNodeKeyType>({valOrOp, fieldID});
-    if (it != nodes.end())
-      return *it;
-    auto newNode = new (allocator) CombNodeImpl(valOrOp, fieldID);
-    nodes.insert(newNode);
-    return newNode;
-  }
-
-  /// Get a node from the graph if it exists.
-  CombNode getNode(ValueOrOpType valOrOp, unsigned fieldID = 0) {
-    auto it = nodes.find_as<CombNodeKeyType>({valOrOp, fieldID});
-    return it != nodes.end() ? *it : nullptr;
-  }
-
-private:
-  /// For allocating memories for combinational nodes.
-  llvm::BumpPtrAllocator allocator;
-
-  /// A set of combinational nodes.
-  DenseSet<CombNode> nodes;
-};
-} // namespace
-
-//===----------------------------------------------------------------------===//
-// GraphTraits on CombNode
-//===----------------------------------------------------------------------===//
-
-namespace llvm {
-template <>
-struct GraphTraits<CombNode> {
-  using NodeRef = CombNode;
-  using ChildIteratorType = NodeRef *;
-
-  static NodeRef getEntryNode(NodeRef node) { return node; }
-
-  static inline ChildIteratorType child_begin(NodeRef node) {
-    return node->child_begin();
-  }
-  static inline ChildIteratorType child_end(NodeRef node) {
-    return node->child_end();
-  }
-};
-} // namespace llvm
-
-//===----------------------------------------------------------------------===//
-// CycleDetector class
-//===----------------------------------------------------------------------===//
-
-/// This is used for storing combinational paths between IOs of a FIRRTL module.
-/// The two elements of the pair are the argument index of the input port and
-/// output port, respectively.
-using CombPaths = SmallVector<std::pair<unsigned, unsigned>>;
-
-namespace {
-class CycleDetector : public FIRRTLVisitor<CycleDetector, bool> {
-public:
-  CycleDetector(FModuleOp module,
-                DenseMap<Operation *, CombPaths> &combPathsMap,
-                InstanceGraph &instanceGraph)
-      : module(module), combPathsMap(combPathsMap),
-        instanceGraph(instanceGraph) {}
-
-  /// Each operation visitor is supposed to finish the following tasks:
-  ///   1. Create a node for each of its results if the result is not a
-  ///   sequential value, such as register and memory write port;
-  ///   2. Create edges between its arguments and results if applicable.
-  using FIRRTLVisitor<CycleDetector, bool>::visitStmt;
-  using FIRRTLVisitor<CycleDetector, bool>::visitDecl;
-  using FIRRTLVisitor<CycleDetector, bool>::visitExpr;
-
-  /// Statement handlers.
-  template <typename ConnectOpType>
-  bool handleConnectOp(ConnectOpType op);
-  bool visitStmt(ConnectOp op) { return handleConnectOp(op); }
-  bool visitStmt(PartialConnectOp op) { return handleConnectOp(op); }
-  bool visitStmt(WhenOp op) {
-    op->emitOpError("unsupported, please run -firrtl-expand-whens first");
-    return false;
-  }
-
-  /// Declaration handlers.
-  bool visitDecl(InstanceOp op);
-  bool visitDecl(MemOp op);
-  bool visitDecl(RegOp op) { return true; }
-  bool visitDecl(RegResetOp op) { return true; }
-
-  /// Expression handlers.
-  bool visitExpr(SubfieldOp op);
-  bool visitExpr(SubindexOp op) {
-    op->emitOpError("unsupported, please run -firrtl-lower-types first");
-    return false;
-  };
-  bool visitExpr(SubaccessOp op) {
-    op->emitOpError("unsupported, please run -firrtl-lower-types first");
-    return false;
-  };
-
-  /// Handle other operations that don't have concrete visitors.
-  bool visitUnhandledOp(Operation *op);
-
-  /// Build combinational graph of the module with the visitor dispatcher.
-  void buildCombGraph();
-
-  /// Detect combinational cycles in the module. Also detect combinational paths
-  /// between IOs of the module and record these paths in the `combPathsMap`.
-  void detect();
-
-private:
-  /// The module detected on.
-  FModuleOp module;
-
-  /// The global combinational paths map.
-  DenseMap<Operation *, CombPaths> &combPathsMap;
-
-  /// The global instance graph.
-  InstanceGraph &instanceGraph;
-
-  /// The local combinational graph.
-  CombGraph combGraph;
-};
-} // namespace
-
-template <typename ConnectOpType>
-bool CycleDetector::handleConnectOp(ConnectOpType op) {
-  // Create an edge between the `source` value and `destination` value if both
-  // exist in the graph.
-  auto srcNode = combGraph.getNode(op.src());
-  auto dstNode = combGraph.getNode(op.dest());
-  if (srcNode && dstNode) {
-    auto connectNode = combGraph.getOrAddNode(op.getOperation());
-    srcNode->addChild(connectNode);
-    connectNode->addChild(dstNode);
-  }
-  return true;
-}
-
-/// Declaration handlers.
-bool CycleDetector::visitDecl(InstanceOp op) {
-  SmallVector<CombNode, 8> nodes;
-  for (auto result : op.getResults())
-    nodes.push_back(combGraph.getOrAddNode(result));
-
-  // Query the combinational paths between IOs and create edges.
-  auto const &combPaths =
-      combPathsMap.lookup(instanceGraph.getReferencedModule(op));
-  for (auto const &combPath : combPaths) {
-    auto srcNode = nodes[combPath.first];
-    auto dstNode = nodes[combPath.second];
-    srcNode->addChild(dstNode);
-  }
-  return true;
-}
-
-bool CycleDetector::visitDecl(MemOp op) {
-  // Combinational paths only exist when reading latency is zero.
-  if (op.readLatency() != 0)
-    return true;
-
-  // Traverse every ports of the memory.
-  for (unsigned i = 0, e = op.getNumResults(); i < e; ++i) {
-    // Combinational paths only exist in `read` or `readwrite` ports.
-    auto portKind = op.getPortKind(i);
-    if (portKind == MemOp::PortKind::Write)
-      continue;
-
-    auto portType = op.getPortType(i).cast<BundleType>();
-
-    auto enIndex = portType.getElementIndex("en");
-    auto addrIndex = portType.getElementIndex("addr");
-    auto dataIndex = portKind == MemOp::PortKind::ReadWrite
-                         ? portType.getElementIndex("rdata")
-                         : portType.getElementIndex("data");
-
-    // Travers all subfields of the memory port. Combinational paths can only
-    // start from `en` or `addr`, and propagate to `rdata` (for `readwrite`
-    // port) or `data` (for `read` port).
-    SmallVector<CombNode, 2> srcNodes;
-    CombNode dstNode = nullptr;
-    for (auto &use : op.getResult(i).getUses()) {
-      auto subField = dyn_cast<SubfieldOp>(use.getOwner());
-      if (!subField) {
-        use.getOwner()->emitOpError(
-            "should only be used by SubFieldOp, please run "
-            "-firrtl-lower-types first");
-        return false;
-      }
-
-      // Record source nodes and destination node of combinational paths.
-      auto fieldIndex = subField.fieldIndex();
-      if (fieldIndex == enIndex || fieldIndex == addrIndex)
-        srcNodes.push_back(combGraph.getOrAddNode(use.get(), fieldIndex + 1));
-      else if (fieldIndex == dataIndex)
-        dstNode = combGraph.getOrAddNode(use.get(), fieldIndex + 1);
-    }
-
-    // Now, we can create edges.
-    if (dstNode) {
-      for (auto srcNode : srcNodes)
-        srcNode->addChild(dstNode);
-    }
-  }
-  return true;
-}
-
-/// Expression handlers.
-bool CycleDetector::visitExpr(SubfieldOp op) {
-  auto definingOp = op.input().getDefiningOp();
-  if (!definingOp || !isa<MemOp>(definingOp)) {
-    op->emitOpError("input must be a port of a MemOp, please run "
-                    "-firrtl-lower-types first");
-    return false;
-  }
-
-  auto portType = op.input().getType().cast<BundleType>();
-  auto fieldIndex = op.fieldIndex();
-  // If the memory port is not on a combinational path, it was not be inserted
-  // into the graph as a node in the MemOp handler.
-  if (auto memPortNode = combGraph.getNode(op.input(), fieldIndex + 1)) {
-    auto node = combGraph.getOrAddNode(op.result());
-
-    // We use `isFlip` to determine the direction of the edge.
-    if (portType.getElement(fieldIndex).isFlip)
-      memPortNode->addChild(node);
-    else
-      node->addChild(memPortNode);
-  }
-  return true;
-}
-
-/// Handle other operations that don't have concrete visitors.
-bool CycleDetector::visitUnhandledOp(Operation *op) {
-  // Create an edge between each exist input node and each output node.
-  SmallVector<CombNode, 4> dstNodes;
-  for (auto result : op->getResults())
-    dstNodes.push_back(combGraph.getOrAddNode(result));
-
-  for (auto operand : op->getOperands()) {
-    if (auto srcNode = combGraph.getNode(operand)) {
-      for (auto dstNode : dstNodes)
-        srcNode->addChild(dstNode);
-    }
-  }
-  return true;
-}
-
-/// Build combinational graph of the module with the visitor dispatcher.
-void CycleDetector::buildCombGraph() {
-  // Each module port should be a node in the graph.
-  for (auto arg : module.getArguments())
-    combGraph.getOrAddNode(arg);
-
-  // Traverse all operations in the module and create combinational nodes and
-  // edges.
-  module.walk([&](Operation *op) {
-    if (!dispatchVisitor(op))
-      return WalkResult::interrupt();
-    return WalkResult::advance();
-  });
-}
-
-/// Detect combinational cycles in the module. Also detect combinational paths
-/// between IOs of the module and record these paths in the `combPathsMap`.
-void CycleDetector::detect() {
-  buildCombGraph();
-
-  // Add a dummy node in the begining to launch a Tarjan's SCC algorithm.
-  auto dummyNode = combGraph.getOrAddNode(nullptr);
-  for (auto connect : module.getOps<ConnectOp>()) {
-    if (auto node = combGraph.getNode(connect.dest()))
-      dummyNode->addChild(node);
-  }
-
-  // Lauch SCC iteration and report diagnostics.
-  using SCCIterator = llvm::scc_iterator<CombNode>;
-  for (auto SCC = SCCIterator::begin(dummyNode); !SCC.isAtEnd(); ++SCC) {
-    if (SCC.hasCycle()) {
-      auto errorDiag = mlir::emitError(
-          module.getLoc(), "detected combinational cycle in a FIRRTL module");
-      for (auto it = SCC->rbegin(), e = SCC->rend(); it != e; ++it) {
-        auto node = *it;
-        auto nodeVal = node->getValOrOp().dyn_cast<Value>();
-        auto nodeOp = node->getValOrOp().dyn_cast<Operation *>();
-
-        auto &noteDiag =
-            errorDiag.attachNote(nodeVal ? nodeVal.getLoc() : nodeOp->getLoc());
-        noteDiag << "this operation is part of the combinational cycle";
-
-        // Indicate field ID if it is not zero.
-        if (auto fieldID = node->getFieldID())
-          noteDiag << ", field ID is " << fieldID;
-
-        // Indicate result number if the definining op has multiple results.
-        if (nodeVal) {
-          auto definingOp = nodeVal.getDefiningOp();
-          if (definingOp && definingOp->getNumResults() > 1) {
-            auto resultNumber = nodeVal.dyn_cast<OpResult>().getResultNumber();
-            noteDiag << ", result number is " << resultNumber;
-          }
-        }
-      }
-    }
-  }
-  dummyNode->clearChilds();
-
-  // Collect all inputs of the module and a port direction list.
-  SmallVector<BlockArgument, 4> inputs;
-  SmallVector<bool, 8> directionList;
-  unsigned index = 0;
-  for (auto &port : module.getPorts()) {
-    directionList.push_back(port.isOutput());
-    if (!port.isOutput())
-      inputs.push_back(module.getPortArgument(index));
-    ++index;
-  }
-
-  // Launch a DFS for each input port to find the output ports that are
-  // combinationally connected to it.
-  auto &combPaths = combPathsMap[module];
-  for (auto input : inputs) {
-    for (auto node : llvm::depth_first<CombNode>(combGraph.getNode(input))) {
-      if (auto val = node->getValOrOp().dyn_cast<Value>())
-        if (auto output = val.dyn_cast<BlockArgument>())
-          if (directionList[output.getArgNumber()])
-            combPaths.push_back({input.getArgNumber(), output.getArgNumber()});
-    }
-  }
-}
-
-//===----------------------------------------------------------------------===//
-// Hashing CombNode
-//===----------------------------------------------------------------------===//
-
-namespace llvm {
-template <>
-struct DenseMapInfo<CombNode> {
-  static CombNode getEmptyKey() {
-    auto pointer = llvm::DenseMapInfo<void *>::getEmptyKey();
-    return static_cast<CombNode>(pointer);
-  }
-  static CombNode getTombstoneKey() {
-    auto pointer = llvm::DenseMapInfo<void *>::getTombstoneKey();
-    return static_cast<CombNode>(pointer);
-  }
-
-  static unsigned getHashValue(const CombNodeImpl *node) {
-    return node->hash_value();
-  }
-  static bool isEqual(const CombNodeImpl *lhs, const CombNodeImpl *rhs) {
-    auto empty = getEmptyKey();
-    auto tombstone = getTombstoneKey();
-    if (lhs == empty || lhs == tombstone || rhs == empty || rhs == tombstone)
-      return lhs == rhs;
-    return *lhs == *rhs;
-  }
-
-  // Allow lookup via find_as(), without constructing a temporary CombNodeImpl.
-  static unsigned getHashValue(const CombNodeKeyType key) {
-    return llvm::hash_combine(key.first.getOpaqueValue(), key.second);
-  }
-  static bool isEqual(const CombNodeKeyType lhs, const CombNodeImpl *rhs) {
-    auto empty = getEmptyKey();
-    auto tombstone = getTombstoneKey();
-    if (rhs == empty || rhs == tombstone)
-      return false;
-    return lhs.first == rhs->getValOrOp() && lhs.second == rhs->getFieldID();
-  }
-};
-} // namespace llvm
-
 //===----------------------------------------------------------------------===//
 // Node class
 //===----------------------------------------------------------------------===//
 
 using CombPathsType = SmallVector<SmallVector<size_t, 2>>;
-using CombPathsMapType = DenseMap<Operation *, CombPathsType>;
+using CombPathsMap = DenseMap<Operation *, CombPathsType>;
 
 namespace {
 /// The graph context containing pointers of the combinational paths map and the
 /// instance graph.
 struct NodeContext {
-  CombPathsMapType *map;
+  CombPathsMap *map;
   InstanceGraph *graph;
 
-  explicit NodeContext(CombPathsMapType *map, InstanceGraph *graph)
+  explicit NodeContext(CombPathsMap *map, InstanceGraph *graph)
       : map(map), graph(graph) {}
 };
 } // namespace
@@ -563,11 +130,12 @@ public:
                                    Node>::operator++;
   NodeIterator &operator++() { return ++child, *this; }
   Node operator*() { return Node(*child, node.context); }
+
   bool operator==(const NodeIterator &rhs) const { return child == rhs.child; }
   bool operator!=(const NodeIterator &rhs) const { return !(*this == rhs); }
 
   Value getValue() { return node.value; }
-  CombPathsMapType *getCombPathsMap() {
+  CombPathsMap *getCombPathsMap() {
     assert(node.context && "invalid node context");
     return node.context->map;
   }
@@ -844,6 +412,7 @@ class CheckCombCyclesPass : public CheckCombCyclesBase<CheckCombCyclesPass> {
   void runOnOperation() override {
     auto &instanceGraph = getAnalysis<InstanceGraph>();
     NodeContext context(&map, &instanceGraph);
+
     // Traverse modules in a post order to make sure the combinational paths
     // between IOs of a module have been detected and recorded in `combPathsMap`
     // before we handle its parent modules.
@@ -899,8 +468,6 @@ class CheckCombCyclesPass : public CheckCombCyclesBase<CheckCombCyclesPass> {
           }
           combPaths.push_back(outputVec);
         }
-        // CycleDetector(module, combPathsMap, instanceGraph).detect();
-
       } else if (auto extModule = dyn_cast<FExtModuleOp>(node->getModule())) {
         // TODO: Handle FExtModuleOp with `ExtModulePathAnnotation`s.
         auto &combPaths = map[extModule];
@@ -912,8 +479,7 @@ class CheckCombCyclesPass : public CheckCombCyclesBase<CheckCombCyclesPass> {
 
 private:
   /// A global map from FIRRTL modules to their combinational paths between IOs.
-  DenseMap<Operation *, CombPaths> combPathsMap;
-  CombPathsMapType map;
+  CombPathsMap map;
 };
 } // namespace
 

--- a/lib/Dialect/FIRRTL/Transforms/CheckCombCycles.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckCombCycles.cpp
@@ -279,7 +279,7 @@ public:
 //===----------------------------------------------------------------------===//
 
 namespace {
-/// The default node iterator.
+/// A dummy source node iterator on the `dest`s of all connect ops.
 class DummySourceNodeIterator
     : public llvm::iterator_facade_base<DummySourceNodeIterator,
                                         std::forward_iterator_tag, Node> {
@@ -474,7 +474,10 @@ class CheckCombCyclesPass : public CheckCombCyclesBase<CheckCombCyclesPass> {
         NodeContext context(&map, &instanceGraph, module.getOps<ConnectOp>());
         auto dummyNode = Node(nullptr, &context);
 
-        // Traversing SCCs in the combinational graph to detect cycles.
+        // Traversing SCCs in the combinational graph to detect cycles. As
+        // FIRRTL module is an SSA region, all cycles must contain at least one
+        // connect op on its path. Thus we introduce a dummy source node to
+        // iterate on the `dest`s of all connect ops in the module.
         using SCCIterator = llvm::scc_iterator<Node>;
         for (auto SCC = SCCIterator::begin(dummyNode); !SCC.isAtEnd(); ++SCC) {
           if (SCC.hasCycle()) {

--- a/lib/Dialect/FIRRTL/Transforms/CheckCombCycles.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckCombCycles.cpp
@@ -1,0 +1,470 @@
+//===- CheckCombCycles.cpp - FIRRTL check combinational cycles --*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the FIRRTL combintational cycles detection pass.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLVisitors.h"
+#include "circt/Dialect/FIRRTL/InstanceGraph.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "llvm/ADT/DepthFirstIterator.h"
+#include "llvm/ADT/PostOrderIterator.h"
+#include "llvm/ADT/SCCIterator.h"
+
+using namespace circt;
+using namespace firrtl;
+
+namespace {
+class CombNodeImpl;
+}
+
+using CombNode = CombNodeImpl *;
+using ValueOrOpType = PointerUnion<Value, Operation *>;
+
+//===----------------------------------------------------------------------===//
+// CombNodeImpl class
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// This is the implementation of a combinational node.
+class CombNodeImpl {
+public:
+  CombNodeImpl(ValueOrOpType valOrOp, unsigned fieldID = 0)
+      : valOrOp(valOrOp), fieldID(fieldID) {}
+
+  bool operator==(const CombNodeImpl &other) const {
+    return valOrOp == other.valOrOp && fieldID == other.fieldID;
+  }
+
+  CombNode *child_begin() { return children.begin(); }
+  CombNode *child_end() { return children.end(); }
+
+  void addChild(CombNode child) { children.emplace_back(child); }
+  void clearChilds() { children.clear(); }
+
+  ValueOrOpType getValOrOp() const { return valOrOp; }
+  unsigned getFieldID() const { return fieldID; }
+
+  llvm::hash_code hash_value() const {
+    return llvm::hash_combine(valOrOp.getOpaqueValue(), fieldID);
+  }
+
+private:
+  /// The underneath value or operation of this node.
+  ValueOrOpType valOrOp;
+
+  /// The field ID this node is referencing to.
+  unsigned fieldID;
+
+  /// Store all children of this node in the graph.
+  SmallVector<CombNode, 4> children;
+};
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// CombGraph class
+//===----------------------------------------------------------------------===//
+
+namespace {
+// This is a combinational graph contains a set of nodes.
+class CombGraph {
+public:
+  /// Get a node from the graph if it exists. Otherwise, allocate a new node and
+  /// add to the graph.
+  CombNode getOrAddNode(ValueOrOpType valOrOp, unsigned fieldID = 0) {
+    auto node = CombNodeImpl(valOrOp, fieldID);
+    auto it = nodes.find(&node);
+    if (it != nodes.end())
+      return *it;
+    auto newNode = new (allocator) CombNodeImpl(std::move(node));
+    nodes.insert(newNode);
+    return newNode;
+  }
+
+  /// Get a node from the graph if it exists.
+  CombNode getNode(ValueOrOpType valOrOp, unsigned fieldID = 0) {
+    auto node = CombNodeImpl(valOrOp, fieldID);
+    auto it = nodes.find(&node);
+    if (it != nodes.end())
+      return *it;
+    return nullptr;
+  }
+
+private:
+  /// For allocating memories for combinational nodes.
+  llvm::BumpPtrAllocator allocator;
+
+  /// A set of combinational nodes.
+  DenseSet<CombNode> nodes;
+};
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// GraphTraits on CombNode
+//===----------------------------------------------------------------------===//
+
+namespace llvm {
+template <>
+struct GraphTraits<CombNode> {
+  using NodeRef = CombNode;
+  using ChildIteratorType = NodeRef *;
+
+  static NodeRef getEntryNode(NodeRef node) { return node; }
+
+  static inline ChildIteratorType child_begin(NodeRef node) {
+    return node->child_begin();
+  }
+  static inline ChildIteratorType child_end(NodeRef node) {
+    return node->child_end();
+  }
+};
+} // namespace llvm
+
+//===----------------------------------------------------------------------===//
+// Detector class
+//===----------------------------------------------------------------------===//
+
+using CombPaths = SmallDenseMap<int64_t, SmallVector<int64_t>>;
+
+namespace {
+class Detector : public FIRRTLVisitor<Detector, bool> {
+public:
+  Detector(FModuleOp module, DenseMap<Operation *, CombPaths> &combPathsMap,
+           InstanceGraph &instanceGraph)
+      : module(module), combPathsMap(combPathsMap),
+        instanceGraph(instanceGraph) {}
+
+  /// Each operation visitor is supposed to finish the following tasks:
+  ///   1. Create a node for each of its results if the result is not a
+  ///   sequential value, such as register and memory write port;
+  ///   2. Create edges between its arguments and results if applicable.
+  using FIRRTLVisitor<Detector, bool>::visitStmt;
+  using FIRRTLVisitor<Detector, bool>::visitDecl;
+  using FIRRTLVisitor<Detector, bool>::visitExpr;
+
+  /// Statement handlers.
+  template <typename ConnectOpType>
+  bool handleConnectOp(ConnectOpType op);
+  bool visitStmt(ConnectOp op) { return handleConnectOp(op); }
+  bool visitStmt(PartialConnectOp op) { return handleConnectOp(op); }
+  bool visitStmt(WhenOp op) {
+    op->emitOpError("unsupported, please run -firrtl-expand-whens first");
+    return false;
+  }
+
+  /// Declaration handlers.
+  bool visitDecl(InstanceOp op);
+  bool visitDecl(MemOp op);
+  bool visitDecl(RegOp op) { return true; }
+  bool visitDecl(RegResetOp op) { return true; }
+
+  /// Expression handlers.
+  bool visitExpr(SubfieldOp op);
+  bool visitExpr(SubindexOp op) {
+    op->emitOpError("unsupported, please run -firrtl-lower-types first");
+    return false;
+  };
+  bool visitExpr(SubaccessOp op) {
+    op->emitOpError("unsupported, please run -firrtl-lower-types first");
+    return false;
+  };
+
+  /// Handle other operations that don't have concrete visitors.
+  bool visitUnhandledOp(Operation *op);
+
+  /// Build combinational graph of the module with the visitor dispatcher.
+  void buildCombGraph();
+
+  /// Detect combinational cycles in the module. Also detect combinational paths
+  /// between IOs of the module and record these paths in the `combPathsMap`.
+  void detect();
+
+private:
+  /// The module detected on.
+  FModuleOp module;
+
+  /// The global combinational paths map.
+  DenseMap<Operation *, CombPaths> &combPathsMap;
+
+  /// The global instance graph.
+  InstanceGraph &instanceGraph;
+
+  /// The local combinational graph.
+  CombGraph combGraph;
+};
+} // namespace
+
+template <typename ConnectOpType>
+bool Detector::handleConnectOp(ConnectOpType op) {
+  // Create an edge between the `source` value and `destination` value if both
+  // exist in the graph.
+  auto srcNode = combGraph.getNode(op.src());
+  auto dstNode = combGraph.getNode(op.dest());
+  if (srcNode && dstNode) {
+    auto connectNode = combGraph.getOrAddNode(op.getOperation());
+    srcNode->addChild(connectNode);
+    connectNode->addChild(dstNode);
+  }
+  return true;
+}
+
+/// Declaration handlers.
+bool Detector::visitDecl(InstanceOp op) {
+  SmallVector<CombNode, 8> nodes;
+  for (auto result : op.getResults())
+    nodes.push_back(combGraph.getOrAddNode(result));
+
+  // Query the combinational paths between IOs and create edges.
+  for (auto combPath :
+       combPathsMap.lookup(instanceGraph.getReferencedModule(op))) {
+    auto srcNode = nodes[combPath.first];
+    for (auto i : combPath.second)
+      srcNode->addChild(nodes[i]);
+  }
+  return true;
+}
+
+bool Detector::visitDecl(MemOp op) {
+  // Combinational paths only exist when reading latency is zero.
+  if (op.readLatency() != 0)
+    return true;
+
+  // Traverse every ports of the memory.
+  for (unsigned i = 0, e = op.getNumResults(); i < e; ++i) {
+    // Combinational paths only exist in `read` or `readwrite` ports.
+    auto portKind = op.getPortKind(i);
+    if (portKind == MemOp::PortKind::Write)
+      continue;
+
+    auto portType = op.getPortType(i).cast<BundleType>();
+
+    auto enIndex = portType.getElementIndex("en");
+    auto addrIndex = portType.getElementIndex("addr");
+    auto dataIndex = portKind == MemOp::PortKind::ReadWrite
+                         ? portType.getElementIndex("rdata")
+                         : portType.getElementIndex("data");
+
+    // Travers all subfields of the memory port. Combinational paths can only
+    // start from `en` or `addr`, and propagate to `rdata` (for `readwrite`
+    // port) or `data` (for `read` port).
+    SmallVector<CombNode, 2> srcNodes;
+    CombNode dstNode = nullptr;
+    for (auto &use : op.getResult(i).getUses()) {
+      auto subField = dyn_cast<SubfieldOp>(use.getOwner());
+      if (!subField) {
+        use.getOwner()->emitOpError(
+            "should only be used by SubFieldOp, please run "
+            "-firrtl-lower-types first");
+        return false;
+      }
+
+      // Record source nodes and destination node of combinational paths.
+      auto fieldIndex = subField.fieldIndex();
+      if (fieldIndex == enIndex || fieldIndex == addrIndex)
+        srcNodes.push_back(combGraph.getOrAddNode(use.get(), fieldIndex + 1));
+      else if (fieldIndex == dataIndex)
+        dstNode = combGraph.getOrAddNode(use.get(), fieldIndex + 1);
+    }
+
+    // Now, we can create edges.
+    if (dstNode) {
+      for (auto srcNode : srcNodes)
+        srcNode->addChild(dstNode);
+    }
+  }
+  return true;
+}
+
+/// Expression handlers.
+bool Detector::visitExpr(SubfieldOp op) {
+  auto definingOp = op.input().getDefiningOp();
+  if (!definingOp || !isa<MemOp>(definingOp)) {
+    op->emitOpError("input must be a port of a MemOp, please run "
+                    "-firrtl-lower-types first");
+    return false;
+  }
+
+  auto portType = op.input().getType().cast<BundleType>();
+  auto fieldIndex = op.fieldIndex();
+  // If the memory port is not on a combinational path, it was not be inserted
+  // into the graph as a node in the MemOp handler.
+  if (auto memPortNode = combGraph.getNode(op.input(), fieldIndex + 1)) {
+    auto node = combGraph.getOrAddNode(op.result());
+    // We use `isFlip` to determine the direction of the edge.
+    if (portType.getElement(fieldIndex).isFlip)
+      memPortNode->addChild(node);
+    else
+      node->addChild(memPortNode);
+  }
+  return true;
+}
+
+/// Handle other operations that don't have concrete visitors.
+bool Detector::visitUnhandledOp(Operation *op) {
+  // Create an edge between each exist input node and each output node.
+  SmallVector<CombNode, 4> dstNodes;
+  for (auto result : op->getResults())
+    dstNodes.push_back(combGraph.getOrAddNode(result));
+
+  for (auto operand : op->getOperands()) {
+    if (auto srcNode = combGraph.getNode(operand)) {
+      for (auto dstNode : dstNodes)
+        srcNode->addChild(dstNode);
+    }
+  }
+  return true;
+}
+
+/// Build combinational graph of the module with the visitor dispatcher.
+void Detector::buildCombGraph() {
+  // Each module port should be a node in the graph.
+  for (auto arg : module.getArguments())
+    combGraph.getOrAddNode(arg);
+
+  // Traverse all operations in the module and create combinational nodes and
+  // edges.
+  module.walk([&](Operation *op) {
+    if (!dispatchVisitor(op))
+      return WalkResult::interrupt();
+    return WalkResult::advance();
+  });
+}
+
+/// Detect combinational cycles in the module. Also detect combinational paths
+/// between IOs of the module and record these paths in the `combPathsMap`.
+void Detector::detect() {
+  buildCombGraph();
+
+  // Add a dummy node in the begining to launch a Tarjan's SCC algorithm.
+  auto dummyNode = combGraph.getOrAddNode(nullptr);
+  for (auto connect : module.getOps<ConnectOp>()) {
+    if (auto node = combGraph.getNode(connect.dest()))
+      dummyNode->addChild(node);
+  }
+
+  // Lauch SCC iteration and report diagnostics.
+  using SCCIterator = llvm::scc_iterator<CombNode>;
+  for (auto SCC = SCCIterator::begin(dummyNode); !SCC.isAtEnd(); ++SCC) {
+    if (SCC.hasCycle()) {
+      auto errorDiag = mlir::emitError(
+          module.getLoc(), "detected combinational SCC in the module");
+      for (auto it = SCC->rbegin(); it < SCC->rend(); ++it) {
+        auto node = *it;
+        auto nodeVal = node->getValOrOp().dyn_cast<Value>();
+        auto nodeOp = node->getValOrOp().dyn_cast<Operation *>();
+
+        auto &noteDiag =
+            errorDiag.attachNote(nodeVal ? nodeVal.getLoc() : nodeOp->getLoc());
+
+        noteDiag << "see node in the combinational SCC";
+        // Indicate field ID if it is not zero.
+        if (auto fieldID = node->getFieldID())
+          noteDiag << ", field ID is " << fieldID;
+        // Indicate result number if the definining op has multiple results.
+        if (nodeVal) {
+          auto definingOp = nodeVal.getDefiningOp();
+          if (definingOp && definingOp->getNumResults() > 1) {
+            auto resultNumber = nodeVal.dyn_cast<OpResult>().getResultNumber();
+            noteDiag << ", result number is " << resultNumber;
+          }
+        }
+      }
+    }
+  }
+  dummyNode->clearChilds();
+
+  // Collect all inputs of the module and a port direction list.
+  SmallVector<BlockArgument, 4> inputs;
+  SmallVector<bool, 8> directionList;
+  unsigned index = 0;
+  for (auto port : module.getPorts()) {
+    directionList.push_back(port.isOutput());
+    if (!port.isOutput())
+      inputs.push_back(module.getPortArgument(index));
+    ++index;
+  }
+
+  // Launch a DFS for each input to find outputs that are combinationally
+  // connected to it.
+  for (auto input : inputs) {
+    auto inputIndex = input.getArgNumber();
+    for (auto node : llvm::depth_first<CombNode>(combGraph.getNode(input))) {
+      if (auto nodeVal = node->getValOrOp().dyn_cast<Value>()) {
+        if (auto output = nodeVal.dyn_cast<BlockArgument>()) {
+          auto outputIndex = output.getArgNumber();
+          if (directionList[outputIndex])
+            combPathsMap[module][inputIndex].push_back(outputIndex);
+        }
+      }
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Hashing CombNode
+//===----------------------------------------------------------------------===//
+
+namespace llvm {
+template <>
+struct DenseMapInfo<CombNode> {
+  static CombNode getEmptyKey() {
+    auto pointer = llvm::DenseMapInfo<void *>::getEmptyKey();
+    return static_cast<CombNode>(pointer);
+  }
+  static CombNode getTombstoneKey() {
+    auto pointer = llvm::DenseMapInfo<void *>::getTombstoneKey();
+    return static_cast<CombNode>(pointer);
+  }
+  static unsigned getHashValue(const CombNodeImpl *node) {
+    return node->hash_value();
+  }
+  static bool isEqual(const CombNodeImpl *lhs, const CombNodeImpl *rhs) {
+    auto empty = getEmptyKey();
+    auto tombstone = getTombstoneKey();
+    if (lhs == empty || lhs == tombstone || rhs == empty || rhs == tombstone)
+      return lhs == rhs;
+    return *lhs == *rhs;
+  }
+};
+} // namespace llvm
+
+//===----------------------------------------------------------------------===//
+// Pass Infrastructure
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// This pass constructs a local graph for each module to detect combinational
+/// cycles. To capture the cross-module combinational cycles, this pass inlines
+/// the combinational paths between IOs of its subinstances into a subgraph and
+/// encodes them in a `combPathsMap`.
+class CheckCombCyclesPass : public CheckCombCyclesBase<CheckCombCyclesPass> {
+  void runOnOperation() override {
+    auto &instanceGraph = getAnalysis<InstanceGraph>();
+    // Traverse modules in a post order to make sure the combinational paths
+    // between IOs of a module have been detected and recorded in `combPathsMap`
+    // before we handle its parent modules.
+    for (auto node : llvm::post_order<InstanceGraph *>(&instanceGraph)) {
+      // TODO: Handle FExtModuleOp with annotations.
+      if (auto module = dyn_cast<FModuleOp>(node->getModule()))
+        Detector(module, combPathsMap, instanceGraph).detect();
+    }
+    markAllAnalysesPreserved();
+  }
+
+private:
+  // Global combinational paths map. Used to store the combinational paths
+  // between IOs of modules in the circuit.
+  DenseMap<Operation *, CombPaths> combPathsMap;
+};
+} // namespace
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createCheckCombCyclesPass() {
+  return std::make_unique<CheckCombCyclesPass>();
+}

--- a/test/Dialect/FIRRTL/check-comb-cycles.mlir
+++ b/test/Dialect/FIRRTL/check-comb-cycles.mlir
@@ -25,16 +25,16 @@ module  {
   // Simple combinational loop
   // CHECK: firrtl.circuit "hasloops"
   firrtl.circuit "hasloops"   {
-    // expected-error @+1 {{detected combinational SCC in the module}}
+    // expected-error @+1 {{detected combinational cycle in a FIRRTL module}}
     firrtl.module @hasloops(in %clk: !firrtl.clock, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>, out %d: !firrtl.uint<1>) {
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       %y = firrtl.wire  : !firrtl.uint<1>
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       %z = firrtl.wire  : !firrtl.uint<1>
       firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %z, %y : !firrtl.uint<1>, !firrtl.uint<1>
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %y, %z : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %d, %z : !firrtl.uint<1>, !firrtl.uint<1>
     }
@@ -47,11 +47,11 @@ module  {
   // Single-element combinational loop
   // CHECK: firrtl.circuit "loop"
   firrtl.circuit "loop"   {
-    // expected-error @+1 {{detected combinational SCC in the module}}
+    // expected-error @+1 {{detected combinational cycle in a FIRRTL module}}
     firrtl.module @loop(out %y: !firrtl.uint<8>) {
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       %w = firrtl.wire  : !firrtl.uint<8>
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %w, %w : !firrtl.uint<8>, !firrtl.uint<8>
       firrtl.connect %y, %w : !firrtl.uint<8>, !firrtl.uint<8>
     }
@@ -64,16 +64,16 @@ module  {
   // Node combinational loop
   // CHECK: firrtl.circuit "hasloops"
   firrtl.circuit "hasloops"   {
-    // expected-error @+1 {{detected combinational SCC in the module}}
+    // expected-error @+1 {{detected combinational cycle in a FIRRTL module}}
     firrtl.module @hasloops(in %clk: !firrtl.clock, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>, out %d: !firrtl.uint<1>) {
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       %y = firrtl.wire  : !firrtl.uint<1>
       firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       %0 = firrtl.and %c, %y : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       %z = firrtl.node %0  : !firrtl.uint<1>
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %y, %z : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %d, %z : !firrtl.uint<1>, !firrtl.uint<1>
     }
@@ -86,30 +86,30 @@ module  {
   // Combinational loop through a combinational memory read port
   // CHECK: firrtl.circuit "hasloops"
   firrtl.circuit "hasloops"   {
-    // expected-error @+1 {{detected combinational SCC in the module}}
+    // expected-error @+1 {{detected combinational cycle in a FIRRTL module}}
     firrtl.module @hasloops(in %clk: !firrtl.clock, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>, out %d: !firrtl.uint<1>) {
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       %y = firrtl.wire  : !firrtl.uint<1>
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       %z = firrtl.wire  : !firrtl.uint<1>
       firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
-      // expected-note @+2 {{see node in the combinational SCC, field ID is 1}}
-      // expected-note @+1 {{see node in the combinational SCC, field ID is 4}}
+      // expected-note @+2 {{this operation is part of the combinational cycle, field ID is 1}}
+      // expected-note @+1 {{this operation is part of the combinational cycle, field ID is 4}}
       %m_r = firrtl.mem Undefined  {depth = 2 : i64, name = "m", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
       %0 = firrtl.subfield %m_r(2) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.clock
       firrtl.connect %0, %clk : !firrtl.clock, !firrtl.clock
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       %1 = firrtl.subfield %m_r(0) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.uint<1>
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %1, %y : !firrtl.uint<1>, !firrtl.uint<1>
       %2 = firrtl.subfield %m_r(1) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.uint<1>
       %c1_ui = firrtl.constant 1 : !firrtl.uint
       firrtl.connect %2, %c1_ui : !firrtl.uint<1>, !firrtl.uint
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       %3 = firrtl.subfield %m_r(3) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.uint<1>
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %z, %3 : !firrtl.uint<1>, !firrtl.uint<1>
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %y, %z : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %d, %z : !firrtl.uint<1>, !firrtl.uint<1>
     }
@@ -125,21 +125,21 @@ module  {
     firrtl.module @thru(in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
       firrtl.connect %out, %in : !firrtl.uint<1>, !firrtl.uint<1>
     }
-    // expected-error @+1 {{detected combinational SCC in the module}}
+    // expected-error @+1 {{detected combinational cycle in a FIRRTL module}}
     firrtl.module @hasloops(in %clk: !firrtl.clock, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>, out %d: !firrtl.uint<1>) {
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       %y = firrtl.wire  : !firrtl.uint<1>
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       %z = firrtl.wire  : !firrtl.uint<1>
       firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
-      // expected-note @+2 {{see node in the combinational SCC, result number is 0}}
-      // expected-note @+1 {{see node in the combinational SCC, result number is 1}}
+      // expected-note @+2 {{this operation is part of the combinational cycle, result number is 0}}
+      // expected-note @+1 {{this operation is part of the combinational cycle, result number is 1}}
       %inner_in, %inner_out = firrtl.instance @thru  {name = "inner"} : !firrtl.uint<1>, !firrtl.uint<1>
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %inner_in, %y : !firrtl.uint<1>, !firrtl.uint<1>
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %z, %inner_out : !firrtl.uint<1>, !firrtl.uint<1>
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %y, %z : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %d, %z : !firrtl.uint<1>, !firrtl.uint<1>
     }
@@ -152,33 +152,33 @@ module  {
   // Multiple simple loops in one SCC
   // CHECK: firrtl.circuit "hasloops"
   firrtl.circuit "hasloops"   {
-    // expected-error @+1 {{detected combinational SCC in the module}}
+    // expected-error @+1 {{detected combinational cycle in a FIRRTL module}}
     firrtl.module @hasloops(in %i: !firrtl.uint<1>, out %o: !firrtl.uint<1>) {
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       %a = firrtl.wire  : !firrtl.uint<1>
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       %b = firrtl.wire  : !firrtl.uint<1>
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       %c = firrtl.wire  : !firrtl.uint<1>
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       %d = firrtl.wire  : !firrtl.uint<1>
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       %e = firrtl.wire  : !firrtl.uint<1>
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       %0 = firrtl.and %c, %i : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %a, %0 : !firrtl.uint<1>, !firrtl.uint<1>
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       %1 = firrtl.and %a, %d : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %b, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       %2 = firrtl.and %c, %e : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %d, %2 : !firrtl.uint<1>, !firrtl.uint<1>
-      // expected-note @+1 {{see node in the combinational SCC}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %e, %b : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %o, %e : !firrtl.uint<1>, !firrtl.uint<1>
     }

--- a/test/Dialect/FIRRTL/check-comb-cycles.mlir
+++ b/test/Dialect/FIRRTL/check-comb-cycles.mlir
@@ -32,9 +32,7 @@ module  {
       // expected-note @+1 {{this operation is part of the combinational cycle}}
       %z = firrtl.wire  : !firrtl.uint<1>
       firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %z, %y : !firrtl.uint<1>, !firrtl.uint<1>
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %y, %z : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %d, %z : !firrtl.uint<1>, !firrtl.uint<1>
     }
@@ -51,7 +49,6 @@ module  {
     firrtl.module @loop(out %y: !firrtl.uint<8>) {
       // expected-note @+1 {{this operation is part of the combinational cycle}}
       %w = firrtl.wire  : !firrtl.uint<8>
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %w, %w : !firrtl.uint<8>, !firrtl.uint<8>
       firrtl.connect %y, %w : !firrtl.uint<8>, !firrtl.uint<8>
     }
@@ -73,7 +70,6 @@ module  {
       %0 = firrtl.and %c, %y : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
       // expected-note @+1 {{this operation is part of the combinational cycle}}
       %z = firrtl.node %0  : !firrtl.uint<1>
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %y, %z : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %d, %z : !firrtl.uint<1>, !firrtl.uint<1>
     }
@@ -93,23 +89,17 @@ module  {
       // expected-note @+1 {{this operation is part of the combinational cycle}}
       %z = firrtl.wire  : !firrtl.uint<1>
       firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
-      // expected-note @+2 {{this operation is part of the combinational cycle, field ID is 1}}
-      // expected-note @+1 {{this operation is part of the combinational cycle, field ID is 4}}
       %m_r = firrtl.mem Undefined  {depth = 2 : i64, name = "m", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
       %0 = firrtl.subfield %m_r(2) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.clock
       firrtl.connect %0, %clk : !firrtl.clock, !firrtl.clock
       // expected-note @+1 {{this operation is part of the combinational cycle}}
       %1 = firrtl.subfield %m_r(0) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.uint<1>
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %1, %y : !firrtl.uint<1>, !firrtl.uint<1>
       %2 = firrtl.subfield %m_r(1) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.uint<1>
       %c1_ui = firrtl.constant 1 : !firrtl.uint
       firrtl.connect %2, %c1_ui : !firrtl.uint<1>, !firrtl.uint
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
       %3 = firrtl.subfield %m_r(3) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.uint<1>
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %z, %3 : !firrtl.uint<1>, !firrtl.uint<1>
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %y, %z : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %d, %z : !firrtl.uint<1>, !firrtl.uint<1>
     }
@@ -132,14 +122,10 @@ module  {
       // expected-note @+1 {{this operation is part of the combinational cycle}}
       %z = firrtl.wire  : !firrtl.uint<1>
       firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
-      // expected-note @+2 {{this operation is part of the combinational cycle, result number is 0}}
-      // expected-note @+1 {{this operation is part of the combinational cycle, result number is 1}}
+      // expected-note @+1 {{this operation is part of the combinational cycle}}
       %inner_in, %inner_out = firrtl.instance @thru  {name = "inner"} : !firrtl.uint<1>, !firrtl.uint<1>
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %inner_in, %y : !firrtl.uint<1>, !firrtl.uint<1>
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %z, %inner_out : !firrtl.uint<1>, !firrtl.uint<1>
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %y, %z : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %d, %z : !firrtl.uint<1>, !firrtl.uint<1>
     }
@@ -166,19 +152,14 @@ module  {
       %e = firrtl.wire  : !firrtl.uint<1>
       // expected-note @+1 {{this operation is part of the combinational cycle}}
       %0 = firrtl.and %c, %i : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %a, %0 : !firrtl.uint<1>, !firrtl.uint<1>
       // expected-note @+1 {{this operation is part of the combinational cycle}}
       %1 = firrtl.and %a, %d : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %b, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
       // expected-note @+1 {{this operation is part of the combinational cycle}}
       %2 = firrtl.and %c, %e : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %d, %2 : !firrtl.uint<1>, !firrtl.uint<1>
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
       firrtl.connect %e, %b : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %o, %e : !firrtl.uint<1>, !firrtl.uint<1>
     }

--- a/test/Dialect/FIRRTL/check-comb-cycles.mlir
+++ b/test/Dialect/FIRRTL/check-comb-cycles.mlir
@@ -1,0 +1,186 @@
+// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-check-comb-cycles)' --split-input-file --verify-diagnostics %s | FileCheck %s
+
+module  {
+  // Loop-free circuit
+  // CHECK: firrtl.circuit "hasnoloops"
+  firrtl.circuit "hasnoloops"   {
+    firrtl.module @thru(in %in1: !firrtl.uint<1>, in %in2: !firrtl.uint<1>, out %out1: !firrtl.uint<1>, out %out2: !firrtl.uint<1>) {
+      firrtl.connect %out1, %in1 : !firrtl.uint<1>, !firrtl.uint<1>
+      firrtl.connect %out2, %in2 : !firrtl.uint<1>, !firrtl.uint<1>
+    }
+    firrtl.module @hasnoloops(in %clk: !firrtl.clock, in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
+      %x = firrtl.wire  : !firrtl.uint<1>
+      %inner_in1, %inner_in2, %inner_out1, %inner_out2 = firrtl.instance @thru  {name = "inner"} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+      firrtl.connect %inner_in1, %a : !firrtl.uint<1>, !firrtl.uint<1>
+      firrtl.connect %x, %inner_out1 : !firrtl.uint<1>, !firrtl.uint<1>
+      firrtl.connect %inner_in2, %x : !firrtl.uint<1>, !firrtl.uint<1>
+      firrtl.connect %b, %inner_out2 : !firrtl.uint<1>, !firrtl.uint<1>
+    }
+  }
+}
+
+// -----
+
+module  {
+  // Simple combinational loop
+  // CHECK: firrtl.circuit "hasloops"
+  firrtl.circuit "hasloops"   {
+    // expected-error @+1 {{detected combinational SCC in the module}}
+    firrtl.module @hasloops(in %clk: !firrtl.clock, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>, out %d: !firrtl.uint<1>) {
+      // expected-note @+1 {{see node in the combinational SCC}}
+      %y = firrtl.wire  : !firrtl.uint<1>
+      // expected-note @+1 {{see node in the combinational SCC}}
+      %z = firrtl.wire  : !firrtl.uint<1>
+      firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
+      // expected-note @+1 {{see node in the combinational SCC}}
+      firrtl.connect %z, %y : !firrtl.uint<1>, !firrtl.uint<1>
+      // expected-note @+1 {{see node in the combinational SCC}}
+      firrtl.connect %y, %z : !firrtl.uint<1>, !firrtl.uint<1>
+      firrtl.connect %d, %z : !firrtl.uint<1>, !firrtl.uint<1>
+    }
+  }
+}
+
+// -----
+
+module  {
+  // Single-element combinational loop
+  // CHECK: firrtl.circuit "loop"
+  firrtl.circuit "loop"   {
+    // expected-error @+1 {{detected combinational SCC in the module}}
+    firrtl.module @loop(out %y: !firrtl.uint<8>) {
+      // expected-note @+1 {{see node in the combinational SCC}}
+      %w = firrtl.wire  : !firrtl.uint<8>
+      // expected-note @+1 {{see node in the combinational SCC}}
+      firrtl.connect %w, %w : !firrtl.uint<8>, !firrtl.uint<8>
+      firrtl.connect %y, %w : !firrtl.uint<8>, !firrtl.uint<8>
+    }
+  }
+}
+
+// -----
+
+module  {
+  // Node combinational loop
+  // CHECK: firrtl.circuit "hasloops"
+  firrtl.circuit "hasloops"   {
+    // expected-error @+1 {{detected combinational SCC in the module}}
+    firrtl.module @hasloops(in %clk: !firrtl.clock, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>, out %d: !firrtl.uint<1>) {
+      // expected-note @+1 {{see node in the combinational SCC}}
+      %y = firrtl.wire  : !firrtl.uint<1>
+      firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
+      // expected-note @+1 {{see node in the combinational SCC}}
+      %0 = firrtl.and %c, %y : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+      // expected-note @+1 {{see node in the combinational SCC}}
+      %z = firrtl.node %0  : !firrtl.uint<1>
+      // expected-note @+1 {{see node in the combinational SCC}}
+      firrtl.connect %y, %z : !firrtl.uint<1>, !firrtl.uint<1>
+      firrtl.connect %d, %z : !firrtl.uint<1>, !firrtl.uint<1>
+    }
+  }
+}
+
+// -----
+
+module  {
+  // Combinational loop through a combinational memory read port
+  // CHECK: firrtl.circuit "hasloops"
+  firrtl.circuit "hasloops"   {
+    // expected-error @+1 {{detected combinational SCC in the module}}
+    firrtl.module @hasloops(in %clk: !firrtl.clock, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>, out %d: !firrtl.uint<1>) {
+      // expected-note @+1 {{see node in the combinational SCC}}
+      %y = firrtl.wire  : !firrtl.uint<1>
+      // expected-note @+1 {{see node in the combinational SCC}}
+      %z = firrtl.wire  : !firrtl.uint<1>
+      firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
+      // expected-note @+2 {{see node in the combinational SCC, field ID is 1}}
+      // expected-note @+1 {{see node in the combinational SCC, field ID is 4}}
+      %m_r = firrtl.mem Undefined  {depth = 2 : i64, name = "m", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
+      %0 = firrtl.subfield %m_r(2) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.clock
+      firrtl.connect %0, %clk : !firrtl.clock, !firrtl.clock
+      // expected-note @+1 {{see node in the combinational SCC}}
+      %1 = firrtl.subfield %m_r(0) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.uint<1>
+      // expected-note @+1 {{see node in the combinational SCC}}
+      firrtl.connect %1, %y : !firrtl.uint<1>, !firrtl.uint<1>
+      %2 = firrtl.subfield %m_r(1) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.uint<1>
+      %c1_ui = firrtl.constant 1 : !firrtl.uint
+      firrtl.connect %2, %c1_ui : !firrtl.uint<1>, !firrtl.uint
+      // expected-note @+1 {{see node in the combinational SCC}}
+      %3 = firrtl.subfield %m_r(3) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.uint<1>
+      // expected-note @+1 {{see node in the combinational SCC}}
+      firrtl.connect %z, %3 : !firrtl.uint<1>, !firrtl.uint<1>
+      // expected-note @+1 {{see node in the combinational SCC}}
+      firrtl.connect %y, %z : !firrtl.uint<1>, !firrtl.uint<1>
+      firrtl.connect %d, %z : !firrtl.uint<1>, !firrtl.uint<1>
+    }
+  }
+}
+
+// -----
+
+module  {
+  // Combination loop through an instance
+  // CHECK: firrtl.circuit "hasloops"
+  firrtl.circuit "hasloops"   {
+    firrtl.module @thru(in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
+      firrtl.connect %out, %in : !firrtl.uint<1>, !firrtl.uint<1>
+    }
+    // expected-error @+1 {{detected combinational SCC in the module}}
+    firrtl.module @hasloops(in %clk: !firrtl.clock, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>, out %d: !firrtl.uint<1>) {
+      // expected-note @+1 {{see node in the combinational SCC}}
+      %y = firrtl.wire  : !firrtl.uint<1>
+      // expected-note @+1 {{see node in the combinational SCC}}
+      %z = firrtl.wire  : !firrtl.uint<1>
+      firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
+      // expected-note @+2 {{see node in the combinational SCC, result number is 0}}
+      // expected-note @+1 {{see node in the combinational SCC, result number is 1}}
+      %inner_in, %inner_out = firrtl.instance @thru  {name = "inner"} : !firrtl.uint<1>, !firrtl.uint<1>
+      // expected-note @+1 {{see node in the combinational SCC}}
+      firrtl.connect %inner_in, %y : !firrtl.uint<1>, !firrtl.uint<1>
+      // expected-note @+1 {{see node in the combinational SCC}}
+      firrtl.connect %z, %inner_out : !firrtl.uint<1>, !firrtl.uint<1>
+      // expected-note @+1 {{see node in the combinational SCC}}
+      firrtl.connect %y, %z : !firrtl.uint<1>, !firrtl.uint<1>
+      firrtl.connect %d, %z : !firrtl.uint<1>, !firrtl.uint<1>
+    }
+  }
+}
+
+// -----
+
+module  {
+  // Multiple simple loops in one SCC
+  // CHECK: firrtl.circuit "hasloops"
+  firrtl.circuit "hasloops"   {
+    // expected-error @+1 {{detected combinational SCC in the module}}
+    firrtl.module @hasloops(in %i: !firrtl.uint<1>, out %o: !firrtl.uint<1>) {
+      // expected-note @+1 {{see node in the combinational SCC}}
+      %a = firrtl.wire  : !firrtl.uint<1>
+      // expected-note @+1 {{see node in the combinational SCC}}
+      %b = firrtl.wire  : !firrtl.uint<1>
+      // expected-note @+1 {{see node in the combinational SCC}}
+      %c = firrtl.wire  : !firrtl.uint<1>
+      // expected-note @+1 {{see node in the combinational SCC}}
+      %d = firrtl.wire  : !firrtl.uint<1>
+      // expected-note @+1 {{see node in the combinational SCC}}
+      %e = firrtl.wire  : !firrtl.uint<1>
+      // expected-note @+1 {{see node in the combinational SCC}}
+      %0 = firrtl.and %c, %i : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+      // expected-note @+1 {{see node in the combinational SCC}}
+      firrtl.connect %a, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+      // expected-note @+1 {{see node in the combinational SCC}}
+      %1 = firrtl.and %a, %d : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+      // expected-note @+1 {{see node in the combinational SCC}}
+      firrtl.connect %b, %1 : !firrtl.uint<1>, !firrtl.uint<1>
+      // expected-note @+1 {{see node in the combinational SCC}}
+      firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
+      // expected-note @+1 {{see node in the combinational SCC}}
+      %2 = firrtl.and %c, %e : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+      // expected-note @+1 {{see node in the combinational SCC}}
+      firrtl.connect %d, %2 : !firrtl.uint<1>, !firrtl.uint<1>
+      // expected-note @+1 {{see node in the combinational SCC}}
+      firrtl.connect %e, %b : !firrtl.uint<1>, !firrtl.uint<1>
+      firrtl.connect %o, %e : !firrtl.uint<1>, !firrtl.uint<1>
+    }
+  }
+}

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -235,6 +235,9 @@ processBuffer(std::unique_ptr<llvm::MemoryBuffer> ownedBuffer,
     }
   }
 
+  if (checkCombCycles)
+    pm.nest<firrtl::CircuitOp>().addPass(firrtl::createCheckCombCyclesPass());
+
   // If we parsed a FIRRTL file and have optimizations enabled, clean it up.
   if (!disableOptimization) {
     auto &modulePM = pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>();
@@ -258,9 +261,6 @@ processBuffer(std::unique_ptr<llvm::MemoryBuffer> ownedBuffer,
       blackBoxRoot, blackBoxRootResourcePath.empty()
                         ? blackBoxRoot
                         : blackBoxRootResourcePath));
-
-  if (checkCombCycles)
-    pm.nest<firrtl::CircuitOp>().addPass(firrtl::createCheckCombCyclesPass());
 
   if (grandCentral) {
     auto &circuitPM = pm.nest<firrtl::CircuitOp>();

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -118,6 +118,11 @@ static cl::opt<bool>
                           "Grand Central annotations"),
                  cl::init(false));
 
+static cl::opt<bool>
+    checkCombCycles("firrtl-check-comb-cycles",
+                    cl::desc("check combinational cycles on firrtl"),
+                    cl::init(false));
+
 enum OutputFormatKind {
   OutputMLIR,
   OutputVerilog,
@@ -253,6 +258,9 @@ processBuffer(std::unique_ptr<llvm::MemoryBuffer> ownedBuffer,
       blackBoxRoot, blackBoxRootResourcePath.empty()
                         ? blackBoxRoot
                         : blackBoxRootResourcePath));
+
+  if (checkCombCycles)
+    pm.nest<firrtl::CircuitOp>().addPass(firrtl::createCheckCombCyclesPass());
 
   if (grandCentral) {
     auto &circuitPM = pm.nest<firrtl::CircuitOp>();


### PR DESCRIPTION
This pass runs a DFS traversing to detect the combinational loops in the IR. As the beginning, the current implementation assumes the aggregated types have been lowered to ground types before this pass.

I tested this with `dot.mlir` and `matmul.mlir` in `integration_test/Dialect/Handshake/`. Combinational loops can be detected on both test cases if `-handshake-insert-buffer` is not applied. Also tested on all cases in [perf](https://github.com/circt/perf), no combinational loop detected :)

Fixes #1138.