### PR TITLE
Bump LLVM for D111695

### DIFF
--- a/lib/Conversion/HWToLLHD/HWToLLHD.cpp
+++ b/lib/Conversion/HWToLLHD/HWToLLHD.cpp
@@ -91,7 +91,7 @@ HWToLLHDTypeConverter::HWToLLHDTypeConverter() {
   addConversion([](SigType type) { return type; });
 
   // Materialze probes when arguments are converted from any type to `SigType`.
-  addArgumentMaterialization(
+  addSourceMaterialization(
       [](OpBuilder &builder, Type type, ValueRange values, Location loc) {
         assert(values.size() == 1);
         auto op = builder.create<PrbOp>(loc, type, values[0]);

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -2253,7 +2253,7 @@ struct HandshakeFuncOpLowering : public OpConversionPattern<handshake::FuncOp> {
       : OpConversionPattern<handshake::FuncOp>(context), circuitOp(circuitOp) {}
 
   LogicalResult
-  matchAndRewrite(handshake::FuncOp funcOp, ArrayRef<Value> operands,
+  matchAndRewrite(handshake::FuncOp funcOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     rewriter.setInsertionPointToStart(circuitOp.getBody());
     auto topModuleOp = createTopModuleOp(funcOp, /*numClocks=*/1, rewriter);

--- a/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
+++ b/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
@@ -1888,11 +1888,12 @@ namespace {
 template <typename SourceOp, typename TargetOp>
 class VariadicOpConversion : public ConvertOpToLLVMPattern<SourceOp> {
 public:
+  using OpAdaptor = typename SourceOp::Adaptor;
   using ConvertOpToLLVMPattern<SourceOp>::ConvertOpToLLVMPattern;
   using Super = VariadicOpConversion<SourceOp, TargetOp>;
 
   LogicalResult
-  matchAndRewrite(SourceOp op, ArrayRef<Value> operands,
+  matchAndRewrite(SourceOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
     size_t numOperands = op.getOperands().size();
@@ -1933,7 +1934,7 @@ struct BitcastOpConversion : public ConvertOpToLLVMPattern<hw::BitcastOp> {
   using ConvertOpToLLVMPattern<hw::BitcastOp>::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(hw::BitcastOp op, ArrayRef<Value> operands,
+  matchAndRewrite(hw::BitcastOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
     Type resultTy = typeConverter->convertType(op.result().getType());
@@ -2093,7 +2094,7 @@ struct HWArrayCreateOpConversion
   using ConvertOpToLLVMPattern<hw::ArrayCreateOp>::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(hw::ArrayCreateOp op, ArrayRef<Value> operands,
+  matchAndRewrite(hw::ArrayCreateOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
     auto arrayTy = typeConverter->convertType(op->getResult(0).getType());
@@ -2124,7 +2125,7 @@ struct HWStructCreateOpConversion
   using ConvertOpToLLVMPattern<hw::StructCreateOp>::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(hw::StructCreateOp op, ArrayRef<Value> operands,
+  matchAndRewrite(hw::StructCreateOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
     auto resTy = typeConverter->convertType(op.result().getType());
@@ -2158,7 +2159,7 @@ struct SigArraySliceOpConversion
   using ConvertOpToLLVMPattern<llhd::SigArraySliceOp>::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(llhd::SigArraySliceOp op, ArrayRef<Value> operands,
+  matchAndRewrite(llhd::SigArraySliceOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
     Type llvmArrTy = typeConverter->convertType(op.getInputArrayType());
@@ -2188,7 +2189,7 @@ struct SigExtractOpConversion
   using ConvertOpToLLVMPattern<llhd::SigExtractOp>::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(llhd::SigExtractOp op, ArrayRef<Value> operands,
+  matchAndRewrite(llhd::SigExtractOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
     Type inputTy = typeConverter->convertType(op.input().getType());
@@ -2226,7 +2227,7 @@ struct SigStructExtractOpConversion
       llhd::SigStructExtractOp>::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(llhd::SigStructExtractOp op, ArrayRef<Value> operands,
+  matchAndRewrite(llhd::SigStructExtractOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
     Type llvmStructTy = typeConverter->convertType(op.getStructType());
@@ -2263,7 +2264,7 @@ struct SigArrayGetOpConversion
   using ConvertOpToLLVMPattern<llhd::SigArrayGetOp>::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(llhd::SigArrayGetOp op, ArrayRef<Value> operands,
+  matchAndRewrite(llhd::SigArrayGetOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
     auto llvmArrTy = typeConverter->convertType(op.getArrayType());
@@ -2325,7 +2326,7 @@ struct StructExtractOpConversion
   using ConvertOpToLLVMPattern<hw::StructExtractOp>::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(hw::StructExtractOp op, ArrayRef<Value> operands,
+  matchAndRewrite(hw::StructExtractOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
     Type inputTy = typeConverter->convertType(op.input().getType());
@@ -2354,7 +2355,7 @@ struct ArrayGetOpConversion : public ConvertOpToLLVMPattern<hw::ArrayGetOp> {
   using ConvertOpToLLVMPattern<hw::ArrayGetOp>::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(hw::ArrayGetOp op, ArrayRef<Value> operands,
+  matchAndRewrite(hw::ArrayGetOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
     auto elemTy = typeConverter->convertType(op.result().getType());
@@ -2393,7 +2394,7 @@ struct ArraySliceOpConversion
   using ConvertOpToLLVMPattern<hw::ArraySliceOp>::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(hw::ArraySliceOp op, ArrayRef<Value> operands,
+  matchAndRewrite(hw::ArraySliceOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
     auto dstTy = typeConverter->convertType(op.dst().getType());
@@ -2443,7 +2444,7 @@ struct StructInjectOpConversion
   using ConvertOpToLLVMPattern<hw::StructInjectOp>::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(hw::StructInjectOp op, ArrayRef<Value> operands,
+  matchAndRewrite(hw::StructInjectOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
     Type inputTy = typeConverter->convertType(op.input().getType());
@@ -2476,7 +2477,7 @@ struct ArrayConcatOpConversion
   using ConvertOpToLLVMPattern<hw::ArrayConcatOp>::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(hw::ArrayConcatOp op, ArrayRef<Value> operands,
+  matchAndRewrite(hw::ArrayConcatOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
     hw::ArrayType arrTy = op.result().getType().cast<hw::ArrayType>();

--- a/lib/Dialect/ESI/ESIPasses.cpp
+++ b/lib/Dialect/ESI/ESIPasses.cpp
@@ -285,13 +285,13 @@ public:
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(ChannelBuffer buffer, ArrayRef<Value> operands,
+  matchAndRewrite(ChannelBuffer buffer, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final;
 };
 } // anonymous namespace
 
 LogicalResult ChannelBufferLowering::matchAndRewrite(
-    ChannelBuffer buffer, ArrayRef<Value> operands,
+    ChannelBuffer buffer, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
   auto loc = buffer.getLoc();
 
@@ -846,7 +846,7 @@ public:
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(PipelineStage stage, ArrayRef<Value> operands,
+  matchAndRewrite(PipelineStage stage, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final;
 
 private:
@@ -855,7 +855,7 @@ private:
 } // anonymous namespace
 
 LogicalResult PipelineStageLowering::matchAndRewrite(
-    PipelineStage stage, ArrayRef<Value> stageOperands,
+    PipelineStage stage, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
   auto loc = stage.getLoc();
   auto chPort = stage.input().getType().dyn_cast<ChannelPort>();
@@ -912,13 +912,13 @@ public:
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(NullSourceOp nullop, ArrayRef<Value> operands,
+  matchAndRewrite(NullSourceOp nullop, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final;
 };
 } // anonymous namespace
 
 LogicalResult NullSourceOpLowering::matchAndRewrite(
-    NullSourceOp nullop, ArrayRef<Value> stageOperands,
+    NullSourceOp nullop, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
   auto innerType = nullop.out().getType().cast<ChannelPort>().getInner();
   Location loc = nullop.getLoc();
@@ -1000,15 +1000,15 @@ public:
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(WrapSVInterface wrap, ArrayRef<Value> operands,
+  matchAndRewrite(WrapSVInterface wrap, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final;
 };
 } // anonymous namespace
 
 LogicalResult
-WrapInterfaceLower::matchAndRewrite(WrapSVInterface wrap,
-                                    ArrayRef<Value> operands,
+WrapInterfaceLower::matchAndRewrite(WrapSVInterface wrap, OpAdaptor adaptor,
                                     ConversionPatternRewriter &rewriter) const {
+  auto operands = adaptor.getOperands();
   if (operands.size() != 1)
     return rewriter.notifyMatchFailure(wrap, [&operands](Diagnostic &d) {
       d << "wrap.iface has 1 argument. Got " << operands.size() << "operands";
@@ -1042,14 +1042,15 @@ public:
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(UnwrapSVInterface wrap, ArrayRef<Value> operands,
+  matchAndRewrite(UnwrapSVInterface wrap, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final;
 };
 } // anonymous namespace
 
 LogicalResult UnwrapInterfaceLower::matchAndRewrite(
-    UnwrapSVInterface unwrap, ArrayRef<Value> operands,
+    UnwrapSVInterface unwrap, OpAdaptor adaptor,
     ConversionPatternRewriter &rewriter) const {
+  auto operands = adaptor.getOperands();
   if (operands.size() != 2)
     return rewriter.notifyMatchFailure(unwrap, [&operands](Diagnostic &d) {
       d << "Unwrap.iface has 2 arguments. Got " << operands.size()
@@ -1088,7 +1089,7 @@ public:
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(CosimEndpoint, ArrayRef<Value> operands,
+  matchAndRewrite(CosimEndpoint, OpAdaptor operands,
                   ConversionPatternRewriter &rewriter) const final;
 
 private:
@@ -1097,7 +1098,7 @@ private:
 } // anonymous namespace
 
 LogicalResult
-CosimLowering::matchAndRewrite(CosimEndpoint ep, ArrayRef<Value> operands,
+CosimLowering::matchAndRewrite(CosimEndpoint ep, OpAdaptor operands,
                                ConversionPatternRewriter &rewriter) const {
 #ifndef CAPNP
   (void)builder;
@@ -1192,7 +1193,7 @@ public:
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(CapnpEncode enc, ArrayRef<Value> operands,
+  matchAndRewrite(CapnpEncode enc, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
 #ifndef CAPNP
     return rewriter.notifyMatchFailure(enc,
@@ -1219,7 +1220,7 @@ public:
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(CapnpDecode dec, ArrayRef<Value> operands,
+  matchAndRewrite(CapnpDecode dec, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
 #ifndef CAPNP
     return rewriter.notifyMatchFailure(dec,

--- a/lib/Dialect/Seq/SeqPasses.cpp
+++ b/lib/Dialect/Seq/SeqPasses.cpp
@@ -38,7 +38,7 @@ public:
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(CompRegOp reg, ArrayRef<Value> operands,
+  matchAndRewrite(CompRegOp reg, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     Location loc = reg.getLoc();
 


### PR DESCRIPTION
Bump LLVM to pull in performance improvements from https://reviews.llvm.org/D111695.

This includes changes to remove deprecated usages of `ArrayRef<Value>`.  For more information see:
  - https://reviews.llvm.org/D110293
  - https://reviews.llvm.org/D110360

This also required a change to HWToLLHD as an argument materializer seemed to be leaving around incomplete conversions.  I am not sure that this is the correct change, however...  With this change, no changes were required to the tests.