### PR TITLE
[MSFT] Add optional sub-path to PhysLocationAttr.

### DIFF
--- a/frontends/PyCDE/src/pycde/attributes.py
+++ b/frontends/PyCDE/src/pycde/attributes.py
@@ -17,7 +17,7 @@ def placement(subpath: Union[str, list[str]],
               x: int,
               y: int,
               num: int = 0):
-  loc = PhysLocation(devtype, x, y, num)
   if isinstance(subpath, list):
     subpath = "|".join(subpath)
+  loc = PhysLocation(devtype, x, y, num, subpath)
   return (f"loc:{subpath}", loc)

--- a/frontends/PyCDE/src/pycde/devicedb.py
+++ b/frontends/PyCDE/src/pycde/devicedb.py
@@ -19,7 +19,8 @@ class PhysLocation:
                prim_type: typing.Union[str, PrimitiveType],
                x: int,
                y: int,
-               num: typing.Union[int, None] = None):
+               num: typing.Union[int, None] = None,
+               sub_path: str = ""):
 
     if isinstance(prim_type, str):
       prim_type = getattr(PrimitiveType, prim_type)
@@ -31,7 +32,7 @@ class PhysLocation:
     assert isinstance(x, int)
     assert isinstance(y, int)
     assert isinstance(num, int)
-    self._loc = msft.PhysLocationAttr.get(prim_type, x, y, num)
+    self._loc = msft.PhysLocationAttr.get(prim_type, x, y, num, sub_path)
 
   def __str__(self) -> str:
     loc = self._loc

--- a/frontends/PyCDE/src/pycde/instance.py
+++ b/frontends/PyCDE/src/pycde/instance.py
@@ -119,14 +119,12 @@ class Instance:
       callback(inst)
       inst.walk(callback)
 
-  def _attach_attribute(self, attr_key: str, attr: ir.Attribute):
+  def _attach_attribute(self, sub_path: str, attr: ir.Attribute):
     if isinstance(attr, PhysLocation):
-      assert attr_key.startswith("loc:")
       attr = attr._loc
 
     db = self.root_instance.placedb._db
-    rc = db.add_placement(attr, self.path_attr, attr_key[4:],
-                          self.instOp.operation)
+    rc = db.add_placement(attr, self.path_attr, sub_path, self.instOp.operation)
     if not rc:
       raise ValueError("Failed to place")
 
@@ -137,7 +135,7 @@ class Instance:
       global_ref = hw.GlobalRefOp(global_ref_symbol, path_attr)
 
     # Attach the attribute to the global ref.
-    global_ref.attributes["loc:" + attr_key[4:]] = attr
+    global_ref.attributes["loc:" + sub_path] = attr
 
     # Add references to the global ref for each instance through the hierarchy.
     for instance in self.path:
@@ -165,7 +163,7 @@ class Instance:
             x: int,
             y: int,
             num: int = 0):
-    loc = msft.PhysLocationAttr.get(devtype, x, y, num)
     if isinstance(subpath, list):
       subpath = "|".join(subpath)
-    self._attach_attribute(f"loc:{subpath}", loc)
+    loc = msft.PhysLocationAttr.get(devtype, x, y, num, subpath)
+    self._attach_attribute(subpath, loc)

--- a/include/circt-c/Dialect/MSFT.h
+++ b/include/circt-c/Dialect/MSFT.h
@@ -41,8 +41,8 @@ MLIR_CAPI_EXPORTED void mlirMSFTAddPhysLocationAttr(MlirOperation op,
 MLIR_CAPI_EXPORTED bool
     circtMSFTAttributeIsAPhysLocationAttribute(MlirAttribute);
 MLIR_CAPI_EXPORTED MlirAttribute
-circtMSFTPhysLocationAttrGet(MlirContext, MlirStringRef, CirctMSFTPrimitiveType,
-                             uint64_t x, uint64_t y, uint64_t num);
+circtMSFTPhysLocationAttrGet(MlirContext, CirctMSFTPrimitiveType, uint64_t x,
+                             uint64_t y, uint64_t num, MlirStringRef subPath);
 MLIR_CAPI_EXPORTED CirctMSFTPrimitiveType
     circtMSFTPhysLocationAttrGetPrimitiveType(MlirAttribute);
 MLIR_CAPI_EXPORTED uint64_t circtMSFTPhysLocationAttrGetX(MlirAttribute);

--- a/include/circt-c/Dialect/MSFT.h
+++ b/include/circt-c/Dialect/MSFT.h
@@ -40,8 +40,9 @@ MLIR_CAPI_EXPORTED void mlirMSFTAddPhysLocationAttr(MlirOperation op,
 
 MLIR_CAPI_EXPORTED bool
     circtMSFTAttributeIsAPhysLocationAttribute(MlirAttribute);
-MLIR_CAPI_EXPORTED MlirAttribute circtMSFTPhysLocationAttrGet(
-    MlirContext, CirctMSFTPrimitiveType, uint64_t x, uint64_t y, uint64_t num);
+MLIR_CAPI_EXPORTED MlirAttribute
+circtMSFTPhysLocationAttrGet(MlirContext, MlirStringRef, CirctMSFTPrimitiveType,
+                             uint64_t x, uint64_t y, uint64_t num);
 MLIR_CAPI_EXPORTED CirctMSFTPrimitiveType
     circtMSFTPhysLocationAttrGetPrimitiveType(MlirAttribute);
 MLIR_CAPI_EXPORTED uint64_t circtMSFTPhysLocationAttrGetX(MlirAttribute);

--- a/include/circt/Dialect/MSFT/MSFTAttributes.td
+++ b/include/circt/Dialect/MSFT/MSFTAttributes.td
@@ -36,9 +36,9 @@ def PhysLocation : MSFT_Attr<"PhysLocation"> {
   }];
   let mnemonic = "physloc";
   let parameters = (ins
-    StringRefParameter<"subPath">:$subPath,
     "PrimitiveTypeAttr":$primitiveType,
-    "uint64_t":$x, "uint64_t":$y, "uint64_t":$num);
+    "uint64_t":$x, "uint64_t":$y, "uint64_t":$num,
+    StringRefParameter<"subPath">:$subPath);
 }
 
 def PhysicalBounds : MSFT_Attr<"PhysicalBounds"> {

--- a/include/circt/Dialect/MSFT/MSFTAttributes.td
+++ b/include/circt/Dialect/MSFT/MSFTAttributes.td
@@ -36,6 +36,7 @@ def PhysLocation : MSFT_Attr<"PhysLocation"> {
   }];
   let mnemonic = "physloc";
   let parameters = (ins
+    StringRefParameter<"subPath">:$subPath,
     "PrimitiveTypeAttr":$primitiveType,
     "uint64_t":$x, "uint64_t":$y, "uint64_t":$num);
 }

--- a/integration_test/Bindings/Python/dialects/msft.py
+++ b/integration_test/Bindings/Python/dialects/msft.py
@@ -43,7 +43,7 @@ with ir.Context() as ctx, ir.Location.unknown():
     path = op.create("inst1")
     minst = msft_mod.create("minst")
 
-  # CHECK: #msft.physloc<"foo_subpath", M20K, 2, 6, 1>
+  # CHECK: #msft.physloc<M20K, 2, 6, 1, "foo_subpath">
   physAttr = msft.PhysLocationAttr.get(msft.M20K,
                                        x=2,
                                        y=6,
@@ -89,7 +89,7 @@ with ir.Context() as ctx, ir.Location.unknown():
 
   place_rc = db.add_placement(physAttr, path, "foo_subpath", resolved_inst)
   assert not place_rc
-  # ERR: error: 'msft.instance' op Could not apply placement #msft.physloc<"foo_subpath", M20K, 2, 6, 1>. Position already occupied by msft.instance @ext1 @MyExternMod
+  # ERR: error: 'msft.instance' op Could not apply placement #msft.physloc<M20K, 2, 6, 1, "foo_subpath">. Position already occupied by msft.instance @ext1 @MyExternMod
 
   devdb = msft.PrimitiveDB()
   assert not devdb.is_valid_location(physAttr)
@@ -128,13 +128,13 @@ with ir.Context() as ctx, ir.Location.unknown():
   print("=== Placements:")
   seeded_pdb.walk_placements(print_placement)
   # CHECK-LABEL: === Placements:
-  # CHECK: #msft.physloc<"foo_subpath", M20K, 2, 6, 1>, [#hw.innerNameRef<@top::@inst1>, #hw.innerNameRef<@MyWidget::@ext1>]
+  # CHECK: #msft.physloc<M20K, 2, 6, 1, "foo_subpath">, [#hw.innerNameRef<@top::@inst1>, #hw.innerNameRef<@MyWidget::@ext1>]
   # CHECK: #msft.physloc<M20K, 2, 50, 1>
 
   print("=== Placements (col 2):")
   seeded_pdb.walk_placements(print_placement, bounds=(2, 2, None, None))
   # CHECK-LABEL: === Placements (col 2):
-  # CHECK: #msft.physloc<"foo_subpath", M20K, 2, 6, 1>, [#hw.innerNameRef<@top::@inst1>, #hw.innerNameRef<@MyWidget::@ext1>]
+  # CHECK: #msft.physloc<M20K, 2, 6, 1, "foo_subpath">, [#hw.innerNameRef<@top::@inst1>, #hw.innerNameRef<@MyWidget::@ext1>]
   # CHECK: #msft.physloc<M20K, 2, 50, 1>
 
   print("=== Placements (col 2, row > 10):")

--- a/integration_test/Bindings/Python/dialects/msft.py
+++ b/integration_test/Bindings/Python/dialects/msft.py
@@ -43,8 +43,12 @@ with ir.Context() as ctx, ir.Location.unknown():
     path = op.create("inst1")
     minst = msft_mod.create("minst")
 
-  # CHECK: #msft.physloc<M20K, 2, 6, 1>
-  physAttr = msft.PhysLocationAttr.get(msft.M20K, x=2, y=6, num=1)
+  # CHECK: #msft.physloc<"foo_subpath", M20K, 2, 6, 1>
+  physAttr = msft.PhysLocationAttr.get(msft.M20K,
+                                       x=2,
+                                       y=6,
+                                       num=1,
+                                       sub_path="foo_subpath")
   print(physAttr)
 
   # CHECK: #msft.physloc<FF, 0, 0, 0>
@@ -85,7 +89,7 @@ with ir.Context() as ctx, ir.Location.unknown():
 
   place_rc = db.add_placement(physAttr, path, "foo_subpath", resolved_inst)
   assert not place_rc
-  # ERR: error: 'msft.instance' op Could not apply placement #msft.physloc<M20K, 2, 6, 1>. Position already occupied by msft.instance @ext1 @MyExternMod
+  # ERR: error: 'msft.instance' op Could not apply placement #msft.physloc<"foo_subpath", M20K, 2, 6, 1>. Position already occupied by msft.instance @ext1 @MyExternMod
 
   devdb = msft.PrimitiveDB()
   assert not devdb.is_valid_location(physAttr)
@@ -124,13 +128,13 @@ with ir.Context() as ctx, ir.Location.unknown():
   print("=== Placements:")
   seeded_pdb.walk_placements(print_placement)
   # CHECK-LABEL: === Placements:
-  # CHECK: #msft.physloc<M20K, 2, 6, 1>, [#hw.innerNameRef<@top::@inst1>, #hw.innerNameRef<@MyWidget::@ext1>]
+  # CHECK: #msft.physloc<"foo_subpath", M20K, 2, 6, 1>, [#hw.innerNameRef<@top::@inst1>, #hw.innerNameRef<@MyWidget::@ext1>]
   # CHECK: #msft.physloc<M20K, 2, 50, 1>
 
   print("=== Placements (col 2):")
   seeded_pdb.walk_placements(print_placement, bounds=(2, 2, None, None))
   # CHECK-LABEL: === Placements (col 2):
-  # CHECK: #msft.physloc<M20K, 2, 6, 1>, [#hw.innerNameRef<@top::@inst1>, #hw.innerNameRef<@MyWidget::@ext1>]
+  # CHECK: #msft.physloc<"foo_subpath", M20K, 2, 6, 1>, [#hw.innerNameRef<@top::@inst1>, #hw.innerNameRef<@MyWidget::@ext1>]
   # CHECK: #msft.physloc<M20K, 2, 50, 1>
 
   print("=== Placements (col 2, row > 10):")

--- a/lib/Bindings/Python/MSFTModule.cpp
+++ b/lib/Bindings/Python/MSFTModule.cpp
@@ -133,13 +133,14 @@ void circt::python::populateDialectMSFTSubmodule(py::module &m) {
       .def_classmethod(
           "get",
           [](py::object cls, PrimitiveType devType, uint64_t x, uint64_t y,
-             uint64_t num, MlirContext ctxt) {
-            return cls(circtMSFTPhysLocationAttrGet(ctxt, (uint64_t)devType, x,
-                                                    y, num));
+             uint64_t num, std::string subPath, MlirContext ctxt) {
+            auto cSubPath = mlirStringRefCreateFromCString(subPath.c_str());
+            return cls(circtMSFTPhysLocationAttrGet(
+                ctxt, cSubPath, (uint64_t)devType, x, y, num));
           },
           "Create a physical location attribute", py::arg(),
           py::arg("dev_type"), py::arg("x"), py::arg("y"), py::arg("num"),
-          py::arg("ctxt") = py::none())
+          py::arg("sub_path") = py::str(""), py::arg("ctxt") = py::none())
       .def_property_readonly(
           "devtype",
           [](MlirAttribute self) {

--- a/lib/Bindings/Python/MSFTModule.cpp
+++ b/lib/Bindings/Python/MSFTModule.cpp
@@ -135,8 +135,8 @@ void circt::python::populateDialectMSFTSubmodule(py::module &m) {
           [](py::object cls, PrimitiveType devType, uint64_t x, uint64_t y,
              uint64_t num, std::string subPath, MlirContext ctxt) {
             auto cSubPath = mlirStringRefCreateFromCString(subPath.c_str());
-            return cls(circtMSFTPhysLocationAttrGet(
-                ctxt, cSubPath, (uint64_t)devType, x, y, num));
+            return cls(circtMSFTPhysLocationAttrGet(ctxt, (uint64_t)devType, x,
+                                                    y, num, cSubPath));
           },
           "Create a physical location attribute", py::arg(),
           py::arg("dev_type"), py::arg("x"), py::arg("y"), py::arg("num"),

--- a/lib/CAPI/Dialect/MSFT.cpp
+++ b/lib/CAPI/Dialect/MSFT.cpp
@@ -134,7 +134,7 @@ void mlirMSFTAddPhysLocationAttr(MlirOperation cOp, const char *entityName,
   mlir::Operation *op = unwrap(cOp);
   mlir::MLIRContext *ctxt = op->getContext();
   PhysLocationAttr loc = PhysLocationAttr::get(
-      ctxt, entityName, PrimitiveTypeAttr::get(ctxt, type), x, y, num);
+      ctxt, PrimitiveTypeAttr::get(ctxt, type), x, y, num, entityName);
   llvm::SmallString<64> entity("loc:");
   entity.append(entityName);
   op->setAttr(entity, loc);
@@ -144,14 +144,13 @@ bool circtMSFTAttributeIsAPhysLocationAttribute(MlirAttribute attr) {
   return unwrap(attr).isa<PhysLocationAttr>();
 }
 MlirAttribute circtMSFTPhysLocationAttrGet(MlirContext cCtxt,
-                                           MlirStringRef subPath,
                                            CirctMSFTPrimitiveType devType,
-                                           uint64_t x, uint64_t y,
-                                           uint64_t num) {
+                                           uint64_t x, uint64_t y, uint64_t num,
+                                           MlirStringRef subPath) {
   auto *ctxt = unwrap(cCtxt);
   return wrap(PhysLocationAttr::get(
-      ctxt, unwrap(subPath),
-      PrimitiveTypeAttr::get(ctxt, (PrimitiveType)devType), x, y, num));
+      ctxt, PrimitiveTypeAttr::get(ctxt, (PrimitiveType)devType), x, y, num,
+      unwrap(subPath)));
 }
 
 CirctMSFTPrimitiveType

--- a/lib/CAPI/Dialect/MSFT.cpp
+++ b/lib/CAPI/Dialect/MSFT.cpp
@@ -134,7 +134,7 @@ void mlirMSFTAddPhysLocationAttr(MlirOperation cOp, const char *entityName,
   mlir::Operation *op = unwrap(cOp);
   mlir::MLIRContext *ctxt = op->getContext();
   PhysLocationAttr loc = PhysLocationAttr::get(
-      ctxt, PrimitiveTypeAttr::get(ctxt, type), x, y, num);
+      ctxt, entityName, PrimitiveTypeAttr::get(ctxt, type), x, y, num);
   llvm::SmallString<64> entity("loc:");
   entity.append(entityName);
   op->setAttr(entity, loc);
@@ -144,12 +144,14 @@ bool circtMSFTAttributeIsAPhysLocationAttribute(MlirAttribute attr) {
   return unwrap(attr).isa<PhysLocationAttr>();
 }
 MlirAttribute circtMSFTPhysLocationAttrGet(MlirContext cCtxt,
+                                           MlirStringRef subPath,
                                            CirctMSFTPrimitiveType devType,
                                            uint64_t x, uint64_t y,
                                            uint64_t num) {
-  auto ctxt = unwrap(cCtxt);
+  auto *ctxt = unwrap(cCtxt);
   return wrap(PhysLocationAttr::get(
-      ctxt, PrimitiveTypeAttr::get(ctxt, (PrimitiveType)devType), x, y, num));
+      ctxt, unwrap(subPath),
+      PrimitiveTypeAttr::get(ctxt, (PrimitiveType)devType), x, y, num));
 }
 
 CirctMSFTPrimitiveType

--- a/lib/Dialect/MSFT/DeviceDB.cpp
+++ b/lib/Dialect/MSFT/DeviceDB.cpp
@@ -55,9 +55,8 @@ void PrimitiveDB::foreach (
     for (auto y : x.second)
       for (auto n : y.second)
         for (auto p : n.second)
-          callback(PhysLocationAttr::get(ctxt, "",
-                                         PrimitiveTypeAttr::get(ctxt, p),
-                                         x.first, y.first, n.first));
+          callback(PhysLocationAttr::get(ctxt, PrimitiveTypeAttr::get(ctxt, p),
+                                         x.first, y.first, n.first, ""));
 }
 
 //===----------------------------------------------------------------------===//
@@ -258,9 +257,9 @@ void PlacementDB::walkPlacements(
           PlacedInstance inst = devF->getSecond();
 
           // Marshall and run the callback.
-          PhysLocationAttr loc = PhysLocationAttr::get(
-              ctxt, inst.subpath, PrimitiveTypeAttr::get(ctxt, devtype), x, y,
-              num);
+          PhysLocationAttr loc =
+              PhysLocationAttr::get(ctxt, PrimitiveTypeAttr::get(ctxt, devtype),
+                                    x, y, num, inst.subpath);
           callback(loc, inst);
         }
       }

--- a/lib/Dialect/MSFT/MSFTAttributes.cpp
+++ b/lib/Dialect/MSFT/MSFTAttributes.cpp
@@ -25,11 +25,20 @@ using namespace msft;
 
 Attribute PhysLocationAttr::parse(AsmParser &p, Type type) {
   llvm::SMLoc loc = p.getCurrentLocation();
+  std::string subPath;
   StringRef devTypeStr;
   uint64_t x, y, num;
-  if (p.parseLess() || p.parseKeyword(&devTypeStr) || p.parseComma() ||
-      p.parseInteger(x) || p.parseComma() || p.parseInteger(y) ||
-      p.parseComma() || p.parseInteger(num) || p.parseGreater())
+  if (p.parseLess())
+    return Attribute();
+
+  // Parse an optional subPath.
+  if (succeeded(p.parseOptionalString(&subPath)))
+    if (p.parseComma())
+      return Attribute();
+
+  if (p.parseKeyword(&devTypeStr) || p.parseComma() || p.parseInteger(x) ||
+      p.parseComma() || p.parseInteger(y) || p.parseComma() ||
+      p.parseInteger(num) || p.parseGreater())
     return Attribute();
 
   Optional<PrimitiveType> devType = symbolizePrimitiveType(devTypeStr);
@@ -39,13 +48,20 @@ Attribute PhysLocationAttr::parse(AsmParser &p, Type type) {
   }
   PrimitiveTypeAttr devTypeAttr =
       PrimitiveTypeAttr::get(p.getContext(), *devType);
-  auto phy = PhysLocationAttr::get(p.getContext(), devTypeAttr, x, y, num);
+  auto phy =
+      PhysLocationAttr::get(p.getContext(), subPath, devTypeAttr, x, y, num);
   return phy;
 }
 
 void PhysLocationAttr::print(AsmPrinter &p) const {
-  p << "<" << stringifyPrimitiveType(getPrimitiveType().getValue()) << ", "
-    << getX() << ", " << getY() << ", " << getNum() << '>';
+  p << "<";
+
+  // Print an optional subPath.
+  if (!getSubPath().empty())
+    p << "\"" << getSubPath() << "\", ";
+
+  p << stringifyPrimitiveType(getPrimitiveType().getValue()) << ", " << getX()
+    << ", " << getY() << ", " << getNum() << '>';
 }
 
 Attribute PhysicalRegionRefAttr::parse(AsmParser &p, Type type) {

--- a/lib/Dialect/MSFT/MSFTPasses.cpp
+++ b/lib/Dialect/MSFT/MSFTPasses.cpp
@@ -195,7 +195,7 @@ public:
   matchAndRewrite(hw::GlobalRefOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     for (auto attr : op->getAttrs()) {
-      if (attr.getName().getValue().startswith("loc")) {
+      if (isa<MSFTDialect>(attr.getValue().getDialect())) {
         rewriter.eraseOp(op);
         return success();
       }
@@ -237,7 +237,7 @@ void LowerToHWPass::runOnOperation() {
   target.addLegalDialect<sv::SVDialect>();
   target.addDynamicallyLegalOp<hw::GlobalRefOp>([](hw::GlobalRefOp op) {
     for (auto attr : op->getAttrs())
-      if (attr.getName().getValue().startswith("loc"))
+      if (isa<MSFTDialect>(attr.getValue().getDialect()))
         return false;
     return true;
   });

--- a/test/Dialect/MSFT/location.mlir
+++ b/test/Dialect/MSFT/location.mlir
@@ -3,11 +3,11 @@
 // RUN: circt-opt %s --lower-msft-to-hw=tops=shallow,deeper,regions,reg --lower-seq-to-sv --export-verilog | FileCheck %s --check-prefix=TCL
 
 hw.globalRef @ref1 [#hw.innerNameRef<@deeper::@branch>, #hw.innerNameRef<@shallow::@leaf>, #hw.innerNameRef<@leaf::@module>] {
-  "foo" = #msft.physloc<"memBank2", M20K, 15, 9, 3>
+  "foo" = #msft.physloc<M20K, 15, 9, 3, "memBank2">
 }
 
 hw.globalRef @ref2 [#hw.innerNameRef<@shallow::@leaf>, #hw.innerNameRef<@leaf::@module>] {
-  "bar" = #msft.physloc<"memBank2", M20K, 8, 19, 1>
+  "bar" = #msft.physloc<M20K, 8, 19, 1, "memBank2">
 }
 
 hw.globalRef @ref3 [#hw.innerNameRef<@regions::@module>] {

--- a/test/Dialect/MSFT/location.mlir
+++ b/test/Dialect/MSFT/location.mlir
@@ -3,19 +3,19 @@
 // RUN: circt-opt %s --lower-msft-to-hw=tops=shallow,deeper,regions,reg --lower-seq-to-sv --export-verilog | FileCheck %s --check-prefix=TCL
 
 hw.globalRef @ref1 [#hw.innerNameRef<@deeper::@branch>, #hw.innerNameRef<@shallow::@leaf>, #hw.innerNameRef<@leaf::@module>] {
-  "loc:memBank2" = #msft.physloc<M20K, 15, 9, 3>
+  "foo" = #msft.physloc<"memBank2", M20K, 15, 9, 3>
 }
 
 hw.globalRef @ref2 [#hw.innerNameRef<@shallow::@leaf>, #hw.innerNameRef<@leaf::@module>] {
-  "loc:memBank2" = #msft.physloc<M20K, 8, 19, 1>
+  "bar" = #msft.physloc<"memBank2", M20K, 8, 19, 1>
 }
 
 hw.globalRef @ref3 [#hw.innerNameRef<@regions::@module>] {
-  "loc:" = #msft.physical_region_ref<@region1>
+  "baz" = #msft.physical_region_ref<@region1>
 }
 
 hw.globalRef @ref4 [#hw.innerNameRef<@reg::@reg>] {
-  "loc:" = #msft.physloc<FF, 0, 0, 0>
+  "qux" = #msft.physloc<FF, 0, 0, 0>
 }
 
 hw.module.extern @Foo()

--- a/test/Dialect/MSFT/translate-errors.mlir
+++ b/test/Dialect/MSFT/translate-errors.mlir
@@ -12,18 +12,3 @@ msft.module @top {} () -> () {
   msft.instance @foo1 @Foo() {circt.globalRef = [#hw.globalNameRef<@ref>], inner_sym = "foo1"} : () -> ()
   msft.output
 }
-
-// -----
-
-hw.module.extern @Foo()
-
-// expected-error @+1 {{'hw.globalRef' op PhysLoc attributes must have names starting with 'loc'}}
-hw.globalRef @ref [#hw.innerNameRef<@top::@foo1>] {
-  "phys:" = #msft.physloc<DSP, 0, 0, 0>
-}
-
-// expected-error @+1 {{Could not place 1 instances}}
-msft.module @top {} () -> () {
-  msft.instance @foo1 @Foo() {circt.globalRef = [#hw.globalNameRef<@ref>], inner_sym = "foo1"} : () -> ()
-  msft.output
-}


### PR DESCRIPTION
Previously, a sub-path could be specified by encoding it in the name
of the attribute using a certain scheme. This is brittle and
non-standard. To make this more natural and robust, the sub-path is
added as a field of the attribute definition as a StringRef. It is not
required, in which case an empty StringRef can be used. The attribute
name for placement attributes is no longer used in any logic.