### PR TITLE
[FIRRTL] Handle RegReset as index to SubAccess

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -206,13 +206,17 @@ static bool insertResetMux(ImplicitLocOpBuilder &builder, Value target,
             resetSubValue.erase();
         })
         // Look through subaccesses.
-        .Case<SubaccessOp>([&](auto op) {
-          auto resetSubValue =
-              builder.create<SubaccessOp>(resetValue, op.index());
+        .Case<SubaccessOp>([&](SubaccessOp op) {
+          Value resetSubValue;
+          if (op.index() == target)
+            resetSubValue = builder.create<SubaccessOp>(op.input(), resetValue);
+          else
+            resetSubValue = builder.create<SubaccessOp>(resetValue, op.index());
+
           if (insertResetMux(builder, op, reset, resetSubValue))
             resetValueUsed = true;
           else
-            resetSubValue.erase();
+            resetSubValue.getDefiningOp()->erase();
         });
   }
   return resetValueUsed;

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -206,17 +206,15 @@ static bool insertResetMux(ImplicitLocOpBuilder &builder, Value target,
             resetSubValue.erase();
         })
         // Look through subaccesses.
-        .Case<SubaccessOp>([&](SubaccessOp op) {
-          Value resetSubValue;
-          if (op.index() == target)
-            resetSubValue = builder.create<SubaccessOp>(op.input(), resetValue);
-          else
-            resetSubValue = builder.create<SubaccessOp>(resetValue, op.index());
-
+        .Case<SubaccessOp>([&](auto op) {
+          if (op.input() != target)
+            return;
+          auto resetSubValue =
+              builder.create<SubaccessOp>(resetValue, op.index());
           if (insertResetMux(builder, op, reset, resetSubValue))
             resetValueUsed = true;
           else
-            resetSubValue.getDefiningOp()->erase();
+            resetSubValue.erase();
         });
   }
   return resetValueUsed;

--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -701,12 +701,9 @@ firrtl.circuit "SubAccess" {
     %reg6 = firrtl.regreset %clock, %init, %c1_ui8 : !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
     %2 = firrtl.subaccess %arr[%reg6] : !firrtl.vector<uint<8>, 1>, !firrtl.uint<2>
     firrtl.connect %2, %in : !firrtl.uint<8>, !firrtl.uint<8>
-    // CHECK:  %[[c0_ui2:.+]] = firrtl.constant 0 : !firrtl.uint<2>
-    // CHECK-NEXT:  %reg6 = firrtl.regreset %clock, %extraReset, %[[c0_ui2]]  : !firrtl.asyncreset, !firrtl.uint<2>, !firrtl.uint<2>
-    // CHECK-NEXT:  %[[v0:.+]] = firrtl.subaccess %arr[%[[c1_ui2:.+]]] : !firrtl.vector<uint<8>, 1>, !firrtl.uint<2>
-    // CHECK-NEXT:  %[[v1:.+]] = firrtl.subaccess %arr[%reg6] : !firrtl.vector<uint<8>, 1>, !firrtl.uint<2>
-    // CHECK-NEXT:  %[[v2:.+]] = firrtl.mux(%init, %[[v0]], %in) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
-    // CHECK-NEXT:  firrtl.connect %[[v1]], %[[v2]] : !firrtl.uint<8>, !firrtl.uint<8>
+    // CHECK:  %reg6 = firrtl.regreset %clock, %extraReset, %c0_ui2  : !firrtl.asyncreset, !firrtl.uint<2>, !firrtl.uint<2>
+    // CHECK-NEXT:  %[[v0:.+]] = firrtl.subaccess %arr[%reg6] : !firrtl.vector<uint<8>, 1>, !firrtl.uint<2>
+    // CHECK-NEXT:  firrtl.connect %[[v0]], %in : !firrtl.uint<8>, !firrtl.uint<8>
 
   }
 }

--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -691,3 +691,22 @@ firrtl.circuit "MoveAcrossBlocks4" {
     // CHECK-NEXT: firrtl.connect %localReset, [[TMP]]
   }
 }
+
+firrtl.circuit "SubAccess" {
+  firrtl.module @SubAccess(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %init: !firrtl.uint<1>, in %in: !firrtl.uint<8>, in %extraReset: !firrtl.asyncreset ) attributes {
+    // CHECK-LABEL: firrtl.module @SubAccess
+    portAnnotations = [[],[],[],[],[{class = "firrtl.transforms.DontTouchAnnotation"}, {class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]]} {
+    %c1_ui8 = firrtl.constant 1 : !firrtl.uint<2>
+    %arr = firrtl.wire : !firrtl.vector<uint<8>, 1>
+    %reg6 = firrtl.regreset %clock, %init, %c1_ui8 : !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
+    %2 = firrtl.subaccess %arr[%reg6] : !firrtl.vector<uint<8>, 1>, !firrtl.uint<2>
+    firrtl.connect %2, %in : !firrtl.uint<8>, !firrtl.uint<8>
+    // CHECK:  %[[c0_ui2:.+]] = firrtl.constant 0 : !firrtl.uint<2>
+    // CHECK-NEXT:  %reg6 = firrtl.regreset %clock, %extraReset, %[[c0_ui2]]  : !firrtl.asyncreset, !firrtl.uint<2>, !firrtl.uint<2>
+    // CHECK-NEXT:  %[[v0:.+]] = firrtl.subaccess %arr[%[[c1_ui2:.+]]] : !firrtl.vector<uint<8>, 1>, !firrtl.uint<2>
+    // CHECK-NEXT:  %[[v1:.+]] = firrtl.subaccess %arr[%reg6] : !firrtl.vector<uint<8>, 1>, !firrtl.uint<2>
+    // CHECK-NEXT:  %[[v2:.+]] = firrtl.mux(%init, %[[v0]], %in) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+    // CHECK-NEXT:  firrtl.connect %[[v1]], %[[v2]] : !firrtl.uint<8>, !firrtl.uint<8>
+
+  }
+}


### PR DESCRIPTION
`InferResets`  was not handling the case when the reset reg is an `index` into the `SubAccess` Op and not the `input`.
Fixes https://github.com/llvm/circt/issues/2132