### PR TITLE
[FIRRTL] Add option to treat non-const async reset as warning/error

### DIFF
--- a/include/circt/Conversion/FIRRTLToHW.h
+++ b/include/circt/Conversion/FIRRTLToHW.h
@@ -24,7 +24,8 @@ class Pass;
 namespace circt {
 
 std::unique_ptr<mlir::Pass>
-createLowerFIRRTLToHWPass(bool enableAnnotationWarning = false);
+createLowerFIRRTLToHWPass(bool enableAnnotationWarning = false,
+                          bool nonConstAsyncResetValueIsError = false);
 
 } // namespace circt
 

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -94,7 +94,10 @@ def LowerFIRRTLToHW : Pass<"lower-firrtl-to-hw", "mlir::ModuleOp"> {
   let options = [
     Option<"enableAnnotationWarning", "warn-on-unprocessed-annotations",
            "bool", "false",
-    "Emit warnings on unprocessed annotations during lower-to-hw pass">
+    "Emit warnings on unprocessed annotations during lower-to-hw pass">,
+    Option<"nonConstAsyncResetValueIsError",
+           "error-on-non-const-async-reset-values", "bool", "false",
+    "Emit errors instead of warnings on non-constant async reset values">
   ];
 }
 

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -243,8 +243,10 @@ struct CircuitLoweringState {
       used_RANDOMIZE_MEM_INIT{false};
   std::atomic<bool> used_RANDOMIZE_GARBAGE_ASSIGN{false};
 
-  CircuitLoweringState(CircuitOp circuitOp, bool warn)
-      : circuitOp(circuitOp), enableAnnotationWarning(warn) {}
+  CircuitLoweringState(CircuitOp circuitOp, bool enableAnnotationWarning,
+                       bool nonConstAsyncResetValueIsError)
+      : circuitOp(circuitOp), enableAnnotationWarning(enableAnnotationWarning),
+        nonConstAsyncResetValueIsError(nonConstAsyncResetValueIsError) {}
 
   Operation *getNewModule(Operation *oldModule) {
     auto it = oldToNewModuleMap.find(oldModule);
@@ -266,6 +268,7 @@ struct CircuitLoweringState {
 
 private:
   friend struct FIRRTLModuleLowering;
+  friend struct FIRRTLLowering;
   CircuitLoweringState(const CircuitLoweringState &) = delete;
   void operator=(const CircuitLoweringState &) = delete;
 
@@ -283,6 +286,10 @@ private:
 
   // Control access to binds.
   std::mutex bindsMutex;
+
+  /// If true, non-constant reset values of async reset registers are printed as
+  /// errors and cause the pass to abort. Otherwise they are warnings.
+  const bool nonConstAsyncResetValueIsError = true;
 };
 
 void CircuitLoweringState::processRemainingAnnotations(
@@ -345,6 +352,9 @@ struct FIRRTLModuleLowering : public LowerFIRRTLToHWBase<FIRRTLModuleLowering> {
 
   void runOnOperation() override;
   void setEnableAnnotationWarning() { enableAnnotationWarning = true; }
+  void setNonConstAsyncResetValueIsError() {
+    nonConstAsyncResetValueIsError = true;
+  }
 
 private:
   void lowerFileHeader(CircuitOp op, CircuitLoweringState &loweringState);
@@ -371,10 +381,13 @@ private:
 
 /// This is the pass constructor.
 std::unique_ptr<mlir::Pass>
-circt::createLowerFIRRTLToHWPass(bool enableAnnotationWarning) {
+circt::createLowerFIRRTLToHWPass(bool enableAnnotationWarning,
+                                 bool nonConstAsyncResetValueIsError) {
   auto pass = std::make_unique<FIRRTLModuleLowering>();
   if (enableAnnotationWarning)
     pass->setEnableAnnotationWarning();
+  if (nonConstAsyncResetValueIsError)
+    pass->setNonConstAsyncResetValueIsError();
   return pass;
 }
 
@@ -399,7 +412,8 @@ void FIRRTLModuleLowering::runOnOperation() {
 
   // Keep track of the mapping from old to new modules.  The result may be null
   // if lowering failed.
-  CircuitLoweringState state(circuit, enableAnnotationWarning);
+  CircuitLoweringState state(circuit, enableAnnotationWarning,
+                             nonConstAsyncResetValueIsError);
 
   SmallVector<FModuleOp, 32> modulesToProcess;
 
@@ -2072,11 +2086,15 @@ LogicalResult FIRRTLLowering::visitDecl(RegResetOp op) {
   };
 
   if (op.resetSignal().getType().isa<AsyncResetType>()) {
-    if (!firrtl::isConstant(op.resetValue()))
-      return op.emitError(
-                   "register with async reset requires constant reset value")
-                 .attachNote(op.resetValue().getLoc())
-             << "reset value defined here:";
+    if (!firrtl::isConstant(op.resetValue())) {
+      auto diag = circuitState.nonConstAsyncResetValueIsError
+                      ? op.emitError()
+                      : op.emitWarning();
+      diag << "register with async reset requires constant reset value";
+      diag.attachNote(op.resetValue().getLoc()) << "reset value defined here:";
+      if (circuitState.nonConstAsyncResetValueIsError)
+        return failure();
+    }
     addToAlwaysBlock(sv::EventControl::AtPosEdge, clockVal,
                      ::ResetType::AsyncReset, sv::EventControl::AtPosEdge,
                      resetSignal, std::function<void()>(), resetFn);

--- a/test/Conversion/FIRRTLToHW/errors.mlir
+++ b/test/Conversion/FIRRTLToHW/errors.mlir
@@ -74,8 +74,7 @@ firrtl.circuit "Div" {
 firrtl.circuit "Foo" {
   // expected-note @+1 {{reset value defined here:}}
   firrtl.module @Foo(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %v: !firrtl.uint<8>) {
-    // expected-error @+2 {{register with async reset requires constant reset value}}
-    // expected-error @+1 {{'firrtl.regreset' op LowerToHW couldn't handle this operation}}
+    // expected-warning @+1 {{register with async reset requires constant reset value}}
     %0 = firrtl.regreset %clock, %reset, %v : !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
   }
 }
@@ -87,8 +86,7 @@ firrtl.circuit "Foo" {
   firrtl.module @Foo(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %v: !firrtl.uint<8>) {
     // expected-note @+1 {{reset value defined here:}}
     %node = firrtl.node %v : !firrtl.uint<8>
-    // expected-error @+2 {{register with async reset requires constant reset value}}
-    // expected-error @+1 {{'firrtl.regreset' op LowerToHW couldn't handle this operation}}
+    // expected-warning @+1 {{register with async reset requires constant reset value}}
     %1 = firrtl.regreset %clock, %reset, %node : !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
   }
 }


### PR DESCRIPTION
Add an option to decide whether `LowerToHW` should treat non-constant async reset values as warning or error. Have firtool keep these as errors unless IMConstProp is disabled, in which case it is highlgy likely that the user does not care about a full stop of the compilation and his downstream tools will possibly break for a lot of other reasons.