### PR TITLE
[Scheduling] Separate problems and algorithms.

### DIFF
--- a/include/circt/Scheduling/Algorithms.h
+++ b/include/circt/Scheduling/Algorithms.h
@@ -1,4 +1,4 @@
-//===- ASAPScheduler.h - As-soon-as-possible list scheduler -----*- C++ -*-===//
+//===- Algorithms.h - Library of scheduling algorithms ----------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,14 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file defines an as-soon-as-possible list scheduler for acyclic problems.
+// This file defines a library of scheduling algorithms.
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef CIRCT_SCHEDULING_ASAPSCHEDULER_H
-#define CIRCT_SCHEDULING_ASAPSCHEDULER_H
+#ifndef CIRCT_SCHEDULING_ALGORITHMS_H
+#define CIRCT_SCHEDULING_ALGORITHMS_H
 
-#include "circt/Scheduling/Scheduler.h"
+#include "circt/Scheduling/Problems.h"
 
 namespace circt {
 namespace scheduling {
@@ -21,15 +21,10 @@ namespace scheduling {
 /// This is a simple list scheduler for solving the basic scheduling problem.
 /// Its objective is to assign each operation its earliest possible start time,
 /// or in other words, to schedule each operation as soon as possible (hence the
-/// name).
-///
-/// The dependence graph must not contain cycles.
-struct ASAPScheduler : public virtual Scheduler {
-  using Scheduler::Scheduler;
-  LogicalResult schedule() override;
-};
+/// name). Fails if the dependence graph contains cycles.
+LogicalResult scheduleASAP(Problem &prob);
 
 } // namespace scheduling
 } // namespace circt
 
-#endif // CIRCT_SCHEDULING_ASAPSCHEDULER_H
+#endif // CIRCT_SCHEDULING_ALGORITHMS_H

--- a/include/circt/Scheduling/DependenceIterator.h
+++ b/include/circt/Scheduling/DependenceIterator.h
@@ -24,7 +24,7 @@
 namespace circt {
 namespace scheduling {
 
-class Scheduler;
+class Problem;
 
 namespace detail {
 
@@ -90,7 +90,7 @@ public:
   /// values of other operations registered in the scheduling problem, which are
   /// used by one of \p op's operands), and over auxiliary dependences (i.e.
   /// from other operation to \p op).
-  DependenceIterator(Scheduler &scheduler, Operation *op, bool end = false);
+  DependenceIterator(Problem &problem, Operation *op, bool end = false);
 
   bool operator==(const DependenceIterator &other) const {
     return dep == other.dep;
@@ -106,7 +106,7 @@ public:
 private:
   void findNextDependence();
 
-  Scheduler &scheduler;
+  Problem &problem;
   Operation *op;
 
   unsigned operandIdx;

--- a/include/circt/Scheduling/Problems.h
+++ b/include/circt/Scheduling/Problems.h
@@ -1,4 +1,4 @@
-//===- Scheduler.h - Common interface for scheduling algorithms -*- C++ -*-===//
+//===- Problems.h - Modeling of scheduling problems -------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -9,13 +9,13 @@
 // Static scheduling algorithms for use in HLS flows all solve similar problems.
 // The classes in this file serve as an interface between clients and algorithm
 // implementations, and model a basic scheduling problem and some commonly used
-// extensions (e.g. modulo scheduling). This includes problem-specific utility
-// and verification methods.
+// extensions (e.g. modulo scheduling). This includes problem-specific
+// verification methods.
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef CIRCT_SCHEDULING_SCHEDULER_H
-#define CIRCT_SCHEDULING_SCHEDULER_H
+#ifndef CIRCT_SCHEDULING_PROBLEMS_H
+#define CIRCT_SCHEDULING_PROBLEMS_H
 
 #include "circt/Scheduling/DependenceIterator.h"
 #include "circt/Support/LLVM.h"
@@ -62,9 +62,9 @@ namespace scheduling {
 ///   is started. Together, the start times for all operations represent the
 ///   problem's solution, i.e. the schedule.
 ///
-/// Subclasses, i.e. base classes for more complex scheduling problems as well
-/// as concrete algorithms, can declare additional properties as needed. The
-/// top-level entrypoint for algorithms is the pure virtual `schedule()` method.
+/// Subclasses, i.e. corresponding to more complex scheduling problems, can
+/// declare additional properties as needed. The `clearSolution` method must be
+/// overridden if the new properties are part of the solution.
 //
 /// The `check...` methods perform validity checks before scheduling, e.g. that
 /// all operations have an associated operator type, etc.
@@ -73,11 +73,11 @@ namespace scheduling {
 /// a concrete scheduling algorithm, e.g. that there are start times available
 /// for each registered operation, and the precedence constraints as modeled by
 /// the dependences are satisfied.
-class Scheduler {
+class Problem {
 public:
   /// Initialize a scheduling problem corresponding to \p containingOp.
-  Scheduler(Operation *containingOp) : containingOp(containingOp) {}
-  virtual ~Scheduler() = default;
+  Problem(Operation *containingOp) : containingOp(containingOp) {}
+  virtual ~Problem() = default;
 
   friend detail::DependenceIterator;
 
@@ -95,11 +95,12 @@ public:
   //===--------------------------------------------------------------------===//
   // Aliases for containers storing the problem components and properties
   //===--------------------------------------------------------------------===//
-protected:
+public:
   using OperationSet = llvm::SetVector<Operation *>;
   using DependenceRange = llvm::iterator_range<detail::DependenceIterator>;
   using OperatorTypeSet = llvm::SetVector<OperatorType>;
 
+protected:
   using AuxDependenceMap =
       llvm::DenseMap<Operation *, llvm::SmallSetVector<Operation *, 4>>;
 
@@ -133,7 +134,7 @@ private:
   OperatorTypeProperty<unsigned> latency;
 
   //===--------------------------------------------------------------------===//
-  // Client interface to construct problem
+  // Problem construction
   //===--------------------------------------------------------------------===//
 public:
   /// Include \p op in this scheduling problem.
@@ -152,12 +153,15 @@ public:
   OperatorType getOrInsertOperatorType(StringRef name);
 
   //===--------------------------------------------------------------------===//
-  // Subclass access to problem components
+  // Access to problem components
   //===--------------------------------------------------------------------===//
-protected:
+public:
+  /// Return the operation containing this problem, e.g. to emit diagnostics.
   Operation *getContainingOp() { return containingOp; }
 
+  /// Return true if \p op is part of this problem.
   bool hasOperation(Operation *op) { return operations.contains(op); }
+  /// Return the set of operations.
   const OperationSet &getOperations() { return operations; }
 
   /// Return a range object to transparently iterate over \p op's *incoming*
@@ -172,31 +176,27 @@ protected:
   /// process the ranges for all registered operations.
   DependenceRange getDependences(Operation *op);
 
+  /// Return true if \p opr is part of this problem.
   bool hasOperatorType(OperatorType opr) { return operatorTypes.contains(opr); }
+  /// Return the set of operator types.
   const OperatorTypeSet &getOperatorTypes() { return operatorTypes; }
 
   //===--------------------------------------------------------------------===//
-  // Subclass access to properties: retrieve problem, set solution
+  // Access to properties
   //===--------------------------------------------------------------------===//
-protected:
+public:
+  /// The linked operator type provides the runtime characteristics for \p op.
   Optional<OperatorType> getLinkedOperatorType(Operation *op) {
     return linkedOperatorType.lookup(op);
   }
-
-  Optional<unsigned> getLatency(OperatorType opr) {
-    return latency.lookup(opr);
-  }
-
-  void setStartTime(Operation *op, unsigned val) { startTime[op] = val; }
-
-  //===--------------------------------------------------------------------===//
-  // Client access to properties: specify problem, retrieve solution
-  //===--------------------------------------------------------------------===//
-public:
   void setLinkedOperatorType(Operation *op, OperatorType opr) {
     linkedOperatorType[op] = opr;
   }
 
+  /// The latency is the number of cycles \p opr needs to compute its result.
+  Optional<unsigned> getLatency(OperatorType opr) {
+    return latency.lookup(opr);
+  }
   void setLatency(OperatorType opr, unsigned val) { latency[opr] = val; }
 
   /// Return the start time for \p op, as computed by the scheduler.
@@ -205,6 +205,10 @@ public:
   Optional<unsigned> getStartTime(Operation *op) {
     return startTime.lookup(op);
   }
+  void setStartTime(Operation *op, unsigned val) { startTime[op] = val; }
+
+  /// Clear all properties that are part of the solution.
+  virtual void clearSolution() { startTime.clear(); }
 
   //===--------------------------------------------------------------------===//
   // Hooks to check/verify the different problem components
@@ -225,16 +229,9 @@ public:
   LogicalResult check();
   /// Return success if the computed solution is valid.
   LogicalResult verify();
-
-  //===--------------------------------------------------------------------===//
-  // Entry point to actual algorithm
-  //===--------------------------------------------------------------------===//
-public:
-  // Attempt to schedule the constructed problem.
-  virtual LogicalResult schedule() = 0;
 };
 
 } // namespace scheduling
 } // namespace circt
 
-#endif // CIRCT_SCHEDULING_SCHEDULER_H
+#endif // CIRCT_SCHEDULING_PROBLEMS_H

--- a/lib/Scheduling/CMakeLists.txt
+++ b/lib/Scheduling/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_circt_library(CIRCTScheduling
   ASAPScheduler.cpp
-  Scheduler.cpp
+  Problems.cpp
 
   LINK_LIBS PUBLIC
   MLIRIR


### PR DESCRIPTION
I believe it was a misconception to model problems and algorithms in the same class hierarchy. Analogy: Imagine LLVM's alias analyses would subclass `Function`.

To rectify this, this PR renames the `Scheduler` class to `Problem` (now living in `circt/Scheduling/Problems.h`), and removes the pure virtual `schedule()` method. Algorithms now declare their entry points in `circt/Scheduling/Algorithms.h`, and may hide their implementation classes, or no longer need to be class, see `scheduleASAP(Problem &prob)`.

Further benefits:
- Clients can contain problem construction code without needing to link any concrete algorithm.
- Algorithms can provide multiple entry points to schedule simpler problem variants. For example, an algorithm capable of sharing arbitrary operators can also solve a problem restricted to fully-pipelined operators (i.e. blocking time = 1), instead of requiring the client (who doesn't care about the general problem) to explicitly set a blocking time of 1 for each operator type.
- Utilities (e.g. the cycle detector I'll need to build) won't be tied into the problem hierarchy, either.