### PR TITLE
[Python] Drop reference to Edge instance after erasing it.

### DIFF
--- a/frontends/PyCDE/test/polynomial.py
+++ b/frontends/PyCDE/test/polynomial.py
@@ -8,6 +8,7 @@ import pycde
 from pycde import (Input, Output, Parameter, module, externmodule, generator,
                    types, dim)
 from circt.dialects import comb, hw
+from circt.support import connect
 
 
 @module
@@ -81,7 +82,8 @@ class Polynomial(pycde.System):
   def build(self, top):
     i32 = types.i32
     x = hw.ConstantOp.create(i32, 23)
-    poly = PolynomialCompute(Coefficients([62, 42, 6]))("example", x=x)
+    poly = PolynomialCompute(Coefficients([62, 42, 6]))("example")
+    connect(poly.x, x)
     PolynomialCompute(coefficients=Coefficients([62, 42, 6]))("example2",
                                                               x=poly.y)
     PolynomialCompute(Coefficients([1, 2, 3, 4, 5]))("example2", x=poly.y)

--- a/lib/Bindings/Python/circt/support.py
+++ b/lib/Bindings/Python/circt/support.py
@@ -49,6 +49,7 @@ def connect(destination, source):
   if destination.backedge_owner and \
      index in destination.backedge_owner.backedges:
     destination.backedge_owner.backedges[index].erase()
+    del destination.backedge_owner.backedges[index]
 
 
 def var_to_attribute(obj, none_on_fail: bool = False) -> ir.Attribute:


### PR DESCRIPTION
We keep a dict of backedges on OpViews that need them, so they may be
cleaned up later. In order to print the OpView in a situation where
the Edge was _not_ cleaned up, we store a reference to the OpView in
the Edge. This is fine, but in the event that the Edge _is_ cleaned
up, we were leaving the Edge in this dict of backedges, which meant
there was still a Python-side reference to the OpView.

Down the road, that prevents the OpView's destructor from running and
removing it from the liveOperations map at the appropriate time. By
forcibly dropping the Edge from the dict of backedges, we allow the
liveOperations map to be kept in sync.

The small change to the existing test case is enough to trigger the
problematic behavior and demonstrate the issue.