### PR TITLE
[LowerToHW] Mark the Design Under Test module with attribute "DesignUnderTest" [NFC]

### DIFF
--- a/docs/FIRRTLAnnotations.md
+++ b/docs/FIRRTLAnnotations.md
@@ -305,7 +305,7 @@ Example:
 
 | Property   | Type   | Description                             |
 | ---------- | ------ | -------------                           |
-| class      | string | `firrte.transforms.DontTouchAnnotation` |
+| class      | string | `firrtl.transforms.DontTouchAnnotation` |
 | target     | string | Reference target                        |
 
 The `DontTouchAnnotation` prevents the removal of elements through
@@ -735,4 +735,11 @@ Example:
   "source":"~GCTMemTap|GCTMemTap>mem"
 }
 ```
+#### Design Under Test
 
+| Property   | Type   | Description                             |
+| ---------- | ------ | -------------                           |
+| class      | string | `sifive.enterprise.firrtl.MarkDUTAnnotation` |
+| target     | string | Reference target                        |
+
+Marks what is the DUT (and not the testbench). This annotation can be lowered to the attribute `DesignUnderTest = [true]` to indicate the module which is the DUT.

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
@@ -68,7 +68,7 @@ firrtl.circuit "moduleAnno" attributes {annotations = [{class = "circuitOpAnnota
 
 // -----
 
-// The following annotations should be whitelisted and not trigger a warning
+// The following annotations should be ignored and not trigger a warning
 // when lowering to HW.
 firrtl.circuit "Foo" {
     firrtl.module @Foo() attributes {annotations = [

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -899,4 +899,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.force %out, %in : !firrtl.uint<42>, !firrtl.uint<42>
   }
 
+  // CHECK-LABEL: hw.module @FooDUT
+  // CHECK: attributes {DesignUnderTest = [true]} 
+  firrtl.module @FooDUT() attributes {annotations = [
+      {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {}
 }


### PR DESCRIPTION
The annotation `sifive.enterprise.firrtl.MarkDUTAnnotation` , marks what is the DUT (and not the testbench). 
Lower the annotation, to the attribute "DesignUnderTest", during `LowerToHW`.
Adds `{DesignUnderTest = [true]}` to the module which has this annotation.
Other `sv/hw` passes can use this attribute to identify the DUT.