### PR TITLE
[Calyx] Add emission for component Block Arguments.

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxOps.h
+++ b/include/circt/Dialect/Calyx/CalyxOps.h
@@ -75,7 +75,7 @@ LogicalResult verifyCell(Operation *op);
 SmallVector<ComponentPortInfo> getComponentPortInfo(Operation *op);
 
 /// Returns port information for the block argument provided.
-ComponentPortInfo getComponentPort(Value blockArg);
+ComponentPortInfo getComponentPortInfo(BlockArgument arg);
 
 } // namespace calyx
 } // namespace circt

--- a/include/circt/Dialect/Calyx/CalyxOps.h
+++ b/include/circt/Dialect/Calyx/CalyxOps.h
@@ -74,6 +74,9 @@ LogicalResult verifyCell(Operation *op);
 /// Returns port information about a given component.
 SmallVector<ComponentPortInfo> getComponentPortInfo(Operation *op);
 
+/// Returns port information for the block argument provided.
+ComponentPortInfo getComponentPort(Value blockArg);
+
 } // namespace calyx
 } // namespace circt
 

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -219,9 +219,9 @@ private:
 
   /// Emits the value of a guard or assignment.
   void emitValue(Value value, bool isIndented) {
-    if (value.isa<BlockArgument>()) {
+    if (auto blockArg = value.dyn_cast<BlockArgument>()) {
       // Emit component block argument.
-      StringAttr portName = getComponentPort(value).name;
+      StringAttr portName = getComponentPortInfo(blockArg).name;
       (isIndented ? indent() : os) << '%' << portName.getValue();
       return;
     }

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -227,9 +227,7 @@ private:
     }
 
     auto definingOp = value.getDefiningOp();
-    if (definingOp == nullptr)
-      // Short-circuit to avoid TypeSwitch on a nullptr.
-      return;
+    assert(definingOp && "Value does not have a defining operation.");
 
     TypeSwitch<Operation *>(definingOp)
         .Case<CellInterface>([&](auto cell) {

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -219,8 +219,16 @@ private:
 
   /// Emits the value of a guard or assignment.
   void emitValue(Value value, bool isIndented) {
+    if (value.isa<BlockArgument>()) {
+      // Emit component block argument.
+      StringAttr portName = getComponentPort(value).name;
+      (isIndented ? indent() : os) << '%' << portName.getValue();
+      return;
+    }
+
     auto definingOp = value.getDefiningOp();
     if (definingOp == nullptr)
+      // Short-circuit to avoid TypeSwitch on a nullptr.
       return;
 
     TypeSwitch<Operation *>(definingOp)

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -222,7 +222,7 @@ private:
     if (auto blockArg = value.dyn_cast<BlockArgument>()) {
       // Emit component block argument.
       StringAttr portName = getComponentPortInfo(blockArg).name;
-      (isIndented ? indent() : os) << '%' << portName.getValue();
+      (isIndented ? indent() : os) << portName.getValue();
       return;
     }
 

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -205,8 +205,8 @@ private:
 
   /// Helper function for emitting combinational operations.
   template <typename CombinationalOp>
-  void emitCombinationalValue(CombinationalOp value, StringRef logicalSymbol) {
-    auto inputs = value.inputs();
+  void emitCombinationalValue(CombinationalOp op, StringRef logicalSymbol) {
+    auto inputs = op.inputs();
     os << LParen();
     for (size_t i = 0, e = inputs.size(); i != e; ++i) {
       emitValue(inputs[i], /*isIndented=*/false);

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -68,40 +68,36 @@ calyx.program {
       calyx.assign %c0.go = %c1.out : i1
     }
     // CHECK-LABEL: control {
+    // CHECK-NEXT:    par {
+    // CHECK-NEXT:      Group1;
+    // CHECK-NEXT:      Group2;
+    // CHECK-NEXT:    }
     // CHECK-NEXT:    seq {
-    // CHECK-NEXT:      par {
-    // CHECK-NEXT:        Group1;
-    // CHECK-NEXT:        Group2;
-    // CHECK-NEXT:      }
-    // CHECK-NEXT:      seq {
-    // CHECK-NEXT:        Group1;
-    // CHECK-NEXT:        while c1.in with Group2 {
-    // CHECK-NEXT:          seq {
-    // CHECK-NEXT:            Group1;
-    // CHECK-NEXT:            Group1;
-    // CHECK-NEXT:            if c1.in with Group2 {
-    // CHECK-NEXT:              Group2;
-    // CHECK-NEXT:            }
+    // CHECK-NEXT:      Group1;
+    // CHECK-NEXT:      while c1.in with Group2 {
+    // CHECK-NEXT:        seq {
+    // CHECK-NEXT:          Group1;
+    // CHECK-NEXT:          Group1;
+    // CHECK-NEXT:          if c1.in with Group2 {
+    // CHECK-NEXT:            Group2;
     // CHECK-NEXT:          }
     // CHECK-NEXT:        }
     // CHECK-NEXT:      }
     // CHECK-NEXT:    }
     // CHECK-NEXT:  }
     calyx.control {
+      calyx.par {
+        calyx.enable @Group1
+        calyx.enable @Group2
+      }
       calyx.seq {
-        calyx.par {
-          calyx.enable @Group1
-          calyx.enable @Group2
-        }
-        calyx.seq {
-          calyx.enable @Group1
-          calyx.while %c1.in with @Group2 {
-            calyx.seq {
-              calyx.enable @Group1
-              calyx.enable @Group1
-              calyx.if %c1.in with @Group2 {
-                calyx.enable @Group2
-              }
+        calyx.enable @Group1
+        calyx.while %c1.in with @Group2 {
+          calyx.seq {
+            calyx.enable @Group1
+            calyx.enable @Group1
+            calyx.if %c1.in with @Group2 {
+              calyx.enable @Group2
             }
           }
         }

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -63,6 +63,8 @@ calyx.program {
       }
       // CHECK:   c0.go = c1.out;
       calyx.assign %c0.go = %c1.out : i1
+      // CHECK:   %done = 1'd1;
+      calyx.assign  %done = %c1 : i1
     }
     // CHECK-LABEL: control {
     // CHECK-NEXT:    par {

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -5,7 +5,11 @@ calyx.program {
   // CHECK-LABEL: component A(in: 8, @go go: 1, @clk clk: 1, @reset reset: 1) -> (out: 8, @done done: 1) {
   calyx.component @A(%in: i8, %go: i1, %clk: i1, %reset: i1) -> (%out: i8, %done: i1) {
     %c1_1 = hw.constant 1 : i1
-    calyx.wires { calyx.assign %done = %c1_1 : i1 }
+
+    calyx.wires {
+      // CHECK: done = 1'd1;
+      calyx.assign %done = %c1_1 : i1
+    }
     calyx.control {}
   }
 
@@ -33,7 +37,8 @@ calyx.program {
     %m1.addr0, %m1.addr1, %m1.write_data, %m1.write_en, %m1.clk, %m1.read_data, %m1.done = calyx.memory "m1"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
     %a0.left, %a0.right, %a0.out = calyx.std_add "a0" : i32, i32, i32
     %s0.in, %s0.out = calyx.std_slice "s0" : i32, i8
-
+    %c0 = hw.constant 0 : i1
+    %c1 = hw.constant 1 : i1
     // CHECK-LABEL: wires {
     calyx.wires {
       // CHECK-NEXT: group Group1 {
@@ -42,8 +47,6 @@ calyx.program {
       // CHECK-NEXT:    Group1[go] = 1'd0;
       // CHECK-NEXT:    c0.in = c0.out;
       // CHECK-NEXT:    Group1[done] = c0.done;
-      %c0 = hw.constant 0 : i1
-      %c1 = hw.constant 1 : i1
       calyx.group @Group1 {
         calyx.assign %s0.in = %a0.out : i32
         calyx.assign %a0.left = %m0.read_data : i32
@@ -63,8 +66,6 @@ calyx.program {
       }
       // CHECK:   c0.go = c1.out;
       calyx.assign %c0.go = %c1.out : i1
-      // CHECK:   %done = 1'd1;
-      calyx.assign  %done = %c1 : i1
     }
     // CHECK-LABEL: control {
     // CHECK-NEXT:    par {

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -68,36 +68,40 @@ calyx.program {
       calyx.assign %c0.go = %c1.out : i1
     }
     // CHECK-LABEL: control {
-    // CHECK-NEXT:    par {
-    // CHECK-NEXT:      Group1;
-    // CHECK-NEXT:      Group2;
-    // CHECK-NEXT:    }
     // CHECK-NEXT:    seq {
-    // CHECK-NEXT:      Group1;
-    // CHECK-NEXT:      while c1.in with Group2 {
-    // CHECK-NEXT:        seq {
-    // CHECK-NEXT:          Group1;
-    // CHECK-NEXT:          Group1;
-    // CHECK-NEXT:          if c1.in with Group2 {
-    // CHECK-NEXT:            Group2;
+    // CHECK-NEXT:      par {
+    // CHECK-NEXT:        Group1;
+    // CHECK-NEXT:        Group2;
+    // CHECK-NEXT:      }
+    // CHECK-NEXT:      seq {
+    // CHECK-NEXT:        Group1;
+    // CHECK-NEXT:        while c1.in with Group2 {
+    // CHECK-NEXT:          seq {
+    // CHECK-NEXT:            Group1;
+    // CHECK-NEXT:            Group1;
+    // CHECK-NEXT:            if c1.in with Group2 {
+    // CHECK-NEXT:              Group2;
+    // CHECK-NEXT:            }
     // CHECK-NEXT:          }
     // CHECK-NEXT:        }
     // CHECK-NEXT:      }
     // CHECK-NEXT:    }
     // CHECK-NEXT:  }
     calyx.control {
-      calyx.par {
-        calyx.enable @Group1
-        calyx.enable @Group2
-      }
       calyx.seq {
-        calyx.enable @Group1
-        calyx.while %c1.in with @Group2 {
-          calyx.seq {
-            calyx.enable @Group1
-            calyx.enable @Group1
-            calyx.if %c1.in with @Group2 {
-              calyx.enable @Group2
+        calyx.par {
+          calyx.enable @Group1
+          calyx.enable @Group2
+        }
+        calyx.seq {
+          calyx.enable @Group1
+          calyx.while %c1.in with @Group2 {
+            calyx.seq {
+              calyx.enable @Group1
+              calyx.enable @Group1
+              calyx.if %c1.in with @Group2 {
+                calyx.enable @Group2
+              }
             }
           }
         }


### PR DESCRIPTION
Before, there was an early short-circuit to ensure that if the Value has no defining operation, we would not `TypeSwitch` on it. A block argument will not have a defining operation. This led to the problem in #1724; since `%done` is a block argument of the ComponentOp, we just short-circuited. This pull request now checks to see if the value is a BlockArgument, and emits the respective port.

Closes #1724. Also updates the assignment verification to use @mortbopet's new interface functions.