### PR TITLE
[FIRRTL][OMIR] Two small format fixes

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -361,6 +361,8 @@ void EmitOMIRPass::emitSourceInfo(Location input, SmallString<64> &into) {
   });
   if (!into.empty())
     into.append("]");
+  else
+    into.append("UnlocatableSourceInfo");
 }
 
 /// Emit an entire `OMNode` as JSON.
@@ -626,7 +628,7 @@ void EmitOMIRPass::emitTrackedTarget(DictionaryAttr node,
     // `OMDeleted` node.
     if (type == "OMReferenceTarget" || type == "OMMemberReferenceTarget" ||
         type == "OMMemberInstanceTarget")
-      return jsonStream.value("OMDeleted");
+      return jsonStream.value("OMDeleted:");
 
     // The remaining types produce an error upon removal of the target.
     auto diag = getOperation().emitError("tracked OMIR target of type `")

--- a/test/Dialect/FIRRTL/emit-omir.mlir
+++ b/test/Dialect/FIRRTL/emit-omir.mlir
@@ -43,7 +43,7 @@ firrtl.circuit "EmptyNode" attributes {annotations = [{class = "freechips.rocket
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
 // CHECK-NEXT:  sv.verbatim
-// CHECK-SAME:  \22info\22: \22\22
+// CHECK-SAME:  \22info\22: \22UnlocatableSourceInfo\22
 // CHECK-SAME:  \22id\22: \22OMID:0\22
 // CHECK-SAME:  \22fields\22: []
 
@@ -228,11 +228,11 @@ firrtl.circuit "DeletedTargets" attributes {annotations = [{
 // CHECK-LABEL: firrtl.circuit "DeletedTargets"
 // CHECK:       sv.verbatim
 // CHECK-SAME:  \22name\22: \22a\22
-// CHECK-SAME:  \22value\22: \22OMDeleted\22
+// CHECK-SAME:  \22value\22: \22OMDeleted:\22
 // CHECK-SAME:  \22name\22: \22b\22
-// CHECK-SAME:  \22value\22: \22OMDeleted\22
+// CHECK-SAME:  \22value\22: \22OMDeleted:\22
 // CHECK-SAME:  \22name\22: \22c\22
-// CHECK-SAME:  \22value\22: \22OMDeleted\22
+// CHECK-SAME:  \22value\22: \22OMDeleted:\22
 
 //===----------------------------------------------------------------------===//
 // Make SRAM Paths Absolute (`SetOMIRSRAMPaths`)


### PR DESCRIPTION
Unknown source information in OMIR should be printing as
`"UnlocatableSourceInfo"` instead of an empty string `""`.

Deleted nodes should be printed with a trailing `:`, as in `OMDeleted:`
instead of `OMDeleted`.