### PR TITLE
[FIRParser] Support parsing larger vector sizes

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -881,7 +881,7 @@ ParseResult FIRParser::parseType(FIRRTLType &result, const Twine &message) {
   // Handle postfix vector sizes.
   while (consumeIf(FIRToken::l_square)) {
     auto sizeLoc = getToken().getLoc();
-    int32_t size;
+    int64_t size;
     if (parseIntLit(size, "expected width") ||
         parseToken(FIRToken::r_square, "expected ]"))
       return failure();

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -352,6 +352,10 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.memoryport.access %tableValue_port[%i8], %clock : !firrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
     read mport tableValue = base_table_1[i8], clock
 
+    ; Check that we can handle large memory sizes.
+    ; CHECK: %testharness = firrtl.seqmem Undefined : !firrtl.cmemory<vector<uint<8>, 16>, 2147483648>
+    smem testharness : UInt<8>[16][2147483648], undefined
+
     ; CHECK: firrtl.pad %i8, 10 : (!firrtl.uint<8>) -> !firrtl.uint<10>
     node n11 = pad(i8, 10)
 


### PR DESCRIPTION
Using an `int32_t` to parse vector types limits our maximum vector
length to 2147483647. We have memory length 1 higher than that maximum,
and we need to use the `int64_t` parser to support it.