### PR TITLE
[Calyx] [SCFToCalyx] Add builders with no guard.

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -282,6 +282,11 @@ def AssignOp : CalyxOp<"assign", [
     AnyType:$src,
     Optional<I1>:$guard
   );
+  let builders = [
+    OpBuilder<(ins "Value":$dest, "Value":$src), [{
+      $_state.addOperands({dest, src});
+    }]>
+  ];
   let verifier = "return ::verify$cppClass(*this);";
 
   // TODO(Calyx): Calyx IR typically represents a
@@ -307,6 +312,11 @@ def GroupDoneOp : CalyxGroupPort<"group_done", [
     ```
   }];
   let results = (outs);
+  let builders = [
+    OpBuilder<(ins "Value":$src), [{
+      $_state.addOperands(src);
+    }]>
+  ];
 }
 
 def GroupGoOp : CalyxGroupPort<"group_go", [
@@ -329,11 +339,9 @@ def GroupGoOp : CalyxGroupPort<"group_go", [
   }];
   let results = (outs I1);
   let builders = [
-    OpBuilder<(ins "Value":$src, CArg<"Value", "{}">:$guard), [{
+    OpBuilder<(ins "Value":$src), [{
       $_state.addTypes($_builder.getI1Type());
       $_state.addOperands(src);
-      if (guard)
-        $_state.addOperands(guard);
     }]>
   ];
 }

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -714,9 +714,9 @@ private:
     assert(addrPorts.size() == addressValues.size() &&
            "Mismatch between number of address ports of the provided memory "
            "and address assignment values");
-    for (auto &idx : enumerate(addressValues))
-      rewriter.create<calyx::AssignOp>(loc, addrPorts[idx.index()],
-                                       idx.value());
+    for (auto &address : enumerate(addressValues))
+      rewriter.create<calyx::AssignOp>(loc, addrPorts[address.index()],
+                                       address.value());
   }
 };
 

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -444,10 +444,10 @@ static void buildAssignmentsForRegisterWrite(ComponentLoweringState &state,
   IRRewriter::InsertionGuard guard(rewriter);
   auto loc = inputValue.getLoc();
   rewriter.setInsertionPointToEnd(groupOp.getBody());
-  rewriter.create<calyx::AssignOp>(loc, reg.in(), inputValue, Value());
-  rewriter.create<calyx::AssignOp>(
-      loc, reg.write_en(), state.getConstant(rewriter, loc, 1, 1), Value());
-  rewriter.create<calyx::GroupDoneOp>(loc, reg.donePort(), Value());
+  rewriter.create<calyx::AssignOp>(loc, reg.in(), inputValue);
+  rewriter.create<calyx::AssignOp>(loc, reg.write_en(),
+                                   state.getConstant(rewriter, loc, 1, 1));
+  rewriter.create<calyx::GroupDoneOp>(loc, reg.donePort());
 }
 
 static calyx::GroupOp buildWhileIterArgAssignments(
@@ -675,7 +675,7 @@ private:
     rewriter.setInsertionPointToEnd(group.getBody());
     for (auto dstOp : enumerate(opInputPorts))
       rewriter.create<calyx::AssignOp>(op.getLoc(), dstOp.value(),
-                                       op->getOperand(dstOp.index()), Value());
+                                       op->getOperand(dstOp.index()));
 
     /// Replace the result values of the source operator with the new operator.
     for (auto res : enumerate(opOutputPorts)) {
@@ -715,8 +715,8 @@ private:
            "Mismatch between number of address ports of the provided memory "
            "and address assignment values");
     for (auto &idx : enumerate(addressValues))
-      rewriter.create<calyx::AssignOp>(loc, addrPorts[idx.index()], idx.value(),
-                                       Value());
+      rewriter.create<calyx::AssignOp>(loc, addrPorts[idx.index()],
+                                       idx.value());
   }
 };
 
@@ -777,13 +777,11 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
                      storeOp.getIndices());
   rewriter.setInsertionPointToEnd(group.getBody());
   rewriter.create<calyx::AssignOp>(storeOp.getLoc(), memoryOp.writeData(),
-                                   storeOp.getValueToStore(), Value());
+                                   storeOp.getValueToStore());
   rewriter.create<calyx::AssignOp>(
       storeOp.getLoc(), memoryOp.writeEn(),
-      getComponentState().getConstant(rewriter, storeOp.getLoc(), 1, 1),
-      Value());
-  rewriter.create<calyx::GroupDoneOp>(storeOp.getLoc(), memoryOp.done(),
-                                      Value());
+      getComponentState().getConstant(rewriter, storeOp.getLoc(), 1, 1));
+  rewriter.create<calyx::GroupDoneOp>(storeOp.getLoc(), memoryOp.done());
   return success();
 }
 LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
@@ -1019,7 +1017,7 @@ public:
       rewriter.setInsertionPoint(assignOp->getBlock(),
                                  assignOp->getBlock()->begin());
       rewriter.create<calyx::AssignOp>(assignOp->getLoc(), sliceOp.getResult(0),
-                                       src, Value());
+                                       src);
       assignOp.setOperand(1, sliceOp.getResult(1));
     } else
       return assignOp.emitError()
@@ -1274,7 +1272,7 @@ class BuildReturnRegs : public FuncOpPartialLoweringPattern {
       rewriter.create<calyx::AssignOp>(
           funcOp->getLoc(),
           getComponentOutput(funcOp, *getComponent(), argType.index()),
-          reg.out(), Value());
+          reg.out());
     }
     return success();
   }


### PR DESCRIPTION
Add some builders that don't require a guard. This diminishes the need to have `Value()`. For the AssignOp builder, we verify type constraints with `SameTypeConstraint<"dest", "src">` trait.

Closes #1855.