### PR TITLE
[FIRRT] use a cached symbol table for resolution of modules

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -46,6 +46,7 @@ def InstanceOp : FIRRTLOp<"instance"> {
     /// Lookup the module or extmodule for the symbol.  This returns null on
     /// invalid IR.
     FModuleLike getReferencedModule();
+    FModuleLike getReferencedModule(SymbolTable& symtbl);
 
     /// Return the port name for the specified result number.
     StringAttr getPortName(size_t resultNo) {

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -939,6 +939,10 @@ FModuleLike InstanceOp::getReferencedModule() {
   return circuit.lookupSymbol<FModuleLike>(moduleName());
 }
 
+FModuleLike InstanceOp::getReferencedModule(SymbolTable &symtbl) {
+  return symtbl.lookup<FModuleLike>(moduleName());
+}
+
 void InstanceOp::build(OpBuilder &builder, OperationState &result,
                        TypeRange resultTypes, StringRef moduleName,
                        StringRef name, ArrayRef<Attribute> annotations,


### PR DESCRIPTION
Let passes use a prepopulated symbol table to resolve modules for instances.

Speedup ranges from none to ~10%.