### PR TITLE
[ExportVerilog] Donot inline lowIndex for ArraySlice

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1787,13 +1787,14 @@ SubExprInfo ExprEmitter::visitTypeOp(ArraySliceOp op) {
   unsigned dstWidth = type_cast<ArrayType>(op.getType()).getSize();
   os << '[';
   bool padTo32Bits = false;
-  if (!isa<ConstantOp>(op.lowIndex().getDefiningOp()) && hw::getBitWidth(op.lowIndex().getType()) < 32 )
+  if (auto defO = op.lowIndex().getDefiningOp())
+  if ( (!isa<ConstantOp>(defO)) && hw::getBitWidth(op.lowIndex().getType()) < 32 )
     padTo32Bits = true;
   if (padTo32Bits)
-    os << "{ 0 + ";
+    os << "(0 + ";
   emitSubExpr(op.lowIndex(), LowestPrecedence, OOLBinary);
   if (padTo32Bits)
-    os << "}";
+    os << ")";
   os << " +: " << dstWidth << ']';
   return {Selection, arrayPrec.signedness};
 }

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1788,8 +1788,9 @@ SubExprInfo ExprEmitter::visitTypeOp(ArraySliceOp op) {
   os << '[';
   bool padTo32Bits = false;
   if (auto defO = op.lowIndex().getDefiningOp())
-  if ( (!isa<ConstantOp>(defO)) && hw::getBitWidth(op.lowIndex().getType()) < 32 )
-    padTo32Bits = true;
+    if ((!isa<ConstantOp>(defO)) &&
+        hw::getBitWidth(op.lowIndex().getType()) < 32)
+      padTo32Bits = true;
   if (padTo32Bits)
     os << "(0 + ";
   emitSubExpr(op.lowIndex(), LowestPrecedence, OOLBinary);

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1787,7 +1787,7 @@ SubExprInfo ExprEmitter::visitTypeOp(ArraySliceOp op) {
   unsigned dstWidth = type_cast<ArrayType>(op.getType()).getSize();
   os << '[';
   bool padTo32Bits = false;
-  if (auto defO = op.lowIndex().getDefiningOp())
+  if (auto *defO = op.lowIndex().getDefiningOp())
     if ((!isa<ConstantOp>(defO)) &&
         hw::getBitWidth(op.lowIndex().getType()) < 32)
       padTo32Bits = true;

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -529,7 +529,6 @@ hw.module @slice_inline_ports(%arr: !hw.array<128xi1>, %x: i3, %y: i7)
   %c1_i2 = hw.constant 1 : i2
   %0 = hw.array_create %x, %x, %x, %x : i3
   // CHECK: wire [3:0][2:0] _T = 
-  // CHECK: wire [6:0] _T_0 = y + 7'h1;
   %1 = hw.array_slice %0 at %c1_i2 : (!hw.array<4xi3>) -> !hw.array<2xi3>
   // CHECK: assign o1 = _T[2'h1 +: 2];
 
@@ -539,7 +538,7 @@ hw.module @slice_inline_ports(%arr: !hw.array<128xi1>, %x: i3, %y: i7)
   // CHECK: assign o2 = arr[7'h1 +: 64];
   %2 = hw.array_slice %arr at %c1_i7 : (!hw.array<128xi1>) -> !hw.array<64xi1>
 
-  // CHECK: assign o3 = arr[_T_0 +: 64];
+  // CHECK: assign o3 = arr[(0 + y + 7'h1) +: 64];
   %sum = comb.add %y, %c1_i7 : i7
   %3 = hw.array_slice %arr at %sum : (!hw.array<128xi1>) -> !hw.array<64xi1>
 

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -529,6 +529,7 @@ hw.module @slice_inline_ports(%arr: !hw.array<128xi1>, %x: i3, %y: i7)
   %c1_i2 = hw.constant 1 : i2
   %0 = hw.array_create %x, %x, %x, %x : i3
   // CHECK: wire [3:0][2:0] _T = 
+  // CHECK: wire [6:0] _T_0 = y + 7'h1;
   %1 = hw.array_slice %0 at %c1_i2 : (!hw.array<4xi3>) -> !hw.array<2xi3>
   // CHECK: assign o1 = _T[2'h1 +: 2];
 
@@ -538,7 +539,7 @@ hw.module @slice_inline_ports(%arr: !hw.array<128xi1>, %x: i3, %y: i7)
   // CHECK: assign o2 = arr[7'h1 +: 64];
   %2 = hw.array_slice %arr at %c1_i7 : (!hw.array<128xi1>) -> !hw.array<64xi1>
 
-  // CHECK: assign o3 = arr[y + 7'h1 +: 64];
+  // CHECK: assign o3 = arr[_T_0 +: 64];
   %sum = comb.add %y, %c1_i7 : i7
   %3 = hw.array_slice %arr at %sum : (!hw.array<128xi1>) -> !hw.array<64xi1>
 


### PR DESCRIPTION
This fixes the verilator warning, by disabling inline for `lowIndex` operand for `ArraySlice`.
Followup to https://github.com/llvm/circt/commit/9a59ecf2f1012d16f05755218edd6328d145280f