### PR TITLE
[ExportVerilog] Use verilogName attr instead of Name Table

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -163,7 +163,7 @@ StringRef getPortVerilogName(Operation *module, ssize_t portArgNum) {
   // portArgNum is the index into the result of getAllModulePortInfos.
   // Also ensure the correct index into the input/output list is computed.
   ssize_t portId = portArgNum;
-  auto verilogNameAttr = "hw.verilogName";
+  char verilogNameAttr[] = "hw.verilogName";
   // Check for input ports.
   if (portArgNum < numInputs) {
     if (auto argAttr = module->getAttrOfType<ArrayAttr>(

--- a/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
+++ b/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
@@ -32,41 +32,6 @@ StringAttr getDeclarationName(Operation *op);
 struct GlobalNameTable {
   GlobalNameTable(GlobalNameTable &&) = default;
 
-  /// Return the string to use for the specified port in the specified module.
-  /// Ports may be renamed for a variety of reasons (e.g. conflicting with
-  /// Verilog keywords), and this returns the legalized name to use.
-  StringRef getPortVerilogName(Operation *module,
-                               const hw::PortInfo &port) const {
-    auto it = renamedPorts.find(std::make_pair(module, port.getId()));
-    return (it != renamedPorts.end() ? it->second : port.name).getValue();
-  }
-
-  /// Return the string to use for the specified port in the specified module.
-  /// Ports may be renamed for a variety of reasons (e.g. conflicting with
-  /// Verilog keywords), and this returns the legalized name to use.
-  StringRef getPortVerilogName(Operation *module, ssize_t portArgNum) const {
-    auto numInputs = hw::getModuleNumInputs(module);
-    // portArgNum is the index into the result of getAllModulePortInfos.
-    // We need to translate it into the PortInfo::getId(), which is a unique
-    // port identifier.
-    // if input port, then (-1 - portArgNum)
-    // else numInputs - portArgNum
-    // Also ensure the correct index into the input/output list is computed.
-    StringAttr nameAttr;
-    ssize_t portId = portArgNum;
-    if (portArgNum < numInputs) {
-      nameAttr = module->getAttrOfType<ArrayAttr>("argNames")[portArgNum]
-                     .cast<StringAttr>();
-      portId = -1 - portArgNum;
-    } else {
-      portId = portArgNum - numInputs;
-      nameAttr = module->getAttrOfType<ArrayAttr>("resultNames")[portId]
-                     .cast<StringAttr>();
-    }
-    auto it = renamedPorts.find(std::make_pair(module, portId));
-    return (it != renamedPorts.end() ? it->second : nameAttr).getValue();
-  }
-
   /// Return the string to use for the specified parameter name in the specified
   /// module.  Parameters may be renamed for a variety of reasons (e.g.
   /// conflicting with ports or Verilog keywords), and this returns the
@@ -77,38 +42,11 @@ struct GlobalNameTable {
     return (it != renamedParams.end() ? it->second : paramName).getValue();
   }
 
-  /// Return the string to use for the specified declaration. The operation is
-  /// commonly a declaration within the module, like `WireOp` and friends, which
-  /// have a `name` attribute. Values may be renamed for a variety of reasons
-  /// (e.g. conflicting with ports or Verilog keywords), and this returns the
-  /// legalized name to use.
-  StringRef getDeclarationVerilogName(Operation *op) const {
-    auto it = renamedDecls.find(op);
-    auto attr = it != renamedDecls.end() ? it->second : getDeclarationName(op);
-    return attr ? attr.getValue() : "";
-  }
-
-  /// Return the string to use for the specified interface. Interfaces and their
-  /// signals may be renamed for a variety of reasons (e.g. conflicting with
-  /// Verilog keywords), and this returns the legalized name to use.
-  StringRef getInterfaceVerilogName(Operation *op) const {
-    auto it = renamedInterfaceOp.find(op);
-    auto attr = it != renamedInterfaceOp.end() ? it->second
-                                               : SymbolTable::getSymbolName(op);
-    return attr.getValue();
-  }
-
 private:
   friend class GlobalNameResolver;
   GlobalNameTable() {}
   GlobalNameTable(const GlobalNameTable &) = delete;
   void operator=(const GlobalNameTable &) = delete;
-
-  void addRenamedPort(Operation *module, const hw::PortInfo &port,
-                      StringRef newName) {
-    renamedPorts[{module, port.getId()}] =
-        StringAttr::get(module->getContext(), newName);
-  }
 
   void addRenamedParam(Operation *module, StringAttr oldName,
                        StringRef newName) {
@@ -116,32 +54,9 @@ private:
         StringAttr::get(oldName.getContext(), newName);
   }
 
-  void addRenamedDeclaration(Operation *declOp, StringRef newName) {
-    renamedDecls[declOp] = StringAttr::get(declOp->getContext(), newName);
-  }
-
-  void addRenamedInterfaceOp(Operation *interfaceOp, StringRef newName) {
-    renamedInterfaceOp[interfaceOp] =
-        StringAttr::get(interfaceOp->getContext(), newName);
-  }
-
-  /// This contains entries for any ports that got renamed.  The key is a
-  /// moduleop/portIdx tuple, the value is the name to use.  The portIdx is the
-  /// index of the port in the list returned by getAllModulePortInfos.
-  /// Note, PortInfo::getId() returns ssize_t.
-  DenseMap<std::pair<Operation *, ssize_t>, StringAttr> renamedPorts;
-
   /// This contains entries for any parameters that got renamed.  The key is a
   /// moduleop/paramName tuple, the value is the name to use.
   DenseMap<std::pair<Operation *, Attribute>, StringAttr> renamedParams;
-
-  /// This contains entries for any declarations that got renamed.
-  DenseMap<Operation *, StringAttr> renamedDecls;
-
-  /// This contains entries for interface operations (sv.interface,
-  /// sv.interface.signal, and sv.interface.modport) that need to be renamed
-  /// due to conflicts.
-  DenseMap<Operation *, StringAttr> renamedInterfaceOp;
 };
 
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/ExportVerilog/LegalizeNames.cpp
+++ b/lib/Conversion/ExportVerilog/LegalizeNames.cpp
@@ -155,19 +155,22 @@ void GlobalNameResolver::legalizeModuleNames(HWModuleOp module) {
 
   // Legalize the value names.
   module.walk([&](Operation *op) {
-    if (auto nameAttr = getDeclarationName(op)) {
-      auto newName = nameResolver.getLegalName(nameAttr);
-      if (newName != nameAttr.getValue()) {
-        op->setAttr(verilogNameAttr, StringAttr::get(ctxt, newName));
+    if (!isa<HWModuleOp>(op))
+      if (auto nameAttr = getDeclarationName(op)) {
+        auto newName = nameResolver.getLegalName(nameAttr);
+        if (newName != nameAttr.getValue()) {
+          op->setAttr(verilogNameAttr, StringAttr::get(ctxt, newName));
+        }
       }
-    }
   });
 }
 
 void GlobalNameResolver::legalizeInterfaceNames(InterfaceOp interface) {
+  MLIRContext *ctxt = interface.getContext();
+  auto verilogNameAttr = StringAttr::get(ctxt, "hw.verilogName");
   auto newName = globalNameResolver.getLegalName(interface.getName());
   if (newName != interface.getName())
-    globalNameTable.addRenamedInterfaceOp(interface, newName);
+    interface->setAttr(verilogNameAttr, StringAttr::get(ctxt, newName));
 
   NameCollisionResolver localNames;
   // Rename signals and modports.
@@ -176,7 +179,7 @@ void GlobalNameResolver::legalizeInterfaceNames(InterfaceOp interface) {
       auto name = SymbolTable::getSymbolName(&op).getValue();
       auto newName = localNames.getLegalName(name);
       if (newName != name)
-        globalNameTable.addRenamedInterfaceOp(&op, newName);
+        op.setAttr(verilogNameAttr, StringAttr::get(ctxt, newName));
     }
   }
 }

--- a/lib/Conversion/ExportVerilog/LegalizeNames.cpp
+++ b/lib/Conversion/ExportVerilog/LegalizeNames.cpp
@@ -135,7 +135,6 @@ void GlobalNameResolver::legalizeModuleNames(HWModuleOp module) {
   for (const PortInfo &port : getAllModulePortInfos(module)) {
     auto newName = nameResolver.getLegalName(port.name);
     if (newName != port.name.getValue()) {
-      globalNameTable.addRenamedPort(module, port, newName);
       if (port.isOutput())
         module.setResultAttr(port.argNum, verilogNameAttr,
                              StringAttr::get(ctxt, newName));
@@ -159,7 +158,6 @@ void GlobalNameResolver::legalizeModuleNames(HWModuleOp module) {
     if (auto nameAttr = getDeclarationName(op)) {
       auto newName = nameResolver.getLegalName(nameAttr);
       if (newName != nameAttr.getValue()) {
-        globalNameTable.addRenamedDeclaration(op, newName);
         op->setAttr(verilogNameAttr, StringAttr::get(ctxt, newName));
       }
     }


### PR DESCRIPTION
Replace the use of global names table with the name attribute on the operation.
LegalizeNames is setting the attribute `hw.verilogName`, with the updated names.
This change will move the process to query the name of an operation to looking up the attribute on the operation, 
instead of maintaining the global map.
The global names for parameter and interface map are still being used. They also need to be ported to a similar
mechanism next.
This change can potentially improve some memory and a minor runtime performance. 