### PR TITLE
[MSFT] Instance specific placement

### DIFF
--- a/include/circt/Dialect/MSFT/MSFT.td
+++ b/include/circt/Dialect/MSFT/MSFT.td
@@ -57,6 +57,13 @@ class MSFT_Attr<string name, list<Trait> traits = [],
   let mnemonic = ?;
 }
 
+def SwitchInstance : MSFT_Attr<"SwitchInstance"> {
+  let summary = "Select an attribute to be use based on the instance";
+  let mnemonic = "switch.inst";
+  let parameters = (ins
+    ArrayRefParameter<"InstIDAttrPair">:$instPairs);
+}
+
 def PhysLocation : MSFT_Attr<"PhysLocation"> {
   let summary = "Descibes a physical location on a device";
   let description = [{

--- a/include/circt/Dialect/MSFT/MSFT.td
+++ b/include/circt/Dialect/MSFT/MSFT.td
@@ -62,6 +62,10 @@ def SwitchInstance : MSFT_Attr<"SwitchInstance"> {
   let mnemonic = "switch.inst";
   let parameters = (ins
     ArrayRefParameter<"InstIDAttrPair">:$instPairs);
+
+  let extraClassDeclaration = [{
+    Attribute lookup(InstanceIDAttr);
+  }];
 }
 
 def PhysLocation : MSFT_Attr<"PhysLocation"> {

--- a/include/circt/Dialect/MSFT/MSFTAttributes.h
+++ b/include/circt/Dialect/MSFT/MSFTAttributes.h
@@ -18,6 +18,13 @@
 
 #include "mlir/IR/BuiltinAttributes.h"
 
+namespace circt {
+namespace msft {
+using InstanceIDAttr = mlir::SymbolRefAttr;
+using InstIDAttrPair = std::pair<InstanceIDAttr, Attribute>;
+} // namespace msft
+} // namespace circt
+
 #define GET_ATTRDEF_CLASSES
 #include "circt/Dialect/MSFT/MSFTAttributes.h.inc"
 

--- a/lib/Dialect/MSFT/MSFTAttributes.cpp
+++ b/lib/Dialect/MSFT/MSFTAttributes.cpp
@@ -52,6 +52,14 @@ void SwitchInstanceAttr::print(DialectAsmPrinter &p) const {
   p << '>';
 }
 
+Attribute SwitchInstanceAttr::lookup(InstanceIDAttr id) {
+  // TODO: This is obviously very slow. Speed this up by using a sorted list.
+  for (auto pair : getInstPairs())
+    if (pair.first == id)
+      return pair.second;
+  return Attribute();
+}
+
 Attribute PhysLocationAttr::parse(MLIRContext *ctxt, DialectAsmParser &p,
                                   Type type) {
   llvm::SMLoc loc = p.getCurrentLocation();

--- a/test/Dialect/MSFT/location.mlir
+++ b/test/Dialect/MSFT/location.mlir
@@ -3,6 +3,7 @@
 
 hw.module.extern @Foo()
 
+// TCL-LABEL: proc top_config
 hw.module @top() {
   // CHECK: hw.instance "foo1" @Foo() {"loc:memBank1" = #msft.physloc<M20K, 4, 10, 1>}
   // TCL:   set_location_assignment M20K_X4_Y10_N1 -to $parent|foo1|memBank1
@@ -11,17 +12,26 @@ hw.module @top() {
   // CHECK: hw.instance "foo2" @Foo() {"loc:memBank2" = #msft.physloc<M20K, 5, 10, 1>}
   // TCL:   set_location_assignment M20K_X5_Y10_N1 -to $parent|foo2|memBank2
   hw.instance "foo2" @Foo() {"loc:memBank2" = #msft.physloc<M20K, 5, 10, 1> } : () -> ()
+}
 
+
+hw.module @leaf() {
   // CHECK: hw.instance "foo3" @Foo() {"loc:memBank2" = #msft.switch.inst<@fakeTop=#msft.physloc<M20K, 8, 19, 1>, @realTop::@fakeTop=#msft.physloc<M20K, 15, 9, 3>>}
   hw.instance "foo3" @Foo() {
     "loc:memBank2" = #msft.switch.inst< @fakeTop=#msft.physloc<M20K, 8, 19, 1>,
                                         @realTop::@fakeTop=#msft.physloc<M20K, 15, 9, 3> > } : () -> ()
 }
 
+// TCL-LABEL: proc realTop_config
 hw.module @realTop() {
-  hw.instance "fakeTop" @top() : () -> ()
+  hw.instance "fakeTop" @leaf() : () -> ()
+  // TCL: set_location_assignment M20K_X8_Y19_N1 -to $parent|fakeTop|foo3|memBank2
 }
 
+// TCL-LABEL: proc forRealsiesTop_config
 hw.module @forRealsiesTop() {
   hw.instance "realTop" @realTop() : () -> ()
+  hw.instance "fakeTop" @leaf() : () -> ()
+  // TCL: set_location_assignment M20K_X15_Y9_N3 -to $parent|realTop|fakeTop|foo3|memBank2
+  // TCL: set_location_assignment M20K_X8_Y19_N1 -to $parent|fakeTop|foo3|memBank2
 }

--- a/test/Dialect/MSFT/location.mlir
+++ b/test/Dialect/MSFT/location.mlir
@@ -11,4 +11,17 @@ hw.module @top() {
   // CHECK: hw.instance "foo2" @Foo() {"loc:memBank2" = #msft.physloc<M20K, 5, 10, 1>}
   // TCL:   set_location_assignment M20K_X5_Y10_N1 -to $parent|foo2|memBank2
   hw.instance "foo2" @Foo() {"loc:memBank2" = #msft.physloc<M20K, 5, 10, 1> } : () -> ()
+
+  // CHECK: hw.instance "foo3" @Foo() {"loc:memBank2" = #msft.switch.inst<@fakeTop=#msft.physloc<M20K, 8, 19, 1>, @realTop::@fakeTop=#msft.physloc<M20K, 15, 9, 3>>}
+  hw.instance "foo3" @Foo() {
+    "loc:memBank2" = #msft.switch.inst< @fakeTop=#msft.physloc<M20K, 8, 19, 1>,
+                                        @realTop::@fakeTop=#msft.physloc<M20K, 15, 9, 3> > } : () -> ()
+}
+
+hw.module @realTop() {
+  hw.instance "fakeTop" @top() : () -> ()
+}
+
+hw.module @forRealsiesTop() {
+  hw.instance "realTop" @realTop() : () -> ()
 }

--- a/test/Dialect/MSFT/translate-errors.mlir
+++ b/test/Dialect/MSFT/translate-errors.mlir
@@ -25,17 +25,3 @@ hw.module @top() {
   // expected-warning @+1 {{Attribute has already been emitted: 'loc:memBank1'}}
   hw.instance "foo2" @Foo() {"loc:memBank1" = #msft.physloc<DSP, 1, 0, 0> } : () -> ()
 }
-
-// -----
-
-hw.module.extern @Foo()
-
-hw.module @bar() {
-  // expected-warning @+1 {{The placement information for this module has already been emitted. Modules are required to only be instantiated once.}}
-  hw.instance "foo1" @Foo() {"loc:memBank" = #msft.physloc<DSP, 0, 0, 0> } : () -> ()
-}
-
-hw.module @top() {
-  hw.instance "bar1" @bar() : () -> ()
-  hw.instance "bar2" @bar() : () -> ()
-}


### PR DESCRIPTION
Placement data can now be filtered to a particular instance. Adds the `SwitchInstance` attribute to select an attribute from a list keyed off the instance ID (currently just the path in the instance hierarchy). This method is not robust to hierarchy changes, but it's a start.

Modified `ExportTcl` to respect the `SwitchInstance` attribute.