### PR TITLE
[FIRRTL] Add optional port symbols to module-like ops

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -28,6 +28,7 @@ struct PortInfo {
   StringAttr name;
   FIRRTLType type;
   Direction direction;
+  StringAttr sym;
   Location loc;
   AnnotationSet annotations = AnnotationSet(type.getContext());
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -138,6 +138,35 @@ def FModuleLike : OpInterface<"FModuleLike"> {
     }]>,
 
     //===------------------------------------------------------------------===//
+    // Port Symbols
+    //===------------------------------------------------------------------===//
+
+    InterfaceMethod<"Get the port symbols attribute",
+    "ArrayAttr", "getPortSymbolsAttr", (ins), [{}],
+    /*defaultImplementation=*/[{
+      return $_op->template
+        getAttrOfType<ArrayAttr>(FModuleLike::getPortSymbolsAttrName());
+    }]>,
+
+    InterfaceMethod<"Get the port symbols",
+    "ArrayRef<Attribute>", "getPortSymbols", (ins), [{}],
+    /*defaultImplementation=*/[{
+      return $_op.getPortSymbolsAttr().getValue();
+    }]>,
+
+    InterfaceMethod<"Get a port symbol",
+    "StringAttr", "getPortSymbolAttr", (ins "size_t":$portIndex), [{}],
+    /*defaultImplementation=*/[{
+      return $_op.getPortSymbols()[portIndex].template cast<StringAttr>();
+    }]>,
+
+    InterfaceMethod<"Get a port symbol",
+    "StringRef", "getPortSymbol", (ins "size_t":$portIndex), [{}],
+    /*defaultImplementation=*/[{
+      return $_op.getPortSymbolAttr(portIndex).getValue();
+    }]>,
+
+    //===------------------------------------------------------------------===//
     // All Port Information
     //===------------------------------------------------------------------===//
 
@@ -170,6 +199,11 @@ def FModuleLike : OpInterface<"FModuleLike"> {
     /// Get the attribute name for port annotations.
     static StringRef getPortAnnotationsAttrName() {
       return "portAnnotations";
+    }
+
+    /// Get the attribute name for port symbols.
+    static StringRef getPortSymbolsAttrName() {
+      return "portSyms";
     }
   }];
 

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -706,6 +706,7 @@ LogicalResult FIRRTLModuleLowering::lowerPorts(
     hw::PortInfo hwPort;
     hwPort.name = firrtlPort.name;
     hwPort.type = lowerType(firrtlPort.type);
+    hwPort.sym = firrtlPort.sym;
 
     // We can't lower all types, so make sure to cleanly reject them.
     if (!hwPort.type) {

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -486,7 +486,8 @@ static FModuleOp createTopModuleOp(handshake::FuncOp funcOp, unsigned numClocks,
       funcOp.emitError("Unsupported data type. Supported data types: integer "
                        "(signed, unsigned, signless), index, none.");
 
-    ports.push_back({portName, bundlePortType, Direction::In, arg.getLoc()});
+    ports.push_back(
+        {portName, bundlePortType, Direction::In, StringAttr{}, arg.getLoc()});
     ++argIndex;
   }
 
@@ -502,24 +503,29 @@ static FModuleOp createTopModuleOp(handshake::FuncOp funcOp, unsigned numClocks,
       funcOp.emitError("Unsupported data type. Supported data types: integer "
                        "(signed, unsigned, signless), index, none.");
 
-    ports.push_back({portName, bundlePortType, Direction::Out, funcLoc});
+    ports.push_back(
+        {portName, bundlePortType, Direction::Out, StringAttr{}, funcLoc});
     ++argIndex;
   }
 
   // Add clock and reset signals.
   if (numClocks == 1) {
     ports.push_back({rewriter.getStringAttr("clock"),
-                     rewriter.getType<ClockType>(), Direction::In, funcLoc});
+                     rewriter.getType<ClockType>(), Direction::In, StringAttr{},
+                     funcLoc});
     ports.push_back({rewriter.getStringAttr("reset"),
-                     rewriter.getType<UIntType>(1), Direction::In, funcLoc});
+                     rewriter.getType<UIntType>(1), Direction::In, StringAttr{},
+                     funcLoc});
   } else if (numClocks > 1) {
     for (unsigned i = 0; i < numClocks; ++i) {
       auto clockName = "clock" + std::to_string(i);
       auto resetName = "reset" + std::to_string(i);
       ports.push_back({rewriter.getStringAttr(clockName),
-                       rewriter.getType<ClockType>(), Direction::In, funcLoc});
+                       rewriter.getType<ClockType>(), Direction::In,
+                       StringAttr{}, funcLoc});
       ports.push_back({rewriter.getStringAttr(resetName),
-                       rewriter.getType<UIntType>(1), Direction::In, funcLoc});
+                       rewriter.getType<UIntType>(1), Direction::In,
+                       StringAttr{}, funcLoc});
     }
   }
 
@@ -590,7 +596,8 @@ static FModuleOp createSubModuleOp(FModuleOp topModuleOp, Operation *oldOp,
       oldOp->emitError("Unsupported data type. Supported data types: integer "
                        "(signed, unsigned, signless), index, none.");
 
-    ports.push_back({portName, bundlePortType, Direction::In, loc});
+    ports.push_back(
+        {portName, bundlePortType, Direction::In, StringAttr{}, loc});
     ++argIndex;
   }
 
@@ -603,16 +610,19 @@ static FModuleOp createSubModuleOp(FModuleOp topModuleOp, Operation *oldOp,
       oldOp->emitError("Unsupported data type. Supported data types: integer "
                        "(signed, unsigned, signless), index, none.");
 
-    ports.push_back({portName, bundlePortType, Direction::Out, loc});
+    ports.push_back(
+        {portName, bundlePortType, Direction::Out, StringAttr{}, loc});
     ++argIndex;
   }
 
   // Add clock and reset signals.
   if (hasClock) {
     ports.push_back({rewriter.getStringAttr("clock"),
-                     rewriter.getType<ClockType>(), Direction::In, loc});
+                     rewriter.getType<ClockType>(), Direction::In, StringAttr{},
+                     loc});
     ports.push_back({rewriter.getStringAttr("reset"),
-                     rewriter.getType<UIntType>(1), Direction::In, loc});
+                     rewriter.getType<UIntType>(1), Direction::In, StringAttr{},
+                     loc});
   }
 
   return rewriter.create<FModuleOp>(

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3275,8 +3275,8 @@ FIRCircuitParser::parsePortList(SmallVectorImpl<PortInfo> &resultPorts,
       annotations = AnnotationSet(
           getAnnotations(moduleTarget + ">" + name.getValue(), info.getFIRLoc(),
                          getConstants().targetSet, type));
-    resultPorts.push_back(
-        {name, type, direction::get(isOutput), info.getLoc(), annotations});
+    resultPorts.push_back({name, type, direction::get(isOutput), StringAttr{},
+                           info.getLoc(), annotations});
     resultPortLocs.push_back(info.getFIRLoc());
   }
 

--- a/lib/Dialect/FIRRTL/Transforms/BlackBoxMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackBoxMemory.cpp
@@ -112,7 +112,7 @@ static void getBlackBoxPortsForMemOp(MemOp op,
       if (bundleElement.isFlip)
         direction = Direction::Out;
       extPorts.push_back(
-          {builder.getStringAttr(name), type, direction, op.getLoc()});
+          {builder.getStringAttr(name), type, direction, {}, op.getLoc()});
     }
   }
 }
@@ -182,7 +182,7 @@ static FModuleOp createWrapperModule(MemOp op,
   for (size_t i = 0, e = memPorts.size(); i != e; ++i) {
     auto name = op.getPortName(i);
     auto type = op.getPortType(i);
-    modPorts.push_back({name, type, Direction::In, op.getLoc()});
+    modPorts.push_back({name, type, Direction::In, {}, op.getLoc()});
   }
   auto moduleOp = builder.create<FModuleOp>(
       op.getLoc(), builder.getStringAttr(memName), modPorts);

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
@@ -172,10 +172,12 @@ FModuleOp ModuleSignalMappings::emitMappingsModule() {
   // are supposed to emit.
   SmallVector<PortInfo> ports;
   for (auto &mapping : mappings) {
-    ports.push_back(PortInfo{mapping.localName, mapping.type,
+    ports.push_back(PortInfo{mapping.localName,
+                             mapping.type,
                              mapping.dir == MappingDirection::DriveRemote
                                  ? Direction::In
                                  : Direction::Out,
+                             {},
                              module.getLoc()});
     LLVM_DEBUG(llvm::dbgs() << "  - Adding port " << mapping.localName << "\n");
   }

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -1378,8 +1378,11 @@ LogicalResult InferResetsPass::implementAsyncReset(FModuleOp module,
   // If needed, add a reset port to the module.
   Value actualReset = domain.existingValue;
   if (domain.newPortName) {
-    PortInfo portInfo{domain.newPortName, AsyncResetType::get(&getContext()),
-                      Direction::In, domain.reset.getLoc()};
+    PortInfo portInfo{domain.newPortName,
+                      AsyncResetType::get(&getContext()),
+                      Direction::In,
+                      {},
+                      domain.reset.getLoc()};
     module.insertPorts({{0, portInfo}});
     actualReset = module.getArgument(0);
     LLVM_DEBUG(llvm::dbgs()

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1197,11 +1197,30 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
   firrtl.extmodule @chkcoverAnno(in clock: !firrtl.clock) attributes {annotations = [{class = "freechips.rocketchip.annotations.InternalVerifBlackBoxAnnotation"}]}
 
+  // CHECK-LABEL: hw.module.extern @InnerNamesExt
+  // CHECK-SAME:  (
+  // CHECK-SAME:    clockIn: i1 {hw.exportPort = @extClockInSym}
+  // CHECK-SAME:  ) -> (
+  // CHECK-SAME:    clockOut: i1 {hw.exportPort = @extClockOutSym}
+  // CHECK-SAME:  )
+  firrtl.extmodule @InnerNamesExt(
+    in clockIn: !firrtl.clock sym @extClockInSym,
+    out clockOut: !firrtl.clock sym @extClockOutSym
+  )
+
   // CHECK-LABEL: hw.module @InnerNames
+  // CHECK-SAME:  (
+  // CHECK-SAME:    %value: i42 {hw.exportPort = @portValueSym}
+  // CHECK-SAME:    %clock: i1 {hw.exportPort = @portClockSym}
+  // CHECK-SAME:    %reset: i1 {hw.exportPort = @portResetSym}
+  // CHECK-SAME:  ) -> (
+  // CHECK-SAME:    out: i1 {hw.exportPort = @portOutSym}
+  // CHECK-SAME:  )
   firrtl.module @InnerNames(
-    in %value: !firrtl.uint<42>,
-    in %clock: !firrtl.clock,
-    in %reset: !firrtl.uint<1>
+    in %value: !firrtl.uint<42> sym @portValueSym,
+    in %clock: !firrtl.clock sym @portClockSym,
+    in %reset: !firrtl.uint<1> sym @portResetSym,
+    out %out: !firrtl.uint<1> sym @portOutSym
   ) {
     firrtl.instance instName sym @instSym @BitCast1()
     // CHECK: hw.instance "instName" sym @instSym @BitCast1
@@ -1216,5 +1235,6 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK: %regResetName = sv.reg sym @regResetSym : !hw.inout<i42>
     %memName_port = firrtl.mem sym @memSym Undefined {depth = 12 : i64, name = "memName", portNames = ["port"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     // CHECK: {{%.+}} = hw.instance "memName" sym @memSym
+    firrtl.connect %out, %reset : !firrtl.uint<1>, !firrtl.uint<1>
   }
 }

--- a/test/Dialect/FIRRTL/SFCTests/verbatim-inner-names.mlir
+++ b/test/Dialect/FIRRTL/SFCTests/verbatim-inner-names.mlir
@@ -2,13 +2,13 @@
 
 firrtl.circuit "Foo" {
   firrtl.extmodule @Bar(
-    in extClockIn: !firrtl.clock,
-    out extClockOut: !firrtl.clock
+    in extClockIn: !firrtl.clock sym @symExtClockIn,
+    out extClockOut: !firrtl.clock sym @symExtClockOut
   )
   firrtl.module @Foo(
-    in %value: !firrtl.uint<42>,
-    in %clock: !firrtl.clock,
-    in %reset: !firrtl.uint<1>
+    in %value: !firrtl.uint<42> sym @symValue,
+    in %clock: !firrtl.clock sym @symClock,
+    in %reset: !firrtl.uint<1> sym @symReset
   ) {
     %instName_clockIn, %instName_clockOut = firrtl.instance instName sym @instSym @Bar(in extClockIn: !firrtl.clock, out extClockOut: !firrtl.clock)
     %nodeName = firrtl.node sym @nodeSym %value : !firrtl.uint<42>
@@ -24,6 +24,16 @@ firrtl.circuit "Foo" {
 
 // CHECK: ----- 8< -----
 sv.verbatim "----- 8< -----"
+sv.verbatim "VERB symExtClockIn = `{{0}}`" {symbols = [#hw.innerNameRef<@Bar::@symExtClockIn>]}
+sv.verbatim "VERB symExtClockOut = `{{0}}`" {symbols = [#hw.innerNameRef<@Bar::@symExtClockOut>]}
+// CHECK-NEXT: VERB symExtClockIn = `extClockIn`
+// CHECK-NEXT: VERB symExtClockOut = `extClockOut`
+sv.verbatim "VERB symValue = `{{0}}`" {symbols = [#hw.innerNameRef<@Foo::@symValue>]}
+sv.verbatim "VERB symClock = `{{0}}`" {symbols = [#hw.innerNameRef<@Foo::@symClock>]}
+sv.verbatim "VERB symReset = `{{0}}`" {symbols = [#hw.innerNameRef<@Foo::@symReset>]}
+// CHECK-NEXT: VERB symValue = `value`
+// CHECK-NEXT: VERB symClock = `clock`
+// CHECK-NEXT: VERB symReset = `reset`
 sv.verbatim "VERB instSym = `{{0}}`" {symbols = [#hw.innerNameRef<@Foo::@instSym>]}
 sv.verbatim "VERB nodeSym = `{{0}}`" {symbols = [#hw.innerNameRef<@Foo::@nodeSym>]}
 sv.verbatim "VERB wireSym = `{{0}}`" {symbols = [#hw.innerNameRef<@Foo::@wireSym>]}

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -98,7 +98,7 @@ firrtl.circuit "foo" {
 // expected-error @+1 {{requires one region}}
 "firrtl.module"() ( { }, { })
    {sym_name = "foo", portTypes = [!firrtl.uint], portDirections = 1 : i1,
-    portNames = ["in0"], portAnnotations = []} : () -> ()
+    portNames = ["in0"], portAnnotations = [], portSyms = [""]} : () -> ()
 }
 
 
@@ -109,7 +109,7 @@ firrtl.circuit "foo" {
 "firrtl.module"() ( {
   ^entry:
 }) {sym_name = "foo", portTypes = [!firrtl.uint], portDirections = 1 : i1,
-    portNames = ["in0"], portAnnotations = []} : () -> ()
+    portNames = ["in0"], portAnnotations = [], portSyms = [""]} : () -> ()
 }
 
 // -----
@@ -119,7 +119,7 @@ firrtl.circuit "foo" {
 "firrtl.module"() ( {
   ^entry(%a: i1):
 }) {sym_name = "foo", portTypes = [!firrtl.uint], portDirections = 1 : i1,
-    portNames = ["in0"], portAnnotations = []} : () -> ()
+    portNames = ["in0"], portAnnotations = [], portSyms = [""]} : () -> ()
 }
 
 // -----

--- a/test/Dialect/FIRRTL/inner-names.mlir
+++ b/test/Dialect/FIRRTL/inner-names.mlir
@@ -4,10 +4,13 @@ firrtl.circuit "Foo" {
   firrtl.extmodule @Bar()
 
   // CHECK-LABEL: firrtl.module @Foo
+  // CHECK-SAME: in %value: !firrtl.uint<42> sym @symValue
+  // CHECK-SAME: in %clock: !firrtl.clock sym @symClock
+  // CHECK-SAME: in %reset: !firrtl.asyncreset sym @symReset
   firrtl.module @Foo(
-    in %value: !firrtl.uint<42>,
-    in %clock: !firrtl.clock,
-    in %reset: !firrtl.asyncreset
+    in %value: !firrtl.uint<42> sym @symValue,
+    in %clock: !firrtl.clock sym @symClock,
+    in %reset: !firrtl.asyncreset sym @symReset
   ) {
     // CHECK: firrtl.instance instName sym @instSym @Bar()
     firrtl.instance instName sym @instSym @Bar()


### PR DESCRIPTION
Extend the FIRRTL dialect such that the `FModuleOp` and `FExtModuleOp` operations can carry an optional symbol for each of their ports. This is done in a similar fashion as port names, directions, and annotations, in that there is a separate array attribute which tracks the symbol for each port. Since leaving null attributes in the IR is a bit yucky, the absence of a symbol is encoded as an empty string.

This extends module-like port lists to support the following:

    firrtl.module @Foo(
      in %a: !firrtl.uint<1> sym @symbolA,
      out %b: !firrtl.uint<1> sym @symbolB
    )

The change to the IR itself is pretty trivial, but causes a whole bunch of follow-up fixes in all the places that build or modify modules. These places are surprisingly numerous and would benefit from some later cleanup. @youngar has looked into moving the module-like signature into a separate single attribute, which may go a long way towards making this prettier.

This also adds tests to ensure port symbols are properly represented within the FIRRTL dialect, they carry over into the HW dialect as expected, and that using FIRRTL port symbols in `sv.verbatim` operations has the intended Verilog output result.

This PR enables a whole bunch of follow-up work to make metadata and OMIR emission cleaner and more robust in the presence of renaming.

### Todo
- [x] Land #2081
- [x] Land #2114
- [x] Land #2115
- [x] Land #2117
- [x] Land #2104