### PR TITLE
[FIRRTL] Use inner names to make GCT data taps more robust

### DIFF
--- a/test/Dialect/FIRRTL/SFCTests/data-taps.anno.json
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps.anno.json
@@ -23,7 +23,7 @@
   },
   {
     "class":"sifive.enterprise.grandcentral.MemTapAnnotation",
-    "source": "~Top|Child>M",
+    "source": "~Top|Child>always",
     "taps":["~Top|MemTap_2>_0", "~Top|MemTap_2>_1"]
   }
 ]

--- a/test/Dialect/FIRRTL/SFCTests/data-taps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps.fir
@@ -14,35 +14,35 @@ circuit Top :
     input reset : Reset
     output io : { flip in : UInt<1>, out : UInt<1>}
 
-    inst bb of BlackBox
-    bb.out is invalid
-    bb.in is invalid
-    bb.in <= io.in
-    io.out <= bb.out
+    inst localparam of BlackBox
+    localparam.out is invalid
+    localparam.in is invalid
+    localparam.in <= io.in
+    io.out <= localparam.out
 
-    mem M :
+    mem always :
       data-type => UInt<1>
       depth => 2
       read-latency => 0
       write-latency => 1
       writer => w
       read-under-write => undefined
-    M.w.clk <= clock
-    M.w.en <= UInt<1>(1)
-    M.w.addr <= UInt<1>(0)
-    M.w.data <= io.in
-    M.w.mask <= UInt<1>(1)
+    always.w.clk <= clock
+    always.w.en <= UInt<1>(1)
+    always.w.addr <= UInt<1>(0)
+    always.w.data <= io.in
+    always.w.mask <= UInt<1>(1)
 
   module ChildWrapper :
     input clock : Clock
     input reset : Reset
     output io : { flip in : UInt<1>, out : UInt<1>}
 
-    inst child of Child
-    child.clock <= clock
-    child.reset <= reset
-    child.io.in <= io.in
-    io.out <= child.io.out
+    inst signed of Child
+    signed.clock <= clock
+    signed.reset <= reset
+    signed.io.in <= io.in
+    io.out <= signed.io.out
 
   extmodule DataTap_2 :
     output _1 : UInt<1>
@@ -59,9 +59,9 @@ circuit Top :
     input reset : UInt<1>
     output io : { flip in : UInt<1>, out : UInt<1>}
 
-    inst child of ChildWrapper
-    child.clock <= clock
-    child.reset <= reset
+    inst unsigned of ChildWrapper
+    unsigned.clock <= clock
+    unsigned.reset <= reset
     wire in : UInt<1>
     wire out : UInt<1>
     inst DataTap_2 of DataTap_2
@@ -70,21 +70,21 @@ circuit Top :
     in <= DataTap_2._0
     out <= DataTap_2._1
     node _child_io_in_T = and(io.in, in)
-    child.io.in <= _child_io_in_T
-    node _io_out_T = and(child.io.out, out)
+    unsigned.io.in <= _child_io_in_T
+    node _io_out_T = and(unsigned.io.out, out)
     io.out <= _io_out_T
     inst MemTap_2 of MemTap_2
 
 ; CHECK: module DataTap_2_impl_0(
 ; CHECK:   output  _1, _0
 ; CHECK: );
-; CHECK:   assign _1 = Top.child.child.bb.foo.bar.out;
-; CHECK:   assign _0 = Top.child.child.bb.foo.bar.in;
+; CHECK:   assign _1 = Top.unsigned_0.signed_0.localparam_0.foo.bar.out;
+; CHECK:   assign _0 = Top.unsigned_0.signed_0.localparam_0.foo.bar.in;
 ; CHECK: endmodule
 
 ; CHECK: module MemTap_2_impl_0(
 ; CHECK:   output  _1, _0
 ; CHECK: );
-; CHECK:   assign _1 = Top.child.child.M.Memory[1];
-; CHECK:   assign _0 = Top.child.child.M.Memory[0];
+; CHECK:   assign _1 = Top.unsigned_0.signed_0.always_1.Memory[1];
+; CHECK:   assign _0 = Top.unsigned_0.signed_0.always_1.Memory[0];
 ; CHECK: endmodule

--- a/test/Dialect/FIRRTL/grand-central-taps.mlir
+++ b/test/Dialect/FIRRTL/grand-central-taps.mlir
@@ -7,7 +7,9 @@ firrtl.circuit "TestHarness" attributes {
     filename = "outputDirectory/bindings.sv"
   }]
 } {
-  // CHECK-LABEL: firrtl.module @Bar
+  // CHECK: firrtl.module @Bar
+  // CHECK-SAME: in %clock: !firrtl.clock sym [[BAR_CLOCK:@[0-9a-zA-Z_]+]]
+  // CHECK-SAME: in %reset: !firrtl.reset sym [[BAR_RESET:@[0-9a-zA-Z_]+]]
   // CHECK-NOT: class = "sifive.enterprise.grandcentral.ReferenceDataTapKey"
   firrtl.module @Bar(
     in %clock: !firrtl.clock,
@@ -27,7 +29,7 @@ firrtl.circuit "TestHarness" attributes {
       type = "source"
     } ],[],[] ] }
   {
-    // CHECK-LABEL: %wire = firrtl.wire
+    // CHECK: %wire = firrtl.wire sym [[WIRE:@[0-9a-zA-Z_]+]]
     // CHECK-NOT: class = "sifive.enterprise.grandcentral.ReferenceDataTapKey"
     // CHECK-SAME: class = "firrtl.transforms.DontTouchAnnotation"
     %wire = firrtl.wire {annotations = [{
@@ -39,7 +41,7 @@ firrtl.circuit "TestHarness" attributes {
       class = "firrtl.transforms.DontTouchAnnotation"
     }]} : !firrtl.uint<1>
 
-    // CHECK-LABEL: %node = firrtl.node
+    // CHECK: %node = firrtl.node sym [[NODE:@[0-9a-zA-Z_]+]]
     // CHECK-NOT: class = "sifive.enterprise.grandcentral.ReferenceDataTapKey"
     // CHECK-SAME: class = "firrtl.transforms.DontTouchAnnotation"
     %node = firrtl.node %in {annotations = [{
@@ -51,7 +53,7 @@ firrtl.circuit "TestHarness" attributes {
       class = "firrtl.transforms.DontTouchAnnotation"
     }]} : !firrtl.uint<1>
 
-    // CHECK-LABEL: %reg = firrtl.reg
+    // CHECK: %reg = firrtl.reg sym [[REG:@[0-9a-zA-Z_]+]]
     // CHECK-NOT: class = "sifive.enterprise.grandcentral.ReferenceDataTapKey"
     // CHECK-SAME: class = "firrtl.transforms.DontTouchAnnotation"
     %reg = firrtl.reg %clock {annotations = [{
@@ -63,7 +65,7 @@ firrtl.circuit "TestHarness" attributes {
       class = "firrtl.transforms.DontTouchAnnotation"
     }]} : !firrtl.uint<1>
 
-    // CHECK-LABEL: %regreset = firrtl.regreset
+    // CHECK: %regreset = firrtl.regreset sym [[REGRESET:@[0-9a-zA-Z_]+]]
     // CHECK-NOT: class = "sifive.enterprise.grandcentral.ReferenceDataTapKey"
     // CHECK-SAME: class = "firrtl.transforms.DontTouchAnnotation"
     %regreset = firrtl.regreset %clock, %reset, %in {annotations = [{
@@ -75,7 +77,7 @@ firrtl.circuit "TestHarness" attributes {
       class = "firrtl.transforms.DontTouchAnnotation"
     }]} : !firrtl.reset, !firrtl.uint<1>, !firrtl.uint<1>
 
-    // CHECK-LABEL: firrtl.mem Undefined
+    // CHECK: firrtl.mem sym [[MEM:@[0-9a-zA-Z_]+]] Undefined
     // CHECK-NOT: class = "sifive.enterprise.grandcentral.MemTapAnnotation"
     // CHECK-SAME: class = "firrtl.transforms.DontTouchAnnotation"
     %mem = firrtl.mem Undefined {
@@ -109,7 +111,8 @@ firrtl.circuit "TestHarness" attributes {
     in %in: !firrtl.uint<1>,
     out %out: !firrtl.uint<1>
   ) {
-    %bar_clock, %bar_reset, %bar_in, %bar_out = firrtl.instance "bar" @Bar(in clock: !firrtl.clock, in reset: !firrtl.reset, in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
+    // CHECK: firrtl.instance bar sym [[BAR:@[0-9a-zA-Z_]+]]
+    %bar_clock, %bar_reset, %bar_in, %bar_out = firrtl.instance bar @Bar(in clock: !firrtl.clock, in reset: !firrtl.reset, in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
     firrtl.connect %bar_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %bar_reset, %reset : !firrtl.reset, !firrtl.reset
     firrtl.connect %bar_in, %in : !firrtl.uint<1>, !firrtl.uint<1>
@@ -129,27 +132,58 @@ firrtl.circuit "TestHarness" attributes {
   // CHECK-SAME: out %_1: !firrtl.clock
   // CHECK-SAME: out %_0: !firrtl.uint<1>
   // CHECK-SAME: #hw.output_file<"outputDirectory/[[DT]].sv">
-  // CHECK-NEXT: [[V10:%.+]] = firrtl.verbatim.expr "TestHarness.harnessWire"
+  // CHECK-NEXT: [[V10:%.+]] = firrtl.verbatim.expr "{{[{][{]0[}][}]}}.{{[{][{]1[}][}]}}"
+  // CHECK-SAME:   @TestHarness,
+  // CHECK-SAME:   #hw.innerNameRef<@TestHarness::[[HARNESSWIRE:@[0-9a-zA-Z_]+]]>
   // CHECK-NEXT: firrtl.connect %_10, [[V10]]
   // CHECK-NEXT: [[V9:%.+]] = firrtl.constant 0 : !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %_9, [[V9]]
   // CHECK-NEXT: [[V8:%.+]] = firrtl.constant -42 : !firrtl.sint<8>
   // CHECK-NEXT: firrtl.connect %_8, [[V8]]
-  // CHECK-NEXT: [[V7:%.+]] = firrtl.verbatim.expr "TestHarness.extmoduleWithTappedPort.out"
+  // CHECK-NEXT: [[V7:%.+]] = firrtl.verbatim.expr "{{[{][{]0[}][}]}}.{{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}"
+  // CHECK-SAME:   @TestHarness,
+  // CHECK-SAME:   #hw.innerNameRef<@TestHarness::[[EXTMODULEWITHTAPPEDPORT:@[0-9a-zA-Z_]+]]>,
+  // CHECK-SAME:   #hw.innerNameRef<@ExtmoduleWithTappedPort::[[EXTMODULEWITHTAPPEDPORTOUT:@[0-9a-zA-Z_]+]]>
   // CHECK-NEXT: firrtl.connect %_7, [[V7]]
-  // CHECK-NEXT: [[V6:%.+]] = firrtl.verbatim.expr "TestHarness.foo.bar.regreset"
+  // CHECK-NEXT: [[V6:%.+]] = firrtl.verbatim.expr "{{[{][{]0[}][}]}}.{{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}.{{[{][{]3[}][}]}}"
+  // CHECK-SAME:   @TestHarness,
+  // CHECK-SAME:   #hw.innerNameRef<@TestHarness::[[FOO:@[0-9a-zA-Z_]+]]>,
+  // CHECK-SAME:   #hw.innerNameRef<@Foo::[[BAR]]>,
+  // CHECK-SAME:   #hw.innerNameRef<@Bar::[[REGRESET]]>
   // CHECK-NEXT: firrtl.connect %_6, [[V6]]
-  // CHECK-NEXT: [[V5:%.+]] = firrtl.verbatim.expr "TestHarness.foo.bar.reg"
+  // CHECK-NEXT: [[V5:%.+]] = firrtl.verbatim.expr "{{[{][{]0[}][}]}}.{{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}.{{[{][{]3[}][}]}}"
+  // CHECK-SAME:   @TestHarness,
+  // CHECK-SAME:   #hw.innerNameRef<@TestHarness::[[FOO]]>,
+  // CHECK-SAME:   #hw.innerNameRef<@Foo::[[BAR]]>,
+  // CHECK-SAME:   #hw.innerNameRef<@Bar::[[REG]]>
   // CHECK-NEXT: firrtl.connect %_5, [[V5]]
-  // CHECK-NEXT: [[V4:%.+]] = firrtl.verbatim.expr "TestHarness.foo.bar.node"
+  // CHECK-NEXT: [[V4:%.+]] = firrtl.verbatim.expr "{{[{][{]0[}][}]}}.{{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}.{{[{][{]3[}][}]}}"
+  // CHECK-SAME:   @TestHarness,
+  // CHECK-SAME:   #hw.innerNameRef<@TestHarness::[[FOO]]>,
+  // CHECK-SAME:   #hw.innerNameRef<@Foo::[[BAR]]>,
+  // CHECK-SAME:   #hw.innerNameRef<@Bar::[[NODE]]>
   // CHECK-NEXT: firrtl.connect %_4, [[V4]]
-  // CHECK-NEXT: [[V3:%.+]] = firrtl.verbatim.expr "TestHarness.bigScary.schwarzschild.no.more"
+  // CHECK-NEXT: [[V3:%.+]] = firrtl.verbatim.expr "{{[{][{]0[}][}]}}.{{[{][{]1[}][}]}}.schwarzschild.no.more"
+  // CHECK-SAME:   @TestHarness,
+  // CHECK-SAME:   #hw.innerNameRef<@TestHarness::[[BIGSCARY:@[0-9a-zA-Z_]+]]>
   // CHECK-NEXT: firrtl.connect %_3, [[V3]]
-  // CHECK-NEXT: [[V2:%.+]] = firrtl.verbatim.expr "TestHarness.foo.bar.reset"
+  // CHECK-NEXT: [[V2:%.+]] = firrtl.verbatim.expr "{{[{][{]0[}][}]}}.{{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}.{{[{][{]3[}][}]}}"
+  // CHECK-SAME:   @TestHarness,
+  // CHECK-SAME:   #hw.innerNameRef<@TestHarness::[[FOO]]>,
+  // CHECK-SAME:   #hw.innerNameRef<@Foo::[[BAR]]>,
+  // CHECK-SAME:   #hw.innerNameRef<@Bar::[[BAR_RESET]]>
   // CHECK-NEXT: firrtl.connect %_2, [[V2]]
-  // CHECK-NEXT: [[V1:%.+]] = firrtl.verbatim.expr "TestHarness.foo.bar.clock"
+  // CHECK-NEXT: [[V1:%.+]] = firrtl.verbatim.expr "{{[{][{]0[}][}]}}.{{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}.{{[{][{]3[}][}]}}"
+  // CHECK-SAME:   @TestHarness,
+  // CHECK-SAME:   #hw.innerNameRef<@TestHarness::[[FOO]]>,
+  // CHECK-SAME:   #hw.innerNameRef<@Foo::[[BAR]]>,
+  // CHECK-SAME:   #hw.innerNameRef<@Bar::[[BAR_CLOCK]]>
   // CHECK-NEXT: firrtl.connect %_1, [[V1]]
-  // CHECK-NEXT: [[V0:%.+]] = firrtl.verbatim.expr "TestHarness.foo.bar.wire"
+  // CHECK-NEXT: [[V0:%.+]] = firrtl.verbatim.expr "{{[{][{]0[}][}]}}.{{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}.{{[{][{]3[}][}]}}"
+  // CHECK-SAME:   @TestHarness,
+  // CHECK-SAME:   #hw.innerNameRef<@TestHarness::[[FOO]]>,
+  // CHECK-SAME:   #hw.innerNameRef<@Foo::[[BAR]]>,
+  // CHECK-SAME:   #hw.innerNameRef<@Bar::[[WIRE]]>
   // CHECK-NEXT: firrtl.connect %_0, [[V0]]
   firrtl.extmodule @DataTap(
     out _10: !firrtl.uint<4>,
@@ -190,9 +224,17 @@ firrtl.circuit "TestHarness" attributes {
   // CHECK-SAME: out %mem_1: !firrtl.uint<1>
   // CHECK-SAME: class = "firrtl.transforms.NoDedupAnnotation"
   // CHECK-SAME: #hw.output_file<"outputDirectory/[[MT]].sv">
-  // CHECK-NEXT: [[V0:%.+]] = firrtl.verbatim.expr "TestHarness.foo.bar.mem.Memory[0]"
+  // CHECK-NEXT: [[V0:%.+]] = firrtl.verbatim.expr "{{[{][{]0[}][}]}}.{{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}.{{[{][{]3[}][}]}}.Memory[0]"
+  // CHECK-SAME:   @TestHarness,
+  // CHECK-SAME:   #hw.innerNameRef<@TestHarness::[[FOO]]>,
+  // CHECK-SAME:   #hw.innerNameRef<@Foo::[[BAR]]>,
+  // CHECK-SAME:   #hw.innerNameRef<@Bar::[[MEM]]>
   // CHECK-NEXT: firrtl.connect %mem_0, [[V0:%.+]]
-  // CHECK-NEXT: [[V1:%.+]] = firrtl.verbatim.expr "TestHarness.foo.bar.mem.Memory[1]"
+  // CHECK-NEXT: [[V1:%.+]] = firrtl.verbatim.expr "{{[{][{]0[}][}]}}.{{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}.{{[{][{]3[}][}]}}.Memory[1]"
+  // CHECK-SAME:   @TestHarness,
+  // CHECK-SAME:   #hw.innerNameRef<@TestHarness::[[FOO]]>,
+  // CHECK-SAME:   #hw.innerNameRef<@Foo::[[BAR]]>,
+  // CHECK-SAME:   #hw.innerNameRef<@Bar::[[MEM]]>
   // CHECK-NEXT: firrtl.connect %mem_1, [[V1:%.+]]
   firrtl.extmodule @MemTap(
     out mem_0: !firrtl.uint<1>,
@@ -218,6 +260,8 @@ firrtl.circuit "TestHarness" attributes {
       portID = 4 : i64 }]
   }
 
+  // CHECK-LABEL: firrtl.extmodule @ExtmoduleWithTappedPort
+  // CHECK-SAME: out out: !firrtl.uint<1> sym [[EXTMODULEWITHTAPPEDPORTOUT]]
   firrtl.extmodule @ExtmoduleWithTappedPort(
     out out: !firrtl.uint<1>) attributes {portAnnotations = [[{
       class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
@@ -227,7 +271,7 @@ firrtl.circuit "TestHarness" attributes {
 
   // CHECK: firrtl.module @TestHarness
   firrtl.module @TestHarness(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
-    // CHECK-LABEL: %harnessWire = firrtl.wire
+    // CHECK: %harnessWire = firrtl.wire sym [[HARNESSWIRE]]
     // CHECK-NOT: class = "sifive.enterprise.grandcentral.ReferenceDataTapKey"
     // CHECK-SAME: class = "firrtl.transforms.DontTouchAnnotation"
     %harnessWire = firrtl.wire {annotations = [{
@@ -239,12 +283,15 @@ firrtl.circuit "TestHarness" attributes {
       class = "firrtl.transforms.DontTouchAnnotation"
     }]} : !firrtl.uint<4>
 
+    // CHECK: firrtl.instance foo sym [[FOO]]
     %foo_clock, %foo_reset, %foo_in, %foo_out = firrtl.instance foo @Foo(in clock: !firrtl.clock, in reset: !firrtl.reset, in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
     firrtl.connect %foo_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %foo_reset, %reset : !firrtl.reset, !firrtl.uint<1>
     firrtl.connect %foo_in, %in : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %out, %foo_out : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK: firrtl.instance bigScary sym [[BIGSCARY]]
     firrtl.instance bigScary @BlackHole()
+    // CHECK: firrtl.instance extmoduleWithTappedPort sym [[EXTMODULEWITHTAPPEDPORT]]
     %0 = firrtl.instance extmoduleWithTappedPort @ExtmoduleWithTappedPort(out out: !firrtl.uint<1>)
     // CHECK: firrtl.instance dataTap @[[DT]]
     %DataTap_10, %DataTap_9, %DataTap_8, %DataTap_7, %DataTap_6, %DataTap_5, %DataTap_4, %DataTap_3, %DataTap_2, %DataTap_1, %DataTap_0 = firrtl.instance dataTap @DataTap(out _10: !firrtl.uint<4>, out _9: !firrtl.uint<1>, out _8: !firrtl.sint<8>, out _7: !firrtl.uint<1>, out _6: !firrtl.uint<1>, out _5: !firrtl.uint<1>, out _4: !firrtl.uint<1>, out _3: !firrtl.uint<1>, out _2: !firrtl.uint<1>, out _1: !firrtl.clock, out _0: !firrtl.uint<1>)


### PR DESCRIPTION
Make use of the new `inner_sym` added to the FIRRTL dialect to replace a lot of the hard-coded declaration names in the `GrandCentralTapsPass` with placeholders that get replaced with the final names during emission in `ExportVerilog`.