### PR TITLE
[ExportVerilog] Legalize declaration op names

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
+++ b/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
@@ -18,16 +18,20 @@ struct LoweringOptions;
 namespace ExportVerilog {
 class GlobalNameResolver;
 
+/// If the given `op` is a declaration, return the attribute that dictates its
+/// name. For things like wires and registers this will be the `name` attribute,
+/// for instances this is `instanceName`, etc.
+StringAttr getDeclarationName(Operation *op);
+
 /// This class keeps track of global names at the module/interface level.
 /// It is built in a global pass over the entire design and then frozen to allow
 /// concurrent accesses.
 struct GlobalNameTable {
   GlobalNameTable(GlobalNameTable &&) = default;
 
-  /// Return the string to use for the specified parameter name in the specified
-  /// module.  Parameters may be renamed for a variety of reasons (e.g.
-  /// conflicting with ports or verilog keywords), and this returns the
-  /// legalized name to use.
+  /// Return the string to use for the specified port in the specified module.
+  /// Ports may be renamed for a variety of reasons (e.g. conflicting with
+  /// Verilog keywords), and this returns the legalized name to use.
   StringRef getPortVerilogName(Operation *module,
                                const hw::PortInfo &port) const {
     auto it = renamedPorts.find(std::make_pair(module, port.getId()));
@@ -36,7 +40,7 @@ struct GlobalNameTable {
 
   /// Return the string to use for the specified parameter name in the specified
   /// module.  Parameters may be renamed for a variety of reasons (e.g.
-  /// conflicting with ports or verilog keywords), and this returns the
+  /// conflicting with ports or Verilog keywords), and this returns the
   /// legalized name to use.
   StringRef getParameterVerilogName(Operation *module,
                                     StringAttr paramName) const {
@@ -44,6 +48,20 @@ struct GlobalNameTable {
     return (it != renamedParams.end() ? it->second : paramName).getValue();
   }
 
+  /// Return the string to use for the specified declaration. The operation is
+  /// commonly a declaration within the module, like `WireOp` and friends, which
+  /// have a `name` attribute. Values may be renamed for a variety of reasons
+  /// (e.g. conflicting with ports or Verilog keywords), and this returns the
+  /// legalized name to use.
+  StringRef getDeclarationVerilogName(Operation *op) const {
+    auto it = renamedDecls.find(op);
+    auto attr = it != renamedDecls.end() ? it->second : getDeclarationName(op);
+    return attr ? attr.getValue() : "";
+  }
+
+  /// Return the string to use for the specified interface. Interfaces and their
+  /// signals may be renamed for a variety of reasons (e.g. conflicting with
+  /// Verilog keywords), and this returns the legalized name to use.
   StringRef getInterfaceVerilogName(Operation *op) const {
     auto it = renamedInterfaceOp.find(op);
     auto attr = it != renamedInterfaceOp.end() ? it->second
@@ -69,6 +87,10 @@ private:
         StringAttr::get(oldName.getContext(), newName);
   }
 
+  void addRenamedDeclaration(Operation *declOp, StringRef newName) {
+    renamedDecls[declOp] = StringAttr::get(declOp->getContext(), newName);
+  }
+
   void addRenamedInterfaceOp(Operation *interfaceOp, StringRef newName) {
     renamedInterfaceOp[interfaceOp] =
         StringAttr::get(interfaceOp->getContext(), newName);
@@ -82,6 +104,9 @@ private:
   /// This contains entries for any parameters that got renamed.  The key is a
   /// moduleop/paramName tuple, the value is the name to use.
   DenseMap<std::pair<Operation *, Attribute>, StringAttr> renamedParams;
+
+  /// This contains entries for any declarations that got renamed.
+  DenseMap<Operation *, StringAttr> renamedDecls;
 
   /// This contains entries for interface operations (sv.interface,
   /// sv.interface.signal, and sv.interface.modport) that need to be renamed

--- a/test/Conversion/ExportVerilog/name-legalize.mlir
+++ b/test/Conversion/ExportVerilog/name-legalize.mlir
@@ -19,7 +19,7 @@ hw.module @parametersNameConflict<p1: i42 = 17, wire: i1>(%p1: i8) {
 
   // CHECK: `ifdef SOMEMACRO
   sv.ifdef "SOMEMACRO" {
-    // CHECK: localparam local_0 = wire_1;
+    // CHECK: localparam local_2 = wire_1;
     %local = sv.localparam : i1 { value = #hw.param.decl.ref<"wire">: i1 }
 
     // CHECK: assign myWire = wire_1;

--- a/test/Conversion/ExportVerilog/verilog-basic.mlir
+++ b/test/Conversion/ExportVerilog/verilog-basic.mlir
@@ -409,17 +409,29 @@ hw.module @UnaryParensIssue755(%a: i8) -> (b: i1) {
 }
 
 
-// Inner name references to input and output ports.
+// Inner name references to ports which are renamed to avoid collisions with
+// reserved Verilog keywords.
 hw.module.extern @VerbatimModuleExtern(%foo: i1 {hw.exportPort = @symA}) -> (bar: i1 {hw.exportPort = @symB})
+// CHECK-LABEL: module VerbatimModule(
+// CHECK-NEXT:    input  signed_0
+// CHECK-NEXT:    output unsigned_1
 hw.module @VerbatimModule(%signed: i1 {hw.exportPort = @symA}) -> (unsigned: i1 {hw.exportPort = @symB}) {
+  %parameter = sv.wire sym @symC : !hw.inout<i4>
+  %localparam = sv.reg sym @symD : !hw.inout<i4>
+  // CHECK: wire [3:0] parameter_2;
+  // CHECK: reg  [3:0] localparam_3;
   hw.output %signed : i1
 }
 sv.verbatim "VERB: module symA `{{0}}`" {symbols = [#hw.innerNameRef<@VerbatimModule::@symA>]}
 sv.verbatim "VERB: module symB `{{0}}`" {symbols = [#hw.innerNameRef<@VerbatimModule::@symB>]}
+sv.verbatim "VERB: module symC `{{0}}`" {symbols = [#hw.innerNameRef<@VerbatimModule::@symC>]}
+sv.verbatim "VERB: module symD `{{0}}`" {symbols = [#hw.innerNameRef<@VerbatimModule::@symD>]}
 sv.verbatim "VERB: module.extern symA `{{0}}`" {symbols = [#hw.innerNameRef<@VerbatimModuleExtern::@symA>]}
 sv.verbatim "VERB: module.extern symB `{{0}}`" {symbols = [#hw.innerNameRef<@VerbatimModuleExtern::@symB>]}
 // CHECK: VERB: module symA `signed_0`
 // CHECK: VERB: module symB `unsigned_1`
+// CHECK: VERB: module symC `parameter_2`
+// CHECK: VERB: module symD `localparam_3`
 // CHECK: VERB: module.extern symA `foo`
 // CHECK: VERB: module.extern symB `bar`
 


### PR DESCRIPTION
With the introduction of inner name references, operations such as `sv.verbatim` can interpolate the name of declarations in other modules, like wires or instances. This requires that all such operations have their names properly legalized and stabilized before the parallel emission of Verilog starts. Currently the names of wires are picked on-the-fly inside `ModuleEmitter`, which is already too late.

This commit extends the name legalization pass and `GlobalNamesTable` to also cover declaration ops. This allows such operations to be properly renamed upfront, with the names being frozen at emission time. The emission code in `ModuleEmitter` then simply uses that pre-frozen name for all declarations.

This enables follow-up work around symbols on FIRRTL module ports, and using them properly in `sv.verbatim` (#2083).

### Todo
- [x] Land #2115