### PR TITLE
[PyCDE] Refactor `Value` class

### DIFF
--- a/frontends/PyCDE/src/pycde/__init__.py
+++ b/frontends/PyCDE/src/pycde/__init__.py
@@ -5,6 +5,7 @@
 from .module import *
 from .system import *
 from .pycde_types import *
+from .value import *
 from .support import obj_to_value
 from circt.support import connect
 

--- a/frontends/PyCDE/src/pycde/module.py
+++ b/frontends/PyCDE/src/pycde/module.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 from pycde.support import obj_to_value
 
 from .pycde_types import types
-from .support import (Value, get_user_loc, var_to_attribute, OpOperandConnect,
+from .support import (get_user_loc, var_to_attribute, OpOperandConnect,
                       create_type_string)
+from .value import Value
 
 from circt import support
 from circt.dialects import hw
@@ -315,8 +316,8 @@ def _module_base(cls, extern: bool, params={}):
   for (idx, (name, type)) in enumerate(mod._output_ports):
     setattr(
         mod, name,
-        property(
-            lambda self, idx=idx, type=type: Value(self.results[idx], type)))
+        property(lambda self, idx=idx, type=type: Value.get(
+            self.results[idx], type)))
     cls._dont_touch.add(name)
   mod._output_ports_lookup = dict(mod._output_ports)
 
@@ -505,5 +506,5 @@ class ModuleDefinition(hw.HWModuleOp):
         ty = self.modcls._input_ports_lookup[name]
       else:
         ty = support.type_to_pytype(val.type)
-      return Value(val, ty)
+      return Value.get(val, ty)
     raise AttributeError(f"unknown input port name {name}")

--- a/frontends/PyCDE/src/pycde/pycde_types.py
+++ b/frontends/PyCDE/src/pycde/pycde_types.py
@@ -104,7 +104,7 @@ def PyCDEType(type):
     """Add methods to an MLIR type class."""
 
     @property
-    def inner(self):
+    def strip(self):
       """Return self or inner type."""
       if isinstance(type, hw.TypeAliasType):
         return PyCDEType(self.inner_type)

--- a/frontends/PyCDE/src/pycde/pycde_types.py
+++ b/frontends/PyCDE/src/pycde/pycde_types.py
@@ -103,18 +103,12 @@ def PyCDEType(type):
   class _PyCDEType(type.__class__):
     """Add methods to an MLIR type class."""
 
-    # If we're subclassing a type alias, use a different 'inner' implementation.
-    if isinstance(type, hw.TypeAliasType):
-
-      @property
-      def inner(self):
-        """Return self or inner type."""
+    @property
+    def inner(self):
+      """Return self or inner type."""
+      if isinstance(type, hw.TypeAliasType):
         return PyCDEType(self.inner_type)
-    else:
-
-      @property
-      def inner(self):
-        """Return self or inner type."""
+      else:
         return self
 
     def create(self, obj):

--- a/frontends/PyCDE/src/pycde/support.py
+++ b/frontends/PyCDE/src/pycde/support.py
@@ -55,6 +55,9 @@ class Value:
   def reg(self, clk, rst=None):
     return seq.reg(self.value, clk, rst)
 
+  def __len__(self):
+    return self.type.size
+
 
 # PyCDE needs a custom version of this to support python classes.
 def var_to_attribute(obj) -> ir.Attribute:
@@ -112,6 +115,7 @@ class OpOperandConnect(support.OpOperand):
 
 def obj_to_value(x, type, result_type=None):
   """Convert a python object to a CIRCT value, given the CIRCT type."""
+  assert x is not None
 
   type = support.type_to_pytype(type)
   if isinstance(type, hw.TypeAliasType):

--- a/frontends/PyCDE/src/pycde/value.py
+++ b/frontends/PyCDE/src/pycde/value.py
@@ -1,0 +1,72 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+from .support import get_user_loc
+
+import circt.support as support
+from circt.dialects import hw, seq
+
+import mlir.ir as ir
+
+
+class Value:
+  @staticmethod
+  def get(value, type=None):
+    from .pycde_types import PyCDEType
+    value = support.get_value(value)
+    if type is None:
+      type = value.type
+    type = PyCDEType(type)
+
+    if isinstance(type, hw.ArrayType):
+      return ListValue()._init(value, type)
+    if isinstance(type, hw.StructType):
+      return StructValue()._init(value, type)
+    return Value()._init(value, type)
+
+  def _init(self, value, type):
+    self.value = value
+    self.type = type
+    return self
+
+  def reg(self, clk, rst=None):
+    return seq.reg(self.value, clk, rst)
+
+
+class ListValue(Value):
+  def __getitem__(self, sub):
+    if isinstance(sub, int):
+      idx = int(sub)
+      if idx >= self.type.size:
+        raise ValueError("Subscript out-of-bounds")
+    else:
+      idx = support.get_value(sub)
+      if idx is None or not isinstance(support.type_to_pytype(idx.type),
+                                       ir.IntegerType):
+        raise TypeError("Subscript on array must be either int or MLIR int"
+                        f" Value, not {type(sub)}.")
+    with get_user_loc():
+      return Value.get(hw.ArrayGetOp.create(self.value, idx))
+
+  def __len__(self):
+    return self.type.strip.size
+
+
+class StructValue(Value):
+  def __getitem__(self, sub):
+    fields = self.type.strip.get_fields()
+    if sub not in [name for name, _ in fields]:
+      raise ValueError(f"Struct field '{sub}' not found in {self.type}")
+    with get_user_loc():
+      return Value.get(hw.StructExtractOp.create(self.value, sub))
+
+  def __getattr__(self, attr):
+    ty = self.type.strip
+    fields = ty.get_fields()
+    if attr in [name for name, _ in fields]:
+      with get_user_loc():
+        return Value.get(hw.StructExtractOp.create(self.value, attr))
+    raise AttributeError(f"'Value' object has no attribute '{attr}'")

--- a/frontends/PyCDE/test/syntactic_sugar.py
+++ b/frontends/PyCDE/test/syntactic_sugar.py
@@ -49,6 +49,7 @@ class ComplexPorts:
 
   @generator
   def build(mod):
+    assert len(mod.data_in) == 3
     return {
       'a': mod.data_in[0].reg(mod.clk),
       'b': mod.data_in[mod.sel],


### PR DESCRIPTION
- Create new module `value`.
- Create `ListValue` and `StructValue` subclasses and move relevant functionality there.
- Add static `get` method to base `Value` class to construct the correct class.
- (Unrelated) Rename `inner` to `strip` and make it more readable