### PR TITLE
[FIRRTL] Refactor FIRRTLFolds, NFC

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1265,8 +1265,8 @@ LogicalResult SubaccessOp::canonicalize(SubaccessOp op,
 
 /// Scan all the uses of the specified value, checking to see if there is
 /// exactly one connect that sets the value as its destination.  This returns
-/// true if the operation is found and if all the other users are "reads" from
-/// the value. Also sets the connect, if its null.
+/// the operation if found and if all the other users are "reads" from the
+/// value.
 static ConnectOp getSingleConnectUserOf(Value value) {
   ConnectOp connect;
   for (Operation *user : value.getUsers()) {

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1282,7 +1282,6 @@ static ConnectOp getSingleConnectUserOf(Value value) {
           return {};
       }
   }
-
   return connect;
 }
 

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1278,7 +1278,7 @@ static ConnectOp getSingleConnectUserOf(Value value) {
       if (aConnect.dest() == value) {
         if (!connect)
           connect = aConnect;
-        else if (aConnect != connect)
+        else
           return {};
       }
   }


### PR DESCRIPTION
Update FIRRTLFolds to use the method `getSingleConnectUserOf` 
that scans all the uses of the specified value, checking to see if there is
exactly one connect that sets the value as its destination.  This returns
the operation if found and if all the other users are "reads" from the
value.
(Followup to address comments on https://github.com/llvm/circt/pull/1546)