### PR TITLE
[FIRRTL] Rename Directions enum to In and Out

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -21,11 +21,11 @@ namespace firrtl {
 
 class FIRRTLType;
 
-enum class Direction { Input = 0, Output };
+enum class Direction { In, Out };
 
 template <typename T>
 T &operator<<(T &os, const Direction &dir) {
-  return os << (dir == Direction::Input ? "input" : "output");
+  return os << (dir == Direction::In ? "input" : "output");
 }
 
 namespace direction {
@@ -62,7 +62,7 @@ struct ModulePortInfo {
   bool isOutput() {
     auto flags = type.getRecursiveTypeProperties();
     return flags.isPassive && !flags.containsAnalog &&
-           direction == Direction::Output;
+           direction == Direction::Out;
   }
 
   /// Return true if this is a simple input-only port.  If you want the
@@ -70,7 +70,7 @@ struct ModulePortInfo {
   bool isInput() {
     auto flags = type.getRecursiveTypeProperties();
     return flags.isPassive && !flags.containsAnalog &&
-           direction == Direction::Input;
+           direction == Direction::In;
   }
 
   /// Return true if this is an inout port.  This will be true if the port

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -400,7 +400,7 @@ static FModuleOp createTopModuleOp(handshake::FuncOp funcOp, unsigned numClocks,
       funcOp.emitError("Unsupported data type. Supported data types: integer "
                        "(signed, unsigned, signless), index, none.");
 
-    ports.push_back({portName, bundlePortType, Direction::Input, arg.getLoc()});
+    ports.push_back({portName, bundlePortType, Direction::In, arg.getLoc()});
     ++argIndex;
   }
 
@@ -415,26 +415,24 @@ static FModuleOp createTopModuleOp(handshake::FuncOp funcOp, unsigned numClocks,
       funcOp.emitError("Unsupported data type. Supported data types: integer "
                        "(signed, unsigned, signless), index, none.");
 
-    ports.push_back({portName, bundlePortType, Direction::Output, funcLoc});
+    ports.push_back({portName, bundlePortType, Direction::Out, funcLoc});
     ++argIndex;
   }
 
   // Add clock and reset signals.
   if (numClocks == 1) {
     ports.push_back({rewriter.getStringAttr("clock"),
-                     rewriter.getType<ClockType>(), Direction::Input, funcLoc});
+                     rewriter.getType<ClockType>(), Direction::In, funcLoc});
     ports.push_back({rewriter.getStringAttr("reset"),
-                     rewriter.getType<UIntType>(1), Direction::Input, funcLoc});
+                     rewriter.getType<UIntType>(1), Direction::In, funcLoc});
   } else if (numClocks > 1) {
     for (unsigned i = 0; i < numClocks; ++i) {
       auto clockName = "clock" + std::to_string(i);
       auto resetName = "reset" + std::to_string(i);
       ports.push_back({rewriter.getStringAttr(clockName),
-                       rewriter.getType<ClockType>(), Direction::Input,
-                       funcLoc});
+                       rewriter.getType<ClockType>(), Direction::In, funcLoc});
       ports.push_back({rewriter.getStringAttr(resetName),
-                       rewriter.getType<UIntType>(1), Direction::Input,
-                       funcLoc});
+                       rewriter.getType<UIntType>(1), Direction::In, funcLoc});
     }
   }
 
@@ -503,7 +501,7 @@ static FModuleOp createSubModuleOp(FModuleOp topModuleOp, Operation *oldOp,
       oldOp->emitError("Unsupported data type. Supported data types: integer "
                        "(signed, unsigned, signless), index, none.");
 
-    ports.push_back({portName, bundlePortType, Direction::Input, loc});
+    ports.push_back({portName, bundlePortType, Direction::In, loc});
     ++argIndex;
   }
 
@@ -516,16 +514,16 @@ static FModuleOp createSubModuleOp(FModuleOp topModuleOp, Operation *oldOp,
       oldOp->emitError("Unsupported data type. Supported data types: integer "
                        "(signed, unsigned, signless), index, none.");
 
-    ports.push_back({portName, bundlePortType, Direction::Output, loc});
+    ports.push_back({portName, bundlePortType, Direction::Out, loc});
     ++argIndex;
   }
 
   // Add clock and reset signals.
   if (hasClock) {
     ports.push_back({rewriter.getStringAttr("clock"),
-                     rewriter.getType<ClockType>(), Direction::Input, loc});
+                     rewriter.getType<ClockType>(), Direction::In, loc});
     ports.push_back({rewriter.getStringAttr("reset"),
-                     rewriter.getType<UIntType>(1), Direction::Input, loc});
+                     rewriter.getType<UIntType>(1), Direction::In, loc});
   }
 
   return rewriter.create<FModuleOp>(

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -277,7 +277,7 @@ void Emitter::emitModulePorts(ArrayRef<ModulePortInfo> ports,
                               Block::BlockArgListType arguments) {
   for (unsigned i = 0, e = ports.size(); i < e; ++i) {
     const auto &port = ports[i];
-    indent() << (port.direction == Direction::Input ? "input " : "output ");
+    indent() << (port.direction == Direction::In ? "input " : "output ");
     if (!arguments.empty())
       addValueName(arguments[i], port.name);
     os << port.name.getValue() << " : ";

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -105,7 +105,7 @@ Flow firrtl::foldFlow(Value val, Flow accumulatedFlow) {
     auto direction = (Direction)cast<FModuleLike>(op)
                          .getPortDirections()
                          .getValue()[blockArg.getArgNumber()];
-    if (direction == Direction::Output)
+    if (direction == Direction::Out)
       return swap();
     return accumulatedFlow;
   }
@@ -126,7 +126,7 @@ Flow firrtl::foldFlow(Value val, Flow accumulatedFlow) {
         for (auto arg : llvm::enumerate(inst.getResults()))
           if (arg.value() == val) {
             if (inst.getReferencedModule().getPortDirection(arg.index()) ==
-                Direction::Output)
+                Direction::Out)
               return accumulatedFlow;
             else
               return swap();
@@ -2637,7 +2637,7 @@ IntegerAttr direction::packAttribute(ArrayRef<Direction> directions,
   // Pack the array of directions into an APInt.  Input is zero, output is one.
   APInt portDirections(size, 0);
   for (size_t i = 0, e = directions.size(); i != e; ++i)
-    if (directions[i] == Direction::Output)
+    if (directions[i] == Direction::Out)
       portDirections.setBit(i);
 
   return IntegerAttr::get(IntegerType::get(ctx, size), portDirections);

--- a/lib/Dialect/FIRRTL/Transforms/BlackBoxMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackBoxMemory.cpp
@@ -122,9 +122,9 @@ getBlackBoxPortsForMemOp(MemOp op, ArrayRef<MemOp::NamedPort> memPorts,
     for (auto bundleElement : type.cast<BundleType>().getElements()) {
       auto name = (prefix + bundleElement.name.getValue()).str();
       auto type = bundleElement.type;
-      auto direction = Direction::Input;
+      auto direction = Direction::In;
       if (bundleElement.isFlip)
-        direction = Direction::Output;
+        direction = Direction::Out;
       extPorts.push_back(
           {builder.getStringAttr(name), type, direction, op.getLoc()});
     }
@@ -195,7 +195,7 @@ createWrapperModule(MemOp op, ArrayRef<MemOp::NamedPort> memPorts,
   for (size_t i = 0, e = memPorts.size(); i != e; ++i) {
     auto name = op.getPortName(i);
     auto type = op.getPortType(i);
-    modPorts.push_back({name, type, Direction::Input, op.getLoc()});
+    modPorts.push_back({name, type, Direction::In, op.getLoc()});
   }
   auto moduleOp = builder.create<FModuleOp>(
       op.getLoc(), builder.getStringAttr(memName), modPorts);

--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -170,7 +170,7 @@ public:
     // coverage.
     auto ref = op.getReferencedModule();
     for (auto result : llvm::enumerate(op.results()))
-      if (ref.getPortDirection(result.index()) == Direction::Output)
+      if (ref.getPortDirection(result.index()) == Direction::Out)
         declareSinks(result.value(), Flow::Source);
       else
         declareSinks(result.value(), Flow::Sink);
@@ -422,7 +422,7 @@ private:
 mlir::FailureOr<bool> ModuleVisitor::run(FModuleOp module) {
   // Track any results (flipped arguments) of the module for init coverage.
   for (auto it : llvm::enumerate(module.getArguments())) {
-    auto flow = module.getPortDirection(it.index()) == Direction::Input
+    auto flow = module.getPortDirection(it.index()) == Direction::In
                     ? Flow::Source
                     : Flow::Sink;
     declareSinks(it.value(), flow);

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -442,7 +442,7 @@ void IMConstPropPass::markInstanceOp(InstanceOp instance) {
          ++resultNo) {
       auto portVal = instance.getResult(resultNo);
       // If this is an input to the extmodule, we can ignore it.
-      if (extModule.getPortDirection(resultNo) == Direction::Input)
+      if (extModule.getPortDirection(resultNo) == Direction::In)
         continue;
 
       // Otherwise this is a result from it or an inout, mark it as overdefined.
@@ -462,7 +462,7 @@ void IMConstPropPass::markInstanceOp(InstanceOp instance) {
     auto instancePortVal = instance.getResult(resultNo);
     // If this is an input to the instance, it will
     // get handled when any connects to it are processed.
-    if (fModule.getPortDirection(resultNo) == Direction::Input)
+    if (fModule.getPortDirection(resultNo) == Direction::In)
       continue;
     // We only support simple values so far.
     if (!instancePortVal.getType().cast<FIRRTLType>().isGround()) {

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -652,7 +652,7 @@ void InferResetsPass::traceResets(InstanceOp inst) {
     auto dir = direction::get(dirs.getValue()[it.index()]);
     Value dstPort = module.getArgument(it.index());
     Value srcPort = it.value();
-    if (dir == Direction::Output)
+    if (dir == Direction::Out)
       std::swap(dstPort, srcPort);
     traceResets(dstPort, srcPort, it.value().getLoc());
   }
@@ -1364,8 +1364,8 @@ LogicalResult InferResetsPass::implementAsyncReset(FModuleOp module,
   Value actualReset = domain.existingValue;
   if (domain.newPortName) {
     ModulePortInfo portInfo{domain.newPortName,
-                            AsyncResetType::get(&getContext()),
-                            Direction::Input, domain.reset.getLoc()};
+                            AsyncResetType::get(&getContext()), Direction::In,
+                            domain.reset.getLoc()};
     module.insertPorts({{0, portInfo}});
     actualReset = module.getArgument(0);
     LLVM_DEBUG(llvm::dbgs()


### PR DESCRIPTION
This switches the Direction enum cases from `Input` and `Output` to `In`
and `Out`, which matches the text we print in the IR.  This was
suggested in a review here:
https://github.com/llvm/circt/pull/1731#discussion_r703565808