### PR TITLE
[SV] Add Concurrent Assertions ("assert property" and friends)

### DIFF
--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -547,6 +547,16 @@ def AssertConcurrentOp : ConcurrentAssertionOp<"assert.concurrent"> {
   }];
 }
 
+def AssumeConcurrentOp : ConcurrentAssertionOp<"assume.concurrent"> {
+  let summary = "concurrent assume statement, i.e., assume property";
+  let description = [{
+    Specify that a property is assumed to be true whenever the property is
+    evaluated.  This can be used to both document the behavior of the design and
+    to test that the design behaves as expected.  See section 16.5 of the
+    SystemVerilog 2017 specification.
+  }];
+}
+
 def BindOp : SVOp<"bind", []> {
   let summary = "indirect instantiation statement";
   let description = [{

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -527,6 +527,26 @@ def CoverOp : ImmediateAssertionOp<"cover", [ProceduralOp]> {
   }];
 }
 
+class ConcurrentAssertionOp<string mnemonic, list<OpTrait> traits = []> :
+    SVOp<mnemonic, traits> {
+  let arguments =
+    (ins EventControlAttr:$event, I1:$clock, I1:$property, StrAttr:$label);
+  let results = (outs);
+  let assemblyFormat =
+    "custom<OmitEmptyStringAttr>($label) $event $clock $property attr-dict `:`"
+    " type($property)";
+}
+
+def AssertConcurrentOp : ConcurrentAssertionOp<"assert.concurrent"> {
+  let summary = "concurrent assertion statement, i.e., assert property";
+  let description = [{
+    Specify that a property of the hardware design is true whenever the property
+    is evaluated.  This can be used to both document the behavior of the design
+    and to test that the design behaves as expected.  See section 16.5 of the
+    SystemVerilog 2017 specification.
+  }];
+}
+
 def BindOp : SVOp<"bind", []> {
   let summary = "indirect instantiation statement";
   let description = [{

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -557,6 +557,15 @@ def AssumeConcurrentOp : ConcurrentAssertionOp<"assume.concurrent"> {
   }];
 }
 
+def CoverConcurrentOp : ConcurrentAssertionOp<"cover.concurrent"> {
+  let summary = "concurrent cover statement, i.e., cover property";
+  let description = [{
+    Specify that a specific property should be monitored for coverage, i.e., a
+    simulation will watch if it occurrs and how many times it occurs.  See
+    section 16.5 of the SystemVerilog 2017 specification.
+  }];
+}
+
 def BindOp : SVOp<"bind", []> {
   let summary = "indirect instantiation statement";
   let description = [{

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -44,6 +44,7 @@ public:
             ReadInterfaceSignalOp,
             // Verification statements.
             AssertOp, AssumeOp, CoverOp, AssertConcurrentOp, AssumeConcurrentOp,
+            CoverConcurrentOp,
             // Bind Statements
             BindOp>([&](auto expr) -> ResultType {
           return thisCast->visitSV(expr, args...);
@@ -119,6 +120,7 @@ public:
   HANDLE(CoverOp, Unhandled);
   HANDLE(AssertConcurrentOp, Unhandled);
   HANDLE(AssumeConcurrentOp, Unhandled);
+  HANDLE(CoverConcurrentOp, Unhandled);
 
   // Bind statements.
   HANDLE(BindOp, Unhandled);

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -43,7 +43,7 @@ public:
             InterfaceInstanceOp, GetModportOp, AssignInterfaceSignalOp,
             ReadInterfaceSignalOp,
             // Verification statements.
-            AssertOp, AssumeOp, CoverOp,
+            AssertOp, AssumeOp, CoverOp, AssertConcurrentOp,
             // Bind Statements
             BindOp>([&](auto expr) -> ResultType {
           return thisCast->visitSV(expr, args...);
@@ -117,6 +117,7 @@ public:
   HANDLE(AssertOp, Unhandled);
   HANDLE(AssumeOp, Unhandled);
   HANDLE(CoverOp, Unhandled);
+  HANDLE(AssertConcurrentOp, Unhandled);
 
   // Bind statements.
   HANDLE(BindOp, Unhandled);

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -43,7 +43,7 @@ public:
             InterfaceInstanceOp, GetModportOp, AssignInterfaceSignalOp,
             ReadInterfaceSignalOp,
             // Verification statements.
-            AssertOp, AssumeOp, CoverOp, AssertConcurrentOp,
+            AssertOp, AssumeOp, CoverOp, AssertConcurrentOp, AssumeConcurrentOp,
             // Bind Statements
             BindOp>([&](auto expr) -> ResultType {
           return thisCast->visitSV(expr, args...);
@@ -118,6 +118,7 @@ public:
   HANDLE(AssumeOp, Unhandled);
   HANDLE(CoverOp, Unhandled);
   HANDLE(AssertConcurrentOp, Unhandled);
+  HANDLE(AssumeConcurrentOp, Unhandled);
 
   // Bind statements.
   HANDLE(BindOp, Unhandled);

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -1723,6 +1723,7 @@ private:
   LogicalResult visitSV(AssertOp op);
   LogicalResult visitSV(AssumeOp op);
   LogicalResult visitSV(CoverOp op);
+  LogicalResult visitSV(AssertConcurrentOp op);
   LogicalResult visitSV(InterfaceOp op);
   LogicalResult visitSV(InterfaceSignalOp op);
   LogicalResult visitSV(InterfaceModportOp op);
@@ -2050,6 +2051,21 @@ LogicalResult StmtEmitter::visitSV(AssumeOp op) {
 
 LogicalResult StmtEmitter::visitSV(CoverOp op) {
   return emitImmediateAssertion(op, "cover", op.label(), op.expression());
+}
+
+LogicalResult StmtEmitter::visitSV(AssertConcurrentOp op) {
+  SmallPtrSet<Operation *, 8> ops;
+  ops.insert(op);
+  auto label = op.label();
+  if (!label.empty())
+    os << op.label() << ": ";
+  os << "assert property (@(" << stringifyEventControl(op.event()) << " ";
+  emitExpression(op.clock(), ops);
+  os << ") ";
+  emitExpression(op.property(), ops);
+  os << ");";
+  emitLocationInfoAndNewLine(ops);
+  return success();
 }
 
 LogicalResult StmtEmitter::emitIfDef(Operation *op, StringRef cond) {

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -1724,6 +1724,7 @@ private:
   LogicalResult visitSV(AssumeOp op);
   LogicalResult visitSV(CoverOp op);
   LogicalResult visitSV(AssertConcurrentOp op);
+  LogicalResult visitSV(AssumeConcurrentOp op);
   LogicalResult visitSV(InterfaceOp op);
   LogicalResult visitSV(InterfaceSignalOp op);
   LogicalResult visitSV(InterfaceModportOp op);
@@ -2060,6 +2061,21 @@ LogicalResult StmtEmitter::visitSV(AssertConcurrentOp op) {
   if (!label.empty())
     os << op.label() << ": ";
   os << "assert property (@(" << stringifyEventControl(op.event()) << " ";
+  emitExpression(op.clock(), ops);
+  os << ") ";
+  emitExpression(op.property(), ops);
+  os << ");";
+  emitLocationInfoAndNewLine(ops);
+  return success();
+}
+
+LogicalResult StmtEmitter::visitSV(AssumeConcurrentOp op) {
+  SmallPtrSet<Operation *, 8> ops;
+  ops.insert(op);
+  auto label = op.label();
+  if (!label.empty())
+    os << op.label() << ": ";
+  os << "assume property (@(" << stringifyEventControl(op.event()) << " ";
   emitExpression(op.clock(), ops);
   os << ") ";
   emitExpression(op.property(), ops);

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -2077,15 +2077,18 @@ LogicalResult StmtEmitter::emitConcurrentAssertion(Operation *op, Twine name,
 }
 
 LogicalResult StmtEmitter::visitSV(AssertConcurrentOp op) {
-  return emitConcurrentAssertion(op, "assert", op.label(), op.event(), op.clock(), op.property());
+  return emitConcurrentAssertion(op, "assert", op.label(), op.event(),
+                                 op.clock(), op.property());
 }
 
 LogicalResult StmtEmitter::visitSV(AssumeConcurrentOp op) {
-  return emitConcurrentAssertion(op, "assume", op.label(), op.event(), op.clock(), op.property());
+  return emitConcurrentAssertion(op, "assume", op.label(), op.event(),
+                                 op.clock(), op.property());
 }
 
 LogicalResult StmtEmitter::visitSV(CoverConcurrentOp op) {
-  return emitConcurrentAssertion(op, "cover", op.label(), op.event(), op.clock(), op.property());
+  return emitConcurrentAssertion(op, "cover", op.label(), op.event(),
+                                 op.clock(), op.property());
 }
 
 LogicalResult StmtEmitter::emitIfDef(Operation *op, StringRef cond) {

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -1725,6 +1725,7 @@ private:
   LogicalResult visitSV(CoverOp op);
   LogicalResult visitSV(AssertConcurrentOp op);
   LogicalResult visitSV(AssumeConcurrentOp op);
+  LogicalResult visitSV(CoverConcurrentOp op);
   LogicalResult visitSV(InterfaceOp op);
   LogicalResult visitSV(InterfaceSignalOp op);
   LogicalResult visitSV(InterfaceModportOp op);
@@ -2076,6 +2077,21 @@ LogicalResult StmtEmitter::visitSV(AssumeConcurrentOp op) {
   if (!label.empty())
     os << op.label() << ": ";
   os << "assume property (@(" << stringifyEventControl(op.event()) << " ";
+  emitExpression(op.clock(), ops);
+  os << ") ";
+  emitExpression(op.property(), ops);
+  os << ");";
+  emitLocationInfoAndNewLine(ops);
+  return success();
+}
+
+LogicalResult StmtEmitter::visitSV(CoverConcurrentOp op) {
+  SmallPtrSet<Operation *, 8> ops;
+  ops.insert(op);
+  auto label = op.label();
+  if (!label.empty())
+    os << op.label() << ": ";
+  os << "cover property (@(" << stringifyEventControl(op.event()) << " ";
   emitExpression(op.clock(), ops);
   os << ") ";
   emitExpression(op.property(), ops);

--- a/test/ExportVerilog/sv-dialect.mlir
+++ b/test/ExportVerilog/sv-dialect.mlir
@@ -173,6 +173,11 @@ hw.module @M1(%clock : i1, %cond : i1, %val : i8) {
   // CHECK-NEXT: assert_1: assert property (@(posedge clock) cond);
   sv.assert.concurrent "assert_1" posedge %clock %cond : i1
 
+  // CHECK-NEXT: assume property (@(posedge clock) cond);
+  sv.assume.concurrent posedge %clock %cond : i1
+  // CHECK-NEXT: assume_1: assume property (@(posedge clock) cond);
+  sv.assume.concurrent "assume_1" posedge %clock %cond : i1
+
   // CHECK-NEXT: initial
   // CHECK-NOT: begin
   sv.initial {

--- a/test/ExportVerilog/sv-dialect.mlir
+++ b/test/ExportVerilog/sv-dialect.mlir
@@ -178,6 +178,11 @@ hw.module @M1(%clock : i1, %cond : i1, %val : i8) {
   // CHECK-NEXT: assume_1: assume property (@(posedge clock) cond);
   sv.assume.concurrent "assume_1" posedge %clock %cond : i1
 
+  // CHECK-NEXT: cover property (@(posedge clock) cond);
+  sv.cover.concurrent posedge %clock %cond : i1
+  // CHECK-NEXT: cover_1: cover property (@(posedge clock) cond);
+  sv.cover.concurrent "cover_1" posedge %clock %cond : i1
+
   // CHECK-NEXT: initial
   // CHECK-NOT: begin
   sv.initial {

--- a/test/ExportVerilog/sv-dialect.mlir
+++ b/test/ExportVerilog/sv-dialect.mlir
@@ -168,6 +168,10 @@ hw.module @M1(%clock : i1, %cond : i1, %val : i8) {
   }
   // CHECK-NEXT:  end // initial
 
+  // CHECK-NEXT: assert property (@(posedge clock) cond);
+  sv.assert.concurrent posedge %clock %cond : i1
+  // CHECK-NEXT: assert_1: assert property (@(posedge clock) cond);
+  sv.assert.concurrent "assert_1" posedge %clock %cond : i1
 
   // CHECK-NEXT: initial
   // CHECK-NOT: begin


### PR DESCRIPTION
Adds three new operations to the SystemVerilog dialect:

  - `sv.assert.concurrent` which maps to `assert property`
  - `sv.assume.concurrent` which maps to `assume property`
  - `sv.cover.concurrent` which maps to `cover property`

These are extremely simple versions that _are not modeling full-on properties_.  These act more like `always_ff` operations which will produce something like:

```verilog
optional_label : assert property(@(posedge clock) condition);
```

This is intended to be the minimal set of features necessary to actually emit `{assert, assume, cover} property` like a user would expect (and also meets the immediate needs of emitting SiFive SVA code).