### PR TITLE
[Comb] Verify ConcatOp input operands total width matches type

### DIFF
--- a/include/circt/Dialect/Comb/Combinational.td
+++ b/include/circt/Dialect/Comb/Combinational.td
@@ -227,7 +227,7 @@ def ConcatOp : VariadicOp<"concat"> {
 
   let hasFolder = true;
   let hasCanonicalizeMethod = true;
-  let verifier =  "return ::verifyConcatOp(*this);";
+  let verifier = "return ::verifyConcatOp(*this);";
 
   let builders = [
     OpBuilder<(ins "ValueRange":$inputs)>,

--- a/include/circt/Dialect/Comb/Combinational.td
+++ b/include/circt/Dialect/Comb/Combinational.td
@@ -227,6 +227,7 @@ def ConcatOp : VariadicOp<"concat"> {
 
   let hasFolder = true;
   let hasCanonicalizeMethod = true;
+  let verifier =  "return ::verifyConcatOp(*this);";
 
   let builders = [
     OpBuilder<(ins "ValueRange":$inputs)>,

--- a/lib/Dialect/Comb/CombOps.cpp
+++ b/lib/Dialect/Comb/CombOps.cpp
@@ -14,6 +14,7 @@
 #include "circt/Dialect/HW/HWOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/PatternMatch.h"
+#include "llvm/Support/FormatVariadic.h"
 
 using namespace circt;
 using namespace comb;
@@ -155,6 +156,18 @@ static unsigned getTotalWidth(ValueRange inputs) {
     resultWidth += input.getType().cast<IntegerType>().getWidth();
   }
   return resultWidth;
+}
+
+static LogicalResult verifyConcatOp(ConcatOp concatOp) {
+  unsigned tyWidth = concatOp.getType().getWidth();
+  unsigned operandsTotalWidth = getTotalWidth(concatOp.inputs());
+  if (tyWidth != operandsTotalWidth)
+    return concatOp.emitOpError(llvm::formatv(
+        "ConcatOp requires operands total width to match type width. operands "
+        "totalWidth is {0}, but concatOp type width is {1}",
+        operandsTotalWidth, tyWidth));
+
+  return success();
 }
 
 void ConcatOp::build(OpBuilder &builder, OperationState &result,

--- a/lib/Dialect/Comb/CombOps.cpp
+++ b/lib/Dialect/Comb/CombOps.cpp
@@ -162,10 +162,10 @@ static LogicalResult verifyConcatOp(ConcatOp concatOp) {
   unsigned tyWidth = concatOp.getType().getWidth();
   unsigned operandsTotalWidth = getTotalWidth(concatOp.inputs());
   if (tyWidth != operandsTotalWidth)
-    return concatOp.emitOpError(llvm::formatv(
-        "ConcatOp requires operands total width to match type width. operands "
-        "totalWidth is {0}, but concatOp type width is {1}",
-        operandsTotalWidth, tyWidth));
+    return concatOp.emitOpError("ConcatOp requires operands total width to "
+                                "match type width. operands "
+                                "totalWidth is")
+           << operandsTotalWidth << ", but concatOp type width is " << tyWidth;
 
   return success();
 }

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -135,9 +135,9 @@ hw.module @subCst(%a: i4) -> (%o1: i4) {
 // CHECK-NEXT:    [[RES:%[0-9]+]] = comb.icmp uge %arg0, %arg1 : i9
 // CHECK-NEXT:    hw.output [[RES]] : i1
 hw.module @compareStrengthReductionRemoveSuffixAndPrefix(%arg0: i9, %arg1: i9) -> (%o : i1) {
-  %0 = comb.concat %arg0, %arg0, %arg1: (i9, i9, i9) -> i18
-  %1 = comb.concat %arg0, %arg1, %arg1: (i9, i9, i9) -> i18
-  %2 = comb.icmp uge %0, %1 : i18
+  %0 = comb.concat %arg0, %arg0, %arg1: (i9, i9, i9) -> i27
+  %1 = comb.concat %arg0, %arg1, %arg1: (i9, i9, i9) -> i27
+  %2 = comb.icmp uge %0, %1 : i27
   hw.output %2 : i1
 }
 


### PR DESCRIPTION
Validates ConcatOp's input operand's total width matches those specified by its type.

Some tests  required some rectification to pass, since they had width mismatches.