### PR TITLE
[FIRRTL] Validate reg async reset value is constant

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -247,6 +247,8 @@ def RegResetOp : FIRRTLOp<"regreset", [/*MemAlloc*/]> {
         StrAttr:$name, AnnotationArrayAttr:$annotations);
   let results = (outs PassiveType:$result);
 
+  let verifier = "return ::verifyRegResetOp(*this);";
+
   let builders = [
     OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$clockVal,
                    "::mlir::Value":$resetSignal, "::mlir::Value":$resetValue,

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -56,6 +56,12 @@ SmallVector<Direction> unpackAttribute(Operation *module);
 /// Return true if the specified operation is a firrtl expression.
 bool isExpression(Operation *op);
 
+/// Return true if the specified operation has a constant value. This trivially
+/// checks for `firrtl.constant` and friends, but also looks through subaccesses
+/// and correctly handles wires driven with only constant values.
+bool isConstant(Operation *op);
+bool isConstant(Value value);
+
 /// This holds the name and type that describes the module's ports.
 struct ModulePortInfo {
   StringAttr name;

--- a/test/Dialect/FIRRTL/basic.mlir
+++ b/test/Dialect/FIRRTL/basic.mlir
@@ -1,0 +1,40 @@
+// RUN: circt-opt %s --verify-diagnostics | FileCheck %s
+
+firrtl.circuit "Foo" {
+firrtl.module @Foo() {}
+
+// CHECK-LABEL: firrtl.module @AsyncResetConst
+// The following should not error.
+firrtl.module @AsyncResetConst(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset) {
+  // Constant check should handle trivial cases.
+  %c0_ui = firrtl.constant 0 : !firrtl.uint<8>
+  %0 = firrtl.regreset %clock, %reset, %c0_ui : (!firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>) -> !firrtl.uint<8>
+
+  // Constant check should see through nodes.
+  %node = firrtl.node %c0_ui : !firrtl.uint<8>
+  %1 = firrtl.regreset %clock, %reset, %node : (!firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>) -> !firrtl.uint<8>
+
+  // Constant check should see through subfield connects.
+  %bundle0 = firrtl.wire : !firrtl.bundle<a: uint<8>>
+  %bundle0.a = firrtl.subfield %bundle0(0) : (!firrtl.bundle<a: uint<8>>) -> !firrtl.uint<8>
+  firrtl.connect %bundle0.a, %c0_ui : !firrtl.uint<8>, !firrtl.uint<8>
+  %2 = firrtl.regreset %clock, %reset, %bundle0 : (!firrtl.clock, !firrtl.asyncreset, !firrtl.bundle<a: uint<8>>) -> !firrtl.bundle<a: uint<8>>
+
+  // Constant check should see through multiple connect hops.
+  %bundle1 = firrtl.wire : !firrtl.bundle<a: uint<8>>
+  firrtl.connect %bundle1, %bundle0 : !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>
+  %3 = firrtl.regreset %clock, %reset, %bundle1 : (!firrtl.clock, !firrtl.asyncreset, !firrtl.bundle<a: uint<8>>) -> !firrtl.bundle<a: uint<8>>
+
+  // Constant check should see through subindex connects.
+  %vector0 = firrtl.wire : !firrtl.vector<uint<8>, 1>
+  %vector0.a = firrtl.subindex %vector0[0] : !firrtl.vector<uint<8>, 1>
+  firrtl.connect %vector0.a, %c0_ui : !firrtl.uint<8>, !firrtl.uint<8>
+  %4 = firrtl.regreset %clock, %reset, %vector0 : (!firrtl.clock, !firrtl.asyncreset, !firrtl.vector<uint<8>, 1>) -> !firrtl.vector<uint<8>, 1>
+
+  // Constant check should see through multiple connect hops.
+  %vector1 = firrtl.wire : !firrtl.vector<uint<8>, 1>
+  firrtl.connect %vector1, %vector0 : !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
+  %5 = firrtl.regreset %clock, %reset, %vector1 : (!firrtl.clock, !firrtl.asyncreset, !firrtl.vector<uint<8>, 1>) -> !firrtl.vector<uint<8>, 1>
+}
+
+}

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -197,6 +197,7 @@ firrtl.module @renaming() {
   %0, %1, %2 = firrtl.instance @declarations {name = "myinst"} : !firrtl.clock, !firrtl.uint<8>, !firrtl.asyncreset
 }
 firrtl.module @declarations(in %clock : !firrtl.clock, in %u8 : !firrtl.uint<8>, in %reset : !firrtl.asyncreset) attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
+  %c0_ui8 = firrtl.constant 0 : !firrtl.uint<8>
   // CHECK: %myinst_cmem = firrtl.cmem  {name = "myinst_cmem"} : !firrtl.uint<8>
   %cmem = firrtl.cmem {name = "cmem"} : !firrtl.uint<8>
   // CHECK: %myinst_mem_read = firrtl.mem Undefined {depth = 1 : i64, name = "myinst_mem", portNames = ["read"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: sint<42>>
@@ -207,8 +208,8 @@ firrtl.module @declarations(in %clock : !firrtl.clock, in %u8 : !firrtl.uint<8>,
   %node = firrtl.node %u8 {name = "node"} : !firrtl.uint<8>
   // CHECK: %myinst_reg = firrtl.reg %myinst_clock : (!firrtl.clock) -> !firrtl.uint<8>
   %reg = firrtl.reg %clock {name = "reg"} : (!firrtl.clock) -> !firrtl.uint<8>
-  // CHECK: %myinst_regreset = firrtl.regreset %myinst_clock, %myinst_reset, %myinst_u8 : (!firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>) -> !firrtl.uint<8>
-  %regreset = firrtl.regreset %clock, %reset, %u8 : (!firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>) -> !firrtl.uint<8>
+  // CHECK: %myinst_regreset = firrtl.regreset %myinst_clock, %myinst_reset, %c0_ui8 : (!firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>) -> !firrtl.uint<8>
+  %regreset = firrtl.regreset %clock, %reset, %c0_ui8 : (!firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>) -> !firrtl.uint<8>
   // CHECK: %myinst_smem = firrtl.smem Undefined  {name = "myinst_smem"} : !firrtl.uint<1>
   %smem = firrtl.smem Undefined {name = "smem"} : !firrtl.uint<1>
   // CHECK: %myinst_wire = firrtl.wire  : !firrtl.uint<1>


### PR DESCRIPTION
Have the verifier of `firrtl.regreset` check that any async reset value is a constant literal (or aggregate thereof). On the Scala side, this is checked in `CheckResets`.