### PR TITLE
[Calyx] Update verification of AssignOp to include Cells.

### DIFF
--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -614,8 +614,8 @@ static Direction getComponentDirectionFor(Value value, ComponentOp op) {
 }
 
 /// Verifies the value of a given assignment operation. The boolean
-/// isDestination is used to distinguish whether the destination or source of
-/// the AssignOp is to be verified.
+/// `isDestination` is used to distinguish whether the destination
+/// or source of the AssignOp is to be verified.
 static LogicalResult verifyAssignOpValue(AssignOp assign, bool isDestination) {
   Value value = isDestination ? assign.dest() : assign.src();
   bool isComponentPort = value.isa<BlockArgument>();

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -587,6 +587,7 @@ static Direction getCellDirectionFor(Value value) {
   Operation *parentOp = value.getDefiningOp();
   assert(isa<CellInterface>(parentOp) &&
          "Pre-condition: this is a Cell Interface.");
+
   size_t i = 0, numResults = parentOp->getNumResults();
   for (; i != numResults && value != parentOp->getResult(i); ++i)
     ;

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -309,7 +309,7 @@ calyx.program {
   calyx.component @main(%in: i32, %go: i1, %clk: i1, %reset: i1) -> (%out: i32, %done: i1) {
     %c1_1 = constant 1 : i1
     calyx.wires {
-      // expected-error @+1 {{'calyx.assign' op has an invalid destination port. The destination of an AssignOp must be drive-able.}}
+      // expected-error @+1 {{'calyx.assign' op has an invalid destination port. It must be drive-able.}}
       calyx.assign %c1_1 = %go : i1
     }
     calyx.control {}
@@ -322,7 +322,7 @@ calyx.program {
   calyx.component @main(%in: i32, %go: i1, %clk: i1, %reset: i1) -> (%out: i32, %done: i1) {
     %c1_1 = constant 1 : i1
     calyx.wires {
-      // expected-error @+1 {{'calyx.assign' op has a component port as the destination with the incorrect direction. It should be Output.}}
+      // expected-error @+1 {{'calyx.assign' op has a component port as the destination with the incorrect direction.}}
       calyx.assign %go = %c1_1 : i1
     }
     calyx.control {}
@@ -335,8 +335,34 @@ calyx.program {
   calyx.component @main(%in: i32, %go: i1, %clk: i1, %reset: i1) -> (%flag: i1, %out: i32, %done: i1) {
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8, i1, i1, i1, i8, i1
     calyx.wires {
-      // expected-error @+1 {{'calyx.assign' op has a component port as the source with the incorrect direction. It should be Input.}}
+      // expected-error @+1 {{'calyx.assign' op has a component port as the source with the incorrect direction.}}
       calyx.assign %r.write_en = %done : i1
+    }
+    calyx.control {}
+  }
+}
+
+// -----
+
+calyx.program {
+  calyx.component @main(%in: i32, %go: i1, %clk: i1, %reset: i1) -> (%flag: i1, %out: i32, %done: i1) {
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8, i1, i1, i1, i8, i1
+    calyx.wires {
+      // expected-error @+1 {{'calyx.assign' op has a cell port as the source with the incorrect direction.}}
+      calyx.assign %done = %r.write_en : i1
+    }
+    calyx.control {}
+  }
+}
+
+// -----
+
+calyx.program {
+  calyx.component @main(%in: i32, %go: i1, %clk: i1, %reset: i1) -> (%flag: i1, %out: i32, %done: i1) {
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8, i1, i1, i1, i8, i1
+    calyx.wires {
+      // expected-error @+1 {{'calyx.assign' op has a cell port as the destination with the incorrect direction.}}
+      calyx.assign %r.done = %go : i1
     }
     calyx.control {}
   }


### PR DESCRIPTION
Add verification for Cells in assignment operations after the addition of the `CellInterface` in #1695.

Addresses a TODO in #1597.