### PR TITLE
[Comb] Narrow Arithmetic and Bitwise Ops - Take 2

### DIFF
--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -11,6 +11,7 @@
 #include "mlir/Dialect/CommonFolders.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 using namespace mlir;
 using namespace circt;
@@ -71,6 +72,114 @@ static bool tryFlatteningOperands(Op op, PatternRewriter &rewriter) {
     return true;
   }
   return false;
+}
+
+// Given a range of uses of an operation, find the lowest and highest bits
+// inclusive that are ever referenced. The range of uses must not be empty.
+static std::pair<size_t, size_t>
+getLowestBitAndHighestBitRequired(Operation::use_range uses,
+                                  bool narrowTrailingBits,
+                                  size_t originalOpWidth) {
+  assert(!uses.empty() && "getLowestBitAndHighestBitRequired cannot operate on "
+                          "a empty list of uses.");
+
+  // when we don't want to narrowTrailingBits (namely in arithmetic
+  // operations), forcing lowestBitRequired = 0
+  size_t lowestBitRequired = narrowTrailingBits ? originalOpWidth - 1 : 0;
+  size_t highestBitRequired = 0;
+
+  for (auto &use : uses) {
+    if (auto extractOp = dyn_cast<ExtractOp>(use.getOwner())) {
+      size_t lowBit = extractOp.lowBit();
+      size_t highBit = extractOp.getType().getWidth() + lowBit - 1;
+      highestBitRequired = std::max(highestBitRequired, highBit);
+      lowestBitRequired = std::min(lowestBitRequired, lowBit);
+      continue;
+    }
+
+    highestBitRequired = originalOpWidth - 1;
+    lowestBitRequired = 0;
+    break;
+  }
+
+  return {lowestBitRequired, highestBitRequired};
+}
+
+// narrowOperationWidth(...) attempts to create a new instance of Op
+// with createOp using narrowed operands. Ie: transforming f(x, y) into
+// f(x[n:m], y[n:m]), It analyzes all usage sites of narrowingCandidate and
+// mutate them to the newly created narrowed version if it's benefitial.
+//
+// narrowTrailingBits determines whether undemanded trailing bits should
+// be aggressively stripped off.
+//
+// This function requires the narrowingCandidate to have at least 1 use.
+//
+// Returns true if IR is mutated. IR is mutated iff narrowing happens.
+template <class Op, class F>
+static bool narrowOperationWidth(Op narrowingCandidate, ValueRange inputs,
+                                 bool narrowTrailingBits,
+                                 PatternRewriter &rewriter, F createOp) {
+  // If the result is never used, no point optimizing this. It will
+  // also complicated error handling in getLowestBitAndHigestBitRequired.
+  Operation::use_range uses = narrowingCandidate.getOperation()->getUses();
+  assert(!uses.empty() && "narrowingCandidate must have at least one use.");
+
+  size_t highestBitRequired;
+  size_t lowestBitRequired;
+  size_t originalOpWidth = narrowingCandidate.getType().getIntOrFloatBitWidth();
+
+  std::tie(lowestBitRequired, highestBitRequired) =
+      getLowestBitAndHighestBitRequired(uses, narrowTrailingBits,
+                                        originalOpWidth);
+
+  // Give up, because we can't make it narrower than it already is.
+  if (lowestBitRequired == 0 && highestBitRequired == originalOpWidth - 1)
+    return false;
+
+  auto loc = narrowingCandidate.getLoc();
+  size_t narrowedWidth = highestBitRequired - lowestBitRequired + 1;
+  auto narrowedType = rewriter.getIntegerType(narrowedWidth);
+  Value narrowedOperation =
+      createOp(SmallVector<Value>(llvm::map_range(inputs, [&](auto input) {
+        return rewriter.create<ExtractOp>(loc, narrowedType, input,
+                                          lowestBitRequired);
+      })));
+
+  // Replace all the use-site's extract operation with the newly minted narrowed
+  // version.
+  for (auto &use : uses) {
+    auto extractUse = cast<ExtractOp>(use.getOwner());
+    auto oldLowBit = extractUse.lowBit();
+
+    assert(oldLowBit >= lowestBitRequired &&
+           "incorrectly deduced the lowest bit required in usage arguments.");
+
+    if (narrowedWidth == extractUse.getType().getWidth()) {
+      rewriter.replaceOp(extractUse, narrowedOperation);
+    } else {
+      uint32_t newLowBit = oldLowBit - lowestBitRequired;
+      rewriter.replaceOpWithNewOp<ExtractOp>(extractUse, extractUse.getType(),
+                                             narrowedOperation, newLowBit);
+    }
+  }
+
+  // It is not necessary to call rewriter.replaceOp(narrowingCandidate,
+  // narrowedOperation) here, since all the use-site now refers to
+  // `narrowedOperation` instead. narrowingCandidate will be eliminated by DCE.
+
+  return true;
+}
+
+template <class Op>
+static bool narrowOperationWidth(Op op, ValueRange inputs,
+                                 bool narrowTrailingBits,
+                                 PatternRewriter &rewriter) {
+  auto createOp = [&](ArrayRef<Value> args) -> Op {
+    return rewriter.create<Op>(op.getLoc(), args);
+  };
+  return narrowOperationWidth(op, inputs, narrowTrailingBits, rewriter,
+                              createOp);
 }
 
 //===----------------------------------------------------------------------===//
@@ -219,20 +328,68 @@ static LogicalResult extractConcatToConcatExtract(ExtractOp op,
   return success();
 }
 
-LogicalResult ExtractOp::canonicalize(ExtractOp op, PatternRewriter &rewriter) {
-  // Narrow Mux
-  // extract(mux(c,a,b)) -> mux(c,extract(a),extract(b))
-  if (auto mux = dyn_cast_or_null<MuxOp>(op.input().getDefiningOp())) {
-    if (mux->hasOneUse()) {
-      auto newT = rewriter.createOrFold<ExtractOp>(
-          mux.getLoc(), op.getType(), mux.trueValue(), op.lowBit());
-      auto newF = rewriter.createOrFold<ExtractOp>(
-          mux.getLoc(), op.getType(), mux.falseValue(), op.lowBit());
-      rewriter.replaceOpWithNewOp<MuxOp>(op, mux.cond(), newT, newF);
-      return success();
-    }
+// Pattern matches on extract(f(a, b)), and transforms f(extract(a), extract(b))
+// for some known f. This is performed by analyzing all usage sites of the
+// result of f(a, b). When this transformation returns true, it mutates all the
+// usage sites of outerExtractOp to reference the newly created narrowed
+// operation.
+static bool narrowExtractWidth(ExtractOp outerExtractOp,
+                               PatternRewriter rewriter) {
+  auto *innerArg = outerExtractOp.input().getDefiningOp();
+
+  if (!innerArg) {
+    return false;
   }
 
+  // In calls to narrowOperationWidth below, innerOp is guranteed to have at
+  // least one use (ie: this extract operation). So we don't need to handle
+  // innerOp with no uses.
+
+  return llvm::TypeSwitch<Operation *, bool>(innerArg)
+      // The unreferenced leading bits of Add, Sub and Mul can be stripped of,
+      // but not the trailing bits. The trailing bits is used to compute the
+      // results of arithmetic operations.
+      .Case<AddOp, MulOp>([&](auto innerOp) {
+        return narrowOperationWidth(innerOp, innerOp.inputs(),
+                                    /* narrowTrailingBits= */ false, rewriter);
+      })
+      .Case<SubOp>([&](auto innerOp) {
+        return narrowOperationWidth(innerOp, {innerOp.lhs(), innerOp.rhs()},
+                                    /* narrowTrailingBits= */ false, rewriter);
+      })
+      // Bit-wise operations and muxes can be narrowed more aggressively.
+      // Trailing bits that are not referenced in the use-sits can all be
+      // removed.
+      .Case<AndOp, OrOp, XorOp>([&](auto innerOp) {
+        return narrowOperationWidth(innerOp, innerOp.inputs(),
+                                    /* narrowTrailingBits= */ true, rewriter);
+      })
+      .Case<MuxOp>([&](auto innerOp) {
+        Type type = innerOp.getType();
+
+        assert(type.isa<IntegerType>() &&
+               "extract() requires input to be of type IntegerType!");
+
+        auto cond = innerOp.cond();
+        auto loc = innerOp.getLoc();
+        auto createMuxOp = [&](ArrayRef<Value> values) -> MuxOp {
+          assert(values.size() == 2 &&
+                 "createMuxOp expects exactly two elements");
+          return rewriter.create<MuxOp>(loc, cond, values[0], values[1]);
+        };
+
+        return narrowOperationWidth(
+            innerOp, {innerOp.trueValue(), innerOp.falseValue()},
+            /* narrowTrailingBits= */ true, rewriter, createMuxOp);
+      })
+
+      // TODO: Cautiously investigate whether this optimization can be performed
+      // on other comb operators (shifts & divs), arrays, memory, or even
+      // sequential operations.
+      .Default([](Operation *op) { return false; });
+}
+
+LogicalResult ExtractOp::canonicalize(ExtractOp op, PatternRewriter &rewriter) {
   // extract(olo, extract(ilo, x)) = extract(olo + ilo, x)
   if (auto innerExtract =
           dyn_cast_or_null<ExtractOp>(op.input().getDefiningOp())) {
@@ -246,6 +403,12 @@ LogicalResult ExtractOp::canonicalize(ExtractOp op, PatternRewriter &rewriter) {
   if (auto innerCat = dyn_cast_or_null<ConcatOp>(op.input().getDefiningOp())) {
     return extractConcatToConcatExtract(op, innerCat, rewriter);
   }
+
+  // extract(f(a, b)) = f(extract(a), extract(b)). This is performed only when
+  // the number of bits to operation f can be reduced. See documentation of
+  // narrowExtractWidth for more information.
+  if (narrowExtractWidth(op, rewriter))
+    return success();
 
   return failure();
 }

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -118,9 +118,8 @@ getLowestBitAndHighestBitRequired(Operation *op, bool narrowTrailingBits,
 //
 // Returns true if IR is mutated. IR is mutated iff narrowing happens.
 static bool
-narrowOperationWidth(ExtractOp outerExtractOp, Operation *narrowingCandidate,
-                     ValueRange inputs, bool narrowTrailingBits,
-                     PatternRewriter &rewriter,
+narrowOperationWidth(Operation *narrowingCandidate, ValueRange inputs,
+                     bool narrowTrailingBits, PatternRewriter &rewriter,
                      function_ref<Value(ArrayRef<Value>)> createOp) {
   // If the result is never used, no point optimizing this. It will
   // also complicated error handling in getLowestBitAndHigestBitRequired.
@@ -128,9 +127,6 @@ narrowOperationWidth(ExtractOp outerExtractOp, Operation *narrowingCandidate,
          "narrowingCandidate must have at least one use.");
   assert(narrowingCandidate->getNumResults() == 1 &&
          "narrowingCandidate must have exactly one result");
-  assert(outerExtractOp &&
-         "narrowOperationWidth must be called from canonicalizing an "
-         "outerExtractOp, which serves as the root op.");
   IntegerType narrowingCandidateType =
       narrowingCandidate->getResultTypes().front().cast<IntegerType>();
 
@@ -173,40 +169,27 @@ narrowOperationWidth(ExtractOp outerExtractOp, Operation *narrowingCandidate,
     return narrowedExtract;
   };
 
-  // Pattern rewriter requires that that the root operation (ie: outerExtractOp)
-  // in question to be updated in place, replaced or erased, so this is
-  // necessary.
-  rewriter.replaceOp(outerExtractOp,
-                     getNarrowedExtractReplacement(outerExtractOp));
-
-  // However, for other use sites, calling rewriter.replaceOp or
-  // replaceOpWithNewOp is potentially memory unsafe, as it requires the
-  // rewriting driver to ensure that dangling references in any internal data
-  // structures are properly cleared out.
-  //
-  // Calling narrowingCandidate->getUsers will not include outerExtractOp, since
-  // rewriter.replaceOp will have removed it from the iterator.
+  // Replaces all existing use sites with the newly created narrowed operation.
+  // This loop captures both the root and non-root use sites.  Note that
+  // PatternRewriter allows calling rewriter.replaceOp on non-root users.
   for (Operation *user :
        llvm::make_early_inc_range(narrowingCandidate->getUsers())) {
     auto extractUser = cast<ExtractOp>(user);
-    rewriter.updateRootInPlace(extractUser, [&]() {
-      extractUser.replaceAllUsesWith(
-          getNarrowedExtractReplacement(extractUser));
-    });
+    rewriter.replaceOp(extractUser, getNarrowedExtractReplacement(extractUser));
   }
 
   return true;
 }
 
 template <class Op>
-static bool narrowOperationWidth(ExtractOp outerExtractOp, Op op,
-                                 ValueRange inputs, bool narrowTrailingBits,
+static bool narrowOperationWidth(Op op, ValueRange inputs,
+                                 bool narrowTrailingBits,
                                  PatternRewriter &rewriter) {
   auto createOp = [&](ArrayRef<Value> args) -> Value {
     return rewriter.create<Op>(op.getLoc(), args);
   };
-  return narrowOperationWidth(outerExtractOp, op, inputs, narrowTrailingBits,
-                              rewriter, createOp);
+  return narrowOperationWidth(op, inputs, narrowTrailingBits, rewriter,
+                              createOp);
 }
 
 //===----------------------------------------------------------------------===//
@@ -361,7 +344,7 @@ static LogicalResult extractConcatToConcatExtract(ExtractOp op,
 // usage sites of outerExtractOp to reference the newly created narrowed
 // operation.
 static bool narrowExtractWidth(ExtractOp outerExtractOp,
-                               PatternRewriter rewriter) {
+                               PatternRewriter &rewriter) {
   auto *innerArg = outerExtractOp.input().getDefiningOp();
 
   if (!innerArg) {
@@ -377,19 +360,18 @@ static bool narrowExtractWidth(ExtractOp outerExtractOp,
       // but not the trailing bits. The trailing bits is used to compute the
       // results of arithmetic operations.
       .Case<AddOp, MulOp>([&](auto innerOp) {
-        return narrowOperationWidth(outerExtractOp, innerOp, innerOp.inputs(),
+        return narrowOperationWidth(innerOp, innerOp.inputs(),
                                     /* narrowTrailingBits= */ false, rewriter);
       })
       .Case<SubOp>([&](SubOp innerOp) {
-        return narrowOperationWidth(outerExtractOp, innerOp,
-                                    {innerOp.lhs(), innerOp.rhs()},
+        return narrowOperationWidth(innerOp, {innerOp.lhs(), innerOp.rhs()},
                                     /* narrowTrailingBits= */ false, rewriter);
       })
       // Bit-wise operations and muxes can be narrowed more aggressively.
       // Trailing bits that are not referenced in the use-sits can all be
       // removed.
       .Case<AndOp, OrOp, XorOp>([&](auto innerOp) {
-        return narrowOperationWidth(outerExtractOp, innerOp, innerOp.inputs(),
+        return narrowOperationWidth(innerOp, innerOp.inputs(),
                                     /* narrowTrailingBits= */ true, rewriter);
       })
       .Case<MuxOp>([&](MuxOp innerOp) {
@@ -406,10 +388,9 @@ static bool narrowExtractWidth(ExtractOp outerExtractOp,
           return rewriter.create<MuxOp>(loc, cond, values[0], values[1]);
         };
 
-        return narrowOperationWidth(outerExtractOp, innerOp,
-                                    {innerOp.trueValue(), innerOp.falseValue()},
-                                    /* narrowTrailingBits= */ true, rewriter,
-                                    createMuxOp);
+        return narrowOperationWidth(
+            innerOp, {innerOp.trueValue(), innerOp.falseValue()},
+            /* narrowTrailingBits= */ true, rewriter, createMuxOp);
       })
 
       // TODO: Cautiously investigate whether this optimization can be performed

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -80,8 +80,9 @@ static std::pair<size_t, size_t>
 getLowestBitAndHighestBitRequired(Operation *op, bool narrowTrailingBits,
                                   size_t originalOpWidth) {
   auto users = op->getUsers();
-  assert(!users.empty() && "getLowestBitAndHighestBitRequired cannot operate on "
-                           "a empty list of uses.");
+  assert(!users.empty() &&
+         "getLowestBitAndHighestBitRequired cannot operate on "
+         "a empty list of uses.");
 
   // when we don't want to narrowTrailingBits (namely in arithmetic
   // operations), forcing lowestBitRequired = 0

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -302,3 +302,165 @@ hw.module @extractCatOnMultiplePartialElements(%arg0: i8, %arg1: i9, %arg2: i10)
   // CHECK-NEXT: hw.output [[RESULT1:%.+]], [[RESULT2:%.+]]
   hw.output %1, %2 : i11, i5
 }
+
+// Validates that addition narrows the operand widths to the width of the
+// single extract usage.
+// CHECK-LABEL: hw.module @narrowAdditionSingleExtractUse
+hw.module @narrowAdditionSingleExtractUse(%x: i8, %y: i8) -> (%z1: i6) {
+  // CHECK-NEXT: [[RX:%.+]] = comb.extract %x from 0 : (i8) -> i6
+  // CHECK-NEXT: [[RY:%.+]] = comb.extract %y from 0 : (i8) -> i6
+  // CHECK-NEXT: [[RESULT:%.+]] = comb.add [[RX]], [[RY]] : i6
+  // CHECK-NEXT: hw.output [[RESULT]]
+
+  %false = hw.constant false
+  %0 = comb.concat %false, %x : (i1, i8) -> i9
+  %1 = comb.concat %false, %y : (i1, i8) -> i9
+  %2 = comb.add %0, %1 : i9
+  %3 = comb.extract %2 from 0 : (i9) -> i6
+  hw.output %3 : i6
+}
+
+// Validates that addition narrows to the element itself without an extract
+// where possible.
+// CHECK-LABEL: hw.module @narrowAdditionToDirectAddition
+hw.module @narrowAdditionToDirectAddition(%x: i8, %y: i8) -> (%z1: i8) {
+  // CHECK-NEXT: [[RESULT:%.+]] = comb.add %x, %y : i8
+  // CHECK-NEXT: hw.output [[RESULT]]
+
+  %false = hw.constant false
+  %0 = comb.concat %x, %x : (i8, i8) -> i16
+  %1 = comb.concat %y, %y : (i8, i8) -> i16
+  %2 = comb.add %0, %1 : i16
+  %3 = comb.extract %2 from 0 : (i16) -> i8
+  hw.output %3 : i8
+}
+
+// Validates that addition narrow to the widest extract
+// CHECK-LABEL: hw.module @narrowAdditionToWidestExtract
+hw.module @narrowAdditionToWidestExtract(%x: i8, %y: i8) -> (%z1: i3, %z2: i4) {
+  // CHECK-NEXT: [[RX:%.+]] = comb.extract %x from 0 : (i8) -> i4
+  // CHECK-NEXT: [[RY:%.+]] = comb.extract %y from 0 : (i8) -> i4
+  // CHECK-NEXT: [[RESULT2:%.+]] = comb.add [[RX]], [[RY]] : i4
+  // CHECK-NEXT: [[RESULT1:%.+]] = comb.extract [[RESULT2]] from 0 : (i4) -> i3
+  // CHECK-NEXT: hw.output [[RESULT1]], [[RESULT2]]
+
+  %0 = comb.concat %x, %x : (i8, i8) -> i9
+  %1 = comb.concat %y, %y : (i8, i8) -> i9
+  %2 = comb.add %0, %1 : i9
+  %3 = comb.extract %2 from 0 : (i9) -> i3
+  %4 = comb.extract %2 from 0 : (i9) -> i4
+  hw.output %3, %4 : i3, i4
+}
+
+// Validates that addition narrow to the widest extract
+// CHECK-LABEL: hw.module @narrowAdditionStripLeadingZero
+hw.module @narrowAdditionStripLeadingZero(%x: i8, %y: i8) -> (%z: i8) {
+  // CHECK-NEXT: [[RESULT:%.+]] = comb.add %x, %y : i8
+  // CHECK-NEXT: hw.output [[RESULT]]
+
+  %false = hw.constant false
+  %0 = comb.concat %false, %x : (i1, i8) -> i9
+  %1 = comb.concat %false, %y : (i1, i8) -> i9
+  %2 = comb.add %0, %1 : i9
+  %3 = comb.extract %2 from 0 : (i9) -> i8
+  hw.output %3 : i8
+}
+
+// Validates that addition narrowing does not happen when the width of the
+// largest use is as wide as the addition result itself.
+// CHECK-LABEL: hw.module @narrowAdditionRetainOriginal
+hw.module @narrowAdditionRetainOriginal(%x: i8, %y: i8) -> (%z0: i9, %z1: i8) {
+  // CHECK-NEXT: false = hw.constant false
+  // CHECK-NEXT: %0 = comb.concat %false, %x : (i1, i8) -> i9
+  // CHECK-NEXT: %1 = comb.concat %false, %y : (i1, i8) -> i9
+  // CHECK-NEXT: %2 = comb.add %0, %1 : i9
+  // CHECK-NEXT: %3 = comb.extract %2 from 0 : (i9) -> i8
+  // CHECK-NEXT: hw.output %2, %3 : i9, i8
+
+  %false = hw.constant false
+  %0 = comb.concat %false, %x : (i1, i8) -> i9
+  %1 = comb.concat %false, %y : (i1, i8) -> i9
+  %2 = comb.add %0, %1 : i9
+  %3 = comb.extract %2 from 0 : (i9) -> i8
+  hw.output %2, %3 : i9, i8
+}
+
+// Validates that addition narrowing retains the lower bits when not extracting from
+// zero.
+// CHECK-LABEL: hw.module @narrowAdditionExtractFromNoneZero
+hw.module @narrowAdditionExtractFromNoneZero(%x: i8, %y: i8) -> (%z0: i4) {
+  // CHECK-NEXT: [[RX:%.+]] = comb.extract %x from 0 : (i8) -> i5
+  // CHECK-NEXT: [[RY:%.+]] = comb.extract %y from 0 : (i8) -> i5
+  // CHECK-NEXT: [[ADD:%.+]] = comb.add [[RX]], [[RY]] : i5
+  // CHECK-NEXT: [[RET:%.+]] = comb.extract [[ADD]] from 1 : (i5) -> i4
+  // CHECK-NEXT: hw.output [[RET]]
+
+  %0 = comb.add %x, %y : i8
+  %1 = comb.extract %0 from 1 : (i8) -> i4
+  hw.output %1 : i4
+}
+
+// Validates that subtraction narrowing retains the lower bits when not extracting from
+// zero.
+// CHECK-LABEL: hw.module @narrowSubExtractFromNoneZero
+hw.module @narrowSubExtractFromNoneZero(%x: i8, %y: i8) -> (%z0: i4) {
+  // CHECK-NEXT: [[RX:%.+]] = comb.extract %x from 0 : (i8) -> i5
+  // CHECK-NEXT: [[RY:%.+]] = comb.extract %y from 0 : (i8) -> i5
+  // CHECK-NEXT: [[ADD:%.+]] = comb.sub [[RX]], [[RY]] : i5
+  // CHECK-NEXT: [[RET:%.+]] = comb.extract [[ADD]] from 1 : (i5) -> i4
+  // CHECK-NEXT: hw.output [[RET]]
+
+  %0 = comb.sub %x, %y : i8
+  %1 = comb.extract %0 from 1 : (i8) -> i4
+  hw.output %1 : i4
+}
+
+// Validates that subtraction narrowing retains the lower bits when not extracting from
+// zero.
+// CHECK-LABEL: hw.module @narrowMulExtractFromNoneZero
+hw.module @narrowMulExtractFromNoneZero(%x: i8, %y: i8) -> (%z0: i4) {
+  // CHECK-NEXT: [[RX:%.+]] = comb.extract %x from 0 : (i8) -> i5
+  // CHECK-NEXT: [[RY:%.+]] = comb.extract %y from 0 : (i8) -> i5
+  // CHECK-NEXT: [[ADD:%.+]] = comb.mul [[RX]], [[RY]] : i5
+  // CHECK-NEXT: [[RET:%.+]] = comb.extract [[ADD]] from 1 : (i5) -> i4
+  // CHECK-NEXT: hw.output [[RET]]
+
+  %0 = comb.mul %x, %y : i8
+  %1 = comb.extract %0 from 1 : (i8) -> i4
+  hw.output %1 : i4
+}
+
+// Validates that bitwise operation does not retain the lower bit when extracting from
+// non-zero.
+// CHECK-LABEL: hw.module @narrowBitwiseOpsExtractFromNoneZero
+hw.module @narrowBitwiseOpsExtractFromNoneZero(%a: i8, %b: i8, %c: i8, %d: i1) -> (%w: i4, %x: i4, %y: i4, %z: i4) {
+  // CHECK-NEXT: [[RA:%.+]] = comb.extract %a from 1 : (i8) -> i4
+  // CHECK-NEXT: [[RB:%.+]] = comb.extract %b from 1 : (i8) -> i4
+  // CHECK-NEXT: [[RC:%.+]] = comb.extract %c from 1 : (i8) -> i4
+  // CHECK-NEXT: [[AND:%.+]] = comb.and [[RA]], [[RB]], [[RC]] : i4
+  %0 = comb.and %a, %b, %c : i8
+  %1 = comb.extract %0 from 1 : (i8) -> i4
+
+  // CHECK-NEXT: [[RA:%.+]] = comb.extract %a from 1 : (i8) -> i4
+  // CHECK-NEXT: [[RB:%.+]] = comb.extract %b from 1 : (i8) -> i4
+  // CHECK-NEXT: [[RC:%.+]] = comb.extract %c from 1 : (i8) -> i4
+  // CHECK-NEXT: [[OR:%.+]] = comb.or [[RA]], [[RB]], [[RC]] : i4
+  %2 = comb.or %a, %b, %c : i8
+  %3 = comb.extract %2 from 1 : (i8) -> i4
+
+  // CHECK-NEXT: [[RA:%.+]] = comb.extract %a from 1 : (i8) -> i4
+  // CHECK-NEXT: [[RB:%.+]] = comb.extract %b from 1 : (i8) -> i4
+  // CHECK-NEXT: [[RC:%.+]] = comb.extract %c from 1 : (i8) -> i4
+  // CHECK-NEXT: [[XOR:%.+]] = comb.xor [[RA]], [[RB]], [[RC]] : i4
+  %4 = comb.xor %a, %b, %c : i8
+  %5 = comb.extract %4 from 1 : (i8) -> i4
+
+  // CHECK-NEXT: [[RA:%.+]] = comb.extract %a from 1 : (i8) -> i4
+  // CHECK-NEXT: [[RB:%.+]] = comb.extract %b from 1 : (i8) -> i4
+  // CHECK-NEXT: [[MUX:%.+]] = comb.mux %d, [[RA]], [[RB]] : i4
+  %6 = comb.mux %d, %a, %b : i8
+  %7 = comb.extract %6 from 1 : (i8) -> i4
+
+  // CHECK-NEXT: hw.output [[AND]], [[OR]], [[XOR]], [[MUX]]
+  hw.output %1, %3, %5, %7 : i4, i4, i4, i4
+}


### PR DESCRIPTION
This is a second attempt in implementing #1424 , fixing some memory access bugs.

There are two memory access issues:
1. What @lattner mentioned about uses in https://github.com/llvm/circt/commit/2660c0b3144be11370839ebfaad8c0c80b335f82#r53799782 . I fixed this by dumping `operation->getUsers` into a vector .
2. Calling `rewriter.replaceOp` ([here](https://github.com/llvm/circt/commit/2660c0b3144be11370839ebfaad8c0c80b335f82#diff-6f80524cbed3f3dee4e82a5f97ae9ade89be7f2132704918ec60d91889bfc751R159)) erases the op under the hood and invalidates that piece of memory.  This was fine when we are replacing the Op being canonicalized, but reasons i'm not sure of, erasing users of the op is buggy.  valgrind confirms that the GreedyPatternRewriter has a dangling reference (see log below), but i can't convince myself why. I fixed this by using `rewriter.replaceAllUsesOfOp`, which does not erase the op's memory. This ends up achieving the desired result, as DCE clears out the unused op.

To help with review, this PR comprises of 3 commits (and more as we iterate through this in review):
1. https://github.com/llvm/circt/commit/9f25b9ce6a521561192c6c77793fb9b1d0d3eb27 Readds the broken patch (ie revert the revert)
2. https://github.com/llvm/circt/commit/02313deb99a2b828777d90e7474a45ad4967a2df Implements the fixes. I move to useing `getUsers` instead of `getUse`, as it returns an iterator over  `Operation*` directly (which is what i care about).
3. https://github.com/llvm/circt/commit/529ab72292ff5f0abf532cf2a8bef11370f3be65 Implements some review comments in discussed in https://github.com/llvm/circt/commit/2660c0b3144be11370839ebfaad8c0c80b335f82 , namely changing `template<typename T>`  into `Operation*`, and `typename F` into `std::function<Value(ArrayRef(Value))>` 

To validate that this works:

1. I ran the Comb cannonicalization test in this feature 10k times
2. Running the HEAD of this PR with valgrind using `./bin/circt-opt --canonicalize ../test/Dialect/Comb/canonicalization.mlir` gets a clean result.

*Verbose Valgrind output follows*

The following is the output from valgrind when ran against the broken commit. This illustrates the problem where `getUses()` memory is being wipped as it is being rewritten.

```
fyq14@linux:~/dev/circt/build$ valgrind ./bin/circt-opt --canonicalize  ../test/Dialect/Comb/canonicalization.mlir 
==33635== Memcheck, a memory error detector
==33635== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==33635== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==33635== Command: ./bin/circt-opt --canonicalize ../test/Dialect/Comb/canonicalization.mlir
==33635== 
==33635== Invalid read of size 8
==33635==    at 0x66168DC: mlir::detail::IROperandBase::getNextOperandUsingThisValue() (mlir/include/mlir/IR/UseDefLists.h:42)
==33635==    by 0x6758DAC: mlir::ValueUseIterator<mlir::OpOperand>::operator++() (mlir/include/mlir/IR/UseDefLists.h:264)
==33635==    by 0x6752EC3: mlir::Operation::UseIterator::operator++() (mlir/lib/IR/Operation.cpp:1334)
==33635==    by 0x755B75: _Z20narrowOperationWidthIN5circt4comb5MuxOpEZZL18narrowExtractWidthNS1_9ExtractOpEN4mlir15PatternRewriterEENKUlT_E2_clIS2_EEDaS6_EUlN4llvm8ArrayRefINS4_5ValueEEEE_EbS6_NS4_10ValueRangeEbRS5_T0_ (CombFolds.cpp:151)
==33635==    by 0x752632: _ZZL18narrowExtractWidthN5circt4comb9ExtractOpEN4mlir15PatternRewriterEENKUlT_E2_clINS0_5MuxOpEEEDaS4_ (CombFolds.cpp:381)
==33635==    by 0x7526C5: llvm::TypeSwitch<mlir::Operation*, bool>& llvm::TypeSwitch<mlir::Operation*, bool>::Case<circt::comb::MuxOp, narrowExtractWidth(circt::comb::ExtractOp, mlir::PatternRewriter)::{lambda(auto:1)#4}>(narrowExtractWidth(circt::comb::ExtractOp, mlir::PatternRewriter)::{lambda(auto:1)#4}&&) (TypeSwitch.h:116)
==33635==    by 0x749F36: narrowExtractWidth(circt::comb::ExtractOp, mlir::PatternRewriter) (CombFolds.cpp:384)
==33635==    by 0x74A0B8: circt::comb::ExtractOp::canonicalize(circt::comb::ExtractOp, mlir::PatternRewriter&) (CombFolds.cpp:410)
==33635==    by 0x785871: mlir::RewritePatternSet& mlir::RewritePatternSet::add<circt::comb::ExtractOp>(mlir::LogicalResult (*)(circt::comb::ExtractOp, mlir::PatternRewriter&))::FnPattern::matchAndRewrite(circt::comb::ExtractOp, mlir::PatternRewriter&) const (PatternMatch.h:978)
==33635==    by 0x78BEB3: mlir::detail::OpOrInterfaceRewritePatternBase<circt::comb::ExtractOp>::matchAndRewrite(mlir::Operation*, mlir::PatternRewriter&) const (PatternMatch.h:329)
==33635==    by 0x53883AF: mlir::PatternApplicator::matchAndRewrite(mlir::Operation*, mlir::PatternRewriter&, llvm::function_ref<bool (mlir::Pattern const&)>, llvm::function_ref<void (mlir::Pattern const&)>, llvm::function_ref<mlir::LogicalResult (mlir::Pattern const&)>) (mlir/lib/Rewrite/PatternApplicator.cpp:201)
==33635==    by 0x5143BE0: (anonymous namespace)::GreedyPatternRewriteDriver::simplify(llvm::MutableArrayRef<mlir::Region>) (mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp:218)
==33635==  Address 0x9f6a340 is 96 bytes inside a block of size 128 free'd
==33635==    at 0x483CA3F: free (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==33635==    by 0x674C557: mlir::Operation::destroy() (mlir/lib/IR/Operation.cpp:224)
==33635==    by 0x674D114: llvm::ilist_traits<mlir::Operation>::deleteNode(mlir::Operation*) (mlir/lib/IR/Operation.cpp:432)
==33635==    by 0x66273E4: llvm::iplist_impl<llvm::simple_ilist<mlir::Operation>, llvm::ilist_traits<mlir::Operation> >::erase(llvm::ilist_iterator<llvm::ilist_detail::node_options<mlir::Operation, true, false, void>, false, false>) (llvm/include/llvm/ADT/ilist.h:268)
==33635==    by 0x6756EE4: llvm::iplist_impl<llvm::simple_ilist<mlir::Operation>, llvm::ilist_traits<mlir::Operation> >::erase(mlir::Operation*) (llvm/include/llvm/ADT/ilist.h:272)
==33635==    by 0x674D36F: mlir::Operation::erase() (mlir/lib/IR/Operation.cpp:481)
==33635==    by 0x676CF25: mlir::RewriterBase::replaceOp(mlir::Operation*, mlir::ValueRange) (mlir/lib/IR/PatternMatch.cpp:230)
==33635==    by 0x755AF8: _Z20narrowOperationWidthIN5circt4comb5MuxOpEZZL18narrowExtractWidthNS1_9ExtractOpEN4mlir15PatternRewriterEENKUlT_E2_clIS2_EEDaS6_EUlN4llvm8ArrayRefINS4_5ValueEEEE_EbS6_NS4_10ValueRangeEbRS5_T0_ (CombFolds.cpp:159)
==33635==    by 0x752632: _ZZL18narrowExtractWidthN5circt4comb9ExtractOpEN4mlir15PatternRewriterEENKUlT_E2_clINS0_5MuxOpEEEDaS4_ (CombFolds.cpp:381)
==33635==    by 0x7526C5: llvm::TypeSwitch<mlir::Operation*, bool>& llvm::TypeSwitch<mlir::Operation*, bool>::Case<circt::comb::MuxOp, narrowExtractWidth(circt::comb::ExtractOp, mlir::PatternRewriter)::{lambda(auto:1)#4}>(narrowExtractWidth(circt::comb::ExtractOp, mlir::PatternRewriter)::{lambda(auto:1)#4}&&) (TypeSwitch.h:116)
==33635==    by 0x749F36: narrowExtractWidth(circt::comb::ExtractOp, mlir::PatternRewriter) (CombFolds.cpp:384)
==33635==    by 0x74A0B8: circt::comb::ExtractOp::canonicalize(circt::comb::ExtractOp, mlir::PatternRewriter&) (CombFolds.cpp:410)
==33635==  Block was alloc'd at
==33635==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==33635==    by 0x674B8E6: mlir::Operation::create(mlir::Location, mlir::OperationName, mlir::TypeRange, mlir::ValueRange, mlir::DictionaryAttr, mlir::BlockRange, unsigned int) (mlir/lib/IR/Operation.cpp:136)
==33635==    by 0x674BE56: mlir::Operation::create(mlir::Location, mlir::OperationName, mlir::TypeRange, mlir::ValueRange, mlir::DictionaryAttr, mlir::BlockRange, mlir::RegionRange) (mlir/lib/IR/Operation.cpp:94)
==33635==    by 0x674BD63: mlir::Operation::create(mlir::OperationState const&) (mlir/lib/IR/Operation.cpp:83)
==33635==    by 0x662F093: mlir::OpBuilder::createOperation(mlir::OperationState const&) (mlir/lib/IR/Builders.cpp:400)
==33635==    by 0x78F0589: (anonymous namespace)::OperationParser::parseCustomOperation(llvm::ArrayRef<std::tuple<llvm::StringRef, unsigned int, llvm::SMLoc> >) (mlir/lib/Parser/Parser.cpp:1922)
==33635==    by 0x78EC806: (anonymous namespace)::OperationParser::parseOperation() (mlir/lib/Parser/Parser.cpp:801)
==33635==    by 0x78F9111: (anonymous namespace)::OperationParser::parseBlockBody(mlir::Block*) (mlir/lib/Parser/Parser.cpp:2131)
==33635==    by 0x78F8797: (anonymous namespace)::OperationParser::parseBlock(mlir::Block*&) (mlir/lib/Parser/Parser.cpp:2099)
==33635==    by 0x78F830B: (anonymous namespace)::OperationParser::parseRegionBody(mlir::Region&, llvm::SMLoc, llvm::ArrayRef<std::pair<(anonymous namespace)::OperationParser::SSAUseInfo, mlir::Type> >, bool) (mlir/lib/Parser/Parser.cpp:2057)
==33635==    by 0x78F763E: (anonymous namespace)::OperationParser::parseRegion(mlir::Region&, llvm::ArrayRef<std::pair<(anonymous namespace)::OperationParser::SSAUseInfo, mlir::Type> >, bool) (mlir/lib/Parser/Parser.cpp:1996)
==33635==    by 0x78F46DB: (anonymous namespace)::CustomOpAsmParser::parseRegion(mlir::Region&, llvm::ArrayRef<mlir::OpAsmParser::OperandType>, llvm::ArrayRef<mlir::Type>, bool) (mlir/lib/Parser/Parser.cpp:1645)
==33635==
<snip>
```

The following diff and valgrind log shows a fix for the `getUses` getting invalidated as we replace uses, and the valgrind log the follows. Note that the greedy pattern driver still contain dangling references.

```diff
diff --git a/lib/Dialect/Comb/CombFolds.cpp b/lib/Dialect/Comb/CombFolds.cpp
index 7b6bbc48..931259e1 100644
--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -148,8 +148,11 @@ static bool narrowOperationWidth(Op narrowingCandidate, ValueRange inputs,
 
   // Replace all the use-site's extract operation with the newly minted narrowed
   // version.
-  for (auto &use : uses) {
-    auto extractUse = cast<ExtractOp>(use.getOwner());
+  SmallVector<Operation*> users(
+      narrowingCandidate.getOperation()->getUsers().begin(),
+      narrowingCandidate.getOperation()->getUsers().end());
+  for (auto &user : users) {
+    auto extractUse = cast<ExtractOp>(user);
     auto oldLowBit = extractUse.lowBit();
 
     assert(oldLowBit >= lowestBitRequired &&
```


```
fyq14@linux:~/dev/circt/build$ valgrind ./bin/circt-opt --canonicalize  ../test/Dialect/Comb/canonicalization.mlir 
==33936== Memcheck, a memory error detector
==33936== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==33936== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==33936== Command: ./bin/circt-opt --canonicalize ../test/Dialect/Comb/canonicalization.mlir
==33936== 
==33936== Invalid read of size 4
==33936==    at 0x63B95B0: mlir::Operation::getResults() (mlir/include/mlir/IR/Operation.h:293)
==33936==    by 0x63B8B04: mlir::Operation::getOpResults() (mlir/include/mlir/IR/Operation.h:297)
==33936==    by 0x63B8A24: mlir::Operation::use_empty() (mlir/include/mlir/IR/Operation.h:578)
==33936==    by 0x63B80C4: mlir::isOpTriviallyDead(mlir::Operation*) (mlir/lib/Interfaces/SideEffectInterfaces.cpp:33)
==33936==    by 0x5143937: (anonymous namespace)::GreedyPatternRewriteDriver::simplify(llvm::MutableArrayRef<mlir::Region>) (mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp:180)
==33936==    by 0x51434E3: mlir::applyPatternsAndFoldGreedily(llvm::MutableArrayRef<mlir::Region>, mlir::FrozenRewritePatternSet const&, mlir::GreedyRewriteConfig) (mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp:256)
==33936==    by 0x4F29D1B: (anonymous namespace)::Canonicalizer::runOnOperation() (mlir/lib/Transforms/Canonicalizer.cpp:48)
==33936==    by 0x541E557: mlir::detail::OpToOpPassAdaptor::run(mlir::Pass*, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int) (mlir/lib/Pass/Pass.cpp:385)
==33936==    by 0x541EB44: mlir::detail::OpToOpPassAdaptor::runPipeline(llvm::iterator_range<llvm::pointee_iterator<std::unique_ptr<mlir::Pass, std::default_delete<mlir::Pass> >*, mlir::Pass> >, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int, mlir::PassInstrumentor*, mlir::PassInstrumentation::PipelineParentInfo const*) (mlir/lib/Pass/Pass.cpp:445)
==33936==    by 0x542022D: mlir::PassManager::runPasses(mlir::Operation*, mlir::AnalysisManager) (mlir/lib/Pass/Pass.cpp:689)
==33936==    by 0x5420117: mlir::PassManager::run(mlir::Operation*) (mlir/lib/Pass/Pass.cpp:669)
==33936==    by 0x4860F88: performActions(llvm::raw_ostream&, bool, bool, llvm::SourceMgr&, mlir::MLIRContext*, mlir::PassPipelineCLParser const&) (mlir/lib/Support/MlirOptMain.cpp:84)
==33936==  Address 0x9fb7aa4 is 52 bytes inside a block of size 128 free'd
==33936==    at 0x483CA3F: free (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==33936==    by 0x674C557: mlir::Operation::destroy() (mlir/lib/IR/Operation.cpp:224)
==33936==    by 0x674D114: llvm::ilist_traits<mlir::Operation>::deleteNode(mlir::Operation*) (mlir/lib/IR/Operation.cpp:432)
==33936==    by 0x66273E4: llvm::iplist_impl<llvm::simple_ilist<mlir::Operation>, llvm::ilist_traits<mlir::Operation> >::erase(llvm::ilist_iterator<llvm::ilist_detail::node_options<mlir::Operation, true, false, void>, false, false>) (llvm/include/llvm/ADT/ilist.h:268)
==33936==    by 0x6756EE4: llvm::iplist_impl<llvm::simple_ilist<mlir::Operation>, llvm::ilist_traits<mlir::Operation> >::erase(mlir::Operation*) (llvm/include/llvm/ADT/ilist.h:272)
==33936==    by 0x674D36F: mlir::Operation::erase() (mlir/lib/IR/Operation.cpp:481)
==33936==    by 0x676CF25: mlir::RewriterBase::replaceOp(mlir::Operation*, mlir::ValueRange) (mlir/lib/IR/PatternMatch.cpp:230)
==33936==    by 0x758E5D: bool narrowOperationWidth<circt::comb::AddOp, bool narrowOperationWidth<circt::comb::AddOp>(circt::comb::AddOp, mlir::ValueRange, bool, mlir::PatternRewriter&)::{lambda(llvm::ArrayRef<mlir::Value>)#1}>(circt::comb::AddOp, mlir::ValueRange, bool, mlir::PatternRewriter&, bool narrowOperationWidth<circt::comb::AddOp>(circt::comb::AddOp, mlir::ValueRange, bool, mlir::PatternRewriter&)::{lambda(llvm::ArrayRef<mlir::Value>)#1}) (CombFolds.cpp:162)
==33936==    by 0x757AB3: bool narrowOperationWidth<circt::comb::AddOp>(circt::comb::AddOp, mlir::ValueRange, bool, mlir::PatternRewriter&) (CombFolds.cpp:184)
==33936==    by 0x755143: _ZZL18narrowExtractWidthN5circt4comb9ExtractOpEN4mlir15PatternRewriterEENKUlT_E_clINS0_5AddOpEEEDaS4_ (CombFolds.cpp:356)
==33936==    by 0x7551D5: llvm::TypeSwitch<mlir::Operation*, bool>& llvm::TypeSwitch<mlir::Operation*, bool>::Case<circt::comb::AddOp, narrowExtractWidth(circt::comb::ExtractOp, mlir::PatternRewriter)::{lambda(auto:1)#1}&>(narrowExtractWidth(circt::comb::ExtractOp, mlir::PatternRewriter)::{lambda(auto:1)#1}&) (TypeSwitch.h:116)
==33936==    by 0x7522AC: llvm::TypeSwitch<mlir::Operation*, bool>& llvm::detail::TypeSwitchBase<llvm::TypeSwitch<mlir::Operation*, bool>, mlir::Operation*>::Case<circt::comb::AddOp, circt::comb::MulOp, , narrowExtractWidth(circt::comb::ExtractOp, mlir::PatternRewriter)::{lambda(auto:1)#1}>(narrowExtractWidth(circt::comb::ExtractOp, mlir::PatternRewriter)::{lambda(auto:1)#1}&&) (TypeSwitch.h:41)
==33936==  Block was alloc'd at
==33936==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==33936==    by 0x674B8E6: mlir::Operation::create(mlir::Location, mlir::OperationName, mlir::TypeRange, mlir::ValueRange, mlir::DictionaryAttr, mlir::BlockRange, unsigned int) (mlir/lib/IR/Operation.cpp:136)
==33936==    by 0x674BE56: mlir::Operation::create(mlir::Location, mlir::OperationName, mlir::TypeRange, mlir::ValueRange, mlir::DictionaryAttr, mlir::BlockRange, mlir::RegionRange) (mlir/lib/IR/Operation.cpp:94)
==33936==    by 0x674BD63: mlir::Operation::create(mlir::OperationState const&) (mlir/lib/IR/Operation.cpp:83)
==33936==    by 0x662F093: mlir::OpBuilder::createOperation(mlir::OperationState const&) (mlir/lib/IR/Builders.cpp:400)
==33936==    by 0x78F0589: (anonymous namespace)::OperationParser::parseCustomOperation(llvm::ArrayRef<std::tuple<llvm::StringRef, unsigned int, llvm::SMLoc> >) (mlir/lib/Parser/Parser.cpp:1922)
==33936==    by 0x78EC806: (anonymous namespace)::OperationParser::parseOperation() (mlir/lib/Parser/Parser.cpp:801)
==33936==    by 0x78F9111: (anonymous namespace)::OperationParser::parseBlockBody(mlir::Block*) (mlir/lib/Parser/Parser.cpp:2131)
==33936==    by 0x78F8797: (anonymous namespace)::OperationParser::parseBlock(mlir::Block*&) (mlir/lib/Parser/Parser.cpp:2099)
==33936==    by 0x78F830B: (anonymous namespace)::OperationParser::parseRegionBody(mlir::Region&, llvm::SMLoc, llvm::ArrayRef<std::pair<(anonymous namespace)::OperationParser::SSAUseInfo, mlir::Type> >, bool) (mlir/lib/Parser/Parser.cpp:2057)
==33936==    by 0x78F763E: (anonymous namespace)::OperationParser::parseRegion(mlir::Region&, llvm::ArrayRef<std::pair<(anonymous namespace)::OperationParser::SSAUseInfo, mlir::Type> >, bool) (mlir/lib/Parser/Parser.cpp:1996)
==33936==    by 0x78F46DB: (anonymous namespace)::CustomOpAsmParser::parseRegion(mlir::Region&, llvm::ArrayRef<mlir::OpAsmParser::OperandType>, llvm::ArrayRef<mlir::Type>, bool) (mlir/lib/Parser/Parser.cpp:1645)
==33936== 
```


