### PR TITLE
[SV][ExportVerilog] Add Ability to Bind Interfaces

### DIFF
--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -607,3 +607,19 @@ def BindOp : SVOp<"bind", []> {
     hw::InstanceOp getReferencedInstance();
   }];
 }
+
+def BindInterfaceOp : SVOp<"bind.interface", []> {
+  let summary = "indirectly instantiate an interface";
+  let description = [{
+    Indirectly instantiate an interface in the context of another module. This
+    operation must pair with a `sv.interface.instance`.
+  }];
+  let arguments = (ins FlatSymbolRefAttr:$interface);
+  let results = (outs);
+  let verifier = "return ::verify$cppClass(*this);";
+  let assemblyFormat = [{ $interface attr-dict }];
+  let extraClassDeclaration = [{
+    sv::InterfaceInstanceOp getReferencedInstance();
+  }];
+
+}

--- a/include/circt/Dialect/SV/SVTypeDecl.td
+++ b/include/circt/Dialect/SV/SVTypeDecl.td
@@ -188,7 +188,7 @@ def ModportType : SVType<"Modport"> {
 // Other operations
 //===----------------------------------------------------------------------===//
 
-def InterfaceInstanceOp : SVOp<"interface.instance", [NoSideEffect]> {
+def InterfaceInstanceOp : SVOp<"interface.instance", []> {
   let summary = "Instantiate an interface";
   let description = [{
     Use this to declare an instance of an interface:
@@ -197,10 +197,18 @@ def InterfaceInstanceOp : SVOp<"interface.instance", [NoSideEffect]> {
     ```
   }];
 
-  let arguments = (ins);
+  let arguments = (ins StrAttr:$name,
+                       OptionalAttr<SymbolNameAttr>:$sym_name);
   let results = (outs InterfaceType : $result);
 
-  let assemblyFormat = "attr-dict `:` type($result)";
+  let assemblyFormat =
+    "(`sym` $sym_name^)? custom<ImplicitSSAName>(attr-dict) `:` type($result)";
+
+  let builders = [
+    OpBuilder<(ins "::mlir::Type":$result), [{
+      return build($_builder, $_state, result, None);
+    }]>
+  ];
 
   let verifier = "return ::verifyInterfaceInstanceOp(*this);";
 

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -1074,6 +1074,31 @@ static void printOmitEmptyStringAttr(OpAsmPrinter &p, Operation *op,
 }
 
 //===----------------------------------------------------------------------===//
+// BindInterfaceOp
+//===----------------------------------------------------------------------===//
+
+sv::InterfaceInstanceOp BindInterfaceOp::getReferencedInstance() {
+  auto topLevelModuleOp = (*this)->getParentOfType<ModuleOp>();
+  if (!topLevelModuleOp)
+    return nullptr;
+
+  /// Lookup the instance for the symbol.  This returns null on
+  /// invalid IR.
+  auto *inst = lookupSymbolInNested(topLevelModuleOp, interface());
+  return dyn_cast_or_null<sv::InterfaceInstanceOp>(inst);
+}
+
+/// Ensure that the symbol being instantiated exists and is an InterfaceOp.
+static LogicalResult verifyBindInterfaceOp(BindInterfaceOp op) {
+  auto inst = op.getReferencedInstance();
+  if (!inst)
+    return op.emitError("Referenced interface doesn't exist");
+  if (!inst->getAttr("doNotPrint"))
+    return op.emitError("Referenced interface isn't marked as doNotPrint");
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // TableGen generated logic.
 //===----------------------------------------------------------------------===//
 

--- a/test/Dialect/ESI/connectivity.mlir
+++ b/test/Dialect/ESI/connectivity.mlir
@@ -64,7 +64,7 @@ hw.module @testIfaceWrap() {
   %idataChanOut = esi.wrap.iface %ifaceOutSink: !sv.modport<@IData::@Sink> -> !esi.channel<i32>
 
   // CHECK-LABEL:  hw.module @testIfaceWrap() {
-  // CHECK-NEXT:     %0 = sv.interface.instance : !sv.interface<@IData>
+  // CHECK-NEXT:     %0 = sv.interface.instance {name = "ifaceOut"} : !sv.interface<@IData>
   // CHECK-NEXT:     %1 = sv.modport.get %0 @Source : !sv.interface<@IData> -> !sv.modport<@IData::@Source>
   // CHECK-NEXT:     hw.instance "ifaceSender" @IFaceSender(%1) : (!sv.modport<@IData::@Source>) -> ()
   // CHECK-NEXT:     %2 = sv.modport.get %0 @Sink : !sv.interface<@IData> -> !sv.modport<@IData::@Sink>
@@ -76,7 +76,7 @@ hw.module @testIfaceWrap() {
   %ifaceInSource = sv.modport.get %ifaceIn @Sink : !sv.interface<@IData> -> !sv.modport<@IData::@Source>
   esi.unwrap.iface %idataChanOut into %ifaceInSource : (!esi.channel<i32>, !sv.modport<@IData::@Source>)
 
-  // CHECK-NEXT:     %4 = sv.interface.instance : !sv.interface<@IData>
+  // CHECK-NEXT:     %4 = sv.interface.instance {name = "ifaceIn"} : !sv.interface<@IData>
   // CHECK-NEXT:     %5 = sv.modport.get %4 @Sink : !sv.interface<@IData> -> !sv.modport<@IData::@Sink>
   // CHECK-NEXT:     hw.instance "ifaceRcvr" @IFaceRcvr(%5) : (!sv.modport<@IData::@Sink>) -> ()
   // CHECK-NEXT:     %6 = sv.modport.get %4 @Sink : !sv.interface<@IData> -> !sv.modport<@IData::@Source>

--- a/test/Dialect/SV/interfaces.mlir
+++ b/test/Dialect/SV/interfaces.mlir
@@ -49,7 +49,7 @@ module {
     sv.interface.signal.assign %iface(@handshake_example::@data) = %zero32 : i32
   }
   // CHECK-LABEL: hw.module @Top() {
-  // CHECK-NEXT:    %0 = sv.interface.instance : !sv.interface<@handshake_example>
+  // CHECK-NEXT:    %0 = sv.interface.instance {name = "iface"} : !sv.interface<@handshake_example>
   // CHECK-NEXT:    %1 = sv.modport.get %0 @dataflow_in : !sv.interface<@handshake_example> -> !sv.modport<@handshake_example::@dataflow_in>
   // CHECK-NEXT:    hw.instance "rcvr" @Rcvr(%1) : (!sv.modport<@handshake_example::@dataflow_in>) -> ()
   // CHECK-NEXT:    %2 = sv.interface.signal.read %0(@handshake_example::@data) : i32

--- a/test/ExportVerilog/sv-interfaces.mlir
+++ b/test/ExportVerilog/sv-interfaces.mlir
@@ -61,14 +61,14 @@ module {
     hw.instance "rcvr2" @Rcvr(%ifaceInPort) : (!sv.modport<@data_vr::@data_in>) -> ()
 
     %c1 = hw.constant 1 : i1
-    // CHECK: assign _T.valid = 1'h1;
+    // CHECK: assign iface.valid = 1'h1;
     sv.interface.signal.assign %iface(@data_vr::@valid) = %c1 : i1
 
     sv.always posedge %clk {
       %validValue = sv.interface.signal.read %iface(@data_vr::@valid) : i1
-      // CHECK: $fwrite(32'h80000002, "valid: %d\n", _T.valid);
+      // CHECK: $fwrite(32'h80000002, "valid: %d\n", iface.valid);
       sv.fwrite "valid: %d\n" (%validValue) : i1
-      // CHECK: assert(_T.valid);
+      // CHECK: assert(iface.valid);
       sv.assert %validValue : i1
 
       sv.if %clk {
@@ -115,7 +115,7 @@ module {
   // CHECK-NOT: wire [383:0] _tmp =
   // CHECK: endmodule
   hw.module @structs(%clk: i1, %rstn: i1) {
-    %0 = sv.interface.instance : !sv.interface<@IValidReady_Struct>
+    %0 = sv.interface.instance {name = "iface"} : !sv.interface<@IValidReady_Struct>
     sv.interface.signal.assign %0(@IValidReady_Struct::@data) = %s : !hw.struct<foo: !hw.array<384xi1>>
     %c0 = hw.constant 0 : i8
     %c64 = hw.constant 100000 : i64

--- a/test/ExportVerilog/sv-interfaces.mlir
+++ b/test/ExportVerilog/sv-interfaces.mlir
@@ -41,12 +41,11 @@ module {
 
   // CHECK-LABEL: module Top
   hw.module @Top (%clk: i1) {
-    // CHECK: data_vr   [[IFACE:.+]]();
+    // CHECK: data_vr [[IFACE:.+]]();
     %iface = sv.interface.instance : !sv.interface<@data_vr>
     // CHECK: struct_vr [[IFACEST:.+]]();
     %structIface = sv.interface.instance : !sv.interface<@struct_vr>
 
-    // CHECK-EMPTY:
     %ifaceInPort = sv.modport.get %iface @data_in :
       !sv.interface<@data_vr> -> !sv.modport<@data_vr::@data_in>
 
@@ -91,7 +90,6 @@ module {
     // CHECK: data_vr [[IFACE:.+]]();{{.*}}//{{.+}}
     %iface = sv.interface.instance : !sv.interface<@data_vr>
 
-    // CHECK-EMPTY:
     %ifaceInPort = sv.modport.get %iface @data_in :
       !sv.interface<@data_vr> -> !sv.modport<@data_vr::@data_in>
 

--- a/test/ExportVerilog/verilog-basic.mlir
+++ b/test/ExportVerilog/verilog-basic.mlir
@@ -403,5 +403,19 @@ hw.module @BindEmission() -> () {
   hw.output
 }
 
+sv.bind.interface @__Interface__ {output_file = {directory = "BindTest", exclude_from_filelist = true, exclude_replicated_ops = true, name = "BindInterface.sv"}}
+sv.interface @Interface {
+  sv.interface.signal @a : i1
+  sv.interface.signal @b : i1
+}
+
+hw.module @BindInterface() -> () {
+  %bar = sv.interface.instance sym @__Interface__ {doNotPrint = true} : !sv.interface<@Interface>
+  hw.output
+}
+
 // CHECK-LABEL: FILE "BindTest/BindEmissionInstance.sv"
 // CHECK: bind BindEmission BindEmissionInstance BindEmissionInstance ();
+
+// CHECK-LABEL: FILE "BindTest/BindInterface.sv"
+// CHECK: bind BindInterface Interface bar (.*);


### PR DESCRIPTION
This adds rough support for converting an interface instance to a bind during emission.  This uses the same strategy as emission of bound instances:

- A `BindInterfaceOp`/`sv.bind.interface` is added, the counterpart of `BindOp`/`sv.bind`
- A mandatory name (derived from the SSA name if one exists) and an optional symbol are added to `InterfaceInstanceOp`.  These become necessary to do emission and for doing the back-tracking to link the `BindInterfaceOp` to a specific instance.
- Naive bind emission, using `(.*)` is added.  I'm not intending this to be the ultimate solution, but interface binds need to work a little differently from instance binds where the port connections are explicit. 
- During emission, interface instances are removed from the `getVerilogDeclWord` code path (which was kind of a weird emission strategy for them anyway).
- Add one test showing emission.

The commits are logically ordered if that makes review easier.