### PR TITLE
[PyCDE] Use setuptools_scm package to infer version from Git.

### DIFF
--- a/frontends/PyCDE/pyproject.toml
+++ b/frontends/PyCDE/pyproject.toml
@@ -14,5 +14,5 @@ build-backend = "setuptools.build_meta"
 # Enable version inference from Git.
 [tool.setuptools_scm]
 root = "../.."
-relative_to = "__file__"
+relative_to = "setup.py"
 tag_regex = "^pycde-(\\d+\\.\\d+\\.\\d+)?$"


### PR DESCRIPTION
This is "the blessed package to manage your versions by scm tags".

The current tag format is `pycde-<major>.<minor>.<patch>`.