### PR TITLE
[HandshakeToFIRRTL] Add top module inference and instance cycle detection

### DIFF
--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -2313,9 +2313,10 @@ static LogicalResult resolveInstanceGraph(ModuleOp moduleOp,
         sorted.insert(sorted.begin(), node);
       };
   for (auto it : instanceGraph) {
-    if (visited.count(it.first) == 0 && !cyclic) {
+    if (visited.count(it.first) == 0)
       cycleUtil(it.first, {});
-    }
+    if (cyclic)
+      break;
   }
 
   if (cyclic) {
@@ -2335,7 +2336,7 @@ static LogicalResult resolveInstanceGraph(ModuleOp moduleOp,
     err << "multiple candidate top-level modules detected (";
     llvm::interleaveComma(candidateTopLevel, err,
                           [&](auto topLevel) { err << topLevel; });
-    err << "). Please remove one of these from the input file.";
+    err << "). Please remove one of these from the source program.";
     return err;
   }
   topLevel = *candidateTopLevel.begin();

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -2262,6 +2262,8 @@ struct HandshakeFuncOpLowering : public OpConversionPattern<handshake::FuncOp> {
   }
 
 private:
+  /// Top level FIRRTL circuit operation, which we'll emit into. Marked as
+  /// mutable due to circuitOp.getBody() being non-const.
   mutable CircuitOp circuitOp;
 };
 

--- a/test/Conversion/HandshakeToFIRRTL/errors.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/errors.mlir
@@ -22,7 +22,7 @@ module {
 // -----
 
 // test multiple candidate top components
-// expected-error @+1 {{'builtin.module' op multiple candidate top-level modules detected (bar, foo). Please remove one of these from the input file.}}
+// expected-error @+1 {{'builtin.module' op multiple candidate top-level modules detected (bar, foo). Please remove one of these from the source program.}}
 module {
   handshake.func @bar(%ctrl : none) -> (none) {
     %0 = handshake.instance @baz(%ctrl) : (none) -> (none)

--- a/test/Conversion/HandshakeToFIRRTL/errors.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/errors.mlir
@@ -1,0 +1,40 @@
+// RUN: circt-opt -lower-handshake-to-firrtl -verify-diagnostics -split-input-file %s
+
+// Test cycle through a component
+// expected-error @+1 {{'builtin.module' op cannot lower handshake program - cycle detected in instance graph (bar->baz->foo->bar).}}
+module {
+  handshake.func @bar(%ctrl : none) -> (none) {
+    %0 = handshake.instance @baz(%ctrl) : (none) -> (none)
+    handshake.return %0: none
+  }
+
+  handshake.func @foo(%ctrl : none) -> (none) {
+    %0 = handshake.instance @bar(%ctrl) : (none) -> (none)
+    handshake.return %0: none  
+  }
+  
+  handshake.func @baz(%ctrl : none) -> (none) {
+    %0 = handshake.instance @foo(%ctrl) : (none) -> (none)
+    handshake.return %0: none  
+  }
+}
+
+// -----
+
+// test multiple candidate top components
+// expected-error @+1 {{'builtin.module' op multiple candidate top-level modules detected (bar, foo). Please remove one of these from the input file.}}
+module {
+  handshake.func @bar(%ctrl : none) -> (none) {
+    %0 = handshake.instance @baz(%ctrl) : (none) -> (none)
+    handshake.return %0: none
+  }
+
+  handshake.func @foo(%ctrl : none) -> (none) {
+    %0 = handshake.instance @baz(%ctrl) : (none) -> (none)
+    handshake.return %0: none  
+  }
+  
+  handshake.func @baz(%ctrl : none) -> (none) {
+    handshake.return %ctrl: none  
+  }
+}


### PR DESCRIPTION
In preparation for supporting `handshake.instance` lowering, this commit introduces top module inference and instance cycle detection. The IR is topologically sorted based on `handshake.instance` usage. During this, we check for instance cycles (and report them to the user) as well as top-module detection. For now, if multiple top modules are available, an error is thrown.

Furthermore, the `firrtl.circuit` op is now created outside of the `handshake.func` operation lowering, based on the inferred top-level name.