### PR TITLE
[MSFT] Introduce `InstanceOp`

### DIFF
--- a/include/circt/Dialect/MSFT/MSFT.td
+++ b/include/circt/Dialect/MSFT/MSFT.td
@@ -15,6 +15,7 @@
 
 include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/IR/OpAsmInterface.td"
 include "mlir/Pass/PassBase.td"
 
 def MSFTDialect : Dialect {

--- a/include/circt/Dialect/MSFT/MSFTOps.h
+++ b/include/circt/Dialect/MSFT/MSFTOps.h
@@ -1,0 +1,24 @@
+//===- MSFTOps.h - Microsoft dialect operations -----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains the MSFT dialect custom operations.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_MSFT_MSFTOPS_H
+#define CIRCT_DIALECT_MSFT_MSFTOPS_H
+
+#include "circt/Dialect/MSFT/MSFTDialect.h"
+#include "circt/Support/LLVM.h"
+
+#include "mlir/IR/BuiltinAttributes.h"
+
+#define GET_OP_CLASSES
+#include "circt/Dialect/MSFT/MSFT.h.inc"
+
+#endif // CIRCT_DIALECT_MSFT_MSFTATTRIBUTES_H

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -9,3 +9,30 @@
 // Base class for the operation in this dialect.
 class MSFTOp<string mnemonic, list<OpTrait> traits = []> :
     Op<MSFTDialect, mnemonic, traits>;
+
+def InstanceOp : MSFTOp<"instance", [
+        DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]> ]> {
+  let summary = "Create an instance of a module";
+
+  let arguments = (ins StrAttr:$instanceName,
+                       FlatSymbolRefAttr:$moduleName,
+                       Variadic<AnyType>:$inputs,
+                       OptionalAttr<DictionaryAttr>:$parameters);
+  let results = (outs Variadic<AnyType>);
+
+  let extraClassDeclaration = [{
+    // Return the name of the specified result or empty string if it cannot be
+    // determined.
+    StringAttr getResultName(size_t i);
+
+    /// Lookup the module or extmodule for the symbol.  This returns null on
+    /// invalid IR.
+    Operation *getReferencedModule();
+  }];
+
+  /// sym keyword for optional symbol simplifies parsing
+  let assemblyFormat = [{
+    $instanceName $moduleName `(` $inputs `)` attr-dict
+      `:` functional-type($inputs, results)
+  }];
+}

--- a/lib/Dialect/MSFT/CMakeLists.txt
+++ b/lib/Dialect/MSFT/CMakeLists.txt
@@ -9,6 +9,7 @@
 add_circt_dialect_library(CIRCTMSFT
   MSFTAttributes.cpp
   MSFTDialect.cpp
+  MSFTOps.cpp
   MSFTGenerator.cpp
   DeviceDB.cpp
 

--- a/lib/Dialect/MSFT/MSFTDialect.cpp
+++ b/lib/Dialect/MSFT/MSFTDialect.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/MSFT/MSFTDialect.h"
+#include "circt/Dialect/MSFT/MSFTOps.h"
 
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -23,7 +24,13 @@ using namespace msft;
 // Dialect specification.
 //===----------------------------------------------------------------------===//
 
-void MSFTDialect::initialize() { registerAttributes(); }
+void MSFTDialect::initialize() {
+  addOperations<
+#define GET_OP_LIST
+#include "circt/Dialect/MSFT/MSFT.cpp.inc"
+      >();
+  registerAttributes();
+}
 
 /// Registered hook to materialize a single constant operation from a given
 /// attribute value with the desired resultant type. This method should use

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -1,0 +1,60 @@
+//===- MSFTOps.cpp - Implement MSFT dialect operations --------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the MSFT dialect operations.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/MSFT/MSFTOps.h"
+#include "circt/Dialect/HW/HWOps.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace circt;
+using namespace msft;
+
+/// Lookup the module or extmodule for the symbol.  This returns null on
+/// invalid IR.
+Operation *InstanceOp::getReferencedModule() {
+  auto topLevelModuleOp = (*this)->getParentOfType<ModuleOp>();
+  if (!topLevelModuleOp)
+    return nullptr;
+
+  return topLevelModuleOp.lookupSymbol(moduleName());
+}
+
+StringAttr InstanceOp::getResultName(size_t idx) {
+  auto *module = getReferencedModule();
+  if (!module)
+    return {};
+
+  return hw::getModuleResultNameAttr(module, idx);
+}
+
+/// Suggest a name for each result value based on the saved result names
+/// attribute.
+void InstanceOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  // Provide default names for instance results.
+  std::string name = instanceName().str() + ".";
+  size_t baseNameLen = name.size();
+
+  for (size_t i = 0, e = getNumResults(); i != e; ++i) {
+    name.resize(baseNameLen);
+    StringAttr resNameAttr = getResultName(i);
+    if (resNameAttr)
+      name += resNameAttr.getValue().str();
+    else
+      name += std::to_string(i);
+    setNameFn(getResult(i), name);
+  }
+}
+
+#define GET_OP_CLASSES
+#include "circt/Dialect/MSFT/MSFT.cpp.inc"

--- a/test/Dialect/MSFT/module_instance.mlir
+++ b/test/Dialect/MSFT/module_instance.mlir
@@ -1,0 +1,9 @@
+// RUN: circt-opt %s -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
+
+hw.module.extern @fooMod ()
+
+// CHECK-LABEL: hw.module @top
+hw.module @top () {
+  msft.instance "foo" @fooMod () : () -> ()
+  // CHECK: msft.instance "foo" @fooMod() : () -> ()
+}

--- a/test/Dialect/MSFT/module_instance.mlir
+++ b/test/Dialect/MSFT/module_instance.mlir
@@ -1,9 +1,9 @@
 // RUN: circt-opt %s -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
 
-hw.module.extern @fooMod ()
+hw.module.extern @fooMod () -> (%x: i32)
 
 // CHECK-LABEL: hw.module @top
 hw.module @top () {
-  msft.instance "foo" @fooMod () : () -> ()
-  // CHECK: msft.instance "foo" @fooMod() : () -> ()
+  msft.instance "foo" @fooMod () : () -> (i32)
+  // CHECK: %foo.x = msft.instance "foo" @fooMod() : () -> i32
 }


### PR DESCRIPTION
`msft.instance` is intended to be like `hw.instance` but with headroom for MSFT-specific additions. It will lower to `hw.instance`. This just creates the op.

Step one of #1755 .