### PR TITLE
[FIRRTL] Fix InferResets failing on zero-width registers

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -89,7 +89,7 @@ def ConstantOp : FIRRTLOp<"constant", [NoSideEffect, ConstantLike,
     }];
 
   let arguments = (ins APSIntAttr:$value);
-  let results = (outs NonZeroIntType:$result);
+  let results = (outs IntType:$result);
 
   // Need a custom parser/printer to avoid redundant type for the attribute and
   // the op itself.

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -118,10 +118,6 @@ def OneBitType : DialectType<FIRRTLDialect,
    "($_self.isa<AnalogType>() && $_self.cast<AnalogType>().getWidth() == 1)">,
  "UInt<1>, SInt<1>, or Analog<1>", "::circt::firrtl::FIRRTLType">;
 
-def NonZeroIntType : DialectType<FIRRTLDialect,
-  CPred<"$_self.isa<IntType>() && $_self.cast<IntType>().getWidth() != 0">,
-  "Int", "::circt::firrtl::IntType">;
-
 def AnyResetType : DialectType<FIRRTLDialect,
     CPred<"$_self.isa<FIRRTLType>() && $_self.cast<FIRRTLType>().isResetType()">,
     "Reset", "::circt::firrtl::FIRRTLType">;

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1850,9 +1850,6 @@ static ParseResult parseConstantOp(OpAsmParser &parser,
   // APInt as appropriate.
   if (resultType.hasWidth()) {
     auto width = (unsigned)resultType.getWidthOrSentinel();
-    if (width == 0)
-      return parser.emitError(loc, "zero bit constants aren't allowed");
-
     if (width > value.getBitWidth()) {
       // sext is always safe here, even for unsigned values, because the
       // parseOptionalInteger method will return something with a zero in the

--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -707,3 +707,15 @@ firrtl.circuit "SubAccess" {
 
   }
 }
+
+// This is a regression check to ensure that a zero-width register gets a proper
+// reset value.
+// CHECK-LABEL: firrtl.module @ZeroWidthRegister
+firrtl.circuit "ZeroWidthRegister" {
+  firrtl.module @ZeroWidthRegister(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset) attributes {
+    portAnnotations = [[],[{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]]} {
+    %reg = firrtl.reg %clock : !firrtl.uint<0>
+    // CHECK-NEXT: [[TMP:%.+]] = firrtl.constant 0 : !firrtl.uint<0>
+    // CHECK-NEXT: %reg = firrtl.regreset %clock, %reset, [[TMP]]
+  }
+}

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -4,6 +4,10 @@ firrtl.circuit "MyModule" {
 
 // Constant op supports different return types.
 firrtl.module @Constants() {
+  // CHECK: %c0_ui0 = firrtl.constant 0 : !firrtl.uint<0>
+  firrtl.constant 0 : !firrtl.uint<0>
+  // CHECK: %c0_si0 = firrtl.constant 0 : !firrtl.sint<0>
+  firrtl.constant 0 : !firrtl.sint<0>
   // CHECK: %c4_ui8 = firrtl.constant 4 : !firrtl.uint<8>
   firrtl.constant 4 : !firrtl.uint<8>
   // CHECK: %c-4_si16 = firrtl.constant -4 : !firrtl.sint<16>


### PR DESCRIPTION
In practice we have come across registers of width zero. The `InferResets` pass then tries to add an asynchronous reset to these, for which it has to come up with a zero value of that type. However, the `firrtl.constant` op cannot generate a value of width 0. This adds a workaround that keeps `ConstantOp` unchanged, but uses the `TailPrimOp` to chop off the only bit from a single-bit value.