### PR TITLE
[Scheduling] Support for basic problems in the simplex scheduler.

### DIFF
--- a/include/circt/Scheduling/Algorithms.h
+++ b/include/circt/Scheduling/Algorithms.h
@@ -32,6 +32,11 @@ LogicalResult scheduleASAP(Problem &prob);
 /// distance.
 LogicalResult scheduleSimplex(CyclicProblem &prob, Operation *lastOp);
 
+/// Solve the basic problem with the aforementioned simplex scheduler. The
+/// objective is to minimize the start time of the given \p lastOp. Fails if the
+/// dependence graph contains cycles.
+LogicalResult scheduleSimplex(Problem &prob, Operation *lastOp);
+
 } // namespace scheduling
 } // namespace circt
 

--- a/lib/Scheduling/SimplexScheduler.cpp
+++ b/lib/Scheduling/SimplexScheduler.cpp
@@ -161,8 +161,8 @@ public:
 };
 
 /// This class just provides storage for the `Problem` reference; otherwise,
-/// the algorithm implementation in the base class is sufficient to solve
-/// acyclic problems.
+/// the algorithm implementation in the base class is already sufficient to
+/// solve acyclic problems.
 class AcyclicSimplexScheduler : public SimplexSchedulerBase {
 private:
   Problem &prob;

--- a/test/Scheduling/problems.mlir
+++ b/test/Scheduling/problems.mlir
@@ -1,7 +1,9 @@
 // RUN: circt-opt %s -test-scheduling-problem -allow-unregistered-dialect
 // RUN: circt-opt %s -test-asap-scheduler -allow-unregistered-dialect | FileCheck %s -check-prefix=ASAP
+// RUN: circt-opt %s -test-simplex-scheduler=acyclic -allow-unregistered-dialect | FileCheck %s -check-prefix=SIMPLEX
 
 // ASAP-LABEL: unit_latencies
+// SIMPLEX-LABEL: unit_latencies
 func @unit_latencies(%a1 : i32, %a2 : i32, %a3 : i32, %a4 : i32) -> i32 {
   // ASAP-NEXT: asapStartTime = 0
   %0 = addi %a1, %a2 { problemStartTime = 0 } : i32
@@ -18,10 +20,13 @@ func @unit_latencies(%a1 : i32, %a2 : i32, %a3 : i32, %a4 : i32) -> i32 {
   // ASAP-NEXT: asapStartTime = 5
   %6 = "more.operands"(%3, %4, %5) { problemStartTime = 6 } : (i32, i32, i32) -> i32
   // ASAP-NEXT: asapStartTime = 6
+  // SIMPLEX: return
+  // SIMPLEX-SAME: simplexStartTime = 6
   return { problemStartTime = 7 } %6 : i32
 }
 
 // ASAP-LABEL: arbitrary_latencies
+// SIMPLEX-LABEL: arbitrary_latencies
 func @arbitrary_latencies(%v : complex<f32>) -> f32 attributes {
   operatortypes = [
     { name = "extr", latency = 0 },
@@ -42,10 +47,13 @@ func @arbitrary_latencies(%v : complex<f32>) -> f32 attributes {
   // ASAP-NEXT: asapStartTime = 9
   %5 = "math.sqrt"(%4) { opr = "sqrt", problemStartTime = 50 } : (f32) -> f32
   // ASAP-NEXT: asapStartTime = 19
+  // SIMPLEX: return
+  // SIMPLEX-SAME: simplexStartTime = 19
   return { problemStartTime = 60 } %5 : f32
 }
 
 // ASAP-LABEL: auxiliary_dependences
+// SIMPLEX-LABEL: auxiliary_dependences
 func @auxiliary_dependences() attributes { auxdeps = [
     [0,1], [0,2], [2,3], [3,4], [3,6], [4,5], [5,6]
   ] } {
@@ -62,5 +70,7 @@ func @auxiliary_dependences() attributes { auxdeps = [
   // ASAP-NEXT: asapStartTime = 4
   %5 = constant { problemStartTime = 5 } 5 : i32
   // ASAP-NEXT: asapStartTime = 5
+  // SIMPLEX: return
+  // SIMPLEX-SAME: simplexStartTime = 5
   return { problemStartTime = 6 }
 }


### PR DESCRIPTION
The simplex scheduler can also solve basic `Problem`s with the following changes:
- Don't query the dependence distance (instead always assume distance=0).
- Ignore the initiation interval, and don't attempt to store it in the solution.