### PR TITLE
[FSM] Add FSM operations

### DIFF
--- a/include/circt/Dialect/FSM/FSM.td
+++ b/include/circt/Dialect/FSM/FSM.td
@@ -29,4 +29,7 @@ class FSMType<string name> : TypeDef<FSMDialect, name> {}
 class FSMOp<string mnemonic, list<OpTrait> traits = []> :
     Op<FSMDialect, mnemonic, traits>;
 
+include "FSMTypes.td"
+include "FSMOps.td"
+
 #endif // CIRCT_DIALECT_FSM_TD

--- a/include/circt/Dialect/FSM/FSMOps.h
+++ b/include/circt/Dialect/FSM/FSMOps.h
@@ -10,6 +10,14 @@
 #define CIRCT_DIALECT_FSM_FSMOPS_H
 
 #include "circt/Dialect/FSM/FSMDialect.h"
+#include "circt/Dialect/FSM/FSMTypes.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/FunctionSupport.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
 
 #define GET_OP_CLASSES
 #include "circt/Dialect/FSM/FSM.h.inc"

--- a/include/circt/Dialect/FSM/FSMOps.td
+++ b/include/circt/Dialect/FSM/FSMOps.td
@@ -1,0 +1,269 @@
+//===- FSMOps.td - Definition of FSM dialect operations -------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_FSM_FSMOPS_TD
+#define CIRCT_DIALECT_FSM_FSMOPS_TD
+
+include "mlir/IR/OpAsmInterface.td"
+include "mlir/IR/SymbolInterfaces.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td"
+
+def HasCustomSSAName : DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>;
+
+def MachineOp : FSMOp<"machine", [HasParent<"mlir::ModuleOp">, FunctionLike,
+      Symbol, SymbolTable, IsolatedFromAbove, NoTerminator]> {
+  let summary = "Define a finite-state machine";
+  let description = [{
+    `fsm.machine` represents a finite-state machine, including a machine name,
+    the type of machine state, and the types of inputs and outputs. This op also
+    includes a `$body` region that contains internal variables and states.
+  }];
+
+  let arguments = (ins StrAttr:$sym_name, TypeAttr:$stateType, TypeAttr:$type);
+  let regions = (region SizedRegion<1>:$body);
+
+  let builders = [
+    OpBuilder<(ins "StringRef":$name, "Type":$stateType, "FunctionType":$type,
+      CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs,
+      CArg<"ArrayRef<DictionaryAttr>", "{}">:$argAttrs)>
+  ];
+
+  let extraClassDeclaration = [{
+    /// Get the default state of the machine.
+    StateOp getDefaultState();
+
+    /// Get the port information of the machine.
+    void getHWPortInfo(SmallVectorImpl<circt::hw::ModulePortInfo> &);
+
+  private:
+    /// This trait needs access to the hooks defined below.
+    friend class OpTrait::FunctionLike<MachineOp>;
+
+    /// Returns the number of arguments. This is a hook for
+    /// OpTrait::FunctionLike.
+    unsigned getNumFuncArguments() { return getType().getInputs().size(); }
+
+    /// Returns the number of results. This is a hook for OpTrait::FunctionLike.
+    unsigned getNumFuncResults() { return getType().getResults().size(); }
+
+    /// Hook for OpTrait::FunctionLike, called after verifying that the 'type'
+    /// attribute is present and checks if it holds a function type. Ensures
+    /// getType, getNumFuncArguments, and getNumFuncResults can be called
+    /// safely.
+    LogicalResult verifyType() {
+      auto type = getTypeAttr().getValue();
+      if (!type.isa<FunctionType>())
+        return emitOpError("requires '" + getTypeAttrName() +
+                           "' attribute of function type");
+      return success();
+    }
+  }];
+
+  let parser = [{ return ::parse$cppClass(parser, result); }];
+  let printer = [{ return ::print(*this, p); }];
+  let verifier = [{ return ::verify$cppClass(*this); }];
+}
+
+def InstanceOp : FSMOp<"instance", [Symbol, HasCustomSSAName]> {
+  let summary = "Create an instance of a state machine";
+  let description = [{
+    `fsm.instance` represents an instance of a state machine, including an
+    instance name and a symbol reference of the machine.
+  }];
+
+  let arguments = (ins StrAttr:$sym_name, FlatSymbolRefAttr:$machine);
+  let results = (outs InstanceType:$instance);
+
+  let assemblyFormat = [{ $sym_name $machine attr-dict }];
+
+  let extraClassDeclaration = [{
+    /// Lookup the machine for the symbol. This returns null on invalid IR.
+    MachineOp getMachine();
+  }];
+
+  let verifier = [{ return ::verify$cppClass(*this); }];
+}
+
+def TriggerOp : FSMOp<"trigger", []> {
+  let summary = "Trigger an instance";
+  let description = [{
+    `fsm.trigger` triggers a state machine instance. The inputs and outputs are
+    correponding to the inputs and outputs of the referenced machine of the
+    instance.
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$inputs, InstanceType:$instance);
+  let results = (outs Variadic<AnyType>:$outputs);
+
+  let assemblyFormat = [{
+    $instance attr-dict `(` $inputs `)` `:` functional-type($inputs, $outputs)
+  }];
+
+  let extraClassDeclaration = [{
+    /// Lookup the machine for the symbol. This returns null on invalid IR.
+    MachineOp getMachine();
+  }];
+
+  let verifier = [{ return ::verify$cppClass(*this); }];
+}
+
+def HWInstanceOp : FSMOp<"hw_instance", [Symbol, AttrSizedOperandSegments]> {
+  let summary = "Create a hardware-style instance of a state machine";
+  let description = [{
+    `fsm.hw_instance` represents a hardware-style instance of a state machine,
+    including an instance name and a symbol reference of the machine. The inputs
+    and outputs are correponding to the inputs and outputs of the referenced
+    machine.
+  }];
+
+  let arguments = (ins StrAttr:$sym_name, FlatSymbolRefAttr:$machine,
+                       Variadic<AnyType>:$inputs, Optional<AnyType>:$clock,
+                       Optional<AnyType>:$reset);
+  let results = (outs Variadic<AnyType>:$outputs);
+
+  let assemblyFormat = [{
+    $sym_name $machine attr-dict `(` $inputs `)` `:`
+    functional-type($inputs, $outputs) (`,` `clock` $clock^ `:` type($clock))?
+    (`,` `reset` $reset^ `:` type($reset))?
+  }];
+
+  let extraClassDeclaration = [{
+    /// Lookup the machine for the symbol. This returns null on invalid IR.
+    MachineOp getMachine();
+  }];
+
+  let verifier = [{ return ::verify$cppClass(*this); }];
+}
+
+def StateOp : FSMOp<"state", [HasParent<"MachineOp">, Symbol,
+       SingleBlockImplicitTerminator<"OutputOp">]> {
+  let summary = "Define a state of a machine";
+  let description = [{
+    `fsm.state` represents a state of a state machine. This op includes an
+    `$output` region with an `fsm.output` as terminator to define the machine
+    outputs under this state. This op also includes a `transitions` region that
+    contains all the transitions of this state.
+  }];
+
+  let arguments = (ins StrAttr:$sym_name);
+  let regions = (region SizedRegion<1>:$output, SizedRegion<1>:$transitions);
+
+  let hasCanonicalizeMethod = true;
+
+  let assemblyFormat = [{
+    $sym_name attr-dict `output` $output `transitions` $transitions
+  }];
+}
+
+def OutputOp : FSMOp<"output", [HasParent<"StateOp">, ReturnLike, Terminator]> {
+  let summary = "Output values from a state machine";
+  let description = [{
+    "fsm.output" represents the outputs of a machine under a specific state. The
+    types of `$operands` should be consistent with the output types of the state
+    machine.
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$operands);
+
+  let builders = [ OpBuilder<(ins), "build($_builder, $_state, llvm::None);"> ];
+
+  let assemblyFormat = [{ attr-dict ($operands^ `:` type($operands))? }];
+
+  let verifier = [{ return ::verify$cppClass(*this); }];
+}
+
+def TransitionOp : FSMOp<"transition", [HasParent<"StateOp">,
+      SingleBlockImplicitTerminator<"ReturnOp">]> {
+  let summary = "Define a transition of a state";
+  let description = [{
+    `fsm.transition` represents a transition of a state with a symbol reference
+    of the next state. This op includes a `$guard` region with an `fsm.return`
+    as terminator that returns a Boolean value indicating the guard condition of
+    this transition. This op also includes an `$action` region that represents
+    the actions to be executed when this transition is taken.
+  }];
+
+  let arguments = (ins FlatSymbolRefAttr:$nextState);
+  let regions = (region SizedRegion<1>:$guard, SizedRegion<1>:$action);
+
+  let hasCanonicalizeMethod = true;
+
+  let assemblyFormat = [{
+    $nextState attr-dict `guard` $guard `action` $action
+  }];
+
+  let extraClassDeclaration = [{
+    /// Lookup the next state for the symbol. This returns null on invalid IR.
+    StateOp getNextState();
+
+    /// Get the current state, this should never fail.
+    StateOp getCurrentState() {
+      return (*this)->getParentOfType<StateOp>();
+    }
+
+    /// Get the return operation of the guard region, this should never fail.
+    ReturnOp getGuardReturn() {
+      return cast<ReturnOp>(guard().front().getTerminator());
+    }
+
+    bool isAlwaysTaken();
+  }];
+
+  let verifier = [{ return ::verify$cppClass(*this); }];
+}
+
+def ReturnOp : FSMOp<"return", [HasParent<"TransitionOp">, ReturnLike,
+      Terminator]> {
+  let summary = "Return values from a region";
+  let description = [{
+    "fsm.return" marks the end of a region of `fsm.transition` and return
+    values if the parent region is a `$guard` region.
+  }];
+
+  let arguments = (ins Optional<I1>:$operand);
+
+  let builders = [ OpBuilder<(ins), "build($_builder, $_state, Value());"> ];
+
+  let assemblyFormat = [{ attr-dict ($operand^)? }];
+}
+
+def VariableOp : FSMOp<"variable", [HasParent<"MachineOp">, HasCustomSSAName,
+      FirstAttrDerivedResultType]> {
+  let summary = "Declare a variable in a state machine";
+  let description = [{
+    `fsm.variable` represents an internal variable in a state machine with an
+    initialization value.
+  }];
+
+  let arguments = (ins AnyAttr:$initValue, StrAttr:$name);
+  let results = (outs AnyType:$result);
+
+  let assemblyFormat = [{ $name attr-dict `:` type($result) }];
+}
+
+def UpdateOp : FSMOp<"update", [HasParent<"TransitionOp">, SameTypeOperands]> {
+  let summary = "Update a variable in a state machine";
+  let description = [{
+    `fsm.update` updates the `$variable` with the `$value`. The definition op of
+    `$variable` should be an `fsm.variable`. This op should *only* appear in the
+    `action` region of a transtion.
+  }];
+
+  let arguments = (ins AnyType:$variable, AnyType:$value);
+
+  let assemblyFormat = [{ attr-dict $variable `,` $value `:` type($value) }];
+
+  let extraClassDeclaration = [{
+    /// Get the targeted variable operation. This returns null on invalid IR.
+    VariableOp getVariable();
+  }];
+
+  let verifier = [{ return ::verify$cppClass(*this); }];
+}
+
+#endif // CIRCT_DIALECT_FSM_FSMOPS_TD

--- a/include/circt/Dialect/FSM/FSMTypes.h
+++ b/include/circt/Dialect/FSM/FSMTypes.h
@@ -1,0 +1,18 @@
+//===- FSMTypes.h - Definition of FSM dialect types -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_FSM_FSMTYPES_H
+#define CIRCT_DIALECT_FSM_FSMTYPES_H
+
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/Types.h"
+
+#define GET_TYPEDEF_CLASSES
+#include "circt/Dialect/FSM/FSMTypes.h.inc"
+
+#endif // CIRCT_DIALECT_FSM_FSMTYPES_H

--- a/include/circt/Dialect/FSM/FSMTypes.td
+++ b/include/circt/Dialect/FSM/FSMTypes.td
@@ -1,0 +1,21 @@
+//===- FSMTypes.td - Definition of FSM dialect types ----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_FSM_FSMTYPES_TD
+#define CIRCT_DIALECT_FSM_FSMTYPES_TD
+
+def InstanceType : FSMType<"Instance"> {
+  let summary = "An FSM instance type";
+  let description = [{
+    Represents an FSM instance.
+  }];
+  let mnemonic = "instance";
+  let parameters = (ins);
+}
+
+#endif // CIRCT_DIALECT_FSM_FSMTYPES_TD

--- a/lib/Dialect/FSM/CMakeLists.txt
+++ b/lib/Dialect/FSM/CMakeLists.txt
@@ -7,5 +7,6 @@ add_circt_dialect_library(CIRCTFSM
   MLIRFSMIncGen
 
   LINK_LIBS PUBLIC
+  MLIRStandard
   MLIRIR
   )

--- a/lib/Dialect/FSM/FSMOps.cpp
+++ b/lib/Dialect/FSM/FSMOps.cpp
@@ -18,6 +18,329 @@ using namespace circt;
 using namespace fsm;
 
 //===----------------------------------------------------------------------===//
+// MachineOp
+//===----------------------------------------------------------------------===//
+
+void MachineOp::build(OpBuilder &builder, OperationState &state, StringRef name,
+                      Type stateType, FunctionType type,
+                      ArrayRef<NamedAttribute> attrs,
+                      ArrayRef<DictionaryAttr> argAttrs) {
+  state.addAttribute(mlir::SymbolTable::getSymbolAttrName(),
+                     builder.getStringAttr(name));
+  state.addAttribute("stateType", TypeAttr::get(stateType));
+  state.addAttribute(getTypeAttrName(), TypeAttr::get(type));
+  state.attributes.append(attrs.begin(), attrs.end());
+  state.addRegion();
+
+  if (argAttrs.empty())
+    return;
+  assert(type.getNumInputs() == argAttrs.size());
+  function_like_impl::addArgAndResultAttrs(builder, state, argAttrs,
+                                           /*resultAttrs=*/llvm::None);
+}
+
+/// Get the default state of the machine.
+StateOp MachineOp::getDefaultState() { return *getOps<StateOp>().begin(); }
+
+/// Get the port information of the machine.
+void MachineOp::getHWPortInfo(
+    SmallVectorImpl<circt::hw::ModulePortInfo> &ports) {
+  ports.clear();
+  auto machineType = getType();
+  auto builder = Builder(*this);
+
+  for (unsigned i = 0, e = machineType.getNumInputs(); i < e; ++i) {
+    circt::hw::ModulePortInfo port;
+    port.name = builder.getStringAttr("in" + std::to_string(i));
+    port.direction = circt::hw::PortDirection::INPUT;
+    port.type = machineType.getInput(i);
+    port.argNum = i;
+    ports.push_back(port);
+  }
+
+  for (unsigned i = 0, e = machineType.getNumResults(); i < e; ++i) {
+    circt::hw::ModulePortInfo port;
+    port.name = builder.getStringAttr("out" + std::to_string(i));
+    port.direction = circt::hw::PortDirection::OUTPUT;
+    port.type = machineType.getResult(i);
+    port.argNum = i;
+    ports.push_back(port);
+  }
+}
+
+static ParseResult parseMachineOp(OpAsmParser &parser, OperationState &result) {
+  auto buildFuncType = [](Builder &builder, ArrayRef<Type> argTypes,
+                          ArrayRef<Type> results,
+                          function_like_impl::VariadicFlag, std::string &) {
+    return builder.getFunctionType(argTypes, results);
+  };
+
+  return function_like_impl::parseFunctionLikeOp(
+      parser, result, /*allowVariadic=*/false, buildFuncType);
+}
+
+static void print(MachineOp op, OpAsmPrinter &p) {
+  FunctionType fnType = op.getType();
+  function_like_impl::printFunctionLikeOp(
+      p, op, fnType.getInputs(), /*isVariadic=*/false, fnType.getResults());
+}
+
+static LogicalResult compareTypes(TypeRange rangeA, TypeRange rangeB) {
+  if (rangeA.size() != rangeB.size())
+    return failure();
+
+  int64_t index = 0;
+  for (auto zip : llvm::zip(rangeA, rangeB)) {
+    if (std::get<0>(zip) != std::get<1>(zip))
+      return failure();
+    ++index;
+  }
+
+  return success();
+}
+
+static LogicalResult verifyMachineOp(MachineOp op) {
+  // If this function is external there is nothing to do.
+  if (op.isExternal())
+    return success();
+
+  if (!op.stateType().isa<IntegerType>())
+    return op.emitOpError("state must be integer type");
+
+  // Verify that the argument list of the function and the arg list of the entry
+  // block line up.  The trait already verified that the number of arguments is
+  // the same between the signature and the block.
+  if (failed(compareTypes(op.getType().getInputs(),
+                          op.front().getArgumentTypes())))
+    return op.emitOpError(
+        "entry block argument types must match the machine input types");
+
+  // Verify that the machine only has one block terminated with OutputOp.
+  if (!llvm::hasSingleElement(op))
+    return op.emitOpError("must only have a single block");
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// InstanceOp
+//===----------------------------------------------------------------------===//
+
+/// Lookup the machine for the symbol.  This returns null on invalid IR.
+MachineOp InstanceOp::getMachine() {
+  auto module = (*this)->getParentOfType<ModuleOp>();
+  return module.lookupSymbol<MachineOp>(machine());
+}
+
+static LogicalResult verifyInstanceOp(InstanceOp op) {
+  auto machine = op.getMachine();
+  if (!machine)
+    return op.emitError("cannot find machine definition '")
+           << op.machine() << "'";
+
+  return success();
+}
+
+void InstanceOp::getAsmResultNames(
+    function_ref<void(Value, StringRef)> setNameFn) {
+  setNameFn(instance(), sym_name());
+}
+
+//===----------------------------------------------------------------------===//
+// TriggerOp
+//===----------------------------------------------------------------------===//
+
+template <typename OpType>
+static LogicalResult verifyCallerTypes(OpType op) {
+  auto machine = op.getMachine();
+  if (!machine)
+    return op.emitError("cannot find machine definition");
+
+  // Check operand types first.
+  if (failed(compareTypes(machine.getType().getInputs(),
+                          op.inputs().getTypes()))) {
+    auto diag =
+        op.emitOpError("operand types must match the machine input types");
+    diag.attachNote(machine->getLoc()) << "original machine declared here";
+    return failure();
+  }
+
+  // Check result types.
+  if (failed(compareTypes(machine.getType().getResults(),
+                          op.outputs().getTypes()))) {
+    auto diag =
+        op.emitOpError("result types must match the machine output types");
+    diag.attachNote(machine->getLoc()) << "original machine declared here";
+    return failure();
+  }
+
+  return success();
+}
+
+/// Lookup the machine for the symbol.  This returns null on invalid IR.
+MachineOp TriggerOp::getMachine() {
+  auto instanceOp = instance().getDefiningOp<InstanceOp>();
+  if (!instanceOp)
+    return nullptr;
+
+  return instanceOp.getMachine();
+}
+
+static LogicalResult verifyTriggerOp(TriggerOp op) {
+  return verifyCallerTypes(op);
+}
+
+//===----------------------------------------------------------------------===//
+// HWInstanceOp
+//===----------------------------------------------------------------------===//
+
+/// Lookup the machine for the symbol.  This returns null on invalid IR.
+MachineOp HWInstanceOp::getMachine() {
+  auto module = (*this)->getParentOfType<ModuleOp>();
+  return module.lookupSymbol<MachineOp>(machine());
+}
+
+static LogicalResult verifyHWInstanceOp(HWInstanceOp op) {
+  return verifyCallerTypes(op);
+}
+
+//===----------------------------------------------------------------------===//
+// StateOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult StateOp::canonicalize(StateOp op, PatternRewriter &rewriter) {
+  bool hasAlwaysTakenTransition = false;
+  SmallVector<TransitionOp, 4> transitionsToErase;
+  // Remove all transitions after an "always-taken" transition.
+  for (auto transition : op.transitions().getOps<TransitionOp>()) {
+    if (!hasAlwaysTakenTransition)
+      hasAlwaysTakenTransition = transition.isAlwaysTaken();
+    else
+      transitionsToErase.push_back(transition);
+  }
+
+  for (auto transition : transitionsToErase)
+    rewriter.eraseOp(transition);
+
+  return failure(transitionsToErase.empty());
+}
+
+//===----------------------------------------------------------------------===//
+// OutputOp
+//===----------------------------------------------------------------------===//
+
+static LogicalResult verifyOutputOp(OutputOp op) {
+  if (op->getParentRegion() == &op->getParentOfType<StateOp>().transitions()) {
+    if (op.getNumOperands() != 0)
+      op.emitOpError("transitions region must not output any value");
+    return success();
+  }
+
+  // Verify that the result list of the machine and the operand list of the
+  // OutputOp line up.
+  auto machine = op->getParentOfType<MachineOp>();
+  if (failed(
+          compareTypes(machine.getType().getResults(), op.getOperandTypes())))
+    return op.emitOpError("operand types must match the machine output types");
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// TransitionOp
+//===----------------------------------------------------------------------===//
+
+/// Lookup the next state for the symbol. This returns null on invalid IR.
+StateOp TransitionOp::getNextState() {
+  auto machineOp = (*this)->getParentOfType<MachineOp>();
+  if (!machineOp)
+    return nullptr;
+
+  return machineOp.lookupSymbol<StateOp>(nextState());
+}
+
+bool TransitionOp::isAlwaysTaken() {
+  auto guardReturn = getGuardReturn();
+  if (guardReturn.getNumOperands() == 0)
+    return true;
+
+  if (auto constantOp =
+          guardReturn.getOperand(0).getDefiningOp<mlir::ConstantOp>())
+    return constantOp.value().cast<BoolAttr>().getValue();
+
+  return false;
+}
+
+LogicalResult TransitionOp::canonicalize(TransitionOp op,
+                                         PatternRewriter &rewriter) {
+  auto guardReturn = op.getGuardReturn();
+  if (guardReturn.getNumOperands() == 1)
+    if (auto constantOp =
+            guardReturn.getOperand(0).getDefiningOp<mlir::ConstantOp>()) {
+      // Simplify when the guard region returns a constant value.
+      if (constantOp.value().cast<BoolAttr>().getValue()) {
+        // Replace the original return op with a new one without any operands
+        // if the constant is TRUE.
+        rewriter.setInsertionPoint(guardReturn);
+        rewriter.create<fsm::ReturnOp>(guardReturn.getLoc());
+        rewriter.eraseOp(guardReturn);
+      } else {
+        // Erase the whole transition op if the constant is FALSE, because the
+        // transition will never be taken.
+        rewriter.eraseOp(op);
+      }
+      return success();
+    }
+
+  return failure();
+}
+
+static LogicalResult verifyTransitionOp(TransitionOp op) {
+  if (!op.getNextState())
+    return op.emitOpError("cannot find the definition of the next state `")
+           << op.nextState() << "`";
+
+  // Verify the action region.
+  if (op.action().front().getTerminator()->getNumOperands() != 0)
+    return op.emitOpError("action region must not return any value");
+
+  // Verify the transition is located in the correct region.
+  if (op->getParentRegion() != &op.getCurrentState().transitions())
+    return op.emitOpError("must only be located in the transitions region");
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// VariableOp
+//===----------------------------------------------------------------------===//
+
+void VariableOp::getAsmResultNames(
+    function_ref<void(Value, StringRef)> setNameFn) {
+  setNameFn(result(), name());
+}
+
+//===----------------------------------------------------------------------===//
+// UpdateOp
+//===----------------------------------------------------------------------===//
+
+/// Get the targeted variable operation. This returns null on invalid IR.
+VariableOp UpdateOp::getVariable() {
+  return variable().getDefiningOp<VariableOp>();
+}
+
+static LogicalResult verifyUpdateOp(UpdateOp op) {
+  if (!op.getVariable())
+    return op.emitOpError("destination is not a variable operation");
+
+  if (!op->getParentOfType<TransitionOp>().action().isAncestor(
+          op->getParentRegion()))
+    return op.emitOpError("must only be located in the action region");
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // TableGen generated logic
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/FSM/FSMTypes.cpp
+++ b/lib/Dialect/FSM/FSMTypes.cpp
@@ -1,0 +1,41 @@
+//===- FSMTypes.cpp - Implementation of FSM dialect types -----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/FSM/FSMTypes.h"
+#include "circt/Dialect/FSM/FSMOps.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringSwitch.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace circt;
+using namespace fsm;
+
+#define GET_TYPEDEF_CLASSES
+#include "circt/Dialect/FSM/FSMTypes.cpp.inc"
+
+/// Parses a type registered to this dialect. Parse out the mnemonic then invoke
+/// the tblgen'd type parser dispatcher.
+Type FSMDialect::parseType(DialectAsmParser &parser) const {
+  llvm::StringRef mnemonic;
+  if (parser.parseKeyword(&mnemonic))
+    return Type();
+  Type genType;
+  auto parseResult =
+      generatedTypeParser(getContext(), parser, mnemonic, genType);
+  if (parseResult.hasValue())
+    return genType;
+  parser.emitError(parser.getNameLoc(), "unknown FSM type: ") << mnemonic;
+  return {};
+}
+
+void FSMDialect::printType(Type type, DialectAsmPrinter &printer) const {
+  if (succeeded(generatedTypePrinter(type, printer)))
+    return;
+  llvm_unreachable("unexpected FSM type");
+}

--- a/test/Dialect/FSM/basics.mlir
+++ b/test/Dialect/FSM/basics.mlir
@@ -1,0 +1,106 @@
+// RUN: circt-opt %s | FileCheck %s
+
+// CHECK: fsm.machine @foo(%arg0: i1) -> i1 attributes {stateType = i1} {
+// CHECK:   %cnt = fsm.variable "cnt" {initValue = 0 : i16} : i16
+// CHECK:   fsm.state "IDLE" output  {
+// CHECK:     %true = constant true
+// CHECK:     fsm.output %true : i1
+// CHECK:   } transitions  {
+// CHECK:     fsm.transition @BUSY guard  {
+// CHECK:       fsm.return %arg0
+// CHECK:     } action  {
+// CHECK:       %c256_i16 = constant 256 : i16
+// CHECK:       fsm.update %cnt, %c256_i16 : i16
+// CHECK:     }
+// CHECK:   }
+// CHECK:   fsm.state "BUSY" output  {
+// CHECK:     %false = constant false
+// CHECK:     fsm.output %false : i1
+// CHECK:   } transitions  {
+// CHECK:     fsm.transition @BUSY guard  {
+// CHECK:       %c0_i16 = constant 0 : i16
+// CHECK:       %0 = cmpi ne, %cnt, %c0_i16 : i16
+// CHECK:       fsm.return %0
+// CHECK:     } action  {
+// CHECK:       %c1_i16 = constant 1 : i16
+// CHECK:       %0 = subi %cnt, %c1_i16 : i16
+// CHECK:       fsm.update %cnt, %0 : i16
+// CHECK:     }
+// CHECK:     fsm.transition @IDLE guard  {
+// CHECK:       %c0_i16 = constant 0 : i16
+// CHECK:       %0 = cmpi eq, %cnt, %c0_i16 : i16
+// CHECK:       fsm.return %0
+// CHECK:     } action  {
+// CHECK:     }
+// CHECK:   }
+// CHECK: }
+// CHECK: hw.module @bar(%clk: i1, %rst_n: i1) {
+// CHECK:   %true = hw.constant true
+// CHECK:   %0 = fsm.hw_instance "foo_inst" @foo(%true) : (i1) -> i1, clock %clk : i1, reset %rst_n : i1
+// CHECK:   hw.output
+// CHECK: }
+// CHECK: func @qux() {
+// CHECK:   %foo_inst = fsm.instance "foo_inst" @foo
+// CHECK:   %true = constant true
+// CHECK:   %0 = fsm.trigger %foo_inst(%true) : (i1) -> i1
+// CHECK:   %false = constant false
+// CHECK:   %1 = fsm.trigger %foo_inst(%false) : (i1) -> i1
+// CHECK:   return
+// CHECK: }
+
+fsm.machine @foo(%arg0: i1) -> i1 attributes {stateType = i1} {
+  %cnt = fsm.variable "cnt" {initValue = 0 : i16} : i16
+
+  fsm.state "IDLE" output  {
+    %true = constant true
+    fsm.output %true : i1
+  } transitions  {
+    // Transit to BUSY when `arg0` is true.
+    fsm.transition @BUSY guard  {
+      fsm.return %arg0
+    } action  {
+      %c256_i16 = constant 256 : i16
+      fsm.update %cnt, %c256_i16 : i16
+    }
+  }
+
+  fsm.state "BUSY" output  {
+    %false = constant false
+    fsm.output %false : i1
+  } transitions  {
+    // Transit to BUSY itself when `cnt` is not equal to zero. Meanwhile,
+    // decrease `cnt` by one.
+    fsm.transition @BUSY guard  {
+      %c0_i16 = constant 0 : i16
+      %0 = cmpi ne, %cnt, %c0_i16 : i16
+      fsm.return %0
+    } action  {
+      %c1_i16 = constant 1 : i16
+      %0 = subi %cnt, %c1_i16 : i16
+      fsm.update %cnt, %0 : i16
+    }
+    // Transit back to IDLE when `cnt` is equal to zero.
+    fsm.transition @IDLE guard  {
+      %c0_i16 = constant 0 : i16
+      %0 = cmpi eq, %cnt, %c0_i16 : i16
+      fsm.return %0
+    } action  {
+    }
+  }
+}
+
+// Hardware-style instantiation.
+hw.module @bar(%clk: i1, %rst_n: i1) {
+  %in = hw.constant true
+  %out = fsm.hw_instance "foo_inst" @foo(%in) : (i1) -> i1, clock %clk : i1, reset %rst_n : i1
+}
+
+// Software-style instantiation and triggering.
+func @qux() {
+  %foo_inst = fsm.instance "foo_inst" @foo
+  %in0 = constant true
+  %out0 = fsm.trigger %foo_inst(%in0) : (i1) -> i1
+  %in1 = constant false
+  %out1 = fsm.trigger %foo_inst(%in1) : (i1) -> i1
+  return
+}


### PR DESCRIPTION
This is the first patch factored out from the [FSM proposal PR](https://github.com/llvm/circt/pull/1506), containing the FSM dialect operations and a rationale document. As the FSM operations tightly correlated with each other, I chose to put them together to make this PR more self-contained.

We have updated the definition of some operations after the open meeting discussion. Several major updates:
1. `fsm.state` no longer has `entry` and `exit` region. As a result, all operations executed during a transition are contained in the `action` region of `fsm.transition`.
2. A new region called `output` region is added to `fsm.state` in order to generate the state machine outputs under the current state. In this way, we can better represent the behavior "in" a state rather than only focusing on the behavior of transitions. This update is inspired by the discussion from @teqdruid @stephenneuendorffer @darthscsi on the open meeting.
3. Now we have two ways of FSM instantiation, `fsm.hw_instance` and `fsm.instance`+`fsm.trigger`, to integrate FSMs into HW and SW, respectively.

Please refer to the rationale document and an updated [FSM dialect slides](https://drive.google.com/file/d/18BSgGHsfvUrv-wyT01WGbn-qff3hgn71/view?usp=sharing) for more information.