### PR TITLE
[Calyx] Fix twine usage in emitter

### DIFF
--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -590,9 +590,11 @@ void Emitter::emitGroup(GroupInterface group) {
     }
   };
 
-  Twine prefix = Twine(isa<CombGroupOp>(group) ? "comb " : "") + "group";
-  Twine groupHeader = Twine(group.symName().getValue()) + getAttributes(group);
-  emitCalyxSection(prefix.str(), emitGroupBody, groupHeader.str());
+  auto prefix = "group";
+  if (isa<CombGroupOp>(group))
+    prefix = "comb group";
+  auto groupHeader = (group.symName().getValue() + getAttributes(group)).str();
+  emitCalyxSection(prefix, emitGroupBody, groupHeader);
 }
 
 void Emitter::emitEnable(EnableOp enable) {


### PR DESCRIPTION
Twines are not safe to store on the stack. This caused undefined
behaviour which lead to an issue where it would print `group` twice
depending on the compiler settings.

```
// Correct:
comb group Group2
// Incorrect:
comb group Group2comb group
```

This issue was noted on the forums here: https://llvm.discourse.group/t/calyx-test-failure/4261