### PR TITLE
[FIRRTL] Donot flatten memory with Donot Touch annotation

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -716,7 +716,8 @@ void TypeLoweringVisitor::visitDecl(MemOp op) {
   // If subannotations present on aggregate fields, we cannot flatten the
   // memory. It must be split into one memory per aggregate field.
   if (flattenAggregateMemData)
-    if (hasSubAnno() || !flattenType(op.getDataType(), flatMemType))
+    if (hasSubAnno() || !flattenType(op.getDataType(), flatMemType) ||
+        AnnotationSet(op).hasDontTouch())
       flattenAggregateMemData = false;
 
   if (flattenAggregateMemData) {

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -298,6 +298,17 @@ firrtl.circuit "TopLevel" {
     // FLATTEN:  firrtl.connect %[[memory_w_data_a]], %wData_a : !firrtl.uint<8>, !firrtl.uint<8>
 
   }
+  firrtl.module @Mem2_flatten_DontTouch(in %clock: !firrtl.clock, in %rAddr: !firrtl.uint<4>, in %rEn: !firrtl.uint<1>, out
+  %rData: !firrtl.bundle<a: uint<8>, b: uint<16>>, in %wAddr: !firrtl.uint<4>, in %wEn: !firrtl.uint<1>, in %wMask:
+  !firrtl.bundle<a: uint<1>, b: uint<1>>, in %wData: !firrtl.bundle<a: uint<8>, b: uint<16>>) {
+    %memory_r, %memory_w = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r", "w"], readLatency
+    = 0 : i32, writeLatency = 1 : i32, annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a:
+    uint<8>, b: uint<16>>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<16>>, mask: bundle<a: uint<1>, b: uint<1>>>
+
+    // FLATTEN: firrtl.mem Undefined {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]
+    // FLATTEN: firrtl.mem Undefined {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]
+
+  }
 // Test that a memory with a readwrite port is split into 1r1w
 //
 // circuit Foo:


### PR DESCRIPTION
Donot flatten a  `FIRRTL` memory with `firrtl.transforms.DontTouchAnnotation` annotation.
This is to ensure that `firrtl.mem` with a memtap is correctly preserved.