### PR TITLE
[FIRRTL] Canonicalize Invalid Connect to Zero

### DIFF
--- a/test/Dialect/FIRRTL/SFCTests/invalid-interpretations.fir
+++ b/test/Dialect/FIRRTL/SFCTests/invalid-interpretations.fir
@@ -1,0 +1,44 @@
+; RUN: firtool -split-input-file -verilog %s | FileCheck %s
+
+; This test checks end-to-end compliance with the Scala FIRRTL Compiler (SFC)
+; context-sensitive interpretation of invalid.
+
+; CHECK-LABEL: module InvalidInterpretations
+circuit InvalidInterpretations:
+  module InvalidInterpretations:
+    input clock: Clock
+    input reset: UInt<1>
+    input cond: UInt<1>
+    input a: UInt<8>
+    output out_when: UInt<8>
+    output out_validif: UInt<8>
+    output out_reg: UInt<8>
+    output out_mux: UInt<8>
+    output out_add: UInt<9>
+
+    wire inv: UInt<8>
+    inv is invalid
+
+    reg r: UInt<8>, clock with : (reset => (reset, inv))
+    r <= a
+    out_reg <= r
+    ; Interpretation 1: Invalid is undefined if used as the initialization value
+    ; of a register in a module-scoped analysis that looks through connects.
+    ; CHECK:       always @(posedge clock)
+    ; CHECK-NOT:     if (reset)
+
+    out_when is invalid
+    when cond:
+      out_when <= a
+    ; Interpretation 2: Invalid is undefined when used as a default value.
+    ; CHECK:       assign out_when = a;
+
+    out_validif <= validif(cond, a)
+    ; Interpretation 3: Invalid is undefined as the false leg of a validif.
+    ; CHECK:       assign out_validif = a;
+
+    out_mux <= mux(cond, a, inv)
+    out_add <= add(a, inv)
+    ; Interpretation 4: Invalid is zero otherwise.
+    ; CHECK:       assign out_mux = cond ? a : 8'h0;
+    ; CHECK-NEXT:  assign out_add = {1'h0, a};


### PR DESCRIPTION
This depends on and includes #2287 which adds a `RemoveResets` pass which then makes this aggressive canonicalization legal.

- [FIRRTL] Canonicalize Invalid Connects to Zero

Extend the behavior of connect canonicalization to convert a connection
to an InvalidValueOp to a connect to zero.  This is done to enforce
compliance with one Scala FIRRTL Compiler (SFC) interpretation of
"invalid is constant zero".

This change requires a RemoveResets pass (#2287) to run before the
canonicalization that this PR adds.  This is because registers require a
separate interpretation of invalid where "invalid is undefined when used
as the initialization value of a register" (and where invalidness is
determined by looking through wires/connects in the current module).
This latter, "register initialization" interpretation needs to run
before invalids are fully removed by the code added in this commit.

- [FIRRTL] Test SFC invalid behaviors, NFC

Add an end-to-end test of firtool that checks for compliance with the
multiple Scala FIRRTL Compiler (SFC) interpretations of invalid.  This
test is added to lock in behavior around invalid as this is known to
cause formal equivalence failures, e.g., if a register has a reset in
CIRCT, but does not in the SFC formal equivalence will rightly complain.
This test can likely be removed or weakened once better semantics for
invalid value are defined other than "whatever the SFC does".