### PR TITLE
[FIRRTL][ExpandWhens] Simplify muxing of connected values

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -381,7 +381,7 @@ void WhenOpVisitor::visitStmt(WhenOp whenOp) {
     mergeBlock(*parentBlock, Block::iterator(whenOp), elseBlock);
   }
 
-  mergeScopes(thenScope, elseScope, thenCondition);
+  mergeScopes(thenScope, elseScope, condition);
 
   // Delete the now empty WhenOp.
   whenOp.erase();

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -288,12 +288,12 @@ firrtl.module @nested2(in %clock : !firrtl.clock, in %p0 : !firrtl.uint<1>, in %
 //CHECK-NEXT:   %0 = firrtl.and %p0, %p1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 //CHECK-NEXT:   %1 = firrtl.not %p1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
 //CHECK-NEXT:   %2 = firrtl.and %p0, %1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-//CHECK-NEXT:   %3 = firrtl.mux(%0, %c0_ui2, %c1_ui2) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
+//CHECK-NEXT:   %3 = firrtl.mux(%p1, %c0_ui2, %c1_ui2) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
 //CHECK-NEXT:   %4 = firrtl.not %p0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
 //CHECK-NEXT:   %5 = firrtl.and %4, %p1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 //CHECK-NEXT:   %6 = firrtl.not %p1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
 //CHECK-NEXT:   %7 = firrtl.and %4, %6 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-//CHECK-NEXT:   %8 = firrtl.mux(%5, %c2_ui2, %c3_ui2) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
+//CHECK-NEXT:   %8 = firrtl.mux(%p1, %c2_ui2, %c3_ui2) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
 //CHECK-NEXT:   %9 = firrtl.mux(%p0, %3, %8) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
 //CHECK-NEXT:   firrtl.connect %out, %9 : !firrtl.uint<2>, !firrtl.uint<2>
 //CHECK-NEXT: }


### PR DESCRIPTION
Expand whens takes the following code:
```firrtl
when a:
  x <= 1
else
  x <= 2
```
And transforms it turns it into the (desirable) code:
```firrtl
x <= mux(a, 1, 2)
```

However for nested whens, it was being overly pessimistic in the
condition of the mux.

Expand whens takes the following code:
```firrtl
when a:
  when b:
    x <= 1
  else:
    x <= 2
else
  x <= 3
```

And transforms it into
```firrtl
x <= mux(a, mux(a & b, 1, 2), 3)
```

When it should transform it into:
```firrtl
x <= mux(a, mux(b, 1, 2), 3)
```

In the code change `condition` refers to the condition of the current
WhenOp , and `thenCondition` refers to the all parent `WhenOp`
conditions `and`ed together.  The `thenCondition` is intended to be used
for simulation constructs which are copied directly into the module's
body.

The following example shows how `thenCondition` is used:
```firrtl
when a:
   when b:
     printf(clock, UInt<1>("h1"), "hi")
```

Here, `thenCondition` is `a & b`:
```firrtl
printf(clock, a & b & 1, "hi")
```