### PR TITLE
[PyCDE] Make tests platform-independent.

### DIFF
--- a/frontends/PyCDE/test/compreg.py
+++ b/frontends/PyCDE/test/compreg.py
@@ -1,6 +1,6 @@
 # RUN: rm -rf %t
-# RUN: OUTPUT_DIRECTORY=%t %PYTHON% %s
-# RUN: FileCheck %s < %t/CompReg.sv
+# RUN: %PYTHON% %s %t
+# RUN: FileCheck %s --input-file %t/CompReg.sv
 
 import pycde
 from pycde import types, module, Input, Output
@@ -8,7 +8,7 @@ from pycde import types, module, Input, Output
 from circt.dialects import seq
 from pycde.module import generator
 
-import os
+import sys
 
 
 @module
@@ -23,9 +23,7 @@ class CompReg:
     ports.output = compreg.data
 
 
-mod = pycde.System([CompReg],
-                   name="CompReg",
-                   output_directory=os.environ["OUTPUT_DIRECTORY"])
+mod = pycde.System([CompReg], name="CompReg", output_directory=sys.argv[1])
 mod.print()
 mod.generate()
 mod.print()

--- a/frontends/PyCDE/test/instances.py
+++ b/frontends/PyCDE/test/instances.py
@@ -1,6 +1,6 @@
 # RUN: rm -rf %t
-# RUN: OUTPUT_DIRECTORY=%t %PYTHON% %s 2>&1 | FileCheck %s
-# RUN: FileCheck %s --check-prefix=OUTPUT < %t/Test.tcl
+# RUN: %PYTHON% %s %t 2>&1 | FileCheck %s
+# RUN: FileCheck %s --input-file %t/Test.tcl --check-prefix=OUTPUT
 
 import pycde
 import circt.dialects.hw
@@ -8,7 +8,7 @@ import circt.dialects.hw
 from pycde.attributes import placement
 from pycde.devicedb import PhysLocation, PrimitiveType
 
-import os
+import sys
 
 
 @pycde.externmodule
@@ -53,10 +53,7 @@ print(PhysLocation(PrimitiveType.DSP, 39, 25))
 
 # CHECK: msft.module @UnParameterized
 # CHECK-NOT: msft.module @UnParameterized
-t = pycde.System([Test],
-                 primdb,
-                 name="Test",
-                 output_directory=os.environ["OUTPUT_DIRECTORY"])
+t = pycde.System([Test], primdb, name="Test", output_directory=sys.argv[1])
 t.generate(["construct"])
 t.print()
 

--- a/frontends/PyCDE/test/polynomial.py
+++ b/frontends/PyCDE/test/polynomial.py
@@ -1,6 +1,6 @@
 # RUN: rm -rf %t
-# RUN: OUTPUT_DIRECTORY=%t %PYTHON% %s 2>&1 | FileCheck %s
-# RUN: FileCheck %s --check-prefix=OUTPUT < %t/PolynomialSystem.sv
+# RUN: %PYTHON% %s %t 2>&1 | FileCheck %s
+# RUN: FileCheck %s --input-file %t/PolynomialSystem.sv --check-prefix=OUTPUT
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from pycde import (Input, Output, module, externmodule, generator, types, dim)
 from circt.dialects import comb, hw
 from circt.support import connect
 
-import os
+import sys
 
 
 @module
@@ -108,7 +108,7 @@ class PolynomialSystem:
 
 poly = pycde.System([PolynomialSystem],
                     name="PolynomialSystem",
-                    output_directory=os.environ["OUTPUT_DIRECTORY"])
+                    output_directory=sys.argv[1])
 poly.print()
 
 print("Generating 1...")


### PR DESCRIPTION
The previous usage of environment variables and shell redirection
wouldn't work on Windows. Replace that with a command line argument
and --input-file respectively.