### PR TITLE
Bump LLVM for Canonicalizer Perf. Regression Fix

### DIFF
--- a/test/Dialect/HW/canonicalization.mlir
+++ b/test/Dialect/HW/canonicalization.mlir
@@ -79,8 +79,8 @@ hw.module @mul_cstfold(%arg0: i7) -> (i7) {
 }
 
 // CHECK-LABEL: hw.module @div_cstfold(%arg0: i7) -> (i7, i7, i7, i7) {
-// CHECK-NEXT:    %c2_i7 = hw.constant 2 : i7
 // CHECK-NEXT:    %c-3_i7 = hw.constant -3 : i7
+// CHECK-NEXT:    %c2_i7 = hw.constant 2 : i7
 // CHECK-NEXT:    hw.output %c2_i7, %arg0, %c-3_i7, %arg0 : i7, i7, i7, i7
 hw.module @div_cstfold(%arg0: i7) -> (i7, i7, i7, i7) {
   %c1_i7 = hw.constant 1 : i7


### PR DESCRIPTION
Fixes #1700.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>