### PR TITLE
[HW] Simplify module/instance input/output size computation. NFC

### DIFF
--- a/include/circt/Dialect/HW/HWOps.h
+++ b/include/circt/Dialect/HW/HWOps.h
@@ -101,19 +101,22 @@ PortInfo getModuleOutputPort(Operation *op, size_t idx);
 /// Return true if this is an hw.module, external module, generated module etc.
 bool isAnyModule(Operation *module);
 
+/// Return true if isAnyModule or instance.
+bool isAnyModuleOrInstance(Operation *module);
+
 /// Return the signature for the specified module as a function type.
 FunctionType getModuleType(Operation *module);
 
 /// Return the number of inputs for the specified module/instance.
 inline unsigned getModuleNumInputs(Operation *moduleOrInstance) {
-  assert(isAnyModule(moduleOrInstance) &&
+  assert(isAnyModuleOrInstance(moduleOrInstance) &&
          "must be called on instance or module");
   return moduleOrInstance->getAttrOfType<ArrayAttr>("argNames").size();
 }
 
 /// Return the number of outputs for the specified module/instance.
 inline unsigned getModuleNumOutputs(Operation *moduleOrInstance) {
-  assert(isAnyModule(moduleOrInstance) &&
+  assert(isAnyModuleOrInstance(moduleOrInstance) &&
          "must be called on instance or module");
   return moduleOrInstance->getAttrOfType<ArrayAttr>("resultNames").size();
 }

--- a/include/circt/Dialect/HW/HWOps.h
+++ b/include/circt/Dialect/HW/HWOps.h
@@ -104,11 +104,19 @@ bool isAnyModule(Operation *module);
 /// Return the signature for the specified module as a function type.
 FunctionType getModuleType(Operation *module);
 
-/// Return the number of inputs for the specified module.
-unsigned getModuleNumInputs(Operation *module);
+/// Return the number of inputs for the specified module/instance.
+inline unsigned getModuleNumInputs(Operation *moduleOrInstance) {
+  assert(isAnyModule(moduleOrInstance) &&
+         "must be called on instance or module");
+  return moduleOrInstance->getAttrOfType<ArrayAttr>("argNames").size();
+}
 
-/// Return the number of outputs for the specified module.
-unsigned getModuleNumOutputs(Operation *module);
+/// Return the number of outputs for the specified module/instance.
+inline unsigned getModuleNumOutputs(Operation *moduleOrInstance) {
+  assert(isAnyModule(moduleOrInstance) &&
+         "must be called on instance or module");
+  return moduleOrInstance->getAttrOfType<ArrayAttr>("resultNames").size();
+}
 
 /// Returns the verilog module name attribute or symbol name of any module-like
 /// operations.

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -232,6 +232,11 @@ bool hw::isAnyModule(Operation *module) {
          isa<HWModuleGeneratedOp>(module);
 }
 
+/// Return true if isAnyModule or instance.
+bool hw::isAnyModuleOrInstance(Operation *moduleOrInstance) {
+  return isAnyModule(moduleOrInstance) || isa<InstanceOp>(moduleOrInstance);
+}
+
 /// Return the signature for a module as a function type from the module itself
 /// or from an hw::InstanceOp.
 FunctionType hw::getModuleType(Operation *moduleOrInstance) {

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -441,7 +441,7 @@ void HWModuleGeneratedOp::build(OpBuilder &builder, OperationState &result,
 /// the specified module or instance.  The input ports always come before the
 /// output ports in the list.
 ModulePortInfo hw::getModulePortInfo(Operation *op) {
-  assert((isa<InstanceOp>(op) || isAnyModule(op)) &&
+  assert(isAnyModuleOrInstance(op) &&
          "Can only get module ports from an instance or module");
 
   SmallVector<PortInfo> inputs, outputs;
@@ -474,7 +474,7 @@ ModulePortInfo hw::getModulePortInfo(Operation *op) {
 /// the specified module or instance.  The input ports always come before the
 /// output ports in the list.
 SmallVector<PortInfo> hw::getAllModulePortInfos(Operation *op) {
-  assert((isa<InstanceOp>(op) || isAnyModule(op)) &&
+  assert(isAnyModuleOrInstance(op) &&
          "Can only get module ports from an instance or module");
 
   SmallVector<PortInfo> results;

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -248,32 +248,6 @@ FunctionType hw::getModuleType(Operation *moduleOrInstance) {
   return typeAttr.getValue().cast<FunctionType>();
 }
 
-/// Return the number of inputs for a module as a function type from the module
-/// itself or from an hw::InstanceOp.
-unsigned hw::getModuleNumInputs(Operation *moduleOrInstance) {
-  if (auto instance = dyn_cast<InstanceOp>(moduleOrInstance)) {
-    return instance->getNumOperands();
-  }
-  assert(isAnyModule(moduleOrInstance) &&
-         "must be called on instance or module");
-  auto typeAttr =
-      moduleOrInstance->getAttrOfType<TypeAttr>(HWModuleOp::getTypeAttrName());
-  return typeAttr.getValue().cast<FunctionType>().getNumInputs();
-}
-
-/// Return the number of results for a module as a function type from the module
-/// itselfA or from an hw::InstanceOp.
-unsigned hw::getModuleNumOutputs(Operation *moduleOrInstance) {
-  if (auto instance = dyn_cast<InstanceOp>(moduleOrInstance)) {
-    return instance->getNumResults();
-  }
-  assert(isAnyModule(moduleOrInstance) &&
-         "must be called on instance or module");
-  auto typeAttr =
-      moduleOrInstance->getAttrOfType<TypeAttr>(HWModuleOp::getTypeAttrName());
-  return typeAttr.getValue().cast<FunctionType>().getNumResults();
-}
-
 /// Return the name to use for the Verilog module that we're referencing
 /// here.  This is typically the symbol, but can be overridden with the
 /// verilogName attribute.


### PR DESCRIPTION
Simplify the function to get the number of input and output ports for modules and instances, since they all have the same argument names.
