### PR TITLE
[FIRRTL] Fix OMIR port widths not being hex values

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -548,7 +548,8 @@ void EmitOMIRPass::emitOptionalRTLPorts(DictionaryAttr node,
 
           // Emit the `width` field.
           buf.assign("OMBigInt:");
-          Twine(port.value().type.getBitWidthOrSentinel()).toVector(buf);
+          Twine::utohexstr(port.value().type.getBitWidthOrSentinel())
+              .toVector(buf);
           jsonStream.attribute("width", buf);
         });
       }

--- a/test/Dialect/FIRRTL/SFCTests/emit-omir.fir
+++ b/test/Dialect/FIRRTL/SFCTests/emit-omir.fir
@@ -65,9 +65,9 @@ circuit Foo : %[[
   extmodule MySRAM:
     defname = MySRAM
   module Foo :
-    input unsigned : UInt<17>
+    input unsigned : UInt<29>
     input zeroW : UInt<0>
-    output signed : UInt<19>
+    output signed : UInt<31>
     inst parameter of Bar
     signed <= unsigned
   module Bar :
@@ -135,11 +135,11 @@ circuit Foo : %[[
 ; CHECK-NEXT:    {
 ; CHECK-NEXT:      "ref": "OMDontTouchedReferenceTarget:~Foo|Foo>unsigned_0",
 ; CHECK-NEXT:      "direction": "OMString:Input",
-; CHECK-NEXT:      "width": "OMBigInt:17"
+; CHECK-NEXT:      "width": "OMBigInt:1d"
 ; CHECK-NEXT:    }
 ; CHECK-NEXT:    {
 ; CHECK-NEXT:      "ref": "OMDontTouchedReferenceTarget:~Foo|Foo>signed_1",
 ; CHECK-NEXT:      "direction": "OMString:Output",
-; CHECK-NEXT:      "width": "OMBigInt:19"
+; CHECK-NEXT:      "width": "OMBigInt:1f"
 ; CHECK-NEXT:    }
 ; CHECK-NEXT:  ]

--- a/test/Dialect/FIRRTL/emit-omir.mlir
+++ b/test/Dialect/FIRRTL/emit-omir.mlir
@@ -374,15 +374,15 @@ firrtl.circuit "AddPorts" attributes {annotations = [{
     }
   ]
 }]} {
-  firrtl.module @AddPorts(in %x: !firrtl.uint<17>, out %y: !firrtl.uint<19>) attributes {annotations = [{class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 0}]} {
-    %w = firrtl.wire {annotations = [{class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 1}]} : !firrtl.uint<17>
-    firrtl.connect %y, %x : !firrtl.uint<19>, !firrtl.uint<17>
+  firrtl.module @AddPorts(in %x: !firrtl.uint<29>, out %y: !firrtl.uint<31>) attributes {annotations = [{class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 0}]} {
+    %w = firrtl.wire {annotations = [{class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 1}]} : !firrtl.uint<29>
+    firrtl.connect %y, %x : !firrtl.uint<31>, !firrtl.uint<29>
   }
 }
 // CHECK-LABEL: firrtl.circuit "AddPorts"
 // CHECK:       firrtl.module @AddPorts
-// CHECK-SAME:    in %x: !firrtl.uint<17> sym [[SYMX:@[a-zA-Z0-9_]+]]
-// CHECK-SAME:    out %y: !firrtl.uint<19> sym [[SYMY:@[a-zA-Z0-9_]+]]
+// CHECK-SAME:    in %x: !firrtl.uint<29> sym [[SYMX:@[a-zA-Z0-9_]+]]
+// CHECK-SAME:    out %y: !firrtl.uint<31> sym [[SYMY:@[a-zA-Z0-9_]+]]
 // CHECK:       %w = firrtl.wire sym [[SYMW:@[a-zA-Z0-9_]+]]
 // CHECK:       sv.verbatim
 
@@ -394,12 +394,12 @@ firrtl.circuit "AddPorts" attributes {annotations = [{
 // CHECK-SAME:      {
 // CHECK-SAME:        \22ref\22: \22OMDontTouchedReferenceTarget:~AddPorts|{{[{][{]0[}][}]}}>{{[{][{]1[}][}]}}\22
 // CHECK-SAME:        \22direction\22: \22OMString:Input\22
-// CHECK-SAME:        \22width\22: \22OMBigInt:17\22
+// CHECK-SAME:        \22width\22: \22OMBigInt:1d\22
 // CHECK-SAME:      }
 // CHECK-SAME:      {
 // CHECK-SAME:        \22ref\22: \22OMDontTouchedReferenceTarget:~AddPorts|{{[{][{]0[}][}]}}>{{[{][{]2[}][}]}}\22
 // CHECK-SAME:        \22direction\22: \22OMString:Output\22
-// CHECK-SAME:        \22width\22: \22OMBigInt:19\22
+// CHECK-SAME:        \22width\22: \22OMBigInt:1f\22
 // CHECK-SAME:      }
 // CHECK-SAME:    ]
 
@@ -411,12 +411,12 @@ firrtl.circuit "AddPorts" attributes {annotations = [{
 // CHECK-SAME:      {
 // CHECK-SAME:        \22ref\22: \22OMDontTouchedReferenceTarget:~AddPorts|{{[{][{]0[}][}]}}>{{[{][{]1[}][}]}}\22
 // CHECK-SAME:        \22direction\22: \22OMString:Input\22
-// CHECK-SAME:        \22width\22: \22OMBigInt:17\22
+// CHECK-SAME:        \22width\22: \22OMBigInt:1d\22
 // CHECK-SAME:      }
 // CHECK-SAME:      {
 // CHECK-SAME:        \22ref\22: \22OMDontTouchedReferenceTarget:~AddPorts|{{[{][{]0[}][}]}}>{{[{][{]2[}][}]}}\22
 // CHECK-SAME:        \22direction\22: \22OMString:Output\22
-// CHECK-SAME:        \22width\22: \22OMBigInt:19\22
+// CHECK-SAME:        \22width\22: \22OMBigInt:1f\22
 // CHECK-SAME:      }
 // CHECK-SAME:    ]
 


### PR DESCRIPTION
Fix an issue in the `EmitOMIR` pass, where the addition of port information would introduce additional `OMBigInt` values which were not properly formatted as hexadecimal values, but just as decimal ones. This updates the emission to make them hexadecimal as expected by other parts of the FIRRTL ecosystem.