### PR TITLE
[ExportVerilog] Add the verilogname attribute for updated verilog name

### DIFF
--- a/lib/Conversion/ExportVerilog/LegalizeNames.cpp
+++ b/lib/Conversion/ExportVerilog/LegalizeNames.cpp
@@ -119,7 +119,7 @@ GlobalNameResolver::GlobalNameResolver(mlir::ModuleOp topLevel) {
 /// keywords or themselves.  If so, add the replacement names to
 /// globalNameTable.
 void GlobalNameResolver::legalizeModuleNames(HWModuleOp module) {
-  auto ctxt = module.getContext();
+  MLIRContext *ctxt = module.getContext();
   // If the module's symbol itself conflicts, then set a "verilogName" attribute
   // on the module to reflect the name we need to use.
   StringRef oldName = module.getName();

--- a/lib/Conversion/ExportVerilog/LegalizeNames.cpp
+++ b/lib/Conversion/ExportVerilog/LegalizeNames.cpp
@@ -119,22 +119,30 @@ GlobalNameResolver::GlobalNameResolver(mlir::ModuleOp topLevel) {
 /// keywords or themselves.  If so, add the replacement names to
 /// globalNameTable.
 void GlobalNameResolver::legalizeModuleNames(HWModuleOp module) {
+  auto ctxt = module.getContext();
   // If the module's symbol itself conflicts, then set a "verilogName" attribute
   // on the module to reflect the name we need to use.
   StringRef oldName = module.getName();
   auto newName = globalNameResolver.getLegalName(oldName);
   if (newName != oldName)
-    module->setAttr("verilogName",
-                    StringAttr::get(module.getContext(), newName));
+    module->setAttr("verilogName", StringAttr::get(ctxt, newName));
 
   NameCollisionResolver nameResolver;
-
+  auto verilogNameAttr = StringAttr::get(ctxt, "hw.verilogName");
   // Legalize the port names.
   size_t portIdx = 0;
+  SmallVector<Attribute, 4> argNames, resultNames;
   for (const PortInfo &port : getAllModulePortInfos(module)) {
     auto newName = nameResolver.getLegalName(port.name);
-    if (newName != port.name.getValue())
+    if (newName != port.name.getValue()) {
       globalNameTable.addRenamedPort(module, port, newName);
+      if (port.isOutput())
+        module.setResultAttr(port.argNum, verilogNameAttr,
+                             StringAttr::get(ctxt, newName));
+      else
+        module.setArgAttr(port.argNum, verilogNameAttr,
+                          StringAttr::get(ctxt, newName));
+    }
     ++portIdx;
   }
 
@@ -150,8 +158,10 @@ void GlobalNameResolver::legalizeModuleNames(HWModuleOp module) {
   module.walk([&](Operation *op) {
     if (auto nameAttr = getDeclarationName(op)) {
       auto newName = nameResolver.getLegalName(nameAttr);
-      if (newName != nameAttr.getValue())
+      if (newName != nameAttr.getValue()) {
         globalNameTable.addRenamedDeclaration(op, newName);
+        op->setAttr(verilogNameAttr, StringAttr::get(ctxt, newName));
+      }
     }
   });
 }

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1149,3 +1149,13 @@ sv.bind #hw.innerNameRef<@NastyPortParent::@foo>
 // CHECK-NEXT:    ._lots24of_dots (foo__lots24of_dots)
 // CHECK-NEXT:    ._more_dots     (foo__more_dots)
 // CHECK-NEXT:  );
+
+// CHECK-LABEL:  hw.module @issue595
+// CHECK-NEXT:    %0 = sv.wire  {hw.verilogName = "_T"} : !hw.inout<i32>
+
+// CHECK-LABEL: hw.module @extInst2
+// CHECK-SAME: (%signed: i1 {hw.verilogName = "signed_0"}
+
+// CHECK-LABEL:  hw.module @remoteInstDut
+// CHECK:    %signed = sv.wire  {hw.verilogName = "signed_0"} : !hw.inout<i1>
+// CHECK:    %output = sv.reg  {hw.verilogName = "output_1"} : !hw.inout<i1>


### PR DESCRIPTION
Add the `hw.verilogName` attribute after `LegalizeNames` updates the name.
This ensures that passes that run after `ExportVerilog` get the correct 
verilog name from the IR.
Fixes part of, https://github.com/llvm/circt/issues/2220, 
the pass still needs to be updated to use the `hw.verilogName` attribute.

We need the `hw.` prefix in the attribute name because argument 
attribute needs the dialect prefix, 
https://github.com/llvm/llvm-project/blob/main/mlir/include/mlir/IR/FunctionSupport.h#L616