### PR TITLE
[FIRRTL] Add message interpolation to verif ops

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -109,40 +109,36 @@ def AtEdge   : I32EnumAttrCase<"AtEdge", 2, "edge">;
 def EventControlAttr : I32EnumAttr<"EventControl", "edge control trigger",
                                    [AtPosEdge, AtNegEdge, AtEdge]>  {}
 
-def AssertOp : FIRRTLOp<"assert"> {
+class VerifOp<string mnemonic, list<OpTrait> traits = []> :
+    FIRRTLOp<mnemonic, traits> {
+  let arguments = (ins
+    ClockType:$clock,
+    UInt1Type:$predicate,
+    UInt1Type:$enable,
+    StrAttr:$message,
+    Variadic<AnyType>:$operands,
+    StrAttr:$name,
+    DefaultValuedAttr<BoolAttr,"false">:$isConcurrent,
+    DefaultValuedAttr<EventControlAttr,"EventControl::AtPosEdge">:$eventControl
+  );
+
+  let assemblyFormat = [{
+    $clock `,` $predicate `,` $enable `,`
+    $message (`(` $operands^ `)` `:` type($operands))?
+    custom<VerifAttrs>(attr-dict)
+  }];
+}
+
+def AssertOp : VerifOp<"assert"> {
   let summary = "Assert Verification Statement";
-
-  let arguments = (ins ClockType:$clock, UInt1Type:$predicate, UInt1Type:$enable,
-    StrAttr:$message, StrAttr:$name, DefaultValuedAttr<BoolAttr,"false">:$isConcurrent,
-    DefaultValuedAttr<EventControlAttr,"EventControl::AtPosEdge">:$eventControl);
-  let results = (outs);
-
-  let assemblyFormat =
-    "$clock `,` $predicate `,` $enable `,` $message custom<VerifAttrs>(attr-dict)";
 }
 
-def AssumeOp : FIRRTLOp<"assume"> {
+def AssumeOp : VerifOp<"assume"> {
   let summary = "Assume Verification Statement";
-
-  let arguments = (ins ClockType:$clock, UInt1Type:$predicate, UInt1Type:$enable,
-    StrAttr:$message, StrAttr:$name, DefaultValuedAttr<BoolAttr,"false">:$isConcurrent,
-    DefaultValuedAttr<EventControlAttr,"EventControl::AtPosEdge">:$eventControl);
-  let results = (outs);
-
-  let assemblyFormat =
-    "$clock `,` $predicate `,` $enable `,` $message custom<VerifAttrs>(attr-dict)";
 }
 
-def CoverOp : FIRRTLOp<"cover"> {
+def CoverOp : VerifOp<"cover"> {
   let summary = "Cover Verification Statement";
-
-  let arguments = (ins ClockType:$clock, UInt1Type:$predicate, UInt1Type:$enable,
-    StrAttr:$message, StrAttr:$name, DefaultValuedAttr<BoolAttr,"false">:$isConcurrent,
-    DefaultValuedAttr<EventControlAttr,"EventControl::AtPosEdge">:$eventControl);
-  let results = (outs);
-
-  let assemblyFormat =
-    "$clock `,` $predicate `,` $enable `,` $message custom<VerifAttrs>(attr-dict)";
 }
 
 def WhenOp : FIRRTLOp<"when", [SingleBlock, NoTerminator, NoRegionArguments,

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2363,8 +2363,8 @@ ParseResult FIRStmtParser::parseAssert() {
 
   locationProcessor.setLoc(startTok.getLoc());
   auto messageUnescaped = FIRToken::getStringValue(message);
-  builder.create<AssertOp>(clock, predicate, enable,
-                           StringRef(messageUnescaped), name.getValue());
+  builder.create<AssertOp>(clock, predicate, enable, messageUnescaped,
+                           ValueRange{}, name.getValue());
   return success();
 }
 
@@ -2387,7 +2387,7 @@ ParseResult FIRStmtParser::parseAssume() {
   locationProcessor.setLoc(startTok.getLoc());
   auto messageUnescaped = FIRToken::getStringValue(message);
   builder.create<AssumeOp>(clock, predicate, enable, messageUnescaped,
-                           name.getValue());
+                           ValueRange{}, name.getValue());
   return success();
 }
 
@@ -2410,7 +2410,7 @@ ParseResult FIRStmtParser::parseCover() {
   locationProcessor.setLoc(startTok.getLoc());
   auto messageUnescaped = FIRToken::getStringValue(message);
   builder.create<CoverOp>(clock, predicate, enable, messageUnescaped,
-                          name.getValue());
+                          ValueRange{}, name.getValue());
   return success();
 }
 

--- a/lib/Dialect/FIRRTL/Import/FIRParserAsserts.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParserAsserts.cpp
@@ -320,22 +320,22 @@ ParseResult foldWhenEncodedVerifOp(ImplicitLocOpBuilder &builder,
     // Scala impl of ExtractTestCode.
     if (flavor == VerifFlavor::Assert || flavor == VerifFlavor::AssertNotX)
       builder.create<AssertOp>(printOp.clock(), predicate, printOp.cond(),
-                               message, label, true);
+                               message, printOp.operands(), label, true);
     else if (flavor == VerifFlavor::Assume)
       builder.create<AssumeOp>(printOp.clock(), predicate, printOp.cond(),
-                               message, label, true);
+                               message, printOp.operands(), label, true);
     else // VerifFlavor::Cover
       builder.create<CoverOp>(printOp.clock(), predicate, printOp.cond(),
-                              message, label, true);
+                              message, printOp.operands(), label, true);
     printOp.erase();
     break;
   }
 
     // Handle the case of builtin Chisel assertions.
   case VerifFlavor::ChiselAssert: {
-    builder.create<AssertOp>(printOp.clock(),
-                             builder.create<NotPrimOp>(whenStmt.condition()),
-                             printOp.cond(), fmt, "chisel3_builtin", true);
+    builder.create<AssertOp>(
+        printOp.clock(), builder.create<NotPrimOp>(whenStmt.condition()),
+        printOp.cond(), fmt, printOp.operands(), "chisel3_builtin", true);
     printOp.erase();
     break;
   }
@@ -471,10 +471,10 @@ ParseResult foldWhenEncodedVerifOp(ImplicitLocOpBuilder &builder,
         predicate); // assertion triggers when predicate fails
     if (flavor == VerifFlavor::VerifLibAssert)
       op = builder.create<AssertOp>(printOp.clock(), predicate, printOp.cond(),
-                                    message, label, true);
+                                    message, printOp.operands(), label, true);
     else // VerifFlavor::VerifLibAssume
       op = builder.create<AssumeOp>(printOp.clock(), predicate, printOp.cond(),
-                                    message, label, true);
+                                    message, printOp.operands(), label, true);
     printOp.erase();
 
     // Attach additional attributes extracted from the JSON object.

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -385,73 +385,85 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.stop %clock2, %reset, 0
   }
 
-// circuit Verification:
-//   module Verification:
-//     input clock: Clock
-//     input aCond: UInt<8>
-//     input aEn: UInt<8>
-//     input bCond: UInt<1>
-//     input bEn: UInt<1>
-//     input cCond: UInt<1>
-//     input cEn: UInt<1>
-//     assert(clock, bCond, bEn, "assert0")
-//     assert(clock, bCond, bEn, "assert0") : assert_0
-//     assume(clock, aCond, aEn, "assume0")
-//     assume(clock, aCond, aEn, "assume0") : assume_0
-//     cover(clock,  cCond, cEn, "cover0)"
-//     cover(clock,  cCond, cEn, "cover0)" : cover_0
+  // circuit Verification:
+  //   module Verification:
+  //     input clock: Clock
+  //     input aCond: UInt<8>
+  //     input aEn: UInt<8>
+  //     input bCond: UInt<1>
+  //     input bEn: UInt<1>
+  //     input cCond: UInt<1>
+  //     input cEn: UInt<1>
+  //     assert(clock, bCond, bEn, "assert0")
+  //     assert(clock, bCond, bEn, "assert0") : assert_0
+  //     assume(clock, aCond, aEn, "assume0")
+  //     assume(clock, aCond, aEn, "assume0") : assume_0
+  //     cover(clock,  cCond, cEn, "cover0)"
+  //     cover(clock,  cCond, cEn, "cover0)" : cover_0
 
   // CHECK-LABEL: hw.module @Verification
   firrtl.module @Verification(in %clock: !firrtl.clock, in %aCond: !firrtl.uint<1>,
-   in %aEn: !firrtl.uint<1>, in %bCond: !firrtl.uint<1>, in %bEn: !firrtl.uint<1>,
-   in %cCond: !firrtl.uint<1>, in %cEn: !firrtl.uint<1>) {
+    in %aEn: !firrtl.uint<1>, in %bCond: !firrtl.uint<1>, in %bEn: !firrtl.uint<1>,
+    in %cCond: !firrtl.uint<1>, in %cEn: !firrtl.uint<1>, in %value: !firrtl.uint<42>) {
 
-    // CHECK-NEXT: %0 = comb.and %aEn, %aCond : i1
-    // CHECK-NEXT: sv.assert.concurrent posedge %clock, %0
-    // CHECK-NEXT: %1 = comb.and %aEn, %aCond : i1
-    // CHECK-NEXT: sv.assert.concurrent posedge %clock, %1 label "assert_0"
-    // CHECK-NEXT: %2 = comb.and %bEn, %bCond : i1
-    // CHECK-NEXT: sv.assume.concurrent posedge %clock, %2
-    // CHECK-NEXT: %3 = comb.and %bEn, %bCond : i1
-    // CHECK-NEXT: sv.assume.concurrent posedge %clock, %3 label "assume_0"
-    // CHECK-NEXT: %4 = comb.and %cEn, %cCond : i1
-    // CHECK-NEXT: sv.cover.concurrent posedge %clock, %4
-    // CHECK-NEXT: %5 = comb.and %cEn, %cCond : i1
-    // CHECK-NEXT: sv.cover.concurrent posedge %clock, %5 label "cover_0"
+    // CHECK-NEXT: [[TMP:%.+]] = comb.and %aEn, %aCond : i1
+    // CHECK-NEXT: sv.assert.concurrent posedge %clock, [[TMP]] message "assert0"
+    // CHECK-NEXT: [[TMP:%.+]] = comb.and %aEn, %aCond : i1
+    // CHECK-NEXT: sv.assert.concurrent posedge %clock, [[TMP]] label "assert_0" message "assert0"
+    // CHECK-NEXT: [[TMP:%.+]] = comb.and %aEn, %aCond : i1
+    // CHECK-NEXT: sv.assert.concurrent posedge %clock, [[TMP]] message "assert0"(%value) : i42
+    // CHECK-NEXT: [[TMP:%.+]] = comb.and %bEn, %bCond : i1
+    // CHECK-NEXT: sv.assume.concurrent posedge %clock, [[TMP]] message "assume0"
+    // CHECK-NEXT: [[TMP:%.+]] = comb.and %bEn, %bCond : i1
+    // CHECK-NEXT: sv.assume.concurrent posedge %clock, [[TMP]] label "assume_0" message "assume0"
+    // CHECK-NEXT: [[TMP:%.+]] = comb.and %bEn, %bCond : i1
+    // CHECK-NEXT: sv.assume.concurrent posedge %clock, [[TMP]] message "assume0"(%value) : i42
+    // CHECK-NEXT: [[TMP:%.+]] = comb.and %cEn, %cCond : i1
+    // CHECK-NEXT: sv.cover.concurrent posedge %clock, [[TMP]]
+    // CHECK-NEXT: [[TMP:%.+]] = comb.and %cEn, %cCond : i1
+    // CHECK-NEXT: sv.cover.concurrent posedge %clock, [[TMP]] label "cover_0"
     // CHECK: sv.cover.concurrent negedge %clock, {{%.+}} label "cover_1"
     // CHECK: sv.cover.concurrent edge %clock, {{%.+}} label "cover_2"
     firrtl.assert %clock, %aCond, %aEn, "assert0" {isConcurrent = true}
     firrtl.assert %clock, %aCond, %aEn, "assert0" {isConcurrent = true, name = "assert_0"}
+    firrtl.assert %clock, %aCond, %aEn, "assert0"(%value) : !firrtl.uint<42> {isConcurrent = true}
     firrtl.assume %clock, %bCond, %bEn, "assume0" {isConcurrent = true}
     firrtl.assume %clock, %bCond, %bEn, "assume0" {isConcurrent = true, name = "assume_0"}
+    firrtl.assume %clock, %bCond, %bEn, "assume0"(%value) : !firrtl.uint<42> {isConcurrent = true}
     firrtl.cover %clock, %cCond, %cEn, "cover0" {isConcurrent = true}
     firrtl.cover %clock, %cCond, %cEn, "cover0" {isConcurrent = true, name = "cover_0"}
+    firrtl.cover %clock, %cCond, %cEn, "cover0"(%value) : !firrtl.uint<42> {isConcurrent = true}
     firrtl.cover %clock, %cCond, %cEn, "cover1" {eventControl = 1 : i32, isConcurrent = true, name = "cover_1"}
     firrtl.cover %clock, %cCond, %cEn, "cover2" {eventControl = 2 : i32, isConcurrent = true, name = "cover_2"}
 
     // CHECK-NEXT: sv.always posedge %clock {
     // CHECK-NEXT:   sv.if %aEn {
-    // CHECK-NEXT:     sv.assert %aCond, immediate
-    // CHECK-NOT:                        label
-    // CHECK-NEXT:     sv.assert %aCond, immediate label "assert_0"
+    // CHECK-NEXT:     sv.assert %aCond, immediate message "assert0"
+    // CHECK-NEXT:     sv.assert %aCond, immediate label "assert_0" message "assert0"
+    // CHECK-NEXT:     sv.assert %aCond, immediate message "assert0"(%value) : i42
     // CHECK-NEXT:   }
     // CHECK-NEXT:   sv.if %bEn {
-    // CHECK-NEXT:     sv.assume %bCond, immediate
-    // CHECK-NOT:                        label
-    // CHECK-NEXT:     sv.assume %bCond, immediate label "assume_0"
+    // CHECK-NEXT:     sv.assume %bCond, immediate message "assume0"
+    // CHECK-NEXT:     sv.assume %bCond, immediate label "assume_0" message "assume0"
+    // CHECK-NEXT:     sv.assume %bCond, immediate message "assume0"(%value) : i42
     // CHECK-NEXT:   }
     // CHECK-NEXT:   sv.if %cEn {
     // CHECK-NEXT:     sv.cover %cCond, immediate
     // CHECK-NOT:                       label
     // CHECK-NEXT:     sv.cover %cCond, immediate label "cover_0"
+    // CHECK-NEXT:     sv.cover %cCond, immediate
+    // CHECK-NOT:                       label
     // CHECK-NEXT:   }
     // CHECK-NEXT: }
     firrtl.assert %clock, %aCond, %aEn, "assert0"
     firrtl.assert %clock, %aCond, %aEn, "assert0" {name = "assert_0"}
+    firrtl.assert %clock, %aCond, %aEn, "assert0"(%value) : !firrtl.uint<42>
     firrtl.assume %clock, %bCond, %bEn, "assume0"
     firrtl.assume %clock, %bCond, %bEn, "assume0" {name = "assume_0"}
+    firrtl.assume %clock, %bCond, %bEn, "assume0"(%value) : !firrtl.uint<42>
     firrtl.cover %clock, %cCond, %cEn, "cover0"
     firrtl.cover %clock, %cCond, %cEn, "cover0" {name = "cover_0"}
+    firrtl.cover %clock, %cCond, %cEn, "cover0"(%value) : !firrtl.uint<42>
     // CHECK-NEXT: hw.output
   }
 

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -867,36 +867,36 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     ; rocket-chip properties
     when cond:
-      printf(clock, enable, "assert:foo 0")
+      printf(clock, enable, "assert:foo 0", value)
     ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "foo 0"
+    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "foo 0"(%value) : !firrtl.uint<42>
 
     when cond:
-      printf(clock, enable, "assume:foo 1")
+      printf(clock, enable, "assume:foo 1", value)
     ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "foo 1"
+    ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "foo 1"(%value) : !firrtl.uint<42>
 
     when cond:
-      printf(clock, enable, "cover:foo 2")
+      printf(clock, enable, "cover:foo 2", value)
     ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.cover %clock, [[TMP]], %enable, "foo 2"
+    ; CHECK-NEXT: firrtl.cover %clock, [[TMP]], %enable, "foo 2"(%value) : !firrtl.uint<42>
 
     when cond:
-      printf(clock, enable, "assert:custom label 0:foo 3")
+      printf(clock, enable, "assert:custom label 0:foo 3", value)
     ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "foo 3"
+    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "foo 3"(%value) : !firrtl.uint<42>
     ; CHECK-SAME: name = "custom label 0"
 
     when cond:
-      printf(clock, enable, "assume:custom label 1:foo 4")
+      printf(clock, enable, "assume:custom label 1:foo 4", value)
     ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "foo 4"
+    ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "foo 4"(%value) : !firrtl.uint<42>
     ; CHECK-SAME: name = "custom label 1"
 
     when cond:
-      printf(clock, enable, "cover:custom label 2:foo 5")
+      printf(clock, enable, "cover:custom label 2:foo 5", value)
     ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.cover %clock, [[TMP]], %enable, "foo 5"
+    ; CHECK-NEXT: firrtl.cover %clock, [[TMP]], %enable, "foo 5"(%value) : !firrtl.uint<42>
     ; CHECK-SAME: name = "custom label 2"
 
     ; Optional `stop` with same clock and condition should be removed.
@@ -918,40 +918,40 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     ; Chisel built-in assertions
     when cond:
-      printf(clock, enable, "Assertion failed")
+      printf(clock, enable, "Assertion failed", value)
       stop(clock, enable, 1)
     ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Assertion failed"
+    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Assertion failed"(%value) : !firrtl.uint<42>
     ; CHECK-SAME: name = "chisel3_builtin"
 
     when cond:
-      printf(clock, enable, "Assertion failed: some message")
+      printf(clock, enable, "Assertion failed: some message", value)
       stop(clock, enable, 1)
     ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Assertion failed: some message"
+    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Assertion failed: some message"(%value) : !firrtl.uint<42>
     ; CHECK-SAME: name = "chisel3_builtin"
 
     ; Verification Library Assertions
 
     ; Predicate modifier `noMod`
     when cond:
-      printf(clock, enable, "Assertion failed: [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"},{\"type\":\"formalOnly\"}],\"labelExts\":[\"label\",\"magic\"],\"format\":{\"type\":\"sva\"},\"baseMsg\":\"Hello Assert\"}")
+      printf(clock, enable, "Assertion failed: [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"},{\"type\":\"formalOnly\"}],\"labelExts\":[\"label\",\"magic\"],\"format\":{\"type\":\"sva\"},\"baseMsg\":\"Hello Assert\"}", value)
       stop(clock, enable, 1)
     ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Hello Assert"
+    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Hello Assert"(%value) : !firrtl.uint<42>
     ; CHECK-SAME: format = "sva"
     ; CHECK-SAME: guards = ["USE_UNR_ONLY_CONSTRAINTS", "USE_FORMAL_ONLY_CONSTRAINTS"]
     ; CHECK-SAME: name = "verif_library_label_magic"
 
     ; Predicate modifier `trueOrIsX`
     when cond:
-      printf(clock, enable, "Assertion failed: [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"trueOrIsX\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"},{\"type\":\"formalOnly\"}],\"labelExts\":[\"label\",\"magic\"],\"format\":{\"type\":\"sva\"},\"baseMsg\":\"Hello Assert\"}")
+      printf(clock, enable, "Assertion failed: [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"trueOrIsX\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"},{\"type\":\"formalOnly\"}],\"labelExts\":[\"label\",\"magic\"],\"format\":{\"type\":\"sva\"},\"baseMsg\":\"Hello Assert\"}", value)
       stop(clock, enable, 1)
     ; CHECK: [[TMP1:%.+]] = firrtl.xorr %cond
     ; CHECK-NEXT: [[TMP2:%.+]] = firrtl.verbatim.expr "{{[{][{]0[}][}]}} === 1'bx"([[TMP1]])
     ; CHECK-NEXT: [[TMP3:%.+]] = firrtl.or %cond, [[TMP2]]
     ; CHECK-NEXT: [[TMP:%.+]] = firrtl.not [[TMP3]]
-    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Hello Assert"
+    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Hello Assert"(%value) : !firrtl.uint<42>
     ; CHECK-SAME: format = "sva"
     ; CHECK-SAME: guards = ["USE_UNR_ONLY_CONSTRAINTS", "USE_FORMAL_ONLY_CONSTRAINTS"]
     ; CHECK-SAME: name = "verif_library_label_magic"
@@ -960,21 +960,21 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     ; Predicate modifier `noMod`
     when cond:
-      printf(clock, enable, "Assumption failed: [verif-library-assume]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"},{\"type\":\"formalOnly\"}],\"labelExts\":[\"label\",\"voodoo\"],\"baseMsg\":\"Hello Assume\"}")
+      printf(clock, enable, "Assumption failed: [verif-library-assume]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"},{\"type\":\"formalOnly\"}],\"labelExts\":[\"label\",\"voodoo\"],\"baseMsg\":\"Hello Assume\"}", value)
       stop(clock, enable, 1)
     ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "Hello Assume"
+    ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "Hello Assume"(%value) : !firrtl.uint<42>
     ; CHECK-SAME: guards = ["USE_UNR_ONLY_CONSTRAINTS", "USE_FORMAL_ONLY_CONSTRAINTS"]
     ; CHECK-SAME: name = "verif_library_label_voodoo"
 
     ; Predicate modifier `trueOrIsX`
     when cond:
-      printf(clock, enable, "Assumption failed: [verif-library-assume]<extraction-summary>{\"predicateModifier\":{\"type\":\"trueOrIsX\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"},{\"type\":\"formalOnly\"}],\"labelExts\":[\"label\",\"voodoo\"],\"baseMsg\":\"Hello Assume\"}")
+      printf(clock, enable, "Assumption failed: [verif-library-assume]<extraction-summary>{\"predicateModifier\":{\"type\":\"trueOrIsX\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"},{\"type\":\"formalOnly\"}],\"labelExts\":[\"label\",\"voodoo\"],\"baseMsg\":\"Hello Assume\"}", value)
       stop(clock, enable, 1)
     ; CHECK: [[TMP1:%.+]] = firrtl.xorr %cond
     ; CHECK-NEXT: [[TMP2:%.+]] = firrtl.verbatim.expr "{{[{][{]0[}][}]}} === 1'bx"([[TMP1]])
     ; CHECK-NEXT: [[TMP3:%.+]] = firrtl.or %cond, [[TMP2]]
     ; CHECK-NEXT: [[TMP:%.+]] = firrtl.not [[TMP3]]
-    ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "Hello Assume"
+    ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "Hello Assume"(%value) : !firrtl.uint<42>
     ; CHECK-SAME: guards = ["USE_UNR_ONLY_CONSTRAINTS", "USE_FORMAL_ONLY_CONSTRAINTS"]
     ; CHECK-SAME: name = "verif_library_label_voodoo"


### PR DESCRIPTION
Extend the assert, assume, and cover verification operations to support optional arguments for interpolation into the message string. Also clean things up a bit by factoring out the commonalities of the verif ops into a `VerifOp` parent class.

Adjust the parser for printf-encoded verification ops to leverage the new message interpolation behaviour, passing through any operands to the `printf` op. Also update the `LowerToHW` pass to carry the message interpolation over into the SV dialect.

### Todo
- [x] Land #1974