### PR TITLE
[SV] Add XMR op

### DIFF
--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -90,6 +90,27 @@ def RegOp : SVOp<"reg", [Symbol,
   }];
 }
 
+def XMROp : SVOp<"xmr", []> {
+  let summary = "Encode a reference to a non-local net.";
+  let description = [{
+    This represents a non-local hierarchical name to a net, sometimes called a
+    cross-module reference.  A hierarchical name may be absolute, when prefixed
+    with '$root', in which case it is resolved from the set of top-level modules
+    (any non-instantiated modules).  Non-absolute paths are resolved by
+    attempting resolution of the path locally, then recursively up the instance
+    graph. See SV Spec 23.6, pp721.
+
+    It is impossible to completely resolve a hierarchical name without making a
+    closed-world assumption in the compiler.  We therefore don't try to link
+    hierarchical names to what they resolve to at compile time.  A frontend
+    generating this op should ensure that any instance or object in the intended
+    path has public visibility so paths are not invalidated.
+  }];
+  let arguments = (ins UnitAttr:$isRooted, StringArrayAttr:$path, StrAttr:$terminal);
+  let results = (outs InOutType:$result);
+  let assemblyFormat = "(`isRooted` $isRooted^)? custom<XMRPath>($path, $terminal) attr-dict `:` type($result)"; 
+}
+
 def ReadInOutOp
  : SVOp<"read_inout",
         [NoSideEffect, InOutElementConstraint<"result", "input">]> {

--- a/include/circt/Dialect/SV/SVTypes.td
+++ b/include/circt/Dialect/SV/SVTypes.td
@@ -56,3 +56,15 @@ def SymRefArrayAttr: ArrayAttrBase<
     ""> {
   let constBuilderCall = "$_builder.getArrayAttr($0)";
 }
+
+def StringArrayAttr: ArrayAttrBase<
+    And<[
+      // Guarantee this is an ArrayAttr first
+      CPred<"$_self.isa<::mlir::ArrayAttr>()">,
+      // Guarantee all elements are StringAttr
+      CPred<"::llvm::all_of($_self.cast<::mlir::ArrayAttr>(), "
+            "[&](::mlir::Attribute attr) { return attr.isa<"
+            "::mlir::StringAttr>();})">]>,
+    ""> {
+  let constBuilderCall = "$_builder.getArrayAttr($0)";
+}

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -31,7 +31,7 @@ public:
             ReadInOutOp, ArrayIndexInOutOp, VerbatimExprOp, VerbatimExprSEOp,
             ConstantXOp, ConstantZOp,
             // Declarations.
-            RegOp, WireOp, LocalParamOp,
+            RegOp, WireOp, LocalParamOp, XMROp,
             // Control flow.
             IfDefOp, IfDefProceduralOp, IfOp, AlwaysOp, AlwaysCombOp,
             AlwaysFFOp, InitialOp, CaseZOp,
@@ -75,6 +75,7 @@ public:
   HANDLE(RegOp, Unhandled);
   HANDLE(WireOp, Unhandled);
   HANDLE(LocalParamOp, Unhandled);
+  HANDLE(XMROp, Unhandled);
 
   // Expressions
   HANDLE(ReadInOutOp, Unhandled);

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -301,7 +301,7 @@ static StringRef getSymOpName(Operation *symOp) {
 /// MemoryEffects should be checked if a client cares.
 bool ExportVerilog::isVerilogExpression(Operation *op) {
   // These are SV dialect expressions.
-  if (isa<ReadInOutOp, ArrayIndexInOutOp, ParamValueOp>(op))
+  if (isa<ReadInOutOp, ArrayIndexInOutOp, ParamValueOp, XMROp>(op))
     return true;
 
   // All HW combinational logic ops and SV expression ops are Verilog
@@ -1021,6 +1021,7 @@ private:
 
   SubExprInfo visitSV(GetModportOp op);
   SubExprInfo visitSV(ReadInterfaceSignalOp op);
+  SubExprInfo visitSV(XMROp op);
   SubExprInfo visitVerbatimExprOp(Operation *op, ArrayAttr symbols);
   SubExprInfo visitSV(VerbatimExprOp op) {
     return visitVerbatimExprOp(op, op.symbols());
@@ -1126,8 +1127,8 @@ private:
   /// location information tracking.
   SmallPtrSet<Operation *, 8> &emittedExprs;
 
-  /// If any subexpressions would result in too large of a line, report it back
-  /// to the caller in this vector.
+  /// If any subexpressions would result in too large of a line, report it
+  /// back to the caller in this vector.
   SmallVectorImpl<Operation *> &tooLargeSubExpressions;
   SmallVectorImpl<char> &outBuffer;
   llvm::raw_svector_ostream os;
@@ -1455,6 +1456,15 @@ SubExprInfo ExprEmitter::visitSV(GetModportOp op) {
 
 SubExprInfo ExprEmitter::visitSV(ReadInterfaceSignalOp op) {
   os << names.getName(op.iface()) + "." + op.signalName();
+  return {Selection, IsUnsigned};
+}
+
+SubExprInfo ExprEmitter::visitSV(XMROp op) {
+  if (op.isRooted())
+    os << "$root.";
+  for (auto s : op.path())
+    os << s.cast<StringAttr>().getValue() << '.';
+  os << op.terminal();
   return {Selection, IsUnsigned};
 }
 

--- a/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
+++ b/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
@@ -133,6 +133,11 @@ static inline bool isExpressionAlwaysInline(Operation *op) {
   if (isa<sv::GetModportOp>(op) || isa<sv::ReadInterfaceSignalOp>(op))
     return true;
 
+  // XMRs can't be spilled if they are on the lhs.  Conservatively never spill
+  // them.
+  if (isa<sv::XMROp>(op))
+    return true;
+
   return false;
 }
 

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -1246,6 +1246,41 @@ static LogicalResult verifyBindInterfaceOp(BindInterfaceOp op) {
 }
 
 //===----------------------------------------------------------------------===//
+// XMROp
+//===----------------------------------------------------------------------===//
+
+ParseResult parseXMRPath(::mlir::OpAsmParser &parser, ArrayAttr &pathAttr,
+                         StringAttr &terminalAttr) {
+  SmallVector<Attribute> strings;
+  ParseResult ret = parser.parseCommaSeparatedList([&]() {
+    StringAttr result;
+    StringRef keyword;
+    if (succeeded(parser.parseOptionalKeyword(&keyword))) {
+      strings.push_back(parser.getBuilder().getStringAttr(keyword));
+      return success();
+    }
+    if (succeeded(parser.parseAttribute(
+            result, parser.getBuilder().getType<NoneType>()))) {
+      strings.push_back(result);
+      return success();
+    }
+    return failure();
+  });
+  if (succeeded(ret)) {
+    pathAttr = parser.getBuilder().getArrayAttr(
+        ArrayRef(strings.begin(), strings.end() - 1));
+    terminalAttr = (*strings.rbegin()).cast<StringAttr>();
+  }
+  return ret;
+}
+
+void printXMRPath(OpAsmPrinter &p, XMROp op, ArrayAttr pathAttr,
+                  StringAttr terminalAttr) {
+  llvm::interleaveComma(pathAttr, p);
+  p << ", " << terminalAttr;
+}
+
+//===----------------------------------------------------------------------===//
 // TableGen generated logic.
 //===----------------------------------------------------------------------===//
 

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -193,3 +193,13 @@ hw.module @AB(%a: i1, %b: i2) {
   hw.instance "whatever" sym @a1 @ExternDestMod(a: %a: i1, b: %b: i2) -> () {doNotPrint=1}
   hw.instance "yo" sym @b1 @InternalDestMod(a: %a: i1, b: %b: i2) -> () {doNotPrint=1}
 }
+
+//CHECK-LABEL: hw.module @XMR_src
+hw.module @XMR_src(%a : i23) {
+  //CHECK-NEXT:   sv.xmr isRooted "a", "b", "c" : !hw.inout<i23>
+  %xmr1 = sv.xmr isRooted a,b,c : !hw.inout<i23>
+  //CHECK-NEXT:   sv.xmr "a", "b", "c" : !hw.inout<i3>
+  %xmr2 = sv.xmr "a",b,c : !hw.inout<i3>
+  %r = sv.read_inout %xmr1 : !hw.inout<i23>
+  sv.assign %xmr1, %a : i23
+}

--- a/test/ExportVerilog/sv-dialect.mlir
+++ b/test/ExportVerilog/sv-dialect.mlir
@@ -936,6 +936,16 @@ hw.module @InlineAutomaticLogicInit(%a : i42, %b: i42, %really_really_long_port:
   }
 }
 
+//CHECK-LABEL: module XMR_src
+//CHECK: assign $root.a.b.c = a;
+//CHECK-NEXT: assign aa = d.e.f;
+hw.module @XMR_src(%a : i23) -> (aa: i3) {
+  %xmr1 = sv.xmr isRooted a,b,c : !hw.inout<i23>
+  %xmr2 = sv.xmr "d",e,f : !hw.inout<i3>
+  %r = sv.read_inout %xmr2 : !hw.inout<i3>
+  sv.assign %xmr1, %a : i23
+  hw.output %r : i3
+}
 
 // CHECK-LABEL: module extInst
 hw.module.extern @extInst(%_h: i1, %_i: i1, %_j: i1, %_k: i1, %_z :i0) -> ()


### PR DESCRIPTION
XMRs or hirarchical names are really annoying.  They have context-dependent lookup rules.  They resolve to multiple elements, including external elements.  Resolution can be dependent on parameterization and generator nodes.  They require whole-world assumptions to resolve; resolving on a partial circuit might indicate something isn't referenced which really is after linking in external code.

This implements a purely syntactic XMR.  It does not try to link the name to existing circuit elements, this requires expensive analysis.  Frontends need to mark path elements with don't touch (or equivalent) where they want a path preserved.