### PR TITLE
Add separateFiles option to exportVerilog

### DIFF
--- a/include/circt/Conversion/ExportVerilog.h
+++ b/include/circt/Conversion/ExportVerilog.h
@@ -25,7 +25,12 @@ createExportSplitVerilogPass(llvm::StringRef directory = "./");
 
 /// Export a module containing HW, and SV dialect code. Requires that the SV
 /// dialect is loaded in to the context.
-mlir::LogicalResult exportVerilog(mlir::ModuleOp module, llvm::raw_ostream &os);
+/// If `separateModules` is set to `true`, this function will output the split
+/// file header with every file (matching the semantics of
+/// `exportSplitVerilog`). Otherwise, only files explicitly specified using the
+/// `hw.output_file` attribute will emit a file header.
+mlir::LogicalResult exportVerilog(mlir::ModuleOp module, bool separateModules,
+                                  llvm::raw_ostream &os);
 
 /// Export a module containing HW, and SV dialect code, as one file per SV
 /// module. Requires that the SV dialect is loaded in to the context.

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -4222,7 +4222,8 @@ static void prepareForEmission(ModuleOp module,
 // Unified Emitter
 //===----------------------------------------------------------------------===//
 
-LogicalResult circt::exportVerilog(ModuleOp module, llvm::raw_ostream &os) {
+LogicalResult circt::exportVerilog(ModuleOp module, bool separateModules,
+                                   llvm::raw_ostream &os) {
   // Prepare the ops in the module for emission and legalize the names that will
   // end up in the output.
   LoweringOptions options(module);
@@ -4230,9 +4231,11 @@ LogicalResult circt::exportVerilog(ModuleOp module, llvm::raw_ostream &os) {
   GlobalNameTable globalNames = legalizeGlobalNames(module);
 
   SharedEmitterState emitter(module, options, std::move(globalNames));
-  emitter.gatherFiles(false);
+  emitter.gatherFiles(separateModules);
 
   SharedEmitterState::EmissionList list;
+
+  // If more than one file,
 
   // Collect the contents of the main file. This is a container for anything
   // not explicitly split out into a separate file.
@@ -4269,7 +4272,7 @@ struct ExportVerilogPass : public ExportVerilogBase<ExportVerilogPass> {
     // TODO: This should be moved up to circt-opt and circt-translate.
     applyLoweringCLOptions(getOperation());
 
-    if (failed(exportVerilog(getOperation(), os)))
+    if (failed(exportVerilog(getOperation(), /*separateModules=*/false, os)))
       signalPassFailure();
   }
 

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -4235,8 +4235,6 @@ LogicalResult circt::exportVerilog(ModuleOp module, bool separateModules,
 
   SharedEmitterState::EmissionList list;
 
-  // If more than one file,
-
   // Collect the contents of the main file. This is a container for anything
   // not explicitly split out into a separate file.
   emitter.collectOpsForFile(emitter.rootFile, list);


### PR DESCRIPTION
This allows you to run `exportVerilog` matching the semantics of `exportSplitVerilog`. This is useful for testing.