### PR TITLE
[LowerToHW] Add whitelist for remaining annotation warnings

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -268,10 +268,29 @@ void CircuitLoweringState::warnOnRemainingAnnotations(
 
   for (auto a : annoSet) {
     auto inserted = alreadyPrinted.insert(a.getClass());
-    if (inserted.second)
-      mlir::emitWarning(op->getLoc(), "unprocessed annotation:'" +
-                                          a.getClass() +
-                                          "' still remaining after LowerToHW");
+    if (!inserted.second)
+      continue;
+
+    // The following annotations are okay to be silently dropped at this point.
+    // This can occur for example if an annotation marks something in the IR as
+    // not to be processed by a pass, but that pass hasn't run anyway.
+    if (a.isClass(
+            // The following are either consumed by a pass running before
+            // LowerToHW, or they have no effect if the pass doesn't run at all.
+            // If the accompanying pass runs on the HW dialect, then LowerToHW
+            // should have consumed and processed these into an attribute on the
+            // output.
+            "sifive.enterprise.firrtl.DontObfuscateModuleAnnotation",
+            "firrtl.transforms.NoDedupAnnotation",
+            // The following are inspected (but not consumed) by FIRRTL/GCT
+            // passes that have all run by now. Since no one is responsible for
+            // consuming these, they will linger around and can be ignored.
+            "sifive.enterprise.firrtl.ScalaClassAnnotation",
+            "sifive.enterprise.firrtl.MarkDUTAnnotation"))
+      continue;
+
+    mlir::emitWarning(op->getLoc(), "unprocessed annotation:'" + a.getClass() +
+                                        "' still remaining after LowerToHW");
   }
 }
 } // end anonymous namespace

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
@@ -65,3 +65,16 @@ firrtl.circuit "moduleAnno" attributes {annotations = [{class = "circuitOpAnnota
     attributes { annotations = [{class = "b"}] } {}
   firrtl.extmodule @extModPorts2(in %io_cpu_flush: !firrtl.uint<1> {firrtl.annotations = [{class="c"}]} )
 }
+
+// -----
+
+// The following annotations should be whitelisted and not trigger a warning
+// when lowering to HW.
+firrtl.circuit "Foo" {
+    firrtl.module @Foo() attributes {annotations = [
+        {class = "firrtl.transforms.NoDedupAnnotation"},
+        {class = "sifive.enterprise.firrtl.DontObfuscateModuleAnnotation"},
+        {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"},
+        {class = "sifive.enterprise.firrtl.ScalaClassAnnotation"}
+    ]} {}
+}


### PR DESCRIPTION
Certain annotations are expected to remain in the IR until LowerToHW runs. For example, annotations that prevent a pass from running on an operation have no effect if the pass doesn't run at all. But in that case, the pass also hasn't consume the annotations. This includes things like don't-obfuscate and don't-dedup.

This PR adds a whitelist to `warnOnRemainingAnnotations` in the`LowerToHW` pass to allow a select set of annotations to be silently dropped.

This currently whitelists the following:

- `sifive.enterprise.firrtl.DontObfuscateModuleAnnotation`
- `firrtl.transforms.NoDedupAnnotation`
- `sifive.enterprise.firrtl.ScalaClassAnnotation`
- `sifive.enterprise.firrtl.MarkDUTAnnotation`