### PR TITLE
[Seq] Add inner_sym attribute to CompReg and use it on RegOp.

### DIFF
--- a/docs/RationaleSeq.md
+++ b/docs/RationaleSeq.md
@@ -61,9 +61,9 @@ addressing, meaning that this operation sets / reads the entire value.
 'reset' is present.
 - **name**: A name for the register, defaults to `""`. Inferred from the textual
 SSA value name, or passed explicitly in builder APIs. The name will be passed to
-the `sv.reg` during lowering, and will be set as the `sv.reg`'s `inner_sym`
-attribute when non-empty. This means a name given to a `seq.compreg` can be used
-as a symbol to refer to the underlying `sv.reg` in lowering pipelines.
+the `sv.reg` during lowering.
+- **innerSym**: An optional symbol to refer to the register. The symbol will be
+passed to the `sv.reg` during lowering if present.
 
 ```mlir
 %q = seq.compreg %input, %clk [, %reset, %resetValue ] : $type(input)

--- a/docs/RationaleSeq.md
+++ b/docs/RationaleSeq.md
@@ -59,6 +59,11 @@ addressing, meaning that this operation sets / reads the entire value.
 - **reset**: Signal to set the state to 'resetValue'. Optional.
 - **resetValue**: A value which the state is set to upon reset. Required iff
 'reset' is present.
+- **name**: A name for the register, defaults to `""`. Inferred from the textual
+SSA value name, or passed explicitly in builder APIs. The name will be passed to
+the `sv.reg` during lowering, and will be set as the `sv.reg`'s `inner_sym`
+attribute when non-empty. This means a name given to a `seq.compreg` can be used
+as a symbol to refer to the underlying `sv.reg` in lowering pipelines.
 
 ```mlir
 %q = seq.compreg %input, %clk [, %reset, %resetValue ] : $type(input)

--- a/frontends/PyCDE/test/verilog_readablility.py
+++ b/frontends/PyCDE/test/verilog_readablility.py
@@ -1,6 +1,6 @@
 # RUN: %PYTHON% %s | FileCheck %s
 
-from pycde import (Output, Input, module, generator, types, dim, System)
+from pycde import Output, Input, module, generator, types, dim, System
 
 
 @module
@@ -18,8 +18,8 @@ class WireNames:
     foo.name = "foo"
     arr_data = dim(32, 4)([1, 2, 3, 4], "arr_data")
     ports.set_all_ports({
-        'a': foo.reg(ports.clk).reg(ports.clk),
-        'b': arr_data[ports.sel],
+        "a": foo.reg(ports.clk).reg(ports.clk),
+        "b": arr_data[ports.sel],
     })
 
 
@@ -33,8 +33,8 @@ sys.print()
 # CHECK:    %c3_i32 = hw.constant 3 : i32
 # CHECK:    %c4_i32 = hw.constant 4 : i32
 # CHECK:    %{{.+}} = hw.array_create %c4_i32, %c3_i32, %c2_i32, %c1_i32 {sv.namehint = "arr_data"} : i32
-# CHECK:    %foo__reg1 = sv.reg  : !hw.inout<i32>
-# CHECK:    %foo__reg2 = sv.reg  : !hw.inout<i32>
+# CHECK:    %foo__reg1 = sv.reg sym @foo__reg1 : !hw.inout<i32>
+# CHECK:    %foo__reg2 = sv.reg sym @foo__reg2 : !hw.inout<i32>
 # CHECK:    %{{.+}} = sv.read_inout %foo__reg2 : !hw.inout<i32>
 # CHECK:    sv.alwaysff(posedge %clk)  {
 # CHECK:      %c0_i2 = hw.constant 0 : i2

--- a/frontends/PyCDE/test/verilog_readablility.py
+++ b/frontends/PyCDE/test/verilog_readablility.py
@@ -33,8 +33,8 @@ sys.print()
 # CHECK:    %c3_i32 = hw.constant 3 : i32
 # CHECK:    %c4_i32 = hw.constant 4 : i32
 # CHECK:    %{{.+}} = hw.array_create %c4_i32, %c3_i32, %c2_i32, %c1_i32 {sv.namehint = "arr_data"} : i32
-# CHECK:    %foo__reg1 = sv.reg sym @foo__reg1 : !hw.inout<i32>
-# CHECK:    %foo__reg2 = sv.reg sym @foo__reg2 : !hw.inout<i32>
+# CHECK:    %foo__reg1 = sv.reg  : !hw.inout<i32>
+# CHECK:    %foo__reg2 = sv.reg  : !hw.inout<i32>
 # CHECK:    %{{.+}} = sv.read_inout %foo__reg2 : !hw.inout<i32>
 # CHECK:    sv.alwaysff(posedge %clk)  {
 # CHECK:      %c0_i2 = hw.constant 0 : i2

--- a/frontends/PyCDE/test/verilog_readablility.py
+++ b/frontends/PyCDE/test/verilog_readablility.py
@@ -1,6 +1,6 @@
 # RUN: %PYTHON% %s | FileCheck %s
 
-from pycde import Output, Input, module, generator, types, dim, System
+from pycde import (Output, Input, module, generator, types, dim, System)
 
 
 @module
@@ -18,8 +18,8 @@ class WireNames:
     foo.name = "foo"
     arr_data = dim(32, 4)([1, 2, 3, 4], "arr_data")
     ports.set_all_ports({
-        "a": foo.reg(ports.clk).reg(ports.clk),
-        "b": arr_data[ports.sel],
+        'a': foo.reg(ports.clk).reg(ports.clk),
+        'b': arr_data[ports.sel],
     })
 
 

--- a/include/circt/Dialect/Seq/Seq.td
+++ b/include/circt/Dialect/Seq/Seq.td
@@ -46,7 +46,8 @@ def CompRegOp : SeqOp<"compreg",
   let description = "See the Seq dialect rationale for a longer description";
 
   let arguments = (ins AnyType:$input, I1:$clk, StrAttr:$name,
-    Optional<I1>:$reset, Optional<AnyType>:$resetValue);
+    Optional<I1>:$reset, Optional<AnyType>:$resetValue,
+    OptionalAttr<SymbolNameAttr>:$innerSym);
   let results = (outs AnyType:$data);
 
   let printer = "return ::print$cppClass(p, *this);";

--- a/lib/Dialect/Seq/SeqPasses.cpp
+++ b/lib/Dialect/Seq/SeqPasses.cpp
@@ -46,6 +46,10 @@ public:
                                             reg.nameAttr());
     svReg->setDialectAttrs(reg->getDialectAttrs());
 
+    // If the seq::CompRegOp has a name, set this for the sv::RegOp inner_sym.
+    if (!reg.name().empty())
+      svReg.inner_symAttr(reg.nameAttr());
+
     auto regVal = rewriter.create<sv::ReadInOutOp>(loc, svReg);
     if (reg.reset() && reg.resetValue()) {
       rewriter.create<sv::AlwaysFFOp>(

--- a/lib/Dialect/Seq/SeqPasses.cpp
+++ b/lib/Dialect/Seq/SeqPasses.cpp
@@ -46,9 +46,10 @@ public:
                                             reg.nameAttr());
     svReg->setDialectAttrs(reg->getDialectAttrs());
 
-    // If the seq::CompRegOp has a name, set this for the sv::RegOp inner_sym.
-    if (!reg.name().empty())
-      svReg.inner_symAttr(reg.nameAttr());
+    // If the seq::CompRegOp has an inner_sym attribute, set this for the
+    // sv::RegOp inner_sym attribute.
+    if (reg.innerSym().hasValue())
+      svReg.inner_symAttr(reg.innerSymAttr());
 
     auto regVal = rewriter.create<sv::ReadInOutOp>(loc, svReg);
     if (reg.reset() && reg.resetValue()) {

--- a/test/Dialect/Seq/basic.mlir
+++ b/test/Dialect/Seq/basic.mlir
@@ -7,7 +7,7 @@ hw.module @top(%clk: i1, %rst: i1, %i: i32, %s: !hw.struct<foo: i32>) {
   seq.compreg %i, %clk : i32
   // CHECK: %{{.+}} = seq.compreg %i, %clk, %rst, %c0_i32  : i32
   // CHECK: %{{.+}} = seq.compreg %i, %clk : i32
-  // SV: [[REG0:%.+]] = sv.reg  : !hw.inout<i32>
+  // SV: [[REG0:%.+]] = sv.reg sym @r0 : !hw.inout<i32>
   // SV: [[REG5:%.+]] = sv.read_inout [[REG0]] : !hw.inout<i32>
   // SV: sv.alwaysff(posedge %clk)  {
   // SV:   sv.passign [[REG0]], %i : i32
@@ -27,7 +27,7 @@ hw.module @top(%clk: i1, %rst: i1, %i: i32, %s: !hw.struct<foo: i32>) {
   // CHECK: %{{.+}} = seq.compreg %s, %clk : !hw.struct<foo: i32>
 
   // SV: [[REGST:%.+]] = hw.struct_create ([[REG5]]) : !hw.struct<foo: i32>
-  // SV: %foo = sv.reg  : !hw.inout<struct<foo: i32>>
+  // SV: %foo = sv.reg sym @foo : !hw.inout<struct<foo: i32>>
   // SV: sv.alwaysff(posedge %clk)  {
   // SV:   sv.passign %foo, %s : !hw.struct<foo: i32>
   // SV: }(syncreset : posedge %rst)  {

--- a/test/Dialect/Seq/basic.mlir
+++ b/test/Dialect/Seq/basic.mlir
@@ -7,7 +7,7 @@ hw.module @top(%clk: i1, %rst: i1, %i: i32, %s: !hw.struct<foo: i32>) {
   seq.compreg %i, %clk : i32
   // CHECK: %{{.+}} = seq.compreg %i, %clk, %rst, %c0_i32  : i32
   // CHECK: %{{.+}} = seq.compreg %i, %clk : i32
-  // SV: [[REG0:%.+]] = sv.reg sym @r0 : !hw.inout<i32>
+  // SV: [[REG0:%.+]] = sv.reg  : !hw.inout<i32>
   // SV: [[REG5:%.+]] = sv.read_inout [[REG0]] : !hw.inout<i32>
   // SV: sv.alwaysff(posedge %clk)  {
   // SV:   sv.passign [[REG0]], %i : i32
@@ -27,7 +27,7 @@ hw.module @top(%clk: i1, %rst: i1, %i: i32, %s: !hw.struct<foo: i32>) {
   // CHECK: %{{.+}} = seq.compreg %s, %clk : !hw.struct<foo: i32>
 
   // SV: [[REGST:%.+]] = hw.struct_create ([[REG5]]) : !hw.struct<foo: i32>
-  // SV: %foo = sv.reg sym @foo : !hw.inout<struct<foo: i32>>
+  // SV: %foo = sv.reg  : !hw.inout<struct<foo: i32>>
   // SV: sv.alwaysff(posedge %clk)  {
   // SV:   sv.passign %foo, %s : !hw.struct<foo: i32>
   // SV: }(syncreset : posedge %rst)  {
@@ -37,4 +37,8 @@ hw.module @top(%clk: i1, %rst: i1, %i: i32, %s: !hw.struct<foo: i32>) {
   // SV: sv.alwaysff(posedge %clk)  {
   // SV:   sv.passign [[REG4]], %s : !hw.struct<foo: i32>
   // SV: }
+
+  seq.compreg sym @reg1 %i, %clk : i32
+  // CHECK: seq.compreg sym @reg1
+  // SV: sv.reg sym @reg1
 }

--- a/test/Dialect/Seq/basic.mlir
+++ b/test/Dialect/Seq/basic.mlir
@@ -38,7 +38,11 @@ hw.module @top(%clk: i1, %rst: i1, %i: i32, %s: !hw.struct<foo: i32>) {
   // SV:   sv.passign [[REG4]], %s : !hw.struct<foo: i32>
   // SV: }
 
-  seq.compreg sym @reg1 %i, %clk : i32
-  // CHECK: seq.compreg sym @reg1
-  // SV: sv.reg sym @reg1
+  %bar = seq.compreg sym @reg1 %i, %clk : i32
+  seq.compreg sym @reg2 %i, %clk : i32
+  // CHECK: %bar = seq.compreg sym @reg1
+  // CHECK: seq.compreg sym @reg2
+
+  // SV: %bar = sv.reg sym @reg1
+  // SV: sv.reg sym @reg2
 }


### PR DESCRIPTION
Adds an innerSym attribute to CompRegOp, which is passed to the RegOp
during lowering. This allows workflows to reliably give a register a
symbol that can refer to the underlying reg.