### PR TITLE
[CMake] Allow users to override CMAKE_CXX_VISIBILITY_PRESET.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,8 @@ else()
 
   # The -fvisibility=hidden option only works for static builds.
   if (NOT BUILD_SHARED_LIBS)
-    set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+    set(CMAKE_CXX_VISIBILITY_PRESET hidden CACHE STRING
+        "Default to visibility=hidden")
   else()
     if (CMAKE_CXX_VISIBILITY_PRESET STREQUAL "hidden")
       message(FATAL_ERROR "CMAKE_CXX_VISIBILITY_PRESET=hidden is incompatible \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,8 +79,8 @@ else()
 
   # The -fvisibility=hidden option only works for static builds.
   if (NOT BUILD_SHARED_LIBS)
-    set(CMAKE_CXX_VISIBILITY_PRESET hidden CACHE STRING
-        "Default to visibility=hidden")
+    set(CMAKE_CXX_VISIBILITY_PRESET default CACHE STRING
+        "Default to visibility=default")
   else()
     if (CMAKE_CXX_VISIBILITY_PRESET STREQUAL "hidden")
       message(FATAL_ERROR "CMAKE_CXX_VISIBILITY_PRESET=hidden is incompatible \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,14 +78,9 @@ else()
   set(CMAKE_VISIBILITY_INLINES_HIDDEN ON CACHE BOOL "Hide inlines")
 
   # The -fvisibility=hidden option only works for static builds.
-  if (NOT BUILD_SHARED_LIBS)
-    set(CMAKE_CXX_VISIBILITY_PRESET default CACHE STRING
-        "Default to visibility=default")
-  else()
-    if (CMAKE_CXX_VISIBILITY_PRESET STREQUAL "hidden")
-      message(FATAL_ERROR "CMAKE_CXX_VISIBILITY_PRESET=hidden is incompatible \
-                           with BUILD_SHARED_LIBS.")
-    endif()
+  if (BUILD_SHARED_LIBS AND (CMAKE_CXX_VISIBILITY_PRESET STREQUAL "hidden"))
+    message(FATAL_ERROR "CMAKE_CXX_VISIBILITY_PRESET=hidden is incompatible \
+                         with BUILD_SHARED_LIBS.")
   endif()
 
   set(MLIR_MAIN_SRC_DIR ${LLVM_MAIN_SRC_DIR}/../mlir ) # --src-root


### PR DESCRIPTION
The default of "hidden" may not always make sense, so allow it to be
overridden.