### PR TITLE
[FIRRTL] Allow firrtl.constant of type Clock, Reset, AsyncReset

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -82,14 +82,10 @@ def RegresetWithInvalidReset : Pat<
   (RegOp $clock, $name, $annotations),
   []>;
 
-// Constraint that has a constant zero value.
-def ZeroValueAttr : Constraint<CPred<"$0.getAPSInt().getExtValue() == 0">>;
-
 // regreset(clock, constant_zero, resetValue, name, {}) -> reg(clock, name, {})
 def RegresetWithZeroReset : Pat<
-  (RegResetOp $clock, (AsAsyncResetPrimOp (ConstantOp $value)), $resetValue,
+  (RegResetOp $clock, (SpecialConstantOp ConstBoolAttrFalse), $resetValue,
    $name, $annotations),
-  (RegOp $clock, $name, $annotations),
-  [(ZeroValueAttr $value)]>;
+  (RegOp $clock, $name, $annotations)>;
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLCANONICALIZATION_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -109,6 +109,29 @@ def ConstantOp : FIRRTLOp<"constant", [NoSideEffect, ConstantLike,
   let verifier = "return ::verifyConstantOp(*this);";
 }
 
+def SpecialConstantOp : FIRRTLOp<"specialconstant", [NoSideEffect,
+                                                     ConstantLike]> {
+  let summary = "Produce a constant Reset or Clock value";
+  let description = [{
+    The constant operation produces a constant value of Reset, AsyncReset, or
+    Clock type. The value can only be 0 or 1.
+    ```
+      %result = firrtl.specialconstant 1 : !firrtl.clock
+    ```
+    }];
+
+  let arguments = (ins BoolAttr:$value);
+  let results = (outs
+    AnyTypeOf<[ClockType, ResetType, AsyncResetType]>:$result);
+
+  // Need a custom parser/printer to avoid redundant type for the attribute and
+  // the op itself.
+  let parser = "return parse$cppClass(parser, result);";
+  let printer = "print$cppClass(p, *this);";
+  let hasFolder = 1;
+  let verifier = "return ::verifySpecialConstantOp(*this);";
+}
+
 def InvalidValueOp : FIRRTLOp<"invalidvalue", [NoSideEffect, ConstantLike]> {
   let summary = "InvalidValue primitive";
   let description = [{

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -129,7 +129,6 @@ def SpecialConstantOp : FIRRTLOp<"specialconstant", [NoSideEffect,
   let parser = "return parse$cppClass(parser, result);";
   let printer = "print$cppClass(p, *this);";
   let hasFolder = 1;
-  let verifier = "return ::verifySpecialConstantOp(*this);";
 }
 
 def InvalidValueOp : FIRRTLOp<"invalidvalue", [NoSideEffect, ConstantLike]> {

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -29,7 +29,8 @@ public:
     return TypeSwitch<Operation *, ResultType>(op)
         // Basic Expressions
         .template Case<
-            ConstantOp, InvalidValueOp, SubfieldOp, SubindexOp, SubaccessOp,
+            ConstantOp, SpecialConstantOp, InvalidValueOp, SubfieldOp,
+            SubindexOp, SubaccessOp,
             // Arithmetic and Logical Binary Primitives.
             AddPrimOp, SubPrimOp, MulPrimOp, DivPrimOp, RemPrimOp, AndPrimOp,
             OrPrimOp, XorPrimOp,
@@ -85,7 +86,8 @@ public:
   }
 
   // Basic expressions.
-  HANDLE(ConstantOp, Unhandled)
+  HANDLE(ConstantOp, Unhandled);
+  HANDLE(SpecialConstantOp, Unhandled);
   HANDLE(SubfieldOp, Unhandled);
   HANDLE(SubindexOp, Unhandled);
   HANDLE(SubaccessOp, Unhandled);
@@ -289,7 +291,7 @@ public:
   /// visitUnhandledOp is an override point for FIRRTL dialect ops that the
   /// concrete visitor didn't bother to implement.
   ResultType visitUnhandledOp(Operation *op, ExtraArgs... args) {
-    return ResultType(); 
+    return ResultType();
   }
 };
 } // namespace firrtl

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1598,7 +1598,8 @@ LogicalResult FIRRTLLowering::visitExpr(ConstantOp op) {
 }
 
 LogicalResult FIRRTLLowering::visitExpr(SpecialConstantOp op) {
-  return setLowering(op, getOrCreateIntConstant(APInt(/*bitWidth*/ 1, op.value())));
+  return setLowering(op,
+                     getOrCreateIntConstant(APInt(/*bitWidth*/ 1, op.value())));
 }
 
 LogicalResult FIRRTLLowering::visitExpr(SubfieldOp op) {

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -958,6 +958,7 @@ struct FIRRTLLowering : public FIRRTLVisitor<FIRRTLLowering, LogicalResult> {
   enum UnloweredOpResult { AlreadyLowered, NowLowered, LoweringFailure };
   UnloweredOpResult handleUnloweredOp(Operation *op);
   LogicalResult visitExpr(ConstantOp op);
+  LogicalResult visitExpr(SpecialConstantOp op);
   LogicalResult visitExpr(SubfieldOp op);
   LogicalResult visitUnhandledOp(Operation *op) { return failure(); }
   LogicalResult visitInvalidOp(Operation *op) { return failure(); }
@@ -1594,6 +1595,10 @@ FIRRTLLowering::handleUnloweredOp(Operation *op) {
 
 LogicalResult FIRRTLLowering::visitExpr(ConstantOp op) {
   return setLowering(op, getOrCreateIntConstant(op.value()));
+}
+
+LogicalResult FIRRTLLowering::visitExpr(SpecialConstantOp op) {
+  return setLowering(op, getOrCreateIntConstant(APInt(/*bitWidth*/ 1, op.value())));
 }
 
 LogicalResult FIRRTLLowering::visitExpr(SubfieldOp op) {

--- a/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
@@ -293,11 +293,17 @@ void FIRRTLDialect::printType(Type type, DialectAsmPrinter &os) const {
 Operation *FIRRTLDialect::materializeConstant(OpBuilder &builder,
                                               Attribute value, Type type,
                                               Location loc) {
+
   // Boolean constants. Boolean attributes are always a special constant type
   // like ClockType and ResetType.  Since BoolAttrs are also IntegerAttrs, its
   // important that this goes first.
-  if (auto attrValue = value.dyn_cast<BoolAttr>())
+  if (auto attrValue = value.dyn_cast<BoolAttr>()) {
+    auto isSpecialConstantType =
+        type.isa<ClockType, AsyncResetType, ResetType>();
+    assert(isSpecialConstantType &&
+           "BoolAttrs can only be materialized for special constant types.");
     return builder.create<SpecialConstantOp>(loc, type, attrValue);
+  }
 
   // Integer constants.
   if (auto attrValue = value.dyn_cast<IntegerAttr>()) {

--- a/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
@@ -295,7 +295,7 @@ Operation *FIRRTLDialect::materializeConstant(OpBuilder &builder,
                                               Location loc) {
   // Boolean constants. Boolean attributes are always a special constant type
   // like ClockType and ResetType.  Since BoolAttrs are also IntegerAttrs, its
-  // important that this goes first. 
+  // important that this goes first.
   if (auto attrValue = value.dyn_cast<BoolAttr>())
     return builder.create<SpecialConstantOp>(loc, type, attrValue);
 

--- a/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
@@ -197,6 +197,22 @@ struct FIRRTLOpAsmDialectInterface : public OpAsmDialectInterface {
       setNameFn(constant.getResult(), specialName.str());
     }
 
+    if (auto specialConstant = dyn_cast<SpecialConstantOp>(op)) {
+      SmallString<32> specialNameBuffer;
+      llvm::raw_svector_ostream specialName(specialNameBuffer);
+      specialName << 'c';
+      specialName << static_cast<unsigned>(specialConstant.value());
+      auto type = specialConstant.getType();
+      if (type.isa<ClockType>()) {
+        specialName << "_clock";
+      } else if (type.isa<ResetType>()) {
+        specialName << "_reset";
+      } else if (type.isa<AsyncResetType>()) {
+        specialName << "_asyncreset";
+      }
+      setNameFn(specialConstant.getResult(), specialName.str());
+    }
+
     // Set invalid values to have a distinct name.
     if (auto invalid = dyn_cast<InvalidValueOp>(op)) {
       std::string name;
@@ -277,6 +293,12 @@ void FIRRTLDialect::printType(Type type, DialectAsmPrinter &os) const {
 Operation *FIRRTLDialect::materializeConstant(OpBuilder &builder,
                                               Attribute value, Type type,
                                               Location loc) {
+  // Boolean constants. Boolean attributes are always a special constant type
+  // like ClockType and ResetType.  Since BoolAttrs are also IntegerAttrs, its
+  // important that this goes first. 
+  if (auto attrValue = value.dyn_cast<BoolAttr>())
+    return builder.create<SpecialConstantOp>(loc, type, attrValue);
+
   // Integer constants.
   if (auto attrValue = value.dyn_cast<IntegerAttr>()) {
     auto intType = type.cast<IntType>();

--- a/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
@@ -298,10 +298,10 @@ Operation *FIRRTLDialect::materializeConstant(OpBuilder &builder,
   // like ClockType and ResetType.  Since BoolAttrs are also IntegerAttrs, its
   // important that this goes first.
   if (auto attrValue = value.dyn_cast<BoolAttr>()) {
-    auto isSpecialConstantType =
-        type.isa<ClockType, AsyncResetType, ResetType>();
-    assert(isSpecialConstantType &&
-           "BoolAttrs can only be materialized for special constant types.");
+    assert(
+        type.isa<ClockType>() || type.isa<AsyncResetType>() ||
+        type.isa<ResetType>() &&
+            "BoolAttrs can only be materialized for special constant types.");
     return builder.create<SpecialConstantOp>(loc, type, attrValue);
   }
 

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -721,16 +721,16 @@ OpFoldResult AsSIntPrimOp::fold(ArrayRef<Attribute> operands) {
   if (!operands[0])
     return {};
 
+  // Constant clocks and resets are bool attributes.
+  if (auto attr = operands[0].dyn_cast<BoolAttr>())
+    return getIntAttr(getType(), APInt(/*bitWidth*/ 1, attr.getValue()));
+
   // Be careful to only fold the cast into the constant if the size is known.
   // Otherwise width inference may produce differently-sized constants if the
   // sign changes.
   if (auto attr = operands[0].dyn_cast<IntegerAttr>())
     if (getType().hasWidth())
       return getIntAttr(getType(), attr.getValue());
-
-  // Constant clocks and resets are bool attributes.
-  if (auto attr = operands[0].dyn_cast<BoolAttr>())
-    return getIntAttr(getType(), APInt(/*bitWidth*/ 1, attr.getValue()));
 
   return {};
 }
@@ -743,16 +743,16 @@ OpFoldResult AsUIntPrimOp::fold(ArrayRef<Attribute> operands) {
   if (!operands[0])
     return {};
 
+  // Constant clocks and resets are bool attributes.
+  if (auto attr = operands[0].dyn_cast<BoolAttr>())
+    return getIntAttr(getType(), APInt(/*bitWidth*/ 1, attr.getValue()));
+
   // Be careful to only fold the cast into the constant if the size is known.
   // Otherwise width inference may produce differently-sized constants if the
   // sign changes.
   if (auto attr = operands[0].dyn_cast<IntegerAttr>())
     if (getType().hasWidth())
       return getIntAttr(getType(), attr.getValue());
-
-  // Constant clocks and resets are bool attributes.
-  if (auto attr = operands[0].dyn_cast<BoolAttr>())
-    return getIntAttr(getType(), APInt(/*bitWidth*/ 1, attr.getValue()));
 
   return {};
 }

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1519,6 +1519,48 @@ void ConstantOp::build(OpBuilder &builder, OperationState &result,
   return build(builder, result, type, attr);
 }
 
+static void printSpecialConstantOp(OpAsmPrinter &p, SpecialConstantOp &op) {
+  p << "firrtl.specialconstant ";
+  // SpecialConstant uses a BoolAttr, and we want to print `true` as `1`.
+  p << static_cast<unsigned>(op.value());
+  p << " : ";
+  p.printType(op.getType());
+  p.printOptionalAttrDict(op->getAttrs(), /*elidedAttrs=*/{"value"});
+}
+
+static ParseResult parseSpecialConstantOp(OpAsmParser &parser,
+                                          OperationState &result) {
+  // Parse the constant value.  SpecialConstant uses bool attributes, but it
+  // prints as an integer.
+  APInt value;
+  auto loc = parser.getCurrentLocation();
+  auto valueResult = parser.parseOptionalInteger(value);
+  if (!valueResult.hasValue())
+    return parser.emitError(loc, "expected integer value");
+
+  // Clocks and resets can only be 0 or 1.
+  if (value != 0 && value != 1)
+    return parser.emitError(loc, "special constants can only be 0 or 1.");
+
+  // Parse the result firrtl type.
+  Type resultType;
+  if (failed(*valueResult) || parser.parseColonType(resultType) ||
+      parser.parseOptionalAttrDict(result.attributes))
+    return failure();
+  result.addTypes(resultType);
+
+  // Create the attribute.
+  auto valueAttr = parser.getBuilder().getBoolAttr(value == 1);
+  result.addAttribute("value", valueAttr);
+  return success();
+}
+
+static LogicalResult verifySpecialConstantOp(SpecialConstantOp constant) {
+  // The attribute is bool and always correct.  The return type is checked by
+  // the type constraints. Nothing to check here.
+  return success();
+}
+
 static LogicalResult verifySubfieldOp(SubfieldOp op) {
   if (op.fieldIndex() >=
       op.input().getType().cast<BundleType>().getNumElements())

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1555,12 +1555,6 @@ static ParseResult parseSpecialConstantOp(OpAsmParser &parser,
   return success();
 }
 
-static LogicalResult verifySpecialConstantOp(SpecialConstantOp constant) {
-  // The attribute is bool and always correct.  The return type is checked by
-  // the type constraints. Nothing to check here.
-  return success();
-}
-
 static LogicalResult verifySubfieldOp(SubfieldOp op) {
   if (op.fieldIndex() >=
       op.input().getType().cast<BundleType>().getNumElements())

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -244,6 +244,7 @@ struct IMConstPropPass : public IMConstPropBase<IMConstPropPass> {
 
   void markInvalidValueOp(InvalidValueOp invalid);
   void markConstantOp(ConstantOp constant);
+  void markSpecialConstantOp(SpecialConstantOp specialConstant);
   void markInstanceOp(InstanceOp instance);
 
   void visitConnect(ConnectOp connect);
@@ -342,6 +343,14 @@ LatticeValue IMConstPropPass::getExtendedLatticeValue(Value value,
   if (result.isInvalidValue())
     return InvalidValueAttr::get(destType);
 
+  auto constant = result.getConstant();
+
+  // If this is a BoolAttr then we are dealing with a special constant.
+  if (auto boolAttr = constant.dyn_cast<BoolAttr>()) {
+    // No extOrTrunc necessary for clock or reset types.
+    return LatticeValue(boolAttr);
+  }
+
   // If destType is wider than the source constant type, extend it.
   auto resultConstant = result.getConstant().getAPSInt();
   auto destWidth = destType.getBitWidthOrSentinel();
@@ -372,6 +381,8 @@ void IMConstPropPass::markBlockExecutable(Block *block) {
       markWireOrUnresetableRegOp(&op);
     else if (auto constant = dyn_cast<ConstantOp>(op))
       markConstantOp(constant);
+    else if (auto specialConstant = dyn_cast<SpecialConstantOp>(op))
+      markSpecialConstantOp(specialConstant);
     else if (auto invalid = dyn_cast<InvalidValueOp>(op))
       markInvalidValueOp(invalid);
     else if (auto instance = dyn_cast<InstanceOp>(op))
@@ -420,6 +431,10 @@ void IMConstPropPass::markMemOp(MemOp mem) {
 
 void IMConstPropPass::markConstantOp(ConstantOp constant) {
   mergeLatticeValue(constant, LatticeValue(constant.valueAttr()));
+}
+
+void IMConstPropPass::markSpecialConstantOp(SpecialConstantOp specialConstant) {
+  mergeLatticeValue(specialConstant, LatticeValue(specialConstant.valueAttr()));
 }
 
 void IMConstPropPass::markInvalidValueOp(InvalidValueOp invalid) {

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -714,7 +714,7 @@ void IMConstPropPass::rewriteModuleBody(FModuleOp module) {
     }
 
     // Don't "refold" constants.  TODO: Unique in the module entry block.
-    if (isa<ConstantOp>(op) || isa<InvalidValueOp>(op))
+    if (isa<ConstantOp, SpecialConstantOp, InvalidValueOp>(op))
       continue;
 
     // If the op had any constants folded, replace them.

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -162,7 +162,7 @@ protected:
 template <class DerivedT, Expr::Kind DerivedKind>
 struct UnaryExprBase : public UnaryExpr {
   template <typename... Args>
-  UnaryExprBase(Args &&... args)
+  UnaryExprBase(Args &&...args)
       : UnaryExpr(DerivedKind, std::forward<Args>(args)...) {}
   static bool classof(const Expr *e) { return e->kind == DerivedKind; }
 };
@@ -201,7 +201,7 @@ protected:
 template <class DerivedT, Expr::Kind DerivedKind>
 struct BinaryExprBase : public BinaryExpr {
   template <typename... Args>
-  BinaryExprBase(Args &&... args)
+  BinaryExprBase(Args &&...args)
       : BinaryExpr(DerivedKind, std::forward<Args>(args)...) {}
   static bool classof(const Expr *e) { return e->kind == DerivedKind; }
 };
@@ -296,7 +296,7 @@ public:
   /// existing one. `R` is the type of the object to be allocated. `R` must be
   /// derived from or be the type `T`.
   template <typename R = T, typename... Args>
-  std::pair<R *, bool> alloc(Args &&... args) {
+  std::pair<R *, bool> alloc(Args &&...args) {
     auto stack_value = R(std::forward<Args>(args)...);
     auto stack_slot = Slot(&stack_value);
     auto it = interned.find(stack_slot);
@@ -320,7 +320,7 @@ public:
   /// Allocate a new object. `R` is the type of the object to be allocated. `R`
   /// must be derived from or be the type `T`.
   template <typename R = T, typename... Args>
-  R *alloc(Args &&... args) {
+  R *alloc(Args &&...args) {
     return new (allocator) R(std::forward<Args>(args)...);
   }
 };
@@ -381,7 +381,7 @@ private:
 
   /// Add an allocated expression to the list above.
   template <typename R, typename T, typename... Args>
-  R *alloc(InternedAllocator<T> &allocator, Args &&... args) {
+  R *alloc(InternedAllocator<T> &allocator, Args &&...args) {
     auto it = allocator.template alloc<R>(std::forward<Args>(args)...);
     if (it.second)
       exprs.push_back(it.first);
@@ -1135,6 +1135,9 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
           e = solver.known(std::max(w, 1u));
         }
         setExpr(op.getResult(), e);
+      })
+      .Case<SpecialConstantOp>([&](auto op) {
+        // Nothing required.
       })
       .Case<WireOp, InvalidValueOp, RegOp>(
           [&](auto op) { declareVars(op.getResult(), op.getLoc()); })

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -162,7 +162,7 @@ protected:
 template <class DerivedT, Expr::Kind DerivedKind>
 struct UnaryExprBase : public UnaryExpr {
   template <typename... Args>
-  UnaryExprBase(Args &&...args)
+  UnaryExprBase(Args &&... args)
       : UnaryExpr(DerivedKind, std::forward<Args>(args)...) {}
   static bool classof(const Expr *e) { return e->kind == DerivedKind; }
 };
@@ -201,7 +201,7 @@ protected:
 template <class DerivedT, Expr::Kind DerivedKind>
 struct BinaryExprBase : public BinaryExpr {
   template <typename... Args>
-  BinaryExprBase(Args &&...args)
+  BinaryExprBase(Args &&... args)
       : BinaryExpr(DerivedKind, std::forward<Args>(args)...) {}
   static bool classof(const Expr *e) { return e->kind == DerivedKind; }
 };
@@ -296,7 +296,7 @@ public:
   /// existing one. `R` is the type of the object to be allocated. `R` must be
   /// derived from or be the type `T`.
   template <typename R = T, typename... Args>
-  std::pair<R *, bool> alloc(Args &&...args) {
+  std::pair<R *, bool> alloc(Args &&... args) {
     auto stack_value = R(std::forward<Args>(args)...);
     auto stack_slot = Slot(&stack_value);
     auto it = interned.find(stack_slot);
@@ -320,7 +320,7 @@ public:
   /// Allocate a new object. `R` is the type of the object to be allocated. `R`
   /// must be derived from or be the type `T`.
   template <typename R = T, typename... Args>
-  R *alloc(Args &&...args) {
+  R *alloc(Args &&... args) {
     return new (allocator) R(std::forward<Args>(args)...);
   }
 };
@@ -381,7 +381,7 @@ private:
 
   /// Add an allocated expression to the list above.
   template <typename R, typename T, typename... Args>
-  R *alloc(InternedAllocator<T> &allocator, Args &&...args) {
+  R *alloc(InternedAllocator<T> &allocator, Args &&... args) {
     auto it = allocator.template alloc<R>(std::forward<Args>(args)...);
     if (it.second)
       exprs.push_back(it.first);

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -31,6 +31,12 @@ firrtl.circuit "Simple" {
     // CHECK: sv.wire sym @__Simple__dntnode
     %dntnode = firrtl.node %in1 {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<4>
 
+    // CHECK: %clockWire = sv.wire  : !hw.inout<i1>
+    // CHECK: sv.connect %clockWire, %false : i1
+    %c0_clock = firrtl.specialconstant 0 : !firrtl.clock
+    %clockWire = firrtl.wire : !firrtl.clock
+    firrtl.connect %clockWire, %c0_clock : !firrtl.clock, !firrtl.clock
+
     // CHECK: sv.connect %out5, %c0_i4 : i4
     %tmp1 = firrtl.invalidvalue : !firrtl.uint<4>
     firrtl.connect %out5, %tmp1 : !firrtl.uint<4>, !firrtl.uint<4>

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -24,6 +24,20 @@ firrtl.module @Casts(in %ui1 : !firrtl.uint<1>, in %si1 : !firrtl.sint<1>,
   // CHECK: firrtl.connect %out_asyncreset, %asyncreset : !firrtl.asyncreset, !firrtl.asyncreset
   %3 = firrtl.asAsyncReset %asyncreset : (!firrtl.asyncreset) -> !firrtl.asyncreset
   firrtl.connect %out_asyncreset, %3 : !firrtl.asyncreset, !firrtl.asyncreset
+
+  /// Constant fold.
+  // CHECK: firrtl.connect %out_ui1, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  %4 = firrtl.asUInt %c1_si1 : (!firrtl.sint<1>) -> !firrtl.uint<1>
+  firrtl.connect %out_ui1, %4 : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK: firrtl.connect %out_si1, %c-1_si1 : !firrtl.sint<1>, !firrtl.sint<1>
+  %5 = firrtl.asSInt %c1_ui1 : (!firrtl.uint<1>) -> !firrtl.sint<1>
+  firrtl.connect %out_si1, %5 : !firrtl.sint<1>, !firrtl.sint<1>
+  // CHECK: firrtl.connect %out_clock, %c1_clock : !firrtl.clock, !firrtl.clock
+  %6 = firrtl.asClock %c1_ui1 : (!firrtl.uint<1>) -> !firrtl.clock
+  firrtl.connect %out_clock, %6 : !firrtl.clock, !firrtl.clock
+  // CHECK: firrtl.connect %out_asyncreset, %c1_asyncreset : !firrtl.asyncreset, !firrtl.asyncreset
+  %7 = firrtl.asAsyncReset %c1_ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset
+  firrtl.connect %out_asyncreset, %7 : !firrtl.asyncreset, !firrtl.asyncreset
 }
 
 // CHECK-LABEL: firrtl.module @Div

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -53,6 +53,60 @@ firrtl.circuit "" {
 // -----
 
 firrtl.circuit "Foo" {
+firrtl.module @Foo() {
+  // expected-error @+1 {{invalid kind of type specified}}
+  firrtl.constant 100 : !firrtl.bundle<>
+}
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+firrtl.module @Foo() {
+  // expected-error @+1 {{constant too large for result type}}
+  firrtl.constant 100 : !firrtl.uint<4>
+}
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+firrtl.module @Foo() {
+  // expected-error @+1 {{constant too large for result type}}
+  firrtl.constant -100 : !firrtl.sint<4>
+}
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+firrtl.module @Foo() {
+  // expected-error @+1 {{special constants can only be 0 or 1}}
+  firrtl.specialconstant 2 : !firrtl.clock
+}
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+firrtl.module @Foo() {
+  // expected-error @+1 {{special constants can only be 0 or 1}}
+  firrtl.specialconstant 2 : !firrtl.reset
+}
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+firrtl.module @Foo() {
+  // expected-error @+1 {{special constants can only be 0 or 1}}
+  firrtl.specialconstant 2 : !firrtl.asyncreset
+}
+}
+
+// -----
+
+firrtl.circuit "Foo" {
   firrtl.module @Foo(in %clk: !firrtl.uint<1>, in %reset: !firrtl.uint<1>) {
     // expected-error @+1 {{'firrtl.reg' op operand #0 must be clock, but got '!firrtl.uint<1>'}}
     %a = firrtl.reg %clk {name = "a"} : (!firrtl.uint<1>) -> !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -48,7 +48,6 @@ firrtl.circuit "Test" {
     // CHECK: firrtl.connect %result2, %c0_clock
     firrtl.connect %result2, %clockWire : !firrtl.clock, !firrtl.clock
 
-
     // Not a constant.
     %nonconstWire = firrtl.wire : !firrtl.uint<1>
     firrtl.connect %nonconstWire, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -57,22 +56,14 @@ firrtl.circuit "Test" {
     // CHECK: firrtl.connect %result3, %nonconstWire
     firrtl.connect %result3, %nonconstWire : !firrtl.uint<1>, !firrtl.uint<1>
 
-
     // Constant propagation through instance.
     %source, %dest = firrtl.instance @PassThrough {name = "", portNames = ["source", "dest"]} : !firrtl.uint<1>, !firrtl.uint<1>
 
     // CHECK: firrtl.connect %inst_source, %c0_ui1
     firrtl.connect %source, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-<<<<<<< HEAD
-    // CHECK: firrtl.connect %result3, %inst_dest
-    firrtl.connect %result3, %dest : !firrtl.uint<1>, !firrtl.uint<1>
-||||||| parent of f3ea2e7d ([FIRRTL] Allow firrtl.constant of type Clock, Reset, AsyncReset)
-    // CHECK: firrtl.connect %result3, %c0_ui1_1
-    firrtl.connect %result3, %dest : !firrtl.uint<1>, !firrtl.uint<1>
-=======
-    // CHECK: firrtl.connect %result4, %c0_ui1_1
+
+    // CHECK: firrtl.connect %result4, %inst_dest
     firrtl.connect %result4, %dest : !firrtl.uint<1>, !firrtl.uint<1>
->>>>>>> f3ea2e7d ([FIRRTL] Allow firrtl.constant of type Clock, Reset, AsyncReset)
 
     // Check connect extensions.
     %extWire = firrtl.wire : !firrtl.uint<2>
@@ -175,7 +166,6 @@ firrtl.circuit "Issue1188"  {
     %9 = firrtl.mux(%reset, %c1_ui6, %4) : (!firrtl.uint<1>, !firrtl.uint<6>, !firrtl.uint<6>) -> !firrtl.uint<6>
     firrtl.connect %D0123456, %9 : !firrtl.uint<6>, !firrtl.uint<6>
   }
-<<<<<<< HEAD
 }
 
 // -----
@@ -277,8 +267,3 @@ firrtl.circuit "InputPortTop"   {
     firrtl.connect %c2_in1, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
-||||||| parent of f3ea2e7d ([FIRRTL] Allow firrtl.constant of type Clock, Reset, AsyncReset)
-}
-=======
-}
->>>>>>> f3ea2e7d ([FIRRTL] Allow firrtl.constant of type Clock, Reset, AsyncReset)

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -20,13 +20,14 @@ firrtl.circuit "Test" {
   // CHECK-LABEL: @Test
   firrtl.module @Test(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>,
                       out %result1: !firrtl.uint<1>,
-                      out %result2: !firrtl.uint<1>,
+                      out %result2: !firrtl.clock,
                       out %result3: !firrtl.uint<1>,
-                      out %result4: !firrtl.uint<2>,
+                      out %result4: !firrtl.uint<1>,
                       out %result5: !firrtl.uint<2>,
-                      out %result6: !firrtl.uint<4>,
+                      out %result6: !firrtl.uint<2>,
                       out %result7: !firrtl.uint<4>,
-                      out %result8: !firrtl.uint<4>) {
+                      out %result8: !firrtl.uint<4>,
+                      out %result9: !firrtl.uint<4>) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
 
@@ -38,13 +39,23 @@ firrtl.circuit "Test" {
     // CHECK: firrtl.connect %result1, %c0_ui1_0
     firrtl.connect %result1, %someWire : !firrtl.uint<1>, !firrtl.uint<1>
 
+    // Trivial wire special constant propagation.
+    %c0_clock = firrtl.specialconstant 0 : !firrtl.clock
+    %clockWire = firrtl.wire : !firrtl.clock
+    firrtl.connect %clockWire, %c0_clock : !firrtl.clock, !firrtl.clock
+
+    // CHECK-NOT: firrtl.wire
+    // CHECK: firrtl.connect %result2, %c0_clock
+    firrtl.connect %result2, %clockWire : !firrtl.clock, !firrtl.clock
+
+
     // Not a constant.
     %nonconstWire = firrtl.wire : !firrtl.uint<1>
     firrtl.connect %nonconstWire, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %nonconstWire, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
 
-    // CHECK: firrtl.connect %result2, %nonconstWire
-    firrtl.connect %result2, %nonconstWire : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK: firrtl.connect %result3, %nonconstWire
+    firrtl.connect %result3, %nonconstWire : !firrtl.uint<1>, !firrtl.uint<1>
 
 
     // Constant propagation through instance.
@@ -52,8 +63,16 @@ firrtl.circuit "Test" {
 
     // CHECK: firrtl.connect %inst_source, %c0_ui1
     firrtl.connect %source, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+<<<<<<< HEAD
     // CHECK: firrtl.connect %result3, %inst_dest
     firrtl.connect %result3, %dest : !firrtl.uint<1>, !firrtl.uint<1>
+||||||| parent of f3ea2e7d ([FIRRTL] Allow firrtl.constant of type Clock, Reset, AsyncReset)
+    // CHECK: firrtl.connect %result3, %c0_ui1_1
+    firrtl.connect %result3, %dest : !firrtl.uint<1>, !firrtl.uint<1>
+=======
+    // CHECK: firrtl.connect %result4, %c0_ui1_1
+    firrtl.connect %result4, %dest : !firrtl.uint<1>, !firrtl.uint<1>
+>>>>>>> f3ea2e7d ([FIRRTL] Allow firrtl.constant of type Clock, Reset, AsyncReset)
 
     // Check connect extensions.
     %extWire = firrtl.wire : !firrtl.uint<2>
@@ -63,8 +82,8 @@ firrtl.circuit "Test" {
     %invalid = firrtl.invalidvalue : !firrtl.uint<2>
     firrtl.connect %extWire, %invalid : !firrtl.uint<2>, !firrtl.uint<2>
 
-    // CHECK: firrtl.connect %result4, %c0_ui2
-    firrtl.connect %result4, %extWire: !firrtl.uint<2>, !firrtl.uint<2>
+    // CHECK: firrtl.connect %result5, %c0_ui2
+    firrtl.connect %result5, %extWire: !firrtl.uint<2>, !firrtl.uint<2>
 
     // regreset
     %c0_ui20 = firrtl.constant 0 : !firrtl.uint<20>
@@ -73,19 +92,19 @@ firrtl.circuit "Test" {
     %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
     firrtl.connect %regreset, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
 
-    // CHECK: firrtl.connect %result5, %c0_ui2
-    firrtl.connect %result5, %regreset: !firrtl.uint<2>, !firrtl.uint<2>
+    // CHECK: firrtl.connect %result6, %c0_ui2
+    firrtl.connect %result6, %regreset: !firrtl.uint<2>, !firrtl.uint<2>
 
     // reg
     %reg = firrtl.reg %clock  : (!firrtl.clock) -> !firrtl.uint<4>
     firrtl.connect %reg, %c0_ui2 : !firrtl.uint<4>, !firrtl.uint<2>
-    // CHECK: firrtl.connect %result6, %c0_ui4
-    firrtl.connect %result6, %reg: !firrtl.uint<4>, !firrtl.uint<4>
+    // CHECK: firrtl.connect %result7, %c0_ui4
+    firrtl.connect %result7, %reg: !firrtl.uint<4>, !firrtl.uint<4>
 
     // Wire without connects to it should turn into 'invalid'.
     %unconnectedWire = firrtl.wire : !firrtl.uint<2>
-    // CHECK: firrtl.connect %result7, %invalid_ui2
-    firrtl.connect %result7, %unconnectedWire: !firrtl.uint<4>, !firrtl.uint<2>
+    // CHECK: firrtl.connect %result8, %invalid_ui2
+    firrtl.connect %result8, %unconnectedWire: !firrtl.uint<4>, !firrtl.uint<2>
 
     %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
     %c2_ui2 = firrtl.constant 2 : !firrtl.uint<2>
@@ -97,8 +116,8 @@ firrtl.circuit "Test" {
     // CHECK-NEXT: firrtl.constant 3
     %c = firrtl.xor %b, %c2_ui2 : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
 
-    // CHECK-NEXT: firrtl.connect %result8, %c3_ui2
-    firrtl.connect %result8, %c: !firrtl.uint<4>, !firrtl.uint<2>
+    // CHECK-NEXT: firrtl.connect %result9, %c3_ui2
+    firrtl.connect %result9, %c: !firrtl.uint<4>, !firrtl.uint<2>
 
 
     // Constant propagation through instance.
@@ -156,6 +175,7 @@ firrtl.circuit "Issue1188"  {
     %9 = firrtl.mux(%reset, %c1_ui6, %4) : (!firrtl.uint<1>, !firrtl.uint<6>, !firrtl.uint<6>) -> !firrtl.uint<6>
     firrtl.connect %D0123456, %9 : !firrtl.uint<6>, !firrtl.uint<6>
   }
+<<<<<<< HEAD
 }
 
 // -----
@@ -257,3 +277,8 @@ firrtl.circuit "InputPortTop"   {
     firrtl.connect %c2_in1, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
+||||||| parent of f3ea2e7d ([FIRRTL] Allow firrtl.constant of type Clock, Reset, AsyncReset)
+}
+=======
+}
+>>>>>>> f3ea2e7d ([FIRRTL] Allow firrtl.constant of type Clock, Reset, AsyncReset)

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -21,6 +21,12 @@ firrtl.circuit "Foo" {
     firrtl.connect %out1, %1 : !firrtl.sint, !firrtl.sint<42>
   }
 
+  // CHECK-LABEL: @InferSpecialConstant
+  firrtl.module @InferSpecialConstant() {
+    // CHECK: %c0_clock = firrtl.specialconstant 0 : !firrtl.clock
+    %c0_clock = firrtl.specialconstant 0 : !firrtl.clock
+  }
+
   // CHECK-LABEL: @InferOutput
   // CHECK-SAME: out %out: !firrtl.uint<2>
   firrtl.module @InferOutput(in %in: !firrtl.uint<2>, out %out: !firrtl.uint) {

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -2,6 +2,20 @@
 
 firrtl.circuit "MyModule" {
 
+// Constant op supports different return types.
+firrtl.module @Constants() {
+  // CHECK: %c4_ui8 = firrtl.constant 4 : !firrtl.uint<8>
+  firrtl.constant 4 : !firrtl.uint<8>
+  // CHECK: %c-4_si16 = firrtl.constant -4 : !firrtl.sint<16>
+  firrtl.constant -4 : !firrtl.sint<16>
+  // CHECK: %c1_clock = firrtl.specialconstant 1 : !firrtl.clock
+  firrtl.specialconstant 1 : !firrtl.clock
+  // CHECK: %c1_reset = firrtl.specialconstant 1 : !firrtl.reset
+  firrtl.specialconstant 1 : !firrtl.reset
+  // CHECK: %c1_asyncreset = firrtl.specialconstant 1 : !firrtl.asyncreset
+  firrtl.specialconstant 1 : !firrtl.asyncreset
+}
+
 //module MyModule :
 //  input in: UInt<8>
 //  output out: UInt<8>


### PR DESCRIPTION
This is a reimplementation of https://github.com/llvm/circt/pull/1354.  This is using a new FIRRTL operation called `firrtl.specialconstant` to create constants of type Reset, AsyncReset, and Clock.  This is also using a BoolAttr (which is a signless `IntegerAttr`) instead of the signed `IntegerAttr` used for other constants.

This was quickly put together just to see what it would look like, and probably requires a bunch more work. EDIT: Should be good to go now.

@lattner any thoughts on this vs the old approach?  I think this is more principled.  We have to handle BoolAttr constant materialization now, which is assumed to be a SpecialConstant.  The custom printer prints BoolAttr as `0` and `1` instead of `false` and `true`.  A few passes have to handle the new op.  IMCP holds these as `Constant` lattice values and checks the Attribute type, but I could have added a `SpecialConstant` case to the enum. 
