### PR TITLE
[HW] Use StringAttr instead of StringRef in FieldInfo, nfc

### DIFF
--- a/include/circt-c/Dialect/HW.h
+++ b/include/circt-c/Dialect/HW.h
@@ -25,7 +25,7 @@ extern "C" {
 #endif
 
 struct HWStructFieldInfo {
-  MlirStringRef name;
+  MlirIdentifier name;
   MlirType type;
 };
 typedef struct HWStructFieldInfo HWStructFieldInfo;

--- a/include/circt/Dialect/HW/HWTypes.h
+++ b/include/circt/Dialect/HW/HWTypes.h
@@ -27,7 +27,7 @@ class TypedeclOp;
 namespace detail {
 /// Struct defining a field. Used in structs and unions.
 struct FieldInfo {
-  mlir::StringRef name;
+  mlir::StringAttr name;
   mlir::Type type;
   FieldInfo allocateInto(mlir::TypeStorageAllocator &alloc) const;
 };

--- a/include/circt/Dialect/HW/HWTypes.h
+++ b/include/circt/Dialect/HW/HWTypes.h
@@ -29,7 +29,6 @@ namespace detail {
 struct FieldInfo {
   mlir::StringAttr name;
   mlir::Type type;
-  FieldInfo allocateInto(mlir::TypeStorageAllocator &alloc) const;
 };
 } // namespace detail
 } // namespace hw

--- a/include/circt/Dialect/HW/HWTypesImpl.td
+++ b/include/circt/Dialect/HW/HWTypesImpl.td
@@ -107,9 +107,7 @@ def StructTypeImpl : HWType<"Struct"> {
   let mnemonic = "struct";
 
   let parameters = (
-    ins
-    // An ArrayRef in the storage constructor.
-    ArrayRefParameter<
+    ins ArrayRefParameter<
       "::circt::hw::StructType::FieldInfo", "struct fields">: $elements
   );
 
@@ -124,9 +122,7 @@ def StructTypeImpl : HWType<"Struct"> {
 def UnionTypeImpl : HWType<"Union"> {
   let summary = "An untagged union of types";
   let parameters = (
-    ins
-    // An ArrayRef in the storage constructor.
-    ArrayRefParameter<
+    ins ArrayRefParameter<
       "::circt::hw::UnionType::FieldInfo", "union fields">: $elements
   );
   let mnemonic = "union";

--- a/include/circt/Dialect/HW/HWTypesImpl.td
+++ b/include/circt/Dialect/HW/HWTypesImpl.td
@@ -108,11 +108,9 @@ def StructTypeImpl : HWType<"Struct"> {
 
   let parameters = (
     ins
-    // An ArrayRef of something which requires allocation in the storage
-    // constructor.
-    ArrayRefOfSelfAllocationParameter<
-      "::circt::hw::StructType::FieldInfo",
-      "struct fields">: $elements
+    // An ArrayRef in the storage constructor.
+    ArrayRefParameter<
+      "::circt::hw::StructType::FieldInfo", "struct fields">: $elements
   );
 
   let extraClassDeclaration = [{
@@ -127,11 +125,9 @@ def UnionTypeImpl : HWType<"Union"> {
   let summary = "An untagged union of types";
   let parameters = (
     ins
-    // An ArrayRef of something which requires allocation in the storage
-    // constructor.
-    ArrayRefOfSelfAllocationParameter<
-      "::circt::hw::UnionType::FieldInfo",
-      "union fields">: $elements
+    // An ArrayRef in the storage constructor.
+    ArrayRefParameter<
+      "::circt::hw::UnionType::FieldInfo", "union fields">: $elements
   );
   let mnemonic = "union";
 

--- a/lib/Bindings/Python/HWModule.cpp
+++ b/lib/Bindings/Python/HWModule.cpp
@@ -57,8 +57,10 @@ void circt::python::populateDialectHWSubmodule(py::module &m) {
               auto type = tuple[1].cast<MlirType>();
               ctx = mlirTypeGetContext(type);
               names.emplace_back(tuple[0].cast<std::string>());
+              auto nameStringRef =
+                  mlirStringRefCreate(names[i].data(), names[i].size());
               mlirFieldInfos.push_back(HWStructFieldInfo{
-                  mlirStringRefCreate(names[i].data(), names[i].size()), type});
+                  mlirIdentifierGet(ctx, nameStringRef), type});
             }
             return cls(hwStructTypeGet(ctx, mlirFieldInfos.size(),
                                        mlirFieldInfos.data()));
@@ -73,7 +75,8 @@ void circt::python::populateDialectHWSubmodule(py::module &m) {
         py::list fields;
         for (intptr_t i = 0; i < num_fields; ++i) {
           auto field = hwStructTypeGetFieldNum(self, i);
-          std::string name(field.name.data, field.name.length);
+          auto fieldName = mlirIdentifierStr(field.name);
+          std::string name(fieldName.data, fieldName.length);
           fields.append(py::make_tuple(name, field.type));
         }
         return fields;

--- a/lib/CAPI/Dialect/HW.cpp
+++ b/lib/CAPI/Dialect/HW.cpp
@@ -69,8 +69,8 @@ MlirType hwStructTypeGet(MlirContext ctx, intptr_t numElements,
   SmallVector<StructType::FieldInfo> fieldInfos;
   fieldInfos.reserve(numElements);
   for (intptr_t i = 0; i < numElements; ++i) {
-    fieldInfos.push_back(StructType::FieldInfo{unwrap(elements[i].name),
-                                               unwrap(elements[i].type)});
+    fieldInfos.push_back(StructType::FieldInfo{
+        unwrap(elements[i].name).cast<StringAttr>(), unwrap(elements[i].type)});
   }
   return wrap(StructType::get(unwrap(ctx), fieldInfos));
 }

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -998,7 +998,7 @@ static bool printPackedTypeImpl(Type type, raw_ostream &os, Location loc,
           printPackedTypeImpl(stripUnpackedTypes(element.type), os, loc,
                               structDims, /*implicitIntType=*/false,
                               /*singleBitDefaultType=*/true, emitter);
-          os << ' ' << element.name;
+          os << ' ' << element.name.getValue();
           emitter.printUnpackedTypePostfix(element.type, os);
           os << "; ";
         }
@@ -2005,7 +2005,7 @@ SubExprInfo ExprEmitter::visitTypeOp(StructCreateOp op) {
   size_t i = 0;
   llvm::interleaveComma(stype.getElements(), os,
                         [&](const StructType::FieldInfo &field) {
-                          os << field.name << ": ";
+                          os << field.name.getValue() << ": ";
                           emitSubExpr(op.getOperand(i++), Selection, OOLBinary);
                         });
   os << '}';
@@ -2023,12 +2023,12 @@ SubExprInfo ExprEmitter::visitTypeOp(StructInjectOp op) {
   os << "'{";
   llvm::interleaveComma(stype.getElements(), os,
                         [&](const StructType::FieldInfo &field) {
-                          os << field.name << ": ";
+                          os << field.name.getValue() << ": ";
                           if (field.name == op.field()) {
                             emitSubExpr(op.newValue(), Selection, OOLBinary);
                           } else {
                             emitSubExpr(op.input(), Selection, OOLBinary);
-                            os << '.' << field.name;
+                            os << '.' << field.name.getValue();
                           }
                         });
   os << '}';

--- a/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
+++ b/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
@@ -54,7 +54,7 @@ uint32_t llvmIndexOfStructField(hw::StructType type, StringRef fieldName) {
   size_t index = 0;
 
   for (const auto *iter = fieldIter.begin(); iter != fieldIter.end(); ++iter) {
-    if (iter->name.equals(fieldName)) {
+    if (iter->name == fieldName) {
       return convertToLLVMEndianess(type, index);
     }
     ++index;

--- a/lib/Dialect/ESI/capnp/Schema.cpp
+++ b/lib/Dialect/ESI/capnp/Schema.cpp
@@ -195,10 +195,12 @@ static bool isPointerType(::capnp::schema::Type::Reader type) {
 TypeSchemaImpl::TypeSchemaImpl(Type t) : type(t) {
   TypeSwitch<Type>(type)
       .Case([this](IntegerType t) {
-        fieldTypes.push_back(FieldInfo{"i", t});
+        fieldTypes.push_back(
+            FieldInfo{StringAttr::get(t.getContext(), "i"), t});
       })
       .Case([this](hw::ArrayType t) {
-        fieldTypes.push_back(FieldInfo{"l", t});
+        fieldTypes.push_back(
+            FieldInfo{StringAttr::get(t.getContext(), "l"), t});
       })
       .Case([this](hw::StructType t) {
         fieldTypes.append(t.getElements().begin(), t.getElements().end());
@@ -433,7 +435,7 @@ LogicalResult TypeSchemaImpl::write(llvm::raw_ostream &rawOS) const {
 
   for (auto field : fieldTypes) {
     // Specify the actual type, followed by the capnp field.
-    os.indent() << field.name;
+    os.indent() << field.name.getValue();
     os.pad(maxNameLength - field.name.size()) << " @" << counter++ << " :";
     emitCapnpType(field.type, os);
     os << ";  # Actual type is " << field.type << ".\n";

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2719,8 +2719,8 @@ static LogicalResult verifyHWStructCastOp(HWStructCastOp cast) {
     int64_t hwWidth = hw::getBitWidth(hwFields[findex].type);
     if (firWidth > 0 && hwWidth > 0 && firWidth != hwWidth)
       return cast.emitError("size of field '")
-             << hwFields[findex].name.getValue() << "' don't match " << firWidth << ", "
-             << hwWidth;
+             << hwFields[findex].name.getValue() << "' don't match " << firWidth
+             << ", " << hwWidth;
   }
 
   return success();

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2713,13 +2713,13 @@ static LogicalResult verifyHWStructCastOp(HWStructCastOp cast) {
     if (firFields[findex].name.getValue() != hwFields[findex].name)
       return cast.emitError("field names don't match '")
              << firFields[findex].name.getValue() << "', '"
-             << hwFields[findex].name << "'";
+             << hwFields[findex].name.getValue() << "'";
     int64_t firWidth =
         FIRRTLType(firFields[findex].type).getBitWidthOrSentinel();
     int64_t hwWidth = hw::getBitWidth(hwFields[findex].type);
     if (firWidth > 0 && hwWidth > 0 && firWidth != hwWidth)
       return cast.emitError("size of field '")
-             << hwFields[findex].name << "' don't match " << firWidth << ", "
+             << hwFields[findex].name.getValue() << "' don't match " << firWidth << ", "
              << hwWidth;
   }
 

--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -32,7 +32,7 @@ using namespace circt::hw::detail;
 #include "circt/Dialect/HW/HWTypes.cpp.inc"
 
 FieldInfo FieldInfo::allocateInto(mlir::TypeStorageAllocator &alloc) const {
-  return FieldInfo{alloc.copyInto(name), type};
+  return FieldInfo{name, type};
 }
 
 //===----------------------------------------------------------------------===//
@@ -236,7 +236,8 @@ static ParseResult parseFields(AsmParser &p,
         Type type;
         if (p.parseKeyword(&name) || p.parseColon() || p.parseType(type))
           return failure();
-        parameters.push_back(FieldInfo{name, type});
+        parameters.push_back(
+            FieldInfo{StringAttr::get(name, p.getContext()), type});
         return success();
       });
 }
@@ -245,7 +246,7 @@ static ParseResult parseFields(AsmParser &p,
 static void printFields(AsmPrinter &p, ArrayRef<FieldInfo> fields) {
   p << '<';
   llvm::interleaveComma(fields, p, [&](const FieldInfo &field) {
-    p << field.name << ": " << field.type;
+    p << field.name.getValue() << ": " << field.type;
   });
   p << ">";
 }

--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -31,10 +31,6 @@ using namespace circt::hw::detail;
 #define GET_TYPEDEF_CLASSES
 #include "circt/Dialect/HW/HWTypes.cpp.inc"
 
-FieldInfo FieldInfo::allocateInto(mlir::TypeStorageAllocator &alloc) const {
-  return FieldInfo{name, type};
-}
-
 //===----------------------------------------------------------------------===//
 // Type Helpers
 //===----------------------------------------------------------------------===/


### PR DESCRIPTION
This commit changes to use StringAttr instead of StringRef
in FieldInfo to avoid unnecessary copies of field names.

Changes are mainly about parser/printer and CAPI.

Will close https://github.com/llvm/circt/issues/2324