### PR TITLE
[FIRRTL] Make GCT data tap hierarchical names start at module

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -526,15 +526,19 @@ void GrandCentralTapsPass::runOnOperation() {
         LLVM_DEBUG(llvm::dbgs()
                    << "  - Shortest prefix " << *shortestPrefix << "\n");
 
+        // Determine the module at which the hierarchical name should start.
+        Operation *opInRootModule =
+            shortestPrefix->empty() ? path.back() : shortestPrefix->front();
+        StringRef rootModule =
+            opInRootModule->getParentOfType<FModuleLike>().moduleName();
+
         // Concatenate the prefix into a proper full hierarchical name.
-        SmallString<128> hname;
+        SmallString<128> hname(rootModule);
         for (auto inst : shortestPrefix.getValue()) {
-          if (!hname.empty())
-            hname += '.';
+          hname += '.';
           hname += inst.name();
         }
-        if (!hname.empty())
-          hname += '.';
+        hname += '.';
         hname += port.suffix;
         LLVM_DEBUG(llvm::dbgs() << "  - Connecting as " << hname << "\n");
 

--- a/test/Dialect/FIRRTL/SFCTests/data-taps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps.fir
@@ -78,13 +78,13 @@ circuit Top :
 ; CHECK: module DataTap_2_impl_0(
 ; CHECK:   output  _1, _0
 ; CHECK: );
-; CHECK:   assign _1 = child.child.bb.foo.bar.out;
-; CHECK:   assign _0 = child.child.bb.foo.bar.in;
+; CHECK:   assign _1 = Top.child.child.bb.foo.bar.out;
+; CHECK:   assign _0 = Top.child.child.bb.foo.bar.in;
 ; CHECK: endmodule
 
 ; CHECK: module MemTap_2_impl_0(
 ; CHECK:   output  _1, _0
 ; CHECK: );
-; CHECK:   assign _1 = child.child.M.Memory[1];
-; CHECK:   assign _0 = child.child.M.Memory[0];
+; CHECK:   assign _1 = Top.child.child.M.Memory[1];
+; CHECK:   assign _0 = Top.child.child.M.Memory[0];
 ; CHECK: endmodule

--- a/test/Dialect/FIRRTL/grand-central-taps.mlir
+++ b/test/Dialect/FIRRTL/grand-central-taps.mlir
@@ -117,6 +117,7 @@ firrtl.circuit "TestHarness" attributes {
   }
 
   // CHECK: firrtl.module @[[DT:DataTap.*]](
+  // CHECK-SAME: out %_10: !firrtl.uint<4>
   // CHECK-SAME: out %_9: !firrtl.uint<1>
   // CHECK-SAME: out %_8: !firrtl.sint<8>
   // CHECK-SAME: out %_7: !firrtl.uint<1>
@@ -128,27 +129,30 @@ firrtl.circuit "TestHarness" attributes {
   // CHECK-SAME: out %_1: !firrtl.clock
   // CHECK-SAME: out %_0: !firrtl.uint<1>
   // CHECK-SAME: #hw.output_file<"outputDirectory/[[DT]].sv">
+  // CHECK-NEXT: [[V10:%.+]] = firrtl.verbatim.expr "TestHarness.harnessWire"
+  // CHECK-NEXT: firrtl.connect %_10, [[V10]]
   // CHECK-NEXT: [[V9:%.+]] = firrtl.constant 0 : !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %_9, [[V9]]
   // CHECK-NEXT: [[V8:%.+]] = firrtl.constant -42 : !firrtl.sint<8>
   // CHECK-NEXT: firrtl.connect %_8, [[V8]]
-  // CHECK-NEXT: [[V7:%.+]] = firrtl.verbatim.expr "extmoduleWithTappedPort.out"
+  // CHECK-NEXT: [[V7:%.+]] = firrtl.verbatim.expr "TestHarness.extmoduleWithTappedPort.out"
   // CHECK-NEXT: firrtl.connect %_7, [[V7]]
-  // CHECK-NEXT: [[V6:%.+]] = firrtl.verbatim.expr "foo.bar.regreset"
+  // CHECK-NEXT: [[V6:%.+]] = firrtl.verbatim.expr "TestHarness.foo.bar.regreset"
   // CHECK-NEXT: firrtl.connect %_6, [[V6]]
-  // CHECK-NEXT: [[V5:%.+]] = firrtl.verbatim.expr "foo.bar.reg"
+  // CHECK-NEXT: [[V5:%.+]] = firrtl.verbatim.expr "TestHarness.foo.bar.reg"
   // CHECK-NEXT: firrtl.connect %_5, [[V5]]
-  // CHECK-NEXT: [[V4:%.+]] = firrtl.verbatim.expr "foo.bar.node"
+  // CHECK-NEXT: [[V4:%.+]] = firrtl.verbatim.expr "TestHarness.foo.bar.node"
   // CHECK-NEXT: firrtl.connect %_4, [[V4]]
-  // CHECK-NEXT: [[V3:%.+]] = firrtl.verbatim.expr "bigScary.schwarzschild.no.more"
+  // CHECK-NEXT: [[V3:%.+]] = firrtl.verbatim.expr "TestHarness.bigScary.schwarzschild.no.more"
   // CHECK-NEXT: firrtl.connect %_3, [[V3]]
-  // CHECK-NEXT: [[V2:%.+]] = firrtl.verbatim.expr "foo.bar.reset"
+  // CHECK-NEXT: [[V2:%.+]] = firrtl.verbatim.expr "TestHarness.foo.bar.reset"
   // CHECK-NEXT: firrtl.connect %_2, [[V2]]
-  // CHECK-NEXT: [[V1:%.+]] = firrtl.verbatim.expr "foo.bar.clock"
+  // CHECK-NEXT: [[V1:%.+]] = firrtl.verbatim.expr "TestHarness.foo.bar.clock"
   // CHECK-NEXT: firrtl.connect %_1, [[V1]]
-  // CHECK-NEXT: [[V0:%.+]] = firrtl.verbatim.expr "foo.bar.wire"
+  // CHECK-NEXT: [[V0:%.+]] = firrtl.verbatim.expr "TestHarness.foo.bar.wire"
   // CHECK-NEXT: firrtl.connect %_0, [[V0]]
   firrtl.extmodule @DataTap(
+    out _10: !firrtl.uint<4>,
     out _9: !firrtl.uint<1>,
     out _8: !firrtl.sint<8>,
     out _7: !firrtl.uint<1>,
@@ -165,6 +169,7 @@ firrtl.circuit "TestHarness" attributes {
       { class = "firrtl.transforms.NoDedupAnnotation" }
     ],
     portAnnotations = [
+      [{class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = 11 : i64, type = "portName"}],
       [{class = "sifive.enterprise.grandcentral.LiteralDataTapKey", literal = "UInt<1>(\"h0\")", id = 0 : i64, portID = 10 : i64 }],
       [{class = "sifive.enterprise.grandcentral.LiteralDataTapKey", literal = "SInt<8>(\"h-2A\")", id = 0 : i64, portID = 9 : i64 }],
       [{class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = 8 : i64, type = "portName"}],
@@ -185,9 +190,9 @@ firrtl.circuit "TestHarness" attributes {
   // CHECK-SAME: out %mem_1: !firrtl.uint<1>
   // CHECK-SAME: class = "firrtl.transforms.NoDedupAnnotation"
   // CHECK-SAME: #hw.output_file<"outputDirectory/[[MT]].sv">
-  // CHECK-NEXT: [[V0:%.+]] = firrtl.verbatim.expr "foo.bar.mem.Memory[0]"
+  // CHECK-NEXT: [[V0:%.+]] = firrtl.verbatim.expr "TestHarness.foo.bar.mem.Memory[0]"
   // CHECK-NEXT: firrtl.connect %mem_0, [[V0:%.+]]
-  // CHECK-NEXT: [[V1:%.+]] = firrtl.verbatim.expr "foo.bar.mem.Memory[1]"
+  // CHECK-NEXT: [[V1:%.+]] = firrtl.verbatim.expr "TestHarness.foo.bar.mem.Memory[1]"
   // CHECK-NEXT: firrtl.connect %mem_1, [[V1:%.+]]
   firrtl.extmodule @MemTap(
     out mem_0: !firrtl.uint<1>,
@@ -222,6 +227,18 @@ firrtl.circuit "TestHarness" attributes {
 
   // CHECK: firrtl.module @TestHarness
   firrtl.module @TestHarness(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
+    // CHECK-LABEL: %harnessWire = firrtl.wire
+    // CHECK-NOT: class = "sifive.enterprise.grandcentral.ReferenceDataTapKey"
+    // CHECK-SAME: class = "firrtl.transforms.DontTouchAnnotation"
+    %harnessWire = firrtl.wire {annotations = [{
+      class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
+      id = 0 : i64,
+      portID = 11 : i64,
+      type = "source"
+    }, {
+      class = "firrtl.transforms.DontTouchAnnotation"
+    }]} : !firrtl.uint<4>
+
     %foo_clock, %foo_reset, %foo_in, %foo_out = firrtl.instance foo @Foo(in clock: !firrtl.clock, in reset: !firrtl.reset, in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
     firrtl.connect %foo_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %foo_reset, %reset : !firrtl.reset, !firrtl.uint<1>
@@ -230,7 +247,7 @@ firrtl.circuit "TestHarness" attributes {
     firrtl.instance bigScary @BlackHole()
     %0 = firrtl.instance extmoduleWithTappedPort @ExtmoduleWithTappedPort(out out: !firrtl.uint<1>)
     // CHECK: firrtl.instance dataTap @[[DT]]
-    %DataTap_9, %DataTap_8, %DataTap_7, %DataTap_6, %DataTap_5, %DataTap_4, %DataTap_3, %DataTap_2, %DataTap_1, %DataTap_0 = firrtl.instance dataTap @DataTap(out _9: !firrtl.uint<1>, out _8: !firrtl.sint<8>, out _7: !firrtl.uint<1>, out _6: !firrtl.uint<1>, out _5: !firrtl.uint<1>, out _4: !firrtl.uint<1>, out _3: !firrtl.uint<1>, out _2: !firrtl.uint<1>, out _1: !firrtl.clock, out _0: !firrtl.uint<1>)
+    %DataTap_10, %DataTap_9, %DataTap_8, %DataTap_7, %DataTap_6, %DataTap_5, %DataTap_4, %DataTap_3, %DataTap_2, %DataTap_1, %DataTap_0 = firrtl.instance dataTap @DataTap(out _10: !firrtl.uint<4>, out _9: !firrtl.uint<1>, out _8: !firrtl.sint<8>, out _7: !firrtl.uint<1>, out _6: !firrtl.uint<1>, out _5: !firrtl.uint<1>, out _4: !firrtl.uint<1>, out _3: !firrtl.uint<1>, out _2: !firrtl.uint<1>, out _1: !firrtl.clock, out _0: !firrtl.uint<1>)
     // CHECK: firrtl.instance memTap @[[MT]]
     %MemTap_mem_0, %MemTap_mem_1 = firrtl.instance memTap @MemTap(out mem_0: !firrtl.uint<1>, out mem_1: !firrtl.uint<1>)
   }


### PR DESCRIPTION
Change how GCT data/memory taps are generated by always starting the hierarchical names with a module. This removes ambiguities where a local declaration `bar` could shadow an instance `bar` in a parent module, rendering the XMR `bar.x` invalid. Also, if a signal is tapped in the same module where the data taps module is instantiated, the resulting hierarchical name would just be `x`, which in SV is not a hierarchical name and causes no resolution against the `x` in the parent module we're interested in. Always inserting a module name prefix removes any such ambiguity, generates a hierarchical name in any case, and causes SV to properly look upwards in the instance graph until that parent module is found.