### PR TITLE
[CMake] Support out-of-tree users of a CIRCT build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,9 +72,6 @@ endif ()
   include(AddMLIR)
   include(HandleLLVMOptions)
 
-  # Workaround for variable not set by MLIRConfig.cmake.
-  set(MLIR_BINARY_DIR ${LLVM_BINARY_DIR})
-
   set(CIRCT_BUILT_STANDALONE 1)
   set(BACKEND_PACKAGE_STRING "LLVM ${LLVM_PACKAGE_VERSION}")
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,8 @@ endif ()
   include(AddMLIR)
   include(HandleLLVMOptions)
 
+  set(MLIR_BINARY_DIR ${PROJECT_SOURCE_DIR}/llvm/build)
+
   set(CIRCT_BUILT_STANDALONE 1)
   set(BACKEND_PACKAGE_STRING "LLVM ${LLVM_PACKAGE_VERSION}")
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,8 @@ endif ()
   include(AddMLIR)
   include(HandleLLVMOptions)
 
-  set(MLIR_BINARY_DIR ${PROJECT_SOURCE_DIR}/llvm/build)
+  # Workaround for variable not set by MLIRConfig.cmake.
+  set(MLIR_BINARY_DIR ${LLVM_BINARY_DIR})
 
   set(CIRCT_BUILT_STANDALONE 1)
   set(BACKEND_PACKAGE_STRING "LLVM ${LLVM_PACKAGE_VERSION}")

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -39,6 +39,15 @@ set(CIRCT_CONFIG_LLVM_CMAKE_DIR)
 set(CIRCT_CONFIG_EXPORTS_FILE)
 set(CIRCT_CONFIG_INCLUDE_DIRS)
 
+# For compatibility with projects that include(CIRCTConfig)
+# via CMAKE_MODULE_PATH, place API modules next to it.
+# Upstream: "This should be removed in the future."
+file(COPY .
+  DESTINATION ${circt_cmake_builddir}
+  FILES_MATCHING PATTERN *.cmake
+  PATTERN CMakeFiles EXCLUDE
+  )
+
 # Generate CIRCTConfig.cmake for the install tree.
 set(CIRCT_CONFIG_CODE "
 # Compute the installation prefix from this LLVMConfig.cmake file location.

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -1,14 +1,8 @@
 set(CIRCT_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/circt)
 set(circt_cmake_builddir "${CMAKE_BINARY_DIR}/${CIRCT_INSTALL_PACKAGE_DIR}")
 
-# Keep this in sync with mlir/cmake/CMakeLists.txt!
-set(MLIR_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/mlir)
-set(mlir_cmake_builddir "${MLIR_BINARY_DIR}/${MLIR_INSTALL_PACKAGE_DIR}")
-
 # Keep this in sync with llvm/cmake/CMakeLists.txt!
 set(LLVM_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm)
-set(llvm_cmake_builddir "${LLVM_BINARY_DIR}/${LLVM_INSTALL_PACKAGE_DIR}")
-
 # Generate a list of CMake library targets so that other CMake projects can
 # link against them. LLVM calls its version of this file LLVMExports.cmake, but
 # the usual CMake convention seems to be ${Project}Targets.cmake.
@@ -23,8 +17,7 @@ get_property(CIRCT_ANALYSIS_LIBS GLOBAL PROPERTY CIRCT_ANALYSIS_LIBS)
 
 # Generate CIRCTConfig.cmake for the build tree.
 set(CIRCT_CONFIG_CMAKE_DIR "${circt_cmake_builddir}")
-set(CIRCT_CONFIG_LLVM_CMAKE_DIR "${llvm_cmake_builddir}")
-set(CIRCT_CONFIG_MLIR_CMAKE_DIR "${mlir_cmake_builddir}")
+set(CIRCT_CONFIG_MLIR_CMAKE_DIR "${MLIR_CMAKE_DIR}")
 set(CIRCT_CONFIG_EXPORTS_FILE "${circt_cmake_builddir}/CIRCTTargets.cmake")
 set(CIRCT_CONFIG_INCLUDE_DIRS
   "${CIRCT_SOURCE_DIR}/include"
@@ -35,7 +28,7 @@ configure_file(
   ${circt_cmake_builddir}/CIRCTConfig.cmake
   @ONLY)
 set(CIRCT_CONFIG_CMAKE_DIR)
-set(CIRCT_CONFIG_LLVM_CMAKE_DIR)
+set(CIRCT_CONFIG_MLIR_CMAKE_DIR)
 set(CIRCT_CONFIG_EXPORTS_FILE)
 set(CIRCT_CONFIG_INCLUDE_DIRS)
 

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -32,14 +32,8 @@ set(CIRCT_CONFIG_MLIR_CMAKE_DIR)
 set(CIRCT_CONFIG_EXPORTS_FILE)
 set(CIRCT_CONFIG_INCLUDE_DIRS)
 
-# For compatibility with projects that include(CIRCTConfig)
-# via CMAKE_MODULE_PATH, place API modules next to it.
-# Upstream: "This should be removed in the future."
-file(COPY .
-  DESTINATION ${circt_cmake_builddir}
-  FILES_MATCHING PATTERN *.cmake
-  PATTERN CMakeFiles EXCLUDE
-  )
+# Make CIRCT-specific CMake definitions available to out-of-tree users.
+file(COPY AddCIRCT.cmake DESTINATION ${circt_cmake_builddir})
 
 # Generate CIRCTConfig.cmake for the install tree.
 set(CIRCT_CONFIG_CODE "


### PR DESCRIPTION
**Draft**, hoping to get some input if this is the right approach:

I'm planning to do some out-of-tree work with CIRCT. To test it out, I set up a dummy project [here](https://github.com/jopperm/coot), and ran into the following issues:

- In principle, `find_package(CIRCT)` should recursively find MLIR and LLVM. However, the hint emitted [here](https://github.com/llvm/circt/blob/9e58c585e8fd1d7e809b169943dc091d2149896a/cmake/modules/CIRCTConfig.cmake.in#L5-L6) is wrong, because the CIRCT build doesn't set `MLIR_BINARY_DIR`.
- `AddCIRCT.cmake` is not copied to the build directory. Upstream, they note that this step should be removed in the future, though I believe we use this particular mechanism in CIRCT as well, to access MLIR's macro definitions.

The changes in this PR only apply to using a non-unified build of CIRCT in the out-of-tree project. I haven't checked the implications for unified builds nor for the install targets yet.