### PR TITLE
[FIRRTL] Constant prop registers with self-init to mux pattern

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1523,7 +1523,7 @@ LogicalResult MemOp::canonicalize(MemOp op, PatternRewriter &rewriter) {
 
 // Turn synchronous reset looking register updates to registers with resets
 // Also, const prop registers that are driven by a mux tree containing only
-// instances of one constant or self-assigns. 
+// instances of one constant or self-assigns.
 static LogicalResult foldHiddenReset(RegOp reg, PatternRewriter &rewriter) {
   // reg ; connect(reg, mux(port, const, val)) ->
   // reg.reset(port, const); connect(reg, val)
@@ -1553,10 +1553,10 @@ static LogicalResult foldHiddenReset(RegOp reg, PatternRewriter &rewriter) {
   // Reset value must be constant
   auto constOp = dyn_cast_or_null<ConstantOp>(high);
 
-  // Detect the case if a register only has two possible drivers: 
-  // (1) itself/uninit and (2) constant. 
-  // The mux can then be replaced with the constant. 
-  // r = mux(cond, r, 3) --> r = 3 
+  // Detect the case if a register only has two possible drivers:
+  // (1) itself/uninit and (2) constant.
+  // The mux can then be replaced with the constant.
+  // r = mux(cond, r, 3) --> r = 3
   // r = mux(cond, 3, r) --> r = 3
   bool constReg = false;
 

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1521,7 +1521,7 @@ LogicalResult MemOp::canonicalize(MemOp op, PatternRewriter &rewriter) {
 // Declarations
 //===----------------------------------------------------------------------===//
 
-// Turn synchronous reset looking register updates to registers with resets
+// Turn synchronous reset looking register updates to registers with resets.
 // Also, const prop registers that are driven by a mux tree containing only
 // instances of one constant or self-assigns.
 static LogicalResult foldHiddenReset(RegOp reg, PatternRewriter &rewriter) {

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1522,6 +1522,8 @@ LogicalResult MemOp::canonicalize(MemOp op, PatternRewriter &rewriter) {
 //===----------------------------------------------------------------------===//
 
 // Turn synchronous reset looking register updates to registers with resets
+// Also, const prop registers that are driven by a mux tree containing only
+// instances of one constant or self-assigns. 
 static LogicalResult foldHiddenReset(RegOp reg, PatternRewriter &rewriter) {
   // reg ; connect(reg, mux(port, const, val)) ->
   // reg.reset(port, const); connect(reg, val)
@@ -1546,9 +1548,24 @@ static LogicalResult foldHiddenReset(RegOp reg, PatternRewriter &rewriter) {
   auto mux = dyn_cast_or_null<MuxPrimOp>(con.src().getDefiningOp());
   if (!mux)
     return failure();
-
+  auto high = mux.high().getDefiningOp();
+  auto low = mux.low().getDefiningOp();
   // Reset value must be constant
-  auto constOp = dyn_cast_or_null<ConstantOp>(mux.high().getDefiningOp());
+  auto constOp = dyn_cast_or_null<ConstantOp>(high);
+
+  // Detect the case if a register only has two possible drivers: 
+  // (1) itself/uninit and (2) constant. 
+  // The mux can then be replaced with the constant. 
+  // r = mux(cond, r, 3) --> r = 3 
+  // r = mux(cond, 3, r) --> r = 3
+  bool constReg = false;
+
+  if (constOp && low == reg)
+    constReg = true;
+  else if (dyn_cast_or_null<ConstantOp>(low) && high == reg) {
+    constReg = true;
+    constOp = dyn_cast<ConstantOp>(low);
+  }
   if (!constOp)
     return failure();
 
@@ -1569,12 +1586,14 @@ static LogicalResult foldHiddenReset(RegOp reg, PatternRewriter &rewriter) {
   if (constOp != &con->getBlock()->front())
     constOp->moveBefore(&con->getBlock()->front());
 
-  rewriter.replaceOpWithNewOp<RegResetOp>(reg, reg.getType(), reg.clockVal(),
-                                          mux.sel(), mux.high(), reg.name(),
-                                          reg.annotations());
+  if (!constReg)
+    rewriter.replaceOpWithNewOp<RegResetOp>(reg, reg.getType(), reg.clockVal(),
+                                            mux.sel(), mux.high(), reg.name(),
+                                            reg.annotations());
   auto pt = rewriter.saveInsertionPoint();
   rewriter.setInsertionPoint(con);
-  rewriter.replaceOpWithNewOp<ConnectOp>(con, con.dest(), mux.low());
+  rewriter.replaceOpWithNewOp<ConnectOp>(con, con.dest(),
+                                         constReg ? constOp : mux.low());
   rewriter.restoreInsertionPoint(pt);
   return success();
 }

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -1917,8 +1917,8 @@ firrtl.module @constReg2(in %clock: !firrtl.clock,
   firrtl.connect %r2, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   %2 = firrtl.xor %r1, %r2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out, %2 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK:  %[[C11:.+]] = firrtl.constant 1 : !firrtl.uint<1>
-  // CHECK:  firrtl.connect %out, %[[C11]] 
+  // CHECK:  %[[C12:.+]] = firrtl.constant 1 : !firrtl.uint<1>
+  // CHECK:  firrtl.connect %out, %[[C12]] 
 }
 
 }

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -1892,4 +1892,33 @@ firrtl.module @dshifts_to_ishifts(in %a_in: !firrtl.sint<58>,
   firrtl.connect %c_out, %2 : !firrtl.sint<58>, !firrtl.sint<58>
 }
 
+// CHECK-LABEL: firrtl.module @constReg
+firrtl.module @constReg(in %clock: !firrtl.clock,
+              in %en: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
+  %r1 = firrtl.reg %clock  : !firrtl.uint<1>
+  %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+  %0 = firrtl.mux(%en, %c1_ui1, %r1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  firrtl.connect %r1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %out, %r1 : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK:  %[[C11:.+]] = firrtl.constant 1 : !firrtl.uint<1>
+  // CHECK:  firrtl.connect %out, %[[C11]] 
+}
+
+// CHECK-LABEL: firrtl.module @constReg
+firrtl.module @constReg2(in %clock: !firrtl.clock,
+              in %en: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
+  %r1 = firrtl.reg %clock  : !firrtl.uint<1>
+  %r2 = firrtl.reg %clock  : !firrtl.uint<1>
+  %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+  %0 = firrtl.mux(%en, %c1_ui1, %r1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  firrtl.connect %r1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+  %1 = firrtl.mux(%en, %r2, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  firrtl.connect %r2, %1 : !firrtl.uint<1>, !firrtl.uint<1>
+  %2 = firrtl.xor %r1, %r2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  firrtl.connect %out, %2 : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK:  %[[C11:.+]] = firrtl.constant 1 : !firrtl.uint<1>
+  // CHECK:  firrtl.connect %out, %[[C11]] 
+}
+
 }


### PR DESCRIPTION
Constant propagate registers that are driven by a mux tree containing only instances of one constant and self-assigns. 

Detect the case if a register only has two possible drivers:  (1) itself/uninit and (2) constant. 
The mux can then be replaced with the constant. 
``reg = mux(cond1, reg, 3)`` can be replaced with --> ``reg = 3 ``
``reg = mux(cond2, 3, reg)`` can be replaced with --> ``reg = 3``

Fix for https://github.com/llvm/circt/issues/1483 

