### PR TITLE
[FIRRTL] Make foldWhenEncodedVerifOp handle PrintOp even when they are not at a block begin

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRAnnotations.h
+++ b/lib/Dialect/FIRRTL/Import/FIRAnnotations.h
@@ -31,6 +31,7 @@ namespace circt {
 namespace firrtl {
 
 class CircuitOp;
+class PrintFOp;
 
 bool fromJSON(llvm::json::Value &value, StringRef circuitTarget,
               llvm::StringMap<ArrayAttr> &annotationMap, llvm::json::Path path,
@@ -49,6 +50,8 @@ bool scatterCustomAnnotations(llvm::StringMap<ArrayAttr> &annotationMap,
 bool fromJSONRaw(llvm::json::Value &value, StringRef circuitTarget,
                  SmallVectorImpl<Attribute> &attrs, llvm::json::Path path,
                  MLIRContext *context);
+
+ParseResult foldWhenEncodedVerifOp(PrintFOp printOp);
 
 } // namespace firrtl
 } // namespace circt

--- a/lib/Dialect/FIRRTL/Import/FIRParserAsserts.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParserAsserts.cpp
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "FIRAnnotations.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
@@ -189,9 +190,6 @@ parseAssertionFormat(const ExtractionSummaryCursor<StringRef> &ex) {
   return llvm::None;
 }
 
-namespace circt {
-namespace firrtl {
-
 /// Chisel has a tendency to emit complex assert/assume/cover statements encoded
 /// as print operations with special formatting and metadata embedded in the
 /// message literal. These always reside in a when block of the following form:
@@ -203,7 +201,7 @@ namespace firrtl {
 /// Depending on the nature the verification operation, the `stop` may be
 /// optional. The Scala implementation simply removes all `stop`s that have the
 /// same condition as the printf.
-ParseResult foldWhenEncodedVerifOp(PrintFOp printOp) {
+ParseResult circt::firrtl::foldWhenEncodedVerifOp(PrintFOp printOp) {
   auto *context = printOp.getContext();
   auto whenStmt = dyn_cast<WhenOp>(printOp->getParentOp());
 
@@ -570,6 +568,3 @@ ParseResult foldWhenEncodedVerifOp(PrintFOp printOp) {
     whenStmt.erase();
   return success();
 }
-
-} // namespace firrtl
-} // namespace circt

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -861,6 +861,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input enable: UInt<1>
     input not_reset: UInt<1>
     input value: UInt<42>
+    input io : {clock: Clock, nest: {enable: UInt<1>}}
 
     ; rocket-chip properties
     when cond:
@@ -1007,3 +1008,10 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       when not_cond3:
         printf(clock, UInt<1>(1), "Assertion failed: double user assert")
     ; CHECK-NOT: firrtl.assert %clock, {{.+}} "double user assert"
+
+    when cond :
+        printf(io.clock, not(enable), "assert: bar")
+    ; CHECK: [[CLOCK:%.+]] = firrtl.subfield %io(0)
+    ; CHECK-NEXT: [[NOT_ENABLE:%.+]] = firrtl.not %enable
+    ; CHECK-NEXT: [[NOT_COND:%.+]] = firrtl.not %cond
+    ; CHECK-NEXT: firrtl.assert [[CLOCK]], [[NOT_COND]], [[NOT_ENABLE]]

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -861,7 +861,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input enable: UInt<1>
     input not_reset: UInt<1>
     input value: UInt<42>
-    input io : {clock: Clock, nest: {enable: UInt<1>}}
+    input io : {clock: Clock}
 
     ; rocket-chip properties
     when cond:


### PR DESCRIPTION
This commit first moves `foldWhenEncodedVerifOp` logic into post parse
processing to restructure operations without fear. Next, foldWhenEncodedVerifOp
is modified to handle printf op not at block's begin. For example,

```scala
circuit Foo:
  module Foo :
    input cond: UInt<1>
    input enable: UInt<1>
    input io : {clock:Clock}
    when cond :
        printf(io.clock, enable, "assert: bar")
```

`circt-translate --import-firrtl` now generates expected IR.

```mlir
firrtl.module @Foo(in %cond: !firrtl.uint<1>, in %enable: !firrtl.uint<1>, in %io: !firrtl.bundle<clock: clock>) {
  %0 = firrtl.subfield %io(0) : (!firrtl.bundle<clock: clock>) -> !firrtl.clock
  %1 = firrtl.not %cond : (!firrtl.uint<1>) -> !firrtl.uint<1>
  firrtl.assert %0, %1, %enable, " bar"  {eventControl = 0 : i32, isConcurrent = true}
}
``` 

will close https://github.com/llvm/circt/issues/2384