### PR TITLE
[SV] Make sv.interface a SingleBlock region

### DIFF
--- a/include/circt/Dialect/SV/SVTypeDecl.td
+++ b/include/circt/Dialect/SV/SVTypeDecl.td
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 def InterfaceOp : SVOp<"interface",
-    [NoTerminator, Symbol, SymbolTable]> {
+    [SingleBlock, NoTerminator, Symbol, SymbolTable]> {
   let summary = "Operation to define a SystemVerilog interface";
 
   let description = [{

--- a/test/Dialect/SV/interfaces.mlir
+++ b/test/Dialect/SV/interfaces.mlir
@@ -3,6 +3,13 @@
 
 // CHECK-LABEL: module {
 module {
+
+  // Empty interface test
+  sv.interface @empty { }
+
+  // CHECK-NEXT: sv.interface @empty {
+  // CHECK-NEXT: }
+
   // Basic interface smoke test
 
   sv.interface @myinterface {


### PR DESCRIPTION
When the MLIR parser reads in an empty region it does not create a
block.  The SymbolTable trait requires that the region has a block.
Adding the SingleBlock trait to the interface operation fixes this
issue.