### PR TITLE
[PyCDE] Refactor `pycde.System` to take a list of modules

### DIFF
--- a/frontends/PyCDE/src/pycde/module.py
+++ b/frontends/PyCDE/src/pycde/module.py
@@ -72,9 +72,10 @@ class module:
     if inspect.isclass(func_or_class):
       # If it's just a module class, we should wrap it immediately
       self.mod = _module_base(func_or_class, extern_name is not None)
-      _register_generator(self.mod.__name__, "extern_instantiate",
-                          self._instantiate,
-                          mlir.ir.DictAttr.get(self.mod._parameters))
+      if extern_name is not None:
+        _register_generator(self.mod.__name__, "extern_instantiate",
+                            self._instantiate,
+                            mlir.ir.DictAttr.get(self.mod._parameters))
       return
     elif not inspect.isfunction(func_or_class):
       raise TypeError("@module got invalid object")
@@ -343,6 +344,11 @@ class _Generate:
   necessary logic to build an HWModule."""
 
   def __init__(self, gen_func):
+    sig = inspect.signature(gen_func)
+    if len(sig.parameters) != 1:
+      raise ValueError(
+          "Generate functions must take one argument and do not support 'self'."
+      )
     self.gen_func = gen_func
     self.modcls = None
     self.loc = get_user_loc()

--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -10,6 +10,8 @@ import mlir.ir
 import mlir.passmanager
 
 import circt
+import circt.support
+from circt.dialects import hw
 
 import sys
 import typing
@@ -24,26 +26,35 @@ class System:
   ]
   passed = False
 
-  def __init__(self):
+  def __init__(self, modules=[]):
+    self.modules = modules
     if not hasattr(self, "name"):
-      self.name = "top"
+      self.name = "__pycde_temp_top"
 
     self.mod = mlir.ir.Module.create()
-    self.get_types()
+    self.system_mod = None
+
+    self.build()
+
+  def build(self):
+    if self.system_mod is not None:
+      return
 
     with mlir.ir.InsertionPoint(self.mod.body):
-      self.declare_externs()
-      ModuleDefinition(modcls=None,
-                       name=self.name,
-                       input_ports=self.inputs,
-                       output_ports=self.outputs,
-                       body_builder=self.build)
+      self.system_mod = ModuleDefinition(modcls=None,
+                                         name=self.name,
+                                         input_ports=[],
+                                         output_ports=[])
 
-  def declare_externs(self):
-    pass
-
-  def get_types(self):
-    pass
+    # Add the module body. Don't use the `body_builder` to avoid using the
+    # `BackedgeBuilder` it creates.
+    bb = circt.support.BackedgeBuilder()
+    with mlir.ir.InsertionPoint(self.system_mod.add_entry_block()), bb:
+      self.mod_ops = set([m().operation.name for m in self.modules])
+      hw.OutputOp([])
+      # We don't care about the backedges since this module is supposed to be
+      # temporary.
+      bb.edges.clear()
 
   @property
   def body(self):
@@ -62,6 +73,12 @@ class System:
     pm = mlir.passmanager.PassManager.parse("run-generators{generators=" +
                                             ",".join(generator_names) + "}")
     pm.run(self.mod)
+    if self.system_mod is None:
+      return
+    sys_mod_block = self.system_mod.operation.regions[0].blocks[0]
+    if all([op.operation.name not in self.mod_ops for op in sys_mod_block]):
+      self.system_mod.operation.erase()
+      self.system_mod = None
 
   def run_passes(self):
     if self.passed:

--- a/frontends/PyCDE/test/compreg.py
+++ b/frontends/PyCDE/test/compreg.py
@@ -1,21 +1,25 @@
 # RUN: %PYTHON% %s | FileCheck %s
 
 import pycde
-from pycde import types
+from pycde import types, module, Input, Output
 
 from circt.dialects import seq
+from pycde.module import generator
 
+@module
+class CompReg:
+  clk = Input(types.i1)
+  input = Input(types.i8)
+  output = Output(types.i8)
 
-class CompReg(pycde.System):
-  inputs = [("clk", types.i1), ("input", types.i8)]
-  outputs = [("output", types.i8)]
-
-  def build(self, top):
-    compreg = seq.CompRegOp.create(types.i8, clk=top.clk, input=top.input)
+  @generator
+  def build(mod):
+    compreg = seq.CompRegOp.create(types.i8, clk=mod.clk, input=mod.input)
     return {"output": compreg.data}
 
 
-mod = CompReg()
+mod = pycde.System([CompReg])
+mod.generate()
 mod.print_verilog()
 
 # CHECK: reg [7:0] [[NAME:.+]];

--- a/frontends/PyCDE/test/generator_options.py
+++ b/frontends/PyCDE/test/generator_options.py
@@ -17,26 +17,18 @@ class GeneratorOptions:
     hw.ConstantOp.create(types.i32, 2)
 
 
-class Top(System):
-  inputs = []
-  outputs = []
-
-  def build(self, top):
-    GeneratorOptions()
-
-
 # CHECK: hw.constant 1
-top1 = Top()
+top1 = System([GeneratorOptions])
 top1.generate(["generator_a"])
 top1.print()
 
 # CHECK: hw.constant 2
-top2 = Top()
+top2 = System([GeneratorOptions])
 top2.generate(["generator_b"])
 top2.print()
 
 # CHECK: generator exception
-top3 = Top()
+top3 = System([GeneratorOptions])
 try:
   top3.generate()
 except RuntimeError:
@@ -44,7 +36,7 @@ except RuntimeError:
   pass
 
 # CHECK: generator exception
-top4 = Top()
+top4 = System([GeneratorOptions])
 try:
   top4.generate(["generator_a", "generator_b"])
 except RuntimeError:
@@ -52,7 +44,7 @@ except RuntimeError:
   pass
 
 # CHECK: generator exception
-top5 = Top()
+top5 = System([GeneratorOptions])
 try:
   top5.generate(["nonexistant"])
 except RuntimeError:

--- a/frontends/PyCDE/test/module_naming.py
+++ b/frontends/PyCDE/test/module_naming.py
@@ -28,11 +28,13 @@ class UnParameterized:
     return {"y": mod.x}
 
 
-class Test(pycde.System):
+@pycde.module
+class Test:
   inputs = []
   outputs = []
 
-  def build(self, top):
+  @pycde.generator
+  def build(_):
     c1 = circt.dialects.hw.ConstantOp.create(pycde.types.i1, 1)
     Parameterized(1)(x=c1)
     Parameterized(1)(x=c1)
@@ -48,6 +50,7 @@ class Test(pycde.System):
 # CHECK-NOT: hw.module @pycde.Module_2
 # CHECK: hw.module @pycde.UnParameterized
 # CHECK-NOT: hw.module @pycde.UnParameterized
-t = Test()
+t = pycde.System([Test])
+t.generate()
 t.generate(["construct"])
 t.print()

--- a/frontends/PyCDE/test/polynomial.py
+++ b/frontends/PyCDE/test/polynomial.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import mlir
-
 import pycde
 from pycde import (Input, Output, Parameter, module, externmodule, generator,
                    types, dim)
@@ -75,11 +73,12 @@ class Coefficients:
     self.coeff = coeff
 
 
-class Polynomial(pycde.System):
-  inputs = []
-  outputs = [('y', types.i32)]
+@module
+class PolynomialSystem:
+  y = Output(types.i32)
 
-  def build(self, top):
+  @generator
+  def construct(_):
     i32 = types.i32
     x = hw.ConstantOp.create(i32, 23)
     poly = PolynomialCompute(Coefficients([62, 42, 6]))("example")
@@ -93,22 +92,26 @@ class Polynomial(pycde.System):
     return {"y": poly.y}
 
 
-poly = Polynomial()
+poly = pycde.System([PolynomialSystem])
+
+print("Generating 1...")
+poly.generate()
 
 print("Printing...")
 poly.print()
-# CHECK-LABEL:  hw.module @top() -> (%y: i32)
+# CHECK-LABEL:  hw.module @pycde.PolynomialSystem() -> (%y: i32)
 # CHECK:    [[REG0:%.+]] = "pycde.PolynomialCompute"(%c23_i32) {instanceName = "example", opNames = ["x"], parameters = {coefficients = {coeff = [62, 42, 6]}, module_name = "PolyComputeForCoeff_62_42_6", unused_parameter = true}, resultNames = ["y"]} : (i32) -> i32
 # CHECK:    [[REG1:%.+]] = "pycde.PolynomialCompute"([[REG0]]) {instanceName = "example2", opNames = ["x"], parameters = {coefficients = {coeff = [62, 42, 6]}, module_name = "PolyComputeForCoeff_62_42_6", unused_parameter = true}, resultNames = ["y"]} : (i32) -> i32
 # CHECK:    [[REG2:%.+]] = "pycde.PolynomialCompute"([[REG0]]) {instanceName = "example2", opNames = ["x"], parameters = {coefficients = {coeff = [1, 2, 3, 4, 5]}, module_name = "PolyComputeForCoeff_1_2_3_4_5", unused_parameter = true}, resultNames = ["y"]} : (i32) -> i32
 # CHECK:    [[REG3:%.+]] = "pycde.CoolPolynomialCompute"(%c23_i32{{.*}}) {coefficients = [4, 42], opNames = ["x"], parameters = {}, resultNames = ["y"]} : (i32) -> i32
 # CHECK:    hw.output [[REG0]] : i32
 
-print("Generating...")
+print("Generating 2...")
 poly.generate()
+
 print("Printing...")
 poly.print()
-# CHECK-LABEL: hw.module @top
+# CHECK-LABEL: hw.module @pycde.PolynomialSystem
 # CHECK: %example.y = hw.instance "example" @PolyComputeForCoeff_62_42_6(%c23_i32) {parameters = {}} : (i32) -> i32
 # CHECK: %example2.y = hw.instance "example2" @PolyComputeForCoeff_62_42_6(%example.y) {parameters = {}} : (i32) -> i32
 # CHECK: %example2.y_0 = hw.instance "example2" @PolyComputeForCoeff_1_2_3_4_5(%example.y) {parameters = {}} : (i32) -> i32

--- a/frontends/PyCDE/test/syntactic_sugar.py
+++ b/frontends/PyCDE/test/syntactic_sugar.py
@@ -18,26 +18,29 @@ class StupidLegacy:
   ignore = Input(dim(1, 4))
 
 
-class Top(System):
-  BarType = types.struct({"foo": types.i12}, "bar")
-  inputs = []
-  outputs = []
+BarType = types.struct({"foo": types.i12}, "bar")
 
-  def build(self, top):
+
+@module
+class Top:
+
+  @generator
+  def build(_):
     obj_to_value({"foo": 7}, types.struct({"foo": types.i12}))
     obj_to_value([42, 45], dim(types.i8, 2))
     obj_to_value(5, types.i8)
 
-    Top.BarType.create({"foo": 7})
+    BarType.create({"foo": 7})
 
     Taps()
     StupidLegacy(ignore=no_connect)
 
 
-top = Top()
+top = System([Top])
+top.generate()
 top.generate(["build"])
 top.print()
-# CHECK-LABEL: hw.module @top()
+# CHECK-LABEL: hw.module @pycde.Top()
 # CHECK:  %c7_i12 = hw.constant 7 : i12
 # CHECK:  %0 = hw.struct_create (%c7_i12) : !hw.struct<foo: i12>
 # CHECK:  %c42_i8 = hw.constant 42 : i8

--- a/lib/Dialect/MSFT/MSFTGenerator.cpp
+++ b/lib/Dialect/MSFT/MSFTGenerator.cpp
@@ -42,7 +42,8 @@ LogicalResult OpGenerator::runOnOperation(mlir::Operation *op,
   if (generators.size() == 0)
     return failure();
   if (generators.size() > 1 && generatorSet.size() < 1)
-    return op->emitError("at least one generator must be selected");
+    return op->emitError(op->getName().getStringRef())
+           << " at least one generator must be selected";
 
   // Check if any of the generators were selected in the generator set. If more
   // than one candidate is present in the generator set, raise an error.


### PR DESCRIPTION
The old `System` was a clone of ESI's `System`. This is more like what one wants out of pycde.