### PR TITLE
[FIRRTL] Add insertPorts utility to FModuleOp

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -93,6 +93,9 @@ def FModuleOp : FIRRTLOp<"module",
       return OpBuilder::atBlockEnd(&bodyBlock);
     }
 
+    /// Inserts the given ports.
+    void insertPorts(ArrayRef<std::pair<unsigned, ModulePortInfo>> ports);
+
     /// Erases the ports listed in `portIndices`.  `portIndices` is expected to
     /// be in order and unique.
     void erasePorts(ArrayRef<unsigned> portIndices);


### PR DESCRIPTION
Add a `insertPorts` utility function to `FModuleOp` that is the complement to the existing `erasePorts`.