### PR TITLE
[Calyx] Emitter only imports a library if necessary.

### DIFF
--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -44,10 +44,12 @@ static constexpr std::string_view LBraceEndL() { return "{\n"; }
 static constexpr std::string_view RBraceEndL() { return "}\n"; }
 static constexpr std::string_view semicolonEndL() { return ";\n"; }
 
-/// Maintain which imports should be included for a given program.
+/// A tracker to determine which libraries should be imported for a given
+/// program.
 struct ImportTracker {
 public:
-  /// Returns the list of used imports for this program.
+  /// Returns the list of library names used for in this program.
+  /// E.g. if `primitives/core.futil` is used, returns { "core" }.
   SmallVector<StringRef> getLibraryNames(ProgramOp program) {
     program.walk([&](ComponentOp component) {
       for (auto &op : *component.getBody()) {
@@ -90,7 +92,7 @@ private:
       std::pair("memory", "core"),
   };
 
-  /// Maintains a list of used imports throughout the life time of this
+  /// Maintains a unique list of libraries used throughout the lifetime of the
   /// tracker.
   SmallVector<StringRef, 4> usedLibraries;
 };
@@ -118,6 +120,8 @@ struct Emitter {
   /// Import emission.
   void emitImports(ProgramOp op) {
     auto emitImport = [&](StringRef library) {
+      // Libraries share a common relative path:
+      //   primitives/<library-name>.futil
       os << "import " << delimiter() << "primitives/" << library << period()
          << "futil" << delimiter() << semicolonEndL();
     };

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -78,7 +78,7 @@ private:
         /*.Case<>([&](auto op) { library = "binary_operators"; })*/
         /*.Case<>([&](auto op) { library = "math"; })*/
         .Default([&](auto op) {
-          llvm_unreachable("Op is not a supported primitive.");
+          llvm_unreachable("Type matching failed for this operation.");
         });
     return library;
   }

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -73,8 +73,8 @@ private:
 
     auto it = operationToLibrary.find(name);
     assert(it != operationToLibrary.end() &&
-           "The mapping between primitive operations and imports needs be "
-           "updated.");
+           "Operation not found. The mapping between primitive operations and "
+           "libraries needs be updated for the Calyx Emitter.");
 
     StringRef opLibrary = it->second;
     if (llvm::any_of(usedLibraries,

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -1,8 +1,6 @@
 // RUN: circt-translate --export-calyx --verify-diagnostics %s | FileCheck %s --strict-whitespace
 
 // CHECK: import "primitives/core.futil";
-// CHECK: import "primitives/binary_operators.futil";
-// CHECK: import "primitives/math.futil";
 calyx.program {
   // CHECK-LABEL: component A(in: 8, @go go: 1, @clk clk: 1, @reset reset: 1) -> (out: 8, @done done: 1) {
   calyx.component @A(%in: i8, %go: i1, %clk: i1, %reset: i1) -> (%out: i8, %done: i1) {


### PR DESCRIPTION
Adds a struct that walks the program to determine which libraries are necessary to be imported for the native Calyx compiler.
This is a very simple approach that isn't looking to optimize anything, since the # of operations and # of import is relatively small.

Closes #1675. 

