### PR TITLE
[SV][HWMemSimImpl] Add option to ignore read enable for memory lowering

### DIFF
--- a/include/circt/Dialect/SV/SVPasses.h
+++ b/include/circt/Dialect/SV/SVPasses.h
@@ -24,7 +24,9 @@ std::unique_ptr<mlir::Pass> createHWCleanupPass();
 std::unique_ptr<mlir::Pass> createHWStubExternalModulesPass();
 std::unique_ptr<mlir::Pass> createHWLegalizeModulesPass();
 std::unique_ptr<mlir::Pass> createHWGeneratorCalloutPass();
-std::unique_ptr<mlir::Pass> createHWMemSimImplPass(bool replSeqMem = false);
+std::unique_ptr<mlir::Pass>
+createHWMemSimImplPass(bool replSeqMem = false,
+                       bool ignoreReadEnableMem = false);
 std::unique_ptr<mlir::Pass> createSVExtractTestCodePass();
 std::unique_ptr<mlir::Pass>
 createHWExportModuleHierarchyPass(llvm::Optional<std::string> directory = {});

--- a/include/circt/Dialect/SV/SVPasses.td
+++ b/include/circt/Dialect/SV/SVPasses.td
@@ -95,7 +95,10 @@ def HWMemSimImpl : Pass<"hw-memory-sim", "ModuleOp"> {
 
   let options = [
     Option<"replSeqMem", "repl-seq-mem", "bool",
-                "false", "Prepare seq mems for macro replacement">
+                "false", "Prepare seq mems for macro replacement">,
+    Option<"ignoreReadEnableMem", "ignore-read-enable-mem", "bool",
+                "false",
+    "ignore the read enable signal, instead of assigning X on read disable">
    ];
 }
 

--- a/test/firtool/memory.fir
+++ b/test/firtool/memory.fir
@@ -1,4 +1,5 @@
 ; RUN: firtool %s --format=fir  --lower-to-hw | FileCheck %s 
+; RUN: firtool %s --format=fir  --lower-to-hw --ignore-read-enable-mem | FileCheck --check-prefix=READ %s 
 
 circuit Qux:
   module Qux:
@@ -51,6 +52,22 @@ circuit Qux:
     memory.rw.wmask <= rwMask
     memory.rw.wdata <= rwDataIn
     rwDataOut <= memory.rw.rdata
+
+
+; READ-LABEL:  hw.module @FIRRTLMem_1_1_1_8_16_1_1_1_0_1_a
+; READ:    %[[vtrue:.+]] = hw.constant true
+; READ:    %[[vMemory:.+]] = sv.reg  : !hw.inout<uarray<16xi8>>
+; READ-NEXT:    %[[v0:.+]] = sv.reg  : !hw.inout<i1>
+; READ-NEXT:    %[[v2:.+]] = sv.reg  : !hw.inout<i4>
+; READ-NEXT:    sv.always posedge %R0_clk {
+; READ-NEXT:      sv.passign %[[v0]], %R0_en : i1
+; READ-NEXT:      sv.passign %[[v2]], %R0_addr : i4
+; READ-NEXT:    }
+; READ-NEXT:    %[[v3:.+]] = sv.read_inout %[[v2]] : !hw.inout<i4>
+; READ-NEXT:    %[[v4:.+]] = sv.array_index_inout %[[vMemory]][%[[v3]]] : !hw.inout<uarray<16xi8>>, i4
+; READ-NEXT:    %[[v6:.+]] = sv.read_inout %[[v4]] : !hw.inout<i8>
+; READ:    hw.output %[[v6]]
+
 ; CHECK:  hw.generator.schema @FIRRTLMem, "FIRRTL_Memory", ["depth", "numReadPorts", "numWritePorts", "numReadWritePorts", "readLatency", "writeLatency", "width", "maskGran", "readUnderWrite", "writeUnderWrite", "writeClockIDs"]
 ; CHECK:  hw.module @FIRRTLMem_1_1_1_8_16_1_1_1_0_1_a(%R0_addr: i4, %R0_en: i1, %R0_clk: i1, %RW0_addr: i4, %RW0_en: i1, %RW0_clk: i1, %RW0_wmode: i1, %RW0_wdata: i8, %RW0_wmask: i1, %W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i8, %W0_mask: i1) -> (R0_data: i8, RW0_rdata: i8) {
 ; CHECK:    %[[vtrue:.+]] = hw.constant true

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -128,6 +128,12 @@ static cl::opt<std::string>
     replSeqMemFile("repl-seq-mem-file",
                    cl::desc("file name for seq mem metadata"), cl::init(""));
 
+static cl::opt<bool>
+    ignoreReadEnableMem("ignore-read-enable-mem",
+                        cl::desc("ignore the read enable signal, instead of "
+                                 "assigning X on read disable"),
+                        cl::init(false));
+
 static cl::opt<bool> imconstprop(
     "imconstprop",
     cl::desc(
@@ -415,7 +421,7 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
       outputFormat == OutputSplitVerilog || outputFormat == OutputVerilogIR) {
     pm.addPass(createLowerFIRRTLToHWPass(enableAnnotationWarning.getValue(),
                                          nonConstAsyncResetValueIsError));
-    pm.addPass(sv::createHWMemSimImplPass(replSeqMem));
+    pm.addPass(sv::createHWMemSimImplPass(replSeqMem, ignoreReadEnableMem));
 
     if (extractTestCode)
       pm.addPass(sv::createSVExtractTestCodePass());


### PR DESCRIPTION
This change adds an option to ignore the memory read enable signal during memory lowering to register banks.

According to the FIRRTL spec, the read output is undefined if the read enable signal is disabled.
But the `firrtl` implementation ignores the read enable signal, 
https://github.com/chipsalliance/firrtl/blob/master/src/main/scala/firrtl/backends/verilog/VerilogEmitter.scala#L1122

This change ensures that, in `HWMemSimImpl` by default the read output is set to `X` if read enable is disabled, but if 
`ignore-read-enable-mem` option is passed, then the read output is set, irrespective of the enable signal.

This provides an option to match the Scala FIRRTL compiler behavior. 