### PR TITLE
 Add a FIR emitter

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIREmitter.h
+++ b/include/circt/Dialect/FIRRTL/FIREmitter.h
@@ -1,0 +1,29 @@
+//===- FIREmitter.h - FIRRTL dialect to .fir emitter ------------*- C++ -*-===//
+//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Defines the interface to the .fir file emitter.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_FIRRTL_FIREMITTER_H
+#define CIRCT_DIALECT_FIRRTL_FIREMITTER_H
+
+#include "circt/Support/LLVM.h"
+
+namespace circt {
+namespace firrtl {
+
+mlir::LogicalResult exportFIRFile(mlir::ModuleOp module, llvm::raw_ostream &os);
+
+void registerToFIRFileTranslation();
+
+} // namespace firrtl
+} // namespace circt
+
+#endif // CIRCT_DIALECT_FIRRTL_FIREMITTER_H

--- a/include/circt/InitAllTranslations.h
+++ b/include/circt/InitAllTranslations.h
@@ -13,6 +13,7 @@
 
 #include "circt/Dialect/Calyx/CalyxEmitter.h"
 #include "circt/Dialect/ESI/ESIDialect.h"
+#include "circt/Dialect/FIRRTL/FIREmitter.h"
 #include "circt/Dialect/FIRRTL/FIRParser.h"
 #include "circt/Dialect/LLHD/Translation/TranslateToVerilog.h"
 #include "circt/Dialect/MSFT/ExportTcl.h"
@@ -32,6 +33,7 @@ inline void registerAllTranslations() {
     esi::registerESITranslations();
     calyx::registerToCalyxTranslation();
     firrtl::registerFromFIRFileTranslation();
+    firrtl::registerToFIRFileTranslation();
     llhd::registerToVerilogTranslation();
     msft::registerMSFTTclTranslation();
     return true;

--- a/lib/Dialect/FIRRTL/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/CMakeLists.txt
@@ -26,5 +26,6 @@ add_dependencies(circt-headers
   CIRCTFIRRTLCanonicalizationIncGen
   )
 
+add_subdirectory(Export)
 add_subdirectory(Import)
 add_subdirectory(Transforms)

--- a/lib/Dialect/FIRRTL/Export/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Export/CMakeLists.txt
@@ -1,0 +1,8 @@
+file(GLOB globbed *.cpp)
+
+add_circt_translation_library(CIRCTExportFIRRTL
+  ${globbed}
+  LINK_LIBS PUBLIC
+  CIRCTFIRRTL
+  MLIRTranslation
+)

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -1,0 +1,643 @@
+//===- FIREmitter.cpp - FIRRTL dialect to .fir emitter --------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This implements a .fir file emitter.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/FIRRTL/FIREmitter.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Translation.h"
+#include "llvm/ADT/APSInt.h"
+#include "llvm/ADT/StringSet.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "export-firrtl"
+
+using namespace circt;
+using namespace firrtl;
+
+//===----------------------------------------------------------------------===//
+// Emitter
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// An emitter for FIRRTL dialect operations to .fir output.
+struct Emitter {
+  Emitter(llvm::raw_ostream &os) : os(os) {}
+  LogicalResult finalize();
+
+  // Indentation
+  raw_ostream &indent() { return os.indent(currentIndent); }
+  void addIndent() { currentIndent += 2; }
+  void reduceIndent() {
+    assert(currentIndent >= 2);
+    currentIndent -= 2;
+  }
+
+  // Circuit/module emission
+  void emitCircuit(CircuitOp op);
+  void emitModule(FModuleOp op);
+  void emitModule(FExtModuleOp op);
+  void emitModulePorts(ArrayRef<ModulePortInfo> ports,
+                       Block::BlockArgListType arguments = {});
+
+  // Statement emission
+  void emitStatementsInBlock(Block &block);
+  void emitStatement(WhenOp op, bool noIndent = false);
+  void emitStatement(WireOp op);
+  void emitStatement(RegOp op);
+  void emitStatement(RegResetOp op);
+  void emitStatement(NodeOp op);
+  void emitStatement(StopOp op);
+  void emitStatement(SkipOp op);
+  void emitStatement(PrintFOp op);
+  void emitStatement(ConnectOp op);
+  void emitStatement(PartialConnectOp op);
+  void emitStatement(InstanceOp op);
+  void emitStatement(AttachOp op);
+  // TODO: Handle MemoryPortOp
+  // TODO: Handle CMemOp
+  // TODO: Handle MemOp
+  // TODO: Handle SMemOp
+
+  template <class T>
+  void emitVerifStatement(T op, StringRef mnemonic);
+  void emitStatement(AssertOp op) { emitVerifStatement(op, "assert"); }
+  void emitStatement(AssumeOp op) { emitVerifStatement(op, "assume"); }
+  void emitStatement(CoverOp op) { emitVerifStatement(op, "cover"); }
+
+  // Exprsesion emission
+  void emitExpression(Value value);
+  void emitExpression(ConstantOp op);
+  void emitExpression(SpecialConstantOp op);
+  void emitExpression(SubfieldOp op);
+  void emitExpression(SubindexOp op);
+  void emitExpression(SubaccessOp op);
+
+  void emitPrimExpr(StringRef mnemonic, Operation *op,
+                    ArrayRef<uint32_t> attrs = {});
+
+  void emitExpression(BitsPrimOp op) {
+    emitPrimExpr("bits", op, {op.hi(), op.lo()});
+  }
+  void emitExpression(HeadPrimOp op) { emitPrimExpr("head", op, op.amount()); }
+  void emitExpression(TailPrimOp op) { emitPrimExpr("tail", op, op.amount()); }
+  void emitExpression(PadPrimOp op) { emitPrimExpr("pad", op, op.amount()); }
+  void emitExpression(ShlPrimOp op) { emitPrimExpr("shl", op, op.amount()); }
+  void emitExpression(ShrPrimOp op) { emitPrimExpr("shr", op, op.amount()); }
+
+  // Funnel all ops without attrs into `emitPrimExpr`.
+#define HANDLE(OPTYPE, MNEMONIC)                                               \
+  void emitExpression(OPTYPE op) { emitPrimExpr(MNEMONIC, op); }
+  HANDLE(AddPrimOp, "add");
+  HANDLE(SubPrimOp, "sub");
+  HANDLE(MulPrimOp, "mul");
+  HANDLE(DivPrimOp, "div");
+  HANDLE(RemPrimOp, "rem");
+  HANDLE(AndPrimOp, "and");
+  HANDLE(OrPrimOp, "or");
+  HANDLE(XorPrimOp, "xor");
+  HANDLE(LEQPrimOp, "leq");
+  HANDLE(LTPrimOp, "lt");
+  HANDLE(GEQPrimOp, "geq");
+  HANDLE(GTPrimOp, "gt");
+  HANDLE(EQPrimOp, "eq");
+  HANDLE(NEQPrimOp, "neq");
+  HANDLE(CatPrimOp, "cat");
+  HANDLE(DShlPrimOp, "dshl");
+  HANDLE(DShlwPrimOp, "dshlw");
+  HANDLE(DShrPrimOp, "dshr");
+  HANDLE(MuxPrimOp, "mux");
+  HANDLE(AsSIntPrimOp, "asSInt");
+  HANDLE(AsUIntPrimOp, "asUInt");
+  HANDLE(AsAsyncResetPrimOp, "asAsyncReset");
+  HANDLE(AsClockPrimOp, "asClock");
+  HANDLE(CvtPrimOp, "cvt");
+  HANDLE(NegPrimOp, "neg");
+  HANDLE(NotPrimOp, "not");
+  HANDLE(AndRPrimOp, "andr");
+  HANDLE(OrRPrimOp, "orr");
+  HANDLE(XorRPrimOp, "xorr");
+#undef HANDLE
+
+  // Types
+  void emitType(FIRRTLType type);
+
+  // Locations
+  void emitLocation(Location loc);
+  void emitLocation(Operation *op) { emitLocation(op->getLoc()); }
+  template <typename... Args>
+  void emitLocationAndNewLine(Args... args) {
+    emitLocation(args...);
+    os << "\n";
+  }
+
+private:
+  /// Emit an error and remark that emission failed.
+  InFlightDiagnostic emitError(Operation *op, const Twine &message) {
+    encounteredError = true;
+    return op->emitError(message);
+  }
+
+  /// Emit an error and remark that emission failed.
+  InFlightDiagnostic emitOpError(Operation *op, const Twine &message) {
+    encounteredError = true;
+    return op->emitOpError(message);
+  }
+
+  /// Return the name used during emission of a `Value`, or none if the value
+  /// has not yet been emitted or it was emitted inline.
+  Optional<StringRef> lookupEmittedName(Value value) {
+    auto it = valueNames.find(value);
+    if (it != valueNames.end())
+      return {it->second};
+    return {};
+  }
+
+private:
+  /// The stream we are emitting into.
+  llvm::raw_ostream &os;
+
+  /// Whether we have encountered any errors during emission.
+  bool encounteredError = false;
+
+  /// Current level of indentation. See `indent()` and
+  /// `addIndent()`/`reduceIndent()`.
+  unsigned currentIndent = 0;
+
+  /// The names used to emit values already encountered. Anything that gets a
+  /// name in the output FIR is listed here, such that future expressions can
+  /// reference it.
+  DenseMap<Value, StringRef> valueNames;
+  StringSet<> valueNamesStorage;
+
+  void addValueName(Value value, StringAttr attr) {
+    valueNames.insert({value, attr.getValue()});
+  }
+  void addValueName(Value value, StringRef str) {
+    auto it = valueNamesStorage.insert(str);
+    valueNames.insert({value, it.first->getKey()});
+  }
+};
+} // namespace
+
+LogicalResult Emitter::finalize() { return failure(encounteredError); }
+
+/// Emit an entire circuit.
+void Emitter::emitCircuit(CircuitOp op) {
+  indent() << "circuit " << op.name() << " :\n";
+  addIndent();
+  for (auto &bodyOp : *op.getBody()) {
+    if (encounteredError)
+      return;
+    TypeSwitch<Operation *>(&bodyOp)
+        .Case<FModuleOp, FExtModuleOp>([&](auto op) {
+          emitModule(op);
+          os << "\n";
+        })
+        .Default([&](auto op) {
+          emitOpError(op, "not supported for emission inside circuit");
+        });
+  }
+  reduceIndent();
+}
+
+/// Emit an entire module.
+void Emitter::emitModule(FModuleOp op) {
+  indent() << "module " << op.getName() << " :\n";
+  addIndent();
+
+  // Emit the ports.
+  auto ports = op.getPorts();
+  emitModulePorts(ports, op.getArguments());
+  if (!ports.empty() && !op.getBodyBlock()->empty())
+    os << "\n";
+
+  // Emit the module body.
+  emitStatementsInBlock(*op.getBodyBlock());
+
+  reduceIndent();
+  valueNames.clear();
+  valueNamesStorage.clear();
+}
+
+/// Emit an external module.
+void Emitter::emitModule(FExtModuleOp op) {
+  indent() << "extmodule " << op.getName() << " :\n";
+  addIndent();
+
+  // Emit the ports.
+  auto ports = op.getPorts();
+  emitModulePorts(ports);
+
+  // Emit the optional `defname`.
+  if (op.defname() && !op.defname()->empty())
+    indent() << "defname = " << op.defname() << "\n";
+
+  // Emit the parameters.
+  if (auto params = op.parameters()) {
+    for (auto param : *params) {
+      indent() << "parameter " << param.first << " = ";
+      TypeSwitch<Attribute>(param.second)
+          .Case<IntegerAttr>([&](auto attr) { os << attr.getValue(); })
+          .Case<FloatAttr>([&](auto attr) {
+            SmallString<16> str;
+            attr.getValue().toString(str);
+            os << str;
+          })
+          .Case<StringAttr>([&](auto attr) {
+            os << "\"";
+            os.write_escaped(attr.getValue());
+            os << "\"";
+          })
+          .Default([&](auto attr) {
+            emitOpError(op, "with unsupported parameter attribute: ") << attr;
+            os << "<unsupported-attr " << attr << ">";
+          });
+      os << "\n";
+    }
+  }
+
+  reduceIndent();
+}
+
+/// Emit the ports of a module or extmodule. If the `arguments` array is
+/// non-empty, it is used to populate `emittedNames` with the port names for use
+/// during expression emission.
+void Emitter::emitModulePorts(ArrayRef<ModulePortInfo> ports,
+                              Block::BlockArgListType arguments) {
+  for (unsigned i = 0, e = ports.size(); i < e; ++i) {
+    const auto &port = ports[i];
+    indent() << (port.direction == Direction::Input ? "input " : "output ");
+    if (!arguments.empty())
+      addValueName(arguments[i], port.name);
+    os << port.name.getValue() << " : ";
+    emitType(port.type);
+    os << "\n";
+  }
+}
+
+/// Check if an operation is inlined into the emission of their users. For
+/// example, subfields are always inlined.
+static bool isEmittedInline(Operation *op) { return isExpression(op); }
+
+void Emitter::emitStatementsInBlock(Block &block) {
+  for (auto &bodyOp : block) {
+    if (encounteredError)
+      return;
+    if (isEmittedInline(&bodyOp))
+      continue;
+    TypeSwitch<Operation *>(&bodyOp)
+        .Case<WhenOp, WireOp, RegOp, RegResetOp, NodeOp, StopOp, SkipOp,
+              PrintFOp, AssertOp, AssumeOp, CoverOp, ConnectOp,
+              PartialConnectOp, InstanceOp, AttachOp>(
+            [&](auto op) { emitStatement(op); })
+        .Default([&](auto op) {
+          indent() << "// operation " << op->getName() << "\n";
+          emitOpError(op, "not supported as statement");
+        });
+  }
+}
+
+void Emitter::emitStatement(WhenOp op, bool noIndent) {
+  (noIndent ? os : indent()) << "when ";
+  emitExpression(op.condition());
+  os << " :";
+  emitLocationAndNewLine(op);
+  addIndent();
+  emitStatementsInBlock(op.getThenBlock());
+  reduceIndent();
+  if (!op.hasElseRegion())
+    return;
+
+  indent() << "else ";
+  // Sugar to `else when ...` if there's only a single when statement in the
+  // else block.
+  auto &elseBlock = op.getElseBlock();
+  if (!elseBlock.empty() && &elseBlock.front() == &elseBlock.back()) {
+    if (auto whenOp = dyn_cast<WhenOp>(&elseBlock.front())) {
+      emitStatement(whenOp, true);
+      return;
+    }
+  }
+  // Otherwise print the block as `else :`.
+  os << ":\n";
+  addIndent();
+  emitStatementsInBlock(elseBlock);
+  reduceIndent();
+}
+
+void Emitter::emitStatement(WireOp op) {
+  addValueName(op, op.nameAttr());
+  indent() << "wire " << op.name() << " : ";
+  emitType(op.getType());
+  emitLocationAndNewLine(op);
+}
+
+void Emitter::emitStatement(RegOp op) {
+  addValueName(op, op.nameAttr());
+  indent() << "reg " << op.name() << " : ";
+  emitType(op.getType());
+  os << ", ";
+  emitExpression(op.clockVal());
+  emitLocationAndNewLine(op);
+}
+
+void Emitter::emitStatement(RegResetOp op) {
+  addValueName(op, op.nameAttr());
+  indent() << "reg " << op.name() << " : ";
+  emitType(op.getType());
+  os << ", ";
+  emitExpression(op.clockVal());
+  os << " with :\n";
+  indent() << "  reset => (";
+  emitExpression(op.resetSignal());
+  os << ", ";
+  emitExpression(op.resetValue());
+  os << ")";
+  emitLocationAndNewLine(op);
+}
+
+void Emitter::emitStatement(NodeOp op) {
+  addValueName(op, op.nameAttr());
+  indent() << "node " << op.name() << " = ";
+  emitExpression(op.input());
+  emitLocationAndNewLine(op);
+}
+
+void Emitter::emitStatement(StopOp op) {
+  indent() << "stop(";
+  emitExpression(op.clock());
+  os << ", ";
+  emitExpression(op.cond());
+  os << ", " << op.exitCode() << ")";
+  if (!op.name().empty()) {
+    os << " : " << op.name();
+  }
+  emitLocationAndNewLine(op);
+}
+
+void Emitter::emitStatement(SkipOp op) {
+  indent() << "skip";
+  emitLocationAndNewLine(op);
+}
+
+void Emitter::emitStatement(PrintFOp op) {
+  indent() << "printf(";
+  emitExpression(op.clock());
+  os << ", ";
+  emitExpression(op.cond());
+  os << ", \"";
+  os.write_escaped(op.formatString());
+  os << "\"";
+  for (auto operand : op.operands()) {
+    os << ", ";
+    emitExpression(operand);
+  }
+  os << ")";
+  if (!op.name().empty()) {
+    os << " : " << op.name();
+  }
+  emitLocationAndNewLine(op);
+}
+
+template <class T>
+void Emitter::emitVerifStatement(T op, StringRef mnemonic) {
+  indent() << mnemonic << "(";
+  emitExpression(op.clock());
+  os << ", ";
+  emitExpression(op.predicate());
+  os << ", ";
+  emitExpression(op.enable());
+  os << ", \"";
+  os.write_escaped(op.message());
+  os << "\"";
+  os << ")";
+  if (!op.name().empty()) {
+    os << " : " << op.name();
+  }
+  emitLocationAndNewLine(op);
+}
+
+void Emitter::emitStatement(ConnectOp op) {
+  indent();
+  emitExpression(op.dest());
+  if (op.src().getDefiningOp<InvalidValueOp>()) {
+    os << " is invalid";
+  } else {
+    os << " <= ";
+    emitExpression(op.src());
+  }
+  emitLocationAndNewLine(op);
+}
+
+void Emitter::emitStatement(PartialConnectOp op) {
+  indent();
+  emitExpression(op.dest());
+  // TODO: Check if partial connects can also encode `<dest> is invalid`.
+  os << " <- ";
+  emitExpression(op.src());
+  emitLocationAndNewLine(op);
+}
+
+void Emitter::emitStatement(InstanceOp op) {
+  indent() << "inst " << op.name() << " of " << op.moduleName();
+  emitLocationAndNewLine(op);
+
+  // Make sure we have a name like `<inst>.<port>` for each of the instance
+  // result values.
+  SmallString<16> portName(op.name());
+  portName.push_back('.');
+  unsigned baseLen = portName.size();
+  auto modulePorts = op.getReferencedModule().getPorts();
+  for (unsigned i = 0, e = op.getNumResults(); i < e; ++i) {
+    portName.append(modulePorts[i].name.getValue());
+    addValueName(op.getResult(i), portName);
+    portName.resize(baseLen);
+  }
+}
+
+void Emitter::emitStatement(AttachOp op) {
+  indent() << "attach(";
+  llvm::interleaveComma(op.getOperands(), os,
+                        [&](auto operand) { emitExpression(operand); });
+  os << ")";
+  emitLocationAndNewLine(op);
+}
+
+void Emitter::emitExpression(Value value) {
+  // Handle the trivial case where we already have a name for this value which
+  // we can use.
+  if (auto name = lookupEmittedName(value)) {
+    os << name;
+    return;
+  }
+
+  auto op = value.getDefiningOp();
+  assert(op && "value must either be a block arg or the result of an op");
+  TypeSwitch<Operation *>(op)
+      .Case<
+          // Basic expressions
+          ConstantOp, SpecialConstantOp, SubfieldOp, SubindexOp, SubaccessOp,
+          // Binary
+          AddPrimOp, SubPrimOp, MulPrimOp, DivPrimOp, RemPrimOp, AndPrimOp,
+          OrPrimOp, XorPrimOp, LEQPrimOp, LTPrimOp, GEQPrimOp, GTPrimOp,
+          EQPrimOp, NEQPrimOp, CatPrimOp, DShlPrimOp, DShlwPrimOp, DShrPrimOp,
+          // Unary
+          AsSIntPrimOp, AsUIntPrimOp, AsAsyncResetPrimOp, AsClockPrimOp,
+          CvtPrimOp, NegPrimOp, NotPrimOp, AndRPrimOp, OrRPrimOp, XorRPrimOp,
+          // Miscellaneous
+          BitsPrimOp, HeadPrimOp, TailPrimOp, PadPrimOp, MuxPrimOp, ShlPrimOp,
+          ShrPrimOp>([&](auto op) { emitExpression(op); })
+      .Default([&](auto op) {
+        emitOpError(op, "not supported as expression");
+        os << "<unsupported-expr-" << op->getName().stripDialect() << ">";
+      });
+}
+
+void Emitter::emitExpression(ConstantOp op) {
+  emitType(op.getType());
+  // TODO: Add option to control base-2/8/10/16 output here.
+  os << "(" << op.value() << ")";
+}
+
+void Emitter::emitExpression(SpecialConstantOp op) {
+  auto emitInner = [&]() { os << "UInt<1>(" << op.value() << ")"; };
+  TypeSwitch<FIRRTLType>(op.getType().cast<FIRRTLType>())
+      .Case<ClockType>([&](auto type) {
+        os << "asClock(";
+        emitInner();
+        os << ")";
+      })
+      .Case<ResetType>([&](auto type) { emitInner(); })
+      .Case<AsyncResetType>([&](auto type) {
+        os << "asAsyncReset(";
+        emitInner();
+        os << ")";
+      });
+}
+
+void Emitter::emitExpression(SubfieldOp op) {
+  auto type = op.input().getType().cast<BundleType>();
+  emitExpression(op.input());
+  os << "." << type.getElementName(op.fieldIndex());
+}
+
+void Emitter::emitExpression(SubindexOp op) {
+  emitExpression(op.input());
+  os << "[" << op.index() << "]";
+}
+
+void Emitter::emitExpression(SubaccessOp op) {
+  emitExpression(op.input());
+  os << "[";
+  emitExpression(op.index());
+  os << "]";
+}
+
+void Emitter::emitPrimExpr(StringRef mnemonic, Operation *op,
+                           ArrayRef<uint32_t> attrs) {
+  os << mnemonic << "(";
+  llvm::interleaveComma(op->getOperands(), os,
+                        [&](Value arg) { emitExpression(arg); });
+  for (auto attr : attrs)
+    os << ", " << attr;
+  os << ")";
+}
+
+/// Emit a FIRRTL type into the output.
+void Emitter::emitType(FIRRTLType type) {
+  auto emitWidth = [&](Optional<int32_t> width) {
+    if (!width.hasValue())
+      return;
+    os << "<" << *width << ">";
+  };
+  TypeSwitch<FIRRTLType>(type)
+      .Case<ClockType>([&](auto) { os << "Clock"; })
+      .Case<ResetType>([&](auto) { os << "Reset"; })
+      .Case<AsyncResetType>([&](auto) { os << "AsyncReset"; })
+      .Case<UIntType>([&](auto type) {
+        os << "UInt";
+        emitWidth(type.getWidth());
+      })
+      .Case<SIntType>([&](auto type) {
+        os << "SInt";
+        emitWidth(type.getWidth());
+      })
+      .Case<AnalogType>([&](auto type) {
+        os << "Analog";
+        emitWidth(type.getWidth());
+      })
+      .Case<BundleType>([&](auto type) {
+        os << "{";
+        bool anyEmitted = false;
+        for (auto &element : type.getElements()) {
+          os << (anyEmitted ? ", " : " ");
+          if (element.isFlip)
+            os << "flip ";
+          os << element.name.getValue() << " : ";
+          emitType(element.type);
+          anyEmitted = true;
+        }
+        if (anyEmitted)
+          os << " ";
+        os << "}";
+      })
+      .Case<FVectorType>([&](auto type) {
+        emitType(type.getElementType());
+        os << "[" << type.getNumElements() << "]";
+      })
+      .Default([&](auto type) {
+        llvm_unreachable("all types should be implemented");
+      });
+}
+
+/// Emit a location as `@[<filename> <line>:<column>]` annotation, including a
+/// leading space.
+void Emitter::emitLocation(Location loc) {
+  // TODO: Handle FusedLoc and uniquify locations, avoid repeated file names.
+  if (auto fileLoc = loc->dyn_cast_or_null<FileLineColLoc>()) {
+    os << " @[" << fileLoc.getFilename();
+    if (auto line = fileLoc.getLine()) {
+      os << " " << line;
+      if (auto col = fileLoc.getColumn())
+        os << ":" << col;
+    }
+    os << "]";
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Driver
+//===----------------------------------------------------------------------===//
+
+// Emit the specified FIRRTL circuit into the given output stream.
+mlir::LogicalResult circt::firrtl::exportFIRFile(mlir::ModuleOp module,
+                                                 llvm::raw_ostream &os) {
+  Emitter emitter(os);
+  for (auto &op : *module.getBody()) {
+    if (auto circuitOp = dyn_cast<CircuitOp>(op))
+      emitter.emitCircuit(circuitOp);
+  }
+  return emitter.finalize();
+}
+
+void circt::firrtl::registerToFIRFileTranslation() {
+  static mlir::TranslateFromMLIRRegistration toFIR(
+      "export-firrtl",
+      [](ModuleOp module, llvm::raw_ostream &os) {
+        return exportFIRFile(module, os);
+      },
+      [](mlir::DialectRegistry &registry) {
+        registry.insert<firrtl::FIRRTLDialect>();
+      });
+}

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -1,0 +1,269 @@
+// RUN: circt-translate --export-firrtl --verify-diagnostics %s -o %t
+// RUN: cat %t | FileCheck %s --strict-whitespace
+// RUN: circt-translate --import-firrtl %t --mlir-print-debuginfo | circt-translate --export-firrtl | diff - %t
+
+// CHECK-LABEL: circuit Foo :
+firrtl.circuit "Foo" {
+  // CHECK-LABEL: module Foo :
+  firrtl.module @Foo() {}
+
+  // CHECK-LABEL: module PortsAndTypes :
+  firrtl.module @PortsAndTypes(
+    // CHECK-NEXT: input a00 : Clock
+    // CHECK-NEXT: input a01 : Reset
+    // CHECK-NEXT: input a02 : AsyncReset
+    // CHECK-NEXT: input a03 : UInt
+    // CHECK-NEXT: input a04 : SInt
+    // CHECK-NEXT: input a05 : Analog
+    // CHECK-NEXT: input a06 : UInt<42>
+    // CHECK-NEXT: input a07 : SInt<42>
+    // CHECK-NEXT: input a08 : Analog<42>
+    // CHECK-NEXT: input a09 : { a : UInt, flip b : UInt }
+    // CHECK-NEXT: input a10 : UInt[42]
+    // CHECK-NEXT: output b0 : UInt
+    in %a00: !firrtl.clock,
+    in %a01: !firrtl.reset,
+    in %a02: !firrtl.asyncreset,
+    in %a03: !firrtl.uint,
+    in %a04: !firrtl.sint,
+    in %a05: !firrtl.analog,
+    in %a06: !firrtl.uint<42>,
+    in %a07: !firrtl.sint<42>,
+    in %a08: !firrtl.analog<42>,
+    in %a09: !firrtl.bundle<a: uint, b flip: uint>,
+    in %a10: !firrtl.vector<uint, 42>,
+    out %b0: !firrtl.uint
+  ) {}
+
+  // CHECK-LABEL: module Simple :
+  // CHECK:         input someIn : UInt<1>
+  // CHECK:         output someOut : UInt<1>
+  firrtl.module @Simple(in %someIn: !firrtl.uint<1>, out %someOut: !firrtl.uint<1>) {
+    firrtl.skip
+  }
+
+  // CHECK-LABEL: module Statements :
+  firrtl.module @Statements(in %ui1: !firrtl.uint<1>, in %someClock: !firrtl.clock, in %someReset: !firrtl.reset, out %someOut: !firrtl.uint<1>) {
+    // CHECK: when ui1 :
+    // CHECK:   skip
+    firrtl.when %ui1 {
+      firrtl.skip
+    }
+    // CHECK: when ui1 :
+    // CHECK:   skip
+    // CHECK: else :
+    // CHECK:   skip
+    firrtl.when %ui1 {
+      firrtl.skip
+    } else {
+      firrtl.skip
+    }
+    // CHECK: when ui1 :
+    // CHECK:   skip
+    // CHECK: else when ui1 :
+    // CHECK:   skip
+    firrtl.when %ui1 {
+      firrtl.skip
+    } else {
+      firrtl.when %ui1 {
+        firrtl.skip
+      }
+    }
+    // CHECK: wire someWire : UInt<1>
+    %someWire = firrtl.wire : !firrtl.uint<1>
+    // CHECK: reg someReg : UInt<1>, someClock
+    %someReg = firrtl.reg %someClock : !firrtl.uint<1>
+    // CHECK: reg someReg2 : UInt<1>, someClock with :
+    // CHECK:   reset => (someReset, ui1)
+    %someReg2 = firrtl.regreset %someClock, %someReset, %ui1 : !firrtl.reset, !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK: node someNode = ui1
+    %someNode = firrtl.node %ui1 : !firrtl.uint<1>
+    // CHECK: stop(someClock, ui1, 42) : foo
+    firrtl.stop %someClock, %ui1, 42 {name = "foo"}
+    // CHECK: skip
+    firrtl.skip
+    // CHECK: printf(someClock, ui1, "some\n magic\"stuff\"", ui1, someReset) : foo
+    firrtl.printf %someClock, %ui1, "some\n magic\"stuff\"" {name = "foo"} (%ui1, %someReset) : !firrtl.uint<1>, !firrtl.reset
+    // CHECK: assert(someClock, ui1, ui1, "msg") : foo
+    // CHECK: assume(someClock, ui1, ui1, "msg") : foo
+    // CHECK: cover(someClock, ui1, ui1, "msg") : foo
+    firrtl.assert %someClock, %ui1, %ui1, "msg" {name = "foo"}
+    firrtl.assume %someClock, %ui1, %ui1, "msg" {name = "foo"}
+    firrtl.cover %someClock, %ui1, %ui1, "msg" {name = "foo"}
+    // CHECK: someOut <= ui1
+    // CHECK: someOut <- ui1
+    firrtl.connect %someOut, %ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.partialconnect %someOut, %ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK: inst someInst of Simple
+    // CHECK: someInst.someIn <= ui1
+    // CHECK: someOut <= someInst.someOut
+    %someInst_someIn, %someInst_someOut = firrtl.instance @Simple {name = "someInst"} : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %someInst_someIn, %ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %someOut, %someInst_someOut : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK: someOut is invalid
+    %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
+    firrtl.connect %someOut, %invalid_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK: attach(an0, an1)
+    %an0 = firrtl.wire : !firrtl.analog<1>
+    %an1 = firrtl.wire : !firrtl.analog<1>
+    firrtl.attach %an0, %an1 : !firrtl.analog<1>, !firrtl.analog<1>
+
+    // CHECK: node k0 = UInt<19>(42)
+    // CHECK: node k1 = SInt<19>(42)
+    // CHECK: node k2 = UInt(42)
+    // CHECK: node k3 = SInt(42)
+    %0 = firrtl.constant 42 : !firrtl.uint<19>
+    %1 = firrtl.constant 42 : !firrtl.sint<19>
+    %2 = firrtl.constant 42 : !firrtl.uint
+    %3 = firrtl.constant 42 : !firrtl.sint
+    %k0 = firrtl.node %0 : !firrtl.uint<19>
+    %k1 = firrtl.node %1 : !firrtl.sint<19>
+    %k2 = firrtl.node %2 : !firrtl.uint
+    %k3 = firrtl.node %3 : !firrtl.sint
+
+    // CHECK: node k4 = asClock(UInt<1>(0))
+    // CHECK: node k5 = asAsyncReset(UInt<1>(0))
+    // CHECK: node k6 = UInt<1>(0)
+    %4 = firrtl.specialconstant 0 : !firrtl.clock
+    %5 = firrtl.specialconstant 0 : !firrtl.asyncreset
+    %6 = firrtl.specialconstant 0 : !firrtl.reset
+    %k4 = firrtl.node %4 : !firrtl.clock
+    %k5 = firrtl.node %5 : !firrtl.asyncreset
+    %k6 = firrtl.node %6 : !firrtl.reset
+
+    // CHECK: wire bundle : { a : UInt, flip b : UInt }
+    // CHECK: wire vector : UInt[42]
+    // CHECK: node subfield = bundle.a
+    // CHECK: node subindex = vector[19]
+    // CHECK: node subaccess = vector[ui1]
+    %bundle = firrtl.wire : !firrtl.bundle<a: uint, b flip: uint>
+    %vector = firrtl.wire : !firrtl.vector<uint, 42>
+    %subfield_tmp = firrtl.subfield %bundle(0) : (!firrtl.bundle<a: uint, b flip: uint>) -> !firrtl.uint
+    %subindex_tmp = firrtl.subindex %vector[19] : !firrtl.vector<uint, 42>
+    %subaccess_tmp = firrtl.subaccess %vector[%ui1] : !firrtl.vector<uint, 42>, !firrtl.uint<1>
+    %subfield = firrtl.node %subfield_tmp : !firrtl.uint
+    %subindex = firrtl.node %subindex_tmp : !firrtl.uint
+    %subaccess = firrtl.node %subaccess_tmp : !firrtl.uint
+
+    %x = firrtl.node %2 : !firrtl.uint
+    %y = firrtl.node %2 : !firrtl.uint
+
+    // CHECK: node addPrimOp = add(x, y)
+    // CHECK: node subPrimOp = sub(x, y)
+    // CHECK: node mulPrimOp = mul(x, y)
+    // CHECK: node divPrimOp = div(x, y)
+    // CHECK: node remPrimOp = rem(x, y)
+    // CHECK: node andPrimOp = and(x, y)
+    // CHECK: node orPrimOp = or(x, y)
+    // CHECK: node xorPrimOp = xor(x, y)
+    // CHECK: node leqPrimOp = leq(x, y)
+    // CHECK: node ltPrimOp = lt(x, y)
+    // CHECK: node geqPrimOp = geq(x, y)
+    // CHECK: node gtPrimOp = gt(x, y)
+    // CHECK: node eqPrimOp = eq(x, y)
+    // CHECK: node neqPrimOp = neq(x, y)
+    // CHECK: node catPrimOp = cat(x, y)
+    // CHECK: node dShlPrimOp = dshl(x, y)
+    // CHECK: node dShlwPrimOp = dshlw(x, y)
+    // CHECK: node dShrPrimOp = dshr(x, y)
+    %addPrimOp_tmp = firrtl.add %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %subPrimOp_tmp = firrtl.sub %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %mulPrimOp_tmp = firrtl.mul %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %divPrimOp_tmp = firrtl.div %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %remPrimOp_tmp = firrtl.rem %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %andPrimOp_tmp = firrtl.and %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %orPrimOp_tmp = firrtl.or %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %xorPrimOp_tmp = firrtl.xor %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %leqPrimOp_tmp = firrtl.leq %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+    %ltPrimOp_tmp = firrtl.lt %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+    %geqPrimOp_tmp = firrtl.geq %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+    %gtPrimOp_tmp = firrtl.gt %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+    %eqPrimOp_tmp = firrtl.eq %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+    %neqPrimOp_tmp = firrtl.neq %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+    %catPrimOp_tmp = firrtl.cat %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %dShlPrimOp_tmp = firrtl.dshl %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %dShlwPrimOp_tmp = firrtl.dshlw %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %dShrPrimOp_tmp = firrtl.dshr %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %addPrimOp = firrtl.node %addPrimOp_tmp : !firrtl.uint
+    %subPrimOp = firrtl.node %subPrimOp_tmp : !firrtl.uint
+    %mulPrimOp = firrtl.node %mulPrimOp_tmp : !firrtl.uint
+    %divPrimOp = firrtl.node %divPrimOp_tmp : !firrtl.uint
+    %remPrimOp = firrtl.node %remPrimOp_tmp : !firrtl.uint
+    %andPrimOp = firrtl.node %andPrimOp_tmp : !firrtl.uint
+    %orPrimOp = firrtl.node %orPrimOp_tmp : !firrtl.uint
+    %xorPrimOp = firrtl.node %xorPrimOp_tmp : !firrtl.uint
+    %leqPrimOp = firrtl.node %leqPrimOp_tmp : !firrtl.uint<1>
+    %ltPrimOp = firrtl.node %ltPrimOp_tmp : !firrtl.uint<1>
+    %geqPrimOp = firrtl.node %geqPrimOp_tmp : !firrtl.uint<1>
+    %gtPrimOp = firrtl.node %gtPrimOp_tmp : !firrtl.uint<1>
+    %eqPrimOp = firrtl.node %eqPrimOp_tmp : !firrtl.uint<1>
+    %neqPrimOp = firrtl.node %neqPrimOp_tmp : !firrtl.uint<1>
+    %catPrimOp = firrtl.node %catPrimOp_tmp : !firrtl.uint
+    %dShlPrimOp = firrtl.node %dShlPrimOp_tmp : !firrtl.uint
+    %dShlwPrimOp = firrtl.node %dShlwPrimOp_tmp : !firrtl.uint
+    %dShrPrimOp = firrtl.node %dShrPrimOp_tmp : !firrtl.uint
+
+    // CHECK: node asSIntPrimOp = asSInt(x)
+    // CHECK: node asUIntPrimOp = asUInt(x)
+    // CHECK: node asAsyncResetPrimOp = asAsyncReset(x)
+    // CHECK: node asClockPrimOp = asClock(x)
+    // CHECK: node cvtPrimOp = cvt(x)
+    // CHECK: node negPrimOp = neg(x)
+    // CHECK: node notPrimOp = not(x)
+    // CHECK: node andRPrimOp = andr(x)
+    // CHECK: node orRPrimOp = orr(x)
+    // CHECK: node xorRPrimOp = xorr(x)
+    %asSIntPrimOp_tmp = firrtl.asSInt %x : (!firrtl.uint) -> !firrtl.sint
+    %asUIntPrimOp_tmp = firrtl.asUInt %x : (!firrtl.uint) -> !firrtl.uint
+    %asAsyncResetPrimOp_tmp = firrtl.asAsyncReset %x : (!firrtl.uint) -> !firrtl.asyncreset
+    %asClockPrimOp_tmp = firrtl.asClock %x : (!firrtl.uint) -> !firrtl.clock
+    %cvtPrimOp_tmp = firrtl.cvt %x : (!firrtl.uint) -> !firrtl.sint
+    %negPrimOp_tmp = firrtl.neg %x : (!firrtl.uint) -> !firrtl.sint
+    %notPrimOp_tmp = firrtl.not %x : (!firrtl.uint) -> !firrtl.uint
+    %andRPrimOp_tmp = firrtl.andr %x : (!firrtl.uint) -> !firrtl.uint<1>
+    %orRPrimOp_tmp = firrtl.orr %x : (!firrtl.uint) -> !firrtl.uint<1>
+    %xorRPrimOp_tmp = firrtl.xorr %x : (!firrtl.uint) -> !firrtl.uint<1>
+    %asSIntPrimOp = firrtl.node %asSIntPrimOp_tmp : !firrtl.sint
+    %asUIntPrimOp = firrtl.node %asUIntPrimOp_tmp : !firrtl.uint
+    %asAsyncResetPrimOp = firrtl.node %asAsyncResetPrimOp_tmp : !firrtl.asyncreset
+    %asClockPrimOp = firrtl.node %asClockPrimOp_tmp : !firrtl.clock
+    %cvtPrimOp = firrtl.node %cvtPrimOp_tmp : !firrtl.sint
+    %negPrimOp = firrtl.node %negPrimOp_tmp : !firrtl.sint
+    %notPrimOp = firrtl.node %notPrimOp_tmp : !firrtl.uint
+    %andRPrimOp = firrtl.node %andRPrimOp_tmp : !firrtl.uint<1>
+    %orRPrimOp = firrtl.node %orRPrimOp_tmp : !firrtl.uint<1>
+    %xorRPrimOp = firrtl.node %xorRPrimOp_tmp : !firrtl.uint<1>
+
+    // CHECK: node bitsPrimOp = bits(x, 4, 2)
+    // CHECK: node headPrimOp = head(x, 4)
+    // CHECK: node tailPrimOp = tail(x, 4)
+    // CHECK: node padPrimOp = pad(x, 16)
+    // CHECK: node muxPrimOp = mux(ui1, x, y)
+    // CHECK: node shlPrimOp = shl(x, 4)
+    // CHECK: node shrPrimOp = shr(x, 4)
+    %bitsPrimOp_tmp = firrtl.bits %x 4 to 2 : (!firrtl.uint) -> !firrtl.uint<3>
+    %headPrimOp_tmp = firrtl.head %x, 4 : (!firrtl.uint) -> !firrtl.uint<4>
+    %tailPrimOp_tmp = firrtl.tail %x, 4 : (!firrtl.uint) -> !firrtl.uint
+    %padPrimOp_tmp = firrtl.pad %x, 16 : (!firrtl.uint) -> !firrtl.uint
+    %muxPrimOp_tmp = firrtl.mux(%ui1, %x, %y) : (!firrtl.uint<1>, !firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %shlPrimOp_tmp = firrtl.shl %x, 4 : (!firrtl.uint) -> !firrtl.uint
+    %shrPrimOp_tmp = firrtl.shr %x, 4 : (!firrtl.uint) -> !firrtl.uint
+    %bitsPrimOp = firrtl.node %bitsPrimOp_tmp : !firrtl.uint<3>
+    %headPrimOp = firrtl.node %headPrimOp_tmp : !firrtl.uint<4>
+    %tailPrimOp = firrtl.node %tailPrimOp_tmp : !firrtl.uint
+    %padPrimOp = firrtl.node %padPrimOp_tmp : !firrtl.uint
+    %muxPrimOp = firrtl.node %muxPrimOp_tmp : !firrtl.uint
+    %shlPrimOp = firrtl.node %shlPrimOp_tmp : !firrtl.uint
+    %shrPrimOp = firrtl.node %shrPrimOp_tmp : !firrtl.uint
+  }
+
+  firrtl.extmodule @MyParameterizedExtModule(in %in: !firrtl.uint, out %out: !firrtl.uint<8>) attributes {defname = "name_thing", parameters = {DEFAULT = 0 : i64, DEPTH = 3.242000e+01 : f64, FORMAT = "xyz_timeout=%d\0A", WIDTH = 32 : i8}}
+  // CHECK-LABEL: extmodule MyParameterizedExtModule :
+  // CHECK-NEXT:    input in : UInt
+  // CHECK-NEXT:    output out : UInt<8>
+  // CHECK-NEXT:    defname = name_thing
+  // CHECK-NEXT:    parameter DEFAULT = 0
+  // CHECK-NEXT:    parameter DEPTH = 32.42
+  // CHECK-NEXT:    parameter FORMAT = "xyz_timeout=%d\n"
+  // CHECK-NEXT:    parameter WIDTH = 32
+}


### PR DESCRIPTION
Add an emitter to export FIRRTL dialect as a .fir file. This is a first shot at such an emitter, with no output formatting options and no opinion on output code quality. Expressions for example are all simply emitted inline, which can lead to some rather nasty nesting and repetition. Supports pretty much all FIRRTL ops that the `FIRParser` would generate, except `MemoryPortOp`, `CMemOp`, `MemOp`, and `SMemOp`.

This came out of a quick hacking sprint towards a FIR reduction and register/wire isolation tool to facilitate debugging.

Tests need expansion, but quite a few real-world FIR extracts round-trip through `circt-translate --import-firrtl | circt-translate --export-firrtl` with only whitespace/int-literal-base differences.

Fixes #454.