### PR TITLE
[FIRRTL] Fix GCT Data Taps for ExtModule Sources

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
@@ -209,13 +209,13 @@ public:
                                 llvm::function_ref<bool(Annotation)> predicate);
   static bool removeAnnotations(Operation *op, StringRef className);
 
-  /// Remove all port annotations from a module for which `predicate` returns
-  /// true. The predicate is guaranteed to be called on every annotation, such
-  /// that this method can be used to partition a module's port annotations by
-  /// extracting and removing annotations at the same time. Returns true if any
-  /// annotations were removed, false otherwise.
+  /// Remove all port annotations from a module or extmodule for which
+  /// `predicate` returns true. The predicate is guaranteed to be called on
+  /// every annotation, such that this method can be used to partition a
+  /// module's port annotations by extracting and removing annotations at the
+  /// same time. Returns true if any annotations were removed, false otherwise.
   static bool removePortAnnotations(
-      FModuleOp module,
+      Operation *module,
       llvm::function_ref<bool(unsigned, Annotation)> predicate);
 
 private:

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
@@ -362,19 +362,20 @@ bool AnnotationSet::removeAnnotations(Operation *op, StringRef className) {
       op, [&](Annotation a) { return (a.getClass() == className); });
 }
 
-/// Remove all port annotations from a module for which `predicate` returns
-/// true.
+/// Remove all port annotations from a module or extmodule for which `predicate`
+/// returns true.
 bool AnnotationSet::removePortAnnotations(
-    FModuleOp module,
+    Operation *module,
     llvm::function_ref<bool(unsigned, Annotation)> predicate) {
   // We need to reserve some space to gather the remaining attributes, without
   // the removed ones.
   SmallVector<DictionaryAttr, 8> filteredArgAttrs;
-  filteredArgAttrs.reserve(module.getNumArguments());
+  FunctionType moduleF = mlir::function_like_impl::getFunctionType(module);
+  filteredArgAttrs.reserve(moduleF.getNumInputs());
 
   // Filter the annotations on each argument.
   bool changed = false;
-  for (unsigned argNum = 0, argNumEnd = module.getNumArguments();
+  for (unsigned argNum = 0, argNumEnd = moduleF.getNumInputs();
        argNum < argNumEnd; ++argNum) {
     auto annos = AnnotationSet::forPort(module, argNum);
 

--- a/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
@@ -737,6 +737,7 @@ bool circt::firrtl::scatterCustomAnnotations(
               source, maybeSourceTarget.getValue(), context);
           if (targetPair.second.hasValue())
             appendTarget(dontTouchAnn, targetPair.second.getValue());
+          source.append("type", StringAttr::get(context, "source"));
           newAnnotations[targetPair.first].push_back(
               DictionaryAttr::getWithSorted(context, source));
           newAnnotations[targetPair.first].push_back(
@@ -744,6 +745,7 @@ bool circt::firrtl::scatterCustomAnnotations(
           if (targetPair.second.hasValue())
             dontTouchAnn.pop_back();
           port.append("portID", portID);
+          port.append("type", StringAttr::get(context, "portName"));
           newAnnotations[portTarget.getValue()].push_back(
               DictionaryAttr::getWithSorted(context, port));
           newAnnotations[portTarget.getValue()].push_back(

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -22,6 +22,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/TinyPtrVector.h"
+#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/FormatVariadic.h"
@@ -49,6 +50,23 @@ public:
   }
 };
 } // end namespace llvm
+
+//===----------------------------------------------------------------------===//
+// Static class names
+//===----------------------------------------------------------------------===//
+
+static constexpr const char *dataTapsClass =
+    "sifive.enterprise.grandcentral.DataTapsAnnotation";
+static constexpr const char *memTapClass =
+    "sifive.enterprise.grandcentral.MemTapAnnotation";
+static constexpr const char *deletedKeyClass =
+    "sifive.enterprise.grandcentral.DeletedDataTapKey";
+static constexpr const char *literalKeyClass =
+    "sifive.enterprise.grandcentral.LiteralDataTapKey";
+static constexpr const char *referenceKeyClass =
+    "sifive.enterprise.grandcentral.ReferenceDataTapKey";
+static constexpr const char *internalKeyClass =
+    "sifive.enterprise.grandcentral.DataTapModuleSignalKey";
 
 //===----------------------------------------------------------------------===//
 // Utilities
@@ -174,22 +192,49 @@ static InstancePath stripCommonPrefix(InstancePath path, InstancePath other) {
   return path;
 }
 
-//===----------------------------------------------------------------------===//
-// Static class names
-//===----------------------------------------------------------------------===//
+/// A reference data tap key, identified by the annotation id and port id.
+using Key = std::pair<Attribute, Attribute>;
 
-static constexpr const char *dataTapsClass =
-    "sifive.enterprise.grandcentral.DataTapsAnnotation";
-static constexpr const char *memTapClass =
-    "sifive.enterprise.grandcentral.MemTapAnnotation";
-static constexpr const char *deletedKeyClass =
-    "sifive.enterprise.grandcentral.DeletedDataTapKey";
-static constexpr const char *literalKeyClass =
-    "sifive.enterprise.grandcentral.LiteralDataTapKey";
-static constexpr const char *referenceKeyClass =
-    "sifive.enterprise.grandcentral.ReferenceDataTapKey";
-static constexpr const char *internalKeyClass =
-    "sifive.enterprise.grandcentral.DataTapModuleSignalKey";
+/// A tapped port, described as the module/extmodule operation and the port
+/// number.
+struct Port : std::pair<Operation *, unsigned> {
+  using std::pair<Operation *, unsigned>::pair;
+  operator bool() const { return bool(first); }
+};
+
+// Allow printing of `Key` through `<<`.
+template <typename T>
+static T &operator<<(T &os, Key key) {
+  return os << "[" << key.first << ", " << key.second << "]";
+}
+
+/// Check if an annotation is a `ReferenceDataTapKey`, and that it has a `type`
+/// field with a given content.
+static bool isReferenceDataTapOfType(Annotation anno, StringRef type) {
+  if (!anno.isClass(referenceKeyClass))
+    return false;
+  auto typeAttr = anno.getMember<StringAttr>("type");
+  if (!typeAttr)
+    return false;
+  return typeAttr.getValue() == type;
+}
+
+/// Check if an annotation is a `ReferenceDataTapKey` with `source` type.
+static bool isReferenceDataTapSource(Annotation anno) {
+  return isReferenceDataTapOfType(anno, "source");
+}
+
+/// Check if an annotation is a `ReferenceDataTapKey` with `portName` type.
+static bool isReferenceDataTapPortName(Annotation anno) {
+  return isReferenceDataTapOfType(anno, "portName");
+}
+
+/// Map an annotation to a `Key`.
+static Key getKey(Annotation anno) {
+  auto id = anno.getMember("id");
+  auto portID = anno.getMember("portID");
+  return {id, portID};
+}
 
 //===----------------------------------------------------------------------===//
 // Pass Infrastructure
@@ -201,9 +246,18 @@ class GrandCentralTapsPass : public GrandCentralTapsBase<GrandCentralTapsPass> {
   void processAnnotation(AnnotatedPort &portAnno, AnnotatedExtModule &blackBox,
                          InstancePaths &instancePaths);
 
-private:
-  DenseMap<Attribute, BlockArgument> tappedArgs;
-  DenseMap<Attribute, Operation *> tappedOps;
+  // Helpers to simplify collecting taps on the various things.
+  void gatherTap(Annotation anno, Port port) {
+    auto it = tappedPorts.insert({getKey(anno), port});
+    assert(it.second && "ambiguous tap annotation");
+  }
+  void gatherTap(Annotation anno, Operation *op) {
+    auto it = tappedOps.insert({getKey(anno), op});
+    assert(it.second && "ambiguous tap annotation");
+  }
+
+  DenseMap<Key, Operation *> tappedOps;
+  DenseMap<Key, Port> tappedPorts;
   SmallDenseMap<Attribute, unsigned, 2> memPortIdx;
   SmallVector<PortWiring, 8> portWiring;
 };
@@ -256,7 +310,8 @@ void GrandCentralTapsPass::runOnOperation() {
       auto annos = AnnotationSet::forPort(extModule, argNum);
       annos.removeAnnotations([&](Annotation anno) {
         if (anno.isClass(memTapClass, deletedKeyClass, literalKeyClass,
-                         referenceKeyClass, internalKeyClass)) {
+                         internalKeyClass) ||
+            isReferenceDataTapPortName(anno)) {
           result.portAnnos.push_back({argNum, anno});
           return true;
         }
@@ -276,12 +331,12 @@ void GrandCentralTapsPass::runOnOperation() {
       modules.push_back(std::move(result));
   }
 
-#ifndef NDEBUG
-  for (auto m : modules) {
-    LLVM_DEBUG(llvm::dbgs() << "Extmodule " << m.extModule.getName() << " has "
-                            << m.portAnnos.size() << " port annotations\n");
-  }
-#endif
+  LLVM_DEBUG({
+    for (auto m : modules) {
+      llvm::dbgs() << "Extmodule " << m.extModule.getName() << " has "
+                   << m.portAnnos.size() << " port annotations\n";
+    }
+  });
 
   // Fast path if there's nothing to do.
   if (modules.empty()) {
@@ -294,31 +349,33 @@ void GrandCentralTapsPass::runOnOperation() {
 
   // Gather the annotated ports and operations throughout the design that we are
   // supposed to tap in one way or another.
-  tappedArgs.clear();
+  tappedPorts.clear();
   tappedOps.clear();
   circuitOp.walk([&](Operation *op) { gatherAnnotations(op); });
 
-#ifndef NDEBUG
-  LLVM_DEBUG(llvm::dbgs() << "Tapped values:\n");
-  for (auto it : tappedArgs)
-    LLVM_DEBUG(llvm::dbgs() << "- " << it.first << ": " << it.second << "\n");
-  LLVM_DEBUG(llvm::dbgs() << "Tapped ops:\n");
-  for (auto it : tappedOps)
-    LLVM_DEBUG(llvm::dbgs() << "- " << it.first << ": " << *it.second << "\n");
-#endif
+  LLVM_DEBUG({
+    llvm::dbgs() << "Tapped ports:\n";
+    for (auto it : tappedPorts)
+      llvm::dbgs() << "- " << it.first << ": "
+                   << it.second.first->getAttr("sym_name") << " port #"
+                   << it.second.second << "\n";
+    llvm::dbgs() << "Tapped ops:\n";
+    for (auto it : tappedOps)
+      llvm::dbgs() << "- " << it.first << ": " << *it.second << "\n";
+  });
 
   // Process each black box independently.
   for (auto blackBox : modules) {
     LLVM_DEBUG(llvm::dbgs() << "Generating impls for "
                             << blackBox.extModule.getName() << "\n");
 
-    // As a first step, gather a list of all absolute paths to instances of this
-    // black box.
+    // As a first step, gather a list of all absolute paths to instances of
+    // this black box.
     auto paths = instancePaths.getAbsolutePaths(blackBox.extModule);
-#ifndef NDEBUG
-    for (auto path : paths)
-      LLVM_DEBUG(llvm::dbgs() << "- " << path << "\n");
-#endif
+    LLVM_DEBUG({
+      for (auto path : paths)
+        llvm::dbgs() << "- " << path << "\n";
+    });
 
     // Go through the port annotations of the tap module and generate a
     // hierarchical path for each.
@@ -328,25 +385,25 @@ void GrandCentralTapsPass::runOnOperation() {
       processAnnotation(portAnno, blackBox, instancePaths);
     }
 
-#ifndef NDEBUG
-    LLVM_DEBUG(llvm::dbgs() << "- Wire up as follows:\n");
-    for (auto wiring : portWiring) {
-      LLVM_DEBUG(llvm::dbgs() << "- Port " << wiring.portNum << ":\n");
-      for (auto path : wiring.prefices) {
-        LLVM_DEBUG(llvm::dbgs()
-                   << "  - " << path << "." << wiring.suffix << "\n");
+    LLVM_DEBUG({
+      llvm::dbgs() << "- Wire up as follows:\n";
+      for (auto wiring : portWiring) {
+        llvm::dbgs() << "- Port " << wiring.portNum << ":\n";
+        for (auto path : wiring.prefices) {
+          llvm::dbgs() << "  - " << path << "." << wiring.suffix << "\n";
+        }
       }
-    }
-#endif
+    });
 
-    // Now we have an awkward mapping problem. We have multiple data tap module
-    // instances, which reference things in modules that in turn have multiple
-    // instances. This is a side-effect of how Grand Central annotates things on
-    // modules rather than instances. (However in practice these will have a
-    // one-to-one correspondence due to CHIRRTL having fully uniquified
-    // instances.) To solve this issue, create a dedicated implementation for
-    // every data tap instance, and among the possible targets for the data taps
-    // choose the one with the shortest relative path to the data tap instance.
+    // Now we have an awkward mapping problem. We have multiple data tap
+    // module instances, which reference things in modules that in turn have
+    // multiple instances. This is a side-effect of how Grand Central
+    // annotates things on modules rather than instances. (However in practice
+    // these will have a one-to-one correspondence due to CHIRRTL having fully
+    // uniquified instances.) To solve this issue, create a dedicated
+    // implementation for every data tap instance, and among the possible
+    // targets for the data taps choose the one with the shortest relative
+    // path to the data tap instance.
     ImplicitLocOpBuilder builder(blackBox.extModule->getLoc(),
                                  blackBox.extModule);
     unsigned implIdx = 0;
@@ -409,10 +466,11 @@ void GrandCentralTapsPass::runOnOperation() {
         builder.create<ConnectOp>(arg, hnameExpr);
       }
 
-      // Switch the instance from the original extmodule to this implementation.
-      // CAVEAT: If the same black box data tap module is instantiated in a
-      // parent module that itself is instantiated in different locations, this
-      // will pretty arbitrarily pick one of those locations.
+      // Switch the instance from the original extmodule to this
+      // implementation. CAVEAT: If the same black box data tap module is
+      // instantiated in a parent module that itself is instantiated in
+      // different locations, this will pretty arbitrarily pick one of those
+      // locations.
       path.back()->setAttr("moduleName",
                            builder.getSymbolRefAttr(name.getValue()));
     }
@@ -422,39 +480,46 @@ void GrandCentralTapsPass::runOnOperation() {
   }
 }
 
-/// Gather the annotations on ports and operations into the `tappedOps` and
-/// `tappedArgs` maps.
+/// Gather the annotations on ports and operations into the `tappedPorts` and
+/// `tappedOps` maps.
 void GrandCentralTapsPass::gatherAnnotations(Operation *op) {
-  if (auto module = dyn_cast<FModuleOp>(op)) {
-    AnnotationSet::removePortAnnotations(
-        module, [&](unsigned argNum, Annotation anno) {
-          if (anno.isClass(referenceKeyClass)) {
-            auto it =
-                tappedArgs.insert({anno.getDict(), module.getArgument(argNum)});
-            assert(it.second && "ambiguous tap annotation");
-            return true;
-          }
-          return false;
-        });
-  } else {
-    AnnotationSet annos(op);
-    if (annos.empty())
-      return;
-
-    // Go through all annotations on this op and extract the interesting ones.
-    // Note that the way tap annotations are scattered to their targets, we
-    // should never see multiple values or memories annotated with the exact
-    // same annotation (hence the asserts).
-    annos.removeAnnotations([&](Annotation anno) {
-      if (anno.isClass(memTapClass, referenceKeyClass, internalKeyClass)) {
-        auto it = tappedOps.insert({anno.getDict(), op});
-        assert(it.second && "ambiguous tap annotation");
+  if (isa<FModuleOp, FExtModuleOp>(op)) {
+    // Handle port annotations on module/extmodule ops.
+    auto gather = [&](unsigned argNum, Annotation anno) {
+      if (isReferenceDataTapSource(anno)) {
+        gatherTap(anno, Port{op, argNum});
         return true;
       }
       return false;
-    });
-    annos.applyToOperation(op);
+    };
+    AnnotationSet::removePortAnnotations(op, gather);
+
+    // Handle internal data taps on extmodule ops.
+    if (isa<FExtModuleOp>(op)) {
+      auto gather = [&](Annotation anno) {
+        if (anno.isClass(internalKeyClass)) {
+          gatherTap(anno, op);
+          return true;
+        }
+        return false;
+      };
+      AnnotationSet::removeAnnotations(op, gather);
+    }
+
+    return;
   }
+
+  // Go through all annotations on this op and extract the interesting
+  // ones. Note that the way tap annotations are scattered to their
+  // targets, we should never see multiple values or memories annotated
+  // with the exact same annotation (hence the asserts).
+  AnnotationSet::removeAnnotations(op, [&](Annotation anno) {
+    if (anno.isClass(memTapClass) || isReferenceDataTapSource(anno)) {
+      gatherTap(anno, op);
+      return true;
+    }
+    return false;
+  });
 }
 
 void GrandCentralTapsPass::processAnnotation(AnnotatedPort &portAnno,
@@ -462,23 +527,22 @@ void GrandCentralTapsPass::processAnnotation(AnnotatedPort &portAnno,
                                              InstancePaths &instancePaths) {
   LLVM_DEBUG(llvm::dbgs() << "- Processing port " << portAnno.portNum
                           << " anno " << portAnno.anno.getDict() << "\n");
+  auto key = getKey(portAnno.anno);
   auto portName = getModulePortName(blackBox.extModule, portAnno.portNum);
   PortWiring wiring = {portAnno.portNum, {}, {}};
 
   // Handle data taps on signals and ports.
   if (portAnno.anno.isClass(referenceKeyClass)) {
-    // Handle block arguments.
-    if (auto blockArg = tappedArgs.lookup(portAnno.anno.getDict())) {
-      auto parentModule = blockArg.getOwner()->getParentOp();
-      wiring.prefices = instancePaths.getAbsolutePaths(parentModule);
-      wiring.suffix =
-          getModulePortName(parentModule, blockArg.getArgNumber()).getValue();
+    // Handle ports.
+    if (auto port = tappedPorts.lookup(key)) {
+      wiring.prefices = instancePaths.getAbsolutePaths(port.first);
+      wiring.suffix = getModulePortName(port.first, port.second).getValue();
       portWiring.push_back(std::move(wiring));
       return;
     }
 
     // Handle operations.
-    if (auto op = tappedOps.lookup(portAnno.anno.getDict())) {
+    if (auto op = tappedOps.lookup(key)) {
       // We require the target to be a wire or node, such that it gets a name
       // during Verilog emission.
       if (!isa<WireOp, NodeOp, RegOp, RegResetOp>(op)) {
@@ -523,7 +587,7 @@ void GrandCentralTapsPass::processAnnotation(AnnotatedPort &portAnno,
 
   // Handle data taps on black boxes.
   if (portAnno.anno.isClass(internalKeyClass)) {
-    auto op = tappedOps.lookup(portAnno.anno.getDict());
+    auto op = tappedOps.lookup(key);
     if (!op) {
       blackBox.extModule.emitOpError(
           "DataTapModuleSignalKey annotation was not scattered to "
@@ -559,7 +623,7 @@ void GrandCentralTapsPass::processAnnotation(AnnotatedPort &portAnno,
 
   // Handle memory taps.
   if (portAnno.anno.isClass(memTapClass)) {
-    auto op = tappedOps.lookup(portAnno.anno.getDict());
+    auto op = tappedOps.lookup(key);
     if (!op) {
       blackBox.extModule.emitOpError(
           "MemTapAnnotation annotation was not scattered to "

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -460,8 +460,8 @@ circuit GCTDataTap : %[
     ; CHECK-LABEL: firrtl.circuit "GCTDataTap"
     ; CHECK-SAME: annotations = [{unrelatedAnnotation}]
     ; CHECK: firrtl.extmodule @DataTap
-    ; CHECK-SAME: %_0: !firrtl.uint<1> {firrtl.annotations = [{class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = [[ID:[0-9]+]] : i64, portID = [[PORT_ID_0:[0-9]+]] : i64}, {class = "firrtl.transforms.DontTouchAnnotation"}]},
-    ; CHECK-SAME: %_1: !firrtl.uint<1> {firrtl.annotations = [{class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = [[PORT_ID_1:[0-9]+]] : i64}, {class = "firrtl.transforms.DontTouchAnnotation"}]},
+    ; CHECK-SAME: %_0: !firrtl.uint<1> {firrtl.annotations = [{class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = [[ID:[0-9]+]] : i64, portID = [[PORT_ID_0:[0-9]+]] : i64, type = "portName"}, {class = "firrtl.transforms.DontTouchAnnotation"}]},
+    ; CHECK-SAME: %_1: !firrtl.uint<1> {firrtl.annotations = [{class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = [[PORT_ID_1:[0-9]+]] : i64, type = "portName"}, {class = "firrtl.transforms.DontTouchAnnotation"}]},
     ; CHECK-SAME: %_2: {{.+}} {firrtl.annotations = [{class = "sifive.enterprise.grandcentral.DataTapModuleSignalKey", id = [[ID]] : i64}, {class = "firrtl.transforms.DontTouchAnnotation"}]},
     ; CHECK-SAME: %_3: {{.+}} {firrtl.annotations = [{class = "sifive.enterprise.grandcentral.DeletedDataTapKey", id = [[ID]] : i64}, {class = "firrtl.transforms.DontTouchAnnotation"}]},
     ; CHECK-SAME: %_4: {{.+}} {firrtl.annotations = [{class = "sifive.enterprise.grandcentral.LiteralDataTapKey", literal = "UInt<16>(\22h2a\22)"}, {class = "firrtl.transforms.DontTouchAnnotation"}]}
@@ -472,10 +472,10 @@ circuit GCTDataTap : %[
 
     ; CHECK: firrtl.module @GCTDataTap
     ; CHECK: firrtl.reg
-    ; CHECk-SAME: annotations = [{class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = [[ID]] : i64, portID = [[PORT_ID_0]] : i64}, {class = "firrtl.transforms.DontTouchAnnotation"}]
+    ; CHECk-SAME: annotations = [{class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = [[ID]] : i64, portID = [[PORT_ID_0]] : i64, type = "source"}, {class = "firrtl.transforms.DontTouchAnnotation"}]
 
     ; CHECK: firrtl.wire
-    ; CHECK-SAME: annotations = [#firrtl.subAnno<fieldID = [1, 1], {class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = [[ID]] : i64, portID = [[PORT_ID_1]] : i64}>, #firrtl.subAnno<fieldID = [1, 1], {class = "firrtl.transforms.DontTouchAnnotation"}>]}
+    ; CHECK-SAME: annotations = [#firrtl.subAnno<fieldID = [1, 1], {class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = [[ID]] : i64, portID = [[PORT_ID_1]] : i64, type = "source"}>, #firrtl.subAnno<fieldID = [1, 1], {class = "firrtl.transforms.DontTouchAnnotation"}>]}
 
 ; // -----
 

--- a/test/Dialect/FIRRTL/grand-central-taps.mlir
+++ b/test/Dialect/FIRRTL/grand-central-taps.mlir
@@ -13,12 +13,14 @@ firrtl.circuit "TestHarness" attributes {
     in %clock: !firrtl.clock {firrtl.annotations = [{
       class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
       id = 0 : i64,
-      portID = 2 : i64
+      portID = 2 : i64,
+      type = "source"
     }]},
     in %reset: !firrtl.reset {firrtl.annotations = [{
       class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
       id = 0 : i64,
-      portID = 3 : i64
+      portID = 3 : i64,
+      type = "source"
     }]},
     in %in: !firrtl.uint<1>,
     out %out: !firrtl.uint<1>
@@ -29,7 +31,8 @@ firrtl.circuit "TestHarness" attributes {
     %wire = firrtl.wire {annotations = [{
       class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
       id = 0 : i64,
-      portID = 1 : i64
+      portID = 1 : i64,
+      type = "source"
     }, {
       class = "firrtl.transforms.DontTouchAnnotation"
     }]} : !firrtl.uint<1>
@@ -40,7 +43,8 @@ firrtl.circuit "TestHarness" attributes {
     %node = firrtl.node %in {annotations = [{
       class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
       id = 0 : i64,
-      portID = 5 : i64
+      portID = 5 : i64,
+      type = "source"
     }, {
       class = "firrtl.transforms.DontTouchAnnotation"
     }]} : !firrtl.uint<1>
@@ -51,7 +55,8 @@ firrtl.circuit "TestHarness" attributes {
     %reg = firrtl.reg %clock {annotations = [{
       class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
       id = 0 : i64,
-      portID = 6 : i64
+      portID = 6 : i64,
+      type = "source"
     }, {
       class = "firrtl.transforms.DontTouchAnnotation"
     }]} : (!firrtl.clock) -> !firrtl.uint<1>
@@ -62,7 +67,8 @@ firrtl.circuit "TestHarness" attributes {
     %regreset = firrtl.regreset %clock, %reset, %in {annotations = [{
       class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
       id = 0 : i64,
-      portID = 7 : i64
+      portID = 7 : i64,
+      type = "source"
     }, {
       class = "firrtl.transforms.DontTouchAnnotation"
     }]} : (!firrtl.clock, !firrtl.reset, !firrtl.uint<1>) -> !firrtl.uint<1>
@@ -109,6 +115,7 @@ firrtl.circuit "TestHarness" attributes {
   }
 
   // CHECK: firrtl.module [[DT:@DataTap.*]](
+  // CHECK-SAME: out %_7: !firrtl.uint<1>
   // CHECK-SAME: out %_6: !firrtl.uint<1>
   // CHECK-SAME: out %_5: !firrtl.uint<1>
   // CHECK-SAME: out %_4: !firrtl.uint<1>
@@ -116,6 +123,8 @@ firrtl.circuit "TestHarness" attributes {
   // CHECK-SAME: out %_2: !firrtl.uint<1>
   // CHECK-SAME: out %_1: !firrtl.clock
   // CHECK-SAME: out %_0: !firrtl.uint<1>
+  // CHECK-NEXT: [[V7:%.+]] = firrtl.verbatim.expr "extmoduleWithTappedPort.out"
+  // CHECK-NEXT: firrtl.connect %_7, [[V7]]
   // CHECK-NEXT: [[V6:%.+]] = firrtl.verbatim.expr "foo.bar.regreset"
   // CHECK-NEXT: firrtl.connect %_6, [[V6]]
   // CHECK-NEXT: [[V5:%.+]] = firrtl.verbatim.expr "foo.bar.reg"
@@ -131,18 +140,26 @@ firrtl.circuit "TestHarness" attributes {
   // CHECK-NEXT: [[V0:%.+]] = firrtl.verbatim.expr "foo.bar.wire"
   // CHECK-NEXT: firrtl.connect %_0, [[V0]]
   firrtl.extmodule @DataTap(
+    out %_7: !firrtl.uint<1> {firrtl.annotations = [{
+      class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
+      id = 0 : i64,
+      portID = 8 : i64,
+      type = "portName" }]},
     out %_6: !firrtl.uint<1> {firrtl.annotations = [{
       class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
       id = 0 : i64,
-      portID = 7 : i64 }]},
+      portID = 7 : i64,
+      type = "portName" }]},
     out %_5: !firrtl.uint<1> {firrtl.annotations = [{
       class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
       id = 0 : i64,
-      portID = 6 : i64 }]},
+      portID = 6 : i64,
+      type = "portName" }]},
     out %_4: !firrtl.uint<1> {firrtl.annotations = [{
       class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
       id = 0 : i64,
-      portID = 5 : i64 }]},
+      portID = 5 : i64,
+      type = "portName" }]},
     out %_3: !firrtl.uint<1> {firrtl.annotations = [{
       class = "sifive.enterprise.grandcentral.DataTapModuleSignalKey",
       internalPath = "schwarzschild.no.more",
@@ -151,15 +168,18 @@ firrtl.circuit "TestHarness" attributes {
     out %_2: !firrtl.uint<1> {firrtl.annotations = [{
       class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
       id = 0 : i64,
-      portID = 3 : i64 }]},
+      portID = 3 : i64,
+      type = "portName" }]},
     out %_1: !firrtl.clock {firrtl.annotations = [{
       class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
       id = 0 : i64,
-      portID = 2 : i64 }]},
+      portID = 2 : i64,
+      type = "portName" }]},
     out %_0: !firrtl.uint<1> {firrtl.annotations = [{
       class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
       id = 0 : i64,
-      portID = 1 : i64 }]}
+      portID = 1 : i64,
+      type = "portName" }]}
   ) attributes {
     annotations = [
       { class = "sifive.enterprise.grandcentral.DataTapsAnnotation" },
@@ -201,6 +221,14 @@ firrtl.circuit "TestHarness" attributes {
       portID = 4 : i64 }]
   }
 
+  firrtl.extmodule @ExtmoduleWithTappedPort(
+    out %out: !firrtl.uint<1> {firrtl.annotations = [{
+      class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
+      id = 0 : i64,
+      portID = 8 : i64,
+      type = "source" }]}
+  )
+
   // CHECK: firrtl.module @TestHarness
   firrtl.module @TestHarness(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
     %foo_clock, %foo_reset, %foo_in, %foo_out = firrtl.instance @Foo {name = "foo"} : !firrtl.clock, !firrtl.reset, !firrtl.uint<1>, !firrtl.uint<1>
@@ -209,8 +237,9 @@ firrtl.circuit "TestHarness" attributes {
     firrtl.connect %foo_in, %in : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %out, %foo_out : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.instance @BlackHole {name = "bigScary"}
+    %0 = firrtl.instance @ExtmoduleWithTappedPort {name = "extmoduleWithTappedPort"} : !firrtl.uint<1>
     // CHECK: firrtl.instance [[DT]] {name = "dataTap"}
-    %DataTap_6, %DataTap_5, %DataTap_4, %DataTap_3, %DataTap_2, %DataTap_1, %DataTap_0 = firrtl.instance @DataTap {name = "dataTap"} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.uint<1>
+    %DataTap_7, %DataTap_6, %DataTap_5, %DataTap_4, %DataTap_3, %DataTap_2, %DataTap_1, %DataTap_0 = firrtl.instance @DataTap {name = "dataTap"} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.uint<1>
     // CHECK: firrtl.instance [[MT]] {name = "memTap"}
     %MemTap_mem_0, %MemTap_mem_1 = firrtl.instance @MemTap {name = "memTap"} : !firrtl.uint<1>, !firrtl.uint<1>
   }


### PR DESCRIPTION
Fix GrandCentral Annotation scattering and GrandCentralTaps pass to
support external module _sources_.  Previously, it was assumed that an
external module port had to be a "portName" sink.  However, it is
entirely possible for an external module port to be tapped.

Implement this fix with the following changes:

First, a new "type" field that can be either "portName" or "source" is
added during scattering of ReferenceDataTapKey Annotations.  This
unambiguously marks these taps as either a sink or a source.

Second, a new map is added to GrandCentralTaps to track external module
tap points.  This is necessary because the mechanism to refer to the tap
isn't either a BlockArgument or a straight Operation.  This needs
additional info after the operation to refer to a specific port.

Third, each map tracking taps is changed to use an <id, portID> tuple as
key.  Previously, this would rely on the actual Annotation as the
key (which was effectively encoding a superset of the same information
that included the annotation name).  Changing annotations to encode type
information ("portName" or "source") means that sources and sinks do
_not_ have the exact same annotation as before.

Update the tests to include "type" information.  Add a test of tapping
an external module port.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

## Metadata

This was _extremely_ hurriedly put together. E.g., there is duplicated code in `TypeSwitch` lambdas that could be much better factored. @fabianschuiki: I am totally happy if you want to pick this up when you're awake. 😄 Otherwise, I can finish this off in ~8 hours or so.

@Ramlakshmi3733: This PR should fix that issue you were seeing. 

## Example

Here's a small example.  In the circuit below `foo.out` is being tapped. This should show up as a connection to `_0` in the module `DataTap`.

```scala
circuit Top: %[
[
  {
    "blackBox": "~Top|DataTap",
    "class": "sifive.enterprise.grandcentral.DataTapsAnnotation",
    "keys": [
      {
        "class": "sifive.enterprise.grandcentral.ReferenceDataTapKey",
        "portName": "~Top|DataTap>_0",
        "source": "~Top|Foo>out"
      }
    ]
  }
]
]
  extmodule DataTap:
    output _0: UInt<1>
  extmodule Foo:
    output out: UInt<1>
  module Top:
    inst foo of Foo
    inst bar of DataTap
```

The new scattering showing `type = "portName"` and `type = "source"` happens on parsing:

```mlir
module  {
  firrtl.circuit "Top"   {
    firrtl.extmodule @DataTap(out %_0: !firrtl.uint<1> {firrtl.annotations = [{class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = 1 : i64, type = "portName"}, {class = "firrtl.transforms.DontTouchAnnotation"}]}) attributes {annotations = [{class = "sifive.enterprise.grandcentral.DataTapsAnnotation"}, {class = "firrtl.transforms.DontTouchAnnotation"}]}
    firrtl.extmodule @Foo(out %out: !firrtl.uint<1> {firrtl.annotations = [{class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = 1 : i64, type = "source"}, {class = "firrtl.transforms.DontTouchAnnotation"}]})
    firrtl.module @Top() {
      %foo_out = firrtl.instance @Foo  {name = "foo"} : !firrtl.uint<1>
      %bar__0 = firrtl.instance @DataTap  {name = "bar"} : !firrtl.uint<1>
    }
  }
}
```

Compiling all the way to Verilog with `firrtl Foo.fir -lower-to-hw -verilog -firrtl-grand-central` produces:

```verilog
module DataTap_impl_0(
  output _0);

  assign _0 = foo.out;	// Foo.fir:16:13
endmodule

// external module Foo

module Top();
  wire bar__0;	// Foo.fir:22:5
  wire foo_out;	// Foo.fir:21:5

  Foo foo (	// Foo.fir:21:5
    .out (foo_out)
  );
  DataTap_impl_0 bar (	// Foo.fir:22:5
    ._0 (bar__0)
  );
endmodule
```

Without this PR, you would get:
```
Foo.fir:16:13: error: 'firrtl.extmodule' op ReferenceDataTapKey annotation was not scattered to an operation: {class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = 1 : i64}
  extmodule DataTap:
            ^
Foo.fir:16:13: note: see current operation: "firrtl.extmodule"() ( {
}) {annotations = [{class = "sifive.enterprise.grandcentral.DataTapsAnnotation"}, {class = "firrtl.transforms.DontTouchAnnotation"}], arg_attrs = [{firrtl.annotations = [{class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = 1 : i64}, {class = "firrtl.transforms.DontTouchAnnotation"}]}], portDirections = true, portNames = ["_0"], sym_name = "DataTap", type = (!firrtl.uint<1>) -> ()} : () -> ()
Foo.fir:18:13: error: 'firrtl.extmodule' op ReferenceDataTapKey annotation was not scattered to an operation: {class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = 1 : i64}
  extmodule Foo:
            ^
Foo.fir:18:13: note: see current operation: "firrtl.extmodule"() ( {
}) {annotations = [], arg_attrs = [{firrtl.annotations = [{class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = 1 : i64}, {class = "firrtl.transforms.DontTouchAnnotation"}]}], portDirections = true, portNames = ["out"], sym_name = "Foo", type = (!firrtl.uint<1>) -> ()} : () -> ()
```