### PR TITLE
[Calyx] Add OpAsmInterface for components. Use all ports as block arguments.

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -81,7 +81,8 @@ def ComponentOp : CalyxOp<"component", [
   // TODO(Calyx): Allow explicit port naming?
   let arguments = (ins
     ArrayAttr:$inPortNames,
-    ArrayAttr:$outPortNames
+    ArrayAttr:$outPortNames,
+    I64Attr:$numInPorts
   );
   let results = (outs);
   let regions = (region SizedRegion<1>: $body);

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -80,8 +80,7 @@ def ComponentOp : CalyxOp<"component", [
 
   // TODO(Calyx): Allow explicit port naming?
   let arguments = (ins
-    ArrayAttr:$inPortNames,
-    ArrayAttr:$outPortNames,
+    ArrayAttr:$portNames,
     I64Attr:$numInPorts
   );
   let results = (outs);

--- a/lib/Dialect/Calyx/CalyxDialect.cpp
+++ b/lib/Dialect/Calyx/CalyxDialect.cpp
@@ -52,9 +52,8 @@ void CalyxOpAsmDialectInterface::getAsmBlockArgumentNames(
     return;
 
   auto ports = getComponentPortInfo(component);
-  for (size_t i = 0, e = block->getNumArguments(); i != e; ++i) {
+  for (size_t i = 0, e = block->getNumArguments(); i != e; ++i)
     setNameFn(block->getArgument(i), ports[i].name.getValue());
-  }
 }
 
 void CalyxDialect::initialize() {

--- a/lib/Dialect/Calyx/CalyxDialect.cpp
+++ b/lib/Dialect/Calyx/CalyxDialect.cpp
@@ -51,9 +51,9 @@ void CalyxOpAsmDialectInterface::getAsmBlockArgumentNames(
   if (component == nullptr)
     return;
 
-  auto ports = getComponentPortInfo(component);
+  auto ports = component.portNames();
   for (size_t i = 0, e = block->getNumArguments(); i != e; ++i)
-    setNameFn(block->getArgument(i), ports[i].name.getValue());
+    setNameFn(block->getArgument(i), ports[i].cast<StringAttr>().getValue());
 }
 
 void CalyxDialect::initialize() {

--- a/lib/Dialect/Calyx/CalyxDialect.cpp
+++ b/lib/Dialect/Calyx/CalyxDialect.cpp
@@ -23,12 +23,49 @@ using namespace circt::calyx;
 // Dialect specification.
 //===----------------------------------------------------------------------===//
 
+namespace {
+
+// We implement the OpAsmDialectInterface so that HW dialect operations
+// automatically interpret the name attribute on operations as their SSA name.
+struct CalyxOpAsmDialectInterface : public OpAsmDialectInterface {
+  using OpAsmDialectInterface::OpAsmDialectInterface;
+
+  /// Get a special name to use when printing the given operation. See
+  /// OpAsmInterface.td#getAsmResultNames for usage details and documentation.
+  void getAsmResultNames(Operation *op,
+                         OpAsmSetValueNameFn setNameFn) const override {}
+
+  /// Get a special name to use when printing the entry block arguments of the
+  /// region contained by an operation in this dialect.
+  void getAsmBlockArgumentNames(Block *block,
+                                OpAsmSetValueNameFn setNameFn) const override;
+};
+
+} // end anonymous namespace
+
+void CalyxOpAsmDialectInterface::getAsmBlockArgumentNames(
+    Block *block, OpAsmSetValueNameFn setNameFn) const {
+  auto *parentOp = block->getParentOp();
+  auto component = dyn_cast<ComponentOp>(parentOp);
+  // Currently only support named block arguments for components.
+  if (component == nullptr)
+    return;
+
+  auto ports = getComponentPortInfo(component);
+  for (size_t i = 0, e = block->getNumArguments(); i != e; ++i) {
+    setNameFn(block->getArgument(i), ports[i].name.getValue());
+  }
+}
+
 void CalyxDialect::initialize() {
   // Register operations.
   addOperations<
 #define GET_OP_LIST
 #include "circt/Dialect/Calyx/Calyx.cpp.inc"
       >();
+
+  // Register interface implementations.
+  addInterfaces<CalyxOpAsmDialectInterface>();
 }
 
 // Provide implementations for the enums and attributes we use.

--- a/lib/Dialect/Calyx/CalyxDialect.cpp
+++ b/lib/Dialect/Calyx/CalyxDialect.cpp
@@ -25,7 +25,7 @@ using namespace circt::calyx;
 
 namespace {
 
-// We implement the OpAsmDialectInterface so that HW dialect operations
+// We implement the OpAsmDialectInterface so that Calyx dialect operations
 // automatically interpret the name attribute on operations as their SSA name.
 struct CalyxOpAsmDialectInterface : public OpAsmDialectInterface {
   using OpAsmDialectInterface::OpAsmDialectInterface;

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -117,8 +117,7 @@ SmallVector<ComponentPortInfo> calyx::getComponentPortInfo(Operation *op) {
   assert(isa<ComponentOp>(op) &&
          "Can only get port information from a component.");
   auto component = dyn_cast<ComponentOp>(op);
-  auto functionType = getComponentType(component);
-  auto portTypes = functionType.getInputs();
+  auto portTypes = getComponentType(component).getInputs();
   auto inPortNamesAttr = getComponentPortNames(component, PortDirection::INPUT);
   auto outPortNamesAttr =
       getComponentPortNames(component, PortDirection::OUTPUT);
@@ -201,7 +200,7 @@ parsePortDefList(OpAsmParser &parser, MLIRContext *context,
   });
   result.addAttribute(attrName, ArrayAttr::get(context, portNames));
 
-  return (parser.parseRParen());
+  return parser.parseRParen();
 }
 
 /// Parses the signature of a Calyx component.
@@ -245,7 +244,7 @@ static ParseResult parseComponentOp(OpAsmParser &parser,
   // arguments so they may be accessed within the component.
   portTypes.insert(portTypes.end(), outPortTypes.begin(), outPortTypes.end());
   ports.insert(ports.end(), outPorts.begin(), outPorts.end());
-  auto type = builder.getFunctionType(portTypes, {});
+  auto type = builder.getFunctionType(portTypes, /*resultTypes=*/{});
   result.addAttribute(ComponentOp::getTypeAttrName(), TypeAttr::get(type));
 
   auto *body = result.addRegion();

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -217,17 +217,15 @@ static ParseResult parseComponentOp(OpAsmParser &parser,
                              result.attributes))
     return failure();
 
-  SmallVector<OpAsmParser::OperandType> ports, outPorts;
-  SmallVector<Type> portTypes, outPortTypes;
+  SmallVector<OpAsmParser::OperandType> ports;
+  SmallVector<Type> portTypes;
   if (parseComponentSignature(parser, result, ports, portTypes))
     return failure();
 
-  auto &builder = parser.getBuilder();
   // Build the component's type for FunctionLike trait. All ports are listed as
   // arguments so they may be accessed within the component.
-  portTypes.insert(portTypes.end(), outPortTypes.begin(), outPortTypes.end());
-  ports.insert(ports.end(), outPorts.begin(), outPorts.end());
-  auto type = builder.getFunctionType(portTypes, /*resultTypes=*/{});
+  auto type =
+      parser.getBuilder().getFunctionType(portTypes, /*resultTypes=*/{});
   result.addAttribute(ComponentOp::getTypeAttrName(), TypeAttr::get(type));
 
   auto *body = result.addRegion();
@@ -310,6 +308,7 @@ void ComponentOp::build(OpBuilder &builder, OperationState &result,
 
   // Record the port names and number of input ports of the component.
   result.addAttribute("portNames", builder.getArrayAttr(portNames));
+  result.addAttribute("numInPorts", builder.getI64IntegerAttr(numInPorts));
 
   // Create a single-blocked region.
   result.addRegion();

--- a/test/Dialect/Calyx/compile-control.mlir
+++ b/test/Dialect/Calyx/compile-control.mlir
@@ -18,7 +18,7 @@ calyx.program {
       // CHECK: %[[GROUP_A_GO_GUARD:.+]] = comb.and %[[FSM_IS_GROUP_A_BEGIN_STATE]], %[[GROUP_A_NOT_DONE]] : i1
       calyx.group @A {
         // CHECK:  %A.go = calyx.group_go %[[SIGNAL_ON]], %[[GROUP_A_GO_GUARD]] ? : i1
-        // CHECK:  calyx.assign %z.go = %arg0, %A.go ? : i1
+        // CHECK:  calyx.assign %z.go = %go, %A.go ? : i1
         %A.go = calyx.group_go %undef : i1
         calyx.assign %z.go = %go, %A.go ? : i1
         calyx.group_done %z.done : i1

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -34,8 +34,8 @@ calyx.program {
         calyx.group_done %c1.done : i1
       }
       calyx.group @Group2 {
-        // CHECK: calyx.assign %c1.in = %c0.out, %c2.out ? : i8
-        calyx.assign %c1.in = %c0.out, %c2.out ? : i8
+        // CHECK: calyx.assign %c1.in = %c0.out, %go ? : i8
+        calyx.assign %c1.in = %c0.out, %go ? : i8
 
         // CHECK: calyx.group_done %c1.done, %0 ? : i1
         %guard = comb.and %c1_i1, %c2.out : i1

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -34,8 +34,8 @@ calyx.program {
         calyx.group_done %c1.done : i1
       }
       calyx.group @Group2 {
-        // CHECK: calyx.assign %c1.in = %c0.out, %go ? : i8
-        calyx.assign %c1.in = %c0.out, %go ? : i8
+        // CHECK: calyx.assign %c1.in = %c0.out, %done ? : i8
+        calyx.assign %c1.in = %c0.out, %done ? : i8
 
         // CHECK: calyx.group_done %c1.done, %0 ? : i1
         %guard = comb.and %c1_i1, %c2.out : i1


### PR DESCRIPTION
This PR adds the OpAsmInterface for components, to allow explicit names for block arguments. Since continuous assignments within a component may use both the arguments and results of its parent, I've decided the FIRRTL-like approach is cleaner. This means _all_ ports are listed as block arguments.

Cleanup:
- Just use a single attribute for all port names. Distinguish input ports and output ports by another attribute.