### PR TITLE
[Support] Use `replaceAllUsesWith` in BackedgeBuilder

### DIFF
--- a/include/circt/Support/BackedgeBuilder.h
+++ b/include/circt/Support/BackedgeBuilder.h
@@ -78,6 +78,7 @@ public:
 
 private:
   mlir::Value value;
+  bool set = false;
 };
 
 } // namespace circt

--- a/lib/Support/BackedgeBuilder.cpp
+++ b/lib/Support/BackedgeBuilder.cpp
@@ -20,9 +20,9 @@ Backedge::Backedge(mlir::Operation *op) : value(op->getResult(0)) {}
 
 void Backedge::setValue(mlir::Value newValue) {
   assert(value.getType() == newValue.getType());
-  for (auto &use : value.getUses())
-    use.set(newValue);
-  value = newValue;
+  assert(!set && "backedge already set to a value!");
+  value.replaceAllUsesWith(newValue);
+  set = true;
 }
 
 BackedgeBuilder::~BackedgeBuilder() {


### PR DESCRIPTION
If a backedge value is referenced multiple times, for some reason, only the last reference is being replaced through the current `setValue` implementation. This is fixed by replacing the value using the more canonical approach of `Value::replaceAllUsesWith`.

Furthermore, adds a check to ensure that a backedge is only set one. I think this is a fair restriction, given that the backedge is a stand-in for an eventual SSA value.