### PR TITLE
[Comb] Fix shift by constant canonicalizers

### DIFF
--- a/test/Dialect/HW/canonicalization.mlir
+++ b/test/Dialect/HW/canonicalization.mlir
@@ -430,7 +430,7 @@ hw.module @xor_idempotent_two_arguments(%arg0: i11) -> (i11) {
 
 // CHECK-LABEL: hw.module @add_reduction1(%arg0: i11, %arg1: i11) -> (i11) {
 // CHECK-NEXT:    %false = hw.constant false
-// CHECK-NEXT:    [[EXTRACT:%[0-9]+]] = comb.extract %arg1 from 1 : (i11) -> i10
+// CHECK-NEXT:    [[EXTRACT:%[0-9]+]] = comb.extract %arg1 from 0 : (i11) -> i10
 // CHECK-NEXT:    [[CONCAT:%[0-9]+]] = comb.concat [[EXTRACT]], %false : (i10, i1) -> i11
 // CHECK-NEXT:    hw.output [[CONCAT]]
 
@@ -453,7 +453,7 @@ hw.module @add_reduction2(%arg0: i11, %arg1: i11) -> (i11) {
 
 // CHECK-LABEL: hw.module @add_reduction3(%arg0: i11, %arg1: i11) -> (i11) {
 // CHECK-NEXT:    %c0_i3 = hw.constant 0 : i3
-// CHECK-NEXT:    [[EXTRACT:%[0-9]+]] = comb.extract %arg1 from 3 : (i11) -> i8
+// CHECK-NEXT:    [[EXTRACT:%[0-9]+]] = comb.extract %arg1 from 0 : (i11) -> i8
 // CHECK-NEXT:    [[CONCAT:%[0-9]+]] = comb.concat [[EXTRACT]], %c0_i3 : (i8, i3) -> i11
 // CHECK-NEXT:    hw.output [[CONCAT]]
 
@@ -469,7 +469,7 @@ hw.module @add_reduction3(%arg0: i11, %arg1: i11) -> (i11) {
 
 // CHECK-LABEL: hw.module @multiply_reduction(%arg0: i11, %arg1: i11) -> (i11) {
 // CHECK-NEXT:    %false = hw.constant false
-// CHECK-NEXT:    [[EXTRACT:%[0-9]+]] = comb.extract %arg1 from 1 : (i11) -> i10
+// CHECK-NEXT:    [[EXTRACT:%[0-9]+]] = comb.extract %arg1 from 0 : (i11) -> i10
 // CHECK-NEXT:    [[CONCAT:%[0-9]+]] = comb.concat [[EXTRACT]], %false : (i10, i1) -> i11
 // CHECK-NEXT:    hw.output [[CONCAT]]
 
@@ -725,7 +725,7 @@ hw.module @shl_fold4(%arg0: i12) -> (i12) {
 
 // CHECK-LABEL: hw.module @shl_shift_to_extract_and_concat(%arg0: i12) -> (i12) {
 // CHECK-NEXT:   %c0_i2 = hw.constant 0 : i2
-// CHECK-NEXT:   %0 = comb.extract %arg0 from 2 : (i12) -> i10
+// CHECK-NEXT:   %0 = comb.extract %arg0 from 0 : (i12) -> i10
 // CHECK-NEXT:   %1 = comb.concat %0, %c0_i2 : (i10, i2) -> i12
 // CHECK-NEXT:   hw.output %1
 hw.module @shl_shift_to_extract_and_concat(%arg0: i12) -> (i12) {
@@ -773,7 +773,7 @@ hw.module @shru_fold4(%arg0: i12) -> (i12) {
 
 // CHECK-LABEL: hw.module @shru_shift_to_extract_and_concat(%arg0: i12) -> (i12) {
 // CHECK-NEXT:   %c0_i2 = hw.constant 0 : i2
-// CHECK-NEXT:   %0 = comb.extract %arg0 from 0 : (i12) -> i10
+// CHECK-NEXT:   %0 = comb.extract %arg0 from 2 : (i12) -> i10
 // CHECK-NEXT:   %1 = comb.concat %c0_i2, %0 : (i2, i10) -> i12
 // CHECK-NEXT:   hw.output %1
 hw.module @shru_shift_to_extract_and_concat(%arg0: i12) -> (i12) {
@@ -811,7 +811,7 @@ hw.module @shrs_fold3(%arg0: i12) -> (i12) {
 }
 
 // CHECK-LABEL: hw.module @shru_shift_to_extract_and_concat0(%arg0: i12) -> (i12) {
-// CHECK-NEXT:   %0 = comb.extract %arg0 from 0 : (i12) -> i1
+// CHECK-NEXT:   %0 = comb.extract %arg0 from 11 : (i12) -> i1
 // CHECK-NEXT:   %1 = comb.sext %0 : (i1) -> i12
 // CHECK-NEXT:   hw.output %1 : i12
 hw.module @shru_shift_to_extract_and_concat0(%arg0: i12) -> (i12) {
@@ -821,8 +821,8 @@ hw.module @shru_shift_to_extract_and_concat0(%arg0: i12) -> (i12) {
 }
 
 // CHECK-LABEL: hw.module @shru_shift_to_extract_and_concat1(%arg0: i12) -> (i12) {
-// CHECK-NEXT:   %0 = comb.extract %arg0 from 0 : (i12) -> i1
-// CHECK-NEXT:   %1 = comb.extract %arg0 from 0 : (i12) -> i10
+// CHECK-NEXT:   %0 = comb.extract %arg0 from 11 : (i12) -> i1
+// CHECK-NEXT:   %1 = comb.extract %arg0 from 2 : (i12) -> i10
 // CHECK-NEXT:   %2 = comb.concat %0, %0, %1 : (i1, i1, i10) -> i12
 // CHECK-NEXT:   hw.output %2
 hw.module @shru_shift_to_extract_and_concat1(%arg0: i12) -> (i12) {


### PR DESCRIPTION
The shift by constant canonicalizers extracts the relevant bits from the
value and prepends or appends 0s depending on the direction shifted. The
canonicalizer made a mistake in the extract op generation, chopping off
the high bits when shifting right, and chopping off the low bits when
shifting left.  When doing a signed ShrS, it was using the low bit of the value
as the sign bit.