### PR TITLE
[FIRRTL] Remove unused builder for InstanceOp

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -35,12 +35,7 @@ def InstanceOp : FIRRTLOp<"instance", [
                    CArg<"StringRef", "{}">:$name,
                    CArg<"ArrayRef<Attribute>", "{}">:$annotations,
                    CArg<"ArrayRef<Attribute>", "{}">:$portAnnotations,
-                   CArg<"bool","false">:$lowerToBind)>,
-
-    /// Constructor that creates a version of the specified instance, but that
-    /// erases some number of results from it.
-    OpBuilder<(ins "InstanceOp":$existingInstance,
-                   "::mlir::ArrayRef<unsigned>":$resultsToErase)>
+                   CArg<"bool","false">:$lowerToBind)>
   ];
 
   let extraClassDeclaration = [{

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -844,21 +844,6 @@ void InstanceOp::build(OpBuilder &builder, OperationState &result,
   }
 }
 
-/// Create a copy of the specified instance operation with some result removed.
-void InstanceOp::build(OpBuilder &builder, OperationState &result,
-                       InstanceOp existingInstance,
-                       ArrayRef<unsigned> resultsToErase) {
-
-  // Drop the direction markers for dead ports.
-  auto resultTypes = SmallVector<Type>(existingInstance.getResultTypes());
-
-  SmallVector<Type> newResultTypes =
-      removeElementsAtIndices<Type>(resultTypes, resultsToErase);
-
-  build(builder, result, newResultTypes, existingInstance->getOperands(),
-        existingInstance->getAttrs());
-}
-
 ArrayAttr InstanceOp::getPortAnnotation(unsigned portIdx) {
   assert(portIdx < getNumResults() &&
          "index should be smaller than result number");


### PR DESCRIPTION
This builder was not used anywhere, so it might make sense to remove it.  It
was originally introduced in 9c8935462be. @lattner Is this still needed?