### PR TITLE
[FIRRTL] Mark don't touch module ports as overdefined

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -111,18 +111,6 @@ public:
     return getValue().dyn_cast_or_null<IntegerAttr>();
   }
 
-  void dump() const {
-    if (isInvalidValue())
-      llvm::errs() << "invalid";
-    if (isUnknown())
-      llvm::errs() << "unknown";
-    if (isOverdefined())
-      llvm::errs() << "overdefined";
-    if (isConstant()) {
-      llvm::errs() << "constant(" << getConstant().getValue() << ")";
-    }
-  }
-
   /// Merge in the value of the 'rhs' lattice into this one. Returns true if the
   /// lattice value changed.
   bool mergeIn(LatticeValue rhs) {


### PR DESCRIPTION
There was nothing forcing these ports to be overdefined before, so constants could leak through.
The undefined flag gets propagated to the instance port moments later.

One could remove the don't touch check in visitConnect now, but it's not clear if checking the attributes is cheaper than merging some lattice values.