### PR TITLE
[Handshake] Introduce handshake.call

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -86,12 +86,69 @@ def FuncOp : Op<Handshake_Dialect, "func", [
   let parser = [{ return ::parse$cppClass(parser, result); }];
 }
 
+// Instance-like operations
+class HandshakeInstanceLike<string mnemonic, list<OpTrait> traits = []> :
+  Op<Handshake_Dialect, mnemonic, traits> {
+  let arguments = (ins FlatSymbolRefAttr:$module, Variadic<AnyType>:$operands);
+  let results = (outs Variadic<AnyType>);
+  let assemblyFormat = [{
+    $module `(` $operands `)` attr-dict `:` functional-type($operands, results)
+  }];
+
+}
+
+def CallOp : HandshakeInstanceLike<"call", []> {
+  let summary = "Handshake dialect call operation.";
+  let description = [{
+    The `handshake.call` operation represents a latency-insensitive call to
+    some external hardware module. The arguments to and results from a call
+    operation are regular handshake SSA values. `handshake.call`
+    operations interact with the external world through ESI channels. Each
+    argument and result is mapped to an ESI channel and it is expected that
+    there exists an external hardware module which provides the expected
+    ESI interface.
+
+    Example:
+    ```mlir
+    hw.module.extern @mac_esi(%a : !esi.channel<i32>, %b : !esi.channel<i32>) -> (res: !esi.channel<i32>)
+    ...
+    %0 = handshake.call @mac_esi(%a, %b, %c) : (i32, i32, i32) -> (i32)
+    ```
+  }];
+
+  let builders = [OpBuilder<
+    (ins "FuncOp":$module, CArg<"ValueRange", "{}">:$operands), [{
+      $_state.addOperands(operands);
+      $_state.addAttribute("module", SymbolRefAttr::get(module));
+      $_state.addTypes(module.getType().getResults());
+  }]>, OpBuilder<
+    (ins "SymbolRefAttr":$module, "TypeRange":$results,
+     CArg<"ValueRange", "{}">:$operands), [{
+      $_state.addOperands(operands);
+      $_state.addAttribute("module", module);
+      $_state.addTypes(results);
+  }]>, OpBuilder<
+    (ins "StringRef":$module, "TypeRange":$results,
+     CArg<"ValueRange", "{}">:$operands), [{
+       build($_builder, $_state,
+             SymbolRefAttr::get($_builder.getContext(), module), results,
+             operands);
+  }]>];
+
+
+  let extraClassDeclaration = [{
+    StringRef getModule() { return module(); }
+  }];
+ 
+  let verifier = [{ return ::verify$cppClass(*this); }];
+}
+
 // InstanceOp
-def InstanceOp : Handshake_Op<"instance", [CallOpInterface]> {
+def InstanceOp : HandshakeInstanceLike<"instance", [CallOpInterface]> {
   let summary = "module instantiate operation";
   let description = [{
-    The `instance` operation represents the instantiation of a module.  This
-	  is similar to a function call, except that different instances of the
+    The `instance` operation represents the instantiation of a handshake module.
+    This is similar to a function call, except that different instances of the
 	  same module are guaranteed to have their own distinct state.
     The instantiated module is encoded as a symbol reference attribute named
     "module". An instance operation takes a control input as its last argument
@@ -102,9 +159,6 @@ def InstanceOp : Handshake_Op<"instance", [CallOpInterface]> {
     %2:2 = handshake.instance @my_add(%0, %1, %ctrl) : (f32, f32, none) -> (f32, none)
     ```
   }];
-
-  let arguments = (ins FlatSymbolRefAttr:$module, Variadic<AnyType>:$operands);
-  let results = (outs Variadic<AnyType>);
 
   let builders = [OpBuilder<
     (ins "FuncOp":$module, CArg<"ValueRange", "{}">:$operands), [{
@@ -128,8 +182,14 @@ def InstanceOp : Handshake_Op<"instance", [CallOpInterface]> {
   }]>];
 
   let extraClassDeclaration = [{
-    StringRef getModule() { return module(); }
-    FunctionType getModuleType();
+    /// Get the control operand of this instance op
+    Value getControl() {
+      return getOperands().back();
+    }
+    /// Return the module of this operation.
+    CallInterfaceCallable getCallableForCallee() {
+      return (*this)->getAttrOfType<SymbolRefAttr>("module");
+    }
 
     /// Get the argument operands to the called function.
     operand_range getArgOperands() {
@@ -139,20 +199,9 @@ def InstanceOp : Handshake_Op<"instance", [CallOpInterface]> {
     operand_iterator arg_operand_begin() { return operand_begin(); }
     operand_iterator arg_operand_end() { return operand_end(); }
 
-    /// Return the module of this operation.
-    CallInterfaceCallable getCallableForCallee() {
-      return (*this)->getAttrOfType<SymbolRefAttr>("module");
-    }
-
-    /// Get the control operand of this instance op
-    Value getControl() {
-      return getOperands().back();
-    }
+    StringRef getModule() { return module(); }
   }];
 
-  let assemblyFormat = [{
-    $module `(` $operands `)` attr-dict `:` functional-type($operands, results)
-  }];
 
   let verifier = [{ return ::verify$cppClass(*this); }];
 }

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -2423,6 +2423,7 @@ resolveInstanceGraph(ModuleOp moduleOp, InstanceGraph &instanceGraph,
 
 namespace {
 
+/// Translates a hw::PortInfo to a firrtl::PortInfo.
 static firrtl::PortInfo hwToFIRRTLPortInfo(Location loc,
                                            const hw::PortInfo &hwPortInfo) {
   auto name = hwPortInfo.name;
@@ -2438,6 +2439,9 @@ static firrtl::PortInfo hwToFIRRTLPortInfo(Location loc,
   return firrtl::PortInfo{name, type, direction, loc};
 }
 
+/// Rewrites hw.module.extern operations referenced by handshake.call operations
+/// to an equivalent firrtl.extmodule which can be referenced by a
+/// firrtl.instance operation.
 static LogicalResult rewriteExtCallModules(MLIRContext *ctx, ModuleOp module,
                                            CircuitOp circuit) {
   OpBuilder builder(ctx);

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -2447,7 +2447,7 @@ static LogicalResult rewriteExtCallModules(MLIRContext *ctx, ModuleOp module,
   OpBuilder builder(ctx);
   builder.setInsertionPoint(circuit.getBody(), circuit.getBody()->begin());
   module.walk([&](handshake::CallOp callOp) {
-    auto extModule = module.lookupSymbol(callOp.getModule());
+    auto *extModule = module.lookupSymbol(callOp.getModule());
     if (isa<firrtl::FExtModuleOp>(extModule)) {
       // Module has already been rewritten
       return;

--- a/lib/Conversion/PassDetail.h
+++ b/lib/Conversion/PassDetail.h
@@ -28,6 +28,10 @@ namespace calyx {
 class CalyxDialect;
 } // namespace calyx
 
+namespace esi {
+class ESIDialect;
+} // namespace esi
+
 namespace firrtl {
 class FIRRTLDialect;
 class FModuleOp;

--- a/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
+++ b/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
@@ -1652,7 +1652,7 @@ LogicalResult replaceCallOps(handshake::FuncOp f,
         block.isEntryBlock() ? getStartOp(&block) : getControlMerge(&block);
     assert(cntrlMg);
     for (Operation &op : block) {
-      if (auto callOp = dyn_cast<CallOp>(op)) {
+      if (auto callOp = dyn_cast<mlir::CallOp>(op)) {
         llvm::SmallVector<Value> operands;
         llvm::copy(callOp.getOperands(), std::back_inserter(operands));
         operands.push_back(cntrlMg->getResult(0));

--- a/lib/Dialect/Handshake/CMakeLists.txt
+++ b/lib/Dialect/Handshake/CMakeLists.txt
@@ -13,6 +13,8 @@ add_circt_dialect_library(CIRCTHandshake
   LINK_LIBS PUBLIC
   MLIRStandard
   MLIRIR
+  CIRCTESI
+  CIRCTHW
 
   DEPENDS
   MLIRHandshakeInterfacesIncGen

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -930,7 +930,7 @@ static LogicalResult verifyInstanceOp(handshake::InstanceOp op) {
            << "last operand must be a control (none-typed) operand.";
 
   auto parentModule = op->getParentOfType<ModuleOp>();
-  auto calleeOp = parentModule.lookupSymbol(op.getModule());
+  auto *calleeOp = parentModule.lookupSymbol(op.getModule());
   if (!dyn_cast<handshake::FuncOp>(calleeOp))
     return op.emitOpError() << "symbol '" << op.getModule()
                             << "' is not a handshake.func operation.";
@@ -941,7 +941,7 @@ static LogicalResult verifyInstanceOp(handshake::InstanceOp op) {
 static LogicalResult verifyCallOp(handshake::CallOp op) {
 
   auto parentModule = op->getParentOfType<ModuleOp>();
-  auto calleeOp = parentModule.lookupSymbol(op.getModule());
+  auto *calleeOp = parentModule.lookupSymbol(op.getModule());
   if (!isa<hw::HWModuleExternOp, hw::HWModuleOp>(calleeOp))
     return op.emitOpError()
            << "symbol '" << op.getModule() << "' must refer to a hw module.";

--- a/test/Conversion/HandshakeToFIRRTL/test_call.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_call.mlir
@@ -1,0 +1,18 @@
+// RUN: circt-opt -lower-handshake-to-firrtl %s | FileCheck %s
+
+// CHECK: firrtl.module @main(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %[[VAL_3:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out %[[VAL_4:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %[[VAL_5:.*]]: !firrtl.clock, in %[[VAL_6:.*]]: !firrtl.uint<1>) {
+// CHECK:   %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]] = firrtl.instance handshake_call  @ext(in a: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in b: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out out: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>)
+// CHECK:   firrtl.connect %[[VAL_7]], %[[VAL_0]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:   firrtl.connect %[[VAL_8]], %[[VAL_1]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:   firrtl.connect %[[VAL_3]], %[[VAL_9]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:   firrtl.connect %[[VAL_4]], %[[VAL_2]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK: }
+// CHECK: firrtl.extmodule @ext(in a: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in b: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out out: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>)
+
+module {
+  hw.module.extern @ext(%a: !esi.channel<i32>, %b: !esi.channel<i32>) -> (out: !esi.channel<i32>)
+  handshake.func @main(%a: i32, %b: i32, %ctrl : none) -> (i32, none) {
+    %c = handshake.call @ext(%a, %b) : (i32, i32) -> (i32)
+    handshake.return %c, %ctrl : i32, none
+  }
+}

--- a/tools/handshake-runner/CMakeLists.txt
+++ b/tools/handshake-runner/CMakeLists.txt
@@ -9,4 +9,6 @@ target_link_libraries(handshake-runner PRIVATE
   ${conversion_libs}
   CIRCTHandshake
   CIRCTStandardToHandshake
+  CIRCTHW
+  CIRCTESI
   )


### PR DESCRIPTION
This commit introduces a new operation `handshake.call` for accessing external modules through the handshake dialect. The operation is intended to model the concept of "communication with the outside world through a latency insensitive interface". Currently, this latency-insentive interface is based on the ESI dialect, which we hopefully can mature into being the standard for everything latency-insensitive in-between different kinds of hardware (or software) interactions.

The operation must reference a `hw.module.extern` or `hw.module` operation. This module is expected to have ESI channel in- and outputs with inner types corresponding to the (bare) types used inside the `handshake` IR.

In FIRRTL lowering, the hw module is rewritten to an external FIRRTL module, which can be instantiated within the lowered `handshake` code. Currently, no modifications are done to the handshake bundles that are generated based on the flat types passed to the `handshake.call` operation - the valid/ready/data signals should map directly to the ESI interface, once the target hw module is lowered.

There are a few todo's for future PRs:
- How do we call external modules with no inputs? in handshake, this is solved by the input `ctrl` operand; we do not (yet) have a definition for "module activation" in ESI.
- How do we ensure that the names of the ESI interface signals agree with what we lower to in HandshakeToFIRRTL?
