### PR TITLE
[Comb] Canonicalize extract(cat(..)) into cat(extract(..)).

### DIFF
--- a/docs/RationaleHW-SV.md
+++ b/docs/RationaleHW-SV.md
@@ -279,7 +279,7 @@ The`concat(extract(..))` form is preferred over the `extract(concat(..))` form,
 because
 
 - `extract` gets "closer" to underlying `add/sub/xor/op` operations, giving way
-  narrowing optimizations like bit-narrowing.
+  optimizations like narrowing.
 - the form gives a more accurate view of the values that are being depended on.
 - redundant extract operations can be removed from the concat args lists, eg:
   `cat(extract(a), b, c, extract(d))`

--- a/docs/RationaleHW-SV.md
+++ b/docs/RationaleHW-SV.md
@@ -273,6 +273,19 @@ do not synthesize into hardware.  All things being equal it is good to reduce
 the number of instances of these (to reduce IR size and increase canonical form)
 but it is ok to introduce more of these to improve on other metrics above.
 
+**Ordering Concat and Extract**
+
+The`concat(extract(..))` form is preferred over the `extract(concat(..))` form,
+because
+
+- `extract` gets "closer" to underlying `add/sub/xor/op` operations, giving way
+  narrowing optimizations like bit-narrowing.
+- the form gives a more accurate view of the values that are being depended on.
+- redundant extract operations can be removed from the concat args lists, eg:
+  `cat(extract(a), b, c, extract(d))`
+
+Both forms perform similarly on hardware, since they are simply bit-copies.
+
 ## The SV Dialect
 
 The SV dialect is one of the dialects that can be mixed into the HW dialect,

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -136,6 +136,9 @@ OpFoldResult ExtractOp::fold(ArrayRef<Attribute> constants) {
   return {};
 }
 
+// Transforms extract(lo, cat(a, b, c, d, e)) into
+// cat(extract(lo1, b), c, extract(lo2, d)).
+// innerCat must be the argument of the provided ExtractOp.
 static LogicalResult extractConcatToConcatExtract(ExtractOp op,
                                                   ConcatOp innerCat,
                                                   PatternRewriter &rewriter) {

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -136,8 +136,9 @@ OpFoldResult ExtractOp::fold(ArrayRef<Attribute> constants) {
   return {};
 }
 
-static LogicalResult extractCatToCatExtract(ExtractOp op, ConcatOp innerCat,
-                                            PatternRewriter &rewriter) {
+static LogicalResult extractConcatToConcatExtract(ExtractOp op,
+                                                  ConcatOp innerCat,
+                                                  PatternRewriter &rewriter) {
   auto reversedConcatArgs = llvm::reverse(innerCat.inputs());
   size_t initialPosition = 0;
   auto it = reversedConcatArgs.begin();
@@ -240,7 +241,7 @@ LogicalResult ExtractOp::canonicalize(ExtractOp op, PatternRewriter &rewriter) {
 
   // extract(lo, cat(a, b, c, d, e)) = cat(extract(lo1, b), c, extract(lo2, d))
   if (auto innerCat = dyn_cast_or_null<ConcatOp>(op.input().getDefiningOp())) {
-    return extractCatToCatExtract(op, innerCat, rewriter);
+    return extractConcatToConcatExtract(op, innerCat, rewriter);
   }
 
   return failure();

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -145,9 +145,8 @@ static LogicalResult extractCatToCatExtract(ExtractOp op, ConcatOp innerCat,
 
   // This loop finds the first concatArg that is covered by the ExtractOp.
   for (; it != reversedConcatArgs.end(); it++) {
-    assert(
-        initialPosition <= lowBit &&
-        "incorrectly moved past an element that lowBit has coverage over");
+    assert(initialPosition <= lowBit &&
+           "incorrectly moved past an element that lowBit has coverage over");
     auto operand = *it;
 
     size_t operandWidth = operand.getType().getIntOrFloatBitWidth();
@@ -177,16 +176,17 @@ static LogicalResult extractCatToCatExtract(ExtractOp op, ConcatOp innerCat,
     // ^---initialPosition
     initialPosition += operandWidth;
   }
-  assert(
-      it != reversedConcatArgs.end()
-      && "incorrectly failed to find an element which contains coverage of lowBit");
+  assert(it != reversedConcatArgs.end() &&
+         "incorrectly failed to find an element which contains coverage of "
+         "lowBit");
 
   SmallVector<Value> reverseConcatArgs;
   size_t widthRemaining = op.getType().getWidth();
   size_t extractLo = lowBit - initialPosition;
 
   // Transform individual arguments of innerCat(..., a, b, c,) into
-  // [ extract(a), b, extract(c) ], skipping an extract operation where possible.
+  // [ extract(a), b, extract(c) ], skipping an extract operation where
+  // possible.
   for (; widthRemaining != 0 && it != reversedConcatArgs.end(); it++) {
     auto concatArg = *it;
     size_t operandWidth = concatArg.getType().getIntOrFloatBitWidth();

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -277,8 +277,9 @@ hw.module @extractCatOnSinglePartialElement(%arg0: i8, %arg1: i9, %arg2: i10) ->
   hw.output %1, %2, %3, %4 : i1, i1, i1, i1
 }
 
-// Validates theat extract(cat(a, b, c)) -> cat(extract(..), .., extract(..)). A few
-// things to validate here:
+// Validates that extract(cat(a, b, c)) -> cat(extract(..), .., extract(..))
+// containing a mix of full elements and extract elements.
+// A few things to look out here:
 // - extract is only inserted at elements that require it
 // - no zero-elements introduced
 // - the order of the elements are correct.

--- a/test/ExportVerilog/hw-dialect.mlir
+++ b/test/ExportVerilog/hw-dialect.mlir
@@ -730,3 +730,14 @@ hw.module @Chi() -> (%Chi_output : i0) {
    hw.output
  }
  hw.module.extern @Bar1360() attributes {verilogName = "RealBar"}
+
+
+// CHECK-LABEL: module TruncateAdditionOp
+hw.module @TruncateAdditionOp(%x: i8, %y: i8) -> (%z: i8) {
+  %false = hw.constant false
+  %0 = comb.concat %false, %x : (i1, i8) -> i9
+  %1 = comb.concat %false, %y : (i1, i8) -> i9
+  %2 = comb.add %0, %1 : i9
+  %3 = comb.extract %2 from 0 : (i9) -> i8
+  hw.output %3 : i8
+}

--- a/test/ExportVerilog/hw-dialect.mlir
+++ b/test/ExportVerilog/hw-dialect.mlir
@@ -730,14 +730,3 @@ hw.module @Chi() -> (%Chi_output : i0) {
    hw.output
  }
  hw.module.extern @Bar1360() attributes {verilogName = "RealBar"}
-
-
-// CHECK-LABEL: module TruncateAdditionOp
-hw.module @TruncateAdditionOp(%x: i8, %y: i8) -> (%z: i8) {
-  %false = hw.constant false
-  %0 = comb.concat %false, %x : (i1, i8) -> i9
-  %1 = comb.concat %false, %y : (i1, i8) -> i9
-  %2 = comb.add %0, %1 : i9
-  %3 = comb.extract %2 from 0 : (i9) -> i8
-  hw.output %3 : i8
-}


### PR DESCRIPTION
The canonicalization routine attempts to reuse as much operands as it is as possible, namely:

Depending on the bit range being extracted, here are the possible outputs:
- `extract(cat(a, b, c))` ->  `c`
- `extract(cat(a, b, c))` -> `extract(c)`
- `extract(cat(a, b, c))` -> `cat(extract(a), extract(b)`
- `extract(cat(a, b, c))` -> `cat(extract(a), b, extract(c))`

The first 3 cases are all monotonically, since they reduces the number of elements we depend on. The last case, while not necessarily profitable, is not bad. I decided to keep it to be consistently canonicalize everything.