### PR TITLE
LLVM Submodule Update

### DIFF
--- a/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
+++ b/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
@@ -2139,8 +2139,9 @@ struct ConstantTimeOpConversion : public ConvertToLLVMPattern {
     uint64_t eps = timeAttr.getEps();
 
     // Create time constant.
-    auto denseAttr = DenseElementsAttr::get(
-        VectorType::get(3, rewriter.getI64Type()), {adjusted, delta, eps});
+    auto denseAttr =
+        DenseElementsAttr::get(RankedTensorType::get(3, rewriter.getI64Type()),
+                               {adjusted, delta, eps});
     rewriter.replaceOpWithNewOp<LLVM::ConstantOp>(op, timeTy, denseAttr);
     return success();
   }

--- a/lib/Scheduling/TestPasses.cpp
+++ b/lib/Scheduling/TestPasses.cpp
@@ -131,6 +131,10 @@ static void emitSchedule(Problem &prob, StringRef attrName,
 namespace {
 struct TestProblemPass : public PassWrapper<TestProblemPass, FunctionPass> {
   void runOnFunction() override;
+  StringRef getArgument() const override { return "test-scheduling-problem"; }
+  StringRef getDescription() const override {
+    return "Import a schedule encoded as attributes";
+  }
 };
 } // namespace
 
@@ -164,6 +168,10 @@ namespace {
 struct TestCyclicProblemPass
     : public PassWrapper<TestCyclicProblemPass, FunctionPass> {
   void runOnFunction() override;
+  StringRef getArgument() const override { return "test-cyclic-problem"; }
+  StringRef getDescription() const override {
+    return "Import a solution for the cyclic problem encoded as attributes";
+  }
 };
 } // namespace
 
@@ -201,6 +209,11 @@ namespace {
 struct TestSPOProblemPass
     : public PassWrapper<TestSPOProblemPass, FunctionPass> {
   void runOnFunction() override;
+  StringRef getArgument() const override { return "test-spo-problem"; }
+  StringRef getDescription() const override {
+    return "Import a solution for the shared, pipelined operators problem "
+           "encoded as attributes";
+  }
 };
 } // namespace
 
@@ -234,6 +247,10 @@ namespace {
 struct TestASAPSchedulerPass
     : public PassWrapper<TestASAPSchedulerPass, FunctionPass> {
   void runOnFunction() override;
+  StringRef getArgument() const override { return "test-asap-scheduler"; }
+  StringRef getDescription() const override {
+    return "Emit ASAP scheduler's solution as attributes";
+  }
 };
 } // anonymous namespace
 
@@ -269,6 +286,10 @@ struct TestSimplexSchedulerPass
   TestSimplexSchedulerPass(const TestSimplexSchedulerPass &) {}
   Option<std::string> problemToTest{*this, "with", llvm::cl::init("Problem")};
   void runOnFunction() override;
+  StringRef getArgument() const override { return "test-simplex-scheduler"; }
+  StringRef getDescription() const override {
+    return "Emit a simplex scheduler's solution as attributes";
+  }
 };
 } // anonymous namespace
 
@@ -347,19 +368,21 @@ void TestSimplexSchedulerPass::runOnFunction() {
 namespace circt {
 namespace test {
 void registerSchedulingTestPasses() {
-  PassRegistration<TestProblemPass> problemTester(
-      "test-scheduling-problem", "Import a schedule encoded as attributes");
-  PassRegistration<TestCyclicProblemPass> cyclicProblemTester(
-      "test-cyclic-problem",
-      "Import a solution for the cyclic problem encoded as attributes");
-  PassRegistration<TestSPOProblemPass> spoTester(
-      "test-spo-problem", "Import a solution for the shared, pipelined "
-                          "operators problem encoded as attributes");
-  PassRegistration<TestASAPSchedulerPass> asapTester(
-      "test-asap-scheduler", "Emit ASAP scheduler's solution as attributes");
-  PassRegistration<TestSimplexSchedulerPass> simplexTester(
-      "test-simplex-scheduler",
-      "Emit a simplex scheduler's solution as attributes");
+  mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
+    return std::make_unique<TestProblemPass>();
+  });
+  mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
+    return std::make_unique<TestCyclicProblemPass>();
+  });
+  mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
+    return std::make_unique<TestSPOProblemPass>();
+  });
+  mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
+    return std::make_unique<TestASAPSchedulerPass>();
+  });
+  mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
+    return std::make_unique<TestSimplexSchedulerPass>();
+  });
 }
 } // namespace test
 } // namespace circt

--- a/test/Conversion/LLHDToLLVM/convert_process_persistence.mlir
+++ b/test/Conversion/LLHDToLLVM/convert_process_persistence.mlir
@@ -120,7 +120,7 @@ llhd.proc @convert_persistent_i32 () -> () {
 // CHECK:           %[[VAL_8:.*]] = llvm.icmp "eq" %[[VAL_6]], %[[VAL_7]] : i32
 // CHECK:           llvm.cond_br %[[VAL_8]], ^bb2, ^bb4
 // CHECK:         ^bb2:
-// CHECK:           %[[VAL_9:.*]] = llvm.mlir.constant(dense<[0, 0, 1]> : vector<3xi64>) : !llvm.array<3 x i64>
+// CHECK:           %[[VAL_9:.*]] = llvm.mlir.constant(dense<[0, 0, 1]> : tensor<3xi64>) : !llvm.array<3 x i64>
 // CHECK:           %[[VAL_10:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:           %[[VAL_11:.*]] = llvm.mlir.constant(3 : i32) : i32
 // CHECK:           %[[VAL_12:.*]] = llvm.mlir.constant(0 : i32) : i32

--- a/test/Conversion/LLHDToLLVM/convert_signals.mlir
+++ b/test/Conversion/LLHDToLLVM/convert_signals.mlir
@@ -74,7 +74,7 @@ llhd.entity @convert_prb (%sI1 : !llhd.sig<i1>, %sArr : !llhd.sig<!hw.array<3xi5
 // CHECK:           %[[VAL_10:.*]] = llvm.insertvalue %[[VAL_8]], %[[VAL_9]][0 : i32] : !llvm.array<3 x i5>
 // CHECK:           %[[VAL_11:.*]] = llvm.insertvalue %[[VAL_8]], %[[VAL_10]][1 : i32] : !llvm.array<3 x i5>
 // CHECK:           %[[VAL_12:.*]] = llvm.insertvalue %[[VAL_8]], %[[VAL_11]][2 : i32] : !llvm.array<3 x i5>
-// CHECK:           %[[VAL_13:.*]] = llvm.mlir.constant(dense<[1000, 0, 0]> : vector<3xi64>) : !llvm.array<3 x i64>
+// CHECK:           %[[VAL_13:.*]] = llvm.mlir.constant(dense<[1000, 0, 0]> : tensor<3xi64>) : !llvm.array<3 x i64>
 // CHECK:           %[[VAL_14:.*]] = llvm.mlir.constant(1 : i64) : i64
 // CHECK:           %[[VAL_15:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK:           %[[VAL_16:.*]] = llvm.alloca %[[VAL_15]] x i1 {alignment = 4 : i64} : (i32) -> !llvm.ptr<i1>
@@ -131,7 +131,7 @@ llhd.entity @convert_drv_enable (%sI1 : !llhd.sig<i1>) -> () {
 // CHECK-SAME:                           %[[VAL_0:.*]]: !llvm.ptr<i8>,
 // CHECK-SAME:                           %[[VAL_1:.*]]: !llvm.ptr<struct<(array<3 x i1>)>>,
 // CHECK-SAME:                           %[[VAL_2:.*]]: !llvm.ptr<struct<(ptr<i8>, i64, i64, i64)>>) {
-// CHECK:           %[[VAL_3:.*]] = llvm.mlir.constant(dense<[1000, 0, 0]> : vector<3xi64>) : !llvm.array<3 x i64>
+// CHECK:           %[[VAL_3:.*]] = llvm.mlir.constant(dense<[1000, 0, 0]> : tensor<3xi64>) : !llvm.array<3 x i64>
 // CHECK:           %[[VAL_4:.*]] = llvm.mlir.constant(false) : i1
 // CHECK:           %[[VAL_5:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:           %[[VAL_6:.*]] = llvm.getelementptr %[[VAL_2]]{{\[}}%[[VAL_5]]] : (!llvm.ptr<struct<(ptr<i8>, i64, i64, i64)>>, i32) -> !llvm.ptr<struct<(ptr<i8>, i64, i64, i64)>>

--- a/test/Conversion/LLHDToLLVM/convert_simple.mlir
+++ b/test/Conversion/LLHDToLLVM/convert_simple.mlir
@@ -23,7 +23,7 @@
 // CHECK:           %[[VAL_16:.*]] = llvm.trunc %[[VAL_15]] : i16 to i1
 // CHECK:           %[[VAL_17:.*]] = llvm.mlir.constant(true) : i1
 // CHECK:           %[[VAL_18:.*]] = llvm.xor %[[VAL_16]], %[[VAL_17]] : i1
-// CHECK:           %[[VAL_19:.*]] = llvm.mlir.constant(dense<[1000, 0, 0]> : vector<3xi64>) : !llvm.array<3 x i64>
+// CHECK:           %[[VAL_19:.*]] = llvm.mlir.constant(dense<[1000, 0, 0]> : tensor<3xi64>) : !llvm.array<3 x i64>
 // CHECK:           %[[VAL_20:.*]] = llvm.mlir.constant(1 : i64) : i64
 // CHECK:           %[[VAL_21:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK:           %[[VAL_22:.*]] = llvm.alloca %[[VAL_21]] x i1 {alignment = 4 : i64} : (i32) -> !llvm.ptr<i1>

--- a/test/Conversion/LLHDToLLVM/convert_wait.mlir
+++ b/test/Conversion/LLHDToLLVM/convert_wait.mlir
@@ -21,7 +21,7 @@
 // CHECK:           %[[VAL_10:.*]] = llvm.icmp "eq" %[[VAL_6]], %[[VAL_9]] : i32
 // CHECK:           llvm.cond_br %[[VAL_10]], ^bb3, ^bb5
 // CHECK:         ^bb3:
-// CHECK:           %[[VAL_11:.*]] = llvm.mlir.constant(dense<[0, 0, 1]> : vector<3xi64>) : !llvm.array<3 x i64>
+// CHECK:           %[[VAL_11:.*]] = llvm.mlir.constant(dense<[0, 0, 1]> : tensor<3xi64>) : !llvm.array<3 x i64>
 // CHECK:           %[[VAL_12:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK:           %[[VAL_13:.*]] = llvm.getelementptr %[[VAL_1]]{{\[}}%[[VAL_3]], %[[VAL_4]]] : (!llvm.ptr<struct<(i32, i32, ptr<array<0 x i1>>, struct<()>)>>, i32, i32) -> !llvm.ptr<i32>
 // CHECK:           llvm.store %[[VAL_12]], %[[VAL_13]] : !llvm.ptr<i32>
@@ -151,7 +151,7 @@ llhd.proc @convert_resume_observe_partial (%in0 : !llhd.sig<i1>, %in1 : !llhd.si
 // CHECK:           %[[VAL_12:.*]] = llvm.icmp "eq" %[[VAL_8]], %[[VAL_11]] : i32
 // CHECK:           llvm.cond_br %[[VAL_12]], ^bb3, ^bb5
 // CHECK:         ^bb3:
-// CHECK:           %[[VAL_13:.*]] = llvm.mlir.constant(dense<[0, 0, 1]> : vector<3xi64>) : !llvm.array<3 x i64>
+// CHECK:           %[[VAL_13:.*]] = llvm.mlir.constant(dense<[0, 0, 1]> : tensor<3xi64>) : !llvm.array<3 x i64>
 // CHECK:           %[[VAL_14:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK:           %[[VAL_15:.*]] = llvm.getelementptr %[[VAL_1]]{{\[}}%[[VAL_5]], %[[VAL_6]]] : (!llvm.ptr<struct<(i32, i32, ptr<array<1 x i1>>, struct<()>)>>, i32, i32) -> !llvm.ptr<i32>
 // CHECK:           llvm.store %[[VAL_14]], %[[VAL_15]] : !llvm.ptr<i32>

--- a/test/Dialect/ESI/esi-tester.cpp
+++ b/test/Dialect/ESI/esi-tester.cpp
@@ -38,14 +38,20 @@ struct TestESIModWrap
           signalPassFailure();
     }
   }
+
+  StringRef getArgument() const override { return "test-mod-wrap"; }
+  StringRef getDescription() const override {
+    return "Test the ESI find and wrap functionality";
+  }
 };
 
 int main(int argc, char **argv) {
   mlir::DialectRegistry registry;
   registry.insert<comb::CombDialect, esi::ESIDialect, hw::HWDialect>();
 
-  mlir::PassRegistration<TestESIModWrap>(
-      "test-mod-wrap", "Test the ESI find and wrap functionality");
+  mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
+    return std::make_unique<TestESIModWrap>();
+  });
 
   return mlir::failed(
       mlir::MlirOptMain(argc, argv, "CIRCT modular optimizer driver", registry,


### PR DESCRIPTION
I need the latest llvm for the recent python improvements.

@fabianschuiki / @maerhart  The LLHD simulator tests are all failing with: `llhd-sim: /home/jodemme/circt/llvm/llvm/lib/IR/Constants.cpp:2628: static llvm::Constant *llvm::ConstantExpr::getExtractValue(llvm::Constant *, ArrayRef<unsigned int>, llvm::Type *): Assertion `ReqTy && "extractvalue indices invalid!"' failed.`

Can one of you take a look?