### PR TITLE
[Calyx] Emit (unguarded) assignments.

### DIFF
--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -22,7 +22,6 @@
 
 using namespace circt;
 using namespace calyx;
-using namespace hw;
 
 //===----------------------------------------------------------------------===//
 // Emitter
@@ -152,7 +151,7 @@ void Emitter::emitComponent(ComponentOp op) {
 void Emitter::emitComponentPorts(ArrayRef<ComponentPortInfo> ports) {
   std::vector<ComponentPortInfo> inPorts, outPorts;
   for (auto &&port : ports) {
-    if (port.direction == calyx::PortDirection::INPUT)
+    if (port.direction == PortDirection::INPUT)
       inPorts.push_back(port);
     else
       outPorts.push_back(port);
@@ -201,7 +200,7 @@ void Emitter::emitAssignment(AssignOp op) {
           emitted += ".";
           emitted += portName.getValue();
         })
-        .template Case<ConstantOp>([&](auto op) {
+        .template Case<hw::ConstantOp>([&](auto op) {
           // A constant is defined as <bit-width>'<base><value>, where the base
           // is `b` (binary), `o` (octal), `h` hexadecimal, or `d` (decimal).
 

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -186,7 +186,7 @@ void Emitter::emitAssignment(AssignOp op) {
   if (op.guard())
     emitOpError(op, "guard not supported for emission currently");
 
-  auto emitAssignmentValue = [&](auto assignValue) -> StringRef {
+  auto emitAssignmentValue = [&](auto assignValue) {
     auto definingOp = assignValue.getDefiningOp();
     std::string emitted;
     TypeSwitch<Operation *>(definingOp)

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -221,7 +221,7 @@ void Emitter::emitAssignment(AssignOp op) {
     return emitted;
   };
   indent() << emitAssignmentValue(op.dest()) << " = "
-           << emitAssignmentValue(op.src()) << ";";
+           << emitAssignmentValue(op.src()) << ";\n";
 }
 
 void Emitter::emitWires(WiresOp op) {

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -98,14 +98,14 @@ private:
     TypeSwitch<Operation *>(definingOp)
         .Case<CellOp>([&](auto op) {
           // A cell port should be defined as <instance-name>.<port-name>
-          auto opResult = value.template cast<OpResult>();
+          auto opResult = value.cast<OpResult>();
           unsigned portIndex = opResult.getResultNumber();
           auto ports = getComponentPortInfo(op.getReferencedComponent());
           StringAttr portName = ports[portIndex].name;
           (isIndented ? indent() : os)
               << op.instanceName() << "." << portName.getValue();
         })
-        .template Case<hw::ConstantOp>([&](auto op) {
+        .Case<hw::ConstantOp>([&](auto op) {
           // A constant is defined as <bit-width>'<base><value>, where the base
           // is `b` (binary), `o` (octal), `h` hexadecimal, or `d` (decimal).
 

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -14,11 +14,16 @@ calyx.program {
     %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.cell "c0" @A : i8, i1, i1, i1, i8, i1
 
     // CHECK: wires {
-    // CHECK:   group Group1 {
     calyx.wires {
+      // CHECK:   group Group1 {
+      // CHECK:     c0.in = c0.out;
       calyx.group @Group1 {
+        calyx.assign %c0.in = %c0.out : i8
         calyx.group_done %c0.done : i1
       }
+      // CHECK:   c0.go = 1'd1;
+      %c1 = hw.constant 1 : i1
+      calyx.assign %c0.go = %c1 : i1
     }
     // CHECK: control {
     calyx.control {

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -21,8 +21,8 @@ calyx.program {
         calyx.assign %c0.in = %c0.out : i8
         calyx.group_done %c0.done : i1
       }
-      // CHECK:   c0.go = 1'd1;
-      %c1 = hw.constant 1 : i1
+      // CHECK:   c0.go = 1'd0;
+      %c1 = hw.constant 0 : i1
       calyx.assign %c0.go = %c1 : i1
     }
     // CHECK: control {

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-translate --export-calyx --verify-diagnostics %s
+// RUN: circt-translate --export-calyx --verify-diagnostics %s | FileCheck %s --strict-whitespace
 
 calyx.program {
   // CHECK-LABEL: component A(in: 8, go: 1, clk: 1, reset: 1) -> (out: 8, done: 1) {

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-translate --export-calyx --verify-diagnostics %s | FileCheck %s --strict-whitespace
+// RUN: circt-translate --export-calyx --verify-diagnostics %s
 
 calyx.program {
   // CHECK-LABEL: component A(in: 8, go: 1, clk: 1, reset: 1) -> (out: 8, done: 1) {
@@ -15,8 +15,8 @@ calyx.program {
 
     // CHECK: wires {
     calyx.wires {
-      // CHECK:   group Group1 {
-      // CHECK:     c0.in = c0.out;
+      // CHECK: group Group1 {
+      // CHECK:   c0.in = c0.out;
       calyx.group @Group1 {
         calyx.assign %c0.in = %c0.out : i8
         calyx.group_done %c0.done : i1


### PR DESCRIPTION
[Example](https://github.com/cucapra/calyx/blob/bcad5395e262e96516ef6f60508ec2f8218d216a/tests/correctness/if.futil#L17) of an unguarded assignment in Calyx.
