### PR TITLE
[FIRRTL] Use inner names to make OMIR output stable under renaming

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -61,7 +61,7 @@ private:
   void emitValue(Attribute node, llvm::json::OStream &jsonStream);
   void emitTrackedTarget(DictionaryAttr node, llvm::json::OStream &jsonStream);
 
-  SmallString<8> addSymbol(FlatSymbolRefAttr symbol) {
+  SmallString<8> addSymbolImpl(Attribute symbol) {
     unsigned id;
     auto it = symbolIndices.find(symbol);
     if (it != symbolIndices.end()) {
@@ -75,11 +75,37 @@ private:
     ("{{" + Twine(id) + "}}").toVector(str);
     return str;
   }
+  SmallString<8> addSymbol(hw::InnerRefAttr symbol) {
+    return addSymbolImpl(symbol);
+  }
+  SmallString<8> addSymbol(FlatSymbolRefAttr symbol) {
+    return addSymbolImpl(symbol);
+  }
   SmallString<8> addSymbol(StringAttr symbolName) {
     return addSymbol(FlatSymbolRefAttr::get(symbolName));
   }
   SmallString<8> addSymbol(Operation *op) {
     return addSymbol(SymbolTable::getSymbolName(op));
+  }
+
+  /// Returns an operation's `inner_sym`, adding one if necessary.
+  StringAttr getOrAddInnerSym(Operation *op);
+  /// Returns a port's `inner_sym`, adding one if necessary.
+  StringAttr getOrAddInnerSym(FModuleLike module, size_t portIdx);
+  /// Obtain an inner reference to an operation, possibly adding an `inner_sym`
+  /// to that operation.
+  hw::InnerRefAttr getInnerRefTo(Operation *op);
+  /// Obtain an inner reference to a module port, possibly adding an `inner_sym`
+  /// to that port.
+  hw::InnerRefAttr getInnerRefTo(FModuleLike module, size_t portIdx);
+
+  /// Get the cached namespace for a module.
+  ModuleNamespace &getModuleNamespace(FModuleLike module) {
+    auto it = moduleNamespaces.find(module);
+    if (it != moduleNamespaces.end())
+      return it->second;
+    return moduleNamespaces.insert({module, ModuleNamespace(module)})
+        .first->second;
   }
 
   /// Whether any errors have occurred in the current `runOnOperation`.
@@ -97,6 +123,7 @@ private:
   SmallDenseMap<Attribute, unsigned> symbolIndices;
   /// Temporary `firrtl.nla` operations to be deleted at the end of the pass.
   SmallVector<NonLocalAnchor> removeTempNLAs;
+  DenseMap<Operation *, ModuleNamespace> moduleNamespaces;
 };
 } // namespace
 
@@ -145,6 +172,7 @@ void EmitOMIRPass::runOnOperation() {
   symbols.clear();
   symbolIndices.clear();
   removeTempNLAs.clear();
+  moduleNamespaces.clear();
   CircuitOp circuitOp = getOperation();
 
   // Gather the relevant annotations from the circuit. On the one hand these are
@@ -500,7 +528,7 @@ void EmitOMIRPass::emitOptionalRTLPorts(DictionaryAttr node,
     jsonStream.attribute("info", buf);
     jsonStream.attribute("name", "ports");
     jsonStream.attributeArray("value", [&] {
-      for (auto &port : module.getPorts()) {
+      for (auto port : llvm::enumerate(module.getPorts())) {
         jsonStream.object([&] {
           // Emit the `ref` field.
           buf.assign("OMDontTouchedReferenceTarget:~");
@@ -508,18 +536,17 @@ void EmitOMIRPass::emitOptionalRTLPorts(DictionaryAttr node,
           buf.push_back('|');
           buf.append(addSymbol(module));
           buf.push_back('>');
-          // TODO: This should really use a symbol on the port.
-          buf.append(port.name.getValue());
+          buf.append(addSymbol(getInnerRefTo(module, port.index())));
           jsonStream.attribute("ref", buf);
 
           // Emit the `direction` field.
           buf.assign("OMString:");
-          buf.append(port.isOutput() ? "Output" : "Input");
+          buf.append(port.value().isOutput() ? "Output" : "Input");
           jsonStream.attribute("direction", buf);
 
           // Emit the `width` field.
           buf.assign("OMBigInt:");
-          Twine(port.type.getBitWidthOrSentinel()).toVector(buf);
+          Twine(port.value().type.getBitWidthOrSentinel()).toVector(buf);
           jsonStream.attribute("width", buf);
         });
       }
@@ -664,7 +691,7 @@ void EmitOMIRPass::emitTrackedTarget(DictionaryAttr node,
   // Serialize the local or non-local module/instance hierarchy path.
   if (tracker.nla) {
     bool notFirst = false;
-    StringAttr instName;
+    hw::InnerRefAttr instName;
     for (auto modAndName : llvm::zip(tracker.nla.modpath().getValue(),
                                      tracker.nla.namepath().getValue())) {
       auto symAttr = std::get<0>(modAndName).cast<FlatSymbolRefAttr>();
@@ -675,22 +702,22 @@ void EmitOMIRPass::emitTrackedTarget(DictionaryAttr node,
         target.push_back('/');
       notFirst = true;
       if (instName) {
-        // TODO: This should *really* drop a symbol to represent the instance
-        // name. See below.
-        target.append(instName.getValue());
+        target.append(addSymbol(instName));
         target.push_back(':');
       }
       target.append(addSymbol(module));
-      instName = nameAttr;
 
-      // Find an instance with the given name in this module.
+      // Find an instance with the given name in this module. Ensure it has a
+      // symbol that we can refer to.
+      instName = {};
       module->walk([&](InstanceOp instOp) {
-        if (instOp.nameAttr() == nameAttr) {
-          LLVM_DEBUG(llvm::dbgs()
-                     << "Marking NLA-participating instance " << nameAttr
-                     << " in module " << symAttr << " as dont-touch\n");
-          AnnotationSet::addDontTouch(instOp);
-        }
+        if (instOp.nameAttr() != nameAttr)
+          return;
+        LLVM_DEBUG(llvm::dbgs()
+                   << "Marking NLA-participating instance " << nameAttr
+                   << " in module " << symAttr << " as dont-touch\n");
+        AnnotationSet::addDontTouch(instOp);
+        instName = getInnerRefTo(instOp);
       });
     }
   } else {
@@ -703,21 +730,18 @@ void EmitOMIRPass::emitTrackedTarget(DictionaryAttr node,
 
   // Serialize any potential component *inside* the module that this target may
   // specifically refer to.
-  StringRef componentName;
+  hw::InnerRefAttr componentName;
   if (isa<WireOp, RegOp, RegResetOp, InstanceOp, NodeOp, MemOp>(tracker.op)) {
-    // TODO: This should *really* drop a symbol placeholder into the JSON. But
-    // we currently don't have any symbols for these FIRRTL ops. May be solved
-    // through NLAs.
-    componentName = tracker.op->getAttrOfType<StringAttr>("name").getValue();
+    componentName = getInnerRefTo(tracker.op);
     AnnotationSet::addDontTouch(tracker.op);
-    LLVM_DEBUG(llvm::dbgs() << "Marking OMIR-targeted `" << componentName
-                            << "` as dont-touch\n");
+    LLVM_DEBUG(llvm::dbgs() << "Marking OMIR-targeted " << componentName
+                            << " as dont-touch\n");
   } else if (!isa<FModuleOp>(tracker.op)) {
     tracker.op->emitError("invalid target for `") << type << "` OMIR";
     anyFailures = true;
     return jsonStream.value("<error>");
   }
-  if (!componentName.empty()) {
+  if (componentName) {
     // Check if the targeted component is going to be emitted as an instance.
     // This is trivially the case for `InstanceOp`s, but also for `MemOp`s that
     // get converted to an instance during lowering to HW dialect and generator
@@ -726,25 +750,58 @@ void EmitOMIRPass::emitTrackedTarget(DictionaryAttr node,
       if (type == "OMMemberInstanceTarget") {
         if (auto instOp = dyn_cast<InstanceOp>(tracker.op)) {
           target.push_back('/');
-          target.append(instOp.name());
+          target.append(addSymbol(componentName));
           target.push_back(':');
           target.append(addSymbol(instOp.moduleNameAttr()));
           return;
         }
         if (auto memOp = dyn_cast<MemOp>(tracker.op)) {
           target.push_back('/');
-          target.append(memOp.name());
+          target.append(addSymbol(componentName));
           target.push_back(':');
           target.append(memOp.getSummary().getFirMemoryName());
           return;
         }
       }
       target.push_back('>');
-      target.append(componentName);
+      target.append(addSymbol(componentName));
     }();
   }
 
   jsonStream.value(target);
+}
+
+StringAttr EmitOMIRPass::getOrAddInnerSym(Operation *op) {
+  auto attr = op->getAttrOfType<StringAttr>("inner_sym");
+  if (attr)
+    return attr;
+  auto module = op->getParentOfType<FModuleOp>();
+  auto name = getModuleNamespace(module).newName("omir_sym");
+  attr = StringAttr::get(op->getContext(), name);
+  op->setAttr("inner_sym", attr);
+  return attr;
+}
+
+StringAttr EmitOMIRPass::getOrAddInnerSym(FModuleLike module, size_t portIdx) {
+  auto attr = module.getPortSymbolAttr(portIdx);
+  if (attr && !attr.getValue().empty())
+    return attr;
+  auto name = getModuleNamespace(module).newName("omir_sym");
+  attr = StringAttr::get(module.getContext(), name);
+  module.setPortSymbolAttr(portIdx, attr);
+  return attr;
+}
+
+hw::InnerRefAttr EmitOMIRPass::getInnerRefTo(Operation *op) {
+  return hw::InnerRefAttr::get(
+      SymbolTable::getSymbolName(op->getParentOfType<FModuleOp>()),
+      getOrAddInnerSym(op));
+}
+
+hw::InnerRefAttr EmitOMIRPass::getInnerRefTo(FModuleLike module,
+                                             size_t portIdx) {
+  return hw::InnerRefAttr::get(SymbolTable::getSymbolName(module),
+                               getOrAddInnerSym(module, portIdx));
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/FIRRTL/SFCTests/emit-omir.fir
+++ b/test/Dialect/FIRRTL/SFCTests/emit-omir.fir
@@ -41,7 +41,7 @@ circuit Foo : %[[
         "id": "OMID:2",
         "fields": [
           {"info": "", "name": "omType", "value": ["OMString:OMLazyModule", "OMString:OMSRAM"]},
-          {"info": "", "name": "finalPath", "value": "OMMemberInstanceTarget:~Foo|Bar>mem1"}
+          {"info": "", "name": "finalPath", "value": "OMMemberInstanceTarget:~Foo|Bar>longint"}
         ]
       },
       {
@@ -49,7 +49,7 @@ circuit Foo : %[[
         "id": "OMID:3",
         "fields": [
           {"info": "", "name": "omType", "value": ["OMString:OMLazyModule", "OMString:OMSRAM"]},
-          {"info": "", "name": "finalPath", "value": "OMMemberReferenceTarget:~Foo|Bar>mem2"}
+          {"info": "", "name": "finalPath", "value": "OMMemberReferenceTarget:~Foo|Bar>shortint"}
         ]
       },
       {
@@ -65,20 +65,20 @@ circuit Foo : %[[
   extmodule MySRAM:
     defname = MySRAM
   module Foo :
-    input x : UInt<17>
-    output y : UInt<19>
-    inst bar of Bar
-    y <= x
+    input unsigned : UInt<17>
+    output signed : UInt<19>
+    inst parameter of Bar
+    signed <= unsigned
   module Bar :
-    inst mem1 of MySRAM
-    mem mem2 :
+    inst longint of MySRAM
+    mem shortint :
         data-type => UInt<42>
         depth => 8
         read-latency => 0
         write-latency => 1
         reader => port
         read-under-write => undefined
-    mem2.port is invalid
+    shortint.port is invalid
 
 ; CHECK-LABEL: FILE "omir.json"
 
@@ -120,11 +120,11 @@ circuit Foo : %[[
 
 ; CHECK:       "id": "OMID:2"
 ; CHECK:       "name": "finalPath"
-; CHECK-NEXT:  "value": "OMMemberInstanceTarget:~Foo|Foo/bar:Bar/mem1:MySRAM"
+; CHECK-NEXT:  "value": "OMMemberInstanceTarget:~Foo|Foo/parameter_2:Bar/longint_0:MySRAM"
 
 ; CHECK:       "id": "OMID:3"
 ; CHECK:       "name": "finalPath"
-; CHECK-NEXT:  "value": "OMMemberInstanceTarget:~Foo|Foo/bar:Bar/mem2:FIRRTLMem_{{[^"]+}}"
+; CHECK-NEXT:  "value": "OMMemberInstanceTarget:~Foo|Foo/parameter_2:Bar/shortint_1:FIRRTLMem_{{[^"]+}}"
 
 ; CHECK:       "id": "OMID:4"
 ; CHECK:       "name": "containingModule"
@@ -132,12 +132,12 @@ circuit Foo : %[[
 ; CHECK:       "name": "ports"
 ; CHECK-NEXT:  "value": [
 ; CHECK-NEXT:    {
-; CHECK-NEXT:      "ref": "OMDontTouchedReferenceTarget:~Foo|Foo>x",
+; CHECK-NEXT:      "ref": "OMDontTouchedReferenceTarget:~Foo|Foo>unsigned_0",
 ; CHECK-NEXT:      "direction": "OMString:Input",
 ; CHECK-NEXT:      "width": "OMBigInt:17"
 ; CHECK-NEXT:    }
 ; CHECK-NEXT:    {
-; CHECK-NEXT:      "ref": "OMDontTouchedReferenceTarget:~Foo|Foo>y",
+; CHECK-NEXT:      "ref": "OMDontTouchedReferenceTarget:~Foo|Foo>signed_1",
 ; CHECK-NEXT:      "direction": "OMString:Output",
 ; CHECK-NEXT:      "width": "OMBigInt:19"
 ; CHECK-NEXT:    }

--- a/test/Dialect/FIRRTL/emit-omir.mlir
+++ b/test/Dialect/FIRRTL/emit-omir.mlir
@@ -168,23 +168,29 @@ firrtl.circuit "LocalTrackers" attributes {annotations = [{
 }
 // CHECK-LABEL: firrtl.circuit "LocalTrackers" {
 // CHECK-NEXT:    firrtl.module @A() {
-// CHECK-NEXT:      %c = firrtl.wire {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<42>
+// CHECK-NEXT:      %c = firrtl.wire sym [[SYMC:@[a-zA-Z0-9_]+]] {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<42>
 // CHECK-NEXT:    }
 // CHECK-NEXT:    firrtl.module @LocalTrackers() {
-// CHECK-NEXT:      firrtl.instance a {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} @A()
-// CHECK-NEXT:      %b = firrtl.wire {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<42>
+// CHECK-NEXT:      firrtl.instance a sym [[SYMA:@[a-zA-Z0-9_]+]] {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} @A()
+// CHECK-NEXT:      %b = firrtl.wire sym [[SYMB:@[a-zA-Z0-9_]+]] {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<42>
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
 // CHECK-NEXT:  sv.verbatim
 // CHECK-SAME:  \22name\22: \22OMReferenceTarget1\22
 // CHECK-SAME:  \22value\22: \22OMReferenceTarget:~LocalTrackers|{{[{][{]0[}][}]}}\22
 // CHECK-SAME:  \22name\22: \22OMReferenceTarget2\22
-// CHECK-SAME:  \22value\22: \22OMReferenceTarget:~LocalTrackers|{{[{][{]0[}][}]}}>c\22
+// CHECK-SAME:  \22value\22: \22OMReferenceTarget:~LocalTrackers|{{[{][{]0[}][}]}}>{{[{][{]1[}][}]}}\22
 // CHECK-SAME:  \22name\22: \22OMReferenceTarget3\22
-// CHECK-SAME:  \22value\22: \22OMReferenceTarget:~LocalTrackers|{{[{][{]1[}][}]}}>b\22
+// CHECK-SAME:  \22value\22: \22OMReferenceTarget:~LocalTrackers|{{[{][{]2[}][}]}}>{{[{][{]3[}][}]}}\22
 // CHECK-SAME:  \22name\22: \22OMReferenceTarget4\22
-// CHECK-SAME:  \22value\22: \22OMReferenceTarget:~LocalTrackers|{{[{][{]1[}][}]}}>a\22
-// CHECK-SAME:  symbols = [@A, @LocalTrackers]
+// CHECK-SAME:  \22value\22: \22OMReferenceTarget:~LocalTrackers|{{[{][{]2[}][}]}}>{{[{][{]4[}][}]}}\22
+// CHECK-SAME:  symbols = [
+// CHECK-SAME:    @A,
+// CHECK-SAME:    #hw.innerNameRef<@A::[[SYMC:@[a-zA-Z0-9_]+]]>,
+// CHECK-SAME:    @LocalTrackers,
+// CHECK-SAME:    #hw.innerNameRef<@LocalTrackers::[[SYMB:@[a-zA-Z0-9_]+]]>,
+// CHECK-SAME:    #hw.innerNameRef<@LocalTrackers::[[SYMA:@[a-zA-Z0-9_]+]]>
+// CHECK-SAME:  ]
 
 //===----------------------------------------------------------------------===//
 // Trackers as Non-Local Annotations
@@ -206,10 +212,18 @@ firrtl.circuit "NonLocalTrackers" attributes {annotations = [{
   }
 }
 // CHECK-LABEL: firrtl.circuit "NonLocalTrackers"
+// CHECK:       firrtl.instance a sym [[SYMA:@[a-zA-Z0-9_]+]]
+// CHECK:       firrtl.instance b sym [[SYMB:@[a-zA-Z0-9_]+]]
 // CHECK:       sv.verbatim
 // CHECK-SAME:  \22name\22: \22OMReferenceTarget1\22
-// CHECK-SAME:  \22value\22: \22OMReferenceTarget:~NonLocalTrackers|{{[{][{]0[}][}]}}/b:{{[{][{]1[}][}]}}/a:{{[{][{]2[}][}]}}\22
-// CHECK-SAME:  symbols = [@NonLocalTrackers, @B, @A]
+// CHECK-SAME:  \22value\22: \22OMReferenceTarget:~NonLocalTrackers|{{[{][{]0[}][}]}}/{{[{][{]1[}][}]}}:{{[{][{]2[}][}]}}/{{[{][{]3[}][}]}}:{{[{][{]4[}][}]}}\22
+// CHECK-SAME:  symbols = [
+// CHECK-SAME:    @NonLocalTrackers,
+// CHECK-SAME:    #hw.innerNameRef<@NonLocalTrackers::[[SYMB:@[a-zA-Z0-9_]+]]>,
+// CHECK-SAME:    @B,
+// CHECK-SAME:    #hw.innerNameRef<@B::[[SYMA:@[a-zA-Z0-9_]+]]>,
+// CHECK-SAME:    @A
+// CHECK-SAME:  ]
 
 //===----------------------------------------------------------------------===//
 // Targets that are allowed to lose their tracker
@@ -275,16 +289,16 @@ firrtl.circuit "SRAMPaths" attributes {annotations = [{
 // CHECK-LABEL: firrtl.circuit "SRAMPaths" {
 // CHECK-NEXT:    firrtl.extmodule @MySRAM()
 // CHECK-NEXT:    firrtl.module @Submodule() {
-// CHECK-NEXT:      firrtl.instance mem1
+// CHECK-NEXT:      firrtl.instance mem1 sym [[SYMMEM1:@[a-zA-Z0-9_]+]]
 // CHECK-SAME:        {class = "firrtl.transforms.DontTouchAnnotation"}
 // CHECK-SAME:        @MySRAM()
-// CHECK-NEXT:      firrtl.mem
+// CHECK-NEXT:      firrtl.mem sym [[SYMMEM2:@[a-zA-Z0-9_]+]]
 // CHECK-SAME:        {class = "firrtl.transforms.DontTouchAnnotation"}
 // CHECK-SAME:        name = "mem2"
 // CHECK-SAME:        : !firrtl.bundle
 // CHECK-NEXT:    }
 // CHECK-NEXT:    firrtl.module @SRAMPaths() {
-// CHECK-NEXT:      firrtl.instance sub
+// CHECK-NEXT:      firrtl.instance sub sym [[SYMSUB:@[a-zA-Z0-9_]+]]
 // CHECK-NOT:         circt.nonlocal
 // CHECK-SAME:        {class = "firrtl.transforms.DontTouchAnnotation"}
 // CHECK-SAME:        @Submodule()
@@ -299,7 +313,7 @@ firrtl.circuit "SRAMPaths" attributes {annotations = [{
 // CHECK-SAME:      \22OMString:OMSRAM\22
 // CHECK-SAME:    ]
 // CHECK-SAME:    \22name\22: \22finalPath\22
-// CHECK-SAME:    \22value\22: \22OMMemberInstanceTarget:~SRAMPaths|{{[{][{]0[}][}]}}/sub:{{[{][{]1[}][}]}}/mem1:{{[{][{]2[}][}]}}\22
+// CHECK-SAME:    \22value\22: \22OMMemberInstanceTarget:~SRAMPaths|{{[{][{]0[}][}]}}/{{[{][{]1[}][}]}}:{{[{][{]2[}][}]}}/{{[{][{]3[}][}]}}:{{[{][{]4[}][}]}}\22
 
 // CHECK-SAME:  \22id\22: \22OMID:1\22
 // CHECK-SAME:    \22name\22: \22omType\22
@@ -308,9 +322,16 @@ firrtl.circuit "SRAMPaths" attributes {annotations = [{
 // CHECK-SAME:      \22OMString:OMSRAM\22
 // CHECK-SAME:    ]
 // CHECK-SAME:    \22name\22: \22finalPath\22
-// CHECK-SAME:    \22value\22: \22OMMemberInstanceTarget:~SRAMPaths|{{[{][{]0[}][}]}}/sub:{{[{][{]1[}][}]}}/mem2:FIRRTLMem_{{[^\\]+}}\22
+// CHECK-SAME:    \22value\22: \22OMMemberInstanceTarget:~SRAMPaths|{{[{][{]0[}][}]}}/{{[{][{]1[}][}]}}:{{[{][{]2[}][}]}}/{{[{][{]5[}][}]}}:FIRRTLMem_{{[^\\]+}}\22
 
-// CHECK-SAME:  symbols = [@SRAMPaths, @Submodule, @MySRAM]
+// CHECK-SAME:  symbols = [
+// CHECK-SAME:    @SRAMPaths,
+// CHECK-SAME:    #hw.innerNameRef<@SRAMPaths::[[SYMSUB:@[a-zA-Z0-9_]+]]>,
+// CHECK-SAME:    @Submodule,
+// CHECK-SAME:    #hw.innerNameRef<@Submodule::[[SYMMEM1:@[a-zA-Z0-9_]+]]>,
+// CHECK-SAME:    @MySRAM,
+// CHECK-SAME:    #hw.innerNameRef<@Submodule::[[SYMMEM2:@[a-zA-Z0-9_]+]]>
+// CHECK-SAME:  ]
 
 //===----------------------------------------------------------------------===//
 // Add module port information to the OMIR (`SetOMIRPorts`)
@@ -359,6 +380,10 @@ firrtl.circuit "AddPorts" attributes {annotations = [{
   }
 }
 // CHECK-LABEL: firrtl.circuit "AddPorts"
+// CHECK:       firrtl.module @AddPorts
+// CHECK-SAME:    in %x: !firrtl.uint<17> sym [[SYMX:@[a-zA-Z0-9_]+]]
+// CHECK-SAME:    out %y: !firrtl.uint<19> sym [[SYMY:@[a-zA-Z0-9_]+]]
+// CHECK:       %w = firrtl.wire sym [[SYMW:@[a-zA-Z0-9_]+]]
 // CHECK:       sv.verbatim
 
 // CHECK-SAME:  \22id\22: \22OMID:0\22
@@ -367,12 +392,12 @@ firrtl.circuit "AddPorts" attributes {annotations = [{
 // CHECK-SAME:    \22name\22: \22ports\22
 // CHECK-SAME:    \22value\22: [
 // CHECK-SAME:      {
-// CHECK-SAME:        \22ref\22: \22OMDontTouchedReferenceTarget:~AddPorts|{{[{][{]0[}][}]}}>x\22
+// CHECK-SAME:        \22ref\22: \22OMDontTouchedReferenceTarget:~AddPorts|{{[{][{]0[}][}]}}>{{[{][{]1[}][}]}}\22
 // CHECK-SAME:        \22direction\22: \22OMString:Input\22
 // CHECK-SAME:        \22width\22: \22OMBigInt:17\22
 // CHECK-SAME:      }
 // CHECK-SAME:      {
-// CHECK-SAME:        \22ref\22: \22OMDontTouchedReferenceTarget:~AddPorts|{{[{][{]0[}][}]}}>y\22
+// CHECK-SAME:        \22ref\22: \22OMDontTouchedReferenceTarget:~AddPorts|{{[{][{]0[}][}]}}>{{[{][{]2[}][}]}}\22
 // CHECK-SAME:        \22direction\22: \22OMString:Output\22
 // CHECK-SAME:        \22width\22: \22OMBigInt:19\22
 // CHECK-SAME:      }
@@ -380,19 +405,24 @@ firrtl.circuit "AddPorts" attributes {annotations = [{
 
 // CHECK-SAME:  \22id\22: \22OMID:1\22
 // CHECK-SAME:    \22name\22: \22containingModule\22
-// CHECK-SAME:    \22value\22: \22OMReferenceTarget:~AddPorts|{{[{][{]0[}][}]}}>w\22
+// CHECK-SAME:    \22value\22: \22OMReferenceTarget:~AddPorts|{{[{][{]0[}][}]}}>{{[{][{]3[}][}]}}\22
 // CHECK-SAME:    \22name\22: \22ports\22
 // CHECK-SAME:    \22value\22: [
 // CHECK-SAME:      {
-// CHECK-SAME:        \22ref\22: \22OMDontTouchedReferenceTarget:~AddPorts|{{[{][{]0[}][}]}}>x\22
+// CHECK-SAME:        \22ref\22: \22OMDontTouchedReferenceTarget:~AddPorts|{{[{][{]0[}][}]}}>{{[{][{]1[}][}]}}\22
 // CHECK-SAME:        \22direction\22: \22OMString:Input\22
 // CHECK-SAME:        \22width\22: \22OMBigInt:17\22
 // CHECK-SAME:      }
 // CHECK-SAME:      {
-// CHECK-SAME:        \22ref\22: \22OMDontTouchedReferenceTarget:~AddPorts|{{[{][{]0[}][}]}}>y\22
+// CHECK-SAME:        \22ref\22: \22OMDontTouchedReferenceTarget:~AddPorts|{{[{][{]0[}][}]}}>{{[{][{]2[}][}]}}\22
 // CHECK-SAME:        \22direction\22: \22OMString:Output\22
 // CHECK-SAME:        \22width\22: \22OMBigInt:19\22
 // CHECK-SAME:      }
 // CHECK-SAME:    ]
 
-// CHECK-SAME:  symbols = [@AddPorts]
+// CHECK-SAME:  symbols = [
+// CHECK-SAME:    @AddPorts,
+// CHECK-SAME:    #hw.innerNameRef<@AddPorts::[[SYMX]]>,
+// CHECK-SAME:    #hw.innerNameRef<@AddPorts::[[SYMY]]>,
+// CHECK-SAME:    #hw.innerNameRef<@AddPorts::[[SYMW]]>
+// CHECK-SAME:  ]


### PR DESCRIPTION
Emit `InnerRefAttr`s for the instances, ports, and declarations the OMIR emitter has to include in its output. This prevents the emitter from having to hardcode these names, and leaves symbolic placeholders which are filled in at the last moment by `ExportVerilog`.

### Todo
- [x] Land #2165
- [x] Land #2166
