### PR TITLE
[ExportVerilog] Fix bind emission, split into parallel/sequential phase

### DIFF
--- a/test/Conversion/ExportVerilog/verilog-split.mlir
+++ b/test/Conversion/ExportVerilog/verilog-split.mlir
@@ -1,0 +1,9 @@
+// RUN: circt-opt --export-split-verilog --verify-diagnostics %s
+
+// The following used to trigger emission of `sv.bind` within a parallel block,
+// triggering an assertion.
+hw.module @Foo() {}
+hw.module @Top() {
+  hw.instance "BindEmissionInstance" sym @instA @Foo() -> () {doNotPrint = true}
+}
+sv.bind #hw.innerNameRef<@Top::@instA> {output_file = #hw.output_file<"foo.sv", excludeFromFileList>}


### PR DESCRIPTION
Emission of `sv.bind` requires to occur in a sequential piece of code. This is currently handled well in `emitOps` if parallelize is `true`, which is the case for single-file Verilog emission. But in split Verilog emission, `emitOps` itself is called in a parallel block, which breaks an implicit assumption in the code.

This change extends the split into parallel and sequential phases of emission, and makes them explicit at the unified/split Verilog emitter level by separating the `emitOps` function into an `emitOpsParallel` and a `emitOpsSequential`. These correspond to the first and second half of the original `emitOps`:

- `emitOpsParallel` performs opportunistic emission of operations. It tries to emit operations in parallel, if possible directly to the   output stream, or into a string buffer otherwise. It may leave operations unemitted.
- `emitOpsSequential` performs the final emission of operations. This includes emitting any string buffers produced by the parallel portion, and actually emitting any ops that were left over.

The split Verilog emitter now keeps a list of `SplitOutputFile`s in a vector, which is used to carry the necessary information from the parallel to the sequential emission phase. The emitter then performs emission in two phases: first calling the `emitParallel` function in a parallel block, and then calling the `emitSequential` function in a sequential block.

This fixes an assertion that triggers when trying to emit any design containing bind statements through the split Verilog emitter.