### PR TITLE
[Calyx] Add Cell trait.

### DIFF
--- a/include/circt/Dialect/Calyx/Calyx.td
+++ b/include/circt/Dialect/Calyx/Calyx.td
@@ -58,6 +58,14 @@ class CalyxCell<string mnemonic, list<OpTrait> traits = []> :
   ])> {
 }
 
+/// Base class for Calyx primitives.
+class CalyxPrimitive<string mnemonic, list<OpTrait> traits = []> :
+  CalyxCell<mnemonic, traits> {
+    let assemblyFormat = "$instanceName attr-dict `:` type(results)";
+    let arguments = (ins StrAttr:$instanceName, StrArrayAttr:$portNames);
+    let skipDefaultBuilders = 1;
+}
+
 /// Base class for Calyx containers.
 class CalyxContainer<string mnemonic, list<OpTrait> traits = []> :
   CalyxOp<mnemonic, !listconcat(traits, [

--- a/include/circt/Dialect/Calyx/Calyx.td
+++ b/include/circt/Dialect/Calyx/Calyx.td
@@ -45,6 +45,23 @@ class SameTypeConstraint<string lhs, string rhs>
 class CalyxOp<string mnemonic, list<OpTrait> traits = []> :
   Op<CalyxDialect, mnemonic, traits>;
 
+/// Op Interface for cells.
+def CellInterface : OpInterface<"CellInterface"> {
+  let cppNamespace = "::circt::calyx";
+  let description = [{
+    This is an op interface for Calyx Cells. Cells consist
+    of primitives and instances of components.
+  }];
+  let methods = [
+    InterfaceMethod<
+      "This returns the port names associated with the cell.",
+      "SmallVector<StringRef>", "portNames"
+    >
+    // TODO(Calyx): Add interface method for port directions
+    // after #1556 is merged.
+  ];
+}
+
 /// Trait used to annotate instances of components and primitives.
 def Cell : NativeOpTrait<"Cell"> {
   let cppNamespace = "::circt::calyx";
@@ -54,7 +71,8 @@ def Cell : NativeOpTrait<"Cell"> {
 class CalyxCell<string mnemonic, list<OpTrait> traits = []> :
   CalyxOp<mnemonic, !listconcat(traits, [
     Cell,
-    DeclareOpInterfaceMethods<OpAsmOpInterface>
+    DeclareOpInterfaceMethods<OpAsmOpInterface>,
+    DeclareOpInterfaceMethods<CellInterface>
   ])> {
 }
 

--- a/include/circt/Dialect/Calyx/Calyx.td
+++ b/include/circt/Dialect/Calyx/Calyx.td
@@ -45,23 +45,6 @@ class SameTypeConstraint<string lhs, string rhs>
 class CalyxOp<string mnemonic, list<OpTrait> traits = []> :
   Op<CalyxDialect, mnemonic, traits>;
 
-/// Op Interface for cells.
-def CellInterface : OpInterface<"CellInterface"> {
-  let cppNamespace = "::circt::calyx";
-  let description = [{
-    This is an op interface for Calyx Cells. Cells consist
-    of primitives and instances of components.
-  }];
-  let methods = [
-    InterfaceMethod<
-      "This returns the port names associated with the cell.",
-      "SmallVector<StringRef>", "portNames"
-    >
-    // TODO(Calyx): Add interface method for port directions
-    // after #1556 is merged.
-  ];
-}
-
 /// Trait used to annotate instances of components and primitives.
 def Cell : NativeOpTrait<"Cell"> {
   let cppNamespace = "::circt::calyx";
@@ -71,10 +54,8 @@ def Cell : NativeOpTrait<"Cell"> {
 class CalyxCell<string mnemonic, list<OpTrait> traits = []> :
   CalyxOp<mnemonic, !listconcat(traits, [
     Cell,
-    DeclareOpInterfaceMethods<OpAsmOpInterface>,
-    DeclareOpInterfaceMethods<CellInterface>
-  ])> {
-}
+    DeclareOpInterfaceMethods<OpAsmOpInterface>
+  ])> {}
 
 /// Base class for Calyx primitives.
 class CalyxPrimitive<string mnemonic, list<OpTrait> traits = []> :

--- a/include/circt/Dialect/Calyx/Calyx.td
+++ b/include/circt/Dialect/Calyx/Calyx.td
@@ -73,8 +73,8 @@ class CalyxGroupPort<string mnemonic, list<OpTrait> traits = []> :
   let assemblyFormat = "$src (`,` $guard^ `?`)? attr-dict `:` type($src)";
 }
 
+include "circt/Dialect/Calyx/CalyxPrimitives.td"
 include "circt/Dialect/Calyx/CalyxStructure.td"
 include "circt/Dialect/Calyx/CalyxControl.td"
-include "circt/Dialect/Calyx/CalyxPrimitives.td"
 
 #endif // CALYX_TD

--- a/include/circt/Dialect/Calyx/Calyx.td
+++ b/include/circt/Dialect/Calyx/Calyx.td
@@ -45,12 +45,25 @@ class SameTypeConstraint<string lhs, string rhs>
 class CalyxOp<string mnemonic, list<OpTrait> traits = []> :
   Op<CalyxDialect, mnemonic, traits>;
 
+/// Trait used to annotate instances of components and primitives.
+def Cell : NativeOpTrait<"Cell"> {
+  let cppNamespace = "::circt::calyx";
+}
+
+/// Base class for Calyx cells.
+class CalyxCell<string mnemonic, list<OpTrait> traits = []> :
+  CalyxOp<mnemonic, !listconcat(traits, [
+    Cell,
+    DeclareOpInterfaceMethods<OpAsmOpInterface>
+  ])> {
+}
+
 /// Base class for Calyx containers.
 class CalyxContainer<string mnemonic, list<OpTrait> traits = []> :
   CalyxOp<mnemonic, !listconcat(traits, [
-      NoRegionArguments,
-      NoTerminator,
-      SingleBlock
+    NoRegionArguments,
+    NoTerminator,
+    SingleBlock
   ])> {
   let assemblyFormat = "$body attr-dict";
   let regions = (region SizedRegion<1>: $body);
@@ -73,8 +86,8 @@ class CalyxGroupPort<string mnemonic, list<OpTrait> traits = []> :
   let assemblyFormat = "$src (`,` $guard^ `?`)? attr-dict `:` type($src)";
 }
 
-include "circt/Dialect/Calyx/CalyxPrimitives.td"
 include "circt/Dialect/Calyx/CalyxStructure.td"
 include "circt/Dialect/Calyx/CalyxControl.td"
+include "circt/Dialect/Calyx/CalyxPrimitives.td"
 
 #endif // CALYX_TD

--- a/include/circt/Dialect/Calyx/Calyx.td
+++ b/include/circt/Dialect/Calyx/Calyx.td
@@ -62,7 +62,7 @@ class CalyxCell<string mnemonic, list<OpTrait> traits = []> :
 class CalyxPrimitive<string mnemonic, list<OpTrait> traits = []> :
   CalyxCell<mnemonic, traits> {
     let assemblyFormat = "$instanceName attr-dict `:` type(results)";
-    let arguments = (ins StrAttr:$instanceName, StrArrayAttr:$portNames);
+    let arguments = (ins StrAttr:$instanceName);
     let skipDefaultBuilders = 1;
 }
 

--- a/include/circt/Dialect/Calyx/CalyxDialect.h
+++ b/include/circt/Dialect/Calyx/CalyxDialect.h
@@ -24,7 +24,7 @@
 
 // Pull in all enum type definitions, attributes,
 // and utility function declarations.
-#include "circt/Dialect/Calyx/CalyxEnums.h.inc"
 #include "circt/Dialect/Calyx/CalyxAttrs.h.inc"
+#include "circt/Dialect/Calyx/CalyxEnums.h.inc"
 
 #endif // CIRCT_DIALECT_CALYX_CALYXDIALECT_H

--- a/include/circt/Dialect/Calyx/CalyxOps.h
+++ b/include/circt/Dialect/Calyx/CalyxOps.h
@@ -24,6 +24,16 @@
 namespace circt {
 namespace calyx {
 
+/// A helper function to verify each operation with the Cell trait.
+LogicalResult verifyCell(Operation *op);
+
+/// Signals that the following operation is a cell.
+template <typename ConcreteType>
+class Cell : public mlir::OpTrait::TraitBase<ConcreteType, Cell> {
+public:
+  static LogicalResult verifyTrait(Operation *op) { return verifyCell(op); }
+};
+
 /// A helper function to verify each control-like operation
 /// has a valid parent and, if applicable, body.
 LogicalResult verifyControlLikeOp(Operation *op);

--- a/include/circt/Dialect/Calyx/CalyxOps.h
+++ b/include/circt/Dialect/Calyx/CalyxOps.h
@@ -25,19 +25,6 @@
 namespace circt {
 namespace calyx {
 
-class CellInterface;
-
-/// A helper function to verify each operation with the Cell trait.
-LogicalResult verifyCell(Operation *op);
-
-/// Signals that the following operation is a cell.
-template <typename ConcreteType>
-class Cell : public mlir::OpTrait::TraitBase<ConcreteType, Cell> {
-public:
-  static LogicalResult verifyTrait(Operation *op) { return verifyCell(op); }
-  SmallVector<StringRef> portNames();
-};
-
 /// A helper function to verify each control-like operation
 /// has a valid parent and, if applicable, body.
 LogicalResult verifyControlLikeOp(Operation *op);
@@ -59,6 +46,18 @@ struct ComponentPortInfo {
   StringAttr name;
   Type type;
   PortDirection direction;
+};
+
+/// A helper function to verify each operation with the Cell trait.
+LogicalResult verifyCell(Operation *op);
+
+/// Signals that the following operation is a cell.
+template <typename ConcreteType>
+class Cell : public mlir::OpTrait::TraitBase<ConcreteType, Cell> {
+public:
+  static LogicalResult verifyTrait(Operation *op) { return verifyCell(op); }
+  SmallVector<StringRef> portNames();
+  SmallVector<PortDirection> portDirections();
 };
 
 /// Returns port information about a given component.

--- a/include/circt/Dialect/Calyx/CalyxOps.h
+++ b/include/circt/Dialect/Calyx/CalyxOps.h
@@ -15,7 +15,6 @@
 
 #include "circt/Dialect/Calyx/CalyxDialect.h"
 #include "mlir/IR/FunctionSupport.h"
-#include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/RegionKindInterface.h"
 #include "mlir/IR/SymbolTable.h"

--- a/include/circt/Dialect/Calyx/CalyxOps.h
+++ b/include/circt/Dialect/Calyx/CalyxOps.h
@@ -15,6 +15,7 @@
 
 #include "circt/Dialect/Calyx/CalyxDialect.h"
 #include "mlir/IR/FunctionSupport.h"
+#include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/RegionKindInterface.h"
 #include "mlir/IR/SymbolTable.h"
@@ -24,6 +25,8 @@
 namespace circt {
 namespace calyx {
 
+class CellInterface;
+
 /// A helper function to verify each operation with the Cell trait.
 LogicalResult verifyCell(Operation *op);
 
@@ -32,6 +35,7 @@ template <typename ConcreteType>
 class Cell : public mlir::OpTrait::TraitBase<ConcreteType, Cell> {
 public:
   static LogicalResult verifyTrait(Operation *op) { return verifyCell(op); }
+  SmallVector<StringRef> portNames();
 };
 
 /// A helper function to verify each control-like operation

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -30,8 +30,5 @@ def RegisterOp : CalyxPrimitive<"register", [
       $_state.addTypes({widthType, i1Type, i1Type, i1Type, widthType, i1Type});
     }]>
   ];
-  let extraClassDeclaration = [{
-    SmallVector<StringRef> portNames() { return {"in", "write_en", "clk", "reset", "out", "done"}; }
-  }];
 
 }

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -10,11 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-// TODO(cgyurgyik): It may be worthwhile to unify component and primitive cells,
-// much in the same way that the native compiler does.
+def Cell : NativeOpTrait<"Cell"> {
+  let cppNamespace = "::circt::calyx";
+}
+
 def RegisterOp : CalyxOp<"register", [
+    Cell,
     DeclareOpInterfaceMethods<OpAsmOpInterface>,
-    HasParent<"ComponentOp">,
     SameTypeConstraint<"in", "out">
   ]> {
   let summary = "Defines a register";

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -36,6 +36,9 @@ def RegisterOp : CalyxCell<"register", [
   ];
 
   let extraClassDeclaration = [{
+    // TODO(Calyx): Use attribute instead. Provide parsing/printing method for CalyxCell.
+    // Something like:
+    // %r.in, ..., %r.out = calyx.register "r" (in: i8, ...) -> (..., out: i8)
     SmallVector<StringRef> portNames() { return {"in", "write_en", "clk", "reset", "out", "done"}; }
   }];
 }

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -10,35 +10,31 @@
 //
 //===----------------------------------------------------------------------===//
 
-def RegisterOp : CalyxCell<"register", [
+def RegisterOp : CalyxPrimitive<"register", [
     SameTypeConstraint<"in", "out">
   ]> {
   let summary = "Defines a register";
   let description = [{
     The "calyx.register" op defines a register.
-    ```
+    ```mlir
+      // A 32-bit register.
       %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i32
     ```
   }];
-  let arguments = (
-    ins StrAttr:$instanceName
-  );
   let results = (outs AnyType:$in, I1:$write_en, I1:$clk, I1:$reset, AnyType:$out, I1:$done);
-  let assemblyFormat = "$instanceName attr-dict `:` type($in)";
-
   let builders = [
     OpBuilder<(ins "StringAttr":$instanceName, "size_t":$width), [{
       $_state.addAttribute("instanceName", instanceName);
+      auto portNames = $_builder.getStrArrayAttr({"in", "write_en", "clk", "reset", "out", "done"});
+      $_state.addAttribute("portNames", portNames);
       auto i1Type = $_builder.getI1Type();
       auto widthType = $_builder.getIntegerType(width);
       $_state.addTypes({widthType, i1Type, i1Type, i1Type, widthType, i1Type});
     }]>
   ];
-
-  let extraClassDeclaration = [{
-    // TODO(Calyx): Use attribute instead. Provide parsing/printing method for CalyxCell.
+    // TODO(Calyx): Use attribute instead. Provide parsing/printing method for Calyx primitives.
     // Something like:
-    // %r.in, ..., %r.out = calyx.register "r" (in: i8, ...) -> (..., out: i8)
-    SmallVector<StringRef> portNames() { return {"in", "write_en", "clk", "reset", "out", "done"}; }
-  }];
+    // %r.in, ..., %r.out = calyx.register "r" (in: i8, ...) -> (..., out: i8) or
+    // %r.in, ..., %r.out = calyx.register "r" inputs: (), outputs: ()
+
 }

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -20,13 +20,19 @@ def RegisterOp : CalyxCell<"register", [
       %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i32
     ```
   }];
-  let arguments = (ins StrAttr:$instanceName);
+  let arguments = (
+    ins StrAttr:$instanceName,
+    DefaultValuedAttr<StrArrayAttr, "{\"in\", \"write_en\", \"clk\", \"reset\", \"out\", \"done\"}">:$portNames
+  );
   let results = (outs AnyType:$in, I1:$write_en, I1:$clk, I1:$reset, AnyType:$out, I1:$done);
   let assemblyFormat = "$instanceName attr-dict `:` type($in)";
 
   let builders = [
     OpBuilder<(ins "StringAttr":$instanceName, "size_t":$width), [{
       $_state.addAttribute("instanceName", instanceName);
+      $_state.addAttribute("portNames", $_builder.getStrArrayAttr(
+        {"in", "write_en", "clk", "reset", "out", "done"}
+      ));
       auto i1Type = $_builder.getI1Type();
       auto widthType = $_builder.getIntegerType(width);
       $_state.addTypes({widthType, i1Type, i1Type, i1Type, widthType, i1Type});

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -10,13 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-def Cell : NativeOpTrait<"Cell"> {
-  let cppNamespace = "::circt::calyx";
-}
-
-def RegisterOp : CalyxOp<"register", [
-    Cell,
-    DeclareOpInterfaceMethods<OpAsmOpInterface>,
+def RegisterOp : CalyxCell<"register", [
     SameTypeConstraint<"in", "out">
   ]> {
   let summary = "Defines a register";
@@ -26,13 +20,13 @@ def RegisterOp : CalyxOp<"register", [
       %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i32
     ```
   }];
-  let arguments = (ins StrAttr:$name);
+  let arguments = (ins StrAttr:$instanceName);
   let results = (outs AnyType:$in, I1:$write_en, I1:$clk, I1:$reset, AnyType:$out, I1:$done);
-  let assemblyFormat = "$name attr-dict `:` type($in)";
+  let assemblyFormat = "$instanceName attr-dict `:` type($in)";
 
   let builders = [
-    OpBuilder<(ins "StringAttr":$name, "size_t":$width), [{
-      $_state.addAttribute("name", name);
+    OpBuilder<(ins "StringAttr":$instanceName, "size_t":$width), [{
+      $_state.addAttribute("instanceName", instanceName);
       auto i1Type = $_builder.getI1Type();
       auto widthType = $_builder.getIntegerType(width);
       $_state.addTypes({widthType, i1Type, i1Type, i1Type, widthType, i1Type});

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -18,23 +18,20 @@ def RegisterOp : CalyxPrimitive<"register", [
     The "calyx.register" op defines a register.
     ```mlir
       // A 32-bit register.
-      %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i32
+      %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i32, i1, i1, i1, i32, i1
     ```
   }];
   let results = (outs AnyType:$in, I1:$write_en, I1:$clk, I1:$reset, AnyType:$out, I1:$done);
   let builders = [
     OpBuilder<(ins "StringAttr":$instanceName, "size_t":$width), [{
       $_state.addAttribute("instanceName", instanceName);
-      auto portNames = $_builder.getStrArrayAttr({"in", "write_en", "clk", "reset", "out", "done"});
-      $_state.addAttribute("portNames", portNames);
       auto i1Type = $_builder.getI1Type();
       auto widthType = $_builder.getIntegerType(width);
       $_state.addTypes({widthType, i1Type, i1Type, i1Type, widthType, i1Type});
     }]>
   ];
-    // TODO(Calyx): Use attribute instead. Provide parsing/printing method for Calyx primitives.
-    // Something like:
-    // %r.in, ..., %r.out = calyx.register "r" (in: i8, ...) -> (..., out: i8) or
-    // %r.in, ..., %r.out = calyx.register "r" inputs: (), outputs: ()
+  let extraClassDeclaration = [{
+    SmallVector<StringRef> portNames() { return {"in", "write_en", "clk", "reset", "out", "done"}; }
+  }];
 
 }

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -30,5 +30,13 @@ def RegisterOp : CalyxPrimitive<"register", [
       $_state.addTypes({widthType, i1Type, i1Type, i1Type, widthType, i1Type});
     }]>
   ];
+  let extraClassDeclaration = [{
+    SmallVector<StringRef> portNames() {
+      return {"in", "write_en", "clk", "reset", "out", "done"};
+    }
+    SmallVector<PortDirection> portDirections() {
+      return { INPUT, INPUT, INPUT, INPUT, OUTPUT, OUTPUT };
+    }
+  }];
 
 }

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -21,8 +21,7 @@ def RegisterOp : CalyxCell<"register", [
     ```
   }];
   let arguments = (
-    ins StrAttr:$instanceName,
-    DefaultValuedAttr<StrArrayAttr, "{\"in\", \"write_en\", \"clk\", \"reset\", \"out\", \"done\"}">:$portNames
+    ins StrAttr:$instanceName
   );
   let results = (outs AnyType:$in, I1:$write_en, I1:$clk, I1:$reset, AnyType:$out, I1:$done);
   let assemblyFormat = "$instanceName attr-dict `:` type($in)";
@@ -30,12 +29,13 @@ def RegisterOp : CalyxCell<"register", [
   let builders = [
     OpBuilder<(ins "StringAttr":$instanceName, "size_t":$width), [{
       $_state.addAttribute("instanceName", instanceName);
-      $_state.addAttribute("portNames", $_builder.getStrArrayAttr(
-        {"in", "write_en", "clk", "reset", "out", "done"}
-      ));
       auto i1Type = $_builder.getI1Type();
       auto widthType = $_builder.getIntegerType(width);
       $_state.addTypes({widthType, i1Type, i1Type, i1Type, widthType, i1Type});
     }]>
   ];
+
+  let extraClassDeclaration = [{
+    SmallVector<StringRef> portNames() { return {"in", "write_en", "clk", "reset", "out", "done"}; }
+  }];
 }

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -143,15 +143,12 @@ def WiresOp : CalyxContainer<"wires", [
   let verifier = "return ::verify$cppClass(*this);";
 }
 
-def InstanceOp : CalyxOp<"instance", [
-    DeclareOpInterfaceMethods<OpAsmOpInterface>,
-    Cell
+def InstanceOp : CalyxCell<"instance", [
   ]> {
   let summary = "Calyx Component Instance";
   let description = [{
     Represents an instance of a Calyx component,
-    which may include state. Some instances may
-    optionally have parameters attributed to them.
+    which may include state.
 
     ```mlir
       %name.in, %name.out = calyx.instance "name" @MyComponent : i64, i16

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -161,8 +161,6 @@ def InstanceOp : CalyxCell<"instance", [
     ComponentOp getReferencedComponent();
   }];
 
-  // TODO(Calyx): Add `parameters` attribute for
-  // SystemVerilog-wrapped primitives.
   let arguments = (ins
     StrAttr:$instanceName,
     FlatSymbolRefAttr:$componentName

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -143,18 +143,18 @@ def WiresOp : CalyxContainer<"wires", [
   let verifier = "return ::verify$cppClass(*this);";
 }
 
-def CellOp : CalyxOp<"cell", [
+def InstanceOp : CalyxOp<"instance", [
     DeclareOpInterfaceMethods<OpAsmOpInterface>,
-    HasParent<"ComponentOp">
+    Cell
   ]> {
-  let summary = "Calyx Cell";
+  let summary = "Calyx Component Instance";
   let description = [{
-    Represents a cell (or instance) of a Calyx component or
-    primitive, which may include state. Some cells may
+    Represents an instance of a Calyx component,
+    which may include state. Some instances may
     optionally have parameters attributed to them.
 
     ```mlir
-      %name.in, %name.out = calyx.cell "name" @MyComponent : i64, i16
+      %name.in, %name.out = calyx.instance "name" @MyComponent : i64, i16
     ```
   }];
 

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -32,10 +32,9 @@ LogicalResult calyx::verifyCell(Operation *op) {
   auto opParent = op->getParentOp();
   if (!isa<ComponentOp>(opParent))
     return op->emitOpError()
-           << "has parent: " << opParent << ". This should be ComponentOp.";
+           << "has parent: " << opParent << ", expected ComponentOp.";
   if (!op->hasAttr("instanceName"))
-    return op->emitOpError()
-           << "with Cell trait does not have an instanceName attribute.";
+    return op->emitOpError() << "does not have an instanceName attribute.";
 
   return success();
 }
@@ -417,7 +416,7 @@ GroupDoneOp GroupOp::getDoneOp() {
 //===----------------------------------------------------------------------===//
 
 /// Gives each result of the cell a meaningful name in the form:
-/// <prefix>.<port-name>
+/// <instance-name>.<port-name>
 static void getCellAsmResultNames(OpAsmSetValueNameFn setNameFn, Operation *op,
                                   ArrayRef<StringRef> portNames) {
   assert(op->hasTrait<Cell>() && "must have the Cell trait");

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -412,7 +412,7 @@ GroupDoneOp GroupOp::getDoneOp() {
 }
 
 //===----------------------------------------------------------------------===//
-// Utilities for Cell-like operations.
+// Utilities for operations with the Cell trait.
 //===----------------------------------------------------------------------===//
 
 /// Gives each result of the cell a meaningful name in the form:

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -34,7 +34,14 @@ LogicalResult calyx::verifyCell(Operation *op) {
     return op->emitOpError()
            << "has parent: " << opParent << ". This should be ComponentOp.";
   if (!op->hasAttr("instanceName"))
-    return op->emitOpError() << "does not have an instance name attribute.";
+    return op->emitOpError()
+           << "with Cell trait does not have an instanceName attribute.";
+
+  // InstanceOps get their port names from the referenced component.
+  // In all other cases, the Cell should have a port names attribute.
+  if (!(isa<InstanceOp>(op) || op->hasAttr("portNames")))
+    return op->emitOpError()
+           << "with Cell trait does not have an portNames attribute.";
 
   return success();
 }
@@ -445,8 +452,7 @@ ComponentOp InstanceOp::getReferencedComponent() {
 
 /// Provide meaningful names to the result values of an InstanceOp.
 void InstanceOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
-  getCellAsmResultNames(setNameFn, *this,
-                        getReferencedComponent().portNames());
+  getCellAsmResultNames(setNameFn, *this, getReferencedComponent().portNames());
 }
 
 static LogicalResult verifyInstanceOp(InstanceOp instance) {

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -506,8 +506,12 @@ void GroupGoOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 //===----------------------------------------------------------------------===//
 
 /// Provide meaningful names to the result values of a RegisterOp.
+
+SmallVector<StringRef> RegisterOp::portNames() {
+  return {"in", "write_en", "clk", "reset", "out", "done"};
+}
 void RegisterOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
-  getCellAsmResultNames(setNameFn, *this, this->portNames());
+  getCellAsmResultNames(setNameFn, *this, {} /*this->portNames()*/);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -78,7 +78,7 @@ LogicalResult calyx::verifyCell(Operation *op) {
   auto opParent = op->getParentOp();
   if (!isa<ComponentOp>(opParent))
     return op->emitOpError()
-        << "has parent: " << opParent << ", expected ComponentOp.";
+           << "has parent: " << opParent << ", expected ComponentOp.";
   if (!op->hasAttr("instanceName"))
     return op->emitOpError() << "does not have an instanceName attribute.";
 

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -506,12 +506,8 @@ void GroupGoOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 //===----------------------------------------------------------------------===//
 
 /// Provide meaningful names to the result values of a RegisterOp.
-
-SmallVector<StringRef> RegisterOp::portNames() {
-  return {"in", "write_en", "clk", "reset", "out", "done"};
-}
 void RegisterOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
-  getCellAsmResultNames(setNameFn, *this, {} /*this->portNames()*/);
+  getCellAsmResultNames(setNameFn, *this, this->portNames());
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -28,6 +28,14 @@ using namespace circt;
 using namespace circt::calyx;
 using namespace mlir;
 
+LogicalResult calyx::verifyCell(Operation *op) {
+  auto opParent = op->getParentOp();
+  if (!isa<ComponentOp>(opParent))
+    return op->emitOpError()
+           << "has parent: " << opParent << ". This should be ComponentOp.";
+  return success();
+}
+
 LogicalResult calyx::verifyControlLikeOp(Operation *op) {
   auto parent = op->getParentOp();
   // Operations that may parent other ControlLike operations.
@@ -78,7 +86,7 @@ namespace {
 /// This is a helper function that should only be used to get the WiresOp or
 /// ControlOp of a ComponentOp, which are guaranteed to exist and generally at
 /// the end of a component's body. In the worst case, this will run in linear
-/// time with respect to the number of instances within the cell.
+/// time with respect to the number of instances within the component.
 template <typename Op>
 static Op getControlOrWiresFrom(ComponentOp op) {
   auto body = op.getBody();
@@ -401,12 +409,12 @@ GroupDoneOp GroupOp::getDoneOp() {
 }
 
 //===----------------------------------------------------------------------===//
-// CellOp
+// InstanceOp
 //===----------------------------------------------------------------------===//
 
 /// Lookup the component for the symbol. This returns null on
 /// invalid IR.
-ComponentOp CellOp::getReferencedComponent() {
+ComponentOp InstanceOp::getReferencedComponent() {
   auto program = (*this)->getParentOfType<ProgramOp>();
   if (!program)
     return nullptr;
@@ -414,8 +422,8 @@ ComponentOp CellOp::getReferencedComponent() {
   return program.lookupSymbol<ComponentOp>(componentName());
 }
 
-/// Provide meaningful names to the result values of a CellOp.
-void CellOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+/// Provide meaningful names to the result values of a InstanceOp.
+void InstanceOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   auto component = getReferencedComponent();
   auto portNames = component.portNames();
 
@@ -426,40 +434,40 @@ void CellOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   }
 }
 
-static LogicalResult verifyCellOp(CellOp cell) {
-  if (cell.componentName() == "main")
-    return cell.emitOpError("cannot reference the entry point.");
+static LogicalResult verifyInstanceOp(InstanceOp instance) {
+  if (instance.componentName() == "main")
+    return instance.emitOpError("cannot reference the entry point.");
 
   // Verify the referenced component exists in this program.
-  ComponentOp referencedComponent = cell.getReferencedComponent();
+  ComponentOp referencedComponent = instance.getReferencedComponent();
   if (!referencedComponent)
-    return cell.emitOpError()
-           << "is referencing component: " << cell.componentName()
+    return instance.emitOpError()
+           << "is referencing component: " << instance.componentName()
            << ", which does not exist.";
 
   // Verify the referenced component is not instantiating itself.
-  auto parentComponent = cell->getParentOfType<ComponentOp>();
+  auto parentComponent = instance->getParentOfType<ComponentOp>();
   if (parentComponent == referencedComponent)
-    return cell.emitOpError()
+    return instance.emitOpError()
            << "is a recursive instantiation of its parent component: "
-           << cell.componentName();
+           << instance.componentName();
 
   // Verify the instance result ports with those of its referenced component.
   SmallVector<ComponentPortInfo> componentPorts =
       getComponentPortInfo(referencedComponent);
 
-  size_t numResults = cell.getNumResults();
+  size_t numResults = instance.getNumResults();
   if (numResults != componentPorts.size())
-    return cell.emitOpError()
+    return instance.emitOpError()
            << "has a wrong number of results; expected: "
            << componentPorts.size() << " but got " << numResults;
 
   for (size_t i = 0; i != numResults; ++i) {
-    auto resultType = cell.getResult(i).getType();
+    auto resultType = instance.getResult(i).getType();
     auto expectedType = componentPorts[i].type;
     if (resultType == expectedType)
       continue;
-    return cell.emitOpError()
+    return instance.emitOpError()
            << "result type for " << componentPorts[i].name << " must be "
            << expectedType << ", but got " << resultType;
   }

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -49,8 +49,8 @@ struct Emitter {
   void emitComponent(ComponentOp op);
   void emitComponentPorts(ArrayRef<ComponentPortInfo> ports);
 
-  // Cell emission
-  void emitCell(CellOp op);
+  // Instance emission
+  void emitInstance(InstanceOp op);
 
   // Wires emission
   void emitWires(WiresOp op);
@@ -96,7 +96,7 @@ private:
   void emitValue(Value value, bool isIndented) {
     auto definingOp = value.getDefiningOp();
     TypeSwitch<Operation *>(definingOp)
-        .Case<CellOp>([&](auto op) {
+        .Case<InstanceOp>([&](auto op) {
           // A cell port should be defined as <instance-name>.<port-name>
           auto opResult = value.cast<OpResult>();
           unsigned portIndex = opResult.getResultNumber();
@@ -165,7 +165,7 @@ void Emitter::emitComponent(ComponentOp op) {
       TypeSwitch<Operation *>(&bodyOp)
           .Case<WiresOp>([&](auto op) { wires = op; })
           .Case<ControlOp>([&](auto op) { control = op; })
-          .Case<CellOp>([&](auto op) { emitCell(op); })
+          .Case<InstanceOp>([&](auto op) { emitInstance(op); })
           .Default([&](auto op) {
             emitOpError(op, "not supported for emission inside component");
           });
@@ -207,7 +207,7 @@ void Emitter::emitComponentPorts(ArrayRef<ComponentPortInfo> ports) {
   emitPorts(outPorts);
 }
 
-void Emitter::emitCell(CellOp op) {
+void Emitter::emitInstance(InstanceOp op) {
   indent() << op.instanceName() << " = " << op.componentName() << "();\n";
 }
 

--- a/test/Dialect/Calyx/compile-control.mlir
+++ b/test/Dialect/Calyx/compile-control.mlir
@@ -7,7 +7,7 @@ calyx.program {
   }
 
   calyx.component @main(%go : i1, %reset : i1, %clk : i1) -> (%done: i1) {
-    // CHECK:  %fsm.in, %fsm.write_en, %fsm.clk, %fsm.reset, %fsm.out, %fsm.done = calyx.register "fsm" : i2
+    // CHECK:  %fsm.in, %fsm.write_en, %fsm.clk, %fsm.reset, %fsm.out, %fsm.done = calyx.register "fsm" {portNames = ["in", "write_en", "clk", "reset", "out", "done"]} : i2
     %z.go, %z.reset, %z.clk, %z.flag, %z.done = calyx.instance "z" @Z : i1, i1, i1, i1, i1
     calyx.wires {
       %undef = calyx.undef : i1

--- a/test/Dialect/Calyx/compile-control.mlir
+++ b/test/Dialect/Calyx/compile-control.mlir
@@ -7,7 +7,7 @@ calyx.program {
   }
 
   calyx.component @main(%go : i1, %reset : i1, %clk : i1) -> (%done: i1) {
-    // CHECK:  %fsm.in, %fsm.write_en, %fsm.clk, %fsm.reset, %fsm.out, %fsm.done = calyx.register "fsm" {portNames = ["in", "write_en", "clk", "reset", "out", "done"]} : i2
+    // CHECK:  %fsm.in, %fsm.write_en, %fsm.clk, %fsm.reset, %fsm.out, %fsm.done = calyx.register "fsm" : i2
     %z.go, %z.reset, %z.clk, %z.flag, %z.done = calyx.instance "z" @Z : i1, i1, i1, i1, i1
     calyx.wires {
       %undef = calyx.undef : i1

--- a/test/Dialect/Calyx/compile-control.mlir
+++ b/test/Dialect/Calyx/compile-control.mlir
@@ -8,7 +8,7 @@ calyx.program {
 
   calyx.component @main(%go : i1, %reset : i1, %clk : i1) -> (%done: i1) {
     // CHECK:  %fsm.in, %fsm.write_en, %fsm.clk, %fsm.reset, %fsm.out, %fsm.done = calyx.register "fsm" : i2
-    %z.go, %z.reset, %z.clk, %z.flag, %z.done = calyx.cell "z" @Z : i1, i1, i1, i1, i1
+    %z.go, %z.reset, %z.clk, %z.flag, %z.done = calyx.instance "z" @Z : i1, i1, i1, i1, i1
     calyx.wires {
       %undef = calyx.undef : i1
       // CHECK: %[[SIGNAL_ON:.+]] = hw.constant true

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -11,7 +11,7 @@ calyx.program {
   calyx.component @main(%go: i1, %clk: i1, %reset: i1) -> (%done: i1) {
     // CHECK: cells {
     // CHECK-NEXT:   c0 = A();
-    %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.cell "c0" @A : i8, i1, i1, i1, i8, i1
+    %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i8, i1, i1, i1, i8, i1
 
     // CHECK: wires {
     calyx.wires {

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -32,7 +32,7 @@ calyx.program {
     calyx.control {}
   }
   calyx.component @main(%go: i1, %clk: i1, %reset: i1) -> (%done: i1) {
-    // expected-error @+1 {{'calyx.instance' op has a wrong number of results; expected: 5 but got 0}}
+    // expected-error @+1 {{'calyx.instance' op Number of results: 0 does not match the number of port names: 5}}
     calyx.instance "a0" @A
     calyx.wires {}
     calyx.control {}

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -16,8 +16,8 @@ calyx.program {
 
 calyx.program {
   calyx.component @main(%go: i1, %clk: i1, %reset: i1) -> (%done: i1) {
-    // expected-error @+1 {{'calyx.cell' op is referencing component: A, which does not exist.}}
-    calyx.cell "a0" @A
+    // expected-error @+1 {{'calyx.instance' op is referencing component: A, which does not exist.}}
+    calyx.instance "a0" @A
 
     calyx.wires {}
     calyx.control {}
@@ -32,8 +32,8 @@ calyx.program {
     calyx.control {}
   }
   calyx.component @main(%go: i1, %clk: i1, %reset: i1) -> (%done: i1) {
-    // expected-error @+1 {{'calyx.cell' op has a wrong number of results; expected: 5 but got 0}}
-    calyx.cell "a0" @A
+    // expected-error @+1 {{'calyx.instance' op has a wrong number of results; expected: 5 but got 0}}
+    calyx.instance "a0" @A
     calyx.wires {}
     calyx.control {}
   }
@@ -47,8 +47,8 @@ calyx.program {
     calyx.control {}
   }
   calyx.component @main(%go: i1, %clk: i1, %reset: i1) -> (%done: i1) {
-    // expected-error @+1 {{'calyx.cell' op result type for "in" must be 'i16', but got 'i1'}}
-    %b0.in, %b0.go, %b0.clk, %b0.reset, %b0.done = calyx.cell "b0" @B : i1, i1, i1, i1, i1
+    // expected-error @+1 {{'calyx.instance' op result type for "in" must be 'i16', but got 'i1'}}
+    %b0.in, %b0.go, %b0.clk, %b0.reset, %b0.done = calyx.instance "b0" @B : i1, i1, i1, i1, i1
 
     calyx.wires {}
     calyx.control {}
@@ -67,8 +67,8 @@ calyx.program {
     calyx.control {}
   }
   calyx.component @main(%go: i1, %clk: i1, %reset: i1) -> (%done: i1) {
-    %a.go, %a.clk, %a.reset, %a.out, %a.done = calyx.cell "a" @A : i1, i1, i1, i16, i1
-    %b.in, %b.go, %b.clk, %b.reset, %b.done = calyx.cell "b" @B : i16, i1, i1, i1, i1
+    %a.go, %a.clk, %a.reset, %a.out, %a.done = calyx.instance "a" @A : i1, i1, i1, i16, i1
+    %b.in, %b.go, %b.clk, %b.reset, %b.done = calyx.instance "b" @B : i16, i1, i1, i1, i1
     // expected-error @+1 {{'calyx.assign' op expects parent op to be one of 'calyx.group, calyx.wires'}}
     calyx.assign %b.in = %a.out : i16
 

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -32,7 +32,7 @@ calyx.program {
     calyx.control {}
   }
   calyx.component @main(%go: i1, %clk: i1, %reset: i1) -> (%done: i1) {
-    // expected-error @+1 {{'calyx.instance' op Number of results: 0 does not match the number of port names: 5}}
+    // expected-error @+1 {{'calyx.instance' op has a wrong number of results; expected: 5 but got 0}}
     calyx.instance "a0" @A
     calyx.wires {}
     calyx.control {}

--- a/test/Dialect/Calyx/go-insertion.mlir
+++ b/test/Dialect/Calyx/go-insertion.mlir
@@ -7,7 +7,7 @@ calyx.program {
   }
   calyx.component @main(%go: i1, %clk: i1, %reset: i1) -> (%done: i1) {
 
-    %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.cell "c0" @A : i8, i1, i1, i1, i8, i1
+    %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i8, i1, i1, i1, i8, i1
     calyx.wires {
       // CHECK: %0 = calyx.undef : i1
       // CHECK-LABEL: calyx.group @Group1 {

--- a/test/Dialect/Calyx/remove-groups.mlir
+++ b/test/Dialect/Calyx/remove-groups.mlir
@@ -9,7 +9,7 @@ calyx.program {
   // CHECK-LABEL: calyx.component @main
   calyx.component @main(%go : i1, %reset : i1, %clk : i1) -> (%done: i1) {
     %z.go, %z.reset, %z.clk, %z.flag, %z.out, %z.done = calyx.instance "z" @Z : i1, i1, i1, i1, i2, i1
-    %fsm.in, %fsm.write_en, %fsm.clk, %fsm.reset, %fsm.out, %fsm.done = calyx.register "fsm" {portNames = ["in", "write_en", "clk", "reset", "out", "done"]} : i2
+    %fsm.in, %fsm.write_en, %fsm.clk, %fsm.reset, %fsm.out, %fsm.done = calyx.register "fsm" : i2
 
     calyx.wires {
       // CHECK: %[[FSM_IS_GROUP_A_BEGIN_STATE:.+]] = comb.icmp eq %fsm.out, {{.+}} : i2

--- a/test/Dialect/Calyx/remove-groups.mlir
+++ b/test/Dialect/Calyx/remove-groups.mlir
@@ -8,7 +8,7 @@ calyx.program {
 
   // CHECK-LABEL: calyx.component @main
   calyx.component @main(%go : i1, %reset : i1, %clk : i1) -> (%done: i1) {
-    %z.go, %z.reset, %z.clk, %z.flag, %z.out, %z.done = calyx.cell "z" @Z : i1, i1, i1, i1, i2, i1
+    %z.go, %z.reset, %z.clk, %z.flag, %z.out, %z.done = calyx.instance "z" @Z : i1, i1, i1, i1, i2, i1
     %fsm.in, %fsm.write_en, %fsm.clk, %fsm.reset, %fsm.out, %fsm.done = calyx.register "fsm" : i2
 
     calyx.wires {

--- a/test/Dialect/Calyx/remove-groups.mlir
+++ b/test/Dialect/Calyx/remove-groups.mlir
@@ -9,7 +9,7 @@ calyx.program {
   // CHECK-LABEL: calyx.component @main
   calyx.component @main(%go : i1, %reset : i1, %clk : i1) -> (%done: i1) {
     %z.go, %z.reset, %z.clk, %z.flag, %z.out, %z.done = calyx.instance "z" @Z : i1, i1, i1, i1, i2, i1
-    %fsm.in, %fsm.write_en, %fsm.clk, %fsm.reset, %fsm.out, %fsm.done = calyx.register "fsm" : i2
+    %fsm.in, %fsm.write_en, %fsm.clk, %fsm.reset, %fsm.out, %fsm.done = calyx.register "fsm" {portNames = ["in", "write_en", "clk", "reset", "out", "done"]} : i2
 
     calyx.wires {
       // CHECK: %[[FSM_IS_GROUP_A_BEGIN_STATE:.+]] = comb.icmp eq %fsm.out, {{.+}} : i2

--- a/test/Dialect/Calyx/remove-groups.mlir
+++ b/test/Dialect/Calyx/remove-groups.mlir
@@ -9,7 +9,7 @@ calyx.program {
   // CHECK-LABEL: calyx.component @main
   calyx.component @main(%go : i1, %reset : i1, %clk : i1) -> (%done: i1) {
     %z.go, %z.reset, %z.clk, %z.flag, %z.out, %z.done = calyx.instance "z" @Z : i1, i1, i1, i1, i2, i1
-    %fsm.in, %fsm.write_en, %fsm.clk, %fsm.reset, %fsm.out, %fsm.done = calyx.register "fsm" : i2
+    %fsm.in, %fsm.write_en, %fsm.clk, %fsm.reset, %fsm.out, %fsm.done = calyx.register "fsm" : i2, i1, i1, i1, i2, i1
 
     calyx.wires {
       // CHECK: %[[FSM_IS_GROUP_A_BEGIN_STATE:.+]] = comb.icmp eq %fsm.out, {{.+}} : i2

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -15,11 +15,11 @@ calyx.program {
   }
 
   calyx.component @main(%go: i1, %clk: i1, %reset: i1) -> (%done: i1) {
-    // CHECK:      %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8
+    // CHECK:      %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" {portNames = ["in", "write_en", "clk", "reset", "out", "done"]} : i8
     // CHECK-NEXT: %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i8, i1, i1, i1, i8, i1
     // CHECK-NEXT: %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance "c1" @A : i8, i1, i1, i1, i8, i1
     // CHECK-NEXT: %c2.go, %c2.clk, %c2.reset, %c2.out, %c2.done = calyx.instance "c2" @B : i1, i1, i1, i1, i1
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" {portNames = ["in", "write_en", "clk", "reset", "out", "done"]} : i8
     %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i8, i1, i1, i1, i8, i1
     %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance "c1" @A : i8, i1, i1, i1, i8, i1
     %c2.go, %c2.clk, %c2.reset, %c2.out, %c2.done = calyx.instance "c2" @B : i1, i1, i1, i1, i1

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -16,13 +16,13 @@ calyx.program {
 
   calyx.component @main(%go: i1, %clk: i1, %reset: i1) -> (%done: i1) {
     // CHECK:      %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8
-    // CHECK-NEXT: %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.cell "c0" @A : i8, i1, i1, i1, i8, i1
-    // CHECK-NEXT: %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.cell "c1" @A : i8, i1, i1, i1, i8, i1
-    // CHECK-NEXT: %c2.go, %c2.clk, %c2.reset, %c2.out, %c2.done = calyx.cell "c2" @B : i1, i1, i1, i1, i1
+    // CHECK-NEXT: %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i8, i1, i1, i1, i8, i1
+    // CHECK-NEXT: %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance "c1" @A : i8, i1, i1, i1, i8, i1
+    // CHECK-NEXT: %c2.go, %c2.clk, %c2.reset, %c2.out, %c2.done = calyx.instance "c2" @B : i1, i1, i1, i1, i1
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8
-    %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.cell "c0" @A : i8, i1, i1, i1, i8, i1
-    %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.cell "c1" @A : i8, i1, i1, i1, i8, i1
-    %c2.go, %c2.clk, %c2.reset, %c2.out, %c2.done = calyx.cell "c2" @B : i1, i1, i1, i1, i1
+    %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i8, i1, i1, i1, i8, i1
+    %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance "c1" @A : i8, i1, i1, i1, i8, i1
+    %c2.go, %c2.clk, %c2.reset, %c2.out, %c2.done = calyx.instance "c2" @B : i1, i1, i1, i1, i1
     %c1_i1 = constant 1 : i1
 
     calyx.wires {

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -15,11 +15,11 @@ calyx.program {
   }
 
   calyx.component @main(%go: i1, %clk: i1, %reset: i1) -> (%done: i1) {
-    // CHECK:      %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" {portNames = ["in", "write_en", "clk", "reset", "out", "done"]} : i8
+    // CHECK:      %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8
     // CHECK-NEXT: %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i8, i1, i1, i1, i8, i1
     // CHECK-NEXT: %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance "c1" @A : i8, i1, i1, i1, i8, i1
     // CHECK-NEXT: %c2.go, %c2.clk, %c2.reset, %c2.out, %c2.done = calyx.instance "c2" @B : i1, i1, i1, i1, i1
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" {portNames = ["in", "write_en", "clk", "reset", "out", "done"]} : i8
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8
     %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i8, i1, i1, i1, i8, i1
     %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance "c1" @A : i8, i1, i1, i1, i8, i1
     %c2.go, %c2.clk, %c2.reset, %c2.out, %c2.done = calyx.instance "c2" @B : i1, i1, i1, i1, i1

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -15,11 +15,11 @@ calyx.program {
   }
 
   calyx.component @main(%go: i1, %clk: i1, %reset: i1) -> (%done: i1) {
-    // CHECK:      %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8
+    // CHECK:      %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8, i1, i1, i1, i8, i1
     // CHECK-NEXT: %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i8, i1, i1, i1, i8, i1
     // CHECK-NEXT: %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance "c1" @A : i8, i1, i1, i1, i8, i1
     // CHECK-NEXT: %c2.go, %c2.clk, %c2.reset, %c2.out, %c2.done = calyx.instance "c2" @B : i1, i1, i1, i1, i1
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8, i1, i1, i1, i8, i1
     %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i8, i1, i1, i1, i8, i1
     %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance "c1" @A : i8, i1, i1, i1, i8, i1
     %c2.go, %c2.clk, %c2.reset, %c2.out, %c2.done = calyx.instance "c2" @B : i1, i1, i1, i1, i1


### PR DESCRIPTION
The `Cell` trait is used to annotate each sub-component within a component. This consists of primitives (e.g. `RegOp`) and component instances. This will be useful for future passes that want to work on `Cell`s, such as resource-sharing.

I've also renamed the `CellOp` to `InstanceOp`, and added a (hopefully) cleaner interface for primitives to minimize code duplication.