### PR TITLE
[Calyx] Add verifier for ParOp.

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxControl.td
+++ b/include/circt/Dialect/Calyx/CalyxControl.td
@@ -124,6 +124,7 @@ def ParOp : CalyxContainer<"par", [
     ```
   }];
   let hasCanonicalizeMethod = true;
+  let verifier = "return ::verify$cppClass(*this);";
 }
 
 def EnableOp : CalyxOp<"enable", [

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -487,6 +487,29 @@ calyx.program "main" {
 // -----
 
 calyx.program "main" {
+  calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
+    %c1_1 = hw.constant 1 : i1
+    calyx.wires {
+      calyx.group @A {
+        calyx.assign %r.in = %c1_1 : i1
+        calyx.assign %r.write_en = %c1_1 : i1
+        calyx.group_done %r.done : i1
+      }
+    }
+    calyx.control {
+      // expected-error @+1 {{'calyx.par' op cannot enable the same group: "A" more than once.}}
+      calyx.par {
+        calyx.enable @A
+        calyx.enable @A
+      }
+    }
+  }
+}
+
+// -----
+
+calyx.program "main" {
   calyx.component @A(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%out: i1, %done: i1 {done}) {
     %c1_1 = hw.constant 1 : i1
     calyx.wires { calyx.assign %done = %c1_1 : i1 }


### PR DESCRIPTION
Adds a simpler verifier for `ParOp` that only looks within the given body (and not nested regions). Anything stricter requires more careful thinking. For example, this should be OK:

```
calyx.par {
  calyx.if {
    calyx.enable @G
  } else {
    calyx.enable @G
  }
}
```

Similarly, nested sequential operations containing the same `EnableOp`s in a ParOp may be valid if their timing is OK. Therefore, I've decided to keep this very loose for now. 