### PR TITLE
[CMake] [NFC] Eliminate cmake `glob`s

### DIFF
--- a/lib/Conversion/ExportVerilog/CMakeLists.txt
+++ b/lib/Conversion/ExportVerilog/CMakeLists.txt
@@ -1,8 +1,8 @@
-file(GLOB globbed *.cpp)
 
 add_circt_translation_library(CIRCTExportVerilog
-  ${globbed}
-  
+  ExportVerilog.cpp
+  PrepareForEmission.cpp
+
   ADDITIONAL_HEADER_DIRS
 
   DEPENDS

--- a/lib/Dialect/Comb/CMakeLists.txt
+++ b/lib/Dialect/Comb/CMakeLists.txt
@@ -1,6 +1,8 @@
-file(GLOB globbed *.cpp)
 add_circt_dialect_library(CIRCTComb
-  ${globbed}
+  CombFolds.cpp
+  CombOps.cpp
+  CombAnalysis.cpp
+  CombDialect.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/Comb

--- a/lib/Dialect/FIRRTL/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/CMakeLists.txt
@@ -1,6 +1,12 @@
-file(GLOB globbed *.cpp)
 add_circt_dialect_library(CIRCTFIRRTL
-  ${globbed}
+  FIRRTLAnnotations.cpp
+  FIRRTLAttributes.cpp
+  FIRRTLDialect.cpp
+  FIRRTLFolds.cpp
+  FIRRTLOpInterfaces.cpp
+  FIRRTLOps.cpp
+  FIRRTLTypes.cpp
+  InstanceGraph.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/FIRRTL

--- a/lib/Dialect/FIRRTL/Export/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Export/CMakeLists.txt
@@ -1,7 +1,6 @@
-file(GLOB globbed *.cpp)
-
 add_circt_translation_library(CIRCTExportFIRRTL
-  ${globbed}
+  FIREmitter.cpp
+
   LINK_LIBS PUBLIC
   CIRCTFIRRTL
   MLIRTranslation

--- a/lib/Dialect/FIRRTL/Import/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Import/CMakeLists.txt
@@ -1,8 +1,8 @@
-file(GLOB globbed *.cpp)
-
 add_circt_translation_library(CIRCTImportFIRFile
-  ${globbed}
-  
+  FIRAnnotations.cpp
+  FIRLexer.cpp
+  FIRParser.cpp
+
   ADDITIONAL_HEADER_DIRS
 
   LINK_LIBS PUBLIC

--- a/lib/Dialect/FSM/CMakeLists.txt
+++ b/lib/Dialect/FSM/CMakeLists.txt
@@ -1,7 +1,7 @@
-file(GLOB globbed *.cpp)
-
 add_circt_dialect_library(CIRCTFSM
-  ${globbed}
+  FSMDialect.cpp
+  FSMOps.cpp
+  FSMTypes.cpp
 
   DEPENDS
   MLIRFSMIncGen

--- a/lib/Dialect/MSFT/TclExport/CMakeLists.txt
+++ b/lib/Dialect/MSFT/TclExport/CMakeLists.txt
@@ -6,11 +6,9 @@
 ##
 ##===----------------------------------------------------------------------===//
 
-file(GLOB globbed *.cpp)
-
 add_circt_translation_library(CIRCTMSFTExportTcl
-  ${globbed}
-  
+  ExportQuartusTcl.cpp
+
   ADDITIONAL_HEADER_DIRS
 
   LINK_LIBS PUBLIC

--- a/lib/Dialect/SV/CMakeLists.txt
+++ b/lib/Dialect/SV/CMakeLists.txt
@@ -1,6 +1,7 @@
-file(GLOB globbed *.cpp)
 add_circt_dialect_library(CIRCTSV
-  ${globbed}
+  SVDialect.cpp
+  SVOps.cpp
+  SVTypes.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/SV

--- a/lib/Dialect/Seq/CMakeLists.txt
+++ b/lib/Dialect/Seq/CMakeLists.txt
@@ -9,9 +9,10 @@
 ##
 ##===----------------------------------------------------------------------===//
 
-file(GLOB globbed *.cpp)
 add_circt_dialect_library(CIRCTSeq
-  ${globbed}
+  SeqDialect.cpp
+  SeqOps.cpp
+  SeqPasses.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/Seq


### PR DESCRIPTION
CMake `glob`s only get run at configuration time; so, when one adds a file,
they must cmake re-configure. When a file gets added and someone git-pulls it
in, they must manually re-configure (since Ninja doesn't detect the
cmake-affecting change). This change makes it so `git pull && ninja` just
works.