### PR TITLE
Non Local Annotations, Distributed Global Table hook

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -188,3 +188,17 @@ def FExtModuleOp : FIRRTLOp<"extmodule",
   let parser = "return ::parse$cppClass(parser, result);";
   let verifier = "return ::verifyFExtModuleOp(*this);";
 }
+
+def NonLocalAnchor : FIRRTLOp<"nla",
+      [IsolatedFromAbove, Symbol, HasParent<"CircuitOp">]> {
+  let summary = "Anchor for non-local annotations";
+  let description = [{
+    The "firrtl.nla" operation represents a common point for non-local (path)
+    annotations to anchor to in the global scope.  This let's components of the
+    path point to a common entity.
+  }];
+  let arguments = (ins SymbolNameAttr:$sym_name);
+  let results = (outs);
+  let assemblyFormat = [{ $sym_name attr-dict}];
+}
+

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -1,0 +1,29 @@
+// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-lower-annotations)' -split-input-file %s |FileCheck %s
+// XFAIL: *
+
+// circt.test copies the annotation to the target
+// circt.testNT puts the targetless annotation on the circuit
+
+
+// A non-local annotation should work.
+
+// CHECK-LABEL: firrtl.circuit "FooNL"
+// CHECK: firrtl.module @BarNL
+// CHECK: firrtl.wire {annotations = [{circt.nonlocal = @"~FooNL|FooNL/baz:BazNL/bar:BarNL>w_NA_0", class = "circt.test", nl = "nl"}]}
+// CHECK: firrtl.instance @BarNL {annotations = [{circt.nonlocal = @"~FooNL|FooNL/baz:BazNL/bar:BarNL>w_NA_0", class = "circt.nonlocal"}], name = "bar"}
+// CHECK: firrtl.instance @BazNL {annotations = [{circt.nonlocal = @"~FooNL|FooNL/baz:BazNL/bar:BarNL>w_NA_0", class = "circt.nonlocal"}], name = "baz"
+// CHECK: firrtl.nla @"~FooNL|FooNL/baz:BazNL/bar:BarNL>w_NA_0"
+firrtl.circuit "FooNL"  attributes {annotations = [{class = "circt.test", nl = "nl", target = "~FooNL|FooNL/baz:BazNL/bar:BarNL>w"}]}  {
+  firrtl.module @BarNL() {
+    %w = firrtl.wire  : !firrtl.uint
+    firrtl.skip
+  }
+  firrtl.module @BazNL() {
+    firrtl.instance @BarNL  {name = "bar"}
+  }
+  firrtl.module @FooNL() {
+    firrtl.instance @BazNL  {name = "baz"}
+  }
+}
+
+


### PR DESCRIPTION
Build a flattened tree for non-local annotations.  This provides a global symbol for a NLA's path.  Each component (instance and final annotation) in a non-local annotation carries a field pointing to the is global. 
Non-local annotations are then identified by having a pointer to the global op in the circt.nonlocal field of an annotation.
Each element along the way carries an annotation with class circt.nonlocal which has a matching circt.nonlocal field pointing to the global op.  Thus instances participating in non-local annotation paths are readily apparent.

The check shows the intended scattering, which is part of the a different patch.