### PR TITLE
[Calyx] Verify that multiple control regions are nested in a sequential or parallel operation.

### DIFF
--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -106,7 +106,6 @@ static LogicalResult verifyControlBody(Operation *op) {
 
     // Verify that multiple control flow operations are nested inside a single
     // control operator. See: https://github.com/llvm/circt/issues/1723
-    // for more details.
     size_t numControlFlowRegions =
         llvm::count_if(opsIt, [](auto &&op) { return hasControlRegion(&op); });
     if (numControlFlowRegions > 1)

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -65,36 +65,40 @@ calyx.program {
       calyx.assign %c0.go = %c1.out : i1
     }
     // CHECK-LABEL: control {
-    // CHECK-NEXT:    par {
-    // CHECK-NEXT:      Group1;
-    // CHECK-NEXT:      Group2;
-    // CHECK-NEXT:    }
     // CHECK-NEXT:    seq {
-    // CHECK-NEXT:      Group1;
-    // CHECK-NEXT:      while c1.in with Group2 {
-    // CHECK-NEXT:        seq {
-    // CHECK-NEXT:          Group1;
-    // CHECK-NEXT:          Group1;
-    // CHECK-NEXT:          if c1.in with Group2 {
-    // CHECK-NEXT:            Group2;
+    // CHECK-NEXT:      par {
+    // CHECK-NEXT:        Group1;
+    // CHECK-NEXT:        Group2;
+    // CHECK-NEXT:      }
+    // CHECK-NEXT:      seq {
+    // CHECK-NEXT:        Group1;
+    // CHECK-NEXT:        while c1.in with Group2 {
+    // CHECK-NEXT:          seq {
+    // CHECK-NEXT:            Group1;
+    // CHECK-NEXT:            Group1;
+    // CHECK-NEXT:            if c1.in with Group2 {
+    // CHECK-NEXT:              Group2;
+    // CHECK-NEXT:            }
     // CHECK-NEXT:          }
     // CHECK-NEXT:        }
     // CHECK-NEXT:      }
     // CHECK-NEXT:    }
     // CHECK-NEXT:  }
     calyx.control {
-      calyx.par {
-        calyx.enable @Group1
-        calyx.enable @Group2
-      }
       calyx.seq {
-        calyx.enable @Group1
-        calyx.while %c1.in with @Group2 {
-          calyx.seq {
-            calyx.enable @Group1
-            calyx.enable @Group1
-            calyx.if %c1.in with @Group2 {
-              calyx.enable @Group2
+        calyx.par {
+          calyx.enable @Group1
+          calyx.enable @Group2
+        }
+        calyx.seq {
+          calyx.enable @Group1
+          calyx.while %c1.in with @Group2 {
+            calyx.seq {
+              calyx.enable @Group1
+              calyx.enable @Group1
+              calyx.if %c1.in with @Group2 {
+                calyx.enable @Group2
+              }
             }
           }
         }

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -98,11 +98,6 @@ calyx.program {
 // -----
 
 calyx.program {
-  calyx.component @B(%go: i1, %clk: i1, %reset: i1) -> (%done: i1) {
-    %c1_1 = hw.constant 1 : i1
-    calyx.wires { calyx.assign %done = %c1_1 : i1 }
-    calyx.control {}
-  }
   calyx.component @main(%go: i1, %clk: i1, %reset: i1) -> (%done: i1) {
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
@@ -380,5 +375,21 @@ calyx.program {
       calyx.assign %r.done = %go : i1
     }
     calyx.control {}
+  }
+}
+
+// -----
+
+calyx.program {
+  calyx.component @main(%go: i1, %clk: i1, %reset: i1) -> (%done: i1) {
+    %c1_1 = hw.constant 1 : i1
+    calyx.wires {
+      calyx.group @A { calyx.group_done %c1_1 : i1 }
+    }
+    // expected-error @+1 {{'calyx.control' op has an invalid control sequence. Multiple control flow operations must all be nested in a single calyx.seq or calyx.par}}
+    calyx.control {
+      calyx.seq { calyx.enable @A }
+      calyx.seq { calyx.enable @A }
+    }
   }
 }

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -58,6 +58,7 @@ calyx.program {
     }
     calyx.control {
       // CHECK:      calyx.seq {
+      // CHECK-NEXT: calyx.seq {
       // CHECK-NEXT: calyx.enable @Group1
       // CHECK-NEXT: calyx.enable @Group2
       // CHECK-NEXT: calyx.seq {
@@ -76,27 +77,29 @@ calyx.program {
       // CHECK-NEXT: calyx.enable @Group1
       // CHECK-NEXT: calyx.enable @Group2
       calyx.seq {
-        calyx.enable @Group1
-        calyx.enable @Group2
         calyx.seq {
-          calyx.if %c2.out with @Group2 {
-            calyx.enable @Group1
-          } else {
-            calyx.enable @Group2
-          }
-          calyx.if %c2.out with @Group2 {
-            calyx.enable @Group1
-          }
-          calyx.while %c2.out with @Group2 {
-            calyx.while %c2.out with @Group2 {
+          calyx.enable @Group1
+          calyx.enable @Group2
+          calyx.seq {
+            calyx.if %c2.out with @Group2 {
               calyx.enable @Group1
+            } else {
+              calyx.enable @Group2
+            }
+            calyx.if %c2.out with @Group2 {
+              calyx.enable @Group1
+            }
+            calyx.while %c2.out with @Group2 {
+              calyx.while %c2.out with @Group2 {
+                calyx.enable @Group1
+              }
             }
           }
         }
-      }
-      calyx.par {
-        calyx.enable @Group1
-        calyx.enable @Group2
+        calyx.par {
+          calyx.enable @Group1
+          calyx.enable @Group2
+        }
       }
     }
   }


### PR DESCRIPTION
If there are multiple control flow operations in a single control region, they should be nested inside a `calyx.seq` or `calyx.par`. This closes #1723. 