### PR TITLE
[FIRRTL] Output GCT Taps into Extraction Directory

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -310,7 +310,7 @@ def GrandCentral : Pass<"firrtl-grand-central", "CircuitOp"> {
 def GrandCentralTaps : Pass<"firrtl-grand-central-taps", "firrtl::CircuitOp"> {
   let summary = "Generate code for grand central data and memory taps";
   let constructor = "circt::firrtl::createGrandCentralTapsPass()";
-  let dependentDialects = ["sv::SVDialect"];
+  let dependentDialects = ["sv::SVDialect", "circt::hw::HWDialect"];
 }
 
 def GrandCentralSignalMappings : Pass<"firrtl-grand-central-signal-mappings",

--- a/lib/Dialect/FIRRTL/AnnotationDetails.h
+++ b/lib/Dialect/FIRRTL/AnnotationDetails.h
@@ -49,6 +49,8 @@ constexpr const char *referenceKeyClass =
     "sifive.enterprise.grandcentral.ReferenceDataTapKey";
 constexpr const char *internalKeyClass =
     "sifive.enterprise.grandcentral.DataTapModuleSignalKey";
+constexpr const char *extractGrandCentralClass =
+    "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation";
 
 } // namespace firrtl
 } // namespace circt

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "../AnnotationDetails.h"
 #include "PassDetails.h"
 #include "circt/Dialect/FIRRTL/CircuitNamespace.h"
 #include "circt/Dialect/FIRRTL/FIRRTLAttributes.h"
@@ -896,8 +897,7 @@ void GrandCentralPass::runOnOperation() {
       worklist.push_back(anno);
       return true;
     }
-    if (anno.isClass(
-            "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation")) {
+    if (anno.isClass(extractGrandCentralClass)) {
       if (maybeExtractInfo.hasValue()) {
         emitCircuitError("more than one 'ExtractGrandCentralAnnotation' was "
                          "found, but exactly one must be provided");

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -18,6 +18,7 @@
 #include "circt/Dialect/FIRRTL/FIRRTLVisitors.h"
 #include "circt/Dialect/FIRRTL/InstanceGraph.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
+#include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Dialect/SV/SVOps.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "llvm/ADT/STLExtras.h"
@@ -301,6 +302,10 @@ class GrandCentralTapsPass : public GrandCentralTapsBase<GrandCentralTapsPass> {
   DenseMap<Key, Operation *> tappedOps;
   DenseMap<Key, Port> tappedPorts;
   SmallVector<PortWiring, 8> portWiring;
+
+  /// The name of the directory where data and mem tap modules should be
+  /// output.
+  StringAttr maybeExtractDirectory = {};
 };
 
 void GrandCentralTapsPass::runOnOperation() {
@@ -330,6 +335,19 @@ void GrandCentralTapsPass::runOnOperation() {
   //   - ReferenceDataTapKey: relative path with "." + source name
   //   - DataTapModuleSignalKey: relative path with "." + internal path
   // - Generate a body for the blackbox module with the signal mapping
+
+  AnnotationSet circuitAnnotations(circuitOp);
+  if (auto dict = circuitAnnotations.getAnnotation(extractGrandCentralClass)) {
+    auto directory = dict.getAs<StringAttr>("directory");
+    if (!directory) {
+      circuitOp->emitError()
+          << "contained an invalid 'ExtractGrandCentralAnnotation' that does "
+             "not contain a 'directory' field: "
+          << dict;
+      return signalPassFailure();
+    }
+    maybeExtractDirectory = directory;
+  }
 
   // Gather a list of extmodules that have data or mem tap annotations to be
   // expanded.
@@ -465,6 +483,14 @@ void GrandCentralTapsPass::runOnOperation() {
                  << blackBox.extModule.getName() << " for " << path << ")\n");
       auto impl =
           builder.create<FModuleOp>(name, ports, blackBox.filteredModuleAnnos);
+      // If extraction information was provided via an
+      // `ExtractGrandCentralAnnotation`, put the created data or memory taps
+      // inside this directory.
+      if (maybeExtractDirectory)
+        impl->setAttr("output_file",
+                      hw::OutputFileAttr::getFromDirectoryAndFilename(
+                          &getContext(), maybeExtractDirectory.getValue(),
+                          impl.getName() + ".sv"));
       builder.setInsertionPointToEnd(impl.getBody());
 
       // Connect the output ports to the appropriate tapped object.

--- a/test/Dialect/FIRRTL/grand-central-taps.mlir
+++ b/test/Dialect/FIRRTL/grand-central-taps.mlir
@@ -3,8 +3,8 @@
 firrtl.circuit "TestHarness" attributes {
   annotations = [{
     class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
-    directory = "builds/sandbox/dataTaps/firrtl",
-    filename = "builds/sandbox/dataTaps/firrtl/bindings.sv"
+    directory = "outputDirectory",
+    filename = "outputDirectory/bindings.sv"
   }]
 } {
   // CHECK-LABEL: firrtl.module @Bar
@@ -116,7 +116,7 @@ firrtl.circuit "TestHarness" attributes {
     firrtl.connect %out, %bar_out : !firrtl.uint<1>, !firrtl.uint<1>
   }
 
-  // CHECK: firrtl.module [[DT:@DataTap.*]](
+  // CHECK: firrtl.module @[[DT:DataTap.*]](
   // CHECK-SAME: out %_9: !firrtl.uint<1>
   // CHECK-SAME: out %_8: !firrtl.sint<8>
   // CHECK-SAME: out %_7: !firrtl.uint<1>
@@ -127,6 +127,7 @@ firrtl.circuit "TestHarness" attributes {
   // CHECK-SAME: out %_2: !firrtl.uint<1>
   // CHECK-SAME: out %_1: !firrtl.clock
   // CHECK-SAME: out %_0: !firrtl.uint<1>
+  // CHECK-SAME: #hw.output_file<"outputDirectory/[[DT]].sv">
   // CHECK-NEXT: [[V9:%.+]] = firrtl.constant 0 : !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %_9, [[V9]]
   // CHECK-NEXT: [[V8:%.+]] = firrtl.constant -42 : !firrtl.sint<8>
@@ -178,11 +179,12 @@ firrtl.circuit "TestHarness" attributes {
     defname = "DataTap"
   }
 
-  // CHECK: firrtl.module [[MT:@MemTap.*]](
+  // CHECK: firrtl.module @[[MT:MemTap.*]](
   // CHECK-NOT: class = "sifive.enterprise.grandcentral.MemTapAnnotation"
   // CHECK-SAME: out %mem_0: !firrtl.uint<1>
   // CHECK-SAME: out %mem_1: !firrtl.uint<1>
   // CHECK-SAME: class = "firrtl.transforms.NoDedupAnnotation"
+  // CHECK-SAME: #hw.output_file<"outputDirectory/[[MT]].sv">
   // CHECK-NEXT: [[V0:%.+]] = firrtl.verbatim.expr "foo.bar.mem.Memory[0]"
   // CHECK-NEXT: firrtl.connect %mem_0, [[V0:%.+]]
   // CHECK-NEXT: [[V1:%.+]] = firrtl.verbatim.expr "foo.bar.mem.Memory[1]"
@@ -227,9 +229,9 @@ firrtl.circuit "TestHarness" attributes {
     firrtl.connect %out, %foo_out : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.instance bigScary @BlackHole()
     %0 = firrtl.instance extmoduleWithTappedPort @ExtmoduleWithTappedPort(out out: !firrtl.uint<1>)
-    // CHECK: firrtl.instance dataTap [[DT]]
+    // CHECK: firrtl.instance dataTap @[[DT]]
     %DataTap_9, %DataTap_8, %DataTap_7, %DataTap_6, %DataTap_5, %DataTap_4, %DataTap_3, %DataTap_2, %DataTap_1, %DataTap_0 = firrtl.instance dataTap @DataTap(out _9: !firrtl.uint<1>, out _8: !firrtl.sint<8>, out _7: !firrtl.uint<1>, out _6: !firrtl.uint<1>, out _5: !firrtl.uint<1>, out _4: !firrtl.uint<1>, out _3: !firrtl.uint<1>, out _2: !firrtl.uint<1>, out _1: !firrtl.clock, out _0: !firrtl.uint<1>)
-    // CHECK: firrtl.instance memTap [[MT]]
+    // CHECK: firrtl.instance memTap @[[MT]]
     %MemTap_mem_0, %MemTap_mem_1 = firrtl.instance memTap @MemTap(out mem_0: !firrtl.uint<1>, out mem_1: !firrtl.uint<1>)
   }
 }


### PR DESCRIPTION
Change the Grand Central Taps pass to output (via the output file
attribute) data and memory taps it creates to a directory indicated by
an optional ExtractGrandCentralAnnotation.  If this annotation does not
exist, do nothing.  This change is made to align Grand Central behavior
with the Scala FIRRTL Compiler.