### PR TITLE
[Handshake] Add new `select` operation

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -466,6 +466,38 @@ def ConditionalBranchOp : Handshake_Op<"cond_br", [
   }];
 }
 
+def SelectOp : Handshake_Op<"select", [
+  NoSideEffect,
+  DeclareOpInterfaceMethods<NamedIOInterface, ["getOperandName"]>,
+  TypesMatchWith<"data operand type matches true branch result type",
+                    "trueOperand", "falseOperand", "$_self">,
+  TypesMatchWith<"data operand type matches false branch result type",
+                    "falseOperand", "result", "$_self">
+]> {
+  let summary = "Select operation";
+  let description = [{
+     The select operation will select between two inputs based on an input
+     conditional. The select operation differs from a mux in that
+     1. both operands must be valid before the operation can transact
+     2. both operands will be transacted once one of them is selected 
+
+     Example:
+     ```mlir
+     %res = select %cond, %true, %false : i32
+     ```
+  }];
+
+  let arguments = (ins I1 : $condOperand,
+                       AnyType : $trueOperand, AnyType : $falseOperand);
+  let results = (outs AnyType : $result);
+
+  let builders = [OpBuilder<(ins 
+    "Value":$condOperand, "Value":$trueOperand, "Value":$falseOperand)>];
+  let skipDefaultBuilders = 1;
+  let printer = "return ::print$cppClass(p, *this);";
+  let parser = "return ::parse$cppClass(parser, result);";
+}
+
 def SinkOp
     : Handshake_Op<"sink", [DeclareOpInterfaceMethods<ExecutableOpInterface>]> {
   let summary = "sink operation";

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -333,14 +333,16 @@ def MuxOp : Handshake_Op<"mux", [
 ]> {
   let summary = "mux operation";
   let description = [{
-    The mux operation represents a(deterministic)
-        merge operation.
+    The mux operation represents a(deterministic) merge operation.
     Operands: select, data0, data1, data2, ...
 
     The 'select' operand is received from ControlMerge of the same
     block and it represents the index of the data operand that the mux
     should propagate to its single output.  The number of data inputs
     corresponds to the number of predecessor blocks.
+
+    The mux operation is intended solely for control+dataflow selection.
+    For purely dataflow selection, use the 'select' operation instead.
 
     Example:
     ```mlir
@@ -480,6 +482,10 @@ def SelectOp : Handshake_Op<"select", [
      conditional. The select operation differs from a mux in that
      1. All operands must be valid before the operation can transact
      2. All operands will be transacted at simultaneously
+
+     The 'select' operation is intended to handle 'std.select' and other
+     ternary-like operators, which considers strictly dataflow. The 'mux' operator
+     considers control+dataflow between blocks.
 
      Example:
      ```mlir

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -478,8 +478,8 @@ def SelectOp : Handshake_Op<"select", [
   let description = [{
      The select operation will select between two inputs based on an input
      conditional. The select operation differs from a mux in that
-     1. both operands must be valid before the operation can transact
-     2. both operands will be transacted once one of them is selected 
+     1. All operands must be valid before the operation can transact
+     2. All operands will be transacted at simultaneously
 
      Example:
      ```mlir

--- a/include/circt/Dialect/Handshake/Visitor.h
+++ b/include/circt/Dialect/Handshake/Visitor.h
@@ -32,8 +32,8 @@ public:
             // Handshake nodes.
             BranchOp, BufferOp, ConditionalBranchOp, ConstantOp, ControlMergeOp,
             EndOp, ForkOp, FuncOp, InstanceOp, JoinOp, LazyForkOp, LoadOp,
-            MemoryOp, ExternalMemoryOp, MergeOp, MuxOp, ReturnOp, SinkOp, handshake::SelectOp,
-            SourceOp, StartOp, StoreOp, TerminatorOp>(
+            MemoryOp, ExternalMemoryOp, MergeOp, MuxOp, ReturnOp, SinkOp,
+            handshake::SelectOp, SourceOp, StartOp, StoreOp, TerminatorOp>(
             [&](auto opNode) -> ResultType {
               return thisCast->visitHandshake(opNode, args...);
             })

--- a/include/circt/Dialect/Handshake/Visitor.h
+++ b/include/circt/Dialect/Handshake/Visitor.h
@@ -32,7 +32,7 @@ public:
             // Handshake nodes.
             BranchOp, BufferOp, ConditionalBranchOp, ConstantOp, ControlMergeOp,
             EndOp, ForkOp, FuncOp, InstanceOp, JoinOp, LazyForkOp, LoadOp,
-            MemoryOp, ExternalMemoryOp, MergeOp, MuxOp, ReturnOp, SinkOp,
+            MemoryOp, ExternalMemoryOp, MergeOp, MuxOp, ReturnOp, SinkOp, handshake::SelectOp,
             SourceOp, StartOp, StoreOp, TerminatorOp>(
             [&](auto opNode) -> ResultType {
               return thisCast->visitHandshake(opNode, args...);
@@ -73,6 +73,7 @@ public:
   HANDLE(LazyForkOp);
   HANDLE(LoadOp);
   HANDLE(MemoryOp);
+  HANDLE(handshake::SelectOp);
   HANDLE(ExternalMemoryOp);
   HANDLE(MergeOp);
   HANDLE(MuxOp);

--- a/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
+++ b/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
@@ -1402,9 +1402,9 @@ struct ConvertSelectOps : public OpConversionPattern<mlir::SelectOp> {
   LogicalResult
   matchAndRewrite(mlir::SelectOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<handshake::MuxOp>(
-        op, adaptor.getCondition(),
-        SmallVector<Value>{adaptor.getFalseValue(), adaptor.getTrueValue()});
+    rewriter.replaceOpWithNewOp<handshake::SelectOp>(op, adaptor.getCondition(),
+                                                     adaptor.getFalseValue(),
+                                                     adaptor.getTrueValue());
     return success();
   };
 };

--- a/test/Conversion/HandshakeToFIRRTL/test_select.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_select.mlir
@@ -1,0 +1,43 @@
+// RUN: circt-opt -lower-handshake-to-firrtl -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL:   firrtl.circuit "test_select"   {
+// CHECK:           firrtl.module @handshake_select_in_ui1_ui32_ui32_out_ui32(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out %[[VAL_3:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) {
+// CHECK:             %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_6:.*]] = firrtl.subfield %[[VAL_0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_7:.*]] = firrtl.subfield %[[VAL_1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_8:.*]] = firrtl.subfield %[[VAL_1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_9:.*]] = firrtl.subfield %[[VAL_1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
+// CHECK:             %[[VAL_10:.*]] = firrtl.subfield %[[VAL_2]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_11:.*]] = firrtl.subfield %[[VAL_2]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_12:.*]] = firrtl.subfield %[[VAL_2]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
+// CHECK:             %[[VAL_13:.*]] = firrtl.subfield %[[VAL_3]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_14:.*]] = firrtl.subfield %[[VAL_3]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_15:.*]] = firrtl.subfield %[[VAL_3]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
+// CHECK:             %[[VAL_16:.*]] = firrtl.bits %[[VAL_6]] 0 to 0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_17:.*]] = firrtl.mux(%[[VAL_16]], %[[VAL_9]], %[[VAL_12]]) : (!firrtl.uint<1>, !firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>
+// CHECK:             firrtl.connect %[[VAL_15]], %[[VAL_17]] : !firrtl.uint<32>, !firrtl.uint<32>
+// CHECK:             %[[VAL_18:.*]] = firrtl.wire  : !firrtl.uint<1>
+// CHECK:             %[[VAL_19:.*]] = firrtl.and %[[VAL_10]], %[[VAL_7]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:             %[[VAL_20:.*]] = firrtl.and %[[VAL_4]], %[[VAL_19]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:             firrtl.connect %[[VAL_18]], %[[VAL_20]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:             firrtl.connect %[[VAL_13]], %[[VAL_18]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:             %[[VAL_21:.*]] = firrtl.and %[[VAL_18]], %[[VAL_14]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:             firrtl.connect %[[VAL_5]], %[[VAL_21]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:             firrtl.connect %[[VAL_8]], %[[VAL_21]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:             firrtl.connect %[[VAL_11]], %[[VAL_21]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:           }
+// CHECK:           firrtl.module @test_select(in %[[VAL_22:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>, in %[[VAL_23:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_24:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_25:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %[[VAL_26:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out %[[VAL_27:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %[[VAL_28:.*]]: !firrtl.clock, in %[[VAL_29:.*]]: !firrtl.uint<1>) {
+// CHECK:             %[[VAL_30:.*]], %[[VAL_31:.*]], %[[VAL_32:.*]], %[[VAL_33:.*]] = firrtl.instance handshake_select0  @handshake_select_in_ui1_ui32_ui32_out_ui32(in sel: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>, in true: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in false: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out out0: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>)
+// CHECK:             firrtl.connect %[[VAL_30]], %[[VAL_22]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>
+// CHECK:             firrtl.connect %[[VAL_31]], %[[VAL_23]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             firrtl.connect %[[VAL_32]], %[[VAL_24]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             firrtl.connect %[[VAL_26]], %[[VAL_33]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>
+// CHECK:             firrtl.connect %[[VAL_27]], %[[VAL_25]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:           }
+// CHECK:         }
+
+handshake.func @test_select(%arg0: i1, %arg1: i32, %arg2: i32, %arg3: none, ...) -> (i32, none) {
+  %0 = select %arg0, %arg1, %arg2 : i32
+  return %0, %arg3 : i32, none
+}

--- a/test/Conversion/StandardToHandshake/test-simple-ops.mlir
+++ b/test/Conversion/StandardToHandshake/test-simple-ops.mlir
@@ -5,7 +5,7 @@
 // CHECK:           %[[VAL_4:.*]] = merge %[[VAL_0]] : i1
 // CHECK:           %[[VAL_5:.*]] = merge %[[VAL_1]] : i32
 // CHECK:           %[[VAL_6:.*]] = merge %[[VAL_2]] : i32
-// CHECK:           %[[VAL_7:.*]] = mux %[[VAL_4]] {{\[}}%[[VAL_6]], %[[VAL_5]]] : i1, i32
+// CHECK:           %[[VAL_7:.*]] = select %[[VAL_4]], %[[VAL_6]], %[[VAL_5]] : i32
 // CHECK:           return %[[VAL_7]], %[[VAL_3]] : i32, none
 // CHECK:         }
 func @main(%c : i1, %a : i32, %b : i32) -> i32 {

--- a/test/Conversion/StandardToHandshake/test16.mlir
+++ b/test/Conversion/StandardToHandshake/test16.mlir
@@ -15,12 +15,12 @@
 // CHECK:           %[[VAL_11:.*]]:2 = fork [2] %[[VAL_10]] : i1
 // CHECK:           %[[VAL_12:.*]] = arith.subi %[[VAL_7]]#1, %[[VAL_3]]#1 : index
 // CHECK:           %[[VAL_13:.*]] = arith.subi %[[VAL_3]]#0, %[[VAL_9]]#0 : index
-// CHECK:           %[[VAL_14:.*]] = mux %[[VAL_11]]#1 {{\[}}%[[VAL_13]], %[[VAL_12]]] : i1, index
+// CHECK:           %[[VAL_14:.*]] = select %[[VAL_11]]#1, %[[VAL_13]], %[[VAL_12]] : index
 // CHECK:           %[[VAL_15:.*]] = arith.divsi %[[VAL_14]], %[[VAL_5]] : index
 // CHECK:           %[[VAL_16:.*]]:2 = fork [2] %[[VAL_15]] : index
 // CHECK:           %[[VAL_17:.*]] = arith.subi %[[VAL_7]]#2, %[[VAL_16]]#1 : index
 // CHECK:           %[[VAL_18:.*]] = arith.addi %[[VAL_16]]#0, %[[VAL_9]]#1 : index
-// CHECK:           %[[VAL_19:.*]] = mux %[[VAL_11]]#0 {{\[}}%[[VAL_18]], %[[VAL_17]]] : i1, index
+// CHECK:           %[[VAL_19:.*]] = select %[[VAL_11]]#0, %[[VAL_18]], %[[VAL_17]] : index
 // CHECK:           return %[[VAL_19]], %[[VAL_4]]#3 : index, none
 // CHECK:         }
 func @affine_apply_ceildiv(%arg0: index) -> index {

--- a/test/Conversion/StandardToHandshake/test17.mlir
+++ b/test/Conversion/StandardToHandshake/test17.mlir
@@ -13,11 +13,11 @@
 // CHECK:           %[[VAL_9:.*]] = arith.cmpi slt, %[[VAL_3]]#2, %[[VAL_6]] : index
 // CHECK:           %[[VAL_10:.*]]:2 = fork [2] %[[VAL_9]] : i1
 // CHECK:           %[[VAL_11:.*]] = arith.subi %[[VAL_8]]#0, %[[VAL_3]]#1 : index
-// CHECK:           %[[VAL_12:.*]] = mux %[[VAL_10]]#1 {{\[}}%[[VAL_3]]#0, %[[VAL_11]]] : i1, index
+// CHECK:           %[[VAL_12:.*]] = select %[[VAL_10]]#1, %[[VAL_3]]#0, %[[VAL_11]] : index
 // CHECK:           %[[VAL_13:.*]] = arith.divsi %[[VAL_12]], %[[VAL_5]] : index
 // CHECK:           %[[VAL_14:.*]]:2 = fork [2] %[[VAL_13]] : index
 // CHECK:           %[[VAL_15:.*]] = arith.subi %[[VAL_8]]#1, %[[VAL_14]]#1 : index
-// CHECK:           %[[VAL_16:.*]] = mux %[[VAL_10]]#0 {{\[}}%[[VAL_14]]#0, %[[VAL_15]]] : i1, index
+// CHECK:           %[[VAL_16:.*]] = select %[[VAL_10]]#0, %[[VAL_14]]#0, %[[VAL_15]] : index
 // CHECK:           return %[[VAL_16]], %[[VAL_4]]#3 : index, none
 // CHECK:         }
 func @affine_apply_floordiv(%arg0: index) -> index {

--- a/test/Conversion/StandardToHandshake/test18.mlir
+++ b/test/Conversion/StandardToHandshake/test18.mlir
@@ -12,7 +12,7 @@
 // CHECK:           %[[VAL_8:.*]] = constant %[[VAL_3]]#0 {value = 0 : index} : index
 // CHECK:           %[[VAL_9:.*]] = arith.cmpi slt, %[[VAL_7]]#2, %[[VAL_8]] : index
 // CHECK:           %[[VAL_10:.*]] = arith.addi %[[VAL_7]]#1, %[[VAL_5]]#1 : index
-// CHECK:           %[[VAL_11:.*]] = mux %[[VAL_9]] {{\[}}%[[VAL_7]]#0, %[[VAL_10]]] : i1, index
+// CHECK:           %[[VAL_11:.*]] = select %[[VAL_9]], %[[VAL_7]]#0, %[[VAL_10]] : index
 // CHECK:           return %[[VAL_11]], %[[VAL_3]]#2 : index, none
 // CHECK:         }
 func @affine_apply_mod(%arg0: index) -> index {

--- a/test/Conversion/StandardToHandshake/test20.mlir
+++ b/test/Conversion/StandardToHandshake/test20.mlir
@@ -8,22 +8,22 @@
 // CHECK:           %[[VAL_4:.*]]:3 = fork [3] %[[VAL_1]] : none
 // CHECK:           %[[VAL_5:.*]] = constant %[[VAL_4]]#1 {value = 0 : index} : index
 // CHECK:           %[[VAL_6:.*]] = arith.cmpi slt, %[[VAL_3]]#12, %[[VAL_3]]#13 : index
-// CHECK:           %[[VAL_7:.*]] = mux %[[VAL_6]] {{\[}}%[[VAL_3]]#11, %[[VAL_3]]#10] : i1, index
+// CHECK:           %[[VAL_7:.*]] = select %[[VAL_6]], %[[VAL_3]]#11, %[[VAL_3]]#10 : index
 // CHECK:           %[[VAL_8:.*]]:2 = fork [2] %[[VAL_7]] : index
 // CHECK:           %[[VAL_9:.*]] = arith.cmpi slt, %[[VAL_8]]#1, %[[VAL_3]]#9 : index
-// CHECK:           %[[VAL_10:.*]] = mux %[[VAL_9]] {{\[}}%[[VAL_3]]#8, %[[VAL_8]]#0] : i1, index
+// CHECK:           %[[VAL_10:.*]] = select %[[VAL_9]], %[[VAL_3]]#8, %[[VAL_8]]#0 : index
 // CHECK:           %[[VAL_11:.*]]:2 = fork [2] %[[VAL_10]] : index
 // CHECK:           %[[VAL_12:.*]] = arith.cmpi slt, %[[VAL_11]]#1, %[[VAL_3]]#7 : index
-// CHECK:           %[[VAL_13:.*]] = mux %[[VAL_12]] {{\[}}%[[VAL_3]]#6, %[[VAL_11]]#0] : i1, index
+// CHECK:           %[[VAL_13:.*]] = select %[[VAL_12]], %[[VAL_3]]#6, %[[VAL_11]]#0 : index
 // CHECK:           %[[VAL_14:.*]]:2 = fork [2] %[[VAL_13]] : index
 // CHECK:           %[[VAL_15:.*]] = arith.cmpi slt, %[[VAL_14]]#1, %[[VAL_3]]#5 : index
-// CHECK:           %[[VAL_16:.*]] = mux %[[VAL_15]] {{\[}}%[[VAL_3]]#4, %[[VAL_14]]#0] : i1, index
+// CHECK:           %[[VAL_16:.*]] = select %[[VAL_15]], %[[VAL_3]]#4, %[[VAL_14]]#0 : index
 // CHECK:           %[[VAL_17:.*]]:2 = fork [2] %[[VAL_16]] : index
 // CHECK:           %[[VAL_18:.*]] = arith.cmpi slt, %[[VAL_17]]#1, %[[VAL_3]]#3 : index
-// CHECK:           %[[VAL_19:.*]] = mux %[[VAL_18]] {{\[}}%[[VAL_3]]#2, %[[VAL_17]]#0] : i1, index
+// CHECK:           %[[VAL_19:.*]] = select %[[VAL_18]], %[[VAL_3]]#2, %[[VAL_17]]#0 : index
 // CHECK:           %[[VAL_20:.*]]:2 = fork [2] %[[VAL_19]] : index
 // CHECK:           %[[VAL_21:.*]] = arith.cmpi slt, %[[VAL_20]]#1, %[[VAL_3]]#1 : index
-// CHECK:           %[[VAL_22:.*]] = mux %[[VAL_21]] {{\[}}%[[VAL_3]]#0, %[[VAL_20]]#0] : i1, index
+// CHECK:           %[[VAL_22:.*]] = select %[[VAL_21]], %[[VAL_3]]#0, %[[VAL_20]]#0 : index
 // CHECK:           %[[VAL_23:.*]] = constant %[[VAL_4]]#0 {value = 1 : index} : index
 // CHECK:           %[[VAL_24:.*]] = br %[[VAL_4]]#2 : none
 // CHECK:           %[[VAL_25:.*]] = br %[[VAL_5]] : index

--- a/test/Conversion/StandardToHandshake/test21.mlir
+++ b/test/Conversion/StandardToHandshake/test21.mlir
@@ -46,12 +46,12 @@
 // CHECK:           %[[VAL_49:.*]] = arith.addi %[[VAL_48]], %[[VAL_41]]#3 : index
 // CHECK:           %[[VAL_50:.*]]:2 = fork [2] %[[VAL_49]] : index
 // CHECK:           %[[VAL_51:.*]] = arith.cmpi sgt, %[[VAL_39]]#3, %[[VAL_50]]#1 : index
-// CHECK:           %[[VAL_52:.*]] = mux %[[VAL_51]] {{\[}}%[[VAL_50]]#0, %[[VAL_39]]#2] : i1, index
+// CHECK:           %[[VAL_52:.*]] = select %[[VAL_51]], %[[VAL_50]]#0, %[[VAL_39]]#2 : index
 // CHECK:           %[[VAL_53:.*]] = constant %[[VAL_46]]#1 {value = 10 : index} : index
 // CHECK:           %[[VAL_54:.*]] = arith.addi %[[VAL_39]]#1, %[[VAL_53]] : index
 // CHECK:           %[[VAL_55:.*]]:2 = fork [2] %[[VAL_54]] : index
 // CHECK:           %[[VAL_56:.*]] = arith.cmpi slt, %[[VAL_41]]#2, %[[VAL_55]]#1 : index
-// CHECK:           %[[VAL_57:.*]] = mux %[[VAL_56]] {{\[}}%[[VAL_55]]#0, %[[VAL_41]]#1] : i1, index
+// CHECK:           %[[VAL_57:.*]] = select %[[VAL_56]], %[[VAL_55]]#0, %[[VAL_41]]#1 : index
 // CHECK:           %[[VAL_58:.*]] = constant %[[VAL_46]]#0 {value = 1 : index} : index
 // CHECK:           %[[VAL_59:.*]] = br %[[VAL_39]]#0 : index
 // CHECK:           %[[VAL_60:.*]] = br %[[VAL_41]]#0 : index

--- a/test/Conversion/StandardToHandshake/test4.mlir
+++ b/test/Conversion/StandardToHandshake/test4.mlir
@@ -20,7 +20,7 @@
 // CHECK:           sink %[[VAL_18]] : i32
 // CHECK:           %[[VAL_19:.*]] = arith.remui %[[VAL_10]]#4, %[[VAL_12]]#4 : i32
 // CHECK:           sink %[[VAL_19]] : i32
-// CHECK:           %[[VAL_20:.*]] = mux %[[VAL_15]] {{\[}}%[[VAL_12]]#3, %[[VAL_10]]#3] : i1, i32
+// CHECK:           %[[VAL_20:.*]] = select %[[VAL_15]], %[[VAL_12]]#3, %[[VAL_10]]#3 : i32
 // CHECK:           sink %[[VAL_20]] : i32
 // CHECK:           %[[VAL_21:.*]] = arith.divf %[[VAL_6]]#1, %[[VAL_8]]#1 : f32
 // CHECK:           sink %[[VAL_21]] : f32

--- a/test/Conversion/StandardToHandshake/test6.mlir
+++ b/test/Conversion/StandardToHandshake/test6.mlir
@@ -22,7 +22,7 @@
 // CHECK:           sink %[[VAL_20]] : i32
 // CHECK:           %[[VAL_21:.*]] = arith.remui %[[VAL_9]]#4, %[[VAL_11]]#4 : i32
 // CHECK:           sink %[[VAL_21]] : i32
-// CHECK:           %[[VAL_22:.*]] = mux %[[VAL_16]] {{\[}}%[[VAL_11]]#3, %[[VAL_9]]#3] : i1, i32
+// CHECK:           %[[VAL_22:.*]] = select %[[VAL_16]], %[[VAL_11]]#3, %[[VAL_9]]#3 : i32
 // CHECK:           sink %[[VAL_22]] : i32
 // CHECK:           %[[VAL_23:.*]] = arith.divf %[[VAL_13]]#2, %[[VAL_7]]#1 : f32
 // CHECK:           sink %[[VAL_23]] : f32


### PR DESCRIPTION
The select operation will select between two inputs based on an input conditional. The select operation differs from a mux in that:
1. both operands must be valid before the operation can transact
2. both operands will be transacted once one of them is selected

We previously lowered select operations directly to mux'es, however, this is incorrect. Since a mux will only transact the selected input, the other input (and the entire upstream path that generates the input) will be left stuck, waiting for the mux to transact.