### PR TITLE
[Analysis] Add a simple bitwidth analysis pass for std operations

### DIFF
--- a/include/circt/Analysis/BitwidthAnalysis.h
+++ b/include/circt/Analysis/BitwidthAnalysis.h
@@ -1,4 +1,4 @@
-//===- BitWidthAnalysis.h - Support for building backedges ----------------===//
+//===- BitwidthAnalysis.h - Support for building backedges ----------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -13,9 +13,7 @@
 #ifndef CIRCT_ANALYSIS_BITWIDTH_H
 #define CIRCT_ANALYSIS_BITWIDTH_H
 
-#include "mlir/Analysis/DataFlowAnalysis.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
-#include "mlir/IR/Region.h"
 #include "llvm/ADT/Optional.h"
 
 #include <memory>

--- a/include/circt/Analysis/BitwidthAnalysis.h
+++ b/include/circt/Analysis/BitwidthAnalysis.h
@@ -1,0 +1,45 @@
+//===- BitWidthAnalysis.h - Support for building backedges ----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides flow-based forward bitwidth analysis.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_ANALYSIS_BITWIDTH_H
+#define CIRCT_ANALYSIS_BITWIDTH_H
+
+#include "mlir/Analysis/DataFlowAnalysis.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/Region.h"
+#include "llvm/ADT/Optional.h"
+
+#include <memory>
+
+namespace circt {
+class BitWidthAnalysisImpl;
+
+/// Analyze the bitwidths of the operations within a top-level operation @p op.
+/// @p saturationWidth delimits the width of a value which the analysis
+/// determines may saturate.
+/// As an example, index types incremented in a loop with dynamic bounds may
+/// saturate..
+class BitwidthAnalysis {
+public:
+  explicit BitwidthAnalysis(mlir::Operation *op, unsigned saturationWidth = 32);
+
+  /// Returns the bit width estimate for the value @p v or empty if value was
+  /// not present within the result set of the bitwidth analysis.
+  llvm::Optional<unsigned> valueWidth(mlir::Value v) const;
+
+private:
+  std::shared_ptr<BitWidthAnalysisImpl> analysis;
+};
+
+} // namespace circt
+
+#endif // CIRCT_ANALYSIS_BITWIDTH_H

--- a/lib/Analysis/BitwidthAnalysis.cpp
+++ b/lib/Analysis/BitwidthAnalysis.cpp
@@ -1,4 +1,4 @@
-//===- BitWidthAnalysis.cpp - Support for building backedges ----*- C++ -*-===//
+//===- BitwidthAnalysis.cpp - Support for building backedges ----*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Analysis/BitwidthAnalysis.h"
+#include "mlir/Analysis/DataFlowAnalysis.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Matchers.h"
 #include "llvm/ADT/SmallSet.h"

--- a/lib/Analysis/BitwidthAnalysis.cpp
+++ b/lib/Analysis/BitwidthAnalysis.cpp
@@ -1,0 +1,380 @@
+//===- BitWidthAnalysis.cpp - Support for building backedges ----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides flow-based forward bitwidth analysis.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Analysis/BitwidthAnalysis.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Matchers.h"
+#include "llvm/ADT/SmallSet.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+static unsigned s_saturationWidth = 64;
+
+using namespace mlir;
+
+namespace circt {
+namespace bitwidth {
+// ============================================================================
+// Utility functions
+// ============================================================================
+
+/// Returns the minimum of two APInt's. In case of mismatched bit width, return
+/// the value with the largest bit width.
+static APInt min(const APInt &lhs, const APInt &rhs) {
+  unsigned lbits = lhs.getBitWidth();
+  unsigned rbits = rhs.getBitWidth();
+  if (lbits != rbits)
+    return lbits < rbits ? rhs : lhs;
+  else
+    return lhs.slt(rhs) ? lhs : rhs;
+}
+
+/// Returns the maximum of two APInt's. In case of mismatched bit width, return
+/// the value with the largest bit width.
+static APInt max(const APInt &lhs, const APInt &rhs) {
+  unsigned lbits = lhs.getBitWidth();
+  unsigned rbits = rhs.getBitWidth();
+  if (lbits != rbits)
+    return lbits < rbits ? rhs : lhs;
+  else
+    return lhs == min(lhs, rhs) ? rhs : lhs;
+}
+
+/// Returns the number of bits needed to represent the value @p v.
+static unsigned bits(const APInt &v) {
+  unsigned n = v.logBase2() + 1;
+  return n == 0 ? 1 : n;
+}
+
+/// The ForwardDataFlowAnalysis solver does not consider loops in the control
+/// flow graph and will pre-emptively converge on values within a loop. This
+/// helper function performs a DFS to analyse if a block resides within a loop.
+static bool inCycle(Block *srcBlock) {
+  llvm::SmallSet<Block *, 8> visited;
+  std::function<bool(Block *)> cycleUtil = [&](Block *block) {
+    if (block == srcBlock)
+      return true;
+    if (visited.contains(block))
+      return false;
+    visited.insert(block);
+    return llvm::any_of(block->getSuccessors(), cycleUtil);
+  };
+  return llvm::any_of(srcBlock->getSuccessors(), cycleUtil);
+}
+
+/// Returns true if any value in @p operands is defined within a control-flow
+/// cycle.
+static bool anyOpInCycle(ValueRange operands) {
+  return llvm::any_of(operands, [](Value op) {
+    if (auto barg = op.dyn_cast<BlockArgument>())
+      return inCycle(barg.getOwner());
+    else
+      return inCycle(op.getDefiningOp()->getBlock());
+  });
+}
+
+/// Attempts to match a constant op and the value which it defines. If
+/// successfull, binds the constant value to @p value and returns true, else,
+/// returns false.
+static bool matchConstantOp(Operation *op, APInt &value) {
+  return mlir::detail::constant_int_op_binder(&value).match(op);
+}
+
+} // namespace bitwidth
+
+// ============================================================================
+// BitWidthLattice
+// ============================================================================
+/// Lattice value for the dataflow algorithm.
+struct BitWidthLattice {
+  BitWidthLattice() {}
+  BitWidthLattice(APInt lmin, APInt lmax) : lmin(lmin), lmax(lmax) {}
+
+  bool operator==(const BitWidthLattice &rhs) const {
+    return (this->lmin.getBitWidth() == rhs.lmin.getBitWidth() &&
+            this->lmin == rhs.lmin) &&
+           (this->lmax.getBitWidth() == rhs.lmax.getBitWidth() &&
+            this->lmax == rhs.lmax);
+  }
+
+  /// Perorms a range-join of the lhs and rhs minimum and maximum values.
+  static BitWidthLattice join(const BitWidthLattice &lhs,
+                              const BitWidthLattice &rhs) {
+    return BitWidthLattice(bitwidth::min(lhs.lmin, rhs.lmin),
+                           bitwidth::max(lhs.lmax, rhs.lmax));
+  }
+
+  /// The (most) pessimistic value is our saturation width.
+  static BitWidthLattice getPessimisticValueState(mlir::MLIRContext *);
+
+  /// Try to infer a bit width from the type of a value, else, fallback to
+  /// saturation width.
+  static BitWidthLattice getPessimisticValueState(mlir::Value value);
+
+  /// Return the number of bits required to represent the value range of this
+  /// lattice.
+  unsigned bits() const {
+    return std::max(bitwidth::bits(lmin), bitwidth::bits(lmax));
+  }
+
+  /// Minimum (lower) and maximum (upper) bounds which determines the value
+  /// range of this lattice. Values are inclusive and signed.
+  APInt lmin, lmax;
+};
+
+/// Returns a signed integer lattice with minimum and maximum values determined
+/// by @p nbits.
+static BitWidthLattice nbitLattice(unsigned nbits) {
+  return BitWidthLattice(APInt::getSignedMinValue(nbits),
+                         APInt::getSignedMaxValue(nbits));
+}
+
+/// Returns a signed integer lattice with minimum and maximum values determined
+/// by the width of the integer type @p t.
+static BitWidthLattice latticeForIntType(Type t) {
+  assert(t.isa<IntegerType>());
+  BitWidthLattice lattice;
+  unsigned nbits = t.getIntOrFloatBitWidth();
+  return nbitLattice(nbits);
+}
+
+BitWidthLattice BitWidthLattice::getPessimisticValueState(mlir::MLIRContext *) {
+  return nbitLattice(s_saturationWidth);
+}
+
+BitWidthLattice BitWidthLattice::getPessimisticValueState(mlir::Value value) {
+  auto type = value.getType();
+  unsigned nbits = s_saturationWidth;
+  if (type.isa<IntegerType>()) {
+    nbits = type.getIntOrFloatBitWidth();
+    return BitWidthLattice(APInt::getSignedMinValue(nbits),
+                           APInt::getSignedMaxValue(nbits));
+  }
+  if (type.isa<FloatType>())
+    nbits = type.getIntOrFloatBitWidth();
+
+  return nbitLattice(nbits);
+}
+
+// ============================================================================
+// BitWidthAnalysis and visitors
+// ============================================================================
+
+/// The AnalyzedOperand struct wraps a value (typically an operand of an
+/// operation) and its corresponding (at the time of instantiation)
+/// BitWidthLattice to provide various operations for determining the bounds of
+/// the value.
+struct AnalyzedOperand {
+public:
+  Value v;
+  const BitWidthLattice &lattice;
+
+  /// Returns the number of bits that is currently estimated to be required to
+  /// represent @v.
+  unsigned bits() const { return lattice.bits(); }
+
+  /// Returns the currently estimated signed maximum value of @v.
+  int64_t smax() const {
+    if (auto constVal = cval()) {
+      return constVal.getValue().getSExtValue();
+    }
+    return APInt::getSignedMaxValue(lattice.lmax.getBitWidth()).getSExtValue();
+  }
+
+  /// Returns the currently estimated signed minimum value of @v.
+  int64_t smin() const {
+    if (auto constVal = cval()) {
+      return constVal.getValue().getSExtValue();
+    }
+    return APInt::getSignedMinValue(lattice.lmin.getBitWidth()).getSExtValue();
+  }
+
+  /// Returns the currently estimated unsigned maximum value of @v.
+  uint64_t umax() const {
+    if (auto constVal = cval()) {
+      return constVal.getValue().getZExtValue();
+    }
+    return APInt::getMaxValue(lattice.lmax.getBitWidth()).getZExtValue();
+  }
+
+  /// Returns the currently estimated unsigned minimum value of @v.
+  uint64_t umin() const {
+    if (auto constVal = cval()) {
+      return constVal.getValue().getZExtValue();
+    }
+    return APInt::getMinValue(lattice.lmin.getBitWidth()).getZExtValue();
+  }
+
+  bool isConstant() const { return cval().hasValue(); }
+
+private:
+  /// Returns the constant value which @v represents, if any
+  Optional<APInt> cval() const {
+    if (auto *defOp = v.getDefiningOp()) {
+      APInt constVal;
+      if (bitwidth::matchConstantOp(defOp, constVal))
+        return constVal;
+    }
+    return {};
+  }
+};
+
+/// Bit width rules for various binary operators
+/// @todo: as a future improvements, operators could implement an interface for
+/// describing their bit-width modifying characteristics.
+template <typename TBinOp>
+unsigned visitBinOp(const AnalyzedOperand &lhs, const AnalyzedOperand &rhs);
+
+template <>
+unsigned visitBinOp<AddIOp>(const AnalyzedOperand &lhs,
+                            const AnalyzedOperand &rhs) {
+  return std::max(lhs.bits(), rhs.bits()) + 1;
+}
+template <>
+unsigned visitBinOp<SubIOp>(const AnalyzedOperand &lhs,
+                            const AnalyzedOperand &rhs) {
+  return std::max(lhs.bits(), rhs.bits()) + 1;
+}
+template <>
+unsigned visitBinOp<MulIOp>(const AnalyzedOperand &lhs,
+                            const AnalyzedOperand &rhs) {
+  return lhs.bits() + rhs.bits();
+}
+template <>
+unsigned visitBinOp<ShiftLeftOp>(const AnalyzedOperand &lhs,
+                                 const AnalyzedOperand &rhs) {
+  // define a cut-off point for width extension as 2*saturation width. This is
+  // relevant when shifting by a non-constant, wide rhs value. In
+  // these cases, default to the lhs bit width.
+  unsigned lhsBits = lhs.bits();
+  uint64_t resBits = lhsBits + rhs.umax();
+  if (!rhs.isConstant() && resBits > 2 * s_saturationWidth)
+    return lhsBits;
+  return resBits;
+}
+unsigned visitRightShift(const AnalyzedOperand &lhs,
+                         const AnalyzedOperand &rhs) {
+  int64_t rhsMin = rhs.umin();
+  int64_t resBits = lhs.bits() - rhsMin;
+  if (rhsMin >= resBits)
+    return 1;
+  return resBits;
+}
+template <>
+unsigned visitBinOp<SignedShiftRightOp>(const AnalyzedOperand &lhs,
+                                        const AnalyzedOperand &rhs) {
+  return visitRightShift(lhs, rhs);
+}
+template <>
+unsigned visitBinOp<UnsignedShiftRightOp>(const AnalyzedOperand &lhs,
+                                          const AnalyzedOperand &rhs) {
+  return visitRightShift(lhs, rhs);
+}
+
+class BitWidthAnalysisImpl
+    : public mlir::ForwardDataFlowAnalysis<BitWidthLattice> {
+public:
+  explicit BitWidthAnalysisImpl(mlir::MLIRContext *context)
+      : ForwardDataFlowAnalysis(context) {}
+
+  mlir::ChangeResult visitOperation(
+      Operation *op,
+      ArrayRef<LatticeElement<BitWidthLattice> *> operands) override {
+    APInt value;
+
+    /// Since this is a forward dataflow pass, values inside loops will
+    /// pre-emptively be marked as converged to a possibly incorrect value. Any
+    /// operation which has an operand that is defined within a loop is
+    /// conservatively visited by the default handler.
+    if (bitwidth::anyOpInCycle(op->getOperands()))
+      return visitDefault(op);
+
+    /// If we can statically determine that an operation defines a constant, we
+    /// define strict value constraints through visitConstant
+    if (bitwidth::matchConstantOp(op, value))
+      return visitConstant(op, value);
+
+    /// Try execute operation-specific visitors, or fallback to the default
+    /// visitor.
+    return TypeSwitch<Operation *, ChangeResult>(op)
+        .Case<AddIOp, MulIOp, SubIOp, ShiftLeftOp, SignedShiftRightOp,
+              UnsignedShiftRightOp>(
+            [&](auto op_t) { return binOpVisitorWrapper(op_t, operands); })
+        .Default([&](auto op_t) { return visitDefault(op_t); });
+  }
+
+private:
+  /// Default handling for determining the constraints on the results of an
+  /// operation, if no other visitor is able to provide operation-specific
+  /// bitwidth inference logic.
+  ChangeResult visitDefault(Operation *op);
+
+  /// visitConstant will set strict upper- lower- and bit width constraints
+  /// based on the constant value.
+  ChangeResult visitConstant(Operation *op, APInt constVal);
+
+  /// Generic wrapper for binary operators. Unpacks the BitWidthLattice's from
+  /// the operands, constructs a new nbitLattice from the bit result of the
+  /// specialized operand function, and joins this with the current lattice of
+  /// the operand result.
+  template <typename OpType>
+  ChangeResult
+  binOpVisitorWrapper(OpType op,
+                      ArrayRef<LatticeElement<BitWidthLattice> *> operands) {
+    BitWidthLattice lattice;
+    assert(operands.size() == 2);
+    auto op0 = AnalyzedOperand{op.getOperand(0), operands[0]->getValue()};
+    auto op1 = AnalyzedOperand{op.getOperand(1), operands[1]->getValue()};
+    unsigned nbits = visitBinOp<OpType>(op0, op1);
+    return getLatticeElement(op.getResult()).join(nbitLattice(nbits));
+  }
+};
+
+ChangeResult BitWidthAnalysisImpl::visitDefault(Operation *op) {
+  ChangeResult chResult = ChangeResult::NoChange;
+
+  // Fallback to the pessimistic fixpoint, or type-defined width (if applicable)
+  for (auto opRes : op->getResults()) {
+    auto type = opRes.getType();
+    if (type.isa<IntegerType>())
+      chResult |= getLatticeElement(opRes).join(latticeForIntType(type));
+    else
+      chResult |= getLatticeElement(opRes).markPessimisticFixpoint();
+  }
+  return chResult;
+}
+
+ChangeResult BitWidthAnalysisImpl::visitConstant(Operation *op,
+                                                 APInt constVal) {
+  assert(op->getResults().size() == 1);
+  unsigned nbits = bitwidth::bits(constVal);
+  return getLatticeElement(op->getResult(0)).join(nbitLattice(nbits));
+}
+
+// ============================================================================
+// BitwidthAnalysis driver
+// ============================================================================
+
+Optional<unsigned> BitwidthAnalysis::valueWidth(Value v) const {
+  if (auto elem = analysis->lookupLatticeElement(v))
+    return elem->getValue().bits();
+  return {};
+}
+
+BitwidthAnalysis::BitwidthAnalysis(Operation *op, unsigned saturationWidth) {
+  // Set the global saturation width (required within the static
+  // getPessimisticValueState functions).
+  s_saturationWidth = saturationWidth;
+  analysis = std::make_shared<BitWidthAnalysisImpl>(op->getContext());
+  analysis->run(op);
+}
+
+} // namespace circt

--- a/test/Analysis/BitwidthAnalysis/test_bitwidth.mlir
+++ b/test/Analysis/BitwidthAnalysis/test_bitwidth.mlir
@@ -1,0 +1,104 @@
+// RUN: circt-opt %s -split-input-file -test-bitwidth-analysis | FileCheck %s
+
+func @f1(%arg0: index) -> (i8) {
+  // CHECK:      %0 = memref.alloc() {"result bits" = [32]} : memref<10xi8>
+  // CHECK-NEXT: %c1_i8 = constant  {"result bits" = [1]} 1 : i8
+  // CHECK-NEXT: memref.store %c1_i8, %0[%arg0] : memref<10xi8>
+  // CHECK-NEXT: %1 = memref.load %0[%arg0] {"result bits" = [8]} : memref<10xi8>
+  %0 = memref.alloc() : memref<10xi8>
+  %c1 = constant 1 : i8
+  memref.store %c1, %0[%arg0] : memref<10xi8>
+  %1 = memref.load %0[%arg0] : memref<10xi8>
+  return %1 : i8
+}
+
+// -----
+
+func @f2() -> index {
+  // CHECK:      %c1 = constant  {"result bits" = [1]} 1 : index
+  // CHECK-NEXT: %c42 = constant  {"result bits" = [6]} 42 : index
+  // CHECK-NEXT: %c63 = constant  {"result bits" = [6]} 63 : index
+  // CHECK-NEXT: %c1_0 = constant  {"result bits" = [1]} 1 : index
+  %c1 = constant 1 : index
+  %c42 = constant 42 : index
+  %c63 = constant 63 : index
+  %c1_0 = constant 1 : index
+  br ^bb1(%c1 : index)
+^bb1(%0: index):	// 2 preds: ^bb0, ^bb2
+  %1 = cmpi slt, %0, %c42 : index
+  // CHECK:      %2 = addi %c63, %c1_0 {"result bits" = [7]} : index
+  %2 = addi %c63, %c1_0 : index
+  return %2: index
+}
+
+// -----
+
+func @f3() -> index {
+  // CHECK:       %c1 = constant  {"result bits" = [1]} 1 : index
+  // CHECK-NEXT:  %c42 = constant  {"result bits" = [6]} 42 : index
+  // CHECK-NEXT:  %c1_0 = constant  {"result bits" = [1]} 1 : index
+  %c1 = constant 1 : index
+  %c42 = constant 42 : index
+  %c1_0 = constant 1 : index
+  br ^bb1(%c1 : index)
+^bb1(%0: index):	// 2 preds: ^bb0, ^bb2
+  // CHECK:    %1 = cmpi slt, %0, %c42 {"result bits" = [1]} : index
+  %1 = cmpi slt, %0, %c42 : index
+  cond_br %1, ^bb2, ^bb3
+^bb2:	// pred: ^bb1
+  // CHECK:     %2 = addi %0, %c1_0 {"result bits" = [32]} : index
+  %2 = addi %0, %c1_0 : index   // NOTE: Add inside loop with ops defined inside loop; default to type width
+  // CHECK:     %3 = addi %c42, %c1_0 {"result bits" = [7]} : index
+  %3 = addi %c42, %c1_0 : index // NOTE: Add inside loop, but ops defined outside loop
+  br ^bb1(%2 : index)
+^bb3:	// pred: ^bb1
+  return %0 : index
+}
+
+// -----
+
+func @f4() -> i32 {
+  // CHECK:       %c1_i32 = constant  {"result bits" = [1]} 1 : i32
+  // CHECK-NEXT:  %c42_i32 = constant  {"result bits" = [6]} 42 : i32
+  // CHECK-NEXT:  %c1_i32_0 = constant  {"result bits" = [1]} 1 : i32
+  %c1 = constant 1 : i32
+  %c42 = constant 42 : i32
+  %c1_0 = constant 1 : i32
+  br ^bb1(%c1 : i32)
+^bb1(%0: i32):	// 2 preds: ^bb0, ^bb2
+  // CHECK:     %1 = cmpi slt, %0, %c42_i32 {"result bits" = [1]} : i32
+  %1 = cmpi slt, %0, %c42 : i32
+  cond_br %1, ^bb2, ^bb3
+^bb2:	// pred: ^bb1
+  // CHECK:     %2 = addi %0, %c1_i32_0 {"result bits" = [32]} : i32
+  %2 = addi %0, %c1_0 : i32   // NOTE: Add inside loop with ops defined inside loop; default to type width
+  // CHECK:     %3 = addi %c42_i32, %c1_i32_0 {"result bits" = [7]} : i32
+  %3 = addi %c42, %c1_0 : i32 // NOTE: Add inside loop, but ops defined outside loop
+  br ^bb1(%2 : i32)
+^bb3:	// pred: ^bb1
+  return %0 : i32
+}
+
+// -----
+
+func @f5(%arg0 : i32) -> i32{
+  // CHECK:      %c5_i32 = constant  {"result bits" = [3]} 5 : i32
+  // CHECK-NEXT: %c42_i32 = constant  {"result bits" = [6]} 42 : i32
+  // CHECK-NEXT: %0 = shift_left %arg0, %c5_i32 {"result bits" = [37]} : i32
+  // CHECK-NEXT: %1 = shift_right_signed %arg0, %c5_i32 {"result bits" = [27]} : i32
+  // CHECK-NEXT: %2 = shift_right_unsigned %arg0, %c5_i32 {"result bits" = [27]} : i32
+  // CHECK-NEXT: %3 = shift_right_unsigned %arg0, %c42_i32 {"result bits" = [1]} : i32
+  // CHECK-NEXT: %4 = shift_right_signed %arg0, %arg0 {"result bits" = [32]} : i32
+  // CHECK-NEXT: %5 = shift_left %arg0, %arg0 {"result bits" = [32]} : i32
+  // CHECK-NEXT: %6 = shift_left %arg0, %c42_i32 {"result bits" = [74]} : i32
+  %c5 = constant 5 : i32
+  %c42 = constant 42 : i32
+  %0 = shift_left %arg0, %c5 : i32
+  %1 = shift_right_signed %arg0, %c5 : i32
+  %2 = shift_right_unsigned %arg0, %c5 : i32 
+  %3 = shift_right_unsigned %arg0, %c42 : i32 
+  %4 = shift_right_signed %arg0, %arg0 : i32  // rshift by unbounded int; default to lhs width
+  %5 = shift_left %arg0, %arg0 : i32          // lshift by unbounded int; default to lhs width
+  %6 = shift_left %arg0, %c42 : i32           // lshift by statically determined constant
+  return %6 : i32
+}

--- a/test/lib/Analysis/CMakeLists.txt
+++ b/test/lib/Analysis/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_mlir_library(CIRCTAnalysisTest
+  TestBitwidthAnalysis.cpp
+
+  LINK_LIBS PUBLIC
+  CIRCTAnalysis
+  MLIRPass
+  )

--- a/test/lib/Analysis/TestBitwidthAnalysis.cpp
+++ b/test/lib/Analysis/TestBitwidthAnalysis.cpp
@@ -1,0 +1,68 @@
+//===- TestBitwidthAnalysis.cpp - Test bitwidth analysis results ----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains test passes for constructing and testing bitwidth analysis
+// results.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Analysis/BitwidthAnalysis.h"
+#include "mlir/Pass/Pass.h"
+
+using namespace circt;
+using namespace mlir;
+using namespace llvm;
+
+namespace {
+
+// Add bitwidths of operation results to all operations.
+void addBitwidthAttributes(MLIRContext *ctx, const BitwidthAnalysis &res,
+                           Operation *op, ValueRange values) {
+  SmallVector<Attribute> resWidths;
+  llvm::transform(
+      values, std::back_inserter(resWidths), [&](auto v) -> Attribute {
+        if (auto width = res.valueWidth(v))
+          return IntegerAttr::get(IntegerType::get(ctx, 64), width.getValue());
+        else
+          return StringAttr::get(ctx, "N/A");
+      });
+  if (resWidths.size() != 0)
+    op->setAttr("result bits", ArrayAttr::get(ctx, resWidths));
+};
+
+struct TestBitwidthAnalysisPass
+    : public PassWrapper<TestBitwidthAnalysisPass,
+                         OperationPass<mlir::ModuleOp>> {
+  StringRef getArgument() const final { return "test-bitwidth-analysis"; }
+  StringRef getDescription() const final {
+    return "Test bitwidth analysis results.";
+  }
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    auto ctx = module.getContext();
+    module.walk([&](mlir::FuncOp func) {
+      auto analysisResult = BitwidthAnalysis(func, 32);
+      func.walk([&](Operation *op) {
+        addBitwidthAttributes(ctx, analysisResult, op, op->getResults());
+      });
+    });
+  }
+};
+} // end anonymous namespace
+
+//===----------------------------------------------------------------------===//
+// Pass Registration
+//===----------------------------------------------------------------------===//
+
+namespace circt {
+namespace test {
+void registerTestBitwidthAnalysisPass() {
+  PassRegistration<TestBitwidthAnalysisPass>();
+}
+} // namespace test
+} // namespace circt

--- a/tools/circt-opt/CMakeLists.txt
+++ b/tools/circt-opt/CMakeLists.txt
@@ -35,7 +35,7 @@ target_link_libraries(circt-opt
   CIRCTStaticLogicOps
   CIRCTSV
   CIRCTSVTransforms
-  
+
   MLIRIR
   MLIRLLVMIR
   MLIRMemRef

--- a/tools/circt-opt/circt-opt.cpp
+++ b/tools/circt-opt/circt-opt.cpp
@@ -29,6 +29,7 @@ namespace circt {
 namespace test {
 void registerAnalysisTestPasses();
 void registerSchedulingTestPasses();
+void registerTestBitwidthAnalysisPass();
 } // namespace test
 } // namespace circt
 
@@ -55,6 +56,7 @@ int main(int argc, char **argv) {
   // Register test passes
   circt::test::registerAnalysisTestPasses();
   circt::test::registerSchedulingTestPasses();
+  circt::test::registerTestBitwidthAnalysisPass();
 
   // Other command line options.
   circt::registerLoweringCLOptions();


### PR DESCRIPTION
This commit implements a flow-sensitive forward dataflow analysis for determining bitwidth constraints of `std` programs. The results are highly conservative and meaningful information is essentially only inferred when data flows involve constants.
Width inference already exists in FIRRTL, but is hardcoded for FIRRTL operators and (as far as i can tell) cannot easily be used as a solution for width inference of `std` programs. The motivation for adding this analysis is to have _some_ form of analysis for inferring bit-widths outside of FIRRTL, most importantly of `index`-typed values - even if estimates are highly conservative.

Proper bitwidth analysis could (should) be based on forward-backwards path-sensitive dataflow analysis ([see paper](http://publications.csail.mit.edu/lcs/pubs/pdf/MIT-LCS-TM-602.pdf)). The current infrastructure (https://github.com/llvm/llvm-project/blob/main/mlir/include/mlir/Analysis/DataFlowAnalysis.h) supports only flow-sensitive forward passes, hence this implementation.

The implementation hardcodes bitwidth inference rules for the relevant `std` operators. In the future, we could imagine that operators may implement a bitwidth inference interface to allow for making this (or a future) pass more generic (and possibly also applicable to FIRRTL).

The analysis can be invoked through `-test-bitwidth-analysis`. If so, the estimated bit-widths for each operand result is added as an attribute of the operation, which is then visible in the IR printout, i.e.:
```mlir
func @foo(%arg0 : i32) -> i32{
  func @f5(%arg0 : i32) -> i32{
  %c5_i32 = constant  {"result bits" = [3]} 5 : i32
  %c42_i32 = constant  {"result bits" = [6]} 42 : i32
  %0 = shift_left %arg0, %c5_i32 {"result bits" = [37]} : i32
  ...
```