### PR TITLE
[CI] Run clang-format after clang-tidy

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -328,6 +328,7 @@ jobs:
         run: |
           git diff -U0 $DIFF_COMMIT | \
             clang-tidy-diff -path build_clang -p1 -fix
+          git clang-format $DIFF_COMMIT
           git diff --ignore-submodules > clang-tidy.patch
           if [ -s clang-tidy.patch ]; then
             echo "Clang-tidy problems in the following files. " \


### PR DESCRIPTION
Currently, clang-format is not applied to the modification of clang-tidy. So it is troublesome if clang-tidy breaks clang-format.