### PR TITLE
[Comb] Fold a large series of of mux ops into array_create/get.

### DIFF
--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -1118,12 +1118,125 @@ OpFoldResult MuxOp::fold(ArrayRef<Attribute> constants) {
   return {};
 }
 
-static mlir::Value sextToDestTypeAndFlip(mlir::Value op, Type destType,
-                                         PatternRewriter &rewriter) {
+static Value sextToDestTypeAndFlip(mlir::Value op, Type destType,
+                                   PatternRewriter &rewriter) {
   op = rewriter.createOrFold<SExtOp>(op.getLoc(), destType, op);
   Value newOperands[] = {
       op, rewriter.create<hw::ConstantOp>(op.getLoc(), destType, -1)};
   return rewriter.create<XorOp>(op.getLoc(), destType, newOperands);
+}
+
+/// Given a mux, check to see if the "on true" value (or "on false" value if
+/// isFalseSide=true) is a mux tree with the same condition.  This allows us
+/// to turn things like `mux(VAL == 0, A, (mux (VAL == 1), B, C))` into
+/// `array_get (array_create(A, B, C), VAL)` which is far more compact and
+/// allows synthesis tools to do more interesting optimizations.
+///
+/// This returns null if we cannot form the mux tree (or do not want to) and
+/// returns a newly created value if the mux can be replaced.
+static Value foldMuxChain(MuxOp rootMux, bool isFalseSide) {
+  // Get the index value being compared.  Later we check to see if it is
+  // compared to a constant with the right predicate.
+  auto rootCmp = rootMux.cond().getDefiningOp<ICmpOp>();
+  if (!rootCmp)
+    return {};
+  Value indexValue = rootCmp.lhs();
+
+  // Check to see if the condition to the specified mux is an equality
+  // comparison `indexValue` and a constant.  If so, return the constant, if not
+  // return null.
+  auto getCondConstant = [&](MuxOp mux) -> hw::ConstantOp {
+    auto topLevelCmp = mux.cond().getDefiningOp<ICmpOp>();
+
+    // TODO: We could conceivably handle things like "x < 2" as two entries
+    // if there was a reason to.  We could also handle a mix of == / !=
+    // comparisons if they occur.
+    auto requiredPredicate =
+        (isFalseSide ? ICmpPredicate::eq : ICmpPredicate::ne);
+    if (!topLevelCmp || topLevelCmp.lhs() != indexValue ||
+        topLevelCmp.predicate() != requiredPredicate)
+      return {};
+    return topLevelCmp.rhs().getDefiningOp<hw::ConstantOp>();
+  };
+
+  // Return the value to use if the equality match succeeds.
+  auto getCaseValue = [&](MuxOp mux) -> Value {
+    return mux.getOperand(1 + unsigned(!isFalseSide));
+  };
+
+  // Return the value to use if the equality match fails.  This is the next
+  // mux in the sequence or the "otherwise" value.
+  auto getTreeValue = [&](MuxOp mux) -> Value {
+    return mux.getOperand(1 + unsigned(isFalseSide));
+  };
+
+  // Make sure the root is a correct comparison with a constant.
+  auto rootCst = getCondConstant(rootMux);
+  if (!rootCst)
+    return {};
+
+  // Make sure that we're not looking at the intermediate node in a mux tree.
+  if (rootMux->hasOneUse()) {
+    if (auto userMux = dyn_cast<MuxOp>(*rootMux->user_begin())) {
+      if (getCondConstant(userMux) &&
+          getTreeValue(userMux) == rootMux.getResult())
+        return {};
+    }
+  }
+
+  // Start scanning the mux tree to see what we've got.  Keep track of the
+  // constant comparison value and the SSA value to use when equal to it.
+  SmallVector<std::pair<hw::ConstantOp, Value>, 4> valuesFound;
+  SmallVector<Location> locationsFound;
+  valuesFound.push_back({rootCst, getCaseValue(rootMux)});
+  locationsFound.push_back(rootMux.getLoc());
+
+  // Scan up the tree linearly.
+  auto nextTreeValue = getTreeValue(rootMux);
+  while (1) {
+    auto nextMux = nextTreeValue.getDefiningOp<MuxOp>();
+    if (!nextMux || !nextMux->hasOneUse())
+      break;
+    auto nextCst = getCondConstant(nextMux);
+    if (!nextCst)
+      break;
+    valuesFound.push_back({nextCst, getCaseValue(nextMux)});
+    locationsFound.push_back(nextMux->getLoc());
+    nextTreeValue = getTreeValue(nextMux);
+  }
+
+  // We need to have more than three values to create an array.  This is an
+  // arbitrary threshold which is saying that one or two muxes together is ok,
+  // but three should be folded.
+  if (valuesFound.size() < 3)
+    return {};
+
+  // Next we need to see if the values are dense-ish.  We don't want to have
+  // a tremendous number of replicated entries in the array.  Some sparsity is
+  // ok though, so we require the table to be at least 5/8 utilized.
+  uint64_t tableSize = 1ULL
+                       << indexValue.getType().cast<IntegerType>().getWidth();
+  if (valuesFound.size() < (tableSize * 5) / 8)
+    return {}; // Not dense enough.
+
+  // Ok, we're going to do the transformation, start by building the table
+  // filled with the "otherwise" value.
+  SmallVector<Value, 8> table(tableSize, nextTreeValue);
+
+  // Fill in entries in the table from the leaf to the root of the expression.
+  // This ensures that any duplicate matches end up with the ultimate value,
+  // which is the one closer to the root.
+  for (auto &elt : llvm::reverse(valuesFound)) {
+    uint64_t idx = elt.first.getValue().getZExtValue();
+    assert(idx < table.size() && "constant should be same bitwidth as index");
+    table[idx] = elt.second;
+  }
+
+  // Build the array_create and the array_get.
+  OpBuilder builder(rootMux);
+  auto fusedLoc = builder.getFusedLoc(locationsFound);
+  auto array = builder.create<hw::ArrayCreateOp>(fusedLoc, table);
+  return builder.create<hw::ArrayGetOp>(fusedLoc, array, indexValue);
 }
 
 LogicalResult MuxOp::canonicalize(MuxOp op, PatternRewriter &rewriter) {
@@ -1178,23 +1291,35 @@ LogicalResult MuxOp::canonicalize(MuxOp op, PatternRewriter &rewriter) {
     }
   }
 
-  // mux(selector, x, mux(selector, y, z) = mux(selector, x, z)
-  if (auto falseCase =
+  if (auto falseMux =
           dyn_cast_or_null<MuxOp>(op.falseValue().getDefiningOp())) {
-    if (op.cond() == falseCase.cond()) {
+    // mux(selector, x, mux(selector, y, z) = mux(selector, x, z)
+    if (op.cond() == falseMux.cond()) {
       Value newT = op.trueValue();
-      Value newF = falseCase.falseValue();
+      Value newF = falseMux.falseValue();
       rewriter.replaceOpWithNewOp<MuxOp>(op, op.cond(), newT, newF);
+      return success();
+    }
+
+    // Check to see if we can fold a mux tree into an array_create/get pair.
+    if (Value result = foldMuxChain(op, /*isFalse*/ true)) {
+      rewriter.replaceOp(op, result);
       return success();
     }
   }
 
-  // mux(selector, mux(selector, a, b), c) = mux(selector, a, c)
-  if (auto trueCase = dyn_cast_or_null<MuxOp>(op.trueValue().getDefiningOp())) {
-    if (op.cond() == trueCase.cond()) {
-      Value newT = trueCase.trueValue();
+  if (auto trueMux = dyn_cast_or_null<MuxOp>(op.trueValue().getDefiningOp())) {
+    // mux(selector, mux(selector, a, b), c) = mux(selector, a, c)
+    if (op.cond() == trueMux.cond()) {
+      Value newT = trueMux.trueValue();
       Value newF = op.falseValue();
       rewriter.replaceOpWithNewOp<MuxOp>(op, op.cond(), newT, newF);
+      return success();
+    }
+
+    // Check to see if we can fold a mux tree into an array_create/get pair.
+    if (Value result = foldMuxChain(op, /*isFalseSide*/ false)) {
+      rewriter.replaceOp(op, result);
       return success();
     }
   }
@@ -1256,7 +1381,6 @@ static bool applyCmpPredicateToEqualOperands(ICmpPredicate predicate) {
 }
 
 OpFoldResult ICmpOp::fold(ArrayRef<Attribute> constants) {
-
   // gt a, a -> false
   // gte a, a -> true
   if (lhs() == rhs()) {
@@ -1294,8 +1418,8 @@ static size_t computeCommonPrefixLength(const Range &a, const Range &b) {
 static size_t getTotalWidth(const OperandRange &range) {
   size_t totalWidth = 0;
   for (auto operand : range) {
-    // getIntOrFloatBitWidth should never raise, since all arguments to ConcatOp
-    // are integers.
+    // getIntOrFloatBitWidth should never raise, since all arguments to
+    // ConcatOp are integers.
     ssize_t width = operand.getType().getIntOrFloatBitWidth();
     assert(width >= 0);
     totalWidth += width;

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -1201,6 +1201,7 @@ static Value foldMuxChain(MuxOp rootMux, bool isFalseSide) {
     if (!nextCst)
       break;
     valuesFound.push_back({nextCst, getCaseValue(nextMux)});
+    locationsFound.push_back(nextMux.cond().getLoc());
     locationsFound.push_back(nextMux->getLoc());
     nextTreeValue = getTreeValue(nextMux);
   }

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -487,3 +487,106 @@ hw.module @narrowBitwiseOpsInsertionPointRegression(%a: i8) -> (%out: i1) {
   %6 = comb.extract %5 from 0 : (i2) -> i1
   hw.output %6 : i1
 }
+
+// CHECK-LABEL: hw.module @fold_mux_tree1
+hw.module @fold_mux_tree1(%sel: i2, %a: i8, %b: i8, %c: i8, %d: i8) -> (%y: i8) {
+  // CHECK-NEXT: %0 = hw.array_create %a, %b, %c, %d : i8
+  // CHECK-NEXT: %1 = hw.array_get %0[%sel]
+  // CHECK-NEXT: hw.output %1
+  %c2_i2 = hw.constant 2 : i2
+  %0 = comb.icmp eq %sel, %c2_i2 : i2
+  %1 = comb.mux %0, %c, %d : i8
+
+  %c1_i2 = hw.constant 1 : i2
+  %2 = comb.icmp eq %sel, %c1_i2 : i2
+  %3 = comb.mux %2, %b, %1 : i8
+
+  %c0_i2 = hw.constant 0 : i2
+  %4 = comb.icmp eq %sel, %c0_i2 : i2
+  %5 = comb.mux %4, %a, %3 : i8
+  hw.output %5 : i8
+}
+
+// CHECK-LABEL: hw.module @fold_mux_tree2
+// This is a sparse tree with 5/8ths load.
+hw.module @fold_mux_tree2(%sel: i3, %a: i8, %b: i8, %c: i8, %d: i8) -> (%y: i8) {
+  // CHECK-NEXT: %0 = hw.array_create %a, %b, %c, %a, %b, %d, %d, %d : i8
+  // CHECK-NEXT: %1 = hw.array_get %0[%sel]
+  // CHECK-NEXT: hw.output %1
+  %c2_i2 = hw.constant 2 : i3
+  %0 = comb.icmp eq %sel, %c2_i2 : i3
+  %1 = comb.mux %0, %c, %d : i8
+
+  %c1_i2 = hw.constant 1 : i3
+  %2 = comb.icmp eq %sel, %c1_i2 : i3
+  %3 = comb.mux %2, %b, %1 : i8
+
+  %c0_i2 = hw.constant 0 : i3
+  %4 = comb.icmp eq %sel, %c0_i2 : i3
+  %5 = comb.mux %4, %a, %3 : i8
+
+  %c3_i2 = hw.constant 3 : i3
+  %6 = comb.icmp eq %sel, %c3_i2 : i3
+  %7 = comb.mux %6, %a, %5 : i8
+
+  %c4_i2 = hw.constant 4 : i3
+  %8 = comb.icmp eq %sel, %c4_i2 : i3
+  %9 = comb.mux %8, %b, %7 : i8
+  hw.output %9 : i8
+}
+
+// CHECK-LABEL: hw.module @fold_mux_tree3
+// This has two selectors for the same index value. Make sure we get the
+// right one.  "%c" should not be used.
+hw.module @fold_mux_tree3(%sel: i2, %a: i8, %b: i8, %c: i8, %d: i8) -> (%y: i8) {
+  // CHECK-NEXT: %0 = hw.array_create %a, %b, %d, %d : i8
+  // CHECK-NEXT: %1 = hw.array_get %0[%sel]
+  // CHECK-NEXT: hw.output %1
+  %c2_i2 = hw.constant 0 : i2
+  %0 = comb.icmp eq %sel, %c2_i2 : i2
+  %1 = comb.mux %0, %c, %d : i8
+
+  %c1_i2 = hw.constant 1 : i2
+  %2 = comb.icmp eq %sel, %c1_i2 : i2
+  %3 = comb.mux %2, %b, %1 : i8
+
+  %c0_i2 = hw.constant 0 : i2
+  %4 = comb.icmp eq %sel, %c0_i2 : i2
+  %5 = comb.mux %4, %a, %3 : i8
+  hw.output %5 : i8
+}
+
+// CHECK-LABEL: hw.module @fold_mux_tree4
+// TODO: This *should* fold, but is not due to Issue #1549
+// CHECK-NOT: hw.array_create
+// CHECK: hw.output
+hw.module @fold_mux_tree4(%sel: i2, %a: i8, %b: i8, %c: i8) -> (%y: i8) {
+  %c0_i2 = hw.constant 0 : i2
+  %c1_i2 = hw.constant 1 : i2
+  %c-1_i8 = hw.constant -1 : i8
+  %c-2_i2 = hw.constant -2 : i2
+  %0 = comb.icmp eq %sel, %c-2_i2 : i2
+  %1 = comb.mux %0, %c, %c-1_i8 : i8
+  %2 = comb.icmp eq %sel, %c1_i2 : i2
+  %3 = comb.mux %2, %b, %1 : i8
+  %4 = comb.icmp eq %sel, %c0_i2 : i2
+  %5 = comb.mux %4, %a, %3 : i8
+  hw.output %5 : i8
+}
+
+// CHECK-LABEL: hw.module @dont_fold_mux_tree1
+// This shouldn't be turned into an array because it is too sparse.
+hw.module @dont_fold_mux_tree1(%sel: i7, %a: i8, %b: i8, %c: i8, %d: i8) -> (%y: i8) {
+  // CHECK-NOT: array_create
+  // CHECK: hw.output
+  %c0_i2 = hw.constant 0 : i7
+  %c1_i2 = hw.constant 1 : i7
+  %c2_i2 = hw.constant 2 : i7
+  %0 = comb.icmp eq %sel, %c2_i2 : i7
+  %1 = comb.mux %0, %c, %d : i8
+  %2 = comb.icmp eq %sel, %c1_i2 : i7
+  %3 = comb.mux %2, %b, %1 : i8
+  %4 = comb.icmp eq %sel, %c0_i2 : i7
+  %5 = comb.mux %4, %a, %3 : i8
+  hw.output %5 : i8
+}


### PR DESCRIPTION
This substantially shrinks the size of the IR and generates much
better verilog.  E.g. before:

```
  module top_mod(
    input  [1:0] sel,
    input  [7:0] a, b, c, d,
    output [7:0] y);

    assign y = sel == 2'h0 ? a : sel == 2'h1 ? b : sel == 2'h2 ? c : d;
  endmodule
```

and after:

```
  module top_mod(
    input  [1:0] sel,
    input  [7:0] a, b, c, d,
    output [7:0] y);

    assign y = ({{a}, {b}, {c}, {d}})[sel];
  endmodule
```

This uses a couple heuristics to keep things from going crazy. This
is progress towards closing Issue #675, but it is still not getting
some important cases due to Issue #1549.  Those can be handled as
follow-up patches.