### PR TITLE
[ExportVerilog] Implement `sv.namehint`

### DIFF
--- a/docs/VerilogGeneration.md
+++ b/docs/VerilogGeneration.md
@@ -145,6 +145,32 @@ of your pipeline should work well:
   exportVerilog(theModule, ...);
 ```
 
+## Signal naming
+
+ExportVerilog checks all signal (and instance) names for keyword conflicts and
+duplicated names. Whenever these conditions are encountered, ExportVerilog will
+change the name to avoid the conflict.
+
+### Ops with explicit names
+
+The `sv.reg` operation, `sv.wire` operation, and the various instance operations
+in the hw dialect have a `name` attribute which gets used.
+
+### Out-of-line expressions ("temporaries")
+
+Expressions are sometimes not emitted inlined (out-of-line) for a variety of
+reasons. These wire (or `automatic logic`) names or existence is **not
+guaranteed** to be stable. (Meaning they could change for *any* reason.) They,
+therefore, should not be relied upon for anything but local waveform debugging.
+In general, any name with prefixed with an underscore should not be relied upon.
+
+These names come from the following sources, listed here in proirity order:
+1. The `sv.namehint` dialect attribute (which can be attached to any operation).
+2. If ExportVerilog has a rule to derive a name based on the operation and
+operands, it will do so. (e.g. `hw.extract` operations get name
+`_<operandName>_<highBit>to<lowBit>` as of writing).
+3. `_T` or `_T_x` wherein `x` is a number.
+
 ## `exportVerilog` Internals
 
 It turns out that producing syntactically correct Verilog that is also pretty is

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -768,53 +768,59 @@ StringAttr EmitterBase::inferStructuralNameForTemporary(Value expr) {
   if (auto read = expr.getDefiningOp<ReadInOutOp>())
     return inferStructuralNameForTemporary(read.input());
 
-  // Generate a pretty name for VerbatimExpr's that look macro-like using the
-  // same logic that generates the MLIR syntax name.
-  if (auto verbatim = expr.getDefiningOp<VerbatimExprOp>()) {
-    verbatim.getAsmResultNames([&](Value, StringRef name) {
-      result = StringAttr::get(expr.getContext(), name);
-    });
-  }
-
-  if (auto verbatim = expr.getDefiningOp<VerbatimExprSEOp>()) {
-    verbatim.getAsmResultNames([&](Value, StringRef name) {
-      result = StringAttr::get(expr.getContext(), name);
-    });
-  }
-
   // Module ports carry names!
   if (auto blockArg = expr.dyn_cast<BlockArgument>()) {
     auto moduleOp = cast<HWModuleOp>(blockArg.getOwner()->getParentOp());
     StringRef name =
         state.globalNames.getPortVerilogName(moduleOp, blockArg.getArgNumber());
     result = StringAttr::get(expr.getContext(), name);
-  }
 
-  // Uses of a wire or register can be done inline.
-  if (auto *op = expr.getDefiningOp()) {
+  } else if (auto *op = expr.getDefiningOp()) {
+    // Uses of a wire or register can be done inline.
     if (isa<WireOp, RegOp>(op)) {
       StringRef name = state.globalNames.getDeclarationVerilogName(op);
       result = StringAttr::get(expr.getContext(), name);
+
+    } else if (auto nameHint = op->getAttrOfType<StringAttr>("sv.namehint")) {
+      // Use a dialect (sv) attribute to get a hint for the name if the op
+      // doesn't explicitly specify it. Do this last
+      result = nameHint;
+
+    } else {
+      TypeSwitch<Operation *>(op)
+          // Generate a pretty name for VerbatimExpr's that look macro-like
+          // using the same logic that generates the MLIR syntax name.
+          .Case([&result](VerbatimExprOp verbatim) {
+            verbatim.getAsmResultNames([&](Value, StringRef name) {
+              result = StringAttr::get(verbatim.getContext(), name);
+            });
+          })
+          .Case([&result](VerbatimExprSEOp verbatim) {
+            verbatim.getAsmResultNames([&](Value, StringRef name) {
+              result = StringAttr::get(verbatim.getContext(), name);
+            });
+          })
+
+          // If this is an extract from a namable object, derive a name from it.
+          .Case([&result, this](ExtractOp extract) {
+            if (auto operandName =
+                    inferStructuralNameForTemporary(extract.input())) {
+              unsigned numBits = extract.getType().getWidth();
+              if (numBits == 1)
+                result = StringAttr::get(extract.getContext(),
+                                         operandName.strref() + "_" +
+                                             Twine(extract.lowBit()));
+              else
+                result =
+                    StringAttr::get(extract.getContext(),
+                                    operandName.strref() + "_" +
+                                        Twine(extract.lowBit() + numBits - 1) +
+                                        "to" + Twine(extract.lowBit()));
+            }
+          });
+      // TODO: handle other common patterns.
     }
   }
-
-  // If this is an extract from a namable object, derive a name from it.
-  if (auto extract = expr.getDefiningOp<ExtractOp>()) {
-    if (auto operandName = inferStructuralNameForTemporary(extract.input())) {
-      unsigned numBits = extract.getType().getWidth();
-      if (numBits == 1)
-        result =
-            StringAttr::get(expr.getContext(), operandName.strref() + "_" +
-                                                   Twine(extract.lowBit()));
-      else
-        result = StringAttr::get(expr.getContext(),
-                                 operandName.strref() + "_" +
-                                     Twine(extract.lowBit() + numBits - 1) +
-                                     "to" + Twine(extract.lowBit()));
-    }
-  }
-
-  // TODO: handle other common patterns.
 
   // Make sure any synthesized name starts with an _.
   if (!result || result.strref().empty())
@@ -2219,19 +2225,10 @@ void NameCollector::collectNames(Block &block) {
         // Remember that this expression should be emitted out of line.
         moduleEmitter.outOfLineExpressions.insert(&op);
 
-        // Use a dialect (sv) attribute to get a hint for the name if all else
-        // fails.
-        auto nameAttr = op.getAttrOfType<StringAttr>("sv.namehint");
-        // Add '_' to namehint if it's not already there.
-        if (nameAttr && !nameAttr.getValue().startswith("_"))
-          nameAttr =
-              StringAttr::get(op.getContext(), "_" + nameAttr.getValue());
-
-        // If we don't have a specified pretty name, try to infer a name from
-        // the structure of the expression.
-        if (!nameAttr)
-          nameAttr = moduleEmitter.inferStructuralNameForTemporary(result);
-        names.addName(result, nameAttr);
+        // Get an explicitly set name or try to infer a name from the structure
+        // of the expression.
+        names.addName(result,
+                      moduleEmitter.inferStructuralNameForTemporary(result));
 
         // Don't measure or emit wires that are emitted inline (i.e. the wire
         // definition is emitted on the line of the expression instead of a

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -2219,12 +2219,13 @@ void NameCollector::collectNames(Block &block) {
         // Remember that this expression should be emitted out of line.
         moduleEmitter.outOfLineExpressions.insert(&op);
 
-        // Since this will be used out-of-line, we'll need a name for it.  If
-        // this expression has a random "name" attribute, keep track of it in
-        // case we end up spilling this.
-        // FIXME: This is highly unprincipled and should be removed.
-        //   https://github.com/llvm/circt/issues/1752
-        auto nameAttr = op.getAttrOfType<StringAttr>("name");
+        // Use a dialect (sv) attribute to get a hint for the name if all else
+        // fails.
+        auto nameAttr = op.getAttrOfType<StringAttr>("sv.namehint");
+        // Add '_' to namehint if it's not already there.
+        if (nameAttr && !nameAttr.getValue().startswith("_"))
+          nameAttr =
+              StringAttr::get(op.getContext(), "_" + nameAttr.getValue());
 
         // If we don't have a specified pretty name, try to infer a name from
         // the structure of the expression.

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -70,6 +70,9 @@ hw.module @TESTSIMPLE(%a: i4, %b: i4, %c: i2, %cond: i1,
   %subArr = hw.array_create %allone, %ab, %allone : i4
   %38 = hw.array_concat %subArr, %subArr : !hw.array<3 x i4>, !hw.array<3 x i4>
 
+  // Having "sv.namehint" (and checking that it works) anywhere will inherently
+  // make tests brittle. This line breaking does not mean your change is no
+  // good! You'll just have to find a new place for `sv.namehint`.
   %elem2d = hw.array_get %array2d[%a] { sv.namehint="array2d_idx_0_name" } : !hw.array<12 x array<10xi4>>
   %37 = hw.array_get %elem2d[%b] : !hw.array<10xi4>
 

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -70,7 +70,7 @@ hw.module @TESTSIMPLE(%a: i4, %b: i4, %c: i2, %cond: i1,
   %subArr = hw.array_create %allone, %ab, %allone : i4
   %38 = hw.array_concat %subArr, %subArr : !hw.array<3 x i4>, !hw.array<3 x i4>
 
-  %elem2d = hw.array_get %array2d[%a] : !hw.array<12 x array<10xi4>>
+  %elem2d = hw.array_get %array2d[%a] { sv.namehint="array2d_idx_0_name" } : !hw.array<12 x array<10xi4>>
   %37 = hw.array_get %elem2d[%b] : !hw.array<10xi4>
 
   %36 = comb.concat %a, %a, %a : i4, i4, i4
@@ -117,7 +117,7 @@ hw.module @TESTSIMPLE(%a: i4, %b: i4, %c: i2, %cond: i1,
 // CHECK-EMPTY:
 // CHECK-NEXT:   wire [8:0][3:0] [[WIRE0:.+]] = {{[{}][{}]}}4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}};
 // CHECK-NEXT:   wire [2:0][3:0] [[WIRE1:.+]] = {{[{}][{}]}}4'hF}, {a + b}, {4'hF}};
-// CHECK-NEXT:   wire [9:0][3:0] [[WIRE2:.+]] = array2d[a];
+// CHECK-NEXT:   wire [9:0][3:0] [[WIRE2:_array2d_idx_0_name]] = array2d[a];
 // CHECK-NEXT:   wire struct packed {logic [1:0] foo; logic [3:0] bar; } [[WIRE3:.+]] = '{foo: c, bar: a};
 // CHECK-NEXT:   assign r0 = a + b;
 // CHECK-NEXT:   assign r2 = a - b;


### PR DESCRIPTION
Use `sv.namehint` instead of just `name` in ExportVerilog. Updated rationale. Closes #1752.