### PR TITLE
[Scheduling] Add problem model for shared, pipelined operators.

### DIFF
--- a/include/circt/Scheduling/Problems.h
+++ b/include/circt/Scheduling/Problems.h
@@ -259,6 +259,34 @@ protected:
   virtual LogicalResult verifyProblem() override;
 };
 
+/// This class models a resource-constrained scheduling problem. An optional,
+/// non-zero *limit* marks operator types to be *shared* by the operations using
+/// them. In an HLS setting, this corresponds to multiplexing multiple
+/// operations onto a pre-allocated number of operator instances. These
+/// instances are assumed to be *fully pipelined*, meaning each instance can
+/// accept new operands (coming from a distinct operation) in each time step.
+///
+/// A solution to this problem is feasible iff the number of operations that use
+/// a certain limited operator type, and start in the same time step, does not
+/// exceed the operator type's limit. These constraints do not apply to operator
+/// types without a limit (not set, or 0).
+class SharedPipelinedOperatorsProblem : public virtual Problem {
+private:
+  OperatorTypeProperty<unsigned> limit;
+
+public:
+  using Problem::Problem;
+
+  /// The limit is the maximum number of operations using \p opr that are
+  /// allowed to start in the same time step.
+  Optional<unsigned> getLimit(OperatorType opr) { return limit.lookup(opr); }
+  void setLimit(OperatorType opr, unsigned val) { limit[opr] = val; }
+
+protected:
+  virtual LogicalResult checkOperatorType(OperatorType opr) override;
+  virtual LogicalResult verifyOperatorType(OperatorType opr) override;
+};
+
 } // namespace scheduling
 } // namespace circt
 

--- a/test/Scheduling/spo-problem-errors.mlir
+++ b/test/Scheduling/spo-problem-errors.mlir
@@ -1,0 +1,23 @@
+// RUN: circt-opt %s -test-spo-problem -verify-diagnostics -split-input-file
+
+// expected-error@+2 {{Limited operator type '_0' has zero latency}}
+// expected-error@+1 {{problem check failed}}
+func @limited_but_zero_latency() attributes {
+  operatortypes = [ { name = "_0", latency = 0, limit = 1} ]
+  } {
+  return { opr = "_0" }
+}
+
+// -----
+
+// expected-error@+2 {{Operator type 'limited' is oversubscribed}}
+// expected-error@+1 {{problem verification failed}}
+func @oversubscribed(%a0 : i32, %a1 : i32, %a2 : i32) -> i32 attributes {
+  operatortypes = [ { name = "limited", latency = 1, limit = 2} ]
+  } {
+  %0 = addi %a0, %a0 { problemStartTime = 0 } : i32
+  %1 = addi %a1, %0 { opr = "limited", problemStartTime = 1 } : i32
+  %2 = addi %0, %a2 { opr = "limited", problemStartTime = 1 } : i32
+  %3 = addi %0, %0 { opr = "limited", problemStartTime = 1 } : i32
+  return { problemStartTime = 2 } %3 : i32
+}

--- a/test/Scheduling/spo-problems.mlir
+++ b/test/Scheduling/spo-problems.mlir
@@ -1,0 +1,38 @@
+// RUN: circt-opt %s -test-spo-problem
+
+func @full_load(%a0 : i32, %a1 : i32, %a2 : i32, %a3 : i32, %a4 : i32, %a5 : i32) -> i32 attributes {
+  operatortypes = [
+    { name = "add", latency = 3, limit = 1}
+  ] } {
+  %0 = addi %a0, %a1 { opr = "add", problemStartTime = 0 } : i32
+  %1 = addi %a1, %a1 { opr = "add", problemStartTime = 1 } : i32
+  %2 = addi %a2, %a3 { opr = "add", problemStartTime = 2 } : i32
+  %3 = addi %a3, %a4 { opr = "add", problemStartTime = 3 } : i32
+  %4 = addi %a4, %a5 { opr = "add", problemStartTime = 4 } : i32
+  return { problemStartTime = 7 } %4 : i32
+}
+
+func @partial_load(%a0 : i32, %a1 : i32, %a2 : i32, %a3 : i32, %a4 : i32, %a5 : i32) -> i32 attributes {
+  operatortypes = [
+    { name = "add", latency = 3, limit = 3}
+  ] } {
+  %0 = addi %a0, %a1 { opr = "add", problemStartTime = 0 } : i32
+  %1 = addi %a1, %a1 { opr = "add", problemStartTime = 1 } : i32
+  %2 = addi %a2, %a3 { opr = "add", problemStartTime = 0 } : i32
+  %3 = addi %a3, %a4 { opr = "add", problemStartTime = 2 } : i32
+  %4 = addi %a4, %a5 { opr = "add", problemStartTime = 1 } : i32
+  return { problemStartTime = 10 } %4 : i32
+}
+
+func @multiple(%a0 : i32, %a1 : i32, %a2 : i32, %a3 : i32, %a4 : i32, %a5 : i32) -> i32 attributes {
+  operatortypes = [
+    { name = "slowAdd", latency = 3, limit = 2},
+    { name = "fastAdd", latency = 1, limit = 1}
+  ] } {
+  %0 = addi %a0, %a1 { opr = "slowAdd", problemStartTime = 0 } : i32
+  %1 = addi %a1, %a1 { opr = "slowAdd", problemStartTime = 1 } : i32
+  %2 = addi %a2, %a3 { opr = "fastAdd", problemStartTime = 0 } : i32
+  %3 = addi %a3, %a4 { opr = "slowAdd", problemStartTime = 1 } : i32
+  %4 = addi %a4, %a5 { opr = "fastAdd", problemStartTime = 1 } : i32
+  return { problemStartTime = 10 } %4 : i32
+}


### PR DESCRIPTION
Extends the basic problem model with a new operator type property `limit`, representing the maximum number of operations that can "use" a given operator type in each time step.