### PR TITLE
[CMake] Ensure the build directory for generated Python exists.

### DIFF
--- a/integration_test/Bindings/Python/dialects/esi.py
+++ b/integration_test/Bindings/Python/dialects/esi.py
@@ -8,7 +8,6 @@ from circt.esi import types
 from circt.dialects import hw
 
 from mlir.ir import *
-from mlir.dialects import builtin
 
 from os import path
 import sys

--- a/lib/Bindings/Python/CMakeLists.txt
+++ b/lib/Bindings/Python/CMakeLists.txt
@@ -116,7 +116,6 @@ add_mlir_python_common_capi_library(CIRCTBindingsPythonCAPI
   RELATIVE_INSTALL_ROOT "../../../.."
   DECLARED_SOURCES
     MLIRPythonSources.Core
-    MLIRPythonExtension.AllPassesRegistration
     CIRCTBindingsPythonSources
     CIRCTBindingsPythonExtension
 )
@@ -130,7 +129,6 @@ add_mlir_python_modules(CIRCTMLIRPythonModules
   INSTALL_PREFIX "python_packages/circt_core/mlir"
   DECLARED_SOURCES
     MLIRPythonSources.Core
-    MLIRPythonExtension.AllPassesRegistration
     # We need the circt extensions co-located with the MLIR extensions. When
     # the namespace is unified, this moves to the below.
     CIRCTBindingsPythonExtension

--- a/lib/Bindings/Python/CMakeLists.txt
+++ b/lib/Bindings/Python/CMakeLists.txt
@@ -53,6 +53,11 @@ declare_mlir_python_sources(CIRCTBindingsPythonSources
 ################################################################################
 # Declare dialect-specific bindings.
 ################################################################################
+
+# Ensure the build directory for generated Python files exists. Ninja is able to
+# generate this, but make does not and the build fails.
+file(MAKE_DIRECTORY ${CIRCT_BINARY_DIR}/lib/Bindings/Python/circt/dialects)
+
 declare_mlir_python_sources(CIRCTBindingsPythonSources.Dialects
   ADD_TO_PARENT CIRCTBindingsPythonSources)
 

--- a/lib/Bindings/Python/CMakeLists.txt
+++ b/lib/Bindings/Python/CMakeLists.txt
@@ -115,8 +115,7 @@ add_mlir_python_common_capi_library(CIRCTBindingsPythonCAPI
   OUTPUT_DIRECTORY "${CIRCT_PYTHON_PACKAGES_DIR}/circt_core/mlir/_mlir_libs"
   RELATIVE_INSTALL_ROOT "../../../.."
   DECLARED_SOURCES
-    # TODO: This can be chopped down significantly for size.
-    MLIRPythonSources
+    MLIRPythonSources.Core
     MLIRPythonExtension.AllPassesRegistration
     CIRCTBindingsPythonSources
     CIRCTBindingsPythonExtension
@@ -130,7 +129,7 @@ add_mlir_python_modules(CIRCTMLIRPythonModules
   ROOT_PREFIX "${CIRCT_PYTHON_PACKAGES_DIR}/circt_core/mlir"
   INSTALL_PREFIX "python_packages/circt_core/mlir"
   DECLARED_SOURCES
-    MLIRPythonSources
+    MLIRPythonSources.Core
     MLIRPythonExtension.AllPassesRegistration
     # We need the circt extensions co-located with the MLIR extensions. When
     # the namespace is unified, this moves to the below.


### PR DESCRIPTION
Ninja is able to generate this, but make does not, and the build
fails.