### PR TITLE
[HW] [ExportVerilog] Allow TypeScopeOps in IfDefOp regions

### DIFF
--- a/include/circt/Dialect/HW/HWTypeDecls.td
+++ b/include/circt/Dialect/HW/HWTypeDecls.td
@@ -15,8 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 def TypeScopeOp : HWOp<"type_scope",
-      [Symbol, SymbolTable, SingleBlock, NoTerminator, NoRegionArguments,
-      HasParent<"mlir::ModuleOp">]> {
+      [Symbol, SymbolTable, SingleBlock, NoTerminator, NoRegionArguments]> {
   let summary = "Type declaration wrapper.";
   let description = [{
     An operation whose one body block contains type declarations. This op

--- a/include/circt/Dialect/HW/HWVisitors.h
+++ b/include/circt/Dialect/HW/HWVisitors.h
@@ -80,9 +80,10 @@ public:
   ResultType dispatchStmtVisitor(Operation *op, ExtraArgs... args) {
     auto *thisCast = static_cast<ConcreteType *>(this);
     return TypeSwitch<Operation *, ResultType>(op)
-        .template Case<OutputOp, InstanceOp>([&](auto expr) -> ResultType {
-          return thisCast->visitStmt(expr, args...);
-        })
+        .template Case<OutputOp, InstanceOp, TypeScopeOp>(
+            [&](auto expr) -> ResultType {
+              return thisCast->visitStmt(expr, args...);
+            })
         .Default([&](auto expr) -> ResultType {
           return thisCast->visitInvalidStmt(op, args...);
         });
@@ -119,6 +120,7 @@ public:
   // Basic nodes.
   HANDLE(OutputOp, Unhandled);
   HANDLE(InstanceOp, Unhandled);
+  HANDLE(TypeScopeOp, Unhandled);
 #undef HANDLE
 };
 

--- a/test/Conversion/ExportVerilog/hw-typedecls.mlir
+++ b/test/Conversion/ExportVerilog/hw-typedecls.mlir
@@ -24,6 +24,16 @@ hw.type_scope @_other_scope {
   hw.typedecl @foo, "_other_scope_foo" : i2
 }
 
+// CHECK: `ifndef __PYCDE_TYPES__
+// CHECK:   typedef struct packed {logic a; } exTypedef;
+// CHECK: `endif
+sv.ifdef "__PYCDE_TYPES__"  {
+} else  {
+  hw.type_scope @pycde  {
+    hw.typedecl @exTypedef : !hw.struct<a: i1>
+  }
+}
+
 // CHECK-LABEL: module testTypeAlias
 hw.module @testTypeAlias(
   // CHECK: input  foo      arg0, arg1


### PR DESCRIPTION
In order to create macro guards, the type scope has to be in an ifdef region. Remove that HasParent restriction. Since we don't want to introduce a HW -> SV dependency, don't replace it with `ModuleOp || sv::IfDefOp`.

Add support for emitting typescopes anywhere. This was painful since it turns out that `VerilogEmitterState.os` isn't always an alias for `EmitterBase.os`. When emitting things as statements, it is an internal buffer and that needs to be used by the typescope emitter (otherwise the `typedef` gets emitted before the `ifdef`). That emitter, however, needs a `ModuleEmitter` to be able to output types. This resulted in the additions to `ExportVerilog` below.