### PR TITLE
[Moore] Specify -attrdefs-dialect when generating attributes, NFC.

### DIFF
--- a/include/circt/Dialect/Moore/CMakeLists.txt
+++ b/include/circt/Dialect/Moore/CMakeLists.txt
@@ -13,7 +13,9 @@ mlir_tablegen(MooreStructs.cpp.inc -gen-struct-attr-defs)
 add_public_tablegen_target(CIRCTMooreStructsIncGen)
 add_dependencies(circt-headers CIRCTMooreStructsIncGen)
 
-mlir_tablegen(MooreAttributes.h.inc -gen-attrdef-decls)
-mlir_tablegen(MooreAttributes.cpp.inc -gen-attrdef-defs)
+mlir_tablegen(MooreAttributes.h.inc -gen-attrdef-decls
+  -attrdefs-dialect MooreDialect)
+mlir_tablegen(MooreAttributes.cpp.inc -gen-attrdef-defs
+  -attrdefs-dialect MooreDialect)
 add_public_tablegen_target(CIRCTMooreAttributesIncGen)
 add_dependencies(circt-headers CIRCTMooreAttributesIncGen)


### PR DESCRIPTION
This flag appears to be needed to support an upcoming revision of
LLVM. Without this, TableGen complains with:

```
error: defs belonging to more than one dialect. Must select one via
'--(attr|type)defs-dialect'
```