### PR TITLE
[Handshake] Fix lowering of std.CallOp to handshake.InstanceOp

### DIFF
--- a/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
+++ b/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
@@ -1296,7 +1296,7 @@ class LowerFuncOpTarget : public ConversionTarget {
 public:
   explicit LowerFuncOpTarget(MLIRContext &context) : ConversionTarget(context) {
     loweredFuncs.clear();
-    addLegalDialect<HandshakeOpsDialect>();
+    addLegalDialect<HandshakeDialect>();
     addLegalDialect<StandardOpsDialect>();
     /// The root function operation to be replaced is marked dynamically legal
     /// based on the lowering status of the given function, see

--- a/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
+++ b/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
@@ -1374,7 +1374,7 @@ LogicalResult lowerToHandshake(TFuncOp op, MLIRContext *context,
 
 // Convenience function for running lowerToHandshake with a partial
 // handshake::FuncOp lowering function.
-template <typename TFuncOp = handshake::FuncOp>
+template <typename TFuncOp>
 std::function<LogicalResult(TFuncOp)> wrapRewriter(
     const std::function<LogicalResult(TFuncOp, ConversionPatternRewriter &)>
         &loweringFunc,

--- a/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
+++ b/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
@@ -1741,17 +1741,9 @@ struct HandshakeDataflowPass
   void runOnOperation() override {
     ModuleOp m = getOperation();
 
-    WalkResult result = m.walk([&](mlir::FuncOp allocOp) {
-      if (failed(
-              lowerFuncOp(*m.getOps<mlir::FuncOp>().begin(), &getContext()))) {
+    for (auto funcOp : llvm::make_early_inc_range(m.getOps<mlir::FuncOp>())) {
+      if (failed(lowerFuncOp(funcOp, &getContext())))
         signalPassFailure();
-        return WalkResult::interrupt();
-      }
-      return WalkResult::advance();
-    });
-
-    if (result.wasInterrupted()) {
-      return;
     }
 
     // Legalize the resulting regions, which can have no basic blocks.

--- a/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
+++ b/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
@@ -1362,7 +1362,7 @@ private:
 ///
 template <typename TConv, typename TFuncOp, typename... TArgs>
 LogicalResult lowerToHandshake(TFuncOp op, MLIRContext *context,
-                               TArgs &... args) {
+                               TArgs &...args) {
   RewritePatternSet patterns(context);
   auto target = LowerFuncOpTarget<TFuncOp>(*context);
   LogicalResult partialLoweringSuccessfull = success();

--- a/test/Conversion/StandardToHandshake/test_call.mlir
+++ b/test/Conversion/StandardToHandshake/test_call.mlir
@@ -1,0 +1,24 @@
+// RUN: circt-opt -create-dataflow %s | FileCheck %s
+func @bar(%0 : i32) -> i32 {
+// CHECK-LABEL:   handshake.func @bar(
+// CHECK-SAME:                        %[[VAL_0:.*]]: i32,
+// CHECK-SAME:                        %[[VAL_1:.*]]: none, ...) -> (i32, none) {
+// CHECK:           %[[VAL_2:.*]] = "handshake.merge"(%[[VAL_0]]) : (i32) -> i32
+// CHECK:           handshake.return %[[VAL_2]], %[[VAL_1]] : i32, none
+// CHECK:         }
+
+  return %0 : i32
+}
+
+func @foo(%0 : i32) -> i32 {
+// CHECK-LABEL:   handshake.func @foo(
+// CHECK-SAME:                        %[[VAL_0:.*]]: i32,
+// CHECK-SAME:                        %[[VAL_1:.*]]: none, ...) -> (i32, none) {
+// CHECK:           %[[VAL_2:.*]] = "handshake.merge"(%[[VAL_0]]) : (i32) -> i32
+// CHECK:           %[[VAL_3:.*]] = handshake.instance @bar(%[[VAL_2]]) : (i32) -> i32
+// CHECK:           handshake.return %[[VAL_3]], %[[VAL_1]] : i32, none
+// CHECK:         }
+
+  %a1 = call @bar(%0) : (i32) -> i32
+  return %a1 : i32
+}


### PR DESCRIPTION
## The problem
To preface this PR, let's start with an example. Take the following std input:
```mlir
func @f(%a : i32) -> i32 {
    return %a : i32
}

func @top(%a : i32) -> i32 {
    %a2 = call @f(%a) : (i32) -> i32
    return %a2 : i32
}
```

this currently gets lowered to:
```mlir
module  {
  handshake.func @f(%arg0: i32, %arg1: none, ...) -> (i32, none) {
    %0 = "handshake.merge"(%arg0) : (i32) -> i32
    handshake.return %0, %arg1 : i32, none
  }
  handshake.func @top(%arg0: i32, %arg1: none, ...) -> (i32, none) {
    %0 = "handshake.merge"(%arg0) : (i32) -> i32
    %1:2 = "handshake.fork"(%0) {control = false} : (i32) -> (i32, i32) // invalid fork, arg0 is single use
    %2 = handshake.instance @f(%1#0) : (i32) -> i32
    "handshake.sink"(%2) : (i32) -> () // invalid sink, %2 is used by handshake.return
    handshake.return %2, %arg1 : i32, none
  }
}
```

wherein we would expect the lowering to be:
```mlir
module  {
  handshake.func @f(%arg0: i32, %arg1: none, ...) -> (i32, none) {
    %0 = "handshake.merge"(%arg0) : (i32) -> i32
    handshake.return %0, %arg1 : i32, none
  }
  handshake.func @top(%arg0: i32, %arg1: none, ...) -> (i32, none) {
    %0 = "handshake.merge"(%arg0) : (i32) -> i32
    %1 = handshake.instance @f(%0, %arg1) : (i32) -> i32
    handshake.return %1, %arg1 : i32, none 
  }
}
```

If we take a look at the body of the function after `addSinkOps` in `FuncOpLowering` we get a bit of insight into the problem:

```mlir
^bb0(%arg0: i32):  // no predecessors
  %0 = "handshake.merge"(%arg0) : (i32) -> i32
  %1 = "handshake.start"() {control = true} : () -> none
  %2 = call @f(%0) : (i32) -> i32
  %3 = handshake.instance @f(%0) : (i32) -> i32
  "handshake.sink"(%3) : (i32) -> ()
  handshake.return %2, %1 : i32, none
  return
```

Even though the `call` op was expected to be replaced in `replaceCallOps` by a call to `rewriter.replaceOpWithNewOp`, the _actual_ replacement has not happened when sinks are inserted, and as such, a sink op is added to `%3` due to it looking like an unreferenced variable.

From https://mlir.llvm.org/docs/DialectConversion/: 

> ... the conversion process does not necessarily update operations in-place and instead creates a mapping of events such as replacements and erasures, and only applies them when the entire conversion process is successful.

This conflicts with how StandardToHandshake is written; the sequential lowering functions are applied without regards to this. This, surprisingly, only seem to present itself as an issue when lowering `std.call` to `handshake.instance`.

## Proposed fix

The PR adds a `wrapRewriter` which wraps the partial lowering functions already in place (such as `replaceCallOps`, `addForkOps`...). This rewriter composes a bit of supporting code (`lowerToHandshake`, `PartialLowerFuncOp`) that creates an instance of a `ConversionTarget` as well as an application of `applyPartialConversion`. The end result is that any rewriting **and** their side effects (most importantly modifications to referencing SSA values) made within each of the partial lowering functions are fully "comitted" after a partial lowering function returns. While being a bit hacky, I suspect that this structure might be generally useful for conversion passes which is heavily dependent on some sequence of transformations being applied in a specific order, where the author does not want to write distinct transformation passes for each of these steps.

Apart from fixing the issue with std.call lowering, there are no changes wrt. StandardToHandshake lowering logic.

Finally, executing handshake.instance ops is currently not supported in the handshake runner. I’m planning to add support for handshake.instance in an upcoming commit, alongside tests for this.
