### PR TITLE
Add circt-reduce

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 add_subdirectory(circt-opt)
+add_subdirectory(circt-reduce)
 add_subdirectory(circt-rtl-sim)
 add_subdirectory(circt-translate)
 add_subdirectory(esi)

--- a/tools/circt-reduce/CMakeLists.txt
+++ b/tools/circt-reduce/CMakeLists.txt
@@ -1,0 +1,29 @@
+set(LLVM_LINK_COMPONENTS
+  Support
+)
+
+add_llvm_tool(circt-reduce
+ circt-reduce.cpp
+)
+llvm_update_compile_flags(circt-reduce)
+target_link_libraries(circt-reduce
+  PRIVATE
+  CIRCTCalyx
+  CIRCTESI
+  CIRCTFIRRTL
+  CIRCTHandshakeOps
+  CIRCTLLHD
+  CIRCTMSFT
+  CIRCTHW
+  CIRCTScheduling
+  CIRCTSeq
+  CIRCTStaticLogicOps
+  CIRCTSV
+
+  MLIRIR
+  MLIRParser
+  MLIRStandard
+  MLIRSupport
+  MLIRTransforms
+  MLIRReduceLib
+)

--- a/tools/circt-reduce/circt-reduce.cpp
+++ b/tools/circt-reduce/circt-reduce.cpp
@@ -1,0 +1,23 @@
+//===- circt-reduce.cpp - The circt-reduce driver -------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the 'circt-reduce' tool, which is the circt analog of
+// mlir-reduce, used to drive test case reduction.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/InitAllDialects.h"
+#include "mlir/Pass/PassRegistry.h"
+#include "mlir/Tools/mlir-reduce/MlirReduceMain.h"
+
+int main(int argc, char **argv) {
+  mlir::DialectRegistry registry;
+  circt::registerAllDialects(registry);
+  mlir::MLIRContext context(registry);
+  return failed(mlirReduceMain(argc, argv, context));
+}


### PR DESCRIPTION
Add a `circt-reduce` utility, which basically follows the "build a custom mlir-reduce" steps described in the MLIR documentation. The intent here is to have a first step towards a CIRCT-specific reduction utility. At a later stage, we may want to start populating the reducer framework with reduction patterns specific to CIRCT (like fan-in/-out cone isolation, port removal, etc).