### PR TITLE
[Handshake] Add pass to add unique IDs to each operation

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakePasses.h
+++ b/include/circt/Dialect/Handshake/HandshakePasses.h
@@ -28,6 +28,7 @@ std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
 createHandshakeOpCountPass();
 std::unique_ptr<mlir::Pass> createHandshakeMaterializeForksSinksPass();
 std::unique_ptr<mlir::Pass> createHandshakeRemoveBuffersPass();
+std::unique_ptr<mlir::Pass> createHandshakeAddIDsPass();
 
 /// Iterates over the handshake::FuncOp's in the program to build an instance
 /// graph. In doing so, we detect whether there are any cycles in this graph, as

--- a/include/circt/Dialect/Handshake/HandshakePasses.td
+++ b/include/circt/Dialect/Handshake/HandshakePasses.td
@@ -53,4 +53,14 @@ def HandshakeRemoveBuffers : Pass<"handshake-remove-buffers", "handshake::FuncOp
   let constructor = "circt::handshake::createHandshakeRemoveBuffersPass()";
 }
 
+def HandshakeAddIDs : Pass<"handshake-add-ids", "handshake::FuncOp"> {
+  let summary = "Add a unique ID to each operation in a handshake function.";
+  let description = [{
+    This pass adds a unique ID to each operation in a handshake function. This
+    unique id can be used in lowerings facilitate mapping lowered IR back to the
+    handshake code which it originated from.
+  }];
+  let constructor = "circt::handshake::createHandshakeAddIDsPass()";
+}
+
 #endif // CIRCT_DIALECT_HANDSHAKE_HANDSHAKEPASSES_TD

--- a/include/circt/Dialect/Handshake/HandshakePasses.td
+++ b/include/circt/Dialect/Handshake/HandshakePasses.td
@@ -54,11 +54,14 @@ def HandshakeRemoveBuffers : Pass<"handshake-remove-buffers", "handshake::FuncOp
 }
 
 def HandshakeAddIDs : Pass<"handshake-add-ids", "handshake::FuncOp"> {
-  let summary = "Add a unique ID to each operation in a handshake function.";
+  let summary = "Add an ID to each operation in a handshake function.";
   let description = [{
-    This pass adds a unique ID to each operation in a handshake function. This
-    unique id can be used in lowerings facilitate mapping lowered IR back to the
-    handshake code which it originated from.
+    This pass adds an ID to each operation in a handshake function. This id can
+    be used in lowerings facilitate mapping lowered IR back to the handshake code
+    which it originated from. An ID is unique with respect to other operations
+    of the same type in the function. The tuple of the operation name and the
+    operation ID denotes a unique identifier for the operation within the
+    `handshake.func` operation.
   }];
   let constructor = "circt::handshake::createHandshakeAddIDsPass()";
 }

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -2405,8 +2405,18 @@ struct HandshakeFuncOpLowering : public OpConversionPattern<handshake::FuncOp> {
 
     NameUniquer instanceUniquer = [&](Operation *op) {
       std::string instName = getInstanceName(op);
-      unsigned id = instanceNameCntr[instName]++;
-      return instName + std::to_string(id);
+
+      if (auto idAttr = op->getAttrOfType<IntegerAttr>("handshake_id");
+          idAttr) {
+        // We use a special naming convention for operations which have a
+        // 'handshake_id' attribute.
+        instName += "_id" + std::to_string(idAttr.getValue().getZExtValue());
+      } else {
+        // Fallback to just prefixing with an integer.
+        instName += std::to_string(instanceNameCntr[instName]++);
+      }
+
+      return instName;
     };
 
     // Traverse and convert each operation in funcOp.

--- a/lib/Dialect/Handshake/Transforms/Analysis.cpp
+++ b/lib/Dialect/Handshake/Transforms/Analysis.cpp
@@ -147,7 +147,8 @@ static std::string dotPrintNode(mlir::raw_indented_ostream &outfile,
   std::string opName = (instanceName + "." + opDialectName).str();
 
   // Follow the naming convention used in FIRRTL lowering.
-  if (auto idAttr = op->getAttrOfType<IntegerAttr>("handshake_id"); idAttr)
+  auto idAttr = op->getAttrOfType<IntegerAttr>("handshake_id");
+  if (idAttr)
     opName += "_id" + std::to_string(idAttr.getValue().getZExtValue());
   else
     opName += std::to_string(opIDs[op]);
@@ -230,6 +231,12 @@ static std::string dotPrintNode(mlir::raw_indented_ostream &outfile,
 
                    return label;
                  });
+  /// If we have an ID attribute, we'll add the ID of the operation as well.
+  /// This helps crossprobing the diagram with the Handshake IR and waveform
+  /// diagrams.
+  if (idAttr)
+    outfile << " " << std::to_string(idAttr.getValue().getZExtValue());
+
   outfile << "\"";
 
   /// Style; add dashed border for control nodes

--- a/test/Dialect/Handshake/add-ids.mlir
+++ b/test/Dialect/Handshake/add-ids.mlir
@@ -1,0 +1,18 @@
+// RUN: circt-opt -split-input-file --handshake-add-ids %s | FileCheck %s
+
+// CHECK: handshake.func @simple_c(%arg0: i32, %arg1: i32, %arg2: none, ...) -> (i32, none) attributes {argNames = ["arg0", "arg1", "arg2"], handshake_id = 0 : index, resNames = ["out0", "outCtrl"]} {
+// CHECK:   %0 = buffer [2] %arg0 {handshake_id = 0 : index, sequential = true} : i32
+// CHECK:   %1 = buffer [2] %arg1 {handshake_id = 1 : index, sequential = true} : i32
+// CHECK:   %2 = arith.addi %0, %1 {handshake_id = 0 : index} : i32
+// CHECK:   %3 = buffer [2] %2 {handshake_id = 2 : index, sequential = true} : i32
+// CHECK:   %4 = buffer [2] %arg2 {handshake_id = 3 : index, sequential = true} : none
+// CHECK:   return %3, %4 {handshake_id = 0 : index} : i32, none
+// CHECK: }
+handshake.func @simple_c(%arg0: i32, %arg1: i32, %arg2: none) -> (i32, none) {
+  %0 = buffer [2] %arg0 {sequential = true} : i32
+  %1 = buffer [2] %arg1 {sequential = true} : i32
+  %2 = arith.addi %0, %1 : i32
+  %3 = buffer [2] %2 {sequential = true} : i32
+  %4 = buffer [2] %arg2 {sequential = true} : none
+  return %3, %4 : i32, none
+}


### PR DESCRIPTION
This commit introduces a new pass `--handshake-add-ids` which will add a unique ID to each operation, with respect to other equivalent operations within a `handshake.func` operation. When present, these IDs are used in both .dot graph printing and FIRRTL instance name generation.
Having this provides a deterministic method of tracing back FIRRTL modules to handshake IR or the .dot file, which is the tuple of the operation name + the operation id.