### PR TITLE
Add default dialect for handshake.func

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+include "mlir/IR/OpAsmInterface.td"
+
 // This is almost exactly like a standard FuncOp, except that it has some
 // extra verification conditions.  In particular, each Value must
 // only have a single use.  Also, it defines a Dominance-Free Scope
@@ -17,7 +19,8 @@ def FuncOp : Op<Handshake_Dialect, "func", [
    IsolatedFromAbove,
    FunctionLike,
    Symbol,
-   RegionKindInterface
+   RegionKindInterface,
+   OpAsmOpInterface
 ]> {
   let summary = "Handshake dialect function.";
   let description = [{
@@ -96,6 +99,14 @@ def FuncOp : Op<Handshake_Dialect, "func", [
         return emitOpError("requires '" + getTypeAttrName() +
                            "' attribute of function type");
       return success();
+    }
+
+    //===------------------------------------------------------------------===//
+    // OpAsmOpInterface Methods
+    //===------------------------------------------------------------------===//
+
+    static ::llvm::StringRef getDefaultDialect() {
+      return "handshake";
     }
   }];
 

--- a/test/Conversion/StandardToHandshake/Affine/test-affine-for.mlir
+++ b/test/Conversion/StandardToHandshake/Affine/test-affine-for.mlir
@@ -56,7 +56,7 @@ func @empty_body () -> () {
 // CHECK:   %34 = "handshake.branch"(%30) {control = false} : (index) -> index
 // CHECK:   %35:2 = "handshake.control_merge"(%falseResult_3) {control = true} : (none) -> (none, index)
 // CHECK:   "handshake.sink"(%35#1) : (index) -> ()
-// CHECK:   handshake.return %35#0 : none
+// CHECK:   return %35#0 : none
 // CHECK: }
 
 // -----
@@ -127,7 +127,7 @@ func @load_store () -> () {
 // CHECK:   %42 = "handshake.branch"(%38) {control = false} : (index) -> index
 // CHECK:   %43:2 = "handshake.control_merge"(%falseResult_3) {control = true} : (none) -> (none, index)
 // CHECK:   "handshake.sink"(%43#1) : (index) -> ()
-// CHECK:   handshake.return %43#0 : none
+// CHECK:   return %43#0 : none
 // CHECK: }
 
 // TODO: affine expr in loop bounds

--- a/test/Conversion/StandardToHandshake/Affine/test-affine-load-store.mlir
+++ b/test/Conversion/StandardToHandshake/Affine/test-affine-load-store.mlir
@@ -23,7 +23,7 @@ func @load_store () -> () {
 // CHECK:   %[[VAL7:.*]], %[[ADDR]] = "handshake.load"(%[[VAL6]]#0, %[[VAL0]]#0, %[[VAL2]]#1) : (index, f32, none) -> (f32, index)
 // CHECK:   %[[VAL8:.*]] = "handshake.join"(%[[VAL2]]#0, %[[VAL1]]#0) {control = true} : (none, none) -> none
 // CHECK:   %[[VAL9]]:2 = "handshake.store"(%[[VAL7]], %[[VAL6]]#1, %[[VAL8]]) : (f32, index, none) -> (f32, index)
-// CHECK:   handshake.return %[[VAL4]] : none
+// CHECK:   return %[[VAL4]] : none
 // CHECK: }
 
 // -----
@@ -53,5 +53,5 @@ func @affine_map_addr () -> () {
 // CHECK-NEXT:   %[[VAL11:.*]] = arith.addi %[[VAL6]]#1, %[[VAL10]] : index
 // CHECK-NEXT:   %[[VAL12:.*]] = "handshake.join"(%[[VAL2]]#0, %[[VAL1]]#0) {control = true} : (none, none) -> none
 // CHECK-NEXT:   %[[VAL13]]:2 = "handshake.store"(%[[VAL9]], %[[VAL11]], %[[VAL12]]) : (f32, index, none) -> (f32, index)
-// CHECK-NEXT:   handshake.return %[[VAL4]] : none
+// CHECK-NEXT:   return %[[VAL4]] : none
 // CHECK-NEXT: }

--- a/test/Conversion/StandardToHandshake/test1.mlir
+++ b/test/Conversion/StandardToHandshake/test1.mlir
@@ -39,7 +39,7 @@ func @simple_loop() {
 // CHECK:           %[[VAL_16]] = "handshake.branch"(%[[VAL_31]]) {control = false} : (index) -> index
 // CHECK:           %[[VAL_32:.*]]:2 = "handshake.control_merge"(%[[VAL_23]]) {control = true} : (none) -> (none, index)
 // CHECK:           "handshake.sink"(%[[VAL_32]]#1) : (index) -> ()
-// CHECK:           handshake.return %[[VAL_32]]#0 : none
+// CHECK:           return %[[VAL_32]]#0 : none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test10.mlir
+++ b/test/Conversion/StandardToHandshake/test10.mlir
@@ -97,7 +97,7 @@
 // CHECK:           %[[VAL_43]] = "handshake.branch"(%[[VAL_90]]) {control = false} : (index) -> index
 // CHECK:           %[[VAL_91:.*]]:2 = "handshake.control_merge"(%[[VAL_64]]) {control = true} : (none) -> (none, index)
 // CHECK:           "handshake.sink"(%[[VAL_91]]#1) : (index) -> ()
-// CHECK:           handshake.return %[[VAL_91]]#0 : none
+// CHECK:           return %[[VAL_91]]#0 : none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test11.mlir
+++ b/test/Conversion/StandardToHandshake/test11.mlir
@@ -97,7 +97,7 @@
 // CHECK:           %[[VAL_18]] = "handshake.branch"(%[[VAL_92]]) {control = false} : (index) -> index
 // CHECK:           %[[VAL_93:.*]]:2 = "handshake.control_merge"(%[[VAL_27]]) {control = true} : (none) -> (none, index)
 // CHECK:           "handshake.sink"(%[[VAL_93]]#1) : (index) -> ()
-// CHECK:           handshake.return %[[VAL_93]]#0 : none
+// CHECK:           return %[[VAL_93]]#0 : none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test12.mlir
+++ b/test/Conversion/StandardToHandshake/test12.mlir
@@ -152,7 +152,7 @@
 // CHECK:           %[[VAL_18]] = "handshake.branch"(%[[VAL_149]]) {control = false} : (index) -> index
 // CHECK:           %[[VAL_150:.*]]:2 = "handshake.control_merge"(%[[VAL_27]]) {control = true} : (none) -> (none, index)
 // CHECK:           "handshake.sink"(%[[VAL_150]]#1) : (index) -> ()
-// CHECK:           handshake.return %[[VAL_150]]#0 : none
+// CHECK:           return %[[VAL_150]]#0 : none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test13.mlir
+++ b/test/Conversion/StandardToHandshake/test13.mlir
@@ -97,7 +97,7 @@
 // CHECK:           %[[VAL_19]] = "handshake.branch"(%[[VAL_93]]) {control = false} : (index) -> index
 // CHECK:           %[[VAL_94:.*]]:2 = "handshake.control_merge"(%[[VAL_28]]) {control = true} : (none) -> (none, index)
 // CHECK:           "handshake.sink"(%[[VAL_94]]#1) : (index) -> ()
-// CHECK:           handshake.return %[[VAL_94]]#0 : none
+// CHECK:           return %[[VAL_94]]#0 : none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test14.mlir
+++ b/test/Conversion/StandardToHandshake/test14.mlir
@@ -69,7 +69,7 @@
 // CHECK:           %[[VAL_29]] = "handshake.branch"(%[[VAL_63]]) {control = false} : (index) -> index
 // CHECK:           %[[VAL_64:.*]]:2 = "handshake.control_merge"(%[[VAL_42]]) {control = true} : (none) -> (none, index)
 // CHECK:           "handshake.sink"(%[[VAL_64]]#1) : (index) -> ()
-// CHECK:           handshake.return %[[VAL_64]]#0 : none
+// CHECK:           return %[[VAL_64]]#0 : none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test15.mlir
+++ b/test/Conversion/StandardToHandshake/test15.mlir
@@ -60,7 +60,7 @@
 // CHECK:           %[[VAL_25]] = "handshake.branch"(%[[VAL_54]]) {control = false} : (index) -> index
 // CHECK:           %[[VAL_55:.*]]:2 = "handshake.control_merge"(%[[VAL_36]]) {control = true} : (none) -> (none, index)
 // CHECK:           "handshake.sink"(%[[VAL_55]]#1) : (index) -> ()
-// CHECK:           handshake.return %[[VAL_55]]#0 : none
+// CHECK:           return %[[VAL_55]]#0 : none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test16.mlir
+++ b/test/Conversion/StandardToHandshake/test16.mlir
@@ -23,7 +23,7 @@ func @affine_apply_ceildiv(%arg0: index) -> index {
 // CHECK:           %[[VAL_17:.*]] = arith.subi %[[VAL_7]]#2, %[[VAL_16]]#1 : index
 // CHECK:           %[[VAL_18:.*]] = arith.addi %[[VAL_16]]#0, %[[VAL_9]]#1 : index
 // CHECK:           %[[VAL_19:.*]] = select %[[VAL_11]]#0, %[[VAL_17]], %[[VAL_18]] : index
-// CHECK:           handshake.return %[[VAL_19]], %[[VAL_4]]#3 : index, none
+// CHECK:           return %[[VAL_19]], %[[VAL_4]]#3 : index, none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test17.mlir
+++ b/test/Conversion/StandardToHandshake/test17.mlir
@@ -20,7 +20,7 @@ func @affine_apply_floordiv(%arg0: index) -> index {
 // CHECK:           %[[VAL_14:.*]]:2 = "handshake.fork"(%[[VAL_13]]) {control = false} : (index) -> (index, index)
 // CHECK:           %[[VAL_15:.*]] = arith.subi %[[VAL_8]]#1, %[[VAL_14]]#1 : index
 // CHECK:           %[[VAL_16:.*]] = select %[[VAL_10]]#0, %[[VAL_15]], %[[VAL_14]]#0 : index
-// CHECK:           handshake.return %[[VAL_16]], %[[VAL_4]]#3 : index, none
+// CHECK:           return %[[VAL_16]], %[[VAL_4]]#3 : index, none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test18.mlir
+++ b/test/Conversion/StandardToHandshake/test18.mlir
@@ -15,7 +15,7 @@ func @affine_apply_mod(%arg0: index) -> index {
 // CHECK:           %[[VAL_9:.*]] = arith.cmpi slt, %[[VAL_7]]#2, %[[VAL_8]] : index
 // CHECK:           %[[VAL_10:.*]] = arith.addi %[[VAL_7]]#1, %[[VAL_5]]#1 : index
 // CHECK:           %[[VAL_11:.*]] = select %[[VAL_9]], %[[VAL_10]], %[[VAL_7]]#0 : index
-// CHECK:           handshake.return %[[VAL_11]], %[[VAL_3]]#2 : index, none
+// CHECK:           return %[[VAL_11]], %[[VAL_3]]#2 : index, none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test19.mlir
+++ b/test/Conversion/StandardToHandshake/test19.mlir
@@ -42,7 +42,7 @@ func @affine_applies() {
 // CHECK:           %[[VAL_32:.*]] = arith.muli %[[VAL_15]], %[[VAL_31]] : index
 // CHECK:           %[[VAL_33:.*]] = arith.addi %[[VAL_30]], %[[VAL_32]] : index
 // CHECK:           "handshake.sink"(%[[VAL_33]]) : (index) -> ()
-// CHECK:           handshake.return %[[VAL_1]]#17 : none
+// CHECK:           return %[[VAL_1]]#17 : none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test2.mlir
+++ b/test/Conversion/StandardToHandshake/test2.mlir
@@ -89,7 +89,7 @@ func @imperfectly_nested_loops() {
 // CHECK:           %[[VAL_16]] = "handshake.branch"(%[[VAL_81]]) {control = false} : (index) -> index
 // CHECK:           %[[VAL_82:.*]]:2 = "handshake.control_merge"(%[[VAL_23]]) {control = true} : (none) -> (none, index)
 // CHECK:           "handshake.sink"(%[[VAL_82]]#1) : (index) -> ()
-// CHECK:           handshake.return %[[VAL_82]]#0 : none
+// CHECK:           return %[[VAL_82]]#0 : none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test20.mlir
+++ b/test/Conversion/StandardToHandshake/test20.mlir
@@ -60,7 +60,7 @@
 // CHECK:           %[[VAL_37]] = "handshake.branch"(%[[VAL_54]]) {control = false} : (index) -> index
 // CHECK:           %[[VAL_55:.*]]:2 = "handshake.control_merge"(%[[VAL_46]]) {control = true} : (none) -> (none, index)
 // CHECK:           "handshake.sink"(%[[VAL_55]]#1) : (index) -> ()
-// CHECK:           handshake.return %[[VAL_55]]#0 : none
+// CHECK:           return %[[VAL_55]]#0 : none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test21.mlir
+++ b/test/Conversion/StandardToHandshake/test21.mlir
@@ -121,7 +121,7 @@ func @loop_min_max(%arg0: index) {
 // CHECK:           %[[VAL_23]] = "handshake.branch"(%[[VAL_118]]) {control = false} : (index) -> index
 // CHECK:           %[[VAL_119:.*]]:2 = "handshake.control_merge"(%[[VAL_34]]) {control = true} : (none) -> (none, index)
 // CHECK:           "handshake.sink"(%[[VAL_119]]#1) : (index) -> ()
-// CHECK:           handshake.return %[[VAL_119]]#0 : none
+// CHECK:           return %[[VAL_119]]#0 : none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test22.mlir
+++ b/test/Conversion/StandardToHandshake/test22.mlir
@@ -198,7 +198,7 @@
 // CHECK:           %[[VAL_95]] = "handshake.branch"(%[[VAL_197]]) {control = false} : (index) -> index
 // CHECK:           %[[VAL_198:.*]]:2 = "handshake.control_merge"(%[[VAL_104]]) {control = true} : (none) -> (none, index)
 // CHECK:           "handshake.sink"(%[[VAL_198]]#1) : (index) -> ()
-// CHECK:           handshake.return %[[VAL_198]]#0 : none
+// CHECK:           return %[[VAL_198]]#0 : none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test23.mlir
+++ b/test/Conversion/StandardToHandshake/test23.mlir
@@ -44,7 +44,7 @@ func @multi_cond(%arg0: index, %arg1: index, %arg2: index, %arg3: index) {
 // CHECK:           %[[VAL_40:.*]] = "handshake.branch"(%[[VAL_39]]#0) {control = true} : (none) -> none
 // CHECK:           %[[VAL_41:.*]]:2 = "handshake.control_merge"(%[[VAL_40]], %[[VAL_38]]) {control = true} : (none, none) -> (none, index)
 // CHECK:           "handshake.sink"(%[[VAL_41]]#1) : (index) -> ()
-// CHECK:           handshake.return %[[VAL_41]]#0 : none
+// CHECK:           return %[[VAL_41]]#0 : none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test24.mlir
+++ b/test/Conversion/StandardToHandshake/test24.mlir
@@ -49,7 +49,7 @@
 // CHECK:           %[[VAL_40:.*]] = "handshake.branch"(%[[VAL_39]]#0) {control = true} : (none) -> none
 // CHECK:           %[[VAL_41:.*]]:2 = "handshake.control_merge"(%[[VAL_40]], %[[VAL_27]]) {control = true} : (none, none) -> (none, index)
 // CHECK:           "handshake.sink"(%[[VAL_41]]#1) : (index) -> ()
-// CHECK:           handshake.return %[[VAL_41]]#0 : none
+// CHECK:           return %[[VAL_41]]#0 : none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test25.mlir
+++ b/test/Conversion/StandardToHandshake/test25.mlir
@@ -22,7 +22,7 @@
 // CHECK:           %[[VAL_14:.*]] = "handshake.branch"(%[[VAL_13]]#0) {control = true} : (none) -> none
 // CHECK:           %[[VAL_15:.*]]:2 = "handshake.control_merge"(%[[VAL_14]], %[[VAL_12]]) {control = true} : (none, none) -> (none, index)
 // CHECK:           "handshake.sink"(%[[VAL_15]]#1) : (index) -> ()
-// CHECK:           handshake.return %[[VAL_15]]#0 : none
+// CHECK:           return %[[VAL_15]]#0 : none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test26.mlir
+++ b/test/Conversion/StandardToHandshake/test26.mlir
@@ -19,7 +19,7 @@
 // CHECK:           %[[VAL_12:.*]] = "handshake.branch"(%[[VAL_11]]#0) {control = true} : (none) -> none
 // CHECK:           %[[VAL_13:.*]]:2 = "handshake.control_merge"(%[[VAL_12]], %[[VAL_10]]) {control = true} : (none, none) -> (none, index)
 // CHECK:           "handshake.sink"(%[[VAL_13]]#1) : (index) -> ()
-// CHECK:           handshake.return %[[VAL_13]]#0 : none
+// CHECK:           return %[[VAL_13]]#0 : none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test27.mlir
+++ b/test/Conversion/StandardToHandshake/test27.mlir
@@ -39,7 +39,7 @@ func @simple_loop() {
 // CHECK:           %[[VAL_16]] = "handshake.branch"(%[[VAL_31]]) {control = false} : (index) -> index
 // CHECK:           %[[VAL_32:.*]]:2 = "handshake.control_merge"(%[[VAL_23]]) {control = true} : (none) -> (none, index)
 // CHECK:           "handshake.sink"(%[[VAL_32]]#1) : (index) -> ()
-// CHECK:           handshake.return %[[VAL_32]]#0 : none
+// CHECK:           return %[[VAL_32]]#0 : none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test28.mlir
+++ b/test/Conversion/StandardToHandshake/test28.mlir
@@ -66,7 +66,7 @@
 // CHECK:           %[[VAL_29]] = "handshake.branch"(%[[VAL_59]]) {control = false} : (index) -> index
 // CHECK:           %[[VAL_63:.*]]:2 = "handshake.control_merge"(%[[VAL_40]]) {control = true} : (none) -> (none, index)
 // CHECK:           "handshake.sink"(%[[VAL_63]]#1) : (index) -> ()
-// CHECK:           handshake.return %[[VAL_63]]#0 : none
+// CHECK:           return %[[VAL_63]]#0 : none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test29.mlir
+++ b/test/Conversion/StandardToHandshake/test29.mlir
@@ -31,7 +31,7 @@
 
 // Result of load operation is sinked.
 // CHECK:   "handshake.sink"(%[[LDDATA:.+]]) : (i32) -> ()
-// CHECK:   handshake.return %[[STLDNONE_AND_CTRL:.+]] : none
+// CHECK:   return %[[STLDNONE_AND_CTRL:.+]] : none
 // CHECK: }
 
 func @load_store(%0 : memref<4xi32>, %1 : index) {

--- a/test/Conversion/StandardToHandshake/test3.mlir
+++ b/test/Conversion/StandardToHandshake/test3.mlir
@@ -139,7 +139,7 @@ func @more_imperfectly_nested_loops() {
 // CHECK:           %[[VAL_16]] = "handshake.branch"(%[[VAL_131]]) {control = false} : (index) -> index
 // CHECK:           %[[VAL_132:.*]]:2 = "handshake.control_merge"(%[[VAL_23]]) {control = true} : (none) -> (none, index)
 // CHECK:           "handshake.sink"(%[[VAL_132]]#1) : (index) -> ()
-// CHECK:           handshake.return %[[VAL_132]]#0 : none
+// CHECK:           return %[[VAL_132]]#0 : none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test30.mlir
+++ b/test/Conversion/StandardToHandshake/test30.mlir
@@ -79,7 +79,7 @@
 // CHECK:           %[[VAL_37]] = "handshake.branch"(%[[VAL_71]]) {control = false} : (index) -> index
 // CHECK:           %[[VAL_76:.*]]:2 = "handshake.control_merge"(%[[VAL_50]]) {control = true} : (none) -> (none, index)
 // CHECK:           "handshake.sink"(%[[VAL_76]]#1) : (index) -> ()
-// CHECK:           handshake.return %[[VAL_76]]#0 : none
+// CHECK:           return %[[VAL_76]]#0 : none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test31.mlir
+++ b/test/Conversion/StandardToHandshake/test31.mlir
@@ -79,7 +79,7 @@
 // CHECK:           %[[VAL_37]] = "handshake.branch"(%[[VAL_71]]) {control = false} : (index) -> index
 // CHECK:           %[[VAL_76:.*]]:2 = "handshake.control_merge"(%[[VAL_50]]) {control = true} : (none) -> (none, index)
 // CHECK:           "handshake.sink"(%[[VAL_76]]#1) : (index) -> ()
-// CHECK:           handshake.return %[[VAL_76]]#0 : none
+// CHECK:           return %[[VAL_76]]#0 : none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test32.mlir
+++ b/test/Conversion/StandardToHandshake/test32.mlir
@@ -56,7 +56,7 @@
 // CHECK:           %[[VAL_26]] = "handshake.branch"(%[[VAL_48]]#0) {control = false} : (index) -> index
 // CHECK:           %[[VAL_52:.*]]:2 = "handshake.control_merge"(%[[VAL_35]]) {control = true} : (none) -> (none, index)
 // CHECK:           "handshake.sink"(%[[VAL_52]]#1) : (index) -> ()
-// CHECK:           handshake.return %[[VAL_52]]#0 : none
+// CHECK:           return %[[VAL_52]]#0 : none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test33.mlir
+++ b/test/Conversion/StandardToHandshake/test33.mlir
@@ -48,7 +48,7 @@
 // CHECK:           %[[VAL_20]] = "handshake.branch"(%[[VAL_40]]#0) {control = false} : (index) -> index
 // CHECK:           %[[VAL_44:.*]]:2 = "handshake.control_merge"(%[[VAL_27]]) {control = true} : (none) -> (none, index)
 // CHECK:           "handshake.sink"(%[[VAL_44]]#1) : (index) -> ()
-// CHECK:           handshake.return %[[VAL_44]]#0 : none
+// CHECK:           return %[[VAL_44]]#0 : none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test34.mlir
+++ b/test/Conversion/StandardToHandshake/test34.mlir
@@ -51,7 +51,7 @@
 // CHECK:           %[[VAL_20]] = "handshake.branch"(%[[VAL_39]]#0) {control = false} : (index) -> index
 // CHECK:           %[[VAL_46:.*]]:2 = "handshake.control_merge"(%[[VAL_27]]) {control = true} : (none) -> (none, index)
 // CHECK:           "handshake.sink"(%[[VAL_46]]#1) : (index) -> ()
-// CHECK:           handshake.return %[[VAL_46]]#0 : none
+// CHECK:           return %[[VAL_46]]#0 : none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test35.mlir
+++ b/test/Conversion/StandardToHandshake/test35.mlir
@@ -57,7 +57,7 @@
 // CHECK:           %[[VAL_28]] = "handshake.branch"(%[[VAL_50]]#0) {control = false} : (index) -> index
 // CHECK:           %[[VAL_53:.*]]:2 = "handshake.control_merge"(%[[VAL_37]]) {control = true} : (none) -> (none, index)
 // CHECK:           "handshake.sink"(%[[VAL_53]]#1) : (index) -> ()
-// CHECK:           handshake.return %[[VAL_53]]#0 : none
+// CHECK:           return %[[VAL_53]]#0 : none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test4.mlir
+++ b/test/Conversion/StandardToHandshake/test4.mlir
@@ -35,7 +35,7 @@ func @ops(f32, f32, i32, i32) -> (f32, i32) {
 // CHECK:           "handshake.sink"(%[[VAL_24]]) : (i32) -> ()
 // CHECK:           %[[VAL_25:.*]] = arith.xori %[[VAL_10]]#0, %[[VAL_12]]#0 : i32
 // CHECK:           "handshake.sink"(%[[VAL_25]]) : (i32) -> ()
-// CHECK:           handshake.return %[[VAL_13]], %[[VAL_16]], %[[VAL_4]] : f32, i32, none
+// CHECK:           return %[[VAL_13]], %[[VAL_16]], %[[VAL_4]] : f32, i32, none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test5.mlir
+++ b/test/Conversion/StandardToHandshake/test5.mlir
@@ -22,7 +22,7 @@ func @dfs_block_order() -> (i32) {
 // CHECK:           %[[VAL_6]] = "handshake.branch"(%[[VAL_12]]) {control = false} : (i32) -> i32
 // CHECK:           %[[VAL_10]] = "handshake.branch"(%[[VAL_14]]#1) {control = true} : (none) -> none
 // CHECK:           %[[VAL_8]] = "handshake.branch"(%[[VAL_15]]) {control = false} : (i32) -> i32
-// CHECK:           handshake.return %[[VAL_11]], %[[VAL_9]]#0 : i32, none
+// CHECK:           return %[[VAL_11]], %[[VAL_9]]#0 : i32, none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test6.mlir
+++ b/test/Conversion/StandardToHandshake/test6.mlir
@@ -37,7 +37,7 @@ func @ops(f32, f32, i32, i32) -> (f32, i32) {
 // CHECK:           "handshake.sink"(%[[VAL_26]]) : (i32) -> ()
 // CHECK:           %[[VAL_27:.*]] = arith.xori %[[VAL_9]]#0, %[[VAL_11]]#0 : i32
 // CHECK:           "handshake.sink"(%[[VAL_27]]) : (i32) -> ()
-// CHECK:           handshake.return %[[VAL_13]]#0, %[[VAL_18]]#0, %[[VAL_4]] : f32, i32, none
+// CHECK:           return %[[VAL_13]]#0, %[[VAL_18]]#0, %[[VAL_4]] : f32, i32, none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test7.mlir
+++ b/test/Conversion/StandardToHandshake/test7.mlir
@@ -32,7 +32,7 @@ func @simple_loop() {
 // CHECK:           %[[VAL_11]] = "handshake.branch"(%[[VAL_24]]) {control = false} : (index) -> index
 // CHECK:           %[[VAL_25:.*]]:2 = "handshake.control_merge"(%[[VAL_17]]) {control = true} : (none) -> (none, index)
 // CHECK:           "handshake.sink"(%[[VAL_25]]#1) : (index) -> ()
-// CHECK:           handshake.return %[[VAL_25]]#0 : none
+// CHECK:           return %[[VAL_25]]#0 : none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test8.mlir
+++ b/test/Conversion/StandardToHandshake/test8.mlir
@@ -32,7 +32,7 @@ func @simple_loop() {
 // CHECK:           %[[VAL_11]] = "handshake.branch"(%[[VAL_20]]#2) {control = true} : (none) -> none
 // CHECK:           %[[VAL_23:.*]]:2 = "handshake.control_merge"(%[[VAL_17]]) {control = true} : (none) -> (none, index)
 // CHECK:           "handshake.sink"(%[[VAL_23]]#1) : (index) -> ()
-// CHECK:           handshake.return %[[VAL_23]]#0 : none
+// CHECK:           return %[[VAL_23]]#0 : none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test9.mlir
+++ b/test/Conversion/StandardToHandshake/test9.mlir
@@ -72,7 +72,7 @@ func @affine_dma_wait(%arg0: index) {
 // CHECK:           %[[VAL_31]] = "handshake.branch"(%[[VAL_65]]) {control = false} : (index) -> index
 // CHECK:           %[[VAL_66:.*]]:2 = "handshake.control_merge"(%[[VAL_46]]) {control = true} : (none) -> (none, index)
 // CHECK:           "handshake.sink"(%[[VAL_66]]#1) : (index) -> ()
-// CHECK:           handshake.return %[[VAL_66]]#0 : none
+// CHECK:           return %[[VAL_66]]#0 : none
 // CHECK:         }
 // CHECK:       }
 

--- a/test/Conversion/StandardToHandshake/test_call.mlir
+++ b/test/Conversion/StandardToHandshake/test_call.mlir
@@ -5,7 +5,7 @@ func @bar(%0 : i32) -> i32 {
 // CHECK-SAME:                        %[[VAL_0:.*]]: i32,
 // CHECK-SAME:                        %[[VAL_1:.*]]: none, ...) -> (i32, none) attributes {argNames = ["in0", "inCtrl"], resNames = ["out0", "outCtrl"]} {
 // CHECK:           %[[VAL_2:.*]] = "handshake.merge"(%[[VAL_0]]) : (i32) -> i32
-// CHECK:           handshake.return %[[VAL_2]], %[[VAL_1]] : i32, none
+// CHECK:           return %[[VAL_2]], %[[VAL_1]] : i32, none
 // CHECK:         }
 
   return %0 : i32
@@ -17,9 +17,9 @@ func @foo(%0 : i32) -> i32 {
 // CHECK-SAME:                        %[[VAL_1:.*]]: none, ...) -> (i32, none) attributes {argNames = ["in0", "inCtrl"], resNames = ["out0", "outCtrl"]} {
 // CHECK:           %[[VAL_2:.*]] = "handshake.merge"(%[[VAL_0]]) : (i32) -> i32
 // CHECK:           %[[VAL_3:.*]]:2 = "handshake.fork"(%[[VAL_1]]) {control = true} : (none) -> (none, none)
-// CHECK:           %[[VAL_4:.*]]:2 = handshake.instance @bar(%[[VAL_2]], %[[VAL_3]]#0) : (i32, none) -> (i32, none)
+// CHECK:           %[[VAL_4:.*]]:2 = instance @bar(%[[VAL_2]], %[[VAL_3]]#0) : (i32, none) -> (i32, none)
 // CHECK:           "handshake.sink"(%[[VAL_4]]#1) {control = true} : (none) -> ()
-// CHECK:           handshake.return %[[VAL_4]]#0, %[[VAL_3]]#1 : i32, none
+// CHECK:           return %[[VAL_4]]#0, %[[VAL_3]]#1 : i32, none
 // CHECK:         }
 
   %a1 = call @bar(%0) : (i32) -> i32
@@ -70,7 +70,7 @@ func @sub(%arg0 : i32, %arg1: i32) -> i32 {
 // CHECK:           %[[VAL_27:.*]] = "handshake.branch"(%[[VAL_25]]#0) {control = false} : (i32) -> i32
 // CHECK:           %[[VAL_28:.*]]:2 = "handshake.control_merge"(%[[VAL_26]], %[[VAL_19]]) {control = true} : (none, none) -> (none, index)
 // CHECK:           %[[VAL_29:.*]] = "handshake.mux"(%[[VAL_28]]#1, %[[VAL_27]], %[[VAL_20]]) : (index, i32, i32) -> i32
-// CHECK:           handshake.return %[[VAL_29]], %[[VAL_28]]#0 : i32, none
+// CHECK:           return %[[VAL_29]], %[[VAL_28]]#0 : i32, none
 // CHECK:         }
 func @main(%arg0 : i32, %arg1 : i32, %cond : i1) -> i32 {
   cond_br %cond, ^bb1, ^bb2

--- a/test/Conversion/StandardToHandshake/test_canonicalize.mlir
+++ b/test/Conversion/StandardToHandshake/test_canonicalize.mlir
@@ -24,15 +24,15 @@ module {
     %6 = "handshake.constant"(%5#0) {value = 42 : index} : (none) -> index
     %7 = arith.addi %4, %6 : index
     "handshake.sink"(%7) : (index) -> ()
-    handshake.return %5#1 : none
+    return %5#1 : none
   }
 
   // CHECK-LABEL: cmerge_with_control_used
   handshake.func @cmerge_with_control_used(%arg0: none, %arg1: none, %arg2: none) -> (none, index, none) {
     // CHECK: "handshake.control_merge"(%{{.+}}, %{{.+}})
-    // CHECK: handshake.return
+    // CHECK: return
     %result, %index = "handshake.control_merge"(%arg0, %arg1) {control = true} : (none, none) -> (none, index)
-    handshake.return %result, %index, %arg2 : none, index, none
+    return %result, %index, %arg2 : none, index, none
   }
 
   // CHECK-LABEL: cmerge_with_control_sunk
@@ -42,7 +42,7 @@ module {
     // CHECK-NOT: "handshake.sink"
     %result, %index = "handshake.control_merge"(%arg0, %arg1) {control = true} : (none, none) -> (none, index)
     "handshake.sink"(%index) : (index) -> ()
-    handshake.return %result, %arg2 : none, none
+    return %result, %arg2 : none, none
   }
 
   // CHECK-LABEL: cmerge_with_control_ignored
@@ -50,7 +50,7 @@ module {
     // CHECK: "handshake.merge"(%{{.+}}, %{{.+}})
     // CHECK-NOT: "handshake.control_merge"
     %result, %index = "handshake.control_merge"(%arg0, %arg1) {control = true} : (none, none) -> (none, index)
-    handshake.return %result, %arg2 : none, none
+    return %result, %arg2 : none, none
   }
 
   // CHECK-LABEL: sunk_constant
@@ -59,6 +59,6 @@ module {
     // CHECK-NOT: handshake.sink
     %0 = "handshake.constant"(%arg0) { value = 24 : i8 } : (none) -> i8
     "handshake.sink"(%0) : (i8) -> ()
-    handshake.return %arg0: none
+    return %arg0: none
   }
 }

--- a/test/Conversion/StandardToHandshake/test_insert_buffer.mlir
+++ b/test/Conversion/StandardToHandshake/test_insert_buffer.mlir
@@ -83,6 +83,6 @@ module {
     // ALL: "handshake.buffer"
     "handshake.sink"(%25#1) : (index) -> ()
     // ALL: "handshake.buffer"
-    handshake.return %25#0 : none
+    return %25#0 : none
   }
 }

--- a/test/Conversion/StandardToHandshake/test_insert_buffer_errors.mlir
+++ b/test/Conversion/StandardToHandshake/test_insert_buffer_errors.mlir
@@ -3,6 +3,6 @@
 module {
   // expected-error @+1 {{Unknown buffer strategy: foo}}
   handshake.func @test(%arg0: none, ...) -> none {
-    handshake.return %arg0 : none
+    return %arg0 : none
   }
 }


### PR DESCRIPTION
This avoids the need for the 'handshake' prefix in the textual IR.