### PR TITLE
[Handshake] Add fork and mux canonicalization patterns

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -364,6 +364,7 @@ def MuxOp : Handshake_Op<"mux", [
   let printer = "return ::print$cppClass(p, *this);";
   let parser = "return ::parse$cppClass(parser, result);";
   let verifier = "return ::verify(*this);";
+  let hasCanonicalizer = 1;
 }
 
 def ControlMergeOp : Handshake_Op<"control_merge", [

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -26,6 +26,7 @@
 #include "mlir/Transforms/InliningUtils.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallBitVector.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 #include <set>
 
@@ -168,12 +169,48 @@ struct EliminateUnusedForkResultsPattern : mlir::OpRewritePattern<ForkOp> {
     return success();
   }
 };
+
+struct EliminateForkToForkPattern : mlir::OpRewritePattern<ForkOp> {
+  using mlir::OpRewritePattern<ForkOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ForkOp op,
+                                PatternRewriter &rewriter) const override {
+    auto parentForkOp =
+        dyn_cast_or_null<ForkOp>(op.getOperand().getDefiningOp());
+    if (!parentForkOp)
+      return failure();
+
+    /// Create the fork with as many outputs as the two source forks.
+    /// Keeping the op.operand() output may or may not be redundant (dependning
+    /// on if op is the single user of the value), but we'll let
+    /// EliminateUnusedForkResultsPattern apply in that case.
+    unsigned totalNumOuts = op.size() + parentForkOp.size();
+    rewriter.updateRootInPlace(parentForkOp, [&] {
+      /// Create a new parent fork op which produces all of the fork outputs and
+      /// replace all of the uses of the old results.
+      auto newParentForkOp = rewriter.create<ForkOp>(
+          parentForkOp.getLoc(), parentForkOp.getOperand(), totalNumOuts);
+
+      for (auto it :
+           llvm::zip(parentForkOp->getResults(), newParentForkOp.getResults()))
+        std::get<0>(it).replaceAllUsesWith(std::get<1>(it));
+      rewriter.eraseOp(parentForkOp);
+
+      /// Replace the results of the matches fork op with the corresponding
+      /// results of the new parent fork op.
+      rewriter.replaceOp(op, newParentForkOp.getResults().take_back(op.size()));
+    });
+    return success();
+  }
+};
+
 } // namespace
 
 void handshake::ForkOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                                     MLIRContext *context) {
-  results.insert<circt::handshake::EliminateSimpleForksPattern>(context);
-  results.insert<EliminateUnusedForkResultsPattern>(context);
+  results.insert<circt::handshake::EliminateSimpleForksPattern,
+                 EliminateForkToForkPattern, EliminateUnusedForkResultsPattern>(
+      context);
 }
 
 void LazyForkOp::build(OpBuilder &builder, OperationState &result,
@@ -239,6 +276,47 @@ void printMergeOp(OpAsmPrinter &p, MergeOp op) { sost::printOp(p, op, false); }
 void MergeOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                           MLIRContext *context) {
   results.insert<circt::handshake::EliminateSimpleMergesPattern>(context);
+}
+
+/// Returns a dematerialized version of the value 'v', defined as the source of
+/// the value before passing through a buffer or fork operation.
+static Value getDematerialized(Value v) {
+  Operation *parentOp = v.getDefiningOp();
+  if (!parentOp)
+    return v;
+
+  return llvm::TypeSwitch<Operation *, Value>(parentOp)
+      .Case<ForkOp>(
+          [&](ForkOp op) { return getDematerialized(op.getOperand()); })
+      .Case<BufferOp>(
+          [&](BufferOp op) { return getDematerialized(op.getOperand()); })
+      .Default([&](auto) { return v; });
+}
+
+namespace {
+
+/// Eliminates muxes with identical data inputs. Data inputs are inspected as
+/// their dematerialized versions. This has the side effect of any subsequently
+/// unused buffers are DCE'd and forks are optimized to be narrower.
+struct EliminateSimpleMuxesPattern : mlir::OpRewritePattern<MuxOp> {
+  using mlir::OpRewritePattern<MuxOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(MuxOp op,
+                                PatternRewriter &rewriter) const override {
+    Value firstDataOperand = getDematerialized(op.dataOperands()[0]);
+    if (!llvm::all_of(op.dataOperands(), [&](Value operand) {
+          return getDematerialized(operand) == firstDataOperand;
+        }))
+      return failure();
+    rewriter.replaceOp(op, firstDataOperand);
+    return success();
+  }
+};
+
+} // namespace
+
+void MuxOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                        MLIRContext *context) {
+  results.insert<EliminateSimpleMuxesPattern>(context);
 }
 
 void MuxOp::build(OpBuilder &builder, OperationState &result, Value anyInput,

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -175,8 +175,7 @@ struct EliminateForkToForkPattern : mlir::OpRewritePattern<ForkOp> {
 
   LogicalResult matchAndRewrite(ForkOp op,
                                 PatternRewriter &rewriter) const override {
-    auto parentForkOp =
-        dyn_cast_or_null<ForkOp>(op.getOperand().getDefiningOp());
+    auto parentForkOp = op.getOperand().getDefiningOp<ForkOp>();
     if (!parentForkOp)
       return failure();
 

--- a/test/Dialect/Handshake/canonicalization.mlir
+++ b/test/Dialect/Handshake/canonicalization.mlir
@@ -80,3 +80,66 @@ handshake.func @unused_fork_result(%arg0: none) -> (none, none) {
   %0:3 = fork [3] %arg0 : none
   handshake.return %0#0, %0#2 : none, none
 }
+
+// -----
+
+// CHECK-LABEL:   handshake.func @simple_mux(
+// CHECK-SAME:                               %[[VAL_0:.*]]: index,
+// CHECK-SAME:                               %[[VAL_1:.*]]: none, ...) -> (none, none)
+// CHECK:           return %[[VAL_1]], %[[VAL_1]] : none, none
+// CHECK:         }
+handshake.func @simple_mux(%c : index, %arg1: none) -> (none, none) {
+  %0 = mux %c [%arg1, %arg1, %arg1] : index, none
+  handshake.return %0, %arg1 : none, none
+}
+
+
+// -----
+
+// CHECK-LABEL:   handshake.func @simple_mux2(
+// CHECK-SAME:                                %[[VAL_0:.*]]: index,
+// CHECK-SAME:                                %[[VAL_1:.*]]: none, ...) -> (none, none)
+// CHECK:           %[[VAL_2:.*]] = buffer [2] %[[VAL_1]] {sequential = true} : none
+// CHECK:           return %[[VAL_2]], %[[VAL_1]] : none, none
+// CHECK:         }
+handshake.func @simple_mux2(%c : index, %arg1: none) -> (none, none) {
+  %0:3 = fork [3] %arg1 : none
+  %1 = buffer [2] %0#0 {sequential = true} : none
+  %2 = buffer [2] %0#1 {sequential = true} : none
+  %3 = mux %c [%1, %0#2] : index, none
+  handshake.return %2, %3 : none, none
+}
+
+// -----
+
+// CHECK-LABEL:   handshake.func @simple_mux3(
+// CHECK-SAME:                                %[[VAL_0:.*]]: i32,
+// CHECK-SAME:                                %[[VAL_1:.*]]: index,
+// CHECK-SAME:                                %[[VAL_2:.*]]: none, ...) -> (i32, i32, none)
+// CHECK:           %[[VAL_3:.*]]:2 = fork [2] %[[VAL_0]] : i32
+// CHECK:           %[[VAL_4:.*]] = buffer [2] %[[VAL_3]]#1 {sequential = true} : i32
+// CHECK:           %[[VAL_5:.*]] = arith.addi %[[VAL_3]]#0, %[[VAL_4]] : i32
+// CHECK:           return %[[VAL_5]], %[[VAL_0]], %[[VAL_2]] : i32, i32, none
+// CHECK:         }
+handshake.func @simple_mux3(%arg0 : i32, %c : index, %arg1: none) -> (i32, i32, none) {
+  %0:3 = fork [3] %arg0 : i32
+  %1:2 = fork [2] %0#0 : i32
+  %3 = mux %c [%1#1, %0#1] : index, i32
+  %4 = buffer [2] %1#1 {sequential = true} : i32
+  %5 = arith.addi %0#1, %4 : i32
+  handshake.return %5, %3, %arg1 : i32, i32, none
+}
+
+// -----
+
+// CHECK-LABEL:   handshake.func @fork_to_fork(
+// CHECK-SAME:                                 %[[VAL_0:.*]]: i32,
+// CHECK-SAME:                                 %[[VAL_1:.*]]: none, ...) -> (i32, i32, i32, none)
+// CHECK:           %[[VAL_2:.*]]:3 = fork [3] %[[VAL_0]] : i32
+// CHECK:           return %[[VAL_2]]#0, %[[VAL_2]]#1, %[[VAL_2]]#2, %[[VAL_1]] : i32, i32, i32, none
+// CHECK:         }
+handshake.func @fork_to_fork(%arg0 : i32, %arg1: none) -> (i32, i32, i32, none) {
+  %0:2 = fork [2] %arg0 : i32
+  %1:2 = fork [2] %0#0 : i32
+  handshake.return %0#1, %1#0, %1#1, %arg1 : i32, i32, i32, none
+}


### PR DESCRIPTION
The use a concept of "dematerialized" values to apply optimizations. Dematerialized values are defined as the source of any given value before passing through a buffer or fork operation.