### PR TITLE
[SV] Fix the parameter integer printing for widths >32 bits

### DIFF
--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -2392,23 +2392,23 @@ LogicalResult StmtEmitter::visitStmt(InstanceOp op) {
   // Helper that prints a parameter constant value in a Verilog compatible way.
   auto printParmValue = [&](Attribute value) {
     if (auto intAttr = value.dyn_cast<IntegerAttr>()) {
-      // Sign comes out before any width specifier.
+      IntegerType intTy = intAttr.getType().cast<IntegerType>();
       APInt value = intAttr.getValue();
-      unsigned signBitWidth = 0;
-      if (value.isNegative()) {
-        os << '-';
-        value = -value;
-        signBitWidth = 1;
+
+      // We omit the width specifier if the value is <= 32-bits in size, which
+      // makes this more compatible with unknown width extmodules.
+      if (intTy.getWidth() > 32) {
+        // Sign comes out before any width specifier.
+        if (intTy.isSigned() && value.isNegative()) {
+          os << '-';
+          value = -value;
+        }
+        if (intTy.isSigned())
+          os << intTy.getWidth() << "'sd";
+        else
+          os << intTy.getWidth() << "'d";
       }
-
-      // The signedness and width of the integer attribute type is arbitrary,
-      // we just look at the active bits of the parameter.  We omit the width
-      // specifier if the value is <= 32-bits in size, which makes this more
-      // compatible with unknown width extmodules.
-      if (value.getActiveBits() >= 32)
-        os << (value.getActiveBits() + signBitWidth) << "'d";
-
-      os << value;
+      value.print(os, intTy.isSigned());
     } else if (auto strAttr = value.dyn_cast<StringAttr>()) {
       os << '"';
       os.write_escaped(strAttr.getValue());

--- a/test/ExportVerilog/hw-dialect.mlir
+++ b/test/ExportVerilog/hw-dialect.mlir
@@ -201,7 +201,7 @@ hw.module @AB(%w: i1, %x: i1, %i2: i2, %i3: i0) -> (%y: i1, %z: i1, %p: i1, %p2:
 
   %p = hw.instance "paramd" @EXT_W_PARAMS(%w, %i3) {parameters = {DEFAULT = 14000240888948784983 : i64, DEPTH = 3.242000e+01 : f64, FORMAT = "xyz_timeout=%d\0A", WIDTH = 32 : i8}} : (i1, i0) -> i1
 
-  %p2 = hw.instance "paramd2" @EXT_W_PARAMS2(%i2) {parameters = {DEFAULT = 1 : i64}} : (i2) -> i1
+  %p2 = hw.instance "paramd2" @EXT_W_PARAMS2(%i2) {parameters = {DEFAULT = 1 : i32}} : (i2) -> i1
 
   hw.output %y, %x, %p, %p2 : i1, i1, i1, i1
 }
@@ -225,7 +225,7 @@ hw.module @AB(%w: i1, %x: i1, %i2: i2, %i3: i0) -> (%y: i1, %z: i1, %p: i1, %p2:
 // CHECK-NEXT:     .c (y)
 // CHECK-NEXT:   );
 // CHECK-NEXT:   FooModule #(
-// CHECK-NEXT:     .DEFAULT(-63'd4446503184760766633),
+// CHECK-NEXT:     .DEFAULT(64'd14000240888948784983),
 // CHECK-NEXT:     .DEPTH(3.242000e+01),
 // CHECK-NEXT:     .FORMAT("xyz_timeout=%d\n"),
 // CHECK-NEXT:     .WIDTH(32)
@@ -718,15 +718,15 @@ hw.module @Chi() -> (%Chi_output : i0) {
 
  hw.module @Foo1360() {
    // CHECK:      RealBar #(
-   // CHECK-NEXT:   .WIDTH0(0),
+   // CHECK-NEXT:   .WIDTH0(64'd0),
    // CHECK-NEXT:   .WIDTH1(4),
-   // CHECK-NEXT:   .WIDTH2(33'd6812312123),
+   // CHECK-NEXT:   .WIDTH2(40'd6812312123),
    // CHECK-NEXT:   .WIDTH3(-1),
-   // CHECK-NEXT:   .WIDTH4(-58'd88888888888888888),
-   // CHECK-NEXT:   .Wtricky(32'd4294967295)
+   // CHECK-NEXT:   .WIDTH4(-68'sd88888888888888888),
+   // CHECK-NEXT:   .Wtricky(40'd4294967295)
    // CHECK-NEXT: ) bar ();
    
-   hw.instance "bar" @Bar1360() {parameters = {WIDTH0 = 0 : i64, WIDTH1 = 4 : i4, WIDTH2 = 6812312123 : i40, WIDTH3 = -1 : i4, WIDTH4 = -88888888888888888 : i68, Wtricky = 4294967295 : i40}} : () -> ()
+   hw.instance "bar" @Bar1360() {parameters = {WIDTH0 = 0 : i64, WIDTH1 = 4 : i4, WIDTH2 = 6812312123 : i40, WIDTH3 = -1 : si4, WIDTH4 = -88888888888888888 : si68, Wtricky = 4294967295 : i40}} : () -> ()
    hw.output
  }
  hw.module.extern @Bar1360() attributes {verilogName = "RealBar"}

--- a/test/ExportVerilog/verilog-basic.mlir
+++ b/test/ExportVerilog/verilog-basic.mlir
@@ -287,7 +287,7 @@ hw.module @UseInstances(%a_in: i8) -> (%a_out: i1) {
   // CHECK:   .out (xyz_out)
   // CHECK: );
   // CHECK: MyParameterizedExtModule #(
-  // CHECK:   .DEFAULT(0),
+  // CHECK:   .DEFAULT(64'd0),
   // CHECK:   .DEPTH(3.500000e+00),
   // CHECK:   .FORMAT("xyz_timeout=%d\n"),
   // CHECK:   .WIDTH(32)


### PR DESCRIPTION
- Print the bitwidth when the width is >32 bits.
- Use "'sd" for signed numbers.