### PR TITLE
[MSFT] Remove SwitchInstanceAttr and RootedInstancePathAttr.

### DIFF
--- a/include/circt-c/Dialect/MSFT.h
+++ b/include/circt-c/Dialect/MSFT.h
@@ -48,25 +48,6 @@ MLIR_CAPI_EXPORTED uint64_t circtMSFTPhysLocationAttrGetX(MlirAttribute);
 MLIR_CAPI_EXPORTED uint64_t circtMSFTPhysLocationAttrGetY(MlirAttribute);
 MLIR_CAPI_EXPORTED uint64_t circtMSFTPhysLocationAttrGetNum(MlirAttribute);
 
-MLIR_CAPI_EXPORTED bool
-    circtMSFTAttributeIsARootedInstancePathAttribute(MlirAttribute);
-MLIR_CAPI_EXPORTED MlirAttribute
-circtMSFTRootedInstancePathAttrGet(MlirContext, MlirAttribute rootSym,
-                                   MlirAttribute *pathStringAttrs, size_t num);
-
-typedef struct {
-  MlirAttribute instance;
-  MlirAttribute attr;
-} CirctMSFTSwitchInstanceCase;
-
-MLIR_CAPI_EXPORTED bool
-    circtMSFTAttributeIsASwitchInstanceAttribute(MlirAttribute);
-MLIR_CAPI_EXPORTED MlirAttribute circtMSFTSwitchInstanceAttrGet(
-    MlirContext, CirctMSFTSwitchInstanceCase *listOfCases, size_t numCases);
-MLIR_CAPI_EXPORTED size_t circtMSFTSwitchInstanceAttrGetNumCases(MlirAttribute);
-MLIR_CAPI_EXPORTED void circtMSFTSwitchInstanceAttrGetCases(
-    MlirAttribute, CirctMSFTSwitchInstanceCase *dstArray, size_t space);
-
 MLIR_CAPI_EXPORTED MlirOperation circtMSFTGetInstance(MlirOperation root,
                                                       MlirAttribute path);
 

--- a/include/circt/Dialect/MSFT/MSFTAttributes.td
+++ b/include/circt/Dialect/MSFT/MSFTAttributes.td
@@ -25,29 +25,6 @@ class MSFT_Attr<string name, list<Trait> traits = [],
   let mnemonic = ?;
 }
 
-def RootedInstancePath : MSFT_Attr<"RootedInstancePath"> {
-  let summary = "A path through the instance hierarchy with the root module";
-  let parameters = (ins
-    "FlatSymbolRefAttr":$rootModule, ArrayRefParameter<"StringAttr">:$path);
-}
-
-def SwitchInstanceCase : MSFT_Attr<"SwitchInstanceCase"> {
-  let summary = "A switch case in the SwitchInstance attribute";
-  let parameters = (ins
-    "RootedInstancePathAttr":$inst, "mlir::Attribute":$attr);
-}
-
-def SwitchInstance : MSFT_Attr<"SwitchInstance"> {
-  let summary = "Select an attribute to be use based on the instance";
-  let mnemonic = "switch.inst";
-  let parameters = (ins
-    ArrayRefParameter<"SwitchInstanceCaseAttr">:$cases);
-
-  let extraClassDeclaration = [{
-    Attribute lookup(RootedInstancePathAttr);
-  }];
-}
-
 def PhysLocation : MSFT_Attr<"PhysLocation"> {
   let summary = "Descibes a physical location on a device";
   let description = [{

--- a/lib/Bindings/Python/MSFTModule.cpp
+++ b/lib/Bindings/Python/MSFTModule.cpp
@@ -158,50 +158,6 @@ void circt::python::populateDialectMSFTSubmodule(py::module &m) {
         return circtMSFTPhysLocationAttrGetNum(self);
       });
 
-  mlir_attribute_subclass(m, "RootedInstancePathAttr",
-                          circtMSFTAttributeIsARootedInstancePathAttribute)
-      .def_classmethod(
-          "get",
-          [](py::object cls, MlirAttribute rootSymbol,
-             std::vector<MlirAttribute> instancePath, MlirContext ctxt) {
-            return cls(circtMSFTRootedInstancePathAttrGet(
-                ctxt, rootSymbol, instancePath.data(), instancePath.size()));
-          },
-          "Create an rooted instance path attribute", py::arg(),
-          py::arg("root_symbol"), py::arg("instance_path"),
-          py::arg("ctxt") = py::none());
-
-  mlir_attribute_subclass(m, "SwitchInstanceAttr",
-                          circtMSFTAttributeIsASwitchInstanceAttribute)
-      .def_classmethod(
-          "get",
-          [](py::object cls,
-             std::vector<std::pair<MlirAttribute, MlirAttribute>> listOfCases,
-             MlirContext ctxt) {
-            std::vector<CirctMSFTSwitchInstanceCase> cases;
-            for (auto p : listOfCases)
-              cases.push_back({std::get<0>(p), std::get<1>(p)});
-            return cls(circtMSFTSwitchInstanceAttrGet(ctxt, cases.data(),
-                                                      cases.size()));
-          },
-          "Create an instance switch attribute", py::arg(),
-          py::arg("list_of_cases"), py::arg("ctxt") = py::none())
-      .def_property_readonly(
-          "cases",
-          [](MlirAttribute self) {
-            size_t numCases = circtMSFTSwitchInstanceAttrGetNumCases(self);
-            std::vector<CirctMSFTSwitchInstanceCase> cases(numCases);
-            circtMSFTSwitchInstanceAttrGetCases(self, cases.data(),
-                                                cases.max_size());
-            std::vector<std::pair<MlirAttribute, MlirAttribute>> pyCases;
-            for (auto c : cases)
-              pyCases.push_back(std::make_pair(c.instance, c.attr));
-            return pyCases;
-          })
-      .def_property_readonly("num_cases", [](MlirAttribute self) {
-        return circtMSFTSwitchInstanceAttrGetNumCases(self);
-      });
-
   mlir_attribute_subclass(m, "PhysicalBoundsAttr",
                           circtMSFTAttributeIsAPhysicalBoundsAttr)
       .def_classmethod(

--- a/lib/CAPI/Dialect/MSFT.cpp
+++ b/lib/CAPI/Dialect/MSFT.cpp
@@ -169,56 +169,6 @@ uint64_t circtMSFTPhysLocationAttrGetNum(MlirAttribute attr) {
   return (CirctMSFTPrimitiveType)unwrap(attr).cast<PhysLocationAttr>().getNum();
 }
 
-bool circtMSFTAttributeIsARootedInstancePathAttribute(MlirAttribute cAttr) {
-  return unwrap(cAttr).isa<RootedInstancePathAttr>();
-}
-MlirAttribute
-circtMSFTRootedInstancePathAttrGet(MlirContext cCtxt, MlirAttribute cRootSym,
-                                   MlirAttribute *cPathStringAttrs,
-                                   size_t num) {
-  auto ctxt = unwrap(cCtxt);
-  auto rootSym = unwrap(cRootSym).cast<FlatSymbolRefAttr>();
-  SmallVector<StringAttr, 16> path;
-  for (size_t i = 0; i < num; ++i)
-    path.push_back(unwrap(cPathStringAttrs[i]).cast<StringAttr>());
-  return wrap(RootedInstancePathAttr::get(ctxt, rootSym, path));
-}
-
-bool circtMSFTAttributeIsASwitchInstanceAttribute(MlirAttribute attr) {
-  return unwrap(attr).isa<SwitchInstanceAttr>();
-}
-MlirAttribute
-circtMSFTSwitchInstanceAttrGet(MlirContext cCtxt,
-                               CirctMSFTSwitchInstanceCase *listOfCases,
-                               size_t numCases) {
-  MLIRContext *ctxt = unwrap(cCtxt);
-  SmallVector<SwitchInstanceCaseAttr, 64> cases;
-  for (size_t i = 0; i < numCases; ++i) {
-    CirctMSFTSwitchInstanceCase pair = listOfCases[i];
-    Attribute instanceAttr = unwrap(pair.instance);
-    auto instance = instanceAttr.dyn_cast<RootedInstancePathAttr>();
-    assert(instance &&
-           "Expected `RootedInstancePathAttr` in switch instance case.");
-    auto attr = unwrap(pair.attr);
-    cases.push_back(SwitchInstanceCaseAttr::get(ctxt, instance, attr));
-  }
-  return wrap(SwitchInstanceAttr::get(ctxt, cases));
-}
-size_t circtMSFTSwitchInstanceAttrGetNumCases(MlirAttribute attr) {
-  return unwrap(attr).cast<SwitchInstanceAttr>().getCases().size();
-}
-void circtMSFTSwitchInstanceAttrGetCases(MlirAttribute attr,
-                                         CirctMSFTSwitchInstanceCase *dstArray,
-                                         size_t space) {
-  auto sw = unwrap(attr).cast<SwitchInstanceAttr>();
-  ArrayRef<SwitchInstanceCaseAttr> cases = sw.getCases();
-  assert(space >= cases.size());
-  for (size_t i = 0, e = cases.size(); i < e; ++i) {
-    auto c = cases[i];
-    dstArray[i] = {wrap(c.getInst()), wrap(c.getAttr())};
-  }
-}
-
 bool circtMSFTAttributeIsAPhysicalBoundsAttr(MlirAttribute attr) {
   return unwrap(attr).isa<PhysicalBoundsAttr>();
 }


### PR DESCRIPTION
These attributes and their use cases are now replaced by
hw::GlobalRefOp and hw::InnerRefAttr, respectively.