### PR TITLE
[Calyx] Rename ComponentPortInfo to PortInfo.

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxInterfaces.td
+++ b/include/circt/Dialect/Calyx/CalyxInterfaces.td
@@ -56,22 +56,22 @@ def CellOpInterface : OpInterface<"CellInterface"> {
       }]
     >,
     InterfaceMethod<
-      "This returns the ComponentPortInfo associated with all of the ports of a cell.",
-      "SmallVector<circt::calyx::ComponentPortInfo>",
+      "This returns the PortInfo associated with all of the ports of a cell.",
+      "SmallVector<circt::calyx::PortInfo>",
       "portInfos",
       (ins),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
-        SmallVector<circt::calyx::ComponentPortInfo> info;
+        SmallVector<circt::calyx::PortInfo> info;
         for (auto it : llvm::zip($_op->getResults(), $_op.portDirections(),$_op.portNames()))
-          info.push_back(ComponentPortInfo{StringAttr::get($_op->getContext(),
+          info.push_back(PortInfo{StringAttr::get($_op->getContext(),
             std::get<2>(it)), std::get<0>(it).getType(), std::get<1>(it)});
         return info;
     }]
     >,
     InterfaceMethod<
-      "This returns the ComponentPortInfo associated with the port of a cell.",
-      "circt::calyx::ComponentPortInfo",
+      "This returns the PortInfo associated with the port of a cell.",
+      "circt::calyx::PortInfo",
       "portInfo",
       (ins "Value":$port),
       /*methodBody=*/"",

--- a/include/circt/Dialect/Calyx/CalyxOps.h
+++ b/include/circt/Dialect/Calyx/CalyxOps.h
@@ -61,7 +61,7 @@ SmallVector<Direction> unpackAttribute(Operation *component);
 SmallVector<Direction> genInOutDirections(size_t nIns, size_t nOuts);
 } // namespace direction
 
-/// This holds the name and type that describes the component's ports.
+/// This holds information about the port to either a component or cell.
 struct PortInfo {
   StringAttr name;
   Type type;

--- a/include/circt/Dialect/Calyx/CalyxOps.h
+++ b/include/circt/Dialect/Calyx/CalyxOps.h
@@ -62,7 +62,7 @@ SmallVector<Direction> genInOutDirections(size_t nIns, size_t nOuts);
 } // namespace direction
 
 /// This holds the name and type that describes the component's ports.
-struct ComponentPortInfo {
+struct PortInfo {
   StringAttr name;
   Type type;
   Direction direction;
@@ -72,10 +72,10 @@ struct ComponentPortInfo {
 LogicalResult verifyCell(Operation *op);
 
 /// Returns port information about a given component.
-SmallVector<ComponentPortInfo> getComponentPortInfo(Operation *op);
+SmallVector<PortInfo> getComponentPortInfo(Operation *op);
 
 /// Returns port information for the block argument provided.
-ComponentPortInfo getComponentPortInfo(BlockArgument arg);
+PortInfo getComponentPortInfo(BlockArgument arg);
 
 } // namespace calyx
 } // namespace circt

--- a/include/circt/Dialect/Calyx/CalyxOps.h
+++ b/include/circt/Dialect/Calyx/CalyxOps.h
@@ -71,11 +71,8 @@ struct PortInfo {
 /// A helper function to verify each operation with the Cell trait.
 LogicalResult verifyCell(Operation *op);
 
-/// Returns port information about a given component.
-SmallVector<PortInfo> getComponentPortInfo(Operation *op);
-
 /// Returns port information for the block argument provided.
-PortInfo getComponentPortInfo(BlockArgument arg);
+PortInfo getPortInfo(BlockArgument arg);
 
 } // namespace calyx
 } // namespace circt

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -104,6 +104,9 @@ def ComponentOp : CalyxOp<"component", [
       /// Returns the body of a Calyx component.
       Block *getBody() { return &getOperation()->getRegion(0).front(); }
 
+      /// Returns the port information for this component.
+      ArrayRef<PortInfo> getPortInfo();
+
       /// Returns the WiresOp of a Calyx Component.
       WiresOp getWiresOp();
 

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -107,6 +107,12 @@ def ComponentOp : CalyxOp<"component", [
       /// Returns the port information for this component.
       SmallVector<PortInfo> getPortInfo();
 
+      /// Returns the input port information for this component.
+      SmallVector<PortInfo> getInputPortInfo();
+
+      /// Returns the input port information for this component.
+      SmallVector<PortInfo> getOutputPortInfo();
+
       /// Returns the WiresOp of a Calyx Component.
       WiresOp getWiresOp();
 

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -105,7 +105,7 @@ def ComponentOp : CalyxOp<"component", [
       Block *getBody() { return &getOperation()->getRegion(0).front(); }
 
       /// Returns the port information for this component.
-      ArrayRef<PortInfo> getPortInfo();
+      SmallVector<PortInfo> getPortInfo();
 
       /// Returns the WiresOp of a Calyx Component.
       WiresOp getWiresOp();

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -86,7 +86,7 @@ def ComponentOp : CalyxOp<"component", [
   let regions = (region SizedRegion<1>: $body);
 
   let builders = [
-    OpBuilder<(ins "StringAttr":$name, "ArrayRef<ComponentPortInfo>":$ports)>
+    OpBuilder<(ins "StringAttr":$name, "ArrayRef<PortInfo>":$ports)>
   ];
 
   let extraClassDeclaration = [{

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -121,7 +121,7 @@ struct Emitter {
 
   // Component emission
   void emitComponent(ComponentOp op);
-  void emitComponentPorts(ArrayRef<ComponentPortInfo> ports);
+  void emitComponentPorts(ArrayRef<PortInfo> ports);
 
   // Instance emission
   void emitInstance(InstanceOp op);
@@ -221,7 +221,7 @@ private:
   void emitValue(Value value, bool isIndented) {
     if (auto blockArg = value.dyn_cast<BlockArgument>()) {
       // Emit component block argument.
-      StringAttr portName = getComponentPortInfo(blockArg).name;
+      StringAttr portName = getPortInfo(blockArg).name;
       (isIndented ? indent() : os) << portName.getValue();
       return;
     }
@@ -337,7 +337,7 @@ void Emitter::emitComponent(ComponentOp op) {
   indent() << "component " << op.getName();
 
   // Emit the ports.
-  auto ports = getComponentPortInfo(op);
+  auto ports = getPortInfo(op);
   emitComponentPorts(ports);
   os << space() << LBraceEndL();
   addIndent();
@@ -374,8 +374,8 @@ void Emitter::emitComponent(ComponentOp op) {
 }
 
 /// Emit the ports of a component.
-void Emitter::emitComponentPorts(ArrayRef<ComponentPortInfo> ports) {
-  std::vector<ComponentPortInfo> inPorts, outPorts;
+void Emitter::emitComponentPorts(ArrayRef<PortInfo> ports) {
+  std::vector<PortInfo> inPorts, outPorts;
   for (auto &&port : ports) {
     if (port.direction == Direction::Input)
       inPorts.push_back(port);

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -121,7 +121,7 @@ struct Emitter {
 
   // Component emission
   void emitComponent(ComponentOp op);
-  void emitComponentPorts(ArrayRef<PortInfo> ports);
+  void emitComponentPorts(ComponentOp op);
 
   // Instance emission
   void emitInstance(InstanceOp op);
@@ -337,7 +337,7 @@ void Emitter::emitComponent(ComponentOp op) {
   indent() << "component " << op.getName();
 
   // Emit the ports.
-  emitComponentPorts(op.getPortInfo());
+  emitComponentPorts(op);
   os << space() << LBraceEndL();
   addIndent();
   WiresOp wires;
@@ -373,15 +373,7 @@ void Emitter::emitComponent(ComponentOp op) {
 }
 
 /// Emit the ports of a component.
-void Emitter::emitComponentPorts(ArrayRef<PortInfo> ports) {
-  std::vector<PortInfo> inPorts, outPorts;
-  for (const PortInfo &port : ports) {
-    if (port.direction == Direction::Input)
-      inPorts.push_back(port);
-    else
-      outPorts.push_back(port);
-  }
-
+void Emitter::emitComponentPorts(ComponentOp op) {
   // To avoid the native compiler adding each of the required ports twice,
   // add the @<port-name> attribute here. This is a quick-fix solution.
   // Eventually we want to add attributes directly to component arguments.
@@ -414,9 +406,9 @@ void Emitter::emitComponentPorts(ArrayRef<PortInfo> ports) {
     }
     os << RParen();
   };
-  emitPorts(inPorts);
+  emitPorts(op.getInputPortInfo());
   os << arrow();
-  emitPorts(outPorts);
+  emitPorts(op.getOutputPortInfo());
 }
 
 void Emitter::emitInstance(InstanceOp op) {

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -221,7 +221,7 @@ private:
   void emitValue(Value value, bool isIndented) {
     if (auto blockArg = value.dyn_cast<BlockArgument>()) {
       // Emit component block argument.
-      StringAttr portName = getComponentPortInfo(blockArg).name;
+      StringAttr portName = getPortInfo(blockArg).name;
       (isIndented ? indent() : os) << portName.getValue();
       return;
     }
@@ -337,8 +337,7 @@ void Emitter::emitComponent(ComponentOp op) {
   indent() << "component " << op.getName();
 
   // Emit the ports.
-  auto ports = getComponentPortInfo(op);
-  emitComponentPorts(ports);
+  emitComponentPorts(op.getPortInfo());
   os << space() << LBraceEndL();
   addIndent();
   WiresOp wires;
@@ -376,7 +375,7 @@ void Emitter::emitComponent(ComponentOp op) {
 /// Emit the ports of a component.
 void Emitter::emitComponentPorts(ArrayRef<PortInfo> ports) {
   std::vector<PortInfo> inPorts, outPorts;
-  for (auto &&port : ports) {
+  for (const PortInfo &port : ports) {
     if (port.direction == Direction::Input)
       inPorts.push_back(port);
     else

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -221,7 +221,7 @@ private:
   void emitValue(Value value, bool isIndented) {
     if (auto blockArg = value.dyn_cast<BlockArgument>()) {
       // Emit component block argument.
-      StringAttr portName = getPortInfo(blockArg).name;
+      StringAttr portName = getComponentPortInfo(blockArg).name;
       (isIndented ? indent() : os) << portName.getValue();
       return;
     }
@@ -337,7 +337,7 @@ void Emitter::emitComponent(ComponentOp op) {
   indent() << "component " << op.getName();
 
   // Emit the ports.
-  auto ports = getPortInfo(op);
+  auto ports = getComponentPortInfo(op);
   emitComponentPorts(ports);
   os << space() << LBraceEndL();
   addIndent();


### PR DESCRIPTION
With the introduction of the `CellInterface`, port information is needed for more than just components.

Closes #1733.