### PR TITLE
[PyCDE] [MSFT] Emit modules into separate SV files

### DIFF
--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -39,7 +39,7 @@ class System:
   __slots__ = [
       "mod", "modules", "name", "passed", "_module_symbols", "_symbol_modules",
       "_old_system_token", "_symbols", "_generate_queue", "_primdb",
-      "_output_directory"
+      "_output_directory", "files"
   ]
 
   PASSES = """
@@ -60,6 +60,7 @@ class System:
     self._symbol_modules: dict[str, _SpecializedModule] = {}
     self._symbols: typing.Set[str] = None
     self._generate_queue = []
+    self.files: typing.Set[str] = set()
 
     self._primdb = primdb
 
@@ -113,6 +114,9 @@ class System:
     # Add to the generation queue, if necessary.
     if isinstance(op, circt.dialects.msft.MSFTModuleOp):
       self._generate_queue.append(spec_mod)
+      file_name = spec_mod.modcls.__name__ + ".sv"
+      self.files.add(file_name)
+      op.fileName = ir.StringAttr.get(file_name)
 
   def _get_symbol_module(self, symbol):
     """Get the _SpecializedModule for a symbol."""

--- a/frontends/PyCDE/test/polynomial.py
+++ b/frontends/PyCDE/test/polynomial.py
@@ -1,6 +1,6 @@
 # RUN: rm -rf %t
 # RUN: %PYTHON% %s %t 2>&1 | FileCheck %s
-# RUN: FileCheck %s --input-file %t/PolynomialSystem.sv --check-prefix=OUTPUT
+# RUN: FileCheck %s --input-file %t/PolynomialCompute.sv --check-prefix=OUTPUT
 
 from __future__ import annotations
 
@@ -71,6 +71,8 @@ class CoolPolynomialCompute:
 @externmodule("parameterized_extern")
 def ExternWithParams(a, b):
 
+  typedef1 = types.struct({"a": types.i1}, "exTypedef")
+
   class M:
     pass
 
@@ -116,7 +118,7 @@ poly.generate(iters=1)
 
 print("Printing...")
 poly.print()
-# CHECK-LABEL: msft.module @PolynomialSystem {} () -> (y: i32) {
+# CHECK-LABEL: msft.module @PolynomialSystem {} () -> (y: i32) attributes {fileName = "PolynomialSystem.sv"} {
 # CHECK:         %example.y = msft.instance @example @PolyComputeForCoeff_62_42_6(%c23_i32) : (i32) -> i32
 # CHECK:         %example2.y = msft.instance @example2 @PolyComputeForCoeff_62_42_6(%example.y) : (i32) -> i32
 # CHECK:         %example2_1.y = msft.instance @example2_1 @PolyComputeForCoeff_1_2_3_4_5(%example.y) : (i32) -> i32

--- a/frontends/PyCDE/test/syntactic_sugar.py
+++ b/frontends/PyCDE/test/syntactic_sugar.py
@@ -80,7 +80,7 @@ top.print()
 sys = System([ComplexPorts])
 sys.generate()
 sys.print()
-# CHECK:  msft.module @ComplexPorts {} (%clk: i1, %data_in: !hw.array<3xi32>, %sel: i2, %struct_data_in: !hw.struct<foo: i36>) -> (a: i32, b: i32, c: i32) {
+# CHECK:  msft.module @ComplexPorts {} (%clk: i1, %data_in: !hw.array<3xi32>, %sel: i2, %struct_data_in: !hw.struct<foo: i36>) -> (a: i32, b: i32, c: i32)
 # CHECK:    %c0_i2 = hw.constant 0 : i2
 # CHECK:    [[REG0:%.+]] = hw.array_get %data_in[%c0_i2] {name = "data_in__0"} : !hw.array<3xi32>
 # CHECK:    [[REGR1:%data_in__0__reg1]] = seq.compreg [[REG0]], %clk : i32

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -66,14 +66,17 @@ def MSFTModuleOp : MSFTOp<"module",
   }];
   let arguments = (ins
       StrArrayAttr:$argNames, StrArrayAttr:$resultNames,
-      DictionaryAttr:$parameters);
+      DictionaryAttr:$parameters,
+      OptionalAttr<StrAttr>:$fileName);
   let results = (outs);
   let regions = (region OneOrNoBlocksRegion:$body);
 
   let skipDefaultBuilders = 1;
   let builders = [
     OpBuilder<(ins "StringAttr":$name, "ArrayRef<hw::PortInfo>":$ports,
-                   "ArrayRef<NamedAttribute>":$params)>
+                   "ArrayRef<NamedAttribute>":$params)>,
+    OpBuilder<(ins "StringAttr":$name, "ArrayRef<hw::PortInfo>":$ports,
+                   "ArrayRef<NamedAttribute>":$params, "StringAttr":$fileName)>
   ];
 
   let extraClassDeclaration = [{

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -74,9 +74,7 @@ def MSFTModuleOp : MSFTOp<"module",
   let skipDefaultBuilders = 1;
   let builders = [
     OpBuilder<(ins "StringAttr":$name, "ArrayRef<hw::PortInfo>":$ports,
-                   "ArrayRef<NamedAttribute>":$params)>,
-    OpBuilder<(ins "StringAttr":$name, "ArrayRef<hw::PortInfo>":$ports,
-                   "ArrayRef<NamedAttribute>":$params, "StringAttr":$fileName)>
+                   "ArrayRef<NamedAttribute>":$params)>
   ];
 
   let extraClassDeclaration = [{

--- a/lib/Bindings/Python/circt/dialects/_msft_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_msft_ops_ext.py
@@ -70,6 +70,7 @@ class MSFTModuleOp(_hw_ext.ModuleLike):
       input_ports=[],
       output_ports=[],
       parameters: _ir.DictAttr = None,
+      file_name: str = None,
       loc=None,
       ip=None,
   ):
@@ -78,6 +79,8 @@ class MSFTModuleOp(_hw_ext.ModuleLike):
       attrs["parameters"] = parameters
     else:
       attrs["parameters"] = _ir.DictAttr.get({})
+    if file_name is not None:
+      attrs["fileName"] = _ir.StringAttr.get(file_name)
     super().__init__(name,
                      input_ports,
                      output_ports,

--- a/lib/Dialect/MSFT/MSFTPasses.cpp
+++ b/lib/Dialect/MSFT/MSFTPasses.cpp
@@ -106,9 +106,14 @@ ModuleOpLowering::matchAndRewrite(MSFTModuleOp mod, OpAdaptor adaptor,
   rewriter.inlineRegionBefore(mod.getBody(), hwmod.getBody(),
                               hwmod.getBody().end());
 
-  if (!outputFile.empty()) {
-    auto outputFileAttr =
-        hw::OutputFileAttr::getFromFilename(rewriter.getContext(), outputFile);
+  auto opOutputFile = mod.fileName();
+  if (opOutputFile) {
+    auto outputFileAttr = hw::OutputFileAttr::getFromFilename(
+        rewriter.getContext(), *opOutputFile, false, true);
+    hwmod->setAttr("output_file", outputFileAttr);
+  } else if (!outputFile.empty()) {
+    auto outputFileAttr = hw::OutputFileAttr::getFromFilename(
+        rewriter.getContext(), outputFile, false, true);
     hwmod->setAttr("output_file", outputFileAttr);
   }
 
@@ -140,8 +145,8 @@ LogicalResult ModuleExternOpLowering::matchAndRewrite(
       mod.parameters());
 
   if (!outputFile.empty()) {
-    auto outputFileAttr =
-        hw::OutputFileAttr::getFromFilename(rewriter.getContext(), outputFile);
+    auto outputFileAttr = hw::OutputFileAttr::getFromFilename(
+        rewriter.getContext(), outputFile, false, true);
     hwMod->setAttr("output_file", outputFileAttr);
   }
 

--- a/test/Dialect/MSFT/module_instance.mlir
+++ b/test/Dialect/MSFT/module_instance.mlir
@@ -14,9 +14,9 @@ hw.module @top () {
   // HWLOW: %extern.out = hw.instance "extern" sym @extern @Extern<param: i1 = false>(in: %true: i1) -> (out: i1)
 }
 
-// CHECK-LABEL: msft.module @B {WIDTH = 1 : i64} (%a: i4) -> (nameOfPortInSV: i4) {
-// HWLOW-LABEL: hw.module @B(%a: i4) -> (nameOfPortInSV: i4) {
-msft.module @B { "WIDTH" = 1 } (%a: i4) -> (nameOfPortInSV: i4) {
+// CHECK-LABEL: msft.module @B {WIDTH = 1 : i64} (%a: i4) -> (nameOfPortInSV: i4) attributes {fileName = "b.sv"} {
+// HWLOW-LABEL: hw.module @B(%a: i4) -> (nameOfPortInSV: i4) attributes {output_file = #hw.output_file<"b.sv", includeReplicatedOps>} {
+msft.module @B { "WIDTH" = 1 } (%a: i4) -> (nameOfPortInSV: i4) attributes {fileName = "b.sv"} {
   %0 = comb.add %a, %a : i4
   // CHECK: comb.add %a, %a : i4
   // HWLOW: comb.add %a, %a : i4


### PR DESCRIPTION
Add an attribute to `msft.module` specifying the filename in which the
generated SystemVerilog should be placed. In PyCDE, use the module name
as the output filename.