### PR TITLE
[FIRRTL] Mark extmodules that had black box anno consumed

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
@@ -137,7 +137,14 @@ void BlackBoxReaderPass::runOnOperation() {
 
     SmallVector<Attribute, 4> filteredAnnos;
     for (auto anno : AnnotationSet(&op)) {
-      if (!runOnAnnotation(&op, anno, builder))
+      if (runOnAnnotation(&op, anno, builder))
+        // Since the annotation was consumed, add a `BlackBox` annotation to
+        // indicate that this extmodule was provided by one of the black box
+        // annotations. This is useful for metadata generation.
+        filteredAnnos.push_back(builder.getDictionaryAttr(
+            {{builder.getIdentifier("class"),
+              builder.getStringAttr("firrtl.transforms.BlackBox")}}));
+      else
         filteredAnnos.push_back(anno.getDict());
     }
 

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -360,7 +360,8 @@ LogicalResult CreateSiFiveMetadataPass::emitSitestBlackboxMetadata() {
   std::array<StringRef, 3> classBlackList = {
       "freechips.rocketchip.util.BlackBoxedROM", "chisel3.shim.CloneModule",
       "sifive.enterprise.grandcentral.MemTap"};
-  std::array<StringRef, 5> blackListedAnnos = {
+  std::array<StringRef, 6> blackListedAnnos = {
+      "firrtl.transforms.BlackBox",
       "firrtl.transforms.BlackBoxInlineAnno",
       "firrtl.transforms.BlackBoxResourceAnno",
       "sifive.enterprise.grandcentral.DataTapsAnnotation",

--- a/test/Dialect/FIRRTL/SFCTests/emit-metadata.fir
+++ b/test/Dialect/FIRRTL/SFCTests/emit-metadata.fir
@@ -1,0 +1,19 @@
+; RUN: firtool --verify-diagnostics --verilog --emit-metadata %s | FileCheck %s
+
+circuit Foo : %[[{
+  "class": "firrtl.transforms.BlackBoxInlineAnno",
+  "name": "hello.v",
+  "text": "// world",
+  "target": "~Foo|Foo"
+},{
+  "class": "sifive.enterprise.firrtl.SitestBlackBoxAnnotation",
+  "filename": "blackboxes.json"
+}]]
+  ; An inline blackbox should not appear in the generated metadata.
+  extmodule Foo :
+    input clock : Clock
+    defname = Foo
+
+; CHECK-LABEL: FILE "blackboxes.json"
+; CHECK-EMPTY:
+; CHECK-NEXT: []

--- a/test/Dialect/FIRRTL/blackbox-reader.mlir
+++ b/test/Dialect/FIRRTL/blackbox-reader.mlir
@@ -1,0 +1,8 @@
+// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-blackbox-reader)' %s | FileCheck %s
+
+firrtl.circuit "Foo" {
+  // CHECK-LABEL: firrtl.extmodule @Foo()
+  // CHECK-NOT: class = "firrtl.transforms.BlackBoxInlineAnno"
+  // CHECK-SAME: class = "firrtl.transforms.BlackBox"
+  firrtl.extmodule @Foo() attributes {annotations = [{class = "firrtl.transforms.BlackBoxInlineAnno", name = "hello.v", text = "// world"}]}
+}

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -89,6 +89,7 @@ firrtl.circuit "BasicBlackboxes" attributes { annotations = [{
   firrtl.extmodule @ignored3() attributes {annotations = [{class = "sifive.enterprise.grandcentral.DataTapsAnnotation"}], defname = "ignored3"}
   firrtl.extmodule @ignored4() attributes {annotations = [{class = "sifive.enterprise.grandcentral.MemTapAnnotation", id = 4 : i64}], defname = "ignored4"}
   firrtl.extmodule @ignored5() attributes {annotations = [{class = "sifive.enterprise.grandcentral.transforms.SignalMappingAnnotation"}], defname = "ignored5"}
+  firrtl.extmodule @ignored6() attributes {annotations = [{class = "firrtl.transforms.BlackBox"}], defname = "ignored6"}
 
   // Gracefully handle missing defnames.
   firrtl.extmodule @NoDefName()


### PR DESCRIPTION
Fix an issue where generating metadata after the blackbox reader pass has run would cause additional blackbox modules to appear in the generated metadata. This happens because the blackbox reader removes the blackbox annotations, which the metadata pass is looking for to blacklist the corresponding extmodules.

This change causes the blackbox reader pass to add a `BlackBox` annotation on any extmodule for which it has processed one of the blackbox annotations. The metadata pass then additionally blacklists this annotation. Also add a unit and integration test to ensure this happens.

Fixes an issue in the SiFive flow (@Ramlakshmi3733).