### PR TITLE
[FIRRTL/LowerToHW] Support bundle type lowering

### DIFF
--- a/include/circt/Dialect/HW/HWAggregates.td
+++ b/include/circt/Dialect/HW/HWAggregates.td
@@ -173,7 +173,8 @@ def StructExtractOp : HWOp<"struct_extract", [NoSideEffect]> {
   let printer = "return ::print$cppClass(p, *this);";
 
   let builders = [
-    OpBuilder<(ins "Value":$input, "StructType::FieldInfo":$field)>
+    OpBuilder<(ins "Value":$input, "StructType::FieldInfo":$field)>,
+    OpBuilder<(ins "Value":$input, "StringRef":$field)>
   ];
 }
 

--- a/include/circt/Dialect/HW/HWAggregates.td
+++ b/include/circt/Dialect/HW/HWAggregates.td
@@ -174,7 +174,7 @@ def StructExtractOp : HWOp<"struct_extract", [NoSideEffect]> {
 
   let builders = [
     OpBuilder<(ins "Value":$input, "StructType::FieldInfo":$field)>,
-    OpBuilder<(ins "Value":$input, "StringRef":$field)>
+    OpBuilder<(ins "Value":$input, "StringAttr":$field)>
   ];
 }
 

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1484,9 +1484,8 @@ Value FIRRTLLowering::getLoweredValue(Value value) {
   return result;
 }
 
-/// Return the lowered array value whose type is converted into `destType`.
+/// Return the lowered aggregate value whose type is converted into `destType`.
 /// We have to care about the extension/truncation/signedness of each element.
-/// If returns a null value for complex arrays such as arrays with bundles.
 Value FIRRTLLowering::getExtOrTruncAggregateValue(Value array,
                                                   FIRRTLType sourceType,
                                                   FIRRTLType destType,

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1136,8 +1136,8 @@ struct FIRRTLLowering : public FIRRTLVisitor<FIRRTLLowering, LogicalResult> {
                                  std::function<void(void)> elseCtor = {});
   void addIfProceduralBlock(Value cond, std::function<void(void)> thenCtor,
                             std::function<void(void)> elseCtor = {});
-  Value getExtOrTruncArrayValue(Value array, FIRRTLType sourceType,
-                                FIRRTLType destType, bool allowTruncate);
+  Value getExtOrTruncAggregateValue(Value array, FIRRTLType sourceType,
+                                    FIRRTLType destType, bool allowTruncate);
 
   // Create a temporary wire at the current insertion point, and try to
   // eliminate it later as part of lowering post processing.
@@ -1487,10 +1487,10 @@ Value FIRRTLLowering::getLoweredValue(Value value) {
 /// Return the lowered array value whose type is converted into `destType`.
 /// We have to care about the extension/truncation/signedness of each element.
 /// If returns a null value for complex arrays such as arrays with bundles.
-Value FIRRTLLowering::getExtOrTruncArrayValue(Value array,
-                                              FIRRTLType sourceType,
-                                              FIRRTLType destType,
-                                              bool allowTruncate) {
+Value FIRRTLLowering::getExtOrTruncAggregateValue(Value array,
+                                                  FIRRTLType sourceType,
+                                                  FIRRTLType destType,
+                                                  bool allowTruncate) {
   SmallVector<Value> resultBuffer;
 
   // Helper function to cast each element of array to dest type.
@@ -1541,6 +1541,30 @@ Value FIRRTLLowering::getExtOrTruncArrayValue(Value array,
           resultBuffer.push_back(array);
           return success();
         })
+        .Case<BundleType>([&](BundleType srcStructType) {
+          auto destStructType = destType.cast<BundleType>();
+          unsigned size = resultBuffer.size();
+
+          // TODO: We don't support partial connects for bundles for now.
+          if (destStructType.getNumElements() != srcStructType.getNumElements())
+            return failure();
+
+          for (auto elem : enumerate(destStructType.getElements())) {
+            auto structExtract = builder.create<hw::StructExtractOp>(
+                src, elem.value().name.getValue());
+            if (failed(recurse(structExtract,
+                               srcStructType.getElementType(elem.index()),
+                               destStructType.getElementType(elem.index()))))
+              return failure();
+          }
+          SmallVector<Value> temp(resultBuffer.begin() + size,
+                                  resultBuffer.end());
+          auto newStruct = builder.createOrFold<hw::StructCreateOp>(
+              lowerType(destStructType), temp);
+          resultBuffer.resize(size);
+          resultBuffer.push_back(newStruct);
+          return success();
+        })
         .Case<IntType>([&](auto) {
           if (auto result = cast(src, srcType, destType)) {
             resultBuffer.push_back(result);
@@ -1588,14 +1612,15 @@ Value FIRRTLLowering::getLoweredAndExtendedValue(Value value, Type destType) {
     return getOrCreateIntConstant(destWidth, 0);
   }
 
-  if (auto array = result.getType().dyn_cast<hw::ArrayType>()) {
+  // Aggregates values
+  if (result.getType().isa<hw::ArrayType, hw::StructType>()) {
     // Types already match.
     if (destType == value.getType())
       return result;
 
-    return getExtOrTruncArrayValue(result, value.getType().cast<FIRRTLType>(),
-                                   destType.cast<FIRRTLType>(),
-                                   /* allowTruncate */ false);
+    return getExtOrTruncAggregateValue(
+        result, value.getType().cast<FIRRTLType>(), destType.cast<FIRRTLType>(),
+        /* allowTruncate */ false);
   }
 
   auto srcWidth = result.getType().cast<IntegerType>().getWidth();
@@ -1647,14 +1672,15 @@ Value FIRRTLLowering::getLoweredAndExtOrTruncValue(Value value, Type destType) {
     return getOrCreateIntConstant(destWidth, 0);
   }
 
-  if (auto array = result.getType().dyn_cast<hw::ArrayType>()) {
+  // Aggregates values
+  if (result.getType().isa<hw::ArrayType, hw::StructType>()) {
     // Types already match.
     if (destType == value.getType())
       return result;
 
-    return getExtOrTruncArrayValue(result, value.getType().cast<FIRRTLType>(),
-                                   destType.cast<FIRRTLType>(),
-                                   /* allowTruncate */ true);
+    return getExtOrTruncAggregateValue(
+        result, value.getType().cast<FIRRTLType>(), destType.cast<FIRRTLType>(),
+        /* allowTruncate */ true);
   }
 
   auto srcWidth = result.getType().cast<IntegerType>().getWidth();
@@ -2179,6 +2205,13 @@ void FIRRTLLowering::initializeRegister(Value reg) {
               auto arrayIndex =
                   builder.create<sv::ArrayIndexInOutOp>(reg, iIdx);
               recurse(arrayIndex, a.getElementType());
+            }
+          })
+          .Case<hw::StructType>([&](hw::StructType s) {
+            for (auto elem : s.getElements()) {
+              auto field =
+                  builder.create<sv::StructFieldInOutOp>(reg, elem.name);
+              recurse(field, elem.type);
             }
           })
           .Default([&](auto type) { emitRandomInit(reg, type); });

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1549,8 +1549,8 @@ Value FIRRTLLowering::getExtOrTruncAggregateValue(Value array,
             return failure();
 
           for (auto elem : enumerate(destStructType.getElements())) {
-            auto structExtract = builder.create<hw::StructExtractOp>(
-                src, elem.value().name.getValue());
+            auto structExtract =
+                builder.create<hw::StructExtractOp>(src, elem.value().name);
             if (failed(recurse(structExtract,
                                srcStructType.getElementType(elem.index()),
                                destStructType.getElementType(elem.index()))))

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1469,6 +1469,13 @@ void StructExtractOp::build(OpBuilder &builder, OperationState &odsState,
   build(builder, odsState, field.type, input, field.name);
 }
 
+void StructExtractOp::build(OpBuilder &builder, OperationState &odsState,
+                            Value input, StringRef field) {
+  auto structType = input.getType().cast<StructType>();
+  auto resultType = structType.getFieldType(field);
+  build(builder, odsState, resultType, input, field);
+}
+
 //===----------------------------------------------------------------------===//
 // StructInjectOp
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1470,10 +1470,10 @@ void StructExtractOp::build(OpBuilder &builder, OperationState &odsState,
 }
 
 void StructExtractOp::build(OpBuilder &builder, OperationState &odsState,
-                            Value input, StringRef field) {
+                            Value input, StringAttr fieldAttr) {
   auto structType = input.getType().cast<StructType>();
-  auto resultType = structType.getFieldType(field);
-  build(builder, odsState, resultType, input, field);
+  auto resultType = structType.getFieldType(fieldAttr);
+  build(builder, odsState, resultType, input, fieldAttr);
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This commit makes LowerToHW handle bundle values properly:
(i) bundle registers initialization and (ii) extension of
`getExtOrTruncArrayValue` to accept struct/bundle values.

It is almost the same change as https://github.com/llvm/circt/pull/2143.