### PR TITLE
[SV] Replace sv.connect with sv.assign.

### DIFF
--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -7,23 +7,9 @@
 //===----------------------------------------------------------------------===//
 //
 // This describes the SystemVerilog dialect ops for working with inout types.
-// These are wires, connect statements, etc.
+// These are wires, NoRegionArguments, etc.
 //
 //===----------------------------------------------------------------------===//
-
-def ConnectOp : SVOp<"connect", [InOutTypeConstraint<"src", "dest">]> {
-  let summary = "Connect two signals";
-  let description = [{
-    Connect Operation:
-    ```
-      sv.connect %dest, %src : t1
-    ```
-    }];
-
-  let arguments = (ins InOutType:$dest, HWValueType:$src);
-  let results = (outs);
-  let assemblyFormat = "$dest `,` $src  attr-dict `:` type($src)";
-}
 
 // Note that net declarations like 'wire' should not appear in an always block.
 def WireOp : SVOp<"wire", [DeclareOpInterfaceMethods<OpAsmOpInterface>,

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -27,6 +27,7 @@ def IfDefOp : SVOp<"ifdef", [SingleBlock, NoTerminator, NoRegionArguments,
 
   let description = [{
     This operation is an #ifdef block, which has a "then" and "else" region.
+    This operation is for non-procedural regions and its body is non-procedural.
   }];
 
   let regions = (region SizedRegion<1>:$thenRegion, AnyRegion:$elseRegion);
@@ -66,11 +67,12 @@ def IfDefOp : SVOp<"ifdef", [SingleBlock, NoTerminator, NoRegionArguments,
 
 def IfDefProceduralOp
   : SVOp<"ifdef.procedural", [SingleBlock, NoTerminator, NoRegionArguments,
-                              ProceduralRegion]> {
+                              ProceduralRegion, ProceduralOp]> {
   let summary = "'ifdef MACRO' block for procedural regions";
 
   let description = [{
     This operation is an #ifdef block, which has a "then" and "else" region.
+    This operation is for procedural regions and its body is procedural.
   }];
 
   let regions = (region SizedRegion<1>:$thenRegion, AnyRegion:$elseRegion);
@@ -349,7 +351,7 @@ def CaseZOp : SVOp<"casez", [SingleBlock, NoTerminator, NoRegionArguments,
 }
 
 //===----------------------------------------------------------------------===//
-// Other Statements
+// Assignment Related Statements
 //===----------------------------------------------------------------------===//
 
 def BPAssignOp : SVOp<"bpassign", [InOutTypeConstraint<"src", "dest">,
@@ -378,6 +380,12 @@ def PAssignOp : SVOp<"passign", [InOutTypeConstraint<"src", "dest">,
   let results = (outs);
   let assemblyFormat = "$dest `,` $src  attr-dict `:` type($src)";
 }
+
+
+
+//===----------------------------------------------------------------------===//
+// Other Statements
+//===----------------------------------------------------------------------===//
 
 def ForceOp : SVOp<"force", [InOutTypeConstraint<"src", "dest">,
                                    ProceduralOp]> {

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -354,6 +354,18 @@ def CaseZOp : SVOp<"casez", [SingleBlock, NoTerminator, NoRegionArguments,
 // Assignment Related Statements
 //===----------------------------------------------------------------------===//
 
+def AssignOp : SVOp<"assign", [InOutTypeConstraint<"src", "dest">,
+                                 NonProceduralOp]> {
+  let summary = "Continuous assignment";
+  let description = [{
+    A SystemVerilog assignment statement 'x = y;'.
+    These occur in module scope.  See SV Spec 10.3.2.
+  }];
+  let arguments = (ins InOutType:$dest, InOutElementType:$src);
+  let results = (outs);
+  let assemblyFormat = "$dest `,` $src  attr-dict `:` type($src)";
+}
+
 def BPAssignOp : SVOp<"bpassign", [InOutTypeConstraint<"src", "dest">,
                                    ProceduralOp]> {
   let summary = "Blocking procedural assignment";

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -36,7 +36,7 @@ public:
             IfDefOp, IfDefProceduralOp, IfOp, AlwaysOp, AlwaysCombOp,
             AlwaysFFOp, InitialOp, CaseZOp,
             // Other Statements.
-            ConnectOp, BPAssignOp, PAssignOp, ForceOp, ReleaseOp, AliasOp,
+            AssignOp, BPAssignOp, PAssignOp, ForceOp, ReleaseOp, AliasOp,
             FWriteOp, FatalOp, FinishOp, VerbatimOp,
             // Type declarations.
             InterfaceOp, InterfaceSignalOp, InterfaceModportOp,
@@ -94,7 +94,7 @@ public:
   HANDLE(CaseZOp, Unhandled);
 
   // Other Statements.
-  HANDLE(ConnectOp, Unhandled);
+  HANDLE(AssignOp, Unhandled);
   HANDLE(BPAssignOp, Unhandled);
   HANDLE(PAssignOp, Unhandled);
   HANDLE(ForceOp, Unhandled);

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -501,10 +501,10 @@ void FIRRTLModuleLowering::lowerFileHeader(CircuitOp op,
     std::string define = "`define ";
     if (!defineFalse) {
       assert(defineTrue && "didn't define anything");
-      b.create<sv::IfDefProceduralOp>(
+      b.create<sv::IfDefOp>(
           guard, [&]() { emitString(define + defineTrue); });
     } else {
-      b.create<sv::IfDefProceduralOp>(
+      b.create<sv::IfDefOp>(
           guard,
           [&]() {
             if (defineTrue)
@@ -569,7 +569,7 @@ void FIRRTLModuleLowering::lowerFileHeader(CircuitOp op,
     emitGuardedDefine("RANDOMIZE_DELAY", nullptr, "RANDOMIZE_DELAY 0.002");
 
     emitString("\n// Define INIT_RANDOM_PROLOG_ for use in our modules below.");
-    b.create<sv::IfDefProceduralOp>(
+    b.create<sv::IfDefOp>(
         "RANDOMIZE",
         [&]() {
           emitGuardedDefine(
@@ -582,7 +582,7 @@ void FIRRTLModuleLowering::lowerFileHeader(CircuitOp op,
   if (state.used_RANDOMIZE_GARBAGE_ASSIGN) {
     emitString("\n// RANDOMIZE_GARBAGE_ASSIGN enable range checks for mem "
                "assignments.");
-    b.create<sv::IfDefProceduralOp>(
+    b.create<sv::IfDefOp>(
         "RANDOMIZE_GARBAGE_ASSIGN",
         [&]() {
           emitString(

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1198,7 +1198,7 @@ void FIRRTLLowering::optimizeTemporaryWire(sv::WireOp wire) {
   // Wires have inout type, so they'll have connects and read_inout operations
   // that work on them.  If anything unexpected is found then leave it alone.
   SmallVector<sv::ReadInOutOp> reads;
-  sv::ConnectOp write;
+  sv::AssignOp write;
 
   for (auto *user : wire->getUsers()) {
     if (auto read = dyn_cast<sv::ReadInOutOp>(user)) {
@@ -1207,10 +1207,10 @@ void FIRRTLLowering::optimizeTemporaryWire(sv::WireOp wire) {
     }
 
     // Otherwise must be a connect, and we must not have seen a write yet.
-    auto connect = dyn_cast<sv::ConnectOp>(user);
-    if (!connect || write)
+    auto assign = dyn_cast<sv::AssignOp>(user);
+    if (!assign || write)
       return;
-    write = connect;
+    write = assign;
   }
 
   // Must have found the write!
@@ -1695,7 +1695,7 @@ LogicalResult FIRRTLLowering::visitDecl(NodeOp op) {
                                          Twine("__") + name.getValue());
 
     auto wire = builder.create<sv::WireOp>(operand.getType(), name, symName);
-    builder.create<sv::ConnectOp>(wire, operand);
+    builder.create<sv::AssignOp>(wire, operand);
   }
 
   return setLowering(op, operand);
@@ -2536,7 +2536,7 @@ LogicalResult FIRRTLLowering::visitStmt(ConnectOp op) {
     return success();
   }
 
-  builder.create<sv::ConnectOp>(destVal, srcVal);
+  builder.create<sv::AssignOp>(destVal, srcVal);
   return success();
 }
 
@@ -2589,7 +2589,7 @@ LogicalResult FIRRTLLowering::visitStmt(PartialConnectOp op) {
     return success();
   }
 
-  builder.create<sv::ConnectOp>(destVal, srcVal);
+  builder.create<sv::AssignOp>(destVal, srcVal);
   return success();
 }
 
@@ -2753,7 +2753,7 @@ LogicalResult FIRRTLLowering::visitStmt(AttachOp op) {
         for (size_t i1 = 0, e = inoutValues.size(); i1 != e; ++i1) {
           for (size_t i2 = 0; i2 != e; ++i2)
             if (i1 != i2)
-              builder.create<sv::ConnectOp>(inoutValues[i1], values[i2]);
+              builder.create<sv::AssignOp>(inoutValues[i1], values[i2]);
         }
       },
       // In the non-synthesis case, we emit a SystemVerilog alias statement.

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -203,10 +203,10 @@ LogicalResult RegOp::canonicalize(RegOp op, PatternRewriter &rewriter) {
   // If the reg has a symbol, then we can't delete it.
   if (op.sym_nameAttr())
     return failure();
-  // Check that all operations on the wire are sv.connects. All other wire
+  // Check that all operations on the wire are sv.assigns. All other wire
   // operations will have been handled by other canonicalization.
   for (auto &use : op.getResult().getUses())
-    if (!isa<ConnectOp>(use.getOwner()))
+    if (!isa<AssignOp>(use.getOwner()))
       return failure();
 
   // Remove all uses of the wire.
@@ -872,10 +872,10 @@ LogicalResult WireOp::canonicalize(WireOp wire, PatternRewriter &rewriter) {
   if (wire.sym_nameAttr())
     return failure();
 
-  // Wires have inout type, so they'll have connects and read_inout operations
+  // Wires have inout type, so they'll have assigns and read_inout operations
   // that work on them.  If anything unexpected is found then leave it alone.
   SmallVector<sv::ReadInOutOp> reads;
-  sv::ConnectOp write;
+  sv::AssignOp write;
 
   for (auto *user : wire->getUsers()) {
     if (auto read = dyn_cast<sv::ReadInOutOp>(user)) {
@@ -883,13 +883,13 @@ LogicalResult WireOp::canonicalize(WireOp wire, PatternRewriter &rewriter) {
       continue;
     }
 
-    // Otherwise must be a connect, and we must not have seen a write yet.
-    auto connect = dyn_cast<sv::ConnectOp>(user);
+    // Otherwise must be an assign, and we must not have seen a write yet.
+    auto assign = dyn_cast<sv::AssignOp>(user);
     // Either the wire has more than one write or another kind of Op (other than
-    // ConectOp and ReadInOutOp), then can't optimize.
-    if (!connect || write)
+    // AssignOp and ReadInOutOp), then can't optimize.
+    if (!assign || write)
       return failure();
-    write = connect;
+    write = assign;
   }
 
   Value connected;

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -3418,7 +3418,7 @@ void RootEmitterBase::gatherFiles(bool separateModules) {
           else
             rootFile.ops.push_back(info);
         })
-        .Case<VerbatimOp, IfDefProceduralOp, TypeScopeOp, HWModuleExternOp>(
+        .Case<VerbatimOp, IfDefOp, TypeScopeOp, HWModuleExternOp>(
             [&](auto &) {
               // Emit into a separate file using the specified file name or
               // replicate the operation in each outputfile.
@@ -3492,7 +3492,7 @@ void RootEmitterBase::emitOperation(VerilogEmitterState &state, Operation *op) {
           [&](auto op) { ModuleEmitter(state).emitHWGeneratedModule(op); })
       .Case<HWGeneratorSchemaOp>([&](auto op) { /* Empty */ })
       .Case<BindOp>([&](auto op) { ModuleEmitter(state).emitBind(op); })
-      .Case<InterfaceOp, VerbatimOp, IfDefProceduralOp>([&](auto op) {
+      .Case<InterfaceOp, VerbatimOp, IfDefOp>([&](auto op) {
         ModuleNameManager emptyNames;
         ModuleEmitter(state).emitStatement(op, emptyNames);
       })

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -1713,7 +1713,7 @@ private:
   LogicalResult visitSV(WireOp op) { return emitNoop(); }
   LogicalResult visitSV(RegOp op) { return emitNoop(); }
   LogicalResult visitSV(InterfaceInstanceOp op) { return emitNoop(); }
-  LogicalResult visitSV(ConnectOp op);
+  LogicalResult visitSV(AssignOp op);
   LogicalResult visitSV(BPAssignOp op);
   LogicalResult visitSV(PAssignOp op);
   LogicalResult visitSV(ForceOp op);
@@ -1863,8 +1863,8 @@ void StmtEmitter::emitStatementExpression(Operation *op) {
   emitLocationInfoAndNewLine(emittedExprs);
 }
 
-LogicalResult StmtEmitter::visitSV(ConnectOp op) {
-  // prepare connects wires to instance outputs, but these are logically handled
+LogicalResult StmtEmitter::visitSV(AssignOp op) {
+  // prepare assigns wires to instance outputs, but these are logically handled
   // in the port binding list when outputing an instance.
   if (dyn_cast_or_null<InstanceOp>(op.src().getDefiningOp()))
     return success();
@@ -2860,17 +2860,17 @@ static void lowerBoundInstance(InstanceOp op) {
 
     auto newWire = builder.create<WireOp>(src.getType(), nameTmp);
     auto newWireRead = builder.create<ReadInOutOp>(newWire);
-    auto connect = builder.create<ConnectOp>(newWire, src);
+    auto connect = builder.create<AssignOp>(newWire, src);
     newWireRead->moveBefore(op);
     connect->moveBefore(op);
     op.setOperand(nextOpNo - 1, newWireRead);
   }
 }
 
-static bool onlyUseIsConnect(Value v) {
+static bool onlyUseIsAssign(Value v) {
   if (!v.hasOneUse())
     return false;
-  if (!dyn_cast_or_null<ConnectOp>(v.getDefiningOp()))
+  if (!dyn_cast_or_null<AssignOp>(v.getDefiningOp()))
     return false;
   return true;
 }
@@ -2892,7 +2892,7 @@ static void lowerInstanceResults(InstanceOp op) {
     auto result = op.getResult(nextResultNo);
     ++nextResultNo;
 
-    if (onlyUseIsConnect(result))
+    if (onlyUseIsAssign(result))
       continue;
 
     bool isOneUseOutput = false;
@@ -2916,7 +2916,7 @@ static void lowerInstanceResults(InstanceOp op) {
         newWireRead->moveBefore(use.getOwner());
       }
 
-      auto connect = builder.create<ConnectOp>(newWire, result);
+      auto connect = builder.create<AssignOp>(newWire, result);
       connect->moveAfter(op);
     }
   }
@@ -2976,7 +2976,7 @@ static void lowerAlwaysInlineOperation(Operation *op) {
 }
 
 /// We lower the Merge operation to a wire at the top level along with
-/// connects to it and a ReadInOut.
+/// assigns to it and a ReadInOut.
 static Value lowerMergeOp(MergeOp merge) {
   auto module = merge->getParentOfType<HWModuleOp>();
   assert(module && "merges should only be in a module");
@@ -2985,14 +2985,14 @@ static Value lowerMergeOp(MergeOp merge) {
   ImplicitLocOpBuilder b(merge.getLoc(), &module.getBodyBlock()->front());
   auto wire = b.create<WireOp>(merge.getType());
 
-  // Each of the operands is a connect or passign into the wire.
+  // Each of the operands is an assign or passign into the wire.
   b.setInsertionPoint(merge);
   if (merge->getParentOp()->hasTrait<sv::ProceduralRegion>()) {
     for (auto op : merge.getOperands())
       b.create<PAssignOp>(wire, op);
   } else {
     for (auto op : merge.getOperands())
-      b.create<ConnectOp>(wire, op);
+      b.create<AssignOp>(wire, op);
   }
 
   return b.create<ReadInOutOp>(wire);
@@ -3043,7 +3043,7 @@ static void lowerUsersToTemporaryWire(Operation &op) {
       newWireRead->moveBefore(use.getOwner());
     }
 
-    auto connect = builder.create<ConnectOp>(newWire, result);
+    auto connect = builder.create<AssignOp>(newWire, result);
     connect->moveAfter(&op);
   }
 }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
@@ -6,7 +6,7 @@
 // CHECK-NOT: firrtl.circuit
 
 // We should get a large header boilerplate.
-// CHECK:   sv.ifdef.procedural "PRINTF_COND" {
+// CHECK:   sv.ifdef "PRINTF_COND" {
 // CHECK-NEXT:   sv.verbatim "`define PRINTF_COND_ (`PRINTF_COND)"
 // CHECK-NEXT:  } else  {
 firrtl.circuit "Simple" {

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -32,12 +32,12 @@ firrtl.circuit "Simple" {
     %dntnode = firrtl.node %in1 {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<4>
 
     // CHECK: %clockWire = sv.wire  : !hw.inout<i1>
-    // CHECK: sv.connect %clockWire, %false : i1
+    // CHECK: sv.assign %clockWire, %false : i1
     %c0_clock = firrtl.specialconstant 0 : !firrtl.clock
     %clockWire = firrtl.wire : !firrtl.clock
     firrtl.connect %clockWire, %c0_clock : !firrtl.clock, !firrtl.clock
 
-    // CHECK: sv.connect %out5, %c0_i4 : i4
+    // CHECK: sv.assign %out5, %c0_i4 : i4
     %tmp1 = firrtl.invalidvalue : !firrtl.uint<4>
     firrtl.connect %out5, %tmp1 : !firrtl.uint<4>, !firrtl.uint<4>
 
@@ -76,14 +76,14 @@ firrtl.circuit "Simple" {
     // CHECK: comb.concat %in1, %in2
     %7 = firrtl.cat %in1, %in2 : (!firrtl.uint<4>, !firrtl.uint<2>) -> !firrtl.uint<6>
 
-    // CHECK-NEXT: sv.connect %out5, [[PADRES2]] : i4
+    // CHECK-NEXT: sv.assign %out5, [[PADRES2]] : i4
     firrtl.connect %out5, %4 : !firrtl.uint<4>, !firrtl.uint<4>
 
-    // CHECK-NEXT: sv.connect %out4, [[XOR]] : i4
+    // CHECK-NEXT: sv.assign %out4, [[XOR]] : i4
     firrtl.connect %out4, %5 : !firrtl.uint<4>, !firrtl.uint<4>
 
     // CHECK-NEXT: [[ZEXT:%.+]] = comb.concat %c0_i2, %in2 : (i2, i2) -> i4
-    // CHECK-NEXT: sv.connect %out4, [[ZEXT]] : i4
+    // CHECK-NEXT: sv.assign %out4, [[ZEXT]] : i4
     firrtl.connect %out4, %in2 : !firrtl.uint<4>, !firrtl.uint<2>
 
     // CHECK-NEXT: %test-name = sv.wire sym @"__Simple__test-name" : !hw.inout<i4>
@@ -151,7 +151,7 @@ firrtl.circuit "Simple" {
     %n1 = firrtl.node %in2  {name = "n1"} : !firrtl.uint<2>
 
     // CHECK-NEXT: [[WIRE:%n2]] = sv.wire sym @__Simple__n2 : !hw.inout<i2>
-    // CHECK-NEXT: sv.connect [[WIRE]], %in2 : i2
+    // CHECK-NEXT: sv.assign [[WIRE]], %in2 : i2
     %n2 = firrtl.node %in2  {name = "n2", annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<2>
 
     // Nodes with no names are just dropped.
@@ -394,7 +394,7 @@ firrtl.circuit "Simple" {
     // CHECK-NEXT:  [[IO]] = sv.read_inout %io_cpu_flush.wire
     // CHECK-NEXT:  [[IO2:%.+]] = sv.read_inout %io_cpu_flush.wire
     // CHECK-NEXT:  %hits_1_7 = sv.wire sym @__foo__hits_1_7
-    // CHECK-NEXT:  sv.connect %hits_1_7, [[IO2]] : i1
+    // CHECK-NEXT:  sv.assign %hits_1_7, [[IO2]] : i1
     %1455 = firrtl.asPassive %hits_1_7 : !firrtl.uint<1>
   }
 
@@ -416,7 +416,7 @@ firrtl.circuit "Simple" {
     // CHECK-NEXT: %1 = comb.divu %0, %inpi : i65
     %0 = firrtl.div %inp_2, %inpi : (!firrtl.uint<27>, !firrtl.uint<65>) -> !firrtl.uint<27>
     // CHECK-NEXT: %2 = comb.extract %1 from 0 : (i65) -> i27
-    // CHECK-NEXT: sv.connect %tmp48, %2 : i27
+    // CHECK-NEXT: sv.assign %tmp48, %2 : i27
     firrtl.connect %tmp48, %0 : !firrtl.uint<27>, !firrtl.uint<27>
   }
 
@@ -436,12 +436,12 @@ firrtl.circuit "Simple" {
   // CHECK-NEXT:     %1 = sv.read_inout %a1 : !hw.inout<i1>
   // CHECK-NEXT:     %2 = sv.read_inout %b1 : !hw.inout<i1>
   // CHECK-NEXT:     %3 = sv.read_inout %c1 : !hw.inout<i1>
-  // CHECK-NEXT:     sv.connect %a1, %2 : i1
-  // CHECK-NEXT:     sv.connect %a1, %3 : i1
-  // CHECK-NEXT:     sv.connect %b1, %1 : i1
-  // CHECK-NEXT:     sv.connect %b1, %3 : i1
-  // CHECK-NEXT:     sv.connect %c1, %1 : i1
-  // CHECK-NEXT:     sv.connect %c1, %2 : i1
+  // CHECK-NEXT:     sv.assign %a1, %2 : i1
+  // CHECK-NEXT:     sv.assign %a1, %3 : i1
+  // CHECK-NEXT:     sv.assign %b1, %1 : i1
+  // CHECK-NEXT:     sv.assign %b1, %3 : i1
+  // CHECK-NEXT:     sv.assign %c1, %1 : i1
+  // CHECK-NEXT:     sv.assign %c1, %2 : i1
   // CHECK-NEXT:    } else {
   // CHECK-NEXT:     sv.ifdef "verilator" {
   // CHECK-NEXT:       sv.verbatim "`error \22Verilator does not support alias and thus cannot arbitrarily connect bidirectional wires and ports\22"
@@ -716,8 +716,8 @@ firrtl.circuit "Simple" {
     // CHECK-NEXT: sv.ifdef "SYNTHESIS"  {
     // CHECK-NEXT:   %0 = sv.read_inout %a : !hw.inout<i1>
     // CHECK-NEXT:   %1 = sv.read_inout %.invalid_analog : !hw.inout<i1>
-    // CHECK-NEXT:   sv.connect %a, %1 : i1
-    // CHECK-NEXT:   sv.connect %.invalid_analog, %0 : i1
+    // CHECK-NEXT:   sv.assign %a, %1 : i1
+    // CHECK-NEXT:   sv.assign %.invalid_analog, %0 : i1
     // CHECK-NEXT: } else {
     // CHECK-NEXT:   sv.ifdef "verilator" {
     // CHECK-NEXT:     sv.verbatim "`error \22Verilator does not support alias and thus cannot arbitrarily connect bidirectional wires and ports\22"

--- a/test/Dialect/HW/basic.mlir
+++ b/test/Dialect/HW/basic.mlir
@@ -130,8 +130,8 @@ hw.module @signed_arrays(%arg0: si8) -> (%out: !hw.array<2xsi8>) {
   // CHECK-NEXT: %0 = hw.array_create %arg0, %arg0 : si8
   %0 = hw.array_create %arg0, %arg0 : si8
 
-  // CHECK-NEXT: sv.connect %wireArray, %0 : !hw.array<2xsi8>
-  sv.connect %wireArray, %0 : !hw.array<2xsi8>
+  // CHECK-NEXT: sv.assign %wireArray, %0 : !hw.array<2xsi8>
+  sv.assign %wireArray, %0 : !hw.array<2xsi8>
 
   %result = sv.read_inout %wireArray : !hw.inout<!hw.array<2xsi8>>
   hw.output %result : !hw.array<2xsi8>

--- a/test/Dialect/HW/canonicalization.mlir
+++ b/test/Dialect/HW/canonicalization.mlir
@@ -926,7 +926,7 @@ hw.module @wire1() {
 hw.module @wire2() {
   %c = hw.constant 1 : i1
   %0 = sv.wire : !hw.inout<i1>
-  sv.connect %0, %c : i1
+  sv.assign %0, %c : i1
   hw.output
 }
 
@@ -936,7 +936,7 @@ hw.module @wire3() {
   %c = hw.constant 1 : i1
   %0 = sv.wire : !hw.inout<i1>
   %1 = sv.read_inout %0 : !hw.inout<i1>
-  sv.connect %0, %c :i1
+  sv.assign %0, %c :i1
   hw.output
 }
 
@@ -944,13 +944,13 @@ hw.module @wire3() {
 // CHECK-NEXT:   %true = hw.constant true
 // CHECK-NEXT:   %0 = sv.wire sym @symName : !hw.inout<i1>
 // CHECK-NEXT:   %1 = sv.read_inout %0 : !hw.inout<i1>
-// CHECK-NEXT:   sv.connect %0, %true : i1
+// CHECK-NEXT:   sv.assign %0, %true : i1
 // CHECK-NEXT:   hw.output %1 : i1
 hw.module @wire4() -> (i1) {
   %true = hw.constant true
   %0 = sv.wire sym @symName : !hw.inout<i1>
   %1 = sv.read_inout %0 : !hw.inout<i1>
-  sv.connect %0, %true : i1
+  sv.assign %0, %true : i1
   hw.output %1 : i1
 }
 
@@ -961,7 +961,7 @@ hw.module @wire4_1() -> (i1) {
   %true = hw.constant true
   %0 = sv.wire : !hw.inout<i1>
   %1 = sv.read_inout %0 : !hw.inout<i1>
-  sv.connect %0, %true : i1
+  sv.assign %0, %true : i1
   hw.output %1 : i1
 }
 
@@ -993,7 +993,7 @@ hw.module @instance_ooo(%arg0: i2, %arg1: i2, %arg2: i3) -> (%out0: i8) {
     %2 = comb.concat %false, %arg0 : (i1, i2) -> i3
     %3 = comb.add %1, %2 : i3
     %4 = comb.icmp eq %3, %arg2 : i3
-    sv.connect %.in.wire, %4 : i1
+    sv.assign %.in.wire, %4 : i1
     hw.output %myext.out : i8
 }
 
@@ -1015,13 +1015,13 @@ hw.module @TestInstance(%u2: i2, %s8: i8, %clock: i1, %reset: i1) {
   %2 = sv.read_inout %.in3.wire : !hw.inout<i8>
   %xyz.out4 = hw.instance "xyz" @Simple(%0, %1, %2) : (i4, i2, i8) -> i4
   %3 = comb.concat %c0_i2, %u2 : (i2, i2) -> i4
-  sv.connect %.in1.wire, %3 : i4
-  sv.connect %.in2.wire, %u2 : i2
-  sv.connect %.in3.wire, %s8 : i8
+  sv.assign %.in1.wire, %3 : i4
+  sv.assign %.in2.wire, %u2 : i2
+  sv.assign %.in3.wire, %s8 : i8
   %.in.wire = sv.wire  : !hw.inout<i1>
   %4 = sv.read_inout %.in.wire : !hw.inout<i1>
   %myext.out = hw.instance "myext" @MyParameterizedExtModule(%4) {parameters = {DEFAULT = 0 : i64, DEPTH = 3.242000e+01 : f64, FORMAT = "xyz_timeout=%d\0A", WIDTH = 32 : i8}} : (i1) -> i8
-  sv.connect %.in.wire, %reset : i1
+  sv.assign %.in.wire, %reset : i1
   hw.output
 }
 
@@ -1035,7 +1035,7 @@ hw.module @instance_cyclic(%arg0: i2, %arg1: i2) {
   %0 = sv.read_inout %.in.wire : !hw.inout<i1>
   %myext.out = hw.instance "myext" @MyParameterizedExtModule(%0) {parameters = {DEFAULT = 0 : i64, DEPTH = 3.242000e+01 : f64, FORMAT = "xyz_timeout=%d\0A", WIDTH = 32 : i8}} : (i1) -> i8
   %1 = comb.extract %myext.out from 2 : (i8) -> i1
-  sv.connect %.in.wire, %1 : i1
+  sv.assign %.in.wire, %1 : i1
   hw.output
 }
 
@@ -1048,7 +1048,7 @@ hw.module @ZeroWidthInstance(%iA: i4) -> (%oA: i4) {
   %.inA.wire = sv.wire  : !hw.inout<i4>
   %0 = sv.read_inout %.inA.wire : !hw.inout<i4>
   %myinst.outa = hw.instance "myinst" @ZeroWidthPorts(%0) : (i4) -> i4
-  sv.connect %.inA.wire, %iA : i4
+  sv.assign %.inA.wire, %iA : i4
   hw.output %myinst.outa : i4
 }
 
@@ -1095,33 +1095,33 @@ hw.module @unintializedWire(%clock1: i1, %clock2: i1, %inpred: i1, %indata: i42)
   %_M.ro_data_0, %_M.rw_rdata_0 = hw.instance "_M" @FIRRTLMem_1_1_1_42_12_0_1_0(%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13) : (i1, i1, i4, i1, i1, i4, i1, i1, i42, i1, i1, i4, i1, i42) -> (i42, i42)
   %14 = sv.read_inout %.read.addr.wire : !hw.inout<i4>
   %c0_i4 = hw.constant 0 : i4
-  sv.connect %.read.addr.wire, %c0_i4 : i4
+  sv.assign %.read.addr.wire, %c0_i4 : i4
   %15 = sv.read_inout %.read.en.wire : !hw.inout<i1>
-  sv.connect %.read.en.wire, %true : i1
+  sv.assign %.read.en.wire, %true : i1
   %16 = sv.read_inout %.read.clk.wire : !hw.inout<i1>
-  sv.connect %.read.clk.wire, %clock1 : i1
+  sv.assign %.read.clk.wire, %clock1 : i1
   %17 = sv.read_inout %.rw.addr.wire : !hw.inout<i4>
   %c0_i4_0 = hw.constant 0 : i4
-  sv.connect %.rw.addr.wire, %c0_i4_0 : i4
+  sv.assign %.rw.addr.wire, %c0_i4_0 : i4
   %18 = sv.read_inout %.rw.en.wire : !hw.inout<i1>
-  sv.connect %.rw.en.wire, %true : i1
+  sv.assign %.rw.en.wire, %true : i1
   %19 = sv.read_inout %.rw.clk.wire : !hw.inout<i1>
-  sv.connect %.rw.clk.wire, %clock1 : i1
+  sv.assign %.rw.clk.wire, %clock1 : i1
   %20 = sv.read_inout %.rw.wmask.wire : !hw.inout<i1>
-  sv.connect %.rw.wmask.wire, %true : i1
+  sv.assign %.rw.wmask.wire, %true : i1
   %21 = sv.read_inout %.rw.wmode.wire : !hw.inout<i1>
-  sv.connect %.rw.wmode.wire, %true : i1
+  sv.assign %.rw.wmode.wire, %true : i1
   %22 = sv.read_inout %.write.addr.wire : !hw.inout<i4>
   %c0_i4_1 = hw.constant 0 : i4
-  sv.connect %.write.addr.wire, %c0_i4_1 : i4
+  sv.assign %.write.addr.wire, %c0_i4_1 : i4
   %23 = sv.read_inout %.write.en.wire : !hw.inout<i1>
-  sv.connect %.write.en.wire, %inpred : i1
+  sv.assign %.write.en.wire, %inpred : i1
   %24 = sv.read_inout %.write.clk.wire : !hw.inout<i1>
-  sv.connect %.write.clk.wire, %clock2 : i1
+  sv.assign %.write.clk.wire, %clock2 : i1
   %25 = sv.read_inout %.write.data.wire : !hw.inout<i42>
-  sv.connect %.write.data.wire, %indata : i42
+  sv.assign %.write.data.wire, %indata : i42
   %26 = sv.read_inout %.write.mask.wire : !hw.inout<i1>
-  sv.connect %.write.mask.wire, %true : i1
+  sv.assign %.write.mask.wire, %true : i1
   hw.output %_M.ro_data_0, %_M.rw_rdata_0 : i42, i42
 }
 
@@ -1145,11 +1145,11 @@ hw.module @IncompleteRead(%clock1: i1) {
   %_M.ro_data_0 = hw.instance "_M" @FIRRTLMem_1_0_0_42_12_0_1_0(%0, %1, %2) : (i1, i1, i4) -> i42
   %3 = sv.read_inout %.read.addr.wire : !hw.inout<i4>
   %c0_i4 = hw.constant 0 : i4
-  sv.connect %.read.addr.wire, %c0_i4 : i4
+  sv.assign %.read.addr.wire, %c0_i4 : i4
   %4 = sv.read_inout %.read.en.wire : !hw.inout<i1>
-  sv.connect %.read.en.wire, %true : i1
+  sv.assign %.read.en.wire, %true : i1
   %5 = sv.read_inout %.read.clk.wire : !hw.inout<i1>
-  sv.connect %.read.clk.wire, %clock1 : i1
+  sv.assign %.read.clk.wire, %clock1 : i1
   hw.output
 }
 
@@ -1165,10 +1165,10 @@ hw.module @foo() {
   %0 = sv.read_inout %.io_cpu_flush.wire : !hw.inout<i1>
   hw.instance "fetch" @bar(%0) : (i1) -> ()
   %1 = sv.read_inout %io_cpu_flush.wire : !hw.inout<i1>
-  sv.connect %.io_cpu_flush.wire, %1 : i1
+  sv.assign %.io_cpu_flush.wire, %1 : i1
   %2 = sv.read_inout %io_cpu_flush.wire : !hw.inout<i1>
   %hits_1_7 = sv.wire  : !hw.inout<i1>
-  sv.connect %hits_1_7, %2 : i1
+  sv.assign %hits_1_7, %2 : i1
   hw.output
 }
 
@@ -1186,11 +1186,11 @@ hw.module @MemDepth1(%clock: i1, %en: i1, %addr: i1) -> (%data: i32) {
   %2 = sv.read_inout %.load0.addr.wire : !hw.inout<i1>
   %mem0.ro_data_0 = hw.instance "mem0" @FIRRTLMem_1_0_0_32_1_0_1_1(%0, %1, %2) : (i1, i1, i1) -> i32
   %3 = sv.read_inout %.load0.clk.wire : !hw.inout<i1>
-  sv.connect %.load0.clk.wire, %clock : i1
+  sv.assign %.load0.clk.wire, %clock : i1
   %4 = sv.read_inout %.load0.addr.wire : !hw.inout<i1>
-  sv.connect %.load0.addr.wire, %addr : i1
+  sv.assign %.load0.addr.wire, %addr : i1
   %5 = sv.read_inout %.load0.en.wire : !hw.inout<i1>
-  sv.connect %.load0.en.wire, %en : i1
+  sv.assign %.load0.en.wire, %en : i1
   hw.output %mem0.ro_data_0 : i32
 }
 

--- a/test/Dialect/HW/modules.mlir
+++ b/test/Dialect/HW/modules.mlir
@@ -30,7 +30,7 @@ module {
     // Instantiate @C with a public symbol on the instance
     %f, %g = hw.instance "c1" sym @E @C(%d) : (i1) -> (i1, i1)
     // Connect the inout port with %f
-    sv.connect %e, %f : i1
+    sv.assign %e, %f : i1
     // Output values
     hw.output %g, %r1 : i1, i1
   }

--- a/test/Dialect/SV/prettify-verilog.mlir
+++ b/test/Dialect/SV/prettify-verilog.mlir
@@ -31,22 +31,26 @@ hw.module @sink_constants(%clock :i1) -> (%out : i1){
   %true = hw.constant true
 
   /// Simple constant sinking.
-  sv.ifdef.procedural "FOO" {
-    // CHECK: [[TRUE:%.*]] = hw.constant true
-    // CHECK: [[FALSE:%.*]] = hw.constant false
-    // CHECK: sv.fwrite "%x"([[TRUE]]) : i1
-    sv.fwrite "%x"(%true) : i1
-    // CHECK: sv.fwrite "%x"([[FALSE]]) : i1
-    sv.fwrite "%x"(%false) : i1
+  sv.ifdef "FOO" {
+    sv.initial {
+      // CHECK: [[TRUE:%.*]] = hw.constant true
+      // CHECK: [[FALSE:%.*]] = hw.constant false
+      // CHECK: sv.fwrite "%x"([[TRUE]]) : i1
+      sv.fwrite "%x"(%true) : i1
+      // CHECK: sv.fwrite "%x"([[FALSE]]) : i1
+      sv.fwrite "%x"(%false) : i1
+    }
   }
 
   /// Multiple uses in the same block should use the same constant.
-  sv.ifdef.procedural "FOO" {
-    // CHECK: [[TRUE:%.*]] = hw.constant true
-    // CHECK: sv.fwrite "%x"([[TRUE]]) : i1
-    // CHECK: sv.fwrite "%x"([[TRUE]]) : i1
-    sv.fwrite "%x"(%true) : i1
-    sv.fwrite "%x"(%true) : i1
+  sv.ifdef "FOO" {
+    sv.initial {
+      // CHECK: [[TRUE:%.*]] = hw.constant true
+      // CHECK: sv.fwrite "%x"([[TRUE]]) : i1
+      // CHECK: sv.fwrite "%x"([[TRUE]]) : i1
+      sv.fwrite "%x"(%true) : i1
+      sv.fwrite "%x"(%true) : i1
+    }
   }
 
   // CHECK: hw.output %false : i1

--- a/test/ExportVerilog/hw-dialect.mlir
+++ b/test/ExportVerilog/hw-dialect.mlir
@@ -327,21 +327,21 @@ hw.module @wires(%in4: i4, %in8: i8) -> (%a: i4, %b: i8, %c: i8) {
   // Wires.
 
   // CHECK-NEXT: assign myWire = in4;
-  sv.connect %myWire, %in4 : i4
+  sv.assign %myWire, %in4 : i4
   %wireout = sv.read_inout %myWire : !hw.inout<i4>
 
   // Packed arrays.
 
   %subscript = sv.array_index_inout %myArray1[%in4] : !hw.inout<array<42 x i8>>, i4
   // CHECK-NEXT: assign myArray1[in4] = in8;
-  sv.connect %subscript, %in8 : i8
+  sv.assign %subscript, %in8 : i8
 
   %memout1 = sv.read_inout %subscript : !hw.inout<i8>
 
     // Unpacked arrays, and unpacked arrays of packed arrays.
   %subscriptu = sv.array_index_inout %myUArray1[%in4] : !hw.inout<uarray<42 x i8>>, i4
   // CHECK-NEXT: assign myUArray1[in4] = in8;
-  sv.connect %subscriptu, %in8 : i8
+  sv.assign %subscriptu, %in8 : i8
 
   %memout2 = sv.read_inout %subscriptu : !hw.inout<i8>
 
@@ -376,7 +376,7 @@ hw.module @signs(%in1: i4, %in2: i4, %in3: i4, %in4: i4)  {
   %a1 = comb.divs %in1, %in2: i4
   %a2 = comb.divs %in3, %in4: i4
   %a3 = comb.divu %a1, %a2: i4
-  sv.connect %awire, %a3: i4
+  sv.assign %awire, %a3: i4
 
   // CHECK: wire [3:0] _tmp = $signed(in1) / $signed(in2) + $signed(in1) / $signed(in2);
   // CHECK: wire [3:0] _tmp_0 = $signed(in1) / $signed(in2) * $signed(in1) / $signed(in2);
@@ -388,14 +388,14 @@ hw.module @signs(%in1: i4, %in2: i4, %in3: i4, %in4: i4)  {
   %b2 = comb.add %b1a, %b1b: i4
   %b3 = comb.mul %b1c, %b1d: i4
   %b4 = comb.divu %b2, %b3: i4
-  sv.connect %awire, %b4: i4
+  sv.assign %awire, %b4: i4
 
   // https://github.com/llvm/circt/issues/369
   // CHECK: assign awire = 4'sh5 / -4'sh3;
   %c5_i4 = hw.constant 5 : i4
   %c-3_i4 = hw.constant -3 : i4
   %divs = comb.divs %c5_i4, %c-3_i4 : i4
-  sv.connect %awire, %divs: i4
+  sv.assign %awire, %divs: i4
 
   hw.output
 }

--- a/test/ExportVerilog/sv-dialect.mlir
+++ b/test/ExportVerilog/sv-dialect.mlir
@@ -301,10 +301,10 @@ hw.module @reg_0(%in4: i4, %in8: i8) -> (%a: i8, %b: i8) {
   %myRegArray1 = sv.reg : !hw.inout<array<42 x i8>>
 
   // CHECK-EMPTY:
-  sv.connect %myReg, %in8 : i8        // CHECK-NEXT: assign myReg = in8;
+  sv.assign %myReg, %in8 : i8        // CHECK-NEXT: assign myReg = in8;
 
   %subscript1 = sv.array_index_inout %myRegArray1[%in4] : !hw.inout<array<42 x i8>>, i4
-  sv.connect %subscript1, %in8 : i8   // CHECK-NEXT: assign myRegArray1[in4] = in8;
+  sv.assign %subscript1, %in8 : i8   // CHECK-NEXT: assign myRegArray1[in4] = in8;
 
   %regout = sv.read_inout %myReg : !hw.inout<i8>
 
@@ -655,7 +655,7 @@ hw.module @oooReg(%in: i1) -> (%result: i1) {
   %0 = sv.read_inout %abc : !hw.inout<i1>
 
   // CHECK: assign abc = in;
-  sv.connect %abc, %in : i1
+  sv.assign %abc, %in : i1
   %abc = sv.wire  : !hw.inout<i1>
 
   // CHECK: assign result = abc;

--- a/test/ExportVerilog/verilog-basic.mlir
+++ b/test/ExportVerilog/verilog-basic.mlir
@@ -146,17 +146,17 @@ hw.module @Precedence(%a: i4, %b: i4, %c: i4) -> (%out1: i1, %out: i10) {
   %4 = comb.concat %false, %2 : (i1, i5) -> i6
   %5 = comb.add %3, %4 : i6
   %6 = comb.concat %c0_i4, %5 : (i4, i6) -> i10
-  sv.connect %_out_output, %6 : i10
+  sv.assign %_out_output, %6 : i10
   %7 = comb.concat %false, %a : (i1, i4) -> i5
   %8 = comb.add %7, %0 : i5
   %9 = comb.concat %false, %8 : (i1, i5) -> i6
   %10 = comb.concat %c0_i2, %c : (i2, i4) -> i6
   %11 = comb.sub %9, %10 : i6
   %12 = comb.concat %c0_i4, %11 : (i4, i6) -> i10
-  sv.connect %_out_output, %12 : i10
+  sv.assign %_out_output, %12 : i10
   %13 = comb.sub %3, %4 : i6
   %14 = comb.concat %c0_i4, %13 : (i4, i6) -> i10
-  sv.connect %_out_output, %14 : i10
+  sv.assign %_out_output, %14 : i10
   %15 = comb.concat %c0_i4, %b : (i4, i4) -> i8
   %16 = comb.concat %c0_i4, %c : (i4, i4) -> i8
   %17 = comb.mul %15, %16 : i8
@@ -164,45 +164,45 @@ hw.module @Precedence(%a: i4, %b: i4, %c: i4) -> (%out1: i1, %out: i10) {
   %19 = comb.concat %false, %17 : (i1, i8) -> i9
   %20 = comb.add %18, %19 : i9
   %21 = comb.concat %false, %20 : (i1, i9) -> i10
-  sv.connect %_out_output, %21 : i10
+  sv.assign %_out_output, %21 : i10
   %22 = comb.concat %c0_i4, %a : (i4, i4) -> i8
   %23 = comb.mul %22, %15 : i8
   %24 = comb.concat %false, %23 : (i1, i8) -> i9
   %25 = comb.concat %c0_i5, %c : (i5, i4) -> i9
   %26 = comb.add %24, %25 : i9
   %27 = comb.concat %false, %26 : (i1, i9) -> i10
-  sv.connect %_out_output, %27 : i10
+  sv.assign %_out_output, %27 : i10
   %28 = comb.concat %c0_i4, %8 : (i4, i5) -> i9
   %29 = comb.mul %28, %25 : i9
   %30 = comb.concat %false, %29 : (i1, i9) -> i10
-  sv.connect %_out_output, %30 : i10
+  sv.assign %_out_output, %30 : i10
   %31 = comb.concat %c0_i4, %2 : (i4, i5) -> i9
   %32 = comb.mul %18, %31 : i9
   %33 = comb.concat %false, %32 : (i1, i9) -> i10
-  sv.connect %_out_output, %33 : i10
+  sv.assign %_out_output, %33 : i10
   %34 = comb.concat %c0_i5, %8 : (i5, i5) -> i10
   %35 = comb.concat %c0_i5, %2 : (i5, i5) -> i10
   %36 = comb.mul %34, %35 : i10
-  sv.connect %_out_output, %36 : i10
+  sv.assign %_out_output, %36 : i10
   %37 = comb.parity %2 : i5
-  sv.connect %_out1_output, %37 : i1
+  sv.assign %_out1_output, %37 : i1
   %38 = comb.icmp ult %b, %c : i4
   %39 = comb.icmp ugt %b, %c : i4
   %40 = comb.or %38, %39 : i1
-  sv.connect %_out1_output, %40 : i1
+  sv.assign %_out1_output, %40 : i1
   %41 = comb.xor %b, %c : i4
   %42 = sv.read_inout %_out1_output : !hw.inout<i1>
   %43 = comb.concat %c0_i3, %42 : (i3, i1) -> i4
   %44 = comb.and %41, %43 : i4
   %45 = comb.concat %c0_i6, %44 : (i6, i4) -> i10
-  sv.connect %_out_output, %45 : i10
+  sv.assign %_out_output, %45 : i10
   %46 = sv.read_inout %_out_output : !hw.inout<i10>
   %47 = comb.extract %46 from 2 : (i10) -> i8
   %48 = comb.concat %c0_i2, %47 : (i2, i8) -> i10
-  sv.connect %_out_output, %48 : i10
+  sv.assign %_out_output, %48 : i10
   %49 = comb.concat %c0_i6, %a : (i6, i4) -> i10
   %50 = comb.icmp ult %46, %49 : i10
-  sv.connect %_out1_output, %50 : i1
+  sv.assign %_out1_output, %50 : i1
   hw.output %42, %46 : i1, i10
 }
 

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -73,9 +73,9 @@ circuit test_mod : %[[{"a": "a"}]]
 ; MLIRLOWER-NEXT :     %1 = comb.concat %c0_i5, %inp_1 : (i5, i1) -> i6
 ; MLIRLOWER-NEXT :     %2 = comb.shl %0, %1 : i6
 ; MLIRLOWER-NEXT :     %3 = comb.extract %2 from 0 : (i6) -> i3
-; MLIRLOWER-NEXT :     sv.connect %.out1.output, %3 : i3
+; MLIRLOWER-NEXT :     sv.assign %.out1.output, %3 : i3
 ; MLIRLOWER-NEXT :     %4 = comb.extract %inp_2 from 0 : (i5) -> i3
-; MLIRLOWER-NEXT :     sv.connect %.out2.output, %4 : i3
+; MLIRLOWER-NEXT :     sv.assign %.out2.output, %4 : i3
 ; MLIRLOWER-NEXT :     %5 = sv.read_inout %.out1.output : !hw.inout<i3>
 ; MLIRLOWER-NEXT :     %6 = sv.read_inout %.out2.output : !hw.inout<i3>
 ; MLIRLOWER-NEXT :     hw.output %5, %6 : i3, i3

--- a/test/firtool/split-verilog.mlir
+++ b/test/firtool/split-verilog.mlir
@@ -10,7 +10,7 @@
 // RUN: FileCheck %s --check-prefix=LIST < %t/filelist.f
 
 sv.verbatim "// I'm everywhere"
-sv.ifdef.procedural "VERILATOR" {
+sv.ifdef "VERILATOR" {
   sv.verbatim "// Hello"
 } else {
   sv.verbatim "// World"


### PR DESCRIPTION
sv.connect was a hold-over from firrtl and doesn't correspond to any sv construct.  It is roughly an sv assignment statement.  Add such an operation and remove sv.connect.