### PR TITLE
[Handshake] Add buffer removal pass

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakePasses.h
+++ b/include/circt/Dialect/Handshake/HandshakePasses.h
@@ -27,6 +27,7 @@ createHandshakeDotPrintPass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
 createHandshakeOpCountPass();
 std::unique_ptr<mlir::Pass> createHandshakeMaterializeForksSinksPass();
+std::unique_ptr<mlir::Pass> createHandshakeRemoveBuffersPass();
 
 /// Iterates over the handshake::FuncOp's in the program to build an instance
 /// graph. In doing so, we detect whether there are any cycles in this graph, as

--- a/include/circt/Dialect/Handshake/HandshakePasses.td
+++ b/include/circt/Dialect/Handshake/HandshakePasses.td
@@ -44,4 +44,13 @@ def HandshakeMaterializeForksSinks : Pass<"handshake-materialize-forks-sinks", "
   let constructor = "circt::handshake::createHandshakeMaterializeForksSinksPass()";
 }
 
+def HandshakeRemoveBuffers : Pass<"handshake-remove-buffers", "handshake::FuncOp"> {
+  let summary = "Remove buffers from handshake functions.";
+  let description = [{
+    This pass analyses a handshake.func operation and removes any buffers from
+    the function.
+  }];
+  let constructor = "circt::handshake::createHandshakeRemoveBuffersPass()";
+}
+
 #endif // CIRCT_DIALECT_HANDSHAKE_HANDSHAKEPASSES_TD

--- a/lib/Dialect/Handshake/Transforms/Buffers.cpp
+++ b/lib/Dialect/Handshake/Transforms/Buffers.cpp
@@ -1,0 +1,55 @@
+//===- Buffers.cpp - buffer materialization passes --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Contains the definitions of buffer materialization passes.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/Handshake/HandshakeOps.h"
+#include "circt/Dialect/Handshake/HandshakePasses.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Rewrite/FrozenRewritePatternSet.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+using namespace circt;
+using namespace handshake;
+using namespace mlir;
+
+namespace {
+
+struct RemoveHandshakeBuffers : public OpRewritePattern<handshake::BufferOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(handshake::BufferOp bufferOp,
+                                PatternRewriter &rewriter) const override {
+    rewriter.replaceOp(bufferOp, bufferOp.operand());
+    return success();
+  }
+};
+
+struct HandshakeRemoveBuffersPass
+    : public HandshakeRemoveBuffersBase<HandshakeRemoveBuffersPass> {
+  void runOnOperation() override {
+    handshake::FuncOp op = getOperation();
+    ConversionTarget target(getContext());
+    target.addIllegalOp<handshake::BufferOp>();
+    RewritePatternSet patterns(&getContext());
+    patterns.insert<RemoveHandshakeBuffers>(&getContext());
+
+    if (failed(applyPartialConversion(op, target, std::move(patterns))))
+      signalPassFailure();
+  };
+};
+
+} // namespace
+
+std::unique_ptr<mlir::Pass>
+circt::handshake::createHandshakeRemoveBuffersPass() {
+  return std::make_unique<HandshakeRemoveBuffersPass>();
+}

--- a/lib/Dialect/Handshake/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Handshake/Transforms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_circt_dialect_library(CIRCTHandshakeTransforms
   Analysis.cpp
   PassHelpers.cpp
   Materialization.cpp
+  Buffers.cpp
 
   DEPENDS
   CIRCTHandshakeTransformsIncGen

--- a/test/Dialect/Handshake/remove_buffers.mlir
+++ b/test/Dialect/Handshake/remove_buffers.mlir
@@ -1,0 +1,15 @@
+// RUN: circt-opt --split-input-file --handshake-remove-buffers %s | FileCheck %s
+
+// CHECK-LABEL:   handshake.func @simple_c(
+// CHECK-SAME:                             %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: none, ...) -> (i32, none)
+// CHECK:           %[[VAL_3:.*]] = arith.addi %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           return %[[VAL_3]], %[[VAL_2]] : i32, none
+// CHECK:         }
+handshake.func @simple_c(%arg0: i32, %arg1: i32, %arg2: none) -> (i32, none) {
+  %0 = buffer [2] %arg0 {sequential = true} : i32
+  %1 = buffer [2] %arg1 {sequential = true} : i32
+  %2 = arith.addi %0, %1 : i32
+  %3 = buffer [2] %2 {sequential = true} : i32
+  %4 = buffer [2] %arg2 {sequential = true} : none
+  return %3, %4 : i32, none
+}


### PR DESCRIPTION
A very simple pass which removes any buffers present in the circuit. This pass can come in handy if:
1. one would like to re-buffer a circuit
2. one would like to simulate without buffers
3. one would like to simplify the circuit (for visual/.dot inspection)