### PR TITLE
[FIRRTL][InferReset] Properly infer resets in nested aggregates

### DIFF
--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -108,6 +108,16 @@ firrtl.module @NestedAggregates(out %buzz: !firrtl.bundle<foo flip: vector<bundl
   firrtl.partialconnect %0, %1 : !firrtl.vector<bundle<a: reset, b flip: asyncreset, c: uint<8>>, 2>, !firrtl.vector<bundle<a: asyncreset, c: uint<1>, b flip: reset>, 2>
 }
 
+// Should work with deeply nested aggregates.
+// CHECK-LABEL: firrtl.module @DeeplyNestedAggregates(in %reset: !firrtl.uint<1>, out %buzz: !firrtl.bundle<a: bundle<b: uint<1>>>) {
+firrtl.module @DeeplyNestedAggregates(in %reset: !firrtl.uint<1>, out %buzz: !firrtl.bundle<a: bundle<b: reset>>) {
+  %0 = firrtl.subfield %buzz(0) : (!firrtl.bundle<a: bundle<b : reset>>) -> !firrtl.bundle<b: reset>
+  %1 = firrtl.subfield %0(0) : (!firrtl.bundle<b: reset>) -> !firrtl.reset
+  // CHECK: firrtl.connect %1, %reset : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %1, %reset : !firrtl.reset, !firrtl.uint<1>
+}
+
+
 // Should not crash if a ResetType has no drivers
 // CHECK-LABEL: firrtl.module @DontCrashIfNoDrivers
 // CHECK-SAME: out %out: !firrtl.uint<1>


### PR DESCRIPTION
When tracing the resets of a connect operation, the pass would recursively trace  the `src` and `dest` values. When one of the values came from a subfield operation, it would associate the resets of the input bundle of the subfield operation with the resets in result.  The pass neglected to recursively trace the resets of the input of each subfield operation, which resulted in a failure to determine the correct reset-network when there were nested aggregates.

To fix this, we need to recursively trace the resets of the input expression of every subfield operation.

This strategy of recursively visiting the `src` and `dest` expressions of a connect statement probably comes from the SFC, where the result of a subfield operation can only be used once.  In MFC this could result in visiting the same subfield operation multiple times.  It is more efficient to handle subfield and subindex operations as we walk through the module. By handling each subfield operation as we see it, we don't need to recursively trace subfield operations.