### PR TITLE
[FIRRTL] Verilator type-check GCT Views Test

### DIFF
--- a/integration_test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
+++ b/integration_test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
@@ -1,0 +1,103 @@
+; RUN: rm -rf %t && mkdir %t && firtool --firrtl-grand-central --split-verilog --annotation-file %s.anno.json --annotation-file %s.extract.anno.json -o %t %s && cd %t && verilator --sv --lint-only Top.sv bindings.sv
+; RUN: firtool --firrtl-grand-central --verilog --annotation-file %s.anno.json %s > %t.one-file.sv && verilator --sv --lint-only %t.one-file.sv
+; REQUIRES: verilator
+
+circuit Top :
+  module Submodule :
+    input clock : Clock
+    input reset : Reset
+    input in : { uint : UInt<1>, vec : UInt<1>[2], vecOfBundle : { uint : UInt<4>, sint : SInt<2>}[2], otherOther : { other : { uint : UInt<4>, sint : SInt<2>}}}
+    output out : { uint : UInt<1>, vec : UInt<1>[2], vecOfBundle : { uint : UInt<4>, sint : SInt<2>}[2], otherOther : { other : { uint : UInt<4>, sint : SInt<2>}}}
+
+    wire w : { uint : UInt<1>, vec : UInt<1>[2], vecOfBundle : { uint : UInt<4>, sint : SInt<2>}[2], otherOther : { other : { uint : UInt<4>, sint : SInt<2>}}}
+    w.otherOther.other.sint <= in.otherOther.other.sint
+    w.otherOther.other.uint <= in.otherOther.other.uint
+    w.vecOfBundle[0].sint <= in.vecOfBundle[0].sint
+    w.vecOfBundle[0].uint <= in.vecOfBundle[0].uint
+    w.vecOfBundle[1].sint <= in.vecOfBundle[1].sint
+    w.vecOfBundle[1].uint <= in.vecOfBundle[1].uint
+    w.vec[0] <= in.vec[0]
+    w.vec[1] <= in.vec[1]
+    w.uint <= in.uint
+    out.otherOther.other.sint <= w.otherOther.other.sint
+    out.otherOther.other.uint <= w.otherOther.other.uint
+    out.vecOfBundle[0].sint <= w.vecOfBundle[0].sint
+    out.vecOfBundle[0].uint <= w.vecOfBundle[0].uint
+    out.vecOfBundle[1].sint <= w.vecOfBundle[1].sint
+    out.vecOfBundle[1].uint <= w.vecOfBundle[1].uint
+    out.vec[0] <= w.vec[0]
+    out.vec[1] <= w.vec[1]
+    out.uint <= w.uint
+
+  module MyView_companion :
+    output io : { }
+
+    wire _WIRE : UInt<1>
+    _WIRE <= UInt<1>("h0")
+
+  module DUT :
+    input clock : Clock
+    input reset : Reset
+    input in : { uint : UInt<1>, vec : UInt<1>[2], vecOfBundle : { uint : UInt<4>, sint : SInt<2>}[2], otherOther : { other : { uint : UInt<4>, sint : SInt<2>}}}
+    output out : { uint : UInt<1>, vec : UInt<1>[2], vecOfBundle : { uint : UInt<4>, sint : SInt<2>}[2], otherOther : { other : { uint : UInt<4>, sint : SInt<2>}}}
+
+    wire w : { uint : UInt<1>, vec : UInt<1>[2], vecOfBundle : { uint : UInt<4>, sint : SInt<2>}[2], otherOther : { other : { uint : UInt<4>, sint : SInt<2>}}}
+    inst submodule of Submodule
+    submodule.clock <= clock
+    submodule.reset <= reset
+    w.otherOther.other.sint <= in.otherOther.other.sint
+    w.otherOther.other.uint <= in.otherOther.other.uint
+    w.vecOfBundle[0].sint <= in.vecOfBundle[0].sint
+    w.vecOfBundle[0].uint <= in.vecOfBundle[0].uint
+    w.vecOfBundle[1].sint <= in.vecOfBundle[1].sint
+    w.vecOfBundle[1].uint <= in.vecOfBundle[1].uint
+    w.vec[0] <= in.vec[0]
+    w.vec[1] <= in.vec[1]
+    w.uint <= in.uint
+    submodule.in.otherOther.other.sint <= w.otherOther.other.sint
+    submodule.in.otherOther.other.uint <= w.otherOther.other.uint
+    submodule.in.vecOfBundle[0].sint <= w.vecOfBundle[0].sint
+    submodule.in.vecOfBundle[0].uint <= w.vecOfBundle[0].uint
+    submodule.in.vecOfBundle[1].sint <= w.vecOfBundle[1].sint
+    submodule.in.vecOfBundle[1].uint <= w.vecOfBundle[1].uint
+    submodule.in.vec[0] <= w.vec[0]
+    submodule.in.vec[1] <= w.vec[1]
+    submodule.in.uint <= w.uint
+    out.otherOther.other.sint <= submodule.out.otherOther.other.sint
+    out.otherOther.other.uint <= submodule.out.otherOther.other.uint
+    out.vecOfBundle[0].sint <= submodule.out.vecOfBundle[0].sint
+    out.vecOfBundle[0].uint <= submodule.out.vecOfBundle[0].uint
+    out.vecOfBundle[1].sint <= submodule.out.vecOfBundle[1].sint
+    out.vecOfBundle[1].uint <= submodule.out.vecOfBundle[1].uint
+    out.vec[0] <= submodule.out.vec[0]
+    out.vec[1] <= submodule.out.vec[1]
+    out.uint <= submodule.out.uint
+    inst MyView_companion of MyView_companion
+
+  module Top :
+    input clock : Clock
+    input reset : UInt<1>
+    input in : { uint : UInt<1>, vec : UInt<1>[2], vecOfBundle : { uint : UInt<4>, sint : SInt<2>}[2], otherOther : { other : { uint : UInt<4>, sint : SInt<2>}}}
+    output out : { uint : UInt<1>, vec : UInt<1>[2], vecOfBundle : { uint : UInt<4>, sint : SInt<2>}[2], otherOther : { other : { uint : UInt<4>, sint : SInt<2>}}}
+
+    inst dut of DUT
+    dut.clock <= clock
+    dut.reset <= reset
+    dut.in.otherOther.other.sint <= in.otherOther.other.sint
+    dut.in.otherOther.other.uint <= in.otherOther.other.uint
+    dut.in.vecOfBundle[0].sint <= in.vecOfBundle[0].sint
+    dut.in.vecOfBundle[0].uint <= in.vecOfBundle[0].uint
+    dut.in.vecOfBundle[1].sint <= in.vecOfBundle[1].sint
+    dut.in.vecOfBundle[1].uint <= in.vecOfBundle[1].uint
+    dut.in.vec[0] <= in.vec[0]
+    dut.in.vec[1] <= in.vec[1]
+    dut.in.uint <= in.uint
+    out.otherOther.other.sint <= dut.out.otherOther.other.sint
+    out.otherOther.other.uint <= dut.out.otherOther.other.uint
+    out.vecOfBundle[0].sint <= dut.out.vecOfBundle[0].sint
+    out.vecOfBundle[0].uint <= dut.out.vecOfBundle[0].uint
+    out.vecOfBundle[1].sint <= dut.out.vecOfBundle[1].sint
+    out.vecOfBundle[1].uint <= dut.out.vecOfBundle[1].uint
+    out.vec[0] <= dut.out.vec[0]
+    out.vec[1] <= dut.out.vec[1]
+    out.uint <= dut.out.uint

--- a/integration_test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir.anno.json
+++ b/integration_test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir.anno.json
@@ -1,0 +1,515 @@
+[
+  {
+    "class": "sifive.enterprise.grandcentral.ViewAnnotation",
+    "name": "MyView",
+    "companion": "~Top|MyView_companion",
+    "parent": "~Top|DUT",
+    "view": {
+      "class": "sifive.enterprise.grandcentral.AugmentedBundleType",
+      "defName": "MyInterface",
+      "elements": [
+        {
+          "name": "uint",
+          "description": "a wire called 'uint'",
+          "tpe": {
+            "class": "sifive.enterprise.grandcentral.AugmentedGroundType",
+            "ref": {
+              "circuit": "Top",
+              "module": "DUT",
+              "path": [],
+              "ref": "w",
+              "component": [
+                {
+                  "class": "firrtl.annotations.TargetToken$Field",
+                  "value": "uint"
+                }
+              ]
+            },
+            "tpe": {
+              "class": "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
+            }
+          }
+        },
+        {
+          "name": "vec",
+          "description": "a vector called 'vec'",
+          "tpe": {
+            "class": "sifive.enterprise.grandcentral.AugmentedVectorType",
+            "elements": [
+              {
+                "class": "sifive.enterprise.grandcentral.AugmentedGroundType",
+                "ref": {
+                  "circuit": "Top",
+                  "module": "DUT",
+                  "path": [],
+                  "ref": "w",
+                  "component": [
+                    {
+                      "class": "firrtl.annotations.TargetToken$Field",
+                      "value": "vec"
+                    },
+                    {
+                      "class": "firrtl.annotations.TargetToken$Index",
+                      "value": 0
+                    }
+                  ]
+                },
+                "tpe": {
+                  "class": "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
+                }
+              },
+              {
+                "class": "sifive.enterprise.grandcentral.AugmentedGroundType",
+                "ref": {
+                  "circuit": "Top",
+                  "module": "DUT",
+                  "path": [],
+                  "ref": "w",
+                  "component": [
+                    {
+                      "class": "firrtl.annotations.TargetToken$Field",
+                      "value": "vec"
+                    },
+                    {
+                      "class": "firrtl.annotations.TargetToken$Index",
+                      "value": 1
+                    }
+                  ]
+                },
+                "tpe": {
+                  "class": "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "vecOfBundle",
+          "description": "a vector of a bundle",
+          "tpe": {
+            "class": "sifive.enterprise.grandcentral.AugmentedVectorType",
+            "elements": [
+              {
+                "class": "sifive.enterprise.grandcentral.AugmentedBundleType",
+                "defName": "VecOfBundle",
+                "elements": [
+                  {
+                    "name": "sint",
+                    "tpe": {
+                      "class": "sifive.enterprise.grandcentral.AugmentedGroundType",
+                      "ref": {
+                        "circuit": "Top",
+                        "module": "DUT",
+                        "path": [],
+                        "ref": "w",
+                        "component": [
+                          {
+                            "class": "firrtl.annotations.TargetToken$Field",
+                            "value": "vecOfBundle"
+                          },
+                          {
+                            "class": "firrtl.annotations.TargetToken$Index",
+                            "value": 0
+                          },
+                          {
+                            "class": "firrtl.annotations.TargetToken$Field",
+                            "value": "sint"
+                          }
+                        ]
+                      },
+                      "tpe": {
+                        "class": "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
+                      }
+                    }
+                  },
+                  {
+                    "name": "uint",
+                    "tpe": {
+                      "class": "sifive.enterprise.grandcentral.AugmentedGroundType",
+                      "ref": {
+                        "circuit": "Top",
+                        "module": "DUT",
+                        "path": [],
+                        "ref": "w",
+                        "component": [
+                          {
+                            "class": "firrtl.annotations.TargetToken$Field",
+                            "value": "vecOfBundle"
+                          },
+                          {
+                            "class": "firrtl.annotations.TargetToken$Index",
+                            "value": 0
+                          },
+                          {
+                            "class": "firrtl.annotations.TargetToken$Field",
+                            "value": "uint"
+                          }
+                        ]
+                      },
+                      "tpe": {
+                        "class": "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "class": "sifive.enterprise.grandcentral.AugmentedBundleType",
+                "defName": "VecOfBundle",
+                "elements": [
+                  {
+                    "name": "sint",
+                    "tpe": {
+                      "class": "sifive.enterprise.grandcentral.AugmentedGroundType",
+                      "ref": {
+                        "circuit": "Top",
+                        "module": "DUT",
+                        "path": [],
+                        "ref": "w",
+                        "component": [
+                          {
+                            "class": "firrtl.annotations.TargetToken$Field",
+                            "value": "vecOfBundle"
+                          },
+                          {
+                            "class": "firrtl.annotations.TargetToken$Index",
+                            "value": 1
+                          },
+                          {
+                            "class": "firrtl.annotations.TargetToken$Field",
+                            "value": "sint"
+                          }
+                        ]
+                      },
+                      "tpe": {
+                        "class": "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
+                      }
+                    }
+                  },
+                  {
+                    "name": "uint",
+                    "tpe": {
+                      "class": "sifive.enterprise.grandcentral.AugmentedGroundType",
+                      "ref": {
+                        "circuit": "Top",
+                        "module": "DUT",
+                        "path": [],
+                        "ref": "w",
+                        "component": [
+                          {
+                            "class": "firrtl.annotations.TargetToken$Field",
+                            "value": "vecOfBundle"
+                          },
+                          {
+                            "class": "firrtl.annotations.TargetToken$Index",
+                            "value": 1
+                          },
+                          {
+                            "class": "firrtl.annotations.TargetToken$Field",
+                            "value": "uint"
+                          }
+                        ]
+                      },
+                      "tpe": {
+                        "class": "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "otherOther",
+          "description": "another bundle",
+          "tpe": {
+            "class": "sifive.enterprise.grandcentral.AugmentedBundleType",
+            "defName": "OtherOther",
+            "elements": [
+              {
+                "name": "other",
+                "tpe": {
+                  "class": "sifive.enterprise.grandcentral.AugmentedBundleType",
+                  "defName": "Other",
+                  "elements": [
+                    {
+                      "name": "sint",
+                      "tpe": {
+                        "class": "sifive.enterprise.grandcentral.AugmentedGroundType",
+                        "ref": {
+                          "circuit": "Top",
+                          "module": "DUT",
+                          "path": [],
+                          "ref": "w",
+                          "component": [
+                            {
+                              "class": "firrtl.annotations.TargetToken$Field",
+                              "value": "otherOther"
+                            },
+                            {
+                              "class": "firrtl.annotations.TargetToken$Field",
+                              "value": "other"
+                            },
+                            {
+                              "class": "firrtl.annotations.TargetToken$Field",
+                              "value": "sint"
+                            }
+                          ]
+                        },
+                        "tpe": {
+                          "class": "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
+                        }
+                      }
+                    },
+                    {
+                      "name": "uint",
+                      "tpe": {
+                        "class": "sifive.enterprise.grandcentral.AugmentedGroundType",
+                        "ref": {
+                          "circuit": "Top",
+                          "module": "DUT",
+                          "path": [],
+                          "ref": "w",
+                          "component": [
+                            {
+                              "class": "firrtl.annotations.TargetToken$Field",
+                              "value": "otherOther"
+                            },
+                            {
+                              "class": "firrtl.annotations.TargetToken$Field",
+                              "value": "other"
+                            },
+                            {
+                              "class": "firrtl.annotations.TargetToken$Field",
+                              "value": "uint"
+                            }
+                          ]
+                        },
+                        "tpe": {
+                          "class": "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "sub_uint",
+          "description": "a wire called 'uint' in the submodule",
+          "tpe": {
+            "class": "sifive.enterprise.grandcentral.AugmentedGroundType",
+            "ref": {
+              "circuit": "Top",
+              "module": "Submodule",
+              "path": [],
+              "ref": "w",
+              "component": [
+                {
+                  "class": "firrtl.annotations.TargetToken$Field",
+                  "value": "uint"
+                }
+              ]
+            },
+            "tpe": {
+              "class": "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
+            }
+          }
+        },
+        {
+          "name": "sub_vec",
+          "description": "a vector called 'vec' in the submodule",
+          "tpe": {
+            "class": "sifive.enterprise.grandcentral.AugmentedVectorType",
+            "elements": [
+              {
+                "class": "sifive.enterprise.grandcentral.AugmentedGroundType",
+                "ref": {
+                  "circuit": "Top",
+                  "module": "Submodule",
+                  "path": [],
+                  "ref": "w",
+                  "component": [
+                    {
+                      "class": "firrtl.annotations.TargetToken$Field",
+                      "value": "vec"
+                    },
+                    {
+                      "class": "firrtl.annotations.TargetToken$Index",
+                      "value": 0
+                    }
+                  ]
+                },
+                "tpe": {
+                  "class": "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
+                }
+              },
+              {
+                "class": "sifive.enterprise.grandcentral.AugmentedGroundType",
+                "ref": {
+                  "circuit": "Top",
+                  "module": "Submodule",
+                  "path": [],
+                  "ref": "w",
+                  "component": [
+                    {
+                      "class": "firrtl.annotations.TargetToken$Field",
+                      "value": "vec"
+                    },
+                    {
+                      "class": "firrtl.annotations.TargetToken$Index",
+                      "value": 1
+                    }
+                  ]
+                },
+                "tpe": {
+                  "class": "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "sub_vecOfBundle",
+          "description": "a vector of a bundle in the submodule with a\nmultiline comment",
+          "tpe": {
+            "class": "sifive.enterprise.grandcentral.AugmentedVectorType",
+            "elements": [
+              {
+                "class": "sifive.enterprise.grandcentral.AugmentedBundleType",
+                "defName": "Sub_vecOfBundle",
+                "elements": [
+                  {
+                    "name": "sint",
+                    "tpe": {
+                      "class": "sifive.enterprise.grandcentral.AugmentedGroundType",
+                      "ref": {
+                        "circuit": "Top",
+                        "module": "Submodule",
+                        "path": [],
+                        "ref": "w",
+                        "component": [
+                          {
+                            "class": "firrtl.annotations.TargetToken$Field",
+                            "value": "vecOfBundle"
+                          },
+                          {
+                            "class": "firrtl.annotations.TargetToken$Index",
+                            "value": 0
+                          },
+                          {
+                            "class": "firrtl.annotations.TargetToken$Field",
+                            "value": "sint"
+                          }
+                        ]
+                      },
+                      "tpe": {
+                        "class": "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
+                      }
+                    }
+                  },
+                  {
+                    "name": "uint",
+                    "tpe": {
+                      "class": "sifive.enterprise.grandcentral.AugmentedGroundType",
+                      "ref": {
+                        "circuit": "Top",
+                        "module": "Submodule",
+                        "path": [],
+                        "ref": "w",
+                        "component": [
+                          {
+                            "class": "firrtl.annotations.TargetToken$Field",
+                            "value": "vecOfBundle"
+                          },
+                          {
+                            "class": "firrtl.annotations.TargetToken$Index",
+                            "value": 0
+                          },
+                          {
+                            "class": "firrtl.annotations.TargetToken$Field",
+                            "value": "uint"
+                          }
+                        ]
+                      },
+                      "tpe": {
+                        "class": "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "class": "sifive.enterprise.grandcentral.AugmentedBundleType",
+                "defName": "Sub_vecOfBundle",
+                "elements": [
+                  {
+                    "name": "sint",
+                    "tpe": {
+                      "class": "sifive.enterprise.grandcentral.AugmentedGroundType",
+                      "ref": {
+                        "circuit": "Top",
+                        "module": "Submodule",
+                        "path": [],
+                        "ref": "w",
+                        "component": [
+                          {
+                            "class": "firrtl.annotations.TargetToken$Field",
+                            "value": "vecOfBundle"
+                          },
+                          {
+                            "class": "firrtl.annotations.TargetToken$Index",
+                            "value": 1
+                          },
+                          {
+                            "class": "firrtl.annotations.TargetToken$Field",
+                            "value": "sint"
+                          }
+                        ]
+                      },
+                      "tpe": {
+                        "class": "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
+                      }
+                    }
+                  },
+                  {
+                    "name": "uint",
+                    "tpe": {
+                      "class": "sifive.enterprise.grandcentral.AugmentedGroundType",
+                      "ref": {
+                        "circuit": "Top",
+                        "module": "Submodule",
+                        "path": [],
+                        "ref": "w",
+                        "component": [
+                          {
+                            "class": "firrtl.annotations.TargetToken$Field",
+                            "value": "vecOfBundle"
+                          },
+                          {
+                            "class": "firrtl.annotations.TargetToken$Index",
+                            "value": 1
+                          },
+                          {
+                            "class": "firrtl.annotations.TargetToken$Field",
+                            "value": "uint"
+                          }
+                        ]
+                      },
+                      "tpe": {
+                        "class": "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+]

--- a/integration_test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir.extract.anno.json
+++ b/integration_test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir.extract.anno.json
@@ -1,0 +1,7 @@
+[
+  {
+    "class":"sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
+    "directory":"",
+    "filename":"bindings.sv"
+  }
+]


### PR DESCRIPTION
Copy the body of the Grand Central Views test over to an integration test.  Run the `-verilog` and `-split-verilog`/extraction output through Verilator `--lint-only` to type check this.  By type-check, I primarily mean assert that the following two things hold:

1. All interfaces are defined
2. All XMRs are correct (indicating that XMRs are using the correct instance names)