### PR TITLE
[FIRRTL] Make Annotation hold on to the actual annotation attribute

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -186,7 +186,7 @@ static void moveVerifAnno(ModuleOp top, AnnotationSet &annos,
   auto ctx = top.getContext();
   if (!anno)
     return;
-  if (auto dir = anno.getAs<StringAttr>("directory")) {
+  if (auto dir = anno.getMember<StringAttr>("directory")) {
     SmallVector<NamedAttribute> old;
     for (auto i : top->getAttrs())
       old.push_back(i);
@@ -194,7 +194,7 @@ static void moveVerifAnno(ModuleOp top, AnnotationSet &annos,
                      hw::OutputFileAttr::getAsDirectory(ctx, dir.getValue()));
     top->setAttrs(old);
   }
-  if (auto file = anno.getAs<StringAttr>("filename")) {
+  if (auto file = anno.getMember<StringAttr>("filename")) {
     SmallVector<NamedAttribute> old;
     for (auto i : top->getAttrs())
       old.push_back(i);
@@ -841,7 +841,7 @@ FIRRTLModuleLowering::lowerModule(FModuleOp oldModule, Block *topLevelModule,
           moduleHierarchyFileAttrName,
           hw::OutputFileAttr::getFromFilename(
               &getContext(),
-              hierAnno.get("filename").cast<StringAttr>().getValue(),
+              hierAnno.getMember<StringAttr>("filename").getValue(),
               /*excludeFromFileList=*/true));
   };
   if (annos.removeAnnotation(dutAnnoClass))

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
@@ -174,41 +174,28 @@ AnnotationSet::applyToPortDictionaryAttr(ArrayRef<NamedAttribute> attrs) const {
                                    false, {});
 }
 
-DictionaryAttr AnnotationSet::getAnnotationImpl(StringAttr className) const {
-  for (auto annotation : annotations) {
-    DictionaryAttr annotDict;
-    if (auto dict = annotation.dyn_cast<DictionaryAttr>())
-      annotDict = dict;
-    else
-      annotDict = annotation.cast<SubAnnotationAttr>().getAnnotations();
-    if (auto annotClass = annotDict.get("class"))
-      if (annotClass == className)
-        return annotDict;
+Annotation AnnotationSet::getAnnotationImpl(StringAttr className) const {
+  for (auto annotation : *this) {
+    if (annotation.getClassAttr() == className)
+      return annotation;
   }
   return {};
 }
 
-DictionaryAttr AnnotationSet::getAnnotationImpl(StringRef className) const {
-  for (auto annotation : annotations) {
-    DictionaryAttr annotDict;
-    if (auto dict = annotation.dyn_cast<DictionaryAttr>())
-      annotDict = dict;
-    else
-      annotDict = annotation.cast<SubAnnotationAttr>().getAnnotations();
-    if (auto annotClass = annotDict.get("class"))
-      if (auto annotClassString = annotClass.dyn_cast<StringAttr>())
-        if (annotClassString.getValue() == className)
-          return annotDict;
+Annotation AnnotationSet::getAnnotationImpl(StringRef className) const {
+  for (auto annotation : *this) {
+    if (annotation.getClass() == className)
+      return annotation;
   }
   return {};
 }
 
 bool AnnotationSet::hasAnnotationImpl(StringAttr className) const {
-  return getAnnotationImpl(className) != DictionaryAttr();
+  return getAnnotationImpl(className) != Annotation();
 }
 
 bool AnnotationSet::hasAnnotationImpl(StringRef className) const {
-  return getAnnotationImpl(className) != DictionaryAttr();
+  return getAnnotationImpl(className) != Annotation();
 }
 
 bool AnnotationSet::hasDontTouch() const {
@@ -336,19 +323,10 @@ bool AnnotationSet::removeAnnotations(
   if (!attr)
     return false;
 
-  // Return an Annotation built from an attribute which may be either a
-  // DictionaryAttr or a SubAnnotationAttr.
-  auto buildAnnotation = [](const Attribute *a) -> Annotation {
-    if (auto b = a->dyn_cast<DictionaryAttr>())
-      return Annotation(b);
-    else
-      return Annotation(a->cast<SubAnnotationAttr>().getAnnotations());
-  };
-
   // Search for the first match.
   ArrayRef<Attribute> annos = getArrayAttr().getValue();
   auto it = annos.begin();
-  while (it != annos.end() && !predicate(buildAnnotation(it)))
+  while (it != annos.end() && !predicate(Annotation(*it)))
     ++it;
 
   // Fast path for sets where the predicate never matched.
@@ -361,7 +339,7 @@ bool AnnotationSet::removeAnnotations(
   filteredAnnos.append(annos.begin(), it);
   ++it;
   while (it != annos.end()) {
-    if (!predicate(buildAnnotation(it)))
+    if (!predicate(Annotation(*it)))
       filteredAnnos.push_back(*it);
     ++it;
   }
@@ -423,9 +401,21 @@ bool AnnotationSet::removePortAnnotations(
 // Annotation
 //===----------------------------------------------------------------------===//
 
+DictionaryAttr Annotation::getDict() const {
+  if (auto subAnno = attr.dyn_cast<SubAnnotationAttr>())
+    return subAnno.getAnnotations();
+  return attr.cast<DictionaryAttr>();
+}
+
+unsigned Annotation::getFieldID() const {
+  if (auto subAnno = attr.dyn_cast<SubAnnotationAttr>())
+    return subAnno.getFieldID();
+  return 0;
+}
+
 /// Return the 'class' that this annotation is representing.
 StringAttr Annotation::getClassAttr() const {
-  return ((DictionaryAttr)attrDict).getAs<StringAttr>("class");
+  return getDict().getAs<StringAttr>("class");
 }
 
 /// Return the 'class' that this annotation is representing.
@@ -440,11 +430,7 @@ StringRef Annotation::getClass() const {
 //===----------------------------------------------------------------------===//
 
 Annotation AnnotationSetIterator::operator*() const {
-  auto attr = this->getBase().getArray()[this->getIndex()];
-  if (auto dictAttr = attr.dyn_cast<DictionaryAttr>())
-    return Annotation(dictAttr);
-  else
-    return Annotation(attr.cast<SubAnnotationAttr>().getAnnotations());
+  return Annotation(this->getBase().getArray()[this->getIndex()]);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -186,7 +186,7 @@ LogicalResult CreateSiFiveMetadataPass::emitMemoryMetadata() {
   auto dirAnno = annos.getAnnotation(metadataDirectoryAnnoClass);
   StringRef metadataDir = "metadata";
   if (dirAnno)
-    if (auto dir = dirAnno.getAs<StringAttr>("dirname"))
+    if (auto dir = dirAnno.getMember<StringAttr>("dirname"))
       metadataDir = dir.getValue();
 
   if (testBenchJsonBuffer != "[]") {
@@ -377,8 +377,7 @@ LogicalResult CreateSiFiveMetadataPass::emitSitestBlackboxMetadata() {
       continue;
 
     // If its a blacklisted scala class, skip it.
-    if (auto scalaAnnoDict = annos.getAnnotation(scalaClassAnnoClass)) {
-      Annotation scalaAnno(scalaAnnoDict);
+    if (auto scalaAnno = annos.getAnnotation(scalaClassAnnoClass)) {
       auto scalaClass = scalaAnno.getMember<StringAttr>("className");
       if (scalaClass &&
           llvm::is_contained(classBlackList, scalaClass.getValue()))

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -370,13 +370,14 @@ void GrandCentralTapsPass::runOnOperation() {
   // - Generate a body for the blackbox module with the signal mapping
 
   AnnotationSet circuitAnnotations(circuitOp);
-  if (auto dict = circuitAnnotations.getAnnotation(extractGrandCentralClass)) {
-    auto directory = dict.getAs<StringAttr>("directory");
+  if (auto extractAnno =
+          circuitAnnotations.getAnnotation(extractGrandCentralClass)) {
+    auto directory = extractAnno.getMember<StringAttr>("directory");
     if (!directory) {
       circuitOp->emitError()
           << "contained an invalid 'ExtractGrandCentralAnnotation' that does "
              "not contain a 'directory' field: "
-          << dict;
+          << extractAnno.getDict();
       return signalPassFailure();
     }
     maybeExtractDirectory = directory;

--- a/lib/Dialect/FIRRTL/Transforms/PrefixModules.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/PrefixModules.cpp
@@ -56,11 +56,10 @@ static PrefixInfo getPrefixInfo(Operation *module) {
   AnnotationSet annotations(module);
 
   // Get the annotation from the module.
-  auto dict = annotations.getAnnotation(
+  auto anno = annotations.getAnnotation(
       "sifive.enterprise.firrtl.NestedPrefixModulesAnnotation");
-  if (!dict)
+  if (!anno)
     return {"", false};
-  Annotation anno(dict);
 
   // Get the prefix from the annotation.
   StringRef prefix = "";


### PR DESCRIPTION
When an annotation targets only part of the thing it is attached to, it
is represented using a `SubAnnotationAttrs`, which contains the field ID
of its target.

The Annotation wrapper class can be only be created from a
DictionaryAttr.  When using a SubAnnotationAttr, it is created from its
internal DictionaryAttr, and the stored field ID is ignored. This makes
it impractical to use `SubAnnotationAttrs` with most of the Annotation
APIs.

This change makes it so the Annotation wrapper holds on to the original
annotation attribute, instead of just a DictionaryAttr.  The annotation
wrapper will check which kind of annotation it has internally when calls
are made.

This change then adds a call to `getFieldID`, which return 0 for regular
annotations, and the field id for `SubAnnotations`.

This also changes the equality comparison for two annotations: a
Annotation created from a SubAnnotationAttr will no longer be equal to a
regular annotation when the dictionary attribute is the same.