### PR TITLE
[Calyx] Rewrite isPortDrivenByGroup based on Cell interface

### DIFF
--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -201,13 +201,13 @@ calyx.program {
 // -----
 
 calyx.program {
-  calyx.component @A(%go: i1, %clk: i1, %reset: i1) -> (%out: i1, %done: i1) {
+  calyx.component @A(%in: i1, %go: i1, %clk: i1, %reset: i1) -> (%out: i1, %done: i1) {
     %c1_1 = hw.constant 1 : i1
     calyx.wires { calyx.assign %done = %c1_1 : i1 }
     calyx.control {}
   }
   calyx.component @main(%go: i1, %clk: i1, %reset: i1) -> (%done: i1) {
-    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i1, i1, i1, i1, i1
+    %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires { calyx.group @Group1 { calyx.group_done %c1_1 : i1 } }
     calyx.control {
@@ -265,13 +265,13 @@ calyx.program {
 // -----
 
 calyx.program {
-  calyx.component @A(%go: i1, %clk: i1, %reset: i1) -> (%out: i1, %done: i1) {
+  calyx.component @A(%in: i1, %go: i1, %clk: i1, %reset: i1) -> (%out: i1, %done: i1) {
     %c1_1 = hw.constant 1 : i1
     calyx.wires { calyx.assign %done = %c1_1 : i1 }
     calyx.control {}
   }
   calyx.component @main(%go: i1, %clk: i1, %reset: i1) -> (%done: i1) {
-    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i1, i1, i1, i1, i1
+    %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires { calyx.group @Group1 { calyx.group_done %c1_1 : i1 } }
     calyx.control {


### PR DESCRIPTION
Apart from simplifying the check, this provides  necessary infrastructure for #1712.

Depends on #1710 - just ignore the things in CalyxInterfaces.td .