### PR TITLE
[PyCDE] Use `System` to track raw CIRCT module ops

### DIFF
--- a/frontends/PyCDE/src/pycde/instance.py
+++ b/frontends/PyCDE/src/pycde/instance.py
@@ -86,7 +86,7 @@ class Instance:
 
       assert "moduleName" in op.attributes
       tgt_modname = ir.FlatSymbolRefAttr(op.attributes["moduleName"]).value
-      tgt_mod = self.sys._symbol_modules[tgt_modname].modcls
+      tgt_mod = self.sys._get_symbol_module(tgt_modname).modcls
       assert tgt_mod is not None
       inst = Instance(tgt_mod, op, self, self.sys)
       callback(inst)

--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -98,6 +98,10 @@ class System:
     if isinstance(op, circt.dialects.msft.MSFTModuleOp):
       self._generate_queue.append(spec_mod)
 
+  def _get_symbol_module(self, symbol):
+    """Get the _SpecializedModule for a symbol."""
+    return self._symbol_modules[symbol]
+
   def _get_module_symbol(self, spec_mod):
     """Get the symbol for a module or its associated _SpecializedModule."""
     if not isinstance(spec_mod, _SpecializedModule):

--- a/frontends/PyCDE/test/instances.py
+++ b/frontends/PyCDE/test/instances.py
@@ -41,11 +41,10 @@ t = pycde.System([Test])
 t.generate(["construct"])
 t.print()
 
-print(Test)
 Test.print()
+UnParameterized.print()
 
 t.run_passes()
-Test.print()
 
 # CHECK-LABEL: === Hierarchy
 print("=== Hierarchy")


### PR DESCRIPTION
Keep all the raw CIRCT module ops in `pycde.System`. Enables the same PyCDE
modules to be used multiple Systems (theoretically, unsupported/untested for
now). It is also the only class which runs CIRCT passes, so it knows when to
invalidate the symbol cache. The symbol cache is the only data structure which
holds CIRCT module ops. Increases memory safety.