### PR TITLE
[ExportVerilog] Add MLIRPass to CMakeLists.txt.

### DIFF
--- a/lib/Translation/ExportVerilog/CMakeLists.txt
+++ b/lib/Translation/ExportVerilog/CMakeLists.txt
@@ -16,6 +16,7 @@ add_circt_translation_library(CIRCTExportVerilog
   CIRCTHW
   CIRCTSupport
   CIRCTSV
+  MLIRPass
   MLIRSideEffectInterfaces
   MLIRTranslation
   )


### PR DESCRIPTION
~Marking this as a Draft PR since I haven't fully tested it locally. I'll update this when I confirm that it passes for me locally.~

This should fix the build errors in main, where we fail to link to some
symbols defined in MLIRPass. This build error appears to only manifest
when BUILD_SHARED_LIBS=ON.

Fixes #1925.