### PR TITLE
[ExportVerilog] Query global state to get the updated names

### DIFF
--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1001,8 +1001,9 @@ hw.module @XMR_src(%a : i23) -> (aa: i3) {
 // CHECK-LABEL: module extInst
 hw.module.extern @extInst(%_h: i1, %_i: i1, %_j: i1, %_k: i1, %_z :i0) -> ()
 
-// CHECK-LABEL: module extInst
-hw.module.extern @extInst2(%signed: i1, %_i: i1, %_j: i1, %_k: i1, %_z :i0) -> ()
+// CHECK-LABEL: module extInst2
+// CHECK-NEXT:     input                signed_0, _i, _j, _k
+hw.module @extInst2(%signed: i1, %_i: i1, %_j: i1, %_k: i1, %_z :i0) -> () {}
 
 // CHECK-LABEL: module remoteInstDut
 hw.module @remoteInstDut(%i: i1, %j: i1, %z: i0) -> () {
@@ -1034,7 +1035,7 @@ hw.module @remoteInstDut(%i: i1, %j: i1, %z: i0) -> () {
 // CHECK:  assign signed__k = 1'h1
 // CHECK-NEXT:  /* This instance is elsewhere emitted as a bind statement
 // CHECK-NEXT:    extInst2 signed_2
-// CHECK-NEXT:    .signed (signed_0)
+// CHECK-NEXT:    .signed_0 (signed_0)
 }
 
 hw.module @bindInMod() {
@@ -1051,12 +1052,10 @@ hw.module @bindInMod() {
 // CHECK-NEXT: //._z (z)
 // CHECK-NEXT: );
 // CHECK-NEXT:  bind remoteInstDut extInst2 signed_2 (
-// CHECK-NEXT:    .signed (signed_0),
-// CHECK-NEXT:    ._i     (output_1),
-// CHECK-NEXT:    ._j     (j),
-// CHECK-NEXT:    ._k     (signed__k)
-// CHECK-NEXT:  //._z     (z)
-// CHECK-NEXT:  );
+// CHECK-NEXT:    .signed_0 (signed_0),
+// CHECK-NEXT:    ._i       (output_1),
+// CHECK-NEXT:    ._j       (j),
+// CHECK-NEXT:    ._k       (signed__k)
 // CHECK: endmodule
 
 sv.bind #hw.innerNameRef<@remoteInstDut::@bindInst2>


### PR DESCRIPTION
The commit https://github.com/llvm/circt/commit/fc7d917466db453d3e7a322194977519c4cb5a19, updated the name legalization to properly rename 
all declaration ops `(<WireOp, RegOp, LocalParamOp, InstanceOp>)`, and 
maintain them in the rename map in the global state. 
This means, the ops no longer have the updated names in the IR.

This commit fixes the `ExportVerilog` to query the global symbol table,
 for getting the name of any Declaration op.
This fixes an issue with the `bind` op printing the incorrect old names.


