### PR TITLE
[Handshake] Add support for `handshake.instance` in dot emission

### DIFF
--- a/lib/Dialect/Handshake/Transforms/Analysis.cpp
+++ b/lib/Dialect/Handshake/Transforms/Analysis.cpp
@@ -102,29 +102,29 @@ struct HandshakeOpCountPass
 
     for (auto func : m.getOps<handshake::FuncOp>()) {
       int count = 0;
-      int fork_count = 0;
-      int merge_count = 0;
-      int branch_count = 0;
-      int join_count = 0;
+      int forkCount = 0;
+      int mergeCount = 0;
+      int branchCount = 0;
+      int joinCount = 0;
       for (Operation &op : func.getOps()) {
         if (isa<ForkOp>(op))
-          fork_count++;
+          forkCount++;
         else if (isa<MergeLikeOpInterface>(op))
-          merge_count++;
+          mergeCount++;
         else if (isa<ConditionalBranchOp>(op))
-          branch_count++;
+          branchCount++;
         else if (isa<JoinOp>(op))
-          join_count++;
+          joinCount++;
         else if (!isa<handshake::BranchOp>(op) && !isa<SinkOp>(op) &&
                  !isa<TerminatorOp>(op))
           count++;
       }
 
-      llvm::outs() << "// Fork count: " << fork_count << "\n";
-      llvm::outs() << "// Merge count: " << merge_count << "\n";
-      llvm::outs() << "// Branch count: " << branch_count << "\n";
-      llvm::outs() << "// Join count: " << join_count << "\n";
-      int total = count + fork_count + merge_count + branch_count;
+      llvm::outs() << "// Fork count: " << forkCount << "\n";
+      llvm::outs() << "// Merge count: " << mergeCount << "\n";
+      llvm::outs() << "// Branch count: " << branchCount << "\n";
+      llvm::outs() << "// Join count: " << joinCount << "\n";
+      int total = count + forkCount + mergeCount + branchCount;
       llvm::outs() << "// Total op count: " << total << "\n";
     }
   }
@@ -442,7 +442,7 @@ std::string HandshakeDotPrintPass::dotPrint(mlir::raw_indented_ostream &os,
     if (barg.index() == bodyBlock->getNumArguments() - 1)
       os << ", style=dashed";
     os << "]\n";
-    for (auto useOp : barg.value().getUsers()) {
+    for (auto *useOp : barg.value().getUsers()) {
       os << "" << getLocalName(instanceName, argName) << " -> "
          << getUsedByNode(barg.value(), useOp);
       if (isControlOperand(useOp, barg.value()))

--- a/lib/Dialect/Handshake/Transforms/Analysis.cpp
+++ b/lib/Dialect/Handshake/Transforms/Analysis.cpp
@@ -18,7 +18,9 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/IndentedOstream.h"
 #include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Debug.h"
 
 using namespace circt;
 using namespace handshake;
@@ -29,12 +31,119 @@ static bool isControlOp(Operation *op) {
          op->getAttrOfType<BoolAttr>("control").getValue();
 }
 
-static void dotPrintNode(llvm::raw_fd_ostream &outfile, Operation *op,
-                         DenseMap<Operation *, unsigned> &opIDs) {
-  outfile << "\t\t";
-  outfile << "\"" + op->getName().getStringRef().str() + "_" +
-                 std::to_string(opIDs[op]) + "\"";
-  outfile << " [";
+namespace {
+struct HandshakeDotPrintPass
+    : public HandshakeDotPrintBase<HandshakeDotPrintPass> {
+  void runOnOperation() override {
+    ModuleOp m = getOperation();
+
+    // Resolve the instance graph to get a top-level module.
+    std::string topLevel;
+    handshake::InstanceGraph uses;
+    SmallVector<std::string> sortedFuncs;
+    if (resolveInstanceGraph(m, uses, topLevel, sortedFuncs).failed()) {
+      signalPassFailure();
+      return;
+    }
+
+    handshake::FuncOp topLevelOp =
+        cast<handshake::FuncOp>(m.lookupSymbol(topLevel));
+
+    // Create top-level graph.
+    std::error_code ec;
+    llvm::raw_fd_ostream outfile(topLevel + ".dot", ec);
+    mlir::raw_indented_ostream os(outfile);
+
+    os << "Digraph G {\n";
+    os.indent();
+    os << "splines=spline;\n";
+    dotPrint(os, topLevelOp);
+    os.unindent();
+    os << "}\n";
+    outfile.close();
+  };
+
+private:
+  /// Prints an instance of a handshake.func to the graph. Returns the unique
+  /// name that was assigned to the instance.
+  std::string dotPrint(mlir::raw_indented_ostream &os, handshake::FuncOp f);
+
+  /// Maintain a mapping of module names and the number of times one of those
+  /// modules have been instantiated in the design. This is used to generate
+  /// unique names in the output graph.
+  std::map<std::string, unsigned> instanceIdMap;
+
+  /// A mapping between operations and their unique name in the .dot file.
+  DenseMap<Operation *, std::string> opNameMap;
+
+  /// A mapping between block arguments and their unique name in the .dot file.
+  DenseMap<Value, std::string> argNameMap;
+
+  void setUsedByMapping(Value v, Operation *op, StringRef node);
+  void setProducedByMapping(Value v, Operation *op, StringRef node);
+
+  /// Returns the name of the vertex using 'v' through 'consumer'.
+  std::string getUsedByNode(Value v, Operation *consumer);
+  /// Returns the name of the vertex producing 'v' through 'producer'.
+  std::string getProducedByNode(Value v, Operation *producer);
+
+  /// Maintain mappings between a value, the operation which (uses/produces) it,
+  /// and the node name which the (tail/head) of an edge should refer to. This
+  /// is used to resolve edges across handshake.instance's.
+  // "'value' used by 'operation*' is used by the 'string' vertex"
+  DenseMap<Value, std::map<Operation *, std::string>> usedByMapping;
+  // "'value' produced by 'operation*' is produced from the 'string' vertex"
+  DenseMap<Value, std::map<Operation *, std::string>> producedByMapping;
+};
+
+struct HandshakeOpCountPass
+    : public HandshakeOpCountBase<HandshakeOpCountPass> {
+  void runOnOperation() override {
+    ModuleOp m = getOperation();
+
+    for (auto func : m.getOps<handshake::FuncOp>()) {
+      int count = 0;
+      int fork_count = 0;
+      int merge_count = 0;
+      int branch_count = 0;
+      int join_count = 0;
+      for (Operation &op : func.getOps()) {
+        if (isa<ForkOp>(op))
+          fork_count++;
+        else if (isa<MergeLikeOpInterface>(op))
+          merge_count++;
+        else if (isa<ConditionalBranchOp>(op))
+          branch_count++;
+        else if (isa<JoinOp>(op))
+          join_count++;
+        else if (!isa<handshake::BranchOp>(op) && !isa<SinkOp>(op) &&
+                 !isa<TerminatorOp>(op))
+          count++;
+      }
+
+      llvm::outs() << "// Fork count: " << fork_count << "\n";
+      llvm::outs() << "// Merge count: " << merge_count << "\n";
+      llvm::outs() << "// Branch count: " << branch_count << "\n";
+      llvm::outs() << "// Join count: " << join_count << "\n";
+      int total = count + fork_count + merge_count + branch_count;
+      llvm::outs() << "// Total op count: " << total << "\n";
+    }
+  }
+};
+
+} // namespace
+
+/// Prints an operation to the dot file and returns the unique name for the
+/// operation within the graph.
+static std::string dotPrintNode(mlir::raw_indented_ostream &outfile,
+                                StringRef instanceName, Operation *op,
+                                DenseMap<Operation *, unsigned> &opIDs) {
+  std::string opName =
+      ("\"" + instanceName + "_" + op->getName().getStringRef().str() + "_" +
+       std::to_string(opIDs[op]) + "\"")
+          .str();
+
+  outfile << opName << " [";
 
   /// Fill color
   outfile << "fillcolor = ";
@@ -117,10 +226,10 @@ static void dotPrintNode(llvm::raw_fd_ostream &outfile, Operation *op,
   outfile << ", style=\"filled";
   if (isControlOp(op))
     outfile << ", dashed";
-
   outfile << "\"";
-
   outfile << "]\n";
+
+  return opName;
 }
 
 /// Returns true if v is used as a control operand in op
@@ -135,11 +244,78 @@ static bool isControlOperand(Operation *op, Value v) {
       .Default([](auto) { return false; });
 }
 
-template <typename FuncOp>
-void dotPrint(FuncOp f, StringRef name) {
+static std::string getLocalName(StringRef instanceName, StringRef suffix) {
+  return (instanceName + "_" + suffix).str();
+}
+
+static std::string getArgName(handshake::FuncOp op, unsigned index) {
+  return op.getArgName(index).getValue().str();
+}
+
+static std::string getUniqueArgName(StringRef instanceName,
+                                    handshake::FuncOp op, unsigned index) {
+  return getLocalName(instanceName, getArgName(op, index));
+}
+
+static std::string getResName(handshake::FuncOp op, unsigned index) {
+  return op.getResName(index).getValue().str();
+}
+
+static std::string getUniqueResName(StringRef instanceName,
+                                    handshake::FuncOp op, unsigned index) {
+  return getLocalName(instanceName, getResName(op, index));
+}
+
+void HandshakeDotPrintPass::setUsedByMapping(Value v, Operation *op,
+                                             StringRef node) {
+  usedByMapping[v][op] = node;
+}
+void HandshakeDotPrintPass::setProducedByMapping(Value v, Operation *op,
+                                                 StringRef node) {
+  producedByMapping[v][op] = node;
+}
+
+std::string HandshakeDotPrintPass::getUsedByNode(Value v, Operation *consumer) {
+  // Check if there is any mapping registerred for the value-use relation.
+  auto it = usedByMapping.find(v);
+  if (it != usedByMapping.end()) {
+    auto it2 = it->second.find(consumer);
+    if (it2 != it->second.end())
+      return it2->second;
+  }
+
+  // fallback to the registerred name for the operation
+  auto opNameIt = opNameMap.find(consumer);
+  assert(opNameIt != opNameMap.end() &&
+         "No name registered for the operation!");
+  return opNameIt->second;
+}
+
+std::string HandshakeDotPrintPass::getProducedByNode(Value v,
+                                                     Operation *producer) {
+  // Check if there is any mapping registerred for the value-produce relation.
+  auto it = producedByMapping.find(v);
+  if (it != producedByMapping.end()) {
+    auto it2 = it->second.find(producer);
+    if (it2 != it->second.end())
+      return it2->second;
+  }
+
+  // fallback to the registerred name for the operation
+  auto opNameIt = opNameMap.find(producer);
+  assert(opNameIt != opNameMap.end() &&
+         "No name registered for the operation!");
+  return opNameIt->second;
+}
+
+std::string HandshakeDotPrintPass::dotPrint(mlir::raw_indented_ostream &os,
+                                            handshake::FuncOp f) {
   // Prints DOT representation of the dataflow graph, used for debugging.
   DenseMap<Block *, unsigned> blockIDs;
   DenseMap<Operation *, unsigned> opIDs;
+  auto name = f.getName();
+  unsigned thisId = instanceIdMap[name.str()]++;
+  std::string instanceName = name.str() + std::to_string(thisId);
   unsigned i = 0;
   unsigned j = 0;
 
@@ -149,137 +325,136 @@ void dotPrint(FuncOp f, StringRef name) {
       opIDs[&op] = j++;
   }
 
-  std::error_code ec;
-  llvm::raw_fd_ostream outfile(name.str() + ".dot", ec);
+  os << "// Subgraph for instance of " << name << "\n";
+  os << "subgraph cluster_" << instanceName << " {\n";
+  os.indent();
+  os << "labeljust=\"l\"\n";
+  os << "node [shape=box style=filled fillcolor=\"white\"]\n";
+  os << "color = \"darkgreen\"\n";
+  os << "label = \"" << instanceName << "\"\n";
 
-  outfile << "Digraph G {\n\tsplines=spline;\n";
+  Block *bodyBlock = &f.getBody().front();
 
-  for (Block &block : f) {
-    outfile << "\tsubgraph cluster_" + std::to_string(blockIDs[&block]) +
-                   " {\n";
-    outfile << "\tnode [shape=box style=filled fillcolor=\"white\"]\n";
-    outfile << "\tcolor = \"darkgreen\"\n";
-    outfile << "\t\tlabel = \" block " + std::to_string(blockIDs[&block]) +
-                   "\"\n";
+  /// Print function arg and res nodes.
+  os << "// Function argument nodes\n";
+  os << "subgraph cluster_" << instanceName << "_args {\n";
+  os.indent();
+  // No label or border; the subgraph just forces args to stay together in the
+  // diagram.
+  os << "label=\"\"\n";
+  os << "peripheries=0\n";
+  for (auto barg : enumerate(bodyBlock->getArguments())) {
+    auto argName = getArgName(f, barg.index());
+    os << "\"" << getLocalName(instanceName, argName) << "\" [shape=diamond";
+    if (barg.index() == bodyBlock->getNumArguments() - 1) // ctrl
+      os << ", style=dashed";
+    os << " label=\"" << argName << "\"";
+    os << "]\n";
+  }
+  os.unindent();
+  os << "}\n";
 
-    for (Operation &op : block)
-      dotPrintNode(outfile, &op, opIDs);
+  os << "// Function return nodes\n";
+  os << "subgraph cluster_" << instanceName << "_res {\n";
+  os.indent();
+  // No label or border; the subgraph just forces args to stay together in the
+  // diagram.
+  os << "label=\"\"\n";
+  os << "peripheries=0\n";
+  // Get the return op; a handshake.func always has a terminator, making this
+  // safe.
+  auto returnOp = *f.getBody().getOps<handshake::ReturnOp>().begin();
+  for (auto res : llvm::enumerate(returnOp.getOperands())) {
+    auto resName = getResName(f, res.index());
+    auto uniqueResName = getUniqueResName(instanceName, f, res.index());
+    os << "\"" << uniqueResName << "\" [shape=diamond";
+    if (res.index() == bodyBlock->getNumArguments() - 1) // ctrl
+      os << ", style=dashed";
+    os << " label=\"" << resName << "\"";
+    os << "]\n";
 
-    for (Operation &op : block) {
-      if (op.getNumResults() == 0)
-        continue;
+    // Create a mapping between the return op argument uses and the return
+    // nodes.
+    setUsedByMapping(res.value(), returnOp, uniqueResName);
+  }
+  os.unindent();
+  os << "}\n";
 
-      for (auto result : op.getResults()) {
-        for (auto &u : result.getUses()) {
-          Operation *useOp = u.getOwner();
-          if (useOp->getBlock() == &block) {
-            outfile << "\t\t";
-            outfile << "\"" + op.getName().getStringRef().str() + "_" +
-                           std::to_string(opIDs[&op]) + "\"";
-            outfile << " -> ";
-            outfile << "\"" + useOp->getName().getStringRef().str() + "_" +
-                           std::to_string(opIDs[useOp]) + "\"";
+  /// Print operation nodes.
+  os << "// Function operation nodes\n";
+  for (Operation &op : *bodyBlock) {
+    if (!isa<handshake::InstanceOp, handshake::ReturnOp>(op)) {
+      // Regular node in the diagram.
+      opNameMap[&op] = dotPrintNode(os, instanceName, &op, opIDs);
+      continue;
+    }
+    auto instOp = dyn_cast<handshake::InstanceOp>(op);
+    if (instOp) {
+      // Recurse into instantiated submodule.
+      auto calledFuncOp =
+          instOp->getParentOfType<ModuleOp>().lookupSymbol<handshake::FuncOp>(
+              instOp.getModule());
+      assert(calledFuncOp);
+      auto subInstanceName = dotPrint(os, calledFuncOp);
 
-            if (isControlOp(&op) || isControlOperand(useOp, result))
-              outfile << " [style=\"dashed\"]\n";
-
-            outfile << "\n";
-          }
-        }
+      // Create a mapping between the instance arguments and the arguments to
+      // the module which it instantiated.
+      for (auto arg : llvm::enumerate(instOp.getOperands())) {
+        setUsedByMapping(
+            arg.value(), instOp,
+            getUniqueArgName(subInstanceName, calledFuncOp, arg.index()));
+      }
+      // Create a  mapping between the instance results and the results from the
+      // module which it instantiated.
+      for (auto res : llvm::enumerate(instOp.getResults())) {
+        setProducedByMapping(
+            res.value(), instOp,
+            getUniqueResName(subInstanceName, calledFuncOp, res.index()));
       }
     }
+  }
 
-    /// Annotate block argument uses
-    for (auto barg : enumerate(block.getArguments())) {
-      std::string argName = "arg" + std::to_string(barg.index());
-      outfile << "\t\"" << argName << "\" [shape=diamond";
-      if (barg.index() == block.getNumArguments() - 1)
-        outfile << ", style=dashed";
-      outfile << "]\n";
-      for (auto useOp : barg.value().getUsers()) {
-        outfile << argName << " -> \""
-                << useOp->getName().getStringRef().str() + "_" +
-                       std::to_string(opIDs[useOp]) + "\"";
-        if (isControlOperand(useOp, barg.value()))
-          outfile << " [style=\"dashed\"]";
-        outfile << "\n";
-      }
-    }
+  /// Print operation result edges.
+  os << "// Operation result edges\n";
+  for (Operation &op : *bodyBlock) {
+    for (auto result : op.getResults()) {
+      for (auto &u : result.getUses()) {
+        Operation *useOp = u.getOwner();
+        if (useOp->getBlock() == bodyBlock) {
+          os << getProducedByNode(result, &op);
+          os << " -> ";
+          os << getUsedByNode(result, useOp);
+          if (isControlOp(&op) || isControlOperand(useOp, result))
+            os << " [style=\"dashed\"]";
 
-    outfile << "\t}\n";
-
-    for (Operation &op : block) {
-      if (op.getNumResults() == 0)
-        continue;
-
-      for (auto result : op.getResults()) {
-        for (auto &u : result.getUses()) {
-          Operation *useOp = u.getOwner();
-          if (useOp->getBlock() != &block) {
-            outfile << "\t\t";
-            outfile << "\"" + op.getName().getStringRef().str() + "_" +
-                           std::to_string(opIDs[&op]) + "\"";
-            outfile << " -> ";
-            outfile << "\"" + useOp->getName().getStringRef().str() + "_" +
-                           std::to_string(opIDs[useOp]) + "\"";
-            outfile << " [minlen = 3]\n";
-          }
+          os << "\n";
         }
       }
     }
   }
 
-  outfile << "\t}\n";
-  outfile.close();
+  os << "}\n";
+
+  /// Print edges for function argument uses.
+  os << "// Function argument edges\n";
+  for (auto barg : enumerate(bodyBlock->getArguments())) {
+    auto argName = getArgName(f, barg.index());
+    os << "\"" << getLocalName(instanceName, argName) << "\" [shape=diamond";
+    if (barg.index() == bodyBlock->getNumArguments() - 1)
+      os << ", style=dashed";
+    os << "]\n";
+    for (auto useOp : barg.value().getUsers()) {
+      os << "" << getLocalName(instanceName, argName) << " -> "
+         << getUsedByNode(barg.value(), useOp);
+      if (isControlOperand(useOp, barg.value()))
+        os << " [style=\"dashed\"]";
+      os << "\n";
+    }
+  }
+
+  os.unindent();
+  return instanceName;
 }
-
-namespace {
-struct HandshakeDotPrintPass
-    : public HandshakeDotPrintBase<HandshakeDotPrintPass> {
-  void runOnOperation() override {
-    ModuleOp m = getOperation();
-
-    for (auto func : m.getOps<handshake::FuncOp>())
-      dotPrint(func, func.getName());
-  };
-};
-
-struct HandshakeOpCountPass
-    : public HandshakeOpCountBase<HandshakeOpCountPass> {
-  void runOnOperation() override {
-    ModuleOp m = getOperation();
-
-    for (auto func : m.getOps<handshake::FuncOp>()) {
-      int count = 0;
-      int fork_count = 0;
-      int merge_count = 0;
-      int branch_count = 0;
-      int join_count = 0;
-      for (Operation &op : func.getOps()) {
-        if (isa<ForkOp>(op))
-          fork_count++;
-        else if (isa<MergeLikeOpInterface>(op))
-          merge_count++;
-        else if (isa<ConditionalBranchOp>(op))
-          branch_count++;
-        else if (isa<JoinOp>(op))
-          join_count++;
-        else if (!isa<handshake::BranchOp>(op) && !isa<SinkOp>(op) &&
-                 !isa<TerminatorOp>(op))
-          count++;
-      }
-
-      llvm::outs() << "// Fork count: " << fork_count << "\n";
-      llvm::outs() << "// Merge count: " << merge_count << "\n";
-      llvm::outs() << "// Branch count: " << branch_count << "\n";
-      llvm::outs() << "// Join count: " << join_count << "\n";
-      int total = count + fork_count + merge_count + branch_count;
-      llvm::outs() << "// Total op count: " << total << "\n";
-    }
-  }
-};
-
-} // namespace
 
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
 circt::handshake::createHandshakeDotPrintPass() {

--- a/lib/Dialect/Handshake/Transforms/Analysis.cpp
+++ b/lib/Dialect/Handshake/Transforms/Analysis.cpp
@@ -20,7 +20,6 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Support/IndentedOstream.h"
 #include "llvm/ADT/TypeSwitch.h"
-#include "llvm/Support/Debug.h"
 
 using namespace circt;
 using namespace handshake;


### PR DESCRIPTION
This commit improves on the dot graph generation by supporting nested modules. This is done by maintaining state about variable use/def chains across `handshake.instance` operations, and resolving these to generate graph edges.
Furthermore, graph writing is cleaned up quite a bit.

```mlir
module  {
  handshake.func @baz(%arg0: i32, %arg1: none, ...) -> (i32, none) attributes {argNames = ["a", "ctrl"], resNames = ["out0", "outCtrl"]} {
    %0 = "handshake.buffer"(%arg0) {control = false, sequential = true, slots = 2 : i32} : (i32) -> i32
    %1 = arith.addi %arg0, %0 : i32
    %2 = "handshake.buffer"(%1) {control = false, sequential = true, slots = 2 : i32} : (i32) -> i32
    %3 = "handshake.buffer"(%arg1) {control = true, sequential = true, slots = 2 : i32} : (none) -> none
    handshake.return %2, %3 : i32, none
  }
  handshake.func @bar(%arg0: i32, %arg1: none, ...) -> (i32, none) attributes {argNames = ["a", "ctrl"], resNames = ["out0", "outCtrl"]} {
    %0 = "handshake.buffer"(%arg0) {control = false, sequential = true, slots = 2 : i32} : (i32) -> i32
    %1:2 = handshake.instance @baz(%0, %arg1) : (i32, none) -> (i32, none)
    %2 = "handshake.buffer"(%1#1) {control = true, sequential = true, slots = 2 : i32} : (none) -> none
    "handshake.sink"(%2) {control = true} : (none) -> ()
    %3 = "handshake.buffer"(%1#0) {control = false, sequential = true, slots = 2 : i32} : (i32) -> i32
    %4 = "handshake.buffer"(%arg1) {control = true, sequential = true, slots = 2 : i32} : (none) -> none
    handshake.return %3, %4 : i32, none
  }
  handshake.func @instance(%arg0: i32, %arg1: none, ...) -> (i32, none) attributes {argNames = ["a", "ctrl"], resNames = ["out0", "outCtrl"]} {
    %0 = "handshake.buffer"(%arg0) {control = false, sequential = true, slots = 2 : i32} : (i32) -> i32
    %1:2 = handshake.instance @bar(%0, %arg1) : (i32, none) -> (i32, none)
    %2 = "handshake.buffer"(%1#1) {control = true, sequential = true, slots = 2 : i32} : (none) -> none
    "handshake.sink"(%2) {control = true} : (none) -> ()
    %3 = "handshake.buffer"(%1#0) {control = false, sequential = true, slots = 2 : i32} : (i32) -> i32
    %4 = "handshake.buffer"(%arg1) {control = true, sequential = true, slots = 2 : i32} : (none) -> none
    handshake.return %3, %4 : i32, none
  }
}
```

plots as:

![image](https://user-images.githubusercontent.com/16338943/141508805-00cf1868-7efd-4775-ac50-9fbedc25f100.png)
