### PR TITLE
[firtool] move BlackboxMemory before LowerTypes 

### DIFF
--- a/test/firtool/chirrtl.fir
+++ b/test/firtool/chirrtl.fir
@@ -1,0 +1,31 @@
+; RUN: firtool -blackbox-memory -verilog %s | FileCheck %s
+
+; This is testing that CHIRRTL enable inference is working as intended.  If the
+; no-op wires and nodes are not optimized away, then both ports should always
+; be enabled.  If they are accidentally removed before the lower-chirrtl pass,
+; then they won't be enabled.
+
+circuit test:
+  module test:
+    input p: UInt<1>
+    input addr: UInt<4>
+    input clock: Clock
+    output out0: UInt<8>
+    output out1: UInt<8>
+
+    ; CHECK: testmem testmem (
+    smem testmem : UInt<8>[16]
+
+    ; CHECK: .testport0_en   (1'h1),
+    node _T_0 = addr
+    when p:
+      read mport testport0 = testmem[_T_0], clock
+    out0 <= testport0
+
+    ; CHECK: .testport1_en   (1'h1),
+    wire _T_1: UInt<4>
+    _T_1 <= addr
+    when p:
+      read mport testport1 = testmem[_T_1], clock
+    out1 <= testport1
+

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -257,6 +257,9 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
   if (inferResets)
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInferResetsPass());
 
+  if (blackBoxMemory)
+    pm.nest<firrtl::CircuitOp>().addPass(firrtl::createBlackBoxMemoryPass());
+
   // The input mlir file could be firrtl dialect so we might need to clean
   // things up.
   if (lowerTypes) {
@@ -281,9 +284,6 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
 
   if (imconstprop)
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createIMConstPropPass());
-
-  if (blackBoxMemory)
-    pm.nest<firrtl::CircuitOp>().addPass(firrtl::createBlackBoxMemoryPass());
 
   // Read black box source files into the IR.
   StringRef blackBoxRoot = blackBoxRootPath.empty()


### PR DESCRIPTION
BlackboxMemory should run before LowerTypes, as it can create modules inputs and outputs with bundle types.  This adds a CHIRRTL integration test that checks the enable inference and memory blackboxing is working with firtool.