### PR TITLE
[Comb] Simplify comb.concat signature to omit result type

### DIFF
--- a/docs/RationaleComb.md
+++ b/docs/RationaleComb.md
@@ -179,7 +179,7 @@ In MLIR assembly, operands are always listed MSB to LSB (big endian style):
 %msb = comb.constant 0xEF : i8
 %mid = comb.constant 0x7 : i4
 %lsb = comb.constant 0xA018 : i16
-%result = comb.concat %msb, %mid, %lsb : (i8, i4, i16) -> i28
+%result = comb.concat %msb, %mid, %lsb : i8, i4, i16
 // %result is 0xEF7A018
 ```
 

--- a/include/circt/Dialect/Comb/Combinational.td
+++ b/include/circt/Dialect/Comb/Combinational.td
@@ -38,9 +38,6 @@ class VariadicOp<string mnemonic, list<OpTrait> traits = []> :
       CombOp<mnemonic, traits # [NoSideEffect]> {
   let arguments = (ins Variadic<HWIntegerType>:$inputs);
   let results = (outs HWIntegerType:$result);
-
-  let assemblyFormat =
-    "$inputs attr-dict `:` functional-type($inputs, results)";
 }
 
 class UTVariadicOp<string mnemonic, list<OpTrait> traits = []> :
@@ -218,6 +215,10 @@ def ConcatOp : VariadicOp<"concat"> {
   let description = [{
     See the HW-SV rationale document for details on operand ordering.
   }];
+
+  // Need a custom parser/printer to avoid redundant result type
+  let parser = "return ::parse$cppClass(parser, result);";
+  let printer = "::print$cppClass(p, *this);";
 
   let hasFolder = true;
   let hasCanonicalizeMethod = true;

--- a/integration_test/EmitVerilog/lint.mlir
+++ b/integration_test/EmitVerilog/lint.mlir
@@ -72,7 +72,7 @@ hw.module @TESTSIMPLE(%a: i4, %b: i4, %cond: i1, %array: !hw.array<10xi4>,
   %21 = comb.icmp ugt %a, %b : i4
   %22 = comb.icmp uge %a, %b : i4
   %23 = comb.parity %a : i4
-  %24 = comb.concat %a, %a, %b : (i4, i4, i4) -> i12
+  %24 = comb.concat %a, %a, %b : i4, i4, i4
   %25 = comb.extract %a from 1 : (i4) -> i2
   %26 = comb.sext %a : (i4) -> i9
   %27 = comb.mux %cond, %a, %b : i4

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
@@ -34,9 +34,9 @@ firrtl.circuit "Simple" {
     // CHECK: comb.sub
     %2 = firrtl.sub %1, %1 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
 
-    // CHECK: %3 = comb.concat %false, %in2 : (i1, i2) -> i3
+    // CHECK: %3 = comb.concat %false, %in2 : i1, i2
     %3 = firrtl.pad %in2, 3 : (!firrtl.uint<2>) -> !firrtl.uint<3>
-    // CHECK: comb.concat %false, %3 : (i1, i3) -> i4
+    // CHECK: comb.concat %false, %3 : i1, i3
     %4 = firrtl.pad %3, 4 : (!firrtl.uint<3>) -> !firrtl.uint<4>
     // CHECK: [[RESULT:%.+]] = comb.xor
     %5 = firrtl.xor %in2, %4 : (!firrtl.uint<2>, !firrtl.uint<4>) -> !firrtl.uint<4>
@@ -54,7 +54,7 @@ firrtl.circuit "Simple" {
     %xyz:4 = firrtl.instance @Simple {name = "xyz", portNames=["in1", "in2", "in3", "out4"]}
      : !firrtl.uint<4>, !firrtl.uint<2>, !firrtl.sint<8>, !firrtl.uint<4>
 
-    // CHECK: [[ARG1]] = comb.concat %c0_i2, %u2 : (i2, i2) -> i4
+    // CHECK: [[ARG1]] = comb.concat %c0_i2, %u2 : i2, i2
     firrtl.connect %xyz#0, %u2 : !firrtl.uint<4>, !firrtl.uint<2>
 
     // CHECK-NOT: hw.connect
@@ -123,7 +123,7 @@ firrtl.circuit "Simple" {
     firrtl.connect %outE, %inE : !firrtl.uint<4>, !firrtl.uint<3>
 
     // Extension for outE
-    // CHECK: [[OUTE:%.+]] = comb.concat %false, %inE : (i1, i3) -> i4
+    // CHECK: [[OUTE:%.+]] = comb.concat %false, %inE : i1, i3
     // CHECK: hw.output %inA, [[OUTBR]], [[OUTCR]], [[OUTDR]], [[OUTE]]
   }
 

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -94,14 +94,14 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %tmp1 = firrtl.invalidvalue : !firrtl.uint<4>
     firrtl.connect %out5, %tmp1 : !firrtl.uint<4>, !firrtl.uint<4>
 
-    // CHECK: [[ZEXT:%.+]] = comb.concat %false, %in1 : (i1, i4) -> i5
+    // CHECK: [[ZEXT:%.+]] = comb.concat %false, %in1 : i1, i4
     // CHECK: [[ADD:%.+]] = comb.add %c12_i5, [[ZEXT]] : i5
     %0 = firrtl.add %c12_ui4, %in1 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
 
     %1 = firrtl.asUInt %in1 : (!firrtl.uint<4>) -> !firrtl.uint<4>
 
-    // CHECK: [[ZEXT1:%.+]] = comb.concat %false, [[ADD]] : (i1, i5) -> i6
-    // CHECK: [[ZEXT2:%.+]] = comb.concat %c0_i2, %in1 : (i2, i4) -> i6
+    // CHECK: [[ZEXT1:%.+]] = comb.concat %false, [[ADD]] : i1, i5
+    // CHECK: [[ZEXT2:%.+]] = comb.concat %c0_i2, %in1 : i2, i4
     // CHECK-NEXT: [[SUB:%.+]] = comb.sub [[ZEXT1]], [[ZEXT2]] : i6
     %2 = firrtl.sub %0, %1 : (!firrtl.uint<5>, !firrtl.uint<4>) -> !firrtl.uint<6>
 
@@ -110,10 +110,10 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK: [[PADRES:%.+]] = comb.sext %in2 : (i2) -> i3
     %3 = firrtl.pad %in2s, 3 : (!firrtl.sint<2>) -> !firrtl.sint<3>
 
-    // CHECK: [[PADRES2:%.+]] = comb.concat %c0_i2, %in2 : (i2, i2) -> i4
+    // CHECK: [[PADRES2:%.+]] = comb.concat %c0_i2, %in2 : i2, i2
     %4 = firrtl.pad %in2, 4 : (!firrtl.uint<2>) -> !firrtl.uint<4>
 
-    // CHECK: [[IN2EXT:%.+]] = comb.concat %c0_i2, %in2 : (i2, i2) -> i4
+    // CHECK: [[IN2EXT:%.+]] = comb.concat %c0_i2, %in2 : i2, i2
     // CHECK: [[XOR:%.+]] = comb.xor [[IN2EXT]], [[PADRES2]] : i4
     %5 = firrtl.xor %in2, %4 : (!firrtl.uint<2>, !firrtl.uint<4>) -> !firrtl.uint<4>
 
@@ -123,7 +123,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK: comb.or [[XOR]]
     %or = firrtl.or %5, %4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
 
-    // CHECK: [[CONCAT1:%.+]] = comb.concat [[PADRES2]], [[XOR]] : (i4, i4) -> i8
+    // CHECK: [[CONCAT1:%.+]] = comb.concat [[PADRES2]], [[XOR]] : i4, i4
     %6 = firrtl.cat %4, %5 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<8>
 
     // CHECK: comb.concat %in1, %in2
@@ -135,7 +135,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: sv.assign %out4, [[XOR]] : i4
     firrtl.connect %out4, %5 : !firrtl.uint<4>, !firrtl.uint<4>
 
-    // CHECK-NEXT: [[ZEXT:%.+]] = comb.concat %c0_i2, %in2 : (i2, i2) -> i4
+    // CHECK-NEXT: [[ZEXT:%.+]] = comb.concat %c0_i2, %in2 : i2, i2
     // CHECK-NEXT: sv.assign %out4, [[ZEXT]] : i4
     firrtl.connect %out4, %in2 : !firrtl.uint<4>, !firrtl.uint<2>
 
@@ -168,7 +168,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: = comb.extract %in3 from 7 : (i8) -> i1
     %13 = firrtl.shr %in3, 8 : (!firrtl.sint<8>) -> !firrtl.sint<1>
 
-    // CHECK-NEXT: = comb.concat [[CONCAT1]], %c0_i3 : (i8, i3) -> i11
+    // CHECK-NEXT: = comb.concat [[CONCAT1]], %c0_i3 : i8, i3
     %14 = firrtl.shl %6, 3 : (!firrtl.uint<8>) -> !firrtl.uint<11>
 
     // CHECK-NEXT: = comb.parity [[CONCAT1]] : i8
@@ -180,8 +180,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: = comb.icmp ne {{.*}}, %c0_i8 : i8
     %17 = firrtl.orr %6 : (!firrtl.uint<8>) -> !firrtl.uint<1>
 
-    // CHECK-NEXT: [[ZEXTC1:%.+]] = comb.concat %c0_i6, [[CONCAT1]] : (i6, i8) -> i14
-    // CHECK-NEXT: [[ZEXT2:%.+]] = comb.concat %c0_i8, [[SUB]] : (i8, i6) -> i14
+    // CHECK-NEXT: [[ZEXTC1:%.+]] = comb.concat %c0_i6, [[CONCAT1]] : i6, i8
+    // CHECK-NEXT: [[ZEXT2:%.+]] = comb.concat %c0_i8, [[SUB]] : i8, i6
     // CHECK-NEXT: [[VAL18:%.+]] = comb.mul  [[ZEXTC1]], [[ZEXT2]] : i14
     %18 = firrtl.mul %6, %2 : (!firrtl.uint<8>, !firrtl.uint<6>) -> !firrtl.uint<14>
 
@@ -210,7 +210,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // Nodes with no names are just dropped.
     %22 = firrtl.node %in2 {name = ""} : !firrtl.uint<2>
 
-    // CHECK-NEXT: [[CVT:%.+]] = comb.concat %false, %in2 : (i1, i2) -> i3
+    // CHECK-NEXT: [[CVT:%.+]] = comb.concat %false, %in2 : i1, i2
     %23 = firrtl.cvt %22 : (!firrtl.uint<2>) -> !firrtl.sint<3>
 
     // Will be dropped, here because this triggered a crash
@@ -237,7 +237,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: [[DSHR:%.+]] = comb.extract [[SHIFT]] from 0 : (i14) -> i3
     %29 = firrtl.dshr %24, %18 : (!firrtl.uint<3>, !firrtl.uint<14>) -> !firrtl.uint<3>
 
-    // CHECK-NEXT: = comb.concat %c0_i5, {{.*}} : (i5, i3) -> i8
+    // CHECK-NEXT: = comb.concat %c0_i5, {{.*}} : i5, i3
     // CHECK-NEXT: [[SHIFT:%.+]] = comb.shrs %in3, {{.*}} : i8
     %a29 = firrtl.dshr %in3, %9 : (!firrtl.sint<8>, !firrtl.uint<3>) -> !firrtl.sint<8>
 
@@ -274,8 +274,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
     // CHECK: [[VERB1:%.+]] = sv.verbatim.expr "MAGIC_CONSTANT" : () -> i42
     // CHECK: [[VERB2:%.+]] = sv.verbatim.expr "$bits({{[{][{]0[}][}]}})"([[VERB1]]) : (i42) -> i32
-    // CHECK: [[VERB1EXT:%.+]] = comb.concat {{%.+}}, [[VERB1]] : (i1, i42) -> i43
-    // CHECK: [[VERB2EXT:%.+]] = comb.concat {{%.+}}, [[VERB2]] : (i11, i32) -> i43
+    // CHECK: [[VERB1EXT:%.+]] = comb.concat {{%.+}}, [[VERB1]] : i1, i42
+    // CHECK: [[VERB2EXT:%.+]] = comb.concat {{%.+}}, [[VERB2]] : i11, i32
     // CHECK: = comb.add [[VERB1EXT]], [[VERB2EXT]] : i43
     %56 = firrtl.verbatim.expr "MAGIC_CONSTANT" : () -> !firrtl.uint<42>
     %57 = firrtl.verbatim.expr "$bits({{0}})"(%56) : (!firrtl.uint<42>) -> !firrtl.uint<32>
@@ -287,7 +287,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %49 = firrtl.and %in3, %3 : (!firrtl.sint<8>, !firrtl.sint<3>) -> !firrtl.uint<8>
 
     // Issue #355: https://github.com/llvm/circt/issues/355
-    // CHECK: [[IN1:%.+]] = comb.concat %c0_i6, %in1 : (i6, i4) -> i10
+    // CHECK: [[IN1:%.+]] = comb.concat %c0_i6, %in1 : i6, i4
     // CHECK: [[DIV:%.+]] = comb.divu [[IN1]], %c306_i10 : i10
     // CHECK: = comb.extract [[DIV]] from 0 : (i10) -> i4
     %c306_ui10 = firrtl.constant 306 : !firrtl.uint<10>
@@ -296,7 +296,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %c1175_ui11 = firrtl.constant 1175 : !firrtl.uint<11>
     %51 = firrtl.neg %c1175_ui11 : (!firrtl.uint<11>) -> !firrtl.sint<12>
     // https://github.com/llvm/circt/issues/821
-    // CHECK: [[CONCAT:%.+]] = comb.concat %false, %in1 : (i1, i4) -> i5
+    // CHECK: [[CONCAT:%.+]] = comb.concat %false, %in1 : i1, i4
     // CHECK:  = comb.sub %c0_i5, [[CONCAT]] : i5
     %52 = firrtl.neg %in1 : (!firrtl.uint<4>) -> !firrtl.sint<5>
     %53 = firrtl.neg %in4 : (!firrtl.uint<0>) -> !firrtl.sint<1>
@@ -499,7 +499,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK: %tmp48 = sv.wire : !hw.inout<i27>
     %tmp48 = firrtl.wire : !firrtl.uint<27>
 
-    // CHECK-NEXT: %0 = comb.concat %c0_i38, %inp_2 : (i38, i27) -> i65
+    // CHECK-NEXT: %0 = comb.concat %c0_i38, %inp_2 : i38, i27
     // CHECK-NEXT: %1 = comb.divu %0, %inpi : i65
     %0 = firrtl.div %inp_2, %inpi : (!firrtl.uint<27>, !firrtl.uint<65>) -> !firrtl.uint<27>
     // CHECK-NEXT: %2 = comb.extract %1 from 0 : (i65) -> i27
@@ -637,8 +637,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT:     }
     // CHECK-NEXT:   }
     // CHECK-NEXT: }
-    // CHECK-NEXT: %2 = comb.concat %false, %0 : (i1, i32) -> i33
-    // CHECK-NEXT: %3 = comb.concat %false, %1 : (i1, i32) -> i33
+    // CHECK-NEXT: %2 = comb.concat %false, %0 : i1, i32
+    // CHECK-NEXT: %3 = comb.concat %false, %1 : i1, i32
     // CHECK-NEXT: %4 = comb.add %2, %3 : i33
     // CHECK-NEXT: %5 = comb.extract %4 from 1 : (i33) -> i32
     // CHECK-NEXT: %6 = comb.mux %io_en, %io_d, %5 : i32
@@ -923,7 +923,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT:       %RANDOM = sv.verbatim.expr.se "`RANDOM" : () -> i32
     // CHECK-NEXT:       %RANDOM_0 = sv.verbatim.expr.se "`RANDOM" : () -> i32
     // CHECK-NEXT:       %3 = comb.extract %RANDOM_0 from 0 : (i32) -> i10
-    // CHECK-NEXT:       %4 = comb.concat %RANDOM, %3 : (i32, i10) -> i42
+    // CHECK-NEXT:       %4 = comb.concat %RANDOM, %3 : i32, i10
     // CHECK-NEXT:       sv.bpassign %count, %4 : i42
     // CHECK-NEXT:     }
     // CHECK-NEXT:    }

--- a/test/Conversion/FIRRTLToHW/zero-width.mlir
+++ b/test/Conversion/FIRRTLToHW/zero-width.mlir
@@ -24,7 +24,7 @@ firrtl.circuit "Arithmetic" {
 
     // CHECK-DAG: %c0_i4 = hw.constant 0 : i4
     // CHECK-DAG: %false = hw.constant false
-    // CHECK-NEXT: [[UIN3EXT:%.+]] = comb.concat %false, %uin3c : (i1, i3) -> i4
+    // CHECK-NEXT: [[UIN3EXT:%.+]] = comb.concat %false, %uin3c : i1, i3
     // CHECK-NEXT: [[ADDRES:%.+]] = comb.add %c0_i4, [[UIN3EXT]] : i4
     %1 = firrtl.add %uin0c, %uin3c : (!firrtl.uint<0>, !firrtl.uint<3>) -> !firrtl.uint<4>
     firrtl.connect %out1, %1 : !firrtl.uint<4>, !firrtl.uint<4>

--- a/test/Conversion/LLHDToLLVM/convert_bitwise.mlir
+++ b/test/Conversion/LLHDToLLVM/convert_bitwise.mlir
@@ -139,7 +139,7 @@ func @convert_comb_shift(%arg0: i32, %arg1: i32, %arg2: i1) -> i32 {
   %2 = comb.shrs %1, %arg1 : i32
 
   // CHECK: %[[CNT:.*]] = "llvm.intr.ctpop"(%arg0) : (i32) -> i32
-  // CHECK: llvm.trunc %[[CNT]] : i32 to i1 
+  // CHECK: llvm.trunc %[[CNT]] : i32 to i1
   %3 = comb.parity %arg0 : i32
 
   // CHECK: %[[AMT:.*]] = llvm.mlir.constant(5 : i32) : i32
@@ -163,7 +163,7 @@ func @convert_comb_shift(%arg0: i32, %arg1: i32, %arg2: i1) -> i32 {
   // CHECK: %[[ZEXT3:.*]] = llvm.zext %arg0 : i32 to i96
   // CHECK: %[[SHIFT3:.*]] = llvm.shl %[[ZEXT3]], %[[A3]]  : i96
   // CHECK: llvm.or %[[OR2]], %[[SHIFT3]]  : i96
-  %6 = comb.concat %arg0, %arg1, %arg0 : (i32, i32, i32) -> i96
+  %6 = comb.concat %arg0, %arg1, %arg0 : i32, i32, i32
 
   // CHECK: llvm.select %arg2, %arg0, %arg1 : i1, i32
   %7 = comb.mux %arg2, %arg0, %arg1 : i32

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -13,7 +13,7 @@ hw.module @narrowMux(%a: i8, %b: i8, %c: i1) -> (o: i4) {
 // CHECK-LABEL: @muxConstantInputs
 hw.module @muxConstantInputs(%cond: i1) -> (o: i2) {
 // CHECK-NEXT: %false = hw.constant false
-// CHECK-NEXT: %0 = comb.concat %cond, %false : (i1, i1) -> i2
+// CHECK-NEXT: %0 = comb.concat %cond, %false : i1, i1
   %c0 = hw.constant 2 : i2
   %c1 = hw.constant 0 : i2
   %0 = comb.mux %cond, %c0, %c1 : i2
@@ -25,7 +25,7 @@ hw.module @muxConstantInputs2(%cond: i1) -> (o: i2) {
 // CHECK-NEXT: %true = hw.constant true
 // CHECK-NEXT: %false = hw.constant false
 // CHECK-NEXT: %0 = comb.xor %cond, %true : i1
-// CHECK-NEXT: %1 = comb.concat %0, %false : (i1, i1) -> i2
+// CHECK-NEXT: %1 = comb.concat %0, %false : i1, i1
   %c0 = hw.constant 0 : i2
   %c1 = hw.constant 2 : i2
   %0 = comb.mux %cond, %c0, %c1: i2
@@ -36,7 +36,7 @@ hw.module @muxConstantInputs2(%cond: i1) -> (o: i2) {
 hw.module @muxConstantInputsNegated(%cond: i1) -> (o: i2) {
 // CHECK-NEXT: %true = hw.constant true
 // CHECK-NEXT: %0 = comb.xor %cond, %true : i1
-// CHECK-NEXT: %1 = comb.concat %true, %0 : (i1, i1) -> i2
+// CHECK-NEXT: %1 = comb.concat %true, %0 : i1, i1
   %c0 = hw.constant 2 : i2
   %c1 = hw.constant 3 : i2
   %0 = comb.mux %cond, %c0, %c1: i2
@@ -131,7 +131,7 @@ hw.module @andCancel(%a: i4, %b : i4) -> (o1: i4, o2: i4) {
 }
 
 
-// CHECK-LABEL: hw.module @andDedup1(%arg0: i7, %arg1: i7) 
+// CHECK-LABEL: hw.module @andDedup1(%arg0: i7, %arg1: i7)
 hw.module @andDedup1(%arg0: i7, %arg1: i7) -> (result: i7) {
 // CHECK-NEXT:    %0 = comb.and %arg0, %arg1 : i7
 // CHECK-NEXT:    hw.output %0 : i7
@@ -160,12 +160,12 @@ hw.module @andDedupLong(%arg0: i7, %arg1: i7, %arg2: i7) -> (result: i7) {
 // CHECK-LABEL: hw.module @orExclusiveConcats
 hw.module @orExclusiveConcats(%arg0: i6, %arg1: i2) -> (o: i9) {
   // CHECK-NEXT:    %false = hw.constant false
-  // CHECK-NEXT:    %0 = comb.concat %arg1, %false, %arg0 : (i2, i1, i6) -> i9
+  // CHECK-NEXT:    %0 = comb.concat %arg1, %false, %arg0 : i2, i1, i6
   // CHECK-NEXT:    hw.output %0 : i9
   %c0 = hw.constant 0 : i3
-  %0 = comb.concat %c0, %arg0 : (i3, i6) -> i9
+  %0 = comb.concat %c0, %arg0 : i3, i6
   %c1 = hw.constant 0 : i7
-  %1 = comb.concat %arg1, %c1 : (i2, i7) -> i9
+  %1 = comb.concat %arg1, %c1 : i2, i7
   %2 = comb.or %0, %1 : i9
   hw.output %2 : i9
 }
@@ -178,15 +178,15 @@ hw.module @orExclusiveConcats(%arg0: i6, %arg1: i2) -> (o: i9) {
 // CHECK-LABEL: hw.module @orExclusiveConcats2
 hw.module @orExclusiveConcats2(%arg0: i6, %arg1: i2, %arg2: i2, %arg3: i3) -> (o: i16) {
   // CHECK-NEXT:    %false = hw.constant false
-  // CHECK-NEXT:    %0 = comb.concat %false, %arg0, %false, %arg2, %arg3, %arg1, %false : (i1, i6, i1, i2, i3, i2, i1) -> i16
+  // CHECK-NEXT:    %0 = comb.concat %false, %arg0, %false, %arg2, %arg3, %arg1, %false : i1, i6, i1, i2, i3, i2, i1
   // CHECK-NEXT:    hw.output %0 : i16
   %c0 = hw.constant 0 : i1
   %c1 = hw.constant 0 : i6
   %c2 = hw.constant 0 : i1
-  %0 = comb.concat %c0, %arg0, %c1, %arg1, %c2: (i1, i6, i6, i2, i1) -> i16
+  %0 = comb.concat %c0, %arg0, %c1, %arg1, %c2: i1, i6, i6, i2, i1
   %c3 = hw.constant 0 : i8
   %c4 = hw.constant 0 : i3
-  %1 = comb.concat %c3, %arg2, %arg3, %c4 : (i8, i2, i3, i3) -> i16
+  %1 = comb.concat %c3, %arg2, %arg3, %c4 : i8, i2, i3, i3
   %2 = comb.or %0, %1 : i16
   hw.output %2 : i16
 }
@@ -201,23 +201,23 @@ hw.module @orExclusiveConcats3(%arg0: i4, %arg1: i2) -> (o: i8) {
   // CHECK-NEXT:    [[RES:%[a-z0-9_-]+]] = hw.constant -1 : i8
   // CHECK-NEXT:    hw.output [[RES]] : i8
   %c0 = hw.constant -1 : i4
-  %0 = comb.concat %arg0, %c0: (i4, i4) -> i8
+  %0 = comb.concat %arg0, %c0: i4, i4
   %c1 = hw.constant -1 : i5
   %c2 = hw.constant 0 : i1
-  %1 = comb.concat %c1, %c2, %arg1 : (i5, i1, i2) -> i8
+  %1 = comb.concat %c1, %c2, %arg1 : i5, i1, i2
   %2 = comb.or %0, %1 : i8
   hw.output %2 : i8
 }
 
 // CHECK-LABEL: hw.module @orMultipleExclusiveConcats
 hw.module @orMultipleExclusiveConcats(%arg0: i2, %arg1: i2, %arg2: i2) -> (o: i6) {
-  // CHECK-NEXT:    %0 = comb.concat %arg0, %arg1, %arg2 : (i2, i2, i2) -> i6
+  // CHECK-NEXT:    %0 = comb.concat %arg0, %arg1, %arg2 : i2, i2, i2
   // CHECK-NEXT:    hw.output %0 : i6
   %c2 = hw.constant 0 : i2
   %c4 = hw.constant 0 : i4
-  %0 = comb.concat %arg0, %c4: (i2, i4) -> i6
-  %1 = comb.concat %c2, %arg1, %c2: (i2, i2, i2) -> i6
-  %2 = comb.concat %c4, %arg2: (i4, i2) -> i6
+  %0 = comb.concat %arg0, %c4: i2, i4
+  %1 = comb.concat %c2, %arg1, %c2: i2, i2, i2
+  %2 = comb.concat %c4, %arg2: i4, i2
   %out = comb.or %0, %1, %2 : i6
   hw.output %out : i6
 }
@@ -225,15 +225,15 @@ hw.module @orMultipleExclusiveConcats(%arg0: i2, %arg1: i2, %arg2: i2) -> (o: i6
 // CHECK-LABEL: hw.module @orConcatsWithMux
 hw.module @orConcatsWithMux(%bit: i1, %cond: i1) -> (o: i6) {
   // CHECK-NEXT:    [[RES:%[a-z0-9_-]+]] = hw.constant 0 : i4
-  // CHECK-NEXT:    %0 = comb.concat [[RES]], %cond, %bit : (i4, i1, i1) -> i6
+  // CHECK-NEXT:    %0 = comb.concat [[RES]], %cond, %bit : i4, i1, i1
   // CHECK-NEXT:    hw.output %0 : i6
   %c0 = hw.constant 0 : i5
-  %0 = comb.concat %c0, %bit: (i5, i1) -> i6
+  %0 = comb.concat %c0, %bit: i5, i1
   %c1 = hw.constant 0 : i4
   %c2 = hw.constant 2 : i2
   %c3 = hw.constant 0 : i2
   %1 = comb.mux %cond, %c2, %c3 : i2
-  %2 = comb.concat %c1, %1 : (i4, i2) -> i6
+  %2 = comb.concat %c1, %1 : i4, i2
   %3 = comb.or %0, %2 : i6
   hw.output %3 : i6
 }
@@ -306,8 +306,8 @@ hw.module @subCst(%a: i4) -> (o1: i4) {
 // CHECK-NEXT:    [[RES:%[0-9]+]] = comb.icmp uge %arg0, %arg1 : i9
 // CHECK-NEXT:    hw.output [[RES]] : i1
 hw.module @compareStrengthReductionRemoveSuffixAndPrefix(%arg0: i9, %arg1: i9) -> (o : i1) {
-  %0 = comb.concat %arg0, %arg0, %arg1: (i9, i9, i9) -> i27
-  %1 = comb.concat %arg0, %arg1, %arg1: (i9, i9, i9) -> i27
+  %0 = comb.concat %arg0, %arg0, %arg1: i9, i9, i9
+  %1 = comb.concat %arg0, %arg1, %arg1: i9, i9, i9
   %2 = comb.icmp uge %0, %1 : i27
   hw.output %2 : i1
 }
@@ -316,13 +316,13 @@ hw.module @compareStrengthReductionRemoveSuffixAndPrefix(%arg0: i9, %arg1: i9) -
 // when there is >1 elements left in one of them, and doens't spuriously remove all non-matching
 // suffices
 // CHECK-LABEL: hw.module @compareStrengthReductionRetainCat
-// CHECK-NEXT:    [[ARG0:%[0-9]+]] = comb.concat %arg0, %arg1 : (i9, i9) -> i18
-// CHECK-NEXT:    [[ARG1:%[0-9]+]] = comb.concat %arg1, %arg0 : (i9, i9) -> i18
+// CHECK-NEXT:    [[ARG0:%[0-9]+]] = comb.concat %arg0, %arg1 : i9, i9
+// CHECK-NEXT:    [[ARG1:%[0-9]+]] = comb.concat %arg1, %arg0 : i9, i9
 // CHECK-NEXT:    [[RES:%[0-9]+]] = comb.icmp uge [[ARG0]], [[ARG1]] : i18
 // CHECK-NEXT:    hw.output [[RES]] : i1
 hw.module @compareStrengthReductionRetainCat(%arg0: i9, %arg1: i9) -> (o : i1) {
-  %0 = comb.concat %arg0, %arg0, %arg1 : (i9, i9, i9) -> i27
-  %1 = comb.concat %arg0, %arg1, %arg0 : (i9, i9, i9) -> i27
+  %0 = comb.concat %arg0, %arg0, %arg1 : i9, i9, i9
+  %1 = comb.concat %arg0, %arg1, %arg0 : i9, i9, i9
   %2 = comb.icmp uge %0, %1 : i27
   hw.output %2 : i1
 }
@@ -330,13 +330,13 @@ hw.module @compareStrengthReductionRetainCat(%arg0: i9, %arg1: i9) -> (o : i1) {
 // Validates that narrowing signed comparisons without stripping the common suffix
 // must not pad an additional sign bit.
 // CHECK-LABEL: hw.module @compareStrengthSignedCommonSuffix
-// CHECK-NEXT:    [[ARG0:%[0-9]+]] = comb.concat %arg0, %arg0 : (i9, i9) -> i18
-// CHECK-NEXT:    [[ARG1:%[0-9]+]] = comb.concat %arg1, %arg1 : (i9, i9) -> i18
+// CHECK-NEXT:    [[ARG0:%[0-9]+]] = comb.concat %arg0, %arg0 : i9, i9
+// CHECK-NEXT:    [[ARG1:%[0-9]+]] = comb.concat %arg1, %arg1 : i9, i9
 // CHECK-NEXT:    [[RES:%[0-9]+]] = comb.icmp sge [[ARG0]], [[ARG1]] : i18
 // CHECK-NEXT:    hw.output [[RES]] : i1
 hw.module @compareStrengthSignedCommonSuffix(%arg0: i9, %arg1: i9) -> (o : i1) {
-  %0 = comb.concat %arg0, %arg0, %arg1 : (i9, i9, i9) -> i27
-  %1 = comb.concat %arg1, %arg1, %arg1 : (i9, i9, i9) -> i27
+  %0 = comb.concat %arg0, %arg0, %arg1 : i9, i9, i9
+  %1 = comb.concat %arg1, %arg1, %arg1 : i9, i9, i9
   %2 = comb.icmp sge %0, %1 : i27
   hw.output %2 : i1
 }
@@ -345,13 +345,13 @@ hw.module @compareStrengthSignedCommonSuffix(%arg0: i9, %arg1: i9) -> (o : i1) {
 // must add the sign-bit.
 // CHECK-LABEL: hw.module @compareStrengthSignedCommonPrefix
 // CHECK-NEXT:    [[SIGNBIT:%[0-9]+]] = comb.extract %arg0 from 2 : (i3) -> i1
-// CHECK-NEXT:    [[ARG1:%[0-9]+]] = comb.concat [[SIGNBIT]], %arg1 : (i1, i9) -> i10
-// CHECK-NEXT:    [[ARG2:%[0-9]+]] = comb.concat [[SIGNBIT]], %arg2 : (i1, i9) -> i10
+// CHECK-NEXT:    [[ARG1:%[0-9]+]] = comb.concat [[SIGNBIT]], %arg1 : i1, i9
+// CHECK-NEXT:    [[ARG2:%[0-9]+]] = comb.concat [[SIGNBIT]], %arg2 : i1, i9
 // CHECK-NEXT:    [[RES:%[0-9]+]] = comb.icmp sge [[ARG1]], [[ARG2]] : i10
 // CHECK-NEXT:    hw.output [[RES]] : i1
 hw.module @compareStrengthSignedCommonPrefix(%arg0 : i3, %arg1: i9, %arg2: i9) -> (o : i1) {
-  %0 = comb.concat %arg0, %arg1 : (i3, i9) -> i12
-  %1 = comb.concat %arg0, %arg2 : (i3, i9) -> i12
+  %0 = comb.concat %arg0, %arg1 : i3, i9
+  %1 = comb.concat %arg0, %arg2 : i3, i9
   %2 = comb.icmp sge %0, %1 : i12
   hw.output %2 : i1
 }
@@ -359,13 +359,13 @@ hw.module @compareStrengthSignedCommonPrefix(%arg0 : i3, %arg1: i9, %arg2: i9) -
 // Validates that narrowing signed comparisons that strips of the common suffix
 // must add the sign-bit. The sign bit if the leading common element has a length of 1.
 // CHECK-LABEL: hw.module @compareStrengthSignedCommonPrefixNoExtract
-// CHECK-NEXT:    [[ARG1:%[0-9]+]] = comb.concat %arg0, %arg2 : (i1, i9) -> i10
-// CHECK-NEXT:    [[ARG2:%[0-9]+]] = comb.concat %arg0, %arg3 : (i1, i9) -> i10
+// CHECK-NEXT:    [[ARG1:%[0-9]+]] = comb.concat %arg0, %arg2 : i1, i9
+// CHECK-NEXT:    [[ARG2:%[0-9]+]] = comb.concat %arg0, %arg3 : i1, i9
 // CHECK-NEXT:    [[RES:%[0-9]+]] = comb.icmp sge [[ARG1]], [[ARG2]] : i10
 // CHECK-NEXT:    hw.output [[RES]] : i1
 hw.module @compareStrengthSignedCommonPrefixNoExtract(%arg0 : i1, %arg1 : i3, %arg2: i9, %arg3: i9) -> (o : i1) {
-  %0 = comb.concat %arg0, %arg1, %arg2 : (i1, i3, i9) -> i13
-  %1 = comb.concat %arg0, %arg1, %arg3 : (i1, i3, i9) -> i13
+  %0 = comb.concat %arg0, %arg1, %arg2 : i1, i3, i9
+  %1 = comb.concat %arg0, %arg1, %arg3 : i1, i3, i9
   %2 = comb.icmp sge %0, %1 : i13
   hw.output %2 : i1
 }
@@ -376,8 +376,8 @@ hw.module @compareStrengthSignedCommonPrefixNoExtract(%arg0 : i1, %arg1 : i3, %a
 // CHECK-NEXT:    %true = hw.constant true
 // CHECK-NEXT:    hw.output %true : i1
 hw.module @compareConcatEliminationTrueCases(%arg0 : i4, %arg1: i9, %arg2: i7) -> (o : i1) {
-  %0 = comb.concat %arg0, %arg1, %arg2 : (i4, i9, i7) -> i20
-  %1 = comb.concat %arg0, %arg1, %arg2 : (i4, i9, i7) -> i20
+  %0 = comb.concat %arg0, %arg1, %arg2 : i4, i9, i7
+  %1 = comb.concat %arg0, %arg1, %arg2 : i4, i9, i7
   %2 = comb.icmp sle %0, %1 : i20
   %3 = comb.icmp sge %0, %1 : i20
   %4 = comb.icmp ule %0, %1 : i20
@@ -393,8 +393,8 @@ hw.module @compareConcatEliminationTrueCases(%arg0 : i4, %arg1: i9, %arg2: i7) -
 // CHECK-NEXT:    %false = hw.constant false
 // CHECK-NEXT:    hw.output %false : i1
 hw.module @compareConcatEliminationFalseCases(%arg0 : i4, %arg1: i9, %arg2: i7) -> (o : i1) {
-  %0 = comb.concat %arg0, %arg1, %arg2 : (i4, i9, i7) -> i20
-  %1 = comb.concat %arg0, %arg1, %arg2 : (i4, i9, i7) -> i20
+  %0 = comb.concat %arg0, %arg1, %arg2 : i4, i9, i7
+  %1 = comb.concat %arg0, %arg1, %arg2 : i4, i9, i7
   %2 = comb.icmp slt %0, %1 : i20
   %3 = comb.icmp sgt %0, %1 : i20
   %4 = comb.icmp ult %0, %1 : i20
@@ -408,7 +408,7 @@ hw.module @compareConcatEliminationFalseCases(%arg0 : i4, %arg1: i9, %arg2: i7) 
 // a when it is a single full element.
 // CHECK-LABEL: hw.module @extractCatAlignWithExactElements
 hw.module @extractCatAlignWithExactElements(%arg0: i8, %arg1: i9, %arg2: i10) -> (o1 : i17, o2: i19, o3: i9, o4: i10) {
-  %0 = comb.concat %arg0, %arg1, %arg2 : (i8, i9, i10) -> i27
+  %0 = comb.concat %arg0, %arg1, %arg2 : i8, i9, i10
 
   // CHECK-NEXT:    [[R0:%.+]] = comb.concat %arg0, %arg1
   %1 = comb.extract %0 from 10 : (i27) -> i17
@@ -426,7 +426,7 @@ hw.module @extractCatAlignWithExactElements(%arg0: i8, %arg1: i9, %arg2: i10) ->
 // partial element
 // CHECK-LABEL: hw.module @extractCatOnSinglePartialElement
 hw.module @extractCatOnSinglePartialElement(%arg0: i8, %arg1: i9, %arg2: i10) -> (o1 : i1, o2: i1, o3: i1, o4: i1) {
-  %0 = comb.concat %arg0, %arg1, %arg2 : (i8, i9, i10) -> i27
+  %0 = comb.concat %arg0, %arg1, %arg2 : i8, i9, i10
 
   // From the first bit position
   // CHECK-NEXT:    [[R0:%.+]] = comb.extract %arg2 from 0 : (i10) -> i1
@@ -456,18 +456,18 @@ hw.module @extractCatOnSinglePartialElement(%arg0: i8, %arg1: i9, %arg2: i10) ->
 // - the order of the elements are correct.
 // CHECK-LABEL: hw.module @extractCatOnMultiplePartialElements
 hw.module @extractCatOnMultiplePartialElements(%arg0: i8, %arg1: i9, %arg2: i10) -> (o1 : i11, o2 : i5) {
-  %0 = comb.concat %arg0, %arg1, %arg2 : (i8, i9, i10) -> i27
+  %0 = comb.concat %arg0, %arg1, %arg2 : i8, i9, i10
 
   // Part of arg0, all of arg1, part of arg2
   // CHECK-NEXT: [[FROMARG2:%.+]] = comb.extract %arg2 from 9 : (i10) -> i1
   // CHECK-NEXT: [[FROMARG0:%.+]] = comb.extract %arg0 from 0 : (i8) -> i1
-  // CHECK-NEXT: [[RESULT1:%.+]] = comb.concat [[FROMARG0]], %arg1, [[FROMARG2]] : (i1, i9, i1) -> i11
+  // CHECK-NEXT: [[RESULT1:%.+]] = comb.concat [[FROMARG0]], %arg1, [[FROMARG2]] : i1, i9, i1
   %1 = comb.extract %0 from 9 : (i27) -> i11
 
   // Part of arg1 and part of arg2
   // CHECK-NEXT: [[FROMARG2:%.+]] = comb.extract %arg2 from 9 : (i10) -> i1
   // CHECK-NEXT: [[FROMARG1:%.+]] = comb.extract %arg1 from 0 : (i9) -> i4
-  // CHECK-NEXT: [[RESULT2:%.+]] = comb.concat [[FROMARG1]], [[FROMARG2]] : (i4, i1) -> i5
+  // CHECK-NEXT: [[RESULT2:%.+]] = comb.concat [[FROMARG1]], [[FROMARG2]] : i4, i1
   %2 = comb.extract %0 from 9 : (i27) -> i5
 
   // CHECK-NEXT: hw.output [[RESULT1:%.+]], [[RESULT2:%.+]]
@@ -484,8 +484,8 @@ hw.module @narrowAdditionSingleExtractUse(%x: i8, %y: i8) -> (z1: i6) {
   // CHECK-NEXT: hw.output [[RESULT]]
 
   %false = hw.constant false
-  %0 = comb.concat %false, %x : (i1, i8) -> i9
-  %1 = comb.concat %false, %y : (i1, i8) -> i9
+  %0 = comb.concat %false, %x : i1, i8
+  %1 = comb.concat %false, %y : i1, i8
   %2 = comb.add %0, %1 : i9
   %3 = comb.extract %2 from 0 : (i9) -> i6
   hw.output %3 : i6
@@ -499,8 +499,8 @@ hw.module @narrowAdditionToDirectAddition(%x: i8, %y: i8) -> (z1: i8) {
   // CHECK-NEXT: hw.output [[RESULT]]
 
   %false = hw.constant false
-  %0 = comb.concat %x, %x : (i8, i8) -> i16
-  %1 = comb.concat %y, %y : (i8, i8) -> i16
+  %0 = comb.concat %x, %x : i8, i8
+  %1 = comb.concat %y, %y : i8, i8
   %2 = comb.add %0, %1 : i16
   %3 = comb.extract %2 from 0 : (i16) -> i8
   hw.output %3 : i8
@@ -515,8 +515,8 @@ hw.module @narrowAdditionToWidestExtract(%x: i8, %y: i8) -> (z1: i3, z2: i4) {
   // CHECK-NEXT: [[RESULT1:%.+]] = comb.extract [[RESULT2]] from 0 : (i4) -> i3
   // CHECK-NEXT: hw.output [[RESULT1]], [[RESULT2]]
 
-  %0 = comb.concat %x, %x : (i8, i8) -> i16
-  %1 = comb.concat %y, %y : (i8, i8) -> i16
+  %0 = comb.concat %x, %x : i8, i8
+  %1 = comb.concat %y, %y : i8, i8
   %2 = comb.add %0, %1 : i16
   %3 = comb.extract %2 from 0 : (i16) -> i3
   %4 = comb.extract %2 from 0 : (i16) -> i4
@@ -530,8 +530,8 @@ hw.module @narrowAdditionStripLeadingZero(%x: i8, %y: i8) -> (z: i8) {
   // CHECK-NEXT: hw.output [[RESULT]]
 
   %false = hw.constant false
-  %0 = comb.concat %false, %x : (i1, i8) -> i9
-  %1 = comb.concat %false, %y : (i1, i8) -> i9
+  %0 = comb.concat %false, %x : i1, i8
+  %1 = comb.concat %false, %y : i1, i8
   %2 = comb.add %0, %1 : i9
   %3 = comb.extract %2 from 0 : (i9) -> i8
   hw.output %3 : i8
@@ -542,15 +542,15 @@ hw.module @narrowAdditionStripLeadingZero(%x: i8, %y: i8) -> (z: i8) {
 // CHECK-LABEL: hw.module @narrowAdditionRetainOriginal
 hw.module @narrowAdditionRetainOriginal(%x: i8, %y: i8) -> (z0: i9, z1: i8) {
   // CHECK-NEXT: false = hw.constant false
-  // CHECK-NEXT: %0 = comb.concat %false, %x : (i1, i8) -> i9
-  // CHECK-NEXT: %1 = comb.concat %false, %y : (i1, i8) -> i9
+  // CHECK-NEXT: %0 = comb.concat %false, %x : i1, i8
+  // CHECK-NEXT: %1 = comb.concat %false, %y : i1, i8
   // CHECK-NEXT: %2 = comb.add %0, %1 : i9
   // CHECK-NEXT: %3 = comb.extract %2 from 0 : (i9) -> i8
   // CHECK-NEXT: hw.output %2, %3 : i9, i8
 
   %false = hw.constant false
-  %0 = comb.concat %false, %x : (i1, i8) -> i9
-  %1 = comb.concat %false, %y : (i1, i8) -> i9
+  %0 = comb.concat %false, %x : i1, i8
+  %1 = comb.concat %false, %y : i1, i8
   %2 = comb.add %0, %1 : i9
   %3 = comb.extract %2 from 0 : (i9) -> i8
   hw.output %2, %3 : i9, i8
@@ -730,7 +730,7 @@ hw.module @fold_mux_tree3(%sel: i2, %a: i8, %b: i8, %c: i8, %d: i8) -> (y: i8) {
 // CHECK-LABEL: hw.module @fold_mux_tree4
 hw.module @fold_mux_tree4(%sel: i2, %a: i8, %b: i8, %c: i8) -> (y: i8) {
   // CHECK-NEXT: %c-1_i8 = hw.constant -1 : i8
-  // CHECK-NEXT: %0 = hw.array_create %c-1_i8, %c, %b, %a : i8 
+  // CHECK-NEXT: %0 = hw.array_create %c-1_i8, %c, %b, %a : i8
   // CHECK-NEXT: %1 = hw.array_get %0[%sel]
   // CHECK-NEXT: hw.output %1
 
@@ -802,7 +802,7 @@ hw.module @SevenSegmentDecoder(%in: i4) -> (out: i7) {
   %0 = comb.icmp eq %in, %c1_i4 : i4
   %1 = comb.mux %0, %c6_i6, %c-1_i6 : i6
   %2 = comb.icmp eq %in, %c2_i4 : i4
-  %3 = comb.concat %false, %1 : (i1, i6) -> i7
+  %3 = comb.concat %false, %1 : i1, i6
   %4 = comb.mux %2, %c-37_i7, %3 : i7
   %5 = comb.icmp eq %in, %c3_i4 : i4
   %6 = comb.mux %5, %c-49_i7, %4 : i7
@@ -832,7 +832,7 @@ hw.module @SevenSegmentDecoder(%in: i4) -> (out: i7) {
   %30 = comb.mux %29, %c-15_i7, %28 : i7
   // CHECK: %0 = comb.icmp eq %in, %c1_i4 : i4
   // CHECK: %1 = comb.mux %0, %c6_i6, %c-1_i6 : i6
-  // CHECK: %2 = comb.concat %false, %1 : (i1, i6) -> i7
+  // CHECK: %2 = comb.concat %false, %1 : i1, i6
   // CHECK: %3 = hw.array_create %c-15_i7, %c-7_i7, %c-34_i7, %c57_i7, %c-4_i7, %c-9_i7, %c-17_i7, %c-1_i7, %c7_i7, %c-3_i7, %c-19_i7, %c-26_i7, %c-49_i7, %c-37_i7, %2, %2 : i7
   // CHECK: %4 = hw.array_get %3[%in]
   hw.output %30 : i7
@@ -850,7 +850,7 @@ hw.module @shru_zero(%a: i8) -> (y: i8) {
 // CHECK-LABEL: hw.module @logical_concat_cst1
 hw.module @logical_concat_cst1(%value: i38, %v2: i39) -> (a: i39) {
   %true = hw.constant true
-  %0 = comb.concat %true, %value : (i1, i38) -> i39
+  %0 = comb.concat %true, %value : i1, i38
 
   %c255 = hw.constant 255 : i39
   %1 = comb.and %0, %v2, %c255 : i39
@@ -859,7 +859,7 @@ hw.module @logical_concat_cst1(%value: i38, %v2: i39) -> (a: i39) {
   // CHECK: %false = hw.constant false
   // CHECK: %c255_i38 = hw.constant 255 : i38
   // CHECK: %0 = comb.and %value, %c255_i38 : i38
-  // CHECK: %1 = comb.concat %false, %0 : (i1, i38) -> i39
+  // CHECK: %1 = comb.concat %false, %0 : i1, i38
   // CHECK: %2 = comb.and %v2, %1 : i39
   // CHECK: hw.output %2 : i39
 }
@@ -869,7 +869,7 @@ hw.module @logical_concat_cst2(%value: i8, %v2: i16) -> (a: i16) {
   %c15 = hw.constant 15 : i8
   %0 = comb.and %value, %c15 : i8
 
-  %1 = comb.concat %value, %0 : (i8, i8) -> i16
+  %1 = comb.concat %value, %0 : i8, i8
 
   %c7 = hw.constant 7 : i16
   %2 = comb.and %v2, %1, %c7 : i16
@@ -878,7 +878,7 @@ hw.module @logical_concat_cst2(%value: i8, %v2: i16) -> (a: i16) {
   // CHECK: %c0_i8 = hw.constant 0 : i8
   // CHECK: %c7_i8 = hw.constant 7 : i8
   // CHECK: %0 = comb.and %value, %c7_i8 : i8
-  // CHECK: %1 = comb.concat %c0_i8, %0 : (i8, i8) -> i16
+  // CHECK: %1 = comb.concat %c0_i8, %0 : i8, i8
   // CHECK: %2 = comb.and %v2, %1 : i16
   // CHECK: hw.output %2 : i16
 }
@@ -886,7 +886,7 @@ hw.module @logical_concat_cst2(%value: i8, %v2: i16) -> (a: i16) {
 // CHECK-LABEL: hw.module @concat_fold
 hw.module @concat_fold(%value: i8) -> (a: i8) {
   // CHECK: hw.output %value : i8
-  %0 = comb.concat %value : (i8) -> i8
+  %0 = comb.concat %value : i8
   hw.output %0 : i8
 }
 
@@ -894,13 +894,13 @@ hw.module @concat_fold(%value: i8) -> (a: i8) {
 // CHECK-LABEL: hw.module @combine_icmp_compare_concat0
 hw.module @combine_icmp_compare_concat0(%thing: i3) -> (a: i1) {
   %false = hw.constant false
-  %0 = comb.concat %thing, %false, %thing : (i3, i1, i3) -> i7
+  %0 = comb.concat %thing, %false, %thing : i3, i1, i3
 
   %c0 = hw.constant 0 : i7
   %1 = comb.icmp ne %0, %c0 : i7
 
   // CHECK: %c0_i6 = hw.constant 0 : i6
-  // CHECK: %0 = comb.concat %thing, %thing : (i3, i3) -> i6
+  // CHECK: %0 = comb.concat %thing, %thing : i3, i3
   // CHECK: %1 = comb.icmp ne %0, %c0_i6 : i6
   // CHECK: hw.output %1 : i1
   hw.output %1 : i1
@@ -909,7 +909,7 @@ hw.module @combine_icmp_compare_concat0(%thing: i3) -> (a: i1) {
 // CHECK-LABEL: hw.module @combine_icmp_compare_concat1
 hw.module @combine_icmp_compare_concat1(%thing: i3) -> (a: i1) {
   %true = hw.constant true
-  %0 = comb.concat %thing, %true, %thing : (i3, i1, i3) -> i7
+  %0 = comb.concat %thing, %true, %thing : i3, i1, i3
 
   %c0 = hw.constant 0 : i7
   %1 = comb.icmp ne %0, %c0 : i7
@@ -921,14 +921,14 @@ hw.module @combine_icmp_compare_concat1(%thing: i3) -> (a: i1) {
 // CHECK-LABEL: hw.module @combine_icmp_compare_concat2
 hw.module @combine_icmp_compare_concat2(%thing: i3) -> (a: i1) {
   %false = hw.constant false
-  %0 = comb.concat %thing, %false, %thing, %false : (i3, i1, i3, i1) -> i8
+  %0 = comb.concat %thing, %false, %thing, %false : i3, i1, i3, i1
 
   %c0 = hw.constant 0 : i8
   %1 = comb.icmp eq %0, %c0 : i8
   hw.output %1 : i1
 
   // CHECK: %c0_i6 = hw.constant 0 : i6
-  // CHECK: %0 = comb.concat %thing, %thing : (i3, i3) -> i6
+  // CHECK: %0 = comb.concat %thing, %thing : i3, i3
   // CHECK: %1 = comb.icmp eq %0, %c0_i6 : i6
   // CHECK: hw.output %1 : i1
 }
@@ -943,7 +943,7 @@ hw.module @combine_icmp_compare_known_bits0(%thing: i4) -> (a: i1) {
 
   // CHECK:   %0 = comb.extract %thing from 2 : (i4) -> i2
   // CHECK:   %1 = comb.extract %thing from 0 : (i4) -> i1
-  // CHECK:   %2 = comb.concat %0, %1 : (i2, i1) -> i3
+  // CHECK:   %2 = comb.concat %0, %1 : i2, i1
   // CHECK:   %3 = comb.icmp eq %2, %c0_i3 : i3
   // CHECK:   hw.output %3 : i1
   // CHECK: }
@@ -1011,7 +1011,7 @@ hw.module @test1560(%value: i38) -> (a: i1) {
 
   %false = hw.constant false
   %true = hw.constant true
-  %254 = comb.concat %false, %253 : (i1, i38) -> i39
+  %254 = comb.concat %false, %253 : i1, i38
 
   %c-536870912_i39 = hw.constant -536870912 : i39
   %255 = comb.and %254, %c-536870912_i39 : i39
@@ -1032,7 +1032,7 @@ hw.module @test1560(%value: i38) -> (a: i1) {
 hw.module @test_sext(%value: i8, %v9: i9) -> (a: i10, b: i11, c: i10) {
   // Known zero sign bit.
   %false = hw.constant false
-  %0 = comb.concat %false, %value : (i1, i8) -> i9
+  %0 = comb.concat %false, %value : i1, i8
   // CHECK: %0 = comb.concat %false, %value
   %1 = comb.sext %0 : (i9) -> i10
   // CHECK: %1 = comb.concat %c0_i2, %value
@@ -1042,7 +1042,7 @@ hw.module @test_sext(%value: i8, %v9: i9) -> (a: i10, b: i11, c: i10) {
   %2 = comb.or %value, %c128 : i8
   %3 = comb.sext %2 : (i8) -> i11
   // CHECK: %2 = comb.or %value, %c-128_i8 : i8
-  // CHECK: %3 = comb.concat %c-1_i3, %2 : (i3, i8) -> i11
+  // CHECK: %3 = comb.concat %c-1_i3, %2 : i3, i8
 
   // Check KnownBitAnalysis for xor.
   %c256 = hw.constant 256 : i9
@@ -1052,8 +1052,8 @@ hw.module @test_sext(%value: i8, %v9: i9) -> (a: i10, b: i11, c: i10) {
 
   // CHECK: %4 = comb.and %v9, %0 : i9
   // CHECK: %5 = comb.xor %4, %c-256_i9 : i9
-  // CHECK: %6 = comb.concat %true, %5 : (i1, i9) -> i10
- 
+  // CHECK: %6 = comb.concat %true, %5 : i1, i9
+
   // CHECK: hw.output %1, %3, %6
   hw.output %1, %3, %5: i10, i11, i10
 }

--- a/test/Dialect/HW/basic.mlir
+++ b/test/Dialect/HW/basic.mlir
@@ -12,14 +12,14 @@ hw.module @test1(%arg0: i3, %arg1: i1, %arg2: !hw.array<1000xi8>) -> (result: i5
   // CHECK-NEXT:    [[RES2:%[0-9]+]] = comb.sext %arg0 : (i3) -> i7
   %d = comb.sext %arg0 : (i3) -> i7
 
-  // CHECK-NEXT:    [[RES4:%[0-9]+]] = comb.concat %c42_i12 : (i12) -> i12
-  %conc1 = comb.concat %a : (i12) -> i12
+  // CHECK-NEXT:    [[RES4:%[0-9]+]] = comb.concat %c42_i12 : i12
+  %conc1 = comb.concat %a : i12
 
   // CHECK-NEXT:    [[RES7:%[0-9]+]] = comb.parity [[RES4]] : i12
   %parity1 = comb.parity %conc1 : i12
 
-  // CHECK-NEXT:    [[RES8:%[0-9]+]] = comb.concat [[RES4]], [[RES0]], [[RES1]], [[RES2]], [[RES2]] : (i12, i12, i12, i7, i7) -> i50
-  %result = comb.concat %conc1, %b, %c, %d, %d : (i12, i12, i12, i7, i7) -> i50
+  // CHECK-NEXT:    [[RES8:%[0-9]+]] = comb.concat [[RES4]], [[RES0]], [[RES1]], [[RES2]], [[RES2]] : i12, i12, i12, i7, i7
+  %result = comb.concat %conc1, %b, %c, %d, %d : i12, i12, i12, i7, i7
 
   // CHECK-NEXT: [[RES9:%[0-9]+]] = comb.extract [[RES8]] from 4 : (i50) -> i19
   %small1 = comb.extract %result from 4 : (i50) -> i19

--- a/test/Dialect/HW/bitwise.mlir
+++ b/test/Dialect/HW/bitwise.mlir
@@ -9,9 +9,9 @@ func @bitwise(%a: i7, %b: i7) -> i21 {
   %or1  = comb.or  %a, %b : i7
   %xor1 = comb.and %a, %b, %a : i7
 
-// CHECK-NEXT:    [[RESULT:%[0-9]+]] = comb.concat [[RES0]], [[RES1]], [[RES2]] : (i7, i7, i7) -> i21
+// CHECK-NEXT:    [[RESULT:%[0-9]+]] = comb.concat [[RES0]], [[RES1]], [[RES2]] : i7, i7, i7
 // CHECK-NEXT:    return [[RESULT]] : i21
-  %result = comb.concat %and1, %or1, %xor1 : (i7, i7, i7) -> i21
+  %result = comb.concat %and1, %or1, %xor1 : i7, i7, i7
   return %result : i21
 }
 

--- a/test/Dialect/HW/canonicalization.mlir
+++ b/test/Dialect/HW/canonicalization.mlir
@@ -431,7 +431,7 @@ hw.module @xor_idempotent_two_arguments(%arg0: i11) -> (result: i11) {
 // CHECK-LABEL: hw.module @add_reduction1(%arg0: i11, %arg1: i11) -> (result: i11) {
 // CHECK-NEXT:    %false = hw.constant false
 // CHECK-NEXT:    [[EXTRACT:%[0-9]+]] = comb.extract %arg1 from 0 : (i11) -> i10
-// CHECK-NEXT:    [[CONCAT:%[0-9]+]] = comb.concat [[EXTRACT]], %false : (i10, i1) -> i11
+// CHECK-NEXT:    [[CONCAT:%[0-9]+]] = comb.concat [[EXTRACT]], %false : i10, i1
 // CHECK-NEXT:    hw.output [[CONCAT]]
 
 hw.module @add_reduction1(%arg0: i11, %arg1: i11) -> (result: i11) {
@@ -452,7 +452,7 @@ hw.module @add_reduction2(%arg0: i11, %arg1: i11) -> (result: i11) {
 // CHECK-LABEL: hw.module @add_reduction3(%arg0: i11, %arg1: i11) -> (result: i11) {
 // CHECK-NEXT:    %c0_i3 = hw.constant 0 : i3
 // CHECK-NEXT:    [[EXTRACT:%[0-9]+]] = comb.extract %arg1 from 0 : (i11) -> i8
-// CHECK-NEXT:    [[CONCAT:%[0-9]+]] = comb.concat [[EXTRACT]], %c0_i3 : (i8, i3) -> i11
+// CHECK-NEXT:    [[CONCAT:%[0-9]+]] = comb.concat [[EXTRACT]], %c0_i3 : i8, i3
 // CHECK-NEXT:    hw.output [[CONCAT]]
 
 hw.module @add_reduction3(%arg0: i11, %arg1: i11) -> (result: i11) {
@@ -467,7 +467,7 @@ hw.module @add_reduction3(%arg0: i11, %arg1: i11) -> (result: i11) {
 // CHECK-LABEL: hw.module @multiply_reduction(%arg0: i11, %arg1: i11) -> (result: i11) {
 // CHECK-NEXT:    %false = hw.constant false
 // CHECK-NEXT:    [[EXTRACT:%[0-9]+]] = comb.extract %arg1 from 0 : (i11) -> i10
-// CHECK-NEXT:    [[CONCAT:%[0-9]+]] = comb.concat [[EXTRACT]], %false : (i10, i1) -> i11
+// CHECK-NEXT:    [[CONCAT:%[0-9]+]] = comb.concat [[EXTRACT]], %false : i10, i1
 // CHECK-NEXT:    hw.output [[CONCAT]]
 
 hw.module @multiply_reduction(%arg0: i11, %arg1: i11) -> (result: i11) {
@@ -511,15 +511,15 @@ hw.module @concat_fold_0() -> (result: i8) {
   %c7_i4 = hw.constant 7 : i4
   %c4_i3 = hw.constant 4 : i3
   %false = hw.constant false
-  %0 = comb.concat %c7_i4, %c4_i3, %false : (i4, i3, i1) -> (i8)
+  %0 = comb.concat %c7_i4, %c4_i3, %false : i4, i3, i1
   hw.output %0 : i8
 }
 
 // CHECK-LABEL: hw.module @concat_fold_1
 // CHECK-NEXT:  %0 = comb.concat %arg0, %arg1, %arg2
 hw.module @concat_fold_1(%arg0: i4, %arg1: i3, %arg2: i1) -> (result: i8) {
-  %a = comb.concat %arg0, %arg1 : (i4, i3) -> (i7)
-  %b = comb.concat %a, %arg2 : (i7, i1) -> (i8)
+  %a = comb.concat %arg0, %arg1 : i4, i3
+  %b = comb.concat %a, %arg2 : i7, i1
   hw.output %b : i8
 }
 
@@ -527,18 +527,18 @@ hw.module @concat_fold_1(%arg0: i4, %arg1: i3, %arg2: i1) -> (result: i8) {
 hw.module @concat_fold_2(%arg0: i3, %arg1: i1) -> (result: i9) {
   // CHECK-NEXT:  %0 = comb.extract %arg0 from 2 : (i3) -> i1
   %b = comb.sext %arg0 : (i3) -> i8
-  // CHECK-NEXT:  = comb.concat %0, %0, %0, %0, %0, %arg0, %arg1 : (i1, i1, i1, i1, i1, i3, i1) -> i9
-  %c = comb.concat %b, %arg1 : (i8, i1) -> (i9)
+  // CHECK-NEXT:  = comb.concat %0, %0, %0, %0, %0, %arg0, %arg1 : i1, i1, i1, i1, i1, i3, i1
+  %c = comb.concat %b, %arg1 : i8, i1
   hw.output %c : i9
 }
 
 // CHECK-LABEL: hw.module @concat_fold_3
 // CHECK-NEXT:    %c60_i7 = hw.constant 60 : i7
-// CHECK-NEXT:    %0 = comb.concat %c60_i7, %arg0 : (i7, i1) -> i8
+// CHECK-NEXT:    %0 = comb.concat %c60_i7, %arg0 : i7, i1
 hw.module @concat_fold_3(%arg0: i1) -> (result: i8) {
   %c7_i4 = hw.constant 7 : i4
   %c4_i3 = hw.constant 4 : i3
-  %0 = comb.concat %c7_i4, %c4_i3, %arg0 : (i4, i3, i1) -> (i8)
+  %0 = comb.concat %c7_i4, %c4_i3, %arg0 : i4, i3, i1
   hw.output %0 : i8
 }
 
@@ -546,20 +546,20 @@ hw.module @concat_fold_3(%arg0: i1) -> (result: i8) {
 // CHECK-NEXT:   %0 = comb.sext %arg0 : (i3) -> i5
 hw.module @concat_fold_4(%arg0: i3) -> (result: i5) {
   %0 = comb.extract %arg0 from 2 : (i3) -> (i1)
-  %1 = comb.concat %0, %0, %arg0 : (i1, i1, i3) -> (i5)
+  %1 = comb.concat %0, %0, %arg0 : i1, i1, i3
   hw.output %1 : i5
 }
 
 
 // CHECK-LABEL: hw.module @concat_fold_5
-// CHECK-NEXT:   %0 = comb.concat %arg0, %arg1 : (i3, i3) -> i6
+// CHECK-NEXT:   %0 = comb.concat %arg0, %arg1 : i3, i3
 // CHECK-NEXT:   hw.output %0, %arg0
 hw.module @concat_fold_5(%arg0: i3, %arg1: i3) -> (result: i6, a: i3) {
   %0 = comb.extract %arg0 from 2 : (i3) -> (i1)
   %1 = comb.extract %arg0 from 0 : (i3) -> i2
-  %2 = comb.concat %0, %1, %arg1 : (i1, i2, i3) -> i6
+  %2 = comb.concat %0, %1, %arg1 : i1, i2, i3
 
-  %3 = comb.concat %0, %1 : (i1, i2) -> i3
+  %3 = comb.concat %0, %1 : i1, i2
   hw.output %2, %3 : i6, i3
 }
 
@@ -569,7 +569,7 @@ hw.module @concat_fold_5(%arg0: i3, %arg1: i3) -> (result: i6, a: i3) {
 hw.module @concat_fold6(%arg0: i5, %arg1: i3) -> (result: i4) {
   %0 = comb.extract %arg0 from 3 : (i5) -> i2
   %1 = comb.extract %arg0 from 1 : (i5) -> i2
-  %2 = comb.concat %0, %1 : (i2, i2) -> i4
+  %2 = comb.concat %0, %1 : i2, i2
   hw.output %2 : i4
 }
 
@@ -588,7 +588,7 @@ hw.module @mux_fold1(%arg0: i1, %arg1: i3) -> (result: i3) {
   hw.output %0 : i3
 }
 
-// CHECK-LABEL: hw.module @icmp_fold_constants() 
+// CHECK-LABEL: hw.module @icmp_fold_constants()
 // CHECK-NEXT:    %false = hw.constant false
 // CHECK-NEXT:    hw.output %false : i1
 hw.module @icmp_fold_constants() -> (result: i1) {
@@ -598,7 +598,7 @@ hw.module @icmp_fold_constants() -> (result: i1) {
   hw.output %0 : i1
 }
 
-// CHECK-LABEL: hw.module @icmp_fold_same_operands(%arg0: i2) 
+// CHECK-LABEL: hw.module @icmp_fold_same_operands(%arg0: i2)
 // CHECK-NEXT:    %false = hw.constant false
 // CHECK-NEXT:    hw.output %false : i1
 hw.module @icmp_fold_same_operands(%arg0: i2) -> (result: i1) {
@@ -722,7 +722,7 @@ hw.module @shl_fold4(%arg0: i12) -> (result: i12) {
 // CHECK-LABEL: hw.module @shl_shift_to_extract_and_concat(%arg0: i12) -> (result: i12) {
 // CHECK-NEXT:   %c0_i2 = hw.constant 0 : i2
 // CHECK-NEXT:   %0 = comb.extract %arg0 from 0 : (i12) -> i10
-// CHECK-NEXT:   %1 = comb.concat %0, %c0_i2 : (i10, i2) -> i12
+// CHECK-NEXT:   %1 = comb.concat %0, %c0_i2 : i10, i2
 // CHECK-NEXT:   hw.output %1
 hw.module @shl_shift_to_extract_and_concat(%arg0: i12) -> (result: i12) {
   %c2_i12 = hw.constant 2 : i12
@@ -770,7 +770,7 @@ hw.module @shru_fold4(%arg0: i12) -> (result: i12) {
 // CHECK-LABEL: hw.module @shru_shift_to_extract_and_concat(%arg0: i12) -> (result: i12) {
 // CHECK-NEXT:   %c0_i2 = hw.constant 0 : i2
 // CHECK-NEXT:   %0 = comb.extract %arg0 from 2 : (i12) -> i10
-// CHECK-NEXT:   %1 = comb.concat %c0_i2, %0 : (i2, i10) -> i12
+// CHECK-NEXT:   %1 = comb.concat %c0_i2, %0 : i2, i10
 // CHECK-NEXT:   hw.output %1
 hw.module @shru_shift_to_extract_and_concat(%arg0: i12) -> (result: i12) {
   %c2_i12 = hw.constant 2 : i12
@@ -819,7 +819,7 @@ hw.module @shru_shift_to_extract_and_concat0(%arg0: i12) -> (result: i12) {
 // CHECK-LABEL: hw.module @shru_shift_to_extract_and_concat1(%arg0: i12) -> (result: i12) {
 // CHECK-NEXT:   %0 = comb.extract %arg0 from 11 : (i12) -> i1
 // CHECK-NEXT:   %1 = comb.extract %arg0 from 2 : (i12) -> i10
-// CHECK-NEXT:   %2 = comb.concat %0, %0, %1 : (i1, i1, i10) -> i12
+// CHECK-NEXT:   %2 = comb.concat %0, %0, %1 : i1, i1, i10
 // CHECK-NEXT:   hw.output %2
 hw.module @shru_shift_to_extract_and_concat1(%arg0: i12) -> (result: i12) {
   %c2_i12 = hw.constant 2 : i12
@@ -863,7 +863,7 @@ hw.module @mux_canonicalize3(%a: i1, %b: i1) -> (result: i1) {
   hw.output %0 : i1
 }
 
-// CHECK-LABEL: hw.module @icmp_fold_1bit_eq1(%arg: i1) 
+// CHECK-LABEL: hw.module @icmp_fold_1bit_eq1(%arg: i1)
 // CHECK-NEXT:   %true = hw.constant true
 // CHECK-NEXT:   %0 = comb.xor %arg, %true : i1
 // CHECK-NEXT:   %1 = comb.xor %arg, %true : i1
@@ -934,16 +934,16 @@ hw.module @sext_and_one_bit(%bit: i1) -> (a: i65, b: i8, c: i8) {
   %c-18446744073709551616_i65 = hw.constant -18446744073709551616 : i65
   %0 = comb.sext %bit : (i1) -> i65
   %1 = comb.and %0, %c-18446744073709551616_i65 : i65
-  // CHECK: [[A:%[0-9]+]] = comb.concat %bit, %c0_i64 : (i1, i64) -> i65
+  // CHECK: [[A:%[0-9]+]] = comb.concat %bit, %c0_i64 : i1, i64
 
   %c4_i8 = hw.constant 4 : i8
   %2 = comb.sext %bit : (i1) -> i8
   %3 = comb.and %2, %c4_i8 : i8
-  // CHECK: [[B:%[0-9]+]] = comb.concat %c0_i5, %bit, %c0_i2 : (i5, i1, i2) -> i8
+  // CHECK: [[B:%[0-9]+]] = comb.concat %c0_i5, %bit, %c0_i2 : i5, i1, i2
 
   %c1_i8 = hw.constant 1 : i8
   %4 = comb.and %2, %c1_i8 : i8
-  // CHECK: [[C:%[0-9]+]] = comb.concat %c0_i7, %bit : (i7, i1) -> i8
+  // CHECK: [[C:%[0-9]+]] = comb.concat %c0_i7, %bit : i7, i1
 
   // CHECK: hw.output [[A]], [[B]], [[C]] :
   hw.output %1, %3, %4 : i65, i8, i8
@@ -983,7 +983,7 @@ hw.module @wire3() {
   hw.output
 }
 
-// CHECK-LABEL: hw.module @wire4() 
+// CHECK-LABEL: hw.module @wire4()
 // CHECK-NEXT:   %true = hw.constant true
 // CHECK-NEXT:   %0 = sv.wire sym @symName : !hw.inout<i1>
 // CHECK-NEXT:   %1 = sv.read_inout %0 : !hw.inout<i1>
@@ -997,7 +997,7 @@ hw.module @wire4() -> (result: i1) {
   hw.output %1 : i1
 }
 
-// CHECK-LABEL: hw.module @wire4_1() 
+// CHECK-LABEL: hw.module @wire4_1()
 // CHECK-NEXT:   %true = hw.constant true
 // CHECK-NEXT:   hw.output %true : i1
 hw.module @wire4_1() -> (result: i1) {
@@ -1050,8 +1050,8 @@ hw.module @sext_extract3(%arg0: i4) -> (a: i3) {
 // CHECK-LABEL:  hw.module @instance_ooo(%arg0: i2, %arg1: i2, %arg2: i3) -> (out0: i8) {
 // CHECK-NEXT:    %false = hw.constant false
 // CHECK-NEXT:    %myext.out = hw.instance "myext" @MyParameterizedExtModule(in: %3: i1) -> (out: i8)  {oldParameters = {DEFAULT = 0 : i64, DEPTH = 3.242000e+01 : f64, FORMAT = "xyz_timeout=%d\0A", WIDTH = 32 : i8}}
-// CHECK-NEXT:    %0 = comb.concat %false, %arg0 : (i1, i2) -> i3
-// CHECK-NEXT:    %1 = comb.concat %false, %arg0 : (i1, i2) -> i3
+// CHECK-NEXT:    %0 = comb.concat %false, %arg0 : i1, i2
+// CHECK-NEXT:    %1 = comb.concat %false, %arg0 : i1, i2
 // CHECK-NEXT:    %2 = comb.add %0, %1 : i3
 // CHECK-NEXT:    %3 = comb.icmp eq %2, %arg2 : i3
 // CHECK-NEXT:    hw.output %myext.out : i8
@@ -1061,8 +1061,8 @@ hw.module @instance_ooo(%arg0: i2, %arg1: i2, %arg2: i3) -> (out0: i8) {
     %.in.wire = sv.wire  : !hw.inout<i1>
     %0 = sv.read_inout %.in.wire : !hw.inout<i1>
     %myext.out = hw.instance "myext" @MyParameterizedExtModule(in: %0: i1) -> (out: i8)  {oldParameters = {DEFAULT = 0 : i64, DEPTH = 3.242000e+01 : f64, FORMAT = "xyz_timeout=%d\0A", WIDTH = 32 : i8}}
-    %1 = comb.concat %false, %arg0 : (i1, i2) -> i3
-    %2 = comb.concat %false, %arg0 : (i1, i2) -> i3
+    %1 = comb.concat %false, %arg0 : i1, i2
+    %2 = comb.concat %false, %arg0 : i1, i2
     %3 = comb.add %1, %2 : i3
     %4 = comb.icmp eq %3, %arg2 : i3
     sv.assign %.in.wire, %4 : i1
@@ -1072,7 +1072,7 @@ hw.module @instance_ooo(%arg0: i2, %arg1: i2, %arg2: i3) -> (out0: i8) {
 // CHECK-LABEL: hw.module @TestInstance(%u2: i2, %s8: i8, %clock: i1, %reset: i1) {
 // CHECK-NEXT:   %c0_i2 = hw.constant 0 : i2
 // CHECK-NEXT:   hw.instance "xyz" @Simple(in1: %0: i4, in2: %u2: i2, in3: %s8: i8)
-// CHECK-NEXT:   %0 = comb.concat %c0_i2, %u2 : (i2, i2) -> i4
+// CHECK-NEXT:   %0 = comb.concat %c0_i2, %u2 : i2, i2
 // CHECK-NEXT:   %myext.out = hw.instance "myext" @MyParameterizedExtModule(in: %reset: i1) -> (out: i8)  {oldParameters = {DEFAULT = 0 : i64, DEPTH = 3.242000e+01 : f64, FORMAT = "xyz_timeout=%d\0A", WIDTH = 32 : i8}}
 // CHECK-NEXT:   hw.output
 hw.module.extern @MyParameterizedExtModule(%in: i1) -> (out: i8) attributes {verilogName = "name_thing"}
@@ -1086,7 +1086,7 @@ hw.module @TestInstance(%u2: i2, %s8: i8, %clock: i1, %reset: i1) {
   %.in3.wire = sv.wire  : !hw.inout<i8>
   %2 = sv.read_inout %.in3.wire : !hw.inout<i8>
   hw.instance "xyz" @Simple(in1: %0: i4, in2: %1: i2, in3: %2: i8) -> ()
-  %3 = comb.concat %c0_i2, %u2 : (i2, i2) -> i4
+  %3 = comb.concat %c0_i2, %u2 : i2, i2
   sv.assign %.in1.wire, %3 : i4
   sv.assign %.in2.wire, %u2 : i2
   sv.assign %.in3.wire, %s8 : i8
@@ -1165,7 +1165,7 @@ hw.module @unintializedWire(%clock1: i1, %clock2: i1, %inpred: i1, %indata: i42)
   %13 = sv.read_inout %.write.data.wire : !hw.inout<i42>
   %_M.ro_data_0, %_M.rw_rdata_0 = hw.instance "_M" @FIRRTLMem_1_1_1_42_12_0_1_0
      (ro_clock_0: %0: i1, ro_en_0: %1: i1, ro_addr_0: %2: i4) -> (ro_data_0: i42, rw_data_0: i42)
- 
+
   %14 = sv.read_inout %.read.addr.wire : !hw.inout<i4>
   %c0_i4 = hw.constant 0 : i4
   sv.assign %.read.addr.wire, %c0_i4 : i4

--- a/test/Dialect/LLHD/Export/verilog_bitwise.mlir
+++ b/test/Dialect/LLHD/Export/verilog_bitwise.mlir
@@ -52,7 +52,7 @@ llhd.entity @check_bitwise() -> () {
   %14 = comb.sext %13 : (i32) -> i64
 
   // CHECK-NEXT: wire [191:0] _{{.*}} = {_[[A]], _[[SEXT]], _[[A]]};
-  %15 = comb.concat %a, %14, %a : (i64, i64, i64) -> i192
+  %15 = comb.concat %a, %14, %a : i64, i64, i64
 
   // CHECK-NEXT: wire _[[COND:.*]] = 1'd1;
   // CHECK-NEXT: wire [63:0] _{{.*}} = _[[COND]] ? _[[A]] : _[[SEXT]];

--- a/test/ExportVerilog/hw-dialect.mlir
+++ b/test/ExportVerilog/hw-dialect.mlir
@@ -51,7 +51,7 @@ hw.module @TESTSIMPLE(%a: i4, %b: i4, %c: i2, %cond: i1,
   %zero4 = hw.constant 0 : i4
   %27 = comb.icmp ne %a, %zero4 : i4
   %28 = comb.parity %a : i4
-  %29 = comb.concat %a, %a, %b : (i4, i4, i4) -> i12
+  %29 = comb.concat %a, %a, %b : i4, i4, i4
   %30 = comb.extract %a from 1 : (i4) -> i2
   %31 = comb.sext %a : (i4) -> i9
   %33 = comb.mux %cond, %a, %b : i4
@@ -71,7 +71,7 @@ hw.module @TESTSIMPLE(%a: i4, %b: i4, %c: i2, %cond: i1,
   %elem2d = hw.array_get %array2d[%a] : !hw.array<12 x array<10xi4>>
   %37 = hw.array_get %elem2d[%b] : !hw.array<10xi4>
 
-  %36 = comb.concat %a, %a, %a : (i4, i4, i4) -> i12
+  %36 = comb.concat %a, %a, %a : i4, i4, i4
 
   %39 = hw.struct_extract %structA["bar"] : !hw.struct<foo: i2, bar: i4>
   %40 = hw.struct_inject %structA["bar"], %a : !hw.struct<foo: i2, bar: i4>
@@ -716,7 +716,7 @@ hw.module @Chi() -> (Chi_output : i0) {
    // CHECK-NEXT:   .WIDTH4(-68'sd88888888888888888),
    // CHECK-NEXT:   .Wtricky(40'd4294967295)
    // CHECK-NEXT: ) bar ();
-   
+
    hw.instance "bar" @Bar1360<
      WIDTH0: i64 = 0, WIDTH1: i4 = 4, WIDTH2: i40 = 6812312123, WIDTH3: si4 = -1,
      WIDTH4: si68 = -88888888888888888, Wtricky: i40 = 4294967295
@@ -766,9 +766,9 @@ hw.module @ShiftAmountZext(%a: i8, %b1: i4, %b2: i4, %b3: i4)
  -> (o1: i8, o2: i8, o3: i8) {
 
   %c = hw.constant 0 : i4
-  %B1 = comb.concat %c, %b1 : (i4, i4) -> i8
-  %B2 = comb.concat %c, %b2 : (i4, i4) -> i8
-  %B3 = comb.concat %c, %b3 : (i4, i4) -> i8
+  %B1 = comb.concat %c, %b1 : i4, i4
+  %B2 = comb.concat %c, %b2 : i4, i4
+  %B3 = comb.concat %c, %b3 : i4, i4
 
   // CHECK: assign o1 = a << b1;
   %r1 = comb.shl %a, %B1 : i8
@@ -794,7 +794,7 @@ hw.module @SignedshiftResultSign(%a: i18) -> (b: i18) {
   %c2856_i18 = hw.constant 2856 : i18
   %c0_i11 = hw.constant 0 : i11
   %0 = comb.extract %a from 0 : (i18) -> i7
-  %1 = comb.concat %c0_i11, %0 : (i11, i7) -> i18
+  %1 = comb.concat %c0_i11, %0 : i11, i7
   %2 = comb.shrs %a, %1 : i18
   %3 = comb.xor %2, %c2856_i18 : i18
   hw.output %3 : i18
@@ -874,7 +874,7 @@ hw.module @UseParameterValue<xx: i42>(%arg0: i8)
   // CHECK-NEXT:  .p1(xx + 42'd17)
   // CHECK-NEXT: ) inst2 (
   %b = hw.instance "inst2" @parameters2<p1: i42 = #hw.param.expr.add<#hw.param.verbatim<"xx">, 17>, p2: i1 = 0>(arg0: %arg0: i8) -> (out: i8)
- 
+
   // CHECK:      parameters2 #(
   // CHECK-NEXT:  .p1(xx * yy + yy * 42'd17)
   // CHECK-NEXT: ) inst3 (

--- a/test/ExportVerilog/verilog-basic.mlir
+++ b/test/ExportVerilog/verilog-basic.mlir
@@ -54,14 +54,14 @@ hw.module @Expressions(%in4: i4, %clock: i1) ->
 
   // CHECK: assign w1 = {2'h0, _T_1 | {in4[2], 1'h0}};
   %6 = comb.extract %in4 from 2 : (i4) -> i2
-  %8 = comb.concat %7, %false : (i1, i1) -> i2
+  %8 = comb.concat %7, %false : i1, i1
   %9 = comb.or %6, %8 : i2
 
   // CHECK: assign w1 = _T;
   // CHECK: assign w1 = clock ? (clock ? 4'h1 : 4'h2) : 4'h3;
   // CHECK: assign w1 = clock ? 4'h1 : clock ? 4'h2 : 4'h3;
   %11 = comb.shrs %in4, %in4 : i4
-  %12 = comb.concat %false, %in4, %in4 : (i1, i4, i4) -> i9
+  %12 = comb.concat %false, %in4, %in4 : i1, i4, i4
   %13 = comb.mux %clock, %c1_i4, %c2_i4 : i4
   %14 = comb.mux %clock, %13, %c3_i4 : i4
   %15 = comb.mux %clock, %c2_i4, %c3_i4 : i4
@@ -69,7 +69,7 @@ hw.module @Expressions(%in4: i4, %clock: i1) ->
 
   // CHECK: assign w1 = {2'h0, _T_1 | _T_0};
   %17 = comb.or %6, %5 : i2
-  %18 = comb.concat %c0_i2, %in4 : (i2, i4) -> i6
+  %18 = comb.concat %c0_i2, %in4 : i2, i4
 
   // CHECK: assign w2 = {6'h0, in4, clock, clock, in4};
   // CHECK: assign w2 = {10'h0, {2'h0, in4} ^ {{..}}2{in4[3]}}, in4} ^ {6{clock}}};
@@ -78,9 +78,9 @@ hw.module @Expressions(%in4: i4, %clock: i1) ->
   %21 = comb.xor %18, %19, %20 : i6
   %22 = comb.sext %in4 : (i4) -> i5
   %23 = comb.sub %c0_i5, %22 : i5
-  %25 = comb.concat %c0_i2, %5 : (i2, i2) -> i4
-  %26 = comb.concat %c0_i2, %9 : (i2, i2) -> i4
-  %27 = comb.concat %c0_i2, %17 : (i2, i2) -> i4
+  %25 = comb.concat %c0_i2, %5 : i2, i2
+  %26 = comb.concat %c0_i2, %9 : i2, i2
+  %27 = comb.concat %c0_i2, %17 : i2, i2
 
   %w1 = sv.wire : !hw.inout<i4>
   %w1_use = sv.read_inout %w1 : !hw.inout<i4>
@@ -94,9 +94,9 @@ hw.module @Expressions(%in4: i4, %clock: i1) ->
   sv.assign %w1, %16 : i4
   sv.assign %w1, %27 : i4
   sv.assign %w1, %10 : i4
-  
-  %29 = comb.concat %c0_i6, %in4, %clock, %clock, %in4 : (i6, i4, i1, i1, i4) -> i16
-  %30 = comb.concat %c0_i10, %21 : (i10, i6) -> i16
+
+  %29 = comb.concat %c0_i6, %in4, %clock, %clock, %in4 : i6, i4, i1, i1, i4
+  %30 = comb.concat %c0_i10, %21 : i10, i6
 
   %w2 = sv.wire : !hw.inout<i16>
   %w2_use = sv.read_inout %w2 : !hw.inout<i16>
@@ -159,49 +159,49 @@ hw.module @Precedence(%a: i4, %b: i4, %c: i4) -> (out1: i1, out: i10) {
   // CHECK: assign _out_output = {6'h0, (b ^ c) & {3'h0, _out1_output}};
   // CHECK: assign _out_output = {2'h0, _out_output[9:2]};
   // CHECK: assign _out1_output = _out_output < {6'h0, a};
-  %0 = comb.concat %false, %b : (i1, i4) -> i5
-  %1 = comb.concat %false, %c : (i1, i4) -> i5
+  %0 = comb.concat %false, %b : i1, i4
+  %1 = comb.concat %false, %c : i1, i4
   %2 = comb.add %0, %1 : i5
-  %3 = comb.concat %c0_i2, %a : (i2, i4) -> i6
-  %4 = comb.concat %false, %2 : (i1, i5) -> i6
+  %3 = comb.concat %c0_i2, %a : i2, i4
+  %4 = comb.concat %false, %2 : i1, i5
   %5 = comb.add %3, %4 : i6
-  %6 = comb.concat %c0_i4, %5 : (i4, i6) -> i10
+  %6 = comb.concat %c0_i4, %5 : i4, i6
   sv.assign %_out_output, %6 : i10
-  %7 = comb.concat %false, %a : (i1, i4) -> i5
+  %7 = comb.concat %false, %a : i1, i4
   %8 = comb.add %7, %0 : i5
-  %9 = comb.concat %false, %8 : (i1, i5) -> i6
-  %10 = comb.concat %c0_i2, %c : (i2, i4) -> i6
+  %9 = comb.concat %false, %8 : i1, i5
+  %10 = comb.concat %c0_i2, %c : i2, i4
   %11 = comb.sub %9, %10 : i6
-  %12 = comb.concat %c0_i4, %11 : (i4, i6) -> i10
+  %12 = comb.concat %c0_i4, %11 : i4, i6
   sv.assign %_out_output, %12 : i10
   %13 = comb.sub %3, %4 : i6
-  %14 = comb.concat %c0_i4, %13 : (i4, i6) -> i10
+  %14 = comb.concat %c0_i4, %13 : i4, i6
   sv.assign %_out_output, %14 : i10
-  %15 = comb.concat %c0_i4, %b : (i4, i4) -> i8
-  %16 = comb.concat %c0_i4, %c : (i4, i4) -> i8
+  %15 = comb.concat %c0_i4, %b : i4, i4
+  %16 = comb.concat %c0_i4, %c : i4, i4
   %17 = comb.mul %15, %16 : i8
-  %18 = comb.concat %c0_i5, %a : (i5, i4) -> i9
-  %19 = comb.concat %false, %17 : (i1, i8) -> i9
+  %18 = comb.concat %c0_i5, %a : i5, i4
+  %19 = comb.concat %false, %17 : i1, i8
   %20 = comb.add %18, %19 : i9
-  %21 = comb.concat %false, %20 : (i1, i9) -> i10
+  %21 = comb.concat %false, %20 : i1, i9
   sv.assign %_out_output, %21 : i10
-  %22 = comb.concat %c0_i4, %a : (i4, i4) -> i8
+  %22 = comb.concat %c0_i4, %a : i4, i4
   %23 = comb.mul %22, %15 : i8
-  %24 = comb.concat %false, %23 : (i1, i8) -> i9
-  %25 = comb.concat %c0_i5, %c : (i5, i4) -> i9
+  %24 = comb.concat %false, %23 : i1, i8
+  %25 = comb.concat %c0_i5, %c : i5, i4
   %26 = comb.add %24, %25 : i9
-  %27 = comb.concat %false, %26 : (i1, i9) -> i10
+  %27 = comb.concat %false, %26 : i1, i9
   sv.assign %_out_output, %27 : i10
-  %28 = comb.concat %c0_i4, %8 : (i4, i5) -> i9
+  %28 = comb.concat %c0_i4, %8 : i4, i5
   %29 = comb.mul %28, %25 : i9
-  %30 = comb.concat %false, %29 : (i1, i9) -> i10
+  %30 = comb.concat %false, %29 : i1, i9
   sv.assign %_out_output, %30 : i10
-  %31 = comb.concat %c0_i4, %2 : (i4, i5) -> i9
+  %31 = comb.concat %c0_i4, %2 : i4, i5
   %32 = comb.mul %18, %31 : i9
-  %33 = comb.concat %false, %32 : (i1, i9) -> i10
+  %33 = comb.concat %false, %32 : i1, i9
   sv.assign %_out_output, %33 : i10
-  %34 = comb.concat %c0_i5, %8 : (i5, i5) -> i10
-  %35 = comb.concat %c0_i5, %2 : (i5, i5) -> i10
+  %34 = comb.concat %c0_i5, %8 : i5, i5
+  %35 = comb.concat %c0_i5, %2 : i5, i5
   %36 = comb.mul %34, %35 : i10
   sv.assign %_out_output, %36 : i10
   %37 = comb.parity %2 : i5
@@ -212,15 +212,15 @@ hw.module @Precedence(%a: i4, %b: i4, %c: i4) -> (out1: i1, out: i10) {
   sv.assign %_out1_output, %40 : i1
   %41 = comb.xor %b, %c : i4
   %42 = sv.read_inout %_out1_output : !hw.inout<i1>
-  %43 = comb.concat %c0_i3, %42 : (i3, i1) -> i4
+  %43 = comb.concat %c0_i3, %42 : i3, i1
   %44 = comb.and %41, %43 : i4
-  %45 = comb.concat %c0_i6, %44 : (i6, i4) -> i10
+  %45 = comb.concat %c0_i6, %44 : i6, i4
   sv.assign %_out_output, %45 : i10
   %46 = sv.read_inout %_out_output : !hw.inout<i10>
   %47 = comb.extract %46 from 2 : (i10) -> i8
-  %48 = comb.concat %c0_i2, %47 : (i2, i8) -> i10
+  %48 = comb.concat %c0_i2, %47 : i2, i8
   sv.assign %_out_output, %48 : i10
-  %49 = comb.concat %c0_i6, %a : (i6, i4) -> i10
+  %49 = comb.concat %c0_i6, %a : i6, i4
   %50 = comb.icmp ult %46, %49 : i10
   sv.assign %_out1_output, %50 : i1
   hw.output %42, %46 : i1, i10
@@ -276,7 +276,7 @@ hw.module @MultiUseExpr(%a: i4) -> (b0: i1, b1: i1, b2: i1, b3: i1, b4: i2) {
   // CHECK: wire _T = ^a;
   %0 = comb.parity %a : i4
   // CHECK-NEXT: wire [4:0] _T_0 = {1'h0, a} << 5'h1;
-  %1 = comb.concat %false, %a : (i1, i4) -> i5
+  %1 = comb.concat %false, %a : i1, i4
   %2 = comb.shl %1, %c1_i5 : i5
 
   // CHECK-NEXT: wire [3:0] _T_1 = ~a;
@@ -365,7 +365,7 @@ hw.module @Print(%clock: i1, %reset: i1, %a: i4, %b: i4) {
   // CHECK:   if (`PRINTF_COND_ & reset)
   // CHECK:     $fwrite(32'h80000002, "Hi %x %x\n", _T, b);
   // CHECK: end // always @(posedge)
-  %0 = comb.concat %false, %a : (i1, i4) -> i5
+  %0 = comb.concat %false, %a : i1, i4
   %1 = comb.shl %0, %c1_i5 : i5
   sv.always posedge %clock  {
     %2 = sv.verbatim.expr "`PRINTF_COND_" : () -> i1

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -117,7 +117,7 @@ circuit test_mod : %[[{"a": "a"}]]
     d <= cat(cat(a, b), c)
 
 ; MLIRLOWER-LABEL: hw.module @Cat(%a: i2, %b: i2, %c: i2) -> (d: i6) {
-; MLIRLOWER-NEXT:    %0 = comb.concat %a, %b, %c : (i2, i2, i2) -> i6
+; MLIRLOWER-NEXT:    %0 = comb.concat %a, %b, %c : i2, i2, i2
 ; MLIRLOWER-NEXT:    hw.output %0 : i6
 ; MLIRLOWER-NEXT:  }
 
@@ -135,7 +135,7 @@ circuit test_mod : %[[{"a": "a"}]]
 ; MLIRLOWER-LABEL: hw.module @ImplicitTrunc(%inp_1: i1, %inp_2: i5) -> (out1: i3, out2: i3) {
 ; MLIRLOWER-NEXT:    %c0_i5 = hw.constant 0 : i5
 ; MLIRLOWER-NEXT:    %0 = comb.sext %inp_2 : (i5) -> i6
-; MLIRLOWER-NEXT:    %1 = comb.concat %c0_i5, %inp_1 : (i5, i1) -> i6
+; MLIRLOWER-NEXT:    %1 = comb.concat %c0_i5, %inp_1 : i5, i1
 ; MLIRLOWER-NEXT:    %2 = comb.shl %0, %1 : i6
 ; MLIRLOWER-NEXT:    %3 = comb.extract %2 from 0 : (i6) -> i3
 ; MLIRLOWER-NEXT:    %4 = comb.extract %inp_2 from 0 : (i5) -> i3


### PR DESCRIPTION
Removes the result type from the comb.concat type signature since it can be
deduced from the inputs.

For example, this previous signature:
```mlir
%0 = comb.concat %false, %b : (i1, i4) -> i5
```

is simplified to:
```mlir
%0 = comb.concat %false, %b : i1, i4
```

Address #1623.