### PR TITLE
[SV] Allow verbatim to have non-integer type

### DIFF
--- a/include/circt/Dialect/SV/SVExpressions.td
+++ b/include/circt/Dialect/SV/SVExpressions.td
@@ -12,7 +12,7 @@
 
 include "mlir/Interfaces/InferTypeOpInterface.td"
 
-def AnySignlessIntegerOrInOutType : AnyTypeOf<[AnySignlessInteger, InOutType]>;
+def HWValueOrInOutType : AnyTypeOf<[HWValueType, InOutType]>;
 def HasCustomSSAName : DeclareOpInterfaceMethods<OpAsmOpInterface,
                          ["getAsmResultNames"]>;
 
@@ -32,7 +32,7 @@ def VerbatimExprOp : SVOp<"verbatim.expr", [NoSideEffect, HasCustomSSAName]> {
 
   let arguments = (ins StrAttr:$string, Variadic<AnyType>:$operands,
                   DefaultValuedAttr<NameRefArrayAttr,"{}">:$symbols);
-  let results = (outs AnyType:$result);
+  let results = (outs HWValueOrInOutType:$result);
   let assemblyFormat = [{
     $string (`(` $operands^ `)`)?
       `:` functional-type($operands, $result) attr-dict 
@@ -68,7 +68,7 @@ def VerbatimExprSEOp : SVOp<"verbatim.expr.se", [HasCustomSSAName]> {
 
   let arguments = (ins StrAttr:$string, Variadic<AnyType>:$operands,
                  DefaultValuedAttr<NameRefArrayAttr,"{}">:$symbols );
-  let results = (outs AnyType:$result);
+  let results = (outs HWValueOrInOutType:$result);
   let assemblyFormat = [{
     $string (`(` $operands^ `)`)?
       `:` functional-type($operands, $result) attr-dict 

--- a/include/circt/Dialect/SV/SVExpressions.td
+++ b/include/circt/Dialect/SV/SVExpressions.td
@@ -32,7 +32,7 @@ def VerbatimExprOp : SVOp<"verbatim.expr", [NoSideEffect, HasCustomSSAName]> {
 
   let arguments = (ins StrAttr:$string, Variadic<AnyType>:$operands,
                   DefaultValuedAttr<NameRefArrayAttr,"{}">:$symbols);
-  let results = (outs AnySignlessIntegerOrInOutType:$result);
+  let results = (outs AnyType:$result);
   let assemblyFormat = [{
     $string (`(` $operands^ `)`)?
       `:` functional-type($operands, $result) attr-dict 
@@ -68,7 +68,7 @@ def VerbatimExprSEOp : SVOp<"verbatim.expr.se", [HasCustomSSAName]> {
 
   let arguments = (ins StrAttr:$string, Variadic<AnyType>:$operands,
                  DefaultValuedAttr<NameRefArrayAttr,"{}">:$symbols );
-  let results = (outs AnySignlessIntegerOrInOutType:$result);
+  let results = (outs AnyType:$result);
   let assemblyFormat = [{
     $string (`(` $operands^ `)`)?
       `:` functional-type($operands, $result) attr-dict 

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -456,12 +456,14 @@ hw.module @AggregateConstantXZ() -> (res1: !hw.struct<foo: i2, bar: !hw.array<3x
 }
 
 // CHECK-LABEL: module AggregateVerbatim(
-hw.module @AggregateVerbatim() -> (res1: !hw.struct<a: i1>, res2: !hw.array<1xi1>) {
+hw.module @AggregateVerbatim() -> (res1: !hw.struct<a: i1>, res2: !hw.array<1xi1>, res3: !hw.array<1xi1>) {
   %a = sv.verbatim.expr "STRUCT_A_" : () -> !hw.struct<a: i1>
   %b = sv.verbatim.expr "ARRAY_" : () -> !hw.array<1xi1>
-  hw.output %a, %b: !hw.struct<a: i1>, !hw.array<1xi1>
+  %c = sv.verbatim.expr "MACRO({{0}}, {{1}})" (%a, %b) : (!hw.struct<a: i1>, !hw.array<1xi1>) -> !hw.array<1xi1>
+  hw.output %a, %b, %c: !hw.struct<a: i1>, !hw.array<1xi1>, !hw.array<1xi1>
   // CHECK: assign res1 = STRUCT_A_;
   // CHECK: assign res2 = ARRAY_;
+  // CHECK: assign res3 = MACRO(STRUCT_A_, ARRAY_);
 }
 
 // CHECK-LABEL: issue508

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -455,6 +455,15 @@ hw.module @AggregateConstantXZ() -> (res1: !hw.struct<foo: i2, bar: !hw.array<3x
   hw.output %0, %1 : !hw.struct<foo: i2, bar: !hw.array<3xi4>>, !hw.struct<foo: i2, bar: !hw.array<3xi4>>
 }
 
+// CHECK-LABEL: module AggegateVerbatim(
+hw.module @AggegateVerbatim() -> (res1: !hw.struct<a: i1>, res2: !hw.array<1xi1>) {
+  %a = sv.verbatim.expr "STRUCT_A_" : () -> !hw.struct<a: i1>
+  %b = sv.verbatim.expr "ARRAY_" : () -> !hw.array<1xi1>
+  hw.output %a, %b: !hw.struct<a: i1>, !hw.array<1xi1>
+  // CHECK: assign res1 = STRUCT_A_;
+  // CHECK: assign res2 = ARRAY_;
+}
+
 // CHECK-LABEL: issue508
 // https://github.com/llvm/circt/issues/508
 hw.module @issue508(%in1: i1, %in2: i1) {

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -455,8 +455,8 @@ hw.module @AggregateConstantXZ() -> (res1: !hw.struct<foo: i2, bar: !hw.array<3x
   hw.output %0, %1 : !hw.struct<foo: i2, bar: !hw.array<3xi4>>, !hw.struct<foo: i2, bar: !hw.array<3xi4>>
 }
 
-// CHECK-LABEL: module AggegateVerbatim(
-hw.module @AggegateVerbatim() -> (res1: !hw.struct<a: i1>, res2: !hw.array<1xi1>) {
+// CHECK-LABEL: module AggregateVerbatim(
+hw.module @AggregateVerbatim() -> (res1: !hw.struct<a: i1>, res2: !hw.array<1xi1>) {
   %a = sv.verbatim.expr "STRUCT_A_" : () -> !hw.struct<a: i1>
   %b = sv.verbatim.expr "ARRAY_" : () -> !hw.array<1xi1>
   hw.output %a, %b: !hw.struct<a: i1>, !hw.array<1xi1>


### PR DESCRIPTION
In aggregate preservation mode, GrandCentral may create VerbatimExpr ops
with aggregate types. This commit allows verbatim to have non-integer type.
I think it is not necessary to limit verbatim to have integer types. 