### PR TITLE
[SV][ExtractTestCode] Extract assume and asserts to separate modules

### DIFF
--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -316,12 +316,13 @@ void SVExtractTestCodeImplPass::runOnOperation() {
     if (auto rtlmod = dyn_cast<hw::HWModuleOp>(op)) {
       // Extract two sets of ops to different modules
       auto isAssert = [](Operation *op) -> bool {
-        return isa<AssertOp>(op) || isa<AssumeOp>(op) || isa<FinishOp>(op) ||
-               isa<FWriteOp>(op);
+        return isa<AssertOp>(op) || isa<FinishOp>(op) || isa<FWriteOp>(op);
       };
+      auto isAssume = [](Operation *op) -> bool { return isa<AssumeOp>(op); };
       auto isCover = [](Operation *op) -> bool { return isa<CoverOp>(op); };
 
       doModule(rtlmod, isAssert, "_assert");
+      doModule(rtlmod, isAssume, "_assume");
       doModule(rtlmod, isCover, "_cover");
     }
 }

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -1,7 +1,8 @@
 // RUN:  circt-opt --sv-extract-test-code %s | FileCheck %s
+// CHECK-LABEL: hw.module @issue1246_assume(%clock: i1) attributes {output_file = {directory = "dir4", exclude_from_filelist = true, exclude_replicated_ops = true, name = ""}} {
+// CHECK: sv.assume
 // CHECK-LABEL: hw.module @issue1246_assert(%clock: i1) attributes {output_file = {directory = "dir3", exclude_from_filelist = true, exclude_replicated_ops = true, name = ""}}
 // CHECK: sv.assert
-// CHECK: sv.assume
 // CHECK: hw.module @issue1246
 // CHECK: sv.bind @__ETC_issue1246_assert {output_file = {directory = "", exclude_from_filelist = true, exclude_replicated_ops = true, name = "./dir3/filename3"}}
   hw.module @issue1246(%clock: i1) -> () {


### PR DESCRIPTION
This PR extracts the `assume` and `assert` statements to different modules, this is to mimic the SFC behavior. 