### PR TITLE
[MemoryDependenceAnalysis] Add ability to replace an op.

### DIFF
--- a/include/circt/Analysis/DependenceAnalysis.h
+++ b/include/circt/Analysis/DependenceAnalysis.h
@@ -66,6 +66,9 @@ struct MemoryDependenceAnalysis {
   // Returns the dependences, if any, that the given Operation depends on.
   ArrayRef<MemoryDependence> getDependences(Operation *);
 
+  // Replaces the dependences, if any, from the source op to the destination op.
+  void replaceOp(Operation *source, Operation *destination);
+
 private:
   // Store dependence results.
   MemoryDependenceResult results;

--- a/include/circt/Analysis/DependenceAnalysis.h
+++ b/include/circt/Analysis/DependenceAnalysis.h
@@ -66,7 +66,7 @@ struct MemoryDependenceAnalysis {
   // Returns the dependences, if any, that the given Operation depends on.
   ArrayRef<MemoryDependence> getDependences(Operation *);
 
-  // Replaces the dependences, if any, from the source op to the destination op.
+  // Replaces the dependences, if any, from the oldOp to the newOp.
   void replaceOp(Operation *oldOp, Operation *newOp);
 
 private:

--- a/include/circt/Analysis/DependenceAnalysis.h
+++ b/include/circt/Analysis/DependenceAnalysis.h
@@ -67,7 +67,7 @@ struct MemoryDependenceAnalysis {
   ArrayRef<MemoryDependence> getDependences(Operation *);
 
   // Replaces the dependences, if any, from the source op to the destination op.
-  void replaceOp(Operation *source, Operation *destination);
+  void replaceOp(Operation *oldOp, Operation *newOp);
 
 private:
   // Store dependence results.

--- a/lib/Analysis/DependenceAnalysis.cpp
+++ b/lib/Analysis/DependenceAnalysis.cpp
@@ -147,3 +147,23 @@ ArrayRef<MemoryDependence>
 circt::analysis::MemoryDependenceAnalysis::getDependences(Operation *op) {
   return results[op];
 }
+
+/// Replaces the dependences, if any, from the source op to the destination op.
+void circt::analysis::MemoryDependenceAnalysis::replaceOp(
+    Operation *source, Operation *destination) {
+  // If source had any dependences.
+  auto it = results.find(source);
+  if (it != results.end())
+    // Move the dependences to destination.
+    it->first = destination;
+
+  // Find any dependences originating from source and replace the source.
+  // TODO(mikeurbach): consider adding an inverted index to avoid this scan.
+  for (auto &it : results)
+    for (auto &dep : it.second)
+      if (dep.source == source)
+        dep.source = destination;
+
+  // Remove the source.
+  results.erase(source);
+}

--- a/lib/Analysis/DependenceAnalysis.cpp
+++ b/lib/Analysis/DependenceAnalysis.cpp
@@ -148,7 +148,7 @@ circt::analysis::MemoryDependenceAnalysis::getDependences(Operation *op) {
   return results[op];
 }
 
-/// Replaces the dependences, if any, from the oldOp op to the newOp op.
+/// Replaces the dependences, if any, from the oldOp to the newOp.
 void circt::analysis::MemoryDependenceAnalysis::replaceOp(Operation *oldOp,
                                                           Operation *newOp) {
   // If oldOp had any dependences.

--- a/lib/Analysis/DependenceAnalysis.cpp
+++ b/lib/Analysis/DependenceAnalysis.cpp
@@ -148,7 +148,7 @@ circt::analysis::MemoryDependenceAnalysis::getDependences(Operation *op) {
   return results[op];
 }
 
-/// Replaces the dependences, if any, from the source op to the destination op.
+/// Replaces the dependences, if any, from the oldOp op to the newOp op.
 void circt::analysis::MemoryDependenceAnalysis::replaceOp(Operation *oldOp,
                                                           Operation *newOp) {
   // If oldOp had any dependences.
@@ -157,13 +157,10 @@ void circt::analysis::MemoryDependenceAnalysis::replaceOp(Operation *oldOp,
     // Move the dependences to newOp.
     it->first = newOp;
 
-  // Find any dependences originating from oldOp and replace the source.
+  // Find any dependences originating from oldOp and make newOp the source.
   // TODO(mikeurbach): consider adding an inverted index to avoid this scan.
   for (auto &it : results)
     for (auto &dep : it.second)
       if (dep.source == oldOp)
         dep.source = newOp;
-
-  // Remove the oldOp.
-  results.erase(oldOp);
 }

--- a/lib/Analysis/DependenceAnalysis.cpp
+++ b/lib/Analysis/DependenceAnalysis.cpp
@@ -149,21 +149,21 @@ circt::analysis::MemoryDependenceAnalysis::getDependences(Operation *op) {
 }
 
 /// Replaces the dependences, if any, from the source op to the destination op.
-void circt::analysis::MemoryDependenceAnalysis::replaceOp(
-    Operation *source, Operation *destination) {
-  // If source had any dependences.
-  auto it = results.find(source);
+void circt::analysis::MemoryDependenceAnalysis::replaceOp(Operation *oldOp,
+                                                          Operation *newOp) {
+  // If oldOp had any dependences.
+  auto it = results.find(oldOp);
   if (it != results.end())
-    // Move the dependences to destination.
-    it->first = destination;
+    // Move the dependences to newOp.
+    it->first = newOp;
 
-  // Find any dependences originating from source and replace the source.
+  // Find any dependences originating from oldOp and replace the source.
   // TODO(mikeurbach): consider adding an inverted index to avoid this scan.
   for (auto &it : results)
     for (auto &dep : it.second)
-      if (dep.source == source)
-        dep.source = destination;
+      if (dep.source == oldOp)
+        dep.source = newOp;
 
-  // Remove the source.
-  results.erase(source);
+  // Remove the oldOp.
+  results.erase(oldOp);
 }


### PR DESCRIPTION
This is useful to transformations that want to be able to reuse the
analysis during progressive lowering. If an affine.load or
affine.store is lowered, this API can be used to maintain any
dependences on the replacement op.