### PR TITLE
[SchedulingAnalysis] Support scf::IfOp and memref::LoadOp/StoreOp.

### DIFF
--- a/lib/Analysis/SchedulingAnalysis.cpp
+++ b/lib/Analysis/SchedulingAnalysis.cpp
@@ -14,6 +14,8 @@
 #include "circt/Analysis/DependenceAnalysis.h"
 #include "circt/Scheduling/Problems.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/SCF.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/AnalysisManager.h"
 #include "mlir/Transforms/LoopUtils.h"
@@ -76,19 +78,33 @@ void circt::analysis::CyclicSchedulingAnalysis::analyzeForOp(
   });
 
   // Insert conditional dependences into the problem.
-  forOp.getBody()->walk([&](AffineIfOp op) {
+  forOp.getBody()->walk([&](Operation *op) {
+    Block *thenBlock = nullptr;
+    Block *elseBlock = nullptr;
+    if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+      thenBlock = ifOp.thenBlock();
+      elseBlock = ifOp.elseBlock();
+    }
+    if (auto ifOp = dyn_cast<AffineIfOp>(op)) {
+      thenBlock = ifOp.getThenBlock();
+      if (ifOp.hasElse())
+        elseBlock = ifOp.getElseBlock();
+    }
+    if (!thenBlock)
+      return WalkResult::advance();
+
     // No special handling required for control-only `if`s.
-    if (op.getNumResults() == 0)
+    if (op->getNumResults() == 0)
       return WalkResult::skip();
 
     // Model the implicit value flow from the `yield` to the `if`'s result(s).
-    Problem::Dependence depThen(op.getThenBlock()->getTerminator(), op);
+    Problem::Dependence depThen(thenBlock->getTerminator(), op);
     auto depInserted = problem.insertDependence(depThen);
     assert(succeeded(depInserted));
     (void)depInserted;
 
-    if (op.hasElse()) {
-      Problem::Dependence depElse(op.getElseBlock()->getTerminator(), op);
+    if (elseBlock) {
+      Problem::Dependence depElse(elseBlock->getTerminator(), op);
       depInserted = problem.insertDependence(depElse);
       assert(succeeded(depInserted));
       (void)depInserted;
@@ -100,7 +116,9 @@ void circt::analysis::CyclicSchedulingAnalysis::analyzeForOp(
   // Set the anchor for scheduling. Insert dependences from all stores to the
   // terminator to ensure the problem schedules them before the terminator.
   auto *anchor = forOp.getBody()->getTerminator();
-  forOp.getBody()->walk([&](AffineWriteOpInterface op) {
+  forOp.getBody()->walk([&](Operation *op) {
+    if (!isa<mlir::AffineStoreOp, memref::StoreOp>(op))
+      return;
     Problem::Dependence dep(op, anchor);
     auto depInserted = problem.insertDependence(dep);
     assert(succeeded(depInserted));

--- a/lib/Analysis/SchedulingAnalysis.cpp
+++ b/lib/Analysis/SchedulingAnalysis.cpp
@@ -84,14 +84,13 @@ void circt::analysis::CyclicSchedulingAnalysis::analyzeForOp(
     if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
       thenBlock = ifOp.thenBlock();
       elseBlock = ifOp.elseBlock();
-    }
-    if (auto ifOp = dyn_cast<AffineIfOp>(op)) {
+    } else if (auto ifOp = dyn_cast<AffineIfOp>(op)) {
       thenBlock = ifOp.getThenBlock();
       if (ifOp.hasElse())
         elseBlock = ifOp.getElseBlock();
-    }
-    if (!thenBlock)
+    } else {
       return WalkResult::advance();
+    }
 
     // No special handling required for control-only `if`s.
     if (op->getNumResults() == 0)

--- a/test/Analysis/scheduling-analysis.mlir
+++ b/test/Analysis/scheduling-analysis.mlir
@@ -150,3 +150,20 @@ func @test9(%arg0: memref<4x4xi32>, %arg1: memref<4x4xi32>, %arg2: memref<4x4xi3
   }
   return
 }
+
+// CHECK-LABEL: func @test10
+func @test10(%arg0: memref<5xi32>) {
+  %true = arith.constant 1 : i1
+  %c0_i32 = arith.constant 0 : i32
+  affine.for %arg1 = 0 to 5 {
+    %0 = scf.if %true -> (i32) {
+      %1 = memref.load %arg0[%arg1] : memref<5xi32>
+      scf.yield %1 : i32
+    } else {
+      memref.store %c0_i32, %arg0[%arg1] : memref<5xi32>
+      scf.yield %c0_i32 : i32
+    }
+    // CHECK: } {dependence}
+  }
+  return
+}


### PR DESCRIPTION
This generalizes the auxiliary dependences added for control flow to
support both Affine and SCF IfOps. Similarly, the auxiliary dependence
from the stores to the terminator are generalized to support both
Affine and MemRef StoreOp. With these enhancements, this analysis now
supports the SCF and MemRef dialects, provided the memory dependences
are correctly assigned.