### PR TITLE
[FIRRTL] Use inner name refs for GCT interface emission

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -620,7 +620,8 @@ void EmitterBase::emitTextWithSubstitutions(
         return state.globalNames.getPortVerilogName(itemOp,
                                                     portInfos[item.getPort()]);
       }
-      if (isa<WireOp, RegOp, LocalParamOp, InstanceOp>(itemOp))
+      if (isa<WireOp, RegOp, LocalParamOp, InstanceOp, InterfaceInstanceOp>(
+              itemOp))
         return state.globalNames.getDeclarationVerilogName(itemOp);
       StringRef symOpName = getSymOpName(itemOp);
       if (!symOpName.empty())
@@ -4005,6 +4006,13 @@ void SharedEmitterState::gatherFiles(bool separateModules) {
       if (auto name = op->getAttrOfType<StringAttr>(
               hw::InnerName::getInnerNameAttrName()))
         symbolCache.addDefinition(moduleOp.getNameAttr(), name.getValue(), op);
+      // HACK: This is to make interface-related operations work as they are at
+      // the moment, with names being stored in `sym_name` instead of
+      // `inner_sym`.
+      if (auto instOp = dyn_cast<InterfaceInstanceOp>(op))
+        if (auto attr = instOp.sym_nameAttr())
+          symbolCache.addDefinition(moduleOp.getNameAttr(), attr.getValue(),
+                                    op);
       if (isa<BindOp>(op))
         modulesContainingBinds.insert(moduleOp);
     });

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -364,6 +364,89 @@ struct MappingContextTraits<sv::InterfaceOp, Context> {
 //===----------------------------------------------------------------------===//
 
 namespace {
+
+/// A helper to build verbatim strings with symbol placeholders. Provides a
+/// mechanism to snapshot the current string and symbols and restore back to
+/// this state after modifications. These snapshots are particularly useful when
+/// the string is assembled through hierarchical traversal of some sort, which
+/// populates the string with a prefix common to all children of a hierarchy
+/// (like the interface field traversal in the `GrandCentralPass`).
+///
+/// The intended use is as follows:
+///
+///     void baz(VerbatimBuilder &v) {
+///       foo(v.snapshot().append("bar"));
+///     }
+///
+/// The function `baz` takes a snapshot of the current verbatim text `v`, adds
+/// "bar" to it and calls `foo` with that appended verbatim text. After the call
+/// to `foo` returns, any changes made by `foo` as well as the "bar" are dropped
+/// from the verbatim text `v`, as the temporary snapshot goes out of scope.
+struct VerbatimBuilder {
+  struct Base {
+    SmallString<128> string;
+    SmallVector<Attribute> symbols;
+    VerbatimBuilder builder() { return VerbatimBuilder(*this); }
+    operator VerbatimBuilder() { return builder(); }
+  };
+
+  /// Constructing a builder will snapshot the `Base` which holds the actual
+  /// string and symbols.
+  VerbatimBuilder(Base &base)
+      : base(base), stringBaseSize(base.string.size()),
+        symbolsBaseSize(base.symbols.size()) {}
+
+  /// Destroying a builder will reset the `Base` to the original string and
+  /// symbols.
+  ~VerbatimBuilder() {
+    base.string.resize(stringBaseSize);
+    base.symbols.resize(symbolsBaseSize);
+  }
+
+  // Disallow copying.
+  VerbatimBuilder(const VerbatimBuilder &) = delete;
+  VerbatimBuilder &operator=(const VerbatimBuilder &) = delete;
+
+  /// Take a snapshot of the current string and symbols. This returns a new
+  /// `VerbatimBuilder` that will reset to the current state of the string once
+  /// destroyed.
+  VerbatimBuilder snapshot() { return VerbatimBuilder(base); }
+
+  /// Get the current string.
+  StringRef getString() const { return base.string; }
+  /// Get the current symbols;
+  ArrayRef<Attribute> getSymbols() const { return base.symbols; }
+
+  /// Append to the string.
+  VerbatimBuilder &append(char c) {
+    base.string.push_back(c);
+    return *this;
+  }
+
+  /// Append to the string.
+  VerbatimBuilder &append(const Twine &twine) {
+    twine.toVector(base.string);
+    return *this;
+  }
+
+  /// Append a placeholder and symbol to the string.
+  VerbatimBuilder &append(Attribute symbol) {
+    unsigned id = base.symbols.size();
+    base.symbols.push_back(symbol);
+    append("{{" + Twine(id) + "}}");
+    return *this;
+  }
+
+  VerbatimBuilder &operator+=(char c) { return append(c); }
+  VerbatimBuilder &operator+=(const Twine &twine) { return append(twine); }
+  VerbatimBuilder &operator+=(Attribute symbol) { return append(symbol); }
+
+private:
+  Base &base;
+  size_t stringBaseSize;
+  size_t symbolsBaseSize;
+};
+
 /// A wrapper around a string that is used to encode a type which cannot be
 /// represented by an mlir::Type for some reason.  This is currently used to
 /// represent either an interface, a n-dimensional vector of interfaces, or a
@@ -470,20 +553,20 @@ private:
 
   /// Recursively examine an AugmentedType to populate the "mappings" file
   /// (generate XMRs) for this interface.  This does not build new interfaces.
-  bool traverseField(Attribute field, IntegerAttr id, Twine path);
+  bool traverseField(Attribute field, IntegerAttr id, VerbatimBuilder &path);
 
   /// Recursively examine an AugmentedType to both build new interfaces and
   /// populate a "mappings" file (generate XMRs) using `traverseField`.  Return
   /// the type of the field exmained.
   Optional<TypeSum> computeField(Attribute field, IntegerAttr id,
-                                 StringAttr prefix, Twine path);
+                                 StringAttr prefix, VerbatimBuilder &path);
 
   /// Recursively examine an AugmentedBundleType to both build new interfaces
   /// and populate a "mappings" file (generate XMRs).  Return none if the
   /// interface is invalid.
   Optional<sv::InterfaceOp> traverseBundle(AugmentedBundleTypeAttr bundle,
                                            IntegerAttr id, StringAttr prefix,
-                                           Twine path);
+                                           VerbatimBuilder &path);
 
   /// Return the module associated with this value.
   FModuleLike getEnclosingModule(Value value);
@@ -514,12 +597,25 @@ private:
   /// using `getNamesapce`.
   Optional<CircuitNamespace> circuitNamespace = None;
 
+  /// The module namespaces. These are lazily constructed by
+  /// `getModuleNamespace`.
+  DenseMap<Operation *, ModuleNamespace> moduleNamespaces;
+
   /// Return a reference to the circuit namespace.  This will lazily construct a
   /// namespace if one does not exist.
   CircuitNamespace &getNamespace() {
     if (!circuitNamespace)
       circuitNamespace = CircuitNamespace(getOperation());
     return circuitNamespace.getValue();
+  }
+
+  /// Get the cached namespace for a module.
+  ModuleNamespace &getModuleNamespace(FModuleLike module) {
+    auto it = moduleNamespaces.find(module);
+    if (it != moduleNamespaces.end())
+      return it->second;
+    return moduleNamespaces.insert({module, ModuleNamespace(module)})
+        .first->second;
   }
 
   /// A symbol table associated with the circuit.  This is lazily constructed by
@@ -561,6 +657,20 @@ private:
 
   /// A store of the YAML representation of interfaces.
   DenseMap<Attribute, sv::InterfaceOp> interfaceMap;
+
+  /// Returns an operation's `inner_sym`, adding one if necessary.
+  StringAttr getOrAddInnerSym(Operation *op);
+
+  /// Returns a port's `inner_sym`, adding one if necessary.
+  StringAttr getOrAddInnerSym(FModuleLike module, size_t portIdx);
+
+  /// Obtain an inner reference to an operation, possibly adding an `inner_sym`
+  /// to that operation.
+  hw::InnerRefAttr getInnerRefTo(Operation *op);
+
+  /// Obtain an inner reference to a module port, possibly adding an `inner_sym`
+  /// to that port.
+  hw::InnerRefAttr getInnerRefTo(FModuleLike module, size_t portIdx);
 };
 
 } // namespace
@@ -633,7 +743,7 @@ Optional<Attribute> GrandCentralPass::fromAttr(Attribute attr) {
 }
 
 bool GrandCentralPass::traverseField(Attribute field, IntegerAttr id,
-                                     Twine path) {
+                                     VerbatimBuilder &path) {
   return TypeSwitch<Attribute, bool>(field)
       .Case<AugmentedGroundTypeAttr>([&](auto ground) {
         Value leafValue = leafMap.lookup(ground.getID());
@@ -646,31 +756,35 @@ bool GrandCentralPass::traverseField(Attribute field, IntegerAttr id,
         auto srcPaths = instancePaths->getAbsolutePaths(enclosing);
         assert(srcPaths.size() == 1 &&
                "Unable to handle multiply instantiated companions");
-        llvm::SmallString<128> srcRef;
-        if (enclosing == getOperation().getMainModule()) {
-          srcRef.append(enclosing.moduleName());
-          srcRef.append(".");
-        }
-        for (auto path : srcPaths[0]) {
-          srcRef.append(path.name());
-          srcRef.append(".");
+
+        // Add the root module.
+        path += " = ";
+        path += FlatSymbolRefAttr::get(SymbolTable::getSymbolName(
+            srcPaths[0].empty()
+                ? enclosing
+                : srcPaths[0][0]->getParentOfType<FModuleLike>()));
+
+        // Add the source path.
+        for (auto inst : srcPaths[0]) {
+          path += '.';
+          path += getInnerRefTo(inst);
         }
 
+        // Add the leaf value to the path.
         auto uloc = builder.getUnknownLoc();
+        path += '.';
         if (auto blockArg = leafValue.dyn_cast<BlockArgument>()) {
-          FModuleOp module =
-              cast<FModuleOp>(blockArg.getOwner()->getParentOp());
-          builder.create<sv::VerbatimOp>(
-              uloc, "assign " + path + " = " + srcRef +
-                        module.getPortName(blockArg.getArgNumber()) + ";");
+          auto module = cast<FModuleOp>(blockArg.getOwner()->getParentOp());
+          path += getInnerRefTo(module, blockArg.getArgNumber());
         } else {
-          auto leafModuleName = leafValue.getDefiningOp()
-                                    ->getAttr("name")
-                                    .cast<StringAttr>()
-                                    .getValue();
-          builder.create<sv::VerbatimOp>(
-              uloc, "assign " + path + " = " + srcRef + leafModuleName + ";");
+          path += getInnerRefTo(leafValue.getDefiningOp());
         }
+
+        // Assemble the verbatim op.
+        builder.create<sv::VerbatimOp>(
+            uloc,
+            StringAttr::get(&getContext(), "assign " + path.getString() + ";"),
+            ValueRange{}, ArrayAttr::get(&getContext(), path.getSymbols()));
         return true;
       })
       .Case<AugmentedVectorTypeAttr>([&](auto vector) {
@@ -681,7 +795,8 @@ bool GrandCentralPass::traverseField(Attribute field, IntegerAttr id,
           if (!field)
             return false;
           notFailed &=
-              traverseField(field.getValue(), id, path + "[" + Twine(i) + "]");
+              traverseField(field.getValue(), id,
+                            path.snapshot().append("[" + Twine(i) + "]"));
         }
         return notFailed;
       })
@@ -695,7 +810,8 @@ bool GrandCentralPass::traverseField(Attribute field, IntegerAttr id,
           if (!name)
             name = element.cast<DictionaryAttr>().getAs<StringAttr>("defName");
           anyFailed &=
-              traverseField(field.getValue(), id, path + "." + name.getValue());
+              traverseField(field.getValue(), id,
+                            path.snapshot().append("." + name.getValue()));
         }
 
         return anyFailed;
@@ -712,7 +828,7 @@ bool GrandCentralPass::traverseField(Attribute field, IntegerAttr id,
 Optional<TypeSum> GrandCentralPass::computeField(Attribute field,
                                                  IntegerAttr id,
                                                  StringAttr prefix,
-                                                 Twine path) {
+                                                 VerbatimBuilder &path) {
 
   auto unsupported = [&](StringRef name, StringRef kind) {
     return VerbatimType({("// <unsupported " + kind + " type>").str(), false});
@@ -740,8 +856,9 @@ Optional<TypeSum> GrandCentralPass::computeField(Attribute field,
             bool notFailed = true;
             auto elements = vector.getElements();
             auto firstElement = fromAttr(elements[0]);
-            auto elementType = computeField(firstElement.getValue(), id, prefix,
-                                            path + "[" + Twine(0) + "]");
+            auto elementType =
+                computeField(firstElement.getValue(), id, prefix,
+                             path.snapshot().append("[" + Twine(0) + "]"));
             if (!elementType)
               return None;
 
@@ -749,8 +866,9 @@ Optional<TypeSum> GrandCentralPass::computeField(Attribute field,
               auto subField = fromAttr(elements[i]);
               if (!subField)
                 return None;
-              notFailed &= traverseField(subField.getValue(), id,
-                                         path + "[" + Twine(i) + "]");
+              notFailed &=
+                  traverseField(subField.getValue(), id,
+                                path.snapshot().append("[" + Twine(i) + "]"));
             }
 
             if (auto *tpe = std::get_if<Type>(&elementType.getValue()))
@@ -794,7 +912,7 @@ Optional<TypeSum> GrandCentralPass::computeField(Attribute field,
 /// drive the interface. Returns false on any failure and true on success.
 Optional<sv::InterfaceOp>
 GrandCentralPass::traverseBundle(AugmentedBundleTypeAttr bundle, IntegerAttr id,
-                                 StringAttr prefix, Twine path) {
+                                 StringAttr prefix, VerbatimBuilder &path) {
   auto builder = OpBuilder::atBlockEnd(getOperation().getBody());
   sv::InterfaceOp iface;
   builder.setInsertionPointToEnd(getOperation().getBody());
@@ -816,8 +934,18 @@ GrandCentralPass::traverseBundle(AugmentedBundleTypeAttr bundle, IntegerAttr id,
       return None;
 
     auto name = element.cast<DictionaryAttr>().getAs<StringAttr>("name");
-    auto elementType = computeField(field.getValue(), id, prefix,
-                                    path + "." + name.getValue());
+    auto signalSym = hw::InnerRefAttr::get(iface.sym_nameAttr(), name);
+    // TODO: The `append(name.getValue())` in the following should actually be
+    // `append(signalSym)`, but this requires that `computeField` and the
+    // functions it calls always return a type for which we can construct an
+    // `InterfaceSignalOp`. Since nested interface instances are currently
+    // busted (due to the interface being a symbol table), this doesn't work at
+    // the moment. Passing a `name` works most of the time, but can be brittle
+    // if the interface field requires renaming in the output (e.g. due to
+    // naming conflicts).
+    auto elementType =
+        computeField(field.getValue(), id, prefix,
+                     path.snapshot().append(".").append(name.getValue()));
     if (!elementType)
       return None;
 
@@ -1356,12 +1484,24 @@ void GrandCentralPass::runOnOperation() {
       continue;
     }
 
+    // Decide on a symbol name to use for the interface instance. This is needed
+    // in `traverseBundle` as a placeholder for the connect operations.
+    auto parentModule = parentIDMap.lookup(bundle.getID()).second;
+    auto symbolName = getNamespace().newName(
+        "__" + companionIDMap.lookup(bundle.getID()).name + "_" +
+        getInterfaceName(bundle.getPrefix(), bundle) + "__");
+
     // Recursively walk the AugmentedBundleType to generate interfaces and XMRs.
     // Error out if this returns None (indicating that the annotation annotation
     // is malformed in some way).  A good error message is generated inside
     // `traverseBundle` or the functions it calls.
-    auto iface = traverseBundle(bundle, bundle.getID(), bundle.getPrefix(),
-                                companionIDMap.lookup(bundle.getID()).name);
+    VerbatimBuilder::Base verbatimData;
+    VerbatimBuilder verbatim(verbatimData);
+    verbatim +=
+        hw::InnerRefAttr::get(SymbolTable::getSymbolName(parentModule),
+                              StringAttr::get(&getContext(), symbolName));
+    auto iface =
+        traverseBundle(bundle, bundle.getID(), bundle.getPrefix(), verbatim);
     if (!iface) {
       removalError = true;
       continue;
@@ -1370,11 +1510,7 @@ void GrandCentralPass::runOnOperation() {
     interfaceVec.push_back(iface.getValue());
 
     // Instantiate the interface inside the parent.
-    builder.setInsertionPointToEnd(
-        parentIDMap.lookup(bundle.getID()).second.getBody());
-    auto symbolName = getNamespace().newName(
-        "__" + companionIDMap.lookup(bundle.getID()).name + "_" +
-        getInterfaceName(bundle.getPrefix(), bundle) + "__");
+    builder.setInsertionPointToEnd(parentModule.getBody());
     auto instance = builder.create<sv::InterfaceInstanceOp>(
         getOperation().getLoc(), iface.getValue().getInterfaceType(),
         companionIDMap.lookup(bundle.getID()).name,
@@ -1422,6 +1558,46 @@ void GrandCentralPass::runOnOperation() {
   // annotations.
   if (removalError)
     return signalPassFailure();
+}
+
+StringAttr GrandCentralPass::getOrAddInnerSym(Operation *op) {
+  auto attr = op->getAttrOfType<StringAttr>("inner_sym");
+  if (attr)
+    return attr;
+  auto module = op->getParentOfType<FModuleOp>();
+  StringRef nameHint = "gct_sym";
+  if (auto attr = op->getAttrOfType<StringAttr>("name"))
+    nameHint = attr.getValue();
+  auto name = getModuleNamespace(module).newName(nameHint);
+  attr = StringAttr::get(op->getContext(), name);
+  op->setAttr("inner_sym", attr);
+  return attr;
+}
+
+StringAttr GrandCentralPass::getOrAddInnerSym(FModuleLike module,
+                                              size_t portIdx) {
+  auto attr = module.getPortSymbolAttr(portIdx);
+  if (attr && !attr.getValue().empty())
+    return attr;
+  StringRef nameHint = "gct_sym";
+  if (auto attr = module.getPortNameAttr(portIdx))
+    nameHint = attr.getValue();
+  auto name = getModuleNamespace(module).newName(nameHint);
+  attr = StringAttr::get(module.getContext(), name);
+  module.setPortSymbolAttr(portIdx, attr);
+  return attr;
+}
+
+hw::InnerRefAttr GrandCentralPass::getInnerRefTo(Operation *op) {
+  return hw::InnerRefAttr::get(
+      SymbolTable::getSymbolName(op->getParentOfType<FModuleOp>()),
+      getOrAddInnerSym(op));
+}
+
+hw::InnerRefAttr GrandCentralPass::getInnerRefTo(FModuleLike module,
+                                                 size_t portIdx) {
+  return hw::InnerRefAttr::get(SymbolTable::getSymbolName(module),
+                               getOrAddInnerSym(module, portIdx));
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Conversion/ExportVerilog/verilog-basic.mlir
+++ b/test/Conversion/ExportVerilog/verilog-basic.mlir
@@ -428,20 +428,24 @@ hw.module.extern @VerbatimModuleExtern(%foo: i1 {hw.exportPort = @symA}) -> (bar
 hw.module @VerbatimModule(%signed: i1 {hw.exportPort = @symA}) -> (unsigned: i1 {hw.exportPort = @symB}) {
   %parameter = sv.wire sym @symC : !hw.inout<i4>
   %localparam = sv.reg sym @symD : !hw.inout<i4>
+  %shortint = sv.interface.instance sym @symE : !sv.interface<@Interface>
   // CHECK: wire [3:0] parameter_2;
   // CHECK: reg  [3:0] localparam_3;
+  // CHECK: Interface shortint();
   hw.output %signed : i1
 }
 sv.verbatim "VERB: module symA `{{0}}`" {symbols = [#hw.innerNameRef<@VerbatimModule::@symA>]}
 sv.verbatim "VERB: module symB `{{0}}`" {symbols = [#hw.innerNameRef<@VerbatimModule::@symB>]}
 sv.verbatim "VERB: module symC `{{0}}`" {symbols = [#hw.innerNameRef<@VerbatimModule::@symC>]}
 sv.verbatim "VERB: module symD `{{0}}`" {symbols = [#hw.innerNameRef<@VerbatimModule::@symD>]}
+sv.verbatim "VERB: module symE `{{0}}`" {symbols = [#hw.innerNameRef<@VerbatimModule::@symE>]}
 sv.verbatim "VERB: module.extern symA `{{0}}`" {symbols = [#hw.innerNameRef<@VerbatimModuleExtern::@symA>]}
 sv.verbatim "VERB: module.extern symB `{{0}}`" {symbols = [#hw.innerNameRef<@VerbatimModuleExtern::@symB>]}
 // CHECK: VERB: module symA `signed_0`
 // CHECK: VERB: module symB `unsigned_1`
 // CHECK: VERB: module symC `parameter_2`
 // CHECK: VERB: module symD `localparam_3`
+// CHECK: VERB: module symE `shortint_4`
 // CHECK: VERB: module.extern symA `foo`
 // CHECK: VERB: module.extern symB `bar`
 

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/HWRename.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/HWRename.fir
@@ -1,5 +1,4 @@
 ; RUN: firtool --firrtl-grand-central --verilog --annotation-file %S/HWRename.anno.json %s | FileCheck %s --check-prefixes CHECK
-; XFAIL: true
 
 circuit Top:
   module Companion :
@@ -36,7 +35,7 @@ circuit Top:
     ; CHECK:      endmodule
 
     ; CHECK:      module MyView_mapping();
-    ; CHECK-NEXT:   assign MyView.[[elementName:.+]] = [[dutName]].[[wireName]]
+    ; CHECK-NEXT:   assign MyView.[[elementName:.+]] = Top.[[dutName]].[[wireName]]
     ; CHECK-NEXT: endmodule
 
     ; CHECK: interface MyInterface

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
@@ -172,28 +172,28 @@ circuit Top :
     ; EXTRACT:        FILE "Wire/firrtl/gct/MyView_mapping.sv"
     ; NOEXTRACT-NOT:  FILE {{.*}}/MyView_mapping.sv
     ; CHECK:          module MyView_mapping();
-    ; CHECK-NEXT:       assign MyView.uint = dut.w_uint;
-    ; CHECK-NEXT:       assign MyView.vec[0] = dut.w_vec_0;
-    ; CHECK-NEXT:       assign MyView.vec[1] = dut.w_vec_1;
-    ; CHECK-NEXT:       assign MyView.multivec[0][0] = dut.w_multivec_0_0;
-    ; CHECK-NEXT:       assign MyView.multivec[0][1] = dut.w_multivec_0_1;
-    ; CHECK-NEXT:       assign MyView.multivec[0][2] = dut.w_multivec_0_2;
-    ; CHECK-NEXT:       assign MyView.multivec[1][0] = dut.w_multivec_1_0;
-    ; CHECK-NEXT:       assign MyView.multivec[1][1] = dut.w_multivec_1_1;
-    ; CHECK-NEXT:       assign MyView.multivec[1][2] = dut.w_multivec_1_2;
-    ; CHECK-NEXT:       assign MyView.vecOfBundle[0].sint = dut.w_vecOfBundle_0_sint;
-    ; CHECK-NEXT:       assign MyView.vecOfBundle[0].uint = dut.w_vecOfBundle_0_uint;
-    ; CHECK-NEXT:       assign MyView.vecOfBundle[1].sint = dut.w_vecOfBundle_1_sint;
-    ; CHECK-NEXT:       assign MyView.vecOfBundle[1].uint = dut.w_vecOfBundle_1_uint;
-    ; CHECK-NEXT:       assign MyView.otherOther.other.sint = dut.w_otherOther_other_sint;
-    ; CHECK-NEXT:       assign MyView.otherOther.other.uint = dut.w_otherOther_other_uint;
-    ; CHECK-NEXT:       assign MyView.sub_uint = dut.submodule.w_uint;
-    ; CHECK-NEXT:       assign MyView.sub_vec[0] = dut.submodule.w_vec_0;
-    ; CHECK-NEXT:       assign MyView.sub_vec[1] = dut.submodule.w_vec_1;
-    ; CHECK-NEXT:       assign MyView.sub_vecOfBundle[0].sint = dut.submodule.w_vecOfBundle_0_sint;
-    ; CHECK-NEXT:       assign MyView.sub_vecOfBundle[0].uint = dut.submodule.w_vecOfBundle_0_uint;
-    ; CHECK-NEXT:       assign MyView.sub_vecOfBundle[1].sint = dut.submodule.w_vecOfBundle_1_sint;
-    ; CHECK-NEXT:       assign MyView.sub_vecOfBundle[1].uint = dut.submodule.w_vecOfBundle_1_uint;
+    ; CHECK-NEXT:       assign MyView.uint = Top.dut.w_uint;
+    ; CHECK-NEXT:       assign MyView.vec[0] = Top.dut.w_vec_0;
+    ; CHECK-NEXT:       assign MyView.vec[1] = Top.dut.w_vec_1;
+    ; CHECK-NEXT:       assign MyView.multivec[0][0] = Top.dut.w_multivec_0_0;
+    ; CHECK-NEXT:       assign MyView.multivec[0][1] = Top.dut.w_multivec_0_1;
+    ; CHECK-NEXT:       assign MyView.multivec[0][2] = Top.dut.w_multivec_0_2;
+    ; CHECK-NEXT:       assign MyView.multivec[1][0] = Top.dut.w_multivec_1_0;
+    ; CHECK-NEXT:       assign MyView.multivec[1][1] = Top.dut.w_multivec_1_1;
+    ; CHECK-NEXT:       assign MyView.multivec[1][2] = Top.dut.w_multivec_1_2;
+    ; CHECK-NEXT:       assign MyView.vecOfBundle[0].sint = Top.dut.w_vecOfBundle_0_sint;
+    ; CHECK-NEXT:       assign MyView.vecOfBundle[0].uint = Top.dut.w_vecOfBundle_0_uint;
+    ; CHECK-NEXT:       assign MyView.vecOfBundle[1].sint = Top.dut.w_vecOfBundle_1_sint;
+    ; CHECK-NEXT:       assign MyView.vecOfBundle[1].uint = Top.dut.w_vecOfBundle_1_uint;
+    ; CHECK-NEXT:       assign MyView.otherOther.other.sint = Top.dut.w_otherOther_other_sint;
+    ; CHECK-NEXT:       assign MyView.otherOther.other.uint = Top.dut.w_otherOther_other_uint;
+    ; CHECK-NEXT:       assign MyView.sub_uint = Top.dut.submodule.w_uint;
+    ; CHECK-NEXT:       assign MyView.sub_vec[0] = Top.dut.submodule.w_vec_0;
+    ; CHECK-NEXT:       assign MyView.sub_vec[1] = Top.dut.submodule.w_vec_1;
+    ; CHECK-NEXT:       assign MyView.sub_vecOfBundle[0].sint = Top.dut.submodule.w_vecOfBundle_0_sint;
+    ; CHECK-NEXT:       assign MyView.sub_vecOfBundle[0].uint = Top.dut.submodule.w_vecOfBundle_0_uint;
+    ; CHECK-NEXT:       assign MyView.sub_vecOfBundle[1].sint = Top.dut.submodule.w_vecOfBundle_1_sint;
+    ; CHECK-NEXT:       assign MyView.sub_vecOfBundle[1].uint = Top.dut.submodule.w_vecOfBundle_1_uint;
     ; CHECK:          endmodule
 
     ; EXTRACT:        FILE "Wire/firrtl/gct/MyInterface.sv"

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -66,8 +66,16 @@ firrtl.circuit "InterfaceGroundType" attributes {
 
 // CHECK: firrtl.module @View_mapping
 // CHECK-SAME: output_file = #hw.output_file<"gct-dir/View_mapping.sv"
-// CHECK-NEXT: sv.verbatim "assign View.foo = dut.a;"
-// CHECK-NEXT: sv.verbatim "assign View.bar = dut.b;"
+// CHECK-NEXT: sv.verbatim "assign {{[{][{]0[}][}]}}.foo = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}.{{[{][{]3[}][}]}};"
+// CHECK-SAME:   #hw.innerNameRef<@DUT::@__View_Foo__>
+// CHECK-SAME:   @InterfaceGroundType
+// CHECK-SAME:   #hw.innerNameRef<@InterfaceGroundType::@dut>
+// CHECK-SAME:   #hw.innerNameRef<@DUT::@a>
+// CHECK-NEXT: sv.verbatim "assign {{[{][{]0[}][}]}}.bar = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}.{{[{][{]3[}][}]}};"
+// CHECK-SAME:   #hw.innerNameRef<@DUT::@__View_Foo__>
+// CHECK-SAME:   @InterfaceGroundType
+// CHECK-SAME:   #hw.innerNameRef<@InterfaceGroundType::@dut>
+// CHECK-SAME:   #hw.innerNameRef<@DUT::@b>
 
 // CHECK: sv.interface {
 // CHECK-SAME: output_file = #hw.output_file<"gct-dir/Foo.sv"
@@ -340,8 +348,10 @@ firrtl.circuit "VecOfVec" attributes {
 // CHECK-LABEL: firrtl.circuit "VecOfVec"
 
 // CHECK:      firrtl.module @View_mapping
-// CHECK-NEXT:    assign View.foo[0][0]
-// CHECK-NEXT:    assign View.foo[0][1]
+// CHECK-NEXT:    assign {{[{][{]0[}][}]}}.foo[0][0]
+// CHECK-SAME:      #hw.innerNameRef<@DUT::@__View_Foo__>
+// CHECK-NEXT:    assign {{[{][{]0[}][}]}}.foo[0][1]
+// CHECK-SAME:      #hw.innerNameRef<@DUT::@__View_Foo__>
 
 // CHECK:      sv.interface {{.+}} @Foo
 // CHECK:        sv.interface.signal @foo : !hw.uarray<1xuarray<2xi3>>
@@ -457,7 +467,7 @@ firrtl.circuit "InterfacePort" attributes {
 
 // The Grand Central annotations are removed.
 // CHECK: firrtl.module @DUT
-// CHECK-SAME: %a: !firrtl.uint<4> [{a}]
+// CHECK-SAME: %a: !firrtl.uint<4> sym @a [{a}]
 
 // CHECK: sv.interface {
 // CHECK-SAME: output_file = #hw.output_file<"gct-dir/Foo.sv"
@@ -774,12 +784,36 @@ firrtl.circuit "NestedInterfaceVectorTypes" attributes {annotations = [
 
 // CHECK-LABEL: firrtl.circuit "NestedInterfaceVectorTypes"
 // CHECK:         firrtl.module @View_mapping
-// CHECK-NEXT:      sv.verbatim "assign View.bar[0][0] = dut.a0;"
-// CHECK-NEXT:      sv.verbatim "assign View.bar[0][1] = dut.a1;"
-// CHECK-NEXT:      sv.verbatim "assign View.bar[0][2] = dut.a2;"
-// CHECK-NEXT:      sv.verbatim "assign View.bar[1][0] = dut.b0;"
-// CHECK-NEXT:      sv.verbatim "assign View.bar[1][1] = dut.b1;"
-// CHECK-NEXT:      sv.verbatim "assign View.bar[1][2] = dut.b2;"
+// CHECK-NEXT:      sv.verbatim "assign {{[{][{]0[}][}]}}.bar[0][0] = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}.{{[{][{]3[}][}]}};"
+// CHECK-SAME:        #hw.innerNameRef<@DUT::@__View_Foo__>
+// CHECK-SAME:        @NestedInterfaceVectorTypes
+// CHECK-SAME:        #hw.innerNameRef<@NestedInterfaceVectorTypes::@dut>
+// CHECK-SAME:        #hw.innerNameRef<@DUT::@a0>
+// CHECK-NEXT:      sv.verbatim "assign {{[{][{]0[}][}]}}.bar[0][1] = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}.{{[{][{]3[}][}]}};"
+// CHECK-SAME:        #hw.innerNameRef<@DUT::@__View_Foo__>
+// CHECK-SAME:        @NestedInterfaceVectorTypes
+// CHECK-SAME:        #hw.innerNameRef<@NestedInterfaceVectorTypes::@dut>
+// CHECK-SAME:        #hw.innerNameRef<@DUT::@a1>
+// CHECK-NEXT:      sv.verbatim "assign {{[{][{]0[}][}]}}.bar[0][2] = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}.{{[{][{]3[}][}]}};"
+// CHECK-SAME:        #hw.innerNameRef<@DUT::@__View_Foo__>
+// CHECK-SAME:        @NestedInterfaceVectorTypes
+// CHECK-SAME:        #hw.innerNameRef<@NestedInterfaceVectorTypes::@dut>
+// CHECK-SAME:        #hw.innerNameRef<@DUT::@a2>
+// CHECK-NEXT:      sv.verbatim "assign {{[{][{]0[}][}]}}.bar[1][0] = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}.{{[{][{]3[}][}]}};"
+// CHECK-SAME:        #hw.innerNameRef<@DUT::@__View_Foo__>
+// CHECK-SAME:        @NestedInterfaceVectorTypes
+// CHECK-SAME:        #hw.innerNameRef<@NestedInterfaceVectorTypes::@dut>
+// CHECK-SAME:        #hw.innerNameRef<@DUT::@b0>
+// CHECK-NEXT:      sv.verbatim "assign {{[{][{]0[}][}]}}.bar[1][1] = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}.{{[{][{]3[}][}]}};"
+// CHECK-SAME:        #hw.innerNameRef<@DUT::@__View_Foo__>
+// CHECK-SAME:        @NestedInterfaceVectorTypes
+// CHECK-SAME:        #hw.innerNameRef<@NestedInterfaceVectorTypes::@dut>
+// CHECK-SAME:        #hw.innerNameRef<@DUT::@b1>
+// CHECK-NEXT:      sv.verbatim "assign {{[{][{]0[}][}]}}.bar[1][2] = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}.{{[{][{]3[}][}]}};"
+// CHECK-SAME:        #hw.innerNameRef<@DUT::@__View_Foo__>
+// CHECK-SAME:        @NestedInterfaceVectorTypes
+// CHECK-SAME:        #hw.innerNameRef<@NestedInterfaceVectorTypes::@dut>
+// CHECK-SAME:        #hw.innerNameRef<@DUT::@b2>
 // CHECK:         sv.interface {
 // CHECK-SAME:      @Foo
 // CHECK-NEXT:      sv.verbatim "// description of bar"
@@ -890,7 +924,10 @@ firrtl.circuit "ParentIsMainModule" attributes {
 //
 // CHECK-LABEL: firrtl.circuit "ParentIsMainModule"
 // CHECK:       firrtl.module @View_mapping
-// CHECK-NEXT:    sv.verbatim "assign View.foo = ParentIsMainModule.a;"
+// CHECK-NEXT:    sv.verbatim "assign {{[{][{]0[}][}]}}.foo = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}};"
+// CHECK-SAME:      #hw.innerNameRef<@ParentIsMainModule::@__View_Foo__>
+// CHECK-SAME:      @ParentIsMainModule
+// CHECK-SAME:      #hw.innerNameRef<@ParentIsMainModule::@a>
 
 // -----
 


### PR DESCRIPTION
Make use of `InnerRefAttr`s inside the `GrandCentralPass` to refer to the interface instances and remote declarations targeted by the mapping module. This makes the names emitted as part of the `sv.verbatim` ops symbolic and allows `ExportVerilog` to substitute them with the final values during emission.

Since nested interface instances are not working at the moment, we still hard-code the name of the interface signals. This is technically only needed for the case where an interface would contain a nested interface. However, the way we have to traverse these nested interfaces in the code makes it very hard to decide upfront whether an interface will be referred to by name, or by symbol, because the fact whether it was emitted as a verbatim op (instead of an instance) is only known after the entire interface has been emitted, which is too late for symbol substitution.

Some follow-up work should rework the SV interface ops a bit. More specifically, `sv.interface` has the `SymbolTable` trait, which blocks resolving the name of nested interfaces to their declaration (because symbol tables don't resolve into their parent ops). It would be much more straightforward to have interfaces *not* be symbol tables, and use `InnerRefAttr` where appropriate. At that point, GCT can properly emit the nested interfaces and the above problem goes away.