### PR TITLE
[PyCDE] Add `no_connect` value

### DIFF
--- a/frontends/PyCDE/src/pycde/support.py
+++ b/frontends/PyCDE/src/pycde/support.py
@@ -99,7 +99,7 @@ class OpOperandConnect(support.OpOperand):
     support.connect(self, val)
 
 
-def obj_to_value(x, type, result_type=None, throw_on_mismatch=True):
+def obj_to_value(x, type, result_type=None):
   """Convert a python object to a CIRCT value, given the CIRCT type."""
 
   type = support.type_to_pytype(type)

--- a/frontends/PyCDE/test/syntactic_sugar.py
+++ b/frontends/PyCDE/test/syntactic_sugar.py
@@ -1,6 +1,7 @@
 # RUN: %PYTHON% %s | FileCheck %s
 
-from pycde import (Output, module, generator, obj_to_value, types, dim, System)
+from pycde import (Output, Input, module, generator, obj_to_value, types, dim, System, no_connect)
+from pycde.module import externmodule
 
 
 @module
@@ -10,6 +11,11 @@ class Taps:
   @generator
   def build(mod):
     return {"taps": [203, 100, 23]}
+
+
+@externmodule
+class StupidLegacy:
+  ignore = Input(dim(1, 4))
 
 
 class Top(System):
@@ -25,6 +31,7 @@ class Top(System):
     Top.BarType.create({"foo": 7})
 
     Taps()
+    StupidLegacy(ignore=no_connect)
 
 
 top = Top()


### PR DESCRIPTION
This indicates not to connect an external modules port.