### PR TITLE
[Calyx] Add IR support for calyx::WhileOp

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxControl.td
+++ b/include/circt/Dialect/Calyx/CalyxControl.td
@@ -115,7 +115,7 @@ def WhileOp : CalyxContainer<"while", [
   let arguments = (ins
     I1:$cond,
     FlatSymbolRefAttr:$groupName
-    );
+  );
   let description = [{
     The "calyx.while" operation represents a construct for continuously
     executing the inner groups of the 'while' operation while the condition port

--- a/include/circt/Dialect/Calyx/CalyxControl.td
+++ b/include/circt/Dialect/Calyx/CalyxControl.td
@@ -107,3 +107,32 @@ def EnableOp : CalyxOp<"enable", [
   let assemblyFormat = "$groupName attr-dict";
   let verifier = "return ::verify$cppClass(*this);";
 }
+
+def WhileOp : CalyxContainer<"while", [
+    ControlLike
+  ]> {
+  let summary = "Calyx While";
+  let arguments = (ins
+    I1:$cond,
+    FlatSymbolRefAttr:$groupName
+    );
+  let description = [{
+    The "calyx.while" operation represents a construct for continuously
+    executing the inner groups of the 'while' operation while the condition port
+    evaluates to true. The operands to a while operation is a 1-bit port and the
+    group under which this port is driven.
+
+    Note: The native and CIRCT Calyx IRs may diverge wrt. 'with' execution, see:
+    https://github.com/cucapra/calyx/discussions/588
+
+    ```mlir
+      calyx.while %1 with @G1 {
+        calyx.enable @G2
+        ...
+      }
+    ```
+  }];
+
+  let assemblyFormat = "$cond `with` $groupName $body attr-dict";
+  let verifier = "return ::verify$cppClass(*this);";
+}

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -208,3 +208,64 @@ calyx.program {
     }
   }
 }
+
+// -----
+
+calyx.program {
+  calyx.component @A(%go: i1, %clk: i1, %reset: i1) -> (%out: i1, %done: i1) {
+    calyx.wires {}
+    calyx.control {}
+  }
+  calyx.component @main(%in: i32, %go: i1, %clk: i1, %reset: i1) -> (%out: i32, %done: i1) {
+    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i1, i1, i1, i1, i1
+    %c1_1 = constant 1 : i1
+    calyx.wires { calyx.group @Group1 { calyx.group_done %c1_1 : i1 } }
+    calyx.control {
+      calyx.seq {
+        // expected-error @+1 {{empty body region.}}
+        calyx.while %c0.out with @Group1 {}
+      }
+    }
+  }
+}
+
+// -----
+
+calyx.program {
+  calyx.component @A(%go: i1, %clk: i1, %reset: i1) -> (%out: i1, %done: i1) {
+    calyx.wires {}
+    calyx.control {}
+  }
+  calyx.component @main(%in: i32, %go: i1, %clk: i1, %reset: i1) -> (%out: i32, %done: i1) {
+    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i1, i1, i1, i1, i1
+    calyx.wires { }
+    calyx.control {
+      calyx.seq {
+        // expected-error @+1 {{'calyx.while' op with group 'Group1', which does not exist.}}
+        calyx.while %c0.out with @Group1 {}
+      }
+    }
+  }
+}
+
+// -----
+
+calyx.program {
+  calyx.component @A(%go: i1, %clk: i1, %reset: i1) -> (%out: i1, %done: i1) {
+    calyx.wires {}
+    calyx.control {}
+  }
+  calyx.component @main(%in: i32, %go: i1, %clk: i1, %reset: i1) -> (%out: i32, %done: i1) {
+    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i1, i1, i1, i1, i1
+    %c1_1 = constant 1 : i1
+    calyx.wires { calyx.group @Group1 { calyx.group_done %c1_1 : i1 } }
+    calyx.control {
+      calyx.seq {
+        // expected-error @+1 {{conditional op: '%c0.out' expected to be driven from group: 'Group1' but no driver was found.}}
+        calyx.while %c0.out with @Group1 {
+          calyx.enable @Group1
+        }
+      }
+    }
+  }
+}

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -55,18 +55,26 @@ calyx.program {
       // CHECK-NEXT: calyx.if %c2.out with @Group2 {
       // CHECK-NEXT: calyx.enable @Group1
       // CHECK-NEXT: }
+      // CHECK-NEXT: calyx.while %c2.out with @Group2 {
+      // CHECK-NEXT: calyx.while %c2.out with @Group2 {
+      // CHECK-NEXT: calyx.enable @Group1
       calyx.seq {
         calyx.enable @Group1
         calyx.enable @Group2
         calyx.seq {
-            calyx.if %c2.out with @Group2 {
+          calyx.if %c2.out with @Group2 {
+            calyx.enable @Group1
+          } else {
+            calyx.enable @Group2
+          }
+          calyx.if %c2.out with @Group2 {
+            calyx.enable @Group1
+          }
+          calyx.while %c2.out with @Group2 {
+            calyx.while %c2.out with @Group2 {
               calyx.enable @Group1
-            } else {
-              calyx.enable @Group2
             }
-            calyx.if %c2.out with @Group2 {
-              calyx.enable @Group1
-            }
+          }
         }
       }
     }


### PR DESCRIPTION
This commit adds support for the Calyx While control operation. The operation takes two arguments; a 1-bit port and a group name. The op has a single body region representing the groups to execute when the condition evaluates to true.

This is solely for IR support and does not include:
- CalyxEmitter support (unsupported for all control ops as of now)
- CompileControl control FSM generation

Note: This PR is essentially the same as the IfOp #1582, so hopefully we worked out most of the issues there!