### PR TITLE
[FIRRTL] Find lowest common ancestor of two modules in the instance graph

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -192,6 +192,10 @@ def PrintInstanceGraph
     : Pass<"firrtl-print-instance-graph", "firrtl::CircuitOp"> {
   let summary = "Print a DOT graph of the module hierarchy.";
   let constructor =  "circt::firrtl::createPrintInstanceGraphPass()";
+  let options = [
+    Option<"printLCA", "print-LCA", "bool", "false",
+              "Print the lowest common ancestor for each pair of modules.">
+  ];
 }
 
 def GrandCentral : Pass<"firrtl-grand-central", "CircuitOp"> {

--- a/lib/Dialect/FIRRTL/InstanceGraph.cpp
+++ b/lib/Dialect/FIRRTL/InstanceGraph.cpp
@@ -113,10 +113,8 @@ InstanceGraphNode *InstanceGraph::getLCA(InstanceGraphNode *node1,
     auto it = node1Ancestors.insert(node);
     if (!it.second)
       continue;
-    for (auto instanceOp : node->uses()) {
-      auto parent = instanceOp->getParent();
-      nodesQ.push_back(parent);
-    }
+    for (auto instanceOp : node->uses())
+      nodesQ.push_back(instanceOp->getParent());
   }
   // Reuse the Queue, to collect all ancestors of node2.
   nodesQ.push_back(node2);
@@ -140,10 +138,8 @@ InstanceGraphNode *InstanceGraph::getLCA(InstanceGraphNode *node1,
       lcaNode = node;
       lcaDepth = node->depth;
     }
-    for (auto instanceOp : node->uses()) {
-      auto parent = instanceOp->getParent();
-      nodesQ.push_back(parent);
-    }
+    for (auto instanceOp : node->uses())
+      nodesQ.push_back(instanceOp->getParent());
   }
 
   return lcaNode;

--- a/lib/Dialect/FIRRTL/InstanceGraph.cpp
+++ b/lib/Dialect/FIRRTL/InstanceGraph.cpp
@@ -43,6 +43,7 @@ InstanceGraph::InstanceGraph(Operation *operation) {
         auto *instanceRecord =
             currentNode->recordInstance(instanceOp, targetNode);
         targetNode->recordUse(instanceRecord);
+        targetNode->depth = std::max(targetNode->depth, currentNode->depth + 1);
       });
     }
   }
@@ -88,4 +89,62 @@ InstanceGraphNode *InstanceGraph::getOrAddNode(StringRef name) {
 
 Operation *InstanceGraph::getReferencedModule(InstanceOp op) {
   return lookup(op.moduleName())->getModule();
+}
+
+InstanceGraphNode *InstanceGraph::getLCA(InstanceGraphNode *node1,
+                                         InstanceGraphNode *node2) {
+  // Algorithm:
+  // 1. Record all ancestors of node1 in set node1Ancestors.
+  // 2. Visit all ancestors of node2.
+  //  2.1. If node2 ancestor also exists in node1Ancestors set
+  //    2.1.1 And its depth is largest of the common ancestors, then
+  //      2.1.1.1 This is a candidate LCA.
+
+  // The default LCA is the top level CircuitOp, if the two nodes donot have any
+  // common ancestor.
+  auto lcaNode = &nodes[0];
+  SmallVector<InstanceGraphNode *, 8> nodesQ;
+  SmallPtrSet<InstanceGraphNode *, 16> node1Ancestors;
+  nodesQ.push_back(node1);
+  // Collect all the ancestors of the node1.
+  while (!nodesQ.empty()) {
+    InstanceGraphNode *node = nodesQ.back();
+    nodesQ.pop_back();
+    auto it = node1Ancestors.insert(node);
+    if (!it.second)
+      continue;
+    for (auto instanceOp : node->uses()) {
+      auto parent = instanceOp->getParent();
+      nodesQ.push_back(parent);
+    }
+  }
+  // Reuse the Queue, to collect all ancestors of node2.
+  nodesQ.push_back(node2);
+  // Initialize the depth of the default LCA to 0.
+  size_t lcaDepth = 0;
+  // Record the set of ancestors already visited.
+  SmallPtrSet<InstanceGraphNode *, 16> node2Ancestors;
+  // Visit all ancestors of node2.
+  while (!nodesQ.empty()) {
+    InstanceGraphNode *node = nodesQ.back();
+    nodesQ.pop_back();
+    // Record the ancestors already visited.
+    auto it = node2Ancestors.insert(node);
+    // Ignore if node already visited.
+    if (!it.second)
+      continue;
+    // If node2 ancestor is also an ancestor of node1, then it a candidate LCA.
+    // A common ancestor with largest depth is the LCA. In case there are
+    // multiple LCAs, this slects any one of them.
+    if (node1Ancestors.contains(node) && node->depth > lcaDepth) {
+      lcaNode = node;
+      lcaDepth = node->depth;
+    }
+    for (auto instanceOp : node->uses()) {
+      auto parent = instanceOp->getParent();
+      nodesQ.push_back(parent);
+    }
+  }
+
+  return lcaNode;
 }

--- a/lib/Dialect/FIRRTL/InstanceGraph.cpp
+++ b/lib/Dialect/FIRRTL/InstanceGraph.cpp
@@ -100,9 +100,8 @@ InstanceGraphNode *InstanceGraph::getLCA(InstanceGraphNode *node1,
   //    2.1.1 And its depth is largest of the common ancestors, then
   //      2.1.1.1 This is a candidate LCA.
 
-  // The default LCA is the top level CircuitOp, if the two nodes donot have any
-  // common ancestor.
-  auto lcaNode = &nodes[0];
+  // Returns nullptr, if the two nodes donot have any common ancestor.
+  InstanceGraphNode *lcaNode = nullptr;
   SmallVector<InstanceGraphNode *, 8> nodesQ;
   SmallPtrSet<InstanceGraphNode *, 16> node1Ancestors;
   nodesQ.push_back(node1);

--- a/lib/Dialect/FIRRTL/InstanceGraph.cpp
+++ b/lib/Dialect/FIRRTL/InstanceGraph.cpp
@@ -133,7 +133,7 @@ InstanceGraphNode *InstanceGraph::getLCA(InstanceGraphNode *node1,
     // If node2 ancestor is also an ancestor of node1, then it a candidate LCA.
     // A common ancestor with largest depth is the LCA. In case there are
     // multiple LCAs, this slects any one of them.
-    if (node1Ancestors.contains(node) && node->depth > lcaDepth) {
+    if (node1Ancestors.contains(node) && node->depth >= lcaDepth) {
       lcaNode = node;
       lcaDepth = node->depth;
     }

--- a/lib/Dialect/FIRRTL/Transforms/PrintInstanceGraph.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/PrintInstanceGraph.cpp
@@ -62,15 +62,17 @@ struct PrintInstanceGraphPass
         for (InstanceGraphNode *node2 : instanceGraph) {
           if (node1 == node2)
             continue;
-          os << "\n LCA of ("
-             << llvm::DOTGraphTraits<InstanceGraph *>::getNodeLabel(
-                    node1, &instanceGraph)
-             << ","
-             << llvm::DOTGraphTraits<InstanceGraph *>::getNodeLabel(
-                    node2, &instanceGraph)
-             << ")="
-             << llvm::DOTGraphTraits<InstanceGraph *>::getNodeLabel(
-                    instanceGraph.getLCA(node1, node2), &instanceGraph);
+          auto lcaNode = instanceGraph.getLCA(node1, node2);
+          if (lcaNode != nullptr)
+            os << "\n LCA of ("
+               << llvm::DOTGraphTraits<InstanceGraph *>::getNodeLabel(
+                      node1, &instanceGraph)
+               << ","
+               << llvm::DOTGraphTraits<InstanceGraph *>::getNodeLabel(
+                      node2, &instanceGraph)
+               << ")="
+               << llvm::DOTGraphTraits<InstanceGraph *>::getNodeLabel(
+                      lcaNode, &instanceGraph);
         }
       }
   }

--- a/test/Dialect/FIRRTL/print-instance-graph.mlir
+++ b/test/Dialect/FIRRTL/print-instance-graph.mlir
@@ -1,15 +1,35 @@
-// RUN: circt-opt -firrtl-print-instance-graph %s -o %t 2>&1 | FileCheck %s
+// RUN: circt-opt -firrtl-print-instance-graph=print-LCA %s -o %t 2>&1 | FileCheck %s
 
 // CHECK: digraph "Top"
 // CHECK:   label="Top";
-// CHECK:   [[TOP:.*]] [shape=record,label="{Top}"];
+// CHECK:   [[TOP:.*]] [shape=record,label="{Top(0)}"];
 // CHECK:   [[TOP]] -> [[ALLIGATOR:.*]][label=alligator];
 // CHECK:   [[TOP]] -> [[CAT:.*]][label=cat];
-// CHECK:   [[ALLIGATOR]] [shape=record,label="{Alligator}"];
+// CHECK:   [[ALLIGATOR]] [shape=record,label="{Alligator(1)}"];
 // CHECK:   [[ALLIGATOR]] -> [[BEAR:.*]][label=bear];
-// CHECK:   [[CAT]] [shape=record,label="{Cat}"];
-// CHECK:   [[BEAR]] [shape=record,label="{Bear}"];
+// CHECK:   [[CAT]] [shape=record,label="{Cat(3)}"];
+// CHECK:   [[BEAR]] [shape=record,label="{Bear(2)}"];
 // CHECK:   [[BEAR]] -> [[CAT]][label=cat];
+// CHECK:  LCA of (Top(0),Alligator(1))=Top(0)
+// CHECK:  LCA of (Top(0),Cat(3))=Top(0)
+// CHECK:  LCA of (Top(0),Bear(2))=Top(0)
+// CHECK:  LCA of (Top(0),Deer(2))=Top(0)
+// CHECK:  LCA of (Alligator(1),Top(0))=Top(0)
+// CHECK:  LCA of (Alligator(1),Cat(3))=Alligator(1)
+// CHECK:  LCA of (Alligator(1),Bear(2))=Alligator(1)
+// CHECK:  LCA of (Alligator(1),Deer(2))=Alligator(1)
+// CHECK:  LCA of (Cat(3),Top(0))=Top(0)
+// CHECK:  LCA of (Cat(3),Alligator(1))=Alligator(1)
+// CHECK:  LCA of (Cat(3),Bear(2))=Bear(2)
+// CHECK:  LCA of (Cat(3),Deer(2))=Alligator(1)
+// CHECK:  LCA of (Bear(2),Top(0))=Top(0)
+// CHECK:  LCA of (Bear(2),Alligator(1))=Alligator(1)
+// CHECK:  LCA of (Bear(2),Cat(3))=Bear(2)
+// CHECK:  LCA of (Bear(2),Deer(2))=Alligator(1)
+// CHECK:  LCA of (Deer(2),Top(0))=Top(0)
+// CHECK:  LCA of (Deer(2),Alligator(1))=Alligator(1)
+// CHECK:  LCA of (Deer(2),Cat(3))=Alligator(1)
+// CHECK:  LCA of (Deer(2),Bear(2))=Alligator(1)
 
 firrtl.circuit "Top" {
 
@@ -20,6 +40,7 @@ firrtl.module @Top() {
 
 firrtl.module @Alligator() {
   firrtl.instance @Bear {name = "bear"}
+  firrtl.instance @Deer {name = "bear"}
 }
 
 firrtl.module @Bear() {
@@ -27,5 +48,9 @@ firrtl.module @Bear() {
 }
 
 firrtl.module @Cat() { }
+
+
+
+firrtl.module @Deer() { }
 
 }

--- a/test/Dialect/FIRRTL/print-instance-graph.mlir
+++ b/test/Dialect/FIRRTL/print-instance-graph.mlir
@@ -49,8 +49,8 @@ firrtl.module @Bear() {
 
 firrtl.module @Cat() { }
 
-
-
 firrtl.module @Deer() { }
+
+firrtl.module @Bat() { }
 
 }


### PR DESCRIPTION
Added an algorithm to `InstanceGraph` that computes the **lowest common ancestor**(`LCA`) of any two given modules. 
Also updated the `printInstanceGraph` pass to print the depth of each node and also the `LCA` of each pair of modules.


The node of greatest depth in a DAG that is an ancestor of both `x` and `y` is a **lowest common ancestor** of `x` and `y`

This will be used by the wiring transforms, to connect/bore connection from a signal in a source module to a sink module.
(https://javadoc.io/static/edu.berkeley.cs/firrtl_2.12/1.3.2/firrtl/passes/wiring/WiringTransform.html)

Implemented a naive algorithm with no caching. 
1. Record the depth of each node while constructing the `InstanceGraph`
2. To compute the LCA between any two modules, 
  2.1. Record all the common ancestors of both the modules. 
  2.2. Return the common ancestor with greatest depth. 
3. Returns `nullptr`, if `LCA` does not exist.
4. Returns any one, if multiple `LCA` exists. Not yet sure, if this case needs special handling.
