### PR TITLE
[LowerToHW] Update attribute DesignUnderTest to firrtl.DesignUnderTest [NFC]

### DIFF
--- a/docs/FIRRTLAnnotations.md
+++ b/docs/FIRRTLAnnotations.md
@@ -418,6 +418,17 @@ Example:
   "inclusive": true
 }
 ```
+## FIRRTL specific attributes applied to HW Modules
+
+### Design Under Test
+
+| Property   | Type   | Description                                   |
+| ---------- | ------ | -------------                                 |
+| class      | string | `sifive.enterprise.firrtl.MarkDUTAnnotation`  |
+| target     | string | Reference target                              |
+
+Marks what is the DUT (and not the testbench). This annotation is lowered to the
+attribute `firrtl.DesignUnderTest` to indicate the module which is the DUT.
 
 ##  Grand Central
 
@@ -735,12 +746,3 @@ Example:
   "source":"~GCTMemTap|GCTMemTap>mem"
 }
 ```
-#### Design Under Test
-
-| Property   | Type   | Description                                   |
-| ---------- | ------ | -------------                                 |
-| class      | string | `sifive.enterprise.firrtl.MarkDUTAnnotation`  |
-| target     | string | Reference target                              |
-
-Marks what is the DUT (and not the testbench). This annotation is lowered to the
-attribute `DesignUnderTest` to indicate the module which is the DUT.

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -721,7 +721,7 @@ FIRRTLModuleLowering::lowerModule(FModuleOp oldModule, Block *topLevelModule,
   if (auto outputFile = oldModule->getAttr("output_file"))
     newModule->setAttr("output_file", outputFile);
   if (AnnotationSet::removeAnnotations(oldModule, dutAnnoClass))
-    newModule->setAttr("DesignUnderTest", builder.getUnitAttr());
+    newModule->setAttr("firrtl.DesignUnderTest", builder.getUnitAttr());
   loweringState.processRemainingAnnotations(oldModule,
                                             AnnotationSet(oldModule));
   return newModule;

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -900,7 +900,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   }
 
   // CHECK-LABEL: hw.module @FooDUT
-  // CHECK: attributes {DesignUnderTest}
+  // CHECK: attributes {firrtl.DesignUnderTest}
   firrtl.module @FooDUT() attributes {annotations = [
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {}
 }


### PR DESCRIPTION
Prefix the attribute `DesignUnderTest` with `firrtl` since it defines a `FIRRTL` specific property. 
Update the docs and tests accordingly.
Followup to https://github.com/llvm/circt/pull/1785 