### PR TITLE
[SV] Make -ignore-read-enable-mem FIRRTL pedantic

### DIFF
--- a/test/firtool/memory.fir
+++ b/test/firtool/memory.fir
@@ -57,11 +57,11 @@ circuit Qux:
 ; READ-LABEL:  hw.module @FIRRTLMem_1_1_1_8_16_1_1_1_0_1_a
 ; READ:    %[[vtrue:.+]] = hw.constant true
 ; READ:    %[[vMemory:.+]] = sv.reg  : !hw.inout<uarray<16xi8>>
-; READ-NEXT:    %[[v0:.+]] = sv.reg  : !hw.inout<i1>
 ; READ-NEXT:    %[[v2:.+]] = sv.reg  : !hw.inout<i4>
 ; READ-NEXT:    sv.always posedge %R0_clk {
-; READ-NEXT:      sv.passign %[[v0]], %R0_en : i1
-; READ-NEXT:      sv.passign %[[v2]], %R0_addr : i4
+; READ-NEXT:      sv.if %R0_en {
+; READ-NEXT:        sv.passign %[[v2]], %R0_addr : i4
+; READ-NEXT:      }
 ; READ-NEXT:    }
 ; READ-NEXT:    %[[v3:.+]] = sv.read_inout %[[v2]] : !hw.inout<i4>
 ; READ-NEXT:    %[[v4:.+]] = sv.array_index_inout %[[vMemory]][%[[v3]]] : !hw.inout<uarray<16xi8>>, i4


### PR DESCRIPTION
Change the behavior of the `-ignore-read-enable-mem` to use the exact
behavior of Scala FIRRTL Compiler default memory lowering.  This will
now use the read enable to gate the update of the latched address.
Previously, the read enable was used to gate the final read.  The net
effect is that the memory will output the last read value continuously.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

With this patch, for the following read-latency-1 memory:
```scala
circuit Foo:
  module Foo:
    input clock: Clock
    input rAddr: UInt<4>
    input rEn: UInt<1>
    output rData: UInt<8>

    mem memory:
      data-type => UInt<8>
      depth => 16
      reader => r
      read-latency => 1
      write-latency => 1
      read-under-write => undefined

    memory.r.clk <= clock
    memory.r.en <= rEn
    memory.r.addr <= rAddr
    rData <= memory.r.data
```

We now get (in the MFC) using `firtool -ignore-read-enable-mem`:
```verilog
module FIRRTLMem_1_0_0_8_16_1_1_0_0_1(	// Foo.fir:8:5
  input  [3:0] R0_addr,
  input        R0_en, R0_clk,
  output [7:0] R0_data);

  reg [7:0] Memory[0:15];
  reg [3:0] _T;

  always @(posedge R0_clk) begin
    if (R0_en)
      _T <= R0_addr;
  end // always @(posedge)
  assign R0_data = Memory[_T];	// Foo.fir:8:5
endmodule

module Foo(	// Foo.fir:2:10
  input        clock,
  input  [3:0] rAddr,
  input        rEn,
  output [7:0] rData);

  FIRRTLMem_1_0_0_8_16_1_1_0_0_1 memory (	// Foo.fir:8:5
    .R0_addr (rAddr),
    .R0_en   (rEn),
    .R0_clk  (clock),
    .R0_data (rData)
  );
endmodule
```

The SFC version is:
```verilog
module Foo(
  input        clock,
  input  [3:0] rAddr,
  input        rEn,
  output [7:0] rData
);
  reg [7:0] memory [0:15];
  wire  memory_r_en;
  wire [3:0] memory_r_addr;
  wire [7:0] memory_r_data;
  reg  memory_r_en_pipe_0;
  reg [3:0] memory_r_addr_pipe_0;
  assign memory_r_en = memory_r_en_pipe_0;
  assign memory_r_addr = memory_r_addr_pipe_0;
  assign memory_r_data = memory[memory_r_addr];
  assign rData = memory_r_data;
  always @(posedge clock) begin
    memory_r_en_pipe_0 <= rEn;
    if (rEn) begin
      memory_r_addr_pipe_0 <= rAddr;
    end
  end
endmodule
```

Previously, we would get:
```verilog
module FIRRTLMem_1_0_0_8_16_1_1_0_0_1(	// Foo.fir:8:5
  input  [3:0] R0_addr,
  input        R0_en, R0_clk,
  output [7:0] R0_data);

  reg [7:0] Memory[0:15];
  reg       _T;
  reg [3:0] _T_0;

  always @(posedge R0_clk) begin
    _T <= R0_en;
    _T_0 <= R0_addr;
  end // always @(posedge)
  assign R0_data = Memory[_T_0];	// Foo.fir:8:5
endmodule

module Foo(	// Foo.fir:2:10
  input        clock,
  input  [3:0] rAddr,
  input        rEn,
  output [7:0] rData);

  FIRRTLMem_1_0_0_8_16_1_1_0_0_1 memory (	// Foo.fir:8:5
    .R0_addr (rAddr),
    .R0_en   (rEn),
    .R0_clk  (clock),
    .R0_data (rData)
  );
endmodule
```