### PR TITLE
[SV] Add ExportModuleHierarchy pass.

### DIFF
--- a/include/circt/Dialect/SV/SVPasses.h
+++ b/include/circt/Dialect/SV/SVPasses.h
@@ -34,6 +34,7 @@ std::unique_ptr<mlir::Pass> createHWLegalizeModulesPass();
 std::unique_ptr<mlir::Pass> createHWGeneratorCalloutPass();
 std::unique_ptr<mlir::Pass> createHWMemSimImplPass();
 std::unique_ptr<mlir::Pass> createSVExtractTestCodePass();
+std::unique_ptr<mlir::Pass> createHWExportModuleHierarchyPass();
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/SV/SVPasses.h.inc"

--- a/include/circt/Dialect/SV/SVPasses.td
+++ b/include/circt/Dialect/SV/SVPasses.td
@@ -117,4 +117,17 @@ def SVExtractTestCode : Pass<"sv-extract-test-code", "ModuleOp"> {
   let dependentDialects = ["circt::sv::SVDialect"];
 }
 
+def HWExportModuleHierarchy : Pass<"hw-export-module-hierarchy",
+                                   "mlir::ModuleOp"> {
+  let summary = "Export module and instance hierarchy information";
+  let description = [{
+    This pass exports the module and instance hierarchy tree for each module
+    with the firrtl.moduleHierarchyFile attribute. These are lowered to
+    sv.verbatim ops with the output_file attribute.
+  }];
+
+  let constructor = "circt::sv::createHWExportModuleHierarchyPass()";
+  let dependentDialects = ["circt::sv::SVDialect"];
+}
+
 #endif // CIRCT_DIALECT_SV_SVPASSES

--- a/lib/Dialect/SV/Transforms/CMakeLists.txt
+++ b/lib/Dialect/SV/Transforms/CMakeLists.txt
@@ -7,6 +7,7 @@ add_circt_dialect_library(CIRCTSVTransforms
   HWMemSimImpl.cpp
   PrettifyVerilog.cpp
   SVExtractTestCode.cpp
+  HWExportModuleHierarchy.cpp
 
   DEPENDS
   CIRCTSVTransformsIncGen

--- a/lib/Dialect/SV/Transforms/HWExportModuleHierarchy.cpp
+++ b/lib/Dialect/SV/Transforms/HWExportModuleHierarchy.cpp
@@ -1,0 +1,98 @@
+//===- HWExportModuleHierarchy.cpp - Export Module Hierarchy ----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//===----------------------------------------------------------------------===//
+//
+// Export the module and instance hierarchy information to JSON. This pass looks
+// for modules with the firrtl.moduleHierarchyFile attribute and collects the
+// hierarchy starting at those modules. The hierarchy information is then
+// encoded as JSON in an sv.verbatim op with the output_file attribute set.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/SV/SVPasses.h"
+#include "mlir/IR/Builders.h"
+#include "llvm/Support/JSON.h"
+
+using namespace circt;
+
+//===----------------------------------------------------------------------===//
+// Pass Implementation
+//===----------------------------------------------------------------------===//
+
+struct HWExportModuleHierarchyPass
+    : public sv::HWExportModuleHierarchyBase<HWExportModuleHierarchyPass> {
+  void runOnOperation() override;
+};
+
+/// Recursively print the module hierarchy as serialized as JSON.
+static void printHierarchy(hw::InstanceOp &inst, SymbolTable &symbolTable,
+                           llvm::json::OStream &J) {
+  J.object([&] {
+    J.attribute("instance_name", inst.instanceName());
+    J.attribute("module_name", inst.moduleName());
+    J.attributeArray("instances", [&] {
+      auto moduleOp =
+          symbolTable.lookup<hw::HWModuleOp>(inst.moduleNameAttr().getValue());
+
+      // Only recurse on module ops, not extern or generated ops, whose internal
+      // are opaque.
+      if (moduleOp) {
+        for (auto op : moduleOp.getOps<hw::InstanceOp>()) {
+          printHierarchy(op, symbolTable, J);
+        }
+      }
+    });
+  });
+}
+
+/// Return the JSON-serialized module hierarchy for the given module as the top
+/// of the hierarchy.
+static std::string extractHierarchyFromTop(hw::HWModuleOp op,
+                                           SymbolTable &symbolTable) {
+  std::string resultBuffer;
+  llvm::raw_string_ostream os(resultBuffer);
+  llvm::json::OStream J(os);
+
+  // As a special case for top-level module, set instance name to module name,
+  // since the top-level module is not instantiated.
+  J.object([&] {
+    J.attribute("instance_name", op.getName());
+    J.attribute("module_name", op.getName());
+    J.attributeArray("instances", [&] {
+      for (auto op : op.getOps<hw::InstanceOp>())
+        printHierarchy(op, symbolTable, J);
+    });
+  });
+
+  return resultBuffer;
+}
+
+/// Find the modules corresponding to the firrtl mainModule and DesignUnderTest,
+/// and if they exist, emit a verbatim op with the module hierarchy for each.
+void HWExportModuleHierarchyPass::runOnOperation() {
+  mlir::ModuleOp mlirModule = getOperation();
+  auto builder = OpBuilder::atBlockEnd(mlirModule.getBody());
+  SymbolTable symbolTable(mlirModule);
+
+  for (auto op : mlirModule.getOps<hw::HWModuleOp>()) {
+    if (auto attr = op->getAttr("firrtl.moduleHierarchyFile")) {
+      auto verbatimOp = builder.create<sv::VerbatimOp>(
+          builder.getUnknownLoc(), extractHierarchyFromTop(op, symbolTable));
+      verbatimOp->setAttr("output_file", attr);
+      op->removeAttr("firrtl.moduleHierarchyFile");
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Pass Creation
+//===----------------------------------------------------------------------===//
+
+std::unique_ptr<mlir::Pass> sv::createHWExportModuleHierarchyPass() {
+  return std::make_unique<HWExportModuleHierarchyPass>();
+}

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
@@ -1,8 +1,6 @@
 // RUN: circt-opt -lower-firrtl-to-hw %s -verify-diagnostics | FileCheck %s
 
-// The firrtl.circuit should be removed, the main module name moved to an
-// attribute on the module.
-// CHECK-LABEL: {{^}}module attributes {firrtl.mainModule = "Simple"} {
+// The firrtl.circuit should be removed.
 // CHECK-NOT: firrtl.circuit
 
 // We should get a large header boilerplate.
@@ -20,7 +18,7 @@ firrtl.circuit "Simple" {
                                 FORMAT = "xyz_timeout=%d\0A",
                                 WIDTH = 32 : i8}}
 
-   // CHECK-LABEL: hw.module @Simple(%in1: i4, %in2: i2, %in3: i8) -> (out4: i4) {
+   // CHECK-LABEL: hw.module @Simple(%in1: i4, %in2: i2, %in3: i8) -> (out4: i4) attributes {firrtl.moduleHierarchyFile
    firrtl.module @Simple(in %in1: !firrtl.uint<4>,
                          in %in2: !firrtl.uint<2>,
                          in %in3: !firrtl.sint<8>,

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -900,7 +900,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   }
 
   // CHECK-LABEL: hw.module @FooDUT
-  // CHECK: attributes {firrtl.DesignUnderTest}
+  // CHECK: attributes {firrtl.moduleHierarchyFile
   firrtl.module @FooDUT() attributes {annotations = [
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {}
 }

--- a/test/Dialect/SV/hw-export-module-hierarchy.mlir
+++ b/test/Dialect/SV/hw-export-module-hierarchy.mlir
@@ -1,0 +1,17 @@
+// RUN: circt-opt -pass-pipeline=hw-export-module-hierarchy %s | FileCheck %s
+
+// CHECK: sv.verbatim "{\22instance_name\22:\22TestHarness\22,\22module_name\22:\22TestHarness\22,\22instances\22:[{\22instance_name\22:\22main_design\22,\22module_name\22:\22MainDesign\22,\22instances\22:[{\22instance_name\22:\22inner\22,\22module_name\22:\22InnerModule\22,\22instances\22:[]}]}]}" {output_file = {directory = "", exclude_from_filelist = true, exclude_replicated_ops = true, name = "testharness_hier.json"}}
+
+hw.module @InnerModule(%in: i1) -> (out: i1) {
+  hw.output %in : i1
+}
+
+hw.module @MainDesign(%in: i1) -> (out: i1) {
+  %0 = hw.instance "inner" @InnerModule(in: %in: i1) -> (out: i1)
+  hw.output %0 : i1
+}
+
+hw.module @TestHarness() attributes {firrtl.moduleHierarchyFile = {directory = "", exclude_from_filelist = true, exclude_replicated_ops = true, name = "testharness_hier.json"}} {
+  %0 = hw.constant 1 : i1
+  hw.instance "main_design" @MainDesign(in: %0: i1) -> (out: i1)
+}

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -150,6 +150,9 @@ static cl::opt<bool>
                  cl::desc("create interfaces and data/memory taps from SiFive "
                           "Grand Central annotations"),
                  cl::init(false));
+static cl::opt<bool> exportModuleHierarchy(
+    "export-module-hierarchy",
+    cl::desc("export module and instance hierarchy as JSON"), cl::init(false));
 
 static cl::opt<bool>
     checkCombCycles("firrtl-check-comb-cycles",
@@ -359,6 +362,9 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
       auto &modulePM = pm.nest<hw::HWModuleOp>();
       modulePM.addPass(sv::createPrettifyVerilogPass());
     }
+
+    if (exportModuleHierarchy)
+      pm.addPass(sv::createHWExportModuleHierarchyPass());
   }
 
   // Load the emitter options from the command line. Command line options if


### PR DESCRIPTION
This adds a pass that collects the full module hierarchy into a JSON
string, which is then exported as part of an sv.verbatim op. The pass
collects two module hierarchies, one for the firrtl.mainModule and one
for the firrtl.DesignUnderTest. This matches SiFive's JSON file format
for the module hierarchy.

The pass can be enabled in firtool by providing the
--export-module-hierarchy option.

I wasn't sure what the best place was to put this pass, so I've added this to the `SVPasses`/`SV/Transforms`, since it operates on the `hw` dialect and exports an `sv.verbatim` op. I could see putting this under `FIRRTL`, since it's very specific to FIRRTL and even relies on the `firrtl.mainModule` and `firrtl.DesignUnderTest` attributes (annotations), despite operating only on the `hw` dialect. Let me know if you have opinions on where this should go, since it should be pretty easy for me to move it elsewhere.

My approach was to recursively visit the module and instance hierarchy, write the serialized JSON to a string buffer, and append an `sv.verbatim` op with the `output_file` attribute set, which is what we came up with after I asked a few of the SiFive folks about this, but let me know if we should try something else, such as directly exporting a JSON file.

I did a few manual tests with some of SiFive's Chisel/SFC designs, and can confirm that this will create the appropriate `module_hier.json` and `testharness_hier.json` files from the Chisel-emitted annotations. I eyeballed the JSON files themselves, and I think they are correct, but I can't mechanically diff it against the SFC-produced JSON files because not all the names exactly match up one-to-one.