### PR TITLE
[HW][SV][ExportVerilog] SV Attributes

### DIFF
--- a/include/circt/Dialect/SV/CMakeLists.txt
+++ b/include/circt/Dialect/SV/CMakeLists.txt
@@ -13,6 +13,11 @@ mlir_tablegen(SVStructs.cpp.inc -gen-struct-attr-defs)
 add_public_tablegen_target(MLIRSVStructsIncGen)
 add_dependencies(circt-headers MLIRSVStructsIncGen)
 
+mlir_tablegen(SVAttributes.h.inc -gen-attrdef-decls -attrdefs-dialect sv)
+mlir_tablegen(SVAttributes.cpp.inc -gen-attrdef-defs -attrdefs-dialect sv)
+add_public_tablegen_target(MLIRSVAttrIncGen)
+add_circt_doc(SV -gen-attrdef-doc SVAttributes Dialects/)
+
 set(LLVM_TARGET_DEFINITIONS SVPasses.td)
 mlir_tablegen(SVPasses.h.inc -gen-pass-decls)
 add_public_tablegen_target(CIRCTSVTransformsIncGen)

--- a/include/circt/Dialect/SV/SV.td
+++ b/include/circt/Dialect/SV/SV.td
@@ -44,5 +44,6 @@ include "circt/Dialect/SV/SVInOutOps.td"
 include "circt/Dialect/SV/SVStatements.td"
 include "circt/Dialect/SV/SVVerification.td"
 include "circt/Dialect/SV/SVTypeDecl.td"
+include "circt/Dialect/SV/SVAttributes.td"
 
 #endif // CIRCT_DIALECT_SV_SV

--- a/include/circt/Dialect/SV/SVAttributes.h
+++ b/include/circt/Dialect/SV/SVAttributes.h
@@ -1,0 +1,18 @@
+//===- SVAttributes.h - Declare SV dialect attributes ------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_SV_ATTRIBUTES_H
+#define CIRCT_DIALECT_SV_ATTRIBUTES_H
+
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinAttributes.h"
+
+#define GET_ATTRDEF_CLASSES
+#include "circt/Dialect/SV/SVAttributes.h.inc"
+
+#endif // CIRCT_DIALECT_SV_ATTRIBUTES_H

--- a/include/circt/Dialect/SV/SVAttributes.td
+++ b/include/circt/Dialect/SV/SVAttributes.td
@@ -1,0 +1,33 @@
+//===- SVAttributes.td - Attributes for HW dialect ---------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines SystemVerilog dialect-specific attributes.
+//
+//===----------------------------------------------------------------------===//
+
+def SVAttributeAttr : AttrDef<SVDialect, "SVAttribute"> {
+  let summary = "a Verilog Attribute";
+  let mnemonic = "attribute";
+  let description = [{
+    This attribute is used to encode a Verilog _attribute_.  A Verilog attribute
+    (not to be confused with an LLVM or MLIR attribute) is a syntactic mechanism
+    for adding metadata to specific declarations, statements, and expressions in
+    the Verilog language.  _There are no "standard" attributes_.  Specific tools
+    define and handle their own attributes.
+
+    Verilog attributes have a mandatory name and an optional constant
+    expression.  This is encoded as a key (name) value (expression) pair.
+    Multiple attributes may be specified, either with multiple separate
+    attributes or by comman-separating name--expression pairs.
+
+    For more information, refer to Section 5.12 of the SystemVerilog (1800-2017)
+    specification.
+  }];
+  let parameters = (ins "::mlir::StringAttr":$name,
+                        "::mlir::StringAttr":$expression);
+}

--- a/include/circt/Dialect/SV/SVDialect.td
+++ b/include/circt/Dialect/SV/SVDialect.td
@@ -26,6 +26,8 @@ def SVDialect : Dialect {
   let extraClassDeclaration = [{
     /// Register all SV types.
     void registerTypes();
+    /// Register all SV attributes.
+    void registerAttributes();
   }];
 }
 

--- a/lib/Dialect/SV/CMakeLists.txt
+++ b/lib/Dialect/SV/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_circt_dialect_library(CIRCTSV
+  SVAttributes.cpp
   SVDialect.cpp
   SVOps.cpp
   SVTypes.cpp
@@ -7,6 +8,7 @@ add_circt_dialect_library(CIRCTSV
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/SV
 
   DEPENDS
+  MLIRSVAttrIncGen
   MLIRSVIncGen
 
   LINK_COMPONENTS

--- a/lib/Dialect/SV/SVAttributes.cpp
+++ b/lib/Dialect/SV/SVAttributes.cpp
@@ -1,0 +1,73 @@
+//===- SVAttributes.cpp - Implement SV Attributes--------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides implementations for SV attributes.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/SV/SVAttributes.h"
+#include "circt/Dialect/SV/SVDialect.h"
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace circt;
+using namespace circt::sv;
+
+//===----------------------------------------------------------------------===//
+// ODS Boilerplate
+//===----------------------------------------------------------------------===//
+
+#define GET_ATTRDEF_CLASSES
+#include "circt/Dialect/SV/SVAttributes.cpp.inc"
+
+void SVDialect::registerAttributes() {
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include "circt/Dialect/SV/SVAttributes.cpp.inc"
+      >();
+}
+
+Attribute SVDialect::parseAttribute(DialectAsmParser &p, Type type) const {
+  StringRef attrName;
+  Attribute attr;
+  if (p.parseKeyword(&attrName))
+    return Attribute();
+  auto parseResult = generatedAttributeParser(p, attrName, type, attr);
+  if (parseResult.hasValue())
+    return attr;
+  p.emitError(p.getNameLoc(), "Unexpected SV attribute '" + attrName + "'");
+  return {};
+}
+
+void SVDialect::printAttribute(Attribute attr, DialectAsmPrinter &p) const {
+  if (succeeded(generatedAttributePrinter(attr, p)))
+    return;
+  llvm_unreachable("Unexpected attribute");
+}
+
+//===----------------------------------------------------------------------===//
+// AttributeInstanceAttr
+//===----------------------------------------------------------------------===//
+
+Attribute SVAttributeAttr::parse(DialectAsmParser &p, Type type) {
+  StringAttr name, expression;
+  if (p.parseLess() || p.parseAttribute<StringAttr>(name))
+    return Attribute();
+  p.parseOptionalEqual() || p.parseAttribute(expression);
+  if (p.parseGreater())
+    return Attribute();
+  return SVAttributeAttr::get(p.getContext(), name, expression);
+}
+
+void SVAttributeAttr::print(::mlir::DialectAsmPrinter &p) const {
+  p << getMnemonic() << "<" << getName();
+  if (auto expression = getExpression())
+    p << "=" << expression;
+  p << ">";
+}

--- a/lib/Dialect/SV/SVDialect.cpp
+++ b/lib/Dialect/SV/SVDialect.cpp
@@ -32,6 +32,9 @@ void SVDialect::initialize() {
   // Register types.
   registerTypes();
 
+  // Register attributes.
+  registerAttributes();
+
   // Register operations.
   addOperations<
 #define GET_OP_LIST

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -927,3 +927,10 @@ hw.module @parameterizedTypes<param: i32 = 1, wire: i32 = 2>
 // CHECK-NEXT:  module moduleWithComment
 hw.module @moduleWithComment()
   attributes {comment = "moduleWithComment has a comment\nhello"} {}
+
+// CHECK-LABEL: (* moduleWithAttributes, foo=bar *)
+// CHECK-NEXT:  moduleWithAttributes
+hw.module @moduleWithAttributes()
+  attributes {attribute_instances = [
+    #sv.attribute<"moduleWithAttributes">,
+    #sv.attribute<"foo" = "bar">]} {}

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -276,3 +276,11 @@ hw.module @XMR_src(%a : i23) {
     // CHECK: = sv.indexed_part_select %[[v4]][%[[in4:.+]]  decrement : 5] : i18, i4
     hw.output %c, %d : i3, i5
 }
+
+// CHECK-LABEL: @ModuleWithSVAttributes
+// CHECK-SAME:    #sv.attribute<"moduleWithAttributes">
+// CHECK-SAME:    #sv.attribute<"foo"="bar">
+hw.module @ModuleWithSVAttributes()
+  attributes {attribute_instances = [
+    #sv.attribute<"moduleWithAttributes">,
+    #sv.attribute<"foo"="bar">]} {}


### PR DESCRIPTION
Add support for SV attributes (e.g., `(* hello = world *)`) and support defining them on `HWModuleOp`s.

Follow-on to #2066.
Fixes #1677.