### PR TITLE
[FIRRTL][Annotation] Remove maxFieldID param from SubAnnoAttr

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -131,11 +131,10 @@ def SubAnnotationAttr
   let summary = "An Annotation that targets part of what it's attached to";
   let description = [{
     An Annotation that is only applicable to part of what it is attached to.
-    This uses a range of field IDs to indicate to which fields it is applicable.
+    This uses a field ID to indicate to which field it is applicable.
   }];
   let mnemonic = "subAnno";
-  let parameters = (ins "int64_t":$minFieldID, "int64_t":$maxFieldID,
-                        "DictionaryAttr":$annotations);
+  let parameters = (ins "int64_t":$fieldID, "DictionaryAttr":$annotations);
 }
 
 def PortAnnotationsAttr : TypedArrayAttrBase<AnnotationArrayAttr,

--- a/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
@@ -56,25 +56,24 @@ void FIRRTLDialect::printAttribute(Attribute attr, DialectAsmPrinter &p) const {
 
 Attribute SubAnnotationAttr::parse(MLIRContext *ctxt, DialectAsmParser &p,
                                    Type type) {
-  int64_t minFieldID, maxFieldID;
+  int64_t fieldID;
   DictionaryAttr annotations;
   StringRef fieldIDKeyword;
 
   if (p.parseLess() || p.parseKeyword(&fieldIDKeyword) || p.parseEqual() ||
-      p.parseLSquare() || p.parseInteger(minFieldID) || p.parseComma() ||
-      p.parseInteger(maxFieldID) || p.parseRSquare() || p.parseComma() ||
+      p.parseInteger(fieldID) || p.parseComma() ||
       p.parseAttribute<DictionaryAttr>(annotations) || p.parseGreater())
     return Attribute();
 
   if (fieldIDKeyword != "fieldID")
     return Attribute();
 
-  return SubAnnotationAttr::get(ctxt, minFieldID, maxFieldID, annotations);
+  return SubAnnotationAttr::get(ctxt, fieldID, annotations);
 }
 
 void SubAnnotationAttr::print(DialectAsmPrinter &p) const {
-  p << getMnemonic() << "<fieldID = [" << getMinFieldID() << ", "
-    << getMaxFieldID() << "], " << getAnnotations() << ">";
+  p << getMnemonic() << "<fieldID = " << getFieldID() << ", "
+    << getAnnotations() << ">";
 }
 
 void FIRRTLDialect::registerAttributes() {

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -49,23 +49,22 @@ struct FlatBundleFieldEntry {
   FIRRTLType type;
   /// The index in the parent type
   size_t index;
-  /// The FieldID range of self and children in the parent type
-  unsigned minFieldID, maxFieldID;
+  /// The fieldID
+  unsigned fieldID;
   /// This is a suffix to add to the field name to make it unique.
   SmallString<16> suffix;
   /// This indicates whether the field was flipped to be an output.
   bool isOutput;
 
-  FlatBundleFieldEntry(const FIRRTLType &type, size_t index,
-                       unsigned minFieldID, unsigned maxFieldID,
+  FlatBundleFieldEntry(const FIRRTLType &type, size_t index, unsigned fieldID,
                        StringRef suffix, bool isOutput)
-      : type(type), index(index), minFieldID(minFieldID),
-        maxFieldID(maxFieldID), suffix(suffix), isOutput(isOutput) {}
+      : type(type), index(index), fieldID(fieldID), suffix(suffix),
+        isOutput(isOutput) {}
 
   void dump() const {
     llvm::errs() << "FBFE{" << type << " index<" << index << "> fieldID<"
-                 << minFieldID << "," << maxFieldID << "> suffix<" << suffix
-                 << "> isOutput<" << isOutput << ">}\n";
+                 << fieldID << "> suffix<" << suffix << "> isOutput<"
+                 << isOutput << ">}\n";
   }
 };
 } // end anonymous namespace
@@ -83,9 +82,8 @@ static bool peelType(Type type, SmallVectorImpl<FlatBundleFieldEntry> &fields) {
           tmpSuffix.resize(0);
           tmpSuffix.push_back('_');
           tmpSuffix.append(elt.name.getValue());
-          fields.emplace_back(elt.type, i, bundle.getFieldID(i),
-                              bundle.getFieldID(i) + elt.type.getMaxFieldID(),
-                              tmpSuffix, elt.isFlip);
+          fields.emplace_back(elt.type, i, bundle.getFieldID(i), tmpSuffix,
+                              elt.isFlip);
         }
         return true;
       })
@@ -94,7 +92,6 @@ static bool peelType(Type type, SmallVectorImpl<FlatBundleFieldEntry> &fields) {
         auto width = vector.getElementType().getMaxFieldID() + 1;
         for (size_t i = 0, e = vector.getNumElements(); i != e; ++i) {
           fields.emplace_back(vector.getElementType(), i, vector.getFieldID(i),
-                              vector.getFieldID(i) + width,
                               "_" + std::to_string(i), false);
         }
         return true;
@@ -138,20 +135,19 @@ static ArrayAttr filterAnnotations(MLIRContext *ctxt, ArrayAttr annotations,
     return ArrayAttr::get(ctxt, retval);
   for (auto opAttr : annotations) {
     if (auto subAnno = opAttr.dyn_cast<SubAnnotationAttr>()) {
-      // Check for overlap of the two ranges
-      if ((field.minFieldID >= subAnno.getMinFieldID() &&
-           field.minFieldID <= subAnno.getMaxFieldID()) ||
-          (field.maxFieldID >= subAnno.getMinFieldID() &&
-           field.minFieldID <= subAnno.getMinFieldID())) {
-        auto newMin =
-            srcType.rootChildFieldID(subAnno.getMinFieldID(), field.index);
-        auto newMax =
-            srcType.rootChildFieldID(subAnno.getMinFieldID(), field.index);
-        if (newMin.first == 0 && newMax.first == 0)
+      // Check whether the annotation falls into the range of the current field.
+      if (subAnno.getFieldID() >= field.fieldID &&
+          subAnno.getFieldID() <= field.fieldID + field.type.getMaxFieldID()) {
+        if (auto newFieldID = subAnno.getFieldID() - field.fieldID) {
+          // If the target is a subfield/subindex of the current field, create a
+          // new sub-annotation with a new field ID.
+          retval.push_back(SubAnnotationAttr::get(ctxt, newFieldID,
+                                                  subAnno.getAnnotations()));
+        } else {
+          // Otherwise, if the current field is exactly the target, degenerate
+          // the sub-annotation to a normal annotation.
           retval.push_back(subAnno.getAnnotations());
-        else
-          retval.push_back(SubAnnotationAttr::get(
-              ctxt, newMin.first, newMax.first, subAnno.getAnnotations()));
+        }
       }
     } else
       retval.push_back(opAttr);
@@ -184,30 +180,27 @@ static MemOp cloneMemWithNewType(ImplicitLocOpBuilder *b, MemOp op,
     SmallVector<Attribute> portAnno;
     for (auto attr : newMem.getPortAnnotation(portIdx)) {
       if (auto subAnno = attr.dyn_cast<SubAnnotationAttr>()) {
-        auto minIdx = oldPortType.getIndexForFieldID(subAnno.getMinFieldID());
-        auto maxIdx = oldPortType.getIndexForFieldID(subAnno.getMaxFieldID());
-        if (minIdx != maxIdx) {
-          op.emitError("Cannot handle annotation ranges spanning fields");
-          continue;
-        }
-        if (minIdx >= 3) { // data or mask
-          // is the annotation in the filtered field?
-          // FieldID of the annotation in the data field.
-          auto minID =
-              oldPortType.rootChildFieldID(subAnno.getMinFieldID(), minIdx);
-          // FieldID of the annotation in filtered data type.
-          minID = op.getDataType().rootChildFieldID(minID.first, field.index);
-          if (minID.second) { // contained!
+        auto index = oldPortType.getIndexForFieldID(subAnno.getFieldID());
+        if (index >= 3) { // data or mask
+          // Check whether the annotation falls into the range of the current
+          // field. Note that the `field` here is peeled from the `data`
+          // sub-field of the memory port, thus we need to add the fieldID of
+          // `data` or `mask` sub-field to get the "real" fieldID.
+          auto fieldID = field.fieldID + oldPortType.getFieldID(index);
+          if (subAnno.getFieldID() >= fieldID &&
+              subAnno.getFieldID() <= fieldID + field.type.getMaxFieldID()) {
+            // Create a new sub-annotation with a new field ID. Similarly, we
+            // need to add the fieldID of `data` or `mask` sub-field in the new
+            // memory port type here.
+            auto newFieldID =
+                subAnno.getFieldID() - fieldID + portType.getFieldID(index);
             portAnno.push_back(SubAnnotationAttr::get(
-                b->getContext(), portType.getFieldID(minIdx) + minID.first,
-                portType.getFieldID(maxIdx) + minID.first,
-                subAnno.getAnnotations()));
+                b->getContext(), newFieldID, subAnno.getAnnotations()));
           }
-
-        } else {
-          portAnno.push_back(SubAnnotationAttr::get(
-              b->getContext(), portType.getFieldID(minIdx),
-              portType.getFieldID(maxIdx), subAnno.getAnnotations()));
+        } else { // addr, en, or clk
+          portAnno.push_back(SubAnnotationAttr::get(b->getContext(),
+                                                    portType.getFieldID(index),
+                                                    subAnno.getAnnotations()));
         }
       } else {
         portAnno.push_back(attr);

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -197,8 +197,10 @@ static MemOp cloneMemWithNewType(ImplicitLocOpBuilder *b, MemOp op,
           continue;
         }
 
-        // Handle `data` and `mask` sub-fields.
-        if (targetIndex >= 3) {
+        // Handle `data`, `rdata`, `wdata`, and `mask` sub-fields.
+        auto portKind = newMem.getPortKind(portIdx);
+        if ((portKind == MemOp::PortKind::ReadWrite && targetIndex > 3) ||
+            (portKind != MemOp::PortKind::ReadWrite && targetIndex > 2)) {
           // Check whether the annotation falls into the range of the current
           // field. Note that the `field` here is peeled from the `data`
           // sub-field of the memory port, thus we need to add the fieldID of

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -102,8 +102,8 @@ circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar.a"},
     ; CHECK-LABEL: module {
     ; CHECK: %bar_a, %bar_b, %bar_c = firrtl.instance @Bar
     ; CHECK-SAME: [{one}],
-    ; CHECK-SAME: [#firrtl.subAnno<fieldID = [1, 1], {two}>,
-    ; CHECK-SAME:  #firrtl.subAnno<fieldID = [2, 2], {three}>],
+    ; CHECK-SAME: [#firrtl.subAnno<fieldID = 1, {two}>,
+    ; CHECK-SAME:  #firrtl.subAnno<fieldID = 2, {three}>],
     ; CHECK-SAME: [{four}]
 
 ; // -----
@@ -155,8 +155,8 @@ circuit Foo: %[[{"a":null,"target":"~Foo|Foo>bar.r"},
     ; CHECK-LABEL: module {
     ; CHECK: firrtl.mem
     ; CHECK-SAME: portAnnotations = [
-    ; CHECK-SAME: [{a}, #firrtl.subAnno<fieldID = [5, 5], {b}>],
-    ; CHECK-SAME: [#firrtl.subAnno<fieldID = [2, 2], {c}>, #firrtl.subAnno<fieldID = [6, 6], {d}>]
+    ; CHECK-SAME: [{a}, #firrtl.subAnno<fieldID = 5, {b}>],
+    ; CHECK-SAME: [#firrtl.subAnno<fieldID = 2, {c}>, #firrtl.subAnno<fieldID = 6, {d}>]
 
 ; // -----
 
@@ -287,8 +287,8 @@ circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar[0]"},{"two":null,"target":"~F
 
     ; CHECK-LABEL: module {
     ; CHECK: %bar = firrtl.wire  {annotations =
-    ; CHECK-SAME: #firrtl.subAnno<fieldID = [1, 3], {one}>
-    ; CHECK-SAME: #firrtl.subAnno<fieldID = [5, 5], {two}>
+    ; CHECK-SAME: #firrtl.subAnno<fieldID = 1, {one}>
+    ; CHECK-SAME: #firrtl.subAnno<fieldID = 5, {two}>
 
 
 ; // -----
@@ -301,8 +301,8 @@ circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar[0]"},{"two":null,"target":"~F
 
     ; CHECK-LABEL: module {
     ; CHECK: %bar = firrtl.reg %clock  {annotations =
-    ; CHECK-SAME: #firrtl.subAnno<fieldID = [1, 3], {one}>
-    ; CHECK-SAME: #firrtl.subAnno<fieldID = [5, 5], {two}>
+    ; CHECK-SAME: #firrtl.subAnno<fieldID = 1, {one}>
+    ; CHECK-SAME: #firrtl.subAnno<fieldID = 5, {two}>
 
 ; // -----
 
@@ -525,9 +525,9 @@ circuit GCTDataTap : %[
     ; CHECK-SAME:    portID = [[PORT_ID_0:[0-9]+]] : i64,
     ; CHECK-SAME:    type = "portName"}
     ; CHECK-SAME: %_1: !firrtl.vector<uint<1>, 1> {firrtl.annotations
-    ; CHECK-SAME:   #firrtl.subAnno<fieldID = [1, 1],
+    ; CHECK-SAME:   #firrtl.subAnno<fieldID = 1,
     ; CHECK-SAME:     {class = "firrtl.transforms.DontTouchAnnotation"}>
-    ; CHECK-SAME:   #firrtl.subAnno<fieldID = [1, 1],
+    ; CHECK-SAME:   #firrtl.subAnno<fieldID = 1,
     ; CHECK-SAME:     {class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
     ; CHECK-SAME:      id = [[ID]] : i64,
     ; CHECK-SAME:      portID = [[PORT_ID_1:[0-9]+]] : i64,
@@ -539,9 +539,9 @@ circuit GCTDataTap : %[
     ; CHECK-SAME:    portID = [[PORT_ID_2:[0-9]+]] : i64,
     ; CHECK-SAME:    type = "portName"}
     ; CHECK-SAME: %_3: !firrtl.vector<uint<1>, 1> {firrtl.annotations =
-    ; CHECK-SAME:   #firrtl.subAnno<fieldID = [1, 1],
+    ; CHECK-SAME:   #firrtl.subAnno<fieldID = 1,
     ; CHECK-SAME:     {class = "firrtl.transforms.DontTouchAnnotation"}>
-    ; CHECK-SAME:   #firrtl.subAnno<fieldID = [1, 1],
+    ; CHECK-SAME:   #firrtl.subAnno<fieldID = 1,
     ; CHECK-SAME:     {class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
     ; CHECK-SAME:      id = [[ID]] : i64,
     ; CHECK-SAME:      portID = [[PORT_ID_3:[0-9]+]] : i64,
@@ -552,9 +552,9 @@ circuit GCTDataTap : %[
     ; CHECK-SAME:    id = [[ID]] : i64,
     ; CHECK-SAME:    portID = [[PORT_ID_4:[0-9]+]] : i64}
     ; CHECK-SAME: %_5: !firrtl.vector<uint<1>, 1> {firrtl.annotations =
-    ; CHECK-SAME:   #firrtl.subAnno<fieldID = [1, 1],
+    ; CHECK-SAME:   #firrtl.subAnno<fieldID = 1,
     ; CHECK-SAME:     {class = "firrtl.transforms.DontTouchAnnotation"}>
-    ; CHECK-SAME:   #firrtl.subAnno<fieldID = [1, 1],
+    ; CHECK-SAME:   #firrtl.subAnno<fieldID = 1,
     ; CHECK-SAME:     {class = "sifive.enterprise.grandcentral.DataTapModuleSignalKey",
     ; CHECK-SAME:      id = [[ID]] : i64,
     ; CHECK-SAME:      portID = [[PORT_ID_5:[0-9]+]] : i64}>
@@ -563,9 +563,9 @@ circuit GCTDataTap : %[
     ; CHECK-SAME:   {class = "sifive.enterprise.grandcentral.DeletedDataTapKey",
     ; CHECK-SAME:    id = [[ID]] : i64}
     ; CHECK-SAME: %_7: !firrtl.vector<uint<1>, 1> {firrtl.annotations =
-    ; CHECK-SAME:   #firrtl.subAnno<fieldID = [1, 1],
+    ; CHECK-SAME:   #firrtl.subAnno<fieldID = 1,
     ; CHECK-SAME:     {class = "firrtl.transforms.DontTouchAnnotation"}>
-    ; CHECK-SAME:   #firrtl.subAnno<fieldID = [1, 1],
+    ; CHECK-SAME:   #firrtl.subAnno<fieldID = 1,
     ; CHECK-SAME:     {class = "sifive.enterprise.grandcentral.DeletedDataTapKey",
     ; CHECK-SAME:      id = [[ID]] : i64}>
     ; CHECK-SAME: %_8: !firrtl.uint<1> {firrtl.annotations = [
@@ -573,7 +573,7 @@ circuit GCTDataTap : %[
     ; CHECK-SAME:   {class = "sifive.enterprise.grandcentral.LiteralDataTapKey",
     ; CHECK-SAME:    literal = "UInt<16>(\22h2a\22)"}
     ; CHECK-SAME: %_9: !firrtl.vector<uint<1>, 1> {firrtl.annotations =
-    ; CHECK-SAME:   #firrtl.subAnno<fieldID = [1, 1],
+    ; CHECK-SAME:   #firrtl.subAnno<fieldID = 1,
     ; CHECK-SAME:     {class = "firrtl.transforms.DontTouchAnnotation"}>
     ; CHECK-SAME:     {class = "sifive.enterprise.grandcentral.LiteralDataTapKey",
     ; CHECK-SAME:      literal = "UInt<16>(\22h2a\22)"}
@@ -604,14 +604,14 @@ circuit GCTDataTap : %[
 
     ; CHECK: firrtl.wire
     ; CHECK-SAME: annotations =
-    ; CHECK-SAME:   #firrtl.subAnno<fieldID = [1, 1],
+    ; CHECK-SAME:   #firrtl.subAnno<fieldID = 1,
     ; CHECK-SAME:     {class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
     ; CHECK-SAME:      id = [[ID]] : i64,
     ; CHECK-SAME:      portID = [[PORT_ID_2]] : i64,
     ; CHECK-SAME:      type = "source"}>
-    ; CHECK-SAME:   #firrtl.subAnno<fieldID = [1, 1],
+    ; CHECK-SAME:   #firrtl.subAnno<fieldID = 1,
     ; CHECK-SAME:     {class = "firrtl.transforms.DontTouchAnnotation"}>
-    ; CHECK-SAME:   #firrtl.subAnno<fieldID = [1, 1],
+    ; CHECK-SAME:   #firrtl.subAnno<fieldID = 1,
     ; CHECK-SAME:     {class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
     ; CHECK-SAME:      id = [[ID]] : i64,
     ; CHECK-SAME:      portID = [[PORT_ID_3]] : i64,
@@ -654,10 +654,10 @@ circuit GCTMemTap : %[
     ; CHECK-SAME: annotations = [{unrelatedAnnotation}]
     ; CHECK: firrtl.extmodule @MemTap
     ; CHECK-SAME: %mem: [[A:.+]] {firrtl.annotations =
-    ; CHECK-SAME:   #firrtl.subAnno<fieldID = [1, 1],
+    ; CHECK-SAME:   #firrtl.subAnno<fieldID = 1,
     ; CHECK-SAME:     {class = "sifive.enterprise.grandcentral.MemTapAnnotation",
     ; CHECK-SAME:      id = [[ID:[0-9]+]] : i64}>
-    ; CHECK-SAME:   #firrtl.subAnno<fieldID = [2, 2],
+    ; CHECK-SAME:   #firrtl.subAnno<fieldID = 2,
     ; CHECK-SAME:     {class = "sifive.enterprise.grandcentral.MemTapAnnotation",
     ; CHECK-SAME:      id = [[ID]] : i64}>
     ; CHECK: firrtl.module @GCTMemTap
@@ -735,7 +735,7 @@ circuit GCTInterface : %[
     ; "r" should be annotated.
     ; CHECK: firrtl.module @GCTInterface
     ; CHECK-SAME: %a: [[TYPE:.+]] {firrtl.annotations = [
-    ; CHECK-SAME:   #firrtl.subAnno<fieldID = [0, 0], {
+    ; CHECK-SAME:   #firrtl.subAnno<fieldID = 0, {
     ; CHECK-SAME:     class = "sifive.enterprise.grandcentral.AugmentedGroundType",
     ; CHECK-SAME:     defName = "ViewName",
     ; CHECK-SAME:     name = "port"}>]}
@@ -745,19 +745,19 @@ circuit GCTInterface : %[
     ; CHECK-SAME:    type = "parent"}]
     ; CHECK: firrtl.reg
     ; CHECK-SAME: annotations
-    ; CHECK-SAME: #firrtl.subAnno<fieldID = [5, 5],
+    ; CHECK-SAME: #firrtl.subAnno<fieldID = 5,
     ; CHECK-SAME:   {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
     ; CHECK-SAME:    defName = "register",
     ; CHECK-SAME:    name = "_2"}>
-    ; CHECK-SAME: #firrtl.subAnno<fieldID = [6, 6],
+    ; CHECK-SAME: #firrtl.subAnno<fieldID = 6,
     ; CHECK-SAME:   {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
     ; CHECK-SAME:    defName = "register",
     ; CHECK-SAME:    name = "_2"}>
-    ; CHECK-SAME: #firrtl.subAnno<fieldID = [3, 3],
+    ; CHECK-SAME: #firrtl.subAnno<fieldID = 3,
     ; CHECK-SAME:    {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
     ; CHECK-SAME:     defName = "_0",
     ; CHECK-SAME:     name = "_1"}>
-    ; CHECK-SAME: #firrtl.subAnno<fieldID = [2, 2],
+    ; CHECK-SAME: #firrtl.subAnno<fieldID = 2,
     ; CHECK-SAME:    {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
     ; CHECK-SAME:     defName = "_0",
     ; CHECK-SAME:     name = "_0"}>

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -554,7 +554,7 @@ firrtl.circuit "TopLevel" {
 // Test that subfield annotations on wire are lowred to appropriate instance based on fieldID.
   // CHECK-LABEL: firrtl.module @AnnotationsBundle
   firrtl.module @AnnotationsBundle() {
-    %bar = firrtl.wire  {annotations = [#firrtl.subAnno<fieldID = [3, 3], {one}>, #firrtl.subAnno<fieldID = [5, 5], {two}>]} : !firrtl.vector<bundle<baz: uint<1>, qux: uint<1>>, 2>
+    %bar = firrtl.wire  {annotations = [#firrtl.subAnno<fieldID = 3, {one}>, #firrtl.subAnno<fieldID = 5, {two}>]} : !firrtl.vector<bundle<baz: uint<1>, qux: uint<1>>, 2>
 
       // TODO: Enable this
       // CHECK: %bar_0_baz = firrtl.wire  : !firrtl.uint<1>
@@ -566,7 +566,7 @@ firrtl.circuit "TopLevel" {
 // Test that subfield annotations on reg are lowred to appropriate instance based on fieldID.
  // CHECK-LABEL: firrtl.module @AnnotationsBundle2
   firrtl.module @AnnotationsBundle2(in %clock: !firrtl.clock) {
-    %bar = firrtl.reg %clock  {annotations = [#firrtl.subAnno<fieldID = [3, 3], {one}>, #firrtl.subAnno<fieldID = [5, 5], {two}>]} : (!firrtl.clock) -> !firrtl.vector<bundle<baz: uint<1>, qux: uint<1>>, 2>
+    %bar = firrtl.reg %clock  {annotations = [#firrtl.subAnno<fieldID = 3, {one}>, #firrtl.subAnno<fieldID = 5, {two}>]} : (!firrtl.clock) -> !firrtl.vector<bundle<baz: uint<1>, qux: uint<1>>, 2>
 
     // TODO: Enable this
     // CHECK: %bar_0_baz = firrtl.reg %clock  : (!firrtl.clock) -> !firrtl.uint<1>
@@ -580,7 +580,7 @@ firrtl.circuit "TopLevel" {
 
  // CHECK-LABEL: firrtl.module @AnnotationsBundle3
   firrtl.module @AnnotationsBundle3(in %clock: !firrtl.clock) {
-    %bar = firrtl.reg %clock  {annotations = [#firrtl.subAnno<fieldID = [6, 6], {one}>, #firrtl.subAnno<fieldID = [12, 14], {two}>, #firrtl.subAnno<fieldID = [8, 10], {three}>]} : (!firrtl.clock) -> !firrtl.vector<bundle<baz: vector<uint<1>, 2>, qux: vector<uint<1>, 2>, yes: bundle<a: uint<1>, b: uint<1>>>, 2>
+    %bar = firrtl.reg %clock  {annotations = [#firrtl.subAnno<fieldID = 6, {one}>, #firrtl.subAnno<fieldID = 12, {two}>, #firrtl.subAnno<fieldID = 8, {three}>]} : (!firrtl.clock) -> !firrtl.vector<bundle<baz: vector<uint<1>, 2>, qux: vector<uint<1>, 2>, yes: bundle<a: uint<1>, b: uint<1>>>, 2>
 
     // TODO: Enable this
     // CHECK: %bar_0_baz_0 = firrtl.reg %clock  : (!firrtl.clock) -> !firrtl.uint<1>
@@ -825,7 +825,7 @@ firrtl.circuit "TopLevel" {
 // matching fieldIDs.  Any other arg attributes should be copied.
     // The annotation should be copied to just a.a.  The firrtl.hello arg
     // attribute should be copied to each new port.
-    firrtl.module @PortBundle(in %a: !firrtl.bundle<a: uint<1>, b flip: uint<1>> {firrtl.annotations = [#firrtl.subAnno<fieldID = [1, 1], {a}>], firrtl.hello}) {}
+    firrtl.module @PortBundle(in %a: !firrtl.bundle<a: uint<1>, b flip: uint<1>> {firrtl.annotations = [#firrtl.subAnno<fieldID = 1, {a}>], firrtl.hello}) {}
     // CHECK-LABEL: firrtl.module @PortBundle
     // CHECK-COUNT-1: firrtl.annotations = [{a}]
     // CHECK-COUNT-2: firrtl.hello
@@ -834,7 +834,7 @@ firrtl.circuit "TopLevel" {
 
     // The annotation should be copied to just a[0].  The firrtl.world arg
     // attribute should be copied to each port.
-    firrtl.extmodule @PortVector(in %a: !firrtl.vector<uint<1>, 2> {firrtl.annotations = [#firrtl.subAnno<fieldID = [1, 1], {b}>], firrtl.world})
+    firrtl.extmodule @PortVector(in %a: !firrtl.vector<uint<1>, 2> {firrtl.annotations = [#firrtl.subAnno<fieldID = 1, {b}>], firrtl.world})
     // CHECK-LABEL: firrtl.extmodule @PortVector
     // CHECK-COUNT-1: firrtl.annotations = [{b}]
     // CHECK-COUNT-2: firrtl.world
@@ -1055,7 +1055,7 @@ firrtl.circuit "TopLevel" {
   // CHECK-LABEL firrtl.module @Foo3
   firrtl.module @Foo3() {
     // CHECK: [{one}], [{two}], []
-    %bar_a, %bar_b = firrtl.instance @Bar3  {name = "bar", portAnnotations = [[{one}], [#firrtl.subAnno<fieldID = [1, 1], {two}>]]} : !firrtl.uint<1>, !firrtl.bundle<baz: uint<1>, qux: uint<1>>
+    %bar_a, %bar_b = firrtl.instance @Bar3  {name = "bar", portAnnotations = [[{one}], [#firrtl.subAnno<fieldID = 1, {two}>]]} : !firrtl.uint<1>, !firrtl.bundle<baz: uint<1>, qux: uint<1>>
   }
 
 
@@ -1069,17 +1069,17 @@ firrtl.circuit "TopLevel" {
   firrtl.module @Foo4() {
     // CHECK: firrtl.mem
     // CHECK-SAME: portAnnotations = [
-    // CHECK-SAME: [{a}, #firrtl.subAnno<fieldID = [4, 4], {b}>],
-    // CHECK-SAME: [#firrtl.subAnno<fieldID = [2, 2], {c}>]
+    // CHECK-SAME: [{a}, #firrtl.subAnno<fieldID = 4, {b}>],
+    // CHECK-SAME: [#firrtl.subAnno<fieldID = 2, {c}>]
 
     // CHECK: firrtl.mem
     // CHECK-SAME: portAnnotations = [
     // CHECK-SAME: [{a}],
-    // CHECK-SAME: [#firrtl.subAnno<fieldID = [2, 2], {c}>, #firrtl.subAnno<fieldID = [4, 4], {d}>]
+    // CHECK-SAME: [#firrtl.subAnno<fieldID = 2, {c}>, #firrtl.subAnno<fieldID = 4, {d}>]
     %bar_r, %bar_w = firrtl.mem Undefined  {depth = 16 : i64, name = "bar",
         portAnnotations = [
-          [{a}, #firrtl.subAnno<fieldID = [5, 5], {b}>],
-          [#firrtl.subAnno<fieldID = [2, 2], {c}>, #firrtl.subAnno<fieldID = [6, 6], {d}>]
+          [{a}, #firrtl.subAnno<fieldID = 5, {b}>],
+          [#firrtl.subAnno<fieldID = 2, {c}>, #firrtl.subAnno<fieldID = 6, {d}>]
         ],
         portNames = ["r", "w"], readLatency = 0 : i32, writeLatency = 1 : i32} :
         !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<baz: uint<8>, qux: uint<8>>>,

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -561,6 +561,12 @@ firrtl.circuit "TopLevel" {
       // CHECK: %bar_0_qux = firrtl.wire  {annotations = [{one}]} : !firrtl.uint<1>
       // CHECK: %bar_1_baz = firrtl.wire  {annotations = [{two}]} : !firrtl.uint<1>
       // CHECK: %bar_1_qux = firrtl.wire  : !firrtl.uint<1>
+
+    %quux = firrtl.wire  {annotations = [#firrtl.subAnno<fieldID = 0, {zero}>]} : !firrtl.vector<bundle<baz: uint<1>, qux: uint<1>>, 2>
+      // CHECK: %quux_0_baz = firrtl.wire  {annotations = [{zero}]} : !firrtl.uint<1>
+      // CHECK: %quux_0_qux = firrtl.wire  {annotations = [{zero}]} : !firrtl.uint<1>
+      // CHECK: %quux_1_baz = firrtl.wire  {annotations = [{zero}]} : !firrtl.uint<1>
+      // CHECK: %quux_1_qux = firrtl.wire  {annotations = [{zero}]} : !firrtl.uint<1>
   }
 
 // Test that subfield annotations on reg are lowred to appropriate instance based on fieldID.
@@ -1061,7 +1067,7 @@ firrtl.circuit "TopLevel" {
 
 // Test MemOp with port annotations.
 // circuit Foo: %[[{"a":null,"target":"~Foo|Foo>bar.r"},
-//                 {"b":null,"target":"~Foo|Foo>bar.r.data.baz"},
+//                 {"b":null,"target":"~Foo|Foo>bar.r.data"},
 //                 {"c":null,"target":"~Foo|Foo>bar.w.en"},
 //                 {"d":null,"target":"~Foo|Foo>bar.w.data.qux"}]]
 
@@ -1074,11 +1080,11 @@ firrtl.circuit "TopLevel" {
 
     // CHECK: firrtl.mem
     // CHECK-SAME: portAnnotations = [
-    // CHECK-SAME: [{a}],
+    // CHECK-SAME: [{a}, #firrtl.subAnno<fieldID = 4, {b}>],
     // CHECK-SAME: [#firrtl.subAnno<fieldID = 2, {c}>, #firrtl.subAnno<fieldID = 4, {d}>]
     %bar_r, %bar_w = firrtl.mem Undefined  {depth = 16 : i64, name = "bar",
         portAnnotations = [
-          [{a}, #firrtl.subAnno<fieldID = 5, {b}>],
+          [{a}, #firrtl.subAnno<fieldID = 4, {b}>],
           [#firrtl.subAnno<fieldID = 2, {c}>, #firrtl.subAnno<fieldID = 6, {d}>]
         ],
         portNames = ["r", "w"], readLatency = 0 : i32, writeLatency = 1 : i32} :

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1069,7 +1069,9 @@ firrtl.circuit "TopLevel" {
 // circuit Foo: %[[{"a":null,"target":"~Foo|Foo>bar.r"},
 //                 {"b":null,"target":"~Foo|Foo>bar.r.data"},
 //                 {"c":null,"target":"~Foo|Foo>bar.w.en"},
-//                 {"d":null,"target":"~Foo|Foo>bar.w.data.qux"}]]
+//                 {"d":null,"target":"~Foo|Foo>bar.w.data.qux"},
+//                 {"e":null,"target":"~Foo|Foo>bar.rw.wmode"}
+//                 {"f":null,"target":"~Foo|Foo>bar.rw.wmask.baz"}]]
 
 // CHECK-LABEL: firrtl.module @Foo4
   firrtl.module @Foo4() {
@@ -1077,19 +1079,23 @@ firrtl.circuit "TopLevel" {
     // CHECK-SAME: portAnnotations = [
     // CHECK-SAME: [{a}, #firrtl.subAnno<fieldID = 4, {b}>],
     // CHECK-SAME: [#firrtl.subAnno<fieldID = 2, {c}>]
+    // CHECK-SAME: [#firrtl.subAnno<fieldID = 4, {e}>, #firrtl.subAnno<fieldID = 7, {f}>]
 
     // CHECK: firrtl.mem
     // CHECK-SAME: portAnnotations = [
     // CHECK-SAME: [{a}, #firrtl.subAnno<fieldID = 4, {b}>],
     // CHECK-SAME: [#firrtl.subAnno<fieldID = 2, {c}>, #firrtl.subAnno<fieldID = 4, {d}>]
-    %bar_r, %bar_w = firrtl.mem Undefined  {depth = 16 : i64, name = "bar",
+    // CHECK-SAME: [#firrtl.subAnno<fieldID = 4, {e}>]
+    %bar_r, %bar_w, %bar_rw = firrtl.mem Undefined  {depth = 16 : i64, name = "bar",
         portAnnotations = [
           [{a}, #firrtl.subAnno<fieldID = 4, {b}>],
-          [#firrtl.subAnno<fieldID = 2, {c}>, #firrtl.subAnno<fieldID = 6, {d}>]
+          [#firrtl.subAnno<fieldID = 2, {c}>, #firrtl.subAnno<fieldID = 6, {d}>],
+          [#firrtl.subAnno<fieldID = 4, {e}>, #firrtl.subAnno<fieldID = 12, {f}>]
         ],
-        portNames = ["r", "w"], readLatency = 0 : i32, writeLatency = 1 : i32} :
+        portNames = ["r", "w", "rw"], readLatency = 0 : i32, writeLatency = 1 : i32} :
         !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<baz: uint<8>, qux: uint<8>>>,
-        !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<baz: uint<8>, qux: uint<8>>, mask: bundle<baz: uint<1>, qux: uint<1>>>
+        !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<baz: uint<8>, qux: uint<8>>, mask: bundle<baz: uint<1>, qux: uint<1>>>,
+        !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, wmode: uint<1>, rdata flip: bundle<baz: uint<8>, qux: uint<8>>, wdata: bundle<baz: uint<8>, qux: uint<8>>, wmask: bundle<baz: uint<1>, qux: uint<1>>>
   }
 
 // Test that partial connects can extend


### PR DESCRIPTION
Previously, `SubAnnoAttr` had a `minFieldID` and a `maxFieldID` to represent the range of `fieldID`s it is targeting. The `maxFieldID` is introduced for the `LowerTypes_v1` to easily tell whether a leaf element is targeted by a `SubAnnoAttr` when filtering annotations without recursively looking into the aggregate type.

However, this `fieldID` range introduced many undefined things like cross-fields annotations (which are not allowed), making `SubAnnoAttr` hard to verify and handle. Meanwhile, as `LowerTypes_v2` doesn't flatten aggregate types at once, but recursively peel off the outermost layer of aggregate types, it no longer needs to answer the question above. Therefore, we decide to make `maxFieldID` retire.

This patch removed `maxFieldID` from `SubAnnoAttr` and renamed `minFieldID` to `fieldID`. Related codes in `FIRParser` and `LowerTypes` are updated as well.

- Fixes #1453.
- Closes #1457.