### PR TITLE
[MSFT] Add Tcl export support for PhysicalRegions.

### DIFF
--- a/include/circt/Dialect/MSFT/DeviceDB.h
+++ b/include/circt/Dialect/MSFT/DeviceDB.h
@@ -80,6 +80,8 @@ public:
   /// Assign an instance to a primitive. Return false if another instance is
   /// already placed at that location.
   LogicalResult addPlacement(PhysLocationAttr, PlacedInstance);
+  /// Assign an operation to a physical region. Return false on failure.
+  LogicalResult addPlacement(PhysicalRegionRefAttr, PlacedInstance);
   /// Using the operation attributes, add the proper placements to the database.
   /// Return the number of placements which weren't added due to conflicts.
   size_t addPlacements(FlatSymbolRefAttr rootMod, mlir::Operation *);
@@ -102,6 +104,10 @@ public:
                           std::make_tuple(-1, -1, -1, -1),
                       Optional<PrimitiveType> primType = {});
 
+  /// Walk the region placement information.
+  void walkRegionPlacements(
+      function_ref<void(PhysicalRegionRefAttr, PlacedInstance)>);
+
 private:
   MLIRContext *ctxt;
   Operation *top;
@@ -110,12 +116,15 @@ private:
   using DimNumMap = DenseMap<size_t, DimDevType>;
   using DimYMap = DenseMap<size_t, DimNumMap>;
   using DimXMap = DenseMap<size_t, DimYMap>;
+  using InstanceAndRegion = std::pair<PhysicalRegionRefAttr, PlacedInstance>;
+  using RegionPlacements = SmallVector<InstanceAndRegion>;
 
   /// Get the leaf node. Abstract this out to make it easier to change the
   /// underlying data structure.
   Optional<PlacedInstance *> getLeaf(PhysLocationAttr);
 
   DimXMap placements;
+  RegionPlacements regionPlacements;
   bool seeded;
 };
 

--- a/lib/Dialect/MSFT/ExportQuartusTcl.cpp
+++ b/lib/Dialect/MSFT/ExportQuartusTcl.cpp
@@ -12,6 +12,7 @@
 
 #include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/HWTypes.h"
 #include "circt/Dialect/MSFT/DeviceDB.h"
 #include "circt/Dialect/MSFT/ExportTcl.h"
 #include "circt/Dialect/MSFT/MSFTAttributes.h"
@@ -57,7 +58,7 @@ void emitInnerRefPart(TclOutputState &s, Operation *op) {
 
   // We append new symbolRefs to the state, so s.symbolRefs.size() is the
   // index of the InnerRefAttr we are about to add.
-  s.os << "{{" << s.symbolRefs.size() << "}}" << '|';
+  s.os << "{{" << s.symbolRefs.size() << "}}";
 
   // At this point, everything is contained within MSFTModuleOps.
   auto mod = op->getParentOfType<MSFTModuleOp>();
@@ -77,13 +78,20 @@ void emitPath(TclOutputState &s, PlacementDB::PlacedInstance inst,
     assert(inst && "path instance must be in symbol cache");
 
     emitInnerRefPart(s, inst);
+    s.os << '|';
   }
 
   // If instance name is specified, add it in between the parent entity path and
   // the child entity path.
   emitInnerRefPart(s, inst.op);
 
-  s.os << inst.subpath << '\n';
+  // Some placements don't require subpaths.
+  if (!inst.subpath.empty()) {
+    s.os << '|';
+    s.os << inst.subpath;
+  }
+
+  s.os << '\n';
 }
 
 /// Emit tcl in the form of:
@@ -113,6 +121,52 @@ static void emit(TclOutputState &s, PlacementDB::PlacedInstance inst,
        << pla.getNum();
 
   // To which entity does this apply?
+  s.os << " -to $parent|";
+  emitPath(s, inst, symCache);
+}
+
+/// Emit tcl in the form of:
+/// set_instance_assignment -name PLACE_REGION "X1 Y1 X20 Y20" -to $parent|a|b|c
+/// set_instance_assignment -name RESERVE_PLACE_REGION OFF -to $parent|a|b|c
+/// set_instance_assignment -name CORE_ONLY_PLACE_REGION ON -to $parent|a|b|c
+/// set_instance_assignment -name REGION_NAME test_region -to $parent|a|b|c
+static void emit(TclOutputState &s, PlacementDB::PlacedInstance inst,
+                 PhysicalRegionRefAttr regionRef, SymbolCache &symCache) {
+  auto topModule = inst.op->getParentOfType<mlir::ModuleOp>();
+  auto physicalRegion =
+      topModule.lookupSymbol<PhysicalRegionOp>(regionRef.getPhysicalRegion());
+  assert(physicalRegion && "must reference an existant physical region");
+
+  // PLACE_REGION directive.
+  s.indent() << "set_instance_assignment -name PLACE_REGION \"";
+  auto physicalBounds =
+      physicalRegion.bounds().getAsRange<PhysicalBoundsAttr>();
+  llvm::interleave(
+      physicalBounds, s.os,
+      [&s](PhysicalBoundsAttr bounds) {
+        s.os << 'X' << bounds.getXMin() << ' ';
+        s.os << 'Y' << bounds.getYMin() << ' ';
+        s.os << 'X' << bounds.getXMax() << ' ';
+        s.os << 'Y' << bounds.getYMax();
+      },
+      ";");
+  s.os << '"';
+  s.os << " -to $parent|";
+  emitPath(s, inst, symCache);
+
+  // RESERVE_PLACE_REGION directive.
+  s.indent() << "set_instance_assignment -name RESERVE_PLACE_REGION OFF";
+  s.os << " -to $parent|";
+  emitPath(s, inst, symCache);
+
+  // CORE_ONLY_PLACE_REGION directive.
+  s.indent() << "set_instance_assignment -name CORE_ONLY_PLACE_REGION ON";
+  s.os << " -to $parent|";
+  emitPath(s, inst, symCache);
+
+  // REGION_NAME directive.
+  s.indent() << "set_instance_assignment -name REGION_NAME ";
+  s.os << physicalRegion.getName();
   s.os << " -to $parent|";
   emitPath(s, inst, symCache);
 }
@@ -154,6 +208,12 @@ LogicalResult circt::msft::exportQuartusTcl(MSFTModuleOp hwMod,
                                         PlacementDB::PlacedInstance inst) {
     emit(state, inst, loc, symCache);
   });
+
+  db.walkRegionPlacements(
+      [&state, &symCache](PhysicalRegionRefAttr regionRef,
+                          PlacementDB::PlacedInstance inst) {
+        emit(state, inst, regionRef, symCache);
+      });
 
   os << "}\n\n";
 

--- a/test/Dialect/MSFT/location.mlir
+++ b/test/Dialect/MSFT/location.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt %s -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
-// RUN: circt-opt %s --lower-msft-to-hw=tops=shallow,deeper | FileCheck %s --check-prefix=LOWER
-// RUN: circt-opt %s --lower-msft-to-hw=tops=shallow,deeper --export-verilog | FileCheck %s --check-prefix=TCL
+// RUN: circt-opt %s --lower-msft-to-hw=tops=shallow,deeper,regions | FileCheck %s --check-prefix=LOWER
+// RUN: circt-opt %s --lower-msft-to-hw=tops=shallow,deeper,regions --export-verilog | FileCheck %s --check-prefix=TCL
 
 hw.module.extern @Foo()
 
@@ -16,6 +16,7 @@ msft.module @leaf {} () -> () {
   } : () -> ()
   // LOWER: sv.verbatim "proc shallow_config
   // LOWER: sv.verbatim "proc deeper_config
+  // LOWER: sv.verbatim "proc regions_config
   msft.output
 }
 
@@ -35,5 +36,21 @@ msft.module @deeper {} () -> () {
   msft.instance @branch @shallow() : () -> ()
   msft.instance @leaf @leaf() : () -> ()
   // TCL: set_location_assignment M20K_X15_Y9_N3 -to $parent|branch|leaf|module_0|memBank2
+  msft.output
+}
+
+msft.physical_region @region1, [
+  #msft.physical_bounds<x: [0, 10], y: [0, 10]>,
+  #msft.physical_bounds<x: [20, 30], y: [20, 30]>]
+
+// TCL-LABEL: proc regions_config
+msft.module @regions {} () -> () {
+  msft.instance @module @Foo() {
+    "msft:loc" = #msft.switch.inst<@regions[]=#msft.physical_region_ref<@region1>>
+  } : () -> ()
+  // TCL: set_instance_assignment -name PLACE_REGION "X0 Y0 X10 Y10;X20 Y20 X30 Y30" -to $parent|module_0
+  // TCL: set_instance_assignment -name RESERVE_PLACE_REGION OFF -to $parent|module_0
+  // TCL: set_instance_assignment -name CORE_ONLY_PLACE_REGION ON -to $parent|module_0
+  // TCL: set_instance_assignment -name REGION_NAME region1 -to $parent|module_0
   msft.output
 }

--- a/test/Dialect/MSFT/translate-errors.mlir
+++ b/test/Dialect/MSFT/translate-errors.mlir
@@ -15,6 +15,17 @@ hw.module.extern @Foo()
 
 // expected-error @+1 {{Could not place 1 instances}}
 msft.module @top {} () -> () {
+  // expected-error @+1 {{'msft.instance' op referenced non-existant PhysicalRegion named region1}}
+  msft.instance @foo1 @Foo() {"loc" = #msft.switch.inst<@top[]=#msft.physical_region_ref<@region1>>} : () -> ()
+  msft.output
+}
+
+// -----
+
+hw.module.extern @Foo()
+
+// expected-error @+1 {{Could not place 1 instances}}
+msft.module @top {} () -> () {
   // expected-error @+1 {{'msft.instance' op PhysLoc attributes must have names starting with 'loc'}}
   msft.instance @foo1 @Foo() {"phys:" = #msft.switch.inst< @top[] = #msft.physloc<DSP, 0, 0, 0> > } : () -> ()
   msft.output


### PR DESCRIPTION
This is a very simple start to Tcl support for PhysicalRegions. For
now physical region references and the PlacedInstances making the
reference are just stored in a vector that can be walked to emit the
necessary Tcl. More complex storage and queries for PhysicalRegions
can be added as the need arises.