### PR TITLE
[MSFT] Add `MSFTModuleOp`

### DIFF
--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -368,7 +368,7 @@ def InstanceOp : HWOp<"instance", [HasParent<"HWModuleOp">, Symbol,
   let printer = "return ::print$cppClass(p, *this);";
 }
 
-def OutputOp : HWOp<"output", [Terminator, HasParent<"HWModuleOp">,
+def OutputOp : HWOp<"output", [Terminator, //HasParent<"HWModuleOp">,
                                 NoSideEffect, ReturnLike]> {
   let summary = "HW termination operation";
   let description = [{

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -386,7 +386,7 @@ def InstanceOp : HWOp<"instance", [HasParent<"HWModuleOp">, Symbol,
   let printer = "return ::print$cppClass(p, *this);";
 }
 
-def OutputOp : HWOp<"output", [Terminator, //HasParent<"HWModuleOp">,
+def OutputOp : HWOp<"output", [Terminator, HasParent<"HWModuleOp">,
                                 NoSideEffect, ReturnLike]> {
   let summary = "HW termination operation";
   let description = [{

--- a/include/circt/Dialect/MSFT/MSFT.td
+++ b/include/circt/Dialect/MSFT/MSFT.td
@@ -15,6 +15,7 @@
 
 include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Pass/PassBase.td"

--- a/include/circt/Dialect/MSFT/MSFT.td
+++ b/include/circt/Dialect/MSFT/MSFT.td
@@ -16,7 +16,9 @@
 include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpAsmInterface.td"
+include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Pass/PassBase.td"
+include "mlir/IR/RegionKindInterface.td"
 
 def MSFTDialect : Dialect {
   let name = "msft";

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -36,3 +36,80 @@ def InstanceOp : MSFTOp<"instance", [
       `:` functional-type($inputs, results)
   }];
 }
+
+def OneOrNoBlocksRegion : Region<
+  CPred<"::llvm::hasNItemsOrLess($_self, 1)">,
+  "region with at most 1 block">;
+
+def MSFTModuleOp : MSFTOp<"module",
+      [IsolatedFromAbove, FunctionLike, Symbol, RegionKindInterface,
+       SingleBlockImplicitTerminator<"::circt::hw::OutputOp">,
+       HasParent<"mlir::ModuleOp">]>{
+  let summary = "HW Module";
+  let description = [{
+    The "hw.module" operation represents a Verilog module, including a given
+    name, a list of ports, and a body that represents the connections within
+    the module.
+  }];
+  let arguments = (ins
+      StrArrayAttr:$argNames, StrArrayAttr:$resultNames,
+      DictionaryAttr:$parameters);
+  let results = (outs);
+  let regions = (region OneOrNoBlocksRegion:$body);
+
+  // let skipDefaultBuilders = 1;
+  // let builders = [
+  //   OpBuilder<(ins "StringAttr":$name, "ArrayRef<ModulePortInfo>":$ports,
+  //                  CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes)>
+  // ];
+
+  let extraClassDeclaration = [{
+    using FunctionLike::front;
+    using FunctionLike::getBody;
+
+    // Implement RegionKindInterface.
+    static RegionKind getRegionKind(unsigned index) {
+      return RegionKind::Graph;
+    }
+
+    // Decode information about the input and output ports on this module.
+    SmallVector<::circt::hw::ModulePortInfo> getPorts();
+
+    // Get the module's symbolic name as StringAttr.
+    StringAttr getNameAttr() {
+      return (*this)->getAttrOfType<StringAttr>(
+        ::mlir::SymbolTable::getSymbolAttrName());
+    }
+
+    // Get the module's symbolic name.
+    StringRef getName() {
+      return getNameAttr().getValue();
+    }
+
+  private:
+    // This trait needs access to the hooks defined below.
+    friend class OpTrait::FunctionLike<MSFTModuleOp>;
+
+    /// Returns the number of arguments, implementing OpTrait::FunctionLike.
+    unsigned getNumFuncArguments() { return getType().getInputs().size(); }
+    /// Returns the number of results, implementing OpTrait::FunctionLike.
+    unsigned getNumFuncResults() { return getType().getResults().size(); }
+
+    /// Hook for OpTrait::FunctionLike, called after verifying that the 'type'
+    /// attribute is present and checks if it holds a function type.  Ensures
+    /// getType, getNumFuncArguments, and getNumFuncResults can be called
+    /// safely.
+    LogicalResult verifyType() {
+      auto type = getTypeAttr().getValue();
+      if (!type.isa<FunctionType>())
+        return emitOpError("requires '" + getTypeAttrName() +
+                           "' attribute of function type");
+      return success();
+    }
+  public:
+  }];
+
+  let printer = "return ::print$cppClass(p, *this);";
+  let parser = "return ::parse$cppClass(parser, result);";
+  let verifier = "return ::verify$cppClass(*this);";
+}

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -45,13 +45,13 @@ def OneOrNoBlocksRegion : Region<
 
 def MSFTModuleOp : MSFTOp<"module",
       [IsolatedFromAbove, FunctionLike, Symbol, RegionKindInterface,
-       SingleBlockImplicitTerminator<"::circt::hw::OutputOp">,
        HasParent<"mlir::ModuleOp">]>{
-  let summary = "HW Module";
+  let summary = "MSFT HW Module";
   let description = [{
-    The "hw.module" operation represents a Verilog module, including a given
-    name, a list of ports, and a body that represents the connections within
-    the module.
+    A lot like `hw.module`, but with a few differences:
+      - Can exist without a body. The body is filled in by a generator post op
+      creation.
+      - MSFT-specific methods and arguments will be added later on.
   }];
   let arguments = (ins
       StrArrayAttr:$argNames, StrArrayAttr:$resultNames,
@@ -113,5 +113,21 @@ def MSFTModuleOp : MSFTOp<"module",
 
   let printer = "return ::print$cppClass(p, *this);";
   let parser = "return ::parse$cppClass(parser, result);";
-  let verifier = "return ::verify$cppClass(*this);";
+  // let verifier = "return ::verify$cppClass(*this);";
+}
+
+
+def OutputOp : MSFTOp<"output", [Terminator, HasParent<"MSFTModuleOp">,
+                                NoSideEffect, ReturnLike]> {
+  let summary = "termination operation";
+
+  let arguments = (ins Variadic<AnyType>:$operands);
+
+  // let builders = [
+  //   OpBuilder<(ins), "build($_builder, $_state, llvm::None);">
+  // ];
+
+  let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";
+
+  // let verifier = "return ::verifyOutputOp(this);";
 }

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -59,12 +59,6 @@ def MSFTModuleOp : MSFTOp<"module",
   let results = (outs);
   let regions = (region OneOrNoBlocksRegion:$body);
 
-  // let skipDefaultBuilders = 1;
-  // let builders = [
-  //   OpBuilder<(ins "StringAttr":$name, "ArrayRef<ModulePortInfo>":$ports,
-  //                  CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes)>
-  // ];
-
   let extraClassDeclaration = [{
     using FunctionLike::front;
     using FunctionLike::getBody;
@@ -113,7 +107,6 @@ def MSFTModuleOp : MSFTOp<"module",
 
   let printer = "return ::print$cppClass(p, *this);";
   let parser = "return ::parse$cppClass(parser, result);";
-  // let verifier = "return ::verify$cppClass(*this);";
 }
 
 
@@ -123,11 +116,5 @@ def OutputOp : MSFTOp<"output", [Terminator, HasParent<"MSFTModuleOp">,
 
   let arguments = (ins Variadic<AnyType>:$operands);
 
-  // let builders = [
-  //   OpBuilder<(ins), "build($_builder, $_state, llvm::None);">
-  // ];
-
   let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";
-
-  // let verifier = "return ::verifyOutputOp(this);";
 }

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -139,10 +139,10 @@ static ParseResult parseMSFTModuleOp(OpAsmParser &parser,
   assert(argAttrs.size() == argTypes.size());
   assert(resultAttrs.size() == resultTypes.size());
 
-  // Add the attributes to the function arguments.
+  // Add the attributes to the module arguments.
   addArgAndResultAttrs(builder, result, argAttrs, resultAttrs);
 
-  // Parse the optional function body.
+  // Parse the optional module body.
   auto regionSuccess = parser.parseOptionalRegion(
       *result.addRegion(), entryArgs,
       entryArgs.empty() ? ArrayRef<Type>() : argTypes);

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -12,9 +12,11 @@
 
 #include "circt/Dialect/MSFT/MSFTOps.h"
 #include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/ModuleImplementation.h"
 
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
+#include "mlir/IR/FunctionImplementation.h"
 #include "llvm/ADT/TypeSwitch.h"
 
 using namespace circt;
@@ -61,6 +63,100 @@ LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
            << moduleName() << "' isn't a module";
   return success();
 }
+
+static bool hasAttribute(StringRef name, ArrayRef<NamedAttribute> attrs) {
+  for (auto &argAttr : attrs)
+    if (argAttr.first == name)
+      return true;
+  return false;
+}
+
+static ParseResult parseMSFTModuleOp(OpAsmParser &parser,
+                                     OperationState &result) {
+  using namespace mlir::function_like_impl;
+
+  auto loc = parser.getCurrentLocation();
+
+  SmallVector<OpAsmParser::OperandType, 4> entryArgs;
+  SmallVector<NamedAttrList, 4> argAttrs;
+  SmallVector<NamedAttrList, 4> resultAttrs;
+  SmallVector<Type, 4> argTypes;
+  SmallVector<Type, 4> resultTypes;
+  auto &builder = parser.getBuilder();
+
+  // Parse the name as a symbol.
+  StringAttr nameAttr;
+  if (parser.parseSymbolName(nameAttr, SymbolTable::getSymbolAttrName(),
+                             result.attributes))
+    return failure();
+
+  // Parse the parameters
+  DictionaryAttr paramsAttr;
+  if (parser.parseAttribute(paramsAttr))
+    return failure();
+  result.addAttribute("parameters", paramsAttr);
+
+  // Parse the function signature.
+  bool isVariadic = false;
+  SmallVector<Attribute> resultNames;
+  if (hw::module_like_impl::parseModuleFunctionSignature(
+          parser, entryArgs, argTypes, argAttrs, isVariadic, resultTypes,
+          resultAttrs, resultNames))
+    return failure();
+
+  // Record the argument and result types as an attribute.  This is necessary
+  // for external modules.
+  auto type = builder.getFunctionType(argTypes, resultTypes);
+  result.addAttribute(getTypeAttrName(), TypeAttr::get(type));
+
+  // If function attributes are present, parse them.
+  if (parser.parseOptionalAttrDictWithKeyword(result.attributes))
+    return failure();
+
+  auto *context = result.getContext();
+
+  if (hasAttribute("argNames", result.attributes) ||
+      hasAttribute("resultNames", result.attributes)) {
+    parser.emitError(
+        loc, "explicit argNames and resultNames attributes not allowed");
+    return failure();
+  }
+
+  // Use the argument and result names if not already specified.
+  SmallVector<Attribute> argNames;
+  if (!entryArgs.empty()) {
+    for (auto &arg : entryArgs)
+      argNames.push_back(
+          hw::module_like_impl::getPortNameAttr(context, arg.name));
+  } else if (!argTypes.empty()) {
+    // The parser returns empty names in a special way.
+    argNames.assign(argTypes.size(), StringAttr::get(context, ""));
+  }
+
+  result.addAttribute("argNames", ArrayAttr::get(context, argNames));
+  result.addAttribute("resultNames", ArrayAttr::get(context, resultNames));
+
+  assert(argAttrs.size() == argTypes.size());
+  assert(resultAttrs.size() == resultTypes.size());
+
+  // Add the attributes to the function arguments.
+  addArgAndResultAttrs(builder, result, argAttrs, resultAttrs);
+
+  // Parse the optional function body.
+  auto *body = result.addRegion();
+  mlir::OptionalParseResult regionSuccess = parser.parseOptionalRegion(
+      *body, entryArgs, entryArgs.empty() ? ArrayRef<Type>() : argTypes);
+  if (regionSuccess.hasValue()) {
+    if (*regionSuccess)
+      return failure();
+    // MSFTModuleOp::ensureTerminator(*body, parser.getBuilder(),
+    // result.location);
+  }
+
+  return success();
+}
+
+static void printMSFTModuleOp(OpAsmPrinter &p, MSFTModuleOp mod) {}
 
 #define GET_OP_CLASSES
 #include "circt/Dialect/MSFT/MSFT.cpp.inc"

--- a/lib/Dialect/MSFT/MSFTPasses.cpp
+++ b/lib/Dialect/MSFT/MSFTPasses.cpp
@@ -191,6 +191,8 @@ void LowerToHWPass::runOnOperation() {
   // Set up a conversion and give it a set of laws.
   ConversionTarget target(*ctxt);
   target.addIllegalDialect<MSFTDialect>();
+  target.addLegalOp<MSFTModuleOp>(); // TODO: Remove me!
+  target.addLegalOp<OutputOp>();     // TODO: Remove me!
   target.addLegalDialect<hw::HWDialect>();
 
   // Add all the conversion patterns.

--- a/test/Dialect/MSFT/module_instance.mlir
+++ b/test/Dialect/MSFT/module_instance.mlir
@@ -10,3 +10,11 @@ hw.module @top () {
   // CHECK: %foo.x = msft.instance "foo" @fooMod() : () -> i32
   // HWLOW: %foo.x = hw.instance "foo" @fooMod() -> (x: i32)
 }
+
+msft.module @B { "WIDTH" = 1 } (%a: i1) -> (nameOfPortInSV: i1) {
+  %0 = comb.or %a, %a : i1
+  %1 = comb.and %a, %a : i1
+  msft.output %0, %1: i1, i1
+}
+
+msft.module @UnGenerated { DEPTH = 3 } (%a: i1) -> (nameOfPortInSV: i1)

--- a/test/Dialect/MSFT/module_instance.mlir
+++ b/test/Dialect/MSFT/module_instance.mlir
@@ -11,10 +11,13 @@ hw.module @top () {
   // HWLOW: %foo.x = hw.instance "foo" @fooMod() -> (x: i32)
 }
 
+// CHECK-LABEL: msft.module @B {WIDTH = 1 : i64} (%a: i1) -> (nameOfPortInSV: i1) {
 msft.module @B { "WIDTH" = 1 } (%a: i1) -> (nameOfPortInSV: i1) {
   %0 = comb.or %a, %a : i1
+  // CHECK: comb.or %a, %a : i1
   %1 = comb.and %a, %a : i1
   msft.output %0, %1: i1, i1
 }
 
+// CHECK-LABEL: msft.module @UnGenerated {DEPTH = 3 : i64} (%a: i1) -> (nameOfPortInSV: i1)
 msft.module @UnGenerated { DEPTH = 3 } (%a: i1) -> (nameOfPortInSV: i1)


### PR DESCRIPTION
Adds a moduleop to the MSFT dialect. For now, it's mostly like `hw.module` but adds `parameters` to represent the specific parameterization of a parameterized module. Also necessarily adds a `msft.output` since `hw.output` expects to be in a `hw.module`. 

Step 3 of #1755.