### PR TITLE
[ExportVerilog] Add always_comb lowering option

### DIFF
--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -62,6 +62,10 @@ struct LoweringOptions {
   // Otherwise, it will print them as always statements
   bool useAlwaysFF = false;
 
+  // If true, ExportVerilog emits AlwaysCombOp as Verilog always_comb
+  // statements.  Otherwise, it will print them as `always @(*)`.
+  bool useAlwaysComb = false;
+
   /// If true, ExportVerilog allows expressions in the sensitivity list of
   /// `always` statements, instead of forcing them to be simple wires. Some EDA
   /// tools rely on these being simple wires.

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -41,6 +41,8 @@ void LoweringOptions::parse(StringRef text, ErrorHandlerT errorHandler) {
       // Empty options are fine.
     } else if (option == "alwaysFF") {
       useAlwaysFF = true;
+    } else if (option == "alwaysComb") {
+      useAlwaysComb = true;
     } else if (option == "exprInEventControl") {
       allowExprInEventControl = true;
     } else if (option == "disallowPackedArrays") {
@@ -65,6 +67,8 @@ std::string LoweringOptions::toString() const {
   // All options should add a trailing comma to simplify the code.
   if (useAlwaysFF)
     options += "alwaysFF,";
+  if (useAlwaysComb)
+    options += "alwaysComb,";
   if (allowExprInEventControl)
     options += "exprInEventControl,";
   if (disallowPackedArrays)

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -2293,8 +2293,12 @@ LogicalResult StmtEmitter::visitSV(AlwaysCombOp op) {
   SmallPtrSet<Operation *, 8> ops;
   ops.insert(op);
 
-  indent() << "always_comb";
-  emitBlockAsStatement(op.getBodyBlock(), ops, "always_comb");
+  StringRef opString = "always @(*)";
+  if (state.options.useAlwaysComb)
+    opString = "always_comb";
+
+  indent() << opString;
+  emitBlockAsStatement(op.getBodyBlock(), ops, opString);
   return success();
 }
 

--- a/test/ExportVerilog/sv-alwayscomb.mlir
+++ b/test/ExportVerilog/sv-alwayscomb.mlir
@@ -1,0 +1,35 @@
+// RUN: circt-translate --split-input-file --export-verilog %s | FileCheck %s --check-prefix=DEFAULT
+// RUN: circt-translate --lowering-options= --split-input-file --export-verilog %s | FileCheck %s --check-prefix=CLEAR
+// RUN: circt-translate --lowering-options=alwaysComb --split-input-file --export-verilog %s | FileCheck %s --check-prefix=ALWAYSCOMB
+
+hw.module @test() {
+  sv.alwayscomb {
+  }
+}
+
+// DEFAULT: always @(*) begin
+// DEFAULT: end // always @(*)
+
+// CLEAR: always @(*) begin
+// CLEAR: end // always @(*)
+
+// ALWAYSCOMB: always_comb begin
+// ALWAYSCOMB: end // always_comb
+
+// -----
+
+module attributes {circt.loweringOptions = "alwaysComb"} {
+hw.module @test() {
+  sv.alwayscomb {
+  }
+}
+}
+
+// DEFAULT: always_comb begin
+// DEFAULT: end // always_comb
+
+// CLEAR: always @(*) begin
+// CLEAR: end // always @(*)
+
+// ALWAYSCOMB: always_comb begin
+// ALWAYSCOMB: end // always_comb

--- a/test/ExportVerilog/sv-dialect.mlir
+++ b/test/ExportVerilog/sv-dialect.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-translate %s -export-verilog -verify-diagnostics --lowering-options=alwaysFF,exprInEventControl | FileCheck %s --strict-whitespace
+// RUN: circt-translate %s -export-verilog -verify-diagnostics --lowering-options=alwaysFF,alwaysComb,exprInEventControl | FileCheck %s --strict-whitespace
 
 // CHECK-LABEL: module M1(
 hw.module @M1(%clock : i1, %cond : i1, %val : i8) {

--- a/test/firtool/style.fir
+++ b/test/firtool/style.fir
@@ -1,10 +1,10 @@
 ; RUN: firtool %s | FileCheck %s --check-prefix=DEFAULT
 ; RUN: not firtool --lowering-options=bad-option %s 2>&1 | FileCheck %s --check-prefix=BADOPTION
-; RUN: firtool --lowering-options=alwaysFF %s | FileCheck %s --check-prefix=ALWAYSFF
+; RUN: firtool --lowering-options=alwaysFF,alwaysComb %s | FileCheck %s --check-prefix=OPTIONS
 
 circuit test :
   module test :
 
 ; DEFAULT: module {
 ; BADOPTION: lowering-options option: unknown style option 'bad-option'
-; ALWAYSFF: module attributes {circt.loweringOptions = "alwaysFF"} {
+; OPTIONS: module attributes {circt.loweringOptions = "alwaysFF,alwaysComb"} {


### PR DESCRIPTION
This add an option to control how `always_comb` is printed by the
verilog exporter.  The default has been changed to print `always_comb`
as `always @(*)`. A lowering option `alwaysComb` has been added, similar
to `alwaysFF`, to use the old printing style.  This change is motivated
by a lack of tool support for the `always_comb` verilog construct.