### PR TITLE
[SV] Add part-select operation to SV dialect

### DIFF
--- a/docs/RationaleSV.md
+++ b/docs/RationaleSV.md
@@ -72,7 +72,45 @@ TODO: Describe `sv.wire`, `sv.reg`,
 ## Expressions
 
 TODO: Describe `sv.read_inout` and `sv.array_index_inout`.
+### Part Select
+Unlike Bit-selects which extract a particular bit from an `InOut` type,
+ part-select can extract several contiguous bits in a vector net, vector reg,
+ integer variable, or time variables. 
+ 
+ `SystemVerilog` supports two types of part-selects, a `constant part-select`
+ and an `indexed part-select`. 
+ `sv.part_select` and `sv.part_select_inout` is lowered to the 
+ `indexed part-select` operation.
+ There are two part select operations defined in SV dialect, 
+ the `sv.part_select` is defined on `Integer` type input and 
+ `sv.part_select_inout` is defined on `inout` type.
 
+ Part select consits of 3 arguments, the input value,
+ a `width` and a `base` and an optional boolean attribute `decrement`.
+ The `width` shall be a compile-time constant expression. 
+ The `base` can be a runtime integer expression. 
+ 
+ The operation selects bits starting at the `base` and ascending 
+ or descending the bit range. The number of bits selected is equal to the
+ `width` expression. The bit addressing is always ascending starting from the
+ `base`, unless the `decrement` attribute is specified.
+
+Part-selects that address a range of bits that are completely out of the
+ address bounds of the net, reg, integer, or time, or when the part-select
+ is x or z, shall yield the value x when read, and shall have no effect on
+ the data stored when written.
+
+Part-selects that are partially out of range shall when read return x for
+ the bits that are out of range, and when written shall only affect the bits
+ that are in range.
+ 
+ In this example, bits starting from `%c2` and of width `1` are addressed.
+ Hence `%0` is of width `1`.
+  ```
+  %0 = sv.part_select_inout %combWire[%c2 : 1] : !hw.inout<i10>, i3, !hw.inout<i1>
+  ```
+  
+  
 ### Verbatim op
 
 The verbatim operation produces a typed value expressed by a string of

--- a/docs/RationaleSV.md
+++ b/docs/RationaleSV.md
@@ -72,17 +72,16 @@ TODO: Describe `sv.wire`, `sv.reg`,
 ## Expressions
 
 TODO: Describe `sv.read_inout` and `sv.array_index_inout`.
-### Part Select
-Unlike Bit-selects which extract a particular bit from an `InOut` type,
+### Indexed Part Select
+Unlike Bit-selects which extract a particular bit from integer types,
  part-select can extract several contiguous bits in a vector net, vector reg,
  integer variable, or time variables. 
  
  `SystemVerilog` supports two types of part-selects, a `constant part-select`
  and an `indexed part-select`. 
- `sv.part_select` and `sv.part_select_inout` is lowered to the 
- `indexed part-select` operation.
- There are two part select operations defined in SV dialect, 
- the `sv.part_select` is defined on `Integer` type input and 
+SV dialect has two ops named `sv.part_select` and `sv.part_select_inout`,
+that is lowered to the `indexed part-select` operation.
+ The `sv.part_select` is defined on `Integer` type input and 
  `sv.part_select_inout` is defined on `inout` type.
 
  Part select consits of 3 arguments, the input value,

--- a/include/circt/Dialect/SV/SVExpressions.td
+++ b/include/circt/Dialect/SV/SVExpressions.td
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+include "mlir/Interfaces/InferTypeOpInterface.td"
+
 def AnySignlessIntegerOrInOutType : AnyTypeOf<[AnySignlessInteger, InOutType]>;
 def HasCustomSSAName : DeclareOpInterfaceMethods<OpAsmOpInterface,
                          ["getAsmResultNames"]>;
@@ -120,4 +122,39 @@ def LocalParamOp : SVOp<"localparam",
   }];
 
   let verifier = "return ::verify$cppClass(*this);";
+}
+
+def IndexedPartSelectOp
+ : SVOp<"indexed_part_select",
+        [NoSideEffect, InferTypeOpInterface]> {
+  let summary = "Read several contiguous bits of an int type."
+                "This is an indexed part-select operator."
+                "The base is an integer expression and the width is an "
+                " integer constant. The bits start from base and the number "
+                "of bits selected is equal to width. If $decrement is true, "
+                " then part select decrements starting from $base."
+                "See SV Spec 11.5.1.";
+  let arguments = (ins HWIntegerType:$input, HWIntegerType:$base, I32Attr:$width,
+                      UnitAttr:$decrement);
+  let results = (outs HWIntegerType:$result);
+
+  let builders = [
+    OpBuilder<(ins "Value":$input, "Value":$base, "int32_t":$width,
+                                                CArg<"bool", "false">:$decrement)>
+  ];
+
+  let verifier = "return ::verifyIndexedPartSelectOp(*this);";
+
+  let extraClassDeclaration = [{
+    /// Infer the return types of this operation.
+    static LogicalResult inferReturnTypes(MLIRContext *context,
+                                          Optional<Location> loc,
+                                          ValueRange operands,
+                                          DictionaryAttr attrs,
+                                          mlir::RegionRange regions,
+                                          SmallVectorImpl<Type> &results);
+  }];
+
+  let assemblyFormat = "$input`[`$base (`decrement` $decrement^)?`:` $width`]`"
+                        " attr-dict `:` type($input) `,` type($base)";
 }

--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 include "circt/Types.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
 
 // Note that net declarations like 'wire' should not appear in an always block.
 def WireOp : SVOp<"wire", [NonProceduralOp, 
@@ -138,4 +139,39 @@ def ArrayIndexInOutOp
 
   let assemblyFormat =
     "$input`[`$index`]` attr-dict `:` type($input) `,` type($index)";
+}
+
+def IndexedPartSelectInOutOp : SVOp<"indexed_part_select_inout",
+                         [NoSideEffect, InferTypeOpInterface]> {
+  let summary = "Address several contiguous bits of an inout type (e.g. a wire"
+                " or inout port). This is an indexed part-select operator."
+                "The base is an integer expression and the width is an "
+                " integer constant. The bits start from base and the number "
+                "of bits selected is equal to width. If $decrement is true, "
+                " then part select decrements starting from $base."
+                "See SV Spec 11.5.1.";
+
+  let arguments = (ins InOutType:$input, HWIntegerType:$base, I32Attr:$width,
+                      UnitAttr:$decrement);
+  let results = (outs InOutType:$result);
+
+  let builders = [
+    OpBuilder<(ins "Value":$input, "Value":$base, "int32_t":$width,
+                                 CArg<"bool", "false">:$decrement)>
+  ];
+
+  let verifier = "return ::verifyIndexedPartSelectOp(*this);";
+
+  let extraClassDeclaration = [{
+    /// Infer the return types of this operation.
+    static LogicalResult inferReturnTypes(MLIRContext *context,
+                                          Optional<Location> loc,
+                                          ValueRange operands,
+                                          DictionaryAttr attrs,
+                                          mlir::RegionRange regions,
+                                          SmallVectorImpl<Type> &results);
+  }];
+
+  let assemblyFormat = "$input`[`$base (`decrement` $decrement^)?`:` $width`]`"
+                        " attr-dict `:` type($input) `,` type($base)";
 }

--- a/include/circt/Dialect/SV/SVOps.h
+++ b/include/circt/Dialect/SV/SVOps.h
@@ -17,6 +17,7 @@
 #include "circt/Dialect/SV/SVTypes.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/SymbolTable.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 namespace circt {

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -29,7 +29,8 @@ public:
         .template Case<
             // Expressions
             ReadInOutOp, ArrayIndexInOutOp, VerbatimExprOp, VerbatimExprSEOp,
-            ConstantXOp, ConstantZOp,
+            IndexedPartSelectInOutOp, IndexedPartSelectOp, ConstantXOp,
+            ConstantZOp,
             // Declarations.
             RegOp, WireOp, LocalParamOp, XMROp,
             // Control flow.
@@ -86,6 +87,8 @@ public:
   HANDLE(ArrayIndexInOutOp, Unhandled);
   HANDLE(VerbatimExprOp, Unhandled);
   HANDLE(VerbatimExprSEOp, Unhandled);
+  HANDLE(IndexedPartSelectInOutOp, Unhandled);
+  HANDLE(IndexedPartSelectOp, Unhandled);
   HANDLE(ConstantXOp, Unhandled);
   HANDLE(ConstantZOp, Unhandled);
 

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -147,7 +147,8 @@ static StringRef getSymOpName(Operation *symOp) {
 /// MemoryEffects should be checked if a client cares.
 bool ExportVerilog::isVerilogExpression(Operation *op) {
   // These are SV dialect expressions.
-  if (isa<ReadInOutOp, ArrayIndexInOutOp, ParamValueOp, XMROp>(op))
+  if (isa<ReadInOutOp, ArrayIndexInOutOp, IndexedPartSelectInOutOp,
+          IndexedPartSelectOp, ParamValueOp, XMROp>(op))
     return true;
 
   // All HW combinational logic ops and SV expression ops are Verilog
@@ -1232,6 +1233,8 @@ private:
     return emitSubExpr(op->getOperand(0), LowestPrecedence, OOLUnary);
   }
   SubExprInfo visitSV(ArrayIndexInOutOp op);
+  SubExprInfo visitSV(IndexedPartSelectInOutOp op);
+  SubExprInfo visitSV(IndexedPartSelectOp op);
 
   // Other
   using TypeOpVisitor::visitTypeOp;
@@ -1821,6 +1824,32 @@ SubExprInfo ExprEmitter::visitSV(ArrayIndexInOutOp op) {
   emitSubExpr(op.index(), LowestPrecedence, OOLBinary);
   os << ']';
   return {Selection, arrayPrec.signedness};
+}
+
+SubExprInfo ExprEmitter::visitSV(IndexedPartSelectInOutOp op) {
+  auto prec = emitSubExpr(op.input(), Selection, OOLUnary);
+  os << '[';
+  emitSubExpr(op.base(), LowestPrecedence, OOLBinary);
+  if (op.decrement())
+    os << " -";
+  else
+    os << " +";
+  os << ": " << op.width();
+  os << ']';
+  return {Selection, prec.signedness};
+}
+
+SubExprInfo ExprEmitter::visitSV(IndexedPartSelectOp op) {
+  auto info = emitSubExpr(op.input(), LowestPrecedence, OOLUnary);
+  os << '[';
+  emitSubExpr(op.base(), LowestPrecedence, OOLBinary);
+  if (op.decrement())
+    os << " -";
+  else
+    os << " +";
+  os << ": " << op.width();
+  os << ']';
+  return info;
 }
 
 SubExprInfo ExprEmitter::visitComb(MuxOp op) {

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -20,6 +20,7 @@
 #include "mlir/IR/PatternMatch.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 using namespace circt;
 using namespace sv;
@@ -1080,6 +1081,91 @@ void ArrayIndexInOutOp::build(OpBuilder &builder, OperationState &result,
   resultType = getAnyHWArrayElementType(resultType);
   assert(resultType && "input should have 'inout of an array' type");
   build(builder, result, InOutType::get(resultType), input, index);
+}
+
+//===----------------------------------------------------------------------===//
+// IndexedPartSelectInOutOp
+//===----------------------------------------------------------------------===//
+
+void IndexedPartSelectInOutOp::build(OpBuilder &builder, OperationState &result,
+                                     Value input, Value base, int32_t width,
+                                     bool decrement) {
+  auto resultType =
+      hw::InOutType::get(IntegerType::get(builder.getContext(), width));
+  build(builder, result, resultType, input, base, width, decrement);
+}
+
+LogicalResult IndexedPartSelectInOutOp::inferReturnTypes(
+    MLIRContext *context, Optional<Location> loc, ValueRange operands,
+    DictionaryAttr attrs, mlir::RegionRange regions,
+    SmallVectorImpl<Type> &results) {
+  auto width = attrs.get("width");
+  if (!width)
+    return failure();
+
+  results.push_back(hw::InOutType::get(
+      IntegerType::get(context, width.cast<IntegerAttr>().getInt())));
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// IndexedPartSelectOp
+//===----------------------------------------------------------------------===//
+
+void IndexedPartSelectOp::build(OpBuilder &builder, OperationState &result,
+                                Value input, Value base, int32_t width,
+                                bool decrement) {
+  auto resultType = (IntegerType::get(builder.getContext(), width));
+  build(builder, result, resultType, input, base, width, decrement);
+}
+
+LogicalResult IndexedPartSelectOp::inferReturnTypes(
+    MLIRContext *context, Optional<Location> loc, ValueRange operands,
+    DictionaryAttr attrs, mlir::RegionRange regions,
+    SmallVectorImpl<Type> &results) {
+  auto width = attrs.get("width");
+  if (!width)
+    return failure();
+
+  results.push_back(
+      IntegerType::get(context, width.cast<IntegerAttr>().getInt()));
+  return success();
+}
+
+static LogicalResult verifyIndexedPartSelectOp(Operation *op) {
+  return TypeSwitch<Operation *, LogicalResult>(op)
+      .Case<IndexedPartSelectOp, IndexedPartSelectInOutOp>(
+          [&](auto p) -> LogicalResult {
+            unsigned inputWidth, resultWidth;
+            auto width = p.width();
+            if (isa<IndexedPartSelectInOutOp>(p)) {
+              if (auto i = p.input()
+                               .getType()
+                               .template cast<InOutType>()
+                               .getElementType()
+                               .template dyn_cast<IntegerType>())
+                inputWidth = i.getWidth();
+              else
+                return op->emitError("input element type must be Integer");
+              if (auto resType = p.getType()
+                                     .template cast<InOutType>()
+                                     .getElementType()
+                                     .template dyn_cast<IntegerType>())
+                resultWidth = resType.getWidth();
+              else
+                return op->emitError("result element type must be Integer");
+            } else
+              resultWidth = p.getType().template cast<IntegerType>().getWidth();
+            if (width > inputWidth)
+              return op->emitError(
+                  "slice width should not be greater than input width");
+            if (width != resultWidth)
+              return op->emitError("result width must be equal to slice width");
+            return success();
+          })
+      .Default([&](auto) { return failure(); });
+
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -1136,7 +1136,7 @@ static LogicalResult verifyIndexedPartSelectOp(Operation *op) {
   return TypeSwitch<Operation *, LogicalResult>(op)
       .Case<IndexedPartSelectOp, IndexedPartSelectInOutOp>(
           [&](auto p) -> LogicalResult {
-            unsigned inputWidth, resultWidth;
+            unsigned inputWidth = 0, resultWidth = 0;
             auto width = p.width();
             if (isa<IndexedPartSelectInOutOp>(p)) {
               if (auto i = p.input()
@@ -1154,8 +1154,11 @@ static LogicalResult verifyIndexedPartSelectOp(Operation *op) {
                 resultWidth = resType.getWidth();
               else
                 return op->emitError("result element type must be Integer");
-            } else
+            } else {
               resultWidth = p.getType().template cast<IntegerType>().getWidth();
+              inputWidth =
+                  p.input().getType().template cast<IntegerType>().getWidth();
+            }
             if (width > inputWidth)
               return op->emitError(
                   "slice width should not be greater than input width");

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -143,6 +143,8 @@ hw.module @test1(%arg0: i1, %arg1: i1, %arg8: i8) {
 
   // CHECK-NEXT: %combWire = sv.reg : !hw.inout<i1>
   %combWire = sv.reg : !hw.inout<i1>
+  // CHECK-NEXT: %selReg = sv.reg : !hw.inout<i10>
+  %selReg = sv.reg : !hw.inout<i10>
   // CHECK-NEXT: %combWire2 = sv.wire : !hw.inout<i1>
   %combWire2 = sv.wire : !hw.inout<i1>
   // CHECK-NEXT: %regForce = sv.reg : !hw.inout<i1>
@@ -153,6 +155,12 @@ hw.module @test1(%arg0: i1, %arg1: i1, %arg8: i8) {
     %tmpx = sv.constantX : i1
     // CHECK-NEXT: sv.passign %combWire, %x_i1 : i1
     sv.passign %combWire, %tmpx : i1
+    // CHECK-NEXT: %[[c2_i3:.+]] = hw.constant 2 : i3
+    // CHECK-NEXT: %[[v0:.+]] = sv.indexed_part_select_inout %selReg[%[[c2_i3]] : 1] : !hw.inout<i10>, i3
+    // CHECK-NEXT: sv.passign %[[v0]], %x_i1 : i1
+    %c2 = hw.constant 2 : i3
+    %xx1 = sv.indexed_part_select_inout %selReg[%c2:1] :  !hw.inout<i10>, i3
+    sv.passign %xx1, %tmpx : i1
     // CHECK-NEXT: sv.force %combWire2, %x_i1 : i1
     sv.force %combWire2, %tmpx : i1
     // CHECK-NEXT: sv.force %regForce, %x_i1 : i1
@@ -244,4 +252,27 @@ hw.module @XMR_src(%a : i23) {
   %xmr2 = sv.xmr "a",b,c : !hw.inout<i3>
   %r = sv.read_inout %xmr1 : !hw.inout<i23>
   sv.assign %xmr1, %a : i23
+}
+
+  hw.module @part_select(%in4 : i4, %in8 : i8) -> (a : i3, b : i5) {
+  // CHECK-LABEL: hw.module @part_select
+
+    %myReg2 = sv.reg : !hw.inout<i18>
+    %c2_i3 = hw.constant 7 : i4
+    // CHECK: = sv.indexed_part_select_inout %myReg2[%[[c7_i4:.+]] : 8] : !hw.inout<i18>, i4
+    %a1 = sv.indexed_part_select_inout %myReg2 [%c2_i3:8] : !hw.inout<i18>, i4
+    sv.assign %a1, %in8 : i8
+    // CHECK:  = sv.indexed_part_select_inout %myReg2[%[[c7_i4]] decrement : 8] : !hw.inout<i18>, i4
+    %b1 = sv.indexed_part_select_inout %myReg2 [%c2_i3 decrement:8] : !hw.inout<i18>, i4
+    sv.assign %b1, %in8 : i8
+    %c3_i3 = hw.constant 3 : i4
+    %rc = sv.read_inout %myReg2 : !hw.inout<i18>
+    %c = sv.indexed_part_select %rc [%c3_i3:3] : i18, i4
+    // CHECK: %[[v2:.+]] = sv.read_inout %myReg2 : !hw.inout<i18>
+    // CHECK: = sv.indexed_part_select %[[v2]][%[[c3_i4:.+]] : 3] : i18, i4
+    %rd = sv.read_inout %myReg2 : !hw.inout<i18>
+    %d = sv.indexed_part_select %rd [%in4 decrement:5] : i18, i4
+    // CHECK: %[[v4:.+]] = sv.read_inout %myReg2 : !hw.inout<i18>
+    // CHECK: = sv.indexed_part_select %[[v4]][%[[in4:.+]]  decrement : 5] : i18, i4
+    hw.output %c, %d : i3, i5
 }

--- a/test/Dialect/SV/errors.mlir
+++ b/test/Dialect/SV/errors.mlir
@@ -180,3 +180,12 @@ hw.module @test() {
   // expected-error @+1 {{op invalid parameter value @test}}
   %param_x = sv.localparam : i42 {value = @test}
 }
+
+// -----
+
+hw.module @part_select1() {
+    %selWire = sv.wire : !hw.inout<i10>
+    %c2 = hw.constant 2 : i3
+  // expected-error @+1 {{slice width should not be greater than input width}}
+    %xx1 = sv.indexed_part_select_inout %selWire[%c2:11] :  !hw.inout<i10>, i3
+}

--- a/test/Dialect/SV/errors.mlir
+++ b/test/Dialect/SV/errors.mlir
@@ -184,8 +184,18 @@ hw.module @test() {
 // -----
 
 hw.module @part_select1() {
-    %selWire = sv.wire : !hw.inout<i10>
-    %c2 = hw.constant 2 : i3
+  %selWire = sv.wire : !hw.inout<i10>
+  %c2 = hw.constant 2 : i3
   // expected-error @+1 {{slice width should not be greater than input width}}
-    %xx1 = sv.indexed_part_select_inout %selWire[%c2:11] :  !hw.inout<i10>, i3
+  %xx1 = sv.indexed_part_select_inout %selWire[%c2:11] :  !hw.inout<i10>, i3
+}
+
+// -----
+
+hw.module @part_select1() {
+  %selWire = sv.wire : !hw.inout<i10>
+  %c2 = hw.constant 2 : i3
+  %r1 = sv.read_inout %selWire : !hw.inout<i10>
+  // expected-error @+1 {{slice width should not be greater than input width}}
+  %c = sv.indexed_part_select %r1[%c2 : 20] : i10,i3
 }


### PR DESCRIPTION
This PR adds the indexed part-select operation to the SV dialect.
In SystemVerilog, the Indexed part-select gives an access to contiguous bits
 of vectors. Part-select can be used to address a part of a vector. 
The range is specified by two, integer expressions: the `base` and the constant
 `width`. The selected bits starts incrementing from `base` and number of bits
 is equal to `width`.
The bit addressing is always ascending starting from the base

Part-select is defined in section 11.5.1 of 1800-2017 spec.

In this example, bits starting from `%c2_i3` and of width 40 are addressed.

```
%wire42 = sv.reg : !hw.inout<i42>
%a = sv.part_select %wire42[%c2_i3 : 40] : !hw.inout<i42>, i3, !hw.inout<i40>
sv.bpassign %a, %c42 : i40
```
Which is lowered to the following verilog
```
 reg        [42:0] wire42
 wire42[3'h2 +: 40] = 42'h2A ;      // ==> wire42[ 39 : 2]

```