### PR TITLE
[LowerToHW] Don't gate reg randomization on reset

### DIFF
--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -750,13 +750,10 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT:   sv.initial {
     // CHECK-NEXT:     sv.verbatim "`INIT_RANDOM_PROLOG_"
     // CHECK-NEXT:     sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
-    // CHECK-NEXT:       sv.if %reset  {
-    // CHECK-NEXT:       } else {
-    // CHECK-NEXT:         %RANDOM = sv.verbatim.expr.se "`RANDOM" : () -> i32
-    // CHECK-NEXT:         sv.bpassign %reg, %RANDOM : i32
-    // CHECK-NEXT:         %RANDOM_0 = sv.verbatim.expr.se "`RANDOM" : () -> i32
-    // CHECK-NEXT:         sv.bpassign %reg2, %RANDOM_0 : i32
-    // CHECK-NEXT:       }
+    // CHECK-NEXT:       %RANDOM = sv.verbatim.expr.se "`RANDOM" : () -> i32
+    // CHECK-NEXT:       sv.bpassign %reg, %RANDOM : i32
+    // CHECK-NEXT:       %RANDOM_0 = sv.verbatim.expr.se "`RANDOM" : () -> i32
+    // CHECK-NEXT:       sv.bpassign %reg2, %RANDOM_0 : i32
     // CHECK-NEXT:     }
     // CHECK-NEXT:   }
     // CHECK-NEXT: }


### PR DESCRIPTION
Change randomization logic to NOT gate randomization based on a
deasserted reset signal when lowering a FIRRTL regreset.  This aligns
randomization with the Scala FIRRTL Compiler and prevents Xs from
showing up if the reset is not held low when the initial block runs.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>