### PR TITLE
[Comb] Don't canonicalize muxs to array-selects when the index is large

### DIFF
--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -1814,9 +1814,9 @@ static bool foldMuxChain(MuxOp rootMux, bool isFalseSide,
     return false;
 
   // If the array is greater that 9 bits, it will take over 512 elements and
-  // it is too large for a regular expression.
+  // it will be too large for a single expression.
   auto indexWidth = indexValue.getType().cast<IntegerType>().getWidth();
-  if (9 <= indexWidth)
+  if (indexWidth <= 9)
     return false;
 
   // Next we need to see if the values are dense-ish.  We don't want to have

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -1816,7 +1816,7 @@ static bool foldMuxChain(MuxOp rootMux, bool isFalseSide,
   // If the array is greater that 9 bits, it will take over 512 elements and
   // it will be too large for a single expression.
   auto indexWidth = indexValue.getType().cast<IntegerType>().getWidth();
-  if (indexWidth <= 9)
+  if (indexWidth >= 9)
     return false;
 
   // Next we need to see if the values are dense-ish.  We don't want to have

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -1813,11 +1813,16 @@ static bool foldMuxChain(MuxOp rootMux, bool isFalseSide,
   if (valuesFound.size() < 3)
     return false;
 
+  // If the array is greater that 9 bits, it will take over 512 elements and
+  // it is too large for a regular expression.
+  auto indexWidth = indexValue.getType().cast<IntegerType>().getWidth();
+  if (9 <= indexWidth)
+    return false;
+
   // Next we need to see if the values are dense-ish.  We don't want to have
   // a tremendous number of replicated entries in the array.  Some sparsity is
   // ok though, so we require the table to be at least 5/8 utilized.
-  uint64_t tableSize = 1ULL
-                       << indexValue.getType().cast<IntegerType>().getWidth();
+  uint64_t tableSize = 1ULL << indexWidth;
   if (valuesFound.size() < (tableSize * 5) / 8)
     return false; // Not dense enough.
 

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -886,6 +886,27 @@ hw.module @dont_fold_mux_tree1(%sel: i7, %a: i8, %b: i8, %c: i8, %d: i8) -> (y: 
   hw.output %5 : i8
 }
 
+// CHECK-LABEL: hw.module @dont_fold_mux_tree2
+// This shouldn't be turned into a mux tree because its too large.
+hw.module @dont_fold_mux_tree2(%sel: i64) -> (o: i3) {
+  // CHECK-NOT: array_create
+  // CHECK: hw.output
+  %c-3_i3 = hw.constant -3 : i3
+  %c-4_i3 = hw.constant -4 : i3
+  %c3_i3 = hw.constant 3 : i3
+  %c0_i3 = hw.constant 0 : i3
+  %c14_i64 = hw.constant 14 : i64
+  %0 = comb.icmp eq %sel, %c14_i64 : i64
+  %1 = comb.mux %0, %c3_i3, %c0_i3 : i3
+  %c15_i64 = hw.constant 15 : i64
+  %2 = comb.icmp eq %sel, %c15_i64 : i64
+  %3 = comb.mux %2, %c-4_i3, %1 : i3
+  %c13_i64 = hw.constant 13 : i64
+  %4 = comb.icmp eq %sel, %c13_i64 : i64
+  %5 = comb.mux %4, %c-3_i3, %3 : i3
+  hw.output %5: i3
+}
+
 // Issue 675: https://github.com/llvm/circt/issues/675
 // CHECK-LABEL: hw.module @SevenSegmentDecoder
 hw.module @SevenSegmentDecoder(%in: i4) -> (out: i7) {


### PR DESCRIPTION
When checking if we can fold a series of `mux`es into an array+select,
this limits the number of array elements to 512.  This is fixing an
overflow when the bitwidth was 64, causing us to try to store a
`1<<bitwidth` in a `uint64_t`, while also trying to pose a sensible
limit.  The limit was chosen arbitrarily.