### PR TITLE
[Calyx] Add a MemoryOp primitive.

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -28,6 +28,11 @@ def RegisterOp : CalyxPrimitive<"register", [
       auto i1Type = $_builder.getI1Type();
       auto widthType = $_builder.getIntegerType(width);
       $_state.addTypes({widthType, i1Type, i1Type, i1Type, widthType, i1Type});
+    }]>,
+    OpBuilder<(ins "StringAttr":$name, "Type":$type), [{
+      $_state.addAttribute("name", name);
+      auto i1Type = $_builder.getI1Type();
+      $_state.addTypes({type, i1Type, i1Type, i1Type, type, i1Type});
     }]>
   ];
   let extraClassDeclaration = [{
@@ -39,4 +44,53 @@ def RegisterOp : CalyxPrimitive<"register", [
     }
   }];
 
+}
+
+def MemoryOp : CalyxPrimitive<"memory", [
+    DeclareOpInterfaceMethods<OpAsmOpInterface>,
+    HasParent<"ComponentOp">
+  ]> {
+  let summary = "Defines a memory";
+  let description = [{
+    The "calyx.memory" op defines a memory. Memories can have any number of
+    dimensions, as specified by the length of the `$sizes` and `$addrSizes`
+    arrays. The `$addrSizes` specify the bitwidth of each dimension's address,
+    and should be wide enough to address the range of the corresponding
+    dimension in `$sizes`. The `$width` attribute dictates the width of a single
+    element.
+
+    See https://capra.cs.cornell.edu/docs/calyx/libraries/core.html#memories for
+    more information.
+
+    ```mlir
+      // A 2-dimensional, 8-bit memory.
+      %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.read_data, %m.done = calyx.memory "m"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i8, i1
+    ```
+  }];
+
+  let arguments = (ins
+    StrAttr:$instanceName,
+    I64Attr:$width,
+    ArrayAttr:$sizes,
+    ArrayAttr:$addrSizes
+  );
+
+  let results = (outs
+    Variadic<AnySignlessInteger>:$results
+  );
+
+  let assemblyFormat = [{
+    $instanceName `<` $sizes `x` $width `>` $addrSizes attr-dict `:` type($results)
+  }];
+
+  let verifier = "return ::verify$cppClass(*this);";
+
+  let builders = [
+    OpBuilder<(ins
+      "Twine":$instanceName,
+      "int64_t":$width,
+      "ArrayRef<int64_t>":$sizes,
+      "ArrayRef<int64_t>":$addrSizes
+    )>
+  ];
 }

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -47,7 +47,6 @@ def RegisterOp : CalyxPrimitive<"register", [
 }
 
 def MemoryOp : CalyxPrimitive<"memory", [
-    DeclareOpInterfaceMethods<OpAsmOpInterface>,
     HasParent<"ComponentOp">
   ]> {
   let summary = "Defines a memory";

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -651,7 +651,7 @@ void MemoryOp::build(OpBuilder &builder, OperationState &state,
   state.addAttribute("sizes", builder.getI64ArrayAttr(sizes));
   state.addAttribute("addrSizes", builder.getI64ArrayAttr(addrSizes));
   SmallVector<Type> types;
-  for (auto size : addrSizes)
+  for (int64_t size : addrSizes)
     types.push_back(builder.getIntegerType(size));
   types.push_back(builder.getIntegerType(width));
   types.push_back(builder.getI1Type());

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -19,6 +19,7 @@
 #include "mlir/IR/FunctionImplementation.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/SymbolTable.h"
+#include "mlir/Support/LLVM.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallSet.h"
@@ -621,6 +622,68 @@ void GroupGoOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 /// Provide meaningful names to the result values of a RegisterOp.
 void RegisterOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   getCellAsmResultNames(setNameFn, *this, this->portNames());
+}
+
+//===----------------------------------------------------------------------===//
+// MemoryOp
+//===----------------------------------------------------------------------===//
+
+/// Provide meaningful names to the result values of a MemoryOp.
+void MemoryOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  SmallVector<StringRef> portNames;
+  SmallVector<SmallString<8>> addrNames;
+  for (size_t i = 0, e = addrSizes().size(); i != e; ++i) {
+    addrNames.emplace_back("addr" + std::to_string(i));
+    portNames.push_back(addrNames[i]);
+  }
+  portNames.push_back("write_data");
+  portNames.push_back("write_en");
+  portNames.push_back("read_data");
+  portNames.push_back("done");
+  getCellAsmResultNames(setNameFn, *this, portNames);
+}
+
+void MemoryOp::build(OpBuilder &builder, OperationState &state,
+                     Twine instanceName, int64_t width, ArrayRef<int64_t> sizes,
+                     ArrayRef<int64_t> addrSizes) {
+  state.addAttribute("name", builder.getStringAttr(instanceName));
+  state.addAttribute("width", builder.getI64IntegerAttr(width));
+  state.addAttribute("sizes", builder.getI64ArrayAttr(sizes));
+  state.addAttribute("addrSizes", builder.getI64ArrayAttr(addrSizes));
+  SmallVector<Type> types;
+  for (auto size : addrSizes)
+    types.push_back(builder.getIntegerType(size));
+  types.push_back(builder.getIntegerType(width));
+  types.push_back(builder.getI1Type());
+  types.push_back(builder.getIntegerType(width));
+  types.push_back(builder.getI1Type());
+  state.addTypes(types);
+}
+
+static LogicalResult verifyMemoryOp(MemoryOp memoryOp) {
+  auto sizes = memoryOp.sizes().getValue();
+  auto addrSizes = memoryOp.addrSizes().getValue();
+  size_t numDims = memoryOp.sizes().size();
+  size_t numAddrs = memoryOp.addrSizes().size();
+  if (numDims != numAddrs)
+    return memoryOp.emitOpError("mismatched number of dimensions (")
+           << numDims << ") and address sizes (" << numAddrs << ")";
+
+  size_t numExtraPorts = 4; // write data/enable and read data/done.
+  if (memoryOp.getNumResults() != numAddrs + numExtraPorts)
+    return memoryOp.emitOpError("incorrect number of address ports, expected ")
+           << numAddrs;
+
+  for (size_t i = 0; i < numDims; ++i) {
+    int64_t size = sizes[i].cast<IntegerAttr>().getInt();
+    int64_t addrSize = addrSizes[i].cast<IntegerAttr>().getInt();
+    if (llvm::Log2_64_Ceil(size) > addrSize)
+      return memoryOp.emitOpError("address size (")
+             << addrSize << ") for dimension " << i
+             << " can't address the entire range (" << size << ")";
+  }
+
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -269,3 +269,36 @@ calyx.program {
     }
   }
 }
+
+// -----
+
+calyx.program {
+  calyx.component @main(%go: i1, %clk: i1, %reset: i1) -> (%done: i1) {
+    // expected-error @+1 {{'calyx.memory' op mismatched number of dimensions (1) and address sizes (2)}}
+    %m.addr0, %m.write_data, %m.write_en, %m.read_data, %m.done = calyx.memory "m"<[64] x 8> [6, 6] : i6, i8, i1, i8, i1
+    calyx.wires {}
+    calyx.control {}
+  }
+}
+
+// -----
+
+calyx.program {
+  calyx.component @main(%go: i1, %clk: i1, %reset: i1) -> (%done: i1) {
+    // expected-error @+1 {{'calyx.memory' op incorrect number of address ports, expected 2}}
+    %m.addr0, %m.write_data, %m.write_en, %m.read_data, %m.done = calyx.memory "m"<[64, 64] x 8> [6, 6] : i6, i8, i1, i8, i1
+    calyx.wires {}
+    calyx.control {}
+  }
+}
+
+// -----
+
+calyx.program {
+  calyx.component @main(%go: i1, %clk: i1, %reset: i1) -> (%done: i1) {
+    // expected-error @+1 {{'calyx.memory' op address size (5) for dimension 0 can't address the entire range (64)}}
+    %m.addr0, %m.write_data, %m.write_en, %m.read_data, %m.done = calyx.memory "m"<[64] x 8> [5] : i5, i8, i1, i5, i1
+    calyx.wires {}
+    calyx.control {}
+  }
+}

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -16,10 +16,12 @@ calyx.program {
 
   calyx.component @main(%go: i1, %clk: i1, %reset: i1) -> (%done: i1) {
     // CHECK:      %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8, i1, i1, i1, i8, i1
+    // CHECK-NEXT: %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.read_data, %m.done = calyx.memory "m"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i8, i1
     // CHECK-NEXT: %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i8, i1, i1, i1, i8, i1
     // CHECK-NEXT: %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance "c1" @A : i8, i1, i1, i1, i8, i1
     // CHECK-NEXT: %c2.in, %c2.go, %c2.clk, %c2.reset, %c2.out, %c2.done = calyx.instance "c2" @B : i8, i1, i1, i1, i1, i1
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8, i1, i1, i1, i8, i1
+    %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.read_data, %m.done = calyx.memory "m"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i8, i1
     %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i8, i1, i1, i1, i8, i1
     %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance "c1" @A : i8, i1, i1, i1, i8, i1
     %c2.in, %c2.go, %c2.clk, %c2.reset, %c2.out, %c2.done = calyx.instance "c2" @B : i8, i1, i1, i1, i1, i1


### PR DESCRIPTION
This follows a similar approach to the RegisterOp. Rather than
defining different primitives for different numbers of dimensions like
the Rust compiler, this uses a single operation to represent any
n-dimensional memory.

This generality means we can't enumerate explicit return types.
Rather, the return type is a variadic list of signless integer types.
A helper build method is provided to support this from C++ code, and a
verifier ensures everything lines up.