### PR TITLE
[ExportVerilog] Don't output temporaries for output port assignments

### DIFF
--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -1498,6 +1498,11 @@ static bool isExpressionUnableToInline(Operation *op) {
 /// Return true if this expression should be emitted inline into any statement
 /// that uses it.
 static bool isExpressionEmittedInline(Operation *op) {
+  // Never create a temporary which is only going to be assigned to an output
+  // port.
+  if (op->hasOneUse() && isa<hw::OutputOp>(*op->getUsers().begin()))
+    return true;
+
   // If it isn't structurally possible to inline this expression, emit it out
   // of line.
   if (isExpressionUnableToInline(op))

--- a/test/ExportVerilog/hw-dialect.mlir
+++ b/test/ExportVerilog/hw-dialect.mlir
@@ -411,8 +411,8 @@ hw.module @casts(%in1: i7, %in2: !hw.array<8xi4>) -> (%r1: !hw.array<7xi1>, %r2:
   %r1 = hw.bitcast %in1 : (i7) -> !hw.array<7xi1>
   %r2 = hw.bitcast %in2 : (!hw.array<8xi4>) -> i32
 
-  // CHECK-NEXT: wire [31:0] {{.+}} = /*cast(bit[31:0])*/in2;
   // CHECK-NEXT: assign r1 = in1;
+  // CHECK-NEXT: assign r2 = /*cast(bit[31:0])*/in2;
   hw.output %r1, %r2 : !hw.array<7xi1>, i32
 }
 
@@ -738,5 +738,3 @@ hw.module @Issue1563(%a: i32) -> (%out : i32) {
   hw.output %0 : i32
   // CHECK: endmodule
 }
-
-


### PR DESCRIPTION
@lattner Is this the correct place to put this logic?