### PR TITLE
[FIRRTL] Add ParamDeclAttr, use for FExtModule

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
@@ -141,4 +141,52 @@ def AugmentedDeletedType : AugmentedType<"AugmentedDeletedType"> {
   let extraClassDeclaration = hasName;
 }
 
+
+/// An attribute describing a module parameter, or instance parameter
+/// specification.
+def ParamDeclAttr : AttrDef<FIRRTLDialect, "ParamDecl"> {
+  let summary = "module or instance parameter definition";
+
+  /// The value of the attribute - in a module, this is the default
+  /// value (and may be missing).  In an instance, this is a required field that
+  /// specifies the value being passed.  The verilog emitter omits printing the
+  /// parameter for an instance when the applied value and the default value are
+  /// the same.
+  let parameters = (ins "::mlir::StringAttr":$name,
+                        "::mlir::TypeAttr":$type,
+                        "::mlir::Attribute":$value);
+  let mnemonic = "param.decl";
+
+  let builders = [
+    AttrBuilderWithInferredContext<(ins "::mlir::StringAttr":$name,
+                                         "::mlir::Type":$type),
+      "auto *context = type.getContext();\n"
+      "return $_get(context, name, TypeAttr::get(type), Attribute());">,
+    AttrBuilderWithInferredContext<(ins "::mlir::StringRef":$name,
+                                         "::mlir::Type":$type),
+      "return get(StringAttr::get(type.getContext(), name), type);">,
+
+    AttrBuilderWithInferredContext<(ins "::mlir::StringAttr":$name,
+                                        "::mlir::Attribute":$value),
+      "auto *context = value.getContext();\n"
+      "return $_get(context, name, TypeAttr::get(value.getType()), value);">,
+    AttrBuilderWithInferredContext<(ins "::mlir::StringRef":$name,
+                                        "::mlir::Attribute":$value),
+      "return get(StringAttr::get(value.getContext(), name), value);">
+  ];
+
+  let extraClassDeclaration = [{
+    static ParamDeclAttr getWithName(ParamDeclAttr param,
+                                     ::mlir::StringAttr name) {
+      return get(param.getContext(), name, param.getType(), param.getValue());
+    }
+  }];
+}
+
+/// An array of ParamDeclAttr's that may or may not have a 'value' specified,
+/// to be used on hw.module or hw.instance.  The hw.instance verifier further
+/// ensures that all the values are specified.
+def ParamDeclArrayAttr
+  : TypedArrayAttrBase<ParamDeclAttr, "parameter array attribute">;
+
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLATTRIBUTES_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -114,8 +114,8 @@ def FExtModuleOp : FIRRTLOp<"extmodule",
   }];
   let arguments = (ins
                    OptionalAttr<StrAttr>:$defname,
-                   OptionalAttr<DictionaryAttr>:$parameters,
-                   DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations
+                   ParamDeclArrayAttr:$parameters,
+                   DefaultValuedAttr<AnnotationArrayAttr, "ArrayAttr()">:$annotations
                   );
   let results = (outs);
   let regions = (region AnyRegion:$body);
@@ -125,7 +125,8 @@ def FExtModuleOp : FIRRTLOp<"extmodule",
     OpBuilder<(ins "StringAttr":$name,
                       "ArrayRef<PortInfo>":$ports,
                       CArg<"StringRef", "StringRef()">:$defnamAttr,
-                      CArg<"ArrayAttr", "ArrayAttr()">:$annotations)>
+                      CArg<"ArrayAttr", "ArrayAttr()">:$annotations,
+                      CArg<"ArrayAttr", "ArrayAttr()">:$parameters)>
   ];
 
   let printer = "return ::print$cppClass(p, *this);";

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -798,8 +798,9 @@ LogicalResult FIRRTLModuleLowering::lowerPorts(
 /// representation for parameters.  If `ignoreValues` is true, all the values
 /// are dropped.
 static ArrayAttr getHWParameters(FExtModuleOp module, bool ignoreValues) {
-  auto paramsOptional = module.parameters();
-  if (!paramsOptional.hasValue())
+  auto params = llvm::map_range(
+      module.parameters(), [](Attribute a) { return a.cast<ParamDeclAttr>(); });
+  if (params.empty())
     return {};
 
   Builder builder(module);
@@ -808,7 +809,7 @@ static ArrayAttr getHWParameters(FExtModuleOp module, bool ignoreValues) {
   // directly.  MLIR's DictionaryAttr always stores keys in the dictionary
   // in sorted order which is nicely stable.
   SmallVector<Attribute> newParams;
-  for (const NamedAttribute &entry : paramsOptional.getValue()) {
+  for (const ParamDeclAttr &entry : params) {
     auto name = entry.getName();
     auto type = TypeAttr::get(entry.getValue().getType());
     auto value = ignoreValues ? Attribute() : entry.getValue();

--- a/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
@@ -111,3 +111,19 @@ void FIRRTLDialect::registerAttributes() {
 #include "circt/Dialect/FIRRTL/FIRRTLAttributes.cpp.inc"
       >();
 }
+
+//===----------------------------------------------------------------------===//
+// ParamDeclAttr
+//===----------------------------------------------------------------------===//
+
+Attribute ParamDeclAttr::parse(AsmParser &p, Type type) {
+  llvm::errs() << "Should never parse raw\n";
+  abort();
+}
+
+void ParamDeclAttr::print(AsmPrinter &p) const {
+  p << "<" << getName() << ": " << getType();
+  if (getValue())
+    p << " = " << getValue();
+  p << ">";
+}

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -278,7 +278,7 @@ static LogicalResult verifyCircuitOp(CircuitOp circuit) {
     FExtModuleOp collidingExtModule;
     if (auto &value = defnameMap[defname]) {
       collidingExtModule = value;
-      if (value.parameters() && !extModule.parameters())
+      if (!value.parameters().empty() && extModule.parameters().empty())
         value = extModule;
     } else {
       value = extModule;
@@ -311,7 +311,8 @@ static LogicalResult verifyCircuitOp(CircuitOp circuit) {
       StringAttr aName = std::get<0>(p).name, bName = std::get<1>(p).name;
       FIRRTLType aType = std::get<0>(p).type, bType = std::get<1>(p).type;
 
-      if (extModule.parameters() || collidingExtModule.parameters()) {
+      if (!extModule.parameters().empty() ||
+          !collidingExtModule.parameters().empty()) {
         aType = aType.getWidthlessType();
         bType = bType.getWidthlessType();
       }
@@ -576,10 +577,13 @@ void FModuleOp::build(OpBuilder &builder, OperationState &result,
 
 void FExtModuleOp::build(OpBuilder &builder, OperationState &result,
                          StringAttr name, ArrayRef<PortInfo> ports,
-                         StringRef defnameAttr, ArrayAttr annotations) {
+                         StringRef defnameAttr, ArrayAttr annotations,
+                         ArrayAttr parameters) {
   buildModule(builder, result, name, ports, annotations);
   if (!defnameAttr.empty())
     result.addAttribute("defname", builder.getStringAttr(defnameAttr));
+  if (!parameters)
+    result.addAttribute("parameters", builder.getArrayAttr({}));
 }
 
 /// Print a list of module ports in the following form:
@@ -734,10 +738,30 @@ parseModulePorts(OpAsmParser &parser, bool hasSSAIdentifiers,
                                         parseArgument);
 }
 
+/// Print a paramter list for a module or instance.
+static void printParameterList(ArrayAttr parameters, OpAsmPrinter &p) {
+  if (!parameters || parameters.empty())
+    return;
+
+  p << '<';
+  llvm::interleaveComma(parameters, p, [&](Attribute param) {
+    auto paramAttr = param.cast<ParamDeclAttr>();
+    p << paramAttr.getName().getValue() << ": " << paramAttr.getType();
+    if (auto value = paramAttr.getValue()) {
+      p << " = ";
+      p.printAttributeWithoutType(value);
+    }
+  });
+  p << '>';
+}
+
 static void printFModuleLikeOp(OpAsmPrinter &p, FModuleLike op) {
   // Print the operation and the function name.
   p << " ";
   p.printSymbolName(op.moduleName());
+
+  // Print the parameter list (if non-empty).
+  printParameterList(op->getAttrOfType<ArrayAttr>("parameters"), p);
 
   // Both modules and external modules have a body, but it is always empty for
   // external modules.
@@ -751,8 +775,9 @@ static void printFModuleLikeOp(OpAsmPrinter &p, FModuleLike op) {
       p, body, portDirections, op.getPortNames(), op.getPortTypes(),
       op.getPortAnnotations(), op.getPortSymbols());
 
-  SmallVector<StringRef, 4> omittedAttrs = {
-      "sym_name", "portDirections", "portTypes", "portAnnotations", "portSyms"};
+  SmallVector<StringRef, 4> omittedAttrs = {"sym_name",  "portDirections",
+                                            "portTypes", "portAnnotations",
+                                            "portSyms",  "parameters"};
 
   // We can omit the portNames if they were able to be printed as properly as
   // block arguments.
@@ -782,6 +807,38 @@ static void printFModuleOp(OpAsmPrinter &p, FModuleOp op) {
                   /*printBlockTerminators=*/true);
 }
 
+/// Parse an parameter list if present.
+/// module-parameter-list ::= `<` parameter-decl (`,` parameter-decl)* `>`
+/// parameter-decl ::= identifier `:` type
+/// parameter-decl ::= identifier `:` type `=` attribute
+///
+static ParseResult
+parseOptionalParameters(OpAsmParser &parser,
+                        SmallVectorImpl<Attribute> &parameters) {
+
+  return parser.parseCommaSeparatedList(
+      OpAsmParser::Delimiter::OptionalLessGreater, [&]() {
+        std::string name;
+        Type type;
+        Attribute value;
+
+        if (parser.parseKeywordOrString(&name) || parser.parseColonType(type))
+          return failure();
+
+        // Parse the default value if present.
+        if (succeeded(parser.parseOptionalEqual())) {
+          if (parser.parseAttribute(value, type))
+            return failure();
+        }
+
+        auto &builder = parser.getBuilder();
+        parameters.push_back(ParamDeclAttr::get(builder.getContext(),
+                                                builder.getStringAttr(name),
+                                                TypeAttr::get(type), value));
+        return success();
+      });
+}
+
 static ParseResult parseFModuleLikeOp(OpAsmParser &parser,
                                       OperationState &result,
                                       bool hasSSAIdentifiers) {
@@ -793,6 +850,12 @@ static ParseResult parseFModuleLikeOp(OpAsmParser &parser,
   if (parser.parseSymbolName(nameAttr, ::mlir::SymbolTable::getSymbolAttrName(),
                              result.attributes))
     return failure();
+
+  // Parse optional parameters.
+  SmallVector<Attribute, 4> parameters;
+  if (parseOptionalParameters(parser, parameters))
+    return failure();
+  result.addAttribute("parameters", builder.getArrayAttr(parameters));
 
   // Parse the module ports.
   SmallVector<OpAsmParser::OperandType> entryArgs;
@@ -882,22 +945,22 @@ static ParseResult parseFExtModuleOp(OpAsmParser &parser,
 }
 
 static LogicalResult verifyFExtModuleOp(FExtModuleOp op) {
-  auto paramDictOpt = op.parameters();
-  if (!paramDictOpt)
+  auto params = op.parameters();
+  if (params.empty())
     return success();
 
-  DictionaryAttr paramDict = paramDictOpt.getValue();
-  auto checkParmValue = [&](NamedAttribute elt) -> bool {
-    auto value = elt.getValue();
+  auto checkParmValue = [&](Attribute elt) -> bool {
+    auto param = elt.cast<ParamDeclAttr>();
+    auto value = param.getValue();
     if (value.isa<IntegerAttr>() || value.isa<StringAttr>() ||
         value.isa<FloatAttr>())
       return true;
     op.emitError() << "has unknown extmodule parameter value '"
-                   << elt.getName().getValue() << "' = " << value;
+                   << param.getName().getValue() << "' = " << value;
     return false;
   };
 
-  if (!llvm::all_of(paramDict, checkParmValue))
+  if (!llvm::all_of(params, checkParmValue))
     return failure();
 
   return success();

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3439,7 +3439,7 @@ ParseResult FIRCircuitParser::parseModule(CircuitOp circuit,
       return failure();
   }
 
-  NamedAttrList parameters;
+  SmallVector<Attribute> parameters;
   SmallPtrSet<StringAttr, 8> seenNames;
 
   // Parse the parameter list.
@@ -3497,15 +3497,13 @@ ParseResult FIRCircuitParser::parseModule(CircuitOp circuit,
     auto nameId = builder.getIdentifier(paramName);
     if (!seenNames.insert(nameId).second)
       return emitError(loc, "redefinition of parameter '" + paramName + "'");
-    parameters.append(nameId, value);
+    parameters.push_back(ParamDeclAttr::get(nameId, value));
   }
 
   auto fmodule = builder.create<FExtModuleOp>(info.getLoc(), name, portList,
                                               defName, annotations);
 
-  if (!parameters.empty())
-    fmodule->setAttr("parameters",
-                     DictionaryAttr::get(getContext(), parameters));
+  fmodule->setAttr("parameters", builder.getArrayAttr(parameters));
 
   return success();
 }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
@@ -13,12 +13,13 @@ firrtl.circuit "Simple" {
    // CHECK-SAME: <DEFAULT: i64, DEPTH: f64, FORMAT: none, WIDTH: i8>
    // CHECK-SAME: (%in: i1) -> (out: i8)
    // CHECK: attributes {verilogName = "name_thing"}
-   firrtl.extmodule @MyParameterizedExtModule(in in: !firrtl.uint<1>, out out: !firrtl.uint<8>)
-      attributes {defname = "name_thing",
-                  parameters = {DEFAULT = 0 : i64,
-                                DEPTH = 3.242000e+01 : f64,
-                                FORMAT = "xyz_timeout=%d\0A",
-                                WIDTH = 32 : i8}}
+   firrtl.extmodule @MyParameterizedExtModule
+     <DEFAULT: i64 = 0,
+      DEPTH: f64 = 3.242000e+01,
+      FORMAT: none = "xyz_timeout=%d\0A",
+      WIDTH: i8 = 32>
+    (in in: !firrtl.uint<1>, out out: !firrtl.uint<8>)
+    attributes {defname = "name_thing"}
 
    // CHECK-LABEL: hw.module @Simple(%in1: i4, %in2: i2, %in3: i8) -> (out4: i4)
    firrtl.module @Simple(in %in1: !firrtl.uint<4>,

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -304,7 +304,7 @@ firrtl.circuit "Foo" {
     // CHECK-NEXT: reg dummyReg : UInt<42>, [[INV]]
   }
 
-  firrtl.extmodule @MyParameterizedExtModule(in in: !firrtl.uint, out out: !firrtl.uint<8>) attributes {defname = "name_thing", parameters = {DEFAULT = 0 : i64, DEPTH = 3.242000e+01 : f64, FORMAT = "xyz_timeout=%d\0A", WIDTH = 32 : i8}}
+  firrtl.extmodule @MyParameterizedExtModule<DEFAULT: i64 = 0, DEPTH: f64 = 3.242000e+01, FORMAT: none = "xyz_timeout=%d\0A", WIDTH: i8 = 32>(in in: !firrtl.uint, out out: !firrtl.uint<8>) attributes {defname = "name_thing"}
   // CHECK-LABEL: extmodule MyParameterizedExtModule :
   // CHECK-NEXT:    input in : UInt
   // CHECK-NEXT:    output out : UInt<8>

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -228,7 +228,7 @@ firrtl.circuit "Foo" {
 // -----
 
 firrtl.circuit "Foo" {
-  firrtl.extmodule @Foo(in a : !firrtl.uint<2>) attributes { defname = "Foo", parameters = { width = 2 : i32 } }
+  firrtl.extmodule @Foo<width: i32 = 2>(in a : !firrtl.uint<2>) attributes { defname = "Foo" }
   // expected-note @+1 {{previous extmodule definition occurred here}}
   firrtl.extmodule @Bar(in a : !firrtl.uint<1>) attributes { defname = "Foo" }
   // expected-error @+1 {{'firrtl.extmodule' op with 'defname' attribute "Foo" has a port with name "a" which has a different type '!firrtl.uint<2>' which does not match the type of the port in the same position of a previously defined extmodule with the same 'defname', expected port to have type '!firrtl.uint<1>'}}
@@ -249,7 +249,7 @@ firrtl.circuit "Foo" {
 firrtl.circuit "Foo" {
 
   // expected-note @+1 {{previous extmodule definition occurred here}}
-  firrtl.extmodule @Foo(in a : !firrtl.uint<2>) attributes { defname = "Foo", parameters = { width = 2 : i32 } }
+  firrtl.extmodule @Foo<width: i32 = 2>(in a : !firrtl.uint<2>) attributes { defname = "Foo" }
   // expected-error @+1 {{'firrtl.extmodule' op with 'defname' attribute "Foo" has a port with name "a" which has a different type '!firrtl.sint' which does not match the type of the port in the same position of a previously defined extmodule with the same 'defname', expected port to have type '!firrtl.uint'}}
   firrtl.extmodule @Bar(in a : !firrtl.sint<1>) attributes { defname = "Foo" }
 
@@ -259,7 +259,7 @@ firrtl.circuit "Foo" {
 
 firrtl.circuit "Foo" {
   // expected-error @+1 {{has unknown extmodule parameter value 'width' = @Foo}}
-  firrtl.extmodule @Foo(in a : !firrtl.uint<2>) attributes { defname = "Foo", parameters = { width = @Foo } }
+  firrtl.extmodule @Foo<width: none = @Foo>(in a : !firrtl.uint<2>) attributes { defname = "Foo" }
 }
 
 // -----

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -27,12 +27,14 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     output ,,, out ,,: ,, UInt,<,8,>  ; Commas are whitespace
     defname = myextmodule
 
-  ; CHECK-LABEL: firrtl.extmodule @MyParameterizedExtModule(in in: !firrtl.uint, out out: !firrtl.uint<8>)
-  ; CHECK: attributes {defname = "name_thing",
-  ; CHECK: parameters = {DEFAULT = 0 : ui32,
-  ; CHECK:               DEPTH = 3.242000e+01 : f64,
-  ; CHECK:               FORMAT = "xyz_timeout=%d\0A",
-  ; CHECK:               WIDTH = 32 : ui32}}
+  ; CHECK-LABEL: firrtl.extmodule @MyParameterizedExtModule
+  ; CHECK-SAME:    <FORMAT: none = "xyz_timeout=%d\0A",
+  ; CHECK-SAME:     DEFAULT: ui32 = 0,
+  ; CHECK-SAME:     WIDTH: ui32 = 32,
+  ; CHECK-SAME:     DEPTH: f64 = 3.242000e+01>
+  ; CHECK-SAME:    (in in: !firrtl.uint,
+  ; CHECK-SAME:     out out: !firrtl.uint<8>)
+  ; CHECK-SAME:    attributes {defname = "name_thing"}
   ; CHECK-NOT: {
   extmodule MyParameterizedExtModule :
     input in: UInt
@@ -575,8 +577,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     tmp12 <= SInt<4>(-4)
     ; CHECK: %c-4_si4 = firrtl.constant -4 : !firrtl.sint<4>
 
-  ; CHECK-LABEL: firrtl.extmodule @issue183()
-  ; CHECK: attributes {parameters = {A = -1 : si32}}
+  ; CHECK-LABEL: firrtl.extmodule @issue183<A: si32 = -1>()
   extmodule issue183:
      parameter A = -1
 
@@ -829,9 +830,9 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     c <= mux(sel, a, b)
 
   ; CHECK-LABEL: firrtl.extmodule @RawStringParam
-  ; CHECK: parameters = {FORMAT = "xyz_timeout=%d\\n",
-  ; CHECK:               MIXED_QUOTES = "\22'\\\22",
-  ; CHECK:               TYPE = "bit"}}
+  ; CHECK-SAME:    <TYPE: none = "bit",
+  ; CHECK-SAME:     FORMAT: none = "xyz_timeout=%d\\n",
+  ; CHECK-SAME:     MIXED_QUOTES: none = "\22'\\\22">
   extmodule RawStringParam :
     parameter TYPE = 'bit'
     parameter FORMAT = 'xyz_timeout=%d\n'


### PR DESCRIPTION
Add HW Dialect's ParamDeclAttr to the FIRRTL Dialect.  This commit only
adds this attribute, but does not use it.  This commit is part of a
series of commits that migrate FIRRTL external modules to use HW-like
parameters.

Change FIRRTL's ExtModule to use ParamDeclAttr for parameter storage as
opposed to using a dictionary.  Modify parsing/printing to put
parameters in a carat-delimited area before ports (just like how HW
Dialect does this).
    
This makes NO modifications to the way ExtModule is represented.
Parameter values are still stored on the ExtModule and not on the
instantiation.  This will be changed in a later commit.