### PR TITLE
[StaticLogic] Verify the pipeline II attribute when present.

### DIFF
--- a/include/circt/Dialect/StaticLogic/StaticLogic.h
+++ b/include/circt/Dialect/StaticLogic/StaticLogic.h
@@ -30,6 +30,15 @@
 
 #include "circt/Dialect/StaticLogic/StaticLogicDialect.h.inc"
 
+// Represents a recurrence-constrained minimum initiation interval. The ii
+// represents the numerical value itself, and the iter arg def and use hold the
+// definition and use of Values that constrain the ii.
+struct RecMII {
+  uint64_t ii;
+  mlir::Value iterArgDef;
+  mlir::OpOperand *iterArgUse;
+};
+
 #define GET_OP_CLASSES
 #include "circt/Dialect/StaticLogic/StaticLogic.h.inc"
 

--- a/include/circt/Dialect/StaticLogic/StaticLogic.td
+++ b/include/circt/Dialect/StaticLogic/StaticLogic.td
@@ -141,8 +141,20 @@ def PipelineWhileOp : Op<StaticLogic_Dialect, "pipeline.while", []> {
   ];
 
   let extraClassDeclaration = [{
+    // Get the condition block.
     Block &getCondBlock() { return condition().front(); }
+
+    // Get the stages block.
     Block &getStagesBlock() { return stages().front(); }
+
+    // Get the terminator of the pipeline.
+    PipelineTerminatorOp getTerminator();
+
+    // Compute the distance between the two stages.
+    uint64_t computeDistance(PipelineStageOp, PipelineStageOp);
+
+    // Compute the initiation interval based on the iter_args def-use chains.
+    uint64_t computeInitiationInterval();
   }];
 }
 

--- a/include/circt/Dialect/StaticLogic/StaticLogic.td
+++ b/include/circt/Dialect/StaticLogic/StaticLogic.td
@@ -150,11 +150,12 @@ def PipelineWhileOp : Op<StaticLogic_Dialect, "pipeline.while", []> {
     // Get the terminator of the pipeline.
     PipelineTerminatorOp getTerminator();
 
-    // Compute the distance between the two stages.
-    uint64_t computeDistance(PipelineStageOp, PipelineStageOp);
+    // Compute the number of stages between the two stages.
+    uint64_t computeNumStages(PipelineStageOp, PipelineStageOp);
 
-    // Compute the initiation interval based on the iter_args def-use chains.
-    uint64_t computeInitiationInterval();
+    // Compute the recurrence-constrained minimum initiation interval, based on
+    // the iter_args definitions and uses.
+    RecMII computeRecMII();
   }];
 }
 

--- a/lib/Conversion/AffineToStaticLogic/AffineToStaticLogic.cpp
+++ b/lib/Conversion/AffineToStaticLogic/AffineToStaticLogic.cpp
@@ -238,8 +238,7 @@ LogicalResult AffineToStaticLogic::createStaticLogicPipeline(
   stageBlock.getTerminator()->insertOperands(0, {incResult});
 
   // Add the induction variable result to the terminator iter args.
-  auto stagesTerminator =
-      cast<PipelineTerminatorOp>(stagesBlock.getTerminator());
+  auto stagesTerminator = pipeline.getTerminator();
   stagesTerminator.iter_argsMutable().append({stage.getResult(0)});
 
   // Remove the loop nest from the IR.

--- a/lib/Dialect/StaticLogic/StaticLogicOps.cpp
+++ b/lib/Dialect/StaticLogic/StaticLogicOps.cpp
@@ -203,23 +203,15 @@ PipelineTerminatorOp PipelineWhileOp::getTerminator() {
 /// Compute the number of stages between the two stages.
 uint64_t PipelineWhileOp::computeNumStages(PipelineStageOp from,
                                            PipelineStageOp to) {
-  // If from and to are the same, distance is 0.
-  if (from == to)
+  // If from and to are non-null and the same, distance is 0.
+  if (from && to && from == to)
     return 0;
 
   // Ensure these are valid stages within this pipeline.
   assert(from && to && from->getParentOp() == getOperation() &&
          to->getParentOp() == getOperation() && from->isBeforeInBlock(to));
 
-  // Traverse the linked list to determine the distance.
-  uint64_t distance = 0;
-  Operation *current = from;
-  while (current != to) {
-    current = from->getNextNode();
-    ++distance;
-  }
-
-  return distance;
+  return std::distance(from->getIterator(), to->getIterator());
 }
 
 /// Compute the recurrence-constrained minimum initiation interval, based on the

--- a/lib/Dialect/StaticLogic/StaticLogicOps.cpp
+++ b/lib/Dialect/StaticLogic/StaticLogicOps.cpp
@@ -203,12 +203,14 @@ PipelineTerminatorOp PipelineWhileOp::getTerminator() {
 /// Compute the number of stages between the two stages.
 uint64_t PipelineWhileOp::computeNumStages(PipelineStageOp from,
                                            PipelineStageOp to) {
-  // If from and to are non-null and the same, distance is 0.
-  if (from && to && from == to)
+  assert(from && to && "must specify non-null stages");
+
+  // If from and to are the same, the number of stages is 0.
+  if (from == to)
     return 0;
 
   // Ensure these are valid stages within this pipeline.
-  assert(from && to && from->getParentOp() == getOperation() &&
+  assert(from->getParentOp() == getOperation() &&
          to->getParentOp() == getOperation() && from->isBeforeInBlock(to));
 
   return std::distance(from->getIterator(), to->getIterator());

--- a/test/Dialect/StaticLogic/errors.mlir
+++ b/test/Dialect/StaticLogic/errors.mlir
@@ -156,3 +156,27 @@ func @invalid_results() {
   }
   return
 }
+
+// -----
+
+func @invalid_initiation_interval() {
+  %c0_i64 = arith.constant 0 : i64
+  %c10_i64 = arith.constant 10 : i64
+  %c1_i64 = arith.constant 1 : i64
+ // expected-error @+1 {{'staticlogic.pipeline.while' op computed minimum II of 2 was greater than specified II of 1}}
+  staticlogic.pipeline.while II =  1 iter_args(%arg0 = %c0_i64) : (i64) -> () {
+    %0 = arith.cmpi ult, %arg0, %c10_i64 : i64
+    staticlogic.pipeline.register %0 : i1
+  } do {
+    %0 = staticlogic.pipeline.stage  {
+      %1 = arith.addi %arg0, %c1_i64 : i64
+      staticlogic.pipeline.register %1 : i64
+    } : i64
+    %2 = staticlogic.pipeline.stage {
+      %3 = arith.addi %arg0, %c1_i64 : i64
+      staticlogic.pipeline.register %3 : i64
+    } : i64
+    staticlogic.pipeline.terminator iter_args(%0), results() : (i64) -> ()
+  }
+  return
+}

--- a/test/Dialect/StaticLogic/errors.mlir
+++ b/test/Dialect/StaticLogic/errors.mlir
@@ -163,16 +163,19 @@ func @invalid_initiation_interval() {
   %c0_i64 = arith.constant 0 : i64
   %c10_i64 = arith.constant 10 : i64
   %c1_i64 = arith.constant 1 : i64
- // expected-error @+1 {{'staticlogic.pipeline.while' op computed minimum II of 2 was greater than specified II of 1}}
+  // expected-error @+2 {{'staticlogic.pipeline.while' op computed minimum II of 2 was greater than specified II of 1}}
+  // expected-note @+1 {{this iter arg}}
   staticlogic.pipeline.while II =  1 iter_args(%arg0 = %c0_i64) : (i64) -> () {
     %0 = arith.cmpi ult, %arg0, %c10_i64 : i64
     staticlogic.pipeline.register %0 : i1
   } do {
+    // expected-note @+1 {{iter arg defined here}}
     %0 = staticlogic.pipeline.stage  {
       %1 = arith.addi %arg0, %c1_i64 : i64
       staticlogic.pipeline.register %1 : i64
     } : i64
     %2 = staticlogic.pipeline.stage {
+      // expected-note @+1 {{iter arg used here}}
       %3 = arith.addi %arg0, %c1_i64 : i64
       staticlogic.pipeline.register %3 : i64
     } : i64


### PR DESCRIPTION
This computes a minimum initiation interval for the pipeline based on
the iter args definitions and uses. It then compares the computed II
against the II attribute that was specified when the pipeline was
created.

The same logic could be used to infer an II when one is not specified,
but that is left as a future enhancement.