### PR TITLE
[HW][SV][ExportVerilog] Add Comment to HWModuleOp, Verilog Emission

### DIFF
--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -29,7 +29,8 @@ def HWModuleOp : HWOp<"module",
     connections within the module.
   }];
   let arguments = (ins StrArrayAttr:$argNames, StrArrayAttr:$resultNames,
-                       ParamDeclArrayAttr:$parameters);
+                       ParamDeclArrayAttr:$parameters,
+                       StrAttr:$comment);
   let results = (outs);
   let regions = (region SizedRegion<1>:$body);
 
@@ -37,10 +38,12 @@ def HWModuleOp : HWOp<"module",
   let builders = [
     OpBuilder<(ins "StringAttr":$name, "ArrayRef<PortInfo>":$ports,
                    CArg<"ArrayAttr", "{}">:$parameters,
-                   CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes)>,
+                   CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes,
+                   CArg<"StringAttr", "{}">:$comment)>,
     OpBuilder<(ins "StringAttr":$name, "const ModulePortInfo &":$ports,
                    CArg<"ArrayAttr", "{}">:$parameters,
-                   CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes)>
+                   CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes,
+                   CArg<"StringAttr", "{}">:$comment)>
   ];
 
   let extraClassDeclaration = [{

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -921,3 +921,9 @@ hw.module @parameterizedTypes<param: i32 = 1, wire: i32 = 2>
   %paramWire = sv.wire : !hw.inout<!hw.int<#hw.param.decl.ref<"wire">>>
 
 }
+
+// CHECK-LABEL: // moduleWithComment has a comment
+// CHECK-NEXT:  // hello
+// CHECK-NEXT:  module moduleWithComment
+hw.module @moduleWithComment()
+  attributes {comment = "moduleWithComment has a comment\nhello"} {}

--- a/test/Conversion/ExportVerilog/line-length.mlir
+++ b/test/Conversion/ExportVerilog/line-length.mlir
@@ -45,3 +45,21 @@ hw.module @longvariadic(%a: i8) -> (b: i8) {
 // LIMIT_LONG-NEXT:   wire [7:0] _tmp_0 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
 // LIMIT_LONG-NEXT:                       a + a + a + a + a + a + a + a + a;
 // LIMIT_LONG-NEXT:   assign b = _tmp + _tmp_0;
+
+hw.module @moduleWithComment()
+  attributes {comment = "The quick brown fox jumps over the lazy dog.  The quick brown fox jumps over the lazy dog.\naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"} {}
+
+// SHORT-LABEL:   // The quick brown fox jumps over the
+// SHORT-NEXT:    // lazy dog.  The quick brown fox jumps
+// SHORT-NEXT:    // over the lazy dog.
+// SHORT-NEXT:    // aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+// SHORT-NEXT:    module moduleWithComment
+//
+// DEFAULT-LABEL: // The quick brown fox jumps over the lazy dog.  The quick brown fox jumps over the lazy
+// DEFAULT-NEXT:  // dog.
+// DEFAULT-NEXT:  // aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+// DEFAULT-NEXT:  module moduleWithComment
+//
+// LONG-LABEL:    // The quick brown fox jumps over the lazy dog.  The quick brown fox jumps over the lazy dog.
+// LONG-NEXT:     // aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+// LONG-NEXT:     module moduleWithComment

--- a/test/Dialect/HW/basic.mlir
+++ b/test/Dialect/HW/basic.mlir
@@ -148,3 +148,7 @@ hw.module @argRenames(%arg1: i32) attributes {argNames = [""]} {
 
 hw.module @fileListTest(%arg1: i32) attributes {output_filelist = #hw.output_filelist<"foo.f">} {
 }
+
+// CHECK-LABEL: hw.module @commentModule
+// CHECK-SAME: attributes {comment = "hello world"}
+hw.module @commentModule() attributes {comment = "hello world"} {}


### PR DESCRIPTION
- [HW] Add Comment to HWModuleOp

Add a new mandatory attribute, "comment", to HWModuleOp that describes a
string comment that should be attached to that module when this module
is emitted by a backend.

- [ExportVerilog] Emit HWModuleOp Comments

Add support for emitting comments associated with HWModuleOps during
ExportVerilog.  Use a simple line breaking algorithm to try to respect
the emittedLineLength option when reasonably possible.

Add tests that comments are emitted and that line breaking changes as
expected with changes to emittedLineLength.

Towards #1677.