### PR TITLE
[ExportVerilog] Remove parallel assert, XFAIL, add comment

### DIFF
--- a/integration_test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
+++ b/integration_test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
@@ -2,9 +2,6 @@
 ; RUN: firtool --firrtl-grand-central --verilog --annotation-file %s.anno.json %s > %t.one-file.sv && verilator --sv --lint-only %t.one-file.sv
 ; REQUIRES: verilator
 
-; XFAIL: *
-; https://github.com/llvm/circt/issues/2243
-
 circuit Top :
   module Submodule :
     input clock : Clock

--- a/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
+++ b/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
@@ -286,12 +286,6 @@ struct SharedEmitterState {
   /// Information about renamed global symbols, parameters, etc.
   const GlobalNameTable globalNames;
 
-  /// Flag indicating whether emission is currently in a parallel processing
-  /// mode. This is used for runtime assertions to ensure that certain blocks of
-  /// the code which cross-reference into other modules do so only in sequential
-  /// regions.
-  std::atomic<bool> isInParallelMode = {};
-
   explicit SharedEmitterState(ModuleOp designOp, const LoweringOptions &options,
                               GlobalNameTable globalNames)
       : designOp(designOp), options(options),

--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -10,6 +10,11 @@
 // gets involved.  This allows us to do some transformations that would be
 // awkward to implement inline in the emitter.
 //
+// NOTE: This file covers the preparation phase of `ExportVerilog` which mainly
+// legalizes the IR and makes adjustments necessary for emission. This is the
+// place to mutate the IR if emission needs it. The IR cannot be modified during
+// emission itself, which happens in parallel.
+//
 //===----------------------------------------------------------------------===//
 
 #include "ExportVerilogInternals.h"


### PR DESCRIPTION
Remove the `isInParallelMode` flag and the corresponding assertion, which are no longer needed since the emission phase of `ExportVerilog` treats the IR as immutable, which allows for pretty straightforward parallelization. All mutation is limited to the preparation phase which lives in the separate `PrepareForEmission.cpp` file.

Also remove the XFAIL on one of the FIRRTL Grand Central integration tests, which used to trigger this assertion.

Add comments to the `ExportVerilog.cpp` and `PrepareForEmission.cpp` files explaining the separation into an IR-mutating preparation and IR-immutable emission phase.