### PR TITLE
[SV][ExtractTestCode] Extract test code output paths from the annotation

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -222,7 +222,8 @@ struct CircuitLoweringState {
     return it != oldToNewModuleMap.end() ? it->second : nullptr;
   }
 
-  // Emit warnings on unprocessed annotations still remaining in the annoSet.
+  // Process remaining annotations and emit warnings on unprocessed annotations
+  // still remaining in the annoSet.
   void processRemainingAnnotations(Operation *op, const AnnotationSet &annoSet);
 
   CircuitOp circuitOp;

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -269,6 +269,7 @@ private:
       return;
     hw::OutputFileAttr outputFileAttr;
     // Check if the assert/assume/cover op has the output_file attribute.
+    // How to handle different path attributes on multiple ops?
     for (auto extractOp : roots)
       if (extractOp->hasAttr("output_file")) {
         outputFileAttr =

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1,6 +1,10 @@
 // RUN: circt-opt -lower-firrtl-to-hw %s | FileCheck %s
 
-firrtl.circuit "Simple" {
+firrtl.circuit "Simple"   attributes {annotations = [{class =
+"sifive.enterprise.firrtl.ExtractAssumptionsAnnotation", directory = "dir",  filename = "./dir1/filename1" }, {class =
+"sifive.enterprise.firrtl.ExtractCoverageAnnotation", directory = "dir",  filename = "./dir2/filename2" }, {class =
+"sifive.enterprise.firrtl.ExtractAssertionsAnnotation", directory = "dir",  filename = "./dir3/filename3" }]}
+{
 
   // CHECK-LABEL: hw.module @Simple
   firrtl.module @Simple(in %in1: !firrtl.uint<4>,
@@ -358,16 +362,16 @@ firrtl.circuit "Simple" {
 
     // CHECK-NEXT: sv.always posedge %clock {
     // CHECK-NEXT:   sv.if %aEn {
-    // CHECK-NEXT:     sv.assert %aCond : i1
-    // CHECK-NEXT:     sv.assert "assert_0" %aCond : i1
+    // CHECK-NEXT:     sv.assert {output_file = {directory = "", exclude_from_filelist = true, exclude_replicated_ops = true, name = "./dir3/filename3"}} %aCond : i1
+    // CHECK-NEXT:     sv.assert "assert_0" {output_file = {directory = "", exclude_from_filelist = true, exclude_replicated_ops = true, name = "./dir3/filename3"}} %aCond : i1
     // CHECK-NEXT:   }
     // CHECK-NEXT:   sv.if %bEn {
-    // CHECK-NEXT:     sv.assume %bCond  : i1
-    // CHECK-NEXT:     sv.assume "assume_0" %bCond  : i1
+    // CHECK-NEXT:     sv.assume {output_file = {directory = "", exclude_from_filelist = true, exclude_replicated_ops = true, name = "./dir1/filename1"}} %bCond : i1
+    // CHECK-NEXT:     sv.assume "assume_0" {output_file = {directory = "", exclude_from_filelist = true, exclude_replicated_ops = true, name = "./dir1/filename1"}} %bCond : i1
     // CHECK-NEXT:   }
     // CHECK-NEXT:   sv.if %cEn {
-    // CHECK-NEXT:     sv.cover %cCond : i1
-    // CHECK-NEXT:     sv.cover "cover_0" %cCond : i1
+    // CHECK-NEXT:     sv.cover {output_file = {directory = "", exclude_from_filelist = true, exclude_replicated_ops = true, name = "./dir2/filename2"}} %cCond : i1
+    // CHECK-NEXT:     sv.cover "cover_0" {output_file = {directory = "", exclude_from_filelist = true, exclude_replicated_ops = true, name = "./dir2/filename2"}} %cCond : i1
     // CHECK-NEXT:   }
     // CHECK-NEXT: }
     firrtl.assert %clock, %aCond, %aEn, "assert0"

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -1,6 +1,5 @@
 // RUN:  circt-opt --sv-extract-test-code %s | FileCheck %s
-
-// CHECK-LABEL: hw.module @issue1246_assert
+// CHECK-LABEL: hw.module @issue1246_assert(%clock: i1) attributes {output_file = {directory = "", exclude_from_filelist = true, exclude_replicated_ops = true, name = "./dir3/filename3"}
 // CHECK: sv.assert
 // CHECK: hw.module @issue1246
   hw.module @issue1246(%clock: i1) -> () {
@@ -8,7 +7,7 @@
       sv.ifdef.procedural "SYNTHESIS"  {
       } else  {
         sv.if %2937  {
-          sv.assert %clock : i1
+          sv.assert {output_file = {directory = "", exclude_from_filelist = true, exclude_replicated_ops = true, name = "./dir3/filename3"}} %clock : i1
         }
       }
     }

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -1,6 +1,7 @@
 // RUN:  circt-opt --sv-extract-test-code %s | FileCheck %s
 // CHECK-LABEL: hw.module @issue1246_assert(%clock: i1) attributes {output_file = {directory = "", exclude_from_filelist = true, exclude_replicated_ops = true, name = "./dir3/filename3"}
 // CHECK: sv.assert
+// CHECK: sv.assume
 // CHECK: hw.module @issue1246
   hw.module @issue1246(%clock: i1) -> () {
     sv.always posedge %clock  {
@@ -8,6 +9,7 @@
       } else  {
         sv.if %2937  {
           sv.assert {output_file = {directory = "", exclude_from_filelist = true, exclude_replicated_ops = true, name = "./dir3/filename3"}} %clock : i1
+          sv.assume {output_file = {directory = "", exclude_from_filelist = true, exclude_replicated_ops = true, name = "./dir4/filename4"}} %clock : i1
         }
       }
     }


### PR DESCRIPTION
Process `ExtractTestCode` annotations, for specifying the file name and directory path

Changes in this PR:
1. Update `LowerToHW` to process remaining annotations before warning on them.
2. Add `hw::OutputFileAttr` from the corresponding annotation to `assume, cover, assert` operations.
3.  Update `SVExtractTestCode` to add the `hw::OutputFileAttr` attribute to the extracted module. 
4. `AssertOp` and `AssumeOp` are extracted into the same module, so handling different filename attributes on the operations is an issue.
5. Annotations handled: 
``` 
sifive.enterprise.firrtl.ExtractAssumptionsAnnotation, sifive.enterprise.firrtl.ExtractAssertionsAnnotation, sifive.enterprise.firrtl.ExtractCoverageAnnotation
``` 
6. The annotation example, 
```
{class = "sifive.enterprise.firrtl.ExtractAssumptionsAnnotation", directory = "federation/builds/coreip_viu75_256/verilog/CoreIPSubsystemVerifTestHarness.SiFiveCoreDesignerAlterations/assumptions", filename = "federation/builds/coreip_viu75_256/verilog/CoreIPSubsystemVerifTestHarness.SiFiveCoreDesignerAlterations/assumptions/assumptions.bindings.sv"}
```