### PR TITLE
[FIRRTL] Correct, Document Invalid Behavior

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -40,6 +40,10 @@ def ZeroConstantOp : Constraint<Or<[
         "$0.getDefiningOp<SpecialConstantOp>().value() == false">
 ]>>;
 
+def IsInvalid : Constraint<
+  CPred<"$0.getDefiningOp<InvalidValueOp>()">
+>;
+
 // leq(const, x) -> geq(x, const)
 def LEQWithConstLHS : Pat<
   (LEQPrimOp (ConstantOp:$lhs $_), $rhs),
@@ -101,5 +105,34 @@ def RegresetWithInvalidResetValue : Pat<
 def RegresetWithZeroReset : Pat<
   (RegResetOp $clock, $reset, $resetValue, $name, $annotations),
   (RegOp $clock, $name, $annotations), [(ZeroConstantOp $reset)]>;
+
+// Return the width of an operation result as an integer attribute.  This is
+// useful to pad another operation up to the width of the original operation.
+def GetWidthAsIntAttr : NativeCodeCall<
+  "IntegerAttr::get(IntegerType::get($_builder.getContext(), 32, IntegerType::Signless), "
+                    "$0.getType().cast<FIRRTLType>().getBitWidthOrSentinel())">;
+
+// add(x, invalid) -> pad(x, width)
+//
+// This is legal because it aligns with the Scala FIRRTL Compiler
+// interpretation of lowering invalid to constant zero before constant
+// propagation.
+def AddWithInvalidOp : Pat<
+  (AddPrimOp:$result $x, $y),
+  (PadPrimOp $x, (GetWidthAsIntAttr $result)), [
+    (KnownWidth $x), (IsInvalid $y)
+  ]>;
+
+// sub(x, invalid) -> pad(x, width)
+//
+// This is legal because it aligns with the Scala FIRRTL Compiler
+// interpretation of lowering invalid to constant zero before constant
+// propagation.
+def SubWithInvalidOp : Pat<
+  (SubPrimOp:$result $x, $y),
+  (PadPrimOp $x, (GetWidthAsIntAttr $result)), [
+    (KnownWidth $x), (IsInvalid $y)
+  ]>;
+
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLCANONICALIZATION_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -292,9 +292,12 @@ class IntBinaryPrimOp<string mnemonic, Type resultType,
                 traits # [SameOperandsIntTypeKind]>;
 
 let inferType = "impl::inferAddSubResult" in {
-  def AddPrimOp : IntBinaryPrimOp<"add", IntType, [Commutative]>;
-  def SubPrimOp : IntBinaryPrimOp<"sub", IntType>;
+  let hasCanonicalizer = true in {
+    def AddPrimOp : IntBinaryPrimOp<"add", IntType, [Commutative]>;
+    def SubPrimOp : IntBinaryPrimOp<"sub", IntType>;
+  }
 }
+
 def MulPrimOp : IntBinaryPrimOp<"mul", IntType, [Commutative]>;
 def DivPrimOp : IntBinaryPrimOp<"div", IntType> {
   let description = [{

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -53,7 +53,7 @@ static IntegerAttr getIntZerosAttr(Type type) {
 
 /// Return an IntegerAttr filled with ones for the specified FIRRTL integer
 /// type.  This handles both the known width and unknown width case.
-static IntegerAttr getIntOnesAttr(Type type) {
+[[maybe_unused]] static IntegerAttr getIntOnesAttr(Type type) {
   int32_t width = abs(type.cast<IntType>().getWidthOrSentinel());
   if (width == 0)
     return {};
@@ -222,46 +222,49 @@ OpFoldResult InvalidValueOp::fold(ArrayRef<Attribute> operands) {
 OpFoldResult AddPrimOp::fold(ArrayRef<Attribute> operands) {
   /// Any folding here requires a bitwidth extension.
 
-  // add(x, invalid) -> invalid
-  if (operands[1].dyn_cast_or_null<InvalidValueAttr>() ||
-      operands[0].dyn_cast_or_null<InvalidValueAttr>())
-    return InvalidValueAttr::get(getType());
-
   /// If both operands are constant, and the result is integer with known
   /// widths, then perform constant folding.
   return constFoldFIRRTLBinaryOp(*this, operands, BinOpKind::Normal,
                                  [=](APSInt a, APSInt b) { return a + b; });
 }
 
-OpFoldResult SubPrimOp::fold(ArrayRef<Attribute> operands) {
-  // sub(x, invalid) -> invalid
-  if (operands[1].dyn_cast_or_null<InvalidValueAttr>() ||
-      operands[0].dyn_cast_or_null<InvalidValueAttr>())
-    return InvalidValueAttr::get(getType());
+void AddPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                            MLIRContext *context) {
+  results.insert<patterns::AddWithInvalidOp>(context);
+}
 
+OpFoldResult SubPrimOp::fold(ArrayRef<Attribute> operands) {
   return constFoldFIRRTLBinaryOp(*this, operands, BinOpKind::Normal,
                                  [=](APSInt a, APSInt b) { return a - b; });
 }
 
+void SubPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                            MLIRContext *context) {
+  results.insert<patterns::SubWithInvalidOp>(context);
+}
+
 OpFoldResult MulPrimOp::fold(ArrayRef<Attribute> operands) {
-  // mul(x, invalid) -> invalid
+  // mul(x, invalid) -> 0
+  //
+  // This is legal because it aligns with the Scala FIRRTL Compiler
+  // interpretation of lowering invalid to constant zero before constant
+  // propagation.  Note: the Scala FIRRTL Compiler does NOT currently optimize
+  // multiplication this way and will emit "x * 0".
   if (operands[1].dyn_cast_or_null<InvalidValueAttr>() ||
       operands[0].dyn_cast_or_null<InvalidValueAttr>())
-    return InvalidValueAttr::get(getType());
+    return getIntZerosAttr(getType());
+
   return constFoldFIRRTLBinaryOp(*this, operands, BinOpKind::Normal,
                                  [=](APSInt a, APSInt b) { return a * b; });
 }
 
 OpFoldResult DivPrimOp::fold(ArrayRef<Attribute> operands) {
-  // div(x, invalid) -> zero
-  if (operands[1].dyn_cast_or_null<InvalidValueAttr>() ||
-      operands[0].dyn_cast_or_null<InvalidValueAttr>())
-    return getIntZerosAttr(getType());
-
   /// div(x, x) -> 1
   ///
-  /// Division by zero is undefined in the FIRRTL specification. This
-  /// fold exploits that fact to optimize self division to one.
+  /// Division by zero is undefined in the FIRRTL specification.  This fold
+  /// exploits that fact to optimize self division to one.  Note: this should
+  /// supersede any division with invalid or zero.  Division of invalid by
+  /// invalid should be one.
   if (lhs() == rhs()) {
     auto width = getType().getWidthOrSentinel();
     if (width == -1)
@@ -269,6 +272,16 @@ OpFoldResult DivPrimOp::fold(ArrayRef<Attribute> operands) {
     if (width != 0)
       return getIntAttr(getType(), APInt(width, 1));
   }
+
+  // div(invalid, x) -> 0
+  //
+  // This is legal because it aligns with the Scala FIRRTL Compiler
+  // interpretation of lowering invalid to constant zero before constant
+  // propagation.  Note: the Scala FIRRTL Compiler does NOT currently optimize
+  // division this way and will emit "0 / x".
+  if (operands[0].dyn_cast_or_null<InvalidValueAttr>() &&
+      !operands[1].dyn_cast_or_null<InvalidValueAttr>())
+    return getIntZerosAttr(getType());
 
   /// div(x, 1) -> x : (uint, uint) -> uint
   ///
@@ -281,9 +294,6 @@ OpFoldResult DivPrimOp::fold(ArrayRef<Attribute> operands) {
 
   return constFoldFIRRTLBinaryOp(*this, operands, BinOpKind::DivideOrShift,
                                  [=](APSInt a, APSInt b) -> APInt {
-                                   // Fold divide by zero to zero.  Would be
-                                   // better to fold it to invalid when we
-                                   // supports this as a constant.
                                    if (!!b)
                                      return a / b;
                                    return APInt(a.getBitWidth(), 0);
@@ -291,16 +301,18 @@ OpFoldResult DivPrimOp::fold(ArrayRef<Attribute> operands) {
 }
 
 OpFoldResult RemPrimOp::fold(ArrayRef<Attribute> operands) {
-  // div(x, invalid) -> zero
-  if (operands[1].dyn_cast_or_null<InvalidValueAttr>() ||
-      operands[0].dyn_cast_or_null<InvalidValueAttr>())
+  // rem(invalid, x) -> 0
+  //
+  // This is legal because it aligns with the Scala FIRRTL Compiler
+  // interpretation of lowering invalid to constant zero before constant
+  // propagation.  Note: the Scala FIRRTL Compiler does NOT currently optimize
+  // division this way and will emit "0 % x".
+  if (operands[0].dyn_cast_or_null<InvalidValueAttr>() &&
+      !operands[1].dyn_cast_or_null<InvalidValueAttr>())
     return getIntZerosAttr(getType());
 
   return constFoldFIRRTLBinaryOp(*this, operands, BinOpKind::DivideOrShift,
                                  [=](APSInt a, APSInt b) -> APInt {
-                                   // Fold divide by zero to zero.  Would be
-                                   // better to fold it to invalid when we
-                                   // supports this as a constant.
                                    if (!!b)
                                      return a % b;
                                    return APInt(a.getBitWidth(), 0);
@@ -330,6 +342,10 @@ OpFoldResult DShrPrimOp::fold(ArrayRef<Attribute> operands) {
 // TODO: Move to DRR.
 OpFoldResult AndPrimOp::fold(ArrayRef<Attribute> operands) {
   // and(x, invalid) -> 0
+  //
+  // This is legal because it aligns with the Scala FIRRTL Compiler
+  // interpretation of lowering invalid to constant zero before constant
+  // propagation.
   if (operands[1].dyn_cast_or_null<InvalidValueAttr>() ||
       operands[0].dyn_cast_or_null<InvalidValueAttr>())
     return getIntZerosAttr(getType());
@@ -355,10 +371,16 @@ OpFoldResult AndPrimOp::fold(ArrayRef<Attribute> operands) {
 }
 
 OpFoldResult OrPrimOp::fold(ArrayRef<Attribute> operands) {
-  // or(x, invalid) -> -1
-  if (operands[1].dyn_cast_or_null<InvalidValueAttr>() ||
-      operands[0].dyn_cast_or_null<InvalidValueAttr>())
-    return getIntOnesAttr(getType());
+  // or(x, invalid) -> x
+  // or(invalid, x) -> x
+  //
+  // This is legal because it aligns with the Scala FIRRTL Compiler
+  // interpretation of lowering invalid to constant zero before constant
+  // propagation.
+  if (operands[0].dyn_cast_or_null<InvalidValueAttr>())
+    return rhs();
+  if (operands[1].dyn_cast_or_null<InvalidValueAttr>())
+    return lhs();
 
   if (auto rhsCst = operands[1].dyn_cast_or_null<IntegerAttr>()) {
     /// or(x, 0) -> x
@@ -381,10 +403,16 @@ OpFoldResult OrPrimOp::fold(ArrayRef<Attribute> operands) {
 }
 
 OpFoldResult XorPrimOp::fold(ArrayRef<Attribute> operands) {
-  // xor(x, invalid) -> invalid
-  if (operands[1].dyn_cast_or_null<InvalidValueAttr>() ||
-      operands[0].dyn_cast_or_null<InvalidValueAttr>())
-    return InvalidValueAttr::get(getType());
+  // xor(x, invalid) -> x
+  // xor(invalid, x) -> x
+  //
+  // This is legal because it aligns with the Scala FIRRTL Compiler
+  // interpretation of lowering invalid to constant zero before constant
+  // propagation.
+  if (operands[0].dyn_cast_or_null<InvalidValueAttr>())
+    return rhs();
+  if (operands[1].dyn_cast_or_null<InvalidValueAttr>())
+    return lhs();
 
   /// xor(x, 0) -> x
   if (auto rhsCst = operands[1].dyn_cast_or_null<IntegerAttr>())
@@ -991,6 +1019,10 @@ static void replaceWithBits(Operation *op, Value value, unsigned hiBit,
 OpFoldResult MuxPrimOp::fold(ArrayRef<Attribute> operands) {
   // mux(cond, x, invalid) -> x
   // mux(cond, invalid, x) -> x
+  //
+  // These are NOT optimizations that the Scala FIRRTL Compiler makes.  However,
+  // these agree with the interpretation of mux with an invalid true of false
+  // condition as a conditionally valid statement.
   if (operands[2].dyn_cast_or_null<InvalidValueAttr>())
     return getOperand(1);
   if (operands[1].dyn_cast_or_null<InvalidValueAttr>())

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -51,15 +51,6 @@ static IntegerAttr getIntZerosAttr(Type type) {
   return getIntAttr(type, APInt(width, 0));
 }
 
-/// Return an IntegerAttr filled with ones for the specified FIRRTL integer
-/// type.  This handles both the known width and unknown width case.
-[[maybe_unused]] static IntegerAttr getIntOnesAttr(Type type) {
-  int32_t width = abs(type.cast<IntType>().getWidthOrSentinel());
-  if (width == 0)
-    return {};
-  return getIntAttr(type, APInt(width, -1ULL, /*isSigned*/ true));
-}
-
 /// Return true if this operation's operands and results all have known width,
 /// or if the result has zero width result (which we cannot constant fold).
 /// This only works for integer types.

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -55,6 +55,7 @@ firrtl.module @Div(in %a: !firrtl.uint<4>,
   // CHECK-DAG: [[ONE_s5:%.+]] = firrtl.constant 1 : !firrtl.sint<5>
   // CHECK-DAG: [[ONE_i2:%.+]] = firrtl.constant 1 : !firrtl.uint
   // CHECK-DAG: [[ONE_s2:%.+]] = firrtl.constant 1 : !firrtl.sint
+  // CHECK-DAG: [[ZERO_i4:%.+]] = firrtl.constant 0 : !firrtl.uint<4>
 
   // Check that 'div(a, a) -> 1' works for known UInt widths.
   // CHECK: firrtl.connect %b, [[ONE_i4]]
@@ -88,6 +89,21 @@ firrtl.module @Div(in %a: !firrtl.uint<4>,
   %5 = firrtl.div %c1_ui4, %c3_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %i, %5 : !firrtl.uint<4>, !firrtl.uint<4>
 
+  // CHECK: firrtl.connect %i, [[ZERO_i4]]
+  %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
+  %6 = firrtl.div %invalid_ui4, %a : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  firrtl.connect %i, %6 : !firrtl.uint<4>, !firrtl.uint<4>
+}
+
+// CHECK-LABEL: @Rem
+firrtl.module @Rem(in %a: !firrtl.uint<4>, out %b: !firrtl.uint<4>) {
+  // CHECK-DAG: %[[ZERO_i4:.+]] = firrtl.constant 0 : !firrtl.uint<4>
+
+  %invalid_i4 = firrtl.invalidvalue : !firrtl.uint<4>
+
+  // CHECK: firrtl.connect %b, %[[ZERO_i4]]
+  %rem = firrtl.rem %invalid_i4, %a : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  firrtl.connect %b, %rem : !firrtl.uint<4>, !firrtl.uint<4>
 }
 
 // CHECK-LABEL: firrtl.module @And
@@ -1494,6 +1510,20 @@ firrtl.module @add_cst_prop3(out %out_b: !firrtl.sint<4>) {
   firrtl.connect %out_b, %add : !firrtl.sint<4>, !firrtl.sint<4>
 }
 
+// CHECK-LABEL: @add_cst_prop4
+// CHECK: %[[pad:.+]] = firrtl.pad %tmp_a, 5
+// CHECK-NEXT: firrtl.connect %out_b, %[[pad]]
+// CHECK-NEXT: %[[pad:.+]] = firrtl.pad %tmp_a, 5
+// CHECK_NEXT: firrtl.connect %out_b, %[[pad]]
+firrtl.module @add_cst_prop4(out %out_b: !firrtl.uint<5>) {
+  %tmp_a = firrtl.wire : !firrtl.uint<4>
+  %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
+  %add = firrtl.add %tmp_a, %invalid_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
+  firrtl.connect %out_b, %add : !firrtl.uint<5>, !firrtl.uint<5>
+  %add2 = firrtl.add %invalid_ui4, %tmp_a : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
+  firrtl.connect %out_b, %add2 : !firrtl.uint<5>, !firrtl.uint<5>
+}
+
 // CHECK-LABEL: @sub_cst_prop1
 // CHECK-NEXT:      %c1_ui9 = firrtl.constant 1 : !firrtl.uint<9>
 // CHECK-NEXT:      firrtl.connect %out_b, %c1_ui9 : !firrtl.uint<9>, !firrtl.uint<9>
@@ -1518,6 +1548,16 @@ firrtl.module @sub_cst_prop2(out %out_b: !firrtl.sint<9>) {
   firrtl.connect %tmp_a, %c6_ui7 : !firrtl.sint<7>, !firrtl.sint<7>
   %add = firrtl.sub %tmp_a, %c5_ui8 : (!firrtl.sint<7>, !firrtl.sint<8>) -> !firrtl.sint<9>
   firrtl.connect %out_b, %add : !firrtl.sint<9>, !firrtl.sint<9>
+}
+
+// CHECK-LABEL: @sub_cst_prop3
+// CHECK: %[[pad:.+]] = firrtl.pad %tmp_a, 5
+// CHECK-NEXT: firrtl.connect %out_b, %[[pad]]
+firrtl.module @sub_cst_prop3(out %out_b: !firrtl.uint<5>) {
+  %tmp_a = firrtl.wire : !firrtl.uint<4>
+  %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
+  %sub = firrtl.sub %tmp_a, %invalid_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
+  firrtl.connect %out_b, %sub : !firrtl.uint<5>, !firrtl.uint<5>
 }
 
 // CHECK-LABEL: @mul_cst_prop1
@@ -1557,6 +1597,19 @@ firrtl.module @mul_cst_prop3(out %out_b: !firrtl.sint<15>) {
   firrtl.connect %tmp_a, %c6_ui7 : !firrtl.sint<7>, !firrtl.sint<7>
   %add = firrtl.mul %tmp_a, %c5_ui8 : (!firrtl.sint<7>, !firrtl.sint<8>) -> !firrtl.sint<15>
   firrtl.connect %out_b, %add : !firrtl.sint<15>, !firrtl.sint<15>
+}
+
+// CHECK-LABEL: @mul_cst_prop4
+// CHECK: %[[zero:.+]] = firrtl.constant 0 : !firrtl.uint<15>
+// CHECK: firrtl.connect %out_b, %[[zero]]
+// CHECK: firrtl.connect %out_b, %[[zero]]
+firrtl.module @mul_cst_prop4(out %out_b: !firrtl.uint<15>) {
+  %tmp_a = firrtl.wire : !firrtl.uint<7>
+  %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<8>
+  %mul = firrtl.mul %tmp_a, %invalid_ui4 : (!firrtl.uint<7>, !firrtl.uint<8>) -> !firrtl.uint<15>
+  firrtl.connect %out_b, %mul : !firrtl.uint<15>, !firrtl.uint<15>
+  %mul2 = firrtl.mul %invalid_ui4, %tmp_a : (!firrtl.uint<8>, !firrtl.uint<7>) -> !firrtl.uint<15>
+  firrtl.connect %out_b, %mul2 : !firrtl.uint<15>, !firrtl.uint<15>
 }
 
 // CHECK-LABEL: firrtl.module @MuxInvalidOpt

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -134,6 +134,15 @@ firrtl.module @And(in %in: !firrtl.uint<4>,
   // CHECK-NEXT: firrtl.connect %out, [[AND]]
   %6 = firrtl.and %sin, %sin : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %6 : !firrtl.uint<4>, !firrtl.uint<4>
+
+  // CHECK: firrtl.connect %out, %c0_ui4
+  %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
+  %7 = firrtl.and %in, %invalid_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  firrtl.connect %out, %7 : !firrtl.uint<4>, !firrtl.uint<4>
+
+  // CHECK: firrtl.connect %out, %c0_ui4
+  %8 = firrtl.and %invalid_ui4, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  firrtl.connect %out, %8 : !firrtl.uint<4>, !firrtl.uint<4>
 }
 
 // CHECK-LABEL: firrtl.module @Or
@@ -171,6 +180,15 @@ firrtl.module @Or(in %in: !firrtl.uint<4>,
   // CHECK-NEXT: firrtl.connect %out, [[OR]]
   %6 = firrtl.or %sin, %sin : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %6 : !firrtl.uint<4>, !firrtl.uint<4>
+
+  // CHECK: firrtl.connect %out, %in
+  %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
+  %7 = firrtl.or %in, %invalid_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  firrtl.connect %out, %7 : !firrtl.uint<4>, !firrtl.uint<4>
+
+  // CHECK: firrtl.connect %out, %in
+  %8 = firrtl.or %invalid_ui4, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  firrtl.connect %out, %8 : !firrtl.uint<4>, !firrtl.uint<4>
 }
 
 // CHECK-LABEL: firrtl.module @Xor
@@ -197,6 +215,15 @@ firrtl.module @Xor(in %in: !firrtl.uint<4>,
   // CHECK: firrtl.connect %out, %c0_ui4
   %6 = firrtl.xor %sin, %sin : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %6 : !firrtl.uint<4>, !firrtl.uint<4>
+
+  // CHECK: firrtl.connect %out, %in
+  %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
+  %7 = firrtl.xor %in, %invalid_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  firrtl.connect %out, %7 : !firrtl.uint<4>, !firrtl.uint<4>
+
+  // CHECK: firrtl.connect %out, %in
+  %8 = firrtl.xor %invalid_ui4, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  firrtl.connect %out, %8 : !firrtl.uint<4>, !firrtl.uint<4>
 }
 
 // CHECK-LABEL: firrtl.module @EQ
@@ -352,6 +379,19 @@ firrtl.module @Mux(in %in: !firrtl.uint<4>,
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   %3 = firrtl.mux (%cond, %c1_ui1, %c1_ui0) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out1, %3 : !firrtl.uint<1>, !firrtl.uint<1>
+
+  // CHECK: firrtl.connect %out, %in
+  %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
+  %4 = firrtl.mux (%cond, %in, %invalid_ui4) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  firrtl.connect %out, %4 : !firrtl.uint<4>, !firrtl.uint<4>
+
+  // CHECK: firrtl.connect %out, %in
+  %5 = firrtl.mux (%cond, %invalid_ui4, %in) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  firrtl.connect %out, %5 : !firrtl.uint<4>, !firrtl.uint<4>
+
+  // CHECK: firrtl.connect %out, %invalid_ui4
+  %6 = firrtl.mux (%cond, %invalid_ui4, %invalid_ui4) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  firrtl.connect %out, %6 : !firrtl.uint<4>, !firrtl.uint<4>
 }
 
 // CHECK-LABEL: firrtl.module @Pad


### PR DESCRIPTION
Change FIRRTL dialect folders to use the Scala FIRRTL Compiler (SFC)
interpretation of invalid.  An invalid involving a non-mux primitive
operation is treated as a constant zero.  An invalid involving the true
or false paths of a multiplexer is treated as a conditionally valid
expression which always evaluates to the non-invalid path.

This intentionally deviates from the FIRRTL spec interpretation of
invalid as undefined behavior.  Invalidations are frequently generated
by Chisel (as a means of telling the SFC that an uninitialized component
is okay) and by a legacy version of Chisel ("Chisel 2 Compatibility
Mode") which defaults all connections to invalid to permanently disable
uninitialized checking.

Concretely, this adds the following folds:

  - add(a, invalid) -> pad(a, width)
  - add(invalid, a) -> pad(a, width)
  - sub(a, invalid) -> pad(a, width)
  - mul(_, invalid) -> 0
  - mul(invalid, _) -> 0
  - ~div(_, invalid) -> 0 (_This may be controversial._)~
  - div(invalid, _) -> 0
  - ~rem(_, invalid) -> 0 (_This may be controversial._)~
  - rem(invalid, _) -> 0
  - or(a, invalid) -> a
  - or(invalid, a) -> a
  - xor(a, invalid) -> a
  - xor(invalid, a) -> a

Add tests to lock in this behavior for folds involving invalid values.

Update the rationale doc describing the two known interpretations of invalid that the Scala FIRRTL Compiler is using and how FIRRTL Dialect optimizes around it.

Fixes #1494 by enshrining the context-sensitive nature of invalids in the FIRRTL Dialect.
