### PR TITLE
[FIRRTL] Add inner names to declarations

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -36,6 +36,7 @@ def NoPortsDontTouch : Constraint<CPred<[{
 
 def NonEmptyStringAttr : Constraint<CPred<"!$0.getValue().empty()">>;
 def uselessNameAttr : Constraint<CPred<"isUselessName($0.getValue())">>;
+def NullAttr : Constraint<CPred<"!$0">>;
 
 // Constraint that enforces equal types
 def EqualTypes : Constraint<CPred<"$0.getType() == $1.getType()">>;
@@ -101,27 +102,27 @@ def MuxSameCondHigh : Pat<
 
 // node(x) -> x
 def EmptyNode : Pat<
-  (NodeOp $x, $name, $annotations),
+  (NodeOp $x, $name, $annotations, $inner_sym),
   (replaceWithValue $x),
-  [(NonEmptyStringAttr $name), (EmptyAttrDict $annotations)]>;
+  [(EmptyAttrDict $annotations), (NullAttr $inner_sym)]>;
 
 // regreset(clock, invalidvalue, resetValue) -> reg(clock)
 def RegResetWithInvalidReset : Pat<
-  (RegResetOp $clock, (InvalidValueOp), $_, $name, $annotations),
-  (RegOp $clock, $name, $annotations),
+  (RegResetOp $clock, (InvalidValueOp), $_, $name, $annotations, $inner_sym),
+  (RegOp $clock, $name, $annotations, $inner_sym),
   []>;
 
 // regreset(clock, reset, invalidvalue) -> reg(clock)
 // This is handled by the `RemoveReset` pass in the original Scala code.
 def RegResetWithInvalidResetValue : Pat<
-  (RegResetOp $clock, $_, (InvalidValueOp), $name, $annotations),
-  (RegOp $clock, $name, $annotations),
+  (RegResetOp $clock, $_, (InvalidValueOp), $name, $annotations, $inner_sym),
+  (RegOp $clock, $name, $annotations, $inner_sym),
   []>;
 
 // regreset(clock, constant_zero, resetValue) -> reg(clock)
 def RegResetWithZeroReset : Pat<
-  (RegResetOp $clock, $reset, $_, $name, $annotations),
-  (RegOp $clock, $name, $annotations), [(ZeroConstantOp $reset)]>;
+  (RegResetOp $clock, $reset, $_, $name, $annotations, $inner_sym),
+  (RegOp $clock, $name, $annotations, $inner_sym), [(ZeroConstantOp $reset)]>;
 
 // Return the width of an operation result as an integer attribute.  This is
 // useful to pad another operation up to the width of the original operation.
@@ -157,32 +158,32 @@ def SubWithInvalidOp : Pat<
 
 // node(x,name),!dnt -> node(x, "")
 def DropNameNode : Pat<
-  (NodeOp $x, $name, $annotations),
-  (NodeOp $x, (GetEmptyString), $annotations),
+  (NodeOp $x, $name, $annotations, $inner_sym),
+  (NodeOp $x, (GetEmptyString), $annotations, $inner_sym),
   [(uselessNameAttr $name), (NoDontTouch $annotations)]>;
 
 // wire(name),!dnt -> wire("")
 def DropNameWire : Pat<
-  (WireOp $name, $annotations),
-  (WireOp (GetEmptyString), $annotations),
+  (WireOp $name, $annotations, $inner_sym),
+  (WireOp (GetEmptyString), $annotations, $inner_sym),
   [(uselessNameAttr $name), (NoDontTouch $annotations)]>;
 
 // reg(clk, name),!dnt -> reg(clk, "")
 def DropNameReg : Pat<
-  (RegOp $clk, $name, $annotations),
-  (RegOp $clk, (GetEmptyString), $annotations),
+  (RegOp $clk, $name, $annotations, $inner_sym),
+  (RegOp $clk, (GetEmptyString), $annotations, $inner_sym),
   [(uselessNameAttr $name), (NoDontTouch $annotations)]>;
 
 // regreset(clk, sig, val, name),!dnt -> regreset(clk, sig, val, "")
 def DropNameRegReset : Pat<
-  (RegResetOp $clk, $sig, $val, $name, $annotations),
-  (RegResetOp $clk, $sig, $val, (GetEmptyString), $annotations),
+  (RegResetOp $clk, $sig, $val, $name, $annotations, $inner_sym),
+  (RegResetOp $clk, $sig, $val, (GetEmptyString), $annotations, $inner_sym),
   [(uselessNameAttr $name), (NoDontTouch $annotations)]>;
 
 // Mem(...,name),!dnt -> Mem(...x, "")
 def DropNameMem : Pat<
-  (MemOp $rd, $rw, $depth, $ruw, $portNames, $name, $annotations, $portAnno),
-  (MemOp $rd, $rw, $depth, $ruw, $portNames, (GetEmptyString), $annotations, $portAnno),
+  (MemOp $rd, $rw, $depth, $ruw, $portNames, $name, $annotations, $portAnno, $inner_sym),
+  (MemOp $rd, $rw, $depth, $ruw, $portNames, (GetEmptyString), $annotations, $portAnno, $inner_sym),
   [(uselessNameAttr $name), (NoDontTouch $annotations), (NoPortsDontTouch $portAnno)]>;
 
 // CombMem(name),!dnt -> CombMem("")

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -27,7 +27,8 @@ def InstanceOp : FIRRTLOp<"instance", [
                        APIntAttr:$portDirections, StrArrayAttr:$portNames,
                        AnnotationArrayAttr:$annotations,
                        PortAnnotationsAttr:$portAnnotations,
-                       BoolAttr:$lowerToBind);
+                       BoolAttr:$lowerToBind,
+                       OptionalAttr<SymbolNameAttr>:$inner_sym);
 
   let results = (outs Variadic<FIRRTLType>:$results);
 
@@ -43,14 +44,16 @@ def InstanceOp : FIRRTLOp<"instance", [
                    "::mlir::ArrayRef<Attribute>":$portNames,
                    CArg<"ArrayRef<Attribute>", "{}">:$annotations,
                    CArg<"ArrayRef<Attribute>", "{}">:$portAnnotations,
-                   CArg<"bool","false">:$lowerToBind)>,
+                   CArg<"bool","false">:$lowerToBind,
+                   CArg<"StringAttr", "StringAttr()">:$inner_sym)>,
 
     /// Constructor when you have the target module in hand.
     OpBuilder<(ins "FModuleLike":$module,
                    "mlir::StringRef":$name,
                    CArg<"ArrayRef<Attribute>", "{}">:$annotations,
                    CArg<"ArrayRef<Attribute>", "{}">:$portAnnotations,
-                   CArg<"bool","false">:$lowerToBind)>
+                   CArg<"bool","false">:$lowerToBind,
+                   CArg<"StringAttr", "StringAttr()">:$inner_sym)>
   ];
 
   let extraClassDeclaration = [{
@@ -178,10 +181,14 @@ def MemOp : FIRRTLOp<"mem"> {
          Confined<I64Attr, [IntMinValue<1>]>:$depth, RUWAttr:$ruw,
          StrArrayAttr:$portNames, StrAttr:$name,
          AnnotationArrayAttr:$annotations,
-         PortAnnotationsAttr:$portAnnotations);
+         PortAnnotationsAttr:$portAnnotations,
+         OptionalAttr<SymbolNameAttr>:$inner_sym);
   let results = (outs Variadic<FIRRTLType>:$results);
 
-  let assemblyFormat = "$ruw custom<MemOp>(attr-dict) `:` type($results)";
+  let assemblyFormat = [{
+    (`sym` $inner_sym^)?
+    $ruw custom<MemOp>(attr-dict) `:` type($results)
+  }];
 
   let builders = [
     OpBuilder<(ins "::mlir::TypeRange":$resultTypes,
@@ -190,7 +197,8 @@ def MemOp : FIRRTLOp<"mem"> {
                    "ArrayRef<Attribute>":$portNames,
                    CArg<"StringRef", "{}">:$name,
                    CArg<"ArrayRef<Attribute>", "{}">:$annotations,
-                   CArg<"ArrayRef<Attribute>", "{}">:$portAnnotations)>
+                   CArg<"ArrayRef<Attribute>", "{}">:$portAnnotations,
+                   CArg<"StringAttr", "StringAttr()">:$inner_sym)>
   ];
 
   let verifier = "return ::verifyMemOp(*this);";
@@ -264,20 +272,25 @@ def NodeOp : FIRRTLOp<"node",
     }];
 
   let arguments = (ins PassiveType:$input, StrAttr:$name,
-                       AnnotationArrayAttr:$annotations);
+                       AnnotationArrayAttr:$annotations,
+                       OptionalAttr<SymbolNameAttr>:$inner_sym);
   let results = (outs FIRRTLType:$result);
 
   let builders = [
     OpBuilder<(ins "::mlir::Type":$elementType,
                    "::mlir::Value":$input,
                    CArg<"StringRef", "{}">:$name,
-                   CArg<"ArrayRef<Attribute>","{}">:$annotations), [{
+                   CArg<"ArrayRef<Attribute>","{}">:$annotations,
+                   CArg<"StringAttr", "StringAttr()">:$inner_sym), [{
       return build($_builder, $_state, elementType, input, name,
-                   $_builder.getArrayAttr(annotations));
+                   $_builder.getArrayAttr(annotations), inner_sym);
     }]>
   ];
 
-  let assemblyFormat = "$input custom<ImplicitSSAName>(attr-dict) `:` type($input)";
+  let assemblyFormat = [{
+    (`sym` $inner_sym^)?
+    $input custom<ImplicitSSAName>(attr-dict) `:` type($input)
+  }];
 
   let hasCanonicalizer = true;
 
@@ -302,21 +315,26 @@ def RegOp : FIRRTLOp<"reg", [/*MemAlloc*/]> {
     ```
     }];
 
-  let arguments =
-    (ins ClockType:$clockVal, StrAttr:$name, AnnotationArrayAttr:$annotations);
+  let arguments = (
+    ins ClockType:$clockVal, StrAttr:$name,
+        AnnotationArrayAttr:$annotations,
+        OptionalAttr<SymbolNameAttr>:$inner_sym);
   let results = (outs PassiveType:$result);
 
   let builders = [
     OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$clockVal,
                    CArg<"StringRef", "{}">:$name,
-                   CArg<"ArrayRef<Attribute>","{}">:$annotations), [{
+                   CArg<"ArrayRef<Attribute>","{}">:$annotations,
+                   CArg<"StringAttr", "StringAttr()">:$inner_sym), [{
       return build($_builder, $_state, elementType, clockVal, name,
-                   $_builder.getArrayAttr(annotations));
+                   $_builder.getArrayAttr(annotations), inner_sym);
     }]>
   ];
 
-  let assemblyFormat =
-    "operands custom<ImplicitSSAName>(attr-dict) `:` type($result)";
+  let assemblyFormat = [{
+    (`sym` $inner_sym^)?
+    operands custom<ImplicitSSAName>(attr-dict) `:` type($result)
+  }];
   let hasCanonicalizeMethod = true;
 }
 
@@ -331,22 +349,27 @@ def RegResetOp : FIRRTLOp<"regreset", [/*MemAlloc*/]> {
 
   let arguments = (
     ins ClockType:$clockVal, AnyResetType:$resetSignal, PassiveType:$resetValue,
-        StrAttr:$name, AnnotationArrayAttr:$annotations);
+        StrAttr:$name, AnnotationArrayAttr:$annotations,
+        OptionalAttr<SymbolNameAttr>:$inner_sym);
   let results = (outs PassiveType:$result);
 
   let builders = [
     OpBuilder<(ins "::mlir::Type":$elementType, "::mlir::Value":$clockVal,
                    "::mlir::Value":$resetSignal, "::mlir::Value":$resetValue,
                    CArg<"StringRef", "{}">:$name,
-                   CArg<"ArrayRef<Attribute>","{}">:$annotations), [{
+                   CArg<"ArrayRef<Attribute>","{}">:$annotations,
+                   CArg<"StringAttr", "StringAttr()">:$inner_sym), [{
       return build($_builder, $_state, elementType, clockVal, resetSignal,
-                   resetValue, name,
-                   $_builder.getArrayAttr(annotations));
+                   resetValue, name, $_builder.getArrayAttr(annotations),
+                   inner_sym);
     }]>
   ];
 
-  let assemblyFormat =
-     "operands custom<ImplicitSSAName>(attr-dict) `:` type($resetSignal) `,` type($resetValue) `,` type($result)";
+  let assemblyFormat = [{
+    (`sym` $inner_sym^)?
+    operands custom<ImplicitSSAName>(attr-dict)
+    `:` type($resetSignal) `,` type($resetValue) `,` type($result)
+  }];
 
   let hasCanonicalizer = true;
 }
@@ -360,18 +383,24 @@ def WireOp : FIRRTLOp<"wire", []> {
     ```
     }];
 
-  let arguments = (ins StrAttr:$name, AnnotationArrayAttr:$annotations);
+  let arguments = (
+    ins StrAttr:$name, AnnotationArrayAttr:$annotations,
+        OptionalAttr<SymbolNameAttr>:$inner_sym);
   let results = (outs FIRRTLType:$result);
 
   let builders = [
     OpBuilder<(ins "::mlir::Type":$elementType,
                       CArg<"StringRef", "{}">:$name,
-                      CArg<"ArrayRef<Attribute>","{}">:$annotations), [{
+                      CArg<"ArrayRef<Attribute>","{}">:$annotations,
+                      CArg<"StringAttr", "StringAttr()">:$inner_sym), [{
       return build($_builder, $_state, elementType, name,
-                   $_builder.getArrayAttr(annotations));
+                   $_builder.getArrayAttr(annotations), inner_sym);
     }]>
   ];
 
-  let assemblyFormat = "custom<ImplicitSSAName>(attr-dict) `:` type($result)";
+  let assemblyFormat = [{
+    (`sym` $inner_sym^)?
+    custom<ImplicitSSAName>(attr-dict) `:` type($result)
+  }];
   let hasCanonicalizer = true;
 }

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1654,9 +1654,9 @@ static LogicalResult foldHiddenReset(RegOp reg, PatternRewriter &rewriter) {
     constOp->moveBefore(&con->getBlock()->front());
 
   if (!constReg)
-    rewriter.replaceOpWithNewOp<RegResetOp>(reg, reg.getType(), reg.clockVal(),
-                                            mux.sel(), mux.high(), reg.name(),
-                                            reg.annotations());
+    rewriter.replaceOpWithNewOp<RegResetOp>(
+        reg, reg.getType(), reg.clockVal(), mux.sel(), mux.high(), reg.name(),
+        reg.annotations(), reg.inner_symAttr());
   auto pt = rewriter.saveInsertionPoint();
   rewriter.setInsertionPoint(con);
   rewriter.replaceOpWithNewOp<ConnectOp>(con, con.dest(),

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2838,16 +2838,16 @@ ParseResult FIRStmtParser::parseMem(unsigned memIndent) {
     result = builder.create<MemOp>(
         resultTypes, readLatency, writeLatency, depth, ruw,
         builder.getArrayAttr(resultNames), id, getConstants().emptyArrayAttr,
-        builder.getArrayAttr(portAnnotations));
+        builder.getArrayAttr(portAnnotations), StringAttr{});
   } else {
     auto annotations =
         getSplitAnnotations(getModuleTarget() + ">" + id, startTok.getLoc(),
                             ports, moduleContext.targetsInModule);
 
-    result =
-        builder.create<MemOp>(resultTypes, readLatency, writeLatency, depth,
-                              ruw, builder.getArrayAttr(resultNames), id,
-                              annotations.first, annotations.second);
+    result = builder.create<MemOp>(
+        resultTypes, readLatency, writeLatency, depth, ruw,
+        builder.getArrayAttr(resultNames), id, annotations.first,
+        annotations.second, StringAttr{});
   }
 
   UnbundledValueEntry unbundledValueEntry;
@@ -2904,7 +2904,7 @@ ParseResult FIRStmtParser::parseNode() {
                        moduleContext.targetsInModule, initializerType);
 
   Value result = builder.create<NodeOp>(initializer.getType(), initializer, id,
-                                        annotations);
+                                        annotations, StringAttr{});
   return moduleContext.addSymbolEntry(id, result, startTok.getLoc());
 }
 
@@ -2932,7 +2932,7 @@ ParseResult FIRStmtParser::parseWire() {
         getAnnotations(getModuleTarget() + ">" + id, startTok.getLoc(),
                        moduleContext.targetsInModule, type);
 
-  auto result = builder.create<WireOp>(type, id, annotations);
+  auto result = builder.create<WireOp>(type, id, annotations, StringAttr{});
   return moduleContext.addSymbolEntry(id, result, startTok.getLoc());
 }
 
@@ -3027,9 +3027,9 @@ ParseResult FIRStmtParser::parseRegister(unsigned regIndent) {
   Value result;
   if (resetSignal)
     result = builder.create<RegResetOp>(type, clock, resetSignal, resetValue,
-                                        id, annotations);
+                                        id, annotations, StringAttr{});
   else
-    result = builder.create<RegOp>(type, clock, id, annotations);
+    result = builder.create<RegOp>(type, clock, id, annotations, StringAttr{});
 
   return moduleContext.addSymbolEntry(id, result, startTok.getLoc());
 }

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -1470,7 +1470,8 @@ void InferResetsPass::implementAsyncReset(Operation *op, FModuleOp module,
       // Create a new instance op with the reset inserted.
       auto newInstOp = builder.create<InstanceOp>(
           resultTypes, instOp.moduleName(), instOp.name(), newPortDirections,
-          newPortNames, instOp.annotations().getValue(), newPortAnnos);
+          newPortNames, instOp.annotations().getValue(), newPortAnnos,
+          instOp.lowerToBind(), instOp.inner_symAttr());
       instReset = newInstOp.getResult(0);
 
       // Update the uses over to the new instance and drop the old instance.
@@ -1503,7 +1504,7 @@ void InferResetsPass::implementAsyncReset(Operation *op, FModuleOp module,
     auto zero = createZeroValue(builder, regOp.getType());
     auto newRegOp = builder.create<RegResetOp>(
         regOp.getType(), regOp.clockVal(), actualReset, zero, regOp.nameAttr(),
-        regOp.annotations());
+        regOp.annotations(), StringAttr{});
     regOp.getResult().replaceAllUsesWith(newRegOp);
     regOp->erase();
     return;

--- a/lib/Dialect/FIRRTL/Transforms/LowerCHIRRTL.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerCHIRRTL.cpp
@@ -334,7 +334,7 @@ void LowerCHIRRTLPass::replaceMem(Operation *cmem, StringRef name,
   auto memory = memBuilder.create<MemOp>(
       resultTypes, readLatency, writeLatency, depth, ruw,
       memBuilder.getArrayAttr(resultNames), name, annotations,
-      memBuilder.getArrayAttr(portAnnotations));
+      memBuilder.getArrayAttr(portAnnotations), StringAttr{});
 
   // Process each memory port, initializing the memory port and inferring when
   // to set the enable signal high.

--- a/test/Dialect/FIRRTL/inner-names.mlir
+++ b/test/Dialect/FIRRTL/inner-names.mlir
@@ -1,0 +1,25 @@
+// RUN: circt-opt --verify-diagnostics %s | FileCheck %s
+
+firrtl.circuit "Foo" {
+  firrtl.extmodule @Bar()
+
+  // CHECK-LABEL: firrtl.module @Foo
+  firrtl.module @Foo(
+    in %value: !firrtl.uint<42>,
+    in %clock: !firrtl.clock,
+    in %reset: !firrtl.asyncreset
+  ) {
+    // CHECK: firrtl.instance instName sym @instSym @Bar()
+    firrtl.instance instName sym @instSym @Bar()
+    // CHECK: %nodeName = firrtl.node sym @nodeSym %value : !firrtl.uint<42>
+    %nodeName = firrtl.node sym @nodeSym %value : !firrtl.uint<42>
+    // CHECK: %wireName = firrtl.wire sym @wireSym : !firrtl.uint<42>
+    %wireName = firrtl.wire sym @wireSym : !firrtl.uint<42>
+    // CHECK: %regName = firrtl.reg sym @regSym %clock : !firrtl.uint<42>
+    %regName = firrtl.reg sym @regSym %clock : !firrtl.uint<42>
+    // CHECK: %regResetName = firrtl.regreset sym @regResetSym %clock, %reset, %value : !firrtl.asyncreset, !firrtl.uint<42>, !firrtl.uint<42>
+    %regResetName = firrtl.regreset sym @regResetSym %clock, %reset, %value : !firrtl.asyncreset, !firrtl.uint<42>, !firrtl.uint<42>
+    // CHECK: %memName_port = firrtl.mem sym @memSym Undefined {depth = 8 : i64, name = "memName", portNames = ["port"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<42>>
+    %memName_port = firrtl.mem sym @memSym Undefined {depth = 8 : i64, name = "memName", portNames = ["port"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<42>>
+  }
+}

--- a/test/Dialect/FIRRTL/lower-types-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-types-errors.mlir
@@ -1,0 +1,59 @@
+// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-lower-types)' --verify-diagnostics --split-input-file %s
+
+firrtl.circuit "Foo" {
+  firrtl.module @Foo(in %a : !firrtl.bundle<a: uint<42>>, in %b : !firrtl.bundle<a: uint<42>, b: uint<9001>>) {
+    %x = firrtl.node sym @sym1 %a : !firrtl.bundle<a: uint<42>>
+    // expected-error @+1 {{replication due to type lowering renders @sym2 ambiguous}}
+    %y = firrtl.node sym @sym2 %b : !firrtl.bundle<a: uint<42>, b: uint<9001>>
+  }
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+  firrtl.module @Foo() {
+    %x = firrtl.wire sym @sym1 : !firrtl.bundle<a: uint<42>>
+    // expected-error @+1 {{replication due to type lowering renders @sym2 ambiguous}}
+    %y = firrtl.wire sym @sym2 : !firrtl.bundle<a: uint<42>, b: uint<9001>>
+  }
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+  firrtl.module @Foo(in %clock: !firrtl.clock) {
+    %x = firrtl.reg sym @sym1 %clock : !firrtl.bundle<a: uint<42>>
+    // expected-error @+1 {{replication due to type lowering renders @sym2 ambiguous}}
+    %y = firrtl.reg sym @sym2 %clock : !firrtl.bundle<a: uint<42>, b: uint<9001>>
+  }
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+  firrtl.module @Foo(
+    in %a: !firrtl.bundle<a: uint<42>>,
+    in %b: !firrtl.bundle<a: uint<42>, b: uint<9001>>,
+    in %clock: !firrtl.clock,
+    in %reset: !firrtl.asyncreset
+  ) {
+    %x = firrtl.regreset sym @sym1 %clock, %reset, %a : !firrtl.asyncreset, !firrtl.bundle<a: uint<42>>, !firrtl.bundle<a: uint<42>>
+    // expected-error @+1 {{replication due to type lowering renders @sym2 ambiguous}}
+    %y = firrtl.regreset sym @sym2 %clock, %reset, %b : !firrtl.asyncreset, !firrtl.bundle<a: uint<42>, b: uint<9001>>, !firrtl.bundle<a: uint<42>, b: uint<9001>>
+  }
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+  firrtl.module @Foo(
+    in %a: !firrtl.bundle<a: uint<42>>,
+    in %b: !firrtl.bundle<a: uint<42>, b: uint<9001>>,
+    in %clock: !firrtl.clock,
+    in %reset: !firrtl.asyncreset
+  ) {
+    %x_port = firrtl.mem sym @sym1 Undefined {depth = 8 : i64, name = "x", portNames = ["port"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: bundle<a: uint<42>>>
+    // expected-error @+1 {{replication due to type lowering renders @sym2 ambiguous}}
+    %y_port = firrtl.mem sym @sym2 Undefined {depth = 8 : i64, name = "y", portNames = ["port"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: bundle<a: uint<42>, b: uint<9001>>>
+  }
+}


### PR DESCRIPTION
Add a `inner_sym` attribute to the following FIRRTL dialect operations:

- `InstanceOp`
- `NodeOp`
- `WireOp`
- `RegOp`
- `RegResetOp`
- `MemOp`

The `inner_sym` attribute allows these operations to be named in a `hw.innerNameRef`, and gives us the ability to attach a name to these operations that will be carried over through lowering into the HW dialect.

An interesting case arises if one of these operations has an inner name and type lowering would have to duplicate the operation. This can occur for example for a wire with aggregate type:

    %x = firrtl.wire sym @foo : !firrtl.bundle<a: uint<1>, b: uint<2>>

Type lowering would convert this into two wires, one for field `a` and one for field `b`. However, since the wire itself defines the symbol `@foo`, it is unclear what should happen with the symbol. At the moment, type lowering will just emit an error in this case. Other valid options would be to drop the symbol (which is kind of brittle), or introduce a breadcrumb operation that keeps track of the change, like:

    %x_a = firrtl.wire sym @foo_a
    %x_b = firrtl.wire sym @foo_b
    firrtl.aggregate_symbol @foo, [@foo_a, @foo_b]

Since we have no such use cases at the moment, just emitting an error seems fine.

This change does not yet include module port symbols, which require significant additional changes that will follow as a separate PR.