### PR TITLE
[Calyx] [SCFToCalyx] Add helper methods for IfOp.

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxControl.td
+++ b/include/circt/Dialect/Calyx/CalyxControl.td
@@ -69,11 +69,16 @@ def IfOp : CalyxContainer<"if", [
   let assemblyFormat = "$cond (`with` $groupName^)? $thenRegion (`else` $elseRegion^)? attr-dict";
   let verifier = "return ::verify$cppClass(*this);";
   let extraClassDeclaration = [{
-    Block *getThenRegion() {
+    /// Checks whether the `then` region exists.
+    bool thenRegionExists() { return !getOperation()->getRegion(0).empty(); }
+    /// Checks whether the `else` region exists.
+    bool elseRegionExists() { return !getOperation()->getRegion(1).empty(); }
+    /// Gets the single basic block representing the `then` region.
+    Block *getThenBody() {
       return &getOperation()->getRegion(0).front();
     }
-    bool elseRegionExists() { return !getOperation()->getRegion(1).empty(); }
-    Block *getElseRegion() {
+    /// Gets the single basic block representing the `else` region.
+    Block *getElseBody() {
       assert(elseRegionExists() && "Else region does not exist.");
       return &getOperation()->getRegion(1).front();
     }

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -405,10 +405,10 @@ private:
             if (auto groupName = op.groupName(); groupName.hasValue())
               os << " with " << groupName.getValue();
 
-            emitCalyxBody([&]() { emitCalyxControl(op.getThenRegion()); });
+            emitCalyxBody([&]() { emitCalyxControl(op.getThenBody()); });
             if (op.elseRegionExists())
               emitCalyxSection("else",
-                               [&]() { emitCalyxControl(op.getElseRegion()); });
+                               [&]() { emitCalyxControl(op.getElseBody()); });
           })
           .Case<EnableOp>([&](auto op) { emitEnable(op); })
           .Default([&](auto op) {


### PR DESCRIPTION
Add helper methods for the `IfOp`. The `IfOp` inherits from `CalyxContainer`, which has the `SingleBlock` trait, so it should be guaranteed that each region has a single block. I've renamed the getters to remain in line with the `getBody` helper for other Calyx containers.

Closes #1866.