### PR TITLE
[Comb] Add KnownBitsAnalysis Pass

### DIFF
--- a/include/circt/Dialect/Comb/CombOps.h
+++ b/include/circt/Dialect/Comb/CombOps.h
@@ -68,6 +68,12 @@ struct KnownBitAnalysis {
   APInt getBitsKnown() const { return ones | zeros; }
 };
 
+/// Register Comb passes to print analysis information.
+void registerCombAnalysisPasses();
+
+/// Register all Comb-related passes.
+void registerCombPasses();
+
 } // namespace comb
 } // namespace circt
 

--- a/include/circt/InitAllPasses.h
+++ b/include/circt/InitAllPasses.h
@@ -16,6 +16,7 @@
 
 #include "circt/Conversion/Passes.h"
 #include "circt/Dialect/Calyx/CalyxPasses.h"
+#include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/ESI/ESIDialect.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/LLHD/Transforms/Passes.h"
@@ -35,6 +36,9 @@ inline void registerAllPasses() {
   llhd::initLLHDTransformationPasses();
   seq::registerSeqPasses();
   sv::registerPasses();
+
+  // Analysis passes
+  comb::registerCombPasses();
 }
 
 } // namespace circt

--- a/include/circt/InitAllPasses.h
+++ b/include/circt/InitAllPasses.h
@@ -31,14 +31,12 @@ inline void registerAllPasses() {
 
   // Standard Passes
   calyx::registerPasses();
+  comb::registerCombPasses();
   esi::registerESIPasses();
   firrtl::registerPasses();
   llhd::initLLHDTransformationPasses();
   seq::registerSeqPasses();
   sv::registerPasses();
-
-  // Analysis passes
-  comb::registerCombPasses();
 }
 
 } // namespace circt

--- a/lib/Dialect/Comb/CombPasses.cpp
+++ b/lib/Dialect/Comb/CombPasses.cpp
@@ -1,0 +1,5 @@
+#include "circt/Dialect/Comb/CombOps.h"
+
+void circt::comb::registerCombPasses() {
+  circt::comb::registerCombAnalysisPasses();
+}

--- a/tools/circt-opt/CMakeLists.txt
+++ b/tools/circt-opt/CMakeLists.txt
@@ -11,6 +11,7 @@ target_link_libraries(circt-opt
   CIRCTCalyx
   CIRCTCalyxToHW
   CIRCTCalyxTransforms
+  CIRCTComb
   CIRCTESI
   CIRCTFIRRTL
   CIRCTFIRRTLToHW


### PR DESCRIPTION
This pass prints out known bits in a mlir module. This generally useful  for debugging when writing more complicated passes that makes use of KnownBits information.

For example, the following IR:

```mlir
hw.module @Foo(%a: i8, %b: i8) -> (%out: i9) {
  %true = hw.constant 1 : i1
  %0 = comb.concat %a, %true : (i8, i1) -> i9
  %1 = comb.concat %b, %true : (i8, i1) -> i9
  %2 = comb.and %0, %1 : i9
  hw.output %2 : i9
}
```

Gets the following output:

```
% ./bin/circt-opt --known-bits-analysis a.mlir 1>/dev/null                                      
module Foo
  %true = hw.constant true
    result[0]: 
      One  bits: 0x1
      Zero bits: 0x0
  %0 = comb.concat %a, %true : (i8, i1) -> i9
    result[0]: 
      One  bits: 0x1
      Zero bits: 0x0
  %1 = comb.concat %b, %true : (i8, i1) -> i9
    result[0]: 
      One  bits: 0x1
      Zero bits: 0x0
  %2 = comb.and %0, %1 : i9
    result[0]: 
      One  bits: 0x1
      Zero bits: 0x0
  hw.output %2 : i9
```