### PR TITLE
[FIRRTL][NFC] Add portAnnotations to FModule and FExtModule

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -60,14 +60,17 @@ def FModuleOp : FIRRTLOp<"module",
   }];
   let arguments =
             (ins StrArrayAttr:$portNames,
-                 DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations);
+                 DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations,
+                 DefaultValuedAttr<AnnotationArrayAttr, "{}">:$portAnnotations);
+
   let results = (outs);
   let regions = (region SizedRegion<1>:$body);
 
   let skipDefaultBuilders = 1;
   let builders = [
     OpBuilder<(ins "StringAttr":$name, "ArrayRef<ModulePortInfo>":$ports,
-               CArg<"ArrayAttr","{}">:$annotations)>
+               CArg<"ArrayAttr","ArrayAttr()">:$annotations,
+               CArg<"ArrayAttr","ArrayAttr()">:$portAnnotations)>
   ];
 
   let extraClassDeclaration = [{
@@ -138,8 +141,8 @@ def FExtModuleOp : FIRRTLOp<"extmodule",
   let arguments = (ins StrArrayAttr:$portNames,
                        OptionalAttr<StrAttr>:$defname,
                        OptionalAttr<DictionaryAttr>:$parameters,
-                       DefaultValuedAttr<AnnotationArrayAttr,
-                                         "{}">:$annotations);
+                       DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations,
+                       DefaultValuedAttr<AnnotationArrayAttr, "{}">:$portAnnotations);
   let results = (outs);
   let regions = (region AnyRegion:$body);
 
@@ -148,7 +151,8 @@ def FExtModuleOp : FIRRTLOp<"extmodule",
     OpBuilder<(ins "StringAttr":$name,
                       "ArrayRef<ModulePortInfo>":$ports,
                       CArg<"StringRef", "StringRef()">:$defnamAttr,
-                      CArg<"ArrayAttr", "{}">:$annotations)>
+                      CArg<"ArrayAttr", "ArrayAttr()">:$annotations,
+                      CArg<"ArrayAttr","ArrayAttr()">:$portAnnotations)>
   ];
 
   let extraClassDeclaration = [{

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -61,7 +61,7 @@ def FModuleOp : FIRRTLOp<"module",
   let arguments =
             (ins StrArrayAttr:$portNames,
                  DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations,
-                 DefaultValuedAttr<AnnotationArrayAttr, "{}">:$portAnnotations);
+                 DefaultValuedAttr<PortAnnotationsAttr, "{}">:$portAnnotations);
 
   let results = (outs);
   let regions = (region SizedRegion<1>:$body);
@@ -142,7 +142,7 @@ def FExtModuleOp : FIRRTLOp<"extmodule",
                        OptionalAttr<StrAttr>:$defname,
                        OptionalAttr<DictionaryAttr>:$parameters,
                        DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations,
-                       DefaultValuedAttr<AnnotationArrayAttr, "{}">:$portAnnotations);
+                       DefaultValuedAttr<PortAnnotationsAttr, "{}">:$portAnnotations);
   let results = (outs);
   let regions = (region AnyRegion:$body);
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -178,8 +178,19 @@ def SubAnnotationAttr
   let parameters = (ins "int64_t":$fieldID, "DictionaryAttr":$annotations);
 }
 
-def PortAnnotationsAttr : TypedArrayAttrBase<AnnotationArrayAttr,
-                                             "FIRRTL port annotations">;
+def PortAnnotationsAttr : ArrayAttrBase<
+    And<[
+      // Guarantee this is an ArrayAttr first
+      CPred<"$_self.isa<::mlir::ArrayAttr>()">,
+      // Guarantee all elements are DictionaryAttr or SubAnnotationAttr
+      CPred<"::llvm::all_of($_self.cast<::mlir::ArrayAttr>(), "
+            "[&](::mlir::Attribute attr) { return attr.isa<"
+            "::mlir::ArrayAttr,"
+            "::mlir::DictionaryAttr>();})">]>,
+    ""> {
+  let constBuilderCall = "$_builder.getArrayAttr($0)";
+}
+
 
 def InvalidValueAttr
   : AttrDef<FIRRTLDialect, "InvalidValue", [], "::mlir::Attribute"> {

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
@@ -51,10 +51,10 @@ firrtl.circuit "unprocessedAnnotations" {
 // expected-warning @+1 {{unprocessed annotation:'circuitOpAnnotation'}}
 firrtl.circuit "moduleAnno" attributes {annotations = [{class = "circuitOpAnnotation"}]} {
   // expected-warning @+1 {{unprocessed annotation:'a'}}
-  firrtl.module @moduleAnno(in %io_cpu_flush: !firrtl.uint<1>
-    {firrtl.annotations = [{class="a"}]}  ){  }
+  firrtl.module @moduleAnno(in %io_cpu_flush: !firrtl.uint<1>) attributes
+    {portAnnotations = [[{class="a"}]]} {  }
   // expected-warning @+1 {{unprocessed annotation:'b'}}
-  firrtl.extmodule @extModPorts(in %io_cpu_flush: !firrtl.uint<1> {firrtl.annotations = [{class="b"}]} )
+  firrtl.extmodule @extModPorts(in %io_cpu_flush: !firrtl.uint<1>) attributes {portAnnotations = [[{class="b"}]]}
   // expected-warning @+1 {{unprocessed annotation:'c'}}
   firrtl.extmodule @extMod(in %io_cpu_flush: !firrtl.uint<1>)
     attributes { annotations = [{class = "c"}] }
@@ -63,7 +63,7 @@ firrtl.circuit "moduleAnno" attributes {annotations = [{class = "circuitOpAnnota
     attributes { annotations = [{class = "d"}] } {}
   firrtl.module @foo2(in %io_cpu_flush: !firrtl.uint<1>)
     attributes { annotations = [{class = "b"}] } {}
-  firrtl.extmodule @extModPorts2(in %io_cpu_flush: !firrtl.uint<1> {firrtl.annotations = [{class="c"}]} )
+  firrtl.extmodule @extModPorts2(in %io_cpu_flush: !firrtl.uint<1>) attributes {portAnnotations = [[{class="c"}]]}
 }
 
 // -----

--- a/test/Dialect/FIRRTL/grand-central-taps.mlir
+++ b/test/Dialect/FIRRTL/grand-central-taps.mlir
@@ -10,21 +10,23 @@ firrtl.circuit "TestHarness" attributes {
   // CHECK-LABEL: firrtl.module @Bar
   // CHECK-NOT: class = "sifive.enterprise.grandcentral.ReferenceDataTapKey"
   firrtl.module @Bar(
-    in %clock: !firrtl.clock {firrtl.annotations = [{
+    in %clock: !firrtl.clock,
+    in %reset: !firrtl.reset,
+    in %in: !firrtl.uint<1>,
+    out %out: !firrtl.uint<1>
+  ) attributes
+   {portAnnotations = [ [ {
       class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
       id = 0 : i64,
       portID = 2 : i64,
       type = "source"
-    }]},
-    in %reset: !firrtl.reset {firrtl.annotations = [{
+    }], [{
       class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
       id = 0 : i64,
       portID = 3 : i64,
       type = "source"
-    }]},
-    in %in: !firrtl.uint<1>,
-    out %out: !firrtl.uint<1>
-  ) {
+    } ],[],[] ] }
+  {
     // CHECK-LABEL: %wire = firrtl.wire
     // CHECK-NOT: class = "sifive.enterprise.grandcentral.ReferenceDataTapKey"
     // CHECK-SAME: class = "firrtl.transforms.DontTouchAnnotation"
@@ -140,50 +142,60 @@ firrtl.circuit "TestHarness" attributes {
   // CHECK-NEXT: [[V0:%.+]] = firrtl.verbatim.expr "foo.bar.wire"
   // CHECK-NEXT: firrtl.connect %_0, [[V0]]
   firrtl.extmodule @DataTap(
-    out %_7: !firrtl.uint<1> {firrtl.annotations = [{
-      class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
-      id = 0 : i64,
-      portID = 8 : i64,
-      type = "portName" }]},
-    out %_6: !firrtl.uint<1> {firrtl.annotations = [{
-      class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
-      id = 0 : i64,
-      portID = 7 : i64,
-      type = "portName" }]},
-    out %_5: !firrtl.uint<1> {firrtl.annotations = [{
-      class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
-      id = 0 : i64,
-      portID = 6 : i64,
-      type = "portName" }]},
-    out %_4: !firrtl.uint<1> {firrtl.annotations = [{
-      class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
-      id = 0 : i64,
-      portID = 5 : i64,
-      type = "portName" }]},
-    out %_3: !firrtl.uint<1> {firrtl.annotations = [{
-      class = "sifive.enterprise.grandcentral.DataTapModuleSignalKey",
-      internalPath = "schwarzschild.no.more",
-      id = 0 : i64,
-      portID = 4 : i64 }]},
-    out %_2: !firrtl.uint<1> {firrtl.annotations = [{
-      class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
-      id = 0 : i64,
-      portID = 3 : i64,
-      type = "portName" }]},
-    out %_1: !firrtl.clock {firrtl.annotations = [{
-      class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
-      id = 0 : i64,
-      portID = 2 : i64,
-      type = "portName" }]},
-    out %_0: !firrtl.uint<1> {firrtl.annotations = [{
-      class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
-      id = 0 : i64,
-      portID = 1 : i64,
-      type = "portName" }]}
+    out %_7: !firrtl.uint<1>,
+    out %_6: !firrtl.uint<1>,
+    out %_5: !firrtl.uint<1>,
+    out %_4: !firrtl.uint<1>,
+    out %_3: !firrtl.uint<1>,
+    out %_2: !firrtl.uint<1>,
+    out %_1: !firrtl.clock,
+    out %_0: !firrtl.uint<1>
   ) attributes {
     annotations = [
       { class = "sifive.enterprise.grandcentral.DataTapsAnnotation" },
       { class = "firrtl.transforms.NoDedupAnnotation" }
+    ],
+    portAnnotations = [
+      [{
+      class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
+      id = 0 : i64,
+      portID = 8 : i64,
+      type = "portName" }],
+      [{
+      class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
+      id = 0 : i64,
+      portID = 7 : i64,
+      type = "portName" }],
+      [{
+      class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
+      id = 0 : i64,
+      portID = 6 : i64,
+      type = "portName" }],
+      [{
+      class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
+      id = 0 : i64,
+      portID = 5 : i64,
+      type = "portName" }],
+      [{
+      class = "sifive.enterprise.grandcentral.DataTapModuleSignalKey",
+      internalPath = "schwarzschild.no.more",
+      id = 0 : i64,
+      portID = 4 : i64 }],
+      [{
+      class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
+      id = 0 : i64,
+      portID = 3 : i64,
+      type = "portName" }],
+      [{
+      class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
+      id = 0 : i64,
+      portID = 2 : i64,
+      type = "portName" }],
+      [{
+      class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
+      id = 0 : i64,
+      portID = 1 : i64,
+      type = "portName" }]
     ],
     defname = "DataTap"
   }
@@ -198,16 +210,20 @@ firrtl.circuit "TestHarness" attributes {
   // CHECK-NEXT: [[V1:%.+]] = firrtl.verbatim.expr "foo.bar.mem.Memory[1]"
   // CHECK-NEXT: firrtl.connect %mem_1, [[V1:%.+]]
   firrtl.extmodule @MemTap(
-    out %mem_0: !firrtl.uint<1> {firrtl.annotations = [{
-      class = "sifive.enterprise.grandcentral.MemTapAnnotation",
-      id = 4 : i64 }]},
-    out %mem_1: !firrtl.uint<1> {firrtl.annotations = [{
-      class = "sifive.enterprise.grandcentral.MemTapAnnotation",
-      id = 4 : i64 }]}
+    out %mem_0: !firrtl.uint<1>,
+    out %mem_1: !firrtl.uint<1> 
   ) attributes {
     annotations = [
       {class = "firrtl.transforms.NoDedupAnnotation"}
     ],
+    portAnnotations = [
+ [{
+      class = "sifive.enterprise.grandcentral.MemTapAnnotation",
+      id = 4 : i64 }],
+    [{
+      class = "sifive.enterprise.grandcentral.MemTapAnnotation",
+      id = 4 : i64 }]
+      ],
     defname = "MemTap"
   }
 
@@ -222,12 +238,11 @@ firrtl.circuit "TestHarness" attributes {
   }
 
   firrtl.extmodule @ExtmoduleWithTappedPort(
-    out %out: !firrtl.uint<1> {firrtl.annotations = [{
+    out %out: !firrtl.uint<1>) attributes {portAnnotations = [[{
       class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
       id = 0 : i64,
       portID = 8 : i64,
-      type = "source" }]}
-  )
+      type = "source" }]]}
 
   // CHECK: firrtl.module @TestHarness
   firrtl.module @TestHarness(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -185,13 +185,13 @@ firrtl.circuit "InterfacePort" attributes {
        {description = "description of foo",
         name = "foo",
         tpe = "sifive.enterprise.grandcentral.AugmentedGroundType"}]}]} {
-  firrtl.module @InterfacePort(in %a : !firrtl.uint<4> {
-    firrtl.annotations = [
+  firrtl.module @InterfacePort(in %a : !firrtl.uint<4>) attributes {
+    portAnnotations = [[
       {a},
       {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
        defName = "Foo",
        name = "foo",
-       target = []}]}) {
+       target = []}]] } {
   }
 }
 
@@ -279,21 +279,23 @@ firrtl.circuit "BindInterfaceTest"  attributes {
     }]
   }]} {
   firrtl.module @BindInterfaceTest(
-    in %a: !firrtl.uint<8> {
-      firrtl.annotations = [
-        #firrtl.subAnno<fieldID = 0, {
-          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-          defName = "InterfaceName",
-          name = "_a"}>
-      ]},
-    out %b: !firrtl.uint<8>) attributes {
+    in %a: !firrtl.uint<8>, out %b: !firrtl.uint<8>) attributes {
       annotations = [{
         class = "sifive.enterprise.grandcentral.ViewAnnotation",
         defName = "InterfaceName",
         id = 0 : i64,
         name = "instanceName",
         type = "parent"
-      }]} {
+      }],
+      portAnnotations = [[
+        #firrtl.subAnno<fieldID = 0, {
+          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+          defName = "InterfaceName",
+          name = "_a"}>
+      ], []
+      ]
+    }
+      {
     firrtl.connect %b, %a : !firrtl.uint<8>, !firrtl.uint<8>
   }
 }

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -172,7 +172,9 @@ firrtl.circuit "Issue1188"  {
 // DontTouch annotation should block constant propagation.
 firrtl.circuit "testDontTouch"  {
   // CHECK-LABEL: firrtl.module @blockProp
-  firrtl.module @blockProp1(in %clock: !firrtl.clock, in %a: !firrtl.uint<1> {firrtl.annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]}, out %b: !firrtl.uint<1>) {
+  firrtl.module @blockProp1(in %clock: !firrtl.clock, in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) attributes {
+    portAnnotations = [[], [{class = "firrtl.transforms.DontTouchAnnotation"}],[]]
+  }{
     //CHECK: %c = firrtl.reg
     %c = firrtl.reg %clock : !firrtl.uint<1>
     firrtl.connect %c, %a : !firrtl.uint<1>, !firrtl.uint<1>
@@ -222,7 +224,8 @@ firrtl.circuit "testDontTouch"  {
 }
 
 firrtl.circuit "OutPortTop" {
-    firrtl.module @OutPortChild1(out %out: !firrtl.uint<1> {firrtl.annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]}) {
+    firrtl.module @OutPortChild1(out %out: !firrtl.uint<1>) attributes {
+      portAnnotations =[[{class = "firrtl.transforms.DontTouchAnnotation"}]]} {
       %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
       firrtl.connect %out, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     }
@@ -250,7 +253,9 @@ firrtl.circuit "InputPortTop"   {
     firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   }
   // CHECK-LABEL: firrtl.module @InputPortChild
-  firrtl.module @InputPortChild(in %in0: !firrtl.uint<1>, in %in1: !firrtl.uint<1> {firrtl.annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]}, out %out: !firrtl.uint<1>) {
+  firrtl.module @InputPortChild(in %in0: !firrtl.uint<1>, in %in1: !firrtl.uint<1>, out %out: !firrtl.uint<1>) attributes {
+    portAnnotations = [[], [{class = "firrtl.transforms.DontTouchAnnotation"}], []]
+  } {
     // CHECK: %0 = firrtl.and %in0, %in1
     %0 = firrtl.and %in0, %in1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/infer-resets-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-resets-errors.mlir
@@ -162,7 +162,7 @@ firrtl.circuit "top" {
 // Ignore reset annotation cannot target port
 firrtl.circuit "top" {
   // expected-error @+1 {{IgnoreFullAsyncResetAnnotation' cannot target port; must target module instead}}
-  firrtl.module @top(in %reset: !firrtl.asyncreset {firrtl.annotations = [{class = "sifive.enterprise.firrtl.IgnoreFullAsyncResetAnnotation"}]}) {
+  firrtl.module @top(in %reset: !firrtl.asyncreset) attributes {portAnnotations =[[{class = "sifive.enterprise.firrtl.IgnoreFullAsyncResetAnnotation"}]]} {
   }
 }
 
@@ -186,7 +186,7 @@ firrtl.circuit "top" {
 firrtl.circuit "top" {
   // expected-error @+2 {{multiple reset annotations on module 'top'}}
   // expected-note @+1 {{conflicting "sifive.enterprise.firrtl.FullAsyncResetAnnotation":}}
-  firrtl.module @top(in %outerReset: !firrtl.asyncreset {firrtl.annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]}) {
+  firrtl.module @top(in %outerReset: !firrtl.asyncreset) attributes {portAnnotations = [[{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]]} {
     // expected-note @+1 {{conflicting "sifive.enterprise.firrtl.FullAsyncResetAnnotation":}}
     %innerReset = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]} : !firrtl.asyncreset
     // expected-note @+1 {{conflicting "sifive.enterprise.firrtl.FullAsyncResetAnnotation":}}
@@ -202,7 +202,7 @@ firrtl.circuit "Top" {
     %reg = firrtl.reg %clock : !firrtl.uint<8>
   }
   // expected-note @+1 {{reset domain 'otherReset' of module 'Child' declared here:}}
-  firrtl.module @Child(in %clock: !firrtl.clock, in %otherReset: !firrtl.asyncreset {firrtl.annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]}) {
+  firrtl.module @Child(in %clock: !firrtl.clock, in %otherReset: !firrtl.asyncreset) attributes {portAnnotations = [[],[{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]]} {
     // expected-note @+1 {{instance 'child/inst' is in reset domain rooted at 'otherReset' of module 'Child'}}
     %inst_clock = firrtl.instance @Foo {name = "inst"} : !firrtl.clock
     firrtl.connect %inst_clock, %clock : !firrtl.clock, !firrtl.clock
@@ -213,7 +213,7 @@ firrtl.circuit "Top" {
     firrtl.connect %inst_clock, %clock : !firrtl.clock, !firrtl.clock
   }
   // expected-note @+1 {{reset domain 'reset' of module 'Top' declared here:}}
-  firrtl.module @Top(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset {firrtl.annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]}) {
+  firrtl.module @Top(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset) attributes {portAnnotations = [[],[{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]]} {
     %child_clock, %child_otherReset = firrtl.instance @Child {name = "child"} : !firrtl.clock, !firrtl.asyncreset
     %other_clock = firrtl.instance @Other {name = "other"} : !firrtl.clock
     // expected-note @+1 {{instance 'foo' is in reset domain rooted at 'reset' of module 'Top'}}

--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -342,7 +342,7 @@ firrtl.module @ConsumeIgnoreAnno() attributes {annotations = [{class = "sifive.e
 
 // CHECK-LABEL: firrtl.module @ConsumeResetAnnoPort
 // CHECK-NOT: FullAsyncResetAnnotation
-firrtl.module @ConsumeResetAnnoPort(in %outerReset: !firrtl.asyncreset {firrtl.annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]}) {
+firrtl.module @ConsumeResetAnnoPort(in %outerReset: !firrtl.asyncreset) attributes {portAnnotations = [[{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]]} {
 }
 
 // CHECK-LABEL: firrtl.module @ConsumeResetAnnoWire
@@ -358,7 +358,8 @@ firrtl.module @ConsumeResetAnnoWire(in %outerReset: !firrtl.asyncreset) {
 // Reset-less registers should inherit the annotated async reset signal.
 firrtl.circuit "Top" {
   // CHECK-LABEL: firrtl.module @Top
-  firrtl.module @Top(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %init: !firrtl.uint<1>, in %in: !firrtl.uint<8>, in %extraReset: !firrtl.asyncreset {firrtl.annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}, {class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]}) {
+  firrtl.module @Top(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %init: !firrtl.uint<1>, in %in: !firrtl.uint<8>, in %extraReset: !firrtl.asyncreset ) attributes {
+    portAnnotations = [[],[],[],[],[{class = "firrtl.transforms.DontTouchAnnotation"}, {class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]]} {
     %c1_ui8 = firrtl.constant 1 : !firrtl.uint<8>
     // CHECK: %reg1 = firrtl.regreset %clock, %extraReset, %c0_ui8
     %reg1 = firrtl.reg %clock : !firrtl.uint<8>
@@ -422,7 +423,8 @@ firrtl.circuit "Top" {
 // types.
 firrtl.circuit "Top" {
   // CHECK-LABEL: firrtl.module @Top
-  firrtl.module @Top(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset {firrtl.annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]}) {
+  firrtl.module @Top(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset) attributes {
+    portAnnotations = [[],[{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]]} {
     // CHECK: %c0_ui = firrtl.constant 0 : !firrtl.uint
     // CHECK: %reg_uint = firrtl.regreset %clock, %reset, %c0_ui
     %reg_uint = firrtl.reg %clock : !firrtl.uint
@@ -484,7 +486,8 @@ firrtl.circuit "ReusePorts" {
     %reg = firrtl.reg %clock : !firrtl.uint<8>
   }
   // CHECK-LABEL: firrtl.module @ReusePorts
-  firrtl.module @ReusePorts(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset {firrtl.annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]}) {
+  firrtl.module @ReusePorts(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset) attributes {
+    portAnnotations = [[],[{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]]} {
     // CHECK: %child_clock, %child_reset = firrtl.instance @Child
     // CHECK: firrtl.connect %child_reset, %reset
     // CHECK: %badName_reset, %badName_clock, %badName_existingReset = firrtl.instance @BadName
@@ -522,7 +525,8 @@ firrtl.circuit "FullAsyncNested" {
     firrtl.connect %io_out, %1 : !firrtl.uint<8>, !firrtl.uint<8>
   }
   // CHECK-LABEL: firrtl.module @FullAsyncNested
-  firrtl.module @FullAsyncNested(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset {firrtl.annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}, {class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]}, in %io_in: !firrtl.uint<8>, out %io_out: !firrtl.uint<8>) {
+  firrtl.module @FullAsyncNested(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %io_in: !firrtl.uint<8>, out %io_out: !firrtl.uint<8>) attributes {
+    portAnnotations=[[],[{class = "firrtl.transforms.DontTouchAnnotation"}, {class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}], [], []] } {
     %inst_clock, %inst_reset, %inst_io_in, %inst_io_out = firrtl.instance @FullAsyncNestedChild  {name = "inst"} : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %inst_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %inst_reset, %reset : !firrtl.asyncreset, !firrtl.asyncreset
@@ -545,7 +549,8 @@ firrtl.circuit "FullAsyncExcluded" {
     firrtl.connect %io_out, %io_out_REG : !firrtl.uint<8>, !firrtl.uint<8>
   }
   // CHECK-LABEL: firrtl.module @FullAsyncExcluded
-  firrtl.module @FullAsyncExcluded(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %io_in: !firrtl.uint<8>, out %io_out: !firrtl.uint<8>, in %extraReset: !firrtl.asyncreset {firrtl.annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}, {class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]}) {
+  firrtl.module @FullAsyncExcluded(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %io_in: !firrtl.uint<8>, out %io_out: !firrtl.uint<8>, in %extraReset: !firrtl.asyncreset) attributes {
+     portAnnotations = [[],[],[],[],[{class = "firrtl.transforms.DontTouchAnnotation"}, {class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]]} {
     // CHECK: %inst_clock, %inst_reset, %inst_io_in, %inst_io_out = firrtl.instance @FullAsyncExcludedChild
     %inst_clock, %inst_reset, %inst_io_in, %inst_io_out = firrtl.instance @FullAsyncExcludedChild  {name = "inst"} : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %inst_clock, %clock : !firrtl.clock, !firrtl.clock

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -833,7 +833,7 @@ firrtl.circuit "TopLevel" {
 // matching fieldIDs.  Any other arg attributes should be copied.
     // The annotation should be copied to just a.a.  The firrtl.hello arg
     // attribute should be copied to each new port.
-    firrtl.module @PortBundle(in %a: !firrtl.bundle<a: uint<1>, b flip: uint<1>> {firrtl.annotations = [#firrtl.subAnno<fieldID = 1, {a}>], firrtl.hello}) {}
+    firrtl.module @PortBundle(in %a: !firrtl.bundle<a: uint<1>, b flip: uint<1>> {firrtl.hello}) attributes {portAnnotations = [[#firrtl.subAnno<fieldID = 1, {a}>]]} {}
     // CHECK-LABEL: firrtl.module @PortBundle
     // CHECK-COUNT-1: firrtl.annotations = [{a}]
     // CHECK-COUNT-2: firrtl.hello
@@ -842,7 +842,7 @@ firrtl.circuit "TopLevel" {
 
     // The annotation should be copied to just a[0].  The firrtl.world arg
     // attribute should be copied to each port.
-    firrtl.extmodule @PortVector(in %a: !firrtl.vector<uint<1>, 2> {firrtl.annotations = [#firrtl.subAnno<fieldID = 1, {b}>], firrtl.world})
+    firrtl.extmodule @PortVector(in %a: !firrtl.vector<uint<1>, 2> {firrtl.world}) attributes {portAnnotations = [[#firrtl.subAnno<fieldID = 1, {b}>]]}
     // CHECK-LABEL: firrtl.extmodule @PortVector
     // CHECK-COUNT-1: firrtl.annotations = [{b}]
     // CHECK-COUNT-2: firrtl.world


### PR DESCRIPTION
Add an explicit attribute for port annotations to FModule and FExtModule.  Adding a common name for port annotations, similar to instance, mem, etc, makes manipulating annotations simpler.  Although this could be folded into argattr, having it in the same format as used in other ops makes annotation scatting able to be operation type invariant, thus simplifying it.