### PR TITLE
[FIRRTL][LowerToHW] Pass through `sv.verbatim` ops

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -446,11 +446,11 @@ void FIRRTLModuleLowering::runOnOperation() {
           state.oldToNewModuleMap[&op] =
               lowerExtModule(extModule, topLevelModule, state);
         })
-        // GrandCentral can generate interfaces.  These need to be let through.
-        // Moving them to the end of the module has the effect of keeping them
-        // in the same spot in the IR.
-        .Case<sv::InterfaceOp>([&](auto passThrough) {
-          passThrough->moveBefore(topLevelModule, topLevelModule->end());
+        // These need to be let through.  EmitMetadata produces VerbatimOps and
+        // GrandCentral can generate interfaces.  Moving them to the end of the
+        // module has the effect of keeping them in the same spot in the IR.
+        .Case<sv::InterfaceOp, sv::VerbatimOp>([&](Operation *op) {
+          op->moveBefore(topLevelModule, topLevelModule->end());
         })
         // Otherwise we don't know what this is.  We are just going to drop
         // it, but emit an error so the client has some chance to know that

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
@@ -256,4 +256,10 @@ firrtl.circuit "Simple" {
     %result = firrtl.instance @bar740 {name = "fpga", portNames = ["led_0"]} : !firrtl.analog<1>
     firrtl.attach %result, %led_0 : !firrtl.analog<1>, !firrtl.analog<1>
   }
+
+  // The following operations should be passed through without an error.
+  // CHECK: sv.verbatim "hello"
+  sv.verbatim "hello"
+  // CHECK: sv.interface @SVInterface
+  sv.interface @SVInterface { }
 }


### PR DESCRIPTION
The LowerToHW pass will emit an error for any unrecognized operation it
finds in the Circuit while lowering.  We need to be able to pass
through `sv.verbatim` operations which are created during metadata
generation.  The `sv.interface` operation is already passed directly
through when lowering, and this change extends this to include
`sv.verbatim` operations.  If we find that there are too many operations
being white-listed, we could modify it to pass-through anything by
default.