### PR TITLE
[Handshake] Always add buffers to unbuffered channels in bufferAllStrategy

### DIFF
--- a/lib/Dialect/Handshake/Transforms/Buffers.cpp
+++ b/lib/Dialect/Handshake/Transforms/Buffers.cpp
@@ -112,11 +112,8 @@ struct HandshakeInsertBuffersPass
   };
 
   // Add a buffer to any un-buffered channel.
-  void bufferAllStrategy(
-      handshake::FuncOp f, OpBuilder &builder, unsigned numSlots,
-      bool sequential = true,
-      llvm::function_ref<bool(Operation *, Operation *)> filter =
-          [](auto *, auto *) { return false; }) {
+  void bufferAllStrategy(handshake::FuncOp f, OpBuilder &builder,
+                         unsigned numSlots, bool sequential = true) {
 
     for (auto &arg : f.getArguments()) {
       if (!shouldBufferArgument(arg))
@@ -126,13 +123,9 @@ struct HandshakeInsertBuffersPass
 
     for (auto &defOp : f.getOps()) {
       for (auto res : defOp.getResults()) {
-        for (auto useOp : res.getUsers()) {
+        for (auto *useOp : res.getUsers()) {
           if (!isUnbufferedChannel(&defOp, useOp))
             continue;
-
-          if (filter(&defOp, useOp))
-            continue;
-
           insertBuffer(res.getLoc(), res, builder, numSlots, sequential);
         }
       }

--- a/test/Dialect/Handshake/compose-buffers.mlir
+++ b/test/Dialect/Handshake/compose-buffers.mlir
@@ -1,0 +1,26 @@
+// Tests whether buffer strategies compose; this is done via. strategy 'allFIFO'
+// which uses sequential buffers on cycles and FIFOs on everything else
+// RUN: circt-opt --handshake-insert-buffers="strategy=allFIFO" %s | FileCheck %s
+
+// CHECK-LABEL:   handshake.func @foo(
+// CHECK-SAME:                        %[[VAL_0:.*]]: i32,
+// CHECK-SAME:                        %[[VAL_1:.*]]: none, ...) -> (i32, none)
+// CHECK:           %[[VAL_2:.*]] = buffer [2] %[[VAL_1]] {sequential = false} : none
+// CHECK:           %[[VAL_3:.*]] = buffer [2] %[[VAL_0]] {sequential = false} : i32
+// CHECK:           %[[VAL_4:.*]]:2 = fork [2] %[[VAL_3]] : i32
+// CHECK:           %[[VAL_5:.*]] = buffer [2] %[[VAL_4]]#1 {sequential = false} : i32
+// CHECK:           %[[VAL_6:.*]] = buffer [2] %[[VAL_4]]#0 {sequential = false} : i32
+// CHECK:           %[[VAL_7:.*]] = mux %[[VAL_6]] {{\[}}%[[VAL_5]], %[[VAL_8:.*]]] : i32, i32
+// CHECK:           %[[VAL_9:.*]] = buffer [2] %[[VAL_7]] {sequential = true} : i32
+// CHECK:           %[[VAL_10:.*]]:2 = fork [2] %[[VAL_9]] : i32
+// CHECK:           %[[VAL_11:.*]] = buffer [2] %[[VAL_10]]#1 {sequential = false} : i32
+// CHECK:           %[[VAL_8]] = buffer [2] %[[VAL_10]]#0 {sequential = false} : i32
+// CHECK:           return %[[VAL_11]], %[[VAL_2]] : i32, none
+// CHECK:         }
+
+handshake.func @foo(%arg0 : i32, %ctrl : none) -> (i32, none) {
+  %0:2 = fork [2] %arg0 : i32
+  %1 = mux %0#0 [%0#1, %2#0] : i32, i32
+  %2:2 = fork [2] %1 : i32
+  return %2#1, %ctrl : i32, none
+}


### PR DESCRIPTION
Due to the previous implementation of this function being based on a graph traversal which stopped at buffer ops, running bufferAllStrategy did not actually "buffer all" unbuffered channels, if some buffers already existed.

This commit simplifies bufferAllStrategy to do what is promised through iterating over all operation and adding buffers on unbuffered uses of each ops' results.