### PR TITLE
[Comb] Merge ors of concats with constant operands.

### DIFF
--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -891,6 +891,104 @@ OpFoldResult OrOp::fold(ArrayRef<Attribute> constants) {
       constants, [](APInt &a, const APInt &b) { a |= b; });
 }
 
+/// Simplify concat ops in an or op when a constant operand is present in either
+/// concat.
+///
+/// This will invert an or(concat, concat) into concat(or, or, ...), which can
+/// often be further simplified due to the smaller or ops being easier to fold.
+///
+/// For example:
+///
+/// or(..., concat(x, 0), concat(0, y))
+///    ==> or(..., concat(x, 0, y)), when x and y don't overlap.
+///
+/// or(..., concat(x: i2, cst1: i4), concat(cst2: i5, y: i1))
+///    ==> or(..., concat(or(x: i2,               extract(cst2, 4..3)),
+///                       or(extract(cst1, 3..1), extract(cst2, 2..0)),
+///                       or(extract(cst1, 0..0), y: i1))
+static bool canonicalizeOrOfConcatsWithCstOperands(OrOp op, size_t concatIdx1,
+                                                   size_t concatIdx2,
+                                                   PatternRewriter &rewriter) {
+  assert(concatIdx1 < concatIdx2 && "concatIdx1 must be < concatIdx2");
+
+  auto inputs = op.inputs();
+  auto concat1 = inputs[concatIdx1].getDefiningOp<ConcatOp>();
+  auto concat2 = inputs[concatIdx2].getDefiningOp<ConcatOp>();
+
+  assert(concat1 && concat2 && "expected indexes to point to ConcatOps");
+
+  // We can simplify as long as a constant is present in either concat.
+  bool hasConstantOp1 =
+      llvm::any_of(concat1->getOperands(), [&](Value operand) -> bool {
+        return operand.getDefiningOp<hw::ConstantOp>();
+      });
+  bool hasConstantOp2 =
+      llvm::any_of(concat2->getOperands(), [&](Value operand) -> bool {
+        return operand.getDefiningOp<hw::ConstantOp>();
+      });
+  if (!hasConstantOp1 && !hasConstantOp2)
+    return false;
+
+  SmallVector<Value> newConcatOperands;
+
+  // Simultaneously iterate over the operands of both concat ops, from MSB to
+  // LSB, pushing out or's of overlapping ranges of the operands. When operands
+  // span different bit ranges, we extract only the maximum overlap.
+  auto operands1 = concat1->getOperands();
+  auto operands2 = concat2->getOperands();
+  // Number of bits already consumed from operands 1 and 2, respectively.
+  unsigned consumedWidth1 = 0;
+  unsigned consumedWidth2 = 0;
+  for (auto it1 = operands1.begin(), end1 = operands1.end(),
+            it2 = operands2.begin(), end2 = operands2.end();
+       it1 != end1 && it2 != end2;) {
+    auto operand1 = *it1;
+    auto operand2 = *it2;
+
+    unsigned remainingWidth1 =
+        hw::getBitWidth(operand1.getType()) - consumedWidth1;
+    unsigned remainingWidth2 =
+        hw::getBitWidth(operand2.getType()) - consumedWidth2;
+    unsigned widthToConsume = std::min(remainingWidth1, remainingWidth2);
+    auto narrowedType = rewriter.getIntegerType(widthToConsume);
+
+    auto extract1 = rewriter.createOrFold<ExtractOp>(
+        op.getLoc(), narrowedType, operand1, remainingWidth1 - widthToConsume);
+    auto extract2 = rewriter.createOrFold<ExtractOp>(
+        op.getLoc(), narrowedType, operand2, remainingWidth2 - widthToConsume);
+
+    newConcatOperands.push_back(
+        rewriter.createOrFold<OrOp>(op.getLoc(), extract1, extract2));
+
+    consumedWidth1 += widthToConsume;
+    consumedWidth2 += widthToConsume;
+
+    if (widthToConsume == remainingWidth1) {
+      ++it1;
+      consumedWidth1 = 0;
+    }
+    if (widthToConsume == remainingWidth2) {
+      ++it2;
+      consumedWidth2 = 0;
+    }
+  }
+
+  ConcatOp newOp = rewriter.create<ConcatOp>(op.getLoc(), newConcatOperands);
+
+  // Copy the old operands except for concatIdx1 and concatIdx2, and append the
+  // new ConcatOp to the end.
+  SmallVector<Value> newOrOperands;
+  newOrOperands.append(inputs.begin(), inputs.begin() + concatIdx1);
+  newOrOperands.append(inputs.begin() + concatIdx1 + 1,
+                       inputs.begin() + concatIdx2);
+  newOrOperands.append(inputs.begin() + concatIdx2 + 1,
+                       inputs.begin() + inputs.size());
+  newOrOperands.push_back(newOp);
+
+  rewriter.replaceOpWithNewOp<OrOp>(op, op.getType(), newOrOperands);
+  return true;
+}
+
 LogicalResult OrOp::canonicalize(OrOp op, PatternRewriter &rewriter) {
   auto inputs = op.inputs();
   auto size = inputs.size();
@@ -934,6 +1032,16 @@ LogicalResult OrOp::canonicalize(OrOp op, PatternRewriter &rewriter) {
   // or(x, or(...)) -> or(x, ...) -- flatten
   if (tryFlatteningOperands(op, rewriter))
     return success();
+
+  // or(..., concat(x, cst1), concat(cst2, y)
+  //    ==> or(..., concat(x, cst3, y)), when x and y don't overlap.
+  for (size_t i = 0; i < size - 1; ++i) {
+    if (auto concat = inputs[i].getDefiningOp<ConcatOp>())
+      for (size_t j = i + 1; j < size; ++j)
+        if (auto concat = inputs[j].getDefiningOp<ConcatOp>())
+          if (canonicalizeOrOfConcatsWithCstOperands(op, i, j, rewriter))
+            return success();
+  }
 
   /// TODO: or(..., x, not(x)) -> or(..., '1) -- complement
   return failure();


### PR DESCRIPTION
Fixes one of the patterns described in #1624, where a common pattern is the or'ing of two values that only have bits set in non-overlapping positions.

This is the first time I've contributed to this codebase, and it's been a long time since I've written C++, so I'm happy to make any changes that are requested.

The approach I took was to simultaneously iterate over the operands of both concats in a left-to-right fashion, resolving the result of the `or`, but it got a bit tricky due to having to split up the constant 0's into narrower constants when the operand bit ranges don't align between the two concats. Please let me know if there's a better or simpler approach to this, since my `while` loop ended up with many different edge cases and it doesn't seem the most elegant.

I also realized that we can handle constant 1's in the concats at the same time by having them mask over any variable bits, but I wasn't sure if that should be done in a different pass or handled at the same time.

Lastly, I'm still coming up to speed on the different classes and methods available, so apologies in advance if I'm using the wrong ones or if I've reimplemented something that's already available as a helper method somewhere.