### PR TITLE
[FIRRTL][Metadata] Ignore OMIR metadata for zero width ports

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -529,6 +529,8 @@ void EmitOMIRPass::emitOptionalRTLPorts(DictionaryAttr node,
     jsonStream.attribute("name", "ports");
     jsonStream.attributeArray("value", [&] {
       for (auto port : llvm::enumerate(module.getPorts())) {
+        if (port.value().type.getBitWidthOrSentinel() == 0)
+          continue;
         jsonStream.object([&] {
           // Emit the `ref` field.
           buf.assign("OMDontTouchedReferenceTarget:~");

--- a/test/Dialect/FIRRTL/SFCTests/emit-omir.fir
+++ b/test/Dialect/FIRRTL/SFCTests/emit-omir.fir
@@ -66,6 +66,7 @@ circuit Foo : %[[
     defname = MySRAM
   module Foo :
     input unsigned : UInt<17>
+    input zeroW : UInt<0>
     output signed : UInt<19>
     inst parameter of Bar
     signed <= unsigned


### PR DESCRIPTION
Since zero width ports will be dropped during `LowerToHW`, donot generate the OMIR metadata for them.
OMIR pass generates symbols for zero width ports, if they are not ignored. 
