### PR TITLE
[FIRRTL] Add lowering support for assert `guards` and `format` attrs

### DIFF
--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -406,53 +406,78 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     in %aEn: !firrtl.uint<1>, in %bCond: !firrtl.uint<1>, in %bEn: !firrtl.uint<1>,
     in %cCond: !firrtl.uint<1>, in %cEn: !firrtl.uint<1>, in %value: !firrtl.uint<42>) {
 
-    // CHECK-NEXT: [[TMP:%.+]] = comb.and %aEn, %aCond : i1
-    // CHECK-NEXT: sv.assert.concurrent posedge %clock, [[TMP]] message "assert0"
-    // CHECK-NEXT: [[TMP:%.+]] = comb.and %aEn, %aCond : i1
-    // CHECK-NEXT: sv.assert.concurrent posedge %clock, [[TMP]] label "assert_0" message "assert0"
-    // CHECK-NEXT: [[TMP:%.+]] = comb.and %aEn, %aCond : i1
-    // CHECK-NEXT: sv.assert.concurrent posedge %clock, [[TMP]] message "assert0"(%value) : i42
-    // CHECK-NEXT: [[TMP:%.+]] = comb.and %bEn, %bCond : i1
-    // CHECK-NEXT: sv.assume.concurrent posedge %clock, [[TMP]] message "assume0"
-    // CHECK-NEXT: [[TMP:%.+]] = comb.and %bEn, %bCond : i1
-    // CHECK-NEXT: sv.assume.concurrent posedge %clock, [[TMP]] label "assume_0" message "assume0"
-    // CHECK-NEXT: [[TMP:%.+]] = comb.and %bEn, %bCond : i1
-    // CHECK-NEXT: sv.assume.concurrent posedge %clock, [[TMP]] message "assume0"(%value) : i42
-    // CHECK-NEXT: [[TMP:%.+]] = comb.and %cEn, %cCond : i1
-    // CHECK-NEXT: sv.cover.concurrent posedge %clock, [[TMP]]
-    // CHECK-NEXT: [[TMP:%.+]] = comb.and %cEn, %cCond : i1
-    // CHECK-NEXT: sv.cover.concurrent posedge %clock, [[TMP]] label "cover_0"
-    // CHECK: sv.cover.concurrent negedge %clock, {{%.+}} label "cover_1"
-    // CHECK: sv.cover.concurrent edge %clock, {{%.+}} label "cover_2"
     firrtl.assert %clock, %aCond, %aEn, "assert0" {isConcurrent = true}
     firrtl.assert %clock, %aCond, %aEn, "assert0" {isConcurrent = true, name = "assert_0"}
     firrtl.assert %clock, %aCond, %aEn, "assert0"(%value) : !firrtl.uint<42> {isConcurrent = true}
+    // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
+    // CHECK-NEXT: [[TMP1:%.+]] = comb.xor %aEn, [[TRUE]]
+    // CHECK-NEXT: [[TMP2:%.+]] = comb.or [[TMP1]], %aCond
+    // CHECK-NEXT: sv.assert.concurrent posedge %clock, [[TMP2]] message "assert0"
+    // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
+    // CHECK-NEXT: [[TMP3:%.+]] = comb.xor %aEn, [[TRUE]]
+    // CHECK-NEXT: [[TMP4:%.+]] = comb.or [[TMP3]], %aCond
+    // CHECK-NEXT: sv.assert.concurrent posedge %clock, [[TMP4]] label "assert__assert_0" message "assert0"
+    // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
+    // CHECK-NEXT: [[TMP5:%.+]] = comb.xor %aEn, [[TRUE]]
+    // CHECK-NEXT: [[TMP6:%.+]] = comb.or [[TMP5]], %aCond
+    // CHECK-NEXT: sv.assert.concurrent posedge %clock, [[TMP6]] message "assert0"(%value) : i42
+    // CHECK-NEXT: sv.ifdef "USE_PROPERTY_AS_CONSTRAINT" {
+    // CHECK-NEXT:   sv.assume.concurrent posedge %clock, [[TMP2]]
+    // CHECK-NEXT:   sv.assume.concurrent posedge %clock, [[TMP4]] label "assume__assert_0"
+    // CHECK-NEXT:   sv.assume.concurrent posedge %clock, [[TMP6]]
+    // CHECK-NEXT: }
     firrtl.assume %clock, %bCond, %bEn, "assume0" {isConcurrent = true}
     firrtl.assume %clock, %bCond, %bEn, "assume0" {isConcurrent = true, name = "assume_0"}
     firrtl.assume %clock, %bCond, %bEn, "assume0"(%value) : !firrtl.uint<42> {isConcurrent = true}
+    // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
+    // CHECK-NEXT: [[TMP1:%.+]] = comb.xor %bEn, [[TRUE]]
+    // CHECK-NEXT: [[TMP2:%.+]] = comb.or [[TMP1]], %bCond
+    // CHECK-NEXT: sv.assume.concurrent posedge %clock, [[TMP2]] message "assume0"
+    // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
+    // CHECK-NEXT: [[TMP1:%.+]] = comb.xor %bEn, [[TRUE]]
+    // CHECK-NEXT: [[TMP2:%.+]] = comb.or [[TMP1]], %bCond
+    // CHECK-NEXT: sv.assume.concurrent posedge %clock, [[TMP2]] label "assume__assume_0" message "assume0"
+    // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
+    // CHECK-NEXT: [[TMP1:%.+]] = comb.xor %bEn, [[TRUE]]
+    // CHECK-NEXT: [[TMP2:%.+]] = comb.or [[TMP1]], %bCond
+    // CHECK-NEXT: sv.assume.concurrent posedge %clock, [[TMP2]] message "assume0"(%value) : i42
     firrtl.cover %clock, %cCond, %cEn, "cover0" {isConcurrent = true}
     firrtl.cover %clock, %cCond, %cEn, "cover0" {isConcurrent = true, name = "cover_0"}
     firrtl.cover %clock, %cCond, %cEn, "cover0"(%value) : !firrtl.uint<42> {isConcurrent = true}
+    // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
+    // CHECK-NEXT: [[TMP1:%.+]] = comb.xor %cEn, [[TRUE]]
+    // CHECK-NEXT: [[TMP2:%.+]] = comb.or [[TMP1]], %cCond
+    // CHECK-NEXT: sv.cover.concurrent posedge %clock, [[TMP2]]
+    // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
+    // CHECK-NEXT: [[TMP1:%.+]] = comb.xor %cEn, [[TRUE]]
+    // CHECK-NEXT: [[TMP2:%.+]] = comb.or [[TMP1]], %cCond
+    // CHECK-NEXT: sv.cover.concurrent posedge %clock, [[TMP2]] label "cover__cover_0"
+    // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
+    // CHECK-NEXT: [[TMP1:%.+]] = comb.xor %cEn, [[TRUE]]
+    // CHECK-NEXT: [[TMP2:%.+]] = comb.or [[TMP1]], %cCond
+    // CHECK-NEXT: sv.cover.concurrent posedge %clock, [[TMP2]]
     firrtl.cover %clock, %cCond, %cEn, "cover1" {eventControl = 1 : i32, isConcurrent = true, name = "cover_1"}
     firrtl.cover %clock, %cCond, %cEn, "cover2" {eventControl = 2 : i32, isConcurrent = true, name = "cover_2"}
+    // CHECK: sv.cover.concurrent negedge %clock, {{%.+}} label "cover__cover_1"
+    // CHECK: sv.cover.concurrent edge %clock, {{%.+}} label "cover__cover_2"
 
     // CHECK-NEXT: sv.always posedge %clock {
     // CHECK-NEXT:   sv.if %aEn {
     // CHECK-NEXT:     sv.assert %aCond, immediate message "assert0"
-    // CHECK-NEXT:     sv.assert %aCond, immediate label "assert_0" message "assert0"
+    // CHECK-NEXT:     sv.assert %aCond, immediate label "assert__assert_0" message "assert0"
     // CHECK-NEXT:     sv.assert %aCond, immediate message "assert0"(%value) : i42
     // CHECK-NEXT:   }
     // CHECK-NEXT:   sv.if %bEn {
     // CHECK-NEXT:     sv.assume %bCond, immediate message "assume0"
-    // CHECK-NEXT:     sv.assume %bCond, immediate label "assume_0" message "assume0"
+    // CHECK-NEXT:     sv.assume %bCond, immediate label "assume__assume_0" message "assume0"
     // CHECK-NEXT:     sv.assume %bCond, immediate message "assume0"(%value) : i42
     // CHECK-NEXT:   }
     // CHECK-NEXT:   sv.if %cEn {
     // CHECK-NEXT:     sv.cover %cCond, immediate
-    // CHECK-NOT:                       label
-    // CHECK-NEXT:     sv.cover %cCond, immediate label "cover_0"
+    // CHECK-NOT:        label
+    // CHECK-NEXT:     sv.cover %cCond, immediate label "cover__cover_0"
     // CHECK-NEXT:     sv.cover %cCond, immediate
-    // CHECK-NOT:                       label
+    // CHECK-NOT:        label
     // CHECK-NEXT:   }
     // CHECK-NEXT: }
     firrtl.assert %clock, %aCond, %aEn, "assert0"
@@ -465,6 +490,77 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.cover %clock, %cCond, %cEn, "cover0" {name = "cover_0"}
     firrtl.cover %clock, %cCond, %cEn, "cover0"(%value) : !firrtl.uint<42>
     // CHECK-NEXT: hw.output
+  }
+
+  // CHECK-LABEL: hw.module @VerificationGuards
+  firrtl.module @VerificationGuards(
+    in %clock: !firrtl.clock,
+    in %cond: !firrtl.uint<1>,
+    in %enable: !firrtl.uint<1>
+  ) {
+    firrtl.assert %clock, %cond, %enable, "assert0" {isConcurrent = true, guards = ["HELLO", "WORLD"]}
+    // CHECK-NEXT: sv.ifdef "HELLO" {
+    // CHECK-NEXT:   sv.ifdef "WORLD" {
+    // CHECK-NEXT:     [[TRUE:%.+]] = hw.constant true
+    // CHECK-NEXT:     [[TMP1:%.+]] = comb.xor %enable, [[TRUE]]
+    // CHECK-NEXT:     [[TMP2:%.+]] = comb.or [[TMP1]], %cond
+    // CHECK-NEXT:     sv.assert.concurrent posedge %clock, [[TMP2]] message "assert0"
+    // CHECK-NEXT:     sv.ifdef "USE_PROPERTY_AS_CONSTRAINT" {
+    // CHECK-NEXT:       sv.assume.concurrent posedge %clock, [[TMP2]]
+    // CHECK-NEXT:     }
+    // CHECK-NEXT:   }
+    // CHECK-NEXT: }
+    firrtl.assume %clock, %cond, %enable, "assume0" {isConcurrent = true, guards = ["HELLO", "WORLD"]}
+    firrtl.cover %clock, %cond, %enable, "cover0" {isConcurrent = true, guards = ["HELLO", "WORLD"]}
+    // CHECK-NEXT: sv.ifdef "HELLO" {
+    // CHECK-NEXT:   sv.ifdef "WORLD" {
+    // CHECK-NEXT:     [[TRUE:%.+]] = hw.constant true
+    // CHECK-NEXT:     [[TMP1:%.+]] = comb.xor %enable, [[TRUE]]
+    // CHECK-NEXT:     [[TMP2:%.+]] = comb.or [[TMP1]], %cond
+    // CHECK-NEXT:     sv.assume.concurrent posedge %clock, [[TMP2]] message "assume0"
+    // CHECK-NEXT:     [[TRUE:%.+]] = hw.constant true
+    // CHECK-NEXT:     [[TMP1:%.+]] = comb.xor %enable, [[TRUE]]
+    // CHECK-NEXT:     [[TMP2:%.+]] = comb.or [[TMP1]], %cond
+    // CHECK-NEXT:     sv.cover.concurrent posedge %clock, [[TMP2]]
+    // CHECK-NOT:      label
+    // CHECK-NEXT:   }
+    // CHECK-NEXT: }
+  }
+
+  // CHECK-LABEL: hw.module @VerificationAssertFormat
+  firrtl.module @VerificationAssertFormat(
+    in %clock: !firrtl.clock,
+    in %cond: !firrtl.uint<1>,
+    in %enable: !firrtl.uint<1>,
+    in %value: !firrtl.uint<42>
+  ) {
+    firrtl.assert %clock, %cond, %enable, "assert0" {isConcurrent = true, format = "sva"}
+    // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
+    // CHECK-NEXT: [[TMP1:%.+]] = comb.xor %enable, [[TRUE]]
+    // CHECK-NEXT: [[TMP2:%.+]] = comb.or [[TMP1]], %cond
+    // CHECK-NEXT: sv.assert.concurrent posedge %clock, [[TMP2]] message "assert0"
+    // CHECK-NEXT: sv.ifdef "USE_PROPERTY_AS_CONSTRAINT" {
+    // CHECK-NEXT:   sv.assume.concurrent posedge %clock, [[TMP2]]
+    // CHECK-NEXT: }
+    firrtl.assert %clock, %cond, %enable, "assert1"(%value) : !firrtl.uint<42> {isConcurrent = true, format = "ifElseFatal"}
+    // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
+    // CHECK-NEXT: [[TMP1:%.+]] = comb.xor %cond, [[TRUE]]
+    // CHECK-NEXT: [[TMP2:%.+]] = comb.and %enable, [[TMP1]]
+    // CHECK-NEXT: sv.always posedge %clock {
+    // CHECK-NEXT:   sv.ifdef.procedural "SYNTHESIS" {
+    // CHECK-NEXT:   } else {
+    // CHECK-NEXT:     sv.if [[TMP2]] {
+    // CHECK-NEXT:       [[ASSERT_VERBOSE_COND:%.+]] = sv.verbatim.expr "`ASSERT_VERBOSE_COND_"
+    // CHECK-NEXT:       sv.if [[ASSERT_VERBOSE_COND]] {
+    // CHECK-NEXT:         sv.error "assert1"(%value) : i42
+    // CHECK-NEXT:       }
+    // CHECK-NEXT:       [[STOP_COND:%.+]] = sv.verbatim.expr "`STOP_COND_"
+    // CHECK-NEXT:       sv.if [[STOP_COND]] {
+    // CHECK-NEXT:         sv.fatal
+    // CHECK-NEXT:       }
+    // CHECK-NEXT:     }
+    // CHECK-NEXT:   }
+    // CHECK-NEXT: }
   }
 
   firrtl.module @bar(in %io_cpu_flush: !firrtl.uint<1>) {

--- a/test/Dialect/FIRRTL/SFCTests/complex-asserts.fir
+++ b/test/Dialect/FIRRTL/SFCTests/complex-asserts.fir
@@ -1,0 +1,148 @@
+; RUN: firtool --verify-diagnostics --verilog %s | FileCheck %s
+; Tests extracted from:
+; - test/scala/firrtl/extractverif/ExtractAssertsSpec.scala
+
+circuit Foo:
+  module Foo:
+    input clock : Clock
+    input reset : AsyncReset
+    input predicate1 : UInt<1>
+    input predicate2 : UInt<1>
+    input predicate3 : UInt<1>
+    input predicate4 : UInt<1>
+    input predicate5 : UInt<1>
+    input predicate6 : UInt<1>
+    input predicate7 : UInt<1>
+    input predicate8 : UInt<1>
+    input predicate9 : UInt<1>
+    input predicate10 : UInt<1>
+    input enable : UInt<1>
+    input other : UInt<1>
+    input sum : UInt<42>
+
+    ; CHECK: always @(posedge clock) begin
+    ; CHECK-NEXT: `ifndef SYNTHESIS
+
+    ; assert with predicate only
+    ; CHECK-NEXT: if (enable & ~(predicate1 | reset)) begin
+    ; CHECK-NEXT:   if (`ASSERT_VERBOSE_COND_)
+    ; CHECK-NEXT:     $error("Assertion failed (verification library): ");
+    ; CHECK-NEXT:   if (`STOP_COND_)
+    ; CHECK-NEXT:     $fatal;
+    ; CHECK-NEXT: end
+    when not(or(predicate1, asUInt(reset))) :
+      printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"format\":{\"type\":\"ifElseFatal\"},\"baseMsg\":\"Assertion failed (verification library): \"}</extraction-summary> bar")
+      stop(clock, enable, 1)
+
+    ; assert with message
+    ; CHECK-NEXT: if (enable & ~(predicate2 | reset)) begin
+    ; CHECK-NEXT:   if (`ASSERT_VERBOSE_COND_)
+    ; CHECK-NEXT:     $error("Assertion failed (verification library): sum =/= 1.U");
+    ; CHECK-NEXT:   if (`STOP_COND_)
+    ; CHECK-NEXT:     $fatal;
+    ; CHECK-NEXT: end
+    when not(or(predicate2, asUInt(reset))) :
+      printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"format\":{\"type\":\"ifElseFatal\"},\"baseMsg\":\"Assertion failed (verification library): sum =/= 1.U\"}</extraction-summary> bar")
+      stop(clock, enable, 1)
+
+    ; assert with when
+    ; CHECK-NEXT: if (other & enable & ~(predicate3 | reset)) begin
+    ; CHECK-NEXT:   if (`ASSERT_VERBOSE_COND_)
+    ; CHECK-NEXT:     $error("Assertion failed (verification library): Assert with when");
+    ; CHECK-NEXT:   if (`STOP_COND_)
+    ; CHECK-NEXT:     $fatal;
+    ; CHECK-NEXT: end
+    when other :
+      when not(or(predicate3, asUInt(reset))) :
+        printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"format\":{\"type\":\"ifElseFatal\"},\"baseMsg\":\"Assertion failed (verification library): Assert with when\"}</extraction-summary> bar")
+        stop(clock, enable, 1)
+
+    ; assert with message with arguments
+    ; CHECK-NEXT: if (enable & ~(predicate4 | reset)) begin
+    ; CHECK-NEXT:   if (`ASSERT_VERBOSE_COND_)
+    ; CHECK-NEXT:     $error("Assertion failed (verification library): expected sum === 2.U but got %d", sum);
+    ; CHECK-NEXT:   if (`STOP_COND_)
+    ; CHECK-NEXT:     $fatal;
+    ; CHECK-NEXT: end
+    when not(or(predicate4, asUInt(reset))) :
+      printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"format\":{\"type\":\"ifElseFatal\"},\"baseMsg\":\"Assertion failed (verification library): expected sum === 2.U but got %d\"}</extraction-summary> bar", sum)
+      stop(clock, enable, 1)
+
+    ; CHECK-NEXT: `endif
+    ; CHECK-NEXT: end
+
+
+    ; assert emitted as SVA
+    ; CHECK-NEXT: wire [[TMP1:.+]] = ~enable | predicate5 | reset;
+    ; CHECK-NEXT: assert__verif_library: assert property (@(posedge clock) [[TMP1]])
+    ; CHECK-SAME:   else $error("Assertion failed (verification library): SVA assert example");
+    when not(or(predicate5, asUInt(reset))) :
+      printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"format\":{\"type\":\"sva\"},\"baseMsg\":\"Assertion failed (verification library): SVA assert example\"}</extraction-summary> bar")
+      stop(clock, enable, 1)
+
+    ; assert with custom label
+    ; CHECK-NEXT: wire [[TMP2:.+]] = ~enable | predicate6 | reset;
+    ; CHECK-NEXT: assert__verif_library_hello_world: assert property (@(posedge clock) [[TMP2]])
+    ; CHECK-SAME:   else $error("Assertion failed (verification library): Custom label example");
+    when not(or(predicate6, asUInt(reset))) :
+      printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"format\":{\"type\":\"sva\"},\"labelExts\":[\"hello\",\"world\"],\"baseMsg\":\"Assertion failed (verification library): Custom label example\"}</extraction-summary> bar")
+      stop(clock, enable, 1)
+
+    ; assert with predicate option for X-passing
+    ; CHECK-NEXT: wire [[TMP3:.+]] = ~enable | ~(~predicate7 | ~predicate7 === 1'bx);
+    ; CHECK-NEXT: assert__verif_library_2: assert property (@(posedge clock) [[TMP3]])
+    ; CHECK-SAME:   else $error("Assertion failed (verification library): X-passing assert example");
+    when not(predicate7) :
+      printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"trueOrIsX\"},\"format\":{\"type\":\"sva\"},\"baseMsg\":\"Assertion failed (verification library): X-passing assert example\"}</extraction-summary> bar")
+      stop(clock, enable, 1)
+
+    ; The companion assumes get bunched up in an ifdef block.
+    ; CHECK-NEXT: `ifdef USE_PROPERTY_AS_CONSTRAINT
+    ; CHECK-NEXT:   assume__verif_library: assume property (@(posedge clock) [[TMP1]]);
+    ; CHECK-NEXT:   assume__verif_library_hello_world: assume property (@(posedge clock) [[TMP2]]);
+    ; CHECK-NEXT:   assume__verif_library_3: assume property (@(posedge clock) [[TMP3]]);
+    ; CHECK-NEXT: `endif
+
+
+    ; assert with toggle option e.g. UNROnly
+    ; CHECK-NEXT: `ifdef USE_UNR_ONLY_CONSTRAINTS
+    ; CHECK-NEXT:   wire [[TMP4:.+]] = ~enable | predicate8 | reset;
+    ; CHECK-NEXT:   assert__verif_library_5: assert property (@(posedge clock) [[TMP4]])
+    ; CHECK-SAME:     else $error("Assertion failed (verification library): Conditional compilation example for UNR-only assert");
+    ; CHECK-NEXT:   `ifdef USE_PROPERTY_AS_CONSTRAINT
+    ; CHECK-NEXT:     assume__verif_library_6: assume property (@(posedge clock) [[TMP4]]);
+    ; CHECK-NEXT:   `endif
+    when not(or(predicate8, asUInt(reset))) :
+      printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"}],\"format\":{\"type\":\"sva\"},\"baseMsg\":\"Assertion failed (verification library): Conditional compilation example for UNR-only assert\"}</extraction-summary> bar")
+      stop(clock, enable, 1)
+
+    ; if-else-fatal style assert with conditional compilation toggles
+    ; CHECK-NEXT:   always @(posedge clock) begin
+    ; CHECK-NEXT:   `ifndef SYNTHESIS
+    ; CHECK-NEXT:     if (enable & ~(predicate9 | reset)) begin
+    ; CHECK-NEXT:       if (`ASSERT_VERBOSE_COND_)
+    ; CHECK-NEXT:         $error("Assertion failed (verification library): Conditional compilation example with if-else-fatal style assert");
+    ; CHECK-NEXT:       if (`STOP_COND_)
+    ; CHECK-NEXT:         $fatal;
+    ; CHECK-NEXT:     end
+    ; CHECK-NEXT:   `endif
+    ; CHECK-NEXT:   end
+    ; CHECK-NEXT: `endif
+    when not(or(predicate9, asUInt(reset))) :
+      printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"}],\"format\":{\"type\":\"ifElseFatal\"},\"baseMsg\":\"Assertion failed (verification library): Conditional compilation example with if-else-fatal style assert\"}</extraction-summary> bar")
+      stop(clock, enable, 1)
+
+    ; assert with multiple toggle options
+    ; CHECK-NEXT: `ifdef USE_FORMAL_ONLY_CONSTRAINTS
+    ; CHECK-NEXT:   `ifdef USE_UNR_ONLY_CONSTRAINTS
+    ; CHECK-NEXT:     wire [[TMP5:.+]] = ~enable | predicate10 | reset;
+    ; CHECK-NEXT:     assert__verif_library_8: assert property (@(posedge clock) [[TMP5]])
+    ; CHECK-SAME:       else $error("Assertion failed (verification library): Conditional compilation example for UNR-only and formal-only assert");
+    ; CHECK-NEXT:     `ifdef USE_PROPERTY_AS_CONSTRAINT
+    ; CHECK-NEXT:       assume__verif_library_9: assume property (@(posedge clock) [[TMP5]]);
+    ; CHECK-NEXT:     `endif
+    ; CHECK-NEXT:   `endif
+    ; CHECK-NEXT: `endif
+    when not(or(predicate10, asUInt(reset))) :
+      printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"formalOnly\"},{\"type\":\"unrOnly\"}],\"format\":{\"type\":\"sva\"},\"baseMsg\":\"Assertion failed (verification library): Conditional compilation example for UNR-only and formal-only assert\"}</extraction-summary> bar")
+      stop(clock, enable, 1)

--- a/test/Dialect/FIRRTL/SFCTests/complex-assumes.fir
+++ b/test/Dialect/FIRRTL/SFCTests/complex-assumes.fir
@@ -1,0 +1,82 @@
+; RUN: firtool --verify-diagnostics --verilog %s | FileCheck %s
+; Tests extracted from:
+; - test/scala/firrtl/extractverif/ExtractAssumesSpec.scala
+
+circuit Foo:
+  module Foo:
+    input clock : Clock
+    input reset : AsyncReset
+    input predicate1 : UInt<1>
+    input predicate2 : UInt<1>
+    input predicate3 : UInt<1>
+    input predicate4 : UInt<1>
+    input predicate5 : UInt<1>
+    input predicate6 : UInt<1>
+    input predicate7 : UInt<1>
+    input predicate8 : UInt<1>
+    input enable : UInt<1>
+    input other : UInt<1>
+    input sum : UInt<42>
+
+    ; assume with predicate only
+    ; CHECK: {{assume__verif_library.*}}: assume property (@(posedge clock) ~enable | predicate1 | reset)
+    ; CHECK-SAME:   else $error("Assumption does not hold (verification library): ");
+    when not(or(predicate1, asUInt(reset))) :
+      printf(clock, enable, "foo [verif-library-assume]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"baseMsg\":\"Assumption does not hold (verification library): \"}</extraction-summary> bar")
+      stop(clock, enable, 1)
+
+    ; assume with message
+    ; CHECK-NEXT: {{assume__verif_library.*}}: assume property (@(posedge clock) ~enable | predicate2 | reset)
+    ; CHECK-SAME:   else $error("Assumption does not hold (verification library): sum =/= 1.U");
+    when not(or(predicate2, asUInt(reset))) :
+      printf(clock, enable, "foo [verif-library-assume]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"baseMsg\":\"Assumption does not hold (verification library): sum =/= 1.U\"}</extraction-summary> bar")
+      stop(clock, enable, 1)
+
+    ; assume with when
+    ; CHECK-NEXT: {{assume__verif_library.*}}: assume property (@(posedge clock) ~(other & enable) | predicate3 | reset)
+    ; CHECK-SAME:   else $error("Assumption does not hold (verification library): assume with when");
+    when other :
+      when not(or(predicate3, asUInt(reset))) :
+        printf(clock, enable, "foo [verif-library-assume]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"baseMsg\":\"Assumption does not hold (verification library): assume with when\"}</extraction-summary> bar")
+        stop(clock, enable, 1)
+
+    ; assume with message with arguments
+    ; CHECK-NEXT: {{assume__verif_library.*}}: assume property (@(posedge clock) ~enable | predicate4 | reset)
+    ; CHECK-SAME:   else $error("Assumption does not hold (verification library): expected sum === 2.U but got %d", sum);
+    when not(or(predicate4, asUInt(reset))) :
+      printf(clock, enable, "foo [verif-library-assume]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"baseMsg\":\"Assumption does not hold (verification library): expected sum === 2.U but got %d\"}</extraction-summary> bar", sum)
+      stop(clock, enable, 1)
+
+    ; assume with custom label
+    ; CHECK-NEXT: assume__verif_library_hello_world: assume property (@(posedge clock) ~enable | predicate5 | reset)
+    ; CHECK-SAME:   else $error("Assumption does not hold (verification library): Custom label example");
+    when not(or(predicate5, asUInt(reset))) :
+      printf(clock, enable, "foo [verif-library-assume]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"labelExts\":[\"hello\",\"world\"],\"baseMsg\":\"Assumption does not hold (verification library): Custom label example\"}</extraction-summary> bar")
+      stop(clock, enable, 1)
+
+    ; assume with predicate option for X-passing
+    ; CHECK-NEXT: {{assume__verif_library.*}}: assume property (@(posedge clock) ~enable | ~(~predicate6 | ~predicate6 === 1'bx))
+    ; CHECK-SAME:   else $error("Assumption does not hold (verification library): X-passing assume example");
+    when not(predicate6) :
+      printf(clock, enable, "foo [verif-library-assume]<extraction-summary>{\"predicateModifier\":{\"type\":\"trueOrIsX\"},\"baseMsg\":\"Assumption does not hold (verification library): X-passing assume example\"}</extraction-summary> bar")
+      stop(clock, enable, 1)
+
+    ; assume with toggle option e.g. UNROnly
+    ; CHECK-NEXT: `ifdef USE_UNR_ONLY_CONSTRAINTS
+    ; CHECK-NEXT:   {{assume__verif_library.*}}: assume property (@(posedge clock) ~enable | predicate7 | reset)
+    ; CHECK-SAME:     else $error("Assumption does not hold (verification library): Conditional compilation example for UNR-only assume");
+    ; CHECK-NEXT: `endif
+    when not(or(predicate7, asUInt(reset))) :
+      printf(clock, enable, "foo [verif-library-assume]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"}],\"baseMsg\":\"Assumption does not hold (verification library): Conditional compilation example for UNR-only assume\"}</extraction-summary> bar")
+      stop(clock, enable, 1)
+
+    ; assume with multiple toggle options
+    ; CHECK-NEXT: `ifdef USE_FORMAL_ONLY_CONSTRAINTS
+    ; CHECK-NEXT:   `ifdef USE_UNR_ONLY_CONSTRAINTS
+    ; CHECK-NEXT:     {{assume__verif_library.*}}: assume property (@(posedge clock) ~enable | predicate8 | reset)
+    ; CHECK-SAME:       else $error("Assumption does not hold (verification library): Conditional compilation example for UNR-only and formal-only assume");
+    ; CHECK-NEXT:   `endif
+    ; CHECK-NEXT: `endif
+    when not(or(predicate8, asUInt(reset))) :
+      printf(clock, enable, "foo [verif-library-assume]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"formalOnly\"},{\"type\":\"unrOnly\"}],\"baseMsg\":\"Assumption does not hold (verification library): Conditional compilation example for UNR-only and formal-only assume\"}</extraction-summary> bar")
+      stop(clock, enable, 1)


### PR DESCRIPTION
Extend the FIRRTL `LowerToHW` pass in three ways:

1.  Honor the `guards` array attribute on assert, assume, and cover operations and wrap the resulting SV dialect operations in the appropriate ifdef blocks.

2.  Honor the `format` attribute on assert and add support for `ifElseFatal` emission. This converts assertions to always processes which use `$error` and `$fatal` to implement the assertion. This should actually be a lowering option instead of an attribute on the operation (because it is more related to the downstream tool than any functionality in the RTL), but doing it this way matches the current Scala FIRRTL implementation.

3.  For concurrent asserts, emit a companion assume property gated by a preprocessor macro. This matches the current Scala FIRRTL implementation.

### Todo
- [x] Land #1989