### PR TITLE
[SV]Add mlir namespace for older gcc, NFC

### DIFF
--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -41,7 +41,7 @@ static void getBackwardSliceSimple(Operation *rootOp,
     Operation *op = worklist.back();
     worklist.pop_back();
 
-    if (!op || op->hasTrait<OpTrait::IsIsolatedFromAbove>())
+    if (!op || op->hasTrait<mlir::OpTrait::IsIsolatedFromAbove>())
       continue;
 
     // Evaluate whether we should keep this def.


### PR DESCRIPTION
`gcc 7.5.0` cannot compile CIRCT, it requires the `mlir` namepsace on `mlir::OpTrait::IsIsolatedFromAbove`.
Fix for https://github.com/llvm/circt/issues/1445