### PR TITLE
Object Model 2.0, Part 1: Read in OM 2.0

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRParser.h
+++ b/include/circt/Dialect/FIRRTL/FIRParser.h
@@ -14,14 +14,15 @@
 #ifndef CIRCT_DIALECT_FIRRTL_FIRPARSER_H
 #define CIRCT_DIALECT_FIRRTL_FIRPARSER_H
 
+#include "circt/Support/LLVM.h"
+
 namespace llvm {
 class SourceMgr;
 }
 
 namespace mlir {
-class MLIRContext;
-class OwningModuleRef;
-} // namespace mlir
+class LocationAttr;
+}
 
 namespace circt {
 namespace firrtl {
@@ -38,6 +39,25 @@ struct FIRParserOptions {
 mlir::OwningModuleRef importFIRFile(llvm::SourceMgr &sourceMgr,
                                     mlir::MLIRContext *context,
                                     FIRParserOptions options = {});
+
+// Decode a source locator string `spelling`, returning a pair indicating that
+// the the `spelling` was correct and an optional location attribute.  The
+// `skipParsing` option can be used to short-circuit parsing and just do
+// validation of the `spelling`.  This require both an Identifier and a
+// FileLineColLoc to use for caching purposes and context as the cache may be
+// updated with a new identifier.
+//
+// This utility exists because source locators can exist outside of normal
+// "parsing".  E.g., these can show up in annotations or in Object Model 2.0
+// JSON.
+//
+// TODO: This API is super wacky and should be streamlined to hide the
+// caching.
+std::pair<bool, llvm::Optional<mlir::LocationAttr>>
+maybeStringToLocation(llvm::StringRef spelling, bool skipParsing,
+                      mlir::Identifier &locatorFilenameCache,
+                      FileLineColLoc &fileLineColLocCache,
+                      MLIRContext *context);
 
 void registerFromFIRFileTranslation();
 

--- a/include/circt/Dialect/FIRRTL/FIRParser.h
+++ b/include/circt/Dialect/FIRRTL/FIRParser.h
@@ -34,6 +34,10 @@ struct FIRParserOptions {
   /// If this is set to true, the annotations are just attached to the circuit
   /// and not scattered or processed.
   bool rawAnnotations = false;
+  /// The number of annotation files that were specified on the command line.
+  /// This, along with numOMIRFiles provides structure to the buffers in the
+  /// source manager.
+  unsigned numAnnotationFiles;
 };
 
 mlir::OwningModuleRef importFIRFile(llvm::SourceMgr &sourceMgr,

--- a/lib/Dialect/FIRRTL/Import/FIRAnnotations.h
+++ b/lib/Dialect/FIRRTL/Import/FIRAnnotations.h
@@ -36,6 +36,10 @@ bool fromJSON(llvm::json::Value &value, StringRef circuitTarget,
               llvm::StringMap<ArrayAttr> &annotationMap, llvm::json::Path path,
               CircuitOp circuit, size_t &nlaNumber);
 
+bool fromOMIRJSON(llvm::json::Value &value, StringRef circuitTarget,
+                  llvm::StringMap<ArrayAttr> &annotationMap,
+                  llvm::json::Path path, CircuitOp circuit);
+
 bool scatterCustomAnnotations(llvm::StringMap<ArrayAttr> &annotationMap,
                               CircuitOp circuit, unsigned &annotationID,
                               Location loc, size_t &nlaNumber);

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3079,6 +3079,11 @@ private:
   ParseResult importAnnotationsRaw(SMLoc loc, StringRef circuitTarget,
                                    StringRef annotationsStr,
                                    SmallVector<Attribute> &attrs);
+  /// Generate OMIR-derived annotations.  Report errors if the OMIR is malformed
+  /// in any way.  This also performs scattering of the OMIR to introduce
+  /// tracking annotations in the circuit.
+  ParseResult importOMIR(CircuitOp circuit, SMLoc loc, StringRef circuitTarget,
+                         StringRef omirStr, size_t &nlaNumber);
 
   ParseResult parseModule(CircuitOp circuit, StringRef circuitTarget,
                           unsigned indent);
@@ -3168,6 +3173,53 @@ ParseResult FIRCircuitParser::importAnnotations(CircuitOp circuit, SMLoc loc,
   if (!scatterCustomAnnotations(thisAnnotationMap, circuit, annotationID,
                                 translateLocation(loc), nlaNumber))
     return failure();
+
+  // Merge the attributes we just parsed into the global set we're accumulating.
+  llvm::StringMap<ArrayAttr> &resultAnnoMap = getConstants().annotationMap;
+  for (auto &thisEntry : thisAnnotationMap) {
+    auto &existing = resultAnnoMap[thisEntry.getKey()];
+    if (!existing) {
+      existing = thisEntry.getValue();
+      continue;
+    }
+
+    SmallVector<Attribute> annotationVec(existing.begin(), existing.end());
+    annotationVec.append(thisEntry.getValue().begin(),
+                         thisEntry.getValue().end());
+    existing = ArrayAttr::get(getContext(), annotationVec);
+  }
+
+  return success();
+}
+
+ParseResult FIRCircuitParser::importOMIR(CircuitOp circuit, SMLoc loc,
+                                         StringRef circuitTarget,
+                                         StringRef annotationsStr,
+                                         size_t &nlaNumber) {
+
+  auto annotations = json::parse(annotationsStr);
+  if (auto err = annotations.takeError()) {
+    handleAllErrors(std::move(err), [&](const json::ParseError &a) {
+      auto diag = emitError(loc, "Failed to parse OMIR file");
+      diag.attachNote() << a.message();
+    });
+    return failure();
+  }
+
+  json::Path::Root root;
+  llvm::StringMap<ArrayAttr> thisAnnotationMap;
+  if (!fromOMIRJSON(annotations.get(), circuitTarget, thisAnnotationMap, root,
+                    circuit)) {
+    auto diag = emitError(loc, "Invalid/unsupported OMIR format");
+    std::string jsonErrorMessage =
+        "See inline comments for problem area in JSON:\n";
+    llvm::raw_string_ostream s(jsonErrorMessage);
+    root.printErrorContext(annotations.get(), s);
+    diag.attachNote() << jsonErrorMessage;
+    return failure();
+  }
+
+  // TODO: Scatter OMIR trackers.
 
   // Merge the attributes we just parsed into the global set we're accumulating.
   llvm::StringMap<ArrayAttr> &resultAnnoMap = getConstants().annotationMap;

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -4,6 +4,7 @@
 ; RUN: firtool %s --format=fir -mlir -lower-to-hw | circt-opt | FileCheck %s --check-prefix=MLIRLOWER
 ; RUN: firtool %s --format=fir -verilog |             FileCheck %s --check-prefix=VERILOG
 ; RUN: firtool %s --annotation-file %s.anno.json,%s.anno.1.json --mlir --parse-only | FileCheck %s --check-prefix=ANNOTATIONS
+; RUN: firtool %s --omir-file %s.omir.anno.json --parse-only | FileCheck %s --check-prefix=OMIR
 
 circuit test_mod : %[[{"a": "a"}]]
 
@@ -14,6 +15,18 @@ circuit test_mod : %[[{"a": "a"}]]
 ; ANNOTATIONS-SAME: info = "a NoTargetAnnotation"
 ; ANNOTATIONS-SAME: info = "a CircuitTarget Annotation
 ; ANNOTATIONS-SAME: info = "a CircuitName Annotation"
+
+; OMIR:       #loc0 = loc(fused["Foo.scala":64:64, "Bar.scala":128:128])
+; OMIR-NEXT:  #loc1 = loc("Foo.scala":32:32)
+; OMIR-LABEL: firrtl.circuit "test_mod"
+; OMIR-SAME:  {class = "freechips.rocketchip.objectmodel.OMIRAnnotation",
+; OMIR-SAME:   nodes = [
+; OMIR-SAME:     {fields = {
+; OMIR-SAME:        stringVal = {
+; OMIR-SAME:          info = #loc0,
+; OMIR-SAME:          value = "OMString:hello"}},
+; OMIR-SAME:      id = "OMID:0",
+; OMIR-SAME:      info = #loc1}]}
 
   module test_mod :
     input clock : Clock

--- a/test/firtool/firtool.fir.omir.anno.json
+++ b/test/firtool/firtool.fir.omir.anno.json
@@ -1,0 +1,13 @@
+[
+  {
+    "info": "@[Foo.scala 32:32]",
+    "id": "OMID:0",
+    "fields": [
+      {
+        "info": "@[Foo.scala 64:64 Bar.scala 128:128]",
+        "name": "stringVal",
+        "value": "OMString:hello"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This adds support for reading in Object Model 2.0 JSON via `firtool`.  This adds a `--omir-file <file>` option to `firtool` that will parse this into an `OMIRAnnotation` on the FIRRTL circuit. No further processing is done (no "tracker" annotations are scattered to things in the circuit).

This is just intended as preliminary support which (after landing scattering of trackers) will then enable some parallel hacking on OM 2.0 stuff.

### Background

For those who have never heard of this, OM 2.0 is the second incarnation of a mechanism that SiFive uses to add a graph of metadata to the circuit.  The graph consists of flat `OMNode`s (which here are represented as an `ArrayAttr`) which may include references to other nodes.  As this evolves in CIRCT, I expect that this will become a full-fledged dialect.  However, we're aiming to adopt the approach that the Scala FIRRTL Compiler uses to handle this data before moving to something more advanced.