### PR TITLE
[FIRRTL][LowerToHW] Set moduleHierarchyFile based on FIRRTL annotations.

### DIFF
--- a/docs/FIRRTLAnnotations.md
+++ b/docs/FIRRTLAnnotations.md
@@ -470,6 +470,26 @@ Example:
 }
 ```
 
+### ModuleHierarchyAnnotation
+
+| Property   | Type   | Description                                          |
+| ---------- | ------ | -------------                                        |
+| class      | string | `sifive.enterprise.firrtl.ModuleHierarchyAnnotation` |
+| filename   | string | The full output file path.                           |
+
+This annotation indicates that a module hierarchy JSON file should be emitted
+for the module hierarchy rooted at the design under test (DUT), as indicated by
+the `MarkDUTAnnotation`. See the SV attribute, `firrtl.moduleHierarchyFile`, for
+information about the JSON file format.
+
+Example:
+```json
+{
+  "class": "sifive.enterprise.firrtl.ModuleHierarchyAnnotation",
+  "filename": "./dir/hier.json"
+}
+```
+
 ### NestedPrefixModulesAnnotation
 
 | Property   | Type   | Description                                              |
@@ -656,6 +676,26 @@ Example:
 {
   "class": "sifive.enterprise.firrtl.TestBenchDirAnnotation",
   "dirname": "output/testbench"
+}
+```
+
+### TestHarnessHierarchyAnnotation
+
+| Property   | Type   | Description                                               |
+| ---------- | ------ | -------------                                             |
+| class      | string | `sifive.enterprise.firrtl.TestHarnessHierarchyAnnotation` |
+| filename   | string | The full output file path.                                |
+
+This annotation indicates that a module hierarchy JSON file should be emitted
+for the module hierarchy rooted at the circuit root module, which is assumed to
+be the test harness. See the SV attribute, `firrtl.moduleHierarchyFile`, for
+information about the JSON file format.
+
+Example:
+```json
+{
+  "class": "sifive.enterprise.firrtl.TestHarnessHierarchyAnnotation",
+  "filename": "./dir/hier.json"
 }
 ```
 
@@ -1007,6 +1047,15 @@ section describes well-defined attributes used by HW/SV passes.
 
 Used by HWExportModuleHierarchy.  Signifies a root from which to dump the module
 hierarchy as a json file. This attribute has type OutputFileAttr.
+
+The exported JSON file encodes a recursive tree of module instances as JSON
+objects, with each object containing the following members:
+
+- `instance_name` - A string describing the name of the instance. Note that the
+  root module will have its `instance_name` set to the module's name.
+- `module_name` - A string describing the name of the module.
+- `instances` - An array of objects, where each object is a direct instance
+  within the current module.
 
 ### firrtl.extract.assert
 

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
@@ -20,7 +20,7 @@ firrtl.circuit "Simple" {
                                 FORMAT = "xyz_timeout=%d\0A",
                                 WIDTH = 32 : i8}}
 
-   // CHECK-LABEL: hw.module @Simple(%in1: i4, %in2: i2, %in3: i8) -> (out4: i4) attributes {firrtl.moduleHierarchyFile
+   // CHECK-LABEL: hw.module @Simple(%in1: i4, %in2: i2, %in3: i8) -> (out4: i4)
    firrtl.module @Simple(in %in1: !firrtl.uint<4>,
                          in %in2: !firrtl.uint<2>,
                          in %in3: !firrtl.sint<8>,

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1078,7 +1078,10 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   }
 
   // CHECK-LABEL: hw.module @FooDUT
-  // CHECK: attributes {firrtl.moduleHierarchyFile
+  // firrtl.moduleHierarchyFile should only be present if both the
+  // MarkDUTAnnotation and the circuit-level ModuleHierarchyAnnotation are
+  // present.
+  // CHECK-NOT: firrtl.moduleHierarchyFile
   firrtl.module @FooDUT() attributes {annotations = [
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {}
 

--- a/test/Conversion/FIRRTLToHW/module-hierarchy-file.mlir
+++ b/test/Conversion/FIRRTLToHW/module-hierarchy-file.mlir
@@ -1,0 +1,17 @@
+// RUN: circt-opt -lower-firrtl-to-hw  %s | FileCheck %s
+
+firrtl.circuit "MyTestHarness" attributes {annotations = [
+  {class = "sifive.enterprise.firrtl.ModuleHierarchyAnnotation", filename = "./dir1/filename1.json" },
+  {class = "sifive.enterprise.firrtl.TestHarnessHierarchyAnnotation", filename = "./dir2/filename2.json" }]}
+{
+  // CHECK-LABEL: hw.module @MyDUT
+  // CHECK: attributes {firrtl.moduleHierarchyFile = #hw.output_file<"./dir1/filename1.json", excludeFromFileList>}
+  firrtl.module @MyDUT() attributes {annotations = [
+      {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {}
+
+  // CHECK-LABEL: hw.module @MyTestHarness
+  // CHECK: attributes {firrtl.moduleHierarchyFile = #hw.output_file<"./dir2/filename2.json", excludeFromFileList>}
+  firrtl.module @MyTestHarness() {
+    firrtl.instance myDUT @MyDUT()
+  }
+}

--- a/test/firtool/memory.fir
+++ b/test/firtool/memory.fir
@@ -87,7 +87,7 @@ circuit Qux:
 ; CHECK-NEXT:    }
 ; CHECK-NEXT:    hw.output %[[v6]], %[[v11]] : i8, i8
 ; CHECK-NEXT:  }
-; CHECK-NEXT:  hw.module @Qux(%clock: i1, %rAddr: i4, %rEn: i1, %wAddr: i4, %wEn: i1, %wMask: i1, %wData: i8, %rwEn: i1, %rwMode: i1, %rwAddr: i4, %rwMask: i1, %rwDataIn: i8) -> (rData: i8, rwDataOut: i8) attributes {firrtl.moduleHierarchyFile = #hw.output_file<"testharness_hier.json", excludeFromFileList>} {
+; CHECK-NEXT:  hw.module @Qux(%clock: i1, %rAddr: i4, %rEn: i1, %wAddr: i4, %wEn: i1, %wMask: i1, %wData: i8, %rwEn: i1, %rwMode: i1, %rwAddr: i4, %rwMask: i1, %rwDataIn: i8) -> (rData: i8, rwDataOut: i8) {
 ; CHECK-NEXT:    %memory.R0_data, %memory.RW0_rdata = hw.instance "memory" @FIRRTLMem_1_1_1_8_16_1_1_1_0_1_a(R0_addr: %rAddr: i4, R0_en: %rEn: i1, R0_clk: %clock: i1, RW0_addr: %rwAddr: i4, RW0_en: %rwEn: i1, RW0_clk: %clock: i1, RW0_wmode: %rwMode: i1, RW0_wdata: %rwDataIn: i8, RW0_wmask: %rwMask: i1, W0_addr: %wAddr: i4, W0_en: %wEn: i1, W0_clk: %clock: i1, W0_data: %wData: i8, W0_mask: %wMask: i1) -> (R0_data: i8, RW0_rdata: i8)
 ; CHECK-NEXT:    hw.output %memory.R0_data, %memory.RW0_rdata : i8, i8
 ; CHECK-NEXT:  }


### PR DESCRIPTION
Previously, LowerToHW set the firrtl.moduleHierarchyFile attribute to
some hardcoded file paths. These file paths are actually specified in
ModuleHierarchyAnnotation and TestHarnessHierarchyAnnotation, so we
should be getting the paths from those annotations. In addition, the
presence or absence of these annotations should also dictate whether the
moduleHierarchyFile attribute is actually lowered into the HW dialect.

The code has been updated to do both these things.

Lastly, we now explicitly delete the annotations and exclude them from
the unprocessed annotations warnings check.

Several of the existing tests have been cleaned up to not have to know
about the moduleHierarchyFile, and a new test,
module-hierarchy-file.mlir, has been created to specifically test the
behavior of the annotations and resulting attributes.

Closes #2014.