### PR TITLE
[FIRRTL][Parser] Stop removing no-op nodes when parsing

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2974,15 +2974,8 @@ ParseResult FIRStmtParser::parseNode() {
 
   // Ignore useless names like _T.
   auto name = hasDontTouch(annotations) ? id : filterUselessName(id);
-
-  // The entire point of a node declaration is to carry a name.  If it got
-  // dropped, then we don't even need to create a result unless it is annotated.
-  Value result;
-  if (!name.empty() || !annotations.empty()) {
-    result = builder.create<NodeOp>(initializer.getType(), initializer, name,
-                                    annotations);
-  } else
-    result = initializer;
+  Value result = builder.create<NodeOp>(initializer.getType(), initializer,
+                                        name, annotations);
   return moduleContext.addSymbolEntry(id, result, startTok.getLoc());
 }
 

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -359,13 +359,8 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ;  Test that _T and _GEN names are ignored by the parser.
     ; CHECK: %{{[0-9]+}} = firrtl.wire
     wire _T_42 : UInt<1>
-
-    ; Test that node decls with ignored names are not generated at all.
-    ; CHECK-NOT: firrtl.node
+    ; CHECK: %{{[0-9]+}} = firrtl.node
     node _GEN_43 = n12
-
-    ; CHECK: firrtl.andr %n12
-    node value = andr(_GEN_43)    ;; Uses n12 directly.
 
     ; CHECK: = firrtl.not %auto : (!firrtl.uint<1>) -> !firrtl.uint<1>
     node n13 = not(auto)
@@ -569,8 +564,9 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
   module flip_one :
     input bf: { flip int_1 : UInt<1>, int_out : UInt<2>}
     ; CHECK: %0 = firrtl.subfield %bf(0)
+    ; CHECK: %1 = firrtl.node %0
     node _T = bf.int_1
-    ; CHECK: firrtl.when %0 {
+    ; CHECK: firrtl.when %1 {
     when _T :
       skip
 


### PR DESCRIPTION
When a node is used as the address (aka index) of a CHIRRTL sequential
read-only memory port, the memory port is enabled at the declaration
location of the node op.  Nodes are being removed by the parser if they
don't carry any annotations. When the node op is removed by the parser,
the enable conditions of the memory change, and sometimes the memory
port is never enabled.

This change removes the small optimization from the FIRParser so that
the memory port enable can be properly inferred.  These node operations
will still be removed later on during canonicalization.