### PR TITLE
[LLHD] Use assembly-format for signal and pointer type

### DIFF
--- a/include/circt/Dialect/LLHD/IR/LLHDTypesImpl.td
+++ b/include/circt/Dialect/LLHD/IR/LLHDTypesImpl.td
@@ -28,8 +28,8 @@ def SigTypeImpl : LLHDType<"Sig"> {
 
   let mnemonic = "sig";
   let parameters = (ins "::mlir::Type":$underlyingType);
+  let assemblyFormat = "`<` $underlyingType `>`";
 
-  let skipDefaultBuilders = 1;
   let builders = [
     AttrBuilderWithInferredContext<(ins "::mlir::Type":$underlyingType), [{
       return $_get(underlyingType.getContext(), underlyingType);
@@ -47,8 +47,8 @@ def PtrTypeImpl : LLHDType<"Ptr"> {
 
   let mnemonic = "ptr";
   let parameters = (ins "::mlir::Type":$underlyingType);
+  let assemblyFormat = "`<` $underlyingType `>`";
 
-  let skipDefaultBuilders = 1;
   let builders = [
     AttrBuilderWithInferredContext<(ins "::mlir::Type":$underlyingType), [{
       return $_get(underlyingType.getContext(), underlyingType);

--- a/lib/Dialect/LLHD/IR/LLHDTypes.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDTypes.cpp
@@ -25,61 +25,6 @@ using namespace circt::llhd;
 #include "circt/Dialect/LLHD/IR/LLHDAttributes.cpp.inc"
 
 //===----------------------------------------------------------------------===//
-// Helpers
-//===----------------------------------------------------------------------===//
-
-/// Parse a nested type, enclosed in angle brackts (`<...>`).
-static Type parseNestedType(AsmParser &parser) {
-  Type underlyingType;
-  if (parser.parseLess())
-    return Type();
-
-  llvm::SMLoc loc = parser.getCurrentLocation();
-  if (parser.parseType(underlyingType)) {
-    parser.emitError(loc, "No signal type found. Signal needs an underlying "
-                          "type.");
-    return nullptr;
-  }
-
-  if (parser.parseGreater())
-    return Type();
-
-  return underlyingType;
-}
-
-//===----------------------------------------------------------------------===//
-// Signal Type
-//===----------------------------------------------------------------------===//
-
-/// Parse a signal type.
-/// Syntax: sig ::= !llhd.sig<type>
-Type SigType::parse(AsmParser &p) {
-  auto loc = p.getEncodedSourceLoc(p.getCurrentLocation());
-  return getChecked(mlir::detail::getDefaultDiagnosticEmitFn(loc),
-                    p.getContext(), parseNestedType(p));
-}
-
-void SigType::print(AsmPrinter &p) const {
-  p << "<" << getUnderlyingType() << '>';
-}
-
-//===----------------------------------------------------------------------===//
-// Pointer Type
-//===----------------------------------------------------------------------===//
-
-/// Parse a pointer type.
-/// Syntax: ptr ::= !llhd.ptr<type>
-Type PtrType::parse(AsmParser &p) {
-  auto loc = p.getEncodedSourceLoc(p.getCurrentLocation());
-  return getChecked(mlir::detail::getDefaultDiagnosticEmitFn(loc),
-                    p.getContext(), parseNestedType(p));
-}
-
-void PtrType::print(AsmPrinter &p) const {
-  p << "<" << getUnderlyingType() << '>';
-}
-
-//===----------------------------------------------------------------------===//
 // Time Attribute
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
Replace the custom parsers and printers of the signal and pointer types in LLHD with the new assembly-format feature.

Why not replace `TimeAttr` printer and parser, too?
The closest we can get is `#llhd.time<1 "ns", 0 d, 0 e>`. Currently, we have `#llhd.time<1ns, 0d, 0e>`