### PR TITLE
[Calyx] Add emitters for library operations

### DIFF
--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -149,10 +149,18 @@ struct Emitter {
 
   // Emits a library primitive with template parameters based on all in- and
   // output ports.
+  // e.g.:
+  //   $f.in0, $f.in1, $f.in2, $f.out : calyx.std_foo "f" : i1, i2, i3, i4
+  // emits:
+  //   foo = std_foo(1, 2, 3, 4);
   void emitLibraryPrimTypedByAllPorts(Operation *op);
 
   // Emits a library primitive with a single template parameter based on the
   // first input port.
+  // e.g.:
+  //   $f.in0, $f.in1, $f.out : calyx.std_foo "f" : i32, i32, i1
+  // emits:
+  //   foo = std_foo(32);
   void emitLibraryPrimTypedByFirstInputPort(Operation *op);
 
 private:

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -493,12 +493,7 @@ void Emitter::emitWires(WiresOp op) {
       TypeSwitch<Operation *>(&bodyOp)
           .Case<GroupOp>([&](auto op) { emitGroup(op); })
           .Case<AssignOp>([&](auto op) { emitAssignment(op); })
-          .Case<hw::ConstantOp, comb::AndOp, comb::OrOp, comb::XorOp,
-                // Calyx stdlib ops
-                LtLibOp, GtLibOp, EqLibOp, NeqLibOp, GeLibOp, LeLibOp, SltLibOp,
-                SgtLibOp, SeqLibOp, SneqLibOp, SgeLibOp, SleLibOp, AddLibOp,
-                SubLibOp, ShruLibOp, RshLibOp, SrshLibOp, LshLibOp, AndLibOp,
-                NotLibOp, OrLibOp, XorLibOp, SliceLibOp, PadLibOp>(
+          .Case<hw::ConstantOp, comb::AndOp, comb::OrOp, comb::XorOp>(
               [&](auto op) { /* Do nothing. */ })
           .Default([&](auto op) {
             emitOpError(op, "not supported for emission inside wires section");

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -24,21 +24,29 @@ calyx.program {
     // CHECK-NEXT:    r = std_reg(8);
     // CHECK-NEXT:    m0 = std_mem_d1(32, 1, 1);
     // CHECK-NEXT:    m1 = std_mem_d2(8, 64, 64, 6, 6);
+    // CHECK-NEXT:    a0 = std_add(32);
+    // CHECK-NEXT:    s0 = std_slice(32, 8);
     %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i8, i1, i1, i1, i8, i1
     %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance "c1" @B : i1, i1, i1, i1, i1, i1
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8, i1, i1, i1, i8, i1
     %m0.addr0, %m0.write_data, %m0.write_en, %m0.clk, %m0.read_data, %m0.done = calyx.memory "m0"<[1] x 32> [1] : i1, i32, i1, i1, i32, i1
     %m1.addr0, %m1.addr1, %m1.write_data, %m1.write_en, %m1.clk, %m1.read_data, %m1.done = calyx.memory "m1"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
+    %a0.left, %a0.right, %a0.out = calyx.std_add "a0" : i32, i32, i32
+    %s0.in, %s0.out = calyx.std_slice "s0" : i32, i8
 
     // CHECK-LABEL: wires {
     calyx.wires {
       // CHECK-NEXT: group Group1 {
+      // CHECK-NEXT:    s0.in = a0.out;
+      // CHECK-NEXT:    a0.left = m0.read_data;
       // CHECK-NEXT:    Group1[go] = 1'd0;
       // CHECK-NEXT:    c0.in = c0.out;
       // CHECK-NEXT:    Group1[done] = c0.done;
       %c0 = hw.constant 0 : i1
       %c1 = hw.constant 1 : i1
       calyx.group @Group1 {
+        calyx.assign %s0.in = %a0.out : i32
+        calyx.assign %a0.left = %m0.read_data : i32
         calyx.group_go %c0 : i1
         calyx.assign %c0.in = %c0.out : i8
         calyx.group_done %c0.done : i1


### PR DESCRIPTION
This commit also refactors value emission for instance ops into a generic version based on the cell interface.

Depends on #1710 (posting now because i'll be gone for the evening) - just ignore the things in `CalyxInterfaces.td `.

fixes #1694.