### PR TITLE
[FIRTOOL] Move HWCleanup after canonicalizer

### DIFF
--- a/test/firtool/optimizations.mlir
+++ b/test/firtool/optimizations.mlir
@@ -1,0 +1,21 @@
+// RUN: firtool %s -verilog | FileCheck %s
+// Issue 2393: Check that if statements created by canonicalizer are merged.
+// CHECK-LABEL: module Issue2393(
+hw.module @Issue2393(%clock: i1, %c: i1, %data: i2) {
+  %r1 = sv.reg : !hw.inout<i2>
+  %1 = sv.read_inout %r1 : !hw.inout<i2>
+  %r2 = sv.reg : !hw.inout<i2>
+  %2 = sv.read_inout %r2 : !hw.inout<i2>
+  %mux1 = comb.mux %c, %data, %1 : i2
+  %mux2 = comb.mux %c, %data, %2 : i2
+  sv.always posedge %clock {
+    sv.passign %r1, %mux1 : i2
+    sv.passign %r2, %mux2 : i2
+  }
+  // CHECK:     always @(posedge clock) begin
+  // CHECK-NEXT:   if (c) begin
+  // CHECK-NEXT:     r1 <= data;
+  // CHECK-NEXT:     r2 <= data;
+  // CHECK-NEXT:   end
+  // CHECK-NEXT: end
+}

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -420,9 +420,9 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
     // If enabled, run the optimizer.
     if (!disableOptimization) {
       auto &modulePM = pm.nest<hw::HWModuleOp>();
-      modulePM.addPass(sv::createHWCleanupPass());
       modulePM.addPass(createCSEPass());
       modulePM.addPass(createSimpleCanonicalizerPass());
+      modulePM.addPass(sv::createHWCleanupPass());
     }
   }
 


### PR DESCRIPTION
Some canonicalizers create new sv.if ops. As a result
we get redundant if statement in output verilog.
This commit fixes the issue by moving HWCleanup to the later.

Will close https://github.com/llvm/circt/issues/2393