### PR TITLE
[Calyx] Use native compiler representation for guarded assignments and ports.

### DIFF
--- a/include/circt/Dialect/Calyx/Calyx.td
+++ b/include/circt/Dialect/Calyx/Calyx.td
@@ -78,7 +78,6 @@ class CalyxGroupPort<string mnemonic, list<OpTrait> traits = []> :
     I1:$src,
     Optional<I1>:$guard
   );
-  let assemblyFormat = "$src (`,` $guard^ `?`)? attr-dict `:` type($src)";
   let verifier = "return ::verify$cppClass(*this);";
 }
 

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -272,8 +272,8 @@ def AssignOp : CalyxOp<"assign", [
     "calyx.wires" section or a "calyx.group".
 
     ```mlir
-      calyx.assign %1 = %2 : i16
-      calyx.assign %1 = %2, %guard ? : i16
+      calyx.assign %dest = %src : i16
+      calyx.assign %dest = %guard ? %src : i16
     ```
   }];
   let arguments = (ins
@@ -287,12 +287,8 @@ def AssignOp : CalyxOp<"assign", [
     }]>
   ];
   let verifier = "return ::verify$cppClass(*this);";
-
-  // TODO(Calyx): Calyx IR typically represents a
-  // guarded assignments as `%dest = %guard ? %src`
-  let assemblyFormat = [{
-    $dest `=` $src (`,` $guard^ `?`)? attr-dict `:` type($dest)
-  }];
+  let printer = "return ::print$cppClass(p, *this);";
+  let parser = "return ::parse$cppClass(parser, result);";
 }
 
 def GroupDoneOp : CalyxGroupPort<"group_done", [
@@ -306,11 +302,13 @@ def GroupDoneOp : CalyxGroupPort<"group_done", [
     when the group's done operation should be active.
 
     ```mlir
-      calyx.group_done %v1 : i1
-      calyx.group_done %v2, %guard ? : i1
+      calyx.group_done %src : i1
+      calyx.group_done %guard ? %src : i1
     ```
   }];
   let results = (outs);
+  let printer = "return ::print$cppClass(p, *this);";
+  let parser = "return ::parse$cppClass(parser, result);";
   let builders = [
     OpBuilder<(ins "Value":$src), [{
       $_state.addOperands(src);
@@ -332,11 +330,13 @@ def GroupGoOp : CalyxGroupPort<"group_go", [
     receive a source until the Compile Control pass.
 
     ```mlir
-      %group_name1.go = calyx.group_go %0 : i1
-      %group_name2.go = calyx.group_go %3, %guard ? : i1
+      %group_name1.go = calyx.group_go %src : i1
+      %group_name2.go = calyx.group_go %guard ? %src : i1
     ```
   }];
   let results = (outs I1);
+  let printer = "return ::print$cppClass(p, *this);";
+  let parser = "return ::parse$cppClass(parser, result);";
   let builders = [
     OpBuilder<(ins "Value":$src), [{
       $_state.addTypes($_builder.getI1Type());

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -404,8 +404,9 @@ static ParseResult parseGroupPort(OpAsmParser &parser, OperationState &result) {
 // A helper function for printing group ports, i.e. GroupGoOp and GroupDoneOp.
 template <typename GroupPortType>
 static void printGroupPort(OpAsmPrinter &p, GroupPortType op) {
-  bool isValidGroupPort = isa<GroupGoOp, GroupDoneOp>(&op);
-  assert(isValidGroupPort && "Should be a Calyx Group port.");
+  static_assert(std::is_same<GroupGoOp, GroupPortType>() ||
+                    std::is_same<GroupDoneOp, GroupPortType>(),
+                "Should be a Calyx Group port.");
 
   p << " ";
   // The guard is optional.

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -371,6 +371,49 @@ LogicalResult calyx::verifyControlLikeOp(Operation *op) {
   return verifyControlBody(op);
 }
 
+// Helper function for parsing a group port operation, i.e. GroupDoneOp and
+// GroupPortOp. These may take one of two different forms:
+// (1) %<guard> ? %<src> : i1
+// (2) %<src> : i1
+static ParseResult parseGroupPort(OpAsmParser &parser, OperationState &result) {
+  SmallVector<OpAsmParser::OperandType, 2> operandInfos;
+  OpAsmParser::OperandType guardOrSource;
+  if (parser.parseOperand(guardOrSource))
+    return failure();
+
+  if (succeeded(parser.parseOptionalQuestion())) {
+    OpAsmParser::OperandType source;
+    // The guard exists.
+    if (parser.parseOperand(source))
+      return failure();
+    operandInfos.push_back(source);
+  }
+  // No matter if this is the source or guard, it should be last.
+  operandInfos.push_back(guardOrSource);
+
+  Type type;
+  // Resolving the operands with the same type works here since the source and
+  // guard of a group port is always i1.
+  if (parser.parseColonType(type) ||
+      parser.resolveOperands(operandInfos, type, result.operands))
+    return failure();
+
+  return success();
+}
+
+// A helper function for printing group ports, i.e. GroupGoOp and GroupDoneOp.
+template <typename GroupPortType>
+static void printGroupPort(OpAsmPrinter &p, GroupPortType op) {
+  bool isValidGroupPort = isa<GroupGoOp, GroupDoneOp>(&op);
+  assert(isValidGroupPort && "Should be a Calyx Group port.");
+
+  p << " ";
+  // The guard is optional.
+  if (op.guard())
+    p << op.guard() << " ? ";
+  p << op.src() << " : " << op.src().getType();
+}
+
 //===----------------------------------------------------------------------===//
 // ProgramOp
 //===----------------------------------------------------------------------===//
@@ -908,6 +951,64 @@ static LogicalResult verifyAssignOp(AssignOp assign) {
   return success();
 }
 
+static ParseResult parseAssignOp(OpAsmParser &parser, OperationState &result) {
+  OpAsmParser::OperandType destination;
+  if (parser.parseOperand(destination) || parser.parseEqual())
+    return failure();
+
+  // An AssignOp takes one of the two following forms:
+  // (1) %<dest> = %<src> : <type>
+  // (2) %<dest> = %<guard> ? %<src> : <type>
+  OpAsmParser::OperandType guardOrSource;
+  if (parser.parseOperand(guardOrSource))
+    return failure();
+
+  // Since the guard is optional, we need to check if there is an accompanying
+  // `?` symbol.
+  OpAsmParser::OperandType source;
+  bool hasGuard = succeeded(parser.parseOptionalQuestion());
+  if (hasGuard) {
+    // The guard exists. Parse the source.
+    if (parser.parseOperand(source))
+      return failure();
+  }
+
+  Type type;
+  if (parser.parseColonType(type) ||
+      parser.resolveOperand(destination, type, result.operands))
+    return failure();
+
+  if (hasGuard) {
+    Type i1Type = parser.getBuilder().getI1Type();
+    // Since the guard is optional, it is listed last in the arguments of the
+    // AssignOp. Therefore, we must parse the source first.
+    if (parser.resolveOperand(source, type, result.operands) ||
+        parser.resolveOperand(guardOrSource, i1Type, result.operands))
+      return failure();
+  } else {
+    // This is actually a source.
+    if (parser.resolveOperand(guardOrSource, type, result.operands))
+      return failure();
+  }
+
+  return success();
+}
+
+static void printAssignOp(OpAsmPrinter &p, AssignOp op) {
+  p << " ";
+  p << op.dest() << " = ";
+
+  Value guard = op.guard();
+  // The guard is optional.
+  if (guard)
+    p << guard << " ? ";
+
+  // We only need to print a single type; the destination and source are
+  // guaranteed to be the same type.
+  Value source = op.src();
+  p << source << " : " << source.getType();
+}
+
 //===----------------------------------------------------------------------===//
 // InstanceOp
 //===----------------------------------------------------------------------===//
@@ -1015,6 +1116,18 @@ void GroupGoOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   setNameFn(getResult(), resultName);
 }
 
+static void printGroupGoOp(OpAsmPrinter &p, GroupGoOp op) {
+  printGroupPort(p, op);
+}
+
+static ParseResult parseGroupGoOp(OpAsmParser &parser, OperationState &result) {
+  if (parseGroupPort(parser, result))
+    return failure();
+
+  result.addTypes(parser.getBuilder().getI1Type());
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // GroupDoneOp
 //===----------------------------------------------------------------------===//
@@ -1035,6 +1148,15 @@ static LogicalResult verifyGroupDoneOp(GroupDoneOp doneOp) {
            << ". This should be a combinational group.";
 
   return verifyNotComplexSource(doneOp);
+}
+
+static void printGroupDoneOp(OpAsmPrinter &p, GroupDoneOp op) {
+  printGroupPort(p, op);
+}
+
+static ParseResult parseGroupDoneOp(OpAsmParser &parser,
+                                    OperationState &result) {
+  return parseGroupPort(parser, result);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -409,9 +409,10 @@ static void printGroupPort(OpAsmPrinter &p, GroupPortType op) {
 
   p << " ";
   // The guard is optional.
-  if (op.guard())
-    p << op.guard() << " ? ";
-  p << op.src() << " : " << op.src().getType();
+  Value guard = op.guard(), source = op.src();
+  if (guard)
+    p << guard << " ? ";
+  p << source << " : " << source.getType();
 }
 
 //===----------------------------------------------------------------------===//
@@ -995,17 +996,15 @@ static ParseResult parseAssignOp(OpAsmParser &parser, OperationState &result) {
 }
 
 static void printAssignOp(OpAsmPrinter &p, AssignOp op) {
-  p << " ";
-  p << op.dest() << " = ";
+  p << " " << op.dest() << " = ";
 
-  Value guard = op.guard();
+  Value guard = op.guard(), source = op.src();
   // The guard is optional.
   if (guard)
     p << guard << " ? ";
 
   // We only need to print a single type; the destination and source are
   // guaranteed to be the same type.
-  Value source = op.src();
   p << source << " : " << source.getType();
 }
 

--- a/test/Conversion/SCFToCalyx/convert_controlflow.mlir
+++ b/test/Conversion/SCFToCalyx/convert_controlflow.mlir
@@ -90,7 +90,7 @@ module {
 // CHECK-NEXT:           calyx.assign %while_0_arg2_reg.write_en = %true : i1
 // CHECK-NEXT:           %0 = comb.and %while_0_arg0_reg.done, %while_0_arg1_reg.done : i1
 // CHECK-NEXT:           %1 = comb.and %0, %while_0_arg2_reg.done : i1
-// CHECK-NEXT:           calyx.group_done %true, %1 ? : i1
+// CHECK-NEXT:           calyx.group_done %1 ? %true : i1
 // CHECK-NEXT:         }
 // CHECK-NEXT:         calyx.comb_group @bb0_0  {
 // CHECK-NEXT:           calyx.assign %std_slt_0.left = %while_0_arg0_reg.out : i32
@@ -108,7 +108,7 @@ module {
 // CHECK-NEXT:           calyx.assign %std_add_0.left = %while_0_arg1_reg.out : i32
 // CHECK-NEXT:           calyx.assign %std_add_0.right = %while_0_arg2_reg.out : i32
 // CHECK-NEXT:           %0 = comb.and %bb3_arg0_reg.done, %bb3_arg1_reg.done : i1
-// CHECK-NEXT:           calyx.group_done %true, %0 ? : i1
+// CHECK-NEXT:           calyx.group_done %0 ? %true : i1
 // CHECK-NEXT:         }
 // CHECK-NEXT:         calyx.group @bb2_to_bb3  {
 // CHECK-NEXT:           calyx.assign %bb3_arg0_reg.in = %std_add_1.out : i32
@@ -118,7 +118,7 @@ module {
 // CHECK-NEXT:           calyx.assign %std_add_1.left = %while_0_arg1_reg.out : i32
 // CHECK-NEXT:           calyx.assign %std_add_1.right = %while_0_arg2_reg.out : i32
 // CHECK-NEXT:           %0 = comb.and %bb3_arg0_reg.done, %bb3_arg1_reg.done : i1
-// CHECK-NEXT:           calyx.group_done %true, %0 ? : i1
+// CHECK-NEXT:           calyx.group_done %0 ? %true : i1
 // CHECK-NEXT:         }
 // CHECK-NEXT:         calyx.group @assign_while_0_latch  {
 // CHECK-NEXT:           calyx.assign %while_0_arg0_reg.in = %std_add_2.out : i32
@@ -131,7 +131,7 @@ module {
 // CHECK-NEXT:           calyx.assign %std_add_2.right = %in2 : i32
 // CHECK-NEXT:           %0 = comb.and %while_0_arg0_reg.done, %while_0_arg1_reg.done : i1
 // CHECK-NEXT:           %1 = comb.and %0, %while_0_arg2_reg.done : i1
-// CHECK-NEXT:           calyx.group_done %true, %1 ? : i1
+// CHECK-NEXT:           calyx.group_done %1 ? %true : i1
 // CHECK-NEXT:         }
 // CHECK-NEXT:         calyx.group @ret_assign_0  {
 // CHECK-NEXT:           calyx.assign %ret_arg0_reg.in = %while_0_arg2_reg.out : i32
@@ -218,7 +218,7 @@ module {
 // CHECK-NEXT:           calyx.assign %while_0_arg2_reg.write_en = %true : i1
 // CHECK-NEXT:           %0 = comb.and %while_0_arg0_reg.done, %while_0_arg1_reg.done : i1
 // CHECK-NEXT:           %1 = comb.and %0, %while_0_arg2_reg.done : i1
-// CHECK-NEXT:           calyx.group_done %true, %1 ? : i1
+// CHECK-NEXT:           calyx.group_done %1 ? %true : i1
 // CHECK-NEXT:         }
 // CHECK-NEXT:         calyx.comb_group @bb0_0  {
 // CHECK-NEXT:           calyx.assign %std_slt_0.left = %while_0_arg0_reg.out : i32
@@ -236,7 +236,7 @@ module {
 // CHECK-NEXT:           calyx.assign %std_add_0.left = %while_0_arg1_reg.out : i32
 // CHECK-NEXT:           calyx.assign %std_add_0.right = %while_0_arg2_reg.out : i32
 // CHECK-NEXT:           %0 = comb.and %bb3_arg0_reg.done, %bb3_arg1_reg.done : i1
-// CHECK-NEXT:           calyx.group_done %true, %0 ? : i1
+// CHECK-NEXT:           calyx.group_done %0 ? %true : i1
 // CHECK-NEXT:         }
 // CHECK-NEXT:         calyx.group @bb2_to_bb3  {
 // CHECK-NEXT:           calyx.assign %bb3_arg0_reg.in = %std_sub_0.out : i32
@@ -246,7 +246,7 @@ module {
 // CHECK-NEXT:           calyx.assign %std_sub_0.left = %while_0_arg1_reg.out : i32
 // CHECK-NEXT:           calyx.assign %std_sub_0.right = %while_0_arg2_reg.out : i32
 // CHECK-NEXT:           %0 = comb.and %bb3_arg0_reg.done, %bb3_arg1_reg.done : i1
-// CHECK-NEXT:           calyx.group_done %true, %0 ? : i1
+// CHECK-NEXT:           calyx.group_done %0 ? %true : i1
 // CHECK-NEXT:         }
 // CHECK-NEXT:         calyx.group @assign_while_0_latch  {
 // CHECK-NEXT:           calyx.assign %while_0_arg0_reg.in = %std_add_1.out : i32
@@ -259,7 +259,7 @@ module {
 // CHECK-NEXT:           calyx.assign %std_add_1.right = %in2 : i32
 // CHECK-NEXT:           %0 = comb.and %while_0_arg0_reg.done, %while_0_arg1_reg.done : i1
 // CHECK-NEXT:           %1 = comb.and %0, %while_0_arg2_reg.done : i1
-// CHECK-NEXT:           calyx.group_done %true, %1 ? : i1
+// CHECK-NEXT:           calyx.group_done %1 ? %true : i1
 // CHECK-NEXT:         }
 // CHECK-NEXT:         calyx.group @ret_assign_0  {
 // CHECK-NEXT:           calyx.assign %ret_arg0_reg.in = %while_0_arg2_reg.out : i32

--- a/test/Conversion/SCFToCalyx/convert_simple.mlir
+++ b/test/Conversion/SCFToCalyx/convert_simple.mlir
@@ -58,7 +58,7 @@ module {
 // CHECK-NEXT:           calyx.assign %ret_arg1_reg.in = %in1 : i32
 // CHECK-NEXT:           calyx.assign %ret_arg1_reg.write_en = %true : i1
 // CHECK-NEXT:           %0 = comb.and %ret_arg0_reg.done, %ret_arg1_reg.done : i1
-// CHECK-NEXT:           calyx.group_done %true, %0 ? : i1
+// CHECK-NEXT:           calyx.group_done %0 ? %true : i1
 // CHECK-NEXT:         }
 // CHECK-NEXT:       }
 // CHECK-NEXT:       calyx.control  {

--- a/test/Dialect/Calyx/compile-control.mlir
+++ b/test/Dialect/Calyx/compile-control.mlir
@@ -18,10 +18,10 @@ calyx.program "main" {
       // CHECK: %[[GROUP_A_NOT_DONE:.+]] = comb.xor %z.done, {{.+}} : i1
       // CHECK: %[[GROUP_A_GO_GUARD:.+]] = comb.and %[[FSM_IS_GROUP_A_BEGIN_STATE]], %[[GROUP_A_NOT_DONE]] : i1
       calyx.group @A {
-        // CHECK:  %A.go = calyx.group_go %[[SIGNAL_ON]], %[[GROUP_A_GO_GUARD]] ? : i1
-        // CHECK:  calyx.assign %z.go = %go, %A.go ? : i1
+        // CHECK:  %A.go = calyx.group_go %[[GROUP_A_GO_GUARD]] ? %[[SIGNAL_ON]] : i1
+        // CHECK:  calyx.assign %z.go = %A.go ? %go : i1
         %A.go = calyx.group_go %undef : i1
-        calyx.assign %z.go = %go, %A.go ? : i1
+        calyx.assign %z.go = %A.go ? %go : i1
         calyx.group_done %z.done : i1
       }
 
@@ -31,9 +31,9 @@ calyx.program "main" {
       // CHECK: %[[GROUP_B_NOT_DONE:.+]] = comb.xor %[[GROUP_B_DONE]], {{.+}} : i1
       // CHECK: %[[GROUP_B_GO_GUARD:.+]] = comb.and %[[FSM_IS_GROUP_B_BEGIN_STATE]], %[[GROUP_B_NOT_DONE]] : i1
       calyx.group @B {
-        // CHECK: %B.go = calyx.group_go %[[SIGNAL_ON]], %[[GROUP_B_GO_GUARD]] ? : i1
+        // CHECK: %B.go = calyx.group_go %[[GROUP_B_GO_GUARD]] ? %[[SIGNAL_ON]] : i1
         %B.go = calyx.group_go %undef : i1
-        calyx.group_done %z.done, %z.flag ? : i1
+        calyx.group_done %z.flag ? %z.done : i1
       }
 
       // CHECK: %[[GROUP_A_ASSIGN_GUARD:.+]] = comb.and %[[FSM_IS_GROUP_A_BEGIN_STATE]], %z.done : i1
@@ -43,15 +43,15 @@ calyx.program "main" {
       // CHECK: %[[SEQ_GROUP_DONE_GUARD:.+]] = comb.icmp eq %fsm.out, %[[FSM_STEP_2]] : i2
 
       // CHECK-LABEL: calyx.group @seq {
-      // CHECK-NEXT:    calyx.assign %fsm.in = %[[FSM_STEP_1]], %[[GROUP_A_ASSIGN_GUARD]] ? : i2
-      // CHECK-NEXT:    calyx.assign %fsm.write_en = %[[SIGNAL_ON]], %[[GROUP_A_ASSIGN_GUARD]] ? : i1
-      // CHECK-NEXT:    calyx.assign %fsm.in = %[[FSM_STEP_2]], %[[GROUP_B_ASSIGN_GUARD]] ? : i2
-      // CHECK-NEXT:    calyx.assign %fsm.write_en = %[[SIGNAL_ON]], %[[GROUP_B_ASSIGN_GUARD]] ? : i1
-      // CHECK-NEXT:    calyx.group_done %[[SIGNAL_ON]], %[[SEQ_GROUP_DONE_GUARD]] ? : i1
+      // CHECK-NEXT:    calyx.assign %fsm.in = %[[GROUP_A_ASSIGN_GUARD]] ? %[[FSM_STEP_1]] : i2
+      // CHECK-NEXT:    calyx.assign %fsm.write_en = %[[GROUP_A_ASSIGN_GUARD]] ? %[[SIGNAL_ON]] : i1
+      // CHECK-NEXT:    calyx.assign %fsm.in = %[[GROUP_B_ASSIGN_GUARD]] ? %[[FSM_STEP_2]] : i2
+      // CHECK-NEXT:    calyx.assign %fsm.write_en = %[[GROUP_B_ASSIGN_GUARD]] ? %[[SIGNAL_ON]] : i1
+      // CHECK-NEXT:    calyx.group_done %[[SEQ_GROUP_DONE_GUARD]] ? %[[SIGNAL_ON]] : i1
 
       // CHECK: %[[FSM_RESET:.+]] = hw.constant 0 : i2
-      // CHECK: calyx.assign %fsm.in = %[[FSM_RESET]], %[[SEQ_GROUP_DONE_GUARD]] ? : i2
-      // CHECK: calyx.assign %fsm.write_en = %[[SIGNAL_ON]], %[[SEQ_GROUP_DONE_GUARD]] ? : i1
+      // CHECK: calyx.assign %fsm.in = %[[SEQ_GROUP_DONE_GUARD]] ? %[[FSM_RESET]] : i2
+      // CHECK: calyx.assign %fsm.write_en =  %[[SEQ_GROUP_DONE_GUARD]] ? %[[SIGNAL_ON]] : i1
     }
 
     // CHECK-LABEL: calyx.control {

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -86,7 +86,7 @@ calyx.program "main" {
         %not = comb.xor %c1.out, %c1 : i1
         %and = comb.and %c1.out, %c1, %not : i1
         %or = comb.or %c1.out, %and : i1
-        calyx.assign %c1.in = %c1.out, %or ? : i1
+        calyx.assign %c1.in = %or ? %c1.out : i1
       }
       // CHECK-LABEL: group Group3 {
       // CHECK-NEXT:     r.in = s0.out;

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -719,7 +719,7 @@ calyx.program "main" {
       calyx.group @A {
         %and = comb.and %c1_1, %c1_1 : i1
         // expected-error @+1 {{'calyx.assign' op has source that is not a port or constant. Complex logic should be conducted in the guard.}}
-        calyx.assign %r.in = %and, %c1_1 ? : i1
+        calyx.assign %r.in = %c1_1 ? %and : i1
         calyx.assign %r.write_en = %c1_1: i1
         calyx.group_done %r.done : i1
       }
@@ -775,7 +775,7 @@ calyx.program "main" {
     calyx.wires {
       calyx.group @A {
         // expected-error @+1 {{'calyx.group_done' op with constant source and constant guard. This should be a combinational group.}}
-        calyx.group_done %c1_1, %c1_1 ? : i1
+        calyx.group_done %c1_1 ? %c1_1 : i1
       }
     }
     calyx.control { calyx.enable @A }

--- a/test/Dialect/Calyx/go-insertion.mlir
+++ b/test/Dialect/Calyx/go-insertion.mlir
@@ -13,13 +13,13 @@ calyx.program "main" {
       // CHECK-LABEL: calyx.group @Group1 {
       // CHECK-NEXT:    %Group1.go = calyx.group_go %0 : i1
       // CHECK-NEXT:    %1 = comb.and %c0.done, %Group1.go : i1
-      // CHECK-NEXT:    calyx.assign %c0.in = %c0.out, %Group1.go ? : i8
-      // CHECK-NEXT:    calyx.assign %c0.in = %c0.out, %1 ? : i8
+      // CHECK-NEXT:    calyx.assign %c0.in = %Group1.go ? %c0.out : i8
+      // CHECK-NEXT:    calyx.assign %c0.in =  %1 ? %c0.out : i8
       // CHECK-NEXT:    calyx.group_done %c0.done : i1
       // CHECK-NEXT:  }
       calyx.group @Group1 {
         calyx.assign %c0.in = %c0.out : i8
-        calyx.assign %c0.in = %c0.out, %c0.done ? : i8
+        calyx.assign %c0.in = %c0.done ? %c0.out : i8
         calyx.group_done %c0.done : i1
       }
     }

--- a/test/Dialect/Calyx/remove-groups.mlir
+++ b/test/Dialect/Calyx/remove-groups.mlir
@@ -30,10 +30,10 @@ calyx.program "main" {
       // CHECK-NOT: calyx.group_done
 
       // Verify that assignments are guarded by the group's GoOp and the component's go signal.
-      // CHECK: calyx.assign %z.go = %z.flag, %[[A_GO_AND_COMPONENT_GO]] ? : i1
+      // CHECK: calyx.assign %z.go = %[[A_GO_AND_COMPONENT_GO]] ? %z.flag : i1
       calyx.group @A {
-        %A.go = calyx.group_go %signal_on, %group_A_go_guard ? : i1
-        calyx.assign %z.go = %z.flag, %A.go ? : i1
+        %A.go = calyx.group_go %group_A_go_guard ? %signal_on : i1
+        calyx.assign %z.go = %A.go ? %z.flag : i1
         calyx.group_done %z.done : i1
       }
 
@@ -43,14 +43,14 @@ calyx.program "main" {
 
       // CHECK: %[[UPDATED_A_ASSIGN_GUARD:.+]] = comb.and %[[GROUP_A_ASSIGN_GUARD]], %go : i1
       // Verify that the component's done signal is assigned the top-level group's DoneOp.
-      // CHECK: calyx.assign %done = {{.+}}, %[[SEQ_GROUP_DONE_GUARD]] ? : i1
+      // CHECK: calyx.assign %done = %[[SEQ_GROUP_DONE_GUARD]] ? {{.+}} : i1
 
       // Verify that the assignments in the top-level group use the updated guard.
-      // CHECK: calyx.assign %fsm.in = {{.+}}, %[[UPDATED_A_ASSIGN_GUARD]] ? : i2
+      // CHECK: calyx.assign %fsm.in = %[[UPDATED_A_ASSIGN_GUARD]] ? {{.+}} : i2
       calyx.group @seq {
-        calyx.assign %fsm.in = %fsm_step_1, %group_A_assign_guard ? : i2
-        calyx.assign %fsm.write_en = %signal_on, %group_A_assign_guard ? : i1
-        calyx.group_done %signal_on, %seq_group_done_guard ? : i1
+        calyx.assign %fsm.in = %group_A_assign_guard ? %fsm_step_1 : i2
+        calyx.assign %fsm.write_en = %group_A_assign_guard ? %signal_on : i1
+        calyx.group_done %seq_group_done_guard ? %signal_on : i1
       }
     }
 


### PR DESCRIPTION
Switches the GroupGoOp, GroupDoneOp, and AssignOp to match the native compiler representation.

```mlir
// Before
calyx.assign %dest = %src, %guard ? : i8

calyx.group_done %src, %guard ? : i1 

%result = calyx.group_go %src, %guard ? : i1
```

```mlir
// After
calyx.assign %dest = %guard ? %src : i8

calyx.group_done %guard ? %src : i1

%result = calyx.group_go %guard ? %src : i1
```

I think Mike brought up a good point in #1873. We're still pretty dependent on the native compiler, so it seems right to keep the IRs as similar as possible. Note that placing the (optional) guard last in the arguments is necessary; otherwise the compiler assumes the source is the guard and wants to mix the types up. Not a huge deal, just requires being careful when writing out the logic for parsing.

Closes #1873; issue for necessary changes in native compiler's CIRCT backend found [here](https://github.com/cucapra/calyx/issues/692) (...and subsequently fixed [here](https://github.com/cucapra/calyx/pull/693)).