### PR TITLE
Support a generalized freechips.rocketchip.annotations.InternalVerifBlackBoxAnnotation in ExtractTestCode

### DIFF
--- a/docs/FIRRTLAnnotations.md
+++ b/docs/FIRRTLAnnotations.md
@@ -900,3 +900,8 @@ modules' bind file. This attribute has type OutputFileAttr.
 
 Used by SVExtractTestCode.  Specifies the output file for extracted
 modules' bind file. This attribute has type OutputFileAttr.
+
+### firrtl.extract.[cover|assume|assert].extra
+
+Used by SVExtractTestCode.  Indicates a module whose instances should be
+extracted from the circuit in the indicated extraction type.

--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
@@ -180,6 +180,7 @@ public:
   /// removed, false otherwise.
   bool removeAnnotation(Annotation anno);
   bool removeAnnotation(Attribute anno);
+  bool removeAnnotation(StringRef className);
 
   /// Remove all annotations from this annotation set for which `predicate`
   /// returns true. The predicate is guaranteed to be called on every

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
@@ -272,6 +272,13 @@ bool AnnotationSet::removeAnnotation(Attribute anno) {
       [&](Annotation other) { return other.getDict() == anno; });
 }
 
+/// Remove an annotation from this annotation set. Returns true if any were
+/// removed, false otherwise.
+bool AnnotationSet::removeAnnotation(StringRef className) {
+  return removeAnnotations(
+      [&](Annotation other) { return other.getClass() == className; });
+}
+
 /// Remove all annotations from this annotation set for which `predicate`
 /// returns true.
 bool AnnotationSet::removeAnnotations(

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1074,4 +1074,6 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %b = firrtl.bitcast %a : (!firrtl.bundle<valid: uint<2>, ready: uint<1>, data: uint<3>>) -> (!firrtl.vector<uint<2>, 3>)
     // CHECK: hw.bitcast %0 : (!hw.struct<valid: i2, ready: i1, data: i3>) -> !hw.array<3xi2>
   }
+
+  firrtl.extmodule @chkcoverAnno(in %clock: !firrtl.clock) attributes {annotations = [{class = "freechips.rocketchip.annotations.InternalVerifBlackBoxAnnotation"}]}
 }

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -1,12 +1,36 @@
 // RUN:  circt-opt --sv-extract-test-code %s | FileCheck %s
-// CHECK-LABEL: hw.module @issue1246_assert(%clock: i1) attributes {output_file = #hw.output_file<"dir3/", excludeFromFileList, includeReplicatedOps>}
+// CHECK-LABEL: module attributes {firrtl.extract.assert = #hw.output_file<"dir3/"
+// CHECK-NEXT: hw.module.extern @foo_cover
+// CHECK-NOT: attributes
+// CHECK-NEXT: hw.module.extern @foo_assume
+// CHECK-NOT: attributes
+// CHECK-NEXT: hw.module.extern @foo_assert
+// CHECK-NOT: attributes
+// CHECK: hw.module @issue1246_assert(%clock: i1) attributes {output_file = #hw.output_file<"dir3/", excludeFromFileList, includeReplicatedOps>}
 // CHECK: sv.assert
+// CHECK: foo_assert
 // CHECK: hw.module @issue1246_assume(%clock: i1) 
 // CHECK-NOT: attributes 
 // CHECK: sv.assume
+// CHECK: foo_assume
+// CHECK: hw.module @issue1246_cover(%clock: i1) 
+// CHECK-NOT: attributes 
+// CHECK: sv.cover
+// CHECK: foo_cover
 // CHECK: hw.module @issue1246
+// CHECK-NOT: sv.assert
+// CHECK-NOT: sv.assume
+// CHECK-NOT: sv.cover
+// CHECK-NOT: foo_assert
+// CHECK-NOT: foo_assume
+// CHECK-NOT: foo_cover
+// CHECK: sv.bind @__ETC_issue1246_assert in @issue1246
 // CHECK: sv.bind @__ETC_issue1246_assume in @issue1246 {output_file = #hw.output_file<"file4", excludeFromFileList>}
+// CHECK: sv.bind @__ETC_issue1246_cover in @issue1246
 module attributes {firrtl.extract.assert =  #hw.output_file<"dir3/", excludeFromFileList, includeReplicatedOps>, firrtl.extract.assume.bindfile = #hw.output_file<"file4", excludeFromFileList>} {
+  hw.module.extern @foo_cover(%a : i1) attributes {"firrtl.extract.cover.extra"} 
+  hw.module.extern @foo_assume(%a : i1) attributes {"firrtl.extract.assume.extra"} 
+  hw.module.extern @foo_assert(%a : i1) attributes {"firrtl.extract.assert.extra"} 
   hw.module @issue1246(%clock: i1) -> () {
     sv.always posedge %clock  {
       sv.ifdef.procedural "SYNTHESIS"  {
@@ -14,10 +38,14 @@ module attributes {firrtl.extract.assert =  #hw.output_file<"dir3/", excludeFrom
         sv.if %2937  {
           sv.assert  %clock : i1
           sv.assume %clock : i1
+          sv.cover %clock : i1
         }
       }
     }
     %2937 = hw.constant 0 : i1
+    hw.instance "bar_cover" @foo_cover(a: %clock : i1) -> ()
+    hw.instance "bar_assume" @foo_assume(a: %clock : i1) -> ()
+    hw.instance "bar_assert" @foo_assert(a: %clock : i1) -> ()
     hw.output
   }
 }


### PR DESCRIPTION
Covert freechips.rocketchip.annotations.InternalVerifBlackBoxAnnotation annotations to a generalized set of annotations that works not just for cover, but assert and assum extraction too.  Process those annotations in ExtractTestCode.