### PR TITLE
[Calyx] Add helper functions, other cleanup for upcoming CompileControl pass.

### DIFF
--- a/include/circt/Dialect/Calyx/Calyx.td
+++ b/include/circt/Dialect/Calyx/Calyx.td
@@ -65,15 +65,6 @@ class CalyxGroupPort<string mnemonic, list<OpTrait> traits = []> :
     I1:$src,
     Optional<I1>:$guard
   );
-  let results = (outs I1);
-  let builders = [
-    OpBuilder<(ins "Value":$src, CArg<"Value", "{}">:$guard), [{
-      $_state.addTypes($_builder.getI1Type());
-      $_state.addOperands(src);
-      if (guard)
-        $_state.addOperands(guard);
-    }]>
-  ];
   let assemblyFormat = "$src (`,` $guard^ `?`)? attr-dict `:` type($src)";
 }
 

--- a/include/circt/Dialect/Calyx/CalyxPasses.td
+++ b/include/circt/Dialect/Calyx/CalyxPasses.td
@@ -47,7 +47,7 @@ def GoInsertion : Pass<"calyx-go-insertion", "calyx::ComponentOp"> {
     }
     ```
   }];
-  let dependentDialects = ["comb::CombDialect", "hw::HWDialect"];
+  let dependentDialects = ["comb::CombDialect"];
   let constructor = "circt::calyx::createGoInsertionPass()";
 }
 

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -80,8 +80,11 @@ def ComponentOp : CalyxOp<"component", [
     ArrayAttr:$outPortNames
   );
   let results = (outs);
-
   let regions = (region SizedRegion<1>: $body);
+
+  let builders = [
+    OpBuilder<(ins "StringAttr":$name, "ArrayRef<ComponentPortInfo>":$ports)>
+  ];
 
   let extraClassDeclaration = [{
     // Necessary to avoid name clashing with `front`.
@@ -192,6 +195,12 @@ def GroupOp : CalyxOp<"group", [
   let extraClassDeclaration = [{
     // Implement RegionKindInterface.
     static RegionKind getRegionKind(unsigned index) { return RegionKind::Graph; }
+
+    /// Returns the GroupGoOp for this group.
+    GroupGoOp getGoOp();
+
+    /// Returns the GroupDoneOp for this group.
+    GroupDoneOp getDoneOp();
   }];
 
   let regions = (region SizedRegion<1>:$body);
@@ -243,10 +252,11 @@ def GroupDoneOp : CalyxGroupPort<"group_done", [
     when the group's done operation should be active.
 
     ```mlir
-      %0 = calyx.group_done %v1 : i1
-      %1 = calyx.group_done %v2, %guard ? : i1
+      calyx.group_done %v1 : i1
+      calyx.group_done %v2, %guard ? : i1
     ```
   }];
+  let results = (outs);
 }
 
 def GroupGoOp : CalyxGroupPort<"group_go", []> {
@@ -265,4 +275,13 @@ def GroupGoOp : CalyxGroupPort<"group_go", []> {
       %2 = calyx.group_go %3, %guard ? : i1
     ```
   }];
+  let results = (outs I1);
+  let builders = [
+    OpBuilder<(ins "Value":$src, CArg<"Value", "{}">:$guard), [{
+      $_state.addTypes($_builder.getI1Type());
+      $_state.addOperands(src);
+      if (guard)
+        $_state.addOperands(guard);
+    }]>
+  ];
 }

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -312,11 +312,10 @@ void ComponentOp::build(OpBuilder &builder, OperationState &result,
   }
 
   // Insert the WiresOp and ControlOp.
-  auto ip = builder.saveInsertionPoint();
+  IRRewriter::InsertionGuard guard(builder);
   builder.setInsertionPointToStart(block);
   builder.create<WiresOp>(result.location);
   builder.create<ControlOp>(result.location);
-  builder.restoreInsertionPoint(ip);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -271,6 +271,54 @@ static LogicalResult verifyComponentOp(ComponentOp op) {
                              "'calyx.wires', 'calyx.control'.";
 }
 
+void ComponentOp::build(OpBuilder &builder, OperationState &result,
+                        StringAttr name, ArrayRef<ComponentPortInfo> ports) {
+  using namespace mlir::function_like_impl;
+
+  result.addAttribute(::mlir::SymbolTable::getSymbolAttrName(), name);
+
+  SmallVector<Type, 4> inPortTypes, outPortTypes;
+  SmallVector<Attribute, 4> inPortNames, outPortNames;
+
+  for (auto &&port : ports) {
+    if (port.direction == PortDirection::INPUT) {
+      inPortTypes.push_back(port.type);
+      inPortNames.push_back(port.name);
+    } else {
+      outPortTypes.push_back(port.type);
+      outPortNames.push_back(port.name);
+    }
+  }
+
+  // Build the function type of the component.
+  auto functionType = builder.getFunctionType(inPortTypes, outPortTypes);
+  result.addAttribute(getTypeAttrName(), TypeAttr::get(functionType));
+
+  // Record the port names of the component.
+  result.addAttribute("inPortNames", builder.getArrayAttr(inPortNames));
+  result.addAttribute("outPortNames", builder.getArrayAttr(outPortNames));
+
+  // Create a single-blocked region.
+  result.addRegion();
+  Region *regionBody = result.regions[0].get();
+  Block *block = new Block();
+  regionBody->push_back(block);
+
+  // Add input ports to the body block.
+  for (auto port : ports) {
+    if (port.direction == PortDirection::OUTPUT)
+      continue;
+    block->addArgument(port.type);
+  }
+
+  // Insert the WiresOp and ControlOp.
+  auto ip = builder.saveInsertionPoint();
+  builder.setInsertionPointToStart(block);
+  builder.create<WiresOp>(result.location);
+  builder.create<ControlOp>(result.location);
+  builder.restoreInsertionPoint(ip);
+}
+
 //===----------------------------------------------------------------------===//
 // ControlOp
 //===----------------------------------------------------------------------===//
@@ -308,6 +356,20 @@ static LogicalResult verifyWiresOp(WiresOp wires) {
                               << " is unused in the control execution schedule";
   }
   return success();
+}
+
+//===----------------------------------------------------------------------===//
+// GroupOp
+//===----------------------------------------------------------------------===//
+GroupGoOp GroupOp::getGoOp() {
+  auto body = this->getBody();
+  auto opIt = body->getOps<GroupGoOp>().begin();
+  return *opIt;
+}
+
+GroupDoneOp GroupOp::getDoneOp() {
+  auto body = this->getBody();
+  return cast<GroupDoneOp>(body->getTerminator());
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Calyx/Transforms/GoInsertion.cpp
+++ b/lib/Dialect/Calyx/Transforms/GoInsertion.cpp
@@ -61,12 +61,12 @@ struct GoInsertionPass : public GoInsertionBase<GoInsertionPass> {
 
 void GoInsertionPass::runOnOperation() {
   ComponentOp component = getOperation();
-  OpBuilder builder(component->getRegion(0));
-
-  auto undefinedOp =
-      builder.create<UndefinedOp>(component->getLoc(), builder.getI1Type());
-
   auto wiresOp = component.getWiresOp();
+
+  OpBuilder builder(wiresOp->getRegion(0));
+  auto undefinedOp =
+      builder.create<UndefinedOp>(wiresOp->getLoc(), builder.getI1Type());
+
   wiresOp.walk([&](GroupOp group) {
     OpBuilder builder(group->getRegion(0));
     // Since the source of a GroupOp's go signal isn't set until the

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -119,7 +119,7 @@ calyx.program {
     calyx.wires {
       // expected-error @+1 {{'calyx.group' op with name: Group1 is unused in the control execution schedule}}
       calyx.group @Group1 {
-        %done = calyx.group_done %c1_1 : i1
+        calyx.group_done %c1_1 : i1
       }
     }
     calyx.control {}

--- a/test/Dialect/Calyx/go-insertion.mlir
+++ b/test/Dialect/Calyx/go-insertion.mlir
@@ -7,16 +7,15 @@ calyx.program {
   }
   calyx.component @main() -> () {
     %in, %out, %flag = calyx.cell "c0" @A : i8, i8, i1
-
-    // CHECK:       %1 = calyx.undef : i1
-    // CHECK-NEXT:  calyx.group @Group1 {
-    // CHECK-NEXT:    %2 = calyx.group_go %1 : i1
-    // CHECK-NEXT:    %3 = comb.and %0#2, %2 : i1
-    // CHECK-NEXT:    calyx.assign %0#0 = %0#1, %2 ? : i8
-    // CHECK-NEXT:    calyx.assign %0#0 = %0#1, %3 ? : i8
-    // CHECK-NEXT:    calyx.group_done %0#2 : i1
-    // CHECK-NEXT:  }
     calyx.wires {
+      // CHECK:       %1 = calyx.undef : i1
+      // CHECK-NEXT:  calyx.group @Group1 {
+      // CHECK-NEXT:    %2 = calyx.group_go %1 : i1
+      // CHECK-NEXT:    %3 = comb.and %0#2, %2 : i1
+      // CHECK-NEXT:    calyx.assign %0#0 = %0#1, %2 ? : i8
+      // CHECK-NEXT:    calyx.assign %0#0 = %0#1, %3 ? : i8
+      // CHECK-NEXT:    calyx.group_done %0#2 : i1
+      // CHECK-NEXT:  }
       calyx.group @Group1 {
         calyx.assign %in = %out : i8
         calyx.assign %in = %out, %flag ? : i8

--- a/test/Dialect/Calyx/go-insertion.mlir
+++ b/test/Dialect/Calyx/go-insertion.mlir
@@ -6,21 +6,21 @@ calyx.program {
     calyx.control {}
   }
   calyx.component @main() -> () {
-    // CHECK: %0 = calyx.undef : i1
     %in, %out, %flag = calyx.cell "c0" @A : i8, i8, i1
 
+    // CHECK:       %1 = calyx.undef : i1
+    // CHECK-NEXT:  calyx.group @Group1 {
+    // CHECK-NEXT:    %2 = calyx.group_go %1 : i1
+    // CHECK-NEXT:    %3 = comb.and %0#2, %2 : i1
+    // CHECK-NEXT:    calyx.assign %0#0 = %0#1, %2 ? : i8
+    // CHECK-NEXT:    calyx.assign %0#0 = %0#1, %3 ? : i8
+    // CHECK-NEXT:    calyx.group_done %0#2 : i1
+    // CHECK-NEXT:  }
     calyx.wires {
-      // CHECK-LABEL: calyx.group @Group1
-      // CHECK-NEXT:  %2 = calyx.group_go %0 : i1
-      // CHECK-NEXT:  %3 = comb.and %1#2, %2 : i1
-      // CHECK-NEXT:  calyx.assign %1#0 = %1#1, %2 ? : i8
-      // CHECK-NEXT:  calyx.assign %1#0 = %1#1, %3 ? : i8
-      // CHECK-NEXT:  %4 = calyx.group_done %1#2 : i1
-      // CHECK-NEXT:  }
       calyx.group @Group1 {
         calyx.assign %in = %out : i8
         calyx.assign %in = %out, %flag ? : i8
-        %done = calyx.group_done %flag : i1
+        calyx.group_done %flag : i1
       }
     }
     calyx.control {

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -49,17 +49,17 @@ calyx.program {
       // CHECK: calyx.group @Group1 {
       calyx.group @Group1 {
         // CHECK: calyx.assign %1#0 = %0#1 : i8
-        // CHECK-NEXT: %3 = calyx.group_done %true : i1
+        // CHECK-NEXT: calyx.group_done %true : i1
         calyx.assign %in2 = %out1 : i8
-        %d0 = calyx.group_done %c1_i1 : i1
+        calyx.group_done %c1_i1 : i1
       }
       calyx.group @Group2 {
         // CHECK:  calyx.assign %1#0 = %0#1, %2 ? : i8
         calyx.assign %in2 = %out1, %out3 ?  : i8
 
-        // CHECK: %4 = calyx.group_done %true, %3 ? : i1
+        // CHECK: calyx.group_done %true, %3 ? : i1
         %guard = comb.and %c1_i1, %out3 : i1
-        %d1 = calyx.group_done %c1_i1, %guard ? : i1
+        calyx.group_done %c1_i1, %guard ? : i1
       }
     }
     calyx.control {


### PR DESCRIPTION
- Removes HW dialect from GoInsertion pass; it is unused.
- Add a component builder that uses `ComponentPortInfo` to define ports.
- Add helper functions to access the GoOp and DoneOp of a group.
- In the `GoInsertion` pass, place the `calyx.undef` value in the `calyx.wires` section. This pattern will be similar for the `CompileControl` pass. Any values used for guarding assignments should remain within the `calyx.wires` section for debugging and readability.
- Remove the result from a GroupOp's terminator. As far as I can tell, this is unnecessary.