### PR TITLE
[PyCDE] Move from returning output values to setting them

### DIFF
--- a/frontends/PyCDE/test/compreg.py
+++ b/frontends/PyCDE/test/compreg.py
@@ -14,9 +14,9 @@ class CompReg:
   output = Output(types.i8)
 
   @generator
-  def build(mod):
-    compreg = seq.CompRegOp.create(types.i8, clk=mod.clk, input=mod.input)
-    return {"output": compreg.data}
+  def build(ports):
+    compreg = seq.CompRegOp.create(types.i8, clk=ports.clk, input=ports.input)
+    ports.output = compreg.data
 
 
 mod = pycde.System([CompReg])

--- a/frontends/PyCDE/test/instances.py
+++ b/frontends/PyCDE/test/instances.py
@@ -20,7 +20,7 @@ class UnParameterized:
   @pycde.generator
   def construct(mod):
     Nothing()
-    return {"y": mod.x}
+    mod.y = mod.x
 
 
 @pycde.module

--- a/frontends/PyCDE/test/module_naming.py
+++ b/frontends/PyCDE/test/module_naming.py
@@ -12,8 +12,8 @@ def Parameterized(param):
     y = pycde.Output(pycde.types.i1)
 
     @pycde.generator
-    def construct(mod):
-      return {"y": mod.x}
+    def construct(ports):
+      ports.y = ports.x
 
   return TestModule
 
@@ -24,8 +24,8 @@ class UnParameterized:
   y = pycde.Output(pycde.types.i1)
 
   @pycde.generator
-  def construct(mod):
-    return {"y": mod.x}
+  def construct(ports):
+    ports.y = ports.x
 
 
 @pycde.module

--- a/frontends/PyCDE/test/polynomial.py
+++ b/frontends/PyCDE/test/polynomial.py
@@ -50,7 +50,7 @@ def PolynomialCompute(coefficients: Coefficients):
         taps.append(newPartialSum)
 
       # Final output
-      return {"y": taps[-1]}
+      mod.y = taps[-1]
 
   return PolynomialCompute
 
@@ -84,7 +84,7 @@ class PolynomialSystem:
   y = Output(types.i32)
 
   @generator
-  def construct(_):
+  def construct(ports):
     i32 = types.i32
     x = hw.ConstantOp.create(i32, 23)
     poly = PolynomialCompute(Coefficients([62, 42, 6]))("example")
@@ -99,7 +99,7 @@ class PolynomialSystem:
     m = ExternWithParams(8, 3)()
     m.name = "pexternInst"
 
-    return {"y": poly.y}
+    ports.y = poly.y
 
 
 poly = pycde.System([PolynomialSystem])

--- a/frontends/PyCDE/test/syntactic_sugar.py
+++ b/frontends/PyCDE/test/syntactic_sugar.py
@@ -10,8 +10,8 @@ class Taps:
   taps = Output(dim(8, 3))
 
   @generator
-  def build(mod):
-    return {"taps": [203, 100, 23]}
+  def build(ports):
+    ports.taps = [203, 100, 23]
 
 
 @externmodule
@@ -49,13 +49,13 @@ class ComplexPorts:
   c = Output(types.i32)
 
   @generator
-  def build(mod):
-    assert len(mod.data_in) == 3
-    return {
-        'a': mod.data_in[0].reg(mod.clk).reg(mod.clk),
-        'b': mod.data_in[mod.sel],
-        'c': mod.struct_data_in.foo[:-4]
-    }
+  def build(ports):
+    assert len(ports.data_in) == 3
+    ports.set_all_ports({
+        'a': ports.data_in[0].reg(ports.clk).reg(ports.clk),
+        'b': ports.data_in[ports.sel],
+        'c': ports.struct_data_in.foo[:-4]
+    })
 
 
 top = System([Top])

--- a/frontends/PyCDE/test/verilog_readablility.py
+++ b/frontends/PyCDE/test/verilog_readablility.py
@@ -13,14 +13,14 @@ class WireNames:
   b = Output(types.i32)
 
   @generator
-  def build(mod):
-    foo = mod.data_in[0]
+  def build(ports):
+    foo = ports.data_in[0]
     foo.name = "foo"
     arr_data = dim(32, 4).create([1, 2, 3, 4], "arr_data")
-    return {
-        'a': foo.reg(mod.clk).reg(mod.clk),
-        'b': arr_data[mod.sel],
-    }
+    ports.set_all_ports({
+        'a': foo.reg(ports.clk).reg(ports.clk),
+        'b': arr_data[ports.sel],
+    })
 
 
 sys = System([WireNames])


### PR DESCRIPTION
Adds a setter on the generator argument which sets the value of the output
port. Also provides a `set_all_ports` method for programatic access and easy
legacy conversion.

There are two advantages of this: (1) Symbolic port names vs. string port
names. (2) More importantly, exceptions are raised when the code tries to set an
output port value, which provides a traceback to the relevant line.