### PR TITLE
[LowerToHW] Lower invalid values with aggregate types

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -2853,14 +2853,22 @@ LogicalResult FIRRTLLowering::visitExpr(InvalidValueOp op) {
     // not attach a symbol name.
     return setLoweringTo<sv::WireOp>(op, resultTy, ".invalid_analog");
 
+  // We don't allow aggregate values which contain values of analog types.
+  if (op.getType().cast<FIRRTLType>().containsAnalog())
+    return failure();
+
   // We lower invalid to 0.  TODO: the FIRRTL spec mentions something about
   // lowering it to a random value, we should see if this is what we need to
   // do.
-  if (auto intType = resultTy.dyn_cast<IntegerType>()) {
-    if (intType.getWidth() == 0) // Let the caller handle zero width values.
+  if (auto bitwidth = firrtl::getBitWidth(op.getType().cast<FIRRTLType>())) {
+    if (bitwidth.getValue() == 0) // Let the caller handle zero width values.
       return failure();
-    return setLowering(
-        op, getOrCreateIntConstant(resultTy.getIntOrFloatBitWidth(), 0));
+
+    auto constant = getOrCreateIntConstant(bitwidth.getValue(), 0);
+    // If the result type is an aggregate value, we bitcast the constant.
+    if (!resultTy.isa<IntegerType>())
+      constant = builder.create<hw::BitcastOp>(resultTy, constant);
+    return setLowering(op, constant);
   }
 
   // Invalid for bundles isn't supported.

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -2865,7 +2865,7 @@ LogicalResult FIRRTLLowering::visitExpr(InvalidValueOp op) {
       return failure();
 
     auto constant = getOrCreateIntConstant(bitwidth.getValue(), 0);
-    // If the result type is an aggregate value, we bitcast the constant.
+    // If the result is an aggregate value, we have to bitcast the constant.
     if (!resultTy.isa<IntegerType>())
       constant = builder.create<hw::BitcastOp>(resultTy, constant);
     return setLowering(op, constant);

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
@@ -7,16 +7,6 @@
 // CHECK:   sv.ifdef.procedural "RANDOMIZE_GARBAGE_ASSIGN"  {
 // CHECK-NEXT:   sv.verbatim "`define RANDOMIZE"
 // CHECK-NEXT:  }
-firrtl.circuit "InvalidBundle" {
-
-  // https://github.com/llvm/circt/issues/593
-  firrtl.module @InvalidBundle() {
-    // expected-error @+1 {{unsupported type}}
-    %0 = firrtl.invalidvalue : !firrtl.bundle<inp_d: uint<14>>
-  }
-}
-
-// -----
 
 firrtl.circuit "OperandTypeIsFIRRTL" {
   firrtl.module @OperandTypeIsFIRRTL() { }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1505,4 +1505,19 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: sv.assign %1, %2 : !hw.struct<b: i1>
     // CHECK-NEXT: hw.output %0 : !hw.struct<a: !hw.struct<b: i1>>
   }
+
+  // CHECK_LABEL: hw.module @AggregateInvalidValue
+  firrtl.module @AggregateInvalidValue(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
+    %invalid = firrtl.invalidvalue : !firrtl.bundle<a: uint<1>, b: vector<uint<10>, 10>>
+    %reg = firrtl.regreset %clock, %reset, %invalid : !firrtl.uint<1>, !firrtl.bundle<a: uint<1>, b: vector<uint<10>, 10>>, !firrtl.bundle<a: uint<1>, b: vector<uint<10>, 10>>
+    // CHECK:      %c0_i101 = hw.constant 0 : i101
+    // CHECK-NEXT: %0 = hw.bitcast %c0_i101 : (i101) -> !hw.struct<a: i1, b: !hw.array<10xi10>>
+    // CHECK-NEXT: %reg = sv.reg  : !hw.inout<struct<a: i1, b: !hw.array<10xi10>>>
+    // CHECK-NEXT: sv.always posedge %clock  {
+    // CHECK-NEXT:   sv.if %reset  {
+    // CHECK-NEXT:     sv.passign %reg, %0 : !hw.struct<a: i1, b: !hw.array<10xi10>>
+    // CHECK-NEXT:   } else  {
+    // CHECK-NEXT:   }
+    // CHECK-NEXT: }
+  }
 }


### PR DESCRIPTION
This commit enables us to lower invalid values with aggregate types.
Since we lower invalid values into zero constant, we apply hw.bitcast
to the constant to get values with aggregate types.