### PR TITLE
[HW] [MSFT] Remove unnecessary assertions in `getReferencedModule` and add SymbolOpUserInterface to MSFT InstanceOp.

### DIFF
--- a/include/circt/Dialect/MSFT/MSFT.td
+++ b/include/circt/Dialect/MSFT/MSFT.td
@@ -16,6 +16,7 @@
 include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpAsmInterface.td"
+include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Pass/PassBase.td"
 
 def MSFTDialect : Dialect {

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -12,8 +12,7 @@ class MSFTOp<string mnemonic, list<OpTrait> traits = []> :
 
 def InstanceOp : MSFTOp<"instance", [
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-        DeclareOpInterfaceMethods<SymbolUserOpInterface>,
-        HasParent<"hw::HWModuleOp">
+        DeclareOpInterfaceMethods<SymbolUserOpInterface>
     ]> {
   let summary = "Create an instance of a module";
 

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -11,7 +11,9 @@ class MSFTOp<string mnemonic, list<OpTrait> traits = []> :
     Op<MSFTDialect, mnemonic, traits>;
 
 def InstanceOp : MSFTOp<"instance", [
-        DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]> ]> {
+        DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+        HasParent<"hw::HWModuleOp">
+    ]> {
   let summary = "Create an instance of a module";
 
   let arguments = (ins StrAttr:$instanceName,

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -22,6 +22,8 @@ def InstanceOp : MSFTOp<"instance", [
                        OptionalAttr<DictionaryAttr>:$parameters);
   let results = (outs Variadic<AnyType>);
 
+  let verifier = "return ::verify$cppClass(*this);";
+
   let extraClassDeclaration = [{
     // Return the name of the specified result or empty string if it cannot be
     // determined.

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -12,6 +12,7 @@ class MSFTOp<string mnemonic, list<OpTrait> traits = []> :
 
 def InstanceOp : MSFTOp<"instance", [
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+        DeclareOpInterfaceMethods<SymbolUserOpInterface>,
         HasParent<"hw::HWModuleOp">
     ]> {
   let summary = "Create an instance of a module";
@@ -21,8 +22,6 @@ def InstanceOp : MSFTOp<"instance", [
                        Variadic<AnyType>:$inputs,
                        OptionalAttr<DictionaryAttr>:$parameters);
   let results = (outs Variadic<AnyType>);
-
-  let verifier = "return ::verify$cppClass(*this);";
 
   let extraClassDeclaration = [{
     // Return the name of the specified result or empty string if it cannot be

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -759,16 +759,12 @@ Operation *InstanceOp::getReferencedModule(const SymbolCache *cache) {
 
   auto topLevelModuleOp = (*this)->getParentOfType<ModuleOp>();
 
-  Operation *referencedModule = topLevelModuleOp.lookupSymbol(moduleName());
-  assert(referencedModule && "This references a non-existent module.");
-  return referencedModule;
+  return topLevelModuleOp.lookupSymbol(moduleName());
 }
 
 // Helper function to verify instance op types
 static LogicalResult verifyInstanceOpTypes(InstanceOp op,
                                            Operation *referencedModule) {
-  assert(referencedModule && "referenced module must not be null");
-
   // Check operand types first.
   auto numOperands = op->getNumOperands();
   auto expectedOperandTypes = getModuleType(referencedModule).getInputs();

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -758,10 +758,10 @@ Operation *InstanceOp::getReferencedModule(const SymbolCache *cache) {
       return result;
 
   auto topLevelModuleOp = (*this)->getParentOfType<ModuleOp>();
-  assert(topLevelModuleOp &&
-         "This instance references a non-existent ModuleOp");
 
-  return topLevelModuleOp.lookupSymbol(moduleName());
+  Operation *referencedModule = topLevelModuleOp.lookupSymbol(moduleName());
+  assert(referencedModule && "This references a non-existent module.");
+  return referencedModule;
 }
 
 // Helper function to verify instance op types

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -758,8 +758,8 @@ Operation *InstanceOp::getReferencedModule(const SymbolCache *cache) {
       return result;
 
   auto topLevelModuleOp = (*this)->getParentOfType<ModuleOp>();
-  if (!topLevelModuleOp)
-    return nullptr;
+  assert(topLevelModuleOp &&
+         "This instance references a non-existent ModuleOp");
 
   return topLevelModuleOp.lookupSymbol(moduleName());
 }
@@ -958,8 +958,6 @@ static void printInstanceOp(OpAsmPrinter &p, InstanceOp op) {
 StringAttr InstanceOp::getArgumentName(size_t idx, const SymbolCache *cache) {
   // TODO: Remove when argNames/resultNames are stored on instances.
   auto *module = getReferencedModule(cache);
-  if (!module)
-    return {};
   auto argNames = module->getAttrOfType<ArrayAttr>("argNames");
   // Tolerate malformed IR here to enable debug printing etc.
   if (argNames && idx < argNames.size())
@@ -972,8 +970,6 @@ StringAttr InstanceOp::getArgumentName(size_t idx, const SymbolCache *cache) {
 StringAttr InstanceOp::getResultName(size_t idx, const SymbolCache *cache) {
   // TODO: Remove when argNames/resultNames are stored on instances.
   auto *module = getReferencedModule(cache);
-  if (!module)
-    return {};
 
   auto resultNames = module->getAttrOfType<ArrayAttr>("resultNames");
   // Tolerate malformed IR here to enable debug printing etc.

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -759,8 +759,7 @@ Operation *InstanceOp::getReferencedModule(const SymbolCache *cache) {
 }
 
 // Helper function to verify instance op types
-static LogicalResult verifyInstanceOpTypes(InstanceOp op,
-                                           Operation *module) {  
+static LogicalResult verifyInstanceOpTypes(InstanceOp op, Operation *module) {
   // Make sure our port and result names match.
   ArrayAttr argNames = op.argNamesAttr();
   ArrayAttr modArgNames = module->getAttrOfType<ArrayAttr>("argNames");

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -24,6 +24,7 @@ using namespace msft;
 /// invalid IR.
 Operation *InstanceOp::getReferencedModule() {
   auto topLevelModuleOp = (*this)->getParentOfType<ModuleOp>();
+  assert(topLevelModuleOp && "Required to have a ModuleOp parent.");
   return topLevelModuleOp.lookupSymbol(moduleName());
 }
 

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -52,6 +52,7 @@ void InstanceOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 static LogicalResult verifyInstanceOp(InstanceOp op) {
   auto topLevelModuleOp = op->getParentOfType<ModuleOp>();
   StringRef moduleName = op.moduleName();
+  // TODO(CIRCT #1790): Use `SymbolUserOpInterface`.
   Operation *referencedModule = topLevelModuleOp.lookupSymbol(moduleName);
 
   if (referencedModule == nullptr)

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -24,8 +24,8 @@ using namespace msft;
 /// invalid IR.
 Operation *InstanceOp::getReferencedModule() {
   auto topLevelModuleOp = (*this)->getParentOfType<ModuleOp>();
-  if (!topLevelModuleOp)
-    return nullptr;
+  assert(topLevelModuleOp &&
+         "This instance references a non-existent ModuleOp");
 
   return topLevelModuleOp.lookupSymbol(moduleName());
 }

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -24,10 +24,7 @@ using namespace msft;
 /// invalid IR.
 Operation *InstanceOp::getReferencedModule() {
   auto topLevelModuleOp = (*this)->getParentOfType<ModuleOp>();
-
-  Operation *referencedModule = topLevelModuleOp.lookupSymbol(moduleName());
-  assert(referencedModule && "This references a non-existent module.");
-  return referencedModule;
+  return topLevelModuleOp.lookupSymbol(moduleName());
 }
 
 StringAttr InstanceOp::getResultName(size_t idx) {

--- a/test/Dialect/HW/errors.mlir
+++ b/test/Dialect/HW/errors.mlir
@@ -29,13 +29,6 @@ func private @test_and() {
 
 // -----
 
-hw.module @M() {
-  // expected-error @+1 {{Cannot find module definition 'Bar'}}
-  hw.instance "instance" @Bar() -> ()
-}
-
-// -----
-
 func private @notModule () {
   return
 }

--- a/test/Dialect/HW/errors.mlir
+++ b/test/Dialect/HW/errors.mlir
@@ -29,6 +29,13 @@ func private @test_and() {
 
 // -----
 
+hw.module @M() {
+  // expected-error @+1 {{Cannot find module definition 'Bar'}}
+  hw.instance "instance" @Bar() -> ()
+}
+
+// -----
+
 func private @notModule () {
   return
 }

--- a/test/Dialect/MSFT/opt-errors.mlir
+++ b/test/Dialect/MSFT/opt-errors.mlir
@@ -17,6 +17,6 @@ module {
 // -----
 
 hw.module @M() {
-  // expected-error @+1 {{Cannot find module definition: 'Bar'}}
+  // expected-error @+1 {{Cannot find module definition 'Bar'}}
   msft.instance "instance" @Bar () : () -> ()
 }

--- a/test/Dialect/MSFT/opt-errors.mlir
+++ b/test/Dialect/MSFT/opt-errors.mlir
@@ -17,6 +17,6 @@ module {
 // -----
 
 hw.module @M() {
-  // expected-error @+1 {{'msft.instance' op Cannot find module definition: 'Bar'}}
+  // expected-error @+1 {{Cannot find module definition: 'Bar'}}
   msft.instance "instance" @Bar () : () -> ()
 }

--- a/test/Dialect/MSFT/opt-errors.mlir
+++ b/test/Dialect/MSFT/opt-errors.mlir
@@ -16,8 +16,6 @@ module {
 
 // -----
 
-hw.module @Foo() {}
-
 hw.module @M() {
   // expected-error @+1 {{'msft.instance' op Cannot find module definition: 'Bar'}}
   msft.instance "instance" @Bar () : () -> ()

--- a/test/Dialect/MSFT/opt-errors.mlir
+++ b/test/Dialect/MSFT/opt-errors.mlir
@@ -13,3 +13,12 @@ module {
   // expected-error @+1 {{Unexpected msft attribute 'foo'}}
   hw.instance "foo1" @Foo() -> () {"loc:" = #msft.foo<""> } 
 }
+
+// -----
+
+hw.module @Foo() {}
+
+hw.module @M() {
+  // expected-error @+1 {{'msft.instance' op Cannot find module definition: 'Bar'}}
+  msft.instance "instance" @Bar () : () -> ()
+}


### PR DESCRIPTION
Remove a lot of assertions and checks that are validated by the ODS and `verifyInstanceOp` function. Subsequent tests are added.

Edit: There already exists a test for non-existent modules in the HW dialect. I removed my test case. This closes #1779.
Edit 2: This also closes #1790.