### PR TITLE
[LLVM] Bump LLVM and update parsers

### DIFF
--- a/lib/Dialect/ESI/ESITypes.cpp
+++ b/lib/Dialect/ESI/ESITypes.cpp
@@ -21,11 +21,11 @@
 using namespace circt;
 using namespace circt::esi;
 
-Type ChannelPort::parse(MLIRContext *ctxt, DialectAsmParser &p) {
+Type ChannelPort::parse(DialectAsmParser &p) {
   Type inner;
   if (p.parseLess() || p.parseType(inner) || p.parseGreater())
     return Type();
-  return get(ctxt, inner);
+  return get(p.getContext(), inner);
 }
 
 void ChannelPort::print(DialectAsmPrinter &p) const {
@@ -43,8 +43,7 @@ Type ESIDialect::parseType(DialectAsmParser &parser) const {
   if (parser.parseKeyword(&mnemonic))
     return Type();
   Type genType;
-  auto parseResult =
-      generatedTypeParser(getContext(), parser, mnemonic, genType);
+  auto parseResult = generatedTypeParser(parser, mnemonic, genType);
   if (parseResult.hasValue())
     return genType;
   parser.emitError(parser.getCurrentLocation(), "Could not parse esi.")

--- a/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
@@ -19,12 +19,11 @@ using namespace firrtl;
 #define GET_ATTRDEF_CLASSES
 #include "circt/Dialect/FIRRTL/FIRRTLAttributes.cpp.inc"
 
-Attribute InvalidValueAttr::parse(MLIRContext *ctxt, DialectAsmParser &p,
-                                  Type typeX) {
+Attribute InvalidValueAttr::parse(DialectAsmParser &p, Type typeX) {
   FIRRTLType type;
   if (p.parseLess() || p.parseType(type) || p.parseGreater())
     return Attribute();
-  return InvalidValueAttr::get(ctxt, type);
+  return InvalidValueAttr::get(p.getContext(), type);
 }
 
 void InvalidValueAttr::print(DialectAsmPrinter &p) const {
@@ -36,8 +35,7 @@ Attribute FIRRTLDialect::parseAttribute(DialectAsmParser &p, Type type) const {
   Attribute attr;
   if (p.parseKeyword(&attrName))
     return Attribute();
-  auto parseResult =
-      generatedAttributeParser(getContext(), p, attrName, type, attr);
+  auto parseResult = generatedAttributeParser(p, attrName, type, attr);
   if (parseResult.hasValue())
     return attr;
   p.emitError(p.getNameLoc(), "Unexpected FIRRTL attribute '" + attrName + "'");
@@ -54,8 +52,7 @@ void FIRRTLDialect::printAttribute(Attribute attr, DialectAsmPrinter &p) const {
 // SubAnnotationAttr
 //===----------------------------------------------------------------------===//
 
-Attribute SubAnnotationAttr::parse(MLIRContext *ctxt, DialectAsmParser &p,
-                                   Type type) {
+Attribute SubAnnotationAttr::parse(DialectAsmParser &p, Type type) {
   int64_t fieldID;
   DictionaryAttr annotations;
   StringRef fieldIDKeyword;
@@ -68,7 +65,7 @@ Attribute SubAnnotationAttr::parse(MLIRContext *ctxt, DialectAsmParser &p,
   if (fieldIDKeyword != "fieldID")
     return Attribute();
 
-  return SubAnnotationAttr::get(ctxt, fieldID, annotations);
+  return SubAnnotationAttr::get(p.getContext(), fieldID, annotations);
 }
 
 void SubAnnotationAttr::print(DialectAsmPrinter &p) const {

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -127,9 +127,9 @@ static ParseResult parseFIRRTLType(FIRRTLType &result,
 ///
 /// bundle-elt ::= identifier ':' type
 /// ```
-static OptionalParseResult customTypeParser(MLIRContext *context,
-                                            DialectAsmParser &parser,
+static OptionalParseResult customTypeParser(DialectAsmParser &parser,
                                             StringRef name, Type &result) {
+  auto *context = parser.getContext();
   if (name.equals("clock"))
     return result = ClockType::get(context), success();
   if (name.equals("reset"))
@@ -225,16 +225,15 @@ static OptionalParseResult customTypeParser(MLIRContext *context,
 /// refer to a type defined in this dialect.
 static ParseResult parseType(Type &result, StringRef name,
                              DialectAsmParser &parser) {
-  auto *context = parser.getBuilder().getContext();
   OptionalParseResult parseResult;
 
   // Try the generated type parser.
-  parseResult = generatedTypeParser(context, parser, name, result);
+  parseResult = generatedTypeParser(parser, name, result);
   if (parseResult.hasValue())
     return parseResult.getValue();
 
   // Try the custom type parser.
-  parseResult = customTypeParser(context, parser, name, result);
+  parseResult = customTypeParser(parser, name, result);
   if (parseResult.hasValue())
     return parseResult.getValue();
 
@@ -979,7 +978,7 @@ void CMemoryType::print(mlir::DialectAsmPrinter &printer) const {
   printer << ", " << getNumElements() << ">";
 }
 
-Type CMemoryType::parse(MLIRContext *context, DialectAsmParser &parser) {
+Type CMemoryType::parse(DialectAsmParser &parser) {
   FIRRTLType elementType;
   unsigned numElements;
   if (parser.parseLess() || parseFIRRTLType(elementType, parser) ||

--- a/lib/Dialect/FSM/FSMTypes.cpp
+++ b/lib/Dialect/FSM/FSMTypes.cpp
@@ -26,8 +26,7 @@ Type FSMDialect::parseType(DialectAsmParser &parser) const {
   if (parser.parseKeyword(&mnemonic))
     return Type();
   Type genType;
-  auto parseResult =
-      generatedTypeParser(getContext(), parser, mnemonic, genType);
+  auto parseResult = generatedTypeParser(parser, mnemonic, genType);
   if (parseResult.hasValue())
     return genType;
   parser.emitError(parser.getNameLoc(), "unknown FSM type: ") << mnemonic;

--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -162,8 +162,7 @@ static ParseResult parseHWElementType(Type &result, DialectAsmParser &p) {
     llvm::StringRef mnemonic;
     if (p.parseKeyword(&mnemonic))
       llvm_unreachable("should have an array or inout keyword here");
-    auto parseResult =
-        generatedTypeParser(p.getBuilder().getContext(), p, mnemonic, result);
+    auto parseResult = generatedTypeParser(p, mnemonic, result);
     return parseResult.hasValue() ? success() : failure();
   }
 
@@ -195,7 +194,7 @@ llvm::hash_code hash_value(const FieldInfo &fi) {
 
 /// Parse a list of field names and types within <>. E.g.:
 /// <foo: i7, bar: i8>
-static ParseResult parseFields(MLIRContext *ctxt, DialectAsmParser &p,
+static ParseResult parseFields(DialectAsmParser &p,
                                SmallVectorImpl<FieldInfo> &parameters) {
   StringRef name;
   if (p.parseLess())
@@ -222,11 +221,11 @@ static void printFields(DialectAsmPrinter &p, ArrayRef<FieldInfo> fields) {
   p << ">";
 }
 
-Type StructType::parse(MLIRContext *ctxt, DialectAsmParser &p) {
+Type StructType::parse(DialectAsmParser &p) {
   llvm::SmallVector<FieldInfo, 4> parameters;
-  if (parseFields(ctxt, p, parameters))
+  if (parseFields(p, parameters))
     return Type();
-  return get(ctxt, parameters);
+  return get(p.getContext(), parameters);
 }
 
 void StructType::print(DialectAsmPrinter &p) const {
@@ -250,11 +249,11 @@ void StructType::getInnerTypes(SmallVectorImpl<Type> &types) {
 // Union Type
 //===----------------------------------------------------------------------===//
 
-Type UnionType::parse(MLIRContext *ctxt, DialectAsmParser &p) {
+Type UnionType::parse(DialectAsmParser &p) {
   llvm::SmallVector<FieldInfo, 4> parameters;
-  if (parseFields(ctxt, p, parameters))
+  if (parseFields(p, parameters))
     return Type();
-  return get(ctxt, parameters);
+  return get(p.getContext(), parameters);
 }
 
 void UnionType::print(DialectAsmPrinter &p) const {
@@ -273,7 +272,7 @@ Type UnionType::getFieldType(mlir::StringRef fieldName) {
 // ArrayType
 //===----------------------------------------------------------------------===//
 
-Type ArrayType::parse(MLIRContext *ctxt, DialectAsmParser &p) {
+Type ArrayType::parse(DialectAsmParser &p) {
   SmallVector<int64_t, 2> dims;
   Type inner;
   if (p.parseLess() || p.parseDimensionList(dims, /* allowDynamic */ false) ||
@@ -289,7 +288,7 @@ Type ArrayType::parse(MLIRContext *ctxt, DialectAsmParser &p) {
                     dims[0])))
     return Type();
 
-  return get(ctxt, inner, dims[0]);
+  return get(p.getContext(), inner, dims[0]);
 }
 
 void ArrayType::print(DialectAsmPrinter &p) const {
@@ -309,7 +308,7 @@ LogicalResult ArrayType::verify(function_ref<InFlightDiagnostic()> emitError,
 // UnpackedArrayType
 //===----------------------------------------------------------------------===//
 
-Type UnpackedArrayType::parse(MLIRContext *ctxt, DialectAsmParser &p) {
+Type UnpackedArrayType::parse(DialectAsmParser &p) {
   SmallVector<int64_t, 2> dims;
   Type inner;
   if (p.parseLess() || p.parseDimensionList(dims, /* allowDynamic */ false) ||
@@ -326,7 +325,7 @@ Type UnpackedArrayType::parse(MLIRContext *ctxt, DialectAsmParser &p) {
                     dims[0])))
     return Type();
 
-  return get(ctxt, inner, dims[0]);
+  return get(p.getContext(), inner, dims[0]);
 }
 
 void UnpackedArrayType::print(DialectAsmPrinter &p) const {
@@ -347,7 +346,7 @@ UnpackedArrayType::verify(function_ref<InFlightDiagnostic()> emitError,
 // InOutType
 //===----------------------------------------------------------------------===//
 
-Type InOutType::parse(MLIRContext *ctxt, DialectAsmParser &p) {
+Type InOutType::parse(DialectAsmParser &p) {
   Type inner;
   if (p.parseLess() || parseHWElementType(inner, p) || p.parseGreater())
     return Type();
@@ -356,7 +355,7 @@ Type InOutType::parse(MLIRContext *ctxt, DialectAsmParser &p) {
   if (failed(verify(mlir::detail::getDefaultDiagnosticEmitFn(loc), inner)))
     return Type();
 
-  return get(ctxt, inner);
+  return get(p.getContext(), inner);
 }
 
 void InOutType::print(DialectAsmPrinter &p) const {
@@ -403,7 +402,7 @@ TypeAliasType TypeAliasType::get(SymbolRefAttr ref, Type innerType) {
   return get(ref.getContext(), ref, innerType, computeCanonicalType(innerType));
 }
 
-Type TypeAliasType::parse(MLIRContext *ctxt, DialectAsmParser &p) {
+Type TypeAliasType::parse(DialectAsmParser &p) {
   SymbolRefAttr ref;
   Type type;
   if (p.parseLess() || p.parseAttribute(ref) || p.parseComma() ||
@@ -448,7 +447,7 @@ Type HWDialect::parseType(DialectAsmParser &parser) const {
   if (parser.parseKeyword(&mnemonic))
     return Type();
   Type type;
-  auto parseResult = generatedTypeParser(getContext(), parser, mnemonic, type);
+  auto parseResult = generatedTypeParser(parser, mnemonic, type);
   if (parseResult.hasValue())
     return type;
   return Type();

--- a/lib/Dialect/LLHD/IR/LLHDTypes.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDTypes.cpp
@@ -53,10 +53,10 @@ static Type parseNestedType(DialectAsmParser &parser) {
 
 /// Parse a signal type.
 /// Syntax: sig ::= !llhd.sig<type>
-Type SigType::parse(MLIRContext *ctxt, DialectAsmParser &p) {
+Type SigType::parse(DialectAsmParser &p) {
   auto loc = p.getEncodedSourceLoc(p.getCurrentLocation());
-  return getChecked(mlir::detail::getDefaultDiagnosticEmitFn(loc), ctxt,
-                    parseNestedType(p));
+  return getChecked(mlir::detail::getDefaultDiagnosticEmitFn(loc),
+                    p.getContext(), parseNestedType(p));
 }
 
 void SigType::print(DialectAsmPrinter &p) const {
@@ -69,10 +69,10 @@ void SigType::print(DialectAsmPrinter &p) const {
 
 /// Parse a pointer type.
 /// Syntax: ptr ::= !llhd.ptr<type>
-Type PtrType::parse(MLIRContext *ctxt, DialectAsmParser &p) {
+Type PtrType::parse(DialectAsmParser &p) {
   auto loc = p.getEncodedSourceLoc(p.getCurrentLocation());
-  return getChecked(mlir::detail::getDefaultDiagnosticEmitFn(loc), ctxt,
-                    parseNestedType(p));
+  return getChecked(mlir::detail::getDefaultDiagnosticEmitFn(loc),
+                    p.getContext(), parseNestedType(p));
 }
 
 void PtrType::print(DialectAsmPrinter &p) const {
@@ -85,7 +85,7 @@ void PtrType::print(DialectAsmPrinter &p) const {
 
 /// Parse a time attribute.
 /// Syntax: timeattr ::= #llhd.time<[time][timeUnit], [delta]d, [epsilon]e>
-Attribute TimeAttr::parse(MLIRContext *ctxt, DialectAsmParser &p, Type type) {
+Attribute TimeAttr::parse(DialectAsmParser &p, Type type) {
   llvm::StringRef timeUnit;
   unsigned time = 0;
   unsigned delta = 0;
@@ -106,8 +106,8 @@ Attribute TimeAttr::parse(MLIRContext *ctxt, DialectAsmParser &p, Type type) {
 
   // return a new instance of time attribute
   auto loc = p.getEncodedSourceLoc(p.getCurrentLocation());
-  return getChecked(mlir::detail::getDefaultDiagnosticEmitFn(loc), ctxt, time,
-                    timeUnit, delta, eps);
+  return getChecked(mlir::detail::getDefaultDiagnosticEmitFn(loc),
+                    p.getContext(), time, timeUnit, delta, eps);
 }
 
 void TimeAttr::print(DialectAsmPrinter &p) const {
@@ -141,7 +141,7 @@ Type LLHDDialect::parseType(DialectAsmParser &parser) const {
     return {};
 
   Type type;
-  if (generatedTypeParser(getContext(), parser, mnemonic, type).hasValue())
+  if (generatedTypeParser(parser, mnemonic, type).hasValue())
     return type;
 
   emitError(parser.getEncodedSourceLoc(parser.getCurrentLocation()),
@@ -166,8 +166,7 @@ Attribute LLHDDialect::parseAttribute(DialectAsmParser &parser,
     return {};
 
   Attribute value;
-  if (generatedAttributeParser(getContext(), parser, mnemonic, type, value)
-          .hasValue())
+  if (generatedAttributeParser(parser, mnemonic, type, value).hasValue())
     return value;
 
   emitError(parser.getEncodedSourceLoc(parser.getCurrentLocation()),

--- a/lib/Dialect/SV/SVTypes.cpp
+++ b/lib/Dialect/SV/SVTypes.cpp
@@ -48,22 +48,22 @@ mlir::Type circt::sv::getInOutElementType(mlir::Type type) {
 // SV Interface type logic.
 //===----------------------------------------------------------------------===//
 
-Type InterfaceType::parse(MLIRContext *ctxt, DialectAsmParser &p) {
+Type InterfaceType::parse(DialectAsmParser &p) {
   FlatSymbolRefAttr iface;
   if (p.parseLess() || p.parseAttribute(iface) || p.parseGreater())
     return Type();
-  return get(ctxt, iface);
+  return get(p.getContext(), iface);
 }
 
 void InterfaceType::print(DialectAsmPrinter &p) const {
   p << "interface<" << getInterface() << ">";
 }
 
-Type ModportType::parse(MLIRContext *ctxt, DialectAsmParser &p) {
+Type ModportType::parse(DialectAsmParser &p) {
   SymbolRefAttr modPort;
   if (p.parseLess() || p.parseAttribute(modPort) || p.parseGreater())
     return Type();
-  return get(ctxt, modPort);
+  return get(p.getContext(), modPort);
 }
 
 void ModportType::print(DialectAsmPrinter &p) const {
@@ -85,7 +85,7 @@ Type SVDialect::parseType(DialectAsmParser &parser) const {
   if (parser.parseKeyword(&mnemonic))
     return Type();
   Type type;
-  auto parseResult = generatedTypeParser(getContext(), parser, mnemonic, type);
+  auto parseResult = generatedTypeParser(parser, mnemonic, type);
   if (parseResult.hasValue())
     return type;
   parser.emitError(loc, "Failed to parse type sv.") << mnemonic << "\n";


### PR DESCRIPTION
Parser functions no longer take an `mlir::MLIRContext *` parameter, so all existing parser functions required updating.
The MLIR parser change is [here](https://github.com/llvm/llvm-project/commit/fb093c83147e591991ffece79752ed80d3ff960a).