### PR TITLE
Properly use `circt-opt` for `export-verilog`

### DIFF
--- a/integration_test/ESI/cosim/basic.mlir
+++ b/integration_test/ESI/cosim/basic.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: esi-cosim
-// RUN: circt-opt %s --lower-esi-to-physical --lower-esi-ports --lower-esi-to-hw | circt-translate --export-verilog > %t1.sv
+// RUN: circt-opt %s --lower-esi-to-physical --lower-esi-ports --lower-esi-to-hw | circt-opt --export-verilog > %t1.sv
 // RUN: circt-translate %s -export-esi-capnp -verify-diagnostics > %t2.capnp
 // RUN: esi-cosim-runner.py --schema %t2.capnp %s %t1.sv %S/../supplements/integers.sv
 // PY: import basic

--- a/integration_test/ESI/cosim/loopback.mlir
+++ b/integration_test/ESI/cosim/loopback.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: esi-cosim
-// RUN: circt-opt %s --lower-esi-to-physical --lower-esi-ports --lower-esi-to-hw --hw-legalize-names | circt-translate --export-verilog > %t1.sv
+// RUN: circt-opt %s --lower-esi-to-physical --lower-esi-ports --lower-esi-to-hw --hw-legalize-names | circt-opt --export-verilog > %t1.sv
 // RUN: circt-translate %s -export-esi-capnp -verify-diagnostics > %t2.capnp
 // RUN: esi-cosim-runner.py --schema %t2.capnp %s %t1.sv
 // PY: import loopback as test

--- a/integration_test/ESI/system/basic.mlir
+++ b/integration_test/ESI/system/basic.mlir
@@ -1,6 +1,6 @@
 // REQUIRES: rtl-sim
 // RUN: circt-opt %s --lower-esi-to-physical --lower-esi-ports --lower-esi-to-hw -verify-diagnostics > %t1.mlir
-// RUN: circt-translate %t1.mlir -export-verilog -verify-diagnostics > %t2.sv
+// RUN: circt-opt %t1.mlir -export-verilog -verify-diagnostics > %t2.sv
 // RUN: circt-rtl-sim.py %t2.sv %INC%/circt/Dialect/ESI/ESIPrimitives.sv %S/../supplements/integers.sv --cycles 150 | FileCheck %s
 
 hw.module.extern @IntCountProd(%clk: i1, %rstn: i1) -> (ints: !esi.channel<i32>)

--- a/integration_test/EmitVerilog/basic.mlir
+++ b/integration_test/EmitVerilog/basic.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: verilator
-// RUN: circt-translate %s -export-verilog -verify-diagnostics > %t1.sv
+// RUN: circt-opt %s -export-verilog -verify-diagnostics > %t1.sv
 // RUN: circt-rtl-sim.py %t1.sv --cycles 8 2>&1 | FileCheck %s
 
 module {

--- a/integration_test/EmitVerilog/lint.mlir
+++ b/integration_test/EmitVerilog/lint.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: verilator
-// RUN: circt-translate %s -export-verilog -verify-diagnostics > %t1.sv
+// RUN: circt-opt %s -export-verilog -verify-diagnostics > %t1.sv
 // RUN: verilator --lint-only --top-module A %t1.sv
 // RUN: verilator --lint-only --top-module AB %t1.sv
 // RUN: verilator --lint-only --top-module shl %t1.sv

--- a/integration_test/EmitVerilog/sv-interfaces.mlir
+++ b/integration_test/EmitVerilog/sv-interfaces.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: hw-sim
-// RUN: circt-translate %s -export-verilog -verify-diagnostics > %t1.sv
+// RUN: circt-opt %s -export-verilog -verify-diagnostics > %t1.sv
 // RUN: verilator --lint-only --top-module top %t1.sv
 // RUN: circt-rtl-sim.py %t1.sv --cycles 2 2>&1 | FileCheck %s
 

--- a/test/Dialect/ESI/cosim.mlir
+++ b/test/Dialect/ESI/cosim.mlir
@@ -1,7 +1,7 @@
 // REQUIRES: capnp
 // RUN: circt-opt %s -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
 // RUN: circt-opt %s --lower-esi-ports --lower-esi-to-hw -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck --check-prefix=COSIM %s
-// Disable the SV test : circt-opt %s --lower-esi-ports --lower-esi-to-hw | circt-translate --export-verilog | FileCheck --check-prefix=SV %s
+// Disable the SV test : circt-opt %s --lower-esi-ports --lower-esi-to-hw | circt-opt --export-verilog | FileCheck --check-prefix=SV %s
 // RUN: circt-translate %s -export-esi-capnp -verify-diagnostics | FileCheck --check-prefix=CAPNP %s
 
 hw.module.extern @Sender() -> (x: !esi.channel<si14>)


### PR DESCRIPTION
Verilog exporting was moved from a translation to a proper pass.  As a
part of this change, it should be invoked by `circt-opt` instead of
`circt-translate`. This change should fix the integration build.

Example broken build: https://github.com/llvm/circt/runs/3802989444?check_suite_focus=true
Testing this on an integration build: https://github.com/llvm/circt/actions/runs/1308501663