### PR TITLE
[HWMemSimImpl] Remove procedural assign to wire

### DIFF
--- a/test/Dialect/SV/hw-memsim.mlir
+++ b/test/Dialect/SV/hw-memsim.mlir
@@ -28,22 +28,19 @@ hw.module.generated @FIRRTLMem_1_1_1_16_10_0_1_0, @FIRRTLMem(%ro_clock_0: i1, %r
 //CHECK-NEXT:  %[[readres:.+]] = comb.mux %ro_en_0, %[[read]], %[[x]]
 //CHECK-NEXT:  %[[rwtmp:.+]] = sv.wire
 //CHECK-NEXT:  %[[rwres:.+]] = sv.read_inout %[[rwtmp]]
+//CHECK-NEXT:  %false = hw.constant false
+//CHECK-NEXT:  %[[rwrcondpre:.+]] = comb.icmp eq %rw_wmode_0, %false
+//CHECK-NEXT:  %[[rwrcond:.+]] = comb.and %rw_en_0, %[[rwrcondpre]]
+//CHECK-NEXT:  %[[rwslot:.+]] = sv.array_index_inout %Memory[%rw_addr_0]
+//CHECK-NEXT:  %[[x2:.+]] = sv.constantX
+//CHECK-NEXT:  %[[rwdata:.+]] = sv.read_inout %[[rwslot]]
+//CHECK-NEXT:  %[[rwdata2:.+]] = comb.mux %[[rwrcond]], %[[rwdata]], %[[x2]]
+//CHECK-NEXT:  sv.assign %[[rwtmp]], %[[rwdata2:.+]]
 //CHECK-NEXT:    sv.alwaysff(posedge %rw_clock_0)  {
-//CHECK-NEXT:      %[[rwslot:.+]] = sv.array_index_inout %Memory[%rw_addr_0]
-//CHECK-NEXT:      %false = hw.constant false
-//CHECK-NEXT:      %[[rwrcondpre:.+]] = comb.icmp eq %rw_wmode_0, %false
-//CHECK-NEXT:      %[[rwrcond:.+]] = comb.and %rw_en_0, %[[rwrcondpre]]
 //CHECK-NEXT:      %[[rwwcondpre:.+]] = comb.and %rw_wmask_0, %rw_wmode_0
 //CHECK-NEXT:      %[[rwwcond:.+]] = comb.and %rw_en_0, %[[rwwcondpre]]
-//CHECK-NEXT:      %[[x2:.+]] = sv.constantX
-//CHECK-NEXT:      sv.passign %[[rwtmp]], %[[x2]]
 //CHECK-NEXT:      sv.if %[[rwwcond]]  {
 //CHECK-NEXT:        sv.passign %[[rwslot]], %rw_wdata_0
-//CHECK-NEXT:      } else  {
-//CHECK-NEXT:        sv.if %[[rwrcond]]  {
-//CHECK-NEXT:          %[[rwdata:.+]] = sv.read_inout %[[rwslot]]
-//CHECK-NEXT:          sv.passign %[[rwtmp]], %[[rwdata]]
-//CHECK-NEXT:        }
 //CHECK-NEXT:      }
 //CHECK-NEXT:    }
 //CHECK-NEXT:  sv.alwaysff(posedge %wo_clock_0)  {


### PR DESCRIPTION
Fix HWMemSimImpl bug where a wire was being procedurally assigned in RW
port code generation.  Update the associated test to reflect this
change.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

The old `HWMemSimImpl` was generating logic that was assigning a net in a procedural block. Verilator nicely complains about this, e.g.:

```
%Error-PROCASSWIRE: /dev/stdin:25:5: Procedural assignment to wire, perhaps intended var (IEEE 1800-2017 6.5): '_T_1'
                                   : ... In instance Qux.memory
   25 |     _T_1 <= _T_2;
      |     ^~~~
%Error-PROCASSWIRE: /dev/stdin:30:9: Procedural assignment to wire, perhaps intended var (IEEE 1800-2017 6.5): '_T_1'
                                   : ... In instance Qux.memory
   30 |         _T_1 <= Memory[rw_addr_0];
      |         ^~~~
%Error: Exiting due to 2 error(s)
        ... See the manual and https://verilator.org for more assistance.
```

In a diff, this changes RW emission in the following way:

```diff
diff --git a/B.sv b/A.sv
index 9df654a7..2dade0b5 100644
--- a/B.sv
+++ b/A.sv
@@ -11,29 +11,22 @@ module FIRRTLMem_1_1_1_8_16_1_1_0(
   input  [7:0] wo_data_0,
   output [7:0] ro_data_0, rw_rdata_0);
 
-  reg  [7:0] Memory[0:15];
-  reg        _T;
-  reg  [3:0] _T_0;
-  wire [7:0] _T_1;
+  reg [7:0] Memory[0:15];
+  reg       _T;
+  reg [3:0] _T_0;
 
   always @(posedge ro_clock_0) begin
     _T <= ro_en_0;
     _T_0 <= ro_addr_0;
   end // always @(posedge)
-  wire [7:0] _T_2 = 8'bx;
   always @(posedge rw_clock_0) begin
-    _T_1 <= _T_2;
     if (rw_en_0 & rw_wmask_0 & rw_wmode_0)
       Memory[rw_addr_0] <= rw_wdata_0;
-    else begin
-      if (rw_en_0 & ~rw_wmode_0)
-        _T_1 <= Memory[rw_addr_0];
-    end
   end // always @(posedge)
   always @(posedge wo_clock_0) begin
     if (wo_en_0 & wo_mask_0)
       Memory[wo_addr_0] <= wo_data_0;
   end // always @(posedge)
-  assign ro_data_0 = _T ? Memory[_T_0] : _T_2;
-  assign rw_rdata_0 = _T_1;
+  assign ro_data_0 = _T ? Memory[_T_0] : 8'bx;
+  assign rw_rdata_0 = rw_en_0 & ~rw_wmode_0 ? Memory[rw_addr_0] : 8'bx;
 endmodule
```