### PR TITLE
[Analysis] Add a DependenceAnalysis for checking memory accesses.

### DIFF
--- a/include/circt/Analysis/DependenceAnalysis.h
+++ b/include/circt/Analysis/DependenceAnalysis.h
@@ -30,15 +30,15 @@ namespace analysis {
 /// It represents the destination of the dependence edge, the type of the
 /// dependence, and the components associated with each enclosing loop.
 struct MemoryDependence {
-  MemoryDependence(Operation *destination,
+  MemoryDependence(Operation *source,
                    mlir::DependenceResult::ResultEnum dependenceType,
                    ArrayRef<mlir::DependenceComponent> dependenceComponents)
-      : destination(destination), dependenceType(dependenceType),
+      : source(source), dependenceType(dependenceType),
         dependenceComponents(dependenceComponents.begin(),
                              dependenceComponents.end()) {}
 
-  // The dependence is from some source operation to this destination operation.
-  Operation *destination;
+  // The source Operation where this dependence originates.
+  Operation *source;
 
   // The dependence type denotes whether or not there is a dependence.
   mlir::DependenceResult::ResultEnum dependenceType;
@@ -48,19 +48,22 @@ struct MemoryDependence {
 };
 
 /// MemoryDependenceResult captures a set of memory dependences. The map key is
-/// the operation from which the dependence originates, and the map value is
-/// zero or more MemoryDependences for that operation.
+/// the operation to which the dependences exist, and the map value is zero or
+/// more MemoryDependences for that operation.
 using MemoryDependenceResult =
     DenseMap<Operation *, SmallVector<MemoryDependence>>;
 
 /// MemoryDependenceAnalysis traverses any AffineForOps in the FuncOp body and
-/// checks for memory access dependences. Results are captured in a
-/// MemoryDependenceResult, which can by queried by Operation.
+/// checks for affine memory access dependences. Non-affine memory dependences
+/// are currently not supported. Results are captured in a
+/// MemoryDependenceResult, and an API is exposed to query dependences of a
+/// given Operation.
+/// TODO(mikeurbach): consider upstreaming this to MLIR's AffineAnalysis.
 struct MemoryDependenceAnalysis {
   // Construct the analysis from a FuncOp.
   MemoryDependenceAnalysis(mlir::FuncOp funcOp);
 
-  // Get the dependences for a given Operation.
+  // Returns the dependences, if any, that the given Operation depends on.
   ArrayRef<MemoryDependence> getDependences(Operation *);
 
 private:

--- a/include/circt/Analysis/DependenceAnalysis.h
+++ b/include/circt/Analysis/DependenceAnalysis.h
@@ -1,0 +1,65 @@
+//===- DependenceAnalysis.h - memory dependence analyses ------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This header file defines prototypes for methods that perform analysis
+// involving memory access dependences.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_ANALYSIS_DEPENDENCE_ANALYSIS_H
+#define CIRCT_ANALYSIS_DEPENDENCE_ANALYSIS_H
+
+#include "circt/Support/LLVM.h"
+#include "mlir/Analysis/AffineAnalysis.h"
+#include <utility>
+
+namespace mlir {
+class DependenceComponent;
+class FuncOp;
+} // namespace mlir
+
+namespace circt {
+namespace analysis {
+
+/// MemoryDependence captures a dependence from one memory operation to another.
+/// It represents the destination of the dependence edge, the type of the
+/// dependence, and the components associated with each enclosing loop.
+struct MemoryDependence {
+  MemoryDependence(Operation *destination,
+                   mlir::DependenceResult::ResultEnum dependenceType,
+                   ArrayRef<mlir::DependenceComponent> dependenceComponents)
+      : destination(destination), dependenceType(dependenceType),
+        dependenceComponents(dependenceComponents.begin(),
+                             dependenceComponents.end()) {}
+
+  // The dependence is from some source operation to this destination operation.
+  Operation *destination;
+
+  // The dependence type denotes whether or not there is a dependence.
+  mlir::DependenceResult::ResultEnum dependenceType;
+
+  // The dependence components include lower and upper bounds for each loop.
+  SmallVector<mlir::DependenceComponent> dependenceComponents;
+};
+
+/// MemoryDependenceResult captures a set of memory dependences. The map key is
+/// the operation from which the dependence originates, and the map value is
+/// zero or more MemoryDependences for that operation.
+using MemoryDependenceResult =
+    DenseMap<Operation *, SmallVector<MemoryDependence>>;
+
+/// getMemoryAccessDependences traverses any AffineForOps in the FuncOp body and
+/// checks for memory access dependences. Results are output into the 'results'
+/// argument.
+void getMemoryAccessDependences(mlir::FuncOp funcOp,
+                                MemoryDependenceResult &results);
+
+} // namespace analysis
+} // namespace circt
+
+#endif // CIRCT_ANALYSIS_DEPENDENCE_ANALYSIS_H

--- a/include/circt/Analysis/DependenceAnalysis.h
+++ b/include/circt/Analysis/DependenceAnalysis.h
@@ -53,11 +53,20 @@ struct MemoryDependence {
 using MemoryDependenceResult =
     DenseMap<Operation *, SmallVector<MemoryDependence>>;
 
-/// getMemoryAccessDependences traverses any AffineForOps in the FuncOp body and
-/// checks for memory access dependences. Results are output into the 'results'
-/// argument.
-void getMemoryAccessDependences(mlir::FuncOp funcOp,
-                                MemoryDependenceResult &results);
+/// MemoryDependenceAnalysis traverses any AffineForOps in the FuncOp body and
+/// checks for memory access dependences. Results are captured in a
+/// MemoryDependenceResult, which can by queried by Operation.
+struct MemoryDependenceAnalysis {
+  // Construct the analysis from a FuncOp.
+  MemoryDependenceAnalysis(mlir::FuncOp funcOp);
+
+  // Get the dependences for a given Operation.
+  ArrayRef<MemoryDependence> getDependences(Operation *);
+
+private:
+  // Store dependence results.
+  MemoryDependenceResult results;
+};
 
 } // namespace analysis
 } // namespace circt

--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -1,0 +1,20 @@
+set(LLVM_OPTIONAL_SOURCES
+  DependenceAnalysis.cpp
+  TestPasses.cpp
+  )
+
+add_circt_library(CIRCTDependenceAnalysis
+  DependenceAnalysis.cpp
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRTransformUtils
+  )
+
+add_circt_library(CIRCTAnalysisTestPasses
+  TestPasses.cpp
+
+  LINK_LIBS PUBLIC
+  CIRCTDependenceAnalysis
+  MLIRPass
+  )

--- a/lib/Analysis/DependenceAnalysis.cpp
+++ b/lib/Analysis/DependenceAnalysis.cpp
@@ -1,0 +1,66 @@
+//===- DependenceAnalysis.cpp - memory dependence analyses ----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements methods that perform analysis involving memory access
+// dependences.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Analysis/DependenceAnalysis.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Transforms/LoopUtils.h"
+#include <mlir/Analysis/AffineStructures.h>
+#include <mlir/Dialect/Affine/IR/AffineMemoryOpInterfaces.h>
+
+using namespace mlir;
+using namespace circt::analysis;
+
+/// Helper to iterate through memory operation pairs and check for dependences
+/// at a given loop nesting depth.
+static void checkMemrefDependence(SmallVectorImpl<Operation *> &memoryOps,
+                                  unsigned depth,
+                                  MemoryDependenceResult &results) {
+  for (auto *source : memoryOps) {
+    results[source] = SmallVector<MemoryDependence>();
+    for (auto *destination : memoryOps) {
+      if (source == destination)
+        continue;
+
+      MemRefAccess src(source);
+      MemRefAccess dst(destination);
+      FlatAffineValueConstraints dependenceConstraints;
+      SmallVector<DependenceComponent, 2> depComps;
+      DependenceResult result = checkMemrefAccessDependence(
+          src, dst, depth, &dependenceConstraints, &depComps, true);
+
+      results[source].emplace_back(destination, result.value, depComps);
+    }
+  }
+}
+
+/// getMemoryAccessDependences traverses any AffineForOps in the FuncOp body and
+/// checks for memory access dependences. Results are output into the 'results'
+/// argument.
+void circt::analysis::getMemoryAccessDependences(
+    mlir::FuncOp funcOp, MemoryDependenceResult &results) {
+  // Collect affine loops grouped by nesting depth.
+  std::vector<SmallVector<AffineForOp, 2>> depthToLoops;
+  mlir::gatherLoops(funcOp, depthToLoops);
+
+  // Collect load and store operations to check.
+  SmallVector<Operation *> memoryOps;
+  funcOp.walk([&](Operation *op) {
+    if (isa<AffineReadOpInterface, AffineWriteOpInterface>(op))
+      memoryOps.push_back(op);
+  });
+
+  // For each depth, check memref accesses.
+  for (unsigned depth = 1, e = depthToLoops.size(); depth <= e; ++depth)
+    checkMemrefDependence(memoryOps, depth, results);
+}

--- a/lib/Analysis/DependenceAnalysis.cpp
+++ b/lib/Analysis/DependenceAnalysis.cpp
@@ -44,11 +44,11 @@ static void checkMemrefDependence(SmallVectorImpl<Operation *> &memoryOps,
   }
 }
 
-/// getMemoryAccessDependences traverses any AffineForOps in the FuncOp body and
-/// checks for memory access dependences. Results are output into the 'results'
-/// argument.
-void circt::analysis::getMemoryAccessDependences(
-    mlir::FuncOp funcOp, MemoryDependenceResult &results) {
+/// MemoryDependenceAnalysis traverses any AffineForOps in the FuncOp body and
+/// checks for memory access dependences. Results are captured in a
+/// MemoryDependenceResult, which can by queried by Operation.
+circt::analysis::MemoryDependenceAnalysis::MemoryDependenceAnalysis(
+    mlir::FuncOp funcOp) {
   // Collect affine loops grouped by nesting depth.
   std::vector<SmallVector<AffineForOp, 2>> depthToLoops;
   mlir::gatherLoops(funcOp, depthToLoops);
@@ -63,4 +63,10 @@ void circt::analysis::getMemoryAccessDependences(
   // For each depth, check memref accesses.
   for (unsigned depth = 1, e = depthToLoops.size(); depth <= e; ++depth)
     checkMemrefDependence(memoryOps, depth, results);
+}
+
+/// Returns the dependences, if any, that originate from the given Operation.
+ArrayRef<MemoryDependence>
+circt::analysis::MemoryDependenceAnalysis::getDependences(Operation *op) {
+  return results[op];
 }

--- a/lib/Analysis/TestPasses.cpp
+++ b/lib/Analysis/TestPasses.cpp
@@ -1,0 +1,79 @@
+//===- TestPasses.cpp - Test passes for the analysis infrastructure -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements test passes for the analysis infrastructure.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Analysis/DependenceAnalysis.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/Support/Debug.h"
+
+using namespace mlir;
+using namespace circt::analysis;
+
+//===----------------------------------------------------------------------===//
+// DependenceAnalysis passes.
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct TestDependenceAnalysisPass
+    : public PassWrapper<TestDependenceAnalysisPass, FunctionPass> {
+  void runOnFunction() override;
+  StringRef getArgument() const override { return "test-dependence-analysis"; }
+  StringRef getDescription() const override {
+    return "Perform dependence analysis and emit results as attributes";
+  }
+};
+} // namespace
+
+void TestDependenceAnalysisPass::runOnFunction() {
+  MLIRContext *context = &getContext();
+
+  MemoryDependenceResult results;
+  getMemoryAccessDependences(getFunction(), results);
+
+  for (auto sourceToDeps : results) {
+    SmallVector<Attribute> deps;
+
+    for (auto dep : sourceToDeps.second) {
+      if (dep.dependenceType != mlir::DependenceResult::HasDependence)
+        continue;
+
+      SmallVector<Attribute> comps;
+      for (auto comp : dep.dependenceComponents) {
+        SmallVector<Attribute> vector;
+        vector.push_back(IntegerAttr::get(IntegerType::get(context, 64),
+                                          comp.lb.getValue()));
+        vector.push_back(IntegerAttr::get(IntegerType::get(context, 64),
+                                          comp.ub.getValue()));
+        comps.push_back(ArrayAttr::get(context, vector));
+      }
+
+      deps.push_back(ArrayAttr::get(context, comps));
+    }
+
+    auto dependences = ArrayAttr::get(context, deps);
+    sourceToDeps.first->setAttr("dependences", dependences);
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Pass registration
+//===----------------------------------------------------------------------===//
+
+namespace circt {
+namespace test {
+void registerAnalysisTestPasses() {
+  mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
+    return std::make_unique<TestDependenceAnalysisPass>();
+  });
+}
+} // namespace test
+} // namespace circt

--- a/test/Analysis/dependence-analysis.mlir
+++ b/test/Analysis/dependence-analysis.mlir
@@ -16,10 +16,10 @@ func @test1(%arg0: memref<?xi32>) -> i32 {
 #set = affine_set<(d0) : (d0 - 3 >= 0)>
 func @test2(%arg0: memref<?xi32>, %arg1: memref<?xi32>) {
   affine.for %arg2 = 0 to 10 {
-    // CHECK{LITERAL}: affine.load %arg0[%arg2] {dependences = [[[3, 3]]]}
+    // CHECK: affine.load %arg0[%arg2] {dependences = []}
     %0 = affine.load %arg0[%arg2] : memref<?xi32>
     affine.if #set(%arg2) {
-      // CHECK: affine.load %arg0[%arg2 - 3] {dependences = []}
+      // CHECK{LITERAL}: affine.load %arg0[%arg2 - 3] {dependences = [[[3, 3]]]}
       %1 = affine.load %arg0[%arg2 - 3] : memref<?xi32>
       %2 = addi %0, %1 : i32
       // CHECK: affine.store %2, %arg1[%arg2 - 3] {dependences = []}
@@ -71,12 +71,12 @@ func @test4(%arg0: memref<?xi32>, %arg1: memref<?xi32>) {
 // CHECK-LABEL: func @test5
 func @test5(%arg0: memref<?xi32>) {
   affine.for %arg1 = 2 to 10 {
-    // CHECK: affine.load %arg0[%arg1 - 2] {dependences = []}
+    // CHECK{LITERAL}: affine.load %arg0[%arg1 - 2] {dependences = [[[1, 1]], [[2, 2]]]}
     %0 = affine.load %arg0[%arg1 - 2] : memref<?xi32>
     // CHECK{LITERAL}: affine.load %arg0[%arg1 - 1] {dependences = [[[1, 1]]]}
     %1 = affine.load %arg0[%arg1 - 1] : memref<?xi32>
     %2 = addi %0, %1 : i32
-    // CHECK{LITERAL}: affine.store %2, %arg0[%arg1] {dependences = [[[2, 2]], [[1, 1]]]}
+    // CHECK: affine.store %2, %arg0[%arg1] {dependences = []}
     affine.store %2, %arg0[%arg1] : memref<?xi32>
   }
   return

--- a/test/Analysis/dependence-analysis.mlir
+++ b/test/Analysis/dependence-analysis.mlir
@@ -1,0 +1,83 @@
+// RUN: circt-opt %s -test-dependence-analysis | FileCheck %s
+
+// CHECK-LABEL: func @test1
+func @test1(%arg0: memref<?xi32>) -> i32 {
+  %c0_i32 = constant 0 : i32
+  %0:2 = affine.for %arg1 = 0 to 10 iter_args(%arg2 = %c0_i32, %arg3 = %c0_i32) -> (i32, i32) {
+    // CHECK: affine.load %arg0[%arg1] {dependences = []}
+    %1 = affine.load %arg0[%arg1] : memref<?xi32>
+    %2 = addi %arg2, %1 : i32
+    affine.yield %2, %2 : i32, i32
+  }
+  return %0#1 : i32
+}
+
+// CHECK-LABEL: func @test2
+#set = affine_set<(d0) : (d0 - 3 >= 0)>
+func @test2(%arg0: memref<?xi32>, %arg1: memref<?xi32>) {
+  affine.for %arg2 = 0 to 10 {
+    // CHECK{LITERAL}: affine.load %arg0[%arg2] {dependences = [[[3, 3]]]}
+    %0 = affine.load %arg0[%arg2] : memref<?xi32>
+    affine.if #set(%arg2) {
+      // CHECK: affine.load %arg0[%arg2 - 3] {dependences = []}
+      %1 = affine.load %arg0[%arg2 - 3] : memref<?xi32>
+      %2 = addi %0, %1 : i32
+      // CHECK: affine.store %2, %arg1[%arg2 - 3] {dependences = []}
+      affine.store %2, %arg1[%arg2 - 3] : memref<?xi32>
+    }
+  }
+  return
+}
+
+// CHECK-LABEL: func @test3
+func @test3(%arg0: memref<?xi32>) {
+  %0 = memref.alloca() : memref<1xi32>
+  %1 = memref.alloca() : memref<1xi32>
+  %2 = memref.alloca() : memref<1xi32>
+  affine.for %arg1 = 0 to 10 {
+    // CHECK{LITERAL}: %3 = affine.load %2[0] {dependences = [[[1, 9]]]}
+    %3 = affine.load %2[0] : memref<1xi32>
+    // CHECK{LITERAL}: %4 = affine.load %1[0] {dependences = [[[1, 9]]]}
+    %4 = affine.load %1[0] : memref<1xi32>
+    // CHECK{LITERAL}: affine.store %4, %2[0] {dependences = [[[1, 9]]]}
+    affine.store %4, %2[0] : memref<1xi32>
+    // CHECK{LITERAL}: %5 = affine.load %0[0] {dependences = [[[1, 9]]]}
+    %5 = affine.load %0[0] : memref<1xi32>
+    // CHECK{LITERAL}: affine.store %5, %1[0] {dependences = [[[1, 9]]]}
+    affine.store %5, %1[0] : memref<1xi32>
+    // CHECK: affine.load %arg0[%arg1] {dependences = []}
+    %6 = affine.load %arg0[%arg1] : memref<?xi32>
+    %7 = addi %3, %6 : i32
+    // CHECK{LITERAL}: affine.store %7, %0[0] {dependences = [[[1, 9]]]}
+    affine.store %7, %0[0] : memref<1xi32>
+  }
+  return
+}
+
+// CHECK-LABEL: func @test4
+func @test4(%arg0: memref<?xi32>, %arg1: memref<?xi32>) {
+  %c1_i32 = constant 1 : i32
+  affine.for %arg2 = 0 to 10 {
+    // CHECK: affine.load %arg1[%arg2] {dependences = []}
+    %0 = affine.load %arg1[%arg2] : memref<?xi32>
+    %1 = index_cast %0 : i32 to index
+    %2 = memref.load %arg0[%1] : memref<?xi32>
+    %3 = addi %2, %c1_i32 : i32
+    memref.store %3, %arg0[%1] : memref<?xi32>
+  }
+  return
+}
+
+// CHECK-LABEL: func @test5
+func @test5(%arg0: memref<?xi32>) {
+  affine.for %arg1 = 2 to 10 {
+    // CHECK: affine.load %arg0[%arg1 - 2] {dependences = []}
+    %0 = affine.load %arg0[%arg1 - 2] : memref<?xi32>
+    // CHECK{LITERAL}: affine.load %arg0[%arg1 - 1] {dependences = [[[1, 1]]]}
+    %1 = affine.load %arg0[%arg1 - 1] : memref<?xi32>
+    %2 = addi %0, %1 : i32
+    // CHECK{LITERAL}: affine.store %2, %arg0[%arg1] {dependences = [[[2, 2]], [[1, 1]]]}
+    affine.store %2, %arg0[%arg1] : memref<?xi32>
+  }
+  return
+}

--- a/tools/circt-opt/CMakeLists.txt
+++ b/tools/circt-opt/CMakeLists.txt
@@ -8,6 +8,7 @@ add_llvm_tool(circt-opt
 llvm_update_compile_flags(circt-opt)
 target_link_libraries(circt-opt
   PRIVATE
+  CIRCTAnalysisTestPasses
   CIRCTCalyx
   CIRCTCalyxToHW
   CIRCTCalyxTransforms

--- a/tools/circt-opt/circt-opt.cpp
+++ b/tools/circt-opt/circt-opt.cpp
@@ -25,6 +25,7 @@
 // Defined in the test directory, no public header.
 namespace circt {
 namespace test {
+void registerAnalysisTestPasses();
 void registerSchedulingTestPasses();
 } // namespace test
 } // namespace circt
@@ -49,6 +50,7 @@ int main(int argc, char **argv) {
   mlir::registerCanonicalizerPass();
 
   // Register test passes
+  circt::test::registerAnalysisTestPasses();
   circt::test::registerSchedulingTestPasses();
 
   return mlir::failed(


### PR DESCRIPTION
This is currently a simple function that traverses pairs of Affine
memory access operations and uses the upstream
`checkMemrefAccessDependence` function. The results are returned in a
convenient data structure that can inform scheduling decisions. A test
pass is added, which outputs the results as attributes for
verification.