### PR TITLE
[FIRRTL] Infer width from mux sel for known result

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1209,6 +1209,9 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
   // case.
   bool allWidthsKnown = true;
   for (auto result : op->getResults()) {
+    if (auto mux = dyn_cast<MuxPrimOp>(op))
+      if (hasUninferredWidth(mux.sel().getType()))
+        allWidthsKnown = false;
     if (!hasUninferredWidth(result.getType()))
       declareVars(result, op->getLoc());
     else

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -326,6 +326,10 @@ firrtl.circuit "Foo" {
     %1 = firrtl.wire : !firrtl.uint
     %2 = firrtl.wire : !firrtl.uint
     %3 = firrtl.mux(%2, %0, %1) : (!firrtl.uint, !firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    // CHECK: %4 = firrtl.wire : !firrtl.uint<1>
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    %4 = firrtl.wire : !firrtl.uint
+    %5 = firrtl.mux(%4, %c1_ui1, %c1_ui1) : (!firrtl.uint, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
     %c2_ui3 = firrtl.constant 2 : !firrtl.uint<3>
     firrtl.connect %0, %c1_ui2 : !firrtl.uint, !firrtl.uint<2>


### PR DESCRIPTION
Relax short circuit logic inside InferWidths so that a MuxPrimOp still
generates constraints from its select line (which sets a hard
requirement on a 1-bit width) even if the width of the mux result is
already known.

Previously, this would set no constraints derived from the select line if the width was already known. This would cause circuits like the following to have uninferred widths:

```scala
circuit top_mod :
  module top_mod :
    input sel: UInt
    input t: UInt<1>
    input f: UInt<1>
    output out: UInt<1>

    out <= mux(sel, t, f)
```