### PR TITLE
[HW] [ExportVerilog] Implement `hw.name`

### DIFF
--- a/include/circt/Dialect/HW/HWMiscOps.td
+++ b/include/circt/Dialect/HW/HWMiscOps.td
@@ -87,3 +87,13 @@ def ParamValueOp : HWOp<"param.value",
   let verifier = "return ::verifyParamValueOp(*this);";
   let hasFolder = true;
 }
+
+def NameOp : HWOp<"name", []> {
+  let summary =
+    "Assign a name hint to a value which is optionally used in outputs.";
+
+  let arguments = (ins AnyType:$input, StrAttr:$name);
+  let assemblyFormat = [{
+    $input $name attr-dict `:` type($input)
+  }];
+}

--- a/include/circt/Dialect/HW/HWVisitors.h
+++ b/include/circt/Dialect/HW/HWVisitors.h
@@ -32,7 +32,7 @@ public:
                        ArraySliceOp, ArrayCreateOp, ArrayConcatOp, ArrayGetOp,
                        // Struct operations
                        StructCreateOp, StructExtractOp, StructInjectOp,
-                       // Cast operation
+                       // Misc operations
                        BitcastOp, ParamValueOp>([&](auto expr) -> ResultType {
           return thisCast->visitTypeOp(expr, args...);
         })
@@ -80,9 +80,10 @@ public:
   ResultType dispatchStmtVisitor(Operation *op, ExtraArgs... args) {
     auto *thisCast = static_cast<ConcreteType *>(this);
     return TypeSwitch<Operation *, ResultType>(op)
-        .template Case<OutputOp, InstanceOp>([&](auto expr) -> ResultType {
-          return thisCast->visitStmt(expr, args...);
-        })
+        .template Case<OutputOp, InstanceOp, NameOp>(
+            [&](auto expr) -> ResultType {
+              return thisCast->visitStmt(expr, args...);
+            })
         .Default([&](auto expr) -> ResultType {
           return thisCast->visitInvalidStmt(op, args...);
         });
@@ -119,6 +120,7 @@ public:
   // Basic nodes.
   HANDLE(OutputOp, Unhandled);
   HANDLE(InstanceOp, Unhandled);
+  HANDLE(NameOp, Unhandled);
 #undef HANDLE
 };
 

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -2020,7 +2020,7 @@ static bool isExpressionEmittedInline(Operation *op) {
   // `hasOneUse()` check, so run it only if that check fails.
   auto hasOneNonHwNameUse = [op]() {
     size_t nonHwNameUserCount = 0;
-    for (auto user : op->getResult(0).getUsers())
+    for (auto *user : op->getResult(0).getUsers())
       if (!isa<NameOp>(user))
         nonHwNameUserCount++;
     return nonHwNameUserCount == 1;

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -78,6 +78,10 @@ hw.module @TESTSIMPLE(%a: i4, %b: i4, %c: i2, %cond: i1,
   %41 = hw.struct_create (%c, %a) : !hw.struct<foo: i2, bar: i4>
   %42 = hw.struct_inject %41["bar"], %b : !hw.struct<foo: i2, bar: i4>
 
+
+  hw.name %41 "structfoobar" : !hw.struct<foo: i2, bar: i4>
+  hw.name %42 "shouldBeInlined" : !hw.struct<foo: i2, bar: i4>
+
   hw.output %0, %2, %4, %6, %7, %8, %9, %10, %11, %12, %13, %14,
               %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27,
               %28, %29, %30, %31, %33, %34, %35, %36, %37, %38, %40, %42 :
@@ -111,7 +115,7 @@ hw.module @TESTSIMPLE(%a: i4, %b: i4, %c: i2, %cond: i1,
 // CHECK-EMPTY:
 // CHECK-NEXT:   wire [8:0][3:0] [[WIRE0:.+]] = {{[{}][{}]}}4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}};
 // CHECK-NEXT:   wire [2:0][3:0] [[WIRE1:.+]] = {{[{}][{}]}}4'hF}, {a + b}, {4'hF}};
-// CHECK-NEXT:   wire struct packed {logic [1:0] foo; logic [3:0] bar; } [[WIRE2:.+]] = '{foo: c, bar: a};
+// CHECK-NEXT:   wire struct packed {logic [1:0] foo; logic [3:0] bar; } structfoobar = '{foo: c, bar: a};
 // CHECK-NEXT:   assign r0 = a + b;
 // CHECK-NEXT:   assign r2 = a - b;
 // CHECK-NEXT:   assign r4 = a * b;
@@ -148,7 +152,7 @@ hw.module @TESTSIMPLE(%a: i4, %b: i4, %c: i2, %cond: i1,
 // CHECK-NEXT:   assign r37 = array2d[a][b];
 // CHECK-NEXT:   assign r38 = {[[WIRE1]], [[WIRE1]]};
 // CHECK-NEXT:   assign r40 = '{foo: structA.foo, bar: a};
-// CHECK-NEXT:   assign r41 = '{foo: _T_1.foo, bar: b};
+// CHECK-NEXT:   assign r41 = '{foo: structfoobar.foo, bar: b};
 // CHECK-NEXT: endmodule
 
 

--- a/test/Dialect/HW/basic.mlir
+++ b/test/Dialect/HW/basic.mlir
@@ -92,8 +92,10 @@ hw.module @test1(%arg0: i3, %arg1: i1, %arg2: !hw.array<1000xi8>) -> (result: i5
   // CHECK-NEXT: :2 = hw.struct_explode [[STR]] : !hw.struct<foo: i19, bar: i7>
   %se:2 = hw.struct_explode %s0 : !hw.struct<foo: i19, bar: i7>
 
-  // CHECK-NEXT: hw.bitcast [[STR]] : (!hw.struct<foo: i19, bar: i7>)
+  // CHECK-NEXT: [[STRBITS:%.+]] = hw.bitcast [[STR]] : (!hw.struct<foo: i19, bar: i7>)
   %structBits = hw.bitcast %s0 : (!hw.struct<foo: i19, bar: i7>) -> i26
+  // CHECK-NEXT: hw.name [[STRBITS]] "bitcastedStruct" : i26
+  hw.name %structBits "bitcastedStruct" : i26
 
   // CHECK-NEXT: = arith.constant 13 : i10
   %idx = arith.constant 13 : i10


### PR DESCRIPTION
Implements the `hw.name` op, which assigns a name hint to a value. Closes #1752.