### PR TITLE
Annotation Scattering and trivial processing Pass

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRParser.h
+++ b/include/circt/Dialect/FIRRTL/FIRParser.h
@@ -30,6 +30,7 @@ struct FIRParserOptions {
   /// If this is set to true, the @info locators are ignored, and the locations
   /// are set to the location in the .fir file.
   bool ignoreInfoLocators = false;
+  bool rawAnnotations = false;
 };
 
 mlir::OwningModuleRef importFIRFile(llvm::SourceMgr &sourceMgr,

--- a/include/circt/Dialect/FIRRTL/FIRParser.h
+++ b/include/circt/Dialect/FIRRTL/FIRParser.h
@@ -30,6 +30,8 @@ struct FIRParserOptions {
   /// If this is set to true, the @info locators are ignored, and the locations
   /// are set to the location in the .fir file.
   bool ignoreInfoLocators = false;
+  /// If this is set to true, the annotations are just attached to the circuit
+  /// and not scattered or processed.
   bool rawAnnotations = false;
 };
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
@@ -28,6 +28,9 @@ class FModuleLike;
 /// Return the name of the attribute used for annotations on FIRRTL ops.
 inline StringRef getAnnotationAttrName() { return "annotations"; }
 
+/// Return the name of the attribute used for port annotations on FIRRTL ops.
+inline StringRef getPortAnnotationAttrName() { return "portAnnotations"; }
+
 /// Return the name of the dialect-prefixed attribute used for annotations.
 inline StringRef getDialectAnnotationAttrName() { return "firrtl.annotations"; }
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -41,7 +41,7 @@ def FModuleLike : OpInterface<"FModuleLike"> {
       return $_op.portNames()[portIndex].template cast<StringAttr>(); 
     }]>,
 
-    InterfaceMethod<"Get infromation about all ports",
+    InterfaceMethod<"Get information about all ports",
     "SmallVector<PortInfo>", "getPorts">,
 
     InterfaceMethod<"Get the module port directions",

--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -24,6 +24,10 @@ class Pass;
 namespace circt {
 namespace firrtl {
 
+std::unique_ptr<mlir::Pass>
+createLowerFIRRTLAnnotationsPass(bool ignoreUnhandledAnnotations = false,
+                                 bool ignoreClasslessAnnotations = false);
+
 std::unique_ptr<mlir::Pass> createLowerFIRRTLTypesPass();
 
 std::unique_ptr<mlir::Pass> createLowerBundleVectorTypesPass();

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -15,6 +15,22 @@
 
 include "mlir/Pass/PassBase.td"
 
+def LowerFIRRTLAnnotations : Pass<"firrtl-lower-annotations", "firrtl::CircuitOp"> {
+  let summary = "Lower FIRRTL annotations to usable entities";
+  let description = [{
+    Lower FIRRTL annotations to usable forms.  FIRRTL annotations are a big bag
+    of semi-structured, irregular json.  This pass normalizes all supported
+    annotations and annotation paths.
+  }];
+  let constructor = "circt::firrtl::createLowerFIRRTLAnnotationsPass()";
+  let options = [
+    Option<"ignoreAnnotationClassless", "disable-annotation-classless", "bool", "false",
+      "Ignore classless annotations.">,
+    Option<"ignoreAnnotationUnknown", "disable-annotation-unknown", "bool", "true",
+      "Ignore unknown annotations.">
+  ];
+}
+
 def LowerFIRRTLTypes : Pass<"firrtl-lower-types", "firrtl::CircuitOp"> {
   let summary = "Lower FIRRTL types to ground types";
   let description = [{

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -152,6 +152,14 @@ DeclKind firrtl::getDeclarationKind(Value val) {
       .Default([](auto) { return DeclKind::Other; });
 }
 
+size_t firrtl::getNumPorts(Operation *op) {
+  if (auto extmod = dyn_cast<FExtModuleOp>(op))
+    return extmod.getType().getInputs().size();
+  if (auto mod = dyn_cast<FModuleOp>(op))
+    return mod.getBodyBlock()->getArguments().size();
+  return op->getNumResults();
+}
+
 //===----------------------------------------------------------------------===//
 // CircuitOp
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
@@ -251,6 +251,61 @@ static A tryGetAs(DictionaryAttr &dict, DictionaryAttr &root, StringRef key,
   return valueA;
 }
 
+/// Convert arbitrary JSON to an MLIR Attribute.
+static Attribute convertJSONToAttribute(MLIRContext *context,
+                                        json::Value &value, json::Path p) {
+  // String or quoted JSON
+  if (auto a = value.getAsString()) {
+    // Test to see if this might be quoted JSON (a string that is actually
+    // JSON).  Sometimes FIRRTL developers will do this to serialize objects
+    // that the Scala FIRRTL Compiler doesn't know about.
+    auto unquotedValue = json::parse(a.getValue());
+    auto err = unquotedValue.takeError();
+    // If this parsed without an error, then it's more JSON and recurse on
+    // that.
+    if (!err)
+      return convertJSONToAttribute(context, unquotedValue.get(), p);
+    // If there was an error, then swallow it and handle this as a string.
+    handleAllErrors(std::move(err), [&](const json::ParseError &a) {});
+    return StringAttr::get(context, a.getValue());
+  }
+
+  // Integer
+  if (auto a = value.getAsInteger())
+    return IntegerAttr::get(IntegerType::get(context, 64), a.getValue());
+
+  // Float
+  if (auto a = value.getAsNumber())
+    return FloatAttr::get(mlir::FloatType::getF64(context), a.getValue());
+
+  // Boolean
+  if (auto a = value.getAsBoolean())
+    return BoolAttr::get(context, a.getValue());
+
+  // Null
+  if (auto a = value.getAsNull())
+    return mlir::UnitAttr::get(context);
+
+  // Object
+  if (auto a = value.getAsObject()) {
+    NamedAttrList metadata;
+    for (auto b : *a)
+      metadata.append(
+          b.first, convertJSONToAttribute(context, b.second, p.field(b.first)));
+    return DictionaryAttr::get(context, metadata);
+  }
+
+  // Array
+  if (auto a = value.getAsArray()) {
+    SmallVector<Attribute> metadata;
+    for (size_t i = 0, e = (*a).size(); i != e; ++i)
+      metadata.push_back(convertJSONToAttribute(context, (*a)[i], p.index(i)));
+    return ArrayAttr::get(context, metadata);
+  }
+
+  llvm_unreachable("Impossible unhandled JSON type");
+};
+
 /// Deserialize a JSON value into FIRRTL Annotations.  Annotations are
 /// represented as a Target-keyed arrays of attributes.  The input JSON value is
 /// checked, at runtime, to be an array of objects.  Returns true if successful,
@@ -292,61 +347,6 @@ bool circt::firrtl::fromJSON(json::Value &value, StringRef circuitTarget,
     // Remove the target field from the annotation and return the target.
     object->erase("target");
     return llvm::Optional<std::string>(target);
-  };
-
-  /// Convert arbitrary JSON to an MLIR Attribute.
-  std::function<Attribute(json::Value &, json::Path)> convertJSONToAttribute =
-      [&](json::Value &value, json::Path p) -> Attribute {
-    // String or quoted JSON
-    if (auto a = value.getAsString()) {
-      // Test to see if this might be quoted JSON (a string that is actually
-      // JSON).  Sometimes FIRRTL developers will do this to serialize objects
-      // that the Scala FIRRTL Compiler doesn't know about.
-      auto unquotedValue = json::parse(a.getValue());
-      auto err = unquotedValue.takeError();
-      // If this parsed without an error, then it's more JSON and recurse on
-      // that.
-      if (!err)
-        return convertJSONToAttribute(unquotedValue.get(), p);
-      // If there was an error, then swallow it and handle this as a string.
-      handleAllErrors(std::move(err), [&](const json::ParseError &a) {});
-      return StringAttr::get(context, a.getValue());
-    }
-
-    // Integer
-    if (auto a = value.getAsInteger())
-      return IntegerAttr::get(IntegerType::get(context, 64), a.getValue());
-
-    // Float
-    if (auto a = value.getAsNumber())
-      return FloatAttr::get(mlir::FloatType::getF64(context), a.getValue());
-
-    // Boolean
-    if (auto a = value.getAsBoolean())
-      return BoolAttr::get(context, a.getValue());
-
-    // Null
-    if (auto a = value.getAsNull())
-      return mlir::UnitAttr::get(context);
-
-    // Object
-    if (auto a = value.getAsObject()) {
-      NamedAttrList metadata;
-      for (auto b : *a)
-        metadata.append(b.first,
-                        convertJSONToAttribute(b.second, p.field(b.first)));
-      return DictionaryAttr::get(context, metadata);
-    }
-
-    // Array
-    if (auto a = value.getAsArray()) {
-      SmallVector<Attribute> metadata;
-      for (size_t i = 0, e = (*a).size(); i != e; ++i)
-        metadata.push_back(convertJSONToAttribute((*a)[i], p.index(i)));
-      return ArrayAttr::get(context, metadata);
-    }
-
-    llvm_unreachable("Impossible unhandled JSON type");
   };
 
   // The JSON value must be an array of objects.  Anything else is reported as
@@ -394,7 +394,7 @@ bool circt::firrtl::fromJSON(json::Value &value, StringRef circuitTarget,
         splitAndAppendTarget(metadata, std::get<0>(NLATargets.back()), context)
             .first;
     for (auto field : *object) {
-      if (auto value = convertJSONToAttribute(field.second, p)) {
+      if (auto value = convertJSONToAttribute(context, field.second, p)) {
         metadata.append(field.first, value);
         continue;
       }
@@ -1080,61 +1080,6 @@ bool circt::firrtl::fromJSONRaw(json::Value &value, StringRef circuitTarget,
                                 SmallVectorImpl<Attribute> &attrs,
                                 json::Path path, MLIRContext *context) {
 
-  /// Convert arbitrary JSON to an MLIR Attribute.
-  std::function<Attribute(json::Value &, json::Path)> convertJSONToAttribute =
-      [&](json::Value &value, json::Path p) -> Attribute {
-    // String or quoted JSON
-    if (auto a = value.getAsString()) {
-      // Test to see if this might be quoted JSON (a string that is actually
-      // JSON).  Sometimes FIRRTL developers will do this to serialize objects
-      // that the Scala FIRRTL Compiler doesn't know about.
-      auto unquotedValue = json::parse(a.getValue());
-      auto err = unquotedValue.takeError();
-      // If this parsed without an error, then it's more JSON and recurse on
-      // that.
-      if (!err)
-        return convertJSONToAttribute(unquotedValue.get(), p);
-      // If there was an error, then swallow it and handle this as a string.
-      handleAllErrors(std::move(err), [&](const json::ParseError &a) {});
-      return StringAttr::get(context, a.getValue());
-    }
-
-    // Integer
-    if (auto a = value.getAsInteger())
-      return IntegerAttr::get(IntegerType::get(context, 64), a.getValue());
-
-    // Float
-    if (auto a = value.getAsNumber())
-      return FloatAttr::get(mlir::FloatType::getF64(context), a.getValue());
-
-    // Boolean
-    if (auto a = value.getAsBoolean())
-      return BoolAttr::get(context, a.getValue());
-
-    // Null
-    if (auto a = value.getAsNull())
-      return mlir::UnitAttr::get(context);
-
-    // Object
-    if (auto a = value.getAsObject()) {
-      NamedAttrList metadata;
-      for (auto b : *a)
-        metadata.append(b.first,
-                        convertJSONToAttribute(b.second, p.field(b.first)));
-      return DictionaryAttr::get(context, metadata);
-    }
-
-    // Array
-    if (auto a = value.getAsArray()) {
-      SmallVector<Attribute> metadata;
-      for (size_t i = 0, e = (*a).size(); i != e; ++i)
-        metadata.push_back(convertJSONToAttribute((*a)[i], p.index(i)));
-      return ArrayAttr::get(context, metadata);
-    }
-
-    llvm_unreachable("Impossible unhandled JSON type");
-  };
-
   // The JSON value must be an array of objects.  Anything else is reported as
   // invalid.
   auto array = value.getAsArray();
@@ -1158,7 +1103,7 @@ bool circt::firrtl::fromJSONRaw(json::Value &value, StringRef circuitTarget,
     NamedAttrList metadata;
 
     for (auto field : *object) {
-      if (auto value = convertJSONToAttribute(field.second, p)) {
+      if (auto value = convertJSONToAttribute(context, field.second, p)) {
         metadata.append(field.first, value);
         continue;
       }

--- a/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
@@ -1071,3 +1071,102 @@ bool circt::firrtl::scatterCustomAnnotations(
 
   return true;
 }
+
+/// Deserialize a JSON value into FIRRTL Annotations.  Annotations are
+/// represented as a Target-keyed arrays of attributes.  The input JSON value is
+/// checked, at runtime, to be an array of objects.  Returns true if successful,
+/// false if unsuccessful.
+bool circt::firrtl::fromJSONRaw(json::Value &value, StringRef circuitTarget,
+                                SmallVectorImpl<Attribute> &attrs,
+                                json::Path path, MLIRContext *context) {
+
+  /// Convert arbitrary JSON to an MLIR Attribute.
+  std::function<Attribute(json::Value &, json::Path)> convertJSONToAttribute =
+      [&](json::Value &value, json::Path p) -> Attribute {
+    // String or quoted JSON
+    if (auto a = value.getAsString()) {
+      // Test to see if this might be quoted JSON (a string that is actually
+      // JSON).  Sometimes FIRRTL developers will do this to serialize objects
+      // that the Scala FIRRTL Compiler doesn't know about.
+      auto unquotedValue = json::parse(a.getValue());
+      auto err = unquotedValue.takeError();
+      // If this parsed without an error, then it's more JSON and recurse on
+      // that.
+      if (!err)
+        return convertJSONToAttribute(unquotedValue.get(), p);
+      // If there was an error, then swallow it and handle this as a string.
+      handleAllErrors(std::move(err), [&](const json::ParseError &a) {});
+      return StringAttr::get(context, a.getValue());
+    }
+
+    // Integer
+    if (auto a = value.getAsInteger())
+      return IntegerAttr::get(IntegerType::get(context, 64), a.getValue());
+
+    // Float
+    if (auto a = value.getAsNumber())
+      return FloatAttr::get(mlir::FloatType::getF64(context), a.getValue());
+
+    // Boolean
+    if (auto a = value.getAsBoolean())
+      return BoolAttr::get(context, a.getValue());
+
+    // Null
+    if (auto a = value.getAsNull())
+      return mlir::UnitAttr::get(context);
+
+    // Object
+    if (auto a = value.getAsObject()) {
+      NamedAttrList metadata;
+      for (auto b : *a)
+        metadata.append(b.first,
+                        convertJSONToAttribute(b.second, p.field(b.first)));
+      return DictionaryAttr::get(context, metadata);
+    }
+
+    // Array
+    if (auto a = value.getAsArray()) {
+      SmallVector<Attribute> metadata;
+      for (size_t i = 0, e = (*a).size(); i != e; ++i)
+        metadata.push_back(convertJSONToAttribute((*a)[i], p.index(i)));
+      return ArrayAttr::get(context, metadata);
+    }
+
+    llvm_unreachable("Impossible unhandled JSON type");
+  };
+
+  // The JSON value must be an array of objects.  Anything else is reported as
+  // invalid.
+  auto array = value.getAsArray();
+  if (!array) {
+    path.report(
+        "Expected annotations to be an array, but found something else.");
+    return false;
+  }
+
+  // Build an array of annotations.
+  for (size_t i = 0, e = (*array).size(); i != e; ++i) {
+    auto object = (*array)[i].getAsObject();
+    auto p = path.index(i);
+    if (!object) {
+      p.report("Expected annotations to be an array of objects, but found an "
+               "array of something else.");
+      return false;
+    }
+
+    // Build up the Attribute to represent the Annotation
+    NamedAttrList metadata;
+
+    for (auto field : *object) {
+      if (auto value = convertJSONToAttribute(field.second, p)) {
+        metadata.append(field.first, value);
+        continue;
+      }
+      return false;
+    }
+
+    attrs.push_back(DictionaryAttr::get(context, metadata));
+  }
+
+  return true;
+}

--- a/lib/Dialect/FIRRTL/Import/FIRAnnotations.h
+++ b/lib/Dialect/FIRRTL/Import/FIRAnnotations.h
@@ -40,6 +40,9 @@ bool scatterCustomAnnotations(llvm::StringMap<ArrayAttr> &annotationMap,
                               CircuitOp circuit, unsigned &annotationID,
                               Location loc, size_t &nlaNumber);
 
+bool fromJSONRaw(llvm::json::Value &value, StringRef circuitTarget,
+                 SmallVectorImpl<Attribute> &attrs, llvm::json::Path path,
+                 MLIRContext *context);
 } // namespace firrtl
 } // namespace circt
 

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -8,6 +8,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   IMConstProp.cpp
   InferResets.cpp
   InferWidths.cpp
+  LowerAnnotations.cpp
   LowerCHIRRTL.cpp
   LowerTypes.cpp
   ModuleInliner.cpp

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -1,0 +1,575 @@
+//===- LowerAnnotations.cpp - Lower Annotations -----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the LowerAnnotations pass.  This pass processes FIRRTL
+// annotations, rewriting them, scattering them, and dealing with non-local
+// annotations.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLAnnotations.h"
+#include "circt/Dialect/FIRRTL/FIRRTLAttributes.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
+#include "circt/Dialect/FIRRTL/FIRRTLVisitors.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "mlir/IR/Diagnostics.h"
+#include "llvm/ADT/APSInt.h"
+#include "llvm/ADT/StringExtras.h"
+
+using namespace circt;
+using namespace firrtl;
+
+namespace {
+
+struct fieldOrIndex {
+  StringRef name;
+  bool isIndex;
+};
+
+struct tokenAnnoTarget {
+  StringRef circuit;
+  SmallVector<std::pair<StringRef, StringRef>> instances;
+  StringRef module;
+  StringRef name;
+  SmallVector<fieldOrIndex> agg;
+};
+
+struct AnnoTarget {
+  Operation *op;
+  size_t portNum;
+  unsigned fieldIdx;
+  AnnoTarget(Operation *op) : op(op), portNum(~0UL), fieldIdx(0) {}
+  AnnoTarget(Operation *mod, size_t portNum)
+      : op(mod), portNum(portNum), fieldIdx(0) {}
+  AnnoTarget() : op(nullptr), portNum(~0), fieldIdx(0) {}
+  operator bool() const { return op != nullptr; }
+
+  bool isPort() const { return op && portNum != ~0UL; }
+  bool isInstance() const { return op && isa<InstanceOp>(op); }
+  FIRRTLType getType() const {
+    if (!op)
+      return FIRRTLType();
+    if (portNum != ~0UL) {
+      if (auto mod = dyn_cast<FModuleLike>(op))
+        return mod.portType(portNum).getSubTypeByFieldID(fieldIdx);
+      if (isa<MemOp, InstanceOp>(op))
+        return op->getResult(portNum)
+            .getType()
+            .cast<FIRRTLType>()
+            .getSubTypeByFieldID(fieldIdx);
+      llvm_unreachable("Unknown port instruction");
+    }
+    if (op->getNumResults() == 0)
+      return FIRRTLType();
+    return op->getResult(0).getType().cast<FIRRTLType>().getSubTypeByFieldID(
+        fieldIdx);
+  }
+};
+
+struct AnnoPathValue {
+  SmallVector<InstanceOp> instances;
+  AnnoTarget ref;
+
+  AnnoPathValue() = default;
+  AnnoPathValue(CircuitOp op) : ref(op) {}
+  AnnoPathValue(Operation *op) : ref(op) {}
+  AnnoPathValue(const SmallVectorImpl<InstanceOp> &insts, AnnoTarget b)
+      : instances(insts.begin(), insts.end()), ref(b) {}
+
+  bool isLocal() const { return instances.empty(); }
+
+  template <typename... T>
+  bool isOpOfType() const {
+    if (!ref || ref.isPort())
+      return false;
+    return isa<T...>(ref.op);
+  }
+};
+
+struct applyState {
+  CircuitOp circuit;
+  SymbolTable &symTbl;
+  llvm::function_ref<void(DictionaryAttr)> addToWorklistFn;
+};
+
+} // namespace
+
+static bool hasName(StringRef name, Operation *op) {
+  return TypeSwitch<Operation *, bool>(op)
+      .Case<InstanceOp, MemOp, NodeOp, RegOp, RegResetOp, WireOp, CombMemOp,
+            SeqMemOp, MemoryPortOp>([&](auto nop) {
+        if (nop.name() == name)
+          return true;
+        return false;
+      })
+      .Default([](auto &) { return false; });
+}
+
+static AnnoTarget findNamedThing(StringRef name, Operation *op) {
+  AnnoTarget retval;
+  auto nameChecker = [name, &retval](Operation *op) -> WalkResult {
+    if (auto mod = dyn_cast<FModuleLike>(op)) {
+      // Check the ports.
+      auto ports = mod.getPorts();
+      for (size_t i = 0, e = ports.size(); i != e; ++i)
+        if (ports[i].name.getValue() == name) {
+          retval = AnnoTarget{op, i};
+          return WalkResult::interrupt();
+        }
+      return WalkResult::advance();
+    }
+    if (hasName(name, op)) {
+      retval = AnnoTarget{op};
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  };
+  op->walk(nameChecker);
+  return retval;
+}
+
+static void addNamedAttr(Operation *op, StringRef name, StringAttr value) {
+  op->setAttr(name, value);
+}
+
+static void addNamedAttr(Operation *op, StringRef name) {
+  op->setAttr(name, BoolAttr::get(op->getContext(), true));
+}
+
+static ArrayAttr getAnnotationsFrom(Operation *op) {
+  if (auto annots = op->getAttrOfType<ArrayAttr>(getAnnotationAttrName()))
+    return annots;
+  return ArrayAttr::get(op->getContext(), {});
+}
+
+static ArrayAttr appendArrayAttr(ArrayAttr array, Attribute a) {
+  if (!array)
+    return ArrayAttr::get(a.getContext(), ArrayRef<Attribute>{a});
+  SmallVector<Attribute> old(array.begin(), array.end());
+  old.push_back(a);
+  return ArrayAttr::get(a.getContext(), old);
+}
+
+static ArrayAttr replaceArrayAttrElement(ArrayAttr array, size_t elem,
+                                         Attribute newVal) {
+  SmallVector<Attribute> old(array.begin(), array.end());
+  old[elem] = newVal;
+  return ArrayAttr::get(array.getContext(), old);
+}
+
+static void addAnnotation(AnnoTarget ref, ArrayRef<NamedAttribute> anno) {
+  DictionaryAttr annotation;
+  if (ref.fieldIdx) {
+    SmallVector<NamedAttribute> annoField(anno.begin(), anno.end());
+    annoField.emplace_back(
+        Identifier::get("circt.fieldID", ref.op->getContext()),
+        IntegerAttr::get(
+            IntegerType::get(ref.op->getContext(), 32, IntegerType::Signless),
+            ref.fieldIdx));
+    annotation = DictionaryAttr::get(ref.op->getContext(), annoField);
+  } else {
+    annotation = DictionaryAttr::get(ref.op->getContext(), anno);
+  }
+
+  if (!ref.isPort()) {
+    auto newAnno = appendArrayAttr(getAnnotationsFrom(ref.op), annotation);
+    ref.op->setAttr(getAnnotationAttrName(), newAnno);
+    return;
+  }
+
+  auto portAnnoRaw = ref.op->getAttr("portAnnotations");
+  ArrayAttr portAnno = portAnnoRaw.dyn_cast_or_null<ArrayAttr>();
+  if (!portAnno || portAnno.size() != getNumPorts(ref.op)) {
+    SmallVector<Attribute> emptyPortAttr(
+        getNumPorts(ref.op), ArrayAttr::get(ref.op->getContext(), {}));
+    portAnno = ArrayAttr::get(ref.op->getContext(), emptyPortAttr);
+  }
+  portAnno = replaceArrayAttrElement(
+      portAnno, ref.portNum,
+      appendArrayAttr(portAnno[ref.portNum].dyn_cast<ArrayAttr>(), annotation));
+  ref.op->setAttr("portAnnotations", portAnno);
+}
+
+Optional<AnnoPathValue> resolveEntities(tokenAnnoTarget path, applyState state) {
+  if (!path.circuit.empty() && state.circuit.name() != path.circuit) {
+    state.circuit->emitError("circuit name doesn't match annotation '") << path.circuit << '\'';
+    return {};
+  }
+  SmallVector<InstanceOp> instances;
+  for (auto p : path.instances) {
+    auto mod = state.symTbl.lookup<FModuleOp>(p.first);
+    if (!mod) {
+      state.circuit->emitError("module doesn't exist '") << p.first << '\'';
+      return {};
+    }
+    auto resolved = findNamedThing(p.second, mod);
+    if (!resolved.isInstance()) {
+      state.circuit.emitError("cannot find instance '")
+          << p.second << "' in '" << mod.getName() << "'";
+      return {};
+    }
+    instances.push_back(cast<InstanceOp>(resolved.op));
+  }
+  assert(!path.module.empty());
+  assert(!path.name.empty());
+  return {}; //AnnoPathValue(instances);
+}
+
+// Some types have been expanded so the first layer of aggregate path is
+// a return value.
+static LogicalResult updateExpandedPort(StringRef field, AnnoTarget &entity) {
+  if (auto mem = dyn_cast<MemOp>(entity.op))
+    for (size_t p = 0, pe = mem.portNames().size(); p < pe; ++p)
+      if (mem.getPortNameStr(p) == field) {
+        entity.portNum = p;
+        return success();
+      }
+  if (auto inst = dyn_cast<InstanceOp>(entity.op))
+    for (size_t p = 0, pe = inst.getNumResults(); p < pe; ++p)
+      if (inst.getPortNameStr(p) == field) {
+        entity.portNum = p;
+        return success();
+      }
+  entity.op->emitError("Cannot find port with name ") << field;
+  return failure();
+}
+
+static LogicalResult updateStruct(StringRef field, AnnoTarget &entity) {
+  // The first field for some ops refers to expanded return values.
+  if (isa<MemOp, InstanceOp>(entity.op) && entity.portNum == ~0UL)
+    return updateExpandedPort(field, entity);
+
+  auto bundle = entity.getType().dyn_cast<BundleType>();
+  if (!bundle)
+    return entity.op->emitError("field access '")
+           << field << "' into non-bundle type '" << bundle << "'";
+  if (auto idx = bundle.getElementIndex(field)) {
+    entity.fieldIdx += bundle.getFieldID(*idx);
+    return success();
+  }
+  return entity.op->emitError("cannot resolve field '")
+         << field << "' in subtype '" << bundle << "'";
+}
+
+static LogicalResult updateArray(unsigned index, AnnoTarget &entity) {
+  auto vec = entity.getType().dyn_cast<FVectorType>();
+  if (!vec)
+    return entity.op->emitError("index access '")
+           << index << "' into non-vector type '" << vec << "'";
+  entity.fieldIdx += vec.getFieldID(index);
+  return success();
+}
+
+/// Return an input \p target string in canonical form.  This converts a Legacy
+/// Annotation (e.g., A.B.C) into a modern annotation (e.g., ~A|B>C).  Trailing
+/// subfield/subindex references are preserved.
+static std::string canonicalizeTarget(StringRef target) {
+
+  if (target.empty())
+    return target.str();
+
+  // If this is a normal Target (not a Named), erase that field in the JSON
+  // object and return that Target.
+  if (target[0] == '~')
+    return target.str();
+
+  // This is a legacy target using the firrtl.annotations.Named type.  This
+  // can be trivially canonicalized to a non-legacy target, so we do it with
+  // the following three mappings:
+  //   1. CircuitName => CircuitTarget, e.g., A -> ~A
+  //   2. ModuleName => ModuleTarget, e.g., A.B -> ~A|B
+  //   3. ComponentName => ReferenceTarget, e.g., A.B.C -> ~A|B>C
+  std::string newTarget = ("~" + target).str();
+  auto n = newTarget.find('.');
+  if (n != std::string::npos)
+    newTarget[n] = '|';
+  n = newTarget.find('.');
+  if (n != std::string::npos)
+    newTarget[n] = '>';
+  return newTarget;
+}
+
+/// split a target string into it constituent parts.  This is the primary parser
+/// for targets.
+static Optional<tokenAnnoTarget>
+tokenizePath(StringRef origTarget) {
+  StringRef target = origTarget;
+  tokenAnnoTarget retval;
+  std::tie(retval.circuit, target) = target.split('|');
+  while (target.count(':')) {
+    StringRef nla;
+    std::tie(nla, target) = target.split(':');
+    StringRef inst, mod;
+    std::tie(mod, inst) = nla.split('/');
+    retval.instances.emplace_back(mod, inst);
+  }
+  // remove aggregate
+  auto targetBase =
+      target.take_until([](char c) { return c == '.' || c == '['; });
+      auto aggBase = target.drop_front(targetBase.size());
+  std::tie(retval.module, retval.name) = targetBase.split('>');
+  if (retval.name.empty())
+    retval.name = retval.module;
+  while (!aggBase.empty()) {
+    if (aggBase[0] == '.') {
+      aggBase = aggBase.drop_front();
+      StringRef field = aggBase.take_front(aggBase.find_first_of("[."));
+      aggBase = aggBase.drop_front(field.size());
+      retval.agg.push_back({field, false});
+    } else if (aggBase[0] == '[') {
+      aggBase = aggBase.drop_front();
+      StringRef index = aggBase.take_front(aggBase.find_first_of(']'));
+      aggBase = aggBase.drop_front(index.size() + 1);
+      retval.agg.push_back({index, true});
+    } else {
+      return {};
+    }
+  }
+
+  return retval;
+}
+
+/// Make an anchor for a non-local annotation.  Use the expanded path to build
+/// the module and name list in the anchor.
+static FlatSymbolRefAttr buildNLA(
+                                  AnnoPathValue target, applyState state) {
+  OpBuilder b(state.circuit.getBodyRegion());
+  SmallVector<Attribute> mods;
+  SmallVector<Attribute> insts;
+  for (auto inst : target.instances) {
+    mods.push_back(
+        FlatSymbolRefAttr::get(inst->getParentOfType<FModuleOp>()));
+    insts.push_back(StringAttr::get(state.circuit.getContext(), inst.name()));
+  }
+  auto modAttr = ArrayAttr::get(state.circuit.getContext(), mods);
+  auto instAttr = ArrayAttr::get(state.circuit.getContext(), insts);
+  auto nla = b.create<NonLocalAnchor>(
+      state.circuit.getLoc(), "nla", modAttr, instAttr);
+  state.symTbl.insert(nla);
+  return FlatSymbolRefAttr::get(nla);
+}
+
+/// Scatter breadcrumb annotations corresponding to non-local annotations
+/// along the instance path.  Returns symbol name used to anchor annotations to
+/// path.
+// FIXME: uniq annotation chain links
+static FlatSymbolRefAttr scatterNonLocalPath(AnnoPathValue target,
+                                             applyState state) {
+
+  FlatSymbolRefAttr sym = buildNLA(target, state);
+
+  NamedAttrList pathmetadata;
+  pathmetadata.append("circt.nonlocal", sym);
+  pathmetadata.append("class", StringAttr::get(state.circuit.getContext(), "circt.nonlocal"));
+  for (auto item : target.instances)
+    addAnnotation(AnnoTarget(item), pathmetadata);
+
+  return sym;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Standard Utility Resolvers
+////////////////////////////////////////////////////////////////////////////////
+
+static Optional<AnnoPathValue> noResolve(DictionaryAttr anno,
+                                         applyState state) {
+  return AnnoPathValue(state.circuit);
+}
+
+static Optional<AnnoPathValue> stdResolveImpl(StringRef rawPath,
+                                              applyState state) {
+  auto pathStr = canonicalizeTarget(rawPath);
+  StringRef path{pathStr};
+
+  auto tokens = tokenizePath(path);
+  if (!tokens) {
+    state.circuit->emitError("Cannot tokenize annotation path ") << rawPath;
+    return {};
+  }
+
+  return resolveEntities(*tokens, state);
+}
+
+static Optional<AnnoPathValue> stdResolve(DictionaryAttr anno,
+                                          applyState state) {
+  auto target = anno.getNamed("target");
+  if (!target) {
+    state.circuit.emitError("No target field in annotation ") << anno;
+    return {};
+  }
+  if (!target->second.isa<StringAttr>()) {
+    state.circuit.emitError(
+        "Target field in annotation doesn't contain string ")
+        << anno;
+    return {};
+  }
+  return stdResolveImpl(target->second.cast<StringAttr>().getValue(), state);
+}
+
+static Optional<AnnoPathValue> tryResolve(DictionaryAttr anno,
+                                          applyState state) {
+  auto target = anno.getNamed("target");
+  if (target)
+    return stdResolveImpl(target->second.cast<StringAttr>().getValue(), state);
+  return AnnoPathValue(state.circuit);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Standard Utility Appliers
+////////////////////////////////////////////////////////////////////////////////
+
+static LogicalResult
+ignoreAnno(AnnoPathValue target, DictionaryAttr anno,
+           llvm::function_ref<void(ArrayAttr)> addToWorklist) {
+  return success();
+}
+
+static LogicalResult applyWithoutTargetImpl(AnnoPathValue target,
+                                                DictionaryAttr anno,
+                                                applyState state,
+                                                bool allowNonLocal) {
+  if (!allowNonLocal && !target.isLocal())
+    return failure();
+  SmallVector<NamedAttribute> newAnnoAttrs;
+  for (auto &na : anno) {
+    if (na.first != "target") {
+      newAnnoAttrs.push_back(na);
+      } else if (!target.isLocal()) {
+        auto sym = scatterNonLocalPath(target, state);
+        newAnnoAttrs.push_back(
+          {Identifier::get("circt.nonlocal", anno.getContext()), sym});
+      }
+  }
+  addAnnotation(target.ref, newAnnoAttrs);
+  return success();
+}
+
+template <bool allowNonLocal, typename T, typename... Tr>
+static LogicalResult applyWithoutTarget(AnnoPathValue target,
+                                        DictionaryAttr anno, applyState state) {
+  if (!target.isOpOfType<T, Tr...>())
+    return failure();
+  return applyWithoutTargetImpl(target, anno, state, allowNonLocal);
+}
+
+template <bool allowNonLocal = false>
+static LogicalResult applyWithoutTarget(AnnoPathValue target,
+                                        DictionaryAttr anno, applyState state) {
+  return applyWithoutTargetImpl(target, anno, state, allowNonLocal);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Driving table
+////////////////////////////////////////////////////////////////////////////////
+
+namespace {
+struct AnnoRecord {
+  llvm::function_ref<Optional<AnnoPathValue>(DictionaryAttr, applyState)>
+      resolver;
+  llvm::function_ref<LogicalResult(AnnoPathValue, DictionaryAttr,
+                                   applyState)>
+      applier;
+};
+}; // namespace
+
+static const llvm::StringMap<AnnoRecord> annotationRecords{{
+
+    // Testing Annotation
+    {"circt.test", {stdResolve, applyWithoutTarget<true>}},
+    {"circt.testNT", {noResolve, applyWithoutTarget<>}},
+    {"circt.missing", {tryResolve, applyWithoutTarget<>}}
+
+}};
+
+static const AnnoRecord *getAnnotationHandler(StringRef annoStr,
+                                              bool ignoreUnhandledAnno) {
+  auto ii = annotationRecords.find(annoStr);
+  if (ii != annotationRecords.end())
+    return &ii->second;
+  if (ignoreUnhandledAnno)
+    return &annotationRecords.find("circt.missing")->second;
+  return nullptr;
+}
+
+//===----------------------------------------------------------------------===//
+// Pass Infrastructure
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct LowerAnnotationsPass
+    : public LowerFIRRTLAnnotationsBase<LowerAnnotationsPass> {
+  void runOnOperation() override;
+  LogicalResult applyAnnotation(DictionaryAttr anno, applyState state);
+
+  bool ignoreUnhandledAnno = false;
+  bool ignoreClasslessAnno = false;
+  SmallVector<DictionaryAttr> worklistAttrs;
+};
+} // end anonymous namespace
+
+LogicalResult LowerAnnotationsPass::applyAnnotation(DictionaryAttr anno,
+                                                    applyState state
+                                                                                                        ) {
+  // Lookup the class
+  StringRef annoClassVal;
+  if (auto annoClass = anno.getNamed("class"))
+    annoClassVal = annoClass->second.cast<StringAttr>().getValue();
+  else if (ignoreClasslessAnno)
+    annoClassVal = "circt.missing";
+  else
+    return state.circuit.emitError("Annotation without a class: ") << anno;
+
+  // See if we handle the class
+  auto record = getAnnotationHandler(annoClassVal, ignoreUnhandledAnno);
+  if (!record)
+      return state.circuit.emitWarning("Unhandled annotation: ") << anno;
+
+  // Try to apply the annotation
+  auto target = record->resolver(anno, state);
+  if (!target)
+    return state.circuit.emitError("Unable to resolve target of annotation: ")
+           << anno;
+  if (record->applier(*target, anno, state).failed())
+    return state.circuit.emitError("Unable to apply annotation: ") << anno;
+  return success();
+}
+
+// This is the main entrypoint for the lowering pass.
+void LowerAnnotationsPass::runOnOperation() {
+  CircuitOp circuit = getOperation();
+  SymbolTable modules(circuit);
+  // Grab the annotations.
+  for (auto anno : circuit.annotations())
+    worklistAttrs.push_back(anno.cast < DictionaryAttr>());
+  // Clear the annotations.
+  circuit.annotationsAttr(ArrayAttr::get(circuit.getContext(), {}));
+  size_t numFailures = 0;
+  applyState state{circuit,
+                   modules, [&](DictionaryAttr ann){worklistAttrs.push_back(ann);
+}
+
+  };
+  while (!worklistAttrs.empty()) {
+    auto attr = worklistAttrs.pop_back_val();
+    if (applyAnnotation(attr, state).failed())
+      ++numFailures;
+  }
+  if (numFailures)
+    signalPassFailure();
+}
+
+/// This is the pass constructor.
+std::unique_ptr<mlir::Pass> circt::firrtl::createLowerFIRRTLAnnotationsPass(
+    bool ignoreUnhandledAnnotations, bool ignoreClasslessAnnotations) {
+  auto pass = std::make_unique<LowerAnnotationsPass>();
+  pass->ignoreUnhandledAnno = ignoreUnhandledAnnotations;
+  pass->ignoreClasslessAnno = ignoreClasslessAnnotations;
+  return pass;
+}

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -14,9 +14,12 @@
 // CHECK: %w2 = firrtl.wire {annotations = [{circt.fieldID = 5 : i32, circt.nonlocal = @nla, class = "circt.test", nl = "nl2"}]} : !firrtl.bundle<a: uint, b: vector<uint, 4>> 
 // CHECK: firrtl.instance @BarNL {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}, {circt.nonlocal = @nla_0, class = "circt.nonlocal"}], name = "bar"}
 // CHECK: firrtl.instance @BazNL {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}, {circt.nonlocal = @nla_0, class = "circt.nonlocal"}], name = "baz"
+// CHECK: firrtl.module @FooL
+// CHECK: %w3 = firrtl.wire {annotations = [{class = "circt.test", nl = "nl3"}]}
 firrtl.circuit "FooNL"  attributes {annotations = [
   {class = "circt.test", nl = "nl", target = "~FooNL|FooNL/baz:BazNL/bar:BarNL>w"},
-  {class = "circt.test", nl = "nl2", target = "~FooNL|FooNL/baz:BazNL/bar:BarNL>w2.b[2]"}
+  {class = "circt.test", nl = "nl2", target = "~FooNL|FooNL/baz:BazNL/bar:BarNL>w2.b[2]"},
+  {class = "circt.test", nl = "nl3", target = "~FooNL|FooL>w3"}
   ]}  {
   firrtl.module @BarNL() {
     %w = firrtl.wire  : !firrtl.uint
@@ -28,6 +31,9 @@ firrtl.circuit "FooNL"  attributes {annotations = [
   }
   firrtl.module @FooNL() {
     firrtl.instance @BazNL  {name = "baz"}
+  }
+  firrtl.module @FooL() {
+    %w3 = firrtl.wire: !firrtl.uint
   }
 }
 

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -1,5 +1,4 @@
 // RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-lower-annotations)' -split-input-file %s |FileCheck %s
-// XFAIL: *
 
 // circt.test copies the annotation to the target
 // circt.testNT puts the targetless annotation on the circuit
@@ -8,14 +7,18 @@
 // A non-local annotation should work.
 
 // CHECK-LABEL: firrtl.circuit "FooNL"
+// CHECK: firrtl.nla @nla [@FooNL, @BazNL, @BarNL] ["baz", "bar", "w"]
 // CHECK: firrtl.module @BarNL
-// CHECK: firrtl.wire {annotations = [{circt.nonlocal = @"~FooNL|FooNL/baz:BazNL/bar:BarNL>w_NA_0", class = "circt.test", nl = "nl"}]}
-// CHECK: firrtl.instance @BarNL {annotations = [{circt.nonlocal = @"~FooNL|FooNL/baz:BazNL/bar:BarNL>w_NA_0", class = "circt.nonlocal"}], name = "bar"}
-// CHECK: firrtl.instance @BazNL {annotations = [{circt.nonlocal = @"~FooNL|FooNL/baz:BazNL/bar:BarNL>w_NA_0", class = "circt.nonlocal"}], name = "baz"
-// CHECK: firrtl.nla @"~FooNL|FooNL/baz:BazNL/bar:BarNL>w_NA_0" [@FooNL, @BazNL, @BarNL] ["baz", "bar", "w"]
-firrtl.circuit "FooNL"  attributes {annotations = [{class = "circt.test", nl = "nl", target = "~FooNL|FooNL/baz:BazNL/bar:BarNL>w"}]}  {
+// CHECK: firrtl.wire {annotations = [{circt.nonlocal = @nla, class = "circt.test", nl = "nl"}]}
+// CHECK: firrtl.instance @BarNL {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}], name = "bar"}
+// CHECK: firrtl.instance @BazNL {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}], name = "baz"
+firrtl.circuit "FooNL"  attributes {annotations = [
+  {class = "circt.test", nl = "nl", target = "~FooNL|FooNL/baz:BazNL/bar:BarNL>w"},
+  {class = "circt.test", nl = "nl2", target = "~FooNL|FooNL/baz:BazNL/bar:BarNL>w2.b[2]"}
+  ]}  {
   firrtl.module @BarNL() {
     %w = firrtl.wire  : !firrtl.uint
+    %w2 = firrtl.wire  : !firrtl.bundle<a: uint, b: vector<uint, 4>>
     firrtl.skip
   }
   firrtl.module @BazNL() {

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -7,11 +7,13 @@
 // A non-local annotation should work.
 
 // CHECK-LABEL: firrtl.circuit "FooNL"
-// CHECK: firrtl.nla @nla [@FooNL, @BazNL, @BarNL] ["baz", "bar", "w"]
+// CHECK: firrtl.nla @nla_0 [@FooNL, @BazNL, @BarNL] ["baz", "bar", "w"]
+// CHECK: firrtl.nla @nla [@FooNL, @BazNL, @BarNL] ["baz", "bar", "w2"] 
 // CHECK: firrtl.module @BarNL
-// CHECK: firrtl.wire {annotations = [{circt.nonlocal = @nla, class = "circt.test", nl = "nl"}]}
-// CHECK: firrtl.instance @BarNL {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}], name = "bar"}
-// CHECK: firrtl.instance @BazNL {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}], name = "baz"
+// CHECK: %w = firrtl.wire {annotations = [{circt.nonlocal = @nla_0, class = "circt.test", nl = "nl"}]}
+// CHECK: %w2 = firrtl.wire {annotations = [{circt.fieldID = 5 : i32, circt.nonlocal = @nla, class = "circt.test", nl = "nl2"}]} : !firrtl.bundle<a: uint, b: vector<uint, 4>> 
+// CHECK: firrtl.instance @BarNL {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}, {circt.nonlocal = @nla_0, class = "circt.nonlocal"}], name = "bar"}
+// CHECK: firrtl.instance @BazNL {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}, {circt.nonlocal = @nla_0, class = "circt.nonlocal"}], name = "baz"
 firrtl.circuit "FooNL"  attributes {annotations = [
   {class = "circt.test", nl = "nl", target = "~FooNL|FooNL/baz:BazNL/bar:BarNL>w"},
   {class = "circt.test", nl = "nl2", target = "~FooNL|FooNL/baz:BazNL/bar:BarNL>w2.b[2]"}

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -97,6 +97,15 @@ static cl::opt<bool> enableAnnotationWarning(
     cl::desc("Warn about annotations that were not removed by lower-to-hw"),
     cl::init(false));
 
+static cl::opt<bool> disableAnnotationsClassless(
+    "disable-annotation-classless",
+    cl::desc("Ignore annotations without a class when parsing"),
+    cl::init(false));
+
+static cl::opt<bool> disableAnnotationsUnknown(
+    "disable-annotation-unknown",
+    cl::desc("Ignore unknown annotations when parsing"), cl::init(false));
+
 static cl::opt<bool> imconstprop(
     "imconstprop",
     cl::desc(
@@ -254,6 +263,8 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
   pm.enableTiming(ts);
   applyPassManagerCLOptions(pm);
 
+  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerFIRRTLAnnotationsPass(
+      disableAnnotationsUnknown, disableAnnotationsClassless));
   if (!disableOptimization) {
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
         createCSEPass());


### PR DESCRIPTION
Add a pass to handle all annotation scattering.  This pass is table driven, with customizable scattering per-annotation-class.  When this is fleshed out, it will replace the annotation handling code in the parser.

Right now, this supports a couple testing annotation to make test cases against.

Until this is live in the pipelines, add an option to the parser to bypass annotation handling and scattering to enable testing.