### PR TITLE
[ExportVerilog] Raise precedence of `>>>` aka signed shr

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1280,7 +1280,7 @@ private:
   SubExprInfo visitComb(ShrSOp op) {
     // >>> is only an arithmetic shift right when both operands are signed.
     // Otherwise it does a logical shift.
-    return emitBinary(op, LowestPrecedence, ">>>",
+    return emitBinary(op, Shift, ">>>",
                       EB_RequireSignedOperands | EB_ForceResultSigned |
                           EB_RHS_UnsignedWithSelfDeterminedWidth);
   }

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -777,7 +777,7 @@ hw.module @ModuleWithLocInfo()  {
 // CHECK-LABEL: module SignedshiftResultSign
 // Issue #1681: https://github.com/llvm/circt/issues/1681
 hw.module @SignedshiftResultSign(%a: i18) -> (b: i18) {
-  // CHECK: assign b = ($signed($signed(a) >>> a[6:0])) ^ 18'hB28;
+  // CHECK: assign b = $signed($signed(a) >>> a[6:0]) ^ 18'hB28;
   %c2856_i18 = hw.constant 2856 : i18
   %c0_i11 = hw.constant 0 : i11
   %0 = comb.extract %a from 0 : (i18) -> i7
@@ -785,6 +785,15 @@ hw.module @SignedshiftResultSign(%a: i18) -> (b: i18) {
   %2 = comb.shrs %a, %1 : i18
   %3 = comb.xor %2, %c2856_i18 : i18
   hw.output %3 : i18
+}
+// CHECK-LABEL: module SignedShiftRightPrecendence
+hw.module @SignedShiftRightPrecendence(%p: i1, %x: i45) -> (o: i45) {
+  // CHECK: assign o = $signed($signed(x) >>> (p ? 45'h5 : 45'h8))
+  %c5_i45 = hw.constant 5 : i45
+  %c8_i45 = hw.constant 8 : i45
+  %0 = comb.mux %p, %c5_i45, %c8_i45 : i45
+  %1 = comb.shrs %x, %0 : i45
+  hw.output %1 : i45
 }
 
 // CHECK-LABEL: module parameters


### PR DESCRIPTION
This raises the precendence of the signed shift operator from the
`LowestPrecedence` to `Shift`.  It was originally `Shift` precedence,
but was changed in #1681. From the issue, it's not clear to me
what the reason for the change was. The current level of precedence is
mismatched from Verilog precedence and is causing brackets to not be
emitted when needed for the `>>>` arguments.

For example, when using a low precedence operator such as the ternary
mux as an argument to the `>>>`, it should surround the mux in
parenthesis.  Currently it is printing:

```verilog
assign o = $signed($signed(x) >>> p ? 45'h5 : 45'h8)
```
When it should be:
```verilog
assign o = $signed($signed(x) >>> (p ? 45'h5 : 45'h8))
```

Changing the precedence does modify one of the test cases to remove an
extra set of surrounding brackets.  I don't know verilog well enough to
be sure that they has no effect.