### PR TITLE
[GrandCentral] Allow AugmentedGroundTypeAttr to annotate aggregate types

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -785,8 +785,8 @@ bool GrandCentralPass::traverseField(Attribute field, IntegerAttr id,
         FIRRTLType tpe = leafValue.getType().cast<FIRRTLType>();
         if (fieldID > tpe.getMaxFieldID()) {
           leafValue.getDefiningOp()->emitError()
-              << "subannotation with fieldID=" << fieldID << " to " << tpe
-              << " is invalid";
+              << "subannotation with fieldID=" << fieldID
+              << " is too large for type " << tpe;
           return false;
         }
 

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -803,7 +803,10 @@ bool GrandCentralPass::traverseField(Attribute field, IntegerAttr id,
                 unsigned index = bundle.getIndexForFieldID(fieldID);
                 tpe = bundle.getSubTypeByFieldID(fieldID);
                 fieldID -= bundle.getFieldID(index);
-                // TODO: Handle invalid field names somehow.
+                // FIXME: Invalid verilog names (e.g. "begin", "reg", .. ) will
+                // be renamed at ExportVerilog so the path constructed here
+                // might become invalid. We can use an inner name ref to encode
+                // a reference to a subfield.
                 path.append("." + Twine(bundle.getElement(index).name));
               })
               .Default([&](auto op) {

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -526,7 +526,7 @@ private:
   Optional<Attribute> fromAttr(Attribute attr);
 
   /// Mapping of ID to leaf ground type associated with that ID.
-  DenseMap<Attribute, Value> leafMap;
+  DenseMap<Attribute, FieldRef> leafMap;
 
   /// Mapping of ID to parent instance and module.  If this module is the top
   /// module, then the first tuple member will be None.
@@ -746,7 +746,9 @@ bool GrandCentralPass::traverseField(Attribute field, IntegerAttr id,
                                      VerbatimBuilder &path) {
   return TypeSwitch<Attribute, bool>(field)
       .Case<AugmentedGroundTypeAttr>([&](auto ground) {
-        Value leafValue = leafMap.lookup(ground.getID());
+        FieldRef fieldRef = leafMap.lookup(ground.getID());
+        Value leafValue = fieldRef.getValue();
+        unsigned fieldID = fieldRef.getFieldID();
         assert(leafValue && "leafValue not found");
 
         auto builder =
@@ -778,6 +780,36 @@ bool GrandCentralPass::traverseField(Attribute field, IntegerAttr id,
           path += getInnerRefTo(module, blockArg.getArgNumber());
         } else {
           path += getInnerRefTo(leafValue.getDefiningOp());
+        }
+
+        FIRRTLType tpe = leafValue.getType().cast<FIRRTLType>();
+        if (fieldID > tpe.getMaxFieldID()) {
+          leafValue.getDefiningOp()->emitError()
+              << "subannotation with fieldID=" << fieldID << " to " << tpe
+              << " is invalid";
+          return false;
+        }
+
+        // Construct a path given by fieldID.
+        while (fieldID) {
+          TypeSwitch<FIRRTLType>(tpe)
+              .template Case<FVectorType>([&](FVectorType vector) {
+                unsigned index = vector.getIndexForFieldID(fieldID);
+                tpe = vector.getSubTypeByFieldID(fieldID);
+                fieldID -= vector.getFieldID(index);
+                path.append("[" + Twine(index) + "]");
+              })
+              .template Case<BundleType>([&](BundleType bundle) {
+                unsigned index = bundle.getIndexForFieldID(fieldID);
+                tpe = bundle.getSubTypeByFieldID(fieldID);
+                fieldID -= bundle.getFieldID(index);
+                // TODO: Handle invalid field names somehow.
+                path.append("." + Twine(bundle.getElement(index).name));
+              })
+              .Default([&](auto op) {
+                llvm_unreachable(
+                    "fieldID > maxFieldID case must be already handled");
+              });
         }
 
         // Assemble the verbatim op.
@@ -838,9 +870,25 @@ Optional<TypeSum> GrandCentralPass::computeField(Attribute field,
       .Case<AugmentedGroundTypeAttr>(
           [&](AugmentedGroundTypeAttr ground) -> Optional<TypeSum> {
             // Traverse to generate mappings.
-            traverseField(field, id, path);
-            auto value = leafMap.lookup(ground.getID());
+            if (!traverseField(field, id, path))
+              return None;
+            auto fieldRef = leafMap.lookup(ground.getID());
+            auto value = fieldRef.getValue();
+            auto fieldID = fieldRef.getFieldID();
             auto tpe = value.getType().cast<FIRRTLType>();
+
+            // Set type to ground type.
+            while (fieldID) {
+              TypeSwitch<FIRRTLType>(tpe)
+                  .Case<FVectorType, BundleType>([&](auto aggregate) {
+                    unsigned index = aggregate.getIndexForFieldID(fieldID);
+                    tpe = aggregate.getSubTypeByFieldID(fieldID);
+                    fieldID -= aggregate.getFieldID(index);
+                  })
+                  .Default([&](auto op) {
+                    llvm_unreachable("must be handled by traverseField");
+                  });
+            }
             if (!tpe.isGround()) {
               value.getDefiningOp()->emitOpError()
                   << "cannot be added to interface with id '"
@@ -1195,7 +1243,8 @@ void GrandCentralPass::runOnOperation() {
             auto maybeID = getID(op, annotation);
             if (!maybeID)
               return false;
-            leafMap[maybeID.getValue()] = op.getResult();
+            leafMap[maybeID.getValue()] = {op.getResult(),
+                                           annotation.getFieldID()};
             return true;
           });
         })
@@ -1249,7 +1298,8 @@ void GrandCentralPass::runOnOperation() {
                 auto maybeID = getID(op, annotation);
                 if (!maybeID)
                   return false;
-                leafMap[maybeID.getValue()] = op.getArgument(i);
+                leafMap[maybeID.getValue()] = {op.getArgument(i),
+                                               annotation.getFieldID()};
 
                 return true;
               });
@@ -1431,20 +1481,27 @@ void GrandCentralPass::runOnOperation() {
     sort();
     llvm::dbgs() << "leafMap:\n";
     for (auto id : ids) {
-      auto value = leafMap.lookup(id);
+      auto fieldRef = leafMap.lookup(id);
+      auto value = fieldRef.getValue();
+      auto fieldID = fieldRef.getValue();
       if (auto blockArg = value.dyn_cast<BlockArgument>()) {
         FModuleOp module = cast<FModuleOp>(blockArg.getOwner()->getParentOp());
         llvm::dbgs() << "  - " << id.getValue() << ": "
                      << module.getName() + ">" +
-                            module.getPortName(blockArg.getArgNumber())
-                     << "\n";
-      } else
+                            module.getPortName(blockArg.getArgNumber());
+        if (fieldID)
+          llvm::dbgs() << ", fieldID=" << fieldID;
+        llvm::dbgs() << "\n";
+      } else {
         llvm::dbgs() << "  - " << id.getValue() << ": "
                      << value.getDefiningOp()
                             ->getAttr("name")
                             .cast<StringAttr>()
-                            .getValue()
-                     << "\n";
+                            .getValue();
+        if (fieldID)
+          llvm::dbgs() << ", fieldID=" << fieldID;
+        llvm::dbgs() << "\n";
+      }
     }
   });
 

--- a/test/Dialect/FIRRTL/grand-central-errors.mlir
+++ b/test/Dialect/FIRRTL/grand-central-errors.mlir
@@ -227,3 +227,42 @@ firrtl.circuit "multiInstance2" attributes {
   firrtl.nla @nla1 [@multiInstance1] ["dut"]
   firrtl.nla @nla2 [@multiInstance1] ["dut1"]
 }
+
+// -----
+
+firrtl.circuit "InvalidFieldID" attributes {
+  annotations = [
+    {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+     defName = "Foo",
+     elements = [
+       {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+        id = 1 : i64,
+        name = "foo"}],
+     id = 0 : i64}
+    ]} {
+  firrtl.module @View_companion() attributes {
+     annotations = [
+       {class = "sifive.enterprise.grandcentral.ViewAnnotation",
+        defName = "Foo",
+        id = 0 : i64,
+        name = "View",
+        type = "companion"}]} {}
+  firrtl.module @DUT() attributes {
+    annotations = [
+      {class = "sifive.enterprise.grandcentral.ViewAnnotation",
+       id = 0 : i64,
+       name = "view",
+       type = "parent"}
+    ]} {
+    // expected-error @+1 {{subannotation with fieldID=3 to '!firrtl.vector<uint<2>, 1>' is invalid}}
+    %a = firrtl.wire {
+      annotations = [
+        {a},
+        #firrtl.subAnno<fieldID = 3, {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+                        id = 1 : i64}>]} : !firrtl.vector<uint<2>, 1>
+    firrtl.instance View_companion @View_companion()
+  }
+  firrtl.module @InvalidFieldID() {
+    firrtl.instance dut @DUT()
+  }
+}

--- a/test/Dialect/FIRRTL/grand-central-errors.mlir
+++ b/test/Dialect/FIRRTL/grand-central-errors.mlir
@@ -254,7 +254,7 @@ firrtl.circuit "InvalidFieldID" attributes {
        name = "view",
        type = "parent"}
     ]} {
-    // expected-error @+1 {{subannotation with fieldID=3 to '!firrtl.vector<uint<2>, 1>' is invalid}}
+    // expected-error @+1 {{subannotation with fieldID=3 is too large for type '!firrtl.vector<uint<2>, 1>'}}
     %a = firrtl.wire {
       annotations = [
         {a},

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -12,7 +12,10 @@ firrtl.circuit "InterfaceGroundType" attributes {
        {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
         description = "multi\nline\ndescription\nof\nbar",
         name = "bar",
-        id = 2 : i64}],
+        id = 2 : i64},
+      {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+        name = "baz",
+        id = 3 : i64}],
      id = 0 : i64,
      name = "View"},
     {class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
@@ -40,6 +43,10 @@ firrtl.circuit "InterfaceGroundType" attributes {
       {a},
       {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
        id = 2 : i64}]} : !firrtl.uint<4>
+    %c = firrtl.wire  {annotations = [
+      {a},
+      #firrtl.subAnno<fieldID = 4, {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+                                    id = 3 : i64}>]} : !firrtl.vector<bundle<d: uint<2>>, 2>
     firrtl.instance View_companion @View_companion()
   }
   firrtl.module @InterfaceGroundType() {
@@ -63,6 +70,8 @@ firrtl.circuit "InterfaceGroundType" attributes {
 // CHECK-SAME: annotations = [{a}]
 // CHECK: %b = firrtl.wire
 // CHECK-SAME: annotations = [{a}]
+// CHECK: %c = firrtl.wire
+// CHECK-SAME: annotations = [{a}]
 
 // CHECK: firrtl.module @View_mapping
 // CHECK-SAME: output_file = #hw.output_file<"gct-dir/View_mapping.sv"
@@ -76,6 +85,11 @@ firrtl.circuit "InterfaceGroundType" attributes {
 // CHECK-SAME:   @InterfaceGroundType
 // CHECK-SAME:   #hw.innerNameRef<@InterfaceGroundType::@dut>
 // CHECK-SAME:   #hw.innerNameRef<@DUT::@b>
+// CHECK-NEXT: sv.verbatim "assign {{[{][{]0[}][}]}}.baz = {{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}.{{[{][{]3[}][}]}}[1].d;"
+// CHECK-SAME:   #hw.innerNameRef<@DUT::@__View_Foo__>
+// CHECK-SAME:   @InterfaceGroundType
+// CHECK-SAME:   #hw.innerNameRef<@InterfaceGroundType::@dut>
+// CHECK-SAME:   #hw.innerNameRef<@DUT::@c>]
 
 // CHECK: sv.interface {
 // CHECK-SAME: output_file = #hw.output_file<"gct-dir/Foo.sv"


### PR DESCRIPTION
This commit tries to annotate AugmentedGroundTypeAttr to non-ground
types. First, I changed the element type of leafMap to be FieldRef
so that we can annotate to subelements. And `computeField` and
`traverseField` are modified to traverse the path represented by `fieldID`.

Will close https://github.com/llvm/circt/issues/2377