### PR TITLE
[MSFT] Fix naming issue in `MSFTModuleOp::removePorts`

### DIFF
--- a/include/circt/Dialect/MSFT/MSFTOps.h
+++ b/include/circt/Dialect/MSFT/MSFTOps.h
@@ -17,6 +17,7 @@
 #include "circt/Support/LLVM.h"
 
 #include "mlir/IR/BuiltinAttributes.h"
+#include "llvm/ADT/BitVector.h"
 
 #define GET_OP_CLASSES
 #include "circt/Dialect/MSFT/MSFT.h.inc"

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -104,7 +104,7 @@ def MSFTModuleOp : MSFTOp<"module",
     // Remove the ports at the specified indexes. Returns the new to old result
     // mapping.
     SmallVector<unsigned>
-    removePorts(ArrayRef<unsigned> inputs, ArrayRef<unsigned> outputs);
+    removePorts(llvm::BitVector inputs, llvm::BitVector outputs);
 
     // Get the module's symbolic name as StringAttr.
     StringAttr getNameAttr() {

--- a/lib/Dialect/MSFT/MSFTPasses.cpp
+++ b/lib/Dialect/MSFT/MSFTPasses.cpp
@@ -749,12 +749,13 @@ void WireCleanupPass::runOnOperation() {
 void WireCleanupPass::bubbleWiresUp(MSFTModuleOp mod) {
   Block *body = mod.getBodyBlock();
   Operation *terminator = body->getTerminator();
+  hw::ModulePortInfo ports = mod.getPorts();
 
   // Find all "passthough" internal wires, filling 'inputPortsToRemove' as a
   // side-effect.
   DenseMap<Value, hw::PortInfo> passThroughs;
-  SmallVector<unsigned> inputPortsToRemove;
-  for (hw::PortInfo inputPort : mod.getPorts().inputs) {
+  llvm::BitVector inputPortsToRemove(ports.inputs.size());
+  for (hw::PortInfo inputPort : ports.inputs) {
     BlockArgument portArg = body->getArgument(inputPort.argNum);
     bool removePort = true;
     for (OpOperand user : portArg.getUsers()) {
@@ -764,14 +765,14 @@ void WireCleanupPass::bubbleWiresUp(MSFTModuleOp mod) {
         removePort = false;
     }
     if (removePort)
-      inputPortsToRemove.push_back(inputPort.argNum);
+      inputPortsToRemove.set(inputPort.argNum);
   }
 
   // Find all output ports which we can remove. Fill in 'outputToInputIdx' to
   // help rewire instantiations later on.
   DenseMap<unsigned, unsigned> outputToInputIdx;
-  SmallVector<unsigned> outputPortsToRemove;
-  for (hw::PortInfo outputPort : mod.getPorts().outputs) {
+  llvm::BitVector outputPortsToRemove(ports.outputs.size());
+  for (hw::PortInfo outputPort : ports.outputs) {
     assert(outputPort.argNum < terminator->getNumOperands() && "Invalid IR");
     Value outputValue = terminator->getOperand(outputPort.argNum);
     auto inputNumF = passThroughs.find(outputValue);
@@ -779,7 +780,7 @@ void WireCleanupPass::bubbleWiresUp(MSFTModuleOp mod) {
       continue;
     hw::PortInfo inputPort = inputNumF->second;
     outputToInputIdx[outputPort.argNum] = inputPort.argNum;
-    outputPortsToRemove.push_back(outputPort.argNum);
+    outputPortsToRemove.set(outputPort.argNum);
   }
 
   // Use MSFTModuleOp's `removePorts` method to remove the ports. It returns a
@@ -789,7 +790,6 @@ void WireCleanupPass::bubbleWiresUp(MSFTModuleOp mod) {
       mod.removePorts(inputPortsToRemove, outputPortsToRemove);
 
   // Update the instantiations.
-  llvm::sort(inputPortsToRemove);
   auto setPassthroughsGetOperands = [&](InstanceOp newInst, InstanceOp oldInst,
                                         SmallVectorImpl<Value> &newOperands) {
     // Re-map the passthrough values around the instance.
@@ -803,15 +803,10 @@ void WireCleanupPass::bubbleWiresUp(MSFTModuleOp mod) {
     }
     // Use a sort-merge-join approach to figure out the operand mapping on the
     // fly.
-    size_t mergeCtr = 0;
     for (size_t operNum = 0, e = oldInst.getNumOperands(); operNum < e;
-         ++operNum) {
-      if (mergeCtr < inputPortsToRemove.size() &&
-          operNum == inputPortsToRemove[mergeCtr])
-        ++mergeCtr;
-      else
+         ++operNum)
+      if (!inputPortsToRemove.test(operNum))
         newOperands.push_back(oldInst.getOperand(operNum));
-    }
   };
   updateInstances(mod, newToOldResult, setPassthroughsGetOperands);
 }
@@ -830,7 +825,7 @@ void WireCleanupPass::sinkWiresDown(MSFTModuleOp mod) {
   // drives it. Populate 'resultsToErase' with output ports which only drive
   // input ports.
   DenseMap<unsigned, unsigned> inputToOutputLoopback;
-  SmallVector<unsigned> resultsToErase; // This is sorted.
+  llvm::BitVector resultsToErase(inst.getNumResults());
   for (unsigned resNum = 0, e = inst.getNumResults(); resNum < e; ++resNum) {
     bool allLoops = true;
     for (auto &use : inst.getResult(resNum).getUses()) {
@@ -840,37 +835,31 @@ void WireCleanupPass::sinkWiresDown(MSFTModuleOp mod) {
         inputToOutputLoopback[use.getOperandNumber()] = resNum;
     }
     if (allLoops)
-      resultsToErase.push_back(resNum);
+      resultsToErase.set(resNum);
   }
 
   // Add internal connections to replace the instantiation's loop back
   // connections.
   Block *body = mod.getBodyBlock();
   Operation *terminator = body->getTerminator();
-  SmallVector<unsigned> argsToErase;
+  llvm::BitVector argsToErase(body->getNumArguments());
   for (auto resOper : inputToOutputLoopback) {
     body->getArgument(resOper.first)
         .replaceAllUsesWith(terminator->getOperand(resOper.second));
-    argsToErase.push_back(resOper.first);
+    argsToErase.set(resOper.first);
   }
 
   // Remove the ports.
   SmallVector<unsigned> newToOldResultMap =
       mod.removePorts(argsToErase, resultsToErase);
   // and update the instantiations.
-  llvm::sort(argsToErase);
   auto getOperands = [&](InstanceOp newInst, InstanceOp oldInst,
                          SmallVectorImpl<Value> &newOperands) {
     // Use sort-merge-join to compute the new operands;
-    unsigned mergeJoinCtr = 0;
     for (unsigned argNum = 0, e = oldInst.getNumOperands(); argNum < e;
-         ++argNum) {
-      if (mergeJoinCtr < argsToErase.size() &&
-          argNum == argsToErase[mergeJoinCtr])
-        ++mergeJoinCtr;
-      else
+         ++argNum)
+      if (!argsToErase.test(argNum))
         newOperands.push_back(oldInst.getOperand(argNum));
-    }
   };
   updateInstances(mod, newToOldResultMap, getOperands);
 }

--- a/test/Dialect/MSFT/partition.mlir
+++ b/test/Dialect/MSFT/partition.mlir
@@ -41,17 +41,17 @@ msft.module @B {} (%clk : i1) -> (x: i2)  {
 // CHECK:    msft.output %b.unit1.foo_x, %b.seq.compreg, %b.unit2.foo_x, %unit1.foo_x : i2, i2, i2, i2
 
 // CLEANUP-LABEL: msft.module @top {} (%clk: i1) -> (out1: i2, out2: i2) {
-// CLEANUP:    %part1.b.unit1.foo_x, %part1.b.seq.compreg.b.seq.compreg = msft.instance @part1 @dp(%b.x, %clk, %c0_i2)  : (i2, i1, i2) -> (i2, i2)
-// CLEANUP:    %b.x = msft.instance @b @B()  : () -> i2
+// CLEANUP:    %part1.b.unit2.foo_x, %part1.unit1.foo_x = msft.instance @part1 @dp(%b.unit1.foo_a, %clk, %c0_i2)  : (i2, i1, i2) -> (i2, i2)
+// CLEANUP:    %b.unit1.foo_a = msft.instance @b @B()  : () -> i2
 // CLEANUP:    %c0_i2 = hw.constant 0 : i2
-// CLEANUP:    msft.output %part1.b.unit1.foo_x, %part1.b.seq.compreg.b.seq.compreg : i2, i2
+// CLEANUP:    msft.output %part1.b.unit2.foo_x, %part1.unit1.foo_x : i2, i2
 // CLEANUP-LABEL: msft.module.extern @Extern(%foo_a: i2) -> (foo_x: i2)
-// CLEANUP-LABEL: msft.module @B {} () -> (x: i2) {
+// CLEANUP-LABEL: msft.module @B {} () -> (unit1.foo_a: i2) {
 // CLEANUP:    %c1_i2 = hw.constant 1 : i2
 // CLEANUP:    msft.output %c1_i2 : i2
-// CLEANUP-LABEL: msft.module @dp {} (%b.unit1.foo_a: i2, %b.seq.compreg.in0: i1, %b.seq.compreg.in1: i2) -> (b.unit1.foo_x: i2, b.seq.compreg.b.seq.compreg: i2) {
+// CLEANUP-LABEL: msft.module @dp {} (%b.unit1.foo_a: i2, %b.seq.compreg.in1: i1, %unit1.foo_a: i2) -> (b.unit2.foo_x: i2, unit1.foo_x: i2)
 // CLEANUP:    %b.unit1.foo_x = msft.instance @b.unit1 @Extern(%b.unit1.foo_a)  : (i2) -> i2
-// CLEANUP:    %b.seq.compreg = seq.compreg %b.unit1.foo_x, %b.seq.compreg.in0 : i2
+// CLEANUP:    %b.seq.compreg = seq.compreg %b.unit1.foo_x, %b.seq.compreg.in1 : i2
 // CLEANUP:    %b.unit2.foo_x = msft.instance @b.unit2 @Extern(%b.seq.compreg)  : (i2) -> i2
-// CLEANUP:    %unit1.foo_x = msft.instance @unit1 @Extern(%b.seq.compreg.in1)  : (i2) -> i2
+// CLEANUP:    %unit1.foo_x = msft.instance @unit1 @Extern(%unit1.foo_a)  : (i2) -> i2
 // CLEANUP:    msft.output %b.unit2.foo_x, %unit1.foo_x : i2, i2


### PR DESCRIPTION
We were fixing up the function type, but neglected to fix the `argNames`
and `resultNames` attributes. This did not affect functional
correctness, "just" the port names.