### PR TITLE
[FIRRTLToHW] Lower vector types correctly. NFC.

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -72,6 +72,12 @@ static Type lowerType(Type type) {
     }
     return hw::StructType::get(type.getContext(), hwfields);
   }
+  if (FVectorType vec = firType.dyn_cast<FVectorType>()) {
+    auto elemTy = lowerType(vec.getElementType());
+    if (!elemTy)
+      return {};
+    return hw::ArrayType::get(elemTy, vec.getNumElements());
+  }
 
   auto width = firType.getBitWidthOrSentinel();
   if (width >= 0) // IntType, analog with known width, clock, etc.

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -145,10 +145,10 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: = sv.wire : !hw.inout<i2>
     %_t_1 = firrtl.wire : !firrtl.uint<2>
 
-    // CHECK-NEXT: = firrtl.wire : !firrtl.vector<uint<1>, 13>
+    // CHECK-NEXT: = sv.wire  : !hw.inout<array<13xi1>>
     %_t_2 = firrtl.wire : !firrtl.vector<uint<1>, 13>
 
-    // CHECK-NEXT: = firrtl.wire : !firrtl.vector<uint<2>, 13>
+    // CHECK-NEXT: = sv.wire  : !hw.inout<array<13xi2>>
     %_t_3 = firrtl.wire : !firrtl.vector<uint<2>, 13>
 
     // CHECK-NEXT: = comb.extract [[CONCAT1]] from 3 : (i8) -> i5


### PR DESCRIPTION
Lower `firttl::FVectorType` to `hw::ArrayType` in `LowerToHW` pass. 
It was leaking the `!firrtl.vector` types to the `hw` dialect.