### PR TITLE
README: fix link for how to get commit access

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ of LLVM discord server.
 for more information.
 
 3) Contribute code.  CIRCT follows all of the LLVM Policies: you can create pull
-requests for the CIRCT repository, and gain commit access using the [standard LLVM policies](https://llvm.discourse.group/c/Projects-that-want-to-become-official-LLVM-Projects/circt/).
+requests for the CIRCT repository, and gain commit access using the [standard LLVM policies](https://llvm.org/docs/DeveloperPolicy.html#obtaining-commit-access).
 
 ## Motivation
 


### PR DESCRIPTION
Previous link went to Discourse which isn't the right location. I believe this link is the right one, but I could be wrong.