### PR TITLE
[FIRRTL] Add port direction information to InstanceOp

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAttributes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAttributes.h
@@ -13,11 +13,8 @@
 #ifndef CIRCT_DIALECT_FIRRTL_FIRRTLATTRIBUTES_H
 #define CIRCT_DIALECT_FIRRTL_FIRRTLATTRIBUTES_H
 
-#include "circt/Dialect/FIRRTL/FIRRTLDialect.h"
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
-#include "circt/Support/LLVM.h"
 #include "llvm/ADT/BitVector.h"
-#include "llvm/ADT/iterator.h"
 
 namespace circt {
 namespace firrtl {
@@ -27,12 +24,10 @@ namespace firrtl {
 //===----------------------------------------------------------------------===//
 
 /// This represents the direction of a single port.
-enum class Direction { Input = 0, Output };
+enum class Direction { In, Out };
 
-inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
-                                     const Direction &dir) {
-  return os << (dir == Direction::Input ? "in" : "out");
-}
+/// Prints the Direction to the stream as either "in" or "out".
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Direction &dir);
 
 /// This represents the directions of ports in a module.  This is a simple type
 /// safe wrapper around a BitVector.
@@ -74,10 +69,7 @@ public:
   }
 
   /// Get the direction of a specifc port.
-  Direction at(unsigned index) const {
-    unsigned val = directions[index];
-    return static_cast<Direction>(val);
-  }
+  Direction at(unsigned index) const { return Direction(directions[index]); }
 
   /// Get the direction of a specifc port.
   Direction operator[](unsigned index) const { return at(index); }
@@ -109,7 +101,7 @@ public:
   }
 
 private:
-  BitVector directions;
+  llvm::BitVector directions;
 };
 
 inline llvm::hash_code hash_value(const PortDirections &portDirections) {

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -19,18 +19,22 @@ def InstanceOp : FIRRTLOp<"instance", [
   }];
 
   let arguments = (ins FlatSymbolRefAttr:$moduleName, StrAttr:$name,
+                       PortDirectionsAttr:$portDirections,
                        AnnotationArrayAttr:$annotations,
                        PortAnnotationsAttr:$portAnnotations,
                        BoolAttr:$lowerToBind);
   let results = (outs Variadic<FIRRTLType>:$results);
 
-  let assemblyFormat =
-    "$moduleName custom<InstanceOp>(attr-dict) (`:` type($results)^ )?";
+  let assemblyFormat = [{
+    $moduleName custom<InstanceOp>(attr-dict)
+    custom<PortList>(type($results), $portDirections)
+  }];
 
   let verifier = "return ::verifyInstanceOp(*this);";
 
   let builders = [
     OpBuilder<(ins "::mlir::TypeRange":$resultTypes,
+                   "PortDirections":$portDirections,
                    "::mlir::StringRef":$moduleName,
                    CArg<"StringRef", "{}">:$name,
                    CArg<"ArrayRef<Attribute>", "{}">:$annotations,
@@ -55,6 +59,11 @@ def InstanceOp : FIRRTLOp<"instance", [
     }
     StringRef getPortNameStr(size_t resultNo) {
       return getPortName(resultNo).getValue();
+    }
+
+    /// Get the direction of the specified port.
+    Direction getPortDirection(size_t resultNo) {
+      return portDirectionsAttr()[resultNo];
     }
 
     /// Hooks for port annotations.

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "circt/Dialect/FIRRTL/FIRRTLAttributes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
 
 #include "mlir/IR/BuiltinTypes.h"
@@ -20,32 +21,6 @@ namespace circt {
 namespace firrtl {
 
 class FIRRTLType;
-
-enum class Direction { Input = 0, Output };
-
-template <typename T>
-T &operator<<(T &os, const Direction &dir) {
-  return os << (dir == Direction::Input ? "input" : "output");
-}
-
-namespace direction {
-
-/// The key in a module's attribute dictionary used to find the direction.
-static const char *const attrKey = "portDirections";
-
-/// Return an output direction if \p isOutput is true, otherwise return an
-/// input direction.
-inline Direction get(bool isOutput) { return (Direction)isOutput; }
-
-/// Return a \p IntegerAttr containing the packed representation of an array
-/// of directions.
-IntegerAttr packAttribute(ArrayRef<Direction> a, MLIRContext *b);
-
-/// Turn a packed representation of port attributes into a vector that can
-/// be worked with.
-SmallVector<Direction> unpackAttribute(Operation *module);
-
-} // namespace direction
 
 /// This holds the name and type that describes the module's ports.
 struct ModulePortInfo {

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -37,7 +37,7 @@ struct ModulePortInfo {
   bool isOutput() {
     auto flags = type.getRecursiveTypeProperties();
     return flags.isPassive && !flags.containsAnalog &&
-           direction == Direction::Output;
+           direction == Direction::Out;
   }
 
   /// Return true if this is a simple input-only port.  If you want the
@@ -45,7 +45,7 @@ struct ModulePortInfo {
   bool isInput() {
     auto flags = type.getRecursiveTypeProperties();
     return flags.isPassive && !flags.containsAnalog &&
-           direction == Direction::Input;
+           direction == Direction::In;
   }
 
   /// Return true if this is an inout port.  This will be true if the port

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -44,17 +44,29 @@ def FModuleLike : OpInterface<"FModuleLike"> {
     InterfaceMethod<"Get infromation about all ports",
     "SmallVector<ModulePortInfo>", "getPorts">,
 
-    InterfaceMethod<"Get the module port directions",
-    "IntegerAttr", "getPortDirections", (ins), [{}],
+    InterfaceMethod<"Get the module port directions attribute",
+    "PortDirectionsAttr", "getPortDirectionsAttr", (ins), [{}],
     /*methodBody=*/[{ 
-      return $_op->template getAttrOfType<IntegerAttr>(direction::attrKey); 
+      return $_op->template getAttrOfType<PortDirectionsAttr>(
+          FModuleLike::getPortDirectionsAttrName()); 
+    }]>,
+
+    InterfaceMethod<"Get the module port directions",
+    "PortDirections", "getPortDirections", (ins), [{}],
+    /*methodBody=*/[{ 
+      return getPortDirectionsAttr().getValue();
     }]>,
 
     InterfaceMethod<"Get a module port direction",
     "Direction", "getPortDirection", (ins "size_t":$portIndex), [{}],
     /*methodBody=*/[{
-      return direction::get($_op.getPortDirections().getValue()[portIndex]); 
+      // Using the attribute avoids copying the underlying bitvector.
+      return getPortDirectionsAttr()[portIndex];
     }]>
-
   ];
+
+  let extraClassDeclaration = [{
+    /// Get the name of the attribute used to store the port directions.
+    static StringRef getPortDirectionsAttrName();
+  }];
 }

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -191,6 +191,36 @@ def PortAnnotationsAttr : ArrayAttrBase<
   let constBuilderCall = "$_builder.getArrayAttr($0)";
 }
 
+def PortDirectionsAttr : AttrDef<FIRRTLDialect, "PortDirections"> {
+  let summary = "An array of port directions";
+  let description = [{
+    Syntax:
+
+    ```
+    direction  ::= 'in' | 'out'
+    directions ::= 'firrtl.directions' '<' (direction (',' direction)*)? '>'
+    ```
+
+    This represents the directions of a list of ports.  This uses a packed
+    bitvector under the hood to store the information.
+
+    Examples:
+
+    ```mlir
+    firrtl.directions<in, out, in>
+    ```
+  }];
+  let mnemonic = "directions";
+  let parameters = (ins "PortDirections":$value);
+  let storageType = "PortDirectionsAttr";
+  let returnType = "PortDirections";
+  let convertFromStorage = "$_self.getValue()";
+  let cppNamespace = "circt::firrtl";
+  let extraClassDeclaration = [{
+    /// Get the direction of a port by index.
+    Direction operator[](unsigned index);
+  }];
+}
 
 def InvalidValueAttr
   : AttrDef<FIRRTLDialect, "InvalidValue", [], "::mlir::Attribute"> {

--- a/include/circt/Support/LLVM.h
+++ b/include/circt/Support/LLVM.h
@@ -71,6 +71,7 @@ using mlir::TypeSwitch;
 // Forward declarations of LLVM classes to be imported in to the circt
 // namespace.
 namespace llvm {
+class BitVector;
 template <typename KeyT, typename ValueT, unsigned InlineBuckets,
           typename KeyInfoT, typename BucketT>
 class SmallDenseMap;
@@ -78,6 +79,7 @@ class SmallDenseMap;
 
 // Import things we want into our namespace.
 namespace circt {
+using llvm::BitVector;
 using llvm::SmallDenseMap;
 } // namespace circt
 

--- a/include/circt/Support/LLVM.h
+++ b/include/circt/Support/LLVM.h
@@ -71,7 +71,6 @@ using mlir::TypeSwitch;
 // Forward declarations of LLVM classes to be imported in to the circt
 // namespace.
 namespace llvm {
-class BitVector;
 template <typename KeyT, typename ValueT, unsigned InlineBuckets,
           typename KeyInfoT, typename BucketT>
 class SmallDenseMap;
@@ -79,7 +78,6 @@ class SmallDenseMap;
 
 // Import things we want into our namespace.
 namespace circt {
-using llvm::BitVector;
 using llvm::SmallDenseMap;
 } // namespace circt
 

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -2003,7 +2003,8 @@ static void createInstOp(Operation *oldOp, FModuleOp subModuleOp,
 
   // Create a instance operation.
   auto instanceOp = rewriter.create<firrtl::InstanceOp>(
-      oldOp->getLoc(), resultTypes, subModuleOp.getName());
+      oldOp->getLoc(), resultTypes, subModuleOp.getPortDirections(),
+      subModuleOp.getName());
 
   // Connect the new created instance with its predecessors and successors in
   // the top-module.

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -400,7 +400,7 @@ static FModuleOp createTopModuleOp(handshake::FuncOp funcOp, unsigned numClocks,
       funcOp.emitError("Unsupported data type. Supported data types: integer "
                        "(signed, unsigned, signless), index, none.");
 
-    ports.push_back({portName, bundlePortType, Direction::Input, arg.getLoc()});
+    ports.push_back({portName, bundlePortType, Direction::In, arg.getLoc()});
     ++argIndex;
   }
 
@@ -415,26 +415,24 @@ static FModuleOp createTopModuleOp(handshake::FuncOp funcOp, unsigned numClocks,
       funcOp.emitError("Unsupported data type. Supported data types: integer "
                        "(signed, unsigned, signless), index, none.");
 
-    ports.push_back({portName, bundlePortType, Direction::Output, funcLoc});
+    ports.push_back({portName, bundlePortType, Direction::Out, funcLoc});
     ++argIndex;
   }
 
   // Add clock and reset signals.
   if (numClocks == 1) {
     ports.push_back({rewriter.getStringAttr("clock"),
-                     rewriter.getType<ClockType>(), Direction::Input, funcLoc});
+                     rewriter.getType<ClockType>(), Direction::In, funcLoc});
     ports.push_back({rewriter.getStringAttr("reset"),
-                     rewriter.getType<UIntType>(1), Direction::Input, funcLoc});
+                     rewriter.getType<UIntType>(1), Direction::In, funcLoc});
   } else if (numClocks > 1) {
     for (unsigned i = 0; i < numClocks; ++i) {
       auto clockName = "clock" + std::to_string(i);
       auto resetName = "reset" + std::to_string(i);
       ports.push_back({rewriter.getStringAttr(clockName),
-                       rewriter.getType<ClockType>(), Direction::Input,
-                       funcLoc});
+                       rewriter.getType<ClockType>(), Direction::In, funcLoc});
       ports.push_back({rewriter.getStringAttr(resetName),
-                       rewriter.getType<UIntType>(1), Direction::Input,
-                       funcLoc});
+                       rewriter.getType<UIntType>(1), Direction::In, funcLoc});
     }
   }
 
@@ -503,7 +501,7 @@ static FModuleOp createSubModuleOp(FModuleOp topModuleOp, Operation *oldOp,
       oldOp->emitError("Unsupported data type. Supported data types: integer "
                        "(signed, unsigned, signless), index, none.");
 
-    ports.push_back({portName, bundlePortType, Direction::Input, loc});
+    ports.push_back({portName, bundlePortType, Direction::In, loc});
     ++argIndex;
   }
 
@@ -516,16 +514,16 @@ static FModuleOp createSubModuleOp(FModuleOp topModuleOp, Operation *oldOp,
       oldOp->emitError("Unsupported data type. Supported data types: integer "
                        "(signed, unsigned, signless), index, none.");
 
-    ports.push_back({portName, bundlePortType, Direction::Output, loc});
+    ports.push_back({portName, bundlePortType, Direction::Out, loc});
     ++argIndex;
   }
 
   // Add clock and reset signals.
   if (hasClock) {
     ports.push_back({rewriter.getStringAttr("clock"),
-                     rewriter.getType<ClockType>(), Direction::Input, loc});
+                     rewriter.getType<ClockType>(), Direction::In, loc});
     ports.push_back({rewriter.getStringAttr("reset"),
-                     rewriter.getType<UIntType>(1), Direction::Input, loc});
+                     rewriter.getType<UIntType>(1), Direction::In, loc});
   }
 
   return rewriter.create<FModuleOp>(

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -277,7 +277,7 @@ void Emitter::emitModulePorts(ArrayRef<ModulePortInfo> ports,
                               Block::BlockArgListType arguments) {
   for (unsigned i = 0, e = ports.size(); i < e; ++i) {
     const auto &port = ports[i];
-    indent() << (port.direction == Direction::Input ? "input " : "output ");
+    indent() << (port.direction == Direction::In ? "input " : "output ");
     if (!arguments.empty())
       addValueName(arguments[i], port.name);
     os << port.name.getValue() << " : ";

--- a/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
@@ -23,8 +23,13 @@ using namespace firrtl;
 // PortDirectionsAttr
 //===----------------------------------------------------------------------===//
 
+llvm::raw_ostream &circt::firrtl::operator<<(llvm::raw_ostream &os,
+                                             const Direction &dir) {
+  return os << (dir == Direction::In ? "in" : "out");
+}
+
 Direction PortDirectionsAttr::operator[](unsigned index) {
-  // This function exists to avoids copying the underlying array to query a bit.
+  // This function exists to avoid copying the underlying array to query a bit.
   return getImpl()->value[index];
 }
 
@@ -35,9 +40,9 @@ Attribute PortDirectionsAttr::parse(MLIRContext *ctxt, DialectAsmParser &p,
   PortDirections directions;
   while (true) {
     if (!p.parseOptionalKeyword("in"))
-      directions.push_back(Direction::Input);
+      directions.push_back(Direction::In);
     else if (!p.parseKeyword("out", "Expected 'in' or 'out'"))
-      directions.push_back(Direction::Output);
+      directions.push_back(Direction::Out);
     else
       return Attribute();
     // If there is no comma, break out of the loop.
@@ -52,7 +57,7 @@ Attribute PortDirectionsAttr::parse(MLIRContext *ctxt, DialectAsmParser &p,
 void PortDirectionsAttr::print(DialectAsmPrinter &p) const {
   p << "directions<";
   llvm::interleaveComma(getValue(), p, [&](auto direction) {
-    p << (direction == Direction::Input ? "in" : "out");
+    p << (direction == Direction::In ? "in" : "out");
   });
   p << '>';
 }

--- a/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
@@ -19,3 +19,12 @@ using namespace llvm;
 using namespace circt::firrtl;
 
 #include "circt/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp.inc"
+
+//===----------------------------------------------------------------------===//
+// FModuleLikeInterface
+//===----------------------------------------------------------------------===//
+
+/// The key in a module's attribute dictionary used to find the direction.
+static const char *const attrKey = "portDirections";
+
+StringRef FModuleLike::getPortDirectionsAttrName() { return attrKey; }

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -103,7 +103,7 @@ Flow firrtl::foldFlow(Value val, Flow accumulatedFlow) {
   if (auto blockArg = val.dyn_cast<BlockArgument>()) {
     auto module = cast<FModuleLike>(val.getParentBlock()->getParentOp());
     auto direction = module.getPortDirection(blockArg.getArgNumber());
-    if (direction == Direction::Output)
+    if (direction == Direction::Out)
       return swap();
     return accumulatedFlow;
   }
@@ -124,7 +124,7 @@ Flow firrtl::foldFlow(Value val, Flow accumulatedFlow) {
         for (auto arg : llvm::enumerate(inst.getResults()))
           if (arg.value() == val) {
             if (inst.getReferencedModule().getPortDirection(arg.index()) ==
-                Direction::Output)
+                Direction::Out)
               return accumulatedFlow;
             else
               return swap();
@@ -598,8 +598,8 @@ static ParseResult parseFunctionArgumentList2(
       if (argNames.empty() && !argTypes.empty())
         return parser.emitError(loc, "expected type instead of SSA identifier");
       argNames.push_back(argument);
-      argDirections.push_back(direction == "out" ? Direction::Output
-                                                 : Direction::Input);
+      argDirections.push_back(direction == "out" ? Direction::Out
+                                                 : Direction::In);
       if (parser.parseColonType(argumentType))
         return failure();
     } else if (allowVariadic && succeeded(parser.parseOptionalEllipsis())) {

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3195,7 +3195,8 @@ FIRCircuitParser::parsePortList(SmallVectorImpl<ModulePortInfo> &resultPorts,
     // output.thing <= input  ; identifier expression
     auto backtrackState = getLexer().getCursor();
 
-    bool isOutput = getToken().is(FIRToken::kw_output);
+    auto portDirection = getToken().is(FIRToken::kw_output) ? Direction::Output
+                                                            : Direction::Input;
     consumeToken();
 
     // If we have something that isn't a keyword then this must be an
@@ -3225,7 +3226,7 @@ FIRCircuitParser::parsePortList(SmallVectorImpl<ModulePortInfo> &resultPorts,
                        getConstants().targetSet, type));
 
     resultPorts.push_back(
-        {name, type, direction::get(isOutput), info.getLoc(), annotations});
+        {name, type, portDirection, info.getLoc(), annotations});
     resultPortLocs.push_back(info.getFIRLoc());
   }
 

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3195,8 +3195,8 @@ FIRCircuitParser::parsePortList(SmallVectorImpl<ModulePortInfo> &resultPorts,
     // output.thing <= input  ; identifier expression
     auto backtrackState = getLexer().getCursor();
 
-    auto portDirection = getToken().is(FIRToken::kw_output) ? Direction::Output
-                                                            : Direction::Input;
+    auto portDirection =
+        getToken().is(FIRToken::kw_output) ? Direction::Out : Direction::In;
     consumeToken();
 
     // If we have something that isn't a keyword then this must be an

--- a/lib/Dialect/FIRRTL/Transforms/BlackBoxMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackBoxMemory.cpp
@@ -122,9 +122,9 @@ getBlackBoxPortsForMemOp(MemOp op, ArrayRef<MemOp::NamedPort> memPorts,
     for (auto bundleElement : type.cast<BundleType>().getElements()) {
       auto name = (prefix + bundleElement.name.getValue()).str();
       auto type = bundleElement.type;
-      auto direction = Direction::Input;
+      auto direction = Direction::In;
       if (bundleElement.isFlip)
-        direction = Direction::Output;
+        direction = Direction::Out;
       extPorts.push_back(
           {builder.getStringAttr(name), type, direction, op.getLoc()});
     }
@@ -195,7 +195,7 @@ createWrapperModule(MemOp op, ArrayRef<MemOp::NamedPort> memPorts,
   for (size_t i = 0, e = memPorts.size(); i != e; ++i) {
     auto name = op.getPortName(i);
     auto type = op.getPortType(i);
-    modPorts.push_back({name, type, Direction::Input, op.getLoc()});
+    modPorts.push_back({name, type, Direction::In, op.getLoc()});
   }
   auto moduleOp = builder.create<FModuleOp>(
       op.getLoc(), builder.getStringAttr(memName), modPorts);

--- a/lib/Dialect/FIRRTL/Transforms/BlackBoxMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackBoxMemory.cpp
@@ -83,12 +83,15 @@ static InstanceOp createInstance(OpBuilder builder, Location loc,
                                  ArrayRef<ModulePortInfo> modulePorts) {
   // Make a bundle of the inputs and outputs of the specified module.
   SmallVector<Type, 4> resultTypes;
+  PortDirections portDirections;
   resultTypes.reserve(modulePorts.size());
-  for (auto port : modulePorts)
+  for (auto port : modulePorts) {
     resultTypes.push_back(port.type);
+    portDirections.push_back(port.direction);
+  }
 
-  return builder.create<InstanceOp>(loc, resultTypes, moduleName,
-                                    instanceName.getValue());
+  return builder.create<InstanceOp>(loc, resultTypes, portDirections,
+                                    moduleName, instanceName.getValue());
 }
 
 /// Get the pohwist for an external module representing a blackbox memory. This

--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -170,7 +170,7 @@ public:
     // coverage.
     auto ref = op.getReferencedModule();
     for (auto result : llvm::enumerate(op.results()))
-      if (ref.getPortDirection(result.index()) == Direction::Output)
+      if (ref.getPortDirection(result.index()) == Direction::Out)
         declareSinks(result.value(), Flow::Source);
       else
         declareSinks(result.value(), Flow::Sink);
@@ -422,7 +422,7 @@ private:
 mlir::FailureOr<bool> ModuleVisitor::run(FModuleOp module) {
   // Track any results (flipped arguments) of the module for init coverage.
   for (auto it : llvm::enumerate(module.getArguments())) {
-    auto flow = module.getPortDirection(it.index()) == Direction::Input
+    auto flow = module.getPortDirection(it.index()) == Direction::In
                     ? Flow::Source
                     : Flow::Sink;
     declareSinks(it.value(), flow);

--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -168,9 +168,8 @@ public:
   void visitDecl(InstanceOp op) {
     // Track any instance inputs which need to be connected to for init
     // coverage.
-    auto ref = op.getReferencedModule();
     for (auto result : llvm::enumerate(op.results()))
-      if (ref.getPortDirection(result.index()) == Direction::Out)
+      if (op.getPortDirection(result.index()) == Direction::Out)
         declareSinks(result.value(), Flow::Source);
       else
         declareSinks(result.value(), Flow::Sink);

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -442,7 +442,7 @@ void IMConstPropPass::markInstanceOp(InstanceOp instance) {
          ++resultNo) {
       auto portVal = instance.getResult(resultNo);
       // If this is an input to the extmodule, we can ignore it.
-      if (extModule.getPortDirection(resultNo) == Direction::Input)
+      if (extModule.getPortDirection(resultNo) == Direction::In)
         continue;
 
       // Otherwise this is a result from it or an inout, mark it as overdefined.
@@ -462,7 +462,7 @@ void IMConstPropPass::markInstanceOp(InstanceOp instance) {
     auto instancePortVal = instance.getResult(resultNo);
     // If this is an input to the instance, it will
     // get handled when any connects to it are processed.
-    if (fModule.getPortDirection(resultNo) == Direction::Input)
+    if (fModule.getPortDirection(resultNo) == Direction::In)
       continue;
     // We only support simple values so far.
     if (!instancePortVal.getType().cast<FIRRTLType>().isGround()) {

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -1429,6 +1429,12 @@ void InferResetsPass::implementAsyncReset(Operation *op, FModuleOp module,
       resultTypes.append(instOp.getResultTypes().begin(),
                          instOp.getResultTypes().end());
 
+      // Determine the new port directions.
+      PortDirections directions;
+      directions.reserve(instOp.getNumResults() + 1);
+      directions.push_back(Direction::In);
+      llvm::copy(instOp.portDirections(), std::back_inserter(directions));
+
       // Create a new list of port annotations.
       SmallVector<Attribute> newPortAnnos;
       if (auto oldPortAnnos = instOp.portAnnotations()) {
@@ -1443,7 +1449,7 @@ void InferResetsPass::implementAsyncReset(Operation *op, FModuleOp module,
 
       // Create a new instance op with the reset inserted.
       auto newInstOp = builder.create<InstanceOp>(
-          resultTypes, instOp.moduleName(), instOp.name(),
+          resultTypes, directions, instOp.moduleName(), instOp.name(),
           instOp.annotations().getValue(), newPortAnnos);
       instReset = newInstOp.getResult(0);
 

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -647,9 +647,9 @@ void InferResetsPass::traceResets(InstanceOp inst) {
   LLVM_DEBUG(llvm::dbgs() << "Visiting instance " << inst.name() << "\n");
 
   // Establish a connection between the instance ports and module ports.
-  auto dirs = module.getPortDirections();
+  auto directions = module.getPortDirections();
   for (auto it : llvm::enumerate(inst.getResults())) {
-    auto dir = direction::get(dirs.getValue()[it.index()]);
+    auto dir = directions[it.index()];
     Value dstPort = module.getArgument(it.index());
     Value srcPort = it.value();
     if (dir == Direction::Output)

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -652,7 +652,7 @@ void InferResetsPass::traceResets(InstanceOp inst) {
     auto dir = directions[it.index()];
     Value dstPort = module.getArgument(it.index());
     Value srcPort = it.value();
-    if (dir == Direction::Output)
+    if (dir == Direction::Out)
       std::swap(dstPort, srcPort);
     traceResets(dstPort, srcPort, it.value().getLoc());
   }
@@ -1364,8 +1364,8 @@ LogicalResult InferResetsPass::implementAsyncReset(FModuleOp module,
   Value actualReset = domain.existingValue;
   if (domain.newPortName) {
     ModulePortInfo portInfo{domain.newPortName,
-                            AsyncResetType::get(&getContext()),
-                            Direction::Input, domain.reset.getLoc()};
+                            AsyncResetType::get(&getContext()), Direction::In,
+                            domain.reset.getLoc()};
     module.insertPorts({{0, portInfo}});
     actualReset = module.getArgument(0);
     LLVM_DEBUG(llvm::dbgs()

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -706,13 +706,14 @@ void TypeLoweringVisitor::visitDecl(FExtModuleOp extModule) {
   for (auto attr : extModule->getAttrDictionary())
     // Drop old "portNames", directions, and argument attributes.  These are
     // handled differently below.
-    if (attr.first != "portNames" && attr.first != direction::attrKey &&
+    if (attr.first != "portNames" &&
+        attr.first != FModuleLike::getPortDirectionsAttrName() &&
         attr.first != "portAnnotations" &&
         attr.first != mlir::function_like_impl::getArgDictAttrName())
       newModuleAttrs.push_back(attr);
 
   SmallVector<Attribute> newArgNames;
-  SmallVector<Direction> newArgDirections;
+  PortDirections newArgDirections;
   SmallVector<Attribute, 8> newArgAttrs;
   SmallVector<Attribute, 8> newArgAnnotations;
   SmallVector<Type, 8> inputTypes;
@@ -726,9 +727,9 @@ void TypeLoweringVisitor::visitDecl(FExtModuleOp extModule) {
   }
   newModuleAttrs.push_back(NamedAttribute(Identifier::get("portNames", context),
                                           builder.getArrayAttr(newArgNames)));
-  newModuleAttrs.push_back(
-      NamedAttribute(Identifier::get(direction::attrKey, context),
-                     direction::packAttribute(newArgDirections, context)));
+  newModuleAttrs.push_back(NamedAttribute(
+      Identifier::get(FModuleLike::getPortDirectionsAttrName(), context),
+      PortDirectionsAttr::get(context, newArgDirections)));
   newModuleAttrs.push_back(
       NamedAttribute(Identifier::get("portAnnotations", context),
                      builder.getArrayAttr(newArgAnnotations)));
@@ -785,13 +786,14 @@ void TypeLoweringVisitor::visitDecl(FModuleOp module) {
   for (auto attr : module->getAttrDictionary())
     // Drop old "portNames", directions, and argument attributes.  These are
     // handled differently below.
-    if (attr.first != "portNames" && attr.first != direction::attrKey &&
+    if (attr.first != "portNames" &&
+        attr.first != FModuleLike::getPortDirectionsAttrName() &&
         attr.first != "portAnnotations" &&
         attr.first != mlir::function_like_impl::getArgDictAttrName())
       newModuleAttrs.push_back(attr);
 
   SmallVector<Attribute> newArgNames;
-  SmallVector<Direction> newArgDirections;
+  PortDirections newArgDirections;
   SmallVector<Attribute, 8> newArgAttrs;
   SmallVector<Attribute, 8> newArgAnnotations;
   for (auto &port : newArgs) {
@@ -802,9 +804,9 @@ void TypeLoweringVisitor::visitDecl(FModuleOp module) {
   }
   newModuleAttrs.push_back(NamedAttribute(Identifier::get("portNames", context),
                                           builder->getArrayAttr(newArgNames)));
-  newModuleAttrs.push_back(
-      NamedAttribute(Identifier::get(direction::attrKey, context),
-                     direction::packAttribute(newArgDirections, context)));
+  newModuleAttrs.push_back(NamedAttribute(
+      Identifier::get(FModuleLike::getPortDirectionsAttrName(), context),
+      PortDirectionsAttr::get(context, newArgDirections)));
   newModuleAttrs.push_back(
       NamedAttribute(Identifier::get("portAnnotations", context),
                      builder->getArrayAttr(newArgAnnotations)));

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
@@ -41,7 +41,7 @@ firrtl.circuit "unprocessedAnnotations" {
     "write"], readLatency = 0 : i32, writeLatency = 1 : i32, annotations = [{class =
     "firrtl.transforms.RemainingAnnotation5"}]} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>
     // expected-warning @+1 {{unprocessed annotation:'firrtl.transforms.RemainingAnnotation6'}}
-    %5 = firrtl.instance @bar {name = "fetch", portNames=["io_cpu_flush"], annotations = [{class = "firrtl.transforms.RemainingAnnotation6"}] } : !firrtl.uint<1>
+    %5 = firrtl.instance @bar {name = "fetch", annotations = [{class = "firrtl.transforms.RemainingAnnotation6"}] } : in !firrtl.uint<1>
     %6 = firrtl.node %1 {annotations = [{class = "firrtl.transforms.RemainingAnnotation3"}]} : !firrtl.uint<1>
   }
 }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
@@ -51,8 +51,7 @@ firrtl.circuit "Simple" {
                               in %reset: !firrtl.uint<1>) {
     // CHECK-NEXT: %c0_i2 = hw.constant
     // CHECK-NEXT: %xyz.out4 = hw.instance "xyz" @Simple([[ARG1:%.+]], %u2, %s8) : (i4, i2, i8) -> i4
-    %xyz:4 = firrtl.instance @Simple {name = "xyz", portNames=["in1", "in2", "in3", "out4"]}
-     : !firrtl.uint<4>, !firrtl.uint<2>, !firrtl.sint<8>, !firrtl.uint<4>
+    %xyz:4 = firrtl.instance @Simple {name = "xyz"} : in !firrtl.uint<4>, in !firrtl.uint<2>, in !firrtl.sint<8>, out !firrtl.uint<4>
 
     // CHECK: [[ARG1]] = comb.concat %c0_i2, %u2 : (i2, i2) -> i4
     firrtl.connect %xyz#0, %u2 : !firrtl.uint<4>, !firrtl.uint<2>
@@ -68,8 +67,7 @@ firrtl.circuit "Simple" {
     // hw.instance carries the parameters, unlike at the FIRRTL layer.
 
     // CHECK: %myext.out = hw.instance "myext" @MyParameterizedExtModule(%reset)  {parameters = {DEFAULT = 0 : i64, DEPTH = 3.242000e+01 : f64, FORMAT = "xyz_timeout=%d\0A", WIDTH = 32 : i8}} : (i1) -> i8
-    %myext:2 = firrtl.instance @MyParameterizedExtModule {name = "myext", portNames=["in", "out"]}
-      : !firrtl.uint<1>, !firrtl.uint<8>
+    %myext:2 = firrtl.instance @MyParameterizedExtModule {name = "myext"} : in !firrtl.uint<1>, out !firrtl.uint<8>
 
     // CHECK: sv.fwrite "%x"(%xyz.out4) : i4
     // CHECK: sv.fwrite "Something interesting! %x"(%myext.out) : i8
@@ -145,8 +143,7 @@ firrtl.circuit "Simple" {
     // CHECK: %false = hw.constant false
 
     // CHECK-NEXT: hw.instance "myext" @MyParameterizedExtModule([[ARG:%.+]]) {parameters
-    %myext:2 = firrtl.instance @MyParameterizedExtModule {name = "myext", portNames=["in", "out"]}
-      : !firrtl.uint<1>, !firrtl.uint<8>
+    %myext:2 = firrtl.instance @MyParameterizedExtModule {name = "myext"} : in !firrtl.uint<1>, out !firrtl.uint<8>
 
     // CHECK: [[ADD:%.+]] = comb.add %0, %1
 
@@ -167,8 +164,7 @@ firrtl.circuit "Simple" {
   // CHECK-LABEL: hw.module @instance_cyclic
   firrtl.module @instance_cyclic(in %arg0: !firrtl.uint<2>, in %arg1: !firrtl.uint<2>) {
     // CHECK: %myext.out = hw.instance "myext" @MyParameterizedExtModule(%0)
-    %myext:2 = firrtl.instance @MyParameterizedExtModule {name = "myext", portNames=["in", "out"]}
-      : !firrtl.uint<1>, !firrtl.uint<8>
+    %myext:2 = firrtl.instance @MyParameterizedExtModule {name = "myext"} : in !firrtl.uint<1>, out !firrtl.uint<8>
 
     // Output of the instance is fed into the input!
     %11 = firrtl.bits %myext#1 2 to 2 : (!firrtl.uint<8>) -> !firrtl.uint<1>
@@ -207,11 +203,9 @@ firrtl.circuit "Simple" {
                                    out %oB: !firrtl.uint<0>) {
 
     // CHECK: %myinst.outa = hw.instance "myinst" @ZeroWidthPorts(%iA) : (i4) -> i4
-    %myinst:5 = firrtl.instance @ZeroWidthPorts {name = "myinst", portNames=["inA", "inB", "inC", "outa", "outb"]}
-      : !firrtl.uint<4>, !firrtl.uint<0>, !firrtl.analog<0>, !firrtl.uint<4>, !firrtl.uint<0>
+    %myinst:5 = firrtl.instance @ZeroWidthPorts {name = "myinst"} : in !firrtl.uint<4>, in !firrtl.uint<0>, in !firrtl.analog<0>, out !firrtl.uint<4>, out !firrtl.uint<0>
     // CHECK: = hw.instance "myinst" @SameNamePorts({{.+}}, {{.+}} {{.+}}) : (i4, i1, !hw.inout<i1>) -> (i4, i1)
-    %myinst_sameName:5 = firrtl.instance @SameNamePorts {name = "myinst"}
-      : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.analog<1>, !firrtl.uint<4>, !firrtl.uint<1>
+    %myinst_sameName:5 = firrtl.instance @SameNamePorts {name = "myinst"} : in !firrtl.uint<4>, in !firrtl.uint<1>, in!firrtl.analog<1>, out !firrtl.uint<4>, out !firrtl.uint<1>
 
     // Output of the instance is fed into the input!
     firrtl.connect %myinst#0, %iA : !firrtl.uint<4>, !firrtl.uint<4>
@@ -238,11 +232,11 @@ firrtl.circuit "Simple" {
   firrtl.module @foo690() {
     // CHECK: %.led_0.wire = sv.wire
     // CHECK: hw.instance "fpga" @bar690(%.led_0.wire) : (!hw.inout<i1>) -> ()
-    %result = firrtl.instance @bar690 {name = "fpga", portNames = ["led_0"]} : !firrtl.analog<1>
+    %result = firrtl.instance @bar690 {name = "fpga"} : in !firrtl.analog<1>
   }
   // CHECK-LABEL: hw.module @foo690a(%a: !hw.inout<i1>) {
   firrtl.module @foo690a(in %a: !firrtl.analog<1>) {
-    %result = firrtl.instance @bar690 {name = "fpga", portNames = ["led_0"]} : !firrtl.analog<1>
+    %result = firrtl.instance @bar690 {name = "fpga"} : in !firrtl.analog<1>
     firrtl.attach %result, %a: !firrtl.analog<1>, !firrtl.analog<1>
   }
 
@@ -253,7 +247,7 @@ firrtl.circuit "Simple" {
   // CHECK-NEXT:  hw.instance "fpga" @bar740(%.led_0.wire)
   firrtl.extmodule @bar740(in %led_0: !firrtl.analog<1>)
   firrtl.module @foo740(in %led_0: !firrtl.analog<1>) {
-    %result = firrtl.instance @bar740 {name = "fpga", portNames = ["led_0"]} : !firrtl.analog<1>
+    %result = firrtl.instance @bar740 {name = "fpga"} : in !firrtl.analog<1>
     firrtl.attach %result, %led_0 : !firrtl.analog<1>, !firrtl.analog<1>
   }
 }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -389,7 +389,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT:  [[IO:%[0-9]+]] = sv.read_inout %io_cpu_flush.wire
     %io_cpu_flush.wire = firrtl.wire {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<1>
     // CHECK-NEXT: hw.instance "fetch" @bar([[IO]])
-    %i = firrtl.instance @bar {name = "fetch", portNames=["io_cpu_flush"]} : !firrtl.uint<1>
+    %i = firrtl.instance @bar {name = "fetch"} : in !firrtl.uint<1>
     firrtl.connect %i, %io_cpu_flush.wire : !firrtl.uint<1>, !firrtl.uint<1>
 
     %hits_1_7 = firrtl.node %io_cpu_flush.wire {name = "hits_1_7", annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<1>
@@ -406,14 +406,14 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-NEXT: hw.module @bindTest()
   firrtl.module @bindTest() {
     // CHECK: hw.instance "baz" sym @[[bazSymbol]] @bar
-    %baz = firrtl.instance @bar {lowerToBind = true, name = "baz"} : !firrtl.uint<1>
+    %baz = firrtl.instance @bar {lowerToBind = true, name = "baz"} : in !firrtl.uint<1>
     // CHECK: hw.instance "qux" sym @[[quxSymbol]] @bar
     %qux = firrtl.instance @bar {lowerToBind = true, name = "qux",
       output_file = {
         directory = "outputDir",
         exclude_from_filelist = true,
         exclude_replicated_ops = true,
-        name = "bindings.sv"}} : !firrtl.uint<1>
+        name = "bindings.sv"}} : in !firrtl.uint<1>
   }
 
 

--- a/test/Conversion/HandshakeToFIRRTL/simple_addi.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/simple_addi.mlir
@@ -30,7 +30,7 @@
 // CHECK-SAME:  in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @simple_addi(%arg0: index, %arg1: index, %arg2: none, ...) -> (index, none) {
 
-  // CHECK:%inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @std_addi_2ins_1outs_ui64  {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @std_addi_2ins_1outs_ui64 {name = ""} : in !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
   // CHECK: firrtl.connect %inst_arg0, %arg0 : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
   // CHECK: firrtl.connect %inst_arg1, %arg1 : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
   %0 = addi %arg0, %arg1 : index

--- a/test/Conversion/HandshakeToFIRRTL/test_branch.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_branch.mlir
@@ -18,7 +18,7 @@
 // CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %arg2: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_branch(%arg0: index, %arg1: none, ...) -> (index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1 = firrtl.instance @handshake_branch_1ins_1outs_ui64  {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+  // CHECK: %inst_arg0, %inst_arg1 = firrtl.instance @handshake_branch_1ins_1outs_ui64 {name = ""} : in !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
   %0 = "handshake.branch"(%arg0) {control = false}: (index) -> index
   handshake.return %0, %arg1 : index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
@@ -82,7 +82,7 @@
 // CHECK-SAME:  in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_buffer(%arg0: none, %arg1: none, ...) -> (none, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_clock, %inst_reset = firrtl.instance @handshake_buffer_1ins_1outs_ctrl_3slots_seq {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.clock, !firrtl.uint<1>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_clock, %inst_reset = firrtl.instance @handshake_buffer_1ins_1outs_ctrl_3slots_seq {name = ""} : in !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in !firrtl.clock, in !firrtl.uint<1>
   %0 = "handshake.buffer"(%arg0) {control = true, sequential = true, slots = 3 : i32} : (none) -> none
   handshake.return %0, %arg1 : none, none
 }
@@ -121,7 +121,7 @@ handshake.func @test_buffer(%arg0: none, %arg1: none, ...) -> (none, none) {
 // CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %arg2: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_buffer_data(%arg0: index, %arg1: none, ...) -> (index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_clock, %inst_reset = firrtl.instance @handshake_buffer_1ins_1outs_ui64_2slots_seq {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.clock, !firrtl.uint<1>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_clock, %inst_reset = firrtl.instance @handshake_buffer_1ins_1outs_ui64_2slots_seq {name = ""} : in !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in !firrtl.clock, in !firrtl.uint<1>
   // CHECK: firrtl.connect %inst_clock, %clock : !firrtl.clock, !firrtl.clock
   // CHECK: firrtl.connect %inst_reset, %reset : !firrtl.uint<1>, !firrtl.uint<1>
   %0 = "handshake.buffer"(%arg0) {control = false, sequential = true, slots = 2 : i32} : (index) -> index

--- a/test/Conversion/HandshakeToFIRRTL/test_cmerge.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_cmerge.mlir
@@ -95,7 +95,7 @@
 // CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %arg2: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %arg4: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %arg5: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_cmerge(%arg0: none, %arg1: none, %arg2: none, ...) -> (none, index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_arg3, %inst_clock, %inst_reset = firrtl.instance @handshake_control_merge_2ins_2outs_ctrl {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.clock, !firrtl.uint<1>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_arg3, %inst_clock, %inst_reset = firrtl.instance @handshake_control_merge_2ins_2outs_ctrl {name = ""} : in !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in !firrtl.clock, in !firrtl.uint<1>
   %0:2 = "handshake.control_merge"(%arg0, %arg1) {control = true} : (none, none) -> (none, index)
   handshake.return %0#0, %0#1, %arg2 : none, index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_conditional_branch.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_conditional_branch.mlir
@@ -32,7 +32,7 @@
 // CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %arg2: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %arg4: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %arg5: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_conditional_branch(%arg0: i1, %arg1: index, %arg2: none, ...) -> (index, index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_arg3 = firrtl.instance @handshake_conditional_branch_2ins_2outs_ui64  {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_arg3 = firrtl.instance @handshake_conditional_branch_2ins_2outs_ui64 {name = ""} : in !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>, in !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
   %0:2 = "handshake.conditional_branch"(%arg0, %arg1) {control = false}: (i1, index) -> (index, index)
   handshake.return %0#0, %0#1, %arg2 : index, index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_constant.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_constant.mlir
@@ -29,16 +29,16 @@
 handshake.func @test_constant(%arg0: none, ...) -> (index, i64, ui32, si32, none) {
   %0:5 = "handshake.fork"(%arg0) {control = true} : (none) -> (none, none, none, none, none)
 
-  // CHECK: %inst_arg0_0, %inst_arg1_1 = firrtl.instance @handshake_constant_1ins_1outs_c42_ui64  {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+  // CHECK: %inst_arg0_0, %inst_arg1_1 = firrtl.instance @handshake_constant_1ins_1outs_c42_ui64 {name = ""} : in !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
   %1 = "handshake.constant"(%0#0) {value = 42 : index}: (none) -> index
 
-  // CHECK: %inst_arg0_2, %inst_arg1_3 = firrtl.instance @handshake_constant_1ins_1outs_c42_ui64  {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+  // CHECL: %inst_arg0_2, %inst_arg1_3 = firrtl.instance @handshake_constant_1ins_1outs_c42_ui64 {name = ""} : in !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
   %2 = "handshake.constant"(%0#1) {value = 42 : i64}: (none) -> i64
 
-  // CHECK: %inst_arg0_4, %inst_arg1_5 = firrtl.instance @handshake_constant_1ins_1outs_c42_ui32  {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+  // CHECK: %inst_arg0_4, %inst_arg1_5 = firrtl.instance @handshake_constant_1ins_1outs_c42_ui32 {name = ""} : in !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
   %3 = "handshake.constant"(%0#2) {value = 42 : ui32}: (none) -> ui32
 
-  // CHECK: %inst_arg0_6, %inst_arg1_7 = firrtl.instance @"handshake_constant_1ins_1outs_c-11_si32"  {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: sint<32>>
+  // CHECK: %inst_arg0_6, %inst_arg1_7 = firrtl.instance @"handshake_constant_1ins_1outs_c-11_si32"  {name = ""} : in !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: sint<32>>
   %4 = "handshake.constant"(%0#3) {value = -11 : si32}: (none) -> si32
   handshake.return %1, %2, %3, %4, %0#4 : index, i64, ui32, si32, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_fork.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_fork.mlir
@@ -64,7 +64,7 @@
 // CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %arg2: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %arg4: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_fork(%arg0: none, %arg1: none, ...) -> (none, none, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_clock, %inst_reset = firrtl.instance @handshake_fork_1ins_2outs_ctrl {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.clock, !firrtl.uint<1>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_clock, %inst_reset = firrtl.instance @handshake_fork_1ins_2outs_ctrl {name = ""} : in !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in !firrtl.clock, in !firrtl.uint<1>
   %0:2 = "handshake.fork"(%arg0) {control = true} : (none) -> (none, none)
   handshake.return %0#0, %0#1, %arg1 : none, none, none
 }
@@ -89,7 +89,7 @@ handshake.func @test_fork(%arg0: none, %arg1: none, ...) -> (none, none, none) {
 // CHECK-SAME:  in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_fork_data(%arg0: index, %arg1: none, ...) -> (index, index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_clock, %inst_reset = firrtl.instance @handshake_fork_1ins_2outs_ui64 {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.clock, !firrtl.uint<1>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_clock, %inst_reset = firrtl.instance @handshake_fork_1ins_2outs_ui64 {name = ""} : in !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in !firrtl.clock, in !firrtl.uint<1>
   %0:2 = "handshake.fork"(%arg0) {control = false} : (index) -> (index, index)
   handshake.return %0#0, %0#1, %arg1 : index, index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_join.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_join.mlir
@@ -21,7 +21,7 @@
 // CHECK-SAME: in %arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %arg2: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %arg4: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_join(%arg0: none, %arg1: none, %arg2: none, ...) -> (none, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @handshake_join_2ins_1outs_ctrl  {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @handshake_join_2ins_1outs_ctrl {name = ""} : in !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
   %0 = "handshake.join"(%arg0, %arg1) {control = true}: (none, none) -> none
   handshake.return %0, %arg2 : none, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_lazy_fork.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_lazy_fork.mlir
@@ -29,7 +29,7 @@
 // CHECK-SAME: in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_lazy_fork(%arg0: index, %arg1: none, ...) -> (index, index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @handshake_lazy_fork_1ins_2outs_ui64  {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @handshake_lazy_fork_1ins_2outs_ui64 {name = ""} : in !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
   %0:2 = "handshake.lazy_fork"(%arg0) {control = false} : (index) -> (index, index)
   handshake.return %0#0, %0#1, %arg1 : index, index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_merge.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_merge.mlir
@@ -62,7 +62,7 @@
 // CHECK-SAME:  in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_merge(%arg0: index, %arg1: index, %arg2: none, ...) -> (index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @handshake_merge_2ins_1outs_ui64 {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @handshake_merge_2ins_1outs_ui64 {name = ""} : in !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
   %0 = "handshake.merge"(%arg0, %arg1) : (index, index) -> index
   handshake.return %0, %arg2 : index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_mux.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_mux.mlir
@@ -37,7 +37,7 @@
 // CHECK: firrtl.module @test_mux(in %arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %arg2: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %arg3: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %arg4: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %arg5: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_mux(%arg0: index, %arg1: index, %arg2: index, %arg3: none, ...) -> (index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_arg3 = firrtl.instance @handshake_mux_3ins_1outs_ui64  {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_arg3 = firrtl.instance @handshake_mux_3ins_1outs_ui64 {name = ""} : in !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
   %0 = "handshake.mux"(%arg0, %arg1, %arg2): (index, index, index) -> index
   handshake.return %0, %arg3 : index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_sink.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_sink.mlir
@@ -11,7 +11,7 @@
 // CHECK-SAME: in %arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %arg2: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_sink(%arg0: index, %arg2: none, ...) -> (none) {
 
-  // CHECK: %inst_arg0 = firrtl.instance @handshake_sink_1ins_0outs_ui64  {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+  // CHECK: %inst_arg0 = firrtl.instance @handshake_sink_1ins_0outs_ui64 {name = ""} : in !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
   // CHECK: firrtl.connect %inst_arg0, %arg0 : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
   "handshake.sink"(%arg0) : (index) -> ()
 

--- a/test/Dialect/FIRRTL/SFCTests/constantProp.mlir
+++ b/test/Dialect/FIRRTL/SFCTests/constantProp.mlir
@@ -5,7 +5,7 @@
 firrtl.circuit "ConstInput"   {
   firrtl.module @ConstInput(in %x: !firrtl.uint<1>, out %z: !firrtl.uint<1>) {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    %c_in0, %c_in1, %c_out = firrtl.instance @Child  {name = "c"} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %c_in0, %c_in1, %c_out = firrtl.instance @Child  {name = "c"} : in !firrtl.uint<1>, in !firrtl.uint<1>, out !firrtl.uint<1>
     firrtl.connect %c_in0, %x : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %c_in1, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %z, %c_out : !firrtl.uint<1>, !firrtl.uint<1>
@@ -29,7 +29,7 @@ firrtl.circuit "InstanceInput"   {
   // CHECK-LABEL: firrtl.module @Child1
   firrtl.module @Child1(out %out: !firrtl.uint<1>) {
     %c1_ui = firrtl.constant 1 : !firrtl.uint
-    %b0_in, %b0_out = firrtl.instance @Bottom1  {name = "b0"} : !firrtl.uint<1>, !firrtl.uint<1>
+    %b0_in, %b0_out = firrtl.instance @Bottom1  {name = "b0"} : in !firrtl.uint<1>, out !firrtl.uint<1>
     firrtl.connect %b0_in, %c1_ui : !firrtl.uint<1>, !firrtl.uint
     // CHECK: %[[C1:.+]] = firrtl.constant 1 :
     // CHECK: firrtl.connect %out, %[[C1]]
@@ -38,10 +38,10 @@ firrtl.circuit "InstanceInput"   {
   // CHECK-LABEL:  firrtl.module @InstanceInput
   firrtl.module @InstanceInput(in %x: !firrtl.uint<1>, out %z: !firrtl.uint<1>) {
     %c1_ui = firrtl.constant 1 : !firrtl.uint
-    %c_out = firrtl.instance @Child1  {name = "c"} : !firrtl.uint<1>
-    %b0_in, %b0_out = firrtl.instance @Bottom1  {name = "b0"} : !firrtl.uint<1>, !firrtl.uint<1>
+    %c_out = firrtl.instance @Child1  {name = "c"} : out !firrtl.uint<1>
+    %b0_in, %b0_out = firrtl.instance @Bottom1  {name = "b0"} : in !firrtl.uint<1>, out !firrtl.uint<1>
     firrtl.connect %b0_in, %c1_ui : !firrtl.uint<1>, !firrtl.uint
-    %b1_in, %b1_out = firrtl.instance @Bottom1  {name = "b1"} : !firrtl.uint<1>, !firrtl.uint<1>
+    %b1_in, %b1_out = firrtl.instance @Bottom1  {name = "b1"} : in !firrtl.uint<1>, out !firrtl.uint<1>
     firrtl.connect %b1_in, %c1_ui : !firrtl.uint<1>, !firrtl.uint
     %0 = firrtl.and %b0_out, %b1_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     %1 = firrtl.and %0, %c_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
@@ -61,7 +61,7 @@ firrtl.circuit "InstanceInput2"   {
  // CHECK-LABEL:  firrtl.module @Child2
   firrtl.module @Child2(out %out: !firrtl.uint<1>) {
     %c1_ui = firrtl.constant 1 : !firrtl.uint
-    %b0_in, %b0_out = firrtl.instance @Bottom2  {name = "b0"} : !firrtl.uint<1>, !firrtl.uint<1>
+    %b0_in, %b0_out = firrtl.instance @Bottom2  {name = "b0"} : in !firrtl.uint<1>, out !firrtl.uint<1>
     firrtl.connect %b0_in, %c1_ui : !firrtl.uint<1>, !firrtl.uint
     // CHECK: firrtl.connect %out, %b0_out
     firrtl.connect %out, %b0_out : !firrtl.uint<1>, !firrtl.uint<1>
@@ -69,10 +69,10 @@ firrtl.circuit "InstanceInput2"   {
  // CHECK-LABEL:  firrtl.module @InstanceInput2
   firrtl.module @InstanceInput2(in %x: !firrtl.uint<1>, out %z: !firrtl.uint<1>) {
     %c1_ui = firrtl.constant 1 : !firrtl.uint
-    %c_out = firrtl.instance @Child2  {name = "c"} : !firrtl.uint<1>
-    %b0_in, %b0_out = firrtl.instance @Bottom2  {name = "b0"} : !firrtl.uint<1>, !firrtl.uint<1>
+    %c_out = firrtl.instance @Child2  {name = "c"} : out !firrtl.uint<1>
+    %b0_in, %b0_out = firrtl.instance @Bottom2  {name = "b0"} : in !firrtl.uint<1>, out !firrtl.uint<1>
     firrtl.connect %b0_in, %x : !firrtl.uint<1>, !firrtl.uint<1>
-    %b1_in, %b1_out = firrtl.instance @Bottom2  {name = "b1"} : !firrtl.uint<1>, !firrtl.uint<1>
+    %b1_in, %b1_out = firrtl.instance @Bottom2  {name = "b1"} : in !firrtl.uint<1>, out !firrtl.uint<1>
     firrtl.connect %b1_in, %c1_ui : !firrtl.uint<1>, !firrtl.uint
     %0 = firrtl.and %b0_out, %b1_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     %1 = firrtl.and %0, %c_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
@@ -102,7 +102,7 @@ firrtl.circuit "constOutput"   {
     firrtl.connect %out, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   }
   firrtl.module @constOutput(in %x: !firrtl.uint<1>, out %z: !firrtl.uint<1>) {
-    %c_out = firrtl.instance @constOutChild  {name = "c"} : !firrtl.uint<1>
+    %c_out = firrtl.instance @constOutChild  {name = "c"} : out !firrtl.uint<1>
     %0 = firrtl.and %x, %c_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.connect %z, %0 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: %[[C3_0:.+]] = firrtl.constant 0 : !firrtl.uint<1>
@@ -196,7 +196,7 @@ firrtl.circuit "padConstOut"   {
   }
   // CHECK-LABEL: firrtl.module @padConstOut
   firrtl.module @padConstOut(out %z: !firrtl.uint<16>) {
-    %c_x = firrtl.instance @padConstOutChild  {name = "c"} : !firrtl.uint<8>
+    %c_x = firrtl.instance @padConstOutChild  {name = "c"} : out !firrtl.uint<8>
     %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
     %0 = firrtl.cat %c3_ui2, %c_x : (!firrtl.uint<2>, !firrtl.uint<8>) -> !firrtl.uint<10>
     // CHECK: %[[C8:.+]] = firrtl.constant 771 : !firrtl.uint<10>
@@ -217,7 +217,7 @@ firrtl.circuit "padConstIn"   {
   }
   // CHECK-LABEL: firrtl.module @padConstIn
   firrtl.module @padConstIn(out %z: !firrtl.uint<16>) {
-    %c_x, %c_y = firrtl.instance @padConstInChild  {name = "c"} : !firrtl.uint<8>, !firrtl.uint<16>
+    %c_x, %c_y = firrtl.instance @padConstInChild  {name = "c"} : in !firrtl.uint<8>, out !firrtl.uint<16>
     %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
     firrtl.connect %c_x, %c3_ui2 : !firrtl.uint<8>, !firrtl.uint<2>
     firrtl.connect %z, %c_y : !firrtl.uint<16>, !firrtl.uint<16>

--- a/test/Dialect/FIRRTL/blackbox-memory.mlir
+++ b/test/Dialect/FIRRTL/blackbox-memory.mlir
@@ -21,7 +21,7 @@ firrtl.circuit "Read" {
 // WRAPPER-LABEL: firrtl.circuit "Read" {
 // WRAPPER-NEXT:   firrtl.extmodule @ReadMemory_ext(in %R0_addr: !firrtl.uint<4>, in %R0_en: !firrtl.uint<1>, in %R0_clk: !firrtl.clock, out %R0_data: !firrtl.sint<8>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // WRAPPER-NEXT:   firrtl.module @ReadMemory(in %read0: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) {
-// WRAPPER-NEXT:     %ReadMemory_R0_addr, %ReadMemory_R0_en, %ReadMemory_R0_clk, %ReadMemory_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory"} : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>
+// WRAPPER-NEXT:     %ReadMemory_R0_addr, %ReadMemory_R0_en, %ReadMemory_R0_clk, %ReadMemory_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory"} : in !firrtl.uint<4>, in !firrtl.uint<1>, in !firrtl.clock, out !firrtl.sint<8>
 // WRAPPER-NEXT:     %0 = firrtl.subfield %read0(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<4>
 // WRAPPER-NEXT:     firrtl.connect %ReadMemory_R0_addr, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 // WRAPPER-NEXT:     %1 = firrtl.subfield %read0(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<1>
@@ -34,7 +34,7 @@ firrtl.circuit "Read" {
 // WRAPPER-NEXT:   firrtl.module @Read() {
 // WRAPPER-NEXT:     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
 // WRAPPER-NEXT:     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-// WRAPPER-NEXT:     %ReadMemory_read0 = firrtl.instance @ReadMemory {name = "ReadMemory"} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
+// WRAPPER-NEXT:     %ReadMemory_read0 = firrtl.instance @ReadMemory {name = "ReadMemory"} : in !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
 // WRAPPER-NEXT:     %0 = firrtl.subfield %ReadMemory_read0(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.sint<8>
 // WRAPPER-NEXT:     %1 = firrtl.subfield %ReadMemory_read0(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<4>
 // WRAPPER-NEXT:     firrtl.connect %1, %c0_ui1 : !firrtl.uint<4>, !firrtl.uint<1>
@@ -49,7 +49,7 @@ firrtl.circuit "Read" {
 // INLINE-NEXT:   firrtl.module @Read() {
 // INLINE-NEXT:     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
 // INLINE-NEXT:     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-// INLINE-NEXT:     %ReadMemory_R0_addr, %ReadMemory_R0_en, %ReadMemory_R0_clk, %ReadMemory_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory"} : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>
+// INLINE-NEXT:     %ReadMemory_R0_addr, %ReadMemory_R0_en, %ReadMemory_R0_clk, %ReadMemory_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory"} : in !firrtl.uint<4>, in !firrtl.uint<1>, in !firrtl.clock, out !firrtl.sint<8>
 // INLINE-NEXT:     %0 = firrtl.wire : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
 // INLINE-NEXT:     %1 = firrtl.subfield %0(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<4>
 // INLINE-NEXT:     firrtl.connect %ReadMemory_R0_addr, %1 : !firrtl.uint<4>, !firrtl.uint<4>
@@ -77,7 +77,7 @@ firrtl.circuit "Write" {
 // WRAPPER-LABEL: firrtl.circuit "Write" {
 // WRAPPER-NEXT:   firrtl.extmodule @WriteMemory_ext(in %W0_addr: !firrtl.uint<1>, in %W0_en: !firrtl.uint<1>, in %W0_clk: !firrtl.clock, in %W0_data: !firrtl.sint<8>, in %W0_mask: !firrtl.uint<1>) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // WRAPPER-NEXT:   firrtl.module @WriteMemory(in %write0: !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) {
-// WRAPPER-NEXT:     %WriteMemory_W0_addr, %WriteMemory_W0_en, %WriteMemory_W0_clk, %WriteMemory_W0_data, %WriteMemory_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory"} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %WriteMemory_W0_addr, %WriteMemory_W0_en, %WriteMemory_W0_clk, %WriteMemory_W0_data, %WriteMemory_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory"} : in !firrtl.uint<1>, in !firrtl.uint<1>, in !firrtl.clock, in !firrtl.sint<8>, in !firrtl.uint<1>
 // WRAPPER-NEXT:     %0 = firrtl.subfield %write0(0) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
 // WRAPPER-NEXT:     firrtl.connect %WriteMemory_W0_addr, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 // WRAPPER-NEXT:     %1 = firrtl.subfield %write0(1) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
@@ -90,14 +90,14 @@ firrtl.circuit "Write" {
 // WRAPPER-NEXT:     firrtl.connect %WriteMemory_W0_mask, %4 : !firrtl.uint<1>, !firrtl.uint<1>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT:   firrtl.module @Write() {
-// WRAPPER-NEXT:     %WriteMemory_write0 = firrtl.instance @WriteMemory {name = "WriteMemory"} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
+// WRAPPER-NEXT:     %WriteMemory_write0 = firrtl.instance @WriteMemory {name = "WriteMemory"} : in !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT: }
 
 // INLINE-LABEL: firrtl.circuit "Write" {
 // INLINE-NEXT:   firrtl.extmodule @WriteMemory_ext(in %W0_addr: !firrtl.uint<1>, in %W0_en: !firrtl.uint<1>, in %W0_clk: !firrtl.clock, in %W0_data: !firrtl.sint<8>, in %W0_mask: !firrtl.uint<1>) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // INLINE-NEXT:   firrtl.module @Write() {
-// INLINE-NEXT:     %WriteMemory_W0_addr, %WriteMemory_W0_en, %WriteMemory_W0_clk, %WriteMemory_W0_data, %WriteMemory_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory"} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// INLINE-NEXT:     %WriteMemory_W0_addr, %WriteMemory_W0_en, %WriteMemory_W0_clk, %WriteMemory_W0_data, %WriteMemory_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory"} : in !firrtl.uint<1>, in !firrtl.uint<1>, in !firrtl.clock, in !firrtl.sint<8>, in !firrtl.uint<1>
 // INLINE-NEXT:     %0 = firrtl.wire  : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
 // INLINE-NEXT:     %1 = firrtl.subfield %0(0) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
 // INLINE-NEXT:     firrtl.connect %WriteMemory_W0_addr, %1 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -180,7 +180,7 @@ firrtl.circuit "MemSimple" {
 // WRAPPER-LABEL: firrtl.circuit "MemSimple" {
 // WRAPPER-NEXT:   firrtl.extmodule @_M_ext(in %R0_addr: !firrtl.uint<4>, in %R0_en: !firrtl.uint<1>, in %R0_clk: !firrtl.clock, out %R0_data: !firrtl.sint<42>, in %W0_addr: !firrtl.uint<4>, in %W0_en: !firrtl.uint<1>, in %W0_clk: !firrtl.clock, in %W0_data: !firrtl.sint<42>, in %W0_mask: !firrtl.uint<1>) attributes {depth = 12 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // WRAPPER-NEXT:   firrtl.module @_M(in %read: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>, in %write: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) {
-// WRAPPER-NEXT:     %_M_R0_addr, %_M_R0_en, %_M_R0_clk, %_M_R0_data, %_M_W0_addr, %_M_W0_en, %_M_W0_clk, %_M_W0_data, %_M_W0_mask = firrtl.instance @_M_ext {name = "_M"} : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<42>, !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<42>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %_M_R0_addr, %_M_R0_en, %_M_R0_clk, %_M_R0_data, %_M_W0_addr, %_M_W0_en, %_M_W0_clk, %_M_W0_data, %_M_W0_mask = firrtl.instance @_M_ext {name = "_M"} : in !firrtl.uint<4>, in !firrtl.uint<1>, in !firrtl.clock, out !firrtl.sint<42>, in !firrtl.uint<4>, in !firrtl.uint<1>, in !firrtl.clock, in !firrtl.sint<42>, in !firrtl.uint<1>
 // WRAPPER-NEXT:     %0 = firrtl.subfield %read(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>) -> !firrtl.uint<4>
 // WRAPPER-NEXT:     firrtl.connect %_M_R0_addr, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 // WRAPPER-NEXT:     %1 = firrtl.subfield %read(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>) -> !firrtl.uint<1>
@@ -204,7 +204,7 @@ firrtl.circuit "MemSimple" {
 // WRAPPER-NEXT:     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
 // WRAPPER-NEXT:     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
 // WRAPPER-NEXT:     %c0_ui3 = firrtl.constant 0 : !firrtl.uint<3>
-// WRAPPER-NEXT:     %_M_read, %_M_write = firrtl.instance @_M {name = "_M"} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>
+// WRAPPER-NEXT:     %_M_read, %_M_write = firrtl.instance @_M {name = "_M"} : in !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>, in !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>
 // WRAPPER-NEXT:     %0 = firrtl.subfield %_M_read(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>) -> !firrtl.sint<42>
 // WRAPPER-NEXT:     firrtl.connect %result, %0 : !firrtl.sint<42>, !firrtl.sint<42>
 // WRAPPER-NEXT:     %1 = firrtl.subfield %_M_read(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>) -> !firrtl.uint<4>
@@ -241,7 +241,7 @@ firrtl.circuit "MemSimple" {
 // INLINE-NEXT:     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
 // INLINE-NEXT:     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
 // INLINE-NEXT:     %c0_ui3 = firrtl.constant 0 : !firrtl.uint<3>
-// INLINE-NEXT:     %_M_R0_addr, %_M_R0_en, %_M_R0_clk, %_M_R0_data, %_M_W0_addr, %_M_W0_en, %_M_W0_clk, %_M_W0_data, %_M_W0_mask = firrtl.instance @_M_ext {name = "_M"} : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<42>, !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<42>, !firrtl.uint<1>
+// INLINE-NEXT:     %_M_R0_addr, %_M_R0_en, %_M_R0_clk, %_M_R0_data, %_M_W0_addr, %_M_W0_en, %_M_W0_clk, %_M_W0_data, %_M_W0_mask = firrtl.instance @_M_ext {name = "_M"} : in !firrtl.uint<4>, in !firrtl.uint<1>, in !firrtl.clock, out !firrtl.sint<42>, in !firrtl.uint<4>, in !firrtl.uint<1>, in !firrtl.clock, in !firrtl.sint<42>, in !firrtl.uint<1>
 // INLINE-NEXT:     %0 = firrtl.wire  : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>
 // INLINE-NEXT:     %1 = firrtl.subfield %0(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>) -> !firrtl.uint<4>
 // INLINE-NEXT:     firrtl.connect %_M_R0_addr, %1 : !firrtl.uint<4>, !firrtl.uint<4>
@@ -305,7 +305,7 @@ firrtl.circuit "NameCollision" {
 // WRAPPER-LABEL: firrtl.circuit "NameCollision" {
 // WRAPPER-NEXT:   firrtl.extmodule @NameCollisionMemory_ext_1(in %W0_addr: !firrtl.uint<4>, in %W0_en: !firrtl.uint<1>, in %W0_clk: !firrtl.clock, in %W0_data: !firrtl.sint<8>, in %W0_mask: !firrtl.uint<1>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // WRAPPER-NEXT:   firrtl.module @NameCollisionMemory_0(in %write0: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) {
-// WRAPPER-NEXT:     %NameCollisionMemory_W0_addr, %NameCollisionMemory_W0_en, %NameCollisionMemory_W0_clk, %NameCollisionMemory_W0_data, %NameCollisionMemory_W0_mask = firrtl.instance @NameCollisionMemory_ext_1 {name = "NameCollisionMemory"} : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %NameCollisionMemory_W0_addr, %NameCollisionMemory_W0_en, %NameCollisionMemory_W0_clk, %NameCollisionMemory_W0_data, %NameCollisionMemory_W0_mask = firrtl.instance @NameCollisionMemory_ext_1 {name = "NameCollisionMemory"} : in !firrtl.uint<4>, in !firrtl.uint<1>, in !firrtl.clock, in !firrtl.sint<8>, in !firrtl.uint<1>
 // WRAPPER-NEXT:     %0 = firrtl.subfield %write0(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<4>
 // WRAPPER-NEXT:     firrtl.connect %NameCollisionMemory_W0_addr, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 // WRAPPER-NEXT:     %1 = firrtl.subfield %write0(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
@@ -319,7 +319,7 @@ firrtl.circuit "NameCollision" {
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT:   firrtl.extmodule @NameCollisionMemory_ext_0(in %R0_addr: !firrtl.uint<4>, in %R0_en: !firrtl.uint<1>, in %R0_clk: !firrtl.clock, out %R0_data: !firrtl.sint<8>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // WRAPPER-NEXT:   firrtl.module @NameCollisionMemory(in %read0: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) {
-// WRAPPER-NEXT:     %NameCollisionMemory_R0_addr, %NameCollisionMemory_R0_en, %NameCollisionMemory_R0_clk, %NameCollisionMemory_R0_data = firrtl.instance @NameCollisionMemory_ext_0 {name = "NameCollisionMemory"} : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>
+// WRAPPER-NEXT:     %NameCollisionMemory_R0_addr, %NameCollisionMemory_R0_en, %NameCollisionMemory_R0_clk, %NameCollisionMemory_R0_data = firrtl.instance @NameCollisionMemory_ext_0 {name = "NameCollisionMemory"} : in !firrtl.uint<4>, in !firrtl.uint<1>, in !firrtl.clock, out !firrtl.sint<8>
 // WRAPPER-NEXT:     %0 = firrtl.subfield %read0(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<4>
 // WRAPPER-NEXT:     firrtl.connect %NameCollisionMemory_R0_addr, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 // WRAPPER-NEXT:     %1 = firrtl.subfield %read0(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<1>
@@ -330,10 +330,10 @@ firrtl.circuit "NameCollision" {
 // WRAPPER-NEXT:     firrtl.connect %3, %NameCollisionMemory_R0_data : !firrtl.sint<8>, !firrtl.sint<8>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT:   firrtl.module @NameCollisionMemory_ext() {
-// WRAPPER-NEXT:     %NameCollisionMemory_read0 = firrtl.instance @NameCollisionMemory {name = "NameCollisionMemory"} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
+// WRAPPER-NEXT:     %NameCollisionMemory_read0 = firrtl.instance @NameCollisionMemory {name = "NameCollisionMemory"} : in !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT:   firrtl.module @NameCollision() {
-// WRAPPER-NEXT:     %NameCollisionMemory_write0 = firrtl.instance @NameCollisionMemory_0 {name = "NameCollisionMemory"} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
+// WRAPPER-NEXT:     %NameCollisionMemory_write0 = firrtl.instance @NameCollisionMemory_0 {name = "NameCollisionMemory"} : in !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT: }
 
@@ -341,7 +341,7 @@ firrtl.circuit "NameCollision" {
 // INLINE-NEXT:   firrtl.extmodule @NameCollisionMemory_ext_1(in %W0_addr: !firrtl.uint<4>, in %W0_en: !firrtl.uint<1>, in %W0_clk: !firrtl.clock, in %W0_data: !firrtl.sint<8>, in %W0_mask: !firrtl.uint<1>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // INLINE-NEXT:   firrtl.extmodule @NameCollisionMemory_ext_0(in %R0_addr: !firrtl.uint<4>, in %R0_en: !firrtl.uint<1>, in %R0_clk: !firrtl.clock, out %R0_data: !firrtl.sint<8>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // INLINE-NEXT:   firrtl.module @NameCollisionMemory_ext() {
-// INLINE-NEXT:     %NameCollisionMemory_R0_addr, %NameCollisionMemory_R0_en, %NameCollisionMemory_R0_clk, %NameCollisionMemory_R0_data = firrtl.instance @NameCollisionMemory_ext_0 {name = "NameCollisionMemory"} : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>
+// INLINE-NEXT:     %NameCollisionMemory_R0_addr, %NameCollisionMemory_R0_en, %NameCollisionMemory_R0_clk, %NameCollisionMemory_R0_data = firrtl.instance @NameCollisionMemory_ext_0 {name = "NameCollisionMemory"} : in !firrtl.uint<4>, in !firrtl.uint<1>, in !firrtl.clock, out !firrtl.sint<8>
 // INLINE-NEXT:     %0 = firrtl.wire  : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
 // INLINE-NEXT:     %1 = firrtl.subfield %0(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<4>
 // INLINE-NEXT:     firrtl.connect %NameCollisionMemory_R0_addr, %1 : !firrtl.uint<4>, !firrtl.uint<4>
@@ -353,7 +353,7 @@ firrtl.circuit "NameCollision" {
 // INLINE-NEXT:     firrtl.connect %4, %NameCollisionMemory_R0_data : !firrtl.sint<8>, !firrtl.sint<8>
 // INLINE-NEXT:   }
 // INLINE-NEXT:   firrtl.module @NameCollision() {
-// INLINE-NEXT:     %NameCollisionMemory_W0_addr, %NameCollisionMemory_W0_en, %NameCollisionMemory_W0_clk, %NameCollisionMemory_W0_data, %NameCollisionMemory_W0_mask = firrtl.instance @NameCollisionMemory_ext_1 {name = "NameCollisionMemory"} : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// INLINE-NEXT:     %NameCollisionMemory_W0_addr, %NameCollisionMemory_W0_en, %NameCollisionMemory_W0_clk, %NameCollisionMemory_W0_data, %NameCollisionMemory_W0_mask = firrtl.instance @NameCollisionMemory_ext_1 {name = "NameCollisionMemory"} : in !firrtl.uint<4>, in !firrtl.uint<1>, in !firrtl.clock, in !firrtl.sint<8>, in !firrtl.uint<1>
 // INLINE-NEXT:     %0 = firrtl.wire  : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
 // INLINE-NEXT:     %1 = firrtl.subfield %0(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<4>
 // INLINE-NEXT:     firrtl.connect %NameCollisionMemory_W0_addr, %1 : !firrtl.uint<4>, !firrtl.uint<4>
@@ -382,7 +382,7 @@ firrtl.circuit "Duplicate" {
 // WRAPPER-LABEL: firrtl.circuit "Duplicate" {
 // WRAPPER-NEXT:   firrtl.extmodule @WriteMemory_ext(in %W0_addr: !firrtl.uint<1>, in %W0_en: !firrtl.uint<1>, in %W0_clk: !firrtl.clock, in %W0_data: !firrtl.sint<8>, in %W0_mask: !firrtl.uint<1>) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // WRAPPER-NEXT:   firrtl.module @WriteMemory(in %write0: !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) {
-// WRAPPER-NEXT:     %WriteMemory_W0_addr, %WriteMemory_W0_en, %WriteMemory_W0_clk, %WriteMemory_W0_data, %WriteMemory_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory"} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %WriteMemory_W0_addr, %WriteMemory_W0_en, %WriteMemory_W0_clk, %WriteMemory_W0_data, %WriteMemory_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory"} : in !firrtl.uint<1>, in !firrtl.uint<1>, in !firrtl.clock, in !firrtl.sint<8>, in !firrtl.uint<1>
 // WRAPPER-NEXT:     %0 = firrtl.subfield %write0(0) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
 // WRAPPER-NEXT:     firrtl.connect %WriteMemory_W0_addr, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 // WRAPPER-NEXT:     %1 = firrtl.subfield %write0(1) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
@@ -396,7 +396,7 @@ firrtl.circuit "Duplicate" {
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT:   firrtl.extmodule @ReadMemory_ext(in %R0_addr: !firrtl.uint<4>, in %R0_en: !firrtl.uint<1>, in %R0_clk: !firrtl.clock, out %R0_data: !firrtl.sint<8>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // WRAPPER-NEXT:   firrtl.module @ReadMemory(in %read0: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) {
-// WRAPPER-NEXT:     %ReadMemory_R0_addr, %ReadMemory_R0_en, %ReadMemory_R0_clk, %ReadMemory_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory"} : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>
+// WRAPPER-NEXT:     %ReadMemory_R0_addr, %ReadMemory_R0_en, %ReadMemory_R0_clk, %ReadMemory_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory"} : in !firrtl.uint<4>, in !firrtl.uint<1>, in !firrtl.clock, out !firrtl.sint<8>
 // WRAPPER-NEXT:     %0 = firrtl.subfield %read0(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<4>
 // WRAPPER-NEXT:     firrtl.connect %ReadMemory_R0_addr, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 // WRAPPER-NEXT:     %1 = firrtl.subfield %read0(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<1>
@@ -407,12 +407,12 @@ firrtl.circuit "Duplicate" {
 // WRAPPER-NEXT:     firrtl.connect %3, %ReadMemory_R0_data : !firrtl.sint<8>, !firrtl.sint<8>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT:   firrtl.module @Duplicate() {
-// WRAPPER-NEXT:     %ReadMemory_read0 = firrtl.instance @ReadMemory {name = "ReadMemory"} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
-// WRAPPER-NEXT:     %WriteMemory_write0 = firrtl.instance @WriteMemory {name = "WriteMemory"} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
-// WRAPPER-NEXT:     %ReadMemory1_read0 = firrtl.instance @ReadMemory {name = "ReadMemory1"} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
-// WRAPPER-NEXT:     %WriteMemory1_write0 = firrtl.instance @WriteMemory {name = "WriteMemory1"} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
-// WRAPPER-NEXT:     %ReadMemory2_read0 = firrtl.instance @ReadMemory {name = "ReadMemory2"} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
-// WRAPPER-NEXT:     %WriteMemory2_write0 = firrtl.instance @WriteMemory {name = "WriteMemory2"} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
+// WRAPPER-NEXT:     %ReadMemory_read0 = firrtl.instance @ReadMemory {name = "ReadMemory"} : in !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
+// WRAPPER-NEXT:     %WriteMemory_write0 = firrtl.instance @WriteMemory {name = "WriteMemory"} : in !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
+// WRAPPER-NEXT:     %ReadMemory1_read0 = firrtl.instance @ReadMemory {name = "ReadMemory1"} : in !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
+// WRAPPER-NEXT:     %WriteMemory1_write0 = firrtl.instance @WriteMemory {name = "WriteMemory1"} : in !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
+// WRAPPER-NEXT:     %ReadMemory2_read0 = firrtl.instance @ReadMemory {name = "ReadMemory2"} : in !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
+// WRAPPER-NEXT:     %WriteMemory2_write0 = firrtl.instance @WriteMemory {name = "WriteMemory2"} : in !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT: }
 
@@ -420,7 +420,7 @@ firrtl.circuit "Duplicate" {
 // INLINE-NEXT:   firrtl.extmodule @WriteMemory_ext(in %W0_addr: !firrtl.uint<1>, in %W0_en: !firrtl.uint<1>, in %W0_clk: !firrtl.clock, in %W0_data: !firrtl.sint<8>, in %W0_mask: !firrtl.uint<1>) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // INLINE-NEXT:   firrtl.extmodule @ReadMemory_ext(in %R0_addr: !firrtl.uint<4>, in %R0_en: !firrtl.uint<1>, in %R0_clk: !firrtl.clock, out %R0_data: !firrtl.sint<8>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // INLINE-NEXT:   firrtl.module @Duplicate() {
-// INLINE-NEXT:     %ReadMemory_R0_addr, %ReadMemory_R0_en, %ReadMemory_R0_clk, %ReadMemory_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory"} : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>
+// INLINE-NEXT:     %ReadMemory_R0_addr, %ReadMemory_R0_en, %ReadMemory_R0_clk, %ReadMemory_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory"} : in !firrtl.uint<4>, in !firrtl.uint<1>, in !firrtl.clock, out !firrtl.sint<8>
 // INLINE-NEXT:     %0 = firrtl.wire  : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
 // INLINE-NEXT:     %1 = firrtl.subfield %0(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<4>
 // INLINE-NEXT:     firrtl.connect %ReadMemory_R0_addr, %1 : !firrtl.uint<4>, !firrtl.uint<4>
@@ -430,7 +430,7 @@ firrtl.circuit "Duplicate" {
 // INLINE-NEXT:     firrtl.connect %ReadMemory_R0_clk, %3 : !firrtl.clock, !firrtl.clock
 // INLINE-NEXT:     %4 = firrtl.subfield %0(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.sint<8>
 // INLINE-NEXT:     firrtl.connect %4, %ReadMemory_R0_data : !firrtl.sint<8>, !firrtl.sint<8>
-// INLINE-NEXT:     %WriteMemory_W0_addr, %WriteMemory_W0_en, %WriteMemory_W0_clk, %WriteMemory_W0_data, %WriteMemory_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory"} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// INLINE-NEXT:     %WriteMemory_W0_addr, %WriteMemory_W0_en, %WriteMemory_W0_clk, %WriteMemory_W0_data, %WriteMemory_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory"} : in !firrtl.uint<1>, in !firrtl.uint<1>, in !firrtl.clock, in !firrtl.sint<8>, in !firrtl.uint<1>
 // INLINE-NEXT:     %5 = firrtl.wire  : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
 // INLINE-NEXT:     %6 = firrtl.subfield %5(0) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
 // INLINE-NEXT:     firrtl.connect %WriteMemory_W0_addr, %6 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -442,7 +442,7 @@ firrtl.circuit "Duplicate" {
 // INLINE-NEXT:     firrtl.connect %WriteMemory_W0_data, %9 : !firrtl.sint<8>, !firrtl.sint<8>
 // INLINE-NEXT:     %10 = firrtl.subfield %5(4) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
 // INLINE-NEXT:     firrtl.connect %WriteMemory_W0_mask, %10 : !firrtl.uint<1>, !firrtl.uint<1>
-// INLINE-NEXT:     %ReadMemory1_R0_addr, %ReadMemory1_R0_en, %ReadMemory1_R0_clk, %ReadMemory1_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory1"} : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>
+// INLINE-NEXT:     %ReadMemory1_R0_addr, %ReadMemory1_R0_en, %ReadMemory1_R0_clk, %ReadMemory1_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory1"} : in !firrtl.uint<4>, in !firrtl.uint<1>, in !firrtl.clock, out !firrtl.sint<8>
 // INLINE-NEXT:     %11 = firrtl.wire  : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
 // INLINE-NEXT:     %12 = firrtl.subfield %11(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<4>
 // INLINE-NEXT:     firrtl.connect %ReadMemory1_R0_addr, %12 : !firrtl.uint<4>, !firrtl.uint<4>
@@ -452,7 +452,7 @@ firrtl.circuit "Duplicate" {
 // INLINE-NEXT:     firrtl.connect %ReadMemory1_R0_clk, %14 : !firrtl.clock, !firrtl.clock
 // INLINE-NEXT:     %15 = firrtl.subfield %11(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.sint<8>
 // INLINE-NEXT:     firrtl.connect %15, %ReadMemory1_R0_data : !firrtl.sint<8>, !firrtl.sint<8>
-// INLINE-NEXT:     %WriteMemory1_W0_addr, %WriteMemory1_W0_en, %WriteMemory1_W0_clk, %WriteMemory1_W0_data, %WriteMemory1_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory1"} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// INLINE-NEXT:     %WriteMemory1_W0_addr, %WriteMemory1_W0_en, %WriteMemory1_W0_clk, %WriteMemory1_W0_data, %WriteMemory1_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory1"} : in !firrtl.uint<1>, in !firrtl.uint<1>, in !firrtl.clock, in !firrtl.sint<8>, in !firrtl.uint<1>
 // INLINE-NEXT:     %16 = firrtl.wire  : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
 // INLINE-NEXT:     %17 = firrtl.subfield %16(0) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
 // INLINE-NEXT:     firrtl.connect %WriteMemory1_W0_addr, %17 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -464,7 +464,7 @@ firrtl.circuit "Duplicate" {
 // INLINE-NEXT:     firrtl.connect %WriteMemory1_W0_data, %20 : !firrtl.sint<8>, !firrtl.sint<8>
 // INLINE-NEXT:     %21 = firrtl.subfield %16(4) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
 // INLINE-NEXT:     firrtl.connect %WriteMemory1_W0_mask, %21 : !firrtl.uint<1>, !firrtl.uint<1>
-// INLINE-NEXT:     %ReadMemory2_R0_addr, %ReadMemory2_R0_en, %ReadMemory2_R0_clk, %ReadMemory2_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory2"} : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>
+// INLINE-NEXT:     %ReadMemory2_R0_addr, %ReadMemory2_R0_en, %ReadMemory2_R0_clk, %ReadMemory2_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory2"} : in !firrtl.uint<4>, in !firrtl.uint<1>, in !firrtl.clock, out !firrtl.sint<8>
 // INLINE-NEXT:     %22 = firrtl.wire  : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
 // INLINE-NEXT:     %23 = firrtl.subfield %22(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<4>
 // INLINE-NEXT:     firrtl.connect %ReadMemory2_R0_addr, %23 : !firrtl.uint<4>, !firrtl.uint<4>
@@ -474,7 +474,7 @@ firrtl.circuit "Duplicate" {
 // INLINE-NEXT:     firrtl.connect %ReadMemory2_R0_clk, %25 : !firrtl.clock, !firrtl.clock
 // INLINE-NEXT:     %26 = firrtl.subfield %22(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.sint<8>
 // INLINE-NEXT:     firrtl.connect %26, %ReadMemory2_R0_data : !firrtl.sint<8>, !firrtl.sint<8>
-// INLINE-NEXT:     %WriteMemory2_W0_addr, %WriteMemory2_W0_en, %WriteMemory2_W0_clk, %WriteMemory2_W0_data, %WriteMemory2_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory2"} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// INLINE-NEXT:     %WriteMemory2_W0_addr, %WriteMemory2_W0_en, %WriteMemory2_W0_clk, %WriteMemory2_W0_data, %WriteMemory2_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory2"} : in !firrtl.uint<1>, in !firrtl.uint<1>, in !firrtl.clock, in !firrtl.sint<8>, in !firrtl.uint<1>
 // INLINE-NEXT:     %27 = firrtl.wire  : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
 // INLINE-NEXT:     %28 = firrtl.subfield %27(0) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
 // INLINE-NEXT:     firrtl.connect %WriteMemory2_W0_addr, %28 : !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/check-comb-cycles.mlir
+++ b/test/Dialect/FIRRTL/check-comb-cycles.mlir
@@ -10,7 +10,7 @@ module  {
     }
     firrtl.module @hasnoloops(in %clk: !firrtl.clock, in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
       %x = firrtl.wire  : !firrtl.uint<1>
-      %inner_in1, %inner_in2, %inner_out1, %inner_out2 = firrtl.instance @thru  {name = "inner"} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+      %inner_in1, %inner_in2, %inner_out1, %inner_out2 = firrtl.instance @thru  {name = "inner"} : in !firrtl.uint<1>, in !firrtl.uint<1>, out !firrtl.uint<1>, out !firrtl.uint<1>
       firrtl.connect %inner_in1, %a : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %x, %inner_out1 : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %inner_in2, %x : !firrtl.uint<1>, !firrtl.uint<1>
@@ -123,7 +123,7 @@ module  {
       %z = firrtl.wire  : !firrtl.uint<1>
       firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
       // expected-note @+1 {{this operation is part of the combinational cycle}}
-      %inner_in, %inner_out = firrtl.instance @thru  {name = "inner"} : !firrtl.uint<1>, !firrtl.uint<1>
+      %inner_in, %inner_out = firrtl.instance @thru  {name = "inner"} : in !firrtl.uint<1>, out !firrtl.uint<1>
       firrtl.connect %inner_in, %y : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %z, %inner_out : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %y, %z : !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -97,7 +97,7 @@ firrtl.circuit "Foo" {
     // CHECK: inst someInst of Simple
     // CHECK: someInst.someIn <= ui1
     // CHECK: someOut <= someInst.someOut
-    %someInst_someIn, %someInst_someOut = firrtl.instance @Simple {name = "someInst"} : !firrtl.uint<1>, !firrtl.uint<1>
+    %someInst_someIn, %someInst_someOut = firrtl.instance @Simple {name = "someInst"} : in !firrtl.uint<1>, out !firrtl.uint<1>
     firrtl.connect %someInst_someIn, %ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %someOut, %someInst_someOut : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: someOut is invalid

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -231,7 +231,7 @@ firrtl.circuit "Foo" {
   firrtl.module @Callee(in %arg0: !firrtl.uint<1>) { }
   firrtl.module @Foo() {
     // expected-error @+1 {{'firrtl.instance' op result type for "arg0" must be '!firrtl.uint<1>', but got '!firrtl.uint<2>'}}
-    %a = firrtl.instance @Callee {name = ""} : !firrtl.uint<2>
+    %a = firrtl.instance @Callee {name = ""} : in !firrtl.uint<2>
   }
 }
 
@@ -255,8 +255,18 @@ firrtl.circuit "Foo" {
   firrtl.module @Callee(in %arg0: !firrtl.uint<1>, in %arg1: !firrtl.bundle<valid: uint<1>>) { }
   firrtl.module @Foo() {
     // expected-error @+1 {{'firrtl.instance' op result type for "arg1" must be '!firrtl.bundle<valid: uint<1>>', but got '!firrtl.bundle<valid: uint<2>>'}}
-    %a:2 = firrtl.instance @Callee {name = ""}
-    : !firrtl.uint<1>, !firrtl.bundle<valid: uint<2>>
+    %a:2 = firrtl.instance @Callee {name = ""} : in !firrtl.uint<1>, in !firrtl.bundle<valid: uint<2>>
+  }
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+
+  firrtl.module @Callee(in %arg0: !firrtl.uint<1> ) { }
+  firrtl.module @Foo() {
+    // expected-error @+1 {{'firrtl.instance' op mistmatched port directions}}
+    firrtl.instance @Callee {name = ""} : out !firrtl.uint<1>
   }
 }
 

--- a/test/Dialect/FIRRTL/expand-whens-errors.mlir
+++ b/test/Dialect/FIRRTL/expand-whens-errors.mlir
@@ -26,7 +26,7 @@ firrtl.module @simple(in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
 }
 firrtl.module @CheckInitialization() {
   // expected-error @+1 {{sink "test.in" not fully initialized}}
-  %simple_out, %simple_in = firrtl.instance @simple {name = "test", portNames=["in", "out"]}: !firrtl.uint<1>, !firrtl.uint<1>
+  %simple_out, %simple_in = firrtl.instance @simple {name = "test", portNames=["in", "out"]}: in !firrtl.uint<1>, out !firrtl.uint<1>
 }
 }
 

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -368,7 +368,7 @@ firrtl.module @bundle_types(in %p : !firrtl.uint<1>, in %clock: !firrtl.clock) {
 firrtl.module @simple(in %in : !firrtl.bundle<a: uint<1>>) { }
 firrtl.module @bundle_ports() {
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-  %simple_in = firrtl.instance @simple {name = "test0"}: !firrtl.bundle<a: uint<1>>
+  %simple_in = firrtl.instance @simple {name = "test0"}: in !firrtl.bundle<a: uint<1>>
   %0 = firrtl.subfield %simple_in(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
   firrtl.connect %0, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
 }
@@ -378,10 +378,10 @@ firrtl.module @simple2(in %in : !firrtl.uint<3>) { }
 firrtl.module @as_passive(in %p : !firrtl.uint<1>) {
   %c2_ui3 = firrtl.constant 2 : !firrtl.uint<3>
   %c3_ui3 = firrtl.constant 3 : !firrtl.uint<3>
-  %simple0_in = firrtl.instance @simple2 {name = "test0"}: !firrtl.uint<3>
+  %simple0_in = firrtl.instance @simple2 {name = "test0"}: in !firrtl.uint<3>
   firrtl.connect %simple0_in, %c2_ui3 : !firrtl.uint<3>, !firrtl.uint<3>
 
-  %simple1_in = firrtl.instance @simple2 {name = "test0"}: !firrtl.uint<3>
+  %simple1_in = firrtl.instance @simple2 {name = "test0"}: in !firrtl.uint<3>
   firrtl.when %p {
     // This is the tricky part, connect the input ports together.
     firrtl.connect %simple1_in, %simple0_in : !firrtl.uint<3>, !firrtl.uint<3>

--- a/test/Dialect/FIRRTL/grand-central-errors.mlir
+++ b/test/Dialect/FIRRTL/grand-central-errors.mlir
@@ -54,7 +54,7 @@ firrtl.circuit "Foo" attributes {
          defName = "View",
          name = "sub_port",
          target = [".a"]}],
-      name = "bar"} : !firrtl.uint<1>
+      name = "bar"} : in !firrtl.uint<1>
     firrtl.connect %bar_a, %a : !firrtl.uint<1>, !firrtl.uint<1>
   }
 }

--- a/test/Dialect/FIRRTL/grand-central-taps.mlir
+++ b/test/Dialect/FIRRTL/grand-central-taps.mlir
@@ -109,7 +109,7 @@ firrtl.circuit "TestHarness" attributes {
     in %in: !firrtl.uint<1>,
     out %out: !firrtl.uint<1>
   ) {
-    %bar_clock, %bar_reset, %bar_in, %bar_out = firrtl.instance @Bar  {name = "bar"} : !firrtl.clock, !firrtl.reset, !firrtl.uint<1>, !firrtl.uint<1>
+    %bar_clock, %bar_reset, %bar_in, %bar_out = firrtl.instance @Bar  {name = "bar"} : in !firrtl.clock, in !firrtl.reset, in !firrtl.uint<1>, out !firrtl.uint<1>
     firrtl.connect %bar_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %bar_reset, %reset : !firrtl.reset, !firrtl.reset
     firrtl.connect %bar_in, %in : !firrtl.uint<1>, !firrtl.uint<1>
@@ -210,16 +210,16 @@ firrtl.circuit "TestHarness" attributes {
 
   // CHECK: firrtl.module @TestHarness
   firrtl.module @TestHarness(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
-    %foo_clock, %foo_reset, %foo_in, %foo_out = firrtl.instance @Foo {name = "foo"} : !firrtl.clock, !firrtl.reset, !firrtl.uint<1>, !firrtl.uint<1>
+    %foo_clock, %foo_reset, %foo_in, %foo_out = firrtl.instance @Foo {name = "foo"} : in !firrtl.clock, in !firrtl.reset, in !firrtl.uint<1>, out !firrtl.uint<1>
     firrtl.connect %foo_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %foo_reset, %reset : !firrtl.reset, !firrtl.uint<1>
     firrtl.connect %foo_in, %in : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %out, %foo_out : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.instance @BlackHole {name = "bigScary"}
-    %0 = firrtl.instance @ExtmoduleWithTappedPort {name = "extmoduleWithTappedPort"} : !firrtl.uint<1>
+    %0 = firrtl.instance @ExtmoduleWithTappedPort {name = "extmoduleWithTappedPort"} : out !firrtl.uint<1>
     // CHECK: firrtl.instance [[DT]] {name = "dataTap"}
-    %DataTap_7, %DataTap_6, %DataTap_5, %DataTap_4, %DataTap_3, %DataTap_2, %DataTap_1, %DataTap_0 = firrtl.instance @DataTap {name = "dataTap"} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.uint<1>
+    %DataTap_7, %DataTap_6, %DataTap_5, %DataTap_4, %DataTap_3, %DataTap_2, %DataTap_1, %DataTap_0 = firrtl.instance @DataTap {name = "dataTap"} : out !firrtl.uint<1>, out !firrtl.uint<1>, out !firrtl.uint<1>, out !firrtl.uint<1>, out !firrtl.uint<1>, out !firrtl.uint<1>, out !firrtl.clock, out !firrtl.uint<1>
     // CHECK: firrtl.instance [[MT]] {name = "memTap"}
-    %MemTap_mem_0, %MemTap_mem_1 = firrtl.instance @MemTap {name = "memTap"} : !firrtl.uint<1>, !firrtl.uint<1>
+    %MemTap_mem_0, %MemTap_mem_1 = firrtl.instance @MemTap {name = "memTap"} : out !firrtl.uint<1>, out !firrtl.uint<1>
   }
 }

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -57,7 +57,7 @@ firrtl.circuit "Test" {
     firrtl.connect %result3, %nonconstWire : !firrtl.uint<1>, !firrtl.uint<1>
 
     // Constant propagation through instance.
-    %source, %dest = firrtl.instance @PassThrough {name = "", portNames = ["source", "dest"]} : !firrtl.uint<1>, !firrtl.uint<1>
+    %source, %dest = firrtl.instance @PassThrough {name = "", portNames = ["source", "dest"]} : in !firrtl.uint<1>, out !firrtl.uint<1>
 
     // CHECK: firrtl.connect %inst_source, %c0_ui1
     firrtl.connect %source, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -198,9 +198,9 @@ firrtl.circuit "testDontTouch"  {
   // CHECK-LABEL: firrtl.module @testDontTouch
   firrtl.module @testDontTouch(in %clock: !firrtl.clock, out %a: !firrtl.uint<1>, out %a1: !firrtl.uint<1>, out %a2: !firrtl.uint<1>) {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    %blockProp1_clock, %blockProp1_a, %blockProp1_b = firrtl.instance @blockProp1  {name = "blockProp1"} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
-    %allowProp_clock, %allowProp_a, %allowProp_b = firrtl.instance @allowProp  {name = "allowProp"} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
-    %blockProp3_clock, %blockProp3_a, %blockProp3_b = firrtl.instance @blockProp3  {name = "blockProp3"} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
+    %blockProp1_clock, %blockProp1_a, %blockProp1_b = firrtl.instance @blockProp1  {name = "blockProp1"} : in !firrtl.clock, in !firrtl.uint<1>, out !firrtl.uint<1>
+    %allowProp_clock, %allowProp_a, %allowProp_b = firrtl.instance @allowProp  {name = "allowProp"} : in !firrtl.clock, in !firrtl.uint<1>, out !firrtl.uint<1>
+    %blockProp3_clock, %blockProp3_a, %blockProp3_b = firrtl.instance @blockProp3  {name = "blockProp3"} : in !firrtl.clock, in !firrtl.uint<1>, out !firrtl.uint<1>
     firrtl.connect %blockProp1_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %allowProp_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %blockProp3_clock, %clock : !firrtl.clock, !firrtl.clock
@@ -235,8 +235,8 @@ firrtl.circuit "OutPortTop" {
     }
   // CHECK-LABEL: firrtl.module @OutPortTop
     firrtl.module @OutPortTop(in %x: !firrtl.uint<1>, out %z: !firrtl.uint<1>) {
-      %c_out = firrtl.instance @OutPortChild1  {name = "c"} : !firrtl.uint<1>
-      %c_out_0 = firrtl.instance @OutPortChild2  {name = "c"} : !firrtl.uint<1>
+      %c_out = firrtl.instance @OutPortChild1  {name = "c"} : out !firrtl.uint<1>
+      %c_out_0 = firrtl.instance @OutPortChild2  {name = "c"} : out !firrtl.uint<1>
       // CHECK: %0 = firrtl.and %x, %c_out
       %0 = firrtl.and %x, %c_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
       // CHECK: %1 = firrtl.and %0, %c0_ui1
@@ -262,8 +262,8 @@ firrtl.circuit "InputPortTop"   {
   }
   firrtl.module @InputPortTop(in %x: !firrtl.uint<1>, out %z: !firrtl.uint<1>, out %z2: !firrtl.uint<1>) {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    %c_in0, %c_in1, %c_out = firrtl.instance @InputPortChild  {name = "c"} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
-    %c2_in0, %c2_in1, %c2_out = firrtl.instance @InputPortChild2  {name = "c2"} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %c_in0, %c_in1, %c_out = firrtl.instance @InputPortChild  {name = "c"} : in !firrtl.uint<1>, in !firrtl.uint<1>, out !firrtl.uint<1>
+    %c2_in0, %c2_in1, %c2_out = firrtl.instance @InputPortChild2  {name = "c2"} : in !firrtl.uint<1>, in !firrtl.uint<1>, out !firrtl.uint<1>
     firrtl.connect %z, %c_out : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %c_in0, %x : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %c_in1, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -277,7 +277,7 @@ firrtl.circuit "InstanceOut"   {
 
   // CHECK-LABEL: firrtl.module @InstanceOut
   firrtl.module @InstanceOut(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
-    %ext_a = firrtl.instance @Ext  {name = "ext"} : !firrtl.uint<1>
+    %ext_a = firrtl.instance @Ext  {name = "ext"} : in !firrtl.uint<1>
     firrtl.connect %ext_a, %a : !firrtl.uint<1>, !firrtl.uint<1>
     %w = firrtl.wire  : !firrtl.uint<1>
     // CHECK: firrtl.connect %w, %ext_a : !firrtl.uint<1>, !firrtl.uint<1>
@@ -292,7 +292,7 @@ firrtl.circuit "InstanceOut2"   {
 
   // CHECK-LABEL: firrtl.module @InstanceOut2
   firrtl.module @InstanceOut2(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
-    %ext_a = firrtl.instance @Ext  {name = "ext"} : !firrtl.uint<1>
+    %ext_a = firrtl.instance @Ext  {name = "ext"} : in !firrtl.uint<1>
     firrtl.connect %ext_a, %a : !firrtl.uint<1>, !firrtl.uint<1>
     %w = firrtl.wire  : !firrtl.uint<1>
     // CHECK: firrtl.connect %w, %ext_a : !firrtl.uint<1>, !firrtl.uint<1>
@@ -379,7 +379,7 @@ firrtl.circuit "Oscillators"   {
   firrtl.extmodule @Ext(in %a: !firrtl.uint<1>)
   // CHECK: firrtl.module @Qux
   firrtl.module @Qux(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, out %a: !firrtl.uint<1>) {
-    %ext_a = firrtl.instance @Ext  {name = "ext"} : !firrtl.uint<1>
+    %ext_a = firrtl.instance @Ext  {name = "ext"} : in !firrtl.uint<1>
     // CHECK: firrtl.reg
     %r = firrtl.reg %clock  : !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
@@ -394,19 +394,19 @@ firrtl.circuit "Oscillators"   {
     firrtl.connect %a, %ext_a : !firrtl.uint<1>, !firrtl.uint<1>
   }
   firrtl.module @Oscillators(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, out %foo_a: !firrtl.uint<1>, out %bar_a: !firrtl.uint<1>, out %baz_a: !firrtl.uint<1>, out %qux_a: !firrtl.uint<1>) {
-    %foo_clock, %foo_reset, %foo_a_0 = firrtl.instance @Foo  {name = "foo"} : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>
+    %foo_clock, %foo_reset, %foo_a_0 = firrtl.instance @Foo  {name = "foo"} : in !firrtl.clock, in !firrtl.asyncreset, out !firrtl.uint<1>
     firrtl.connect %foo_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %foo_reset, %reset : !firrtl.asyncreset, !firrtl.asyncreset
     firrtl.connect %foo_a, %foo_a_0 : !firrtl.uint<1>, !firrtl.uint<1>
-    %bar_clock, %bar_reset, %bar_a_1 = firrtl.instance @Bar  {name = "bar"} : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>
+    %bar_clock, %bar_reset, %bar_a_1 = firrtl.instance @Bar  {name = "bar"} : in !firrtl.clock, in !firrtl.asyncreset, out !firrtl.uint<1>
     firrtl.connect %bar_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %bar_reset, %reset : !firrtl.asyncreset, !firrtl.asyncreset
     firrtl.connect %bar_a, %bar_a_1 : !firrtl.uint<1>, !firrtl.uint<1>
-    %baz_clock, %baz_reset, %baz_a_2 = firrtl.instance @Baz  {name = "baz"} : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>
+    %baz_clock, %baz_reset, %baz_a_2 = firrtl.instance @Baz  {name = "baz"} : in !firrtl.clock, in !firrtl.asyncreset, out !firrtl.uint<1>
     firrtl.connect %baz_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %baz_reset, %reset : !firrtl.asyncreset, !firrtl.asyncreset
     firrtl.connect %baz_a, %baz_a_2 : !firrtl.uint<1>, !firrtl.uint<1>
-    %qux_clock, %qux_reset, %qux_a_3 = firrtl.instance @Qux  {name = "qux"} : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>
+    %qux_clock, %qux_reset, %qux_a_3 = firrtl.instance @Qux  {name = "qux"} : in !firrtl.clock, in !firrtl.asyncreset, out !firrtl.uint<1>
     firrtl.connect %qux_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %qux_reset, %reset : !firrtl.asyncreset, !firrtl.asyncreset
     firrtl.connect %qux_a, %qux_a_3 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -430,7 +430,7 @@ firrtl.circuit "rhs_sink_output_used_as_wire" {
     firrtl.connect %d, %_c : !firrtl.uint<1>, !firrtl.uint<1>
   }
   firrtl.module @rhs_sink_output_used_as_wire(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>, out %d: !firrtl.uint<1>) {
-    %bar_a, %bar_b, %bar_c, %bar_d = firrtl.instance @Bar  {name = "bar"} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %bar_a, %bar_b, %bar_c, %bar_d = firrtl.instance @Bar  {name = "bar"} : in !firrtl.uint<1>, in !firrtl.uint<1>, out !firrtl.uint<1>, out !firrtl.uint<1>
     firrtl.connect %bar_a, %a : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %bar_b, %b : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %c, %bar_c : !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/infer-resets-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-resets-errors.mlir
@@ -109,7 +109,7 @@ firrtl.circuit "top" {
   firrtl.extmodule @ext(out %out: !firrtl.bundle<foo: reset>)
   firrtl.module @top(out %out: !firrtl.reset) {
     // expected-error @+1 {{reset network never driven with concrete type}}
-    %e_out = firrtl.instance @ext  {name = "e"} : !firrtl.bundle<foo: reset>
+    %e_out = firrtl.instance @ext  {name = "e"} : out !firrtl.bundle<foo: reset>
     %0 = firrtl.subfield %e_out(0) : (!firrtl.bundle<foo: reset>) -> !firrtl.reset
     firrtl.connect %out, %0 : !firrtl.reset, !firrtl.reset
   }
@@ -204,20 +204,20 @@ firrtl.circuit "Top" {
   // expected-note @+1 {{reset domain 'otherReset' of module 'Child' declared here:}}
   firrtl.module @Child(in %clock: !firrtl.clock, in %otherReset: !firrtl.asyncreset) attributes {portAnnotations = [[],[{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]]} {
     // expected-note @+1 {{instance 'child/inst' is in reset domain rooted at 'otherReset' of module 'Child'}}
-    %inst_clock = firrtl.instance @Foo {name = "inst"} : !firrtl.clock
+    %inst_clock = firrtl.instance @Foo {name = "inst"} : in !firrtl.clock
     firrtl.connect %inst_clock, %clock : !firrtl.clock, !firrtl.clock
   }
   firrtl.module @Other(in %clock: !firrtl.clock) attributes {annotations = [{class = "sifive.enterprise.firrtl.IgnoreFullAsyncResetAnnotation"}]} {
     // expected-note @+1 {{instance 'other/inst' is in no reset domain}}
-    %inst_clock = firrtl.instance @Foo {name = "inst"} : !firrtl.clock
+    %inst_clock = firrtl.instance @Foo {name = "inst"} : in !firrtl.clock
     firrtl.connect %inst_clock, %clock : !firrtl.clock, !firrtl.clock
   }
   // expected-note @+1 {{reset domain 'reset' of module 'Top' declared here:}}
   firrtl.module @Top(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset) attributes {portAnnotations = [[],[{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]]} {
-    %child_clock, %child_otherReset = firrtl.instance @Child {name = "child"} : !firrtl.clock, !firrtl.asyncreset
-    %other_clock = firrtl.instance @Other {name = "other"} : !firrtl.clock
+    %child_clock, %child_otherReset = firrtl.instance @Child {name = "child"} : in !firrtl.clock, in !firrtl.asyncreset
+    %other_clock = firrtl.instance @Other {name = "other"} : in !firrtl.clock
     // expected-note @+1 {{instance 'foo' is in reset domain rooted at 'reset' of module 'Top'}}
-    %foo_clock = firrtl.instance @Foo {name = "foo"} : !firrtl.clock
+    %foo_clock = firrtl.instance @Foo {name = "foo"} : in !firrtl.clock
     firrtl.connect %child_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %other_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %foo_clock, %clock : !firrtl.clock, !firrtl.clock

--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -34,10 +34,10 @@ firrtl.module @MergeNetsTop(in %reset: !firrtl.asyncreset) {
   // CHECK: %localReset = firrtl.wire : !firrtl.asyncreset
   %localReset = firrtl.wire : !firrtl.reset
   firrtl.connect %localReset, %reset : !firrtl.reset, !firrtl.asyncreset
-  // CHECK: %c1_reset = firrtl.instance @MergeNetsChild1 {{.*}} : !firrtl.asyncreset
-  // CHECK: %c2_reset = firrtl.instance @MergeNetsChild2 {{.*}} : !firrtl.asyncreset
-  %c1_reset = firrtl.instance @MergeNetsChild1  {name = "c1"} : !firrtl.reset
-  %c2_reset = firrtl.instance @MergeNetsChild2  {name = "c2"} : !firrtl.reset
+  // CHECK: %c1_reset = firrtl.instance @MergeNetsChild1 {{.*}} : in !firrtl.asyncreset
+  // CHECK: %c2_reset = firrtl.instance @MergeNetsChild2 {{.*}} : in !firrtl.asyncreset
+  %c1_reset = firrtl.instance @MergeNetsChild1  {name = "c1"} : in !firrtl.reset
+  %c2_reset = firrtl.instance @MergeNetsChild2  {name = "c2"} : in !firrtl.reset
   firrtl.connect %c1_reset, %localReset : !firrtl.reset, !firrtl.reset
   firrtl.connect %c2_reset, %localReset : !firrtl.reset, !firrtl.reset
 }
@@ -70,8 +70,8 @@ firrtl.module @ModuleBoundariesChild(in %clock: !firrtl.clock, in %childReset: !
 }
 // CHECK-LABEL: firrtl.module @ModuleBoundariesTop
 firrtl.module @ModuleBoundariesTop(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %x: !firrtl.uint<8>, out %z: !firrtl.uint<8>) {
-  // CHECK: {{.*}} = firrtl.instance @ModuleBoundariesChild {{.*}} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
-  %c_clock, %c_childReset, %c_x, %c_z = firrtl.instance @ModuleBoundariesChild {name = "c"} : !firrtl.clock, !firrtl.reset, !firrtl.uint<8>, !firrtl.uint<8>
+  // CHECK: {{.*}} = firrtl.instance @ModuleBoundariesChild {{.*}} : in !firrtl.clock, in !firrtl.uint<1>, in !firrtl.uint<8>, out !firrtl.uint<8>
+  %c_clock, %c_childReset, %c_x, %c_z = firrtl.instance @ModuleBoundariesChild {name = "c"} : in !firrtl.clock, in !firrtl.reset, in !firrtl.uint<8>, out !firrtl.uint<8>
   firrtl.connect %c_clock, %clock : !firrtl.clock, !firrtl.clock
   firrtl.connect %c_childReset, %reset : !firrtl.reset, !firrtl.uint<1>
   firrtl.connect %c_x, %x : !firrtl.uint<8>, !firrtl.uint<8>
@@ -87,8 +87,8 @@ firrtl.module @MultipleModuleBoundariesChild(in %resetIn: !firrtl.reset, out %re
 }
 // CHECK-LABEL: firrtl.module @MultipleModuleBoundariesTop
 firrtl.module @MultipleModuleBoundariesTop(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %x: !firrtl.uint<8>, out %z: !firrtl.uint<8>) {
-  // CHECK: {{.*}} = firrtl.instance @MultipleModuleBoundariesChild {{.*}} : !firrtl.uint<1>, !firrtl.uint<1>
-  %c_resetIn, %c_resetOut = firrtl.instance @MultipleModuleBoundariesChild  {name = "c"} : !firrtl.reset, !firrtl.reset
+  // CHECK: {{.*}} = firrtl.instance @MultipleModuleBoundariesChild {{.*}} : in !firrtl.uint<1>, out !firrtl.uint<1>
+  %c_resetIn, %c_resetOut = firrtl.instance @MultipleModuleBoundariesChild  {name = "c"} : in !firrtl.reset, out !firrtl.reset
   firrtl.connect %c_resetIn, %reset : !firrtl.reset, !firrtl.uint<1>
   %c123_ui = firrtl.constant 123 : !firrtl.uint
   // CHECK: %r = firrtl.regreset %clock, %c_resetOut, %c123_ui : !firrtl.uint<1>, !firrtl.uint, !firrtl.uint<8>
@@ -208,16 +208,16 @@ firrtl.module @DedupDifferentlyChild2(in %clock: !firrtl.clock, in %childReset: 
 }
 // CHECK-LABEL: firrtl.module @DedupDifferentlyTop
 firrtl.module @DedupDifferentlyTop(in %clock: !firrtl.clock, in %reset1: !firrtl.uint<1>, in %reset2: !firrtl.asyncreset, in %x: !firrtl.vector<uint<8>, 2>, out %z: !firrtl.vector<uint<8>, 2>) {
-  // CHECK: {{.*}} = firrtl.instance @DedupDifferentlyChild1 {{.*}} : !firrtl.clock, !firrtl.uint<1>
-  %c1_clock, %c1_childReset, %c1_x, %c1_z = firrtl.instance @DedupDifferentlyChild1  {name = "c1"} : !firrtl.clock, !firrtl.reset, !firrtl.uint<8>, !firrtl.uint<8>
+  // CHECK: {{.*}} = firrtl.instance @DedupDifferentlyChild1 {{.*}} : in !firrtl.clock, in !firrtl.uint<1>
+  %c1_clock, %c1_childReset, %c1_x, %c1_z = firrtl.instance @DedupDifferentlyChild1  {name = "c1"} : in !firrtl.clock, in !firrtl.reset, in !firrtl.uint<8>, out !firrtl.uint<8>
   firrtl.connect %c1_clock, %clock : !firrtl.clock, !firrtl.clock
   firrtl.connect %c1_childReset, %reset1 : !firrtl.reset, !firrtl.uint<1>
   %0 = firrtl.subindex %x[0] : !firrtl.vector<uint<8>, 2>
   firrtl.connect %c1_x, %0 : !firrtl.uint<8>, !firrtl.uint<8>
   %1 = firrtl.subindex %z[0] : !firrtl.vector<uint<8>, 2>
   firrtl.connect %1, %c1_z : !firrtl.uint<8>, !firrtl.uint<8>
-  // CHECK: {{.*}} = firrtl.instance @DedupDifferentlyChild2 {{.*}} : !firrtl.clock, !firrtl.asyncreset
-  %c2_clock, %c2_childReset, %c2_x, %c2_z = firrtl.instance @DedupDifferentlyChild2  {name = "c2"} : !firrtl.clock, !firrtl.reset, !firrtl.uint<8>, !firrtl.uint<8>
+  // CHECK: {{.*}} = firrtl.instance @DedupDifferentlyChild2 {{.*}} : in !firrtl.clock, in !firrtl.asyncreset
+  %c2_clock, %c2_childReset, %c2_x, %c2_z = firrtl.instance @DedupDifferentlyChild2  {name = "c2"} : in !firrtl.clock, in !firrtl.reset, in !firrtl.uint<8>, out !firrtl.uint<8>
   firrtl.connect %c2_clock, %clock : !firrtl.clock, !firrtl.clock
   firrtl.connect %c2_childReset, %reset2 : !firrtl.reset, !firrtl.asyncreset
   %2 = firrtl.subindex %x[1] : !firrtl.vector<uint<8>, 2>
@@ -273,8 +273,8 @@ firrtl.module @InternalAndExternalChild(in %i: !firrtl.asyncreset, out %o: !firr
 }
 // CHECK-LABEL: firrtl.module @InternalAndExternalTop
 firrtl.module @InternalAndExternalTop(in %in: !firrtl.asyncreset, out %out: !firrtl.asyncreset) {
-  // CHECK: {{.*}} = firrtl.instance @InternalAndExternalChild {{.*}} : !firrtl.asyncreset, !firrtl.asyncreset
-  %c_i, %c_o = firrtl.instance @InternalAndExternalChild  {name = "c"} : !firrtl.asyncreset, !firrtl.reset
+  // CHECK: {{.*}} = firrtl.instance @InternalAndExternalChild {{.*}} : in !firrtl.asyncreset, out !firrtl.asyncreset
+  %c_i, %c_o = firrtl.instance @InternalAndExternalChild  {name = "c"} : in !firrtl.asyncreset, out !firrtl.reset
   firrtl.connect %c_i, %in : !firrtl.asyncreset, !firrtl.asyncreset
   firrtl.connect %out, %c_o : !firrtl.asyncreset, !firrtl.reset
 }
@@ -322,9 +322,9 @@ firrtl.module @InvalidValueShouldNotConnect(
 // CHECK-SAME: in %reset: !firrtl.uint<1>
 firrtl.extmodule @ShouldAdjustExtModule1(in %reset: !firrtl.reset)
 // CHECK-LABEL: firrtl.module @ShouldAdjustExtModule2
-// CHECK: %x_reset = firrtl.instance @ShouldAdjustExtModule1 {name = "x"} : !firrtl.uint<1>
+// CHECK: %x_reset = firrtl.instance @ShouldAdjustExtModule1 {name = "x"} : in !firrtl.uint<1>
 firrtl.module @ShouldAdjustExtModule2() {
-  %x_reset = firrtl.instance @ShouldAdjustExtModule1 {name = "x"} : !firrtl.reset
+  %x_reset = firrtl.instance @ShouldAdjustExtModule1 {name = "x"} : in !firrtl.reset
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   firrtl.connect %x_reset, %c1_ui1 : !firrtl.reset, !firrtl.uint<1>
 }
@@ -494,9 +494,9 @@ firrtl.circuit "ReusePorts" {
     // CHECK: firrtl.connect %badName_reset, %reset
     // CHECK: %badType_reset_0, %badType_clock, %badType_reset = firrtl.instance @BadType
     // CHECK: firrtl.connect %badType_reset_0, %reset
-    %child_clock, %child_reset = firrtl.instance @Child {name = "child"} : !firrtl.clock, !firrtl.asyncreset
-    %badName_clock, %badName_existingReset = firrtl.instance @BadName {name = "badName"} : !firrtl.clock, !firrtl.asyncreset
-    %badType_clock, %badType_reset = firrtl.instance @BadType {name = "badType"} : !firrtl.clock, !firrtl.uint<1>
+    %child_clock, %child_reset = firrtl.instance @Child {name = "child"} : in !firrtl.clock, in !firrtl.asyncreset
+    %badName_clock, %badName_existingReset = firrtl.instance @BadName {name = "badName"} : in !firrtl.clock, in !firrtl.asyncreset
+    %badType_clock, %badType_reset = firrtl.instance @BadType {name = "badType"} : in !firrtl.clock, in !firrtl.uint<1>
   }
 }
 
@@ -513,7 +513,7 @@ firrtl.circuit "FullAsyncNested" {
   }
   // CHECK-LABEL: firrtl.module @FullAsyncNestedChild
   firrtl.module @FullAsyncNestedChild(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %io_in: !firrtl.uint<8>, out %io_out: !firrtl.uint<8>) {
-    %inst_clock, %inst_reset, %inst_io_in, %inst_io_out = firrtl.instance @FullAsyncNestedDeeper  {name = "inst"} : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
+    %inst_clock, %inst_reset, %inst_io_in, %inst_io_out = firrtl.instance @FullAsyncNestedDeeper  {name = "inst"} : in !firrtl.clock, in !firrtl.asyncreset, in !firrtl.uint<8>, out !firrtl.uint<8>
     firrtl.connect %inst_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %inst_reset, %reset : !firrtl.asyncreset, !firrtl.asyncreset
     firrtl.connect %inst_io_in, %io_in : !firrtl.uint<8>, !firrtl.uint<8>
@@ -527,7 +527,7 @@ firrtl.circuit "FullAsyncNested" {
   // CHECK-LABEL: firrtl.module @FullAsyncNested
   firrtl.module @FullAsyncNested(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %io_in: !firrtl.uint<8>, out %io_out: !firrtl.uint<8>) attributes {
     portAnnotations=[[],[{class = "firrtl.transforms.DontTouchAnnotation"}, {class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}], [], []] } {
-    %inst_clock, %inst_reset, %inst_io_in, %inst_io_out = firrtl.instance @FullAsyncNestedChild  {name = "inst"} : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
+    %inst_clock, %inst_reset, %inst_io_in, %inst_io_out = firrtl.instance @FullAsyncNestedChild  {name = "inst"} : in !firrtl.clock, in !firrtl.asyncreset, in !firrtl.uint<8>, out !firrtl.uint<8>
     firrtl.connect %inst_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %inst_reset, %reset : !firrtl.asyncreset, !firrtl.asyncreset
     firrtl.connect %io_out, %inst_io_out : !firrtl.uint<8>, !firrtl.uint<8>
@@ -552,7 +552,7 @@ firrtl.circuit "FullAsyncExcluded" {
   firrtl.module @FullAsyncExcluded(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %io_in: !firrtl.uint<8>, out %io_out: !firrtl.uint<8>, in %extraReset: !firrtl.asyncreset) attributes {
      portAnnotations = [[],[],[],[],[{class = "firrtl.transforms.DontTouchAnnotation"}, {class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]]} {
     // CHECK: %inst_clock, %inst_reset, %inst_io_in, %inst_io_out = firrtl.instance @FullAsyncExcludedChild
-    %inst_clock, %inst_reset, %inst_io_in, %inst_io_out = firrtl.instance @FullAsyncExcludedChild  {name = "inst"} : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
+    %inst_clock, %inst_reset, %inst_io_in, %inst_io_out = firrtl.instance @FullAsyncExcludedChild  {name = "inst"} : in !firrtl.clock, in !firrtl.asyncreset, in !firrtl.uint<8>, out !firrtl.uint<8>
     firrtl.connect %inst_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %inst_reset, %reset : !firrtl.asyncreset, !firrtl.asyncreset
     firrtl.connect %io_out, %inst_io_out : !firrtl.uint<8>, !firrtl.uint<8>

--- a/test/Dialect/FIRRTL/infer-widths-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-widths-errors.mlir
@@ -22,7 +22,7 @@ firrtl.circuit "Foo" {
   firrtl.module @Foo(in %in: !firrtl.uint<42>, out %out: !firrtl.uint) {
     // expected-error @+2 {{extern module `Bar` has ports of uninferred width}}
     // expected-note @+1 {{Only non-extern FIRRTL modules may contain unspecified widths to be inferred automatically.}}
-    %inst_in, %inst_out = firrtl.instance @Bar {name = "inst"} : !firrtl.uint, !firrtl.uint
+    %inst_in, %inst_out = firrtl.instance @Bar {name = "inst"} : in !firrtl.uint, out !firrtl.uint
     firrtl.connect %inst_in, %in : !firrtl.uint, !firrtl.uint<42>
     firrtl.connect %out, %inst_out : !firrtl.uint, !firrtl.uint
   }

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -534,7 +534,7 @@ firrtl.circuit "Foo" {
     firrtl.connect %out, %0 : !firrtl.uint, !firrtl.uint
   }
   firrtl.module @InterModuleSimpleBar(in %in: !firrtl.uint<42>, out %out: !firrtl.uint) {
-    %inst_in, %inst_out = firrtl.instance @InterModuleSimpleFoo {name = "inst"} : !firrtl.uint, !firrtl.uint
+    %inst_in, %inst_out = firrtl.instance @InterModuleSimpleFoo {name = "inst"} : in !firrtl.uint, out !firrtl.uint
     %0 = firrtl.add %inst_out, %inst_out : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
     firrtl.connect %inst_in, %in : !firrtl.uint, !firrtl.uint<42>
     firrtl.connect %out, %0 : !firrtl.uint, !firrtl.uint
@@ -553,8 +553,8 @@ firrtl.circuit "Foo" {
     firrtl.connect %out, %0 : !firrtl.uint, !firrtl.uint
   }
   firrtl.module @InterModuleMultipleBar(in %in1: !firrtl.uint<17>, in %in2: !firrtl.uint<42>, out %out: !firrtl.uint) {
-    %inst1_in, %inst1_out = firrtl.instance @InterModuleMultipleFoo {name = "inst1"} : !firrtl.uint, !firrtl.uint
-    %inst2_in, %inst2_out = firrtl.instance @InterModuleMultipleFoo {name = "inst2"} : !firrtl.uint, !firrtl.uint
+    %inst1_in, %inst1_out = firrtl.instance @InterModuleMultipleFoo {name = "inst1"} : in !firrtl.uint, out !firrtl.uint
+    %inst2_in, %inst2_out = firrtl.instance @InterModuleMultipleFoo {name = "inst2"} : in !firrtl.uint, out !firrtl.uint
     %0 = firrtl.xor %inst1_out, %inst2_out : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
     firrtl.connect %inst1_in, %in1 : !firrtl.uint, !firrtl.uint<17>
     firrtl.connect %inst2_in, %in2 : !firrtl.uint, !firrtl.uint<42>
@@ -922,7 +922,7 @@ firrtl.circuit "Foo" {
   // CHECK-LABEL: @InterModuleGoodCycleBar
   // CHECK-SAME: out %out: !firrtl.uint<39>
   firrtl.module @InterModuleGoodCycleBar(in %in: !firrtl.uint<42>, out %out: !firrtl.uint) {
-    %inst_in, %inst_out = firrtl.instance @InterModuleGoodCycleFoo {name = "inst"} : !firrtl.uint, !firrtl.uint
+    %inst_in, %inst_out = firrtl.instance @InterModuleGoodCycleFoo {name = "inst"} : in !firrtl.uint, out !firrtl.uint
     firrtl.connect %inst_in, %in : !firrtl.uint, !firrtl.uint<42>
     firrtl.connect %inst_in, %inst_out : !firrtl.uint, !firrtl.uint
     firrtl.connect %out, %inst_out : !firrtl.uint, !firrtl.uint

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -130,7 +130,7 @@ firrtl.module @InlineMe1(in %in0: !firrtl.uint<4>, in %in1: !firrtl.uint<4>,
                    out %out0: !firrtl.uint<4>,
                    out %out1: !firrtl.uint<4>)
         attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
-  %a_in0, %a_in1, %a_out0, %a_out1 = firrtl.instance @InlineMe0 {name = "a"} : !firrtl.uint<4>, !firrtl.uint<4>, !firrtl.uint<4>, !firrtl.uint<4>
+  %a_in0, %a_in1, %a_out0, %a_out1 = firrtl.instance @InlineMe0 {name = "a"} : in !firrtl.uint<4>, in !firrtl.uint<4>, out !firrtl.uint<4>, out !firrtl.uint<4>
   firrtl.connect %a_in0, %in0 : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %a_in1, %in1 : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out0, %a_out0 : !firrtl.uint<4>, !firrtl.uint<4>
@@ -139,7 +139,7 @@ firrtl.module @InlineMe1(in %in0: !firrtl.uint<4>, in %in1: !firrtl.uint<4>,
 firrtl.module @TestConnections(in %in0: !firrtl.uint<4>, in %in1: !firrtl.uint<4>,
                    out %out0: !firrtl.uint<4>,
                    out %out1: !firrtl.uint<4>) {
-  %b_in0, %b_in1, %b_out0, %b_out1 = firrtl.instance @InlineMe1 {name = "b"} : !firrtl.uint<4>, !firrtl.uint<4>, !firrtl.uint<4>, !firrtl.uint<4>
+  %b_in0, %b_in1, %b_out0, %b_out1 = firrtl.instance @InlineMe1 {name = "b"} : in !firrtl.uint<4>, in !firrtl.uint<4>, out !firrtl.uint<4>, out !firrtl.uint<4>
   firrtl.connect %b_in0, %in0 : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %b_in1, %in1 : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out0, %b_out0 : !firrtl.uint<4>, !firrtl.uint<4>
@@ -179,7 +179,7 @@ firrtl.module @InlineMe0(in %in0: !firrtl.bundle<a: uint<4>, b flip: uint<4>>,
 }
 firrtl.module @TestBulkConnections(in %in0: !firrtl.bundle<a: uint<4>, b flip: uint<4>>,
                                    out %out0: !firrtl.bundle<a: uint<4>, b flip: uint<4>>) {
-  %i_in0, %i_out0 = firrtl.instance @InlineMe0 {name = "i"} : !firrtl.bundle<a: uint<4>, b flip: uint<4>>, !firrtl.bundle<a: uint<4>, b flip: uint<4>>
+  %i_in0, %i_out0 = firrtl.instance @InlineMe0 {name = "i"} : in !firrtl.bundle<a: uint<4>, b flip: uint<4>>, out !firrtl.bundle<a: uint<4>, b flip: uint<4>>
   firrtl.connect %i_in0, %in0 : !firrtl.bundle<a: uint<4>, b flip: uint<4>>, !firrtl.bundle<a: uint<4>, b flip: uint<4>>
   firrtl.connect %out0, %i_out0 : !firrtl.bundle<a: uint<4>, b flip: uint<4>>, !firrtl.bundle<a: uint<4>, b flip: uint<4>>
 // CHECK: %i_in0 = firrtl.wire  : !firrtl.bundle<a: uint<4>, b flip: uint<4>>
@@ -193,7 +193,7 @@ firrtl.module @TestBulkConnections(in %in0: !firrtl.bundle<a: uint<4>, b flip: u
 // Test that all operations with names are renamed.
 firrtl.circuit "renaming" {
 firrtl.module @renaming() {
-  %0, %1, %2 = firrtl.instance @declarations {name = "myinst"} : !firrtl.clock, !firrtl.uint<8>, !firrtl.asyncreset
+  %0, %1, %2 = firrtl.instance @declarations {name = "myinst"} : in !firrtl.clock, in !firrtl.uint<8>, in !firrtl.asyncreset
 }
 firrtl.module @declarations(in %clock : !firrtl.clock, in %u8 : !firrtl.uint<8>, in %reset : !firrtl.asyncreset) attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
   // CHECK: %myinst_cmem = firrtl.combmem : !firrtl.cmemory<uint<8>, 8>

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -42,8 +42,8 @@ firrtl.circuit "TopLevel" {
 
     // CHECK-NEXT: %inst_source_valid, %inst_source_ready, %inst_source_data, %inst_sink_valid, %inst_sink_ready, %inst_sink_data
     // CHECK-SAME: = firrtl.instance @Simple {name = ""} :
-    // CHECK-SAME: !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<64>
-    %sourceV, %sinkV = firrtl.instance @Simple {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+    // CHECK-SAME: in !firrtl.uint<1>, out !firrtl.uint<1>, in !firrtl.uint<64>, out !firrtl.uint<1>, in !firrtl.uint<1>, out !firrtl.uint<64>
+    %sourceV, %sinkV = firrtl.instance @Simple {name = ""} : in !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 
     // CHECK-NEXT: firrtl.connect %inst_source_valid, %source_valid
     // CHECK-NEXT: firrtl.connect %source_ready, %inst_source_ready
@@ -276,7 +276,7 @@ firrtl.circuit "TopLevel" {
     firrtl.module @mod_2(in %clock: !firrtl.clock, in %inp_a: !firrtl.bundle<inp_d: uint<14>>) {
     }
     firrtl.module @top_mod(in %clock: !firrtl.clock) {
-      %U0_clock, %U0_inp_a = firrtl.instance @mod_2 {name = "U0"} : !firrtl.clock, !firrtl.bundle<inp_d: uint<14>>
+      %U0_clock, %U0_inp_a = firrtl.instance @mod_2 {name = "U0"} : in !firrtl.clock, in !firrtl.bundle<inp_d: uint<14>>
       %0 = firrtl.invalidvalue : !firrtl.clock
       firrtl.connect %U0_clock, %0 : !firrtl.clock, !firrtl.clock
       %1 = firrtl.invalidvalue : !firrtl.bundle<inp_d: uint<14>>
@@ -287,7 +287,7 @@ firrtl.circuit "TopLevel" {
 
 //CHECK-LABEL:     firrtl.module @mod_2(in %clock: !firrtl.clock, in %inp_a_inp_d: !firrtl.uint<14>)
 //CHECK:    firrtl.module @top_mod(in %clock: !firrtl.clock)
-//CHECK-NEXT:      %U0_clock, %U0_inp_a_inp_d = firrtl.instance @mod_2 {name = "U0"} : !firrtl.clock, !firrtl.uint<14>
+//CHECK-NEXT:      %U0_clock, %U0_inp_a_inp_d = firrtl.instance @mod_2 {name = "U0"} : in !firrtl.clock, in !firrtl.uint<14>
 //CHECK-NEXT:      %invalid_clock = firrtl.invalidvalue : !firrtl.clock
 //CHECK-NEXT:      firrtl.connect %U0_clock, %invalid_clock : !firrtl.clock, !firrtl.clock
 //CHECK-NEXT:      %invalid_ui14 = firrtl.invalidvalue : !firrtl.uint<14>
@@ -406,8 +406,8 @@ firrtl.circuit "TopLevel" {
   // CHECK-LABEL: firrtl.extmodule @ExternalModule(in %source_valid: !firrtl.uint<1>, out %source_ready: !firrtl.uint<1>, in %source_data: !firrtl.uint<64>)
   firrtl.extmodule @ExternalModule(in %source: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>> )
   firrtl.module @Test() {
-    // CHECK:  %inst_source_valid, %inst_source_ready, %inst_source_data = firrtl.instance @ExternalModule  {name = ""} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<64>
-    %inst_source = firrtl.instance @ExternalModule {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+    // CHECK:  %inst_source_valid, %inst_source_ready, %inst_source_data = firrtl.instance @ExternalModule  {name = ""} : in !firrtl.uint<1>, out !firrtl.uint<1>, in !firrtl.uint<64>
+    %inst_source = firrtl.instance @ExternalModule {name = ""} : in !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
   }
 
 // Test RegResetOp lowering
@@ -482,7 +482,7 @@ firrtl.circuit "TopLevel" {
     firrtl.connect %a, %0 : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
   }
   firrtl.module @AnnotationsInstanceOp() {
-    %bar_a = firrtl.instance @Bar  {annotations = [{a = "a"}], name = "bar"} : !firrtl.vector<uint<1>, 2>
+    %bar_a = firrtl.instance @Bar  {annotations = [{a = "a"}], name = "bar"} : out !firrtl.vector<uint<1>, 2>
   }
   // CHECK: firrtl.instance
   // CHECK-SAME: annotations = [{a = "a"}]
@@ -778,7 +778,7 @@ firrtl.circuit "TopLevel" {
   firrtl.module @PartialConnectLHSFlip(in %a: !firrtl.bundle<b: bundle<c flip: uint<2>>>) { }
    // CHECK-LABEL: firrtl.module @FooFlipType
   firrtl.module @FooFlipType(in %a: !firrtl.bundle<b: bundle<c flip: uint<2>>>) {
-    %mgmt_a = firrtl.instance @PartialConnectLHSFlip  {name = "mgmt"} : !firrtl.bundle<b: bundle<c flip: uint<2>>>
+    %mgmt_a = firrtl.instance @PartialConnectLHSFlip  {name = "mgmt"} : in !firrtl.bundle<b: bundle<c flip: uint<2>>>
     %0 = firrtl.subfield %mgmt_a(0) : (!firrtl.bundle<b: bundle<c flip: uint<2>>>) -> !firrtl.bundle<c flip: uint<2>>
     %1 = firrtl.subfield %0(0) : (!firrtl.bundle<c flip: uint<2>>) -> !firrtl.uint<2>
     // CHECK: firrtl.connect %a_b_c, %mgmt_a_b_c : !firrtl.uint<2>, !firrtl.uint<2>
@@ -825,7 +825,7 @@ firrtl.circuit "TopLevel" {
   // CHECK-COUNT-2: firrtl.annotations = [{b}]
   // CHECK-NOT: firrtl.annotations = [{a}]
   firrtl.module @Port(in %a: !firrtl.vector<uint<1>, 2> {firrtl.annotations = [{b}]}) {
-    %sub_a = firrtl.instance @Sub1  {name = "sub", portNames = ["a"]} : !firrtl.vector<uint<1>, 2>
+    %sub_a = firrtl.instance @Sub1  {name = "sub"} : in !firrtl.vector<uint<1>, 2>
     firrtl.connect %sub_a, %a : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
   }
 
@@ -860,7 +860,7 @@ firrtl.circuit "TopLevel" {
     // CHECK: %[[a_b:.+]] = firrtl.wire
     %a = firrtl.wire  : !firrtl.bundle<b: uint<1>>
     // CHECK-NEXT: %bar_a = firrtl.instance @Bar
-    %bar_a = firrtl.instance @Bar2  {name = "bar"} : !firrtl.uint<2>
+    %bar_a = firrtl.instance @Bar2  {name = "bar"} : in !firrtl.uint<2>
     // CHECK-NEXT: %invalid_ui2 = firrtl.invalidvalue
     %invalid_ui2 = firrtl.invalidvalue : !firrtl.uint<2>
     // CHECK-NEXT: firrtl.connect %bar_a, %invalid_ui2
@@ -1063,7 +1063,7 @@ firrtl.circuit "TopLevel" {
   // CHECK-LABEL firrtl.module @Foo3
   firrtl.module @Foo3() {
     // CHECK: [{one}], [{two}], []
-    %bar_a, %bar_b = firrtl.instance @Bar3  {name = "bar", portAnnotations = [[{one}], [#firrtl.subAnno<fieldID = 1, {two}>]]} : !firrtl.uint<1>, !firrtl.bundle<baz: uint<1>, qux: uint<1>>
+    %bar_a, %bar_b = firrtl.instance @Bar3  {name = "bar", portAnnotations = [[{one}], [#firrtl.subAnno<fieldID = 1, {two}>]]} : in !firrtl.uint<1>, out !firrtl.bundle<baz: uint<1>, qux: uint<1>>
   }
 
 
@@ -1129,7 +1129,7 @@ firrtl.module @bofa(out %auto: !firrtl.bundle<io_out: bundle<foo: bundle<bar: an
 firrtl.extmodule @is1436_BAR(out %io: !firrtl.bundle<llWakeup flip: vector<uint<1>, 1>>)
 // CHECK-LABEL: firrtl.module @is1436_FOO
 firrtl.module @is1436_FOO() {
-  %thing_io = firrtl.instance @is1436_BAR  {name = "thing"} : !firrtl.bundle<llWakeup flip: vector<uint<1>, 1>>
+  %thing_io = firrtl.instance @is1436_BAR  {name = "thing"} : out !firrtl.bundle<llWakeup flip: vector<uint<1>, 1>>
   %0 = firrtl.subfield %thing_io(0) : (!firrtl.bundle<llWakeup flip: vector<uint<1>, 1>>) -> !firrtl.vector<uint<1>, 1>
   %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
   %1 = firrtl.subaccess %0[%c0_ui2] : !firrtl.vector<uint<1>, 1>, !firrtl.uint<2>

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -308,7 +308,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     reg _t_2622 : UInt<4>, clock with :
       reset => (UInt<1>("h0"), _t_2622)
 
-    ; CHECK: %xyz_in = firrtl.instance @circuit {name = "xyz"} : !firrtl.uint<80>
+    ; CHECK: %xyz_in = firrtl.instance @circuit {name = "xyz"} : in !firrtl.uint<80>
     inst xyz of circuit
     ; CHECK: firrtl.connect %xyz_in, %i8 : !firrtl.uint<80>, !firrtl.uint<8>
     xyz.in <= i8

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -129,6 +129,10 @@ firrtl.module @TestInvalidAttr() {
   }
 }
 
+// Test round-tripping the direction attribute.
+// CHECK: firrtl.directions<in, out, in>
+firrtl.module @PortDirectionsAttr() attributes {circt.test = #firrtl.directions<in, out, in>} { }
+
 // CHECK-LABEL: @VerbatimExpr
 firrtl.module @VerbatimExpr() {
   // CHECK: %[[TMP:.+]] = firrtl.verbatim.expr "FOO" : () -> !firrtl.uint<42>

--- a/test/circt-reduce/trivial.mlir
+++ b/test/circt-reduce/trivial.mlir
@@ -11,8 +11,8 @@ firrtl.circuit "Foo" {
   }
   // CHECK: firrtl.module @FooFoo
   firrtl.module @FooFoo(in %x: !firrtl.uint<1>, out %y: !firrtl.uint<1>) {
-    %x0_x, %x0_y = firrtl.instance @FooFooFoo {name = "x0"} : !firrtl.uint<1>, !firrtl.uint<1>
-    %x1_x, %x1_y = firrtl.instance @FooFooBar {name = "x1"} : !firrtl.uint<1>, !firrtl.uint<1>
+    %x0_x, %x0_y = firrtl.instance @FooFooFoo {name = "x0"} : in !firrtl.uint<1>, out !firrtl.uint<1>
+    %x1_x, %x1_y = firrtl.instance @FooFooBar {name = "x1"} : in !firrtl.uint<1>, out !firrtl.uint<1>
     firrtl.connect %x0_x, %x : !firrtl.uint<1>, !firrtl.uint<1>
     // Skip %x1_x to trigger a "sink not fully initialized" warning
     firrtl.connect %y, %x0_y : !firrtl.uint<1>, !firrtl.uint<1>
@@ -23,8 +23,8 @@ firrtl.circuit "Foo" {
   }
   // CHECK: firrtl.extmodule @Foo
   firrtl.module @Foo(in %x: !firrtl.uint<1>, out %y: !firrtl.uint<1>) {
-    %x0_x, %x0_y = firrtl.instance @FooFoo {name = "x0"} : !firrtl.uint<1>, !firrtl.uint<1>
-    %x1_x, %x1_y = firrtl.instance @FooBar {name = "x1"} : !firrtl.uint<1>, !firrtl.uint<1>
+    %x0_x, %x0_y = firrtl.instance @FooFoo {name = "x0"} : in !firrtl.uint<1>, out !firrtl.uint<1>
+    %x1_x, %x1_y = firrtl.instance @FooBar {name = "x1"} : in !firrtl.uint<1>, out !firrtl.uint<1>
     firrtl.connect %x0_x, %x : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %x1_x, %x : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %y, %x0_y : !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -42,24 +42,24 @@ circuit test_mod : %[[{"a": "a"}]]
     c <= flipFlop.a_q
 
 ; MLIR-LABEL: firrtl.module @test_mod(in %clock: !firrtl.clock, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<2>, out %c: !firrtl.uint<1>) {
-; MLIR-NEXT:    %cat_a, %cat_b, %cat_c, %cat_d = firrtl.instance @Cat  {name = "cat"} : !firrtl.uint<2>, !firrtl.uint<2>, !firrtl.uint<2>, !firrtl.uint<6>
+; MLIR-NEXT:    %cat_a, %cat_b, %cat_c, %cat_d = firrtl.instance @Cat {name = "cat"} : in !firrtl.uint<2>, in !firrtl.uint<2>, in !firrtl.uint<2>, out !firrtl.uint<6>
 ; MLIR-NEXT:    firrtl.connect %cat_a, %b : !firrtl.uint<2>, !firrtl.uint<2>
 ; MLIR-NEXT:    firrtl.connect %cat_b, %b : !firrtl.uint<2>, !firrtl.uint<2>
 ; MLIR-NEXT:    firrtl.connect %cat_c, %b : !firrtl.uint<2>, !firrtl.uint<2>
-; MLIR-NEXT:    %implicitTrunc_inp_1, %implicitTrunc_inp_2, %implicitTrunc_out1, %implicitTrunc_out2 = firrtl.instance @ImplicitTrunc  {name = "implicitTrunc"} : !firrtl.uint<1>, !firrtl.sint<5>, !firrtl.sint<3>, !firrtl.sint<3>
+; MLIR-NEXT:    %implicitTrunc_inp_1, %implicitTrunc_inp_2, %implicitTrunc_out1, %implicitTrunc_out2 = firrtl.instance @ImplicitTrunc {name = "implicitTrunc"} : in !firrtl.uint<1>, in !firrtl.sint<5>, out !firrtl.sint<3>, out !firrtl.sint<3>
 ; MLIR-NEXT:    firrtl.connect %implicitTrunc_inp_1, %a : !firrtl.uint<1>, !firrtl.uint<1>
 ; MLIR-NEXT:    %0 = firrtl.asSInt %cat_d : (!firrtl.uint<6>) -> !firrtl.sint<6>
 ; MLIR-NEXT:    %1 = firrtl.bits %0 4 to 0 : (!firrtl.sint<6>) -> !firrtl.uint<5>
 ; MLIR-NEXT:    %2 = firrtl.asSInt %1 : (!firrtl.uint<5>) -> !firrtl.sint<5>
 ; MLIR-NEXT:    firrtl.connect %implicitTrunc_inp_2, %2 : !firrtl.sint<5>, !firrtl.sint<5>
-; MLIR-NEXT:    %prettifyExample_inp_1, %prettifyExample_inp_2, %prettifyExample_inp_3, %prettifyExample_out1, %prettifyExample_out2 = firrtl.instance @PrettifyExample  {name = "prettifyExample"} : !firrtl.uint<5>, !firrtl.uint<5>, !firrtl.uint<5>, !firrtl.uint<10>, !firrtl.uint<10>
+; MLIR-NEXT:    %prettifyExample_inp_1, %prettifyExample_inp_2, %prettifyExample_inp_3, %prettifyExample_out1, %prettifyExample_out2 = firrtl.instance @PrettifyExample {name = "prettifyExample"} : in !firrtl.uint<5>, in !firrtl.uint<5>, in !firrtl.uint<5>, out !firrtl.uint<10>, out !firrtl.uint<10>
 ; MLIR-NEXT:    %3 = firrtl.bits %cat_d 4 to 0 : (!firrtl.uint<6>) -> !firrtl.uint<5>
 ; MLIR-NEXT:    firrtl.connect %prettifyExample_inp_1, %3 : !firrtl.uint<5>, !firrtl.uint<5>
 ; MLIR-NEXT:    %4 = firrtl.bits %cat_d 4 to 0 : (!firrtl.uint<6>) -> !firrtl.uint<5>
 ; MLIR-NEXT:    firrtl.connect %prettifyExample_inp_2, %4 : !firrtl.uint<5>, !firrtl.uint<5>
 ; MLIR-NEXT:    %5 = firrtl.bits %cat_d 4 to 0 : (!firrtl.uint<6>) -> !firrtl.uint<5>
 ; MLIR-NEXT:    firrtl.connect %prettifyExample_inp_3, %5 : !firrtl.uint<5>, !firrtl.uint<5>
-; MLIR-NEXT:    %flipFlop_clock, %flipFlop_a_d, %flipFlop_a_q = firrtl.instance @FlipFlop  {name = "flipFlop"} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
+; MLIR-NEXT:    %flipFlop_clock, %flipFlop_a_d, %flipFlop_a_q = firrtl.instance @FlipFlop {name = "flipFlop"} : in !firrtl.clock, in !firrtl.uint<1>, out !firrtl.uint<1>
 ; MLIR-NEXT:    firrtl.connect %flipFlop_clock, %clock : !firrtl.clock, !firrtl.clock
 ; MLIR-NEXT:    firrtl.connect %flipFlop_a_d, %a : !firrtl.uint<1>, !firrtl.uint<1>
 ; MLIR-NEXT:    firrtl.connect %c, %flipFlop_a_q : !firrtl.uint<1>, !firrtl.uint<1>


### PR DESCRIPTION
This PR depends on #1731 , only review the last commit.

This duplicates the port direction information from the module operation
on to the instance op.  This will let us query information about port
direction without looking up the related module.  This can be used to
speed up connect flow verification, and a few passes.

The port direction is printed in the ir interleaved with the port types,
similar to modules:
```mlir
    %result = firrtl.instance @bar740 {name = "fpga"} : in !firrtl.analog<1>
```