### PR TITLE
[Calyx] Add `clk` port to MemoryOp.

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -70,11 +70,11 @@ def MemoryOp : CalyxPrimitive<"memory", []> {
     ```mlir
       // A 1-dimensional, 32-bit memory with size dimension 1. Equivalent representation in the native compiler:
       // `m1 = std_mem_d1(32, 1, 1)`
-      %m1.addr0, %m1.write_data, %m1.write_en, %m1.read_data, %m1.done = calyx.memory "m1"<[1] x 32> [1] : i1, i32, i1, i32, i1
+      %m1.addr0, %m1.write_data, %m1.write_en, %m1.clk, %m1.read_data, %m1.done = calyx.memory "m1"<[1] x 32> [1] : i1, i32, i1, i1, i32, i1
 
       // A 2-dimensional, 8-bit memory with size dimensions 64 x 64. Equivalent representation in the native compiler:
       // `m2 = std_mem_d2(8, 64, 64, 6, 6)`
-      %m2.addr0, %m2.addr1, %m2.write_data, %m2.write_en, %m2.read_data, %m2.done = calyx.memory "m2"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i8, i1
+      %m2.addr0, %m2.addr1, %m2.write_data, %m2.write_en, %m2.clk, %m2.read_data, %m2.done = calyx.memory "m2"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
     ```
   }];
 
@@ -111,8 +111,9 @@ def MemoryOp : CalyxPrimitive<"memory", []> {
     Value addrPort(size_t i) { assert(i<getNumDimensions() && "Out of bounds of address ports for this memory."); return getResults()[i]; }
     Value writeData() { return getResult(getNumDimensions()); }
     Value writeEn()   { return getResult(getNumDimensions() + 1); }
-    Value readData()  { return getResult(getNumDimensions() + 2); }
-    Value done()      { return getResult(getNumDimensions() + 3); }
+    Value clk()       { return getResult(getNumDimensions() + 2); }
+    Value readData()  { return getResult(getNumDimensions() + 3); }
+    Value done()      { return getResult(getNumDimensions() + 4); }
   }];
 }
 

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -762,10 +762,7 @@ SmallVector<StringRef> MemoryOp::portNames() {
         StringAttr::get(this->getContext(), "addr" + std::to_string(i));
     portNames.push_back(nameAttr.getValue());
   }
-  portNames.push_back("write_data");
-  portNames.push_back("write_en");
-  portNames.push_back("read_data");
-  portNames.push_back("done");
+  portNames.append({"write_data", "write_en", "clk", "read_data", "done"});
   return portNames;
 }
 
@@ -773,10 +770,7 @@ SmallVector<Direction> MemoryOp::portDirections() {
   SmallVector<Direction> portDirections;
   for (size_t i = 0, e = addrSizes().size(); i != e; ++i)
     portDirections.push_back(Input);
-  portDirections.push_back(Input);
-  portDirections.push_back(Input);
-  portDirections.push_back(Output);
-  portDirections.push_back(Output);
+  portDirections.append({Input, Input, Input, Output, Output});
   return portDirections;
 }
 
@@ -789,11 +783,12 @@ void MemoryOp::build(OpBuilder &builder, OperationState &state,
   state.addAttribute("addrSizes", builder.getI64ArrayAttr(addrSizes));
   SmallVector<Type> types;
   for (int64_t size : addrSizes)
-    types.push_back(builder.getIntegerType(size));
-  types.push_back(builder.getIntegerType(width));
-  types.push_back(builder.getI1Type());
-  types.push_back(builder.getIntegerType(width));
-  types.push_back(builder.getI1Type());
+    types.push_back(builder.getIntegerType(size)); // Addresses
+  types.push_back(builder.getIntegerType(width));  // Write data
+  types.push_back(builder.getI1Type());            // Write enable
+  types.push_back(builder.getI1Type());            // Clk
+  types.push_back(builder.getIntegerType(width));  // Read data
+  types.push_back(builder.getI1Type());            // Done
   state.addTypes(types);
 }
 
@@ -806,7 +801,7 @@ static LogicalResult verifyMemoryOp(MemoryOp memoryOp) {
     return memoryOp.emitOpError("mismatched number of dimensions (")
            << numDims << ") and address sizes (" << numAddrs << ")";
 
-  size_t numExtraPorts = 4; // write data/enable and read data/done.
+  size_t numExtraPorts = 5; // write data/enable, clk, and read data/done.
   if (memoryOp.getNumResults() != numAddrs + numExtraPorts)
     return memoryOp.emitOpError("incorrect number of address ports, expected ")
            << numAddrs;

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -25,8 +25,8 @@ calyx.program {
     %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i8, i1, i1, i1, i8, i1
     %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance "c1" @B : i1, i1, i1, i1, i1, i1
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8, i1, i1, i1, i8, i1
-    %m0.addr0, %m0.write_data, %m0.write_en, %m0.read_data, %m0.done = calyx.memory "m0"<[1] x 32> [1] : i1, i32, i1, i32, i1
-    %m1.addr0, %m1.addr1, %m1.write_data, %m1.write_en, %m1.read_data, %m1.done = calyx.memory "m1"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i8, i1
+    %m0.addr0, %m0.write_data, %m0.write_en, %m0.clk, %m0.read_data, %m0.done = calyx.memory "m0"<[1] x 32> [1] : i1, i32, i1, i1, i32, i1
+    %m1.addr0, %m1.addr1, %m1.write_data, %m1.write_en, %m1.clk, %m1.read_data, %m1.done = calyx.memory "m1"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
 
     // CHECK-LABEL: wires {
     calyx.wires {

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -275,7 +275,7 @@ calyx.program {
 calyx.program {
   calyx.component @main(%go: i1, %clk: i1, %reset: i1) -> (%done: i1) {
     // expected-error @+1 {{'calyx.memory' op mismatched number of dimensions (1) and address sizes (2)}}
-    %m.addr0, %m.write_data, %m.write_en, %m.read_data, %m.done = calyx.memory "m"<[64] x 8> [6, 6] : i6, i8, i1, i8, i1
+    %m.addr0, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory "m"<[64] x 8> [6, 6] : i6, i8, i1, i1, i8, i1
     calyx.wires {}
     calyx.control {}
   }
@@ -286,7 +286,7 @@ calyx.program {
 calyx.program {
   calyx.component @main(%go: i1, %clk: i1, %reset: i1) -> (%done: i1) {
     // expected-error @+1 {{'calyx.memory' op incorrect number of address ports, expected 2}}
-    %m.addr0, %m.write_data, %m.write_en, %m.read_data, %m.done = calyx.memory "m"<[64, 64] x 8> [6, 6] : i6, i8, i1, i8, i1
+    %m.addr0, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory "m"<[64, 64] x 8> [6, 6] : i6, i8, i1, i1, i8, i1
     calyx.wires {}
     calyx.control {}
   }
@@ -297,7 +297,7 @@ calyx.program {
 calyx.program {
   calyx.component @main(%go: i1, %clk: i1, %reset: i1) -> (%done: i1) {
     // expected-error @+1 {{'calyx.memory' op address size (5) for dimension 0 can't address the entire range (64)}}
-    %m.addr0, %m.write_data, %m.write_en, %m.read_data, %m.done = calyx.memory "m"<[64] x 8> [5] : i5, i8, i1, i5, i1
+    %m.addr0, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory "m"<[64] x 8> [5] : i5, i8, i1, i1, i5, i1
     calyx.wires {}
     calyx.control {}
   }

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -16,7 +16,7 @@ calyx.program {
 
   calyx.component @main(%go: i1, %clk: i1, %reset: i1) -> (%done: i1) {
     // CHECK:      %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8, i1, i1, i1, i8, i1
-    // CHECK-NEXT: %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.read_data, %m.done = calyx.memory "m"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i8, i1
+    // CHECK-NEXT: %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory "m"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
     // CHECK-NEXT: %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i8, i1, i1, i1, i8, i1
     // CHECK-NEXT: %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance "c1" @A : i8, i1, i1, i1, i8, i1
     // CHECK-NEXT: %c2.in, %c2.go, %c2.clk, %c2.reset, %c2.out, %c2.done = calyx.instance "c2" @B : i8, i1, i1, i1, i1, i1
@@ -25,7 +25,7 @@ calyx.program {
     // CHECK-NEXT: %pad.in, %pad.out = calyx.std_pad "pad" : i8, i9
     // CHECK-NEXT: %slice.in, %slice.out = calyx.std_slice "slice" : i8, i7
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8, i1, i1, i1, i8, i1
-    %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.read_data, %m.done = calyx.memory "m"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i8, i1
+    %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory "m"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
     %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i8, i1, i1, i1, i8, i1
     %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance "c1" @A : i8, i1, i1, i1, i8, i1
     %c2.in, %c2.go, %c2.clk, %c2.reset, %c2.out, %c2.done = calyx.instance "c2" @B : i8, i1, i1, i1, i1, i1


### PR DESCRIPTION
Add a `clk` port to the MemoryOp. A pleasant surprise: The primitive ports already aligned with the native compiler.