### PR TITLE
[FIRRTL] Donot create empty metadata verbatim ops

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -210,25 +210,31 @@ LogicalResult CreateSiFiveMetadataPass::emitMemoryMetadata() {
     if (auto dir = dirAnno.getAs<StringAttr>("dirname"))
       metadataDir = dir.getValue();
 
-  // Use unknown loc to avoid printing the location in the metadata files.
-  auto tbVerbatimOp = builder.create<sv::VerbatimOp>(builder.getUnknownLoc(),
-                                                     testBenchJsonBuffer);
-  auto dutVerbatimOp =
-      builder.create<sv::VerbatimOp>(builder.getUnknownLoc(), dutJsonBuffer);
-  auto confVerbatimOp =
-      builder.create<sv::VerbatimOp>(builder.getUnknownLoc(), seqMemConfStr);
-  auto fileAttr = hw::OutputFileAttr::getFromDirectoryAndFilename(
-      context, metadataDir, "seq_mems.json", /*excludeFromFilelist=*/true);
-  dutVerbatimOp->setAttr("output_file", fileAttr);
-  fileAttr = hw::OutputFileAttr::getFromDirectoryAndFilename(
-      context, metadataDir, "tb_seq_mems.json", /*excludeFromFilelist=*/true);
-  tbVerbatimOp->setAttr("output_file", fileAttr);
-  StringRef confFile = "memory";
-  if (dutMod)
-    confFile = dutMod.getName();
-  fileAttr = hw::OutputFileAttr::getFromDirectoryAndFilename(
-      context, metadataDir, confFile + ".conf", /*excludeFromFilelist=*/true);
-  confVerbatimOp->setAttr("output_file", fileAttr);
+  if (testBenchJsonBuffer != "[]") {
+    // Use unknown loc to avoid printing the location in the metadata files.
+    auto tbVerbatimOp = builder.create<sv::VerbatimOp>(builder.getUnknownLoc(),
+                                                       testBenchJsonBuffer);
+    auto fileAttr = hw::OutputFileAttr::getFromDirectoryAndFilename(
+        context, metadataDir, "tb_seq_mems.json", /*excludeFromFilelist=*/true);
+    tbVerbatimOp->setAttr("output_file", fileAttr);
+  }
+  if (dutJsonBuffer != "[]") {
+    auto dutVerbatimOp =
+        builder.create<sv::VerbatimOp>(builder.getUnknownLoc(), dutJsonBuffer);
+    auto fileAttr = hw::OutputFileAttr::getFromDirectoryAndFilename(
+        context, metadataDir, "seq_mems.json", /*excludeFromFilelist=*/true);
+    dutVerbatimOp->setAttr("output_file", fileAttr);
+  }
+  if (!seqMemConfStr.empty()) {
+    auto confVerbatimOp =
+        builder.create<sv::VerbatimOp>(builder.getUnknownLoc(), seqMemConfStr);
+    StringRef confFile = "memory";
+    if (dutMod)
+      confFile = dutMod.getName();
+    auto fileAttr = hw::OutputFileAttr::getFromDirectoryAndFilename(
+        context, metadataDir, confFile + ".conf", /*excludeFromFilelist=*/true);
+    confVerbatimOp->setAttr("output_file", fileAttr);
+  }
 
   return success();
 }


### PR DESCRIPTION
Don't create empty metadata operations.
This Fixes the integration test failures.