### PR TITLE
[Scheduling] Define cyclic problem.

### DIFF
--- a/include/circt/Scheduling/Problems.h
+++ b/include/circt/Scheduling/Problems.h
@@ -63,8 +63,7 @@ namespace scheduling {
 ///   problem's solution, i.e. the schedule.
 ///
 /// Subclasses, i.e. corresponding to more complex scheduling problems, can
-/// declare additional properties as needed. The `clearSolution` method must be
-/// overridden if the new properties are part of the solution.
+/// declare additional properties as needed.
 //
 /// The `check...` methods perform validity checks before scheduling, e.g. that
 /// all operations have an associated operator type, etc.
@@ -207,9 +206,6 @@ public:
   }
   void setStartTime(Operation *op, unsigned val) { startTime[op] = val; }
 
-  /// Clear all properties that are part of the solution.
-  virtual void clearSolution() { startTime.clear(); }
-
   //===--------------------------------------------------------------------===//
   // Hooks to check/verify the different problem components
   //===--------------------------------------------------------------------===//
@@ -257,8 +253,6 @@ public:
   /// problem's solution.
   Optional<unsigned> getInitiationInterval() { return initiationInterval; }
   void setInitiationInterval(unsigned val) { initiationInterval = val; }
-
-  virtual void clearSolution() override { initiationInterval.reset(); }
 
 protected:
   virtual LogicalResult verifyDependence(Dependence dep) override;

--- a/lib/Scheduling/Problems.cpp
+++ b/lib/Scheduling/Problems.cpp
@@ -142,6 +142,41 @@ LogicalResult Problem::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// CyclicProblem
+//===----------------------------------------------------------------------===//
+
+LogicalResult CyclicProblem::verifyDependence(Dependence dep) {
+  // fail early if II is not set or invalid
+  if (!getInitiationInterval() || *getInitiationInterval() == 0)
+    return getContainingOp()->emitError("Invalid initiation interval");
+
+  Operation *i = dep.getSource();
+  Operation *j = dep.getDestination();
+
+  unsigned stI = *getStartTime(i);
+  unsigned latI = *getLatency(*getLinkedOperatorType(i));
+  unsigned stJ = *getStartTime(j);
+  unsigned dist = getDistance(dep).getValueOr(0); // optional property
+  unsigned ii = *getInitiationInterval();
+
+  // check if i's result is available before j starts (dist iterations later)
+  if (!(stI + latI <= stJ + dist * ii))
+    return getContainingOp()->emitError()
+           << "Precedence violated for dependence."
+           << "\n  from: " << *i << ", result available in t=" << (stI + latI)
+           << "\n  to:   " << *j << ", starts in t=" << stJ
+           << "\n  dist: " << dist << ", II=" << ii;
+
+  return success();
+}
+
+LogicalResult CyclicProblem::verifyProblem() {
+  if (!getInitiationInterval() || *getInitiationInterval() == 0)
+    return getContainingOp()->emitError("Invalid initiation interval");
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // Dependence
 //===----------------------------------------------------------------------===//
 

--- a/test/Scheduling/cyclic-problem-errors.mlir
+++ b/test/Scheduling/cyclic-problem-errors.mlir
@@ -1,0 +1,21 @@
+// RUN: circt-opt %s -test-cyclic-problem -verify-diagnostics -split-input-file
+
+// expected-error@+2 {{Invalid initiation interval}}
+// expected-error@+1 {{problem verification failed}}
+func @no_II() {
+  return { problemStartTime = 0 }
+}
+
+// -----
+
+// expected-error@+2 {{Precedence violated for dependence}}
+// expected-error@+1 {{problem verification failed}}
+func @backedge_violated(%a1 : i32, %a2 : i32) -> i32 attributes {
+  problemInitiationInterval = 2,
+  auxdeps = [ [2,0,1] ]
+  } {
+  %0 = addi %a1, %a2 { problemStartTime = 0 } : i32
+  %1 = addi %0, %0 { problemStartTime = 1 } : i32
+  %2 = addi %1, %1 { problemStartTime = 2 } : i32
+  return { problemStartTime = 3 } %2 : i32
+}

--- a/test/Scheduling/cyclic-problems.mlir
+++ b/test/Scheduling/cyclic-problems.mlir
@@ -1,0 +1,14 @@
+// RUN: circt-opt %s -test-cyclic-problem
+
+func @cyclic(%a1 : i32, %a2 : i32) -> i32 attributes {
+  problemInitiationInterval = 2,
+  auxdeps = [ [4,1,1], [4,2,2] ],
+  operatortypes = [ { name = "_0", latency = 0 }, { name = "_2", latency = 2 } ]
+  } {
+  %c42 = constant { problemStartTime = 0 } 42 : i32
+  %0 = addi %a1, %a2 { opr = "_0", problemStartTime = 2 } : i32
+  %1 = subi %a2, %a1 { opr = "_2", problemStartTime = 0 } : i32
+  %2 = muli %0, %1 { problemStartTime = 2 } : i32
+  %3 = divi_unsigned %1, %c42 { problemStartTime = 3 } : i32
+  return { problemStartTime = 4 } %2 : i32
+}


### PR DESCRIPTION
Straightforward extension of the basic scheduling problem:
- Dependences have an optional *distance* property.
- The cyclic problem has a solution property *initiation interval* (II).
- The solution is valid iff for each dependence `i -> j` with distance `dist` (default value 0, if not set), `i` finishes before `j` starts `dist` iterations/samples/pipeline starts/etc. later. Formally:
`startTime(i) + latency(assocOpr(i)) <= startTime(j) + dist * II`
