### PR TITLE
[SV] Replace copy-pasted HW types with include of HWTypes.td

### DIFF
--- a/include/circt/Dialect/HW/HWTypes.td
+++ b/include/circt/Dialect/HW/HWTypes.td
@@ -35,6 +35,9 @@ def HWValueType : DialectType<HWDialect,
 def HWNonInOutType : DialectType<HWDialect,
     CPred<"!hw::hasHWInOutType($_self)">, "a type without inout">;
 
+def InOutType : DialectType<HWDialect,
+    CPred<"hw::type_isa<hw::InOutType>($_self)">, "InOutType", "InOutType">;
+
 // A handle to refer to hw::ArrayType in ODS.
 def ArrayType : DialectType<HWDialect,
     CPred<"hw::type_isa<hw::ArrayType>($_self)">, "an ArrayType",

--- a/include/circt/Dialect/HW/HWTypesImpl.td
+++ b/include/circt/Dialect/HW/HWTypesImpl.td
@@ -57,7 +57,7 @@ def UnpackedArrayType : HWType<"UnpackedArray"> {
   }];
 }
 
-def InOutType : HWType<"InOut"> {
+def InOutTypeImpl : HWType<"InOut"> {
   let summary = "inout type";
   let description = [{
     InOut type is used for model operations and values that have "connection"

--- a/include/circt/Dialect/SV/SVTypes.td
+++ b/include/circt/Dialect/SV/SVTypes.td
@@ -16,25 +16,7 @@ class SVType<string name> : TypeDef<SVDialect, name> { }
 // Generic stuff shared with HW Dialect.
 //===----------------------------------------------------------------------===//
 
-// Type constraint that indicates that an operand/result may only be a valid,
-// known, non-directional type.
-def HWIntegerType : Type<CPred<"hw::isHWIntegerType($_self)">,
-                          "an integer bitvector of one or more bits",
-                          "::mlir::IntegerType">;
-
-// Type constraint that indicates that an operand/result may only be a valid,
-// known, non-directional type.
-def HWValueType : Type<CPred<"hw::isHWValueType($_self)">,
-                        "a known primitive element">;
-
-// Type constraint that indicates that an operand/result may only be a valid
-// non-directional type.
-def HWNonInOutType : Type<CPred<"!hw::hasHWInOutType($_self)">,
-                           "a type without inout">;
-
-// FIXME: Shouldn't have to duplicate this from the HW dialect tblgen files.
-def InOutType : Type<CPred<"$_self.isa<hw::InOutType>()">, "InOutType",
-                           "::circt::hw::InOutType">;
+include "circt/Dialect/HW/HWTypes.td"
 
 //===----------------------------------------------------------------------===//
 // InOut type and related helpers.


### PR DESCRIPTION
Let SV dialect benefit from `HWTypes.td` refactoring as well :smile: