### PR TITLE
[HW] Support TypeAliasType in return type for aggregate create ops.

### DIFF
--- a/include/circt/Dialect/HW/HWAggregates.td
+++ b/include/circt/Dialect/HW/HWAggregates.td
@@ -30,7 +30,7 @@ def ArrayCreateOp : HWOp<"array_create", [NoSideEffect, SameTypeOperands]> {
   }];
 
   let arguments = (ins Variadic<HWNonInOutType>:$inputs);
-  let results = (outs ArrayTypeImpl:$result);
+  let results = (outs ArrayType:$result);
 
   let verifier = [{
     unsigned returnSize = getType().cast<ArrayType>().getSize();
@@ -155,7 +155,7 @@ def ArrayGetOp : HWOp<"array_get",
 def StructCreateOp : HWOp<"struct_create", [NoSideEffect]> {
   let summary = "Create a struct from constituent parts.";
   let arguments = (ins Variadic<HWNonInOutType>:$input);
-  let results = (outs StructTypeImpl:$result);
+  let results = (outs StructType:$result);
 
   let parser = "return ::parse$cppClass(parser, result);";
   let printer = "return ::print$cppClass(p, *this);";
@@ -214,7 +214,7 @@ def UnionCreateOp : HWOp<"union_create", [NoSideEffect]> {
   }];
 
   let arguments = (ins StrAttr:$field, HWNonInOutType:$input);
-  let results = (outs UnionTypeImpl:$result);
+  let results = (outs UnionType:$result);
 
   let parser = "return ::parse$cppClass(parser, result);";
   let printer = "return ::print$cppClass(p, *this);";

--- a/include/circt/Dialect/HW/HWTypes.h
+++ b/include/circt/Dialect/HW/HWTypes.h
@@ -92,6 +92,21 @@ BaseTy type_dyn_cast(Type type) {
   return type_cast<BaseTy>(type);
 }
 
+template <typename BaseTy>
+class TypeAliasOr
+    : public ::mlir::Type::TypeBase<TypeAliasOr<BaseTy>, mlir::Type,
+                                    mlir::TypeStorage> {
+  using mlir::Type::TypeBase<TypeAliasOr<BaseTy>, mlir::Type,
+                             mlir::TypeStorage>::Base::Base;
+
+public:
+  // Support LLVM isa/cast/dyn_cast to BaseTy.
+  static bool classof(Type other) { return type_isa<BaseTy>(other); }
+
+  // Support C++ implicit conversions to BaseTy.
+  operator BaseTy() const { return type_cast<BaseTy>(*this); }
+};
+
 } // namespace hw
 } // namespace circt
 

--- a/include/circt/Dialect/HW/HWTypes.td
+++ b/include/circt/Dialect/HW/HWTypes.td
@@ -60,7 +60,8 @@ def ArrayTypeImpl : HWType<"Array"> {
 
 // A handle to refer to hw::ArrayType in ODS.
 def ArrayType : DialectType<HWDialect,
-    CPred<"type_isa<ArrayType>($_self)">, "an ArrayType">;
+    CPred<"type_isa<ArrayType>($_self)">, "an ArrayType",
+    "TypeAliasOr<ArrayType>">;
 
 // An 'unpacked' array of fixed size.
 def UnpackedArrayType : HWType<"UnpackedArray"> {
@@ -127,7 +128,8 @@ def StructTypeImpl : HWType<"Struct"> {
 
 // A handle to refer to hw::StructType in ODS.
 def StructType : DialectType<HWDialect,
-    CPred<"type_isa<StructType>($_self)">, "a StructType">;
+    CPred<"type_isa<StructType>($_self)">, "a StructType",
+    "TypeAliasOr<StructType>">;
 
 // An untagged union. Declares the hw::UnionType in C++.
 def UnionTypeImpl : HWType<"Union"> {
@@ -150,7 +152,8 @@ def UnionTypeImpl : HWType<"Union"> {
 
 // A handle to refer to hw::UnionType in ODS.
 def UnionType : DialectType<HWDialect,
-    CPred<"type_isa<UnionType>($_self)">, "a UnionType">;
+    CPred<"type_isa<UnionType>($_self)">, "a UnionType",
+    "TypeAliasOr<UnionType>">;
 
 def TypeAliasType : HWType<"TypeAlias"> {
   let summary = "An symbolic reference to a type declaration";

--- a/test/Dialect/HW/errors.mlir
+++ b/test/Dialect/HW/errors.mlir
@@ -77,7 +77,7 @@ hw.module @wire(%a: i42) {
 // -----
 
 hw.module @struct(%a: i42) {
-  // expected-error @+1 {{custom op 'hw.struct_create' invalid kind of type specified}}
+  // expected-error @+1 {{custom op 'hw.struct_create' expected !hw.struct type or alias}}
   %aget = hw.struct_create(%a) : i42
 }
 

--- a/test/Dialect/HW/types.mlir
+++ b/test/Dialect/HW/types.mlir
@@ -42,4 +42,13 @@ module {
     %arg4: !hw.inout<uarray<2xarray<42xi8>>>) {
     return
   }
+
+  // CHECK-LABEL: aliasedAggregates
+  func @aliasedAggregates(%i: i1) {
+    // CHECK: !hw.typealias<@ns::@bar, !hw.struct<a: i1, b: i1>>
+    %0 = hw.struct_create(%i, %i) : !hw.typealias<@ns::@bar, !hw.struct<a: i1, b: i1>>
+    // CHECK: !hw.typealias<@ns::@bar, !hw.union<a: i1, b: i1>>
+    %1 = hw.union_create "a", %i : !hw.typealias<@ns::@bar, !hw.union<a: i1, b: i1>>
+    return
+  }
 }

--- a/test/ExportVerilog/hw-typedecls.mlir
+++ b/test/ExportVerilog/hw-typedecls.mlir
@@ -45,3 +45,14 @@ hw.module @testRegOp() -> () {
   // CHECK: foo[2:0] {{.+}};
   %r2 = sv.reg : !hw.inout<!hw.array<3xtypealias<@__hw_typedecls::@foo,i1>>>
 }
+
+// CHECK-LABEL: module testAggregateCreate
+hw.module @testAggregateCreate(%i: i1) -> (%out1: i1, %out2: i1) {
+  // CHECK: wire bar [[NAME:.+]] = {{.+}};
+  %0 = hw.struct_create(%i, %i) : !hw.typealias<@__hw_typedecls::@bar,!hw.struct<a: i1, b: i1>>
+  // CHECK: [[NAME]].a
+  %1 = hw.struct_extract %0["a"] : !hw.typealias<@__hw_typedecls::@bar,!hw.struct<a: i1, b: i1>>
+  // CHECK: [[NAME]].b
+  %2 = hw.struct_extract %0["b"] : !hw.typealias<@__hw_typedecls::@bar,!hw.struct<a: i1, b: i1>>
+  hw.output %1, %2 : i1, i1
+}


### PR DESCRIPTION
This was always intended to be supported, but was removed in
862f1b4. This adds it back, and updates the parsers for the relevant
ops to actually support type aliases (they previously didn't).

In order to help avoid the need to cast away aliases everywhere, a new
base class is added to all aggregate types that support aliases. This
class can represent a type alias or the aggregate type. It implicitly
converts to the aggregate type, which helps avoid explicit casts.