### PR TITLE
[LLHD] Remove TerminatorOp; NFC

### DIFF
--- a/include/circt/Dialect/LLHD/IR/StructureOps.td
+++ b/include/circt/Dialect/LLHD/IR/StructureOps.td
@@ -14,7 +14,8 @@ def LLHD_EntityOp : LLHD_Op<"entity", [
     Symbol,
     FunctionLike,
     IsolatedFromAbove,
-    SingleBlockImplicitTerminator<"TerminatorOp">,
+    SingleBlock,
+    NoTerminator,
     DeclareOpInterfaceMethods<CallableOpInterface>
   ]> {
   let summary = "Create an entity.";
@@ -224,22 +225,6 @@ def LLHD_ConnectOp : LLHD_Op<"con", [
 //===----------------------------------------------------------------------===//
 //=== Control Flow Operations
 //===----------------------------------------------------------------------===//
-
-def LLHD_TerminatorOp : LLHD_Op<"terminator", [
-    Terminator,
-    HasParent<"EntityOp">
-  ]> {
-  let summary = "Dummy terminator";
-  let description = [{
-    The `"llhd.terminator"` op is a dummy terminator for an `EntityOp` unit.
-    It provides no further meaning other than ensuring correct termination
-    of an entitiy's region. This operation provides no custom syntax and
-    should never explicitly appear in LLHD's custom syntax.
-  }];
-
-  let parser = ?;
-  let printer = ?;
-}
 
 def LLHD_WaitOp : LLHD_Op<"wait", [
     Terminator,

--- a/lib/Conversion/HWToLLHD/HWToLLHD.cpp
+++ b/lib/Conversion/HWToLLHD/HWToLLHD.cpp
@@ -197,8 +197,7 @@ struct ConvertOutput : public OpConversionPattern<OutputOp> {
       rewriter.create<DrvOp>(output.getLoc(), dest, src, delta, Value());
     }
 
-    // Replace the output with an LLHD terminator.
-    rewriter.create<llhd::TerminatorOp>(entity.getLoc());
+    // Remove the output op.
     rewriter.eraseOp(output);
 
     return success();

--- a/lib/Dialect/LLHD/Export/TranslateToVerilog.cpp
+++ b/lib/Dialect/LLHD/Export/TranslateToVerilog.cpp
@@ -79,9 +79,7 @@ LogicalResult VerilogPrinter::printModule(ModuleOp module) {
     out << ";\n";
 
     // Print the operations within the entity
-    for (auto iter = entryBlock.begin();
-         iter != entryBlock.end() && !dyn_cast<llhd::TerminatorOp>(iter);
-         ++iter) {
+    for (auto iter = entryBlock.begin(); iter != entryBlock.end(); ++iter) {
       if (failed(printOperation(&(*iter), 4))) {
         return emitError(iter->getLoc(), "Operation not supported!");
       }

--- a/lib/Dialect/LLHD/Simulator/Engine.cpp
+++ b/lib/Dialect/LLHD/Simulator/Engine.cpp
@@ -38,7 +38,7 @@ Engine::Engine(
 
   // Insert explicit instantiation of the design root.
   OpBuilder insertInst =
-      OpBuilder::atBlockTerminator(&rootEntity.getBody().getBlocks().front());
+      OpBuilder::atBlockEnd(&rootEntity.getBody().getBlocks().front());
   insertInst.create<InstOp>(rootEntity.getBlocks().front().back().getLoc(),
                             llvm::None, root, root, ArrayRef<Value>(),
                             ArrayRef<Value>());

--- a/lib/Dialect/LLHD/Transforms/ProcessLoweringPass.cpp
+++ b/lib/Dialect/LLHD/Transforms/ProcessLoweringPass.cpp
@@ -116,10 +116,8 @@ void ProcessLoweringPass::runOnOperation() {
     op.getOperation()->dropAllDefinedValueUses();
     op.getOperation()->erase();
 
-    // Replace the llhd.halt or llhd.wait with the implicit entity terminator
-    builder.setInsertionPointToEnd(&entity.body().front());
+    // Remove the remaining llhd.halt or llhd.wait terminator
     Operation *terminator = entity.body().front().getTerminator();
-    builder.create<llhd::TerminatorOp>(terminator->getLoc());
     terminator->dropAllReferences();
     terminator->dropAllUses();
     terminator->erase();

--- a/test/Dialect/LLHD/IR/entity.mlir
+++ b/test/Dialect/LLHD/IR/entity.mlir
@@ -8,7 +8,6 @@
   %0 = hw.constant 1 : i64
   // CHECK-NEXT: %[[P0:.*]] = llhd.prb %[[ARG0]]
   %1 = llhd.prb %arg0 : !llhd.sig<i64>
-  "llhd.terminator"() {} : () -> ()
 // CHECK-NEXT: }
 }) {sym_name="foo", ins=2, type=(!llhd.sig<i64>, !llhd.sig<i64>, !llhd.sig<i64>)->()} : () -> ()
 
@@ -16,7 +15,6 @@
 // CHECK-NEXT: llhd.entity @bar () -> (%{{.*}} : !llhd.sig<i64>) {
 "llhd.entity"() ({
 ^body(%0 : !llhd.sig<i64>):
-  "llhd.terminator"() {} : () -> ()
 // CHECK-NEXT: }
 }) {sym_name="bar", ins=0, type=(!llhd.sig<i64>)->()} : () -> ()
 
@@ -24,7 +22,6 @@
 // CHECK-NEXT: llhd.entity @baz (%{{.*}} : !llhd.sig<i64>) -> () {
 "llhd.entity"() ({
 ^body(%arg0 : !llhd.sig<i64>):
-  "llhd.terminator"() {} : () -> ()
 // CHECK-NEXT: }
 }) {sym_name="baz", ins=1, type=(!llhd.sig<i64>)->()} : () -> ()
 
@@ -32,6 +29,5 @@
 // CHECK-NEXT: llhd.entity @out_of_names () -> () {
 "llhd.entity"() ({
 ^body:
-  "llhd.terminator"() {} : () -> ()
 // CHECK-NEXT : }
 }) {sym_name="out_of_names", ins=0, type=()->()} : () -> ()


### PR DESCRIPTION
Since MLIR has gained the `NoTerminator` op trait in the meantime, remove the LLHD `TerminatorOp` that was originally introduced to get around a lack of this trait. This requires adjusting the code in a few places where the terminator is handled explicitly.