### PR TITLE
[FIRRTL][Inliner] Don't delete unknown ops when deleting dead modules

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -340,7 +340,7 @@ void Inliner::run() {
 
   // Delete all unreferenced modules.
   for (auto &op : llvm::make_early_inc_range(*circuit.getBody())) {
-    if (!liveModules.count(&op))
+    if (isa<FExtModuleOp, FModuleOp>(op) && !liveModules.count(&op))
       op.erase();
   }
 }

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -219,4 +219,11 @@ firrtl.module @declarations(in %clock : !firrtl.clock, in %u8 : !firrtl.uint<8>,
   }
 }
 
+// Test that non-module operations should not be deleted.
+firrtl.circuit "PreserveUnknownOps" {
+firrtl.module @PreserveUnknownOps() { }
+// CHECK: sv.verbatim "hello"
+sv.verbatim "hello"
+}
+
 }


### PR DESCRIPTION
The inliner removes any module which is left uninstantiated after all
inlining is complete.  It was mistakenly deleting non-module operations
because there was no instance of them.  For example, an `sv.verbatim`
operation would be deleted since it is not the sort of thing that could
be instantiated.  This adds a check that the operation it is considering
for deletion is in fact a module operation before removing it.