### PR TITLE
[reduce] Add FIRRTL lowering passes, improve pattern application strategy

### DIFF
--- a/tools/circt-reduce/Reduction.cpp
+++ b/tools/circt-reduce/Reduction.cpp
@@ -44,8 +44,8 @@ Reduction::~Reduction() {}
 //===----------------------------------------------------------------------===//
 
 PassReduction::PassReduction(MLIRContext *context, std::unique_ptr<Pass> pass,
-                             bool canIncreaseSize)
-    : context(context), canIncreaseSize(canIncreaseSize) {
+                             bool canIncreaseSize, bool oneShot)
+    : context(context), canIncreaseSize(canIncreaseSize), oneShot(oneShot) {
   passName = pass->getArgument();
   if (passName.empty())
     passName = pass->getName();
@@ -239,6 +239,16 @@ void circt::createAllReductions(
   add(std::make_unique<PassReduction>(context, firrtl::createInlinerPass()));
   add(std::make_unique<PassReduction>(context,
                                       createSimpleCanonicalizerPass()));
+  add(std::make_unique<PassReduction>(context, firrtl::createLowerCHIRRTLPass(),
+                                      true, true));
+  add(std::make_unique<PassReduction>(context, firrtl::createInferWidthsPass(),
+                                      true, true));
+  add(std::make_unique<PassReduction>(context, firrtl::createInferResetsPass(),
+                                      true, true));
+  add(std::make_unique<PassReduction>(
+      context, firrtl::createLowerFIRRTLTypesPass(), true, true));
+  add(std::make_unique<PassReduction>(context, firrtl::createExpandWhensPass(),
+                                      true, true));
   add(std::make_unique<PassReduction>(context, createCSEPass()));
   add(std::make_unique<ConnectInvalidator>());
   add(std::make_unique<OperationPruner>());

--- a/tools/circt-reduce/Reduction.h
+++ b/tools/circt-reduce/Reduction.h
@@ -52,22 +52,41 @@ struct Reduction {
   /// This can be handy for patterns that reduce the complexity of the IR at the
   /// cost of some verbosity.
   virtual bool acceptSizeIncrease() const { return false; }
+
+  /// Return true if the tool should not try to reapply this reduction after it
+  /// has been successful. This is useful for reductions whose `match()`
+  /// function keeps returning true even after the reduction has reached a
+  /// fixed-point and no longer performs any change. An example of this are
+  /// reductions that apply a lowering pass which always applies but may leave
+  /// the input unmodified.
+  ///
+  /// This is mainly useful in conjunction with returning true from
+  /// `acceptSizeIncrease()`. For reductions that don't accept an increase, the
+  /// module size has to decrease for them to be considered useful, which
+  /// prevents the tool from getting stuck at a local point where the reduction
+  /// applies but produces no change in the input. However, reductions that *do*
+  /// accept a size increase can get stuck in this local fixed-point as they
+  /// keep applying to the same operations and the tool keeps accepting the
+  /// unmodified input as an improvement.
+  virtual bool isOneShot() const { return false; }
 };
 
 /// A reduction pattern that applies an `mlir::Pass`.
 struct PassReduction : public Reduction {
   PassReduction(mlir::MLIRContext *context, std::unique_ptr<mlir::Pass> pass,
-                bool canIncreaseSize = false);
+                bool canIncreaseSize = false, bool oneShot = false);
   bool match(mlir::Operation *op) const override;
   mlir::LogicalResult rewrite(mlir::Operation *op) const override;
   std::string getName() const override;
   bool acceptSizeIncrease() const override { return canIncreaseSize; }
+  bool isOneShot() const override { return oneShot; }
 
 protected:
   mlir::MLIRContext *const context;
   std::unique_ptr<mlir::PassManager> pm;
   llvm::StringRef passName;
   bool canIncreaseSize;
+  bool oneShot;
 };
 
 /// Calls the function `add` with each available reduction, in the order they


### PR DESCRIPTION
This PR improves *circt-reduce* as follows:

### Add a root port pruning reduction pattern

Add a pattern to circt-reduce which removes unused ports from the root module, which can significantly reduce the size of the test case.

### Keep current pattern chunk size after successful reduction

The circt-reduce tool iteratively tries to apply a rewrite pattern on large subsets of the operations. If the pattern doesn't apply on the current subset, the number of operations is halved and application is retried, forming a sort of binary search for reductions.

In the current implementation, when circt-reduce applies a pattern that improves the output, it will immediately reset the subset to its maximum size and restart trying pattern application from the top. This can be very cumbersome in the case where the rewrite pattern applies only when a fine granularity of operations is chosen. However, it takes a while to arrive at that granularity, with circt-reduce having to try through all the larger operation subsets first. But having arrived at a small subset size suggests that subsequent successful rewrites will occur at the same subset size, or even smaller. So it makes much more sense to continue trying rewriting at the current level of granularity, even after a pattern has applied successfully.

This commit changes circt-reduce such that it does not restart pattern application at the top with largest granularity, but keeps going at the current setting. If that runs through, the reduction will rerun from the top anyway due to the pattern having successfully applied.

### Add one-shot reductions, enable FIRRTL passes

Add the ability for reductions to declared themselves as "one-shot", which indicates to circt-reduce that it should not try to reapply the same reduction at the same location again. This is useful for reductions that always apply, like lowerings and optimization passes, as they are likely to be marked as accepting increases in module size for the sake of reduced complexity elsewhere. This can get them stuck in a loop where circt-reduce would accept their reduction, and then immediately try to reapply them at the exact same spot. Marking a reduction as "one-shot" will cause circt-reduce to skip this reapplication, and also to not restart pattern application at the top after a successful reduction.

This now allows this kind of lowering pass to be used as a reduction pattern in circt-reduce, and this commit enables a whole bunch of passes from the FIRRTL dialect as one-shot reduction patterns.
