### PR TITLE
[Comb] Canonicalize away shifts by a constant

### DIFF
--- a/include/circt/Dialect/Comb/Combinational.td
+++ b/include/circt/Dialect/Comb/Combinational.td
@@ -67,12 +67,12 @@ let hasFolder = true in {
   def DivSOp : UTBinOp<"divs">;
   def ModUOp : UTBinOp<"modu">;
   def ModSOp : UTBinOp<"mods">;
-  def ShlOp : UTBinOp<"shl">;
-  def ShrUOp : UTBinOp<"shru">;
-  def ShrSOp : UTBinOp<"shrs">;
-
-  let hasCanonicalizeMethod = true in
-  def SubOp : UTBinOp<"sub">;
+  let hasCanonicalizeMethod = true in {
+    def ShlOp : UTBinOp<"shl">;
+    def ShrUOp : UTBinOp<"shru">;
+    def ShrSOp : UTBinOp<"shrs">;
+    def SubOp : UTBinOp<"sub">;
+  }
 }
 
 def AndOp : UTVariadicOp<"and", [Commutative]>;

--- a/include/circt/Dialect/Comb/Combinational.td
+++ b/include/circt/Dialect/Comb/Combinational.td
@@ -200,6 +200,13 @@ def ExtractOp : CombOp<"extract", [NoSideEffect]> {
   let hasFolder = true;
   let verifier = "return ::verifyExtractOp(*this);";
   let hasCanonicalizeMethod = true;
+
+  let builders = [
+    OpBuilder<(ins "Value":$lhs, "int32_t":$lowBit, "int32_t":$bitWidth), [{
+      auto resultType = $_builder.getIntegerType(bitWidth);
+      return build($_builder, $_state, resultType, lhs, lowBit);
+    }]>
+  ];
 }
 
 def SExtOp : CombOp<"sext", [NoSideEffect]> {

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -266,8 +266,7 @@ LogicalResult ShlOp::canonicalize(ShlOp op, PatternRewriter &rewriter) {
   auto extract =
       rewriter.create<ExtractOp>(op.getLoc(), extractType, op.lhs(), shift);
 
-  Value operand[] = {extract, zeros};
-  rewriter.replaceOpWithNewOp<ConcatOp>(op, operand);
+  rewriter.replaceOpWithNewOp<ConcatOp>(op, ArrayRef<Value>{extract, zeros});
   return success();
 }
 
@@ -288,22 +287,21 @@ LogicalResult ShrUOp::canonicalize(ShrUOp op, PatternRewriter &rewriter) {
   if (!matchPattern(op.rhs(), m_RConstant(value)))
     return failure();
 
-  unsigned srcWidth = op.lhs().getType().cast<IntegerType>().getWidth();
+  unsigned width = op.lhs().getType().cast<IntegerType>().getWidth();
   unsigned shift = value.getZExtValue();
 
   // This case is handled by fold.
-  if (srcWidth <= shift)
+  if (width <= shift)
     return failure();
 
   auto zeros =
       rewriter.create<hw::ConstantOp>(op.getLoc(), APInt::getNullValue(shift));
 
-  auto extractType = rewriter.getIntegerType(srcWidth - shift);
+  auto extractType = rewriter.getIntegerType(width - shift);
   auto extract =
       rewriter.create<ExtractOp>(op.getLoc(), extractType, op.lhs(), 0);
 
-  Value operand[] = {zeros, extract};
-  rewriter.replaceOpWithNewOp<ConcatOp>(op, operand);
+  rewriter.replaceOpWithNewOp<ConcatOp>(op, ArrayRef<Value>{zeros, extract});
   return success();
 }
 
@@ -335,8 +333,7 @@ LogicalResult ShrSOp::canonicalize(ShrSOp op, PatternRewriter &rewriter) {
   auto extract =
       rewriter.create<ExtractOp>(op.getLoc(), extractType, op.lhs(), 0);
 
-  Value operand[] = {sext, extract};
-  rewriter.replaceOpWithNewOp<ConcatOp>(op, operand);
+  rewriter.replaceOpWithNewOp<ConcatOp>(op, ArrayRef<Value>{sext, extract});
   return success();
 }
 

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -317,8 +317,7 @@ LogicalResult ShrSOp::canonicalize(ShrSOp op, PatternRewriter &rewriter) {
   unsigned width = op.lhs().getType().cast<IntegerType>().getWidth();
   unsigned shift = value.getZExtValue();
 
-  auto topbit = rewriter.create<ExtractOp>(
-      op.getLoc(),  op.lhs(), 0, 1);
+  auto topbit = rewriter.create<ExtractOp>(op.getLoc(), op.lhs(), 0, 1);
   auto sext = rewriter.create<SExtOp>(op.getLoc(),
                                       rewriter.getIntegerType(shift), topbit);
 


### PR DESCRIPTION
This PR adds following canonicalization. 

```
ShlOp(x, cst) -> Concat(Extract(x), zeros)
ShrUOp(x, cst) -> Concat(zeros, Extract(x))
ShrSOp(x, cst) -> Concat(sext(extract(x, topbit)),extract(x))
```
If shift amounts are larger than the width, they will be converted into `zeros` or `sext(topbit)`.

Will close #1261