### PR TITLE
[Scheduling] Implement de Dinechin's "fast" modulo scheduler.

### DIFF
--- a/lib/Scheduling/SimplexSchedulers.cpp
+++ b/lib/Scheduling/SimplexSchedulers.cpp
@@ -226,6 +226,42 @@ public:
   LogicalResult schedule() override;
 };
 
+// This class solves the `ModuloProblem` using the iterative heuristic presented
+// in [2].
+class ModuloSimplexScheduler : public CyclicSimplexScheduler {
+private:
+  struct MRT {
+    ModuloSimplexScheduler &sched;
+
+    using TableType = SmallDenseMap<unsigned, DenseSet<Operation *>>;
+    using ReverseTableType = SmallDenseMap<Operation *, unsigned>;
+    SmallDenseMap<Problem::OperatorType, TableType> tables;
+    SmallDenseMap<Problem::OperatorType, ReverseTableType> reverseTables;
+
+    explicit MRT(ModuloSimplexScheduler &sched) : sched(sched) {}
+    LogicalResult enter(Operation *op, unsigned timeStep);
+    void release(Operation *op);
+  };
+
+  ModuloProblem &prob;
+  SmallVector<unsigned> asapTimes, alapTimes;
+  SmallVector<Operation *> unscheduled, scheduled;
+  MRT mrt;
+
+protected:
+  Problem &getProblem() override { return prob; }
+  enum { OBJ_LATENCY = 0, OBJ_AXAP /* i.e. either ASAP or ALAP */ };
+  bool fillObjectiveRow(SmallVector<int> &row, unsigned obj) override;
+  void updateMargins();
+  void incrementII();
+  void scheduleOperation(Operation *n);
+
+public:
+  ModuloSimplexScheduler(ModuloProblem &prob, Operation *lastOp)
+      : CyclicSimplexScheduler(prob, lastOp), prob(prob), mrt(*this) {}
+  LogicalResult schedule() override;
+};
+
 } // anonymous namespace
 
 //===----------------------------------------------------------------------===//
@@ -843,6 +879,225 @@ LogicalResult SharedOperatorsSimplexScheduler::schedule() {
 }
 
 //===----------------------------------------------------------------------===//
+// ModuloSimplexScheduler
+//===----------------------------------------------------------------------===//
+
+LogicalResult ModuloSimplexScheduler::MRT::enter(Operation *op,
+                                                 unsigned timeStep) {
+  auto opr = *sched.prob.getLinkedOperatorType(op);
+  auto lim = *sched.prob.getLimit(opr);
+  assert(lim > 0);
+
+  auto &revTab = reverseTables[opr];
+  assert(!revTab.count(op));
+
+  unsigned slot = timeStep % sched.parameterT;
+  auto &cell = tables[opr][slot];
+  if (cell.size() < lim) {
+    cell.insert(op);
+    revTab[op] = slot;
+    return success();
+  }
+  return failure();
+}
+
+void ModuloSimplexScheduler::MRT::release(Operation *op) {
+  auto opr = *sched.prob.getLinkedOperatorType(op);
+  auto &revTab = reverseTables[opr];
+  auto it = revTab.find(op);
+  assert(it != revTab.end());
+  tables[opr][it->second].erase(op);
+  revTab.erase(it);
+}
+
+bool ModuloSimplexScheduler::fillObjectiveRow(SmallVector<int> &row,
+                                              unsigned obj) {
+  switch (obj) {
+  case OBJ_LATENCY:
+    // Minimize start time of user-specified last operation.
+    row[startTimeLocations[startTimeVariables[lastOp]]] = 1;
+    return true;
+  case OBJ_AXAP:
+    // Minimize sum of start times of all-but-the-last operation.
+    for (auto *op : getProblem().getOperations())
+      if (op != lastOp)
+        row[startTimeLocations[startTimeVariables[op]]] = 1;
+    return false;
+  default:
+    llvm_unreachable("Unsupported objective requested");
+  }
+}
+
+void ModuloSimplexScheduler::updateMargins() {
+  // Assumption: current secondary objective is "ASAP".
+  // Negate the objective row once to effectively maximize the sum of start
+  // times, which yields the "ALAP" times after solving the tableau. Then,
+  // negate it again to restore the "ASAP" objective, and store these times as
+  // well.
+  for (auto *axapTimes : {&alapTimes, &asapTimes}) {
+    multiplyRow(OBJ_AXAP, -1);
+    // This should not fail for a feasible tableau.
+    assert(succeeded(restoreDualFeasibility()) && succeeded(solveTableau()));
+
+    for (unsigned stv = 0; stv < startTimeLocations.size(); ++stv)
+      (*axapTimes)[stv] = getStartTime(stv);
+  }
+}
+
+void ModuloSimplexScheduler::incrementII() {
+  // Account for the shift in the frozen start times that will be caused by
+  // increasing `parameterT`: Assuming decompositions of
+  //   t = phi * II + tau  and  t' = phi * (II + 1) + tau,
+  // so the required shift is
+  //   t' - t = phi = floordiv(t / II)
+  for (auto &kv : frozenVariables) {
+    unsigned &frozenTime = kv.getSecond();
+    frozenTime += frozenTime / parameterT;
+  }
+
+  // Increment the parameter.
+  ++parameterT;
+}
+
+void ModuloSimplexScheduler::scheduleOperation(Operation *n) {
+  unsigned stvN = startTimeVariables[n];
+
+  // Get current state of the LP, and determine range of alternative times
+  // guaranteed to be feasible.
+  unsigned stN = getStartTime(stvN);
+  unsigned lbN = (unsigned)std::max<int>(asapTimes[stvN], stN - parameterT + 1);
+  unsigned ubN = (unsigned)std::min<int>(alapTimes[stvN], lbN + parameterT - 1);
+
+  LLVM_DEBUG(dbgs() << "Attempting to schedule at t=" << stN << ", or in ["
+                    << lbN << ", " << ubN << "]: " << *n << '\n');
+
+  SmallVector<unsigned> candTimes;
+  candTimes.push_back(stN);
+  for (unsigned ct = lbN; ct <= ubN; ++ct)
+    if (ct != stN)
+      candTimes.push_back(ct);
+
+  for (unsigned ct : candTimes)
+    if (succeeded(mrt.enter(n, ct))) {
+      assert(succeeded(scheduleAt(stvN, stN)));
+      LLVM_DEBUG(dbgs() << "Success at t=" << stN << " " << *n << '\n');
+      return;
+    }
+
+  // As a last resort, increase II to make room for the op. De Dinechin's
+  // Theorem 1 lays out conditions/guidelines to transform the current partial
+  // schedule for II to a valid one for a larger II'.
+
+  LLVM_DEBUG(dbgs() << "Incrementing II to " << (parameterT + 1)
+                    << " to resolve resource conflict for " << *n << '\n');
+
+  // Note that the approach below is much simpler than in the paper
+  // because of the fully-pipelined operators. In our case, it's always
+  // sufficient to increment the II by one.
+
+  // Decompose start time.
+  unsigned phiN = stN / parameterT;
+  unsigned tauN = stN % parameterT;
+
+  // Keep track whether the following moves free at least one operator
+  // instance in the slot desired by the current op - then it can stay there.
+  unsigned deltaN = 1;
+
+  // We're going to revisit the current partial schedule.
+  SmallVector<Operation *> moved;
+  for (Operation *j : scheduled) {
+    unsigned stvJ = startTimeVariables[j];
+    unsigned stJ = getStartTime(stvJ);
+    unsigned phiJ = stJ / parameterT;
+    unsigned tauJ = stJ % parameterT;
+    unsigned deltaJ = 0;
+
+    // To actually resolve the resource conflicts, we move operations that are
+    // "preceded" (cf. de Dinechin's ≺ relation) one slot to the right.
+    if (tauN < tauJ || (tauN == tauJ && phiN > phiJ) ||
+        (tauN == tauJ && phiN == phiJ && stvN < stvJ)) {
+      // TODO: Replace the last condition with a proper graph analysis.
+
+      deltaJ = 1;
+      moved.push_back(j);
+      if (tauN == tauJ)
+        deltaN = 0;
+    }
+
+    // Apply the move to the tableau.
+    moveBy(stvJ, deltaJ);
+  }
+
+  // Finally, increment the II.
+  incrementII();
+  assert(succeeded(solveTableau()));
+
+  // Re-enter moved operations into their new slots.
+  for (auto *m : moved)
+    mrt.release(m);
+  for (auto *m : moved)
+    assert(succeeded(mrt.enter(m, getStartTime(startTimeVariables[m]))));
+
+  // Finally, schedule the operation. Adding `phiN` accounts for the implicit
+  // shift caused by incrementing the II; cf. `incrementII()`.
+  assert(succeeded(scheduleAt(stvN, stN + phiN + deltaN)));
+  assert(succeeded(mrt.enter(n, tauN + deltaN)));
+}
+
+LogicalResult ModuloSimplexScheduler::schedule() {
+  parameterS = 0;
+  parameterT = 1;
+  buildTableau();
+  asapTimes.resize(startTimeLocations.size());
+  alapTimes.resize(startTimeLocations.size());
+
+  LLVM_DEBUG(dbgs() << "Initial tableau:\n"; dumpTableau());
+
+  if (failed(solveTableau()))
+    return prob.getContainingOp()->emitError() << "problem is infeasible";
+
+  // Determine which operations are subject to resource constraints.
+  auto &ops = prob.getOperations();
+  for (auto *op : ops)
+    if (isLimited(op, prob))
+      unscheduled.push_back(op);
+
+  // Main loop: Iteratively fix limited operations to time steps.
+  while (!unscheduled.empty()) {
+    // Update ASAP/ALAP times.
+    updateMargins();
+
+    // Heuristically (here: least amount of slack) pick the next operation to
+    // schedule.
+    auto *opIt =
+        std::min_element(unscheduled.begin(), unscheduled.end(),
+                         [&](Operation *opA, Operation *opB) {
+                           auto stvA = startTimeVariables[opA];
+                           auto stvB = startTimeVariables[opB];
+                           auto slackA = alapTimes[stvA] - asapTimes[stvA];
+                           auto slackB = alapTimes[stvB] - asapTimes[stvB];
+                           return slackA < slackB;
+                         });
+    Operation *op = *opIt;
+    unscheduled.erase(opIt);
+
+    scheduleOperation(op);
+    scheduled.push_back(op);
+  }
+
+  LLVM_DEBUG(dbgs() << "Final tableau:\n"; dumpTableau();
+             dbgs() << "Solution found with II = " << parameterT
+                    << " and start time of last operation = "
+                    << -getParametricConstant(0) << '\n');
+
+  prob.setInitiationInterval(parameterT);
+  for (auto *op : ops)
+    prob.setStartTime(op, getStartTime(startTimeVariables[op]));
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // Public API
 //===----------------------------------------------------------------------===//
 
@@ -865,5 +1120,6 @@ LogicalResult scheduling::scheduleSimplex(SharedOperatorsProblem &prob,
 
 LogicalResult scheduling::scheduleSimplex(ModuloProblem &prob,
                                           Operation *lastOp) {
-  return failure();
+  ModuloSimplexScheduler simplex(prob, lastOp);
+  return simplex.schedule();
 }

--- a/test/Scheduling/modulo-problems.mlir
+++ b/test/Scheduling/modulo-problems.mlir
@@ -1,8 +1,11 @@
 // RUN: circt-opt %s -test-modulo-problem -allow-unregistered-dialect
+// RUN: circt-opt %s -test-simplex-scheduler=with=ModuloProblem -allow-unregistered-dialect | FileCheck %s -check-prefix=SIMPLEX
 
+// SIMPLEX-LABEL: canis14_fig2
+// SIMPLEX-SAME: simplexInitiationInterval = 4
 func @canis14_fig2() attributes {
   problemInitiationInterval = 3,
-  auxdeps = [ [2,0,1], [3,4] ],
+  auxdeps = [ [3,0,1], [3,4] ],
   operatortypes = [
     { name = "mem_port", latency = 1, limit = 1 },
     { name = "add", latency = 1 }
@@ -11,9 +14,13 @@ func @canis14_fig2() attributes {
   %1 = "dummy.load_B"() { opr = "mem_port", problemStartTime = 0 } : () -> i32
   %2 = arith.addi %0, %1 { opr = "add", problemStartTime = 3 } : i32
   "dummy.store_A"(%2) { opr = "mem_port", problemStartTime = 4 } : (i32) -> ()
+  // SIMPLEX: return
+  // SIMPLEX-SAME: simplexStartTime = 4
   return { problemStartTime = 5 }
 }
 
+// SIMPLEX-LABEL: minII_feasible
+// SIMPLEX-SAME: simplexInitiationInterval = 4
 func @minII_feasible() attributes {
   problemInitiationInterval = 3,
   auxdeps = [ [6,1,5], [5,2,3], [6,7] ],
@@ -30,9 +37,13 @@ func @minII_feasible() attributes {
   %4 = arith.subi %3, %2 { opr = "sub", problemStartTime = 3 } : i32
   %5 = arith.subi %0, %4 { opr = "sub", problemStartTime = 7 } : i32
   %6 = arith.subi %4, %5 { opr = "sub", problemStartTime = 11 } : i32
+  // SIMPLEX: return
+  // SIMPLEX-SAME: simplexStartTime = 14
   return { problemStartTime = 14 }
 }
 
+// SIMPLEX-LABEL: minII_infeasible
+// SIMPLEX-SAME: simplexInitiationInterval = 4
 func @minII_infeasible() -> i32 attributes {
   problemInitiationInterval = 4,
   auxdeps = [ [0,1], [5,1,1] ],
@@ -46,5 +57,7 @@ func @minII_infeasible() -> i32 attributes {
   %3 = "dummy.op"(%1) { opr = "limited", problemStartTime = 3 } : (i32) -> i32
   %4 = "dummy.op"(%1) { opr = "limited", problemStartTime = 2 } : (i32) -> i32
   %5 = "dummy.mux"(%2, %3, %4) { opr = "unlimited", problemStartTime = 4 } : (i32, i32, i32) -> i32
+  // SIMPLEX: return
+  // SIMPLEX-SAME: simplexStartTime = 5
   return { opr = "unlimited", problemStartTime = 5 } %5 : i32
 }


### PR DESCRIPTION
This adds a heuristic modulo scheduler, based on the papers by de Dinechin, but a bit simpler, because our `ModuloProblem` per definition only contains fully-pipelined operators.

I think this algorithm makes a good reference/fall-back scheduler for us because it doesn't use backtracking (cannot get stuck!) and doesn't need a range of candidate IIs to be determined beforehand. The flip side of this approach is that it increases the II to resolve non-trivial resource conflicts.