### PR TITLE
[Scheduling] Add simplex scheduler for the cyclic problem.

### DIFF
--- a/include/circt/Scheduling/Algorithms.h
+++ b/include/circt/Scheduling/Algorithms.h
@@ -24,6 +24,14 @@ namespace scheduling {
 /// name). Fails if the dependence graph contains cycles.
 LogicalResult scheduleASAP(Problem &prob);
 
+/// This scheduler solves the resource-free cyclic problem using linear
+/// programming and a handwritten implementation of the simplex algorithm. Its
+/// objectives are to determine the smallest feasible initiation interval, and
+/// to minimize the start time of the given \p lastOp. Fails if the dependence
+/// graph contains cycles that do not include at least one edge with a non-zero
+/// distance.
+LogicalResult scheduleSimplex(CyclicProblem &prob, Operation *lastOp);
+
 } // namespace scheduling
 } // namespace circt
 

--- a/lib/Scheduling/CMakeLists.txt
+++ b/lib/Scheduling/CMakeLists.txt
@@ -1,12 +1,14 @@
 set(LLVM_OPTIONAL_SOURCES
   ASAPScheduler.cpp
   Problems.cpp
+  SimplexScheduler.cpp
   TestPasses.cpp
   )
 
 add_circt_library(CIRCTScheduling
   ASAPScheduler.cpp
   Problems.cpp
+  SimplexScheduler.cpp
 
   LINK_LIBS PUBLIC
   MLIRIR

--- a/lib/Scheduling/SimplexScheduler.cpp
+++ b/lib/Scheduling/SimplexScheduler.cpp
@@ -292,11 +292,18 @@ void SimplexScheduler::dumpTableau() {
         dbgs() << " |";
       dbgs() << format(" %3d", tableau[i][j]);
     }
+    if (i >= firstConstraintRow)
+      dbgs() << format(" |< %2d", basicVariables[i - firstConstraintRow]);
     dbgs() << '\n';
   }
   for (unsigned j = 0; j < nColumns; ++j)
     dbgs() << "====";
   dbgs() << "==\n";
+  dbgs() << "          ";
+  for (unsigned j = firstNonBasicVariableColumn; j < nColumns; ++j)
+    dbgs() << format(" %2d^",
+                     nonBasicVariables[j - firstNonBasicVariableColumn]);
+  dbgs() << '\n';
 }
 
 LogicalResult SimplexScheduler::schedule() {

--- a/lib/Scheduling/SimplexScheduler.cpp
+++ b/lib/Scheduling/SimplexScheduler.cpp
@@ -1,0 +1,379 @@
+//===- SimplexScheduler.cpp - Linear programming-based scheduler ----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Implementation of a scheduler that applies the simplex algorithm to a linear
+// program formulation of the resource-free cyclic scheduling problem.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Scheduling/Algorithms.h"
+
+#include "mlir/IR/Operation.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/Format.h"
+
+#define DEBUG_TYPE "simplex-scheduler"
+
+using namespace circt;
+using namespace circt::scheduling;
+
+using llvm::dbgs;
+using llvm::format;
+
+namespace {
+
+/// This class models the cyclic scheduling problem as a lexico-parametric
+/// linear program (LP), and solves it with an extended version of the dual
+/// simplex algorithm.
+///
+/// The approach is described in:
+///   B. D. de Dinechin, "Simplex Scheduling: More than Lifetime-Sensitive
+///   Instruction Scheduling", PRISM 1994.22, 1994.
+///
+/// Our `CyclicProblem` corresponds to de Dinechin's initial, resource-free
+/// "central problem", and results in an *integer* linear programming
+/// formulation with a totally unimodular constraint matrix. Such ILPs can
+/// however be solved optimally in polynomial time with a (non-integer) LP
+/// solver (such as the simplex algorithm), as the LP solution is guaranteed to
+/// be integer.
+/// (Note that this is the same idea as used by SDC-based schedulers.)
+///
+/// The LP's objective is to minimize the start time of the client-provided
+/// "last" operation. The optimal initiation interval (II) is determined as a
+/// side product of solving the parametric problem, and corresponds to the
+/// "RecMII" (= recurrence-constrained minimum II) usually considered as one
+/// component in the lower II bound used by modulo schedulers.
+class SimplexScheduler {
+private:
+  CyclicProblem &prob;
+  Operation *lastOp;
+
+  /// The minimally-feasible initiation interval is computed by the algorithm.
+  int parameterII;
+
+  /// The simplex tableau is the algorithm's main data structure.
+  /// The dashed parts always contain the zero respectively the identity matrix,
+  /// and therefore are not stored explicitly.
+  ///
+  ///                          ◀───nColumns──▶
+  ///                         ┌───┬───────────┬ ─ ─ ─ ─ ┐
+  ///          objectiveRow > │~Z │. . ~C^T. .│    0        ▲
+  ///                         ├───┼───────────┼ ─ ─ ─ ─ ┤   │
+  ///    firstConstraintRow > │. .│. . . . . .│1            │
+  ///                         │. .│. . . . . .│  1      │   │nRows
+  ///                         │~B |. . ~A  . .│    1        │
+  ///                         │. .│. . . . . .│      1  │   │
+  ///                         │. .│. . . . . .│        1    ▼
+  ///                         └───┴───────────┴ ─ ─ ─ ─ ┘
+  ///       parameterOneColumn ^
+  ///          parameterIIColumn ^
+  ///  firstNonBasicVariableColumn ^
+  ///                              ─────────── ──────────
+  ///                       nonBasicVariables   basicVariables
+  SmallVector<SmallVector<int>> tableau;
+
+  /// During the pivot operation, one column in the elided part of the tableau
+  /// is modified; this vector temporarily catches the changes.
+  SmallVector<int> implicitBasicVariableColumnVector;
+
+  /// The linear program models the operations' start times as variables, which
+  /// we identify here as 0, ..., |ops|-1.
+  /// Additionally, for each depedence (precisely, the inequality modeling the
+  /// precedence constraint), a slack variable is required; these are identified
+  /// as |ops|, ..., |ops|+|deps|-1.
+  ///
+  /// This vector stores the numeric IDs of non-basic variables. A variable's
+  /// index *i* in this vector corresponds to the tableau *column*
+  /// `firstNonBasicVariableColum`+*i*.
+  SmallVector<unsigned> nonBasicVariables;
+
+  /// This vector store the numeric IDs of basic variables. A variable's index
+  /// *i* in this vector corresponds to the tableau *row*
+  /// `firstConstraintRow`+*i*.
+  SmallVector<unsigned> basicVariables;
+
+  /// Number of rows in the tableau = 1 + |deps|.
+  unsigned nRows;
+  /// Number of explicitly stored columns in the tableau = 2 + |ops|.
+  unsigned nColumns;
+
+  /// The first row encodes the LP's objective function.
+  static constexpr unsigned objectiveRow = 0;
+  /// All other rows encode linear constraints.
+  static constexpr unsigned firstConstraintRow = 1;
+
+  /// The first column corresponds to the always-one "parameter" in u = (1,S,T).
+  static constexpr unsigned parameterOneColumn = 0;
+  /// The second column corresponds to the parameter T, i.e. the initiation
+  /// interval. Note that we do not model the parameter S yet.
+  static constexpr unsigned parameterIIColumn = 1;
+  /// All other (explicitly stored) columns represent non-basic variables.
+  static constexpr unsigned firstNonBasicVariableColumn = 2;
+
+  void buildTableau();
+  Optional<unsigned> findPivotRow();
+  Optional<unsigned> findPivotColumn(unsigned pivotRow);
+  void multiplyRow(unsigned row, int factor);
+  void addMultipleOfRow(unsigned sourceRow, int factor, unsigned targetRow);
+  void pivot(unsigned pivotRow, unsigned pivotColumn);
+
+  void dumpTableau();
+
+public:
+  SimplexScheduler(CyclicProblem &prob, Operation *lastOp)
+      : prob(prob), lastOp(lastOp) {}
+  LogicalResult schedule();
+};
+
+} // anonymous namespace
+
+void SimplexScheduler::buildTableau() {
+  // Helper map to lookup an operation's column number in the tableau.
+  SmallDenseMap<Operation *, unsigned> opCols;
+
+  // The initial tableau is constructed so that operations' start time variables
+  // are out of basis, whereas all slack variables are in basis. We will number
+  // them accordingly.
+  unsigned varNum = 0;
+
+  // Assign column and variable numbers to the operations' start times.
+  nColumns = 2; // 0: `parameterOneColumn`, 1: `parameterIIColumn`
+  for (auto *op : prob.getOperations()) {
+    opCols[op] = nColumns++;
+    nonBasicVariables.push_back(varNum++);
+  }
+
+  // Set up the objective row.
+  auto &objRowVec = tableau.emplace_back(nColumns, 0);
+  objRowVec[opCols[lastOp]] = 1;
+
+  // Now set up rows/constraints for the dependences.
+  nRows = 1; // 0: `objectiveRow`
+  for (auto *op : prob.getOperations()) {
+    for (auto &dep : prob.getDependences(op)) {
+      auto &consRowVec = tableau.emplace_back(nColumns, 0);
+      nRows++;
+      basicVariables.push_back(varNum++);
+
+      Operation *src = dep.getSource();
+      Operation *dst = dep.getDestination();
+      unsigned latency = *prob.getLatency(*prob.getLinkedOperatorType(src));
+      unsigned distance = prob.getDistance(dep).getValueOr(0);
+      consRowVec[parameterOneColumn] = -latency; // note the negation
+      consRowVec[parameterIIColumn] = distance;
+      consRowVec[opCols[src]] = 1;
+      consRowVec[opCols[dst]] = -1;
+    }
+  }
+
+  // Set up the temporary column vector, and zero-initialize it.
+  implicitBasicVariableColumnVector.set_size(nRows);
+  std::fill(implicitBasicVariableColumnVector.begin(),
+            implicitBasicVariableColumnVector.end(), 0);
+}
+
+Optional<unsigned> SimplexScheduler::findPivotRow() {
+  // Find the first row for which the dot product "~B_p u" is negative.
+  for (unsigned row = firstConstraintRow; row < nRows; ++row) {
+    int rowVal = tableau[row][parameterOneColumn] +
+                 tableau[row][parameterIIColumn] * parameterII;
+    if (rowVal < 0)
+      return row;
+  }
+
+  return None;
+}
+
+Optional<unsigned> SimplexScheduler::findPivotColumn(unsigned pivotRow) {
+  Optional<int> maxQuot;
+  Optional<unsigned> pivotCol;
+  // Look for negative entries in the ~A part of the tableau. If multiple
+  // candidates exist, take the one with maximum of the quotient:
+  // tableau[objectiveRow][col] / pivotCand
+  for (unsigned col = firstNonBasicVariableColumn; col < nColumns; ++col) {
+    int pivotCand = tableau[pivotRow][col];
+    if (pivotCand < 0) {
+      // The ~A part of the tableau has only {-1, 0, 1} entries by construction.
+      assert(pivotCand == -1);
+      int quot = -tableau[objectiveRow][col];
+      // Quotient in general: tableau[objectiveRow][col] / pivotCand
+      if (!maxQuot || quot > *maxQuot) {
+        maxQuot = quot;
+        pivotCol = col;
+      }
+    }
+  }
+
+  return pivotCol;
+}
+
+void SimplexScheduler::multiplyRow(unsigned row, int factor) {
+  assert(factor != 0);
+  for (unsigned col = 0; col < nColumns; ++col)
+    tableau[row][col] *= factor;
+  // Also multiply the corresponding entry in the temporary column vector.
+  implicitBasicVariableColumnVector[row] *= factor;
+}
+
+void SimplexScheduler::addMultipleOfRow(unsigned sourceRow, int factor,
+                                        unsigned targetRow) {
+  assert(factor != 0 && sourceRow != targetRow);
+  for (unsigned col = 0; col < nColumns; ++col)
+    tableau[targetRow][col] += tableau[sourceRow][col] * factor;
+  // Again, perform row operation on the temporary column vector as well.
+  implicitBasicVariableColumnVector[targetRow] +=
+      implicitBasicVariableColumnVector[sourceRow] * factor;
+}
+
+/// The pivot operation applies elementary row operations to the tableau in
+/// order to make the \p pivotColumn (corresponding to a non-basic variable) a
+/// unit vector (only the \p pivotRow'th entry is 1). Then, a basis exchange is
+/// performed: the non-basic variable is swapped with the basic variable
+/// associated with the pivot row.
+void SimplexScheduler::pivot(unsigned pivotRow, unsigned pivotColumn) {
+  // The implicit columns are part of an identity matrix.
+  implicitBasicVariableColumnVector[pivotRow] = 1;
+
+  int pivotElem = tableau[pivotRow][pivotColumn];
+  // The ~A part of the tableau has only {-1, 0, 1} entries by construction.
+  // The pivot element must be negative, so it can only be -1.
+  assert(pivotElem == -1);
+  // Make `tableau[pivotRow][pivotColumn]` := 1
+  multiplyRow(pivotRow, -1); // Factor in general: 1 / pivotElement
+
+  for (unsigned row = 0; row < nRows; ++row) {
+    if (row == pivotRow)
+      continue;
+
+    int elem = tableau[row][pivotColumn];
+    if (elem == 0)
+      continue; // nothing to do
+
+    assert(elem * elem == 1);
+    // Make `tableau[row][pivotColumn]` := 0
+    addMultipleOfRow(pivotRow, -elem, row); // Factor in general: -1 / elem
+  }
+
+  // Swap the pivot column with the implictly constructed column vector.
+  // We really only need to copy in one direction here, as the former pivot
+  // column is a unit vector, which is not stored explictly.
+  for (unsigned row = 0; row < nRows; ++row) {
+    tableau[row][pivotColumn] = implicitBasicVariableColumnVector[row];
+    implicitBasicVariableColumnVector[row] = 0; // Reset for next pivot step.
+  }
+
+  // Record the swap in the variable lists.
+  std::swap(nonBasicVariables[pivotColumn - firstNonBasicVariableColumn],
+            basicVariables[pivotRow - firstConstraintRow]);
+}
+
+void SimplexScheduler::dumpTableau() {
+  for (unsigned j = 0; j < nColumns; ++j)
+    dbgs() << "====";
+  dbgs() << "==\n";
+  for (unsigned i = 0; i < nRows; ++i) {
+    if (i == firstConstraintRow) {
+      for (unsigned j = 0; j < nColumns; ++j) {
+        if (j == firstNonBasicVariableColumn)
+          dbgs() << "-+";
+        dbgs() << "----";
+      }
+      dbgs() << '\n';
+    }
+    for (unsigned j = 0; j < nColumns; ++j) {
+      if (j == firstNonBasicVariableColumn)
+        dbgs() << " |";
+      dbgs() << format(" %3d", tableau[i][j]);
+    }
+    dbgs() << '\n';
+  }
+  for (unsigned j = 0; j < nColumns; ++j)
+    dbgs() << "====";
+  dbgs() << "==\n";
+}
+
+LogicalResult SimplexScheduler::schedule() {
+  // Initialize data structures.
+  parameterII = 0;
+  buildTableau();
+
+  LLVM_DEBUG(dbgs() << "Initial tableau:\n");
+  LLVM_DEBUG(dumpTableau());
+
+  // Iterate as long as we find rows to pivot on (~B_p u is negative), otherwise
+  // an optimal solution has been found.
+  while (auto pivotRow = findPivotRow()) {
+    // Look for pivot elements.
+    if (auto pivotCol = findPivotColumn(*pivotRow)) {
+      pivot(*pivotRow, *pivotCol);
+
+      LLVM_DEBUG(dbgs() << "Pivoted with " << *pivotRow << ',' << *pivotCol
+                        << ":\n");
+      LLVM_DEBUG(dumpTableau());
+
+      continue;
+    }
+
+    // If we did not find a pivot column, then the entire row contained only
+    // positive entries, and the problem is in principle infeasible. However, if
+    // the entry in the `parameterIIColumn` is positive, we can make the LP
+    // feasible again by increasing the II.
+    int entryOneCol = tableau[*pivotRow][parameterOneColumn];
+    int entryIICol = tableau[*pivotRow][parameterIIColumn];
+    if (entryIICol > 0) {
+      // The negation of `entryOneCol` is not in the paper. I think this is an
+      // oversight, because `entryOneCol` certainly is negative (otherwise the
+      // row would not have been a valid pivot row), and without the negation,
+      // the new II would be negative.
+      assert(entryOneCol < 0);
+      parameterII = (-entryOneCol - 1) / entryIICol + 1;
+
+      LLVM_DEBUG(dbgs() << "Increased II to " << parameterII << '\n');
+
+      continue;
+    }
+
+    // Otherwise, there is nothing we can do.
+    return prob.getContainingOp()->emitError("problem is infeasible");
+  }
+
+  LLVM_DEBUG(dbgs() << "Optimal solution found with II = " << parameterII
+                    << " and start time of last operation = "
+                    << -tableau[objectiveRow][parameterOneColumn] << '\n');
+
+  // Store solution in the problem object.
+  prob.setInitiationInterval(parameterII);
+
+  auto &ops = prob.getOperations();
+  unsigned nOps = ops.size();
+  // For the start time variables currently in basis, we look up the solution
+  // in the first column. The slack variables (IDs >= |ops|) are ignored.
+  for (unsigned i = 0; i < basicVariables.size(); ++i) {
+    unsigned varNum = basicVariables[i];
+    if (varNum < nOps)
+      prob.setStartTime(ops[varNum],
+                        tableau[firstConstraintRow + i][parameterOneColumn]);
+  }
+
+  // Non-basic variables are 0 at the end of the simplex algorithm.
+  for (unsigned i = 0; i < nonBasicVariables.size(); ++i) {
+    unsigned varNum = nonBasicVariables[i];
+    if (varNum < nOps)
+      prob.setStartTime(ops[varNum], 0);
+  }
+
+  return success();
+}
+
+LogicalResult scheduling::scheduleSimplex(CyclicProblem &prob,
+                                          Operation *lastOp) {
+  SimplexScheduler simplex(prob, lastOp);
+  return simplex.schedule();
+}

--- a/lib/Scheduling/SimplexScheduler.cpp
+++ b/lib/Scheduling/SimplexScheduler.cpp
@@ -308,7 +308,7 @@ void SimplexScheduler::dumpTableau() {
 
 LogicalResult SimplexScheduler::schedule() {
   // Initialize data structures.
-  parameterII = 0;
+  parameterII = 1;
   buildTableau();
 
   LLVM_DEBUG(dbgs() << "Initial tableau:\n");

--- a/lib/Scheduling/SimplexScheduler.cpp
+++ b/lib/Scheduling/SimplexScheduler.cpp
@@ -361,12 +361,16 @@ LogicalResult SimplexScheduler::schedule() {
   auto &ops = prob.getOperations();
   unsigned nOps = ops.size();
   // For the start time variables currently in basis, we look up the solution
-  // in the first column. The slack variables (IDs >= |ops|) are ignored.
+  // in the ~B part of the tableau. The slack variables (IDs >= |ops|) are
+  // ignored.
   for (unsigned i = 0; i < basicVariables.size(); ++i) {
     unsigned varNum = basicVariables[i];
-    if (varNum < nOps)
-      prob.setStartTime(ops[varNum],
-                        tableau[firstConstraintRow + i][parameterOneColumn]);
+    if (varNum < nOps) {
+      unsigned startTime =
+          tableau[firstConstraintRow + i][parameterOneColumn] +
+          tableau[firstConstraintRow + i][parameterIIColumn] * parameterII;
+      prob.setStartTime(ops[varNum], startTime);
+    }
   }
 
   // Non-basic variables are 0 at the end of the simplex algorithm.

--- a/lib/Scheduling/SimplexScheduler.cpp
+++ b/lib/Scheduling/SimplexScheduler.cpp
@@ -256,9 +256,9 @@ void SimplexScheduler::pivot(unsigned pivotRow, unsigned pivotColumn) {
     if (elem == 0)
       continue; // nothing to do
 
-    assert(elem * elem == 1);
-    // Make `tableau[row][pivotColumn]` := 0
-    addMultipleOfRow(pivotRow, -elem, row); // Factor in general: -1 / elem
+    // Make `tableau[row][pivotColumn]` := 0.
+    // Factor in general: -elem / pivotElem
+    addMultipleOfRow(pivotRow, -elem, row);
   }
 
   // Swap the pivot column with the implictly constructed column vector.

--- a/lib/Scheduling/SimplexScheduler.cpp
+++ b/lib/Scheduling/SimplexScheduler.cpp
@@ -91,7 +91,7 @@ private:
   ///
   /// This vector stores the numeric IDs of non-basic variables. A variable's
   /// index *i* in this vector corresponds to the tableau *column*
-  /// `firstNonBasicVariableColum`+*i*.
+  /// `firstNonBasicVariableColumn`+*i*.
   SmallVector<unsigned> nonBasicVariables;
 
   /// This vector store the numeric IDs of basic variables. A variable's index
@@ -146,7 +146,8 @@ void SimplexScheduler::buildTableau() {
   // Assign column and variable numbers to the operations' start times.
   for (auto *op : prob.getOperations()) {
     opCols[op] = firstNonBasicVariableColumn + varNum;
-    nonBasicVariables.push_back(varNum++);
+    nonBasicVariables.push_back(varNum);
+    ++varNum;
   }
 
   // `parameterOneColumn` + `parameterIIColumn` + one column per operation
@@ -166,7 +167,8 @@ void SimplexScheduler::buildTableau() {
   for (auto *op : prob.getOperations()) {
     for (auto &dep : prob.getDependences(op)) {
       auto &consRowVec = addRow();
-      basicVariables.push_back(varNum++);
+      basicVariables.push_back(varNum);
+      ++varNum;
 
       Operation *src = dep.getSource();
       Operation *dst = dep.getDestination();

--- a/test/Scheduling/cyclic-problems.mlir
+++ b/test/Scheduling/cyclic-problems.mlir
@@ -21,3 +21,66 @@ func @cyclic(%a1 : i32, %a2 : i32) -> i32 attributes {
   // SIMPLEX-NEXT: simplexStartTime = 3
   return { problemStartTime = 4 } %3 : i32
 }
+
+// SIMPLEX-LABEL: mobility
+// SIMPLEX-SAME: simplexInitiationInterval = 3
+func @mobility() attributes {
+  problemInitiationInterval = 3,
+  auxdeps = [
+    [0,1], [0,2], [1,3], [2,3],
+    [3,4], [3,5], [4,6], [5,6],
+    [5,2,1]
+  ],
+  operatortypes = [ { name = "_4", latency = 4 }]
+  } {
+  // SIMPLEX-NEXT: simplexStartTime = 0
+  %0 = constant { problemStartTime = 0 } 0 : i32
+  // SIMPLEX-NEXT: simplexStartTime = 1
+  %1 = constant { opr = "_4", problemStartTime = 1 } 1 : i32
+  // SIMPLEX-NEXT: simplexStartTime = 4
+  %2 = constant { problemStartTime = 4 } 2 : i32
+  // SIMPLEX-NEXT: simplexStartTime = 5
+  %3 = constant { problemStartTime = 5 } 3 : i32
+  // SIMPLEX-NEXT: simplexStartTime = 6
+  %4 = constant { opr = "_4", problemStartTime = 6 } 4 : i32
+  // SIMPLEX-NEXT: simplexStartTime = 6
+  %5 = constant { problemStartTime = 6} 5 : i32
+  // SIMPLEX-NEXT: simplexStartTime = 10
+  return { problemStartTime = 10 }
+}
+
+// SIMPLEX-LABEL: interleaved_cycles
+// SIMPLEX-SAME: simplexInitiationInterval = 4
+func @interleaved_cycles() attributes {
+  problemInitiationInterval = 4,
+  auxdeps = [
+    [0,1], [0,2], [1,3], [2,3],
+    [3,4], [4,7], [3,5], [5,6], [6,7],
+    [7,8], [7,9], [8,10], [9,10],
+    [6,2,2], [9,5,2]
+  ],
+  operatortypes = [ { name = "_10", latency = 10 } ]
+  } {
+  // SIMPLEX-NEXT: simplexStartTime = 0
+  %0 = constant { problemStartTime = 0 } 0 : i32
+  // SIMPLEX-NEXT: simplexStartTime = 1
+  %1 = constant { opr = "_10", problemStartTime = 1 } 1 : i32
+  // SIMPLEX-NEXT: simplexStartTime = 10
+  %2 = constant { problemStartTime = 10 } 2 : i32
+  // SIMPLEX-NEXT: simplexStartTime = 11
+  %3 = constant { problemStartTime = 11 } 3 : i32
+  // SIMPLEX-NEXT: simplexStartTime = 12
+  %4 = constant { opr = "_10", problemStartTime = 12 } 4 : i32
+  // SIMPLEX-NEXT: simplexStartTime = 16
+  %5 = constant { problemStartTime = 16 } 5 : i32
+  // SIMPLEX-NEXT: simplexStartTime = 17
+  %6 = constant { problemStartTime = 17 } 6 : i32
+  // SIMPLEX-NEXT: simplexStartTime = 22
+  %7 = constant { problemStartTime = 22 } 7 : i32
+  // SIMPLEX-NEXT: simplexStartTime = 23
+  %8 = constant { opr = "_10", problemStartTime = 23 } 8 : i32
+  // SIMPLEX-NEXT: simplexStartTime = 23
+  %9 = constant { problemStartTime = 23 } 9 : i32
+  // SIMPLEX-NEXT: simplexStartTime = 33
+  return { problemStartTime = 33 }
+}

--- a/test/Scheduling/cyclic-problems.mlir
+++ b/test/Scheduling/cyclic-problems.mlir
@@ -10,7 +10,7 @@ func @cyclic(%a1 : i32, %a2 : i32) -> i32 attributes {
   } {
   // SIMPLEX-NEXT: simplexStartTime = 0
   %0 = constant { problemStartTime = 0 } 42 : i32
-  // SIMPLEX-NEXT: simplexStartTime = 2
+  // SIMPLEX-NEXT: simplexStartTime = 1
   %1 = addi %a1, %a2 { opr = "_0", problemStartTime = 2 } : i32
   // SIMPLEX-NEXT: simplexStartTime = 0
   %2 = subi %a2, %a1 { opr = "_2", problemStartTime = 0 } : i32

--- a/test/Scheduling/cyclic-problems.mlir
+++ b/test/Scheduling/cyclic-problems.mlir
@@ -9,15 +9,15 @@ func @cyclic(%a1 : i32, %a2 : i32) -> i32 attributes {
   operatortypes = [ { name = "_0", latency = 0 }, { name = "_2", latency = 2 } ]
   } {
   // SIMPLEX-NEXT: simplexStartTime = 0
-  %c42 = constant { problemStartTime = 0 } 42 : i32
+  %0 = constant { problemStartTime = 0 } 42 : i32
   // SIMPLEX-NEXT: simplexStartTime = 2
-  %0 = addi %a1, %a2 { opr = "_0", problemStartTime = 2 } : i32
+  %1 = addi %a1, %a2 { opr = "_0", problemStartTime = 2 } : i32
   // SIMPLEX-NEXT: simplexStartTime = 0
-  %1 = subi %a2, %a1 { opr = "_2", problemStartTime = 0 } : i32
+  %2 = subi %a2, %a1 { opr = "_2", problemStartTime = 0 } : i32
   // SIMPLEX-NEXT: simplexStartTime = 2
-  %2 = muli %0, %1 { problemStartTime = 2 } : i32
+  %3 = muli %1, %2 { problemStartTime = 2 } : i32
   // SIMPLEX-NEXT: simplexStartTime = 2
-  %3 = divi_unsigned %1, %c42 { problemStartTime = 3 } : i32
+  %4 = divi_unsigned %2, %0 { problemStartTime = 3 } : i32
   // SIMPLEX-NEXT: simplexStartTime = 3
-  return { problemStartTime = 4 } %2 : i32
+  return { problemStartTime = 4 } %3 : i32
 }

--- a/test/Scheduling/cyclic-problems.mlir
+++ b/test/Scheduling/cyclic-problems.mlir
@@ -1,14 +1,23 @@
 // RUN: circt-opt %s -test-cyclic-problem
+// RUN: circt-opt %s -test-simplex-scheduler | FileCheck %s -check-prefix=SIMPLEX
 
+// SIMPLEX-LABEL: cyclic
+// SIMPLEX-SAME: simplexInitiationInterval = 2
 func @cyclic(%a1 : i32, %a2 : i32) -> i32 attributes {
   problemInitiationInterval = 2,
   auxdeps = [ [4,1,1], [4,2,2] ],
   operatortypes = [ { name = "_0", latency = 0 }, { name = "_2", latency = 2 } ]
   } {
+  // SIMPLEX-NEXT: simplexStartTime = 0
   %c42 = constant { problemStartTime = 0 } 42 : i32
+  // SIMPLEX-NEXT: simplexStartTime = 2
   %0 = addi %a1, %a2 { opr = "_0", problemStartTime = 2 } : i32
+  // SIMPLEX-NEXT: simplexStartTime = 0
   %1 = subi %a2, %a1 { opr = "_2", problemStartTime = 0 } : i32
+  // SIMPLEX-NEXT: simplexStartTime = 2
   %2 = muli %0, %1 { problemStartTime = 2 } : i32
+  // SIMPLEX-NEXT: simplexStartTime = 2
   %3 = divi_unsigned %1, %c42 { problemStartTime = 3 } : i32
+  // SIMPLEX-NEXT: simplexStartTime = 3
   return { problemStartTime = 4 } %2 : i32
 }

--- a/test/Scheduling/simplex-errors.mlir
+++ b/test/Scheduling/simplex-errors.mlir
@@ -1,0 +1,13 @@
+// RUN: circt-opt %s -test-simplex-scheduler -verify-diagnostics -split-input-file
+
+// expected-error@+2 {{problem is infeasible}}
+// expected-error@+1 {{scheduling failed}}
+func @cyclic_graph() attributes {
+  auxdeps = [ [0,1], [1,2], [2,3], [3,1] ]
+  } {
+  %0 = constant 0 : i32
+  %1 = constant 1 : i32
+  %2 = constant 2 : i32
+  %3 = constant 3 : i32
+  return
+}


### PR DESCRIPTION
This scheduler uses linear programming and a handwritten simplex solver to compute the II and start times for the `CyclicProblem`. I'll add support for the basic `Problem` in a later PR.

This is an implementation of the approach proposed in:
> B. D. de Dinechin, "Simplex Scheduling: More than Lifetime-Sensitive Instruction Scheduling", PRISM 1994.22, 1994.
([Paper on ResearchGate](https://www.researchgate.net/publication/2607040_Simplex_Scheduling_More_than_Lifetime-Sensitive_Instruction_Scheduling))


**Rationale** Linear programming is the superior framework for tackling the "computing start times"-aspect of scheduling problems, so I wanted to have LP-based scheduling technology as soon as possible. This, of course, requires an LP solver. I decided to implement this very basic and non-generic simplex solver myself to have a default option available in CIRCT that does not require external libraries. I do not plan to expose the simplex solver as a standalone utility to other parts of CIRCT, but will rather look into integrating existing solvers ([Google OR tools](https://developers.google.com/optimization/) look promising) as optional library dependencies.
