### PR TITLE
[SVExtractCode] Add missing assert operations

### DIFF
--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -335,15 +335,19 @@ void SVExtractTestCodeImplPass::runOnOperation() {
         if (mod->getAttr("firrtl.extract.assert.extra"))
           return true;
 
-    // Error with a message which starts with "assert:" or "Assertion failed" is
-    // considered as an assert.
+    // If the format of assert is "ifElseFatal", PrintOp is lowered into
+    // ErrorOp. So we have to check message contents whether they encode
+    // verifications. See FIRParserAsserts for more details.
     if (auto error = dyn_cast<ErrorOp>(op)) {
       if (auto message = error.message())
         return message.getValue().startswith("assert:") ||
-               message.getValue().startswith("Assertion failed");
+               message.getValue().startswith("Assertion failed") ||
+               message.getValue().startswith("assertNotX:") ||
+               message.getValue().contains("[verif-library-assert]");
       return false;
     }
-    return isa<AssertOp>(op) || isa<FinishOp>(op) ||
+
+    return isa<AssertOp>(op) || isa<FinishOp>(op) || isa<FWriteOp>(op) ||
            isa<AssertConcurrentOp>(op) || isa<FatalOp>(op);
   };
   auto isAssume = [&symCache](Operation *op) -> bool {

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -344,12 +344,6 @@ void SVExtractTestCodeImplPass::runOnOperation() {
       return false;
     }
 
-    // FWrite with a message which starts with "assert:" or "Assertion failed"
-    // is considered as assert.
-    if (auto fwrite = dyn_cast<FWriteOp>(op))
-      return fwrite.string().startswith("assert:") ||
-             fwrite.string().startswith("Assertion failed");
-
     return isa<AssertOp>(op) || isa<FinishOp>(op) ||
            isa<AssertConcurrentOp>(op) || isa<FatalOp>(op);
   };
@@ -360,11 +354,6 @@ void SVExtractTestCodeImplPass::runOnOperation() {
         if (mod->getAttr("firrtl.extract.assume.extra"))
           return true;
 
-    // FWrite with a message which starts with "assume:" is considered as
-    // assume.
-    if (auto fwrite = dyn_cast<FWriteOp>(op))
-      return fwrite.string().startswith("assume:");
-
     return isa<AssumeOp>(op) || isa<AssumeConcurrentOp>(op);
   };
   auto isCover = [&symCache](Operation *op) -> bool {
@@ -372,10 +361,6 @@ void SVExtractTestCodeImplPass::runOnOperation() {
       if (auto mod = symCache.getDefinition(inst.moduleNameAttr()))
         if (mod->getAttr("firrtl.extract.cover.extra"))
           return true;
-
-    // FWrite with a message which starts with "cover:" is considered as cover.
-    if (auto fwrite = dyn_cast<FWriteOp>(op))
-      return fwrite.string().startswith("cover:");
 
     return isa<CoverOp>(op) || isa<CoverConcurrentOp>(op);
   };

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -343,17 +343,14 @@ void SVExtractTestCodeImplPass::runOnOperation() {
                message.getValue().startswith("Assertion failed");
       return false;
     }
-
     return isa<AssertOp>(op) || isa<FinishOp>(op) ||
            isa<AssertConcurrentOp>(op) || isa<FatalOp>(op);
   };
-
   auto isAssume = [&symCache](Operation *op) -> bool {
     if (auto inst = dyn_cast<hw::InstanceOp>(op))
       if (auto mod = symCache.getDefinition(inst.moduleNameAttr()))
         if (mod->getAttr("firrtl.extract.assume.extra"))
           return true;
-
     return isa<AssumeOp>(op) || isa<AssumeConcurrentOp>(op);
   };
   auto isCover = [&symCache](Operation *op) -> bool {
@@ -361,7 +358,6 @@ void SVExtractTestCodeImplPass::runOnOperation() {
       if (auto mod = symCache.getDefinition(inst.moduleNameAttr()))
         if (mod->getAttr("firrtl.extract.cover.extra"))
           return true;
-
     return isa<CoverOp>(op) || isa<CoverConcurrentOp>(op);
   };
 

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -8,14 +8,21 @@
 // CHECK-NOT: attributes
 // CHECK: hw.module @issue1246_assert(%clock: i1) attributes {output_file = #hw.output_file<"dir3/", excludeFromFileList, includeReplicatedOps>}
 // CHECK: sv.assert
+// CHECK: sv.error "Assertion failed"
+// CHECK: sv.error "assert:"
+// CHECK: sv.fwrite "assert:"
+// CHECK: sv.fwrite "Assertion failed:"
+// CHECK: sv.fatal 1
 // CHECK: foo_assert
 // CHECK: hw.module @issue1246_assume(%clock: i1) 
 // CHECK-NOT: attributes 
 // CHECK: sv.assume
+// CHECK: sv.fwrite "assume:"
 // CHECK: foo_assume
 // CHECK: hw.module @issue1246_cover(%clock: i1) 
 // CHECK-NOT: attributes 
 // CHECK: sv.cover
+// CHECK: sv.fwrite "cover:"
 // CHECK: foo_cover
 // CHECK: hw.module @issue1246
 // CHECK-NOT: sv.assert
@@ -37,8 +44,15 @@ module attributes {firrtl.extract.assert =  #hw.output_file<"dir3/", excludeFrom
       } else  {
         sv.if %2937  {
           sv.assert %clock, immediate
+          sv.error "Assertion failed"
+          sv.error "assert:"
+          sv.fwrite "assert:"
+          sv.fwrite "Assertion failed:"
+          sv.fatal 1
           sv.assume %clock, immediate
+          sv.fwrite "assume:"
           sv.cover %clock, immediate
+          sv.fwrite "cover:"
         }
       }
     }

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -10,19 +10,15 @@
 // CHECK: sv.assert
 // CHECK: sv.error "Assertion failed"
 // CHECK: sv.error "assert:"
-// CHECK: sv.fwrite "assert:"
-// CHECK: sv.fwrite "Assertion failed:"
 // CHECK: sv.fatal 1
 // CHECK: foo_assert
 // CHECK: hw.module @issue1246_assume(%clock: i1) 
 // CHECK-NOT: attributes 
 // CHECK: sv.assume
-// CHECK: sv.fwrite "assume:"
 // CHECK: foo_assume
 // CHECK: hw.module @issue1246_cover(%clock: i1) 
 // CHECK-NOT: attributes 
 // CHECK: sv.cover
-// CHECK: sv.fwrite "cover:"
 // CHECK: foo_cover
 // CHECK: hw.module @issue1246
 // CHECK-NOT: sv.assert
@@ -46,13 +42,9 @@ module attributes {firrtl.extract.assert =  #hw.output_file<"dir3/", excludeFrom
           sv.assert %clock, immediate
           sv.error "Assertion failed"
           sv.error "assert:"
-          sv.fwrite "assert:"
-          sv.fwrite "Assertion failed:"
           sv.fatal 1
           sv.assume %clock, immediate
-          sv.fwrite "assume:"
           sv.cover %clock, immediate
-          sv.fwrite "cover:"
         }
       }
     }

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -10,6 +10,8 @@
 // CHECK: sv.assert
 // CHECK: sv.error "Assertion failed"
 // CHECK: sv.error "assert:"
+// CHECK: sv.error "assertNotX:"
+// CHECK: sv.error "check [verif-library-assert] is included"
 // CHECK: sv.fatal 1
 // CHECK: foo_assert
 // CHECK: hw.module @issue1246_assume(%clock: i1) 
@@ -42,6 +44,8 @@ module attributes {firrtl.extract.assert =  #hw.output_file<"dir3/", excludeFrom
           sv.assert %clock, immediate
           sv.error "Assertion failed"
           sv.error "assert:"
+          sv.error "assertNotX:"
+          sv.error "check [verif-library-assert] is included"
           sv.fatal 1
           sv.assume %clock, immediate
           sv.cover %clock, immediate


### PR DESCRIPTION
SFC regards printf operations whose messages have specific prefixs
like "assert:", "assume:" or "cover" as assert/assume/cover
operations. This commits makes MFC align with that behavior. More
specifically,

* sv.fatal => assert
* sv.error/~~sv.fwrite~~ starts with "assert:" or "Asserion failed" => assert
* ~~sv.fwrite starts with "assume:" => assume~~
* ~~sv.fwrite starts with "cover:" => cover~~

