### PR TITLE
[MSFT] Lower msft.instance to hw.instance

### DIFF
--- a/include/circt/Dialect/MSFT/MSFTPasses.td
+++ b/include/circt/Dialect/MSFT/MSFTPasses.td
@@ -25,3 +25,8 @@ def RunGenerators: Pass<"run-generators", "mlir::ModuleOp"> {
                "llvm::cl::OneOrMore, llvm::cl::MiscFlags::CommaSeparated">
   ];
 }
+
+def LowerToHW: Pass<"msft-lower-to-hw", "mlir::ModuleOp"> {
+  let summary = "Lower MSFT ops to hw ops";
+  let constructor = "circt::msft::createLowerToHWPass()";
+}

--- a/include/circt/InitAllPasses.h
+++ b/include/circt/InitAllPasses.h
@@ -19,6 +19,7 @@
 #include "circt/Dialect/ESI/ESIDialect.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/LLHD/Transforms/Passes.h"
+#include "circt/Dialect/MSFT/MSFTDialect.h"
 #include "circt/Dialect/SV/SVPasses.h"
 #include "circt/Dialect/Seq/SeqDialect.h"
 
@@ -33,6 +34,7 @@ inline void registerAllPasses() {
   esi::registerESIPasses();
   firrtl::registerPasses();
   llhd::initLLHDTransformationPasses();
+  msft::registerMSFTPasses();
   seq::registerSeqPasses();
   sv::registerPasses();
 }

--- a/lib/Dialect/MSFT/CMakeLists.txt
+++ b/lib/Dialect/MSFT/CMakeLists.txt
@@ -10,7 +10,7 @@ add_circt_dialect_library(CIRCTMSFT
   MSFTAttributes.cpp
   MSFTDialect.cpp
   MSFTOps.cpp
-  MSFTGenerator.cpp
+  MSFTPasses.cpp
   DeviceDB.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/Dialect/MSFT/MSFTPasses.cpp
+++ b/lib/Dialect/MSFT/MSFTPasses.cpp
@@ -172,7 +172,11 @@ LogicalResult
 InstanceOpLowering::matchAndRewrite(InstanceOp msftInst,
                                     ArrayRef<Value> operands,
                                     ConversionPatternRewriter &rewriter) const {
-  return failure();
+  auto hwInst = rewriter.create<hw::InstanceOp>(
+      msftInst.getLoc(), msftInst.getResultTypes(), msftInst.instanceNameAttr(),
+      msftInst.moduleNameAttr(), operands, DictionaryAttr{}, StringAttr{});
+  rewriter.replaceOp(msftInst, hwInst.getResults());
+  return success();
 }
 
 namespace {
@@ -188,6 +192,7 @@ void LowerToHWPass::runOnOperation() {
   // Set up a conversion and give it a set of laws.
   ConversionTarget target(*ctxt);
   target.addIllegalDialect<MSFTDialect>();
+  target.addLegalDialect<hw::HWDialect>();
 
   // Add all the conversion patterns.
   RewritePatternSet patterns(ctxt);

--- a/lib/Dialect/MSFT/MSFTPasses.cpp
+++ b/lib/Dialect/MSFT/MSFTPasses.cpp
@@ -155,9 +155,8 @@ std::unique_ptr<Pass> createRunGeneratorsPass() {
 //===----------------------------------------------------------------------===//
 
 namespace {
-/// Lower `ChannelBuffer`s, breaking out the various options. For now, just
-/// replace with the specified number of pipeline stages (since that's the only
-/// option).
+/// Lower MSFT's InstanceOp to HW's. Currently trivial since `msft.instance` is
+/// currently a subset of `hw.instance`.
 struct InstanceOpLowering : public OpConversionPattern<InstanceOp> {
 public:
   using OpConversionPattern::OpConversionPattern;

--- a/lib/Dialect/MSFT/MSFTPasses.cpp
+++ b/lib/Dialect/MSFT/MSFTPasses.cpp
@@ -1,4 +1,4 @@
-//===- MSFTGenerator.cpp - Implement MSFT generators ----------------------===//
+//===- MSFTPasses.cpp - Implement MSFT passes -----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -7,10 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/MSFT/MSFTDialect.h"
+#include "circt/Dialect/MSFT/MSFTOps.h"
 
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassRegistry.h"
+#include "mlir/Transforms/DialectConversion.h"
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallSet.h"
@@ -20,6 +22,10 @@
 using namespace circt;
 using namespace msft;
 using GeneratorSet = llvm::SmallSet<StringRef, 8>;
+
+//===----------------------------------------------------------------------===//
+// Generators.
+//===----------------------------------------------------------------------===//
 
 namespace {
 /// Holds the set of registered generators for each operation.
@@ -114,7 +120,6 @@ namespace msft {
 } // namespace circt
 
 namespace {
-/// Run all the physical lowerings.
 struct RunGeneratorsPass : public RunGeneratorsBase<RunGeneratorsPass> {
   void runOnOperation() override;
 };
@@ -142,7 +147,62 @@ namespace msft {
 std::unique_ptr<Pass> createRunGeneratorsPass() {
   return std::make_unique<RunGeneratorsPass>();
 }
+} // namespace msft
+} // namespace circt
 
+//===----------------------------------------------------------------------===//
+// Lower MSFT to HW.
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// Lower `ChannelBuffer`s, breaking out the various options. For now, just
+/// replace with the specified number of pipeline stages (since that's the only
+/// option).
+struct InstanceOpLowering : public OpConversionPattern<InstanceOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(InstanceOp, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const final;
+};
+} // anonymous namespace
+
+LogicalResult
+InstanceOpLowering::matchAndRewrite(InstanceOp msftInst,
+                                    ArrayRef<Value> operands,
+                                    ConversionPatternRewriter &rewriter) const {
+  return failure();
+}
+
+namespace {
+struct LowerToHWPass : public LowerToHWBase<LowerToHWPass> {
+  void runOnOperation() override;
+};
+} // anonymous namespace
+
+void LowerToHWPass::runOnOperation() {
+  auto top = getOperation();
+  auto ctxt = &getContext();
+
+  // Set up a conversion and give it a set of laws.
+  ConversionTarget target(*ctxt);
+  target.addIllegalDialect<MSFTDialect>();
+
+  // Add all the conversion patterns.
+  RewritePatternSet patterns(ctxt);
+  patterns.insert<InstanceOpLowering>(ctxt);
+
+  // Run the conversion.
+  if (failed(applyPartialConversion(top, target, std::move(patterns))))
+    signalPassFailure();
+}
+
+namespace circt {
+namespace msft {
+std::unique_ptr<Pass> createLowerToHWPass() {
+  return std::make_unique<LowerToHWPass>();
+}
 } // namespace msft
 } // namespace circt
 

--- a/test/Dialect/MSFT/module_instance.mlir
+++ b/test/Dialect/MSFT/module_instance.mlir
@@ -1,10 +1,12 @@
 // RUN: circt-opt %s -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
-// RUN: circt-opt %s --msft-lower-to-hw -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
+// RUN: circt-opt %s --msft-lower-to-hw -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s --check-prefix=HWLOW
 
 hw.module.extern @fooMod () -> (%x: i32)
 
 // CHECK-LABEL: hw.module @top
+// HWLOW-LABEL: hw.module @top
 hw.module @top () {
   msft.instance "foo" @fooMod () : () -> (i32)
   // CHECK: %foo.x = msft.instance "foo" @fooMod() : () -> i32
+  // HWLOW: %foo.x = hw.instance "foo" @fooMod() : () -> i32
 }

--- a/test/Dialect/MSFT/module_instance.mlir
+++ b/test/Dialect/MSFT/module_instance.mlir
@@ -1,4 +1,5 @@
 // RUN: circt-opt %s -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
+// RUN: circt-opt %s --msft-lower-to-hw -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
 
 hw.module.extern @fooMod () -> (%x: i32)
 


### PR DESCRIPTION
Add a very straight-forward lowering of `msft::InstanceOp` to `hw::InstanceOp`. Part 2 of #1755.