### PR TITLE
[FIRRTL] Fix type hierarchy

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -93,9 +93,7 @@ public:
   int32_t getBitWidthOrSentinel();
 
   /// Support method to enable LLVM-style type casting.
-  static bool classof(Type type) {
-    return llvm::isa<FIRRTLDialect>(type.getDialect());
-  }
+  static bool classof(Type type);
 
   /// Return true if this is a valid "reset" type.
   bool isResetType();

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -321,6 +321,14 @@ unsigned RecursiveTypeProperties::toFlags() const {
 //===----------------------------------------------------------------------===//
 // FIRRTLType Implementation
 //===----------------------------------------------------------------------===//
+bool FIRRTLType::classof(Type type) {
+  // CHIRRTL types cmemory and cmemory port are both in the FIRRTLDialect, but
+  // are not FIRRTLTypes.  This is why we can't just check the dialect here.
+  return TypeSwitch<Type, bool>(type)
+      .Case<ClockType, ResetType, AsyncResetType, SIntType, UIntType,
+            AnalogType, BundleType, FVectorType>([](auto type) { return true; })
+      .Default([](auto type) { return false; });
+}
 
 /// Return true if this is a 'ground' type, aka a non-aggregate type.
 bool FIRRTLType::isGround() {


### PR DESCRIPTION
The check for `isa<FIRRTLType>(type)` should return false for the
CHIRRTL types `cmemory` and `cmemoryport`.  The problem is that
`isa<FIRRTLType` was just checking if the dialect of the type was
FIRRTL, and so it would return `true` for the CHIRRTL types. This change
hard-codes the types which are subtypes of `FIRRTLType` into the
`FIRRTLType::classof` function.