### PR TITLE
[FIRRTL] Add tests from RemoveResetSpec.scala, apply fixes

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -32,6 +32,14 @@ def KnownWidth : Constraint<CPred<[{
     $0.getType().cast<FIRRTLType>().getBitWidthOrSentinel() >= 0
   }]>>;
 
+/// Constraint that matches a zero ConstantOp or SpecialConstantOp.
+def ZeroConstantOp : Constraint<Or<[
+  CPred<"$0.getDefiningOp<ConstantOp>() &&"
+        "$0.getDefiningOp<ConstantOp>().value().isNullValue()">,
+  CPred<"$0.getDefiningOp<SpecialConstantOp>() &&"
+        "$0.getDefiningOp<SpecialConstantOp>().value() == false">
+]>>;
+
 // leq(const, x) -> geq(x, const)
 def LEQWithConstLHS : Pat<
   (LEQPrimOp (ConstantOp:$lhs $_), $rhs),
@@ -91,8 +99,7 @@ def RegresetWithInvalidResetValue : Pat<
 
 // regreset(clock, constant_zero, resetValue) -> reg(clock)
 def RegresetWithZeroReset : Pat<
-  (RegResetOp $clock, (SpecialConstantOp ConstBoolAttrFalse), $resetValue,
-   $name, $annotations),
-  (RegOp $clock, $name, $annotations)>;
+  (RegResetOp $clock, $reset, $resetValue, $name, $annotations),
+  (RegOp $clock, $name, $annotations), [(ZeroConstantOp $reset)]>;
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLCANONICALIZATION_TD

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -1789,19 +1789,4 @@ firrtl.module @dshifts_to_ishifts(in %a_in: !firrtl.sint<58>,
   firrtl.connect %c_out, %2 : !firrtl.sint<58>, !firrtl.sint<58>
 }
 
-// RemoveReset: `firrtl.invalidvalue` reset values should be canonicalized to a
-// reset-less register.
-// CHECK-LABEL: firrtl.module @StripInvalidValueReset
-firrtl.module @StripInvalidValueReset(
-  in %clk: !firrtl.clock,
-  in %rst: !firrtl.uint<1>,
-  in %arst: !firrtl.asyncreset
-) {
-  %invalid_ui42 = firrtl.invalidvalue : !firrtl.uint<42>
-  // CHECK: %0 = firrtl.reg %clk : (!firrtl.clock) -> !firrtl.uint<42>
-  // CHECK: %1 = firrtl.reg %clk : (!firrtl.clock) -> !firrtl.uint<42>
-  %0 = firrtl.regreset %clk, %rst, %invalid_ui42 : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<42>) -> !firrtl.uint<42>
-  %1 = firrtl.regreset %clk, %arst, %invalid_ui42 : (!firrtl.clock, !firrtl.asyncreset, !firrtl.uint<42>) -> !firrtl.uint<42>
-}
-
 }

--- a/test/Dialect/FIRRTL/remove-reset.mlir
+++ b/test/Dialect/FIRRTL/remove-reset.mlir
@@ -1,0 +1,126 @@
+// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-lower-types,firrtl-imconstprop),canonicalize' %s | FileCheck %s
+// Tests extracted from:
+// - test/scala/firrtlTests/transforms/RemoveResetSpec.scala
+
+firrtl.circuit "Foo" {
+firrtl.module @Foo() {}
+
+// Should not generate a reset mux for an invalid init.
+// CHECK-LABEL: firrtl.module @NoMuxForInvalid
+firrtl.module @NoMuxForInvalid(
+  in %clk: !firrtl.clock,
+  in %rst: !firrtl.reset,
+  in %arst: !firrtl.asyncreset,
+  in %srst: !firrtl.uint<1>
+) {
+  // CHECK: %foo0 = firrtl.reg %clk :
+  // CHECK: %foo1 = firrtl.reg %clk :
+  // CHECK: %foo2 = firrtl.reg %clk :
+  %invalid_ui42 = firrtl.invalidvalue : !firrtl.uint<42>
+  %foo0 = firrtl.regreset %clk, %rst, %invalid_ui42 : (!firrtl.clock, !firrtl.reset, !firrtl.uint<42>) -> !firrtl.uint<42>
+  %foo1 = firrtl.regreset %clk, %arst, %invalid_ui42 : (!firrtl.clock, !firrtl.asyncreset, !firrtl.uint<42>) -> !firrtl.uint<42>
+  %foo2 = firrtl.regreset %clk, %srst, %invalid_ui42 : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<42>) -> !firrtl.uint<42>
+}
+
+// Should not generate a reset mux for an invalid init.
+// CHECK-LABEL: firrtl.module @NoMuxForInvalidWire
+firrtl.module @NoMuxForInvalidWire(
+  in %clk: !firrtl.clock,
+  in %rst: !firrtl.reset,
+  in %arst: !firrtl.asyncreset,
+  in %srst: !firrtl.uint<1>
+) {
+  // CHECK: %foo0 = firrtl.reg %clk :
+  // CHECK: %foo1 = firrtl.reg %clk :
+  // CHECK: %foo2 = firrtl.reg %clk :
+  %bar = firrtl.wire  : !firrtl.uint<42>
+  %invalid_ui42 = firrtl.invalidvalue : !firrtl.uint<42>
+  firrtl.connect %bar, %invalid_ui42 : !firrtl.uint<42>, !firrtl.uint<42>
+  %foo0 = firrtl.regreset %clk, %rst, %bar : (!firrtl.clock, !firrtl.reset, !firrtl.uint<42>) -> !firrtl.uint<42>
+  %foo1 = firrtl.regreset %clk, %arst, %bar : (!firrtl.clock, !firrtl.asyncreset, !firrtl.uint<42>) -> !firrtl.uint<42>
+  %foo2 = firrtl.regreset %clk, %srst, %bar : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<42>) -> !firrtl.uint<42>
+}
+
+// Should generate a reset mux for only the portion of an invalid aggregate that
+// is reset.
+// CHECK-LABEL: firrtl.module @PartiallyNoMuxInAggregate
+firrtl.module @PartiallyNoMuxInAggregate(
+  in %clk: !firrtl.clock,
+  in %rst: !firrtl.reset,
+  in %arst: !firrtl.asyncreset,
+  in %srst: !firrtl.uint<1>
+) {
+  %invalid = firrtl.invalidvalue : !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<1>>
+  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+
+  %bar = firrtl.wire : !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<1>>
+
+  firrtl.connect %bar, %invalid : !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<1>>, !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<1>>
+  %0 = firrtl.subfield %bar(0) : (!firrtl.bundle<a: vector<uint<1>, 2>, b: uint<1>>) -> !firrtl.vector<uint<1>, 2>
+  %1 = firrtl.subindex %0[1] : !firrtl.vector<uint<1>, 2>
+  firrtl.connect %1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+
+  // CHECK: %foo0_a_0 = firrtl.reg %clk :
+  // CHECK: %foo0_a_1 = firrtl.regreset %clk, %rst, %bar_a_1 :
+  // CHECK: %foo0_b = firrtl.reg %clk :
+  // CHECK: %foo1_a_0 = firrtl.reg %clk :
+  // CHECK: %foo1_a_1 = firrtl.regreset %clk, %arst, %bar_a_1 :
+  // CHECK: %foo1_b = firrtl.reg %clk :
+  // CHECK: %foo2_a_0 = firrtl.reg %clk :
+  // CHECK: %foo2_a_1 = firrtl.regreset %clk, %srst, %bar_a_1 :
+  // CHECK: %foo2_b = firrtl.reg %clk :
+  %foo0 = firrtl.regreset %clk, %rst, %bar  : (!firrtl.clock, !firrtl.reset, !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<1>>) -> !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<1>>
+  %foo1 = firrtl.regreset %clk, %arst, %bar  : (!firrtl.clock, !firrtl.asyncreset, !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<1>>) -> !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<1>>
+  %foo2 = firrtl.regreset %clk, %srst, %bar  : (!firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<1>>) -> !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<1>>
+}
+
+// Should propagate invalidations across connects.
+// CHECK-LABEL: firrtl.module @PropagateInvalidAcrossConnects
+firrtl.module @PropagateInvalidAcrossConnects(
+  in %clk: !firrtl.clock,
+  in %rst: !firrtl.reset,
+  in %arst: !firrtl.asyncreset,
+  in %srst: !firrtl.uint<1>
+) {
+  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+  %invalid = firrtl.invalidvalue : !firrtl.bundle<a: uint<1>, b: uint<1>>
+
+  %bar = firrtl.wire : !firrtl.bundle<a: uint<1>, b: uint<1>>
+  %baz = firrtl.wire : !firrtl.bundle<a: uint<1>, b: uint<1>>
+
+  firrtl.connect %bar, %invalid : !firrtl.bundle<a: uint<1>, b: uint<1>>, !firrtl.bundle<a: uint<1>, b: uint<1>>
+  %bar_a = firrtl.subfield %bar(0) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
+  firrtl.connect %bar_a, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+
+  firrtl.connect %baz, %invalid : !firrtl.bundle<a: uint<1>, b: uint<1>>, !firrtl.bundle<a: uint<1>, b: uint<1>>
+  firrtl.connect %baz, %bar : !firrtl.bundle<a: uint<1>, b: uint<1>>, !firrtl.bundle<a: uint<1>, b: uint<1>>
+
+  // CHECK: %foo0_a = firrtl.regreset %clk, %rst, %bar_a :
+  // CHECK: %foo0_b = firrtl.reg %clk :
+  // CHECK: %foo1_a = firrtl.regreset %clk, %arst, %bar_a :
+  // CHECK: %foo1_b = firrtl.reg %clk :
+  // CHECK: %foo2_a = firrtl.regreset %clk, %srst, %bar_a :
+  // CHECK: %foo2_b = firrtl.reg %clk :
+  %foo0 = firrtl.regreset %clk, %rst, %bar  : (!firrtl.clock, !firrtl.reset, !firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
+  %foo1 = firrtl.regreset %clk, %arst, %bar  : (!firrtl.clock, !firrtl.asyncreset, !firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
+  %foo2 = firrtl.regreset %clk, %srst, %bar  : (!firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
+}
+
+// Should convert a reset wired to UInt(0) to a canonical non-reset.
+// CHECK-LABEL: firrtl.module @TreatUInt0ResetAsNonReset
+firrtl.module @TreatUInt0ResetAsNonReset(
+  in %clk: !firrtl.clock
+) {
+  %rst = firrtl.specialconstant 0 : !firrtl.reset
+  %arst = firrtl.specialconstant 0 : !firrtl.asyncreset
+  %srst = firrtl.constant 0 : !firrtl.uint<1>
+  %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
+  // CHECK: %foo0 = firrtl.reg %clk :
+  // CHECK: %foo1 = firrtl.reg %clk :
+  // CHECK: %foo2 = firrtl.reg %clk :
+  %foo0 = firrtl.regreset %clk, %rst, %c3_ui2  : (!firrtl.clock, !firrtl.reset, !firrtl.uint<2>) -> !firrtl.uint<2>
+  %foo1 = firrtl.regreset %clk, %arst, %c3_ui2  : (!firrtl.clock, !firrtl.asyncreset, !firrtl.uint<2>) -> !firrtl.uint<2>
+  %foo2 = firrtl.regreset %clk, %srst, %c3_ui2  : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<2>) -> !firrtl.uint<2>
+}
+
+}


### PR DESCRIPTION
Port the Scala FIRRTL test cases from `RemoveResetSpec.scala`. Fix a regression in the canonicalizer where the switch to `specialconstant` removed a fold for `uint<1>` resets of cosntant `0`.