### PR TITLE
[Handshake] Enforce single-use results and function arguments

### DIFF
--- a/include/circt/Dialect/Handshake/Handshake.td
+++ b/include/circt/Dialect/Handshake/Handshake.td
@@ -25,11 +25,17 @@ def Handshake_Dialect : Dialect {
   let cppNamespace = "::circt::handshake";
 }
 
+def HasSingleUseResults : PredOpTrait<
+  "all results should have exactly one use",
+  CPred<[{ llvm::all_of(getOperation()->getResults(), [&](auto res) { return res.hasOneUse(); }) }]>>;
+
 // Base class for Handshake dialect ops.
 class Handshake_Op<string mnemonic, list<OpTrait> traits = []>
     : Op<Handshake_Dialect, mnemonic,
          traits #[HasParent<"handshake::FuncOp">,
-         DeclareOpInterfaceMethods<NamedIOInterface>]> {
+         DeclareOpInterfaceMethods<NamedIOInterface>,
+         HasSingleUseResults
+         ]> {
 }
 
 include "circt/Dialect/Handshake/HandshakeOps.td"

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -70,10 +70,6 @@ static bool hasSingleUse(Value v) {
   return std::distance(users.begin(), users.end()) == 1;
 }
 
-static bool allResultsHaveSingleUse(Operation *op) {
-  return llvm::all_of(op->getResults(), hasSingleUse);
-}
-
 // Fetch values from the value map and consume them
 std::vector<llvm::Any>
 fetchValues(ArrayRef<mlir::Value> values,
@@ -422,8 +418,7 @@ static ParseResult verifyFuncOp(handshake::FuncOp op) {
   // Verify that any non-handshake operation result has a single use. Handshake
   // operations themselves validate this through the HasSingleUseResults trait.
   for (auto &subOp : op.getOps()) {
-    if (subOp.getDialect()->getNamespace() ==
-        HandshakeDialect::getDialectNamespace())
+    if (isa<HandshakeDialect>(subOp.getDialect()))
       continue;
     for (auto res : llvm::enumerate(subOp.getResults())) {
       if (!hasSingleUse(res.value()))

--- a/test/Conversion/HandshakeToFIRRTL/test_instance.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_instance.mlir
@@ -2,55 +2,55 @@
 
 // CHECK:           firrtl.module @foo(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out %[[VAL_3:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %[[VAL_4:.*]]: !firrtl.clock, in %[[VAL_5:.*]]: !firrtl.uint<1>) {
 // CHECK:             %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]] = firrtl.instance bar0  @bar(in a: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in ctrl: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out out0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out outCtrl: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in clock: !firrtl.clock, in reset: !firrtl.uint<1>)
-// CHECK:             %[[VAL_12:.*]] = firrtl.instance handshake_sink0  @handshake_sink_1ins_0outs_ctrl(in [[ARG0:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>)
 // CHECK:             firrtl.connect %[[VAL_6]], %[[VAL_0]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
 // CHECK:             firrtl.connect %[[VAL_7]], %[[VAL_1]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
 // CHECK:             firrtl.connect %[[VAL_10]], %[[VAL_4]] : !firrtl.clock, !firrtl.clock
 // CHECK:             firrtl.connect %[[VAL_11]], %[[VAL_5]] : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:             firrtl.connect %[[VAL_12]], %[[VAL_9]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
 // CHECK:             firrtl.connect %[[VAL_2]], %[[VAL_8]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
-// CHECK:             firrtl.connect %[[VAL_3]], %[[VAL_1]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:             firrtl.connect %[[VAL_3]], %[[VAL_9]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
 // CHECK:           }
 
-// CHECK:           firrtl.module @handshake_sink_1ins_0outs_ctrl(in %[[VAL_13:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>) {
-
-// CHECK:           firrtl.module @bar(in %[[VAL_16:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_17:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %[[VAL_18:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out %[[VAL_19:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %[[VAL_20:.*]]: !firrtl.clock, in %[[VAL_21:.*]]: !firrtl.uint<1>) {
-// CHECK:             %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]], %[[VAL_26:.*]], %[[VAL_27:.*]] = firrtl.instance baz0  @baz(in a: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in ctrl: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out out0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out outCtrl: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in clock: !firrtl.clock, in reset: !firrtl.uint<1>)
-// CHECK:             %[[VAL_28:.*]] = firrtl.instance handshake_sink0  @handshake_sink_1ins_0outs_ctrl(in [[ARG0:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>)
-// CHECK:             firrtl.connect %[[VAL_22]], %[[VAL_16]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
-// CHECK:             firrtl.connect %[[VAL_23]], %[[VAL_17]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
-// CHECK:             firrtl.connect %[[VAL_26]], %[[VAL_20]] : !firrtl.clock, !firrtl.clock
-// CHECK:             firrtl.connect %[[VAL_27]], %[[VAL_21]] : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:             firrtl.connect %[[VAL_28]], %[[VAL_25]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
-// CHECK:             firrtl.connect %[[VAL_18]], %[[VAL_24]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
-// CHECK:             firrtl.connect %[[VAL_19]], %[[VAL_17]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:           firrtl.module @bar(in %[[VAL_12:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_13:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %[[VAL_14:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out %[[VAL_15:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %[[VAL_16:.*]]: !firrtl.clock, in %[[VAL_17:.*]]: !firrtl.uint<1>) {
+// CHECK:             %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]] = firrtl.instance baz0  @baz(in a: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in ctrl: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out out0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out outCtrl: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in clock: !firrtl.clock, in reset: !firrtl.uint<1>)
+// CHECK:             firrtl.connect %[[VAL_18]], %[[VAL_12]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             firrtl.connect %[[VAL_19]], %[[VAL_13]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:             firrtl.connect %[[VAL_22]], %[[VAL_16]] : !firrtl.clock, !firrtl.clock
+// CHECK:             firrtl.connect %[[VAL_23]], %[[VAL_17]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:             firrtl.connect %[[VAL_14]], %[[VAL_20]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             firrtl.connect %[[VAL_15]], %[[VAL_21]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
 // CHECK:           }
+
+// CHECK:           firrtl.module @handshake_fork_in_ui32_out_ui32_ui32(in %[[VAL_24:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out %[[VAL_25:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out %[[VAL_26:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_27:.*]]: !firrtl.clock, in %[[VAL_28:.*]]: !firrtl.uint<1>) {
 
 // CHECK:           firrtl.module @arith_addi_in_ui32_ui32_out_ui32(in %[[VAL_29:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_30:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out %[[VAL_31:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) {
 
-// CHECK:           firrtl.module @baz(in %[[VAL_45:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_46:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %[[VAL_47:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out %[[VAL_48:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %[[VAL_49:.*]]: !firrtl.clock, in %[[VAL_50:.*]]: !firrtl.uint<1>) {
-// CHECK:             %[[VAL_51:.*]], %[[VAL_52:.*]], %[[VAL_53:.*]] = firrtl.instance arith_addi0  @arith_addi_in_ui32_ui32_out_ui32(in [[ARG0:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in [[ARG1:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out [[ARG2:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>)
-// CHECK:             firrtl.connect %[[VAL_51]], %[[VAL_45]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
-// CHECK:             firrtl.connect %[[VAL_52]], %[[VAL_45]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
-// CHECK:             firrtl.connect %[[VAL_47]], %[[VAL_53]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
-// CHECK:             firrtl.connect %[[VAL_48]], %[[VAL_46]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:           firrtl.module @baz(in %[[VAL_77:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_78:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %[[VAL_79:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out %[[VAL_80:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %[[VAL_81:.*]]: !firrtl.clock, in %[[VAL_82:.*]]: !firrtl.uint<1>) {
+// CHECK:             %[[VAL_83:.*]], %[[VAL_84:.*]], %[[VAL_85:.*]], %[[VAL_86:.*]], %[[VAL_87:.*]] = firrtl.instance handshake_fork0  @handshake_fork_in_ui32_out_ui32_ui32(in in0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out out0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out out1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in clock: !firrtl.clock, in reset: !firrtl.uint<1>)
+// CHECK:             %[[VAL_88:.*]], %[[VAL_89:.*]], %[[VAL_90:.*]] = firrtl.instance arith_addi0  @arith_addi_in_ui32_ui32_out_ui32(in in0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in in1: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out out0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>)
+// CHECK:             firrtl.connect %[[VAL_83]], %[[VAL_77]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             firrtl.connect %[[VAL_86]], %[[VAL_81]] : !firrtl.clock, !firrtl.clock
+// CHECK:             firrtl.connect %[[VAL_87]], %[[VAL_82]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:             firrtl.connect %[[VAL_88]], %[[VAL_84]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             firrtl.connect %[[VAL_89]], %[[VAL_85]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             firrtl.connect %[[VAL_79]], %[[VAL_90]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             firrtl.connect %[[VAL_80]], %[[VAL_78]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
 // CHECK:           }
+// CHECK:         }
 
 module {
   handshake.func @baz(%a: i32, %ctrl : none) -> (i32, none) {
-    %0 = arith.addi %a, %a : i32
-    handshake.return %0, %ctrl : i32, none
+    %0:2 = "handshake.fork"(%a) {control = false} : (i32) -> (i32, i32)
+    %1 = arith.addi %0#0, %0#1 : i32
+    handshake.return %1, %ctrl : i32, none
   }
 
   handshake.func @bar(%a: i32, %ctrl : none) -> (i32, none) {
     %c:2 = handshake.instance @baz(%a, %ctrl) : (i32, none) -> (i32, none)
-    "handshake.sink"(%c#1) {control = true} : (none) -> ()
-    handshake.return %c#0, %ctrl : i32, none
+    handshake.return %c#0, %c#1 : i32, none
   }
 
   handshake.func @foo(%a: i32, %ctrl : none) -> (i32, none) {
     %b:2 = handshake.instance @bar(%a, %ctrl) : (i32, none) -> (i32, none)
-    "handshake.sink"(%b#1) {control = true} : (none) -> ()
-    handshake.return %b#0, %ctrl : i32, none
+    handshake.return %b#0, %b#1: i32, none
   }
 }

--- a/test/Conversion/HandshakeToFIRRTL/test_store.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_store.mlir
@@ -40,6 +40,7 @@
 // CHECK: firrtl.module @main(in %[[VAL_24:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>, in %[[VAL_25:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in %[[VAL_26:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %[[VAL_27:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>, out %[[VAL_28:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, out %[[VAL_29:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %[[VAL_30:.*]]: !firrtl.clock, in %[[VAL_31:.*]]: !firrtl.uint<1>) {
 // CHECK:   %[[VAL_32:.*]], %[[VAL_33:.*]], %[[VAL_34:.*]], %[[VAL_35:.*]], %[[VAL_36:.*]] = firrtl.instance handshake_store0  @handshake_store_in_ui8_ui64_out_ui8_ui64(in [[ARG0:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>, in [[ARG1:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, in [[ARG2:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out [[ARG3:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<8>>, out [[ARG4:.+]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>)
 handshake.func @main(%arg0: i8, %arg1: index, %arg2: none, ...) -> (i8, index, none) {
-  %0:2 = "handshake.store"(%arg0, %arg1, %arg2) : (i8, index, none) -> (i8, index)
-  handshake.return %0#0, %0#1, %arg2 : i8, index, none
+  %ctrl:2 = "handshake.fork"(%arg2) {control = true} : (none) -> (none, none)
+  %0:2 = "handshake.store"(%arg0, %arg1, %ctrl#0) : (i8, index, none) -> (i8, index)
+  handshake.return %0#0, %0#1, %ctrl#1 : i8, index, none
 }

--- a/test/Conversion/StandardToHandshake/test_canonicalize.mlir
+++ b/test/Conversion/StandardToHandshake/test_canonicalize.mlir
@@ -5,13 +5,14 @@ module {
   // CHECK-LABEL: handshake.func @simple(
   // CHECK-SAME:                         %[[VAL_0:.*]]: none, ...) -> none attributes {argNames = ["arg0"], resNames = ["outCtrl"]} {
   handshake.func @simple(%arg0: none, ...) -> none {
+    %c:2 = "handshake.fork"(%arg0) {control = true} : (none) -> (none, none)
 
     // CHECK: %[[VAL_1:.*]] = "handshake.constant"(%[[VAL_0:.*]]) {value = 1 : index} : (none) -> index
-    %0 = "handshake.constant"(%arg0) {value = 1 : index} : (none) -> index
+    %0 = "handshake.constant"(%c#0) {value = 1 : index} : (none) -> index
 
     // CHECK-NOT: %[[TMP_0:.*]] = "handshake.branch"(%[[VAL_0:.*]]) {control = true} : (none) -> none
     // CHECK-NOT: %[[TMP_1:.*]] = "handshake.branch"(%[[VAL_1:.*]]) {control = false} : (index) -> index
-    %1 = "handshake.branch"(%arg0) {control = true} : (none) -> none
+    %1 = "handshake.branch"(%c#1) {control = true} : (none) -> none
     %2 = "handshake.branch"(%0) {control = false} : (index) -> index
 
     // CHECK-NOT: %[[TMP_2:.*]] = "handshake.merge"(%[[TMP_0:.*]]) : (none) -> none
@@ -45,20 +46,14 @@ module {
     handshake.return %result, %arg2 : none, none
   }
 
-  // CHECK-LABEL: cmerge_with_control_ignored
-  handshake.func @cmerge_with_control_ignored(%arg0: none, %arg1: none, %arg2: none) -> (none, none) {
-    // CHECK: "handshake.merge"(%{{.+}}, %{{.+}})
-    // CHECK-NOT: "handshake.control_merge"
-    %result, %index = "handshake.control_merge"(%arg0, %arg1) {control = true} : (none, none) -> (none, index)
-    handshake.return %result, %arg2 : none, none
-  }
-
   // CHECK-LABEL: sunk_constant
   handshake.func @sunk_constant(%arg0: none) -> (none) {
+    // CHECK-NOT: handshake.fork
     // CHECK-NOT: handshake.constant
     // CHECK-NOT: handshake.sink
-    %0 = "handshake.constant"(%arg0) { value = 24 : i8 } : (none) -> i8
+    %c:2 = "handshake.fork"(%arg0) {control = true} : (none) -> (none, none)
+    %0 = "handshake.constant"(%c#0) { value = 24 : i8 } : (none) -> i8
     "handshake.sink"(%0) : (i8) -> ()
-    handshake.return %arg0: none
+    handshake.return %c#1: none
   }
 }

--- a/test/Dialect/Handshake/errors.mlir
+++ b/test/Dialect/Handshake/errors.mlir
@@ -44,9 +44,9 @@ handshake.func @foo(%ctrl : none) -> none{
   handshake.return %ctrl : none
 }
 
-handshake.func @invalid_instance_op(%arg0 : i32, %ctrl : none) -> none {
+handshake.func @invalid_instance_op(%arg0 : i32, %arg1 : none, %ctrl : none) -> none {
   // expected-error @+1 {{'handshake.instance' op last operand must be a control (none-typed) operand.}}
-  handshake.instance @foo(%ctrl, %arg0) : (none, i32) -> ()
+  handshake.instance @foo(%arg1, %arg0) : (none, i32) -> ()
   handshake.return %ctrl : none
 }
 
@@ -104,4 +104,31 @@ handshake.func @invalid_num_resnames(%a : i32, %b : i32, %c : none) -> (i32, non
 // expected-error @+1 {{'handshake.func' op expected all entries in attribute 'resNames' to be strings.}}
 handshake.func @invalid_type_resnames(%a : i32, %b : none) -> none attributes {resNames = [2 : i32]} {
   handshake.return %b : none
+}
+
+// -----
+
+// expected-error @+1 {{'handshake.func' op argument 0 has multiple uses.}}
+handshake.func @invalid_mutliple_use_arg(%a : i32, %ctrl : none) -> (i32, none) {
+  %0 = arith.addi %a, %a : i32
+  handshake.return %0, %ctrl : i32, none
+}
+
+// -----
+
+handshake.func @invalid_mutliple_use_nonhandshake_op(%a : i32, %b : i32, %c : i32, %d : i32, %ctrl : none) -> (i32, none) {
+  // expected-error @+1 {{'arith.addi' op result 0 has multiple uses.}}
+  %0 = arith.addi %a, %b : i32
+  %1 = arith.addi %0, %c : i32
+  %2 = arith.addi %0, %d : i32
+  handshake.return %2, %ctrl : i32, none
+}
+
+// -----
+
+handshake.func @invalid_multiple_use_handshake_op(%a : i32, %ctrl : none) -> (i32, none) {
+  // expected-error @+1 {{'handshake.fork' op failed to verify that all results should have exactly one use}}
+  %0:2 = "handshake.fork"(%a) {control = false} : (i32) -> (i32, i32)
+  %1 = arith.addi %0#0, %0#0 : i32
+  handshake.return %1, %ctrl : i32, none
 }


### PR DESCRIPTION
This commits adds constraints to the Handshake IR, requiring that results of operations and handshake arguments are single-use.

Pros:
- It is now **not** the job of a lowering pass to check if forks or sinks are missing from the IR. Instead, it is a precondition that the Handshake IR is valid.
- Improves handshake IR by making it more robust (verified) through use of MLIRs verification system.
- The verification can guide those who hand-write handshake code, ensuring that it is valid (...if any).

Cons:
- Cannot hand-write Handshake IR and let forks and sinks be inferred by a pass.

I think this is a fair trade-off. Working with verifying the handshake dialect, I've come to experience quite a few issues which could have been avoided by having proper verification constraints on the IR.