### PR TITLE
[FIRRTL] Move name dropping later in the pipeline

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -27,7 +27,12 @@ def EmptyAttrDict : Constraint<CPred<"$0.empty()">>;
 def NoDontTouch : Constraint<CPred<"!AnnotationSet($0).hasDontTouch()">>;
 
 // Constraint that matches annotation sets without dontTouch.
-def NoPortsDontTouch : Constraint<CPred<"llvm::all_of($0, [](Attribute a) { if (auto b = a.dyn_cast<ArrayAttr>()) return !AnnotationSet(b).hasDontTouch(); return true; })">>;
+def NoPortsDontTouch : Constraint<CPred<[{
+  llvm::all_of($0, [](Attribute a) { 
+    if (auto b = a.dyn_cast<ArrayAttr>()) 
+      return !AnnotationSet(b).hasDontTouch();
+     return true;
+  })}]>>;
 
 def NonEmptyStringAttr : Constraint<CPred<"!$0.getValue().empty()">>;
 def uselessNameAttr : Constraint<CPred<"isUselessName($0.getValue())">>;

--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -23,6 +23,15 @@ def NonConstantOp : Constraint<CPred<"!$0.getDefiningOp<ConstantOp>()">>;
 // there are no FIRRTL annotation on an operation.
 def EmptyAttrDict : Constraint<CPred<"$0.empty()">>;
 
+// Constraint that matches annotation sets without dontTouch.
+def NoDontTouch : Constraint<CPred<"!AnnotationSet($0).hasDontTouch()">>;
+
+// Constraint that matches annotation sets without dontTouch.
+def NoPortsDontTouch : Constraint<CPred<"llvm::all_of($0, [](Attribute a) { if (auto b = a.dyn_cast<ArrayAttr>()) return !AnnotationSet(b).hasDontTouch(); return true; })">>;
+
+def NonEmptyStringAttr : Constraint<CPred<"!$0.getValue().empty()">>;
+def uselessNameAttr : Constraint<CPred<"isUselessName($0.getValue())">>;
+
 // Constraint that enforces equal types
 def EqualTypes : Constraint<CPred<"$0.getType() == $1.getType()">>;
 
@@ -43,6 +52,9 @@ def ZeroConstantOp : Constraint<Or<[
 def IsInvalid : Constraint<
   CPred<"$0.getDefiningOp<InvalidValueOp>()">
 >;
+
+def GetEmptyString : NativeCodeCall<
+  "StringAttr::get($_builder.getContext(), {}) ">;
 
 // leq(const, x) -> geq(x, const)
 def LEQWithConstLHS : Pat<
@@ -86,7 +98,7 @@ def MuxSameCondHigh : Pat<
 def EmptyNode : Pat<
   (NodeOp $x, $name, $annotations),
   (replaceWithValue $x),
-  [(EmptyAttrDict $annotations)]>;
+  [(NonEmptyStringAttr $name), (EmptyAttrDict $annotations)]>;
 
 // regreset(clock, invalidvalue, resetValue) -> reg(clock)
 def RegresetWithInvalidReset : Pat<
@@ -133,6 +145,58 @@ def SubWithInvalidOp : Pat<
   (PadPrimOp $x, (GetWidthAsIntAttr $result)), [
     (KnownWidth $x), (IsInvalid $y)
   ]>;
+
+////////////////////////////////////////////////////////////////////////////////
+// DontTouch application
+////////////////////////////////////////////////////////////////////////////////
+
+// node(x,name),!dnt -> node(x, "")
+def DropNameNode : Pat<
+  (NodeOp $x, $name, $annotations),
+  (NodeOp $x, (GetEmptyString), $annotations),
+  [(uselessNameAttr $name), (NoDontTouch $annotations)]>;
+
+// wire(name),!dnt -> wire("")
+def DropNameWire : Pat<
+  (WireOp $name, $annotations),
+  (WireOp (GetEmptyString), $annotations),
+  [(uselessNameAttr $name), (NoDontTouch $annotations)]>;
+
+// reg(clk, name),!dnt -> reg(clk, "")
+def DropNameReg : Pat<
+  (RegOp $clk, $name, $annotations),
+  (RegOp $clk, (GetEmptyString), $annotations),
+  [(uselessNameAttr $name), (NoDontTouch $annotations)]>;
+
+// regreset(clk, sig, val, name),!dnt -> regreset(clk, sig, val, "")
+def DropNameRegReset : Pat<
+  (RegResetOp $clk, $sig, $val, $name, $annotations),
+  (RegResetOp $clk, $sig, $val, (GetEmptyString), $annotations),
+  [(uselessNameAttr $name), (NoDontTouch $annotations)]>;
+
+// Mem(...,name),!dnt -> Mem(...x, "")
+def DropNameMem : Pat<
+  (MemOp $rd, $rw, $depth, $ruw, $portNames, $name, $annotations, $portAnno),
+  (MemOp $rd, $rw, $depth, $ruw, $portNames, (GetEmptyString), $annotations, $portAnno),
+  [(uselessNameAttr $name), (NoDontTouch $annotations), (NoPortsDontTouch $portAnno)]>;
+
+// CombMem(name),!dnt -> CombMem("")
+def DropNameCombMem : Pat<
+  (CombMemOp $name, $annotations),
+  (CombMemOp (GetEmptyString), $annotations),
+  [(uselessNameAttr $name), (NoDontTouch $annotations)]>;
+
+// SeqMem(ruw, name),!dnt -> SeqMem(ruw, "")
+def DropNameSeqMem : Pat<
+  (SeqMemOp $ruw, $name, $annotations),
+  (SeqMemOp $ruw, (GetEmptyString), $annotations),
+  [(uselessNameAttr $name), (NoDontTouch $annotations)]>;
+
+// memoryport(..., name),!dnt -> memoryport(..., "")
+def DropNameMemoryPort : Pat<
+  (MemoryPortOp  $memory, $direction, $name, $annotations),
+  (MemoryPortOp  $memory, $direction, (GetEmptyString), $annotations),
+  [(uselessNameAttr $name), (NoDontTouch $annotations)]>;
 
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLCANONICALIZATION_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -72,6 +72,7 @@ def CombMemOp : FIRRTLOp<"combmem"> {
   let arguments = (ins StrAttr:$name, AnnotationArrayAttr:$annotations);
   let results = (outs CMemoryType:$result);
   let assemblyFormat = "custom<ImplicitSSAName>(attr-dict) `:` type($result)";
+  let hasCanonicalizer = true;
 }
 
 def SeqMemOp : FIRRTLOp<"seqmem"> {
@@ -84,6 +85,7 @@ def SeqMemOp : FIRRTLOp<"seqmem"> {
                        AnnotationArrayAttr:$annotations);
   let results = (outs CMemoryType:$result);
   let assemblyFormat = "$ruw custom<SeqMemOp>(attr-dict) `:` type($result)";
+  let hasCanonicalizer = true;
 }
 
 def MemoryPortOp : FIRRTLOp<"memoryport", [InferTypeOpInterface,
@@ -110,6 +112,7 @@ def MemoryPortOp : FIRRTLOp<"memoryport", [InferTypeOpInterface,
     $direction $memory custom<MemoryPortOp>(attr-dict) `:`
        functional-type(operands, results)
   }];
+  let hasCanonicalizer = true;
 
   let builders = [
     OpBuilder<(ins "::mlir::Type":$dataType, "::mlir::Value":$memory,
@@ -345,4 +348,5 @@ def WireOp : FIRRTLOp<"wire", []> {
   ];
 
   let assemblyFormat = "custom<ImplicitSSAName>(attr-dict) `:` type($result)";
+  let hasCanonicalizer = true;
 }

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -42,39 +42,6 @@ using mlir::LocationAttr;
 
 namespace json = llvm::json;
 
-/// Return true if this is a useless temporary name produced by FIRRTL.  We
-/// drop these as they don't convey semantic meaning.
-static bool isUselessName(StringRef name) {
-  // Ignore _T and _T_123
-  if (name.startswith("_T")) {
-    if (name.size() == 2)
-      return true;
-    return name.size() > 3 && name[2] == '_' && llvm::isDigit(name[3]);
-  }
-
-  // Ignore _GEN and _GEN_123, these are produced by Namespace.scala.
-  if (name.startswith("_GEN")) {
-    if (name.size() == 4)
-      return true;
-    return name.size() > 5 && name[4] == '_' && llvm::isDigit(name[5]);
-  }
-  return false;
-}
-
-/// If the specified name is a useless temporary name produced by FIRRTL, return
-/// an empty string to ignore it.  Otherwise, return the argument unmodified.
-static StringRef filterUselessName(StringRef name) {
-  return isUselessName(name) ? "" : name;
-}
-
-/// Get an annotation with a class name field.
-static DictionaryAttr getAnnotationOfClass(MLIRContext *context,
-                                           StringRef classString) {
-  auto id = NamedAttribute(Identifier::get("class", context),
-                           StringAttr::get(context, classString));
-  return DictionaryAttr::getWithSorted(context, {id});
-}
-
 //===----------------------------------------------------------------------===//
 // SharedParserConstants
 //===----------------------------------------------------------------------===//
@@ -90,8 +57,6 @@ using TargetSet = StringSet<llvm::BumpPtrAllocator>;
 struct SharedParserConstants {
   SharedParserConstants(MLIRContext *context, FIRParserOptions options)
       : context(context), options(options),
-        dontTouchAnnotation(getAnnotationOfClass(
-            context, "firrtl.transforms.DontTouchAnnotation")),
         emptyArrayAttr(ArrayAttr::get(context, {})),
         loIdentifier(Identifier::get("lo", context)),
         hiIdentifier(Identifier::get("hi", context)),
@@ -115,9 +80,6 @@ struct SharedParserConstants {
   /// unapplied from the annotationMap.  This, like the annotationMap, should
   /// not be mutated directly unless the client is the Circuit parser.
   TargetSet targetSet;
-
-  /// Cached annotation for DontTouch.
-  const DictionaryAttr dontTouchAnnotation;
 
   /// An empty array attribute.
   const ArrayAttr emptyArrayAttr;
@@ -310,13 +272,6 @@ struct FIRParser {
   getSplitAnnotations(ArrayRef<Twine> targets, SMLoc loc,
                       ArrayRef<std::pair<StringAttr, Type>> ports,
                       TargetSet &targetSet);
-
-  /// Returns true if the annotation list contains the DontTouchAnnotation. This
-  /// method is slightly more efficient than other lookup methods, because it
-  /// uses a stashed copy of the annotation for lookup.
-  bool hasDontTouch(ArrayAttr annotations) {
-    return AnnotationSet(annotations).hasDontTouch();
-  }
 
 private:
   FIRParser(const FIRParser &) = delete;
@@ -2269,7 +2224,6 @@ ParseResult FIRStmtParser::parseMemPort(MemDirAttr direction) {
 
   auto annotations = getAnnotations(getModuleTarget() + ">" + id, startLoc,
                                     moduleContext.targetsInModule, resultType);
-  auto name = hasDontTouch(annotations) ? id : filterUselessName(id);
 
   locationProcessor.setLoc(startLoc);
 
@@ -2279,7 +2233,7 @@ ParseResult FIRStmtParser::parseMemPort(MemDirAttr direction) {
     OpBuilder::InsertionGuard guard(builder);
     builder.setInsertionPointAfterValue(memory);
     auto memoryPortOp = builder.create<MemoryPortOp>(
-        resultType, CMemoryPortType::get(getContext()), memory, direction, name,
+        resultType, CMemoryPortType::get(getContext()), memory, direction, id,
         annotations);
     memoryData = memoryPortOp.getResult(0);
     memoryPort = memoryPortOp.getResult(1);
@@ -2656,14 +2610,7 @@ ParseResult FIRStmtParser::parseInstance() {
        getModuleTarget() + "/" + id + ":" + moduleName},
       startTok.getLoc(), resultNamesAndTypes, moduleContext.targetsInModule);
 
-  // Keep the name if a dont touch exist on either the instance or its ports.
-  auto dontTouch = hasDontTouch(annotations.first) ||
-                   llvm::any_of(annotations.second, [&](Attribute a) {
-                     return hasDontTouch(a.cast<ArrayAttr>());
-                   });
-  auto name = dontTouch ? id : filterUselessName(id);
-
-  auto result = builder.create<InstanceOp>(resultTypes, moduleName, name,
+  auto result = builder.create<InstanceOp>(resultTypes, moduleName, id,
                                            annotations.first.getValue(),
                                            annotations.second.getValue());
 
@@ -2711,9 +2658,8 @@ ParseResult FIRStmtParser::parseCombMem() {
   auto annotations =
       getAnnotations(getModuleTarget() + ">" + id, startTok.getLoc(),
                      moduleContext.targetsInModule, type);
-  auto name = hasDontTouch(annotations) ? id : filterUselessName(id);
 
-  auto result = builder.create<CombMemOp>(memType, name, annotations);
+  auto result = builder.create<CombMemOp>(memType, id, annotations);
   return moduleContext.addSymbolEntry(id, result, startTok.getLoc());
 }
 
@@ -2749,9 +2695,8 @@ ParseResult FIRStmtParser::parseSeqMem() {
   auto annotations =
       getAnnotations(getModuleTarget() + ">" + id, startTok.getLoc(),
                      moduleContext.targetsInModule, type);
-  auto name = hasDontTouch(annotations) ? id : filterUselessName(id);
 
-  auto result = builder.create<SeqMemOp>(memType, ruw, name, annotations);
+  auto result = builder.create<SeqMemOp>(memType, ruw, id, annotations);
   return moduleContext.addSymbolEntry(id, result, startTok.getLoc());
 }
 
@@ -2878,16 +2823,9 @@ ParseResult FIRStmtParser::parseMem(unsigned memIndent) {
       getSplitAnnotations(getModuleTarget() + ">" + id, startTok.getLoc(),
                           ports, moduleContext.targetsInModule);
 
-  // Keep the name if a dont touch exist on either the instance or its ports.
-  auto dontTouch = hasDontTouch(annotations.first) ||
-                   llvm::any_of(annotations.second, [&](Attribute a) {
-                     return hasDontTouch(a.cast<ArrayAttr>());
-                   });
-  auto name = dontTouch ? id : filterUselessName(id);
-
   auto result =
       builder.create<MemOp>(resultTypes, readLatency, writeLatency, depth, ruw,
-                            builder.getArrayAttr(resultNames), name,
+                            builder.getArrayAttr(resultNames), id,
                             annotations.first, annotations.second);
 
   UnbundledValueEntry unbundledValueEntry;
@@ -2941,10 +2879,8 @@ ParseResult FIRStmtParser::parseNode() {
       getAnnotations(getModuleTarget() + ">" + id, startTok.getLoc(),
                      moduleContext.targetsInModule, initializerType);
 
-  // Ignore useless names like _T.
-  auto name = hasDontTouch(annotations) ? id : filterUselessName(id);
-  Value result = builder.create<NodeOp>(initializer.getType(), initializer,
-                                        name, annotations);
+  Value result = builder.create<NodeOp>(initializer.getType(), initializer, id,
+                                        annotations);
   return moduleContext.addSymbolEntry(id, result, startTok.getLoc());
 }
 
@@ -2969,9 +2905,8 @@ ParseResult FIRStmtParser::parseWire() {
   auto annotations =
       getAnnotations(getModuleTarget() + ">" + id, startTok.getLoc(),
                      moduleContext.targetsInModule, type);
-  auto name = hasDontTouch(annotations) ? id : filterUselessName(id);
 
-  auto result = builder.create<WireOp>(type, name, annotations);
+  auto result = builder.create<WireOp>(type, id, annotations);
   return moduleContext.addSymbolEntry(id, result, startTok.getLoc());
 }
 
@@ -3060,14 +2995,13 @@ ParseResult FIRStmtParser::parseRegister(unsigned regIndent) {
   auto annotations =
       getAnnotations(getModuleTarget() + ">" + id, startTok.getLoc(),
                      moduleContext.targetsInModule, type);
-  auto name = hasDontTouch(annotations) ? id : filterUselessName(id);
 
   Value result;
   if (resetSignal)
     result = builder.create<RegResetOp>(type, clock, resetSignal, resetValue,
-                                        name, annotations);
+                                        id, annotations);
   else
-    result = builder.create<RegOp>(type, clock, name, annotations);
+    result = builder.create<RegOp>(type, clock, id, annotations);
 
   return moduleContext.addSymbolEntry(id, result, startTok.getLoc());
 }

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -341,22 +341,22 @@ circuit Foo: %[[{"target": "~Foo|Foo>_T_0", "a": "a"},
     input reset : UInt<1>
     input clock : Clock
 
-    ; CHECK: %0 = firrtl.wire  {annotations = [{a = "a"}]}
+    ; CHECK: %_T_0 = firrtl.wire  {annotations = [{a = "a"}]}
     wire _T_0 : UInt<1>
-    ; CHECK: %1 = firrtl.node
+    ; CHECK: %_T_1 = firrtl.node
     node _T_1 = _T_0
-    ; CHECK: %2 = firrtl.reg %clock  {annotations = [{a = "a"}]}
+    ; CHECK: %_T_2 = firrtl.reg %clock  {annotations = [{a = "a"}]}
     reg _T_2 : UInt<1>, clock
-    ; CHECK: %3 = firrtl.regreset {{.+}}  {annotations = [{a = "a"}]}
+    ; CHECK: %_T_3 = firrtl.regreset {{.+}}  {annotations = [{a = "a"}]}
     reg _T_3 : UInt<4>, clock with :
       reset => (reset, UInt<4>("h0"))
-    ; CHECK: %4 = firrtl.seqmem Undefined {annotations = [{a = "a"}]}
+    ; CHECK: %_T_4 = firrtl.seqmem Undefined {annotations = [{a = "a"}]}
     smem _T_4 : UInt<1>[9] [256]
-    ; CHECK: %5 = firrtl.combmem  {annotations = [{a = "a"}]}
+    ; CHECK: %_T_5 = firrtl.combmem  {annotations = [{a = "a"}]}
     cmem _T_5 : UInt<1>[9] [256]
     ; CHECK: firrtl.memoryport {{.+}} {annotations = [{a = "a"}]
     infer mport _T_6 = _T_5[reset], clock
-    ; CHECK: firrtl.instance @Bar  {annotations = [{a = "a"}], name = ""}
+    ; CHECK: firrtl.instance @Bar  {annotations = [{a = "a"}], name = "_T_7"}
     inst _T_7 of Bar
     ; CHECK: firrtl.mem Undefined  {annotations = [{a = "a"}]
     mem _T_8 :

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -1987,4 +1987,19 @@ firrtl.module @constReg8(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, o
   firrtl.connect %out, %r : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
+// CHECK-LABEL: firrtl.module @namedrop
+firrtl.module @namedrop(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
+  // CHECK-NOT: _T_ 
+  %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+  %_T_0 = firrtl.node %in : !firrtl.uint<1>
+  %_T_1 = firrtl.wire : !firrtl.uint<1>
+  %_T_2 = firrtl.reg %clock : !firrtl.uint<1>
+  %_T_3 = firrtl.regreset %clock, %reset, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+  %a = firrtl.mem Undefined {depth = 8 : i64, name = "_T_5", portNames = ["a"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<1>>
+  %_T_6 = firrtl.combmem : !firrtl.cmemory<uint<1>, 8>
+  %_T_7 = firrtl.seqmem Undefined: !firrtl.cmemory<uint<1>, 8>
+  firrtl.connect %out, %in : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK: firrtl.connect %out, %in
+}
+
 }

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -362,12 +362,6 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.andr %n11 : (!firrtl.uint<10>) -> !firrtl.uint<1>
     node n12 = andr(n11)
 
-    ;  Test that _T and _GEN names are ignored by the parser.
-    ; CHECK: %{{[0-9]+}} = firrtl.wire
-    wire _T_42 : UInt<1>
-    ; CHECK: %{{[0-9]+}} = firrtl.node
-    node _GEN_43 = n12
-
     ; CHECK: = firrtl.not %auto : (!firrtl.uint<1>) -> !firrtl.uint<1>
     node n13 = not(auto)
 
@@ -547,9 +541,9 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
   module flip_one :
     input bf: { flip int_1 : UInt<1>, int_out : UInt<2>}
     ; CHECK: %0 = firrtl.subfield %bf(0)
-    ; CHECK: %1 = firrtl.node %0
+    ; CHECK: %_T = firrtl.node %0
     node _T = bf.int_1
-    ; CHECK: firrtl.when %1 {
+    ; CHECK: firrtl.when %_T {
     when _T :
       skip
 


### PR DESCRIPTION
Part of #1758, move name dropping later in the pipeline.  This makes the parser simpler, but more importantly, keeps names around until after we've processed annotations, some of which produce better output or might require the original names.