### PR TITLE
[FIRRTL][LowerToHW] Don't emit warnings for non-local annotations

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -300,6 +300,11 @@ void CircuitLoweringState::processRemainingAnnotations(
     // This can occur for example if an annotation marks something in the IR as
     // not to be processed by a pass, but that pass hasn't run anyway.
     if (a.isClass(
+            // If the class is `circt.nonlocal`, it's not really an annotation,
+            // but part of a path specifier for another annotation which is
+            // non-local.  We can ignore these path specifiers since there will
+            // be a warning produced for the real annotation.
+            "circt.nonlocal",
             // The following are either consumed by a pass running before
             // LowerToHW, or they have no effect if the pass doesn't run at all.
             // If the accompanying pass runs on the HW dialect, then LowerToHW
@@ -421,6 +426,9 @@ void FIRRTLModuleLowering::runOnOperation() {
         .Case<FExtModuleOp>([&](auto extModule) {
           state.oldToNewModuleMap[&op] =
               lowerExtModule(extModule, topLevelModule, state);
+        })
+        .Case<NonLocalAnchor>([&](auto nla) {
+          // Just drop it.
         })
         .Default([&](Operation *op) {
           // We don't know what this op is.  If it has no illegal FIRRTL types,

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
@@ -117,6 +117,11 @@ firrtl.circuit "Foo" attributes {annotations = [
         {class = "sifive.enterprise.firrtl.DontObfuscateModuleAnnotation"},
         {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"},
         {class = "sifive.enterprise.firrtl.ScalaClassAnnotation"},
-        {class = "firrtl.transforms.BlackBox"}
+        {class = "firrtl.transforms.BlackBox", circt.nonlocal = @nla_1}
     ]} {}
+    // Non-local annotations should not produce errors either.
+    firrtl.nla  @nla_1 [@Bar, @Foo] ["foo", "Foo"]
+    firrtl.module @Bar() {
+      firrtl.instance foo {annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}]} @Foo()
+    }
 }


### PR DESCRIPTION
In FIRRTL unprocessed annotations are dropped in LowerToHW, unless the
`-warn-on-unprocessed-annotations` flag is passed,  which  will create a
a warning for each remaining annotation.

When a non-local annotation goes unhandled, it leaves behind some
`NonLocalAnchor` operations and a few "fake" `circt.nonlocal`
annotations along the instance path. This change makes it so that we
drop `NLA` operations in `LowerToHW` instead of erroring on them. This
also changes the flag `warn-on-unprocessed` to not emit a warning for the
intermediate `circt.nonlocal` annotations along the NLA path, since we
will emit a warning for the real annotation. This should align with the behaviour
of local annotations.