### PR TITLE
[SCFToCalyx] Support scf.execute_region operations [9/13]

### DIFF
--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -821,6 +821,7 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
 ///       ERO to jump to
 ///  ii : Rewrite scf.yield calls inside the ERO to branch to the sink block
 ///  iii: inline the ERO region
+/// TODO(#1850) evaluate the usefulness of this lowering pattern.
 class InlineExecuteRegionOpPattern
     : public OpRewritePattern<scf::ExecuteRegionOp> {
   using OpRewritePattern::OpRewritePattern;

--- a/test/Conversion/SCFToCalyx/convert_controlflow.mlir
+++ b/test/Conversion/SCFToCalyx/convert_controlflow.mlir
@@ -128,3 +128,119 @@ module {
     return %0 : i32
   }
 }
+
+// -----
+
+// module  {
+//   calyx.program "main"  {
+//     calyx.component @main(%in0: i32, %in1: i32, %in2: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out0: i32, %done: i1 {done}) {
+//       %true = hw.constant true
+//       %std_slt_1.left, %std_slt_1.right, %std_slt_1.out = calyx.std_slt "std_slt_1" : i32, i32, i1
+//       %std_slt_0.left, %std_slt_0.right, %std_slt_0.out = calyx.std_slt "std_slt_0" : i32, i32, i1
+//       %while_0_arg0_reg.in, %while_0_arg0_reg.write_en, %while_0_arg0_reg.clk, %while_0_arg0_reg.reset, %while_0_arg0_reg.out, %while_0_arg0_reg.done = calyx.register "while_0_arg0_reg" : i32, i1, i1, i1, i32, i1
+//       %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register "ret_arg0_reg" : i32, i1, i1, i1, i32, i1
+//       %bb4_arg0_reg.in, %bb4_arg0_reg.write_en, %bb4_arg0_reg.clk, %bb4_arg0_reg.reset, %bb4_arg0_reg.out, %bb4_arg0_reg.done = calyx.register "bb4_arg0_reg" : i32, i1, i1, i1, i32, i1
+//       %bb3_arg0_reg.in, %bb3_arg0_reg.write_en, %bb3_arg0_reg.clk, %bb3_arg0_reg.reset, %bb3_arg0_reg.out, %bb3_arg0_reg.done = calyx.register "bb3_arg0_reg" : i32, i1, i1, i1, i32, i1
+//       calyx.wires  {
+//         calyx.assign %out0 = %ret_arg0_reg.out : i32
+//         calyx.group @assign_while_0_init  {
+//           calyx.assign %while_0_arg0_reg.in = %in0 : i32
+//           calyx.assign %while_0_arg0_reg.write_en = %true : i1
+//           calyx.group_done %while_0_arg0_reg.done : i1
+//         }
+//         calyx.comb_group @bb0_0  {
+//           calyx.assign %std_slt_0.left = %while_0_arg0_reg.out : i32
+//           calyx.assign %std_slt_0.right = %in1 : i32
+//         }
+//         calyx.comb_group @bb0_1  {
+//           calyx.assign %std_slt_1.left = %while_0_arg0_reg.out : i32
+//           calyx.assign %std_slt_1.right = %in0 : i32
+//         }
+//         calyx.group @bb1_to_bb3  {
+//           calyx.assign %bb3_arg0_reg.in = %in0 : i32
+//           calyx.assign %bb3_arg0_reg.write_en = %true : i1
+//           calyx.group_done %bb3_arg0_reg.done : i1
+//         }
+//         calyx.group @bb2_to_bb3  {
+//           calyx.assign %bb3_arg0_reg.in = %in1 : i32
+//           calyx.assign %bb3_arg0_reg.write_en = %true : i1
+//           calyx.group_done %bb3_arg0_reg.done : i1
+//         }
+//         calyx.group @bb3_to_bb4  {
+//           calyx.assign %bb4_arg0_reg.in = %bb3_arg0_reg.out : i32
+//           calyx.assign %bb4_arg0_reg.write_en = %true : i1
+//           calyx.group_done %bb4_arg0_reg.done : i1
+//         }
+//         calyx.group @assign_while_0_latch  {
+//           calyx.assign %while_0_arg0_reg.in = %bb4_arg0_reg.out : i32
+//           calyx.assign %while_0_arg0_reg.write_en = %true : i1
+//           calyx.group_done %while_0_arg0_reg.done : i1
+//         }
+//         calyx.group @ret_assign_0  {
+//           calyx.assign %ret_arg0_reg.in = %while_0_arg0_reg.out : i32
+//           calyx.assign %ret_arg0_reg.write_en = %true : i1
+//           calyx.group_done %ret_arg0_reg.done : i1
+//         }
+//       }
+//       calyx.control  {
+//         calyx.seq  {
+//           calyx.seq  {
+//             calyx.enable @assign_while_0_init {compiledGroups = []}
+//             calyx.while %std_slt_0.out with @bb0_0  {
+//               calyx.seq  {
+//                 calyx.if %std_slt_1.out with @bb0_1  {
+//                   calyx.seq  {
+//                     calyx.seq  {
+//                     }
+//                     calyx.seq  {
+//                       calyx.enable @bb1_to_bb3 {compiledGroups = []}
+//                     }
+//                     calyx.seq  {
+//                       calyx.enable @bb3_to_bb4 {compiledGroups = []}
+//                     }
+//                   }
+//                 } else  {
+//                   calyx.seq  {
+//                     calyx.seq  {
+//                     }
+//                     calyx.seq  {
+//                       calyx.enable @bb2_to_bb3 {compiledGroups = []}
+//                     }
+//                     calyx.seq  {
+//                       calyx.enable @bb3_to_bb4 {compiledGroups = []}
+//                     }
+//                   }
+//                 }
+//                 calyx.enable @assign_while_0_latch {compiledGroups = []}
+//               }
+//             }
+//             calyx.enable @ret_assign_0 {compiledGroups = []}
+//           }
+//         }
+//       }
+//     }
+//   }
+// }
+module {
+  func @main(%arg0: i32, %arg1: i32, %arg2: i32) -> i32 {
+    %cst = constant 0 : i32
+    %0 = scf.while (%arg3 = %arg0) : (i32) -> (i32) {
+      %1 = cmpi slt, %arg3, %arg1 : i32
+      scf.condition(%1) %arg3 : i32
+    } do {
+    ^bb0(%arg3: i32):  // no predecessors
+      %2 = scf.execute_region -> i32 {
+        %3 = cmpi slt, %arg3, %arg0 : i32
+        cond_br %3, ^bb1, ^bb2
+      ^bb1:
+        br ^bb3(%arg0 : i32)
+      ^bb2:
+        br ^bb3(%arg1 : i32)
+      ^bb3(%4 : i32):
+        scf.yield %4 : i32
+      }
+      scf.yield %2 : i32
+    }
+    return %0 : i32
+  }
+}


### PR DESCRIPTION
Inlines Calyx ExecuteRegionOp operations within their parent blocks. An execution region op (ERO) is inlined by:
 1. add a sink basic block for all yield operations inside the ERO to jump to
 2. Rewrite scf.yield calls inside the ERO to branch to the sink block
 3. inline the ERO region