### PR TITLE
[LowerToHW] Fix reg init via verbatim ops

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -2163,55 +2163,112 @@ void FIRRTLLowering::emitRandomizePrologIfNeeded() {
 }
 
 void FIRRTLLowering::initializeRegister(Value reg) {
+  typedef std::pair<Attribute, std::pair<unsigned, unsigned>> SymbolAndRange;
+
+  // The point in the design where we should add randomization register
+  // definitions.  This is at the top of the "`ifndef SYNTHESIS" block.
+  mlir::OpBuilder::InsertPoint regInsertionPoint;
+
+  auto regDef = cast<sv::RegOp>(reg.getDefiningOp());
+  if (!regDef->hasAttrOfType<StringAttr>("inner_sym"))
+    regDef->setAttr("inner_sym", builder.getStringAttr(moduleNamespace.newName(
+                                     Twine("__") + regDef.name() + "__")));
+  auto regDefSym =
+      hw::InnerRefAttr::get(theModule.getNameAttr(), regDef.inner_symAttr());
+
   // Construct and return a new reference to `RANDOM.  It is always a 32-bit
   // unsigned expression.  Calls to $random have side effects, so we use
   // VerbatimExprSEOp.
   constexpr unsigned randomWidth = 32;
-  auto getRandom32Val = [&]() -> Value {
-    return builder.create<sv::VerbatimExprSEOp>(
-        builder.getIntegerType(randomWidth), "`RANDOM");
+  auto getRandom32Val = [&](Twine suffix = "") -> Value {
+    sv::RegOp randReg;
+    {
+      OpBuilder::InsertionGuard topBuilder(builder);
+      builder.restoreInsertionPoint(regInsertionPoint);
+      randReg = builder.create<sv::RegOp>(
+          reg.getLoc(), builder.getIntegerType(randomWidth),
+          /*name=*/builder.getStringAttr("_RANDOM"),
+          /*inner_sym=*/
+          builder.getStringAttr(moduleNamespace.newName(Twine("_RANDOM"))));
+    }
+
+    builder.create<sv::VerbatimOp>(
+        builder.getStringAttr(Twine("{{0}} = `RANDOM;")), ValueRange{},
+        builder.getArrayAttr({hw::InnerRefAttr::get(theModule.getNameAttr(),
+                                                    randReg.inner_symAttr())}));
+
+    return randReg.getResult();
   };
 
-  // Return an expression containing random bits of the specified width.
-  // An explicit std::function is required here due to recursion.
-  std::function<Value(IntegerType)> getRandomValue =
-      [&](IntegerType type) -> Value {
-    assert(type.getWidth() != 0 && "zero bit width's not supported");
-    auto &randomValueAndRemain = blockRandomValueAndRemain[builder.getBlock()];
-    if (randomValueAndRemain.second >= type.getWidth()) {
-      auto value = builder.createOrFold<comb::ExtractOp>(
-          type, randomValueAndRemain.first,
-          randomWidth - randomValueAndRemain.second);
+  auto getRandomValues = [&](IntegerType type,
+                             SmallVector<SymbolAndRange> &values) {
+    auto width = type.getWidth();
+    assert(width != 0 && "zero bit width's not supported");
+    while (width > 0) {
+      auto &randomValueAndRemain =
+          blockRandomValueAndRemain[builder.getBlock()];
 
-      randomValueAndRemain.second -= type.getWidth();
-      return value;
+      // If there are no bits left, then generate a new random value.
+      if (!randomValueAndRemain.second)
+        randomValueAndRemain = {getRandom32Val("foo"), randomWidth};
+
+      auto reg = cast<sv::RegOp>(randomValueAndRemain.first.getDefiningOp());
+
+      auto symbol =
+          hw::InnerRefAttr::get(theModule.getNameAttr(), reg.inner_symAttr());
+      unsigned low = randomWidth - randomValueAndRemain.second;
+      unsigned high = randomWidth - 1;
+      if (width <= randomValueAndRemain.second)
+        high = width - 1 + low;
+      unsigned consumed = high - low + 1;
+      values.push_back({symbol, {high, low}});
+      randomValueAndRemain.second -= consumed;
+      width -= consumed;
     }
-
-    // If nothing remains, produce new 32 bit random value and call it
-    // recursively.
-    if (randomValueAndRemain.second == 0) {
-      randomValueAndRemain = {getRandom32Val(), randomWidth};
-      return getRandomValue(type);
-    }
-
-    // Consume all the bits we have now, and then concat the rest.
-    auto currentWidth = builder.getIntegerType(randomValueAndRemain.second);
-    auto value = builder.createOrFold<comb::ExtractOp>(
-        currentWidth, randomValueAndRemain.first,
-        randomWidth - randomValueAndRemain.second);
-    randomValueAndRemain = {getRandom32Val(), randomWidth};
-    auto rest = getRandomValue(
-        builder.getIntegerType(type.getWidth() - currentWidth.getWidth()));
-    return builder.createOrFold<comb::ConcatOp>(value, rest);
   };
 
   // Get a random value with the specified width, combining or truncating
   // 32-bit units as necessary.
-  auto emitRandomInit = [&](Value dest, Type type) {
+  auto emitRandomInit = [&](Value dest, Type type, Twine accessor) {
     auto intType = type.cast<IntegerType>();
     if (intType.getWidth() == 0)
       return;
-    builder.create<sv::BPAssignOp>(dest, getRandomValue(intType));
+
+    SmallVector<SymbolAndRange> values;
+    getRandomValues(intType, values);
+
+    SmallString<32> rhs(("{{0}}" + accessor + " = ").str());
+    unsigned i = 1;
+    SmallVector<Attribute, 4> symbols({regDefSym});
+    if (values.size() > 1)
+      rhs.append("{");
+    for (auto [value, range] : llvm::reverse(values)) {
+      symbols.push_back(value);
+      auto [high, low] = range;
+      if (i > 1)
+        rhs.append(", ");
+      rhs.append(("{{" + Twine(i++) + "}}").str());
+
+      // This uses all bits of the random value. Emit without part select.
+      if (high == randomWidth - 1 && low == 0)
+        continue;
+
+      // Emit a single bit part select, e.g., emit "[0]" and not "[0:0]".
+      if (high == low) {
+        rhs.append(("[" + Twine(high) + "]").str());
+        continue;
+      }
+
+      // Emit a part select, e.g., "[4:2]"
+      rhs.append(
+          ("[" + Twine(range.first) + ":" + Twine(range.second) + "]").str());
+    }
+    if (values.size() > 1)
+      rhs.append("}");
+    rhs.append(";");
+
+    builder.create<sv::VerbatimOp>(rhs, ValueRange{},
+                                   builder.getArrayAttr(symbols));
   };
 
   // Randomly initialize everything in the register. If the register
@@ -2219,32 +2276,29 @@ void FIRRTLLowering::initializeRegister(Value reg) {
   // constituent ground types.
   auto randomInit = [&]() {
     auto type = reg.getType().dyn_cast<hw::InOutType>().getElementType();
-    std::function<void(Value, Type)> recurse = [&](Value reg, Type type) {
+    std::function<void(Value, Type, Twine)> recurse = [&](Value reg, Type type,
+                                                          Twine accessor) {
       TypeSwitch<Type>(type)
           .Case<hw::UnpackedArrayType, hw::ArrayType>([&](auto a) {
-            for (size_t i = 0, e = a.getSize(); i != e; ++i) {
-              auto iIdx =
-                  getOrCreateIntConstant(getBitWidthFromVectorSize(e), i);
-              auto arrayIndex =
-                  builder.create<sv::ArrayIndexInOutOp>(reg, iIdx);
-              recurse(arrayIndex, a.getElementType());
-            }
+            for (size_t i = 0, e = a.getSize(); i != e; ++i)
+              recurse(reg, a.getElementType(), accessor + "[" + Twine(i) + "]");
           })
           .Case<hw::StructType>([&](hw::StructType s) {
-            for (auto elem : s.getElements()) {
-              auto field =
-                  builder.create<sv::StructFieldInOutOp>(reg, elem.name);
-              recurse(field, elem.type);
-            }
+            for (auto elem : s.getElements())
+              recurse(reg, elem.type, accessor + "." + elem.name.getValue());
           })
-          .Default([&](auto type) { emitRandomInit(reg, type); });
+          .Default([&](auto type) { emitRandomInit(reg, type, accessor); });
     };
-    recurse(reg, type);
+    recurse(reg, type, "");
   };
 
   // Emit the initializer expression for simulation that fills it with random
   // value.
   addToIfDefBlock("SYNTHESIS", std::function<void()>(), [&]() {
+    addToIfDefBlock(
+        "RANDOMIZE_REG_INIT",
+        [&]() { regInsertionPoint = builder.saveInsertionPoint(); },
+        std::function<void()>());
     addToInitialBlock([&]() {
       emitRandomizePrologIfNeeded();
       circuitState.used_RANDOMIZE_REG_INIT = 1;

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -690,12 +690,14 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
     // CHECK-NEXT: sv.ifdef "SYNTHESIS"  {
     // CHECK-NEXT:   } else {
+    // CHECK-NEXT:    sv.ifdef "RANDOMIZE_REG_INIT" {
+    // CHECK-NEXT:      %[[RANDOM:.+]] = sv.reg sym @[[RANDOM_SYM:[_A-Za-z0-9]+]] {{.+}}
+    // CHECK-NEXT:    }
     // CHECK-NEXT:    sv.initial {
     // CHECK-NEXT:    sv.verbatim "`INIT_RANDOM_PROLOG_"
     // CHECK-NEXT:    sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
-    // CHECK-NEXT:       %RANDOM = sv.verbatim.expr.se "`RANDOM" : () -> i32
-    // CHECK-NEXT:       %3 = comb.extract %RANDOM from 0 : (i32) -> i2
-    // CHECK-NEXT:       sv.bpassign %count, %3 : i2
+    // CHECK-NEXT:       sv.verbatim "{{[{][{]0[}][}]}} = `RANDOM;" {symbols = [#hw.innerNameRef<@UninitReg1::@[[RANDOM_SYM]]>]}
+    // CHECK-NEXT:       sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}}[1:0];" {symbols = [#hw.innerNameRef<@UninitReg1::@count>, #hw.innerNameRef<@UninitReg1::@[[RANDOM_SYM]]>]}
     // CHECK-NEXT:     }
     // CHECK-NEXT:    }
     // CHECK-NEXT:  }
@@ -735,9 +737,9 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
     %4 = firrtl.asAsyncReset %reset : (!firrtl.uint<1>) -> !firrtl.asyncreset
 
-    // CHECK-NEXT: %reg = sv.reg : !hw.inout<i32>
+    // CHECK-NEXT: %reg = sv.reg sym @[[reg_sym:.+]] : !hw.inout<i32>
     // CHECK-NEXT: %0 = sv.read_inout %reg : !hw.inout<i32>
-    // CHECK-NEXT: %reg2 = sv.reg : !hw.inout<i32>
+    // CHECK-NEXT: %reg2 = sv.reg sym @[[reg2_sym:.+]] : !hw.inout<i32>
     // CHECK-NEXT: %1 = sv.read_inout %reg2 : !hw.inout<i32>
     // CHECK-NEXT: sv.always posedge %clock  {
     // CHECK-NEXT:   sv.if %reset  {
@@ -747,13 +749,17 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: }
     // CHECK-NEXT: sv.ifdef "SYNTHESIS"  {
     // CHECK-NEXT: } else {
+    // CHECK-NEXT:   sv.ifdef "RANDOMIZE_REG_INIT" {
+    // CHECK-NEXT:     %[[RANDOM:.+]] = sv.reg sym @[[RANDOM_SYM:[_A-Za-z0-9]+]] {{.+}}
+    // CHECK-NEXT:     %[[RANDOM_2:.+]] = sv.reg sym @[[RANDOM_2_SYM:[_A-Za-z0-9]+]] {{.+}}
+    // CHECK-NEXT:   }
     // CHECK-NEXT:   sv.initial {
     // CHECK-NEXT:     sv.verbatim "`INIT_RANDOM_PROLOG_"
     // CHECK-NEXT:     sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
-    // CHECK-NEXT:       %RANDOM = sv.verbatim.expr.se "`RANDOM" : () -> i32
-    // CHECK-NEXT:       sv.bpassign %reg, %RANDOM : i32
-    // CHECK-NEXT:       %RANDOM_0 = sv.verbatim.expr.se "`RANDOM" : () -> i32
-    // CHECK-NEXT:       sv.bpassign %reg2, %RANDOM_0 : i32
+    // CHECK-NEXT:       sv.verbatim "{{[{][{]0[}][}]}} = `RANDOM;" {symbols = [#hw.innerNameRef<@InitReg1::@[[RANDOM_SYM]]>]}
+    // CHECK-NEXT:       sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}};" {symbols = [#hw.innerNameRef<@InitReg1::@[[reg_sym]]>, #hw.innerNameRef<@InitReg1::@[[RANDOM_SYM]]>]}
+    // CHECK-NEXT:       sv.verbatim "{{[{][{]0[}][}]}} = `RANDOM;" {symbols = [#hw.innerNameRef<@InitReg1::@[[RANDOM_2_SYM]]>]}
+    // CHECK-NEXT:       sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}};" {symbols = [#hw.innerNameRef<@InitReg1::@[[reg2_sym]]>, #hw.innerNameRef<@InitReg1::@[[RANDOM_2_SYM]]>]}
     // CHECK-NEXT:     }
     // CHECK-NEXT:   }
     // CHECK-NEXT: }
@@ -1039,14 +1045,16 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
     // CHECK: sv.ifdef "SYNTHESIS"  {
     // CHECK-NEXT:   } else {
+    // CHECK-NEXT:    sv.ifdef "RANDOMIZE_REG_INIT" {
+    // CHECK-NEXT:      %[[RANDOM_0:.+]] = sv.reg sym @[[RANDOM_0_SYM:[_A-Za-z0-9]+]] {{.+}}
+    // CHECK-NEXT:      %[[RANDOM_1:.+]] = sv.reg sym @[[RANDOM_1_SYM:[_A-Za-z0-9]+]] {{.+}}
+    // CHECK-NEXT:    }
     // CHECK-NEXT:    sv.initial {
     // CHECK-NEXT:    sv.verbatim "`INIT_RANDOM_PROLOG_"
     // CHECK-NEXT:    sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
-    // CHECK-NEXT:       %RANDOM = sv.verbatim.expr.se "`RANDOM" : () -> i32
-    // CHECK-NEXT:       %RANDOM_0 = sv.verbatim.expr.se "`RANDOM" : () -> i32
-    // CHECK-NEXT:       %3 = comb.extract %RANDOM_0 from 0 : (i32) -> i10
-    // CHECK-NEXT:       %4 = comb.concat %RANDOM, %3 : i32, i10
-    // CHECK-NEXT:       sv.bpassign %count, %4 : i42
+    // CHECK-NEXT:       sv.verbatim "{{[{][{]0[}][}]}} = `RANDOM;" {symbols = [#hw.innerNameRef<@UninitReg42::@[[RANDOM_0_SYM]]>]}
+    // CHECK-NEXT:       sv.verbatim "{{[{][{]0[}][}]}} = `RANDOM;" {symbols = [#hw.innerNameRef<@UninitReg42::@[[RANDOM_1_SYM]]>]}
+    // CHECK-NEXT:       sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{][{]1[}][}]}}[9:0], {{[{][{]2[}][}][}]}};" {symbols = [#hw.innerNameRef<@UninitReg42::@count>, #hw.innerNameRef<@UninitReg42::@[[RANDOM_1_SYM]]>, #hw.innerNameRef<@UninitReg42::@[[RANDOM_0_SYM]]>]}
     // CHECK-NEXT:     }
     // CHECK-NEXT:    }
     // CHECK-NEXT:  }
@@ -1253,27 +1261,34 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %r2 = firrtl.reg %clock  : !firrtl.uint<4>
     %r3 = firrtl.reg %clock  : !firrtl.uint<32>
     %r4 = firrtl.reg %clock  : !firrtl.uint<100>
-    // CHECK:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
-    // CHECK-NEXT:    %RANDOM = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
-    // CHECK-NEXT:    %8 = comb.extract %RANDOM from 0 : (i32) -> i2
-    // CHECK-NEXT:    sv.bpassign %r1, %8 : i2
-    // CHECK-NEXT:    %9 = comb.extract %RANDOM from 2 : (i32) -> i4
-    // CHECK-NEXT:    sv.bpassign %r2, %9 : i4
-    // CHECK-NEXT:    %10 = comb.extract %RANDOM from 6 : (i32) -> i26
-    // CHECK-NEXT:    %RANDOM_0 = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
-    // CHECK-NEXT:    %11 = comb.extract %RANDOM_0 from 0 : (i32) -> i6
-    // CHECK-NEXT:    %12 = comb.concat %10, %11 : i26, i6
-    // CHECK-NEXT:    sv.bpassign %r3, %12 : i32
-    // CHECK-NEXT:    %13 = comb.extract %RANDOM_0 from 6 : (i32) -> i26
-    // CHECK-NEXT:    %RANDOM_1 = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
-    // CHECK-NEXT:    %RANDOM_2 = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
-    // CHECK-NEXT:    %RANDOM_3 = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
-    // CHECK-NEXT:    %14 = comb.extract %RANDOM_3 from 0 : (i32) -> i10
-    // CHECK-NEXT:    %15 = comb.concat %RANDOM_2, %14 : i32, i10
-    // CHECK-NEXT:    %16 = comb.concat %RANDOM_1, %15 : i32, i42
-    // CHECK-NEXT:    %17 = comb.concat %13, %16 : i26, i74
-    // CHECK-NEXT:    sv.bpassign %r4, %17 : i100
-    // CHECK-NEXT:  }
+    // CHECK:      %r1 = sv.reg sym @[[r1_sym:[_A-Za-z0-9]+]]
+    // CHECK:      %r2 = sv.reg sym @[[r2_sym:[_A-Za-z0-9]+]]
+    // CHECK:      %r3 = sv.reg sym @[[r3_sym:[_A-Za-z0-9]+]]
+    // CHECK:      %r4 = sv.reg sym @[[r4_sym:[_A-Za-z0-9]+]]
+    // CHECK:      sv.ifdef "SYNTHESIS" {
+    // CHECK-NEXT: } else {
+    // CHECK-NEXT:   sv.ifdef "RANDOMIZE_REG_INIT" {
+    // CHECK-NEXT:     %[[RANDOM_0:.+]] = sv.reg sym @[[RANDOM_0_SYM:[_A-Za-z0-9]+]]
+    // CHECK-NEXT:     %[[RANDOM_1:.+]] = sv.reg sym @[[RANDOM_1_SYM:[_A-Za-z0-9]+]]
+    // CHECK-NEXT:     %[[RANDOM_2:.+]] = sv.reg sym @[[RANDOM_2_SYM:[_A-Za-z0-9]+]]
+    // CHECK-NEXT:     %[[RANDOM_3:.+]] = sv.reg sym @[[RANDOM_3_SYM:[_A-Za-z0-9]+]]
+    // CHECK-NEXT:     %[[RANDOM_4:.+]] = sv.reg sym @[[RANDOM_4_SYM:[_A-Za-z0-9]+]]{{.+}}
+    // CHECK-NEXT:   }
+    // CHECK-NEXT:   sv.initial {
+    // CHECK-NEXT:     sv.verbatim "`INIT_RANDOM_PROLOG_"
+    // CHECK-NEXT:     sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
+    // CHECK-NEXT:       sv.verbatim "{{[{][{]0[}][}]}} = `RANDOM;" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_0_SYM]]>]}
+    // CHECK-NEXT:       sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}}[1:0];" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[r1_sym]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_0_SYM]]>]}
+    // CHECK-NEXT:       sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}}[5:2];" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[r2_sym]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_0_SYM]]>]}
+    // CHECK-NEXT:       sv.verbatim "{{[{][{]0[}][}]}} = `RANDOM;" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_1_SYM]]>]}
+    // CHECK-NEXT:       sv.verbatim "{{[{][{]0[}][}]}} = {{[{]}}{{[{][{]1[}][}]}}[5:0], {{[{][{]2[}][}]}}[31:6]{{[}]}};" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[r3_sym]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_1_SYM]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_0_SYM]]>]}
+    // CHECK-NEXT:       sv.verbatim "{{[{][{]0[}][}]}} = `RANDOM;" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_2_SYM]]>]}
+    // CHECK-NEXT:       sv.verbatim "{{[{][{]0[}][}]}} = `RANDOM;" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_3_SYM]]>]}
+    // CHECK-NEXT:       sv.verbatim "{{[{][{]0[}][}]}} = `RANDOM;" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_4_SYM]]>]}
+    // CHECK-NEXT:       sv.verbatim "{{[{][{]0[}][}]}} = {{[{]}}{{[{][{]1[}][}]}}[9:0], {{[{][{]2[}][}]}}, {{[{][{]3[}][}]}}, {{[{][{]4[}][}]}}[31:6]{{[}]}};" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[r4_sym]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_4_SYM]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_3_SYM]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_2_SYM]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_1_SYM]]>]}
+    // CHECK-NEXT:     }
+    // CHECK-NEXT:   }
+    // CHECK-NEXT: }
     firrtl.connect %r1, %a : !firrtl.uint<2>, !firrtl.uint<1>
     firrtl.connect %r2, %a : !firrtl.uint<4>, !firrtl.uint<1>
     firrtl.connect %r3, %a : !firrtl.uint<32>, !firrtl.uint<1>
@@ -1283,18 +1298,24 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.connect %o3, %r3 : !firrtl.uint<32>, !firrtl.uint<32>
     firrtl.connect %o4, %r4 : !firrtl.uint<100>, !firrtl.uint<100>
   }
-  
+
   // CHECK-LABEL: hw.module @init1DVector
   firrtl.module @init1DVector(in %clock: !firrtl.clock, in %a: !firrtl.vector<uint<1>, 2>, out %b: !firrtl.vector<uint<1>, 2>) {
     %r = firrtl.reg %clock  : !firrtl.vector<uint<1>, 2>
-    // CHECK:      sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
-    // CHECK-NEXT:   %1 = sv.array_index_inout %r[%false] : !hw.inout<array<2xi1>>, i1
-    // CHECK-NEXT:   %RANDOM = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
-    // CHECK-NEXT:   %2 = comb.extract %RANDOM from 0 : (i32) -> i1
-    // CHECK-NEXT:   sv.bpassign %1, %2 : i1
-    // CHECK-NEXT:   %3 = sv.array_index_inout %r[%true] : !hw.inout<array<2xi1>>, i1
-    // CHECK-NEXT:   %4 = comb.extract %RANDOM from 1 : (i32) -> i1
-    // CHECK-NEXT:   sv.bpassign %3, %4 : i1
+    // CHECK:      %r = sv.reg sym @[[r_sym:[_A-Za-z0-9]+]]
+    // CHECK:      sv.ifdef "SYNTHESIS" {
+    // CHECK-NEXT: } else {
+    // CHECK-NEXT:   sv.ifdef "RANDOMIZE_REG_INIT" {
+    // CHECK-NEXT:     %[[RANDOM:.+]] = sv.reg sym @[[RANDOM_SYM:[_A-Za-z0-9]+]]{{.+}}
+    // CHECK-NEXT:   }
+    // CHECK-NEXT:   sv.initial {
+    // CHECK-NEXT:     sv.verbatim "`INIT_RANDOM_PROLOG_"
+    // CHECK-NEXT:     sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
+    // CHECK-NEXT:       sv.verbatim "{{[{][{]0[}][}]}} = `RANDOM;" {symbols = [#hw.innerNameRef<@init1DVector::@[[RANDOM_SYM]]>]}
+    // CHECK-NEXT:       sv.verbatim "{{[{][{]0[}][}]}}[0] = {{[{][{]1[}][}]}}[0];" {symbols = [#hw.innerNameRef<@init1DVector::@[[r_sym]]>, #hw.innerNameRef<@init1DVector::@[[RANDOM_SYM]]>]}
+    // CHECK-NEXT:       sv.verbatim "{{[{][{]0[}][}]}}[1] = {{[{][{]1[}][}]}}[1];" {symbols = [#hw.innerNameRef<@init1DVector::@[[r_sym]]>, #hw.innerNameRef<@init1DVector::@[[RANDOM_SYM]]>]}
+    // CHECK-NEXT:     }
+    // CHECK-NEXT:   }
     // CHECK-NEXT: }
 
     firrtl.connect %r, %a : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
@@ -1469,13 +1490,21 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
   // CHECK-LABEL: hw.module @initStruct
   firrtl.module @initStruct(in %clock: !firrtl.clock) {
-    // CHECK:      sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
-    // CHECK-NEXT:   %0 = sv.struct_field_inout %r["a"] : !hw.inout<struct<a: i1>>
-    // CHECK-NEXT:   %RANDOM = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
-    // CHECK-NEXT:   %1 = comb.extract %RANDOM from 0 : (i32) -> i1
-    // CHECK-NEXT:   sv.bpassign %0, %1 : i1
-    // CHECK-NEXT: }
     %r = firrtl.reg %clock  : !firrtl.bundle<a: uint<1>>
+    // CHECK:      %r = sv.reg sym @[[r_sym:[_A-Za-z0-9]+]]
+    // CHECK:      sv.ifdef "SYNTHESIS" {
+    // CHECK-NEXT: } else {
+    // CHECK-NEXT:   sv.ifdef "RANDOMIZE_REG_INIT" {
+    // CHECK-NEXT:     %[[RANDOM:.+]] = sv.reg sym @[[RANDOM_SYM:[_A-Za-z0-9]+]]{{.+}}
+    // CHECK-NEXT:   }
+    // CHECK-NEXT:   sv.initial {
+    // CHECK-NEXT:     sv.verbatim "`INIT_RANDOM_PROLOG_"
+    // CHECK-NEXT:     sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
+    // CHECK-NEXT:       sv.verbatim "{{[{][{]0[}][}]}} = `RANDOM;" {symbols = [#hw.innerNameRef<@initStruct::@[[RANDOM_SYM]]>]}
+    // CHECK-NEXT:       sv.verbatim "{{[{][{]0[}][}]}}.a = {{[{][{]1[}][}]}}[0];" {symbols = [#hw.innerNameRef<@initStruct::@[[r_sym]]>, #hw.innerNameRef<@initStruct::@[[RANDOM_SYM]]>]}
+    // CHECK-NEXT:     }
+    // CHECK-NEXT:   }
+    // CHECK-NEXT: }
   }
 
   // CHECK-LABEL: hw.module @RegResetStructNarrow
@@ -1483,7 +1512,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK:      %0 = hw.struct_extract %init["a"] : !hw.struct<a: i2>
     // CHECK-NEXT: %1 = comb.extract %0 from 0 : (i2) -> i1
     // CHECK-NEXT: %2 = hw.struct_create (%1) : !hw.struct<a: i1>
-    // CHECK-NEXT: %reg = sv.reg  : !hw.inout<struct<a: i1>>
+    // CHECK-NEXT: %reg = sv.reg {{.+}}  : !hw.inout<struct<a: i1>>
     // CHECK-NEXT: sv.always posedge %clock  {
     // CHECK-NEXT:   sv.if %reset  {
     // CHECK-NEXT:     sv.passign %reg, %2 : !hw.struct<a: i1>
@@ -1512,7 +1541,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %reg = firrtl.regreset %clock, %reset, %invalid : !firrtl.uint<1>, !firrtl.bundle<a: uint<1>, b: vector<uint<10>, 10>>, !firrtl.bundle<a: uint<1>, b: vector<uint<10>, 10>>
     // CHECK:      %c0_i101 = hw.constant 0 : i101
     // CHECK-NEXT: %0 = hw.bitcast %c0_i101 : (i101) -> !hw.struct<a: i1, b: !hw.array<10xi10>>
-    // CHECK-NEXT: %reg = sv.reg  : !hw.inout<struct<a: i1, b: !hw.array<10xi10>>>
+    // CHECK-NEXT: %reg = sv.reg {{.+}} : !hw.inout<struct<a: i1, b: !hw.array<10xi10>>>
     // CHECK-NEXT: sv.always posedge %clock  {
     // CHECK-NEXT:   sv.if %reset  {
     // CHECK-NEXT:     sv.passign %reg, %0 : !hw.struct<a: i1, b: !hw.array<10xi10>>


### PR DESCRIPTION
Work around a bug in Verilog emission with the disallowLocalVariables
option where temporaries are spilled to wires which violates the
ordering of the initial block used for register randomization.  This
manifests as X's showing up in registers after initialization.  This
avoids this entirely by using explicit registers and verbatim operations
using those registers.

Fixes #2310.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

For the example FIRRTL circuit shown in #2310:

```verilog
circuit Foo:
  module Foo:
    input clock: Clock
    input d: UInt<1>
    output q: UInt<1>

    reg r: UInt<1>, clock

    r <= d
    q <= r
```

This PR produces, with or without `-lowering-options=disallowLocalVariables`:

```verilog
module Foo(	// Bar.fir:2:10
  input  clock, d,
  output q);

  reg r;	// Bar.fir:7:5

  `ifndef SYNTHESIS	// Bar.fir:7:5
    `ifdef RANDOMIZE_REG_INIT	// Bar.fir:7:5
      reg [31:0] _RANDOM;	// Bar.fir:7:5

    `endif
    initial begin	// Bar.fir:7:5
      `INIT_RANDOM_PROLOG_	// Bar.fir:7:5
      `ifdef RANDOMIZE_REG_INIT	// Bar.fir:7:5
        _RANDOM = `RANDOM;	// Bar.fir:7:5
        r = _RANDOM[0];	// Bar.fir:7:5
      `endif
    end // initial
  `endif
  always @(posedge clock)	// Bar.fir:9:7
    r <= d;	// Bar.fir:9:7
  assign q = r;	// Bar.fir:2:10
endmodule
```