### PR TITLE
[ExportVerilog] Add verifLabels lowering option

### DIFF
--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -79,6 +79,12 @@ struct LoweringOptions {
   /// declarations, emitting top level wire and reg's instead.
   bool disallowLocalVariables = false;
 
+  /// If true, verification statements like `assert`, `assume`, and `cover` will
+  /// always be emitted with a label. If the statement has no label in the IR, a
+  /// generic one will be created. Some EDA tools require verification
+  /// statements to be labeled.
+  bool enforceVerifLabels = false;
+
   /// This is the target width of lines in an emitted verilog source file in
   /// columns.
   enum { DEFAULT_LINE_LENGTH = 90 };

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -49,6 +49,8 @@ void LoweringOptions::parse(StringRef text, ErrorHandlerT errorHandler) {
       disallowPackedArrays = true;
     } else if (option == "disallowLocalVariables") {
       disallowLocalVariables = true;
+    } else if (option == "verifLabels") {
+      enforceVerifLabels = true;
     } else if (option.startswith("emittedLineLength=")) {
       option = option.drop_front(strlen("emittedLineLength="));
       if (option.getAsInteger(10, emittedLineLength)) {
@@ -75,6 +77,8 @@ std::string LoweringOptions::toString() const {
     options += "disallowPackedArrays,";
   if (disallowLocalVariables)
     options += "disallowLocalVariables,";
+  if (enforceVerifLabels)
+    options += "verifLabels,";
 
   if (emittedLineLength != DEFAULT_LINE_LENGTH)
     options += "emittedLineLength=" + std::to_string(emittedLineLength) + ',';

--- a/lib/Translation/ExportVerilog/ExportVerilogInternals.h
+++ b/lib/Translation/ExportVerilog/ExportVerilogInternals.h
@@ -44,6 +44,7 @@ struct ModuleNameManager {
   StringRef getName(Operation *op) { return getName(ValueOrOp(op)); }
 
   bool hasName(Value value) { return nameTable.count(ValueOrOp(value)); }
+  bool hasName(Operation *op) { return nameTable.count(ValueOrOp(op)); }
 
   void addOutputNames(StringRef name, Operation *module) {
     outputNames.push_back(addLegalName(nullptr, name, module));

--- a/test/ExportVerilog/sv-verifLabels.mlir
+++ b/test/ExportVerilog/sv-verifLabels.mlir
@@ -1,0 +1,70 @@
+// RUN: circt-translate --lowering-options= --export-verilog %s | FileCheck %s --check-prefix=CHECK-OFF
+// RUN: circt-translate --lowering-options=verifLabels --export-verilog %s | FileCheck %s --check-prefix=CHECK-ON
+
+hw.module @foo(%clock: i1, %cond: i1) {
+  sv.initial {
+    // CHECK-OFF: assert(
+    // CHECK-OFF: assume(
+    // CHECK-OFF: cover(
+    // CHECK-ON:  assert_1: assert(
+    // CHECK-ON:  assume_3: assume(
+    // CHECK-ON:  cover_5: cover(
+    sv.assert %cond : i1
+    sv.assume %cond : i1
+    sv.cover %cond : i1
+  }
+  // CHECK-OFF: assert property
+  // CHECK-OFF: assume property
+  // CHECK-OFF: cover property
+  // CHECK-ON:  assert_7: assert property
+  // CHECK-ON:  assume_9: assume property
+  // CHECK-ON:  cover_11: cover property
+  sv.assert.concurrent posedge %clock %cond : i1
+  sv.assume.concurrent posedge %clock %cond : i1
+  sv.cover.concurrent posedge %clock %cond : i1
+
+  // Explicitly labeled ops should keep their label.
+  sv.initial {
+    // CHECK-OFF: imm_assert: assert(
+    // CHECK-ON:  imm_assert: assert(
+    // CHECK-OFF: imm_assume: assume(
+    // CHECK-ON:  imm_assume: assume(
+    // CHECK-OFF: imm_cover: cover(
+    // CHECK-ON:  imm_cover: cover(
+    sv.assert "imm_assert" %cond : i1
+    sv.assume "imm_assume" %cond : i1
+    sv.cover "imm_cover" %cond : i1
+  }
+  // CHECK-OFF: con_assert: assert property
+  // CHECK-ON:  con_assert: assert property
+  // CHECK-OFF: con_assume: assume property
+  // CHECK-ON:  con_assume: assume property
+  // CHECK-OFF: con_cover: cover property
+  // CHECK-ON:  con_cover: cover property
+  sv.assert.concurrent "con_assert" posedge %clock %cond : i1
+  sv.assume.concurrent "con_assume" posedge %clock %cond : i1
+  sv.cover.concurrent "con_cover" posedge %clock %cond : i1
+
+  // Explicitly labeled ops that conflict with implicit labels should force the
+  // implicit labels to change, even if they appear earlier in the output.
+  sv.initial {
+    // CHECK-OFF: assert_0: assert(
+    // CHECK-ON:  assert_0: assert(
+    // CHECK-OFF: assume_2: assume(
+    // CHECK-ON:  assume_2: assume(
+    // CHECK-OFF: cover_4: cover(
+    // CHECK-ON:  cover_4: cover(
+    sv.assert "assert_0" %cond : i1
+    sv.assume "assume_2" %cond : i1
+    sv.cover "cover_4" %cond : i1
+  }
+  // CHECK-OFF: assert_6: assert property
+  // CHECK-ON:  assert_6: assert property
+  // CHECK-OFF: assume_8: assume property
+  // CHECK-ON:  assume_8: assume property
+  // CHECK-OFF: cover_10: cover property
+  // CHECK-ON:  cover_10: cover property
+  sv.assert.concurrent "assert_6" posedge %clock %cond : i1
+  sv.assume.concurrent "assume_8" posedge %clock %cond : i1
+  sv.cover.concurrent "cover_10" posedge %clock %cond : i1
+}


### PR DESCRIPTION
Add the `verifLabels` lowering option which assigns an automatically generated label to all verification statements (assert/assume/cover) that have no label specified. This works around the issue of verification EDA tools commonly requiring all verification statements to be labeled.

This commit adds the labels of these ops to the name manager in the ExportVerilog prepass, and then uses the manager to uniquify a generic label generated for unlabeled ops in case the `verifLabels` option is set.

Fixes #1691.