### PR TITLE
[FIRRTL/LowerToHW] Reuse random bits in register initialization

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1957,10 +1957,10 @@ void FIRRTLLowering::initializeRegister(Value reg, Value resetSignal) {
   // Construct and return a new reference to `RANDOM.  It is always a 32-bit
   // unsigned expression.  Calls to $random have side effects, so we use
   // VerbatimExprSEOp.
-  constexpr unsigned RANDOM_WIDTH = 32;
+  constexpr unsigned randomWidth = 32;
   auto getRandom32Val = [&]() -> Value {
     return builder.create<sv::VerbatimExprSEOp>(
-        builder.getIntegerType(RANDOM_WIDTH), "`RANDOM");
+        builder.getIntegerType(randomWidth), "`RANDOM");
   };
 
   // Return an expression containing random bits of the specified width.
@@ -1972,7 +1972,7 @@ void FIRRTLLowering::initializeRegister(Value reg, Value resetSignal) {
     if (randomValueAndRemain.second >= type.getWidth()) {
       auto value = builder.createOrFold<comb::ExtractOp>(
           type, randomValueAndRemain.first,
-          RANDOM_WIDTH - randomValueAndRemain.second);
+          randomWidth - randomValueAndRemain.second);
 
       randomValueAndRemain.second -= type.getWidth();
       return value;
@@ -1981,7 +1981,7 @@ void FIRRTLLowering::initializeRegister(Value reg, Value resetSignal) {
     // If nothing remains, produce new 32 bit random value and call it
     // recursively.
     if (randomValueAndRemain.second == 0) {
-      randomValueAndRemain = {getRandom32Val(), RANDOM_WIDTH};
+      randomValueAndRemain = {getRandom32Val(), randomWidth};
       return getRandomValue(type);
     }
 
@@ -1989,8 +1989,8 @@ void FIRRTLLowering::initializeRegister(Value reg, Value resetSignal) {
     auto currentWidth = builder.getIntegerType(randomValueAndRemain.second);
     auto value = builder.createOrFold<comb::ExtractOp>(
         currentWidth, randomValueAndRemain.first,
-        RANDOM_WIDTH - randomValueAndRemain.second);
-    randomValueAndRemain = {getRandom32Val(), RANDOM_WIDTH};
+        randomWidth - randomValueAndRemain.second);
+    randomValueAndRemain = {getRandom32Val(), randomWidth};
     auto rest = getRandomValue(
         builder.getIntegerType(type.getWidth() - currentWidth.getWidth()));
     return builder.createOrFold<comb::ConcatOp>(value, rest);

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1295,6 +1295,10 @@ private:
   /// This is true if we've emitted `INIT_RANDOM_PROLOG_ into an initial
   /// block in this module already.
   bool randomizePrologEmitted;
+
+  /// This is a map from block to a pair of a random value and its unused bits.
+  /// It is used to reduce the number of random value.
+  DenseMap<Block *, std::pair<Value, unsigned>> blockRandomValueAndRemain;
 };
 } // end anonymous namespace
 
@@ -1953,9 +1957,10 @@ void FIRRTLLowering::initializeRegister(Value reg, Value resetSignal) {
   // Construct and return a new reference to `RANDOM.  It is always a 32-bit
   // unsigned expression.  Calls to $random have side effects, so we use
   // VerbatimExprSEOp.
+  constexpr unsigned RANDOM_WIDTH = 32;
   auto getRandom32Val = [&]() -> Value {
-    return builder.create<sv::VerbatimExprSEOp>(builder.getIntegerType(32),
-                                                "`RANDOM");
+    return builder.create<sv::VerbatimExprSEOp>(
+        builder.getIntegerType(RANDOM_WIDTH), "`RANDOM");
   };
 
   // Return an expression containing random bits of the specified width.
@@ -1963,13 +1968,32 @@ void FIRRTLLowering::initializeRegister(Value reg, Value resetSignal) {
   std::function<Value(IntegerType)> getRandomValue =
       [&](IntegerType type) -> Value {
     assert(type.getWidth() != 0 && "zero bit width's not supported");
-    auto rand32 = getRandom32Val();
-    if (type.getWidth() <= 32)
-      return builder.createOrFold<comb::ExtractOp>(type, rand32, 0);
+    auto &randomValueAndRemain = blockRandomValueAndRemain[builder.getBlock()];
+    if (randomValueAndRemain.second >= type.getWidth()) {
+      auto value = builder.createOrFold<comb::ExtractOp>(
+          type, randomValueAndRemain.first,
+          RANDOM_WIDTH - randomValueAndRemain.second);
 
-    // Get the top part.
-    auto rest = getRandomValue(builder.getIntegerType(type.getWidth() - 32));
-    return builder.createOrFold<comb::ConcatOp>(rand32, rest);
+      randomValueAndRemain.second -= type.getWidth();
+      return value;
+    }
+
+    // If nothing remains, produce new 32 bit random value and call it
+    // recursively.
+    if (randomValueAndRemain.second == 0) {
+      randomValueAndRemain = {getRandom32Val(), RANDOM_WIDTH};
+      return getRandomValue(type);
+    }
+
+    // Consume all the bits we have now, and then concat the rest.
+    auto currentWidth = builder.getIntegerType(randomValueAndRemain.second);
+    auto value = builder.createOrFold<comb::ExtractOp>(
+        currentWidth, randomValueAndRemain.first,
+        RANDOM_WIDTH - randomValueAndRemain.second);
+    randomValueAndRemain = {getRandom32Val(), RANDOM_WIDTH};
+    auto rest = getRandomValue(
+        builder.getIntegerType(type.getWidth() - currentWidth.getWidth()));
+    return builder.createOrFold<comb::ConcatOp>(value, rest);
   };
 
   // Get a random value with the specified width, combining or truncating

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1217,4 +1217,41 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %memName_port = firrtl.mem sym @memSym Undefined {depth = 12 : i64, name = "memName", portNames = ["port"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     // CHECK: {{%.+}} = hw.instance "memName" sym @memSym
   }
+
+  // CHECK-LABEL: hw.module @regInitRandomReuse
+  firrtl.module @regInitRandomReuse(in %clock: !firrtl.clock, in %a: !firrtl.uint<1>, out %o1: !firrtl.uint<2>, out %o2: !firrtl.uint<4>, out %o3: !firrtl.uint<32>, out %o4: !firrtl.uint<100>) {
+    %r1 = firrtl.reg %clock  : !firrtl.uint<2>
+    %r2 = firrtl.reg %clock  : !firrtl.uint<4>
+    %r3 = firrtl.reg %clock  : !firrtl.uint<32>
+    %r4 = firrtl.reg %clock  : !firrtl.uint<100>
+    // CHECK:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
+    // CHECK-NEXT:    %RANDOM = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+    // CHECK-NEXT:    %8 = comb.extract %RANDOM from 0 : (i32) -> i2
+    // CHECK-NEXT:    sv.bpassign %r1, %8 : i2
+    // CHECK-NEXT:    %9 = comb.extract %RANDOM from 2 : (i32) -> i4
+    // CHECK-NEXT:    sv.bpassign %r2, %9 : i4
+    // CHECK-NEXT:    %10 = comb.extract %RANDOM from 6 : (i32) -> i26
+    // CHECK-NEXT:    %RANDOM_0 = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+    // CHECK-NEXT:    %11 = comb.extract %RANDOM_0 from 0 : (i32) -> i6
+    // CHECK-NEXT:    %12 = comb.concat %10, %11 : i26, i6
+    // CHECK-NEXT:    sv.bpassign %r3, %12 : i32
+    // CHECK-NEXT:    %13 = comb.extract %RANDOM_0 from 6 : (i32) -> i26
+    // CHECK-NEXT:    %RANDOM_1 = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+    // CHECK-NEXT:    %RANDOM_2 = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+    // CHECK-NEXT:    %RANDOM_3 = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
+    // CHECK-NEXT:    %14 = comb.extract %RANDOM_3 from 0 : (i32) -> i10
+    // CHECK-NEXT:    %15 = comb.concat %RANDOM_2, %14 : i32, i10
+    // CHECK-NEXT:    %16 = comb.concat %RANDOM_1, %15 : i32, i42
+    // CHECK-NEXT:    %17 = comb.concat %13, %16 : i26, i74
+    // CHECK-NEXT:    sv.bpassign %r4, %17 : i100
+    // CHECK-NEXT:  }
+    firrtl.connect %r1, %a : !firrtl.uint<2>, !firrtl.uint<1>
+    firrtl.connect %r2, %a : !firrtl.uint<4>, !firrtl.uint<1>
+    firrtl.connect %r3, %a : !firrtl.uint<32>, !firrtl.uint<1>
+    firrtl.connect %r4, %a : !firrtl.uint<100>, !firrtl.uint<1>
+    firrtl.connect %o1, %r1 : !firrtl.uint<2>, !firrtl.uint<2>
+    firrtl.connect %o2, %r2 : !firrtl.uint<4>, !firrtl.uint<4>
+    firrtl.connect %o3, %r3 : !firrtl.uint<32>, !firrtl.uint<32>
+    firrtl.connect %o4, %r4 : !firrtl.uint<100>, !firrtl.uint<100>
+  }
 }


### PR DESCRIPTION
This PR changes the lowering to track used random bits length and reuse appropriately. 
With this patch, 
```
circuit Foo:
  module Foo:
    input clock: Clock
    input a: UInt<1>
    output o: UInt<138>


    reg r1: UInt<2>, clock
    reg r2: UInt<4>, clock
    reg r3: UInt<32>, clock
    reg r4: UInt<100>, clock

    r1 <= a
    r2 <= a
    r3 <= a
    r4 <= a
    o <= cat(r1, cat(r2, cat(r3, r4)))
```
will be initialized like this:
```verilog
`ifdef RANDOMIZE_REG_INIT // foo.fir:8:5
        _T = `RANDOM;   // foo.fir:8:5
        r1 = _T[1:0];   // foo.fir:8:5
        r2 = _T[5:2];   // foo.fir:9:5
        _T_0 = `RANDOM; // foo.fir:10:5
        r3 = {_T[31:6], _T_0[5:0]};     // foo.fir:10:5
        _T_1 = `RANDOM; // foo.fir:11:5
        r4 = {_T_0[31:6], `RANDOM, `RANDOM, _T_1[9:0]}; // foo.fir:11:5
`endif
```

Will close https://github.com/llvm/circt/issues/2094
