### PR TITLE
[HW] Add a new op HW::GlobalRef, to replace the FIRRTL::NonLocalAnchor

### DIFF
--- a/docs/RationaleHW.md
+++ b/docs/RationaleHW.md
@@ -160,6 +160,8 @@ and also for metadata emission.
 ``` mlir
   hw.globalRef @glbl_B_M1 [#hw.innerNameRef<@A::@inst_1>, #hw.innerNameRef<@B::@memInst>]
   hw.globalRef @glbl_D_M1 [#hw.innerNameRef<@A::@inst_0>, #hw.innerNameRef<@C::@inst>, #hw.innerNameRef<@D::@memInst>]
+  hw.globalRef @glbl_D_M2 [#hw.innerNameRef<@A::@SF>, #hw.innerNameRef<@F::@symA>]
+  hw.globalRef @glbl_D_M3 [#hw.innerNameRef<@A::@SF>, #hw.innerNameRef<@F::@symB>]
   hw.module @D() -> () {
     hw.instance "M1" sym @memInst @FIRRTLMem() -> () {circt.globalRef = [#hw.globalNameRef<@glbl_D_M1>]}
   }
@@ -172,7 +174,10 @@ and also for metadata emission.
   hw.module @A() -> () {
     hw.instance "h1" sym @inst_1 @B() -> () {circt.globalRef = [#hw.globalNameRef<@glbl_B_M1>]}
     hw.instance "h2" sym @inst_0 @C() -> () {circt.globalRef = [#hw.globalNameRef<@glbl_D_M1>]}
+    %c0 = hw.constant 0 : i1
+    %2 = hw.instance "ab" sym @SF  @F (a1: %c0: i1) -> (a2 : i1) {circt.globalRef = [#hw.globalNameRef<@glbl_D_M2>, #hw.globalNameRef<@glbl_D_M3>]}
   }
+  hw.module.extern  @F(%a1: i1 {hw.exportPort = @symA, circt.globalRef = [#hw.globalNameRef<@glbl_D_M2>]}) -> (a2: i1 {hw.exportPort = @symB, circt.globalRef = [#hw.globalNameRef<@glbl_D_M3>]}) attributes {}
 
 sv.verbatim "{{0}}" { symbols = [@glbl_D_M1] }
 sv.verbatim "{{0}}" { symbols = [@glbl_B_M1] }

--- a/docs/RationaleHW.md
+++ b/docs/RationaleHW.md
@@ -142,6 +142,42 @@ notable differences: for example:
    on the other hand, do support both of these.  Zero width ports are omitted (printed as
    comments) when generating verilog.
 
+### GlobalRef
+The GlobalRef operation (`hw.globalRef`) can be used to identify the unique
+ instance path of an operation globally.
+`hw.globalRef` can be used to attach nonlocal annotations in FIRRTL dialect
+and also for metadata emission.
+`hw.globalRef` defines a symbol and contains a list of module local
+`hw.innerNameRef` symbols to define the instance path.
+ For example, in the following example, `@glbl_B_M1` specifies instance
+ "h1" in module `@A`, followed by instance
+ "M1" in module `@B`.
+
+`hw.globalRef` can define a unique instance path, and each element along the way
+ carries an attribute `circt.globalRef`, pointing to the global op. 
+ Thus instances participating in nonlocal paths are readily apparent.
+
+``` mlir
+  hw.globalRef @glbl_B_M1 [#hw.innerNameRef<@A::@inst_1>, #hw.innerNameRef<@B::@memInst>]
+  hw.globalRef @glbl_D_M1 [#hw.innerNameRef<@A::@inst_0>, #hw.innerNameRef<@C::@inst>, #hw.innerNameRef<@D::@memInst>]
+  hw.module @D() -> () {
+    hw.instance "M1" sym @memInst @FIRRTLMem() -> () {circt.globalRef = [#hw.globalNameRef<@glbl_D_M1>]}
+  }
+  hw.module @B() -> () {
+     hw.instance "M1" sym @memInst @FIRRTLMem() -> () {circt.globalRef = [#hw.globalNameRef<@glbl_B_M1>]}
+  }
+  hw.module @C() -> () {
+    hw.instance "m" sym @inst @D() -> () {circt.globalRef = [#hw.globalNameRef<@glbl_D_M1>]}
+  }
+  hw.module @A() -> () {
+    hw.instance "h1" sym @inst_1 @B() -> () {circt.globalRef = [#hw.globalNameRef<@glbl_B_M1>]}
+    hw.instance "h2" sym @inst_0 @C() -> () {circt.globalRef = [#hw.globalNameRef<@glbl_D_M1>]}
+  }
+
+sv.verbatim "{{0}}" { symbols = [@glbl_D_M1] }
+sv.verbatim "{{0}}" { symbols = [@glbl_B_M1] }
+```
+
 ### Instance paths
 
 An IR for Hardware is different than an IR for Software in a very important way:

--- a/docs/RationaleHW.md
+++ b/docs/RationaleHW.md
@@ -142,8 +142,8 @@ notable differences: for example:
    on the other hand, do support both of these.  Zero width ports are omitted (printed as
    comments) when generating verilog.
 
-### GlobalRef
-The GlobalRef operation (`hw.globalRef`) can be used to identify the unique
+### GlobalRefOp
+The GlobalRefOp operation (`hw.globalRef`) can be used to identify the unique
  instance path of an operation globally.
 `hw.globalRef` can be used to attach nonlocal annotations in FIRRTL dialect
 and also for metadata emission.

--- a/include/circt/Dialect/HW/HWAttributesNaming.td
+++ b/include/circt/Dialect/HW/HWAttributesNaming.td
@@ -22,4 +22,19 @@ def InnerRefAttr : AttrDef<HWDialect, "InnerRef"> {
       return get(module.getContext(), module, name);
     }]>,
   ];
+  let extraClassDeclaration = [{
+    /// Get the InnerRefAttr for an operation and add the sym on it.
+    static InnerRefAttr getFromOperation(mlir::Operation *op,
+                  mlir::StringAttr symName, mlir::StringAttr moduleName) ;
+  }];
+}
+
+def GlobalRefAttr : AttrDef<HWDialect, "GlobalRef"> {
+  let summary = "Refer to a non-local symbol";
+  let description = [{
+    This works like a symbol reference, but to a global symbol with a possible
+    unique instance path.
+  }];
+  let mnemonic = "globalNameRef";
+  let parameters = (ins "::mlir::FlatSymbolRefAttr":$glblSym);
 }

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -438,7 +438,7 @@ def OutputOp : HWOp<"output", [Terminator, HasParent<"HWModuleOp">,
   let verifier = "return ::verifyOutputOp(this);";
 }
 
-def GlobalRef : HWOp<"globalRef", [IsolatedFromAbove, Symbol]> {
+def GlobalRefOp : HWOp<"globalRef", [IsolatedFromAbove, Symbol]> {
   let summary = "A global reference to uniquely identify each"
                                     "instance of an operation";
   let description = [{

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -437,3 +437,18 @@ def OutputOp : HWOp<"output", [Terminator, HasParent<"HWModuleOp">,
 
   let verifier = "return ::verifyOutputOp(this);";
 }
+
+def GlobalRef : HWOp<"globalRef", [IsolatedFromAbove, Symbol]> {
+  let summary = "A global reference to uniquely identify each"
+                                    "instance of an operation";
+  let description = [{
+    This works like a symbol reference to an operation by specifying the
+    instance path to uniquely identify it globally.
+    It can be used to attach per instance metadata (non-local attributes).
+    This also lets components of the path point to a common entity.
+  }];
+
+  let arguments = (ins SymbolNameAttr:$sym_name, NameRefArrayAttr:$namepath);
+
+  let assemblyFormat = [{ $sym_name $namepath attr-dict}];
+}

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -448,7 +448,13 @@ def GlobalRef : HWOp<"globalRef", [IsolatedFromAbove, Symbol]> {
     This also lets components of the path point to a common entity.
   }];
 
+  let extraClassDeclaration = [{
+    LogicalResult verifyGlobalRef();
+  }];
+
   let arguments = (ins SymbolNameAttr:$sym_name, NameRefArrayAttr:$namepath);
 
   let assemblyFormat = [{ $sym_name $namepath attr-dict}];
+
+  let verifier = "return this->verifyGlobalRef();";
 }

--- a/lib/Dialect/HW/HWAttributes.cpp
+++ b/lib/Dialect/HW/HWAttributes.cpp
@@ -210,7 +210,7 @@ void InnerRefAttr::print(AsmPrinter &p) const {
 InnerRefAttr InnerRefAttr::getFromOperation(mlir::Operation *op,
                                             mlir::StringAttr symName,
                                             mlir::StringAttr moduleName) {
-  auto attrName = "inner_sym";
+  char attrName[] = "inner_sym";
   auto attr = op->getAttrOfType<StringAttr>(attrName);
   if (!attr) {
     attr = symName;

--- a/lib/Dialect/HW/HWAttributes.cpp
+++ b/lib/Dialect/HW/HWAttributes.cpp
@@ -205,6 +205,38 @@ void InnerRefAttr::print(AsmPrinter &p) const {
   p << ">";
 }
 
+/// Get an InnerRefAttr, and add the sym to the op if not already
+/// there. Also reponsibility of client to ensure the symName is unique.
+InnerRefAttr InnerRefAttr::getFromOperation(mlir::Operation *op,
+                                            mlir::StringAttr symName,
+                                            mlir::StringAttr moduleName) {
+  auto attrName = "inner_sym";
+  auto attr = op->getAttrOfType<StringAttr>(attrName);
+  if (!attr) {
+    attr = symName;
+    op->setAttr(attrName, attr);
+  }
+  return InnerRefAttr::get(moduleName, attr);
+}
+
+//===----------------------------------------------------------------------===//
+// GlobalRefAttr
+//===----------------------------------------------------------------------===//
+
+Attribute GlobalRefAttr::parse(AsmParser &p, Type type) {
+  FlatSymbolRefAttr attr;
+  if (p.parseLess() || p.parseAttribute<FlatSymbolRefAttr>(attr) ||
+      p.parseGreater())
+    return Attribute();
+  return GlobalRefAttr::get(p.getContext(), attr);
+}
+
+void GlobalRefAttr::print(AsmPrinter &p) const {
+  p << "<";
+  p.printSymbolName(getGlblSym().getValue());
+  p << ">";
+}
+
 //===----------------------------------------------------------------------===//
 // ParamDeclAttr
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1222,9 +1222,10 @@ static LogicalResult verifyOutputOp(OutputOp *op) {
 // Other Operations
 //===----------------------------------------------------------------------===//
 
-LogicalResult GlobalRef::verifyGlobalRef() {
-  auto parent = (*this)->getParentOp();
-  auto symNameAttr = (*this).sym_nameAttr();
+LogicalResult GlobalRefOp::verifyGlobalRef() {
+  // TODO: Cannot verify GlobalRef on ports yet.
+  Operation* parent = (*this)->getParentOp();
+  StringAttr symNameAttr = (*this).sym_nameAttr();
   static const char globalRefStr[] = "circt.globalRef";
   SymbolTable symTable(parent);
   // For all inner refs in the namepath, ensure they have a corresponding
@@ -1232,14 +1233,14 @@ LogicalResult GlobalRef::verifyGlobalRef() {
   for (auto innerRef : namepath().getAsRange<hw::InnerRefAttr>()) {
     StringAttr modName = innerRef.getModule();
     StringAttr innerSym = innerRef.getName();
-    auto mod = symTable.lookup(modName);
+    Operation* mod = symTable.lookup(modName);
     if (!mod) {
       (*this)->emitOpError("module:'" + modName.str() + "' not found");
       return failure();
     }
     bool glblSymNotFound = true;
     mod->walk([&](Operation *op) -> WalkResult {
-      auto attr = op->getAttrOfType<StringAttr>("inner_sym");
+      StringAttr attr = op->getAttrOfType<StringAttr>("inner_sym");
       // If this is one of the ops in the instance path for the GlobalRefOp.
       if (attr && attr == innerSym) {
         // Each op can have an array of GlobalRefAttr, check if this op is one

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1261,7 +1261,8 @@ LogicalResult GlobalRefOp::verifyGlobalRef() {
       return WalkResult::advance();
     });
     if (glblSymNotFound) {
-      // TODO: Doesn't yet work for symbls on FIRRTL module ports. Need to implement an interface.
+      // TODO: Doesn't yet work for symbls on FIRRTL module ports. Need to
+      // implement an interface.
       if (isa<HWModuleOp, HWModuleExternOp>(mod)) {
         if (auto argAttrs =
                 mod->getAttr(mlir::function_like_impl::getArgDictAttrName()))

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1224,7 +1224,7 @@ static LogicalResult verifyOutputOp(OutputOp *op) {
 
 LogicalResult GlobalRefOp::verifyGlobalRef() {
   // TODO: Cannot verify GlobalRef on ports yet.
-  Operation* parent = (*this)->getParentOp();
+  Operation *parent = (*this)->getParentOp();
   StringAttr symNameAttr = (*this).sym_nameAttr();
   static const char globalRefStr[] = "circt.globalRef";
   SymbolTable symTable(parent);
@@ -1233,7 +1233,7 @@ LogicalResult GlobalRefOp::verifyGlobalRef() {
   for (auto innerRef : namepath().getAsRange<hw::InnerRefAttr>()) {
     StringAttr modName = innerRef.getModule();
     StringAttr innerSym = innerRef.getName();
-    Operation* mod = symTable.lookup(modName);
+    Operation *mod = symTable.lookup(modName);
     if (!mod) {
       (*this)->emitOpError("module:'" + modName.str() + "' not found");
       return failure();

--- a/test/Dialect/HW/basic.mlir
+++ b/test/Dialect/HW/basic.mlir
@@ -152,3 +152,29 @@ hw.module @fileListTest(%arg1: i32) attributes {output_filelist = #hw.output_fil
 // CHECK-LABEL: hw.module @commentModule
 // CHECK-SAME: attributes {comment = "hello world"}
 hw.module @commentModule() attributes {comment = "hello world"} {}
+
+module {
+// CHECK-LABEL: module {
+  hw.globalRef @glbl_B_M1 [#hw.innerNameRef<@A::@inst_1>, #hw.innerNameRef<@B::@memInst>]
+  hw.globalRef @glbl_D_M1 [#hw.innerNameRef<@A::@inst_0>, #hw.innerNameRef<@C::@inst>, #hw.innerNameRef<@D::@memInst>]
+
+  // CHECK:  hw.globalRef @glbl_B_M1 [#hw.innerNameRef<@A::@inst_1>, #hw.innerNameRef<@B::@memInst>]
+  // CHECK:  hw.globalRef @glbl_D_M1 [#hw.innerNameRef<@A::@inst_0>, #hw.innerNameRef<@C::@inst>, #hw.innerNameRef<@D::@memInst>]
+
+
+  hw.module @FIRRTLMem() -> () {
+  }
+  hw.module @D() -> () {
+    hw.instance "M1" sym @memInst @FIRRTLMem() -> () {circt.globalRef = [#hw.globalNameRef<@glbl_D_M1>]}
+  }
+  hw.module @B() -> () {
+     hw.instance "M1" sym @memInst @FIRRTLMem() -> () {circt.globalRef = [#hw.globalNameRef<@glbl_B_M1>]}
+  }
+  hw.module @C() -> () {
+    hw.instance "m" sym @inst @D() -> () {circt.globalRef = [#hw.globalNameRef<@glbl_D_M1>]}
+  }
+  hw.module @A() -> () {
+    hw.instance "h1" sym @inst_1 @B() -> () {circt.globalRef = [#hw.globalNameRef<@glbl_B_M1>]}
+    hw.instance "h2" sym @inst_0 @C() -> () {circt.globalRef = [#hw.globalNameRef<@glbl_D_M1>]}
+  }
+}

--- a/test/Dialect/HW/basic.mlir
+++ b/test/Dialect/HW/basic.mlir
@@ -1,180 +1,34 @@
 // RUN: circt-opt %s -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
 
-// CHECK-LABEL: hw.module @test1(%arg0: i3, %arg1: i1, %arg2: !hw.array<1000xi8>) -> (result: i50) {
-hw.module @test1(%arg0: i3, %arg1: i1, %arg2: !hw.array<1000xi8>) -> (result: i50) {
-  // CHECK-NEXT:    %c42_i12 = hw.constant 42 : i12
-  // CHECK-NEXT:    [[RES0:%[0-9]+]] = comb.add %c42_i12, %c42_i12 : i12
-  // CHECK-NEXT:    [[RES1:%[0-9]+]] = comb.mul %c42_i12, [[RES0]] : i12
-  %a = hw.constant 42 : i12
-  %b = comb.add %a, %a : i12
-  %c = comb.mul %a, %b : i12
-
-  // CHECK-NEXT:    [[RES2:%[0-9]+]] = comb.concat %arg0, %arg0, %arg1
-  %d = comb.concat %arg0, %arg0, %arg1 : i3, i3, i1
-
-  // CHECK-NEXT:    [[RES4:%[0-9]+]] = comb.concat %c42_i12 : i12
-  %conc1 = comb.concat %a : i12
-
-  // CHECK-NEXT:    [[RES7:%[0-9]+]] = comb.parity [[RES4]] : i12
-  %parity1 = comb.parity %conc1 : i12
-
-  // CHECK-NEXT:    [[RES8:%[0-9]+]] = comb.concat [[RES4]], [[RES0]], [[RES1]], [[RES2]], [[RES2]] : i12, i12, i12, i7, i7
-  %result = comb.concat %conc1, %b, %c, %d, %d : i12, i12, i12, i7, i7
-
-  // CHECK-NEXT: [[RES9:%[0-9]+]] = comb.extract [[RES8]] from 4 : (i50) -> i19
-  %small1 = comb.extract %result from 4 : (i50) -> i19
-
-  // CHECK-NEXT: [[RES10:%[0-9]+]] = comb.extract [[RES8]] from 31 : (i50) -> i19
-  %small2 = comb.extract %result from 31 : (i50) -> i19
-
-  // CHECK-NEXT: comb.add [[RES9]], [[RES10]] : i19
-  %add = comb.add %small1, %small2 : i19
-
-  // CHECK-NEXT: comb.icmp eq [[RES9]], [[RES10]] : i19
-  %eq = comb.icmp eq %small1, %small2 : i19
-
-  // CHECK-NEXT: comb.icmp ne [[RES9]], [[RES10]] : i19
-  %neq = comb.icmp ne %small1, %small2 : i19
-
-  // CHECK-NEXT: comb.icmp slt [[RES9]], [[RES10]] : i19
-  %lt = comb.icmp slt %small1, %small2 : i19
-
-  // CHECK-NEXT: comb.icmp ult [[RES9]], [[RES10]] : i19
-  %ult = comb.icmp ult %small1, %small2 : i19
-
-  // CHECK-NEXT: comb.icmp sle [[RES9]], [[RES10]] : i19
-  %leq = comb.icmp sle %small1, %small2 : i19
-
-  // CHECK-NEXT: comb.icmp ule [[RES9]], [[RES10]] : i19
-  %uleq = comb.icmp ule %small1, %small2 : i19
-
-  // CHECK-NEXT: comb.icmp sgt [[RES9]], [[RES10]] : i19
-  %gt = comb.icmp sgt %small1, %small2 : i19
-
-  // CHECK-NEXT: comb.icmp ugt [[RES9]], [[RES10]] : i19
-  %ugt = comb.icmp ugt %small1, %small2 : i19
-
-  // CHECK-NEXT: comb.icmp sge [[RES9]], [[RES10]] : i19
-  %geq = comb.icmp sge %small1, %small2 : i19
-
-  // CHECK-NEXT: comb.icmp uge [[RES9]], [[RES10]] : i19
-  %ugeq = comb.icmp uge %small1, %small2 : i19
-
-  // CHECK-NEXT: %w = sv.wire : !hw.inout<i4>
-  %w = sv.wire : !hw.inout<i4>
-
-  // CHECK-NEXT: %after1 = sv.wire : !hw.inout<i4>
-  %before1 = sv.wire {name = "after1"} : !hw.inout<i4>
-
-  // CHECK-NEXT: sv.read_inout %after1 : !hw.inout<i4>
-  %read_before1 = sv.read_inout %before1 : !hw.inout<i4>
-
-  // CHECK-NEXT: %after2_conflict = sv.wire : !hw.inout<i4>
-  // CHECK-NEXT: %after2_conflict_0 = sv.wire {name = "after2_conflict"} : !hw.inout<i4>
-  %before2_0 = sv.wire {name = "after2_conflict"} : !hw.inout<i4>
-  %before2_1 = sv.wire {name = "after2_conflict"} : !hw.inout<i4>
-
-  // CHECK-NEXT: %after3 = sv.wire {someAttr = "foo"} : !hw.inout<i4>
-  %before3 = sv.wire {name = "after3", someAttr = "foo"} : !hw.inout<i4>
-
-  // CHECK-NEXT: = comb.mux %arg1, [[RES2]], [[RES2]] : i7
-  %mux = comb.mux %arg1, %d, %d : i7
-
-  // CHECK-NEXT: [[STR:%[0-9]+]] = hw.struct_create ({{.*}}, {{.*}}) : !hw.struct<foo: i19, bar: i7>
-  %s0 = hw.struct_create (%small1, %mux) : !hw.struct<foo: i19, bar: i7>
-
-  // CHECK-NEXT: = hw.struct_extract [[STR]]["foo"] : !hw.struct<foo: i19, bar: i7>
-  %sf1 = hw.struct_extract %s0["foo"] : !hw.struct<foo: i19, bar: i7>
-
-  // CHECK-NEXT: = hw.struct_inject [[STR]]["foo"], {{.*}} : !hw.struct<foo: i19, bar: i7>
-  %s1 = hw.struct_inject %s0["foo"], %sf1 : !hw.struct<foo: i19, bar: i7>
-
-  // CHECK-NEXT: :2 = hw.struct_explode [[STR]] : !hw.struct<foo: i19, bar: i7>
-  %se:2 = hw.struct_explode %s0 : !hw.struct<foo: i19, bar: i7>
-
-  // CHECK-NEXT: hw.bitcast [[STR]] : (!hw.struct<foo: i19, bar: i7>)
-  %structBits = hw.bitcast %s0 : (!hw.struct<foo: i19, bar: i7>) -> i26
-
-  // CHECK-NEXT: = arith.constant 13 : i10
-  %idx = arith.constant 13 : i10
-  // CHECK-NEXT: = hw.array_slice %arg2 at %c13_i10 : (!hw.array<1000xi8>) -> !hw.array<24xi8>
-  %subArray = hw.array_slice %arg2 at %idx : (!hw.array<1000xi8>) -> !hw.array<24xi8>
-  // CHECK-NEXT: [[ARR1:%.+]] = hw.array_create [[RES9]], [[RES10]] : i19
-  %arrCreated = hw.array_create %small1, %small2 : i19
-  // CHECK-NEXT: [[ARR2:%.+]] = hw.array_create [[RES9]], [[RES10]], {{.+}} : i19
-  %arr2 = hw.array_create %small1, %small2, %add : i19
-  // CHECK-NEXT: = hw.array_concat [[ARR1]], [[ARR2]] : !hw.array<2xi19>, !hw.array<3xi19>
-  %bigArray = hw.array_concat %arrCreated, %arr2 : !hw.array<2 x i19>, !hw.array<3 x i19>
-
-  // CHECK-NEXT:    hw.output [[RES8]] : i50
-  hw.output %result : i50
-}
-// CHECK-NEXT:  }
-
-hw.module @UnionOps(%a: !hw.union<foo: i1, bar: i3>) -> (x: i3, z: !hw.union<bar: i3, baz: i8>) {
-  %x = hw.union_extract %a["bar"] : !hw.union<foo: i1, bar: i3>
-  %z = hw.union_create "bar", %x : !hw.union<bar: i3, baz: i8>
-  hw.output %x, %z : i3, !hw.union<bar: i3, baz: i8>
-}
-// CHECK-LABEL: hw.module @UnionOps(%a: !hw.union<foo: i1, bar: i3>) -> (x: i3, z: !hw.union<bar: i3, baz: i8>) {
-// CHECK-NEXT:    [[I3REG:%.+]] = hw.union_extract %a["bar"] : !hw.union<foo: i1, bar: i3>
-// CHECK-NEXT:    [[UREG:%.+]] = hw.union_create "bar", [[I3REG]] : !hw.union<bar: i3, baz: i8>
-// CHECK-NEXT:    hw.output [[I3REG]], [[UREG]] : i3, !hw.union<bar: i3, baz: i8>
-
-// https://github.com/llvm/circt/issues/863
-// CHECK-LABEL: hw.module @signed_arrays
-hw.module @signed_arrays(%arg0: si8) -> (out: !hw.array<2xsi8>) {
-  // CHECK-NEXT:  %wireArray = sv.wire  : !hw.inout<array<2xsi8>>
-  %wireArray = sv.wire : !hw.inout<!hw.array<2xsi8>>
-
-  // CHECK-NEXT: %0 = hw.array_create %arg0, %arg0 : si8
-  %0 = hw.array_create %arg0, %arg0 : si8
-
-  // CHECK-NEXT: sv.assign %wireArray, %0 : !hw.array<2xsi8>
-  sv.assign %wireArray, %0 : !hw.array<2xsi8>
-
-  %result = sv.read_inout %wireArray : !hw.inout<!hw.array<2xsi8>>
-  hw.output %result : !hw.array<2xsi8>
-}
-
-/// Port names that aren't valid MLIR identifiers are handled with `argNames`
-/// attribute being explicitly printed.
-// https://github.com/llvm/circt/issues/1822
-
-// CHECK-LABEL: hw.module @argRenames
-// CHECK-SAME: attributes {argNames = [""]}
-hw.module @argRenames(%arg1: i32) attributes {argNames = [""]} {
-}
-
-hw.module @fileListTest(%arg1: i32) attributes {output_filelist = #hw.output_filelist<"foo.f">} {
-}
-
-// CHECK-LABEL: hw.module @commentModule
-// CHECK-SAME: attributes {comment = "hello world"}
-hw.module @commentModule() attributes {comment = "hello world"} {}
 
 module {
 // CHECK-LABEL: module {
   hw.globalRef @glbl_B_M1 [#hw.innerNameRef<@A::@inst_1>, #hw.innerNameRef<@B::@memInst>]
   hw.globalRef @glbl_D_M1 [#hw.innerNameRef<@A::@inst_0>, #hw.innerNameRef<@C::@inst>, #hw.innerNameRef<@D::@memInst>]
+    hw.globalRef @glbl_D_M2 [#hw.innerNameRef<@A::@inst_0>, #hw.innerNameRef<@C::@inst>, #hw.innerNameRef<@D::@SF>, #hw.innerNameRef<@F::@symA>]
+    hw.globalRef @glbl_D_M3 [#hw.innerNameRef<@A::@inst_0>, #hw.innerNameRef<@C::@inst>,   #hw.innerNameRef<@D::@SF>, #hw.innerNameRef<@F::@symB>]
 
   // CHECK:  hw.globalRef @glbl_B_M1 [#hw.innerNameRef<@A::@inst_1>, #hw.innerNameRef<@B::@memInst>]
   // CHECK:  hw.globalRef @glbl_D_M1 [#hw.innerNameRef<@A::@inst_0>, #hw.innerNameRef<@C::@inst>, #hw.innerNameRef<@D::@memInst>]
+  // CHECK:  hw.globalRef @glbl_D_M2 [#hw.innerNameRef<@A::@inst_0>, #hw.innerNameRef<@C::@inst>, #hw.innerNameRef<@D::@SF>, #hw.innerNameRef<@F::@symA>]
+  // CHECK:  hw.globalRef @glbl_D_M3 [#hw.innerNameRef<@A::@inst_0>, #hw.innerNameRef<@C::@inst>, #hw.innerNameRef<@D::@SF>, #hw.innerNameRef<@F::@symB>]
 
-
+  hw.module.extern @F(%in: i1 {hw.exportPort = @symA}) -> (out: i1 {hw.exportPort = @symB}) attributes {circt.globalRef = [[#hw.globalNameRef<@glbl_D_M2>], [#hw.globalNameRef<@glbl_D_M3>]]}
   hw.module @FIRRTLMem() -> () {
   }
   hw.module @D() -> () {
     hw.instance "M1" sym @memInst @FIRRTLMem() -> () {circt.globalRef = [#hw.globalNameRef<@glbl_D_M1>]}
+    %c0 = hw.constant 0 : i1
+    %2 = hw.instance "ab" sym @SF  @F (in: %c0: i1) -> (out : i1) {circt.globalRef = [#hw.globalNameRef<@glbl_D_M2>, #hw.globalNameRef<@glbl_D_M3>]}
   }
   hw.module @B() -> () {
      hw.instance "M1" sym @memInst @FIRRTLMem() -> () {circt.globalRef = [#hw.globalNameRef<@glbl_B_M1>]}
   }
   hw.module @C() -> () {
-    hw.instance "m" sym @inst @D() -> () {circt.globalRef = [#hw.globalNameRef<@glbl_D_M1>]}
+    hw.instance "m" sym @inst @D() -> () {circt.globalRef = [#hw.globalNameRef<@glbl_D_M1>, #hw.globalNameRef<@glbl_D_M2>, #hw.globalNameRef<@glbl_D_M3>]}
   }
   hw.module @A() -> () {
     hw.instance "h1" sym @inst_1 @B() -> () {circt.globalRef = [#hw.globalNameRef<@glbl_B_M1>]}
-    hw.instance "h2" sym @inst_0 @C() -> () {circt.globalRef = [#hw.globalNameRef<@glbl_D_M1>]}
+    hw.instance "h2" sym @inst_0 @C() -> () {circt.globalRef = [#hw.globalNameRef<@glbl_D_M1>, #hw.globalNameRef<@glbl_D_M2>, #hw.globalNameRef<@glbl_D_M3>]}
   }
 }

--- a/test/Dialect/HW/basic.mlir
+++ b/test/Dialect/HW/basic.mlir
@@ -1,19 +1,175 @@
 // RUN: circt-opt %s -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
 
+// CHECK-LABEL: hw.module @test1(%arg0: i3, %arg1: i1, %arg2: !hw.array<1000xi8>) -> (result: i50) {
+hw.module @test1(%arg0: i3, %arg1: i1, %arg2: !hw.array<1000xi8>) -> (result: i50) {
+  // CHECK-NEXT:    %c42_i12 = hw.constant 42 : i12
+  // CHECK-NEXT:    [[RES0:%[0-9]+]] = comb.add %c42_i12, %c42_i12 : i12
+  // CHECK-NEXT:    [[RES1:%[0-9]+]] = comb.mul %c42_i12, [[RES0]] : i12
+  %a = hw.constant 42 : i12
+  %b = comb.add %a, %a : i12
+  %c = comb.mul %a, %b : i12
+
+  // CHECK-NEXT:    [[RES2:%[0-9]+]] = comb.concat %arg0, %arg0, %arg1
+  %d = comb.concat %arg0, %arg0, %arg1 : i3, i3, i1
+
+  // CHECK-NEXT:    [[RES4:%[0-9]+]] = comb.concat %c42_i12 : i12
+  %conc1 = comb.concat %a : i12
+
+  // CHECK-NEXT:    [[RES7:%[0-9]+]] = comb.parity [[RES4]] : i12
+  %parity1 = comb.parity %conc1 : i12
+
+  // CHECK-NEXT:    [[RES8:%[0-9]+]] = comb.concat [[RES4]], [[RES0]], [[RES1]], [[RES2]], [[RES2]] : i12, i12, i12, i7, i7
+  %result = comb.concat %conc1, %b, %c, %d, %d : i12, i12, i12, i7, i7
+
+  // CHECK-NEXT: [[RES9:%[0-9]+]] = comb.extract [[RES8]] from 4 : (i50) -> i19
+  %small1 = comb.extract %result from 4 : (i50) -> i19
+
+  // CHECK-NEXT: [[RES10:%[0-9]+]] = comb.extract [[RES8]] from 31 : (i50) -> i19
+  %small2 = comb.extract %result from 31 : (i50) -> i19
+
+  // CHECK-NEXT: comb.add [[RES9]], [[RES10]] : i19
+  %add = comb.add %small1, %small2 : i19
+
+  // CHECK-NEXT: comb.icmp eq [[RES9]], [[RES10]] : i19
+  %eq = comb.icmp eq %small1, %small2 : i19
+
+  // CHECK-NEXT: comb.icmp ne [[RES9]], [[RES10]] : i19
+  %neq = comb.icmp ne %small1, %small2 : i19
+
+  // CHECK-NEXT: comb.icmp slt [[RES9]], [[RES10]] : i19
+  %lt = comb.icmp slt %small1, %small2 : i19
+
+  // CHECK-NEXT: comb.icmp ult [[RES9]], [[RES10]] : i19
+  %ult = comb.icmp ult %small1, %small2 : i19
+
+  // CHECK-NEXT: comb.icmp sle [[RES9]], [[RES10]] : i19
+  %leq = comb.icmp sle %small1, %small2 : i19
+
+  // CHECK-NEXT: comb.icmp ule [[RES9]], [[RES10]] : i19
+  %uleq = comb.icmp ule %small1, %small2 : i19
+
+  // CHECK-NEXT: comb.icmp sgt [[RES9]], [[RES10]] : i19
+  %gt = comb.icmp sgt %small1, %small2 : i19
+
+  // CHECK-NEXT: comb.icmp ugt [[RES9]], [[RES10]] : i19
+  %ugt = comb.icmp ugt %small1, %small2 : i19
+
+  // CHECK-NEXT: comb.icmp sge [[RES9]], [[RES10]] : i19
+  %geq = comb.icmp sge %small1, %small2 : i19
+
+  // CHECK-NEXT: comb.icmp uge [[RES9]], [[RES10]] : i19
+  %ugeq = comb.icmp uge %small1, %small2 : i19
+
+  // CHECK-NEXT: %w = sv.wire : !hw.inout<i4>
+  %w = sv.wire : !hw.inout<i4>
+
+  // CHECK-NEXT: %after1 = sv.wire : !hw.inout<i4>
+  %before1 = sv.wire {name = "after1"} : !hw.inout<i4>
+
+  // CHECK-NEXT: sv.read_inout %after1 : !hw.inout<i4>
+  %read_before1 = sv.read_inout %before1 : !hw.inout<i4>
+
+  // CHECK-NEXT: %after2_conflict = sv.wire : !hw.inout<i4>
+  // CHECK-NEXT: %after2_conflict_0 = sv.wire {name = "after2_conflict"} : !hw.inout<i4>
+  %before2_0 = sv.wire {name = "after2_conflict"} : !hw.inout<i4>
+  %before2_1 = sv.wire {name = "after2_conflict"} : !hw.inout<i4>
+
+  // CHECK-NEXT: %after3 = sv.wire {someAttr = "foo"} : !hw.inout<i4>
+  %before3 = sv.wire {name = "after3", someAttr = "foo"} : !hw.inout<i4>
+
+  // CHECK-NEXT: = comb.mux %arg1, [[RES2]], [[RES2]] : i7
+  %mux = comb.mux %arg1, %d, %d : i7
+
+  // CHECK-NEXT: [[STR:%[0-9]+]] = hw.struct_create ({{.*}}, {{.*}}) : !hw.struct<foo: i19, bar: i7>
+  %s0 = hw.struct_create (%small1, %mux) : !hw.struct<foo: i19, bar: i7>
+
+  // CHECK-NEXT: = hw.struct_extract [[STR]]["foo"] : !hw.struct<foo: i19, bar: i7>
+  %sf1 = hw.struct_extract %s0["foo"] : !hw.struct<foo: i19, bar: i7>
+
+  // CHECK-NEXT: = hw.struct_inject [[STR]]["foo"], {{.*}} : !hw.struct<foo: i19, bar: i7>
+  %s1 = hw.struct_inject %s0["foo"], %sf1 : !hw.struct<foo: i19, bar: i7>
+
+  // CHECK-NEXT: :2 = hw.struct_explode [[STR]] : !hw.struct<foo: i19, bar: i7>
+  %se:2 = hw.struct_explode %s0 : !hw.struct<foo: i19, bar: i7>
+
+  // CHECK-NEXT: hw.bitcast [[STR]] : (!hw.struct<foo: i19, bar: i7>)
+  %structBits = hw.bitcast %s0 : (!hw.struct<foo: i19, bar: i7>) -> i26
+
+  // CHECK-NEXT: = arith.constant 13 : i10
+  %idx = arith.constant 13 : i10
+  // CHECK-NEXT: = hw.array_slice %arg2 at %c13_i10 : (!hw.array<1000xi8>) -> !hw.array<24xi8>
+  %subArray = hw.array_slice %arg2 at %idx : (!hw.array<1000xi8>) -> !hw.array<24xi8>
+  // CHECK-NEXT: [[ARR1:%.+]] = hw.array_create [[RES9]], [[RES10]] : i19
+  %arrCreated = hw.array_create %small1, %small2 : i19
+  // CHECK-NEXT: [[ARR2:%.+]] = hw.array_create [[RES9]], [[RES10]], {{.+}} : i19
+  %arr2 = hw.array_create %small1, %small2, %add : i19
+  // CHECK-NEXT: = hw.array_concat [[ARR1]], [[ARR2]] : !hw.array<2xi19>, !hw.array<3xi19>
+  %bigArray = hw.array_concat %arrCreated, %arr2 : !hw.array<2 x i19>, !hw.array<3 x i19>
+
+  // CHECK-NEXT:    hw.output [[RES8]] : i50
+  hw.output %result : i50
+}
+// CHECK-NEXT:  }
+
+hw.module @UnionOps(%a: !hw.union<foo: i1, bar: i3>) -> (x: i3, z: !hw.union<bar: i3, baz: i8>) {
+  %x = hw.union_extract %a["bar"] : !hw.union<foo: i1, bar: i3>
+  %z = hw.union_create "bar", %x : !hw.union<bar: i3, baz: i8>
+  hw.output %x, %z : i3, !hw.union<bar: i3, baz: i8>
+}
+// CHECK-LABEL: hw.module @UnionOps(%a: !hw.union<foo: i1, bar: i3>) -> (x: i3, z: !hw.union<bar: i3, baz: i8>) {
+// CHECK-NEXT:    [[I3REG:%.+]] = hw.union_extract %a["bar"] : !hw.union<foo: i1, bar: i3>
+// CHECK-NEXT:    [[UREG:%.+]] = hw.union_create "bar", [[I3REG]] : !hw.union<bar: i3, baz: i8>
+// CHECK-NEXT:    hw.output [[I3REG]], [[UREG]] : i3, !hw.union<bar: i3, baz: i8>
+
+// https://github.com/llvm/circt/issues/863
+// CHECK-LABEL: hw.module @signed_arrays
+hw.module @signed_arrays(%arg0: si8) -> (out: !hw.array<2xsi8>) {
+  // CHECK-NEXT:  %wireArray = sv.wire  : !hw.inout<array<2xsi8>>
+  %wireArray = sv.wire : !hw.inout<!hw.array<2xsi8>>
+
+  // CHECK-NEXT: %0 = hw.array_create %arg0, %arg0 : si8
+  %0 = hw.array_create %arg0, %arg0 : si8
+
+  // CHECK-NEXT: sv.assign %wireArray, %0 : !hw.array<2xsi8>
+  sv.assign %wireArray, %0 : !hw.array<2xsi8>
+
+  %result = sv.read_inout %wireArray : !hw.inout<!hw.array<2xsi8>>
+  hw.output %result : !hw.array<2xsi8>
+}
+
+/// Port names that aren't valid MLIR identifiers are handled with `argNames`
+/// attribute being explicitly printed.
+// https://github.com/llvm/circt/issues/1822
+
+// CHECK-LABEL: hw.module @argRenames
+// CHECK-SAME: attributes {argNames = [""]}
+hw.module @argRenames(%arg1: i32) attributes {argNames = [""]} {
+}
+
+hw.module @fileListTest(%arg1: i32) attributes {output_filelist = #hw.output_filelist<"foo.f">} {
+}
+
+// CHECK-LABEL: hw.module @commentModule
+// CHECK-SAME: attributes {comment = "hello world"}
+hw.module @commentModule() attributes {comment = "hello world"} {}
 
 module {
 // CHECK-LABEL: module {
   hw.globalRef @glbl_B_M1 [#hw.innerNameRef<@A::@inst_1>, #hw.innerNameRef<@B::@memInst>]
   hw.globalRef @glbl_D_M1 [#hw.innerNameRef<@A::@inst_0>, #hw.innerNameRef<@C::@inst>, #hw.innerNameRef<@D::@memInst>]
-    hw.globalRef @glbl_D_M2 [#hw.innerNameRef<@A::@inst_0>, #hw.innerNameRef<@C::@inst>, #hw.innerNameRef<@D::@SF>, #hw.innerNameRef<@F::@symA>]
-    hw.globalRef @glbl_D_M3 [#hw.innerNameRef<@A::@inst_0>, #hw.innerNameRef<@C::@inst>,   #hw.innerNameRef<@D::@SF>, #hw.innerNameRef<@F::@symB>]
+  hw.globalRef @glbl_D_M2 [#hw.innerNameRef<@A::@inst_0>, #hw.innerNameRef<@C::@inst>, #hw.innerNameRef<@D::@SF>, #hw.innerNameRef<@F::@symA>]
+  hw.globalRef @glbl_D_M3 [#hw.innerNameRef<@A::@inst_0>, #hw.innerNameRef<@C::@inst>,   #hw.innerNameRef<@D::@SF>, #hw.innerNameRef<@F::@symB>]
 
   // CHECK:  hw.globalRef @glbl_B_M1 [#hw.innerNameRef<@A::@inst_1>, #hw.innerNameRef<@B::@memInst>]
   // CHECK:  hw.globalRef @glbl_D_M1 [#hw.innerNameRef<@A::@inst_0>, #hw.innerNameRef<@C::@inst>, #hw.innerNameRef<@D::@memInst>]
   // CHECK:  hw.globalRef @glbl_D_M2 [#hw.innerNameRef<@A::@inst_0>, #hw.innerNameRef<@C::@inst>, #hw.innerNameRef<@D::@SF>, #hw.innerNameRef<@F::@symA>]
   // CHECK:  hw.globalRef @glbl_D_M3 [#hw.innerNameRef<@A::@inst_0>, #hw.innerNameRef<@C::@inst>, #hw.innerNameRef<@D::@SF>, #hw.innerNameRef<@F::@symB>]
 
-  hw.module.extern @F(%in: i1 {hw.exportPort = @symA}) -> (out: i1 {hw.exportPort = @symB}) attributes {circt.globalRef = [[#hw.globalNameRef<@glbl_D_M2>], [#hw.globalNameRef<@glbl_D_M3>]]}
+  // hw.module.extern @F(%in: i1 {hw.exportPort = @symA}) -> (out: i1 {hw.exportPort = @symB}) attributes {circt.globalRef = [[#hw.globalNameRef<@glbl_D_M2>], [#hw.globalNameRef<@glbl_D_M3>]]}
+  hw.module.extern  @F(%in: i1 {hw.exportPort = @symA, circt.globalRef = [#hw.globalNameRef<@glbl_D_M2>]}) -> (out: i1 {hw.exportPort = @symB, circt.globalRef = [#hw.globalNameRef<@glbl_D_M3>]}) attributes {}
+  hw.module @F1(%in: i1 {hw.exportPort = @symA, circt.globalRef = [#hw.globalNameRef<@glbl_D_M2>]}) -> (out: i1 {hw.exportPort = @symB, circt.globalRef = [#hw.globalNameRef<@glbl_D_M3>]}) attributes {} {
+   hw.output %in : i1
+  }
   hw.module @FIRRTLMem() -> () {
   }
   hw.module @D() -> () {

--- a/test/Dialect/HW/errors.mlir
+++ b/test/Dialect/HW/errors.mlir
@@ -275,3 +275,15 @@ hw.module @Use<xx: i41>() {
 hw.module @Use<xx: i41, xx: i41>() {
 }
 
+// -----
+
+module  {
+// expected-error @+1 {{'inst_1' in module:'A' does not contain a reference to 'glbl_D_M1'}}
+  hw.globalRef @glbl_D_M1 [#hw.innerNameRef<@A::@inst_1>]
+  hw.module @C() -> () {
+  }
+  hw.module @A() -> () {
+    hw.instance "h2" sym @inst_1 @C() -> () {circt.globalRef = []}
+    hw.instance "h2" sym @inst_0 @C() -> () {circt.globalRef = [#hw.globalNameRef<@glbl_D_M1>]}
+  }
+}


### PR DESCRIPTION
Add a new operation `GlobalRef` to `HW` dialect, that will eventually replace `FIRRTL::NonLocalAnchor`. 
`GlobalRef` can be used to identify a unique instance path of an operation globally.

This is part of the plan to move the `firrtl.nla` to `HW` dialect and use it for all 
metadata emission.
Part of the PR :https://github.com/llvm/circt/pull/2252