### PR TITLE
Add `circt-lsp-server` tool which can be used with the MLIR VSCode extension

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_subdirectory(circt-lsp-server)
 add_subdirectory(circt-opt)
 add_subdirectory(circt-reduce)
 add_subdirectory(circt-rtl-sim)

--- a/tools/circt-lsp-server/CMakeLists.txt
+++ b/tools/circt-lsp-server/CMakeLists.txt
@@ -1,0 +1,55 @@
+set(LLVM_OPTIONAL_SOURCES
+  null.cpp
+)
+
+get_property(mlir_dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+get_property(circt_dialect_libs GLOBAL PROPERTY CIRCT_DIALECT_LIBS)
+get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
+set(LLVM_LINK_COMPONENTS
+  Core
+  Support
+  AsmParser
+  )
+
+if(MLIR_INCLUDE_TESTS)
+  set(test_libs
+    MLIRAffineTransformsTestPasses
+    MLIRShapeTestPasses
+    MLIRSPIRVTestPasses
+    MLIRTestAnalysis
+    MLIRTestDialect
+    MLIRTestIR
+    MLIRTestPass
+    MLIRTestReducer
+    MLIRTestRewrite
+    MLIRTestTransforms
+    )
+endif()
+
+set(LIBS
+  ${mlir_dialect_libs}
+  ${circt_dialect_libs}
+  ${conversion_libs}
+  ${test_libs}
+  MLIRLoopAnalysis
+  MLIRAnalysis
+  MLIRDialect
+  MLIRLspServerLib
+  MLIRParser
+  MLIRPass
+  MLIRTransforms
+  MLIRTransformUtils
+  MLIRSupport
+  MLIRIR
+  )
+
+add_llvm_tool(circt-lsp-server
+  circt-lsp-server.cpp
+
+  DEPENDS
+  ${LIBS}
+  )
+target_link_libraries(circt-lsp-server PRIVATE ${LIBS})
+llvm_update_compile_flags(circt-lsp-server)
+
+mlir_check_all_link_libraries(circt-lsp-server)

--- a/tools/circt-lsp-server/circt-lsp-server.cpp
+++ b/tools/circt-lsp-server/circt-lsp-server.cpp
@@ -1,4 +1,4 @@
-//===- mlir-lsp-server.cpp - MLIR Language Server -------------------------===//
+//===- circt-lsp-server.cpp - CIRCT Language Server ---------- ------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/tools/circt-lsp-server/circt-lsp-server.cpp
+++ b/tools/circt-lsp-server/circt-lsp-server.cpp
@@ -1,0 +1,22 @@
+//===- mlir-lsp-server.cpp - MLIR Language Server -------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/InitAllDialects.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/InitAllDialects.h"
+#include "mlir/Tools/mlir-lsp-server/MlirLspServerMain.h"
+
+using namespace mlir;
+
+int main(int argc, char **argv) {
+  DialectRegistry registry;
+  registerAllDialects(registry);
+  circt::registerAllDialects(registry);
+  return failed(MlirLspServerMain(argc, argv, registry));
+}


### PR DESCRIPTION
<img width="739" alt="image" src="https://user-images.githubusercontent.com/989903/142272073-112cc08c-6f59-4e7f-a120-167c6239bdeb.png">

This was very difficult and definitely took me more than 10 minutes get working. Thank you @River707 for making this super complicated :)
... All joking aside this was very simple and feels like a big deal for approachability, especially for bindings which need to know the explicit names of things that might be elided by the pretty format.

To use, install the [MLIR](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-mlir) extension and make it point to the `circt-lsp-server` executable in your project: 
<img width="357" alt="image" src="https://user-images.githubusercontent.com/989903/142273061-d7c2e9c7-7ddf-4872-8ca8-04205baabff8.png">
(Note: I put my build products in `build/vscode` but most folks just use `build`, so you might need to adjust the path for your setup)