### PR TITLE
[Scheduling] Prepare simplex implementation for the modulo scheduler.

### DIFF
--- a/include/circt/Scheduling/Algorithms.h
+++ b/include/circt/Scheduling/Algorithms.h
@@ -43,6 +43,13 @@ LogicalResult scheduleSimplex(CyclicProblem &prob, Operation *lastOp);
 /// dependence graph contains cycles.
 LogicalResult scheduleSimplex(SharedOperatorsProblem &prob, Operation *lastOp);
 
+/// Solve the modulo scheduling problem using a linear programming-based
+/// heuristic. The approach tries to determine the smallest feasible initiation
+/// interval, and to minimize the start time of the given \p lastOp, but
+/// optimality is not guaranteed. Fails if the dependence graph contains cycles
+/// that do not include at least one edge with a non-zero distance.
+LogicalResult scheduleSimplex(ModuloProblem &prob, Operation *lastOp);
+
 } // namespace scheduling
 } // namespace circt
 


### PR DESCRIPTION
The most significant change here is the support solving a tableau with multiple objective rows.

**Why?** The upcoming modulo scheduling heuristic needs ASAP and ALAP times for ops in the partial schedule, and computing these all at once be using a suitable second objective functions is the elegant way to do it.

**How?** After changing the order of the objective rows, we may need to restore "primal feasibility", which means that the column vectors in the "objectives-part" of the tableau must be made lexico-positive through pivot operations.

Additionally, this sets up the boilerplate for the modulo scheduler, and includes a few quality-of-life improvements in the simplex framework itself.