### PR TITLE
[FIRRTL] Stop declaring FModuleLike attributes as op arguments

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -59,9 +59,7 @@ def FModuleOp : FIRRTLOp<"module", [IsolatedFromAbove, Symbol, SingleBlock,
     the module.
   }];
   let arguments =
-            (ins StrArrayAttr:$portNames,
-                 DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations,
-                 DefaultValuedAttr<PortAnnotationsAttr, "{}">:$portAnnotations);
+            (ins DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations);
 
   let results = (outs);
   let regions = (region SizedRegion<1>:$body);
@@ -112,11 +110,10 @@ def FExtModuleOp : FIRRTLOp<"extmodule",
     The "firrtl.extmodule" operation represents an external reference to a
     Verilog module, including a given name and a list of ports.
   }];
-  let arguments = (ins StrArrayAttr:$portNames,
+  let arguments = (ins
                    OptionalAttr<StrAttr>:$defname,
                    OptionalAttr<DictionaryAttr>:$parameters,
-                   DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations,
-                   DefaultValuedAttr<PortAnnotationsAttr, "{}">:$portAnnotations
+                   DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations
                   );
   let results = (outs);
   let regions = (region AnyRegion:$body);

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -423,7 +423,7 @@ void FModuleOp::erasePorts(ArrayRef<unsigned> portIndices) {
   SmallVector<Direction> directions =
       direction::unpackAttribute(this->getPortDirectionsAttr());
   ArrayRef<Attribute> portNames = this->getPortNames();
-  ArrayRef<Attribute> portAnno = this->portAnnotations().getValue();
+  ArrayRef<Attribute> portAnno = this->getPortAnnotations();
   ArrayRef<Attribute> portTypes = this->getPortTypes();
   assert(directions.size() == portNames.size());
 


### PR DESCRIPTION
This change removes the `portAnnotations` and `portNames`  attributes
from the FExtModule and FModule op's argument lists.  It is a little
unclear to me if this change is a good idea.  I noticed that some
attributes which are managed by OpInterfaces are not always declared as
ODS arguments, for example neither of these ops define `sym_name` from
`Symbol`. Here are the differences that this change makes as far as I
can tell:

1. Less obvious that these attributes exist on the operation (bad thing)
2. We don't have redundant `portAnnotations()` and
   `getPortAnnotations()` functions defined (good thing)
3. We don't have redundant verification of the attribute from the
   `AnnotationArrayAttr` type constraint and `FModuleLike` verifier
   (might be a good thing).
4. Does not affect the builder methods, as these ops do not use the
   generated builder methods. (no effect)

Given what I have seen in other interfaces, I think this is the way to
go.