### PR TITLE
[FIRRTL][GCT] Generate Binds for Grand Central Interfaces

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -242,6 +242,10 @@ private:
 
   DenseMap<Operation *, Operation *> oldToNewModuleMap;
 
+  /// These are ops that are just copied as they go through.  This is intended
+  /// to be used for ops that are from other dialects and are expected.
+  SmallVector<Operation *> passThroughOps;
+
   // Record the set of remaining annotation classes. This is used to warn only
   // once about any annotation class.
   StringSet<> alreadyPrinted;
@@ -351,11 +355,19 @@ void FIRRTLModuleLowering::runOnOperation() {
       continue;
     }
 
-    // Otherwise we don't know what this is.  We are just going to drop it,
-    // but emit an error so the client has some chance to know that this is
-    // going to happen.
-    op.emitError("unexpected operation '")
-        << op.getName() << "' in a firrtl.circuit";
+    // Anything which is _not_ a module or an extmoulde is treated carefully.
+    // By default, this produces an error.
+    TypeSwitch<Operation *>(&op)
+        // GrandCentral can generate interfaces.  These need to be let through.
+        .Case<sv::InterfaceOp>(
+            [&](auto op) { state.passThroughOps.push_back(op); })
+        .Default([](auto op) {
+          // Otherwise we don't know what this is.  We are just going to drop
+          // it, but emit an error so the client has some chance to know that
+          // this is going to happen.
+          op->emitError("unexpected operation '")
+              << op->getName() << "' in a firrtl.circuit";
+        });
   }
 
   SmallVector<FirMemory> memories;
@@ -381,6 +393,10 @@ void FIRRTLModuleLowering::runOnOperation() {
   for (auto bind : state.binds) {
     bind->moveBefore(bind->getParentOfType<hw::HWModuleOp>());
   }
+
+  // Move any pass through ops into the top of the new module.
+  for (auto *passThrough : state.passThroughOps)
+    passThrough->moveAfter(topLevelModule, topLevelModule->begin());
 
   // Finally delete all the old modules.
   for (auto oldNew : state.oldToNewModuleMap)

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -355,7 +355,7 @@ void FIRRTLModuleLowering::runOnOperation() {
       continue;
     }
 
-    // Anything which is _not_ a module or an extmoulde is treated carefully.
+    // Anything which is _not_ a module or an extmodule is treated carefully.
     // By default, this produces an error.
     TypeSwitch<Operation *>(&op)
         // GrandCentral can generate interfaces.  These need to be let through.

--- a/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
@@ -886,13 +886,23 @@ bool circt::firrtl::scatterCustomAnnotations(
       if (!parentAttr)
         return false;
       parentAttrs.append("class", dict.get("class"));
+      auto viewAttr = tryGetAs<DictionaryAttr>(dict, dict, "view", loc, clazz);
+      if (!viewAttr)
+        return false;
+      auto defName =
+          tryGetAs<StringAttr>(viewAttr, viewAttr, "defName", loc, clazz);
+      if (!defName)
+        return false;
       parentAttrs.append("id", id);
+      auto name = tryGetAs<StringAttr>(dict, dict, "name", loc, clazz);
+      if (!name)
+        return false;
+      parentAttrs.append("name", name);
       parentAttrs.append("type", StringAttr::get(context, "parent"));
+      parentAttrs.append("defName", defName);
       newAnnotations[parentAttr.getValue()].push_back(
           DictionaryAttr::get(context, parentAttrs));
-      auto viewAttr = tryGetAs<DictionaryAttr>(dict, dict, "view", loc, clazz);
-      if (!viewAttr ||
-          !parseAugmentedType(context, viewAttr, dict, newAnnotations,
+      if (!parseAugmentedType(context, viewAttr, dict, newAnnotations,
                               companion, {}, {}, loc, clazz, "view"))
         return false;
       continue;

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -463,14 +463,15 @@ void GrandCentralPass::runOnOperation() {
           auto instance = builder.create<sv::InterfaceInstanceOp>(
               circuitOp->getLoc(),
               interfaces.lookup(defName.getValue()).getInterfaceType(), name,
-              builder.getStringAttr("__" + defName.getValue() + "__"));
+              builder.getStringAttr(
+                  "__" + op.getAttrOfType<StringAttr>("sym_name").getValue() +
+                  "_" + defName.getValue() + "__"));
           instance->setAttr("doNotPrint", builder.getBoolAttr(true));
           builder.setInsertionPointToStart(
               op.getParentOfType<ModuleOp>().getBody());
           auto bind = builder.create<sv::BindInterfaceOp>(
               circuitOp->getLoc(),
-              builder.getSymbolRefAttr(
-                  ("__" + defName.getValue() + "__").str()));
+              builder.getSymbolRefAttr(instance.sym_name().getValue()));
           bind->setAttr(
               "output_file",
               hw::OutputFileAttr::get(

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -741,7 +741,9 @@ circuit GCTInterface : %[
     ; CHECK-SAME:     name = "port"}>]}
     ; CHECK-SAME: annotations = [
     ; CHECK-SAME:   {class = "sifive.enterprise.grandcentral.GrandCentralView$SerializedViewAnnotation",
+    ; CHECK-SAME:    defName = "ViewName",
     ; CHECK-SAME:    id = [[ID]] : i64,
+    ; CHECK-SAME:    name = "view",
     ; CHECK-SAME:    type = "parent"}]
     ; CHECK: firrtl.reg
     ; CHECK-SAME: annotations

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -173,7 +173,7 @@ firrtl.circuit "BindInterfaceTest"  attributes {
   firrtl.module @BindInterfaceTest(
     in %a: !firrtl.uint<8> {
       firrtl.annotations = [
-        #firrtl.subAnno<fieldID = [0, 0], {
+        #firrtl.subAnno<fieldID = 0, {
           class = "sifive.enterprise.grandcentral.AugmentedGroundType",
           defName = "InterfaceName",
           name = "_a"}>


### PR DESCRIPTION
Add support to the existing Grand Central pass to instantiate the interface that it's already generating and to bind it into the "parent" module.  The "parent" module is the module targeted by an annotation where the interface is supposed to be bound in.

In order to do this, SystemVerilog ops are now generated in the Grand Central pass.  `LowerToHW` is updated to let allow-listed ops that it doesn't understand that are peers of FIRRTL modules and external modules (just `sv::InterfaceOp` for now) to go straight through to the lowered circuit.  Previously, this could be avoided because the interface was created in the root module.  However, interface instance ops need to be able to get at symbols (and this wasn't working without it).  There may be a more clever solution here.

This is necessarily rebased on top of #1432 as that adds support for binding interface instance ops. A review could only use the relevant, ordered commits.

### Example

This is an example that shows both binding an instance (a "companion") which is already supported as well as  binding an interface.  

You start with the following FIRRTL IR:

```scala
circuit Foo: %[[
{
  "class":"sifive.enterprise.grandcentral.GrandCentralView$SerializedViewAnnotation",
  "name":"Bar",
  "companion":"~Foo|Bar_companion",
  "parent":"~Foo|Foo",
  "view":{
    "class":"sifive.enterprise.grandcentral.AugmentedBundleType",
    "defName":"View",
    "elements":[
      {
        "name": "port",
        "description": "the port 'a' in GCTInterface",
        "tpe": {
          "class": "sifive.enterprise.grandcentral.AugmentedGroundType",
          "ref": {
            "circuit": "Foo",
            "module": "Foo",
            "path": [],
            "ref": "a",
            "component": []
          },
          "tpe": {
            "class": "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
          }
        }
      }
    ]
  }
}
]]
  module Bar_companion:
    input a: UInt<1>

    skip

  module Foo:
    input a: UInt<1>
    output b: UInt<1>
    inst Bar_companion of Bar_companion

    b <= a

    Bar_companion.a <= a
```

Compiling this all the way to Verilog now gives you:

```verilog
interface View;
  
  // the port 'a' in GCTInterface       // gct/Bind.fir:37:10
  logic port;
endinterface

module Bar_companion(
  input a);

endmodule

module Foo(
  input  a,
  output b);

  // This instance is elsewhere emitted as a bind statement.
  // Bar_companion Bar_companion (      // gct/Bind.fir:40:5
  //   .a (a)
  // );
  // This interface is elsewhere emitted as a bind statement.
  // View Bar();        // gct/Bind.fir:1:1
  assign b = a; // gct/Bind.fir:37:10
endmodule


// ----- 8< ----- FILE "bindings.sv" ----- 8< -----

bind Foo View Bar (.*);

bind Foo Bar_companion Bar_companion (
  .a (a)
);
```

The key thing that this PR adds is the `bind Foo View Bar (.*);`.