### PR TITLE
[ExportVerilog] Fix empty struct emission

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -231,7 +231,7 @@ static bool isZeroBitType(Type type) {
     return isZeroBitType(array.getElementType());
   if (auto structType = type.dyn_cast<hw::StructType>()) {
     return llvm::all_of(structType.getElements(),
-                 [](auto elem) { return isZeroBitType(elem.type); });
+                        [](auto elem) { return isZeroBitType(elem.type); });
   }
 
   // We have an open type system, so assume it is ok.

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -229,6 +229,10 @@ static bool isZeroBitType(Type type) {
     return isZeroBitType(uarray.getElementType());
   if (auto array = type.dyn_cast<hw::ArrayType>())
     return isZeroBitType(array.getElementType());
+  if (auto structType = type.dyn_cast<hw::StructType>()) {
+    return llvm::all_of(structType.getElements(),
+                 [](auto elem) { return isZeroBitType(elem.type); });
+  }
 
   // We have an open type system, so assume it is ok.
   return false;
@@ -992,6 +996,12 @@ static bool printPackedTypeImpl(Type type, raw_ostream &os, Location loc,
                                    emitter);
       })
       .Case<StructType>([&](StructType structType) {
+        if (structType.getElements().empty()) {
+          if (!implicitIntType)
+            os << "logic ";
+          os << "/*Zero Width*/";
+          return true;
+        }
         os << "struct packed {";
         for (auto &element : structType.getElements()) {
           SmallVector<Attribute, 8> structDims;

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -229,10 +229,9 @@ static bool isZeroBitType(Type type) {
     return isZeroBitType(uarray.getElementType());
   if (auto array = type.dyn_cast<hw::ArrayType>())
     return isZeroBitType(array.getElementType());
-  if (auto structType = type.dyn_cast<hw::StructType>()) {
+  if (auto structType = type.dyn_cast<hw::StructType>())
     return llvm::all_of(structType.getElements(),
                         [](auto elem) { return isZeroBitType(elem.type); });
-  }
 
   // We have an open type system, so assume it is ok.
   return false;

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -448,6 +448,38 @@ hw.module @TestZeroInstance(%aa: i4, %azeroBit: i0, %aarrZero: !hw.array<3xi0>)
   hw.output %o1, %o2, %o3 : i4, i0, !hw.array<3xi0>
 }
 
+// CHECK: module TestZeroStruct(
+// CHECK-NEXT:  // input  /*Zero Width*/                           structZero,
+// CHECK-NEXT:  // input  struct packed {logic /*Zero Width*/ a; } structZeroNest,
+// CHECK-NEXT:  // output /*Zero Width*/                           structZero_0,
+// CHECK-NEXT:  // output struct packed {logic /*Zero Width*/ a; } structZeroNest_0
+// CHECK-NEXT: );
+hw.module @TestZeroStruct(%structZero: !hw.struct<>, %structZeroNest: !hw.struct<a: !hw.struct<>>)
+  -> (structZero_0: !hw.struct<>, structZeroNest_0: !hw.struct<a: !hw.struct<>>) {
+
+  hw.output %structZero, %structZeroNest : !hw.struct<>, !hw.struct<a: !hw.struct<>>
+  // CHECK:      // Zero width: assign structZero_0 = structZero;
+  // CHECK-NEXT: // Zero width: assign structZeroNest_0 = structZeroNest;
+  // CHECK-NEXT: endmodule
+}
+
+// CHECK-LABEL: TestZeroStructInstance
+hw.module @TestZeroStructInstance(%structZero: !hw.struct<>, %structZeroNest: !hw.struct<a: !hw.struct<>>)
+  -> (structZero_0: !hw.struct<>, structZeroNest_0: !hw.struct<a: !hw.struct<>>) {
+
+// CHECK: TestZeroStruct iii (
+// CHECK-NEXT:  //.structZero       (structZero)
+// CHECK-NEXT:  //.structZeroNest   (structZeroNest)
+// CHECK-NEXT:  //.structZero_0     (structZero_0)
+// CHECK-NEXT:  //.structZeroNest_0 (structZeroNest_0)
+// CHECK-NEXT:  );
+
+  %o1, %o2 = hw.instance "iii" @TestZeroStruct(structZero: %structZero: !hw.struct<>, structZeroNest: %structZeroNest: !hw.struct<a: !hw.struct<>>)
+                                -> (structZero_0: !hw.struct<>, structZeroNest_0: !hw.struct<a: !hw.struct<>>)
+
+  hw.output %o1, %o2 : !hw.struct<>, !hw.struct<a: !hw.struct<>>
+}
+
 // https://github.com/llvm/circt/issues/438
 // CHECK-LABEL: module cyclic
 hw.module @cyclic(%a: i1) -> (b: i1) {


### PR DESCRIPTION
This commit fixes the issue of empty struct emission. If structs are
empty we shouldn't emit `struct packed {}` because it causes syntax
errors. This adds handlings of struct types to `isZeroBitType` and
`printPackedTypeImpl`.

Will close https://github.com/llvm/circt/issues/2327