### PR TITLE
[MSFT] Use MSFTModuleOp for design partitions

### DIFF
--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -57,7 +57,8 @@ def OneOrNoBlocksRegion : Region<
 
 def MSFTModuleOp : MSFTOp<"module",
       [IsolatedFromAbove, FunctionLike, Symbol, RegionKindInterface,
-       HasParent<"mlir::ModuleOp">]>{
+       HasParent<"mlir::ModuleOp">,
+       SingleBlockImplicitTerminator<"OutputOp">]>{
   let summary = "MSFT HW Module";
   let description = [{
     A lot like `hw.module`, but with a few differences:
@@ -74,7 +75,7 @@ def MSFTModuleOp : MSFTOp<"module",
 
   let skipDefaultBuilders = 1;
   let builders = [
-    OpBuilder<(ins "StringAttr":$name, "ArrayRef<hw::PortInfo>":$ports,
+    OpBuilder<(ins "StringAttr":$name, "hw::ModulePortInfo":$ports,
                    "ArrayRef<NamedAttribute>":$params)>
   ];
 
@@ -188,6 +189,9 @@ def OutputOp : MSFTOp<"output", [Terminator, HasParent<"MSFTModuleOp">,
   let summary = "termination operation";
 
   let arguments = (ins Variadic<AnyType>:$operands);
+  let builders = [
+    OpBuilder<(ins)>
+  ];
 
   let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";
 }

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -20,6 +20,7 @@
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/FunctionImplementation.h"
 #include "mlir/IR/FunctionSupport.h"
+#include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/TypeSwitch.h"
 
@@ -30,12 +31,15 @@ using namespace msft;
 /// invalid IR.
 Operation *InstanceOp::getReferencedModule() {
   auto topLevelModuleOp = (*this)->getParentOfType<ModuleOp>();
-  assert(topLevelModuleOp && "Required to have a ModuleOp parent.");
+  if (!topLevelModuleOp)
+    return nullptr;
   return topLevelModuleOp.lookupSymbol(moduleName());
 }
 
 StringAttr InstanceOp::getResultName(size_t idx) {
-  return hw::getModuleResultNameAttr(getReferencedModule(), idx);
+  if (auto refMod = getReferencedModule())
+    return hw::getModuleResultNameAttr(refMod, idx);
+  return StringAttr();
 }
 
 /// Suggest a name for each result value based on the saved result names
@@ -128,10 +132,75 @@ MSFTModuleOp::addPorts(ArrayRef<std::pair<StringAttr, Type>> inputs,
   return newBlockArgs;
 }
 
-void MSFTModuleOp::build(OpBuilder &odsBuilder, OperationState &odsState,
-                         StringAttr name, ArrayRef<hw::PortInfo> ports,
+// Copied nearly exactly from hwops.cpp.
+// TODO: Unify code once a `ModuleLike` op interface exists.
+static void buildModule(OpBuilder &builder, OperationState &result,
+                        StringAttr name, const hw::ModulePortInfo &ports) {
+  using namespace mlir::function_like_impl;
+
+  // Add an attribute for the name.
+  result.addAttribute(SymbolTable::getSymbolAttrName(), name);
+
+  SmallVector<Attribute> argNames, resultNames;
+  SmallVector<Type, 4> argTypes, resultTypes;
+  SmallVector<Attribute> argAttrs, resultAttrs;
+  auto exportPortIdent = StringAttr::get("hw.exportPort", builder.getContext());
+
+  for (auto elt : ports.inputs) {
+    if (elt.direction == hw::PortDirection::INOUT &&
+        !elt.type.isa<hw::InOutType>())
+      elt.type = hw::InOutType::get(elt.type);
+    argTypes.push_back(elt.type);
+    argNames.push_back(elt.name);
+    Attribute attr;
+    if (elt.sym && !elt.sym.getValue().empty())
+      attr = builder.getDictionaryAttr(
+          {{exportPortIdent, FlatSymbolRefAttr::get(elt.sym)}});
+    else
+      attr = builder.getDictionaryAttr({});
+    argAttrs.push_back(attr);
+  }
+
+  for (auto elt : ports.outputs) {
+    resultTypes.push_back(elt.type);
+    resultNames.push_back(elt.name);
+    Attribute attr;
+    if (elt.sym && !elt.sym.getValue().empty())
+      attr = builder.getDictionaryAttr(
+          {{exportPortIdent, FlatSymbolRefAttr::get(elt.sym)}});
+    else
+      attr = builder.getDictionaryAttr({});
+    resultAttrs.push_back(attr);
+  }
+
+  // Record the argument and result types as an attribute.
+  auto type = builder.getFunctionType(argTypes, resultTypes);
+  result.addAttribute(getTypeAttrName(), TypeAttr::get(type));
+  result.addAttribute("argNames", builder.getArrayAttr(argNames));
+  result.addAttribute("resultNames", builder.getArrayAttr(resultNames));
+  result.addAttribute("parameters", builder.getDictionaryAttr({}));
+  result.addAttribute(mlir::function_like_impl::getArgDictAttrName(),
+                      builder.getArrayAttr(argAttrs));
+  result.addAttribute(mlir::function_like_impl::getResultDictAttrName(),
+                      builder.getArrayAttr(resultAttrs));
+  result.addRegion();
+}
+
+void MSFTModuleOp::build(OpBuilder &builder, OperationState &result,
+                         StringAttr name, hw::ModulePortInfo ports,
                          ArrayRef<NamedAttribute> params) {
-  assert(false && "Unimplemented");
+  buildModule(builder, result, name, ports);
+
+  // Create a region and a block for the body.
+  auto *bodyRegion = result.regions[0].get();
+  Block *body = new Block();
+  bodyRegion->push_back(body);
+
+  // Add arguments to the body block.
+  for (auto elt : ports.inputs)
+    body->addArgument(elt.type);
+
+  MSFTModuleOp::ensureTerminator(*bodyRegion, builder, result.location);
 }
 
 LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
@@ -317,7 +386,7 @@ static ParseResult parseParameterList(OpAsmParser &parser,
 /// Print a parameter list for a module or instance. Same format as HW dialect.
 static void printParameterList(OpAsmPrinter &p, Operation *op,
                                ArrayAttr parameters) {
-  if (parameters.empty())
+  if (!parameters || parameters.empty())
     return;
 
   p << '<';
@@ -584,6 +653,8 @@ hw::ModulePortInfo MSFTModuleExternOp::getPorts() {
 
   return hw::ModulePortInfo(inputs, outputs);
 }
+
+void OutputOp::build(OpBuilder &builder, OperationState &result) {}
 
 #define GET_OP_CLASSES
 #include "circt/Dialect/MSFT/MSFT.cpp.inc"

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -37,7 +37,7 @@ Operation *InstanceOp::getReferencedModule() {
 }
 
 StringAttr InstanceOp::getResultName(size_t idx) {
-  if (auto refMod = getReferencedModule())
+  if (auto *refMod = getReferencedModule())
     return hw::getModuleResultNameAttr(refMod, idx);
   return StringAttr();
 }

--- a/test/Dialect/MSFT/partition.mlir
+++ b/test/Dialect/MSFT/partition.mlir
@@ -24,16 +24,16 @@ msft.module @B {} (%clk : i1) -> (x: i1)  {
 }
 
 // CHECK-LABEL: msft.module @top {} (%clk: i1) {
-// CHECK:         %part1.b.unit1.foo_x, %part1.b.seq.compreg.b.seq.compreg, %part1.b.unit2.foo_x, %part1.unit1.foo_x = hw.instance "part1" sym @part1 @dp(b.unit1.foo_a: %b.unit1.foo_a: i1, b.seq.compreg.in0: %b.seq.compreg.in0: i1, b.seq.compreg.in1: %b.seq.compreg.in1: i1, b.unit2.foo_a: %b.unit2.foo_a: i1, unit1.foo_a: %false: i1) -> (b.unit1.foo_x: i1, b.seq.compreg.b.seq.compreg: i1, b.unit2.foo_x: i1, unit1.foo_x: i1)
+// CHECK:         %part1.b.unit1.foo_x, %part1.b.seq.compreg.b.seq.compreg, %part1.b.unit2.foo_x, %part1.unit1.foo_x = msft.instance @part1 @dp(%b.unit1.foo_a, %b.seq.compreg.in0, %b.seq.compreg.in1, %b.unit2.foo_a, %false) : (i1, i1, i1, i1, i1) -> (i1, i1, i1, i1)
 // CHECK:         %b.x, %b.unit1.foo_a, %b.seq.compreg.in0, %b.seq.compreg.in1, %b.unit2.foo_a = msft.instance @b @B(%clk, %part1.b.unit1.foo_x, %part1.b.seq.compreg.b.seq.compreg, %part1.b.unit2.foo_x)  : (i1, i1, i1, i1) -> (i32, i1, i1, i1, i1)
 // CHECK:         %false = hw.constant false
 // CHECK:         msft.output
 // CHECK-LABEL: msft.module @B {} (%clk: i1, %unit1.foo_x: i1, %seq.compreg.out0: i1, %unit2.foo_x: i1) -> (x: i1, unit1.foo_a: i1, seq.compreg.in0: i1, seq.compreg.in1: i1, unit2.foo_a: i1) {
 // CHECK:         %true = hw.constant true
 // CHECK:         msft.output %unit2.foo_x, %true, %unit1.foo_x, %clk, %seq.compreg.out0 : i1, i1, i1, i1, i1
-// CHECK-LABEL: hw.module @dp(%b.unit1.foo_a: i1, %b.seq.compreg.in0: i1, %b.seq.compreg.in1: i1, %b.unit2.foo_a: i1, %unit1.foo_a: i1) -> (b.unit1.foo_x: i1, b.seq.compreg.b.seq.compreg: i1, b.unit2.foo_x: i1, unit1.foo_x: i1) {
+// CHECK-LABEL: msft.module @dp {} (%b.unit1.foo_a: i1, %b.seq.compreg.in0: i1, %b.seq.compreg.in1: i1, %b.unit2.foo_a: i1, %unit1.foo_a: i1) -> (b.unit1.foo_x: i1, b.seq.compreg.b.seq.compreg: i1, b.unit2.foo_x: i1, unit1.foo_x: i1) {
 // CHECK:         %b.unit1.foo_x = msft.instance @b.unit1 @Extern(%b.unit1.foo_a)  : (i1) -> i1
 // CHECK:         %b.seq.compreg = seq.compreg %b.seq.compreg.in0, %b.seq.compreg.in1 : i1
 // CHECK:         %b.unit2.foo_x = msft.instance @b.unit2 @Extern(%b.unit2.foo_a)  : (i1) -> i1
 // CHECK:         %unit1.foo_x = msft.instance @unit1 @Extern(%unit1.foo_a)  : (i1) -> i1
-// CHECK:         hw.output %b.unit1.foo_x, %b.seq.compreg, %b.unit2.foo_x, %unit1.foo_x : i1, i1, i1, i1
+// CHECK:         msft.output %b.unit1.foo_x, %b.seq.compreg, %b.unit2.foo_x, %unit1.foo_x : i1, i1, i1, i1


### PR DESCRIPTION
The design partitioning pass used to build HWModuleOps. The new wire
cleanup passes, however, will be operating on the design partitions so
the modifying extensions will come in handy.

Adds the necessary builder methods for creating from C++.