### PR TITLE
[PyCDE] Make systems feel more like modules

### DIFF
--- a/frontends/PyCDE/src/pycde/module.py
+++ b/frontends/PyCDE/src/pycde/module.py
@@ -448,6 +448,10 @@ class ModuleDefinition(hw.HWModuleOp):
   def __getattr__(self, name):
     if name in self.input_indices:
       index = self.input_indices[name]
-      return Value(self.entry_block.arguments[index],
-                   self.modcls._input_ports_lookup[name])
+      val = self.entry_block.arguments[index]
+      if self.modcls:
+        ty = self.modcls._input_ports_lookup[name]
+      else:
+        ty = support.type_to_pytype(val.type)
+      return Value(val, ty)
     raise AttributeError(f"unknown input port name {name}")

--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -3,6 +3,7 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from .types import types
+from .module import ModuleDefinition
 
 import mlir
 import mlir.ir
@@ -22,15 +23,19 @@ class System:
   passed = False
 
   def __init__(self):
+    if not hasattr(self, "name"):
+      self.name = "top"
+
     self.mod = mlir.ir.Module.create()
     self.get_types()
 
     with mlir.ir.InsertionPoint(self.mod.body):
       self.declare_externs()
-      hw.HWModuleOp(name='top',
-                    input_ports=self.inputs,
-                    output_ports=self.outputs,
-                    body_builder=self.build)
+      ModuleDefinition(modcls=None,
+                       name=self.name,
+                       input_ports=self.inputs,
+                       output_ports=self.outputs,
+                       body_builder=self.build)
 
   def declare_externs(self):
     pass


### PR DESCRIPTION
- Adds customized naming
- The body_builder 'mod' input ports now return PyCDE values