### PR TITLE
[Calyx] [SCFToCalyx] Initialize bodies upon build.

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxControl.td
+++ b/include/circt/Dialect/Calyx/CalyxControl.td
@@ -32,6 +32,13 @@ def ControlOp : CalyxContainer<"control", [
     ```
   }];
   let verifier = "return ::verify$cppClass(*this);";
+  let skipDefaultBuilders = true;
+  let builders = [
+    OpBuilder<(ins), [{
+      Region* region = $_state.addRegion();
+      region->push_back(new Block());
+    }]>
+  ];
 }
 
 def IfOp : CalyxContainer<"if", [
@@ -94,6 +101,23 @@ def IfOp : CalyxContainer<"if", [
       return &getOperation()->getRegion(1).front();
     }
   }];
+  let skipDefaultBuilders = true;
+  let builders = [
+    OpBuilder<(ins
+      "Value":$cond,
+      CArg<"FlatSymbolRefAttr", "nullptr">:$groupName,
+      CArg<"bool", "false">:$initializeElseBody), [{
+        $_state.addOperands(cond);
+        if (groupName)
+          $_state.addAttribute("groupName", groupName);
+
+        Region *thenRegion = $_state.addRegion();
+        Region *elseRegion = $_state.addRegion();
+        thenRegion->push_back(new Block());
+        if (initializeElseBody)
+          elseRegion->push_back(new Block());
+    }]>
+  ];
 }
 
 def SeqOp : CalyxContainer<"seq", [
@@ -215,4 +239,18 @@ def WhileOp : CalyxContainer<"while", [
   let hasCanonicalizeMethod = true;
   let assemblyFormat = "$cond (`with` $groupName^)? $body attr-dict";
   let verifier = "return ::verify$cppClass(*this);";
+  let skipDefaultBuilders = true;
+  let builders = [
+    OpBuilder<(ins
+      "Value":$cond,
+      CArg<"FlatSymbolRefAttr", "nullptr">:$groupName), [{
+        $_state.addOperands(cond);
+        if (groupName)
+          $_state.addAttribute("groupName", groupName);
+
+        Region *body = $_state.addRegion();
+        body->push_back(new Block());
+    }]>
+  ];
+
 }

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -154,6 +154,13 @@ def WiresOp : CalyxContainer<"wires", [
       }
     ```
   }];
+  let skipDefaultBuilders = true;
+  let builders = [
+    OpBuilder<(ins), [{
+      Region* region = $_state.addRegion();
+      region->push_back(new Block());
+    }]>
+  ];
   let verifier = "return ::verify$cppClass(*this);";
 }
 
@@ -225,6 +232,22 @@ def GroupOp : CalyxOp<"group", [
 
   let regions = (region SizedRegion<1>:$body);
   let assemblyFormat = "$sym_name $body attr-dict";
+  let skipDefaultBuilders = true;
+  let builders = [
+    OpBuilder<(ins "StringRef":$sym_name), [{
+      $_state.addAttribute(
+        mlir::SymbolTable::getSymbolAttrName(),
+        StringAttr::get($_state.getContext(), sym_name)
+      );
+      Region* region = $_state.addRegion();
+      region->push_back(new Block());
+    }]>,
+    OpBuilder<(ins "StringAttr":$sym_name), [{
+      $_state.addAttribute(::mlir::SymbolTable::getSymbolAttrName(), sym_name);
+      Region* region = $_state.addRegion();
+      region->push_back(new Block());
+    }]>
+  ];
 }
 
 def CombGroupOp : CalyxOp<"comb_group", [
@@ -249,9 +272,7 @@ def CombGroupOp : CalyxOp<"comb_group", [
       }
     ```
   }];
-
   let arguments = (ins SymbolNameAttr: $sym_name);
-
   let extraClassDeclaration = [{
     // Implement RegionKindInterface.
     static RegionKind getRegionKind(unsigned index) { return RegionKind::Graph; }
@@ -260,6 +281,22 @@ def CombGroupOp : CalyxOp<"comb_group", [
   let regions = (region SizedRegion<1>:$body);
   let assemblyFormat = "$sym_name $body attr-dict";
   let verifier = "return ::verify$cppClass(*this);";
+  let skipDefaultBuilders = true;
+  let builders = [
+    OpBuilder<(ins "StringRef":$sym_name), [{
+      $_state.addAttribute(
+        mlir::SymbolTable::getSymbolAttrName(),
+        StringAttr::get($_state.getContext(), sym_name)
+      );
+      Region* region = $_state.addRegion();
+      region->push_back(new Block());
+    }]>,
+    OpBuilder<(ins "StringAttr":$sym_name), [{
+      $_state.addAttribute(::mlir::SymbolTable::getSymbolAttrName(), sym_name);
+      Region* region = $_state.addRegion();
+      region->push_back(new Block());
+    }]>
+  ];
 }
 
 def AssignOp : CalyxOp<"assign", [

--- a/lib/Dialect/Calyx/Transforms/CompileControl.cpp
+++ b/lib/Dialect/Calyx/Transforms/CompileControl.cpp
@@ -102,8 +102,6 @@ void CompileControlVisitor::visit(SeqOp seq, ComponentOp &component) {
   builder.setInsertionPointToEnd(wiresBody);
   auto seqGroup =
       builder.create<GroupOp>(wires->getLoc(), builder.getStringAttr("seq"));
-  Block *seqGroupBody = new Block();
-  seqGroup->getRegion(0).push_back(seqGroupBody);
 
   // Guarantees a unique SymbolName for the group.
   SymbolTable symTable(wires);
@@ -155,7 +153,7 @@ void CompileControlVisitor::visit(SeqOp seq, ComponentOp &component) {
     // Add guarded assignments to the fsm register `in` and `write_en` ports.
     fsmNextState =
         createConstant(builder, wires->getLoc(), fsmBitWidth, fsmIndex + 1);
-    builder.setInsertionPointToEnd(seqGroupBody);
+    builder.setInsertionPointToEnd(seqGroup.getBody());
     builder.create<AssignOp>(wires->getLoc(), fsmIn, fsmNextState,
                              groupDoneGuard);
     builder.create<AssignOp>(wires->getLoc(), fsmWriteEn, oneConstant,
@@ -171,7 +169,7 @@ void CompileControlVisitor::visit(SeqOp seq, ComponentOp &component) {
       wires->getLoc(), comb::ICmpPredicate::eq, fsmOut, fsmNextState);
 
   // Insert the respective GroupDoneOp.
-  builder.setInsertionPointToEnd(seqGroupBody);
+  builder.setInsertionPointToEnd(seqGroup.getBody());
   builder.create<GroupDoneOp>(seqGroup->getLoc(), oneConstant, isFinalState);
 
   // Add continuous wires to reset the `in` and `write_en` ports of the fsm


### PR DESCRIPTION
Adds builders to initialize bodies for `IfOp`, `WhileOp`, `CombGroupOp`, `GroupOp`, `WiresOp`, and `ControlOp`. This also removes their default builders, since it would be odd to want a Calyx container without a body. The rest is necessary clean-up in SCFToCalyx and CompileControl. Closes #1884.