### PR TITLE
[Scheduling] [1/3] Add scheduler for shared pipelined operators problem: Preparations.

### DIFF
--- a/include/circt/Scheduling/Algorithms.h
+++ b/include/circt/Scheduling/Algorithms.h
@@ -37,6 +37,13 @@ LogicalResult scheduleSimplex(Problem &prob, Operation *lastOp);
 /// cycles that do not include at least one edge with a non-zero distance.
 LogicalResult scheduleSimplex(CyclicProblem &prob, Operation *lastOp);
 
+/// Solve the acyclic problem with shared pipelined operators using a linear
+/// programming-based heuristic. The approach tries to minimize the start time
+/// of the given \p lastOp, but optimality is not guaranteed. Fails if the
+/// dependence graph contains cycles.
+LogicalResult scheduleSimplex(SharedPipelinedOperatorsProblem &prob,
+                              Operation *lastOp);
+
 } // namespace scheduling
 } // namespace circt
 

--- a/test/Scheduling/cyclic-problems.mlir
+++ b/test/Scheduling/cyclic-problems.mlir
@@ -1,5 +1,5 @@
 // RUN: circt-opt %s -test-cyclic-problem
-// RUN: circt-opt %s -test-simplex-scheduler | FileCheck %s -check-prefix=SIMPLEX
+// RUN: circt-opt %s -test-simplex-scheduler=with=CyclicProblem | FileCheck %s -check-prefix=SIMPLEX
 
 // SIMPLEX-LABEL: cyclic
 // SIMPLEX-SAME: simplexInitiationInterval = 2

--- a/test/Scheduling/problems.mlir
+++ b/test/Scheduling/problems.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt %s -test-scheduling-problem -allow-unregistered-dialect
 // RUN: circt-opt %s -test-asap-scheduler -allow-unregistered-dialect | FileCheck %s -check-prefix=ASAP
-// RUN: circt-opt %s -test-simplex-scheduler=acyclic -allow-unregistered-dialect | FileCheck %s -check-prefix=SIMPLEX
+// RUN: circt-opt %s -test-simplex-scheduler=with=Problem -allow-unregistered-dialect | FileCheck %s -check-prefix=SIMPLEX
 
 // ASAP-LABEL: unit_latencies
 // SIMPLEX-LABEL: unit_latencies

--- a/test/Scheduling/simplex-errors.mlir
+++ b/test/Scheduling/simplex-errors.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s -test-simplex-scheduler -verify-diagnostics -split-input-file
+// RUN: circt-opt %s -test-simplex-scheduler=with=CyclicProblem -verify-diagnostics -split-input-file
 
 // expected-error@+2 {{problem is infeasible}}
 // expected-error@+1 {{scheduling failed}}

--- a/test/Scheduling/spo-problems.mlir
+++ b/test/Scheduling/spo-problems.mlir
@@ -1,38 +1,55 @@
-// RUN: circt-opt %s -test-spo-problem
+// RUN: circt-opt %s -test-spo-problem -allow-unregistered-dialect
+// RUN: circt-opt %s -test-simplex-scheduler=with=SharedPipelinedOperatorsProblem -allow-unregistered-dialect | FileCheck %s -check-prefix=SIMPLEX
+// XFAIL: *
 
+// SIMPLEX-LABEL: full_load
 func @full_load(%a0 : i32, %a1 : i32, %a2 : i32, %a3 : i32, %a4 : i32, %a5 : i32) -> i32 attributes {
   operatortypes = [
-    { name = "add", latency = 3, limit = 1}
+    { name = "add", latency = 3, limit = 1 },
+    { name = "_0", latency = 0 }
   ] } {
   %0 = addi %a0, %a1 { opr = "add", problemStartTime = 0 } : i32
   %1 = addi %a1, %a1 { opr = "add", problemStartTime = 1 } : i32
   %2 = addi %a2, %a3 { opr = "add", problemStartTime = 2 } : i32
   %3 = addi %a3, %a4 { opr = "add", problemStartTime = 3 } : i32
   %4 = addi %a4, %a5 { opr = "add", problemStartTime = 4 } : i32
-  return { problemStartTime = 7 } %4 : i32
+  %5 = "barrier"(%0, %1, %2, %3, %4) { opr = "_0", problemStartTime = 7 } : (i32, i32, i32, i32, i32) -> i32
+  // SIMPLEX: return
+  // SIMPLEX-SAME: simplexStartTime = 7
+  return { problemStartTime = 7 } %5 : i32
 }
 
+// SIMPLEX-LABEL: partial_load
 func @partial_load(%a0 : i32, %a1 : i32, %a2 : i32, %a3 : i32, %a4 : i32, %a5 : i32) -> i32 attributes {
   operatortypes = [
-    { name = "add", latency = 3, limit = 3}
+    { name = "add", latency = 3, limit = 3},
+    { name = "_0", latency = 0 }
   ] } {
   %0 = addi %a0, %a1 { opr = "add", problemStartTime = 0 } : i32
   %1 = addi %a1, %a1 { opr = "add", problemStartTime = 1 } : i32
   %2 = addi %a2, %a3 { opr = "add", problemStartTime = 0 } : i32
   %3 = addi %a3, %a4 { opr = "add", problemStartTime = 2 } : i32
   %4 = addi %a4, %a5 { opr = "add", problemStartTime = 1 } : i32
-  return { problemStartTime = 10 } %4 : i32
+  %5 = "barrier"(%0, %1, %2, %3, %4) { opr = "_0", problemStartTime = 10 } : (i32, i32, i32, i32, i32) -> i32
+  // SIMPLEX: return
+  // SIMPLEX-SAME: simplexStartTime = 4
+  return { problemStartTime = 10 } %5 : i32
 }
 
+// SIMPLEX-LABEL: multiple
 func @multiple(%a0 : i32, %a1 : i32, %a2 : i32, %a3 : i32, %a4 : i32, %a5 : i32) -> i32 attributes {
   operatortypes = [
     { name = "slowAdd", latency = 3, limit = 2},
-    { name = "fastAdd", latency = 1, limit = 1}
+    { name = "fastAdd", latency = 1, limit = 1},
+    { name = "_0", latency = 0 }
   ] } {
   %0 = addi %a0, %a1 { opr = "slowAdd", problemStartTime = 0 } : i32
   %1 = addi %a1, %a1 { opr = "slowAdd", problemStartTime = 1 } : i32
   %2 = addi %a2, %a3 { opr = "fastAdd", problemStartTime = 0 } : i32
   %3 = addi %a3, %a4 { opr = "slowAdd", problemStartTime = 1 } : i32
   %4 = addi %a4, %a5 { opr = "fastAdd", problemStartTime = 1 } : i32
-  return { problemStartTime = 10 } %4 : i32
+  %5 = "barrier"(%0, %1, %2, %3, %4) { opr = "_0", problemStartTime = 10 } : (i32, i32, i32, i32, i32) -> i32
+  // SIMPLEX: return
+  // SIMPLEX-SAME: simplexStartTime = 4
+  return { problemStartTime = 10 } %5 : i32
 }


### PR DESCRIPTION
First part of a patch series that adds a heuristic scheduler for the (resource-constrained) `SharedPipelinedOperatorsProblem`. Here, I do some necessary preparations that would otherwise dilute the diffs in the following PRs with the actual implementation.

- Add parameter S to the simplex tableau.
- Keep track of variable locations in the tableau.
- Add entry point in Algorithms.h.
- Set up test pass, prepare test cases.