### PR TITLE
[Calyx] Add support for primitive port attributes.

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxInterfaces.td
+++ b/include/circt/Dialect/Calyx/CalyxInterfaces.td
@@ -59,6 +59,10 @@ def CellOpInterface : OpInterface<"CellInterface"> {
       "SmallVector<circt::calyx::Direction>", "portDirections"
     >,
     InterfaceMethod<
+      "This returns the port attributes associated with the cell.",
+      "SmallVector<DictionaryAttr>", "portAttributes"
+    >,
+    InterfaceMethod<
       "This returns the instance name of the cell.",
       "StringRef",
       "instanceName",
@@ -86,19 +90,23 @@ def CellOpInterface : OpInterface<"CellInterface"> {
     InterfaceMethod<
       "This returns the PortInfo associated with all of the ports of a cell.",
       "SmallVector<circt::calyx::PortInfo>",
-      "portInfos",
+      "getPortInfo",
       (ins),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
         SmallVector<circt::calyx::PortInfo> info;
-
-        auto zip = llvm::zip($_op->getResults(), $_op.portDirections(), $_op.portNames());
-        for (auto&& [result, direction, name] : zip)
+        auto zippedPortInfo = llvm::zip(
+          $_op->getResults(),
+          $_op.portDirections(),
+          $_op.portNames(),
+          $_op.portAttributes()
+        );
+        for (auto&& [result, direction, name, attr] : zippedPortInfo)
           info.push_back(PortInfo{
               StringAttr::get($_op->getContext(), name),
               result.getType(),
               direction,
-              DictionaryAttr()
+              attr
           });
         return info;
     }]
@@ -109,7 +117,7 @@ def CellOpInterface : OpInterface<"CellInterface"> {
       "portInfo",
       (ins "Value":$port),
       /*methodBody=*/"",
-      /*defaultImplementation=*/[{ return portInfos()[portIndex(port)]; }]
+      /*defaultImplementation=*/[{ return getPortInfo()[portIndex(port)]; }]
     >,
     InterfaceMethod<
       "This returns the direction of a given port of a cell.",
@@ -126,6 +134,14 @@ def CellOpInterface : OpInterface<"CellInterface"> {
       (ins "Value":$port),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{ return portInfo(port).name.getValue(); }]
+    >,
+    InterfaceMethod<
+      "This returns the attributes of a given port of a cell.",
+      "DictionaryAttr",
+      "portDictionaryAttr",
+      (ins "Value":$port),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{ return portInfo(port).attributes; }]
     >,
     InterfaceMethod<
       "This returns the input ports of a cell.",
@@ -162,16 +178,16 @@ def CellOpInterface : OpInterface<"CellInterface"> {
       (ins "calyx::Direction":$dir),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
-        auto isInterfacePort = [](StringRef portName) {
-          return portName == "clk" || portName == "reset" ||
-                 portName == "go"  || portName == "done";
+        auto isInterfacePort = [](const PortInfo& port) {
+          return port.hasAttribute("go")   || port.hasAttribute("reset") ||
+                 port.hasAttribute("done") || port.hasAttribute("clk");
         };
 
         SmallVector<Value> filteredPorts;
-        for (auto&& [result, port] : llvm::zip($_op->getResults(), $_op.portInfos())) {
-          StringRef name = port.name.getValue();
-          if (port.direction == dir && !isInterfacePort(name))
-            filteredPorts.push_back(result);
+        for (auto&& [result, port] : llvm::zip($_op->getResults(), $_op.getPortInfo())) {
+          if (port.direction != dir || !isInterfacePort(port))
+            continue;
+          filteredPorts.push_back(result);
         }
         return filteredPorts;
       }]

--- a/include/circt/Dialect/Calyx/CalyxInterfaces.td
+++ b/include/circt/Dialect/Calyx/CalyxInterfaces.td
@@ -94,21 +94,22 @@ def CellOpInterface : OpInterface<"CellInterface"> {
       (ins),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
-        SmallVector<circt::calyx::PortInfo> info;
+        SmallVector<circt::calyx::PortInfo> ports;
+        MLIRContext* context = $_op->getContext();
         auto zippedPortInfo = llvm::zip(
           $_op->getResults(),
           $_op.portDirections(),
           $_op.portNames(),
           $_op.portAttributes()
         );
-        for (auto&& [result, direction, name, attr] : zippedPortInfo)
-          info.push_back(PortInfo{
-              StringAttr::get($_op->getContext(), name),
+        for (auto&& [result, direction, name, attributes] : zippedPortInfo)
+          ports.push_back(PortInfo{
+              StringAttr::get(context, name),
               result.getType(),
               direction,
-              attr
+              attributes
           });
-        return info;
+        return ports;
     }]
     >,
     InterfaceMethod<
@@ -146,7 +147,7 @@ def CellOpInterface : OpInterface<"CellInterface"> {
     InterfaceMethod<
       "This returns the input ports of a cell.",
       "SmallVector<Value>",
-      "inputPorts",
+      "getInputPorts",
       (ins),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
@@ -160,7 +161,7 @@ def CellOpInterface : OpInterface<"CellInterface"> {
     InterfaceMethod<
       "This returns the output ports of a cell.",
       "SmallVector<Value>",
-      "outputPorts",
+      "getOutputPorts",
       (ins),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{

--- a/include/circt/Dialect/Calyx/CalyxOps.h
+++ b/include/circt/Dialect/Calyx/CalyxOps.h
@@ -69,9 +69,7 @@ struct PortInfo {
   DictionaryAttr attributes;
 
   /// Returns whether the given port has attribute with Identifier `name`.
-  bool hasAttribute(StringRef identifier) {
-    if (attributes == nullptr)
-      return false;
+  bool hasAttribute(StringRef identifier) const {
     return llvm::any_of(attributes, [&](auto idToAttribute) {
       return identifier == std::get<0>(idToAttribute);
     });
@@ -79,10 +77,7 @@ struct PortInfo {
 
   /// Returns the attribute associated with the given name if it exists,
   /// otherwise std::nullopt.
-  llvm::Optional<Attribute> getAttribute(StringRef identifier) {
-    if (attributes == nullptr)
-      return None;
-
+  llvm::Optional<Attribute> getAttribute(StringRef identifier) const {
     auto it = llvm::find_if(attributes, [&](auto idToAttribute) {
       return identifier == std::get<0>(idToAttribute);
     });
@@ -92,10 +87,7 @@ struct PortInfo {
   }
 
   /// Returns all identifiers for this dictionary attribute.
-  SmallVector<StringRef> getAllIdentifiers() {
-    if (attributes == nullptr)
-      return {};
-
+  SmallVector<StringRef> getAllIdentifiers() const {
     SmallVector<StringRef> identifiers;
     llvm::transform(
         attributes, std::back_inserter(identifiers),

--- a/include/circt/Dialect/Calyx/CalyxOps.h
+++ b/include/circt/Dialect/Calyx/CalyxOps.h
@@ -70,6 +70,7 @@ struct PortInfo {
 
   /// Returns whether the given port has attribute with Identifier `name`.
   bool hasAttribute(StringRef identifier) const {
+    assert(attributes && "PortInfo::attributes should be instantiated.");
     return llvm::any_of(attributes, [&](auto idToAttribute) {
       return identifier == std::get<0>(idToAttribute);
     });
@@ -78,6 +79,7 @@ struct PortInfo {
   /// Returns the attribute associated with the given name if it exists,
   /// otherwise std::nullopt.
   llvm::Optional<Attribute> getAttribute(StringRef identifier) const {
+    assert(attributes && "PortInfo::attributes should be instantiated.");
     auto it = llvm::find_if(attributes, [&](auto idToAttribute) {
       return identifier == std::get<0>(idToAttribute);
     });
@@ -88,6 +90,7 @@ struct PortInfo {
 
   /// Returns all identifiers for this dictionary attribute.
   SmallVector<StringRef> getAllIdentifiers() const {
+    assert(attributes && "PortInfo::attributes should be instantiated.");
     SmallVector<StringRef> identifiers;
     llvm::transform(
         attributes, std::back_inserter(identifiers),

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -33,13 +33,13 @@ def RegisterOp : CalyxPrimitive<"register", [
   let builders = [
     OpBuilder<(ins "StringAttr":$instanceName, "size_t":$width), [{
       $_state.addAttribute("instanceName", instanceName);
-      auto i1Type = $_builder.getI1Type();
-      auto widthType = $_builder.getIntegerType(width);
+      Type i1Type = $_builder.getI1Type();
+      Type widthType = $_builder.getIntegerType(width);
       $_state.addTypes({widthType, i1Type, i1Type, i1Type, widthType, i1Type});
     }]>,
-    OpBuilder<(ins "StringAttr":$name, "Type":$type), [{
-      $_state.addAttribute("name", name);
-      auto i1Type = $_builder.getI1Type();
+    OpBuilder<(ins "StringAttr":$instanceName, "Type":$type), [{
+      $_state.addAttribute("instanceName", instanceName);
+      Type i1Type = $_builder.getI1Type();
       $_state.addTypes({type, i1Type, i1Type, i1Type, type, i1Type});
     }]>
   ];

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -542,10 +542,11 @@ void Emitter::emitLibraryPrimTypedByAllPorts(Operation *op) {
 
 void Emitter::emitLibraryPrimTypedByFirstInputPort(Operation *op) {
   auto cell = cast<CellInterface>(op);
-  unsigned bitwidth = cell.inputPorts()[0].getType().getIntOrFloatBitWidth();
+  unsigned bitWidth = cell.getInputPorts()[0].getType().getIntOrFloatBitWidth();
+  StringRef opName = op->getName().getStringRef();
   indent() << getAttributes(op) << cell.instanceName() << space() << equals()
-           << space() << removeCalyxPrefix(op->getName().getStringRef())
-           << LParen() << bitwidth << RParen() << semicolonEndL();
+           << space() << removeCalyxPrefix(opName) << LParen() << bitWidth
+           << RParen() << semicolonEndL();
 }
 
 void Emitter::emitAssignment(AssignOp op) {

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -209,7 +209,7 @@ calyx.program {
     %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
-      calyx.comb_group @Group1 {  calyx.assign %c0.go = %c1_1 : i1 }
+      calyx.comb_group @Group1 {}
       calyx.group @Group2 { calyx.group_done %c1_1 : i1 } 
     }
     calyx.control {


### PR DESCRIPTION
Adds support for attributes on primitive ports. No emission is necessary for the ports of a primitive. Calyx primitive attributes are already supported as well. This closes #1744.

I've also lessened the restriction for port driving to `returns success if any input port is driven`. I think this is sufficient for now.

#1763 discusses cleanup for port access functions.