### PR TITLE
[FIRRTL] Clean up generated type parser/printer use

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -55,8 +55,6 @@ struct RecursiveTypeProperties {
 // This is a common base class for all FIRRTL types.
 class FIRRTLType : public Type {
 public:
-  void print(raw_ostream &os) const;
-
   /// Return true if this is a "passive" type - one that contains no "flip"
   /// types recursively within itself.
   bool isPassive() { return getRecursiveTypeProperties().isPassive; }

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -3,7 +3,7 @@
 firrtl.circuit "X" {
 
 firrtl.module @X(in %b : !firrtl.unknowntype) {
-  // expected-error @-1 {{unknown firrtl type}}
+  // expected-error @-1 {{unknown FIRRTL dialect type: "unknowntype"}}
 }
 
 }


### PR DESCRIPTION
Calling `parseFIRRTLType` and `FIRRTLType::print` would currently only consider the hand-written type parsers and printers. On the other hand, using the dialect hooks `FIRRTLDialect::parseType` and `FIRRTLDialect::printType` would properly try to apply the generated parsers and printers first, and then resort to the manual implementations. This commit fixes the inconsistency by moving the call to the generated functions into `parseFIRRTLType` and `FIRRTLType::print` to ensure they are always tried first.