### PR TITLE
[FIRRTL] Value probe operation

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -202,3 +202,14 @@ def ForceOp : FIRRTLOp<"force", [SameTypeOperands]> {
   let assemblyFormat =
     "$dest `,` $src attr-dict `:` type($dest) `,` type($src)";
 }
+
+def ProbeOp : FIRRTLOp<"probe", []> {
+  let summary = "FIRRTL Value Probe";
+  let description = [{
+
+  }];
+  let arguments = (ins OptionalAttr<SymbolNameAttr>:$inner_sym, Variadic<FIRRTLType>:$operands);
+  let results = (outs);
+
+  let assemblyFormat = "`sym` $inner_sym $operands attr-dict `:` type($operands)";
+}

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -208,8 +208,9 @@ def ProbeOp : FIRRTLOp<"probe", []> {
   let description = [{
 
   }];
-  let arguments = (ins OptionalAttr<SymbolNameAttr>:$inner_sym, Variadic<FIRRTLType>:$operands);
+  let arguments = (ins SymbolNameAttr:$inner_sym, Variadic<FIRRTLType>:$operands);
   let results = (outs);
 
   let assemblyFormat = "`sym` $inner_sym $operands attr-dict `:` type($operands)";
 }
+

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -156,4 +156,17 @@ firrtl.module @LowerToBind() {
 firrtl.nla @NLA1 [] []
 firrtl.nla @NLA2 [@InstanceLowerToBind] ["foo"]
 
+
+// CHECK-LABEL: @ProbeTest
+firrtl.module @ProbeTest(in %in1 : !firrtl.uint<2>, in %in2 : !firrtl.uint<3>, out %out3: !firrtl.uint<3>) {
+  %w1 = firrtl.wire  : !firrtl.uint<4>
+  // CHECK: %[[TMP3:.+]] = firrtl.cat
+  %w2 = firrtl.cat %in1, %in1 : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<4>
+  firrtl.connect %w1, %w2 : !firrtl.uint<4>, !firrtl.uint<4>
+  firrtl.connect %out3, %in2 : !firrtl.uint<3>, !firrtl.uint<3>
+  %someNode = firrtl.node %in1 : !firrtl.uint<2>
+  // CHECK: firrtl.probe sym @foobar %in1, %in2, %out3, %w1, %[[TMP3]], %someNode : !firrtl.uint<2>, !firrtl.uint<3>, !firrtl.uint<3>, !firrtl.uint<4>, !firrtl.uint<4>, !firrtl.uint<2>
+  firrtl.probe sym @foobar %in1, %in2, %out3, %w1, %w2, %someNode : !firrtl.uint<2>, !firrtl.uint<3>, !firrtl.uint<3>, !firrtl.uint<4>, !firrtl.uint<4>, !firrtl.uint<2>
+}
+
 }


### PR DESCRIPTION
A minimal semantics value probe operation which allows extracting values out of a module without needing to route each through a symboled entity which restricts transformation.

This will be used for binds and GrandCentral views.