### PR TITLE
[SV] Allow constantX/Z to have non-integer types

### DIFF
--- a/include/circt/Dialect/SV/SVExpressions.td
+++ b/include/circt/Dialect/SV/SVExpressions.td
@@ -90,8 +90,14 @@ def ConstantXOp : SVOp<"constantX", [NoSideEffect, HasCustomSSAName]> {
     }];
 
   let arguments = (ins);
-  let results = (outs HWIntegerType:$result);
+  let results = (outs HWValueType:$result);
   let assemblyFormat = " attr-dict `:` type($result)";
+  let verifier = "return ::verify$cppClass(*this);";
+  let extraClassDeclaration = [{
+    int64_t getWidth() {
+      return hw::getBitWidth(getType());
+    }
+  }];
 }
 
 def ConstantZOp : SVOp<"constantZ", [NoSideEffect, HasCustomSSAName]> {
@@ -102,8 +108,14 @@ def ConstantZOp : SVOp<"constantZ", [NoSideEffect, HasCustomSSAName]> {
     }];
 
   let arguments = (ins);
-  let results = (outs HWIntegerType:$result);
+  let results = (outs HWValueType:$result);
   let assemblyFormat = " attr-dict `:` type($result)";
+  let verifier = "return ::verify$cppClass(*this);";
+  let extraClassDeclaration = [{
+    int64_t getWidth() {
+      return hw::getBitWidth(getType());
+    }
+  }];
 }
 
 def LocalParamOp : SVOp<"localparam",

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1868,12 +1868,14 @@ SubExprInfo ExprEmitter::visitVerbatimExprOp(Operation *op, ArrayAttr symbols) {
 }
 
 SubExprInfo ExprEmitter::visitSV(ConstantXOp op) {
-  os << op.getType().getWidth() << "'bx";
+  auto bitWidth = hw::getBitWidth(op.getType());
+  os << bitWidth << "'bx";
   return {Unary, IsUnsigned};
 }
 
 SubExprInfo ExprEmitter::visitSV(ConstantZOp op) {
-  os << op.getType().getWidth() << "'bz";
+  auto bitWidth = hw::getBitWidth(op.getType());
+  os << bitWidth << "'bz";
   return {Unary, IsUnsigned};
 }
 
@@ -1888,7 +1890,7 @@ SubExprInfo ExprEmitter::visitTypeOp(ConstantOp op) {
     isNegated = true;
   }
 
-  os << op.getType().getWidth() << '\'';
+  os << op.getWidth() << '\'';
 
   // Emit this as a signed constant if the caller would prefer that.
   if (signPreference == RequireSigned)

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1868,14 +1868,12 @@ SubExprInfo ExprEmitter::visitVerbatimExprOp(Operation *op, ArrayAttr symbols) {
 }
 
 SubExprInfo ExprEmitter::visitSV(ConstantXOp op) {
-  auto bitWidth = op.getWidth();
-  os << bitWidth << "'bx";
+  os << op.getWidth() << "'bx";
   return {Unary, IsUnsigned};
 }
 
 SubExprInfo ExprEmitter::visitSV(ConstantZOp op) {
-  auto bitWidth = op.getWidth();
-  os << bitWidth << "'bz";
+  os << op.getWidth() << "'bz";
   return {Unary, IsUnsigned};
 }
 

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1868,13 +1868,13 @@ SubExprInfo ExprEmitter::visitVerbatimExprOp(Operation *op, ArrayAttr symbols) {
 }
 
 SubExprInfo ExprEmitter::visitSV(ConstantXOp op) {
-  auto bitWidth = hw::getBitWidth(op.getType());
+  auto bitWidth = op.getWidth();
   os << bitWidth << "'bx";
   return {Unary, IsUnsigned};
 }
 
 SubExprInfo ExprEmitter::visitSV(ConstantZOp op) {
-  auto bitWidth = hw::getBitWidth(op.getType());
+  auto bitWidth = op.getWidth();
   os << bitWidth << "'bz";
   return {Unary, IsUnsigned};
 }
@@ -1890,7 +1890,7 @@ SubExprInfo ExprEmitter::visitTypeOp(ConstantOp op) {
     isNegated = true;
   }
 
-  os << op.getWidth() << '\'';
+  os << op.getType().getWidth() << '\'';
 
   // Emit this as a signed constant if the caller would prefer that.
   if (signPreference == RequireSigned)

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -170,16 +170,30 @@ void ConstantXOp::getAsmResultNames(
     function_ref<void(Value, StringRef)> setNameFn) {
   SmallVector<char, 32> specialNameBuffer;
   llvm::raw_svector_ostream specialName(specialNameBuffer);
-  specialName << "x_" << getType();
+  specialName << "x_i" << getWidth();
   setNameFn(getResult(), specialName.str());
+}
+
+static LogicalResult verifyConstantXOp(ConstantXOp op) {
+  // We don't allow zero width constant or unknown width.
+  if (op.getWidth() <= 0)
+    return op.emitError("unsupported type");
+  return success();
 }
 
 void ConstantZOp::getAsmResultNames(
     function_ref<void(Value, StringRef)> setNameFn) {
   SmallVector<char, 32> specialNameBuffer;
   llvm::raw_svector_ostream specialName(specialNameBuffer);
-  specialName << "z_" << getType();
+  specialName << "z_i" << getWidth();
   setNameFn(getResult(), specialName.str());
+}
+
+static LogicalResult verifyConstantZOp(ConstantZOp op) {
+  // We don't allow zero width constant or unknown type.
+  if (op.getWidth() <= 0)
+    return op.emitError("unsupported type");
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -445,6 +445,16 @@ hw.module @struct_field_inout2(%a: !hw.inout<struct<b: !hw.struct<c: i1>>>) {
   sv.assign %1, %true : i1
 }
 
+// CHECK-LABEL: moodule AggregateConstantXZ
+hw.module @AggregateConstantXZ() -> (res1: !hw.struct<foo: i2, bar: !hw.array<3xi4>>,
+                                     res2: !hw.struct<foo: i2, bar: !hw.array<3xi4>>) {
+  %0 = sv.constantX : !hw.struct<foo: i2, bar: !hw.array<3xi4>>
+  %1 = sv.constantZ : !hw.struct<foo: i2, bar: !hw.array<3xi4>>
+  // CHECK: assign res1 = 14'bx
+  // CHECK: assign res2 = 14'bz
+  hw.output %0, %1 : !hw.struct<foo: i2, bar: !hw.array<3xi4>>, !hw.struct<foo: i2, bar: !hw.array<3xi4>>
+}
+
 // CHECK-LABEL: issue508
 // https://github.com/llvm/circt/issues/508
 hw.module @issue508(%in1: i1, %in2: i1) {

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -445,7 +445,7 @@ hw.module @struct_field_inout2(%a: !hw.inout<struct<b: !hw.struct<c: i1>>>) {
   sv.assign %1, %true : i1
 }
 
-// CHECK-LABEL: moodule AggregateConstantXZ
+// CHECK-LABEL: module AggregateConstantXZ(
 hw.module @AggregateConstantXZ() -> (res1: !hw.struct<foo: i2, bar: !hw.array<3xi4>>,
                                      res2: !hw.struct<foo: i2, bar: !hw.array<3xi4>>) {
   %0 = sv.constantX : !hw.struct<foo: i2, bar: !hw.array<3xi4>>

--- a/test/Dialect/SV/errors.mlir
+++ b/test/Dialect/SV/errors.mlir
@@ -203,7 +203,6 @@ hw.module @part_select1() {
 // -----
 
 hw.module @ZeroWidthConstantX() {
-
   // expected-error @+1 {{unsupported type}}
   %0 = sv.constantX : !hw.struct<>
 }

--- a/test/Dialect/SV/errors.mlir
+++ b/test/Dialect/SV/errors.mlir
@@ -199,3 +199,18 @@ hw.module @part_select1() {
   // expected-error @+1 {{slice width should not be greater than input width}}
   %c = sv.indexed_part_select %r1[%c2 : 20] : i10,i3
 }
+
+// -----
+
+hw.module @ZeroWidthConstantX() {
+
+  // expected-error @+1 {{unsupported type}}
+  %0 = sv.constantX : !hw.struct<>
+}
+
+// -----
+
+hw.module @ZeroWidthConstantZ() {
+  // expected-error @+1 {{unsupported type}}
+  %0 = sv.constantZ : !hw.struct<>
+}


### PR DESCRIPTION
This commit allows constantX/Z op to have non-integer types for the use case like https://github.com/llvm/circt/pull/2332.