### PR TITLE
[FIRRTL/LowerTypes][FIRTOOL] Preserve aggregate at lowertypes

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -28,7 +28,9 @@ std::unique_ptr<mlir::Pass>
 createLowerFIRRTLAnnotationsPass(bool ignoreUnhandledAnnotations = false,
                                  bool ignoreClasslessAnnotations = false);
 
-std::unique_ptr<mlir::Pass> createLowerFIRRTLTypesPass(bool replSeqMem = false);
+std::unique_ptr<mlir::Pass>
+createLowerFIRRTLTypesPass(bool replSeqMem = false,
+                           bool preserveAggregate = false);
 
 std::unique_ptr<mlir::Pass> createLowerBundleVectorTypesPass();
 

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -45,8 +45,9 @@ def LowerFIRRTLTypes : Pass<"firrtl-lower-types", "firrtl::CircuitOp"> {
   let constructor = "circt::firrtl::createLowerFIRRTLTypesPass()";
   let options = [
     Option<"flattenAggregateMemData", "flatten-mem", "bool", "false",
-           "Concat all elements of the aggregate data into a single element.">
-
+           "Concat all elements of the aggregate data into a single element.">,
+    Option<"preserveAggregate", "preserve-aggregate", "bool", "false",
+           "(Experimental) Preserve aggregate vectors/bundles if possible.">
   ];
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -68,11 +68,34 @@ struct FlatBundleFieldEntry {
 };
 } // end anonymous namespace
 
+/// Return true if the type has more than zero bitwidth.
+static bool hasNonZeroBitWidth(FIRRTLType type) {
+  return TypeSwitch<FIRRTLType, bool>(type)
+      .Case<BundleType>([&](auto bundle) {
+        for (size_t i = 0, e = bundle.getNumElements(); i < e; ++i) {
+          auto elt = bundle.getElement(i);
+          if (hasNonZeroBitWidth(elt.type))
+            return true;
+        }
+        return false;
+      })
+      .Case<FVectorType>([&](auto vector) {
+        if (vector.getNumElements() == 0)
+          return false;
+        return hasNonZeroBitWidth(vector.getElementType());
+      })
+      .Default([](auto groundType) {
+        return firrtl::getBitWidth(groundType).getValueOr(0) > 0;
+      });
+}
+
 /// Return true if we can preserve the aggregate type. We can a preserve the
-/// type iff type is not passive and don't contain analog.
+/// type iff (i) the type is not passive, (ii) the type don't contain analog and
+/// (iii) type has non-zero bitwidth.
 static bool isPreservableAggregateType(Type type) {
   auto firrtlType = type.cast<FIRRTLType>();
-  return firrtlType.isPassive() && !firrtlType.containsAnalog();
+  return firrtlType.isPassive() && !firrtlType.containsAnalog() &&
+         hasNonZeroBitWidth(firrtlType);
 }
 
 /// Peel one layer of an aggregate type into its components.  Type may be

--- a/test/Dialect/FIRRTL/lower-types-aggregate.mlir
+++ b/test/Dialect/FIRRTL/lower-types-aggregate.mlir
@@ -1,0 +1,9 @@
+// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-lower-types{preserve-aggregate=true})' %s | FileCheck %s
+
+firrtl.circuit "VectorSimple" {
+  // CHECK-LABEL: firrtl.module @VectorSimple(in %source: !firrtl.vector<uint<1>, 2>, out %sink: !firrtl.vector<uint<1>, 2>)
+  firrtl.module @VectorSimple(in %source: !firrtl.vector<uint<1>, 2>, out %sink: !firrtl.vector<uint<1>, 2>) {
+    // CHECK-NEXT: firrtl.connect %sink, %source
+    firrtl.connect %sink, %source : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
+  }
+} // CIRCUIT

--- a/test/Dialect/FIRRTL/lower-types-aggregate.mlir
+++ b/test/Dialect/FIRRTL/lower-types-aggregate.mlir
@@ -1,9 +1,0 @@
-// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-lower-types{preserve-aggregate=true})' %s | FileCheck %s
-
-firrtl.circuit "VectorSimple" {
-  // CHECK-LABEL: firrtl.module @VectorSimple(in %source: !firrtl.vector<uint<1>, 2>, out %sink: !firrtl.vector<uint<1>, 2>)
-  firrtl.module @VectorSimple(in %source: !firrtl.vector<uint<1>, 2>, out %sink: !firrtl.vector<uint<1>, 2>) {
-    // CHECK-NEXT: firrtl.connect %sink, %source
-    firrtl.connect %sink, %source : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
-  }
-} // CIRCUIT

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -120,6 +120,10 @@ static cl::opt<bool> replSeqMem(
     cl::desc(
         "replace the seq mem for macro replacement and emit relevant metadata"),
     cl::init(false));
+static cl::opt<bool>
+    preserveAggregate("preserve-aggregate",
+                      cl::desc("preserve aggregate types in lower types"),
+                      cl::init(false));
 static cl::opt<std::string>
     replSeqMemCircuit("repl-seq-mem-circuit",
                       cl::desc("circuit root for seq mem metadata"),
@@ -359,7 +363,7 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
   // things up.
   if (lowerTypes) {
     pm.addNestedPass<firrtl::CircuitOp>(
-        firrtl::createLowerFIRRTLTypesPass(replSeqMem));
+        firrtl::createLowerFIRRTLTypesPass(replSeqMem, preserveAggregate));
     // Only enable expand whens if lower types is also enabled.
     if (expandWhens) {
       auto &modulePM = pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>();

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -121,7 +121,7 @@ static cl::opt<bool> replSeqMem(
         "replace the seq mem for macro replacement and emit relevant metadata"),
     cl::init(false));
 static cl::opt<bool>
-    preserveAggregate("preserve-aggregate",
+    preserveAggregate("experimental-preserve-aggregate",
                       cl::desc("preserve aggregate types in lower types"),
                       cl::init(false));
 static cl::opt<std::string>


### PR DESCRIPTION
This commit adds `preserve-aggregate` flag to enable an experimental feature to preserve passive aggregate wires/registers. If preserve-aggregate flag is enabled, we change the behavior of `peelTypes` function not to flatten the type when the condition holds. 

We can't preserve aggregate if any of the following condition holds:
1. They are ports of MemOp (Ports of MemOp must be ground types) 
2. They are non-passive types
3. They contain an analog type
4. They are types with zero width.

 

