### PR TITLE
[FIRRTL] Add unknown width `mux(p, invalid, x) -> x` canonicalizer

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -85,6 +85,16 @@ def GTWithConstLHS : Pat<
   (LTPrimOp $rhs, $lhs),
   [(NonConstantOp $rhs)]>;
 
+// mux(cond, x, invalid) -> x
+def MuxInvalidLow : Pat<
+  (MuxPrimOp $cond, $x, (InvalidValueOp)),
+  (replaceWithValue $x)>;
+
+// mux(cond, invalid, x) -> x
+def MuxInvalidHigh : Pat<
+  (MuxPrimOp $cond, (InvalidValueOp), $x),
+  (replaceWithValue $x)>;
+
 // mux(cond, x, mux(cond, y, z)) -> mux(cond, x, z)
 def MuxSameCondLow : Pat<
   (MuxPrimOp $cond, $x, (MuxPrimOp $cond, $y, $z)),

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1131,6 +1131,8 @@ static LogicalResult canonicalizeMux(MuxPrimOp op, PatternRewriter &rewriter) {
 void MuxPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                             MLIRContext *context) {
   results.add(canonicalizeMux);
+  results.add<patterns::MuxInvalidLow>(context);
+  results.add<patterns::MuxInvalidHigh>(context);
   results.add<patterns::MuxSameCondLow>(context);
   results.add<patterns::MuxSameCondHigh>(context);
 }

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -415,9 +415,14 @@ firrtl.module @Mux(in %in: !firrtl.uint<4>,
   %5 = firrtl.mux (%cond, %invalid_ui4, %in) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %5 : !firrtl.uint<4>, !firrtl.uint<4>
 
+  // CHECK: firrtl.connect %out, %in
+  %invalid_ui = firrtl.invalidvalue : !firrtl.uint
+  %6 = firrtl.mux(%cond, %in, %invalid_ui) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint) -> !firrtl.uint
+  firrtl.connect %out, %6 : !firrtl.uint<4>, !firrtl.uint
+
   // CHECK: firrtl.connect %out, %invalid_ui4
-  %6 = firrtl.mux (%cond, %invalid_ui4, %invalid_ui4) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  firrtl.connect %out, %6 : !firrtl.uint<4>, !firrtl.uint<4>
+  %7 = firrtl.mux (%cond, %invalid_ui4, %invalid_ui4) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  firrtl.connect %out, %7 : !firrtl.uint<4>, !firrtl.uint<4>
 }
 
 // CHECK-LABEL: firrtl.module @Pad


### PR DESCRIPTION
This duplicates the functionality of a mux fold as a canonicalization to
support invalid values of unknown width.

A change to MLIR core disallows folds which change the return type of
the value used. When the invalid value is of unknown width, the mux's
return type will also be unknown width, but after the fold is performed
the type changes to the known width operand.

For example,
```
mux(p: uint<1>, invalid: uint, x: uint<2>) -> uint
```
canonicalizes to return `uint<2>`.