### PR TITLE
[PyCDE] Add Value wrappers for comparators and ArrayConcat.

### DIFF
--- a/frontends/PyCDE/test/pycde_values.py
+++ b/frontends/PyCDE/test/pycde_values.py
@@ -1,0 +1,28 @@
+import pycde
+from pycde.dialects import comb, hw
+from pycde import dim, module, generator, Input, Output
+
+
+@module
+def MyModule(SIZE: int):
+
+  class Mod:
+    inp = Input(dim(SIZE))
+    out = Output(dim(SIZE))
+
+    @generator
+    def construct(mod):
+      c1 = hw.ConstantOp(dim(SIZE), 1)
+      eq = comb.EqOp(c1, mod.inp)
+      a1 = hw.ArrayCreateOp([eq, eq])
+      a2 = hw.ArrayCreateOp([eq, eq])
+      combined = hw.ArrayConcatOp(a1, a2)
+      mod.out = hw.BitcastOp(dim(SIZE), combined)
+
+  return Mod
+
+
+mymod = MyModule(4)
+module = pycde.System([mymod], name="mymod")
+module.generate()
+module.print()

--- a/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
@@ -418,6 +418,31 @@ class ArrayCreateOp:
     return hw.ArrayCreateOp(hw.ArrayType.get(type, len(vals)), vals)
 
 
+class ArrayConcatOp:
+
+  @staticmethod
+  def create(*args):
+    vals = []
+    types = []
+    element_type = None
+    for array in args:
+      array_value = support.get_value(array)
+      array_type = support.type_to_pytype(array_value.type)
+      if array_value is None or not isinstance(array_type, hw.ArrayType):
+        raise TypeError(f"Cannot concatenate {array_value}")
+      if element_type is None:
+        element_type = array_type.element_type
+      elif element_type != array_type.element_type:
+        raise TypeError(
+            "All arguments must be the same type to concatenate arrays")
+      vals.append(array_value)
+      types.append(array_type)
+
+    size = sum(t.size for t in types)
+    combined_type = hw.ArrayType.get(element_type, size)
+    return hw.ArrayConcatOp(combined_type, vals)
+
+
 class StructCreateOp:
 
   @staticmethod

--- a/lib/Bindings/Python/circt/dialects/comb.py
+++ b/lib/Bindings/Python/circt/dialects/comb.py
@@ -6,7 +6,7 @@ from ._comb_ops_gen import *
 
 from circt.support import NamedValueOpView
 
-from mlir.ir import IntegerAttr, IntegerType
+from mlir.ir import IntegerAttr, IntegerType, OpView
 
 
 # Sugar classes for the various possible verions of ICmpOp.
@@ -28,7 +28,7 @@ def CompareOp(predicate):
 
   def decorated(cls):
 
-    class _Class(cls):
+    class _Class(cls, OpView):
 
       @staticmethod
       def create(lhs=None, rhs=None):


### PR DESCRIPTION
The comparator subclasses didn't subclass OpView when they should
have, which prevents them from being automatically wrapped with PyCDE
Values.

The create extension for ArrayConcat was simply missing.