### PR TITLE
[ExtractTestCode] Fix attribute name in LowerToHW

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -399,9 +399,12 @@ void FIRRTLModuleLowering::runOnOperation() {
   SmallVector<FModuleOp, 32> modulesToProcess;
 
   AnnotationSet circuitAnno(circuit);
-  moveVerifAnno(getOperation(), circuitAnno, assertAnnoClass, "firrtl.assert");
-  moveVerifAnno(getOperation(), circuitAnno, assumeAnnoClass, "firrtl.assume");
-  moveVerifAnno(getOperation(), circuitAnno, coverAnnoClass, "firrtl.cover");
+  moveVerifAnno(getOperation(), circuitAnno, assertAnnoClass,
+                "firrtl.extract.assert");
+  moveVerifAnno(getOperation(), circuitAnno, assumeAnnoClass,
+                "firrtl.extract.assume");
+  moveVerifAnno(getOperation(), circuitAnno, coverAnnoClass,
+                "firrtl.extract.cover");
   circuitAnno.removeAnnotationsWithClass(assertAnnoClass, assumeAnnoClass,
                                          coverAnnoClass);
 


### PR DESCRIPTION
Mismatch between LowerToHW and what SVExtractTestCode expects (which matches the documentation).