### PR TITLE
[FIRRTL][InferWidths] Infer invalid value widths

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -86,16 +86,6 @@ def GTWithConstLHS : Pat<
   (LTPrimOp $rhs, $lhs),
   [(NonConstantOp $rhs)]>;
 
-// mux(cond, x, invalid) -> x
-def MuxInvalidLow : Pat<
-  (MuxPrimOp $cond, $x, (InvalidValueOp)),
-  (replaceWithValue $x)>;
-
-// mux(cond, invalid, x) -> x
-def MuxInvalidHigh : Pat<
-  (MuxPrimOp $cond, (InvalidValueOp), $x),
-  (replaceWithValue $x)>;
-
 // mux(cond, x, mux(cond, y, z)) -> mux(cond, x, z)
 def MuxSameCondLow : Pat<
   (MuxPrimOp $cond, $x, (MuxPrimOp $cond, $y, $z)),

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1131,8 +1131,6 @@ static LogicalResult canonicalizeMux(MuxPrimOp op, PatternRewriter &rewriter) {
 void MuxPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                             MLIRContext *context) {
   results.add(canonicalizeMux);
-  results.add<patterns::MuxInvalidLow>(context);
-  results.add<patterns::MuxInvalidHigh>(context);
   results.add<patterns::MuxSameCondLow>(context);
   results.add<patterns::MuxSameCondHigh>(context);
 }

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -415,11 +415,6 @@ firrtl.module @Mux(in %in: !firrtl.uint<4>,
   %5 = firrtl.mux (%cond, %invalid_ui4, %in) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %5 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.connect %out, %in
-  %invalid_ui = firrtl.invalidvalue : !firrtl.uint
-  %6 = firrtl.mux(%cond, %in, %invalid_ui) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint) -> !firrtl.uint
-  firrtl.connect %out, %6 : !firrtl.uint<4>, !firrtl.uint
-
   // CHECK: firrtl.connect %out, %invalid_ui4
   %7 = firrtl.mux (%cond, %invalid_ui4, %invalid_ui4) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %7 : !firrtl.uint<4>, !firrtl.uint<4>

--- a/test/Dialect/FIRRTL/infer-widths-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-widths-errors.mlir
@@ -107,3 +107,22 @@ firrtl.circuit "Foo"  {
     firrtl.partialconnect %w1, %w0 : !firrtl.vector<uint, 0>, !firrtl.vector<uint<3>, 10>
   }
 }
+
+// -----
+firrtl.circuit "Foo"  {
+  firrtl.module @Foo() {
+    // expected-error @+1 {{uninferred width: invalid value is unconstrained}}
+    %0 = firrtl.invalidvalue : !firrtl.bundle<x: uint>
+  }
+}
+
+// -----
+firrtl.circuit "Foo"  {
+  firrtl.module @Foo() {
+    // This should complain about the wire, not the invalid value.
+    %0 = firrtl.invalidvalue : !firrtl.bundle<x: uint>
+    // expected-error @+1 {{uninferred width: wire "w.x" is unconstrained}}
+    %w = firrtl.wire  : !firrtl.bundle<x: uint>
+    firrtl.connect %w, %0 : !firrtl.bundle<x: uint>, !firrtl.bundle<x: uint>
+  }
+}


### PR DESCRIPTION
### [FIRRTL][InferWidths] Start inferring the width of invalid values 

This adds support to infer the width of invalid values in the
InferWidths pass.  The width of InvalidValueOps is inferred as a special
case, where it will always be set to the width of the thing it is
connected to.

When an InvalidValue of unknown width is used by an operation that is
not a connect, such as an `AddPrimOp`, then there is no way to infer the
width and we will emit an error.

When a single invalid value with unknown width is used by mutliple
operations, the pass will duplicate the invalid value for each use.
This is so that we can infer a different width depending on the
location, as we don't want to impose an artificial constaint that each
location has the same width. This situation easily arises after running
CSE.

InvalidValues are not being constructed as a part of the constraint
problem, although they could be. Instead, we just update their width
when mapping the rest of the solved widths back into the program.

### [FIRRTL] Drop recently added canonicalizer 

Now that InvalidValueOps are having their width inferred, we don't need
this canonicalizer, as we already have a fold which will do the job.
For more information see #2093.
