### PR TITLE
[FIRRTL] Move port directions + names to `firrtl.instance`

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAttributes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAttributes.h
@@ -35,6 +35,10 @@ namespace direction {
 /// input direction.
 inline Direction get(bool isOutput) { return (Direction)isOutput; }
 
+inline StringRef toString(Direction direction) {
+  return direction == Direction::In ? "in" : "out";
+}
+
 /// Return a \p IntegerAttr containing the packed representation of an array
 /// of directions.
 IntegerAttr packAttribute(MLIRContext *context, ArrayRef<Direction> directions);

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -16,23 +16,31 @@ def InstanceOp : FIRRTLOp<"instance", [
   let description = [{
     This represents an instance of a module.  The results are the modules inputs
     and outputs.  The inputs have flip type, the outputs do not.
+
+    Examples:
+    ```mlir
+    %0 = firrtl.instance foo @Foo(in io: !firrtl.uint)
+    ```
   }];
 
   let arguments = (ins FlatSymbolRefAttr:$moduleName, StrAttr:$name,
+                       APIntAttr:$portDirections, StrArrayAttr:$portNames,
                        AnnotationArrayAttr:$annotations,
                        PortAnnotationsAttr:$portAnnotations,
                        BoolAttr:$lowerToBind);
+
   let results = (outs Variadic<FIRRTLType>:$results);
 
-  let assemblyFormat =
-    "$moduleName custom<InstanceOp>(attr-dict) (`:` type($results)^ )?";
-
   let verifier = "return ::verifyInstanceOp(*this);";
+  let printer = "printInstanceOp(p, *this);";
+  let parser = "return parseInstanceOp(parser, result);";
 
   let builders = [
     OpBuilder<(ins "::mlir::TypeRange":$resultTypes,
                    "::mlir::StringRef":$moduleName,
-                   CArg<"StringRef", "{}">:$name,
+                   "::mlir::StringRef":$name,
+                   "::mlir::ArrayRef<Direction>":$portDirections,
+                   "::mlir::ArrayRef<Attribute>":$portNames,
                    CArg<"ArrayRef<Attribute>", "{}">:$annotations,
                    CArg<"ArrayRef<Attribute>", "{}">:$portAnnotations,
                    CArg<"bool","false">:$lowerToBind)>,
@@ -51,9 +59,14 @@ def InstanceOp : FIRRTLOp<"instance", [
     FModuleLike getReferencedModule();
     FModuleLike getReferencedModule(SymbolTable& symtbl);
 
+    /// Return the port direction for the specified result number.
+    Direction getPortDirection(size_t resultNo) {
+      return direction::get(portDirections()[resultNo]);
+    }
+
     /// Return the port name for the specified result number.
     StringAttr getPortName(size_t resultNo) {
-      return getReferencedModule().getPortNameAttr(resultNo);
+      return portNames()[resultNo].cast<StringAttr>();
     }
     StringRef getPortNameStr(size_t resultNo) {
       return getPortName(resultNo).getValue();

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -458,9 +458,8 @@ void Emitter::emitStatement(InstanceOp op) {
   SmallString<16> portName(op.name());
   portName.push_back('.');
   unsigned baseLen = portName.size();
-  auto modulePorts = op.getReferencedModule().getPorts();
   for (unsigned i = 0, e = op.getNumResults(); i < e; ++i) {
-    portName.append(modulePorts[i].name.getValue());
+    portName.append(op.getPortNameStr(i));
     addValueName(op.getResult(i), portName);
     portName.resize(baseLen);
   }

--- a/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
@@ -103,7 +103,7 @@ SmallVector<Direction> direction::unpackAttribute(IntegerAttr directions) {
 
 llvm::raw_ostream &circt::firrtl::operator<<(llvm::raw_ostream &os,
                                              const Direction &dir) {
-  return os << (dir == Direction::In ? "in" : "out");
+  return os << direction::toString(dir);
 }
 
 void FIRRTLDialect::registerAttributes() {

--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -203,9 +203,8 @@ public:
   void visitDecl(InstanceOp op) {
     // Track any instance inputs which need to be connected to for init
     // coverage.
-    auto ref = op.getReferencedModule();
     for (auto result : llvm::enumerate(op.results()))
-      if (ref.getPortDirection(result.index()) == Direction::Out)
+      if (op.getPortDirection(result.index()) == Direction::Out)
         declareSinks(result.value(), Flow::Source);
       else
         declareSinks(result.value(), Flow::Sink);

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
@@ -76,7 +76,7 @@ firrtl.circuit "unprocessedAnnotations" {
     "write"], readLatency = 0 : i32, writeLatency = 1 : i32, annotations = [{class =
     "firrtl.transforms.RemainingAnnotation5"}]} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>
     // expected-warning @+1 {{unprocessed annotation:'firrtl.transforms.RemainingAnnotation6'}}
-    %5 = firrtl.instance @bar {name = "fetch", portNames=["io_cpu_flush"], annotations = [{class = "firrtl.transforms.RemainingAnnotation6"}] } : !firrtl.uint<1>
+    %5 = firrtl.instance fetch {annotations = [{class = "firrtl.transforms.RemainingAnnotation6"}]} @bar(in io_cpu_flush: !firrtl.uint<1>)
     %6 = firrtl.node %1 {annotations = [{class = "firrtl.transforms.RemainingAnnotation3"}]} : !firrtl.uint<1>
   }
 }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
@@ -51,8 +51,7 @@ firrtl.circuit "Simple" {
                               in %reset: !firrtl.uint<1>) {
     // CHECK-NEXT: %c0_i2 = hw.constant
     // CHECK-NEXT: %xyz.out4 = hw.instance "xyz" @Simple(in1: [[ARG1:%.+]]: i4, in2: %u2: i2, in3: %s8: i8) -> (out4: i4)
-    %xyz:4 = firrtl.instance @Simple {name = "xyz", portNames=["in1", "in2", "in3", "out4"]}
-     : !firrtl.uint<4>, !firrtl.uint<2>, !firrtl.sint<8>, !firrtl.uint<4>
+    %xyz:4 = firrtl.instance xyz @Simple(in in1: !firrtl.uint<4>, in in2: !firrtl.uint<2>, in in3: !firrtl.sint<8>, out out4: !firrtl.uint<4>)
 
     // CHECK: [[ARG1]] = comb.concat %c0_i2, %u2 : i2, i2
     firrtl.connect %xyz#0, %u2 : !firrtl.uint<4>, !firrtl.uint<2>
@@ -68,8 +67,7 @@ firrtl.circuit "Simple" {
     // hw.instance carries the parameters, unlike at the FIRRTL layer.
 
     // CHECK: %myext.out = hw.instance "myext" @MyParameterizedExtModule<DEFAULT: i64 = 0, DEPTH: f64 = 3.242000e+01, FORMAT: none = "xyz_timeout=%d\0A", WIDTH: i8 = 32>(in: %reset: i1) -> (out: i8)
-    %myext:2 = firrtl.instance @MyParameterizedExtModule {name = "myext", portNames=["in", "out"]}
-      : !firrtl.uint<1>, !firrtl.uint<8>
+    %myext:2 = firrtl.instance myext @MyParameterizedExtModule(in in: !firrtl.uint<1>, out out: !firrtl.uint<8>)
 
     // CHECK: sv.fwrite "%x"(%xyz.out4) : i4
     // CHECK: sv.fwrite "Something interesting! %x"(%myext.out) : i8
@@ -145,8 +143,7 @@ firrtl.circuit "Simple" {
     // CHECK: %false = hw.constant false
 
     // CHECK-NEXT: hw.instance "myext" @MyParameterizedExtModule<DEFAULT: i64 = 0, DEPTH: f64 = 3.242000e+01, FORMAT: none = "xyz_timeout=%d\0A", WIDTH: i8 = 32>(in: [[ARG:%.+]]: i1) -> (out: i8)
-    %myext:2 = firrtl.instance @MyParameterizedExtModule {name = "myext", portNames=["in", "out"]}
-      : !firrtl.uint<1>, !firrtl.uint<8>
+    %myext:2 = firrtl.instance myext @MyParameterizedExtModule(in in: !firrtl.uint<1>, out out: !firrtl.uint<8>)
 
     // CHECK: [[ADD:%.+]] = comb.add %0, %1
 
@@ -167,8 +164,7 @@ firrtl.circuit "Simple" {
   // CHECK-LABEL: hw.module @instance_cyclic
   firrtl.module @instance_cyclic(in %arg0: !firrtl.uint<2>, in %arg1: !firrtl.uint<2>) {
     // CHECK: %myext.out = hw.instance "myext" @MyParameterizedExtModule<DEFAULT: i64 = 0, DEPTH: f64 = 3.242000e+01, FORMAT: none = "xyz_timeout=%d\0A", WIDTH: i8 = 32>(in: %0: i1)
-    %myext:2 = firrtl.instance @MyParameterizedExtModule {name = "myext", portNames=["in", "out"]}
-      : !firrtl.uint<1>, !firrtl.uint<8>
+    %myext:2 = firrtl.instance myext @MyParameterizedExtModule(in in: !firrtl.uint<1>, out out: !firrtl.uint<8>)
 
     // Output of the instance is fed into the input!
     %11 = firrtl.bits %myext#1 2 to 2 : (!firrtl.uint<8>) -> !firrtl.uint<1>
@@ -207,11 +203,11 @@ firrtl.circuit "Simple" {
                                    out %oB: !firrtl.uint<0>) {
 
     // CHECK: %myinst.outa = hw.instance "myinst" @ZeroWidthPorts(inA: %iA: i4) -> (outa: i4)
-    %myinst:5 = firrtl.instance @ZeroWidthPorts {name = "myinst", portNames=["inA", "inB", "inC", "outa", "outb"]}
-      : !firrtl.uint<4>, !firrtl.uint<0>, !firrtl.analog<0>, !firrtl.uint<4>, !firrtl.uint<0>
+    %myinst:5 = firrtl.instance myinst @ZeroWidthPorts(
+      in inA: !firrtl.uint<4>, in inB: !firrtl.uint<0>, in inC: !firrtl.analog<0>, out outa: !firrtl.uint<4>, out outb: !firrtl.uint<0>)
     // CHECK: = hw.instance "myinst" @SameNamePorts(inA: {{.+}}, inA: {{.+}}, inA: {{.+}}) -> (outa: i4, outa: i1)
-    %myinst_sameName:5 = firrtl.instance @SameNamePorts {name = "myinst"}
-      : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.analog<1>, !firrtl.uint<4>, !firrtl.uint<1>
+    %myinst_sameName:5 = firrtl.instance myinst @SameNamePorts(
+      in inA: !firrtl.uint<4>, in inA: !firrtl.uint<1>, in inA: !firrtl.analog<1>, out outa: !firrtl.uint<4>, out outa: !firrtl.uint<1>)
 
     // Output of the instance is fed into the input!
     firrtl.connect %myinst#0, %iA : !firrtl.uint<4>, !firrtl.uint<4>
@@ -238,11 +234,11 @@ firrtl.circuit "Simple" {
   firrtl.module @foo690() {
     // CHECK: %.led_0.wire = sv.wire
     // CHECK: hw.instance "fpga" @bar690(led_0: %.led_0.wire: !hw.inout<i1>) -> ()
-    %result = firrtl.instance @bar690 {name = "fpga", portNames = ["led_0"]} : !firrtl.analog<1>
+    %result = firrtl.instance fpga @bar690(in led_0: !firrtl.analog<1>)
   }
   // CHECK-LABEL: hw.module @foo690a(%a: !hw.inout<i1>) {
   firrtl.module @foo690a(in %a: !firrtl.analog<1>) {
-    %result = firrtl.instance @bar690 {name = "fpga", portNames = ["led_0"]} : !firrtl.analog<1>
+    %result = firrtl.instance fpga @bar690(in led_0: !firrtl.analog<1>)
     firrtl.attach %result, %a: !firrtl.analog<1>, !firrtl.analog<1>
   }
 
@@ -253,7 +249,7 @@ firrtl.circuit "Simple" {
   // CHECK-NEXT:  hw.instance "fpga" @bar740(led_0: %.led_0.wire: !hw.inout<i1>) -> ()
   firrtl.extmodule @bar740(in led_0: !firrtl.analog<1>)
   firrtl.module @foo740(in %led_0: !firrtl.analog<1>) {
-    %result = firrtl.instance @bar740 {name = "fpga", portNames = ["led_0"]} : !firrtl.analog<1>
+    %result = firrtl.instance fpga @bar740(in led_0: !firrtl.analog<1>)
     firrtl.attach %result, %led_0 : !firrtl.analog<1>, !firrtl.analog<1>
   }
 

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -572,7 +572,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT:  [[IO:%[0-9]+]] = sv.read_inout %io_cpu_flush.wire
     %io_cpu_flush.wire = firrtl.wire {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<1>
     // CHECK-NEXT: hw.instance "fetch" @bar(io_cpu_flush: [[IO]]: i1)
-    %i = firrtl.instance @bar {name = "fetch", portNames=["io_cpu_flush"]} : !firrtl.uint<1>
+    %i = firrtl.instance fetch @bar(in io_cpu_flush: !firrtl.uint<1>)
     firrtl.connect %i, %io_cpu_flush.wire : !firrtl.uint<1>, !firrtl.uint<1>
 
     %hits_1_7 = firrtl.node %io_cpu_flush.wire {name = "hits_1_7", annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<1>
@@ -588,11 +588,9 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-NEXT: hw.module @bindTest()
   firrtl.module @bindTest() {
     // CHECK: hw.instance "baz" sym @[[bazSymbol]] @bar
-    %baz = firrtl.instance @bar {lowerToBind = true, name = "baz"} : !firrtl.uint<1>
+    %baz = firrtl.instance baz {lowerToBind = true} @bar(in io_cpu_flush: !firrtl.uint<1>)
     // CHECK: hw.instance "qux" sym @[[quxSymbol]] @bar
-    %qux = firrtl.instance @bar { lowerToBind = true, name = "qux",
-      output_file = #hw.output_file<"outputDir/bindings.sv", excludeFromFileList>
-    } : !firrtl.uint<1>
+    %qux = firrtl.instance qux {lowerToBind = true, output_file = #hw.output_file<"outputDir/bindings.sv", excludeFromFileList>} @bar(in io_cpu_flush: !firrtl.uint<1>)
   }
 
 

--- a/test/Conversion/HandshakeToFIRRTL/simple_addi.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/simple_addi.mlir
@@ -30,7 +30,7 @@
 // CHECK-SAME:  in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @simple_addi(%arg0: index, %arg1: index, %arg2: none, ...) -> (index, none) {
 
-  // CHECK:%inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @std_addi_in_ui64_ui64_out_ui64  {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance "" @std_addi_in_ui64_ui64_out_ui64(in arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out arg2: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>)
   // CHECK: firrtl.connect %inst_arg0, %arg0 : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
   // CHECK: firrtl.connect %inst_arg1, %arg1 : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
   %0 = addi %arg0, %arg1 : index

--- a/test/Conversion/HandshakeToFIRRTL/test_branch.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_branch.mlir
@@ -18,7 +18,7 @@
 // CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %arg2: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_branch(%arg0: index, %arg1: none, ...) -> (index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1 = firrtl.instance @handshake_branch_in_ui64_out_ui64  {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+  // CHECK: %inst_arg0, %inst_arg1 = firrtl.instance "" @handshake_branch_in_ui64_out_ui64(in arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>)
   %0 = "handshake.branch"(%arg0) {control = false}: (index) -> index
   handshake.return %0, %arg1 : index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
@@ -82,7 +82,7 @@
 // CHECK-SAME:  in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_buffer(%arg0: none, %arg1: none, ...) -> (none, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_clock, %inst_reset = firrtl.instance @handshake_buffer_3slots_seq_1ins_1outs_ctrl {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.clock, !firrtl.uint<1>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_clock, %inst_reset = firrtl.instance "" @handshake_buffer_3slots_seq_1ins_1outs_ctrl(in arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in clock: !firrtl.clock, in reset: !firrtl.uint<1>)
   %0 = "handshake.buffer"(%arg0) {control = true, sequential = true, slots = 3 : i32} : (none) -> none
   handshake.return %0, %arg1 : none, none
 }
@@ -121,7 +121,7 @@ handshake.func @test_buffer(%arg0: none, %arg1: none, ...) -> (none, none) {
 // CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %arg2: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_buffer_data(%arg0: index, %arg1: none, ...) -> (index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_clock, %inst_reset = firrtl.instance @handshake_buffer_in_ui64_out_ui64_2slots_seq {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.clock, !firrtl.uint<1>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_clock, %inst_reset = firrtl.instance "" @handshake_buffer_in_ui64_out_ui64_2slots_seq(in arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in clock: !firrtl.clock, in reset: !firrtl.uint<1>)
   // CHECK: firrtl.connect %inst_clock, %clock : !firrtl.clock, !firrtl.clock
   // CHECK: firrtl.connect %inst_reset, %reset : !firrtl.uint<1>, !firrtl.uint<1>
   %0 = "handshake.buffer"(%arg0) {control = false, sequential = true, slots = 2 : i32} : (index) -> index

--- a/test/Conversion/HandshakeToFIRRTL/test_cmerge.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_cmerge.mlir
@@ -95,7 +95,7 @@
 // CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %arg2: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %arg4: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %arg5: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_cmerge(%arg0: none, %arg1: none, %arg2: none, ...) -> (none, index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_arg3, %inst_clock, %inst_reset = firrtl.instance @handshake_control_merge_out_ui64_2ins_2outs_ctrl {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.clock, !firrtl.uint<1>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_arg3, %inst_clock, %inst_reset = firrtl.instance "" @handshake_control_merge_out_ui64_2ins_2outs_ctrl(in arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out arg2: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out arg3: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in clock: !firrtl.clock, in reset: !firrtl.uint<1>)
   %0:2 = "handshake.control_merge"(%arg0, %arg1) {control = true} : (none, none) -> (none, index)
   handshake.return %0#0, %0#1, %arg2 : none, index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_conditional_branch.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_conditional_branch.mlir
@@ -32,7 +32,7 @@
 // CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %arg2: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %arg4: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %arg5: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_conditional_branch(%arg0: i1, %arg1: index, %arg2: none, ...) -> (index, index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_arg3 = firrtl.instance @handshake_conditional_branch_in_ui1_ui64_out_ui64_ui64  {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_arg3 = firrtl.instance "" @handshake_conditional_branch_in_ui1_ui64_out_ui64_ui64(in arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>, in arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out arg2: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out arg3: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>)
   %0:2 = "handshake.conditional_branch"(%arg0, %arg1) {control = false}: (i1, index) -> (index, index)
   handshake.return %0#0, %0#1, %arg2 : index, index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_constant.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_constant.mlir
@@ -29,16 +29,16 @@
 handshake.func @test_constant(%arg0: none, ...) -> (index, i64, ui32, si32, none) {
   %0:5 = "handshake.fork"(%arg0) {control = true} : (none) -> (none, none, none, none, none)
 
-  // CHECK: %inst_arg0_0, %inst_arg1_1 = firrtl.instance @handshake_constant_c42_out_ui64  {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+  // CHECK: %inst_arg0_0, %inst_arg1_1 = firrtl.instance "" @handshake_constant_c42_out_ui64(in arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>)
   %1 = "handshake.constant"(%0#0) {value = 42 : index}: (none) -> index
 
-  // CHECK: %inst_arg0_2, %inst_arg1_3 = firrtl.instance @handshake_constant_c42_out_ui64  {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+  // CHECK: %inst_arg0_2, %inst_arg1_3 = firrtl.instance "" @handshake_constant_c42_out_ui64(in arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>)
   %2 = "handshake.constant"(%0#1) {value = 42 : i64}: (none) -> i64
 
-  // CHECK: %inst_arg0_4, %inst_arg1_5 = firrtl.instance @handshake_constant_c42_out_ui32  {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+  // CHECK: %inst_arg0_4, %inst_arg1_5 = firrtl.instance "" @handshake_constant_c42_out_ui32(in arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>)
   %3 = "handshake.constant"(%0#2) {value = 42 : ui32}: (none) -> ui32
 
-  // CHECK: %inst_arg0_6, %inst_arg1_7 = firrtl.instance @"handshake_constant_c-11_out_si32"  {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: sint<32>>
+  // CHECK: %inst_arg0_6, %inst_arg1_7 = firrtl.instance "" @"handshake_constant_c-11_out_si32"(in arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: sint<32>>)
   %4 = "handshake.constant"(%0#3) {value = -11 : si32}: (none) -> si32
   handshake.return %1, %2, %3, %4, %0#4 : index, i64, ui32, si32, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_fork.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_fork.mlir
@@ -64,7 +64,7 @@
 // CHECK-SAME:  in %arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %arg2: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %arg4: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_fork(%arg0: none, %arg1: none, ...) -> (none, none, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_clock, %inst_reset = firrtl.instance @handshake_fork_1ins_2outs_ctrl {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.clock, !firrtl.uint<1>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_clock, %inst_reset = firrtl.instance "" @handshake_fork_1ins_2outs_ctrl(in arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out arg2: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in clock: !firrtl.clock, in reset: !firrtl.uint<1>)
   %0:2 = "handshake.fork"(%arg0) {control = true} : (none) -> (none, none)
   handshake.return %0#0, %0#1, %arg1 : none, none, none
 }
@@ -89,7 +89,7 @@ handshake.func @test_fork(%arg0: none, %arg1: none, ...) -> (none, none, none) {
 // CHECK-SAME:  in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_fork_data(%arg0: index, %arg1: none, ...) -> (index, index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_clock, %inst_reset = firrtl.instance @handshake_fork_in_ui64_out_ui64_ui64 {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.clock, !firrtl.uint<1>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_clock, %inst_reset = firrtl.instance "" @handshake_fork_in_ui64_out_ui64_ui64(in arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out arg2: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in clock: !firrtl.clock, in reset: !firrtl.uint<1>)
   %0:2 = "handshake.fork"(%arg0) {control = false} : (index) -> (index, index)
   handshake.return %0#0, %0#1, %arg1 : index, index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_index_cast.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_index_cast.mlir
@@ -21,7 +21,7 @@
 // CHECK-SAME:  out %arg3: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>,
 // CHECK-SAME:  in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_index_cast(%arg0: index, %arg1: none, ...) -> (i8, none) {
-  // CHECK:      %inst_arg0, %inst_arg1 = firrtl.instance @std_index_cast_in_ui64_out_ui8  {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>
+  // CHECK:      %inst_arg0, %inst_arg1 = firrtl.instance "" @std_index_cast_in_ui64_out_ui8(in arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>)
   // CHECK-NEXT: firrtl.connect %inst_arg0, %arg0 : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
   %0 = index_cast %arg0 : index to i8
 
@@ -68,8 +68,8 @@ handshake.func @test_index_cast(%arg0: index, %arg1: none, ...) -> (i8, none) {
 // CHECK-SAME:  out %arg5: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, 
 // CHECK-SAME:  in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_index_cast2(%arg0: i8, %arg1 : i9, %arg2: none, ...) -> (index, index, none) {
-// CHECK: %inst_arg0, %inst_arg1 = firrtl.instance @std_index_cast_in_ui8_out_ui64  {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
-// CHECK: %inst_arg0_0, %inst_arg1_1 = firrtl.instance @std_index_cast_in_ui9_out_ui64  {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<9>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK: %inst_arg0, %inst_arg1 = firrtl.instance "" @std_index_cast_in_ui8_out_ui64(in arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>, out arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>)
+// CHECK:%inst_arg0_0, %inst_arg1_1 = firrtl.instance "" @std_index_cast_in_ui9_out_ui64(in arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<9>>, out arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>)
 // CHECK: firrtl.connect %inst_arg0, %arg0 : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>
 // CHECK: firrtl.connect %inst_arg0_0, %arg1 : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<9>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<9>>
   %0 = index_cast %arg0 : i8 to index

--- a/test/Conversion/HandshakeToFIRRTL/test_join.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_join.mlir
@@ -21,7 +21,7 @@
 // CHECK-SAME: in %arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %arg2: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %arg4: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_join(%arg0: none, %arg1: none, %arg2: none, ...) -> (none, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @handshake_join_2ins_1outs_ctrl  {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance "" @handshake_join_2ins_1outs_ctrl(in arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out arg2: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>)
   %0 = "handshake.join"(%arg0, %arg1) {control = true}: (none, none) -> none
   handshake.return %0, %arg2 : none, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_lazy_fork.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_lazy_fork.mlir
@@ -29,7 +29,7 @@
 // CHECK-SAME: in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_lazy_fork(%arg0: index, %arg1: none, ...) -> (index, index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @handshake_lazy_fork_in_ui64_out_ui64_ui64  {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance "" @handshake_lazy_fork_in_ui64_out_ui64_ui64(in arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out arg2: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>)
   %0:2 = "handshake.lazy_fork"(%arg0) {control = false} : (index) -> (index, index)
   handshake.return %0#0, %0#1, %arg1 : index, index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_memory.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_memory.mlir
@@ -98,7 +98,7 @@
 // CHECK-LABEL: firrtl.module @main
 handshake.func @main(%arg0: i8, %arg1: index, %arg2: index, ...) -> (i8, none, none) {
   // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_arg3, %inst_arg4, %inst_arg5, %inst_clock, %inst_reset
-  // CHECK: = firrtl.instance @handshake_memory_out_ui8_id0
+  // CHECK: = firrtl.instance "" @handshake_memory_out_ui8_id0
   %0:3 = "handshake.memory"(%arg0, %arg1, %arg2) {id = 0 : i32, ld_count = 1 : i32, lsq = false, st_count = 1 : i32, type = memref<10xi8>} : (i8, index, index) -> (i8, none, none)
 
   handshake.return %0#0, %0#1, %0#2: i8, none, none

--- a/test/Conversion/HandshakeToFIRRTL/test_merge.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_merge.mlir
@@ -62,7 +62,7 @@
 // CHECK-SAME:  in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_merge(%arg0: index, %arg1: index, %arg2: none, ...) -> (index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance @handshake_merge_in_ui64_ui64_out_ui64 {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2 = firrtl.instance "" @handshake_merge_in_ui64_ui64_out_ui64(in arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out arg2: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>)
   %0 = "handshake.merge"(%arg0, %arg1) : (index, index) -> index
   handshake.return %0, %arg2 : index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_mux.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_mux.mlir
@@ -37,7 +37,7 @@
 // CHECK: firrtl.module @test_mux(in %arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %arg2: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %arg3: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %arg4: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %arg5: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_mux(%arg0: index, %arg1: index, %arg2: index, %arg3: none, ...) -> (index, none) {
 
-  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_arg3 = firrtl.instance @handshake_mux_in_ui64_ui64_ui64_out_ui64  {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+  // CHECK: %inst_arg0, %inst_arg1, %inst_arg2, %inst_arg3 = firrtl.instance "" @handshake_mux_in_ui64_ui64_ui64_out_ui64(in arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in arg2: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out arg3: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>)
   %0 = "handshake.mux"(%arg0, %arg1, %arg2): (index, index, index) -> index
   handshake.return %0, %arg3 : index, none
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_sink.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_sink.mlir
@@ -11,7 +11,7 @@
 // CHECK-SAME: in %arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %arg2: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 handshake.func @test_sink(%arg0: index, %arg2: none, ...) -> (none) {
 
-  // CHECK: %inst_arg0 = firrtl.instance @handshake_sink_in_ui64  {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+  // CHECK: %inst_arg0 = firrtl.instance "" @handshake_sink_in_ui64(in arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>)
   // CHECK: firrtl.connect %inst_arg0, %arg0 : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
   "handshake.sink"(%arg0) : (index) -> ()
 

--- a/test/Conversion/HandshakeToFIRRTL/test_store.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_store.mlir
@@ -39,7 +39,7 @@
 
 // CHECK-LABEL: firrtl.module @main
 handshake.func @main(%arg0: i8, %arg1: index, %arg2: none, ...) -> (i8, index, none) {
-  // CHECK: {{.+}} = firrtl.instance @handshake_store_in_ui8_ui64_out_ui8_ui64
+  // CHECK: {{.+}} = firrtl.instance "" @handshake_store_in_ui8_ui64_out_ui8_ui64
   %0:2 = "handshake.store"(%arg0, %arg1, %arg2) : (i8, index, none) -> (i8, index)
 
   handshake.return %0#0, %0#1, %arg2 : i8, index, none

--- a/test/Dialect/FIRRTL/SFCTests/constantProp.mlir
+++ b/test/Dialect/FIRRTL/SFCTests/constantProp.mlir
@@ -5,7 +5,7 @@
 firrtl.circuit "ConstInput"   {
   firrtl.module @ConstInput(in %x: !firrtl.uint<1>, out %z: !firrtl.uint<1>) {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    %c_in0, %c_in1, %c_out = firrtl.instance @Child  {name = "c"} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %c_in0, %c_in1, %c_out = firrtl.instance c @Child(in in0: !firrtl.uint<1>, in in1: !firrtl.uint<1>, out out: !firrtl.uint<1>)
     firrtl.connect %c_in0, %x : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %c_in1, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %z, %c_out : !firrtl.uint<1>, !firrtl.uint<1>
@@ -29,7 +29,7 @@ firrtl.circuit "InstanceInput"   {
   // CHECK-LABEL: firrtl.module @Child1
   firrtl.module @Child1(out %out: !firrtl.uint<1>) {
     %c1_ui = firrtl.constant 1 : !firrtl.uint
-    %b0_in, %b0_out = firrtl.instance @Bottom1  {name = "b0"} : !firrtl.uint<1>, !firrtl.uint<1>
+    %b0_in, %b0_out = firrtl.instance b0 @Bottom1(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
     firrtl.connect %b0_in, %c1_ui : !firrtl.uint<1>, !firrtl.uint
     // CHECK: %[[C1:.+]] = firrtl.constant 1 :
     // CHECK: firrtl.connect %out, %[[C1]]
@@ -38,10 +38,10 @@ firrtl.circuit "InstanceInput"   {
   // CHECK-LABEL:  firrtl.module @InstanceInput
   firrtl.module @InstanceInput(in %x: !firrtl.uint<1>, out %z: !firrtl.uint<1>) {
     %c1_ui = firrtl.constant 1 : !firrtl.uint
-    %c_out = firrtl.instance @Child1  {name = "c"} : !firrtl.uint<1>
-    %b0_in, %b0_out = firrtl.instance @Bottom1  {name = "b0"} : !firrtl.uint<1>, !firrtl.uint<1>
+    %c_out = firrtl.instance c @Child1(out out: !firrtl.uint<1>)
+    %b0_in, %b0_out = firrtl.instance b0  @Bottom1(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
     firrtl.connect %b0_in, %c1_ui : !firrtl.uint<1>, !firrtl.uint
-    %b1_in, %b1_out = firrtl.instance @Bottom1  {name = "b1"} : !firrtl.uint<1>, !firrtl.uint<1>
+    %b1_in, %b1_out = firrtl.instance b1  @Bottom1(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
     firrtl.connect %b1_in, %c1_ui : !firrtl.uint<1>, !firrtl.uint
     %0 = firrtl.and %b0_out, %b1_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     %1 = firrtl.and %0, %c_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
@@ -61,7 +61,7 @@ firrtl.circuit "InstanceInput2"   {
  // CHECK-LABEL:  firrtl.module @Child2
   firrtl.module @Child2(out %out: !firrtl.uint<1>) {
     %c1_ui = firrtl.constant 1 : !firrtl.uint
-    %b0_in, %b0_out = firrtl.instance @Bottom2  {name = "b0"} : !firrtl.uint<1>, !firrtl.uint<1>
+    %b0_in, %b0_out = firrtl.instance b0 @Bottom2(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
     firrtl.connect %b0_in, %c1_ui : !firrtl.uint<1>, !firrtl.uint
     // CHECK: firrtl.connect %out, %b0_out
     firrtl.connect %out, %b0_out : !firrtl.uint<1>, !firrtl.uint<1>
@@ -69,10 +69,10 @@ firrtl.circuit "InstanceInput2"   {
  // CHECK-LABEL:  firrtl.module @InstanceInput2
   firrtl.module @InstanceInput2(in %x: !firrtl.uint<1>, out %z: !firrtl.uint<1>) {
     %c1_ui = firrtl.constant 1 : !firrtl.uint
-    %c_out = firrtl.instance @Child2  {name = "c"} : !firrtl.uint<1>
-    %b0_in, %b0_out = firrtl.instance @Bottom2  {name = "b0"} : !firrtl.uint<1>, !firrtl.uint<1>
+    %c_out = firrtl.instance c @Child2(out out: !firrtl.uint<1>)
+    %b0_in, %b0_out = firrtl.instance b0 @Bottom2(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
     firrtl.connect %b0_in, %x : !firrtl.uint<1>, !firrtl.uint<1>
-    %b1_in, %b1_out = firrtl.instance @Bottom2  {name = "b1"} : !firrtl.uint<1>, !firrtl.uint<1>
+    %b1_in, %b1_out = firrtl.instance b1 @Bottom2(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
     firrtl.connect %b1_in, %c1_ui : !firrtl.uint<1>, !firrtl.uint
     %0 = firrtl.and %b0_out, %b1_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     %1 = firrtl.and %0, %c_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
@@ -102,7 +102,7 @@ firrtl.circuit "constOutput"   {
     firrtl.connect %out, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   }
   firrtl.module @constOutput(in %x: !firrtl.uint<1>, out %z: !firrtl.uint<1>) {
-    %c_out = firrtl.instance @constOutChild  {name = "c"} : !firrtl.uint<1>
+    %c_out = firrtl.instance c @constOutChild(out out: !firrtl.uint<1>)
     %0 = firrtl.and %x, %c_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.connect %z, %0 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: %[[C3_0:.+]] = firrtl.constant 0 : !firrtl.uint<1>
@@ -196,7 +196,7 @@ firrtl.circuit "padConstOut"   {
   }
   // CHECK-LABEL: firrtl.module @padConstOut
   firrtl.module @padConstOut(out %z: !firrtl.uint<16>) {
-    %c_x = firrtl.instance @padConstOutChild  {name = "c"} : !firrtl.uint<8>
+    %c_x = firrtl.instance c @padConstOutChild(out x: !firrtl.uint<8>)
     %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
     %0 = firrtl.cat %c3_ui2, %c_x : (!firrtl.uint<2>, !firrtl.uint<8>) -> !firrtl.uint<10>
     // CHECK: %[[C8:.+]] = firrtl.constant 771 : !firrtl.uint<10>
@@ -217,7 +217,7 @@ firrtl.circuit "padConstIn"   {
   }
   // CHECK-LABEL: firrtl.module @padConstIn
   firrtl.module @padConstIn(out %z: !firrtl.uint<16>) {
-    %c_x, %c_y = firrtl.instance @padConstInChild  {name = "c"} : !firrtl.uint<8>, !firrtl.uint<16>
+    %c_x, %c_y = firrtl.instance c @padConstInChild(in x: !firrtl.uint<8>, out y: !firrtl.uint<16>)
     %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
     firrtl.connect %c_x, %c3_ui2 : !firrtl.uint<8>, !firrtl.uint<2>
     firrtl.connect %z, %c_y : !firrtl.uint<16>, !firrtl.uint<16>

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -81,7 +81,7 @@ circuit Foo: %[[
     ; CHECK: firrtl.module @Bar
     ; CHECK-SAME annotations = [{c = "c"}]
     ; CHECK: firrtl.module @Foo
-    ; CHECK: firrtl.instance @Bar
+    ; CHECK: firrtl.instance bar
     ; CHECK-SAME: annotations = [{a = "a"}, {b = "b"}, {circt.nonlocal = @nla_1, class = "circt.nonlocal"}]
 
 ; // -----
@@ -102,7 +102,7 @@ circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar.a"},
     ; CHECK: firrtl.nla @nla_1 [@Foo, @Bar] ["bar", "b"]
     ; CHECK: firrtl.module @Bar
     ; CHECK-SAME: [#firrtl.subAnno<fieldID = 2, {circt.nonlocal = @nla_1, three}>]
-    ; CHECK: %bar_a, %bar_b, %bar_c = firrtl.instance @Bar
+    ; CHECK: %bar_a, %bar_b, %bar_c = firrtl.instance bar
     ; CHECK-SAME: [{one}],
     ; CHECK-SAME: [#firrtl.subAnno<fieldID = 1, {two}>],
     ; CHECK-SAME: [{four}]
@@ -356,7 +356,7 @@ circuit Foo: %[[{"target": "~Foo|Foo>_T_0", "a": "a"},
     cmem _T_5 : UInt<1>[9] [256]
     ; CHECK: firrtl.memoryport {{.+}} {annotations = [{a = "a"}]
     infer mport _T_6 = _T_5[reset], clock
-    ; CHECK: firrtl.instance @Bar  {annotations = [{a = "a"}], name = "_T_7"}
+    ; CHECK: firrtl.instance _T_7 {annotations = [{a = "a"}]}
     inst _T_7 of Bar
     ; CHECK: firrtl.mem Undefined  {annotations = [{a = "a"}]
     mem _T_8 :
@@ -408,7 +408,7 @@ circuit Foo: %[[{"target": "~Foo|Foo>_T_0", "class": "firrtl.transforms.DontTouc
     ; CHECK: firrtl.memoryport Infer %_T_5 {annotations =
     ; CHECK-SAME: {class = "firrtl.transforms.DontTouchAnnotation"}
     infer mport _T_6 = _T_5[reset], clock
-    ; CHECK: firrtl.instance @Bar  {annotations =
+    ; CHECK: firrtl.instance _T_7 {annotations =
     ; CHECK-SAME: {class = "firrtl.transforms.DontTouchAnnotation"}
     inst _T_7 of Bar
     ; CHECK: firrtl.mem Undefined  {annotations =
@@ -898,10 +898,10 @@ circuit Foo: %[[{"a":"a","target":"~Foo|Foo/bar:Bar/baz:Baz"}, {"b":"b","target"
 ; CHECK: firrtl.module @Baz
 ; CHECK-SAME: annotations = [{a = "a", circt.nonlocal = @nla_1}, {b = "b", circt.nonlocal = @nla_2}]
 ; CHECK: firrtl.module @Bar()
-; CHECK: firrtl.instance @Baz
+; CHECK: firrtl.instance baz
 ; CHECK-SAME: [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}, {circt.nonlocal = @nla_2, class = "circt.nonlocal"}]
 ; CHECK: firrtl.module @Foo()
-; CHECK: firrtl.instance @Bar
+; CHECK: firrtl.instance bar
 ; CHECK-SAME: [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}, {circt.nonlocal = @nla_2, class = "circt.nonlocal"}]
 
 ; // -----

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -12,8 +12,8 @@
 // CHECK: firrtl.module @BarNL
 // CHECK: %w = firrtl.wire {annotations = [{circt.nonlocal = @nla_0, class = "circt.test", nl = "nl"}]}
 // CHECK: %w2 = firrtl.wire {annotations = [{circt.fieldID = 5 : i32, circt.nonlocal = @nla, class = "circt.test", nl = "nl2"}]} : !firrtl.bundle<a: uint, b: vector<uint, 4>> 
-// CHECK: firrtl.instance @BarNL {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}, {circt.nonlocal = @nla_0, class = "circt.nonlocal"}], name = "bar"}
-// CHECK: firrtl.instance @BazNL {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}, {circt.nonlocal = @nla_0, class = "circt.nonlocal"}], name = "baz"
+// CHECK: firrtl.instance bar {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}, {circt.nonlocal = @nla_0, class = "circt.nonlocal"}]} @BarNL()
+// CHECK: firrtl.instance baz {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}, {circt.nonlocal = @nla_0, class = "circt.nonlocal"}]} @BazNL()
 // CHECK: firrtl.module @FooL
 // CHECK: %w3 = firrtl.wire {annotations = [{class = "circt.test", nl = "nl3"}]}
 firrtl.circuit "FooNL"  attributes {annotations = [
@@ -27,10 +27,10 @@ firrtl.circuit "FooNL"  attributes {annotations = [
     firrtl.skip
   }
   firrtl.module @BazNL() {
-    firrtl.instance @BarNL  {name = "bar"}
+    firrtl.instance bar @BarNL()
   }
   firrtl.module @FooNL() {
-    firrtl.instance @BazNL  {name = "baz"}
+    firrtl.instance baz @BazNL()
   }
   firrtl.module @FooL() {
     %w3 = firrtl.wire: !firrtl.uint

--- a/test/Dialect/FIRRTL/blackbox-memory.mlir
+++ b/test/Dialect/FIRRTL/blackbox-memory.mlir
@@ -21,7 +21,7 @@ firrtl.circuit "Read" {
 // WRAPPER-LABEL: firrtl.circuit "Read" {
 // WRAPPER-NEXT:   firrtl.extmodule @ReadMemory_ext(in R0_addr: !firrtl.uint<4>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.sint<8>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // WRAPPER-NEXT:   firrtl.module @ReadMemory(in %read0: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) {
-// WRAPPER-NEXT:     %ReadMemory_R0_addr, %ReadMemory_R0_en, %ReadMemory_R0_clk, %ReadMemory_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory"} : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>
+// WRAPPER-NEXT:     %ReadMemory_R0_addr, %ReadMemory_R0_en, %ReadMemory_R0_clk, %ReadMemory_R0_data = firrtl.instance ReadMemory @ReadMemory_ext
 // WRAPPER-NEXT:     %0 = firrtl.subfield %read0(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<4>
 // WRAPPER-NEXT:     firrtl.connect %ReadMemory_R0_addr, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 // WRAPPER-NEXT:     %1 = firrtl.subfield %read0(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<1>
@@ -34,7 +34,7 @@ firrtl.circuit "Read" {
 // WRAPPER-NEXT:   firrtl.module @Read() {
 // WRAPPER-NEXT:     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
 // WRAPPER-NEXT:     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-// WRAPPER-NEXT:     %ReadMemory_read0 = firrtl.instance @ReadMemory {name = "ReadMemory"} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
+// WRAPPER-NEXT:     %ReadMemory_read0 = firrtl.instance ReadMemory @ReadMemory
 // WRAPPER-NEXT:     %0 = firrtl.subfield %ReadMemory_read0(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.sint<8>
 // WRAPPER-NEXT:     %1 = firrtl.subfield %ReadMemory_read0(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<4>
 // WRAPPER-NEXT:     firrtl.connect %1, %c0_ui1 : !firrtl.uint<4>, !firrtl.uint<1>
@@ -49,7 +49,7 @@ firrtl.circuit "Read" {
 // INLINE-NEXT:   firrtl.module @Read() {
 // INLINE-NEXT:     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
 // INLINE-NEXT:     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-// INLINE-NEXT:     %ReadMemory_R0_addr, %ReadMemory_R0_en, %ReadMemory_R0_clk, %ReadMemory_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory"} : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>
+// INLINE-NEXT:     %ReadMemory_R0_addr, %ReadMemory_R0_en, %ReadMemory_R0_clk, %ReadMemory_R0_data = firrtl.instance ReadMemory @ReadMemory_ext
 // INLINE-NEXT:     %0 = firrtl.wire : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
 // INLINE-NEXT:     %1 = firrtl.subfield %0(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<4>
 // INLINE-NEXT:     firrtl.connect %ReadMemory_R0_addr, %1 : !firrtl.uint<4>, !firrtl.uint<4>
@@ -77,7 +77,7 @@ firrtl.circuit "Write" {
 // WRAPPER-LABEL: firrtl.circuit "Write" {
 // WRAPPER-NEXT:   firrtl.extmodule @WriteMemory_ext(in W0_addr: !firrtl.uint<1>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.sint<8>, in W0_mask: !firrtl.uint<1>) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // WRAPPER-NEXT:   firrtl.module @WriteMemory(in %write0: !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) {
-// WRAPPER-NEXT:     %WriteMemory_W0_addr, %WriteMemory_W0_en, %WriteMemory_W0_clk, %WriteMemory_W0_data, %WriteMemory_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory"} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %WriteMemory_W0_addr, %WriteMemory_W0_en, %WriteMemory_W0_clk, %WriteMemory_W0_data, %WriteMemory_W0_mask = firrtl.instance WriteMemory @WriteMemory_ext
 // WRAPPER-NEXT:     %0 = firrtl.subfield %write0(0) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
 // WRAPPER-NEXT:     firrtl.connect %WriteMemory_W0_addr, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 // WRAPPER-NEXT:     %1 = firrtl.subfield %write0(1) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
@@ -90,14 +90,14 @@ firrtl.circuit "Write" {
 // WRAPPER-NEXT:     firrtl.connect %WriteMemory_W0_mask, %4 : !firrtl.uint<1>, !firrtl.uint<1>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT:   firrtl.module @Write() {
-// WRAPPER-NEXT:     %WriteMemory_write0 = firrtl.instance @WriteMemory {name = "WriteMemory"} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
+// WRAPPER-NEXT:     %WriteMemory_write0 = firrtl.instance WriteMemory @WriteMemory
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT: }
 
 // INLINE-LABEL: firrtl.circuit "Write" {
 // INLINE-NEXT:   firrtl.extmodule @WriteMemory_ext(in W0_addr: !firrtl.uint<1>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.sint<8>, in W0_mask: !firrtl.uint<1>) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // INLINE-NEXT:   firrtl.module @Write() {
-// INLINE-NEXT:     %WriteMemory_W0_addr, %WriteMemory_W0_en, %WriteMemory_W0_clk, %WriteMemory_W0_data, %WriteMemory_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory"} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// INLINE-NEXT:     %WriteMemory_W0_addr, %WriteMemory_W0_en, %WriteMemory_W0_clk, %WriteMemory_W0_data, %WriteMemory_W0_mask = firrtl.instance WriteMemory @WriteMemory_ext
 // INLINE-NEXT:     %0 = firrtl.wire  : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
 // INLINE-NEXT:     %1 = firrtl.subfield %0(0) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
 // INLINE-NEXT:     firrtl.connect %WriteMemory_W0_addr, %1 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -180,7 +180,7 @@ firrtl.circuit "MemSimple" {
 // WRAPPER-LABEL: firrtl.circuit "MemSimple" {
 // WRAPPER-NEXT:   firrtl.extmodule @_M_ext(in R0_addr: !firrtl.uint<4>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.sint<42>, in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.sint<42>, in W0_mask: !firrtl.uint<1>) attributes {depth = 12 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // WRAPPER-NEXT:   firrtl.module @_M(in %read: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>, in %write: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>) {
-// WRAPPER-NEXT:     %_M_R0_addr, %_M_R0_en, %_M_R0_clk, %_M_R0_data, %_M_W0_addr, %_M_W0_en, %_M_W0_clk, %_M_W0_data, %_M_W0_mask = firrtl.instance @_M_ext {name = "_M"} : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<42>, !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<42>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %_M_R0_addr, %_M_R0_en, %_M_R0_clk, %_M_R0_data, %_M_W0_addr, %_M_W0_en, %_M_W0_clk, %_M_W0_data, %_M_W0_mask = firrtl.instance _M @_M_ext
 // WRAPPER-NEXT:     %0 = firrtl.subfield %read(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>) -> !firrtl.uint<4>
 // WRAPPER-NEXT:     firrtl.connect %_M_R0_addr, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 // WRAPPER-NEXT:     %1 = firrtl.subfield %read(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>) -> !firrtl.uint<1>
@@ -204,7 +204,7 @@ firrtl.circuit "MemSimple" {
 // WRAPPER-NEXT:     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
 // WRAPPER-NEXT:     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
 // WRAPPER-NEXT:     %c0_ui3 = firrtl.constant 0 : !firrtl.uint<3>
-// WRAPPER-NEXT:     %_M_read, %_M_write = firrtl.instance @_M {name = "_M"} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>
+// WRAPPER-NEXT:     %_M_read, %_M_write = firrtl.instance _M @_M
 // WRAPPER-NEXT:     %0 = firrtl.subfield %_M_read(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>) -> !firrtl.sint<42>
 // WRAPPER-NEXT:     firrtl.connect %result, %0 : !firrtl.sint<42>, !firrtl.sint<42>
 // WRAPPER-NEXT:     %1 = firrtl.subfield %_M_read(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>) -> !firrtl.uint<4>
@@ -241,7 +241,7 @@ firrtl.circuit "MemSimple" {
 // INLINE-NEXT:     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
 // INLINE-NEXT:     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
 // INLINE-NEXT:     %c0_ui3 = firrtl.constant 0 : !firrtl.uint<3>
-// INLINE-NEXT:     %_M_R0_addr, %_M_R0_en, %_M_R0_clk, %_M_R0_data, %_M_W0_addr, %_M_W0_en, %_M_W0_clk, %_M_W0_data, %_M_W0_mask = firrtl.instance @_M_ext {name = "_M"} : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<42>, !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<42>, !firrtl.uint<1>
+// INLINE-NEXT:     %_M_R0_addr, %_M_R0_en, %_M_R0_clk, %_M_R0_data, %_M_W0_addr, %_M_W0_en, %_M_W0_clk, %_M_W0_data, %_M_W0_mask = firrtl.instance _M @_M_ext
 // INLINE-NEXT:     %0 = firrtl.wire  : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>
 // INLINE-NEXT:     %1 = firrtl.subfield %0(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>) -> !firrtl.uint<4>
 // INLINE-NEXT:     firrtl.connect %_M_R0_addr, %1 : !firrtl.uint<4>, !firrtl.uint<4>
@@ -305,7 +305,7 @@ firrtl.circuit "NameCollision" {
 // WRAPPER-LABEL: firrtl.circuit "NameCollision" {
 // WRAPPER-NEXT:   firrtl.extmodule @NameCollisionMemory_ext_1(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.sint<8>, in W0_mask: !firrtl.uint<1>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // WRAPPER-NEXT:   firrtl.module @NameCollisionMemory_0(in %write0: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) {
-// WRAPPER-NEXT:     %NameCollisionMemory_W0_addr, %NameCollisionMemory_W0_en, %NameCollisionMemory_W0_clk, %NameCollisionMemory_W0_data, %NameCollisionMemory_W0_mask = firrtl.instance @NameCollisionMemory_ext_1 {name = "NameCollisionMemory"} : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %NameCollisionMemory_W0_addr, %NameCollisionMemory_W0_en, %NameCollisionMemory_W0_clk, %NameCollisionMemory_W0_data, %NameCollisionMemory_W0_mask = firrtl.instance NameCollisionMemory @NameCollisionMemory_ext_1
 // WRAPPER-NEXT:     %0 = firrtl.subfield %write0(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<4>
 // WRAPPER-NEXT:     firrtl.connect %NameCollisionMemory_W0_addr, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 // WRAPPER-NEXT:     %1 = firrtl.subfield %write0(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
@@ -319,7 +319,7 @@ firrtl.circuit "NameCollision" {
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT:   firrtl.extmodule @NameCollisionMemory_ext_0(in R0_addr: !firrtl.uint<4>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.sint<8>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // WRAPPER-NEXT:   firrtl.module @NameCollisionMemory(in %read0: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) {
-// WRAPPER-NEXT:     %NameCollisionMemory_R0_addr, %NameCollisionMemory_R0_en, %NameCollisionMemory_R0_clk, %NameCollisionMemory_R0_data = firrtl.instance @NameCollisionMemory_ext_0 {name = "NameCollisionMemory"} : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>
+// WRAPPER-NEXT:     %NameCollisionMemory_R0_addr, %NameCollisionMemory_R0_en, %NameCollisionMemory_R0_clk, %NameCollisionMemory_R0_data = firrtl.instance NameCollisionMemory @NameCollisionMemory_ext_0
 // WRAPPER-NEXT:     %0 = firrtl.subfield %read0(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<4>
 // WRAPPER-NEXT:     firrtl.connect %NameCollisionMemory_R0_addr, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 // WRAPPER-NEXT:     %1 = firrtl.subfield %read0(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<1>
@@ -330,10 +330,10 @@ firrtl.circuit "NameCollision" {
 // WRAPPER-NEXT:     firrtl.connect %3, %NameCollisionMemory_R0_data : !firrtl.sint<8>, !firrtl.sint<8>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT:   firrtl.module @NameCollisionMemory_ext() {
-// WRAPPER-NEXT:     %NameCollisionMemory_read0 = firrtl.instance @NameCollisionMemory {name = "NameCollisionMemory"} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
+// WRAPPER-NEXT:     %NameCollisionMemory_read0 = firrtl.instance NameCollisionMemory @NameCollisionMemory
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT:   firrtl.module @NameCollision() {
-// WRAPPER-NEXT:     %NameCollisionMemory_write0 = firrtl.instance @NameCollisionMemory_0 {name = "NameCollisionMemory"} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
+// WRAPPER-NEXT:     %NameCollisionMemory_write0 = firrtl.instance NameCollisionMemory @NameCollisionMemory_0
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT: }
 
@@ -341,7 +341,7 @@ firrtl.circuit "NameCollision" {
 // INLINE-NEXT:   firrtl.extmodule @NameCollisionMemory_ext_1(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.sint<8>, in W0_mask: !firrtl.uint<1>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // INLINE-NEXT:   firrtl.extmodule @NameCollisionMemory_ext_0(in R0_addr: !firrtl.uint<4>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.sint<8>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // INLINE-NEXT:   firrtl.module @NameCollisionMemory_ext() {
-// INLINE-NEXT:     %NameCollisionMemory_R0_addr, %NameCollisionMemory_R0_en, %NameCollisionMemory_R0_clk, %NameCollisionMemory_R0_data = firrtl.instance @NameCollisionMemory_ext_0 {name = "NameCollisionMemory"} : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>
+// INLINE-NEXT:     %NameCollisionMemory_R0_addr, %NameCollisionMemory_R0_en, %NameCollisionMemory_R0_clk, %NameCollisionMemory_R0_data = firrtl.instance NameCollisionMemory @NameCollisionMemory_ext_0
 // INLINE-NEXT:     %0 = firrtl.wire  : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
 // INLINE-NEXT:     %1 = firrtl.subfield %0(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<4>
 // INLINE-NEXT:     firrtl.connect %NameCollisionMemory_R0_addr, %1 : !firrtl.uint<4>, !firrtl.uint<4>
@@ -353,7 +353,7 @@ firrtl.circuit "NameCollision" {
 // INLINE-NEXT:     firrtl.connect %4, %NameCollisionMemory_R0_data : !firrtl.sint<8>, !firrtl.sint<8>
 // INLINE-NEXT:   }
 // INLINE-NEXT:   firrtl.module @NameCollision() {
-// INLINE-NEXT:     %NameCollisionMemory_W0_addr, %NameCollisionMemory_W0_en, %NameCollisionMemory_W0_clk, %NameCollisionMemory_W0_data, %NameCollisionMemory_W0_mask = firrtl.instance @NameCollisionMemory_ext_1 {name = "NameCollisionMemory"} : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// INLINE-NEXT:     %NameCollisionMemory_W0_addr, %NameCollisionMemory_W0_en, %NameCollisionMemory_W0_clk, %NameCollisionMemory_W0_data, %NameCollisionMemory_W0_mask = firrtl.instance NameCollisionMemory @NameCollisionMemory_ext_1
 // INLINE-NEXT:     %0 = firrtl.wire  : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
 // INLINE-NEXT:     %1 = firrtl.subfield %0(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<4>
 // INLINE-NEXT:     firrtl.connect %NameCollisionMemory_W0_addr, %1 : !firrtl.uint<4>, !firrtl.uint<4>
@@ -382,7 +382,7 @@ firrtl.circuit "Duplicate" {
 // WRAPPER-LABEL: firrtl.circuit "Duplicate" {
 // WRAPPER-NEXT:   firrtl.extmodule @WriteMemory_ext(in W0_addr: !firrtl.uint<1>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.sint<8>, in W0_mask: !firrtl.uint<1>) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // WRAPPER-NEXT:   firrtl.module @WriteMemory(in %write0: !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) {
-// WRAPPER-NEXT:     %WriteMemory_W0_addr, %WriteMemory_W0_en, %WriteMemory_W0_clk, %WriteMemory_W0_data, %WriteMemory_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory"} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// WRAPPER-NEXT:     %WriteMemory_W0_addr, %WriteMemory_W0_en, %WriteMemory_W0_clk, %WriteMemory_W0_data, %WriteMemory_W0_mask = firrtl.instance WriteMemory @WriteMemory_ext
 // WRAPPER-NEXT:     %0 = firrtl.subfield %write0(0) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
 // WRAPPER-NEXT:     firrtl.connect %WriteMemory_W0_addr, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 // WRAPPER-NEXT:     %1 = firrtl.subfield %write0(1) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
@@ -396,7 +396,7 @@ firrtl.circuit "Duplicate" {
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT:   firrtl.extmodule @ReadMemory_ext(in R0_addr: !firrtl.uint<4>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.sint<8>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // WRAPPER-NEXT:   firrtl.module @ReadMemory(in %read0: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) {
-// WRAPPER-NEXT:     %ReadMemory_R0_addr, %ReadMemory_R0_en, %ReadMemory_R0_clk, %ReadMemory_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory"} : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>
+// WRAPPER-NEXT:     %ReadMemory_R0_addr, %ReadMemory_R0_en, %ReadMemory_R0_clk, %ReadMemory_R0_data = firrtl.instance ReadMemory @ReadMemory_ext
 // WRAPPER-NEXT:     %0 = firrtl.subfield %read0(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<4>
 // WRAPPER-NEXT:     firrtl.connect %ReadMemory_R0_addr, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 // WRAPPER-NEXT:     %1 = firrtl.subfield %read0(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<1>
@@ -407,12 +407,12 @@ firrtl.circuit "Duplicate" {
 // WRAPPER-NEXT:     firrtl.connect %3, %ReadMemory_R0_data : !firrtl.sint<8>, !firrtl.sint<8>
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT:   firrtl.module @Duplicate() {
-// WRAPPER-NEXT:     %ReadMemory_read0 = firrtl.instance @ReadMemory {name = "ReadMemory"} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
-// WRAPPER-NEXT:     %WriteMemory_write0 = firrtl.instance @WriteMemory {name = "WriteMemory"} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
-// WRAPPER-NEXT:     %ReadMemory1_read0 = firrtl.instance @ReadMemory {name = "ReadMemory1"} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
-// WRAPPER-NEXT:     %WriteMemory1_write0 = firrtl.instance @WriteMemory {name = "WriteMemory1"} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
-// WRAPPER-NEXT:     %ReadMemory2_read0 = firrtl.instance @ReadMemory {name = "ReadMemory2"} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
-// WRAPPER-NEXT:     %WriteMemory2_write0 = firrtl.instance @WriteMemory {name = "WriteMemory2"} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
+// WRAPPER-NEXT:     %ReadMemory_read0 = firrtl.instance ReadMemory @ReadMemory
+// WRAPPER-NEXT:     %WriteMemory_write0 = firrtl.instance WriteMemory @WriteMemory
+// WRAPPER-NEXT:     %ReadMemory1_read0 = firrtl.instance ReadMemory1 @ReadMemory
+// WRAPPER-NEXT:     %WriteMemory1_write0 = firrtl.instance WriteMemory1 @WriteMemory
+// WRAPPER-NEXT:     %ReadMemory2_read0 = firrtl.instance ReadMemory2 @ReadMemory
+// WRAPPER-NEXT:     %WriteMemory2_write0 = firrtl.instance WriteMemory2 @WriteMemory
 // WRAPPER-NEXT:   }
 // WRAPPER-NEXT: }
 
@@ -420,7 +420,7 @@ firrtl.circuit "Duplicate" {
 // INLINE-NEXT:   firrtl.extmodule @WriteMemory_ext(in W0_addr: !firrtl.uint<1>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.sint<8>, in W0_mask: !firrtl.uint<1>) attributes {depth = 1 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // INLINE-NEXT:   firrtl.extmodule @ReadMemory_ext(in R0_addr: !firrtl.uint<4>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.sint<8>) attributes {depth = 16 : i64, generator = "FIRRTLMemory", readLatency = 1 : i32, ruw = 0 : i32, writeLatency = 1 : i32}
 // INLINE-NEXT:   firrtl.module @Duplicate() {
-// INLINE-NEXT:     %ReadMemory_R0_addr, %ReadMemory_R0_en, %ReadMemory_R0_clk, %ReadMemory_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory"} : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>
+// INLINE-NEXT:     %ReadMemory_R0_addr, %ReadMemory_R0_en, %ReadMemory_R0_clk, %ReadMemory_R0_data = firrtl.instance ReadMemory @ReadMemory_ext
 // INLINE-NEXT:     %0 = firrtl.wire  : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
 // INLINE-NEXT:     %1 = firrtl.subfield %0(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<4>
 // INLINE-NEXT:     firrtl.connect %ReadMemory_R0_addr, %1 : !firrtl.uint<4>, !firrtl.uint<4>
@@ -430,7 +430,7 @@ firrtl.circuit "Duplicate" {
 // INLINE-NEXT:     firrtl.connect %ReadMemory_R0_clk, %3 : !firrtl.clock, !firrtl.clock
 // INLINE-NEXT:     %4 = firrtl.subfield %0(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.sint<8>
 // INLINE-NEXT:     firrtl.connect %4, %ReadMemory_R0_data : !firrtl.sint<8>, !firrtl.sint<8>
-// INLINE-NEXT:     %WriteMemory_W0_addr, %WriteMemory_W0_en, %WriteMemory_W0_clk, %WriteMemory_W0_data, %WriteMemory_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory"} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// INLINE-NEXT:     %WriteMemory_W0_addr, %WriteMemory_W0_en, %WriteMemory_W0_clk, %WriteMemory_W0_data, %WriteMemory_W0_mask = firrtl.instance WriteMemory @WriteMemory_ext
 // INLINE-NEXT:     %5 = firrtl.wire  : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
 // INLINE-NEXT:     %6 = firrtl.subfield %5(0) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
 // INLINE-NEXT:     firrtl.connect %WriteMemory_W0_addr, %6 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -442,7 +442,7 @@ firrtl.circuit "Duplicate" {
 // INLINE-NEXT:     firrtl.connect %WriteMemory_W0_data, %9 : !firrtl.sint<8>, !firrtl.sint<8>
 // INLINE-NEXT:     %10 = firrtl.subfield %5(4) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
 // INLINE-NEXT:     firrtl.connect %WriteMemory_W0_mask, %10 : !firrtl.uint<1>, !firrtl.uint<1>
-// INLINE-NEXT:     %ReadMemory1_R0_addr, %ReadMemory1_R0_en, %ReadMemory1_R0_clk, %ReadMemory1_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory1"} : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>
+// INLINE-NEXT:     %ReadMemory1_R0_addr, %ReadMemory1_R0_en, %ReadMemory1_R0_clk, %ReadMemory1_R0_data = firrtl.instance ReadMemory1 @ReadMemory_ext
 // INLINE-NEXT:     %11 = firrtl.wire  : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
 // INLINE-NEXT:     %12 = firrtl.subfield %11(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<4>
 // INLINE-NEXT:     firrtl.connect %ReadMemory1_R0_addr, %12 : !firrtl.uint<4>, !firrtl.uint<4>
@@ -452,7 +452,7 @@ firrtl.circuit "Duplicate" {
 // INLINE-NEXT:     firrtl.connect %ReadMemory1_R0_clk, %14 : !firrtl.clock, !firrtl.clock
 // INLINE-NEXT:     %15 = firrtl.subfield %11(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.sint<8>
 // INLINE-NEXT:     firrtl.connect %15, %ReadMemory1_R0_data : !firrtl.sint<8>, !firrtl.sint<8>
-// INLINE-NEXT:     %WriteMemory1_W0_addr, %WriteMemory1_W0_en, %WriteMemory1_W0_clk, %WriteMemory1_W0_data, %WriteMemory1_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory1"} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// INLINE-NEXT:     %WriteMemory1_W0_addr, %WriteMemory1_W0_en, %WriteMemory1_W0_clk, %WriteMemory1_W0_data, %WriteMemory1_W0_mask = firrtl.instance WriteMemory1 @WriteMemory_ext
 // INLINE-NEXT:     %16 = firrtl.wire  : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
 // INLINE-NEXT:     %17 = firrtl.subfield %16(0) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
 // INLINE-NEXT:     firrtl.connect %WriteMemory1_W0_addr, %17 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -464,7 +464,7 @@ firrtl.circuit "Duplicate" {
 // INLINE-NEXT:     firrtl.connect %WriteMemory1_W0_data, %20 : !firrtl.sint<8>, !firrtl.sint<8>
 // INLINE-NEXT:     %21 = firrtl.subfield %16(4) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
 // INLINE-NEXT:     firrtl.connect %WriteMemory1_W0_mask, %21 : !firrtl.uint<1>, !firrtl.uint<1>
-// INLINE-NEXT:     %ReadMemory2_R0_addr, %ReadMemory2_R0_en, %ReadMemory2_R0_clk, %ReadMemory2_R0_data = firrtl.instance @ReadMemory_ext {name = "ReadMemory2"} : !firrtl.uint<4>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>
+// INLINE-NEXT:     %ReadMemory2_R0_addr, %ReadMemory2_R0_en, %ReadMemory2_R0_clk, %ReadMemory2_R0_data = firrtl.instance ReadMemory2 @ReadMemory_ext
 // INLINE-NEXT:     %22 = firrtl.wire  : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
 // INLINE-NEXT:     %23 = firrtl.subfield %22(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.uint<4>
 // INLINE-NEXT:     firrtl.connect %ReadMemory2_R0_addr, %23 : !firrtl.uint<4>, !firrtl.uint<4>
@@ -474,7 +474,7 @@ firrtl.circuit "Duplicate" {
 // INLINE-NEXT:     firrtl.connect %ReadMemory2_R0_clk, %25 : !firrtl.clock, !firrtl.clock
 // INLINE-NEXT:     %26 = firrtl.subfield %22(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>) -> !firrtl.sint<8>
 // INLINE-NEXT:     firrtl.connect %26, %ReadMemory2_R0_data : !firrtl.sint<8>, !firrtl.sint<8>
-// INLINE-NEXT:     %WriteMemory2_W0_addr, %WriteMemory2_W0_en, %WriteMemory2_W0_clk, %WriteMemory2_W0_data, %WriteMemory2_W0_mask = firrtl.instance @WriteMemory_ext {name = "WriteMemory2"} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.sint<8>, !firrtl.uint<1>
+// INLINE-NEXT:     %WriteMemory2_W0_addr, %WriteMemory2_W0_en, %WriteMemory2_W0_clk, %WriteMemory2_W0_data, %WriteMemory2_W0_mask = firrtl.instance WriteMemory2 @WriteMemory_ext
 // INLINE-NEXT:     %27 = firrtl.wire  : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>
 // INLINE-NEXT:     %28 = firrtl.subfield %27(0) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: sint<8>, mask: uint<1>>) -> !firrtl.uint<1>
 // INLINE-NEXT:     firrtl.connect %WriteMemory2_W0_addr, %28 : !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/check-comb-cycles.mlir
+++ b/test/Dialect/FIRRTL/check-comb-cycles.mlir
@@ -10,7 +10,7 @@ module  {
     }
     firrtl.module @hasnoloops(in %clk: !firrtl.clock, in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
       %x = firrtl.wire  : !firrtl.uint<1>
-      %inner_in1, %inner_in2, %inner_out1, %inner_out2 = firrtl.instance @thru  {name = "inner"} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+      %inner_in1, %inner_in2, %inner_out1, %inner_out2 = firrtl.instance inner @thru(in in1: !firrtl.uint<1>, in in2: !firrtl.uint<1>, out out1: !firrtl.uint<1>, out out2: !firrtl.uint<1>)
       firrtl.connect %inner_in1, %a : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %x, %inner_out1 : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %inner_in2, %x : !firrtl.uint<1>, !firrtl.uint<1>
@@ -123,7 +123,7 @@ module  {
       %z = firrtl.wire  : !firrtl.uint<1>
       firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
       // expected-note @+1 {{this operation is part of the combinational cycle}}
-      %inner_in, %inner_out = firrtl.instance @thru  {name = "inner"} : !firrtl.uint<1>, !firrtl.uint<1>
+      %inner_in, %inner_out = firrtl.instance inner @thru(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
       firrtl.connect %inner_in, %y : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %z, %inner_out : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %y, %z : !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -97,7 +97,7 @@ firrtl.circuit "Foo" {
     // CHECK: inst someInst of Simple
     // CHECK: someInst.someIn <= ui1
     // CHECK: someOut <= someInst.someOut
-    %someInst_someIn, %someInst_someOut = firrtl.instance @Simple {name = "someInst"} : !firrtl.uint<1>, !firrtl.uint<1>
+    %someInst_someIn, %someInst_someOut = firrtl.instance someInst @Simple(in someIn: !firrtl.uint<1>, out someOut: !firrtl.uint<1>)
     firrtl.connect %someInst_someIn, %ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %someOut, %someInst_someOut : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: someOut is invalid

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -77,9 +77,9 @@ firrtl.circuit "BasicBlackboxes" attributes { annotations = [{
 
   firrtl.module @BasicBlackboxes() attributes {annotations = [
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
-    firrtl.instance @DUTBlackbox_0 { name = "test" }
-    firrtl.instance @DUTBlackbox_1 { name = "test" }
-    firrtl.instance @DUTBlackbox_2 { name = "test" }
+    firrtl.instance test @DUTBlackbox_0()
+    firrtl.instance test @DUTBlackbox_1()
+    firrtl.instance test @DUTBlackbox_2()
   }
 
   // These should all be ignored.
@@ -108,15 +108,15 @@ firrtl.circuit "BasicBlackboxes" attributes { annotations = [{
 firrtl.circuit "top" 
 {
     firrtl.module @top()  {
-      firrtl.instance @dut {name = "dut"}
-      firrtl.instance @Mem1 {name = "mem1"}
+      firrtl.instance dut @dut()
+      firrtl.instance mem1 @Mem1()
     }
     firrtl.module @Mem1() {
       %head_MPORT_2 = firrtl.mem Undefined  {depth = 20 : i64, name = "head", portNames = ["MPORT_2", "MPORT_6"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<5>, mask: uint<1>>
     }
-    firrtl.module @dut()attributes {annotations = [
+    firrtl.module @dut() attributes {annotations = [
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
-      firrtl.instance @Mem {name = "mem1"}
+      firrtl.instance mem1 @Mem()
     }
     firrtl.module @Mem() {
       %memory_rw, %memory_rw_r = firrtl.mem Undefined  {annotations = [{class = "sifive.enterprise.firrtl.SeqMemInstanceMetadataAnnotation", data = {baseAddress = 2147483648 : i64, dataBits = 8 : i64, eccBits = 0 : i64, eccIndices = [], eccScheme = "none"}}], depth = 16 : i64, name = "memory", portNames = ["rw", "rw_r", "rw_w"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, wdata: uint<8>, wmask: uint<1>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -198,7 +198,6 @@ firrtl.circuit "Foo" {
 // -----
 
 firrtl.circuit "Foo" {
-
   // expected-error @+1 {{'firrtl.extmodule' op attribute 'defname' with value "Bar" conflicts with the name of another module in the circuit}}
   firrtl.extmodule @Foo() attributes { defname = "Bar" }
   // expected-note @+1 {{previous module declared here}}
@@ -211,46 +210,38 @@ firrtl.circuit "Foo" {
 // -----
 
 firrtl.circuit "Foo" {
-
   // expected-note @+1 {{previous extmodule definition occurred here}}
   firrtl.extmodule @Foo(in a : !firrtl.uint<1>) attributes { defname = "Foo" }
   // expected-error @+1 {{'firrtl.extmodule' op with 'defname' attribute "Foo" has 0 ports which is different from a previously defined extmodule with the same 'defname' which has 1 ports}}
   firrtl.extmodule @Bar() attributes { defname = "Foo" }
-
 }
 
 // -----
 
 firrtl.circuit "Foo" {
-
   // expected-note @+1 {{previous extmodule definition occurred here}}
   firrtl.extmodule @Foo(in a : !firrtl.uint<1>) attributes { defname = "Foo" }
   // expected-error @+1 {{'firrtl.extmodule' op with 'defname' attribute "Foo" has a port with name "b" which does not match the name of the port in the same position of a previously defined extmodule with the same 'defname', expected port to have name "a"}}
   firrtl.extmodule @Foo_(in b : !firrtl.uint<1>) attributes { defname = "Foo" }
-
 }
 
 // -----
 
 firrtl.circuit "Foo" {
-
   firrtl.extmodule @Foo(in a : !firrtl.uint<2>) attributes { defname = "Foo", parameters = { width = 2 : i32 } }
   // expected-note @+1 {{previous extmodule definition occurred here}}
   firrtl.extmodule @Bar(in a : !firrtl.uint<1>) attributes { defname = "Foo" }
   // expected-error @+1 {{'firrtl.extmodule' op with 'defname' attribute "Foo" has a port with name "a" which has a different type '!firrtl.uint<2>' which does not match the type of the port in the same position of a previously defined extmodule with the same 'defname', expected port to have type '!firrtl.uint<1>'}}
   firrtl.extmodule @Baz(in a : !firrtl.uint<2>) attributes { defname = "Foo" }
-
 }
 
 // -----
 
 firrtl.circuit "Foo" {
-
   // expected-note @+1 {{previous extmodule definition occurred here}}
   firrtl.extmodule @Foo(in a : !firrtl.uint<1>) attributes { defname = "Foo" }
   // expected-error @+1 {{'firrtl.extmodule' op with 'defname' attribute "Foo" has a port with name "a" which has a different type '!firrtl.sint<1>' which does not match the type of the port in the same position of a previously defined extmodule with the same 'defname', expected port to have type '!firrtl.uint<1>'}}
   firrtl.extmodule @Foo_(in a : !firrtl.sint<1>) attributes { defname = "Foo" }
-
 }
 
 // -----
@@ -267,68 +258,80 @@ firrtl.circuit "Foo" {
 // -----
 
 firrtl.circuit "Foo" {
-
   // expected-error @+1 {{has unknown extmodule parameter value 'width' = @Foo}}
   firrtl.extmodule @Foo(in a : !firrtl.uint<2>) attributes { defname = "Foo", parameters = { width = @Foo } }
-
 }
 
 // -----
 
 firrtl.circuit "Foo" {
-
   firrtl.extmodule @Foo()
   // expected-error @+1 {{'firrtl.instance' op should be embedded in a 'firrtl.module'}}
-  firrtl.instance @Foo {name = ""}
-
+  firrtl.instance "" @Foo()
 }
 
 // -----
 
 firrtl.circuit "Foo" {
-
   // expected-note @+1 {{containing module declared here}}
   firrtl.module @Foo() {
     // expected-error @+1 {{'firrtl.instance' op is a recursive instantiation of its containing module}}
-    firrtl.instance @Foo {name = ""}
+    firrtl.instance "" @Foo()
   }
-
 }
 
 // -----
 
 firrtl.circuit "Foo" {
-
   // expected-note @+1 {{original module declared here}}
   firrtl.module @Callee(in %arg0: !firrtl.uint<1>) { }
   firrtl.module @Foo() {
     // expected-error @+1 {{'firrtl.instance' op result type for "arg0" must be '!firrtl.uint<1>', but got '!firrtl.uint<2>'}}
-    %a = firrtl.instance @Callee {name = ""} : !firrtl.uint<2>
+    %a = firrtl.instance "" @Callee(in arg0: !firrtl.uint<2>)
   }
 }
 
 // -----
 
 firrtl.circuit "Foo" {
-
   // expected-note @+1 {{original module declared here}}
   firrtl.module @Callee(in %arg0: !firrtl.uint<1> ) { }
   firrtl.module @Foo() {
     // expected-error @+1 {{'firrtl.instance' op has a wrong number of results; expected 1 but got 0}}
-    firrtl.instance @Callee {name = ""}
+    firrtl.instance "" @Callee()
   }
 }
 
 // -----
 
 firrtl.circuit "Foo" {
-
   // expected-note @+1 {{original module declared here}}
   firrtl.module @Callee(in %arg0: !firrtl.uint<1>, in %arg1: !firrtl.bundle<valid: uint<1>>) { }
   firrtl.module @Foo() {
     // expected-error @+1 {{'firrtl.instance' op result type for "arg1" must be '!firrtl.bundle<valid: uint<1>>', but got '!firrtl.bundle<valid: uint<2>>'}}
-    %a:2 = firrtl.instance @Callee {name = ""}
-    : !firrtl.uint<1>, !firrtl.bundle<valid: uint<2>>
+    %a:2 = firrtl.instance "" @Callee(in arg0: !firrtl.uint<1>, in arg1: !firrtl.bundle<valid: uint<2>>)
+  }
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+  // expected-note @+1 {{original module declared here}}
+  firrtl.module @Callee(in %arg0: !firrtl.uint<1>, in %arg1: !firrtl.bundle<valid: uint<1>>) { }
+  firrtl.module @Foo() {
+    // expected-error @+1 {{'firrtl.instance' op name for port 1 must be "arg1", but got "xxx"}}
+    %a:2 = firrtl.instance "" @Callee(in arg0: !firrtl.uint<1>, in xxx: !firrtl.bundle<valid: uint<1>>)
+  }
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+  // expected-note @+1 {{original module declared here}}
+  firrtl.module @Callee(in %arg0: !firrtl.uint<1>, in %arg1: !firrtl.bundle<valid: uint<1>>) { }
+  firrtl.module @Foo() {
+    // expected-error @+1 {{'firrtl.instance' op direction for "arg1" must be "in", but got "out"}}
+    %a:2 = firrtl.instance "" @Callee(in arg0: !firrtl.uint<1>, out arg1: !firrtl.bundle<valid: uint<1>>)
   }
 }
 

--- a/test/Dialect/FIRRTL/expand-whens-errors.mlir
+++ b/test/Dialect/FIRRTL/expand-whens-errors.mlir
@@ -26,7 +26,7 @@ firrtl.module @simple(in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
 }
 firrtl.module @CheckInitialization() {
   // expected-error @+1 {{sink "test.in" not fully initialized}}
-  %simple_out, %simple_in = firrtl.instance @simple {name = "test", portNames=["in", "out"]}: !firrtl.uint<1>, !firrtl.uint<1>
+  %simple_out, %simple_in = firrtl.instance test @simple(in in : !firrtl.uint<1>, out out : !firrtl.uint<1>)
 }
 }
 

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -369,7 +369,7 @@ firrtl.module @bundle_types(in %p : !firrtl.uint<1>, in %clock: !firrtl.clock) {
 firrtl.module @simple(in %in : !firrtl.bundle<a: uint<1>>) { }
 firrtl.module @bundle_ports() {
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-  %simple_in = firrtl.instance @simple {name = "test0"}: !firrtl.bundle<a: uint<1>>
+  %simple_in = firrtl.instance test0 @simple(in in : !firrtl.bundle<a: uint<1>>)
   %0 = firrtl.subfield %simple_in(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
   firrtl.connect %0, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
 }
@@ -379,10 +379,10 @@ firrtl.module @simple2(in %in : !firrtl.uint<3>) { }
 firrtl.module @as_passive(in %p : !firrtl.uint<1>) {
   %c2_ui3 = firrtl.constant 2 : !firrtl.uint<3>
   %c3_ui3 = firrtl.constant 3 : !firrtl.uint<3>
-  %simple0_in = firrtl.instance @simple2 {name = "test0"}: !firrtl.uint<3>
+  %simple0_in = firrtl.instance test0 @simple2(in in : !firrtl.uint<3>)
   firrtl.connect %simple0_in, %c2_ui3 : !firrtl.uint<3>, !firrtl.uint<3>
 
-  %simple1_in = firrtl.instance @simple2 {name = "test0"}: !firrtl.uint<3>
+  %simple1_in = firrtl.instance test0 @simple2(in in : !firrtl.uint<3>)
   firrtl.when %p {
     // This is the tricky part, connect the input ports together.
     firrtl.connect %simple1_in, %simple0_in : !firrtl.uint<3>, !firrtl.uint<3>

--- a/test/Dialect/FIRRTL/grand-central-errors.mlir
+++ b/test/Dialect/FIRRTL/grand-central-errors.mlir
@@ -51,10 +51,10 @@ firrtl.circuit "NonGroundType" attributes {
         {a},
         {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
          id = 1 : i64}]} : !firrtl.vector<uint<2>, 1>
-    firrtl.instance @View_companion { name = "View_companion" }
+    firrtl.instance View_companion @View_companion()
   }
   firrtl.module @NonGroundType() {
-    firrtl.instance @DUT {name = "dut"}
+    firrtl.instance dut @DUT()
   }
 }
 
@@ -98,16 +98,14 @@ firrtl.circuit "Foo" attributes {
        name = "View",
        type = "parent"}]} {
     // expected-error @+1 {{'firrtl.instance' op is marked as an interface element, but this should be impossible due to how the Chisel Grand Central API works}}
-    %bar_a = firrtl.instance @Bar {
-      portAnnotations = [[
+    %bar_a = firrtl.instance bar @Bar(in a: !firrtl.uint<1> [
         {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-         id = 1 : i64}]],
-      name = "bar"} : !firrtl.uint<1>
+         id = 1 : i64}])
     firrtl.connect %bar_a, %a : !firrtl.uint<1>, !firrtl.uint<1>
-    firrtl.instance @View_companion { name = "View_companion" }
+    firrtl.instance View_companion @View_companion()
   }
   firrtl.module @Foo() {
-    %dut_a = firrtl.instance @DUT {name = "dut"} : !firrtl.uint<1>
+    %dut_a = firrtl.instance dut @DUT(in a: !firrtl.uint<1>)
   }
 }
 
@@ -149,10 +147,10 @@ firrtl.circuit "Foo" attributes {
       portNames = ["r"],
       readLatency = 0 : i32,
       writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
-    firrtl.instance @View_companion { name = "View_companion" }
+    firrtl.instance View_companion @View_companion()
   }
   firrtl.module @Foo() {
-    %dut_a = firrtl.instance @DUT {name = "dut"} : !firrtl.uint<1>
+    %dut_a = firrtl.instance dut @DUT(in a: !firrtl.uint<1>)
   }
 }
 
@@ -184,9 +182,9 @@ firrtl.circuit "Foo" attributes {
        id = 0 : i64,
        name = "View",
        type = "parent"}]} {
-    firrtl.instance @View_companion {name = "View_companion"}
+    firrtl.instance View_companion @View_companion()
   }
   firrtl.module @Foo() {
-    firrtl.instance @DUT {name = "dut"}
+    firrtl.instance dut @DUT()
   }
 }

--- a/test/Dialect/FIRRTL/grand-central-signal-mappings.mlir
+++ b/test/Dialect/FIRRTL/grand-central-signal-mappings.mlir
@@ -21,10 +21,10 @@ firrtl.circuit "SubCircuit" {
   firrtl.module @Foo() attributes {annotations = [{class = "sifive.enterprise.grandcentral.SignalDriverAnnotation", id = 0 : i64}]} {
     %clock_source = firrtl.wire {annotations = [{class = "sifive.enterprise.grandcentral.SignalDriverAnnotation", dir = "source", id = 0 : i64, peer = "~Main|MainA>clock", side = "local", targetId = 0 : i64}]} : !firrtl.clock
     %clock_sink = firrtl.wire {annotations = [{class = "sifive.enterprise.grandcentral.SignalDriverAnnotation", dir = "sink", id = 0 : i64, peer = "~Main|MainB>clock", side = "local", targetId = 1 : i64}]} : !firrtl.clock
-    %ext_clockIn, %ext_clockOut = firrtl.instance @FooExtern {name = "ext"} : !firrtl.clock, !firrtl.clock
+    %ext_clockIn, %ext_clockOut = firrtl.instance ext @FooExtern(in clockIn: !firrtl.clock, out clockOut: !firrtl.clock)
     firrtl.connect %ext_clockIn, %clock_source : !firrtl.clock, !firrtl.clock
     firrtl.connect %clock_sink, %ext_clockOut : !firrtl.clock, !firrtl.clock
-    // CHECK: [[T1:%.+]], [[T2:%.+]] = firrtl.instance @Foo_signal_mappings
+    // CHECK: [[T1:%.+]], [[T2:%.+]] = firrtl.instance signal_mappings @Foo_signal_mappings
     // CHECK: firrtl.connect %clock_source, [[T1]] :
     // CHECK: firrtl.connect [[T2]], %clock_sink :
   }
@@ -42,10 +42,10 @@ firrtl.circuit "SubCircuit" {
   firrtl.module @Bar() attributes {annotations = [{class = "sifive.enterprise.grandcentral.SignalDriverAnnotation", id = 1 : i64}]} {
     %data_source = firrtl.wire {annotations = [{class = "sifive.enterprise.grandcentral.SignalDriverAnnotation", dir = "source", id = 1 : i64, peer = "~Main|MainA>dataOut.x.y.z", side = "local", targetId = 0 : i64}]} : !firrtl.uint<42>
     %data_sink = firrtl.wire {annotations = [{class = "sifive.enterprise.grandcentral.SignalDriverAnnotation", dir = "sink", id = 1 : i64, peer = "~Main|MainA>dataIn.a.b.c", side = "local", targetId = 1 : i64}]} : !firrtl.uint<42>
-    %ext_someInput, %ext_someOutput = firrtl.instance @BarExtern {name = "ext"} : !firrtl.uint<42>, !firrtl.uint<42>
+    %ext_someInput, %ext_someOutput = firrtl.instance ext @BarExtern(in someInput: !firrtl.uint<42>, out someOutput: !firrtl.uint<42>)
     firrtl.connect %ext_someInput, %data_source : !firrtl.uint<42>, !firrtl.uint<42>
     firrtl.connect %data_sink, %ext_someOutput : !firrtl.uint<42>, !firrtl.uint<42>
-    // CHECK: [[T1:%.+]], [[T2:%.+]] = firrtl.instance @Bar_signal_mappings_0
+    // CHECK: [[T1:%.+]], [[T2:%.+]] = firrtl.instance signal_mappings @Bar_signal_mappings_0
     // CHECK: firrtl.connect %data_source, [[T1]] :
     // CHECK: firrtl.connect [[T2]], %data_sink :
   }
@@ -64,14 +64,14 @@ firrtl.circuit "SubCircuit" {
     out %data_source: !firrtl.uint<42> [{class = "sifive.enterprise.grandcentral.SignalDriverAnnotation", dir = "source", id = 2 : i64, peer = "~Main|MainA>dataOut", side = "local", targetId = 0 : i64}],
     in %data_sink: !firrtl.uint<42> [{class = "sifive.enterprise.grandcentral.SignalDriverAnnotation", dir = "sink", id = 2 : i64, peer = "~Main|MainA>dataIn", side = "local", targetId = 1 : i64}]
   ) attributes {annotations = [{class = "sifive.enterprise.grandcentral.SignalDriverAnnotation", id = 2 : i64}]} {
-    // CHECK: [[T1:%.+]], [[T2:%.+]] = firrtl.instance @Baz_signal_mappings
+    // CHECK: [[T1:%.+]], [[T2:%.+]] = firrtl.instance signal_mappings @Baz_signal_mappings
     // CHECK: firrtl.connect %data_source, [[T1]] :
     // CHECK: firrtl.connect [[T2]], %data_sink :
   }
 
   firrtl.module @SubCircuit() {
-    firrtl.instance @Foo {name = "foo"}
-    firrtl.instance @Bar {name = "bar"}
-    %baz_data_source, %baz_data_sink = firrtl.instance @Baz {name = "baz"} : !firrtl.uint<42>, !firrtl.uint<42>
+    firrtl.instance foo @Foo()
+    firrtl.instance bar @Bar()
+    %baz_data_source, %baz_data_sink = firrtl.instance baz @Baz(out data_source: !firrtl.uint<42>, in data_sink: !firrtl.uint<42>)
   }
 }

--- a/test/Dialect/FIRRTL/grand-central-taps.mlir
+++ b/test/Dialect/FIRRTL/grand-central-taps.mlir
@@ -109,7 +109,7 @@ firrtl.circuit "TestHarness" attributes {
     in %in: !firrtl.uint<1>,
     out %out: !firrtl.uint<1>
   ) {
-    %bar_clock, %bar_reset, %bar_in, %bar_out = firrtl.instance @Bar  {name = "bar"} : !firrtl.clock, !firrtl.reset, !firrtl.uint<1>, !firrtl.uint<1>
+    %bar_clock, %bar_reset, %bar_in, %bar_out = firrtl.instance "bar" @Bar(in clock: !firrtl.clock, in reset: !firrtl.reset, in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
     firrtl.connect %bar_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %bar_reset, %reset : !firrtl.reset, !firrtl.reset
     firrtl.connect %bar_in, %in : !firrtl.uint<1>, !firrtl.uint<1>
@@ -220,16 +220,16 @@ firrtl.circuit "TestHarness" attributes {
 
   // CHECK: firrtl.module @TestHarness
   firrtl.module @TestHarness(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
-    %foo_clock, %foo_reset, %foo_in, %foo_out = firrtl.instance @Foo {name = "foo"} : !firrtl.clock, !firrtl.reset, !firrtl.uint<1>, !firrtl.uint<1>
+    %foo_clock, %foo_reset, %foo_in, %foo_out = firrtl.instance foo @Foo(in clock: !firrtl.clock, in reset: !firrtl.reset, in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
     firrtl.connect %foo_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %foo_reset, %reset : !firrtl.reset, !firrtl.uint<1>
     firrtl.connect %foo_in, %in : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %out, %foo_out : !firrtl.uint<1>, !firrtl.uint<1>
-    firrtl.instance @BlackHole {name = "bigScary"}
-    %0 = firrtl.instance @ExtmoduleWithTappedPort {name = "extmoduleWithTappedPort"} : !firrtl.uint<1>
-    // CHECK: firrtl.instance [[DT]] {name = "dataTap"}
-    %DataTap_9, %DataTap_8, %DataTap_7, %DataTap_6, %DataTap_5, %DataTap_4, %DataTap_3, %DataTap_2, %DataTap_1, %DataTap_0 = firrtl.instance @DataTap {name = "dataTap"} : !firrtl.uint<1>, !firrtl.sint<8>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.clock, !firrtl.uint<1>
-    // CHECK: firrtl.instance [[MT]] {name = "memTap"}
-    %MemTap_mem_0, %MemTap_mem_1 = firrtl.instance @MemTap {name = "memTap"} : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.instance bigScary @BlackHole()
+    %0 = firrtl.instance extmoduleWithTappedPort @ExtmoduleWithTappedPort(out out: !firrtl.uint<1>)
+    // CHECK: firrtl.instance dataTap [[DT]]
+    %DataTap_9, %DataTap_8, %DataTap_7, %DataTap_6, %DataTap_5, %DataTap_4, %DataTap_3, %DataTap_2, %DataTap_1, %DataTap_0 = firrtl.instance dataTap @DataTap(out _9: !firrtl.uint<1>, out _8: !firrtl.sint<8>, out _7: !firrtl.uint<1>, out _6: !firrtl.uint<1>, out _5: !firrtl.uint<1>, out _4: !firrtl.uint<1>, out _3: !firrtl.uint<1>, out _2: !firrtl.uint<1>, out _1: !firrtl.clock, out _0: !firrtl.uint<1>)
+    // CHECK: firrtl.instance memTap [[MT]]
+    %MemTap_mem_0, %MemTap_mem_1 = firrtl.instance memTap @MemTap(out mem_0: !firrtl.uint<1>, out mem_1: !firrtl.uint<1>)
   }
 }

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -40,10 +40,10 @@ firrtl.circuit "InterfaceGroundType" attributes {
       {a},
       {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
        id = 2 : i64}]} : !firrtl.uint<4>
-    firrtl.instance @View_companion { name = "View_companion" }
+    firrtl.instance View_companion @View_companion()
   }
   firrtl.module @InterfaceGroundType() {
-    firrtl.instance @DUT {name = "dut" }
+    firrtl.instance dut @DUT()
   }
 }
 
@@ -55,7 +55,7 @@ firrtl.circuit "InterfaceGroundType" attributes {
 
 // CHECK: firrtl.module @View_companion
 // CHECK-SAME: output_file = #hw.output_file<"gct-dir/View_companion.sv"
-// CHECK-NEXT: firrtl.instance @View_mapping {name = "View_mapping"}
+// CHECK-NEXT: firrtl.instance View_mapping @View_mapping
 
 // All Grand Central annotations are removed from the wires.
 // CHECK: firrtl.module @DUT
@@ -124,10 +124,10 @@ firrtl.circuit "InterfaceVectorType" attributes {
         {a},
         {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
          id = 2 : i64}]} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
-    firrtl.instance @View_companion {name = "View_companion"}
+    firrtl.instance View_companion @View_companion()
   }
   firrtl.module @InterfaceVectorType() {
-    %dut_clock, %dut_reset = firrtl.instance @DUT {name = "dut"} : !firrtl.clock, !firrtl.uint<1>
+    %dut_clock, %dut_reset = firrtl.instance dut @DUT(in clock: !firrtl.clock, in reset: !firrtl.uint<1>)
   }
 }
 
@@ -139,7 +139,7 @@ firrtl.circuit "InterfaceVectorType" attributes {
 
 // CHECK: firrtl.module @View_companion
 // CHECK-SAME: output_file = #hw.output_file<"gct-dir/View_companion.sv"
-// CHECK-NEXT: firrtl.instance @View_mapping {name = "View_mapping"}
+// CHECK-NEXT: firrtl.instance View_mapping @View_mapping
 
 // All Grand Central annotations are removed from the registers.
 // CHECK: firrtl.module @DUT
@@ -201,10 +201,10 @@ firrtl.circuit "InterfaceBundleType" attributes {
         {a},
         {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
          id = 1 : i64}]} : !firrtl.uint<2>
-    firrtl.instance @View_companion {name = "View_companion"}
+    firrtl.instance View_companion @View_companion()
   }
   firrtl.module @InterfaceBundleType() {
-    firrtl.instance @DUT {name = "dut"}
+    firrtl.instance dut @DUT()
   }
 }
 
@@ -271,10 +271,10 @@ firrtl.circuit "InterfaceVecOfBundleType" attributes {
         {a},
         {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
          id = 1 : i64}]} : !firrtl.uint<2>
-    firrtl.instance @View_companion {name = "View_companion"}
+    firrtl.instance View_companion @View_companion()
   }
   firrtl.module @InterfaceVecOfBundleType() {
-    firrtl.instance @DUT {name = "dut"}
+    firrtl.instance dut @DUT()
   }
 }
 
@@ -324,10 +324,10 @@ firrtl.circuit "InterfaceNode" attributes {
          defName = "Foo",
          name = "foo",
          id = 1 : i64}]} : !firrtl.uint<2>
-    firrtl.instance @View_companion {name = "View_companion"}
+    firrtl.instance View_companion @View_companion()
   }
   firrtl.module @InterfaceNode() {
-    firrtl.instance @DUT {name = "dut"}
+    firrtl.instance dut @DUT()
   }
 }
 
@@ -381,10 +381,10 @@ firrtl.circuit "InterfacePort" attributes {
       {a},
       {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
        id = 1 : i64}]] } {
-    firrtl.instance @View_companion {name = "View_companion"}
+    firrtl.instance View_companion @View_companion()
   }
   firrtl.module @InterfacePort() {
-    %dut_a = firrtl.instance @DUT {name = "dut"} : !firrtl.uint<4>
+    %dut_a = firrtl.instance dut @DUT(in a : !firrtl.uint<4>)
   }
 }
 
@@ -439,10 +439,10 @@ firrtl.circuit "UnsupportedTypes" attributes {
        name = "view",
        type = "parent"}
     ]} {
-    firrtl.instance @View_companion {name = "View_companion"}
+    firrtl.instance View_companion @View_companion()
   }
   firrtl.module @UnsupportedTypes() {
-    firrtl.instance @DUT {name = "dut"}
+    firrtl.instance dut @DUT()
   }
 }
 
@@ -503,10 +503,10 @@ firrtl.circuit "BindInterfaceTest"  attributes {
     }
       {
     firrtl.connect %b, %a : !firrtl.uint<8>, !firrtl.uint<8>
-    firrtl.instance @View_companion {name = "View_companion"}
+    firrtl.instance View_companion @View_companion()
   }
   firrtl.module @BindInterfaceTest() {
-    %dut_a, %dut_b = firrtl.instance @DUT {name = "dut"} : !firrtl.uint<8>, !firrtl.uint<8>
+    %dut_a, %dut_b = firrtl.instance dut @DUT(in a: !firrtl.uint<8>, out b: !firrtl.uint<8>)
   }
 }
 
@@ -587,10 +587,10 @@ firrtl.circuit "MultipleGroundTypeInterfaces" attributes {
        id = 1 : i64},
        {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
        id = 3 : i64}]} : !firrtl.uint<2>
-    firrtl.instance @View_companion { name = "View_companion" }
+    firrtl.instance View_companion @View_companion()
   }
   firrtl.module @MultipleGroundTypeInterfaces() {
-    firrtl.instance @DUT {name = "dut" }
+    firrtl.instance dut @DUT()
   }
 }
 

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -57,7 +57,7 @@ firrtl.circuit "Test" {
     firrtl.connect %result3, %nonconstWire : !firrtl.uint<1>, !firrtl.uint<1>
 
     // Constant propagation through instance.
-    %source, %dest = firrtl.instance @PassThrough {name = "", portNames = ["source", "dest"]} : !firrtl.uint<1>, !firrtl.uint<1>
+    %source, %dest = firrtl.instance "" @PassThrough(in source: !firrtl.uint<1>, out dest: !firrtl.uint<1>)
 
     // CHECK: firrtl.connect %inst_source, %c0_ui1
     firrtl.connect %source, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -112,7 +112,7 @@ firrtl.circuit "Test" {
 
 
     // Constant propagation through instance.
-    firrtl.instance @ReadMem {name = "ReadMem"}
+    firrtl.instance ReadMem @ReadMem()
   }
 
   // Unused modules should NOT be completely dropped.
@@ -199,9 +199,9 @@ firrtl.circuit "testDontTouch"  {
   // CHECK-LABEL: firrtl.module @testDontTouch
   firrtl.module @testDontTouch(in %clock: !firrtl.clock, out %a: !firrtl.uint<1>, out %a1: !firrtl.uint<1>, out %a2: !firrtl.uint<1>) {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    %blockProp1_clock, %blockProp1_a, %blockProp1_b = firrtl.instance @blockProp1  {name = "blockProp1"} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
-    %allowProp_clock, %allowProp_a, %allowProp_b = firrtl.instance @allowProp  {name = "allowProp"} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
-    %blockProp3_clock, %blockProp3_a, %blockProp3_b = firrtl.instance @blockProp3  {name = "blockProp3"} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
+    %blockProp1_clock, %blockProp1_a, %blockProp1_b = firrtl.instance blockProp1 @blockProp1(in clock: !firrtl.clock, in a: !firrtl.uint<1>, out b: !firrtl.uint<1>)
+    %allowProp_clock, %allowProp_a, %allowProp_b = firrtl.instance allowProp @allowProp(in clock: !firrtl.clock, in a: !firrtl.uint<1>, out b: !firrtl.uint<1>)
+    %blockProp3_clock, %blockProp3_a, %blockProp3_b = firrtl.instance blockProp3 @blockProp3(in clock: !firrtl.clock, in a: !firrtl.uint<1>, out b: !firrtl.uint<1>)
     firrtl.connect %blockProp1_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %allowProp_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %blockProp3_clock, %clock : !firrtl.clock, !firrtl.clock
@@ -237,8 +237,8 @@ firrtl.circuit "OutPortTop" {
     }
   // CHECK-LABEL: firrtl.module @OutPortTop
     firrtl.module @OutPortTop(in %x: !firrtl.uint<1>, out %zc: !firrtl.uint<1>, out %zn: !firrtl.uint<1>) {
-      %c_out = firrtl.instance @OutPortChild1  {name = "c"} : !firrtl.uint<1>
-      %c_out_0 = firrtl.instance @OutPortChild2  {name = "c"} : !firrtl.uint<1>
+      %c_out = firrtl.instance c @OutPortChild1(out out: !firrtl.uint<1>)
+      %c_out_0 = firrtl.instance c @OutPortChild2(out out: !firrtl.uint<1>)
       // CHECK: %0 = firrtl.and %x, %c_out
       %0 = firrtl.and %x, %c_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
       // CHECK: %c0_ui1_1 = firrtl.constant 0 
@@ -270,8 +270,8 @@ firrtl.circuit "InputPortTop"   {
   }
   firrtl.module @InputPortTop(in %x: !firrtl.uint<1>, out %z: !firrtl.uint<1>, out %z2: !firrtl.uint<1>) {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    %c_in0, %c_in1, %c_out = firrtl.instance @InputPortChild  {name = "c"} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
-    %c2_in0, %c2_in1, %c2_out = firrtl.instance @InputPortChild2  {name = "c2"} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %c_in0, %c_in1, %c_out = firrtl.instance c @InputPortChild(in in0: !firrtl.uint<1>, in in1: !firrtl.uint<1>, out out: !firrtl.uint<1>)
+    %c2_in0, %c2_in1, %c2_out = firrtl.instance c2 @InputPortChild2(in in0: !firrtl.uint<1>, in in1: !firrtl.uint<1>, out out: !firrtl.uint<1>)
     firrtl.connect %z, %c_out : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %c_in0, %x : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %c_in1, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -288,7 +288,7 @@ firrtl.circuit "InstanceOut"   {
 
   // CHECK-LABEL: firrtl.module @InstanceOut
   firrtl.module @InstanceOut(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
-    %ext_a = firrtl.instance @Ext  {name = "ext"} : !firrtl.uint<1>
+    %ext_a = firrtl.instance ext @Ext(in a: !firrtl.uint<1>)
     firrtl.connect %ext_a, %a : !firrtl.uint<1>, !firrtl.uint<1>
     %w = firrtl.wire  : !firrtl.uint<1>
     // CHECK: firrtl.connect %w, %ext_a : !firrtl.uint<1>, !firrtl.uint<1>
@@ -306,7 +306,7 @@ firrtl.circuit "InstanceOut2"   {
 
   // CHECK-LABEL: firrtl.module @InstanceOut2
   firrtl.module @InstanceOut2(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
-    %ext_a = firrtl.instance @Ext  {name = "ext"} : !firrtl.uint<1>
+    %ext_a = firrtl.instance ext @Ext(in a: !firrtl.uint<1>)
     firrtl.connect %ext_a, %a : !firrtl.uint<1>, !firrtl.uint<1>
     %w = firrtl.wire  : !firrtl.uint<1>
     // CHECK: firrtl.connect %w, %ext_a : !firrtl.uint<1>, !firrtl.uint<1>
@@ -401,7 +401,7 @@ firrtl.circuit "Oscillators"   {
   firrtl.extmodule @Ext(in a: !firrtl.uint<1>)
   // CHECK: firrtl.module @Qux
   firrtl.module @Qux(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, out %a: !firrtl.uint<1>) {
-    %ext_a = firrtl.instance @Ext  {name = "ext"} : !firrtl.uint<1>
+    %ext_a = firrtl.instance ext @Ext(in a: !firrtl.uint<1>)
     // CHECK: firrtl.reg
     %r = firrtl.reg %clock  : !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
@@ -416,19 +416,19 @@ firrtl.circuit "Oscillators"   {
     firrtl.connect %a, %ext_a : !firrtl.uint<1>, !firrtl.uint<1>
   }
   firrtl.module @Oscillators(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, out %foo_a: !firrtl.uint<1>, out %bar_a: !firrtl.uint<1>, out %baz_a: !firrtl.uint<1>, out %qux_a: !firrtl.uint<1>) {
-    %foo_clock, %foo_reset, %foo_a_0 = firrtl.instance @Foo  {name = "foo"} : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>
+    %foo_clock, %foo_reset, %foo_a_0 = firrtl.instance foo @Foo(in clock: !firrtl.clock, in reset: !firrtl.asyncreset, out a: !firrtl.uint<1>)
     firrtl.connect %foo_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %foo_reset, %reset : !firrtl.asyncreset, !firrtl.asyncreset
     firrtl.connect %foo_a, %foo_a_0 : !firrtl.uint<1>, !firrtl.uint<1>
-    %bar_clock, %bar_reset, %bar_a_1 = firrtl.instance @Bar  {name = "bar"} : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>
+    %bar_clock, %bar_reset, %bar_a_1 = firrtl.instance bar @Bar (in clock: !firrtl.clock, in reset: !firrtl.asyncreset, out a: !firrtl.uint<1>)
     firrtl.connect %bar_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %bar_reset, %reset : !firrtl.asyncreset, !firrtl.asyncreset
     firrtl.connect %bar_a, %bar_a_1 : !firrtl.uint<1>, !firrtl.uint<1>
-    %baz_clock, %baz_reset, %baz_a_2 = firrtl.instance @Baz  {name = "baz"} : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>
+    %baz_clock, %baz_reset, %baz_a_2 = firrtl.instance baz @Baz(in clock: !firrtl.clock, in reset: !firrtl.asyncreset, out a: !firrtl.uint<1>)
     firrtl.connect %baz_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %baz_reset, %reset : !firrtl.asyncreset, !firrtl.asyncreset
     firrtl.connect %baz_a, %baz_a_2 : !firrtl.uint<1>, !firrtl.uint<1>
-    %qux_clock, %qux_reset, %qux_a_3 = firrtl.instance @Qux  {name = "qux"} : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>
+    %qux_clock, %qux_reset, %qux_a_3 = firrtl.instance qux @Qux(in clock: !firrtl.clock, in reset: !firrtl.asyncreset, out a: !firrtl.uint<1>)
     firrtl.connect %qux_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %qux_reset, %reset : !firrtl.asyncreset, !firrtl.asyncreset
     firrtl.connect %qux_a, %qux_a_3 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -454,7 +454,7 @@ firrtl.circuit "rhs_sink_output_used_as_wire" {
     firrtl.connect %d, %_c : !firrtl.uint<1>, !firrtl.uint<1>
   }
   firrtl.module @rhs_sink_output_used_as_wire(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>, out %d: !firrtl.uint<1>) {
-    %bar_a, %bar_b, %bar_c, %bar_d = firrtl.instance @Bar  {name = "bar"} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %bar_a, %bar_b, %bar_c, %bar_d = firrtl.instance bar @Bar(in a: !firrtl.uint<1>, in b: !firrtl.uint<1>, out c: !firrtl.uint<1>, out d: !firrtl.uint<1>)
     firrtl.connect %bar_a, %a : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %bar_b, %b : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %c, %bar_c : !firrtl.uint<1>, !firrtl.uint<1>
@@ -533,7 +533,7 @@ firrtl.circuit "dntOutput" {
   // CHECK-NEXT: firrtl.connect %b, %0
   firrtl.module @dntOutput(out %b : !firrtl.uint<3>, in %c : !firrtl.uint<1>) {
     %const = firrtl.constant 2 : !firrtl.uint<3>
-    %int_b = firrtl.instance @foo  {name = "int"} : !firrtl.uint<3>
+    %int_b = firrtl.instance int @foo(out b: !firrtl.uint<3>)
     %m = firrtl.mux(%c, %int_b, %const) : (!firrtl.uint<1>, !firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
     firrtl.connect %b, %m : !firrtl.uint<3>, !firrtl.uint<3>
   }

--- a/test/Dialect/FIRRTL/infer-resets-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-resets-errors.mlir
@@ -109,7 +109,7 @@ firrtl.circuit "top" {
   firrtl.extmodule @ext(out out: !firrtl.bundle<foo: reset>)
   firrtl.module @top(out %out: !firrtl.reset) {
     // expected-error @+1 {{reset network never driven with concrete type}}
-    %e_out = firrtl.instance @ext  {name = "e"} : !firrtl.bundle<foo: reset>
+    %e_out = firrtl.instance e @ext(out out: !firrtl.bundle<foo: reset>)
     %0 = firrtl.subfield %e_out(0) : (!firrtl.bundle<foo: reset>) -> !firrtl.reset
     firrtl.connect %out, %0 : !firrtl.reset, !firrtl.reset
   }
@@ -204,20 +204,20 @@ firrtl.circuit "Top" {
   // expected-note @+1 {{reset domain 'otherReset' of module 'Child' declared here:}}
   firrtl.module @Child(in %clock: !firrtl.clock, in %otherReset: !firrtl.asyncreset) attributes {portAnnotations = [[],[{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]]} {
     // expected-note @+1 {{instance 'child/inst' is in reset domain rooted at 'otherReset' of module 'Child'}}
-    %inst_clock = firrtl.instance @Foo {name = "inst"} : !firrtl.clock
+    %inst_clock = firrtl.instance inst @Foo(in clock: !firrtl.clock)
     firrtl.connect %inst_clock, %clock : !firrtl.clock, !firrtl.clock
   }
   firrtl.module @Other(in %clock: !firrtl.clock) attributes {annotations = [{class = "sifive.enterprise.firrtl.IgnoreFullAsyncResetAnnotation"}]} {
     // expected-note @+1 {{instance 'other/inst' is in no reset domain}}
-    %inst_clock = firrtl.instance @Foo {name = "inst"} : !firrtl.clock
+    %inst_clock = firrtl.instance inst @Foo(in clock: !firrtl.clock)
     firrtl.connect %inst_clock, %clock : !firrtl.clock, !firrtl.clock
   }
   // expected-note @+1 {{reset domain 'reset' of module 'Top' declared here:}}
   firrtl.module @Top(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset) attributes {portAnnotations = [[],[{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]]} {
-    %child_clock, %child_otherReset = firrtl.instance @Child {name = "child"} : !firrtl.clock, !firrtl.asyncreset
-    %other_clock = firrtl.instance @Other {name = "other"} : !firrtl.clock
+    %child_clock, %child_otherReset = firrtl.instance child @Child(in clock: !firrtl.clock, in otherReset: !firrtl.asyncreset)
+    %other_clock = firrtl.instance other @Other(in clock: !firrtl.clock)
     // expected-note @+1 {{instance 'foo' is in reset domain rooted at 'reset' of module 'Top'}}
-    %foo_clock = firrtl.instance @Foo {name = "foo"} : !firrtl.clock
+    %foo_clock = firrtl.instance foo @Foo(in clock: !firrtl.clock)
     firrtl.connect %child_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %other_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %foo_clock, %clock : !firrtl.clock, !firrtl.clock

--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -34,10 +34,10 @@ firrtl.module @MergeNetsTop(in %reset: !firrtl.asyncreset) {
   // CHECK: %localReset = firrtl.wire : !firrtl.asyncreset
   %localReset = firrtl.wire : !firrtl.reset
   firrtl.connect %localReset, %reset : !firrtl.reset, !firrtl.asyncreset
-  // CHECK: %c1_reset = firrtl.instance @MergeNetsChild1 {{.*}} : !firrtl.asyncreset
-  // CHECK: %c2_reset = firrtl.instance @MergeNetsChild2 {{.*}} : !firrtl.asyncreset
-  %c1_reset = firrtl.instance @MergeNetsChild1  {name = "c1"} : !firrtl.reset
-  %c2_reset = firrtl.instance @MergeNetsChild2  {name = "c2"} : !firrtl.reset
+  // CHECK: %c1_reset = firrtl.instance c1 @MergeNetsChild1(in reset: !firrtl.asyncreset)
+  // CHECK: %c2_reset = firrtl.instance c2 @MergeNetsChild2(in reset: !firrtl.asyncreset)
+  %c1_reset = firrtl.instance c1 @MergeNetsChild1(in reset: !firrtl.reset)
+  %c2_reset = firrtl.instance c2 @MergeNetsChild2(in reset: !firrtl.reset)
   firrtl.connect %c1_reset, %localReset : !firrtl.reset, !firrtl.reset
   firrtl.connect %c2_reset, %localReset : !firrtl.reset, !firrtl.reset
 }
@@ -70,8 +70,8 @@ firrtl.module @ModuleBoundariesChild(in %clock: !firrtl.clock, in %childReset: !
 }
 // CHECK-LABEL: firrtl.module @ModuleBoundariesTop
 firrtl.module @ModuleBoundariesTop(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %x: !firrtl.uint<8>, out %z: !firrtl.uint<8>) {
-  // CHECK: {{.*}} = firrtl.instance @ModuleBoundariesChild {{.*}} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
-  %c_clock, %c_childReset, %c_x, %c_z = firrtl.instance @ModuleBoundariesChild {name = "c"} : !firrtl.clock, !firrtl.reset, !firrtl.uint<8>, !firrtl.uint<8>
+  // CHECK: {{.*}} = firrtl.instance c @ModuleBoundariesChild(in clock: !firrtl.clock, in childReset: !firrtl.uint<1>, in x: !firrtl.uint<8>, out z: !firrtl.uint<8>)
+  %c_clock, %c_childReset, %c_x, %c_z = firrtl.instance c @ModuleBoundariesChild(in clock: !firrtl.clock, in childReset: !firrtl.reset, in x: !firrtl.uint<8>, out z: !firrtl.uint<8>)
   firrtl.connect %c_clock, %clock : !firrtl.clock, !firrtl.clock
   firrtl.connect %c_childReset, %reset : !firrtl.reset, !firrtl.uint<1>
   firrtl.connect %c_x, %x : !firrtl.uint<8>, !firrtl.uint<8>
@@ -87,8 +87,8 @@ firrtl.module @MultipleModuleBoundariesChild(in %resetIn: !firrtl.reset, out %re
 }
 // CHECK-LABEL: firrtl.module @MultipleModuleBoundariesTop
 firrtl.module @MultipleModuleBoundariesTop(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %x: !firrtl.uint<8>, out %z: !firrtl.uint<8>) {
-  // CHECK: {{.*}} = firrtl.instance @MultipleModuleBoundariesChild {{.*}} : !firrtl.uint<1>, !firrtl.uint<1>
-  %c_resetIn, %c_resetOut = firrtl.instance @MultipleModuleBoundariesChild  {name = "c"} : !firrtl.reset, !firrtl.reset
+  // CHECK: {{.*}} = firrtl.instance c @MultipleModuleBoundariesChild(in resetIn: !firrtl.uint<1>, out resetOut: !firrtl.uint<1>)
+  %c_resetIn, %c_resetOut = firrtl.instance c @MultipleModuleBoundariesChild(in resetIn: !firrtl.reset, out resetOut: !firrtl.reset)
   firrtl.connect %c_resetIn, %reset : !firrtl.reset, !firrtl.uint<1>
   %c123_ui = firrtl.constant 123 : !firrtl.uint
   // CHECK: %r = firrtl.regreset %clock, %c_resetOut, %c123_ui : !firrtl.uint<1>, !firrtl.uint, !firrtl.uint<8>
@@ -208,16 +208,16 @@ firrtl.module @DedupDifferentlyChild2(in %clock: !firrtl.clock, in %childReset: 
 }
 // CHECK-LABEL: firrtl.module @DedupDifferentlyTop
 firrtl.module @DedupDifferentlyTop(in %clock: !firrtl.clock, in %reset1: !firrtl.uint<1>, in %reset2: !firrtl.asyncreset, in %x: !firrtl.vector<uint<8>, 2>, out %z: !firrtl.vector<uint<8>, 2>) {
-  // CHECK: {{.*}} = firrtl.instance @DedupDifferentlyChild1 {{.*}} : !firrtl.clock, !firrtl.uint<1>
-  %c1_clock, %c1_childReset, %c1_x, %c1_z = firrtl.instance @DedupDifferentlyChild1  {name = "c1"} : !firrtl.clock, !firrtl.reset, !firrtl.uint<8>, !firrtl.uint<8>
+  // CHECK: {{.*}} = firrtl.instance c1 @DedupDifferentlyChild1(in clock: !firrtl.clock, in childReset: !firrtl.uint<1>
+  %c1_clock, %c1_childReset, %c1_x, %c1_z = firrtl.instance c1 @DedupDifferentlyChild1(in clock: !firrtl.clock, in childReset: !firrtl.reset, in x: !firrtl.uint<8>, out z: !firrtl.uint<8>)
   firrtl.connect %c1_clock, %clock : !firrtl.clock, !firrtl.clock
   firrtl.connect %c1_childReset, %reset1 : !firrtl.reset, !firrtl.uint<1>
   %0 = firrtl.subindex %x[0] : !firrtl.vector<uint<8>, 2>
   firrtl.connect %c1_x, %0 : !firrtl.uint<8>, !firrtl.uint<8>
   %1 = firrtl.subindex %z[0] : !firrtl.vector<uint<8>, 2>
   firrtl.connect %1, %c1_z : !firrtl.uint<8>, !firrtl.uint<8>
-  // CHECK: {{.*}} = firrtl.instance @DedupDifferentlyChild2 {{.*}} : !firrtl.clock, !firrtl.asyncreset
-  %c2_clock, %c2_childReset, %c2_x, %c2_z = firrtl.instance @DedupDifferentlyChild2  {name = "c2"} : !firrtl.clock, !firrtl.reset, !firrtl.uint<8>, !firrtl.uint<8>
+  // CHECK: {{.*}} = firrtl.instance c2 @DedupDifferentlyChild2(in clock: !firrtl.clock, in childReset: !firrtl.asyncreset
+  %c2_clock, %c2_childReset, %c2_x, %c2_z = firrtl.instance c2 @DedupDifferentlyChild2(in clock: !firrtl.clock, in childReset: !firrtl.reset, in x: !firrtl.uint<8>, out z: !firrtl.uint<8>)
   firrtl.connect %c2_clock, %clock : !firrtl.clock, !firrtl.clock
   firrtl.connect %c2_childReset, %reset2 : !firrtl.reset, !firrtl.asyncreset
   %2 = firrtl.subindex %x[1] : !firrtl.vector<uint<8>, 2>
@@ -273,8 +273,8 @@ firrtl.module @InternalAndExternalChild(in %i: !firrtl.asyncreset, out %o: !firr
 }
 // CHECK-LABEL: firrtl.module @InternalAndExternalTop
 firrtl.module @InternalAndExternalTop(in %in: !firrtl.asyncreset, out %out: !firrtl.asyncreset) {
-  // CHECK: {{.*}} = firrtl.instance @InternalAndExternalChild {{.*}} : !firrtl.asyncreset, !firrtl.asyncreset
-  %c_i, %c_o = firrtl.instance @InternalAndExternalChild  {name = "c"} : !firrtl.asyncreset, !firrtl.reset
+  // CHECK: {{.*}} = firrtl.instance c @InternalAndExternalChild(in i: !firrtl.asyncreset, out o: !firrtl.asyncreset)
+  %c_i, %c_o = firrtl.instance c @InternalAndExternalChild(in i: !firrtl.asyncreset, out o: !firrtl.reset)
   firrtl.connect %c_i, %in : !firrtl.asyncreset, !firrtl.asyncreset
   firrtl.connect %out, %c_o : !firrtl.asyncreset, !firrtl.reset
 }
@@ -322,9 +322,9 @@ firrtl.module @InvalidValueShouldNotConnect(
 // CHECK-SAME: in reset: !firrtl.uint<1>
 firrtl.extmodule @ShouldAdjustExtModule1(in reset: !firrtl.reset)
 // CHECK-LABEL: firrtl.module @ShouldAdjustExtModule2
-// CHECK: %x_reset = firrtl.instance @ShouldAdjustExtModule1 {name = "x"} : !firrtl.uint<1>
+// CHECK: %x_reset = firrtl.instance x @ShouldAdjustExtModule1(in reset: !firrtl.uint<1>)
 firrtl.module @ShouldAdjustExtModule2() {
-  %x_reset = firrtl.instance @ShouldAdjustExtModule1 {name = "x"} : !firrtl.reset
+  %x_reset = firrtl.instance x @ShouldAdjustExtModule1(in reset: !firrtl.reset)
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   firrtl.connect %x_reset, %c1_ui1 : !firrtl.reset, !firrtl.uint<1>
 }
@@ -488,15 +488,15 @@ firrtl.circuit "ReusePorts" {
   // CHECK-LABEL: firrtl.module @ReusePorts
   firrtl.module @ReusePorts(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset) attributes {
     portAnnotations = [[],[{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]]} {
-    // CHECK: %child_clock, %child_reset = firrtl.instance @Child
+    // CHECK: %child_clock, %child_reset = firrtl.instance child
     // CHECK: firrtl.connect %child_reset, %reset
-    // CHECK: %badName_reset, %badName_clock, %badName_existingReset = firrtl.instance @BadName
+    // CHECK: %badName_reset, %badName_clock, %badName_existingReset = firrtl.instance badName
     // CHECK: firrtl.connect %badName_reset, %reset
-    // CHECK: %badType_reset_0, %badType_clock, %badType_reset = firrtl.instance @BadType
+    // CHECK: %badType_reset_0, %badType_clock, %badType_reset = firrtl.instance badType
     // CHECK: firrtl.connect %badType_reset_0, %reset
-    %child_clock, %child_reset = firrtl.instance @Child {name = "child"} : !firrtl.clock, !firrtl.asyncreset
-    %badName_clock, %badName_existingReset = firrtl.instance @BadName {name = "badName"} : !firrtl.clock, !firrtl.asyncreset
-    %badType_clock, %badType_reset = firrtl.instance @BadType {name = "badType"} : !firrtl.clock, !firrtl.uint<1>
+    %child_clock, %child_reset = firrtl.instance child @Child(in clock: !firrtl.clock, in reset: !firrtl.asyncreset)
+    %badName_clock, %badName_existingReset = firrtl.instance badName @BadName(in clock: !firrtl.clock, in existingReset: !firrtl.asyncreset)
+    %badType_clock, %badType_reset = firrtl.instance badType @BadType(in clock: !firrtl.clock, in reset: !firrtl.uint<1>)
   }
 }
 
@@ -513,7 +513,7 @@ firrtl.circuit "FullAsyncNested" {
   }
   // CHECK-LABEL: firrtl.module @FullAsyncNestedChild
   firrtl.module @FullAsyncNestedChild(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %io_in: !firrtl.uint<8>, out %io_out: !firrtl.uint<8>) {
-    %inst_clock, %inst_reset, %inst_io_in, %inst_io_out = firrtl.instance @FullAsyncNestedDeeper  {name = "inst"} : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
+    %inst_clock, %inst_reset, %inst_io_in, %inst_io_out = firrtl.instance inst @FullAsyncNestedDeeper(in clock: !firrtl.clock, in reset: !firrtl.asyncreset, in io_in: !firrtl.uint<8>, out io_out: !firrtl.uint<8>)
     firrtl.connect %inst_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %inst_reset, %reset : !firrtl.asyncreset, !firrtl.asyncreset
     firrtl.connect %inst_io_in, %io_in : !firrtl.uint<8>, !firrtl.uint<8>
@@ -527,7 +527,7 @@ firrtl.circuit "FullAsyncNested" {
   // CHECK-LABEL: firrtl.module @FullAsyncNested
   firrtl.module @FullAsyncNested(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %io_in: !firrtl.uint<8>, out %io_out: !firrtl.uint<8>) attributes {
     portAnnotations=[[],[{class = "firrtl.transforms.DontTouchAnnotation"}, {class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}], [], []] } {
-    %inst_clock, %inst_reset, %inst_io_in, %inst_io_out = firrtl.instance @FullAsyncNestedChild  {name = "inst"} : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
+    %inst_clock, %inst_reset, %inst_io_in, %inst_io_out = firrtl.instance inst @FullAsyncNestedChild(in clock: !firrtl.clock, in reset: !firrtl.asyncreset, in io_in: !firrtl.uint<8>, out io_out: !firrtl.uint<8>)
     firrtl.connect %inst_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %inst_reset, %reset : !firrtl.asyncreset, !firrtl.asyncreset
     firrtl.connect %io_out, %inst_io_out : !firrtl.uint<8>, !firrtl.uint<8>
@@ -551,8 +551,8 @@ firrtl.circuit "FullAsyncExcluded" {
   // CHECK-LABEL: firrtl.module @FullAsyncExcluded
   firrtl.module @FullAsyncExcluded(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %io_in: !firrtl.uint<8>, out %io_out: !firrtl.uint<8>, in %extraReset: !firrtl.asyncreset) attributes {
      portAnnotations = [[],[],[],[],[{class = "firrtl.transforms.DontTouchAnnotation"}, {class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]]} {
-    // CHECK: %inst_clock, %inst_reset, %inst_io_in, %inst_io_out = firrtl.instance @FullAsyncExcludedChild
-    %inst_clock, %inst_reset, %inst_io_in, %inst_io_out = firrtl.instance @FullAsyncExcludedChild  {name = "inst"} : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
+    // CHECK: %inst_clock, %inst_reset, %inst_io_in, %inst_io_out = firrtl.instance inst @FullAsyncExcludedChild
+    %inst_clock, %inst_reset, %inst_io_in, %inst_io_out = firrtl.instance inst @FullAsyncExcludedChild(in clock: !firrtl.clock, in reset: !firrtl.asyncreset, in io_in: !firrtl.uint<8>, out io_out: !firrtl.uint<8>)
     firrtl.connect %inst_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %inst_reset, %reset : !firrtl.asyncreset, !firrtl.asyncreset
     firrtl.connect %io_out, %inst_io_out : !firrtl.uint<8>, !firrtl.uint<8>

--- a/test/Dialect/FIRRTL/infer-widths-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-widths-errors.mlir
@@ -22,7 +22,7 @@ firrtl.circuit "Foo" {
   firrtl.module @Foo(in %in: !firrtl.uint<42>, out %out: !firrtl.uint) {
     // expected-error @+2 {{extern module `Bar` has ports of uninferred width}}
     // expected-note @+1 {{Only non-extern FIRRTL modules may contain unspecified widths to be inferred automatically.}}
-    %inst_in, %inst_out = firrtl.instance @Bar {name = "inst"} : !firrtl.uint, !firrtl.uint
+    %inst_in, %inst_out = firrtl.instance inst @Bar(in in: !firrtl.uint, out out: !firrtl.uint)
     firrtl.connect %inst_in, %in : !firrtl.uint, !firrtl.uint<42>
     firrtl.connect %out, %inst_out : !firrtl.uint, !firrtl.uint
   }

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -532,7 +532,7 @@ firrtl.circuit "Foo" {
     firrtl.connect %out, %0 : !firrtl.uint, !firrtl.uint
   }
   firrtl.module @InterModuleSimpleBar(in %in: !firrtl.uint<42>, out %out: !firrtl.uint) {
-    %inst_in, %inst_out = firrtl.instance @InterModuleSimpleFoo {name = "inst"} : !firrtl.uint, !firrtl.uint
+    %inst_in, %inst_out = firrtl.instance inst @InterModuleSimpleFoo(in in: !firrtl.uint, out out: !firrtl.uint)
     %0 = firrtl.add %inst_out, %inst_out : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
     firrtl.connect %inst_in, %in : !firrtl.uint, !firrtl.uint<42>
     firrtl.connect %out, %0 : !firrtl.uint, !firrtl.uint
@@ -551,8 +551,8 @@ firrtl.circuit "Foo" {
     firrtl.connect %out, %0 : !firrtl.uint, !firrtl.uint
   }
   firrtl.module @InterModuleMultipleBar(in %in1: !firrtl.uint<17>, in %in2: !firrtl.uint<42>, out %out: !firrtl.uint) {
-    %inst1_in, %inst1_out = firrtl.instance @InterModuleMultipleFoo {name = "inst1"} : !firrtl.uint, !firrtl.uint
-    %inst2_in, %inst2_out = firrtl.instance @InterModuleMultipleFoo {name = "inst2"} : !firrtl.uint, !firrtl.uint
+    %inst1_in, %inst1_out = firrtl.instance inst1 @InterModuleMultipleFoo(in in: !firrtl.uint, out out: !firrtl.uint)
+    %inst2_in, %inst2_out = firrtl.instance inst2 @InterModuleMultipleFoo(in in: !firrtl.uint, out out: !firrtl.uint)
     %0 = firrtl.xor %inst1_out, %inst2_out : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
     firrtl.connect %inst1_in, %in1 : !firrtl.uint, !firrtl.uint<17>
     firrtl.connect %inst2_in, %in2 : !firrtl.uint, !firrtl.uint<42>
@@ -920,7 +920,7 @@ firrtl.circuit "Foo" {
   // CHECK-LABEL: @InterModuleGoodCycleBar
   // CHECK-SAME: out %out: !firrtl.uint<39>
   firrtl.module @InterModuleGoodCycleBar(in %in: !firrtl.uint<42>, out %out: !firrtl.uint) {
-    %inst_in, %inst_out = firrtl.instance @InterModuleGoodCycleFoo {name = "inst"} : !firrtl.uint, !firrtl.uint
+    %inst_in, %inst_out = firrtl.instance inst  @InterModuleGoodCycleFoo(in in: !firrtl.uint, out out: !firrtl.uint)
     firrtl.connect %inst_in, %in : !firrtl.uint, !firrtl.uint<42>
     firrtl.connect %inst_in, %inst_out : !firrtl.uint, !firrtl.uint
     firrtl.connect %out, %inst_out : !firrtl.uint, !firrtl.uint

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -12,8 +12,8 @@ firrtl.circuit "main_extmodule" {
 // Test that unused modules are deleted.
 firrtl.circuit "delete_dead_modules" {
 firrtl.module @delete_dead_modules () {
-  firrtl.instance @used {name = "used"}
-  firrtl.instance @used_ext {name = "used"}
+  firrtl.instance used @used()
+  firrtl.instance used @used_ext()
 }
 firrtl.module @unused () { }
 firrtl.module @used () { }
@@ -22,8 +22,8 @@ firrtl.extmodule @used_ext ()
 }
 // CHECK-LABEL: firrtl.circuit "delete_dead_modules" {
 // CHECK-NEXT:   firrtl.module @delete_dead_modules() {
-// CHECK-NEXT:     firrtl.instance @used  {name = "used"}
-// CHECK-NEXT:     firrtl.instance @used_ext  {name = "used"}
+// CHECK-NEXT:     firrtl.instance used @used()
+// CHECK-NEXT:     firrtl.instance used @used_ext
 // CHECK-NEXT:   }
 // CHECK-NEXT:   firrtl.module @used() {
 // CHECK-NEXT:   }
@@ -34,12 +34,12 @@ firrtl.extmodule @used_ext ()
 // Test basic inlining
 firrtl.circuit "inlining" {
 firrtl.module @inlining() {
-  firrtl.instance @test1 {name = "test1"}
+  firrtl.instance test1 @test1()
 }
 firrtl.module @test1()
   attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
   %test_wire = firrtl.wire : !firrtl.uint<2>
-  firrtl.instance @test2 {name = "test2"}
+  firrtl.instance test2 @test2()
 }
 firrtl.module @test2()
   attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
@@ -58,11 +58,11 @@ firrtl.module @test2()
 firrtl.circuit "flattening" {
 firrtl.module @flattening()
   attributes {annotations = [{class = "firrtl.transforms.FlattenAnnotation"}]} {
-  firrtl.instance @test1 {name = "test1"}
+  firrtl.instance test1 @test1()
 }
 firrtl.module @test1() {
   %test_wire = firrtl.wire : !firrtl.uint<2>
-  firrtl.instance @test2 {name = "test2"}
+  firrtl.instance test2 @test2()
 }
 firrtl.module @test2() {
   %test_wire = firrtl.wire : !firrtl.uint<2>
@@ -79,21 +79,21 @@ firrtl.module @test2() {
 // Test that inlining and flattening compose well.
 firrtl.circuit "compose" {
 firrtl.module @compose() {
-  firrtl.instance @test1 {name = "test1"}
-  firrtl.instance @test2 {name = "test2"}
-  firrtl.instance @test3 {name = "test3"}
+  firrtl.instance test1 @test1()
+  firrtl.instance test2 @test2()
+  firrtl.instance test3 @test3()
 }
 firrtl.module @test1() attributes {annotations =
         [{class = "firrtl.transforms.FlattenAnnotation"},
          {class = "firrtl.passes.InlineAnnotation"}]} {
   %test_wire = firrtl.wire : !firrtl.uint<2>
-  firrtl.instance @test2 {name = "test2"}
-  firrtl.instance @test3 {name = "test3"}
+  firrtl.instance test2 @test2()
+  firrtl.instance test3 @test3()
 }
 firrtl.module @test2() attributes {annotations =
         [{class = "firrtl.passes.InlineAnnotation"}]} {
   %test_wire = firrtl.wire : !firrtl.uint<2>
-  firrtl.instance @test3 {name = "test3"}
+  firrtl.instance test3 @test3()
 }
 firrtl.module @test3() {
   %test_wire = firrtl.wire : !firrtl.uint<2>
@@ -106,8 +106,8 @@ firrtl.module @test3() {
 // CHECK-NEXT:     %test1_test2_test3_test_wire = firrtl.wire  : !firrtl.uint<2>
 // CHECK-NEXT:     %test1_test3_test_wire = firrtl.wire  : !firrtl.uint<2>
 // CHECK-NEXT:     %test2_test_wire = firrtl.wire  : !firrtl.uint<2>
-// CHECK-NEXT:     firrtl.instance @test3  {name = "test2_test3"}
-// CHECK-NEXT:     firrtl.instance @test3  {name = "test3"}
+// CHECK-NEXT:     firrtl.instance test2_test3 @test3()
+// CHECK-NEXT:     firrtl.instance test3 @test3()
 // CHECK-NEXT:   }
 // CHECK-NEXT:   firrtl.module @test3() {
 // CHECK-NEXT:     %test_wire = firrtl.wire  : !firrtl.uint<2>
@@ -127,19 +127,17 @@ firrtl.module @InlineMe0(in %in0: !firrtl.uint<4>, in %in1: !firrtl.uint<4>,
   firrtl.connect %out1, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 }
 firrtl.module @InlineMe1(in %in0: !firrtl.uint<4>, in %in1: !firrtl.uint<4>,
-                   out %out0: !firrtl.uint<4>,
-                   out %out1: !firrtl.uint<4>)
+                   out %out0: !firrtl.uint<4>, out %out1: !firrtl.uint<4>)
         attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
-  %a_in0, %a_in1, %a_out0, %a_out1 = firrtl.instance @InlineMe0 {name = "a"} : !firrtl.uint<4>, !firrtl.uint<4>, !firrtl.uint<4>, !firrtl.uint<4>
+  %a_in0, %a_in1, %a_out0, %a_out1 = firrtl.instance a @InlineMe0(in in0: !firrtl.uint<4>, in in1: !firrtl.uint<4>, out out0: !firrtl.uint<4>, out out1: !firrtl.uint<4>)
   firrtl.connect %a_in0, %in0 : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %a_in1, %in1 : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out0, %a_out0 : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out1, %a_out1 : !firrtl.uint<4>, !firrtl.uint<4>
 }
 firrtl.module @TestConnections(in %in0: !firrtl.uint<4>, in %in1: !firrtl.uint<4>,
-                   out %out0: !firrtl.uint<4>,
-                   out %out1: !firrtl.uint<4>) {
-  %b_in0, %b_in1, %b_out0, %b_out1 = firrtl.instance @InlineMe1 {name = "b"} : !firrtl.uint<4>, !firrtl.uint<4>, !firrtl.uint<4>, !firrtl.uint<4>
+                   out %out0: !firrtl.uint<4>, out %out1: !firrtl.uint<4>) {
+  %b_in0, %b_in1, %b_out0, %b_out1 = firrtl.instance b @InlineMe1(in in0: !firrtl.uint<4>, in in1: !firrtl.uint<4>, out out0: !firrtl.uint<4>, out out1: !firrtl.uint<4>)
   firrtl.connect %b_in0, %in0 : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %b_in1, %in1 : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out0, %b_out0 : !firrtl.uint<4>, !firrtl.uint<4>
@@ -179,7 +177,7 @@ firrtl.module @InlineMe0(in %in0: !firrtl.bundle<a: uint<4>, b flip: uint<4>>,
 }
 firrtl.module @TestBulkConnections(in %in0: !firrtl.bundle<a: uint<4>, b flip: uint<4>>,
                                    out %out0: !firrtl.bundle<a: uint<4>, b flip: uint<4>>) {
-  %i_in0, %i_out0 = firrtl.instance @InlineMe0 {name = "i"} : !firrtl.bundle<a: uint<4>, b flip: uint<4>>, !firrtl.bundle<a: uint<4>, b flip: uint<4>>
+  %i_in0, %i_out0 = firrtl.instance i @InlineMe0(in in0: !firrtl.bundle<a: uint<4>, b flip: uint<4>>, out out0: !firrtl.bundle<a: uint<4>, b flip: uint<4>>)
   firrtl.connect %i_in0, %in0 : !firrtl.bundle<a: uint<4>, b flip: uint<4>>, !firrtl.bundle<a: uint<4>, b flip: uint<4>>
   firrtl.connect %out0, %i_out0 : !firrtl.bundle<a: uint<4>, b flip: uint<4>>, !firrtl.bundle<a: uint<4>, b flip: uint<4>>
 // CHECK: %i_in0 = firrtl.wire  : !firrtl.bundle<a: uint<4>, b flip: uint<4>>
@@ -193,7 +191,7 @@ firrtl.module @TestBulkConnections(in %in0: !firrtl.bundle<a: uint<4>, b flip: u
 // Test that all operations with names are renamed.
 firrtl.circuit "renaming" {
 firrtl.module @renaming() {
-  %0, %1, %2 = firrtl.instance @declarations {name = "myinst"} : !firrtl.clock, !firrtl.uint<8>, !firrtl.asyncreset
+  %0, %1, %2 = firrtl.instance myinst @declarations(in clock : !firrtl.clock, in u8 : !firrtl.uint<8>, in reset : !firrtl.asyncreset)
 }
 firrtl.module @declarations(in %clock : !firrtl.clock, in %u8 : !firrtl.uint<8>, in %reset : !firrtl.asyncreset) attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
   %c0_ui8 = firrtl.constant 0 : !firrtl.uint<8>

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -42,9 +42,10 @@ firrtl.circuit "TopLevel" {
                           out %sink: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) {
 
     // CHECK-NEXT: %inst_source_valid, %inst_source_ready, %inst_source_data, %inst_sink_valid, %inst_sink_ready, %inst_sink_data
-    // CHECK-SAME: = firrtl.instance @Simple {name = ""} :
-    // CHECK-SAME: !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<64>
-    %sourceV, %sinkV = firrtl.instance @Simple {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+    // CHECK-SAME: = firrtl.instance "" @Simple(
+    // CHECK-SAME: in source_valid: !firrtl.uint<1>, out source_ready: !firrtl.uint<1>, in source_data: !firrtl.uint<64>, out sink_valid: !firrtl.uint<1>, in sink_ready: !firrtl.uint<1>, out sink_data: !firrtl.uint<64>
+    %sourceV, %sinkV = firrtl.instance "" @Simple(in source: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>,
+                        out sink: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>)
 
     // CHECK-NEXT: firrtl.connect %inst_source_valid, %source_valid
     // CHECK-NEXT: firrtl.connect %source_ready, %inst_source_ready
@@ -356,7 +357,7 @@ firrtl.circuit "TopLevel" {
     firrtl.module @mod_2(in %clock: !firrtl.clock, in %inp_a: !firrtl.bundle<inp_d: uint<14>>) {
     }
     firrtl.module @top_mod(in %clock: !firrtl.clock) {
-      %U0_clock, %U0_inp_a = firrtl.instance @mod_2 {name = "U0"} : !firrtl.clock, !firrtl.bundle<inp_d: uint<14>>
+      %U0_clock, %U0_inp_a = firrtl.instance U0 @mod_2(in clock: !firrtl.clock, in inp_a: !firrtl.bundle<inp_d: uint<14>>)
       %0 = firrtl.invalidvalue : !firrtl.clock
       firrtl.connect %U0_clock, %0 : !firrtl.clock, !firrtl.clock
       %1 = firrtl.invalidvalue : !firrtl.bundle<inp_d: uint<14>>
@@ -367,7 +368,7 @@ firrtl.circuit "TopLevel" {
 
 //CHECK-LABEL:     firrtl.module @mod_2(in %clock: !firrtl.clock, in %inp_a_inp_d: !firrtl.uint<14>)
 //CHECK:    firrtl.module @top_mod(in %clock: !firrtl.clock)
-//CHECK-NEXT:      %U0_clock, %U0_inp_a_inp_d = firrtl.instance @mod_2 {name = "U0"} : !firrtl.clock, !firrtl.uint<14>
+//CHECK-NEXT:      %U0_clock, %U0_inp_a_inp_d = firrtl.instance U0 @mod_2(in clock: !firrtl.clock, in inp_a_inp_d: !firrtl.uint<14>)
 //CHECK-NEXT:      %invalid_clock = firrtl.invalidvalue : !firrtl.clock
 //CHECK-NEXT:      firrtl.connect %U0_clock, %invalid_clock : !firrtl.clock, !firrtl.clock
 //CHECK-NEXT:      %invalid_ui14 = firrtl.invalidvalue : !firrtl.uint<14>
@@ -484,10 +485,10 @@ firrtl.circuit "TopLevel" {
   }
 
   // CHECK-LABEL: firrtl.extmodule @ExternalModule(in source_valid: !firrtl.uint<1>, out source_ready: !firrtl.uint<1>, in source_data: !firrtl.uint<64>)
-  firrtl.extmodule @ExternalModule(in source: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>> )
+  firrtl.extmodule @ExternalModule(in source: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>)
   firrtl.module @Test() {
-    // CHECK:  %inst_source_valid, %inst_source_ready, %inst_source_data = firrtl.instance @ExternalModule  {name = ""} : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<64>
-    %inst_source = firrtl.instance @ExternalModule {name = ""} : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+    // CHECK: %inst_source_valid, %inst_source_ready, %inst_source_data = firrtl.instance "" @ExternalModule(in source_valid: !firrtl.uint<1>, out source_ready: !firrtl.uint<1>, in source_data: !firrtl.uint<64>)
+    %inst_source = firrtl.instance "" @ExternalModule(in source: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>)
   }
 
 // Test RegResetOp lowering
@@ -562,7 +563,7 @@ firrtl.circuit "TopLevel" {
     firrtl.connect %a, %0 : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
   }
   firrtl.module @AnnotationsInstanceOp() {
-    %bar_a = firrtl.instance @Bar  {annotations = [{a = "a"}], name = "bar"} : !firrtl.vector<uint<1>, 2>
+    %bar_a = firrtl.instance bar {annotations = [{a = "a"}]} @Bar(out a: !firrtl.vector<uint<1>, 2>)
   }
   // CHECK: firrtl.instance
   // CHECK-SAME: annotations = [{a = "a"}]
@@ -880,7 +881,7 @@ firrtl.circuit "TopLevel" {
   firrtl.module @PartialConnectLHSFlip(in %a: !firrtl.bundle<b: bundle<c flip: uint<2>>>) { }
    // CHECK-LABEL: firrtl.module @FooFlipType
   firrtl.module @FooFlipType(in %a: !firrtl.bundle<b: bundle<c flip: uint<2>>>) {
-    %mgmt_a = firrtl.instance @PartialConnectLHSFlip  {name = "mgmt"} : !firrtl.bundle<b: bundle<c flip: uint<2>>>
+    %mgmt_a = firrtl.instance mgmt @PartialConnectLHSFlip(in a: !firrtl.bundle<b: bundle<c flip: uint<2>>>)
     %0 = firrtl.subfield %mgmt_a(0) : (!firrtl.bundle<b: bundle<c flip: uint<2>>>) -> !firrtl.bundle<c flip: uint<2>>
     %1 = firrtl.subfield %0(0) : (!firrtl.bundle<c flip: uint<2>>) -> !firrtl.uint<2>
     // CHECK: firrtl.connect %a_b_c, %mgmt_a_b_c : !firrtl.uint<2>, !firrtl.uint<2>
@@ -927,7 +928,7 @@ firrtl.circuit "TopLevel" {
   // CHECK-COUNT-2: [{b}]
   // CHECK-NOT: [{a}]
   firrtl.module @Port(in %a: !firrtl.vector<uint<1>, 2> [{b}]) {
-    %sub_a = firrtl.instance @Sub1  {name = "sub", portNames = ["a"]} : !firrtl.vector<uint<1>, 2>
+    %sub_a = firrtl.instance sub @Sub1(in a: !firrtl.vector<uint<1>, 2>)
     firrtl.connect %sub_a, %a : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
   }
 
@@ -949,8 +950,8 @@ firrtl.circuit "TopLevel" {
   firrtl.module @TruncatingConnectWithFlip() {
     // CHECK: %[[a_b:.+]] = firrtl.wire
     %a = firrtl.wire  : !firrtl.bundle<b: uint<1>>
-    // CHECK-NEXT: %bar_a = firrtl.instance @Bar
-    %bar_a = firrtl.instance @Bar2  {name = "bar"} : !firrtl.uint<2>
+    // CHECK-NEXT: %bar_a = firrtl.instance bar @Bar
+    %bar_a = firrtl.instance bar @Bar2(in a: !firrtl.uint<2>)
     // CHECK-NEXT: %invalid_ui2 = firrtl.invalidvalue
     %invalid_ui2 = firrtl.invalidvalue : !firrtl.uint<2>
     // CHECK-NEXT: firrtl.connect %bar_a, %invalid_ui2
@@ -1152,8 +1153,8 @@ firrtl.circuit "TopLevel" {
   }
   // CHECK-LABEL firrtl.module @Foo3
   firrtl.module @Foo3() {
-    // CHECK: [{one}], [{two}], []
-    %bar_a, %bar_b = firrtl.instance @Bar3  {name = "bar", portAnnotations = [[{one}], [#firrtl.subAnno<fieldID = 1, {two}>]]} : !firrtl.uint<1>, !firrtl.bundle<baz: uint<1>, qux: uint<1>>
+    // CHECK: in a: !firrtl.uint<1> [{one}], out b_baz: !firrtl.uint<1> [{two}], out b_qux: !firrtl.uint<1>
+    %bar_a, %bar_b = firrtl.instance bar @Bar3(in a: !firrtl.uint<1> [{one}], out b: !firrtl.bundle<baz: uint<1>, qux: uint<1>> [#firrtl.subAnno<fieldID = 1, {two}>])
   }
 
 
@@ -1233,7 +1234,7 @@ firrtl.module @bofa(out %auto: !firrtl.bundle<io_out: bundle<foo: bundle<bar: an
 firrtl.extmodule @is1436_BAR(out io: !firrtl.bundle<llWakeup flip: vector<uint<1>, 1>>)
 // CHECK-LABEL: firrtl.module @is1436_FOO
 firrtl.module @is1436_FOO() {
-  %thing_io = firrtl.instance @is1436_BAR  {name = "thing"} : !firrtl.bundle<llWakeup flip: vector<uint<1>, 1>>
+  %thing_io = firrtl.instance thing @is1436_BAR(out io: !firrtl.bundle<llWakeup flip: vector<uint<1>, 1>>)
   %0 = firrtl.subfield %thing_io(0) : (!firrtl.bundle<llWakeup flip: vector<uint<1>, 1>>) -> !firrtl.vector<uint<1>, 1>
   %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
   %1 = firrtl.subaccess %0[%c0_ui2] : !firrtl.vector<uint<1>, 1>, !firrtl.uint<2>

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -308,23 +308,19 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     reg _t_2622 : UInt<4>, clock with :
       reset => (UInt<1>("h0"), _t_2622)
 
-    ; CHECK: %xyz_in = firrtl.instance @circuit {name = "xyz"} : !firrtl.uint<80>
+    ; CHECK: %xyz_in = firrtl.instance xyz @circuit(in in: !firrtl.uint<80>)
     inst xyz of circuit
     ; CHECK: firrtl.connect %xyz_in, %i8 : !firrtl.uint<80>, !firrtl.uint<8>
     xyz.in <= i8
 
-    ; CHECK: %myext_in, %myext_out = firrtl.instance @MyExtModule
-    ; CHECK: {name = "myext"} :
-    ; CHECK: !firrtl.uint, !firrtl.uint<8>
+    ; CHECK: %myext_in, %myext_out = firrtl.instance myext @MyExtModule(in in: !firrtl.uint, out out: !firrtl.uint<8>)
     inst myext of MyExtModule
     myext.in <= i8
     printf(clock, reset, "Something interesting! %x", myext.out)
 
     ; CHECK: firrtl.when %reset  {
     when reset :
-      ; CHECK: %reset_myext_in, %reset_myext_out = firrtl.instance @MyExtModule
-      ; CHECK: {name = "reset_myext"} :
-      ; CHECK: !firrtl.uint, !firrtl.uint<8>
+      ; CHECK: %reset_myext_in, %reset_myext_out = firrtl.instance reset_myext @MyExtModule(in in: !firrtl.uint, out out: !firrtl.uint<8>)
       inst reset_myext of MyExtModule
       reset_myext.in <= i8
     ; CHECK: }
@@ -438,7 +434,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
   ; CHECK-LABEL: firrtl.module @expr_stmt_ambiguity2(
   module expr_stmt_ambiguity2 :
-    ; CHECK: firrtl.instance @circuit
+    ; CHECK: firrtl.instance write @circuit
     inst write of circuit
     ; CHECK: firrtl.connect %write_in
     write.in <= UInt(1)
@@ -732,7 +728,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     wire2 is invalid
 
     ; https://github.com/llvm/circt/issues/563
-    ; CHECK: %U0_in0, %U0_in1, %U0_out0, %U0_out1 = firrtl.instance @mod_0_563
+    ; CHECK: %U0_in0, %U0_in1, %U0_out0, %U0_out1 = firrtl.instance U0 @mod_0_563
     inst U0 of mod_0_563
 
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue

--- a/test/Dialect/FIRRTL/prefix-modules.mlir
+++ b/test/Dialect/FIRRTL/prefix-modules.mlir
@@ -38,7 +38,7 @@ firrtl.circuit "Top" {
       prefix = "T_",
       inclusive = false
     }]} {
-    firrtl.instance @Zebra { name = "test" }
+    firrtl.instance test @Zebra()
   }
 
   // CHECK: firrtl.module @T_Zebra
@@ -76,7 +76,7 @@ firrtl.circuit "Top" {
       inclusive = true
     }]} {
 
-    firrtl.instance @ExternalModule {name = "ext"}
+    firrtl.instance ext @ExternalModule()
   }
 }
 
@@ -89,7 +89,7 @@ firrtl.circuit "Top0" {
       prefix = "T_",
       inclusive = false
     }]} {
-    firrtl.instance @Zebra { name = "test" }
+    firrtl.instance test @Zebra()
   }
 
   firrtl.module @Top1()
@@ -98,7 +98,7 @@ firrtl.circuit "Top0" {
       prefix = "T_",
       inclusive = false
     }]} {
-    firrtl.instance @Zebra { name = "test" }
+    firrtl.instance test @Zebra()
   }
 
   // CHECK: firrtl.module @T_Zebra
@@ -119,11 +119,11 @@ firrtl.circuit "Top" {
       inclusive = true
     }]} {
 
-    // CHECK: firrtl.instance @T_Aardvark
-    firrtl.instance @Aardvark { name = "test" }
+    // CHECK: firrtl.instance test @T_Aardvark()
+    firrtl.instance test @Aardvark()
 
-    // CHECK: firrtl.instance @T_Z_Zebra
-    firrtl.instance @Zebra { name = "test" }
+    // CHECK: firrtl.instance test @T_Z_Zebra()
+    firrtl.instance test @Zebra()
   }
 
   // CHECK: firrtl.module @T_Aardvark
@@ -134,8 +134,8 @@ firrtl.circuit "Top" {
       inclusive = false
     }]} {
 
-    // CHECK: firrtl.instance @T_A_Z_Zebra
-    firrtl.instance @Zebra { name = "test" }
+    // CHECK: firrtl.instance test @T_A_Z_Zebra()
+    firrtl.instance test @Zebra()
   }
 
   // CHECK: firrtl.module @T_Z_Zebra

--- a/test/Dialect/FIRRTL/print-instance-graph.mlir
+++ b/test/Dialect/FIRRTL/print-instance-graph.mlir
@@ -14,16 +14,16 @@
 firrtl.circuit "Top" {
 
 firrtl.module @Top() {
-  firrtl.instance @Alligator {name = "alligator" }
-  firrtl.instance @Cat {name = "cat"}
+  firrtl.instance alligator @Alligator()
+  firrtl.instance cat @Cat()
 }
 
 firrtl.module @Alligator() {
-  firrtl.instance @Bear {name = "bear"}
+  firrtl.instance bear @Bear()
 }
 
 firrtl.module @Bear() {
-  firrtl.instance @Cat {name = "cat" }
+  firrtl.instance cat @Cat()
 }
 
 firrtl.module @Cat() { }

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -143,10 +143,10 @@ firrtl.module @VerbatimExpr() {
 }
 
 // CHECK-LABL: @LowerToBind
-// CHECK: firrtl.instance @InstanceLowerToBind {lowerToBind = true, name = "foo"}
+// CHECK: firrtl.instance foo {lowerToBind = true} @InstanceLowerToBind()
 firrtl.module @InstanceLowerToBind() {}
 firrtl.module @LowerToBind() {
-  firrtl.instance @InstanceLowerToBind {lowerToBind = true, name = "foo"}
+  firrtl.instance foo {lowerToBind = true} @InstanceLowerToBind()
 }
 
 firrtl.nla @NLA1 [] []

--- a/test/circt-reduce/trivial.mlir
+++ b/test/circt-reduce/trivial.mlir
@@ -11,8 +11,8 @@ firrtl.circuit "Foo" {
   }
   // CHECK: firrtl.module @FooFoo
   firrtl.module @FooFoo(in %x: !firrtl.uint<1>, out %y: !firrtl.uint<1>) {
-    %x0_x, %x0_y = firrtl.instance @FooFooFoo {name = "x0"} : !firrtl.uint<1>, !firrtl.uint<1>
-    %x1_x, %x1_y = firrtl.instance @FooFooBar {name = "x1"} : !firrtl.uint<1>, !firrtl.uint<1>
+    %x0_x, %x0_y = firrtl.instance x0 @FooFooFoo(in x: !firrtl.uint<1>, out y: !firrtl.uint<1>)
+    %x1_x, %x1_y = firrtl.instance x1 @FooFooBar(in x: !firrtl.uint<1>, out y: !firrtl.uint<1>)
     firrtl.connect %x0_x, %x : !firrtl.uint<1>, !firrtl.uint<1>
     // Skip %x1_x to trigger a "sink not fully initialized" warning
     firrtl.connect %y, %x0_y : !firrtl.uint<1>, !firrtl.uint<1>
@@ -23,8 +23,8 @@ firrtl.circuit "Foo" {
   }
   // CHECK: firrtl.extmodule @Foo
   firrtl.module @Foo(in %x: !firrtl.uint<1>, out %y: !firrtl.uint<1>) {
-    %x0_x, %x0_y = firrtl.instance @FooFoo {name = "x0"} : !firrtl.uint<1>, !firrtl.uint<1>
-    %x1_x, %x1_y = firrtl.instance @FooBar {name = "x1"} : !firrtl.uint<1>, !firrtl.uint<1>
+    %x0_x, %x0_y = firrtl.instance x0 @FooFoo(in x: !firrtl.uint<1>, out y: !firrtl.uint<1>)
+    %x1_x, %x1_y = firrtl.instance x1 @FooBar(in x: !firrtl.uint<1>, out y: !firrtl.uint<1>)
     firrtl.connect %x0_x, %x : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %x1_x, %x : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %y, %x0_y : !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/firtool/blackbox.mlir
+++ b/test/firtool/blackbox.mlir
@@ -27,9 +27,9 @@ firrtl.circuit "test_mod" attributes {annotations = [
   // VERILOG-TOP-NEXT:    ExtPath gib
   // VERILOG-TOP-NEXT:  endmodule
   firrtl.module @test_mod() {
-    firrtl.instance @ExtInline {name = "foo", portNames = []}
-    firrtl.instance @ExtResource {name = "bar", portNames = []}
-    firrtl.instance @ExtPath {name = "gib", portNames = []}
+    firrtl.instance foo @ExtInline()
+    firrtl.instance bar @ExtResource()
+    firrtl.instance gib @ExtPath()
   }
 
   // VERILOG-FOO-LABEL: module ExtInline(); endmodule

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -56,24 +56,24 @@ circuit test_mod : %[[{"a": "a"}]]
     c <= flipFlop.a_q
 
 ; MLIR-LABEL: firrtl.module @test_mod(in %clock: !firrtl.clock, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<2>, out %c: !firrtl.uint<1>) {
-; MLIR-NEXT:    %cat_a, %cat_b, %cat_c, %cat_d = firrtl.instance @Cat  {name = "cat"} : !firrtl.uint<2>, !firrtl.uint<2>, !firrtl.uint<2>, !firrtl.uint<6>
+; MLIR-NEXT:    %cat_a, %cat_b, %cat_c, %cat_d = firrtl.instance cat @Cat(in a: !firrtl.uint<2>, in b: !firrtl.uint<2>, in c: !firrtl.uint<2>, out d: !firrtl.uint<6>)
 ; MLIR-NEXT:    firrtl.connect %cat_a, %b : !firrtl.uint<2>, !firrtl.uint<2>
 ; MLIR-NEXT:    firrtl.connect %cat_b, %b : !firrtl.uint<2>, !firrtl.uint<2>
 ; MLIR-NEXT:    firrtl.connect %cat_c, %b : !firrtl.uint<2>, !firrtl.uint<2>
-; MLIR-NEXT:    %implicitTrunc_inp_1, %implicitTrunc_inp_2, %implicitTrunc_out1, %implicitTrunc_out2 = firrtl.instance @ImplicitTrunc  {name = "implicitTrunc"} : !firrtl.uint<1>, !firrtl.sint<5>, !firrtl.sint<3>, !firrtl.sint<3>
+; MLIR-NEXT:    %implicitTrunc_inp_1, %implicitTrunc_inp_2, %implicitTrunc_out1, %implicitTrunc_out2 = firrtl.instance implicitTrunc @ImplicitTrunc(in inp_1: !firrtl.uint<1>, in inp_2: !firrtl.sint<5>, out out1: !firrtl.sint<3>, out out2: !firrtl.sint<3>)
 ; MLIR-NEXT:    firrtl.connect %implicitTrunc_inp_1, %a : !firrtl.uint<1>, !firrtl.uint<1>
 ; MLIR-NEXT:    %0 = firrtl.asSInt %cat_d : (!firrtl.uint<6>) -> !firrtl.sint<6>
 ; MLIR-NEXT:    %1 = firrtl.bits %0 4 to 0 : (!firrtl.sint<6>) -> !firrtl.uint<5>
 ; MLIR-NEXT:    %2 = firrtl.asSInt %1 : (!firrtl.uint<5>) -> !firrtl.sint<5>
 ; MLIR-NEXT:    firrtl.connect %implicitTrunc_inp_2, %2 : !firrtl.sint<5>, !firrtl.sint<5>
-; MLIR-NEXT:    %prettifyExample_inp_1, %prettifyExample_inp_2, %prettifyExample_inp_3, %prettifyExample_out1, %prettifyExample_out2 = firrtl.instance @PrettifyExample  {name = "prettifyExample"} : !firrtl.uint<5>, !firrtl.uint<5>, !firrtl.uint<5>, !firrtl.uint<10>, !firrtl.uint<10>
+; MLIR-NEXT:    %prettifyExample_inp_1, %prettifyExample_inp_2, %prettifyExample_inp_3, %prettifyExample_out1, %prettifyExample_out2 = firrtl.instance prettifyExample @PrettifyExample(in inp_1: !firrtl.uint<5>, in inp_2: !firrtl.uint<5>, in inp_3: !firrtl.uint<5>, out out1: !firrtl.uint<10>, out out2: !firrtl.uint<10>)
 ; MLIR-NEXT:    %3 = firrtl.bits %cat_d 4 to 0 : (!firrtl.uint<6>) -> !firrtl.uint<5>
 ; MLIR-NEXT:    firrtl.connect %prettifyExample_inp_1, %3 : !firrtl.uint<5>, !firrtl.uint<5>
 ; MLIR-NEXT:    %4 = firrtl.bits %cat_d 4 to 0 : (!firrtl.uint<6>) -> !firrtl.uint<5>
 ; MLIR-NEXT:    firrtl.connect %prettifyExample_inp_2, %4 : !firrtl.uint<5>, !firrtl.uint<5>
 ; MLIR-NEXT:    %5 = firrtl.bits %cat_d 4 to 0 : (!firrtl.uint<6>) -> !firrtl.uint<5>
 ; MLIR-NEXT:    firrtl.connect %prettifyExample_inp_3, %5 : !firrtl.uint<5>, !firrtl.uint<5>
-; MLIR-NEXT:    %flipFlop_clock, %flipFlop_a_d, %flipFlop_a_q = firrtl.instance @FlipFlop  {name = "flipFlop"} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
+; MLIR-NEXT:    %flipFlop_clock, %flipFlop_a_d, %flipFlop_a_q = firrtl.instance flipFlop @FlipFlop(in clock: !firrtl.clock, in a_d: !firrtl.uint<1>, out a_q: !firrtl.uint<1>)
 ; MLIR-NEXT:    firrtl.connect %flipFlop_clock, %clock : !firrtl.clock, !firrtl.clock
 ; MLIR-NEXT:    firrtl.connect %flipFlop_a_d, %a : !firrtl.uint<1>, !firrtl.uint<1>
 ; MLIR-NEXT:    firrtl.connect %c, %flipFlop_a_q : !firrtl.uint<1>, !firrtl.uint<1>


### PR DESCRIPTION
The primary contribution of this change is to add port directions
and names to the instance op.  This fixes the issue where we had to
fetch this information from the referenced module, which was not
guaranteed to be thread safe.

The printed form of the instance op is now a hybrid between the HW
instance op and a FIRRTL module, printing the entire "module signature"
at the end. This is quite verbose but needs to be in the IR format
(i.e. every op has to be parsable using only local information).

```mlir
firrtl.instance test @simple(in a: !firrtl.uint<1>, out b: !firrtl.uint<1>)
```