### PR TITLE
[FIRRTL] Add method to insert ports into instance ops

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -83,6 +83,11 @@ def InstanceOp : FIRRTLOp<"instance", [
     /// and updates any users of the remaining ports to point at the new
     /// instance.
     InstanceOp erasePorts(OpBuilder &builder, ArrayRef<unsigned> portIndices);
+
+    /// Clone the instance op and add ports.  This is usually used in
+    /// conjuction with adding ports to the referenced module. This will emit
+    /// the new InstanceOp to the same location.
+    InstanceOp cloneAndInsertPorts(ArrayRef<std::pair<unsigned, PortInfo>> ports);
   }];
 }
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -28,8 +28,8 @@ struct PortInfo {
   StringAttr name;
   FIRRTLType type;
   Direction direction;
-  StringAttr sym;
-  Location loc;
+  StringAttr sym = {};
+  Location loc = UnknownLoc::get(type.getContext());
   AnnotationSet annotations = AnnotationSet(type.getContext());
 
   StringRef getName() const { return name ? name.getValue() : ""; }

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1006,6 +1006,47 @@ void InstanceOp::setAllPortAnnotations(ArrayRef<Attribute> annotations) {
                    ArrayAttr::get(getContext(), annotations));
 }
 
+InstanceOp InstanceOp::cloneAndInsertPorts(
+    ArrayRef<std::pair<unsigned, PortInfo>> ports) {
+  auto portSize = ports.size();
+  auto newPortCount = getNumResults() + portSize;
+  SmallVector<Direction> newPortDirections;
+  newPortDirections.reserve(newPortCount);
+  SmallVector<Attribute> newPortNames;
+  newPortNames.reserve(newPortCount);
+  SmallVector<Type> newPortTypes;
+  newPortTypes.reserve(newPortCount);
+  SmallVector<Attribute> newPortAnnos;
+  newPortAnnos.reserve(newPortCount);
+
+  unsigned oldIndex = 0;
+  unsigned newIndex = 0;
+  while (oldIndex + newIndex < newPortCount) {
+    // Check if we should insert a port here.
+    if (newIndex < portSize && ports[newIndex].first == oldIndex) {
+      auto &newPort = ports[newIndex].second;
+      newPortDirections.push_back(newPort.direction);
+      newPortNames.push_back(newPort.name);
+      newPortTypes.push_back(newPort.type);
+      newPortAnnos.push_back(newPort.annotations.getArrayAttr());
+      ++newIndex;
+    } else {
+      // Copy the next old port.
+      newPortDirections.push_back(getPortDirection(oldIndex));
+      newPortNames.push_back(getPortName(oldIndex));
+      newPortTypes.push_back(getType(oldIndex));
+      newPortAnnos.push_back(getPortAnnotation(oldIndex));
+      ++oldIndex;
+    }
+  }
+
+  // Create a new instance op with the reset inserted.
+  return OpBuilder(*this).create<InstanceOp>(getLoc(),
+      newPortTypes, moduleName(), name(), newPortDirections,
+      newPortNames, annotations().getValue(), newPortAnnos,
+      lowerToBind(), inner_symAttr());
+}
+
 LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   auto module = (*this)->getParentOfType<FModuleOp>();
   auto referencedModule =

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1006,8 +1006,8 @@ void InstanceOp::setAllPortAnnotations(ArrayRef<Attribute> annotations) {
                    ArrayAttr::get(getContext(), annotations));
 }
 
-InstanceOp InstanceOp::cloneAndInsertPorts(
-    ArrayRef<std::pair<unsigned, PortInfo>> ports) {
+InstanceOp
+InstanceOp::cloneAndInsertPorts(ArrayRef<std::pair<unsigned, PortInfo>> ports) {
   auto portSize = ports.size();
   auto newPortCount = getNumResults() + portSize;
   SmallVector<Direction> newPortDirections;
@@ -1041,10 +1041,10 @@ InstanceOp InstanceOp::cloneAndInsertPorts(
   }
 
   // Create a new instance op with the reset inserted.
-  return OpBuilder(*this).create<InstanceOp>(getLoc(),
-      newPortTypes, moduleName(), name(), newPortDirections,
-      newPortNames, annotations().getValue(), newPortAnnos,
-      lowerToBind(), inner_symAttr());
+  return OpBuilder(*this).create<InstanceOp>(
+      getLoc(), newPortTypes, moduleName(), name(), newPortDirections,
+      newPortNames, annotations().getValue(), newPortAnnos, lowerToBind(),
+      inner_symAttr());
 }
 
 LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -1506,44 +1506,10 @@ void InferResetsPass::implementAsyncReset(Operation *op, FModuleOp module,
     if (domain.newPortName) {
       LLVM_DEBUG(llvm::dbgs() << "  - Adding new result as reset\n");
 
-      // Determine the new result types.
-      SmallVector<Type> resultTypes;
-      resultTypes.reserve(instOp.getNumResults() + 1);
-      resultTypes.push_back(actualReset.getType());
-      resultTypes.append(instOp.getResultTypes().begin(),
-                         instOp.getResultTypes().end());
-
-      // Determine new port directions.
-      SmallVector<Direction> newPortDirections;
-      newPortDirections.reserve(instOp.getNumResults() + 1);
-      newPortDirections.push_back(Direction::In);
-      auto oldPortDirections =
-          direction::unpackAttribute(instOp.portDirectionsAttr());
-      newPortDirections.append(oldPortDirections);
-
-      // Determine new port names.
-      SmallVector<Attribute> newPortNames;
-      newPortNames.reserve(instOp.getNumResults() + 1);
-      newPortNames.push_back(domain.newPortName);
-      newPortNames.append(instOp.portNames().begin(), instOp.portNames().end());
-
-      // Create a new list of port annotations.
-      SmallVector<Attribute> newPortAnnos;
-      if (auto oldPortAnnos = instOp.portAnnotations()) {
-        newPortAnnos.reserve(oldPortAnnos.size() + 1);
-        newPortAnnos.push_back(builder.getArrayAttr({}));
-        newPortAnnos.append(oldPortAnnos.begin(), oldPortAnnos.end());
-      }
-      LLVM_DEBUG(llvm::dbgs()
-                 << "  - Result types: " << resultTypes.size() << "\n");
-      LLVM_DEBUG(llvm::dbgs()
-                 << "  - Port annos: " << newPortAnnos.size() << "\n");
-
-      // Create a new instance op with the reset inserted.
-      auto newInstOp = builder.create<InstanceOp>(
-          resultTypes, instOp.moduleName(), instOp.name(), newPortDirections,
-          newPortNames, instOp.annotations().getValue(), newPortAnnos,
-          instOp.lowerToBind(), instOp.inner_symAttr());
+      auto newInstOp = instOp.cloneAndInsertPorts(
+          {{/*portIndex=*/0,
+            {domain.newPortName, actualReset.getType().cast<FIRRTLType>(),
+             Direction::In}}});
       instReset = newInstOp.getResult(0);
 
       // Update the uses over to the new instance and drop the old instance.


### PR DESCRIPTION
This adds a method to insert ports into an instance op.  Since this
increases the number of results of the instance op, it actually has to
be cloned.  It is assumed that the user will manually call
`replaceAllUses` and erase the original instance operation.  This
functionality is useful for any pass that adds ports to modules.