### PR TITLE
Update LLVM to 345ace026b6e5cdbc38d207291e4b399d72e62ee.

### DIFF
--- a/lib/Bindings/Python/CMakeLists.txt
+++ b/lib/Bindings/Python/CMakeLists.txt
@@ -4,6 +4,8 @@
 
 include(AddMLIRPython)
 add_custom_target(CIRCTBindingsPython)
+add_dependencies(CIRCTBindingsPython MLIRBindingsPythonExtension)
+add_dependencies(CIRCTBindingsPython MLIRBindingsPythonSources)
 
 ################################################################################
 # Build native Python extension
@@ -25,6 +27,7 @@ add_mlir_python_extension(CIRCTBindingsPythonExtension _circt
     CIRCTCAPISeq
     CIRCTCAPISV
     CIRCTCAPIExportVerilog
+    MLIRPythonCAPI
 )
 add_dependencies(CIRCTBindingsPython CIRCTBindingsPythonExtension)
 

--- a/lib/Bindings/Python/CMakeLists.txt
+++ b/lib/Bindings/Python/CMakeLists.txt
@@ -4,6 +4,10 @@
 
 include(AddMLIRPython)
 add_custom_target(CIRCTBindingsPython)
+
+include_directories(
+  "${MLIR_SOURCE_DIR}/lib/Bindings/Python"
+  "${MLIR_SOURCE_DIR}/python")
 add_dependencies(CIRCTBindingsPython MLIRBindingsPythonExtension)
 add_dependencies(CIRCTBindingsPython MLIRBindingsPythonSources)
 

--- a/lib/Bindings/Python/CMakeLists.txt
+++ b/lib/Bindings/Python/CMakeLists.txt
@@ -5,12 +5,6 @@
 include(AddMLIRPython)
 add_custom_target(CIRCTBindingsPython)
 
-include_directories(
-  "${MLIR_SOURCE_DIR}/lib/Bindings/Python"
-  "${MLIR_SOURCE_DIR}/python")
-add_dependencies(CIRCTBindingsPython MLIRBindingsPythonExtension)
-add_dependencies(CIRCTBindingsPython MLIRBindingsPythonSources)
-
 ################################################################################
 # Build native Python extension
 ################################################################################

--- a/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
+++ b/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
@@ -22,6 +22,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/BlockAndValueMapping.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -2772,7 +2773,7 @@ void LLHDToLLVMLoweringPass::runOnOperation() {
 
   LLVMConversionTarget target(getContext());
   target.addIllegalOp<InstOp>();
-  target.addLegalOp<LLVM::DialectCastOp>();
+  target.addLegalOp<UnrealizedConversionCastOp>();
 
   // Apply the partial conversion.
   if (failed(
@@ -2787,7 +2788,7 @@ void LLHDToLLVMLoweringPass::runOnOperation() {
 
   target.addLegalDialect<LLVM::LLVMDialect>();
   target.addLegalOp<ModuleOp>();
-  target.addIllegalOp<LLVM::DialectCastOp>();
+  target.addIllegalOp<UnrealizedConversionCastOp>();
 
   // Apply the full conversion.
   if (failed(applyFullConversion(getOperation(), target, std::move(patterns))))


### PR DESCRIPTION
This picks up the start of some reworking happening upstream for
Python bindings, as well as another minor change in LLVM conversion.