### PR TITLE
[ExportVerilog] Don't spill expressions which are used only once

### DIFF
--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -85,6 +85,10 @@ struct LoweringOptions {
   /// statements to be labeled.
   bool enforceVerifLabels = false;
 
+  /// https://github.com/verilator/verilator/issues/2752
+  enum { DEFAULT_TOKEN_NUMBER = 40000 };
+  unsigned maximumNumberOfTokensOnLine = DEFAULT_LINE_LENGTH;
+
   /// This is the target width of lines in an emitted Verilog source file in
   /// columns.
   enum { DEFAULT_LINE_LENGTH = 90 };

--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -87,7 +87,7 @@ struct LoweringOptions {
 
   /// https://github.com/verilator/verilator/issues/2752
   enum { DEFAULT_TOKEN_NUMBER = 40000 };
-  unsigned maximumNumberOfTokensOnLine = DEFAULT_LINE_LENGTH;
+  unsigned maximumNumberOfTokens = DEFAULT_TOKEN_NUMBER;
 
   /// This is the target width of lines in an emitted Verilog source file in
   /// columns.

--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -85,9 +85,10 @@ struct LoweringOptions {
   /// statements to be labeled.
   bool enforceVerifLabels = false;
 
+  /// This parameter limits the maximum number of tokes per one experssion.
   /// https://github.com/verilator/verilator/issues/2752
-  enum { DEFAULT_TOKEN_NUMBER = 40000 };
-  unsigned maximumNumberOfTokens = DEFAULT_TOKEN_NUMBER;
+  enum { DEFAULT_TOKEN_NUMBER = 20000 };
+  unsigned maximumNumberOfTokensPerExpression = DEFAULT_TOKEN_NUMBER;
 
   /// This is the target width of lines in an emitted Verilog source file in
   /// columns.

--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -87,7 +87,7 @@ struct LoweringOptions {
 
   /// This parameter limits the maximum number of tokes per one experssion.
   /// https://github.com/verilator/verilator/issues/2752
-  enum { DEFAULT_TOKEN_NUMBER = 20000 };
+  enum { DEFAULT_TOKEN_NUMBER = 40000 };
   unsigned maximumNumberOfTokensPerExpression = DEFAULT_TOKEN_NUMBER;
 
   /// This is the target width of lines in an emitted Verilog source file in

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1401,12 +1401,15 @@ void ExprEmitter::formatOutBuffer() {
   SmallVector<char> tmpOutBuffer;
   llvm::raw_svector_ostream tmpOs(tmpOutBuffer);
   auto it = outBuffer.begin();
-  unsigned int currentIndex = 0;
+  unsigned currentIndex = 0;
+
   while (it != outBuffer.end()) {
+    // Split by a white space.
     auto next = std::find(it, outBuffer.end(), ' ');
-    unsigned int tokenLength = std::distance(it, next);
+    unsigned tokenLength = std::distance(it, next);
 
     if (currentIndex + tokenLength > state.options.emittedLineLength) {
+      // It breaks the line constraint, so insert a newline and indent.
       tmpOs << '\n';
       tmpOs.indent(state.currentIndent *
                    SPACE_PER_INDENT_IN_EXPRESSION_FORMATTING);
@@ -1422,11 +1425,12 @@ void ExprEmitter::formatOutBuffer() {
       }
       tmpOutBuffer.insert(tmpOutBuffer.end(), it, next);
     }
+
     if (next == outBuffer.end())
       break;
     it = next + 1;
   }
-  outBuffer.swap(tmpOutBuffer);
+  outBuffer = std::move(tmpOutBuffer);
 }
 
 /// We eagerly emit single-use expressions inline into big expression trees...

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1521,7 +1521,7 @@ SubExprInfo ExprEmitter::emitSubExpr(Value exp,
                          signRequirement);
     };
 
-    if (getenv("NO") || !op->hasOneUse())
+    if (!op->hasOneUse())
       return emitExpressionIntoTemporary();
 
     // If op has only one use, we don't have to spill the expression.
@@ -1530,8 +1530,8 @@ SubExprInfo ExprEmitter::emitSubExpr(Value exp,
     SmallVector<char> tmpOutBuffer;
     llvm::raw_svector_ostream tmpOs(tmpOutBuffer);
 
-    // Since outBuffer already contains newline characters, replace them with
-    // spaces.
+    // Since outBuffer already contains newline characters in the recursive
+    // calls, replace them with spaces to align with the current subexpression.
     std::replace(outBuffer.begin() + subExprStartIndex, outBuffer.end(), '\n',
                  ' ');
 

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1541,18 +1541,7 @@ SubExprInfo ExprEmitter::emitSubExpr(Value exp,
     unsigned int currentPosition = 0;
     while (it != outBuffer.end()) {
       auto next = std::find(it, outBuffer.end(), ' ');
-      /*
-      if (it == next) {
-        tmpOs << " ";
-        it = next + 1;
-        currentPosition++;
-        continue;
-      }
-      */
       unsigned int length = std::distance(it, next);
-
-      LLVM_DEBUG(llvm::dbgs() << "Len " << length << " " << currentPosition
-                              << " " << threshold << "\n";);
 
       if (currentPosition + length >= threshold) {
         assert(length <= threshold);

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -2310,12 +2310,6 @@ private:
 void StmtEmitter::emitExpression(Value exp,
                                  SmallPtrSet<Operation *, 8> &emittedExprs,
                                  VerilogPrecedence parenthesizeIfLooserThan) {
-  /*
-assert(savedStmtIndent.hasValue() &&
-os.GetNumBytesInBuffer() > savedStmtIndent.getValue() &&
-"savedStmtIndent must be valid here.");
-*/
-
   SmallVector<char, 128> exprBuffer;
   SmallVector<Operation *> tooLargeSubExpressions;
   ExprEmitter(emitter, exprBuffer, emittedExprs, tooLargeSubExpressions, names)

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1140,7 +1140,8 @@ public:
   /// expression, we emit that expression, otherwise we emit a reference to the
   /// already computed name.
   ///
-  void emitExpression(Value exp, VerilogPrecedence parenthesizeIfLooserThan) {
+  void emitExpression(Value exp, VerilogPrecedence parenthesizeIfLooserThan,
+                      int indentLevel) {
     // Emit the expression.
     emitSubExpr(exp, parenthesizeIfLooserThan, OOLTopLevel,
                 /*signRequirement*/ NoRequirement);
@@ -2189,6 +2190,7 @@ private:
 
   void
   emitExpression(Value exp, SmallPtrSet<Operation *, 8> &emittedExprs,
+                 int indentLevel = -1,
                  VerilogPrecedence parenthesizeIfLooserThan = LowestPrecedence);
 
   using StmtVisitor::visitStmt;
@@ -2306,11 +2308,12 @@ private:
 ///
 void StmtEmitter::emitExpression(Value exp,
                                  SmallPtrSet<Operation *, 8> &emittedExprs,
+                                 int indentLevel,
                                  VerilogPrecedence parenthesizeIfLooserThan) {
   SmallVector<char, 128> exprBuffer;
   SmallVector<Operation *> tooLargeSubExpressions;
   ExprEmitter(emitter, exprBuffer, emittedExprs, tooLargeSubExpressions, names)
-      .emitExpression(exp, parenthesizeIfLooserThan);
+      .emitExpression(exp, parenthesizeIfLooserThan, indentLevel);
   os.write(exprBuffer.data(), exprBuffer.size());
 
   // It is possible that the emitted expression was too large to fit on a line

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1567,9 +1567,9 @@ SubExprInfo ExprEmitter::emitSubExpr(Value exp,
 
     // If op has multiple uses or op is a too large expression, we have to spill
     // the expression.
-    if (getenv("NO") || !op->hasOneUse() ||
-        (outBuffer.size() - subExprStartIndex) >
-            state.options.maximumNumberOfTokens)
+    if (!op->hasOneUse() ||
+        outBuffer.size() - subExprStartIndex >
+            state.options.maximumNumberOfTokensPerExpression)
       return emitExpressionIntoTemporary();
   }
 

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -57,6 +57,12 @@ void LoweringOptions::parse(StringRef text, ErrorHandlerT errorHandler) {
         errorHandler("expected integer source width");
         emittedLineLength = DEFAULT_LINE_LENGTH;
       }
+    } else if (option.startswith("maximumNumberOfTokensPerExpression=")) {
+      option = option.drop_front(strlen("maximumNumberOfTokensPerExpression="));
+      if (option.getAsInteger(10, maximumNumberOfTokensPerExpression)) {
+        errorHandler("expected integer source width");
+        emittedLineLength = DEFAULT_LINE_LENGTH;
+      }
     } else {
       errorHandler(llvm::Twine("unknown style option \'") + option + "\'");
       // We continue parsing options after a failure.
@@ -82,6 +88,9 @@ std::string LoweringOptions::toString() const {
 
   if (emittedLineLength != DEFAULT_LINE_LENGTH)
     options += "emittedLineLength=" + std::to_string(emittedLineLength) + ',';
+  if (maximumNumberOfTokensPerExpression != DEFAULT_TOKEN_NUMBER)
+    options += "maximumNumberOfTokensPerExpression=" +
+               std::to_string(maximumNumberOfTokensPerExpression) + ',';
 
   // Remove a trailing comma if present.
   if (!options.empty()) {
@@ -133,7 +142,8 @@ struct LoweringCLOptions {
       llvm::cl::desc(
           "Style options.  Valid flags include: alwaysFF, "
           "noAlwaysComb, exprInEventControl, disallowPackedArrays, "
-          "disallowLocalVariables, verifLabels, emittedLineLength=<n>"),
+          "disallowLocalVariables, verifLabels, emittedLineLength=<n>,"
+          "maximumNumberOfTokensPerExpression=<n>"),
       llvm::cl::value_desc("option")};
 };
 } // namespace

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -61,13 +61,16 @@ void LoweringOptions::parse(StringRef text, ErrorHandlerT errorHandler) {
       option = option.drop_front(strlen("maximumNumberOfTokensPerExpression="));
       if (option.getAsInteger(10, maximumNumberOfTokensPerExpression)) {
         errorHandler("expected integer source width");
-        emittedLineLength = DEFAULT_LINE_LENGTH;
+        maximumNumberOfTokensPerExpression = DEFAULT_TOKEN_NUMBER;
       }
     } else {
       errorHandler(llvm::Twine("unknown style option \'") + option + "\'");
       // We continue parsing options after a failure.
     }
   }
+  if (maximumNumberOfTokensPerExpression < emittedLineLength)
+    errorHandler("maximumNumberOfTokensPerExpression must be equal or larger "
+                 "than emittedLineLength");
 }
 
 std::string LoweringOptions::toString() const {

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -368,7 +368,7 @@ hw.module @signs(%in1: i4, %in2: i4, %in3: i4, %in4: i4)  {
   sv.assign %awire, %a3: i4
 
   // CHECK: assign awire = $unsigned($signed(in1) / $signed(in2) + $signed(in1) / $signed(in2)) /
-  //                       $unsigned($signed(in1) / $signed(in2) * $signed(in1) / $signed(in2));
+  // CHECK-NEXT:           $unsigned($signed(in1) / $signed(in2) * $signed(in1) / $signed(in2));
   %b1a = comb.divs %in1, %in2: i4
   %b1b = comb.divs %in1, %in2: i4
   %b1c = comb.divs %in1, %in2: i4
@@ -463,10 +463,10 @@ hw.module @cyclic(%a: i1) -> (b: i1) {
 // CHECK-LABEL: module longExpressions
 hw.module @longExpressions(%a: i8, %a2: i8) -> (b: i8) {
   // CHECK:  assign b = (a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a)
-  // CHECK:              * (a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
-  // CHECK:              a) | (a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a
-  // CHECK:              + a) * (a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
-  // CHECK:              a + a);
+  // CHECK-NEXT:        * (a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
+  // CHECK-NEXT:        a) | (a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a
+  // CHECK-NEXT:        + a) * (a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
+  // CHECK-NEXT:        a + a);
 
   %1 = comb.add %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a : i8
   %2 = comb.add %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a : i8
@@ -481,18 +481,9 @@ hw.module @longExpressions(%a: i8, %a2: i8) -> (b: i8) {
 // https://github.com/llvm/circt/issues/668
 // CHECK-LABEL: module longvariadic
 hw.module @longvariadic(%a: i8) -> (b: i8) {
-  // CHECK:  assign b = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
-  // CHECK:             a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
-  // CHECK:             a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
-  // CHECK:             a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
-  // CHECK:             a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
-  // CHECK:             a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
-  // CHECK:             a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
-  // CHECK:             a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
-  // CHECK:             a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
-  // CHECK:             a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
-  // CHECK:             a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
-  // CHECK:             a + a + a;
+  // CHECK:  assign b =
+  // CHECK-COUNT-11: a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
+  // CHECK-NEXT:     a + a + a;
 
   %1 = comb.add %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a,
                 %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a,

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -367,9 +367,8 @@ hw.module @signs(%in1: i4, %in2: i4, %in3: i4, %in4: i4)  {
   %a3 = comb.divu %a1, %a2: i4
   sv.assign %awire, %a3: i4
 
-  // CHECK: assign awire = $unsigned($signed(in1) / $signed(in2) +
-  // CHECK: $signed(in1) / $signed(in2)) / $unsigned($signed(in1) / $signed(in2) *
-  // CHECK: $signed(in1) / $signed(in2));
+  // CHECK: assign awire = $unsigned($signed(in1) / $signed(in2) + $signed(in1) / $signed(in2)) /
+  //                       $unsigned($signed(in1) / $signed(in2) * $signed(in1) / $signed(in2));
   %b1a = comb.divs %in1, %in2: i4
   %b1b = comb.divs %in1, %in2: i4
   %b1c = comb.divs %in1, %in2: i4
@@ -463,13 +462,12 @@ hw.module @cyclic(%a: i1) -> (b: i1) {
 // https://github.com/llvm/circt/issues/668
 // CHECK-LABEL: module longExpressions
 hw.module @longExpressions(%a: i8, %a2: i8) -> (b: i8) {
-  // CHECK:  assign b = (a + a + a + a + a + a + a + a + a + a + a + a
-  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a) *
-  // CHECK-NEXT: (a + a + a + a + a + a + a + a + a + a + a + a
-  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a) | (a + a + a + a + a + a + a + a + a + a + a + a
-  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a) *
-  // CHECK-NEXT: (a + a + a + a + a + a + a + a + a + a + a + a
-  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a);
+  // CHECK:  assign b = (a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a)
+  // CHECK:              * (a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
+  // CHECK:              a) | (a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a
+  // CHECK:              + a) * (a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
+  // CHECK:              a + a);
+
   %1 = comb.add %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a : i8
   %2 = comb.add %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a : i8
   %3 = comb.add %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a : i8
@@ -483,29 +481,19 @@ hw.module @longExpressions(%a: i8, %a2: i8) -> (b: i8) {
 // https://github.com/llvm/circt/issues/668
 // CHECK-LABEL: module longvariadic
 hw.module @longvariadic(%a: i8) -> (b: i8) {
-  // CHECK:  assign b = a + a + a + a + a + a + a + a + a + a + a + a
-  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a +
-  // CHECK-NEXT: a + a + a + a + a + a + a + a + a + a + a + a
-  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a +
-  // CHECK-NEXT: a + a + a + a + a + a + a + a + a + a + a + a
-  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a +
-  // CHECK-NEXT: a + a + a + a + a + a + a + a + a + a + a + a
-  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a +
-  // CHECK-NEXT: a + a + a + a + a + a + a + a + a + a + a + a
-  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a +
-  // CHECK-NEXT: a + a + a + a + a + a + a + a + a + a + a + a
-  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a + a + a
-  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a +
-  // CHECK-NEXT: a + a + a + a + a + a + a + a + a + a + a + a
-  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a +
-  // CHECK-NEXT: a + a + a + a + a + a + a + a + a + a + a + a
-  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a +
-  // CHECK-NEXT: a + a + a + a + a + a + a + a + a + a + a + a
-  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a +
-  // CHECK-NEXT: a + a + a + a + a + a + a + a + a + a + a + a
-  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a +
-  // CHECK-NEXT: a + a + a + a + a + a + a + a + a + a + a + a
-  // CHECK-NEXT: + a;
+  // CHECK:  assign b = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
+  // CHECK:             a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
+  // CHECK:             a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
+  // CHECK:             a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
+  // CHECK:             a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
+  // CHECK:             a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
+  // CHECK:             a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
+  // CHECK:             a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
+  // CHECK:             a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
+  // CHECK:             a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
+  // CHECK:             a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
+  // CHECK:             a + a + a;
+
   %1 = comb.add %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a,
                 %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a,
                 %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a,

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -367,9 +367,9 @@ hw.module @signs(%in1: i4, %in2: i4, %in3: i4, %in4: i4)  {
   %a3 = comb.divu %a1, %a2: i4
   sv.assign %awire, %a3: i4
 
-  // CHECK: wire [3:0] _tmp = $signed(in1) / $signed(in2) + $signed(in1) / $signed(in2);
-  // CHECK: wire [3:0] _tmp_0 = $signed(in1) / $signed(in2) * $signed(in1) / $signed(in2);
-  // CHECK: assign awire = _tmp / _tmp_0;
+  // CHECK: assign awire = $unsigned($signed(in1) / $signed(in2) +
+  // CHECK: $signed(in1) / $signed(in2)) / $unsigned($signed(in1) / $signed(in2) *
+  // CHECK: $signed(in1) / $signed(in2));
   %b1a = comb.divs %in1, %in2: i4
   %b1b = comb.divs %in1, %in2: i4
   %b1c = comb.divs %in1, %in2: i4
@@ -463,15 +463,17 @@ hw.module @cyclic(%a: i1) -> (b: i1) {
 // https://github.com/llvm/circt/issues/668
 // CHECK-LABEL: module longExpressions
 hw.module @longExpressions(%a: i8, %a2: i8) -> (b: i8) {
-  // CHECK: wire [7:0] _tmp = a + a + a + a + a
+  // CHECK:  assign b = (a + a + a + a + a + a + a + a + a + a + a + a
+  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a) *
+  // CHECK-NEXT: (a + a + a + a + a + a + a + a + a + a + a + a
+  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a) | (a + a + a + a + a + a + a + a + a + a + a + a
+  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a) *
+  // CHECK-NEXT: (a + a + a + a + a + a + a + a + a + a + a + a
+  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a);
   %1 = comb.add %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a : i8
-  // CHECK-NEXT: wire [7:0] _tmp_0 = a + a + a
   %2 = comb.add %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a : i8
-  // CHECK-NEXT: wire [7:0] _tmp_1 = a + a + a + a + a + a + a + a
   %3 = comb.add %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a : i8
-  // CHECK-NEXT: wire [7:0] _tmp_2 = a + a + a + a + a + a + a + a
   %4 = comb.add %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a : i8
-  // CHECK-NEXT: assign b = _tmp * _tmp_0 | _tmp_1 * _tmp_2;
   %5 = comb.mul %1, %2 : i8
   %6 = comb.mul %3, %4 : i8
   %7 = comb.or %5, %6 : i8
@@ -481,25 +483,29 @@ hw.module @longExpressions(%a: i8, %a2: i8) -> (b: i8) {
 // https://github.com/llvm/circt/issues/668
 // CHECK-LABEL: module longvariadic
 hw.module @longvariadic(%a: i8) -> (b: i8) {
-  // CHECK: wire [7:0] _tmp = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
-  // CHECK: wire [7:0] _tmp_0 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
-  // CHECK: wire [7:0] _tmp_1 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
-  // CHECK: wire [7:0] _tmp_2 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
-  // CHECK: wire [7:0] _tmp_3 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
-  // CHECK: wire [7:0] _tmp_4 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
-  // CHECK: wire [7:0] _tmp_5 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
-  // CHECK: wire [7:0] _tmp_6 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
-  // CHECK: wire [7:0] _tmp_7 = _tmp + _tmp_0 + _tmp_1 + _tmp_2 + _tmp_3 + _tmp_4 + _tmp_5 + _tmp_6;
-  // CHECK: wire [7:0] _tmp_8 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
-  // CHECK: wire [7:0] _tmp_9 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
-  // CHECK: wire [7:0] _tmp_10 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
-  // CHECK: wire [7:0] _tmp_11 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
-  // CHECK: wire [7:0] _tmp_12 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
-  // CHECK: wire [7:0] _tmp_13 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
-  // CHECK: wire [7:0] _tmp_14 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
-  // CHECK: wire [7:0] _tmp_15 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
-  // CHECK: wire [7:0] _tmp_16 = _tmp_8 + _tmp_9 + _tmp_10 + _tmp_11 + _tmp_12 + _tmp_13 + _tmp_14 + _tmp_15;
-  // CHECK: assign b = _tmp_7 + _tmp_16;
+  // CHECK:  assign b = a + a + a + a + a + a + a + a + a + a + a + a
+  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a +
+  // CHECK-NEXT: a + a + a + a + a + a + a + a + a + a + a + a
+  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a +
+  // CHECK-NEXT: a + a + a + a + a + a + a + a + a + a + a + a
+  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a +
+  // CHECK-NEXT: a + a + a + a + a + a + a + a + a + a + a + a
+  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a +
+  // CHECK-NEXT: a + a + a + a + a + a + a + a + a + a + a + a
+  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a +
+  // CHECK-NEXT: a + a + a + a + a + a + a + a + a + a + a + a
+  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a + a + a
+  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a +
+  // CHECK-NEXT: a + a + a + a + a + a + a + a + a + a + a + a
+  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a +
+  // CHECK-NEXT: a + a + a + a + a + a + a + a + a + a + a + a
+  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a +
+  // CHECK-NEXT: a + a + a + a + a + a + a + a + a + a + a + a
+  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a +
+  // CHECK-NEXT: a + a + a + a + a + a + a + a + a + a + a + a
+  // CHECK-NEXT: + a + a + a + a + a + a + a + a + a + a + a +
+  // CHECK-NEXT: a + a + a + a + a + a + a + a + a + a + a + a
+  // CHECK-NEXT: + a;
   %1 = comb.add %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a,
                 %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a,
                 %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a,

--- a/test/Conversion/ExportVerilog/line-length.mlir
+++ b/test/Conversion/ExportVerilog/line-length.mlir
@@ -12,26 +12,26 @@ hw.module @longvariadic(%a: i8) -> (b: i8) {
 }
 
 // SHORT-LABEL: module longvariadic
-// SHORT: wire [7:0] _tmp = a + a + a + a + a + a + a + a;
-// SHORT: wire [7:0] _tmp_0 = a + a + a + a + a + a + a + a;
-// SHORT: wire [7:0] _tmp_1 = a + a + a + a + a + a + a + a;
-// SHORT: wire [7:0] _tmp_2 = a + a + a + a + a + a + a + a;
-// SHORT: wire [7:0] _tmp_3 = _tmp + _tmp_0 + _tmp_1 + _tmp_2;
-// SHORT: wire [7:0] _tmp_4 = a + a + a + a + a + a + a + a;
-// SHORT: wire [7:0] _tmp_5 = a + a + a + a + a + a + a + a;
-// SHORT: wire [7:0] _tmp_6 = a + a + a + a + a + a + a + a;
-// SHORT: wire [7:0] _tmp_7 = a + a + a + a + a + a + a + a;
-// SHORT: wire [7:0] _tmp_8 = _tmp_4 + _tmp_5 + _tmp_6 + _tmp_7;
-// SHORT: assign b = _tmp_3 + _tmp_8;
+// SHORT: assign b =  a + a + a + a + a + a
+// SHORT: + a + a + a + a + a +
+// SHORT: a + a + a + a + a + a
+// SHORT: + a + a + a + a + a +
+// SHORT: a + a + a + a + a + a
+// SHORT: + a + a + a + a + a + a + a + a + a + a
+// SHORT: + a + a + a + a + a +
+// SHORT: a + a + a + a + a + a
+// SHORT: + a + a + a + a + a +
+// SHORT: a + a + a + a + a + a
+// SHORT: + a + a + a + a;
 
 // DEFAULT-LABEL: module longvariadic
-// DEFAULT: wire [7:0] _tmp = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
-// DEFAULT: wire [7:0] _tmp_0 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
-// DEFAULT: wire [7:0] _tmp_1 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
-// DEFAULT: wire [7:0] _tmp_2 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
-// DEFAULT: assign b = _tmp + _tmp_0 + _tmp_1 + _tmp_2;
+// DEFAULT: assign b = a + a + a + a + a + a + a + a + a + a + a + a
+// DEFAULT: + a + a + a + a + a + a + a + a + a + a + a +
+// DEFAULT: a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a
+// DEFAULT: + a + a + a + a + a + a + a + a + a + a + a +
+// DEFAULT: a + a + a + a + a + a + a + a + a;
 
 // LONG-LABEL: module longvariadic
-// LONG: wire [7:0] _tmp = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
-// LONG: wire [7:0] _tmp_0 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
-// LONG: assign b = _tmp + _tmp_0;
+// LONG-LABEL: assign b = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
+// LONG-LABEL: a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
+// LONG-LABEL: a + a + a + a + a + a + a + a + a;

--- a/test/Conversion/ExportVerilog/line-length.mlir
+++ b/test/Conversion/ExportVerilog/line-length.mlir
@@ -1,6 +1,7 @@
 // RUN: circt-opt --lowering-options=emittedLineLength=40 --export-verilog %s | FileCheck %s --check-prefix=SHORT
 // RUN: circt-opt --export-verilog %s | FileCheck %s --check-prefix=DEFAULT
 // RUN: circt-opt --lowering-options=emittedLineLength=180 --export-verilog %s | FileCheck %s --check-prefix=LONG
+// RUN: circt-opt --lowering-options=maximumNumberOfTokensPerExpression=30 --export-verilog %s | FileCheck %s --check-prefix=LIMIT
 
 hw.module @longvariadic(%a: i8) -> (b: i8) {
   %1 = comb.add %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a,
@@ -26,5 +27,12 @@ hw.module @longvariadic(%a: i8) -> (b: i8) {
 // DEFAULT:            a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a; 
 
 // LONG-LABEL: module longvariadic
-// LONG-LABEL: assign b = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a
+// LONG: assign b = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a
 //                        + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
+
+// LIMIT-LABEL: module longvariadic
+// LIMIT:   wire [7:0] _tmp = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
+// LIMIT:   wire [7:0] _tmp_0 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
+// LIMIT:   wire [7:0] _tmp_1 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
+// LIMIT:   wire [7:0] _tmp_2 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
+// LIMIT:   assign b = _tmp + _tmp_0 + _tmp_1 + _tmp_2;

--- a/test/Conversion/ExportVerilog/line-length.mlir
+++ b/test/Conversion/ExportVerilog/line-length.mlir
@@ -12,26 +12,19 @@ hw.module @longvariadic(%a: i8) -> (b: i8) {
 }
 
 // SHORT-LABEL: module longvariadic
-// SHORT: assign b =  a + a + a + a + a + a
-// SHORT: + a + a + a + a + a +
-// SHORT: a + a + a + a + a + a
-// SHORT: + a + a + a + a + a +
-// SHORT: a + a + a + a + a + a
-// SHORT: + a + a + a + a + a + a + a + a + a + a
-// SHORT: + a + a + a + a + a +
-// SHORT: a + a + a + a + a + a
-// SHORT: + a + a + a + a + a +
-// SHORT: a + a + a + a + a + a
-// SHORT: + a + a + a + a;
+// SHORT: assign b =  a + a + a + a + a + a + a + a + a + a + a
+// SHORT:             + a + a + a + a + a + a + a + a + a + a +
+// SHORT:             a + a + a + a + a + a + a + a + a + a + a
+// SHORT:             + a + a + a + a + a + a + a + a + a + a +
+// SHORT:             a + a + a + a + a + a + a + a + a + a + a
+// SHORT:             + a + a + a + a + a + a + a + a + a + a +
+// SHORT:             a;
 
 // DEFAULT-LABEL: module longvariadic
-// DEFAULT: assign b = a + a + a + a + a + a + a + a + a + a + a + a
-// DEFAULT: + a + a + a + a + a + a + a + a + a + a + a +
-// DEFAULT: a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a
-// DEFAULT: + a + a + a + a + a + a + a + a + a + a + a +
-// DEFAULT: a + a + a + a + a + a + a + a + a;
+// DEFAULT: assign b = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
+// DEFAULT:            a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
+// DEFAULT:            a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a; 
 
 // LONG-LABEL: module longvariadic
-// LONG-LABEL: assign b = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
-// LONG-LABEL: a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
-// LONG-LABEL: a + a + a + a + a + a + a + a + a;
+// LONG-LABEL: assign b = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a
+//                        + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;

--- a/test/Conversion/ExportVerilog/line-length.mlir
+++ b/test/Conversion/ExportVerilog/line-length.mlir
@@ -14,37 +14,37 @@ hw.module @longvariadic(%a: i8) -> (b: i8) {
 }
 
 // SHORT-LABEL: module longvariadic
-// SHORT: assign b =  a + a + a + a + a + a + a + a + a + a + a
-// SHORT:             + a + a + a + a + a + a + a + a + a + a +
-// SHORT:             a + a + a + a + a + a + a + a + a + a + a
-// SHORT:             + a + a + a + a + a + a + a + a + a + a +
-// SHORT:             a + a + a + a + a + a + a + a + a + a + a
-// SHORT:             + a + a + a + a + a + a + a + a + a + a +
-// SHORT:             a;
+// SHORT:       assign b = a + a + a + a + a + a + a + a + a + a + a
+// SHORT-NEXT:             + a + a + a + a + a + a + a + a + a + a +
+// SHORT-NEXT:             a + a + a + a + a + a + a + a + a + a + a
+// SHORT-NEXT:             + a + a + a + a + a + a + a + a + a + a +
+// SHORT-NEXT:             a + a + a + a + a + a + a + a + a + a + a
+// SHORT-NEXT:             + a + a + a + a + a + a + a + a + a + a +
+// SHORT-NEXT:             a;
 
 // DEFAULT-LABEL: module longvariadic
-// DEFAULT: assign b = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
-// DEFAULT:            a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
-// DEFAULT:            a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a; 
+// DEFAULT:       assign b = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
+// DEFAULT-NEXT:             a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
+// DEFAULT-NEXT:             a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
 
 // LONG-LABEL: module longvariadic
-// LONG: assign b = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a
-//                  + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
+// LONG:       assign b = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a
+// LONG-NEXT:             + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
 
 // LIMIT_SHORT-LABEL: module longvariadic
-// LIMIT_SHORT:  wire [7:0] _tmp = a + a + a + a + a + a + a + a + a + a + a
-// LIMIT_SHORT:                    + a + a + a + a + a;
-// LIMIT_SHORT:  wire [7:0] _tmp_0 = a + a + a + a + a + a + a + a + a + a + a
-// LIMIT_SHORT:                      + a + a + a + a + a;
-// LIMIT_SHORT:  wire [7:0] _tmp_1 = a + a + a + a + a + a + a + a + a + a + a
-// LIMIT_SHORT:                      + a + a + a + a + a;
-// LIMIT_SHORT:  wire [7:0] _tmp_2 = a + a + a + a + a + a + a + a + a + a + a
-// LIMIT_SHORT:                      + a + a + a + a + a;
-// LIMIT_SHORT:  assign b = _tmp + _tmp_0 + _tmp_1 + _tmp_2;
+// LIMIT_SHORT:       wire [7:0] _tmp = a + a + a + a + a + a + a + a + a + a + a
+// LIMIT_SHORT-NEXT:                    + a + a + a + a + a;
+// LIMIT_SHORT-NEXT:  wire [7:0] _tmp_0 = a + a + a + a + a + a + a + a + a + a + a
+// LIMIT_SHORT-NEXT:                      + a + a + a + a + a;
+// LIMIT_SHORT-NEXT:  wire [7:0] _tmp_1 = a + a + a + a + a + a + a + a + a + a + a
+// LIMIT_SHORT-NEXT:                      + a + a + a + a + a;
+// LIMIT_SHORT-NEXT:  wire [7:0] _tmp_2 = a + a + a + a + a + a + a + a + a + a + a
+// LIMIT_SHORT-NEXT:                      + a + a + a + a + a;
+// LIMIT_SHORT-NEXT:  assign b = _tmp + _tmp_0 + _tmp_1 + _tmp_2;
 
 // LIMIT_-LABEL: module longvariadic
-// LIMIT_LONG:   wire [7:0] _tmp = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
-// LIMIT_LONG:                     a + a + a + a + a + a + a + a + a;
-// LIMIT_LONG:   wire [7:0] _tmp_0 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
-// LIMIT_LONG:                       a + a + a + a + a + a + a + a + a;
-// LIMIT_LONG:   assign b = _tmp + _tmp_0;
+// LIMIT_LONG:        wire [7:0] _tmp = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
+// LIMIT_LONG-NEXT:                     a + a + a + a + a + a + a + a + a;
+// LIMIT_LONG-NEXT:   wire [7:0] _tmp_0 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
+// LIMIT_LONG-NEXT:                       a + a + a + a + a + a + a + a + a;
+// LIMIT_LONG-NEXT:   assign b = _tmp + _tmp_0;

--- a/test/Conversion/ExportVerilog/line-length.mlir
+++ b/test/Conversion/ExportVerilog/line-length.mlir
@@ -1,7 +1,8 @@
 // RUN: circt-opt --lowering-options=emittedLineLength=40 --export-verilog %s | FileCheck %s --check-prefix=SHORT
 // RUN: circt-opt --export-verilog %s | FileCheck %s --check-prefix=DEFAULT
 // RUN: circt-opt --lowering-options=emittedLineLength=180 --export-verilog %s | FileCheck %s --check-prefix=LONG
-// RUN: circt-opt --lowering-options=maximumNumberOfTokensPerExpression=30 --export-verilog %s | FileCheck %s --check-prefix=LIMIT
+// RUN: circt-opt --lowering-options=emittedLineLength=40,maximumNumberOfTokensPerExpression=60 --export-verilog %s | FileCheck %s --check-prefix=LIMIT_SHORT
+// RUN: circt-opt --lowering-options=maximumNumberOfTokensPerExpression=120 --export-verilog %s | FileCheck %s --check-prefix=LIMIT_LONG
 
 hw.module @longvariadic(%a: i8) -> (b: i8) {
   %1 = comb.add %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a,
@@ -28,11 +29,22 @@ hw.module @longvariadic(%a: i8) -> (b: i8) {
 
 // LONG-LABEL: module longvariadic
 // LONG: assign b = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a
-//                        + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
+//                  + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
 
-// LIMIT-LABEL: module longvariadic
-// LIMIT:   wire [7:0] _tmp = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
-// LIMIT:   wire [7:0] _tmp_0 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
-// LIMIT:   wire [7:0] _tmp_1 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
-// LIMIT:   wire [7:0] _tmp_2 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
-// LIMIT:   assign b = _tmp + _tmp_0 + _tmp_1 + _tmp_2;
+// LIMIT_SHORT-LABEL: module longvariadic
+// LIMIT_SHORT:  wire [7:0] _tmp = a + a + a + a + a + a + a + a + a + a + a
+// LIMIT_SHORT:                    + a + a + a + a + a;
+// LIMIT_SHORT:  wire [7:0] _tmp_0 = a + a + a + a + a + a + a + a + a + a + a
+// LIMIT_SHORT:                      + a + a + a + a + a;
+// LIMIT_SHORT:  wire [7:0] _tmp_1 = a + a + a + a + a + a + a + a + a + a + a
+// LIMIT_SHORT:                      + a + a + a + a + a;
+// LIMIT_SHORT:  wire [7:0] _tmp_2 = a + a + a + a + a + a + a + a + a + a + a
+// LIMIT_SHORT:                      + a + a + a + a + a;
+// LIMIT_SHORT:  assign b = _tmp + _tmp_0 + _tmp_1 + _tmp_2;
+
+// LIMIT_-LABEL: module longvariadic
+// LIMIT_LONG:   wire [7:0] _tmp = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
+// LIMIT_LONG:                     a + a + a + a + a + a + a + a + a;
+// LIMIT_LONG:   wire [7:0] _tmp_0 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
+// LIMIT_LONG:                       a + a + a + a + a + a + a + a + a;
+// LIMIT_LONG:   assign b = _tmp + _tmp_0;

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -492,11 +492,10 @@ hw.module @issue595_variant2_checkRedunctionAnd(%arr: !hw.array<128xi1>) {
 hw.module @if_multi_line_expr1(%clock: i1, %reset: i1, %really_long_port: i11) {
   %tmp6 = sv.reg  : !hw.inout<i25>
 
-  // CHECK:      if (reset)
+  // CHECK: if (reset)
   // CHECK-NEXT:   tmp6 <= 25'h0;
-  // CHECK-NEXT: else begin
-  // CHECK-NEXT:   automatic logic [24:0] _tmp = {{..}}14{really_long_port[10]}}, really_long_port};
-  // CHECK-NEXT:   tmp6 <= _tmp & 25'h3039;
+  // CHECK-NEXT: else
+  // CHECK-NEXT:   tmp6 <= {{..}}14{really_long_port[10]}}, really_long_port} & 25'h3039;
   // CHECK-NEXT: end
   sv.alwaysff(posedge %clock)  {
     %0 = comb.sext %really_long_port : (i11) -> i25
@@ -517,8 +516,8 @@ hw.module @if_multi_line_expr2(%clock: i1, %reset: i1, %really_long_port: i11) {
   %c12345_i25 = hw.constant 12345 : i25
   %0 = comb.sext %really_long_port : (i11) -> i25
   %1 = comb.and %0, %c12345_i25 : i25
-  // CHECK:        wire [24:0] _tmp = {{..}}14{really_long_port[10]}}, really_long_port};
-  // CHECK-NEXT:   wire [24:0] _T = _tmp & 25'h3039;
+  // CHECK:   wire [24:0] _T = {{..}}14{really_long_port[10]}}, really_long_port} & 25'h3039;
+
 
   // CHECK:      if (reset)
   // CHECK-NEXT:   tmp6 <= 25'h0;
@@ -609,10 +608,10 @@ hw.module @issue720ifdef(%clock: i1, %arg1: i1, %arg2: i1, %arg3: i1) {
 // CHECK-LABEL: module issue728(
 hw.module @issue728(%clock: i1, %asdfasdfasdfasdfafa: i1, %gasfdasafwjhijjafija: i1) {
   // CHECK:  always @(posedge clock) begin
-  // CHECK:    automatic logic _tmp = asdfasdfasdfasdfafa & gasfdasafwjhijjafija & asdfasdfasdfasdfafa;
-  // CHECK:    automatic logic _tmp_0 = gasfdasafwjhijjafija & asdfasdfasdfasdfafa & gasfdasafwjhijjafija;
   // CHECK:    $fwrite(32'h80000002, "force output");
-  // CHECK:    if (_tmp & _tmp_0)
+  // CHECK:    if (asdfasdfasdfasdfafa & gasfdasafwjhijjafija &
+  // CHECK:  asdfasdfasdfasdfafa & gasfdasafwjhijjafija & asdfasdfasdfasdfafa &
+  // CHECK:  gasfdasafwjhijjafija)
   // CHECK:      $fwrite(32'h80000002, "this cond is split");
   // CHECK:  end // always @(posedge)
   sv.always posedge %clock  {
@@ -628,13 +627,11 @@ hw.module @issue728(%clock: i1, %asdfasdfasdfasdfafa: i1, %gasfdasafwjhijjafija:
 // CHECK-LABEL: module issue728ifdef(
 hw.module @issue728ifdef(%clock: i1, %asdfasdfasdfasdfafa: i1, %gasfdasafwjhijjafija: i1) {
   // CHECK: always @(posedge clock) begin
-  // CHECK:      automatic logic _tmp;
-  // CHECK:      automatic logic _tmp_0;
   // CHECK:    $fwrite(32'h80000002, "force output");
   // CHECK:    `ifdef FUN_AND_GAMES
-  // CHECK:      _tmp = asdfasdfasdfasdfafa & gasfdasafwjhijjafija & asdfasdfasdfasdfafa;
-  // CHECK:      _tmp_0 = gasfdasafwjhijjafija & asdfasdfasdfasdfafa & gasfdasafwjhijjafija;
-  // CHECK:      if (_tmp & _tmp_0)
+  // CHECK:      if (asdfasdfasdfasdfafa & gasfdasafwjhijjafija &
+  // CHECK: asdfasdfasdfasdfafa & gasfdasafwjhijjafija & asdfasdfasdfasdfafa &
+  // CHECK: gasfdasafwjhijjafija)
   // CHECK:        $fwrite(32'h80000002, "this cond is split");
   // CHECK:    `endif
   // CHECK: end // always @(posedge)
@@ -948,15 +945,13 @@ hw.module @InlineAutomaticLogicInit(%a : i42, %b: i42, %really_really_long_port:
   // CHECK: initial begin
   sv.initial {
     // CHECK: automatic logic [41:0] [[THING:.+]] = `THING;
-    // CHECK: automatic logic [41:0] _tmp = {{..}}31{really_really_long_port[10]}}, really_really_long_port};
-    // CHECK: automatic logic [41:0] [[THING3:.+]] = [[THING]] + _tmp;
-    // CHECK: automatic logic [41:0] _tmp_6 = [[THING]] * [[THING]]
-    // CHECK: automatic logic [41:0] _tmp_7 = [[THING]] * [[THING]]
-    // CHECK: automatic logic [41:0] [[MANYTHING:.+]] = _tmp_6 * _tmp_7;
+    // CHECK: automatic logic [41:0] [[THING3:.+]] = [[THING]] + {{..}}31{really_really_long_port[10]}},
+    // CHECK: really_really_long_port};
+    // CHECK: automatic logic [41:0] [[MANYTHING:.+]] = [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]]
+    // CHECK: * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]]
+    // CHECK: * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]];
 
     // Check the indentation level of temporaries.  Issue #1625
-    // CHECK: {{^    }}automatic logic [41:0] _tmp_8;
-    // CHECK: {{^    }}automatic logic [41:0] _tmp_9;
     %thing = sv.verbatim.expr.se "`THING" : () -> i42
 
     %thing2 = comb.sext %really_really_long_port : (i11) -> i42

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -609,9 +609,8 @@ hw.module @issue720ifdef(%clock: i1, %arg1: i1, %arg2: i1, %arg3: i1) {
 hw.module @issue728(%clock: i1, %asdfasdfasdfasdfafa: i1, %gasfdasafwjhijjafija: i1) {
   // CHECK:  always @(posedge clock) begin
   // CHECK:    $fwrite(32'h80000002, "force output");
-  // CHECK:    if (asdfasdfasdfasdfafa & gasfdasafwjhijjafija &
-  // CHECK:  asdfasdfasdfasdfafa & gasfdasafwjhijjafija & asdfasdfasdfasdfafa &
-  // CHECK:  gasfdasafwjhijjafija)
+  // CHECK:    if (asdfasdfasdfasdfafa & gasfdasafwjhijjafija & asdfasdfasdfasdfafa & gasfdasafwjhijjafija &
+  // CHECK:        asdfasdfasdfasdfafa & gasfdasafwjhijjafija)
   // CHECK:      $fwrite(32'h80000002, "this cond is split");
   // CHECK:  end // always @(posedge)
   sv.always posedge %clock  {
@@ -629,9 +628,8 @@ hw.module @issue728ifdef(%clock: i1, %asdfasdfasdfasdfafa: i1, %gasfdasafwjhijja
   // CHECK: always @(posedge clock) begin
   // CHECK:    $fwrite(32'h80000002, "force output");
   // CHECK:    `ifdef FUN_AND_GAMES
-  // CHECK:      if (asdfasdfasdfasdfafa & gasfdasafwjhijjafija &
-  // CHECK: asdfasdfasdfasdfafa & gasfdasafwjhijjafija & asdfasdfasdfasdfafa &
-  // CHECK: gasfdasafwjhijjafija)
+  // CHECK:    if (asdfasdfasdfasdfafa & gasfdasafwjhijjafija & asdfasdfasdfasdfafa & gasfdasafwjhijjafija &
+  // CHECK:        asdfasdfasdfasdfafa & gasfdasafwjhijjafija)
   // CHECK:        $fwrite(32'h80000002, "this cond is split");
   // CHECK:    `endif
   // CHECK: end // always @(posedge)
@@ -947,9 +945,8 @@ hw.module @InlineAutomaticLogicInit(%a : i42, %b: i42, %really_really_long_port:
     // CHECK: automatic logic [41:0] [[THING:.+]] = `THING;
     // CHECK: automatic logic [41:0] [[THING3:.+]] = [[THING]] + {{..}}31{really_really_long_port[10]}},
     // CHECK: really_really_long_port};
-    // CHECK: automatic logic [41:0] [[MANYTHING:.+]] = [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]]
-    // CHECK: * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]]
-    // CHECK: * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]];
+    // CHECK: automatic logic [41:0] [[MANYTHING:.+]] = [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] *
+    // CHECK:                                           [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]] * [[THING]];
 
     // Check the indentation level of temporaries.  Issue #1625
     %thing = sv.verbatim.expr.se "`THING" : () -> i42

--- a/test/Conversion/ExportVerilog/sv-interfaces.mlir
+++ b/test/Conversion/ExportVerilog/sv-interfaces.mlir
@@ -114,8 +114,8 @@ module {
     sv.interface.signal @data : !hw.struct<foo: !hw.array<384xi1>>
   }
   // CHECK-LABEL: module structs(
-  // CHECK: wire [383:0] _tmp = {
   // CHECK-NOT: wire [383:0] _tmp =
+  // CHECK: wire struct packed {logic [383:0] foo; } _T_2
   // CHECK: endmodule
   hw.module @structs(%clk: i1, %rstn: i1) {
     %0 = sv.interface.instance {name = "iface"} : !sv.interface<@IValidReady_Struct>


### PR DESCRIPTION
For #840, this PR is trying to remove temporary wires caused by the line length restriction. 

If the length of the buffer filled by the current subexpression is larger than threshold,
it splits the buffer into multiple lines by inserting a endline character.

With this patch, this IR 

```mlir
hw.module @longvariadic(%a: i8) -> (b: i8) {
  %1 = comb.add %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a,
                %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a,
                %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a,
                %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a
                 : i8
  hw.output %1 : i8
}
```
will be convert into  
```verilog
module longvariadic(    // variadic.mlir:1:1
  input  [7:0] a,
  output [7:0] b);

  assign b = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
                a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
                a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
endmodule
```



-----
before
```verilog
module longvariadic
  wire [7:0] _tmp = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
  wire [7:0] _tmp_0 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
  wire [7:0] _tmp_1 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
  wire [7:0] _tmp_2 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
  assign b = _tmp + _tmp_0 + _tmp_1 + _tmp_2;
```
