### PR TITLE
[Calyx] Sort component ports in ComponentOp::build

### DIFF
--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -313,10 +313,18 @@ void ComponentOp::build(OpBuilder &builder, OperationState &result,
 
   result.addAttribute(::mlir::SymbolTable::getSymbolAttrName(), name);
 
+  // Order ports [inputs, outputs]
+  SmallVector<ComponentPortInfo> sortedPorts;
+  llvm::transform(ports, std::back_inserter(sortedPorts),
+                  [](const auto &p) { return p; });
+  llvm::sort(sortedPorts, [](const auto &lhs, const auto & /*rhs*/) {
+    return lhs.direction == PortDirection::INPUT;
+  });
+
   SmallVector<Type, 8> portTypes;
   SmallVector<Attribute, 8> portNames;
   uint64_t numInPorts = 0;
-  for (auto &&port : ports) {
+  for (auto &&port : sortedPorts) {
     if (port.direction == PortDirection::INPUT)
       ++numInPorts;
     portNames.push_back(port.name);


### PR DESCRIPTION
If the ArrayRef<ComponentPortInfo> ports argument contains an unordered list of ports, the first `numInPorts` ports are registered as the input ports, and the remainder as outputs.
I.e. the following list of ports:

```c++
SmallVector<calyx::ComponentPortInfo> ports;
ports.push_back({rewriter.getStringAttr("clk"), rewriter.getI1Type(), calyx::PortDirection::INPUT});
ports.push_back({rewriter.getStringAttr("reset"), rewriter.getI1Type(), calyx::PortDirection::INPUT});
ports.push_back({rewriter.getStringAttr("done"), rewriter.getI1Type(), calyx::PortDirection::OUTPUT}); // <--
ports.push_back({rewriter.getStringAttr("go"), rewriter.getI1Type(), calyx::PortDirection::INPUT});
```

will (incorrectly) create a component with the following signature:
```mlir
calyx.component @main(%clk: i1, %reset: i1, %done: i1) -> (%go: i1) {
   ...
}
```

---

**Note:** I used `llvm::transform` here instead of `llvm::copy`. For some reason, if `llvm::copy`/`std::copy` is used with *_any_* container inside `CalyxOps.cpp`:, a compilation error is raised. i.e. compiling the following inside `CalyxOps.cpp`:
```c++
  std::vector<int> a, b;
  llvm::copy(a, b);
```
raises:
```
/usr/include/c++/9/bits/stl_algobase.h:396: error: no type named ‘value_type’ in ‘struct std::iterator_traits<std::vector<int> >’
In file included from /usr/include/c++/9/memory:62,
                 from ../llvm/llvm/include/llvm/Support/Casting.h:20,
                 from ../llvm/mlir/include/mlir/Support/LLVM.h:24,
                 from ../llvm/mlir/include/mlir/IR/MLIRContext.h:12,
                 from ../llvm/mlir/include/mlir/IR/AttributeSupport.h:16,
                 from ../llvm/mlir/include/mlir/IR/Attributes.h:12,
                 from ../llvm/mlir/include/mlir/IR/SubElementInterfaces.h:17,
                 from ../llvm/mlir/include/mlir/IR/BuiltinAttributes.h:12,
                 from ../include/circt/Dialect/Comb/CombDialect.h:16,
                 from ../include/circt/Dialect/Calyx/CalyxDialect.h:16,
                 from ../include/circt/Dialect/Calyx/CalyxOps.h:16,
                 from ../lib/Dialect/Calyx/CalyxOps.cpp:13:
/usr/include/c++/9/bits/stl_algobase.h: In instantiation of ‘_OI std::__copy_move_a(_II, _II, _OI) [with bool _IsMove = false; _II = int*; _OI = std::vector<int>]’:
/usr/include/c++/9/bits/stl_algobase.h:441:30:   required from ‘_OI std::__copy_move_a2(_II, _II, _OI) [with bool _IsMove = false; _II = __gnu_cxx::__normal_iterator<int*, std::vector<int> >; _OI = std::vector<int>]’
/usr/include/c++/9/bits/stl_algobase.h:474:7:   required from ‘_OI std::copy(_II, _II, _OI) [with _II = __gnu_cxx::__normal_iterator<int*, std::vector<int> >; _OI = std::vector<int>]’
../llvm/llvm/include/llvm/ADT/STLExtras.h:1586:19:   required from ‘OutputIt llvm::copy(R&&, OutputIt) [with R = std::vector<int>&; OutputIt = std::vector<int>]’
../lib/Dialect/Calyx/CalyxOps.cpp:317:18:   required from here
/usr/include/c++/9/bits/stl_algobase.h:396:57: error: no type named ‘value_type’ in ‘struct std::iterator_traits<std::vector<int> >’
  396 |       typedef typename iterator_traits<_OI>::value_type _ValueTypeO;
      |                                                         ^~~~~~~~~~~
```