### PR TITLE
[FIRRTL] Try to get windows compiling

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1581,7 +1581,10 @@ ParseResult FIRStmtParser::parseExpImpl(Value &result, const Twine &message,
                                         bool isLeadingStmt) {
   switch (getToken().getKind()) {
 
-    // Handle all the primitive ops: primop exp* intLit*  ')'
+    // Handle all the primitive ops: primop exp* intLit*  ')'.  There is a
+    // redundant definition of TOK_LPKEYWORD_PRIM which is needed to to get
+    // around a bug in the MSVC preprocessor to properly paste together the
+    // tokens lp_##SPELLING.
 #define TOK_LPKEYWORD(SPELLING) case FIRToken::lp_##SPELLING:
 #define TOK_LPKEYWORD_PRIM(SPELLING, CLASS, NUMOPERANDS)                       \
   case FIRToken::lp_##SPELLING:

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1583,6 +1583,8 @@ ParseResult FIRStmtParser::parseExpImpl(Value &result, const Twine &message,
 
     // Handle all the primitive ops: primop exp* intLit*  ')'
 #define TOK_LPKEYWORD(SPELLING) case FIRToken::lp_##SPELLING:
+#define TOK_LPKEYWORD_PRIM(SPELLING, CLASS, NUMOPERANDS)                       \
+  case FIRToken::lp_##SPELLING:
 #include "FIRTokenKinds.def"
     if (parsePrimExp(result))
       return failure();


### PR DESCRIPTION
Windows is failing to token paste `add`, `not`, `or`, and `xor` when
expanding the macros. The macro `TOK_LPKEYWORD_PRIM` normally delegates
to `TOK_LPKEYWORD` when it is not defined by the user.

Windows build running here, will check this in the morning: https://github.com/llvm/circt/actions/runs/1032980651