### PR TITLE
Add scattering for ModuleReplacementAnnotation

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
@@ -1729,9 +1729,9 @@ bool circt::firrtl::scatterCustomAnnotations(
         auto canonTarget = canonicalizeTarget(targetString.getValue());
         if (!canonTarget)
           return false;
-        auto NLATargets = expandNonLocal(*canonTarget);
+        auto nlaTargets = expandNonLocal(*canonTarget);
         auto leafTarget = splitAndAppendTarget(
-            fields, std::get<0>(NLATargets.back()), context);
+            fields, std::get<0>(nlaTargets.back()), context);
 
         // Add a don't touch annotation to whatever this annotation targets.
         addDontTouch(leafTarget.first, leafTarget.second);
@@ -1755,11 +1755,11 @@ bool circt::firrtl::scatterCustomAnnotations(
         auto canonTarget = canonicalizeTarget(targetString.getValue());
         if (!canonTarget)
           return false;
-        auto NLATargets = expandNonLocal(*canonTarget);
+        auto nlaTargets = expandNonLocal(*canonTarget);
         auto leafTarget = splitAndAppendTarget(
-            fields, std::get<0>(NLATargets.back()), context);
-        if (NLATargets.size() > 1) {
-          buildNLA(circuit, ++nlaNumber, NLATargets);
+            fields, std::get<0>(nlaTargets.back()), context);
+        if (nlaTargets.size() > 1) {
+          buildNLA(circuit, ++nlaNumber, nlaTargets);
           fields.append("circt.nonlocal",
                         FlatSymbolRefAttr::get(context, *canonTarget));
         }
@@ -1767,12 +1767,12 @@ bool circt::firrtl::scatterCustomAnnotations(
             DictionaryAttr::get(context, fields));
 
         // Annotate instances along the NLA path.
-        for (int i = 0, e = NLATargets.size() - 1; i < e; ++i) {
+        for (int i = 0, e = nlaTargets.size() - 1; i < e; ++i) {
           NamedAttrList fields;
           fields.append("circt.nonlocal",
                         FlatSymbolRefAttr::get(context, *canonTarget));
           fields.append("class", StringAttr::get(context, "circt.nonlocal"));
-          newAnnotations[std::get<0>(NLATargets[i])].push_back(
+          newAnnotations[std::get<0>(nlaTargets[i])].push_back(
               DictionaryAttr::get(context, fields));
         }
       }

--- a/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
@@ -1694,6 +1694,90 @@ bool circt::firrtl::scatterCustomAnnotations(
       continue;
     }
 
+    if (clazz == "sifive.enterprise.grandcentral.ModuleReplacementAnnotation") {
+      auto id = newID();
+      NamedAttrList fields;
+      auto annotationsAttr =
+          tryGetAs<ArrayAttr>(dict, dict, "annotations", loc, clazz);
+      auto circuitAttr =
+          tryGetAs<StringAttr>(dict, dict, "circuit", loc, clazz);
+      auto circuitPackageAttr =
+          tryGetAs<StringAttr>(dict, dict, "circuitPackage", loc, clazz);
+      auto dontTouchesAttr =
+          tryGetAs<ArrayAttr>(dict, dict, "dontTouches", loc, clazz);
+      if (!annotationsAttr || !circuitAttr || !circuitPackageAttr || !dontTouchesAttr)
+        return false;
+      fields.append("class", classAttr);
+      fields.append("id", id);
+      fields.append("annotations", annotationsAttr);
+      fields.append("circuit", circuitAttr);
+      fields.append("circuitPackage", circuitPackageAttr);
+      newAnnotations["~"].push_back(DictionaryAttr::get(context, fields));
+
+      // Add a don't touches for each target in "dontTouches" list
+      for (auto dontTouch: dontTouchesAttr) {
+        StringAttr targetString = dontTouch.dyn_cast<StringAttr>();
+        if (!targetString) {
+          mlir::emitError(loc, "ModuleReplacementAnnotation dontTouches "
+                               "entries must be strings")
+                  .attachNote()
+              << "annotation:" << dict << "\n";
+          return false;
+        }
+        auto canonTarget = canonicalizeTarget(targetString.getValue());
+        if (!canonTarget)
+          return false;
+        auto NLATargets = expandNonLocal(*canonTarget);
+        auto leafTarget = splitAndAppendTarget(
+            fields, std::get<0>(NLATargets.back()), context);
+
+        // Add a don't touch annotation to whatever this annotation targets.
+        addDontTouch(leafTarget.first, leafTarget.second);
+      }
+
+      auto targets = tryGetAs<ArrayAttr>(dict, dict, "targets", loc, clazz);
+      if (!targets)
+        return false;
+      for (auto targetAttr: targets) {
+        auto targetId = newID();
+        NamedAttrList fields;
+        fields.append("class", classAttr);
+        fields.append("id", id);
+        fields.append("targetId", targetId);
+        StringAttr targetString = targetAttr.dyn_cast<StringAttr>();
+        if (!targetString) {
+          mlir::emitError(loc, "ModuleReplacementAnnotation targets "
+                               "entries must be strings")
+                  .attachNote()
+              << "annotation:" << dict << "\n";
+          return false;
+        }
+        auto canonTarget = canonicalizeTarget(targetString.getValue());
+        if (!canonTarget)
+          return false;
+        auto NLATargets = expandNonLocal(*canonTarget);
+        auto leafTarget = splitAndAppendTarget(
+            fields, std::get<0>(NLATargets.back()), context);
+        if (NLATargets.size() > 1) {
+          buildNLA(circuit, ++nlaNumber, NLATargets);
+          fields.append("circt.nonlocal",
+                        FlatSymbolRefAttr::get(context, *canonTarget));
+        }
+        newAnnotations[leafTarget.first].push_back(
+            DictionaryAttr::get(context, fields));
+
+        // Annotate instances along the NLA path.
+        for (int i = 0, e = NLATargets.size() - 1; i < e; ++i) {
+          NamedAttrList fields;
+          fields.append("circt.nonlocal",
+                        FlatSymbolRefAttr::get(context, *canonTarget));
+          fields.append("class", StringAttr::get(context, "circt.nonlocal"));
+          newAnnotations[std::get<0>(NLATargets[i])].push_back(
+              DictionaryAttr::get(context, fields));
+        }
+      }
+    }
+
     // Scatter trackers out from OMIR JSON.
     if (clazz == omirAnnoClass) {
       auto newAnno = scatterOMIRAnnotation(dict, annotationID, newAnnotations,

--- a/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
@@ -1705,7 +1705,8 @@ bool circt::firrtl::scatterCustomAnnotations(
           tryGetAs<StringAttr>(dict, dict, "circuitPackage", loc, clazz);
       auto dontTouchesAttr =
           tryGetAs<ArrayAttr>(dict, dict, "dontTouches", loc, clazz);
-      if (!annotationsAttr || !circuitAttr || !circuitPackageAttr || !dontTouchesAttr)
+      if (!annotationsAttr || !circuitAttr || !circuitPackageAttr ||
+          !dontTouchesAttr)
         return false;
       fields.append("class", classAttr);
       fields.append("id", id);
@@ -1715,11 +1716,12 @@ bool circt::firrtl::scatterCustomAnnotations(
       newAnnotations["~"].push_back(DictionaryAttr::get(context, fields));
 
       // Add a don't touches for each target in "dontTouches" list
-      for (auto dontTouch: dontTouchesAttr) {
+      for (auto dontTouch : dontTouchesAttr) {
         StringAttr targetString = dontTouch.dyn_cast<StringAttr>();
         if (!targetString) {
-          mlir::emitError(loc, "ModuleReplacementAnnotation dontTouches "
-                               "entries must be strings")
+          mlir::emitError(
+              loc,
+              "ModuleReplacementAnnotation dontTouches entries must be strings")
                   .attachNote()
               << "annotation:" << dict << "\n";
           return false;
@@ -1738,16 +1740,14 @@ bool circt::firrtl::scatterCustomAnnotations(
       auto targets = tryGetAs<ArrayAttr>(dict, dict, "targets", loc, clazz);
       if (!targets)
         return false;
-      for (auto targetAttr: targets) {
-        auto targetId = newID();
+      for (auto targetAttr : targets) {
         NamedAttrList fields;
-        fields.append("class", classAttr);
         fields.append("id", id);
-        fields.append("targetId", targetId);
         StringAttr targetString = targetAttr.dyn_cast<StringAttr>();
         if (!targetString) {
-          mlir::emitError(loc, "ModuleReplacementAnnotation targets "
-                               "entries must be strings")
+          mlir::emitError(
+              loc,
+              "ModuleReplacementAnnotation targets entries must be strings")
                   .attachNote()
               << "annotation:" << dict << "\n";
           return false;

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -1114,7 +1114,6 @@ circuit Sub : %[[{
 ; Grand Central's ModuleReplacementAnnotation is properly scattered to the circuit
 ; and the targeted operations.
 
-
 circuit Top : %[[{
   "class": "sifive.enterprise.grandcentral.ModuleReplacementAnnotation",
   "targets": [
@@ -1122,7 +1121,7 @@ circuit Top : %[[{
     "~Top|Top/childWrapper:ChildWrapper/child:Child"
   ],
   "circuit": "",
-  "annotations": [],
+  "annotations": ["foo", "bar"],
   "circuitPackage": "other",
   "dontTouches":[
     "~Top|Child>in",
@@ -1146,10 +1145,10 @@ circuit Top : %[[{
     inst childWrapper of ChildWrapper
 
 ; CHECK-LABEL: firrtl.circuit "Top"
-; CHECK-SAME: {annotations = [], circuit = "", circuitPackage = "other", class = "sifive.enterprise.grandcentral.ModuleReplacementAnnotation", id = [[ID:.+]] : i64}
+; CHECK-SAME: {annotations = ["foo", "bar"], circuit = "", circuitPackage = "other", class = "sifive.enterprise.grandcentral.ModuleReplacementAnnotation", id = [[ID:.+]] : i64}
 
 ; CHECK: %child_in, %child_out = firrtl.instance child
-; CHECK-SAME: {annotations = [{circt.nonlocal = @"~Top|Top/childWrapper:ChildWrapper/child:Child", class = "circt.nonlocal"}]} @Child(in in: !firrtl.uint<123>, out out: !firrtl.uint<456>)
+; CHECK-SAME: {annotations = [{circt.nonlocal = @"~Top|Top/childWrapper:ChildWrapper/child:Child", class = "circt.nonlocal"}]}
 
 ; CHECK: firrtl.extmodule @Child(
 ; CHECK-SAME:   in in: !firrtl.uint<123> [{class = "firrtl.transforms.DontTouchAnnotation"}],

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -1155,6 +1155,6 @@ circuit Top : %[[{
 ; CHECK-SAME:   out out: !firrtl.uint<456> [{class = "firrtl.transforms.DontTouchAnnotation"}]
 ; CHECK-SAME: )
 ; CHECK-SAME: attributes {annotations = [
-; CHECK-SAME:   {circt.nonlocal = @"~Top|Top/child:Child", class = "sifive.enterprise.grandcentral.ModuleReplacementAnnotation", id = [[ID]] : i64, targetId = 1 : i64},
-; CHECK-SAME:   {circt.nonlocal = @"~Top|Top/childWrapper:ChildWrapper/child:Child", class = "sifive.enterprise.grandcentral.ModuleReplacementAnnotation", id = [[ID]] : i64, targetId = 2 : i64}
+; CHECK-SAME:   {circt.nonlocal = @"~Top|Top/child:Child", id = [[ID]] : i64},
+; CHECK-SAME:   {circt.nonlocal = @"~Top|Top/childWrapper:ChildWrapper/child:Child", id = [[ID]] : i64}
 ; CHECK-SAME: ]}

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -1108,3 +1108,54 @@ circuit Sub : %[[{
 ; CHECK-SAME: #firrtl<"subAnno<fieldID = 1, {class = \22sifive.enterprise.grandcentral.SignalDriverAnnotation\22, dir = \22sink\22, id = [[ID]] : i64, peer = \22~Top|Foo>dataIn.a.b.c\22, side = \22local\22, targetId = 6 : i64}>">
 ; CHECK-SAME: #firrtl<"subAnno<fieldID = 2, {class = \22sifive.enterprise.grandcentral.SignalDriverAnnotation\22, dir = \22sink\22, id = [[ID]] : i64, peer = \22~Top|Foo>dataIn.d\22, side = \22local\22, targetId = 7 : i64}>">
 ; CHECK-SAME: #firrtl<"subAnno<fieldID = 3, {class = \22sifive.enterprise.grandcentral.SignalDriverAnnotation\22, dir = \22sink\22, id = [[ID]] : i64, peer = \22~Top|Foo>dataIn.e\22, side = \22local\22, targetId = 8 : i64}>">
+
+; // -----
+
+; Grand Central's ModuleReplacementAnnotation is properly scattered to the circuit
+; and the targeted operations.
+
+
+circuit Top : %[[{
+  "class": "sifive.enterprise.grandcentral.ModuleReplacementAnnotation",
+  "targets": [
+    "~Top|Top/child:Child",
+    "~Top|Top/childWrapper:ChildWrapper/child:Child"
+  ],
+  "circuit": "",
+  "annotations": [],
+  "circuitPackage": "other",
+  "dontTouches":[
+    "~Top|Child>in",
+    "~Top|Child>out"
+  ]
+}]]
+  module ChildWrapper :
+    input in : UInt<123>
+    output out : UInt<456>
+
+    inst child of Child
+    child.in <= in
+    out <= child.out
+
+  extmodule Child :
+    input in : UInt<123>
+    output out : UInt<456>
+
+  module Top :
+    inst child of Child
+    inst childWrapper of ChildWrapper
+
+; CHECK-LABEL: firrtl.circuit "Top"
+; CHECK-SAME: {annotations = [], circuit = "", circuitPackage = "other", class = "sifive.enterprise.grandcentral.ModuleReplacementAnnotation", id = [[ID:.+]] : i64}
+
+; CHECK: %child_in, %child_out = firrtl.instance child
+; CHECK-SAME: {annotations = [{circt.nonlocal = @"~Top|Top/childWrapper:ChildWrapper/child:Child", class = "circt.nonlocal"}]} @Child(in in: !firrtl.uint<123>, out out: !firrtl.uint<456>)
+
+; CHECK: firrtl.extmodule @Child(
+; CHECK-SAME:   in in: !firrtl.uint<123> [{class = "firrtl.transforms.DontTouchAnnotation"}],
+; CHECK-SAME:   out out: !firrtl.uint<456> [{class = "firrtl.transforms.DontTouchAnnotation"}]
+; CHECK-SAME: )
+; CHECK-SAME: attributes {annotations = [
+; CHECK-SAME:   {circt.nonlocal = @"~Top|Top/child:Child", class = "sifive.enterprise.grandcentral.ModuleReplacementAnnotation", id = [[ID]] : i64, targetId = 1 : i64},
+; CHECK-SAME:   {circt.nonlocal = @"~Top|Top/childWrapper:ChildWrapper/child:Child", class = "sifive.enterprise.grandcentral.ModuleReplacementAnnotation", id = [[ID]] : i64, targetId = 2 : i64}
+; CHECK-SAME: ]}


### PR DESCRIPTION
Scatters a `ModuleReplacementAnnotation`.

```json5
{
  "class": "sifive.enterprise.grandcentral.ModuleReplacementAnnotation",

  // the list of intances/modules to replace
  "targets": [
    "~Top|Top/child:Child",
    "~Top|Top/childWrapper:ChildWrapper/child:Child"
  ],

  // the replacement module
  "circuit": "",

  // annotations associated with the replacement module
  "annotations": [],

  // prefix and output sub-directory of the replacement module
  "circuitPackage": "other",

  // dontTouch all the ports of replaced modules
  "dontTouches":[
    "~Top|Child>in",
    "~Top|Child>out"
  ]
}
```

This adds a parent annotation to the circuit, annotates each member of `targets` with an id and the parent id, and adds dontTouches to each entry in `dontTouches`. Mostly copied from `SignalDriverAnnotation`