### PR TITLE
[FIRRTL] Implement SFC's RemoveCHIRRTL pass

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -167,6 +167,15 @@ def SubfieldOp : FIRRTLExprOp<"subfield"> {
   let assemblyFormat =
     "$input `(` $fieldIndex `)` attr-dict `:` functional-type($input, $result)";
 
+  let builders = [
+    OpBuilder<(ins "Value":$input, "StringRef":$fieldName), [{
+      auto bundleType = input.getType().cast<BundleType>();
+      auto fieldIndex = bundleType.getElementIndex(fieldName);
+      assert(fieldIndex.hasValue() && "subfield operation to unknown field");
+      return build($_builder, $_state, input, *fieldIndex);
+    }]>
+  ];
+
   let firrtlExtraClassDeclaration = [{
     /// Return true if the specified field is flipped.
     bool isFieldFlipped();

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -142,6 +142,19 @@ enum class ReadPortSubfield { addr, en, clk, data };
 enum class WritePortSubfield { addr, en, clk, data, mask };
 enum class ReadWritePortSubfield { addr, en, clk, rdata, wmode, wdata, wmask };
 
+/// Allow 'or'ing MemDirAttr.  This allows combining Read and Write into
+/// ReadWrite.
+inline MemDirAttr operator|(MemDirAttr lhs, MemDirAttr rhs) {
+  return static_cast<MemDirAttr>(
+      static_cast<std::underlying_type<MemDirAttr>::type>(lhs) |
+      static_cast<std::underlying_type<MemDirAttr>::type>(rhs));
+}
+
+inline MemDirAttr &operator|=(MemDirAttr &lhs, MemDirAttr rhs) {
+  lhs = lhs | rhs;
+  return lhs;
+}
+
 // Out-of-line implementation of various trait verification methods and
 // functions commonly used among operations.
 namespace impl {

--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -28,6 +28,8 @@ std::unique_ptr<mlir::Pass> createLowerFIRRTLTypesPass();
 
 std::unique_ptr<mlir::Pass> createLowerBundleVectorTypesPass();
 
+std::unique_ptr<mlir::Pass> createLowerCHIRRTLPass();
+
 std::unique_ptr<mlir::Pass> createIMConstPropPass();
 
 std::unique_ptr<mlir::Pass> createInlinerPass();
@@ -35,8 +37,6 @@ std::unique_ptr<mlir::Pass> createInlinerPass();
 std::unique_ptr<mlir::Pass> createBlackBoxMemoryPass();
 
 std::unique_ptr<mlir::Pass> createExpandWhensPass();
-
-std::unique_ptr<mlir::Pass> createInferMemoriesPass();
 
 std::unique_ptr<mlir::Pass> createInferWidthsPass();
 

--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -36,6 +36,8 @@ std::unique_ptr<mlir::Pass> createBlackBoxMemoryPass();
 
 std::unique_ptr<mlir::Pass> createExpandWhensPass();
 
+std::unique_ptr<mlir::Pass> createInferMemoriesPass();
+
 std::unique_ptr<mlir::Pass> createInferWidthsPass();
 
 std::unique_ptr<mlir::Pass> createInferResetsPass();

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -100,6 +100,39 @@ def ExpandWhens : Pass<"firrtl-expand-whens", "firrtl::FModuleOp"> {
   let constructor = "circt::firrtl::createExpandWhensPass()";
 }
 
+def InferMemories : Pass<"firrtl-infer-memories", "firrtl::FModuleOp"> {
+  let summary = "Infer the memory ports of SeqMem and CombMem";
+  let description = [{
+      This pass finds the CHIRRTL behavioral memories and their ports, and
+      transforms them into standard FIRRTL memory operations.  For each
+      `seqmem` or `combmem`, a new memory is created.  For every `memoryport`
+      operation using a CHIRRTL memory, a memory port is defined on the
+      new standard memory.
+
+      The direction or kind of the port is inferred from how each of the memory
+      ports is used in the IR. If a memory port is only written to, it becomes
+      a `Write` port.  If a memory port is only read from, it become a `Read`
+      port.  If it is used both ways, it becomes a `ReadWrite` port.
+
+      `Write`, `ReadWrite` and combinational `Read` ports are disabled by
+      default, but then enabled when the CHIRRTL memory port is declared.
+      Sequential `Read` ports have more complicated enable inference:
+
+      1. If a wire or register is used as the index of the memory port, then
+         the memory is enabled whenever a non-invalid value is driven to the
+         address. 
+      2. If a node is used as the index of the memory port, then the memory is
+         enabled at the declaration of the node.
+      3. In all other cases, the memory is never enabled.
+
+      In the first two cases, they can easily produce a situation where we try
+      to enable the memory before it is even declared. This produces a
+      compilation error.
+
+  }];
+  let constructor = "circt::firrtl::createInferMemoriesPass()";
+}
+
 def InferWidths : Pass<"firrtl-infer-widths", "firrtl::CircuitOp"> {
   let summary = "Infer the width of types";
   let description = [{

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -100,7 +100,7 @@ def ExpandWhens : Pass<"firrtl-expand-whens", "firrtl::FModuleOp"> {
   let constructor = "circt::firrtl::createExpandWhensPass()";
 }
 
-def InferMemories : Pass<"firrtl-infer-memories", "firrtl::FModuleOp"> {
+def LowerCHIRRTL : Pass<"firrtl-lower-chirrtl", "firrtl::FModuleOp"> {
   let summary = "Infer the memory ports of SeqMem and CombMem";
   let description = [{
       This pass finds the CHIRRTL behavioral memories and their ports, and
@@ -130,7 +130,7 @@ def InferMemories : Pass<"firrtl-infer-memories", "firrtl::FModuleOp"> {
       compilation error.
 
   }];
-  let constructor = "circt::firrtl::createInferMemoriesPass()";
+  let constructor = "circt::firrtl::createLowerCHIRRTLPass()";
 }
 
 def InferWidths : Pass<"firrtl-infer-widths", "firrtl::CircuitOp"> {

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -1,17 +1,17 @@
 add_circt_dialect_library(CIRCTFIRRTLTransforms
   BlackBoxMemory.cpp
   BlackBoxReader.cpp
+  CheckCombCycles.cpp
   ExpandWhens.cpp
   GrandCentral.cpp
   GrandCentralTaps.cpp
   IMConstProp.cpp
-  InferMemories.cpp
-  InferWidths.cpp
   InferResets.cpp
+  InferWidths.cpp
+  LowerCHIRRTL.cpp
   LowerTypes.cpp
   ModuleInliner.cpp
   PrintInstanceGraph.cpp
-  CheckCombCycles.cpp
 
   DEPENDS
   CIRCTFIRRTLTransformsIncGen

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -5,6 +5,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   GrandCentral.cpp
   GrandCentralTaps.cpp
   IMConstProp.cpp
+  InferMemories.cpp
   InferWidths.cpp
   InferResets.cpp
   LowerTypes.cpp

--- a/lib/Dialect/FIRRTL/Transforms/InferMemories.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferMemories.cpp
@@ -1,0 +1,718 @@
+//===- InferMemories.cpp ----------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//===----------------------------------------------------------------------===//
+//
+// Transform CHIRRTL memory operations and memory ports into standard FIRRTL
+// memory operations.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
+#include "circt/Dialect/FIRRTL/FIRRTLVisitors.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/OperationSupport.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace circt;
+using namespace firrtl;
+
+namespace {
+struct InferMemoriesPass : public InferMemoriesBase<InferMemoriesPass>,
+                           public FIRRTLVisitor<InferMemoriesPass> {
+
+  using FIRRTLVisitor<InferMemoriesPass>::visitDecl;
+  using FIRRTLVisitor<InferMemoriesPass>::visitExpr;
+  using FIRRTLVisitor<InferMemoriesPass>::visitStmt;
+
+  void visitDecl(CombMemOp op);
+  void visitDecl(SeqMemOp op);
+  void visitStmt(MemoryPortOp op);
+  void visitExpr(SubaccessOp op);
+  void visitExpr(SubfieldOp op);
+  void visitExpr(SubindexOp op);
+  void visitStmt(ConnectOp op);
+  void visitStmt(PartialConnectOp op);
+  void visitUnhandledOp(Operation *op);
+
+  /// Get a the constant 0.  This constant is inserted at the beginning of the
+  /// module.
+  Value getConstZero() {
+    if (!constZero) {
+      auto builder = OpBuilder::atBlockBegin(getOperation().getBodyBlock());
+      auto u1Type = UIntType::get(builder.getContext(), /*width*/ 1);
+      constZero = builder.create<ConstantOp>(builder.getUnknownLoc(), u1Type,
+                                             APInt(1, 0, false));
+    }
+    return constZero;
+  }
+
+  /// Get the constant 1.  This constant is inserted at the beginning of the
+  /// module.
+  Value getConstOne() {
+    if (!constOne) {
+      auto builder = OpBuilder::atBlockBegin(getOperation().getBodyBlock());
+      auto u1Type = UIntType::get(builder.getContext(), /*width*/ 1);
+      constOne = builder.create<ConstantOp>(builder.getUnknownLoc(), u1Type,
+                                            APInt(1, 1, false));
+    }
+    return constOne;
+  }
+
+  /// Get an invalid value of a certain type.  This will try to minimize the
+  /// number of invalid values created by this pass.
+  Value getInvalid(Type type) {
+    auto &invalid = invalidCache[type];
+    if (!invalid) {
+      auto builder = OpBuilder::atBlockBegin(getOperation().getBodyBlock());
+      invalid = builder.create<InvalidValueOp>(builder.getUnknownLoc(), type);
+    }
+    return invalid;
+  }
+
+  void clear() {
+    // Clear out any stale data.
+    constOne = nullptr;
+    constZero = nullptr;
+    invalidCache.clear();
+    opsToDelete.clear();
+    subfieldDirs.clear();
+    rdataValues.clear();
+    wdataValues.clear();
+  }
+
+  void emitInvalid(ImplicitLocOpBuilder &builder, Value value);
+
+  MemDirAttr inferMemoryPortKind(MemoryPortOp memPort);
+
+  void replaceMem(Operation *op, StringRef name, bool isSequential, RUWAttr ruw,
+                  ArrayAttr annotations);
+
+  template <typename OpType, typename... T>
+  void cloneSubindexOpForMemory(OpType op, Value input, T... operands);
+
+  void emitPartialConnectMask(
+      ImplicitLocOpBuilder builder, Type destType, Type srcType,
+      llvm::function_ref<Value(ImplicitLocOpBuilder &)> getSubAccess);
+
+  void runOnOperation() override;
+
+  /// Cached constants
+  Value constOne;
+  Value constZero;
+  DenseMap<Type, Value> invalidCache;
+
+  /// List of operations to delete at the end of the pass.
+  SmallVector<Operation *> opsToDelete;
+
+  /// This maps subfield-like if they are indexing memory to
+  DenseMap<Operation *, MemDirAttr> subfieldDirs;
+
+  /// This maps a subfield-like operation from a MemoryPortOp to a new subfield
+  /// operation which can be used to read from the MemoryOp. This is used to
+  /// update any operations to read from the new memory.
+  DenseMap<Value, Value> rdataValues;
+
+  /// This maps a subfield-like operation from a MemoryPortOp to a new subfield
+  /// operation which can be used to write to the memory, the mask value which
+  /// should be set to 1, and the the correspoding wmode port of the memory
+  /// which should be set to 1.  Not all memories have wmodes, so this field
+  /// can be null. This is used to update operations to write to the new memory.
+  struct WDataInfo {
+    Value data;
+    Value mask;
+    Value mode;
+  };
+  DenseMap<Value, WDataInfo> wdataValues;
+};
+} // end anonymous namespace
+
+/// Performs the callback for each leaf element of a value.  This will create
+/// any subindex and subfield operations needed to access the leaf values of the
+/// aggregate value.
+static void forEachLeaf(ImplicitLocOpBuilder &builder, Value value,
+                        llvm::function_ref<void(Value)> func) {
+  auto type = value.getType();
+  if (auto bundleType = type.dyn_cast<BundleType>()) {
+    for (size_t i = 0, e = bundleType.getNumElements(); i < e; ++i)
+      forEachLeaf(builder, builder.create<SubfieldOp>(value, i), func);
+  } else if (auto vectorType = type.dyn_cast<FVectorType>()) {
+    for (size_t i = 0, e = vectorType.getNumElements(); i != e; ++i)
+      forEachLeaf(builder, builder.create<SubindexOp>(value, i), func);
+  } else {
+    func(value);
+  }
+}
+
+/// Drive a value to all leafs of the input aggregate value. This only makes
+/// sense when all leaf values have the same type, since the same value will be
+/// connected to each leaf. This does not work for aggregates with flip types.
+static void connectLeafsTo(ImplicitLocOpBuilder &builder, Value bundle,
+                           Value value) {
+  forEachLeaf(builder, bundle,
+              [&](Value leaf) { builder.create<ConnectOp>(leaf, value); });
+}
+
+/// Connect each leaf of an aggregate type to invalid.  This does not support
+/// aggregates with flip types.
+void InferMemoriesPass::emitInvalid(ImplicitLocOpBuilder &builder,
+                                    Value value) {
+  forEachLeaf(builder, value, [&](Value leaf) {
+    builder.create<ConnectOp>(leaf, getInvalid(leaf.getType()));
+  });
+}
+
+/// Combines two MemDirAttrs into a new one which maintains the union of the
+/// Read and Write options.
+static MemDirAttr mergeDirection(MemDirAttr a, MemDirAttr b) {
+  if (a == MemDirAttr::ReadWrite || b == MemDirAttr::ReadWrite)
+    return MemDirAttr::ReadWrite;
+  if (a == MemDirAttr::Write) {
+    if (b == MemDirAttr::Read)
+      return MemDirAttr::ReadWrite;
+    // b == Write || b == Infer
+    return MemDirAttr::Write;
+  }
+  if (a == MemDirAttr::Read) {
+    if (b == MemDirAttr::Write)
+      return MemDirAttr::ReadWrite;
+    // b == Read || b == Infer
+    return MemDirAttr::Read;
+  }
+  // a == Infer
+  return b;
+}
+
+/// Converts a CHIRRTL memory port direction to a MemoryOp port type.  The
+/// biggest difference is that there is no match for the Infer port type.
+static MemOp::PortKind memDirAttrToPortKind(MemDirAttr direction) {
+  switch (direction) {
+  case MemDirAttr::Read:
+    return MemOp::PortKind::Read;
+  case MemDirAttr::Write:
+    return MemOp::PortKind::Write;
+  case MemDirAttr::ReadWrite:
+    return MemOp::PortKind::ReadWrite;
+  default:
+    llvm_unreachable(
+        "Unhandled MemDirAttr, was the port direction not inferred?");
+  }
+}
+
+/// This function infers the memory direction of each CHIRRTL memory port. Each
+/// memory port has an initial memory direction which is explicitly declared in
+/// the MemoryPortOp, which is used as a starting point.  For example, if the
+/// port is declared to be Write, but it is only ever read from, the port will
+/// become a ReadWrite port.
+///
+/// When the memory port is eventually replaced with a memory, we will go from
+/// having a single data value to having separate rdata and wdata values.  In
+/// this function we record how the result of each data subfield operation is
+/// used, so that later on we can make sure the SubfieldOp is cloned to index
+/// into the correct rdata and wdata fields of the memory.
+MemDirAttr InferMemoriesPass::inferMemoryPortKind(MemoryPortOp memPort) {
+  // This function does a depth-first walk of the use-lists of the memport
+  // operation to look through subindex operations and find the places where it
+  // is ultimately used.  At each node we record how the children ops are using
+  // the result of the current operation.  When we are done visiting the current
+  // operation we store how it is used into a global hashtable for later use.
+  // This records how both the MemoryPort and Subfield operations are used.
+  struct StackElement {
+    Operation *operation;
+    Operation::use_iterator iterator;
+    MemDirAttr mode;
+  };
+
+  SmallVector<StackElement> stack;
+  stack.push_back({memPort, memPort->use_begin(), memPort.direction()});
+  MemDirAttr mode = MemDirAttr::Infer;
+
+  while (!stack.empty()) {
+    auto *iter = &stack.back().iterator;
+    auto end = stack.back().operation->use_end();
+    stack.back().mode = mergeDirection(stack.back().mode, mode);
+
+    while (*iter != end) {
+      auto &element = stack.back();
+      auto &use = *(*iter);
+      auto *user = use.getOwner();
+      ++(*iter);
+      if (isa<SubindexOp, SubfieldOp>(user)) {
+        // We recurse into Subindex ops to find the leaf-uses.
+        stack.push_back({user, user->getUses().begin(), MemDirAttr::Infer});
+        mode = MemDirAttr::Infer;
+        iter = &stack.back().iterator;
+        end = user->use_end();
+        continue;
+      }
+      if (auto subaccessOp = dyn_cast<SubaccessOp>(user)) {
+        // Subaccess has two arguments, the vector and the index. If we are
+        // using the memory port as an index, we can ignore it. If we are using
+        // the memory as the vector, we need to recurse.
+        if (use.get() == subaccessOp.input()) {
+          stack.push_back({user, user->getUses().begin(), MemDirAttr::Infer});
+          mode = MemDirAttr::Infer;
+          iter = &stack.back().iterator;
+          end = user->use_end();
+          continue;
+        }
+        // Otherwise we are reading from a memory for the index.
+        element.mode = mergeDirection(element.mode, MemDirAttr::Read);
+      } else if (auto connectOp = dyn_cast<ConnectOp>(user)) {
+        if (use.get() == connectOp.dest()) {
+          element.mode = mergeDirection(element.mode, MemDirAttr::Write);
+        } else {
+          element.mode = mergeDirection(element.mode, MemDirAttr::Read);
+        }
+      } else if (auto partialConnectOp = dyn_cast<PartialConnectOp>(user)) {
+        if (use.get() == partialConnectOp.dest()) {
+          element.mode = mergeDirection(element.mode, MemDirAttr::Write);
+        } else {
+          element.mode = mergeDirection(element.mode, MemDirAttr::Read);
+        }
+      } else {
+        // Every other use of a memory is a read operation.
+        element.mode = mergeDirection(element.mode, MemDirAttr::Read);
+      }
+    }
+    mode = stack.back().mode;
+
+    // Store the direction of the current operation in the global map. This will
+    // be used later to determine if this subaccess operation needs to be cloned
+    // into rdata, wdata, and wmask.
+    subfieldDirs[stack.back().operation] = mode;
+    stack.pop_back();
+  }
+
+  return mode;
+}
+
+void InferMemoriesPass::replaceMem(Operation *cmem, StringRef name,
+                                   bool isSequential, RUWAttr ruw,
+                                   ArrayAttr annotations) {
+  assert(isa<CombMemOp>(cmem) || isa<SeqMemOp>(cmem));
+
+  // We have several early breaks in this function, so we record the CHIRRTL
+  // memory for deletion here.
+  opsToDelete.push_back(cmem);
+
+  auto cmemType = cmem->getResult(0).getType().cast<CMemoryType>();
+  auto depth = cmemType.getNumElements();
+  auto type = cmemType.getElementType();
+
+  // Collect the information from each of the CMemoryPorts.
+  struct PortInfo {
+    StringAttr name;
+    Type type;
+    Attribute annotations;
+    MemOp::PortKind portKind;
+    MemoryPortOp cmemPort;
+  };
+  SmallVector<PortInfo, 4> ports;
+  for (auto *user : cmem->getUsers()) {
+    auto cmemoryPort = cast<MemoryPortOp>(user);
+
+    // Infer the type of memory port we need to create.
+    auto portDirection = inferMemoryPortKind(cmemoryPort);
+
+    // If the memory port is never used, it will have the Infer type and should
+    // just be deleted. TODO: this is mirroring SFC, but should we be checking
+    // for annotations on the memory port before removing it?
+    if (portDirection == MemDirAttr::Infer)
+      continue;
+    auto portKind = memDirAttrToPortKind(portDirection);
+
+    // Add the new port.
+    ports.push_back({cmemoryPort.nameAttr(),
+                     MemOp::getTypeForPort(depth, type, portKind),
+                     cmemoryPort.annotationsAttr(), portKind, cmemoryPort});
+  }
+
+  // If there are no valid memory ports, don't create a memory.
+  if (ports.empty())
+    return;
+
+  // Canonicalize the ports into alphabetical order.
+  llvm::array_pod_sort(ports.begin(), ports.end(),
+                       [](const PortInfo *lhs, const PortInfo *rhs) -> int {
+                         return lhs->name.getValue().compare(
+                             rhs->name.getValue());
+                       });
+
+  SmallVector<Attribute, 4> resultNames;
+  SmallVector<Type, 4> resultTypes;
+  SmallVector<Attribute, 4> portAnnotations;
+  for (auto port : ports) {
+    resultNames.push_back(port.name);
+    resultTypes.push_back(port.type);
+    portAnnotations.push_back(port.annotations);
+  }
+
+  // Write latency is always 1, while the read latency depends on the memory
+  // type.
+  auto readLatency = isSequential ? 1 : 0;
+  auto writeLatency = 1;
+
+  // Create the memory.
+  ImplicitLocOpBuilder memBuilder(cmem->getLoc(), cmem);
+  auto memory = memBuilder.create<MemOp>(
+      resultTypes, readLatency, writeLatency, depth, ruw,
+      memBuilder.getArrayAttr(resultNames), name, annotations,
+      memBuilder.getArrayAttr(portAnnotations));
+
+  // Process each memory port, initializing the memory port and inferring when
+  // to set the enable signal high.
+  for (unsigned i = 0, e = memory.getNumResults(); i < e; ++i) {
+    auto cmemoryPort = ports[i].cmemPort;
+    auto memoryPort = memory.getResult(i);
+    auto portKind = ports[i].portKind;
+
+    // Most fields on the newly created memory will be assigned an initial value
+    // immediately following the memory decl, and then will be assigned a second
+    // value at the location of the CHIRRTL memory port.
+
+    // Initialization at the MemoryOp.
+    ImplicitLocOpBuilder portBuilder(cmemoryPort.getLoc(), cmemoryPort);
+    auto address = memBuilder.create<SubfieldOp>(memoryPort, "addr");
+    emitInvalid(memBuilder, address);
+    auto enable = memBuilder.create<SubfieldOp>(memoryPort, "en");
+    memBuilder.create<ConnectOp>(enable, getConstZero());
+    auto clock = memBuilder.create<SubfieldOp>(memoryPort, "clk");
+    emitInvalid(memBuilder, clock);
+
+    // Initialization at the MemoryPortOp
+    portBuilder.create<ConnectOp>(address, cmemoryPort.index());
+    // Sequential+Read ports have a more complicated "enable inference".
+    // Everything else sets the enable to true.
+    if (!(portKind == MemOp::PortKind::Read && isSequential)) {
+      portBuilder.create<ConnectOp>(enable, getConstOne());
+    }
+    portBuilder.create<ConnectOp>(clock, cmemoryPort.clock());
+
+    if (portKind == MemOp::PortKind::Read) {
+      // Store the read information for updating subfield ops.
+      auto data = memBuilder.create<SubfieldOp>(memoryPort, "data");
+      rdataValues[cmemoryPort] = data;
+    } else if (portKind == MemOp::PortKind::Write) {
+      // Initialization at the MemoryOp.
+      auto data = memBuilder.create<SubfieldOp>(memoryPort, "data");
+      emitInvalid(memBuilder, data);
+      auto mask = memBuilder.create<SubfieldOp>(memoryPort, "mask");
+      emitInvalid(memBuilder, mask);
+
+      // Initialization at the MemoryPortOp.
+      connectLeafsTo(portBuilder, mask, getConstZero());
+
+      // Store the write information for updating subfield ops.
+      wdataValues[cmemoryPort] = {data, mask, nullptr};
+    } else if (portKind == MemOp::PortKind::ReadWrite) {
+      // Initialization at the MemoryOp.
+      auto rdata = memBuilder.create<SubfieldOp>(memoryPort, "rdata");
+      auto wmode = memBuilder.create<SubfieldOp>(memoryPort, "wmode");
+      memBuilder.create<ConnectOp>(wmode, getConstZero());
+      auto wdata = memBuilder.create<SubfieldOp>(memoryPort, "wdata");
+      emitInvalid(memBuilder, wdata);
+      auto wmask = memBuilder.create<SubfieldOp>(memoryPort, "wmask");
+      emitInvalid(memBuilder, wmask);
+
+      // Initialization at the MemoryPortOp.
+      connectLeafsTo(portBuilder, wmask, getConstZero());
+
+      // Store the read and write information for updating subfield ops.
+      wdataValues[cmemoryPort] = {wdata, wmask, wmode};
+      rdataValues[cmemoryPort] = rdata;
+    }
+
+    // Sequential read only memory ports have "enable inference", which
+    // detects when to set the enable high. All other memory ports set the
+    // enable high when the memport is declared. This is higly questionable
+    // logic that is easily defeated. This behaviour depends on the kind of
+    // operation used as the memport index.
+    if (portKind == MemOp::PortKind::Read && isSequential) {
+      auto *indexOp = cmemoryPort.index().getDefiningOp();
+      bool success = false;
+      if (!indexOp) {
+        // TODO: SFC does not infer any enable when using a module port as the
+        // address.  This seems like something that should be fixed sooner
+        // rather than later.
+      } else if (isa<WireOp, RegResetOp, RegOp>(indexOp)) {
+        // If the address is a reference, then we set the enable whenever the
+        // address is driven.
+
+        // Find the uses of the address that write a value to it, ignoring the
+        // ones driving an invalid value.
+        auto drivers =
+            make_filter_range(indexOp->getUsers(), [&](Operation *op) {
+              if (auto connectOp = dyn_cast<ConnectOp>(op)) {
+                if (cmemoryPort.index() == connectOp.dest())
+                  return !dyn_cast_or_null<InvalidValueOp>(
+                      connectOp.src().getDefiningOp());
+              } else if (auto pConnectOp = dyn_cast<PartialConnectOp>(op)) {
+                if (cmemoryPort.index() == pConnectOp.dest())
+                  return !dyn_cast_or_null<InvalidValueOp>(
+                      pConnectOp.src().getDefiningOp());
+              }
+              return false;
+            });
+
+        // At each location where we drive a value to the index, set the enable.
+        for (auto *driver : drivers) {
+          OpBuilder(driver).create<ConnectOp>(driver->getLoc(), enable,
+                                              getConstOne());
+          success = true;
+        }
+      } else if (isa<NodeOp>(indexOp)) {
+        // If using a Node for the address, then the we place the enable at the
+        // Node op's
+        OpBuilder(indexOp).create<ConnectOp>(indexOp->getLoc(), enable,
+                                             getConstOne());
+        success = true;
+      }
+
+      // If we don't infer any enable points, it is almost always a user error.
+      if (!success)
+        cmemoryPort.emitWarning("memory port is never enabled");
+    }
+  }
+}
+
+void InferMemoriesPass::visitDecl(CombMemOp combmem) {
+  replaceMem(combmem, combmem.name(), /*isSequential*/ false,
+             RUWAttr::Undefined, combmem.annotations());
+}
+
+void InferMemoriesPass::visitDecl(SeqMemOp seqmem) {
+  replaceMem(seqmem, seqmem.name(), /*isSequential*/ true, seqmem.ruw(),
+             seqmem.annotations());
+}
+
+void InferMemoriesPass::visitStmt(MemoryPortOp memPort) {
+  // The memory port is mostly handled while processing the memory.
+  opsToDelete.push_back(memPort);
+}
+
+void InferMemoriesPass::visitStmt(ConnectOp connect) {
+  // Check if we are writing to a memory and, if we are, replace the
+  // destination.
+  auto writeIt = wdataValues.find(connect.dest());
+  if (writeIt != wdataValues.end()) {
+    auto writeData = writeIt->second;
+    connect.destMutable().assign(writeData.data);
+    // Assign the write mask.
+    ImplicitLocOpBuilder builder(connect.getLoc(), connect);
+    connectLeafsTo(builder, writeData.mask, getConstOne());
+    // Only ReadWrite memories have a write mode.
+    if (writeData.mode)
+      builder.create<ConnectOp>(writeData.mode, getConstOne());
+  }
+  // Check if we are reading from a memory and, if we are, replace the
+  // source.
+  auto readIt = rdataValues.find(connect.src());
+  if (readIt != rdataValues.end()) {
+    auto newSource = readIt->second;
+    connect.srcMutable().assign(newSource);
+  }
+}
+
+/// This will find which fields of an aggregate type are connected by a partial
+/// connect and connect the same field of the mask to 1. This function is
+/// recursive over the types of the destination and source of the partial
+/// connect. This uses lambdas to lazily emit subfield operations on the mask
+/// only when there is a valid pair-wise connection point.
+void InferMemoriesPass::emitPartialConnectMask(
+    ImplicitLocOpBuilder builder, Type destType, Type srcType,
+    llvm::function_ref<Value(ImplicitLocOpBuilder &)> getSubaccess) {
+  if (auto destBundle = destType.dyn_cast<BundleType>()) {
+    // Partial connect will connect together any two fields with the same name.
+    // The verifier will have checked that the fields have the same type.
+    auto srcBundle = srcType.cast<BundleType>();
+    auto end = destBundle.getNumElements();
+    for (unsigned destIndex = 0; destIndex < end; ++destIndex) {
+      // Try to find a field with the same name in the srcType.
+      auto fieldName = destBundle.getElements()[destIndex].name.getValue();
+      auto srcIndex = srcBundle.getElementIndex(fieldName);
+      if (!srcIndex)
+        continue;
+      auto &destElt = destBundle.getElements()[destIndex];
+      auto &srcElt = srcBundle.getElements()[*srcIndex];
+
+      // Call back to lazily create the subfield op on the mask.
+      Value subfield = nullptr;
+      auto lazySubfield = [&](ImplicitLocOpBuilder &builder) {
+        if (!subfield)
+          subfield =
+              builder.create<SubfieldOp>(getSubaccess(builder), destIndex);
+        return subfield;
+      };
+
+      // Recursively handle the connection point.
+      emitPartialConnectMask(builder, destElt.type, srcElt.type, lazySubfield);
+    }
+  } else if (auto destVector = destType.dyn_cast<FVectorType>()) {
+    // Partial connect will connect all elements of the vectors together up to
+    // the length of the shorter vector.  This needs to recurse for each pair of
+    // connected elements.
+    auto srcVector = srcType.dyn_cast<FVectorType>();
+    auto destEltType = destVector.getElementType();
+    auto srcEltType = srcVector.getElementType();
+    auto end =
+        std::min(destVector.getNumElements(), srcVector.getNumElements());
+
+    for (unsigned i = 0; i < end; i++) {
+      // Call back to lazily create the subindex op on the mask.
+      Value subindex = nullptr;
+      auto lazySubindex = [&](ImplicitLocOpBuilder builder) {
+        if (!subindex)
+          subindex = builder.create<SubindexOp>(getSubaccess(builder), i);
+        return subindex;
+      };
+
+      // Recursively handle the connection point.
+      emitPartialConnectMask(builder, destEltType, srcEltType, lazySubindex);
+    }
+  } else {
+    // Connect the mask to 1, forcing the creation of any required subfield and
+    // subindex operations.
+    builder.create<ConnectOp>(getSubaccess(builder), getConstOne());
+  }
+}
+
+void InferMemoriesPass::visitStmt(PartialConnectOp partialConnect) {
+  // Check if we are writing to a memory and, if we are, replace the
+  // destination.
+  auto writeIt = wdataValues.find(partialConnect.dest());
+  if (writeIt != wdataValues.end()) {
+    auto writeData = writeIt->second;
+
+    // Update the destination to use the new memory.
+    partialConnect.destMutable().assign(writeData.data);
+
+    // Handle the partial connect write mask.  This only sets the mask
+    // for the elements which are connected by the partial connect.
+    ImplicitLocOpBuilder builder(partialConnect.getLoc(), partialConnect);
+    emitPartialConnectMask(
+        builder, partialConnect.dest().getType(),
+        partialConnect.src().getType(),
+        [&](ImplicitLocOpBuilder builder) { return writeData.mask; });
+
+    // Only ReadWrite memories have a write mode, so this field can sometimes be
+    // null.
+    if (writeData.mode)
+      builder.create<ConnectOp>(writeData.mode, getConstOne());
+  }
+
+  // Check if we are reading from a memory and, if we are, replace the
+  // source.
+  auto readIt = rdataValues.find(partialConnect.src());
+  if (readIt != rdataValues.end()) {
+    auto newSource = readIt->second;
+    // Update the source to use the new memory.
+    partialConnect.srcMutable().assign(newSource);
+  }
+}
+
+/// This function will create clones of subaccess, subindex, and subfield
+/// operations which are indexing a CHIRRTL memory ports that will index into
+/// the new memory's data field.  If a subfield result is used to read from a
+/// memory port, it will be cloned to read from the memory's rdata field.  If
+/// the subfield is used to write to a memory port, it will be cloned twice to
+/// write to both the wdata and wmask fields. Users of this subfield operation
+/// will be redirected to the appropriate clone when they are visited.
+template <typename OpType, typename... T>
+void InferMemoriesPass::cloneSubindexOpForMemory(OpType op, Value input,
+                                                 T... operands) {
+  // If the subaccess operation has no direction recorded, then it does not
+  // index a CHIRRTL memory and will be left alone.
+  auto it = subfieldDirs.find(op);
+  if (it == subfieldDirs.end())
+    return;
+
+  // All uses of this op will be updated to use the appropriate clone.  If the
+  // recorded direction of this subfield is Infer, then the value is not
+  // actually used to read or write from a memory port, and it will be just
+  // removed.
+  opsToDelete.push_back(op);
+
+  auto direction = it->second;
+  ImplicitLocOpBuilder builder(op->getLoc(), op);
+
+  // If the subaccess operation is used to read from a memory port, we need to
+  // clone it to read from the rdata field.
+  if (direction == MemDirAttr::Read || direction == MemDirAttr::ReadWrite) {
+    rdataValues[op] = builder.create<OpType>(rdataValues[input], operands...);
+  }
+
+  // If the subaccess operation is used to write to the memory, we need to clone
+  // it to write to the the wdata and the wmask fields.
+  if (direction == MemDirAttr::Write || direction == MemDirAttr::ReadWrite) {
+    auto writeData = wdataValues[input];
+    auto write = builder.create<OpType>(writeData.data, operands...);
+    auto mask = builder.create<OpType>(writeData.mask, operands...);
+    wdataValues[op] = {write, mask, writeData.mode};
+  }
+}
+
+void InferMemoriesPass::visitExpr(SubaccessOp subaccess) {
+  // Check if the subaccess reads from a memory for
+  // the index.
+  auto readIt = rdataValues.find(subaccess.index());
+  if (readIt != rdataValues.end()) {
+    subaccess.indexMutable().assign(readIt->second);
+  }
+  // Handle it like normal.
+  cloneSubindexOpForMemory(subaccess, subaccess.input(), subaccess.index());
+}
+
+void InferMemoriesPass::visitExpr(SubfieldOp subfield) {
+  cloneSubindexOpForMemory<SubfieldOp>(subfield, subfield.input(),
+                                       subfield.fieldIndex());
+}
+
+void InferMemoriesPass::visitExpr(SubindexOp subindex) {
+  cloneSubindexOpForMemory<SubindexOp>(subindex, subindex.input(),
+                                       subindex.index());
+}
+
+void InferMemoriesPass::visitUnhandledOp(Operation *op) {
+  // For every operand, check if it is reading from a memory port and
+  // replace it with a read from the new memory.
+  for (auto &operand : op->getOpOperands()) {
+    auto it = rdataValues.find(operand.get());
+    if (it != rdataValues.end()) {
+      operand.set(it->second);
+    }
+  }
+}
+
+void InferMemoriesPass::runOnOperation() {
+  // Walk the entire body of the module and dispatch the visitor on each
+  // function.  This will replace all CHIRRTL memories and ports, and update all
+  // uses.
+  getOperation().getBodyBlock()->walk(
+      [&](Operation *op) { dispatchVisitor(op); });
+
+  // If there are no operations to delete, then we didn't find any CHIRRTL
+  // memories.
+  if (opsToDelete.empty())
+    markAllAnalysesPreserved();
+
+  // Remove the old memories and their ports.
+  while (!opsToDelete.empty())
+    opsToDelete.pop_back_val()->erase();
+
+  // Clear out any cached data.
+  clear();
+}
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createInferMemoriesPass() {
+  return std::make_unique<InferMemoriesPass>();
+}

--- a/test/Dialect/FIRRTL/infer-memories-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-memories-errors.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -verify-diagnostics -pass-pipeline='firrtl.circuit(firrtl.module(firrtl-infer-memories))'  %s
+// RUN: circt-opt -verify-diagnostics -pass-pipeline='firrtl.circuit(firrtl.module(firrtl-lower-chirrtl))'  %s
 
 firrtl.circuit "NoInferredEnables" {
 firrtl.module @NoInferredEnables(in %p: !firrtl.uint<1>, in %addr: !firrtl.uint<4>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %v: !firrtl.uint<32>) {

--- a/test/Dialect/FIRRTL/infer-memories-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-memories-errors.mlir
@@ -6,7 +6,9 @@ firrtl.module @NoInferredEnables(in %p: !firrtl.uint<1>, in %addr: !firrtl.uint<
   %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
   %r = firrtl.regreset %clock, %reset, %c0_ui4  : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
   // expected-warning @+1 {{memory port is never enabled}}
-  %data, %port = firrtl.memoryport Read %ram, %r, %clock  : (!firrtl.cmemory<uint<32>, 16>, !firrtl.uint<4>, !firrtl.clock) -> !firrtl.uint<32>
-  firrtl.connect %v, %ramport : !firrtl.uint<32>, !firrtl.uint<32>
+  %ramport_data, %ramport_port = firrtl.memoryport Read %ram {name = "ramport"} : (!firrtl.cmemory<uint<32>, 16>) -> (!firrtl.uint<32>, !firrtl.cmemoryport)
+  firrtl.memoryport.access %ramport_port[%addr], %clock : !firrtl.cmemoryport, !firrtl.uint<4>, !firrtl.clock
+
+  firrtl.connect %v, %ramport_data : !firrtl.uint<32>, !firrtl.uint<32>
 }
 }

--- a/test/Dialect/FIRRTL/infer-memories-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-memories-errors.mlir
@@ -6,7 +6,7 @@ firrtl.module @NoInferredEnables(in %p: !firrtl.uint<1>, in %addr: !firrtl.uint<
   %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
   %r = firrtl.regreset %clock, %reset, %c0_ui4  : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
   // expected-warning @+1 {{memory port is never enabled}}
-  %ramport = firrtl.memoryport Read %ram, %r, %clock  : (!firrtl.cmemory<uint<32>, 16>, !firrtl.uint<4>, !firrtl.clock) -> !firrtl.uint<32>
+  %data, %port = firrtl.memoryport Read %ram, %r, %clock  : (!firrtl.cmemory<uint<32>, 16>, !firrtl.uint<4>, !firrtl.clock) -> !firrtl.uint<32>
   firrtl.connect %v, %ramport : !firrtl.uint<32>, !firrtl.uint<32>
 }
 }

--- a/test/Dialect/FIRRTL/infer-memories-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-memories-errors.mlir
@@ -1,0 +1,12 @@
+// RUN: circt-opt -verify-diagnostics -pass-pipeline='firrtl.circuit(firrtl.module(firrtl-infer-memories))'  %s
+
+firrtl.circuit "NoInferredEnables" {
+firrtl.module @NoInferredEnables(in %p: !firrtl.uint<1>, in %addr: !firrtl.uint<4>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %v: !firrtl.uint<32>) {
+  %ram = firrtl.seqmem Undefined  : !firrtl.cmemory<uint<32>, 16>
+  %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
+  %r = firrtl.regreset %clock, %reset, %c0_ui4  : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
+  // expected-warning @+1 {{memory port is never enabled}}
+  %ramport = firrtl.memoryport Read %ram, %r, %clock  : (!firrtl.cmemory<uint<32>, 16>, !firrtl.uint<4>, !firrtl.clock) -> !firrtl.uint<32>
+  firrtl.connect %v, %ramport : !firrtl.uint<32>, !firrtl.uint<32>
+}
+}

--- a/test/Dialect/FIRRTL/infer-memories.mlir
+++ b/test/Dialect/FIRRTL/infer-memories.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl.module(firrtl-infer-memories))'  %s | FileCheck %s
+// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl.module(firrtl-lower-chirrtl))'  %s | FileCheck %s
 
 firrtl.circuit "Empty" {
 

--- a/test/Dialect/FIRRTL/infer-memories.mlir
+++ b/test/Dialect/FIRRTL/infer-memories.mlir
@@ -13,12 +13,12 @@ firrtl.module @Empty(in %clock: !firrtl.clock) {
 firrtl.module @UnusedMemPort(in %clock: !firrtl.clock, in %addr : !firrtl.uint<1>) {
   %ram = firrtl.combmem : !firrtl.cmemory<vector<uint<1>, 2>, 2>
   // This port should be deleted.
-  %port0, %port0_port = firrtl.memoryport Infer %ram : (!firrtl.cmemory<vector<uint<1>, 2>, 2>) -> (!firrtl.vector<uint<1>, 2>, !firrtl.cmemoryport)
+  %port0_data, %port0_port = firrtl.memoryport Infer %ram {name = "port0"} : (!firrtl.cmemory<vector<uint<1>, 2>, 2>) -> (!firrtl.vector<uint<1>, 2>, !firrtl.cmemoryport)
   firrtl.memoryport.access %port0_port[%addr], %clock : !firrtl.cmemoryport, !firrtl.uint<1>, !firrtl.clock
   // Subindexing a port should not count as a "use".
-  %port1, %port1_port = firrtl.memoryport Infer %ram : (!firrtl.cmemory<vector<uint<1>, 2>, 2>) -> (!firrtl.vector<uint<1>, 2>, !firrtl.cmemoryport)
+  %port1_data, %port1_port = firrtl.memoryport Infer %ram {name = "port1"} : (!firrtl.cmemory<vector<uint<1>, 2>, 2>) -> (!firrtl.vector<uint<1>, 2>, !firrtl.cmemoryport)
   firrtl.memoryport.access %port1_port[%addr], %clock : !firrtl.cmemoryport, !firrtl.uint<1>, !firrtl.clock
-  %0 = firrtl.subindex %port1[1] : !firrtl.vector<uint<1>, 2>
+  %0 = firrtl.subindex %port1_data[1] : !firrtl.vector<uint<1>, 2>
 }
 // CHECK:      firrtl.module @UnusedMemPort(in %clock: !firrtl.clock, in %addr: !firrtl.uint<1>) {
 // CHECK-NEXT: }
@@ -33,7 +33,7 @@ firrtl.module @InferRead(in %cond: !firrtl.uint<1>, in %clock: !firrtl.clock, in
   // CHECK: firrtl.connect [[CLOCK]], %invalid_clock
   // CHECK: [[DATA:%.*]] = firrtl.subfield %ram_ramport(3)
   %ram = firrtl.combmem : !firrtl.cmemory<uint<1>, 256>
-  %ramport, %ramport_port = firrtl.memoryport Infer %ram : (!firrtl.cmemory<uint<1>, 256>) -> (!firrtl.uint<1>, !firrtl.cmemoryport)
+  %ramport_data, %ramport_port = firrtl.memoryport Infer %ram {name = "ramport"} : (!firrtl.cmemory<uint<1>, 256>) -> (!firrtl.uint<1>, !firrtl.cmemoryport)
 
   // CHECK: firrtl.when %cond {
   // CHECK:   firrtl.connect [[ADDR]], %addr
@@ -45,17 +45,17 @@ firrtl.module @InferRead(in %cond: !firrtl.uint<1>, in %clock: !firrtl.clock, in
   }
 
   // CHECK: %node = firrtl.node [[DATA]]
-  %node = firrtl.node %ramport : !firrtl.uint<1>
+  %node = firrtl.node %ramport_data : !firrtl.uint<1>
 
   // CHECK: firrtl.connect %out, [[DATA]]
-  firrtl.connect %out, %ramport : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %out, %ramport_data : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: firrtl.partialconnect %out, [[DATA]]
-  firrtl.partialconnect %out, %ramport : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.partialconnect %out, %ramport_data : !firrtl.uint<1>, !firrtl.uint<1>
 
   // TODO: How do you get FileCheck to accept "[[[DATA]]]"?
   // CHECK: firrtl.subaccess %vec{{\[}}[[DATA]]{{\]}} : !firrtl.vector<uint<1>, 2>, !firrtl.uint<1>
-  firrtl.subaccess %vec[%ramport] : !firrtl.vector<uint<1>, 2>, !firrtl.uint<1>
+  firrtl.subaccess %vec[%ramport_data] : !firrtl.vector<uint<1>, 2>, !firrtl.uint<1>
 }
 
 firrtl.module @InferWrite(in %cond: !firrtl.uint<1>, in %clock: !firrtl.clock, in %addr: !firrtl.uint<8>, in %in : !firrtl.uint<1>) {
@@ -71,7 +71,7 @@ firrtl.module @InferWrite(in %cond: !firrtl.uint<1>, in %clock: !firrtl.clock, i
   // CHECK: [[MASK:%.*]] = firrtl.subfield %ram_ramport(4)
   // CHECK: firrtl.connect [[MASK]], %invalid_ui1
   %ram = firrtl.combmem : !firrtl.cmemory<uint<1>, 256>
-  %ramport, %ramport_port = firrtl.memoryport Infer %ram : (!firrtl.cmemory<uint<1>, 256>) -> (!firrtl.uint<1>, !firrtl.cmemoryport)
+  %ramport_data, %ramport_port = firrtl.memoryport Infer %ram {name = "ramport"} : (!firrtl.cmemory<uint<1>, 256>) -> (!firrtl.uint<1>, !firrtl.cmemoryport)
 
   // CHECK: firrtl.when %cond {
   // CHECK:   firrtl.connect [[ADDR]], %addr
@@ -85,11 +85,11 @@ firrtl.module @InferWrite(in %cond: !firrtl.uint<1>, in %clock: !firrtl.clock, i
 
   // CHECK: firrtl.connect [[MASK]], %c1_ui1
   // CHECK: firrtl.connect [[DATA]], %in
-  firrtl.connect %ramport, %in : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %ramport_data, %in : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: firrtl.connect [[MASK]], %c1_ui1
   // CHECK: firrtl.partialconnect [[DATA]], %in
-  firrtl.partialconnect %ramport, %in : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.partialconnect %ramport_data, %in : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
 firrtl.module @InferReadWrite(in %clock: !firrtl.clock, in %addr: !firrtl.uint<8>, in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
@@ -113,16 +113,16 @@ firrtl.module @InferReadWrite(in %clock: !firrtl.clock, in %addr: !firrtl.uint<8
   // CHECK: firrtl.connect [[EN]], %c1_ui1
   // CHECK: firrtl.connect [[CLOCK]], %clock
   // CHECK: firrtl.connect [[WMASK]], %c0_ui1
-  %ramport, %ramport_port = firrtl.memoryport Read %ram : (!firrtl.cmemory<uint<1>, 256>) -> (!firrtl.uint<1>, !firrtl.cmemoryport)
+  %ramport_data, %ramport_port = firrtl.memoryport Read %ram {name = "ramport"} : (!firrtl.cmemory<uint<1>, 256>) -> (!firrtl.uint<1>, !firrtl.cmemoryport)
   firrtl.memoryport.access %ramport_port[%addr], %clock : !firrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
 
   // CHECK: firrtl.connect [[WMASK]], %c1_ui1
   // CHECK: firrtl.connect [[WMODE]], %c1_ui1
   // CHECK: firrtl.connect [[WDATA]], %in
-  firrtl.connect %ramport, %in : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %ramport_data, %in : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: firrtl.connect %out, [[RDATA]] 
-  firrtl.connect %out, %ramport : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %out, %ramport_data : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
 // Check that partial connect properly sets the write mask for the elements which are actually connected.
@@ -154,7 +154,7 @@ firrtl.module @PartialConnectWriteMask(in %clock: !firrtl.clock, in %addr: !firr
   // CHECK: firrtl.connect [[C_1]], %c0_ui1 
   // CHECK: [[C_2:%.*]] = firrtl.subindex [[C]][2] : !firrtl.vector<uint<1>, 3>
   // CHECK: firrtl.connect [[C_2]], %c0_ui1 
-  %ramport, %ramport_port = firrtl.memoryport Infer %ram : (!firrtl.cmemory<bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>, 256>) -> (!firrtl.bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>, !firrtl.cmemoryport)
+  %ramport_data, %ramport_port = firrtl.memoryport Infer %ram {name = "ramport"} : (!firrtl.cmemory<bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>, 256>) -> (!firrtl.bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>, !firrtl.cmemoryport)
   firrtl.memoryport.access %ramport_port[%addr], %clock : !firrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
 
 
@@ -166,15 +166,15 @@ firrtl.module @PartialConnectWriteMask(in %clock: !firrtl.clock, in %addr: !firr
   // CHECK: [[C_1:%.*]] = firrtl.subindex [[C]][1] : !firrtl.vector<uint<1>, 3>
   // CHECK: firrtl.connect [[C_1]], %c1_ui1 
   // CHECK: firrtl.partialconnect [[DATA]], %data
-  firrtl.partialconnect %ramport, %data : !firrtl.bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>, !firrtl.bundle<c: vector<uint<3>, 2>, a: uint<1>>
+  firrtl.partialconnect %ramport_data, %data : !firrtl.bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>, !firrtl.bundle<c: vector<uint<3>, 2>, a: uint<1>>
 }
 
 firrtl.module @WriteToSubfield(in %clock: !firrtl.clock, in %addr: !firrtl.uint<8>, in %value: !firrtl.uint<1>) {
   %ram = firrtl.combmem : !firrtl.cmemory<bundle<a: uint<1>, b: uint<1>>, 256>
-  %ramport, %ramport_port = firrtl.memoryport Infer %ram : (!firrtl.cmemory<bundle<a: uint<1>, b: uint<1>>, 256>) -> (!firrtl.bundle<a: uint<1>, b: uint<1>>, !firrtl.cmemoryport)
+  %ramport_data, %ramport_port = firrtl.memoryport Infer %ram {name = "ramport"} : (!firrtl.cmemory<bundle<a: uint<1>, b: uint<1>>, 256>) -> (!firrtl.bundle<a: uint<1>, b: uint<1>>, !firrtl.cmemoryport)
   firrtl.memoryport.access %ramport_port[%addr], %clock : !firrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
 
-  %ramport_b = firrtl.subfield %ramport(1) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
+  %ramport_b = firrtl.subfield %ramport_data(1) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
   // Check that only the subfield of the mask is written to.
   // CHECK: [[DATA:%.*]] = firrtl.subfield %ram_ramport(3)
   // CHECK: [[MASK:%.*]] = firrtl.subfield %ram_ramport(4)
@@ -189,7 +189,7 @@ firrtl.module @WriteToSubfield(in %clock: !firrtl.clock, in %addr: !firrtl.uint<
 // whole should be inferred to read+write.
 firrtl.module @ReadAndWriteToSubfield(in %clock: !firrtl.clock, in %addr: !firrtl.uint<8>, in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
   %ram = firrtl.combmem : !firrtl.cmemory<bundle<a: uint<1>, b: uint<1>>, 256>
-  %ramport, %ramport_port = firrtl.memoryport Infer %ram : (!firrtl.cmemory<bundle<a: uint<1>, b:uint<1>>, 256>) -> (!firrtl.bundle<a: uint<1>, b: uint<1>>, !firrtl.cmemoryport)
+  %ramport_data, %ramport_port = firrtl.memoryport Infer %ram {name = "ramport"} : (!firrtl.cmemory<bundle<a: uint<1>, b:uint<1>>, 256>) -> (!firrtl.bundle<a: uint<1>, b: uint<1>>, !firrtl.cmemoryport)
   firrtl.memoryport.access %ramport_port[%addr], %clock : !firrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
 
 
@@ -202,12 +202,12 @@ firrtl.module @ReadAndWriteToSubfield(in %clock: !firrtl.clock, in %addr: !firrt
   // CHECK: firrtl.connect [[WMASK_A]], %c1_ui1
   // CHECK: firrtl.connect [[WMODE]], %c1_ui1
   // CHECK: firrtl.connect [[WDATA_A]], %in
-  %port_a = firrtl.subfield %ramport(0) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
+  %port_a = firrtl.subfield %ramport_data(0) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
   firrtl.connect %port_a, %in : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: [[RDATA_B:%.*]] = firrtl.subfield [[RDATA]](1) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
   // CHECK: firrtl.connect %out, [[RDATA_B]] : !firrtl.uint<1>, !firrtl.uint<1>
-  %port_b = firrtl.subfield %ramport(1) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
+  %port_b = firrtl.subfield %ramport_data(1) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
   firrtl.connect %out, %port_b : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
@@ -215,11 +215,11 @@ firrtl.module @ReadAndWriteToSubfield(in %clock: !firrtl.clock, in %addr: !firrt
 firrtl.module @SortedPorts(in %clock: !firrtl.clock, in %addr : !firrtl.uint<8>, out %out: !firrtl.uint<1>) {
   // CHECK: portNames = ["a", "b", "c"]
   %ram = firrtl.combmem : !firrtl.cmemory<vector<uint<1>, 2>, 256>
-  %c, %c_port = firrtl.memoryport Read %ram : (!firrtl.cmemory<vector<uint<1>, 2>, 256>) -> (!firrtl.vector<uint<1>, 2>, !firrtl.cmemoryport)
+  %c_data, %c_port = firrtl.memoryport Read %ram {name = "c"} : (!firrtl.cmemory<vector<uint<1>, 2>, 256>) -> (!firrtl.vector<uint<1>, 2>, !firrtl.cmemoryport)
   firrtl.memoryport.access %c_port[%addr], %clock : !firrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
-  %a, %a_port = firrtl.memoryport Write %ram : (!firrtl.cmemory<vector<uint<1>, 2>, 256>) -> (!firrtl.vector<uint<1>, 2>, !firrtl.cmemoryport)
+  %a_data, %a_port = firrtl.memoryport Write %ram {name = "a"} : (!firrtl.cmemory<vector<uint<1>, 2>, 256>) -> (!firrtl.vector<uint<1>, 2>, !firrtl.cmemoryport)
   firrtl.memoryport.access %a_port[%addr], %clock : !firrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
-  %b, %b_port = firrtl.memoryport ReadWrite %ram : (!firrtl.cmemory<vector<uint<1>, 2>, 256>) -> (!firrtl.vector<uint<1>, 2>, !firrtl.cmemoryport)
+  %b_data, %b_port = firrtl.memoryport ReadWrite %ram {name = "b"} : (!firrtl.cmemory<vector<uint<1>, 2>, 256>) -> (!firrtl.vector<uint<1>, 2>, !firrtl.cmemoryport)
   firrtl.memoryport.access %b_port[%addr], %clock : !firrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
 }
 
@@ -233,9 +233,9 @@ firrtl.module @Annotations(in %clock: !firrtl.clock, in %addr : !firrtl.uint<8>,
   // CHECK-SAME: ]
   // CHECK-SAME: portNames = ["port0", "port1"]
   %ram = firrtl.combmem {annotations = [{a = "a"}]} : !firrtl.cmemory<vector<uint<1>, 2>, 256>
-  %port0, %port0_port = firrtl.memoryport Read %ram {annotations = [{b = "b"}]} : (!firrtl.cmemory<vector<uint<1>, 2>, 256>) -> (!firrtl.vector<uint<1>, 2>, !firrtl.cmemoryport)
+  %port0_data, %port0_port = firrtl.memoryport Read %ram  {annotations = [{b = "b"}], name = "port0"} : (!firrtl.cmemory<vector<uint<1>, 2>, 256>) -> (!firrtl.vector<uint<1>, 2>, !firrtl.cmemoryport)
   firrtl.memoryport.access %port0_port[%addr], %clock : !firrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
-  %port1, %port1_port = firrtl.memoryport Read %ram {annotations = [{c = "c"}]} : (!firrtl.cmemory<vector<uint<1>, 2>, 256>) -> (!firrtl.vector<uint<1>, 2>, !firrtl.cmemoryport)
+  %port1_data, %port1_port = firrtl.memoryport Read %ram {annotations = [{c = "c"}], name = "port1"} : (!firrtl.cmemory<vector<uint<1>, 2>, 256>) -> (!firrtl.vector<uint<1>, 2>, !firrtl.cmemoryport)
   firrtl.memoryport.access %port1_port[%addr], %clock : !firrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
 }
 
@@ -252,7 +252,7 @@ firrtl.module @EnableInference0(in %p: !firrtl.uint<1>, in %addr: !firrtl.uint<4
   // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_ramport(0)
   // CHECK: [[EN:%.*]] = firrtl.subfield %ram_ramport(1)
   %ram = firrtl.seqmem Undefined  : !firrtl.cmemory<uint<32>, 16>
-  %ramport, %ramport_port = firrtl.memoryport Read %ram : (!firrtl.cmemory<uint<32>, 16>) -> (!firrtl.uint<32>, !firrtl.cmemoryport)
+  %ramport_data, %ramport_port = firrtl.memoryport Read %ram  {name = "ramport"}: (!firrtl.cmemory<uint<32>, 16>) -> (!firrtl.uint<32>, !firrtl.cmemoryport)
   firrtl.memoryport.access %ramport_port[%w], %clock : !firrtl.cmemoryport, !firrtl.uint<4>, !firrtl.clock
 
   // CHECK: firrtl.when %p {
@@ -261,7 +261,7 @@ firrtl.module @EnableInference0(in %p: !firrtl.uint<1>, in %addr: !firrtl.uint<4
     // CHECK-NEXT: firrtl.connect %w, %addr
     firrtl.connect %w, %addr : !firrtl.uint<4>, !firrtl.uint<4>
   }
-  firrtl.connect %v, %ramport : !firrtl.uint<32>, !firrtl.uint<32>
+  firrtl.connect %v, %ramport_data : !firrtl.uint<32>, !firrtl.uint<32>
 }
 
 // When the address is a node, the enable should be inferred where the address is declared.
@@ -279,9 +279,9 @@ firrtl.module @EnableInference1(in %p: !firrtl.uint<1>, in %addr: !firrtl.uint<4
    // CHECK-NEXT: firrtl.connect %2, %clock
    // CHECK-NEXT: firrtl.connect %v, %3
     %n = firrtl.node %addr : !firrtl.uint<4>
-    %ramport, %ramport_port = firrtl.memoryport Read %ram : (!firrtl.cmemory<uint<32>, 16>) -> (!firrtl.uint<32>, !firrtl.cmemoryport)
+    %ramport_data, %ramport_port = firrtl.memoryport Read %ram {name = "ramport"} : (!firrtl.cmemory<uint<32>, 16>) -> (!firrtl.uint<32>, !firrtl.cmemoryport)
     firrtl.memoryport.access %ramport_port[%n], %clock : !firrtl.cmemoryport, !firrtl.uint<4>, !firrtl.clock
-    firrtl.connect %v, %ramport : !firrtl.uint<32>, !firrtl.uint<32>
+    firrtl.connect %v, %ramport_data : !firrtl.uint<32>, !firrtl.uint<32>
   }
 }
 }

--- a/test/Dialect/FIRRTL/infer-memories.mlir
+++ b/test/Dialect/FIRRTL/infer-memories.mlir
@@ -13,110 +13,123 @@ firrtl.module @Empty(in %clock: !firrtl.clock) {
 firrtl.module @UnusedMemPort(in %clock: !firrtl.clock, in %addr : !firrtl.uint<1>) {
   %ram = firrtl.combmem : !firrtl.cmemory<vector<uint<1>, 2>, 2>
   // This port should be deleted.
-  %port0 = firrtl.memoryport Infer %ram, %addr, %clock : (!firrtl.cmemory<vector<uint<1>, 2>, 2>, !firrtl.uint<1>, !firrtl.clock) -> !firrtl.vector<uint<1>, 2>
+  %port0, %port0_port = firrtl.memoryport Infer %ram : (!firrtl.cmemory<vector<uint<1>, 2>, 2>) -> (!firrtl.vector<uint<1>, 2>, !firrtl.cmemoryport)
+  firrtl.memoryport.access %port0_port[%addr], %clock : !firrtl.cmemoryport, !firrtl.uint<1>, !firrtl.clock
   // Subindexing a port should not count as a "use".
-  %port1 = firrtl.memoryport Infer %ram, %addr, %clock : (!firrtl.cmemory<vector<uint<1>, 2>, 2>, !firrtl.uint<1>, !firrtl.clock) -> !firrtl.vector<uint<1>, 2>
+  %port1, %port1_port = firrtl.memoryport Infer %ram : (!firrtl.cmemory<vector<uint<1>, 2>, 2>) -> (!firrtl.vector<uint<1>, 2>, !firrtl.cmemoryport)
+  firrtl.memoryport.access %port1_port[%addr], %clock : !firrtl.cmemoryport, !firrtl.uint<1>, !firrtl.clock
   %0 = firrtl.subindex %port1[1] : !firrtl.vector<uint<1>, 2>
 }
 // CHECK:      firrtl.module @UnusedMemPort(in %clock: !firrtl.clock, in %addr: !firrtl.uint<1>) {
 // CHECK-NEXT: }
 
-firrtl.module @InferRead(in %clock: !firrtl.clock, in %addr: !firrtl.uint<1>, out %out : !firrtl.uint<1>, in %vec : !firrtl.vector<uint<1>, 2>) {
-  // CHECK: %ram_port = firrtl.mem Undefined  {depth = 2 : i64, name = "ram", portNames = ["port"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
-  // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_port(0)
-  // CHECK: firrtl.connect [[ADDR]], %invalid_ui1
-  // CHECK: [[EN:%.*]] = firrtl.subfield %ram_port(1)
+firrtl.module @InferRead(in %cond: !firrtl.uint<1>, in %clock: !firrtl.clock, in %addr: !firrtl.uint<8>, out %out : !firrtl.uint<1>, in %vec : !firrtl.vector<uint<1>, 2>) {
+  // CHECK: %ram_ramport = firrtl.mem Undefined {depth = 256 : i64, name = "ram", portNames = ["ramport"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<8>, en: uint<1>, clk: clock, data flip: uint<1>>
+  // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_ramport(0)
+  // CHECK: firrtl.connect [[ADDR]], %invalid_ui8
+  // CHECK: [[EN:%.*]] = firrtl.subfield %ram_ramport(1)
   // CHECK: firrtl.connect [[EN]], %c0_ui1
-  // CHECK: [[CLOCK:%.*]] = firrtl.subfield %ram_port(2)
+  // CHECK: [[CLOCK:%.*]] = firrtl.subfield %ram_ramport(2)
   // CHECK: firrtl.connect [[CLOCK]], %invalid_clock
-  // CHECK: [[DATA:%.*]] = firrtl.subfield %ram_port(3)
-  %ram = firrtl.combmem : !firrtl.cmemory<uint<1>, 2>
+  // CHECK: [[DATA:%.*]] = firrtl.subfield %ram_ramport(3)
+  %ram = firrtl.combmem : !firrtl.cmemory<uint<1>, 256>
+  %ramport, %ramport_port = firrtl.memoryport Infer %ram : (!firrtl.cmemory<uint<1>, 256>) -> (!firrtl.uint<1>, !firrtl.cmemoryport)
 
-  // CHECK: firrtl.connect [[ADDR]], %addr
-  // CHECK: firrtl.connect [[EN]], %c1_ui1
-  // CHECK: firrtl.connect [[CLOCK]], %clock
-  %port = firrtl.memoryport Infer %ram, %addr, %clock : (!firrtl.cmemory<uint<1>, 2>, !firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
+  // CHECK: firrtl.when %cond {
+  // CHECK:   firrtl.connect [[ADDR]], %addr
+  // CHECK:   firrtl.connect [[EN]], %c1_ui1
+  // CHECK:   firrtl.connect [[CLOCK]], %clock
+  // CHECK: }
+  firrtl.when %cond {
+    firrtl.memoryport.access %ramport_port[%addr], %clock : !firrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
+  }
 
   // CHECK: %node = firrtl.node [[DATA]]
-  %node = firrtl.node %port : !firrtl.uint<1>
+  %node = firrtl.node %ramport : !firrtl.uint<1>
 
   // CHECK: firrtl.connect %out, [[DATA]]
-  firrtl.connect %out, %port : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %out, %ramport : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: firrtl.partialconnect %out, [[DATA]]
-  firrtl.partialconnect %out, %port : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.partialconnect %out, %ramport : !firrtl.uint<1>, !firrtl.uint<1>
 
   // TODO: How do you get FileCheck to accept "[[[DATA]]]"?
   // CHECK: firrtl.subaccess %vec{{\[}}[[DATA]]{{\]}} : !firrtl.vector<uint<1>, 2>, !firrtl.uint<1>
-  firrtl.subaccess %vec[%port] : !firrtl.vector<uint<1>, 2>, !firrtl.uint<1>
+  firrtl.subaccess %vec[%ramport] : !firrtl.vector<uint<1>, 2>, !firrtl.uint<1>
 }
 
-firrtl.module @InferWrite(in %clock: !firrtl.clock, in %addr: !firrtl.uint<1>, in %in : !firrtl.uint<1>) {
-  // CHECK: %ram_port = firrtl.mem Undefined {depth = 2 : i64, name = "ram", portNames = ["port"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<1>, mask: uint<1>>
-  // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_port(0)
-  // CHECK: firrtl.connect [[ADDR]], %invalid_ui1
-  // CHECK: [[EN:%.*]] = firrtl.subfield %ram_port(1)
+firrtl.module @InferWrite(in %cond: !firrtl.uint<1>, in %clock: !firrtl.clock, in %addr: !firrtl.uint<8>, in %in : !firrtl.uint<1>) {
+  // CHECK: %ram_ramport = firrtl.mem Undefined {depth = 256 : i64, name = "ram", portNames = ["ramport"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<8>, en: uint<1>, clk: clock, data: uint<1>, mask: uint<1>>
+  // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_ramport(0)
+  // CHECK: firrtl.connect [[ADDR]], %invalid_ui8
+  // CHECK: [[EN:%.*]] = firrtl.subfield %ram_ramport(1)
   // CHECK: firrtl.connect [[EN]], %c0_ui1
-  // CHECK: [[CLOCK:%.*]] = firrtl.subfield %ram_port(2)
+  // CHECK: [[CLOCK:%.*]] = firrtl.subfield %ram_ramport(2)
   // CHECK: firrtl.connect [[CLOCK]], %invalid_clock
-  // CHECK: [[DATA:%.*]] = firrtl.subfield %ram_port(3)
+  // CHECK: [[DATA:%.*]] = firrtl.subfield %ram_ramport(3)
   // CHECK: firrtl.connect [[DATA]], %invalid_ui1
-  // CHECK: [[MASK:%.*]] = firrtl.subfield %ram_port(4)
+  // CHECK: [[MASK:%.*]] = firrtl.subfield %ram_ramport(4)
   // CHECK: firrtl.connect [[MASK]], %invalid_ui1
-  %ram = firrtl.combmem : !firrtl.cmemory<uint<1>, 2>
+  %ram = firrtl.combmem : !firrtl.cmemory<uint<1>, 256>
+  %ramport, %ramport_port = firrtl.memoryport Infer %ram : (!firrtl.cmemory<uint<1>, 256>) -> (!firrtl.uint<1>, !firrtl.cmemoryport)
 
-  // CHECK: firrtl.connect [[ADDR]], %addr
-  // CHECK: firrtl.connect [[EN]], %c1_ui1
-  // CHECK: firrtl.connect [[CLOCK]], %clock
-  // CHECK: firrtl.connect [[MASK]], %c0_ui1
-  %port = firrtl.memoryport Infer %ram, %addr, %clock : (!firrtl.cmemory<uint<1>, 2>, !firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
+  // CHECK: firrtl.when %cond {
+  // CHECK:   firrtl.connect [[ADDR]], %addr
+  // CHECK:   firrtl.connect [[EN]], %c1_ui1
+  // CHECK:   firrtl.connect [[CLOCK]], %clock
+  // CHECK:   firrtl.connect [[MASK]], %c0_ui1
+  // CHECK: }
+  firrtl.when %cond {
+    firrtl.memoryport.access %ramport_port[%addr], %clock : !firrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
+  }
 
   // CHECK: firrtl.connect [[MASK]], %c1_ui1
   // CHECK: firrtl.connect [[DATA]], %in
-  firrtl.connect %port, %in : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %ramport, %in : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: firrtl.connect [[MASK]], %c1_ui1
   // CHECK: firrtl.partialconnect [[DATA]], %in
-  firrtl.partialconnect %port, %in : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.partialconnect %ramport, %in : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
-firrtl.module @InferReadWrite(in %clock: !firrtl.clock, in %addr: !firrtl.uint<1>, in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
-  // CHECK: %ram_port = firrtl.mem Undefined  {depth = 2 : i64, name = "ram", portNames = ["port"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, rdata flip: uint<1>, wmode: uint<1>,  wdata: uint<1>, wmask: uint<1>>
-  // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_port(0)
-  // CHECK: firrtl.connect [[ADDR]], %invalid_ui1
-  // CHECK: [[EN:%.*]] = firrtl.subfield %ram_port(1)
+firrtl.module @InferReadWrite(in %clock: !firrtl.clock, in %addr: !firrtl.uint<8>, in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
+  // CHECK: %ram_ramport = firrtl.mem Undefined {depth = 256 : i64, name = "ram", portNames = ["ramport"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<8>, en: uint<1>, clk: clock, rdata flip: uint<1>, wmode: uint<1>, wdata: uint<1>, wmask: uint<1>>
+  // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_ramport(0)
+  // CHECK: firrtl.connect [[ADDR]], %invalid_ui8
+  // CHECK: [[EN:%.*]] = firrtl.subfield %ram_ramport(1)
   // CHECK: firrtl.connect [[EN]], %c0_ui1
-  // CHECK: [[CLOCK:%.*]] = firrtl.subfield %ram_port(2)
+  // CHECK: [[CLOCK:%.*]] = firrtl.subfield %ram_ramport(2)
   // CHECK: firrtl.connect [[CLOCK]], %invalid_clock
-  // CHECK: [[RDATA:%.*]] = firrtl.subfield %ram_port(3)
-  // CHECK: [[WMODE:%.*]] = firrtl.subfield %ram_port(4)
+  // CHECK: [[RDATA:%.*]] = firrtl.subfield %ram_ramport(3)
+  // CHECK: [[WMODE:%.*]] = firrtl.subfield %ram_ramport(4)
   // CHECK: firrtl.connect [[WMODE]], %c0_ui1
-  // CHECK: [[WDATA:%.*]] = firrtl.subfield %ram_port(5)
+  // CHECK: [[WDATA:%.*]] = firrtl.subfield %ram_ramport(5)
   // CHECK: firrtl.connect [[WDATA]], %invalid_ui1
-  // CHECK: [[WMASK:%.*]] = firrtl.subfield %ram_port(6)
+  // CHECK: [[WMASK:%.*]] = firrtl.subfield %ram_ramport(6)
   // CHECK: firrtl.connect [[WMASK]], %invalid_ui1
-  %ram = firrtl.combmem : !firrtl.cmemory<uint<1>, 2>
+  %ram = firrtl.combmem : !firrtl.cmemory<uint<1>, 256>
 
-  // CHECK: firrtl.connect [[ADDR]], %addr : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK: firrtl.connect [[ADDR]], %addr : !firrtl.uint<8>, !firrtl.uint<8>
   // CHECK: firrtl.connect [[EN]], %c1_ui1
   // CHECK: firrtl.connect [[CLOCK]], %clock
   // CHECK: firrtl.connect [[WMASK]], %c0_ui1
-  %port = firrtl.memoryport Read %ram, %addr, %clock : (!firrtl.cmemory<uint<1>, 2>, !firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
+  %ramport, %ramport_port = firrtl.memoryport Read %ram : (!firrtl.cmemory<uint<1>, 256>) -> (!firrtl.uint<1>, !firrtl.cmemoryport)
+  firrtl.memoryport.access %ramport_port[%addr], %clock : !firrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
 
   // CHECK: firrtl.connect [[WMASK]], %c1_ui1
   // CHECK: firrtl.connect [[WMODE]], %c1_ui1
   // CHECK: firrtl.connect [[WDATA]], %in
-  firrtl.connect %port, %in : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %ramport, %in : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: firrtl.connect %out, [[RDATA]] 
-  firrtl.connect %out, %port : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %out, %ramport : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
 // Check that partial connect properly sets the write mask for the elements which are actually connected.
-firrtl.module @PartialConnectWriteMask(in %clock: !firrtl.clock, in %addr: !firrtl.uint<1>, in %data : !firrtl.bundle<c: vector<uint<3>, 2>, a: uint<1>>) {
-  // CHECK: %ram_port = firrtl.mem Undefined  {depth = 2 : i64, name = "ram", portNames = ["port"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>, mask: bundle<a: uint<1>, b: uint<1>, c: vector<uint<1>, 3>>>
-  // CHECK: [[DATA:%.*]] = firrtl.subfield %ram_port(3)
-  // CHECK: [[MASK:%.*]] = firrtl.subfield %ram_port(4)
+firrtl.module @PartialConnectWriteMask(in %clock: !firrtl.clock, in %addr: !firrtl.uint<8>, in %data : !firrtl.bundle<c: vector<uint<3>, 2>, a: uint<1>>) {
+  // CHECK: %ram_ramport = firrtl.mem Undefined {depth = 256 : i64, name = "ram", portNames = ["ramport"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<8>, en: uint<1>, clk: clock, data: bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>, mask: bundle<a: uint<1>, b: uint<1>, c: vector<uint<1>, 3>>>
+  // CHECK: [[DATA:%.*]] = firrtl.subfield %ram_ramport(3)
+  // CHECK: [[MASK:%.*]] = firrtl.subfield %ram_ramport(4)
   // CHECK: [[A:%.*]] = firrtl.subfield [[MASK]](0)
   // CHECK: firrtl.connect [[A]], %invalid_ui1 
   // CHECK: [[B:%.*]] = firrtl.subfield [[MASK]](1)
@@ -128,7 +141,7 @@ firrtl.module @PartialConnectWriteMask(in %clock: !firrtl.clock, in %addr: !firr
   // CHECK: firrtl.connect [[C_1]], %invalid_ui1 
   // CHECK: [[C_2:%.*]] = firrtl.subindex [[C]][2]
   // CHECK: firrtl.connect [[C_2]], %invalid_ui1 
-  %ram = firrtl.combmem : !firrtl.cmemory<bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>, 2>
+  %ram = firrtl.combmem : !firrtl.cmemory<bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>, 256>
 
   // CHECK: [[A:%.*]] = firrtl.subfield [[MASK]](0)
   // CHECK: firrtl.connect [[A]], %c0_ui1 
@@ -141,7 +154,9 @@ firrtl.module @PartialConnectWriteMask(in %clock: !firrtl.clock, in %addr: !firr
   // CHECK: firrtl.connect [[C_1]], %c0_ui1 
   // CHECK: [[C_2:%.*]] = firrtl.subindex [[C]][2] : !firrtl.vector<uint<1>, 3>
   // CHECK: firrtl.connect [[C_2]], %c0_ui1 
-  %port = firrtl.memoryport Infer %ram, %addr, %clock : (!firrtl.cmemory<bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>, 2>, !firrtl.uint<1>, !firrtl.clock) -> !firrtl.bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>
+  %ramport, %ramport_port = firrtl.memoryport Infer %ram : (!firrtl.cmemory<bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>, 256>) -> (!firrtl.bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>, !firrtl.cmemoryport)
+  firrtl.memoryport.access %ramport_port[%addr], %clock : !firrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
+
 
   // CHECK: [[A:%.*]] = firrtl.subfield [[MASK]](0) : (!firrtl.bundle<a: uint<1>, b: uint<1>, c: vector<uint<1>, 3>>) -> !firrtl.uint<1>
   // CHECK: firrtl.connect [[A]], %c1_ui1 
@@ -151,58 +166,65 @@ firrtl.module @PartialConnectWriteMask(in %clock: !firrtl.clock, in %addr: !firr
   // CHECK: [[C_1:%.*]] = firrtl.subindex [[C]][1] : !firrtl.vector<uint<1>, 3>
   // CHECK: firrtl.connect [[C_1]], %c1_ui1 
   // CHECK: firrtl.partialconnect [[DATA]], %data
-  firrtl.partialconnect %port, %data : !firrtl.bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>, !firrtl.bundle<c: vector<uint<3>, 2>, a: uint<1>>
+  firrtl.partialconnect %ramport, %data : !firrtl.bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>, !firrtl.bundle<c: vector<uint<3>, 2>, a: uint<1>>
 }
 
-firrtl.module @WriteToSubfield(in %clock: !firrtl.clock, in %addr: !firrtl.uint<1>, in %value: !firrtl.uint<1>) {
-  %ram = firrtl.combmem : !firrtl.cmemory<bundle<a: uint<1>, b: uint<1>>, 2>
-  %port = firrtl.memoryport Infer %ram, %addr, %clock : (!firrtl.cmemory<bundle<a: uint<1>, b:uint<1>>, 2>, !firrtl.uint<1>, !firrtl.clock) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
-  %port_b = firrtl.subfield %port(1) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
+firrtl.module @WriteToSubfield(in %clock: !firrtl.clock, in %addr: !firrtl.uint<8>, in %value: !firrtl.uint<1>) {
+  %ram = firrtl.combmem : !firrtl.cmemory<bundle<a: uint<1>, b: uint<1>>, 256>
+  %ramport, %ramport_port = firrtl.memoryport Infer %ram : (!firrtl.cmemory<bundle<a: uint<1>, b: uint<1>>, 256>) -> (!firrtl.bundle<a: uint<1>, b: uint<1>>, !firrtl.cmemoryport)
+  firrtl.memoryport.access %ramport_port[%addr], %clock : !firrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
+
+  %ramport_b = firrtl.subfield %ramport(1) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
   // Check that only the subfield of the mask is written to.
-  // CHECK: [[DATA:%.*]] = firrtl.subfield %ram_port(3) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<1>, b: uint<1>>, mask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
-  // CHECK: [[MASK:%.*]] = firrtl.subfield %ram_port(4) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<1>, b: uint<1>>, mask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
-  // CHECK: [[DATA_B:%.*]] = firrtl.subfield [[DATA]](1) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
-  // CHECK: [[MASK_B:%.*]] = firrtl.subfield [[MASK]](1) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
-  // CHECK: firrtl.connect [[MASK_B]], %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.connect [[DATA_B]], %value : !firrtl.uint<1>, !firrtl.uint<1>
-  firrtl.connect %port_b, %value : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK: [[DATA:%.*]] = firrtl.subfield %ram_ramport(3)
+  // CHECK: [[MASK:%.*]] = firrtl.subfield %ram_ramport(4)
+  // CHECK: [[DATA_B:%.*]] = firrtl.subfield [[DATA]](1)
+  // CHECK: [[MASK_B:%.*]] = firrtl.subfield [[MASK]](1)
+  // CHECK: firrtl.connect [[MASK_B]], %c1_ui1
+  // CHECK: firrtl.connect [[DATA_B]], %value
+  firrtl.connect %ramport_b, %value : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
 // Read and write from different subfields of the memory.  The memory as a
 // whole should be inferred to read+write.
-firrtl.module @ReadAndWriteToSubfield(in %clock: !firrtl.clock, in %addr: !firrtl.uint<1>, in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
-  %ram = firrtl.combmem : !firrtl.cmemory<bundle<a: uint<1>, b: uint<1>>, 2>
-  %port = firrtl.memoryport Infer %ram, %addr, %clock : (!firrtl.cmemory<bundle<a: uint<1>, b:uint<1>>, 2>, !firrtl.uint<1>, !firrtl.clock) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
+firrtl.module @ReadAndWriteToSubfield(in %clock: !firrtl.clock, in %addr: !firrtl.uint<8>, in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
+  %ram = firrtl.combmem : !firrtl.cmemory<bundle<a: uint<1>, b: uint<1>>, 256>
+  %ramport, %ramport_port = firrtl.memoryport Infer %ram : (!firrtl.cmemory<bundle<a: uint<1>, b:uint<1>>, 256>) -> (!firrtl.bundle<a: uint<1>, b: uint<1>>, !firrtl.cmemoryport)
+  firrtl.memoryport.access %ramport_port[%addr], %clock : !firrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
 
-  // CHECK: [[RDATA:%.*]] = firrtl.subfield %ram_port(3) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, rdata flip: bundle<a: uint<1>, b: uint<1>>, wmode: uint<1>, wdata: bundle<a: uint<1>, b: uint<1>>, wmask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
-  // CHECK: [[WMODE:%.*]] = firrtl.subfield %ram_port(4) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, rdata flip: bundle<a: uint<1>, b: uint<1>>, wmode: uint<1>, wdata: bundle<a: uint<1>, b: uint<1>>, wmask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.uint<1>
-  // CHECK: [[WDATA:%.*]] = firrtl.subfield %ram_port(5) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, rdata flip: bundle<a: uint<1>, b: uint<1>>, wmode: uint<1>, wdata: bundle<a: uint<1>, b: uint<1>>, wmask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
-  // CHECK: [[WMASK:%.*]] = firrtl.subfield %ram_port(6) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, rdata flip: bundle<a: uint<1>, b: uint<1>>, wmode: uint<1>, wdata: bundle<a: uint<1>, b: uint<1>>, wmask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
-  // CHECK: [[WDATA_A:%.*]] = firrtl.subfield [[WDATA]](0) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
-  // CHECK: [[WMASK_A:%.*]] = firrtl.subfield [[WMASK]](0) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
+
+  // CHECK: [[RDATA:%.*]] = firrtl.subfield %ram_ramport(3)
+  // CHECK: [[WMODE:%.*]] = firrtl.subfield %ram_ramport(4)
+  // CHECK: [[WDATA:%.*]] = firrtl.subfield %ram_ramport(5)
+  // CHECK: [[WMASK:%.*]] = firrtl.subfield %ram_ramport(6)
+  // CHECK: [[WDATA_A:%.*]] = firrtl.subfield [[WDATA]](0)
+  // CHECK: [[WMASK_A:%.*]] = firrtl.subfield [[WMASK]](0)
   // CHECK: firrtl.connect [[WMASK_A]], %c1_ui1
   // CHECK: firrtl.connect [[WMODE]], %c1_ui1
   // CHECK: firrtl.connect [[WDATA_A]], %in
-  %port_a = firrtl.subfield %port(0) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
+  %port_a = firrtl.subfield %ramport(0) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
   firrtl.connect %port_a, %in : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: [[RDATA_B:%.*]] = firrtl.subfield [[RDATA]](1) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
   // CHECK: firrtl.connect %out, [[RDATA_B]] : !firrtl.uint<1>, !firrtl.uint<1>
-  %port_b = firrtl.subfield %port(1) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
+  %port_b = firrtl.subfield %ramport(1) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
   firrtl.connect %out, %port_b : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
 // Check that ports are sorted in alphabetical order.
-firrtl.module @SortedPorts(in %clock: !firrtl.clock, in %addr : !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
+firrtl.module @SortedPorts(in %clock: !firrtl.clock, in %addr : !firrtl.uint<8>, out %out: !firrtl.uint<1>) {
   // CHECK: portNames = ["a", "b", "c"]
-  %ram = firrtl.combmem : !firrtl.cmemory<vector<uint<1>, 2>, 2>
-  %c = firrtl.memoryport Read %ram, %addr, %clock : (!firrtl.cmemory<vector<uint<1>, 2>, 2>, !firrtl.uint<1>, !firrtl.clock) -> !firrtl.vector<uint<1>, 2>
-  %a = firrtl.memoryport Write %ram, %addr, %clock : (!firrtl.cmemory<vector<uint<1>, 2>, 2>, !firrtl.uint<1>, !firrtl.clock) -> !firrtl.vector<uint<1>, 2>
-  %b = firrtl.memoryport ReadWrite %ram, %addr, %clock  : (!firrtl.cmemory<vector<uint<1>, 2>, 2>, !firrtl.uint<1>, !firrtl.clock) -> !firrtl.vector<uint<1>, 2>
+  %ram = firrtl.combmem : !firrtl.cmemory<vector<uint<1>, 2>, 256>
+  %c, %c_port = firrtl.memoryport Read %ram : (!firrtl.cmemory<vector<uint<1>, 2>, 256>) -> (!firrtl.vector<uint<1>, 2>, !firrtl.cmemoryport)
+  firrtl.memoryport.access %c_port[%addr], %clock : !firrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
+  %a, %a_port = firrtl.memoryport Write %ram : (!firrtl.cmemory<vector<uint<1>, 2>, 256>) -> (!firrtl.vector<uint<1>, 2>, !firrtl.cmemoryport)
+  firrtl.memoryport.access %a_port[%addr], %clock : !firrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
+  %b, %b_port = firrtl.memoryport ReadWrite %ram : (!firrtl.cmemory<vector<uint<1>, 2>, 256>) -> (!firrtl.vector<uint<1>, 2>, !firrtl.cmemoryport)
+  firrtl.memoryport.access %b_port[%addr], %clock : !firrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
 }
 
 // Check that annotations are preserved.
-firrtl.module @Annotations(in %clock: !firrtl.clock, in %addr : !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
+firrtl.module @Annotations(in %clock: !firrtl.clock, in %addr : !firrtl.uint<8>, out %out: !firrtl.uint<1>) {
   // CHECK: firrtl.mem Undefined 
   // CHECK-SAME: annotations = [{a = "a"}]
   // CHECK-SAME: portAnnotations = [
@@ -210,25 +232,28 @@ firrtl.module @Annotations(in %clock: !firrtl.clock, in %addr : !firrtl.uint<1>,
   // CHECK-SAME:   [{c = "c"}]
   // CHECK-SAME: ]
   // CHECK-SAME: portNames = ["port0", "port1"]
-  %ram = firrtl.combmem {annotations = [{a = "a"}]} : !firrtl.cmemory<vector<uint<1>, 2>, 2>
-  %port0 = firrtl.memoryport Read %ram, %addr, %clock {annotations = [{b = "b"}]} : (!firrtl.cmemory<vector<uint<1>, 2>, 2>, !firrtl.uint<1>, !firrtl.clock) -> !firrtl.vector<uint<1>, 2>
-  %port1 = firrtl.memoryport Read %ram, %addr, %clock {annotations = [{c = "c"}]} : (!firrtl.cmemory<vector<uint<1>, 2>, 2>, !firrtl.uint<1>, !firrtl.clock) -> !firrtl.vector<uint<1>, 2>
+  %ram = firrtl.combmem {annotations = [{a = "a"}]} : !firrtl.cmemory<vector<uint<1>, 2>, 256>
+  %port0, %port0_port = firrtl.memoryport Read %ram {annotations = [{b = "b"}]} : (!firrtl.cmemory<vector<uint<1>, 2>, 256>) -> (!firrtl.vector<uint<1>, 2>, !firrtl.cmemoryport)
+  firrtl.memoryport.access %port0_port[%addr], %clock : !firrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
+  %port1, %port1_port = firrtl.memoryport Read %ram {annotations = [{c = "c"}]} : (!firrtl.cmemory<vector<uint<1>, 2>, 256>) -> (!firrtl.vector<uint<1>, 2>, !firrtl.cmemoryport)
+  firrtl.memoryport.access %port1_port[%addr], %clock : !firrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
 }
 
 // When the address is a wire, the enable should be inferred where the address
 // is driven.
 firrtl.module @EnableInference0(in %p: !firrtl.uint<1>, in %addr: !firrtl.uint<4>, in %clock: !firrtl.clock, out %v: !firrtl.uint<32>) {
   %w = firrtl.wire  : !firrtl.uint<4>
-  %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
   // This connect should not count as "driving" a value.  If it accidentally
   // inserts an enable here, we will get a use-before-def error, so it is
   // enough of a check that this compiles.
+  %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
   firrtl.connect %w, %invalid_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_ramport(0)
   // CHECK: [[EN:%.*]] = firrtl.subfield %ram_ramport(1)
   %ram = firrtl.seqmem Undefined  : !firrtl.cmemory<uint<32>, 16>
-  %ramport = firrtl.memoryport Read %ram, %w, %clock  : (!firrtl.cmemory<uint<32>, 16>, !firrtl.uint<4>, !firrtl.clock) -> !firrtl.uint<32>
+  %ramport, %ramport_port = firrtl.memoryport Read %ram : (!firrtl.cmemory<uint<32>, 16>) -> (!firrtl.uint<32>, !firrtl.cmemoryport)
+  firrtl.memoryport.access %ramport_port[%w], %clock : !firrtl.cmemoryport, !firrtl.uint<4>, !firrtl.clock
 
   // CHECK: firrtl.when %p {
   firrtl.when %p  {
@@ -254,7 +279,8 @@ firrtl.module @EnableInference1(in %p: !firrtl.uint<1>, in %addr: !firrtl.uint<4
    // CHECK-NEXT: firrtl.connect %2, %clock
    // CHECK-NEXT: firrtl.connect %v, %3
     %n = firrtl.node %addr : !firrtl.uint<4>
-    %ramport = firrtl.memoryport Read %ram, %n, %clock  : (!firrtl.cmemory<uint<32>, 16>, !firrtl.uint<4>, !firrtl.clock) -> !firrtl.uint<32>
+    %ramport, %ramport_port = firrtl.memoryport Read %ram : (!firrtl.cmemory<uint<32>, 16>) -> (!firrtl.uint<32>, !firrtl.cmemoryport)
+    firrtl.memoryport.access %ramport_port[%n], %clock : !firrtl.cmemoryport, !firrtl.uint<4>, !firrtl.clock
     firrtl.connect %v, %ramport : !firrtl.uint<32>, !firrtl.uint<32>
   }
 }

--- a/test/Dialect/FIRRTL/infer-memories.mlir
+++ b/test/Dialect/FIRRTL/infer-memories.mlir
@@ -1,0 +1,262 @@
+// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl.module(firrtl-infer-memories))'  %s | FileCheck %s
+
+firrtl.circuit "Empty" {
+
+// Memories with no ports should be deleted.
+firrtl.module @Empty(in %clock: !firrtl.clock) {
+  %ram = firrtl.combmem : !firrtl.cmemory<uint<1>, 2>
+}
+// CHECK:      firrtl.module @Empty(in %clock: !firrtl.clock) {
+// CHECK-NEXT: }
+
+// Unused ports should be deleted.
+firrtl.module @UnusedMemPort(in %clock: !firrtl.clock, in %addr : !firrtl.uint<1>) {
+  %ram = firrtl.combmem : !firrtl.cmemory<vector<uint<1>, 2>, 2>
+  // This port should be deleted.
+  %port0 = firrtl.memoryport Infer %ram, %addr, %clock : (!firrtl.cmemory<vector<uint<1>, 2>, 2>, !firrtl.uint<1>, !firrtl.clock) -> !firrtl.vector<uint<1>, 2>
+  // Subindexing a port should not count as a "use".
+  %port1 = firrtl.memoryport Infer %ram, %addr, %clock : (!firrtl.cmemory<vector<uint<1>, 2>, 2>, !firrtl.uint<1>, !firrtl.clock) -> !firrtl.vector<uint<1>, 2>
+  %0 = firrtl.subindex %port1[1] : !firrtl.vector<uint<1>, 2>
+}
+// CHECK:      firrtl.module @UnusedMemPort(in %clock: !firrtl.clock, in %addr: !firrtl.uint<1>) {
+// CHECK-NEXT: }
+
+firrtl.module @InferRead(in %clock: !firrtl.clock, in %addr: !firrtl.uint<1>, out %out : !firrtl.uint<1>, in %vec : !firrtl.vector<uint<1>, 2>) {
+  // CHECK: %ram_port = firrtl.mem Undefined  {depth = 2 : i64, name = "ram", portNames = ["port"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
+  // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_port(0)
+  // CHECK: firrtl.connect [[ADDR]], %invalid_ui1
+  // CHECK: [[EN:%.*]] = firrtl.subfield %ram_port(1)
+  // CHECK: firrtl.connect [[EN]], %c0_ui1
+  // CHECK: [[CLOCK:%.*]] = firrtl.subfield %ram_port(2)
+  // CHECK: firrtl.connect [[CLOCK]], %invalid_clock
+  // CHECK: [[DATA:%.*]] = firrtl.subfield %ram_port(3)
+  %ram = firrtl.combmem : !firrtl.cmemory<uint<1>, 2>
+
+  // CHECK: firrtl.connect [[ADDR]], %addr
+  // CHECK: firrtl.connect [[EN]], %c1_ui1
+  // CHECK: firrtl.connect [[CLOCK]], %clock
+  %port = firrtl.memoryport Infer %ram, %addr, %clock : (!firrtl.cmemory<uint<1>, 2>, !firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
+
+  // CHECK: %node = firrtl.node [[DATA]]
+  %node = firrtl.node %port : !firrtl.uint<1>
+
+  // CHECK: firrtl.connect %out, [[DATA]]
+  firrtl.connect %out, %port : !firrtl.uint<1>, !firrtl.uint<1>
+
+  // CHECK: firrtl.partialconnect %out, [[DATA]]
+  firrtl.partialconnect %out, %port : !firrtl.uint<1>, !firrtl.uint<1>
+
+  // TODO: How do you get FileCheck to accept "[[[DATA]]]"?
+  // CHECK: firrtl.subaccess %vec{{\[}}[[DATA]]{{\]}} : !firrtl.vector<uint<1>, 2>, !firrtl.uint<1>
+  firrtl.subaccess %vec[%port] : !firrtl.vector<uint<1>, 2>, !firrtl.uint<1>
+}
+
+firrtl.module @InferWrite(in %clock: !firrtl.clock, in %addr: !firrtl.uint<1>, in %in : !firrtl.uint<1>) {
+  // CHECK: %ram_port = firrtl.mem Undefined {depth = 2 : i64, name = "ram", portNames = ["port"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<1>, mask: uint<1>>
+  // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_port(0)
+  // CHECK: firrtl.connect [[ADDR]], %invalid_ui1
+  // CHECK: [[EN:%.*]] = firrtl.subfield %ram_port(1)
+  // CHECK: firrtl.connect [[EN]], %c0_ui1
+  // CHECK: [[CLOCK:%.*]] = firrtl.subfield %ram_port(2)
+  // CHECK: firrtl.connect [[CLOCK]], %invalid_clock
+  // CHECK: [[DATA:%.*]] = firrtl.subfield %ram_port(3)
+  // CHECK: firrtl.connect [[DATA]], %invalid_ui1
+  // CHECK: [[MASK:%.*]] = firrtl.subfield %ram_port(4)
+  // CHECK: firrtl.connect [[MASK]], %invalid_ui1
+  %ram = firrtl.combmem : !firrtl.cmemory<uint<1>, 2>
+
+  // CHECK: firrtl.connect [[ADDR]], %addr
+  // CHECK: firrtl.connect [[EN]], %c1_ui1
+  // CHECK: firrtl.connect [[CLOCK]], %clock
+  // CHECK: firrtl.connect [[MASK]], %c0_ui1
+  %port = firrtl.memoryport Infer %ram, %addr, %clock : (!firrtl.cmemory<uint<1>, 2>, !firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
+
+  // CHECK: firrtl.connect [[MASK]], %c1_ui1
+  // CHECK: firrtl.connect [[DATA]], %in
+  firrtl.connect %port, %in : !firrtl.uint<1>, !firrtl.uint<1>
+
+  // CHECK: firrtl.connect [[MASK]], %c1_ui1
+  // CHECK: firrtl.partialconnect [[DATA]], %in
+  firrtl.partialconnect %port, %in : !firrtl.uint<1>, !firrtl.uint<1>
+}
+
+firrtl.module @InferReadWrite(in %clock: !firrtl.clock, in %addr: !firrtl.uint<1>, in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
+  // CHECK: %ram_port = firrtl.mem Undefined  {depth = 2 : i64, name = "ram", portNames = ["port"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, rdata flip: uint<1>, wmode: uint<1>,  wdata: uint<1>, wmask: uint<1>>
+  // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_port(0)
+  // CHECK: firrtl.connect [[ADDR]], %invalid_ui1
+  // CHECK: [[EN:%.*]] = firrtl.subfield %ram_port(1)
+  // CHECK: firrtl.connect [[EN]], %c0_ui1
+  // CHECK: [[CLOCK:%.*]] = firrtl.subfield %ram_port(2)
+  // CHECK: firrtl.connect [[CLOCK]], %invalid_clock
+  // CHECK: [[RDATA:%.*]] = firrtl.subfield %ram_port(3)
+  // CHECK: [[WMODE:%.*]] = firrtl.subfield %ram_port(4)
+  // CHECK: firrtl.connect [[WMODE]], %c0_ui1
+  // CHECK: [[WDATA:%.*]] = firrtl.subfield %ram_port(5)
+  // CHECK: firrtl.connect [[WDATA]], %invalid_ui1
+  // CHECK: [[WMASK:%.*]] = firrtl.subfield %ram_port(6)
+  // CHECK: firrtl.connect [[WMASK]], %invalid_ui1
+  %ram = firrtl.combmem : !firrtl.cmemory<uint<1>, 2>
+
+  // CHECK: firrtl.connect [[ADDR]], %addr : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK: firrtl.connect [[EN]], %c1_ui1
+  // CHECK: firrtl.connect [[CLOCK]], %clock
+  // CHECK: firrtl.connect [[WMASK]], %c0_ui1
+  %port = firrtl.memoryport Read %ram, %addr, %clock : (!firrtl.cmemory<uint<1>, 2>, !firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
+
+  // CHECK: firrtl.connect [[WMASK]], %c1_ui1
+  // CHECK: firrtl.connect [[WMODE]], %c1_ui1
+  // CHECK: firrtl.connect [[WDATA]], %in
+  firrtl.connect %port, %in : !firrtl.uint<1>, !firrtl.uint<1>
+
+  // CHECK: firrtl.connect %out, [[RDATA]] 
+  firrtl.connect %out, %port : !firrtl.uint<1>, !firrtl.uint<1>
+}
+
+// Check that partial connect properly sets the write mask for the elements which are actually connected.
+firrtl.module @PartialConnectWriteMask(in %clock: !firrtl.clock, in %addr: !firrtl.uint<1>, in %data : !firrtl.bundle<c: vector<uint<3>, 2>, a: uint<1>>) {
+  // CHECK: %ram_port = firrtl.mem Undefined  {depth = 2 : i64, name = "ram", portNames = ["port"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>, mask: bundle<a: uint<1>, b: uint<1>, c: vector<uint<1>, 3>>>
+  // CHECK: [[DATA:%.*]] = firrtl.subfield %ram_port(3)
+  // CHECK: [[MASK:%.*]] = firrtl.subfield %ram_port(4)
+  // CHECK: [[A:%.*]] = firrtl.subfield [[MASK]](0)
+  // CHECK: firrtl.connect [[A]], %invalid_ui1 
+  // CHECK: [[B:%.*]] = firrtl.subfield [[MASK]](1)
+  // CHECK: firrtl.connect [[B]], %invalid_ui1 
+  // CHECK: [[C:%.*]] = firrtl.subfield [[MASK]](2)
+  // CHECK: [[C_0:%.*]] = firrtl.subindex [[C]][0]
+  // CHECK: firrtl.connect [[C_0]], %invalid_ui1 
+  // CHECK: [[C_1:%.*]] = firrtl.subindex [[C]][1]
+  // CHECK: firrtl.connect [[C_1]], %invalid_ui1 
+  // CHECK: [[C_2:%.*]] = firrtl.subindex [[C]][2]
+  // CHECK: firrtl.connect [[C_2]], %invalid_ui1 
+  %ram = firrtl.combmem : !firrtl.cmemory<bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>, 2>
+
+  // CHECK: [[A:%.*]] = firrtl.subfield [[MASK]](0)
+  // CHECK: firrtl.connect [[A]], %c0_ui1 
+  // CHECK: [[B:%.*]] = firrtl.subfield [[MASK]](1) : (!firrtl.bundle<a: uint<1>, b: uint<1>, c: vector<uint<1>, 3>>) -> !firrtl.uint<1>
+  // CHECK: firrtl.connect [[B]], %c0_ui1 
+  // CHECK: [[C:%.*]] = firrtl.subfield [[MASK]](2) : (!firrtl.bundle<a: uint<1>, b: uint<1>, c: vector<uint<1>, 3>>) -> !firrtl.vector<uint<1>, 3>
+  // CHECK: [[C_0:%.*]] = firrtl.subindex [[C]][0] : !firrtl.vector<uint<1>, 3>
+  // CHECK: firrtl.connect [[C_0]], %c0_ui1 
+  // CHECK: [[C_1:%.*]] = firrtl.subindex [[C]][1] : !firrtl.vector<uint<1>, 3>
+  // CHECK: firrtl.connect [[C_1]], %c0_ui1 
+  // CHECK: [[C_2:%.*]] = firrtl.subindex [[C]][2] : !firrtl.vector<uint<1>, 3>
+  // CHECK: firrtl.connect [[C_2]], %c0_ui1 
+  %port = firrtl.memoryport Infer %ram, %addr, %clock : (!firrtl.cmemory<bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>, 2>, !firrtl.uint<1>, !firrtl.clock) -> !firrtl.bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>
+
+  // CHECK: [[A:%.*]] = firrtl.subfield [[MASK]](0) : (!firrtl.bundle<a: uint<1>, b: uint<1>, c: vector<uint<1>, 3>>) -> !firrtl.uint<1>
+  // CHECK: firrtl.connect [[A]], %c1_ui1 
+  // CHECK: [[C:%.*]] = firrtl.subfield [[MASK]](2) : (!firrtl.bundle<a: uint<1>, b: uint<1>, c: vector<uint<1>, 3>>) -> !firrtl.vector<uint<1>, 3>
+  // CHECK: [[C_0:%.*]] = firrtl.subindex [[C]][0] : !firrtl.vector<uint<1>, 3>
+  // CHECK: firrtl.connect [[C_0]], %c1_ui1 
+  // CHECK: [[C_1:%.*]] = firrtl.subindex [[C]][1] : !firrtl.vector<uint<1>, 3>
+  // CHECK: firrtl.connect [[C_1]], %c1_ui1 
+  // CHECK: firrtl.partialconnect [[DATA]], %data
+  firrtl.partialconnect %port, %data : !firrtl.bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>, !firrtl.bundle<c: vector<uint<3>, 2>, a: uint<1>>
+}
+
+firrtl.module @WriteToSubfield(in %clock: !firrtl.clock, in %addr: !firrtl.uint<1>, in %value: !firrtl.uint<1>) {
+  %ram = firrtl.combmem : !firrtl.cmemory<bundle<a: uint<1>, b: uint<1>>, 2>
+  %port = firrtl.memoryport Infer %ram, %addr, %clock : (!firrtl.cmemory<bundle<a: uint<1>, b:uint<1>>, 2>, !firrtl.uint<1>, !firrtl.clock) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
+  %port_b = firrtl.subfield %port(1) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
+  // Check that only the subfield of the mask is written to.
+  // CHECK: [[DATA:%.*]] = firrtl.subfield %ram_port(3) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<1>, b: uint<1>>, mask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
+  // CHECK: [[MASK:%.*]] = firrtl.subfield %ram_port(4) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<1>, b: uint<1>>, mask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
+  // CHECK: [[DATA_B:%.*]] = firrtl.subfield [[DATA]](1) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
+  // CHECK: [[MASK_B:%.*]] = firrtl.subfield [[MASK]](1) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
+  // CHECK: firrtl.connect [[MASK_B]], %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK: firrtl.connect [[DATA_B]], %value : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %port_b, %value : !firrtl.uint<1>, !firrtl.uint<1>
+}
+
+// Read and write from different subfields of the memory.  The memory as a
+// whole should be inferred to read+write.
+firrtl.module @ReadAndWriteToSubfield(in %clock: !firrtl.clock, in %addr: !firrtl.uint<1>, in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
+  %ram = firrtl.combmem : !firrtl.cmemory<bundle<a: uint<1>, b: uint<1>>, 2>
+  %port = firrtl.memoryport Infer %ram, %addr, %clock : (!firrtl.cmemory<bundle<a: uint<1>, b:uint<1>>, 2>, !firrtl.uint<1>, !firrtl.clock) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
+
+  // CHECK: [[RDATA:%.*]] = firrtl.subfield %ram_port(3) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, rdata flip: bundle<a: uint<1>, b: uint<1>>, wmode: uint<1>, wdata: bundle<a: uint<1>, b: uint<1>>, wmask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
+  // CHECK: [[WMODE:%.*]] = firrtl.subfield %ram_port(4) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, rdata flip: bundle<a: uint<1>, b: uint<1>>, wmode: uint<1>, wdata: bundle<a: uint<1>, b: uint<1>>, wmask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.uint<1>
+  // CHECK: [[WDATA:%.*]] = firrtl.subfield %ram_port(5) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, rdata flip: bundle<a: uint<1>, b: uint<1>>, wmode: uint<1>, wdata: bundle<a: uint<1>, b: uint<1>>, wmask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
+  // CHECK: [[WMASK:%.*]] = firrtl.subfield %ram_port(6) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, rdata flip: bundle<a: uint<1>, b: uint<1>>, wmode: uint<1>, wdata: bundle<a: uint<1>, b: uint<1>>, wmask: bundle<a: uint<1>, b: uint<1>>>) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
+  // CHECK: [[WDATA_A:%.*]] = firrtl.subfield [[WDATA]](0) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
+  // CHECK: [[WMASK_A:%.*]] = firrtl.subfield [[WMASK]](0) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
+  // CHECK: firrtl.connect [[WMASK_A]], %c1_ui1
+  // CHECK: firrtl.connect [[WMODE]], %c1_ui1
+  // CHECK: firrtl.connect [[WDATA_A]], %in
+  %port_a = firrtl.subfield %port(0) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
+  firrtl.connect %port_a, %in : !firrtl.uint<1>, !firrtl.uint<1>
+
+  // CHECK: [[RDATA_B:%.*]] = firrtl.subfield [[RDATA]](1) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
+  // CHECK: firrtl.connect %out, [[RDATA_B]] : !firrtl.uint<1>, !firrtl.uint<1>
+  %port_b = firrtl.subfield %port(1) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
+  firrtl.connect %out, %port_b : !firrtl.uint<1>, !firrtl.uint<1>
+}
+
+// Check that ports are sorted in alphabetical order.
+firrtl.module @SortedPorts(in %clock: !firrtl.clock, in %addr : !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
+  // CHECK: portNames = ["a", "b", "c"]
+  %ram = firrtl.combmem : !firrtl.cmemory<vector<uint<1>, 2>, 2>
+  %c = firrtl.memoryport Read %ram, %addr, %clock : (!firrtl.cmemory<vector<uint<1>, 2>, 2>, !firrtl.uint<1>, !firrtl.clock) -> !firrtl.vector<uint<1>, 2>
+  %a = firrtl.memoryport Write %ram, %addr, %clock : (!firrtl.cmemory<vector<uint<1>, 2>, 2>, !firrtl.uint<1>, !firrtl.clock) -> !firrtl.vector<uint<1>, 2>
+  %b = firrtl.memoryport ReadWrite %ram, %addr, %clock  : (!firrtl.cmemory<vector<uint<1>, 2>, 2>, !firrtl.uint<1>, !firrtl.clock) -> !firrtl.vector<uint<1>, 2>
+}
+
+// Check that annotations are preserved.
+firrtl.module @Annotations(in %clock: !firrtl.clock, in %addr : !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
+  // CHECK: firrtl.mem Undefined 
+  // CHECK-SAME: annotations = [{a = "a"}]
+  // CHECK-SAME: portAnnotations = [
+  // CHECK-SAME:   [{b = "b"}],
+  // CHECK-SAME:   [{c = "c"}]
+  // CHECK-SAME: ]
+  // CHECK-SAME: portNames = ["port0", "port1"]
+  %ram = firrtl.combmem {annotations = [{a = "a"}]} : !firrtl.cmemory<vector<uint<1>, 2>, 2>
+  %port0 = firrtl.memoryport Read %ram, %addr, %clock {annotations = [{b = "b"}]} : (!firrtl.cmemory<vector<uint<1>, 2>, 2>, !firrtl.uint<1>, !firrtl.clock) -> !firrtl.vector<uint<1>, 2>
+  %port1 = firrtl.memoryport Read %ram, %addr, %clock {annotations = [{c = "c"}]} : (!firrtl.cmemory<vector<uint<1>, 2>, 2>, !firrtl.uint<1>, !firrtl.clock) -> !firrtl.vector<uint<1>, 2>
+}
+
+// When the address is a wire, the enable should be inferred where the address
+// is driven.
+firrtl.module @EnableInference0(in %p: !firrtl.uint<1>, in %addr: !firrtl.uint<4>, in %clock: !firrtl.clock, out %v: !firrtl.uint<32>) {
+  %w = firrtl.wire  : !firrtl.uint<4>
+  %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
+  // This connect should not count as "driving" a value.  If it accidentally
+  // inserts an enable here, we will get a use-before-def error, so it is
+  // enough of a check that this compiles.
+  firrtl.connect %w, %invalid_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
+
+  // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_ramport(0)
+  // CHECK: [[EN:%.*]] = firrtl.subfield %ram_ramport(1)
+  %ram = firrtl.seqmem Undefined  : !firrtl.cmemory<uint<32>, 16>
+  %ramport = firrtl.memoryport Read %ram, %w, %clock  : (!firrtl.cmemory<uint<32>, 16>, !firrtl.uint<4>, !firrtl.clock) -> !firrtl.uint<32>
+
+  // CHECK: firrtl.when %p {
+  firrtl.when %p  {
+    // CHECK-NEXT: firrtl.connect [[EN]], %c1_ui1
+    // CHECK-NEXT: firrtl.connect %w, %addr
+    firrtl.connect %w, %addr : !firrtl.uint<4>, !firrtl.uint<4>
+  }
+  firrtl.connect %v, %ramport : !firrtl.uint<32>, !firrtl.uint<32>
+}
+
+// When the address is a node, the enable should be inferred where the address is declared.
+firrtl.module @EnableInference1(in %p: !firrtl.uint<1>, in %addr: !firrtl.uint<4>, in %clock: !firrtl.clock, out %v: !firrtl.uint<32>) {
+  %ram = firrtl.seqmem Undefined  : !firrtl.cmemory<uint<32>, 16>
+  %invalid_ui32 = firrtl.invalidvalue : !firrtl.uint<32>
+  firrtl.connect %v, %invalid_ui32 : !firrtl.uint<32>, !firrtl.uint<32>
+  // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_ramport(0)
+  // CHECK: [[EN:%.*]] = firrtl.subfield %ram_ramport(1)
+  // CHECK: firrtl.when %p
+  firrtl.when %p  {
+   // CHECK-NEXT: firrtl.connect [[EN]], %c1_ui1
+   // CHECK-NEXT: %n = firrtl.node %addr
+   // CHECK-NEXT: firrtl.connect [[ADDR]], %n
+   // CHECK-NEXT: firrtl.connect %2, %clock
+   // CHECK-NEXT: firrtl.connect %v, %3
+    %n = firrtl.node %addr : !firrtl.uint<4>
+    %ramport = firrtl.memoryport Read %ram, %n, %clock  : (!firrtl.cmemory<uint<32>, 16>, !firrtl.uint<4>, !firrtl.clock) -> !firrtl.uint<32>
+    firrtl.connect %v, %ramport : !firrtl.uint<32>, !firrtl.uint<32>
+  }
+}
+}
+

--- a/test/Dialect/FIRRTL/infer-memories.mlir
+++ b/test/Dialect/FIRRTL/infer-memories.mlir
@@ -129,18 +129,9 @@ firrtl.module @InferReadWrite(in %clock: !firrtl.clock, in %addr: !firrtl.uint<8
 firrtl.module @PartialConnectWriteMask(in %clock: !firrtl.clock, in %addr: !firrtl.uint<8>, in %data : !firrtl.bundle<c: vector<uint<3>, 2>, a: uint<1>>) {
   // CHECK: %ram_ramport = firrtl.mem Undefined {depth = 256 : i64, name = "ram", portNames = ["ramport"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<8>, en: uint<1>, clk: clock, data: bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>, mask: bundle<a: uint<1>, b: uint<1>, c: vector<uint<1>, 3>>>
   // CHECK: [[DATA:%.*]] = firrtl.subfield %ram_ramport(3)
+  // CHECK: firrtl.connect [[DATA]], %invalid
   // CHECK: [[MASK:%.*]] = firrtl.subfield %ram_ramport(4)
-  // CHECK: [[A:%.*]] = firrtl.subfield [[MASK]](0)
-  // CHECK: firrtl.connect [[A]], %invalid_ui1 
-  // CHECK: [[B:%.*]] = firrtl.subfield [[MASK]](1)
-  // CHECK: firrtl.connect [[B]], %invalid_ui1 
-  // CHECK: [[C:%.*]] = firrtl.subfield [[MASK]](2)
-  // CHECK: [[C_0:%.*]] = firrtl.subindex [[C]][0]
-  // CHECK: firrtl.connect [[C_0]], %invalid_ui1 
-  // CHECK: [[C_1:%.*]] = firrtl.subindex [[C]][1]
-  // CHECK: firrtl.connect [[C_1]], %invalid_ui1 
-  // CHECK: [[C_2:%.*]] = firrtl.subindex [[C]][2]
-  // CHECK: firrtl.connect [[C_2]], %invalid_ui1 
+  // CHECK: firrtl.connect [[MASK]], %invalid
   %ram = firrtl.combmem : !firrtl.cmemory<bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>, 256>
 
   // CHECK: [[A:%.*]] = firrtl.subfield [[MASK]](0)
@@ -156,7 +147,6 @@ firrtl.module @PartialConnectWriteMask(in %clock: !firrtl.clock, in %addr: !firr
   // CHECK: firrtl.connect [[C_2]], %c0_ui1 
   %ramport_data, %ramport_port = firrtl.memoryport Infer %ram {name = "ramport"} : (!firrtl.cmemory<bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>, 256>) -> (!firrtl.bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>, !firrtl.cmemoryport)
   firrtl.memoryport.access %ramport_port[%addr], %clock : !firrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
-
 
   // CHECK: [[A:%.*]] = firrtl.subfield [[MASK]](0) : (!firrtl.bundle<a: uint<1>, b: uint<1>, c: vector<uint<1>, 3>>) -> !firrtl.uint<1>
   // CHECK: firrtl.connect [[A]], %c1_ui1 
@@ -212,7 +202,7 @@ firrtl.module @ReadAndWriteToSubfield(in %clock: !firrtl.clock, in %addr: !firrt
 }
 
 // Check that ports are sorted in alphabetical order.
-firrtl.module @SortedPorts(in %clock: !firrtl.clock, in %addr : !firrtl.uint<8>, out %out: !firrtl.uint<1>) {
+firrtl.module @SortedPorts(in %clock: !firrtl.clock, in %addr : !firrtl.uint<8>) {
   // CHECK: portNames = ["a", "b", "c"]
   %ram = firrtl.combmem : !firrtl.cmemory<vector<uint<1>, 2>, 256>
   %c_data, %c_port = firrtl.memoryport Read %ram {name = "c"} : (!firrtl.cmemory<vector<uint<1>, 2>, 256>) -> (!firrtl.vector<uint<1>, 2>, !firrtl.cmemoryport)
@@ -224,7 +214,7 @@ firrtl.module @SortedPorts(in %clock: !firrtl.clock, in %addr : !firrtl.uint<8>,
 }
 
 // Check that annotations are preserved.
-firrtl.module @Annotations(in %clock: !firrtl.clock, in %addr : !firrtl.uint<8>, out %out: !firrtl.uint<1>) {
+firrtl.module @Annotations(in %clock: !firrtl.clock, in %addr : !firrtl.uint<8>) {
   // CHECK: firrtl.mem Undefined 
   // CHECK-SAME: annotations = [{a = "a"}]
   // CHECK-SAME: portAnnotations = [

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -123,6 +123,11 @@ static cl::opt<bool>
                        cl::init(false));
 
 static cl::opt<bool>
+    inferMemories("infer-memories",
+                  cl::desc("run the width inference pass on firrtl"),
+                  cl::init(true));
+
+static cl::opt<bool>
     inferWidths("infer-widths",
                 cl::desc("run the width inference pass on firrtl"),
                 cl::init(true));
@@ -240,6 +245,10 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
         createCSEPass());
   }
+
+  if (inferMemories)
+    pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
+        firrtl::createInferMemoriesPass());
 
   // Width inference creates canonicalization opportunities.
   if (inferWidths)

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -123,9 +123,9 @@ static cl::opt<bool>
                        cl::init(false));
 
 static cl::opt<bool>
-    inferMemories("infer-memories",
-                  cl::desc("run the width inference pass on firrtl"),
-                  cl::init(true));
+    lowerCHIRRTL("lower-chirrtl",
+                 cl::desc("lower CHIRRTL memories to FIRRTL memories"),
+                 cl::init(true));
 
 static cl::opt<bool>
     inferWidths("infer-widths",
@@ -246,9 +246,9 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
         createCSEPass());
   }
 
-  if (inferMemories)
+  if (lowerCHIRRTL)
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
-        firrtl::createInferMemoriesPass());
+        firrtl::createLowerCHIRRTLPass());
 
   // Width inference creates canonicalization opportunities.
   if (inferWidths)


### PR DESCRIPTION
This adds an implementation of the `RemoveCHIRRTL` pass called
`InferMemories`.  This pass takes the CHIRRTL memory operations, `seqmem`
and `combmem`, and transforms them into standard FIRRTL `mem`
operations.