### PR TITLE
[FIRRTL] Update NonLocalAnchor to use InnerRef

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+include "circt/Dialect/HW/HWTypes.td"
 include "circt/Types.td"
 
 def CircuitOp : FIRRTLOp<"circuit",
@@ -142,8 +143,7 @@ def NonLocalAnchor : FIRRTLOp<"nla",
     annotations to anchor to in the global scope.  This lets components of the
     path point to a common entity.
   }];
-  let arguments = (ins SymbolNameAttr:$sym_name,
-                       FlatSymbolRefArrayAttr:$modpath, StrArrayAttr:$namepath);
+  let arguments = (ins SymbolNameAttr:$sym_name, NameRefArrayAttr:$namepath);
   let results = (outs);
-  let assemblyFormat = [{ $sym_name $modpath $namepath attr-dict}];
+  let assemblyFormat = [{ $sym_name $namepath attr-dict}];
 }

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -29,6 +29,7 @@ def LowerFIRRTLAnnotations : Pass<"firrtl-lower-annotations", "firrtl::CircuitOp
     Option<"ignoreAnnotationUnknown", "disable-annotation-unknown", "bool", "true",
       "Ignore unknown annotations.">
   ];
+  let dependentDialects = ["hw::HWDialect"];
 }
 
 def LowerFIRRTLTypes : Pass<"firrtl-lower-types", "firrtl::CircuitOp"> {
@@ -49,6 +50,7 @@ def LowerFIRRTLTypes : Pass<"firrtl-lower-types", "firrtl::CircuitOp"> {
     Option<"preserveAggregate", "preserve-aggregate", "bool", "false",
            "Preserve passive aggregate types in the module.">
   ];
+  let dependentDialects = ["hw::HWDialect"];
 }
 
 def IMConstProp : Pass<"firrtl-imconstprop", "firrtl::CircuitOp"> {
@@ -113,6 +115,7 @@ def CreateSiFiveMetadata : Pass<"firrtl-emit-metadata", "firrtl::CircuitOp"> {
     Option<"replSeqMemFile", "repl-seq-mem-file", "std::string", "",
       "File to which emit seq meme metadata">
   ];
+  let dependentDialects = ["hw::HWDialect"];
 }
 
 def EmitOMIR : Pass<"firrtl-emit-omir", "firrtl::CircuitOp"> {

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -17,6 +17,7 @@
 #include "circt/Dialect/FIRRTL/FIRRTLAttributes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Dialect/FIRRTL/Namespace.h"
+#include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -3841,7 +3842,7 @@ OwningModuleRef circt::firrtl::importFIRFile(SourceMgr &sourceMgr,
         sourceMgr.getMemoryBuffer(sourceMgr.getMainFileID() + fileID));
 
   context->loadDialect<CHIRRTLDialect>();
-  context->loadDialect<FIRRTLDialect>();
+  context->loadDialect<FIRRTLDialect, hw::HWDialect>();
 
   // This is the result module we are parsing into.
   OwningModuleRef module(ModuleOp::create(

--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -335,7 +335,7 @@ void EmitOMIRPass::runOnOperation() {
 
   removeTempNLAs.clear();
   // Remove the temp symbol from instances.
-  for (auto op : tempSymInstances)
+  for (auto *op : tempSymInstances)
     cast<InstanceOp>(op)->removeAttr("inner_sym");
   tempSymInstances.clear();
 

--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -125,7 +125,9 @@ private:
   SmallVector<NonLocalAnchor> removeTempNLAs;
   DenseMap<Operation *, ModuleNamespace> moduleNamespaces;
   /// Lookup table of instances by name and parent module.
-  DenseMap<std::pair<Operation *, StringAttr>, InstanceOp> instancesByName;
+  DenseMap<hw::InnerRefAttr, InstanceOp> instancesByName;
+  /// Record to remove any temporary symbols added to instances.
+  DenseSet<Operation *> tempSymInstances;
 };
 } // namespace
 
@@ -224,6 +226,17 @@ void EmitOMIRPass::runOnOperation() {
   if (anyFailures)
     return signalPassFailure();
 
+  // If an OMIR output filename has been specified as a pass parameter, override
+  // whatever the annotations have configured. If neither are specified we just
+  // bail.
+  if (!this->outputFilename.empty())
+    outputFilename = this->outputFilename;
+  if (!outputFilename) {
+    LLVM_DEBUG(llvm::dbgs() << "Not emitting OMIR because no annotation or "
+                               "pass parameter specified an output file\n");
+    markAllAnalysesPreserved();
+    return;
+  }
   // Establish some of the analyses we need throughout the pass.
   SymbolTable currentSymtbl(circuitOp);
   CircuitNamespace currentCircuitNamespace(circuitOp);
@@ -235,9 +248,18 @@ void EmitOMIRPass::runOnOperation() {
   // Traverse the IR and collect all tracker annotations that were previously
   // scattered into the circuit.
   circuitOp.walk([&](Operation *op) {
-    if (auto instOp = dyn_cast<InstanceOp>(op))
+    if (auto instOp = dyn_cast<InstanceOp>(op)) {
+      // This instance does not have a symbol, but we are adding one. Remove it
+      // after the pass.
+      if (!op->getAttrOfType<StringAttr>("inner_sym"))
+        tempSymInstances.insert(instOp);
+
       instancesByName.insert(
-          {{op->getParentOfType<FModuleOp>(), instOp.nameAttr()}, instOp});
+          {hw::InnerRefAttr::getFromOperation(
+               op, instOp.nameAttr(),
+               op->getParentOfType<FModuleOp>().getNameAttr()),
+           instOp});
+    }
     AnnotationSet::removeAnnotations(op, [&](Annotation anno) {
       if (!anno.isClass(omirTrackerAnnoClass))
         return false;
@@ -259,18 +281,6 @@ void EmitOMIRPass::runOnOperation() {
       return true;
     });
   });
-
-  // If an OMIR output filename has been specified as a pass parameter, override
-  // whatever the annotations have configured. If neither are specified we just
-  // bail.
-  if (!this->outputFilename.empty())
-    outputFilename = this->outputFilename;
-  if (!outputFilename) {
-    LLVM_DEBUG(llvm::dbgs() << "Not emitting OMIR because no annotation or "
-                               "pass parameter specified an output file\n");
-    markAllAnalysesPreserved();
-    return;
-  }
 
   // Build the output JSON.
   std::string jsonBuffer;
@@ -297,14 +307,13 @@ void EmitOMIRPass::runOnOperation() {
   for (auto nla : removeTempNLAs) {
     LLVM_DEBUG(llvm::dbgs() << "Removing " << nla << "\n");
     nlaSymNamesToDrop.insert(nla.sym_nameAttr());
-    for (auto modAndName :
-         llvm::zip(nla.modpath().getAsRange<FlatSymbolRefAttr>(),
-                   nla.namepath().getAsRange<StringAttr>())) {
-      Operation *mod = symtbl->lookup(std::get<0>(modAndName).getValue());
-      auto it = instancesByName.find({mod, std::get<1>(modAndName)});
-      if (it == instancesByName.end())
-        continue;
-      instsToModify.insert(it->second);
+    for (auto nameRef : nla.namepath()) {
+      if (auto innerRef = nameRef.dyn_cast<hw::InnerRefAttr>()) {
+        auto it = instancesByName.find(innerRef);
+        if (it == instancesByName.end())
+          continue;
+        instsToModify.insert(it->second);
+      }
     }
     nla->erase();
   }
@@ -325,6 +334,10 @@ void EmitOMIRPass::runOnOperation() {
   }
 
   removeTempNLAs.clear();
+  // Remove the temp symbol from instances.
+  for (auto op : tempSymInstances)
+    cast<InstanceOp>(op)->removeAttr("inner_sym");
+  tempSymInstances.clear();
 
   // Emit the OMIR JSON as a verbatim op.
   auto builder = OpBuilder(circuitOp);
@@ -378,22 +391,22 @@ void EmitOMIRPass::makeTrackerAbsolute(Tracker &tracker) {
 
   // Assemble the module and name path for the NLA. Also attach an NLA reference
   // annotation to each instance participating in the path.
-  SmallVector<Attribute> modpath, namepath;
+  SmallVector<Attribute> namepath;
   auto addToPath = [&](Operation *op, StringAttr name) {
     AnnotationSet annos(op);
     annos.addAnnotations(nlaAttr);
     annos.applyToOperation(op);
-    modpath.push_back(FlatSymbolRefAttr::get(op->getParentOfType<FModuleOp>()));
-    namepath.push_back(name);
+    namepath.push_back(hw::InnerRefAttr::getFromOperation(
+        op, name, op->getParentOfType<FModuleOp>().getNameAttr()));
   };
   for (InstanceOp inst : paths[0])
     addToPath(inst, inst.nameAttr());
   addToPath(tracker.op, opName);
 
   // Add the NLA to the tracker and mark it to be deleted later.
-  tracker.nla = builder.create<NonLocalAnchor>(
-      builder.getUnknownLoc(), builder.getStringAttr(nlaName),
-      builder.getArrayAttr(modpath), builder.getArrayAttr(namepath));
+  tracker.nla = builder.create<NonLocalAnchor>(builder.getUnknownLoc(),
+                                               builder.getStringAttr(nlaName),
+                                               builder.getArrayAttr(namepath));
   removeTempNLAs.push_back(tracker.nla);
 }
 
@@ -714,11 +727,13 @@ void EmitOMIRPass::emitTrackedTarget(DictionaryAttr node,
   if (tracker.nla) {
     bool notFirst = false;
     hw::InnerRefAttr instName;
-    for (auto modAndName : llvm::zip(tracker.nla.modpath().getValue(),
-                                     tracker.nla.namepath().getValue())) {
-      auto symAttr = std::get<0>(modAndName).cast<FlatSymbolRefAttr>();
-      auto nameAttr = std::get<1>(modAndName).cast<StringAttr>();
-      Operation *module = symtbl->lookup(symAttr.getValue());
+    for (auto nameRef : tracker.nla.namepath()) {
+      StringRef modName;
+      if (auto innerRef = nameRef.dyn_cast<hw::InnerRefAttr>())
+        modName = innerRef.getModule().getValue();
+      else if (auto ref = nameRef.dyn_cast<FlatSymbolRefAttr>())
+        modName = ref.getValue();
+      Operation *module = symtbl->lookup(modName);
       assert(module);
       if (notFirst)
         target.push_back('/');
@@ -729,15 +744,18 @@ void EmitOMIRPass::emitTrackedTarget(DictionaryAttr node,
       }
       target.append(addSymbol(module));
 
-      // Find an instance with the given name in this module. Ensure it has a
-      // symbol that we can refer to.
-      auto instOp = instancesByName.lookup({module, nameAttr});
-      if (!instOp)
-        continue;
-      LLVM_DEBUG(llvm::dbgs()
-                 << "Marking NLA-participating instance " << nameAttr
-                 << " in module " << symAttr << " as dont-touch\n");
-      instName = getInnerRefTo(instOp);
+      if (auto innerRef = nameRef.dyn_cast<hw::InnerRefAttr>()) {
+        auto nameAttr = innerRef.getName();
+        // Find an instance with the given name in this module. Ensure it has a
+        // symbol that we can refer to.
+        auto instOp = instancesByName.lookup(innerRef);
+        if (!instOp)
+          continue;
+        LLVM_DEBUG(llvm::dbgs()
+                   << "Marking NLA-participating instance " << nameAttr
+                   << " in module " << modName << " as dont-touch\n");
+        instName = getInnerRefTo(instOp);
+      }
     }
   } else {
     FModuleOp module = dyn_cast<FModuleOp>(tracker.op);
@@ -790,10 +808,12 @@ void EmitOMIRPass::emitTrackedTarget(DictionaryAttr node,
 }
 
 StringAttr EmitOMIRPass::getOrAddInnerSym(Operation *op) {
+  tempSymInstances.erase(op);
   auto attr = op->getAttrOfType<StringAttr>("inner_sym");
   if (attr)
     return attr;
   auto module = op->getParentOfType<FModuleOp>();
+  // TODO: Cache the module namespace.
   auto name = getModuleNamespace(module).newName("omir_sym");
   attr = StringAttr::get(op->getContext(), name);
   op->setAttr("inner_sym", attr);

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -190,7 +190,9 @@ struct IMConstPropPass : public IMConstPropBase<IMConstPropPass> {
   /// revisitation.
   void mergeLatticeValue(Value value, LatticeValue &valueEntry,
                          LatticeValue source) {
-    if (!source.isOverdefined() && hasDontTouch(value))
+    if (!source.isOverdefined() &&
+        (!isa_and_nonnull<InstanceOp>(value.getDefiningOp()) &&
+         hasDontTouch(value)))
       source = LatticeValue::getOverdefined();
     if (valueEntry.mergeIn(source))
       changedLatticeValueWorklist.push(value);
@@ -220,7 +222,9 @@ struct IMConstPropPass : public IMConstPropBase<IMConstPropPass> {
     if (source.isUnknown())
       return;
 
-    if (!source.isOverdefined() && hasDontTouch(value))
+    if (!source.isOverdefined() &&
+        (!isa_and_nonnull<InstanceOp>(value.getDefiningOp()) &&
+         hasDontTouch(value)))
       source = LatticeValue::getOverdefined();
     // If we've changed this value then revisit all the users.
     auto &valueEntry = latticeValues[value];

--- a/lib/Dialect/FIRRTL/Transforms/PrefixModules.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/PrefixModules.cpp
@@ -172,9 +172,10 @@ void PrefixModulesPass::renameModuleBody(std::string prefix, FModuleOp module) {
               // it.
               SmallVector<Attribute, 4> newMods;
               for (auto nameRef : nlaOp.namepath()) {
+                // nameRef is either an InnerRefAttr or a FlatSymbolRefAttr.
                 if (auto oldMod = nameRef.dyn_cast<hw::InnerRefAttr>()) {
-                  if (instanceOp.moduleName().equals(
-                          oldMod.getModule().getValue()))
+                  if (instanceOp.moduleNameAttr().getAttr() ==
+                      oldMod.getModule())
                     newMods.push_back(hw::InnerRefAttr::get(
                         StringAttr::get(context, newTarget), oldMod.getName()));
                   else

--- a/lib/Dialect/FIRRTL/Transforms/PrefixModules.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/PrefixModules.cpp
@@ -179,8 +179,14 @@ void PrefixModulesPass::renameModuleBody(std::string prefix, FModuleOp module) {
                         StringAttr::get(context, newTarget), oldMod.getName()));
                   else
                     newMods.push_back(oldMod);
-                } else
-                  newMods.push_back(oldMod);
+                } else {
+                  if (instanceOp.moduleNameAttr() ==
+                      nameRef.cast<FlatSymbolRefAttr>())
+                    newMods.push_back(
+                        FlatSymbolRefAttr::get(context, newTarget));
+                  else
+                    newMods.push_back(nameRef);
+                }
               }
               nlaOp->setAttr("namepath", ArrayAttr::get(context, newMods));
             }

--- a/lib/Dialect/FIRRTL/Transforms/PrefixModules.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/PrefixModules.cpp
@@ -16,6 +16,7 @@
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Dialect/FIRRTL/InstanceGraph.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
+#include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Support/LLVM.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/PostOrderIterator.h"
@@ -170,14 +171,18 @@ void PrefixModulesPass::renameModuleBody(std::string prefix, FModuleOp module) {
               // Iterate over the modules of the NonLocalAnchor op, and update
               // it.
               SmallVector<Attribute, 4> newMods;
-              for (auto oldMod : nlaOp.modpath()) {
-                if (instanceOp.moduleNameAttr() ==
-                    oldMod.cast<FlatSymbolRefAttr>())
-                  newMods.push_back(FlatSymbolRefAttr::get(context, newTarget));
-                else
-                  newMods.push_back(oldMod.cast<FlatSymbolRefAttr>());
+              for (auto nameRef : nlaOp.namepath()) {
+                if (auto oldMod = nameRef.dyn_cast<hw::InnerRefAttr>()) {
+                  if (instanceOp.moduleName().equals(
+                          oldMod.getModule().getValue()))
+                    newMods.push_back(hw::InnerRefAttr::get(
+                        StringAttr::get(context, newTarget), oldMod.getName()));
+                  else
+                    newMods.push_back(oldMod);
+                } else
+                  newMods.push_back(oldMod);
               }
-              nlaOp->setAttr("modpath", ArrayAttr::get(context, newMods));
+              nlaOp->setAttr("namepath", ArrayAttr::get(context, newMods));
             }
           }
       }
@@ -322,14 +327,15 @@ void PrefixModulesPass::runOnOperation() {
     // Now update all the NLAs that have the top level module symbol.
     for (auto &n : nlaMap) {
       auto nla = cast<NonLocalAnchor>(n.second);
-      auto oldMods = nla.modpath();
+      auto oldMods = nla.namepath();
       if (oldMods.empty())
         continue;
       SmallVector<Attribute, 4> newMods(oldMods.begin(), oldMods.end());
-      if (nla.modpath()[0].cast<FlatSymbolRefAttr>().getValue().equals(
-              mainModule.moduleName()))
-        newMods[0] = FlatSymbolRefAttr::get(context, newMainModuleName);
-      nla->setAttr("modpath", ArrayAttr::get(context, newMods));
+      auto iref = oldMods[0].cast<hw::InnerRefAttr>();
+      if (iref.getModule().getValue().equals(mainModule.moduleName()))
+        newMods[0] = hw::InnerRefAttr::get(
+            StringAttr::get(context, newMainModuleName), iref.getName());
+      nla->setAttr("namepath", ArrayAttr::get(context, newMods));
     }
   }
 

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
@@ -110,7 +110,7 @@ firrtl.circuit "Foo" attributes {annotations = [
         {class = "firrtl.transforms.BlackBox", circt.nonlocal = @nla_1}
     ]} {}
     // Non-local annotations should not produce errors either.
-    firrtl.nla  @nla_1 [@Bar, @Foo] ["foo", "Foo"]
+    firrtl.nla  @nla_1 [#hw.innerNameRef<@Bar::@foo>, #hw.innerNameRef<@Foo::@Foo>]
     firrtl.module @Bar() {
       firrtl.instance foo {annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}]} @Foo()
     }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1575,8 +1575,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   }
 
   // CHECK-LABEL: hw.module @ForceNameSubmodule
-  firrtl.nla @nla_1 [#hw.innerNameRef<@ForceNameTop::@sym_foo>,#hw.innerNameRef<@ForceNameSubmodule::@ForceNameSubmodule>]
-  firrtl.nla @nla_2 [#hw.innerNameRef<@ForceNameTop::@sym_bar>,#hw.innerNameRef<@ForceNameSubmodule::@ForceNameSubmodule>]
+  firrtl.nla @nla_1 [#hw.innerNameRef<@ForceNameTop::@sym_foo>,@ForceNameSubmodule]
+  firrtl.nla @nla_2 [#hw.innerNameRef<@ForceNameTop::@sym_bar>,@ForceNameSubmodule]
   firrtl.module @ForceNameSubmodule() attributes {annotations = [
     {circt.nonlocal = @nla_2,
      class = "chisel3.util.experimental.ForceNameAnnotation", name = "Bar"},

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1575,8 +1575,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   }
 
   // CHECK-LABEL: hw.module @ForceNameSubmodule
-  firrtl.nla @nla_1 [@ForceNameTop, @ForceNameSubmodule] ["foo", "ForceNameSubmodule"]
-  firrtl.nla @nla_2 [@ForceNameTop, @ForceNameSubmodule] ["bar", "ForceNameSubmodule"]
+  firrtl.nla @nla_1 [#hw.innerNameRef<@ForceNameTop::@sym_foo>,#hw.innerNameRef<@ForceNameSubmodule::@ForceNameSubmodule>]
+  firrtl.nla @nla_2 [#hw.innerNameRef<@ForceNameTop::@sym_bar>,#hw.innerNameRef<@ForceNameSubmodule::@ForceNameSubmodule>]
   firrtl.module @ForceNameSubmodule() attributes {annotations = [
     {circt.nonlocal = @nla_2,
      class = "chisel3.util.experimental.ForceNameAnnotation", name = "Bar"},
@@ -1584,13 +1584,13 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
      class = "chisel3.util.experimental.ForceNameAnnotation", name = "Foo"}]} {}
   // CHECK: hw.module @ForceNameTop
   firrtl.module @ForceNameTop() {
-    firrtl.instance foo
+    firrtl.instance foo sym @sym_foo
       {annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}]}
       @ForceNameSubmodule()
-    firrtl.instance bar
+    firrtl.instance bar sym @sym_bar
       {annotations = [{circt.nonlocal = @nla_2, class = "circt.nonlocal"}]}
       @ForceNameSubmodule()
-    // CHECK:      hw.instance "foo" {{.+}} {hw.verilogName = "Foo"}
-    // CHECK-NEXT: hw.instance "bar" {{.+}} {hw.verilogName = "Bar"}
+    // CHECK:      hw.instance "foo" sym @sym_foo {{.+}} {hw.verilogName = "Foo"}
+    // CHECK-NEXT: hw.instance "bar" sym @sym_bar {{.+}} {hw.verilogName = "Bar"}
   }
 }

--- a/test/Dialect/FIRRTL/annotations-errors.fir
+++ b/test/Dialect/FIRRTL/annotations-errors.fir
@@ -147,7 +147,7 @@ circuit Foo: %[[{"a":null,"target":"~Foo|Foo>x"}]]
 
 ; A target pointing at a non-existent instance should error.
 
-; expected-error @+1 {{unapplied annotations with target '~Foo|Foo>baz' and payload '[{circt.nonlocal = @nla_1, class = "circt.nonlocal"}]'}}
+; expected-error @+1 {{unapplied annotations with target '~Foo|Foo>baz' and payload '[{circt.nonlocal = @nla_1, class = "circt.nonlocal"}, {class = "firrtl.transforms.DontTouchAnnotation"}]'}}
 circuit Foo: %[[{"a":null,"target":"~Foo|Foo/baz:Bar"}]]
   module Bar:
     skip

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -77,7 +77,7 @@ circuit Foo: %[[
   module Foo:
     inst bar of Bar
     ; CHECK-LABEL: firrtl.circuit "Foo"
-    ; CHECK: firrtl.nla  @nla_1 [@Foo, @Bar] ["bar", "Bar"]
+    ; CHECK: firrtl.nla  @nla_1 [#hw.innerNameRef<@Foo::@bar>, @Bar]
     ; CHECK: firrtl.module @Bar
     ; CHECK-SAME annotations = [{c = "c"}]
     ; CHECK: firrtl.module @Foo
@@ -99,7 +99,7 @@ circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar.a"},
     inst bar of Bar
 
     ; CHECK-LABEL: firrtl.circuit "Foo"
-    ; CHECK: firrtl.nla @nla_1 [@Foo, @Bar] ["bar", "b"]
+    ; CHECK: firrtl.nla @nla_1 [#hw.innerNameRef<@Foo::@bar>, #hw.innerNameRef<@Bar::@b>]
     ; CHECK: firrtl.module @Bar
     ; CHECK-SAME: [#firrtl.subAnno<fieldID = 2, {circt.nonlocal = @nla_1, three}>]
     ; CHECK: %bar_a, %bar_b, %bar_c = firrtl.instance bar
@@ -545,7 +545,7 @@ circuit GCTDataTap : %[
 
     ; CHECK-LABEL: firrtl.circuit "GCTDataTap"
     ; CHECK-SAME: annotations = [{unrelatedAnnotation}]
-    ; CHECK:      firrtl.nla @nla_1 [@GCTDataTap, @InnerMod] ["im", "w"]
+    ; CHECK:      firrtl.nla @nla_1 [#hw.innerNameRef<@GCTDataTap::@im>, #hw.innerNameRef<@InnerMod::@w>]
     ; CHECK: firrtl.extmodule @DataTap
     ; CHECK-SAME: _0: !firrtl.uint<1> sym @_0 [
     ; CHECK-SAME:   {class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
@@ -1017,8 +1017,8 @@ circuit Foo: %[[{"a":"a","target":"~Foo|Foo/bar:Bar/baz:Baz"}, {"b":"b","target"
   module Foo :
     inst bar of Bar
 ; CHECK-LABEL: firrtl.circuit "Foo"
-; CHECK: firrtl.nla @nla_2 [@Foo, @Bar, @Baz] ["bar", "baz", "Baz"]
-; CHECK: firrtl.nla @nla_1 [@Foo, @Bar, @Baz] ["bar", "baz", "Baz"]
+; CHECK: firrtl.nla @nla_2 [#hw.innerNameRef<@Foo::@bar>, #hw.innerNameRef<@Bar::@baz>, @Baz]
+; CHECK: firrtl.nla @nla_1 [#hw.innerNameRef<@Foo::@bar>, #hw.innerNameRef<@Bar::@baz>, @Baz]
 ; CHECK: firrtl.module @Baz
 ; CHECK-SAME: annotations = [{a = "a", circt.nonlocal = @nla_1}, {b = "b", circt.nonlocal = @nla_2}]
 ; CHECK: firrtl.module @Bar()

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -7,8 +7,8 @@
 // A non-local annotation should work.
 
 // CHECK-LABEL: firrtl.circuit "FooNL"
-// CHECK: firrtl.nla @nla_0 [@FooNL, @BazNL, @BarNL] ["baz", "bar", "w"]
-// CHECK: firrtl.nla @nla [@FooNL, @BazNL, @BarNL] ["baz", "bar", "w2"] 
+// CHECK: firrtl.nla @nla_0 [#hw.innerNameRef<@FooNL::@baz>, #hw.innerNameRef<@BazNL::@bar>, #hw.innerNameRef<@BarNL::@w>]
+// CHECK: firrtl.nla @nla [#hw.innerNameRef<@FooNL::@baz>, #hw.innerNameRef<@BazNL::@bar>, #hw.innerNameRef<@BarNL::@w2>] 
 // CHECK: firrtl.module @BarNL
 // CHECK: %w = firrtl.wire {annotations = [{circt.nonlocal = @nla_0, class = "circt.test", nl = "nl"}]}
 // CHECK: %w2 = firrtl.wire {annotations = [{circt.fieldID = 5 : i32, circt.nonlocal = @nla, class = "circt.test", nl = "nl2"}]} : !firrtl.bundle<a: uint, b: vector<uint, 4>> 

--- a/test/Dialect/FIRRTL/emit-omir.mlir
+++ b/test/Dialect/FIRRTL/emit-omir.mlir
@@ -202,13 +202,13 @@ firrtl.circuit "NonLocalTrackers" attributes {annotations = [{
     OMReferenceTarget1 = {info = #loc, index = 1, id = "OMID:1", value = {omir.tracker, id = 0, type = "OMReferenceTarget"}}
   }}]
 }]} {
-  firrtl.nla @nla_0 [@NonLocalTrackers, @B, @A] ["b", "a", "A"]
+  firrtl.nla @nla_0 [#hw.innerNameRef<@NonLocalTrackers::@b>, #hw.innerNameRef<@B::@a>, @A]
   firrtl.module @A() attributes {annotations = [{circt.nonlocal = @nla_0, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 0}]} {}
   firrtl.module @B() {
-    firrtl.instance a {annotations = [{circt.nonlocal = @nla_0, class = "circt.nonlocal"}]} @A()
+    firrtl.instance a sym @a {annotations = [{circt.nonlocal = @nla_0, class = "circt.nonlocal"}]} @A()
   }
   firrtl.module @NonLocalTrackers() {
-    firrtl.instance b {annotations = [{circt.nonlocal = @nla_0, class = "circt.nonlocal"}]} @B()
+    firrtl.instance b sym @b {annotations = [{circt.nonlocal = @nla_0, class = "circt.nonlocal"}]} @B()
   }
 }
 // CHECK-LABEL: firrtl.circuit "NonLocalTrackers"

--- a/test/Dialect/FIRRTL/grand-central-errors.mlir
+++ b/test/Dialect/FIRRTL/grand-central-errors.mlir
@@ -224,8 +224,8 @@ firrtl.circuit "multiInstance2" attributes {
     firrtl.instance dut @DUTE() // expected-note {{parent is instantiated here}}
     firrtl.instance dut1 @DUTE() // expected-note {{parent is instantiated here}}
   }
-  firrtl.nla @nla1 [@multiInstance1] ["dut"]
-  firrtl.nla @nla2 [@multiInstance1] ["dut1"]
+  firrtl.nla @nla1 [#hw.innerNameRef<@multiInstance1::@dut>]
+  firrtl.nla @nla2 [#hw.innerNameRef<@multiInstance1::@dut1>]
 }
 
 // -----

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -57,7 +57,7 @@ firrtl.circuit "Test" {
     firrtl.connect %result3, %nonconstWire : !firrtl.uint<1>, !firrtl.uint<1>
 
     // Constant propagation through instance.
-    %source, %dest = firrtl.instance "" @PassThrough(in source: !firrtl.uint<1>, out dest: !firrtl.uint<1>)
+    %source, %dest = firrtl.instance "" sym @dm21 @PassThrough(in source: !firrtl.uint<1>, out dest: !firrtl.uint<1>)
 
     // CHECK: firrtl.connect %inst_source, %c0_ui1
     firrtl.connect %source, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -200,9 +200,9 @@ firrtl.circuit "testDontTouch"  {
   // CHECK-LABEL: firrtl.module @testDontTouch
   firrtl.module @testDontTouch(in %clock: !firrtl.clock, out %a: !firrtl.uint<1>, out %a1: !firrtl.uint<1>, out %a2: !firrtl.uint<1>) {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    %blockProp1_clock, %blockProp1_a, %blockProp1_b = firrtl.instance blockProp1 @blockProp1(in clock: !firrtl.clock, in a: !firrtl.uint<1>, out b: !firrtl.uint<1>)
-    %allowProp_clock, %allowProp_a, %allowProp_b = firrtl.instance allowProp @allowProp(in clock: !firrtl.clock, in a: !firrtl.uint<1>, out b: !firrtl.uint<1>)
-    %blockProp3_clock, %blockProp3_a, %blockProp3_b = firrtl.instance blockProp3 @blockProp3(in clock: !firrtl.clock, in a: !firrtl.uint<1>, out b: !firrtl.uint<1>)
+    %blockProp1_clock, %blockProp1_a, %blockProp1_b = firrtl.instance blockProp1 sym @a1 @blockProp1(in clock: !firrtl.clock, in a: !firrtl.uint<1>, out b: !firrtl.uint<1>)
+    %allowProp_clock, %allowProp_a, %allowProp_b = firrtl.instance allowProp sym @a2 @allowProp(in clock: !firrtl.clock, in a: !firrtl.uint<1>, out b: !firrtl.uint<1>)
+    %blockProp3_clock, %blockProp3_a, %blockProp3_b = firrtl.instance blockProp3  sym @a3 @blockProp3(in clock: !firrtl.clock, in a: !firrtl.uint<1>, out b: !firrtl.uint<1>)
     firrtl.connect %blockProp1_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %allowProp_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %blockProp3_clock, %clock : !firrtl.clock, !firrtl.clock
@@ -238,8 +238,8 @@ firrtl.circuit "OutPortTop" {
     }
   // CHECK-LABEL: firrtl.module @OutPortTop
     firrtl.module @OutPortTop(in %x: !firrtl.uint<1>, out %zc: !firrtl.uint<1>, out %zn: !firrtl.uint<1>) {
-      %c_out = firrtl.instance c @OutPortChild1(out out: !firrtl.uint<1>)
-      %c_out_0 = firrtl.instance c @OutPortChild2(out out: !firrtl.uint<1>)
+      %c_out = firrtl.instance c  sym @a2 @OutPortChild1(out out: !firrtl.uint<1>)
+      %c_out_0 = firrtl.instance c  sym @a1 @OutPortChild2(out out: !firrtl.uint<1>)
       // CHECK: %0 = firrtl.and %x, %c_out
       %0 = firrtl.and %x, %c_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
       // CHECK: %c0_ui1_1 = firrtl.constant 0 

--- a/test/Dialect/FIRRTL/prefix-modules.mlir
+++ b/test/Dialect/FIRRTL/prefix-modules.mlir
@@ -191,10 +191,10 @@ firrtl.circuit "GCTInterfacePrefix"
 // CHECK: firrtl.circuit "T_NLATop"
 firrtl.circuit "NLATop" {
 
-  firrtl.nla @nla [@NLATop, @Aardvark, @Zebra] ["test", "test", "Zebra"]
-  firrtl.nla @nla_1 [@NLATop, @Aardvark, @Zebra] ["test", "test_1", "Zebra"]
-  // CHECK: firrtl.nla @nla [@T_NLATop, @T_Aardvark, @T_A_Z_Zebra] ["test", "test", "Zebra"]
-  // CHECK: firrtl.nla @nla_1 [@T_NLATop, @T_Aardvark, @T_A_Z_Zebra] ["test", "test_1", "Zebra"]
+  firrtl.nla @nla [#hw.innerNameRef<@NLATop::@test>, #hw.innerNameRef<@Aardvark::@test>, #hw.innerNameRef<@Zebra::@Zebra>]
+  firrtl.nla @nla_1 [#hw.innerNameRef<@NLATop::@test>,#hw.innerNameRef<@Aardvark::@test_1>, #hw.innerNameRef<@Zebra::@Zebra>]
+  // CHECK: firrtl.nla @nla [#hw.innerNameRef<@T_NLATop::@test>, #hw.innerNameRef<@T_Aardvark::@test>, #hw.innerNameRef<@T_A_Z_Zebra::@Zebra>]
+  // CHECK: firrtl.nla @nla_1 [#hw.innerNameRef<@T_NLATop::@test>, #hw.innerNameRef<@T_Aardvark::@test_1>, #hw.innerNameRef<@T_A_Z_Zebra::@Zebra>]
   // CHECK: firrtl.module @T_NLATop
   firrtl.module @NLATop()
     attributes {annotations = [{

--- a/test/Dialect/FIRRTL/prefix-modules.mlir
+++ b/test/Dialect/FIRRTL/prefix-modules.mlir
@@ -191,10 +191,10 @@ firrtl.circuit "GCTInterfacePrefix"
 // CHECK: firrtl.circuit "T_NLATop"
 firrtl.circuit "NLATop" {
 
-  firrtl.nla @nla [#hw.innerNameRef<@NLATop::@test>, #hw.innerNameRef<@Aardvark::@test>, #hw.innerNameRef<@Zebra::@Zebra>]
-  firrtl.nla @nla_1 [#hw.innerNameRef<@NLATop::@test>,#hw.innerNameRef<@Aardvark::@test_1>, #hw.innerNameRef<@Zebra::@Zebra>]
-  // CHECK: firrtl.nla @nla [#hw.innerNameRef<@T_NLATop::@test>, #hw.innerNameRef<@T_Aardvark::@test>, #hw.innerNameRef<@T_A_Z_Zebra::@Zebra>]
-  // CHECK: firrtl.nla @nla_1 [#hw.innerNameRef<@T_NLATop::@test>, #hw.innerNameRef<@T_Aardvark::@test_1>, #hw.innerNameRef<@T_A_Z_Zebra::@Zebra>]
+  firrtl.nla @nla [#hw.innerNameRef<@NLATop::@test>, #hw.innerNameRef<@Aardvark::@test>, @Zebra]
+  firrtl.nla @nla_1 [#hw.innerNameRef<@NLATop::@test>,#hw.innerNameRef<@Aardvark::@test_1>, @Zebra]
+  // CHECK: firrtl.nla @nla [#hw.innerNameRef<@T_NLATop::@test>, #hw.innerNameRef<@T_Aardvark::@test>, @T_A_Z_Zebra]
+  // CHECK: firrtl.nla @nla_1 [#hw.innerNameRef<@T_NLATop::@test>, #hw.innerNameRef<@T_Aardvark::@test_1>, @T_A_Z_Zebra]
   // CHECK: firrtl.module @T_NLATop
   firrtl.module @NLATop()
     attributes {annotations = [{

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -153,8 +153,8 @@ firrtl.module @LowerToBind() {
   firrtl.instance foo {lowerToBind = true} @InstanceLowerToBind()
 }
 
-firrtl.nla @NLA1 [] []
-firrtl.nla @NLA2 [@InstanceLowerToBind] ["foo"]
+firrtl.nla @NLA1 []
+firrtl.nla @NLA2 [#hw.innerNameRef<@InstanceLowerToBind::@foo>]
 
 
 // CHECK-LABEL: @ProbeTest


### PR DESCRIPTION
This change will update the `FIRRTL::NonLocalAnchor` to use an 
array of `InnerRefAttr` instead of separate arrays of modules and local names.

The `InnerRefAttr` specifies the module and the name within the module.

This is part of the changes from https://github.com/llvm/circt/pull/2252