### PR TITLE
[HandshakeToFIRRTL] Rework mux tree generation

### DIFF
--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -424,9 +424,10 @@ static Value createMuxTree(ArrayRef<Value> inputs, Value select,
   std::function<Value(ArrayRef<Value>)> buildTreeRec =
       [&](ArrayRef<Value> operands) {
         assert(!operands.empty());
+        Value retVal;
         // Base case
         if (operands.size() == 1)
-          return operands.front();
+          retVal = operands.front();
         else {
           // Mux case. In each layer we take a look at the significant bit wrt.
           // the # of operands provided, and split the operands at the log2
@@ -440,11 +441,12 @@ static Value createMuxTree(ArrayRef<Value> inputs, Value select,
           auto lowerTree = buildTreeRec(front);
           auto upperTree = buildTreeRec(back);
           auto layerSelect = createBits(select, selectBit);
-          return rewriter
-              .create<MuxPrimOp>(insertLoc, muxDataType, layerSelect, upperTree,
-                                 lowerTree)
-              .result();
+          retVal = rewriter
+                       .create<MuxPrimOp>(insertLoc, muxDataType, layerSelect,
+                                          upperTree, lowerTree)
+                       .result();
         }
+        return retVal;
       };
 
   return buildTreeRec(inputs);

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -406,68 +406,48 @@ static std::string getSubModuleName(Operation *oldOp) {
   return subModuleName;
 }
 
+static std::pair<ArrayRef<Value>, ArrayRef<Value>>
+splitArrayRef(ArrayRef<Value> ref, unsigned pos) {
+  return {ref.take_front(pos), ref.drop_front(pos)};
+}
+
 /// Construct a tree of 1-bit muxes to multiplex arbitrary numbers of signals
 /// using a binary-encoded select value.
 static Value createMuxTree(ArrayRef<Value> inputs, Value select,
                            Location insertLoc,
                            ConversionPatternRewriter &rewriter) {
-  // Variables used to control iteration and select the appropriate bit.
-  size_t numInputs = inputs.size();
-  size_t numLayers = getNumIndexBits(numInputs);
-  size_t selectIdx = 0;
-
-  // Keep a vector of ValueRanges to represent the mux tree. Each value in the
-  // range is the output of a mux.
-  SmallVector<SmallVector<Value, 4>, 2> muxes;
-
-  // Helpers for repetetive calls.
+  Type muxDataType = inputs[0].getType();
   auto createBits = [&](Value select, size_t idx) {
     return rewriter.create<BitsPrimOp>(insertLoc, select, idx, idx);
   };
 
-  auto createMux = [&](Value select, ArrayRef<Value> operands, size_t idx) {
-    return rewriter.create<MuxPrimOp>(insertLoc, operands[0].getType(), select,
-                                      operands[idx + 1], operands[idx]);
-  };
+  std::function<Value(ArrayRef<Value>)> buildTreeRec =
+      [&](ArrayRef<Value> operands) {
+        assert(!operands.empty());
+        // Base case
+        if (operands.size() == 1)
+          return operands.front();
+        else {
+          // Mux case. In each layer we take a look at the significant bit wrt.
+          // the # of operands provided, and split the operands at the log2
+          // boundary. By doing so, every subsequent layer can the ignore the
+          // MSBs considered by its preceding layer.
+          unsigned selectBit = llvm::Log2_64_Ceil(operands.size()) - 1;
+          // Split the operands at the selected index
+          unsigned splitIdx = 1 << selectBit;
 
-  // Create an op to extract the least significant select bit.
-  auto selectBit = createBits(select, selectIdx);
+          auto [front, back] = splitArrayRef(operands, splitIdx);
+          auto lowerTree = buildTreeRec(front);
+          auto upperTree = buildTreeRec(back);
+          auto layerSelect = createBits(select, selectBit);
+          return rewriter
+              .create<MuxPrimOp>(insertLoc, muxDataType, layerSelect, upperTree,
+                                 lowerTree)
+              .result();
+        }
+      };
 
-  // Create the first layer of muxes for the inputs.
-  auto &initialValues = muxes.emplace_back();
-  for (size_t i = 0; i < numInputs - 1; i += 2)
-    initialValues.push_back(createMux(selectBit, inputs, i));
-
-  // If the number of inputs is odd, we need to add the last input as well.
-  if (numInputs % 2)
-    initialValues.push_back(inputs[numInputs - 1]);
-
-  // Create any inner layers of muxes.
-  for (size_t layer = 1; layer < numLayers; ++layer, ++selectIdx) {
-    // Get the previous layer of muxes.
-    auto &prevLayer = muxes[layer - 1];
-    size_t prevSize = prevLayer.size();
-
-    // Create an op to extract the select bit.
-    selectBit = createBits(select, selectIdx);
-
-    // Create this layer of muxes.
-    auto &values = muxes.emplace_back();
-    for (size_t i = 0; i < prevSize - 1; i += 2)
-      values.push_back(createMux(selectBit, prevLayer, i));
-
-    // If the number of values in the previous layer is odd, we need to add the
-    // last value as well.
-    if (prevSize % 2)
-      values.push_back(prevLayer[prevSize - 1]);
-
-    muxes.push_back(values);
-  }
-
-  // Get the last layer of muxes, which has a single value, and return it.
-  auto &lastLayer = muxes.back();
-  assert(lastLayer.size() == 1 && "mux tree didn't result in a single value");
-  return lastLayer[0];
+  return buildTreeRec(inputs);
 }
 
 /// Construct a tree of 1-bit muxes to multiplex arbitrary numbers of signals

--- a/test/Conversion/HandshakeToFIRRTL/test_mux.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_mux.mlir
@@ -73,9 +73,9 @@ handshake.func @test_mux_3way(%arg0: index, %arg1: index, %arg2: index, %arg3: i
 // CHECK: %[[RESULT:.+]] = firrtl.subfield %[[VAL_9]](2)
 // CHECK: %[[MUX1:.+]] = firrtl.mux({{.+}}, %[[DATA2]], %[[DATA1]])
 // CHECK: %[[MUX2:.+]] = firrtl.mux({{.+}}, %[[DATA4]], %[[DATA3]])
+// CHECK: %[[MUX5:.+]] = firrtl.mux({{.+}}, %[[MUX2]], %[[MUX1]])
 // CHECK: %[[MUX3:.+]] = firrtl.mux({{.+}}, %[[DATA6]], %[[DATA5]])
 // CHECK: %[[MUX4:.+]] = firrtl.mux({{.+}}, %[[DATA8]], %[[DATA7]])
-// CHECK: %[[MUX5:.+]] = firrtl.mux({{.+}}, %[[MUX2]], %[[MUX1]])
 // CHECK: %[[MUX6:.+]] = firrtl.mux({{.+}}, %[[MUX4]], %[[MUX3]])
 // CHECK: %[[MUX7:.+]] = firrtl.mux({{.+}}, %[[MUX6]], %[[MUX5]])
 // CHECK: firrtl.connect %[[RESULT]], %[[MUX7]]
@@ -105,6 +105,7 @@ handshake.func @test_mux_5way(%arg0: index, %arg1: index, %arg2: index, %arg3: i
   return %0, %arg6 : index, none
 }
 
+
 // -----
 
 // Test a mux tree with multiple layers and a partial first layer (even).
@@ -119,9 +120,9 @@ handshake.func @test_mux_5way(%arg0: index, %arg1: index, %arg2: index, %arg3: i
 // CHECK: %[[RESULT:.+]] = firrtl.subfield %[[VAL_7]](2)
 // CHECK: %[[MUX1:.+]] = firrtl.mux({{.+}}, %[[DATA2]], %[[DATA1]])
 // CHECK: %[[MUX2:.+]] = firrtl.mux({{.+}}, %[[DATA4]], %[[DATA3]])
-// CHECK: %[[MUX3:.+]] = firrtl.mux({{.+}}, %[[DATA6]], %[[DATA5]])
-// CHECK: %[[MUX4:.+]] = firrtl.mux({{.+}}, %[[MUX2]], %[[MUX1]])
-// CHECK: %[[MUX5:.+]] = firrtl.mux({{.+}}, %[[MUX3]], %[[MUX4]])
+// CHECK: %[[MUX3:.+]] = firrtl.mux({{.+}}, %[[MUX2]], %[[MUX1]])
+// CHECK: %[[MUX4:.+]] = firrtl.mux({{.+}}, %[[DATA6]], %[[DATA5]])
+// CHECK: %[[MUX5:.+]] = firrtl.mux({{.+}}, %[[MUX4]], %[[MUX3]])
 // CHECK: firrtl.connect %[[RESULT]], %[[MUX5]]
 handshake.func @test_mux_6way(%arg0: index, %arg1: index, %arg2: index, %arg3: index, %arg4: index, %arg5: index, %arg6: index, %arg7: none, ...) -> (index, none) {
   %0 = mux %arg0 [%arg1, %arg2, %arg3, %arg4, %arg5, %arg6] : index, index


### PR DESCRIPTION
This commit reworks how mux trees are generated in `HandshakeToFIRRTL` lowering. The rework is motivated by bugs within the old implementation wrt. how select signals are calculated. The implementation should hopefully also be a bit more readable than the prior, due to the recursive approach.

The old implementation resulted in verilog where some input signals had been optimized out:
```verilog
module handshake_mux_in_ui64_ui64_ui64_ui64_out_ui64(	// <stdin>:633:5
  input         select_valid,
  input  [63:0] select_data,
  input         in0_valid,
  input  [63:0] in0_data,
  input         in1_valid, // <--- input never referenced in body
  input  [63:0] in1_data, // <--- input never referenced in body
  input         in2_valid,
  input  [63:0] in2_data,
  input         out0_ready,
  output        select_ready, in0_ready, in1_ready, in2_ready, out0_valid,
  output [63:0] out0_data);

  wire _select_data_0 = select_data[0];	// <stdin>:649:13
  wire _T = (_select_data_0 ? in2_valid : in0_valid) & select_valid;	// <stdin>:655:13, :657:13, :658:13
  wire _T_0 = _T & out0_ready;	// <stdin>:660:13
  wire [1:0] _select_data_1to0 = select_data[1:0];	// <stdin>:662:13
  assign select_ready = _T_0;	// <stdin>:633:5
  assign in0_ready = _select_data_1to0 == 2'h0 & _T_0;	// <stdin>:633:5, :664:13, :665:13, :666:13
  assign in1_ready = _select_data_1to0 == 2'h1 & _T_0;	// <stdin>:633:5, :664:13, :668:13, :669:13
  assign in2_ready = _select_data_1to0 == 2'h2 & _T_0;	// <stdin>:633:5, :664:13, :671:13, :672:13
  assign out0_valid = _T;	// <stdin>:633:5
  assign out0_data = _select_data_0 ? in2_data : in0_data;	// <stdin>:633:5, :650:13, :652:13
endmodule
```

Whereas the reworked implementation produces:
```verilog
module handshake_mux_in_ui64_ui64_ui64_ui64_out_ui64(	// <stdin>:633:5
  input         select_valid,
  input  [63:0] select_data,
  input         in0_valid,
  input  [63:0] in0_data,
  input         in1_valid,
  input  [63:0] in1_data,
  input         in2_valid,
  input  [63:0] in2_data,
  input         out0_ready,
  output        select_ready, in0_ready, in1_ready, in2_ready, out0_valid,
  output [63:0] out0_data);

  wire _select_data_0 = select_data[0];	// <stdin>:649:13
  wire _select_data_1 = select_data[1];	// <stdin>:651:13
  wire _T = (_select_data_1 ? in2_valid : _select_data_0 ? in1_valid : in0_valid) & select_valid;	// <stdin>:655:13, :657:13, :658:13
  wire _T_0 = _T & out0_ready;	// <stdin>:660:13
  wire [1:0] _select_data_1to0 = select_data[1:0];	// <stdin>:662:13
  assign select_ready = _T_0;	// <stdin>:633:5
  assign in0_ready = _select_data_1to0 == 2'h0 & _T_0;	// <stdin>:633:5, :664:13, :665:13, :666:13
  assign in1_ready = _select_data_1to0 == 2'h1 & _T_0;	// <stdin>:633:5, :664:13, :668:13, :669:13
  assign in2_ready = _select_data_1to0 == 2'h2 & _T_0;	// <stdin>:633:5, :664:13, :671:13, :672:13
  assign out0_valid = _T;	// <stdin>:633:5
  assign out0_data = _select_data_1 ? in2_data : _select_data_0 ? in1_data : in0_data;	// <stdin>:633:5, :650:13, :652:13
endmodule
```