### PR TITLE
[PyCDE] Add `PyCDEType` to extend a type, adding `inner` and `create` methods

### DIFF
--- a/frontends/PyCDE/src/pycde/support.py
+++ b/frontends/PyCDE/src/pycde/support.py
@@ -9,14 +9,15 @@ import os
 class Value:
 
   def __init__(self, value, type=None):
+    from .types import PyCDEType
     self.value = support.get_value(value)
     if type is None:
-      self.type = support.type_to_pytype(self.value.type)
+      self.type = PyCDEType(self.value.type)
     else:
-      self.type = type
+      self.type = PyCDEType(type)
 
   def __getitem__(self, sub):
-    ty = support.get_self_or_inner(self.type)
+    ty = self.type.inner
     if isinstance(ty, hw.ArrayType):
       idx = int(sub)
       if idx >= self.type.size:
@@ -35,7 +36,7 @@ class Value:
         "Subscripting only supported on hw.array and hw.struct types")
 
   def __getattr__(self, attr):
-    ty = support.get_self_or_inner(self.type)
+    ty = self.type.inner
     if isinstance(ty, hw.StructType):
       fields = ty.get_fields()
       if attr in [name for name, _ in fields]:
@@ -93,8 +94,8 @@ def get_user_loc() -> ir.Location:
 class OpOperandConnect(support.OpOperand):
   """An OpOperand pycde extension which adds a connect method."""
 
-  def connect(self, obj):
-    val = obj_to_value(obj, self.type)
+  def connect(self, obj, result_type=None):
+    val = obj_to_value(obj, self.type, result_type)
     support.connect(self, val)
 
 

--- a/frontends/PyCDE/src/pycde/types.py
+++ b/frontends/PyCDE/src/pycde/types.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 
 import mlir.ir
 from circt.dialects import hw
+import circt.support
 
 
 class _Types:
@@ -20,39 +21,40 @@ class _Types:
     return mlir.ir.Type.parse(name)
 
   def int(self, width: int, name: str = None):
-    return self.maybe_create_alias(mlir.ir.IntegerType.get_signless(width),
-                                   name)
+    return self.wrap(mlir.ir.IntegerType.get_signless(width), name)
 
   def array(self,
             inner: mlir.ir.Type,
             size: int,
             name: str = None) -> hw.ArrayType:
-    return self.maybe_create_alias(hw.ArrayType.get(inner, size), name)
+    return self.wrap(hw.ArrayType.get(inner, size), name)
 
   def struct(self, members, name: str = None) -> hw.StructType:
+    members = OrderedDict(members)
     if isinstance(members, dict):
-      return self.maybe_create_alias(hw.StructType.get(list(members.items())),
-                                     name)
+      return self.wrap(hw.StructType.get(list(members.items())), name)
     if isinstance(members, list):
-      return self.maybe_create_alias(hw.StructType.get(members), name)
+      return self.wrap(hw.StructType.get(members), name)
     raise TypeError("Expected either list or dict.")
 
-  def maybe_create_alias(self, inner_type, name):
+  def wrap(self, type, name=None):
     if name is not None:
-      alias = hw.TypeAliasType.get(_Types.TYPE_SCOPE, name, inner_type)
+      type = self._create_alias(type, name)
+    return PyCDEType(type)
 
-      if name in self.registered_aliases:
-        if alias != self.registered_aliases[name]:
-          raise RuntimeError(
-              f"Re-defining type alias for {name}! "
-              f"Given: {inner_type}, "
-              f"existing: {self.registered_aliases[name].inner_type}")
-        return self.registered_aliases[name]
+  def _create_alias(self, inner_type, name):
+    alias = hw.TypeAliasType.get(_Types.TYPE_SCOPE, name, inner_type)
 
-      self.registered_aliases[name] = alias
-      return alias
+    if name in self.registered_aliases:
+      if alias != self.registered_aliases[name]:
+        raise RuntimeError(
+            f"Re-defining type alias for {name}! "
+            f"Given: {inner_type}, "
+            f"existing: {self.registered_aliases[name].inner_type}")
+      return self.registered_aliases[name]
 
-    return inner_type
+    self.registered_aliases[name] = alias
+    return alias
 
   def declare_types(self, mod):
     if not self.registered_aliases:
@@ -89,4 +91,33 @@ def dim(inner_type_or_bitwidth, *size: int, name: str = None) -> hw.ArrayType:
     ret = inner_type_or_bitwidth
   for s in size:
     ret = hw.ArrayType.get(ret, s)
-  return types.maybe_create_alias(ret, name)
+  return types.wrap(ret, name)
+
+
+# Parameterized class to subclass 'type'.
+def PyCDEType(type):
+  if type.__class__.__name__ == "_PyCDEType":
+    return type
+  type = circt.support.type_to_pytype(type)
+
+  class _PyCDEType(type.__class__):
+    """Add methods to an MLIR type class."""
+
+    # If we're subclassing a type alias, use a different 'inner' implementation.
+    if isinstance(type, hw.TypeAliasType):
+      @property
+      def inner(self):
+        """Return self or inner type."""
+        return PyCDEType(self.inner_type)
+    else:
+      @property
+      def inner(self):
+        """Return self or inner type."""
+        return self
+
+    def create(self, obj):
+      """Create a Value of this type from a python object."""
+      from .support import obj_to_value
+      return obj_to_value(obj, self, self)
+
+  return _PyCDEType(type)

--- a/frontends/PyCDE/test/syntactic_sugar.py
+++ b/frontends/PyCDE/test/syntactic_sugar.py
@@ -4,6 +4,7 @@ from pycde import types, dim, obj_to_value, System
 
 
 class Top(System):
+  BarType = types.struct({"foo": types.i12}, "bar")
   inputs = []
   outputs = []
 
@@ -12,7 +13,7 @@ class Top(System):
     obj_to_value([42, 45], dim(types.i8, 2))
     obj_to_value(5, types.i8)
 
-    obj_to_value({"foo": 7}, types.struct({"foo": types.i12}, "bar"))
+    Top.BarType.create({"foo": 7})
 
 
 top = Top()


### PR DESCRIPTION
- `inner` returns either itself or -- in the case of a type alias -- the inner type.
- `create` instantiates the type.