### PR TITLE
[HW] Fix canonicalization for wires with aggregate types

### DIFF
--- a/test/Dialect/HW/canonicalization.mlir
+++ b/test/Dialect/HW/canonicalization.mlir
@@ -1187,6 +1187,16 @@ hw.module @unintializedWire(%clock1: i1, %clock2: i1, %inpred: i1, %indata: i42)
   hw.output %_M.ro_data_0, %_M.rw_rdata_0 : i42, i42
 }
 
+// CHECK-LABEL: hw.module @unintializedWireStruct
+hw.module @unintializedWireStruct() -> (result: !hw.struct<a: i1, b: i1>) {
+  %0 = sv.wire : !hw.inout<!hw.struct<a: i1, b: i1>>
+  %1 = sv.read_inout %0 : !hw.inout<!hw.struct<a: i1, b: i1>>
+  hw.output %1 : !hw.struct<a: i1, b: i1>
+  // CHECK-NEXT: %x_i2 = sv.constantX : i2
+  // CHECK-NEXT: %0 = hw.bitcast %x_i2 : (i2) -> !hw.struct<a: i1, b: i1>
+  // CHECK-NEXT: hw.output %0
+}
+
 // CHECK-LABEL:  hw.module @IncompleteRead(%clock1: i1) {
 // CHECK-NEXT:    %c0_i4 = hw.constant 0 : i4
 // CHECK-NEXT:    %true = hw.constant true

--- a/test/Dialect/HW/canonicalization.mlir
+++ b/test/Dialect/HW/canonicalization.mlir
@@ -1187,14 +1187,21 @@ hw.module @unintializedWire(%clock1: i1, %clock2: i1, %inpred: i1, %indata: i42)
   hw.output %_M.ro_data_0, %_M.rw_rdata_0 : i42, i42
 }
 
-// CHECK-LABEL: hw.module @unintializedWireStruct
-hw.module @unintializedWireStruct() -> (result: !hw.struct<a: i1, b: i1>) {
+// CHECK-LABEL: hw.module @uninitializedWireAggregate
+hw.module @uninitializedWireAggregate() -> (result1: !hw.struct<a: i1, b: i1>,
+                                            result2: !hw.struct<a: i1, b: !hw.array<10x!hw.struct<a: i1, b: i1>>>)
+{
   %0 = sv.wire : !hw.inout<!hw.struct<a: i1, b: i1>>
   %1 = sv.read_inout %0 : !hw.inout<!hw.struct<a: i1, b: i1>>
-  hw.output %1 : !hw.struct<a: i1, b: i1>
+  %2 = sv.wire : !hw.inout<!hw.struct<a: i1, b: !hw.array<10x!hw.struct<a: i1, b: i1>>>>
+  %3 = sv.read_inout %2 :  !hw.inout<!hw.struct<a: i1, b: !hw.array<10x!hw.struct<a: i1, b: i1>>>>
+
+  hw.output %1, %3 : !hw.struct<a: i1, b: i1>, !hw.struct<a: i1, b: !hw.array<10x!hw.struct<a: i1, b: i1>>>
   // CHECK-NEXT: %x_i2 = sv.constantX : i2
   // CHECK-NEXT: %0 = hw.bitcast %x_i2 : (i2) -> !hw.struct<a: i1, b: i1>
-  // CHECK-NEXT: hw.output %0
+  // CHECK-NEXT:  %x_i21 = sv.constantX : i21
+  // CHECK-NEXT: %1 = hw.bitcast %x_i21 : (i21) -> !hw.struct<a: i1, b: !hw.array<10xstruct<a: i1, b: i1>>>
+  // CHECK-NEXT: hw.output %0, %1
 }
 
 // CHECK-LABEL:  hw.module @IncompleteRead(%clock1: i1) {


### PR DESCRIPTION
The optimization to replace unwritten wires with x-values currently
assumes that the wire has integer types. So canonicalization crashes for 
aggregate types. This commit fixes the issue by bitcasting x-values into 
aggregate values.