### PR TITLE
[FIRRTL] Fix unpacked array ordering in GCT and ExportVerilog

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -941,8 +941,8 @@ void ModuleEmitter::printUnpackedTypePostfix(Type type, raw_ostream &os) {
         printUnpackedTypePostfix(inoutType.getElementType(), os);
       })
       .Case<UnpackedArrayType>([&](UnpackedArrayType arrayType) {
-        printUnpackedTypePostfix(arrayType.getElementType(), os);
         os << "[0:" << (arrayType.getSize() - 1) << "]";
+        printUnpackedTypePostfix(arrayType.getElementType(), os);
       })
       .Case<InterfaceType>([&](auto) {
         // Interface instantiations have parentheses like a module with no

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -323,8 +323,8 @@ hw.module @wires(%in4: i4, %in8: i8) -> (a: i4, b: i8, c: i8) {
   // CHECK-NEXT: wire [7:0]            myUArray1[0:41];
   %myUArray1 = sv.wire : !hw.inout<uarray<42 x i8>>
 
-  // CHECK-NEXT: wire [41:0][3:0]      myWireUArray2[0:2];
-  %myWireUArray2 = sv.wire : !hw.inout<uarray<3 x array<42 x i4>>>
+  // CHECK-NEXT: wire [9:0][7:0]       myUArray2[0:13][0:11];
+  %myUArray2 = sv.wire : !hw.inout<uarray<14 x uarray<12 x array<10 x i8>>>>
 
   // CHECK-EMPTY:
 

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.anno.json
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.anno.json
@@ -84,6 +84,127 @@
           }
         },
         {
+          "name": "multivec",
+          "description": "a 2D vector called 'multivec'",
+          "tpe": {
+            "class": "sifive.enterprise.grandcentral.AugmentedVectorType",
+            "elements": [
+              {
+                "class": "sifive.enterprise.grandcentral.AugmentedVectorType",
+                "elements": [
+                  {
+                    "class": "sifive.enterprise.grandcentral.AugmentedGroundType",
+                    "ref": {
+                      "circuit": "Top",
+                      "module": "DUT",
+                      "path": [],
+                      "ref": "w",
+                      "component": [
+                        {"class": "firrtl.annotations.TargetToken$Field", "value": "multivec"},
+                        {"class": "firrtl.annotations.TargetToken$Index", "value": 0},
+                        {"class": "firrtl.annotations.TargetToken$Index", "value": 0}
+                      ]
+                    },
+                    "tpe": {
+                      "class": "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
+                    }
+                  },
+                  {
+                    "class": "sifive.enterprise.grandcentral.AugmentedGroundType",
+                    "ref": {
+                      "circuit": "Top",
+                      "module": "DUT",
+                      "path": [],
+                      "ref": "w",
+                      "component": [
+                        {"class": "firrtl.annotations.TargetToken$Field", "value": "multivec"},
+                        {"class": "firrtl.annotations.TargetToken$Index", "value": 0},
+                        {"class": "firrtl.annotations.TargetToken$Index", "value": 1}
+                      ]
+                    },
+                    "tpe": {
+                      "class": "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
+                    }
+                  },
+                  {
+                    "class": "sifive.enterprise.grandcentral.AugmentedGroundType",
+                    "ref": {
+                      "circuit": "Top",
+                      "module": "DUT",
+                      "path": [],
+                      "ref": "w",
+                      "component": [
+                        {"class": "firrtl.annotations.TargetToken$Field", "value": "multivec"},
+                        {"class": "firrtl.annotations.TargetToken$Index", "value": 0},
+                        {"class": "firrtl.annotations.TargetToken$Index", "value": 2}
+                      ]
+                    },
+                    "tpe": {
+                      "class": "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
+                    }
+                  }
+                ]
+              },
+              {
+                "class": "sifive.enterprise.grandcentral.AugmentedVectorType",
+                "elements": [
+                  {
+                    "class": "sifive.enterprise.grandcentral.AugmentedGroundType",
+                    "ref": {
+                      "circuit": "Top",
+                      "module": "DUT",
+                      "path": [],
+                      "ref": "w",
+                      "component": [
+                        {"class": "firrtl.annotations.TargetToken$Field", "value": "multivec"},
+                        {"class": "firrtl.annotations.TargetToken$Index", "value": 1},
+                        {"class": "firrtl.annotations.TargetToken$Index", "value": 0}
+                      ]
+                    },
+                    "tpe": {
+                      "class": "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
+                    }
+                  },
+                  {
+                    "class": "sifive.enterprise.grandcentral.AugmentedGroundType",
+                    "ref": {
+                      "circuit": "Top",
+                      "module": "DUT",
+                      "path": [],
+                      "ref": "w",
+                      "component": [
+                        {"class": "firrtl.annotations.TargetToken$Field", "value": "multivec"},
+                        {"class": "firrtl.annotations.TargetToken$Index", "value": 1},
+                        {"class": "firrtl.annotations.TargetToken$Index", "value": 1}
+                      ]
+                    },
+                    "tpe": {
+                      "class": "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
+                    }
+                  },
+                  {
+                    "class": "sifive.enterprise.grandcentral.AugmentedGroundType",
+                    "ref": {
+                      "circuit": "Top",
+                      "module": "DUT",
+                      "path": [],
+                      "ref": "w",
+                      "component": [
+                        {"class": "firrtl.annotations.TargetToken$Field", "value": "multivec"},
+                        {"class": "firrtl.annotations.TargetToken$Index", "value": 1},
+                        {"class": "firrtl.annotations.TargetToken$Index", "value": 2}
+                      ]
+                    },
+                    "tpe": {
+                      "class": "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
           "name": "vecOfBundle",
           "description": "a vector of a bundle",
           "tpe": {

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
@@ -5,10 +5,10 @@ circuit Top :
   module Submodule :
     input clock : Clock
     input reset : Reset
-    input in : { uint : UInt<1>, vec : UInt<1>[2], vecOfBundle : { uint : UInt<4>, sint : SInt<2>}[2], otherOther : { other : { uint : UInt<4>, sint : SInt<2>}}}
-    output out : { uint : UInt<1>, vec : UInt<1>[2], vecOfBundle : { uint : UInt<4>, sint : SInt<2>}[2], otherOther : { other : { uint : UInt<4>, sint : SInt<2>}}}
+    input in : { uint : UInt<1>, vec : UInt<1>[2], multivec : UInt<1>[3][2], vecOfBundle : { uint : UInt<4>, sint : SInt<2>}[2], otherOther : { other : { uint : UInt<4>, sint : SInt<2>}}}
+    output out : { uint : UInt<1>, vec : UInt<1>[2], multivec : UInt<1>[3][2], vecOfBundle : { uint : UInt<4>, sint : SInt<2>}[2], otherOther : { other : { uint : UInt<4>, sint : SInt<2>}}}
 
-    wire w : { uint : UInt<1>, vec : UInt<1>[2], vecOfBundle : { uint : UInt<4>, sint : SInt<2>}[2], otherOther : { other : { uint : UInt<4>, sint : SInt<2>}}}
+    wire w : { uint : UInt<1>, vec : UInt<1>[2], multivec : UInt<1>[3][2], vecOfBundle : { uint : UInt<4>, sint : SInt<2>}[2], otherOther : { other : { uint : UInt<4>, sint : SInt<2>}}}
     w.otherOther.other.sint <= in.otherOther.other.sint
     w.otherOther.other.uint <= in.otherOther.other.uint
     w.vecOfBundle[0].sint <= in.vecOfBundle[0].sint
@@ -17,6 +17,12 @@ circuit Top :
     w.vecOfBundle[1].uint <= in.vecOfBundle[1].uint
     w.vec[0] <= in.vec[0]
     w.vec[1] <= in.vec[1]
+    w.multivec[0][0] <= in.multivec[0][0]
+    w.multivec[0][1] <= in.multivec[0][1]
+    w.multivec[0][2] <= in.multivec[0][2]
+    w.multivec[1][0] <= in.multivec[1][0]
+    w.multivec[1][1] <= in.multivec[1][1]
+    w.multivec[1][2] <= in.multivec[1][2]
     w.uint <= in.uint
     out.otherOther.other.sint <= w.otherOther.other.sint
     out.otherOther.other.uint <= w.otherOther.other.uint
@@ -26,6 +32,12 @@ circuit Top :
     out.vecOfBundle[1].uint <= w.vecOfBundle[1].uint
     out.vec[0] <= w.vec[0]
     out.vec[1] <= w.vec[1]
+    out.multivec[0][0] <= w.multivec[0][0]
+    out.multivec[0][1] <= w.multivec[0][1]
+    out.multivec[0][2] <= w.multivec[0][2]
+    out.multivec[1][0] <= w.multivec[1][0]
+    out.multivec[1][1] <= w.multivec[1][1]
+    out.multivec[1][2] <= w.multivec[1][2]
     out.uint <= w.uint
 
   module MyView_companion :
@@ -37,10 +49,10 @@ circuit Top :
   module DUT :
     input clock : Clock
     input reset : Reset
-    input in : { uint : UInt<1>, vec : UInt<1>[2], vecOfBundle : { uint : UInt<4>, sint : SInt<2>}[2], otherOther : { other : { uint : UInt<4>, sint : SInt<2>}}}
-    output out : { uint : UInt<1>, vec : UInt<1>[2], vecOfBundle : { uint : UInt<4>, sint : SInt<2>}[2], otherOther : { other : { uint : UInt<4>, sint : SInt<2>}}}
+    input in : { uint : UInt<1>, vec : UInt<1>[2], multivec : UInt<1>[3][2], vecOfBundle : { uint : UInt<4>, sint : SInt<2>}[2], otherOther : { other : { uint : UInt<4>, sint : SInt<2>}}}
+    output out : { uint : UInt<1>, vec : UInt<1>[2], multivec : UInt<1>[3][2], vecOfBundle : { uint : UInt<4>, sint : SInt<2>}[2], otherOther : { other : { uint : UInt<4>, sint : SInt<2>}}}
 
-    wire w : { uint : UInt<1>, vec : UInt<1>[2], vecOfBundle : { uint : UInt<4>, sint : SInt<2>}[2], otherOther : { other : { uint : UInt<4>, sint : SInt<2>}}}
+    wire w : { uint : UInt<1>, vec : UInt<1>[2], multivec : UInt<1>[3][2], vecOfBundle : { uint : UInt<4>, sint : SInt<2>}[2], otherOther : { other : { uint : UInt<4>, sint : SInt<2>}}}
     inst submodule of Submodule
     submodule.clock <= clock
     submodule.reset <= reset
@@ -52,6 +64,12 @@ circuit Top :
     w.vecOfBundle[1].uint <= in.vecOfBundle[1].uint
     w.vec[0] <= in.vec[0]
     w.vec[1] <= in.vec[1]
+    w.multivec[0][0] <= in.multivec[0][0]
+    w.multivec[0][1] <= in.multivec[0][1]
+    w.multivec[0][2] <= in.multivec[0][2]
+    w.multivec[1][0] <= in.multivec[1][0]
+    w.multivec[1][1] <= in.multivec[1][1]
+    w.multivec[1][2] <= in.multivec[1][2]
     w.uint <= in.uint
     submodule.in.otherOther.other.sint <= w.otherOther.other.sint
     submodule.in.otherOther.other.uint <= w.otherOther.other.uint
@@ -61,6 +79,12 @@ circuit Top :
     submodule.in.vecOfBundle[1].uint <= w.vecOfBundle[1].uint
     submodule.in.vec[0] <= w.vec[0]
     submodule.in.vec[1] <= w.vec[1]
+    submodule.in.multivec[0][0] <= w.multivec[0][0]
+    submodule.in.multivec[0][1] <= w.multivec[0][1]
+    submodule.in.multivec[0][2] <= w.multivec[0][2]
+    submodule.in.multivec[1][0] <= w.multivec[1][0]
+    submodule.in.multivec[1][1] <= w.multivec[1][1]
+    submodule.in.multivec[1][2] <= w.multivec[1][2]
     submodule.in.uint <= w.uint
     out.otherOther.other.sint <= submodule.out.otherOther.other.sint
     out.otherOther.other.uint <= submodule.out.otherOther.other.uint
@@ -70,14 +94,20 @@ circuit Top :
     out.vecOfBundle[1].uint <= submodule.out.vecOfBundle[1].uint
     out.vec[0] <= submodule.out.vec[0]
     out.vec[1] <= submodule.out.vec[1]
+    out.multivec[0][0] <= submodule.out.multivec[0][0]
+    out.multivec[0][1] <= submodule.out.multivec[0][1]
+    out.multivec[0][2] <= submodule.out.multivec[0][2]
+    out.multivec[1][0] <= submodule.out.multivec[1][0]
+    out.multivec[1][1] <= submodule.out.multivec[1][1]
+    out.multivec[1][2] <= submodule.out.multivec[1][2]
     out.uint <= submodule.out.uint
     inst MyView_companion of MyView_companion
 
   module Top :
     input clock : Clock
     input reset : UInt<1>
-    input in : { uint : UInt<1>, vec : UInt<1>[2], vecOfBundle : { uint : UInt<4>, sint : SInt<2>}[2], otherOther : { other : { uint : UInt<4>, sint : SInt<2>}}}
-    output out : { uint : UInt<1>, vec : UInt<1>[2], vecOfBundle : { uint : UInt<4>, sint : SInt<2>}[2], otherOther : { other : { uint : UInt<4>, sint : SInt<2>}}}
+    input in : { uint : UInt<1>, vec : UInt<1>[2], multivec : UInt<1>[3][2], vecOfBundle : { uint : UInt<4>, sint : SInt<2>}[2], otherOther : { other : { uint : UInt<4>, sint : SInt<2>}}}
+    output out : { uint : UInt<1>, vec : UInt<1>[2], multivec : UInt<1>[3][2], vecOfBundle : { uint : UInt<4>, sint : SInt<2>}[2], otherOther : { other : { uint : UInt<4>, sint : SInt<2>}}}
 
     inst dut of DUT
     dut.clock <= clock
@@ -90,6 +120,12 @@ circuit Top :
     dut.in.vecOfBundle[1].uint <= in.vecOfBundle[1].uint
     dut.in.vec[0] <= in.vec[0]
     dut.in.vec[1] <= in.vec[1]
+    dut.in.multivec[0][0] <= in.multivec[0][0]
+    dut.in.multivec[0][1] <= in.multivec[0][1]
+    dut.in.multivec[0][2] <= in.multivec[0][2]
+    dut.in.multivec[1][0] <= in.multivec[1][0]
+    dut.in.multivec[1][1] <= in.multivec[1][1]
+    dut.in.multivec[1][2] <= in.multivec[1][2]
     dut.in.uint <= in.uint
     out.otherOther.other.sint <= dut.out.otherOther.other.sint
     out.otherOther.other.uint <= dut.out.otherOther.other.uint
@@ -99,6 +135,12 @@ circuit Top :
     out.vecOfBundle[1].uint <= dut.out.vecOfBundle[1].uint
     out.vec[0] <= dut.out.vec[0]
     out.vec[1] <= dut.out.vec[1]
+    out.multivec[0][0] <= dut.out.multivec[0][0]
+    out.multivec[0][1] <= dut.out.multivec[0][1]
+    out.multivec[0][2] <= dut.out.multivec[0][2]
+    out.multivec[1][0] <= dut.out.multivec[1][0]
+    out.multivec[1][1] <= dut.out.multivec[1][1]
+    out.multivec[1][2] <= dut.out.multivec[1][2]
     out.uint <= dut.out.uint
 
     ; NOEXTRACT:      module MyView_companion();
@@ -130,6 +172,12 @@ circuit Top :
     ; CHECK-NEXT:       assign MyView.uint = dut.w_uint;
     ; CHECK-NEXT:       assign MyView.vec[0] = dut.w_vec_0;
     ; CHECK-NEXT:       assign MyView.vec[1] = dut.w_vec_1;
+    ; CHECK-NEXT:       assign MyView.multivec[0][0] = dut.w_multivec_0_0;
+    ; CHECK-NEXT:       assign MyView.multivec[0][1] = dut.w_multivec_0_1;
+    ; CHECK-NEXT:       assign MyView.multivec[0][2] = dut.w_multivec_0_2;
+    ; CHECK-NEXT:       assign MyView.multivec[1][0] = dut.w_multivec_1_0;
+    ; CHECK-NEXT:       assign MyView.multivec[1][1] = dut.w_multivec_1_1;
+    ; CHECK-NEXT:       assign MyView.multivec[1][2] = dut.w_multivec_1_2;
     ; CHECK-NEXT:       assign MyView.vecOfBundle[0].sint = dut.w_vecOfBundle_0_sint;
     ; CHECK-NEXT:       assign MyView.vecOfBundle[0].uint = dut.w_vecOfBundle_0_uint;
     ; CHECK-NEXT:       assign MyView.vecOfBundle[1].sint = dut.w_vecOfBundle_1_sint;
@@ -152,6 +200,8 @@ circuit Top :
     ; CHECK-NEXT:       logic uint;
     ; CHECK-NEXT:       // a vector called 'vec'
     ; CHECK-NEXT:       logic vec[0:1];
+    ; CHECK-NEXT:       // a 2D vector called 'multivec'
+    ; CHECK-NEXT:       logic multivec[0:1][0:2];
     ; CHECK-NEXT:       // a vector of a bundle
     ; CHECK-NEXT:       VecOfBundle vecOfBundle[2]();
     ; CHECK-NEXT:       // another bundle

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -341,7 +341,7 @@ firrtl.circuit "VecOfVec" attributes {
 
 // CHECK:      firrtl.module @View_mapping
 // CHECK-NEXT:    assign View.foo[0][0]
-// CHECK-NEXT:    assign View.foo[1][0]
+// CHECK-NEXT:    assign View.foo[0][1]
 
 // CHECK:      sv.interface {{.+}} @Foo
 // CHECK:        sv.interface.signal @foo : !hw.uarray<1xuarray<2xi3>>
@@ -708,3 +708,142 @@ firrtl.circuit "PrefixInterfacesAnnotation"
 
 // Interface "Bar" is prefixed.
 // CHECK:       sv.interface @PREFIX_Bar
+
+// -----
+
+firrtl.circuit "NestedInterfaceVectorTypes" attributes {annotations = [
+  {
+    class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+    id = 0,
+    name = "View",
+    defName = "Foo",
+    elements = [{
+      class = "sifive.enterprise.grandcentral.AugmentedVectorType",
+      name = "bar",
+      description = "description of bar",
+      elements = [
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedVectorType",
+          name = "baz",
+          elements = [
+            {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 1, name = "baz"},
+            {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 2, name = "baz"},
+            {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 3, name = "baz"}
+          ]
+        },
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedVectorType",
+          name = "baz",
+          elements = [
+            {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 4, name = "baz"},
+            {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 5, name = "baz"},
+            {class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 6, name = "baz"}
+          ]
+        }
+      ]
+    }]
+  },
+  {
+    class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
+    directory = "gct-dir",
+    filename = "gct-dir/bindings.sv"
+  }
+]} {
+
+  firrtl.module @View_companion() attributes {annotations = [
+    {class = "sifive.enterprise.grandcentral.ViewAnnotation", defName = "Foo", id = 0, name = "View", type = "companion"}
+  ]} {}
+
+  firrtl.module @DUT(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) attributes {annotations = [
+    {class = "sifive.enterprise.grandcentral.ViewAnnotation", id = 0, name = "view", type = "parent"}
+  ]} {
+    %a0 = firrtl.reg %clock {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 1}]} : !firrtl.uint<1>
+    %a1 = firrtl.reg %clock {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 2}]} : !firrtl.uint<1>
+    %a2 = firrtl.reg %clock {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 3}]} : !firrtl.uint<1>
+    %b0 = firrtl.reg %clock {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 4}]} : !firrtl.uint<1>
+    %b1 = firrtl.reg %clock {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 5}]} : !firrtl.uint<1>
+    %b2 = firrtl.reg %clock {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 6}]} : !firrtl.uint<1>
+    firrtl.instance View_companion @View_companion()
+  }
+
+  firrtl.module @NestedInterfaceVectorTypes() {
+    %dut_clock, %dut_reset = firrtl.instance dut @DUT(in clock: !firrtl.clock, in reset: !firrtl.uint<1>)
+  }
+}
+
+// CHECK-LABEL: firrtl.circuit "NestedInterfaceVectorTypes"
+// CHECK:         firrtl.module @View_mapping
+// CHECK-NEXT:      sv.verbatim "assign View.bar[0][0] = dut.a0;"
+// CHECK-NEXT:      sv.verbatim "assign View.bar[0][1] = dut.a1;"
+// CHECK-NEXT:      sv.verbatim "assign View.bar[0][2] = dut.a2;"
+// CHECK-NEXT:      sv.verbatim "assign View.bar[1][0] = dut.b0;"
+// CHECK-NEXT:      sv.verbatim "assign View.bar[1][1] = dut.b1;"
+// CHECK-NEXT:      sv.verbatim "assign View.bar[1][2] = dut.b2;"
+// CHECK:         sv.interface {
+// CHECK-SAME:      @Foo
+// CHECK-NEXT:      sv.verbatim "// description of bar"
+// CHECK-NEXT:      sv.interface.signal @bar : !hw.uarray<2xuarray<3xi1>>
+
+// -----
+
+firrtl.circuit "VerbatimTypesInVector" attributes {annotations = [
+  {
+    class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+    id = 0,
+    name = "View",
+    defName = "Foo",
+    elements = [{
+      class = "sifive.enterprise.grandcentral.AugmentedVectorType",
+      name = "bar",
+      description = "description of bar",
+      elements = [
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedVectorType",
+          name = "baz",
+          description = "description of baz",
+          elements = [
+            {class = "sifive.enterprise.grandcentral.AugmentedStringType", name = "baz"},
+            {class = "sifive.enterprise.grandcentral.AugmentedStringType", name = "baz"},
+            {class = "sifive.enterprise.grandcentral.AugmentedStringType", name = "baz"}
+          ]
+        },
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedVectorType",
+          name = "baz",
+          description = "description of baz",
+          elements = [
+            {class = "sifive.enterprise.grandcentral.AugmentedStringType", name = "baz"},
+            {class = "sifive.enterprise.grandcentral.AugmentedStringType", name = "baz"},
+            {class = "sifive.enterprise.grandcentral.AugmentedStringType", name = "baz"}
+          ]
+        }
+      ]
+    }]
+  },
+  {
+    class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
+    directory = "gct-dir",
+    filename = "gct-dir/bindings.sv"
+  }
+]} {
+
+  firrtl.module @View_companion() attributes {annotations = [
+    {class = "sifive.enterprise.grandcentral.ViewAnnotation", defName = "Foo", id = 0, name = "View", type = "companion"}
+  ]} {}
+
+  firrtl.module @DUT(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) attributes {annotations = [
+    {class = "sifive.enterprise.grandcentral.ViewAnnotation", id = 0, name = "view", type = "parent"}
+  ]} {
+    firrtl.instance View_companion @View_companion()
+  }
+
+  firrtl.module @VerbatimTypesInVector() {
+    %dut_clock, %dut_reset = firrtl.instance dut @DUT(in clock: !firrtl.clock, in reset: !firrtl.uint<1>)
+  }
+}
+
+// CHECK-LABEL: firrtl.circuit "VerbatimTypesInVector"
+// CHECK:         sv.interface {
+// CHECK-SAME:      @Foo
+// CHECK-NEXT:      sv.verbatim "// description of bar"
+// CHECK-NEXT:      sv.verbatim "// <unsupported string type> bar[2][3];"


### PR DESCRIPTION
The FIRRTL Grand Central pass and ExportVerilog currently order unpacked arrays in reverse upon emission. A nested array like `uarray<2 x uarray<3 x i1>>` has the shape `[[a,b,c], [d,e,f]]` and should produce the following verilog:

    logic foo [2][3]; // non-range indices used for clarity

Generally the following SV declaration:

    logic [2:0][1:0] bar [4:0][3:0];

Reads its dimensions from outer- to innermost as:

    [4:0], [3:0], [2:0], [1:0]

Currently, ExportVerilog will emit the above `foo` example as `foo[3][2]`, which is incorrect. Fixing ExportVerilog also provides a fix for an issue @seldridge tackled earlier in ca5bfac. This change reverts parts of that older fix since the updated declaration order now makes the original Grand Central index order correct.

The output now matches what the Scala FIRRTL compiler produces.