### PR TITLE
[PyCDE] Setup improvements for wheel building in CI.

### DIFF
--- a/frontends/PyCDE/setup.py
+++ b/frontends/PyCDE/setup.py
@@ -22,7 +22,7 @@ from setuptools import find_namespace_packages, setup, Extension
 from setuptools.command.build_ext import build_ext
 from setuptools.command.build_py import build_py
 
-_this_dir = os.path.abspath(os.path.dirname(__file__))
+_thisdir = os.path.abspath(os.path.dirname(__file__))
 
 
 # Build phase discovery is unreliable. Just tell it what phases to run.
@@ -50,7 +50,7 @@ class CMakeBuild(build_py):
       cmake_build_dir = os.path.join(target_dir, "..", "cmake_build")
     cmake_install_dir = os.path.join(target_dir, "..", "cmake_install")
     circt_dir = os.path.abspath(
-        os.environ.get("CIRCT_DIRECTORY", os.path.join(_this_dir, "..", "..")))
+        os.environ.get("CIRCT_DIRECTORY", os.path.join(_thisdir, "..", "..")))
     src_dir = os.path.abspath(os.path.join(circt_dir, "llvm", "llvm"))
     cfg = "Release"
     cmake_args = [


### PR DESCRIPTION
This adds two changes to PyCDE's setup.py to help build wheels in CI:

* Adds an optional CIRCT_DIRECTORY environment variable for CIs to
  pass a path to the CIRCT root. This is needed, for example, when
  building with cibuildwheel.
* Makes the path to LLVM relative to CIRCT, assuming the submodule is
  used. This previously looked for an LLVM directory sibling to the
  CIRCT directory, which puts an assumption on how LLVM is downloaded.
  The submodule is the documented location, and if something else is
  required, we can add an environment variable for that.