### PR TITLE
[FIRRTL][IMConstProp] Proper initialization

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -367,9 +367,6 @@ void IMConstPropPass::markBlockExecutable(Block *block) {
     return; // Already executable.
 
   for (auto &op : *block) {
-    // Filter out primitives etc quickly.
-    if (op.getNumOperands() != 0 || isa<RegResetOp>(&op))
-      continue;
 
     // Handle each of the special operations in the firrtl dialect.
     if (isa<WireOp>(op) || isa<RegOp>(op))
@@ -386,10 +383,6 @@ void IMConstPropPass::markBlockExecutable(Block *block) {
       markRegResetOp(regReset);
     else if (auto mem = dyn_cast<MemOp>(op))
       markMemOp(mem);
-    else {
-      for (auto result : op.getResults())
-        markOverdefined(result);
-    }
   }
 }
 

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -296,3 +296,25 @@ firrtl.circuit "InstanceOut2"   {
     firrtl.connect %b, %w : !firrtl.uint<1>, !firrtl.uint<1>
   }  
 }
+firrtl.circuit "invalidReg1"   {
+  // CHECK_LABEL: @invalidReg1
+  firrtl.module @invalidReg1(in %clock: !firrtl.clock, out %a: !firrtl.uint<1>) {
+    %foobar = firrtl.reg %clock  : (!firrtl.clock) -> !firrtl.uint<1>
+      //CHECK: %0 = firrtl.not %foobar : (!firrtl.uint<1>) -> !firrtl.uint<1>
+      %0 = firrtl.not %foobar : (!firrtl.uint<1>) -> !firrtl.uint<1>
+      //CHECK: firrtl.connect %foobar, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+      firrtl.connect %foobar, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+      //CHECK: firrtl.connect %a, %foobar : !firrtl.uint<1>, !firrtl.uint<1>
+      firrtl.connect %a, %foobar : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+}
+firrtl.circuit "invalidReg2"   {
+  // CHECK_LABEL: @invalidReg2
+  firrtl.module @invalidReg2(in %clock: !firrtl.clock, out %a: !firrtl.uint<1>) {
+    %foobar = firrtl.reg %clock  : (!firrtl.clock) -> !firrtl.uint<1>
+    firrtl.connect %foobar, %foobar : !firrtl.uint<1>, !firrtl.uint<1>
+    //CHECK: %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
+    //CHECK: firrtl.connect %a, %invalid_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %a, %foobar : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+}


### PR DESCRIPTION
The initialization code in `IMConstProp` had an early exit, which seems to be initializing incorrectly to `unknown`. 
Remove the early exit and properly initialize all operations. 
Fix for https://github.com/llvm/circt/issues/1465