### PR TITLE
[MSFT] [DeviceDB] Teach `walkPlacements` about boundaries

### DIFF
--- a/include/circt-c/Dialect/MSFT.h
+++ b/include/circt-c/Dialect/MSFT.h
@@ -25,7 +25,7 @@ MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(MSFT, msft);
 MLIR_CAPI_EXPORTED void mlirMSFTRegisterPasses();
 
 // Values represented in `MSFT.td`.
-typedef uint32_t CirctMSFTPrimitiveType;
+typedef int32_t CirctMSFTPrimitiveType;
 
 /// Emits tcl for the specified module using the provided callback and user
 /// data
@@ -41,8 +41,8 @@ MLIR_CAPI_EXPORTED MlirLogicalResult mlirMSFTExportTcl(MlirOperation,
 /// and y coordinates, and number.
 MLIR_CAPI_EXPORTED void mlirMSFTAddPhysLocationAttr(MlirOperation op,
                                                     const char *entityName,
-                                                    PrimitiveType type, long x,
-                                                    long y, long num);
+                                                    CirctMSFTPrimitiveType type,
+                                                    long x, long y, long num);
 
 bool circtMSFTAttributeIsAPhysLocationAttribute(MlirAttribute);
 MlirAttribute circtMSFTPhysLocationAttrGet(MlirContext, CirctMSFTPrimitiveType,
@@ -121,9 +121,12 @@ MlirAttribute circtMSFTPlacementDBGetNearestFreeInColumn(
 typedef void (*CirctMSFTPlacementCallback)(MlirAttribute loc,
                                            CirctMSFTPlacedInstance,
                                            void *userData);
-/// Walk all the placements. Set 'colNo' to -1 to walk all of the columns.
-void circtMSFTPlacementDBWalkPlacements(CirctMSFTPlacementDB, int64_t colNo,
+/// Walk all the placements within 'bounds' ([xmin, xmax, ymin, ymax], inclusive
+/// on all sides), with -1 meaning unbounded.
+void circtMSFTPlacementDBWalkPlacements(CirctMSFTPlacementDB,
                                         CirctMSFTPlacementCallback,
+                                        int64_t bounds[4],
+                                        CirctMSFTPrimitiveType primTypeFilter,
                                         void *userData);
 
 #ifdef __cplusplus

--- a/include/circt/Dialect/MSFT/DeviceDB.h
+++ b/include/circt/Dialect/MSFT/DeviceDB.h
@@ -94,13 +94,13 @@ public:
   PhysLocationAttr getNearestFreeInColumn(PrimitiveType prim, uint64_t column,
                                           uint64_t nearestToY);
 
-  /// Walk the placement information in some sort of reasonable order.
-  void walkPlacements(function_ref<void(PhysLocationAttr, PlacedInstance)>);
-
-  /// Walk the column placements in some sort of reasonable order.
-  void
-  walkColumnPlacements(uint64_t column,
-                       function_ref<void(PhysLocationAttr, PlacedInstance)>);
+  /// Walk the placement information in some sort of reasonable order. Bounds
+  /// restricts the walk to a rectangle of [xmin, xmax, ymin, ymax] (inclusive),
+  /// with -1 meaning unbounded.
+  void walkPlacements(function_ref<void(PhysLocationAttr, PlacedInstance)>,
+                      std::tuple<int64_t, int64_t, int64_t, int64_t> bounds =
+                          std::make_tuple(-1, -1, -1, -1),
+                      Optional<PrimitiveType> primType = {});
 
 private:
   MLIRContext *ctxt;

--- a/integration_test/Bindings/Python/dialects/msft.py
+++ b/integration_test/Bindings/Python/dialects/msft.py
@@ -126,13 +126,18 @@ with ir.Context() as ctx, ir.Location.unknown():
   # CHECK: #msft.physloc<M20K, 2, 50, 1>
 
   print("=== Placements (col 2):")
-  seeded_pdb.walk_placements(print_placement, column_num=2)
+  seeded_pdb.walk_placements(print_placement, bounds=(2, 2, None, None))
   # CHECK-LABEL: === Placements (col 2):
   # CHECK: #msft.physloc<M20K, 2, 6, 1>, #msft<"@top[\22inst1\22,\22ext1\22]">
   # CHECK: #msft.physloc<M20K, 2, 50, 1>
 
+  print("=== Placements (col 2, row > 10):")
+  seeded_pdb.walk_placements(print_placement, bounds=(2, 2, 10, None))
+  # CHECK-LABEL: === Placements (col 2, row > 10):
+  # CHECK: #msft.physloc<M20K, 2, 50, 1>
+
   print("=== Placements (col 6):")
-  seeded_pdb.walk_placements(print_placement, column_num=6)
+  seeded_pdb.walk_placements(print_placement, bounds=(6, 6, None, None))
   # CHECK-LABEL: === Placements (col 6):
 
   print("=== Errors:", file=sys.stderr)

--- a/lib/CAPI/Dialect/MSFT.cpp
+++ b/lib/CAPI/Dialect/MSFT.cpp
@@ -111,8 +111,10 @@ MlirAttribute circtMSFTPlacementDBGetNearestFreeInColumn(
       db->getNearestFreeInColumn((PrimitiveType)prim, column, nearestToY));
 }
 
-void circtMSFTPlacementDBWalkPlacements(CirctMSFTPlacementDB cdb, int64_t colNo,
+void circtMSFTPlacementDBWalkPlacements(CirctMSFTPlacementDB cdb,
                                         CirctMSFTPlacementCallback ccb,
+                                        int64_t bounds[4],
+                                        CirctMSFTPrimitiveType cPrimTypeFilter,
                                         void *userData) {
   PlacementDB *db = unwrap(cdb);
   auto cb = [ccb, userData](PhysLocationAttr loc,
@@ -121,10 +123,12 @@ void circtMSFTPlacementDBWalkPlacements(CirctMSFTPlacementDB cdb, int64_t colNo,
                                           p.subpath.size(), wrap(p.op)};
     ccb(wrap(loc), cPlacement, userData);
   };
-  if (colNo >= 0)
-    db->walkColumnPlacements(colNo, cb);
-  else
-    db->walkPlacements(cb);
+  Optional<PrimitiveType> primTypeFilter;
+  if (cPrimTypeFilter >= 0)
+    primTypeFilter = static_cast<PrimitiveType>(cPrimTypeFilter);
+  db->walkPlacements(
+      cb, std::make_tuple(bounds[0], bounds[1], bounds[2], bounds[3]),
+      primTypeFilter);
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
`walkPlacements` now takes a bounding rectangle and a primitive type upon which to filter. Ditch `walkColumnPlacements`.