### PR TITLE
[FIRRTL] Code Cleanup for SubfieldOp, NFC

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
@@ -42,9 +42,8 @@ FieldRef circt::firrtl::getFieldRefFromValue(Value value) {
     if (auto subfieldOp = dyn_cast<SubfieldOp>(op)) {
       value = subfieldOp.input();
       auto bundleType = value.getType().cast<BundleType>();
-      auto index = subfieldOp.fieldIndex();
       // Rebase the current index on the parent field's index.
-      id += bundleType.getFieldID(index);
+      id += bundleType.getFieldID(subfieldOp.fieldIndex());
     } else if (auto subindexOp = dyn_cast<SubindexOp>(op)) {
       auto vecType = subindexOp.input().getType().cast<FVectorType>();
       // Rebase the current index on the parent field's index.

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1547,9 +1547,8 @@ FIRRTLType SubfieldOp::inferReturnType(ValueRange operands,
 }
 
 bool SubfieldOp::isFieldFlipped() {
-  auto fieldIndex = this->fieldIndex();
   auto bundle = input().getType().cast<BundleType>();
-  return bundle.getElement(fieldIndex).isFlip;
+  return bundle.getElement(fieldIndex()).isFlip;
 }
 
 FIRRTLType SubindexOp::inferReturnType(ValueRange operands,


### PR DESCRIPTION
Inline `fieldIndex()` in `FIRRTLDialect.cpp` and `FIRRTLOps.cpp` .
This is a cleanup related to 6fe0463eac523f15f7a2b954c2a46663fc9c4c40