### PR TITLE
[ExportVerilog] Add IndexedPartSelectInoutOp to `isExpressionAlwaysInline`

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
+++ b/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
@@ -222,7 +222,7 @@ struct SharedEmitterState {
 static inline bool isExpressionAlwaysInline(Operation *op) {
   // We need to emit array indexes inline per verilog "lvalue" semantics.
   if (isa<sv::ArrayIndexInOutOp>(op) || isa<sv::StructFieldInOutOp>(op) ||
-      isa<sv::ReadInOutOp>(op))
+      isa<sv::IndexedPartSelectInOutOp>(op) || isa<sv::ReadInOutOp>(op))
     return true;
 
   // An SV interface modport is a symbolic name that is always inlined.

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -445,6 +445,19 @@ hw.module @struct_field_inout2(%a: !hw.inout<struct<b: !hw.struct<c: i1>>>) {
   sv.assign %1, %true : i1
 }
 
+// CHECK-LABEL: module PartSelectInoutInline(
+hw.module @PartSelectInoutInline(%v:i40) {
+  %r = sv.reg : !hw.inout<i42>
+  %c2_i3 = hw.constant 2 : i3
+  %a = sv.indexed_part_select_inout %r[%c2_i3 : 40] : !hw.inout<i42>, i3
+  // CHECK:      localparam [2:0] _T = 3'h2;
+  // CHECK-NEXT: initial
+  // CHECK-NEXT:   r[_T +: 40] = v;
+  sv.initial {
+    sv.bpassign %a, %v : i40
+  }
+}
+
 // CHECK-LABEL: module AggregateConstantXZ(
 hw.module @AggregateConstantXZ() -> (res1: !hw.struct<foo: i2, bar: !hw.array<3xi4>>,
                                      res2: !hw.struct<foo: i2, bar: !hw.array<3xi4>>) {


### PR DESCRIPTION
This commit adds IndexedPartSelectInoutOp to `isExpressionAlwaysInline`
which was missing.

