### PR TITLE
[PyCDE] Support python objects as generator returns

### DIFF
--- a/frontends/PyCDE/src/pycde/module.py
+++ b/frontends/PyCDE/src/pycde/module.py
@@ -328,13 +328,16 @@ def _register_generator(class_name, generator_name, generator, parameters):
                                 generator_name, generator, parameters)
 
 
+class GeneratorError:
+  pass
+
+
 class _Generate:
   """Represents a generator. Stores the generate function and wraps it with the
   necessary logic to build an HWModule."""
 
   def __init__(self, gen_func):
     self.gen_func = gen_func
-    self.gen_name = gen_func.__name__
     self.modcls = None
     self.loc = get_user_loc()
 
@@ -441,16 +444,14 @@ class _Generate:
       if len(output_ports) == 0:
         hw.OutputOp([])
         return
-      raise support.ConnectionError(
-          f"In {self.modcls} generator {self.gen_name}, must return dict")
+      raise support.ConnectionError("Generator must return dict")
 
     # Now create the output op depending on the object type returned
     outputs: list[Value] = list()
 
     # Only acceptable return is a dict of port, value mappings.
     if not isinstance(gen_ret, dict):
-      raise support.ConnectionError(
-          f"In {self.modcls}, generators must return a dict of outputs")
+      raise support.ConnectionError("Generator must return a dict of outputs")
 
     # A dict of `OutputPortName` -> ValueLike or convertable objects must be
     # converted to a list in port order.
@@ -465,7 +466,7 @@ class _Generate:
         gen_ret.pop(name)
     if len(gen_ret) > 0:
       raise support.ConnectionError(
-          f"Could not map the following to output ports in {self.modcls}: " +
+          "Could not map the following to output ports: " +
           ",".join(gen_ret.keys()))
 
     hw.OutputOp(outputs)

--- a/frontends/PyCDE/src/pycde/module.py
+++ b/frontends/PyCDE/src/pycde/module.py
@@ -456,6 +456,8 @@ class _Generate:
         val = obj_to_value(gen_ret[name], port_type)
         outputs.append(val)
         gen_ret.pop(name)
+    if len(unconnected_ports) > 0:
+      raise support.UnconnectedSignalError(unconnected_ports)
     if len(gen_ret) > 0:
       raise support.ConnectionError(
           "Could not map the following to output ports: " +

--- a/frontends/PyCDE/src/pycde/module.py
+++ b/frontends/PyCDE/src/pycde/module.py
@@ -202,13 +202,7 @@ def _module_base(cls, extern: bool, params={}):
       self.backedges: dict[int:BackedgeBuilder.Edge] = {}
       for (idx, (name, type)) in enumerate(mod._input_ports):
         if name in inputs:
-          value = obj_to_value(inputs[name], type, throw_on_mismatch=False)
-          if value is None:
-            if not extern:
-              raise TypeError(f"Input '{name}' has type '{value.type}' "
-                              f"but expected '{type}'")
-            else:
-              value = support.get_value(inputs[name])
+          value = obj_to_value(inputs[name], type)
         else:
           backedge = BackedgeBuilder.current().create(type, name, self, loc=loc)
           self.backedges[idx] = backedge

--- a/frontends/PyCDE/src/pycde/module.py
+++ b/frontends/PyCDE/src/pycde/module.py
@@ -337,6 +337,12 @@ class _Generate:
     self.modcls = None
     self.loc = get_user_loc()
 
+  def _generate(self, mod):
+    ret = self.gen_func(mod)
+    if ret is None:
+      return
+    return {name: obj_to_value(obj) for (name, obj) in ret.items()}
+
   def __call__(self, op):
     """Build an HWModuleOp and run the generator as the body builder."""
 
@@ -379,7 +385,7 @@ class _Generate:
                                module_name,
                                input_ports=self.modcls._input_ports,
                                output_ports=self.modcls._output_ports,
-                               body_builder=self.gen_func)
+                               body_builder=self._generate)
     else:
       assert (len(existing_module_names) == 1)
       mod = existing_module_names[0]

--- a/frontends/PyCDE/src/pycde/support.py
+++ b/frontends/PyCDE/src/pycde/support.py
@@ -116,10 +116,7 @@ def obj_to_value(x, type, result_type=None, throw_on_mismatch=True):
   # If x is already a valid value, just return it.
   if val is not None:
     if val.type != result_type:
-      if throw_on_mismatch:
-        raise ValueError(f"Expected {result_type}, got {val.type}")
-      else:
-        return None
+      raise ValueError(f"Expected {result_type}, got {val.type}")
     return val
 
   if isinstance(x, int):

--- a/frontends/PyCDE/src/pycde/support.py
+++ b/frontends/PyCDE/src/pycde/support.py
@@ -9,14 +9,15 @@ import os
 class Value:
 
   def __init__(self, value, type=None):
+    from .types import PyCDEType
     self.value = support.get_value(value)
     if type is None:
-      self.type = support.type_to_pytype(self.value.type)
+      self.type = PyCDEType(self.value.type)
     else:
-      self.type = type
+      self.type = PyCDEType(type)
 
   def __getitem__(self, sub):
-    ty = support.get_self_or_inner(self.type)
+    ty = self.type.inner
     if isinstance(ty, hw.ArrayType):
       idx = int(sub)
       if idx >= self.type.size:
@@ -35,7 +36,7 @@ class Value:
         "Subscripting only supported on hw.array and hw.struct types")
 
   def __getattr__(self, attr):
-    ty = support.get_self_or_inner(self.type)
+    ty = self.type.inner
     if isinstance(ty, hw.StructType):
       fields = ty.get_fields()
       if attr in [name for name, _ in fields]:
@@ -93,8 +94,8 @@ def get_user_loc() -> ir.Location:
 class OpOperandConnect(support.OpOperand):
   """An OpOperand pycde extension which adds a connect method."""
 
-  def connect(self, obj):
-    val = obj_to_value(obj, self.type)
+  def connect(self, obj, result_type=None):
+    val = obj_to_value(obj, self.type, result_type)
     support.connect(self, val)
 
 

--- a/frontends/PyCDE/src/pycde/support.py
+++ b/frontends/PyCDE/src/pycde/support.py
@@ -99,7 +99,7 @@ class OpOperandConnect(support.OpOperand):
     support.connect(self, val)
 
 
-def obj_to_value(x, type=None, result_type=None):
+def obj_to_value(x, type, result_type=None, throw_on_mismatch=True):
   """Convert a python object to a CIRCT value, given the CIRCT type."""
 
   type = support.type_to_pytype(type)
@@ -116,7 +116,10 @@ def obj_to_value(x, type=None, result_type=None):
   # If x is already a valid value, just return it.
   if val is not None:
     if val.type != result_type:
-      raise ValueError(f"Expected {result_type}, got {val.type}")
+      if throw_on_mismatch:
+        raise ValueError(f"Expected {result_type}, got {val.type}")
+      else:
+        return None
     return val
 
   if isinstance(x, int):

--- a/frontends/PyCDE/src/pycde/types.py
+++ b/frontends/PyCDE/src/pycde/types.py
@@ -105,11 +105,13 @@ def PyCDEType(type):
 
     # If we're subclassing a type alias, use a different 'inner' implementation.
     if isinstance(type, hw.TypeAliasType):
+
       @property
       def inner(self):
         """Return self or inner type."""
         return PyCDEType(self.inner_type)
     else:
+
       @property
       def inner(self):
         """Return self or inner type."""

--- a/frontends/PyCDE/src/pycde/types.py
+++ b/frontends/PyCDE/src/pycde/types.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 
 import mlir.ir
 from circt.dialects import hw
+import circt.support
 
 
 class _Types:
@@ -20,39 +21,40 @@ class _Types:
     return mlir.ir.Type.parse(name)
 
   def int(self, width: int, name: str = None):
-    return self.maybe_create_alias(mlir.ir.IntegerType.get_signless(width),
-                                   name)
+    return self.wrap(mlir.ir.IntegerType.get_signless(width), name)
 
   def array(self,
             inner: mlir.ir.Type,
             size: int,
             name: str = None) -> hw.ArrayType:
-    return self.maybe_create_alias(hw.ArrayType.get(inner, size), name)
+    return self.wrap(hw.ArrayType.get(inner, size), name)
 
   def struct(self, members, name: str = None) -> hw.StructType:
+    members = OrderedDict(members)
     if isinstance(members, dict):
-      return self.maybe_create_alias(hw.StructType.get(list(members.items())),
-                                     name)
+      return self.wrap(hw.StructType.get(list(members.items())), name)
     if isinstance(members, list):
-      return self.maybe_create_alias(hw.StructType.get(members), name)
+      return self.wrap(hw.StructType.get(members), name)
     raise TypeError("Expected either list or dict.")
 
-  def maybe_create_alias(self, inner_type, name):
+  def wrap(self, type, name=None):
     if name is not None:
-      alias = hw.TypeAliasType.get(_Types.TYPE_SCOPE, name, inner_type)
+      type = self._create_alias(type, name)
+    return PyCDEType(type)
 
-      if name in self.registered_aliases:
-        if alias != self.registered_aliases[name]:
-          raise RuntimeError(
-              f"Re-defining type alias for {name}! "
-              f"Given: {inner_type}, "
-              f"existing: {self.registered_aliases[name].inner_type}")
-        return self.registered_aliases[name]
+  def _create_alias(self, inner_type, name):
+    alias = hw.TypeAliasType.get(_Types.TYPE_SCOPE, name, inner_type)
 
-      self.registered_aliases[name] = alias
-      return alias
+    if name in self.registered_aliases:
+      if alias != self.registered_aliases[name]:
+        raise RuntimeError(
+            f"Re-defining type alias for {name}! "
+            f"Given: {inner_type}, "
+            f"existing: {self.registered_aliases[name].inner_type}")
+      return self.registered_aliases[name]
 
-    return inner_type
+    self.registered_aliases[name] = alias
+    return alias
 
   def declare_types(self, mod):
     if not self.registered_aliases:
@@ -89,4 +91,33 @@ def dim(inner_type_or_bitwidth, *size: int, name: str = None) -> hw.ArrayType:
     ret = inner_type_or_bitwidth
   for s in size:
     ret = hw.ArrayType.get(ret, s)
-  return types.maybe_create_alias(ret, name)
+  return types.wrap(ret, name)
+
+
+# Parameterized class to subclass 'type'.
+def PyCDEType(type):
+  if type.__class__.__name__ == "_PyCDEType":
+    return type
+  type = circt.support.type_to_pytype(type)
+
+  class _PyCDEType(type.__class__):
+    """Add methods to an MLIR type class."""
+
+    # If we're subclassing a type alias, use a different 'inner' implementation.
+    if isinstance(type, hw.TypeAliasType):
+      @property
+      def inner(self):
+        """Return self or inner type."""
+        return PyCDEType(self.inner_type)
+    else:
+      @property
+      def inner(self):
+        """Return self or inner type."""
+        return self
+
+    def create(self, obj):
+      """Create a Value of this type from a python object."""
+      from .support import obj_to_value
+      return obj_to_value(obj, self, self)
+
+  return _PyCDEType(type)

--- a/frontends/PyCDE/test/syntactic_sugar.py
+++ b/frontends/PyCDE/test/syntactic_sugar.py
@@ -4,6 +4,7 @@ from pycde import types, dim, obj_to_value, System
 
 
 class Top(System):
+  BarType = types.struct({"foo": types.i12}, "bar")
   inputs = []
   outputs = []
 
@@ -12,7 +13,7 @@ class Top(System):
     obj_to_value([42, 45], dim(types.i8, 2))
     obj_to_value(5, types.i8)
 
-    obj_to_value({"foo": 7}, types.struct({"foo": types.i12}, "bar"))
+    Top.BarType.create({"foo": 7})
 
 
 top = Top()

--- a/frontends/PyCDE/test/syntactic_sugar.py
+++ b/frontends/PyCDE/test/syntactic_sugar.py
@@ -1,6 +1,15 @@
 # RUN: %PYTHON% %s | FileCheck %s
 
-from pycde import types, dim, obj_to_value, System
+from pycde import (Output, module, generator, obj_to_value, types, dim, System)
+
+
+@module
+class Taps:
+  taps = Output(dim(8, 3))
+
+  @generator
+  def build(mod):
+    return {"taps": [203, 100, 23]}
 
 
 class Top(System):
@@ -15,8 +24,11 @@ class Top(System):
 
     Top.BarType.create({"foo": 7})
 
+    Taps()
+
 
 top = Top()
+top.generate(["build"])
 top.print()
 # CHECK-LABEL: hw.module @top()
 # CHECK:  %c7_i12 = hw.constant 7 : i12
@@ -28,3 +40,10 @@ top.print()
 # CHECK:  %c7_i12_0 = hw.constant 7 : i12
 # CHECK:  %2 = hw.struct_create (%c7_i12_0) : !hw.struct<foo: i12>
 # CHECK:  %3 = hw.bitcast %2 : (!hw.struct<foo: i12>) -> !hw.typealias<@pycde::@bar, !hw.struct<foo: i12>>
+
+# CHECK:  hw.module @pycde.Taps() -> (%taps: !hw.array<3xi8>)
+# CHECK:    %c-53_i8 = hw.constant -53 : i8
+# CHECK:    %c100_i8 = hw.constant 100 : i8
+# CHECK:    %c23_i8 = hw.constant 23 : i8
+# CHECK:    [[REG0:%.+]] = hw.array_create %c23_i8, %c100_i8, %c-53_i8 : i8
+# CHECK:    hw.output [[REG0]] : !hw.array<3xi8>


### PR DESCRIPTION
Instead of requiring users to create CIRCT arrays/structs themselves, just return lists and dicts! Involved putting type checking in `obj_to_value`, so I broke the externmod type mismatch exception. Will fix in a subsequent PR which will accomplish this in a more principled way.

I ended up copying `_create_output_op` and drastically simplifying it from the python bindings. It's different enough that it's not worth it to share code. We should consider dropping the original since it goes a bit beyond "just a binding".