### PR TITLE
[FIRRTLToHW] Donot add firrtl.extract.cover.extra to extern modules

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -883,11 +883,8 @@ FIRRTLModuleLowering::lowerExtModule(FExtModuleOp oldModule,
   auto parameters = getHWParameters(oldModule, /*ignoreValues=*/true);
   auto newModule = builder.create<hw::HWModuleExternOp>(
       oldModule.getLoc(), nameAttr, ports, verilogName, parameters);
-  // Transform module annotations
-  AnnotationSet annos(oldModule);
-  if (annos.removeAnnotation(verifBBClass))
-    newModule->setAttr("firrtl.extract.cover.extra", builder.getUnitAttr());
-  loweringState.processRemainingAnnotations(oldModule, annos);
+  loweringState.processRemainingAnnotations(oldModule,
+                                            AnnotationSet(oldModule));
   return newModule;
 }
 


### PR DESCRIPTION
This is a followup to fix a bug in (https://github.com/llvm/circt/commit/e6cde1f09499770497d37e290b808d39fbc7ff02, PR https://github.com/llvm/circt/pull/1956), 
Don't add `firrtl.extract.cover.extra` to extern modules with `freechips.rocketchip.annotations.InternalVerifBlackBoxAnnotation`. 