### PR TITLE
[FIRRTL][GrandCentral] Force AugmentedGroundType non-local paths into local paths

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
@@ -800,7 +800,13 @@ static Optional<DictionaryAttr> parseAugmentedType(
 
     auto id = newID();
 
+    // TODO: We don't support non-local annotations, so force this annotation
+    // into a local annotation.  This does not properly check that the
+    // non-local and local targets are totally equivalent.
     auto target = maybeTarget.getValue();
+    auto localTarget = std::get<0>(expandNonLocal(target.first).back());
+    auto subTargets = target.second;
+
     NamedAttrList elementIface, elementScattered, dontTouch;
 
     // Populate the annotation for the interface element.
@@ -817,14 +823,14 @@ static Optional<DictionaryAttr> parseAugmentedType(
         "class",
         StringAttr::get(context, "firrtl.transforms.DontTouchAnnotation"));
     // If there are sub-targets, then add these.
-    if (target.second) {
-      elementScattered.append("target", target.second);
-      dontTouch.append("target", target.second);
+    if (subTargets) {
+      elementScattered.append("target", subTargets);
+      dontTouch.append("target", subTargets);
     }
 
-    newAnnotations[target.first].push_back(
+    newAnnotations[localTarget].push_back(
         DictionaryAttr::getWithSorted(context, elementScattered));
-    newAnnotations[target.first].push_back(
+    newAnnotations[localTarget].push_back(
         DictionaryAttr::getWithSorted(context, dontTouch));
 
     return DictionaryAttr::getWithSorted(context, elementIface);

--- a/test/Dialect/FIRRTL/annotations-errors.fir
+++ b/test/Dialect/FIRRTL/annotations-errors.fir
@@ -160,7 +160,7 @@ circuit Foo: %[[{"a":null,"target":"~Foo|Foo/baz:Bar"}]]
 ; nlas. 
 
 ; expected-error @+2 {{unapplied annotations with target '~NLAParse|A_companion' and payload '[{class = "sifive.enterprise.grandcentral.ViewAnnotation", id = 0 : i64, name = "A", type = "companion"}]'}}
-; expected-error @+1 {{unapplied annotations with target '~NLAParse|NLAParse/dut:DUT/foobar:FooBar>clock' and payload '[{class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 1 : i64, target = []}, {class = "firrtl.transforms.DontTouchAnnotation", target = []}]'}}
+; expected-error @+1 {{unapplied annotations with target '~NLAParse|FooBar>clock' and payload '[{class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 1 : i64, target = []}, {class = "firrtl.transforms.DontTouchAnnotation", target = []}]'}}
 circuit NLAParse : %[[
   {
    "class": "sifive.enterprise.grandcentral.GrandCentralView$SerializedViewAnnotation", 


### PR DESCRIPTION
This is a follow on to edd8956ec1c1, where we adapted to a new path
format for Grand Central `AugmentedGroundType`s. The problem with this new
format is that all created annotation targets are non-local, which is
not applying correctly using NLAs. This change takes all given
non-local targets for augmented types and changes them to local targets,
without regard to whether these targets are equivalent.  This works for now
because all non-local targets and their corresponding local target
are in fact equivalent.

The proper change is to either a) attach these as non-local annotations
and add support for non-local annotations to Grand Central or b) have a
target canonicalizer which correctly makes these non-local annotations
local only when legal to do so.

Since this problem is currently blocking integration testing, I am
proposing this change for now.  I will be looking at moving the
GrandCentral annotation scattering into the newer
`firrtl-lower-annotations` pass, where hopefully we will accomplish
option `b`.