### PR TITLE
[ExportVerilog] Don't emit "logic" for temporaries with struct types

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -297,12 +297,11 @@ static StringRef getVerilogDeclWord(Operation *op,
   // fall through to default.
   bool isProcedural = op->getParentOp()->hasTrait<ProceduralRegion>();
 
-  // "automatic logic" values aren't allowed in disallowLocalVariables mode.
-  assert((!isProcedural || !options.disallowLocalVariables) &&
-         "automatic variables not allowed");
-
   if (!isProcedural)
     return "wire";
+
+  // "automatic" values aren't allowed in disallowLocalVariables mode.
+  assert(!options.disallowLocalVariables && "automatic variables not allowed");
 
   // If the type contains a struct type, we have to use only "automatic" because
   // "automatic struct" is syntactically correct.


### PR DESCRIPTION
This commit fixes the issue related to the emission of automatic
variable. If the type contains a struct type, we shouldn't emit "logic"
because "automatic struct" is syntactically correct. 

Will close #2335 .