### PR TITLE
[FIRRTL] Delay metadata emission

### DIFF
--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -301,9 +301,6 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
     pm.nest<firrtl::CircuitOp>().addPass(
         firrtl::createLowerFIRRTLAnnotationsPass(disableAnnotationsUnknown,
                                                  disableAnnotationsClassless));
-  if (emitMetadata)
-    pm.nest<firrtl::CircuitOp>().addPass(
-        firrtl::createCreateSiFiveMetadataPass());
 
   if (!disableOptimization) {
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
@@ -375,6 +372,10 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
   if (!disableOptimization)
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
         createSimpleCanonicalizerPass());
+
+  if (emitMetadata)
+    pm.nest<firrtl::CircuitOp>().addPass(
+        firrtl::createCreateSiFiveMetadataPass());
 
   // Lower if we are going to verilog or if lowering was specifically requested.
   if (lowerToHW || outputFormat == OutputVerilog ||


### PR DESCRIPTION
Delay the `firrtl::createCreateSiFiveMetadataPass` to just before `LowerToHW`. 
This is required to ensure the `LowerTypes` has run and all the memory lowering
 has been done, for correct memory metadata generation.