### PR TITLE
[FIRRTL][SV] Add names/labels to side effect stmts

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -63,12 +63,12 @@ def PrintFOp : FIRRTLOp<"printf"> {
   let summary = "Formatted Print Statement";
 
   let arguments = (ins ClockType:$clock, UInt1Type:$cond, StrAttr:$formatString,
-                       Variadic<FIRRTLType>:$operands);
+                       Variadic<FIRRTLType>:$operands, StrAttr:$name);
   let results = (outs);
 
   let assemblyFormat = [{
-    $clock `,` $cond `,` $formatString attr-dict (`(` $operands^ `)`
-    `:` type($operands))?
+    $clock `,` $cond `,` $formatString custom<PrintfAttrs>(attr-dict)
+    (`(` $operands^ `)` `:` type($operands))?
   }];
 }
 
@@ -92,43 +92,44 @@ def SkipOp : FIRRTLOp<"skip", [NoSideEffect]> {
 def StopOp : FIRRTLOp<"stop"> {
   let summary = "Stop Statement";
 
-  let arguments = (ins ClockType:$clock, UInt1Type:$cond, I32Attr:$exitCode);
+  let arguments = (ins ClockType:$clock, UInt1Type:$cond, I32Attr:$exitCode,
+                       StrAttr:$name);
   let results = (outs);
 
-  let assemblyFormat = "$clock `,` $cond `,` $exitCode attr-dict";
+  let assemblyFormat = "$clock `,` $cond `,` $exitCode custom<StopAttrs>(attr-dict)";
 }
 
 def AssertOp : FIRRTLOp<"assert"> {
   let summary = "Assert Verification Statement";
 
   let arguments = (ins ClockType:$clock, UInt1Type:$predicate, UInt1Type:$enable,
-    StrAttr:$message);
+    StrAttr:$message, StrAttr:$name);
   let results = (outs);
 
   let assemblyFormat =
-    "$clock `,` $predicate `,` $enable `,` $message attr-dict";
+    "$clock `,` $predicate `,` $enable `,` $message custom<VerifAttrs>(attr-dict)";
 }
 
 def AssumeOp : FIRRTLOp<"assume"> {
   let summary = "Assume Verification Statement";
 
   let arguments = (ins ClockType:$clock, UInt1Type:$predicate, UInt1Type:$enable,
-    StrAttr:$message);
+    StrAttr:$message, StrAttr:$name);
   let results = (outs);
 
   let assemblyFormat =
-    "$clock `,` $predicate `,` $enable `,` $message attr-dict";
+    "$clock `,` $predicate `,` $enable `,` $message custom<VerifAttrs>(attr-dict)";
 }
 
 def CoverOp : FIRRTLOp<"cover"> {
   let summary = "Cover Verification Statement";
 
   let arguments = (ins ClockType:$clock, UInt1Type:$predicate, UInt1Type:$enable,
-    StrAttr:$message);
+    StrAttr:$message, StrAttr:$name);
   let results = (outs);
 
   let assemblyFormat =
-    "$clock `,` $predicate `,` $enable `,` $message attr-dict";
+    "$clock `,` $predicate `,` $enable `,` $message custom<VerifAttrs>(attr-dict)";
 }
 
 def WhenOp : FIRRTLOp<"when", [SingleBlock, NoTerminator, NoRegionArguments,

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -500,7 +500,7 @@ def AssertOp : SVOp<"assert", [ProceduralOp]> {
   let arguments = (ins AnyType:$predicate, StrAttr:$label);
   let results = (outs);
   let assemblyFormat =
-    "custom<ElideEmptyLabel>(attr-dict) $predicate `:` type($predicate)";
+    "custom<OmitEmptyStringAttr>($label) attr-dict $predicate `:` type($predicate)";
 }
 
 def AssumeOp : SVOp<"assume", [ProceduralOp]> {
@@ -512,7 +512,7 @@ def AssumeOp : SVOp<"assume", [ProceduralOp]> {
   let arguments = (ins AnyType:$property, StrAttr:$label);
   let results = (outs);
   let assemblyFormat =
-    "custom<ElideEmptyLabel>(attr-dict) $property `:` type($property)";
+    "custom<OmitEmptyStringAttr>($label) attr-dict $property `:` type($property)";
 }
 
 def CoverOp : SVOp<"cover", [ProceduralOp]> {
@@ -524,7 +524,7 @@ def CoverOp : SVOp<"cover", [ProceduralOp]> {
   let arguments = (ins AnyType:$property, StrAttr:$label);
   let results = (outs);
   let assemblyFormat =
-    "custom<ElideEmptyLabel>(attr-dict) $property `:` type($property)";
+    "custom<OmitEmptyStringAttr>($label) attr-dict $property `:` type($property)";
 }
 
 def BindOp : SVOp<"bind", []> {

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -499,7 +499,8 @@ def AssertOp : SVOp<"assert", [ProceduralOp]> {
 
   let arguments = (ins AnyType:$predicate, StrAttr:$label);
   let results = (outs);
-  let assemblyFormat = "custom<ElideLabel>(attr-dict) $predicate `:` type($predicate)";
+  let assemblyFormat =
+    "custom<ElideEmptyLabel>(attr-dict) $predicate `:` type($predicate)";
 }
 
 def AssumeOp : SVOp<"assume", [ProceduralOp]> {
@@ -510,7 +511,8 @@ def AssumeOp : SVOp<"assume", [ProceduralOp]> {
 
   let arguments = (ins AnyType:$property, StrAttr:$label);
   let results = (outs);
-  let assemblyFormat = "custom<ElideLabel>(attr-dict) $property `:` type($property)";
+  let assemblyFormat =
+    "custom<ElideEmptyLabel>(attr-dict) $property `:` type($property)";
 }
 
 def CoverOp : SVOp<"cover", [ProceduralOp]> {
@@ -521,7 +523,8 @@ def CoverOp : SVOp<"cover", [ProceduralOp]> {
 
   let arguments = (ins AnyType:$property, StrAttr:$label);
   let results = (outs);
-  let assemblyFormat = "custom<ElideLabel>(attr-dict) $property `:` type($property)";
+  let assemblyFormat =
+    "custom<ElideEmptyLabel>(attr-dict) $property `:` type($property)";
 }
 
 def BindOp : SVOp<"bind", []> {

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -497,9 +497,9 @@ def AssertOp : SVOp<"assert", [ProceduralOp]> {
     Assert that a specific condition is always true.
   }];
 
-  let arguments = (ins AnyType:$predicate);
+  let arguments = (ins AnyType:$predicate, StrAttr:$label);
   let results = (outs);
-  let assemblyFormat = "attr-dict $predicate `:` type($predicate)";
+  let assemblyFormat = "custom<ElideLabel>(attr-dict) $predicate `:` type($predicate)";
 }
 
 def AssumeOp : SVOp<"assume", [ProceduralOp]> {
@@ -508,9 +508,9 @@ def AssumeOp : SVOp<"assume", [ProceduralOp]> {
     Assume that a specific property is always true.
   }];
 
-  let arguments = (ins AnyType:$property);
+  let arguments = (ins AnyType:$property, StrAttr:$label);
   let results = (outs);
-  let assemblyFormat = "attr-dict $property `:` type($property)";
+  let assemblyFormat = "custom<ElideLabel>(attr-dict) $property `:` type($property)";
 }
 
 def CoverOp : SVOp<"cover", [ProceduralOp]> {
@@ -519,9 +519,9 @@ def CoverOp : SVOp<"cover", [ProceduralOp]> {
     Assert that a specific property happens during the course of execution.
   }];
 
-  let arguments = (ins AnyType:$property);
+  let arguments = (ins AnyType:$property, StrAttr:$label);
   let results = (outs);
-  let assemblyFormat = "attr-dict $property `:` type($property)";
+  let assemblyFormat = "custom<ElideLabel>(attr-dict) $property `:` type($property)";
 }
 
 def BindOp : SVOp<"bind", []> {

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -2639,7 +2639,12 @@ LogicalResult FIRRTLLowering::lowerVerificationStatement(AOpTy op) {
   addToAlwaysBlock(clock, [&]() {
     addIfProceduralBlock(enable, [&]() {
       // Create BOpTy inside the always/if.
-      builder.create<BOpTy>(predicate);
+      StringAttr label;
+      if (op.nameAttr())
+        label = op.nameAttr();
+      else
+        label = builder.getStringAttr("");
+      builder.create<BOpTy>(predicate, label);
     });
   });
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2441,6 +2441,56 @@ SmallVector<Direction> direction::unpackAttribute(Operation *module) {
 }
 
 //===----------------------------------------------------------------------===//
+// Miscellaneous custom elision logic.
+//===----------------------------------------------------------------------===//
+
+static ParseResult parseElideName(OpAsmParser &p, NamedAttrList &resultAttrs) {
+  auto result = p.parseOptionalAttrDict(resultAttrs);
+  if (!resultAttrs.get("name"))
+    resultAttrs.append("name", p.getBuilder().getStringAttr(""));
+
+  return result;
+}
+
+static void printElideName(OpAsmPrinter &p, Operation *op, DictionaryAttr attr,
+                           ArrayRef<StringRef> extraElides = {}) {
+
+  SmallVector<StringRef> elides(extraElides.begin(), extraElides.end());
+  if (op->getAttrOfType<StringAttr>("name").getValue().empty())
+    elides.push_back("name");
+
+  p.printOptionalAttrDict(op->getAttrs(), elides);
+}
+
+static ParseResult parsePrintfAttrs(OpAsmParser &p,
+                                    NamedAttrList &resultAttrs) {
+  return parseElideName(p, resultAttrs);
+}
+
+static void printPrintfAttrs(OpAsmPrinter &p, Operation *op,
+                             DictionaryAttr attr) {
+  printElideName(p, op, attr, {"formatString"});
+}
+
+static ParseResult parseStopAttrs(OpAsmParser &p, NamedAttrList &resultAttrs) {
+  return parseElideName(p, resultAttrs);
+}
+
+static void printStopAttrs(OpAsmPrinter &p, Operation *op,
+                           DictionaryAttr attr) {
+  printElideName(p, op, attr, {"exitCode"});
+}
+
+static ParseResult parseVerifAttrs(OpAsmParser &p, NamedAttrList &resultAttrs) {
+  return parseElideName(p, resultAttrs);
+}
+
+static void printVerifAttrs(OpAsmPrinter &p, Operation *op,
+                            DictionaryAttr attr) {
+  printElideName(p, op, attr, {"message"});
+}
+
+//===----------------------------------------------------------------------===//
 // TblGen Generated Logic.
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2444,7 +2444,8 @@ SmallVector<Direction> direction::unpackAttribute(Operation *module) {
 // Miscellaneous custom elision logic.
 //===----------------------------------------------------------------------===//
 
-static ParseResult parseElideName(OpAsmParser &p, NamedAttrList &resultAttrs) {
+static ParseResult parseElideEmptyName(OpAsmParser &p,
+                                       NamedAttrList &resultAttrs) {
   auto result = p.parseOptionalAttrDict(resultAttrs);
   if (!resultAttrs.get("name"))
     resultAttrs.append("name", p.getBuilder().getStringAttr(""));
@@ -2452,8 +2453,9 @@ static ParseResult parseElideName(OpAsmParser &p, NamedAttrList &resultAttrs) {
   return result;
 }
 
-static void printElideName(OpAsmPrinter &p, Operation *op, DictionaryAttr attr,
-                           ArrayRef<StringRef> extraElides = {}) {
+static void printElideEmptyName(OpAsmPrinter &p, Operation *op,
+                                DictionaryAttr attr,
+                                ArrayRef<StringRef> extraElides = {}) {
 
   SmallVector<StringRef> elides(extraElides.begin(), extraElides.end());
   if (op->getAttrOfType<StringAttr>("name").getValue().empty())
@@ -2464,30 +2466,30 @@ static void printElideName(OpAsmPrinter &p, Operation *op, DictionaryAttr attr,
 
 static ParseResult parsePrintfAttrs(OpAsmParser &p,
                                     NamedAttrList &resultAttrs) {
-  return parseElideName(p, resultAttrs);
+  return parseElideEmptyName(p, resultAttrs);
 }
 
 static void printPrintfAttrs(OpAsmPrinter &p, Operation *op,
                              DictionaryAttr attr) {
-  printElideName(p, op, attr, {"formatString"});
+  printElideEmptyName(p, op, attr, {"formatString"});
 }
 
 static ParseResult parseStopAttrs(OpAsmParser &p, NamedAttrList &resultAttrs) {
-  return parseElideName(p, resultAttrs);
+  return parseElideEmptyName(p, resultAttrs);
 }
 
 static void printStopAttrs(OpAsmPrinter &p, Operation *op,
                            DictionaryAttr attr) {
-  printElideName(p, op, attr, {"exitCode"});
+  printElideEmptyName(p, op, attr, {"exitCode"});
 }
 
 static ParseResult parseVerifAttrs(OpAsmParser &p, NamedAttrList &resultAttrs) {
-  return parseElideName(p, resultAttrs);
+  return parseElideEmptyName(p, resultAttrs);
 }
 
 static void printVerifAttrs(OpAsmPrinter &p, Operation *op,
                             DictionaryAttr attr) {
-  printElideName(p, op, attr, {"message"});
+  printElideEmptyName(p, op, attr, {"message"});
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2325,27 +2325,24 @@ ParseResult FIRStmtParser::parsePrintf() {
     APInt constOne(1, 1, false);
     auto constTrue =
         builder.create<ConstantOp>(UIntType::get(getContext(), 1), constOne);
-    builder.create<CoverOp>(clock, condition, constTrue,
-                            builder.getStringAttr(formatStrUnescaped),
-                            builder.getStringAttr(""));
+    builder.create<CoverOp>(clock, condition, constTrue, formatStrUnescaped,
+                            "");
     return success();
   }
   if (formatStringRef.startswith("assert:")) {
     APInt constOne(1, 1, false);
     auto constTrue =
         builder.create<ConstantOp>(UIntType::get(getContext(), 1), constOne);
-    builder.create<AssertOp>(clock, condition, constTrue,
-                             builder.getStringAttr(formatStrUnescaped),
-                             builder.getStringAttr(""));
+    builder.create<AssertOp>(clock, condition, constTrue, formatStrUnescaped,
+                             "");
     return success();
   }
   if (formatStringRef.startswith("assume:")) {
     APInt constOne(1, 1, false);
     auto constTrue =
         builder.create<ConstantOp>(UIntType::get(getContext(), 1), constOne);
-    builder.create<AssumeOp>(clock, condition, constTrue,
-                             builder.getStringAttr(formatStrUnescaped),
-                             builder.getStringAttr(""));
+    builder.create<AssumeOp>(clock, condition, constTrue, formatStrUnescaped,
+                             "");
     return success();
   }
 

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -181,6 +181,10 @@ struct FIRParser {
   /// if not, ignore it.
   ParseResult parseOptionalInfoLocator(LocationAttr &result);
 
+  /// Parse an optional name that may appear in Stop, Printf, or Verification
+  /// statements.
+  ParseResult parseOptionalName(StringAttr &name);
+
   //===--------------------------------------------------------------------===//
   // Annotation Parsing
   //===--------------------------------------------------------------------===//
@@ -544,6 +548,27 @@ ParseResult FIRParser::parseOptionalInfoLocator(LocationAttr &result) {
     std::reverse(extraLocs.begin(), extraLocs.end());
     result = FusedLoc::get(getContext(), extraLocs);
   }
+  return success();
+}
+
+/// Parse an optional trailing name that may show up on assert, assume, cover,
+/// stop, or printf.
+///
+/// optional_name ::= ( ':' id )?
+ParseResult FIRParser::parseOptionalName(StringAttr &name) {
+
+  if (getToken().isNot(FIRToken::colon)) {
+    name = StringAttr::get(getContext(), "");
+    return success();
+  }
+
+  consumeToken(FIRToken::colon);
+  StringRef nameRef;
+  if (parseId(nameRef, "expected result name"))
+    return failure();
+
+  name = StringAttr::get(getContext(), nameRef);
+
   return success();
 }
 
@@ -2285,6 +2310,10 @@ ParseResult FIRStmtParser::parsePrintf() {
       return failure();
   }
 
+  StringAttr name;
+  if (parseOptionalName(name))
+    return failure();
+
   if (parseOptionalInfo())
     return failure();
 
@@ -2297,7 +2326,8 @@ ParseResult FIRStmtParser::parsePrintf() {
     auto constTrue =
         builder.create<ConstantOp>(UIntType::get(getContext(), 1), constOne);
     builder.create<CoverOp>(clock, condition, constTrue,
-                            builder.getStringAttr(formatStrUnescaped));
+                            builder.getStringAttr(formatStrUnescaped),
+                            builder.getStringAttr(""));
     return success();
   }
   if (formatStringRef.startswith("assert:")) {
@@ -2305,7 +2335,8 @@ ParseResult FIRStmtParser::parsePrintf() {
     auto constTrue =
         builder.create<ConstantOp>(UIntType::get(getContext(), 1), constOne);
     builder.create<AssertOp>(clock, condition, constTrue,
-                             builder.getStringAttr(formatStrUnescaped));
+                             builder.getStringAttr(formatStrUnescaped),
+                             builder.getStringAttr(""));
     return success();
   }
   if (formatStringRef.startswith("assume:")) {
@@ -2313,12 +2344,14 @@ ParseResult FIRStmtParser::parsePrintf() {
     auto constTrue =
         builder.create<ConstantOp>(UIntType::get(getContext(), 1), constOne);
     builder.create<AssumeOp>(clock, condition, constTrue,
-                             builder.getStringAttr(formatStrUnescaped));
+                             builder.getStringAttr(formatStrUnescaped),
+                             builder.getStringAttr(""));
     return success();
   }
 
   builder.create<PrintFOp>(clock, condition,
-                           builder.getStringAttr(formatStrUnescaped), operands);
+                           builder.getStringAttr(formatStrUnescaped), operands,
+                           name);
   return success();
 }
 
@@ -2345,15 +2378,17 @@ ParseResult FIRStmtParser::parseStop() {
 
   Value clock, condition;
   int64_t exitCode;
+  StringAttr name;
   if (parseExp(clock, "expected clock expression in 'stop'") ||
       parseExp(condition, "expected condition in 'stop'") ||
       parseIntLit(exitCode, "expected exit code in 'stop'") ||
       parseToken(FIRToken::r_paren, "expected ')' in 'stop'") ||
-      parseOptionalInfo())
+      parseOptionalName(name) || parseOptionalInfo())
     return failure();
 
   locationProcessor.setLoc(startTok.getLoc());
-  builder.create<StopOp>(clock, condition, builder.getI32IntegerAttr(exitCode));
+  builder.create<StopOp>(clock, condition, builder.getI32IntegerAttr(exitCode),
+                         name);
   return success();
 }
 
@@ -2363,19 +2398,20 @@ ParseResult FIRStmtParser::parseAssert() {
 
   Value clock, predicate, enable;
   StringRef message;
+  StringAttr name;
   if (parseExp(clock, "expected clock expression in 'assert'") ||
       parseExp(predicate, "expected predicate in 'assert'") ||
       parseExp(enable, "expected enable in 'assert'") ||
       parseGetSpelling(message) ||
       parseToken(FIRToken::string, "expected message in 'assert'") ||
       parseToken(FIRToken::r_paren, "expected ')' in 'assert'") ||
-      parseOptionalInfo())
+      parseOptionalName(name) || parseOptionalInfo())
     return failure();
 
   locationProcessor.setLoc(startTok.getLoc());
   auto messageUnescaped = FIRToken::getStringValue(message);
   builder.create<AssertOp>(clock, predicate, enable,
-                           builder.getStringAttr(messageUnescaped));
+                           builder.getStringAttr(messageUnescaped), name);
   return success();
 }
 
@@ -2385,19 +2421,20 @@ ParseResult FIRStmtParser::parseAssume() {
 
   Value clock, predicate, enable;
   StringRef message;
+  StringAttr name;
   if (parseExp(clock, "expected clock expression in 'assume'") ||
       parseExp(predicate, "expected predicate in 'assume'") ||
       parseExp(enable, "expected enable in 'assume'") ||
       parseGetSpelling(message) ||
       parseToken(FIRToken::string, "expected message in 'assume'") ||
       parseToken(FIRToken::r_paren, "expected ')' in 'assume'") ||
-      parseOptionalInfo())
+      parseOptionalName(name) || parseOptionalInfo())
     return failure();
 
   locationProcessor.setLoc(startTok.getLoc());
   auto messageUnescaped = FIRToken::getStringValue(message);
   builder.create<AssumeOp>(clock, predicate, enable,
-                           builder.getStringAttr(messageUnescaped));
+                           builder.getStringAttr(messageUnescaped), name);
   return success();
 }
 
@@ -2407,19 +2444,20 @@ ParseResult FIRStmtParser::parseCover() {
 
   Value clock, predicate, enable;
   StringRef message;
+  StringAttr name;
   if (parseExp(clock, "expected clock expression in 'cover'") ||
       parseExp(predicate, "expected predicate in 'cover'") ||
       parseExp(enable, "expected enable in 'cover'") ||
       parseGetSpelling(message) ||
       parseToken(FIRToken::string, "expected message in 'cover'") ||
       parseToken(FIRToken::r_paren, "expected ')' in 'cover'") ||
-      parseOptionalInfo())
+      parseOptionalName(name) || parseOptionalInfo())
     return failure();
 
   locationProcessor.setLoc(startTok.getLoc());
   auto messageUnescaped = FIRToken::getStringValue(message);
   builder.create<CoverOp>(clock, predicate, enable,
-                          builder.getStringAttr(messageUnescaped));
+                          builder.getStringAttr(messageUnescaped), name);
   return success();
 }
 

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2291,7 +2291,7 @@ ParseResult FIRStmtParser::parseMemPort(MemDirAttr direction) {
                                       insertNameIntoGlobalScope);
 }
 
-/// printf ::= 'printf(' exp exp StringLit exp* ')' info?
+/// printf ::= 'printf(' exp exp StringLit exp* ')' name? info?
 ParseResult FIRStmtParser::parsePrintf() {
   auto startTok = consumeToken(FIRToken::lp_printf);
 

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -1030,6 +1030,30 @@ static LogicalResult verifyBindOp(BindOp op) {
 }
 
 //===----------------------------------------------------------------------===//
+// BindOp
+//===----------------------------------------------------------------------===//
+
+static ParseResult parseElideLabel(OpAsmParser &p, NamedAttrList &resultAttrs) {
+
+  auto result = p.parseOptionalAttrDict(resultAttrs);
+  if (!resultAttrs.get("label"))
+    resultAttrs.append("label", p.getBuilder().getStringAttr(""));
+
+  return result;
+}
+
+static void printElideLabel(OpAsmPrinter &p, Operation *op,
+                            DictionaryAttr attr) {
+
+  SmallVector<StringRef, 1> elides;
+  // Elide "label" if it is an empty string.
+  if (op->getAttrOfType<StringAttr>("label").getValue().empty())
+    elides.push_back("label");
+
+  p.printOptionalAttrDict(op->getAttrs(), elides);
+}
+
+//===----------------------------------------------------------------------===//
 // TableGen generated logic.
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -1033,7 +1033,8 @@ static LogicalResult verifyBindOp(BindOp op) {
 // Helpers to elide "label" attributes.
 //===----------------------------------------------------------------------===//
 
-static ParseResult parseElideLabel(OpAsmParser &p, NamedAttrList &resultAttrs) {
+static ParseResult parseElideEmptyLabel(OpAsmParser &p,
+                                        NamedAttrList &resultAttrs) {
 
   auto result = p.parseOptionalAttrDict(resultAttrs);
   if (!resultAttrs.get("label"))
@@ -1042,8 +1043,8 @@ static ParseResult parseElideLabel(OpAsmParser &p, NamedAttrList &resultAttrs) {
   return result;
 }
 
-static void printElideLabel(OpAsmPrinter &p, Operation *op,
-                            DictionaryAttr attr) {
+static void printElideEmptyLabel(OpAsmPrinter &p, Operation *op,
+                                 DictionaryAttr attr) {
 
   SmallVector<StringRef, 1> elides;
   // Elide "label" if it is an empty string.

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -1034,11 +1034,10 @@ static LogicalResult verifyBindOp(BindOp op) {
 //===----------------------------------------------------------------------===//
 
 static ParseResult parseOmitEmptyStringAttr(OpAsmParser &p, StringAttr &str) {
-  // TODO: There is no parseOptionalAttribute(StringAttr &foo, Type bar) API
-  // available for OpAsmParse.  Use of parseAttribute(StringAttr &foo, Type bar)
-  // does exist, but produces an opError during parsing.  This can be cleaned up
-  // to avoid using a dummy NamedAttrList (which will be thrown away) if such an
-  // API is added to MLIR.
+  // TODO: No OpAsmParser::parseOptionalAttribute(StringAttr &a, Type b) API
+  // exists.  OpAsmParser::parseAttribute(StringAttr &a, Type b) does exist, but
+  // produces an opError during parsing.  This should eventually be cleaned up
+  // to avoid the need to use a dummy attribute list.
   NamedAttrList dummy;
   p.parseOptionalAttribute(str, p.getBuilder().getType<mlir::NoneType>(),
                            "label", dummy);

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -1030,7 +1030,7 @@ static LogicalResult verifyBindOp(BindOp op) {
 }
 
 //===----------------------------------------------------------------------===//
-// BindOp
+// Helpers to elide "label" attributes.
 //===----------------------------------------------------------------------===//
 
 static ParseResult parseElideLabel(OpAsmParser &p, NamedAttrList &resultAttrs) {

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -2022,7 +2022,11 @@ LogicalResult StmtEmitter::visitSV(FinishOp op) {
 LogicalResult StmtEmitter::visitSV(AssertOp op) {
   SmallPtrSet<Operation *, 8> ops;
   ops.insert(op);
-  indent() << "assert(";
+  indent();
+  auto label = op.label();
+  if (!label.empty())
+    os << op.label() << ": ";
+  os << "assert(";
   emitExpression(op.predicate(), ops);
   os << ");";
   emitLocationInfoAndNewLine(ops);
@@ -2032,7 +2036,11 @@ LogicalResult StmtEmitter::visitSV(AssertOp op) {
 LogicalResult StmtEmitter::visitSV(AssumeOp op) {
   SmallPtrSet<Operation *, 8> ops;
   ops.insert(op);
-  indent() << "assume(";
+  indent();
+  auto label = op.label();
+  if (!label.empty())
+    os << label << ": ";
+  os << "assume(";
   emitExpression(op.property(), ops);
   os << ");";
   emitLocationInfoAndNewLine(ops);
@@ -2042,7 +2050,11 @@ LogicalResult StmtEmitter::visitSV(AssumeOp op) {
 LogicalResult StmtEmitter::visitSV(CoverOp op) {
   SmallPtrSet<Operation *, 8> ops;
   ops.insert(op);
-  indent() << "cover(";
+  indent();
+  auto label = op.label();
+  if (!label.empty())
+    os << op.label() << ": ";
+  os << "cover(";
   emitExpression(op.property(), ops);
   os << ");";
   emitLocationInfoAndNewLine(ops);

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -2025,7 +2025,7 @@ LogicalResult StmtEmitter::visitSV(AssertOp op) {
   indent();
   auto label = op.label();
   if (!label.empty())
-    os << op.label() << ": ";
+    os << label << ": ";
   os << "assert(";
   emitExpression(op.predicate(), ops);
   os << ");";
@@ -2053,7 +2053,7 @@ LogicalResult StmtEmitter::visitSV(CoverOp op) {
   indent();
   auto label = op.label();
   if (!label.empty())
-    os << op.label() << ": ";
+    os << label << ": ";
   os << "cover(";
   emitExpression(op.property(), ops);
   os << ");";

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -353,15 +353,15 @@ firrtl.circuit "Simple" {
     // CHECK-NEXT: sv.always posedge %clock {
     // CHECK-NEXT:   sv.if %aEn {
     // CHECK-NEXT:     sv.assert %aCond : i1
-    // CHECK-NEXT:     sv.assert {label = "assert_0"} %aCond : i1
+    // CHECK-NEXT:     sv.assert "assert_0" %aCond : i1
     // CHECK-NEXT:   }
     // CHECK-NEXT:   sv.if %bEn {
     // CHECK-NEXT:     sv.assume %bCond  : i1
-    // CHECK-NEXT:     sv.assume {label = "assume_0"} %bCond  : i1
+    // CHECK-NEXT:     sv.assume "assume_0" %bCond  : i1
     // CHECK-NEXT:   }
     // CHECK-NEXT:   sv.if %cEn {
     // CHECK-NEXT:     sv.cover %cCond : i1
-    // CHECK-NEXT:     sv.cover {label = "cover_0"} %cCond : i1
+    // CHECK-NEXT:     sv.cover "cover_0" %cCond : i1
     // CHECK-NEXT:   }
     // CHECK-NEXT: }
     firrtl.assert %clock, %aCond, %aEn, "assert0"

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -339,8 +339,11 @@ firrtl.circuit "Simple" {
 //     input cCond: UInt<1>
 //     input cEn: UInt<1>
 //     assert(clock, bCond, bEn, "assert0")
+//     assert(clock, bCond, bEn, "assert0") : assert_0
 //     assume(clock, aCond, aEn, "assume0")
-//     cover(clock,  cCond, cEn, "cover0")
+//     assume(clock, aCond, aEn, "assume0") : assume_0
+//     cover(clock,  cCond, cEn, "cover0)"
+//     cover(clock,  cCond, cEn, "cover0)" : cover_0
 
   // CHECK-LABEL: hw.module @Verification
   firrtl.module @Verification(in %clock: !firrtl.clock, in %aCond: !firrtl.uint<1>,
@@ -350,17 +353,23 @@ firrtl.circuit "Simple" {
     // CHECK-NEXT: sv.always posedge %clock {
     // CHECK-NEXT:   sv.if %aEn {
     // CHECK-NEXT:     sv.assert %aCond : i1
+    // CHECK-NEXT:     sv.assert {label = "assert_0"} %aCond : i1
     // CHECK-NEXT:   }
     // CHECK-NEXT:   sv.if %bEn {
     // CHECK-NEXT:     sv.assume %bCond  : i1
+    // CHECK-NEXT:     sv.assume {label = "assume_0"} %bCond  : i1
     // CHECK-NEXT:   }
     // CHECK-NEXT:   sv.if %cEn {
     // CHECK-NEXT:     sv.cover %cCond : i1
+    // CHECK-NEXT:     sv.cover {label = "cover_0"} %cCond : i1
     // CHECK-NEXT:   }
     // CHECK-NEXT: }
     firrtl.assert %clock, %aCond, %aEn, "assert0"
+    firrtl.assert %clock, %aCond, %aEn, "assert0" {name = "assert_0"}
     firrtl.assume %clock, %bCond, %bEn, "assume0"
+    firrtl.assume %clock, %bCond, %bEn, "assume0" {name = "assume_0"}
     firrtl.cover %clock, %cCond, %cEn, "cover0"
+    firrtl.cover %clock, %cCond, %cEn, "cover0" {name = "cover_0"}
     // CHECK-NEXT: hw.output
   }
 

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -252,11 +252,17 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     else :
       _t <= _t_2
 
-    ; CHECK: firrtl.printf %clock, %reset, "Something interesting!\0A %x %x"(%_t, %_t_2) : !firrtl.vector<uint<1>, 12>, !firrtl.vector<uint<1>, 12>
+    ; CHECK: firrtl.printf %clock, %reset, "Something interesting!\0A %x %x" (%_t, %_t_2) : !firrtl.vector<uint<1>, 12>, !firrtl.vector<uint<1>, 12>
     printf(clock, reset, "Something interesting!\n %x %x", _t, _t_2)
+
+    ; CHECK: firrtl.printf %clock, %reset, "Something interesting!\0A %x %x" {name = "printf_0"}(%_t, %_t_2) : !firrtl.vector<uint<1>, 12>, !firrtl.vector<uint<1>, 12>
+    printf(clock, reset, "Something interesting!\n %x %x", _t, _t_2) : printf_0
 
     ; CHECK: firrtl.stop %clock, %reset, 42
     stop(clock, reset, 42)
+
+    ; CHECK: firrtl.stop %clock, %reset, 42 {name = "stop_0"}
+    stop(clock, reset, 42) : stop_0
 
     ; CHECK: firrtl.bits %i8 4 to 2 : (!firrtl.uint<8>) -> !firrtl.uint<3>
     node n4 = bits(i8, 4, 2)
@@ -396,16 +402,22 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     en <= not(reset)
     ; CHECK: firrtl.assert %clock, %pred, %en, "X equals Y when Z is valid"
     assert(clock, pred, en, "X equals Y when Z is valid")
+    ; CHECK: firrtl.assert %clock, %pred, %en, "X equals Y when Z is valid" {name = "assert_0"}
+    assert(clock, pred, en, "X equals Y when Z is valid") : assert_0
     ; CHECK: [[C:%.+]] = firrtl.constant 1 : !firrtl.uint<1>
     ; CHECK-NEXT: firrtl.assert %clock, %pred, [[C]], "assert:X equals Y when Z is valid"
     printf(clock, pred, "assert:X equals Y when Z is valid")
     ; CHECK: firrtl.assume %clock, %pred, %en, "X equals Y when Z is valid"
     assume(clock, pred, en, "X equals Y when Z is valid")
+    ; CHECK: firrtl.assume %clock, %pred, %en, "X equals Y when Z is valid" {name = "assume_0"}
+    assume(clock, pred, en, "X equals Y when Z is valid") : assume_0
     ; CHECK: [[C2:%.+]] = firrtl.constant 1 : !firrtl.uint<1>
     ; CHECK-NEXT: firrtl.assume %clock, %pred, [[C2]], "assume:X equals Y when Z is valid"
     printf(clock, pred, "assume:X equals Y when Z is valid")
     ; CHECK: firrtl.cover %clock, %pred, %en, "X equals Y when Z is valid"
     cover(clock, pred, en, "X equals Y when Z is valid")
+    ; CHECK: firrtl.cover %clock, %pred, %en, "X equals Y when Z is valid" {name = "cover_0"}
+    cover(clock, pred, en, "X equals Y when Z is valid") : cover_0
     ; CHECK: [[C3:%.+]] = firrtl.constant 1 : !firrtl.uint<1>
     ; CHECK-NEXT: firrtl.cover %clock, %pred, [[C3]], "cover:X equals Y when Z is valid"
     printf(clock, pred, "cover:X equals Y when Z is valid")

--- a/test/ExportVerilog/sv-dialect.mlir
+++ b/test/ExportVerilog/sv-dialect.mlir
@@ -134,17 +134,17 @@ hw.module @M1(%clock : i1, %cond : i1, %val : i8) {
       // CHECK-NEXT:     assert(cond);
       sv.assert %cond : i1
       // CHECK-NEXT:     assert_0: assert(cond);
-      sv.assert {label = "assert_0"} %cond : i1
+      sv.assert "assert_0" %cond : i1
 
       // CHECK-NEXT:     assume(cond);
       sv.assume %cond : i1
       // CHECK-NEXT:     assume_0: assume(cond);
-      sv.assume {label = "assume_0"} %cond : i1
+      sv.assume "assume_0" %cond : i1
 
       // CHECK-NEXT:     cover(cond);
       sv.cover %cond : i1
       // CHECK-NEXT:     cover_0: cover(cond);
-      sv.cover {label = "cover_0"} %cond : i1
+      sv.cover "cover_0" %cond : i1
 
       // CHECK-NEXT:   $fatal
       sv.fatal

--- a/test/ExportVerilog/sv-dialect.mlir
+++ b/test/ExportVerilog/sv-dialect.mlir
@@ -133,10 +133,18 @@ hw.module @M1(%clock : i1, %cond : i1, %val : i8) {
 
       // CHECK-NEXT:     assert(cond);
       sv.assert %cond : i1
+      // CHECK-NEXT:     assert_0: assert(cond);
+      sv.assert {label = "assert_0"} %cond : i1
+
       // CHECK-NEXT:     assume(cond);
       sv.assume %cond : i1
+      // CHECK-NEXT:     assume_0: assume(cond);
+      sv.assume {label = "assume_0"} %cond : i1
+
       // CHECK-NEXT:     cover(cond);
       sv.cover %cond : i1
+      // CHECK-NEXT:     cover_0: cover(cond);
+      sv.cover {label = "cover_0"} %cond : i1
 
       // CHECK-NEXT:   $fatal
       sv.fatal


### PR DESCRIPTION
Add optional labels to the assert, assume, and cover SystemVerilog
operations.  Add optional labels to the assert, assume, cover, stop and
printf FIRRTL operations.

Flesh out lowering from these FIRRTL ops to their corresponding
SystemVerilog ops.  Emit the SystemVerilog ops as you'd expect for
assert, assume, and cover.  Names on stop and printf are dropped during
Verilog emission.

Labels/names are _optionally_ encoded using empty strings to represent
none.  This necessitates the proliferation of "custom<FooBar>"
directives in ODS.  This may be more cleanly handled (in ODS) with the
use of an "OptionalAttr<StrAttr>" or with upstream changes to MLIR to
better handle default-valued empty StrAttrs.

Fixes #1313.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

I originally used the `OptionalAttr<StrAttr>` approach because I didn't read @lattner's [comment on #1313](https://github.com/llvm/circt/issues/1313#issuecomment-866387949). 😅 If you want a direct comparison of the approaches, you can see the alternative approach on https://github.com/llvm/circt/compare/dev/seldridge/sv-labels-firrtl-names.