### PR TITLE
[FIRRTL] Update output ports in IMCP lattice

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -505,6 +505,8 @@ void IMConstPropPass::visitConnect(ConnectOp connect) {
     if (!AnnotationSet::get(blockArg).hasDontTouch())
       for (auto userOfResultPort : resultPortToInstanceResultMapping[blockArg])
         mergeLatticeValue(userOfResultPort, srcValue);
+    // Output ports are wire-like and may have users.
+    mergeLatticeValue(connect.dest(), srcValue);
     return;
   }
 


### PR DESCRIPTION
Change IMCP to update output ports and not just _external_ users of
output ports.  Output ports have wire-like semantics and may be read
from as well as written to.

Fixes #1478.
Fixes #1488.