### PR TITLE
[FIRRTL] Replace some lowerings with UnrealizedConversionCastOp

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -600,37 +600,6 @@ def VerbatimWireOp : FIRRTLOp<"verbatim.wire",
 // Conversions to/from fixed-width signless integer types in standard dialect.
 //===----------------------------------------------------------------------===//
 
-// firrtl.stdIntCast takes inputs and results that are either signless integers
-// or integer-like things in the FIRRTL dialect.
-def IntCastType : AnyTypeOf<[PassiveType, AnySignlessInteger],
-                            "passive FIRRTL type or signless builtin integer">;
-
-// This operation converts from an SInt/UInt/Clock/etc to a signless integer
-// type, or visa-versa.  FIRRTL source/destination types must be passive.
-def StdIntCastOp : FIRRTLOp<"stdIntCast", [NoSideEffect]> {
-  let arguments = (ins IntCastType:$input);
-  let results = (outs IntCastType:$result);
-
-  let assemblyFormat =
-    "$input attr-dict `:` functional-type($input, $result)";
-
-  let hasFolder = 1;
-  let verifier = "return ::verifyStdIntCastOp(*this);";
-}
-
-// This operation converts from an Analog type to an InOut type of the
-// corresponding width, or visa-versa.
-def AnalogInOutCastOp : FIRRTLOp<"analogInOutCast", [NoSideEffect]> {
-  let arguments = (ins AnyType:$input);
-  let results = (outs AnyType:$result);
-
-  let assemblyFormat =
-    "$input attr-dict `:` functional-type($input, $result)";
-
-  let hasFolder = 1;
-  let verifier = "return ::verifyAnalogInOutCastOp(*this);";
-}
-
 // This operation converts from a struct to a bundle
 // type, or visa-versa.  FIRRTL source/destination types must be passive.
 def HWStructCastOp : FIRRTLOp<"hwStructCast", [NoSideEffect]> {
@@ -641,36 +610,4 @@ def HWStructCastOp : FIRRTLOp<"hwStructCast", [NoSideEffect]> {
     "$input attr-dict `:` functional-type($input, $result)";
 
   let verifier = "return ::verifyHWStructCastOp(*this);";
-}
-
-// MLIR specific pseudo ops.
-
-
-class PassiveConstraint<string value, string resultValue>
-  : TypesMatchWith<"type should be a passive type",
-                   value, resultValue,
-                   "firrtl::getPassiveType($_self)">;
-
-// Convert a value with non-passive type to a value with passive type.
-def AsPassivePrimOp : FIRRTLOp<"asPassive", [NoSideEffect,
-                               PassiveConstraint<"input", "result">]> {
-  let arguments = (ins FIRRTLType:$input);
-  let results = (outs PassiveType:$result);
-
-  let hasFolder = 1;
-  let assemblyFormat = "$input attr-dict `:` type($input)";
-
-  let builders = [
-    OpBuilder<(ins "Value":$input)>
-  ];
-}
-
-// Convert a passive value to a non-passive type.
-def AsNonPassivePrimOp : FIRRTLOp<"asNonPassive", [NoSideEffect,
-                                  PassiveConstraint<"result", "input">]> {
-  let arguments = (ins PassiveType:$input);
-  let results = (outs FIRRTLType:$result);
-
-  let hasFolder = 1;
-  let assemblyFormat = "$input attr-dict `:` type($result)";
 }

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -14,6 +14,7 @@
 #define CIRCT_DIALECT_FIRRTL_FIRRTLVISITORS_H
 
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "llvm/ADT/TypeSwitch.h"
 
 namespace circt {
@@ -43,13 +44,10 @@ public:
             CvtPrimOp, NegPrimOp, NotPrimOp, AndRPrimOp, OrRPrimOp, XorRPrimOp,
             // Miscellaneous.
             BitsPrimOp, HeadPrimOp, MuxPrimOp, PadPrimOp, ShlPrimOp, ShrPrimOp,
-            TailPrimOp, VerbatimExprOp, AsPassivePrimOp, AsNonPassivePrimOp,
-
-            // Conversion from FIRRTL to HW dialect types.
-            StdIntCastOp, HWStructCastOp, AnalogInOutCastOp>(
-            [&](auto expr) -> ResultType {
-              return thisCast->visitExpr(expr, args...);
-            })
+            TailPrimOp, VerbatimExprOp, HWStructCastOp,
+            mlir::UnrealizedConversionCastOp>([&](auto expr) -> ResultType {
+          return thisCast->visitExpr(expr, args...);
+        })
         .Default([&](auto expr) -> ResultType {
           return thisCast->visitInvalidExpr(op, args...);
         });
@@ -138,13 +136,10 @@ public:
   HANDLE(ShrPrimOp, Unhandled);
   HANDLE(TailPrimOp, Unhandled);
   HANDLE(VerbatimExprOp, Unhandled);
-  HANDLE(AsPassivePrimOp, Unhandled);
-  HANDLE(AsNonPassivePrimOp, Unhandled);
 
-  // Conversion from FIRRTL to HW dialect types.
-  HANDLE(StdIntCastOp, Unhandled);
+  // Conversions.
   HANDLE(HWStructCastOp, Unhandled);
-  HANDLE(AnalogInOutCastOp, Unhandled);
+  HANDLE(mlir::UnrealizedConversionCastOp, Unhandled);
 #undef HANDLE
 };
 

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -81,13 +81,13 @@ static Value castToFIRRTLType(Value val, Type type,
                               ImplicitLocOpBuilder &builder) {
   auto firType = type.cast<FIRRTLType>();
 
-  // Use UnrealizedConversionCastOp except for a bundle type.
+  // Use HWStructCastOp for a bundle type.
   if (BundleType bundle = type.dyn_cast<BundleType>()) {
     val = builder.createOrFold<HWStructCastOp>(firType.getPassiveType(), val);
-  } else {
-    val = builder.create<mlir::UnrealizedConversionCastOp>(firType, val)
-              .getResult(0);
   }
+
+  val = builder.create<mlir::UnrealizedConversionCastOp>(firType, val)
+            .getResult(0);
 
   return val;
 }

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1376,50 +1376,6 @@ LogicalResult ConnectOp::canonicalize(ConnectOp op, PatternRewriter &rewriter) {
 }
 
 //===----------------------------------------------------------------------===//
-// Conversions
-//===----------------------------------------------------------------------===//
-
-OpFoldResult StdIntCastOp::fold(ArrayRef<Attribute> operands) {
-  if (auto castInput =
-          dyn_cast_or_null<StdIntCastOp>(getOperand().getDefiningOp()))
-    if (castInput.getOperand().getType() == getType())
-      return castInput.getOperand();
-
-  return {};
-}
-
-OpFoldResult AnalogInOutCastOp::fold(ArrayRef<Attribute> operands) {
-  if (auto castInput =
-          dyn_cast_or_null<AnalogInOutCastOp>(getOperand().getDefiningOp()))
-    if (castInput.getOperand().getType() == getType())
-      return castInput.getOperand();
-
-  return {};
-}
-
-OpFoldResult AsPassivePrimOp::fold(ArrayRef<Attribute> operands) {
-  // If the input is already passive, then we don't need a conversion.
-  if (getOperand().getType() == getType())
-    return getOperand();
-
-  if (auto castInput =
-          dyn_cast_or_null<AsNonPassivePrimOp>(getOperand().getDefiningOp()))
-    if (castInput.getOperand().getType() == getType())
-      return castInput.getOperand();
-
-  return {};
-}
-
-OpFoldResult AsNonPassivePrimOp::fold(ArrayRef<Attribute> operands) {
-  if (auto castInput =
-          dyn_cast_or_null<AsPassivePrimOp>(getOperand().getDefiningOp()))
-    if (castInput.getOperand().getType() == getType())
-      return castInput.getOperand();
-
-  return {};
-}
-
-//===----------------------------------------------------------------------===//
 // Statements
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -127,8 +127,8 @@ public:
   Value convertToPassive(OpBuilder &builder, Location loc, Value input) {
     auto inType = input.getType().cast<FIRRTLType>();
     return builder
-        .create<mlir::UnrealizedConversionCastOp>(
-            loc, inType.getPassiveType(), input)
+        .create<mlir::UnrealizedConversionCastOp>(loc, inType.getPassiveType(),
+                                                  input)
         .getResult(0);
   }
 

--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -126,8 +126,10 @@ public:
   /// If a value has an outer flip, convert the value to passive.
   Value convertToPassive(OpBuilder &builder, Location loc, Value input) {
     auto inType = input.getType().cast<FIRRTLType>();
-    return builder.createOrFold<AsPassivePrimOp>(loc, inType.getPassiveType(),
-                                                 input);
+    return builder
+        .create<mlir::UnrealizedConversionCastOp>(
+            loc, inType.getPassiveType(), input)
+        .getResult(0);
   }
 
   /// Take two connection operations and merge them in to a new connect under a

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1374,9 +1374,10 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
       })
 
       // Handle operations whose output width matches the input width.
-      .Case<NotPrimOp, AsSIntPrimOp, AsUIntPrimOp, AsPassivePrimOp,
-            AsNonPassivePrimOp>(
+      .Case<NotPrimOp, AsSIntPrimOp, AsUIntPrimOp>(
           [&](auto op) { setExpr(op.getResult(), getExpr(op.input())); })
+      .Case<mlir::UnrealizedConversionCastOp>(
+          [&](auto op) { setExpr(op.getResult(0), getExpr(op.getOperand(0))); })
 
       // Handle operations with a single result type that always has a
       // well-known width.

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -260,6 +260,7 @@ struct TypeLoweringVisitor : public FIRRTLVisitor<TypeLoweringVisitor> {
   void visitExpr(InvalidValueOp op);
   void visitExpr(SubaccessOp op);
   void visitExpr(MuxPrimOp op);
+  void visitExpr(mlir::UnrealizedConversionCastOp op);
   void visitStmt(ConnectOp op);
   void visitStmt(PartialConnectOp op);
   void visitStmt(WhenOp op);
@@ -876,6 +877,16 @@ void TypeLoweringVisitor::visitExpr(MuxPrimOp op) {
     auto high = getSubWhatever(op.high(), field.index);
     auto low = getSubWhatever(op.low(), field.index);
     return builder->create<MuxPrimOp>(op.sel(), high, low);
+  };
+  lowerProducer(op, clone);
+}
+
+// Expand UnrealizedConversionCastOp of aggregates
+void TypeLoweringVisitor::visitExpr(mlir::UnrealizedConversionCastOp op) {
+  auto clone = [&](FlatBundleFieldEntry field, StringRef name,
+                   ArrayAttr attrs) -> Operation * {
+    auto input = getSubWhatever(op.getOperand(0), field.index);
+    return builder->create<mlir::UnrealizedConversionCastOp>(field.type, input);
   };
   lowerProducer(op, clone);
 }

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -260,7 +260,6 @@ struct TypeLoweringVisitor : public FIRRTLVisitor<TypeLoweringVisitor> {
   void visitExpr(InvalidValueOp op);
   void visitExpr(SubaccessOp op);
   void visitExpr(MuxPrimOp op);
-  void visitExpr(AsPassivePrimOp op);
   void visitStmt(ConnectOp op);
   void visitStmt(PartialConnectOp op);
   void visitStmt(WhenOp op);
@@ -877,16 +876,6 @@ void TypeLoweringVisitor::visitExpr(MuxPrimOp op) {
     auto high = getSubWhatever(op.high(), field.index);
     auto low = getSubWhatever(op.low(), field.index);
     return builder->create<MuxPrimOp>(op.sel(), high, low);
-  };
-  lowerProducer(op, clone);
-}
-
-// Expand AsPassivePrimOp of aggregates
-void TypeLoweringVisitor::visitExpr(AsPassivePrimOp op) {
-  auto clone = [&](FlatBundleFieldEntry field, StringRef name,
-                   ArrayAttr attrs) -> Operation * {
-    auto input = getSubWhatever(op.input(), field.index);
-    return builder->create<AsPassivePrimOp>(field.type, input);
   };
   lowerProducer(op, clone);
 }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -418,7 +418,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %hits_1_7 = firrtl.node %io_cpu_flush.wire {name = "hits_1_7", annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<1>
     // CHECK-NEXT:  %hits_1_7 = sv.wire sym @__foo__hits_1_7
     // CHECK-NEXT:  sv.assign %hits_1_7, [[IO]] : i1
-    %1455 = firrtl.asPassive %hits_1_7 : !firrtl.uint<1>
+    %1455 = builtin.unrealized_conversion_cast %hits_1_7 : !firrtl.uint<1> to !firrtl.uint<1>
   }
 
   // CHECK: sv.bind @[[bazSymbol:.+]] in @bindTest

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -363,13 +363,11 @@ firrtl.circuit "Foo" {
   // CHECK-LABEL: @PassiveCastOp
   firrtl.module @PassiveCastOp() {
     // CHECK: %0 = firrtl.wire : !firrtl.uint<5>
-    // CHECK: %1 = firrtl.asNonPassive {{.*}} : !firrtl.uint<5>
-    // CHECK: %2 = firrtl.asPassive {{.*}} : !firrtl.uint<5>
+    // CHECK: %1 = builtin.unrealized_conversion_cast %ui : !firrtl.uint<5> to !firrtl.uint<5>
     %ui = firrtl.wire : !firrtl.uint
     %0 = firrtl.wire : !firrtl.uint
-    %1 = firrtl.asNonPassive %ui : !firrtl.uint
-    %2 = firrtl.asPassive %1 : !firrtl.uint
-    firrtl.connect %0, %2 : !firrtl.uint, !firrtl.uint
+    %1 = builtin.unrealized_conversion_cast %ui : !firrtl.uint to !firrtl.uint
+    firrtl.connect %0, %1 : !firrtl.uint, !firrtl.uint
     %c0_ui5 = firrtl.constant 0 : !firrtl.uint<5>
     firrtl.connect %ui, %c0_ui5 : !firrtl.uint, !firrtl.uint<5>
   }

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -85,11 +85,11 @@ firrtl.module @no_ports() {
 // stdIntCast can work with clock inputs/outputs too.
 // CHECK-LABEL: @ClockCast
 firrtl.module @ClockCast(in %clock: !firrtl.clock) {
-  // CHECK: %0 = firrtl.stdIntCast %clock : (!firrtl.clock) -> i1
-  %0 = firrtl.stdIntCast %clock : (!firrtl.clock) -> i1
+  // CHECK: %0 = builtin.unrealized_conversion_cast %clock : !firrtl.clock to i1
+  %0 = builtin.unrealized_conversion_cast %clock : !firrtl.clock to i1
 
-  // CHECK: %1 = firrtl.stdIntCast %0 : (i1) -> !firrtl.clock
-  %1 = firrtl.stdIntCast %0 : (i1) -> !firrtl.clock
+  // CHECK: %1 = builtin.unrealized_conversion_cast %0 : i1 to !firrtl.clock
+  %1 = builtin.unrealized_conversion_cast %0 : i1 to !firrtl.clock
 }
 
 


### PR DESCRIPTION
Will close #515.
This PR replaces StdIntCastOp/AnalogInOutCastOp/AsPassivePrimOp/AsNonPassivePrimOp with UnrealizedConversionCastOp.
This includes changes of InferWidth and LowerTypes.  
It makes conversions much simpler but also verification weak so maybe it is better to left as it is.
