### PR TITLE
[Calyx] [SCFToCalyx] Add EnableOp builder which doesn't require the `compiledGroups` attribute.

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxControl.td
+++ b/include/circt/Dialect/Calyx/CalyxControl.td
@@ -138,6 +138,14 @@ def EnableOp : CalyxOp<"enable", [
     FlatSymbolRefAttr:$groupName,
     OptionalAttr<ArrayAttr>:$compiledGroups
   );
+  let builders = [
+    OpBuilder<(ins "StringRef":$groupName), [{
+      $_state.addAttribute(
+        "groupName",
+        FlatSymbolRefAttr::get($_builder.getContext(), groupName)
+      );
+    }]>
+  ];
   let assemblyFormat = "$groupName attr-dict";
   let verifier = "return ::verify$cppClass(*this);";
 }

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -1361,7 +1361,7 @@ public:
   /// results are skipped for Once patterns).
   template <typename TPattern, typename... PatternArgs>
   void addOncePattern(SmallVectorImpl<LoweringPattern> &patterns,
-                      PatternArgs &&... args) {
+                      PatternArgs &&...args) {
     RewritePatternSet ps(&getContext());
     ps.add<TPattern>(&getContext(), partialPatternRes, args...);
     patterns.push_back(
@@ -1370,7 +1370,7 @@ public:
 
   template <typename TPattern, typename... PatternArgs>
   void addGreedyPattern(SmallVectorImpl<LoweringPattern> &patterns,
-                        PatternArgs &&... args) {
+                        PatternArgs &&...args) {
     RewritePatternSet ps(&getContext());
     ps.add<TPattern>(&getContext(), args...);
     patterns.push_back(

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -1108,15 +1108,14 @@ private:
     for (auto &group : compBlockScheduleables) {
       rewriter.setInsertionPointToEnd(parentCtrlBlock);
       if (auto groupPtr = std::get_if<calyx::GroupOp>(&group); groupPtr) {
-        rewriter.create<calyx::EnableOp>(loc, groupPtr->sym_name(),
-                                         rewriter.getArrayAttr({}));
+        rewriter.create<calyx::EnableOp>(loc, groupPtr->sym_name());
       } else if (auto whileSchedPtr = std::get_if<WhileScheduleable>(&group);
                  whileSchedPtr) {
         auto &whileOp = whileSchedPtr->whileOp;
 
         /// Insert while iter arg initialization group.
-        rewriter.create<calyx::EnableOp>(
-            loc, whileSchedPtr->initGroup.getName(), rewriter.getArrayAttr({}));
+        rewriter.create<calyx::EnableOp>(loc,
+                                         whileSchedPtr->initGroup.getName());
 
         auto cond = whileOp.getConditionOp().getOperand(0);
         auto condGroup =
@@ -1138,8 +1137,7 @@ private:
         // Insert loop-latch at the end of the while group
         rewriter.setInsertionPointToEnd(whileSeqOp.getBody());
         rewriter.create<calyx::EnableOp>(
-            loc, getComponentState().getWhileLatchGroup(whileOp).getName(),
-            rewriter.getArrayAttr({}));
+            loc, getComponentState().getWhileLatchGroup(whileOp).getName());
         if (res.failed())
           return res;
       } else
@@ -1163,8 +1161,7 @@ private:
     auto preSeqOp = createSeqOp(rewriter, loc);
     rewriter.setInsertionPointToEnd(preSeqOp.getBody());
     for (auto barg : getComponentState().getBlockArgGroups(from, to))
-      rewriter.create<calyx::EnableOp>(loc, barg.sym_name(),
-                                       rewriter.getArrayAttr({}));
+      rewriter.create<calyx::EnableOp>(loc, barg.sym_name());
 
     return buildCFGControl(path, rewriter, parentCtrlBlock, from, to);
   }
@@ -1364,7 +1361,7 @@ public:
   /// results are skipped for Once patterns).
   template <typename TPattern, typename... PatternArgs>
   void addOncePattern(SmallVectorImpl<LoweringPattern> &patterns,
-                      PatternArgs &&...args) {
+                      PatternArgs &&... args) {
     RewritePatternSet ps(&getContext());
     ps.add<TPattern>(&getContext(), partialPatternRes, args...);
     patterns.push_back(
@@ -1373,7 +1370,7 @@ public:
 
   template <typename TPattern, typename... PatternArgs>
   void addGreedyPattern(SmallVectorImpl<LoweringPattern> &patterns,
-                        PatternArgs &&...args) {
+                        PatternArgs &&... args) {
     RewritePatternSet ps(&getContext());
     ps.add<TPattern>(&getContext(), args...);
     patterns.push_back(

--- a/test/Conversion/SCFToCalyx/convert_controlflow.mlir
+++ b/test/Conversion/SCFToCalyx/convert_controlflow.mlir
@@ -36,18 +36,18 @@
 // CHECK-NEXT:               calyx.seq  {
 // CHECK-NEXT:               }
 // CHECK-NEXT:               calyx.seq  {
-// CHECK-NEXT:                 calyx.enable @bb1_to_bb3 {compiledGroups = []}
+// CHECK-NEXT:                 calyx.enable @bb1_to_bb3
 // CHECK-NEXT:               }
-// CHECK-NEXT:               calyx.enable @ret_assign_0 {compiledGroups = []}
+// CHECK-NEXT:               calyx.enable @ret_assign_0
 // CHECK-NEXT:             }
 // CHECK-NEXT:           } else  {
 // CHECK-NEXT:             calyx.seq  {
 // CHECK-NEXT:               calyx.seq  {
 // CHECK-NEXT:               }
 // CHECK-NEXT:               calyx.seq  {
-// CHECK-NEXT:                 calyx.enable @bb2_to_bb3 {compiledGroups = []}
+// CHECK-NEXT:                 calyx.enable @bb2_to_bb3
 // CHECK-NEXT:               }
-// CHECK-NEXT:               calyx.enable @ret_assign_0 {compiledGroups = []}
+// CHECK-NEXT:               calyx.enable @ret_assign_0
 // CHECK-NEXT:             }
 // CHECK-NEXT:           }
 // CHECK-NEXT:         }
@@ -102,13 +102,13 @@ module {
 // CHECK-NEXT:       calyx.control  {
 // CHECK-NEXT:         calyx.seq  {
 // CHECK-NEXT:           calyx.seq  {
-// CHECK-NEXT:             calyx.enable @assign_while_0_init {compiledGroups = []}
+// CHECK-NEXT:             calyx.enable @assign_while_0_init
 // CHECK-NEXT:             calyx.while %std_slt_0.out with @bb0_0  {
 // CHECK-NEXT:               calyx.seq  {
-// CHECK-NEXT:                 calyx.enable @assign_while_0_latch {compiledGroups = []}
+// CHECK-NEXT:                 calyx.enable @assign_while_0_latch
 // CHECK-NEXT:               }
 // CHECK-NEXT:             }
-// CHECK-NEXT:             calyx.enable @ret_assign_0 {compiledGroups = []}
+// CHECK-NEXT:             calyx.enable @ret_assign_0
 // CHECK-NEXT:           }
 // CHECK-NEXT:         }
 // CHECK-NEXT:       }
@@ -185,7 +185,7 @@ module {
 //       calyx.control  {
 //         calyx.seq  {
 //           calyx.seq  {
-//             calyx.enable @assign_while_0_init {compiledGroups = []}
+//             calyx.enable @assign_while_0_init
 //             calyx.while %std_slt_0.out with @bb0_0  {
 //               calyx.seq  {
 //                 calyx.if %std_slt_1.out with @bb0_1  {
@@ -193,10 +193,10 @@ module {
 //                     calyx.seq  {
 //                     }
 //                     calyx.seq  {
-//                       calyx.enable @bb1_to_bb3 {compiledGroups = []}
+//                       calyx.enable @bb1_to_bb3
 //                     }
 //                     calyx.seq  {
-//                       calyx.enable @bb3_to_bb4 {compiledGroups = []}
+//                       calyx.enable @bb3_to_bb4
 //                     }
 //                   }
 //                 } else  {
@@ -204,17 +204,17 @@ module {
 //                     calyx.seq  {
 //                     }
 //                     calyx.seq  {
-//                       calyx.enable @bb2_to_bb3 {compiledGroups = []}
+//                       calyx.enable @bb2_to_bb3
 //                     }
 //                     calyx.seq  {
-//                       calyx.enable @bb3_to_bb4 {compiledGroups = []}
+//                       calyx.enable @bb3_to_bb4
 //                     }
 //                   }
 //                 }
-//                 calyx.enable @assign_while_0_latch {compiledGroups = []}
+//                 calyx.enable @assign_while_0_latch
 //               }
 //             }
-//             calyx.enable @ret_assign_0 {compiledGroups = []}
+//             calyx.enable @ret_assign_0
 //           }
 //         }
 //       }

--- a/test/Conversion/SCFToCalyx/convert_simple.mlir
+++ b/test/Conversion/SCFToCalyx/convert_simple.mlir
@@ -35,7 +35,7 @@ module {
 // CHECK-NEXT:       }
 // CHECK-NEXT:       calyx.control  {
 // CHECK-NEXT:         calyx.seq  {
-// CHECK-NEXT:           calyx.enable @ret_assign_0 {compiledGroups = []}
+// CHECK-NEXT:           calyx.enable @ret_assign_0
 // CHECK-NEXT:         }
 // CHECK-NEXT:       }
 // CHECK-NEXT:     }


### PR DESCRIPTION
The `compiledGroups` attribute is only used during the (currently incomplete) lowering process of Calyx IR to signify which groups are attributed to the calyx.enable during compilation. This maintains the invariant that all Group symbols are referenced throughout the life time of a Calyx program. This PR adds another builder to skip initializing it.

Closes #1844.