### PR TITLE
[Handshake] Ensure presence of `argNames` and `resNames` attributes

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -35,14 +35,7 @@ def FuncOp : Op<Handshake_Dialect, "func", [
 
   let builders =
        [OpBuilder<(ins "StringRef":$name, "FunctionType":$type,
-                      CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs),
-                      [{
-                     $_state.addAttribute(SymbolTable::getSymbolAttrName(),
-                                         $_builder.getStringAttr(name));
-                     $_state.addAttribute(getTypeAttrName(), TypeAttr::get(type));
-                     $_state.attributes.append(attrs.begin(), attrs.end());
-                     $_state.addRegion();
-                   }]>];
+                      CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs)>];
 
   let extraClassDeclaration = [{
     // Add an entry block to an empty function, and set up the block arguments
@@ -67,6 +60,31 @@ def FuncOp : Op<Handshake_Dialect, "func", [
 
     /// Returns the number of results. This is a hook for OpTrait::FunctionLike.
     unsigned getNumFuncResults() { return getType().getResults().size(); }
+
+    /// Returns the names of the arguments to this function.
+    ArrayAttr getArgNames() {
+      return (*this)->getAttrOfType<ArrayAttr>("argNames");
+    }
+
+    /// Returns the names of the results from this function.
+    ArrayAttr getResNames() {
+      return (*this)->getAttrOfType<ArrayAttr>("resNames");
+    }
+
+    /// Returns the argument name at the given index.
+    StringAttr getArgName(unsigned idx) {
+      return getArgNames()[idx].cast<StringAttr>();
+    }
+
+    /// Returns the result name at the given index.
+    StringAttr getResName(unsigned idx) {
+      return getResNames()[idx].cast<StringAttr>();
+    }
+
+    /// Resolve argument and result names. This can be used during building of
+    /// a handshake.func operation to ensure that names provided by an incoming
+    /// operation fulfills the name requirements of the handshake function.
+    void resolveArgAndResNames();
 
     /// Hook for OpTrait::FunctionLike, called after verifying that the 'type'
     /// attribute is present and checks if it holds a function type.  Ensures

--- a/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
+++ b/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
@@ -1759,6 +1759,12 @@ LogicalResult lowerFuncOp(mlir::FuncOp funcOp, MLIRContext *ctx) {
         auto funcType = rewriter.getFunctionType(argTypes, resTypes);
         nfo.setType(funcType);
         auto ctrlArg = nfo.front().addArgument(rewriter.getNoneType());
+
+        // We've now added all types to the handshake.funcOp; resolve arg- and
+        // res names to ensure they are up to date with the final type
+        // signature.
+        nfo.resolveArgAndResNames();
+
         Operation *startOp = findStartOp(&nfo.getRegion());
         startOp->getResult(0).replaceAllUsesWith(ctrlArg);
         rewriter.eraseOp(startOp);

--- a/test/Conversion/HandshakeToFIRRTL/test_naming.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_naming.mlir
@@ -23,7 +23,7 @@ handshake.func @main(%a: index, %b: index, %inCtrl: none, ...) -> (index, none) 
 // CHECK:  out %coutTest: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, 
 // CHECK:  in %clock: !firrtl.clock, 
 // CHECK:  in %reset: !firrtl.uint<1>) {
-handshake.func @main(%a: index, %b: index, %inCtrl: none, ...) -> (index, none) attributes {argNames = ["aTest", "bTest", "cTest"], outNames = ["outTest", "coutTest"]} {
+handshake.func @main(%a: index, %b: index, %inCtrl: none, ...) -> (index, none) attributes {argNames = ["aTest", "bTest", "cTest"], resNames = ["outTest", "coutTest"]} {
   %0 = arith.addi %a, %b : index
   handshake.return %0, %inCtrl : index, none
 }

--- a/test/Conversion/StandardToHandshake/Affine/test-affine-for.mlir
+++ b/test/Conversion/StandardToHandshake/Affine/test-affine-for.mlir
@@ -9,7 +9,7 @@ func @empty_body () -> () {
   return
 }
 
-// CHECK: handshake.func @empty_body(%arg0: none, ...) -> none {
+// CHECK: handshake.func @empty_body(%arg0: none, ...) -> none attributes {argNames = ["inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:   %0:4 = "handshake.fork"(%arg0) {control = true} : (none) -> (none, none, none, none)
 // CHECK:   %1 = "handshake.constant"(%0#2) {value = 0 : index} : (none) -> index
 // CHECK:   %2 = "handshake.constant"(%0#1) {value = 10 : index} : (none) -> index
@@ -72,7 +72,7 @@ func @load_store () -> () {
   return
 }
 
-// CHECK: handshake.func @load_store(%arg0: none, ...) -> none {
+// CHECK: handshake.func @load_store(%arg0: none, ...) -> none attributes {argNames = ["inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:   %0:3 = "handshake.memory"(%28#0, %28#1, %addressResults) {id = 0 : i32, ld_count = 1 : i32, lsq = false, st_count = 1 : i32, type = memref<10xf32>} : (f32, index, index) -> (f32, none, none)
 // CHECK:   %1:2 = "handshake.fork"(%0#2) {control = true} : (none) -> (none, none)
 // CHECK:   %2:4 = "handshake.fork"(%arg0) {control = true} : (none) -> (none, none, none, none)

--- a/test/Conversion/StandardToHandshake/Affine/test-affine-load-store.mlir
+++ b/test/Conversion/StandardToHandshake/Affine/test-affine-load-store.mlir
@@ -12,7 +12,7 @@ func @load_store () -> () {
   return
 }
 
-// CHECK: handshake.func @load_store(%[[ARG0:.*]]: none, ...) -> none {
+// CHECK: handshake.func @load_store(%[[ARG0:.*]]: none, ...) -> none attributes {argNames = ["inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:   %[[VAL0:.*]]:3 = "handshake.memory"(%[[VAL9:.*]]#0, %[[VAL9]]#1, %[[ADDR:.*]]) {id = 0 : i32, ld_count = 1 : i32, lsq = false, st_count = 1 : i32, type = memref<10xf32>} : (f32, index, index) -> (f32, none, none)
 // CHECK:   %[[VAL1:.*]]:2 = "handshake.fork"(%[[VAL0]]#2) {control = true} : (none) -> (none, none)
 // CHECK:   %[[VAL2:.*]]:3 = "handshake.fork"(%[[ARG0]]) {control = true} : (none) -> (none, none, none)
@@ -38,7 +38,7 @@ func @affine_map_addr () -> () {
   return
 }
 
-// CHECK:      handshake.func @affine_map_addr(%[[ARG0:.*]]: none, ...) -> none {
+// CHECK:      handshake.func @affine_map_addr(%[[ARG0:.*]]: none, ...) -> none attributes {argNames = ["inCtrl"], resNames = ["outCtrl"]} {
 // CHECK-NEXT:   %[[VAL0:.*]]:3 = "handshake.memory"(%[[VAL13:.*]]#0, %[[VAL13]]#1, %[[ADDR:.*]]) {id = 0 : i32, ld_count = 1 : i32, lsq = false, st_count = 1 : i32, type = memref<10xf32>} : (f32, index, index) -> (f32, none, none)
 // CHECK-NEXT:   %[[VAL1:.*]]:2 = "handshake.fork"(%[[VAL0]]#2) {control = true} : (none) -> (none, none)
 // CHECK-NEXT:   %[[VAL2:.*]]:3 = "handshake.fork"(%[[ARG0]]) {control = true} : (none) -> (none, none, none)

--- a/test/Conversion/StandardToHandshake/test1.mlir
+++ b/test/Conversion/StandardToHandshake/test1.mlir
@@ -4,7 +4,7 @@ func @simple_loop() {
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @simple_loop(
-// CHECK-SAME:                                %[[VAL_0:.*]]: none, ...) -> none {
+// CHECK-SAME:                                %[[VAL_0:.*]]: none, ...) -> none attributes {argNames = ["inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:           %[[VAL_1:.*]] = "handshake.branch"(%[[VAL_0]]) {control = true} : (none) -> none
 // CHECK:           %[[VAL_2:.*]]:2 = "handshake.control_merge"(%[[VAL_1]]) {control = true} : (none) -> (none, index)
 // CHECK:           %[[VAL_3:.*]]:3 = "handshake.fork"(%[[VAL_2]]#0) {control = true} : (none) -> (none, none, none)

--- a/test/Conversion/StandardToHandshake/test10.mlir
+++ b/test/Conversion/StandardToHandshake/test10.mlir
@@ -4,7 +4,7 @@
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @affine_dma_start(
-// CHECK-SAME:                                     %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> none {
+// CHECK-SAME:                                     %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> none attributes {argNames = ["in0", "inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:           %[[VAL_2:.*]] = "handshake.merge"(%[[VAL_0]]) : (index) -> index
 // CHECK:           %[[VAL_3:.*]]:6 = "handshake.fork"(%[[VAL_1]]) {control = true} : (none) -> (none, none, none, none, none, none)
 // CHECK:           %[[VAL_4:.*]] = memref.alloc() : memref<100xf32>

--- a/test/Conversion/StandardToHandshake/test11.mlir
+++ b/test/Conversion/StandardToHandshake/test11.mlir
@@ -4,7 +4,7 @@
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @imperfectly_nested_loops(
-// CHECK-SAME:                                             %[[VAL_0:.*]]: none, ...) -> none {
+// CHECK-SAME:                                             %[[VAL_0:.*]]: none, ...) -> none attributes {argNames = ["inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:           %[[VAL_1:.*]]:4 = "handshake.fork"(%[[VAL_0]]) {control = true} : (none) -> (none, none, none, none)
 // CHECK:           %[[VAL_2:.*]] = "handshake.constant"(%[[VAL_1]]#2) {value = 0 : index} : (none) -> index
 // CHECK:           %[[VAL_3:.*]] = "handshake.constant"(%[[VAL_1]]#1) {value = 42 : index} : (none) -> index

--- a/test/Conversion/StandardToHandshake/test12.mlir
+++ b/test/Conversion/StandardToHandshake/test12.mlir
@@ -4,7 +4,7 @@
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @more_imperfectly_nested_loops(
-// CHECK-SAME:                                                  %[[VAL_0:.*]]: none, ...) -> none {
+// CHECK-SAME:                                                  %[[VAL_0:.*]]: none, ...) -> none attributes {argNames = ["inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:           %[[VAL_1:.*]]:4 = "handshake.fork"(%[[VAL_0]]) {control = true} : (none) -> (none, none, none, none)
 // CHECK:           %[[VAL_2:.*]] = "handshake.constant"(%[[VAL_1]]#2) {value = 0 : index} : (none) -> index
 // CHECK:           %[[VAL_3:.*]] = "handshake.constant"(%[[VAL_1]]#1) {value = 42 : index} : (none) -> index

--- a/test/Conversion/StandardToHandshake/test13.mlir
+++ b/test/Conversion/StandardToHandshake/test13.mlir
@@ -4,7 +4,7 @@
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @affine_apply_loops_shorthand(
-// CHECK-SAME:                                                 %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> none {
+// CHECK-SAME:                                                 %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> none attributes {argNames = ["in0", "inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:           %[[VAL_2:.*]] = "handshake.merge"(%[[VAL_0]]) : (index) -> index
 // CHECK:           %[[VAL_3:.*]]:3 = "handshake.fork"(%[[VAL_1]]) {control = true} : (none) -> (none, none, none)
 // CHECK:           %[[VAL_4:.*]] = "handshake.constant"(%[[VAL_3]]#1) {value = 0 : index} : (none) -> index

--- a/test/Conversion/StandardToHandshake/test14.mlir
+++ b/test/Conversion/StandardToHandshake/test14.mlir
@@ -4,7 +4,7 @@
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @affine_store(
-// CHECK-SAME:                                 %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> none {
+// CHECK-SAME:                                 %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> none attributes {argNames = ["in0", "inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:           %[[VAL_2:.*]] = "handshake.memory"(%[[VAL_3:.*]]#0, %[[VAL_3]]#1) {id = 0 : i32, ld_count = 0 : i32, lsq = false, st_count = 1 : i32, type = memref<10xf32>} : (f32, index) -> none
 // CHECK:           %[[VAL_4:.*]] = "handshake.merge"(%[[VAL_0]]) : (index) -> index
 // CHECK:           %[[VAL_5:.*]]:5 = "handshake.fork"(%[[VAL_1]]) {control = true} : (none) -> (none, none, none, none, none)

--- a/test/Conversion/StandardToHandshake/test15.mlir
+++ b/test/Conversion/StandardToHandshake/test15.mlir
@@ -4,7 +4,7 @@
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @affine_load(
-// CHECK-SAME:                                %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> none {
+// CHECK-SAME:                                %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> none attributes {argNames = ["in0", "inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:           %[[VAL_2:.*]]:2 = "handshake.memory"(%[[VAL_3:.*]]) {id = 0 : i32, ld_count = 1 : i32, lsq = false, st_count = 0 : i32, type = memref<10xf32>} : (index) -> (f32, none)
 // CHECK:           %[[VAL_4:.*]] = "handshake.merge"(%[[VAL_0]]) : (index) -> index
 // CHECK:           %[[VAL_5:.*]]:4 = "handshake.fork"(%[[VAL_1]]) {control = true} : (none) -> (none, none, none, none)

--- a/test/Conversion/StandardToHandshake/test16.mlir
+++ b/test/Conversion/StandardToHandshake/test16.mlir
@@ -4,7 +4,7 @@ func @affine_apply_ceildiv(%arg0: index) -> index {
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @affine_apply_ceildiv(
-// CHECK-SAME:                                         %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> (index, none) {
+// CHECK-SAME:                                         %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> (index, none) attributes {argNames = ["in0", "inCtrl"], resNames = ["out0", "outCtrl"]} {
 // CHECK:           %[[VAL_2:.*]] = "handshake.merge"(%[[VAL_0]]) : (index) -> index
 // CHECK:           %[[VAL_3:.*]]:3 = "handshake.fork"(%[[VAL_2]]) {control = false} : (index) -> (index, index, index)
 // CHECK:           %[[VAL_4:.*]]:4 = "handshake.fork"(%[[VAL_1]]) {control = true} : (none) -> (none, none, none, none)

--- a/test/Conversion/StandardToHandshake/test17.mlir
+++ b/test/Conversion/StandardToHandshake/test17.mlir
@@ -4,7 +4,7 @@ func @affine_apply_floordiv(%arg0: index) -> index {
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @affine_apply_floordiv(
-// CHECK-SAME:                                          %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> (index, none) {
+// CHECK-SAME:                                          %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> (index, none) attributes {argNames = ["in0", "inCtrl"], resNames = ["out0", "outCtrl"]} {
 // CHECK:           %[[VAL_2:.*]] = "handshake.merge"(%[[VAL_0]]) : (index) -> index
 // CHECK:           %[[VAL_3:.*]]:3 = "handshake.fork"(%[[VAL_2]]) {control = false} : (index) -> (index, index, index)
 // CHECK:           %[[VAL_4:.*]]:4 = "handshake.fork"(%[[VAL_1]]) {control = true} : (none) -> (none, none, none, none)

--- a/test/Conversion/StandardToHandshake/test18.mlir
+++ b/test/Conversion/StandardToHandshake/test18.mlir
@@ -4,7 +4,7 @@ func @affine_apply_mod(%arg0: index) -> index {
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @affine_apply_mod(
-// CHECK-SAME:                                     %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> (index, none) {
+// CHECK-SAME:                                     %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> (index, none) attributes {argNames = ["in0", "inCtrl"], resNames = ["out0", "outCtrl"]} {
 // CHECK:           %[[VAL_2:.*]] = "handshake.merge"(%[[VAL_0]]) : (index) -> index
 // CHECK:           %[[VAL_3:.*]]:3 = "handshake.fork"(%[[VAL_1]]) {control = true} : (none) -> (none, none, none)
 // CHECK:           %[[VAL_4:.*]] = "handshake.constant"(%[[VAL_3]]#1) {value = 42 : index} : (none) -> index

--- a/test/Conversion/StandardToHandshake/test19.mlir
+++ b/test/Conversion/StandardToHandshake/test19.mlir
@@ -4,7 +4,7 @@ func @affine_applies() {
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @affine_applies(
-// CHECK-SAME:                                   %[[VAL_0:.*]]: none, ...) -> none {
+// CHECK-SAME:                                   %[[VAL_0:.*]]: none, ...) -> none attributes {argNames = ["inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:           %[[VAL_1:.*]]:18 = "handshake.fork"(%[[VAL_0]]) {control = true} : (none) -> (none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none, none)
 // CHECK:           %[[VAL_2:.*]] = "handshake.constant"(%[[VAL_1]]#16) {value = 0 : index} : (none) -> index
 // CHECK:           %[[VAL_3:.*]]:2 = "handshake.fork"(%[[VAL_2]]) {control = false} : (index) -> (index, index)

--- a/test/Conversion/StandardToHandshake/test2.mlir
+++ b/test/Conversion/StandardToHandshake/test2.mlir
@@ -4,7 +4,7 @@ func @imperfectly_nested_loops() {
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @imperfectly_nested_loops(
-// CHECK-SAME:                                             %[[VAL_0:.*]]: none, ...) -> none {
+// CHECK-SAME:                                             %[[VAL_0:.*]]: none, ...) -> none attributes {argNames = ["inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:           %[[VAL_1:.*]] = "handshake.branch"(%[[VAL_0]]) {control = true} : (none) -> none
 // CHECK:           %[[VAL_2:.*]]:2 = "handshake.control_merge"(%[[VAL_1]]) {control = true} : (none) -> (none, index)
 // CHECK:           %[[VAL_3:.*]]:3 = "handshake.fork"(%[[VAL_2]]#0) {control = true} : (none) -> (none, none, none)

--- a/test/Conversion/StandardToHandshake/test20.mlir
+++ b/test/Conversion/StandardToHandshake/test20.mlir
@@ -4,7 +4,7 @@
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @min_reduction_tree(
-// CHECK-SAME:                                       %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> none {
+// CHECK-SAME:                                       %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> none attributes {argNames = ["in0", "inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:           %[[VAL_2:.*]] = "handshake.merge"(%[[VAL_0]]) : (index) -> index
 // CHECK:           %[[VAL_3:.*]]:14 = "handshake.fork"(%[[VAL_2]]) {control = false} : (index) -> (index, index, index, index, index, index, index, index, index, index, index, index, index, index)
 // CHECK:           %[[VAL_4:.*]]:3 = "handshake.fork"(%[[VAL_1]]) {control = true} : (none) -> (none, none, none)

--- a/test/Conversion/StandardToHandshake/test21.mlir
+++ b/test/Conversion/StandardToHandshake/test21.mlir
@@ -4,7 +4,7 @@ func @loop_min_max(%arg0: index) {
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @loop_min_max(
-// CHECK-SAME:                                 %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> none {
+// CHECK-SAME:                                 %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> none attributes {argNames = ["in0", "inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:           %[[VAL_2:.*]] = "handshake.merge"(%[[VAL_0]]) : (index) -> index
 // CHECK:           %[[VAL_3:.*]]:4 = "handshake.fork"(%[[VAL_1]]) {control = true} : (none) -> (none, none, none, none)
 // CHECK:           %[[VAL_4:.*]] = "handshake.constant"(%[[VAL_3]]#2) {value = 0 : index} : (none) -> index

--- a/test/Conversion/StandardToHandshake/test22.mlir
+++ b/test/Conversion/StandardToHandshake/test22.mlir
@@ -4,7 +4,7 @@
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @if_for(
-// CHECK-SAME:                           %[[VAL_0:.*]]: none, ...) -> none {
+// CHECK-SAME:                           %[[VAL_0:.*]]: none, ...) -> none attributes {argNames = ["inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:           %[[VAL_1:.*]]:4 = "handshake.fork"(%[[VAL_0]]) {control = true} : (none) -> (none, none, none, none)
 // CHECK:           %[[VAL_2:.*]] = "handshake.constant"(%[[VAL_1]]#2) {value = 0 : index} : (none) -> index
 // CHECK:           %[[VAL_3:.*]] = "handshake.constant"(%[[VAL_1]]#1) {value = -1 : index} : (none) -> index

--- a/test/Conversion/StandardToHandshake/test23.mlir
+++ b/test/Conversion/StandardToHandshake/test23.mlir
@@ -4,7 +4,7 @@ func @multi_cond(%arg0: index, %arg1: index, %arg2: index, %arg3: index) {
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @multi_cond(
-// CHECK-SAME:                               %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: index, %[[VAL_2:.*]]: index, %[[VAL_3:.*]]: index, %[[VAL_4:.*]]: none, ...) -> none {
+// CHECK-SAME:                               %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: index, %[[VAL_2:.*]]: index, %[[VAL_3:.*]]: index, %[[VAL_4:.*]]: none, ...) -> none attributes {argNames = ["in0", "in1", "in2", "in3", "inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:           %[[VAL_5:.*]] = "handshake.merge"(%[[VAL_0]]) : (index) -> index
 // CHECK:           %[[VAL_6:.*]]:2 = "handshake.fork"(%[[VAL_5]]) {control = false} : (index) -> (index, index)
 // CHECK:           %[[VAL_7:.*]] = "handshake.merge"(%[[VAL_1]]) : (index) -> index

--- a/test/Conversion/StandardToHandshake/test24.mlir
+++ b/test/Conversion/StandardToHandshake/test24.mlir
@@ -4,7 +4,7 @@
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @nested_ifs(
-// CHECK-SAME:                               %[[VAL_0:.*]]: none, ...) -> none {
+// CHECK-SAME:                               %[[VAL_0:.*]]: none, ...) -> none attributes {argNames = ["inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:           %[[VAL_1:.*]]:4 = "handshake.fork"(%[[VAL_0]]) {control = true} : (none) -> (none, none, none, none)
 // CHECK:           %[[VAL_2:.*]] = "handshake.constant"(%[[VAL_1]]#2) {value = 0 : index} : (none) -> index
 // CHECK:           %[[VAL_3:.*]]:2 = "handshake.fork"(%[[VAL_2]]) {control = false} : (index) -> (index, index)

--- a/test/Conversion/StandardToHandshake/test25.mlir
+++ b/test/Conversion/StandardToHandshake/test25.mlir
@@ -4,7 +4,7 @@
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @if_else(
-// CHECK-SAME:                            %[[VAL_0:.*]]: none, ...) -> none {
+// CHECK-SAME:                            %[[VAL_0:.*]]: none, ...) -> none attributes {argNames = ["inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:           %[[VAL_1:.*]]:4 = "handshake.fork"(%[[VAL_0]]) {control = true} : (none) -> (none, none, none, none)
 // CHECK:           %[[VAL_2:.*]] = "handshake.constant"(%[[VAL_1]]#2) {value = 0 : index} : (none) -> index
 // CHECK:           %[[VAL_3:.*]]:2 = "handshake.fork"(%[[VAL_2]]) {control = false} : (index) -> (index, index)

--- a/test/Conversion/StandardToHandshake/test26.mlir
+++ b/test/Conversion/StandardToHandshake/test26.mlir
@@ -4,7 +4,7 @@
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @if_only(
-// CHECK-SAME:                            %[[VAL_0:.*]]: none, ...) -> none {
+// CHECK-SAME:                            %[[VAL_0:.*]]: none, ...) -> none attributes {argNames = ["inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:           %[[VAL_1:.*]]:4 = "handshake.fork"(%[[VAL_0]]) {control = true} : (none) -> (none, none, none, none)
 // CHECK:           %[[VAL_2:.*]] = "handshake.constant"(%[[VAL_1]]#2) {value = 0 : index} : (none) -> index
 // CHECK:           %[[VAL_3:.*]]:2 = "handshake.fork"(%[[VAL_2]]) {control = false} : (index) -> (index, index)

--- a/test/Conversion/StandardToHandshake/test27.mlir
+++ b/test/Conversion/StandardToHandshake/test27.mlir
@@ -4,7 +4,7 @@ func @simple_loop() {
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @simple_loop(
-// CHECK-SAME:                                %[[VAL_0:.*]]: none, ...) -> none {
+// CHECK-SAME:                                %[[VAL_0:.*]]: none, ...) -> none attributes {argNames = ["inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:           %[[VAL_1:.*]] = "handshake.branch"(%[[VAL_0]]) {control = true} : (none) -> none
 // CHECK:           %[[VAL_2:.*]]:2 = "handshake.control_merge"(%[[VAL_1]]) {control = true} : (none) -> (none, index)
 // CHECK:           %[[VAL_3:.*]]:2 = "handshake.fork"(%[[VAL_2]]#0) {control = true} : (none) -> (none, none)

--- a/test/Conversion/StandardToHandshake/test28.mlir
+++ b/test/Conversion/StandardToHandshake/test28.mlir
@@ -4,7 +4,7 @@
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @affine_load(
-// CHECK-SAME:                                %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> none {
+// CHECK-SAME:                                %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> none attributes {argNames = ["in0", "inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:           %[[VAL_2:.*]]:3 = "handshake.memory"(%[[VAL_3:.*]]#0, %[[VAL_3]]#1, %[[VAL_4:.*]]) {id = 1 : i32, ld_count = 1 : i32, lsq = false, st_count = 1 : i32, type = memref<10xf32>} : (f32, index, index) -> (f32, none, none)
 // CHECK:           %[[VAL_5:.*]]:2 = "handshake.fork"(%[[VAL_2]]#2) {control = true} : (none) -> (none, none)
 // CHECK:           %[[VAL_6:.*]]:2 = "handshake.memory"(%[[VAL_7:.*]]) {id = 0 : i32, ld_count = 1 : i32, lsq = false, st_count = 0 : i32, type = memref<10xf32>} : (index) -> (f32, none)

--- a/test/Conversion/StandardToHandshake/test29.mlir
+++ b/test/Conversion/StandardToHandshake/test29.mlir
@@ -2,7 +2,7 @@
 // RUN: circt-opt -lower-std-to-handshake %s | FileCheck %s
 func @load_store(memref<4xi32>, index) {
 // CHECK-LABEL: handshake.func @load_store(
-// CHECK-SAME:  %arg0: memref<4xi32>, %arg1: index, %arg2: none, ...) -> none {
+// CHECK-SAME:  %arg0: memref<4xi32>, %arg1: index, %arg2: none, ...) -> none attributes {argNames = ["in0", "in1", "inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:   %[[LDDATA_STNONE_LDNONE:.+]]:3 = "handshake.memory"(%[[STDATA_STIDX0:.+]]#0, %[[STDATA_STIDX0:.+]]#1, %[[LDIDX0:.+]]) {id = 0 : i32, ld_count = 1 : i32, lsq = false, st_count = 1 : i32, type = memref<4xi32>} : (i32, index, index) -> (i32, none, none)
 // CHECK:   %[[STNONE_STNONE:.+]]:2 = "handshake.fork"(%[[LDDATA_STNONE_LDNONE:.+]]#1) {control = true} : (none) -> (none, none)
 

--- a/test/Conversion/StandardToHandshake/test3.mlir
+++ b/test/Conversion/StandardToHandshake/test3.mlir
@@ -4,7 +4,7 @@ func @more_imperfectly_nested_loops() {
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @more_imperfectly_nested_loops(
-// CHECK-SAME:                                                  %[[VAL_0:.*]]: none, ...) -> none {
+// CHECK-SAME:                                                  %[[VAL_0:.*]]: none, ...) -> none attributes {argNames = ["inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:           %[[VAL_1:.*]] = "handshake.branch"(%[[VAL_0]]) {control = true} : (none) -> none
 // CHECK:           %[[VAL_2:.*]]:2 = "handshake.control_merge"(%[[VAL_1]]) {control = true} : (none) -> (none, index)
 // CHECK:           %[[VAL_3:.*]]:3 = "handshake.fork"(%[[VAL_2]]#0) {control = true} : (none) -> (none, none, none)

--- a/test/Conversion/StandardToHandshake/test30.mlir
+++ b/test/Conversion/StandardToHandshake/test30.mlir
@@ -4,7 +4,7 @@
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @affine_load(
-// CHECK-SAME:                                %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> none {
+// CHECK-SAME:                                %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> none attributes {argNames = ["in0", "inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:           %[[VAL_2:.*]]:7 = "handshake.memory"(%[[VAL_3:.*]]#0, %[[VAL_3]]#1, %[[VAL_4:.*]], %[[VAL_5:.*]], %[[VAL_6:.*]]) {id = 0 : i32, ld_count = 3 : i32, lsq = false, st_count = 1 : i32, type = memref<10xf32>} : (f32, index, index, index, index) -> (f32, f32, f32, none, none, none, none)
 // CHECK:           %[[VAL_7:.*]]:2 = "handshake.fork"(%[[VAL_2]]#6) {control = true} : (none) -> (none, none)
 // CHECK:           %[[VAL_8:.*]]:2 = "handshake.fork"(%[[VAL_2]]#5) {control = true} : (none) -> (none, none)

--- a/test/Conversion/StandardToHandshake/test31.mlir
+++ b/test/Conversion/StandardToHandshake/test31.mlir
@@ -4,7 +4,7 @@
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @affine_load(
-// CHECK-SAME:                                %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> none {
+// CHECK-SAME:                                %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> none attributes {argNames = ["in0", "inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:           %[[VAL_2:.*]]:3 = "handshake.memory"(%[[VAL_3:.*]]#0, %[[VAL_3]]#1, %[[VAL_4:.*]]) {id = 1 : i32, ld_count = 1 : i32, lsq = false, st_count = 1 : i32, type = memref<10xf32>} : (f32, index, index) -> (f32, none, none)
 // CHECK:           %[[VAL_5:.*]]:2 = "handshake.fork"(%[[VAL_2]]#2) {control = true} : (none) -> (none, none)
 // CHECK:           %[[VAL_6:.*]]:4 = "handshake.memory"(%[[VAL_7:.*]], %[[VAL_8:.*]]) {id = 0 : i32, ld_count = 2 : i32, lsq = false, st_count = 0 : i32, type = memref<10xf32>} : (index, index) -> (f32, f32, none, none)

--- a/test/Conversion/StandardToHandshake/test32.mlir
+++ b/test/Conversion/StandardToHandshake/test32.mlir
@@ -4,7 +4,7 @@
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @test(
-// CHECK-SAME:                         %[[VAL_0:.*]]: none, ...) -> none {
+// CHECK-SAME:                         %[[VAL_0:.*]]: none, ...) -> none attributes {argNames = ["inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:           %[[VAL_1:.*]]:5 = "handshake.memory"(%[[VAL_2:.*]]#0, %[[VAL_2]]#1, %[[VAL_3:.*]], %[[VAL_4:.*]]) {id = 0 : i32, ld_count = 2 : i32, lsq = false, st_count = 1 : i32, type = memref<10xf32>} : (f32, index, index, index) -> (f32, f32, none, none, none)
 // CHECK:           %[[VAL_5:.*]]:2 = "handshake.fork"(%[[VAL_1]]#4) {control = true} : (none) -> (none, none)
 // CHECK:           %[[VAL_6:.*]]:2 = "handshake.fork"(%[[VAL_0]]) {control = true} : (none) -> (none, none)

--- a/test/Conversion/StandardToHandshake/test33.mlir
+++ b/test/Conversion/StandardToHandshake/test33.mlir
@@ -4,7 +4,7 @@
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @test(
-// CHECK-SAME:                         %[[VAL_0:.*]]: none, ...) -> none {
+// CHECK-SAME:                         %[[VAL_0:.*]]: none, ...) -> none attributes {argNames = ["inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:           %[[VAL_1:.*]]:5 = "handshake.memory"(%[[VAL_2:.*]]#0, %[[VAL_2]]#1, %[[VAL_3:.*]], %[[VAL_4:.*]]) {id = 0 : i32, ld_count = 2 : i32, lsq = false, st_count = 1 : i32, type = memref<10xf32>} : (f32, index, index, index) -> (f32, f32, none, none, none)
 // CHECK:           %[[VAL_5:.*]]:2 = "handshake.fork"(%[[VAL_1]]#4) {control = true} : (none) -> (none, none)
 // CHECK:           %[[VAL_6:.*]]:2 = "handshake.fork"(%[[VAL_1]]#3) {control = true} : (none) -> (none, none)

--- a/test/Conversion/StandardToHandshake/test34.mlir
+++ b/test/Conversion/StandardToHandshake/test34.mlir
@@ -4,7 +4,7 @@
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @test(
-// CHECK-SAME:                         %[[VAL_0:.*]]: none, ...) -> none {
+// CHECK-SAME:                         %[[VAL_0:.*]]: none, ...) -> none attributes {argNames = ["inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:           %[[VAL_1:.*]]:5 = "handshake.memory"(%[[VAL_2:.*]]#0, %[[VAL_2]]#1, %[[VAL_3:.*]], %[[VAL_4:.*]]) {id = 0 : i32, ld_count = 2 : i32, lsq = false, st_count = 1 : i32, type = memref<10xf32>} : (f32, index, index, index) -> (f32, f32, none, none, none)
 // CHECK:           %[[VAL_5:.*]]:2 = "handshake.fork"(%[[VAL_1]]#3) {control = true} : (none) -> (none, none)
 // CHECK:           %[[VAL_6:.*]]:2 = "handshake.fork"(%[[VAL_1]]#2) {control = true} : (none) -> (none, none)

--- a/test/Conversion/StandardToHandshake/test35.mlir
+++ b/test/Conversion/StandardToHandshake/test35.mlir
@@ -4,7 +4,7 @@
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @test(
-// CHECK-SAME:                         %[[VAL_0:.*]]: none, ...) -> none {
+// CHECK-SAME:                         %[[VAL_0:.*]]: none, ...) -> none attributes {argNames = ["inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:           %[[VAL_1:.*]]:3 = "handshake.memory"(%[[VAL_2:.*]]#0, %[[VAL_2]]#1, %[[VAL_3:.*]]) {id = 1 : i32, ld_count = 1 : i32, lsq = false, st_count = 1 : i32, type = memref<10xf32>} : (f32, index, index) -> (f32, none, none)
 // CHECK:           %[[VAL_4:.*]]:3 = "handshake.memory"(%[[VAL_5:.*]]#0, %[[VAL_5]]#1, %[[VAL_6:.*]]) {id = 0 : i32, ld_count = 1 : i32, lsq = false, st_count = 1 : i32, type = memref<10xf32>} : (f32, index, index) -> (f32, none, none)
 // CHECK:           %[[VAL_7:.*]]:3 = "handshake.fork"(%[[VAL_0]]) {control = true} : (none) -> (none, none, none)

--- a/test/Conversion/StandardToHandshake/test4.mlir
+++ b/test/Conversion/StandardToHandshake/test4.mlir
@@ -4,7 +4,7 @@ func @ops(f32, f32, i32, i32) -> (f32, i32) {
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @ops(
-// CHECK-SAME:                        %[[VAL_0:.*]]: f32, %[[VAL_1:.*]]: f32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: none, ...) -> (f32, i32, none) {
+// CHECK-SAME:                        %[[VAL_0:.*]]: f32, %[[VAL_1:.*]]: f32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: none, ...) -> (f32, i32, none) attributes {argNames = ["in0", "in1", "in2", "in3", "inCtrl"], resNames = ["out0", "out1", "outCtrl"]} {
 // CHECK:           %[[VAL_5:.*]] = "handshake.merge"(%[[VAL_0]]) : (f32) -> f32
 // CHECK:           %[[VAL_6:.*]]:3 = "handshake.fork"(%[[VAL_5]]) {control = false} : (f32) -> (f32, f32, f32)
 // CHECK:           %[[VAL_7:.*]] = "handshake.merge"(%[[VAL_1]]) : (f32) -> f32

--- a/test/Conversion/StandardToHandshake/test5.mlir
+++ b/test/Conversion/StandardToHandshake/test5.mlir
@@ -4,7 +4,7 @@ func @dfs_block_order() -> (i32) {
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @dfs_block_order(
-// CHECK-SAME:                                    %[[VAL_0:.*]]: none, ...) -> (i32, none) {
+// CHECK-SAME:                                    %[[VAL_0:.*]]: none, ...) -> (i32, none) attributes {argNames = ["inCtrl"], resNames = ["out0", "outCtrl"]} {
 // CHECK:           %[[VAL_1:.*]]:2 = "handshake.fork"(%[[VAL_0]]) {control = true} : (none) -> (none, none)
 // CHECK:           %[[VAL_2:.*]] = "handshake.constant"(%[[VAL_1]]#0) {value = 42 : i32} : (none) -> i32
 // CHECK:           %[[VAL_3:.*]] = "handshake.branch"(%[[VAL_1]]#1) {control = true} : (none) -> none

--- a/test/Conversion/StandardToHandshake/test6.mlir
+++ b/test/Conversion/StandardToHandshake/test6.mlir
@@ -4,7 +4,7 @@ func @ops(f32, f32, i32, i32) -> (f32, i32) {
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @ops(
-// CHECK-SAME:                        %[[VAL_0:.*]]: f32, %[[VAL_1:.*]]: f32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: none, ...) -> (f32, i32, none) {
+// CHECK-SAME:                        %[[VAL_0:.*]]: f32, %[[VAL_1:.*]]: f32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: none, ...) -> (f32, i32, none) attributes {argNames = ["in0", "in1", "in2", "in3", "inCtrl"], resNames = ["out0", "out1", "outCtrl"]} {
 // CHECK:           %[[VAL_5:.*]] = "handshake.merge"(%[[VAL_0]]) : (f32) -> f32
 // CHECK:           %[[VAL_6:.*]] = "handshake.merge"(%[[VAL_1]]) : (f32) -> f32
 // CHECK:           %[[VAL_7:.*]]:3 = "handshake.fork"(%[[VAL_6]]) {control = false} : (f32) -> (f32, f32, f32)

--- a/test/Conversion/StandardToHandshake/test7.mlir
+++ b/test/Conversion/StandardToHandshake/test7.mlir
@@ -4,7 +4,7 @@ func @simple_loop() {
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @simple_loop(
-// CHECK-SAME:                                %[[VAL_0:.*]]: none, ...) -> none {
+// CHECK-SAME:                                %[[VAL_0:.*]]: none, ...) -> none attributes {argNames = ["inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:           %[[VAL_1:.*]] = "handshake.branch"(%[[VAL_0]]) {control = true} : (none) -> none
 // CHECK:           %[[VAL_2:.*]]:2 = "handshake.control_merge"(%[[VAL_1]]) {control = true} : (none) -> (none, index)
 // CHECK:           %[[VAL_3:.*]]:2 = "handshake.fork"(%[[VAL_2]]#0) {control = true} : (none) -> (none, none)

--- a/test/Conversion/StandardToHandshake/test8.mlir
+++ b/test/Conversion/StandardToHandshake/test8.mlir
@@ -4,7 +4,7 @@ func @simple_loop() {
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @simple_loop(
-// CHECK-SAME:                                %[[VAL_0:.*]]: none, ...) -> none {
+// CHECK-SAME:                                %[[VAL_0:.*]]: none, ...) -> none attributes {argNames = ["inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:           %[[VAL_1:.*]] = "handshake.branch"(%[[VAL_0]]) {control = true} : (none) -> none
 // CHECK:           %[[VAL_2:.*]]:2 = "handshake.control_merge"(%[[VAL_1]]) {control = true} : (none) -> (none, index)
 // CHECK:           %[[VAL_3:.*]]:2 = "handshake.fork"(%[[VAL_2]]#0) {control = true} : (none) -> (none, none)

--- a/test/Conversion/StandardToHandshake/test9.mlir
+++ b/test/Conversion/StandardToHandshake/test9.mlir
@@ -4,7 +4,7 @@ func @affine_dma_wait(%arg0: index) {
 // CHECK:       module {
 
 // CHECK-LABEL:   handshake.func @affine_dma_wait(
-// CHECK-SAME:                                    %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> none {
+// CHECK-SAME:                                    %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: none, ...) -> none attributes {argNames = ["in0", "inCtrl"], resNames = ["outCtrl"]} {
 // CHECK:           %[[VAL_2:.*]] = "handshake.merge"(%[[VAL_0]]) : (index) -> index
 // CHECK:           %[[VAL_3:.*]]:5 = "handshake.fork"(%[[VAL_1]]) {control = true} : (none) -> (none, none, none, none, none)
 // CHECK:           %[[VAL_4:.*]] = memref.alloc() : memref<1xi32>

--- a/test/Conversion/StandardToHandshake/test_call.mlir
+++ b/test/Conversion/StandardToHandshake/test_call.mlir
@@ -3,7 +3,7 @@
 func @bar(%0 : i32) -> i32 {
 // CHECK-LABEL:   handshake.func @bar(
 // CHECK-SAME:                        %[[VAL_0:.*]]: i32,
-// CHECK-SAME:                        %[[VAL_1:.*]]: none, ...) -> (i32, none) {
+// CHECK-SAME:                        %[[VAL_1:.*]]: none, ...) -> (i32, none) attributes {argNames = ["in0", "inCtrl"], resNames = ["out0", "outCtrl"]} {
 // CHECK:           %[[VAL_2:.*]] = "handshake.merge"(%[[VAL_0]]) : (i32) -> i32
 // CHECK:           handshake.return %[[VAL_2]], %[[VAL_1]] : i32, none
 // CHECK:         }
@@ -14,7 +14,7 @@ func @bar(%0 : i32) -> i32 {
 func @foo(%0 : i32) -> i32 {
 // CHECK-LABEL:   handshake.func @foo(
 // CHECK-SAME:                        %[[VAL_0:.*]]: i32,
-// CHECK-SAME:                        %[[VAL_1:.*]]: none, ...) -> (i32, none) {
+// CHECK-SAME:                        %[[VAL_1:.*]]: none, ...) -> (i32, none) attributes {argNames = ["in0", "inCtrl"], resNames = ["out0", "outCtrl"]} {
 // CHECK:           %[[VAL_2:.*]] = "handshake.merge"(%[[VAL_0]]) : (i32) -> i32
 // CHECK:           %[[VAL_3:.*]]:2 = "handshake.fork"(%[[VAL_1]]) {control = true} : (none) -> (none, none)
 // CHECK:           %[[VAL_4:.*]]:2 = handshake.instance @bar(%[[VAL_2]], %[[VAL_3]]#0) : (i32, none) -> (i32, none)
@@ -42,7 +42,7 @@ func @sub(%arg0 : i32, %arg1: i32) -> i32 {
   return %0 : i32
 }
 
-// CHECK:   handshake.func @main(%[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: none, ...) -> (i32, none) {
+// CHECK:   handshake.func @main(%[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: none, ...) -> (i32, none) attributes {argNames = ["in0", "in1", "in2", "inCtrl"], resNames = ["out0", "outCtrl"]} {
 // CHECK:           %[[VAL_4:.*]] = "handshake.merge"(%[[VAL_0]]) : (i32) -> i32
 // CHECK:           %[[VAL_5:.*]] = "handshake.merge"(%[[VAL_1]]) : (i32) -> i32
 // CHECK:           %[[VAL_6:.*]] = "handshake.merge"(%[[VAL_2]]) : (i1) -> i1

--- a/test/Conversion/StandardToHandshake/test_canonicalize.mlir
+++ b/test/Conversion/StandardToHandshake/test_canonicalize.mlir
@@ -3,7 +3,7 @@
 module {
 
   // CHECK-LABEL: handshake.func @simple(
-  // CHECK-SAME:                         %[[VAL_0:.*]]: none, ...) -> none attributes {argNames = ["arg0"]} {
+  // CHECK-SAME:                         %[[VAL_0:.*]]: none, ...) -> none attributes {argNames = ["arg0"], resNames = ["outCtrl"]} {
   handshake.func @simple(%arg0: none, ...) -> none {
 
     // CHECK: %[[VAL_1:.*]] = "handshake.constant"(%[[VAL_0:.*]]) {value = 1 : index} : (none) -> index

--- a/test/Conversion/StandardToHandshake/test_naming.mlir
+++ b/test/Conversion/StandardToHandshake/test_naming.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt -lower-std-to-handshake %s | FileCheck %s
 
-// CHECK-LABEL: handshake.func @main(%arg0: i32, %arg1: i32, %arg2: i32, %arg3: none, ...) -> (i32, none) attributes {argNames = ["a", "b", "c"], outNames = ["res"]} {
-func @main(%arg0 : i32, %b : i32, %c: i32) -> i32 attributes {argNames = ["a", "b", "c"], outNames = ["res"]} {
+// CHECK-LABEL: handshake.func @main(%arg0: i32, %arg1: i32, %arg2: i32, %arg3: none, ...) -> (i32, none) attributes {argNames = ["a", "b", "c", "inCtrl"], resNames = ["res", "outCtrl"]} {
+func @main(%arg0 : i32, %b : i32, %c: i32) -> i32 attributes {argNames = ["a", "b", "c"], resNames = ["res"]} {
   return %arg0 : i32
 }

--- a/test/Dialect/Handshake/errors.mlir
+++ b/test/Dialect/Handshake/errors.mlir
@@ -77,3 +77,31 @@ handshake.func @invalid_dynamic_memory() {
   "handshake.memory"() {type = memref<?xi8>, id = 0 : i32, ld_count = 1 : i32, lsq = false, st_count = 1 : i32} : () -> ()
   return
 }
+
+// -----
+
+// expected-error @+1 {{'handshake.func' op attribute 'argNames' has 2 entries but is expected to have 3.}}
+handshake.func @invalid_num_argnames(%a : i32, %b : i32, %c : none) -> none attributes {argNames = ["a", "b"]} {
+  handshake.return %c : none
+}
+
+// -----
+
+// expected-error @+1 {{'handshake.func' op expected all entries in attribute 'argNames' to be strings.}}
+handshake.func @invalid_type_argnames(%a : i32, %b : none) -> none attributes {argNames = ["a", 2 : i32]} {
+  handshake.return %b : none
+}
+
+// -----
+
+// expected-error @+1 {{'handshake.func' op attribute 'resNames' has 1 entries but is expected to have 2.}}
+handshake.func @invalid_num_resnames(%a : i32, %b : i32, %c : none) -> (i32, none) attributes {resNames = ["a"]} {
+  handshake.return %a, %c : i32, none
+}
+
+// -----
+
+// expected-error @+1 {{'handshake.func' op expected all entries in attribute 'resNames' to be strings.}}
+handshake.func @invalid_type_resnames(%a : i32, %b : none) -> none attributes {resNames = [2 : i32]} {
+  handshake.return %b : none
+}


### PR DESCRIPTION
This commit ensures that the `argNames` and `resNames` attributes are always present in a `handshake.func` operation. The names are either partially (if some names were already provided to the op during conversion) or fully inferred based on whatever information we have available.
In doing so, we move signal name generation from handshakeToFIRRTL into being part of the operation itself. 