### PR TITLE
ExportVerilog: handle substitutions with extra braces

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -644,8 +644,10 @@ void EmitterBase::emitTextWithSubstitutions(
       while (next < string.size() && isdigit(string[next]))
         ++next;
       // We need at least one digit.
-      if (start == next)
+      if (start == next) {
+        next -= 1;
         continue;
+      }
 
       // We must have a }} right after the digits.
       if (!string.substr(next).startswith("}}"))

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -645,7 +645,7 @@ void EmitterBase::emitTextWithSubstitutions(
         ++next;
       // We need at least one digit.
       if (start == next) {
-        next -= 1;
+        next--;
         continue;
       }
 

--- a/test/Conversion/ExportVerilog/verilog-basic.mlir
+++ b/test/Conversion/ExportVerilog/verilog-basic.mlir
@@ -445,6 +445,13 @@ sv.verbatim "VERB: module.extern symB `{{0}}`" {symbols = [#hw.innerNameRef<@Ver
 // CHECK: VERB: module.extern symB `bar`
 
 
+// Should be able to nest interpolated symbols in extra braces
+hw.module @CheckNestedBracesSymbol() { hw.output }
+sv.verbatim "{{0}} {{{0}}}" {symbols = [@CheckNestedBracesSymbol]}
+// CHECK-LABEL: module CheckNestedBracesSymbol();
+// CHECK: CheckNestedBracesSymbol {CheckNestedBracesSymbol}
+
+
 sv.bind #hw.innerNameRef<@BindEmission::@__BindEmissionInstance__> {output_file = #hw.output_file<"BindTest/BindEmissionInstance.sv", excludeFromFileList>}
 // CHECK-LABL: module BindEmissionInstance()
 hw.module @BindEmissionInstance() {


### PR DESCRIPTION
Fixes issue with `sv.verbatim` op where symbols with extra braces around them (e.g. `{{{symbol_id}}}`) were not interpolated