### PR TITLE
[FIRRTL] Remove `.` during port lowering

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1004,7 +1004,7 @@ void FIRRTLModuleLowering::lowerModuleBody(
     // anything outside the module.  Inputs are lowered to zero.
     if (isZeroWidth && port.isInput()) {
       Value newArg = bodyBuilder.create<WireOp>(
-          port.type, "." + port.getName().str() + ".0width_input");
+          port.type, "__" + port.getName().str() + "_0width_input");
       oldArg.replaceAllUsesWith(newArg);
       continue;
     }
@@ -1020,7 +1020,7 @@ void FIRRTLModuleLowering::lowerModuleBody(
     // Outputs need a temporary wire so they can be connect'd to, which we
     // then return.
     Value newArg = bodyBuilder.create<WireOp>(
-        port.type, "." + port.getName().str() + ".output");
+        port.type, "__" + port.getName().str() + "_output");
     // Switch all uses of the old operands to the new ones.
     oldArg.replaceAllUsesWith(newArg);
 

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
@@ -98,21 +98,21 @@ firrtl.circuit "Simple" {
                              out %outD: !firrtl.uint<4>,
                              in %inE: !firrtl.uint<3>,
                              out %outE: !firrtl.uint<4>) {
-    // CHECK: %.outB.output = sv.wire : !hw.inout<i4>
-    // CHECK: [[OUTBR:%.+]] = sv.read_inout %.outB.output
+    // CHECK: %[[outBVar:.+]] = sv.wire : !hw.inout<i4>
+    // CHECK: [[OUTBR:%.+]] = sv.read_inout %[[outBVar]]
     // CHECK: [[OUTC:%.+]] = sv.wire : !hw.inout<i4>
-    // CHECK: [[OUTCR:%.+]] = sv.read_inout %.outC.output
+    // CHECK: [[OUTCR:%.+]] = sv.read_inout [[OUTC]]
     // CHECK: [[OUTD:%.+]] = sv.wire : !hw.inout<i4>
-    // CHECK: [[OUTDR:%.+]] = sv.read_inout %.outD.output
+    // CHECK: [[OUTDR:%.+]] = sv.read_inout [[OUTD]]
 
     // Normal
     firrtl.connect %outA, %inA : !firrtl.uint<4>, !firrtl.uint<4>
 
     // Multi connect
     firrtl.connect %outB, %inA : !firrtl.uint<4>, !firrtl.uint<4>
-    // CHECK: sv.assign %.outB.output, %inA : i4
+    // CHECK: sv.assign %[[outBVar]], %inA : i4
     firrtl.connect %outB, %inB : !firrtl.uint<4>, !firrtl.uint<4>
-    // CHECK: sv.assign %.outB.output, %inB : i4
+    // CHECK: sv.assign %[[outBVar]], %inB : i4
 
     %0 = firrtl.sub %inA, %outC : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
 


### PR DESCRIPTION
Remove the `.` when creating a wire for module port lowering.
Fix for https://github.com/llvm/circt/issues/2084