### PR TITLE
[firtool] Add --parse-only option

### DIFF
--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -2,6 +2,7 @@
 ; RUN: firtool %s --format=fir -mlir --annotation-file %s.anno.json | circt-opt | FileCheck %s --check-prefix=ANNOTATIONS
 ; RUN: firtool %s --format=fir -mlir -lower-to-hw | circt-opt | FileCheck %s --check-prefix=MLIRLOWER
 ; RUN: firtool %s --format=fir -verilog |             FileCheck %s --check-prefix=VERILOG
+; RUN: firtool %s --annotation-file %s.anno.json --mlir --parse-only | FileCheck %s --check-prefix=ANNOTATIONS
 
 circuit test_mod : %[[{"a": "a"}]]
 

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -66,6 +66,10 @@ static cl::opt<std::string>
                    cl::value_desc("filename"), cl::init("-"));
 
 static cl::opt<bool>
+    parseOnly("parse-only",
+              cl::desc("Stop after parsing inputs and annotations"));
+
+static cl::opt<bool>
     splitInputFile("split-input-file",
                    cl::desc("Split the input file into pieces and process each "
                             "chunk independently"),
@@ -218,6 +222,12 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
   }
   if (!module)
     return failure();
+
+  // If the user asked for just a parse, stop here.
+  if (parseOnly) {
+    auto outputTimer = ts.nest("Output");
+    return callback(module.release());
+  }
 
   // Apply any pass manager command line options.
   PassManager pm(&context);


### PR DESCRIPTION
Add a `--parse-only` option to `firtool` which causes the program to stop after the FIR/MLIR and annotation input files have been parsed and processed, and writes the resulting MLIR module to the output. This is interesting and useful since `firtool` performs a unique combination of input translation and annotation scattering that is not trivially reproduced with `circt-translate` and `circt-opt`. Useful for test case reduction.