### PR TITLE
[SV] Make SVTypes.td includable from other dialects

### DIFF
--- a/include/circt/Dialect/SV/SV.td
+++ b/include/circt/Dialect/SV/SV.td
@@ -10,29 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SV_TD
-#define SV_TD
+#ifndef CIRCT_DIALECT_SV_SV
+#define CIRCT_DIALECT_SV_SV
 
 include "mlir/IR/OpBase.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
-def SVDialect : Dialect {
-  let name = "sv";
-
-  let summary = "Types and operations for SV dialect";
-  let description = [{
-    This dialect defines the `sv` dialect, which represents various
-    SystemVerilog-specific constructs in an AST-like representation.
-  }];
-  let dependentDialects = ["circt::comb::CombDialect"];
-  let cppNamespace = "::circt::sv";
-  let extraClassDeclaration = [{
-    /// Register all SV types.
-    void registerTypes();
-  }];
-}
+include "circt/Dialect/SV/SVDialect.td"
 
 // Base class for the operation in this dialect.
 class SVOp<string mnemonic, list<OpTrait> traits = []> :
@@ -59,4 +45,4 @@ include "circt/Dialect/SV/SVStatements.td"
 include "circt/Dialect/SV/SVVerification.td"
 include "circt/Dialect/SV/SVTypeDecl.td"
 
-#endif // SV_TD
+#endif // CIRCT_DIALECT_SV_SV

--- a/include/circt/Dialect/SV/SVDialect.td
+++ b/include/circt/Dialect/SV/SVDialect.td
@@ -1,0 +1,32 @@
+//===- SVDialect.td - SystemVerilog dialect definition -----*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This contains the SV dialect definition to be included in other files.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_SV_SVDIALECT
+#define CIRCT_DIALECT_SV_SVDIALECT
+
+def SVDialect : Dialect {
+  let name = "sv";
+
+  let summary = "Types and operations for SV dialect";
+  let description = [{
+    This dialect defines the `sv` dialect, which represents various
+    SystemVerilog-specific constructs in an AST-like representation.
+  }];
+  let dependentDialects = ["circt::comb::CombDialect"];
+  let cppNamespace = "::circt::sv";
+  let extraClassDeclaration = [{
+    /// Register all SV types.
+    void registerTypes();
+  }];
+}
+
+#endif // CIRCT_DIALECT_SV_SVDIALECT

--- a/include/circt/Dialect/SV/SVTypes.td
+++ b/include/circt/Dialect/SV/SVTypes.td
@@ -10,6 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef CIRCT_DIALECT_SV_SVTYPES
+#define CIRCT_DIALECT_SV_SVTYPES
+
+include "circt/Dialect/SV/SVDialect.td"
+
 class SVType<string name> : TypeDef<SVDialect, name> { }
 
 //===----------------------------------------------------------------------===//
@@ -82,3 +87,4 @@ def StringArrayAttr: ArrayAttrBase<
   let constBuilderCall = "$_builder.getArrayAttr($0)";
 }
 
+#endif // CIRCT_DIALECT_SV_SVTYPES


### PR DESCRIPTION
Similar to the refactoring done in HW, move the `SVDialect` definition into a separate `SVDialect.td` file, such that other dialects can selectively include `SVTypes.td` to gain access to the declarations there. This should help structure the dialects in a fashion that allows portions to be reused and keep repetition down.