### PR TITLE
[FIRRTL] Expand coverage for printf-encoded verif ops

### DIFF
--- a/lib/Dialect/FIRRTL/Import/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Import/CMakeLists.txt
@@ -2,6 +2,7 @@ add_circt_translation_library(CIRCTImportFIRFile
   FIRAnnotations.cpp
   FIRLexer.cpp
   FIRParser.cpp
+  FIRParserAsserts.cpp
 
   ADDITIONAL_HEADER_DIRS
 

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -46,6 +46,13 @@ namespace json = llvm::json;
 // Parser-related utilities
 //===----------------------------------------------------------------------===//
 
+namespace circt {
+namespace firrtl {
+ParseResult foldWhenEncodedVerifOp(ImplicitLocOpBuilder &builder,
+                                   WhenOp whenStmt);
+} // namespace firrtl
+} // namespace circt
+
 std::pair<bool, Optional<LocationAttr>> circt::firrtl::maybeStringToLocation(
     StringRef spelling, bool skipParsing, Identifier &locatorFilenameCache,
     FileLineColLoc &fileLineColLocCache, MLIRContext *context) {
@@ -2266,18 +2273,6 @@ ParseResult FIRStmtParser::parseMemPort(MemDirAttr direction) {
   return moduleContext.addSymbolEntry(id, memoryData, startLoc, true);
 }
 
-template <typename Op>
-static ParseResult generatePrintfEncodedVerifOp(ImplicitLocOpBuilder &builder,
-                                                Value clock, Value condition,
-                                                StringRef message) {
-  APInt constOne(1, 1, false);
-  Value constTrue = builder.create<ConstantOp>(
-      UIntType::get(builder.getContext(), 1), constOne);
-  builder.create<Op>(clock, condition, constTrue, message, "",
-                     /*isConcurrent=*/true);
-  return success();
-}
-
 /// printf ::= 'printf(' exp exp StringLit exp* ')' name? info?
 ParseResult FIRStmtParser::parsePrintf() {
   auto startTok = consumeToken(FIRToken::lp_printf);
@@ -2307,20 +2302,6 @@ ParseResult FIRStmtParser::parsePrintf() {
   locationProcessor.setLoc(startTok.getLoc());
 
   auto formatStrUnescaped = FIRToken::getStringValue(formatString);
-  StringRef formatStringRef(formatStrUnescaped);
-
-  // Check if this is a printf-encoded verification statement. These are
-  // introduced by "assert:" and friends.
-  if (formatStringRef.startswith("assert:"))
-    return generatePrintfEncodedVerifOp<AssertOp>(builder, clock, condition,
-                                                  formatStringRef);
-  if (formatStringRef.startswith("assume:"))
-    return generatePrintfEncodedVerifOp<AssumeOp>(builder, clock, condition,
-                                                  formatStringRef);
-  if (formatStringRef.startswith("cover:"))
-    return generatePrintfEncodedVerifOp<CoverOp>(builder, clock, condition,
-                                                 formatStringRef);
-
   builder.create<PrintFOp>(clock, condition,
                            builder.getStringAttr(formatStrUnescaped), operands,
                            name);
@@ -2495,13 +2476,13 @@ ParseResult FIRStmtParser::parseWhen(unsigned whenIndent) {
 
   // If the else is present, handle it otherwise we're done.
   if (getToken().isNot(FIRToken::kw_else))
-    return success();
+    return foldWhenEncodedVerifOp(builder, whenStmt);
 
   // If the 'else' is less indented than the when, then it must belong to some
   // containing 'when'.
   auto elseIndent = getIndentation();
   if (elseIndent.hasValue() && elseIndent.getValue() < whenIndent)
-    return success();
+    return foldWhenEncodedVerifOp(builder, whenStmt);
 
   consumeToken(FIRToken::kw_else);
 

--- a/lib/Dialect/FIRRTL/Import/FIRParserAsserts.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParserAsserts.cpp
@@ -1,0 +1,443 @@
+//===- FIRParserAsserts.cpp - Printf-encoded assert handling --------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements handling of printf-encoded verification operations
+// embedded in when blocks.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "llvm/Support/JSON.h"
+
+using namespace circt;
+using namespace firrtl;
+
+namespace json = llvm::json;
+
+namespace {
+/// Helper class to destructure parsed JSON and emit appropriate error messages.
+template <typename JsonType>
+struct ExtractionSummaryCursor {
+  Location loc;
+  const Twine &path;
+  JsonType value;
+
+  ExtractionSummaryCursor(const ExtractionSummaryCursor &) = delete;
+  ExtractionSummaryCursor &operator=(const ExtractionSummaryCursor &) = delete;
+
+  /// Report an error about the current path.
+  InFlightDiagnostic emitError() const {
+    auto diag = mlir::emitError(loc, "extraction summary ");
+    if (!path.isTriviallyEmpty())
+      diag << "field `" << path << "` ";
+    return diag;
+  }
+
+  /// Access a field in an object.
+  ParseResult withField(StringRef field,
+                        llvm::function_ref<ParseResult(
+                            const ExtractionSummaryCursor<json::Value *> &)>
+                            fn,
+                        bool optional = false) const {
+    auto fieldValue = value->get(field);
+    if (!fieldValue) {
+      if (optional)
+        return success();
+      emitError() << "missing `" << field << "` field";
+      return failure();
+    }
+    return fn({loc, path.isTriviallyEmpty() ? field : path + "." + field,
+               fieldValue});
+  }
+
+  /// Access a JSON value as an object.
+  ParseResult withObject(llvm::function_ref<ParseResult(
+                             const ExtractionSummaryCursor<json::Object *> &)>
+                             fn) const {
+    auto obj = value->getAsObject();
+    if (!obj) {
+      emitError() << "must be an object";
+      return failure();
+    }
+    return fn({loc, path, obj});
+  }
+
+  /// Access a JSON value as a string.
+  ParseResult withString(llvm::function_ref<ParseResult(
+                             const ExtractionSummaryCursor<StringRef> &)>
+                             fn) const {
+    auto str = value->getAsString();
+    if (!str) {
+      emitError() << "must be a string";
+      return failure();
+    }
+    return fn({loc, path, *str});
+  }
+
+  /// Access a JSON value as an array.
+  ParseResult withArray(llvm::function_ref<ParseResult(
+                            const ExtractionSummaryCursor<json::Value *> &)>
+                            fn) const {
+    auto array = value->getAsArray();
+    if (!array) {
+      emitError() << "must be an array";
+      return failure();
+    }
+    for (size_t i = 0, e = array->size(); i < e; ++i)
+      if (fn({loc, path + "[" + Twine(i) + "]", &(*array)[i]}))
+        return failure();
+    return success();
+  }
+
+  /// Access an object field as an object.
+  ParseResult
+  withObjectField(StringRef field,
+                  llvm::function_ref<ParseResult(
+                      const ExtractionSummaryCursor<json::Object *> &)>
+                      fn,
+                  bool optional = false) const {
+    return withField(
+        field, [&](const auto &cursor) { return cursor.withObject(fn); },
+        optional);
+  }
+
+  /// Access an object field as a string.
+  ParseResult withStringField(StringRef field,
+                              llvm::function_ref<ParseResult(
+                                  const ExtractionSummaryCursor<StringRef> &)>
+                                  fn,
+                              bool optional = false) const {
+    return withField(
+        field, [&](const auto &cursor) { return cursor.withString(fn); },
+        optional);
+  }
+
+  /// Access an object field as an array.
+  ParseResult
+  withArrayField(StringRef field,
+                 llvm::function_ref<ParseResult(
+                     const ExtractionSummaryCursor<json::Value *> &)>
+                     fn,
+                 bool optional = true) const {
+    return withField(
+        field, [&](const auto &cursor) { return cursor.withArray(fn); },
+        optional);
+  }
+};
+
+/// Convenience function to create a `ExtractionSummaryCursor`.
+template <typename JsonType>
+ExtractionSummaryCursor<JsonType>
+makeExtractionSummaryCursor(Location loc, JsonType jsonValue) {
+  return ExtractionSummaryCursor<JsonType>{loc, {}, jsonValue};
+}
+} // namespace
+
+/// A flavor of when-printf-encoded verification statement.
+enum class VerifFlavor {
+  VerifLibAssert, // contains "[verif-library-assert]"
+  VerifLibAssume, // contains "[verif-library-assume]"
+  Assert,         // begins with "assert:"
+  Assume,         // begins with "assume:"
+  Cover,          // begins with "cover:"
+  ChiselAssert,   // begins with "Assertion failed"
+  AssertNotX      // begins with "assertNotX:"
+};
+
+namespace circt {
+namespace firrtl {
+
+/// Chisel has a tendency to emit complex assert/assume/cover statements encoded
+/// as print operations with special formatting and metadata embedded in the
+/// message literal. These always reside in a when block of the following form:
+///
+///     when invCond:
+///       printf(clock, UInt<1>(1), "...[verif-library-assert]...")
+///       stop(clock, UInt<1>(1), 1)
+///
+/// Depending on the nature the verification operation, the `stop` may be
+/// optional. The Scala implementation simply removes all `stop`s that have the
+/// same condition as the printf.
+ParseResult foldWhenEncodedVerifOp(ImplicitLocOpBuilder &builder,
+                                   WhenOp whenStmt) {
+  auto *context = builder.getContext();
+
+  // The when blocks we're interested in don't have an else region.
+  if (whenStmt.hasElseRegion())
+    return success();
+
+  // The when blocks we're interested in contain a `PrintFOp` and an optional
+  // `StopOp` with the same clock and condition as the print.
+  Block &thenBlock = whenStmt.getThenBlock();
+  auto opIt = thenBlock.begin();
+  auto opEnd = thenBlock.end();
+  if (opIt == opEnd)
+    return success();
+
+  // `printf(clock, enable, ...)`
+  auto printOp = dyn_cast<PrintFOp>(*opIt++);
+  if (!printOp)
+    return success();
+
+  // optional `stop(clock, enable, ...)`
+  if (opIt != opEnd) {
+    auto stopOp = dyn_cast<StopOp>(*opIt++);
+    if (!stopOp || opIt != opEnd || stopOp.clock() != printOp.clock() ||
+        stopOp.cond() != printOp.cond())
+      return success();
+    stopOp.erase();
+  }
+
+  // Detect if we're dealing with a verification statement, and what flavor of
+  // statement it is.
+  auto fmt = printOp.formatString();
+  VerifFlavor flavor;
+  if (fmt.contains("[verif-library-assert]"))
+    flavor = VerifFlavor::VerifLibAssert;
+  else if (fmt.contains("[verif-library-assume]"))
+    flavor = VerifFlavor::VerifLibAssume;
+  else if (fmt.consume_front("assert:"))
+    flavor = VerifFlavor::Assert;
+  else if (fmt.consume_front("assume:"))
+    flavor = VerifFlavor::Assume;
+  else if (fmt.consume_front("cover:"))
+    flavor = VerifFlavor::Cover;
+  else if (fmt.consume_front("assertNotX:"))
+    flavor = VerifFlavor::AssertNotX;
+  else if (fmt.startswith("Assertion failed"))
+    flavor = VerifFlavor::ChiselAssert;
+  else
+    return success();
+
+  builder.setInsertionPointAfter(whenStmt);
+
+  // CAREFUL: Since the assertions are encoded as "when something wrong, then
+  // print" an error message, we're actually asserting that something is *not*
+  // going wrong.
+  //
+  // In code:
+  //
+  //     when somethingGoingWrong:
+  //       printf("oops")
+  //
+  // Actually expresses:
+  //
+  //     assert(not(somethingGoingWrong), "oops")
+  //
+  // So you'll find quite a few inversions of the when condition below to
+  // represent this.
+
+  // TODO: None of the following ops preserve interpolated operands in the
+  // format string. SV allows this, and we might want to extend the
+  // `firrtl.{assert,assume,cover}` operations to deal with this.
+
+  switch (flavor) {
+    // Handle the case of property verification encoded as `<assert>:<msg>` or
+    // `<assert>:<label>:<msg>`.
+  case VerifFlavor::Assert:
+  case VerifFlavor::Assume:
+  case VerifFlavor::Cover:
+  case VerifFlavor::AssertNotX: {
+    // Extract label and message from the format string.
+    StringRef label, message;
+    std::tie(label, message) = fmt.split(':');
+    if (message.empty())
+      std::swap(label, message); // in case of no label
+
+    // AssertNotX has the special format `assertNotX:%d:msg`, where the `%d`
+    // would theoretically interpolate the value being check for X, but in
+    // practice the Scala impl of ExtractTestCode just discards that `%d` label
+    // and replaces it with `notX`. Also prepare the condition to be checked
+    // here.
+    Value predicate;
+    if (flavor == VerifFlavor::AssertNotX) {
+      label = "notX";
+      if (printOp.operands().size() != 1) {
+        printOp.emitError("printf-encoded assertNotX requires one operand");
+        return failure();
+      }
+      // Construct a `whenCond | (value !== 1'bx)` predicate.
+      predicate = builder.create<XorRPrimOp>(printOp.operands()[0]);
+      predicate = builder.create<VerbatimExprOp>(UIntType::get(context, 1),
+                                                 "{{0}} !== 1'bx", predicate);
+      predicate = builder.create<OrPrimOp>(whenStmt.condition(), predicate);
+    } else {
+      predicate = builder.create<NotPrimOp>(whenStmt.condition());
+    }
+
+    // CAVEAT: The Scala impl of ExtractTestCode explicitly sets `emitSVA` to
+    // false for these flavors of verification operations. I think it's a bad
+    // idea to decide at parse time if something becomes an SVA or a print+fatal
+    // process, so I'm not doing this here. If we ever come across this need, we
+    // may want to annotate the operation with an attribute to indicate that it
+    // wants to explicitly *not* be an SVA.
+
+    // TODO: Sanitize the label by replacing whitespace with "_" as done in the
+    // Scala impl of ExtractTestCode.
+    if (flavor == VerifFlavor::Assert || flavor == VerifFlavor::AssertNotX)
+      builder.create<AssertOp>(printOp.clock(), predicate, printOp.cond(),
+                               message, label, true);
+    else if (flavor == VerifFlavor::Assume)
+      builder.create<AssumeOp>(printOp.clock(), predicate, printOp.cond(),
+                               message, label, true);
+    else // VerifFlavor::Cover
+      builder.create<CoverOp>(printOp.clock(), predicate, printOp.cond(),
+                              message, label, true);
+    printOp.erase();
+    break;
+  }
+
+    // Handle the case of builtin Chisel assertions.
+  case VerifFlavor::ChiselAssert: {
+    builder.create<AssertOp>(printOp.clock(),
+                             builder.create<NotPrimOp>(whenStmt.condition()),
+                             printOp.cond(), fmt, "chisel3_builtin", true);
+    printOp.erase();
+    break;
+  }
+
+    // Handle the SiFive verification library asserts/assumes, which contain
+    // additional configuration attributes for the verification op, serialized
+    // to JSON and embedded in the print message within `<extraction-summary>`
+    // XML tags.
+  case VerifFlavor::VerifLibAssert:
+  case VerifFlavor::VerifLibAssume: {
+    // Isolate the JSON text in the `<extraction-summary>` XML tag.
+    StringRef prefix, exStr, suffix;
+    std::tie(prefix, exStr) = fmt.split("<extraction-summary>");
+    std::tie(exStr, suffix) = exStr.split("</extraction-summary>");
+
+    // The extraction summary is necessary for this kind of assertion, so we
+    // throw an error if it is missing.
+    if (exStr.empty()) {
+      auto diag = printOp.emitError(
+          "printf-encoded assert/assume requires extraction summary");
+      diag.attachNote(printOp.getLoc())
+          << "because printf message contains "
+             "`[verif-library-{assert,assume}]` tag";
+      diag.attachNote(printOp.getLoc())
+          << "expected JSON-encoded extraction summary in "
+             "`<extraction-summary>` XML tag";
+      return failure();
+    }
+
+    // Parse the extraction summary, which contains additional parameters for
+    // the assertion.
+    auto ex = json::parse(exStr);
+    if (auto err = ex.takeError()) {
+      handleAllErrors(std::move(err), [&](const json::ParseError &a) {
+        printOp.emitError("failed to parse JSON extraction summary")
+                .attachNote()
+            << a.message();
+      });
+      return failure();
+    }
+
+    // The extraction summary must be an object.
+    auto exObj = ex->getAsObject();
+    if (!exObj) {
+      printOp.emitError("extraction summary must be a JSON object");
+      return failure();
+    }
+
+    // Extract the common fields from the JSON.
+    StringRef predMod;
+    if (makeExtractionSummaryCursor(printOp.getLoc(), exObj)
+            .withObjectField("predicateModifier", [&](const auto &ex) {
+              return ex.withStringField("type", [&](const auto &ex) {
+                // TODO: Check that the string is one of the allowed values, and
+                // possibly convert to an enum.
+                predMod = ex.value;
+                return success();
+              });
+            }))
+      return failure();
+    // TODO: We should probably apply the predicate modifier here immediately.
+
+    SmallVector<Attribute> condCompToggles;
+    if (makeExtractionSummaryCursor(printOp.getLoc(), exObj)
+            .withArrayField("conditionalCompileToggles", [&](const auto &ex) {
+              return ex.withObject([&](const auto &ex) {
+                return ex.withStringField("type", [&](const auto &ex) {
+                  // TODO: Check that the string is one of the allowed values,
+                  // and possibly convert to an enum. Report errors as:
+                  //     ex.emitError() << "must be one of `blahrg`";
+                  //     return failure();
+                  condCompToggles.push_back(StringAttr::get(context, ex.value));
+                  return success();
+                });
+              });
+            }))
+      return failure();
+
+    SmallString<32> label("verif_library");
+    if (makeExtractionSummaryCursor(printOp.getLoc(), exObj)
+            .withArrayField("labelExts", [&](const auto &ex) {
+              return ex.withString([&](const auto &ex) {
+                label.push_back('_');
+                label.append(ex.value);
+                return success();
+              });
+            }))
+      return failure();
+
+    StringRef message = fmt;
+    if (makeExtractionSummaryCursor(printOp.getLoc(), exObj)
+            .withStringField("baseMsg", [&](const auto &ex) {
+              message = ex.value;
+              return success();
+            }))
+      return failure();
+
+    // Assertions carry an additional `format` field.
+    Optional<StringRef> format;
+    if (flavor == VerifFlavor::VerifLibAssert) {
+      if (makeExtractionSummaryCursor(printOp.getLoc(), exObj)
+              .withObjectField("format", [&](const auto &ex) {
+                return ex.withStringField("type", [&](const auto &ex) {
+                  // TODO: Check that the string is one of the allowed values,
+                  // and possibly convert to an enum.
+                  format = ex.value;
+                  return success();
+                });
+              }))
+        return failure();
+    }
+
+    // Build the verification op itself.
+    Operation *op;
+    auto predicate = builder.create<NotPrimOp>(whenStmt.condition());
+    if (flavor == VerifFlavor::VerifLibAssert)
+      op = builder.create<AssertOp>(printOp.clock(), predicate, printOp.cond(),
+                                    message, label, true);
+    else // VerifFlavor::VerifLibAssume
+      op = builder.create<AssumeOp>(printOp.clock(), predicate, printOp.cond(),
+                                    message, label, true);
+    printOp.erase();
+
+    // Attach additional attributes extracted from the JSON object.
+    op->setAttr("predicateModifier", StringAttr::get(context, predMod));
+    op->setAttr("conditionalCompileToggles",
+                ArrayAttr::get(context, condCompToggles));
+    if (format)
+      op->setAttr("format", StringAttr::get(context, *format));
+
+    break;
+  }
+  }
+
+  // Clean up the `WhenOp` if it has become completely empty.
+  if (thenBlock.empty())
+    whenStmt.erase();
+  return success();
+}
+
+} // namespace firrtl
+} // namespace circt

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -399,23 +399,14 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     assert(clock, pred, en, "X equals Y when Z is valid")
     ; CHECK: firrtl.assert %clock, %pred, %en, "X equals Y when Z is valid"  {eventControl = 0 : i32, isConcurrent = false, name = "assert_0"}
     assert(clock, pred, en, "X equals Y when Z is valid") : assert_0
-    ; CHECK: [[C:%.+]] = firrtl.constant 1 : !firrtl.uint<1>
-    ; CHECK-NEXT: firrtl.assert %clock, %pred, %c1_ui1, "assert:X equals Y when Z is valid"  {eventControl = 0 : i32, isConcurrent = true}
-    printf(clock, pred, "assert:X equals Y when Z is valid")
     ; CHECK: firrtl.assume %clock, %pred, %en, "X equals Y when Z is valid"  {eventControl = 0 : i32, isConcurrent = false}
     assume(clock, pred, en, "X equals Y when Z is valid")
     ; CHECK: firrtl.assume %clock, %pred, %en, "X equals Y when Z is valid" {eventControl = 0 : i32, isConcurrent = false, name = "assume_0"}
     assume(clock, pred, en, "X equals Y when Z is valid") : assume_0
-    ; CHECK: [[C2:%.+]] = firrtl.constant 1 : !firrtl.uint<1>
-    ; CHECK-NEXT: firrtl.assume %clock, %pred, [[C2]], "assume:X equals Y when Z is valid"  {eventControl = 0 : i32, isConcurrent = true}
-    printf(clock, pred, "assume:X equals Y when Z is valid")
     ; CHECK: firrtl.cover %clock, %pred, %en, "X equals Y when Z is valid"  {eventControl = 0 : i32, isConcurrent = false}
     cover(clock, pred, en, "X equals Y when Z is valid")
     ; CHECK: firrtl.cover %clock, %pred, %en, "X equals Y when Z is valid" {eventControl = 0 : i32, isConcurrent = false, name = "cover_0"}
     cover(clock, pred, en, "X equals Y when Z is valid") : cover_0
-    ; CHECK: [[C3:%.+]] = firrtl.constant 1 : !firrtl.uint<1>
-    ; CHECK-NEXT: firrtl.cover %clock, %pred, [[C3]], "cover:X equals Y when Z is valid"  {eventControl = 0 : i32, isConcurrent = true}
-    printf(clock, pred, "cover:X equals Y when Z is valid")
 
   ; CHECK-LABEL: firrtl.module @type_handling(
   module type_handling :
@@ -866,3 +857,97 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     b <= a
     ; CHECK: firrtl.connect %b, %a : !firrtl.bundle<a: reset, b: reset>, !firrtl.bundle<a: uint<1>, b: asyncreset>
+
+  ; CHECK-LABEL: @WhenEncodedVerification
+  module WhenEncodedVerification:
+    input clock: Clock
+    input cond: UInt<1>
+    input enable: UInt<1>
+    input value: UInt<42>
+
+    ; rocket-chip properties
+    when cond:
+      printf(clock, enable, "assert:foo 0")
+    ; CHECK: [[TMP:%.+]] = firrtl.not %cond
+    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "foo 0"
+
+    when cond:
+      printf(clock, enable, "assume:foo 1")
+    ; CHECK: [[TMP:%.+]] = firrtl.not %cond
+    ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "foo 1"
+
+    when cond:
+      printf(clock, enable, "cover:foo 2")
+    ; CHECK: [[TMP:%.+]] = firrtl.not %cond
+    ; CHECK-NEXT: firrtl.cover %clock, [[TMP]], %enable, "foo 2"
+
+    when cond:
+      printf(clock, enable, "assert:custom label 0:foo 3")
+    ; CHECK: [[TMP:%.+]] = firrtl.not %cond
+    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "foo 3"
+    ; CHECK-SAME: name = "custom label 0"
+
+    when cond:
+      printf(clock, enable, "assume:custom label 1:foo 4")
+    ; CHECK: [[TMP:%.+]] = firrtl.not %cond
+    ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "foo 4"
+    ; CHECK-SAME: name = "custom label 1"
+
+    when cond:
+      printf(clock, enable, "cover:custom label 2:foo 5")
+    ; CHECK: [[TMP:%.+]] = firrtl.not %cond
+    ; CHECK-NEXT: firrtl.cover %clock, [[TMP]], %enable, "foo 5"
+    ; CHECK-SAME: name = "custom label 2"
+
+    ; Optional `stop` with same clock and condition should be removed.
+    when cond:
+      printf(clock, enable, "assert:without_stop")
+      stop(clock, enable, 1)
+    ; CHECK: firrtl.assert %clock, {{%.+}}, %enable, "without_stop"
+    ; CHECK-NOT: firrtl.stop
+
+    ; AssertNotX -- usually `cond` only checks for not-in-reset, and `enable` is
+    ; just set to 1; the actual check `^value !== 'x` is implicit.
+    when cond:
+      printf(clock, enable, "assertNotX:%d:value must not be X!", value)
+    ; CHECK: [[TMP1:%.+]] = firrtl.xorr %value
+    ; CHECK: [[TMP2:%.+]] = firrtl.verbatim.expr "{{[{][{]0[}][}]}} !== 1'bx"([[TMP1]])
+    ; CHECK: [[TMP3:%.+]] = firrtl.or %cond, [[TMP2]]
+    ; CHECK: firrtl.assert %clock, [[TMP3]], %enable, "value must not be X!"
+    ; CHECK-SAME: name = "notX"
+
+    ; Chisel built-in assertions
+    when cond:
+      printf(clock, enable, "Assertion failed")
+      stop(clock, enable, 1)
+    ; CHECK: [[TMP:%.+]] = firrtl.not %cond
+    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Assertion failed"
+    ; CHECK-SAME: name = "chisel3_builtin"
+
+    when cond:
+      printf(clock, enable, "Assertion failed: some message")
+      stop(clock, enable, 1)
+    ; CHECK: [[TMP:%.+]] = firrtl.not %cond
+    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Assertion failed: some message"
+    ; CHECK-SAME: name = "chisel3_builtin"
+
+    ; Verification Library Assertions
+
+    when cond:
+      printf(clock, enable, "Assertion failed: [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"}],\"labelExts\":[\"label\",\"magic\"],\"format\":{\"type\":\"sva\"},\"baseMsg\":\"Hello Assert\"}")
+      stop(clock, enable, 1)
+    ; CHECK: [[TMP:%.+]] = firrtl.not %cond
+    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Hello Assert"
+    ; CHECK-SAME: conditionalCompileToggles = ["unrOnly"]
+    ; CHECK-SAME: format = "sva"
+    ; CHECK-SAME: name = "verif_library_label_magic"
+    ; CHECK-SAME: predicateModifier = "noMod"
+
+    when cond:
+      printf(clock, enable, "Assumption failed: [verif-library-assume]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"}],\"labelExts\":[\"label\",\"voodoo\"],\"baseMsg\":\"Hello Assume\"}")
+      stop(clock, enable, 1)
+    ; CHECK: [[TMP:%.+]] = firrtl.not %cond
+    ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "Hello Assume"
+    ; CHECK-SAME: conditionalCompileToggles = ["unrOnly"]
+    ; CHECK-SAME: name = "verif_library_label_voodoo"
+    ; CHECK-SAME: predicateModifier = "noMod"


### PR DESCRIPTION
Chisel and some of the SiFive-internal code make use of a variety of asserts encoded as printf statements to get around limitations of the native (possibly MFC-only) verification operations in FIRRTL. These are generally encoded as `printf` in a `when` block:

    when somethingGoingWrong:
      printf(..., "assert:some_label:Oops, something wrong here")

The flavors include "assert", "assume", "cover", "assertNotX", but also variations of "Assertion failed" and tags like "[verif-library-assert]". There's also precedence for XML tags wrapping a JSON-serialized Scala object describing additional properties of the assertion. Since we need to reason about these in `ExtractTestCode` and when we generate Verilog, these constructs should be converted to dedicated `firrtl.assert` ops (and friends), which have clear semantics.

This change introduces a post-processing step for `when` blocks into the FIRRTL parser, which pattern matches against these constructs and replaces them with an actual `firrtl.{assert,assume,cover}` which encodes the actual verification operation.