### PR TITLE
[Calyx] Add more operations for emission to native compiler.

### DIFF
--- a/include/circt/Dialect/Calyx/Calyx.td
+++ b/include/circt/Dialect/Calyx/Calyx.td
@@ -57,14 +57,6 @@ class CalyxCell<string mnemonic, list<OpTrait> traits = []> :
     DeclareOpInterfaceMethods<OpAsmOpInterface>
   ])> {}
 
-/// Base class for Calyx primitives.
-class CalyxPrimitive<string mnemonic, list<OpTrait> traits = []> :
-  CalyxCell<mnemonic, traits> {
-    let assemblyFormat = "$instanceName attr-dict `:` type(results)";
-    let arguments = (ins StrAttr:$instanceName);
-    let skipDefaultBuilders = 1;
-}
-
 /// Base class for Calyx containers.
 class CalyxContainer<string mnemonic, list<OpTrait> traits = []> :
   CalyxOp<mnemonic, !listconcat(traits, [

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -10,6 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+/// Base class for Calyx primitives.
+class CalyxPrimitive<string mnemonic, list<OpTrait> traits = []> :
+  CalyxCell<mnemonic, traits> {
+    let assemblyFormat = "$instanceName attr-dict `:` type(results)";
+    let arguments = (ins StrAttr:$instanceName);
+    let skipDefaultBuilders = 1;
+}
+
 def RegisterOp : CalyxPrimitive<"register", [
     SameTypeConstraint<"in", "out">
   ]> {
@@ -53,9 +61,7 @@ def RegisterOp : CalyxPrimitive<"register", [
 
 }
 
-def MemoryOp : CalyxPrimitive<"memory", [
-    HasParent<"ComponentOp">
-  ]> {
+def MemoryOp : CalyxPrimitive<"memory", []> {
   let summary = "Defines a memory";
   let description = [{
     The "calyx.memory" op defines a memory. Memories can have any number of
@@ -69,7 +75,10 @@ def MemoryOp : CalyxPrimitive<"memory", [
     more information.
 
     ```mlir
-      // A 2-dimensional, 8-bit memory.
+      // A 1-dimensional, 32-bit memory. Equivalent representation in the native compiler: std_mem_d1(32, 1, 1)
+      %m0.addr0, %m0.write_data, %m0.write_en, %m0.read_data, %m0.done = calyx.memory "m0"<[1] x 32> [1] : i1, i32, i1, i32, i1
+
+      // A 2-dimensional, 8-bit memory. Equivalent representation in the native compiler: std_mem_d2(8, 64, 64, 6, 6)
       %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.read_data, %m.done = calyx.memory "m"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i8, i1
     ```
   }];

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -75,11 +75,11 @@ def MemoryOp : CalyxPrimitive<"memory", []> {
     more information.
 
     ```mlir
-      // A 1-dimensional, 32-bit memory. Equivalent representation in the native compiler:
+      // A 1-dimensional, 32-bit memory with size dimension 1. Equivalent representation in the native compiler:
       // `m1 = std_mem_d1(32, 1, 1)`
       %m1.addr0, %m1.write_data, %m1.write_en, %m1.read_data, %m1.done = calyx.memory "m1"<[1] x 32> [1] : i1, i32, i1, i32, i1
 
-      // A 2-dimensional, 8-bit memory. Equivalent representation in the native compiler:
+      // A 2-dimensional, 8-bit memory with size dimensions 64 x 64. Equivalent representation in the native compiler:
       // `m2 = std_mem_d2(8, 64, 64, 6, 6)`
       %m2.addr0, %m2.addr1, %m2.write_data, %m2.write_en, %m2.read_data, %m2.done = calyx.memory "m2"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i8, i1
     ```

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -75,11 +75,13 @@ def MemoryOp : CalyxPrimitive<"memory", []> {
     more information.
 
     ```mlir
-      // A 1-dimensional, 32-bit memory. Equivalent representation in the native compiler: std_mem_d1(32, 1, 1)
-      %m0.addr0, %m0.write_data, %m0.write_en, %m0.read_data, %m0.done = calyx.memory "m0"<[1] x 32> [1] : i1, i32, i1, i32, i1
+      // A 1-dimensional, 32-bit memory. Equivalent representation in the native compiler:
+      // `m1 = std_mem_d1(32, 1, 1)`
+      %m1.addr0, %m1.write_data, %m1.write_en, %m1.read_data, %m1.done = calyx.memory "m1"<[1] x 32> [1] : i1, i32, i1, i32, i1
 
-      // A 2-dimensional, 8-bit memory. Equivalent representation in the native compiler: std_mem_d2(8, 64, 64, 6, 6)
-      %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.read_data, %m.done = calyx.memory "m"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i8, i1
+      // A 2-dimensional, 8-bit memory. Equivalent representation in the native compiler:
+      // `m2 = std_mem_d2(8, 64, 64, 6, 6)`
+      %m2.addr0, %m2.addr1, %m2.write_data, %m2.write_en, %m2.read_data, %m2.done = calyx.memory "m2"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i8, i1
     ```
   }];
 

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -155,12 +155,11 @@ private:
         .Case<hw::ConstantOp>([&](auto op) {
           // A constant is defined as <bit-width>'<base><value>, where the base
           // is `b` (binary), `o` (octal), `h` hexadecimal, or `d` (decimal).
-
-          // Emit the Radix-10 version of the ConstantOp.
           APInt value = op.value();
 
           (isIndented ? indent() : os)
               << std::to_string(value.getBitWidth()) << apostrophe() << "d";
+          // We currently default to the decimal represntation.
           value.print(os, /*isSigned=*/false);
         })
         .Default(

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -80,18 +80,18 @@ private:
   std::string RSquare() { return "]"; }
   std::string LParen() { return "("; }
   std::string RParen() { return ")"; }
-  std::string Colon() { return ": "; }
-  std::string Semicolon() { return ";"; }
+  std::string colon() { return ": "; }
+  std::string semicolon() { return ";"; }
   std::string Space() { return " "; }
-  std::string Period() { return "."; }
-  std::string Equals() { return " = "; }
-  std::string Comma() { return ", "; }
-  std::string Arrow() { return " -> "; }
-  std::string Apostrophe() { return "'"; }
-  std::string EndL() { return "\n"; }
-  std::string LBraceEndL() { return LBrace() + EndL(); }
-  std::string RBraceEndL() { return RBrace() + EndL(); }
-  std::string SemicolonEndL() { return Semicolon() + EndL(); }
+  std::string period() { return "."; }
+  std::string equals() { return " = "; }
+  std::string comma() { return ", "; }
+  std::string arrow() { return " -> "; }
+  std::string apostrophe() { return "'"; }
+  std::string endL() { return "\n"; }
+  std::string LBraceEndL() { return LBrace() + endL(); }
+  std::string RBraceEndL() { return RBrace() + endL(); }
+  std::string semicolonEndL() { return semicolon() + endL(); }
 
   /// Emit an error and remark that emission failed.
   InFlightDiagnostic emitError(Operation *op, const Twine &message) {
@@ -150,7 +150,7 @@ private:
           auto ports = getComponentPortInfo(op.getReferencedComponent());
           StringAttr portName = ports[portIndex].name;
           (isIndented ? indent() : os)
-              << op.instanceName() << Period() << portName.getValue();
+              << op.instanceName() << period() << portName.getValue();
         })
         .Case<hw::ConstantOp>([&](auto op) {
           // A constant is defined as <bit-width>'<base><value>, where the base
@@ -160,7 +160,7 @@ private:
           APInt value = op.value();
 
           (isIndented ? indent() : os)
-              << std::to_string(value.getBitWidth()) << Apostrophe() << "d";
+              << std::to_string(value.getBitWidth()) << apostrophe() << "d";
           value.print(os, /*isSigned=*/false);
         })
         .Default(
@@ -176,9 +176,9 @@ private:
     if (op.guard())
       emitOpError(op, "Guards not supported for emission yet.");
     indent() << group.sym_name() << LSquare() << portHole << RSquare()
-             << Equals();
+             << equals();
     emitValue(op.src(), /*isIndented=*/false);
-    os << SemicolonEndL();
+    os << semicolonEndL();
   }
 
   /// Recursively emits the Calyx control.
@@ -288,27 +288,27 @@ void Emitter::emitComponentPorts(ArrayRef<ComponentPortInfo> ports) {
       auto name = port.name.getValue();
       // We only care about the bit width in the emitted .futil file.
       auto bitWidth = port.type.getIntOrFloatBitWidth();
-      os << name << Colon() << bitWidth;
+      os << name << colon() << bitWidth;
 
       if (i + 1 < e)
-        os << Comma();
+        os << comma();
     }
     os << RParen();
   };
   emitPorts(inPorts);
-  os << Arrow();
+  os << arrow();
   emitPorts(outPorts);
 }
 
 void Emitter::emitInstance(InstanceOp op) {
-  indent() << op.instanceName() << Equals() << op.componentName() << LParen()
-           << RParen() << SemicolonEndL();
+  indent() << op.instanceName() << equals() << op.componentName() << LParen()
+           << RParen() << semicolonEndL();
 }
 
 void Emitter::emitRegister(RegisterOp reg) {
   size_t bitWidth = reg.inPort().getType().getIntOrFloatBitWidth();
-  indent() << reg.instanceName() << Equals() << "std_reg" << LParen()
-           << std::to_string(bitWidth) << RParen() << SemicolonEndL();
+  indent() << reg.instanceName() << equals() << "std_reg" << LParen()
+           << std::to_string(bitWidth) << RParen() << semicolonEndL();
 }
 
 void Emitter::emitMemory(MemoryOp memory) {
@@ -320,11 +320,11 @@ void Emitter::emitMemory(MemoryOp memory) {
   }
   indent() << memory.instanceName() << " = std_mem_d"
            << std::to_string(dimension) << LParen() << memory.width()
-           << Comma();
+           << comma();
   for (Attribute size : memory.sizes()) {
     APInt memSize = size.cast<IntegerAttr>().getValue();
     memSize.print(os, /*isSigned=*/false);
-    os << Comma();
+    os << comma();
   }
 
   ArrayAttr addrSizes = memory.addrSizes();
@@ -333,9 +333,9 @@ void Emitter::emitMemory(MemoryOp memory) {
     addrSize.print(os, /*isSigned=*/false);
     if (i + 1 == e)
       continue;
-    os << Comma();
+    os << comma();
   }
-  os << RParen() << SemicolonEndL();
+  os << RParen() << semicolonEndL();
 }
 
 void Emitter::emitAssignment(AssignOp op) {
@@ -344,9 +344,9 @@ void Emitter::emitAssignment(AssignOp op) {
     emitOpError(op, "guard not supported for emission currently");
 
   emitValue(op.dest(), /*isIndented=*/true);
-  os << Equals();
+  os << equals();
   emitValue(op.src(), /*isIndented=*/false);
-  os << SemicolonEndL();
+  os << semicolonEndL();
 }
 
 void Emitter::emitWires(WiresOp op) {
@@ -380,7 +380,7 @@ void Emitter::emitGroup(GroupOp group) {
 }
 
 void Emitter::emitEnable(EnableOp enable) {
-  indent() << enable.groupName() << SemicolonEndL();
+  indent() << enable.groupName() << semicolonEndL();
 }
 
 void Emitter::emitControl(ControlOp control) {

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -38,6 +38,7 @@ static constexpr std::string_view colon() { return ": "; }
 static constexpr std::string_view space() { return " "; }
 static constexpr std::string_view period() { return "."; }
 static constexpr std::string_view questionMark() { return " ? "; }
+static constexpr std::string_view exclamationMark() { return "!"; }
 static constexpr std::string_view equals() { return " = "; }
 static constexpr std::string_view comma() { return ", "; }
 static constexpr std::string_view arrow() { return " -> "; }
@@ -187,7 +188,7 @@ private:
           }
           // The LHS is the value to be negated, and the RHS is a constant with
           // all ones (guaranteed by isBinaryNot).
-          os << "!";
+          os << exclamationMark();
           emitValue(op.inputs()[0], /*isIndented=*/false);
         })
         .Default(

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -29,6 +29,21 @@ using namespace calyx;
 
 namespace {
 
+static constexpr std::string_view LSquare() { return "["; }
+static constexpr std::string_view RSquare() { return "]"; }
+static constexpr std::string_view LParen() { return "("; }
+static constexpr std::string_view RParen() { return ")"; }
+static constexpr std::string_view colon() { return ": "; }
+static constexpr std::string_view Space() { return " "; }
+static constexpr std::string_view period() { return "."; }
+static constexpr std::string_view equals() { return " = "; }
+static constexpr std::string_view comma() { return ", "; }
+static constexpr std::string_view arrow() { return " -> "; }
+static constexpr std::string_view apostrophe() { return "'"; }
+static constexpr std::string_view LBraceEndL() { return "{\n"; }
+static constexpr std::string_view RBraceEndL() { return "}\n"; }
+static constexpr std::string_view semicolonEndL() { return ";\n"; }
+
 /// An emitter for Calyx dialect operations to .futil output.
 struct Emitter {
   Emitter(llvm::raw_ostream &os) : os(os) {}
@@ -74,25 +89,6 @@ struct Emitter {
   void emitMemory(MemoryOp memory);
 
 private:
-  std::string LBrace() { return "{"; }
-  std::string RBrace() { return "}"; }
-  std::string LSquare() { return "["; }
-  std::string RSquare() { return "]"; }
-  std::string LParen() { return "("; }
-  std::string RParen() { return ")"; }
-  std::string colon() { return ": "; }
-  std::string semicolon() { return ";"; }
-  std::string Space() { return " "; }
-  std::string period() { return "."; }
-  std::string equals() { return " = "; }
-  std::string comma() { return ", "; }
-  std::string arrow() { return " -> "; }
-  std::string apostrophe() { return "'"; }
-  std::string endL() { return "\n"; }
-  std::string LBraceEndL() { return LBrace() + endL(); }
-  std::string RBraceEndL() { return RBrace() + endL(); }
-  std::string semicolonEndL() { return semicolon() + endL(); }
-
   /// Emit an error and remark that emission failed.
   InFlightDiagnostic emitError(Operation *op, const Twine &message) {
     encounteredError = true;

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -39,6 +39,7 @@ static constexpr std::string_view period() { return "."; }
 static constexpr std::string_view equals() { return " = "; }
 static constexpr std::string_view comma() { return ", "; }
 static constexpr std::string_view arrow() { return " -> "; }
+static constexpr std::string_view delimiter() { return "\""; }
 static constexpr std::string_view apostrophe() { return "'"; }
 static constexpr std::string_view LBraceEndL() { return "{\n"; }
 static constexpr std::string_view RBraceEndL() { return "}\n"; }
@@ -59,6 +60,17 @@ struct Emitter {
 
   // Program emission
   void emitProgram(ProgramOp op);
+
+  /// Import emission.
+  /// TODO(Calyx): Only import a library if a primitive is used from it.
+  void emitAllImports() {
+    auto emitImport = [&](StringRef path) {
+      os << "import " << delimiter() << path << delimiter() << semicolonEndL();
+    };
+    emitImport("primitives/core.futil");
+    emitImport("primitives/binary_operators.futil");
+    emitImport("primitives/math.futil");
+  }
 
   // Component emission
   void emitComponent(ComponentOp op);
@@ -390,6 +402,7 @@ void Emitter::emitControl(ControlOp control) {
 mlir::LogicalResult circt::calyx::exportCalyx(mlir::ModuleOp module,
                                               llvm::raw_ostream &os) {
   Emitter emitter(os);
+  emitter.emitAllImports();
   for (auto &op : *module.getBody()) {
     if (auto programOp = dyn_cast<ProgramOp>(op))
       emitter.emitProgram(programOp);

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -34,7 +34,7 @@ static constexpr std::string_view RSquare() { return "]"; }
 static constexpr std::string_view LParen() { return "("; }
 static constexpr std::string_view RParen() { return ")"; }
 static constexpr std::string_view colon() { return ": "; }
-static constexpr std::string_view Space() { return " "; }
+static constexpr std::string_view space() { return " "; }
 static constexpr std::string_view period() { return "."; }
 static constexpr std::string_view equals() { return " = "; }
 static constexpr std::string_view comma() { return ", "; }
@@ -108,7 +108,7 @@ private:
   /// }
   template <typename Func>
   void emitCalyxBody(Func emitBody) {
-    os << Space() << LBraceEndL();
+    os << space() << LBraceEndL();
     addIndent();
     emitBody();
     reduceIndent();
@@ -121,7 +121,7 @@ private:
                         StringRef symbolName = "") {
     indent() << sectionName;
     if (!symbolName.empty())
-      os << Space() << symbolName;
+      os << space() << symbolName;
     emitCalyxBody(emitBody);
   }
 
@@ -131,7 +131,7 @@ private:
   template <typename Func>
   void emitCalyxSection(Func emitBody, StringRef symbolName = "") {
     if (!symbolName.empty())
-      os << Space() << symbolName;
+      os << space() << symbolName;
     emitCalyxBody(emitBody);
   }
 
@@ -240,7 +240,7 @@ void Emitter::emitComponent(ComponentOp op) {
   // Emit the ports.
   auto ports = getComponentPortInfo(op);
   emitComponentPorts(ports);
-  os << Space() << LBraceEndL();
+  os << space() << LBraceEndL();
   addIndent();
   WiresOp wires;
   ControlOp control;

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -17,7 +17,6 @@
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
-#include "mlir/Support/LLVM.h"
 #include "mlir/Translation.h"
 #include "llvm/ADT/TypeSwitch.h"
 
@@ -87,6 +86,20 @@ private:
     return op->emitOpError(message);
   }
 
+  /// Helper function for emitting a Calyx section. It emits the body in the
+  /// following format:
+  /// {
+  ///   <body>
+  /// }
+  template <typename Func>
+  void emitCalyxBody(Func emitBody) {
+    os << " {\n";
+    addIndent();
+    emitBody();
+    reduceIndent();
+    indent() << "}\n";
+  }
+
   /// Emits a Calyx section.
   template <typename Func>
   void emitCalyxSection(StringRef sectionName, Func emitBody,
@@ -94,12 +107,7 @@ private:
     indent() << sectionName;
     if (!symbolName.empty())
       os << " " << symbolName;
-    os << " {\n";
-    addIndent();
-
-    emitBody();
-    reduceIndent();
-    indent() << "}\n";
+    emitCalyxBody(emitBody);
   }
 
   /// Overloaded version for names that require port emission in the section
@@ -109,12 +117,7 @@ private:
   void emitCalyxSection(Func emitBody, StringRef symbolName = "") {
     if (!symbolName.empty())
       os << " " << symbolName;
-    os << " {\n";
-    addIndent();
-
-    emitBody();
-    reduceIndent();
-    indent() << "}\n";
+    emitCalyxBody(emitBody);
   }
 
   /// Emits the value of a guard or assignment.

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -167,7 +167,7 @@ private:
 
           (isIndented ? indent() : os)
               << std::to_string(value.getBitWidth()) << apostrophe() << "d";
-          // We currently default to the decimal represntation.
+          // We currently default to the decimal representation.
           value.print(os, /*isSigned=*/false);
         })
         .Default(

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -7,28 +7,70 @@ calyx.program {
     calyx.control {}
   }
 
+  // CHECK-LABEL: component B(in: 1, go: 1, clk: 1, reset: 1) -> (out: 1, done: 1) {
+  calyx.component @B(%in: i1, %go: i1, %clk: i1, %reset: i1) -> (%out: i1, %done: i1) {
+    calyx.wires {}
+    calyx.control {}
+  }
+
   // CHECK-LABEL: component main(go: 1, clk: 1, reset: 1) -> (done: 1) {
   calyx.component @main(%go: i1, %clk: i1, %reset: i1) -> (%done: i1) {
-    // CHECK: cells {
-    // CHECK-NEXT:   c0 = A();
+    // CHECK-LABEL: cells {
+    // CHECK-NEXT:    c0 = A();
+    // CHECK-NEXT:    c1 = B();
+    // CHECK-NEXT:    r = std_reg(8);
+    // CHECK-NEXT:    m0 = std_mem_d1(32, 1, 1);
+    // CHECK-NEXT:    m1 = std_mem_d2(8, 64, 64, 6, 6);
     %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i8, i1, i1, i1, i8, i1
+    %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance "c1" @B : i1, i1, i1, i1, i1, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8, i1, i1, i1, i8, i1
+    %m0.addr0, %m0.write_data, %m0.write_en, %m0.read_data, %m0.done = calyx.memory "m0"<[1] x 32> [1] : i1, i32, i1, i32, i1
+    %m1.addr0, %m1.addr1, %m1.write_data, %m1.write_en, %m1.read_data, %m1.done = calyx.memory "m1"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i8, i1
 
-    // CHECK: wires {
+    // CHECK-LABEL: wires {
     calyx.wires {
-      // CHECK: group Group1 {
-      // CHECK:   c0.in = c0.out;
+      // CHECK-NEXT: group Group1 {
+      // CHECK-NEXT:    Group1[go] = c0.go;
+      // CHECK-NEXT:    c0.in = c0.out;
+      // CHECK-NEXT:    Group1[done] = c0.done;
       calyx.group @Group1 {
+        calyx.group_go %c0.go : i1
         calyx.assign %c0.in = %c0.out : i8
         calyx.group_done %c0.done : i1
+      }
+      // CHECK-LABEL: group Group2 {
+      // CHECK-NEXT:    c1.in = c1.out;
+      // CHECK-NEXT:    Group2[done] = c1.done;
+      calyx.group @Group2 {
+        calyx.assign %c1.in = %c1.out : i1
+        calyx.group_done %c1.done : i1
       }
       // CHECK:   c0.go = 1'd0;
       %c1 = hw.constant 0 : i1
       calyx.assign %c0.go = %c1 : i1
     }
-    // CHECK: control {
+    // CHECK-LABEL: control {
+    // CHECK-NEXT:    seq {
+    // CHECK-NEXT:      Group1;
+    // CHECK-NEXT:      while c1.in with Group2 {
+    // CHECK-NEXT:        Group1;
+    // CHECK-NEXT:        Group1;
+    // CHECK-NEXT:        if c1.in with Group2 {
+    // CHECK-NEXT:          Group2;
+    // CHECK-NEXT:        }
+    // CHECK-NEXT:      }
+    // CHECK-NEXT:    }
+    // CHECK-NEXT:  }
     calyx.control {
       calyx.seq {
         calyx.enable @Group1
+        calyx.while %c1.in with @Group2 {
+          calyx.enable @Group1
+          calyx.enable @Group1
+          calyx.if %c1.in with @Group2 {
+            calyx.enable @Group2
+          }
+        }
       }
     }
   }

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -45,16 +45,16 @@ calyx.program {
       }
       // CHECK-LABEL: group Group2 {
       // CHECK-NEXT:    c1.in = (c1.out | 1'd0) ? c1.out;
-      // CHECK-NEXT:    Group2[done] = (c1.out & 1'd1 & 1'd0) ? c1.done;
+      // CHECK-NEXT:    Group2[done] = (c1.out & 1'd1 & !c1.out) ? c1.done;
       calyx.group @Group2 {
         %or = comb.or %c1.out, %c0 : i1
         calyx.assign %c1.in = %c1.out, %or ? : i1
-        %and = comb.and %c1.out, %c1, %c0 : i1
+        %not = comb.xor %c1.out, %c1 : i1
+        %and = comb.and %c1.out, %c1, %not : i1
         calyx.group_done %c1.done, %and ? : i1
       }
-      %not = comb.xor %c1.out, %c1 : i1
-      // CHECK:   c0.go = !c1.out;
-      calyx.assign %c0.go = %not : i1
+      // CHECK:   c0.go = c1.out;
+      calyx.assign %c0.go = %c1.out : i1
     }
     // CHECK-LABEL: control {
     // CHECK-NEXT:    seq {

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -33,11 +33,12 @@ calyx.program {
     // CHECK-LABEL: wires {
     calyx.wires {
       // CHECK-NEXT: group Group1 {
-      // CHECK-NEXT:    Group1[go] = c0.go;
+      // CHECK-NEXT:    Group1[go] = 1'd0;
       // CHECK-NEXT:    c0.in = c0.out;
       // CHECK-NEXT:    Group1[done] = c0.done;
+      %c1 = hw.constant 0 : i1
       calyx.group @Group1 {
-        calyx.group_go %c0.go : i1
+        calyx.group_go %c1 : i1
         calyx.assign %c0.in = %c0.out : i8
         calyx.group_done %c0.done : i1
       }
@@ -49,7 +50,6 @@ calyx.program {
         calyx.group_done %c1.done : i1
       }
       // CHECK:   c0.go = 1'd0;
-      %c1 = hw.constant 0 : i1
       calyx.assign %c0.go = %c1 : i1
     }
     // CHECK-LABEL: control {

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -1,5 +1,8 @@
 // RUN: circt-translate --export-calyx --verify-diagnostics %s | FileCheck %s --strict-whitespace
 
+// CHECK: import "primitives/core.futil";
+// CHECK: import "primitives/binary_operators.futil";
+// CHECK: import "primitives/math.futil";
 calyx.program {
   // CHECK-LABEL: component A(in: 8, go: 1, clk: 1, reset: 1) -> (out: 8, done: 1) {
   calyx.component @A(%in: i8, %go: i1, %clk: i1, %reset: i1) -> (%out: i8, %done: i1) {

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -4,19 +4,19 @@
 // CHECK: import "primitives/binary_operators.futil";
 // CHECK: import "primitives/math.futil";
 calyx.program {
-  // CHECK-LABEL: component A(in: 8, go: 1, clk: 1, reset: 1) -> (out: 8, done: 1) {
+  // CHECK-LABEL: component A(in: 8, @go go: 1, @clk clk: 1, @reset reset: 1) -> (out: 8, @done done: 1) {
   calyx.component @A(%in: i8, %go: i1, %clk: i1, %reset: i1) -> (%out: i8, %done: i1) {
     calyx.wires {}
     calyx.control {}
   }
 
-  // CHECK-LABEL: component B(in: 1, go: 1, clk: 1, reset: 1) -> (out: 1, done: 1) {
+  // CHECK-LABEL: component B(in: 1, @go go: 1, @clk clk: 1, @reset reset: 1) -> (out: 1, @done done: 1) {
   calyx.component @B(%in: i1, %go: i1, %clk: i1, %reset: i1) -> (%out: i1, %done: i1) {
     calyx.wires {}
     calyx.control {}
   }
 
-  // CHECK-LABEL: component main(go: 1, clk: 1, reset: 1) -> (done: 1) {
+  // CHECK-LABEL: component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   calyx.component @main(%go: i1, %clk: i1, %reset: i1) -> (%done: i1) {
     // CHECK-LABEL: cells {
     // CHECK-NEXT:    c0 = A();

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -56,10 +56,12 @@ calyx.program {
     // CHECK-NEXT:    seq {
     // CHECK-NEXT:      Group1;
     // CHECK-NEXT:      while c1.in with Group2 {
-    // CHECK-NEXT:        Group1;
-    // CHECK-NEXT:        Group1;
-    // CHECK-NEXT:        if c1.in with Group2 {
-    // CHECK-NEXT:          Group2;
+    // CHECK-NEXT:        seq {
+    // CHECK-NEXT:          Group1;
+    // CHECK-NEXT:          Group1;
+    // CHECK-NEXT:          if c1.in with Group2 {
+    // CHECK-NEXT:            Group2;
+    // CHECK-NEXT:          }
     // CHECK-NEXT:        }
     // CHECK-NEXT:      }
     // CHECK-NEXT:    }
@@ -68,10 +70,12 @@ calyx.program {
       calyx.seq {
         calyx.enable @Group1
         calyx.while %c1.in with @Group2 {
-          calyx.enable @Group1
-          calyx.enable @Group1
-          calyx.if %c1.in with @Group2 {
-            calyx.enable @Group2
+          calyx.seq {
+            calyx.enable @Group1
+            calyx.enable @Group1
+            calyx.if %c1.in with @Group2 {
+              calyx.enable @Group2
+            }
           }
         }
       }


### PR DESCRIPTION
- Adds emitters for RegisterOp, MemoryOp, GroupGoOp, GroupDoneOp, SeqOp, WhileOp, IfOp, EnableOp, combinational guards.
- Remove `HasParent` trait from MemoryOp since this is checked by the `Cell` trait (inherited by CalyxCell).
- Move base class for CalyxPrimitive to `CalyxPrimitives.td`.
- Helper functions for constants.
- Simple emitter for imports. Eventually we should provide a constant mapping between primitives and their respective libraries, so that only used libraries are imported (annotated in #1508).
- Adds native compiler's attributes to required ports. This is a quick-fix; search for a better solution is remarked in #1666.
- Closes #1667.

Continued progress on #1508.

For reference, emitted program in `emit.mlir`:

```mlir
import "primitives/core.futil";
import "primitives/binary_operators.futil";
import "primitives/math.futil";
component A(in: 8, @go go: 1, @clk clk: 1, @reset reset: 1) -> (out: 8, @done done: 1) {
  cells {
  }
  wires {
  }
  control {
  }
}
component B(in: 1, @go go: 1, @clk clk: 1, @reset reset: 1) -> (out: 1, @done done: 1) {
  cells {
  }
  wires {
  }
  control {
  }
}
component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
  cells {
    c0 = A();
    c1 = B();
    r = std_reg(8);
    m0 = std_mem_d1(32, 1, 1);
    m1 = std_mem_d2(8, 64, 64, 6, 6);
  }
  wires {
    group Group1 {
      Group1[go] = 1'd0;
      c0.in = c0.out;
      Group1[done] = c0.done;
    }
    group Group2 {
      c1.in = (c1.out | 1'd0) ? c1.out;
      Group2[done] = (c1.out & 1'd1 & !c1.out) ? c1.done;
    }
    c0.go = c1.out;
  }
  control {
    seq {
      Group1;
      while c1.in with Group2 {
        seq {
          Group1;
          Group1;
          if c1.in with Group2 {
            Group2;
          }
        }
      }
    }
  }
}
```