### PR TITLE
[FIRRTL] Fold pad(invalid, width) -> zero<width>

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -62,6 +62,9 @@ def IsInvalid : Constraint<
 def GetEmptyString : NativeCodeCall<
   "StringAttr::get($_builder.getContext(), {}) ">;
 
+def GetZeroConstant : NativeCodeCall<
+  "$_builder.create<ConstantOp>($0.getLoc(), APSInt($0.getType().cast<FIRRTLType>().getBitWidthOrSentinel()))">;
+
 // leq(const, x) -> geq(x, const)
 def LEQWithConstLHS : Pat<
   (LEQPrimOp (ConstantOp:$lhs $_), $rhs),
@@ -152,10 +155,10 @@ def SubWithInvalidOp : Pat<
     (KnownWidth $x), (IsInvalid $y)
   ]>;
 
-// pad(invalid, width) -> invalid
+// pad(invalid, width) -> zero<width>
 def PadInvalid : Pat<
-  (PadPrimOp (InvalidValueOp), $_),
-  (InvalidValueOp), []>;
+  (PadPrimOp:$result (InvalidValueOp), $_),
+  (GetZeroConstant $result), []>;
 
 ////////////////////////////////////////////////////////////////////////////////
 // DontTouch application

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2037,8 +2037,8 @@ firrtl.module @namedrop(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in
 // Issue #2197
 // CHECK-LABEL: @Issue2197
 firrtl.module @Issue2197(in %clock: !firrtl.clock, out %x: !firrtl.uint<2>) {
-  // CHECK: [[TMP:%.+]] = firrtl.invalidvalue : !firrtl.uint<2>
-  // CHECK-NEXT: firrtl.connect %x, [[TMP]] : !firrtl.uint<2>, !firrtl.uint<2>
+  // CHECK: [[ZERO:%.+]] = firrtl.constant 0 : !firrtl.uint<2>
+  // CHECK-NEXT: firrtl.connect %x, [[ZERO]] : !firrtl.uint<2>, !firrtl.uint<2>
   %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
   %reg = firrtl.reg %clock : !firrtl.uint<2>
   %0 = firrtl.pad %invalid_ui1, 2 : (!firrtl.uint<1>) -> !firrtl.uint<2>


### PR DESCRIPTION
Change the behavior of folding around pad, as discussed in #2197 and
implemented in #2198, to fold a pad of an invalid value to a constant
zero.  This prevents propagation of invalids which is generally viewed
as a source of errors.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>