### PR TITLE
[MSFT] Cast attributes passed from PlacementDB to their subclass.

### DIFF
--- a/integration_test/Bindings/Python/dialects/msft.py
+++ b/integration_test/Bindings/Python/dialects/msft.py
@@ -102,12 +102,15 @@ with ir.Context() as ctx, ir.Location.unknown():
   rc = seeded_pdb.add_placement(physAttr, path, "foo_subpath", resolved_inst)
   assert rc
 
-  print(seeded_pdb.get_nearest_free_in_column(msft.M20K, 2, 4))
+  nearest = seeded_pdb.get_nearest_free_in_column(msft.M20K, 2, 4)
+  assert isinstance(nearest, msft.PhysLocationAttr)
+  print(nearest)
 
   # CHECK: #msft.physloc<M20K, 2, 50, 1>
 
 
   def print_placement(loc, placement):
+    assert isinstance(loc, msft.PhysLocationAttr)
     if placement:
       path = msft.RootedInstancePathAttr(placement[0])
       print(f"{loc}, {path}")

--- a/lib/Bindings/Python/MSFTModule.cpp
+++ b/lib/Bindings/Python/MSFTModule.cpp
@@ -26,38 +26,6 @@ using namespace circt;
 using namespace circt::msft;
 using namespace mlir::python::adaptors;
 
-namespace pybind11 {
-namespace detail {
-/// Casts object <-> PhysLocationAttr
-template <>
-struct type_caster<PhysLocationAttr> {
-  PYBIND11_TYPE_CASTER(PhysLocationAttr, _("PhysLocationAttr"));
-  bool load(handle src, bool) {
-    py::object capsule = mlirApiObjectToCapsule(src);
-    Attribute attr = unwrap(mlirPythonCapsuleToAttribute(capsule.ptr()));
-    if (auto physLoc = attr.dyn_cast_or_null<PhysLocationAttr>()) {
-      value = physLoc;
-      return true;
-    }
-    return true;
-  }
-  static handle cast(PhysLocationAttr v, return_value_policy, handle) {
-    py::object capsule = py::reinterpret_steal<py::object>(
-        mlirPythonAttributeToCapsule(wrap(v)));
-
-    auto attr = py::module::import(MAKE_MLIR_PYTHON_QUALNAME("ir"))
-                    .attr("Attribute")
-                    .attr(MLIR_PYTHON_CAPI_FACTORY_ATTR)(capsule)
-                    .release();
-
-    return py::module::import("circt.dialects.msft")
-        .attr("PhysLocationAttr")(attr)
-        .release();
-  }
-};
-} // namespace detail
-} // namespace pybind11
-
 class PrimitiveDB {
 public:
   PrimitiveDB(MlirContext ctxt) { db = circtMSFTCreatePrimitiveDB(ctxt); }
@@ -142,6 +110,8 @@ private:
 };
 
 /// Populate the msft python module.
+DEFINE_ATTRIBUTE_CASTER(PhysLocationAttr, "PhysLocationAttr", "circt.dialects.msft")
+
 void circt::python::populateDialectMSFTSubmodule(py::module &m) {
   mlirMSFTRegisterPasses();
 

--- a/lib/Bindings/Python/MSFTModule.cpp
+++ b/lib/Bindings/Python/MSFTModule.cpp
@@ -72,7 +72,7 @@ public:
         db, prim, column, nearestToY);
     if (!nearest.ptr)
       return py::none();
-    return pyPhysLocationAttr.attr("cast")(nearest);
+    return pyPhysLocationAttr(nearest).release();
   }
   void walkPlacements(
       py::function pycb,
@@ -97,8 +97,8 @@ public:
           py::gil_scoped_acquire gil;
           py::function pycb = *((py::function *)(userData));
           auto physLoc = py::module::import("circt.dialects.msft")
-                             .attr("PhysLocationAttr")
-                             .attr("cast")(loc);
+                             .attr("PhysLocationAttr")(loc)
+                             .release();
           if (!p.op.ptr) {
             pycb(physLoc, py::none());
           } else {


### PR DESCRIPTION
This adds a helper to create a Python object of the appropriate
subclass when passing attributes returned or provided to a callback.