### PR TITLE
[FIRRTL] Error on Annotations that Do Not Apply

### DIFF
--- a/test/Dialect/FIRRTL/annotations-errors.fir
+++ b/test/Dialect/FIRRTL/annotations-errors.fir
@@ -134,3 +134,32 @@ circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar[1].baz[0]"}]]
     input clock: Clock
 ; expected-error @+1 {{the 3-th token of [1].baz[0] expects an aggregate type}}
     reg bar: {baz: UInt<1>, qux: UInt<1>}[2], clock
+
+; // -----
+
+; COM: A target pointing at a non-existent module should error.
+
+; expected-error @+1 {{unapplied annotations with target '~Foo|Bar' and payload '[{a}]'}}
+circuit Foo: %[[{"a":null,"target":"~Foo|Bar"}]]
+  module Foo:
+    skip
+
+; // -----
+
+; COM: A target pointing at a non-existent component should error.
+
+; expected-error @+1 {{unapplied annotations with target '~Foo|Foo>x' and payload '[{a}]'}}
+circuit Foo: %[[{"a":null,"target":"~Foo|Foo>x"}]]
+  module Foo:
+    skip
+
+; // -----
+
+; COM: A target pointing at a non-existent instance should error.
+
+; expected-error @+1 {{unapplied annotations with target '~Foo|Foo/baz:Bar' and payload '[{a}]'}}
+circuit Foo: %[[{"a":null,"target":"~Foo|Foo/baz:Bar"}]]
+  module Bar:
+    skip
+  module Foo:
+    inst bar of Bar


### PR DESCRIPTION
Change the FIRRTL parser to error if any Annotations are unapplied to
the circuit.  Put differently, this will error if any Target in an
Annotation (or a generated Target from Annotation scattering) points at
something which does not exist in the circuit.

Residual Annotations indicate either a user problem like inconsistent
FIRRTL and Annotation files or some problem with scattering logic or the
parser itself.  E.g., you can hit this if you have busted scattering
code (that creates targets that do not exist) or for cases where
non-local Annotations get through scattering logic.  This is a situation
that needs to be addressed and continuing compilation may result in
extremely tedious errors due to the compiler effectively dropping
Annotation information which is assumed to be critical to control
compilation in a way the user wants.

Together with a894ad8c and a08f15ca this should cause all unapplied
Annotations to produce parse-time errors.

Fixes #1013.  #1280 and #1327 do a great job of taking care of malformed Annotations where a field/index doesn't exist or the circuit is invalid.  This takes care of the remaining situations and catches anything that gets into the parser with invalid syntax (e.g., with hypothetical third-party Annotation scattering code or presently unchecked scattered annotations that have non-local targets).

~_Note: I am not happy about this implementation, but wanted to get something going._~

~This is currently implemented as exfiltrating the discovered module namespace into a `SmallVector<StringAttr>`, converting that to a `StringSet<>`, and then asserting that each key (a target) in the Annotation map exists in the set.  This set can be very large and the majority of it is thrown away.  Also, this is using `StringAttr`s (which should be uniqued and pretty cheap?), but it seems like switching to `StringRef`s pointing at things that will exist after the modules are parsed is better.  This is all done using `parallelTransformReduce` so that it's actually safe.~

~A better formulation would be to exfiltrate _annotations that do apply_ and then diffing this with the Annotation map.  The Annotation map cannot be mutated directly, but each parsing thread could append to an "applied annotations" data structure passed into `parseModuleBody` and its child calls.  (I initially didn't see a way to mutate the Annotation map and thought the `StringSet<>` approach was necessary...)~

*This PR was updated to use the better approach of recording what targets were found and applied by `getAnnotations` and `getSplitAnnotations`.  No massive set of all names is being built up anymore.*