### PR TITLE
[reduce] Add `ConnectSourceOperandForwarder` reduction

### DIFF
--- a/test/circt-reduce/connect-source-operand-forward.mlir
+++ b/test/circt-reduce/connect-source-operand-forward.mlir
@@ -1,0 +1,20 @@
+// RUN: circt-reduce %s --test %S/test.sh --test-arg cat --test-arg "firrtl.module @Foo" --keep-best=0 --include connect-source-operand-0-forwarder | FileCheck %s
+firrtl.circuit "Foo" {
+  // CHECK-LABEL: firrtl.module @Foo
+  firrtl.module @Foo(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %val: !firrtl.uint<2>) {
+    %a = firrtl.wire : !firrtl.uint<1>
+    %b = firrtl.reg %clock : !firrtl.uint<1>
+    %c = firrtl.regreset %clock, %reset, %reset : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %0 = firrtl.bits %val 0 to 0 : (!firrtl.uint<2>) -> !firrtl.uint<1>
+    firrtl.connect %a, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %b, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %c, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK-NEXT:   %0 = firrtl.wire  : !firrtl.uint<2>
+    // CHECK-NEXT:   %1 = firrtl.reg %clock  : !firrtl.uint<2>
+    // CHECK-NEXT:   %2 = firrtl.reg %clock  : !firrtl.uint<2>
+    // CHECK-NEXT:   firrtl.connect %0, %val : !firrtl.uint<2>, !firrtl.uint<2>
+    // CHECK-NEXT:   firrtl.connect %1, %val : !firrtl.uint<2>, !firrtl.uint<2>
+    // CHECK-NEXT:   firrtl.connect %2, %val : !firrtl.uint<2>, !firrtl.uint<2>
+    // CHECK-NEXT: }
+  }
+}

--- a/tools/circt-reduce/Reduction.cpp
+++ b/tools/circt-reduce/Reduction.cpp
@@ -622,7 +622,7 @@ struct ExtmoduleInstanceRemover : public Reduction {
 };
 
 /// A sample reduction pattern that replaces a single-use wire and register with
-/// with an operand of the source value of the connection.
+/// an operand of the source value of the connection.
 template <unsigned OpNum>
 struct ConnectSourceOperandForwarder : public Reduction {
   bool match(Operation *op) override {

--- a/tools/circt-reduce/Reduction.cpp
+++ b/tools/circt-reduce/Reduction.cpp
@@ -630,14 +630,14 @@ struct ConnectSourceOperandForwarder : public Reduction {
     if (!connect)
       return false;
     auto dest = connect.dest();
-    auto destOp = connect.dest().getDefiningOp();
+    auto *destOp = dest.getDefiningOp();
 
     // Ensure that the destination is used only once.
     if (!destOp || !destOp->hasOneUse() ||
         !isa<firrtl::WireOp, firrtl::RegOp, firrtl::RegResetOp>(destOp))
       return false;
 
-    auto srcOp = connect.src().getDefiningOp();
+    auto *srcOp = connect.src().getDefiningOp();
     if (!srcOp || OpNum >= srcOp->getNumOperands())
       return false;
 
@@ -654,8 +654,8 @@ struct ConnectSourceOperandForwarder : public Reduction {
 
   LogicalResult rewrite(Operation *op) override {
     auto connect = cast<firrtl::ConnectOp>(op);
-    auto destOp = connect.dest().getDefiningOp();
-    auto srcOp = connect.src().getDefiningOp();
+    auto *destOp = connect.dest().getDefiningOp();
+    auto *srcOp = connect.src().getDefiningOp();
     auto forwardedOperand = srcOp->getOperand(OpNum);
     ImplicitLocOpBuilder builder(destOp->getLoc(), destOp);
     Value newDest;

--- a/tools/circt-reduce/Reduction.cpp
+++ b/tools/circt-reduce/Reduction.cpp
@@ -621,6 +621,71 @@ struct ExtmoduleInstanceRemover : public Reduction {
   SymbolCache symbols;
 };
 
+/// A sample reduction pattern that replaces a single-use wire and register with
+/// with an operand of the source value of the connection.
+template <unsigned OpNum>
+struct ConnectSourceOperandForwarder : public Reduction {
+  bool match(Operation *op) override {
+    auto connect = dyn_cast<firrtl::ConnectOp>(op);
+    if (!connect)
+      return false;
+    auto dest = connect.dest();
+    auto destOp = connect.dest().getDefiningOp();
+
+    // Ensure that the destination is used only once.
+    if (!destOp || !destOp->hasOneUse() ||
+        !isa<firrtl::WireOp, firrtl::RegOp, firrtl::RegResetOp>(destOp))
+      return false;
+
+    auto srcOp = connect.src().getDefiningOp();
+    if (!srcOp || OpNum >= srcOp->getNumOperands())
+      return false;
+
+    auto resultTy = dest.getType().dyn_cast<firrtl::FIRRTLType>();
+    auto opTy =
+        srcOp->getOperand(OpNum).getType().dyn_cast<firrtl::FIRRTLType>();
+
+    return resultTy && opTy &&
+           resultTy.getWidthlessType() == opTy.getWidthlessType() &&
+           ((resultTy.getBitWidthOrSentinel() == -1) ==
+            (opTy.getBitWidthOrSentinel() == -1)) &&
+           resultTy.isa<firrtl::UIntType, firrtl::SIntType>();
+  }
+
+  LogicalResult rewrite(Operation *op) override {
+    auto connect = cast<firrtl::ConnectOp>(op);
+    auto destOp = connect.dest().getDefiningOp();
+    auto srcOp = connect.src().getDefiningOp();
+    auto forwardedOperand = srcOp->getOperand(OpNum);
+    ImplicitLocOpBuilder builder(destOp->getLoc(), destOp);
+    Value newDest;
+    if (isa<firrtl::WireOp>(destOp))
+      newDest = builder.create<firrtl::WireOp>(forwardedOperand.getType());
+    else {
+      // We can promote the register into a wire but we wouldn't do here because
+      // the error might be caused by the register.
+      auto clock = destOp->getOperand(0);
+      newDest =
+          builder.create<firrtl::RegOp>(forwardedOperand.getType(), clock);
+    }
+
+    // Create new connection between a new wire and the forwarded operand.
+    builder.setInsertionPointAfter(op);
+    builder.create<firrtl::ConnectOp>(newDest, forwardedOperand);
+
+    // Remove the old connection and destination. We don't have to replace them
+    // because destination has only one use.
+    op->erase();
+    destOp->erase();
+    pruneUnusedOps(srcOp);
+
+    return success();
+  }
+  std::string getName() const override {
+    return ("connect-source-operand-" + Twine(OpNum) + "-forwarder").str();
+  }
+};
+
 //===----------------------------------------------------------------------===//
 // Reduction Registration
 //===----------------------------------------------------------------------===//
@@ -666,4 +731,7 @@ void circt::createAllReductions(
   add(std::make_unique<AnnotationRemover>());
   add(std::make_unique<RootPortPruner>());
   add(std::make_unique<ExtmoduleInstanceRemover>());
+  add(std::make_unique<ConnectSourceOperandForwarder<0>>());
+  add(std::make_unique<ConnectSourceOperandForwarder<1>>());
+  add(std::make_unique<ConnectSourceOperandForwarder<2>>());
 }


### PR DESCRIPTION
This commit adds a new reducion called `ConnectSourceOperandForwarder`.
If a wire is used only once as a destination of a connect, we can
forward the wire to one of operands of the source value. `OperandForwarder`
can't reduce this because of the wire connection.

For example, consider the following IR.
```mlir
%a = firrtl.wire : !firrtl.uint<1>
%src0 = firrtl.wire : !firrtl.uint<2>
%src1 = firrtl.bits %src0 0 to 0 : (!firrtl.uint<2>) -> !firrtl.uint<1>
firrtl.connect %a, %src1
```
ConnectSourceOperandForwarder reduces the IR above into
```mlir
%a = firrtl.wire : !firrtl.uint<2>
%src0 = firrtl.wire : !firrtl.uint<2>
firrtl.connect %a, %src0
```

This reduction is potentially useful for cleaning up chains of bits/pad
op inserted by the reducer.