### PR TITLE
[FIRRTL] Add symbol interpolation to verbatim ops

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+include "circt/Dialect/HW/HWTypes.td"
 include "circt/Types.td"
 
 def SameOperandsIntTypeKind : NativeOpTrait<"SameOperandsIntTypeKind"> {
@@ -548,16 +549,21 @@ def VerbatimExprOp : FIRRTLOp<"verbatim.expr",
     `firrtl.verbatim.expr` allows operand substitutions with `{{0}}` syntax.
   }];
 
-  let arguments = (ins StrAttr:$text, Variadic<AnyType>:$operands);
+  let arguments = (ins StrAttr:$text, Variadic<AnyType>:$operands,
+                       DefaultValuedAttr<NameRefArrayAttr,"{}">:$symbols);
   let results = (outs FIRRTLType:$result);
   let assemblyFormat = [{
-    $text attr-dict (`(` $operands^ `)`)?
-      `:` functional-type($operands, $result)
+    $text (`(` $operands^ `)`)?
+    `:` functional-type($operands, $result) attr-dict
   }];
 
   let builders = [
-    OpBuilder<(ins "Type":$resultType, "StringRef":$text),
-               "build(odsBuilder, odsState, resultType, text, ValueRange{});">
+    OpBuilder<(ins "Type":$resultType, "Twine":$text,
+                   CArg<"ValueRange", "{}">:$operands,
+                   CArg<"ArrayRef<Attribute>", "{}">:$symbols), [{
+      build(odsBuilder, odsState, resultType, odsBuilder.getStringAttr(text),
+            operands, odsBuilder.getArrayAttr(symbols));
+    }]>
   ];
 }
 
@@ -577,16 +583,21 @@ def VerbatimWireOp : FIRRTLOp<"verbatim.wire",
     `firrtl.verbatim.wire` allows operand substitutions with `{{0}}` syntax.
   }];
 
-  let arguments = (ins StrAttr:$text, Variadic<AnyType>:$operands);
+  let arguments = (ins StrAttr:$text, Variadic<AnyType>:$operands,
+                       DefaultValuedAttr<NameRefArrayAttr,"{}">:$symbols);
   let results = (outs FIRRTLType:$result);
   let assemblyFormat = [{
-    $text attr-dict (`(` $operands^ `)`)?
-      `:` functional-type($operands, $result)
+    $text (`(` $operands^ `)`)?
+    `:` functional-type($operands, $result) attr-dict
   }];
 
   let builders = [
-    OpBuilder<(ins "Type":$resultType, "StringRef":$text),
-               "build(odsBuilder, odsState, resultType, text, ValueRange{});">
+    OpBuilder<(ins "Type":$resultType, "Twine":$text,
+                   CArg<"ValueRange", "{}">:$operands,
+                   CArg<"ArrayRef<Attribute>", "{}">:$symbols), [{
+      build(odsBuilder, odsState, resultType, odsBuilder.getStringAttr(text),
+            operands, odsBuilder.getArrayAttr(symbols));
+    }]>
   ];
 }
 

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1907,8 +1907,12 @@ LogicalResult FIRRTLLowering::visitDecl(VerbatimWireOp op) {
     operands.push_back(lowered);
   }
 
+  ArrayAttr symbols = op.symbolsAttr();
+  if (!symbols)
+    symbols = ArrayAttr::get(op.getContext(), {});
+
   return setLoweringTo<sv::VerbatimExprOp>(op, resultTy, op.textAttr(),
-                                           operands);
+                                           operands, symbols);
 }
 
 LogicalResult FIRRTLLowering::visitDecl(NodeOp op) {
@@ -2738,8 +2742,12 @@ LogicalResult FIRRTLLowering::visitExpr(VerbatimExprOp op) {
     operands.push_back(lowered);
   }
 
+  ArrayAttr symbols = op.symbolsAttr();
+  if (!symbols)
+    symbols = ArrayAttr::get(op.getContext(), {});
+
   return setLoweringTo<sv::VerbatimExprOp>(op, resultTy, op.textAttr(),
-                                           operands);
+                                           operands, symbols);
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -277,13 +277,20 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %48 = firrtl.asAsyncReset %44 : (!firrtl.uint<1>) -> !firrtl.asyncreset
 
     // CHECK: [[VERB1:%.+]] = sv.verbatim.expr "MAGIC_CONSTANT" : () -> i42
-    // CHECK: [[VERB2:%.+]] = sv.verbatim.expr "$bits({{[{][{]0[}][}]}})"([[VERB1]]) : (i42) -> i32
+    // CHECK: [[VERB2:%.+]] = sv.verbatim.expr "$bits({{[{][{]0[}][}]}}, {{[{][{]1[}][}]}})"([[VERB1]]) : (i42) -> i32 {symbols = [@Simple]}
+    // CHECK: [[VERB3:%.+]] = sv.verbatim.expr "$size({{[{][{]0[}][}]}}, {{[{][{]1[}][}]}})"([[VERB1]]) : (i42) -> !hw.inout<i32> {symbols = [@Simple]}
+    // CHECK: [[VERB3READ:%.+]] = sv.read_inout [[VERB3]]
     // CHECK: [[VERB1EXT:%.+]] = comb.concat {{%.+}}, [[VERB1]] : i1, i42
     // CHECK: [[VERB2EXT:%.+]] = comb.concat {{%.+}}, [[VERB2]] : i11, i32
-    // CHECK: = comb.add [[VERB1EXT]], [[VERB2EXT]] : i43
+    // CHECK: [[ADD:%.+]] = comb.add [[VERB1EXT]], [[VERB2EXT]] : i43
+    // CHECK: [[VERB3EXT:%.+]] = comb.concat {{%.+}}, [[VERB3READ]] : i12, i32
+    // CHECK: [[ADDEXT:%.+]] = comb.concat {{%.+}}, [[ADD]] : i1, i43
+    // CHECK: = comb.add [[VERB3EXT]], [[ADDEXT]] : i44
     %56 = firrtl.verbatim.expr "MAGIC_CONSTANT" : () -> !firrtl.uint<42>
-    %57 = firrtl.verbatim.expr "$bits({{0}})"(%56) : (!firrtl.uint<42>) -> !firrtl.uint<32>
-    %58 = firrtl.add %56, %57 : (!firrtl.uint<42>, !firrtl.uint<32>) -> !firrtl.uint<43>
+    %57 = firrtl.verbatim.expr "$bits({{0}}, {{1}})"(%56) : (!firrtl.uint<42>) -> !firrtl.uint<32> {symbols = [@Simple]}
+    %58 = firrtl.verbatim.wire "$size({{0}}, {{1}})"(%56) : (!firrtl.uint<42>) -> !firrtl.uint<32> {symbols = [@Simple]}
+    %59 = firrtl.add %56, %57 : (!firrtl.uint<42>, !firrtl.uint<32>) -> !firrtl.uint<43>
+    %60 = firrtl.add %58, %59 : (!firrtl.uint<32>, !firrtl.uint<43>) -> !firrtl.uint<44>
 
     // Issue #353
     // CHECK: [[PADRES_EXT:%.+]] = comb.sext [[PADRES]] : (i3) -> i8


### PR DESCRIPTION
Extend the `VerbatimExprOp` and `VerbatimWireOp` to also support symbols during string interpolation. This reflects recent changes in the SV dialect. The additional symbols are simply passed through during lowering to the HW dialect. Having this support will allow some FIRRTL passes to properly mention module and declarations by name in their verbatim output.

### Todo
- [x] Land #2112
- [x] Land #2120