### PR TITLE
[Python] Flush error stream in MSFT tests.

### DIFF
--- a/integration_test/Bindings/Python/dialects/msft.py
+++ b/integration_test/Bindings/Python/dialects/msft.py
@@ -136,6 +136,8 @@ with ir.Context() as ctx, ir.Location.unknown():
   # CHECK-LABEL: === Placements (col 6):
 
   print("=== Errors:", file=sys.stderr)
+  # TODO: Python's sys.stderr doesn't seem to be shared with C++ errors.
+  # See https://github.com/llvm/circt/issues/1983 for more info.
   sys.stderr.flush()
   # ERR-LABEL: === Errors:
   bad_loc = msft.PhysLocationAttr.get(msft.M20K, x=7, y=99, num=1)


### PR DESCRIPTION
I found that this test consistently failed because the === Errors:
label was always showing up at the end of the error file being
checked. By manually flushing, the test consistently passes.