### PR TITLE
[ExportVerilog] Flip the default output of `sv.alwaysComb` ops

### DIFF
--- a/docs/VerilogGeneration.md
+++ b/docs/VerilogGeneration.md
@@ -64,8 +64,8 @@ The current set of "tool capability" Lowering Options is:
 
  * `useAlwaysFF` (default=`false`).  If true, emits `sv.alwaysff` as
     Verilog `always_ff` statements.  Otherwise, print them as `always` statements.
- * `useAlwaysComb` (default=`false`).  If true, emits `sv.alwayscomb` as Verilog
-   `always_comb` statements.  Otherwise, print them as `always @(*)`.
+ * `noAlwaysComb` (default=`false`).  If true, emits `sv.alwayscomb` as Verilog
+   `always @(*)` statements.  Otherwise, print them as `always_comb`.
  * `allowExprInEventControl` (default=`false`).   If true, expressions are
    allowed in the sensitivity list of `always` statements, otherwise they are
    forced to be simple wires. Some EDA tools rely on these being simple wires.

--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -62,9 +62,9 @@ struct LoweringOptions {
   /// print them as `always` statements
   bool useAlwaysFF = false;
 
-  /// If true, emits `sv.alwayscomb` as Verilog `always_comb` statements.
-  /// Otherwise, print them as `always @(*)`.
-  bool useAlwaysComb = false;
+  /// If true, emits `sv.alwayscomb` as Verilog `always @(*)` statements.
+  /// Otherwise, print them as `always_comb`.
+  bool noAlwaysComb = false;
 
   /// If true, expressions are allowed in the sensitivity list of `always`
   /// statements, otherwise they are forced to be simple wires. Some EDA

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -41,8 +41,8 @@ void LoweringOptions::parse(StringRef text, ErrorHandlerT errorHandler) {
       // Empty options are fine.
     } else if (option == "alwaysFF") {
       useAlwaysFF = true;
-    } else if (option == "alwaysComb") {
-      useAlwaysComb = true;
+    } else if (option == "noAlwaysComb") {
+      noAlwaysComb = true;
     } else if (option == "exprInEventControl") {
       allowExprInEventControl = true;
     } else if (option == "disallowPackedArrays") {
@@ -69,8 +69,8 @@ std::string LoweringOptions::toString() const {
   // All options should add a trailing comma to simplify the code.
   if (useAlwaysFF)
     options += "alwaysFF,";
-  if (useAlwaysComb)
-    options += "alwaysComb,";
+  if (noAlwaysComb)
+    options += "noAlwaysComb,";
   if (allowExprInEventControl)
     options += "exprInEventControl,";
   if (disallowPackedArrays)

--- a/lib/Translation/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Translation/ExportVerilog/ExportVerilog.cpp
@@ -2334,9 +2334,9 @@ LogicalResult StmtEmitter::visitSV(AlwaysCombOp op) {
   SmallPtrSet<Operation *, 8> ops;
   ops.insert(op);
 
-  StringRef opString = "always @(*)";
-  if (state.options.useAlwaysComb)
-    opString = "always_comb";
+  StringRef opString = "always_comb";
+  if (state.options.noAlwaysComb)
+    opString = "always @(*)";
 
   indent() << opString;
   emitBlockAsStatement(op.getBodyBlock(), ops, opString);

--- a/test/ExportVerilog/sv-alwayscomb.mlir
+++ b/test/ExportVerilog/sv-alwayscomb.mlir
@@ -1,35 +1,35 @@
 // RUN: circt-translate --split-input-file --export-verilog %s | FileCheck %s --check-prefix=DEFAULT
 // RUN: circt-translate --lowering-options= --split-input-file --export-verilog %s | FileCheck %s --check-prefix=CLEAR
-// RUN: circt-translate --lowering-options=alwaysComb --split-input-file --export-verilog %s | FileCheck %s --check-prefix=ALWAYSCOMB
+// RUN: circt-translate --lowering-options=noAlwaysComb --split-input-file --export-verilog %s | FileCheck %s --check-prefix=NOALWAYSCOMB
 
 hw.module @test() {
   sv.alwayscomb {
   }
-}
-
-// DEFAULT: always @(*) begin
-// DEFAULT: end // always @(*)
-
-// CLEAR: always @(*) begin
-// CLEAR: end // always @(*)
-
-// ALWAYSCOMB: always_comb begin
-// ALWAYSCOMB: end // always_comb
-
-// -----
-
-module attributes {circt.loweringOptions = "alwaysComb"} {
-hw.module @test() {
-  sv.alwayscomb {
-  }
-}
 }
 
 // DEFAULT: always_comb begin
 // DEFAULT: end // always_comb
 
-// CLEAR: always @(*) begin
-// CLEAR: end // always @(*)
+// CLEAR: always_comb begin
+// CLEAR: end // always_comb
 
-// ALWAYSCOMB: always_comb begin
-// ALWAYSCOMB: end // always_comb
+// NOALWAYSCOMB: always @(*) begin
+// NOALWAYSCOMB: end // always @(*)
+
+// -----
+
+module attributes {circt.loweringOptions = "noAlwaysComb"} {
+hw.module @test() {
+  sv.alwayscomb {
+  }
+}
+}
+
+// DEFAULT: always @(*) begin
+// DEFAULT: end // always @(*)
+
+// CLEAR: always_comb begin
+// CLEAR: end // always_comb
+
+// NOALWAYSCOMB: always @(*) begin
+// NOALWAYSCOMB: end // always @(*)

--- a/test/ExportVerilog/sv-dialect.mlir
+++ b/test/ExportVerilog/sv-dialect.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-translate %s -export-verilog -verify-diagnostics --lowering-options=alwaysFF,alwaysComb,exprInEventControl | FileCheck %s --strict-whitespace
+// RUN: circt-translate %s -export-verilog -verify-diagnostics --lowering-options=alwaysFF,exprInEventControl | FileCheck %s --strict-whitespace
 
 // CHECK-LABEL: module M1(
 hw.module @M1(%clock : i1, %cond : i1, %val : i8) {

--- a/test/firtool/style.fir
+++ b/test/firtool/style.fir
@@ -1,10 +1,10 @@
 ; RUN: firtool %s | FileCheck %s --check-prefix=DEFAULT
 ; RUN: not firtool --lowering-options=bad-option %s 2>&1 | FileCheck %s --check-prefix=BADOPTION
-; RUN: firtool --lowering-options=alwaysFF,alwaysComb %s | FileCheck %s --check-prefix=OPTIONS
+; RUN: firtool --lowering-options=alwaysFF,noAlwaysComb %s | FileCheck %s --check-prefix=OPTIONS
 
 circuit test :
   module test :
 
 ; DEFAULT: module {
 ; BADOPTION: lowering-options option: unknown style option 'bad-option'
-; OPTIONS: module attributes {circt.loweringOptions = "alwaysFF,alwaysComb"} {
+; OPTIONS: module attributes {circt.loweringOptions = "alwaysFF,noAlwaysComb"} {


### PR DESCRIPTION
We have decided that we want the default options in CIRCT to make use of
newer SystemVerilog constructs which improve the quality of output. In
the initial commit for adding a lowering option for `alwaysComb`
printing, we defaulted to print `always_comb` as `always @(*)`. This
flips the default setting and the changes the flag name to
`noAlwaysComb`, which is more in line with our desired output.

This is probably not the end of our efforts to support customized lowering of
`alwaysComb`: `always @(*)` and `always_comb` are not 100% equivalent
and have differences in their behavior at time 0.