### PR TITLE
[Calyx] Use explicit in- and output port lists in ComponentOp::build

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxOps.h
+++ b/include/circt/Dialect/Calyx/CalyxOps.h
@@ -57,7 +57,7 @@ IntegerAttr packAttribute(ArrayRef<Direction> a, MLIRContext *b);
 /// worked with.
 SmallVector<Direction> unpackAttribute(Operation *component);
 
-/// Convenience function for generating an vector of directions
+/// Convenience function for generating a vector of directions.
 SmallVector<Direction> genInOutDirections(size_t nIns, size_t nOuts);
 } // namespace direction
 

--- a/include/circt/Dialect/Calyx/CalyxOps.h
+++ b/include/circt/Dialect/Calyx/CalyxOps.h
@@ -37,14 +37,35 @@ public:
   }
 };
 
-/// The direction of a Calyx port.
-enum PortDirection { INPUT = 0, OUTPUT = 1 };
+/// The port direction attribute follows the implementation style of FIRRTL
+/// module port direction attributes.
+enum Direction { Input = 0, Output };
+namespace direction {
+
+/// The key in a components's attribute dictionary used to find the direction.
+constexpr const char *attrKey = "portDirections";
+
+/// Return an output direction if \p isOutput is true, otherwise return an
+/// input direction.
+Direction get(bool isOutput);
+
+/// Return a \p IntegerAttr containing the packed representation of an array
+/// of directions.
+IntegerAttr packAttribute(ArrayRef<Direction> a, MLIRContext *b);
+
+/// Turn a packed representation of port attributes into a vector that can be
+/// worked with.
+SmallVector<Direction> unpackAttribute(Operation *component);
+
+/// Convenience function for generating an vector of directions
+SmallVector<Direction> genInOutDirections(size_t nIns, size_t nOuts);
+} // namespace direction
 
 /// This holds the name and type that describes the component's ports.
 struct ComponentPortInfo {
   StringAttr name;
   Type type;
-  PortDirection direction;
+  Direction direction;
 };
 
 /// Returns port information about a given component.

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -80,16 +80,13 @@ def ComponentOp : CalyxOp<"component", [
 
   // TODO(Calyx): Allow explicit port naming?
   let arguments = (ins
-    ArrayAttr:$portNames,
-    I64Attr:$numInPorts
+    ArrayAttr:$portNames
   );
   let results = (outs);
   let regions = (region SizedRegion<1>: $body);
 
   let builders = [
-    OpBuilder<(ins "StringAttr":$name,
-      "ArrayRef<ComponentPortInfo>":$inputs,
-      "ArrayRef<ComponentPortInfo>":$outputs)>
+    OpBuilder<(ins "StringAttr":$name, "ArrayRef<ComponentPortInfo>":$ports)>
   ];
 
   let extraClassDeclaration = [{

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -87,7 +87,9 @@ def ComponentOp : CalyxOp<"component", [
   let regions = (region SizedRegion<1>: $body);
 
   let builders = [
-    OpBuilder<(ins "StringAttr":$name, "ArrayRef<ComponentPortInfo>":$ports)>
+    OpBuilder<(ins "StringAttr":$name,
+      "ArrayRef<ComponentPortInfo>":$inputs,
+      "ArrayRef<ComponentPortInfo>":$outputs)>
   ];
 
   let extraClassDeclaration = [{

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -356,8 +356,8 @@ static LogicalResult verifyComponentOp(ComponentOp op) {
 
 /// Returns a new vector containing the concatenation of vectors @p a and @p b.
 template <typename T>
-SmallVector<T> concat(const SmallVectorImpl<T> &a,
-                      const SmallVectorImpl<T> &b) {
+static SmallVector<T> concat(const SmallVectorImpl<T> &a,
+                             const SmallVectorImpl<T> &b) {
   SmallVector<T> out;
   out.append(a);
   out.append(b);

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -63,8 +63,9 @@ SmallVector<Direction> direction::unpackAttribute(Operation *component) {
       component->getAttr(direction::attrKey).cast<IntegerAttr>().getValue();
 
   SmallVector<Direction> result;
-  result.reserve(value.getBitWidth());
-  for (size_t i = 0, e = value.getBitWidth(); i != e; ++i)
+  auto bitWidth = value.getBitWidth();
+  result.reserve(bitWidth);
+  for (size_t i = 0, e = bitWidth; i != e; ++i)
     result.push_back(direction::get(value[i]));
   return result;
 }

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -46,15 +46,7 @@ SmallVector<Direction> direction::genInOutDirections(size_t nIns,
 
 IntegerAttr direction::packAttribute(ArrayRef<Direction> directions,
                                      MLIRContext *ctx) {
-
-  // If the module contaions no ports (parameter a is empty), then use an APInt
-  // of size 1 with value 0 to store the ports.  This works around an issue
-  // where APInt cannot be zero-sized.  This aligns with port name storage which
-  // will use a zero-element array.
-  auto size = directions.size();
-  if (size == 0)
-    size = 1;
-
+  const size_t size = directions.size();
   // Pack the array of directions into an APInt.  Input is zero, output is one.
   APInt portDirections(size, 0);
   for (size_t i = 0, e = directions.size(); i != e; ++i)

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -308,19 +308,20 @@ static LogicalResult verifyComponentOp(ComponentOp op) {
 }
 
 void ComponentOp::build(OpBuilder &builder, OperationState &result,
-                        StringAttr name, ArrayRef<ComponentPortInfo> ports) {
+                        StringAttr name, ArrayRef<ComponentPortInfo> inputs,
+                        ArrayRef<ComponentPortInfo> outputs) {
   using namespace mlir::function_like_impl;
 
   result.addAttribute(::mlir::SymbolTable::getSymbolAttrName(), name);
 
   SmallVector<Type, 8> portTypes;
   SmallVector<Attribute, 8> portNames;
-  uint64_t numInPorts = 0;
-  for (auto &&port : ports) {
-    if (port.direction == PortDirection::INPUT)
-      ++numInPorts;
-    portNames.push_back(port.name);
-    portTypes.push_back(port.type);
+  uint64_t numInPorts = inputs.size();
+  for (auto &&ports : {inputs, outputs}) {
+    for (auto &&port : ports) {
+      portNames.push_back(port.name);
+      portTypes.push_back(port.type);
+    }
   }
 
   // Build the function type of the component.

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -182,7 +182,7 @@ void Emitter::emitComponent(ComponentOp op) {
 void Emitter::emitComponentPorts(ArrayRef<ComponentPortInfo> ports) {
   std::vector<ComponentPortInfo> inPorts, outPorts;
   for (auto &&port : ports) {
-    if (port.direction == PortDirection::INPUT)
+    if (port.direction == Direction::Input)
       inPorts.push_back(port);
     else
       outPorts.push_back(port);


### PR DESCRIPTION
If the ArrayRef ports argument contains an unordered list of ports, the first numInPorts ports are registered as the input ports, and the remainder as outputs.
I.e. the following list of ports:

```c++
SmallVector<calyx::ComponentPortInfo> ports;
ports.push_back({rewriter.getStringAttr("clk"), rewriter.getI1Type(), calyx::PortDirection::INPUT});
ports.push_back({rewriter.getStringAttr("reset"), rewriter.getI1Type(), calyx::PortDirection::INPUT});
ports.push_back({rewriter.getStringAttr("done"), rewriter.getI1Type(), calyx::PortDirection::OUTPUT}); // <--
ports.push_back({rewriter.getStringAttr("go"), rewriter.getI1Type(), calyx::PortDirection::INPUT});
```

will currently (incorrectly) create a component with the following signature:

```mlir
calyx.component @main(%clk: i1, %reset: i1, %done: i1) -> (%go: i1) {
   ...
}
```

The commit introduces explicit input- and output port lists.
The `Direction` of the ports within the `calyx::ComponentPortInfo` structs passed to ComponentOp::build are ignored; this aligns with the remainder of the logic surrounding port direction inference in `CalyxOps.cpp`, wherein the first `nInputPorts` are regarded as inputs, and the remainder as outputs _regardlessly_ of what `Direction` was set for the port when building the component.