### PR TITLE
[FIRRTL] Add dedicated PortDirectionsAttr

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAttributes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAttributes.h
@@ -13,11 +13,8 @@
 #ifndef CIRCT_DIALECT_FIRRTL_FIRRTLATTRIBUTES_H
 #define CIRCT_DIALECT_FIRRTL_FIRRTLATTRIBUTES_H
 
-#include "circt/Dialect/FIRRTL/FIRRTLDialect.h"
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
-#include "circt/Support/LLVM.h"
 #include "llvm/ADT/BitVector.h"
-#include "llvm/ADT/iterator.h"
 
 namespace circt {
 namespace firrtl {
@@ -27,12 +24,10 @@ namespace firrtl {
 //===----------------------------------------------------------------------===//
 
 /// This represents the direction of a single port.
-enum class Direction { Input = 0, Output };
+enum class Direction { In, Out };
 
-inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
-                                     const Direction &dir) {
-  return os << (dir == Direction::Input ? "in" : "out");
-}
+/// Prints the Direction to the stream as either "in" or "out".
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Direction &dir);
 
 /// This represents the directions of ports in a module.  This is a simple type
 /// safe wrapper around a BitVector.
@@ -74,10 +69,7 @@ public:
   }
 
   /// Get the direction of a specifc port.
-  Direction at(unsigned index) const {
-    unsigned val = directions[index];
-    return static_cast<Direction>(val);
-  }
+  Direction at(unsigned index) const { return Direction(directions[index]); }
 
   /// Get the direction of a specifc port.
   Direction operator[](unsigned index) const { return at(index); }
@@ -109,7 +101,7 @@ public:
   }
 
 private:
-  BitVector directions;
+  llvm::BitVector directions;
 };
 
 inline llvm::hash_code hash_value(const PortDirections &portDirections) {

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "circt/Dialect/FIRRTL/FIRRTLAttributes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
 
 #include "mlir/IR/BuiltinTypes.h"
@@ -20,32 +21,6 @@ namespace circt {
 namespace firrtl {
 
 class FIRRTLType;
-
-enum class Direction { Input = 0, Output };
-
-template <typename T>
-T &operator<<(T &os, const Direction &dir) {
-  return os << (dir == Direction::Input ? "input" : "output");
-}
-
-namespace direction {
-
-/// The key in a module's attribute dictionary used to find the direction.
-static const char *const attrKey = "portDirections";
-
-/// Return an output direction if \p isOutput is true, otherwise return an
-/// input direction.
-inline Direction get(bool isOutput) { return (Direction)isOutput; }
-
-/// Return a \p IntegerAttr containing the packed representation of an array
-/// of directions.
-IntegerAttr packAttribute(ArrayRef<Direction> a, MLIRContext *b);
-
-/// Turn a packed representation of port attributes into a vector that can
-/// be worked with.
-SmallVector<Direction> unpackAttribute(Operation *module);
-
-} // namespace direction
 
 /// This holds the name and type that describes the module's ports.
 struct ModulePortInfo {

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -37,7 +37,7 @@ struct ModulePortInfo {
   bool isOutput() {
     auto flags = type.getRecursiveTypeProperties();
     return flags.isPassive && !flags.containsAnalog &&
-           direction == Direction::Output;
+           direction == Direction::Out;
   }
 
   /// Return true if this is a simple input-only port.  If you want the
@@ -45,7 +45,7 @@ struct ModulePortInfo {
   bool isInput() {
     auto flags = type.getRecursiveTypeProperties();
     return flags.isPassive && !flags.containsAnalog &&
-           direction == Direction::Input;
+           direction == Direction::In;
   }
 
   /// Return true if this is an inout port.  This will be true if the port

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -44,17 +44,29 @@ def FModuleLike : OpInterface<"FModuleLike"> {
     InterfaceMethod<"Get infromation about all ports",
     "SmallVector<ModulePortInfo>", "getPorts">,
 
-    InterfaceMethod<"Get the module port directions",
-    "IntegerAttr", "getPortDirections", (ins), [{}],
+    InterfaceMethod<"Get the module port directions attribute",
+    "PortDirectionsAttr", "getPortDirectionsAttr", (ins), [{}],
     /*methodBody=*/[{ 
-      return $_op->template getAttrOfType<IntegerAttr>(direction::attrKey); 
+      return $_op->template getAttrOfType<PortDirectionsAttr>(
+          FModuleLike::getPortDirectionsAttrName()); 
+    }]>,
+
+    InterfaceMethod<"Get the module port directions",
+    "PortDirections", "getPortDirections", (ins), [{}],
+    /*methodBody=*/[{ 
+      return getPortDirectionsAttr().getValue();
     }]>,
 
     InterfaceMethod<"Get a module port direction",
     "Direction", "getPortDirection", (ins "size_t":$portIndex), [{}],
     /*methodBody=*/[{
-      return direction::get($_op.getPortDirections().getValue()[portIndex]); 
+      // Using the attribute avoids copying the underlying bitvector.
+      return getPortDirectionsAttr()[portIndex];
     }]>
-
   ];
+
+  let extraClassDeclaration = [{
+    /// Get the name of the attribute used to store the port directions.
+    static StringRef getPortDirectionsAttrName();
+  }];
 }

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -191,6 +191,36 @@ def PortAnnotationsAttr : ArrayAttrBase<
   let constBuilderCall = "$_builder.getArrayAttr($0)";
 }
 
+def PortDirectionsAttr : AttrDef<FIRRTLDialect, "PortDirections"> {
+  let summary = "An array of port directions";
+  let description = [{
+    Syntax:
+
+    ```
+    direction  ::= 'in' | 'out'
+    directions ::= 'firrtl.directions' '<' (direction (',' direction)*)? '>'
+    ```
+
+    This represents the directions of a list of ports.  This uses a packed
+    bitvector under the hood to store the information.
+
+    Examples:
+
+    ```mlir
+    firrtl.directions<in, out, in>
+    ```
+  }];
+  let mnemonic = "directions";
+  let parameters = (ins "PortDirections":$value);
+  let storageType = "PortDirectionsAttr";
+  let returnType = "PortDirections";
+  let convertFromStorage = "$_self.getValue()";
+  let cppNamespace = "circt::firrtl";
+  let extraClassDeclaration = [{
+    /// Get the direction of a port by index.
+    Direction operator[](unsigned index);
+  }];
+}
 
 def InvalidValueAttr
   : AttrDef<FIRRTLDialect, "InvalidValue", [], "::mlir::Attribute"> {

--- a/include/circt/Support/LLVM.h
+++ b/include/circt/Support/LLVM.h
@@ -71,6 +71,7 @@ using mlir::TypeSwitch;
 // Forward declarations of LLVM classes to be imported in to the circt
 // namespace.
 namespace llvm {
+class BitVector;
 template <typename KeyT, typename ValueT, unsigned InlineBuckets,
           typename KeyInfoT, typename BucketT>
 class SmallDenseMap;
@@ -78,6 +79,7 @@ class SmallDenseMap;
 
 // Import things we want into our namespace.
 namespace circt {
+using llvm::BitVector;
 using llvm::SmallDenseMap;
 } // namespace circt
 

--- a/include/circt/Support/LLVM.h
+++ b/include/circt/Support/LLVM.h
@@ -71,7 +71,6 @@ using mlir::TypeSwitch;
 // Forward declarations of LLVM classes to be imported in to the circt
 // namespace.
 namespace llvm {
-class BitVector;
 template <typename KeyT, typename ValueT, unsigned InlineBuckets,
           typename KeyInfoT, typename BucketT>
 class SmallDenseMap;
@@ -79,7 +78,6 @@ class SmallDenseMap;
 
 // Import things we want into our namespace.
 namespace circt {
-using llvm::BitVector;
 using llvm::SmallDenseMap;
 } // namespace circt
 

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -400,7 +400,7 @@ static FModuleOp createTopModuleOp(handshake::FuncOp funcOp, unsigned numClocks,
       funcOp.emitError("Unsupported data type. Supported data types: integer "
                        "(signed, unsigned, signless), index, none.");
 
-    ports.push_back({portName, bundlePortType, Direction::Input, arg.getLoc()});
+    ports.push_back({portName, bundlePortType, Direction::In, arg.getLoc()});
     ++argIndex;
   }
 
@@ -415,26 +415,24 @@ static FModuleOp createTopModuleOp(handshake::FuncOp funcOp, unsigned numClocks,
       funcOp.emitError("Unsupported data type. Supported data types: integer "
                        "(signed, unsigned, signless), index, none.");
 
-    ports.push_back({portName, bundlePortType, Direction::Output, funcLoc});
+    ports.push_back({portName, bundlePortType, Direction::Out, funcLoc});
     ++argIndex;
   }
 
   // Add clock and reset signals.
   if (numClocks == 1) {
     ports.push_back({rewriter.getStringAttr("clock"),
-                     rewriter.getType<ClockType>(), Direction::Input, funcLoc});
+                     rewriter.getType<ClockType>(), Direction::In, funcLoc});
     ports.push_back({rewriter.getStringAttr("reset"),
-                     rewriter.getType<UIntType>(1), Direction::Input, funcLoc});
+                     rewriter.getType<UIntType>(1), Direction::In, funcLoc});
   } else if (numClocks > 1) {
     for (unsigned i = 0; i < numClocks; ++i) {
       auto clockName = "clock" + std::to_string(i);
       auto resetName = "reset" + std::to_string(i);
       ports.push_back({rewriter.getStringAttr(clockName),
-                       rewriter.getType<ClockType>(), Direction::Input,
-                       funcLoc});
+                       rewriter.getType<ClockType>(), Direction::In, funcLoc});
       ports.push_back({rewriter.getStringAttr(resetName),
-                       rewriter.getType<UIntType>(1), Direction::Input,
-                       funcLoc});
+                       rewriter.getType<UIntType>(1), Direction::In, funcLoc});
     }
   }
 
@@ -503,7 +501,7 @@ static FModuleOp createSubModuleOp(FModuleOp topModuleOp, Operation *oldOp,
       oldOp->emitError("Unsupported data type. Supported data types: integer "
                        "(signed, unsigned, signless), index, none.");
 
-    ports.push_back({portName, bundlePortType, Direction::Input, loc});
+    ports.push_back({portName, bundlePortType, Direction::In, loc});
     ++argIndex;
   }
 
@@ -516,16 +514,16 @@ static FModuleOp createSubModuleOp(FModuleOp topModuleOp, Operation *oldOp,
       oldOp->emitError("Unsupported data type. Supported data types: integer "
                        "(signed, unsigned, signless), index, none.");
 
-    ports.push_back({portName, bundlePortType, Direction::Output, loc});
+    ports.push_back({portName, bundlePortType, Direction::Out, loc});
     ++argIndex;
   }
 
   // Add clock and reset signals.
   if (hasClock) {
     ports.push_back({rewriter.getStringAttr("clock"),
-                     rewriter.getType<ClockType>(), Direction::Input, loc});
+                     rewriter.getType<ClockType>(), Direction::In, loc});
     ports.push_back({rewriter.getStringAttr("reset"),
-                     rewriter.getType<UIntType>(1), Direction::Input, loc});
+                     rewriter.getType<UIntType>(1), Direction::In, loc});
   }
 
   return rewriter.create<FModuleOp>(

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -277,7 +277,7 @@ void Emitter::emitModulePorts(ArrayRef<ModulePortInfo> ports,
                               Block::BlockArgListType arguments) {
   for (unsigned i = 0, e = ports.size(); i < e; ++i) {
     const auto &port = ports[i];
-    indent() << (port.direction == Direction::Input ? "input " : "output ");
+    indent() << (port.direction == Direction::In ? "input " : "output ");
     if (!arguments.empty())
       addValueName(arguments[i], port.name);
     os << port.name.getValue() << " : ";

--- a/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
@@ -23,8 +23,13 @@ using namespace firrtl;
 // PortDirectionsAttr
 //===----------------------------------------------------------------------===//
 
+llvm::raw_ostream &circt::firrtl::operator<<(llvm::raw_ostream &os,
+                                             const Direction &dir) {
+  return os << (dir == Direction::In ? "in" : "out");
+}
+
 Direction PortDirectionsAttr::operator[](unsigned index) {
-  // This function exists to avoids copying the underlying array to query a bit.
+  // This function exists to avoid copying the underlying array to query a bit.
   return getImpl()->value[index];
 }
 
@@ -35,9 +40,9 @@ Attribute PortDirectionsAttr::parse(MLIRContext *ctxt, DialectAsmParser &p,
   PortDirections directions;
   while (true) {
     if (!p.parseOptionalKeyword("in"))
-      directions.push_back(Direction::Input);
+      directions.push_back(Direction::In);
     else if (!p.parseKeyword("out", "Expected 'in' or 'out'"))
-      directions.push_back(Direction::Output);
+      directions.push_back(Direction::Out);
     else
       return Attribute();
     // If there is no comma, break out of the loop.
@@ -52,7 +57,7 @@ Attribute PortDirectionsAttr::parse(MLIRContext *ctxt, DialectAsmParser &p,
 void PortDirectionsAttr::print(DialectAsmPrinter &p) const {
   p << "directions<";
   llvm::interleaveComma(getValue(), p, [&](auto direction) {
-    p << (direction == Direction::Input ? "in" : "out");
+    p << (direction == Direction::In ? "in" : "out");
   });
   p << '>';
 }

--- a/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
@@ -19,3 +19,12 @@ using namespace llvm;
 using namespace circt::firrtl;
 
 #include "circt/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp.inc"
+
+//===----------------------------------------------------------------------===//
+// FModuleLikeInterface
+//===----------------------------------------------------------------------===//
+
+/// The key in a module's attribute dictionary used to find the direction.
+static const char *const attrKey = "portDirections";
+
+StringRef FModuleLike::getPortDirectionsAttrName() { return attrKey; }

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -103,7 +103,7 @@ Flow firrtl::foldFlow(Value val, Flow accumulatedFlow) {
   if (auto blockArg = val.dyn_cast<BlockArgument>()) {
     auto module = cast<FModuleLike>(val.getParentBlock()->getParentOp());
     auto direction = module.getPortDirection(blockArg.getArgNumber());
-    if (direction == Direction::Output)
+    if (direction == Direction::Out)
       return swap();
     return accumulatedFlow;
   }
@@ -124,7 +124,7 @@ Flow firrtl::foldFlow(Value val, Flow accumulatedFlow) {
         for (auto arg : llvm::enumerate(inst.getResults()))
           if (arg.value() == val) {
             if (inst.getReferencedModule().getPortDirection(arg.index()) ==
-                Direction::Output)
+                Direction::Out)
               return accumulatedFlow;
             else
               return swap();
@@ -598,8 +598,8 @@ static ParseResult parseFunctionArgumentList2(
       if (argNames.empty() && !argTypes.empty())
         return parser.emitError(loc, "expected type instead of SSA identifier");
       argNames.push_back(argument);
-      argDirections.push_back(direction == "out" ? Direction::Output
-                                                 : Direction::Input);
+      argDirections.push_back(direction == "out" ? Direction::Out
+                                                 : Direction::In);
       if (parser.parseColonType(argumentType))
         return failure();
     } else if (allowVariadic && succeeded(parser.parseOptionalEllipsis())) {

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3195,7 +3195,8 @@ FIRCircuitParser::parsePortList(SmallVectorImpl<ModulePortInfo> &resultPorts,
     // output.thing <= input  ; identifier expression
     auto backtrackState = getLexer().getCursor();
 
-    bool isOutput = getToken().is(FIRToken::kw_output);
+    auto portDirection = getToken().is(FIRToken::kw_output) ? Direction::Output
+                                                            : Direction::Input;
     consumeToken();
 
     // If we have something that isn't a keyword then this must be an
@@ -3225,7 +3226,7 @@ FIRCircuitParser::parsePortList(SmallVectorImpl<ModulePortInfo> &resultPorts,
                        getConstants().targetSet, type));
 
     resultPorts.push_back(
-        {name, type, direction::get(isOutput), info.getLoc(), annotations});
+        {name, type, portDirection, info.getLoc(), annotations});
     resultPortLocs.push_back(info.getFIRLoc());
   }
 

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3195,8 +3195,8 @@ FIRCircuitParser::parsePortList(SmallVectorImpl<ModulePortInfo> &resultPorts,
     // output.thing <= input  ; identifier expression
     auto backtrackState = getLexer().getCursor();
 
-    auto portDirection = getToken().is(FIRToken::kw_output) ? Direction::Output
-                                                            : Direction::Input;
+    auto portDirection =
+        getToken().is(FIRToken::kw_output) ? Direction::Out : Direction::In;
     consumeToken();
 
     // If we have something that isn't a keyword then this must be an

--- a/lib/Dialect/FIRRTL/Transforms/BlackBoxMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackBoxMemory.cpp
@@ -122,9 +122,9 @@ getBlackBoxPortsForMemOp(MemOp op, ArrayRef<MemOp::NamedPort> memPorts,
     for (auto bundleElement : type.cast<BundleType>().getElements()) {
       auto name = (prefix + bundleElement.name.getValue()).str();
       auto type = bundleElement.type;
-      auto direction = Direction::Input;
+      auto direction = Direction::In;
       if (bundleElement.isFlip)
-        direction = Direction::Output;
+        direction = Direction::Out;
       extPorts.push_back(
           {builder.getStringAttr(name), type, direction, op.getLoc()});
     }
@@ -195,7 +195,7 @@ createWrapperModule(MemOp op, ArrayRef<MemOp::NamedPort> memPorts,
   for (size_t i = 0, e = memPorts.size(); i != e; ++i) {
     auto name = op.getPortName(i);
     auto type = op.getPortType(i);
-    modPorts.push_back({name, type, Direction::Input, op.getLoc()});
+    modPorts.push_back({name, type, Direction::In, op.getLoc()});
   }
   auto moduleOp = builder.create<FModuleOp>(
       op.getLoc(), builder.getStringAttr(memName), modPorts);

--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -170,7 +170,7 @@ public:
     // coverage.
     auto ref = op.getReferencedModule();
     for (auto result : llvm::enumerate(op.results()))
-      if (ref.getPortDirection(result.index()) == Direction::Output)
+      if (ref.getPortDirection(result.index()) == Direction::Out)
         declareSinks(result.value(), Flow::Source);
       else
         declareSinks(result.value(), Flow::Sink);
@@ -422,7 +422,7 @@ private:
 mlir::FailureOr<bool> ModuleVisitor::run(FModuleOp module) {
   // Track any results (flipped arguments) of the module for init coverage.
   for (auto it : llvm::enumerate(module.getArguments())) {
-    auto flow = module.getPortDirection(it.index()) == Direction::Input
+    auto flow = module.getPortDirection(it.index()) == Direction::In
                     ? Flow::Source
                     : Flow::Sink;
     declareSinks(it.value(), flow);

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -442,7 +442,7 @@ void IMConstPropPass::markInstanceOp(InstanceOp instance) {
          ++resultNo) {
       auto portVal = instance.getResult(resultNo);
       // If this is an input to the extmodule, we can ignore it.
-      if (extModule.getPortDirection(resultNo) == Direction::Input)
+      if (extModule.getPortDirection(resultNo) == Direction::In)
         continue;
 
       // Otherwise this is a result from it or an inout, mark it as overdefined.
@@ -462,7 +462,7 @@ void IMConstPropPass::markInstanceOp(InstanceOp instance) {
     auto instancePortVal = instance.getResult(resultNo);
     // If this is an input to the instance, it will
     // get handled when any connects to it are processed.
-    if (fModule.getPortDirection(resultNo) == Direction::Input)
+    if (fModule.getPortDirection(resultNo) == Direction::In)
       continue;
     // We only support simple values so far.
     if (!instancePortVal.getType().cast<FIRRTLType>().isGround()) {

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -647,9 +647,9 @@ void InferResetsPass::traceResets(InstanceOp inst) {
   LLVM_DEBUG(llvm::dbgs() << "Visiting instance " << inst.name() << "\n");
 
   // Establish a connection between the instance ports and module ports.
-  auto dirs = module.getPortDirections();
+  auto directions = module.getPortDirections();
   for (auto it : llvm::enumerate(inst.getResults())) {
-    auto dir = direction::get(dirs.getValue()[it.index()]);
+    auto dir = directions[it.index()];
     Value dstPort = module.getArgument(it.index());
     Value srcPort = it.value();
     if (dir == Direction::Output)

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -652,7 +652,7 @@ void InferResetsPass::traceResets(InstanceOp inst) {
     auto dir = directions[it.index()];
     Value dstPort = module.getArgument(it.index());
     Value srcPort = it.value();
-    if (dir == Direction::Output)
+    if (dir == Direction::Out)
       std::swap(dstPort, srcPort);
     traceResets(dstPort, srcPort, it.value().getLoc());
   }
@@ -1364,8 +1364,8 @@ LogicalResult InferResetsPass::implementAsyncReset(FModuleOp module,
   Value actualReset = domain.existingValue;
   if (domain.newPortName) {
     ModulePortInfo portInfo{domain.newPortName,
-                            AsyncResetType::get(&getContext()),
-                            Direction::Input, domain.reset.getLoc()};
+                            AsyncResetType::get(&getContext()), Direction::In,
+                            domain.reset.getLoc()};
     module.insertPorts({{0, portInfo}});
     actualReset = module.getArgument(0);
     LLVM_DEBUG(llvm::dbgs()

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -706,13 +706,14 @@ void TypeLoweringVisitor::visitDecl(FExtModuleOp extModule) {
   for (auto attr : extModule->getAttrDictionary())
     // Drop old "portNames", directions, and argument attributes.  These are
     // handled differently below.
-    if (attr.first != "portNames" && attr.first != direction::attrKey &&
+    if (attr.first != "portNames" &&
+        attr.first != FModuleLike::getPortDirectionsAttrName() &&
         attr.first != "portAnnotations" &&
         attr.first != mlir::function_like_impl::getArgDictAttrName())
       newModuleAttrs.push_back(attr);
 
   SmallVector<Attribute> newArgNames;
-  SmallVector<Direction> newArgDirections;
+  PortDirections newArgDirections;
   SmallVector<Attribute, 8> newArgAttrs;
   SmallVector<Attribute, 8> newArgAnnotations;
   SmallVector<Type, 8> inputTypes;
@@ -726,9 +727,9 @@ void TypeLoweringVisitor::visitDecl(FExtModuleOp extModule) {
   }
   newModuleAttrs.push_back(NamedAttribute(Identifier::get("portNames", context),
                                           builder.getArrayAttr(newArgNames)));
-  newModuleAttrs.push_back(
-      NamedAttribute(Identifier::get(direction::attrKey, context),
-                     direction::packAttribute(newArgDirections, context)));
+  newModuleAttrs.push_back(NamedAttribute(
+      Identifier::get(FModuleLike::getPortDirectionsAttrName(), context),
+      PortDirectionsAttr::get(context, newArgDirections)));
   newModuleAttrs.push_back(
       NamedAttribute(Identifier::get("portAnnotations", context),
                      builder.getArrayAttr(newArgAnnotations)));
@@ -785,13 +786,14 @@ void TypeLoweringVisitor::visitDecl(FModuleOp module) {
   for (auto attr : module->getAttrDictionary())
     // Drop old "portNames", directions, and argument attributes.  These are
     // handled differently below.
-    if (attr.first != "portNames" && attr.first != direction::attrKey &&
+    if (attr.first != "portNames" &&
+        attr.first != FModuleLike::getPortDirectionsAttrName() &&
         attr.first != "portAnnotations" &&
         attr.first != mlir::function_like_impl::getArgDictAttrName())
       newModuleAttrs.push_back(attr);
 
   SmallVector<Attribute> newArgNames;
-  SmallVector<Direction> newArgDirections;
+  PortDirections newArgDirections;
   SmallVector<Attribute, 8> newArgAttrs;
   SmallVector<Attribute, 8> newArgAnnotations;
   for (auto &port : newArgs) {
@@ -802,9 +804,9 @@ void TypeLoweringVisitor::visitDecl(FModuleOp module) {
   }
   newModuleAttrs.push_back(NamedAttribute(Identifier::get("portNames", context),
                                           builder->getArrayAttr(newArgNames)));
-  newModuleAttrs.push_back(
-      NamedAttribute(Identifier::get(direction::attrKey, context),
-                     direction::packAttribute(newArgDirections, context)));
+  newModuleAttrs.push_back(NamedAttribute(
+      Identifier::get(FModuleLike::getPortDirectionsAttrName(), context),
+      PortDirectionsAttr::get(context, newArgDirections)));
   newModuleAttrs.push_back(
       NamedAttribute(Identifier::get("portAnnotations", context),
                      builder->getArrayAttr(newArgAnnotations)));

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -129,6 +129,10 @@ firrtl.module @TestInvalidAttr() {
   }
 }
 
+// Test round-tripping the direction attribute.
+// CHECK: firrtl.directions<in, out, in>
+firrtl.module @PortDirectionsAttr() attributes {circt.test = #firrtl.directions<in, out, in>} { }
+
 // CHECK-LABEL: @VerbatimExpr
 firrtl.module @VerbatimExpr() {
   // CHECK: %[[TMP:.+]] = firrtl.verbatim.expr "FOO" : () -> !firrtl.uint<42>


### PR DESCRIPTION
This adds a dedicated attribute to represent the `in` and `out`
directions of module ports.  This is represented under the hood using an
LLVM bitvector.

This replaces using an `IntegerAttr` as a bitvector for the port directions.
`IntegerAttr` had a large limitation in that it could not represent 0 ports,
since it has a minimum bit-width of 1.  To make this work, the old
implementation relied on using the relevant Op to determine the number of
ports. 

Cleaning this up will make it easier to share the port direction
information stored in FModuleLike operations with the Instance Op.