### PR TITLE
[FIRRTL] Fix expand whens bug

### DIFF
--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -254,8 +254,9 @@ firrtl.module @nested(in %clock : !firrtl.clock, in %p0 : !firrtl.uint<1>, in %p
 // CHECK-NEXT:   %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
 // CHECK-NEXT:   %c2_ui2 = firrtl.constant 2 : !firrtl.uint<2>
 // CHECK-NEXT:   %0 = firrtl.and %p0, %p1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:   %1 = firrtl.mux(%p0, %c1_ui2, %c0_ui2) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
-// CHECK-NEXT:   firrtl.connect %out, %1 : !firrtl.uint<2>, !firrtl.uint<2>
+// CHECK-NEXT:   %1 = firrtl.mux(%p1, %c1_ui2, %c0_ui2) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
+// CHECK-NEXT:   %2 = firrtl.mux(%p0, %1, %c0_ui2) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
+// CHECK-NEXT:   firrtl.connect %out, %2 : !firrtl.uint<2>, !firrtl.uint<2>
 // CHECK-NEXT: }
 
 


### PR DESCRIPTION
[This has two commits which can be reviewed separately, the first one is NFC code shuffling]

When ExpandWhens sees the the following code, it *should* produce the
following:

```firrtl
out <= in0
when p0 :
  when p1 :
    out <= in1
```

```firrtl
out <= mux(p0, mux(p1, in1, in0), in0)
```

There was a mistake in the code where it would only track previously
driven values from one level of outer scope.  This means that when
producing the inner mux, `mux(p1, in1, in0)`, it never found that `in0`
was previously driven to `out`, and never formed a mux with the `in1`
connection:

```firrtl
out <= mux(p0, in1, in0)
```

To solve this, we had to make sure that the all scopes stored previously
driven values in the same hashtable.  This allowed the code to find the
previously driven value from all surrounding scopes.

At the same time, we needed to be able to remove all elements added in
scope from the global hashtable.  For example, after processing a `then`
block we need to reuse the global hashtable for the `else` block without
the modifcations of the `then` block.

To avoid this problem, we could create a copy of the hashtable before
recursing on WhenOps.  Instead of this, this adds a HashTableStack that
allows us to quickly pop off nested hashtables to reset the state. We
don't use a ScopedHashTable so that we can pop a scope and keep the
scope information for merging `then` and `else` scopes into the parent
scope.