### PR TITLE
[Scheduling] Define problem to model operator chaining.

### DIFF
--- a/include/circt/Scheduling/Problems.h
+++ b/include/circt/Scheduling/Problems.h
@@ -291,22 +291,15 @@ public:
 ///
 /// A solution to this problem comprises per-operation start times in a
 /// continuous unit, e.g. in nanoseconds, inside the discrete time steps/cycles
-/// determined by the underlying scheduling problem. The start times in the
-/// respective cycles must satisfy a given cycle time constraint.
+/// determined by the underlying scheduling problem.
 class ChainingProblem : public virtual Problem {
   DEFINE_FACTORY_METHOD(ChainingProblem)
 
 private:
-  ProblemProperty<float> cycleTime;
   OperatorTypeProperty<float> incomingDelay, outgoingDelay;
   OperationProperty<float> startTimeInCycle;
 
 public:
-  /// The cycle time constrains the accumulated delays along combinational paths
-  /// inside a time step.
-  Optional<float> getCycleTime() { return cycleTime; }
-  void setCycleTime(float time) { cycleTime = time; }
-
   /// The incoming delay denotes the propagation time from the operand inputs to
   /// either the result outputs (combinational operators) or the first internal
   /// register stage.
@@ -337,16 +330,11 @@ public:
   }
 
 protected:
-  /// A positive value for the desired cycle time is set.
-  virtual LogicalResult checkCycleTime();
-  /// Incoming/outgoing delays are set for \p opr, non-negative, and smaller
-  /// than the desired cycle time. The delays are equal if \p opr is a
-  /// zero-latency operator type.
+  /// Incoming/outgoing delays are set for \p opr and non-negative. The delays
+  /// are equal if \p opr is a zero-latency operator type.
   virtual LogicalResult checkDelays(OperatorType opr);
 
-  /// \p op has a non-negative start time in its cycle, which is also early
-  /// enough in the scheduled time step to accommodate the linked operator
-  /// type's incoming delay.
+  /// \p op has a non-negative start time in its cycle.
   virtual LogicalResult verifyStartTimeInCycle(Operation *op);
   /// If \p dep is an SSA edge and its source operation finishes in the same
   /// time step as the destination operation, the source's result is available

--- a/include/circt/Scheduling/Problems.h
+++ b/include/circt/Scheduling/Problems.h
@@ -294,14 +294,14 @@ public:
 /// determined by the underlying scheduling problem. The start times in the
 /// respective cycles must satisfy a given cycle time constraint.
 class ChainingProblem : public virtual Problem {
+  DEFINE_FACTORY_METHOD(ChainingProblem)
+
 private:
   ProblemProperty<float> cycleTime;
   OperatorTypeProperty<float> incomingDelay, outgoingDelay;
   OperationProperty<float> startTimeInCycle;
 
 public:
-  explicit ChainingProblem(Operation *containingOp) : Problem(containingOp) {}
-
   /// The cycle time constrains the accumulated delays along combinational paths
   /// inside a time step.
   Optional<float> getCycleTime() { return cycleTime; }

--- a/lib/Scheduling/TestPasses.cpp
+++ b/lib/Scheduling/TestPasses.cpp
@@ -120,7 +120,7 @@ static void constructChainingProblem(ChainingProblem &prob, FuncOp func) {
   prob.setIncomingDelay(unitOpr, 0.0f);
   prob.setOutgoingDelay(unitOpr, 0.0f);
 
-  // parse operator type info (again) to extract physical delays
+  // parse operator type info (again) to extract delays
   if (auto attr = func->getAttrOfType<ArrayAttr>("operatortypes")) {
     for (auto &elem : parseArrayOfDicts<float>(attr, "incdelay")) {
       auto opr = prob.getOrInsertOperatorType(std::get<0>(elem));
@@ -261,9 +261,8 @@ void TestChainingProblemPass::runOnFunction() {
   for (auto *op : prob.getOperations()) {
     if (auto startTimeAttr = op->getAttrOfType<IntegerAttr>("problemStartTime"))
       prob.setStartTime(op, startTimeAttr.getInt());
-    if (auto physicalTimeAttr =
-            op->getAttrOfType<FloatAttr>("problemPhysicalStartTime"))
-      prob.setPhysicalStartTime(op, physicalTimeAttr.getValueAsDouble());
+    if (auto sticAttr = op->getAttrOfType<FloatAttr>("problemStartTimeInCycle"))
+      prob.setStartTimeInCycle(op, sticAttr.getValueAsDouble());
   }
 
   if (failed(prob.verify())) {

--- a/lib/Scheduling/TestPasses.cpp
+++ b/lib/Scheduling/TestPasses.cpp
@@ -33,14 +33,23 @@ static SmallVector<SmallVector<unsigned>> parseArrayOfArrays(ArrayAttr attr) {
   return result;
 }
 
-static SmallVector<std::pair<llvm::StringRef, unsigned>>
+template <typename T = unsigned>
+static SmallVector<std::pair<llvm::StringRef, T>>
 parseArrayOfDicts(ArrayAttr attr, StringRef key) {
-  SmallVector<std::pair<llvm::StringRef, unsigned>> result;
+  SmallVector<std::pair<llvm::StringRef, T>> result;
   for (auto dictAttr : attr.getAsRange<DictionaryAttr>()) {
     auto name = dictAttr.getAs<StringAttr>("name");
-    auto value = dictAttr.getAs<IntegerAttr>(key);
-    if (name && value)
-      result.push_back(std::make_pair(name.getValue(), value.getInt()));
+    if (!name)
+      continue;
+    auto intAttr = dictAttr.getAs<IntegerAttr>(key);
+    if (intAttr) {
+      result.push_back(std::make_pair(name.getValue(), intAttr.getInt()));
+      continue;
+    }
+    auto floatAttr = dictAttr.getAs<FloatAttr>(key);
+    if (floatAttr)
+      result.push_back(
+          std::make_pair(name.getValue(), floatAttr.getValueAsDouble()));
   }
   return result;
 }
@@ -97,6 +106,29 @@ static void constructCyclicProblem(CyclicProblem &prob, FuncOp func) {
       Operation *to = ops[elemArr[1]];
       unsigned dist = elemArr[2];
       prob.setDistance(std::make_pair(from, to), dist);
+    }
+  }
+}
+
+static void constructChainingProblem(ChainingProblem &prob, FuncOp func) {
+  // get desired cycle time from test case
+  if (auto attr = func->getAttrOfType<FloatAttr>("cycletime"))
+    prob.setCycleTime(attr.getValueAsDouble());
+
+  // patch the default operator type to have zero-delay
+  auto unitOpr = prob.getOrInsertOperatorType("unit");
+  prob.setIncomingDelay(unitOpr, 0.0f);
+  prob.setOutgoingDelay(unitOpr, 0.0f);
+
+  // parse operator type info (again) to extract physical delays
+  if (auto attr = func->getAttrOfType<ArrayAttr>("operatortypes")) {
+    for (auto &elem : parseArrayOfDicts<float>(attr, "incdelay")) {
+      auto opr = prob.getOrInsertOperatorType(std::get<0>(elem));
+      prob.setIncomingDelay(opr, std::get<1>(elem));
+    }
+    for (auto &elem : parseArrayOfDicts<float>(attr, "outdelay")) {
+      auto opr = prob.getOrInsertOperatorType(std::get<0>(elem));
+      prob.setOutgoingDelay(opr, std::get<1>(elem));
     }
   }
 }
@@ -191,6 +223,48 @@ void TestCyclicProblemPass::runOnFunction() {
   for (auto *op : prob.getOperations())
     if (auto startTimeAttr = op->getAttrOfType<IntegerAttr>("problemStartTime"))
       prob.setStartTime(op, startTimeAttr.getInt());
+
+  if (failed(prob.verify())) {
+    func->emitError("problem verification failed");
+    return signalPassFailure();
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// ChainingProblem
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct TestChainingProblemPass
+    : public PassWrapper<TestChainingProblemPass, FunctionPass> {
+  void runOnFunction() override;
+  StringRef getArgument() const override { return "test-chaining-problem"; }
+  StringRef getDescription() const override {
+    return "Import a solution for the chaining problem encoded as attributes";
+  }
+};
+} // namespace
+
+void TestChainingProblemPass::runOnFunction() {
+  auto func = getFunction();
+
+  ChainingProblem prob(func);
+  constructProblem(prob, func);
+  constructChainingProblem(prob, func);
+
+  if (failed(prob.check())) {
+    func->emitError("problem check failed");
+    return signalPassFailure();
+  }
+
+  // get schedule and physical start times from the test case
+  for (auto *op : prob.getOperations()) {
+    if (auto startTimeAttr = op->getAttrOfType<IntegerAttr>("problemStartTime"))
+      prob.setStartTime(op, startTimeAttr.getInt());
+    if (auto physicalTimeAttr =
+            op->getAttrOfType<FloatAttr>("problemPhysicalStartTime"))
+      prob.setPhysicalStartTime(op, physicalTimeAttr.getValueAsDouble());
+  }
 
   if (failed(prob.verify())) {
     func->emitError("problem verification failed");
@@ -417,6 +491,9 @@ void registerSchedulingTestPasses() {
   });
   mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
     return std::make_unique<TestCyclicProblemPass>();
+  });
+  mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
+    return std::make_unique<TestChainingProblemPass>();
   });
   mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
     return std::make_unique<TestSharedOperatorsProblemPass>();

--- a/lib/Scheduling/TestPasses.cpp
+++ b/lib/Scheduling/TestPasses.cpp
@@ -248,7 +248,7 @@ struct TestChainingProblemPass
 void TestChainingProblemPass::runOnFunction() {
   auto func = getFunction();
 
-  ChainingProblem prob(func);
+  auto prob = ChainingProblem::get(func);
   constructProblem(prob, func);
   constructChainingProblem(prob, func);
 

--- a/lib/Scheduling/TestPasses.cpp
+++ b/lib/Scheduling/TestPasses.cpp
@@ -111,10 +111,6 @@ static void constructCyclicProblem(CyclicProblem &prob, FuncOp func) {
 }
 
 static void constructChainingProblem(ChainingProblem &prob, FuncOp func) {
-  // get desired cycle time from test case
-  if (auto attr = func->getAttrOfType<FloatAttr>("cycletime"))
-    prob.setCycleTime(attr.getValueAsDouble());
-
   // patch the default operator type to have zero-delay
   auto unitOpr = prob.getOrInsertOperatorType("unit");
   prob.setIncomingDelay(unitOpr, 0.0f);

--- a/test/Scheduling/chaining-problem-errors.mlir
+++ b/test/Scheduling/chaining-problem-errors.mlir
@@ -1,19 +1,9 @@
 // RUN: circt-opt %s -test-chaining-problem -verify-diagnostics -split-input-file
 
-// expected-error@+2 {{Invalid cycle time}}
-// expected-error@+1 {{problem check failed}}
-func @invalid_cycletime() attributes {
-  cycletime = -3.14
-  } {
-  return
-}
-
-// -----
-
 // expected-error@+2 {{Missing delays}}
 // expected-error@+1 {{problem check failed}}
 func @missing_delay() attributes {
-  cycletime = 10.0, operatortypes = [
+  operatortypes = [
     { name = "foo", latency = 0}
   ]} {
   return
@@ -24,30 +14,8 @@ func @missing_delay() attributes {
 // expected-error@+2 {{Negative delays}}
 // expected-error@+1 {{problem check failed}}
 func @negative_delay() attributes {
-  cycletime = 10.0, operatortypes = [
+  operatortypes = [
     { name = "foo", latency = 0, incdelay = -1.0, outdelay = -1.0}
-  ]} {
-  return
-}
-
-// -----
-
-// expected-error@+2 {{Incoming delay (2.000000e+00) for operator type 'foo' exceeds cycle time}}
-// expected-error@+1 {{problem check failed}}
-func @incdelay_exceeds() attributes {
-  cycletime = 1.0, operatortypes = [
-    { name = "foo", latency = 1, incdelay = 2.0, outdelay = 1.0}
-  ]} {
-  return
-}
-
-// -----
-
-// expected-error@+2 {{Outgoing delay (2.000000e+00) for operator type 'foo' exceeds cycle time}}
-// expected-error@+1 {{problem check failed}}
-func @outdelay_exceeds() attributes {
-  cycletime = 1.0, operatortypes = [
-    { name = "foo", latency = 1, incdelay = 1.0, outdelay = 2.0}
   ]} {
   return
 }
@@ -66,20 +34,9 @@ func @inc_out_mismatch() attributes {
 // -----
 
 // expected-error@+1 {{problem verification failed}}
-func @no_pst() attributes { cycletime = 10.0} {
-  // expected-error@+1 {{Operation has no start time in cycle}}
+func @no_stic() {
+  // expected-error@+1 {{Operation has no non-negative start time in cycle}}
   return { problemStartTime = 0 }
-}
-
-// -----
-
-// expected-error@+1 {{problem verification failed}}
-func @cycle_time_exceeded() attributes {
-  cycletime = 10.0, operatortypes = [
-    { name = "foo", latency = 0, incdelay = 1.0, outdelay = 1.0}
-  ] } {
-  // expected-error@+1 {{Operation violates cycle time constraint}}
-  return { opr = "foo", problemStartTime = 0, problemStartTimeInCycle = 9.5 }
 }
 
 // -----
@@ -87,12 +44,12 @@ func @cycle_time_exceeded() attributes {
 // expected-error@+2 {{Precedence violated in cycle 0}}
 // expected-error@+1 {{problem verification failed}}
 func @precedence1(%arg0 : i32, %arg1 : i32) attributes {
-  cycletime = 10.0, operatortypes = [
-     { name = "add", latency = 0, incdelay = 1.0, outdelay = 1.0}
-    ] } {
-    %0 = arith.addi %arg0, %arg1 { opr = "add", problemStartTime = 0, problemStartTimeInCycle = 1.1 } : i32
-    %1 = arith.addi %0, %arg1 { opr = "add", problemStartTime = 0, problemStartTimeInCycle = 2.0 } : i32
-    return { problemStartTime = 0, problemStartTimeInCycle = 0.0 }
+  operatortypes = [
+    { name = "add", latency = 0, incdelay = 1.0, outdelay = 1.0}
+  ] } {
+  %0 = arith.addi %arg0, %arg1 { opr = "add", problemStartTime = 0, problemStartTimeInCycle = 1.1 } : i32
+  %1 = arith.addi %0, %arg1 { opr = "add", problemStartTime = 0, problemStartTimeInCycle = 2.0 } : i32
+  return { problemStartTime = 0, problemStartTimeInCycle = 0.0 }
 }
 
 // -----
@@ -100,11 +57,11 @@ func @precedence1(%arg0 : i32, %arg1 : i32) attributes {
 // expected-error@+2 {{Precedence violated in cycle 3}}
 // expected-error@+1 {{problem verification failed}}
 func @precedence2(%arg0 : i32, %arg1 : i32) attributes {
-  cycletime = 10.0, operatortypes = [
-     { name = "add", latency = 0, incdelay = 1.0, outdelay = 1.0},
-     { name = "mul", latency = 3, incdelay = 2.5, outdelay = 3.75}
-    ] } {
-    %0 = arith.muli %arg0, %arg1 { opr = "mul", problemStartTime = 0, problemStartTimeInCycle = 0.0 } : i32
-    %1 = arith.addi %0, %arg1 { opr = "add", problemStartTime = 3, problemStartTimeInCycle = 3.0 } : i32
-    return { problemStartTime = 4, problemStartTimeInCycle = 0.0 }
+  operatortypes = [
+   { name = "add", latency = 0, incdelay = 1.0, outdelay = 1.0},
+   { name = "mul", latency = 3, incdelay = 2.5, outdelay = 3.75}
+  ] } {
+  %0 = arith.muli %arg0, %arg1 { opr = "mul", problemStartTime = 0, problemStartTimeInCycle = 0.0 } : i32
+  %1 = arith.addi %0, %arg1 { opr = "add", problemStartTime = 3, problemStartTimeInCycle = 3.0 } : i32
+  return { problemStartTime = 4, problemStartTimeInCycle = 0.0 }
 }

--- a/test/Scheduling/chaining-problem-errors.mlir
+++ b/test/Scheduling/chaining-problem-errors.mlir
@@ -10,7 +10,7 @@ func @invalid_cycletime() attributes {
 
 // -----
 
-// expected-error@+2 {{Missing physical delays}}
+// expected-error@+2 {{Missing delays}}
 // expected-error@+1 {{problem check failed}}
 func @missing_delay() attributes {
   cycletime = 10.0, operatortypes = [
@@ -21,7 +21,7 @@ func @missing_delay() attributes {
 
 // -----
 
-// expected-error@+2 {{Negative physical delays}}
+// expected-error@+2 {{Negative delays}}
 // expected-error@+1 {{problem check failed}}
 func @negative_delay() attributes {
   cycletime = 10.0, operatortypes = [
@@ -67,7 +67,7 @@ func @inc_out_mismatch() attributes {
 
 // expected-error@+1 {{problem verification failed}}
 func @no_pst() attributes { cycletime = 10.0} {
-  // expected-error@+1 {{Operation has no physical start time}}
+  // expected-error@+1 {{Operation has no start time in cycle}}
   return { problemStartTime = 0 }
 }
 
@@ -79,32 +79,32 @@ func @cycle_time_exceeded() attributes {
     { name = "foo", latency = 0, incdelay = 1.0, outdelay = 1.0}
   ] } {
   // expected-error@+1 {{Operation violates cycle time constraint}}
-  return { opr = "foo", problemStartTime = 0, problemPhysicalStartTime = 9.5 }
+  return { opr = "foo", problemStartTime = 0, problemStartTimeInCycle = 9.5 }
 }
 
 // -----
 
-// expected-error@+2 {{Physical delays violated in time step 0}}
+// expected-error@+2 {{Precedence violated in cycle 0}}
 // expected-error@+1 {{problem verification failed}}
 func @precedence1(%arg0 : i32, %arg1 : i32) attributes {
   cycletime = 10.0, operatortypes = [
      { name = "add", latency = 0, incdelay = 1.0, outdelay = 1.0}
     ] } {
-    %0 = arith.addi %arg0, %arg1 { opr = "add", problemStartTime = 0, problemPhysicalStartTime = 1.1 } : i32
-    %1 = arith.addi %0, %arg1 { opr = "add", problemStartTime = 0, problemPhysicalStartTime = 2.0 } : i32
-    return { problemStartTime = 0, problemPhysicalStartTime = 0.0 }
+    %0 = arith.addi %arg0, %arg1 { opr = "add", problemStartTime = 0, problemStartTimeInCycle = 1.1 } : i32
+    %1 = arith.addi %0, %arg1 { opr = "add", problemStartTime = 0, problemStartTimeInCycle = 2.0 } : i32
+    return { problemStartTime = 0, problemStartTimeInCycle = 0.0 }
 }
 
 // -----
 
-// expected-error@+2 {{Physical delays violated in time step 3}}
+// expected-error@+2 {{Precedence violated in cycle 3}}
 // expected-error@+1 {{problem verification failed}}
 func @precedence2(%arg0 : i32, %arg1 : i32) attributes {
   cycletime = 10.0, operatortypes = [
      { name = "add", latency = 0, incdelay = 1.0, outdelay = 1.0},
      { name = "mul", latency = 3, incdelay = 2.5, outdelay = 3.75}
     ] } {
-    %0 = arith.muli %arg0, %arg1 { opr = "mul", problemStartTime = 0, problemPhysicalStartTime = 0.0 } : i32
-    %1 = arith.addi %0, %arg1 { opr = "add", problemStartTime = 3, problemPhysicalStartTime = 3.0 } : i32
-    return { problemStartTime = 4, problemPhysicalStartTime = 0.0 }
+    %0 = arith.muli %arg0, %arg1 { opr = "mul", problemStartTime = 0, problemStartTimeInCycle = 0.0 } : i32
+    %1 = arith.addi %0, %arg1 { opr = "add", problemStartTime = 3, problemStartTimeInCycle = 3.0 } : i32
+    return { problemStartTime = 4, problemStartTimeInCycle = 0.0 }
 }

--- a/test/Scheduling/chaining-problem-errors.mlir
+++ b/test/Scheduling/chaining-problem-errors.mlir
@@ -1,0 +1,110 @@
+// RUN: circt-opt %s -test-chaining-problem -verify-diagnostics -split-input-file
+
+// expected-error@+2 {{Invalid cycle time}}
+// expected-error@+1 {{problem check failed}}
+func @invalid_cycletime() attributes {
+  cycletime = -3.14
+  } {
+  return
+}
+
+// -----
+
+// expected-error@+2 {{Missing physical delays}}
+// expected-error@+1 {{problem check failed}}
+func @missing_delay() attributes {
+  cycletime = 10.0, operatortypes = [
+    { name = "foo", latency = 0}
+  ]} {
+  return
+}
+
+// -----
+
+// expected-error@+2 {{Negative physical delays}}
+// expected-error@+1 {{problem check failed}}
+func @negative_delay() attributes {
+  cycletime = 10.0, operatortypes = [
+    { name = "foo", latency = 0, incdelay = -1.0, outdelay = -1.0}
+  ]} {
+  return
+}
+
+// -----
+
+// expected-error@+2 {{Incoming delay (2.000000e+00) for operator type 'foo' exceeds cycle time}}
+// expected-error@+1 {{problem check failed}}
+func @incdelay_exceeds() attributes {
+  cycletime = 1.0, operatortypes = [
+    { name = "foo", latency = 1, incdelay = 2.0, outdelay = 1.0}
+  ]} {
+  return
+}
+
+// -----
+
+// expected-error@+2 {{Outgoing delay (2.000000e+00) for operator type 'foo' exceeds cycle time}}
+// expected-error@+1 {{problem check failed}}
+func @outdelay_exceeds() attributes {
+  cycletime = 1.0, operatortypes = [
+    { name = "foo", latency = 1, incdelay = 1.0, outdelay = 2.0}
+  ]} {
+  return
+}
+
+// -----
+
+// expected-error@+2 {{Incoming & outgoing delay must be equal for zero-latency operator type}}
+// expected-error@+1 {{problem check failed}}
+func @inc_out_mismatch() attributes {
+  cycletime = 10.0, operatortypes = [
+    { name = "foo", latency = 0, incdelay = 1.0, outdelay = 2.0}
+  ]} {
+  return
+}
+
+// -----
+
+// expected-error@+1 {{problem verification failed}}
+func @no_pst() attributes { cycletime = 10.0} {
+  // expected-error@+1 {{Operation has no physical start time}}
+  return { problemStartTime = 0 }
+}
+
+// -----
+
+// expected-error@+1 {{problem verification failed}}
+func @cycle_time_exceeded() attributes {
+  cycletime = 10.0, operatortypes = [
+    { name = "foo", latency = 0, incdelay = 1.0, outdelay = 1.0}
+  ] } {
+  // expected-error@+1 {{Operation violates cycle time constraint}}
+  return { opr = "foo", problemStartTime = 0, problemPhysicalStartTime = 9.5 }
+}
+
+// -----
+
+// expected-error@+2 {{Physical delays violated in time step 0}}
+// expected-error@+1 {{problem verification failed}}
+func @precedence1(%arg0 : i32, %arg1 : i32) attributes {
+  cycletime = 10.0, operatortypes = [
+     { name = "add", latency = 0, incdelay = 1.0, outdelay = 1.0}
+    ] } {
+    %0 = arith.addi %arg0, %arg1 { opr = "add", problemStartTime = 0, problemPhysicalStartTime = 1.1 } : i32
+    %1 = arith.addi %0, %arg1 { opr = "add", problemStartTime = 0, problemPhysicalStartTime = 2.0 } : i32
+    return { problemStartTime = 0, problemPhysicalStartTime = 0.0 }
+}
+
+// -----
+
+// expected-error@+2 {{Physical delays violated in time step 3}}
+// expected-error@+1 {{problem verification failed}}
+func @precedence2(%arg0 : i32, %arg1 : i32) attributes {
+  cycletime = 10.0, operatortypes = [
+     { name = "add", latency = 0, incdelay = 1.0, outdelay = 1.0},
+     { name = "mul", latency = 3, incdelay = 2.5, outdelay = 3.75}
+    ] } {
+    %0 = arith.muli %arg0, %arg1 { opr = "mul", problemStartTime = 0, problemPhysicalStartTime = 0.0 } : i32
+    %1 = arith.addi %0, %arg1 { opr = "add", problemStartTime = 3, problemPhysicalStartTime = 3.0 } : i32
+    return { problemStartTime = 4, problemPhysicalStartTime = 0.0 }
+}

--- a/test/Scheduling/chaining-problems.mlir
+++ b/test/Scheduling/chaining-problems.mlir
@@ -4,12 +4,12 @@ func @adder_chain(%arg0 : i32, %arg1 : i32) -> i32 attributes {
   cycletime = 10.0, operatortypes = [
    { name = "add", latency = 0, incdelay = 2.34, outdelay = 2.34}
   ] } {
-  %0 = arith.addi %arg0, %arg1 { opr = "add", problemStartTime = 0, problemPhysicalStartTime = 0.0 } : i32
-  %1 = arith.addi %0, %arg1 { opr = "add", problemStartTime = 0, problemPhysicalStartTime = 2.34 } : i32
-  %2 = arith.addi %1, %arg1 { opr = "add", problemStartTime = 0, problemPhysicalStartTime = 4.68 } : i32
-  %3 = arith.addi %2, %arg1 { opr = "add", problemStartTime = 1, problemPhysicalStartTime = 0.0 } : i32
-  %4 = arith.addi %3, %arg1 { opr = "add", problemStartTime = 1, problemPhysicalStartTime = 2.34 } : i32
-  return { problemStartTime = 2, problemPhysicalStartTime = 0.0 } %4 : i32
+  %0 = arith.addi %arg0, %arg1 { opr = "add", problemStartTime = 0, problemStartTimeInCycle = 0.0 } : i32
+  %1 = arith.addi %0, %arg1 { opr = "add", problemStartTime = 0, problemStartTimeInCycle = 2.34 } : i32
+  %2 = arith.addi %1, %arg1 { opr = "add", problemStartTime = 0, problemStartTimeInCycle = 4.68 } : i32
+  %3 = arith.addi %2, %arg1 { opr = "add", problemStartTime = 1, problemStartTimeInCycle = 0.0 } : i32
+  %4 = arith.addi %3, %arg1 { opr = "add", problemStartTime = 1, problemStartTimeInCycle = 2.34 } : i32
+  return { problemStartTime = 2, problemStartTimeInCycle = 0.0 } %4 : i32
 }
 
 func @multi_cycle(%arg0 : i32, %arg1 : i32) -> i32 attributes {
@@ -17,10 +17,10 @@ func @multi_cycle(%arg0 : i32, %arg1 : i32) -> i32 attributes {
    { name = "add", latency = 0, incdelay = 2.34, outdelay = 2.34},
    { name = "mul", latency = 3, incdelay = 2.5, outdelay = 3.75}
   ] } {
-  %0 = arith.addi %arg0, %arg1 { opr = "add", problemStartTime = 0, problemPhysicalStartTime = 0.0 } : i32
-  %1 = arith.addi %0, %arg1 { opr = "add", problemStartTime = 0, problemPhysicalStartTime = 2.34 } : i32
-  %2 = arith.muli %1, %0 { opr = "mul", problemStartTime = 0, problemPhysicalStartTime = 4.68 } : i32
-  %3 = arith.addi %2, %1 { opr = "add", problemStartTime = 3, problemPhysicalStartTime = 3.75 } : i32
-  %4 = arith.addi %3, %2 { opr = "add", problemStartTime = 3, problemPhysicalStartTime = 6.09 } : i32
-  return { problemStartTime = 4, problemPhysicalStartTime = 0.0 } %4 : i32
+  %0 = arith.addi %arg0, %arg1 { opr = "add", problemStartTime = 0, problemStartTimeInCycle = 0.0 } : i32
+  %1 = arith.addi %0, %arg1 { opr = "add", problemStartTime = 0, problemStartTimeInCycle = 2.34 } : i32
+  %2 = arith.muli %1, %0 { opr = "mul", problemStartTime = 0, problemStartTimeInCycle = 4.68 } : i32
+  %3 = arith.addi %2, %1 { opr = "add", problemStartTime = 3, problemStartTimeInCycle = 3.75 } : i32
+  %4 = arith.addi %3, %2 { opr = "add", problemStartTime = 3, problemStartTimeInCycle = 6.09 } : i32
+  return { problemStartTime = 4, problemStartTimeInCycle = 0.0 } %4 : i32
 }

--- a/test/Scheduling/chaining-problems.mlir
+++ b/test/Scheduling/chaining-problems.mlir
@@ -1,0 +1,26 @@
+// RUN: circt-opt %s -test-chaining-problem -allow-unregistered-dialect
+
+func @adder_chain(%arg0 : i32, %arg1 : i32) -> i32 attributes {
+  cycletime = 10.0, operatortypes = [
+   { name = "add", latency = 0, incdelay = 2.34, outdelay = 2.34}
+  ] } {
+  %0 = arith.addi %arg0, %arg1 { opr = "add", problemStartTime = 0, problemPhysicalStartTime = 0.0 } : i32
+  %1 = arith.addi %0, %arg1 { opr = "add", problemStartTime = 0, problemPhysicalStartTime = 2.34 } : i32
+  %2 = arith.addi %1, %arg1 { opr = "add", problemStartTime = 0, problemPhysicalStartTime = 4.68 } : i32
+  %3 = arith.addi %2, %arg1 { opr = "add", problemStartTime = 1, problemPhysicalStartTime = 0.0 } : i32
+  %4 = arith.addi %3, %arg1 { opr = "add", problemStartTime = 1, problemPhysicalStartTime = 2.34 } : i32
+  return { problemStartTime = 2, problemPhysicalStartTime = 0.0 } %4 : i32
+}
+
+func @multi_cycle(%arg0 : i32, %arg1 : i32) -> i32 attributes {
+  cycletime = 10.0, operatortypes = [
+   { name = "add", latency = 0, incdelay = 2.34, outdelay = 2.34},
+   { name = "mul", latency = 3, incdelay = 2.5, outdelay = 3.75}
+  ] } {
+  %0 = arith.addi %arg0, %arg1 { opr = "add", problemStartTime = 0, problemPhysicalStartTime = 0.0 } : i32
+  %1 = arith.addi %0, %arg1 { opr = "add", problemStartTime = 0, problemPhysicalStartTime = 2.34 } : i32
+  %2 = arith.muli %1, %0 { opr = "mul", problemStartTime = 0, problemPhysicalStartTime = 4.68 } : i32
+  %3 = arith.addi %2, %1 { opr = "add", problemStartTime = 3, problemPhysicalStartTime = 3.75 } : i32
+  %4 = arith.addi %3, %2 { opr = "add", problemStartTime = 3, problemPhysicalStartTime = 6.09 } : i32
+  return { problemStartTime = 4, problemPhysicalStartTime = 0.0 } %4 : i32
+}

--- a/test/Scheduling/chaining-problems.mlir
+++ b/test/Scheduling/chaining-problems.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt %s -test-chaining-problem -allow-unregistered-dialect
 
 func @adder_chain(%arg0 : i32, %arg1 : i32) -> i32 attributes {
-  cycletime = 10.0, operatortypes = [
+  operatortypes = [
    { name = "add", latency = 0, incdelay = 2.34, outdelay = 2.34}
   ] } {
   %0 = arith.addi %arg0, %arg1 { opr = "add", problemStartTime = 0, problemStartTimeInCycle = 0.0 } : i32
@@ -13,7 +13,7 @@ func @adder_chain(%arg0 : i32, %arg1 : i32) -> i32 attributes {
 }
 
 func @multi_cycle(%arg0 : i32, %arg1 : i32) -> i32 attributes {
-  cycletime = 10.0, operatortypes = [
+  operatortypes = [
    { name = "add", latency = 0, incdelay = 2.34, outdelay = 2.34},
    { name = "mul", latency = 3, incdelay = 2.5, outdelay = 3.75}
   ] } {


### PR DESCRIPTION
This PR defines a `ChainingProblem`, which models the accumulation of physical propagation delays on combinational paths along SSA dependences within a scheduling problem's abstract time steps/cycles.

For example, the modeling for the `@multi_cycle` test case from `chaining-problems.mlir` would look like this:

![chaining](https://user-images.githubusercontent.com/302546/143212283-d0755189-fa57-45b1-8e50-d5879bdcb1c6.png)
