### PR TITLE
[MSFT] Introduce `RootedInstancePath` and re-factor based on it

### DIFF
--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -113,6 +113,6 @@ class System:
     self.run_passes()
     circt.export_verilog(self.mod, out_stream)
 
-  def print_tcl(self, out_stream: typing.TextIO = sys.stdout):
+  def print_tcl(self, top_module: str, out_stream: typing.TextIO = sys.stdout):
     self.run_passes()
-    msft.export_tcl(self.mod, out_stream)
+    msft.export_tcl(self.get_module(top_module).operation, out_stream)

--- a/frontends/PyCDE/test/instances.py
+++ b/frontends/PyCDE/test/instances.py
@@ -89,15 +89,16 @@ assert instance_attrs.find_unused() is None
 instance_attrs.lookup(pycde.AppID("doesnotexist")).add_attribute(loc)
 assert (len(instance_attrs.find_unused()) == 1)
 
+print("=== Final mlir dump")
 t.print()
 
 # CHECK-LABEL: === Tcl
 print("=== Tcl")
 
 # CHECK-LABEL: proc pycde_Test_config { parent }
-# CHECK-NEXT:  set_location_assignment MPDSP_X0_Y10_N0 -to $parent|pycde_UnParameterized|pycde_Nothing|dsp_inst
-# CHECK-NEXT:  set_location_assignment M20K_X15_Y25_N0 -to $parent|pycde_UnParameterized|pycde_Nothing|memory|bank
-# CHECK-NEXT:  set_location_assignment M20K_X15_Y25_N0 -to $parent|pycde_UnParameterized|memory|bank
-# CHECK-NEXT:  set_location_assignment MPDSP_X1_Y12_N0 -to $parent|pycde_UnParameterized_0|pycde_Nothing|dsp_inst
-# CHECK-NEXT:  set_location_assignment M20K_X39_Y25_N0 -to $parent|pycde_UnParameterized_0|memory|bank
-t.print_tcl()
+# CHECK-DAG:  set_location_assignment MPDSP_X0_Y10_N0 -to $parent|pycde_UnParameterized|pycde_Nothing|dsp_inst
+# CHECK-DAG:  set_location_assignment M20K_X15_Y25_N0 -to $parent|pycde_UnParameterized|pycde_Nothing|memory|bank
+# CHECK-DAG:  set_location_assignment M20K_X15_Y25_N0 -to $parent|pycde_UnParameterized|memory|bank
+# CHECK-DAG:  set_location_assignment MPDSP_X1_Y12_N0 -to $parent|pycde_UnParameterized_0|pycde_Nothing|dsp_inst
+# CHECK-DAG:  set_location_assignment M20K_X39_Y25_N0 -to $parent|pycde_UnParameterized_0|memory|bank
+t.print_tcl("pycde_Test")

--- a/include/circt-c/Dialect/MSFT.h
+++ b/include/circt-c/Dialect/MSFT.h
@@ -26,7 +26,7 @@ MLIR_CAPI_EXPORTED void mlirMSFTRegisterPasses();
 
 /// Emits tcl for the specified module using the provided callback and user
 /// data
-MLIR_CAPI_EXPORTED MlirLogicalResult mlirMSFTExportTcl(MlirModule,
+MLIR_CAPI_EXPORTED MlirLogicalResult mlirMSFTExportTcl(MlirOperation,
                                                        MlirStringCallback,
                                                        void *userData);
 
@@ -62,6 +62,12 @@ CirctMSFTDevType circtMSFTPhysLocationAttrGetDeviceType(MlirAttribute);
 uint64_t circtMSFTPhysLocationAttrGetX(MlirAttribute);
 uint64_t circtMSFTPhysLocationAttrGetY(MlirAttribute);
 uint64_t circtMSFTPhysLocationAttrGetNum(MlirAttribute);
+
+bool circtMSFTAttributeIsARootedInstancePathAttribute(MlirAttribute);
+MlirAttribute circtMSFTRootedInstancePathAttrGet(MlirContext,
+                                                 MlirAttribute rootSym,
+                                                 MlirAttribute *pathStringAttrs,
+                                                 size_t num);
 
 typedef struct {
   MlirAttribute instance;

--- a/include/circt/Dialect/MSFT/ExportTcl.h
+++ b/include/circt/Dialect/MSFT/ExportTcl.h
@@ -23,9 +23,14 @@ class ModuleOp;
 } // namespace mlir
 
 namespace circt {
+namespace hw {
+class HWModuleOp;
+}
+
 namespace msft {
-/// Export TCL for a module.
-mlir::LogicalResult exportQuartusTcl(mlir::ModuleOp module,
+
+/// Export TCL for a specific hw module.
+mlir::LogicalResult exportQuartusTcl(hw::HWModuleOp module,
                                      llvm::raw_ostream &os);
 
 /// Register the Tcl exports.

--- a/include/circt/Dialect/MSFT/MSFT.td
+++ b/include/circt/Dialect/MSFT/MSFT.td
@@ -57,14 +57,26 @@ class MSFT_Attr<string name, list<Trait> traits = [],
   let mnemonic = ?;
 }
 
+def RootedInstancePath : MSFT_Attr<"RootedInstancePath"> {
+  let summary = "A path through the instance hierarchy with the root module";
+  let parameters = (ins
+    "FlatSymbolRefAttr":$rootModule, ArrayRefParameter<"StringAttr">:$path);
+}
+
+def SwitchInstanceCase : MSFT_Attr<"SwitchInstanceCase"> {
+  let summary = "A switch case in the SwitchInstance attribute";
+  let parameters = (ins
+    "RootedInstancePathAttr":$inst, "mlir::Attribute":$attr);
+}
+
 def SwitchInstance : MSFT_Attr<"SwitchInstance"> {
   let summary = "Select an attribute to be use based on the instance";
   let mnemonic = "switch.inst";
   let parameters = (ins
-    ArrayRefParameter<"SwitchInstanceCase">:$cases);
+    ArrayRefParameter<"SwitchInstanceCaseAttr">:$cases);
 
   let extraClassDeclaration = [{
-    Attribute lookup(InstanceIDAttr);
+    Attribute lookup(RootedInstancePathAttr);
   }];
 }
 

--- a/include/circt/Dialect/MSFT/MSFTAttributes.h
+++ b/include/circt/Dialect/MSFT/MSFTAttributes.h
@@ -18,13 +18,6 @@
 
 #include "mlir/IR/BuiltinAttributes.h"
 
-namespace circt {
-namespace msft {
-using InstanceIDAttr = mlir::SymbolRefAttr;
-using SwitchInstanceCase = std::pair<InstanceIDAttr, Attribute>;
-} // namespace msft
-} // namespace circt
-
 #define GET_ATTRDEF_CLASSES
 #include "circt/Dialect/MSFT/MSFTAttributes.h.inc"
 

--- a/lib/CAPI/Dialect/MSFT.cpp
+++ b/lib/CAPI/Dialect/MSFT.cpp
@@ -21,11 +21,15 @@ using namespace circt::msft;
 
 void mlirMSFTRegisterPasses() { circt::msft::registerMSFTPasses(); }
 
-MlirLogicalResult mlirMSFTExportTcl(MlirModule module,
+MlirLogicalResult mlirMSFTExportTcl(MlirOperation module,
                                     MlirStringCallback callback,
                                     void *userData) {
+  Operation *op = unwrap(module);
+  hw::HWModuleOp hwmod = dyn_cast<hw::HWModuleOp>(op);
+  if (!hwmod)
+    return wrap(op->emitOpError("Export TCL can only be run on HWModules"));
   mlir::detail::CallbackOstream stream(callback, userData);
-  return wrap(exportQuartusTcl(unwrap(module), stream));
+  return wrap(exportQuartusTcl(hwmod, stream));
 }
 
 void mlirMSFTRegisterGenerator(MlirContext cCtxt, const char *opName,
@@ -80,6 +84,21 @@ uint64_t circtMSFTPhysLocationAttrGetNum(MlirAttribute attr) {
   return (CirctMSFTDevType)unwrap(attr).cast<PhysLocationAttr>().getNum();
 }
 
+bool circtMSFTAttributeIsARootedInstancePathAttribute(MlirAttribute cAttr) {
+  return unwrap(cAttr).isa<RootedInstancePathAttr>();
+}
+MlirAttribute
+circtMSFTRootedInstancePathAttrGet(MlirContext cCtxt, MlirAttribute cRootSym,
+                                   MlirAttribute *cPathStringAttrs,
+                                   size_t num) {
+  auto ctxt = unwrap(cCtxt);
+  auto rootSym = unwrap(cRootSym).cast<FlatSymbolRefAttr>();
+  SmallVector<StringAttr, 16> path;
+  for (size_t i = 0; i < num; ++i)
+    path.push_back(unwrap(cPathStringAttrs[i]).cast<StringAttr>());
+  return wrap(RootedInstancePathAttr::get(ctxt, rootSym, path));
+}
+
 bool circtMSFTAttributeIsASwitchInstanceAttribute(MlirAttribute attr) {
   return unwrap(attr).isa<SwitchInstanceAttr>();
 }
@@ -87,14 +106,18 @@ MlirAttribute
 circtMSFTSwitchInstanceAttrGet(MlirContext cCtxt,
                                CirctMSFTSwitchInstanceCase *listOfCases,
                                size_t numCases) {
-  SmallVector<SwitchInstanceCase, 64> cases;
+  MLIRContext *ctxt = unwrap(cCtxt);
+  SmallVector<SwitchInstanceCaseAttr, 64> cases;
   for (size_t i = 0; i < numCases; ++i) {
     CirctMSFTSwitchInstanceCase pair = listOfCases[i];
-    auto instance = unwrap(pair.instance).cast<SymbolRefAttr>();
+    Attribute instanceAttr = unwrap(pair.instance);
+    auto instance = instanceAttr.dyn_cast<RootedInstancePathAttr>();
+    assert(instance &&
+           "Expected `RootedInstancePathAttr` in switch instance case.");
     auto attr = unwrap(pair.attr);
-    cases.push_back(std::make_pair(instance, attr));
+    cases.push_back(SwitchInstanceCaseAttr::get(ctxt, instance, attr));
   }
-  return wrap(SwitchInstanceAttr::get(unwrap(cCtxt), cases));
+  return wrap(SwitchInstanceAttr::get(ctxt, cases));
 }
 size_t circtMSFTSwitchInstanceAttrGetNumCases(MlirAttribute attr) {
   return unwrap(attr).cast<SwitchInstanceAttr>().getCases().size();
@@ -103,11 +126,11 @@ void circtMSFTSwitchInstanceAttrGetCases(MlirAttribute attr,
                                          CirctMSFTSwitchInstanceCase *dstArray,
                                          size_t space) {
   auto sw = unwrap(attr).cast<SwitchInstanceAttr>();
-  ArrayRef<SwitchInstanceCase> cases = sw.getCases();
+  ArrayRef<SwitchInstanceCaseAttr> cases = sw.getCases();
   assert(space >= cases.size());
   for (size_t i = 0, e = cases.size(); i < e; ++i) {
     auto c = cases[i];
-    dstArray[i] = {wrap(c.first), wrap(c.second)};
+    dstArray[i] = {wrap(c.getInst()), wrap(c.getAttr())};
   }
 }
 

--- a/lib/Dialect/MSFT/MSFTAttributes.cpp
+++ b/lib/Dialect/MSFT/MSFTAttributes.cpp
@@ -28,14 +28,16 @@ static Attribute parseRootedInstancePath(MLIRContext *ctxt,
   if (p.parseAttribute(root) || p.parseLSquare())
     return Attribute();
   SmallVector<StringAttr, 16> path;
-  do {
-    StringAttr instName;
-    if (p.parseAttribute(instName))
+  if (p.parseOptionalRSquare()) {
+    do {
+      StringAttr instName;
+      if (p.parseAttribute(instName))
+        return Attribute();
+      path.push_back(instName);
+    } while (!p.parseOptionalComma());
+    if (p.parseRSquare())
       return Attribute();
-    path.push_back(instName);
-  } while (!p.parseOptionalComma());
-  if (p.parseRSquare())
-    return Attribute();
+  }
   return RootedInstancePathAttr::get(ctxt, root, path);
 }
 

--- a/lib/Dialect/MSFT/MSFTAttributes.cpp
+++ b/lib/Dialect/MSFT/MSFTAttributes.cpp
@@ -22,6 +22,30 @@ using namespace msft;
 #define GET_ATTRDEF_CLASSES
 #include "circt/Dialect/MSFT/MSFTAttributes.cpp.inc"
 
+static Attribute parseRootedInstancePath(MLIRContext *ctxt,
+                                         DialectAsmParser &p) {
+  FlatSymbolRefAttr root;
+  if (p.parseAttribute(root) || p.parseLSquare())
+    return Attribute();
+  SmallVector<StringAttr, 16> path;
+  do {
+    StringAttr instName;
+    if (p.parseAttribute(instName))
+      return Attribute();
+    path.push_back(instName);
+  } while (!p.parseOptionalComma());
+  if (p.parseRSquare())
+    return Attribute();
+  return RootedInstancePathAttr::get(ctxt, root, path);
+}
+
+static void printRootedInstancePath(RootedInstancePathAttr me,
+                                    DialectAsmPrinter &p) {
+  p << me.getRootModule() << '[';
+  llvm::interleave(me.getPath(), p, ",");
+  p << ']';
+}
+
 Attribute SwitchInstanceAttr::parse(MLIRContext *ctxt, DialectAsmParser &p,
                                     Type type) {
   if (p.parseLess())
@@ -29,13 +53,17 @@ Attribute SwitchInstanceAttr::parse(MLIRContext *ctxt, DialectAsmParser &p,
   if (!p.parseOptionalGreater())
     return SwitchInstanceAttr::get(ctxt, {});
 
-  SmallVector<SwitchInstanceCase> instPairs;
+  SmallVector<SwitchInstanceCaseAttr> instPairs;
   do {
-    SymbolRefAttr instId;
-    Attribute attr;
-    if (p.parseAttribute(instId) || p.parseEqual() || p.parseAttribute(attr))
+    auto path = parseRootedInstancePath(ctxt, p)
+                    .dyn_cast_or_null<RootedInstancePathAttr>();
+    if (!path)
       return Attribute();
-    instPairs.push_back(std::make_pair(instId, attr));
+
+    Attribute attr;
+    if (p.parseEqual() || p.parseAttribute(attr))
+      return Attribute();
+    instPairs.push_back(SwitchInstanceCaseAttr::get(ctxt, path, attr));
   } while (!p.parseOptionalComma());
   if (p.parseGreater())
     return Attribute();
@@ -45,18 +73,19 @@ Attribute SwitchInstanceAttr::parse(MLIRContext *ctxt, DialectAsmParser &p,
 
 void SwitchInstanceAttr::print(DialectAsmPrinter &p) const {
   p << "switch.inst<";
-  llvm::interleaveComma(getCases(), p, [&](auto instPair) {
-    p << instPair.first << '=';
-    p.printAttribute(instPair.second);
+  llvm::interleaveComma(getCases(), p, [&](auto instCase) {
+    printRootedInstancePath(instCase.getInst(), p);
+    p << '=';
+    p.printAttribute(instCase.getAttr());
   });
   p << '>';
 }
 
-Attribute SwitchInstanceAttr::lookup(InstanceIDAttr id) {
+Attribute SwitchInstanceAttr::lookup(RootedInstancePathAttr id) {
   // TODO: This is obviously very slow. Speed this up by using a sorted list.
-  for (auto pair : getCases())
-    if (pair.first == id)
-      return pair.second;
+  for (auto c : getCases())
+    if (c.getInst() == id)
+      return c.getAttr();
   return Attribute();
 }
 

--- a/lib/Dialect/MSFT/TclExport/ExportQuartusTcl.cpp
+++ b/lib/Dialect/MSFT/TclExport/ExportQuartusTcl.cpp
@@ -109,8 +109,8 @@ static LogicalResult emitAttr(TclOutputState &s, RootedInstancePathAttr path,
 static LogicalResult emitAttrs(TclOutputState &s, Operation *root,
                                Operation *op) {
 
-  auto rootName = FlatSymbolRefAttr::get(root->getContext(),
-                                         SymbolTable::getSymbolName(root));
+  auto rootName = FlatSymbolRefAttr::get(
+      root->getContext(), SymbolTable::getSymbolName(root).getValue());
 
   // Iterate again through the attributes, looking for instance-specific
   // attributes.

--- a/lib/Dialect/MSFT/TclExport/ExportQuartusTcl.cpp
+++ b/lib/Dialect/MSFT/TclExport/ExportQuartusTcl.cpp
@@ -25,7 +25,6 @@ using namespace msft;
 
 // TODO: Currently assumes Stratix 10 and QuartusPro. Make more general.
 
-/*
 namespace {
 /// Utility struct to assist in output and track other relevent state which are
 /// not specific to the entity hierarchy (global WRT to the entity hierarchy).
@@ -37,78 +36,19 @@ struct TclOutputState {
     os.indent(2);
     return os;
   };
-
-  /// Track which modules have been examined so we can issue warnings for
-  /// instance-specific annotations if we write out the same one twice.
-  SmallPtrSet<Operation *, 32> modulesEmitted;
 };
 } // anonymous namespace
 
-namespace {
-/// Represents a Verilog 'entity' -- a unique identifier which locates a
-/// particular instance in the module-instance hierarchy.
-struct Entity {
-  Entity(TclOutputState &s)
-      : s(s), parent(nullptr), insideEmittedModule(false) {}
-  Entity(Entity *parent, InstanceOp inst, bool insideEmittedModule)
-      : s(parent->s), parent(parent), inst(inst),
-        insideEmittedModule(insideEmittedModule) {}
-
-  /// Return the entity inside this instance.
-  Optional<Entity> enter(InstanceOp inst);
-  /// Emit a physical location tcl command.
-  LogicalResult emit(Operation *, StringRef attrName, PhysLocationAttr);
-  /// Emit the entity hierarchy.
-  void emitPath();
-
-  TclOutputState &s;
-  Entity *parent;
-  InstanceOp inst;
-  bool insideEmittedModule;
-
-  StringSet<> emittedAttrKeys;
-
-  StringRef name() {
-    if (inst == nullptr)
-      return "$parent";
-    return inst.instanceName();
-  }
-
-  Optional<InstanceIDAttr> instID() {
-    SmallVector<FlatSymbolRefAttr> stack;
-    return _instID(stack);
-  }
-
-private:
-  Optional<InstanceIDAttr> _instID(SmallVectorImpl<FlatSymbolRefAttr> &stack) {
-    if (parent == nullptr)
-      return {};
-    if (parent->parent == nullptr) {
-      SmallVector<FlatSymbolRefAttr, 32> reverseStack(llvm::reverse(stack));
-      return SymbolRefAttr::get(inst.getContext(), inst.instanceName(),
-                                reverseStack);
-    }
-    stack.push_back(SymbolRefAttr::get(inst.getContext(), inst.instanceName()));
-    return parent->_instID(stack);
-  }
-};
-} // anonymous namespace
-
-Optional<Entity> Entity::enter(InstanceOp inst) {
-  auto mod = dyn_cast_or_null<hw::HWModuleOp>(inst.getReferencedModule());
-  if (!mod) // Could be an extern module, which we should ignore.
-    return {};
-  bool modEmitted = insideEmittedModule ||
-                    s.modulesEmitted.find(mod) != s.modulesEmitted.end();
-  s.modulesEmitted.insert(mod);
-
-  return Entity(this, inst, modEmitted);
+void emitPath(TclOutputState &s, RootedInstancePathAttr path) {
+  for (auto part : path.getPath())
+    s.os << part.getValue() << '|';
 }
 
 /// Emit tcl in the form of:
 /// "set_location_assignment MPDSP_X34_Y285_N0 -to $parent|fooInst|entityName"
-LogicalResult Entity::emit(Operation *op, StringRef attrKey,
-                           PhysLocationAttr pla) {
+static LogicalResult emit(TclOutputState &s, RootedInstancePathAttr path,
+                          Operation *op, StringRef attrKey,
+                          PhysLocationAttr pla) {
 
   if (!attrKey.startswith_insensitive("loc:"))
     return op->emitError("Error in '")
@@ -140,8 +80,8 @@ LogicalResult Entity::emit(Operation *op, StringRef attrKey,
        << pla.getNum();
 
   // To which entity does this apply?
-  s.os << " -to ";
-  emitPath();
+  s.os << " -to $parent|";
+  emitPath(s, path);
   // If instance name is specified, add it in between the parent entity path and
   // the child entity patch.
   if (auto inst = dyn_cast<hw::InstanceOp>(op))
@@ -150,21 +90,14 @@ LogicalResult Entity::emit(Operation *op, StringRef attrKey,
     s.os << name.getValue() << '|';
   s.os << childEntity << '\n';
 
-  emittedAttrKeys.insert(attrKey);
   return success();
 }
 
-void Entity::emitPath() {
-  if (parent)
-    parent->emitPath();
-  // Names are separated by '|'.
-  s.os << name() << "|";
-}
-
-static LogicalResult emitAttr(Entity &entity, Operation *op, StringRef key,
+static LogicalResult emitAttr(TclOutputState &s, RootedInstancePathAttr path,
+                              Operation *op, StringRef attrName,
                               Attribute attr) {
   if (auto loc = attr.dyn_cast<PhysLocationAttr>())
-    if (failed(entity.emit(op, key, loc)))
+    if (failed(emit(s, path, op, attrName, loc)))
       return failure();
   return success();
 }
@@ -173,70 +106,82 @@ static LogicalResult emitAttr(Entity &entity, Operation *op, StringRef key,
 /// recusively, assume that all descendants are in the same entity. When this is
 /// no longer a sound assuption, we'll have to refactor this code. For now, only
 /// HWModule instances create a new entity.
-static LogicalResult exportTcl(Entity &entity, Operation *op) {
-  // Instances require a new child entity and trigger a descent of the
-  // instantiated module in the new entity.
-  if (auto inst = dyn_cast<hw::InstanceOp>(op)) {
-    Optional<Entity> inModule = entity.enter(inst);
-    if (inModule && failed(exportTcl(*inModule, inst.getReferencedModule())))
-      return failure();
-  }
+static LogicalResult emitAttrs(TclOutputState &s, Operation *root,
+                               Operation *op) {
 
-  // Iterate through 'op's attributes, looking for attributes which we
-  // recognize.
-  for (NamedAttribute attr : op->getAttrs()) {
-    if (entity.emittedAttrKeys.find(attr.first) != entity.emittedAttrKeys.end())
-      op->emitWarning("Attribute has already been emitted: '")
-          << attr.first << "'";
-    if (failed(emitAttr(entity, op, attr.first, attr.second)))
-      return failure();
-  }
+  auto rootName = FlatSymbolRefAttr::get(root->getContext(),
+                                         SymbolTable::getSymbolName(root));
 
   // Iterate again through the attributes, looking for instance-specific
   // attributes.
   for (NamedAttribute attr : op->getAttrs()) {
-    if (auto instSwitch = attr.second.dyn_cast<SwitchInstanceAttr>()) {
-      auto instID = entity.instID();
-      if (!instID)
-        continue;
-      Attribute instAttr = instSwitch.lookup(*instID);
-      if (instAttr && failed(emitAttr(entity, op, attr.first, instAttr)))
-        return failure();
-    }
-  }
+    auto result =
+        llvm::TypeSwitch<Attribute, LogicalResult>(attr.second)
 
-  auto result = op->walk([&](Operation *innerOp) {
-    if (innerOp != op && failed(exportTcl(entity, innerOp)))
+            // Handle switch instance.
+            .Case([&](SwitchInstanceAttr instSwitch) {
+              for (auto switchCase : instSwitch.getCases()) {
+                // Filter for only paths rooted at the root module.
+                auto caseRoot = switchCase.getInst().getRootModule();
+                if (caseRoot != rootName)
+                  continue;
+
+                // Output the attribute.
+                if (failed(emitAttr(s, switchCase.getInst(), op, attr.first,
+                                    switchCase.getAttr())))
+                  return failure();
+              }
+              return success();
+            })
+
+            // Physloc outside of a switch instance is not valid.
+            .Case([op](PhysLocationAttr) {
+              return op->emitOpError("PhysLoc attribute must be inside an "
+                                     "instance switch attribute");
+            })
+
+            // Ignore attributes we don't understand.
+            .Default([](Attribute) { return success(); });
+
+    if (failed(result))
+      return failure();
+  }
+  return success();
+}
+
+/// Write out all the relevant tcl commands. Create one 'proc' per module which
+/// takes the parent entity name since we don't assume that the created module
+/// is the top level for the entire design.
+LogicalResult circt::msft::exportQuartusTcl(hw::HWModuleOp hwMod,
+                                            llvm::raw_ostream &os) {
+  TclOutputState state(os);
+  mlir::ModuleOp mlirModule = hwMod->getParentOfType<mlir::ModuleOp>();
+
+  os << "proc " << hwMod.getName() << "_config { parent } {\n";
+
+  auto result = mlirModule->walk([&](Operation *innerOp) {
+    if (failed(emitAttrs(state, hwMod, innerOp)))
       return mlir::WalkResult::interrupt();
     return mlir::WalkResult::advance();
   });
+
+  os << "}\n\n";
   return failure(result.wasInterrupted());
 }
-*/
-/// Write out all the relevant tcl commands. Create one 'proc' per module (since
-/// we don't know which one will be the 'top' module). Said procedure takes the
-/// parent entity name since we don't assume that the created module is the top
-/// level for the entire design.
-LogicalResult circt::msft::exportQuartusTcl(ModuleOp module,
-                                            llvm::raw_ostream &os) {
-  // TclOutputState state(os);
 
-  // for (auto &op : module.getBody()->getOperations()) {
-  //   auto hwMod = dyn_cast<HWModuleOp>(op);
-  //   if (!hwMod)
-  //     continue;
-  //   os << "proc " << hwMod.getName() << "_config { parent } {\n";
-  //   Entity entity(state);
-  //   if (failed(exportTcl(entity, hwMod)))
-  //     return failure();
-  //   os << "}\n\n";
-  // }
+static LogicalResult exportQuartusTclForAll(mlir::ModuleOp mod,
+                                            llvm::raw_ostream &os) {
+  for (Operation &op : mod.getBody()->getOperations()) {
+    if (auto hwmod = dyn_cast<hw::HWModuleOp>(op))
+      if (failed(exportQuartusTcl(hwmod, os)))
+        return failure();
+  }
   return success();
 }
 
 void circt::msft::registerMSFTTclTranslation() {
   mlir::TranslateFromMLIRRegistration toQuartusTcl(
-      "export-quartus-tcl", exportQuartusTcl,
+      "export-quartus-tcl", exportQuartusTclForAll,
       [](mlir::DialectRegistry &registry) {
         registry.insert<MSFTDialect, HWDialect>();
       });

--- a/lib/Dialect/MSFT/TclExport/ExportQuartusTcl.cpp
+++ b/lib/Dialect/MSFT/TclExport/ExportQuartusTcl.cpp
@@ -25,6 +25,7 @@ using namespace msft;
 
 // TODO: Currently assumes Stratix 10 and QuartusPro. Make more general.
 
+/*
 namespace {
 /// Utility struct to assist in output and track other relevent state which are
 /// not specific to the entity hierarchy (global WRT to the entity hierarchy).
@@ -211,25 +212,25 @@ static LogicalResult exportTcl(Entity &entity, Operation *op) {
   });
   return failure(result.wasInterrupted());
 }
-
+*/
 /// Write out all the relevant tcl commands. Create one 'proc' per module (since
 /// we don't know which one will be the 'top' module). Said procedure takes the
 /// parent entity name since we don't assume that the created module is the top
 /// level for the entire design.
 LogicalResult circt::msft::exportQuartusTcl(ModuleOp module,
                                             llvm::raw_ostream &os) {
-  TclOutputState state(os);
+  // TclOutputState state(os);
 
-  for (auto &op : module.getBody()->getOperations()) {
-    auto hwMod = dyn_cast<HWModuleOp>(op);
-    if (!hwMod)
-      continue;
-    os << "proc " << hwMod.getName() << "_config { parent } {\n";
-    Entity entity(state);
-    if (failed(exportTcl(entity, hwMod)))
-      return failure();
-    os << "}\n\n";
-  }
+  // for (auto &op : module.getBody()->getOperations()) {
+  //   auto hwMod = dyn_cast<HWModuleOp>(op);
+  //   if (!hwMod)
+  //     continue;
+  //   os << "proc " << hwMod.getName() << "_config { parent } {\n";
+  //   Entity entity(state);
+  //   if (failed(exportTcl(entity, hwMod)))
+  //     return failure();
+  //   os << "}\n\n";
+  // }
   return success();
 }
 

--- a/test/Dialect/MSFT/location.mlir
+++ b/test/Dialect/MSFT/location.mlir
@@ -3,35 +3,23 @@
 
 hw.module.extern @Foo()
 
-// TCL-LABEL: proc top_config
-hw.module @top() {
-  // CHECK: hw.instance "foo1" @Foo() {"loc:memBank1" = #msft.physloc<M20K, 4, 10, 1>}
-  // TCL:   set_location_assignment M20K_X4_Y10_N1 -to $parent|foo1|memBank1
-  hw.instance "foo1" @Foo() {"loc:memBank1" = #msft.physloc<M20K, 4, 10, 1> } : () -> ()
-
-  // CHECK: hw.instance "foo2" @Foo() {"loc:memBank2" = #msft.physloc<M20K, 5, 10, 1>}
-  // TCL:   set_location_assignment M20K_X5_Y10_N1 -to $parent|foo2|memBank2
-  hw.instance "foo2" @Foo() {"loc:memBank2" = #msft.physloc<M20K, 5, 10, 1> } : () -> ()
-}
-
-
+// CHECK-LABEL: hw.module @leaf
 hw.module @leaf() {
-  // CHECK: hw.instance "foo3" @Foo() {"loc:memBank2" = #msft.switch.inst<@fakeTop=#msft.physloc<M20K, 8, 19, 1>, @realTop::@fakeTop=#msft.physloc<M20K, 15, 9, 3>>}
-  hw.instance "foo3" @Foo() {
-    "loc:memBank2" = #msft.switch.inst< @fakeTop=#msft.physloc<M20K, 8, 19, 1>,
-                                        @realTop::@fakeTop=#msft.physloc<M20K, 15, 9, 3> > } : () -> ()
+  // CHECK: hw.instance "foo" @Foo() {"loc:memBank2" = #msft.switch.inst<@shallow["leaf"]=#msft.physloc<M20K, 8, 19, 1>, @deeper["branch","leaf"]=#msft.physloc<M20K, 15, 9, 3>>} : () -> ()
+  hw.instance "foo" @Foo() {
+    "loc:memBank2" = #msft.switch.inst< @shallow["leaf"]=#msft.physloc<M20K, 8, 19, 1>,
+                                        @deeper["branch","leaf"]=#msft.physloc<M20K, 15, 9, 3> > } : () -> ()
 }
 
 // TCL-LABEL: proc realTop_config
-hw.module @realTop() {
-  hw.instance "fakeTop" @leaf() : () -> ()
+hw.module @shallow() {
+  hw.instance "leaf" @leaf() : () -> ()
   // TCL: set_location_assignment M20K_X8_Y19_N1 -to $parent|fakeTop|foo3|memBank2
 }
 
 // TCL-LABEL: proc forRealsiesTop_config
-hw.module @forRealsiesTop() {
-  hw.instance "realTop" @realTop() : () -> ()
-  hw.instance "fakeTop" @leaf() : () -> ()
+hw.module @deeper() {
+  hw.instance "branch" @shallow() : () -> ()
+  hw.instance "leaf" @leaf() : () -> ()
   // TCL: set_location_assignment M20K_X15_Y9_N3 -to $parent|realTop|fakeTop|foo3|memBank2
-  // TCL: set_location_assignment M20K_X8_Y19_N1 -to $parent|fakeTop|foo3|memBank2
 }

--- a/test/Dialect/MSFT/location.mlir
+++ b/test/Dialect/MSFT/location.mlir
@@ -11,15 +11,15 @@ hw.module @leaf() {
                                         @deeper["branch","leaf"]=#msft.physloc<M20K, 15, 9, 3> > } : () -> ()
 }
 
-// TCL-LABEL: proc realTop_config
+// TCL-LABEL: proc shallow_config
 hw.module @shallow() {
   hw.instance "leaf" @leaf() : () -> ()
-  // TCL: set_location_assignment M20K_X8_Y19_N1 -to $parent|fakeTop|foo3|memBank2
+  // TCL: set_location_assignment M20K_X8_Y19_N1 -to $parent|leaf|foo|memBank2
 }
 
-// TCL-LABEL: proc forRealsiesTop_config
+// TCL-LABEL: proc deeper_config
 hw.module @deeper() {
   hw.instance "branch" @shallow() : () -> ()
   hw.instance "leaf" @leaf() : () -> ()
-  // TCL: set_location_assignment M20K_X15_Y9_N3 -to $parent|realTop|fakeTop|foo3|memBank2
+  // TCL: set_location_assignment M20K_X15_Y9_N3 -to $parent|branch|leaf|foo|memBank2
 }

--- a/test/Dialect/MSFT/translate-errors.mlir
+++ b/test/Dialect/MSFT/translate-errors.mlir
@@ -3,7 +3,7 @@
 hw.module.extern @Foo()
 
 hw.module @top() {
-  // expected-error @+1 {{Entity name cannot be empty in 'loc:<entityName>'}}
+  // expected-error @+1 {{PhysLoc attribute must be inside an instance switch attribute}}
   hw.instance "foo1" @Foo() {"loc:" = #msft.physloc<DSP, 0, 0, 0> } : () -> ()
 }
 
@@ -13,15 +13,5 @@ hw.module.extern @Foo()
 
 hw.module @top() {
   // expected-error @+1 {{Error in 'phys:' PhysLocation attribute. Expected loc:<entityName>}}
-  hw.instance "foo1" @Foo() {"phys:" = #msft.physloc<DSP, 0, 0, 0> } : () -> ()
-}
-
-// -----
-
-hw.module.extern @Foo()
-
-hw.module @top() {
-  hw.instance "foo1" @Foo() {"loc:memBank1" = #msft.physloc<DSP, 0, 0, 0> } : () -> ()
-  // expected-warning @+1 {{Attribute has already been emitted: 'loc:memBank1'}}
-  hw.instance "foo2" @Foo() {"loc:memBank1" = #msft.physloc<DSP, 1, 0, 0> } : () -> ()
+  hw.instance "foo1" @Foo() {"phys:" = #msft.switch.inst< @top[] = #msft.physloc<DSP, 0, 0, 0> > } : () -> ()
 }


### PR DESCRIPTION
A `RootedInstancePath` is just an instance path prepended with the root (aka top) module which the instance path is relative to. If we structure the placements based on this, we no longer have to walk the instance hierarchy while exporting TCL! 

This patch also removes support for locations not inside of instance switches. That use case required the design be fully elaborated which isn't really done.