### PR TITLE
[CI] Fix diff command for clang-tidy

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -326,7 +326,7 @@ jobs:
       - name: clang-tidy
         if: ${{ always() }}
         run: |
-          git diff -U0 $DIFF_COMMIT | \
+          git diff -U0 $DIFF_COMMIT...HEAD | \
             clang-tidy-diff -path build_clang -p1 -fix
           git clang-format $DIFF_COMMIT
           git diff --ignore-submodules > clang-tidy.patch


### PR DESCRIPTION
It seems diff command to apply for clang-tidy was incorrect for PR review and caused some false positive.
Here we need to use three dots instead of two dots.