### PR TITLE
[CI] Update pull request testing image

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build LLVM
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/circt/images/circt-ci-build:20210516180131
+      image: ghcr.io/circt/images/circt-ci-build:20210808063912
     steps:
       # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
       # time.
@@ -88,7 +88,7 @@ jobs:
     needs: build-llvm
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/circt/images/circt-ci-build:20210516180131
+      image: ghcr.io/circt/images/circt-ci-build:20210808063912
     steps:
       - name: Configure Environment
         run: echo "$GITHUB_WORKSPACE/llvm/install/bin" >> $GITHUB_PATH


### PR DESCRIPTION
The new image uses LLVM 12, notably pulling in a newer version of clang
and clang-format.