### PR TITLE
Revert "[HW][SV][ExportVerilog] Add Comment to HWModuleOp, Verilog Emission"

### DIFF
--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -29,8 +29,7 @@ def HWModuleOp : HWOp<"module",
     connections within the module.
   }];
   let arguments = (ins StrArrayAttr:$argNames, StrArrayAttr:$resultNames,
-                       ParamDeclArrayAttr:$parameters,
-                       StrAttr:$comment);
+                       ParamDeclArrayAttr:$parameters);
   let results = (outs);
   let regions = (region SizedRegion<1>:$body);
 
@@ -38,12 +37,10 @@ def HWModuleOp : HWOp<"module",
   let builders = [
     OpBuilder<(ins "StringAttr":$name, "ArrayRef<PortInfo>":$ports,
                    CArg<"ArrayAttr", "{}">:$parameters,
-                   CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes,
-                   CArg<"StringAttr", "{}">:$comment)>,
+                   CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes)>,
     OpBuilder<(ins "StringAttr":$name, "const ModulePortInfo &":$ports,
                    CArg<"ArrayAttr", "{}">:$parameters,
-                   CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes,
-                   CArg<"StringAttr", "{}">:$comment)>
+                   CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes)>
   ];
 
   let extraClassDeclaration = [{

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -573,12 +573,6 @@ public:
                                  std::function<void(Value)> operandEmitter,
                                  ArrayAttr symAttrs, ModuleNameManager &names);
 
-  /// Emit the value of a StringAttr as one or more Verilog "one-line" comments
-  /// ("//").  Break the comment to respect the emittedLineLength and trim
-  /// whitespace after a line break.  Do nothing if the StringAttr is null or
-  /// the value is empty.
-  void emitComment(StringAttr comment);
-
 private:
   void operator=(const EmitterBase &) = delete;
   EmitterBase(const EmitterBase &) = delete;
@@ -687,65 +681,6 @@ void EmitterBase::emitTextWithSubstitutions(
 
   // Emit any text after the last substitution.
   os << string;
-}
-
-void EmitterBase::emitComment(StringAttr comment) {
-  if (!comment)
-    return;
-
-  // Set a line length for the comment.  Subtract off the leading comment and
-  // space ("// ") as well as the current indent level to simplify later
-  // arithmetic.  Ensure that this line length doesn't go below zero.
-  auto lineLength = state.options.emittedLineLength - state.currentIndent - 3;
-  if (lineLength > state.options.emittedLineLength)
-    lineLength = 0;
-
-  // Process the comment in line chunks extracted from manually specified line
-  // breaks.  This is done to preserve user-specified line breaking if used.
-  auto ref = comment.getValue();
-  StringRef line;
-  while (!ref.empty()) {
-    std::tie(line, ref) = ref.split("\n");
-    // Emit each comment line breaking it if it exceeds the emittedLineLength.
-    for (;;) {
-      indent();
-      os << "// ";
-
-      // Base case 1: the entire comment fits on one line.
-      if (line.size() <= lineLength) {
-        os << line << "\n";
-        break;
-      }
-
-      // The comment does NOT fit on one line.  Use a simple algorithm to find
-      // a position to break the line:
-      //   1) Search backwards for whitespace and break there if you find it.
-      //   2) If no whitespace exists in (1), search forward for whitespace
-      //      and break there.
-      // This algorithm violates the emittedLineLength if (2) ever occurrs,
-      // but it's dead simple.
-      auto breakPos = line.rfind(' ', lineLength);
-      // No whitespace exists looking backwards.
-      if (breakPos == StringRef::npos) {
-        breakPos = line.find(' ', lineLength);
-        // No whitespace exists looking forward (you hit the end of the
-        // string).
-        if (breakPos == StringRef::npos)
-          breakPos = line.size();
-      }
-
-      // Emit up to the break position.  Trim any whitespace after the break
-      // position.  Exit if nothing is left to emit.  Otherwise, update the
-      // comment ref and continue;
-      os << line.take_front(breakPos) << "\n";
-      breakPos = line.find_first_not_of(' ', breakPos);
-      // Base Case 2: nothing left except whitespace.
-      if (breakPos == StringRef::npos)
-        break;
-
-      line = line.drop_front(breakPos);
-    }
-  }
 }
 
 //===----------------------------------------------------------------------===//
@@ -3717,8 +3652,6 @@ void ModuleEmitter::emitHWModule(HWModuleOp module) {
 
   SmallPtrSet<Operation *, 8> moduleOpSet;
   moduleOpSet.insert(module);
-
-  emitComment(module.commentAttr());
 
   os << "module " << getVerilogModuleName(module);
 

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -301,8 +301,7 @@ enum ExternModKind { PlainMod, ExternMod, GenMod };
 static void buildModule(OpBuilder &builder, OperationState &result,
                         StringAttr name, const ModulePortInfo &ports,
                         ArrayAttr parameters,
-                        ArrayRef<NamedAttribute> attributes,
-                        StringAttr comment) {
+                        ArrayRef<NamedAttribute> attributes) {
   using namespace mlir::function_like_impl;
 
   // Add an attribute for the name.
@@ -353,9 +352,6 @@ static void buildModule(OpBuilder &builder, OperationState &result,
   result.addAttribute(mlir::function_like_impl::getResultDictAttrName(),
                       builder.getArrayAttr(resultAttrs));
   result.addAttribute("parameters", parameters);
-  if (!comment)
-    comment = builder.getStringAttr("");
-  result.addAttribute("comment", comment);
   result.addAttributes(attributes);
   result.addRegion();
 }
@@ -363,9 +359,8 @@ static void buildModule(OpBuilder &builder, OperationState &result,
 void HWModuleOp::build(OpBuilder &builder, OperationState &result,
                        StringAttr name, const ModulePortInfo &ports,
                        ArrayAttr parameters,
-                       ArrayRef<NamedAttribute> attributes,
-                       StringAttr comment) {
-  buildModule(builder, result, name, ports, parameters, attributes, comment);
+                       ArrayRef<NamedAttribute> attributes) {
+  buildModule(builder, result, name, ports, parameters, attributes);
 
   // Create a region and a block for the body.
   auto *bodyRegion = result.regions[0].get();
@@ -382,10 +377,8 @@ void HWModuleOp::build(OpBuilder &builder, OperationState &result,
 void HWModuleOp::build(OpBuilder &builder, OperationState &result,
                        StringAttr name, ArrayRef<PortInfo> ports,
                        ArrayAttr parameters,
-                       ArrayRef<NamedAttribute> attributes,
-                       StringAttr comment) {
-  build(builder, result, name, ModulePortInfo(ports), parameters, attributes,
-        comment);
+                       ArrayRef<NamedAttribute> attributes) {
+  build(builder, result, name, ModulePortInfo(ports), parameters, attributes);
 }
 
 /// Return the name to use for the Verilog module that we're referencing
@@ -410,7 +403,7 @@ void HWModuleExternOp::build(OpBuilder &builder, OperationState &result,
                              StringAttr name, const ModulePortInfo &ports,
                              StringRef verilogName, ArrayAttr parameters,
                              ArrayRef<NamedAttribute> attributes) {
-  buildModule(builder, result, name, ports, parameters, attributes, {});
+  buildModule(builder, result, name, ports, parameters, attributes);
 
   if (!verilogName.empty())
     result.addAttribute("verilogName", builder.getStringAttr(verilogName));
@@ -429,7 +422,7 @@ void HWModuleGeneratedOp::build(OpBuilder &builder, OperationState &result,
                                 const ModulePortInfo &ports,
                                 StringRef verilogName, ArrayAttr parameters,
                                 ArrayRef<NamedAttribute> attributes) {
-  buildModule(builder, result, name, ports, parameters, attributes, {});
+  buildModule(builder, result, name, ports, parameters, attributes);
   result.addAttribute("generatorKind", genKind);
   if (!verilogName.empty())
     result.addAttribute("verilogName", builder.getStringAttr(verilogName));
@@ -644,8 +637,6 @@ static ParseResult parseHWModuleOp(OpAsmParser &parser, OperationState &result,
     result.addAttribute("argNames", ArrayAttr::get(context, argNames));
   result.addAttribute("resultNames", ArrayAttr::get(context, resultNames));
   result.addAttribute("parameters", ArrayAttr::get(context, parameters));
-  if (!hasAttribute("comment", result.attributes))
-    result.addAttribute("comment", StringAttr::get(context, ""));
 
   assert(argAttrs.size() == argTypes.size());
   assert(resultAttrs.size() == resultTypes.size());
@@ -727,8 +718,6 @@ static void printModuleOp(OpAsmPrinter &p, Operation *op,
     omittedAttrs.push_back("argNames");
   omittedAttrs.push_back("resultNames");
   omittedAttrs.push_back("parameters");
-  if (op->getAttrOfType<StringAttr>("comment").getValue().empty())
-    omittedAttrs.push_back("comment");
 
   printFunctionAttributes(p, op, argTypes.size(), resultTypes.size(),
                           omittedAttrs);

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -921,9 +921,3 @@ hw.module @parameterizedTypes<param: i32 = 1, wire: i32 = 2>
   %paramWire = sv.wire : !hw.inout<!hw.int<#hw.param.decl.ref<"wire">>>
 
 }
-
-// CHECK-LABEL: // moduleWithComment has a comment
-// CHECK-NEXT:  // hello
-// CHECK-NEXT:  module moduleWithComment
-hw.module @moduleWithComment()
-  attributes {comment = "moduleWithComment has a comment\nhello"} {}

--- a/test/Conversion/ExportVerilog/line-length.mlir
+++ b/test/Conversion/ExportVerilog/line-length.mlir
@@ -45,21 +45,3 @@ hw.module @longvariadic(%a: i8) -> (b: i8) {
 // LIMIT_LONG-NEXT:   wire [7:0] _tmp_0 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
 // LIMIT_LONG-NEXT:                       a + a + a + a + a + a + a + a + a;
 // LIMIT_LONG-NEXT:   assign b = _tmp + _tmp_0;
-
-hw.module @moduleWithComment()
-  attributes {comment = "The quick brown fox jumps over the lazy dog.  The quick brown fox jumps over the lazy dog.\naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"} {}
-
-// SHORT-LABEL:   // The quick brown fox jumps over the
-// SHORT-NEXT:    // lazy dog.  The quick brown fox jumps
-// SHORT-NEXT:    // over the lazy dog.
-// SHORT-NEXT:    // aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-// SHORT-NEXT:    module moduleWithComment
-//
-// DEFAULT-LABEL: // The quick brown fox jumps over the lazy dog.  The quick brown fox jumps over the lazy
-// DEFAULT-NEXT:  // dog.
-// DEFAULT-NEXT:  // aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-// DEFAULT-NEXT:  module moduleWithComment
-//
-// LONG-LABEL:    // The quick brown fox jumps over the lazy dog.  The quick brown fox jumps over the lazy dog.
-// LONG-NEXT:     // aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-// LONG-NEXT:     module moduleWithComment

--- a/test/Dialect/HW/basic.mlir
+++ b/test/Dialect/HW/basic.mlir
@@ -148,7 +148,3 @@ hw.module @argRenames(%arg1: i32) attributes {argNames = [""]} {
 
 hw.module @fileListTest(%arg1: i32) attributes {output_filelist = #hw.output_filelist<"foo.f">} {
 }
-
-// CHECK-LABEL: hw.module @commentModule
-// CHECK-SAME: attributes {comment = "hello world"}
-hw.module @commentModule() attributes {comment = "hello world"} {}


### PR DESCRIPTION
Reverts llvm/circt#2066

This broke all the python unit tests.  They are probably trivial to fix, but I'd like the builders to get back to green.