### PR TITLE
[ExportVerilog] Add option to force wires in event control exprs

### DIFF
--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -58,6 +58,11 @@ struct LoweringOptions {
   // Otherwise, it will print them as always statements
   bool useAlwaysFF = false;
 
+  /// If true, ExportVerilog allows expressions in the sensitivity list of
+  /// `always` statements, instead of forcing them to be simple wires. Some EDA
+  /// tools rely on these being simple wires.
+  bool allowExprInEventControl = false;
+
   /// This is the target width of lines in an emitted verilog source file in
   /// columns.
   unsigned emittedLineLength = 90;

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -41,6 +41,8 @@ void LoweringOptions::parse(StringRef text, ErrorHandlerT errorHandler) {
       // Empty options are fine.
     } else if (option == "alwaysFF") {
       useAlwaysFF = true;
+    } else if (option == "exprInEventControl") {
+      allowExprInEventControl = true;
     } else if (option.startswith("emittedLineLength=")) {
       option = option.drop_front(strlen("emittedLineLength="));
       if (option.getAsInteger(10, emittedLineLength)) {
@@ -59,6 +61,8 @@ std::string LoweringOptions::toString() const {
   // All options should add a trailing comma to simplify the code.
   if (useAlwaysFF)
     options += "alwaysFF,";
+  if (allowExprInEventControl)
+    options += "exprInEventControl,";
   if (emittedLineLength != 90)
     options += "emittedLineLength=" + std::to_string(emittedLineLength) + ',';
 

--- a/test/ExportVerilog/sv-always-wire.mlir
+++ b/test/ExportVerilog/sv-always-wire.mlir
@@ -1,0 +1,29 @@
+// RUN: circt-translate %s --export-verilog --verify-diagnostics --lowering-options=alwaysFF | FileCheck %s --strict-whitespace
+
+// CHECK-LABEL: module AlwaysSpill(
+hw.module @AlwaysSpill(%port: i1) {
+  %false = hw.constant false
+  %true = hw.constant true
+  %awire = sv.wire : !hw.inout<i1>
+
+  // CHECK: wire [[AWIRE:.+]] = awire;
+  %awire2 = sv.read_inout %awire : !hw.inout<i1>
+
+  // Existing simple names should not cause additional spill.
+  // CHECK: always @(posedge port)
+  sv.always posedge %port {}
+  // CHECK: always_ff @(posedge port)
+  sv.alwaysff(posedge %port) {}
+  // CHECK: always @(posedge [[AWIRE]])
+  sv.always posedge %awire2 {}
+  // CHECK: always_ff @(posedge [[AWIRE]])
+  sv.alwaysff(posedge %awire2) {}
+
+  // Constant values should cause a spill.
+  // CHECK: wire [[TMP:.+]] =
+  // CHECK-NEXT: always @(posedge [[TMP]])
+  sv.always posedge %false {}
+  // CHECK: wire [[TMP:.+]] =
+  // CHECK-NEXT: always_ff @(posedge [[TMP]])
+  sv.alwaysff(posedge %true) {}
+}

--- a/test/ExportVerilog/sv-dialect.mlir
+++ b/test/ExportVerilog/sv-dialect.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-translate %s -export-verilog -verify-diagnostics --lowering-options=alwaysFF | FileCheck %s --strict-whitespace
+// RUN: circt-translate %s -export-verilog -verify-diagnostics --lowering-options=alwaysFF,exprInEventControl | FileCheck %s --strict-whitespace
 
 // CHECK-LABEL: module M1(
 hw.module @M1(%clock : i1, %cond : i1, %val : i8) {


### PR DESCRIPTION
Add the `exprInEventControl` lowering option to `ExportVerilog`, which if forces the emitted Verilog to spill constants (which live in a `localparam`) into a `wire` when they are used as part of an event control (`@(posedge ...)`). The `exprInEventControl` option restores the old behavior of allowing arbitrary expressions in the event control.

Fixes #1450.