### PR TITLE
[FIRRTL][LowerToHW] Passthrough any operation not using FIRRTL types

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -104,10 +104,9 @@ static LogicalResult verifyOpLegality(Operation *op) {
         failed(checkTypeRange(op->getResultTypes())))
       return WalkResult::interrupt();
 
-    // Recursively verify this operation.
+    // Check the block argument types.
     for (auto &region : op->getRegions())
       for (auto &block : region)
-        // Check the block argument types.
         if (failed(checkTypeRange(block.getArgumentTypes())))
           return WalkResult::interrupt();
 

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -80,6 +80,52 @@ static Type lowerType(Type type) {
   return {};
 }
 
+/// This verifies that the target operation has been lowered to a legal
+// operation.  This checks that the operation recursively has no FIRRTL
+// operations or types.
+static LogicalResult verifyOpLegality(Operation *op) {
+  SmallVector<Operation *> worklist = {op};
+  while (!worklist.empty()) {
+    op = worklist.pop_back_val();
+
+    // Check that this operation is not a FIRRTL op.
+    if (op->getDialect() && (FIRRTLDialect::getDialectNamespace() ==
+                             op->getDialect()->getNamespace()))
+      return op->emitError("Found unhandled FIRRTL operation '")
+             << op->getName() << "'";
+
+    // Helper to check a TypeRange for any FIRRTL types.
+    auto checkTypes = [&](TypeRange types) -> LogicalResult {
+      if (llvm::any_of(types, [](Type type) {
+            return type.getDialect().getNamespace() ==
+                   FIRRTLDialect::getDialectNamespace();
+          }))
+        return op->emitOpError("found unhandled FIRRTL type");
+      return success();
+    };
+
+    // Check operand and result types.
+    if (failed(checkTypes(op->getOperandTypes())) ||
+        failed(checkTypes(op->getResultTypes())))
+      return failure();
+
+    // Recursively verify this operation.
+    for (auto &region : op->getRegions()) {
+      for (auto &block : region) {
+
+        // Check the block argument types.
+        if (failed(checkTypes(block.getArgumentTypes())))
+          return failure();
+
+        for (auto &childOp : block) {
+          worklist.push_back(&childOp);
+        }
+      }
+    }
+  }
+  return success();
+}
+
 /// Given two FIRRTL integer types, return the widest one.
 static IntType getWidestIntType(Type t1, Type t2) {
   auto t1c = t1.cast<IntType>(), t2c = t2.cast<IntType>();
@@ -483,19 +529,13 @@ void FIRRTLModuleLowering::runOnOperation() {
           state.oldToNewModuleMap[&op] =
               lowerExtModule(extModule, topLevelModule, state);
         })
-        // These need to be let through.  Some metadata passes create
-        // VerbatimOps and GrandCentral can generate interfaces.  Moving them to
-        // the end of the module has the effect of keeping them in the same spot
-        // in the IR.
-        .Case<sv::InterfaceOp, sv::VerbatimOp>([&](Operation *op) {
-          op->moveBefore(topLevelModule, topLevelModule->end());
-        })
-        // Otherwise we don't know what this is.  We are just going to drop
-        // it, but emit an error so the client has some chance to know that
-        // this is going to happen.
-        .Default([](auto other) {
-          other->emitError("unexpected operation '")
-              << other->getName() << "' in a firrtl.circuit";
+        .Default([&](Operation *op) {
+          // We don't know what this op is.  If it has no illegal FIRRTL types,
+          // we can forward the operation.  Otherwise, we emit an error and drop
+          // the operation from the circuit.
+          if (succeeded(verifyOpLegality(op))) {
+            op->moveBefore(topLevelModule, topLevelModule->end());
+          }
         });
   }
 

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -112,14 +112,11 @@ static LogicalResult verifyOpLegality(Operation *op) {
     // Recursively verify this operation.
     for (auto &region : op->getRegions()) {
       for (auto &block : region) {
-
         // Check the block argument types.
         if (failed(checkTypes(block.getArgumentTypes())))
           return failure();
-
-        for (auto &childOp : block) {
+        for (auto &childOp : block)
           worklist.push_back(&childOp);
-        }
       }
     }
   }
@@ -533,9 +530,8 @@ void FIRRTLModuleLowering::runOnOperation() {
           // We don't know what this op is.  If it has no illegal FIRRTL types,
           // we can forward the operation.  Otherwise, we emit an error and drop
           // the operation from the circuit.
-          if (succeeded(verifyOpLegality(op))) {
+          if (succeeded(verifyOpLegality(op)))
             op->moveBefore(topLevelModule, topLevelModule->end());
-          }
         });
   }
 

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
@@ -258,8 +258,6 @@ firrtl.circuit "Simple" {
   }
 
   // The following operations should be passed through without an error.
-  // CHECK: sv.verbatim "hello"
-  sv.verbatim "hello"
   // CHECK: sv.interface @SVInterface
   sv.interface @SVInterface { }
 }


### PR DESCRIPTION
We had some hardcoded logic to allow `sv.verbatim` and `sv.interface`
operations to be copied from a `CircuitOp` when lowering to HW.
This change makes this more generic by automatically passing through any
operation which (recursively) does not have any FIRRTL type or
operation.

This change only affects operations which appear in the CircuitOp's
body.  Operations appearing in a ModuleBody are handled by
`handleUnloweredOp`.

Fixes #1838