### PR TITLE
[FIRRTL] Parse params < 32-bit as 32-bit

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3404,6 +3404,11 @@ ParseResult FIRCircuitParser::parseModule(CircuitOp circuit,
       if (parseIntLit(result, "invalid integer parameter"))
         return failure();
 
+      // If the integer parameter is less than 32-bits, sign extend this to a
+      // 32-bit value.  This needs to eventually emit as a 32-bit value in
+      // Verilog and we want to get the size correct immediately.
+      result = result.sextOrSelf(32);
+
       value = builder.getIntegerAttr(
           builder.getIntegerType(result.getBitWidth()), result);
       break;

--- a/test/Dialect/FIRRTL/SFCTests/parameters.fir
+++ b/test/Dialect/FIRRTL/SFCTests/parameters.fir
@@ -1,0 +1,18 @@
+; RUN: firtool -split-input-file -verilog %s | FileCheck %s
+
+; Test that a negative parameter prints out as a 32-bit parameter.  It is fine
+; to change this test to print as "-1" in the output Verilog, but not as a
+; non-32-bit "-1" like "0xF".
+circuit NegativeParameter:
+  extmodule Foo:
+    output a: UInt<1>
+    parameter x = -1
+  module NegativeParameter:
+    output a: UInt<1>
+
+    inst foo of Foo
+    a <= foo.a
+
+; CHECK-LABEL: module NegativeParameter
+; CHECK:         Foo #(
+; CHECK-NEXT:      .x(4294967295)

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -32,7 +32,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
   ; CHECK: parameters = {DEFAULT = 0 : i32,
   ; CHECK:               DEPTH = 3.242000e+01 : f64,
   ; CHECK:               FORMAT = "xyz_timeout=%d\0A",
-  ; CHECK:               WIDTH = 32 : i8}}
+  ; CHECK:               WIDTH = 32 : i32}}
   ; CHECK-NOT: {
   extmodule MyParameterizedExtModule :
     input in: UInt
@@ -576,7 +576,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %c-4_si4 = firrtl.constant -4 : !firrtl.sint<4>
 
   ; CHECK-LABEL: firrtl.extmodule @issue183()
-  ; CHECK: attributes {parameters = {A = -1 : i4}}
+  ; CHECK: attributes {parameters = {A = -1 : i32}}
   extmodule issue183:
      parameter A = -1
 


### PR DESCRIPTION
Change FIRRTL parsing to convert all parameters less than 32-bit to
32-bit APInts.  This fixes downstream issues with Verilog emission,
where negative parameters may have too few bits in their APInt
representation and print as shorter-than-expected literals.
    
Fixes #2299.

This follows the minimal suggestion of [this comment](https://github.com/llvm/circt/pull/2076#issuecomment-962184122) to just store parameters as 32-bit values.