### PR TITLE
[FIRRTL] Fix SubPrimOp canonicalization bug

### DIFF
--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2259,4 +2259,21 @@ firrtl.module @Issue2251(out %o: !firrtl.sint<15>) {
   // CHECK-NEXT: firrtl.connect %o, %[[zero]]
 }
 
+// Issue mentioned in #2289
+// CHECK-LABEL: @Issue2289
+firrtl.module @Issue2289(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %out: !firrtl.uint<5>) {
+  %r = firrtl.reg %clock  : !firrtl.uint<1>
+  firrtl.connect %r, %r : !firrtl.uint<1>, !firrtl.uint<1>
+  %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
+  %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+  %0 = firrtl.dshl %c1_ui1, %r : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
+  %1 = firrtl.sub %c0_ui4, %0 : (!firrtl.uint<4>, !firrtl.uint<2>) -> !firrtl.uint<5>
+  firrtl.connect %out, %1 : !firrtl.uint<5>, !firrtl.uint<5>
+  // CHECK:      %[[dshl:.+]] = firrtl.dshl
+  // CHECK-NEXT: %[[neg:.+]] = firrtl.neg %[[dshl]]
+  // CHECK-NEXT: %[[pad:.+]] = firrtl.pad %[[neg]], 5
+  // CHECK-NEXT: %[[cast:.+]] = firrtl.asUInt %[[pad]]
+  // CHECK-NEXT: firrtl.connect %out, %[[cast]]
+}
+
 }


### PR DESCRIPTION
Fix a bug in SubPrimOp canonicalization where an asUInt cast was applied
before the pad inside a utility method.  This commit changes the utility
method to apply a cast (either asUInt or asSInt) if needed.

Fixes #2289.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>