### PR TITLE
[Scheduling] [3/3] Add scheduler for shared pipelined operators problem: Heuristic algorithm.

### DIFF
--- a/test/Scheduling/spo-problems.mlir
+++ b/test/Scheduling/spo-problems.mlir
@@ -1,6 +1,5 @@
 // RUN: circt-opt %s -test-spo-problem -allow-unregistered-dialect
 // RUN: circt-opt %s -test-simplex-scheduler=with=SharedPipelinedOperatorsProblem -allow-unregistered-dialect | FileCheck %s -check-prefix=SIMPLEX
-// XFAIL: *
 
 // SIMPLEX-LABEL: full_load
 func @full_load(%a0 : i32, %a1 : i32, %a2 : i32, %a3 : i32, %a4 : i32, %a5 : i32) -> i32 attributes {


### PR DESCRIPTION
Final part of a patch series that adds a heuristic scheduler for the (resource-constrained) `SharedPipelinedOperatorsProblem`. This implements the actual algorithm, and enables the tests.