### PR TITLE
[FIRRTL] Make presence of `inner_sym` equiv to dont-touch

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -86,6 +86,15 @@ inline MemDirAttr &operator|=(MemDirAttr &lhs, MemDirAttr rhs) {
   return lhs;
 }
 
+/// Check whether a block argument ("port") or the operation defining a value
+/// has a `DontTouch` annotation, or a symbol that should prevent certain types
+/// of canonicalizations.
+bool hasDontTouch(Value value);
+
+/// Check whether an operation has a `DontTouch` annotation, or a symbol that
+/// should prevent certain types of canonicalizations.
+bool hasDontTouch(Operation *op);
+
 // Out-of-line implementation of various trait verification methods and
 // functions commonly used among operations.
 namespace impl {

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1338,7 +1338,7 @@ static LogicalResult foldSingleSetConnect(ConnectOp op,
   // Only support wire and reg for now.
   if (!isa<WireOp>(connectedDecl) && !isa<RegOp>(connectedDecl))
     return failure();
-  if (AnnotationSet(connectedDecl).hasDontTouch())
+  if (hasDontTouch(connectedDecl))
     return failure();
 
   // Only forward if the types exactly match and there is one connect.
@@ -1436,7 +1436,7 @@ LogicalResult AttachOp::canonicalize(AttachOp op, PatternRewriter &rewriter) {
     // TODO: May need to be sensitive to "don't touch" or other
     // annotations.
     if (auto wire = dyn_cast_or_null<WireOp>(operand.getDefiningOp())) {
-      if (!AnnotationSet(wire).hasDontTouch() && wire->hasOneUse()) {
+      if (!hasDontTouch(wire.getOperation()) && wire->hasOneUse()) {
         SmallVector<Value> newOperands;
         for (auto newOperand : op.getOperands())
           if (newOperand != operand) // Don't the add wire.
@@ -1518,7 +1518,7 @@ struct foldResetMux : public mlir::RewritePattern {
                                 PatternRewriter &rewriter) const override {
     auto reg = cast<RegResetOp>(op);
     auto reset = dyn_cast_or_null<ConstantOp>(reg.resetValue().getDefiningOp());
-    if (!reset || AnnotationSet(reg).hasDontTouch())
+    if (!reset || hasDontTouch(reg.getOperation()))
       return failure();
     // Find the one true connect, or bail
     ConnectOp con = getSingleConnectUserOf(reg.result());
@@ -1666,7 +1666,7 @@ static LogicalResult foldHiddenReset(RegOp reg, PatternRewriter &rewriter) {
 }
 
 LogicalResult RegOp::canonicalize(RegOp op, PatternRewriter &rewriter) {
-  if (!(AnnotationSet(op).hasDontTouch()) &&
+  if (!hasDontTouch(op.getOperation()) &&
       succeeded(foldHiddenReset(op, rewriter)))
     return success();
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -159,6 +159,24 @@ size_t firrtl::getNumPorts(Operation *op) {
   return op->getNumResults();
 }
 
+/// Check whether an operation has a `DontTouch` annotation, or a symbol that
+/// should prevent certain types of canonicalizations.
+bool firrtl::hasDontTouch(Operation *op) {
+  return op->getAttr(hw::InnerName::getInnerNameAttrName()) ||
+         AnnotationSet(op).hasDontTouch();
+}
+
+/// Check whether a block argument ("port") or the operation defining a value
+/// has a `DontTouch` annotation, or a symbol that should prevent certain types
+/// of canonicalizations.
+bool firrtl::hasDontTouch(Value value) {
+  if (auto *op = value.getDefiningOp())
+    return hasDontTouch(op);
+  auto arg = value.dyn_cast<BlockArgument>();
+  auto module = cast<FModuleOp>(arg.getOwner()->getParentOp());
+  return AnnotationSet::forPort(module, arg.getArgNumber()).hasDontTouch();
+}
+
 //===----------------------------------------------------------------------===//
 // CircuitOp
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -25,7 +25,7 @@ static bool isWireOrReg(Operation *op) {
 
 /// Return true if this is a wire or register we're allowed to delete.
 static bool isDeletableWireOrReg(Operation *op) {
-  return isWireOrReg(op) && !AnnotationSet(op).hasDontTouch();
+  return isWireOrReg(op) && !hasDontTouch(op);
 }
 
 //===----------------------------------------------------------------------===//
@@ -189,7 +189,7 @@ struct IMConstPropPass : public IMConstPropBase<IMConstPropPass> {
   /// revisitation.
   void mergeLatticeValue(Value value, LatticeValue &valueEntry,
                          LatticeValue source) {
-    if (!source.isOverdefined() && AnnotationSet::get(value).hasDontTouch())
+    if (!source.isOverdefined() && hasDontTouch(value))
       source = LatticeValue::getOverdefined();
     if (valueEntry.mergeIn(source))
       changedLatticeValueWorklist.push_back(value);
@@ -219,7 +219,7 @@ struct IMConstPropPass : public IMConstPropBase<IMConstPropPass> {
     if (source.isUnknown())
       return;
 
-    if (!source.isOverdefined() && AnnotationSet::get(value).hasDontTouch())
+    if (!source.isOverdefined() && hasDontTouch(value))
       source = LatticeValue::getOverdefined();
     // If we've changed this value then revisit all the users.
     auto &valueEntry = latticeValues[value];
@@ -476,7 +476,7 @@ void IMConstPropPass::markInstanceOp(InstanceOp instance) {
     BlockArgument modulePortVal = fModule.getArgument(resultNo);
 
     // Mark don't touch results as overdefined
-    if (AnnotationSet::get(modulePortVal).hasDontTouch())
+    if (hasDontTouch(modulePortVal))
       markOverdefined(modulePortVal);
 
     resultPortToInstanceResultMapping[modulePortVal].push_back(instancePortVal);

--- a/test/Dialect/FIRRTL/SFCTests/verbatim-inner-names.mlir
+++ b/test/Dialect/FIRRTL/SFCTests/verbatim-inner-names.mlir
@@ -1,0 +1,36 @@
+// RUN: firtool --verilog %s | FileCheck %s
+
+firrtl.circuit "Foo" {
+  firrtl.extmodule @Bar(
+    in extClockIn: !firrtl.clock,
+    out extClockOut: !firrtl.clock
+  )
+  firrtl.module @Foo(
+    in %value: !firrtl.uint<42>,
+    in %clock: !firrtl.clock,
+    in %reset: !firrtl.uint<1>
+  ) {
+    %instName_clockIn, %instName_clockOut = firrtl.instance instName sym @instSym @Bar(in extClockIn: !firrtl.clock, out extClockOut: !firrtl.clock)
+    %nodeName = firrtl.node sym @nodeSym %value : !firrtl.uint<42>
+    %wireName = firrtl.wire sym @wireSym : !firrtl.uint<42>
+    %regName = firrtl.reg sym @regSym %clock : !firrtl.uint<42>
+    %regResetName = firrtl.regreset sym @regResetSym %clock, %reset, %value : !firrtl.uint<1>, !firrtl.uint<42>, !firrtl.uint<42>
+
+    %invalid_ui42 = firrtl.invalidvalue : !firrtl.uint<42>
+    firrtl.connect %instName_clockIn, %clock : !firrtl.clock, !firrtl.clock
+    firrtl.connect %wireName, %invalid_ui42 : !firrtl.uint<42>, !firrtl.uint<42>
+  }
+}
+
+// CHECK: ----- 8< -----
+sv.verbatim "----- 8< -----"
+sv.verbatim "VERB instSym = `{{0}}`" {symbols = [#hw.innerNameRef<@Foo::@instSym>]}
+sv.verbatim "VERB nodeSym = `{{0}}`" {symbols = [#hw.innerNameRef<@Foo::@nodeSym>]}
+sv.verbatim "VERB wireSym = `{{0}}`" {symbols = [#hw.innerNameRef<@Foo::@wireSym>]}
+sv.verbatim "VERB regSym = `{{0}}`" {symbols = [#hw.innerNameRef<@Foo::@regSym>]}
+sv.verbatim "VERB regResetSym = `{{0}}`" {symbols = [#hw.innerNameRef<@Foo::@regResetSym>]}
+// CHECK-NEXT: VERB instSym = `instName`
+// CHECK-NEXT: VERB nodeSym = `nodeName`
+// CHECK-NEXT: VERB wireSym = `wireName`
+// CHECK-NEXT: VERB regSym = `regName`
+// CHECK-NEXT: VERB regResetSym = `regResetName`


### PR DESCRIPTION
With inner symbols added to many of the FIRRTL declaration operations, there now arises a problem where another operation may have a reference to such a symbol, but an transformation deletes the original declaration. In the HW dialect, the presence of an inner symbol on an operation is interpreted as a dont-touch. This commit extends the checks for dont-touch performed within the FIRRTL dialect (specifically during folding and IMConstProp) such that they consider the presence of a `inner_sym` attribute equivalent to a `DontTouchAnnotation`.

At a later point we may even decide to remove `DontTouchAnnotation`s already in the parser and simply ensure that the targeted operations do have a `inner_sym`, which would have a similar effect. There are some possibly weird interactions with `LowerTypes` where the annotation is easier to maintain than the symbols which likely warrants a separate PR and discussion.