### PR TITLE
[FIRRTL/IMConstantProp] Add new state "ValidValue"

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -735,7 +735,7 @@ void IMConstPropPass::rewriteModuleBody(FModuleOp module) {
     if (auto connect = dyn_cast<ConnectOp>(op)) {
       if (auto *destOp = connect.dest().getDefiningOp()) {
         if (isDeletableWireOrReg(destOp) &&
-          !(isOverdefined(connect.dest()) || isValidValue(connect.dest()))) {
+            !(isOverdefined(connect.dest()) || isValidValue(connect.dest()))) {
           connect.erase();
           ++numErasedOp;
         }

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -558,7 +558,7 @@ firrtl.circuit "ContinueInvalidValue"   {
     firrtl.connect %r3, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %r2, %r1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %r4, %r3 : !firrtl.uint<1>, !firrtl.uint<1>
-    %0 = firrtl.add %r1, %r4 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
+    %0 = firrtl.add %r2, %r4 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
     // CHECK: %c2_ui2 = firrtl.constant 2 : !firrtl.uint<2>
     // CHECK-NEXT: firrtl.connect %b, %c2_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
     firrtl.connect %b, %0 : !firrtl.uint<2>, !firrtl.uint<2>

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -542,3 +542,26 @@ firrtl.circuit "dntOutput" {
     firrtl.connect %b, %const : !firrtl.uint<3>, !firrtl.uint<3>
   }
 }
+
+// -----
+
+firrtl.circuit "ContinueInvalidValue"   {
+  // CHECK-LABEL: firrtl.module @ContinueInvalidValue
+  firrtl.module @ContinueInvalidValue(in %clock: !firrtl.clock, in %a: !firrtl.uint<1>, out %b: !firrtl.uint<2>) {
+    %r1 = firrtl.reg %clock  : !firrtl.uint<1>
+    %r2 = firrtl.reg %clock  : !firrtl.uint<1>
+    %r3 = firrtl.reg %clock  : !firrtl.uint<1>
+    %r4 = firrtl.reg %clock  : !firrtl.uint<1>
+
+
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    firrtl.connect %r1, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %r3, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %r2, %r1 : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %r4, %r3 : !firrtl.uint<1>, !firrtl.uint<1>
+    %0 = firrtl.add %r1, %r4 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
+    // CHECK: %c2_ui2 = firrtl.constant 2 : !firrtl.uint<2>
+    // CHECK-NEXT: firrtl.connect %b, %c2_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
+    firrtl.connect %b, %0 : !firrtl.uint<2>, !firrtl.uint<2>
+  }
+}

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -553,7 +553,6 @@ firrtl.circuit "ContinueInvalidValue"   {
     %r3 = firrtl.reg %clock  : !firrtl.uint<1>
     %r4 = firrtl.reg %clock  : !firrtl.uint<1>
 
-
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     firrtl.connect %r1, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %r3, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>


### PR DESCRIPTION
Currently, when we fail to fold operations, we immediately change their lattice values to be overdefined in the process of fixpoint iterations. The problem here is that we may success to fold after a number of iterations. This commit fix the issue by adding a new lattice value called "ValidValue" into between "InvalidValue" and "Constant".  Generally, it introduces better constant propagation (1%~40% depending on tests). For example  `perf/regress/chipyard.TestHarness.RocketSmall1Medium1Big1_BoomMedium1Large1Mega1.top.v.lo.fir`
```
* num-folded-op - Number of operations folded 
425 -> 574
* num-erased-op - Number of operations erased 
293 -> 434
```

The extension to aggregate types was blocked by this issue so I hope this is a proper fix. Will close #2237.