### PR TITLE
[LowerToHW] Check a root value to identify reg/regreset op

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -2997,7 +2997,7 @@ LogicalResult FIRRTLLowering::visitStmt(ConnectOp op) {
   if (!destVal.getType().isa<hw::InOutType>())
     return op.emitError("destination isn't an inout type");
 
-  auto definingOp = getFieldRefFromValue(dest).getValue().getDefiningOp();
+  auto* definingOp = getFieldRefFromValue(dest).getValue().getDefiningOp();
 
   // If this is an assignment to a register, then the connect implicitly
   // happens under the clock that gates the register.
@@ -3050,7 +3050,7 @@ LogicalResult FIRRTLLowering::visitStmt(PartialConnectOp op) {
   if (!destVal.getType().isa<hw::InOutType>())
     return op.emitError("destination isn't an inout type");
 
-  auto definingOp = getFieldRefFromValue(dest).getValue().getDefiningOp();
+  auto* definingOp = getFieldRefFromValue(dest).getValue().getDefiningOp();
 
   // If this is an assignment to a register, then the connect implicitly
   // happens under the clock that gates the register.

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -2997,9 +2997,11 @@ LogicalResult FIRRTLLowering::visitStmt(ConnectOp op) {
   if (!destVal.getType().isa<hw::InOutType>())
     return op.emitError("destination isn't an inout type");
 
+  auto definingOp = getFieldRefFromValue(dest).getValue().getDefiningOp();
+
   // If this is an assignment to a register, then the connect implicitly
   // happens under the clock that gates the register.
-  if (auto regOp = dyn_cast_or_null<RegOp>(dest.getDefiningOp())) {
+  if (auto regOp = dyn_cast_or_null<RegOp>(definingOp)) {
     Value clockVal = getLoweredValue(regOp.clockVal());
     if (!clockVal)
       return failure();
@@ -3011,7 +3013,7 @@ LogicalResult FIRRTLLowering::visitStmt(ConnectOp op) {
 
   // If this is an assignment to a RegReset, then the connect implicitly
   // happens under the clock and reset that gate the register.
-  if (auto regResetOp = dyn_cast_or_null<RegResetOp>(dest.getDefiningOp())) {
+  if (auto regResetOp = dyn_cast_or_null<RegResetOp>(definingOp)) {
     Value clockVal = getLoweredValue(regResetOp.clockVal());
     Value resetSignal = getLoweredValue(regResetOp.resetSignal());
     if (!clockVal || !resetSignal)
@@ -3048,9 +3050,11 @@ LogicalResult FIRRTLLowering::visitStmt(PartialConnectOp op) {
   if (!destVal.getType().isa<hw::InOutType>())
     return op.emitError("destination isn't an inout type");
 
+  auto definingOp = getFieldRefFromValue(dest).getValue().getDefiningOp();
+
   // If this is an assignment to a register, then the connect implicitly
   // happens under the clock that gates the register.
-  if (auto regOp = dyn_cast_or_null<RegOp>(dest.getDefiningOp())) {
+  if (auto regOp = dyn_cast_or_null<RegOp>(definingOp)) {
     Value clockVal = getLoweredValue(regOp.clockVal());
     if (!clockVal)
       return failure();
@@ -3062,7 +3066,7 @@ LogicalResult FIRRTLLowering::visitStmt(PartialConnectOp op) {
 
   // If this is an assignment to a RegReset, then the connect implicitly
   // happens under the clock and reset that gate the register.
-  if (auto regResetOp = dyn_cast_or_null<RegResetOp>(dest.getDefiningOp())) {
+  if (auto regResetOp = dyn_cast_or_null<RegResetOp>(definingOp)) {
     Value clockVal = getLoweredValue(regResetOp.clockVal());
     Value resetSignal = getLoweredValue(regResetOp.resetSignal());
     if (!clockVal || !resetSignal)

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -2997,7 +2997,7 @@ LogicalResult FIRRTLLowering::visitStmt(ConnectOp op) {
   if (!destVal.getType().isa<hw::InOutType>())
     return op.emitError("destination isn't an inout type");
 
-  auto* definingOp = getFieldRefFromValue(dest).getValue().getDefiningOp();
+  auto *definingOp = getFieldRefFromValue(dest).getValue().getDefiningOp();
 
   // If this is an assignment to a register, then the connect implicitly
   // happens under the clock that gates the register.
@@ -3050,7 +3050,7 @@ LogicalResult FIRRTLLowering::visitStmt(PartialConnectOp op) {
   if (!destVal.getType().isa<hw::InOutType>())
     return op.emitError("destination isn't an inout type");
 
-  auto* definingOp = getFieldRefFromValue(dest).getValue().getDefiningOp();
+  auto *definingOp = getFieldRefFromValue(dest).getValue().getDefiningOp();
 
   // If this is an assignment to a register, then the connect implicitly
   // happens under the clock that gates the register.

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1520,4 +1520,23 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT:   }
     // CHECK-NEXT: }
   }
+
+  // CHECK-LABEL: hw.module @AggregateRegAssign
+  firrtl.module @AggregateRegAssign(in %clock: !firrtl.clock, in %value: !firrtl.uint<1>) {
+    %reg = firrtl.reg %clock : !firrtl.vector<uint<1>, 1>
+    %reg_0 = firrtl.subindex %reg[0] : !firrtl.vector<uint<1>, 1>
+    firrtl.connect %reg_0, %value : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK:  %0 = sv.array_index_inout %reg[%false] : !hw.inout<array<1xi1>>, i1
+    // CHECK:  sv.passign %0, %value : i1
+  }
+
+  // CHECK-LABEL: hw.module @AggregateRegResetAssign
+  firrtl.module @AggregateRegResetAssign(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>,
+                                         in %init: !firrtl.vector<uint<1>, 1>, in %value: !firrtl.uint<1>) {
+    %reg = firrtl.regreset %clock, %reset, %init  : !firrtl.uint<1>, !firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 1>
+    %reg_0 = firrtl.subindex %reg[0] : !firrtl.vector<uint<1>, 1>
+    firrtl.connect %reg_0, %value : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK:  %0 = sv.array_index_inout %reg[%false] : !hw.inout<array<1xi1>>, i1
+    // CHECK:  sv.passign %0, %value : i1
+  }
 }


### PR DESCRIPTION
Connections to reg/regreset op should be lowered to assignments in
always statements. But when the destinations are derived by subfield
or subindex, we didn't identify them as registers. Fixed by just checking
fieldRef to get their root values.

Will close https://github.com/llvm/circt/issues/2343