### PR TITLE
[Comb] Canonicalize mux with constant inputs

### DIFF
--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -1696,12 +1696,12 @@ LogicalResult MuxOp::canonicalize(MuxOp op, PatternRewriter &rewriter) {
           rewriter.replaceOpWithNewOp<XorOp>(op, op.cond(), op.falseValue());
           return success();
         }
-      } else {
+      } else { // !value.isZero() => value is a single-bit 1.
         // mux(a, 1, b) -> or(a, b) for single-bit values.
         rewriter.replaceOpWithNewOp<OrOp>(op, op.cond(), op.falseValue());
         return success();
       }
-    } else {
+    } else { // value.getBitWidth() > 1
       APInt value2;
       if (matchPattern(op.falseValue(), m_RConstant(value2))) {
         // When both inputs are constants and differ by only one bit, we can

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -32,6 +32,17 @@ hw.module @muxConstantInputs2(%cond: i1) -> (o: i2) {
   hw.output %0 : i2
 }
 
+// CHECK-LABEL: @muxConstantInputsNegated
+hw.module @muxConstantInputsNegated(%cond: i1) -> (o: i2) {
+// CHECK-NEXT: %true = hw.constant true
+// CHECK-NEXT: %0 = comb.xor %cond, %true : i1
+// CHECK-NEXT: %1 = comb.concat %true, %0 : (i1, i1) -> i2
+  %c0 = hw.constant 2 : i2
+  %c1 = hw.constant 3 : i2
+  %0 = comb.mux %cond, %c0, %c1: i2
+  hw.output %0 : i2
+}
+
 // CHECK-LABEL: @notMux
 hw.module @notMux(%a: i4, %b: i4, %c: i1) -> (o: i4) {
 // CHECK-NEXT: comb.mux %c, %b, %a : i4
@@ -773,13 +784,11 @@ hw.module @SevenSegmentDecoder(%in: i4) -> (out: i7) {
   %28 = comb.mux %27, %c-7_i7, %26 : i7
   %29 = comb.icmp eq %in, %c-1_i4 : i4
   %30 = comb.mux %29, %c-15_i7, %28 : i7
-  // CHECK: %1 = comb.xor %0, %true : i1
-  // CHECK: %2 = comb.xor %0, %true : i1
-  // CHECK: %3 = comb.xor %0, %true : i1
-  // CHECK: %4 = comb.xor %0, %true : i1
-  // CHECK: %5 = comb.concat %false, %1, %2, %3, %c-1_i2, %4 : (i1, i1, i1, i1, i2, i1) -> i7
-  // CHECK: %6 = hw.array_create %c-15_i7, %c-7_i7, %c-34_i7, %c57_i7, %c-4_i7, %c-9_i7, %c-17_i7, %c-1_i7, %c7_i7, %c-3_i7, %c-19_i7, %c-26_i7, %c-49_i7, %c-37_i7, %5, %5 : i7
-  // CHECK: %7 = hw.array_get %6[%in] : !hw.array<16xi7>
+  // CHECK: %0 = comb.icmp eq %in, %c1_i4 : i4
+  // CHECK: %1 = comb.mux %0, %c6_i6, %c-1_i6 : i6
+  // CHECK: %2 = comb.concat %false, %1 : (i1, i6) -> i7
+  // CHECK: %3 = hw.array_create %c-15_i7, %c-7_i7, %c-34_i7, %c57_i7, %c-4_i7, %c-9_i7, %c-17_i7, %c-1_i7, %c7_i7, %c-3_i7, %c-19_i7, %c-26_i7, %c-49_i7, %c-37_i7, %2, %2 : i7
+  // CHECK: %4 = hw.array_get %3[%in]
   hw.output %30 : i7
 }
 

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -52,16 +52,62 @@ hw.module @notMux(%a: i4, %b: i4, %c: i1) -> (o: i4) {
   hw.output %1 : i4
 }
 
+// mux(a, 0, 1) -> ~a
 // CHECK-LABEL: @notMuxResult
-hw.module @notMuxResult(%cond: i1) -> (o: i1) {
+hw.module @notMuxResult(%a: i1) -> (o: i1) {
   // CHECK-NEXT: %true = hw.constant true
-  // CHECK-NEXT: %0 = comb.xor %cond, %true : i1
+  // CHECK-NEXT: %0 = comb.xor %a, %true : i1
   // CHECK-NEXT: hw.output %0
   %c0 = hw.constant 0 : i1
   %c1 = hw.constant 1 : i1
-  %0 = comb.mux %cond, %c0, %c1 : i1
+  %0 = comb.mux %a, %c0, %c1 : i1
   hw.output %0 : i1
 }
+
+// mux(a, 0, b) -> and(~a, b)
+// CHECK-LABEL: @muxSingleBitConstantInputs
+hw.module @muxSingleBitConstantInputs(%a: i1, %b: i1) -> (o: i1) {
+  // CHECK-NEXT: %true = hw.constant true
+  // CHECK-NEXT: %0 = comb.xor %a, %true : i1
+  // CHECK-NEXT: %1 = comb.and %0, %b : i1
+  // CHECK-NEXT: hw.output %1
+  %c0 = hw.constant 0 : i1
+  %0 = comb.mux %a, %c0, %b : i1
+  hw.output %0 : i1
+}
+
+// mux(a, 1, b) -> or(a, b)
+// CHECK-LABEL: @muxSingleBitConstantInputs2
+hw.module @muxSingleBitConstantInputs2(%a: i1, %b: i1) -> (o: i1) {
+  // CHECK-NEXT: %0 = comb.or %a, %b : i1
+  // CHECK-NEXT: hw.output %0
+  %c0 = hw.constant 1 : i1
+  %0 = comb.mux %a, %c0, %b : i1
+  hw.output %0 : i1
+}
+
+// mux(a, b, 0) -> and(a, b)
+// CHECK-LABEL: @muxSingleBitConstantInputs3
+hw.module @muxSingleBitConstantInputs3(%a: i1, %b: i1) -> (o: i1) {
+  // CHECK-NEXT: %0 = comb.and %a, %b : i1
+  // CHECK-NEXT: hw.output %0
+  %c0 = hw.constant 0 : i1
+  %0 = comb.mux %a, %b, %c0 : i1
+  hw.output %0 : i1
+}
+
+// mux(a, b, 1) -> or(~a, b)
+// CHECK-LABEL: @muxSingleBitConstantInputs4
+hw.module @muxSingleBitConstantInputs4(%cond: i1, %arg0: i1) -> (o: i1) {
+  // CHECK-NEXT: %true = hw.constant true
+  // CHECK-NEXT: %0 = comb.xor %cond, %true : i1
+  // CHECK-NEXT: %1 = comb.or %0, %arg0 : i1
+  // CHECK-NEXT: hw.output %1
+  %c0 = hw.constant 1 : i1
+  %0 = comb.mux %cond, %arg0, %c0 : i1
+  hw.output %0 : i1
+}
+
 
 // CHECK-LABEL: @notNot
 hw.module @notNot(%a: i1) -> (o: i1) {

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -19,6 +19,17 @@ hw.module @notMux(%a: i4, %b: i4, %c: i1) -> (o: i4) {
   hw.output %1 : i4
 }
 
+// CHECK-LABEL: @notMuxResult
+hw.module @notMuxResult(%cond: i1) -> (o: i1) {
+  // CHECK-NEXT: %true = hw.constant true
+  // CHECK-NEXT: %0 = comb.xor %cond, %true : i1
+  // CHECK-NEXT: hw.output %0
+  %c0 = hw.constant 0 : i1
+  %c1 = hw.constant 1 : i1
+  %0 = comb.mux %cond, %c0, %c1 : i1
+  hw.output %0 : i1
+}
+
 // CHECK-LABEL: @notNot
 hw.module @notNot(%a: i1) -> (o: i1) {
 // CHECK-NEXT: hw.output %a


### PR DESCRIPTION
Fixes the second half of #1624.

This simplifies mux expressions that have constant values for both the true and false cases by pushing the mux condition down to the individual bits of the inputs, combining the results with a concat op. This takes advantage of the simpler folds/canonicalization patterns that have already been implemented for muxes.

Separately, I also added a canonicalization pattern for the special case of `mux(cond, 0, 1'h1)`, which is equivalent to `~cond`. This helps with matching other patterns that look for bitwise not operations.

In the simplest case, it should simplify expressions like `mux(cond, 2'h2, 2'h0) -> concat(mux(cond, 1'h1, 1'h0), 1'h0) -> concat(cond, 1'h0)`. More generally, the end result should be the concatenation of one of four possible values: 0, 1, `cond`, or `~cond`.

I wasn't sure if applying this transformation on all mux ops that have constant inputs was being too aggressive or too conservative, since I don't have a great sense of what is "simpler," so I was hoping to get some guidance here. I can see that this transformation might make some mux expressions even more complicated (for example `mux(cond, 3'h6, 0) -> concat(cond, cond, 0)`), so I could restrict this something even stricter than "any mux op with constant inputs". On the flip side, I can also see that restricting it to constants may cause us to miss out on cases where we still be able to simplify the expression.

One somewhat negative effect of this transformation can be seen in the Comb canonicalization tests, specifically in the SevenSegmentDecoder test case. Here it looks like the result of my changes causes several duplicates of `comb.xor %0, %true : i1` in the output. These go away when `-cse` is run, but I don't know if that's something we want to turn on for these tests.