### PR TITLE
[FIRRTL] Add data taps integration test, fix issues

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
@@ -864,6 +864,7 @@ bool circt::firrtl::scatterCustomAnnotations(
         NamedAttrList foo;
         foo.append("class", dict.get("class"));
         foo.append("id", id);
+        foo.append("word", IntegerAttr::get(IntegerType::get(context, 64), i));
         auto canonTarget = canonicalizeTarget(tap.getValue());
         if (!canonTarget)
           return false;

--- a/test/Dialect/FIRRTL/SFCTests/data-taps.anno.json
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps.anno.json
@@ -1,0 +1,29 @@
+[
+  {
+    "class":"firrtl.transforms.NoDedupAnnotation",
+    "target":"~Top|DataTap_2"
+  },
+  {
+    "class":"sifive.enterprise.grandcentral.DataTapsAnnotation",
+    "blackBox":"~Top|DataTap_2",
+    "keys":[
+      {
+        "class":"sifive.enterprise.grandcentral.DataTapModuleSignalKey",
+        "module":"~Top|BlackBox",
+        "internalPath":"foo.bar.in",
+        "portName":"~Top|DataTap_2>_0"
+      },
+      {
+        "class":"sifive.enterprise.grandcentral.DataTapModuleSignalKey",
+        "module":"~Top|BlackBox",
+        "internalPath":"foo.bar.out",
+        "portName":"~Top|DataTap_2>_1"
+      }
+    ]
+  },
+  {
+    "class":"sifive.enterprise.grandcentral.MemTapAnnotation",
+    "source": "~Top|Child>M",
+    "taps":["~Top|MemTap_2>_0", "~Top|MemTap_2>_1"]
+  }
+]

--- a/test/Dialect/FIRRTL/SFCTests/data-taps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps.fir
@@ -1,0 +1,90 @@
+; RUN: firtool --firrtl-grand-central --verilog --annotation-file %S/data-taps.anno.json %s | FileCheck %s
+; Tests extracted from:
+; - github.com/sifive/$internal:
+;   - src/test/scala/grandcentral/DataTapsTest.scala
+
+circuit Top :
+  extmodule BlackBox :
+    input in : UInt<1>
+    output out : UInt<1>
+    defname = BlackBox
+
+  module Child :
+    input clock : Clock
+    input reset : Reset
+    output io : { flip in : UInt<1>, out : UInt<1>}
+
+    inst bb of BlackBox
+    bb.out is invalid
+    bb.in is invalid
+    bb.in <= io.in
+    io.out <= bb.out
+
+    mem M :
+      data-type => UInt<1>
+      depth => 2
+      read-latency => 0
+      write-latency => 1
+      writer => w
+      read-under-write => undefined
+    M.w.clk <= clock
+    M.w.en <= UInt<1>(1)
+    M.w.addr <= UInt<1>(0)
+    M.w.data <= io.in
+    M.w.mask <= UInt<1>(1)
+
+  module ChildWrapper :
+    input clock : Clock
+    input reset : Reset
+    output io : { flip in : UInt<1>, out : UInt<1>}
+
+    inst child of Child
+    child.clock <= clock
+    child.reset <= reset
+    child.io.in <= io.in
+    io.out <= child.io.out
+
+  extmodule DataTap_2 :
+    output _1 : UInt<1>
+    output _0 : UInt<1>
+    defname = DataTap_2
+
+  extmodule MemTap_2 :
+    output _1 : UInt<1>
+    output _0 : UInt<1>
+    defname = MemTap_2
+
+  module Top :
+    input clock : Clock
+    input reset : UInt<1>
+    output io : { flip in : UInt<1>, out : UInt<1>}
+
+    inst child of ChildWrapper
+    child.clock <= clock
+    child.reset <= reset
+    wire in : UInt<1>
+    wire out : UInt<1>
+    inst DataTap_2 of DataTap_2
+    DataTap_2._0 is invalid
+    DataTap_2._1 is invalid
+    in <= DataTap_2._0
+    out <= DataTap_2._1
+    node _child_io_in_T = and(io.in, in)
+    child.io.in <= _child_io_in_T
+    node _io_out_T = and(child.io.out, out)
+    io.out <= _io_out_T
+    inst MemTap_2 of MemTap_2
+
+; CHECK: module DataTap_2_impl_0(
+; CHECK:   output  _1, _0
+; CHECK: );
+; CHECK:   assign _1 = child.child.bb.foo.bar.out;
+; CHECK:   assign _0 = child.child.bb.foo.bar.in;
+; CHECK: endmodule
+
+; CHECK: module MemTap_2_impl_0(
+; CHECK:   output  _1, _0
+; CHECK: );
+; CHECK:   assign _1 = child.child.M.Memory[1];
+; CHECK:   assign _0 = child.child.M.Memory[0];
+; CHECK: endmodule

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -673,10 +673,10 @@ circuit GCTMemTap : %[
     ; CHECK-SAME: %mem: [[A:.+]] {firrtl.annotations =
     ; CHECK-SAME:   #firrtl.subAnno<fieldID = 1,
     ; CHECK-SAME:     {class = "sifive.enterprise.grandcentral.MemTapAnnotation",
-    ; CHECK-SAME:      id = [[ID:[0-9]+]] : i64}>
+    ; CHECK-SAME:      id = [[ID:[0-9]+]] : i64, word = 0 : i64}>
     ; CHECK-SAME:   #firrtl.subAnno<fieldID = 2,
     ; CHECK-SAME:     {class = "sifive.enterprise.grandcentral.MemTapAnnotation",
-    ; CHECK-SAME:      id = [[ID]] : i64}>
+    ; CHECK-SAME:      id = [[ID]] : i64, word = 1 : i64}>
     ; CHECK: firrtl.module @GCTMemTap
     ; CHECK: %mem = firrtl.combmem
     ; CHECK-SAME: annotations = [

--- a/test/Dialect/FIRRTL/grand-central-taps.mlir
+++ b/test/Dialect/FIRRTL/grand-central-taps.mlir
@@ -156,46 +156,14 @@ firrtl.circuit "TestHarness" attributes {
       { class = "firrtl.transforms.NoDedupAnnotation" }
     ],
     portAnnotations = [
-      [{
-      class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
-      id = 0 : i64,
-      portID = 8 : i64,
-      type = "portName" }],
-      [{
-      class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
-      id = 0 : i64,
-      portID = 7 : i64,
-      type = "portName" }],
-      [{
-      class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
-      id = 0 : i64,
-      portID = 6 : i64,
-      type = "portName" }],
-      [{
-      class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
-      id = 0 : i64,
-      portID = 5 : i64,
-      type = "portName" }],
-      [{
-      class = "sifive.enterprise.grandcentral.DataTapModuleSignalKey",
-      internalPath = "schwarzschild.no.more",
-      id = 0 : i64,
-      portID = 4 : i64 }],
-      [{
-      class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
-      id = 0 : i64,
-      portID = 3 : i64,
-      type = "portName" }],
-      [{
-      class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
-      id = 0 : i64,
-      portID = 2 : i64,
-      type = "portName" }],
-      [{
-      class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
-      id = 0 : i64,
-      portID = 1 : i64,
-      type = "portName" }]
+      [{class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = 8 : i64, type = "portName"}],
+      [{class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = 7 : i64, type = "portName"}],
+      [{class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = 6 : i64, type = "portName"}],
+      [{class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = 5 : i64, type = "portName"}],
+      [{class = "sifive.enterprise.grandcentral.DataTapModuleSignalKey", id = 0 : i64, portID = 4 : i64}],
+      [{class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = 3 : i64, type = "portName"}],
+      [{class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = 2 : i64, type = "portName"}],
+      [{class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = 1 : i64, type = "portName"}]
     ],
     defname = "DataTap"
   }
@@ -217,13 +185,9 @@ firrtl.circuit "TestHarness" attributes {
       {class = "firrtl.transforms.NoDedupAnnotation"}
     ],
     portAnnotations = [
- [{
-      class = "sifive.enterprise.grandcentral.MemTapAnnotation",
-      id = 4 : i64 }],
-    [{
-      class = "sifive.enterprise.grandcentral.MemTapAnnotation",
-      id = 4 : i64 }]
-      ],
+      [{class = "sifive.enterprise.grandcentral.MemTapAnnotation", id = 4 : i64, word = 0 : i64}],
+      [{class = "sifive.enterprise.grandcentral.MemTapAnnotation", id = 4 : i64, word = 1 : i64}]
+    ],
     defname = "MemTap"
   }
 


### PR DESCRIPTION
Add the `DataTapTests` from the Scala implementation of FIRRTL as an integration test for the FIRRTL dialect. This uncovers a few subtle breakages in the `GrandCentralTaps` introduced by changes to the annotation scattering code that happened a while back. This fixes those issues and the test ensures we don't have any regressions of this in the future.