### PR TITLE
[FIRRTL] Work Around Zero Width APInt Sign Extend Issues

### DIFF
--- a/include/circt/Support/APInt.h
+++ b/include/circt/Support/APInt.h
@@ -1,0 +1,30 @@
+//===- APInt.h - CIRCT Lowering Options -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Utilities for working around limitations of upstream LLVM APInts.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_SUPPORT_APINT_H
+#define CIRCT_SUPPORT_APINT_H
+
+#include "circt/Support/LLVM.h"
+
+namespace circt {
+
+/// A safe version of APInt::sextOrSelf that will NOT assert on zero-width
+/// signed APSInts.  Instead of asserting, this will zero extend.
+APInt sextOrSelfZeroWidth(APInt value, unsigned width);
+
+/// A safe version of APSInt::extOrTrunc that will NOT assert on zero-width
+/// signed APSInts.  Instead of asserting, this will zero extend.
+APSInt extOrTruncZeroWidth(APSInt value, unsigned width);
+
+} // namespace circt
+
+#endif // CIRCT_SUPPORT_APINT_H

--- a/lib/Dialect/FIRRTL/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/CMakeLists.txt
@@ -17,11 +17,13 @@ add_circt_dialect_library(CIRCTFIRRTL
   CIRCTFIRRTLEnumsIncGen
   CIRCTFIRRTLCanonicalizationIncGen
   CIRCTFIRRTLOpInterfacesIncGen
-  
+
   LINK_COMPONENTS
+
   Support
 
   LINK_LIBS PUBLIC
+  CIRCTSupport
   CIRCTHW
   MLIRIR
   MLIRPass

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -11,6 +11,7 @@
 #include "circt/Dialect/FIRRTL/FIRRTLAttributes.h"
 #include "circt/Dialect/FIRRTL/InstanceGraph.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
+#include "circt/Support/APInt.h"
 #include "mlir/IR/Threading.h"
 #include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/TinyPtrVector.h"
@@ -354,7 +355,7 @@ LatticeValue IMConstPropPass::getExtendedLatticeValue(Value value,
     return result; // Already the right width, we're done.
 
   // Otherwise, extend the constant using the signedness of the source.
-  resultConstant = resultConstant.extOrTrunc(destWidth);
+  resultConstant = extOrTruncZeroWidth(resultConstant, destWidth);
   return LatticeValue(IntegerAttr::get(destType.getContext(), resultConstant));
 }
 

--- a/lib/Support/APInt.cpp
+++ b/lib/Support/APInt.cpp
@@ -1,0 +1,27 @@
+//===- APInt.h - CIRCT Lowering Options -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Utilities for working around limitations of upstream LLVM APInts.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Support/APInt.h"
+#include "llvm/ADT/APSInt.h"
+
+using namespace circt;
+
+APInt circt::sextOrSelfZeroWidth(APInt value, unsigned width) {
+  return value.getBitWidth() ? value.sextOrSelf(width)
+                             : value.zextOrSelf(width);
+}
+
+APSInt circt::extOrTruncZeroWidth(APSInt value, unsigned width) {
+  return value.getBitWidth()
+             ? value.extOrTrunc(width)
+             : APSInt(value.zextOrTrunc(width), value.isUnsigned());
+}

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -8,7 +8,8 @@ add_circt_library(CIRCTSupport
   FieldRef.cpp
   LoweringOptions.cpp
   Path.cpp
-  
+  APInt.cpp
+
   ADDITIONAL_HEADER_DIRS
 
   LINK_LIBS PUBLIC

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -1424,6 +1424,7 @@ firrtl.module @ComparisonOfConsts(
   out %y22: !firrtl.uint<1>,
   out %y23: !firrtl.uint<1>
 ) {
+  %c0_si0 = firrtl.constant 0 : !firrtl.sint<0>
   %c2_si4 = firrtl.constant 2 : !firrtl.sint<4>
   %c-3_si3 = firrtl.constant -3 : !firrtl.sint<3>
   %c2_ui4 = firrtl.constant 2 : !firrtl.uint<4>
@@ -1436,51 +1437,72 @@ firrtl.module @ComparisonOfConsts(
   %1 = firrtl.leq %c-3_si3, %c2_si4 : (!firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.uint<1>
   %2 = firrtl.leq %c2_ui4, %c5_ui3 : (!firrtl.uint<4>, !firrtl.uint<3>) -> !firrtl.uint<1>
   %3 = firrtl.leq %c5_ui3, %c2_ui4 : (!firrtl.uint<3>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %4 = firrtl.lt %c2_si4, %c-3_si3 : (!firrtl.sint<4>, !firrtl.sint<3>) -> !firrtl.uint<1>
-  %5 = firrtl.lt %c-3_si3, %c2_si4 : (!firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.uint<1>
-  %6 = firrtl.lt %c2_ui4, %c5_ui3 : (!firrtl.uint<4>, !firrtl.uint<3>) -> !firrtl.uint<1>
-  %7 = firrtl.lt %c5_ui3, %c2_ui4 : (!firrtl.uint<3>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %8 = firrtl.geq %c2_si4, %c-3_si3 : (!firrtl.sint<4>, !firrtl.sint<3>) -> !firrtl.uint<1>
-  %9 = firrtl.geq %c-3_si3, %c2_si4 : (!firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.uint<1>
-  %10 = firrtl.geq %c2_ui4, %c5_ui3 : (!firrtl.uint<4>, !firrtl.uint<3>) -> !firrtl.uint<1>
-  %11 = firrtl.geq %c5_ui3, %c2_ui4 : (!firrtl.uint<3>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %12 = firrtl.gt %c2_si4, %c-3_si3 : (!firrtl.sint<4>, !firrtl.sint<3>) -> !firrtl.uint<1>
-  %13 = firrtl.gt %c-3_si3, %c2_si4 : (!firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.uint<1>
-  %14 = firrtl.gt %c2_ui4, %c5_ui3 : (!firrtl.uint<4>, !firrtl.uint<3>) -> !firrtl.uint<1>
-  %15 = firrtl.gt %c5_ui3, %c2_ui4 : (!firrtl.uint<3>, !firrtl.uint<4>) -> !firrtl.uint<1>
+  %4 = firrtl.leq %c2_si4, %c0_si0 : (!firrtl.sint<4>, !firrtl.sint<0>) -> !firrtl.uint<1>
+
+  %5 = firrtl.lt %c2_si4, %c-3_si3 : (!firrtl.sint<4>, !firrtl.sint<3>) -> !firrtl.uint<1>
+  %6 = firrtl.lt %c-3_si3, %c2_si4 : (!firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.uint<1>
+  %7 = firrtl.lt %c2_ui4, %c5_ui3 : (!firrtl.uint<4>, !firrtl.uint<3>) -> !firrtl.uint<1>
+  %8 = firrtl.lt %c5_ui3, %c2_ui4 : (!firrtl.uint<3>, !firrtl.uint<4>) -> !firrtl.uint<1>
+  %9 = firrtl.lt %c2_si4, %c0_si0 : (!firrtl.sint<4>, !firrtl.sint<0>) -> !firrtl.uint<1>
+
+  %10 = firrtl.geq %c2_si4, %c-3_si3 : (!firrtl.sint<4>, !firrtl.sint<3>) -> !firrtl.uint<1>
+  %11 = firrtl.geq %c-3_si3, %c2_si4 : (!firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.uint<1>
+  %12 = firrtl.geq %c2_ui4, %c5_ui3 : (!firrtl.uint<4>, !firrtl.uint<3>) -> !firrtl.uint<1>
+  %13 = firrtl.geq %c5_ui3, %c2_ui4 : (!firrtl.uint<3>, !firrtl.uint<4>) -> !firrtl.uint<1>
+  %14 = firrtl.geq %c2_si4, %c0_si0 : (!firrtl.sint<4>, !firrtl.sint<0>) -> !firrtl.uint<1>
+
+  %15 = firrtl.gt %c2_si4, %c-3_si3 : (!firrtl.sint<4>, !firrtl.sint<3>) -> !firrtl.uint<1>
+  %16 = firrtl.gt %c-3_si3, %c2_si4 : (!firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.uint<1>
+  %17 = firrtl.gt %c2_ui4, %c5_ui3 : (!firrtl.uint<4>, !firrtl.uint<3>) -> !firrtl.uint<1>
+  %18 = firrtl.gt %c5_ui3, %c2_ui4 : (!firrtl.uint<3>, !firrtl.uint<4>) -> !firrtl.uint<1>
+  %19 = firrtl.gt %c2_si4, %c0_si0 : (!firrtl.sint<4>, !firrtl.sint<0>) -> !firrtl.uint<1>
 
   firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y2, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y4, %4 : !firrtl.uint<1>, !firrtl.uint<1>
+
   firrtl.connect %y5, %5 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y6, %6 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y7, %7 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y8, %8 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y9, %9 : !firrtl.uint<1>, !firrtl.uint<1>
+
   firrtl.connect %y10, %10 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y11, %11 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y12, %12 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y13, %13 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y14, %14 : !firrtl.uint<1>, !firrtl.uint<1>
+
   firrtl.connect %y15, %15 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y16, %16 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y17, %17 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y18, %18 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %y19, %19 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.connect %y0, %c0_ui1
   // CHECK-NEXT: firrtl.connect %y1, %c1_ui1
   // CHECK-NEXT: firrtl.connect %y2, %c1_ui1
   // CHECK-NEXT: firrtl.connect %y3, %c0_ui1
   // CHECK-NEXT: firrtl.connect %y4, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y5, %c1_ui1
+
+  // CHECK-NEXT: firrtl.connect %y5, %c0_ui1
   // CHECK-NEXT: firrtl.connect %y6, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y7, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y8, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y7, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y8, %c0_ui1
   // CHECK-NEXT: firrtl.connect %y9, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y10, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y11, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y12, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y13, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y14, %c0_ui1
+
+  // CHECK-NEXT: firrtl.connect %y10, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y11, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y12, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y13, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y14, %c1_ui1
+
   // CHECK-NEXT: firrtl.connect %y15, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y16, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y17, %c0_ui1
+  // CHECK-NEXT: firrtl.connect %y18, %c1_ui1
+  // CHECK-NEXT: firrtl.connect %y19, %c1_ui1
 }
 
 // CHECK-LABEL: @add_cst_prop1
@@ -2022,6 +2044,48 @@ firrtl.module @Issue2197(in %clock: !firrtl.clock, out %x: !firrtl.uint<2>) {
   %0 = firrtl.pad %invalid_ui1, 2 : (!firrtl.uint<1>) -> !firrtl.uint<2>
   firrtl.connect %reg, %0 : !firrtl.uint<2>, !firrtl.uint<2>
   firrtl.connect %x, %reg : !firrtl.uint<2>, !firrtl.uint<2>
+}
+
+// This is checking the behavior of sign extension of zero-width constants that
+// results from trying to primops.
+// CHECK-LABEL: @ZeroWidthAdd
+firrtl.module @ZeroWidthAdd(out %a: !firrtl.sint<1>) {
+  %zw = firrtl.constant 0 : !firrtl.sint<0>
+  %0 = firrtl.constant 0 : !firrtl.sint<0>
+  %1 = firrtl.add %0, %zw : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.sint<1>
+  firrtl.connect %a, %1 : !firrtl.sint<1>, !firrtl.sint<1>
+  // CHECK:      %[[zero:.+]] = firrtl.constant 0 : !firrtl.sint<1>
+  // CHECK-NEXT: firrtl.connect %a, %[[zero]]
+}
+
+// CHECK-LABEL: @ZeroWidthDshr
+firrtl.module @ZeroWidthDshr(in %a: !firrtl.sint<0>, out %b: !firrtl.sint<0>) {
+  %zw = firrtl.constant 0 : !firrtl.uint<0>
+  %0 = firrtl.dshr %a, %zw : (!firrtl.sint<0>, !firrtl.uint<0>) -> !firrtl.sint<0>
+  firrtl.connect %b, %0 : !firrtl.sint<0>, !firrtl.sint<0>
+  // CHECK:      %[[zero:.+]] = firrtl.constant 0 : !firrtl.sint<0>
+  // CHECK-NEXT: firrtl.connect %b, %[[zero]]
+}
+
+// CHECK-LABEL: @ZeroWidthPad
+firrtl.module @ZeroWidthPad(out %b: !firrtl.sint<1>) {
+  %zw = firrtl.constant 0 : !firrtl.sint<0>
+  %0 = firrtl.pad %zw, 1 : (!firrtl.sint<0>) -> !firrtl.sint<1>
+  firrtl.connect %b, %0 : !firrtl.sint<1>, !firrtl.sint<1>
+  // CHECK:      %[[zero:.+]] = firrtl.constant 0 : !firrtl.sint<1>
+  // CHECK-NEXT: firrtl.connect %b, %[[zero]]
+}
+
+// CHECK-LABEL: @ZeroWidthCat
+firrtl.circuit "ZeroWidthCat"   {
+  firrtl.module @ZeroWidthCat(out %a: !firrtl.uint<1>) {
+    %one = firrtl.constant 1 : !firrtl.uint<1>
+    %zw = firrtl.constant 0 : !firrtl.uint<0>
+    %0 = firrtl.cat %one, %zw : (!firrtl.uint<1>, !firrtl.uint<0>) -> !firrtl.uint<1>
+    firrtl.connect %a, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+  // CHECK:      %[[one:.+]] = firrtl.constant 1 : !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.connect %a, %[[one]]
 }
 
 }


### PR DESCRIPTION
Upstream LLVM zero-width APInts will assert if you try to use any methods which involve sign extension.  This attempts to work around this by either using better methods which don't error or defining new methods which treat zero-width behavior as zero extension regardless of sign.

This should get the nightly performance regressions back to passing.