### PR TITLE
[Calyx] [SCFToCalyx] Change Cell instance name from StringAttr to FlatSymbolRefAttr.

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxInterfaces.td
+++ b/include/circt/Dialect/Calyx/CalyxInterfaces.td
@@ -72,7 +72,7 @@ def CellOpInterface : OpInterface<"CellInterface"> {
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
         Operation* op = (*static_cast<ConcreteOp *>($_op));
-        return op->getAttrOfType<mlir::StringAttr>("instanceName").getValue();
+        return op->getAttrOfType<mlir::FlatSymbolRefAttr>("instanceName").getValue();
       }]
     >,
     InterfaceMethod<

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -133,6 +133,13 @@ class CalyxLibraryOp<string mnemonic, list<OpTrait> traits = []> :
     This operation represents an instance of a Calyx library primitive.
     A library primitive maps to some hardware-implemented component within the
     native Calyx compiler.
+
+    ```mlir
+      // A 32-bit adder.
+      %add.left, %add.right, %add.out = calyx.std_add @add : i32, i32, i32
+      // A 8-bit comparison operator (with a 1-bit output).
+      %gt.left, %gt.right, %gt.out = calyx.std_gt @gt : i8, i8, i1
+    ```
   }];
 
   let arguments = (ins FlatSymbolRefAttr:$instanceName);

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -14,7 +14,7 @@
 class CalyxPrimitive<string mnemonic, list<OpTrait> traits = []> :
   CalyxCell<mnemonic, traits> {
     let assemblyFormat = "$instanceName attr-dict `:` type(results)";
-    let arguments = (ins StrAttr:$instanceName);
+    let arguments = (ins FlatSymbolRefAttr:$instanceName);
     let skipDefaultBuilders = 1;
 }
 
@@ -31,19 +31,19 @@ def RegisterOp : CalyxPrimitive<"register", [
     The "calyx.register" op defines a register.
     ```mlir
       // A 32-bit register.
-      %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i32, i1, i1, i1, i32, i1
+      %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i32, i1, i1, i1, i32, i1
     ```
   }];
   let results = (outs AnyType:$in, I1:$write_en, I1:$clk, I1:$reset, AnyType:$out, I1:$done);
   let builders = [
-    OpBuilder<(ins "StringAttr":$instanceName, "size_t":$width), [{
-      $_state.addAttribute("instanceName", instanceName);
+    OpBuilder<(ins "StringRef":$instanceName, "size_t":$width), [{
+      $_state.addAttribute("instanceName", FlatSymbolRefAttr::get($_builder.getContext(), instanceName));
       Type i1Type = $_builder.getI1Type();
       Type widthType = $_builder.getIntegerType(width);
       $_state.addTypes({widthType, i1Type, i1Type, i1Type, widthType, i1Type});
     }]>,
-    OpBuilder<(ins "StringAttr":$instanceName, "Type":$type), [{
-      $_state.addAttribute("instanceName", instanceName);
+    OpBuilder<(ins "StringRef":$instanceName, "Type":$type), [{
+      $_state.addAttribute("instanceName", FlatSymbolRefAttr::get($_builder.getContext(), instanceName));
       Type i1Type = $_builder.getI1Type();
       $_state.addTypes({type, i1Type, i1Type, i1Type, type, i1Type});
     }]>
@@ -75,16 +75,16 @@ def MemoryOp : CalyxPrimitive<"memory", []> {
     ```mlir
       // A 1-dimensional, 32-bit memory with size dimension 1. Equivalent representation in the native compiler:
       // `m1 = std_mem_d1(32, 1, 1)`
-      %m1.addr0, %m1.write_data, %m1.write_en, %m1.clk, %m1.read_data, %m1.done = calyx.memory "m1"<[1] x 32> [1] : i1, i32, i1, i1, i32, i1
+      %m1.addr0, %m1.write_data, %m1.write_en, %m1.clk, %m1.read_data, %m1.done = calyx.memory @m1 <[1] x 32> [1] : i1, i32, i1, i1, i32, i1
 
       // A 2-dimensional, 8-bit memory with size dimensions 64 x 64. Equivalent representation in the native compiler:
       // `m2 = std_mem_d2(8, 64, 64, 6, 6)`
-      %m2.addr0, %m2.addr1, %m2.write_data, %m2.write_en, %m2.clk, %m2.read_data, %m2.done = calyx.memory "m2"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
+      %m2.addr0, %m2.addr1, %m2.write_data, %m2.write_en, %m2.clk, %m2.read_data, %m2.done = calyx.memory @m2 <[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
     ```
   }];
 
   let arguments = (ins
-    StrAttr:$instanceName,
+    FlatSymbolRefAttr:$instanceName,
     I64Attr:$width,
     ArrayAttr:$sizes,
     ArrayAttr:$addrSizes
@@ -95,14 +95,14 @@ def MemoryOp : CalyxPrimitive<"memory", []> {
   );
 
   let assemblyFormat = [{
-    $instanceName `<` $sizes `x` $width `>` $addrSizes attr-dict `:` type($results)
+    $instanceName ` ` `<` $sizes `x` $width `>` $addrSizes attr-dict `:` type($results)
   }];
 
   let verifier = "return ::verify$cppClass(*this);";
 
   let builders = [
     OpBuilder<(ins
-      "Twine":$instanceName,
+      "StringRef":$instanceName,
       "int64_t":$width,
       "ArrayRef<int64_t>":$sizes,
       "ArrayRef<int64_t>":$addrSizes
@@ -135,9 +135,9 @@ class CalyxLibraryOp<string mnemonic, list<OpTrait> traits = []> :
     native Calyx compiler.
   }];
 
-  let arguments = (ins StrAttr:$instanceName);
+  let arguments = (ins FlatSymbolRefAttr:$instanceName);
   let builders = [
-    OpBuilder<(ins "StringAttr":$instanceName, "::mlir::TypeRange":$resultTypes), [{
+    OpBuilder<(ins "FlatSymbolRefAttr":$instanceName, "::mlir::TypeRange":$resultTypes), [{
       $_state.addAttribute("instanceName", instanceName);
       $_state.addTypes(resultTypes);
     }]>

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -137,8 +137,10 @@ class CalyxLibraryOp<string mnemonic, list<OpTrait> traits = []> :
 
   let arguments = (ins FlatSymbolRefAttr:$instanceName);
   let builders = [
-    OpBuilder<(ins "FlatSymbolRefAttr":$instanceName, "::mlir::TypeRange":$resultTypes), [{
-      $_state.addAttribute("instanceName", instanceName);
+    OpBuilder<(ins "StringRef":$instanceName, "::mlir::TypeRange":$resultTypes), [{
+      $_state.addAttribute("instanceName",
+        FlatSymbolRefAttr::get($_builder.getContext(), instanceName)
+      );
       $_state.addTypes(resultTypes);
     }]>
   ];

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -187,7 +187,7 @@ def InstanceOp : CalyxCell<"instance", [
   }];
 
   let arguments = (ins
-    StrAttr:$instanceName,
+    FlatSymbolRefAttr:$instanceName,
     FlatSymbolRefAttr:$componentName
   );
   let results = (outs Variadic<AnyType>:$results);

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -176,7 +176,7 @@ def InstanceOp : CalyxCell<"instance", [
     Represents an instance of a Calyx component, which may include state.
 
     ```mlir
-      %name.in, %name.out = calyx.instance "name" @MyComponent : i64, i16
+      %c.in, %c.out = calyx.instance @c @MyComponent : i64, i16
     ```
   }];
 

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -177,7 +177,7 @@ def InstanceOp : CalyxCell<"instance", [
     Represents an instance of a Calyx component, which may include state.
 
     ```mlir
-      %c.in, %c.out = calyx.instance @c @MyComponent : i64, i16
+      %c.in, %c.out = calyx.instance @c of @MyComponent : i64, i16
     ```
   }];
 
@@ -194,7 +194,7 @@ def InstanceOp : CalyxCell<"instance", [
   let results = (outs Variadic<AnyType>:$results);
 
   let assemblyFormat = [{
-    $instanceName $componentName attr-dict (`:` type($results)^)?
+    $instanceName `of` $componentName attr-dict (`:` type($results)^)?
   }];
 }
 

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -58,6 +58,7 @@ def ProgramOp : CalyxContainer<"program", [
 
 def ComponentOp : CalyxOp<"component", [
     HasParent<"ProgramOp">,
+    SymbolTable,
     Symbol,
     FunctionLike,
     IsolatedFromAbove,

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -205,9 +205,9 @@ public:
     IRRewriter::InsertionGuard guard(rewriter);
     rewriter.setInsertionPoint(compOp.getBody(), compOp.getBody()->begin());
     auto name = TLibraryOp::getOperationName().split(".").second;
-    auto uniqueName = getUniqueName(name);
-    return rewriter.create<TLibraryOp>(loc, rewriter.getStringAttr(uniqueName),
-                                       resTypes);
+    return rewriter.create<TLibraryOp>(
+        loc, FlatSymbolRefAttr::get(rewriter.getContext(), getUniqueName(name)),
+        resTypes);
   }
 
   /// Register value v as being evaluated when scheduling group.
@@ -574,8 +574,8 @@ static calyx::RegisterOp createReg(ComponentLoweringState &compState,
                                    Twine prefix, size_t width) {
   IRRewriter::InsertionGuard guard(rewriter);
   rewriter.setInsertionPointToStart(compState.getComponentOp().getBody());
-  return rewriter.create<calyx::RegisterOp>(
-      loc, rewriter.getStringAttr(prefix + "_reg"), width);
+  return rewriter.create<calyx::RegisterOp>(loc, (prefix + "_reg").str(),
+                                            width);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1951,7 +1951,7 @@ public:
   /// results are skipped for Once patterns).
   template <typename TPattern, typename... PatternArgs>
   void addOncePattern(SmallVectorImpl<LoweringPattern> &patterns,
-                      PatternArgs &&...args) {
+                      PatternArgs &&... args) {
     RewritePatternSet ps(&getContext());
     ps.add<TPattern>(&getContext(), partialPatternRes, args...);
     patterns.push_back(
@@ -1960,7 +1960,7 @@ public:
 
   template <typename TPattern, typename... PatternArgs>
   void addGreedyPattern(SmallVectorImpl<LoweringPattern> &patterns,
-                        PatternArgs &&...args) {
+                        PatternArgs &&... args) {
     RewritePatternSet ps(&getContext());
     ps.add<TPattern>(&getContext(), args...);
     patterns.push_back(

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -205,9 +205,7 @@ public:
     IRRewriter::InsertionGuard guard(rewriter);
     rewriter.setInsertionPoint(compOp.getBody(), compOp.getBody()->begin());
     auto name = TLibraryOp::getOperationName().split(".").second;
-    return rewriter.create<TLibraryOp>(
-        loc, FlatSymbolRefAttr::get(rewriter.getContext(), getUniqueName(name)),
-        resTypes);
+    return rewriter.create<TLibraryOp>(loc, getUniqueName(name), resTypes);
   }
 
   /// Register value v as being evaluated when scheduling group.
@@ -1951,7 +1949,7 @@ public:
   /// results are skipped for Once patterns).
   template <typename TPattern, typename... PatternArgs>
   void addOncePattern(SmallVectorImpl<LoweringPattern> &patterns,
-                      PatternArgs &&... args) {
+                      PatternArgs &&...args) {
     RewritePatternSet ps(&getContext());
     ps.add<TPattern>(&getContext(), partialPatternRes, args...);
     patterns.push_back(
@@ -1960,7 +1958,7 @@ public:
 
   template <typename TPattern, typename... PatternArgs>
   void addGreedyPattern(SmallVectorImpl<LoweringPattern> &patterns,
-                        PatternArgs &&... args) {
+                        PatternArgs &&...args) {
     RewritePatternSet ps(&getContext());
     ps.add<TPattern>(&getContext(), args...);
     patterns.push_back(

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -1340,8 +1340,8 @@ SmallVector<DictionaryAttr> MemoryOp::portAttributes() {
 }
 
 void MemoryOp::build(OpBuilder &builder, OperationState &state,
-                     StringRef instanceName, int64_t width, ArrayRef<int64_t> sizes,
-                     ArrayRef<int64_t> addrSizes) {
+                     StringRef instanceName, int64_t width,
+                     ArrayRef<int64_t> sizes, ArrayRef<int64_t> addrSizes) {
   state.addAttribute("instanceName", FlatSymbolRefAttr::get(
                                          builder.getContext(), instanceName));
   state.addAttribute("width", builder.getI64IntegerAttr(width));

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -1128,8 +1128,8 @@ static LogicalResult verifyInstanceOpType(InstanceOp instance,
   StringRef entryPointName = program.entryPointName();
   if (instance.componentName() == entryPointName)
     return instance.emitOpError()
-           << "cannot reference the entry-point component: \"" << entryPointName
-           << "\".";
+           << "cannot reference the entry-point component: '" << entryPointName
+           << "'.";
 
   // Verify there are no other instances with this name.
   auto component = instance->getParentOfType<ComponentOp>();
@@ -1143,8 +1143,8 @@ static LogicalResult verifyInstanceOpType(InstanceOp instance,
                      return use.getUser() != instance;
                    }))
     return instance.emitOpError()
-           << "with instance symbol: " << name.getValue()
-           << " is already a symbol for another instance.";
+           << "with instance symbol: '" << name.getValue()
+           << "' is already a symbol for another instance.";
 
   // Verify the instance result ports with those of its referenced component.
   SmallVector<PortInfo> componentPorts = referencedComponent.getPortInfo();
@@ -1174,20 +1174,20 @@ LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   Operation *referencedComponent =
       symbolTable.lookupNearestSymbolFrom(program, componentNameAttr());
   if (referencedComponent == nullptr)
-    return emitError() << "referencing component: " << componentName()
-                       << ", which does not exist.";
+    return emitError() << "referencing component: '" << componentName()
+                       << "', which does not exist.";
 
   Operation *shadowedComponentName =
       symbolTable.lookupNearestSymbolFrom(program, instanceNameAttr());
   if (shadowedComponentName != nullptr)
-    return emitError() << "instance symbol: " << instanceName()
-                       << " is already a symbol for another component.";
+    return emitError() << "instance symbol: '" << instanceName()
+                       << "' is already a symbol for another component.";
 
   // Verify the referenced component is not instantiating itself.
   auto parentComponent = op->getParentOfType<ComponentOp>();
   if (parentComponent == referencedComponent)
-    return emitError() << "recursive instantiation of its parent component: "
-                       << componentName();
+    return emitError() << "recursive instantiation of its parent component: '"
+                       << componentName() << "'";
 
   assert(isa<ComponentOp>(referencedComponent) && "Should be a ComponentOp.");
   return verifyInstanceOpType(*this, cast<ComponentOp>(referencedComponent));

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -1171,7 +1171,11 @@ LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 
 /// Provide meaningful names to the result values of an InstanceOp.
 void InstanceOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
-  getCellAsmResultNames(setNameFn, *this, this->portNames());
+  Operation* op = *this;
+  auto instanceName = op->getAttrOfType<FlatSymbolRefAttr>("instanceName").getValue();
+  std::string prefix = instanceName.str() + ".";
+  for (size_t i = 0, e = portNames().size(); i != e; ++i)
+    setNameFn(op->getResult(i), prefix + portNames()[i].str());
 }
 
 SmallVector<StringRef> InstanceOp::portNames() {

--- a/lib/Dialect/Calyx/Transforms/CompileControl.cpp
+++ b/lib/Dialect/Calyx/Transforms/CompileControl.cpp
@@ -44,9 +44,7 @@ static RegisterOp createRegister(OpBuilder &builder, ComponentOp &component,
                                  size_t width, StringRef name) {
   IRRewriter::InsertionGuard guard(builder);
   builder.setInsertionPointToStart(component.getBody());
-  auto *context = builder.getContext();
-  return builder.create<RegisterOp>(component->getLoc(),
-                                    StringAttr::get(context, name), width);
+  return builder.create<RegisterOp>(component->getLoc(), name, width);
 }
 
 class CompileControlVisitor {

--- a/test/Conversion/SCFToCalyx/convert_controlflow.mlir
+++ b/test/Conversion/SCFToCalyx/convert_controlflow.mlir
@@ -4,9 +4,9 @@
 // CHECK-NEXT:   calyx.program "main"  {
 // CHECK-NEXT:     calyx.component @main(%in0: i32, %in1: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out0: i32, %done: i1 {done}) {
 // CHECK-DAG:        %true = hw.constant true
-// CHECK-DAG:        %std_slt_0.left, %std_slt_0.right, %std_slt_0.out = calyx.std_slt "std_slt_0" : i32, i32, i1
-// CHECK-DAG:        %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register "ret_arg0_reg" : i32, i1, i1, i1, i32, i1
-// CHECK-DAG:        %bb3_arg0_reg.in, %bb3_arg0_reg.write_en, %bb3_arg0_reg.clk, %bb3_arg0_reg.reset, %bb3_arg0_reg.out, %bb3_arg0_reg.done = calyx.register "bb3_arg0_reg" : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %std_slt_0.left, %std_slt_0.right, %std_slt_0.out = calyx.std_slt @std_slt_0 : i32, i32, i1
+// CHECK-DAG:        %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %bb3_arg0_reg.in, %bb3_arg0_reg.write_en, %bb3_arg0_reg.clk, %bb3_arg0_reg.reset, %bb3_arg0_reg.out, %bb3_arg0_reg.done = calyx.register @bb3_arg0_reg : i32, i1, i1, i1, i32, i1
 // CHECK-NEXT:       calyx.wires  {
 // CHECK-NEXT:         calyx.assign %out0 = %ret_arg0_reg.out : i32
 // CHECK-NEXT:         calyx.comb_group @bb0_0  {
@@ -68,17 +68,17 @@ module {
 // CHECK-LABEL:    calyx.component @main(%in0: i32, %in1: i32, %in2: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out0: i32, %done: i1 {done}) {
 // CHECK-DAG:        %true = hw.constant true
 // CHECK-DAG:        %c0_i32 = hw.constant 0 : i32
-// CHECK-DAG:        %std_add_2.left, %std_add_2.right, %std_add_2.out = calyx.std_add "std_add_2" : i32, i32, i32
-// CHECK-DAG:        %std_add_1.left, %std_add_1.right, %std_add_1.out = calyx.std_add "std_add_1" : i32, i32, i32
-// CHECK-DAG:        %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add "std_add_0" : i32, i32, i32
-// CHECK-DAG:        %std_slt_1.left, %std_slt_1.right, %std_slt_1.out = calyx.std_slt "std_slt_1" : i32, i32, i1
-// CHECK-DAG:        %std_slt_0.left, %std_slt_0.right, %std_slt_0.out = calyx.std_slt "std_slt_0" : i32, i32, i1
-// CHECK-DAG:        %while_0_arg2_reg.in, %while_0_arg2_reg.write_en, %while_0_arg2_reg.clk, %while_0_arg2_reg.reset, %while_0_arg2_reg.out, %while_0_arg2_reg.done = calyx.register "while_0_arg2_reg" : i32, i1, i1, i1, i32, i1
-// CHECK-DAG:        %while_0_arg1_reg.in, %while_0_arg1_reg.write_en, %while_0_arg1_reg.clk, %while_0_arg1_reg.reset, %while_0_arg1_reg.out, %while_0_arg1_reg.done = calyx.register "while_0_arg1_reg" : i32, i1, i1, i1, i32, i1
-// CHECK-DAG:        %while_0_arg0_reg.in, %while_0_arg0_reg.write_en, %while_0_arg0_reg.clk, %while_0_arg0_reg.reset, %while_0_arg0_reg.out, %while_0_arg0_reg.done = calyx.register "while_0_arg0_reg" : i32, i1, i1, i1, i32, i1
-// CHECK-DAG:        %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register "ret_arg0_reg" : i32, i1, i1, i1, i32, i1
-// CHECK-DAG:        %bb3_arg1_reg.in, %bb3_arg1_reg.write_en, %bb3_arg1_reg.clk, %bb3_arg1_reg.reset, %bb3_arg1_reg.out, %bb3_arg1_reg.done = calyx.register "bb3_arg1_reg" : i32, i1, i1, i1, i32, i1
-// CHECK-DAG:        %bb3_arg0_reg.in, %bb3_arg0_reg.write_en, %bb3_arg0_reg.clk, %bb3_arg0_reg.reset, %bb3_arg0_reg.out, %bb3_arg0_reg.done = calyx.register "bb3_arg0_reg" : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %std_add_2.left, %std_add_2.right, %std_add_2.out = calyx.std_add @std_add_2 : i32, i32, i32
+// CHECK-DAG:        %std_add_1.left, %std_add_1.right, %std_add_1.out = calyx.std_add @std_add_1 : i32, i32, i32
+// CHECK-DAG:        %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add @std_add_0 : i32, i32, i32
+// CHECK-DAG:        %std_slt_1.left, %std_slt_1.right, %std_slt_1.out = calyx.std_slt @std_slt_1 : i32, i32, i1
+// CHECK-DAG:        %std_slt_0.left, %std_slt_0.right, %std_slt_0.out = calyx.std_slt @std_slt_0 : i32, i32, i1
+// CHECK-DAG:        %while_0_arg2_reg.in, %while_0_arg2_reg.write_en, %while_0_arg2_reg.clk, %while_0_arg2_reg.reset, %while_0_arg2_reg.out, %while_0_arg2_reg.done = calyx.register @while_0_arg2_reg : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %while_0_arg1_reg.in, %while_0_arg1_reg.write_en, %while_0_arg1_reg.clk, %while_0_arg1_reg.reset, %while_0_arg1_reg.out, %while_0_arg1_reg.done = calyx.register @while_0_arg1_reg : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %while_0_arg0_reg.in, %while_0_arg0_reg.write_en, %while_0_arg0_reg.clk, %while_0_arg0_reg.reset, %while_0_arg0_reg.out, %while_0_arg0_reg.done = calyx.register @while_0_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %bb3_arg1_reg.in, %bb3_arg1_reg.write_en, %bb3_arg1_reg.clk, %bb3_arg1_reg.reset, %bb3_arg1_reg.out, %bb3_arg1_reg.done = calyx.register @bb3_arg1_reg : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %bb3_arg0_reg.in, %bb3_arg0_reg.write_en, %bb3_arg0_reg.clk, %bb3_arg0_reg.reset, %bb3_arg0_reg.out, %bb3_arg0_reg.done = calyx.register @bb3_arg0_reg : i32, i1, i1, i1, i32, i1
 // CHECK-NEXT:       calyx.wires  {
 // CHECK-NEXT:         calyx.assign %out0 = %ret_arg0_reg.out : i32
 // CHECK-NEXT:         calyx.group @assign_while_0_init  {
@@ -194,17 +194,17 @@ module {
 // CHECK-LABEL:    calyx.component @main(%in0: i32, %in1: i32, %in2: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out0: i32, %done: i1 {done}) {
 // CHECK-DAG:        %true = hw.constant true
 // CHECK-DAG:        %c0_i32 = hw.constant 0 : i32
-// CHECK-DAG:        %std_add_1.left, %std_add_1.right, %std_add_1.out = calyx.std_add "std_add_1" : i32, i32, i32
-// CHECK-DAG:        %std_sub_0.left, %std_sub_0.right, %std_sub_0.out = calyx.std_sub "std_sub_0" : i32, i32, i32
-// CHECK-DAG:        %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add "std_add_0" : i32, i32, i32
-// CHECK-DAG:        %std_slt_1.left, %std_slt_1.right, %std_slt_1.out = calyx.std_slt "std_slt_1" : i32, i32, i1
-// CHECK-DAG:        %std_slt_0.left, %std_slt_0.right, %std_slt_0.out = calyx.std_slt "std_slt_0" : i32, i32, i1
-// CHECK-DAG:        %while_0_arg2_reg.in, %while_0_arg2_reg.write_en, %while_0_arg2_reg.clk, %while_0_arg2_reg.reset, %while_0_arg2_reg.out, %while_0_arg2_reg.done = calyx.register "while_0_arg2_reg" : i32, i1, i1, i1, i32, i1
-// CHECK-DAG:        %while_0_arg1_reg.in, %while_0_arg1_reg.write_en, %while_0_arg1_reg.clk, %while_0_arg1_reg.reset, %while_0_arg1_reg.out, %while_0_arg1_reg.done = calyx.register "while_0_arg1_reg" : i32, i1, i1, i1, i32, i1
-// CHECK-DAG:        %while_0_arg0_reg.in, %while_0_arg0_reg.write_en, %while_0_arg0_reg.clk, %while_0_arg0_reg.reset, %while_0_arg0_reg.out, %while_0_arg0_reg.done = calyx.register "while_0_arg0_reg" : i32, i1, i1, i1, i32, i1
-// CHECK-DAG:        %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register "ret_arg0_reg" : i32, i1, i1, i1, i32, i1
-// CHECK-DAG:        %bb3_arg1_reg.in, %bb3_arg1_reg.write_en, %bb3_arg1_reg.clk, %bb3_arg1_reg.reset, %bb3_arg1_reg.out, %bb3_arg1_reg.done = calyx.register "bb3_arg1_reg" : i32, i1, i1, i1, i32, i1
-// CHECK-DAG:        %bb3_arg0_reg.in, %bb3_arg0_reg.write_en, %bb3_arg0_reg.clk, %bb3_arg0_reg.reset, %bb3_arg0_reg.out, %bb3_arg0_reg.done = calyx.register "bb3_arg0_reg" : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %std_add_1.left, %std_add_1.right, %std_add_1.out = calyx.std_add @std_add_1 : i32, i32, i32
+// CHECK-DAG:        %std_sub_0.left, %std_sub_0.right, %std_sub_0.out = calyx.std_sub @std_sub_0 : i32, i32, i32
+// CHECK-DAG:        %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add @std_add_0 : i32, i32, i32
+// CHECK-DAG:        %std_slt_1.left, %std_slt_1.right, %std_slt_1.out = calyx.std_slt @std_slt_1 : i32, i32, i1
+// CHECK-DAG:        %std_slt_0.left, %std_slt_0.right, %std_slt_0.out = calyx.std_slt @std_slt_0 : i32, i32, i1
+// CHECK-DAG:        %while_0_arg2_reg.in, %while_0_arg2_reg.write_en, %while_0_arg2_reg.clk, %while_0_arg2_reg.reset, %while_0_arg2_reg.out, %while_0_arg2_reg.done = calyx.register @while_0_arg2_reg : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %while_0_arg1_reg.in, %while_0_arg1_reg.write_en, %while_0_arg1_reg.clk, %while_0_arg1_reg.reset, %while_0_arg1_reg.out, %while_0_arg1_reg.done = calyx.register @while_0_arg1_reg : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %while_0_arg0_reg.in, %while_0_arg0_reg.write_en, %while_0_arg0_reg.clk, %while_0_arg0_reg.reset, %while_0_arg0_reg.out, %while_0_arg0_reg.done = calyx.register @while_0_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %bb3_arg1_reg.in, %bb3_arg1_reg.write_en, %bb3_arg1_reg.clk, %bb3_arg1_reg.reset, %bb3_arg1_reg.out, %bb3_arg1_reg.done = calyx.register @bb3_arg1_reg : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %bb3_arg0_reg.in, %bb3_arg0_reg.write_en, %bb3_arg0_reg.clk, %bb3_arg0_reg.reset, %bb3_arg0_reg.out, %bb3_arg0_reg.done = calyx.register @bb3_arg0_reg : i32, i1, i1, i1, i32, i1
 // CHECK-NEXT:       calyx.wires  {
 // CHECK-NEXT:         calyx.assign %out0 = %ret_arg0_reg.out : i32
 // CHECK-NEXT:         calyx.group @assign_while_0_init  {
@@ -321,10 +321,10 @@ module {
 // CHECK-NEXT:   calyx.program "main"  {
 // CHECK-LABEL:    calyx.component @main(%in0: i32, %in1: i32, %in2: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out0: i32, %done: i1 {done}) {
 // CHECK-DAG:        %true = hw.constant true
-// CHECK-DAG:        %std_ge_0.left, %std_ge_0.right, %std_ge_0.out = calyx.std_ge "std_ge_0" : i32, i32, i1
-// CHECK-DAG:        %std_add_1.left, %std_add_1.right, %std_add_1.out = calyx.std_add "std_add_1" : i32, i32, i32
-// CHECK-DAG:        %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add "std_add_0" : i32, i32, i32
-// CHECK-DAG:        %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register "ret_arg0_reg" : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %std_ge_0.left, %std_ge_0.right, %std_ge_0.out = calyx.std_ge @std_ge_0 : i32, i32, i1
+// CHECK-DAG:        %std_add_1.left, %std_add_1.right, %std_add_1.out = calyx.std_add @std_add_1 : i32, i32, i32
+// CHECK-DAG:        %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add @std_add_0 : i32, i32, i32
+// CHECK-DAG:        %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
 // CHECK-NEXT:       calyx.wires  {
 // CHECK-NEXT:         calyx.assign %out0 = %ret_arg0_reg.out : i32
 // CHECK-NEXT:         calyx.comb_group @bb0_2  {

--- a/test/Conversion/SCFToCalyx/convert_memory.mlir
+++ b/test/Conversion/SCFToCalyx/convert_memory.mlir
@@ -7,13 +7,13 @@
 // CHECK-DAG:        %c0_i32 = hw.constant 0 : i32
 // CHECK-DAG:        %c1_i32 = hw.constant 1 : i32
 // CHECK-DAG:        %true = hw.constant true
-// CHECK-DAG:        %std_slice_1.in, %std_slice_1.out = calyx.std_slice "std_slice_1" : i32, i6
-// CHECK-DAG:        %std_slice_0.in, %std_slice_0.out = calyx.std_slice "std_slice_0" : i32, i6
-// CHECK-DAG:        %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add "std_add_0" : i32, i32, i32
-// CHECK-DAG:        %std_lt_0.left, %std_lt_0.right, %std_lt_0.out = calyx.std_lt "std_lt_0" : i32, i32, i1
-// CHECK-DAG:        %mem_1.addr0, %mem_1.write_data, %mem_1.write_en, %mem_1.clk, %mem_1.read_data, %mem_1.done = calyx.memory "mem_1"<[64] x 32> [6] : i6, i32, i1, i1, i32, i1
-// CHECK-DAG:        %mem_0.addr0, %mem_0.write_data, %mem_0.write_en, %mem_0.clk, %mem_0.read_data, %mem_0.done = calyx.memory "mem_0"<[64] x 32> [6] : i6, i32, i1, i1, i32, i1
-// CHECK-DAG:        %while_0_arg0_reg.in, %while_0_arg0_reg.write_en, %while_0_arg0_reg.clk, %while_0_arg0_reg.reset, %while_0_arg0_reg.out, %while_0_arg0_reg.done = calyx.register "while_0_arg0_reg" : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %std_slice_1.in, %std_slice_1.out = calyx.std_slice @std_slice_1 : i32, i6
+// CHECK-DAG:        %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i6
+// CHECK-DAG:        %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add @std_add_0 : i32, i32, i32
+// CHECK-DAG:        %std_lt_0.left, %std_lt_0.right, %std_lt_0.out = calyx.std_lt @std_lt_0 : i32, i32, i1
+// CHECK-DAG:        %mem_1.addr0, %mem_1.write_data, %mem_1.write_en, %mem_1.clk, %mem_1.read_data, %mem_1.done = calyx.memory @mem_1 <[64] x 32> [6] : i6, i32, i1, i1, i32, i1
+// CHECK-DAG:        %mem_0.addr0, %mem_0.write_data, %mem_0.write_en, %mem_0.clk, %mem_0.read_data, %mem_0.done = calyx.memory @mem_0 <[64] x 32> [6] : i6, i32, i1, i1, i32, i1
+// CHECK-DAG:        %while_0_arg0_reg.in, %while_0_arg0_reg.write_en, %while_0_arg0_reg.clk, %while_0_arg0_reg.reset, %while_0_arg0_reg.out, %while_0_arg0_reg.done = calyx.register @while_0_arg0_reg : i32, i1, i1, i1, i32, i1
 // CHECK-NEXT:       calyx.wires  {
 // CHECK-NEXT:         calyx.group @assign_while_0_init  {
 // CHECK-NEXT:           calyx.assign %while_0_arg0_reg.in = %c0_i32 : i32
@@ -88,11 +88,11 @@ module {
 // CHECK-DAG:        %c0_i32 = hw.constant 0 : i32
 // CHECK-DAG:        %c1_i32 = hw.constant 1 : i32
 // CHECK-DAG:        %true = hw.constant true
-// CHECK-DAG:        %std_slice_0.in, %std_slice_0.out = calyx.std_slice "std_slice_0" : i32, i6
-// CHECK-DAG:        %std_add_1.left, %std_add_1.right, %std_add_1.out = calyx.std_add "std_add_1" : i32, i32, i32
-// CHECK-DAG:        %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add "std_add_0" : i32, i32, i32
-// CHECK-DAG:        %mem_0.addr0, %mem_0.write_data, %mem_0.write_en, %mem_0.clk, %mem_0.read_data, %mem_0.done = calyx.memory "mem_0"<[64] x 32> [6] : i6, i32, i1, i1, i32, i1
-// CHECK-DAG:        %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register "ret_arg0_reg" : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i6
+// CHECK-DAG:        %std_add_1.left, %std_add_1.right, %std_add_1.out = calyx.std_add @std_add_1 : i32, i32, i32
+// CHECK-DAG:        %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add @std_add_0 : i32, i32, i32
+// CHECK-DAG:        %mem_0.addr0, %mem_0.write_data, %mem_0.write_en, %mem_0.clk, %mem_0.read_data, %mem_0.done = calyx.memory @mem_0 <[64] x 32> [6] : i6, i32, i1, i1, i32, i1
+// CHECK-DAG:        %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
 // CHECK-NEXT:       calyx.wires  {
 // CHECK-NEXT:         calyx.assign %out0 = %ret_arg0_reg.out : i32
 // CHECK-NEXT:         calyx.group @bb0_1  {
@@ -143,12 +143,12 @@ module {
 // CHECK-DAG:        %c0_i32 = hw.constant 0 : i32
 // CHECK-DAG:        %c1_i32 = hw.constant 1 : i32
 // CHECK-DAG:        %true = hw.constant true
-// CHECK-DAG:        %std_slice_0.in, %std_slice_0.out = calyx.std_slice "std_slice_0" : i32, i6
-// CHECK-DAG:        %std_add_2.left, %std_add_2.right, %std_add_2.out = calyx.std_add "std_add_2" : i32, i32, i32
-// CHECK-DAG:        %std_add_1.left, %std_add_1.right, %std_add_1.out = calyx.std_add "std_add_1" : i32, i32, i32
-// CHECK-DAG:        %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add "std_add_0" : i32, i32, i32
-// CHECK-DAG:        %mem_0.addr0, %mem_0.write_data, %mem_0.write_en, %mem_0.clk, %mem_0.read_data, %mem_0.done = calyx.memory "mem_0"<[64] x 32> [6] : i6, i32, i1, i1, i32, i1
-// CHECK-DAG:        %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register "ret_arg0_reg" : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i6
+// CHECK-DAG:        %std_add_2.left, %std_add_2.right, %std_add_2.out = calyx.std_add @std_add_2 : i32, i32, i32
+// CHECK-DAG:        %std_add_1.left, %std_add_1.right, %std_add_1.out = calyx.std_add @std_add_1 : i32, i32, i32
+// CHECK-DAG:        %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add @std_add_0 : i32, i32, i32
+// CHECK-DAG:        %mem_0.addr0, %mem_0.write_data, %mem_0.write_en, %mem_0.clk, %mem_0.read_data, %mem_0.done = calyx.memory @mem_0 <[64] x 32> [6] : i6, i32, i1, i1, i32, i1
+// CHECK-DAG:        %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
 // CHECK-NEXT:       calyx.wires  {
 // CHECK-NEXT:         calyx.assign %out0 = %ret_arg0_reg.out : i32
 // CHECK-NEXT:         calyx.group @bb0_2  {
@@ -202,14 +202,14 @@ module {
 // CHECK-LABEL:    calyx.component @main(%in0: i6, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out0: i32, %done: i1 {done}) {
 // CHECK-DAG:        %c1_i32 = hw.constant 1 : i32
 // CHECK-DAG:        %true = hw.constant true
-// CHECK-DAG:        %std_slice_1.in, %std_slice_1.out = calyx.std_slice "std_slice_1" : i32, i6
-// CHECK-DAG:        %std_slice_0.in, %std_slice_0.out = calyx.std_slice "std_slice_0" : i32, i6
-// CHECK-DAG:        %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add "std_add_0" : i32, i32, i32
-// CHECK-DAG:        %load_1_reg.in, %load_1_reg.write_en, %load_1_reg.clk, %load_1_reg.reset, %load_1_reg.out, %load_1_reg.done = calyx.register "load_1_reg" : i32, i1, i1, i1, i32, i1
-// CHECK-DAG:        %load_0_reg.in, %load_0_reg.write_en, %load_0_reg.clk, %load_0_reg.reset, %load_0_reg.out, %load_0_reg.done = calyx.register "load_0_reg" : i32, i1, i1, i1, i32, i1
-// CHECK-DAG:        %std_pad_0.in, %std_pad_0.out = calyx.std_pad "std_pad_0" : i6, i32
-// CHECK-DAG:        %mem_0.addr0, %mem_0.write_data, %mem_0.write_en, %mem_0.clk, %mem_0.read_data, %mem_0.done = calyx.memory "mem_0"<[64] x 32> [6] : i6, i32, i1, i1, i32, i1
-// CHECK-DAG:        %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register "ret_arg0_reg" : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %std_slice_1.in, %std_slice_1.out = calyx.std_slice @std_slice_1 : i32, i6
+// CHECK-DAG:        %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i6
+// CHECK-DAG:        %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add @std_add_0 : i32, i32, i32
+// CHECK-DAG:        %load_1_reg.in, %load_1_reg.write_en, %load_1_reg.clk, %load_1_reg.reset, %load_1_reg.out, %load_1_reg.done = calyx.register @load_1_reg : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %load_0_reg.in, %load_0_reg.write_en, %load_0_reg.clk, %load_0_reg.reset, %load_0_reg.out, %load_0_reg.done = calyx.register @load_0_reg : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %std_pad_0.in, %std_pad_0.out = calyx.std_pad @std_pad_0 : i6, i32
+// CHECK-DAG:        %mem_0.addr0, %mem_0.write_data, %mem_0.write_en, %mem_0.clk, %mem_0.read_data, %mem_0.done = calyx.memory @mem_0 <[64] x 32> [6] : i6, i32, i1, i1, i32, i1
+// CHECK-DAG:        %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
 // CHECK-NEXT:       calyx.wires  {
 // CHECK-NEXT:         calyx.assign %out0 = %ret_arg0_reg.out : i32
 // CHECK-NEXT:         calyx.group @bb0_1  {
@@ -265,9 +265,9 @@ module {
 // CHECK-NEXT:   calyx.program "main"  {
 // CHECK-NEXT:     calyx.component @main(%in0: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out0: i32, %done: i1 {done}) {
 // CHECK-DAG:        %true = hw.constant true
-// CHECK-DAG:        %std_slice_0.in, %std_slice_0.out = calyx.std_slice "std_slice_0" : i32, i6
-// CHECK-DAG:        %mem_0.addr0, %mem_0.write_data, %mem_0.write_en, %mem_0.clk, %mem_0.read_data, %mem_0.done = calyx.memory "mem_0"<[64] x 32> [6] : i6, i32, i1, i1, i32, i1
-// CHECK-DAG:        %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register "ret_arg0_reg" : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i6
+// CHECK-DAG:        %mem_0.addr0, %mem_0.write_data, %mem_0.write_en, %mem_0.clk, %mem_0.read_data, %mem_0.done = calyx.memory @mem_0 <[64] x 32> [6] : i6, i32, i1, i1, i32, i1
+// CHECK-DAG:        %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
 // CHECK-NEXT:       calyx.wires  {
 // CHECK-NEXT:         calyx.assign %out0 = %ret_arg0_reg.out : i32
 // CHECK-NEXT:         calyx.group @ret_assign_0  {
@@ -302,8 +302,8 @@ module {
 // CHECH-NEXT:   calyx.program "main"  {
 // CHECH-NEXT:     calyx.component @main(%in0: i8, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out0: i32, %done: i1 {done}) {
 // CHECH-DAG:        %true = hw.constant true
-// CHECH-DAG:        %std_pad_0.in, %std_pad_0.out = calyx.std_pad "std_pad_0" : i8, i32
-// CHECH-DAG:        %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register "ret_arg0_reg" : i32, i1, i1, i1, i32, i1
+// CHECH-DAG:        %std_pad_0.in, %std_pad_0.out = calyx.std_pad @std_pad_0 : i8, i32
+// CHECH-DAG:        %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
 // CHECH-NEXT:       calyx.wires  {
 // CHECH-NEXT:         calyx.assign %out0 = %ret_arg0_reg.out : i32
 // CHECH-NEXT:         calyx.group @ret_assign_0  {
@@ -336,7 +336,7 @@ module {
 // CHECK-NEXT:   calyx.program "main"  {
 // CHECK:        calyx.component @main(%in0: i32, %ext_mem0_read_data: i32, %ext_mem0_done: i1, %in2: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%ext_mem0_write_data: i32, %ext_mem0_addr0: i8, %ext_mem0_write_en: i1, %done: i1 {done}) {
 // CHECK-DAG:        %true = hw.constant true
-// CHECK-DAG:        %std_slice_0.in, %std_slice_0.out = calyx.std_slice "std_slice_0" : i32, i8
+// CHECK-DAG:        %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i8
 // CHECK-NEXT:       calyx.wires  {
 // CHECK-NEXT:         calyx.group @bb0_0  {
 // CHECK-NEXT:           calyx.assign %std_slice_0.in = %in2 : i32
@@ -369,8 +369,8 @@ module {
 // CHECK-NEXT:   calyx.program "main"  {
 // CHECK:        calyx.component @main(%in0: i32, %ext_mem0_read_data: i32, %ext_mem0_done: i1, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%ext_mem0_write_data: i32, %ext_mem0_addr0: i8, %ext_mem0_write_en: i1, %out0: i32, %done: i1 {done}) {
 // CHECK:            %true = hw.constant true
-// CHECK:            %std_slice_0.in, %std_slice_0.out = calyx.std_slice "std_slice_0" : i32, i8
-// CHECK:            %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register "ret_arg0_reg" : i32, i1, i1, i1, i32, i1
+// CHECK:            %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i8
+// CHECK:            %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
 // CHECK-NEXT:       calyx.wires  {
 // CHECK-NEXT:         calyx.assign %out0 = %ret_arg0_reg.out : i32
 // CHECK-NEXT:         calyx.group @ret_assign_0  {
@@ -404,12 +404,12 @@ module {
 // CHECK-NEXT:   calyx.program "main"  {
 // CHECK:        calyx.component @main(%in0: i32, %in1: i32, %ext_mem0_read_data: i32, %ext_mem0_done: i1, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%ext_mem0_write_data: i32, %ext_mem0_addr0: i8, %ext_mem0_write_en: i1, %out0: i32, %out1: i32, %done: i1 {done}) {
 // CHECK-DAG:        %true = hw.constant true
-// CHECK-DAG:        %std_slice_1.in, %std_slice_1.out = calyx.std_slice "std_slice_1" : i32, i8
-// CHECK-DAG:        %std_slice_0.in, %std_slice_0.out = calyx.std_slice "std_slice_0" : i32, i8
-// CHECK-DAG:        %load_1_reg.in, %load_1_reg.write_en, %load_1_reg.clk, %load_1_reg.reset, %load_1_reg.out, %load_1_reg.done = calyx.register "load_1_reg" : i32, i1, i1, i1, i32, i1
-// CHECK-DAG:        %load_0_reg.in, %load_0_reg.write_en, %load_0_reg.clk, %load_0_reg.reset, %load_0_reg.out, %load_0_reg.done = calyx.register "load_0_reg" : i32, i1, i1, i1, i32, i1
-// CHECK-DAG:        %ret_arg1_reg.in, %ret_arg1_reg.write_en, %ret_arg1_reg.clk, %ret_arg1_reg.reset, %ret_arg1_reg.out, %ret_arg1_reg.done = calyx.register "ret_arg1_reg" : i32, i1, i1, i1, i32, i1
-// CHECK-DAG:        %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register "ret_arg0_reg" : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %std_slice_1.in, %std_slice_1.out = calyx.std_slice @std_slice_1 : i32, i8
+// CHECK-DAG:        %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i8
+// CHECK-DAG:        %load_1_reg.in, %load_1_reg.write_en, %load_1_reg.clk, %load_1_reg.reset, %load_1_reg.out, %load_1_reg.done = calyx.register @load_1_reg : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %load_0_reg.in, %load_0_reg.write_en, %load_0_reg.clk, %load_0_reg.reset, %load_0_reg.out, %load_0_reg.done = calyx.register @load_0_reg : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %ret_arg1_reg.in, %ret_arg1_reg.write_en, %ret_arg1_reg.clk, %ret_arg1_reg.reset, %ret_arg1_reg.out, %ret_arg1_reg.done = calyx.register @ret_arg1_reg : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
 // CHECK-NEXT:       calyx.wires  {
 // CHECK-NEXT:         calyx.assign %out1 = %ret_arg1_reg.out : i32
 // CHECK-NEXT:         calyx.assign %out0 = %ret_arg0_reg.out : i32

--- a/test/Conversion/SCFToCalyx/convert_simple.mlir
+++ b/test/Conversion/SCFToCalyx/convert_simple.mlir
@@ -4,10 +4,10 @@
 // CHECK-NEXT:   calyx.program "main" {
 // CHECK-LABEL:    calyx.component @main(%in0: i32, %in1: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out0: i32, %done: i1 {done}) {
 // CHECK-DAG:        %true = hw.constant true
-// CHECK-DAG:        %std_sub_0.left, %std_sub_0.right, %std_sub_0.out = calyx.std_sub "std_sub_0" : i32, i32, i32
-// CHECK-DAG:        %std_lsh_0.left, %std_lsh_0.right, %std_lsh_0.out = calyx.std_lsh "std_lsh_0" : i32, i32, i32
-// CHECK-DAG:        %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add "std_add_0" : i32, i32, i32
-// CHECK-DAG:        %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register "ret_arg0_reg" : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %std_sub_0.left, %std_sub_0.right, %std_sub_0.out = calyx.std_sub @std_sub_0 : i32, i32, i32
+// CHECK-DAG:        %std_lsh_0.left, %std_lsh_0.right, %std_lsh_0.out = calyx.std_lsh @std_lsh_0 : i32, i32, i32
+// CHECK-DAG:        %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add @std_add_0 : i32, i32, i32
+// CHECK-DAG:        %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
 // CHECK-NEXT:       calyx.wires  {
 // CHECK-NEXT:         calyx.assign %out0 = %ret_arg0_reg.out : i32
 // CHECK-NEXT:         calyx.group @ret_assign_0  {
@@ -47,8 +47,8 @@ module {
 // CHECK-NEXT:   calyx.program "main"  {
 // CHECK-LABEL:    calyx.component @main(%in0: i32, %in1: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out0: i32, %out1: i32, %done: i1 {done}) {
 // CHECK-DAG:        %true = hw.constant true
-// CHECK-DAG:        %ret_arg1_reg.in, %ret_arg1_reg.write_en, %ret_arg1_reg.clk, %ret_arg1_reg.reset, %ret_arg1_reg.out, %ret_arg1_reg.done = calyx.register "ret_arg1_reg" : i32, i1, i1, i1, i32, i1
-// CHECK-DAG:        %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register "ret_arg0_reg" : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %ret_arg1_reg.in, %ret_arg1_reg.write_en, %ret_arg1_reg.clk, %ret_arg1_reg.reset, %ret_arg1_reg.out, %ret_arg1_reg.done = calyx.register @ret_arg1_reg : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:        %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
 // CHECK-NEXT:       calyx.wires  {
 // CHECK-NEXT:         calyx.assign %out1 = %ret_arg1_reg.out : i32
 // CHECK-NEXT:         calyx.assign %out0 = %ret_arg0_reg.out : i32

--- a/test/Dialect/Calyx/canonicalization.mlir
+++ b/test/Dialect/Calyx/canonicalization.mlir
@@ -3,7 +3,7 @@
 // Nested SeqOps are collapsed.
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
       calyx.group @A {
@@ -32,7 +32,7 @@ calyx.program "main" {
 // Nested ParOps are collapsed.
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
       calyx.group @A {
@@ -61,8 +61,8 @@ calyx.program "main" {
 // IfOp nested in SeqOp removes common tail from within SeqOps.
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
-    %eq.left, %eq.right, %eq.out = calyx.std_eq "eq" : i1, i1, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
+    %eq.left, %eq.right, %eq.out = calyx.std_eq @eq : i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
       calyx.comb_group @Cond {
@@ -122,8 +122,8 @@ calyx.program "main" {
 // IfOp nested in ParOp removes common tails from within ParOps.
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
-    %eq.left, %eq.right, %eq.out = calyx.std_eq "eq" : i1, i1, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
+    %eq.left, %eq.right, %eq.out = calyx.std_eq @eq : i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
       calyx.comb_group @Cond {
@@ -192,8 +192,8 @@ calyx.program "main" {
 // here is ensuring the removed EnableOps are still computed sequentially.
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
-    %eq.left, %eq.right, %eq.out = calyx.std_eq "eq" : i1, i1, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
+    %eq.left, %eq.right, %eq.out = calyx.std_eq @eq : i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
       calyx.comb_group @Cond {
@@ -256,8 +256,8 @@ calyx.program "main" {
 // here is ensuring the removed EnableOps are still computed in parallel.
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
-    %eq.left, %eq.right, %eq.out = calyx.std_eq "eq" : i1, i1, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
+    %eq.left, %eq.right, %eq.out = calyx.std_eq @eq : i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
       calyx.comb_group @Cond {
@@ -327,9 +327,9 @@ calyx.program "main" {
 // Empty Then and Else regions lead to the removal of the IfOp (as well as unused cells and groups).
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
-    // CHECK-NOT: %eq.left, %eq.right, %eq.out = calyx.std_eq "eq" : i1, i1, i1
-    %eq.left, %eq.right, %eq.out = calyx.std_eq "eq" : i1, i1, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
+    // CHECK-NOT: %eq.left, %eq.right, %eq.out = calyx.std_eq @eq : i1, i1, i1
+    %eq.left, %eq.right, %eq.out = calyx.std_eq @eq : i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
       // CHECK-NOT: calyx.comp_group @Cond
@@ -369,9 +369,9 @@ calyx.program "main" {
 // Empty Then region and no Else region leads to removal of IfOp (as well as unused cells).
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
-    // CHECK-NOT: %eq.left, %eq.right, %eq.out = calyx.std_eq "eq" : i1, i1, i1
-    %eq.left, %eq.right, %eq.out = calyx.std_eq "eq" : i1, i1, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
+    // CHECK-NOT: %eq.left, %eq.right, %eq.out = calyx.std_eq @eq : i1, i1, i1
+    %eq.left, %eq.right, %eq.out = calyx.std_eq @eq : i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
       calyx.group @A {
@@ -399,9 +399,9 @@ calyx.program "main" {
 // Empty body leads to removal of WhileOp (as well as unused cells and groups).
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
-    // CHECK: %eq.left, %eq.right, %eq.out = calyx.std_eq "eq" : i1, i1, i1
-    %eq.left, %eq.right, %eq.out = calyx.std_eq "eq" : i1, i1, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
+    // CHECK: %eq.left, %eq.right, %eq.out = calyx.std_eq @eq : i1, i1, i1
+    %eq.left, %eq.right, %eq.out = calyx.std_eq @eq : i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
       // CHECK-NOT: calyx.comp_group @Cond
@@ -435,7 +435,7 @@ calyx.program "main" {
 // Empty ParOp and SeqOp are removed.
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
       calyx.group @A {

--- a/test/Dialect/Calyx/compile-control.mlir
+++ b/test/Dialect/Calyx/compile-control.mlir
@@ -9,7 +9,7 @@ calyx.program "main" {
 
   calyx.component @main(%go : i1 {go}, %reset : i1 {reset}, %clk : i1 {clk}) -> (%done : i1 {done}) {
     // CHECK:  %fsm.in, %fsm.write_en, %fsm.clk, %fsm.reset, %fsm.out, %fsm.done = calyx.register @fsm : i2
-    %z.go, %z.reset, %z.clk, %z.flag, %z.done = calyx.instance @z @Z : i1, i1, i1, i1, i1
+    %z.go, %z.reset, %z.clk, %z.flag, %z.done = calyx.instance @z of @Z : i1, i1, i1, i1, i1
     calyx.wires {
       %undef = calyx.undef : i1
       // CHECK: %[[SIGNAL_ON:.+]] = hw.constant true

--- a/test/Dialect/Calyx/compile-control.mlir
+++ b/test/Dialect/Calyx/compile-control.mlir
@@ -8,7 +8,7 @@ calyx.program "main" {
   }
 
   calyx.component @main(%go : i1 {go}, %reset : i1 {reset}, %clk : i1 {clk}) -> (%done : i1 {done}) {
-    // CHECK:  %fsm.in, %fsm.write_en, %fsm.clk, %fsm.reset, %fsm.out, %fsm.done = calyx.register "fsm" : i2
+    // CHECK:  %fsm.in, %fsm.write_en, %fsm.clk, %fsm.reset, %fsm.out, %fsm.done = calyx.register @fsm : i2
     %z.go, %z.reset, %z.clk, %z.flag, %z.done = calyx.instance @z @Z : i1, i1, i1, i1, i1
     calyx.wires {
       %undef = calyx.undef : i1

--- a/test/Dialect/Calyx/compile-control.mlir
+++ b/test/Dialect/Calyx/compile-control.mlir
@@ -9,7 +9,7 @@ calyx.program "main" {
 
   calyx.component @main(%go : i1 {go}, %reset : i1 {reset}, %clk : i1 {clk}) -> (%done : i1 {done}) {
     // CHECK:  %fsm.in, %fsm.write_en, %fsm.clk, %fsm.reset, %fsm.out, %fsm.done = calyx.register "fsm" : i2
-    %z.go, %z.reset, %z.clk, %z.flag, %z.done = calyx.instance "z" @Z : i1, i1, i1, i1, i1
+    %z.go, %z.reset, %z.clk, %z.flag, %z.done = calyx.instance @z @Z : i1, i1, i1, i1, i1
     calyx.wires {
       %undef = calyx.undef : i1
       // CHECK: %[[SIGNAL_ON:.+]] = hw.constant true

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -15,7 +15,7 @@ calyx.program "main" {
 
   // CHECK-LABEL: component B(in: 1, @go go: 1, @clk clk: 1, @reset reset: 1) -> (out: 1, @done done: 1) {
   calyx.component @B(%in: i1, %go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%out: i1, %done: i1 {done}) {
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
       calyx.group @RegisterWrite {
@@ -53,11 +53,11 @@ calyx.program "main" {
     // CHECK-NEXT:    @generated s0 = std_slice(32, 8);
     %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i32, i1, i1, i1, i32, i1
     %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance @c1 @B {not_calyx_attr="foo", precious} : i1, i1, i1, i1, i1, i1
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8, i1, i1, i1, i8, i1
-    %m0.addr0, %m0.write_data, %m0.write_en, %m0.clk, %m0.read_data, %m0.done = calyx.memory "m0"<[1] x 32> [1] {external = 32} : i1, i32, i1, i1, i32, i1
-    %m1.addr0, %m1.addr1, %m1.write_data, %m1.write_en, %m1.clk, %m1.read_data, %m1.done = calyx.memory "m1"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
-    %a0.left, %a0.right, %a0.out = calyx.std_add "a0" {generated} : i32, i32, i32
-    %s0.in, %s0.out = calyx.std_slice "s0" {generated} : i32, i8
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i8, i1, i1, i1, i8, i1
+    %m0.addr0, %m0.write_data, %m0.write_en, %m0.clk, %m0.read_data, %m0.done = calyx.memory @m0 <[1] x 32> [1] {external = 32} : i1, i32, i1, i1, i32, i1
+    %m1.addr0, %m1.addr1, %m1.write_data, %m1.write_en, %m1.clk, %m1.read_data, %m1.done = calyx.memory @m1 <[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
+    %a0.left, %a0.right, %a0.out = calyx.std_add @a0 {generated} : i32, i32, i32
+    %s0.in, %s0.out = calyx.std_slice @s0 {generated} : i32, i8
     %c0 = hw.constant 0 : i1
     %c1 = hw.constant 1 : i1
     %c1_i32 = hw.constant 1 : i32

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -51,8 +51,8 @@ calyx.program "main" {
     // CHECK-NEXT:    m1 = std_mem_d2(8, 64, 64, 6, 6);
     // CHECK-NEXT:    @generated a0 = std_add(32);
     // CHECK-NEXT:    @generated s0 = std_slice(32, 8);
-    %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i32, i1, i1, i1, i32, i1
-    %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance "c1" @B {not_calyx_attr="foo", precious} : i1, i1, i1, i1, i1, i1
+    %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i32, i1, i1, i1, i32, i1
+    %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance @c1 @B {not_calyx_attr="foo", precious} : i1, i1, i1, i1, i1, i1
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8, i1, i1, i1, i8, i1
     %m0.addr0, %m0.write_data, %m0.write_en, %m0.clk, %m0.read_data, %m0.done = calyx.memory "m0"<[1] x 32> [1] {external = 32} : i1, i32, i1, i1, i32, i1
     %m1.addr0, %m1.addr1, %m1.write_data, %m1.write_en, %m1.clk, %m1.read_data, %m1.done = calyx.memory "m1"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -51,8 +51,8 @@ calyx.program "main" {
     // CHECK-NEXT:    m1 = std_mem_d2(8, 64, 64, 6, 6);
     // CHECK-NEXT:    @generated a0 = std_add(32);
     // CHECK-NEXT:    @generated s0 = std_slice(32, 8);
-    %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i32, i1, i1, i1, i32, i1
-    %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance @c1 @B {not_calyx_attr="foo", precious} : i1, i1, i1, i1, i1, i1
+    %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 of @A : i32, i1, i1, i1, i32, i1
+    %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance @c1 of @B {not_calyx_attr="foo", precious} : i1, i1, i1, i1, i1, i1
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i8, i1, i1, i1, i8, i1
     %m0.addr0, %m0.write_data, %m0.write_en, %m0.clk, %m0.read_data, %m0.done = calyx.memory @m0 <[1] x 32> [1] {external = 32} : i1, i32, i1, i1, i32, i1
     %m1.addr0, %m1.addr1, %m1.write_data, %m1.write_en, %m1.clk, %m1.read_data, %m1.done = calyx.memory @m1 <[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -19,7 +19,7 @@ calyx.program "foo" {
 calyx.program "main" {
   calyx.component @foo(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     // expected-error @+1 {{'calyx.instance' op cannot reference the entry-point component: "main".}}
-    calyx.instance "c" @main : i16, i1, i1, i1, i1
+    calyx.instance @c @main : i16, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires { calyx.assign %done = %c1_1 : i1 }
     calyx.control {}
@@ -45,7 +45,7 @@ calyx.program "main" {
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     // expected-error @+1 {{referencing component: A, which does not exist.}}
-    calyx.instance "c" @A
+    calyx.instance @c @A
     %c1_1 = hw.constant 1 : i1
     calyx.wires { calyx.assign %done = %c1_1 : i1 }
     calyx.control {}
@@ -57,7 +57,7 @@ calyx.program "main" {
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     // expected-error @+1 {{recursive instantiation of its parent component: main}}
-    calyx.instance "c" @main : i1, i1, i1, i1
+    calyx.instance @c @main : i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires { calyx.assign %done = %c1_1 : i1 }
     calyx.control {}
@@ -74,7 +74,7 @@ calyx.program "main" {
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     // expected-error @+1 {{'calyx.instance' op has a wrong number of results; expected: 5 but got 0}}
-    calyx.instance "a0" @A
+    calyx.instance @a0 @A
     %c1_1 = hw.constant 1 : i1
     calyx.wires { calyx.assign %done = %c1_1 : i1 }
     calyx.control {}
@@ -91,7 +91,7 @@ calyx.program "main" {
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     // expected-error @+1 {{'calyx.instance' op result type for "in" must be 'i16', but got 'i1'}}
-    %b0.in, %b0.go, %b0.clk, %b0.reset, %b0.done = calyx.instance "b0" @B : i1, i1, i1, i1, i1
+    %b0.in, %b0.go, %b0.clk, %b0.reset, %b0.done = calyx.instance @b0 @B : i1, i1, i1, i1, i1
     calyx.wires { calyx.assign %done = %b0.done : i1 }
     calyx.control {}
   }
@@ -111,8 +111,8 @@ calyx.program "main" {
     calyx.control {}
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %a.go, %a.clk, %a.reset, %a.out, %a.done = calyx.instance "a" @A : i1, i1, i1, i16, i1
-    %b.in, %b.go, %b.clk, %b.reset, %b.done = calyx.instance "b" @B : i16, i1, i1, i1, i1
+    %a.go, %a.clk, %a.reset, %a.out, %a.done = calyx.instance @a @A : i1, i1, i1, i16, i1
+    %b.in, %b.go, %b.clk, %b.reset, %b.done = calyx.instance @b @B : i16, i1, i1, i1, i1
     // expected-error @+1 {{'calyx.assign' op expects parent op to be one of 'calyx.group, calyx.comb_group, calyx.wires'}}
     calyx.assign %b.in = %a.out : i16
 
@@ -186,7 +186,7 @@ calyx.program "main" {
     calyx.control {}
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i1, i1, i1, i1, i1
+    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i1, i1, i1, i1, i1
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
@@ -220,7 +220,7 @@ calyx.program "main" {
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     %c1_1 = hw.constant 1 : i1
-    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i1, i1, i1, i1, i1
+    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i1, i1, i1, i1, i1
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
     calyx.wires {
       calyx.group @Group2 {
@@ -247,7 +247,7 @@ calyx.program "main" {
     calyx.control {}
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i1, i1, i1, i1, i1, i1
+    %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i1, i1, i1, i1, i1, i1
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
@@ -279,7 +279,7 @@ calyx.program "main" {
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     %c1_1 = hw.constant 1 : i1
-    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i1, i1, i1, i1, i1
+    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i1, i1, i1, i1, i1
     calyx.wires { calyx.comb_group @Group2 { calyx.assign %c0.go = %c1_1 : i1 } }
     calyx.control {
       calyx.seq {
@@ -301,7 +301,7 @@ calyx.program "main" {
     calyx.control {}
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i1, i1, i1, i1, i1, i1
+    %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i1, i1, i1, i1, i1, i1
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
@@ -475,7 +475,7 @@ calyx.program "main" {
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
-    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i1, i1, i1, i1, i1
+    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
       calyx.group @Group1 {
@@ -502,7 +502,7 @@ calyx.program "main" {
     calyx.control {}
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i1, i1, i1, i1, i1
+    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i1, i1, i1, i1, i1
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
@@ -530,7 +530,7 @@ calyx.program "main" {
     calyx.control {}
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i1, i1, i1, i1, i1
+    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires { calyx.comb_group @Group1 { calyx.assign %c0.go = %c1_1 : i1 } }
     calyx.control {

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -18,7 +18,7 @@ calyx.program "foo" {
 
 calyx.program "main" {
   calyx.component @foo(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    // expected-error @+1 {{'calyx.instance' op cannot reference the entry-point component: "main".}}
+    // expected-error @+1 {{'calyx.instance' op cannot reference the entry-point component: 'main'.}}
     calyx.instance @c of @main : i16, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires { calyx.assign %done = %c1_1 : i1 }
@@ -41,7 +41,7 @@ calyx.program "main" {
   }
   calyx.component @main(%in: i16, %go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     %c1_1 = hw.constant 1 : i1
-    // expected-error @+1 {{'calyx.instance' op with instance symbol: c is already a symbol for another instance.}}
+    // expected-error @+1 {{'calyx.instance' op with instance symbol: 'c' is already a symbol for another instance.}}
     calyx.instance @c of @foo : i1, i1, i1, i1
     calyx.instance @c of @foo : i1, i1, i1, i1
     calyx.wires { calyx.assign %done = %c1_1 : i1 }
@@ -59,7 +59,7 @@ calyx.program "main" {
   }
   calyx.component @main(%in: i16, %go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     %c1_1 = hw.constant 1 : i1
-    // expected-error @+1 {{instance symbol: foo is already a symbol for another component.}}
+    // expected-error @+1 {{instance symbol: 'foo' is already a symbol for another component.}}
     calyx.instance @foo of @foo : i1, i1, i1, i1
     calyx.wires { calyx.assign %done = %c1_1 : i1 }
     calyx.control {}
@@ -79,7 +79,7 @@ calyx.program "main" {
 
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    // expected-error @+1 {{referencing component: A, which does not exist.}}
+    // expected-error @+1 {{referencing component: 'A', which does not exist.}}
     calyx.instance @c of @A
     %c1_1 = hw.constant 1 : i1
     calyx.wires { calyx.assign %done = %c1_1 : i1 }
@@ -91,7 +91,7 @@ calyx.program "main" {
 
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    // expected-error @+1 {{recursive instantiation of its parent component: main}}
+    // expected-error @+1 {{recursive instantiation of its parent component: 'main'}}
     calyx.instance @c of @main : i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires { calyx.assign %done = %c1_1 : i1 }

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -34,6 +34,41 @@ calyx.program "main" {
 // -----
 
 calyx.program "main" {
+  calyx.component @foo(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
+    %c1_1 = hw.constant 1 : i1
+    calyx.wires { calyx.assign %done = %c1_1 : i1 }
+    calyx.control {}
+  }
+  calyx.component @main(%in: i16, %go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
+    %c1_1 = hw.constant 1 : i1
+    // expected-error @+1 {{'calyx.instance' op with instance symbol: c is already a symbol for another instance.}}
+    calyx.instance @c @foo : i1, i1, i1, i1
+    calyx.instance @c @foo : i1, i1, i1, i1
+    calyx.wires { calyx.assign %done = %c1_1 : i1 }
+    calyx.control {}
+  }
+}
+
+// -----
+
+calyx.program "main" {
+  calyx.component @foo(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
+    %c1_1 = hw.constant 1 : i1
+    calyx.wires { calyx.assign %done = %c1_1 : i1 }
+    calyx.control {}
+  }
+  calyx.component @main(%in: i16, %go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
+    %c1_1 = hw.constant 1 : i1
+    // expected-error @+1 {{instance symbol: foo is already a symbol for another component.}}
+    calyx.instance @foo @foo : i1, i1, i1, i1
+    calyx.wires { calyx.assign %done = %c1_1 : i1 }
+    calyx.control {}
+  }
+}
+
+// -----
+
+calyx.program "main" {
   // expected-error @+1 {{'calyx.component' op requires exactly one of each: 'calyx.wires', 'calyx.control'.}}
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     calyx.control {}

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -139,7 +139,7 @@ calyx.program "main" {
 
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
       calyx.group @A {
@@ -160,7 +160,7 @@ calyx.program "main" {
 
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
       // expected-error @+1 {{'calyx.group' op with name: "Group1" is unused in the control execution schedule}}
@@ -179,7 +179,7 @@ calyx.program "main" {
 
 calyx.program "main" {
   calyx.component @A(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%out: i1, %done: i1 {done}) {
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8, i1, i1, i1, i8, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i8, i1, i1, i1, i8, i1
     calyx.wires {
       calyx.assign %done = %r.done : i1
     }
@@ -187,7 +187,7 @@ calyx.program "main" {
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i1, i1, i1, i1, i1
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
       calyx.comb_group @Group1 {
@@ -221,7 +221,7 @@ calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     %c1_1 = hw.constant 1 : i1
     %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i1, i1, i1, i1, i1
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     calyx.wires {
       calyx.group @Group2 {
         calyx.assign %r.in = %c1_1 : i1
@@ -248,7 +248,7 @@ calyx.program "main" {
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i1, i1, i1, i1, i1, i1
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
       calyx.comb_group @Group1 {}
@@ -302,7 +302,7 @@ calyx.program "main" {
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i1, i1, i1, i1, i1, i1
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
       calyx.comb_group @Group1 { }
@@ -328,7 +328,7 @@ calyx.program "main" {
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     // expected-error @+1 {{'calyx.memory' op mismatched number of dimensions (1) and address sizes (2)}}
-    %m.addr0, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory "m"<[64] x 8> [6, 6] : i6, i8, i1, i1, i8, i1
+    %m.addr0, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory @m <[64] x 8> [6, 6] : i6, i8, i1, i1, i8, i1
     calyx.wires { calyx.assign %done = %m.done : i1 }
     calyx.control {}
   }
@@ -339,7 +339,7 @@ calyx.program "main" {
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     // expected-error @+1 {{'calyx.memory' op incorrect number of address ports, expected 2}}
-    %m.addr0, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory "m"<[64, 64] x 8> [6, 6] : i6, i8, i1, i1, i8, i1
+    %m.addr0, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory @m <[64, 64] x 8> [6, 6] : i6, i8, i1, i1, i8, i1
     calyx.wires { calyx.assign %done = %m.done : i1}
     calyx.control {}
   }
@@ -350,7 +350,7 @@ calyx.program "main" {
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     // expected-error @+1 {{'calyx.memory' op address size (5) for dimension 0 can't address the entire range (64)}}
-    %m.addr0, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory "m"<[64] x 8> [5] : i5, i8, i1, i1, i5, i1
+    %m.addr0, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory @m <[64] x 8> [5] : i5, i8, i1, i1, i5, i1
     calyx.wires { calyx.assign %done = %m.done : i1 }
     calyx.control {}
   }
@@ -386,7 +386,7 @@ calyx.program "main" {
 
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8, i1, i1, i1, i8, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i8, i1, i1, i1, i8, i1
     calyx.wires {
       // expected-error @+1 {{'calyx.assign' op has a component port as the source with the incorrect direction.}}
       calyx.assign %r.write_en = %done : i1
@@ -399,7 +399,7 @@ calyx.program "main" {
 
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8, i1, i1, i1, i8, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i8, i1, i1, i1, i8, i1
     calyx.wires {
       // expected-error @+1 {{'calyx.assign' op has a cell port as the source with the incorrect direction.}}
       calyx.assign %done = %r.write_en : i1
@@ -412,7 +412,7 @@ calyx.program "main" {
 
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8, i1, i1, i1, i8, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i8, i1, i1, i1, i8, i1
     calyx.wires {
       // expected-error @+1 {{'calyx.assign' op has a cell port as the destination with the incorrect direction.}}
       calyx.assign %r.done = %go : i1
@@ -425,7 +425,7 @@ calyx.program "main" {
 
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
       calyx.group @A {
@@ -446,7 +446,7 @@ calyx.program "main" {
 
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
       calyx.group @A {
@@ -474,7 +474,7 @@ calyx.program "main" {
     calyx.control {}
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
@@ -503,7 +503,7 @@ calyx.program "main" {
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i1, i1, i1, i1, i1
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
       calyx.group @Group1 {
@@ -559,7 +559,7 @@ calyx.program "main" {
 
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
       // expected-error @+1 {{'calyx.group' op with cell: calyx.register "r" is performing a write and failed to drive all necessary ports.}}
@@ -576,7 +576,7 @@ calyx.program "main" {
 
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory "m"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
+    %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory @m <[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
     %c1_i8 = hw.constant 1 : i8
     calyx.wires {
       // expected-error @+1 {{'calyx.group' op with cell: calyx.memory "m" is performing a write and failed to drive all necessary ports.}}
@@ -593,12 +593,12 @@ calyx.program "main" {
 
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %gt.left, %gt.right, %gt.out = calyx.std_gt "gt" : i8, i8, i1
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
+    %gt.left, %gt.right, %gt.out = calyx.std_gt @gt : i8, i8, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     %c1_i8 = hw.constant 1 : i8
     %c1_i1 = hw.constant 1 : i1
     calyx.wires {
-      // expected-error @+1 {{calyx.group' op with cell: calyx.std_gt "gt" is performing a write and failed to drive all necessary ports.}}
+      // expected-error @+1 {{'calyx.group' op with cell: calyx.std_gt "gt" is performing a write and failed to drive all necessary ports.}}
       calyx.group @A {
         calyx.assign %r.in = %gt.out : i1
         calyx.assign %r.write_en = %c1_i1 : i1
@@ -614,8 +614,8 @@ calyx.program "main" {
 
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory "m"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8, i1, i1, i1, i8, i1
+    %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory @m <[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i8, i1, i1, i1, i8, i1
     %c1_i1 = hw.constant 1 : i1
     calyx.wires {
       // expected-error @+1 {{'calyx.group' op with cell: calyx.memory "m" is having a read performed upon it, and failed to drive all necessary ports.}}
@@ -633,7 +633,7 @@ calyx.program "main" {
 
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
       // expected-error @+1 {{'calyx.comb_group' op with register: "r" is conducting a memory store. This is not combinational.}}
@@ -661,8 +661,8 @@ calyx.program "main" {
 
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory "m"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
+    %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory @m <[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     %c1_i8 = hw.constant 1 : i8
     %c0_i6 = hw.constant 0 : i6
     %c1_i1 = hw.constant 1 : i1
@@ -694,7 +694,7 @@ calyx.program "main" {
 
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
       calyx.group @A {
@@ -713,7 +713,7 @@ calyx.program "main" {
 
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
       calyx.group @A {
@@ -732,7 +732,7 @@ calyx.program "main" {
 
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i1, i1, i1, i1, i1, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
       calyx.group @A {

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -19,7 +19,7 @@ calyx.program "foo" {
 calyx.program "main" {
   calyx.component @foo(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     // expected-error @+1 {{'calyx.instance' op cannot reference the entry-point component: "main".}}
-    calyx.instance @c @main : i16, i1, i1, i1, i1
+    calyx.instance @c of @main : i16, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires { calyx.assign %done = %c1_1 : i1 }
     calyx.control {}
@@ -42,8 +42,8 @@ calyx.program "main" {
   calyx.component @main(%in: i16, %go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     %c1_1 = hw.constant 1 : i1
     // expected-error @+1 {{'calyx.instance' op with instance symbol: c is already a symbol for another instance.}}
-    calyx.instance @c @foo : i1, i1, i1, i1
-    calyx.instance @c @foo : i1, i1, i1, i1
+    calyx.instance @c of @foo : i1, i1, i1, i1
+    calyx.instance @c of @foo : i1, i1, i1, i1
     calyx.wires { calyx.assign %done = %c1_1 : i1 }
     calyx.control {}
   }
@@ -60,7 +60,7 @@ calyx.program "main" {
   calyx.component @main(%in: i16, %go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     %c1_1 = hw.constant 1 : i1
     // expected-error @+1 {{instance symbol: foo is already a symbol for another component.}}
-    calyx.instance @foo @foo : i1, i1, i1, i1
+    calyx.instance @foo of @foo : i1, i1, i1, i1
     calyx.wires { calyx.assign %done = %c1_1 : i1 }
     calyx.control {}
   }
@@ -80,7 +80,7 @@ calyx.program "main" {
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     // expected-error @+1 {{referencing component: A, which does not exist.}}
-    calyx.instance @c @A
+    calyx.instance @c of @A
     %c1_1 = hw.constant 1 : i1
     calyx.wires { calyx.assign %done = %c1_1 : i1 }
     calyx.control {}
@@ -92,7 +92,7 @@ calyx.program "main" {
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     // expected-error @+1 {{recursive instantiation of its parent component: main}}
-    calyx.instance @c @main : i1, i1, i1, i1
+    calyx.instance @c of @main : i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires { calyx.assign %done = %c1_1 : i1 }
     calyx.control {}
@@ -109,7 +109,7 @@ calyx.program "main" {
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     // expected-error @+1 {{'calyx.instance' op has a wrong number of results; expected: 5 but got 0}}
-    calyx.instance @a0 @A
+    calyx.instance @a0 of @A
     %c1_1 = hw.constant 1 : i1
     calyx.wires { calyx.assign %done = %c1_1 : i1 }
     calyx.control {}
@@ -126,7 +126,7 @@ calyx.program "main" {
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     // expected-error @+1 {{'calyx.instance' op result type for "in" must be 'i16', but got 'i1'}}
-    %b0.in, %b0.go, %b0.clk, %b0.reset, %b0.done = calyx.instance @b0 @B : i1, i1, i1, i1, i1
+    %b0.in, %b0.go, %b0.clk, %b0.reset, %b0.done = calyx.instance @b of @B : i1, i1, i1, i1, i1
     calyx.wires { calyx.assign %done = %b0.done : i1 }
     calyx.control {}
   }
@@ -146,8 +146,8 @@ calyx.program "main" {
     calyx.control {}
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %a.go, %a.clk, %a.reset, %a.out, %a.done = calyx.instance @a @A : i1, i1, i1, i16, i1
-    %b.in, %b.go, %b.clk, %b.reset, %b.done = calyx.instance @b @B : i16, i1, i1, i1, i1
+    %a.go, %a.clk, %a.reset, %a.out, %a.done = calyx.instance @a of @A : i1, i1, i1, i16, i1
+    %b.in, %b.go, %b.clk, %b.reset, %b.done = calyx.instance @b of @B : i16, i1, i1, i1, i1
     // expected-error @+1 {{'calyx.assign' op expects parent op to be one of 'calyx.group, calyx.comb_group, calyx.wires'}}
     calyx.assign %b.in = %a.out : i16
 
@@ -221,7 +221,7 @@ calyx.program "main" {
     calyx.control {}
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i1, i1, i1, i1, i1
+    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 of @A : i1, i1, i1, i1, i1
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
@@ -255,7 +255,7 @@ calyx.program "main" {
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     %c1_1 = hw.constant 1 : i1
-    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i1, i1, i1, i1, i1
+    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 of @A : i1, i1, i1, i1, i1
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     calyx.wires {
       calyx.group @Group2 {
@@ -282,7 +282,7 @@ calyx.program "main" {
     calyx.control {}
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i1, i1, i1, i1, i1, i1
+    %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 of @A : i1, i1, i1, i1, i1, i1
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
@@ -314,7 +314,7 @@ calyx.program "main" {
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     %c1_1 = hw.constant 1 : i1
-    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i1, i1, i1, i1, i1
+    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 of @A : i1, i1, i1, i1, i1
     calyx.wires { calyx.comb_group @Group2 { calyx.assign %c0.go = %c1_1 : i1 } }
     calyx.control {
       calyx.seq {
@@ -336,7 +336,7 @@ calyx.program "main" {
     calyx.control {}
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i1, i1, i1, i1, i1, i1
+    %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 of @A : i1, i1, i1, i1, i1, i1
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
@@ -510,7 +510,7 @@ calyx.program "main" {
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
-    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i1, i1, i1, i1, i1
+    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 of @A : i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
       calyx.group @Group1 {
@@ -537,7 +537,7 @@ calyx.program "main" {
     calyx.control {}
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i1, i1, i1, i1, i1
+    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 of @A : i1, i1, i1, i1, i1
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires {
@@ -565,7 +565,7 @@ calyx.program "main" {
     calyx.control {}
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i1, i1, i1, i1, i1
+    %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 of @A : i1, i1, i1, i1, i1
     %c1_1 = hw.constant 1 : i1
     calyx.wires { calyx.comb_group @Group1 { calyx.assign %c0.go = %c1_1 : i1 } }
     calyx.control {

--- a/test/Dialect/Calyx/go-insertion.mlir
+++ b/test/Dialect/Calyx/go-insertion.mlir
@@ -7,7 +7,7 @@ calyx.program "main" {
     calyx.control {}
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i8, i1, i1, i1, i8, i1
+    %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i8, i1, i1, i1, i8, i1
     calyx.wires {
       // CHECK: %0 = calyx.undef : i1
       // CHECK-LABEL: calyx.group @Group1 {

--- a/test/Dialect/Calyx/go-insertion.mlir
+++ b/test/Dialect/Calyx/go-insertion.mlir
@@ -7,7 +7,7 @@ calyx.program "main" {
     calyx.control {}
   }
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i8, i1, i1, i1, i8, i1
+    %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 of @A : i8, i1, i1, i1, i8, i1
     calyx.wires {
       // CHECK: %0 = calyx.undef : i1
       // CHECK-LABEL: calyx.group @Group1 {

--- a/test/Dialect/Calyx/remove-groups.mlir
+++ b/test/Dialect/Calyx/remove-groups.mlir
@@ -9,7 +9,7 @@ calyx.program "main" {
 
   // CHECK-LABEL: calyx.component @main
   calyx.component @main(%go: i1 {go}, %reset: i1 {reset}, %clk: i1 {clk}) -> (%done: i1 {done}) {
-    %z.go, %z.reset, %z.clk, %z.flag, %z.out, %z.done = calyx.instance "z" @Z : i1, i1, i1, i1, i2, i1
+    %z.go, %z.reset, %z.clk, %z.flag, %z.out, %z.done = calyx.instance @z @Z : i1, i1, i1, i1, i2, i1
     %fsm.in, %fsm.write_en, %fsm.clk, %fsm.reset, %fsm.out, %fsm.done = calyx.register "fsm" : i2, i1, i1, i1, i2, i1
 
     calyx.wires {

--- a/test/Dialect/Calyx/remove-groups.mlir
+++ b/test/Dialect/Calyx/remove-groups.mlir
@@ -9,7 +9,7 @@ calyx.program "main" {
 
   // CHECK-LABEL: calyx.component @main
   calyx.component @main(%go: i1 {go}, %reset: i1 {reset}, %clk: i1 {clk}) -> (%done: i1 {done}) {
-    %z.go, %z.reset, %z.clk, %z.flag, %z.out, %z.done = calyx.instance @z @Z : i1, i1, i1, i1, i2, i1
+    %z.go, %z.reset, %z.clk, %z.flag, %z.out, %z.done = calyx.instance @z of @Z : i1, i1, i1, i1, i2, i1
     %fsm.in, %fsm.write_en, %fsm.clk, %fsm.reset, %fsm.out, %fsm.done = calyx.register @fsm : i2, i1, i1, i1, i2, i1
 
     calyx.wires {

--- a/test/Dialect/Calyx/remove-groups.mlir
+++ b/test/Dialect/Calyx/remove-groups.mlir
@@ -10,7 +10,7 @@ calyx.program "main" {
   // CHECK-LABEL: calyx.component @main
   calyx.component @main(%go: i1 {go}, %reset: i1 {reset}, %clk: i1 {clk}) -> (%done: i1 {done}) {
     %z.go, %z.reset, %z.clk, %z.flag, %z.out, %z.done = calyx.instance @z @Z : i1, i1, i1, i1, i2, i1
-    %fsm.in, %fsm.write_en, %fsm.clk, %fsm.reset, %fsm.out, %fsm.done = calyx.register "fsm" : i2, i1, i1, i1, i2, i1
+    %fsm.in, %fsm.write_en, %fsm.clk, %fsm.reset, %fsm.out, %fsm.done = calyx.register @fsm : i2, i1, i1, i1, i2, i1
 
     calyx.wires {
       // CHECK: %[[FSM_IS_GROUP_A_BEGIN_STATE:.+]] = comb.icmp eq %fsm.out, {{.+}} : i2

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -18,26 +18,26 @@ calyx.program "main" {
 
   // CHECK-LABEL:   calyx.component @main(%clk: i1 {clk}, %go: i1 {go}, %reset: i1 {reset}) -> (%done: i1 {done}) {
   calyx.component @main(%clk: i1 {clk}, %go: i1 {go}, %reset: i1 {reset}) -> (%done: i1 {done}) {
-    // CHECK:      %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8, i1, i1, i1, i8, i1
-    // CHECK-NEXT: %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory "m"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
+    // CHECK:      %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i8, i1, i1, i1, i8, i1
+    // CHECK-NEXT: %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory @m <[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
     // CHECK-NEXT: %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i8, i1, i1, i1, i8, i1
     // CHECK-NEXT: %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance @c1 @A : i8, i1, i1, i1, i8, i1
     // CHECK-NEXT: %c2.in, %c2.clk, %c2.go, %c2.reset, %c2.out, %c2.done = calyx.instance @c2 @B : i8, i1, i1, i1, i1, i1
-    // CHECK-NEXT: %adder.left, %adder.right, %adder.out = calyx.std_add "adder" : i8, i8, i8
-    // CHECK-NEXT: %gt.left, %gt.right, %gt.out = calyx.std_gt "gt" : i8, i8, i1
-    // CHECK-NEXT: %pad.in, %pad.out = calyx.std_pad "pad" : i8, i9
-    // CHECK-NEXT: %slice.in, %slice.out = calyx.std_slice "slice" : i8, i7
-    // CHECK-NEXT: %not.in, %not.out = calyx.std_not "not" : i8, i8
-    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8, i1, i1, i1, i8, i1
-    %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory "m"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
+    // CHECK-NEXT: %adder.left, %adder.right, %adder.out = calyx.std_add @adder : i8, i8, i8
+    // CHECK-NEXT: %gt.left, %gt.right, %gt.out = calyx.std_gt @gt : i8, i8, i1
+    // CHECK-NEXT: %pad.in, %pad.out = calyx.std_pad @pad : i8, i9
+    // CHECK-NEXT: %slice.in, %slice.out = calyx.std_slice @slice : i8, i7
+    // CHECK-NEXT: %not.in, %not.out = calyx.std_not @not : i8, i8
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i8, i1, i1, i1, i8, i1
+    %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory @m <[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
     %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i8, i1, i1, i1, i8, i1
     %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance @c1 @A : i8, i1, i1, i1, i8, i1
     %c2.in, %c2.clk, %c2.go, %c2.reset, %c2.out, %c2.done = calyx.instance @c2 @B : i8, i1, i1, i1, i1, i1
-    %adder.left, %adder.right, %adder.out = calyx.std_add "adder" : i8, i8, i8
-    %gt.left, %gt.right, %gt.out = calyx.std_gt "gt" : i8, i8, i1
-    %pad.in, %pad.out = calyx.std_pad "pad" : i8, i9
-    %slice.in, %slice.out = calyx.std_slice "slice" : i8, i7
-    %not.in, %not.out = calyx.std_not "not" : i8, i8
+    %adder.left, %adder.right, %adder.out = calyx.std_add @adder : i8, i8, i8
+    %gt.left, %gt.right, %gt.out = calyx.std_gt @gt : i8, i8, i1
+    %pad.in, %pad.out = calyx.std_pad @pad : i8, i9
+    %slice.in, %slice.out = calyx.std_slice @slice : i8, i7
+    %not.in, %not.out = calyx.std_not @not : i8, i8
     %c1_i1 = hw.constant 1 : i1
     %c0_i6 = hw.constant 0 : i6
     %c0_i8 = hw.constant 0 : i8

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -20,9 +20,9 @@ calyx.program "main" {
   calyx.component @main(%clk: i1 {clk}, %go: i1 {go}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     // CHECK:      %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8, i1, i1, i1, i8, i1
     // CHECK-NEXT: %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory "m"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
-    // CHECK-NEXT: %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i8, i1, i1, i1, i8, i1
-    // CHECK-NEXT: %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance "c1" @A : i8, i1, i1, i1, i8, i1
-    // CHECK-NEXT: %c2.in, %c2.clk, %c2.go, %c2.reset, %c2.out, %c2.done = calyx.instance "c2" @B : i8, i1, i1, i1, i1, i1
+    // CHECK-NEXT: %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i8, i1, i1, i1, i8, i1
+    // CHECK-NEXT: %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance @c1 @A : i8, i1, i1, i1, i8, i1
+    // CHECK-NEXT: %c2.in, %c2.clk, %c2.go, %c2.reset, %c2.out, %c2.done = calyx.instance @c2 @B : i8, i1, i1, i1, i1, i1
     // CHECK-NEXT: %adder.left, %adder.right, %adder.out = calyx.std_add "adder" : i8, i8, i8
     // CHECK-NEXT: %gt.left, %gt.right, %gt.out = calyx.std_gt "gt" : i8, i8, i1
     // CHECK-NEXT: %pad.in, %pad.out = calyx.std_pad "pad" : i8, i9
@@ -30,9 +30,9 @@ calyx.program "main" {
     // CHECK-NEXT: %not.in, %not.out = calyx.std_not "not" : i8, i8
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register "r" : i8, i1, i1, i1, i8, i1
     %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory "m"<[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
-    %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance "c0" @A : i8, i1, i1, i1, i8, i1
-    %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance "c1" @A : i8, i1, i1, i1, i8, i1
-    %c2.in, %c2.clk, %c2.go, %c2.reset, %c2.out, %c2.done = calyx.instance "c2" @B : i8, i1, i1, i1, i1, i1
+    %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i8, i1, i1, i1, i8, i1
+    %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance @c1 @A : i8, i1, i1, i1, i8, i1
+    %c2.in, %c2.clk, %c2.go, %c2.reset, %c2.out, %c2.done = calyx.instance @c2 @B : i8, i1, i1, i1, i1, i1
     %adder.left, %adder.right, %adder.out = calyx.std_add "adder" : i8, i8, i8
     %gt.left, %gt.right, %gt.out = calyx.std_gt "gt" : i8, i8, i1
     %pad.in, %pad.out = calyx.std_pad "pad" : i8, i9

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -20,9 +20,9 @@ calyx.program "main" {
   calyx.component @main(%clk: i1 {clk}, %go: i1 {go}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     // CHECK:      %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i8, i1, i1, i1, i8, i1
     // CHECK-NEXT: %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory @m <[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
-    // CHECK-NEXT: %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i8, i1, i1, i1, i8, i1
-    // CHECK-NEXT: %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance @c1 @A : i8, i1, i1, i1, i8, i1
-    // CHECK-NEXT: %c2.in, %c2.clk, %c2.go, %c2.reset, %c2.out, %c2.done = calyx.instance @c2 @B : i8, i1, i1, i1, i1, i1
+    // CHECK-NEXT: %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 of @A : i8, i1, i1, i1, i8, i1
+    // CHECK-NEXT: %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance @c1 of @A : i8, i1, i1, i1, i8, i1
+    // CHECK-NEXT: %c2.in, %c2.clk, %c2.go, %c2.reset, %c2.out, %c2.done = calyx.instance @c2 of @B : i8, i1, i1, i1, i1, i1
     // CHECK-NEXT: %adder.left, %adder.right, %adder.out = calyx.std_add @adder : i8, i8, i8
     // CHECK-NEXT: %gt.left, %gt.right, %gt.out = calyx.std_gt @gt : i8, i8, i1
     // CHECK-NEXT: %pad.in, %pad.out = calyx.std_pad @pad : i8, i9
@@ -30,9 +30,9 @@ calyx.program "main" {
     // CHECK-NEXT: %not.in, %not.out = calyx.std_not @not : i8, i8
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i8, i1, i1, i1, i8, i1
     %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory @m <[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
-    %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 @A : i8, i1, i1, i1, i8, i1
-    %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance @c1 @A : i8, i1, i1, i1, i8, i1
-    %c2.in, %c2.clk, %c2.go, %c2.reset, %c2.out, %c2.done = calyx.instance @c2 @B : i8, i1, i1, i1, i1, i1
+    %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 of @A : i8, i1, i1, i1, i8, i1
+    %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance @c1 of @A : i8, i1, i1, i1, i8, i1
+    %c2.in, %c2.clk, %c2.go, %c2.reset, %c2.out, %c2.done = calyx.instance @c2 of @B : i8, i1, i1, i1, i1, i1
     %adder.left, %adder.right, %adder.out = calyx.std_add @adder : i8, i8, i8
     %gt.left, %gt.right, %gt.out = calyx.std_gt @gt : i8, i8, i1
     %pad.in, %pad.out = calyx.std_pad @pad : i8, i9


### PR DESCRIPTION
Changes a cell's `instanceName` argument from StringAttr to FlatSymbolRefAttr. This will be necessary for the addition of an `InvokeOp`, which needs to verify that the instance being invoked actually exists. Since primitives (namely multi-cycle ones) may also be `invoke`able, this is required for all cells.

By-product(s):
1. We are now guaranteed that instance names do not clash component names.
2. I've made all builders similar, requiring that a `StringRef` be passed in rather than the previous mixture of `StringRef` and `StringAttr`.