### PR TITLE
[PyCDE] Introduce the notion of 'appid'

### DIFF
--- a/frontends/PyCDE/src/pycde/module.py
+++ b/frontends/PyCDE/src/pycde/module.py
@@ -184,6 +184,9 @@ def _module_base(cls, extern: bool, params={}):
     _output_ports: list[(str, mlir.ir.Type)] = []
     _parameters: dict[str, mlir.ir.PyAttribute] = {}
 
+    # This property is technically redundant with __setattr__ below. I'm adding
+    # it here since we will want to add code to make this robust to hierarchy
+    # changes (e.g. inlining) in the future.
     @property
     def appid(self):
       """Many times the instance heirarchy contains instances of no

--- a/frontends/PyCDE/src/pycde/module.py
+++ b/frontends/PyCDE/src/pycde/module.py
@@ -201,11 +201,13 @@ def _module_base(cls, extern: bool, params={}):
     @appid.setter
     def appid(self, new_appid: str):
       assert self._opview_valid
+      if any([not (c in "_[]" or c.isalnum()) for c in new_appid]):
+        raise ValueError("AppID can only contain alphanumerics and '_[]'")
       self.attributes["appid"] = mlir.ir.StringAttr.get(new_appid)
 
     # Keep module attributes up do date.
     def __setattr__(self, name, value):
-      self.__dict__[name] = value
+      super().__setattr__(name, value)
       if name.startswith("_") or not self._opview_valid:
         return
       try:

--- a/frontends/PyCDE/test/polynomial.py
+++ b/frontends/PyCDE/test/polynomial.py
@@ -65,6 +65,7 @@ class CoolPolynomialCompute:
 
   def __init__(self, coefficients):
     self.coefficients = coefficients
+    self.appid = "coolDev1"
 
 
 class Coefficients:
@@ -103,7 +104,7 @@ poly.print()
 # CHECK:    [[REG0:%.+]] = "pycde.PolynomialCompute"(%c23_i32) {instanceName = "example", opNames = ["x"], parameters = {coefficients = {coeff = [62, 42, 6]}, module_name = "PolyComputeForCoeff_62_42_6", unused_parameter = true}, resultNames = ["y"]} : (i32) -> i32
 # CHECK:    [[REG1:%.+]] = "pycde.PolynomialCompute"([[REG0]]) {instanceName = "example2", opNames = ["x"], parameters = {coefficients = {coeff = [62, 42, 6]}, module_name = "PolyComputeForCoeff_62_42_6", unused_parameter = true}, resultNames = ["y"]} : (i32) -> i32
 # CHECK:    [[REG2:%.+]] = "pycde.PolynomialCompute"([[REG0]]) {instanceName = "example2", opNames = ["x"], parameters = {coefficients = {coeff = [1, 2, 3, 4, 5]}, module_name = "PolyComputeForCoeff_1_2_3_4_5", unused_parameter = true}, resultNames = ["y"]} : (i32) -> i32
-# CHECK:    [[REG3:%.+]] = "pycde.CoolPolynomialCompute"(%c23_i32{{.*}}) {coefficients = [4, 42], opNames = ["x"], parameters = {}, resultNames = ["y"]} : (i32) -> i32
+# CHECK:    [[REG3:%.+]] = "pycde.CoolPolynomialCompute"(%c23_i32{{.*}}) {appid = "coolDev1", coefficients = [4, 42], opNames = ["x"], parameters = {}, resultNames = ["y"]} : (i32) -> i32
 # CHECK:    hw.output [[REG0]] : i32
 
 print("Generating 2...")
@@ -115,7 +116,7 @@ poly.print()
 # CHECK: %example.y = hw.instance "example" @PolyComputeForCoeff_62_42_6(%c23_i32) {parameters = {}} : (i32) -> i32
 # CHECK: %example2.y = hw.instance "example2" @PolyComputeForCoeff_62_42_6(%example.y) {parameters = {}} : (i32) -> i32
 # CHECK: %example2.y_0 = hw.instance "example2" @PolyComputeForCoeff_1_2_3_4_5(%example.y) {parameters = {}} : (i32) -> i32
-# CHECK: %pycde.CoolPolynomialCompute.y = hw.instance "pycde.CoolPolynomialCompute" @supercooldevice(%c23_i32{{.*}}) {coefficients = [4, 42], parameters = {}} : (i32) -> i32
+# CHECK: %pycde.CoolPolynomialCompute.y = hw.instance "pycde.CoolPolynomialCompute" @supercooldevice(%c23_i32{{.*}}) {appid = "coolDev1", coefficients = [4, 42], parameters = {}} : (i32) -> i32
 # CHECK-LABEL: hw.module @PolyComputeForCoeff_62_42_6(%x: i32) -> (%y: i32)
 # CHECK: hw.constant 62
 # CHECK: hw.constant 42


### PR DESCRIPTION
Many times the instance heirarchy contains instances of no consequences,
architecturally or application wise. PyCDE adds a notion of `appid`s to name
modules which are relevant to the application. They will allow designers to
locate specific modules by application names via the `appid` hierarchy.

This PR adds the ability to set the appid. It also changes the order in which the constructors are called to enable calling 'appid' from the constructor.