### PR TITLE
[Calyx] Add combinational trait.

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxOps.h
+++ b/include/circt/Dialect/Calyx/CalyxOps.h
@@ -37,6 +37,19 @@ public:
   }
 };
 
+/// A helper function to verify a combinational operation.
+LogicalResult verifyCombinationalOp(Operation *op);
+
+/// Signals that the following operation is combinational.
+template <typename ConcreteType>
+class Combinational
+    : public mlir::OpTrait::TraitBase<ConcreteType, Combinational> {
+public:
+  static LogicalResult verifyTrait(Operation *op) {
+    return verifyCombinationalOp(op);
+  }
+};
+
 /// The port direction attribute follows the implementation style of FIRRTL
 /// module port direction attributes.
 enum Direction { Input = 0, Output };

--- a/include/circt/Dialect/Calyx/CalyxOps.h
+++ b/include/circt/Dialect/Calyx/CalyxOps.h
@@ -46,7 +46,20 @@ class Combinational
     : public mlir::OpTrait::TraitBase<ConcreteType, Combinational> {
 public:
   static LogicalResult verifyTrait(Operation *op) {
-    return verifyCombinationalOp(op);
+    Attribute staticAttribute = op->getAttr("static");
+    if (staticAttribute == nullptr)
+      return success();
+
+    // If the operation has the static attribute, verify it is zero.
+    APInt staticValue = staticAttribute.cast<IntegerAttr>().getValue();
+    if (staticValue == 0)
+      return success();
+
+    SmallVector<char> staticStr;
+    staticValue.toStringUnsigned(staticStr);
+    return op->emitOpError()
+           << "with static value: " << staticStr
+           << ". Cannot have non-zero static value and Combinational trait.";
   }
 };
 

--- a/include/circt/Dialect/Calyx/CalyxOps.h
+++ b/include/circt/Dialect/Calyx/CalyxOps.h
@@ -52,14 +52,9 @@ public:
 
     // If the operation has the static attribute, verify it is zero.
     APInt staticValue = staticAttribute.cast<IntegerAttr>().getValue();
-    if (staticValue == 0)
-      return success();
+    assert(staticValue == 0 && "If combinational, it should take 0 cycles.");
 
-    SmallVector<char> staticStr;
-    staticValue.toStringUnsigned(staticStr);
-    return op->emitOpError()
-           << "with static value: " << staticStr
-           << ". Cannot have non-zero static value and Combinational trait.";
+    return success();
   }
 };
 

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -125,9 +125,8 @@ def MemoryOp : CalyxPrimitive<"memory", []> {
   }];
 }
 
-class CalyxLibraryOp<string mnemonic, list<OpTrait> traits = [
-    Combinational
-  ]> : CalyxPrimitive<"std_" # mnemonic, traits> {
+class CalyxLibraryOp<string mnemonic, list<OpTrait> traits = []> :
+  CalyxPrimitive<"std_" # mnemonic, !listconcat(traits, [Combinational])> {
 
   let summary = "Defines an operation which maps to a Calyx library primitive";
   let description = [{

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -18,6 +18,11 @@ class CalyxPrimitive<string mnemonic, list<OpTrait> traits = []> :
     let skipDefaultBuilders = 1;
 }
 
+/// Trait used to mark certain operations in the Calyx dialect as combinational.
+def Combinational : NativeOpTrait<"Combinational"> {
+  let cppNamespace = "::circt::calyx";
+}
+
 def RegisterOp : CalyxPrimitive<"register", [
     SameTypeConstraint<"in", "out">
   ]> {
@@ -117,20 +122,12 @@ def MemoryOp : CalyxPrimitive<"memory", []> {
     Value clk()       { return getResult(getNumDimensions() + 2); }
     Value readData()  { return getResult(getNumDimensions() + 3); }
     Value done()      { return getResult(getNumDimensions() + 4); }
-
-    /// Returns the ports used in a memory read.
-    SmallVector<Value> getReadPorts() {
-      SmallVector<Value> ports;
-      for (size_t i = 0, e = addrSizes().size(); i != e; ++i)
-        ports.push_back(getResult(i));
-      ports.push_back(readData());
-      return ports;
-    }
   }];
 }
 
-class CalyxLibraryOp<string mnemonic, list<OpTrait> traits = []> :
-  CalyxPrimitive<"std_" # mnemonic, traits> {
+class CalyxLibraryOp<string mnemonic, list<OpTrait> traits = [
+    Combinational
+  ]> : CalyxPrimitive<"std_" # mnemonic, traits> {
 
   let summary = "Defines an operation which maps to a Calyx library primitive";
   let description = [{

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -345,6 +345,23 @@ LogicalResult calyx::verifyControlLikeOp(Operation *op) {
   return verifyControlBody(op);
 }
 
+LogicalResult calyx::verifyCombinationalOp(Operation *op) {
+  Attribute staticAttribute = op->getAttr("static");
+  if (staticAttribute == nullptr)
+    return success();
+
+  // If the operation has the static attribute, verify it is zero.
+  APInt staticValue = staticAttribute.cast<IntegerAttr>().getValue();
+  if (staticValue == 0)
+    return success();
+
+  SmallVector<char> staticStr;
+  staticValue.toStringUnsigned(staticStr);
+  return op->emitOpError()
+         << "with static value: " << staticStr
+         << ". Cannot have non-zero static value and Combinational trait.";
+}
+
 //===----------------------------------------------------------------------===//
 // ProgramOp
 //===----------------------------------------------------------------------===//
@@ -731,38 +748,54 @@ static LogicalResult verifyWiresOp(WiresOp wires) {
 // CombGroupOp
 //===----------------------------------------------------------------------===//
 
+/// Determines whether the given value indicates this is a memory store.
+static bool isMemoryStorePort(Value port) {
+  Operation *op = port.getDefiningOp();
+  if (op == nullptr)
+    return false;
+
+  if (auto r = dyn_cast<RegisterOp>(op))
+    return port != r.outPort();
+
+  if (auto m = dyn_cast<MemoryOp>(op)) {
+    auto writePorts = {m.writeData(), m.writeEn()};
+    return llvm::any_of(writePorts, [&](Value p) { return p == port; });
+  }
+
+  return false;
+}
+
 /// Verifies the defining operation of a value is combinational.
 static LogicalResult isCombinational(Value value, GroupInterface group) {
   Operation *definingOp = value.getDefiningOp();
-  if (definingOp == nullptr)
+  if (definingOp == nullptr || definingOp->hasTrait<Combinational>())
+    // This is a port of the parent component or combinational.
     return success();
 
-  // For now, assumes all component instances may be combinational. Once
-  // combinational components are supported, this can be changed.
+  // For now, assumes all component instances are combinational. Once
+  // combinational components are supported, this can be strictly enforced.
   if (isa<InstanceOp>(definingOp))
     return success();
 
-  // Reads to MemoryOp and RegisterOp are combinational. Writes are not.
-  if (auto r = dyn_cast<RegisterOp>(definingOp)) {
-    if (value != r.outPort())
-      return group->emitOpError()
-             << "with register: \""
-             << cast<CellInterface>(definingOp).instanceName()
-             << "\" is conducting a memory store. This is not combinational.";
-  } else if (auto m = dyn_cast<MemoryOp>(definingOp)) {
-    if (llvm::none_of(m.getReadPorts(), [&](Value p) { return p == value; }))
-      return group->emitOpError()
-             << "with memory: \""
-             << cast<CellInterface>(definingOp).instanceName()
-             << "\" is conducting a memory store. This is not combinational.";
-  }
+  // Constants and logical operations are OK.
+  if (isa<comb::CombDialect, hw::HWDialect>(definingOp->getDialect()))
+    return success();
 
-  return success();
+  // Either this is a non-combinational cell or an improper use of memory.
+  auto cell = cast<CellInterface>(definingOp);
+  bool isMemoryStore = isMemoryStorePort(value);
+  if (!isMemoryStore)
+    return success();
+
+  assert(cell && "this should be a CellInterface.");
+  return group->emitOpError()
+         << "with " << cell->getName() << ": \"" << cell.instanceName() << "\" "
+         << (isMemoryStore ? "is conducting a memory store. " : "")
+         << "This is not combinational.";
 }
 
 /// Verifies a combinational group may contain only combinational primitives or
 /// perform combinational logic.
-// TODO(www.github.com/llvm/circt/issues/1739): Add Combinational trait.
 static LogicalResult verifyCombGroupOp(CombGroupOp group) {
 
   for (auto &&op : *group.getBody()) {

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -345,23 +345,6 @@ LogicalResult calyx::verifyControlLikeOp(Operation *op) {
   return verifyControlBody(op);
 }
 
-LogicalResult calyx::verifyCombinationalOp(Operation *op) {
-  Attribute staticAttribute = op->getAttr("static");
-  if (staticAttribute == nullptr)
-    return success();
-
-  // If the operation has the static attribute, verify it is zero.
-  APInt staticValue = staticAttribute.cast<IntegerAttr>().getValue();
-  if (staticValue == 0)
-    return success();
-
-  SmallVector<char> staticStr;
-  staticValue.toStringUnsigned(staticStr);
-  return op->emitOpError()
-         << "with static value: " << staticStr
-         << ". Cannot have non-zero static value and Combinational trait.";
-}
-
 //===----------------------------------------------------------------------===//
 // ProgramOp
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -564,7 +564,7 @@ calyx.program {
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
-      // expected-error @+1 {{'calyx.comb_group' op with register: "r" is conducting a memory store. This is not combinational.}}
+      // expected-error @+1 {{'calyx.comb_group' op with calyx.register: "r" is conducting a memory store. This is not combinational.}}
       calyx.comb_group @IncorrectCombGroup {
         calyx.assign %r.in = %c1_1 : i1
         calyx.assign %r.write_en = %c1_1 : i1
@@ -572,6 +572,39 @@ calyx.program {
       calyx.group @A {
         calyx.assign %r.in = %c1_1 : i1
         calyx.assign %r.write_en = %c1_1 : i1
+        calyx.group_done %r.done : i1
+      }
+    }
+    calyx.control {
+      calyx.seq {
+        calyx.if %r.out with @IncorrectCombGroup {
+          calyx.enable @A
+        }
+      }
+    }
+  }
+}
+
+// -----
+
+calyx.program {
+  calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
+    %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory "m"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
+    %c1_i8 = hw.constant 1 : i8
+    %c0_i6 = hw.constant 0 : i6
+    %c1_i1 = hw.constant 1 : i1
+    calyx.wires {
+      // expected-error @+1 {{'calyx.comb_group' op with calyx.memory: "m" is conducting a memory store. This is not combinational.}}
+      calyx.comb_group @IncorrectCombGroup {
+        calyx.assign %m.write_data = %c1_i8 : i8
+        calyx.assign %m.addr0 = %c0_i6 : i6
+        calyx.assign %m.addr1 = %c0_i6 : i6
+        calyx.assign %m.write_en = %c1_i1 : i1
+      }
+      calyx.group @A {
+        calyx.assign %r.in = %c1_i1 : i1
+        calyx.assign %r.write_en = %c1_i1 : i1
         calyx.group_done %r.done : i1
       }
     }

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -741,16 +741,3 @@ calyx.program {
     calyx.control { calyx.enable @A }
   }
 }
-
-// -----
-
-calyx.program {
-
-  calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    // expected-error @+1 {{'calyx.std_gt' op with static value: 1. Cannot have non-zero static value and Combinational trait.}}
-    %gt.left, %gt.right, %gt.out = calyx.std_gt "gt" {static=1} : i8, i8, i1
-    %c1_1 = hw.constant 1 : i1
-    calyx.wires { calyx.assign %done = %c1_1 : i1 }
-    calyx.control {}
-  }
-}

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -564,7 +564,7 @@ calyx.program {
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
-      // expected-error @+1 {{'calyx.comb_group' op with calyx.register: "r" is conducting a memory store. This is not combinational.}}
+      // expected-error @+1 {{'calyx.comb_group' op with register: "r" is conducting a memory store. This is not combinational.}}
       calyx.comb_group @IncorrectCombGroup {
         calyx.assign %r.in = %c1_1 : i1
         calyx.assign %r.write_en = %c1_1 : i1
@@ -595,7 +595,7 @@ calyx.program {
     %c0_i6 = hw.constant 0 : i6
     %c1_i1 = hw.constant 1 : i1
     calyx.wires {
-      // expected-error @+1 {{'calyx.comb_group' op with calyx.memory: "m" is conducting a memory store. This is not combinational.}}
+      // expected-error @+1 {{'calyx.comb_group' op with memory: "m" is conducting a memory store. This is not combinational.}}
       calyx.comb_group @IncorrectCombGroup {
         calyx.assign %m.write_data = %c1_i8 : i8
         calyx.assign %m.addr0 = %c0_i6 : i6

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -617,3 +617,16 @@ calyx.program {
     }
   }
 }
+
+// -----
+
+calyx.program {
+
+  calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
+    // expected-error @+1 {{'calyx.std_gt' op with static value: 1. Cannot have non-zero static value and Combinational trait.}}
+    %gt.left, %gt.right, %gt.out = calyx.std_gt "gt" {static=1} : i8, i8, i1
+    %c1_1 = hw.constant 1 : i1
+    calyx.wires { calyx.assign %done = %c1_1 : i1 }
+    calyx.control {}
+  }
+}

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -39,6 +39,8 @@ calyx.program {
     %slice.in, %slice.out = calyx.std_slice "slice" : i8, i7
     %not.in, %not.out = calyx.std_not "not" : i8, i8
     %c1_i1 = hw.constant 1 : i1
+    %c0_i6 = hw.constant 0 : i6
+    %c0_i8 = hw.constant 0 : i8
 
     calyx.wires {
       // CHECK: calyx.group @Group1 {
@@ -48,9 +50,11 @@ calyx.program {
         calyx.assign %c1.in = %c0.out : i8
         calyx.group_done %c1.done : i1
       }
-      calyx.comb_group @Group2 {
-        // CHECK: calyx.assign %c2.in = %c0.out, %done ? : i8
-        calyx.assign %c2.in = %c0.out, %done ? : i8
+      calyx.comb_group @ReadMemory {
+        calyx.assign %m.addr0 = %c0_i6 : i6
+        calyx.assign %m.addr1 = %c0_i6 : i6
+        calyx.assign %gt.left = %m.read_data : i8
+        calyx.assign %gt.right = %c0_i8 : i8
       }
       calyx.group @Group3 {
         calyx.assign %r.in = %c0.out : i8
@@ -64,7 +68,7 @@ calyx.program {
       // CHECK-NEXT: calyx.enable @Group1
       // CHECK-NEXT: calyx.enable @Group3
       // CHECK-NEXT: calyx.seq {
-      // CHECK-NEXT: calyx.if %c2.out with @Group2 {
+      // CHECK-NEXT: calyx.if %gt.out with @ReadMemory {
       // CHECK-NEXT: calyx.enable @Group1
       // CHECK-NEXT: } else {
       // CHECK-NEXT: calyx.enable @Group3
@@ -72,7 +76,7 @@ calyx.program {
       // CHECK-NEXT: calyx.if %c2.out {
       // CHECK-NEXT: calyx.enable @Group1
       // CHECK-NEXT: }
-      // CHECK-NEXT: calyx.while %c2.out with @Group2 {
+      // CHECK-NEXT: calyx.while %gt.out with @ReadMemory {
       // CHECK-NEXT: calyx.while %c2.out {
       // CHECK-NEXT: calyx.enable @Group1
       // CHECK:      calyx.par {
@@ -83,7 +87,7 @@ calyx.program {
           calyx.enable @Group1
           calyx.enable @Group3
           calyx.seq {
-            calyx.if %c2.out with @Group2 {
+            calyx.if %gt.out with @ReadMemory {
               calyx.enable @Group1
             } else {
               calyx.enable @Group3
@@ -91,7 +95,7 @@ calyx.program {
             calyx.if %c2.out {
               calyx.enable @Group1
             }
-            calyx.while %c2.out with @Group2 {
+            calyx.while %gt.out with @ReadMemory {
               calyx.while %c2.out {
                 calyx.enable @Group1
               }

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -51,6 +51,10 @@ calyx.program {
         calyx.group_done %c1.done : i1
       }
       calyx.comb_group @ReadMemory {
+        // CHECK: calyx.assign %m.addr0 = %c0_i6 : i6
+        // CHECK-NEXT: calyx.assign %m.addr1 = %c0_i6 : i6
+        // CHECK-NEXT: calyx.assign %gt.left = %m.read_data : i8
+        // CHECK-NEXT: calyx.assign %gt.right = %c0_i8 : i8
         calyx.assign %m.addr0 = %c0_i6 : i6
         calyx.assign %m.addr1 = %c0_i6 : i6
         calyx.assign %gt.left = %m.read_data : i8


### PR DESCRIPTION
This adds a combinational trait to Calyx operations. We can throw this on all non-memory operations for now, since they are all combinational. Eventually we'll need to split this off. Closes #1739. 

I also fixed a bug where it was considering a memory load as a store, since the address ports are used when both storing and loading to a MemoryOp. A test is added to verify this no longer occurs.