### PR TITLE
[FIRRTL] Fold Mux with the same constant high and low

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1045,6 +1045,9 @@ OpFoldResult MuxPrimOp::fold(ArrayRef<Attribute> operands) {
   if (auto lowCst = operands[2].dyn_cast_or_null<IntegerAttr>()) {
     // mux(cond, c1, c2)
     if (auto highCst = operands[1].dyn_cast_or_null<IntegerAttr>()) {
+      if (highCst.getType() == lowCst.getType() &&
+          highCst.getValue() == lowCst.getValue())
+        return highCst;
       // mux(cond, 1, 0) -> cond
       if (highCst.getValue().isOneValue() && lowCst.getValue().isNullValue() &&
           getType() == sel().getType())

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -434,42 +434,9 @@ firrtl.circuit "rhs_sink_output_used_as_wire" {
 }
 
 
-firrtl.circuit "constReg" {
-// CHECK-LABEL: firrtl.module @constReg
-firrtl.module @constReg(in %clock: !firrtl.clock,
-              in %en: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
-  %r1 = firrtl.reg %clock  : !firrtl.uint<1>
-  %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-  %0 = firrtl.mux(%en, %c1_ui1, %r1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-  firrtl.connect %r1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
-  firrtl.connect %out, %r1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK:  %[[C11:.+]] = firrtl.constant 1 : !firrtl.uint<1>
-  // CHECK:  firrtl.connect %out, %[[C11]] 
-}
-}
-
-firrtl.circuit "constReg2" {
-// CHECK-LABEL: firrtl.module @constReg
-firrtl.module @constReg2(in %clock: !firrtl.clock,
-              in %en: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
-  %r1 = firrtl.reg %clock  : !firrtl.uint<1>
-  %r2 = firrtl.reg %clock  : !firrtl.uint<1>
-  %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-  %0 = firrtl.mux(%en, %c1_ui1, %r1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-  firrtl.connect %r1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
-  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-  %1 = firrtl.mux(%en, %r2, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-  firrtl.connect %r2, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-  %2 = firrtl.xor %r1, %r2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-  firrtl.connect %out, %2 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK:  %[[C12:.+]] = firrtl.constant 1 : !firrtl.uint<1>
-  // CHECK:  firrtl.connect %out, %[[C12]] 
-}
-}
-
-firrtl.circuit "constReg3" {
-// CHECK-LABEL: firrtl.module @constReg3
-firrtl.module @constReg3(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cond: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
+firrtl.circuit "constRegReset" {
+// CHECK-LABEL: firrtl.module @constRegReset
+firrtl.module @constRegReset(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cond: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
   %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
   %r = firrtl.regreset %clock, %reset, %c11_ui8  : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
   %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
@@ -480,9 +447,9 @@ firrtl.module @constReg3(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, i
 }
 }
 
-firrtl.circuit "constReg4" {
-// CHECK-LABEL: firrtl.module @constReg4
-firrtl.module @constReg4(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cond: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
+firrtl.circuit "constRegReset2" {
+// CHECK-LABEL: firrtl.module @constRegReset2
+firrtl.module @constRegReset2(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cond: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
   %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
   %c11_ui4 = firrtl.constant 11 : !firrtl.uint<8>
   %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
@@ -492,64 +459,6 @@ firrtl.module @constReg4(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, i
   // CHECK: firrtl.connect %z, %[[C14]]
   firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
 }
-}
-
-firrtl.circuit "constReg6" {
-// CHECK-LABEL: firrtl.module @constReg6
-firrtl.module @constReg6(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cond: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
-  %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
-  %c11_ui4 = firrtl.constant 11 : !firrtl.uint<8>
-  %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
-  %aa = firrtl.add %r, %c11_ui4 : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<9>
-  %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
-  firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
-  // CHECK:  %[[C15:.+]] = firrtl.constant 11
-  // CHECK: firrtl.connect %z, %[[C15]]
-  firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
-}
-}
-
-firrtl.circuit "constReg5" {
-// Cannot optimize if bit mismatch with constant reset.
-// CHECK-LABEL: firrtl.module @constReg5
-firrtl.module @constReg5(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cond: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
-  %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
-  %c11_ui4 = firrtl.constant 11 : !firrtl.uint<4>
-  %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<8>
-  %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
-  firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
-  firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
-  // CHECK:  %[[C16:.+]] = firrtl.constant 11
-  // CHECK: firrtl.connect %z, %[[C16]]
-}
-}
-
-firrtl.circuit "constReg7"   {
-// CHECK-LABEL: firrtl.module @constReg7
-  firrtl.module @constReg7(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cmd: !firrtl.uint<3>, out %z: !firrtl.uint<8>) {
-    %c7_ui8 = firrtl.constant 7 : !firrtl.uint<8>
-    %c2_ui8 = firrtl.constant 2 : !firrtl.uint<8>
-    %c2_ui3 = firrtl.constant 2 : !firrtl.uint<3>
-    %c1_ui3 = firrtl.constant 1 : !firrtl.uint<3>
-    %c7_ui4 = firrtl.constant 7 : !firrtl.uint<4>
-    %r = firrtl.regreset %clock, %reset, %c7_ui4  : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<8>
-    %0 = firrtl.orr %cmd : (!firrtl.uint<3>) -> !firrtl.uint<1>
-    %1 = firrtl.not %0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    %2 = firrtl.not %1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    %3 = firrtl.eq %cmd, %c1_ui3 : (!firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<1>
-    %4 = firrtl.and %2, %3 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    %5 = firrtl.not %3 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    %6 = firrtl.and %2, %5 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    %7 = firrtl.eq %cmd, %c2_ui3 : (!firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<1>
-    %8 = firrtl.and %6, %7 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    %9 = firrtl.mux(%8, %c7_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
-    %10 = firrtl.mux(%4, %r, %9) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
-    %11 = firrtl.mux(%1, %c7_ui8, %10) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
-    firrtl.connect %r, %11 : !firrtl.uint<8>, !firrtl.uint<8>
-    firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
-    // CHECK:  %c7_ui8 = firrtl.constant 7 : !firrtl.uint<8>
-    // CHECK:  firrtl.connect %z, %c7_ui8 : !firrtl.uint<8>, !firrtl.uint<8>
-  }
 }
 
 firrtl.circuit "regMuxTree"   {

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -451,8 +451,8 @@ firrtl.circuit "constRegReset2" {
 // CHECK-LABEL: firrtl.module @constRegReset2
 firrtl.module @constRegReset2(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cond: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
   %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
-  %c11_ui4 = firrtl.constant 11 : !firrtl.uint<8>
-  %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+  %c11_ui4 = firrtl.constant 11 : !firrtl.uint<4>
+  %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<8>
   %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
   firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
   // CHECK:  %[[C14:.+]] = firrtl.constant 11

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -432,3 +432,150 @@ firrtl.circuit "rhs_sink_output_used_as_wire" {
     firrtl.connect %d, %bar_d : !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
+
+
+firrtl.circuit "constReg" {
+// CHECK-LABEL: firrtl.module @constReg
+firrtl.module @constReg(in %clock: !firrtl.clock,
+              in %en: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
+  %r1 = firrtl.reg %clock  : !firrtl.uint<1>
+  %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+  %0 = firrtl.mux(%en, %c1_ui1, %r1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  firrtl.connect %r1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %out, %r1 : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK:  %[[C11:.+]] = firrtl.constant 1 : !firrtl.uint<1>
+  // CHECK:  firrtl.connect %out, %[[C11]] 
+}
+}
+
+firrtl.circuit "constReg2" {
+// CHECK-LABEL: firrtl.module @constReg
+firrtl.module @constReg2(in %clock: !firrtl.clock,
+              in %en: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
+  %r1 = firrtl.reg %clock  : !firrtl.uint<1>
+  %r2 = firrtl.reg %clock  : !firrtl.uint<1>
+  %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+  %0 = firrtl.mux(%en, %c1_ui1, %r1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  firrtl.connect %r1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+  %1 = firrtl.mux(%en, %r2, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  firrtl.connect %r2, %1 : !firrtl.uint<1>, !firrtl.uint<1>
+  %2 = firrtl.xor %r1, %r2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  firrtl.connect %out, %2 : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK:  %[[C12:.+]] = firrtl.constant 1 : !firrtl.uint<1>
+  // CHECK:  firrtl.connect %out, %[[C12]] 
+}
+}
+
+firrtl.circuit "constReg3" {
+// CHECK-LABEL: firrtl.module @constReg3
+firrtl.module @constReg3(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cond: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
+  %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
+  %r = firrtl.regreset %clock, %reset, %c11_ui8  : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+  %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+  firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
+  // CHECK:  %[[C13:.+]] = firrtl.constant 11
+  // CHECK: firrtl.connect %z, %[[C13]]
+  firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
+}
+}
+
+firrtl.circuit "constReg4" {
+// CHECK-LABEL: firrtl.module @constReg4
+firrtl.module @constReg4(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cond: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
+  %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
+  %c11_ui4 = firrtl.constant 11 : !firrtl.uint<8>
+  %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+  %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+  firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
+  // CHECK:  %[[C14:.+]] = firrtl.constant 11
+  // CHECK: firrtl.connect %z, %[[C14]]
+  firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
+}
+}
+
+firrtl.circuit "constReg6" {
+// CHECK-LABEL: firrtl.module @constReg6
+firrtl.module @constReg6(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cond: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
+  %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
+  %c11_ui4 = firrtl.constant 11 : !firrtl.uint<8>
+  %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
+  %aa = firrtl.add %r, %c11_ui4 : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<9>
+  %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+  firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
+  // CHECK:  %[[C15:.+]] = firrtl.constant 11
+  // CHECK: firrtl.connect %z, %[[C15]]
+  firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
+}
+}
+
+firrtl.circuit "constReg5" {
+// Cannot optimize if bit mismatch with constant reset.
+// CHECK-LABEL: firrtl.module @constReg5
+firrtl.module @constReg5(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cond: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
+  %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
+  %c11_ui4 = firrtl.constant 11 : !firrtl.uint<4>
+  %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<8>
+  %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+  firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
+  firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
+  // CHECK:  %[[C16:.+]] = firrtl.constant 11
+  // CHECK: firrtl.connect %z, %[[C16]]
+}
+}
+
+firrtl.circuit "constReg7"   {
+// CHECK-LABEL: firrtl.module @constReg7
+  firrtl.module @constReg7(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cmd: !firrtl.uint<3>, out %z: !firrtl.uint<8>) {
+    %c7_ui8 = firrtl.constant 7 : !firrtl.uint<8>
+    %c2_ui8 = firrtl.constant 2 : !firrtl.uint<8>
+    %c2_ui3 = firrtl.constant 2 : !firrtl.uint<3>
+    %c1_ui3 = firrtl.constant 1 : !firrtl.uint<3>
+    %c7_ui4 = firrtl.constant 7 : !firrtl.uint<4>
+    %r = firrtl.regreset %clock, %reset, %c7_ui4  : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<8>
+    %0 = firrtl.orr %cmd : (!firrtl.uint<3>) -> !firrtl.uint<1>
+    %1 = firrtl.not %0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %2 = firrtl.not %1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %3 = firrtl.eq %cmd, %c1_ui3 : (!firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<1>
+    %4 = firrtl.and %2, %3 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %5 = firrtl.not %3 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %6 = firrtl.and %2, %5 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %7 = firrtl.eq %cmd, %c2_ui3 : (!firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<1>
+    %8 = firrtl.and %6, %7 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %9 = firrtl.mux(%8, %c7_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+    %10 = firrtl.mux(%4, %r, %9) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+    %11 = firrtl.mux(%1, %c7_ui8, %10) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+    firrtl.connect %r, %11 : !firrtl.uint<8>, !firrtl.uint<8>
+    firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
+    // CHECK:  %c7_ui8 = firrtl.constant 7 : !firrtl.uint<8>
+    // CHECK:  firrtl.connect %z, %c7_ui8 : !firrtl.uint<8>, !firrtl.uint<8>
+  }
+}
+
+firrtl.circuit "regMuxTree"   {
+  // CHECK-LABEL: firrtl.module @regMuxTree
+  firrtl.module @regMuxTree(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cmd: !firrtl.uint<3>, out %z: !firrtl.uint<8>) {
+    %c7_ui8 = firrtl.constant 7 : !firrtl.uint<8>
+    %c2_ui8 = firrtl.constant 2 : !firrtl.uint<8>
+    %c2_ui3 = firrtl.constant 2 : !firrtl.uint<3>
+    %c1_ui3 = firrtl.constant 1 : !firrtl.uint<3>
+    %c7_ui4 = firrtl.constant 7 : !firrtl.uint<4>
+    %r = firrtl.regreset %clock, %reset, %c7_ui4  : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<8>
+    %0 = firrtl.orr %cmd : (!firrtl.uint<3>) -> !firrtl.uint<1>
+    %1 = firrtl.not %0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %2 = firrtl.not %1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %3 = firrtl.eq %cmd, %c1_ui3 : (!firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<1>
+    %4 = firrtl.and %2, %3 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %5 = firrtl.not %3 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %6 = firrtl.and %2, %5 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %7 = firrtl.eq %cmd, %c2_ui3 : (!firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<1>
+    %8 = firrtl.and %6, %7 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %9 = firrtl.mux(%8, %c7_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+    %10 = firrtl.mux(%4, %r, %9) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+    %11 = firrtl.mux(%1, %c7_ui8, %10) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+    firrtl.connect %r, %11 : !firrtl.uint<8>, !firrtl.uint<8>
+    firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
+    // CHECK:  %[[c7_ui8:.+]] = firrtl.constant 7 : !firrtl.uint<8>
+    // CHECK:  firrtl.connect %z, %[[c7_ui8]] : !firrtl.uint<8>, !firrtl.uint<8>
+  }
+}


### PR DESCRIPTION
Add the fold pattern for a mux with the same constant low and high.
That is, ` x = mux (cond, <constant1> ,<constant1>)` can be replaced with, -->  `x = constant1`

This triggers the following constant propagation:
``` mlir
  %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
  %r = firrtl.regreset %clock, %reset, %c11_ui8  : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
  %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
  firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
  firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
```
Can be optimized to :: 
```mlir
  %c11_ui8 = firrtl.constant 11
  firrtl.connect %z, %c11_ui8
```
This triggers other constant propagation of mux trees with registers and reset registers.
This change should also make https://github.com/llvm/circt/commit/0a6ad1a2b42334f5a1b8e0c3f13332dc0670abb9 redundant
(Will revert (https://github.com/llvm/circt/commit/0a6ad1a2b42334f5a1b8e0c3f13332dc0670abb9) after this is merged in)