### PR TITLE
[Namespace] Improve newName trials by skipping trivially used names

### DIFF
--- a/include/circt/Support/Namespace.h
+++ b/include/circt/Support/Namespace.h
@@ -56,9 +56,12 @@ public:
       return inserted.first->getKey();
 
     // Try different suffixes until we get a collision-free one.
-    size_t i = 0;
     if (tryName.empty())
       name.toVector(tryName); // toStringRef may leave tryName unfilled
+
+    // Indexes between [0, nextIndex[tryName]) are already used, so skip
+    // them.
+    size_t &i = nextIndex[tryName];
     tryName.push_back('_');
     size_t baseLength = tryName.size();
     for (;;) {
@@ -72,6 +75,7 @@ public:
 
 protected:
   llvm::StringSet<> internal;
+  llvm::StringMap<size_t> nextIndex;
 };
 
 } // namespace circt


### PR DESCRIPTION
This commit modifies the creation of new names to skip already used
ones. This fixes regression of LowerToHW caused by many creations of
RANDOM values. `Namespace::newName`  creates new name for 
"RANDOM" but it is trying  "RANDOM_0", "RANDOM_1", ...., "RANDOM_N"
 every time which causes squared time complexity.


For test2.fir, 
Before: 
```
  Total Execution Time: 130.0296 seconds

  ----Wall Time----  ----Name----
    1.7655 (  1.4%)  FIR Parser
    7.8127 (  6.0%)  'firrtl.circuit' Pipeline
    0.6226 (  0.5%)    'firrtl.module' Pipeline
    0.5154 (  0.4%)      CSE
    0.0000 (  0.0%)        (A) DominanceInfo
    0.1072 (  0.1%)      LowerCHIRRTLPass
    0.0485 (  0.0%)    InferWidths
    0.3083 (  0.2%)    InferResets
    0.0095 (  0.0%)      (A) circt::firrtl::InstanceGraph
    0.0105 (  0.0%)    PrefixModules
    0.3344 (  0.3%)    LowerFIRRTLTypes
    3.2386 (  2.5%)    'firrtl.module' Pipeline
    0.3939 (  0.3%)      ExpandWhens
    0.0102 (  0.0%)      RemoveResets
    2.8345 (  2.2%)      Canonicalizer
    0.1964 (  0.2%)    Inliner
    0.6132 (  0.5%)    IMConstProp
    0.0256 (  0.0%)      (A) circt::firrtl::InstanceGraph
    0.0000 (  0.0%)    BlackBoxReader
    2.1803 (  1.7%)    'firrtl.module' Pipeline
    2.1803 (  1.7%)      Canonicalizer
    0.1827 (  0.1%)    CreateSiFiveMetadata
    0.0770 (  0.1%)    EmitOMIR
    0.0252 (  0.0%)      (A) circt::firrtl::InstanceGraph
  115.2874 ( 88.7%)  LowerFIRRTLToHW
    0.0000 (  0.0%)  HWMemSimImpl
    3.4060 (  2.6%)  'hw.module' Pipeline
    0.3016 (  0.2%)    HWCleanup
    0.4017 (  0.3%)    CSE
    0.0000 (  0.0%)      (A) DominanceInfo
    2.2856 (  1.8%)    Canonicalizer
    0.0451 (  0.0%)    HWLegalizeModules
    0.3720 (  0.3%)    PrettifyVerilog
    1.7385 (  1.3%)  ExportVerilog
    0.0100 (  0.0%)  Rest
  130.0296 (100.0%)  Total
```

After:

```
  Total Execution Time: 16.3125 seconds
  ----Wall Time----  ----Name----
    1.7228 ( 10.6%)  FIR Parser
    7.6299 ( 46.8%)  'firrtl.circuit' Pipeline
    0.5875 (  3.6%)    'firrtl.module' Pipeline
    0.4919 (  3.0%)      CSE
    0.0000 (  0.0%)        (A) DominanceInfo
    0.0955 (  0.6%)      LowerCHIRRTLPass
    0.0453 (  0.3%)    InferWidths
    0.3173 (  1.9%)    InferResets
    0.0089 (  0.1%)      (A) circt::firrtl::InstanceGraph
    0.0100 (  0.1%)    PrefixModules
    0.3173 (  1.9%)    LowerFIRRTLTypes
    3.1213 ( 19.1%)    'firrtl.module' Pipeline
    0.3759 (  2.3%)      ExpandWhens
    0.0097 (  0.1%)      RemoveResets
    2.7357 ( 16.8%)      Canonicalizer
    0.2011 (  1.2%)    Inliner
    0.6092 (  3.7%)    IMConstProp
    0.0269 (  0.2%)      (A) circt::firrtl::InstanceGraph
    0.0000 (  0.0%)    BlackBoxReader
    2.1667 ( 13.3%)    'firrtl.module' Pipeline
    2.1667 ( 13.3%)      Canonicalizer
    0.1767 (  1.1%)    CreateSiFiveMetadata
    0.0775 (  0.5%)    EmitOMIR
    0.0259 (  0.2%)      (A) circt::firrtl::InstanceGraph
    1.7765 ( 10.9%)  LowerFIRRTLToHW
    0.0000 (  0.0%)  HWMemSimImpl
    3.4297 ( 21.0%)  'hw.module' Pipeline
    0.3003 (  1.8%)    HWCleanup
    0.4116 (  2.5%)    CSE
    0.0000 (  0.0%)      (A) DominanceInfo
    2.2964 ( 14.1%)    Canonicalizer
    0.0471 (  0.3%)    HWLegalizeModules
    0.3743 (  2.3%)    PrettifyVerilog
    1.7347 ( 10.6%)  ExportVerilog
    0.0096 (  0.1%)  Rest
   16.3125 (100.0%)  Total
```
Will close https://github.com/llvm/circt/issues/2390