### PR TITLE
[HW] Implement SymbolUserOpInterface for HW's IntanceOp

### DIFF
--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -278,6 +278,7 @@ def HWModuleGeneratedOp : HWOp<"module.generated",
 }
 
 def InstanceOp : HWOp<"instance", [HasParent<"HWModuleOp">, Symbol,
+        DeclareOpInterfaceMethods<SymbolUserOpInterface>,
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
   let summary = "Create an instance of a module";
   let description = [{
@@ -326,8 +327,6 @@ def InstanceOp : HWOp<"instance", [HasParent<"HWModuleOp">, Symbol,
     $instanceName (`sym` $sym_name^)? $moduleName `(` $inputs `)` attr-dict
       `:` functional-type($inputs, results)
   }];
-
-  let verifier = "return ::verifyInstanceOp(*this);";
 }
 
 def OutputOp : HWOp<"output", [Terminator, HasParent<"HWModuleOp">,

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -725,18 +725,18 @@ static LogicalResult verifyInstanceOpTypes(InstanceOp op,
   return success();
 }
 
-static LogicalResult verifyInstanceOp(InstanceOp op) {
-  auto referencedModule = op.getReferencedModule();
+LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  auto *referencedModule =
+      symbolTable.lookupNearestSymbolFrom(*this, moduleNameAttr());
   if (referencedModule == nullptr)
-    return op.emitError("Cannot find module definition '")
-           << op.moduleName() << "'";
+    return emitError("Cannot find module definition '") << moduleName() << "'";
 
-  // If the referenced module is internal, check that input and result types are
-  // consistent with the referenced module.
   if (!isa<HWModuleOp>(referencedModule))
     return success();
 
-  return verifyInstanceOpTypes(op, referencedModule);
+  // If the referenced module is internal, check that input and result types are
+  // consistent with the referenced module.
+  return verifyInstanceOpTypes(*this, referencedModule);
 }
 
 StringAttr InstanceOp::getResultName(size_t idx,


### PR DESCRIPTION
This speeds up verification by using a prebuilt symbol table to look up
the referenced module instead of a linear walk of the IR.  A similar
change was recently made to the FIRRTL InstanceOp in 438ffeb0.