### PR TITLE
[HW] Merge sv::IndexedPartSelectOp to hw::ArraySliceOp

### DIFF
--- a/include/circt/Dialect/HW/HWAggregates.td
+++ b/include/circt/Dialect/HW/HWAggregates.td
@@ -75,16 +75,16 @@ def ArrayConcatOp : HWOp<"array_concat", [NoSideEffect]> {
   ];
 }
 
-def ArraySliceOp : HWOp<"array_slice", [NoSideEffect]> {
+def IndexedPartSelectOp : HWOp<"indexed_part_select", [NoSideEffect]> {
   let summary = "Get a range of values from an array";
   let description = [{
-    Extracts a sub-range from an array. The range is from `lowIndex` to
-    `lowIndex` + the number of elements in the return type, non-inclusive on
-    the high end. For instance,
+    Extracts a sub-range of contiguous bits from a vector or packed array.
+    The range is from `lowIndex` to `lowIndex` + the number of elements in
+    the return type, non-inclusive on the high end. For instance,
 
     ```
     // Slices 16 elements starting at '%offset'.
-    %subArray = hw.slice %largerArray at %offset :
+    %subArray = hw.indexed_part_select %largerArray at %offset :
         (!hw.array<1024xi8>) -> !hw.array<16xi8>
     ```
 
@@ -101,19 +101,41 @@ def ArraySliceOp : HWOp<"array_slice", [NoSideEffect]> {
     behavior.
   }];
 
-  let arguments = (ins ArrayType:$input, HWIntegerType:$lowIndex);
-  let results = (outs ArrayType:$dst);
+  let arguments = (ins HWValueType:$input, HWIntegerType:$lowIndex,
+                                                  UnitAttr:$decrement);
+  let results = (outs HWValueType:$dst);
+
+  let builders = [
+    OpBuilder<(ins "Type":$dst, "Value":$input, "Value":$lowIndex),
+              "build(odsBuilder, odsState, dst, input, lowIndex, false);">
+  ];
+
   let verifier = [{
-    unsigned inputSize = type_cast<ArrayType>(input().getType()).getSize();
+    unsigned inputSize;
+    if (hw::type_isa<hw::ArrayType>(input().getType()))
+      inputSize = type_cast<ArrayType>(input().getType()).getSize();
+    else {
+      auto w = getBitWidth(input().getType());
+      if (w == -1)
+        return emitOpError("cannot determine width of input");
+      inputSize = w;
+    }
+    unsigned resultSize;
+    if (hw::type_isa<hw::ArrayType>(getType()))
+      resultSize = type_cast<ArrayType>(getType()).getSize();
+    else
+      resultSize = getBitWidth(getType());
+    if (inputSize  < resultSize)
+      return emitOpError("result size cannot be greater than input size");
     if (llvm::Log2_64_Ceil(inputSize) !=
           lowIndex().getType().getIntOrFloatBitWidth())
       return emitOpError(
-        "ArraySlice: index width must match clog2 of array size");
+        "index width must match clog2 of input size");
     return success();
   }];
 
   let assemblyFormat = [{
-    $input `at` $lowIndex attr-dict `:`
+    $input `at` $lowIndex attr-dict (`decrement` $decrement^)? `:`
       `(` custom<SliceTypes>(type($input), type($lowIndex)) `)` `->` type($dst)
   }];
 }

--- a/include/circt/Dialect/HW/HWVisitors.h
+++ b/include/circt/Dialect/HW/HWVisitors.h
@@ -29,7 +29,8 @@ public:
     return TypeSwitch<Operation *, ResultType>(op)
         .template Case<ConstantOp,
                        // Array operations
-                       ArraySliceOp, ArrayCreateOp, ArrayConcatOp, ArrayGetOp,
+                       IndexedPartSelectOp, ArrayCreateOp, ArrayConcatOp,
+                       ArrayGetOp,
                        // Struct operations
                        StructCreateOp, StructExtractOp, StructInjectOp,
                        // Cast operation
@@ -65,7 +66,7 @@ public:
   HANDLE(StructCreateOp, Unhandled);
   HANDLE(StructExtractOp, Unhandled);
   HANDLE(StructInjectOp, Unhandled);
-  HANDLE(ArraySliceOp, Unhandled);
+  HANDLE(IndexedPartSelectOp, Unhandled);
   HANDLE(ArrayGetOp, Unhandled);
   HANDLE(ArrayCreateOp, Unhandled);
   HANDLE(ArrayConcatOp, Unhandled);

--- a/include/circt/Dialect/SV/SVExpressions.td
+++ b/include/circt/Dialect/SV/SVExpressions.td
@@ -123,38 +123,3 @@ def LocalParamOp : SVOp<"localparam",
 
   let verifier = "return ::verify$cppClass(*this);";
 }
-
-def IndexedPartSelectOp
- : SVOp<"indexed_part_select",
-        [NoSideEffect, InferTypeOpInterface]> {
-  let summary = "Read several contiguous bits of an int type."
-                "This is an indexed part-select operator."
-                "The base is an integer expression and the width is an "
-                " integer constant. The bits start from base and the number "
-                "of bits selected is equal to width. If $decrement is true, "
-                " then part select decrements starting from $base."
-                "See SV Spec 11.5.1.";
-  let arguments = (ins HWIntegerType:$input, HWIntegerType:$base, I32Attr:$width,
-                      UnitAttr:$decrement);
-  let results = (outs HWIntegerType:$result);
-
-  let builders = [
-    OpBuilder<(ins "Value":$input, "Value":$base, "int32_t":$width,
-                                                CArg<"bool", "false">:$decrement)>
-  ];
-
-  let verifier = "return ::verifyIndexedPartSelectOp(*this);";
-
-  let extraClassDeclaration = [{
-    /// Infer the return types of this operation.
-    static LogicalResult inferReturnTypes(MLIRContext *context,
-                                          Optional<Location> loc,
-                                          ValueRange operands,
-                                          DictionaryAttr attrs,
-                                          mlir::RegionRange regions,
-                                          SmallVectorImpl<Type> &results);
-  }];
-
-  let assemblyFormat = "$input`[`$base (`decrement` $decrement^)?`:` $width`]`"
-                        " attr-dict `:` type($input) `,` type($base)";
-}

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -29,8 +29,7 @@ public:
         .template Case<
             // Expressions
             ReadInOutOp, ArrayIndexInOutOp, VerbatimExprOp, VerbatimExprSEOp,
-            IndexedPartSelectInOutOp, IndexedPartSelectOp, ConstantXOp,
-            ConstantZOp,
+            IndexedPartSelectInOutOp, ConstantXOp, ConstantZOp,
             // Declarations.
             RegOp, WireOp, LocalParamOp, XMROp,
             // Control flow.
@@ -88,7 +87,6 @@ public:
   HANDLE(VerbatimExprOp, Unhandled);
   HANDLE(VerbatimExprSEOp, Unhandled);
   HANDLE(IndexedPartSelectInOutOp, Unhandled);
-  HANDLE(IndexedPartSelectOp, Unhandled);
   HANDLE(ConstantXOp, Unhandled);
   HANDLE(ConstantZOp, Unhandled);
 

--- a/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
+++ b/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
@@ -1811,8 +1811,8 @@ struct ShrOpConversion : public ConvertToLLVMPattern {
 
       auto combined = rewriter.create<hw::ArrayConcatOp>(
           op->getLoc(), ValueRange({shrOp.hidden(), shrOp.base()}));
-      rewriter.replaceOpWithNewOp<hw::ArraySliceOp>(op, arrTy, combined,
-                                                    transformed.amount());
+      rewriter.replaceOpWithNewOp<hw::IndexedPartSelectOp>(
+          op, arrTy, combined, transformed.amount());
 
       return success();
     }
@@ -2390,11 +2390,11 @@ namespace {
 /// Pattern: array_slice(input, lowIndex) =>
 ///   load(bitcast(gep(store(input, alloca), zext(lowIndex))))
 struct ArraySliceOpConversion
-    : public ConvertOpToLLVMPattern<hw::ArraySliceOp> {
-  using ConvertOpToLLVMPattern<hw::ArraySliceOp>::ConvertOpToLLVMPattern;
+    : public ConvertOpToLLVMPattern<hw::IndexedPartSelectOp> {
+  using ConvertOpToLLVMPattern<hw::IndexedPartSelectOp>::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(hw::ArraySliceOp op, OpAdaptor adaptor,
+  matchAndRewrite(hw::IndexedPartSelectOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
     auto dstTy = typeConverter->convertType(op.dst().getType());

--- a/lib/Dialect/ESI/capnp/Schema.cpp
+++ b/lib/Dialect/ESI/capnp/Schema.cpp
@@ -614,7 +614,7 @@ public:
         builder->getIntegerType(llvm::Log2_64_Ceil(type.getSize()));
     Value lsbConst = builder->create<hw::ConstantOp>(loc(), idxTy, lsb);
     Value newSlice =
-        builder->create<hw::ArraySliceOp>(loc(), dstTy, s, lsbConst);
+        builder->create<hw::IndexedPartSelectOp>(loc(), dstTy, s, lsbConst);
     return Slice(this, lsb, newSlice);
   }
 
@@ -632,7 +632,8 @@ public:
     else if (lsbWidth < expIdxWidth)
       assert(false && "LSB Value must not be smaller than expected.");
     auto dstTy = hw::ArrayType::get(type.getElementType(), size);
-    Value newSlice = builder->create<hw::ArraySliceOp>(loc(), dstTy, s, lsb);
+    Value newSlice =
+        builder->create<hw::IndexedPartSelectOp>(loc(), dstTy, s, lsb);
     return Slice(this, llvm::Optional<int64_t>(), newSlice);
   }
   Slice &name(const Twine &name) { return GasketComponent::name<Slice>(name); }

--- a/lib/Dialect/HW/HWDialect.cpp
+++ b/lib/Dialect/HW/HWDialect.cpp
@@ -68,7 +68,7 @@ struct HWInlinerInterface : public mlir::DialectInlinerInterface {
                        BlockAndValueMapping &) const final {
     return isa<ConstantOp>(op) || isa<BitcastOp>(op) ||
            isa<ArrayCreateOp>(op) || isa<ArrayConcatOp>(op) ||
-           isa<ArraySliceOp>(op) || isa<ArrayGetOp>(op) ||
+           isa<IndexedPartSelectOp>(op) || isa<ArrayGetOp>(op) ||
            isa<StructCreateOp>(op) || isa<StructInjectOp>(op) ||
            isa<UnionCreateOp>(op) || isa<UnionExtractOp>(op);
   }

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1212,10 +1212,10 @@ static ParseResult parseSliceTypes(OpAsmParser &p, Type &srcType,
   if (p.parseType(type))
     return p.emitError(p.getCurrentLocation(), "Expected type");
   auto arrType = type_dyn_cast<ArrayType>(type);
-  if (!arrType)
-    return p.emitError(p.getCurrentLocation(), "Expected !hw.array type");
+  if (!arrType && !isHWIntegerType(type) )
+    return p.emitError(p.getCurrentLocation(), "Expected !hw.array or integer type");
   srcType = type;
-  unsigned idxWidth = llvm::Log2_64_Ceil(arrType.getSize());
+  unsigned idxWidth = llvm::Log2_64_Ceil(arrType ? arrType.getSize() : getBitWidth(type));
   idxType = IntegerType::get(p.getBuilder().getContext(), idxWidth);
   return success();
 }

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1212,10 +1212,12 @@ static ParseResult parseSliceTypes(OpAsmParser &p, Type &srcType,
   if (p.parseType(type))
     return p.emitError(p.getCurrentLocation(), "Expected type");
   auto arrType = type_dyn_cast<ArrayType>(type);
-  if (!arrType && !isHWIntegerType(type) )
-    return p.emitError(p.getCurrentLocation(), "Expected !hw.array or integer type");
+  if (!arrType && !isHWIntegerType(type))
+    return p.emitError(p.getCurrentLocation(),
+                       "Expected !hw.array or integer type");
   srcType = type;
-  unsigned idxWidth = llvm::Log2_64_Ceil(arrType ? arrType.getSize() : getBitWidth(type));
+  unsigned idxWidth =
+      llvm::Log2_64_Ceil(arrType ? arrType.getSize() : getBitWidth(type));
   idxType = IntegerType::get(p.getBuilder().getContext(), idxWidth);
   return success();
 }

--- a/lib/Dialect/SV/Transforms/HWMemSimImpl.cpp
+++ b/lib/Dialect/SV/Transforms/HWMemSimImpl.cpp
@@ -102,6 +102,9 @@ void HWMemSimImplPass::generateMemory(HWModuleOp op, FirMemory mem) {
   if (mem.maskGran == 0)
     mem.maskGran = mem.dataWidth;
   auto maskBits = mem.dataWidth / mem.maskGran;
+  auto logDataWidth = llvm::Log2_64_Ceil(mem.dataWidth);
+  if (!logDataWidth)
+    logDataWidth = 1;
   // Each mask bit controls mask-granularity number of data bits.
   auto dataType = b.getIntegerType(mem.dataWidth);
 
@@ -177,7 +180,7 @@ void HWMemSimImplPass::generateMemory(HWModuleOp op, FirMemory mem) {
           b.create<sv::PAssignOp>(
               b.createOrFold<sv::IndexedPartSelectInOutOp>(
                   slotReg,
-                  b.createOrFold<ConstantOp>(b.getIntegerType(32),
+                  b.createOrFold<ConstantOp>(b.getIntegerType(logDataWidth),
                                              wmask.index() * mem.maskGran),
                   mem.maskGran),
               dataValues[wmask.index()]);
@@ -223,7 +226,7 @@ void HWMemSimImplPass::generateMemory(HWModuleOp op, FirMemory mem) {
           b.create<sv::PAssignOp>(
               b.createOrFold<sv::IndexedPartSelectInOutOp>(
                   slot,
-                  b.createOrFold<ConstantOp>(b.getIntegerType(32),
+                  b.createOrFold<ConstantOp>(b.getIntegerType((logDataWidth)),
                                              wmask.index() * mem.maskGran),
                   mem.maskGran),
               dataValues[wmask.index()]);

--- a/lib/Dialect/SV/Transforms/PrettifyVerilog.cpp
+++ b/lib/Dialect/SV/Transforms/PrettifyVerilog.cpp
@@ -117,7 +117,7 @@ bool PrettifyVerilogPass::prettifyUnaryOperator(Operation *op) {
   // If this operation has any users that cannot inline the operation, then
   // don't duplicate any of them.
   for (auto *user : op->getUsers()) {
-    if (isa<comb::ExtractOp, hw::ArraySliceOp, comb::SExtOp>(user))
+    if (isa<comb::ExtractOp, hw::IndexedPartSelectOp, comb::SExtOp>(user))
       return false;
   }
 

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -60,8 +60,8 @@ hw.module @TESTSIMPLE(%a: i4, %b: i4, %c: i2, %cond: i1,
   %34 = comb.xor %a, %allone : i4
 
   %arrCreated = hw.array_create %allone, %allone, %allone, %allone, %allone, %allone, %allone, %allone, %allone : i4
-  %slice1 = hw.array_slice %arrCreated at %a : (!hw.array<9xi4>) -> !hw.array<3xi4>
-  %slice2 = hw.array_slice %arrCreated at %b : (!hw.array<9xi4>) -> !hw.array<3xi4>
+  %slice1 = hw.indexed_part_select %arrCreated at %a : (!hw.array<9xi4>) -> !hw.array<3xi4>
+  %slice2 = hw.indexed_part_select %arrCreated at %b : (!hw.array<9xi4>) -> !hw.array<3xi4>
   %35 = comb.mux %cond, %slice1, %slice2 : !hw.array<3xi4>
 
   %ab = comb.add %a, %b : i4

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -105,12 +105,12 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
       sv.bpassign %wire42, %c42 : i42
       %c40 = hw.constant 42 : i40
 
-      %c2_i3 = hw.constant 2 : i3
-      // CHECK-NEXT: partSelectReg[3'h2 +: 40] = 40'h2A;
-      %a = sv.indexed_part_select_inout %partSelectReg[%c2_i3 : 40] : !hw.inout<i42>, i3
+      %c2_i6 = hw.constant 2 : i6
+      // CHECK-NEXT: partSelectReg[6'h2 +: 40] = 40'h2A;
+      %a = sv.indexed_part_select_inout %partSelectReg[%c2_i6 : 40] : !hw.inout<i42>, i6
       sv.bpassign %a, %c40 : i40
-      // CHECK-NEXT: partSelectReg[3'h2 -: 40] = 40'h2A;
-      %b = sv.indexed_part_select_inout %partSelectReg[%c2_i3 decrement: 40] : !hw.inout<i42>, i3
+      // CHECK-NEXT: partSelectReg[6'h2 -: 40] = 40'h2A;
+      %b = sv.indexed_part_select_inout %partSelectReg[%c2_i6 decrement: 40] : !hw.inout<i42>, i6
       sv.bpassign %b, %c40 : i40
     } else {
       // CHECK: wire42 = param_y;
@@ -400,26 +400,26 @@ hw.module @reg_0(%in4: i4, %in8: i8) -> (a: i8, b: i8) {
   hw.output %regout, %memout : i8, i8
 }
 
-hw.module @reg_1(%in4: i4, %in8: i8) -> (a : i3, b : i5) {
+hw.module @reg_1(%in4: i5, %in8: i8) -> (a : i3, b : i5) {
   // CHECK-LABEL: module reg_1(
 
   // CHECK: reg [17:0] myReg2
   %myReg2 = sv.reg : !hw.inout<i18>
 
   // CHECK-EMPTY:
-  // CHECK-NEXT: assign myReg2[4'h7 +: 8] = in8;
-  // CHECK-NEXT: assign myReg2[4'h7 -: 8] = in8;
+  // CHECK-NEXT: assign myReg2[5'h7 +: 8] = in8;
+  // CHECK-NEXT: assign myReg2[5'h7 -: 8] = in8;
 
-  %c2_i3 = hw.constant 7 : i4
-  %a1 = sv.indexed_part_select_inout %myReg2[%c2_i3 : 8] : !hw.inout<i18>, i4
+  %c2_i3 = hw.constant 7 : i5
+  %a1 = sv.indexed_part_select_inout %myReg2[%c2_i3 : 8] : !hw.inout<i18>, i5
   sv.assign %a1, %in8 : i8
-  %b1 = sv.indexed_part_select_inout %myReg2[%c2_i3 decrement: 8] : !hw.inout<i18>, i4
+  %b1 = sv.indexed_part_select_inout %myReg2[%c2_i3 decrement: 8] : !hw.inout<i18>, i5
   sv.assign %b1, %in8 : i8
-  %c3_i3 = hw.constant 3 : i4
+  %c3_i3 = hw.constant 3 : i5
   %r1 = sv.read_inout %myReg2 : !hw.inout<i18>
-  %c = sv.indexed_part_select %r1[%c3_i3 : 3] : i18,i4
-  %d = sv.indexed_part_select %r1[%in4 decrement:5] :i18, i4
-  // CHECK-NEXT: assign a = myReg2[4'h3 +: 3];
+  %c = hw.indexed_part_select %r1 at %c3_i3 : (i18) -> i3
+  %d = hw.indexed_part_select %r1 at %in4 decrement : (i18) -> i5
+  // CHECK-NEXT: assign a = myReg2[5'h3 +: 3];
   // CHECK-NEXT: assign b = myReg2[in4 -: 5];
   hw.output %c, %d : i3,i5
 }
@@ -470,8 +470,8 @@ hw.module @issue595(%arr: !hw.array<128xi1>) {
 
   // CHECK: wire [63:0] _T_1 = arr[7'h0 +: 64];
   // CHECK: assign _T = _T_1[6'h0 +: 32];
-  %1 = hw.array_slice %arr at %c0_i7 : (!hw.array<128xi1>) -> !hw.array<64xi1>
-  %2 = hw.array_slice %1 at %c0_i6 : (!hw.array<64xi1>) -> !hw.array<32xi1>
+  %1 = hw.indexed_part_select %arr at %c0_i7 : (!hw.array<128xi1>) -> !hw.array<64xi1>
+  %2 = hw.indexed_part_select %1 at %c0_i6 : (!hw.array<64xi1>) -> !hw.array<32xi1>
   %3 = hw.bitcast %2 : (!hw.array<32xi1>) -> i32
   hw.output
 }
@@ -493,8 +493,8 @@ hw.module @issue595_variant1(%arr: !hw.array<128xi1>) {
 
   // CHECK: wire [63:0] _T_1 = arr[7'h0 +: 64];
   // CHECK: assign _T = _T_1[6'h0 +: 32];
-  %1 = hw.array_slice %arr at %c0_i7 : (!hw.array<128xi1>) -> !hw.array<64xi1>
-  %2 = hw.array_slice %1 at %c0_i6 : (!hw.array<64xi1>) -> !hw.array<32xi1>
+  %1 = hw.indexed_part_select %arr at %c0_i7 : (!hw.array<128xi1>) -> !hw.array<64xi1>
+  %2 = hw.indexed_part_select %1 at %c0_i6 : (!hw.array<64xi1>) -> !hw.array<32xi1>
   %3 = hw.bitcast %2 : (!hw.array<32xi1>) -> i32
   hw.output
 }
@@ -515,8 +515,8 @@ hw.module @issue595_variant2_checkRedunctionAnd(%arr: !hw.array<128xi1>) {
 
   // CHECK: wire [63:0] _T_1 = arr[7'h0 +: 64];
   // CHECK: assign _T = _T_1[6'h0 +: 32];
-  %1 = hw.array_slice %arr at %c0_i7 : (!hw.array<128xi1>) -> !hw.array<64xi1>
-  %2 = hw.array_slice %1 at %c0_i6 : (!hw.array<64xi1>) -> !hw.array<32xi1>
+  %1 = hw.indexed_part_select %arr at %c0_i7 : (!hw.array<128xi1>) -> !hw.array<64xi1>
+  %2 = hw.indexed_part_select %1 at %c0_i6 : (!hw.array<64xi1>) -> !hw.array<32xi1>
   %3 = hw.bitcast %2 : (!hw.array<32xi1>) -> i32
   hw.output
 }
@@ -529,18 +529,18 @@ hw.module @slice_inline_ports(%arr: !hw.array<128xi1>, %x: i3, %y: i7)
   %c1_i2 = hw.constant 1 : i2
   %0 = hw.array_create %x, %x, %x, %x : i3
   // CHECK: wire [3:0][2:0] _T = 
-  %1 = hw.array_slice %0 at %c1_i2 : (!hw.array<4xi3>) -> !hw.array<2xi3>
+  %1 = hw.indexed_part_select %0 at %c1_i2 : (!hw.array<4xi3>) -> !hw.array<2xi3>
   // CHECK: assign o1 = _T[2'h1 +: 2];
 
   %c1_i7 = hw.constant 1 : i7
 
   /// This can be inlined.
   // CHECK: assign o2 = arr[7'h1 +: 64];
-  %2 = hw.array_slice %arr at %c1_i7 : (!hw.array<128xi1>) -> !hw.array<64xi1>
+  %2 = hw.indexed_part_select %arr at %c1_i7 : (!hw.array<128xi1>) -> !hw.array<64xi1>
 
   // CHECK: assign o3 = arr[y + 7'h1 +: 64];
   %sum = comb.add %y, %c1_i7 : i7
-  %3 = hw.array_slice %arr at %sum : (!hw.array<128xi1>) -> !hw.array<64xi1>
+  %3 = hw.indexed_part_select %arr at %sum : (!hw.array<128xi1>) -> !hw.array<64xi1>
 
   hw.output %1, %2, %3: !hw.array<2xi3>, !hw.array<64xi1>, !hw.array<64xi1>
 }

--- a/test/Conversion/LLHDToLLVM/convert_aggregates.mlir
+++ b/test/Conversion/LLHDToLLVM/convert_aggregates.mlir
@@ -47,7 +47,7 @@ func @convertArray(%arg0 : i1, %arg1: !hw.array<2xi32>) {
   // CHECK-NEXT: %10 = llvm.getelementptr %8[%6, %9] : (!llvm.ptr<array<2 x i32>>, i32, i2) -> !llvm.ptr<i32>
   // CHECK-NEXT: %11 = llvm.bitcast %10 : !llvm.ptr<i32> to !llvm.ptr<array<1 x i32>>
   // CHECK-NEXT: llvm.load %11 : !llvm.ptr<array<1 x i32>>
-  %1 = hw.array_slice %arg1 at %arg0 : (!hw.array<2xi32>) -> !hw.array<1xi32>
+  %1 = hw.indexed_part_select %arg1 at %arg0 : (!hw.array<2xi32>) -> !hw.array<1xi32>
 
   // CHECK-NEXT: %[[UNDEF:.*]] = llvm.mlir.undef : !llvm.array<4 x i32>
   // CHECK-NEXT: %[[E1:.*]] = llvm.extractvalue %arg1[0 : i32] : !llvm.array<2 x i32>

--- a/test/Dialect/HW/basic.mlir
+++ b/test/Dialect/HW/basic.mlir
@@ -97,8 +97,8 @@ hw.module @test1(%arg0: i3, %arg1: i1, %arg2: !hw.array<1000xi8>) -> (result: i5
 
   // CHECK-NEXT: = arith.constant 13 : i10
   %idx = arith.constant 13 : i10
-  // CHECK-NEXT: = hw.array_slice %arg2 at %c13_i10 : (!hw.array<1000xi8>) -> !hw.array<24xi8>
-  %subArray = hw.array_slice %arg2 at %idx : (!hw.array<1000xi8>) -> !hw.array<24xi8>
+  // CHECK-NEXT: = hw.indexed_part_select %arg2 at %c13_i10 : (!hw.array<1000xi8>) -> !hw.array<24xi8>
+  %subArray = hw.indexed_part_select %arg2 at %idx : (!hw.array<1000xi8>) -> !hw.array<24xi8>
   // CHECK-NEXT: [[ARR1:%.+]] = hw.array_create [[RES9]], [[RES10]] : i19
   %arrCreated = hw.array_create %small1, %small2 : i19
   // CHECK-NEXT: [[ARR2:%.+]] = hw.array_create [[RES9]], [[RES10]], {{.+}} : i19

--- a/test/Dialect/HW/typedecls.mlir
+++ b/test/Dialect/HW/typedecls.mlir
@@ -36,7 +36,7 @@ hw.module @testTypeAliasArray(%arg0: !Foo, %arg1: !Foo, %arg2: !FooArray) {
   %c1 = hw.constant 1 : i1
   %0 = hw.array_create %arg0, %arg1 : !Foo
   %1 = hw.array_concat %arg2, %arg2 : !FooArray, !FooArray
-  %2 = hw.array_slice %arg2 at %c1 : (!FooArray) -> !hw.array<1x!Foo>
+  %2 = hw.indexed_part_select %arg2 at %c1 : (!FooArray) -> !hw.array<1x!Foo>
   %3 = hw.array_get %arg2[%c1] : !FooArray
 }
 

--- a/test/Dialect/LLHD/Simulator/sim_hw_array_get_concat.mlir
+++ b/test/Dialect/LLHD/Simulator/sim_hw_array_get_concat.mlir
@@ -36,7 +36,7 @@ llhd.entity @root () -> () {
 
     %array = hw.array_concat %array1, %array2 : !hw.array<2xi8>, !hw.array<2xi8>
     %get = hw.array_get %array[%index] : !hw.array<4xi8>
-    %slice = hw.array_slice %array at %indexz : (!hw.array<4xi8>) -> !hw.array<2xi8>
+    %slice = hw.indexed_part_select %array at %indexz : (!hw.array<4xi8>) -> !hw.array<2xi8>
 
     %concatsig = llhd.sig "concat" %arrayinit : !hw.array<4xi8> 
     %getsig = llhd.sig "get" %0 : i8

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -155,11 +155,11 @@ hw.module @test1(%arg0: i1, %arg1: i1, %arg8: i8) {
     %tmpx = sv.constantX : i1
     // CHECK-NEXT: sv.passign %combWire, %x_i1 : i1
     sv.passign %combWire, %tmpx : i1
-    // CHECK-NEXT: %[[c2_i3:.+]] = hw.constant 2 : i3
-    // CHECK-NEXT: %[[v0:.+]] = sv.indexed_part_select_inout %selReg[%[[c2_i3]] : 1] : !hw.inout<i10>, i3
+    // CHECK-NEXT: %[[c2_i3:.+]] = hw.constant 2 : i4
+    // CHECK-NEXT: %[[v0:.+]] = sv.indexed_part_select_inout %selReg[%[[c2_i3]] : 1] : !hw.inout<i10>, i4
     // CHECK-NEXT: sv.passign %[[v0]], %x_i1 : i1
-    %c2 = hw.constant 2 : i3
-    %xx1 = sv.indexed_part_select_inout %selReg[%c2:1] :  !hw.inout<i10>, i3
+    %c2 = hw.constant 2 : i4
+    %xx1 = sv.indexed_part_select_inout %selReg[%c2:1] :  !hw.inout<i10>, i4
     sv.passign %xx1, %tmpx : i1
     // CHECK-NEXT: sv.force %combWire2, %x_i1 : i1
     sv.force %combWire2, %tmpx : i1
@@ -254,25 +254,25 @@ hw.module @XMR_src(%a : i23) {
   sv.assign %xmr1, %a : i23
 }
 
-  hw.module @part_select(%in4 : i4, %in8 : i8) -> (a : i3, b : i5) {
+  hw.module @part_select(%in4 : i5, %in8 : i8) -> (a : i3, b : i5) {
   // CHECK-LABEL: hw.module @part_select
 
     %myReg2 = sv.reg : !hw.inout<i18>
-    %c2_i3 = hw.constant 7 : i4
-    // CHECK: = sv.indexed_part_select_inout %myReg2[%[[c7_i4:.+]] : 8] : !hw.inout<i18>, i4
-    %a1 = sv.indexed_part_select_inout %myReg2 [%c2_i3:8] : !hw.inout<i18>, i4
+    %c2_i3 = hw.constant 7 : i5
+    // CHECK: = sv.indexed_part_select_inout %myReg2[%[[c7_i4:.+]] : 8] : !hw.inout<i18>, i5
+    %a1 = sv.indexed_part_select_inout %myReg2 [%c2_i3:8] : !hw.inout<i18>, i5
     sv.assign %a1, %in8 : i8
-    // CHECK:  = sv.indexed_part_select_inout %myReg2[%[[c7_i4]] decrement : 8] : !hw.inout<i18>, i4
-    %b1 = sv.indexed_part_select_inout %myReg2 [%c2_i3 decrement:8] : !hw.inout<i18>, i4
+    // CHECK:  = sv.indexed_part_select_inout %myReg2[%[[c7_i4]] decrement : 8] : !hw.inout<i18>, i5
+    %b1 = sv.indexed_part_select_inout %myReg2 [%c2_i3 decrement:8] : !hw.inout<i18>, i5
     sv.assign %b1, %in8 : i8
-    %c3_i3 = hw.constant 3 : i4
+    %c3_i5 = hw.constant 3 : i5
     %rc = sv.read_inout %myReg2 : !hw.inout<i18>
-    %c = sv.indexed_part_select %rc [%c3_i3:3] : i18, i4
+    %c = hw.indexed_part_select %rc at %c3_i5 : (i18) -> i3
     // CHECK: %[[v2:.+]] = sv.read_inout %myReg2 : !hw.inout<i18>
-    // CHECK: = sv.indexed_part_select %[[v2]][%[[c3_i4:.+]] : 3] : i18, i4
+    // CHECK: hw.indexed_part_select %[[v2]] at %c3_i5 : (i18) -> i3
     %rd = sv.read_inout %myReg2 : !hw.inout<i18>
-    %d = sv.indexed_part_select %rd [%in4 decrement:5] : i18, i4
+    %d = hw.indexed_part_select %rd at %in4 decrement : (i18) -> i5
     // CHECK: %[[v4:.+]] = sv.read_inout %myReg2 : !hw.inout<i18>
-    // CHECK: = sv.indexed_part_select %[[v4]][%[[in4:.+]]  decrement : 5] : i18, i4
+    // CHECK: hw.indexed_part_select %[[v4]] at %in4 decrement : (i18) -> i5
     hw.output %c, %d : i3, i5
 }

--- a/test/Dialect/SV/errors.mlir
+++ b/test/Dialect/SV/errors.mlir
@@ -194,8 +194,8 @@ hw.module @part_select1() {
 
 hw.module @part_select1() {
   %selWire = sv.wire : !hw.inout<i10>
-  %c2 = hw.constant 2 : i3
+  %c2 = hw.constant 2 : i4
   %r1 = sv.read_inout %selWire : !hw.inout<i10>
-  // expected-error @+1 {{slice width should not be greater than input width}}
-  %c = sv.indexed_part_select %r1[%c2 : 20] : i10,i3
+  // expected-error @+1 {{result size cannot be greater than input size}}
+  %c = hw.indexed_part_select %r1 at %c2 : (i10) -> i20
 }

--- a/test/Dialect/SV/hw-memsim.mlir
+++ b/test/Dialect/SV/hw-memsim.mlir
@@ -90,8 +90,7 @@ hw.module.generated @FIRRTLMem_1_1_1_16_10_0_1_0_0, @FIRRTLMem(%ro_addr_0: i4, %
 //CHECK-NEXT:      %[[rwwcondpre:.+]] = comb.and %[[rw_wmask_0]], %rw_wmode_0
 //CHECK-NEXT:      %[[rwwcond:.+]] = comb.and %rw_en_0, %[[rwwcondpre]]
 //CHECK-NEXT:      sv.if %[[rwwcond]]  {
-//CHECK-NEXT:        %[[c0_i32:.+]] = hw.constant 0 : i32
-//CHECK-NEXT:        sv.passign %[[rwslot]], %[[rw_wdata_0]]
+//CHECK:        sv.passign %[[rwslot]], %[[rw_wdata_0]]
 //CHECK-NEXT:      }
 //CHECK-NEXT:    }
 //CHECK-NEXT:  %[[v14:.+]] = comb.extract %wo_mask_0 from 0 : (i1) -> i1
@@ -100,8 +99,7 @@ hw.module.generated @FIRRTLMem_1_1_1_16_10_0_1_0_0, @FIRRTLMem(%ro_addr_0: i4, %
 //CHECK-NEXT:    %[[wcond:.+]] = comb.and %wo_en_0, %[[v14]]
 //CHECK-NEXT:    sv.if %[[wcond]]  {
 //CHECK-NEXT:      %[[wslot:.+]] = sv.array_index_inout %Memory[%wo_addr_0]
-//CHECK-NEXT:      %[[c0_i32:.+]] = hw.constant 0 : i32
-//CHECK-NEXT:      sv.passign %[[wslot]], %[[v15]]
+//CHECK:      sv.passign %[[wslot]], %[[v15]]
 //CHECK-NEXT:    }
 //CHECK-NEXT:  }
 //CHECK-NEXT:  hw.output %[[readres]], %[[rwres]]
@@ -169,8 +167,8 @@ hw.module.generated @FIRRTLMemTwoAlways, @FIRRTLMem( %wo_addr_0: i4, %wo_en_0: i
   // CHECK-NEXT:     %[[v22:.+]] = comb.and %W0_en, %[[v14]] : i1
   // CHECK-NEXT:     sv.if %[[v22]]  {
   // CHECK-NEXT:       %[[v26:.+]] = sv.array_index_inout %[[Memory]][%W0_addr] : !hw.inout<uarray<16xi32>>, i4
-  // CHECK-NEXT:      %[[c0_i32:.+]] = hw.constant 0 : i32
-  // CHECK-NEXT:      %[[v220:.+]] = sv.indexed_part_select_inout %[[v26]][%[[c0_i32]] : 8] : !hw.inout<i32>, i32
+  // CHECK-NEXT:      %[[c0_i32:.+]] = hw.constant 0 : i5
+  // CHECK-NEXT:      %[[v220:.+]] = sv.indexed_part_select_inout %[[v26]][%[[c0_i32]] : 8] : !hw.inout<i32>, i5
   // CHECK-NEXT:      sv.passign %[[v220]], %[[v15]] : i8
 
   hw.module.generated @FIRRTLMem_1_1_0_32_16_1_1_0_1_b, @FIRRTLMem(%R0_addr: i4, %R0_en: i1, %R0_clk: i1, %W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i32, %W0_mask: i2) -> (R0_data: i32) attributes {depth = 16 : i64, maskGran = 16 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 2 : ui32, readUnderWrite = 0 : ui32, width = 32 : ui32, writeClockIDs = [0 : i32], writeLatency = 3 : ui32, writeUnderWrite = 1 : i32}
@@ -210,8 +208,8 @@ hw.module.generated @FIRRTLMemTwoAlways, @FIRRTLMem( %wo_addr_0: i4, %wo_en_0: i
   // CHECK:    %[[v34:.+]] = comb.and %[[v21:.+]], %[[v30]] : i1
   // CHECK:    sv.if %[[v34]]  {
   // CHECK:      %[[v36:.+]] = sv.array_index_inout %[[Memory0]][%[[v117:.+]]] :
-  // CHECK:      %c0_i32 = hw.constant 0 : i32
-  // CHECK:      %[[v36:.+]] = sv.indexed_part_select_inout %33[%c0_i32 : 16] : !hw.inout<i32>, i32
+  // CHECK:      %[[c0_i32:.+]] = hw.constant 0 : i5
+  // CHECK:      %[[v36:.+]] = sv.indexed_part_select_inout %33[%[[c0_i32]] : 16] : !hw.inout<i32>
   // CHECK:      sv.passign %[[v36]], %[[v31]] : i16
   // CHECK:    }
   // CHECK:  hw.output %[[v13]] : i32
@@ -252,13 +250,13 @@ numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32,maskGran = 8 :ui32, numWri
 // CHECK:      %[[v86:.+]] = comb.and %[[v69:.+]], %[[v82]] : i1
 // CHECK:      sv.if %[[v86]]  {
 // CHECK:        %[[v88:.+]] = sv.array_index_inout %[[Memory0]][%[[v63:.+]]] :
-// CHECK:        %[[vv83:.+]] = sv.indexed_part_select_inout %[[v88]][%[[c0_i32:.+]] : 8] : !hw.inout<i16>, i32
+// CHECK:        %[[vv83:.+]] = sv.indexed_part_select_inout %[[v88]][%[[c0_i32:.+]] : 8] : !hw.inout<i16>, i4
 // CHECK:        sv.passign %[[vv83]], %[[v83]] : i8
 // CHECK:      }
 // CHECK:      sv.if %[[v87:.+]]  {
 // CHECK:        %[[v88:.+]] = sv.array_index_inout %[[Memory0]][%[[v63]]] : !hw.inout<uarray<10xi16>>, i4
-// CHECK:        %[[c8_i32:.+]] = hw.constant 8 : i32
-// CHECK:        %[[vv83:.+]] = sv.indexed_part_select_inout %[[v88]][%[[c8_i32]] : 8] : !hw.inout<i16>, i32
+// CHECK:        %[[c8_i32:.+]] = hw.constant -8 : i4
+// CHECK:        %[[vv83:.+]] = sv.indexed_part_select_inout %[[v88]][%[[c8_i32]] : 8] : !hw.inout<i16>, i4
 // CHECK:        sv.passign %[[vv83]], %[[v85]] : i8
 // CHECK:      }
 // CHECK:    }


### PR DESCRIPTION
Indexed part-select op can be used to  extract several contiguous bits from a vector or a packed array.

According to the spec, the term part-select refers to a selection of one or more contiguous bits of a single-dimension packed array and the term slice refers to a selection of one or more contiguous elements of an array.

I'm not sure if this renaming is appropriate.
This change renames the `ArraySliceOp` to `IndexedPartSelectOp` and makes it more general and not just limited to `!hw.array`. 
This merges the existing part select op in SV dialect with the ArraySlice of HW dialect, and updates the corresponding 
`IndexedPartSelectInOutOp` too.
