### PR TITLE
[ExportVerilog] Remove temporary vector in text substitution

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -678,7 +678,7 @@ void EmitterBase::emitTextWithSubstitutions(
         auto sym = symAttrs[symOpNum];
         SmallString<12> symVerilogName;
         if (auto fsym = sym.dyn_cast<FlatSymbolRefAttr>())
-          if (auto symOp = state.symbolCache.getDefinition(fsym))
+          if (auto *symOp = state.symbolCache.getDefinition(fsym))
             symVerilogName = namify(sym, symOp);
         if (auto isym = sym.dyn_cast<InnerRefAttr>()) {
           auto symOp =

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -676,7 +676,7 @@ void EmitterBase::emitTextWithSubstitutions(
       else if ((operandNo - op->getNumOperands()) < numSymOps) {
         unsigned symOpNum = operandNo - op->getNumOperands();
         auto sym = symAttrs[symOpNum];
-        SmallString<12> symVerilogName;
+        StringRef symVerilogName;
         if (auto fsym = sym.dyn_cast<FlatSymbolRefAttr>()) {
           if (auto *symOp = state.symbolCache.getDefinition(fsym))
             symVerilogName = namify(sym, symOp);

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -677,10 +677,10 @@ void EmitterBase::emitTextWithSubstitutions(
         unsigned symOpNum = operandNo - op->getNumOperands();
         auto sym = symAttrs[symOpNum];
         SmallString<12> symVerilogName;
-        if (auto fsym = sym.dyn_cast<FlatSymbolRefAttr>())
+        if (auto fsym = sym.dyn_cast<FlatSymbolRefAttr>()) {
           if (auto *symOp = state.symbolCache.getDefinition(fsym))
             symVerilogName = namify(sym, symOp);
-        if (auto isym = sym.dyn_cast<InnerRefAttr>()) {
+        } else if (auto isym = sym.dyn_cast<InnerRefAttr>()) {
           auto symOp =
               state.symbolCache.getDefinition(isym.getModule(), isym.getName());
           symVerilogName = namify(sym, symOp);


### PR DESCRIPTION
It is cheaper to call `namify` than to store it in `SmallVector` during text substitution.
Seems to drop runtime of a test case from 150.5509 sec to 2.7712 sec, size of the vector was ~400 elements.