### PR TITLE
[MSFT] Add PhysicalRegion op and related attributes.

### DIFF
--- a/include/circt/Dialect/MSFT/MSFTAttributes.td
+++ b/include/circt/Dialect/MSFT/MSFTAttributes.td
@@ -61,3 +61,30 @@ def PhysLocation : MSFT_Attr<"PhysLocation"> {
     "PrimitiveTypeAttr":$primitiveType,
     "uint64_t":$x, "uint64_t":$y, "uint64_t":$num);
 }
+
+def PhysicalBounds : MSFT_Attr<"PhysicalBounds"> {
+  let summary = "Describes a rectangle bounding a physical region on a device";
+  let mnemonic = "physical_bounds";
+  let parameters = (ins
+    "uint64_t":$xMin,
+    "uint64_t":$xMax,
+    "uint64_t":$yMin,
+    "uint64_t":$yMax
+  );
+}
+
+def PhysicalBoundsArray : TypedArrayAttrBase<PhysicalBounds,
+  "array of PhysicalBounds">;
+
+def PhysicalRegionRef : MSFT_Attr<"PhysicalRegionRef"> {
+  let summary = "Describes a reference to a physical region on a device";
+  let description = [{
+    Annotate a particular entity within an op with the region of the devices
+    on an FPGA to which it should mapped. The physicalRegion must refer to a
+    PhysicalRegion operation.
+  }];
+  let mnemonic = "physical_region_ref";
+  let parameters = (ins
+    "FlatSymbolRefAttr":$physicalRegion
+  );
+}

--- a/include/circt/Dialect/MSFT/MSFTAttributes.td
+++ b/include/circt/Dialect/MSFT/MSFTAttributes.td
@@ -64,6 +64,10 @@ def PhysLocation : MSFT_Attr<"PhysLocation"> {
 
 def PhysicalBounds : MSFT_Attr<"PhysicalBounds"> {
   let summary = "Describes a rectangle bounding a physical region on a device";
+  let description = [{
+    Describes a rectangular bound within a device. The lower and upper bounds
+    must be specified for both the X and Y axis. The bounds are inclusive.
+  }];
   let mnemonic = "physical_bounds";
   let parameters = (ins
     "uint64_t":$xMin,

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -165,3 +165,15 @@ def OutputOp : MSFTOp<"output", [Terminator, HasParent<"MSFTModuleOp">,
 
   let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";
 }
+
+def PhysicalRegionOp : MSFTOp<"physical_region",
+    [Symbol, HasParent<"mlir::ModuleOp">]> {
+  let arguments = (ins
+    SymbolNameAttr:$sym_name,
+    PhysicalBoundsArray:$bounds
+  );
+
+  let assemblyFormat = [{
+    $sym_name `,` $bounds attr-dict
+  }];
+}

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -14,6 +14,7 @@
 #include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/HW/ModuleImplementation.h"
+#include "circt/Dialect/MSFT/MSFTAttributes.h"
 
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"

--- a/test/Dialect/MSFT/attributes.mlir
+++ b/test/Dialect/MSFT/attributes.mlir
@@ -1,0 +1,18 @@
+// RUN: circt-opt %s -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
+
+// CHECK-LABEL: msft.physical_region @region1
+msft.physical_region @region1, [
+  // CHECK-SAME: #msft.physical_bounds<x: [0, 10], y: [0, 10]>
+  #msft.physical_bounds<x: [0, 10], y: [0, 10]>,
+  // CHECK-SAME: #msft.physical_bounds<x: [20, 30], y: [20, 30]>
+  #msft.physical_bounds<x: [20, 30], y: [20, 30]>]
+
+msft.module.extern @ext()
+
+msft.module @mod {} () -> () {
+  msft.instance @inst @ext() {
+    // CHECK: "msft:locate" = #msft.physical_region_ref<@region1>
+    "msft:locate" = #msft.physical_region_ref<@region1>
+  }: () -> ()
+  msft.output
+}


### PR DESCRIPTION
A PhysicalRegion is a Symbol which can be referred to by ops to be
placed within it. It contains potentially multiple rectangular bounds
on the physical device.