### PR TITLE
[SV][ExportVerilog] Add sv.struct_field_inout op

### DIFF
--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -176,3 +176,30 @@ def IndexedPartSelectInOutOp : SVOp<"indexed_part_select_inout",
   let assemblyFormat = "$input`[`$base (`decrement` $decrement^)?`:` $width`]`"
                         " attr-dict `:` type($input) `,` type($base)";
 }
+
+def InOutStructType
+  : Type<CPred<"getInOutElementType($_self).isa<hw::StructType>()">,
+         "an inout type with struct field", "::circt::hw::InOutType">;
+
+def StructFieldInOutOp : SVOp<"struct_field_inout",
+                              [NoSideEffect, InferTypeOpInterface]> {
+  let summary = "Create an subfield inout memory to produce an inout element.";
+  let description = "See SV Spec 7.2.";
+
+  let arguments = (ins InOutStructType:$input, StrAttr:$field);
+  let results = (outs InOutType:$result);
+
+  let assemblyFormat =
+    "$input `(` $field `)` attr-dict `:` type($input)";
+
+  let extraClassDeclaration = [{
+    /// Infer the return types of this operation.
+    static LogicalResult inferReturnTypes(MLIRContext *context,
+                                          Optional<Location> loc,
+                                          ValueRange operands,
+                                          DictionaryAttr attrs,
+                                          mlir::RegionRange regions,
+                                          SmallVectorImpl<Type> &results);
+  }];
+
+}

--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -190,7 +190,7 @@ def StructFieldInOutOp : SVOp<"struct_field_inout",
   let results = (outs InOutType:$result);
 
   let assemblyFormat =
-    "$input `(` $field `)` attr-dict `:` type($input)";
+    "$input `[` $field `]` attr-dict `:` type($input)";
 
   let extraClassDeclaration = [{
     /// Infer the return types of this operation.

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -29,8 +29,8 @@ public:
         .template Case<
             // Expressions
             ReadInOutOp, ArrayIndexInOutOp, VerbatimExprOp, VerbatimExprSEOp,
-            IndexedPartSelectInOutOp, IndexedPartSelectOp, ConstantXOp,
-            ConstantZOp,
+            IndexedPartSelectInOutOp, IndexedPartSelectOp, StructFieldInOutOp,
+            ConstantXOp, ConstantZOp,
             // Declarations.
             RegOp, WireOp, LocalParamOp, XMROp,
             // Control flow.
@@ -89,6 +89,7 @@ public:
   HANDLE(VerbatimExprSEOp, Unhandled);
   HANDLE(IndexedPartSelectInOutOp, Unhandled);
   HANDLE(IndexedPartSelectOp, Unhandled);
+  HANDLE(StructFieldInOutOp, Unhandled);
   HANDLE(ConstantXOp, Unhandled);
   HANDLE(ConstantZOp, Unhandled);
 

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -152,7 +152,7 @@ static StringRef getSymOpName(Operation *symOp) {
 bool ExportVerilog::isVerilogExpression(Operation *op) {
   // These are SV dialect expressions.
   if (isa<ReadInOutOp, ArrayIndexInOutOp, IndexedPartSelectInOutOp,
-          IndexedPartSelectOp, ParamValueOp, XMROp>(op))
+          StructFieldInOutOp, IndexedPartSelectOp, ParamValueOp, XMROp>(op))
     return true;
 
   // All HW combinational logic ops and SV expression ops are Verilog
@@ -1375,6 +1375,7 @@ private:
   SubExprInfo visitSV(ArrayIndexInOutOp op);
   SubExprInfo visitSV(IndexedPartSelectInOutOp op);
   SubExprInfo visitSV(IndexedPartSelectOp op);
+  SubExprInfo visitSV(StructFieldInOutOp op);
 
   // Other
   using TypeOpVisitor::visitTypeOp;
@@ -1972,6 +1973,12 @@ SubExprInfo ExprEmitter::visitSV(IndexedPartSelectOp op) {
   os << op.width();
   os << ']';
   return info;
+}
+
+SubExprInfo ExprEmitter::visitSV(StructFieldInOutOp op) {
+  auto prec = emitSubExpr(op.input(), Selection, OOLUnary);
+  os << '.' << op.field();
+  return {Selection, prec.signedness};
 }
 
 SubExprInfo ExprEmitter::visitComb(MuxOp op) {

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -1179,6 +1179,27 @@ static LogicalResult verifyIndexedPartSelectOp(Operation *op) {
 }
 
 //===----------------------------------------------------------------------===//
+// StructFieldInOutOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult StructFieldInOutOp::inferReturnTypes(
+    MLIRContext *context, Optional<Location> loc, ValueRange operands,
+    DictionaryAttr attrs, mlir::RegionRange regions,
+    SmallVectorImpl<Type> &results) {
+  auto field = attrs.get("field");
+  if (!field)
+    return failure();
+  auto structType =
+      getInOutElementType(operands[0].getType()).cast<hw::StructType>();
+  auto resultType = structType.getFieldType(field.cast<StringAttr>());
+  if (!resultType)
+    return failure();
+
+  results.push_back(hw::InOutType::get(resultType));
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // Other ops.
 //===----------------------------------------------------------------------===//
 

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -430,7 +430,7 @@ hw.module @struct_field_inout1(%a : !hw.inout<struct<b: i1>>) {
   // CHECK-EMPTY:
   // CHECK-NEXT: assign a.b = 1'h1;
   %true = hw.constant true
-  %0 = sv.struct_field_inout %a("b") : !hw.inout<struct<b: i1>>
+  %0 = sv.struct_field_inout %a["b"] : !hw.inout<struct<b: i1>>
   sv.assign %0, %true : i1
 }
 
@@ -440,8 +440,8 @@ hw.module @struct_field_inout2(%a: !hw.inout<struct<b: !hw.struct<c: i1>>>) {
   // CHECK-EMPTY:
   // CHECK-NEXT: assign a.b.c = 1'h1;
   %true = hw.constant true
-  %0 = sv.struct_field_inout %a("b") : !hw.inout<struct<b: !hw.struct<c: i1>>>
-  %1 = sv.struct_field_inout %0("c") : !hw.inout<struct<c: i1>>
+  %0 = sv.struct_field_inout %a["b"] : !hw.inout<struct<b: !hw.struct<c: i1>>>
+  %1 = sv.struct_field_inout %0["c"] : !hw.inout<struct<c: i1>>
   sv.assign %1, %true : i1
 }
 

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -424,6 +424,27 @@ hw.module @reg_1(%in4: i4, %in8: i8) -> (a : i3, b : i5) {
   hw.output %c, %d : i3,i5
 }
 
+// CHECK-LABEL: module struct_field_inout1(
+hw.module @struct_field_inout1(%a : !hw.inout<struct<b: i1>>) {
+  // CHECK: inout struct packed {logic b; } a);
+  // CHECK-EMPTY:
+  // CHECK-NEXT: assign a.b = 1'h1;
+  %true = hw.constant true
+  %0 = sv.struct_field_inout %a("b") : !hw.inout<struct<b: i1>>
+  sv.assign %0, %true : i1
+}
+
+// CHECK-LABEL: module struct_field_inout2(
+hw.module @struct_field_inout2(%a: !hw.inout<struct<b: !hw.struct<c: i1>>>) {
+  // CHECK: inout struct packed {struct packed {logic c; } b; } a);
+  // CHECK-EMPTY:
+  // CHECK-NEXT: assign a.b.c = 1'h1;
+  %true = hw.constant true
+  %0 = sv.struct_field_inout %a("b") : !hw.inout<struct<b: !hw.struct<c: i1>>>
+  %1 = sv.struct_field_inout %0("c") : !hw.inout<struct<c: i1>>
+  sv.assign %1, %true : i1
+}
+
 // CHECK-LABEL: issue508
 // https://github.com/llvm/circt/issues/508
 hw.module @issue508(%in1: i1, %in2: i1) {


### PR DESCRIPTION
This commit adds an new operation `sv.struct_field_inout` to create
inout memory for hw::StructType. Potentially, this will be used to
lower firrtl bundle types.