### PR TITLE
[FIRRTL] Canonicalize regreset with invalidvalue

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -70,19 +70,26 @@ def MuxSameCondHigh : Pat<
     (EqualTypes $x, $y), (EqualTypes $x, $z), (KnownWidth $x)
   ]>;
 
-// node(x, name, {}) -> x
+// node(x) -> x
 def EmptyNode : Pat<
   (NodeOp $x, $name, $annotations),
   (replaceWithValue $x),
   [(EmptyAttrDict $annotations)]>;
 
-// regreset(clock, invalidvalue, resetValue, name, {}) -> reg(clock, name, {})
+// regreset(clock, invalidvalue, resetValue) -> reg(clock)
 def RegresetWithInvalidReset : Pat<
   (RegResetOp $clock, (InvalidValueOp), $resetValue, $name, $annotations),
   (RegOp $clock, $name, $annotations),
   []>;
 
-// regreset(clock, constant_zero, resetValue, name, {}) -> reg(clock, name, {})
+// regreset(clock, reset, invalidvalue) -> reg(clock)
+// This is handled by the `RemoveReset` pass in the original Scala code.
+def RegresetWithInvalidResetValue : Pat<
+  (RegResetOp $clock, $reset, (InvalidValueOp), $name, $annotations),
+  (RegOp $clock, $name, $annotations),
+  []>;
+
+// regreset(clock, constant_zero, resetValue) -> reg(clock)
 def RegresetWithZeroReset : Pat<
   (RegResetOp $clock, (SpecialConstantOp ConstBoolAttrFalse), $resetValue,
    $name, $annotations),

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1469,7 +1469,8 @@ void NodeOp::getCanonicalizationPatterns(RewritePatternSet &results,
 void RegResetOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                              MLIRContext *context) {
   results.insert<patterns::RegresetWithZeroReset,
-                 patterns::RegresetWithInvalidReset>(context);
+                 patterns::RegresetWithInvalidReset,
+                 patterns::RegresetWithInvalidResetValue>(context);
 }
 
 LogicalResult MemOp::canonicalize(MemOp op, PatternRewriter &rewriter) {

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -1795,4 +1795,19 @@ firrtl.module @dshifts_to_ishifts(in %a_in: !firrtl.sint<58>,
   firrtl.connect %c_out, %2 : !firrtl.sint<58>, !firrtl.sint<58>
 }
 
+// RemoveReset: `firrtl.invalidvalue` reset values should be canonicalized to a
+// reset-less register.
+// CHECK-LABEL: firrtl.module @StripInvalidValueReset
+firrtl.module @StripInvalidValueReset(
+  in %clk: !firrtl.clock,
+  in %rst: !firrtl.uint<1>,
+  in %arst: !firrtl.asyncreset
+) {
+  %invalid_ui42 = firrtl.invalidvalue : !firrtl.uint<42>
+  // CHECK: %0 = firrtl.reg %clk : (!firrtl.clock) -> !firrtl.uint<42>
+  // CHECK: %1 = firrtl.reg %clk : (!firrtl.clock) -> !firrtl.uint<42>
+  %0 = firrtl.regreset %clk, %rst, %invalid_ui42 : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<42>) -> !firrtl.uint<42>
+  %1 = firrtl.regreset %clk, %arst, %invalid_ui42 : (!firrtl.clock, !firrtl.asyncreset, !firrtl.uint<42>) -> !firrtl.uint<42>
+}
+
 }


### PR DESCRIPTION
Canonicalize regreset(clock, reset, invalidvalue) to reg(clock). On the Scala side this is done by the `RemoveReset` pass.