### PR TITLE
[HWExportModuleHierarchy] Directly emit JSON to a file instead of an sv.verbatim op.

### DIFF
--- a/include/circt/Dialect/SV/SVPasses.h
+++ b/include/circt/Dialect/SV/SVPasses.h
@@ -13,8 +13,8 @@
 #ifndef CIRCT_DIALECT_SV_SVPASSES_H
 #define CIRCT_DIALECT_SV_SVPASSES_H
 
-#include "llvm/ADT/StringRef.h"
 #include "mlir/Pass/Pass.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace circt {
 namespace sv {

--- a/include/circt/Dialect/SV/SVPasses.h
+++ b/include/circt/Dialect/SV/SVPasses.h
@@ -13,6 +13,7 @@
 #ifndef CIRCT_DIALECT_SV_SVPASSES_H
 #define CIRCT_DIALECT_SV_SVPASSES_H
 
+#include "llvm/ADT/StringRef.h"
 #include "mlir/Pass/Pass.h"
 
 namespace circt {
@@ -26,7 +27,8 @@ std::unique_ptr<mlir::Pass> createHWLegalizeModulesPass();
 std::unique_ptr<mlir::Pass> createHWGeneratorCalloutPass();
 std::unique_ptr<mlir::Pass> createHWMemSimImplPass();
 std::unique_ptr<mlir::Pass> createSVExtractTestCodePass();
-std::unique_ptr<mlir::Pass> createHWExportModuleHierarchyPass();
+std::unique_ptr<mlir::Pass>
+createHWExportModuleHierarchyPass(llvm::StringRef directory = "./");
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/SV/SVPasses.h.inc"

--- a/include/circt/Dialect/SV/SVPasses.h
+++ b/include/circt/Dialect/SV/SVPasses.h
@@ -28,7 +28,7 @@ std::unique_ptr<mlir::Pass> createHWGeneratorCalloutPass();
 std::unique_ptr<mlir::Pass> createHWMemSimImplPass();
 std::unique_ptr<mlir::Pass> createSVExtractTestCodePass();
 std::unique_ptr<mlir::Pass>
-createHWExportModuleHierarchyPass(llvm::StringRef directory = "./");
+createHWExportModuleHierarchyPass(llvm::Optional<std::string> directory = {});
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/SV/SVPasses.h.inc"

--- a/include/circt/Dialect/SV/SVPasses.td
+++ b/include/circt/Dialect/SV/SVPasses.td
@@ -130,7 +130,7 @@ def HWExportModuleHierarchy : Pass<"hw-export-module-hierarchy",
   let dependentDialects = ["circt::sv::SVDialect"];
 
   let options = [
-    Option<"directoryName", "dir-name", "std::string", "",
+    Option<"directoryName", "dir-name", "std::string", "\"./\"",
             "Directory to emit into">
    ];
 }

--- a/include/circt/Dialect/SV/SVPasses.td
+++ b/include/circt/Dialect/SV/SVPasses.td
@@ -128,6 +128,11 @@ def HWExportModuleHierarchy : Pass<"hw-export-module-hierarchy",
 
   let constructor = "circt::sv::createHWExportModuleHierarchyPass()";
   let dependentDialects = ["circt::sv::SVDialect"];
+
+  let options = [
+    Option<"directoryName", "dir-name", "std::string", "",
+            "Directory to emit into">
+   ];
 }
 
 #endif // CIRCT_DIALECT_SV_SVPASSES

--- a/include/circt/Support/Path.h
+++ b/include/circt/Support/Path.h
@@ -1,0 +1,30 @@
+//===- Path.h - Path Utilities ----------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Utilities for file system path handling, supplementing the ones from
+// llvm::sys::path.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_SUPPORT_PATH_H
+#define CIRCT_SUPPORT_PATH_H
+
+#include "circt/Support/LLVM.h"
+
+namespace circt {
+
+/// Append a path to an existing path, replacing it if the other path is
+/// absolute. This mimicks the behaviour of `foo/bar` and `/foo/bar` being used
+/// in a working directory `/home`, resulting in `/home/foo/bar` and `/foo/bar`,
+/// respectively.
+void appendPossiblyAbsolutePath(llvm::SmallVectorImpl<char> &base,
+                                const llvm::Twine &suffix);
+
+} // namespace circt
+
+#endif // CIRCT_SUPPORT_PATH_H

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -21,6 +21,7 @@
 #include "circt/Dialect/SV/SVVisitors.h"
 #include "circt/Support/LLVM.h"
 #include "circt/Support/LoweringOptions.h"
+#include "circt/Support/Path.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/IR/Threading.h"
@@ -681,22 +682,6 @@ getLocationInfoAsString(const SmallPtrSet<Operation *, 8> &ops) {
   }
 
   return sstr.str();
-}
-
-/// Append a path to an existing path, replacing it if the other path is
-/// absolute. This mimicks the behaviour of `foo/bar` and `/foo/bar` being used
-/// in a working directory `/home`, resulting in `/home/foo/bar` and `/foo/bar`,
-/// respectively.
-// TODO: This also exists in BlackBoxReader.cpp. Maybe we should move this to
-// some CIRCT-wide file system utility source file?
-static void appendPossiblyAbsolutePath(SmallVectorImpl<char> &base,
-                                       const Twine &suffix) {
-  if (llvm::sys::path::is_absolute(suffix)) {
-    base.clear();
-    suffix.toVector(base);
-  } else {
-    llvm::sys::path::append(base, suffix);
-  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
@@ -19,6 +19,7 @@
 #include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Dialect/HW/HWDialect.h"
 #include "circt/Dialect/SV/SVOps.h"
+#include "circt/Support/Path.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/Support/FileUtilities.h"
 #include "llvm/ADT/SmallPtrSet.h"
@@ -33,20 +34,6 @@ using namespace firrtl;
 
 using hw::OutputFileAttr;
 using sv::VerbatimOp;
-
-/// Append a path to an existing path, replacing it if the other path is
-/// absolute. This mimicks the behaviour of `foo/bar` and `/foo/bar` being used
-/// in a working directory `/home`, resulting in `/home/foo/bar` and `/foo/bar`,
-/// respectively.
-static void appendPossiblyAbsolutePath(SmallVectorImpl<char> &base,
-                                       const Twine &suffix) {
-  if (llvm::sys::path::is_absolute(suffix)) {
-    base.clear();
-    suffix.toVector(base);
-  } else {
-    llvm::sys::path::append(base, suffix);
-  }
-}
 
 //===----------------------------------------------------------------------===//
 // Pass Implementation

--- a/lib/Dialect/SV/Transforms/HWExportModuleHierarchy.cpp
+++ b/lib/Dialect/SV/Transforms/HWExportModuleHierarchy.cpp
@@ -93,7 +93,8 @@ void HWExportModuleHierarchyPass::runOnOperation() {
       if (!directoryCreated) {
         auto error = llvm::sys::fs::create_directory(directoryName);
         if (error) {
-          llvm::errs() << error.message() << "\n";
+          op->emitError("Error creating directory in HWExportModuleHierarchy: ")
+              << error.message();
           signalPassFailure();
           return;
         }
@@ -105,7 +106,8 @@ void HWExportModuleHierarchyPass::runOnOperation() {
       std::unique_ptr<llvm::ToolOutputFile> outputFile(
           mlir::openOutputFile(outputPath, &errorMessage));
       if (!outputFile) {
-        llvm::errs() << errorMessage << "\n";
+        op->emitError("Error creating file in HWExportModuleHierarchy: ")
+            << errorMessage;
         signalPassFailure();
         return;
       }

--- a/lib/Dialect/SV/Transforms/HWExportModuleHierarchy.cpp
+++ b/lib/Dialect/SV/Transforms/HWExportModuleHierarchy.cpp
@@ -32,8 +32,9 @@ using namespace circt;
 
 struct HWExportModuleHierarchyPass
     : public sv::HWExportModuleHierarchyBase<HWExportModuleHierarchyPass> {
-  HWExportModuleHierarchyPass(StringRef directory) {
-    directoryName = directory.str();
+  HWExportModuleHierarchyPass(Optional<std::string> directory) {
+    if (directory.hasValue())
+      directoryName = directory.getValue();
   }
   void runOnOperation() override;
 };
@@ -126,6 +127,6 @@ void HWExportModuleHierarchyPass::runOnOperation() {
 //===----------------------------------------------------------------------===//
 
 std::unique_ptr<mlir::Pass>
-sv::createHWExportModuleHierarchyPass(StringRef directory) {
+sv::createHWExportModuleHierarchyPass(Optional<std::string> directory) {
   return std::make_unique<HWExportModuleHierarchyPass>(directory);
 }

--- a/lib/Support/Path.cpp
+++ b/lib/Support/Path.cpp
@@ -1,0 +1,31 @@
+//===- Path.cpp - Path Utilities --------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Utilities for file system path handling, supplementing the ones from
+// llvm::sys::path.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Support/Path.h"
+#include "llvm/Support/Path.h"
+
+using namespace circt;
+
+/// Append a path to an existing path, replacing it if the other path is
+/// absolute. This mimicks the behaviour of `foo/bar` and `/foo/bar` being used
+/// in a working directory `/home`, resulting in `/home/foo/bar` and `/foo/bar`,
+/// respectively.
+void circt::appendPossiblyAbsolutePath(llvm::SmallVectorImpl<char> &base,
+                                       const llvm::Twine &suffix) {
+  if (llvm::sys::path::is_absolute(suffix)) {
+    base.clear();
+    suffix.toVector(base);
+  } else {
+    llvm::sys::path::append(base, suffix);
+  }
+}

--- a/test/Dialect/SV/hw-export-module-hierarchy.mlir
+++ b/test/Dialect/SV/hw-export-module-hierarchy.mlir
@@ -1,6 +1,8 @@
-// RUN: circt-opt -pass-pipeline=hw-export-module-hierarchy %s | FileCheck %s
+// RUN: rm -rf %t
+// RUN: circt-opt -pass-pipeline='hw-export-module-hierarchy{dir-name=%t}' %s
+// RUN: FileCheck %s < %t/testharness_hier.json
 
-// CHECK: sv.verbatim "{\22instance_name\22:\22TestHarness\22,\22module_name\22:\22TestHarness\22,\22instances\22:[{\22instance_name\22:\22main_design\22,\22module_name\22:\22MainDesign\22,\22instances\22:[{\22instance_name\22:\22inner\22,\22module_name\22:\22InnerModule\22,\22instances\22:[]}]}]}" {output_file = {directory = "", exclude_from_filelist = true, exclude_replicated_ops = true, name = "testharness_hier.json"}, symbols = []}
+// CHECK: {"instance_name":"TestHarness","module_name":"TestHarness","instances":[{"instance_name":"main_design","module_name":"MainDesign","instances":[{"instance_name":"inner","module_name":"InnerModule","instances":[]}]}]}
 
 hw.module @InnerModule(%in: i1) -> (out: i1) {
   hw.output %in : i1
@@ -11,7 +13,7 @@ hw.module @MainDesign(%in: i1) -> (out: i1) {
   hw.output %0 : i1
 }
 
-hw.module @TestHarness() attributes {firrtl.moduleHierarchyFile = {directory = "", exclude_from_filelist = true, exclude_replicated_ops = true, name = "testharness_hier.json"}} {
+hw.module @TestHarness() attributes {firrtl.moduleHierarchyFile = #hw.output_file<"testharness_hier.json", excludeFromFileList>} {
   %0 = hw.constant 1 : i1
   hw.instance "main_design" @MainDesign(in: %0: i1) -> (out: i1)
 }

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -408,11 +408,6 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
     // Legalize the module names.
     pm.addPass(sv::createHWLegalizeNamesPass());
 
-    // Run module hierarchy emission after verilog emission, which ensures we
-    // pick up any changes that verilog emission made.
-    if (exportModuleHierarchy)
-      pm.addPass(sv::createHWExportModuleHierarchyPass());
-
     // Emit a single file or multiple files depending on the output format.
     switch (outputFormat) {
     case OutputMLIR:
@@ -423,6 +418,10 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
       break;
     case OutputSplitVerilog:
       pm.addPass(createExportSplitVerilogPass(outputFilename));
+      // Run module hierarchy emission after verilog emission, which ensures we
+      // pick up any changes that verilog emission made.
+      if (exportModuleHierarchy)
+        pm.addPass(sv::createHWExportModuleHierarchyPass(outputFilename));
       break;
     }
   }


### PR DESCRIPTION
This should unblock https://github.com/llvm/circt/issues/1708 as discussed in https://github.com/llvm/circt/pull/1792#issuecomment-934057209.

Previously this pass created an sv.verbatim op with the entirety of the
module hierarchy JSON file embedded into it, with the expectation that
the --split-verilog mode of firtool would actually be the one to create
it. This is now problematic because we'd like to move name legalization,
into the ExportVerilog pass, which means module names could change after
ExportVerilog runs.

Moving the HWExportModuleHierarchy pass after ExportVerilog guarantees
that names match the final verilog, but that means that
HWExportModuleHierarchy may no longer rely on the sv.verbatim op
output_file method to actually emit the file.

This commit changes HWExportModuleHierarchy to directly write the module
hierarchy JSON files. Note that firtool will now only run the
HWExportModuleHierarchy pass when --split-verilog mode is enabled, since
we now only want to run it when we have an output directory to dump
files to.


Also, this PR does one small, independent refactoring to move the `appendPossiblyAbsolutePath()` function into a new `lib/Support/Path.cpp` file so that I could use it without having to create a third copy of the function: https://github.com/llvm/circt/commit/07f72f4061495d9c2467cddd5cd93ec4c401716b. I could land this commit separately from the rest of this PR if I need to do significant rework on the main changes here.


A few questions I had about my changes here:

- I'm still pretty unfamiliar with exactly how TableGen works, so I copied what the `ExportSplitVerilog` pass was doing in order to get an option for the directory name. Let me know if I missed something or if there's a better way of doing this.
- I changed firtool to add the `HWExportModuleHierarchy` pass only if `ExportSplitVerilog` is run, just because I didn't think it'd be a good experience to have the export module hierarchy stuff dump a bunch of files into the current working directory. I could have this run after either `ExportVerilog` or `ExportSplitVerilog` if we think that's fine.
- I'm now doing a lot of file system-y stuff in the pass, such as creating the output directory if it doesn't exist, opening each output file for writing, etc. Is this the `HWExportModuleHierarchy` pass the right place to be doing these kinds of things? Before it was very "pure" in the sense of not relying on system-y stuff, but now it needs to directly call these kinds of functions and appropriately handle failure.