### PR TITLE
[PyCDE] Misc usability features

### DIFF
--- a/frontends/PyCDE/src/pycde/module.py
+++ b/frontends/PyCDE/src/pycde/module.py
@@ -97,8 +97,13 @@ class module:
       cls = self.func(*args, **kwargs)
       if cls is None:
         raise ValueError("Parameterization function must return module class")
+
+      # Function arguments which start with '_' don't become parameters.
+      params = {n: v for n, v
+                in param_values.arguments.items()
+                if not n.startswith("_")}
       mod = _module_base(cls, self.extern_name is not None,
-                         param_values.arguments)
+                         params)
 
       if self.extern_name:
         _register_generator(cls.__name__, "extern_instantiate",
@@ -229,6 +234,10 @@ def _module_base(cls, extern: bool, params={}):
                              results=[type for (_, type) in mod._output_ports],
                              operands=input_ports_values,
                              loc=loc))
+
+    def output_values(self):
+      return {op_name: self.operation.results[idx]
+              for (idx, (op_name, _)) in enumerate(mod._output_ports)}
 
     @staticmethod
     def inputs() -> list[(str, mlir.ir.Type)]:

--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -42,8 +42,8 @@ class System:
   def body(self):
     return self.mod.body
 
-  def print(self, **kwargs):
-    self.mod.operation.print(**kwargs)
+  def print(self, *argv, **kwargs):
+    self.mod.operation.print(*argv, **kwargs)
 
   def graph(self, short_names=True):
     import mlir.all_passes_registration

--- a/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
@@ -197,7 +197,7 @@ def _create_output_op(cls_name, output_ports, entry_block, bb_ret):
   # Only acceptable return is a dict of port, value mappings.
   if not isinstance(bb_ret, dict):
     raise support.ConnectionError(
-        "In {cls_name}, can only return a dict of port, value mappings "
+        f"In {cls_name}, can only return a dict of port, value mappings "
         "from body_builder.")
 
   # A dict of `OutputPortName` -> ValueLike must be converted to a list in port


### PR DESCRIPTION
- Hide module parameterization function arguments beginning with '_' from operation parameters.
- Module `.output_values()` returns a dict of output ports to Values.
- `System.print` passes through args.