### PR TITLE
[FIRRTL][FIRRTLToHW] Add an allowList to ignore unprocessed annotations

### DIFF
--- a/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
@@ -30,6 +30,7 @@ firrtl.circuit "unprocessedAnnotations" {
                             in %cond: !firrtl.uint<1>, in %value: !firrtl.uint<2>) {
     // expected-warning @+1 {{unprocessed annotation:'firrtl.transforms.RemainingAnnotation1'}}
     %1 = firrtl.wire {annotations = [{class = "firrtl.transforms.RemainingAnnotation1"}]} : !firrtl.uint<1>
+    %11 = firrtl.wire {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<1>
     // expected-warning @+1 {{unprocessed annotation:'firrtl.transforms.RemainingAnnotation2'}}
     %2 = firrtl.node %1 {annotations = [{class = "firrtl.transforms.RemainingAnnotation2"}]} : !firrtl.uint<1>
     // expected-warning @+1 {{unprocessed annotation:'firrtl.transforms.RemainingAnnotation3'}}


### PR DESCRIPTION
`LowerToHW` emits warnings on unprocessed annotations. Some annotations will be processed during the `LowerToHW` like `DontTouch` and `sifive.enterprise.firrtl.ExtractAssertionsAnnotation`. 
And some other annotations like `DontTouch` on `module` can be ignored currently. 
This PR adds a set of annotations that can be ignored if they are unprocessed at `LowerToHW`. We will continue to add more annotations to this set.