### PR TITLE
[PyCDE] Add support for placing CompRegOp.

### DIFF
--- a/frontends/PyCDE/src/pycde/value.py
+++ b/frontends/PyCDE/src/pycde/value.py
@@ -52,7 +52,8 @@ class Value:
                            input=self.value,
                            clk=clk,
                            reset=rst,
-                           name=name)
+                           name=name,
+                           inner_sym=name)
 
   @property
   def _namehint_attrname(self):

--- a/frontends/PyCDE/test/compreg.py
+++ b/frontends/PyCDE/test/compreg.py
@@ -1,10 +1,13 @@
 # RUN: rm -rf %t
 # RUN: %PYTHON% %s %t
 # RUN: FileCheck %s --input-file %t/CompReg.sv
+# RUN: FileCheck %s --input-file %t/CompReg.tcl --check-prefix TCL
 
 import pycde
 from pycde import types, module, Input, Output
 
+from pycde.attributes import placement
+from pycde.devicedb import PrimitiveType
 from pycde.dialects import seq
 from pycde.module import generator
 
@@ -19,16 +22,26 @@ class CompReg:
 
   @generator
   def build(ports):
-    compreg = seq.CompRegOp(types.i8, clk=ports.clk, input=ports.input)
+    compreg = seq.CompRegOp(types.i8,
+                            clk=ports.clk,
+                            input=ports.input,
+                            inner_sym="reg")
     ports.output = compreg
 
+
+appid = pycde.AppIDIndex()
+loc = placement([], PrimitiveType.FF, 0, 0, 0)
+appid.lookup(pycde.AppID("reg")).add_attribute(loc)
 
 mod = pycde.System([CompReg], name="CompReg", output_directory=sys.argv[1])
 mod.print()
 mod.generate()
+mod.get_instance(CompReg).walk(appid.apply_attributes_visitor)
 mod.print()
 mod.emit_outputs()
 
 # CHECK: reg [7:0] [[NAME:.+]];
 # CHECK: always_ff @(posedge clk)
 # CHECK: [[NAME]] <= {{.+}}
+
+# TCL: set_location_assignment FF_X0_Y0_N0 -to $parent|{{.+}}

--- a/frontends/PyCDE/test/compreg.py
+++ b/frontends/PyCDE/test/compreg.py
@@ -25,6 +25,7 @@ class CompReg:
     compreg = seq.CompRegOp(types.i8,
                             clk=ports.clk,
                             input=ports.input,
+                            name="reg",
                             inner_sym="reg")
     ports.output = compreg
 
@@ -40,8 +41,8 @@ mod.get_instance(CompReg).walk(appid.apply_attributes_visitor)
 mod.print()
 mod.emit_outputs()
 
-# CHECK: reg [7:0] [[NAME:.+]];
+# CHECK: reg [7:0] [[NAME:reg_.]];
 # CHECK: always_ff @(posedge clk)
 # CHECK: [[NAME]] <= {{.+}}
 
-# TCL: set_location_assignment FF_X0_Y0_N0 -to $parent|{{.+}}
+# TCL: set_location_assignment FF_X0_Y0_N0 -to $parent|reg_{{.}}

--- a/frontends/PyCDE/test/syntactic_sugar.py
+++ b/frontends/PyCDE/test/syntactic_sugar.py
@@ -83,8 +83,8 @@ sys.print()
 # CHECK:  msft.module @ComplexPorts {} (%clk: i1, %data_in: !hw.array<3xi32>, %sel: i2, %struct_data_in: !hw.struct<foo: i36>) -> (a: i32, b: i32, c: i32)
 # CHECK:    %c0_i2 = hw.constant 0 : i2
 # CHECK:    [[REG0:%.+]] = hw.array_get %data_in[%c0_i2] {sv.namehint = "data_in__0"} : !hw.array<3xi32>
-# CHECK:    [[REGR1:%data_in__0__reg1]] = seq.compreg [[REG0]], %clk : i32
-# CHECK:    [[REGR2:%data_in__0__reg2]] = seq.compreg [[REGR1]], %clk : i32
+# CHECK:    [[REGR1:%data_in__0__reg1]] = seq.compreg sym @data_in__0__reg1 [[REG0]], %clk : i32
+# CHECK:    [[REGR2:%data_in__0__reg2]] = seq.compreg sym @data_in__0__reg2 [[REGR1]], %clk : i32
 # CHECK:    [[REG1:%.+]] = hw.array_get %data_in[%sel] : !hw.array<3xi32>
 # CHECK:    [[REG2:%.+]] = hw.struct_extract %struct_data_in["foo"] {sv.namehint = "struct_data_in__foo"} : !hw.struct<foo: i36>
 # CHECK:    [[REG3:%.+]] = comb.extract [[REG2]] from 0 {sv.namehint = "struct_data_in__foo_0upto32"} : (i36) -> i32

--- a/frontends/PyCDE/test/verilog_readablility.py
+++ b/frontends/PyCDE/test/verilog_readablility.py
@@ -33,8 +33,8 @@ sys.print()
 # CHECK:    %c3_i32 = hw.constant 3 : i32
 # CHECK:    %c4_i32 = hw.constant 4 : i32
 # CHECK:    %{{.+}} = hw.array_create %c4_i32, %c3_i32, %c2_i32, %c1_i32 {sv.namehint = "arr_data"} : i32
-# CHECK:    %foo__reg1 = sv.reg  : !hw.inout<i32>
-# CHECK:    %foo__reg2 = sv.reg  : !hw.inout<i32>
+# CHECK:    %foo__reg1 = sv.reg sym @foo__reg1 : !hw.inout<i32>
+# CHECK:    %foo__reg2 = sv.reg sym @foo__reg2 : !hw.inout<i32>
 # CHECK:    %{{.+}} = sv.read_inout %foo__reg2 : !hw.inout<i32>
 # CHECK:    sv.alwaysff(posedge %clk)  {
 # CHECK:      %c0_i2 = hw.constant 0 : i2

--- a/lib/Dialect/MSFT/CMakeLists.txt
+++ b/lib/Dialect/MSFT/CMakeLists.txt
@@ -30,6 +30,7 @@ add_circt_dialect_library(CIRCTMSFT
   MLIRIR
   MLIRTransforms
   CIRCTHW
+  CIRCTSeq
   CIRCTSV
    )
 


### PR DESCRIPTION
This extends the Instance wrapper to wrap not just instances but also
registers. Additionally, in the Tcl export, this looks for registers,
adds them to the symbol cache, and uses their symbol names.

Users are now able to place CompRegOp when its innerSym attribute is
set. If they create a CompRegOp directly, the inner_sym must be passed
explicitly, but the `reg(...)` helper on Value is extended to use the
name as the inner_sym when passed.