### PR TITLE
[FIRRTL] Fix use of invalidated iterators in InferResets

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -734,17 +734,19 @@ void InferResetsPass::traceResets(FIRRTLType dstType, Value dst, unsigned dstID,
 
       // If dst got merged into src, append dst's drives to src's, or vice
       // versa.
-      auto &unionDrives = resetDrives[unionLeader];
       if (dstLeader != srcLeader) {
+        ResetDrives otherDrives;
         if (unionLeader == dstLeader)
-          unionDrives.append(std::move(resetDrives[srcLeader]));
+          std::swap(otherDrives, resetDrives[srcLeader]);
         else
-          unionDrives.append(std::move(resetDrives[dstLeader]));
+          std::swap(otherDrives, resetDrives[dstLeader]);
+        resetDrives[unionLeader].append(std::move(otherDrives));
       }
 
       // Keep note of this drive so we can point the user at the right location
       // in case something goes wrong.
-      unionDrives.push_back({{dstField, dstType}, {srcField, srcType}, loc});
+      resetDrives[unionLeader].push_back(
+          {{dstField, dstType}, {srcField, srcType}, loc});
     }
     return;
   }


### PR DESCRIPTION
Fix two issues in InferResets:

1.  References into a dense map that may get invalidated while being live by inserts being done into the map through subsequent accesses.
2.  Vectors being `std::move`d out of potentially multiple times. This is problematic because the move may leave an invalid vector behind which is no longer safe to access again. The fix properly uses a `std::swap` to move data out of the vector and leave an empty one behind.