### PR TITLE
[MSFT] Refactor placement export to use hw::GlobalRefs.

### DIFF
--- a/include/circt/Dialect/MSFT/DeviceDB.h
+++ b/include/circt/Dialect/MSFT/DeviceDB.h
@@ -72,7 +72,7 @@ public:
   /// modeled in MLIR, the instance path within the MLIR instance is often
   /// necessary as most often the instance is an extern module.
   struct PlacedInstance {
-    RootedInstancePathAttr path;
+    ArrayAttr path;
     llvm::StringRef subpath;
     Operation *op;
   };

--- a/include/circt/Dialect/MSFT/ExportTcl.h
+++ b/include/circt/Dialect/MSFT/ExportTcl.h
@@ -33,11 +33,8 @@ namespace msft {
 class MSFTModuleOp;
 
 /// Export TCL for a specific hw module.
-mlir::LogicalResult exportQuartusTcl(MSFTModuleOp module, hw::SymbolCache &,
+mlir::LogicalResult exportQuartusTcl(MSFTModuleOp module,
                                      llvm::StringRef outputFile = "");
-
-/// Populate a SymbolCache to use during Tcl export.
-void populateSymbolCache(mlir::ModuleOp mod, hw::SymbolCache &);
 
 } // namespace msft
 } // namespace circt

--- a/lib/CAPI/Dialect/MSFT.cpp
+++ b/lib/CAPI/Dialect/MSFT.cpp
@@ -68,8 +68,7 @@ MlirLogicalResult
 circtMSFTPlacementDBAddPlacement(CirctMSFTPlacementDB self, MlirAttribute cLoc,
                                  CirctMSFTPlacedInstance cInst) {
   Attribute attr = unwrap(cLoc);
-  RootedInstancePathAttr path =
-      unwrap(cInst.path).cast<RootedInstancePathAttr>();
+  ArrayAttr path = unwrap(cInst.path).cast<ArrayAttr>();
   StringAttr subpath = StringAttr::get(
       attr.getContext(), StringRef(cInst.subpath, cInst.subpathLength));
   auto inst =

--- a/lib/Dialect/MSFT/DeviceDB.cpp
+++ b/lib/Dialect/MSFT/DeviceDB.cpp
@@ -117,23 +117,11 @@ size_t PlacementDB::addPlacements(FlatSymbolRefAttr rootMod,
   if (!globalRef)
     return 0;
 
-  // Build a RootedInstancePathAttr for the database.
-  FlatSymbolRefAttr rootModule;
-  SmallVector<StringAttr> path;
-  for (auto innerRef : globalRef.namepath().getAsRange<hw::InnerRefAttr>()) {
-    if (!rootModule) {
-      rootModule = FlatSymbolRefAttr::get(innerRef.getModule());
-      continue;
-    }
-
-    path.push_back(innerRef.getName());
-  }
-
-  auto instPath =
-      RootedInstancePathAttr::get(op->getContext(), rootModule, path);
+  ArrayAttr instPath = globalRef.namepath();
 
   // Filter out all paths which aren't related to this DB.
-  if (instPath.getRootModule() != rootMod)
+  auto rootInnerRef = instPath.getValue()[0].cast<hw::InnerRefAttr>();
+  if (rootInnerRef.getModule().getValue() != rootMod.getValue())
     return 0;
 
   size_t numFailed = 0;

--- a/test/Dialect/MSFT/translate-errors.mlir
+++ b/test/Dialect/MSFT/translate-errors.mlir
@@ -2,10 +2,14 @@
 
 hw.module.extern @Foo()
 
+// expected-error @+1 {{'hw.globalRef' op referenced non-existant PhysicalRegion named region1}}
+hw.globalRef @ref [#hw.innerNameRef<@top::@foo1>] {
+  "loc:" = #msft.physical_region_ref<@region1>
+}
+
 // expected-error @+1 {{Could not place 1 instances}}
 msft.module @top {} () -> () {
-  // expected-error @+1 {{PhysLoc attribute must be inside an instance switch attribute}}
-  msft.instance @foo1 @Foo() {"loc:" = #msft.physloc<DSP, 0, 0, 0> } : () -> ()
+  msft.instance @foo1 @Foo() {circt.globalRef = [#hw.globalNameRef<@ref>], inner_sym = "foo1"} : () -> ()
   msft.output
 }
 
@@ -13,20 +17,13 @@ msft.module @top {} () -> () {
 
 hw.module.extern @Foo()
 
-// expected-error @+1 {{Could not place 1 instances}}
-msft.module @top {} () -> () {
-  // expected-error @+1 {{'msft.instance' op referenced non-existant PhysicalRegion named region1}}
-  msft.instance @foo1 @Foo() {"loc" = #msft.switch.inst<@top[]=#msft.physical_region_ref<@region1>>} : () -> ()
-  msft.output
+// expected-error @+1 {{'hw.globalRef' op PhysLoc attributes must have names starting with 'loc'}}
+hw.globalRef @ref [#hw.innerNameRef<@top::@foo1>] {
+  "phys:" = #msft.physloc<DSP, 0, 0, 0>
 }
 
-// -----
-
-hw.module.extern @Foo()
-
 // expected-error @+1 {{Could not place 1 instances}}
 msft.module @top {} () -> () {
-  // expected-error @+1 {{'msft.instance' op PhysLoc attributes must have names starting with 'loc'}}
-  msft.instance @foo1 @Foo() {"phys:" = #msft.switch.inst< @top[] = #msft.physloc<DSP, 0, 0, 0> > } : () -> ()
+  msft.instance @foo1 @Foo() {circt.globalRef = [#hw.globalNameRef<@ref>], inner_sym = "foo1"} : () -> ()
   msft.output
 }


### PR DESCRIPTION
This refactors ExportQuartusTcl to use the hw::GlobalRefs and arrays
of hw::InnerRefAttrs directly. This greatly simplifies the
implementation, and removes the need for SwitchInstanceAttr. That
attribute will be fully removed in a follow up.