### PR TITLE
[FIRRTL] Emit warning for unprocessed annotations on CircuitOp operation

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -320,6 +320,7 @@ void FIRRTLModuleLowering::runOnOperation() {
 
   SmallVector<FModuleOp, 32> modulesToProcess;
 
+  state.warnOnRemainingAnnotations(circuit, AnnotationSet(circuit));
   // Iterate through each operation in the circuit body, transforming any
   // FModule's we come across.
   for (auto &op : circuitBody->getOperations()) {

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
@@ -48,7 +48,8 @@ firrtl.circuit "unprocessedAnnotations" {
 
 // -----
 
-firrtl.circuit "moduleAnno" {
+// expected-warning @+1 {{unprocessed annotation:'circuitOpAnnotation'}}
+firrtl.circuit "moduleAnno" attributes {annotations = [{class = "circuitOpAnnotation"}]} {
   // expected-warning @+1 {{unprocessed annotation:'a'}}
   firrtl.module @moduleAnno(in %io_cpu_flush: !firrtl.uint<1> 
     {firrtl.annotations = [{class="a"}]}  ){  }


### PR DESCRIPTION
Add the warnings for unprocessed annotations on CircuitOp.