### PR TITLE
[ExportVerilog] Avoid getAllModulePortInfos for getting individual port name

### DIFF
--- a/include/circt/Dialect/HW/HWOps.h
+++ b/include/circt/Dialect/HW/HWOps.h
@@ -104,6 +104,12 @@ bool isAnyModule(Operation *module);
 /// Return the signature for the specified module as a function type.
 FunctionType getModuleType(Operation *module);
 
+/// Return the number of inputs for the specified module as a function type.
+unsigned getModuleNumInputs(Operation *module);
+
+/// Return the number of outputs for the specified module as a function type.
+unsigned getModuleNumOutputs(Operation *module);
+
 /// Returns the verilog module name attribute or symbol name of any module-like
 /// operations.
 StringAttr getVerilogModuleNameAttr(Operation *module);

--- a/include/circt/Dialect/HW/HWOps.h
+++ b/include/circt/Dialect/HW/HWOps.h
@@ -104,10 +104,10 @@ bool isAnyModule(Operation *module);
 /// Return the signature for the specified module as a function type.
 FunctionType getModuleType(Operation *module);
 
-/// Return the number of inputs for the specified module as a function type.
+/// Return the number of inputs for the specified module.
 unsigned getModuleNumInputs(Operation *module);
 
-/// Return the number of outputs for the specified module as a function type.
+/// Return the number of outputs for the specified module.
 unsigned getModuleNumOutputs(Operation *module);
 
 /// Returns the verilog module name attribute or symbol name of any module-like

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -616,7 +616,7 @@ void EmitterBase::emitTextWithSubstitutions(
     // haven't, take a look at name name legalization first.
     if (auto itemOp = item.getOp()) {
       if (item.hasPort()) {
-        auto portInfos = getAllModulePortInfos(itemOp);
+        auto portInfos = state.globalNames.getPortsInfo(itemOp);
         return state.globalNames.getPortVerilogName(itemOp,
                                                     portInfos[item.getPort()]);
       }
@@ -3141,7 +3141,7 @@ LogicalResult StmtEmitter::visitStmt(InstanceOp op) {
 
   os << ' ' << names.getName(op) << " (";
 
-  SmallVector<PortInfo> portInfo = getAllModulePortInfos(op);
+  SmallVector<PortInfo> portInfo = state.globalNames.getPortsInfo(op);
 
   // Get the max port name length so we can align the '('.
   size_t maxNameLength = 0;
@@ -3561,7 +3561,7 @@ void ModuleEmitter::emitBind(BindOp op) {
            << state.globalNames.getDeclarationVerilogName(inst) << " (";
 
   ModulePortInfo parentPortInfo = parentMod.getPorts();
-  SmallVector<PortInfo> childPortInfo = getAllModulePortInfos(inst);
+  SmallVector<PortInfo> childPortInfo = state.globalNames.getPortsInfo(inst);
 
   // Get the max port name length so we can align the '('.
   size_t maxNameLength = 0;
@@ -3652,7 +3652,7 @@ void ModuleEmitter::emitHWModule(HWModuleOp module) {
   ModuleNameManager names;
 
   // Add all the ports to the name table so wires etc don't reuse the name.
-  SmallVector<PortInfo> portInfo = module.getAllPorts();
+  SmallVector<PortInfo> portInfo = state.globalNames.getPortsInfo(module);
   for (auto &port : portInfo) {
     StringRef name = state.globalNames.getPortVerilogName(module, port);
     Value value;

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -616,9 +616,7 @@ void EmitterBase::emitTextWithSubstitutions(
     // haven't, take a look at name name legalization first.
     if (auto itemOp = item.getOp()) {
       if (item.hasPort()) {
-        auto portInfos = state.globalNames.getPortsInfo(itemOp);
-        return state.globalNames.getPortVerilogName(itemOp,
-                                                    portInfos[item.getPort()]);
+        return state.globalNames.getPortVerilogName(itemOp, item.getPort());
       }
       if (isa<WireOp, RegOp, LocalParamOp, InstanceOp, InterfaceInstanceOp>(
               itemOp))
@@ -3141,7 +3139,7 @@ LogicalResult StmtEmitter::visitStmt(InstanceOp op) {
 
   os << ' ' << names.getName(op) << " (";
 
-  SmallVector<PortInfo> portInfo = state.globalNames.getPortsInfo(op);
+  SmallVector<PortInfo> portInfo = getAllModulePortInfos(op);
 
   // Get the max port name length so we can align the '('.
   size_t maxNameLength = 0;
@@ -3561,7 +3559,7 @@ void ModuleEmitter::emitBind(BindOp op) {
            << state.globalNames.getDeclarationVerilogName(inst) << " (";
 
   ModulePortInfo parentPortInfo = parentMod.getPorts();
-  SmallVector<PortInfo> childPortInfo = state.globalNames.getPortsInfo(inst);
+  SmallVector<PortInfo> childPortInfo = getAllModulePortInfos(inst);
 
   // Get the max port name length so we can align the '('.
   size_t maxNameLength = 0;
@@ -3652,7 +3650,7 @@ void ModuleEmitter::emitHWModule(HWModuleOp module) {
   ModuleNameManager names;
 
   // Add all the ports to the name table so wires etc don't reuse the name.
-  SmallVector<PortInfo> portInfo = state.globalNames.getPortsInfo(module);
+  SmallVector<PortInfo> portInfo = module.getAllPorts();
   for (auto &port : portInfo) {
     StringRef name = state.globalNames.getPortVerilogName(module, port);
     Value value;

--- a/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
+++ b/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
@@ -69,6 +69,27 @@ struct GlobalNameTable {
     return attr.getValue();
   }
 
+  /// Return the getAllModulePortInfos for mod, return cached if it exists else
+  /// cache it.
+  SmallVector<hw::PortInfo> getPortsInfo(Operation *mod) {
+    auto it = modPortInfos.find(mod);
+    SmallVector<hw::PortInfo> result;
+    if (it == modPortInfos.end()) {
+      result = hw::getAllModulePortInfos(mod);
+      modPortInfos[mod] = result;
+    } else
+      result = it->getSecond();
+    return result;
+  }
+
+  /// Return the cached result for getAllModulePortInfos for mod.
+  SmallVector<hw::PortInfo> getPortsInfo(Operation *mod) const {
+    auto it = modPortInfos.find(mod);
+    if (it == modPortInfos.end())
+      return hw::getAllModulePortInfos(mod);
+    return it->getSecond();
+  }
+
 private:
   friend class GlobalNameResolver;
   GlobalNameTable() {}
@@ -112,6 +133,9 @@ private:
   /// sv.interface.signal, and sv.interface.modport) that need to be renamed
   /// due to conflicts.
   DenseMap<Operation *, StringAttr> renamedInterfaceOp;
+
+  /// This caches the result of getAllModulePortInfos.
+  DenseMap<Operation *, SmallVector<hw::PortInfo>> modPortInfos;
 };
 
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
+++ b/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
@@ -38,6 +38,30 @@ struct GlobalNameTable {
     return (it != renamedPorts.end() ? it->second : port.name).getValue();
   }
 
+  /// Return the string to use for the specified port in the specified module.
+  /// Ports may be renamed for a variety of reasons (e.g. conflicting with
+  /// Verilog keywords), and this returns the legalized name to use.
+  StringRef getPortVerilogName(Operation *module, ssize_t portArgNum) const {
+    auto numInputs = hw::getModuleNumInputs(module);
+    // portArgNum is the index into the result of getAllModulePortInfos.
+    // We need to translate it into the PortInfo::getId(), which is a unique
+    // port identifier. if input port, then (-1 - portArgNum) else numInputs -
+    // portArgNum Also ensure the correct index into the input/output list is
+    // computed.
+    StringAttr nameAttr;
+    if (portArgNum < numInputs) {
+      nameAttr = module->getAttrOfType<ArrayAttr>("argNames")[portArgNum]
+                     .cast<StringAttr>();
+      portArgNum = -1 - portArgNum;
+    } else {
+      portArgNum = numInputs - portArgNum;
+      nameAttr = module->getAttrOfType<ArrayAttr>("resultNames")[portArgNum]
+                     .cast<StringAttr>();
+    }
+    auto it = renamedPorts.find(std::make_pair(module, portArgNum));
+    return (it != renamedPorts.end() ? it->second : nameAttr).getValue();
+  }
+
   /// Return the string to use for the specified parameter name in the specified
   /// module.  Parameters may be renamed for a variety of reasons (e.g.
   /// conflicting with ports or Verilog keywords), and this returns the
@@ -67,27 +91,6 @@ struct GlobalNameTable {
     auto attr = it != renamedInterfaceOp.end() ? it->second
                                                : SymbolTable::getSymbolName(op);
     return attr.getValue();
-  }
-
-  /// Return the getAllModulePortInfos for mod, return cached if it exists else
-  /// cache it.
-  SmallVector<hw::PortInfo> getPortsInfo(Operation *mod) {
-    auto it = modPortInfos.find(mod);
-    SmallVector<hw::PortInfo> result;
-    if (it == modPortInfos.end()) {
-      result = hw::getAllModulePortInfos(mod);
-      modPortInfos[mod] = result;
-    } else
-      result = it->getSecond();
-    return result;
-  }
-
-  /// Return the cached result for getAllModulePortInfos for mod.
-  SmallVector<hw::PortInfo> getPortsInfo(Operation *mod) const {
-    auto it = modPortInfos.find(mod);
-    if (it == modPortInfos.end())
-      return hw::getAllModulePortInfos(mod);
-    return it->getSecond();
   }
 
 private:
@@ -120,7 +123,8 @@ private:
   /// This contains entries for any ports that got renamed.  The key is a
   /// moduleop/portIdx tuple, the value is the name to use.  The portIdx is the
   /// index of the port in the list returned by getAllModulePortInfos.
-  DenseMap<std::pair<Operation *, size_t>, StringAttr> renamedPorts;
+  /// Note, PortInfo::getId() returns ssize_t.
+  DenseMap<std::pair<Operation *, ssize_t>, StringAttr> renamedPorts;
 
   /// This contains entries for any parameters that got renamed.  The key is a
   /// moduleop/paramName tuple, the value is the name to use.
@@ -133,9 +137,6 @@ private:
   /// sv.interface.signal, and sv.interface.modport) that need to be renamed
   /// due to conflicts.
   DenseMap<Operation *, StringAttr> renamedInterfaceOp;
-
-  /// This caches the result of getAllModulePortInfos.
-  DenseMap<Operation *, SmallVector<hw::PortInfo>> modPortInfos;
 };
 
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
+++ b/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
@@ -45,20 +45,22 @@ struct GlobalNameTable {
     auto numInputs = hw::getModuleNumInputs(module);
     // portArgNum is the index into the result of getAllModulePortInfos.
     // We need to translate it into the PortInfo::getId(), which is a unique
-    // port identifier. if input port, then (-1 - portArgNum) else numInputs -
-    // portArgNum Also ensure the correct index into the input/output list is
-    // computed.
+    // port identifier.
+    // if input port, then (-1 - portArgNum)
+    // else numInputs - portArgNum
+    // Also ensure the correct index into the input/output list is computed.
     StringAttr nameAttr;
+    ssize_t portId = portArgNum;
     if (portArgNum < numInputs) {
       nameAttr = module->getAttrOfType<ArrayAttr>("argNames")[portArgNum]
                      .cast<StringAttr>();
-      portArgNum = -1 - portArgNum;
+      portId = -1 - portArgNum;
     } else {
-      portArgNum = numInputs - portArgNum;
-      nameAttr = module->getAttrOfType<ArrayAttr>("resultNames")[portArgNum]
+      portId = portArgNum - numInputs;
+      nameAttr = module->getAttrOfType<ArrayAttr>("resultNames")[portId]
                      .cast<StringAttr>();
     }
-    auto it = renamedPorts.find(std::make_pair(module, portArgNum));
+    auto it = renamedPorts.find(std::make_pair(module, portId));
     return (it != renamedPorts.end() ? it->second : nameAttr).getValue();
   }
 

--- a/lib/Conversion/ExportVerilog/LegalizeNames.cpp
+++ b/lib/Conversion/ExportVerilog/LegalizeNames.cpp
@@ -131,7 +131,7 @@ void GlobalNameResolver::legalizeModuleNames(HWModuleOp module) {
 
   // Legalize the port names.
   size_t portIdx = 0;
-  for (const PortInfo &port : getAllModulePortInfos(module)) {
+  for (const PortInfo &port : globalNameTable.getPortsInfo(module)) {
     auto newName = nameResolver.getLegalName(port.name);
     if (newName != port.name.getValue())
       globalNameTable.addRenamedPort(module, port, newName);

--- a/lib/Conversion/ExportVerilog/LegalizeNames.cpp
+++ b/lib/Conversion/ExportVerilog/LegalizeNames.cpp
@@ -131,7 +131,7 @@ void GlobalNameResolver::legalizeModuleNames(HWModuleOp module) {
 
   // Legalize the port names.
   size_t portIdx = 0;
-  for (const PortInfo &port : globalNameTable.getPortsInfo(module)) {
+  for (const PortInfo &port : getAllModulePortInfos(module)) {
     auto newName = nameResolver.getLegalName(port.name);
     if (newName != port.name.getValue())
       globalNameTable.addRenamedPort(module, port, newName);

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -248,6 +248,32 @@ FunctionType hw::getModuleType(Operation *moduleOrInstance) {
   return typeAttr.getValue().cast<FunctionType>();
 }
 
+/// Return the number of inputs for a module as a function type from the module
+/// itself or from an hw::InstanceOp.
+unsigned hw::getModuleNumInputs(Operation *moduleOrInstance) {
+  if (auto instance = dyn_cast<InstanceOp>(moduleOrInstance)) {
+    return instance->getNumOperands();
+  }
+  assert(isAnyModule(moduleOrInstance) &&
+         "must be called on instance or module");
+  auto typeAttr =
+      moduleOrInstance->getAttrOfType<TypeAttr>(HWModuleOp::getTypeAttrName());
+  return typeAttr.getValue().cast<FunctionType>().getNumInputs();
+}
+
+/// Return the number of results for a module as a function type from the module
+/// itselfA or from an hw::InstanceOp.
+unsigned hw::getModuleNumOutputs(Operation *moduleOrInstance) {
+  if (auto instance = dyn_cast<InstanceOp>(moduleOrInstance)) {
+    return instance->getNumResults();
+  }
+  assert(isAnyModule(moduleOrInstance) &&
+         "must be called on instance or module");
+  auto typeAttr =
+      moduleOrInstance->getAttrOfType<TypeAttr>(HWModuleOp::getTypeAttrName());
+  return typeAttr.getValue().cast<FunctionType>().getNumResults();
+}
+
 /// Return the name to use for the Verilog module that we're referencing
 /// here.  This is typically the symbol, but can be overridden with the
 /// verilogName attribute.


### PR DESCRIPTION
Avoid calling `getAllModulePortInfos` for getting the name of every port.
The `port id` should be enough to compute the required information.
The `emitTextWithSubstitutions` was calling `getAllModulePortInfos` and 
was causing a run-time blow up for a large design with a module > 100 ports,
 with symbols on each of them which were used on a `VerbatimOp`.
(In particular, the `EmitOMIR` pass is creating this `VerbatimOp` and
adding a symbol to all the ports in the design.)
`ExportVerilog` runtime for a test case reduced from  580.3878 sec to 152.1718 sec


