### PR TITLE
[ExportVerilog] Emit zero param as "0" not "64'd0"

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -967,8 +967,10 @@ ModuleEmitter::printParamValue(Attribute value, raw_ostream &os,
     APInt value = intAttr.getValue();
 
     // We omit the width specifier if the value is <= 32-bits in size, which
-    // makes this more compatible with unknown width extmodules.
-    if (intTy.getWidth() > 32) {
+    // makes this more compatible with unknown width extmodules.  Additionally,
+    // special case a zero valued parameter.  This is canonically stored as
+    // 64-bits.  However, we don't want to print 64'd0 here.
+    if (!value.isZero() && intTy.getWidth() > 32) {
       // Sign comes out before any width specifier.
       if (intTy.isSigned() && value.isNegative()) {
         os << '-';

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -709,7 +709,7 @@ hw.module @Chi() -> (Chi_output : i0) {
 
  hw.module @Foo1360() {
    // CHECK:      RealBar #(
-   // CHECK-NEXT:   .WIDTH0(64'd0),
+   // CHECK-NEXT:   .WIDTH0(0),
    // CHECK-NEXT:   .WIDTH1(4),
    // CHECK-NEXT:   .WIDTH2(40'd6812312123),
    // CHECK-NEXT:   .WIDTH3(-1),

--- a/test/Conversion/ExportVerilog/verilog-basic.mlir
+++ b/test/Conversion/ExportVerilog/verilog-basic.mlir
@@ -318,7 +318,7 @@ hw.module @UseInstances(%a_in: i8) -> (a_out1: i1, a_out2: i1) {
   // CHECK:   .out (a_out1)
   // CHECK: );
   // CHECK: MyParameterizedExtModule #(
-  // CHECK:   .DEFAULT(64'd0),
+  // CHECK:   .DEFAULT(0),
   // CHECK:   .DEPTH(3.500000e+00),
   // CHECK:   .FORMAT("xyz_timeout=%d\n"),
   // CHECK:   .WIDTH(32)


### PR DESCRIPTION
Change ExportVerilog emission of a zero-valued parameter to use "0" and
not "64'd0".  MLIR infrastructure will parse a zero as an APInt of type
i64.  This causes problem for emission of FIRRTL-parsed parameters which
need to show up in the output as "0" instead of "64'd0" which some tools
may reject.

This is special cased during Verilog emission to prevent having to
deviate from the seemingly canonical handling of a zero-valued APInt
being stored as an i64.

Concretely, this fixes a problem that @Ramlakshmi3733 has seen where a circuit like the following:

```scala
circuit Foo:
  extmodule Bar:
    input a: UInt<1>
    parameter X = 0
    parameter Y = 1

  module Foo:
    input a: UInt<1>

    inst bar of Bar
    bar.a <= a
```

Would, without this, result in:

```verilog
module Foo(	
  input a);

  Bar #(
    .X(64'd0),
    .Y(1)
  ) bar (	
    .a (a)
  );
endmodule
```

With this patch, this will result in:

```verilog
module Foo(	
  input a);

  Bar #(
    .X(0),
    .Y(1)
  ) bar (	
    .a (a)
  );
endmodule
```