### PR TITLE
[FIRRTL] Fix index overflows during subaccess lowering

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -502,8 +502,7 @@ void TypeLoweringVisitor::lowerSAWritePath(Operation *op,
                                            ArrayRef<Operation *> writePath) {
   SubaccessOp sao = cast<SubaccessOp>(writePath.back());
   auto saoType = sao.input().getType().cast<FVectorType>();
-  auto selectWidth =
-      sao.index().getType().cast<FIRRTLType>().getBitWidthOrSentinel();
+  auto selectWidth = llvm::Log2_64_Ceil(saoType.getNumElements());
 
   for (size_t index = 0, e = saoType.getNumElements(); index < e; ++index) {
     auto cond = builder->create<EQPrimOp>(
@@ -1207,8 +1206,7 @@ bool TypeLoweringVisitor::visitExpr(SubaccessOp op) {
   }
 
   // Reads.  All writes have been eliminated before now
-  auto selectWidth =
-      op.index().getType().cast<FIRRTLType>().getBitWidthOrSentinel();
+  auto selectWidth = llvm::Log2_64_Ceil(vType.getNumElements());
 
   // We have at least one element
   Value mux = builder->create<SubindexOp>(input, 0);

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -978,12 +978,12 @@ firrtl.circuit "TopLevel" {
   }
 
 // CHECK-LABEL: firrtl.module @multidimRead(in %a_0_0: !firrtl.uint<2>, in %a_0_1: !firrtl.uint<2>, in %a_1_0: !firrtl.uint<2>, in %a_1_1: !firrtl.uint<2>, in %sel: !firrtl.uint<2>, out %b: !firrtl.uint<2>) {
-// CHECK-NEXT:      %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
-// CHECK-NEXT:      %0 = firrtl.eq %sel, %c1_ui2 : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<1>
+// CHECK-NEXT:      %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+// CHECK-NEXT:      %0 = firrtl.eq %sel, %c1_ui1 : (!firrtl.uint<2>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:      %1 = firrtl.mux(%0, %a_1_0, %a_0_0) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
 // CHECK-NEXT:      %2 = firrtl.mux(%0, %a_1_1, %a_0_1) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
-// CHECK-NEXT:      %c1_ui2_0 = firrtl.constant 1 : !firrtl.uint<2>
-// CHECK-NEXT:      %3 = firrtl.eq %sel, %c1_ui2_0 : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<1>
+// CHECK-NEXT:      %c1_ui1_0 = firrtl.constant 1 : !firrtl.uint<1>
+// CHECK-NEXT:      %3 = firrtl.eq %sel, %c1_ui1_0 : (!firrtl.uint<2>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:      %4 = firrtl.mux(%3, %2, %1) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
 // CHECK-NEXT:      firrtl.connect %b, %4 : !firrtl.uint<2>, !firrtl.uint<2>
 // CHECK-NEXT: }
@@ -1005,13 +1005,13 @@ firrtl.circuit "TopLevel" {
 // CHECK-LABEL:    firrtl.module @write1D(in %b: !firrtl.uint<1>, in %sel: !firrtl.uint<2>, in %default_0: !firrtl.uint<1>, in %default_1: !firrtl.uint<1>, out %a_0: !firrtl.uint<1>, out %a_1: !firrtl.uint<1>) {
 // CHECK-NEXT:      firrtl.connect %a_0, %default_0 : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT:      firrtl.connect %a_1, %default_1 : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK-NEXT:      %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
-// CHECK-NEXT:      %0 = firrtl.eq %sel, %c0_ui2 : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<1>
+// CHECK-NEXT:      %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+// CHECK-NEXT:      %0 = firrtl.eq %sel, %c0_ui1 : (!firrtl.uint<2>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:      firrtl.when %0  {
 // CHECK-NEXT:        firrtl.connect %a_0, %b : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
-// CHECK-NEXT:      %1 = firrtl.eq %sel, %c1_ui2 : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<1>
+// CHECK-NEXT:      %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+// CHECK-NEXT:      %1 = firrtl.eq %sel, %c1_ui1 : (!firrtl.uint<2>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:      firrtl.when %1  {
 // CHECK-NEXT:        firrtl.connect %a_1, %b : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT:      }
@@ -1084,13 +1084,13 @@ firrtl.circuit "TopLevel" {
 // CHECK-NEXT:      firrtl.connect %b_0_valid, %def_0_valid : !firrtl.uint<2>, !firrtl.uint<2>
 // CHECK-NEXT:      firrtl.connect %b_1_wo, %def_1_wo : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT:      firrtl.connect %b_1_valid, %def_1_valid : !firrtl.uint<2>, !firrtl.uint<2>
-// CHECK-NEXT:      %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
-// CHECK-NEXT:      %0 = firrtl.eq %sel, %c0_ui2 : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<1>
+// CHECK-NEXT:      %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+// CHECK-NEXT:      %0 = firrtl.eq %sel, %c0_ui1 : (!firrtl.uint<2>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:      firrtl.when %0  {
 // CHECK-NEXT:        firrtl.connect %b_0_wo, %a_wo : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
-// CHECK-NEXT:      %1 = firrtl.eq %sel, %c1_ui2 : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<1>
+// CHECK-NEXT:      %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+// CHECK-NEXT:      %1 = firrtl.eq %sel, %c1_ui1 : (!firrtl.uint<2>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:      firrtl.when %1  {
 // CHECK-NEXT:        firrtl.connect %b_1_wo, %a_wo : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT:      }
@@ -1363,4 +1363,25 @@ firrtl.module @is1436_FOO() {
    // FLATTEN:   %[[v11:.+]] = firrtl.cat %[[SiFive_ram_MPORT_data_qos:.+]], %[[v10]] : (!firrtl.uint<4>, !firrtl.uint<56>) -> !firrtl.uint<60>
    // FLATTEN:   firrtl.connect %[[v3]], %[[v11]] : !firrtl.uint<60>, !firrtl.uint<60>
   }
+
+// Issue #2315: Narrow index constants overflow when subaccessing long vectors.
+// https://github.com/llvm/circt/issues/2315
+// CHECK-LABEL: firrtl.module @Issue2315
+firrtl.module @Issue2315(in %x: !firrtl.vector<uint<10>, 5>, in %source: !firrtl.uint<2>, out %z: !firrtl.uint<10>) {
+  %0 = firrtl.subaccess %x[%source] : !firrtl.vector<uint<10>, 5>, !firrtl.uint<2>
+  firrtl.connect %z, %0 : !firrtl.uint<10>, !firrtl.uint<10>
+  // CHECK-NEXT: [[IDX:%.+]] = firrtl.constant 1
+  // CHECK-NEXT: [[EQ:%.+]] = firrtl.eq %source, [[IDX]]
+  // CHECK-NEXT: firrtl.mux([[EQ]], %x_1, %x_0)
+  // CHECK-NEXT: [[IDX:%.+]] = firrtl.constant 2
+  // CHECK-NEXT: [[EQ:%.+]] = firrtl.eq %source, [[IDX]]
+  // CHECK-NEXT: firrtl.mux([[EQ]], %x_2,
+  // CHECK-NEXT: [[IDX:%.+]] = firrtl.constant 3
+  // CHECK-NEXT: [[EQ:%.+]] = firrtl.eq %source, [[IDX]]
+  // CHECK-NEXT: firrtl.mux([[EQ]], %x_3,
+  // CHECK-NEXT: [[IDX:%.+]] = firrtl.constant 4
+  // CHECK-NEXT: [[EQ:%.+]] = firrtl.eq %source, [[IDX]]
+  // CHECK-NEXT: firrtl.mux([[EQ]], %x_4,
+}
+
 } // CIRCUIT


### PR DESCRIPTION
Fix an issue in `LowerTypes` around `SubaccessOp`s, where narrow index expressions could cause constant overflows. If the subaccess index had fewer bits than necessary to address all elements of the vector, the comparisons between that index and a constant generated for every element would see the constant overflow for all the elements beyond reach.

For example, using a 2-bit index `x` to access a 5-element vector `y` would generate comparisons as follows:

- `x == 0 : i2`
- `x == 1 : i2`
- `x == 2 : i2`
- `x == 3 : i2`
- `x == 0 : i2` (4 overflows in the 2-bit constant)

This fixes the issue by choosing the width of the constants according to `ceil(log2(vectorLength))`, which is guaranteed to always have enough bits to represent all vector indices. This makes the generated equality checks compare numbers of potentially different bit widths, which is fine in FIRRTL.

Fixes #2315.