### PR TITLE
[Handshake] Add interface for specializing port naming

### DIFF
--- a/include/circt/Dialect/Handshake/Handshake.td
+++ b/include/circt/Dialect/Handshake/Handshake.td
@@ -28,7 +28,8 @@ def Handshake_Dialect : Dialect {
 // Base class for Handshake dialect ops.
 class Handshake_Op<string mnemonic, list<OpTrait> traits = []>
     : Op<Handshake_Dialect, mnemonic,
-         traits #[HasParent<"handshake::FuncOp">]> {
+         traits #[HasParent<"handshake::FuncOp">,
+         DeclareOpInterfaceMethods<NamedIOInterface>]> {
 }
 
 include "circt/Dialect/Handshake/HandshakeOps.td"

--- a/include/circt/Dialect/Handshake/HandshakeInterfaces.td
+++ b/include/circt/Dialect/Handshake/HandshakeInterfaces.td
@@ -105,6 +105,30 @@ def MemoryOpInterface : OpInterface<"MemoryOpInterface"> {
   ];
 }
 
+def NamedIOInterface : OpInterface<"NamedIOInterface"> {
+  let description =
+      [{"Provides detailed names for the operands and results of an operation."}];
+
+  let methods = [
+    InterfaceMethod<
+        "Get the name of an operand.",
+        "std::string", "getOperandName", (ins "unsigned" : $idx),
+        "",
+        [{
+          // Return the default name of an operand.
+          return "in" + std::to_string(idx);
+        }]>,
+    InterfaceMethod<
+        "Get the name of a result.",
+        "std::string", "getResultName", (ins "unsigned" : $idx),
+        "",
+        [{
+          // Return the default name of a result.
+          return "out" + std::to_string(idx);
+        }]>
+  ];
+}
+
 def HasClock : NativeOpTrait<"HasClock">;
 
 #endif // HANDSHAKE_OP_INTERFACES

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -272,7 +272,8 @@ def MergeOp : Handshake_Op<"merge", [
 
 def MuxOp : Handshake_Op<"mux", [
   NoSideEffect, MergeLikeOpInterface,
-  DeclareOpInterfaceMethods<ExecutableOpInterface>
+  DeclareOpInterfaceMethods<ExecutableOpInterface>,
+  DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName"]>
 ]> {
   let summary = "mux operation";
   let description = [{

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -59,6 +59,10 @@ bool isReadyToExecute(ArrayRef<mlir::Value> ins, ArrayRef<mlir::Value> outs,
   return true;
 }
 
+static std::string defaultOperandName(unsigned int idx) {
+  return "in" + std::to_string(idx);
+}
+
 // Fetch values from the value map and consume them
 std::vector<llvm::Any>
 fetchValues(ArrayRef<mlir::Value> values,
@@ -231,6 +235,10 @@ void MuxOp::build(OpBuilder &builder, OperationState &result, Value operand,
   // Operands from predecessor blocks
   for (int i = 0, e = inputs; i < e; ++i)
     result.addOperands(operand);
+}
+
+std::string handshake::MuxOp::getOperandName(unsigned int idx) {
+  return idx == 0 ? "select" : defaultOperandName(idx - 1);
 }
 
 bool handshake::MuxOp::tryExecute(

--- a/test/Conversion/HandshakeToFIRRTL/test_naming.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_naming.mlir
@@ -27,3 +27,19 @@ handshake.func @main(%a: index, %b: index, %inCtrl: none, ...) -> (index, none) 
   %0 = arith.addi %a, %b : index
   handshake.return %0, %inCtrl : index, none
 }
+
+
+// -----
+
+// CHECK-LABEL: firrtl.module @handshake_mux_in_ui64_ui64_ui64_out_ui64(
+// CHECK:         in %select: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, 
+// CHECK:         in %in0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, 
+// CHECK:         in %in1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, 
+// CHECK:         out %out0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) {
+
+// CHECK-LABEL: firrtl.module @test_mux(
+// CHECK: %handshake_mux_select, %handshake_mux_in0, %handshake_mux_in1, %handshake_mux_out0 = firrtl.instance handshake_mux  @handshake_mux_in_ui64_ui64_ui64_out_ui64(in select: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in in0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in in1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out out0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>)
+handshake.func @test_mux(%arg0: index, %arg1: index, %arg2: index, %arg3: none, ...) -> (index, none) {
+  %0 = "handshake.mux"(%arg0, %arg1, %arg2): (index, index, index) -> index
+  handshake.return %0, %arg3 : index, none
+}


### PR DESCRIPTION
This commit introduces a new interface `NamedIOInterface` for handshake operations. This interface is intended to capture the naming of the in- and output operands of a handshake operation. The interface implements a default naming convention equal to what's currently being used (in#, out#). However, operations can override this interface to provide more specialized naming, such as the `MuxOp` example used in the commit.

The interface is used in in HandshakeToFIRRTL through a class `PortNameGenerator`. This class handles port name generation for all operands which may be lowered into handshake modules. If the source operand was a handshake operand (which implements the `NamedIOInterface`) the interface is used to generate port names. Else, default names are generated.