### PR TITLE
[Handshake] Do early replacement of argument SSA values

### DIFF
--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -495,17 +495,29 @@ static FModuleOp createTopModuleOp(handshake::FuncOp funcOp, unsigned numClocks,
   auto topModuleOp = rewriter.create<FModuleOp>(
       funcOp.getLoc(), rewriter.getStringAttr(funcOp.getName()), ports);
 
-  // rewriter.mergeBlocks will not rewrite SSA arguments instantly, and as such
-  // will leave dangling SSA values in the IR. replaceAllUsesWith performs SSA
-  // rewriting directly.
-  for (auto &oldArg : enumerate(funcOp.getArguments()))
-    oldArg.value().replaceAllUsesWith(topModuleOp.getArgument(oldArg.index()));
+  rewriter.inlineRegionBefore(funcOp.body(), topModuleOp.body(),
+                              topModuleOp.body().end());
 
-  auto replacementArgs =
-      topModuleOp.getArguments().take_front(funcOp.getNumArguments());
-  rewriter.mergeBlocks(&funcOp.getBody().front(), topModuleOp.getBody(),
-                       replacementArgs);
+  // In the following section, we manually merge the two regions and manually
+  // replace arguments. This is an alternative to using rewriter.mergeBlocks; we
+  // do this to ensure that argument SSA values are replaced instantly, instead
+  // of late, as would be the case for mergeBlocks.
 
+  // Merge the second block (inlined from funcOp) of the top-module into the
+  // entry block.
+  auto &blockIterator = topModuleOp.body().getBlocks();
+  Block *entryBlock = &blockIterator.front();
+  Block *secondBlock = &*std::next(blockIterator.begin());
+
+  // Replace uses of each argument of the second block with the corresponding
+  // argument of the entry block.
+  for (auto &oldArg : enumerate(secondBlock->getArguments()))
+    oldArg.value().replaceAllUsesWith(entryBlock->getArgument(oldArg.index()));
+
+  // Move all operations of the second block to the entry block.
+  entryBlock->getOperations().splice(entryBlock->end(),
+                                     secondBlock->getOperations());
+  rewriter.eraseBlock(secondBlock);
   return topModuleOp;
 }
 


### PR DESCRIPTION
f1ea4f5 introduced a "hidden" regression given that (as far as i know) `rewriter.mergeBlocks` does not instantly replace block SSA arguments, but instead at some later point in time.

This is visible if we dump the top module at any point after argument conversion:
```mlir
firrtl.module @main(in %arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %arg2: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>, out %arg4: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %arg5: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
  %0:3 = "handshake.memory"(<<UNKNOWN SSA VALUE>>, <<UNKNOWN SSA VALUE>>, <<UNKNOWN SSA VALUE>>) {id = 0 : i32, ld_count = 1 : i32, lsq = false, st_count = 1 : i32, type = memref<10xi8>} : (i8, index, index) -> (i8, none, none)
  handshake.return %0#0, %0#1, %0#2 : i8, none, none
}
```

This is surprisingly not raising any issues to the conversion process since all of the operator logic is outlined into separate modules. However, I need to do a transformation on the input argument of the top-level module, which ends up triggering this issue.

Notably, this is the same issue that we've run into in both StandardToHandshake and SCFToCalyx; placing too many assumptions on rewriter side-effects being comitted after a rewrite call has been done. Over there, we've employed a technique for doing "partial lowering", splitting out distinct lowering steps (which does not erase the top-level op) into separate rewrite pattern application runs, to ensure that rewriter side-effects are committed.

To avoid changing the lowering style of HandshakeToFIRRTL, this commit is a bit of a hacky-workaround to ensure that the SSA operands are rewritten instantly.

With this commit, we again have the SSA values directly replaced:
```mlir
firrtl.module @main(in %arg0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>, in %arg1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %arg2: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %arg3: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>, out %arg4: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %arg5: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
  %0:3 = "handshake.memory"(%arg0, %arg1, %arg2) {id = 0 : i32, ld_count = 1 : i32, lsq = false, st_count = 1 : i32, type = memref<10xi8>} : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) -> (i8, none, none)
  handshake.return %0#0, %0#1, %0#2 : i8, none, none
}
```