### PR TITLE
[Handshake] Postpone adding ctrl arg to handshake::FuncOp until end of conversion

### DIFF
--- a/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
+++ b/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
@@ -1559,7 +1559,6 @@ LogicalResult lowerFuncOp(mlir::FuncOp funcOp, MLIRContext *ctx) {
   (void)partiallyLowerFuncOp<mlir::FuncOp>(
       [&](mlir::FuncOp funcOp, PatternRewriter &rewriter) {
         auto noneType = rewriter.getNoneType();
-        argTypes.push_back(noneType);
         resTypes.push_back(noneType);
         auto func_type = rewriter.getFunctionType(argTypes, resTypes);
         newFuncOp = rewriter.create<handshake::FuncOp>(
@@ -1608,8 +1607,10 @@ LogicalResult lowerFuncOp(mlir::FuncOp funcOp, MLIRContext *ctx) {
   // op.
   (void)partiallyLowerFuncOp<handshake::FuncOp>(
       [&](handshake::FuncOp nfo, PatternRewriter &rewriter) {
-        auto noneType = rewriter.getNoneType();
-        auto ctrlArg = nfo.front().addArgument(noneType);
+        argTypes.push_back(rewriter.getNoneType());
+        auto funcType = rewriter.getFunctionType(argTypes, resTypes);
+        nfo.setType(funcType);
+        auto ctrlArg = nfo.front().addArgument(rewriter.getNoneType());
         Operation *startOp = findStartOp(&nfo.getRegion());
         startOp->getResult(0).replaceAllUsesWith(ctrlArg);
         rewriter.eraseOp(startOp);


### PR DESCRIPTION
No functional change, but a major step in the debug-ability of the pass. Previously, there was a discrepancy between the # of args of the Handshake FuncOp and the inlined body of the source FuncOp. This meant that any attempt at dump'ing the IR during conversion would crash, due a mismatch between the type signature of the handshake funcop and its entry block arguments.

This commit postpones adding the control argument to (and modifying the type signature of) the handshake funcOp until end of conversion.