### PR TITLE
[FIRRTL] Add RTL ports to OMIR data

### DIFF
--- a/test/Dialect/FIRRTL/SFCTests/emit-omir.fir
+++ b/test/Dialect/FIRRTL/SFCTests/emit-omir.fir
@@ -51,6 +51,13 @@ circuit Foo : %[[
           {"info": "", "name": "omType", "value": ["OMString:OMLazyModule", "OMString:OMSRAM"]},
           {"info": "", "name": "instancePath", "value": "OMMemberReferenceTarget:~Foo|Bar>mem2"}
         ]
+      },
+      {
+        "info": "",
+        "id": "OMID:4",
+        "fields": [
+          {"info": "", "name": "containingModule", "value": "OMInstanceTarget:~Foo|Foo"}
+        ]
       }
     ]
   }
@@ -58,7 +65,10 @@ circuit Foo : %[[
   extmodule MySRAM:
     defname = MySRAM
   module Foo :
+    input x : UInt<17>
+    output y : UInt<19>
     inst bar of Bar
+    y <= x
   module Bar :
     inst mem1 of MySRAM
     mem mem2 :
@@ -115,3 +125,20 @@ circuit Foo : %[[
 ; CHECK:       "id": "OMID:3"
 ; CHECK:       "name": "instancePath"
 ; CHECK-NEXT:  "value": "OMMemberInstanceTarget:~Foo|Foo/bar:Bar/mem2:FIRRTLMem_{{[^"]+}}"
+
+; CHECK:       "id": "OMID:4"
+; CHECK:       "name": "containingModule"
+; CHECK-NEXT:  "value": "OMInstanceTarget:~Foo|Foo"
+; CHECK:       "name": "ports"
+; CHECK-NEXT:  "value": [
+; CHECK-NEXT:    {
+; CHECK-NEXT:      "ref": "OMDontTouchedReferenceTarget:~Foo|Foo>x",
+; CHECK-NEXT:      "direction": "OMString:Input",
+; CHECK-NEXT:      "width": "OMBigInt:17"
+; CHECK-NEXT:    }
+; CHECK-NEXT:    {
+; CHECK-NEXT:      "ref": "OMDontTouchedReferenceTarget:~Foo|Foo>y",
+; CHECK-NEXT:      "direction": "OMString:Output",
+; CHECK-NEXT:      "width": "OMBigInt:19"
+; CHECK-NEXT:    }
+; CHECK-NEXT:  ]

--- a/test/Dialect/FIRRTL/emit-omir.mlir
+++ b/test/Dialect/FIRRTL/emit-omir.mlir
@@ -235,7 +235,7 @@ firrtl.circuit "DeletedTargets" attributes {annotations = [{
 // CHECK-SAME:  \22value\22: \22OMDeleted\22
 
 //===----------------------------------------------------------------------===//
-// Make SRAM Paths Absolute
+// Make SRAM Paths Absolute (`SetOMIRSRAMPaths`)
 //===----------------------------------------------------------------------===//
 
 firrtl.circuit "SRAMPaths" attributes {annotations = [{
@@ -291,20 +291,108 @@ firrtl.circuit "SRAMPaths" attributes {annotations = [{
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
 // CHECK-NEXT:  sv.verbatim
+
 // CHECK-SAME:  \22id\22: \22OMID:0\22
 // CHECK-SAME:    \22name\22: \22omType\22
 // CHECK-SAME:    \22value\22: [
 // CHECK-SAME:      \22OMString:OMLazyModule\22
-// CHECK-SAME:      \22OMString:OMSRAM\22\0A
+// CHECK-SAME:      \22OMString:OMSRAM\22
 // CHECK-SAME:    ]
 // CHECK-SAME:    \22name\22: \22instancePath\22
 // CHECK-SAME:    \22value\22: \22OMMemberInstanceTarget:~SRAMPaths|{{[{][{]0[}][}]}}/sub:{{[{][{]1[}][}]}}/mem1:{{[{][{]2[}][}]}}\22
+
 // CHECK-SAME:  \22id\22: \22OMID:1\22
 // CHECK-SAME:    \22name\22: \22omType\22
 // CHECK-SAME:    \22value\22: [
 // CHECK-SAME:      \22OMString:OMLazyModule\22
-// CHECK-SAME:      \22OMString:OMSRAM\22\0A
+// CHECK-SAME:      \22OMString:OMSRAM\22
 // CHECK-SAME:    ]
 // CHECK-SAME:    \22name\22: \22instancePath\22
 // CHECK-SAME:    \22value\22: \22OMMemberInstanceTarget:~SRAMPaths|{{[{][{]0[}][}]}}/sub:{{[{][{]1[}][}]}}/mem2:FIRRTLMem_{{[^\\]+}}\22
+
 // CHECK-SAME:  symbols = [@SRAMPaths, @Submodule, @MySRAM]
+
+//===----------------------------------------------------------------------===//
+// Add module port information to the OMIR (`SetOMIRPorts`)
+//===----------------------------------------------------------------------===//
+
+firrtl.circuit "AddPorts" attributes {annotations = [{
+  class = "freechips.rocketchip.objectmodel.OMIRAnnotation",
+  nodes = [
+    {
+      info = #loc,
+      id = "OMID:0",
+      fields = {
+        containingModule = {
+          info = #loc,
+          index = 0,
+          value = {
+            omir.tracker,
+            id = 0,
+            path = "~AddPorts|AddPorts",
+            type = "OMInstanceTarget"
+          }
+        }
+      }
+    },
+    {
+      info = #loc,
+      id = "OMID:1",
+      fields = {
+        containingModule = {
+          info = #loc,
+          index = 0,
+          value = {
+            omir.tracker,
+            id = 1,
+            path = "~AddPorts|AddPorts>w",
+            type = "OMReferenceTarget"
+          }
+        }
+      }
+    }
+  ]
+}]} {
+  firrtl.module @AddPorts(in %x: !firrtl.uint<17>, out %y: !firrtl.uint<19>) attributes {annotations = [{class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 0}]} {
+    %w = firrtl.wire {annotations = [{class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 1}]} : !firrtl.uint<17>
+    firrtl.connect %y, %x : !firrtl.uint<19>, !firrtl.uint<17>
+  }
+}
+// CHECK-LABEL: firrtl.circuit "AddPorts"
+// CHECK:       sv.verbatim
+
+// CHECK-SAME:  \22id\22: \22OMID:0\22
+// CHECK-SAME:    \22name\22: \22containingModule\22
+// CHECK-SAME:    \22value\22: \22OMInstanceTarget:~AddPorts|{{[{][{]0[}][}]}}\22
+// CHECK-SAME:    \22name\22: \22ports\22
+// CHECK-SAME:    \22value\22: [
+// CHECK-SAME:      {
+// CHECK-SAME:        \22ref\22: \22OMDontTouchedReferenceTarget:~AddPorts|{{[{][{]0[}][}]}}>x\22
+// CHECK-SAME:        \22direction\22: \22OMString:Input\22
+// CHECK-SAME:        \22width\22: \22OMBigInt:17\22
+// CHECK-SAME:      }
+// CHECK-SAME:      {
+// CHECK-SAME:        \22ref\22: \22OMDontTouchedReferenceTarget:~AddPorts|{{[{][{]0[}][}]}}>y\22
+// CHECK-SAME:        \22direction\22: \22OMString:Output\22
+// CHECK-SAME:        \22width\22: \22OMBigInt:19\22
+// CHECK-SAME:      }
+// CHECK-SAME:    ]
+
+// CHECK-SAME:  \22id\22: \22OMID:1\22
+// CHECK-SAME:    \22name\22: \22containingModule\22
+// CHECK-SAME:    \22value\22: \22OMReferenceTarget:~AddPorts|{{[{][{]0[}][}]}}>w\22
+// CHECK-SAME:    \22name\22: \22ports\22
+// CHECK-SAME:    \22value\22: [
+// CHECK-SAME:      {
+// CHECK-SAME:        \22ref\22: \22OMDontTouchedReferenceTarget:~AddPorts|{{[{][{]0[}][}]}}>x\22
+// CHECK-SAME:        \22direction\22: \22OMString:Input\22
+// CHECK-SAME:        \22width\22: \22OMBigInt:17\22
+// CHECK-SAME:      }
+// CHECK-SAME:      {
+// CHECK-SAME:        \22ref\22: \22OMDontTouchedReferenceTarget:~AddPorts|{{[{][{]0[}][}]}}>y\22
+// CHECK-SAME:        \22direction\22: \22OMString:Output\22
+// CHECK-SAME:        \22width\22: \22OMBigInt:19\22
+// CHECK-SAME:      }
+// CHECK-SAME:    ]
+
+// CHECK-SAME:  symbols = [@AddPorts]


### PR DESCRIPTION
Implement the functionality of the `SetOMIRPorts` in the Scala FIRRTL compiler, which essentially extends all OMIR nodes that have a `containingModule` field with a list of RTL ports of that module. There are some quirks about `containingModule`, for example that it apparently does not need to point to a module per se, that need handling. Besides that though, this is a fairly mechanical process.

This should enable IPXACT exporting based on the OMIR JSON that comes out of the MLIR-based FIRRTL compiler.