### PR TITLE
[Calyx] Add a primitive cell instance operation

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -116,64 +116,51 @@ def MemoryOp : CalyxPrimitive<"memory", []> {
   }];
 }
 
+class CalyxLibraryOp<string mnemonic, list<OpTrait> traits = []> :
+  CalyxPrimitive<"lib_" # mnemonic, traits> {
 
-// Primitive operation functions
-def PrimitiveOpFuncNOT  : I64EnumAttrCase<"NOT", 0, "not">;
-def PrimitiveOpFuncAND  : I64EnumAttrCase<"AND", 1, "and">;
-def PrimitiveOpFuncOR   : I64EnumAttrCase<"OR", 2, "or">;
-def PrimitiveOpFuncXOR  : I64EnumAttrCase<"XOR", 3, "xor">;
-def PrimitiveOpFuncADD  : I64EnumAttrCase<"add", 4>;
-def PrimitiveOpFuncSUB  : I64EnumAttrCase<"sub", 5>;
-def PrimitiveOpFuncGT   : I64EnumAttrCase<"gt", 6>;
-def PrimitiveOpFuncLT   : I64EnumAttrCase<"lt", 7>;
-def PrimitiveOpFuncEQ   : I64EnumAttrCase<"eq", 8>;
-def PrimitiveOpFuncNEQ  : I64EnumAttrCase<"neq", 9>;
-def PrimitiveOpFuncGE   : I64EnumAttrCase<"ge", 10>;
-def PrimitiveOpFuncLE   : I64EnumAttrCase<"le", 11>;
-def PrimitiveOpFuncSHL  : I64EnumAttrCase<"shl", 12>;
-def PrimitiveOpFuncSHRU : I64EnumAttrCase<"shru", 13>;
-
-let cppNamespace = "circt::calyx" in
-def PrimitiveOpFunc : I64EnumAttr<
-    "PrimitiveOpFunc",
-    "calyx.prim function type",
-    [PrimitiveOpFuncNOT, PrimitiveOpFuncAND, PrimitiveOpFuncOR, PrimitiveOpFuncXOR, PrimitiveOpFuncADD,
-     PrimitiveOpFuncSUB, PrimitiveOpFuncGT, PrimitiveOpFuncLT, PrimitiveOpFuncEQ, PrimitiveOpFuncNEQ,
-     PrimitiveOpFuncGE, PrimitiveOpFuncLE, PrimitiveOpFuncSHL, PrimitiveOpFuncSHRU]>;
-
-def PrimitiveOp : CalyxPrimitive<"prim"> {
-  let summary = "Defines a primitive arithmetic operation";
+  let summary = "Defines an operation which maps to a Calyx library primitive";
   let description = [{
-    This operation represents an instance of a Calyx arithmetic primitive. The
-    operation function is specified by the `$func` parameter. The result types
-    of the parameter must match the natural type constraints of the provided
-    `$func`.
-    I.e. for binary arithmetic operations the result and input types are
-    expected to be the identical, whereas for boolean comparison operators
-    input types should be identical with a 1-bit wide output type.
-
-    ```mlir
-      // A 32-bit adder.
-       %adder.in0, %adder.in1, %adder.out = calyx.prim "adder" add : i8, i8, i8
-      // An 8-bit greater-than comparison.
-      %gt.in0, %gt.in1, %gt.out = calyx.prim "gt" gt : i8, i8, i1
-    ```
+    This operation represents an instance of a Calyx library primitive.
+    A library primitive maps to some hardware-implemented component within the
+    native Calyx compiler.
   }];
 
-  let arguments = (ins StrAttr:$instanceName, PrimitiveOpFunc:$func);
-  let results = (outs Variadic<AnySignlessInteger>:$results);
-
-  let assemblyFormat = [{
-    $instanceName $func attr-dict `:` type($results)
-  }];
-
-  let verifier = "return ::verify$cppClass(*this);";
-
+  let arguments = (ins StrAttr:$instanceName);
   let builders = [
-    OpBuilder<(ins
-      "Twine":$instanceName,
-      "PrimitiveOpFunc":$func,
-      "::mlir::TypeRange":$resultTypes
-    )>
+    OpBuilder<(ins "StringAttr":$instanceName, "::mlir::TypeRange":$resultTypes), [{
+      $_state.addAttribute("instanceName", instanceName);
+      $_state.addTypes(resultTypes);
+    }]>
   ];
 }
+
+class BoolBinLibOp<string mnemonic> : CalyxLibraryOp<mnemonic, [
+    SameTypeConstraint<"left", "right">
+  ]> {
+  let results = (outs AnyType:$left, AnyType:$right, I1:$out);
+}
+
+def LtLibOp  : BoolBinLibOp<"lt"> {}
+def GtLibOp  : BoolBinLibOp<"gt"> {}
+def EqLibOp  : BoolBinLibOp<"eq"> {}
+def NeqLibOp : BoolBinLibOp<"neq"> {}
+def GeLibOp  : BoolBinLibOp<"ge"> {}
+def LeLibOp  : BoolBinLibOp<"le"> {}
+
+class ArithBinLibOp<string mnemonic> : CalyxLibraryOp<mnemonic, [
+    SameTypeConstraint<"left", "right">,
+    SameTypeConstraint<"left", "out">
+  ]> {
+  let results = (outs AnyType:$left, AnyType:$right, AnyType:$out);
+}
+
+def AddLibOp  : ArithBinLibOp<"add"> {}
+def SubLibOp  : ArithBinLibOp<"sub"> {}
+def ShruLibOp : ArithBinLibOp<"shru"> {}
+def ShrLibOp  : ArithBinLibOp<"shr"> {}
+def ShlLibOp  : ArithBinLibOp<"shl"> {}
+def AndLibOp  : ArithBinLibOp<"and"> {}
+def NotLibOp  : ArithBinLibOp<"not"> {}
+def OrLibOp   : ArithBinLibOp<"or"> {}
+def XorLibOp  : ArithBinLibOp<"xor"> {}

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -164,3 +164,23 @@ def AndLibOp  : ArithBinaryLibraryOp<"and"> {}
 def NotLibOp  : ArithBinaryLibraryOp<"not"> {}
 def OrLibOp   : ArithBinaryLibraryOp<"or"> {}
 def XorLibOp  : ArithBinaryLibraryOp<"xor"> {}
+
+class UnaryLibraryOp<string mnemonic> : CalyxLibraryOp<mnemonic, [
+  ]> {
+  let results = (outs AnyInteger:$in, AnyInteger:$out);
+}
+
+def PadLibOp : UnaryLibraryOp<"pad"> {
+  let verifier = [{
+    unsigned inBits = getResult(0).getType().getIntOrFloatBitWidth();
+    unsigned outBits = getResult(1).getType().getIntOrFloatBitWidth();
+    return success(inBits < outBits);
+  }];
+}
+
+def SliceLibOp : UnaryLibraryOp<"slice"> {
+  let verifier = [{
+    unsigned inBits = getResult(0).getType().getIntOrFloatBitWidth();
+    unsigned outBits = getResult(1).getType().getIntOrFloatBitWidth();
+    return success(inBits > outBits);  }];
+}

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -115,3 +115,66 @@ def MemoryOp : CalyxPrimitive<"memory", []> {
     Value done()      { return getResult(getNumDimensions() + 3); }
   }];
 }
+
+
+// Primitive operation functions
+def PrimOpFuncNOT  : I64EnumAttrCase<"NOT", 0, "not">;
+def PrimOpFuncAND  : I64EnumAttrCase<"AND", 1, "and">;
+def PrimOpFuncOR   : I64EnumAttrCase<"OR", 2, "or">;
+def PrimOpFuncXOR  : I64EnumAttrCase<"XOR", 3, "xor">;
+def PrimOpFuncADD  : I64EnumAttrCase<"add", 4>;
+def PrimOpFuncSUB  : I64EnumAttrCase<"sub", 5>;
+def PrimOpFuncGT   : I64EnumAttrCase<"gt", 6>;
+def PrimOpFuncLT   : I64EnumAttrCase<"lt", 7>;
+def PrimOpFuncEQ   : I64EnumAttrCase<"eq", 8>;
+def PrimOpFuncNEQ  : I64EnumAttrCase<"neq", 9>;
+def PrimOpFuncGE   : I64EnumAttrCase<"ge", 10>;
+def PrimOpFuncLE   : I64EnumAttrCase<"le", 11>;
+def PrimOpFuncSHL  : I64EnumAttrCase<"shl", 12>;
+def PrimOpFuncSHRU : I64EnumAttrCase<"shru", 13>;
+
+let cppNamespace = "circt::calyx" in
+def PrimOpFunc : I64EnumAttr<
+    "PrimOpFunc",
+    "calyx.prim function type",
+    [PrimOpFuncNOT, PrimOpFuncAND, PrimOpFuncOR, PrimOpFuncXOR, PrimOpFuncADD,
+     PrimOpFuncSUB, PrimOpFuncGT, PrimOpFuncLT, PrimOpFuncEQ, PrimOpFuncNEQ,
+     PrimOpFuncGE, PrimOpFuncLE, PrimOpFuncSHL, PrimOpFuncSHRU]>;
+
+def PrimOp : CalyxPrimitive<"prim", [
+    HasParent<"ComponentOp">
+  ]> {
+  let summary = "Defines a primitive arithmetic operation";
+  let description = [{
+    This operation represents an instance of a circuit primitive. The operation
+    function is specified by the `$func` parameter. The result types of the
+    parameter must match the natural type constraints of the provided `$func`.
+    I.e. for binary arithmetic operations the result and input types are
+    expected to be the identical, whereas for boolean comparison operators
+    input types should be identical with a 1-bit wide output type.
+
+    ```mlir
+      // A 32-bit adder.
+       %adder.in0, %adder.in1, %adder.out = calyx.prim "adder" add : i8, i8, i8
+      // An 8-bit greater-than comparison.
+      %gt.in0, %gt.in1, %gt.out = calyx.prim "gt" gt : i8, i8, i1
+    ```
+  }];
+
+  let arguments = (ins StrAttr:$instanceName, PrimOpFunc:$func);
+  let results = (outs Variadic<AnySignlessInteger>:$results);
+
+  let assemblyFormat = [{
+    $instanceName $func attr-dict `:` type($results)
+  }];
+
+  let verifier = "return ::verify$cppClass(*this);";
+
+  let builders = [
+    OpBuilder<(ins
+      "Twine":$instanceName,
+      "PrimOpFunc":$func,
+      "::mlir::TypeRange":$resultTypes
+    )>
+  ];
+}

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -117,7 +117,7 @@ def MemoryOp : CalyxPrimitive<"memory", []> {
 }
 
 class CalyxLibraryOp<string mnemonic, list<OpTrait> traits = []> :
-  CalyxPrimitive<"lib_" # mnemonic, traits> {
+  CalyxPrimitive<"std_" # mnemonic, traits> {
 
   let summary = "Defines an operation which maps to a Calyx library primitive";
   let description = [{
@@ -135,32 +135,32 @@ class CalyxLibraryOp<string mnemonic, list<OpTrait> traits = []> :
   ];
 }
 
-class BoolBinLibOp<string mnemonic> : CalyxLibraryOp<mnemonic, [
+class BoolBinaryLibraryOp<string mnemonic> : CalyxLibraryOp<mnemonic, [
     SameTypeConstraint<"left", "right">
   ]> {
   let results = (outs AnyType:$left, AnyType:$right, I1:$out);
 }
 
-def LtLibOp  : BoolBinLibOp<"lt"> {}
-def GtLibOp  : BoolBinLibOp<"gt"> {}
-def EqLibOp  : BoolBinLibOp<"eq"> {}
-def NeqLibOp : BoolBinLibOp<"neq"> {}
-def GeLibOp  : BoolBinLibOp<"ge"> {}
-def LeLibOp  : BoolBinLibOp<"le"> {}
+def LtLibOp  : BoolBinaryLibraryOp<"lt"> {}
+def GtLibOp  : BoolBinaryLibraryOp<"gt"> {}
+def EqLibOp  : BoolBinaryLibraryOp<"eq"> {}
+def NeqLibOp : BoolBinaryLibraryOp<"neq"> {}
+def GeLibOp  : BoolBinaryLibraryOp<"ge"> {}
+def LeLibOp  : BoolBinaryLibraryOp<"le"> {}
 
-class ArithBinLibOp<string mnemonic> : CalyxLibraryOp<mnemonic, [
+class ArithBinaryLibraryOp<string mnemonic> : CalyxLibraryOp<mnemonic, [
     SameTypeConstraint<"left", "right">,
     SameTypeConstraint<"left", "out">
   ]> {
   let results = (outs AnyType:$left, AnyType:$right, AnyType:$out);
 }
 
-def AddLibOp  : ArithBinLibOp<"add"> {}
-def SubLibOp  : ArithBinLibOp<"sub"> {}
-def ShruLibOp : ArithBinLibOp<"shru"> {}
-def ShrLibOp  : ArithBinLibOp<"shr"> {}
-def ShlLibOp  : ArithBinLibOp<"shl"> {}
-def AndLibOp  : ArithBinLibOp<"and"> {}
-def NotLibOp  : ArithBinLibOp<"not"> {}
-def OrLibOp   : ArithBinLibOp<"or"> {}
-def XorLibOp  : ArithBinLibOp<"xor"> {}
+def AddLibOp  : ArithBinaryLibraryOp<"add"> {}
+def SubLibOp  : ArithBinaryLibraryOp<"sub"> {}
+def ShruLibOp : ArithBinaryLibraryOp<"shru"> {}
+def ShrLibOp  : ArithBinaryLibraryOp<"shr"> {}
+def ShlLibOp  : ArithBinaryLibraryOp<"shl"> {}
+def AndLibOp  : ArithBinaryLibraryOp<"and"> {}
+def NotLibOp  : ArithBinaryLibraryOp<"not"> {}
+def OrLibOp   : ArithBinaryLibraryOp<"or"> {}
+def XorLibOp  : ArithBinaryLibraryOp<"xor"> {}

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -118,37 +118,36 @@ def MemoryOp : CalyxPrimitive<"memory", []> {
 
 
 // Primitive operation functions
-def PrimOpFuncNOT  : I64EnumAttrCase<"NOT", 0, "not">;
-def PrimOpFuncAND  : I64EnumAttrCase<"AND", 1, "and">;
-def PrimOpFuncOR   : I64EnumAttrCase<"OR", 2, "or">;
-def PrimOpFuncXOR  : I64EnumAttrCase<"XOR", 3, "xor">;
-def PrimOpFuncADD  : I64EnumAttrCase<"add", 4>;
-def PrimOpFuncSUB  : I64EnumAttrCase<"sub", 5>;
-def PrimOpFuncGT   : I64EnumAttrCase<"gt", 6>;
-def PrimOpFuncLT   : I64EnumAttrCase<"lt", 7>;
-def PrimOpFuncEQ   : I64EnumAttrCase<"eq", 8>;
-def PrimOpFuncNEQ  : I64EnumAttrCase<"neq", 9>;
-def PrimOpFuncGE   : I64EnumAttrCase<"ge", 10>;
-def PrimOpFuncLE   : I64EnumAttrCase<"le", 11>;
-def PrimOpFuncSHL  : I64EnumAttrCase<"shl", 12>;
-def PrimOpFuncSHRU : I64EnumAttrCase<"shru", 13>;
+def PrimitiveOpFuncNOT  : I64EnumAttrCase<"NOT", 0, "not">;
+def PrimitiveOpFuncAND  : I64EnumAttrCase<"AND", 1, "and">;
+def PrimitiveOpFuncOR   : I64EnumAttrCase<"OR", 2, "or">;
+def PrimitiveOpFuncXOR  : I64EnumAttrCase<"XOR", 3, "xor">;
+def PrimitiveOpFuncADD  : I64EnumAttrCase<"add", 4>;
+def PrimitiveOpFuncSUB  : I64EnumAttrCase<"sub", 5>;
+def PrimitiveOpFuncGT   : I64EnumAttrCase<"gt", 6>;
+def PrimitiveOpFuncLT   : I64EnumAttrCase<"lt", 7>;
+def PrimitiveOpFuncEQ   : I64EnumAttrCase<"eq", 8>;
+def PrimitiveOpFuncNEQ  : I64EnumAttrCase<"neq", 9>;
+def PrimitiveOpFuncGE   : I64EnumAttrCase<"ge", 10>;
+def PrimitiveOpFuncLE   : I64EnumAttrCase<"le", 11>;
+def PrimitiveOpFuncSHL  : I64EnumAttrCase<"shl", 12>;
+def PrimitiveOpFuncSHRU : I64EnumAttrCase<"shru", 13>;
 
 let cppNamespace = "circt::calyx" in
-def PrimOpFunc : I64EnumAttr<
-    "PrimOpFunc",
+def PrimitiveOpFunc : I64EnumAttr<
+    "PrimitiveOpFunc",
     "calyx.prim function type",
-    [PrimOpFuncNOT, PrimOpFuncAND, PrimOpFuncOR, PrimOpFuncXOR, PrimOpFuncADD,
-     PrimOpFuncSUB, PrimOpFuncGT, PrimOpFuncLT, PrimOpFuncEQ, PrimOpFuncNEQ,
-     PrimOpFuncGE, PrimOpFuncLE, PrimOpFuncSHL, PrimOpFuncSHRU]>;
+    [PrimitiveOpFuncNOT, PrimitiveOpFuncAND, PrimitiveOpFuncOR, PrimitiveOpFuncXOR, PrimitiveOpFuncADD,
+     PrimitiveOpFuncSUB, PrimitiveOpFuncGT, PrimitiveOpFuncLT, PrimitiveOpFuncEQ, PrimitiveOpFuncNEQ,
+     PrimitiveOpFuncGE, PrimitiveOpFuncLE, PrimitiveOpFuncSHL, PrimitiveOpFuncSHRU]>;
 
-def PrimOp : CalyxPrimitive<"prim", [
-    HasParent<"ComponentOp">
-  ]> {
+def PrimitiveOp : CalyxPrimitive<"prim"> {
   let summary = "Defines a primitive arithmetic operation";
   let description = [{
-    This operation represents an instance of a circuit primitive. The operation
-    function is specified by the `$func` parameter. The result types of the
-    parameter must match the natural type constraints of the provided `$func`.
+    This operation represents an instance of a Calyx arithmetic primitive. The
+    operation function is specified by the `$func` parameter. The result types
+    of the parameter must match the natural type constraints of the provided
+    `$func`.
     I.e. for binary arithmetic operations the result and input types are
     expected to be the identical, whereas for boolean comparison operators
     input types should be identical with a 1-bit wide output type.
@@ -161,7 +160,7 @@ def PrimOp : CalyxPrimitive<"prim", [
     ```
   }];
 
-  let arguments = (ins StrAttr:$instanceName, PrimOpFunc:$func);
+  let arguments = (ins StrAttr:$instanceName, PrimitiveOpFunc:$func);
   let results = (outs Variadic<AnySignlessInteger>:$results);
 
   let assemblyFormat = [{
@@ -173,7 +172,7 @@ def PrimOp : CalyxPrimitive<"prim", [
   let builders = [
     OpBuilder<(ins
       "Twine":$instanceName,
-      "PrimOpFunc":$func,
+      "PrimitiveOpFunc":$func,
       "::mlir::TypeRange":$resultTypes
     )>
   ];

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -888,42 +888,43 @@ static LogicalResult verifyWhileOp(WhileOp whileOp) {
 // Calyx library ops
 //===----------------------------------------------------------------------===//
 
-// The Calyx library operations implement the OpAsmOpInterface which expects a
-// getAsmResultNames member function to be defined out of line of the
-// tablegen'erated files. Since there is no "extraClassDefinitions" function in
-// the TableGen backend for Op classes, we have to manually define these here.
-static void getBinOpAsmResultNames(Operation *op,
-                                   OpAsmSetValueNameFn setNameFn) {
-  unsigned numResults = op->getNumResults();
-  assert(numResults == 3);
-  SmallVector<StringRef> portNames;
-  portNames.push_back("left");
-  portNames.push_back("right");
-  portNames.push_back("out");
-  getCellAsmResultNames(setNameFn, op, portNames);
-}
-
-#define AsmResultsForLibraryOp(OpType)                                         \
+#define ImplUnaryOpCellInterface(OpType)                                       \
+  SmallVector<StringRef> OpType::portNames() { return {"in", "out"}; }         \
+  SmallVector<Direction> OpType::portDirections() { return {Input, Output}; }  \
   void OpType::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {              \
-    getBinOpAsmResultNames(*this, setNameFn);                                  \
+    getCellAsmResultNames(setNameFn, *this, this->portNames());                \
   }
 
-AsmResultsForLibraryOp(LtLibOp);
-AsmResultsForLibraryOp(GtLibOp);
-AsmResultsForLibraryOp(EqLibOp);
-AsmResultsForLibraryOp(NeqLibOp);
-AsmResultsForLibraryOp(GeLibOp);
-AsmResultsForLibraryOp(LeLibOp);
+#define ImplBinOpCellInterface(OpType)                                         \
+  SmallVector<StringRef> OpType::portNames() {                                 \
+    return {"left", "right", "out"};                                           \
+  }                                                                            \
+  SmallVector<Direction> OpType::portDirections() {                            \
+    return {Input, Input, Output};                                             \
+  }                                                                            \
+  void OpType::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {              \
+    getCellAsmResultNames(setNameFn, *this, this->portNames());                \
+  }
 
-AsmResultsForLibraryOp(AddLibOp);
-AsmResultsForLibraryOp(SubLibOp);
-AsmResultsForLibraryOp(ShruLibOp);
-AsmResultsForLibraryOp(ShrLibOp);
-AsmResultsForLibraryOp(ShlLibOp);
-AsmResultsForLibraryOp(AndLibOp);
-AsmResultsForLibraryOp(NotLibOp);
-AsmResultsForLibraryOp(OrLibOp);
-AsmResultsForLibraryOp(XorLibOp);
+ImplUnaryOpCellInterface(PadLibOp);
+ImplUnaryOpCellInterface(SliceLibOp);
+
+ImplBinOpCellInterface(LtLibOp);
+ImplBinOpCellInterface(GtLibOp);
+ImplBinOpCellInterface(EqLibOp);
+ImplBinOpCellInterface(NeqLibOp);
+ImplBinOpCellInterface(GeLibOp);
+ImplBinOpCellInterface(LeLibOp);
+
+ImplBinOpCellInterface(AddLibOp);
+ImplBinOpCellInterface(SubLibOp);
+ImplBinOpCellInterface(ShruLibOp);
+ImplBinOpCellInterface(ShrLibOp);
+ImplBinOpCellInterface(ShlLibOp);
+ImplBinOpCellInterface(AndLibOp);
+ImplBinOpCellInterface(NotLibOp);
+ImplBinOpCellInterface(OrLibOp);
+ImplBinOpCellInterface(XorLibOp);
 
 //===----------------------------------------------------------------------===//
 // TableGen generated logic.

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -885,6 +885,83 @@ static LogicalResult verifyWhileOp(WhileOp whileOp) {
 }
 
 //===----------------------------------------------------------------------===//
+// PrimOp
+//===----------------------------------------------------------------------===//
+void PrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  SmallVector<StringRef> portNames;
+  SmallVector<SmallString<8>> inNames;
+  for (size_t i = 0, e = getNumResults() - 1; i != e; ++i) {
+    inNames.emplace_back("in" + std::to_string(i));
+    portNames.push_back(inNames.back());
+  }
+  portNames.push_back("out");
+  getCellAsmResultNames(setNameFn, *this, portNames);
+}
+
+void PrimOp::build(OpBuilder &builder, OperationState &state,
+                   Twine instanceName, PrimOpFunc func,
+                   ::mlir::TypeRange resultTypes) {
+  state.addAttribute("name", builder.getStringAttr(instanceName));
+  state.addAttribute(
+      "func", circt::calyx::PrimOpFuncAttr::get(builder.getContext(), func));
+  state.addTypes(resultTypes);
+}
+
+namespace {
+enum class PrimOpTypeConstraint { AllIdentical, OpsIdenticalBoolRes };
+}
+// clang-format off
+static PrimOpTypeConstraint primFuncTypeConstraint(PrimOpFunc func) {
+  switch (func) {
+  case PrimOpFunc::add: case PrimOpFunc::sub: case PrimOpFunc::shru:
+  case PrimOpFunc::shl: case PrimOpFunc::AND: case PrimOpFunc::NOT:
+  case PrimOpFunc::OR: case PrimOpFunc::XOR:
+    return PrimOpTypeConstraint::AllIdentical;
+
+  case PrimOpFunc::lt: case PrimOpFunc::gt: case PrimOpFunc::eq:
+  case PrimOpFunc::neq: case PrimOpFunc::ge: case PrimOpFunc::le:
+    return PrimOpTypeConstraint::OpsIdenticalBoolRes;
+  }
+  llvm_unreachable("Unknown primitive op function");
+}
+// clang-format on
+
+static LogicalResult verifyPrimOp(PrimOp primOp) {
+  auto resTypes = primOp.getResultTypes();
+
+  // # of results verification - currently, all operators are binary operators.
+  if (resTypes.size() != 3)
+    return primOp.emitOpError()
+           << "expected 3 return types for binary operator.";
+
+  // Type verification
+  switch (primFuncTypeConstraint(primOp.func())) {
+    // Identical input types + return type.
+  case PrimOpTypeConstraint::AllIdentical: {
+    bool AllIdenticalType = llvm::all_of(resTypes, [&](auto type) {
+      return type == primOp->getResultTypes()[0];
+    });
+    if (!AllIdenticalType)
+      return primOp.emitOpError()
+             << "expected identical input and output types.";
+    break;
+  }
+    // Identical input types, return type is 1 bit.
+  case PrimOpTypeConstraint::OpsIdenticalBoolRes: {
+    if (!resTypes[resTypes.size() - 1].isInteger(1))
+      return primOp.emitOpError() << "expected 1-bit return type.";
+    if (!llvm::all_of(
+            llvm::make_range(resTypes.begin() + 0, resTypes.end() - 1),
+            [&](auto type) { return type == primOp->getResultTypes()[0]; }))
+      return primOp.emitOpError() << "expected identical input types.";
+    break;
+  }
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // TableGen generated logic.
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -897,11 +897,8 @@ static void getBinOpAsmResultNames(Operation *op,
   unsigned numResults = op->getNumResults();
   assert(numResults == 3);
   SmallVector<StringRef> portNames;
-  SmallVector<SmallString<8>> inNames;
-  for (size_t i = 0, e = numResults - 1; i != e; ++i) {
-    inNames.emplace_back("in" + std::to_string(i));
-    portNames.push_back(inNames.back());
-  }
+  portNames.push_back("left");
+  portNames.push_back("right");
   portNames.push_back("out");
   getCellAsmResultNames(setNameFn, op, portNames);
 }

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -22,6 +22,8 @@ calyx.program {
     // CHECK-NEXT: %c2.in, %c2.go, %c2.clk, %c2.reset, %c2.out, %c2.done = calyx.instance "c2" @B : i8, i1, i1, i1, i1, i1
     // CHECK-NEXT: %adder.left, %adder.right, %adder.out = calyx.std_add "adder" : i8, i8, i8
     // CHECK-NEXT: %gt.left, %gt.right, %gt.out = calyx.std_gt "gt" : i8, i8, i1
+    // CHECK-NEXT: %pad.in, %pad.out = calyx.std_pad "pad" : i8, i9
+    // CHECK-NEXT: %slice.in, %slice.out = calyx.std_slice "slice" : i8, i7
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8, i1, i1, i1, i8, i1
     %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.read_data, %m.done = calyx.memory "m"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i8, i1
     %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i8, i1, i1, i1, i8, i1
@@ -29,6 +31,8 @@ calyx.program {
     %c2.in, %c2.go, %c2.clk, %c2.reset, %c2.out, %c2.done = calyx.instance "c2" @B : i8, i1, i1, i1, i1, i1
     %adder.left, %adder.right, %adder.out = calyx.std_add "adder" : i8, i8, i8
     %gt.left, %gt.right, %gt.out = calyx.std_gt "gt" : i8, i8, i1
+    %pad.in, %pad.out = calyx.std_pad "pad" : i8, i9
+    %slice.in, %slice.out = calyx.std_slice "slice" : i8, i7
     %c1_i1 = constant 1 : i1
 
     calyx.wires {

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -20,15 +20,15 @@ calyx.program {
     // CHECK-NEXT: %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i8, i1, i1, i1, i8, i1
     // CHECK-NEXT: %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance "c1" @A : i8, i1, i1, i1, i8, i1
     // CHECK-NEXT: %c2.in, %c2.go, %c2.clk, %c2.reset, %c2.out, %c2.done = calyx.instance "c2" @B : i8, i1, i1, i1, i1, i1
-    // CHECK-NEXT: %adder.in0, %adder.in1, %adder.out = calyx.lib_add "adder" : i8, i8, i8
-    // CHECK-NEXT: %gt.in0, %gt.in1, %gt.out = calyx.lib_gt "gt" : i8, i8, i1
+    // CHECK-NEXT: %adder.left, %adder.right, %adder.out = calyx.std_add "adder" : i8, i8, i8
+    // CHECK-NEXT: %gt.left, %gt.right, %gt.out = calyx.std_gt "gt" : i8, i8, i1
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8, i1, i1, i1, i8, i1
     %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.read_data, %m.done = calyx.memory "m"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i8, i1
     %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i8, i1, i1, i1, i8, i1
     %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance "c1" @A : i8, i1, i1, i1, i8, i1
     %c2.in, %c2.go, %c2.clk, %c2.reset, %c2.out, %c2.done = calyx.instance "c2" @B : i8, i1, i1, i1, i1, i1
-    %adder.in0, %adder.in1, %adder.out = calyx.lib_add "adder" : i8, i8, i8
-    %gt.in0, %gt.in1, %gt.out = calyx.lib_gt "gt" : i8, i8, i1
+    %adder.left, %adder.right, %adder.out = calyx.std_add "adder" : i8, i8, i8
+    %gt.left, %gt.right, %gt.out = calyx.std_gt "gt" : i8, i8, i1
     %c1_i1 = constant 1 : i1
 
     calyx.wires {

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -20,11 +20,15 @@ calyx.program {
     // CHECK-NEXT: %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i8, i1, i1, i1, i8, i1
     // CHECK-NEXT: %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance "c1" @A : i8, i1, i1, i1, i8, i1
     // CHECK-NEXT: %c2.in, %c2.go, %c2.clk, %c2.reset, %c2.out, %c2.done = calyx.instance "c2" @B : i8, i1, i1, i1, i1, i1
+    // CHECK-NEXT: %adder.in0, %adder.in1, %adder.out = calyx.prim "adder" add : i8, i8, i8
+    // CHECK-NEXT: %gt.in0, %gt.in1, %gt.out = calyx.prim "gt" gt : i8, i8, i1
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8, i1, i1, i1, i8, i1
     %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.read_data, %m.done = calyx.memory "m"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i8, i1
     %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i8, i1, i1, i1, i8, i1
     %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance "c1" @A : i8, i1, i1, i1, i8, i1
     %c2.in, %c2.go, %c2.clk, %c2.reset, %c2.out, %c2.done = calyx.instance "c2" @B : i8, i1, i1, i1, i1, i1
+    %adder.in0, %adder.in1, %adder.out = calyx.prim "adder" add : i8, i8, i8
+    %gt.in0, %gt.in1, %gt.out = calyx.prim "gt" gt : i8, i8, i1
     %c1_i1 = constant 1 : i1
 
     calyx.wires {

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -20,15 +20,15 @@ calyx.program {
     // CHECK-NEXT: %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i8, i1, i1, i1, i8, i1
     // CHECK-NEXT: %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance "c1" @A : i8, i1, i1, i1, i8, i1
     // CHECK-NEXT: %c2.in, %c2.go, %c2.clk, %c2.reset, %c2.out, %c2.done = calyx.instance "c2" @B : i8, i1, i1, i1, i1, i1
-    // CHECK-NEXT: %adder.in0, %adder.in1, %adder.out = calyx.prim "adder" add : i8, i8, i8
-    // CHECK-NEXT: %gt.in0, %gt.in1, %gt.out = calyx.prim "gt" gt : i8, i8, i1
+    // CHECK-NEXT: %adder.in0, %adder.in1, %adder.out = calyx.lib_add "adder" : i8, i8, i8
+    // CHECK-NEXT: %gt.in0, %gt.in1, %gt.out = calyx.lib_gt "gt" : i8, i8, i1
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8, i1, i1, i1, i8, i1
     %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.read_data, %m.done = calyx.memory "m"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i8, i1
     %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i8, i1, i1, i1, i8, i1
     %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance "c1" @A : i8, i1, i1, i1, i8, i1
     %c2.in, %c2.go, %c2.clk, %c2.reset, %c2.out, %c2.done = calyx.instance "c2" @B : i8, i1, i1, i1, i1, i1
-    %adder.in0, %adder.in1, %adder.out = calyx.prim "adder" add : i8, i8, i8
-    %gt.in0, %gt.in1, %gt.out = calyx.prim "gt" gt : i8, i8, i1
+    %adder.in0, %adder.in1, %adder.out = calyx.lib_add "adder" : i8, i8, i8
+    %gt.in0, %gt.in1, %gt.out = calyx.lib_gt "gt" : i8, i8, i1
     %c1_i1 = constant 1 : i1
 
     calyx.wires {


### PR DESCRIPTION
This operation represents an instance of a circuit primitive. The operation function is specified by the `$func` parameter. The result types of the parameter must match the natural type constraints of the provided `$func`. I.e. for binary arithmetic operations the result and input types are expected to be the identical, whereas for boolean comparison operators input types should be identical with a 1-bit wide output type.

The available operations maps to the [native Calyx logical and primitive operations](https://github.com/cucapra/calyx/blob/master/primitives/core.futil), please let me know whether you think it'd be smarter to map to the `std.comb` operations instead (or a mix of the two).

I'd like to discuss whether we should constrain the "prim" operations to be purely combinational standard operations. This would imply that if we in the future add an operation for i.e., multi-cycle multiplication (which would have `clk,reset,go,done` signals), this would have to be a separate calyx component. If so, we might also want to change to operation name from `calyx.prim` to i.e. `calyx.comb`.