### PR TITLE
[ExportVerilog] Prepare modules before name legalization; NFC

### DIFF
--- a/test/Conversion/ExportVerilog/verilog-basic.mlir
+++ b/test/Conversion/ExportVerilog/verilog-basic.mlir
@@ -495,6 +495,6 @@ hw.module @BindInterface() -> () {
 
 sv.bind #hw.innerNameRef<@SiFive_MulDiv::@__ETC_SiFive_MulDiv_assert>
 // CHECK-LABEL: bind SiFive_MulDiv bind_rename_port InvisibleBind_assert
-// CHECK-NEXT:  ._io_req_ready_output (InvisibleBind_assert_.io_req_ready.output)
+// CHECK-NEXT:  ._io_req_ready_output (InvisibleBind_assert__io_req_ready_output)
 // CHECK-NEXT:  .reset                (reset),
 // CHECK-NEXT:  .clock                (clock)


### PR DESCRIPTION
At the moment, the call to `legalizeGlobalNames` which populates the `GlobalNameTable` occurs *before* individual modules are prepared for emission. This is problematic because this preparation may spawn additional wires that require legalized names.

The call to `prepareHWModule` currently happens inside the parallel execution of `emitHWModule`, right at the start. This change moves the call to this function out of `emitHWModule` and into a parallel section before name legalization. Module preparation would already happen in parallel and before the module was emitted, but it occurring as part of `emitHWModule` would mean it happened intertwined with all the other emission code. Moving the call outside has the same effect, but gives a clean point in the code at which all modules are known to have been prepared, after which name legalization can be performed.

This unblocks future work in fixing the emission of `bind` statements, which rely on some of the wires introduced by `prepareHWModule` and require names for them.

This is intended to be a non-functional change except for a fix to a test affected by the currently broken bind emission above.