### PR TITLE
[HW] Fix PortInfo construction to get the symbols. NFC

### DIFF
--- a/include/circt/Dialect/HW/HWOps.h
+++ b/include/circt/Dialect/HW/HWOps.h
@@ -162,6 +162,14 @@ LogicalResult checkParameterInContext(Attribute value, Operation *module,
                                       Operation *usingOp,
                                       bool disallowParamRefs = false);
 
+/// Return the symbol (if exists, else null) on the corresponding input port
+/// argument.
+StringAttr getArgSym(Operation *op, unsigned i);
+
+/// Return the symbol (if any, else null) on the corresponding output port
+/// argument.
+StringAttr getResultSym(Operation *op, unsigned i);
+
 /// This stores lookup tables to make manipulating and working with the IR more
 /// efficient.  There are two phases to this object: the "building" phase in
 /// which it is "write only" and then the "using" phase which is read-only (and


### PR DESCRIPTION
The `getModulePortInfo` was dropping the symbols, when constructing the `PortInfo`.
Parse the `hw.exportPort` to get the symbols on ports.
There is no client for this change right now.
The PR when we added the port symbols, (https://github.com/llvm/circt/commit/755ea04229cb26d86885c39fc0e9c1620149b4d5)