### PR TITLE
[FIRRTL] Enum the kind of subfields of MemOp ports

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -138,6 +138,10 @@ enum class DeclKind { Port, Instance, Other };
 
 DeclKind getDeclarationKind(Value val);
 
+enum class ReadPortSubfield { addr, en, clk, data };
+enum class WritePortSubfield { addr, en, clk, data, mask };
+enum class ReadWritePortSubfield { addr, en, clk, wmode, rdata, wdata, wmask };
+
 // Out-of-line implementation of various trait verification methods and
 // functions commonly used among operations.
 namespace impl {


### PR DESCRIPTION
Since the order of subfields of MemOp ports is fixed, it makes sense to define the kind of them as an enum type. This can avoid to compare the subfield index with some magic numbers.
See also the discussion [here](https://github.com/llvm/circt/pull/1388#discussion_r681944097).