### PR TITLE
[FIRRTL] Add builder InstanceOp which takes a module

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -35,6 +35,13 @@ def InstanceOp : FIRRTLOp<"instance", [
                    CArg<"StringRef", "{}">:$name,
                    CArg<"ArrayRef<Attribute>", "{}">:$annotations,
                    CArg<"ArrayRef<Attribute>", "{}">:$portAnnotations,
+                   CArg<"bool","false">:$lowerToBind)>,
+
+    /// Constructor when you have the target module in hand.
+    OpBuilder<(ins "FModuleLike":$module,
+                   "mlir::StringRef":$name,
+                   CArg<"ArrayRef<Attribute>", "{}">:$annotations,
+                   CArg<"ArrayRef<Attribute>", "{}">:$portAnnotations,
                    CArg<"bool","false">:$lowerToBind)>
   ];
 

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -2108,16 +2108,9 @@ static void createInstOp(Operation *oldOp, FModuleOp subModuleOp,
                          ConversionPatternRewriter &rewriter) {
   rewriter.setInsertionPointAfter(oldOp);
 
-  llvm::SmallVector<Type> resultTypes;
-
-  // Bundle all ports of the instance into a new flattened bundle type.
-  SmallVector<PortInfo, 8> portInfo = subModuleOp.getPorts();
-  for (auto &port : portInfo)
-    resultTypes.push_back(port.type);
-
   // Create a instance operation.
-  auto instanceOp = rewriter.create<firrtl::InstanceOp>(
-      oldOp->getLoc(), resultTypes, subModuleOp.getName());
+  auto instanceOp =
+      rewriter.create<firrtl::InstanceOp>(oldOp->getLoc(), subModuleOp, "");
 
   // Connect the new created instance with its predecessors and successors in
   // the top-module.

--- a/lib/Dialect/FIRRTL/Transforms/BlackBoxMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackBoxMemory.cpp
@@ -77,20 +77,6 @@ struct MemOpInfo : public llvm::DenseMapInfo<MemOp> {
 };
 } // end anonymous namespace
 
-/// Create an instance of a Module using the module name and the port list.
-static InstanceOp createInstance(OpBuilder builder, Location loc,
-                                 StringRef moduleName, StringAttr instanceName,
-                                 ArrayRef<PortInfo> modulePorts) {
-  // Make a bundle of the inputs and outputs of the specified module.
-  SmallVector<Type, 4> resultTypes;
-  resultTypes.reserve(modulePorts.size());
-  for (auto port : modulePorts)
-    resultTypes.push_back(port.type);
-
-  return builder.create<InstanceOp>(loc, resultTypes, moduleName,
-                                    instanceName.getValue());
-}
-
 /// Get the pohwist for an external module representing a blackbox memory. This
 /// external module must be compatible with the modules which are generated for
 /// `vlsi_mem_gen`, which can be found in the rocketchip project.
@@ -212,8 +198,8 @@ static FModuleOp createWrapperModule(MemOp op,
 
   // Create the module
   builder.setInsertionPointToStart(moduleOp.getBody());
-  auto instanceOp = createInstance(builder, op.getLoc(), extModuleOp.getName(),
-                                   op.nameAttr(), extPorts);
+  auto instanceOp =
+      builder.create<InstanceOp>(op.getLoc(), extModuleOp, op.name());
 
   // Connect the ports between the memory module and the instance of the black
   // box memory module. The outer module has a single bundle representing each
@@ -308,9 +294,8 @@ replaceMemWithWrapperModule(DenseMap<MemOp, FModuleOp, MemOpInfo> &knownMems,
   }
 
   // Create an instance of the wrapping module
-  auto instanceOp =
-      createInstance(OpBuilder(memOp), memOp.getLoc(), moduleOp.getName(),
-                     memOp.nameAttr(), modPorts);
+  auto instanceOp = OpBuilder(memOp).create<InstanceOp>(memOp.getLoc(),
+                                                        moduleOp, memOp.name());
 
   // Replace the memory operation with the module instance
   memOp.replaceAllUsesWith(instanceOp.getResults());
@@ -376,8 +361,7 @@ replaceMemWithExtModule(DenseMap<MemOp, FExtModuleOp, MemOpInfo> &knownMems,
 
   // Create an instance of the black box module
   auto instanceOp =
-      createInstance(builder, memOp.getLoc(), extModuleOp.getName(),
-                     memOp.nameAttr(), extPortList);
+      builder.create<InstanceOp>(memOp.getLoc(), extModuleOp, memOp.name());
 
   // Create a wire for every memory port
   SmallVector<Value, 2> results;

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -734,9 +734,8 @@ void GrandCentralPass::runOnOperation() {
 
               // Instantiate the mapping module inside the companion.
               builder.setInsertionPointToEnd(op.getBody());
-              builder.create<InstanceOp>(circuitOp.getLoc(),
-                                         SmallVector<Type>({}),
-                                         mapping.getName(), mapping.getName());
+              builder.create<InstanceOp>(circuitOp.getLoc(), mapping,
+                                         mapping.getName());
 
               // Assert that the companion is instantiated once and only once.
               auto instance = exactlyOneInstance(op, "companion");


### PR DESCRIPTION
When port directions and names are moved on to the instance op these
fields can be taken directly off of the module.  In many cases this
greatly simplifies the process of creating a new instance operation.