### PR TITLE
[PyCDE] Add entry method for PhysicalRegions and their references.

### DIFF
--- a/frontends/PyCDE/src/pycde/devicedb.py
+++ b/frontends/PyCDE/src/pycde/devicedb.py
@@ -39,11 +39,23 @@ class PhysLocation:
 
 
 class PhysicalRegion:
+  _counter = 0
+  _used_names = set([])
+
   __slots__ = ["_physical_region"]
 
-  def __init__(self, name: str, bounds: list = None):
+  def __init__(self, name: str = None, bounds: list = None):
+    if name is None or name in PhysicalRegion._used_names:
+      prefix = name if name is not None else "region"
+      name = f"{prefix}_{PhysicalRegion._counter}"
+      while name in PhysicalRegion._used_names:
+        PhysicalRegion._counter += 1
+        name = f"{prefix}_{PhysicalRegion._counter}"
+    PhysicalRegion._used_names.add(name)
+
     if bounds is None:
       bounds = []
+
     name_attr = StringAttr.get(name)
     bounds_attr = ArrayAttr.get(bounds)
     self._physical_region = msft.PhysicalRegionOp(name_attr, bounds_attr)

--- a/frontends/PyCDE/src/pycde/devicedb.py
+++ b/frontends/PyCDE/src/pycde/devicedb.py
@@ -7,6 +7,8 @@ import typing
 
 from circt.dialects import msft
 
+from mlir.ir import StringAttr, ArrayAttr
+
 PrimitiveType = msft.PrimitiveType
 
 
@@ -34,6 +36,37 @@ class PhysLocation:
   def __str__(self) -> str:
     loc = self._loc
     return f"PhysLocation<{loc.devtype}, x:{loc.x}, y:{loc.y}, num:{loc.num}>"
+
+
+class PhysicalRegion:
+  __slots__ = ["_physical_region"]
+
+  def __init__(self, name: str, bounds: list = None):
+    if bounds is None:
+      bounds = []
+    name_attr = StringAttr.get(name)
+    bounds_attr = ArrayAttr.get(bounds)
+    self._physical_region = msft.PhysicalRegionOp(name_attr, bounds_attr)
+
+  def add_bounds(self, x_bounds: tuple, y_bounds: tuple):
+    """Add a new bounding box to the region."""
+    if (len(x_bounds) != 2):
+      raise ValueError(f"expected lower and upper x bounds, got: {x_bounds}")
+    if (len(y_bounds) != 2):
+      raise ValueError(f"expected lower and upper y bounds, got: {y_bounds}")
+
+    x_min, x_max = x_bounds
+    y_min, y_max = y_bounds
+    bounds = msft.PhysicalBoundsAttr.get(x_min, x_max, y_min, y_max)
+
+    self._physical_region.add_bounds(bounds)
+
+    return self
+
+  def get_ref(self):
+    """Get a pair suitable for add_attribute to attach to an operation."""
+    name = self._physical_region.sym_name.value
+    return ("loc", msft.PhysicalRegionRefAttr.get(name))
 
 
 class PrimitiveDB:

--- a/frontends/PyCDE/src/pycde/instance.py
+++ b/frontends/PyCDE/src/pycde/instance.py
@@ -99,12 +99,13 @@ class Instance:
   def _attach_attribute(self, attr_key: str, attr: ir.Attribute):
     if isinstance(attr, PhysLocation):
       assert attr_key.startswith("loc:")
-      db = self.root_instance.placedb._db
       attr = attr._loc
-      rc = db.add_placement(attr, self.path_attr, attr_key[4:],
-                            self.instOp.operation)
-      if not rc:
-        raise ValueError("Failed to place")
+
+    db = self.root_instance.placedb._db
+    rc = db.add_placement(attr, self.path_attr, attr_key[4:],
+                          self.instOp.operation)
+    if not rc:
+      raise ValueError("Failed to place")
 
     if attr_key not in self.instOp.attributes:
       cases = []

--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -4,7 +4,7 @@
 
 import builtins
 
-from pycde.devicedb import PrimitiveDB
+from pycde.devicedb import PrimitiveDB, PhysicalRegion
 
 from .module import _SpecializedModule
 from .pycde_types import types
@@ -97,6 +97,11 @@ class System:
       ret = basename + "_" + str(ctr)
     self.symbols[ret] = None
     return ret
+
+  def create_physical_region(self, name):
+    with self._get_ip():
+      physical_region = PhysicalRegion(name)
+    return physical_region
 
   def _create_circt_mod(self, spec_mod: _SpecializedModule, create_cb):
     """Wrapper for a callback (which actually builds the CIRCT op) which

--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -98,7 +98,7 @@ class System:
     self.symbols[ret] = None
     return ret
 
-  def create_physical_region(self, name):
+  def create_physical_region(self, name: str = None):
     with self._get_ip():
       physical_region = PhysicalRegion(name)
     return physical_region

--- a/frontends/PyCDE/test/instances.py
+++ b/frontends/PyCDE/test/instances.py
@@ -95,6 +95,13 @@ instance_attrs.lookup(pycde.AppID("UnParameterized")).add_attribute(loc)
 loc = placement(["memory", "bank"], PrimitiveType.DSP, 39, 25, 0)
 instance_attrs.lookup(pycde.AppID("UnParameterized",
                                   "Nothing")).add_attribute(loc)
+
+region1 = t.create_physical_region("region1").add_bounds((0, 10), (0, 10))
+region1.add_bounds((10, 20), (10, 20))
+ref = region1.get_ref()
+instance_attrs.lookup(pycde.AppID("UnParameterized",
+                                  "Nothing")).add_attribute(ref)
+
 test_inst = t.get_instance(Test)
 test_inst.walk(instance_attrs.apply_attributes_visitor)
 
@@ -117,4 +124,8 @@ t.print()
 # OUTPUT-DAG:  set_location_assignment M20K_X15_Y25_N0 -to $parent|UnParameterized|memory|bank
 # OUTPUT-DAG:  set_location_assignment MPDSP_X1_Y12_N0 -to $parent|UnParameterized_1|Nothing|dsp_inst
 # OUTPUT-DAG:  set_location_assignment M20K_X39_Y25_N0 -to $parent|UnParameterized_1|memory|bank
+# OUTPUT-DAG:  set_instance_assignment -name PLACE_REGION "X0 Y0 X10 Y10;X10 Y10 X20 Y20" -to $parent|UnParameterized|Nothing
+# OUTPUT-DAG:  set_instance_assignment -name RESERVE_PLACE_REGION OFF -to $parent|UnParameterized|Nothing
+# OUTPUT-DAG:  set_instance_assignment -name CORE_ONLY_PLACE_REGION ON -to $parent|UnParameterized|Nothing
+# OUTPUT-DAG:  set_instance_assignment -name REGION_NAME region1 -to $parent|UnParameterized|Nothing
 t.emit_outputs()

--- a/frontends/PyCDE/test/instances.py
+++ b/frontends/PyCDE/test/instances.py
@@ -133,5 +133,5 @@ t.print()
 # OUTPUT-DAG:  set_instance_assignment -name PLACE_REGION "X0 Y0 X10 Y10;X10 Y10 X20 Y20" -to $parent|UnParameterized|Nothing
 # OUTPUT-DAG:  set_instance_assignment -name RESERVE_PLACE_REGION OFF -to $parent|UnParameterized|Nothing
 # OUTPUT-DAG:  set_instance_assignment -name CORE_ONLY_PLACE_REGION ON -to $parent|UnParameterized|Nothing
-# OUTPUT-DAG:  set_instance_assignment -name REGION_NAME region1 -to $parent|UnParameterized|Nothing
+# OUTPUT-DAG:  set_instance_assignment -name REGION_NAME region_0 -to $parent|UnParameterized|Nothing
 t.emit_outputs()

--- a/frontends/PyCDE/test/instances.py
+++ b/frontends/PyCDE/test/instances.py
@@ -96,11 +96,17 @@ loc = placement(["memory", "bank"], PrimitiveType.DSP, 39, 25, 0)
 instance_attrs.lookup(pycde.AppID("UnParameterized",
                                   "Nothing")).add_attribute(loc)
 
-region1 = t.create_physical_region("region1").add_bounds((0, 10), (0, 10))
+region1 = t.create_physical_region("region_0").add_bounds((0, 10), (0, 10))
 region1.add_bounds((10, 20), (10, 20))
 ref = region1.get_ref()
 instance_attrs.lookup(pycde.AppID("UnParameterized",
                                   "Nothing")).add_attribute(ref)
+
+region_anon = t.create_physical_region()
+assert region_anon._physical_region.sym_name.value == "region_1"
+
+region_explicit = t.create_physical_region("region_1")
+assert region_explicit._physical_region.sym_name.value == "region_1_1"
 
 test_inst = t.get_instance(Test)
 test_inst.walk(instance_attrs.apply_attributes_visitor)

--- a/include/circt-c/Dialect/MSFT.h
+++ b/include/circt-c/Dialect/MSFT.h
@@ -70,6 +70,16 @@ MLIR_CAPI_EXPORTED void circtMSFTSwitchInstanceAttrGetCases(
 MLIR_CAPI_EXPORTED MlirOperation circtMSFTGetInstance(MlirOperation root,
                                                       MlirAttribute path);
 
+MLIR_CAPI_EXPORTED bool circtMSFTAttributeIsAPhysicalBoundsAttr(MlirAttribute);
+MLIR_CAPI_EXPORTED
+MlirAttribute circtMSFTPhysicalBoundsAttrGet(MlirContext, uint64_t, uint64_t,
+                                             uint64_t, uint64_t);
+
+MLIR_CAPI_EXPORTED bool
+    circtMSFTAttributeIsAPhysicalRegionRefAttr(MlirAttribute);
+MLIR_CAPI_EXPORTED
+MlirAttribute circtMSFTPhysicalRegionRefAttrGet(MlirContext, MlirStringRef);
+
 //===----------------------------------------------------------------------===//
 // PrimitiveDB.
 //===----------------------------------------------------------------------===//

--- a/lib/Bindings/Python/MSFTModule.cpp
+++ b/lib/Bindings/Python/MSFTModule.cpp
@@ -193,6 +193,32 @@ void circt::python::populateDialectMSFTSubmodule(py::module &m) {
         return circtMSFTSwitchInstanceAttrGetNumCases(self);
       });
 
+  mlir_attribute_subclass(m, "PhysicalBoundsAttr",
+                          circtMSFTAttributeIsAPhysicalBoundsAttr)
+      .def_classmethod(
+          "get",
+          [](py::object cls, uint64_t xMin, uint64_t xMax, uint64_t yMin,
+             uint64_t yMax, MlirContext ctxt) {
+            auto physicalBounds =
+                circtMSFTPhysicalBoundsAttrGet(ctxt, xMin, xMax, yMin, yMax);
+            return cls(physicalBounds);
+          },
+          "Create a PhysicalBounds attribute", py::arg("class"),
+          py::arg("xMin"), py::arg("xMax"), py::arg("yMin"), py::arg("yMax"),
+          py::arg("context") = py::none());
+
+  mlir_attribute_subclass(m, "PhysicalRegionRefAttr",
+                          circtMSFTAttributeIsAPhysicalRegionRefAttr)
+      .def_classmethod(
+          "get",
+          [](py::object cls, std::string name, MlirContext ctxt) {
+            auto physicalBounds = circtMSFTPhysicalRegionRefAttrGet(
+                ctxt, mlirStringRefCreateFromCString(name.c_str()));
+            return cls(physicalBounds);
+          },
+          "Create a PhysicalRegionRef attribute", py::arg("class"),
+          py::arg("name"), py::arg("context") = py::none());
+
   py::class_<PrimitiveDB>(m, "PrimitiveDB")
       .def(py::init<MlirContext>(), py::arg("ctxt") = py::none())
       .def("add_primitive", &PrimitiveDB::addPrimitive,

--- a/lib/Bindings/Python/MSFTModule.cpp
+++ b/lib/Bindings/Python/MSFTModule.cpp
@@ -203,8 +203,8 @@ void circt::python::populateDialectMSFTSubmodule(py::module &m) {
                 circtMSFTPhysicalBoundsAttrGet(ctxt, xMin, xMax, yMin, yMax);
             return cls(physicalBounds);
           },
-          "Create a PhysicalBounds attribute", py::arg("class"),
-          py::arg("xMin"), py::arg("xMax"), py::arg("yMin"), py::arg("yMax"),
+          "Create a PhysicalBounds attribute", py::arg("cls"), py::arg("xMin"),
+          py::arg("xMax"), py::arg("yMin"), py::arg("yMax"),
           py::arg("context") = py::none());
 
   mlir_attribute_subclass(m, "PhysicalRegionRefAttr",
@@ -216,7 +216,7 @@ void circt::python::populateDialectMSFTSubmodule(py::module &m) {
                 ctxt, mlirStringRefCreateFromCString(name.c_str()));
             return cls(physicalBounds);
           },
-          "Create a PhysicalRegionRef attribute", py::arg("class"),
+          "Create a PhysicalRegionRef attribute", py::arg("cls"),
           py::arg("name"), py::arg("context") = py::none());
 
   py::class_<PrimitiveDB>(m, "PrimitiveDB")

--- a/lib/Bindings/Python/circt/dialects/_msft_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_msft_ops_ext.py
@@ -127,3 +127,12 @@ class MSFTModuleExternOp(_hw_ext.ModuleLike):
                            parameters=parameters,
                            loc=loc,
                            ip=ip)
+
+
+class PhysicalRegionOp:
+
+  def add_bounds(self, bounds):
+    existing_bounds = [b for b in _ir.ArrayAttr(self.attributes["bounds"])]
+    existing_bounds.append(bounds)
+    new_bounds = _ir.ArrayAttr.get(existing_bounds)
+    self.attributes["bounds"] = new_bounds


### PR DESCRIPTION
This add the necessary Python binding boilerplate to create
PhysicalBounds and PhysicalRegionRef attributes. A new API is added to
System, which inserts a PhysicalRegion. A wrapper class for
PhysicalRegion allows creating a region, adding bounds, and getting a
reference attribute suitable for use with the add_attribute API.