### PR TITLE
[firtool] Move CSE before HWCleanup

### DIFF
--- a/test/firtool/optimization-hw.fir
+++ b/test/firtool/optimization-hw.fir
@@ -1,0 +1,22 @@
+; RUN: firtool %s -lower-to-hw | FileCheck %s --check-prefix=OPT
+
+; Ensure that HW-related optimizations cause only a single always block to be
+; generated even if LowerToHW generates multiple always blocks.
+;
+; See: https://github.com/llvm/circt/issues/1594
+circuit test_cse_reg_reset :
+  module test_cse_reg_reset :
+    input clock : Clock
+    input reset : UInt<1>
+    input a: UInt<1>
+    output b : UInt<1>
+
+    wire reset_n: UInt<1>
+    reset_n <= not(reset)
+    reg r : UInt<1>, clock with: (reset => (reset_n, UInt(0)))
+    r <= a
+    b <= r
+
+    ; OPT-LABEL: @test_cse_reg_reset
+    ; OPT-COUNT-1: sv.alwaysff
+    ; OPT-NOT: sv.alwaysff

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -299,8 +299,8 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
     // If enabled, run the optimizer.
     if (!disableOptimization) {
       auto &modulePM = pm.nest<hw::HWModuleOp>();
-      modulePM.addPass(sv::createHWCleanupPass());
       modulePM.addPass(createCSEPass());
+      modulePM.addPass(sv::createHWCleanupPass());
       modulePM.addPass(createSimpleCanonicalizerPass());
     }
   }


### PR DESCRIPTION
Move CSE before HWCleanup to cause reset conditions to properly merge.
This avoids duplicate always block emission for situations where logic
may be applied to a reset wire resulting in multiple read_inout
statements.

Fixes #1594.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>