### PR TITLE
[SCFToCalyx] Add support for `memref` function arguments

### DIFF
--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -1083,7 +1083,7 @@ public:
         pls.compLoweringState(assignOp->getParentOfType<calyx::ComponentOp>());
 
     auto dest = assignOp.dest();
-    if (state.isInputPortOfMemory(dest).hasValue())
+    if (!state.isInputPortOfMemory(dest).hasValue())
       return success();
 
     auto src = assignOp.src();
@@ -1457,7 +1457,7 @@ class BuildReturnRegs : public FuncOpPartialLoweringPattern {
           funcOp->getLoc(),
           getComponentOutput(
               *getComponent(),
-              getComponentState().getFuncOpResultMapping(argTypeIt.index())),
+              getComponentState().getFuncOpResultMapping(argType.index())),
           reg.out());
     }
     return success();
@@ -2113,6 +2113,8 @@ void SCFToCalyxPass::runOnOperation() {
     signalPassFailure();
     return;
   }
+
+  getOperation().dump();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -375,7 +375,7 @@ public:
   }
 
   /// If v is an input to any memory registered within this component, returns
-  /// a pointer to said memory. If not, returns null.
+  /// the memory. If not, returns null.
   Optional<CalyxMemoryInterface> isInputPortOfMemory(Value v) {
     for (auto &memIf : memories) {
       auto &mem = memIf.getSecond();
@@ -1245,7 +1245,7 @@ struct FuncOpConversion : public FuncOpPartialLoweringPattern {
     DenseMap<unsigned, unsigned> funcOpResultMapping;
 
     /// Maintain a mapping between an external memory argument (identified by a
-    /// memref) and eventual component input- and output port indicies that will
+    /// memref) and eventual component input- and output port indices that will
     /// map to the memory ports. The pair denotes the start index of the memory
     /// ports in the in- and output ports of the component. Ports are expected
     /// to be ordered in the same manner as they are added by
@@ -1284,7 +1284,7 @@ struct FuncOpConversion : public FuncOpPartialLoweringPattern {
           DictionaryAttr::get(rewriter.getContext(), {})});
     }
 
-    /// We've now recorded all necessary indicies. Merge in- and output ports
+    /// We've now recorded all necessary indices. Merge in- and output ports
     /// and add the required mandatory component ports.
     auto ports = inPorts;
     llvm::append_range(ports, outPorts);

--- a/test/Conversion/SCFToCalyx/convert_memory.mlir
+++ b/test/Conversion/SCFToCalyx/convert_memory.mlir
@@ -327,3 +327,129 @@ module {
     return %0 : index
   }
 }
+
+// -----
+
+// External memory store
+
+// CHECK:      module  {
+// CHECK-NEXT:   calyx.program "main"  {
+// CHECK:        calyx.component @main(%in0: i32, %ext_mem0_read_data: i32, %ext_mem0_done: i1, %in2: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%ext_mem0_write_data: i32, %ext_mem0_addr0: i8, %ext_mem0_write_en: i1, %done: i1 {done}) {
+// CHECK-DAG:        %true = hw.constant true
+// CHECK-DAG:        %std_slice_0.in, %std_slice_0.out = calyx.std_slice "std_slice_0" : i32, i8
+// CHECK-NEXT:       calyx.wires  {
+// CHECK-NEXT:         calyx.group @bb0_0  {
+// CHECK-NEXT:           calyx.assign %std_slice_0.in = %in2 : i32
+// CHECK-NEXT:           calyx.assign %ext_mem0_addr0 = %std_slice_0.out : i8
+// CHECK-NEXT:           calyx.assign %ext_mem0_write_data = %in0 : i32
+// CHECK-NEXT:           calyx.assign %ext_mem0_write_en = %true : i1
+// CHECK-NEXT:           calyx.group_done %ext_mem0_done : i1
+// CHECK-NEXT:         }
+// CHECK-NEXT:       }
+// CHECK-NEXT:       calyx.control  {
+// CHECK-NEXT:         calyx.seq  {
+// CHECK-NEXT:           calyx.enable @bb0_0
+// CHECK-NEXT:         }
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+module {
+  func @main(%arg0 : i32, %mem0 : memref<8xi32>, %i : index) {
+    memref.store %arg0, %mem0[%i] : memref<8xi32>
+    return
+  }
+}
+
+// -----
+
+// External memory load
+
+// CHECK:      module  {
+// CHECK-NEXT:   calyx.program "main"  {
+// CHECK:        calyx.component @main(%in0: i32, %ext_mem0_read_data: i32, %ext_mem0_done: i1, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%ext_mem0_write_data: i32, %ext_mem0_addr0: i8, %ext_mem0_write_en: i1, %out0: i32, %done: i1 {done}) {
+// CHECK:            %true = hw.constant true
+// CHECK:            %std_slice_0.in, %std_slice_0.out = calyx.std_slice "std_slice_0" : i32, i8
+// CHECK:            %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register "ret_arg0_reg" : i32, i1, i1, i1, i32, i1
+// CHECK-NEXT:       calyx.wires  {
+// CHECK-NEXT:         calyx.assign %out0 = %ret_arg0_reg.out : i32
+// CHECK-NEXT:         calyx.group @ret_assign_0  {
+// CHECK-NEXT:           calyx.assign %std_slice_0.in = %in0 : i32
+// CHECK-NEXT:           calyx.assign %ret_arg0_reg.in = %ext_mem0_read_data : i32
+// CHECK-NEXT:           calyx.assign %ret_arg0_reg.write_en = %true : i1
+// CHECK-NEXT:           calyx.assign %ext_mem0_addr0 = %std_slice_0.out : i8
+// CHECK-NEXT:           calyx.group_done %ret_arg0_reg.done : i1
+// CHECK-NEXT:         }
+// CHECK-NEXT:       }
+// CHECK-NEXT:       calyx.control  {
+// CHECK-NEXT:         calyx.seq  {
+// CHECK-NEXT:           calyx.enable @ret_assign_0
+// CHECK-NEXT:         }
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+module {
+  func @main(%i : index, %mem0 : memref<8xi32>) -> i32 {
+    %0 = memref.load %mem0[%i] : memref<8xi32>
+    return %0 : i32
+  }
+}
+
+// -----
+
+// External memory hazard
+
+// CHECK:      module  {
+// CHECK-NEXT:   calyx.program "main"  {
+// CHECK:        calyx.component @main(%in0: i32, %in1: i32, %ext_mem0_read_data: i32, %ext_mem0_done: i1, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%ext_mem0_write_data: i32, %ext_mem0_addr0: i8, %ext_mem0_write_en: i1, %out0: i32, %out1: i32, %done: i1 {done}) {
+// CHECK-DAG:        %true = hw.constant true
+// CHECK-DAG:        %std_slice_1.in, %std_slice_1.out = calyx.std_slice "std_slice_1" : i32, i8
+// CHECK-DAG:        %std_slice_0.in, %std_slice_0.out = calyx.std_slice "std_slice_0" : i32, i8
+// CHECK-DAG:        %load_1_reg.in, %load_1_reg.write_en, %load_1_reg.clk, %load_1_reg.reset, %load_1_reg.out, %load_1_reg.done = calyx.register "load_1_reg" : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %load_0_reg.in, %load_0_reg.write_en, %load_0_reg.clk, %load_0_reg.reset, %load_0_reg.out, %load_0_reg.done = calyx.register "load_0_reg" : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %ret_arg1_reg.in, %ret_arg1_reg.write_en, %ret_arg1_reg.clk, %ret_arg1_reg.reset, %ret_arg1_reg.out, %ret_arg1_reg.done = calyx.register "ret_arg1_reg" : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register "ret_arg0_reg" : i32, i1, i1, i1, i32, i1
+// CHECK-NEXT:       calyx.wires  {
+// CHECK-NEXT:         calyx.assign %out1 = %ret_arg1_reg.out : i32
+// CHECK-NEXT:         calyx.assign %out0 = %ret_arg0_reg.out : i32
+// CHECK-NEXT:         calyx.group @bb0_0  {
+// CHECK-NEXT:           calyx.assign %std_slice_1.in = %in0 : i32
+// CHECK-NEXT:           calyx.assign %ext_mem0_addr0 = %std_slice_1.out : i8
+// CHECK-NEXT:           calyx.assign %load_0_reg.in = %ext_mem0_read_data : i32
+// CHECK-NEXT:           calyx.assign %load_0_reg.write_en = %true : i1
+// CHECK-NEXT:           calyx.group_done %load_0_reg.done : i1
+// CHECK-NEXT:         }
+// CHECK-NEXT:         calyx.group @bb0_1  {
+// CHECK-NEXT:           calyx.assign %std_slice_0.in = %in1 : i32
+// CHECK-NEXT:           calyx.assign %ext_mem0_addr0 = %std_slice_0.out : i8
+// CHECK-NEXT:           calyx.assign %load_1_reg.in = %ext_mem0_read_data : i32
+// CHECK-NEXT:           calyx.assign %load_1_reg.write_en = %true : i1
+// CHECK-NEXT:           calyx.group_done %load_1_reg.done : i1
+// CHECK-NEXT:         }
+// CHECK-NEXT:         calyx.group @ret_assign_0  {
+// CHECK-NEXT:           calyx.assign %ret_arg0_reg.in = %load_0_reg.out : i32
+// CHECK-NEXT:           calyx.assign %ret_arg0_reg.write_en = %true : i1
+// CHECK-NEXT:           calyx.assign %ret_arg1_reg.in = %load_1_reg.out : i32
+// CHECK-NEXT:           calyx.assign %ret_arg1_reg.write_en = %true : i1
+// CHECK-NEXT:           %0 = comb.and %ret_arg0_reg.done, %ret_arg1_reg.done : i1
+// CHECK-NEXT:           calyx.group_done %0 ? %true : i1
+// CHECK-NEXT:         }
+// CHECK-NEXT:       }
+// CHECK-NEXT:       calyx.control  {
+// CHECK-NEXT:         calyx.seq  {
+// CHECK-NEXT:           calyx.enable @bb0_0
+// CHECK-NEXT:           calyx.enable @bb0_1
+// CHECK-NEXT:           calyx.enable @ret_assign_0
+// CHECK-NEXT:         }
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+module {
+  func @main(%i0 : index, %i1 : index, %mem0 : memref<8xi32>) -> (i32, i32) {
+    %0 = memref.load %mem0[%i0] : memref<8xi32>
+    %1 = memref.load %mem0[%i1] : memref<8xi32>
+    return %0, %1 : i32, i32
+  }
+}

--- a/test/Conversion/SCFToCalyx/convert_memory.mlir
+++ b/test/Conversion/SCFToCalyx/convert_memory.mlir
@@ -330,7 +330,7 @@ module {
 
 // -----
 
-// External memory store
+// External memory store.
 
 // CHECK:      module  {
 // CHECK-NEXT:   calyx.program "main"  {
@@ -363,7 +363,7 @@ module {
 
 // -----
 
-// External memory load
+// External memory load.
 
 // CHECK:      module  {
 // CHECK-NEXT:   calyx.program "main"  {
@@ -398,7 +398,7 @@ module {
 
 // -----
 
-// External memory hazard
+// External memory hazard.
 
 // CHECK:      module  {
 // CHECK-NEXT:   calyx.program "main"  {


### PR DESCRIPTION
This commit adds support for `memref` function arguments. This should greatly expand the number of meaningful accelerators which we are able to generate through `SCFToCalyx`.
The signature of the top-level component is rewritten to include in- and output ports expected for the memory. These ports are written into a new `CalyxMemoryPorts` structure. This, alongside rewriting memory getter/setters to use `CalyxMemoryInterface` allows the external memories to be used like `calyx::MemoryOp`s within the remainder of the code.

The implementation assumes identical semantics for external memories as for Calyx memories, namely that reads are combinational.

Depends on #1896.