### PR TITLE
[Comb] Narrow addition operation to Bits that are observed

### DIFF
--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -111,7 +111,7 @@ getLowestBitAndHighestBitRequired(Operation::use_range uses,
 // mutate them to the newly created narrowed version if it's benefitial.
 //
 // narrowTrailingBits determines whether undemanded trailing bits should
-// be aggressively stripped of.
+// be aggressively stripped off.
 //
 // Returns true if IR is mutated. IR is mutated iff narrowing happens.
 template <class Op, class F>
@@ -134,9 +134,8 @@ static bool narrowOperationWidth(Op narrowingCandidate, ValueRange inputs,
                                         originalOpWidth);
 
   // Give up, because we can't make it narrower than it already is.
-  if (lowestBitRequired == 0 && highestBitRequired == originalOpWidth - 1) {
+  if (lowestBitRequired == 0 && highestBitRequired == originalOpWidth - 1)
     return false;
-  }
 
   auto loc = narrowingCandidate.getLoc();
   size_t narrowedWidth = highestBitRequired - lowestBitRequired + 1;

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -121,9 +121,8 @@ static bool narrowOperationWidth(Op narrowingCandidate, ValueRange inputs,
   // If the result is never used, no point optimizing this. It will
   // also complicated error handling in getLowestBitAndHigestBitRequired.
   Operation::use_range uses = narrowingCandidate.getOperation()->getUses();
-  if (uses.empty()) {
+  if (uses.empty())
     return false;
-  }
 
   size_t highestBitRequired;
   size_t lowestBitRequired;
@@ -366,8 +365,6 @@ static bool narrowExtractWidth(ExtractOp outerExtractOp,
         assert(type.isa<IntegerType>() &&
                "extract() requires input to be of type IntegerType!");
 
-        // mux(cond, t, f) -> concat(0, mux(cond, t[n-1:0], f[n-1:0])),
-        // where n is the widest demanded width
         auto cond = innerOp.cond();
         auto loc = innerOp.getLoc();
         auto createMuxOp = [&](ArrayRef<Value> values) -> MuxOp {
@@ -382,7 +379,8 @@ static bool narrowExtractWidth(ExtractOp outerExtractOp,
       })
 
       // TODO: Cautiously investigate whether this optimization can be performed
-      // on arrays, memory, or even sequential operations.
+      // on other comb operators (shifts & divs), arrays, memory, or even
+      // sequential operations.
       .Default([](Operation *op) { return false; });
 }
 

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -77,10 +77,11 @@ static bool tryFlatteningOperands(Op op, PatternRewriter &rewriter) {
 // Given a range of uses of an operation, find the lowest and highest bits
 // inclusive that are ever referenced. The range of uses must not be empty.
 static std::pair<size_t, size_t>
-getLowestBitAndHighestBitRequired(Operation::use_range uses, bool narrowTrailingBits, size_t originalOpWidth)
-{
-  assert(!uses.empty() &&
-      "getLowestBitAndHighestBitRequired cannot operate on a empty list of uses.");
+getLowestBitAndHighestBitRequired(Operation::use_range uses,
+                                  bool narrowTrailingBits,
+                                  size_t originalOpWidth) {
+  assert(!uses.empty() && "getLowestBitAndHighestBitRequired cannot operate on "
+                          "a empty list of uses.");
 
   // when we don't want to narrowTrailingBits (namely in arithmetic
   // operations), forcing lowestBitRequired = 0
@@ -129,7 +130,8 @@ static bool narrowOperationWidth(Op narrowingCandidate, ValueRange inputs,
   size_t originalOpWidth = narrowingCandidate.getType().getIntOrFloatBitWidth();
 
   std::tie(lowestBitRequired, highestBitRequired) =
-    getLowestBitAndHighestBitRequired(uses, narrowTrailingBits, originalOpWidth);
+      getLowestBitAndHighestBitRequired(uses, narrowTrailingBits,
+                                        originalOpWidth);
 
   // Give up, because we can't make it narrower than it already is.
   if (lowestBitRequired == 0 && highestBitRequired == originalOpWidth - 1) {

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -302,3 +302,150 @@ hw.module @extractCatOnMultiplePartialElements(%arg0: i8, %arg1: i9, %arg2: i10)
   // CHECK-NEXT: hw.output [[RESULT1:%.+]], [[RESULT2:%.+]]
   hw.output %1, %2 : i11, i5
 }
+
+// Validates that addition narrows the operand widths to the width of the
+// single extract usage.
+// CHECK-LABEL: hw.module @narrowAdditionSingleExtractUse
+hw.module @narrowAdditionSingleExtractUse(%x: i8, %y: i8) -> (%z1: i6) {
+  // CHECK-NEXT: [[RX:%.+]] = comb.extract %x from 0 : (i8) -> i6
+  // CHECK-NEXT: [[RY:%.+]] = comb.extract %y from 0 : (i8) -> i6
+  // CHECK-NEXT: [[RESULT:%.+]] = comb.add [[RX]], [[RY]] : i6
+  // CHECK-NEXT: hw.output [[RESULT]]
+
+  %false = hw.constant false
+  %0 = comb.concat %false, %x : (i1, i8) -> i9
+  %1 = comb.concat %false, %y : (i1, i8) -> i9
+  %2 = comb.add %0, %1 : i9
+  %3 = comb.extract %2 from 0 : (i9) -> i6
+  hw.output %3 : i6
+}
+
+// Validates that addition narrows to the element itself without an extract
+// where possible.
+// CHECK-LABEL: hw.module @narrowAdditionToDirectAddition
+hw.module @narrowAdditionToDirectAddition(%x: i8, %y: i8) -> (%z1: i8) {
+  // CHECK-NEXT: [[RESULT:%.+]] = comb.add %x, %y : i8
+  // CHECK-NEXT: hw.output [[RESULT]]
+
+  %false = hw.constant false
+  %0 = comb.concat %x, %x : (i8, i8) -> i16
+  %1 = comb.concat %y, %y : (i8, i8) -> i16
+  %2 = comb.add %0, %1 : i16
+  %3 = comb.extract %2 from 0 : (i16) -> i8
+  hw.output %3 : i8
+}
+
+// Validates that addition narrow to the widest extract
+// CHECK-LABEL: hw.module @narrowAdditionToWidestExtract
+hw.module @narrowAdditionToWidestExtract(%x: i8, %y: i8) -> (%z1: i3, %z2: i4) {
+  // CHECK-NEXT: [[RX:%.+]] = comb.extract %x from 0 : (i8) -> i4
+  // CHECK-NEXT: [[RY:%.+]] = comb.extract %y from 0 : (i8) -> i4
+  // CHECK-NEXT: [[RESULT2:%.+]] = comb.add [[RX]], [[RY]] : i4
+  // CHECK-NEXT: [[RESULT1:%.+]] = comb.extract [[RESULT2]] from 0 : (i4) -> i3
+  // CHECK-NEXT: hw.output [[RESULT1]], [[RESULT2]]
+
+  %0 = comb.concat %x, %x : (i8, i8) -> i9
+  %1 = comb.concat %y, %y : (i8, i8) -> i9
+  %2 = comb.add %0, %1 : i9
+  %3 = comb.extract %2 from 0 : (i9) -> i3
+  %4 = comb.extract %2 from 0 : (i9) -> i4
+  hw.output %3, %4 : i3, i4
+}
+
+// Validates that addition narrow to the widest extract
+// CHECK-LABEL: hw.module @narrowAdditionStripLeadingZero
+hw.module @narrowAdditionStripLeadingZero(%x: i8, %y: i8) -> (%z: i8) {
+  // CHECK-NEXT: [[RESULT:%.+]] = comb.add %x, %y : i8
+  // CHECK-NEXT: hw.output [[RESULT]]
+
+  %false = hw.constant false
+  %0 = comb.concat %false, %x : (i1, i8) -> i9
+  %1 = comb.concat %false, %y : (i1, i8) -> i9
+  %2 = comb.add %0, %1 : i9
+  %3 = comb.extract %2 from 0 : (i9) -> i8
+  hw.output %3 : i8
+}
+
+// Validates that addition narrowing does not happen when the width of the
+// largest use is as wide as the addition result itself.
+// CHECK-LABEL: hw.module @narrowAdditionRetainOriginal
+hw.module @narrowAdditionRetainOriginal(%x: i8, %y: i8) -> (%z0: i9, %z1: i8) {
+  // CHECK-NEXT: false = hw.constant false
+  // CHECK-NEXT: %0 = comb.concat %false, %x : (i1, i8) -> i9
+  // CHECK-NEXT: %1 = comb.concat %false, %y : (i1, i8) -> i9
+  // CHECK-NEXT: %2 = comb.add %0, %1 : i9
+  // CHECK-NEXT: %3 = comb.extract %2 from 0 : (i9) -> i8
+  // CHECK-NEXT: hw.output %2, %3 : i9, i8
+
+  %false = hw.constant false
+  %0 = comb.concat %false, %x : (i1, i8) -> i9
+  %1 = comb.concat %false, %y : (i1, i8) -> i9
+  %2 = comb.add %0, %1 : i9
+  %3 = comb.extract %2 from 0 : (i9) -> i8
+  hw.output %2, %3 : i9, i8
+}
+
+// Validates that addition narrowing retains the lower bits when not extracting from
+// zero.
+// CHECK-LABEL: hw.module @narrowAdditionExtractFromNoneZero
+hw.module @narrowAdditionExtractFromNoneZero(%x: i8, %y: i8) -> (%z0: i4) {
+  // CHECK-NEXT: [[RX:%.+]] = comb.extract %x from 0 : (i8) -> i5
+  // CHECK-NEXT: [[RY:%.+]] = comb.extract %y from 0 : (i8) -> i5
+  // CHECK-NEXT: [[ADD:%.+]] = comb.add [[RX]], [[RY]] : i5
+  // CHECK-NEXT: [[RET:%.+]] = comb.extract [[ADD]] from 1 : (i5) -> i4
+  // CHECK-NEXT: hw.output [[RET]]
+
+  %0 = comb.add %x, %y : i8
+  %1 = comb.extract %0 from 1 : (i8) -> i4
+  hw.output %1 : i4
+}
+
+// Validates that subtraction narrowing retains the lower bits when not extracting from
+// zero.
+// CHECK-LABEL: hw.module @narrowSubExtractFromNoneZero
+hw.module @narrowSubExtractFromNoneZero(%x: i8, %y: i8) -> (%z0: i4) {
+  // CHECK-NEXT: [[RX:%.+]] = comb.extract %x from 0 : (i8) -> i5
+  // CHECK-NEXT: [[RY:%.+]] = comb.extract %y from 0 : (i8) -> i5
+  // CHECK-NEXT: [[ADD:%.+]] = comb.sub [[RX]], [[RY]] : i5
+  // CHECK-NEXT: [[RET:%.+]] = comb.extract [[ADD]] from 1 : (i5) -> i4
+  // CHECK-NEXT: hw.output [[RET]]
+
+  %0 = comb.sub %x, %y : i8
+  %1 = comb.extract %0 from 1 : (i8) -> i4
+  hw.output %1 : i4
+}
+
+// Validates that bitwise operation does not retain the lower bit when extracting from
+// non-zero.
+// CHECK-LABEL: hw.module @narrowBitwiseOpsExtractFromNoneZero
+hw.module @narrowBitwiseOpsExtractFromNoneZero(%a: i8, %b: i8, %c: i8, %d: i1) -> (%w: i4, %x: i4, %y: i4, %z: i4) {
+  // CHECK-NEXT: [[RA:%.+]] = comb.extract %a from 1 : (i8) -> i4
+  // CHECK-NEXT: [[RB:%.+]] = comb.extract %b from 1 : (i8) -> i4
+  // CHECK-NEXT: [[RC:%.+]] = comb.extract %c from 1 : (i8) -> i4
+  // CHECK-NEXT: [[AND:%.+]] = comb.and [[RA]], [[RB]], [[RC]] : i4
+  %0 = comb.and %a, %b, %c : i8
+  %1 = comb.extract %0 from 1 : (i8) -> i4
+
+  // CHECK-NEXT: [[RA:%.+]] = comb.extract %a from 1 : (i8) -> i4
+  // CHECK-NEXT: [[RB:%.+]] = comb.extract %b from 1 : (i8) -> i4
+  // CHECK-NEXT: [[RC:%.+]] = comb.extract %c from 1 : (i8) -> i4
+  // CHECK-NEXT: [[OR:%.+]] = comb.or [[RA]], [[RB]], [[RC]] : i4
+  %2 = comb.or %a, %b, %c : i8
+  %3 = comb.extract %2 from 1 : (i8) -> i4
+
+  // CHECK-NEXT: [[RA:%.+]] = comb.extract %a from 1 : (i8) -> i4
+  // CHECK-NEXT: [[RB:%.+]] = comb.extract %b from 1 : (i8) -> i4
+  // CHECK-NEXT: [[RC:%.+]] = comb.extract %c from 1 : (i8) -> i4
+  // CHECK-NEXT: [[XOR:%.+]] = comb.xor [[RA]], [[RB]], [[RC]] : i4
+  %4 = comb.xor %a, %b, %c : i8
+  %5 = comb.extract %4 from 1 : (i8) -> i4
+
+  // CHECK-NEXT: [[RA:%.+]] = comb.extract %a from 1 : (i8) -> i4
+  // CHECK-NEXT: [[RB:%.+]] = comb.extract %b from 1 : (i8) -> i4
+  // CHECK-NEXT: [[MUX:%.+]] = comb.mux %d, [[RA]], [[RB]] : i4
+  %6 = comb.mux %d, %a, %b : i8
+  %7 = comb.extract %6 from 1 : (i8) -> i4
+
+  // CHECK-NEXT: hw.output [[AND]], [[OR]], [[XOR]], [[MUX]]
+  hw.output %1, %3, %5, %7 : i4, i4, i4, i4
+}

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -415,6 +415,21 @@ hw.module @narrowSubExtractFromNoneZero(%x: i8, %y: i8) -> (%z0: i4) {
   hw.output %1 : i4
 }
 
+// Validates that subtraction narrowing retains the lower bits when not extracting from
+// zero.
+// CHECK-LABEL: hw.module @narrowMulExtractFromNoneZero
+hw.module @narrowMulExtractFromNoneZero(%x: i8, %y: i8) -> (%z0: i4) {
+  // CHECK-NEXT: [[RX:%.+]] = comb.extract %x from 0 : (i8) -> i5
+  // CHECK-NEXT: [[RY:%.+]] = comb.extract %y from 0 : (i8) -> i5
+  // CHECK-NEXT: [[ADD:%.+]] = comb.mul [[RX]], [[RY]] : i5
+  // CHECK-NEXT: [[RET:%.+]] = comb.extract [[ADD]] from 1 : (i5) -> i4
+  // CHECK-NEXT: hw.output [[RET]]
+
+  %0 = comb.mul %x, %y : i8
+  %1 = comb.extract %0 from 1 : (i8) -> i4
+  hw.output %1 : i4
+}
+
 // Validates that bitwise operation does not retain the lower bit when extracting from
 // non-zero.
 // CHECK-LABEL: hw.module @narrowBitwiseOpsExtractFromNoneZero


### PR DESCRIPTION
Builds on top of https://github.com/llvm/circt/pull/1423 (ie: should not be merged into that feature is merged).

Narrow the strength of addition from

```mlir
%addResult = add %a, %b : i10
%addResult = extract %addResult from 0 : i10 -> i3
```

into addition only on bits that will be used

```mlir
%a'         = extract %a from 0 : i3
%b'         = extract %b from 0 : i3
%addResult' = add %a', %b' : i3
%c0         = hw.constant 0 : i7
%addResult  = concat %c0, %addResult' : (i7, i3) -> i10
%addResult  = extract %addResult from 0 : i10 -> i3
```

Further extract-concat cannonicalizer passes (https://github.com/llvm/circt/pull/1423) will remove the leading bits in
%addResult