### PR TITLE
[FIRRTL] Add option to enable FIRRTL memory lowering and metadata

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -40,7 +40,8 @@ std::unique_ptr<mlir::Pass> createInlinerPass();
 
 std::unique_ptr<mlir::Pass> createBlackBoxMemoryPass();
 
-std::unique_ptr<mlir::Pass> createCreateSiFiveMetadataPass();
+std::unique_ptr<mlir::Pass>
+createCreateSiFiveMetadataPass(bool replSeqMem = false);
 
 std::unique_ptr<mlir::Pass> createExpandWhensPass();
 

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -96,6 +96,8 @@ def CreateSiFiveMetadata : Pass<"firrtl-emit-metadata", "firrtl::CircuitOp"> {
     This pass handles the emission of several different kinds of metadata.
   }];
   let constructor = "circt::firrtl::createCreateSiFiveMetadataPass()";
+  let options = [Option<"replSeqMem", "repl-seq-mem", "bool", "false",
+      "Lower the seq mem for macro replacement and emit relevant metadata">];
 }
 
 def ExpandWhens : Pass<"firrtl-expand-whens", "firrtl::FModuleOp"> {

--- a/include/circt/Dialect/SV/SVPasses.h
+++ b/include/circt/Dialect/SV/SVPasses.h
@@ -24,7 +24,7 @@ std::unique_ptr<mlir::Pass> createHWCleanupPass();
 std::unique_ptr<mlir::Pass> createHWStubExternalModulesPass();
 std::unique_ptr<mlir::Pass> createHWLegalizeModulesPass();
 std::unique_ptr<mlir::Pass> createHWGeneratorCalloutPass();
-std::unique_ptr<mlir::Pass> createHWMemSimImplPass();
+std::unique_ptr<mlir::Pass> createHWMemSimImplPass(bool replSeqMem = false);
 std::unique_ptr<mlir::Pass> createSVExtractTestCodePass();
 std::unique_ptr<mlir::Pass>
 createHWExportModuleHierarchyPass(llvm::Optional<std::string> directory = {});

--- a/include/circt/Dialect/SV/SVPasses.td
+++ b/include/circt/Dialect/SV/SVPasses.td
@@ -92,6 +92,11 @@ def HWMemSimImpl : Pass<"hw-memory-sim", "ModuleOp"> {
 
   let constructor = "circt::sv::createHWMemSimImplPass()";
   let dependentDialects = ["circt::sv::SVDialect"];
+
+  let options = [
+    Option<"replSeqMem", "repl-seq-mem", "bool",
+                "false", "Prepare seq mems for macro replacement">
+   ];
 }
 
 def SVExtractTestCode : Pass<"sv-extract-test-code", "ModuleOp"> {

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -45,12 +45,17 @@ class CreateSiFiveMetadataPass
   DenseSet<Operation *> dutModuleSet;
   // The design under test module.
   FModuleOp dutMod;
+
+public:
+  CreateSiFiveMetadataPass(bool e) { replSeqMem = e; }
 };
 } // end anonymous namespace
 
 /// This function collects all the firrtl.mem ops and creates a verbatim op with
 /// the relevant memory attributes.
 LogicalResult CreateSiFiveMetadataPass::emitMemoryMetadata() {
+  if (!replSeqMem)
+    return success();
 
   // Lambda to get the number of read, write and read-write ports corresponding
   // to a MemOp.
@@ -476,6 +481,7 @@ void CreateSiFiveMetadataPass::runOnOperation() {
   markAnalysesPreserved<InstanceGraph>();
 }
 
-std::unique_ptr<mlir::Pass> circt::firrtl::createCreateSiFiveMetadataPass() {
-  return std::make_unique<CreateSiFiveMetadataPass>();
+std::unique_ptr<mlir::Pass>
+circt::firrtl::createCreateSiFiveMetadataPass(bool replSeqMem) {
+  return std::make_unique<CreateSiFiveMetadataPass>(replSeqMem);
 }

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-emit-metadata)' %s | FileCheck %s
+// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-emit-metadata{repl-seq-mem=true})' %s | FileCheck %s
 
 firrtl.circuit "empty" {
   firrtl.module @empty() {

--- a/test/firtool/memoryMetadata.fir
+++ b/test/firtool/memoryMetadata.fir
@@ -1,4 +1,4 @@
-; RUN: firtool %s --format=fir  --annotation-file %s.anno.json -emit-metadata --verilog |  FileCheck %s
+; RUN: firtool %s --format=fir  --annotation-file %s.anno.json --repl-seq-mem --verilog |  FileCheck %s
 
 circuit test:
   module memoryTest1:

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -109,7 +109,13 @@ static cl::opt<bool> disableAnnotationsUnknown(
 static cl::opt<bool>
     emitMetadata("emit-metadata",
                  cl::desc("emit metadata for metadata annotations"),
-                 cl::init(false));
+                 cl::init(true));
+
+static cl::opt<bool> replSeqMem(
+    "repl-seq-mem",
+    cl::desc(
+        "replace the seq mem for macro replacement and emit relevant metadata"),
+    cl::init(false));
 
 static cl::opt<bool> imconstprop(
     "imconstprop",
@@ -375,13 +381,13 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
 
   if (emitMetadata)
     pm.nest<firrtl::CircuitOp>().addPass(
-        firrtl::createCreateSiFiveMetadataPass());
+        firrtl::createCreateSiFiveMetadataPass(replSeqMem));
 
   // Lower if we are going to verilog or if lowering was specifically requested.
   if (lowerToHW || outputFormat == OutputVerilog ||
       outputFormat == OutputSplitVerilog) {
     pm.addPass(createLowerFIRRTLToHWPass(enableAnnotationWarning.getValue()));
-    pm.addPass(sv::createHWMemSimImplPass());
+    pm.addPass(sv::createHWMemSimImplPass(replSeqMem));
 
     if (extractTestCode)
       pm.addPass(sv::createSVExtractTestCodePass());


### PR DESCRIPTION
Add the `--repl-seq-mem` option to enable memory lowering for macro
 substitution and metadata emission. 
 Changes in this PR:
 1. Enable metadata emission by default, except memory metadata
 2. Add an option `repl-seq-mem` to enable memory metadata emission
 3. Add an option `repl-seq-mem` to generate external module 
    for certain FIRRTL memories, that are candidates for macro substitution.
 4. The requirements for macro replacement:
       1. read latency and write latency of one.
       2. only one readwrite port or write port.
       3. zero or one read port.
       4. undefined read-under-write behavior.


This a subset of changes from the approved PR https://github.com/llvm/circt/pull/1957