### PR TITLE
[FIRRTL] Constant prop RegReset with constant reset and constant mux

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1487,12 +1487,82 @@ void NodeOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                          MLIRContext *context) {
   results.insert<patterns::EmptyNode>(context);
 }
+// A register with constant reset and all connection to either itself or the
+// same constant, must be replaced by the constant.
+struct foldResetMux : public mlir::RewritePattern {
+  foldResetMux(MLIRContext *context)
+      : RewritePattern(RegResetOp::getOperationName(), 0, context) {}
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const override {
+    auto reg = dyn_cast_or_null<RegResetOp>(op);
+    if (!reg)
+      return failure();
+    auto reset = dyn_cast_or_null<ConstantOp>(reg.resetValue().getDefiningOp());
+    auto resetSignal = reg.resetSignal();
+    // Check for a valid const reset.
+    // TODO: Shoud we add a check for resetSignal.isa<BlockArgument>()?
+    if (!reset || resetSignal.getType().isa<AsyncResetType>())
+      return failure();
+    // Find the one true connect, or bail
+    ConnectOp con;
+    for (Operation *user : reg->getUsers()) {
+      // If we see a partial connect or attach, just conservatively fail.
+      if (isa<PartialConnectOp>(user) || isa<AttachOp>(user))
+        return failure();
+
+      auto aConnect = dyn_cast<ConnectOp>(user);
+      if (aConnect && aConnect.dest().getDefiningOp() == reg) {
+        if (con)
+          return failure();
+        con = aConnect;
+      }
+    }
+    if (!con)
+      return failure();
+
+    auto mux = dyn_cast_or_null<MuxPrimOp>(con.src().getDefiningOp());
+    if (!mux)
+      return failure();
+    auto high = mux.high().getDefiningOp();
+    auto low = mux.low().getDefiningOp();
+    auto constOp = dyn_cast_or_null<ConstantOp>(high);
+
+    if (constOp && low != reg)
+      return failure();
+    else if (dyn_cast_or_null<ConstantOp>(low) && high == reg)
+      constOp = dyn_cast<ConstantOp>(low);
+
+    if (!constOp || constOp.getType() != reset.getType() ||
+        constOp.value() != reset.value())
+      return failure();
+
+    // Check all types should be typed by now
+    auto regTy = reg.getType();
+    if (con.dest().getType() != regTy || con.src().getType() != regTy ||
+        mux.high().getType() != regTy || mux.low().getType() != regTy ||
+        regTy.getBitWidthOrSentinel() < 1)
+      return failure();
+
+    // Ok, we know we are doing the transformation.
+
+    // Make sure the constant dominates all users.
+    if (constOp != &con->getBlock()->front())
+      constOp->moveBefore(&con->getBlock()->front());
+
+    // Replace the register with the constant.
+    rewriter.replaceOp(reg, constOp.getResult());
+    // Remove the connect.
+    con.erase();
+    return success();
+  }
+};
 
 void RegResetOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                              MLIRContext *context) {
   results.insert<patterns::RegresetWithZeroReset,
                  patterns::RegresetWithInvalidReset,
-                 patterns::RegresetWithInvalidResetValue>(context);
+                 patterns::RegresetWithInvalidResetValue, foldResetMux>(
+      context);
 }
 
 LogicalResult MemOp::canonicalize(MemOp op, PatternRewriter &rewriter) {

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -1921,4 +1921,52 @@ firrtl.module @constReg2(in %clock: !firrtl.clock,
   // CHECK:  firrtl.connect %out, %[[C12]] 
 }
 
+// CHECK-LABEL: firrtl.module @constReg3
+firrtl.module @constReg3(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cond: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
+  %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
+  %r = firrtl.regreset %clock, %reset, %c11_ui8  : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+  %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+  firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
+  // CHECK:  %[[C14:.+]] = firrtl.constant 11
+  // CHECK: firrtl.connect %z, %[[C14]]
+  firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
+}
+
+// CHECK-LABEL: firrtl.module @constReg4
+firrtl.module @constReg4(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cond: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
+  %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
+  %c11_ui4 = firrtl.constant 11 : !firrtl.uint<8>
+  %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+  %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+  firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
+  // CHECK:  %[[C13:.+]] = firrtl.constant 11
+  // CHECK: firrtl.connect %z, %[[C13]]
+  firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
+}
+
+// CHECK-LABEL: firrtl.module @constReg6
+firrtl.module @constReg6(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cond: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
+  %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
+  %c11_ui4 = firrtl.constant 11 : !firrtl.uint<8>
+  %resCond = firrtl.and %reset, %cond : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %r = firrtl.regreset %clock, %resCond, %c11_ui4  : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+  %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+  firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
+  // CHECK:  %[[C13:.+]] = firrtl.constant 11
+  // CHECK: firrtl.connect %z, %[[C13]]
+  firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
+}
+
+// Cannot optimize if bit mismatch with constant reset.
+// CHECK-LABEL: firrtl.module @constReg5
+firrtl.module @constReg5(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cond: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
+  %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
+  %c11_ui4 = firrtl.constant 11 : !firrtl.uint<4>
+  %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<8>
+  // CHECK: %0 = firrtl.mux(%cond, %c11_ui8, %r)
+  %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+  // CHECK: firrtl.connect %r, %0
+  firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
+  firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
+}
 }


### PR DESCRIPTION
A register with constant reset and a single connection to a mux with the same constant can be replaced with that constant
```mlir
  %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
  %r = firrtl.regreset %clock, %reset, %c11_ui8  : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
  %0 = firrtl.mux(%cond, %c11_ui8, %r) 
  firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
  firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
```
can be replaced with 
```mlir
  %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
  firrtl.connect %z, %c11_ui8 : !firrtl.uint<8>, !firrtl.uint<8>
```

In this PR, handled this constant prop using `RewritePattern`. Another option could be handling it in `IMConstProp`.
The pattern matching code is very similar to `foldHiddenReset`