### PR TITLE
[FIRRTL/ExpandWhens] Support vector types

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -155,6 +155,7 @@ public:
         return;
       }
 
+      // If this is a vector type, recurse to each of the elements.
       if (auto vectorType = type.dyn_cast<FVectorType>()) {
         for (unsigned i = 0; i < vectorType.getNumElements(); ++i) {
           id++;

--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -155,6 +155,14 @@ public:
         return;
       }
 
+      if (auto vectorType = type.dyn_cast<FVectorType>()) {
+        for (unsigned i = 0; i < vectorType.getNumElements(); ++i) {
+          id++;
+          declare(vectorType.getElementType(), flow);
+        }
+        return;
+      }
+
       // If this is an analog type, it does not need to be tracked.
       if (auto analogType = type.dyn_cast<AnalogType>())
         return;

--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -206,8 +206,10 @@ public:
   void visitDecl(RegResetOp op) {
     // Registers are initialized to themselves.
     // TODO: register of aggregate types are not supported.
-    assert(op.result().getType().cast<FIRRTLType>().isGround() &&
-           "registers can't be aggregate type");
+    if (!op.getType().cast<FIRRTLType>().isGround()) {
+      op.emitError() << "aggegate type register is not supported";
+      return;
+    }
     auto connect = OpBuilder(op->getBlock(), ++Block::iterator(op))
                        .create<ConnectOp>(op.getLoc(), op, op);
     driverMap[getFieldRefFromValue(op.result())] = connect;

--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -193,7 +193,11 @@ public:
 
   void visitDecl(RegOp op) {
     // Registers are initialized to themselves.
-    // TODO: register of bundle type are not supported.
+    // TODO: register of aggregate types are not supported.
+    if (!op.getType().cast<FIRRTLType>().isGround()) {
+      op.emitError() << "aggegate type register is not supported";
+      return;
+    }
     auto connect = OpBuilder(op->getBlock(), ++Block::iterator(op))
                        .create<ConnectOp>(op.getLoc(), op, op);
     driverMap[getFieldRefFromValue(op.result())] = connect;
@@ -201,9 +205,11 @@ public:
 
   void visitDecl(RegResetOp op) {
     // Registers are initialized to themselves.
-    // TODO: register of bundle type are not supported.
-    assert(!op.result().getType().isa<BundleType>() &&
-           "registers can't be bundle type");
+    // TODO: register of aggregate types are not supported.
+    if (!op.getType().cast<FIRRTLType>().isGround()) {
+      op.emitError() << "aggegate type register is not supported";
+      return;
+    }
     auto connect = OpBuilder(op->getBlock(), ++Block::iterator(op))
                        .create<ConnectOp>(op.getLoc(), op, op);
     driverMap[getFieldRefFromValue(op.result())] = connect;

--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -206,10 +206,8 @@ public:
   void visitDecl(RegResetOp op) {
     // Registers are initialized to themselves.
     // TODO: register of aggregate types are not supported.
-    if (!op.getType().cast<FIRRTLType>().isGround()) {
-      op.emitError() << "aggegate type register is not supported";
-      return;
-    }
+    assert(op.result().getType().cast<FIRRTLType>().isGround() &&
+           "registers can't be aggregate type");
     auto connect = OpBuilder(op->getBlock(), ++Block::iterator(op))
                        .create<ConnectOp>(op.getLoc(), op, op);
     driverMap[getFieldRefFromValue(op.result())] = connect;

--- a/test/Dialect/FIRRTL/expand-whens-errors.mlir
+++ b/test/Dialect/FIRRTL/expand-whens-errors.mlir
@@ -115,6 +115,7 @@ firrtl.module @CheckInitialization(in %in : !firrtl.uint<1>, out %out : !firrtl.
 }
 
 // -----
+
 firrtl.circuit "CheckInitialization" {
 firrtl.module @CheckInitialization(in %in : !firrtl.uint<1>, out %out : !firrtl.vector<vector<uint<1>, 1>, 1>) {
   // expected-error @-1 {{sink "out[0][0]" not fully initialized}}
@@ -122,6 +123,7 @@ firrtl.module @CheckInitialization(in %in : !firrtl.uint<1>, out %out : !firrtl.
 }
 
 // -----
+
 firrtl.circuit "CheckInitialization" {
 firrtl.module @CheckInitialization(in %p : !firrtl.uint<1>, out %out: !firrtl.vector<bundle<a:uint<1>, b:uint<1>>, 1>) {
   // expected-error @-1 {{sink "out[0].a" not fully initialized}}

--- a/test/Dialect/FIRRTL/expand-whens-errors.mlir
+++ b/test/Dialect/FIRRTL/expand-whens-errors.mlir
@@ -86,3 +86,44 @@ firrtl.module @complex(in %p : !firrtl.uint<1>, in %q : !firrtl.uint<1>) {
 }
 
 }
+
+// -----
+
+firrtl.circuit "CheckInitialization" {
+firrtl.module @CheckInitialization(out %out : !firrtl.vector<uint<1>, 1>) {
+  // expected-error @-1 {{sink "out[0]" not fully initialized}}
+}
+}
+
+// -----
+
+firrtl.circuit "CheckInitialization" {
+firrtl.module @CheckInitialization() {
+  // expected-error @+1 {{sink "w[0]" not fully initialized}}
+  %w = firrtl.wire : !firrtl.vector<uint<1>, 2>
+}
+}
+
+// -----
+
+firrtl.circuit "CheckInitialization" {
+firrtl.module @CheckInitialization(in %in : !firrtl.uint<1>, out %out : !firrtl.vector<uint<1>, 2>) {
+  // expected-error @-1 {{sink "out[1]" not fully initialized}}
+  %0 = firrtl.subindex %out[0] : !firrtl.vector<uint<1>, 2>
+  firrtl.connect %0, %in : !firrtl.uint<1>, !firrtl.uint<1>
+}
+}
+
+// -----
+firrtl.circuit "CheckInitialization" {
+firrtl.module @CheckInitialization(in %in : !firrtl.uint<1>, out %out : !firrtl.vector<vector<uint<1>, 1>, 1>) {
+  // expected-error @-1 {{sink "out[0][0]" not fully initialized}}
+}
+}
+
+// -----
+firrtl.circuit "CheckInitialization" {
+firrtl.module @CheckInitialization(in %p : !firrtl.uint<1>, out %out: !firrtl.vector<bundle<a:uint<1>, b:uint<1>>, 1>) {
+  // expected-error @-1 {{sink "out[0].a" not fully initialized}}
+}
+}

--- a/test/Dialect/FIRRTL/expand-whens-errors.mlir
+++ b/test/Dialect/FIRRTL/expand-whens-errors.mlir
@@ -127,3 +127,12 @@ firrtl.module @CheckInitialization(in %p : !firrtl.uint<1>, out %out: !firrtl.ve
   // expected-error @-1 {{sink "out[0].a" not fully initialized}}
 }
 }
+
+// -----
+
+firrtl.circuit "CheckInitialization" {
+firrtl.module @CheckInitialization(in %clock: !firrtl.clock) {
+  // expected-error @+1 {{aggegate type register is not supported}}
+  %reg0 = firrtl.reg %clock : !firrtl.vector<uint<1>, 1>
+}
+}

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -405,4 +405,61 @@ firrtl.module @analog(out %analog : !firrtl.analog<1>) {
   firrtl.connect %w_a, %c1 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
+// CHECK-LABEL: @vector_simple
+firrtl.module @vector_simple(in %clock: !firrtl.clock, out %ret: !firrtl.vector<uint<1>, 1>) {
+  %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+  %0 = firrtl.subindex %ret[0] : !firrtl.vector<uint<1>, 1>
+  firrtl.connect %0, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %0, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK:      %0 = firrtl.subindex %ret[0] : !firrtl.vector<uint<1>, 1>
+  // CHECK-NEXT: firrtl.connect %0, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1
+}
+
+// CHECK-LABEL: @shadow_when_vector
+firrtl.module @shadow_when_vector(in %p : !firrtl.uint<1>) {
+  %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
+  %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
+  firrtl.when %p {
+    %w = firrtl.wire : !firrtl.vector<uint<2>, 1>
+    %0 = firrtl.subindex %w[0] : !firrtl.vector<uint<2>, 1>
+    firrtl.connect %0, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
+    firrtl.connect %0, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
+  }
+  // CHECK:      %w = firrtl.wire  : !firrtl.vector<uint<2>, 1>
+  // CHECK-NEXT: %0 = firrtl.subindex %w[0] : !firrtl.vector<uint<2>, 1>
+  // CHECK-NEXT: firrtl.connect %0, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
+}
+
+// CHECK-LABEL: @multi_dim_vector
+firrtl.module @multi_dim_vector(in %p : !firrtl.uint<1>) {
+  %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
+  %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
+  %w = firrtl.wire : !firrtl.vector<vector<uint<2>, 2>, 1>
+  %0 = firrtl.subindex %w[0] : !firrtl.vector<vector<uint<2>, 2>, 1>
+  %1 = firrtl.subindex %0[0] : !firrtl.vector<uint<2>, 2>
+  %2 = firrtl.subindex %0[1] : !firrtl.vector<uint<2>, 2>
+  firrtl.when %p {
+    firrtl.connect %1, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
+    firrtl.connect %2, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
+  } else {
+    firrtl.connect %1, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
+    firrtl.connect %2, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
+  }
+  // CHECK:      [[MUX1:%.*]] = firrtl.mux(%p, %c0_ui2, %c1_ui2) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
+  // CHECK-NEXT: firrtl.connect %1, [[MUX1]] : !firrtl.uint<2>, !firrtl.uint<2>
+  // CHECK-NEXT: [[MUX2:%.*]] = firrtl.mux(%p, %c1_ui2, %c0_ui2) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
+  // CHECK-NEXT: firrtl.connect %2, [[MUX2]] : !firrtl.uint<2>, !firrtl.uint<2>
+}
+
+// CHECK-LABEL: @vector_of_bundle
+firrtl.module @vector_of_bundle(in %p : !firrtl.uint<1>, out %ret: !firrtl.vector<bundle<a:uint<1>>, 1>) {
+  %0 = firrtl.subindex %ret[0] : !firrtl.vector<bundle<a:uint<1>>, 1>
+  %1 = firrtl.subfield %0(0) : (!firrtl.bundle<a:uint<1>>) -> !firrtl.uint<1>
+  %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+  firrtl.connect %1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %1, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK: firrtl.connect %1, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+}
 }

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -460,6 +460,7 @@ firrtl.module @vector_of_bundle(in %p : !firrtl.uint<1>, out %ret: !firrtl.vecto
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   firrtl.connect %1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %1, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.connect %1, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK-NOT: firrtl.connect %1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK:     firrtl.connect %1, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 }


### PR DESCRIPTION
This commit changes expandWhens to accept vector types under the condition that connections are expanded, i.e. all the connections are between ground types.
I changed `declareSinks` to handle vector types and diff is very small thanks to FieldRef implementation. 

