### PR TITLE
[NFC] Fix a build warning

### DIFF
--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -370,7 +370,7 @@ private:
     Operation *parent = body->getParentOp();
     assert(isa<ControlOp>(parent) ||
            (parent->hasTrait<ControlLike>() &&
-               "This should only be used to emit Calyx Control structures."));
+            "This should only be used to emit Calyx Control structures."));
 
     // Check to see if this is a stand-alone EnableOp, i.e.
     // calyx.control { calyx.enable @G }

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -369,8 +369,8 @@ private:
   void emitCalyxControl(Block *body) {
     Operation *parent = body->getParentOp();
     assert(isa<ControlOp>(parent) ||
-           parent->hasTrait<ControlLike>() &&
-               "This should only be used to emit Calyx Control structures.");
+           (parent->hasTrait<ControlLike>() &&
+               "This should only be used to emit Calyx Control structures."));
 
     // Check to see if this is a stand-alone EnableOp, i.e.
     // calyx.control { calyx.enable @G }

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -368,9 +368,8 @@ private:
   /// Recursively emits the Calyx control.
   void emitCalyxControl(Block *body) {
     Operation *parent = body->getParentOp();
-    assert((isa<ControlOp>(parent) ||
-           parent->hasTrait<ControlLike>()) &&
-            "This should only be used to emit Calyx Control structures.");
+    assert((isa<ControlOp>(parent) || parent->hasTrait<ControlLike>()) &&
+           "This should only be used to emit Calyx Control structures.");
 
     // Check to see if this is a stand-alone EnableOp, i.e.
     // calyx.control { calyx.enable @G }

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -368,9 +368,9 @@ private:
   /// Recursively emits the Calyx control.
   void emitCalyxControl(Block *body) {
     Operation *parent = body->getParentOp();
-    assert(isa<ControlOp>(parent) ||
-           (parent->hasTrait<ControlLike>() &&
-            "This should only be used to emit Calyx Control structures."));
+    assert((isa<ControlOp>(parent) ||
+           parent->hasTrait<ControlLike>()) &&
+            "This should only be used to emit Calyx Control structures.");
 
     // Check to see if this is a stand-alone EnableOp, i.e.
     // calyx.control { calyx.enable @G }


### PR DESCRIPTION
During the build of CIRCT with GCC 11, I was getting two warnings. It will fix one of them:
```
[172/353] Building CXX object lib/Dialect/Calyx/Export/CMakeFiles/obj.CIRCTExportCalyx.dir/CalyxEmitter.cpp.o
/home/xgupta/llvm/circt/lib/Dialect/Calyx/Export/CalyxEmitter.cpp:372:44: warning: suggest parentheses around '&&' within '||' [-Wparentheses]
   372 |            parent->hasTrait<ControlLike>() &&
       |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
   373 |                "This should only be used to emit Calyx Control structures.");
       |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```