### PR TITLE
[Calyx] Add enhancements to common tail elimination for `IfOp`.

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxControl.td
+++ b/include/circt/Dialect/Calyx/CalyxControl.td
@@ -68,7 +68,7 @@ def IfOp : CalyxContainer<"if", [
 
   let assemblyFormat = "$cond (`with` $groupName^)? $thenRegion (`else` $elseRegion^)? attr-dict";
   let verifier = "return ::verify$cppClass(*this);";
-  let hasCanonicalizeMethod = true;
+  let hasCanonicalizer = true;
   let extraClassDeclaration = [{
     /// Checks whether the `then` region exists.
     bool thenRegionExists() { return !getOperation()->getRegion(0).empty(); }

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -1431,10 +1431,10 @@ static llvm::StringMap<EnableOp> getAllEnableOpsInImmediateBody(ParOp parent) {
 /// in SeqOp and ParOp. This canonicalization is stringent about not entering
 /// nested control operations, as this may cause unintentional changes in
 /// behavior.
-struct CommonIfTailPattern : mlir::OpRewritePattern<calyx::IfOp> {
-  using mlir::OpRewritePattern<calyx::IfOp>::OpRewritePattern;
+struct CommonIfTailPattern : mlir::OpRewritePattern<IfOp> {
+  using mlir::OpRewritePattern<IfOp>::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(calyx::IfOp ifOp,
+  LogicalResult matchAndRewrite(IfOp ifOp,
                                 PatternRewriter &rewriter) const override {
     if (!ifOp.thenRegionExists() || !ifOp.elseRegionExists())
       return failure();

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -117,14 +117,14 @@ static std::string valueName(Operation *scopeOp, Value v) {
 static bool isPort(Value value) {
   Operation *definingOp = value.getDefiningOp();
   return value.isa<BlockArgument>() ||
-      (definingOp && isa<CellInterface>(definingOp));
+         (definingOp && isa<CellInterface>(definingOp));
 }
 
 /// Gets the port for a given BlockArgument.
 PortInfo calyx::getPortInfo(BlockArgument arg) {
   Operation *op = arg.getOwner()->getParentOp();
   assert(isa<ComponentOp>(op) &&
-      "Only ComponentOp should support lookup by BlockArgument.");
+         "Only ComponentOp should support lookup by BlockArgument.");
   return cast<ComponentOp>(op).getPortInfo()[arg.getArgNumber()];
 }
 
@@ -238,7 +238,7 @@ LogicalResult calyx::verifyCell(Operation *op) {
   auto opParent = op->getParentOp();
   if (!isa<ComponentOp>(opParent))
     return op->emitOpError()
-        << "has parent: " << opParent << ", expected ComponentOp.";
+           << "has parent: " << opParent << ", expected ComponentOp.";
   if (!op->hasAttr("instanceName"))
     return op->emitOpError() << "does not have an instanceName attribute.";
 
@@ -262,10 +262,10 @@ static LogicalResult verifyPrimitivePortDriving(AssignOp assign,
             // We only want to verify this is written to if the {write enable,
             // in} port is driven.
             return succeeded(anyPortsDrivenByGroup(
-                {op.writeEnPort(), op.inPort()}, group))
-                   ? allPortsDrivenByGroup({op.writeEnPort(), op.inPort()},
-                                           group)
-                   : success();
+                       {op.writeEnPort(), op.inPort()}, group))
+                       ? allPortsDrivenByGroup({op.writeEnPort(), op.inPort()},
+                                               group)
+                       : success();
           })
           .Case<MemoryOp>([&](auto op) {
             SmallVector<Value> requiredWritePorts;
@@ -279,9 +279,9 @@ static LogicalResult verifyPrimitivePortDriving(AssignOp assign,
             // We only want to verify the write ports if either write_data or
             // write_en is driven.
             return succeeded(anyPortsDrivenByGroup(
-                {op.writeData(), op.writeEn()}, group))
-                   ? allPortsDrivenByGroup(requiredWritePorts, group)
-                   : success();
+                       {op.writeData(), op.writeEn()}, group))
+                       ? allPortsDrivenByGroup(requiredWritePorts, group)
+                       : success();
           })
           .Case<AndLibOp, OrLibOp, XorLibOp, AddLibOp, SubLibOp, GtLibOp,
                 LtLibOp, EqLibOp, NeqLibOp, GeLibOp, LeLibOp, LshLibOp,
@@ -289,17 +289,17 @@ static LogicalResult verifyPrimitivePortDriving(AssignOp assign,
                 SleLibOp, SrshLibOp>([&](auto op) {
             Value lhs = op.lhsPort(), rhs = op.rhsPort();
             return succeeded(anyPortsDrivenByGroup({lhs, rhs}, group))
-                   ? allPortsDrivenByGroup({lhs, rhs}, group)
-                   : success();
+                       ? allPortsDrivenByGroup({lhs, rhs}, group)
+                       : success();
           })
           .Default([&](auto op) { return success(); });
 
   if (failed(verifyWrites))
     return group->emitOpError()
-        << "with cell: " << destCell->getName() << " \""
-        << destCell.instanceName()
-        << "\" is performing a write and failed to drive all necessary "
-           "ports.";
+           << "with cell: " << destCell->getName() << " \""
+           << destCell.instanceName()
+           << "\" is performing a write and failed to drive all necessary "
+              "ports.";
 
   Operation *srcDefiningOp = assign.src().getDefiningOp();
   if (srcDefiningOp == nullptr)
@@ -315,8 +315,8 @@ static LogicalResult verifyPrimitivePortDriving(AssignOp assign,
             // we only want to verify the read ports if read_data is used in the
             // group.
             return succeeded(anyPortsReadByGroup({op.readData()}, group))
-                   ? allPortsDrivenByGroup(op.addrPorts(), group)
-                   : success();
+                       ? allPortsDrivenByGroup(op.addrPorts(), group)
+                       : success();
           })
           .Default([&](auto op) { return success(); });
 
@@ -349,8 +349,8 @@ LogicalResult calyx::verifyControlLikeOp(Operation *op) {
   auto parent = op->getParentOp();
   if (!hasControlRegion(parent))
     return op->emitOpError()
-        << "has parent: " << parent
-        << ", which is not allowed for a control-like operation.";
+           << "has parent: " << parent
+           << ", which is not allowed for a control-like operation.";
 
   if (op->getNumRegions() == 0)
     return success();
@@ -365,8 +365,8 @@ LogicalResult calyx::verifyControlLikeOp(Operation *op) {
       continue;
 
     return op->emitOpError()
-        << "has operation: " << bodyOp.getName()
-        << ", which is not allowed in this control-like operation";
+           << "has operation: " << bodyOp.getName()
+           << ", which is not allowed in this control-like operation";
   }
   return verifyControlBody(op);
 }
@@ -558,8 +558,8 @@ static void printComponentOp(OpAsmPrinter &p, ComponentOp op) {
   printPortDefList(op.getOutputPortInfo());
 
   p.printRegion(op.body(), /*printEntryBlockArgs=*/false,
-      /*printBlockTerminators=*/false,
-      /*printEmptyBlock=*/false);
+                /*printBlockTerminators=*/false,
+                /*printEmptyBlock=*/false);
 }
 
 /// Parses the ports of a Calyx component signature, and adds the corresponding
@@ -581,8 +581,8 @@ parsePortDefList(OpAsmParser &parser, OperationState &result,
 
     NamedAttrList portAttr;
     portAttrs.push_back(succeeded(parser.parseOptionalAttrDict(portAttr))
-                        ? portAttr
-                        : NamedAttrList());
+                            ? portAttr
+                            : NamedAttrList());
     return success();
   };
 
@@ -698,8 +698,8 @@ static LogicalResult hasRequiredPorts(ComponentOp op) {
                       intersection.begin(), intersection.end(),
                       std::back_inserter(difference));
   return op->emitOpError()
-      << "is missing the following required port attribute identifiers: "
-      << difference;
+         << "is missing the following required port attribute identifiers: "
+         << difference;
 }
 
 static LogicalResult verifyComponentOp(ComponentOp op) {
@@ -707,7 +707,7 @@ static LogicalResult verifyComponentOp(ComponentOp op) {
   auto wIt = op.getBody()->getOps<WiresOp>();
   auto cIt = op.getBody()->getOps<ControlOp>();
   if (std::distance(wIt.begin(), wIt.end()) +
-      std::distance(cIt.begin(), cIt.end()) !=
+          std::distance(cIt.begin(), cIt.end()) !=
       2)
     return op.emitOpError(
         "requires exactly one of each: 'calyx.wires', 'calyx.control'.");
@@ -771,8 +771,8 @@ void ComponentOp::build(OpBuilder &builder, OperationState &result,
   result.addAttribute("portNames", builder.getArrayAttr(portNames));
   result.addAttribute(direction::attrKey,
                       direction::packAttribute(direction::genInOutDirections(
-                          portIOTypes.first.size(),
-                          portIOTypes.second.size()),
+                                                   portIOTypes.first.size(),
+                                                   portIOTypes.second.size()),
                                                builder.getContext()));
   // Record the attributes of the ports.
   result.addAttribute("portAttributes", builder.getArrayAttr(portAttributes));
@@ -882,19 +882,19 @@ static LogicalResult isCombinational(Value value, GroupInterface group) {
   // Reads to MemoryOp and RegisterOp are combinational. Writes are not.
   if (auto r = dyn_cast<RegisterOp>(definingOp)) {
     return value == r.outPort()
-           ? success()
-           : group->emitOpError()
-               << "with register: \"" << r.instanceName()
-               << "\" is conducting a memory store. This is not "
-                  "combinational.";
+               ? success()
+               : group->emitOpError()
+                     << "with register: \"" << r.instanceName()
+                     << "\" is conducting a memory store. This is not "
+                        "combinational.";
   } else if (auto m = dyn_cast<MemoryOp>(definingOp)) {
     auto writePorts = {m.writeData(), m.writeEn()};
     return (llvm::none_of(writePorts, [&](Value p) { return p == value; }))
-           ? success()
-           : group->emitOpError()
-               << "with memory: \"" << m.instanceName()
-               << "\" is conducting a memory store. This "
-                  "is not combinational.";
+               ? success()
+               : group->emitOpError()
+                     << "with memory: \"" << m.instanceName()
+                     << "\" is conducting a memory store. This "
+                        "is not combinational.";
   }
 
   std::string portName =
@@ -960,27 +960,27 @@ static LogicalResult verifyPortDirection(AssignOp op, Value value,
                                          bool isDestination) {
   Operation *definingOp = value.getDefiningOp();
   bool isComponentPort = value.isa<BlockArgument>(),
-      isCellInterfacePort = definingOp && isa<CellInterface>(definingOp);
+       isCellInterfacePort = definingOp && isa<CellInterface>(definingOp);
   assert((isComponentPort || isCellInterfacePort) && "Not a port.");
 
   PortInfo port = isComponentPort
-                  ? getPortInfo(value.cast<BlockArgument>())
-                  : cast<CellInterface>(definingOp).portInfo(value);
+                      ? getPortInfo(value.cast<BlockArgument>())
+                      : cast<CellInterface>(definingOp).portInfo(value);
 
   bool isSource = !isDestination;
   // Component output ports and cell interface input ports should be driven.
   Direction validDirection =
       (isDestination && isComponentPort) || (isSource && isCellInterfacePort)
-      ? Direction::Output
-      : Direction::Input;
+          ? Direction::Output
+          : Direction::Input;
 
   return port.direction == validDirection
-         ? success()
-         : op.emitOpError()
-             << "has a " << (isComponentPort ? "component" : "cell")
-             << " port as the "
-             << (isDestination ? "destination" : "source")
-             << " with the incorrect direction.";
+             ? success()
+             : op.emitOpError()
+                   << "has a " << (isComponentPort ? "component" : "cell")
+                   << " port as the "
+                   << (isDestination ? "destination" : "source")
+                   << " with the incorrect direction.";
 }
 
 /// Verifies the value of a given assignment operation. The boolean
@@ -1091,8 +1091,8 @@ static LogicalResult verifyInstanceOpType(InstanceOp instance,
   StringRef entryPointName = program.entryPointName();
   if (instance.componentName() == entryPointName)
     return instance.emitOpError()
-        << "cannot reference the entry-point component: \"" << entryPointName
-        << "\".";
+           << "cannot reference the entry-point component: \"" << entryPointName
+           << "\".";
 
   // Verify the instance result ports with those of its referenced component.
   SmallVector<PortInfo> componentPorts = referencedComponent.getPortInfo();
@@ -1101,8 +1101,8 @@ static LogicalResult verifyInstanceOpType(InstanceOp instance,
   size_t numResults = instance.getNumResults();
   if (numResults != numPorts)
     return instance.emitOpError()
-        << "has a wrong number of results; expected: " << numPorts
-        << " but got " << numResults;
+           << "has a wrong number of results; expected: " << numPorts
+           << " but got " << numResults;
 
   for (size_t i = 0; i != numResults; ++i) {
     auto resultType = instance.getResult(i).getType();
@@ -1110,8 +1110,8 @@ static LogicalResult verifyInstanceOpType(InstanceOp instance,
     if (resultType == expectedType)
       continue;
     return instance.emitOpError()
-        << "result type for " << componentPorts[i].name << " must be "
-        << expectedType << ", but got " << resultType;
+           << "result type for " << componentPorts[i].name << " must be "
+           << expectedType << ", but got " << resultType;
   }
   return success();
 }
@@ -1203,8 +1203,8 @@ static LogicalResult verifyGroupDoneOp(GroupDoneOp doneOp) {
 
   if (isa<hw::ConstantOp>(srcOp) && (noGuard || isa<hw::ConstantOp>(guardOp)))
     return doneOp->emitOpError()
-        << "with constant source" << (noGuard ? "" : " and constant guard")
-        << ". This should be a combinational group.";
+           << "with constant source" << (noGuard ? "" : " and constant guard")
+           << ". This should be a combinational group.";
 
   return verifyNotComplexSource(doneOp);
 }
@@ -1327,20 +1327,20 @@ static LogicalResult verifyMemoryOp(MemoryOp memoryOp) {
   size_t numAddrs = memoryOp.addrSizes().size();
   if (numDims != numAddrs)
     return memoryOp.emitOpError("mismatched number of dimensions (")
-        << numDims << ") and address sizes (" << numAddrs << ")";
+           << numDims << ") and address sizes (" << numAddrs << ")";
 
   size_t numExtraPorts = 5; // write data/enable, clk, and read data/done.
   if (memoryOp.getNumResults() != numAddrs + numExtraPorts)
     return memoryOp.emitOpError("incorrect number of address ports, expected ")
-        << numAddrs;
+           << numAddrs;
 
   for (size_t i = 0; i < numDims; ++i) {
     int64_t size = sizes[i].cast<IntegerAttr>().getInt();
     int64_t addrSize = addrSizes[i].cast<IntegerAttr>().getInt();
     if (llvm::Log2_64_Ceil(size) > addrSize)
       return memoryOp.emitOpError("address size (")
-          << addrSize << ") for dimension " << i
-          << " can't address the entire range (" << size << ")";
+             << addrSize << ") for dimension " << i
+             << " can't address the entire range (" << size << ")";
   }
 
   return success();
@@ -1357,7 +1357,7 @@ static LogicalResult verifyEnableOp(EnableOp enableOp) {
   auto groupOp = wiresOp.lookupSymbol<GroupInterface>(groupName);
   if (!groupOp)
     return enableOp.emitOpError()
-        << "with group '" << groupName << "', which does not exist.";
+           << "with group '" << groupName << "', which does not exist.";
 
   if (isa<CombGroupOp>(groupOp))
     return enableOp.emitOpError() << "with group '" << groupName
@@ -1389,7 +1389,7 @@ static LogicalResult verifyIfOp(IfOp ifOp) {
   auto groupOp = wiresOp.lookupSymbol<GroupInterface>(groupName);
   if (!groupOp)
     return ifOp.emitOpError()
-        << "with group '" << groupName << "', which does not exist.";
+           << "with group '" << groupName << "', which does not exist.";
 
   if (isa<GroupOp>(groupOp))
     return ifOp.emitOpError() << "with group '" << groupName
@@ -1397,9 +1397,9 @@ static LogicalResult verifyIfOp(IfOp ifOp) {
 
   if (failed(portDrivenByGroup(ifOp.cond(), groupOp)))
     return ifOp.emitError()
-        << "with conditional op: '" << valueName(component, ifOp.cond())
-        << "' expected to be driven from group: '" << groupName
-        << "' but no driver was found.";
+           << "with conditional op: '" << valueName(component, ifOp.cond())
+           << "' expected to be driven from group: '" << groupName
+           << "' but no driver was found.";
 
   return success();
 }
@@ -1462,7 +1462,7 @@ struct CommonIfTailPattern : mlir::OpRewritePattern<IfOp> {
       //      }
       //    }
       llvm::StringMap<EnableOp> A = getAllEnableOpsInImmediateBody(r1),
-          B = getAllEnableOpsInImmediateBody(r2);
+                                B = getAllEnableOpsInImmediateBody(r2);
 
       // Compute the intersection between `A` and `B`.
       SmallVector<StringRef> groupNames;
@@ -1493,7 +1493,7 @@ struct CommonIfTailPattern : mlir::OpRewritePattern<IfOp> {
 
       return success();
     } else if (auto r1 = dyn_cast<SeqOp>(thenControl);
-        auto r2 = dyn_cast<SeqOp>(elseControl)) {
+               auto r2 = dyn_cast<SeqOp>(elseControl)) {
       //                                         seq {
       //   if %a with @G {                         if %a with @G {
       //     seq { ... calyx.enable @A }             seq { ... }
@@ -1503,7 +1503,7 @@ struct CommonIfTailPattern : mlir::OpRewritePattern<IfOp> {
       //                                           calyx.enable @A
       //                                         }
       EnableOp lastThenEnableOp = getLastEnableOp(r1),
-          lastElseEnableOp = getLastEnableOp(r2);
+               lastElseEnableOp = getLastEnableOp(r2);
 
       if (lastThenEnableOp == nullptr || lastElseEnableOp == nullptr)
         return failure();
@@ -1554,7 +1554,7 @@ static LogicalResult verifyWhileOp(WhileOp whileOp) {
   auto groupOp = wiresOp.lookupSymbol<GroupInterface>(groupName);
   if (!groupOp)
     return whileOp.emitOpError()
-        << "with group '" << groupName << "', which does not exist.";
+           << "with group '" << groupName << "', which does not exist.";
 
   if (isa<GroupOp>(groupOp))
     return whileOp.emitOpError() << "with group '" << groupName
@@ -1562,9 +1562,9 @@ static LogicalResult verifyWhileOp(WhileOp whileOp) {
 
   if (failed(portDrivenByGroup(whileOp.cond(), groupOp)))
     return whileOp.emitError()
-        << "conditional op: '" << valueName(component, whileOp.cond())
-        << "' expected to be driven from group: '" << groupName
-        << "' but no driver was found.";
+           << "conditional op: '" << valueName(component, whileOp.cond())
+           << "' expected to be driven from group: '" << groupName
+           << "' but no driver was found.";
 
   return success();
 }

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -1427,112 +1427,130 @@ static llvm::StringMap<EnableOp> getAllEnableOpsInImmediateBody(ParOp parent) {
   return enables;
 }
 
-/// Removes common tail enable operations for then and else regions encompassed
-/// in SeqOp and ParOp. This canonicalization is stringent about not entering
-/// nested control operations, as this may cause unintentional changes in
+/// Checks preconditions for the common tail pattern. This canonicalization is
+/// stringent about not entering nested control operations, as this may cause
+/// unintentional changes in behavior.
+/// We only look for two cases: (1) both regions are ParOps, and
+/// (2) both regions are SeqOps. The case when these are different, e.g. ParOp
+/// and SeqOp, will only produce less optimal code, or even worse, change the
 /// behavior.
-struct CommonIfTailPattern : mlir::OpRewritePattern<IfOp> {
+template <typename OpTy>
+static bool hasCommonTailPatternPreConditions(IfOp op) {
+  static_assert(std::is_same<SeqOp, OpTy>() || std::is_same<ParOp, OpTy>(),
+                "Should be a SeqOp or ParOp.");
+
+  if (!op.thenBodyExists() || !op.elseBodyExists())
+    return false;
+
+  Block *thenBody = op.getThenBody(), *elseBody = op.getElseBody();
+  return isa<OpTy>(thenBody->front()) && isa<OpTy>(elseBody->front());
+}
+
+///                                         seq {
+///   if %a with @G {                         if %a with @G {
+///     seq { ... calyx.enable @A }             seq { ... }
+///   else {                          ->      } else {
+///     seq { ... calyx.enable @A }             seq { ... }
+///   }                                       }
+///                                           calyx.enable @A
+///
+struct CommonTailPatternWithSeq : mlir::OpRewritePattern<IfOp> {
   using mlir::OpRewritePattern<IfOp>::OpRewritePattern;
 
   LogicalResult matchAndRewrite(IfOp ifOp,
                                 PatternRewriter &rewriter) const override {
-    if (!ifOp.thenBodyExists() || !ifOp.elseBodyExists())
+    if (!hasCommonTailPatternPreConditions<SeqOp>(ifOp))
       return failure();
+
+    auto thenControl = cast<SeqOp>(ifOp.getThenBody()->front()),
+         elseControl = cast<SeqOp>(ifOp.getElseBody()->front());
+    EnableOp lastThenEnableOp = getLastEnableOp(thenControl),
+             lastElseEnableOp = getLastEnableOp(elseControl);
+
+    if (lastThenEnableOp == nullptr || lastElseEnableOp == nullptr)
+      return failure();
+    if (lastThenEnableOp.groupName() != lastElseEnableOp.groupName())
+      return failure();
+
+    // Place the IfOp and pulled EnableOp inside a sequential region, in case
+    // this IfOp is nested in a ParOp. This avoids unintentionally
+    // parallelizing the pulled out EnableOps.
     rewriter.setInsertionPointAfter(ifOp);
-    auto &thenControl = ifOp.getThenBody()->front();
-    auto &elseControl = ifOp.getElseBody()->front();
+    SeqOp seqOp = rewriter.create<SeqOp>(ifOp.getLoc());
+    rewriter.createBlock(&seqOp.getBodyRegion());
+    Block *body = seqOp.getBody();
+    ifOp->remove();
+    body->push_back(ifOp);
+    rewriter.create<EnableOp>(seqOp.getLoc(), lastThenEnableOp.groupName());
 
-    // We only look for two cases: (1) both regions are ParOps, and
-    // (2) both regions are SeqOps. The case when these are different, e.g.
-    // ParOp and SeqOp, will only produce less optimal code, or even worse,
-    // change the behavior.
-    if (auto r1 = dyn_cast<ParOp>(thenControl);
-        auto r2 = dyn_cast<ParOp>(elseControl)) {
-      //    if %a with @G {              par {
-      //      par {                        if %a with @G {
-      //        ...                          par { ... }
-      //        calyx.enable @A            } else {
-      //        calyx.enable @B    ->        par { ... }
-      //      }                            }
-      //    } else {                       calyx.enable @A
-      //      par {                        calyx.enable @B
-      //        ...                      }
-      //        calyx.enable @A
-      //        calyx.enable @B
-      //      }
-      //    }
-      llvm::StringMap<EnableOp> A = getAllEnableOpsInImmediateBody(r1),
-                                B = getAllEnableOpsInImmediateBody(r2);
+    // Erase the common EnableOp from the Then and Else regions.
+    rewriter.eraseOp(lastThenEnableOp);
+    rewriter.eraseOp(lastElseEnableOp);
+    return success();
+  }
+};
 
-      // Compute the intersection between `A` and `B`.
-      SmallVector<StringRef> groupNames;
-      for (auto a = A.begin(); a != A.end(); ++a) {
-        StringRef groupName = a->getKey();
-        auto b = B.find(groupName);
-        if (b == B.end())
-          continue;
-        // This is also an element in B.
-        groupNames.push_back(groupName);
-        // Since these are being pulled out, erase them.
-        rewriter.eraseOp(a->getValue());
-        rewriter.eraseOp(b->getValue());
-      }
-      // Place the IfOp and EnableOp(s) inside a parallel region, in case this
-      // IfOp is nested in a SeqOp. This avoids unintentionally sequentializing
-      // the pulled out EnableOps.
-      ParOp parOp = rewriter.create<ParOp>(ifOp.getLoc());
-      rewriter.createBlock(&parOp.getBodyRegion());
-      Block *body = parOp.getBody();
-      ifOp->remove();
-      body->push_back(ifOp);
+///    if %a with @G {              par {
+///      par {                        if %a with @G {
+///        ...                          par { ... }
+///        calyx.enable @A            } else {
+///        calyx.enable @B    ->        par { ... }
+///      }                            }
+///    } else {                       calyx.enable @A
+///      par {                        calyx.enable @B
+///        ...                      }
+///        calyx.enable @A
+///        calyx.enable @B
+///      }
+///    }
+struct CommonTailPatternWithPar : mlir::OpRewritePattern<IfOp> {
+  using mlir::OpRewritePattern<IfOp>::OpRewritePattern;
 
-      // Pull out the intersection between these two sets, and erase their
-      // counterparts in the Then and Else regions.
-      for (StringRef groupName : groupNames)
-        rewriter.create<EnableOp>(parOp.getLoc(), groupName);
+  LogicalResult matchAndRewrite(IfOp ifOp,
+                                PatternRewriter &rewriter) const override {
+    if (!hasCommonTailPatternPreConditions<ParOp>(ifOp))
+      return failure();
+    auto thenControl = cast<ParOp>(ifOp.getThenBody()->front()),
+         elseControl = cast<ParOp>(ifOp.getElseBody()->front());
 
-      return success();
-    } else if (auto r1 = dyn_cast<SeqOp>(thenControl);
-               auto r2 = dyn_cast<SeqOp>(elseControl)) {
-      //                                         seq {
-      //   if %a with @G {                         if %a with @G {
-      //     seq { ... calyx.enable @A }             seq { ... }
-      //   else {                          ->      } else {
-      //     seq { ... calyx.enable @A }             seq { ... }
-      //   }                                       }
-      //                                           calyx.enable @A
-      //                                         }
-      EnableOp lastThenEnableOp = getLastEnableOp(r1),
-               lastElseEnableOp = getLastEnableOp(r2);
+    llvm::StringMap<EnableOp> A = getAllEnableOpsInImmediateBody(thenControl),
+                              B = getAllEnableOpsInImmediateBody(elseControl);
 
-      if (lastThenEnableOp == nullptr || lastElseEnableOp == nullptr)
-        return failure();
-      if (lastThenEnableOp.groupName() != lastElseEnableOp.groupName())
-        return failure();
-
-      // Place the IfOp and pulled EnableOp inside a sequential region, in case
-      // this IfOp is nested in a ParOp. This avoids unintentionally
-      // parallelizing the pulled out EnableOps.
-      SeqOp seqOp = rewriter.create<SeqOp>(ifOp.getLoc());
-      rewriter.createBlock(&seqOp.getBodyRegion());
-      Block *body = seqOp.getBody();
-      ifOp->remove();
-      body->push_back(ifOp);
-      rewriter.create<EnableOp>(seqOp.getLoc(), lastThenEnableOp.groupName());
-
-      // Erase the common EnableOp from the Then and Else regions.
-      rewriter.eraseOp(lastThenEnableOp);
-      rewriter.eraseOp(lastElseEnableOp);
-      return success();
+    // Compute the intersection between `A` and `B`.
+    SmallVector<StringRef> groupNames;
+    for (auto a = A.begin(); a != A.end(); ++a) {
+      StringRef groupName = a->getKey();
+      auto b = B.find(groupName);
+      if (b == B.end())
+        continue;
+      // This is also an element in B.
+      groupNames.push_back(groupName);
+      // Since these are being pulled out, erase them.
+      rewriter.eraseOp(a->getValue());
+      rewriter.eraseOp(b->getValue());
     }
+    // Place the IfOp and EnableOp(s) inside a parallel region, in case this
+    // IfOp is nested in a SeqOp. This avoids unintentionally sequentializing
+    // the pulled out EnableOps.
+    rewriter.setInsertionPointAfter(ifOp);
+    ParOp parOp = rewriter.create<ParOp>(ifOp.getLoc());
+    rewriter.createBlock(&parOp.getBodyRegion());
+    Block *body = parOp.getBody();
+    ifOp->remove();
+    body->push_back(ifOp);
 
-    return failure();
+    // Pull out the intersection between these two sets, and erase their
+    // counterparts in the Then and Else regions.
+    for (StringRef groupName : groupNames)
+      rewriter.create<EnableOp>(parOp.getLoc(), groupName);
+
+    return success();
   }
 };
 
 void IfOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
                                        MLIRContext *context) {
-  patterns.add<CommonIfTailPattern>(context);
+  patterns.add<CommonTailPatternWithSeq, CommonTailPatternWithPar>(context);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -1453,7 +1453,7 @@ static bool hasCommonTailPatternPreConditions(IfOp op) {
 ///     seq { ... calyx.enable @A }             seq { ... }
 ///   }                                       }
 ///                                           calyx.enable @A
-///
+///                                         }
 struct CommonTailPatternWithSeq : mlir::OpRewritePattern<IfOp> {
   using mlir::OpRewritePattern<IfOp>::OpRewritePattern;
 

--- a/test/Dialect/Calyx/canonicalization.mlir
+++ b/test/Dialect/Calyx/canonicalization.mlir
@@ -54,7 +54,7 @@ calyx.program "main" {
   }
 }
 
-// IfOp removes common tails from within SeqOps.
+// IfOp nested in SeqOp removes common tail from within SeqOps.
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
@@ -87,7 +87,7 @@ calyx.program "main" {
     // CHECK-NEXT:        calyx.seq {
     // CHECK-NEXT:          calyx.enable @B
     // CHECK-NEXT:        }
-    // CHECK-NEXT:      else {
+    // CHECK-NEXT:      } else {
     // CHECK-NEXT:        calyx.seq {
     // CHECK-NEXT:          calyx.enable @C
     // CHECK-NEXT:        }
@@ -106,6 +106,205 @@ calyx.program "main" {
           calyx.seq {
             calyx.enable @C
             calyx.enable @A
+          }
+        }
+      }
+    }
+  }
+}
+
+// IfOp nested in ParOp removes common tails from within ParOps.
+calyx.program "main" {
+  calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
+    %eq.left, %eq.right, %eq.out = calyx.std_eq "eq" : i1, i1, i1
+    %c1_1 = hw.constant 1 : i1
+    calyx.wires {
+      calyx.comb_group @Cond {
+        calyx.assign %eq.left =  %c1_1 : i1
+        calyx.assign %eq.right = %c1_1 : i1
+      }
+      calyx.group @A {
+        calyx.assign %r.in = %c1_1 : i1
+        calyx.assign %r.write_en = %c1_1 : i1
+        calyx.group_done %r.done : i1
+      }
+      calyx.group @B {
+        calyx.assign %r.in = %c1_1 : i1
+        calyx.assign %r.write_en = %c1_1 : i1
+        calyx.group_done %r.done : i1
+      }
+      calyx.group @C {
+        calyx.assign %r.in = %c1_1 : i1
+        calyx.assign %r.write_en = %c1_1 : i1
+        calyx.group_done %r.done : i1
+      }
+      calyx.group @D {
+        calyx.assign %r.in = %c1_1 : i1
+        calyx.assign %r.write_en = %c1_1 : i1
+        calyx.group_done %r.done : i1
+      }
+    }
+    // CHECK-LABEL: calyx.control {
+    // CHECK-NEXT:    calyx.par {
+    // CHECK-NEXT:      calyx.if %eq.out with @Cond {
+    // CHECK-NEXT:        calyx.par {
+    // CHECK-NEXT:          calyx.enable @A
+    // CHECK-NEXT:        }
+    // CHECK-NEXT:      } else {
+    // CHECK-NEXT:        calyx.par {
+    // CHECK-NEXT:          calyx.enable @B
+    // CHECK-NEXT:        }
+    // CHECK-NEXT:     }
+    // CHECK-NEXT:     calyx.enable @C
+    // CHECK-NEXT:     calyx.enable @D
+    // CHECK-NEXT:   }
+    // CHECK-NEXT: }
+    calyx.control {
+      calyx.par {
+        calyx.if %eq.out with @Cond {
+          calyx.par {
+            calyx.enable @A
+            calyx.enable @C
+            calyx.enable @D
+          }
+        } else {
+          calyx.par {
+            calyx.enable @B
+            calyx.enable @C
+            calyx.enable @D
+          }
+        }
+      }
+    }
+  }
+}
+
+// IfOp nested in ParOp removes common tail from within SeqOps. The important check
+// here is ensuring the removed EnableOps are still computed sequentially.
+calyx.program "main" {
+  calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
+    %eq.left, %eq.right, %eq.out = calyx.std_eq "eq" : i1, i1, i1
+    %c1_1 = hw.constant 1 : i1
+    calyx.wires {
+      calyx.comb_group @Cond {
+        calyx.assign %eq.left =  %c1_1 : i1
+        calyx.assign %eq.right = %c1_1 : i1
+      }
+      calyx.group @A {
+        calyx.assign %r.in = %c1_1 : i1
+        calyx.assign %r.write_en = %c1_1 : i1
+        calyx.group_done %r.done : i1
+      }
+      calyx.group @B {
+        calyx.assign %r.in = %c1_1 : i1
+        calyx.assign %r.write_en = %c1_1 : i1
+        calyx.group_done %r.done : i1
+      }
+      calyx.group @C {
+        calyx.assign %r.in = %c1_1 : i1
+        calyx.assign %r.write_en = %c1_1 : i1
+        calyx.group_done %r.done : i1
+      }
+    }
+    // CHECK-LABEL: calyx.control {
+    // CHECK-NEXT:    calyx.par {
+    // CHECK-NEXT:      calyx.seq {
+    // CHECK-NEXT:        calyx.if %eq.out with @Cond {
+    // CHECK-NEXT:          calyx.seq {
+    // CHECK-NEXT:            calyx.enable @B
+    // CHECK-NEXT:          }
+    // CHECK-NEXT:        } else {
+    // CHECK-NEXT:          calyx.seq {
+    // CHECK-NEXT:            calyx.enable @C
+    // CHECK-NEXT:          }
+    // CHECK-NEXT:        }
+    // CHECK-NEXT:        calyx.enable @A
+    // CHECK-NEXT:      }
+    // CHECK-NEXT:    }
+    // CHECK-NEXT:  }
+    calyx.control {
+      calyx.par {
+        calyx.if %eq.out with @Cond {
+          calyx.seq {
+            calyx.enable @B
+            calyx.enable @A
+          }
+        } else {
+          calyx.seq {
+            calyx.enable @C
+            calyx.enable @A
+          }
+        }
+      }
+    }
+  }
+}
+
+// IfOp nested in SeqOp removes common tail from within ParOps. The important check
+// here is ensuring the removed EnableOps are still computed in parallel.
+calyx.program "main" {
+  calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
+    %eq.left, %eq.right, %eq.out = calyx.std_eq "eq" : i1, i1, i1
+    %c1_1 = hw.constant 1 : i1
+    calyx.wires {
+      calyx.comb_group @Cond {
+        calyx.assign %eq.left =  %c1_1 : i1
+        calyx.assign %eq.right = %c1_1 : i1
+      }
+      calyx.group @A {
+        calyx.assign %r.in = %c1_1 : i1
+        calyx.assign %r.write_en = %c1_1 : i1
+        calyx.group_done %r.done : i1
+      }
+      calyx.group @B {
+        calyx.assign %r.in = %c1_1 : i1
+        calyx.assign %r.write_en = %c1_1 : i1
+        calyx.group_done %r.done : i1
+      }
+      calyx.group @C {
+        calyx.assign %r.in = %c1_1 : i1
+        calyx.assign %r.write_en = %c1_1 : i1
+        calyx.group_done %r.done : i1
+      }
+      calyx.group @D {
+        calyx.assign %r.in = %c1_1 : i1
+        calyx.assign %r.write_en = %c1_1 : i1
+        calyx.group_done %r.done : i1
+      }
+    }
+    // CHECK-LABEL: calyx.control {
+    // CHECK-NEXT:    calyx.seq {
+    // CHECK-NEXT:      calyx.par {
+    // CHECK-NEXT:        calyx.if %eq.out with @Cond {
+    // CHECK-NEXT:          calyx.par {
+    // CHECK-NEXT:            calyx.enable @A
+    // CHECK-NEXT:          }
+    // CHECK-NEXT:        } else {
+    // CHECK-NEXT:          calyx.par {
+    // CHECK-NEXT:            calyx.enable @B
+    // CHECK-NEXT:          }
+    // CHECK-NEXT:        }
+    // CHECK-NEXT:        calyx.enable @C
+    // CHECK-NEXT:        calyx.enable @D
+    // CHECK-NEXT:      }
+    // CHECK-NEXT:    }
+    // CHECK-NEXT:  }
+    calyx.control {
+      calyx.seq {
+        calyx.if %eq.out with @Cond {
+          calyx.par {
+            calyx.enable @A
+            calyx.enable @C
+            calyx.enable @D
+          }
+        } else {
+          calyx.par {
+            calyx.enable @B
+            calyx.enable @C
+            calyx.enable @D
           }
         }
       }


### PR DESCRIPTION
This adds a pattern for when `then` and `else` regions are both `ParOp`s. It also takes into consideration the parent region of the `IfOp`, since we don't want to unintentionally change the behavior when pulling out `EnableOp`s. 

I also do not touch anything that's not immediately within the given `ParOp`'s body; doing so may also change the behavior of the program.

The case where the `then` and `else` regions are different, e.g. `SeqOp` and  `ParOp`, should never pull out an `EnableOp`; it will always produce worse code, e.g.
```mlir
calyx.seq {
  calyx.if {
    calyx.par { ... calyx.enable @A }
  } else {
    calyx.seq { ... calyx.enable @A } 
  }
}

// Choice A: Place it in a SeqOp.
calyx.seq {
  calyx.if {
    calyx.par { ... }
  } else {
    calyx.seq { ... } 
  }
  calyx.enable @A // Now, it is no longer parallelized for the `then` region.
}

// Choice B: Place it in a ParOp.
calyx.seq {
  calyx.par {
    calyx.if {
      calyx.par { ... }
    } else {
      calyx.seq { ... } 
    }
    calyx.enable @A  // This is just plain wrong.
  } 
}
```

Closes #1861.