### PR TITLE
[Documentation] fix veriloggen docs

### DIFF
--- a/docs/VerilogGeneration.md
+++ b/docs/VerilogGeneration.md
@@ -72,7 +72,7 @@ The current set of "tool capability" Lowering Options is:
  * `disallowLocalVariables` (default=`false`).  If true, do not emit
    SystemVerilog locally scoped "automatic" or logic declarations - emit top
    level wire and reg's instead.
- * `enforceVerifLabels` (default=`false`).  If true, verification statements
+ * `verifLabels` (default=`false`).  If true, verification statements
    like `assert`, `assume`, and `cover` will always be emitted with a label. If
    the statement has no label in the IR, a generic one will be created. Some EDA
    tools require verification statements to be labeled.

--- a/docs/VerilogGeneration.md
+++ b/docs/VerilogGeneration.md
@@ -64,7 +64,7 @@ The current set of "tool capability" Lowering Options is:
 
  * `noAlwaysComb` (default=`false`).  If true, emits `sv.alwayscomb` as Verilog
    `always @(*)` statements.  Otherwise, print them as `always_comb`.
- * `allowExprInEventControl` (default=`false`).   If true, expressions are
+ * `exprInEventControl` (default=`false`).   If true, expressions are
    allowed in the sensitivity list of `always` statements, otherwise they are
    forced to be simple wires. Some EDA tools rely on these being simple wires.
  * `disallowPackedArrays` (default=`false`).  If true, eliminate packed arrays


### PR DESCRIPTION
changed the `allowExprInEventControl` to `exprInEventControl` and `enforceVerifLabels` to `verifLabels`. Ran into this issue while playing around with Verilog Generation and was a little stumped until I started digging into the code. Hopefully this will save newer users from running into the same issue.