### PR TITLE
[Python] Fix integration tests after llvm update

### DIFF
--- a/lib/Bindings/Python/circt/dialects/_ods_common.py
+++ b/lib/Bindings/Python/circt/dialects/_ods_common.py
@@ -10,4 +10,6 @@ from mlir.dialects._ods_common import (
     equally_sized_accessor,
     extend_opview_class,
     get_default_loc_context,
+    get_op_result_or_value,
+    get_op_results_or_values
 )


### PR DESCRIPTION
Additional symbols needed to be imported from `mlir.dialects._ods_common`.

See failed build [here](https://github.com/llvm/circt/runs/3865021524)