### PR TITLE
[FIRRTL][IMConstProp] Update lattice for instance op result

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -525,6 +525,8 @@ void IMConstPropPass::visitConnect(ConnectOp connect) {
   // Driving an instance argument port drives the corresponding argument of the
   // referenced module.
   if (auto instance = dest.getDefiningOp<InstanceOp>()) {
+    // Update the dest, when its an instance op.
+    mergeLatticeValue(connect.dest(), srcValue);
     auto module =
         dyn_cast<FModuleOp>(instanceGraph->getReferencedModule(instance));
     if (!module)

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -285,7 +285,7 @@ firrtl.circuit "InstanceOut2"   {
   firrtl.module @Ext(in %a: !firrtl.uint<1>) {
   }
   
-  // CHECK-LABEL: firrtl.module @InstanceOut
+  // CHECK-LABEL: firrtl.module @InstanceOut2
   firrtl.module @InstanceOut2(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
     %ext_a = firrtl.instance @Ext  {name = "ext"} : !firrtl.uint<1>
     firrtl.connect %ext_a, %a : !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -267,3 +267,32 @@ firrtl.circuit "InputPortTop"   {
     firrtl.connect %c2_in1, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
+firrtl.circuit "InstanceOut"   {
+  firrtl.extmodule @Ext(in %a: !firrtl.uint<1>)
+  
+  // CHECK-LABEL: firrtl.module @InstanceOut
+  firrtl.module @InstanceOut(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
+    %ext_a = firrtl.instance @Ext  {name = "ext"} : !firrtl.uint<1>
+    firrtl.connect %ext_a, %a : !firrtl.uint<1>, !firrtl.uint<1>
+    %w = firrtl.wire  : !firrtl.uint<1>
+    // CHECK: firrtl.connect %w, %ext_a : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %w, %ext_a : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK: firrtl.connect %b, %w : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %b, %w : !firrtl.uint<1>, !firrtl.uint<1>
+  }  
+}
+firrtl.circuit "InstanceOut2"   {
+  firrtl.module @Ext(in %a: !firrtl.uint<1>) {
+  }
+  
+  // CHECK-LABEL: firrtl.module @InstanceOut
+  firrtl.module @InstanceOut2(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
+    %ext_a = firrtl.instance @Ext  {name = "ext"} : !firrtl.uint<1>
+    firrtl.connect %ext_a, %a : !firrtl.uint<1>, !firrtl.uint<1>
+    %w = firrtl.wire  : !firrtl.uint<1>
+    // CHECK: firrtl.connect %w, %ext_a : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %w, %ext_a : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK: firrtl.connect %b, %w : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %b, %w : !firrtl.uint<1>, !firrtl.uint<1>
+  }  
+}


### PR DESCRIPTION
`IMConstProp` was ignoring updating the lattice value for result of 'instance' op. 
It was only propagating the value into the module. This caused the result of `instance` op staying invalid.
Fixes https://github.com/llvm/circt/issues/1466