### PR TITLE
[FIRRTL] Rename EmitMetadata to CreateSiFIveMetadata

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -40,7 +40,7 @@ std::unique_ptr<mlir::Pass> createInlinerPass();
 
 std::unique_ptr<mlir::Pass> createBlackBoxMemoryPass();
 
-std::unique_ptr<mlir::Pass> createEmitMetadataPass();
+std::unique_ptr<mlir::Pass> createCreateSiFiveMetadataPass();
 
 std::unique_ptr<mlir::Pass> createExpandWhensPass();
 

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -90,12 +90,12 @@ def BlackBoxMemory : Pass<"firrtl-blackbox-memory", "firrtl::CircuitOp"> {
   ];
 }
 
-def EmitMetadata : Pass<"firrtl-emit-metadata", "firrtl::CircuitOp"> {
+def CreateSiFiveMetadata : Pass<"firrtl-emit-metadata", "firrtl::CircuitOp"> {
   let summary = "Emit metadata of the FIRRTL modules";
   let description = [{
     This pass handles the emission of several different kinds of metadata.
   }];
-  let constructor = "circt::firrtl::createEmitMetadataPass()";
+  let constructor = "circt::firrtl::createCreateSiFiveMetadataPass()";
 }
 
 def ExpandWhens : Pass<"firrtl-expand-whens", "firrtl::FModuleOp"> {

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -483,9 +483,10 @@ void FIRRTLModuleLowering::runOnOperation() {
           state.oldToNewModuleMap[&op] =
               lowerExtModule(extModule, topLevelModule, state);
         })
-        // These need to be let through.  EmitMetadata produces VerbatimOps and
-        // GrandCentral can generate interfaces.  Moving them to the end of the
-        // module has the effect of keeping them in the same spot in the IR.
+        // These need to be let through.  Some metadata passes create
+        // VerbatimOps and GrandCentral can generate interfaces.  Moving them to
+        // the end of the module has the effect of keeping them in the same spot
+        // in the IR.
         .Case<sv::InterfaceOp, sv::VerbatimOp>([&](Operation *op) {
           op->moveBefore(topLevelModule, topLevelModule->end());
         })

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -1,9 +1,8 @@
-add_circt_dialect_library(
-  CIRCTFIRRTLTransforms
+add_circt_dialect_library(CIRCTFIRRTLTransforms
   BlackBoxMemory.cpp
   BlackBoxReader.cpp
   CheckCombCycles.cpp
-  EmitMetadata.cpp
+  CreateSiFiveMetadata.cpp
   ExpandWhens.cpp
   GrandCentral.cpp
   GrandCentralTaps.cpp

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -1,4 +1,4 @@
-//===- EmitMetadata.cpp - Emit various types of metadata --------*- C++ -*-===//
+//===- CreateSiFiveMetadata.cpp - Create various metadata -------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file defines the EmitMetadata pass.
+// This file defines the CreateSiFiveMetadata pass.
 //
 //===----------------------------------------------------------------------===//
 
@@ -26,7 +26,8 @@ using namespace circt;
 using namespace firrtl;
 
 namespace {
-class EmitMetadataPass : public EmitMetadataBase<EmitMetadataPass> {
+class CreateSiFiveMetadataPass
+    : public CreateSiFiveMetadataBase<CreateSiFiveMetadataPass> {
   LogicalResult emitRetimeModulesMetadata();
   LogicalResult emitSitestBlackboxMetadata();
   void getDependentDialects(mlir::DialectRegistry &registry) const override;
@@ -81,7 +82,7 @@ static LogicalResult removeAnnotationWithFilename(Operation *op,
 
 /// This function collects the name of each module annotated and prints them
 /// all as a JSON array.
-LogicalResult EmitMetadataPass::emitRetimeModulesMetadata() {
+LogicalResult CreateSiFiveMetadataPass::emitRetimeModulesMetadata() {
 
   // Circuit level annotation.
   auto *retimeModulesAnnoClass =
@@ -136,7 +137,7 @@ LogicalResult EmitMetadataPass::emitRetimeModulesMetadata() {
 
 /// This function finds all external modules which will need to be generated for
 /// the test harness to run.
-LogicalResult EmitMetadataPass::emitSitestBlackboxMetadata() {
+LogicalResult CreateSiFiveMetadataPass::emitSitestBlackboxMetadata() {
   auto *dutBlackboxAnnoClass =
       "sifive.enterprise.firrtl.SitestBlackBoxAnnotation";
   auto *testBlackboxAnnoClass =
@@ -255,13 +256,13 @@ LogicalResult EmitMetadataPass::emitSitestBlackboxMetadata() {
   return success();
 }
 
-void EmitMetadataPass::getDependentDialects(
+void CreateSiFiveMetadataPass::getDependentDialects(
     mlir::DialectRegistry &registry) const {
   // We need this for SV verbatim and HW attributes.
   registry.insert<hw::HWDialect, sv::SVDialect>();
 }
 
-void EmitMetadataPass::runOnOperation() {
+void CreateSiFiveMetadataPass::runOnOperation() {
   if (failed(emitRetimeModulesMetadata()) ||
       failed(emitSitestBlackboxMetadata()))
     return signalPassFailure();
@@ -270,6 +271,6 @@ void EmitMetadataPass::runOnOperation() {
   markAnalysesPreserved<InstanceGraph>();
 }
 
-std::unique_ptr<mlir::Pass> circt::firrtl::createEmitMetadataPass() {
-  return std::make_unique<EmitMetadataPass>();
+std::unique_ptr<mlir::Pass> circt::firrtl::createCreateSiFiveMetadataPass() {
+  return std::make_unique<CreateSiFiveMetadataPass>();
 }

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -285,7 +285,8 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
         firrtl::createLowerFIRRTLAnnotationsPass(disableAnnotationsUnknown,
                                                  disableAnnotationsClassless));
   if (emitMetadata)
-    pm.nest<firrtl::CircuitOp>().addPass(firrtl::createEmitMetadataPass());
+    pm.nest<firrtl::CircuitOp>().addPass(
+        firrtl::createCreateSiFiveMetadataPass());
 
   if (!disableOptimization) {
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(


### PR DESCRIPTION
Since this is creating verbatim operations instead of emitting files
directly, `create` makes more sense as a verb.

Since the metadata created is specific to SiFive build flows,  this
renames the pass to make it clear that it is not generically useful.
This leaves the pass on by default since the pass will only do anything
if the correct annotations exist.

This change was suggested here:
https://github.com/llvm/circt/pull/1875#discussion_r716070526