### PR TITLE
[StaticLogic] Add new PipelineWhile operation.

### DIFF
--- a/include/circt/Dialect/StaticLogic/StaticLogic.td
+++ b/include/circt/Dialect/StaticLogic/StaticLogic.td
@@ -72,4 +72,165 @@ def ReturnOp : Op<StaticLogic_Dialect, "return", [Terminator]> {
   let arguments = (ins Variadic<AnyType>: $operands);
 }
 
+def PipelineWhileOp : Op<StaticLogic_Dialect, "pipeline.while", []> {
+  let summary = "StaticLogic dialect pipeline while-loop.";
+  let description = [{
+    The `staticlogic.pipeline.while` operation represents a statically scheduled
+    pipeline stucture that executes while a condition is true. For more details,
+    see: https://llvm.discourse.group/t/rfc-representing-pipelined-loops/4171.
+
+    This is the top-level operation representing a high-level pipeline. It is
+    not isolated from above, but could be if this is helpful. A pipeline
+    contains two regions: `condition` and `stages`.
+
+    The pipeline may accept an optional `iter_args`, similar to the SCF dialect,
+    for representing loop-carried values like induction variables or reductions.
+    When the pipeline starts execution, the registers indicated as `iter_args`
+    by `staticlogic.pipeline.terminator` should be initialized to the initial
+    values specified in the `iter_args` section here. The `iter_args` relate to
+    the initiation interval of the loop. The maximum distance in stages between
+    where an `iter_arg` is used and where that `iter_arg` is registered must be
+    less than the loop's initiation interval. For example, with II=1, each
+    `iter_arg` must be used and registered in the same stage.
+
+    The single-block `condition` region dictates the condition under which the
+    pipeline should execute. It has a `staticlogic.register` terminator, and the
+    pipeline initiates new iterations while the registered value is `true : i1`.
+    It may access SSA values dominating the pipeline, as well as `iter_args`,
+    which are block arguments. The body of the block may only contain
+    "combinational" operations, which are currently defined to be simple
+    arithmetic, comparisons, and selects from the `Standard` dialect.
+
+    The single-block `stages` region wraps `staticlogic.pipeline.stage`
+    operations. It has a `staticlogic.pipeline.terminator` terminator, which can
+    both return results from the pipeline and register `iter_args`. Stages may
+    access SSA values dominating the pipeline, as well as `iter_args`, which are
+    block arguments.
+  }];
+
+  let arguments = (ins
+    Variadic<AnyType>:$iterArgs
+  );
+
+  let results = (outs
+    Variadic<AnyType>:$results
+  );
+
+  let regions = (region
+    SizedRegion<1>:$condition,
+    SizedRegion<1>:$stages
+  );
+
+  let parser = [{
+    return parse$cppClass(parser, result);
+  }];
+
+  let printer = [{
+    print$cppClass(p, *this);
+  }];
+
+  let verifier = [{
+    return ::verify$cppClass(*this);
+  }];
+}
+
+def PipelineStageOp : Op<StaticLogic_Dialect, "pipeline.stage",
+    [HasParent<"PipelineWhileOp">]> {
+  let summary = "StaticLogic dialect pipeline stage.";
+  let description = [{
+    This operation has a single-block region which dictates the operations that
+    may occur concurrently.
+
+    It may have an optional `when` predicate, which supports conditional
+    execution for each stage. This is in addition to the `condition` region that
+    controls the execution of the whole pipeline. A stage with a `when`
+    predicate should only execute when the predicate is `true : i1`, and push a
+    bubble through the pipeline otherwise.
+
+    It has a `staticlogic.register` terminator, which passes the concurrently
+    computed values forward to the next stage.
+
+    Any stage may access `iter_args`. If a stage accesses an `iter_arg` after
+    the stage in which it is defined, it is up to lowering passes to preserve
+    this value until the last stage that needs it.
+
+    Other than `iter_args`, stages may only access SSA values dominating the
+    pipeline or SSA values computed by a previous stage. This ensures the stages
+    capture the coarse-grained schedule of the pipeline and how values feed
+    forward and backward.
+  }];
+
+  let arguments = (ins
+    Optional<I1>:$when
+  );
+
+  let results = (outs
+    Variadic<AnyType>:$results
+  );
+
+  let regions = (region
+    SizedRegion<1>:$body
+  );
+
+  let assemblyFormat = [{
+    (`when` $when^)? $body (`:` type($results)^)? attr-dict
+  }];
+}
+
+def PipelineRegisterOp : Op<StaticLogic_Dialect, "pipeline.register",
+    [ParentOneOf<["PipelineWhileOp", "PipelineStageOp"]>, Terminator]> {
+  let summary = "StaticLogic dialect pipeline register.";
+  let description = [{
+    The `staticlogic.pipeline.register` terminates a pipeline stage and
+    "registers" the values specified as operands. These values become the
+    results of the stage.
+  }];
+
+  let arguments = (ins
+    Variadic<AnyType>:$operands
+  );
+
+  let assemblyFormat = [{
+    $operands (`:` type($operands)^)? attr-dict
+  }];
+
+  let verifier = [{
+    return ::verify$cppClass(*this);
+  }];
+}
+
+def PipelineTerminatorOp : Op<StaticLogic_Dialect, "pipeline.terminator",
+    [HasParent<"PipelineWhileOp">, Terminator, AttrSizedOperandSegments]> {
+  let summary = "StaticLogic dialect pipeline terminator.";
+  let description = [{
+    The `staticlogic.pipeline.terminator` operation represents the terminator of
+    a `staticlogic.pipeline.while`.
+
+    The `results` section accepts a variadic list of values which become the
+    pipeline’s return values. These must be results of a stage, and their types
+    must match the pipeline's return types. The results need not be defined in
+    the final stage, and it is up to lowering passes to preserve these values
+    until the final stage is complete.
+
+    The `iter_args` section accepts a variadic list of values which become the
+    next iteration’s `iter_args`. These may be the results of any stage, and
+    their types must match the pipeline's `iter_args` types.
+  }];
+
+  let arguments = (ins
+    Variadic<AnyType>:$iter_args,
+    Variadic<AnyType>:$results
+  );
+
+  let assemblyFormat = [{
+    `iter_args` `(` $iter_args `)` `,`
+    `results` `(` $results `)` `:`
+    functional-type($iter_args, $results) attr-dict
+  }];
+
+  let verifier = [{
+    return ::verify$cppClass(*this);
+  }];
+}
+
 #endif // STATICLOGIC_OPS

--- a/lib/Dialect/StaticLogic/StaticLogicOps.cpp
+++ b/lib/Dialect/StaticLogic/StaticLogicOps.cpp
@@ -11,12 +11,193 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/StaticLogic/StaticLogic.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/FunctionImplementation.h"
 
+using namespace mlir;
 using namespace circt;
 using namespace circt::staticlogic;
 
 #include "circt/Dialect/StaticLogic/StaticLogicDialect.cpp.inc"
+
+//===----------------------------------------------------------------------===//
+// PipelineWhileOp
+//===----------------------------------------------------------------------===//
+
+static ParseResult parsePipelineWhileOp(OpAsmParser &parser,
+                                        OperationState &result) {
+  // Parse iter_args assignment list.
+  SmallVector<OpAsmParser::OperandType> regionArgs, operands;
+  if (succeeded(parser.parseOptionalKeyword("iter_args"))) {
+    if (parser.parseAssignmentList(regionArgs, operands))
+      return failure();
+  }
+
+  // Parse function type from iter_args to results.
+  FunctionType type;
+  if (parser.parseColon() || parser.parseType(type))
+    return failure();
+
+  // Function result type is the pipeline result type.
+  result.addTypes(type.getResults());
+
+  // Resolve iter_args operands.
+  for (auto [operand, type] : llvm::zip(operands, type.getInputs()))
+    if (parser.resolveOperand(operand, type, result.operands))
+      return failure();
+
+  // Parse condition region.
+  Region *condition = result.addRegion();
+  parser.parseRegion(*condition, regionArgs, type.getInputs());
+
+  // Parse stages region.
+  if (parser.parseKeyword("do"))
+    return failure();
+  Region *stages = result.addRegion();
+  parser.parseRegion(*stages, regionArgs, type.getInputs());
+
+  return success();
+}
+
+static void printPipelineWhileOp(OpAsmPrinter &p, PipelineWhileOp op) {
+  // Print iter_args assignment list.
+  p << " iter_args(";
+  llvm::interleaveComma(
+      llvm::zip(op.stages().getArguments(), op.iterArgs()), p,
+      [&](auto it) { p << std::get<0>(it) << " = " << std::get<1>(it); });
+  p << ") : ";
+
+  // Print function type from iter_args to results.
+  auto type = FunctionType::get(op.getContext(), op.stages().getArgumentTypes(),
+                                op.getResultTypes());
+  p.printType(type);
+
+  // Print condition region.
+  p.printRegion(op.condition(), /*printEntryBlockArgs=*/false);
+  p << " do";
+
+  // Print stages region.
+  p.printRegion(op.stages(), /*printEntryBlockArgs=*/false);
+}
+
+static LogicalResult verifyPipelineWhileOp(PipelineWhileOp op) {
+  // Verify the condition block is "combinational" based on an allowlist of
+  // Standard ops.
+  Block &conditionBlock = op.condition().front();
+  Operation *nonCombinational;
+  WalkResult conditionWalk = conditionBlock.walk([&](Operation *op) {
+    if (isa<StaticLogicDialect>(op->getDialect()))
+      return WalkResult::advance();
+
+    if (!isa<AddIOp, AndOp, BitcastOp, CmpIOp, ConstantOp, IndexCastOp, MulIOp,
+             OrOp, SelectOp, ShiftLeftOp, SignExtendIOp, SignedCeilDivIOp,
+             SignedDivIOp, SignedFloorDivIOp, SignedRemIOp, SignedShiftRightOp,
+             SubIOp, TruncateIOp, UnsignedDivIOp, UnsignedRemIOp,
+             UnsignedShiftRightOp, XOrOp, ZeroExtendIOp>(op)) {
+      nonCombinational = op;
+      return WalkResult::interrupt();
+    }
+
+    return WalkResult::advance();
+  });
+
+  if (conditionWalk.wasInterrupted())
+    return op.emitOpError("condition must have a combinational body, found ")
+           << *nonCombinational;
+
+  // Verify the condition block terminates with a value of type i1.
+  TypeRange conditionResults =
+      conditionBlock.getTerminator()->getOperandTypes();
+  if (conditionResults.size() != 1)
+    return op.emitOpError(
+               "condition must terminate with a single result, found ")
+           << conditionResults;
+
+  if (conditionResults.front() != IntegerType::get(op.getContext(), 1))
+    return op.emitOpError("condition must terminate with an i1 result, found ")
+           << conditionResults.front();
+
+  // Verify the stages block contains at least one stage and a terminator.
+  Block &stagesBlock = op.stages().front();
+  if (stagesBlock.getOperations().size() < 2)
+    return op.emitOpError("stages must contain at least one stage");
+
+  // Verify the stages block contains only `staticlogic.pipeline.stage` and
+  // `staticlogic.pipeline.terminator` ops.
+  for (Operation &inner : stagesBlock)
+    if (!isa<PipelineStageOp, PipelineTerminatorOp>(inner))
+      return op.emitOpError(
+                 "stages may only contain 'staticlogic.pipeline.stage' or "
+                 "'staticlogic.pipeline.terminator' ops, found ")
+             << inner;
+
+  // TODO: once there is an II attribute, verify that the II is satisfied by the
+  // definitions and uses of `iter_args`.
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// PipelineRegisterOp
+//===----------------------------------------------------------------------===//
+
+static LogicalResult verifyPipelineRegisterOp(PipelineRegisterOp op) {
+  PipelineStageOp stage = op->getParentOfType<PipelineStageOp>();
+
+  // If this doesn't terminate a stage, it is terminating the condition.
+  if (stage == nullptr)
+    return success();
+
+  // Verify stage terminates with the same types as the result types.
+  TypeRange registerTypes = op.getOperandTypes();
+  TypeRange resultTypes = stage.getResultTypes();
+  if (registerTypes != resultTypes)
+    return op.emitOpError("operand types (")
+           << registerTypes << ") must match result types (" << resultTypes
+           << ")";
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// PipelineTerminatorOp
+//===----------------------------------------------------------------------===//
+
+static LogicalResult verifyPipelineTerminatorOp(PipelineTerminatorOp op) {
+  PipelineWhileOp pipeline = op->getParentOfType<PipelineWhileOp>();
+
+  // Verify pipeline terminates with the same `iter_args` types as the pipeline.
+  auto iterArgs = op.iter_args();
+  TypeRange terminatorArgTypes = iterArgs.getTypes();
+  TypeRange pipelineArgTypes = pipeline.iterArgs().getTypes();
+  if (terminatorArgTypes != pipelineArgTypes)
+    return op.emitOpError("'iter_args' types (")
+           << terminatorArgTypes << ") must match pipeline 'iter_args' types ("
+           << pipelineArgTypes << ")";
+
+  // Verify `iter_args` are defined by a pipeline stage.
+  for (auto iterArg : iterArgs)
+    if (iterArg.getDefiningOp<PipelineStageOp>() == nullptr)
+      return op.emitOpError(
+          "'iter_args' must be defined by a 'staticlogic.pipeline.stage'");
+
+  // Verify pipeline terminates with the same result types as the pipeline.
+  auto results = op.results();
+  TypeRange terminatorResultTypes = results.getTypes();
+  TypeRange pipelineResultTypes = pipeline.getResultTypes();
+  if (terminatorResultTypes != pipelineResultTypes)
+    return op.emitOpError("'results' types (")
+           << terminatorResultTypes << ") must match pipeline result types ("
+           << pipelineResultTypes << ")";
+
+  // Verify `results` are defined by a pipeline stage.
+  for (auto result : results)
+    if (result.getDefiningOp<PipelineStageOp>() == nullptr)
+      return op.emitOpError(
+          "'results' must be defined by a 'staticlogic.pipeline.stage'");
+
+  return success();
+}
 
 #define GET_OP_CLASSES
 #include "circt/Dialect/StaticLogic/StaticLogic.cpp.inc"

--- a/test/Dialect/StaticLogic/errors.mlir
+++ b/test/Dialect/StaticLogic/errors.mlir
@@ -1,0 +1,158 @@
+// RUN: circt-opt %s -split-input-file -verify-diagnostics
+
+func @combinational_condition() {
+  %c0_i32 = constant 0 : i32
+  %0 = memref.alloc() : memref<8xi32>
+  // expected-error @+1 {{'staticlogic.pipeline.while' op condition must have a combinational body, found %1 = memref.load %0[%c0] : memref<8xi32>}}
+  staticlogic.pipeline.while iter_args(%arg0 = %c0_i32) : (i32) -> () {
+    %c0 = constant 0 : index
+    %1 = memref.load %0[%c0] : memref<8xi32>
+    %2 = cmpi ult, %1, %arg0 : i32
+    staticlogic.pipeline.register %2 : i1
+  } do {
+    staticlogic.pipeline.stage {
+      staticlogic.pipeline.register
+    }
+    staticlogic.pipeline.terminator iter_args(), results() : () -> ()
+  }
+  return
+}
+
+// -----
+
+func @single_condition() {
+  %false = constant 0 : i1
+  // expected-error @+1 {{'staticlogic.pipeline.while' op condition must terminate with a single result, found 'i1', 'i1'}}
+  staticlogic.pipeline.while iter_args(%arg0 = %false) : (i1) -> () {
+    staticlogic.pipeline.register %arg0, %arg0 : i1, i1
+  } do {
+    staticlogic.pipeline.stage {
+      staticlogic.pipeline.register
+    }
+    staticlogic.pipeline.terminator iter_args(), results() : () -> ()
+  }
+  return
+}
+
+// -----
+
+func @boolean_condition() {
+  %c0_i32 = constant 0 : i32
+  // expected-error @+1 {{'staticlogic.pipeline.while' op condition must terminate with an i1 result, found 'i32'}}
+  staticlogic.pipeline.while iter_args(%arg0 = %c0_i32) : (i32) -> () {
+    staticlogic.pipeline.register %arg0 : i32
+  } do {
+    staticlogic.pipeline.stage {
+      staticlogic.pipeline.register
+    }
+    staticlogic.pipeline.terminator iter_args(), results() : () -> ()
+  }
+  return
+}
+
+// -----
+
+func @only_stages() {
+  %false = constant 0 : i1
+  // expected-error @+1 {{'staticlogic.pipeline.while' op stages must contain at least one stage}}
+  staticlogic.pipeline.while iter_args(%arg0 = %false) : (i1) -> () {
+    staticlogic.pipeline.register %arg0 : i1
+  } do {
+    staticlogic.pipeline.terminator iter_args(), results() : () -> ()
+  }
+  return
+}
+
+// -----
+
+func @only_stages() {
+  %false = constant 0 : i1
+  // expected-error @+1 {{'staticlogic.pipeline.while' op stages may only contain 'staticlogic.pipeline.stage' or 'staticlogic.pipeline.terminator' ops, found %0 = addi %arg0, %arg0 : i1}}
+  staticlogic.pipeline.while iter_args(%arg0 = %false) : (i1) -> () {
+    staticlogic.pipeline.register %arg0 : i1
+  } do {
+    %0 = addi %arg0, %arg0 : i1
+    staticlogic.pipeline.terminator iter_args(), results() : () -> ()
+  }
+  return
+}
+
+// -----
+
+func @mismatched_register_types() {
+  %false = constant 0 : i1
+  staticlogic.pipeline.while iter_args(%arg0 = %false) : (i1) -> () {
+    staticlogic.pipeline.register %arg0 : i1
+  } do {
+    %0 = staticlogic.pipeline.stage {
+      // expected-error @+1 {{'staticlogic.pipeline.register' op operand types ('i1') must match result types ('i2')}}
+      staticlogic.pipeline.register %arg0 : i1
+    } : i2
+    staticlogic.pipeline.terminator iter_args(), results() : () -> ()
+  }
+  return
+}
+
+// -----
+
+func @mismatched_iter_args_types() {
+  %false = constant 0 : i1
+  staticlogic.pipeline.while iter_args(%arg0 = %false) : (i1) -> () {
+    staticlogic.pipeline.register %arg0 : i1
+  } do {
+    staticlogic.pipeline.stage {
+      staticlogic.pipeline.register
+    }
+    // expected-error @+1 {{'staticlogic.pipeline.terminator' op 'iter_args' types () must match pipeline 'iter_args' types ('i1')}}
+    staticlogic.pipeline.terminator iter_args(), results() : () -> ()
+  }
+  return
+}
+
+// -----
+
+func @invalid_iter_args() {
+  %false = constant 0 : i1
+  staticlogic.pipeline.while iter_args(%arg0 = %false) : (i1) -> (i1) {
+    staticlogic.pipeline.register %arg0 : i1
+  } do {
+    staticlogic.pipeline.stage {
+      staticlogic.pipeline.register
+    }
+    // expected-error @+1 {{'staticlogic.pipeline.terminator' op 'iter_args' must be defined by a 'staticlogic.pipeline.stage'}}
+    staticlogic.pipeline.terminator iter_args(%false), results() : (i1) -> ()
+  }
+  return
+}
+
+// -----
+
+func @mismatched_result_types() {
+  %false = constant 0 : i1
+  staticlogic.pipeline.while iter_args(%arg0 = %false) : (i1) -> (i1) {
+    staticlogic.pipeline.register %arg0 : i1
+  } do {
+    %0 = staticlogic.pipeline.stage {
+      staticlogic.pipeline.register %arg0 : i1
+    } : i1
+    // expected-error @+1 {{'staticlogic.pipeline.terminator' op 'results' types () must match pipeline result types ('i1')}}
+    staticlogic.pipeline.terminator iter_args(%0), results() : (i1) -> ()
+  }
+  return
+}
+
+// -----
+
+func @invalid_results() {
+  %false = constant 0 : i1
+  staticlogic.pipeline.while iter_args(%arg0 = %false) : (i1) -> (i1) {
+    staticlogic.pipeline.register %arg0 : i1
+  } do {
+    %0 = staticlogic.pipeline.stage {
+      staticlogic.pipeline.register %arg0 : i1
+    } : i1
+    // expected-error @+1 {{'staticlogic.pipeline.terminator' op 'results' must be defined by a 'staticlogic.pipeline.stage'}}
+    staticlogic.pipeline.terminator iter_args(%0), results(%false) : (i1) -> (i1)
+  }
+  return
+}

--- a/test/Dialect/StaticLogic/round-trip.mlir
+++ b/test/Dialect/StaticLogic/round-trip.mlir
@@ -1,0 +1,177 @@
+// RUN: circt-opt %s -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
+
+func @test1(%arg0: memref<?xi32>) -> i32 {
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %c10 = constant 10 : index
+  %c0_i32 = constant 0 : i32
+  // CHECK: staticlogic.pipeline.while
+  // CHECK-SAME: iter_args(%arg1 = %c0, %arg2 = %c0_i32)
+  // CHECK-SAME: (index, i32) -> i32
+  // CHECK-SAME: {
+  %0 = staticlogic.pipeline.while iter_args(%arg1 = %c0, %arg2 = %c0_i32) : (index, i32) -> i32 {
+    %1 = cmpi ult, %arg1, %c10 : index
+    staticlogic.pipeline.register %1 : i1
+  // CHECK: } do {
+  } do {
+    // CHECK: staticlogic.pipeline.stage {
+    %1:2 = staticlogic.pipeline.stage  {
+      %3 = addi %arg1, %c1 : index
+      %4 = memref.load %arg0[%arg1] : memref<?xi32>
+      // CHECK: staticlogic.pipeline.register {{.+}} : {{.+}}
+      // CHECK-NEXT: } : index, i32
+      staticlogic.pipeline.register %3, %4 : index, i32
+    } : index, i32
+    %2 = staticlogic.pipeline.stage  {
+      %3 = addi %1#1, %arg2 : i32
+      staticlogic.pipeline.register %3 : i32
+    } : i32
+    // CHECK: staticlogic.pipeline.terminator iter_args({{.+}}), results({{.+}}) : {{.+}}
+    staticlogic.pipeline.terminator iter_args(%1#0, %2), results(%2) : (index, i32) -> i32
+  }
+  return %0 : i32
+}
+
+func @test2(%arg0: memref<?xi32>, %arg1: memref<?xi32>) {
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %c3 = constant 3 : index
+  %c10 = constant 10 : index
+  // CHECK: staticlogic.pipeline.while
+  // CHECK-SAME: iter_args(%arg2 = %c0)
+  // CHECK-SAME: (index) -> ()
+  staticlogic.pipeline.while iter_args(%arg2 = %c0) : (index) -> () {
+    %0 = cmpi ult, %arg2, %c10 : index
+    staticlogic.pipeline.register %0 : i1
+  } do {
+    %0:4 = staticlogic.pipeline.stage  {
+      %4 = addi %arg2, %c1 : index
+      %5 = memref.load %arg0[%arg2] : memref<?xi32>
+      %6 = cmpi uge, %arg2, %c3 : index
+      staticlogic.pipeline.register %arg2, %4, %5, %6 : index, index, i32, i1
+    } : index, index, i32, i1
+    // CHECK: staticlogic.pipeline.stage when %0#3
+    %1:3 = staticlogic.pipeline.stage when %0#3  {
+      %4 = subi %0#0, %c3 : index
+      staticlogic.pipeline.register %0#2, %0#3, %4 : i32, i1, index
+    } : i32, i1, index
+    %2:4 = staticlogic.pipeline.stage when %1#1  {
+      %4 = memref.load %arg0[%1#2] : memref<?xi32>
+      staticlogic.pipeline.register %1#0, %1#1, %1#2, %4 : i32, i1, index, i32
+    } : i32, i1, index, i32
+    %3:3 = staticlogic.pipeline.stage when %2#1  {
+      %4 = addi %2#0, %2#3 : i32
+      staticlogic.pipeline.register %2#1, %2#2, %4 : i1, index, i32
+    } : i1, index, i32
+    staticlogic.pipeline.stage when %3#0  {
+      memref.store %3#2, %arg1[%3#1] : memref<?xi32>
+      staticlogic.pipeline.register 
+    }
+    staticlogic.pipeline.terminator iter_args(%0#0), results() : (index) -> ()
+  }
+  return
+}
+
+func @test3(%arg0: memref<?xi32>) {
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %c10 = constant 10 : index
+  %0 = memref.alloca() : memref<1xi32>
+  %1 = memref.alloca() : memref<1xi32>
+  %2 = memref.alloca() : memref<1xi32>
+  // CHECK: staticlogic.pipeline.while
+  // CHECK-SAME: iter_args(%arg1 = %c0)
+  // CHECK-SAME: (index) -> ()
+  staticlogic.pipeline.while iter_args(%arg1 = %c0) : (index) -> () {
+    %3 = cmpi ult, %arg1, %c10 : index
+    staticlogic.pipeline.register %3 : i1
+  } do {
+    %3:5 = staticlogic.pipeline.stage  {
+      %5 = addi %arg1, %c1 : index
+      %6 = memref.load %2[%c0] : memref<1xi32>
+      %7 = memref.load %1[%c0] : memref<1xi32>
+      %8 = memref.load %0[%c0] : memref<1xi32>
+      %9 = memref.load %arg0[%arg1] : memref<?xi32>
+      staticlogic.pipeline.register %5, %6, %7, %8, %9 : index, i32, i32, i32, i32
+    } : index, i32, i32, i32, i32
+    %4 = staticlogic.pipeline.stage  {
+      memref.store %3#2, %2[%c0] : memref<1xi32>
+      memref.store %3#3, %1[%c0] : memref<1xi32>
+      %5 = addi %3#1, %3#4 : i32
+      staticlogic.pipeline.register %5 : i32
+    } : i32
+    staticlogic.pipeline.stage  {
+      memref.store %4, %0[%c0] : memref<1xi32>
+      staticlogic.pipeline.register 
+    }
+    staticlogic.pipeline.terminator iter_args(%3#0), results() : (index) -> ()
+  }
+  return
+}
+
+func @test4(%arg0: memref<?xi32>, %arg1: memref<?xi32>) {
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %c10 = constant 10 : index
+  %c1_i32 = constant 1 : i32
+  // CHECK: staticlogic.pipeline.while
+  // CHECK-SAME: iter_args(%arg2 = %c0)
+  // CHECK-SAME: (index) -> ()
+  staticlogic.pipeline.while iter_args(%arg2 = %c0) : (index) -> () {
+    %0 = cmpi ult, %arg2, %c10 : index
+    staticlogic.pipeline.register %0 : i1
+  } do {
+    %0:2 = staticlogic.pipeline.stage  {
+      %3 = addi %arg2, %c1 : index
+      %4 = memref.load %arg1[%arg2] : memref<?xi32>
+      %5 = index_cast %4 : i32 to index
+      staticlogic.pipeline.register %3, %5 : index, index
+    } : index, index
+    %1:2 = staticlogic.pipeline.stage  {
+      %3 = memref.load %arg0[%0#1] : memref<?xi32>
+      staticlogic.pipeline.register %0#1, %3 : index, i32
+    } : index, i32
+    %2:2 = staticlogic.pipeline.stage  {
+      %3 = addi %1#1, %c1_i32 : i32
+      staticlogic.pipeline.register %1#0, %3 : index, i32
+    } : index, i32
+    staticlogic.pipeline.stage  {
+      memref.store %2#1, %arg0[%2#0] : memref<?xi32>
+      staticlogic.pipeline.register 
+    }
+    staticlogic.pipeline.terminator iter_args(%0#0), results() : (index) -> ()
+  }
+  return
+}
+
+func @test5(%arg0: memref<?xi32>) {
+  %c1 = constant 1 : index
+  %c2 = constant 2 : index
+  %c10 = constant 10 : index
+  // CHECK: staticlogic.pipeline.while
+  // CHECK-SAME: iter_args(%arg1 = %c2)
+  // CHECK-SAME: (index) -> ()
+  staticlogic.pipeline.while iter_args(%arg1 = %c2) : (index) -> () {
+    %0 = cmpi ult, %arg1, %c10 : index
+    staticlogic.pipeline.register %0 : i1
+  } do {
+    %0 = staticlogic.pipeline.stage  {
+      %2 = subi %arg1, %c2 : index
+      %3 = memref.load %arg0[%2] : memref<?xi32>
+      staticlogic.pipeline.register %3 : i32
+    } : i32
+    %1:2 = staticlogic.pipeline.stage  {
+      %2 = subi %arg1, %c1 : index
+      %3 = memref.load %arg0[%2] : memref<?xi32>
+      %4 = addi %arg1, %c1 : index
+      staticlogic.pipeline.register %3, %4 : i32, index
+    } : i32, index
+    staticlogic.pipeline.stage  {
+      %2 = addi %0, %1#0 : i32
+      memref.store %2, %arg0[%arg1] : memref<?xi32>
+      staticlogic.pipeline.register 
+    }
+    staticlogic.pipeline.terminator iter_args(%1#1), results() : (index) -> ()
+  }
+  return
+}


### PR DESCRIPTION
https://llvm.discourse.group/t/rfc-representing-pipelined-loops/4171/1
for more discussion.

This defines the operation's syntax more or less as discussed,
including round-trip tests for the four running examples we've had.

In order to reduce test churn, the existing PipelineOp and the
StandardToStaticLogic pass are left untouched for now. Ultimately, the
new pipeline operation could replace the existing PipelineOp.