### PR TITLE
[SCFToCalyx] Add partial lowering infrastructure [4/13]

### DIFF
--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -27,6 +27,16 @@ using namespace mlir;
 namespace circt {
 
 //===----------------------------------------------------------------------===//
+// Utility types
+//===----------------------------------------------------------------------===//
+
+/// A mapping is maintained between a function operation and its corresponding
+/// Calyx component. This facilitates translation when function and Calyx name
+/// are not identical, such as when the top-level function is renamed to
+/// 'main' to comply with Calyx conventions.
+using FuncMapping = DenseMap<FuncOp, calyx::ComponentOp>;
+
+//===----------------------------------------------------------------------===//
 // Lowering state classes
 //===----------------------------------------------------------------------===//
 
@@ -135,6 +145,95 @@ private:
 };
 
 //===----------------------------------------------------------------------===//
+// Partial lowering infrastructure
+//===----------------------------------------------------------------------===//
+
+/// Base class for partial lowering passes. A partial lowering pass
+/// modifies the root operation in place, but does not replace the root
+/// operation.
+/// The RewritePatternType template parameter allows for using both
+/// OpRewritePattern (default) or OpInterfaceRewritePattern.
+template <class OpType,
+          template <class> class RewritePatternType = OpRewritePattern>
+class PartialLoweringPattern : public RewritePatternType<OpType> {
+public:
+  using RewritePatternType<OpType>::RewritePatternType;
+  PartialLoweringPattern(MLIRContext *ctx, LogicalResult &resRef)
+      : RewritePatternType<OpType>(ctx), partialPatternRes(resRef) {}
+
+  LogicalResult matchAndRewrite(OpType op,
+                                PatternRewriter &rewriter) const override {
+    rewriter.updateRootInPlace(
+        op, [&] { partialPatternRes = partiallyLower(op, rewriter); });
+    return partialPatternRes;
+  }
+
+  virtual LogicalResult partiallyLower(OpType op,
+                                       PatternRewriter &rewriter) const = 0;
+
+private:
+  LogicalResult &partialPatternRes;
+};
+
+//===----------------------------------------------------------------------===//
+// Partial lowering patterns
+//===----------------------------------------------------------------------===//
+
+/// FuncOpPartialLoweringPatterns are patterns which intend to match on FuncOps
+/// and then perform their own walking of the IR. FuncOpPartialLoweringPatterns
+/// have direct access to the ComponentLoweringState for the corresponding
+/// component of the matched FuncOp.
+class FuncOpPartialLoweringPattern
+    : public PartialLoweringPattern<mlir::FuncOp> {
+public:
+  FuncOpPartialLoweringPattern(MLIRContext *context, LogicalResult &resRef,
+                               FuncMapping &_funcMap, ProgramLoweringState &pls)
+      : PartialLoweringPattern(context, resRef), funcMap(_funcMap), pls(pls) {}
+
+  LogicalResult partiallyLower(mlir::FuncOp funcOp,
+                               PatternRewriter &rewriter) const override final {
+    // Initialize the component op references if a calyx::ComponentOp has been
+    // created for the matched funcOp.
+    auto it = funcMap.find(funcOp);
+    if (it != funcMap.end()) {
+      compOp = &it->second;
+      compLoweringState = &pls.compLoweringState(*comp());
+    }
+
+    return PartiallyLowerFuncToComp(funcOp, rewriter);
+  }
+
+  // Returns the component operation associated with the currently executing
+  // partial lowering.
+  calyx::ComponentOp *comp() const {
+    assert(compOp != nullptr);
+    return compOp;
+  }
+
+  // Returns the component state associated with the currently executing
+  // partial lowering.
+  ComponentLoweringState &state() const {
+    assert(compLoweringState != nullptr);
+    return *compLoweringState;
+  }
+
+  ProgramLoweringState &progState() const { return pls; }
+
+  /// Partial lowering implementation.
+  virtual LogicalResult
+  PartiallyLowerFuncToComp(mlir::FuncOp funcOp,
+                           PatternRewriter &rewriter) const = 0;
+
+protected:
+  FuncMapping &funcMap;
+
+private:
+  mutable calyx::ComponentOp *compOp = nullptr;
+  mutable ComponentLoweringState *compLoweringState = nullptr;
+  ProgramLoweringState &pls;
+};
+
+//===----------------------------------------------------------------------===//
 // Conversion patterns
 //===----------------------------------------------------------------------===//
 
@@ -183,7 +282,8 @@ private:
 //===----------------------------------------------------------------------===//
 class SCFToCalyxPass : public SCFToCalyxBase<SCFToCalyxPass> {
 public:
-  SCFToCalyxPass() : SCFToCalyxBase<SCFToCalyxPass>() {}
+  SCFToCalyxPass()
+      : SCFToCalyxBase<SCFToCalyxPass>(), m_partialPatternRes(success()) {}
   void runOnOperation() override;
 
   LogicalResult setTopLevelFunction(mlir::ModuleOp moduleOp,
@@ -209,18 +309,24 @@ public:
         return failure();
       }
     }
-
     return success();
   }
 
+  struct LoweringPattern {
+    enum class Strategy { Once, Greedy };
+    RewritePatternSet pattern;
+    Strategy strategy;
+  };
+
   //// Creates a new Calyx program with the contents of the source module
   /// inlined within.
-  /// Furthermore, this function performs validation on the input function, to
-  /// ensure that we've implemented the capabilities necessary to convert it.
+  /// Furthermore, this function performs validation on the input function,
+  /// to ensure that we've implemented the capabilities necessary to convert
+  /// it.
   LogicalResult createProgram(StringRef topLevelFunction,
                               calyx::ProgramOp *programOpOut) {
-    // Program legalization - the partial conversion driver will not run unless
-    // some pattern is provided - provide a dummy pattern.
+    // Program legalization - the partial conversion driver will not run
+    // unless some pattern is provided - provide a dummy pattern.
     struct DummyPattern : public OpRewritePattern<mlir::ModuleOp> {
       using OpRewritePattern::OpRewritePattern;
       LogicalResult matchAndRewrite(mlir::ModuleOp,
@@ -261,7 +367,51 @@ public:
                                   std::move(conversionPatterns));
   }
 
+  /// 'Once' patterns are expected to take an additional LogicalResult&
+  /// argument, to forward their result state (greedyPatternRewriteDriver
+  /// results are skipped for Once patterns).
+  template <typename TPattern, typename... PatternArgs>
+  void addOncePattern(SmallVectorImpl<LoweringPattern> &patterns,
+                      PatternArgs &&...args) {
+    RewritePatternSet ps(&getContext());
+    ps.add<TPattern>(&getContext(), m_partialPatternRes, args...);
+    patterns.push_back(
+        LoweringPattern{std::move(ps), LoweringPattern::Strategy::Once});
+  }
+
+  template <typename TPattern, typename... PatternArgs>
+  void addGreedyPattern(SmallVectorImpl<LoweringPattern> &patterns,
+                        PatternArgs &&...args) {
+    RewritePatternSet ps(&getContext());
+    ps.add<TPattern>(&getContext(), args...);
+    patterns.push_back(
+        LoweringPattern{std::move(ps), LoweringPattern::Strategy::Greedy});
+  }
+
+  LogicalResult runPartialPattern(RewritePatternSet &pattern, bool runOnce) {
+    auto &nativePatternSet = pattern.getNativePatterns();
+    assert(nativePatternSet.size() == 1 &&
+           "Should only apply 1 partial lowering pattern at once");
+
+    // During component creation, the function body is inlined into the
+    // component body for further processing. However, proper control flow
+    // will only be established later in the conversion process, so ensure
+    // that rewriter optimizations (especially DCE) are disabled.
+    GreedyRewriteConfig config;
+    config.enableRegionSimplification = false;
+    if (runOnce)
+      config.maxIterations = 1;
+
+    /// can't return applyPatternsAndFoldGreedily. Root isn't
+    /// necessarily erased so it will always return failed(). Instead,
+    /// forward the 'succeeded' value from PartialLoweringPatternBase.
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(pattern),
+                                       config);
+    return m_partialPatternRes;
+  }
+
 private:
+  LogicalResult m_partialPatternRes;
   std::shared_ptr<ProgramLoweringState> m_loweringState = nullptr;
 };
 
@@ -283,6 +433,25 @@ void SCFToCalyxPass::runOnOperation() {
          "conversion, if module conversion succeeded.");
   m_loweringState =
       std::make_shared<ProgramLoweringState>(programOp, topLevelFunction);
+
+  /// --------------------------------------------------------------------------
+  /// If you are a developer, it may be helpful to add a
+  /// 'm_module.dump()' operation after the execution of each stage to view
+  /// the transformations that's going on.
+  /// --------------------------------------------------------------------------
+  FuncMapping funcMap;
+  SmallVector<LoweringPattern, 8> loweringPatterns;
+
+  /// Sequentially apply each lowering pattern.
+  for (auto &pat : loweringPatterns) {
+    auto res = runPartialPattern(pat.pattern,
+                                 /*runOnce=*/pat.strategy ==
+                                     LoweringPattern::Strategy::Once);
+    if (failed(res)) {
+      signalPassFailure();
+      return;
+    }
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -31,9 +31,7 @@ namespace circt {
 //===----------------------------------------------------------------------===//
 
 /// A mapping is maintained between a function operation and its corresponding
-/// Calyx component. This facilitates translation when function and Calyx name
-/// are not identical, such as when the top-level function is renamed to
-/// 'main' to comply with Calyx conventions.
+/// Calyx component.
 using FuncMapping = DenseMap<FuncOp, calyx::ComponentOp>;
 
 //===----------------------------------------------------------------------===//
@@ -402,7 +400,7 @@ public:
     if (runOnce)
       config.maxIterations = 1;
 
-    /// can't return applyPatternsAndFoldGreedily. Root isn't
+    /// Can't return applyPatternsAndFoldGreedily. Root isn't
     /// necessarily erased so it will always return failed(). Instead,
     /// forward the 'succeeded' value from PartialLoweringPatternBase.
     (void)applyPatternsAndFoldGreedily(getOperation(), std::move(pattern),
@@ -444,13 +442,13 @@ void SCFToCalyxPass::runOnOperation() {
 
   /// Sequentially apply each lowering pattern.
   for (auto &pat : loweringPatterns) {
-    auto res = runPartialPattern(pat.pattern,
-                                 /*runOnce=*/pat.strategy ==
-                                     LoweringPattern::Strategy::Once);
-    if (failed(res)) {
-      signalPassFailure();
-      return;
-    }
+    LogicalResult partialPatternRes = runPartialPattern(
+        pat.pattern,
+        /*runOnce=*/pat.strategy == LoweringPattern::Strategy::Once);
+    if (succeeded(partialPatternRes))
+      continue;
+    signalPassFailure();
+    return;
   }
 }
 

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -204,14 +204,18 @@ public:
   // Returns the component operation associated with the currently executing
   // partial lowering.
   calyx::ComponentOp *getComponent() const {
-    assert(compOp != nullptr);
+    assert(
+        compOp != nullptr &&
+        "Expected component op to have been set during pattern construction");
     return compOp;
   }
 
   // Returns the component state associated with the currently executing
   // partial lowering.
   ComponentLoweringState &getComponentState() const {
-    assert(compLoweringState != nullptr);
+    assert(compLoweringState != nullptr &&
+           "Expected component lowering state to have been set during pattern "
+           "construction");
     return *compLoweringState;
   }
 


### PR DESCRIPTION
This commit adds a partial lowering infrastructure to the SCFToCalyx pass. Similarly to `StandardToHandshake`, `SCFToCalyx` structures its conversion into multiple distinct stages. Some of these stages perform IR modifications instead of IR replacements. The partial lowering infrastructure allows for writing passes which are driven by the conversion infrastructure, but relaxes the requirement of "if a conversion pattern matches, the matched operation should be replaced or erased".

`FuncOpPartialLoweringPattern`s are patterns which intend to match on `FuncOp`s and then perform their own walking from these. These patterns are initialized with access to the `ComponentLoweringState` for corresponding component of the matched `FuncOp`.