### PR TITLE
[FIRRTL] Implement LiteralDataTapKey support

### DIFF
--- a/test/Dialect/FIRRTL/grand-central-taps.mlir
+++ b/test/Dialect/FIRRTL/grand-central-taps.mlir
@@ -117,6 +117,8 @@ firrtl.circuit "TestHarness" attributes {
   }
 
   // CHECK: firrtl.module [[DT:@DataTap.*]](
+  // CHECK-SAME: out %_9: !firrtl.uint<1>
+  // CHECK-SAME: out %_8: !firrtl.sint<8>
   // CHECK-SAME: out %_7: !firrtl.uint<1>
   // CHECK-SAME: out %_6: !firrtl.uint<1>
   // CHECK-SAME: out %_5: !firrtl.uint<1>
@@ -125,6 +127,10 @@ firrtl.circuit "TestHarness" attributes {
   // CHECK-SAME: out %_2: !firrtl.uint<1>
   // CHECK-SAME: out %_1: !firrtl.clock
   // CHECK-SAME: out %_0: !firrtl.uint<1>
+  // CHECK-NEXT: [[V9:%.+]] = firrtl.constant 0 : !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.connect %_9, [[V9]]
+  // CHECK-NEXT: [[V8:%.+]] = firrtl.constant -42 : !firrtl.sint<8>
+  // CHECK-NEXT: firrtl.connect %_8, [[V8]]
   // CHECK-NEXT: [[V7:%.+]] = firrtl.verbatim.expr "extmoduleWithTappedPort.out"
   // CHECK-NEXT: firrtl.connect %_7, [[V7]]
   // CHECK-NEXT: [[V6:%.+]] = firrtl.verbatim.expr "foo.bar.regreset"
@@ -142,6 +148,8 @@ firrtl.circuit "TestHarness" attributes {
   // CHECK-NEXT: [[V0:%.+]] = firrtl.verbatim.expr "foo.bar.wire"
   // CHECK-NEXT: firrtl.connect %_0, [[V0]]
   firrtl.extmodule @DataTap(
+    out %_9: !firrtl.uint<1>,
+    out %_8: !firrtl.sint<8>,
     out %_7: !firrtl.uint<1>,
     out %_6: !firrtl.uint<1>,
     out %_5: !firrtl.uint<1>,
@@ -156,6 +164,8 @@ firrtl.circuit "TestHarness" attributes {
       { class = "firrtl.transforms.NoDedupAnnotation" }
     ],
     portAnnotations = [
+      [{class = "sifive.enterprise.grandcentral.LiteralDataTapKey", literal = "UInt<1>(\"h0\")", id = 0 : i64, portID = 10 : i64 }],
+      [{class = "sifive.enterprise.grandcentral.LiteralDataTapKey", literal = "SInt<8>(\"h-2A\")", id = 0 : i64, portID = 9 : i64 }],
       [{class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = 8 : i64, type = "portName"}],
       [{class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = 7 : i64, type = "portName"}],
       [{class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = 6 : i64, type = "portName"}],
@@ -179,7 +189,7 @@ firrtl.circuit "TestHarness" attributes {
   // CHECK-NEXT: firrtl.connect %mem_1, [[V1:%.+]]
   firrtl.extmodule @MemTap(
     out %mem_0: !firrtl.uint<1>,
-    out %mem_1: !firrtl.uint<1> 
+    out %mem_1: !firrtl.uint<1>
   ) attributes {
     annotations = [
       {class = "firrtl.transforms.NoDedupAnnotation"}
@@ -218,7 +228,7 @@ firrtl.circuit "TestHarness" attributes {
     firrtl.instance @BlackHole {name = "bigScary"}
     %0 = firrtl.instance @ExtmoduleWithTappedPort {name = "extmoduleWithTappedPort"} : !firrtl.uint<1>
     // CHECK: firrtl.instance [[DT]] {name = "dataTap"}
-    %DataTap_7, %DataTap_6, %DataTap_5, %DataTap_4, %DataTap_3, %DataTap_2, %DataTap_1, %DataTap_0 = firrtl.instance @DataTap {name = "dataTap"} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.uint<1>
+    %DataTap_9, %DataTap_8, %DataTap_7, %DataTap_6, %DataTap_5, %DataTap_4, %DataTap_3, %DataTap_2, %DataTap_1, %DataTap_0 = firrtl.instance @DataTap {name = "dataTap"} : !firrtl.uint<1>, !firrtl.sint<8>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.uint<1>
     // CHECK: firrtl.instance [[MT]] {name = "memTap"}
     %MemTap_mem_0, %MemTap_mem_1 = firrtl.instance @MemTap {name = "memTap"} : !firrtl.uint<1>, !firrtl.uint<1>
   }


### PR DESCRIPTION
Add support for `LiteralDataTapKey`s to the `GrandCentralTaps` pass. The change to GCT itself is simple enough, merely adding additional connects that drive the constant literal to the appropriate output port.

This is the first time as far as I can tell that we have the need to call the FIR parser on some string buffer. This commit adds a dedicated `firrtl::parseIntegerLiteralExp` that takes an input `StringRef`, sets up the entire parser machinery, and then treats the input string as an integer literal.

@lattner what are your thoughts on this? Error reporting is not ideal at the moment: the parser *does* add a location passed in from the outside as location info on the operations, but syntax errors on the input string can't point back at the module that had the annotation with the bad code. Maybe it's worthwhile adding a mechanism to have FIRParser emit syntax errors based on some other `Location` (opt-in), rather than always relying on the `SMLoc` from the buffer?

Annotations have been spotted in the wild which contain snippets of FIRRTL as strings, and probably need parsing/inlining at some point. Those annos will benefit from figuring the parsing out.

Fixes #1384.