### PR TITLE
[ExportVerilog] Get legalized bind port names

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3543,6 +3543,8 @@ void ModuleEmitter::emitBind(BindOp op) {
   // Get the max port name length so we can align the '('.
   size_t maxNameLength = 0;
   for (auto &elt : childPortInfo) {
+    auto portName = state.globalNames.getPortVerilogName(childMod, elt);
+    elt.name = Builder(inst.getContext()).getStringAttr(portName);
     maxNameLength = std::max(maxNameLength, elt.getName().size());
   }
 


### PR DESCRIPTION
The `emitBind` was using incorrect port names during `ExportVerilog`. 
Use `getPortVerilogName` to get the updated name. 
Fixes https://github.com/llvm/circt/issues/2084