### PR TITLE
[FIRRTL] Fix use-after-free of ops erased during assert parsing

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1406,6 +1406,16 @@ struct LazyLocationListener : public OpBuilder::Listener {
         opAndSMLoc.first->setLoc(parser.translateLocation(opAndSMLoc.second));
     }
 
+    // Destroy any subOps that have been previously `remove`d. Some parts of the
+    // parser may create operations that are immediately removed by a subsequent
+    // folding/restructuring function (e.g. `foldWhenEncodedVerifOp`). Those
+    // pieces of code use `remove` to remove the operations from the parent
+    // block without already destroying them, allowing this `endStatement` call
+    // to properly process them and then do the necessary cleanup.
+    for (auto opAndSMLoc : subOps)
+      if (!opAndSMLoc.first->getBlock())
+        opAndSMLoc.first->destroy();
+
     // Reset our state.
     isActive = false;
     infoLoc = LocationAttr();

--- a/lib/Dialect/FIRRTL/Import/FIRParserAsserts.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParserAsserts.cpp
@@ -27,7 +27,7 @@ namespace {
 template <typename JsonType>
 struct ExtractionSummaryCursor {
   Location loc;
-  const Twine &path;
+  Twine path;
   JsonType value;
 
   ExtractionSummaryCursor(const ExtractionSummaryCursor &) = delete;


### PR DESCRIPTION
Fix an issue where the `foldWhenEncodedVerifOp` function would erase operations while the `LazyLocationListener` of the parser still has a pointer to them. This causes `endStatement` to try and assign locations to those operations, which for the erased operations is a use after free. This adjusts the `foldWhenEncodedVerifOp` function to only remove the operation but not immediately destroy it. This allows the listener to do its updates and properly clean up the removed operations once it's done.

Fixes #2355.