### PR TITLE
[FIRRTL] Add FlowKind op interface

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-def InstanceOp : FIRRTLOp<"instance", [
+def InstanceOp : FIRRTLOp<"instance", [ResultFlowKind,
     DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
   let summary = "Instantiate an instance of a module";
   let description = [{
@@ -78,6 +78,9 @@ def InstanceOp : FIRRTLOp<"instance", [
     /// Hooks for port annotations.
     ArrayAttr getPortAnnotation(unsigned portIdx);
     void setAllPortAnnotations(ArrayRef<Attribute> annotations);
+
+    /// Get the flow of this operation.
+    FlowResult getFlow(OpResult result);
   }];
 }
 
@@ -106,7 +109,7 @@ def SeqMemOp : FIRRTLOp<"seqmem"> {
   let hasCanonicalizer = true;
 }
 
-def MemoryPortOp : FIRRTLOp<"memoryport", [InferTypeOpInterface,
+def MemoryPortOp : FIRRTLOp<"memoryport", [InferTypeOpInterface, ResultFlowKind,
          DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
   let summary = "Declares a memory port on a memory";
 
@@ -151,6 +154,11 @@ def MemoryPortOp : FIRRTLOp<"memoryport", [InferTypeOpInterface,
                                           DictionaryAttr attrs,
                                           mlir::RegionRange regions,
                                           SmallVectorImpl<Type> &results);
+
+    /// Get the flow of this operation.
+    FlowResult getFlow(OpResult result) {
+      return Flow::Duplex;
+    }
   }];
 }
 
@@ -173,7 +181,7 @@ def MemoryPortAccessOp : FIRRTLOp<"memoryport.access"> {
   }];
 }
 
-def MemOp : FIRRTLOp<"mem"> {
+def MemOp : FIRRTLOp<"mem", [ResultFlowKind]> {
   let summary = "Define a new mem";
   let arguments =
     (ins Confined<I32Attr, [IntMinValue<0>]>:$readLatency,
@@ -254,6 +262,11 @@ def MemOp : FIRRTLOp<"mem"> {
 
     // Extract the relevant attributes from the MemOp and return a FirMemory object.
     FirMemory getSummary();
+
+    /// Get the flow of this operation.
+    FlowResult getFlow(OpResult result) {
+      return Flow::Sink;
+    }
   }];
 }
 
@@ -305,7 +318,7 @@ def NodeOp : FIRRTLOp<"node",
   }];
 }
 
-def RegOp : FIRRTLOp<"reg", [/*MemAlloc*/]> {
+def RegOp : FIRRTLOp<"reg", [ResultFlowKind]> {
   let summary = "Define a new register";
   let description = [{
     Declare a new register:
@@ -335,10 +348,18 @@ def RegOp : FIRRTLOp<"reg", [/*MemAlloc*/]> {
     (`sym` $inner_sym^)?
     operands custom<ImplicitSSAName>(attr-dict) `:` type($result)
   }];
+
+  let extraClassDeclaration = [{
+    /// Get the flow of this operation.
+    FlowResult getFlow(OpResult result) {
+      return Flow::Duplex;
+    }
+  }];
+
   let hasCanonicalizeMethod = true;
 }
 
-def RegResetOp : FIRRTLOp<"regreset", [/*MemAlloc*/]> {
+def RegResetOp : FIRRTLOp<"regreset", [ResultFlowKind]> {
   let summary = "Define a new register with a reset";
   let description = [{
     Declare a new register:
@@ -371,10 +392,17 @@ def RegResetOp : FIRRTLOp<"regreset", [/*MemAlloc*/]> {
     `:` type($resetSignal) `,` type($resetValue) `,` type($result)
   }];
 
+  let extraClassDeclaration = [{
+    /// Get the flow of this operation.
+    FlowResult getFlow(OpResult result) {
+      return Flow::Duplex;
+    }
+  }];
+
   let hasCanonicalizer = true;
 }
 
-def WireOp : FIRRTLOp<"wire", []> {
+def WireOp : FIRRTLOp<"wire", [ResultFlowKind]> {
   let summary = "Define a new wire";
   let description = [{
     Declare a new wire:
@@ -402,5 +430,13 @@ def WireOp : FIRRTLOp<"wire", []> {
     (`sym` $inner_sym^)?
     custom<ImplicitSSAName>(attr-dict) `:` type($result)
   }];
+
+  let extraClassDeclaration = [{
+    /// Get the flow of this operation.
+    FlowResult getFlow(OpResult result) {
+      return Flow::Duplex;
+    }
+  }];
+
   let hasCanonicalizer = true;
 }

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -144,7 +144,7 @@ def InvalidValueOp : FIRRTLOp<"invalidvalue", [NoSideEffect, ConstantLike]> {
   let assemblyFormat = "attr-dict `:` type($result)";
 }
 
-def SubfieldOp : FIRRTLExprOp<"subfield"> {
+def SubfieldOp : FIRRTLExprOp<"subfield", [ResultFlowKind]> {
   let summary = "Extract a subfield of another value";
   let description = [{
     The subfield expression refers to a subelement of an expression with a
@@ -179,6 +179,15 @@ def SubfieldOp : FIRRTLExprOp<"subfield"> {
       return FieldRef(input(), input().getType().cast<BundleType>()
                                       .getFieldID(fieldIndex()));
     }
+
+    /// Get the flow of this operation.
+    FlowResult getFlow(OpResult result) {
+      // The flow of this operation is based on the input. If this is a flipped
+      // field, we are the flip of the parent's flow.
+      if (isFieldFlipped())
+        return FlowResult::flipOf(input());
+      return input();
+    }
   }];
 
   let verifier = "return ::verifySubfieldOp(*this);";
@@ -190,7 +199,7 @@ class IndexConstraint<string value, string resultValue>
                    "firrtl::getVectorElementType($_self)">;
 
 def SubindexOp : FIRRTLExprOp<"subindex", [
-    IndexConstraint<"input", "result">
+    IndexConstraint<"input", "result">, ResultFlowKind
   ]> {
   let summary = "Extract an element of a vector value";
   let description = [{
@@ -216,11 +225,17 @@ def SubindexOp : FIRRTLExprOp<"subindex", [
       return FieldRef(input(), input().getType().cast<FVectorType>()
                                       .getFieldID(index()));
     }
+    
+    /// Get the flow of this operation.
+    FlowResult getFlow(OpResult result) {
+      // The flow of this operation is based on its input.
+      return input();
+    }
   }];
 }
 
 def SubaccessOp : FIRRTLExprOp<"subaccess", [
-    IndexConstraint<"input", "result">
+    IndexConstraint<"input", "result">, ResultFlowKind
   ]> {
   let summary = "Extract a dynamic element of a vector value";
   let description = [{
@@ -237,6 +252,14 @@ def SubaccessOp : FIRRTLExprOp<"subaccess", [
 
   let assemblyFormat =
      "$input `[` $index `]` attr-dict `:` type($input) `,` type($index)";
+  
+  let firrtlExtraClassDeclaration = [{
+    /// Get the flow of this operation.
+    FlowResult getFlow(OpResult result) {
+      // The flow of this operation is based on its input.
+      return input();
+    }
+  }];
 
   let hasCanonicalizeMethod = true;
 }

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -23,6 +23,41 @@ namespace firrtl {
 
 class FIRRTLType;
 
+//===----------------------------------------------------------------------===//
+// FlowKind
+//===----------------------------------------------------------------------===//
+
+enum class Flow { Source, Sink, Duplex };
+
+/// Get a flow's reverse.
+Flow flipFlow(Flow flow);
+
+/// This is used to represent the result of querying the flow of an operation.
+/// If the operation has sink or source flow, this can be implicitly created
+/// from a Flow instance.  If an operation has the same flow as a different
+/// value, presumably one of its arguments, this can be implcitly created from
+/// a Value.  If the operation has the flipped flow of a value, it can signal so
+/// by using `FlowResult::flipOf(value)`.
+struct FlowResult {
+  /*implicit*/ FlowResult(Flow flow) : flow(flow) {}
+  /*implicit*/ FlowResult(Value value) : value(value) {}
+  static FlowResult flipOf(Value value) {
+    return FlowResult(Flow::Sink, value);
+  }
+
+  Flow getFlow() { return flow; }
+  Value getValue() { return value; }
+
+private:
+  FlowResult(Flow flow, Value value) : flow(flow), value(value) {}
+  Flow flow = Flow::Source;
+  Value value;
+};
+
+//===----------------------------------------------------------------------===//
+// FModuleLike
+//===----------------------------------------------------------------------===//
+
 /// This holds the name and type that describes the module's ports.
 struct PortInfo {
   StringAttr name;

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -17,8 +17,6 @@ def FlowKind : OpInterface<"FlowKind"> {
   let description = [{
     Allows operations to specify what kind of flow they have.  When an operation
     does not implement this interface, they are assumed to have "source" flow.
-
-    If an operation has results, they should implement `getFlow`.  If they
   }];
   let methods = [
     InterfaceMethod<"Get the flow of a value",

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -12,6 +12,59 @@
 
 include "mlir/IR/OpBase.td"
 
+def FlowKind : OpInterface<"FlowKind"> {
+  let cppNamespace = "circt::firrtl";
+  let description = [{
+    Allows operations to specify what kind of flow they have.  When an operation
+    does not implement this interface, they are assumed to have "source" flow.
+
+    If an operation has results, they should implement `getFlow`.  If they
+  }];
+  let methods = [
+    InterfaceMethod<"Get the flow of a value",
+    "::circt::firrtl::FlowResult", "getFlow",
+    (ins "::mlir::OpResult":$result),
+    /*methodBody=*/[{
+      // Ask the op implementation what the flow is.
+      return $_op.getFlow(result);
+    }], /*defaultImplementation=*/[{
+      // By default all results arguments are source flow.
+      return ::circt::firrtl::Flow::Source;
+    }]>,
+
+    InterfaceMethod<"Get the flow of a block argument.",
+    "::circt::firrtl::FlowResult", "getBlockArgFlow",
+    (ins "::mlir::BlockArgument":$arg),
+    /*methodBody=*/[{
+      // Ask the op implementation what the flow is.
+      return $_op.getBlockArgFlow(arg);
+    }], /*defaultImplementation=*/[{
+      // By default all block arguments are source flow.
+      return ::circt::firrtl::Flow::Source;
+    }]>
+  ];
+  let extraClassDeclaration = [{
+    /// Compute the flow for a Value, \p val, as determined by the FIRRTL
+    /// specification.  This recursively walks backwards from \p val to the
+    /// declaration.  The resulting flow is a combination of the declaration
+    /// flow (output ports and instance inputs are sinks, registers and wires
+    /// are duplex, anything else is a source) and the number of intermediary
+    /// flips. An even number of flips will result in the same flow as the
+    /// declaration. An odd number of flips will result in reversed flow being
+    /// returned.  The reverse of source is sink.  The reverse of sink is
+    /// source.  The reverse of duplex is duplex.
+    static Flow get(Value value);
+  }];
+}
+
+/// Convenience helper for overriding the result flow kind.
+def ResultFlowKind : OpTraitList<[
+  DeclareOpInterfaceMethods<FlowKind, ["getFlow"]>]>;
+
+/// Convenience helper for overriding the block argument flow kind.
+def ArgumentFlowKind : OpTraitList<[
+  DeclareOpInterfaceMethods<FlowKind, ["getBlockArgumentFlow"]>]>;
+
 def FModuleLike : OpInterface<"FModuleLike"> {
   let cppNamespace = "circt::firrtl";
   let description = "Provide common  module information.";

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -52,6 +52,15 @@ def FlowKind : OpInterface<"FlowKind"> {
     /// returned.  The reverse of source is sink.  The reverse of sink is
     /// source.  The reverse of duplex is duplex.
     static Flow get(Value value);
+
+    /// Check if the computed flow of the value is `Flow::Source`.
+    static bool isSource(Value value);
+
+    /// Check if the computed flow of the value is `Flow::Sink`.
+    static bool isSink(Value value);
+
+    /// Check if the computed flow of the value is `Flow::Duplex`.
+    static bool isDuplex(Value value);
   }];
 }
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -60,8 +60,8 @@ def ResultFlowKind : OpTraitList<[
   DeclareOpInterfaceMethods<FlowKind, ["getFlow"]>]>;
 
 /// Convenience helper for overriding the block argument flow kind.
-def ArgumentFlowKind : OpTraitList<[
-  DeclareOpInterfaceMethods<FlowKind, ["getBlockArgumentFlow"]>]>;
+def BlockArgFlowKind : OpTraitList<[
+  DeclareOpInterfaceMethods<FlowKind, ["getBlockArgFlow"]>]>;
 
 def FModuleLike : OpInterface<"FModuleLike"> {
   let cppNamespace = "circt::firrtl";

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -41,29 +41,6 @@ size_t getNumPorts(Operation *op);
 bool isConstant(Operation *op);
 bool isConstant(Value value);
 
-/// Returns true if the value results from an expression with duplex flow.
-/// Duplex values have special treatment in bundle connect operations, and
-/// their flip orientation is not used to determine the direction of each
-/// pairwise connect.
-bool isDuplexValue(Value val);
-
-enum class Flow { Source, Sink, Duplex };
-
-/// Get a flow's reverse.
-Flow swapFlow(Flow flow);
-
-/// Compute the flow for a Value, \p val, as determined by the FIRRTL
-/// specification.  This recursively walks backwards from \p val to the
-/// declaration.  The resulting flow is a combination of the declaration flow
-/// (output ports and instance inputs are sinks, registers and wires are
-/// duplex, anything else is a source) and the number of intermediary flips.
-/// An even number of flips will result in the same flow as the declaration.
-/// An odd number of flips will result in reversed flow being returned.  The
-/// reverse of source is sink.  The reverse of sink is source.  The reverse of
-/// duplex is duplex.  The \p accumulatedFlow parameter sets the initial flow.
-/// A user should normally \a not have to change this from its default of \p
-/// Flow::Source.
-Flow foldFlow(Value val, Flow accumulatedFlow = Flow::Source);
 
 enum class DeclKind { Port, Instance, Other };
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -53,7 +53,7 @@ def CircuitOp : FIRRTLOp<"circuit",
 
 def FModuleOp : FIRRTLOp<"module", [IsolatedFromAbove, Symbol, SingleBlock,
                                     NoTerminator, HasParent<"CircuitOp">,
-                                    ArgumentFlowKind,
+                                    BlockArgFlowKind,
                                     DeclareOpInterfaceMethods<FModuleLike>]> {
   let summary = "FIRRTL Module";
   let description = [{
@@ -109,7 +109,7 @@ def FModuleOp : FIRRTLOp<"module", [IsolatedFromAbove, Symbol, SingleBlock,
 }
 
 def FExtModuleOp : FIRRTLOp<"extmodule",
-      [IsolatedFromAbove, Symbol, HasParent<"CircuitOp">, ArgumentFlowKind,
+      [IsolatedFromAbove, Symbol, HasParent<"CircuitOp">, BlockArgFlowKind,
        DeclareOpInterfaceMethods<FModuleLike>]> {
   let summary = "FIRRTL extmodule";
   let description = [{

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -53,6 +53,7 @@ def CircuitOp : FIRRTLOp<"circuit",
 
 def FModuleOp : FIRRTLOp<"module", [IsolatedFromAbove, Symbol, SingleBlock,
                                     NoTerminator, HasParent<"CircuitOp">,
+                                    ArgumentFlowKind,
                                     DeclareOpInterfaceMethods<FModuleLike>]> {
   let summary = "FIRRTL Module";
   let description = [{
@@ -98,14 +99,17 @@ def FModuleOp : FIRRTLOp<"module", [IsolatedFromAbove, Symbol, SingleBlock,
     /// Erases the ports listed in `portIndices`.  `portIndices` is expected to
     /// be in order and unique.
     void erasePorts(ArrayRef<unsigned> portIndices);
+
+    /// Get the flow of a block argument.
+    FlowResult getBlockArgFlow(BlockArgument arg);
   }];
 
   let printer = "return ::print$cppClass(p, *this);";
   let parser = "return ::parse$cppClass(parser, result);";
 }
 
-def FExtModuleOp : FIRRTLOp<"extmodule", 
-      [IsolatedFromAbove, Symbol, HasParent<"CircuitOp">,
+def FExtModuleOp : FIRRTLOp<"extmodule",
+      [IsolatedFromAbove, Symbol, HasParent<"CircuitOp">, ArgumentFlowKind,
        DeclareOpInterfaceMethods<FModuleLike>]> {
   let summary = "FIRRTL extmodule";
   let description = [{
@@ -127,7 +131,10 @@ def FExtModuleOp : FIRRTLOp<"extmodule",
                       CArg<"StringRef", "StringRef()">:$defnamAttr,
                       CArg<"ArrayAttr", "ArrayAttr()">:$annotations)>
   ];
-
+  let extraClassDeclaration = [{
+    /// Get the flow of a block argument.
+    FlowResult getBlockArgFlow(BlockArgument arg);
+  }];
   let printer = "return ::print$cppClass(p, *this);";
   let parser = "return ::parse$cppClass(parser, result);";
   let verifier = "return ::verifyFExtModuleOp(*this);";

--- a/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
@@ -73,6 +73,18 @@ Flow FlowKind::get(Value value) {
   return flow;
 }
 
+bool FlowKind::isSource(Value value) {
+  return FlowKind::get(value) == Flow::Source;
+}
+
+bool FlowKind::isSink(Value value) {
+  return FlowKind::get(value) == Flow::Sink;
+}
+
+bool FlowKind::isDuplex(Value value) {
+  return FlowKind::get(value) == Flow::Duplex;
+}
+
 //===----------------------------------------------------------------------===//
 // FModuleLike
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1593,7 +1593,7 @@ static LogicalResult verifyConnectOp(ConnectOp connect) {
 
   // TODO: Relax this to allow reads from output ports,
   // instance/memory input ports.
-  if (FlowKind::get(connect.src()) == Flow::Sink) {
+  if (FlowKind::isSink(connect.src())) {
     // A sink that is a port output or instance input used as a source is okay.
     auto kind = getDeclarationKind(connect.src());
     if (kind != DeclKind::Port && kind != DeclKind::Instance) {
@@ -1607,7 +1607,7 @@ static LogicalResult verifyConnectOp(ConnectOp connect) {
     }
   }
 
-  if (FlowKind::get(connect.dest()) == Flow::Source) {
+  if (FlowKind::isSource(connect.dest())) {
     auto diag = connect.emitOpError()
                 << "has invalid flow: the left-hand-side has source flow "
                    "(expected sink or duplex flow).";
@@ -1628,7 +1628,7 @@ static LogicalResult verifyPartialConnectOp(PartialConnectOp partialConnect) {
            << ". Types are not weakly equivalent.";
 
   // Check that the flows make sense.
-  if (FlowKind::get(partialConnect.src()) == Flow::Sink) {
+  if (FlowKind::isSink(partialConnect.src())) {
     // A sink that is a port output or instance input used as a source is okay.
     auto kind = getDeclarationKind(partialConnect.src());
     if (kind != DeclKind::Port && kind != DeclKind::Instance) {
@@ -1642,7 +1642,7 @@ static LogicalResult verifyPartialConnectOp(PartialConnectOp partialConnect) {
     }
   }
 
-  if (FlowKind::get(partialConnect.dest()) == Flow::Source) {
+  if (FlowKind::isSource(partialConnect.dest())) {
     auto diag = partialConnect.emitOpError()
                 << "has invalid flow: the left-hand-side has source flow "
                    "(expected sink or duplex flow).";

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1478,7 +1478,7 @@ private:
   // implicit connect semantics.  The FIRRTL dialect models it as a primitive
   // that returns an "Invalid Value", followed by an explicit connect to make
   // the representation simpler and more consistent.
-  void emitInvalidate(Value val) { emitInvalidate(val, foldFlow(val)); }
+  void emitInvalidate(Value val) { emitInvalidate(val, FlowKind::get(val)); }
 
   /// Parse an @info marker if present and inform locationProcessor about it.
   ParseResult parseOptionalInfo() {
@@ -1555,7 +1555,7 @@ void FIRStmtParser::emitInvalidate(Value val, Flow flow) {
         for (size_t i = 0, e = tpe.getNumElements(); i < e; ++i) {
           auto subfield = builder.create<SubfieldOp>(val, i);
           emitInvalidate(subfield,
-                         subfield.isFieldFlipped() ? swapFlow(flow) : flow);
+                         subfield.isFieldFlipped() ? flipFlow(flow) : flow);
         }
       })
       .Case<FVectorType>([&](auto tpe) {

--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -148,7 +148,7 @@ public:
         for (auto &element : bundleType.getElements()) {
           id++;
           if (element.isFlip)
-            declare(element.type, swapFlow(flow));
+            declare(element.type, flipFlow(flow));
           else
             declare(element.type, flow);
         }


### PR DESCRIPTION
This is an op interface to calculate the flow of operations. When an
operation has flow other than `Source`, it can implement this interface
to customize its flow kind.

This is helpful because it makes flow checking of the FIRRTL dialect
extensible.  This is needed to be able to move the CHIRRTL operations
into their own dialect without having the FIRRTL dialect depend on the
CHIRRTL dialect, creating a circular dependency.