### PR TITLE
[FIRRTL][Metadata] Add FileListTransform metadata

### DIFF
--- a/docs/FIRRTLAnnotations.md
+++ b/docs/FIRRTLAnnotations.md
@@ -322,6 +322,43 @@ Example:
 }
 ```
 
+### FileListAnnotation
+
+| Property   | Type   | Description                                   |
+| ---------- | ------ | -------------                                 |
+| class      | string | `sifive.enterprise.firrtl.FileListAnnotation` |
+| target     | string | Reference target                              |
+
+This annotation indicates that the target module should be added to the file
+list specified by `FileListInfoFileAnnotation`.
+
+Example:
+```json
+{
+  "class":"sifive.enterprise.firrtl.FileListAnnotation",
+  "target": "~Foo|Bar/d:Baz"
+}
+```
+
+### FileListInfoFileAnnotation
+
+| Property   | Type   | Description                                           |
+| ---------- | ------ | -------------                                         |
+| class      | string | `sifive.enterprise.firrtl.FileListInfoFileAnnotation` |
+| filename   | string | The filename with full path where it will be written  |
+
+This annotation indicates that a list of all modules annotation with
+`FileListAnnotation` should be created at `filename`. Each module name is
+separated by a newline.
+
+Example:
+```json
+{
+  "class":"sifive.enterprise.firrtl.FileListInfoFileAnnotation",
+  "filename":"filelist.txt"
+}
+```
+
 ### [FlattenAnnotation](https://www.chisel-lang.org/api/firrtl/latest/firrtl/transforms/FlattenAnnotation.html)
 
 | Property   | Type   | Description                           |

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -10,6 +10,41 @@ firrtl.circuit "empty" {
 // CHECK-NEXT:  }
 
 //===----------------------------------------------------------------------===//
+// FileList
+//===----------------------------------------------------------------------===//
+
+// Should remove the annotation when there is no file list
+firrtl.circuit "filelist_empty" {
+  firrtl.module @filelist_empty() attributes { annotations = [{
+      class = "sifive.enterprise.firrtl.FileListAnnotation"
+  }]} { }
+}
+// CHECK-LABEL: firrtl.circuit "filelist_empty"
+// CHECK-NOT: sifive.enterprise.firrtl.FileListAnnotation
+
+
+// Should put each annotated module on its own line.
+firrtl.circuit "filelist0" attributes { annotations = [{
+    class = "sifive.enterprise.firrtl.FileListInfoFileAnnotation",
+    filename = "filelist.txt"
+}]} {
+
+  firrtl.module @filelist0() attributes { annotations = [{
+      class = "sifive.enterprise.firrtl.FileListAnnotation"
+  }]} { }
+
+  firrtl.module @filelist1() { }
+
+  firrtl.module @filelist2() attributes { annotations = [{
+      class = "sifive.enterprise.firrtl.FileListAnnotation"
+  }]} { }
+}
+// CHECK-LABEL:      firrtl.circuit "filelist0"
+// CHECK-NOT:        class = "sifive.enterprise.firrtl.FileListInfoFileAnnotation"
+// CHECK-NOT:        class = "sifive.enterprise.firrtl.FileListAnnotation"
+// CHECK{LITERAL}:   sv.verbatim "{{0}}\0A{{1}}\0A" {output_file = #hw.output_file<"filelist.txt", excludeFromFileList>, symbols = [@filelist0, @filelist2]}
+
+//===----------------------------------------------------------------------===//
 // RetimeModules
 //===----------------------------------------------------------------------===//
 
@@ -103,6 +138,10 @@ firrtl.circuit "BasicBlackboxes" attributes { annotations = [{
   firrtl.extmodule @DUTBlackbox_2() attributes {defname = "DUTBlackbox1"}
   // CHECK: sv.verbatim "[\22DUTBlackbox1\22,\22DUTBlackbox2\22]" {output_file = #hw.output_file<"dut_blackboxes.json", excludeFromFileList>, symbols = []}
 }
+
+//===----------------------------------------------------------------------===//
+// SeqMem
+//===----------------------------------------------------------------------===//
 
 // CHECK-LABEL: firrtl.circuit "top"
 firrtl.circuit "top" 


### PR DESCRIPTION
This adds support for the SiFive specific `FileListTransform` to create
metadata. This transform simply gathers any module annotated with
`FileListAnnotation` and prints its name to the file indicated by
`FileListInfoFileAnnotation`.