### PR TITLE
[TableGen] Factor common defs out into common `Types.td`

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -10,13 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-def APSIntAttr : Attr<CPred<"$_self.isa<::mlir::IntegerAttr>()">,
-                      "arbitrary integer attribute with sign"> {
-  let storageType = [{ ::mlir::IntegerAttr }];
-  let returnType = [{ ::llvm::APSInt }];
-  let constBuilderCall = "IntegerAttr::get($_builder.getContext(), $0)";
-  let convertFromStorage = "APSInt($_self.getValue(), !getType().isSigned())";
-}
+include "circt/Types.td"
 
 def SameOperandsIntTypeKind : NativeOpTrait<"SameOperandsIntTypeKind"> {
   let cppNamespace = "::circt::firrtl";

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+include "circt/Types.td"
+
 def CircuitOp : FIRRTLOp<"circuit",
       [IsolatedFromAbove, SymbolTable, SingleBlock, NoTerminator,
        NoRegionArguments]> {
@@ -139,8 +141,8 @@ def NonLocalAnchor : FIRRTLOp<"nla",
     annotations to anchor to in the global scope.  This lets components of the
     path point to a common entity.
   }];
-  let arguments = (ins SymbolNameAttr:$sym_name, SymbolArrayAttr:$modpath, 
-                      StringArrayAttr:$namepath);
+  let arguments = (ins SymbolNameAttr:$sym_name,
+                       FlatSymbolRefArrayAttr:$modpath, StrArrayAttr:$namepath);
   let results = (outs);
   let assemblyFormat = [{ $sym_name $modpath $namepath attr-dict}];
 }

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -212,30 +212,6 @@ def InvalidValueAttr : AttrDef<FIRRTLDialect, "InvalidValue"> {
   ];
 }
 
-def SymbolArrayAttr: ArrayAttrBase<
-    And<[
-      // Guarantee this is an ArrayAttr first
-      CPred<"$_self.isa<::mlir::ArrayAttr>()">,
-      // Guarantee all elements are FlatSymbolRefAttr
-      CPred<"::llvm::all_of($_self.cast<::mlir::ArrayAttr>(), "
-            "[&](::mlir::Attribute attr) { return attr.isa<"
-            "::mlir::FlatSymbolRefAttr>();})">]>,
-    ""> {
-  let constBuilderCall = "$_builder.getArrayAttr($0)";
-}
-
-def StringArrayAttr: ArrayAttrBase<
-    And<[
-      // Guarantee this is an ArrayAttr first
-      CPred<"$_self.isa<::mlir::ArrayAttr>()">,
-      // Guarantee all elements are StringAttr
-      CPred<"::llvm::all_of($_self.cast<::mlir::ArrayAttr>(), "
-            "[&](::mlir::Attribute attr) { return attr.isa<"
-            "::mlir::StringAttr>();})">]>,
-    ""> {
-  let constBuilderCall = "$_builder.getArrayAttr($0)";
-}
-
 class AugmentedType<string name> : AttrDef<FIRRTLDialect, name> {
   let parameters = (
     ins "DictionaryAttr":$underlying

--- a/include/circt/Dialect/HW/HWTypes.td
+++ b/include/circt/Dialect/HW/HWTypes.td
@@ -57,5 +57,15 @@ def UnionType : DialectType<HWDialect,
 // Type Definitions
 //===----------------------------------------------------------------------===//
 
+/// A flat symbol reference or a reference to a name within a module.
+def NameRefAttr : Attr<
+  CPred<"$_self.isa<::mlir::FlatSymbolRefAttr, ::hw::InnerRefAttr>()">,
+  "name reference attribute">;
+
+// Like a FlatSymbolRefArrayAttr, but can also refer to names inside modules.
+def NameRefArrayAttr : TypedArrayAttrBase<NameRefAttr,
+  "name reference array attribute"> {
+  let constBuilderCall = "$_builder.getArrayAttr($0)";
+}
 
 #endif // CIRCT_DIALECT_HW_HWTYPES

--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -11,6 +11,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+include "circt/Types.td"
+
 // Note that net declarations like 'wire' should not appear in an always block.
 def WireOp : SVOp<"wire", [NonProceduralOp, 
           DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
@@ -91,7 +93,7 @@ def XMROp : SVOp<"xmr", []> {
     generating this op should ensure that any instance or object in the intended
     path has public visibility so paths are not invalidated.
   }];
-  let arguments = (ins UnitAttr:$isRooted, StringArrayAttr:$path, StrAttr:$terminal);
+  let arguments = (ins UnitAttr:$isRooted, StrArrayAttr:$path, StrAttr:$terminal);
   let results = (outs InOutType:$result);
   let assemblyFormat = "(`isRooted` $isRooted^)? custom<XMRPath>($path, $terminal) attr-dict `:` type($result)"; 
 }

--- a/include/circt/Dialect/SV/SVTypes.td
+++ b/include/circt/Dialect/SV/SVTypes.td
@@ -15,6 +15,9 @@
 
 include "circt/Dialect/SV/SVDialect.td"
 
+// TODO: The following should go into a `SVTypesImpl.td` if we ever actually
+// define any SV-specific types. Doing so will keep this `SVTypes.td` file
+// includable for other dialects, without polluting their output with SV types.
 class SVType<string name> : TypeDef<SVDialect, name> { }
 
 //===----------------------------------------------------------------------===//
@@ -47,44 +50,5 @@ class InOutTypeConstraint<string value, string inoutValue>
 class InOutElementConstraint<string value, string inoutValue>
   : TypesMatchWith<"type should be element of inout type",
                    inoutValue, value, "sv::getInOutElementType($_self)">;
-
-// This type is an array of FlatSymbolRefAttr.
-// TODO: This should be moved to mlir, it does not depend on HW dialect.
-def SymRefArrayAttr: ArrayAttrBase<
-    And<[
-      // Guarantee this is an ArrayAttr first
-      CPred<"$_self.isa<::mlir::ArrayAttr>()">,
-      // Guarantee all elements are DictionaryAttr or SubAnnotationAttr
-      CPred<"::llvm::all_of($_self.cast<::mlir::ArrayAttr>(), "
-            "[&](::mlir::Attribute attr) { return attr.isa<"
-            "::mlir::FlatSymbolRefAttr>();})">]>,
-    ""> {
-  let constBuilderCall = "$_builder.getArrayAttr($0)";
-}
-
-// Like a SymRefArrayAttr, but can also refer to names inside modules.
-def NameRefArrayAttr: ArrayAttrBase<
-    And<[
-      // Guarantee this is an ArrayAttr first
-      CPred<"$_self.isa<::mlir::ArrayAttr>()">,
-      // Guarantee all elements are symbols or name refs
-      CPred<"::llvm::all_of($_self.cast<::mlir::ArrayAttr>(), "
-            "[&](::mlir::Attribute attr) { return attr.isa<"
-            "::mlir::FlatSymbolRefAttr, ::hw::InnerRefAttr>();})">]>,
-    ""> {
-  let constBuilderCall = "$_builder.getArrayAttr($0)";
-}
-
-def StringArrayAttr: ArrayAttrBase<
-    And<[
-      // Guarantee this is an ArrayAttr first
-      CPred<"$_self.isa<::mlir::ArrayAttr>()">,
-      // Guarantee all elements are StringAttr
-      CPred<"::llvm::all_of($_self.cast<::mlir::ArrayAttr>(), "
-            "[&](::mlir::Attribute attr) { return attr.isa<"
-            "::mlir::StringAttr>();})">]>,
-    ""> {
-  let constBuilderCall = "$_builder.getArrayAttr($0)";
-}
 
 #endif // CIRCT_DIALECT_SV_SVTYPES

--- a/include/circt/Types.td
+++ b/include/circt/Types.td
@@ -1,0 +1,29 @@
+//===- Types.td - Common type predicates and definitions ---*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file collects type predicates and definitions commonly used in the CIRCT
+// dialects.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_TYPES
+#define CIRCT_TYPES
+
+//===----------------------------------------------------------------------===//
+// Attributes
+//===----------------------------------------------------------------------===//
+
+def APSIntAttr : Attr<CPred<"$_self.isa<::mlir::IntegerAttr>()">,
+                      "arbitrary integer attribute with sign"> {
+  let storageType = [{ ::mlir::IntegerAttr }];
+  let returnType = [{ ::llvm::APSInt }];
+  let constBuilderCall = "IntegerAttr::get($_builder.getContext(), $0)";
+  let convertFromStorage = "APSInt($_self.getValue(), !getType().isSigned())";
+}
+
+#endif // CIRCT_TYPES


### PR DESCRIPTION
Create a CIRCT-wide `include/circt/Types.td` file that can collect the common type, attribute, and constraint definitions used throughout the CIRCT project, which may not be specific to one of the given dialects. Things that land here would generally be candidates for upstreaming to MLIR, but it's better to have a common place in CIRCT first where they can incubate.

While we're at it, get rid of some of the type definitions which have since appeared in upstream MLIR, and factor some first commonalities out into `Types.td`. There will be quite a few more in the future.

---

~~Change the `FIRRTLExpressions.td` to depend on `SVTypes.td` for the definition of `StringArrayAttr` (and later also `NameRefArrayAttr` for work in #2113).~~

~~As @lattner mentioned in #2112, this creates a dependency (at least a build-time/tablegen-time dependency) from FIRRTL to the SV dialect, which might not be ideal. We have a few of these type predicates scattered throughout the CIRCT code base, with some duplication I've seen in the past, so it might also make sense to just have a common `include/circt/Types.td` file that all dialects can include.~~
