### PR TITLE
[SCFToCalyx] Support if- and while control-flow operations [8/13]

### DIFF
--- a/test/Conversion/SCFToCalyx/convert_controlflow.mlir
+++ b/test/Conversion/SCFToCalyx/convert_controlflow.mlir
@@ -1,0 +1,130 @@
+// RUN: circt-opt %s --lower-scf-to-calyx -split-input-file | FileCheck %s
+
+// CHECK:      module  {
+// CHECK-NEXT:   calyx.program "main"  {
+// CHECK-NEXT:     calyx.component @main(%in0: i32, %in1: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out0: i32, %done: i1 {done}) {
+// CHECK-NEXT:       %true = hw.constant true
+// CHECK-NEXT:       %std_slt_0.left, %std_slt_0.right, %std_slt_0.out = calyx.std_slt "std_slt_0" : i32, i32, i1
+// CHECK-NEXT:       %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register "ret_arg0_reg" : i32, i1, i1, i1, i32, i1
+// CHECK-NEXT:       %bb3_arg0_reg.in, %bb3_arg0_reg.write_en, %bb3_arg0_reg.clk, %bb3_arg0_reg.reset, %bb3_arg0_reg.out, %bb3_arg0_reg.done = calyx.register "bb3_arg0_reg" : i32, i1, i1, i1, i32, i1
+// CHECK-NEXT:       calyx.wires  {
+// CHECK-NEXT:         calyx.assign %out0 = %ret_arg0_reg.out : i32
+// CHECK-NEXT:         calyx.comb_group @bb0_0  {
+// CHECK-NEXT:           calyx.assign %std_slt_0.left = %in0 : i32
+// CHECK-NEXT:           calyx.assign %std_slt_0.right = %in1 : i32
+// CHECK-NEXT:         }
+// CHECK-NEXT:         calyx.group @bb1_to_bb3  {
+// CHECK-NEXT:           calyx.assign %bb3_arg0_reg.in = %in0 : i32
+// CHECK-NEXT:           calyx.assign %bb3_arg0_reg.write_en = %true : i1
+// CHECK-NEXT:           calyx.group_done %bb3_arg0_reg.done : i1
+// CHECK-NEXT:         }
+// CHECK-NEXT:         calyx.group @bb2_to_bb3  {
+// CHECK-NEXT:           calyx.assign %bb3_arg0_reg.in = %in1 : i32
+// CHECK-NEXT:           calyx.assign %bb3_arg0_reg.write_en = %true : i1
+// CHECK-NEXT:           calyx.group_done %bb3_arg0_reg.done : i1
+// CHECK-NEXT:         }
+// CHECK-NEXT:         calyx.group @ret_assign_0  {
+// CHECK-NEXT:           calyx.assign %ret_arg0_reg.in = %bb3_arg0_reg.out : i32
+// CHECK-NEXT:           calyx.assign %ret_arg0_reg.write_en = %true : i1
+// CHECK-NEXT:           calyx.group_done %ret_arg0_reg.done : i1
+// CHECK-NEXT:         }
+// CHECK-NEXT:       }
+// CHECK-NEXT:       calyx.control  {
+// CHECK-NEXT:         calyx.seq  {
+// CHECK-NEXT:           calyx.if %std_slt_0.out with @bb0_0  {
+// CHECK-NEXT:             calyx.seq  {
+// CHECK-NEXT:               calyx.seq  {
+// CHECK-NEXT:               }
+// CHECK-NEXT:               calyx.seq  {
+// CHECK-NEXT:                 calyx.enable @bb1_to_bb3 {compiledGroups = []}
+// CHECK-NEXT:               }
+// CHECK-NEXT:               calyx.enable @ret_assign_0 {compiledGroups = []}
+// CHECK-NEXT:             }
+// CHECK-NEXT:           } else  {
+// CHECK-NEXT:             calyx.seq  {
+// CHECK-NEXT:               calyx.seq  {
+// CHECK-NEXT:               }
+// CHECK-NEXT:               calyx.seq  {
+// CHECK-NEXT:                 calyx.enable @bb2_to_bb3 {compiledGroups = []}
+// CHECK-NEXT:               }
+// CHECK-NEXT:               calyx.enable @ret_assign_0 {compiledGroups = []}
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:         }
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+module {
+  func @main(%arg0 : i32, %arg1 : i32) -> i32 {
+    %0 = cmpi slt, %arg0, %arg1 : i32
+    cond_br %0, ^bb1, ^bb2
+  ^bb1:
+    br ^bb3(%arg0 : i32)
+  ^bb2:
+    br ^bb3(%arg1 : i32)
+  ^bb3(%1 : i32):
+    return %1 : i32
+  }
+}
+
+// -----
+
+// CHECK:      module  {
+// CHECK-NEXT:   calyx.program "main"  {
+// CHECK-NEXT:     calyx.component @main(%in0: i32, %in1: i32, %in2: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out0: i32, %done: i1 {done}) {
+// CHECK-NEXT:       %true = hw.constant true
+// CHECK-NEXT:       %std_slt_0.left, %std_slt_0.right, %std_slt_0.out = calyx.std_slt "std_slt_0" : i32, i32, i1
+// CHECK-NEXT:       %while_0_arg0_reg.in, %while_0_arg0_reg.write_en, %while_0_arg0_reg.clk, %while_0_arg0_reg.reset, %while_0_arg0_reg.out, %while_0_arg0_reg.done = calyx.register "while_0_arg0_reg" : i32, i1, i1, i1, i32, i1
+// CHECK-NEXT:       %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register "ret_arg0_reg" : i32, i1, i1, i1, i32, i1
+// CHECK-NEXT:       calyx.wires  {
+// CHECK-NEXT:         calyx.assign %out0 = %ret_arg0_reg.out : i32
+// CHECK-NEXT:         calyx.group @assign_while_0_init  {
+// CHECK-NEXT:           calyx.assign %while_0_arg0_reg.in = %in0 : i32
+// CHECK-NEXT:           calyx.assign %while_0_arg0_reg.write_en = %true : i1
+// CHECK-NEXT:           calyx.group_done %while_0_arg0_reg.done : i1
+// CHECK-NEXT:         }
+// CHECK-NEXT:         calyx.comb_group @bb0_0  {
+// CHECK-NEXT:           calyx.assign %std_slt_0.left = %while_0_arg0_reg.out : i32
+// CHECK-NEXT:           calyx.assign %std_slt_0.right = %in1 : i32
+// CHECK-NEXT:         }
+// CHECK-NEXT:         calyx.group @assign_while_0_latch  {
+// CHECK-NEXT:           calyx.assign %while_0_arg0_reg.in = %while_0_arg0_reg.out : i32
+// CHECK-NEXT:           calyx.assign %while_0_arg0_reg.write_en = %true : i1
+// CHECK-NEXT:           calyx.group_done %while_0_arg0_reg.done : i1
+// CHECK-NEXT:         }
+// CHECK-NEXT:         calyx.group @ret_assign_0  {
+// CHECK-NEXT:           calyx.assign %ret_arg0_reg.in = %while_0_arg0_reg.out : i32
+// CHECK-NEXT:           calyx.assign %ret_arg0_reg.write_en = %true : i1
+// CHECK-NEXT:           calyx.group_done %ret_arg0_reg.done : i1
+// CHECK-NEXT:         }
+// CHECK-NEXT:       }
+// CHECK-NEXT:       calyx.control  {
+// CHECK-NEXT:         calyx.seq  {
+// CHECK-NEXT:           calyx.seq  {
+// CHECK-NEXT:             calyx.enable @assign_while_0_init {compiledGroups = []}
+// CHECK-NEXT:             calyx.while %std_slt_0.out with @bb0_0  {
+// CHECK-NEXT:               calyx.seq  {
+// CHECK-NEXT:                 calyx.enable @assign_while_0_latch {compiledGroups = []}
+// CHECK-NEXT:               }
+// CHECK-NEXT:             }
+// CHECK-NEXT:             calyx.enable @ret_assign_0 {compiledGroups = []}
+// CHECK-NEXT:           }
+// CHECK-NEXT:         }
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+module {
+  func @main(%arg0: i32, %arg1: i32, %arg2: i32) -> i32 {
+    %cst = constant 0 : i32
+    %0 = scf.while (%arg3 = %arg0) : (i32) -> (i32) {
+      %1 = cmpi slt, %arg3, %arg1 : i32
+      scf.condition(%1) %arg3 : i32
+    } do {
+    ^bb0(%arg3: i32):  // no predecessors
+      scf.yield %arg3 : i32
+    }
+    return %0 : i32
+  }
+}

--- a/test/Conversion/SCFToCalyx/errors.mlir
+++ b/test/Conversion/SCFToCalyx/errors.mlir
@@ -19,3 +19,14 @@ module {
     return
   }
 }
+
+// -----
+
+func @main() {
+  br ^bb1
+^bb1:
+  br ^bb2
+^bb2:
+  // expected-error @+1 {{CFG backedge detected. Loops must be raised to 'scf.while' or 'scf.for' operations.}}
+  br ^bb1
+}


### PR DESCRIPTION
This commit adds support for `std::BranchOpInterface` and `scf::WhileOp` operations. Control flow operations are supported by argument parsing through registers; this being basic block arguments and while iter args.