### PR TITLE
[ExportVerilog] Make `hoistNonSideEffectExpr` hoist inout chains

### DIFF
--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -311,7 +311,8 @@ static bool rewriteSideEffectingExpr(Operation *op) {
 static bool hoistNonSideEffectExpr(Operation *op) {
   // Never hoist "always inline" expressions - they will never generate a
   // temporary and in fact must always be emitted inline.
-  if (isExpressionAlwaysInline(op) && !isa<sv::ReadInOutOp>(op))
+  if (isExpressionAlwaysInline(op) &&
+      !isa<sv::ReadInOutOp, sv::ArrayIndexInOutOp, sv::StructFieldInOutOp>(op))
     return false;
 
   // Scan to the top of the region tree to find out where to move the op.

--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -309,36 +309,15 @@ static bool rewriteSideEffectingExpr(Operation *op) {
 /// non-constant expressions out to the top level so they don't turn into local
 /// variable declarations.
 static bool hoistNonSideEffectExpr(Operation *op) {
-  // Never hoist "always inline" expressions - they will never generate a
-  // temporary and in fact must always be emitted inline.
-  if (isExpressionAlwaysInline(op) && !isa<sv::ReadInOutOp>(op))
+  // Never hoist "always inline" expressions except for inout stuffs - they will
+  // never generate a temporary and in fact must always be emitted inline.
+  if (isExpressionAlwaysInline(op) &&
+      !(isa<sv::ReadInOutOp>(op) ||
+        op->getResult(0).getType().isa<hw::InOutType>()))
     return false;
 
   // Scan to the top of the region tree to find out where to move the op.
   Operation *parentOp = findParentInNonProceduralRegion(op);
-
-  // If op is a read_inout, we have to hoist the inout chains at the same time
-  // so handle read_inout specially.
-  if (isa<sv::ReadInOutOp>(op)) {
-    std::function<void(Operation *)> moveBefore = [&](Operation *op) {
-      if (!isa_and_nonnull<sv::ArrayIndexInOutOp, sv::IndexedPartSelectInOutOp,
-                           sv::StructFieldInOutOp, sv::ReadInOutOp>(op))
-        return;
-
-      // If op is already in a nonprocedural region, it's ok.
-      if (!op->getParentOp()->hasTrait<ProceduralRegion>())
-        return;
-
-      // We recursively hoist the operands first.
-      llvm::for_each(op->getOperands(), [&](Value operand) {
-        moveBefore(operand.getDefiningOp());
-      });
-
-      op->moveBefore(parentOp);
-    };
-    moveBefore(op);
-    return true;
-  }
 
   // We can typically hoist all the way out to the top level in one step, but
   // there may be intermediate operands that aren't hoistable.  If so, just


### PR DESCRIPTION
This commit fixes the crash of disallowLocalVars mode for the IR with
array_index_inout/struct_field_inout and sv.read_inout, for example: 
```mlir
// circt-opt --lowering-options=disallowLocalVariables --export-verilog
hw.module @Foo(%clock: i1) {
    %false = hw.constant false
    %c0_i16 = hw.constant 0 : i16
    %status_regs = sv.reg : !hw.inout<array<1xi32>>
    sv.always posedge %clock  {
      %0 = sv.array_index_inout %status_regs[%false] : !hw.inout<array<1xi32>>, i1
      %1 = sv.read_inout %0 : !hw.inout<i32>
      %2 = comb.extract %1 from 0 : (i32) -> i16
      %3 = comb.concat %c0_i16, %2 : i16, i16
      sv.passign %0, %3 : i32
    }
}
```  

Currently `hoistNonSideEffectExpr` doesn't hoist inouts
 because they are considered to be lvalues
(hence `%0` in the example is not hoisted).
This is true only if they are not read. The values read from them are 
not hoisted since their operands (array_index_inout/struct_field_inout) 
are not hoisted. Therefore we have to hoist array_index_inout/struct_field_inout 
as well as read_inout op.

Will close https://github.com/llvm/circt/issues/2404.