### PR TITLE
[FIRRTL][Emitter] Add SeqMem and CombMem support

### DIFF
--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -558,7 +558,8 @@ void Emitter::emitStatement(CombMemOp op) {
 }
 
 void Emitter::emitStatement(MemoryPortOp op) {
-  // Nothing to output for this operation. 
+  // Nothing to output for this operation.
+  addValueName(op.data(), op.name());
 }
 
 void Emitter::emitStatement(MemoryPortAccessOp op) {

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -294,6 +294,9 @@ firrtl.circuit "Foo" {
     // CHECK-NEXT: when ui1 :
     // CHECK-NEXT:   infer mport port1 = seqmem[someAddr], someClock
 
+    firrtl.connect %port0_data, %port1_data : !firrtl.uint<3>, !firrtl.uint<3>
+    // CHECK: port0 <= port1
+
     %invalid_clock = firrtl.invalidvalue : !firrtl.clock
     %dummyReg = firrtl.reg %invalid_clock : !firrtl.uint<42>
     // CHECK: wire [[INV:_invalid.*]] : Clock


### PR DESCRIPTION
This adds support for emitting `SeqMemOp`, `CombMemOp`, and their memory
ports, `MemoryPortOp` and `MemoryPortAccessOp`.

The code for emitting memory port access is a little tricky because it
must reach backwards and find the original CHIRRTL memory declaration
and memory port to get all the information needed to print.
Theoretically the port name could have been stored using `addValueName`,
but we already had the port op in hand for other attributes, so we just ask it directly
for its name.

The code doesn't have error checking because the error cases are all
covered by the verifier.