### PR TITLE
[SV] Add a LocalparamOp

### DIFF
--- a/include/circt/Dialect/SV/SVExpressions.td
+++ b/include/circt/Dialect/SV/SVExpressions.td
@@ -91,3 +91,22 @@ def ConstantZOp : SVOp<"constantZ", [NoSideEffect, HasCustomSSAName]> {
   let results = (outs HWIntegerType:$result);
   let assemblyFormat = " attr-dict `:` type($result)";
 }
+
+def LocalParamOp : SVOp<"localparam",
+      [SameOperandsAndResultType, NoSideEffect, HasCustomSSAName]> {
+  let summary = "Declare a localparam";
+  let description = [{
+    The localparam operation produces a `localparam` declaration. See SV spec
+    6.20.4 p125.
+    ```
+      %result = hw.localparam %input : t1
+    ```
+    }];
+
+  let arguments = (ins StrAttr:$name, HWIntegerType:$input);
+  let results = (outs HWIntegerType:$result);
+
+  let assemblyFormat = [{
+    custom<ImplicitSSAName>(attr-dict) $input `:` type($result)
+  }];
+}

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -31,7 +31,7 @@ public:
             ReadInOutOp, ArrayIndexInOutOp, VerbatimExprOp, VerbatimExprSEOp,
             ConstantXOp, ConstantZOp,
             // Declarations.
-            RegOp, WireOp,
+            RegOp, WireOp, LocalParamOp,
             // Control flow.
             IfDefOp, IfDefProceduralOp, IfOp, AlwaysOp, AlwaysCombOp,
             AlwaysFFOp, InitialOp, CaseZOp,
@@ -74,6 +74,7 @@ public:
   // Declarations
   HANDLE(RegOp, Unhandled);
   HANDLE(WireOp, Unhandled);
+  HANDLE(LocalParamOp, Unhandled);
 
   // Expressions
   HANDLE(ReadInOutOp, Unhandled);

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -176,6 +176,17 @@ void ConstantZOp::getAsmResultNames(
 }
 
 //===----------------------------------------------------------------------===//
+// LocalParamOp
+//===----------------------------------------------------------------------===//
+
+void LocalParamOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  // If the localparam has an optional 'name' attribute, use it.
+  auto nameAttr = (*this)->getAttrOfType<StringAttr>("name");
+  if (!nameAttr.getValue().empty())
+    setNameFn(getResult(), nameAttr.getValue());
+}
+
+//===----------------------------------------------------------------------===//
 // RegOp
 //===----------------------------------------------------------------------===//
 

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -4,6 +4,10 @@
 // CHECK-LABEL: hw.module @test1(%arg0: i1, %arg1: i1, %arg8: i8) {
 hw.module @test1(%arg0: i1, %arg1: i1, %arg8: i8) {
 
+  %c11_i42 = hw.constant 11: i42
+  // CHECK: %param_x = sv.localparam %c11_i42 : i42
+  %param_x = sv.localparam %c11_i42 : i42
+
   // This corresponds to this block of system verilog code:
   //    always @(posedge arg0) begin
   //      `ifndef SYNTHESIS

--- a/test/ExportVerilog/sv-dialect.mlir
+++ b/test/ExportVerilog/sv-dialect.mlir
@@ -4,6 +4,14 @@
 hw.module @M1(%clock : i1, %cond : i1, %val : i8) {
   %wire42 = sv.wire : !hw.inout<i42>
   %forceWire = sv.wire : !hw.inout<i1>
+ 
+  %c11_i42 = hw.constant 11: i42
+  // CHECK: localparam [41:0] param_x = 42'hB;
+  %param_x = sv.localparam %c11_i42 : i42
+
+  %param_tmp = comb.add %param_x, %c11_i42 : i42
+  // CHECK: localparam [41:0] param_y = param_x + 42'hB;
+  %param_y = sv.localparam %param_tmp : i42
 
   // CHECK:      always @(posedge clock) begin
   sv.always posedge %clock {
@@ -94,6 +102,9 @@ hw.module @M1(%clock : i1, %cond : i1, %val : i8) {
 
       // CHECK-NEXT: wire42 = 42'h2A;
       sv.bpassign %wire42, %c42 : i42
+    } else {
+      // CHECK: wire42 = param_y;
+      sv.bpassign %wire42, %param_y : i42
     }
 
     // CHECK-NEXT:   if (cond)


### PR DESCRIPTION
In many cases, we need to represent named `localparam`s to make the emitted verilog prettier. For example, in the implementation of FSM, we want:
```verilog
  localparam [1:0] IDLE = 2'h0; // <stdin>:19:13
  always @(posedge clk or negedge rst_n) begin  // <stdin>:23:5
    if (!rst_n) begin   // <stdin>:23:5
      state <= IDLE;    // <stdin>:169:7
    end
```
rather than:
```verilog
  localparam [1:0] _T_0 = 2'h0; // <stdin>:19:13
  always @(posedge clk or negedge rst_n) begin  // <stdin>:23:5
    if (!rst_n) begin   // <stdin>:23:5
      state <= _T_0;    // <stdin>:169:7
    end
```
or:
```verilog
  always @(posedge clk or negedge rst_n) begin  // <stdin>:23:5
    if (!rst_n) begin   // <stdin>:23:5
      state <= 2'h0;    // <stdin>:169:7
    end
```
This patch introduce an `sv.localparam` operation with a `name` attribute. Both `sv.localparam` and `hw.constant` are emitted as `localparam` declaration. However, `sv.localparam` does not have `ConstantLike` trait so that it will not be folded or manipulated like a constant in optimizations.