### PR TITLE
[Scheduling] Add a ComponentLibrary datastructure.

### DIFF
--- a/include/circt/Scheduling/ComponentLibrary.h
+++ b/include/circt/Scheduling/ComponentLibrary.h
@@ -1,0 +1,42 @@
+//===- ComponentLibrary.h - Library of components ---------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines a library of components that can be scheduled.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_SCHEDULING_COMPONENTLIBRARY_H
+#define CIRCT_SCHEDULING_COMPONENTLIBRARY_H
+
+#include "circt/Support/LLVM.h"
+#include "llvm/ADT/StringMap.h"
+
+namespace circt {
+namespace scheduling {
+
+struct ComponentData {
+  ComponentData(unsigned latency) : latency(latency) {}
+  unsigned latency;
+};
+
+struct ComponentLibrary {
+  template <typename SourceOp>
+  void addComponent(unsigned latency) {
+    components.insert(
+        std::pair(SourceOp::getOperationName(), ComponentData(latency)));
+  }
+  llvm::Optional<unsigned> getLatency(Operation *);
+
+private:
+  llvm::StringMap<ComponentData> components;
+};
+
+} // namespace scheduling
+} // namespace circt
+
+#endif // CIRCT_SCHEDULING_COMPONENTLIBRARY_H

--- a/lib/Scheduling/CMakeLists.txt
+++ b/lib/Scheduling/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(LLVM_OPTIONAL_SOURCES
   ASAPScheduler.cpp
+  ComponentLibrary.cpp
   Problems.cpp
   SimplexSchedulers.cpp
   TestPasses.cpp
@@ -16,10 +17,20 @@ add_circt_library(CIRCTScheduling
   MLIRSupport
   )
 
+add_circt_library(CIRCTComponentLibrary
+  ComponentLibrary.cpp
+
+  LINK_LIBS PUBLIC
+  MLIRTransformUtils
+  )
+
+
 add_circt_library(CIRCTSchedulingTestPasses
   TestPasses.cpp
 
   LINK_LIBS PUBLIC
+  CIRCTComb
   CIRCTScheduling
+  CIRCTComponentLibrary
   MLIRPass
   )

--- a/lib/Scheduling/ComponentLibrary.cpp
+++ b/lib/Scheduling/ComponentLibrary.cpp
@@ -1,0 +1,27 @@
+//===- ComponentLibrary.cpp - Library of components -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements a library of components that can be scheduled.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Scheduling/ComponentLibrary.h"
+#include "mlir/IR/Operation.h"
+
+using namespace mlir;
+using namespace circt::scheduling;
+
+Optional<unsigned>
+circt::scheduling::ComponentLibrary::getLatency(Operation *op) {
+  StringRef opName = op->getName().getStringRef();
+  auto it = components.find(opName);
+  if (it != components.end())
+    return it->second.latency;
+
+  return llvm::None;
+}

--- a/test/Scheduling/component-library.mlir
+++ b/test/Scheduling/component-library.mlir
@@ -1,0 +1,11 @@
+// RUN: circt-opt %s -test-component-library | FileCheck %s
+
+// CHECK-LABEL: func @mac
+func @mac(%arg0: i32, %arg1: i32, %arg2: i32) -> i32 {
+  // CHECK: %[[TMP0:.+]] = muli {{.+}} {latency = 3 : i64}
+  %0 = muli %arg0, %arg1 : i32
+  // CHECK: %[[TMP1:.+]] = addi {{.+}} {latency = 0 : i64}
+  %1 = addi %0, %arg2 : i32
+  // CHECK: return %[[TMP1]] : i32
+  return %1 : i32
+}


### PR DESCRIPTION
This associates scheduling information to operations, allowing
dialects to inform the scheduling infrastructure about the properties
of the primitives operators they support.