### PR TITLE
[FIRRTL] Validate reg async reset value is constant at LowerToHW Time

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -106,20 +106,20 @@ def EmptyNode : Pat<
   [(NonEmptyStringAttr $name), (EmptyAttrDict $annotations)]>;
 
 // regreset(clock, invalidvalue, resetValue) -> reg(clock)
-def RegresetWithInvalidReset : Pat<
+def RegResetWithInvalidReset : Pat<
   (RegResetOp $clock, (InvalidValueOp), $_, $name, $annotations),
   (RegOp $clock, $name, $annotations),
   []>;
 
 // regreset(clock, reset, invalidvalue) -> reg(clock)
 // This is handled by the `RemoveReset` pass in the original Scala code.
-def RegresetWithInvalidResetValue : Pat<
+def RegResetWithInvalidResetValue : Pat<
   (RegResetOp $clock, $_, (InvalidValueOp), $name, $annotations),
   (RegOp $clock, $name, $annotations),
   []>;
 
 // regreset(clock, constant_zero, resetValue) -> reg(clock)
-def RegresetWithZeroReset : Pat<
+def RegResetWithZeroReset : Pat<
   (RegResetOp $clock, $reset, $_, $name, $annotations),
   (RegOp $clock, $name, $annotations), [(ZeroConstantOp $reset)]>;
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -272,8 +272,9 @@ def RegOp : FIRRTLOp<"reg", [/*MemAlloc*/]> {
   let summary = "Define a new register";
   let description = [{
     Declare a new register:
+
     ```
-      %name = firrtl.reg %clockVal : t1
+    %name = firrtl.reg %clockVal : t1
     ```
     }];
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -305,7 +305,7 @@ def RegResetOp : FIRRTLOp<"regreset", [/*MemAlloc*/]> {
     }];
 
   let arguments = (
-    ins ClockType:$clockVal, ResetType:$resetSignal, PassiveType:$resetValue,
+    ins ClockType:$clockVal, AnyResetType:$resetSignal, PassiveType:$resetValue,
         StrAttr:$name, AnnotationArrayAttr:$annotations);
   let results = (outs PassiveType:$result);
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -34,6 +34,12 @@ bool isExpression(Operation *op);
 /// Return the number of ports in a module-like thing (modules, memories, etc)
 size_t getNumPorts(Operation *op);
 
+/// Return true if the specified operation has a constant value. This trivially
+/// checks for `firrtl.constant` and friends, but also looks through subaccesses
+/// and correctly handles wires driven with only constant values.
+bool isConstant(Operation *op);
+bool isConstant(Value value);
+
 /// Returns true if the value results from an expression with duplex flow.
 /// Duplex values have special treatment in bundle connect operations, and
 /// their flip orientation is not used to determine the direction of each

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -18,8 +18,8 @@ def FIRRTLType : DialectType<FIRRTLDialect, CPred<"$_self.isa<FIRRTLType>()">,
   "FIRRTLType", "::circt::firrtl::FIRRTLType">;
 
 def ClockType : DialectType<FIRRTLDialect, CPred<"$_self.isa<ClockType>()">,
- "clock", "::circt::firrtl::ClockType">,
- BuildableType<"ClockType::get($_builder.getContext())">;
+    "clock", "::circt::firrtl::ClockType">,
+  BuildableType<"ClockType::get($_builder.getContext())">;
 
 def IntType : DialectType<FIRRTLDialect, CPred<"$_self.isa<IntType>()">,
  "sint or uint type", "::circt::firrtl::IntType">;
@@ -40,15 +40,21 @@ def FVectorType : DialectType<FIRRTLDialect, CPred<"$_self.isa<FVectorType>()">,
   "FVectorType", "::circt::firrtl::FVectorType">;
 
 def UInt1Type : DialectType<FIRRTLDialect,
-  CPred<"$_self.isa<UIntType>() && "
-        "($_self.cast<UIntType>().getWidth() == 1 ||"
-        " $_self.cast<UIntType>().getWidth() == None)">,
-   "UInt<1> or UInt", "::circt::firrtl::UIntType">,
-   BuildableType<"UIntType::get($_builder.getContext(), 1)">;
+    CPred<"$_self.isa<UIntType>() && "
+          "($_self.cast<UIntType>().getWidth() == 1 ||"
+          " $_self.cast<UIntType>().getWidth() == None)">,
+    "UInt<1> or UInt", "::circt::firrtl::UIntType">,
+  BuildableType<"UIntType::get($_builder.getContext(), 1)">;
 
 def AsyncResetType : DialectType<FIRRTLDialect,
-  CPred<"$_self.isa<AsyncResetType>()">,
-  "AsyncReset", "::circt::firrtl::AsyncResetType">;
+    CPred<"$_self.isa<AsyncResetType>()">,
+    "AsyncReset", "::circt::firrtl::AsyncResetType">,
+  BuildableType<"AsyncResetType::get($_builder.getContext())">;
+
+def ResetType : DialectType<FIRRTLDialect,
+    CPred<"$_self.isa<ResetType>()">,
+    "Reset", "::circt::firrtl::ResetType">,
+  BuildableType<"ResetType::get($_builder.getContext())">;
 
 def PassiveType : DialectType<FIRRTLDialect,
   CPred<"$_self.isa<FIRRTLType>() && $_self.cast<FIRRTLType>().isPassive()">,
@@ -116,16 +122,16 @@ def NonZeroIntType : DialectType<FIRRTLDialect,
   CPred<"$_self.isa<IntType>() && $_self.cast<IntType>().getWidth() != 0">,
   "Int", "::circt::firrtl::IntType">;
 
-def ResetType : DialectType<FIRRTLDialect,
-  CPred<"$_self.isa<FIRRTLType>() && $_self.cast<FIRRTLType>().isResetType()">,
-  "Reset", "::circt::firrtl::FIRRTLType">;
+def AnyResetType : DialectType<FIRRTLDialect,
+    CPred<"$_self.isa<FIRRTLType>() && $_self.cast<FIRRTLType>().isResetType()">,
+    "Reset", "::circt::firrtl::FIRRTLType">;
 
 def UIntSIntClockType : AnyTypeOf<[SIntType, UIntType, ClockType],
                                   "sint, uint, or clock",
                                   "::circt::firrtl::FIRRTLType">;
 
 def OneBitCastableType : AnyTypeOf<
-  [OneBitType, ResetType, AsyncResetType, ClockType],
+  [OneBitType, AnyResetType, AsyncResetType, ClockType],
   "1-bit uint/sint/analog, reset, asyncreset, or clock",
                                   "::circt::firrtl::FIRRTLType">;
 

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -2078,6 +2078,11 @@ LogicalResult FIRRTLLowering::visitDecl(RegResetOp op) {
   };
 
   if (op.resetSignal().getType().isa<AsyncResetType>()) {
+    if (!firrtl::isConstant(op.resetValue()))
+      return op.emitError(
+                   "register with async reset requires constant reset value")
+                 .attachNote(op.resetValue().getLoc())
+             << "reset value defined here:";
     addToAlwaysFFBlock(sv::EventControl::AtPosEdge, clockVal,
                        ::ResetType::AsyncReset, sv::EventControl::AtPosEdge,
                        resetSignal, std::function<void()>(), resetFn);

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1549,10 +1549,10 @@ struct foldResetMux : public mlir::RewritePattern {
 
 void RegResetOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                              MLIRContext *context) {
-  results.insert<patterns::RegresetWithZeroReset,
-                 patterns::RegresetWithInvalidReset,
-                 patterns::RegresetWithInvalidResetValue, foldResetMux,
-                 patterns::DropNameRegReset>(context);
+  results.insert<patterns::RegResetWithZeroReset,
+                 patterns::RegResetWithInvalidReset,
+                 patterns::RegResetWithInvalidResetValue,
+                 patterns::DropNameRegReset, foldResetMux>(context);
 }
 
 LogicalResult MemOp::canonicalize(MemOp op, PatternRewriter &rewriter) {

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1723,6 +1723,48 @@ static LogicalResult verifySubfieldOp(SubfieldOp op) {
   return success();
 }
 
+/// Return true if the specified operation has a constant value. This trivially
+/// checks for `firrtl.constant` and friends, but also looks through subaccesses
+/// and correctly handles wires driven with only constant values.
+bool firrtl::isConstant(Operation *op) {
+  // Worklist of ops that need to be examined that should all be constant in
+  // order for the input operation to be constant.
+  SmallVector<Operation *, 8> worklist({op});
+
+  // Mutable state indicating if this op is a constant.  Assume it is a constant
+  // and look for counterexamples.
+  bool constant = true;
+
+  // While we haven't found a counterexample and there are still ops in the
+  // worklist, pull ops off the worklist.  If it provides a counterexample, set
+  // the `constant` to false (and exit on the next loop iteration).  Otherwise,
+  // look through the op or spawn off more ops to look at.
+  while (constant && !(worklist.empty()))
+    TypeSwitch<Operation *>(worklist.pop_back_val())
+        .Case<NodeOp, AsSIntPrimOp, AsUIntPrimOp>([&](auto op) {
+          if (auto definingOp = op.input().getDefiningOp())
+            worklist.push_back(definingOp);
+          constant = false;
+        })
+        .Case<WireOp, SubindexOp, SubfieldOp>([&](auto op) {
+          for (auto &use : op.getResult().getUses())
+            worklist.push_back(use.getOwner());
+        })
+        .Case<ConstantOp, SpecialConstantOp>([](auto) {})
+        .Default([&](auto) { constant = false; });
+
+  return constant;
+}
+
+/// Return true if the specified value is a constant. This trivially checks for
+/// `firrtl.constant` and friends, but also looks through subaccesses and
+/// correctly handles wires driven with only constant values.
+bool firrtl::isConstant(Value value) {
+  if (auto *op = value.getDefiningOp())
+    return isConstant(op);
+  return false;
+}
+
 FIRRTLType SubfieldOp::inferReturnType(ValueRange operands,
                                        ArrayRef<NamedAttribute> attrs,
                                        Optional<Location> loc) {

--- a/test/Conversion/FIRRTLToHW/errors.mlir
+++ b/test/Conversion/FIRRTLToHW/errors.mlir
@@ -67,3 +67,28 @@ firrtl.circuit "Div" {
     firrtl.partialconnect %7, %c0_ui25 : !firrtl.uint<0>, !firrtl.uint<25>
   }
 }
+
+// -----
+
+// Constant check should handle trivial cases.
+firrtl.circuit "Foo" {
+  // expected-note @+1 {{reset value defined here:}}
+  firrtl.module @Foo(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %v: !firrtl.uint<8>) {
+    // expected-error @+2 {{register with async reset requires constant reset value}}
+    // expected-error @+1 {{'firrtl.regreset' op LowerToHW couldn't handle this operation}}
+    %0 = firrtl.regreset %clock, %reset, %v : !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
+  }
+}
+
+// -----
+
+// Constant check should see through nodes.
+firrtl.circuit "Foo" {
+  firrtl.module @Foo(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %v: !firrtl.uint<8>) {
+    // expected-note @+1 {{reset value defined here:}}
+    %node = firrtl.node %v : !firrtl.uint<8>
+    // expected-error @+2 {{register with async reset requires constant reset value}}
+    // expected-error @+1 {{'firrtl.regreset' op LowerToHW couldn't handle this operation}}
+    %1 = firrtl.regreset %clock, %reset, %node : !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
+  }
+}

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -966,4 +966,35 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %tmp = firrtl.node %clock1 : !firrtl.clock
     firrtl.connect %clk_ab_node_w1, %tmp : !firrtl.clock, !firrtl.clock
   }
+
+  // CHECK-LABEL: hw.module @AsyncResetBasic(
+  firrtl.module @AsyncResetBasic(in %clock: !firrtl.clock, in %arst: !firrtl.asyncreset, in %srst: !firrtl.uint<1>) {
+    %c9_ui42 = firrtl.constant 9 : !firrtl.uint<42>
+    %c-9_si42 = firrtl.constant -9 : !firrtl.sint<42>
+    // The following should not error because the reset values are constant.
+    %r0 = firrtl.regreset %clock, %arst, %c9_ui42 : !firrtl.asyncreset, !firrtl.uint<42>, !firrtl.uint<42>
+    %r1 = firrtl.regreset %clock, %srst, %c9_ui42 : !firrtl.uint<1>, !firrtl.uint<42>, !firrtl.uint<42>
+    %r2 = firrtl.regreset %clock, %arst, %c-9_si42 : !firrtl.asyncreset, !firrtl.sint<42>, !firrtl.sint<42>
+    %r3 = firrtl.regreset %clock, %srst, %c-9_si42 : !firrtl.uint<1>, !firrtl.sint<42>, !firrtl.sint<42>
+  }
+
+  // CHECK-LABEL: hw.module @AsyncResetThroughWires(
+  firrtl.module @AsyncResetThroughWires(in %clock: !firrtl.clock, in %arst: !firrtl.asyncreset) {
+    %c9000_ui42 = firrtl.constant 9000 : !firrtl.uint<42>
+    %c9001_ui42 = firrtl.constant 9001 : !firrtl.uint<42>
+    %constWire = firrtl.wire : !firrtl.uint<42>
+    firrtl.connect %constWire, %c9000_ui42 : !firrtl.uint<42>, !firrtl.uint<42>
+    firrtl.connect %constWire, %c9001_ui42 : !firrtl.uint<42>, !firrtl.uint<42>
+    // The following should not error because the reset values are constant.
+    %r0 = firrtl.regreset %clock, %arst, %constWire : !firrtl.asyncreset, !firrtl.uint<42>, !firrtl.uint<42>
+  }
+
+  // CHECK-LABEL: hw.module @AsyncResetThroughNodes(
+  firrtl.module @AsyncResetThroughNodes(in %clock: !firrtl.clock, in %arst: !firrtl.asyncreset) {
+    %c1337_ui42 = firrtl.constant 1337 : !firrtl.uint<42>
+    %constNode = firrtl.node %c1337_ui42 : !firrtl.uint<42>
+    // The following should not error because the reset values are constant.
+    %r0 = firrtl.regreset %clock, %arst, %constNode : !firrtl.asyncreset, !firrtl.uint<42>, !firrtl.uint<42>
+  }
+
 }

--- a/test/Dialect/FIRRTL/SFCTests/async-reset-errors.mlir
+++ b/test/Dialect/FIRRTL/SFCTests/async-reset-errors.mlir
@@ -1,25 +1,26 @@
-// RUN: firtool --split-input-file --verify-diagnostics %s
-// XFAIL: *
+// RUN: firtool --lower-to-hw --split-input-file --verify-diagnostics %s
 // These will be picked up by https://github.com/llvm/circt/pull/1444
 
 // Tests extracted from:
 // - test/scala/firrtlTests/AsyncResetSpec.scala
 
 firrtl.circuit "Foo" {
+  // expected-note @+1 {{reset value defined here:}}
   firrtl.module @Foo(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %v: !firrtl.uint<8>) {
     // Constant check should see through subfield connects.
     %bundle0 = firrtl.wire : !firrtl.bundle<a: uint<8>>
     %bundle0.a = firrtl.subfield %bundle0(0) : (!firrtl.bundle<a: uint<8>>) -> !firrtl.uint<8>
     firrtl.connect %bundle0.a, %v : !firrtl.uint<8>, !firrtl.uint<8>
     // expected-error @+2 {{register with async reset requires constant reset value}}
-    // expected-note @-4 {{reset value defined here:}}
-    %2 = firrtl.regreset %clock, %reset, %bundle0 : (!firrtl.clock, !firrtl.asyncreset, !firrtl.bundle<a: uint<8>>) -> !firrtl.bundle<a: uint<8>>
+    // expected-error @+1 {{'firrtl.regreset' op LowerToHW couldn't handle this operation}}
+    %2 = firrtl.regreset %clock, %reset, %bundle0 : !firrtl.asyncreset, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>
   }
 }
 
 // -----
 
 firrtl.circuit "Foo" {
+  // expected-note @+1 {{reset value defined here:}}
   firrtl.module @Foo(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %v: !firrtl.uint<8>) {
     // Constant check should see through multiple connect hops.
     %bundle0 = firrtl.wire : !firrtl.bundle<a: uint<8>>
@@ -28,28 +29,30 @@ firrtl.circuit "Foo" {
     %bundle1 = firrtl.wire : !firrtl.bundle<a: uint<8>>
     firrtl.connect %bundle1, %bundle0 : !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>
     // expected-error @+2 {{register with async reset requires constant reset value}}
-    // expected-note @-3 {{reset value defined here:}}
-    %3 = firrtl.regreset %clock, %reset, %bundle1 : (!firrtl.clock, !firrtl.asyncreset, !firrtl.bundle<a: uint<8>>) -> !firrtl.bundle<a: uint<8>>
+    // expected-error @+1 {{'firrtl.regreset' op LowerToHW couldn't handle this operation}}
+    %3 = firrtl.regreset %clock, %reset, %bundle1 : !firrtl.asyncreset, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>
   }
 }
 
 // -----
 
 firrtl.circuit "Foo" {
+  // expected-note @+1 {{reset value defined here:}}
   firrtl.module @Foo(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %v: !firrtl.uint<8>) {
     // Constant check should see through subindex connects.
     %vector0 = firrtl.wire : !firrtl.vector<uint<8>, 1>
     %vector0.a = firrtl.subindex %vector0[0] : !firrtl.vector<uint<8>, 1>
     firrtl.connect %vector0.a, %v : !firrtl.uint<8>, !firrtl.uint<8>
     // expected-error @+2 {{register with async reset requires constant reset value}}
-    // expected-note @-4 {{reset value defined here:}}
-    %4 = firrtl.regreset %clock, %reset, %vector0 : (!firrtl.clock, !firrtl.asyncreset, !firrtl.vector<uint<8>, 1>) -> !firrtl.vector<uint<8>, 1>
+    // expected-error @+1 {{'firrtl.regreset' op LowerToHW couldn't handle this operation}}
+    %4 = firrtl.regreset %clock, %reset, %vector0 : !firrtl.asyncreset, !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
   }
 }
 
 // -----
 
 firrtl.circuit "Foo" {
+  // expected-note @+1 {{reset value defined here:}}
   firrtl.module @Foo(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %v: !firrtl.uint<8>) {
     // Constant check should see through multiple connect hops.
     %vector0 = firrtl.wire : !firrtl.vector<uint<8>, 1>
@@ -58,8 +61,8 @@ firrtl.circuit "Foo" {
     %vector1 = firrtl.wire : !firrtl.vector<uint<8>, 1>
     firrtl.connect %vector1, %vector0 : !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
     // expected-error @+2 {{register with async reset requires constant reset value}}
-    // expected-note @-3 {{reset value defined here:}}
-    %5 = firrtl.regreset %clock, %reset, %vector1 : (!firrtl.clock, !firrtl.asyncreset, !firrtl.vector<uint<8>, 1>) -> !firrtl.vector<uint<8>, 1>
+    // expected-error @+1 {{'firrtl.regreset' op LowerToHW couldn't handle this operation}}
+    %5 = firrtl.regreset %clock, %reset, %vector1 : !firrtl.asyncreset, !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
   }
 }
 
@@ -67,8 +70,8 @@ firrtl.circuit "Foo" {
 
 // Hidden Non-literals should NOT be allowed as reset values for AsyncReset
 firrtl.circuit "Foo" {
+  // expected-note @+1 {{reset value defined here:}}
   firrtl.module @Foo(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %x: !firrtl.vector<uint<1>, 4>, in %y: !firrtl.uint<1>, out %z: !firrtl.vector<uint<1>, 4>) {
-    // expected-note @+1 {{reset value defined here:}}
     %literal = firrtl.wire  : !firrtl.vector<uint<1>, 4>
     %0 = firrtl.subindex %literal[0] : !firrtl.vector<uint<1>, 4>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
@@ -79,8 +82,9 @@ firrtl.circuit "Foo" {
     firrtl.connect %2, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     %3 = firrtl.subindex %literal[3] : !firrtl.vector<uint<1>, 4>
     firrtl.connect %3, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-    // expected-error @+1 {{register with async reset requires constant reset value}}
-    %r = firrtl.regreset %clock, %reset, %literal  : (!firrtl.clock, !firrtl.asyncreset, !firrtl.vector<uint<1>, 4>) -> !firrtl.vector<uint<1>, 4>
+    // expected-error @+2 {{register with async reset requires constant reset value}}
+    // expected-error @+1 {{'firrtl.regreset' op LowerToHW couldn't handle this operation}}
+    %r = firrtl.regreset %clock, %reset, %literal  : !firrtl.asyncreset, !firrtl.vector<uint<1>, 4>, !firrtl.vector<uint<1>, 4>
     firrtl.connect %r, %x : !firrtl.vector<uint<1>, 4>, !firrtl.vector<uint<1>, 4>
     firrtl.connect %z, %r : !firrtl.vector<uint<1>, 4>, !firrtl.vector<uint<1>, 4>
   }
@@ -98,8 +102,9 @@ firrtl.circuit "Foo"   {
     firrtl.when %cond  {
       firrtl.connect %w, %y : !firrtl.uint<1>, !firrtl.uint<1>
     }
-    // expected-error @+1 {{register with async reset requires constant reset value}}
-    %r = firrtl.regreset %clock, %reset, %w  : (!firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>) -> !firrtl.uint<1>
+    // expected-error @+2 {{register with async reset requires constant reset value}}
+    // expected-error @+1 {{'firrtl.regreset' op LowerToHW couldn't handle this operation}}
+    %r = firrtl.regreset %clock, %reset, %w  : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %r, %x : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %z, %r : !firrtl.uint<1>, !firrtl.uint<1>
   }

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -196,6 +196,7 @@ firrtl.module @renaming() {
   %0, %1, %2 = firrtl.instance @declarations {name = "myinst"} : !firrtl.clock, !firrtl.uint<8>, !firrtl.asyncreset
 }
 firrtl.module @declarations(in %clock : !firrtl.clock, in %u8 : !firrtl.uint<8>, in %reset : !firrtl.asyncreset) attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
+  %c0_ui8 = firrtl.constant 0 : !firrtl.uint<8>
   // CHECK: %myinst_cmem = firrtl.combmem : !firrtl.cmemory<uint<8>, 8>
   %cmem = firrtl.combmem : !firrtl.cmemory<uint<8>, 8>
   // CHECK: %myinst_mem_read = firrtl.mem Undefined {depth = 1 : i64, name = "myinst_mem", portNames = ["read"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: sint<42>>
@@ -207,8 +208,8 @@ firrtl.module @declarations(in %clock : !firrtl.clock, in %u8 : !firrtl.uint<8>,
   %node = firrtl.node %u8 {name = "node"} : !firrtl.uint<8>
   // CHECK: %myinst_reg = firrtl.reg %myinst_clock : !firrtl.uint<8>
   %reg = firrtl.reg %clock {name = "reg"} : !firrtl.uint<8>
-  // CHECK: %myinst_regreset = firrtl.regreset %myinst_clock, %myinst_reset, %myinst_u8 : !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
-  %regreset = firrtl.regreset %clock, %reset, %u8 : !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
+  // CHECK: %myinst_regreset = firrtl.regreset %myinst_clock, %myinst_reset, %c0_ui8 : !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
+  %regreset = firrtl.regreset %clock, %reset, %c0_ui8 : !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
   // CHECK: %myinst_smem = firrtl.seqmem Undefined : !firrtl.cmemory<uint<8>, 8>
   %smem = firrtl.seqmem Undefined : !firrtl.cmemory<uint<8>, 8>
   // CHECK: %myinst_wire = firrtl.wire  : !firrtl.uint<1>


### PR DESCRIPTION
Have the verifier of `firrtl.regreset` check that any async reset value is a constant literal (or aggregate thereof). On the Scala side, this is checked in `CheckResets`.

*Note:* Had to open a new PR for this -- GitHub somehow screwed up the other branch ("cannot lock ref 'refs/heads/check-async-reset-const': reference already exists"). Thanks Microsoft.

### Todo
- [x] Land #1527
- [x] Land #1530