### PR TITLE
[FIRRTL] Fix local wire/node resets not dominating inferred connections

### DIFF
--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -559,3 +559,135 @@ firrtl.circuit "FullAsyncExcluded" {
     firrtl.connect %inst_io_in, %io_in : !firrtl.uint<8>, !firrtl.uint<8>
   }
 }
+
+
+// -----
+
+// Local wire as async reset should be moved before all its uses.
+firrtl.circuit "WireShouldDominate" {
+  // CHECK-LABEL: firrtl.module @WireShouldDominate
+  firrtl.module @WireShouldDominate(in %clock: !firrtl.clock) {
+    %reg = firrtl.reg %clock : !firrtl.uint<8> // gets wired to localReset
+    %localReset = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]} : !firrtl.asyncreset
+    // CHECK-NEXT: %localReset = firrtl.wire
+    // CHECK-NEXT: [[RV:%.+]] = firrtl.constant 0
+    // CHECK-NEXT: %reg = firrtl.regreset %clock, %localReset, [[RV]]
+  }
+}
+
+// Local node as async reset should be moved before all its uses if its input
+// value dominates the target location in the module.
+firrtl.circuit "MovableNodeShouldDominate" {
+  // CHECK-LABEL: firrtl.module @MovableNodeShouldDominate
+  firrtl.module @MovableNodeShouldDominate(in %clock: !firrtl.clock, in %ui1: !firrtl.uint<1>) {
+    %0 = firrtl.asAsyncReset %ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset // does not block move of node
+    %reg = firrtl.reg %clock : !firrtl.uint<8> // gets wired to localReset
+    %localReset = firrtl.node sym @theReset %0 {annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]} : !firrtl.asyncreset
+    // CHECK-NEXT: %0 = firrtl.asAsyncReset %ui1
+    // CHECK-NEXT: %localReset = firrtl.node sym @theReset %0
+    // CHECK-NEXT: [[RV:%.+]] = firrtl.constant 0
+    // CHECK-NEXT: %reg = firrtl.regreset %clock, %localReset, [[RV]]
+  }
+}
+
+// Local node as async reset should be replaced by a wire and moved before all
+// its uses if its input value does not dominate the target location in the
+// module.
+firrtl.circuit "UnmovableNodeShouldDominate" {
+  // CHECK-LABEL: firrtl.module @UnmovableNodeShouldDominate
+  firrtl.module @UnmovableNodeShouldDominate(in %clock: !firrtl.clock, in %ui1: !firrtl.uint<1>) {
+    %reg = firrtl.reg %clock : !firrtl.uint<8> // gets wired to localReset
+    %0 = firrtl.asAsyncReset %ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset // blocks move of node
+    %localReset = firrtl.node sym @theReset %0 {annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]} : !firrtl.asyncreset
+    // CHECK-NEXT: %localReset = firrtl.wire sym @theReset
+    // CHECK-NEXT: [[RV:%.+]] = firrtl.constant 0
+    // CHECK-NEXT: %reg = firrtl.regreset %clock, %localReset, [[RV]]
+    // CHECK-NEXT: %0 = firrtl.asAsyncReset %ui1
+    // CHECK-NEXT: firrtl.connect %localReset, %0
+  }
+}
+
+// Move of local async resets should work across blocks.
+firrtl.circuit "MoveAcrossBlocks1" {
+  // CHECK-LABEL: firrtl.module @MoveAcrossBlocks1
+  firrtl.module @MoveAcrossBlocks1(in %clock: !firrtl.clock, in %ui1: !firrtl.uint<1>) {
+    // <-- should move reset here
+    firrtl.when %ui1 {
+      %reg = firrtl.reg %clock : !firrtl.uint<8> // gets wired to localReset
+    }
+    firrtl.when %ui1 {
+      %0 = firrtl.asAsyncReset %ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset // blocks move of node
+      %localReset = firrtl.node sym @theReset %0 {annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]} : !firrtl.asyncreset
+    }
+    // CHECK-NEXT: %localReset = firrtl.wire
+    // CHECK-NEXT: firrtl.when %ui1 {
+    // CHECK-NEXT:   [[RV:%.+]] = firrtl.constant 0
+    // CHECK-NEXT:   %reg = firrtl.regreset %clock, %localReset, [[RV]]
+    // CHECK-NEXT: }
+    // CHECK-NEXT: firrtl.when %ui1 {
+    // CHECK-NEXT:   [[TMP:%.+]] = firrtl.asAsyncReset %ui1
+    // CHECK-NEXT:   firrtl.connect %localReset, [[TMP]]
+    // CHECK-NEXT: }
+  }
+}
+
+firrtl.circuit "MoveAcrossBlocks2" {
+  // CHECK-LABEL: firrtl.module @MoveAcrossBlocks2
+  firrtl.module @MoveAcrossBlocks2(in %clock: !firrtl.clock, in %ui1: !firrtl.uint<1>) {
+    // <-- should move reset here
+    firrtl.when %ui1 {
+      %0 = firrtl.asAsyncReset %ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset // blocks move of node
+      %localReset = firrtl.node sym @theReset %0 {annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]} : !firrtl.asyncreset
+    }
+    firrtl.when %ui1 {
+      %reg = firrtl.reg %clock : !firrtl.uint<8> // gets wired to localReset
+    }
+    // CHECK-NEXT: %localReset = firrtl.wire
+    // CHECK-NEXT: firrtl.when %ui1 {
+    // CHECK-NEXT:   [[TMP:%.+]] = firrtl.asAsyncReset %ui1
+    // CHECK-NEXT:   firrtl.connect %localReset, [[TMP]]
+    // CHECK-NEXT: }
+    // CHECK-NEXT: firrtl.when %ui1 {
+    // CHECK-NEXT:   [[RV:%.+]] = firrtl.constant 0
+    // CHECK-NEXT:   %reg = firrtl.regreset %clock, %localReset, [[RV]]
+    // CHECK-NEXT: }
+  }
+}
+
+firrtl.circuit "MoveAcrossBlocks3" {
+  // CHECK-LABEL: firrtl.module @MoveAcrossBlocks3
+  firrtl.module @MoveAcrossBlocks3(in %clock: !firrtl.clock, in %ui1: !firrtl.uint<1>) {
+    // <-- should move reset here
+    %reg = firrtl.reg %clock : !firrtl.uint<8> // gets wired to localReset
+    firrtl.when %ui1 {
+      %0 = firrtl.asAsyncReset %ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset // blocks move of node
+      %localReset = firrtl.node sym @theReset %0 {annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]} : !firrtl.asyncreset
+    }
+    // CHECK-NEXT: %localReset = firrtl.wire
+    // CHECK-NEXT: [[RV:%.+]] = firrtl.constant 0
+    // CHECK-NEXT: %reg = firrtl.regreset %clock, %localReset, [[RV]]
+    // CHECK-NEXT: firrtl.when %ui1 {
+    // CHECK-NEXT:   [[TMP:%.+]] = firrtl.asAsyncReset %ui1
+    // CHECK-NEXT:   firrtl.connect %localReset, [[TMP]]
+    // CHECK-NEXT: }
+  }
+}
+
+firrtl.circuit "MoveAcrossBlocks4" {
+  // CHECK-LABEL: firrtl.module @MoveAcrossBlocks4
+  firrtl.module @MoveAcrossBlocks4(in %clock: !firrtl.clock, in %ui1: !firrtl.uint<1>) {
+    // <-- should move reset here
+    firrtl.when %ui1 {
+      %reg = firrtl.reg %clock : !firrtl.uint<8> // gets wired to localReset
+    }
+    %0 = firrtl.asAsyncReset %ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset // blocks move of node
+    %localReset = firrtl.node sym @theReset %0 {annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]} : !firrtl.asyncreset
+    // CHECK-NEXT: %localReset = firrtl.wire
+    // CHECK-NEXT: firrtl.when %ui1 {
+    // CHECK-NEXT:   [[RV:%.+]] = firrtl.constant 0
+    // CHECK-NEXT:   %reg = firrtl.regreset %clock, %localReset, [[RV]]
+    // CHECK-NEXT: }
+    // CHECK-NEXT: [[TMP:%.+]] = firrtl.asAsyncReset %ui1
+    // CHECK-NEXT: firrtl.connect %localReset, [[TMP]]
+  }
+}


### PR DESCRIPTION
Fix an issue in `InferResets` where using a local wire or node as the async reset for the module could cause dominance issues when the wire was declared *after* some of things it would end up getting connected to. A typical example would be:

    %reg = firrtl.reg %clock
    %localReset = firrtl.wire /*FullAsyncResetAnnotation*/

In this case `InferResets` would decide to hook `%localReset` up to the register `%reg`, creating a dominance problem.

This commit changes the behavior of `InferResets` such that it moves the local reset declaration up to before the first thing it gets connected to, possibly converting a `NodeOp` to a `WireOp` if the node's input value blocks the move due to it not dominating the target site.

Thanks to @youngar for finding this issue!