### PR TITLE
[LowerToHW] Lower NonLocalAnchor symbols to hw.innerNameRef in verbatim op

### DIFF
--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -45,7 +45,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-SAME: readLatency = 0 : ui32, readUnderWrite = 0 : ui32,
   // CHECK-SAME: width = 42 : ui32, writeClockIDs = [],
   // CHECK-SAME: writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
-  // CHECK-NEXT: hw.module.generated @FIRRTLMem_1_1_1_40_1022_1_1_4_0_1_a, 
+  // CHECK: hw.module.generated @FIRRTLMem_1_1_1_40_1022_1_1_4_0_1_a, 
   // CHECK-SAME:  @FIRRTLMem(%R0_addr: i10, %R0_en: i1, %R0_clk: i1, %RW0_addr: i10, %RW0_en: i1, %RW0_clk: i1, %RW0_wmode: i1, %RW0_wdata: i40, %RW0_wmask: i4, %W0_addr: i10, %W0_en: i1, %W0_clk: i1, %W0_data: i40, %W0_mask: i4) -> (R0_data: i40, RW0_rdata: i40)
   // CHECK-NEXT:  hw.module.generated @FIRRTLMem_1_1_1_42_12_0_1_1_0_1_a,
   // CHECK-SAME: @FIRRTLMem(%R0_addr: i4, %R0_en: i1, %R0_clk: i1, %RW0_addr: i4, %RW0_en: i1, %RW0_clk: i1, %RW0_wmode: i1, %RW0_wdata: i42, %RW0_wmask: i1, %W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i42, %W0_mask: i1) -> (R0_data: i42, RW0_rdata: i42)
@@ -1188,4 +1188,38 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   }
 
   firrtl.extmodule @chkcoverAnno(in clock: !firrtl.clock) attributes {annotations = [{class = "freechips.rocketchip.annotations.InternalVerifBlackBoxAnnotation"}]}
+
+  // CHECK-LABEL: hw.module @dutModule2()
+  firrtl.module @dutModule2() {
+    %dutMemory_r, %dutMemory_w = firrtl.mem Undefined  {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}, {circt.nonlocal = @nla1, class = "circt.nonlocal"}], depth = 32 : i64, name = "dutMemory", portNames = ["r", "w"], readLatency = 4 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+    // CHECK: hw.instance "dutMemory" @[[nla1_mem:.+]](R0_addr
+    %a = firrtl.wire {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}, {circt.nonlocal = @nla4, class = "circt.nonlocal"}]} : !firrtl.uint<3>
+    // CHECK: %a = sv.wire sym @[[wireName:.+]] : !hw.inout<i3>
+  }
+  // CHECK-LABEL: hw.module @hier1()
+  firrtl.module @hier1() {
+    %clock = firrtl.wire : !firrtl.clock
+    %count = firrtl.reg %clock {name = "count", annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}, {circt.nonlocal = @nla3, class ="circt.nonlocal"}]} : !firrtl.uint<2>
+    // CHECK: %count = sv.reg sym @count  : !hw.inout<i2>
+  }
+  firrtl.module @verbatimNLAtest() {
+    firrtl.instance h1  {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]}@hier1()
+    firrtl.instance m2  {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}, {circt.nonlocal = @nla4, class ="circt.nonlocal"}]}@dutModule()
+  }
+  firrtl.module @dutModule() {
+    firrtl.instance m  {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}, {circt.nonlocal = @nla4, class ="circt.nonlocal"}]}@dutModule2()
+  }
+  firrtl.nla @nla1 [@dutModule2] ["dutMemory"]
+  firrtl.nla @nla4 [@dutModule, @dutModule2] ["m", "a"]
+  firrtl.nla @nla3 [@hier1] ["count"]
+  sv.verbatim "[name : {{0}}]" {output_file = #hw.output_file<"metadata/tb_seq_mems.json", excludeFromFileList>, symbols = [@nla4]}
+  // CHECK: output_file = #hw.output_file<"metadata/tb_seq_mems.json", excludeFromFileList>
+  // CHECK-SAME: symbols = [#hw.innerNameRef<@dutModule2::@[[wireName]]
+  sv.verbatim "name {{0}} name {{1}} depth {{2}} " {output_file = #hw.output_file<"metadata/dutModule.conf", excludeFromFileList>, symbols = [@nla1, @nla4, @nla1, @nla3]}
+  // CHECK: output_file = #hw.output_file<"metadata/dutModule.conf", excludeFromFileList>
+  // CHECK-SAME: [#hw.innerNameRef<@dutModule2::@[[nla1_mem]]
+  // CHECK-SAME: #hw.innerNameRef<@dutModule2::@[[wireName]]
+  // CHECK-SAME: #hw.innerNameRef<@dutModule2::@[[nla1_mem]]
+  // CHECK-SAME: #hw.innerNameRef<@hier1::@count>]
+
 }


### PR DESCRIPTION
The `NonLocalAnchor` can be used for specifying the symbol name in the `VerbatimOp`. 
This PR lowers the `nla` symbol to the corresponding `hw.innerNameRef`. 
For example, the `@nla1` should be lowered to the wire symbol name.
```
  hw.module @dutModule2() {
    %a = sv.wire sym @__dutModule2__a  : !hw.inout<i3>
 }
 firrtl.nla @nla1 [@dutModule, @dutModule2] ["m", "a"]
 sv.verbatim "[name : {{0}}]" {symbols = [@nla1]}
```
Should be lowered to:
```
sv.verbatim "[name : {{0}}]"  symbols = [#hw.innerNameRef<@dutModule2::@__dutModule2__a>]}
```

This requires building a map of `FIRRTL` operation name to the `hw.innerNameRef` for every module.
After all the modules are lowered, the `nla` op is mapped to the corresponding lowered symbol names.
Finally, the `nla` symbol is substituted with the `hw.innerNameRef` corresponding to the leaf of the instance path.

As a future extension, a hierarchical name can be substituted instead of just the leaf symbol name.