### PR TITLE
[FIRRTL] Allow more zero-width folds

### DIFF
--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -622,7 +622,8 @@ firrtl.module @issue437(out %tmp19: !firrtl.uint<1>) {
 }
 
 // CHECK-LABEL: firrtl.module @issue446
-// CHECK-NEXT: firrtl.xor %inp_1, %inp_1
+// CHECK-NEXT: [[TMP:%.+]] = firrtl.constant 0 : !firrtl.uint<0>
+// CHECK-NEXT: firrtl.connect %tmp10, [[TMP]] : !firrtl.uint<1>, !firrtl.uint<0>
 firrtl.module @issue446(in %inp_1: !firrtl.sint<0>, out %tmp10: !firrtl.uint<1>) {
   %0 = firrtl.xor %inp_1, %inp_1 : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.uint<0>
   firrtl.connect %tmp10, %0 : !firrtl.uint<1>, !firrtl.uint<0>
@@ -637,7 +638,8 @@ firrtl.module @xorUnsized(in %inp_1: !firrtl.sint, out %tmp10: !firrtl.uint) {
 
 // https://github.com/llvm/circt/issues/516
 // CHECK-LABEL: @issue516
-// CHECK-NEXT: firrtl.div
+// CHECK-NEXT: [[TMP:%.+]] = firrtl.constant 0 : !firrtl.uint<0>
+// CHECK-NEXT: firrtl.connect %tmp3, [[TMP]] : !firrtl.uint<0>, !firrtl.uint<0>
 firrtl.module @issue516(in %inp_0: !firrtl.uint<0>, out %tmp3: !firrtl.uint<0>) {
   %0 = firrtl.div %inp_0, %inp_0 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
   firrtl.connect %tmp3, %0 : !firrtl.uint<0>, !firrtl.uint<0>


### PR DESCRIPTION
Now that upstream `APInt` and friends properly support values of zero bits, some of the guards against zero width types in `FIRRTLFolds` have become obsolete. Remove these to generally operate on anything that has a known width, zero and up. Some operations need to work with values that are one bit narrower than the input, for example to compute things like `inputWidth - 1` in signed right shifts. Make these fold to a constant zero early on, or skip canonicalization altogether.

This follows up on a suggestion by @lattner in #2207.