### PR TITLE
[Seq] Make `CompRegOp` name optional

### DIFF
--- a/include/circt/Dialect/Seq/Seq.td
+++ b/include/circt/Dialect/Seq/Seq.td
@@ -46,7 +46,8 @@ def CompRegOp : SeqOp<"compreg",
   let description = "See the Seq dialect rationale for a longer description";
 
   let arguments = (ins AnyType:$input, I1:$clk,
-    Optional<I1>:$reset, Optional<AnyType>:$resetValue, StrAttr:$name);
+    Optional<I1>:$reset, Optional<AnyType>:$resetValue,
+    OptionalAttr<StrAttr>:$name);
   let results = (outs AnyType:$data);
 
   let printer = "return ::print$cppClass(p, *this);";

--- a/integration_test/Bindings/Python/dialects/seq.py
+++ b/integration_test/Bindings/Python/dialects/seq.py
@@ -44,14 +44,14 @@ with Context() as ctx, Location.unknown():
               module.clk,
               reset=module.rstn,
               reset_value=custom_reset)
-      # CHECK: seq.compreg {{.+}} {name = "FuBar"}
+      # CHECK: %FuBar = seq.compreg {{.+}}
       seq.reg(reg_input, module.clk, name="FuBar")
 
-      # CHECK: seq.compreg %[[INPUT_VAL]], %clk {name = "reg1"}
+      # CHECK: %reg1 = seq.compreg %[[INPUT_VAL]], %clk
       reg1 = seq.CompRegOp.create(i32, clk=module.clk, name="reg1")
       connect(reg1.input, reg_input)
 
-      # CHECK: seq.compreg %[[INPUT_VAL]], %clk {name = "reg2"}
+      # CHECK: %reg2 = seq.compreg %[[INPUT_VAL]], %clk
       reg2 = seq.CompRegOp.create(i32, name="reg2")
       connect(reg2.input, reg_input)
       connect(reg2.clk, module.clk)
@@ -70,7 +70,7 @@ with Context() as ctx, Location.unknown():
   # CHECK-LABEL: === Verilog ===
   print("=== Verilog ===")
 
-  pm = PassManager.parse("lower-seq-to-sv")
+  pm = PassManager.parse("lower-seq-to-sv,hw-legalize-names")
   pm.run(m)
   # CHECK: always @(posedge clk)
   # CHECK: my_reg <= {{.+}}

--- a/lib/Dialect/Seq/SeqOps.cpp
+++ b/lib/Dialect/Seq/SeqOps.cpp
@@ -54,9 +54,9 @@ ParseResult parseCompRegOp(OpAsmParser &parser, OperationState &result) {
     // If there is no explicit name attribute, get it from the SSA result name.
     // If numeric, just use an empty name.
     auto resultName = parser.getResultName(0).first;
-    if (!resultName.empty() && isdigit(resultName[0]))
-      resultName = "";
-    result.addAttribute("name", parser.getBuilder().getStringAttr(resultName));
+    if (!resultName.empty() && !isdigit(resultName[0]))
+      result.addAttribute("name",
+                          parser.getBuilder().getStringAttr(resultName));
   }
 
   result.addTypes({ty});
@@ -74,9 +74,7 @@ static void printCompRegOp(::mlir::OpAsmPrinter &p, CompRegOp reg) {
 
   SmallVector<StringRef> elidedAttrs;
   // Determine if 'name' can be elided.
-  if (reg.name().empty()) {
-    elidedAttrs.push_back("name");
-  } else {
+  if (reg.name()) {
     SmallString<32> resultNameStr;
     llvm::raw_svector_ostream tmpStream(resultNameStr);
     p.printOperand(reg.data(), tmpStream);
@@ -93,8 +91,8 @@ static void printCompRegOp(::mlir::OpAsmPrinter &p, CompRegOp reg) {
 /// attribute.
 void CompRegOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   // If the wire has an optional 'name' attribute, use it.
-  if (!name().empty())
-    setNameFn(getResult(), name());
+  if (auto n = name())
+    setNameFn(getResult(), *n);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Seq/SeqPasses.cpp
+++ b/lib/Dialect/Seq/SeqPasses.cpp
@@ -42,8 +42,11 @@ public:
                   ConversionPatternRewriter &rewriter) const final {
     Location loc = reg.getLoc();
 
-    auto svReg = rewriter.create<sv::RegOp>(loc, reg.getResult().getType(),
-                                            reg.nameAttr());
+    StringAttr name = reg.nameAttr();
+    if (!name)
+      name = rewriter.getStringAttr("_compreg");
+    auto svReg =
+        rewriter.create<sv::RegOp>(loc, reg.getResult().getType(), name);
     DictionaryAttr regAttrs = reg->getAttrDictionary();
     if (!regAttrs.empty())
       svReg->setAttrs(regAttrs);

--- a/test/Dialect/Seq/basic.mlir
+++ b/test/Dialect/Seq/basic.mlir
@@ -33,7 +33,7 @@ hw.module @top(%clk: i1, %rst: i1, %i: i32, %s: !hw.struct<foo: i32>) {
   // SV: }(syncreset : posedge %rst)  {
   // SV:   sv.passign %foo, [[REGST]] : !hw.struct<foo: i32>
   // SV: }
-  // SV: [[REG4:%.+]] = sv.reg  : !hw.inout<struct<foo: i32>>
+  // SV: [[REG4:%.+]] = sv.reg {name = "_compreg"} : !hw.inout<struct<foo: i32>>
   // SV: sv.alwaysff(posedge %clk)  {
   // SV:   sv.passign [[REG4]], %s : !hw.struct<foo: i32>
   // SV: }


### PR DESCRIPTION
- Allow `seq.compreg` to be unnamed.
- Fixed the python integration test

I didn't realize that `sv.reg` required a name or that `OptionalAttr<>` existed.