### PR TITLE
[MSFT] Fix getNearestFreeInColumn logic.

### DIFF
--- a/integration_test/Bindings/Python/dialects/msft.py
+++ b/integration_test/Bindings/Python/dialects/msft.py
@@ -94,6 +94,8 @@ with ir.Context() as ctx, ir.Location.unknown():
 
   seeded_pdb = msft.PlacementDB(top.operation, devdb)
 
+  print(seeded_pdb.get_nearest_free_in_column(msft.M20K, 2, 49))
+  # CHECK: #msft.physloc<M20K, 2, 50, 1>
   print(seeded_pdb.get_nearest_free_in_column(msft.M20K, 2, 4))
   # CHECK: #msft.physloc<M20K, 2, 6, 1>
 

--- a/lib/Dialect/MSFT/DeviceDB.cpp
+++ b/lib/Dialect/MSFT/DeviceDB.cpp
@@ -186,7 +186,7 @@ PhysLocationAttr PlacementDB::getNearestFreeInColumn(PrimitiveType prim,
   // Simplest possible algorithm.
   PhysLocationAttr nearest = {};
   walkPlacements(
-      [&nearest, columnNum](PhysLocationAttr loc, PlacedInstance inst) {
+      [&nearest, nearestToY](PhysLocationAttr loc, PlacedInstance inst) {
         if (inst.op)
           return;
         if (!nearest) {
@@ -194,8 +194,8 @@ PhysLocationAttr PlacementDB::getNearestFreeInColumn(PrimitiveType prim,
           return;
         }
         int64_t curDist =
-            std::abs((int64_t)columnNum - (int64_t)nearest.getY());
-        int64_t replDist = std::abs((int64_t)columnNum - (int64_t)loc.getY());
+            std::abs((int64_t)nearestToY - (int64_t)nearest.getY());
+        int64_t replDist = std::abs((int64_t)nearestToY - (int64_t)loc.getY());
         if (replDist < curDist)
           nearest = loc;
       },


### PR DESCRIPTION
This needs to check the available location against the target
y-axis. Adds a test that was reliably reproducing the issue.