### PR TITLE
[FIRRTL] Remove fold `mux(p, invalid, x) -> x`

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1119,16 +1119,6 @@ static void replaceWithBits(Operation *op, Value value, unsigned hiBit,
 }
 
 OpFoldResult MuxPrimOp::fold(ArrayRef<Attribute> operands) {
-  // mux(cond, x, invalid) -> x
-  // mux(cond, invalid, x) -> x
-  //
-  // These are NOT optimizations that the Scala FIRRTL Compiler makes.  However,
-  // these agree with the interpretation of mux with an invalid true of false
-  // condition as a conditionally valid statement.
-  if (operands[2].dyn_cast_or_null<InvalidValueAttr>())
-    return getOperand(1);
-  if (operands[1].dyn_cast_or_null<InvalidValueAttr>())
-    return getOperand(2);
 
   // mux(cond, x, x) -> x
   if (high() == low())

--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -183,10 +183,23 @@ public:
                                           Operation *whenTrueConn,
                                           Operation *whenFalseConn) {
     auto whenTrue = getConnectedValue(whenTrueConn);
+    auto trueIsInvalid =
+        isa_and_nonnull<InvalidValueOp>(whenTrue.getDefiningOp());
     auto whenFalse = getConnectedValue(whenFalseConn);
-    auto newValue = b.createOrFold<MuxPrimOp>(loc, cond, whenTrue, whenFalse);
-    auto newConnect = b.create<ConnectOp>(loc, dest, newValue);
-    return newConnect;
+    auto falseIsInvalid =
+        isa_and_nonnull<InvalidValueOp>(whenFalse.getDefiningOp());
+    // If one of the branches of the mux is an invalid value, we optimize the
+    // the mux to be the non-invalid value.  This optimization can only be
+    // performed while lowering when-ops into muxes, and would not be legal as
+    // a more general mux folder.
+    // mux(cond, invalid, x) -> x
+    // mux(cond, x, invalid) -> x
+    Value newValue = whenTrue;
+    if (trueIsInvalid == falseIsInvalid)
+      newValue = b.createOrFold<MuxPrimOp>(loc, cond, whenTrue, whenFalse);
+    else if (trueIsInvalid)
+      newValue = whenFalse;
+    return b.create<ConnectOp>(loc, dest, newValue);
   }
 
   void visitDecl(WireOp op) { declareSinks(op.result(), Flow::Duplex); }

--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -189,7 +189,7 @@ public:
     auto falseIsInvalid =
         isa_and_nonnull<InvalidValueOp>(whenFalse.getDefiningOp());
     // If one of the branches of the mux is an invalid value, we optimize the
-    // the mux to be the non-invalid value.  This optimization can only be
+    // mux to be the non-invalid value.  This optimization can only be
     // performed while lowering when-ops into muxes, and would not be legal as
     // a more general mux folder.
     // mux(cond, invalid, x) -> x

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -585,15 +585,9 @@ void IMConstPropPass::visitOperation(Operation *op) {
 
     // If the operand is an unknown value, then we generally don't want to
     // process it - we want to wait until the value is resolved to by the SCCP
-    // algorithm.  However, some operations are defined on partial operations,
-    // including firrtl.mux in particular.  We resolve these eagerly because the
-    // fold hooks know how to deal with them, and they often form cycles.
-    if (operandLattice.isUnknown()) {
-      if (!isa<MuxPrimOp>(op))
-        return;
-      operandConstants.push_back(InvalidValueAttr::get(operand.getType()));
-      continue;
-    }
+    // algorithm.
+    if (operandLattice.isUnknown())
+      return;
 
     // Otherwise, it must be constant, invalid, or overdefined.  Translate them
     // into attributes that the fold hook can look at.

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -457,16 +457,8 @@ firrtl.module @Mux(in %in: !firrtl.uint<4>,
   %3 = firrtl.mux (%cond, %c1_ui1, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out1, %3 : !firrtl.uint<1>, !firrtl.uint<1>
 
-  // CHECK: firrtl.connect %out, %in
-  %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
-  %4 = firrtl.mux (%cond, %in, %invalid_ui4) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  firrtl.connect %out, %4 : !firrtl.uint<4>, !firrtl.uint<4>
-
-  // CHECK: firrtl.connect %out, %in
-  %5 = firrtl.mux (%cond, %invalid_ui4, %in) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  firrtl.connect %out, %5 : !firrtl.uint<4>, !firrtl.uint<4>
-
   // CHECK: firrtl.connect %out, %invalid_ui4
+  %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
   %7 = firrtl.mux (%cond, %invalid_ui4, %invalid_ui4) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %7 : !firrtl.uint<4>, !firrtl.uint<4>
 
@@ -1795,32 +1787,6 @@ firrtl.module @mul_cst_prop4(out %out_b: !firrtl.uint<15>) {
   firrtl.connect %out_b, %mul : !firrtl.uint<15>, !firrtl.uint<15>
   %mul2 = firrtl.mul %invalid_ui4, %tmp_a : (!firrtl.uint<8>, !firrtl.uint<7>) -> !firrtl.uint<15>
   firrtl.connect %out_b, %mul2 : !firrtl.uint<15>, !firrtl.uint<15>
-}
-
-// CHECK-LABEL: firrtl.module @MuxInvalidOpt
-firrtl.module @MuxInvalidOpt(in %cond: !firrtl.uint<1>, in %data: !firrtl.uint<4>, out %out1: !firrtl.uint<4>, out %out2: !firrtl.uint<4>, out %out3: !firrtl.uint<4>, out %out4: !firrtl.uint<4>) {
-  %invalid = firrtl.invalidvalue : !firrtl.uint<4>
-
-  // We can optimize out these mux's since the invalid value can take on any input.
-  %a = firrtl.mux(%cond, %data, %invalid) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  // CHECK: firrtl.connect %out1, %data
-  firrtl.connect %out1, %a : !firrtl.uint<4>, !firrtl.uint<4>
-
-  %b = firrtl.mux(%cond, %invalid, %data) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  // CHECK: firrtl.connect %out2, %data
-  firrtl.connect %out2, %b : !firrtl.uint<4>, !firrtl.uint<4>
-
-  // This fold is required to return %data for SFC compatibility.
-  %false = firrtl.constant 0 : !firrtl.uint<1>
-  %c = firrtl.mux(%false, %data, %invalid) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  // CHECK: firrtl.connect %out3, %data
-  firrtl.connect %out3, %c : !firrtl.uint<4>, !firrtl.uint<4>
-
-  // This fold is required to return %data for SFC compatibility.
-  %true = firrtl.constant 1 : !firrtl.uint<1>
-  %d = firrtl.mux(%true, %invalid, %data) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  // CHECK: firrtl.connect %out4, %data
-  firrtl.connect %out4, %d : !firrtl.uint<4>, !firrtl.uint<4>
 }
 
 // CHECK-LABEL: firrtl.module @MuxCanon

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -299,6 +299,55 @@ firrtl.module @nested2(in %clock : !firrtl.clock, in %p0 : !firrtl.uint<1>, in %
 //CHECK-NEXT:   firrtl.connect %out, %9 : !firrtl.uint<2>, !firrtl.uint<2>
 //CHECK-NEXT: }
 
+// Test invalid value optimization
+// CHECK-LABEL: firrtl.module @InvalidValues
+firrtl.module @InvalidValues(in %p: !firrtl.uint<1>, out %out0: !firrtl.uint<2>, out %out1: !firrtl.uint<2>, out %out2: !firrtl.uint<2>, out %out3: !firrtl.uint<2>, out %out4: !firrtl.uint<2>, out %out5: !firrtl.uint<2>) {
+  %c2_ui2 = firrtl.constant 2 : !firrtl.uint<2>
+  %invalid_ui2 = firrtl.invalidvalue : !firrtl.uint<2>
+
+  firrtl.when %p  {
+    firrtl.connect %out0, %c2_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
+  } else  {
+    firrtl.connect %out0, %invalid_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
+  }
+  // CHECK: firrtl.connect %out0, %c2_ui2
+
+  firrtl.when %p  {
+    firrtl.connect %out1, %invalid_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
+  } else  {
+    firrtl.connect %out1, %c2_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
+  }
+  // CHECK: firrtl.connect %out1, %c2_ui2
+
+  firrtl.connect %out2, %invalid_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
+  firrtl.when %p  {
+    firrtl.connect %out2, %c2_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
+  }
+  // CHECK: firrtl.connect %out2, %c2_ui2
+
+  firrtl.connect %out3, %invalid_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
+  firrtl.when %p  {
+    firrtl.skip
+  } else  {
+    firrtl.connect %out3, %c2_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
+  }
+  // CHECK: firrtl.connect %out3, %c2_ui2
+
+  firrtl.connect %out4, %c2_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
+  firrtl.when %p  {
+    firrtl.connect %out4, %invalid_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
+  }
+  // CHECK: firrtl.connect %out4, %c2_ui2
+
+  firrtl.connect %out5, %c2_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
+  firrtl.when %p  {
+    firrtl.skip
+  } else  {
+    firrtl.connect %out5, %invalid_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
+  }
+  // CHECK: firrtl.connect %out5, %c2_ui2
+}
+    
 // Test that registers are multiplexed with themselves.
 firrtl.module @register_mux(in %p : !firrtl.uint<1>, in %clock: !firrtl.clock) {
   %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>


### PR DESCRIPTION
This commit removes the mux canonicalization which optimizes muxes when
one of the branches is invalid to the value of the other branch.

```mlir
mux(p, invalid, x) -> x
```

This optimization is not actually implemented by the SFC compiler, and
we actually need invalids to be treated as 0 when used in a mux.

We do need a similar optimization when lowering `WhenOp`s to muxes
during `ExpandWhens`.  When a wire is invalidated in one branch of a
when op, we optimize away the invalid.  This was previously handled by
creating a mux operation and relying on the folder to perform the
optimization.

A side effect of this change is that in IMCP we no longer want to pass
unknown lattice values as `InvalidAttr` constants to the Mux folder.
Doing this without the invalid folder causes the mux to fail to fold,
which marks the mux operation as overdefined.  Instead, we can just wait
until SCCP knows the values for all the operands to the Mux op before
attempting to fold.