### PR TITLE
[FIRRTL] Add InferReadWrite Pass

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -40,6 +40,8 @@ std::unique_ptr<mlir::Pass> createIMConstPropPass();
 
 std::unique_ptr<mlir::Pass> createInlinerPass();
 
+std::unique_ptr<mlir::Pass> createInferReadWritePass();
+
 std::unique_ptr<mlir::Pass> createBlackBoxMemoryPass();
 
 std::unique_ptr<mlir::Pass>

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -343,8 +343,12 @@ def RemoveResets : Pass<"firrtl-remove-resets", "firrtl::FModuleOp"> {
 def InferReadWrite : Pass<"firrtl-infer-rw", "firrtl::FModuleOp"> {
   let summary = "Infer the read-write memory port";
   let description = [{
-    This pass merges the read and write ports of a memory,
-    if the enable conditions are mutually exclusive.
+    This pass merges the read and write ports of a memory, based a simple
+    module-scoped heuristic. The heuristic checks if the read and write enable
+    conditions are mutually exclusive.
+    The heuristic tries to break up the read enable and write enable logic into an
+    `AND` expression tree. It then compares the read and write `AND` terms,
+    looking for a situation where the read/write is the complement of the write/read. 
   }];
   let constructor = "circt::firrtl::createInferReadWritePass()";
 }

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -340,4 +340,13 @@ def RemoveResets : Pass<"firrtl-remove-resets", "firrtl::FModuleOp"> {
   let constructor = "circt::firrtl::createRemoveResetsPass()";
 }
 
+def InferReadWrite : Pass<"firrtl-infer-rw", "firrtl::FModuleOp"> {
+  let summary = "Infer the read-write memory port";
+  let description = [{
+    This pass merges the read and write ports of a memory,
+    if the enable conditions are mutually exclusive.
+  }];
+  let constructor = "circt::firrtl::createInferReadWritePass()";
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_PASSES_TD

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -10,6 +10,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   GrandCentralSignalMappings.cpp
   IMConstProp.cpp
   InferResets.cpp
+  InferReadWrite.cpp
   InferWidths.cpp
   LowerAnnotations.cpp
   LowerCHIRRTL.cpp

--- a/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
@@ -187,7 +187,7 @@ struct InferReadWritePass : public InferReadWriteBase<InferReadWritePass> {
 private:
   // Get the source value which is connected to the dst.
   Value getConnectSrc(Value dst) {
-    for (auto c : dst.getUsers())
+    for (auto *c : dst.getUsers())
       if (auto connect = dyn_cast<ConnectOp>(c))
         if (connect.dest() == dst)
           return connect.src();

--- a/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
@@ -136,7 +136,8 @@ struct InferReadWritePass : public InferReadWriteBase<InferReadWritePass> {
       auto wAddr = builder.create<WireOp>(addr.getType(), "writeAddr");
       auto wEnWire = builder.create<WireOp>(enb.getType(), "writeEnable");
       auto rEnWire = builder.create<WireOp>(enb.getType(), "readEnable");
-      auto writeClock = builder.create<WireOp>(ClockType::get(enb.getContext()));
+      auto writeClock =
+          builder.create<WireOp>(ClockType::get(enb.getContext()));
       // addr = Mux(WriteEnable, WriteAddress, ReadAddress).
       builder.create<ConnectOp>(
           addr, builder.create<MuxPrimOp>(wEnWire, wAddr, rAddr));

--- a/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
@@ -18,6 +18,8 @@
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "llvm/ADT/APSInt.h"
+#include "llvm/ADT/StringSwitch.h"
+#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
 
 #define DEBUG_TYPE "firrtl-infer-read-write"
@@ -69,25 +71,10 @@ struct InferReadWritePass : public InferReadWriteBase<InferReadWritePass> {
           }
         // End of loop for getting MemOp port users.
       }
-      if (rClock != wClock) {
-        DenseSet<Value> rClocks, wClocks;
-        while (rClock) {
-          rClocks.insert(rClock);
-          rClock = getConnectSrc(rClock);
-        }
+      if (!sameDrive(rClock, wClock))
+        continue;
 
-        bool sameClock = false;
-        while (wClock) {
-          if (rClocks.find(wClock) != rClocks.end()) {
-            sameClock = true;
-            break;
-          }
-          wClock = getConnectSrc(wClock);
-        }
-        if (!sameClock)
-          continue;
-        rClock = wClock;
-      }
+      rClock = wClock;
       LLVM_DEBUG(
           llvm::dbgs() << "\n read clock:" << rClock
                        << " --- write clock:" << wClock;
@@ -100,112 +87,103 @@ struct InferReadWritePass : public InferReadWriteBase<InferReadWritePass> {
                                                << "\n term::" << t;
 
       );
-      // If the read and write clocks are the same and the product terms have a
-      // complement of each other.
-      if (checkComplement(portTerms)) {
-        SmallVector<Attribute, 4> resultNames;
-        SmallVector<Type, 4> resultTypes;
-        SmallVector<Attribute, 4> portAnnotations;
-        // There is only a single port, the rw.
-        resultNames.push_back(
-            StringAttr::get(modNamespace.newName("rw"), mem.getContext()));
-        // Set the type of the rw port.
-        resultTypes.push_back(MemOp::getTypeForPort(
-            mem.depth(), mem.getDataType(), MemOp::PortKind::ReadWrite,
-            mem.getMaskBits()));
-        ImplicitLocOpBuilder builder(mem.getLoc(), mem);
-        SmallVector<Attribute> portAtts;
-        // Append the annotations from the two ports.
-        if (!mem.portAnnotations()[0].cast<ArrayAttr>().empty())
-          portAtts.push_back(mem.portAnnotations()[0]);
-        if (!mem.portAnnotations()[1].cast<ArrayAttr>().empty())
-          portAtts.push_back(mem.portAnnotations()[1]);
-        portAnnotations.push_back(builder.getArrayAttr(portAtts));
-        // Create the new rw memory.
-        auto rwMem = builder.create<MemOp>(
-            resultTypes, mem.readLatency(), mem.writeLatency(), mem.depth(),
-            RUWAttr::Undefined, builder.getArrayAttr(resultNames),
-            mem.nameAttr(), mem.annotations(),
-            builder.getArrayAttr(portAnnotations), mem.inner_symAttr());
-        auto rwPort = rwMem.getResult(0);
-        // Create the subfield access to all fields of the port.
-        // The addr should be connected to read/write address depending on the
-        // read/write mode.
-        auto addr = builder.create<SubfieldOp>(rwPort, "addr");
-        // Enable is high whenever the memory is written or read.
-        auto enb = builder.create<SubfieldOp>(rwPort, "en");
-        // Read/Write clock.
-        auto clk = builder.create<SubfieldOp>(rwPort, "clk");
-        auto readData = builder.create<SubfieldOp>(rwPort, "rdata");
-        // wmode is high when the port is in write mode. That is this can be
-        // connected to the write enable.
-        auto wmode = builder.create<SubfieldOp>(rwPort, "wmode");
-        auto writeData = builder.create<SubfieldOp>(rwPort, "wdata");
-        auto mask = builder.create<SubfieldOp>(rwPort, "wmask");
-        // Temp wires to replace the original memory connects.
-        auto rAddr = builder.create<WireOp>(addr.getType(), "readAddr");
-        auto wAddr = builder.create<WireOp>(addr.getType(), "writeAddr");
-        auto wEnWire = builder.create<WireOp>(enb.getType(), "writeEnable");
-        auto rEnWire = builder.create<WireOp>(enb.getType(), "readEnable");
-        // addr = Mux(WriteEnable, WriteAddress, ReadAddress).
-        builder.create<ConnectOp>(
-            addr, builder.create<MuxPrimOp>(wEnWire, wAddr, rAddr));
-        // Enable = Or(WriteEnable, ReadEnable).
-        builder.create<ConnectOp>(enb,
-                                  builder.create<OrPrimOp>(rEnWire, wEnWire));
-        // WriteMode = WriteEnable.
-        builder.create<ConnectOp>(wmode, wEnWire);
-        // Now iterate over the original memory read and write ports.
-        for (auto portIt : llvm::enumerate(mem.results())) {
-          // Get the port value.
-          Value portVal = portIt.value();
-          // Get the port kind.
-          bool readPort =
-              mem.getPortKind(portIt.index()) == MemOp::PortKind::Read;
-          // Iterate over all users of the port, which are the subfield ops, and
-          // replace them.
-          for (Operation *u : portVal.getUsers())
-            if (auto sf = dyn_cast<SubfieldOp>(u)) {
-              auto fName =
-                  sf.input().getType().cast<BundleType>().getElementName(
-                      sf.fieldIndex());
-              if (fName.equals("en")) {
-                if (readPort)
-                  sf->replaceAllUsesWith(rEnWire);
-                else
-                  sf->replaceAllUsesWith(wEnWire);
-              } else if (fName.equals("clk")) {
-                if (readPort)
-                  sf->replaceAllUsesWith(clk);
-                else {
-                  auto dummyWire = builder.create<WireOp>(sf.getType());
-                  sf->replaceAllUsesWith(dummyWire);
-                }
-              } else if (fName.equals("addr")) {
-                if (readPort)
-                  sf->replaceAllUsesWith(rAddr);
-                else
-                  sf->replaceAllUsesWith(wAddr);
-              } else if (fName.equals("data")) {
-                if (readPort)
-                  sf->replaceAllUsesWith(readData);
-                else
-                  sf->replaceAllUsesWith(writeData);
-              } else if (fName.equals("mask")) {
-                if (!readPort)
-                  sf->replaceAllUsesWith(mask);
-              }
-              // Once all the uses of the subfield op replaced, delete it.
-              sf.erase();
-            }
-        }
-        // All uses for all results of mem removed, now erase the mem.
-        mem.erase();
+      // If the read and write clocks are the same, check if any of the product
+      // terms are a complement of each other.
+      if (!checkComplement(portTerms))
+        continue;
+
+      SmallVector<Attribute, 4> resultNames;
+      SmallVector<Type, 4> resultTypes;
+      SmallVector<Attribute, 4> portAnnotations;
+      // Create the merged rw port for the new memory.
+      resultNames.push_back(
+          StringAttr::get(modNamespace.newName("rw"), mem.getContext()));
+      // Set the type of the rw port.
+      resultTypes.push_back(
+          MemOp::getTypeForPort(mem.depth(), mem.getDataType(),
+                                MemOp::PortKind::ReadWrite, mem.getMaskBits()));
+      ImplicitLocOpBuilder builder(mem.getLoc(), mem);
+      SmallVector<Attribute> portAtts;
+      // Append the annotations from the two ports.
+      if (!mem.portAnnotations()[0].cast<ArrayAttr>().empty())
+        portAtts.push_back(mem.portAnnotations()[0]);
+      if (!mem.portAnnotations()[1].cast<ArrayAttr>().empty())
+        portAtts.push_back(mem.portAnnotations()[1]);
+      portAnnotations.push_back(builder.getArrayAttr(portAtts));
+      // Create the new rw memory.
+      auto rwMem = builder.create<MemOp>(
+          resultTypes, mem.readLatency(), mem.writeLatency(), mem.depth(),
+          RUWAttr::Undefined, builder.getArrayAttr(resultNames), mem.nameAttr(),
+          mem.annotations(), builder.getArrayAttr(portAnnotations),
+          mem.inner_symAttr());
+      auto rwPort = rwMem.getResult(0);
+      // Create the subfield access to all fields of the port.
+      // The addr should be connected to read/write address depending on the
+      // read/write mode.
+      auto addr = builder.create<SubfieldOp>(rwPort, "addr");
+      // Enable is high whenever the memory is written or read.
+      auto enb = builder.create<SubfieldOp>(rwPort, "en");
+      // Read/Write clock.
+      auto clk = builder.create<SubfieldOp>(rwPort, "clk");
+      auto readData = builder.create<SubfieldOp>(rwPort, "rdata");
+      // wmode is high when the port is in write mode. That is this can be
+      // connected to the write enable.
+      auto wmode = builder.create<SubfieldOp>(rwPort, "wmode");
+      auto writeData = builder.create<SubfieldOp>(rwPort, "wdata");
+      auto mask = builder.create<SubfieldOp>(rwPort, "wmask");
+      // Temp wires to replace the original memory connects.
+      auto rAddr = builder.create<WireOp>(addr.getType(), "readAddr");
+      auto wAddr = builder.create<WireOp>(addr.getType(), "writeAddr");
+      auto wEnWire = builder.create<WireOp>(enb.getType(), "writeEnable");
+      auto rEnWire = builder.create<WireOp>(enb.getType(), "readEnable");
+      // addr = Mux(WriteEnable, WriteAddress, ReadAddress).
+      builder.create<ConnectOp>(
+          addr, builder.create<MuxPrimOp>(wEnWire, wAddr, rAddr));
+      // Enable = Or(WriteEnable, ReadEnable).
+      builder.create<ConnectOp>(enb,
+                                builder.create<OrPrimOp>(rEnWire, wEnWire));
+      // WriteMode = WriteEnable.
+      builder.create<ConnectOp>(wmode, wEnWire);
+      // Now iterate over the original memory read and write ports.
+      for (auto portIt : llvm::enumerate(mem.results())) {
+        // Get the port value.
+        Value portVal = portIt.value();
+        // Get the port kind.
+        bool readPort =
+            mem.getPortKind(portIt.index()) == MemOp::PortKind::Read;
+        // Iterate over all users of the port, which are the subfield ops, and
+        // replace them.
+        for (Operation *u : portVal.getUsers())
+          if (auto sf = dyn_cast<SubfieldOp>(u)) {
+            StringRef fName =
+                sf.input().getType().cast<BundleType>().getElementName(
+                    sf.fieldIndex());
+            Value repl;
+            if (readPort)
+              repl = llvm::StringSwitch<Value>(fName)
+                         .Case("en", rEnWire)
+                         .Case("clk", clk)
+                         .Case("addr", rAddr)
+                         .Case("data", readData);
+            else
+              repl = llvm::StringSwitch<Value>(fName)
+                         .Case("en", wEnWire)
+                         .Case("clk", builder.create<WireOp>(sf.getType()))
+                         .Case("addr", wAddr)
+                         .Case("data", writeData)
+                         .Case("mask", mask);
+            sf.replaceAllUsesWith(repl);
+            // Once all the uses of the subfield op replaced, delete it.
+            sf.erase();
+          }
       }
+      // All uses for all results of mem removed, now erase the mem.
+      mem.erase();
     }
   }
 
 private:
+  // Get the source value which is connected to the dst.
   Value getConnectSrc(Value dst) {
     for (auto c : dst.getUsers())
       if (auto connect = dyn_cast<ConnectOp>(c))
@@ -215,43 +193,82 @@ private:
     return nullptr;
   }
 
-  void getProductTerms(Value a, SmallVector<Value> &terms) {
-    if (!a)
-      return;
-    terms.push_back(a);
-    if (a.isa<BlockArgument>())
-      return;
-    if (auto node = dyn_cast<NodeOp>(a.getDefiningOp()))
-      return getProductTerms(node.input(), terms);
+  /// If the ports are not directly connected to the same clock, then check
+  /// if indirectly connected to the same clock.
+  bool sameDriver(Value rClock, Value wClock) {
+    if (rClock == wClock)
+      return true;
+    DenseSet<Value> rClocks, wClocks;
+    while (rClock) {
+      // Record all the values which are indirectly connected to the clock
+      // port.
+      rClocks.insert(rClock);
+      rClock = getConnectSrc(rClock);
+    }
 
-    if (auto src = getConnectSrc(a))
-      return getProductTerms(src, terms);
-
-    if (auto op = a.getDefiningOp()) {
-      if (auto andOp = dyn_cast<AndPrimOp>(op)) {
-        for (auto i : op->getOperands())
-          getProductTerms(i, terms);
-        return;
-      } else if (auto muxOp = dyn_cast<MuxPrimOp>(op)) {
-        if (ConstantOp cLow =
-                dyn_cast_or_null<ConstantOp>(muxOp.low().getDefiningOp()))
-          if (cLow.value().isZero()) {
-            getProductTerms(muxOp.sel(), terms);
-            getProductTerms(muxOp.high(), terms);
-            return;
-          }
+    bool sameClock = false;
+    // Now check all the indirect connections to the write memory clock
+    // port.
+    while (wClock) {
+      if (rClocks.find(wClock) != rClocks.end()) {
+        sameClock = true;
+        break;
       }
+      wClock = getConnectSrc(wClock);
+    }
+    return sameClock;
+  }
+
+  void getProductTerms(Value enValue, SmallVector<Value> &terms) {
+    if (!enValue)
+      return;
+    SmallVector<Value> worklist;
+    worklist.push_back(enValue);
+    while (!worklist.empty()) {
+      auto term = worklist.back();
+      worklist.pop_back();
+      terms.push_back(term);
+      if (term.isa<BlockArgument>())
+        continue;
+      TypeSwitch<Operation *>(term.getDefiningOp())
+          .Case<NodeOp>([&](auto n) { worklist.push_back(n.input()); })
+          .Case<AndPrimOp>([&](AndPrimOp andOp) {
+            worklist.push_back(andOp.getOperand(0));
+            worklist.push_back(andOp.getOperand(1));
+          })
+          .Case<MuxPrimOp>([&](auto muxOp) {
+            // Check for the pattern when low is 0, which is equivalent to (sel
+            // & high)
+            // term = mux (sel, high, 0) => term = sel & high
+            if (ConstantOp cLow =
+                    dyn_cast_or_null<ConstantOp>(muxOp.low().getDefiningOp()))
+              if (cLow.value().isZero()) {
+                worklist.push_back(muxOp.sel());
+                worklist.push_back(muxOp.high());
+              }
+          })
+          .Default([&](auto) {
+            if (auto src = getConnectSrc(term))
+              worklist.push_back(src);
+          });
     }
   }
 
+  /// Check if any of the terms in the prodTerms[0] is a complement of any of
+  /// the terms in prodTerms[1]. prodTerms[0], prodTerms[1] is a vector of
+  /// Value, each of which correspond to the two product terms of read/write
+  /// enable.
   bool checkComplement(SmallVector<Value> prodTerms[2]) {
     bool isComplement = false;
+    // Foreach Value in first term, check if it is the complement of any of the
+    // Value in second term.
     for (auto t1 : prodTerms[0])
       for (auto t2 : prodTerms[1]) {
+        // Return true if t1 is a Not of t2.
         if (!t1.isa<BlockArgument>() && isa<NotPrimOp>(t1.getDefiningOp()))
           if (cast<NotPrimOp>(t1.getDefiningOp()).input() == t2)
             return true;
-
+        // Else Return true if t2 is a Not of t1.
         if (!t2.isa<BlockArgument>() && isa<NotPrimOp>(t2.getDefiningOp()))
           if (cast<NotPrimOp>(t2.getDefiningOp()).input() == t1)
             return true;

--- a/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
@@ -71,7 +71,7 @@ struct InferReadWritePass : public InferReadWriteBase<InferReadWritePass> {
           }
         // End of loop for getting MemOp port users.
       }
-      if (!sameDrive(rClock, wClock))
+      if (!sameDriver(rClock, wClock))
         continue;
 
       rClock = wClock;
@@ -136,6 +136,7 @@ struct InferReadWritePass : public InferReadWriteBase<InferReadWritePass> {
       auto wAddr = builder.create<WireOp>(addr.getType(), "writeAddr");
       auto wEnWire = builder.create<WireOp>(enb.getType(), "writeEnable");
       auto rEnWire = builder.create<WireOp>(enb.getType(), "readEnable");
+      auto writeClock = builder.create<WireOp>(ClockType::get(enb.getContext()));
       // addr = Mux(WriteEnable, WriteAddress, ReadAddress).
       builder.create<ConnectOp>(
           addr, builder.create<MuxPrimOp>(wEnWire, wAddr, rAddr));
@@ -168,7 +169,7 @@ struct InferReadWritePass : public InferReadWriteBase<InferReadWritePass> {
             else
               repl = llvm::StringSwitch<Value>(fName)
                          .Case("en", wEnWire)
-                         .Case("clk", builder.create<WireOp>(sf.getType()))
+                         .Case("clk", writeClock)
                          .Case("addr", wAddr)
                          .Case("data", writeData)
                          .Case("mask", mask);

--- a/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
@@ -1,0 +1,268 @@
+//===- InferReadWrite.cpp - Infer Read Write Memory -------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the InferReadWrite pass.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLAnnotations.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
+#include "circt/Dialect/FIRRTL/Namespace.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "llvm/ADT/APSInt.h"
+#include "llvm/Support/Debug.h"
+#include <set>
+
+#define DEBUG_TYPE "firrtl-infer-read-write"
+
+using namespace circt;
+using namespace firrtl;
+
+namespace {
+struct InferReadWritePass : public InferReadWriteBase<InferReadWritePass> {
+
+  void runOnOperation() override {
+    LLVM_DEBUG(llvm::dbgs() << "\n Running Infer Read Write on module:"
+                            << getOperation().getName());
+    ModuleNamespace modNamespace(getOperation());
+    for (MemOp mem : llvm::make_early_inc_range(
+             getOperation().getBody()->getOps<MemOp>())) {
+      size_t nReads, nWrites, nRWs;
+      mem.getNumPorts(nReads, nWrites, nRWs);
+      // Run the analysis only for Seq memories (latency=1) and a single read
+      // and write ports.
+      if (!(nReads == 1 && nWrites == 1 && nRWs == 0) ||
+          !(mem.readLatency() == 1 && mem.writeLatency() == 1))
+        continue;
+      Value rClock, wClock;
+      // The memory has exactly two ports.
+      SmallVector<Value> portTerms[2];
+      for (auto portIt : llvm::enumerate(mem.results())) {
+        // Get the port value.
+        Value portVal = portIt.value();
+        // Get the port kind.
+        bool readPort =
+            mem.getPortKind(portIt.index()) == MemOp::PortKind::Read;
+        // Iterate over all users of the port.
+        for (Operation *u : portVal.getUsers())
+          if (auto sf = dyn_cast<SubfieldOp>(u)) {
+            // Get the field name.
+            auto fName = sf.input().getType().cast<BundleType>().getElementName(
+                sf.fieldIndex());
+            // If this is the enable field, record the product terms(the And
+            // expression tree).
+            if (fName.equals("en"))
+              getProductTerms(sf, portTerms[portIt.index()]);
+            else if (fName.equals("clk")) {
+              if (readPort)
+                rClock = getConnectSrc(sf);
+              else
+                wClock = getConnectSrc(sf);
+            }
+          }
+        // End of loop for getting MemOp port users.
+      }
+      if (rClock != wClock) {
+        DenseSet<Value> rClocks, wClocks;
+        while (rClock) {
+          rClocks.insert(rClock);
+          rClock = getConnectSrc(rClock);
+        }
+
+        bool sameClock = false;
+        while (wClock) {
+          if (rClocks.find(wClock) != rClocks.end()) {
+            sameClock = true;
+            break;
+          }
+          wClock = getConnectSrc(wClock);
+        }
+        if (!sameClock)
+          continue;
+        rClock = wClock;
+      }
+      LLVM_DEBUG(
+          llvm::dbgs() << "\n read clock:" << rClock
+                       << " --- write clock:" << wClock;
+          llvm::dbgs() << "\n Read terms==>"; for (auto t
+                                                   : portTerms[0]) llvm::dbgs()
+                                              << "\n term::" << t;
+
+          llvm::dbgs() << "\n Write terms==>"; for (auto t
+                                                    : portTerms[1]) llvm::dbgs()
+                                               << "\n term::" << t;
+
+      );
+      // If the read and write clocks are the same and the product terms have a
+      // complement of each other.
+      if (checkComplement(portTerms)) {
+        SmallVector<Attribute, 4> resultNames;
+        SmallVector<Type, 4> resultTypes;
+        SmallVector<Attribute, 4> portAnnotations;
+        // There is only a single port, the rw.
+        resultNames.push_back(
+            StringAttr::get(modNamespace.newName("rw"), mem.getContext()));
+        // Set the type of the rw port.
+        resultTypes.push_back(MemOp::getTypeForPort(
+            mem.depth(), mem.getDataType(), MemOp::PortKind::ReadWrite,
+            mem.getMaskBits()));
+        ImplicitLocOpBuilder builder(mem.getLoc(), mem);
+        SmallVector<Attribute> portAtts;
+        // Append the annotations from the two ports.
+        if (!mem.portAnnotations()[0].cast<ArrayAttr>().empty())
+          portAtts.push_back(mem.portAnnotations()[0]);
+        if (!mem.portAnnotations()[1].cast<ArrayAttr>().empty())
+          portAtts.push_back(mem.portAnnotations()[1]);
+        portAnnotations.push_back(builder.getArrayAttr(portAtts));
+        // Create the new rw memory.
+        auto rwMem = builder.create<MemOp>(
+            resultTypes, mem.readLatency(), mem.writeLatency(), mem.depth(),
+            RUWAttr::Undefined, builder.getArrayAttr(resultNames),
+            mem.nameAttr(), mem.annotations(),
+            builder.getArrayAttr(portAnnotations), mem.inner_symAttr());
+        auto rwPort = rwMem.getResult(0);
+        // Create the subfield access to all fields of the port.
+        // The addr should be connected to read/write address depending on the
+        // read/write mode.
+        auto addr = builder.create<SubfieldOp>(rwPort, "addr");
+        // Enable is high whenever the memory is written or read.
+        auto enb = builder.create<SubfieldOp>(rwPort, "en");
+        // Read/Write clock.
+        auto clk = builder.create<SubfieldOp>(rwPort, "clk");
+        auto readData = builder.create<SubfieldOp>(rwPort, "rdata");
+        // wmode is high when the port is in write mode. That is this can be
+        // connected to the write enable.
+        auto wmode = builder.create<SubfieldOp>(rwPort, "wmode");
+        auto writeData = builder.create<SubfieldOp>(rwPort, "wdata");
+        auto mask = builder.create<SubfieldOp>(rwPort, "wmask");
+        // Temp wires to replace the original memory connects.
+        auto rAddr = builder.create<WireOp>(addr.getType(), "readAddr");
+        auto wAddr = builder.create<WireOp>(addr.getType(), "writeAddr");
+        auto wEnWire = builder.create<WireOp>(enb.getType(), "writeEnable");
+        auto rEnWire = builder.create<WireOp>(enb.getType(), "readEnable");
+        // addr = Mux(WriteEnable, WriteAddress, ReadAddress).
+        builder.create<ConnectOp>(
+            addr, builder.create<MuxPrimOp>(wEnWire, wAddr, rAddr));
+        // Enable = Or(WriteEnable, ReadEnable).
+        builder.create<ConnectOp>(enb,
+                                  builder.create<OrPrimOp>(rEnWire, wEnWire));
+        // WriteMode = WriteEnable.
+        builder.create<ConnectOp>(wmode, wEnWire);
+        // Now iterate over the original memory read and write ports.
+        for (auto portIt : llvm::enumerate(mem.results())) {
+          // Get the port value.
+          Value portVal = portIt.value();
+          // Get the port kind.
+          bool readPort =
+              mem.getPortKind(portIt.index()) == MemOp::PortKind::Read;
+          // Iterate over all users of the port, which are the subfield ops, and
+          // replace them.
+          for (Operation *u : portVal.getUsers())
+            if (auto sf = dyn_cast<SubfieldOp>(u)) {
+              auto fName =
+                  sf.input().getType().cast<BundleType>().getElementName(
+                      sf.fieldIndex());
+              if (fName.equals("en")) {
+                if (readPort)
+                  sf->replaceAllUsesWith(rEnWire);
+                else
+                  sf->replaceAllUsesWith(wEnWire);
+              } else if (fName.equals("clk")) {
+                if (readPort)
+                  sf->replaceAllUsesWith(clk);
+                else {
+                  auto dummyWire = builder.create<WireOp>(sf.getType());
+                  sf->replaceAllUsesWith(dummyWire);
+                }
+              } else if (fName.equals("addr")) {
+                if (readPort)
+                  sf->replaceAllUsesWith(rAddr);
+                else
+                  sf->replaceAllUsesWith(wAddr);
+              } else if (fName.equals("data")) {
+                if (readPort)
+                  sf->replaceAllUsesWith(readData);
+                else
+                  sf->replaceAllUsesWith(writeData);
+              } else if (fName.equals("mask")) {
+                if (!readPort)
+                  sf->replaceAllUsesWith(mask);
+              }
+              // Once all the uses of the subfield op replaced, delete it.
+              sf.erase();
+            }
+        }
+        // All uses for all results of mem removed, now erase the mem.
+        mem.erase();
+      }
+    }
+  }
+
+private:
+  Value getConnectSrc(Value dst) {
+    for (auto c : dst.getUsers())
+      if (auto connect = dyn_cast<ConnectOp>(c))
+        if (connect.dest() == dst)
+          return connect.src();
+
+    return nullptr;
+  }
+
+  void getProductTerms(Value a, SmallVector<Value> &terms) {
+    if (!a)
+      return;
+    terms.push_back(a);
+    if (a.isa<BlockArgument>())
+      return;
+    if (auto node = dyn_cast<NodeOp>(a.getDefiningOp()))
+      return getProductTerms(node.input(), terms);
+
+    if (auto src = getConnectSrc(a))
+      return getProductTerms(src, terms);
+
+    if (auto op = a.getDefiningOp()) {
+      if (auto andOp = dyn_cast<AndPrimOp>(op)) {
+        for (auto i : op->getOperands())
+          getProductTerms(i, terms);
+        return;
+      } else if (auto muxOp = dyn_cast<MuxPrimOp>(op)) {
+        if (ConstantOp cLow =
+                dyn_cast_or_null<ConstantOp>(muxOp.low().getDefiningOp()))
+          if (cLow.value().isZero()) {
+            getProductTerms(muxOp.sel(), terms);
+            getProductTerms(muxOp.high(), terms);
+            return;
+          }
+      }
+    }
+  }
+
+  bool checkComplement(SmallVector<Value> prodTerms[2]) {
+    bool isComplement = false;
+    for (auto t1 : prodTerms[0])
+      for (auto t2 : prodTerms[1]) {
+        if (!t1.isa<BlockArgument>() && isa<NotPrimOp>(t1.getDefiningOp()))
+          if (cast<NotPrimOp>(t1.getDefiningOp()).input() == t2)
+            return true;
+
+        if (!t2.isa<BlockArgument>() && isa<NotPrimOp>(t2.getDefiningOp()))
+          if (cast<NotPrimOp>(t2.getDefiningOp()).input() == t1)
+            return true;
+      }
+
+    return isComplement;
+  }
+};
+} // end anonymous namespace
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createInferReadWritePass() {
+  return std::make_unique<InferReadWritePass>();
+}

--- a/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
@@ -1,4 +1,4 @@
-//===- InferReadWrite.cpp - Infer Read Write Memory -------*- C++ -*-===//
+//===- InferReadWrite.cpp - Infer Read Write Memory -----------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -19,7 +19,6 @@
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "llvm/ADT/APSInt.h"
 #include "llvm/Support/Debug.h"
-#include <set>
 
 #define DEBUG_TYPE "firrtl-infer-read-write"
 

--- a/test/Dialect/FIRRTL/inferRW.mlir
+++ b/test/Dialect/FIRRTL/inferRW.mlir
@@ -1,0 +1,235 @@
+// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl.module(firrtl-infer-rw))' %s | FileCheck %s
+
+firrtl.circuit "TLRAM" {
+    firrtl.module @TLRAM(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %index: !firrtl.uint<4>, in %index2: !firrtl.uint<4>, in %data_0: !firrtl.uint<8>, in %wen: !firrtl.uint<1>, in %_T_29: !firrtl.uint<1>, out %auto_0: !firrtl.uint<8>) {
+      %mem_MPORT_en = firrtl.wire  : !firrtl.uint<1>
+      %mem_MPORT_data_0 = firrtl.wire  : !firrtl.uint<8>
+      %mem_0_MPORT, %mem_0_MPORT_1 = firrtl.mem Undefined  {depth = 16 : i64, name = "mem_0", portNames = ["MPORT", "MPORT_1"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+      // CHECK: %mem_0_rw = firrtl.mem Undefined  {depth = 16 : i64, name = "mem_0", portNames = ["rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, wdata: uint<8>, wmask: uint<1>>
+      %0 = firrtl.subfield %mem_0_MPORT(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.uint<4>
+      firrtl.connect %0, %index2 : !firrtl.uint<4>, !firrtl.uint<4>
+      %1 = firrtl.subfield %mem_0_MPORT(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.uint<1>
+      firrtl.connect %1, %mem_MPORT_en : !firrtl.uint<1>, !firrtl.uint<1>
+      %2 = firrtl.subfield %mem_0_MPORT(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.clock
+      firrtl.connect %2, %clock : !firrtl.clock, !firrtl.clock
+      %3 = firrtl.subfield %mem_0_MPORT(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.uint<8>
+      firrtl.connect %mem_MPORT_data_0, %3 : !firrtl.uint<8>, !firrtl.uint<8>
+      %4 = firrtl.subfield %mem_0_MPORT_1(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.uint<4>
+      firrtl.connect %4, %index : !firrtl.uint<4>, !firrtl.uint<4>
+      %5 = firrtl.subfield %mem_0_MPORT_1(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+      firrtl.connect %5, %wen : !firrtl.uint<1>, !firrtl.uint<1>
+      %6 = firrtl.subfield %mem_0_MPORT_1(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.clock
+      firrtl.connect %6, %clock : !firrtl.clock, !firrtl.clock
+      %7 = firrtl.subfield %mem_0_MPORT_1(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.uint<8>
+      firrtl.connect %7, %data_0 : !firrtl.uint<8>, !firrtl.uint<8>
+      %8 = firrtl.subfield %mem_0_MPORT_1(4) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.uint<1>
+      firrtl.connect %8, %_T_29 : !firrtl.uint<1>, !firrtl.uint<1>
+      %9 = firrtl.not %wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
+      firrtl.connect %mem_MPORT_en, %9 : !firrtl.uint<1>, !firrtl.uint<1>
+      %REG = firrtl.reg %clock  : !firrtl.uint<1>
+      firrtl.connect %REG, %9 : !firrtl.uint<1>, !firrtl.uint<1>
+      %r_0 = firrtl.reg %clock  : !firrtl.uint<8>
+      %10 = firrtl.mux(%REG, %mem_MPORT_data_0, %r_0) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+      firrtl.connect %r_0, %10 : !firrtl.uint<8>, !firrtl.uint<8>
+      %11 = firrtl.mux(%REG, %mem_MPORT_data_0, %r_0) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+      firrtl.connect %auto_0, %11 : !firrtl.uint<8>, !firrtl.uint<8>
+
+     // CHECK:  %[[v7:.+]] = firrtl.mux(%[[writeEnable:.+]], %[[writeAddr:.+]], %[[readAddr:.+]]) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+     // CHECK:  firrtl.connect %[[v0:.+]], %[[v7]] : !firrtl.uint<4>, !firrtl.uint<4>
+     // CHECK:  %[[v8:.+]] = firrtl.or %[[readEnable:.+]], %[[writeEnable]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+     // CHECK:  firrtl.connect %[[v1:.+]], %[[v8]] : !firrtl.uint<1>, !firrtl.uint<1>
+     // CHECK:  firrtl.connect %[[v4:.+]], %[[writeEnable]] : !firrtl.uint<1>, !firrtl.uint<1>
+     // CHECK:  %9 = firrtl.wire  : !firrtl.clock
+     // CHECK:  firrtl.connect %[[readAddr]], %[[index2:.+]] : !firrtl.uint<4>, !firrtl.uint<4>
+     // CHECK:  firrtl.connect %[[readEnable]], %mem_MPORT_en : !firrtl.uint<1>, !firrtl.uint<1>
+     // CHECK:  firrtl.connect %[[writeAddr]], %index : !firrtl.uint<4>, !firrtl.uint<4>
+     // CHECK:  firrtl.connect %[[writeEnable]], %wen : !firrtl.uint<1>, !firrtl.uint<1>
+     // CHECK:  %[[v10:.+]] = firrtl.not %wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
+     // CHECK:  firrtl.connect %mem_MPORT_en, %[[v10]] : !firrtl.uint<1>, !firrtl.uint<1>
+    }
+}
+
+firrtl.circuit "sram6t"   {
+// CHECK-LABEL: firrtl.module @sram6t
+  firrtl.module @sram6t(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_addr: !firrtl.uint<11>, in %io_valid: !firrtl.uint<1>, in %io_write: !firrtl.uint<1>, in %io_dataIn: !firrtl.uint<32>, out %io_dataOut: !firrtl.uint<32>) {
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    %mem__T_14, %mem__T_22 = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["_T_14", "_T_22"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>, !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
+      // CHECK: %mem_rw = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
+   // CHECK:   %[[v7:.+]] = firrtl.mux(%writeEnable, %writeAddr, %readAddr) : (!firrtl.uint<1>, !firrtl.uint<11>, !firrtl.uint<11>) -> !firrtl.uint<11>
+   // CHECK:   firrtl.connect %[[v0:.+]], %[[v7]] : !firrtl.uint<11>, !firrtl.uint<11>
+   // CHECK:   %8 = firrtl.or %readEnable, %writeEnable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %0 = firrtl.subfield %mem__T_14(0) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<11>
+    %1 = firrtl.subfield %mem__T_14(1) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
+    %2 = firrtl.subfield %mem__T_14(2) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.clock
+    %3 = firrtl.subfield %mem__T_14(3) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<32>
+    %4 = firrtl.subfield %mem__T_14(4) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
+    %5 = firrtl.subfield %mem__T_22(0) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<11>
+    %6 = firrtl.subfield %mem__T_22(1) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<1>
+    %7 = firrtl.subfield %mem__T_22(2) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.clock
+    %8 = firrtl.subfield %mem__T_22(3) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<32>
+    %9 = firrtl.and %io_valid, %io_write : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %10 = firrtl.not %io_write : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %11 = firrtl.and %io_valid, %10 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    firrtl.connect %0, %io_addr : !firrtl.uint<11>, !firrtl.uint<11>
+    firrtl.connect %1, %9 : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %2, %clock : !firrtl.clock, !firrtl.clock
+    firrtl.connect %4, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %3, %io_dataIn : !firrtl.uint<32>, !firrtl.uint<32>
+    %12 = firrtl.not %9 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %13 = firrtl.mux(%12, %11, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    firrtl.connect %6, %13 : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %5, %io_addr : !firrtl.uint<11>, !firrtl.uint<11>
+    firrtl.connect %7, %clock : !firrtl.clock, !firrtl.clock
+    firrtl.connect %io_dataOut, %8 : !firrtl.uint<32>, !firrtl.uint<32>
+  }
+// CHECK-LABEL: firrtl.module @sram7t
+  firrtl.module @sram7t(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_addr: !firrtl.uint<11>, in %io_valid: !firrtl.uint<1>, in %io_write: !firrtl.uint<1>, in %io_dataIn: !firrtl.uint<32>, out %io_dataOut: !firrtl.uint<32>) {
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    %mem__T_14, %mem__T_22 = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["_T_14", "_T_22"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>, !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
+      // CHECK: %mem__T_14, %mem__T_22 = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["_T_14", "_T_22"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>, !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
+    %0 = firrtl.subfield %mem__T_14(0) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<11>
+    %1 = firrtl.subfield %mem__T_14(1) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
+    %2 = firrtl.subfield %mem__T_14(2) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.clock
+    %3 = firrtl.subfield %mem__T_14(3) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<32>
+    %4 = firrtl.subfield %mem__T_14(4) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
+    %5 = firrtl.subfield %mem__T_22(0) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<11>
+    %6 = firrtl.subfield %mem__T_22(1) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<1>
+    %7 = firrtl.subfield %mem__T_22(2) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.clock
+    %8 = firrtl.subfield %mem__T_22(3) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<32>
+    %9 = firrtl.and %io_valid, %io_write : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %10 = firrtl.not %io_write : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %11 = firrtl.and %io_valid, %10 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    firrtl.connect %0, %io_addr : !firrtl.uint<11>, !firrtl.uint<11>
+    firrtl.connect %1, %9 : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %2, %clock : !firrtl.clock, !firrtl.clock
+    firrtl.connect %4, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %3, %io_dataIn : !firrtl.uint<32>, !firrtl.uint<32>
+    %12 = firrtl.not %9 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %13 = firrtl.mux(%12, %11, %c1_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    firrtl.connect %6, %13 : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %5, %io_addr : !firrtl.uint<11>, !firrtl.uint<11>
+    firrtl.connect %7, %clock : !firrtl.clock, !firrtl.clock
+    firrtl.connect %io_dataOut, %8 : !firrtl.uint<32>, !firrtl.uint<32>
+  }
+// Check for different clocks
+// CHECK-LABEL: firrtl.module @sram5t
+firrtl.module @sram5t(in %clk1: !firrtl.clock, in %clk2: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_en: !firrtl.uint<1>, in %io_wen: !firrtl.uint<1>, in %io_waddr: !firrtl.uint<8>, in %io_wdata: !firrtl.uint<32>, in %io_raddr: !firrtl.uint<8>, out %io_rdata: !firrtl.uint<32>) {
+  %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+  %mem_T_3, %mem_T_5 = firrtl.mem Undefined  {depth = 128 : i64, name = "mem", portNames = ["T_3", "T_5"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>, !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+  // CHECK:    %mem_T_3, %mem_T_5 = firrtl.mem Undefined  {depth = 128 : i64, name = "mem", portNames = ["T_3", "T_5"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>, !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+  %0 = firrtl.subfield %mem_T_3(0) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<7>
+  %1 = firrtl.subfield %mem_T_3(1) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<1>
+  %2 = firrtl.subfield %mem_T_3(2) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.clock
+  %3 = firrtl.subfield %mem_T_3(3) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<32>
+  %4 = firrtl.subfield %mem_T_5(0) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<7>
+  %5 = firrtl.subfield %mem_T_5(1) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
+  %6 = firrtl.subfield %mem_T_5(2) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.clock
+  %7 = firrtl.subfield %mem_T_5(3) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<32>
+  %8 = firrtl.subfield %mem_T_5(4) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
+  %9 = firrtl.not %io_wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
+  %10 = firrtl.and %io_en, %9 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  firrtl.connect %1, %10 : !firrtl.uint<1>, !firrtl.uint<1>
+  %11 = firrtl.bits %io_raddr 6 to 0 : (!firrtl.uint<8>) -> !firrtl.uint<7>
+  firrtl.connect %0, %11 : !firrtl.uint<7>, !firrtl.uint<7>
+  firrtl.connect %2, %clk1 : !firrtl.clock, !firrtl.clock
+  firrtl.connect %io_rdata, %3 : !firrtl.uint<32>, !firrtl.uint<32>
+  %12 = firrtl.and %io_en, %io_wen : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %13 = firrtl.bits %io_waddr 6 to 0 : (!firrtl.uint<8>) -> !firrtl.uint<7>
+  firrtl.connect %4, %13 : !firrtl.uint<7>, !firrtl.uint<7>
+  firrtl.connect %5, %12 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %6, %clk2 : !firrtl.clock, !firrtl.clock
+  firrtl.connect %8, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %7, %io_wdata : !firrtl.uint<32>, !firrtl.uint<32>
+}
+
+// CHECK-LABEL: firrtl.module @sram4t
+firrtl.module @sram4t(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_addr: !firrtl.uint<11>, in %io_ren: !firrtl.uint<1>, in %io_wen: !firrtl.uint<1>, in %io_dataIn: !firrtl.uint<32>, out %io_dataOut: !firrtl.uint<32>) {
+  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+  %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+  %mem__T_14, %mem__T_22 = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["_T_14", "_T_22"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>, !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
+  // CHECK:    %mem_rw = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
+  %0 = firrtl.subfield %mem__T_14(0) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<11>
+  %1 = firrtl.subfield %mem__T_14(1) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
+  %2 = firrtl.subfield %mem__T_14(2) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.clock
+  %3 = firrtl.subfield %mem__T_14(3) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<32>
+  %4 = firrtl.subfield %mem__T_14(4) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
+  %5 = firrtl.subfield %mem__T_22(0) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<11>
+  %6 = firrtl.subfield %mem__T_22(1) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<1>
+  %7 = firrtl.subfield %mem__T_22(2) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.clock
+  %8 = firrtl.subfield %mem__T_22(3) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<32>
+  firrtl.connect %0, %io_addr : !firrtl.uint<11>, !firrtl.uint<11>
+  firrtl.connect %1, %io_wen : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %2, %clock : !firrtl.clock, !firrtl.clock
+  firrtl.connect %4, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %3, %io_dataIn : !firrtl.uint<32>, !firrtl.uint<32>
+  %9 = firrtl.not %io_wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
+  %10 = firrtl.mux(%9, %io_ren, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  firrtl.connect %6, %10 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %5, %io_addr : !firrtl.uint<11>, !firrtl.uint<11>
+  firrtl.connect %7, %clock : !firrtl.clock, !firrtl.clock
+  firrtl.connect %io_dataOut, %8 : !firrtl.uint<32>, !firrtl.uint<32>
+}
+// CHECK-LABEL: firrtl.module @sram3t
+firrtl.module @sram3t(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_en: !firrtl.uint<1>, in %io_wen: !firrtl.uint<1>, in %io_waddr: !firrtl.uint<8>, in %io_wdata: !firrtl.uint<32>, in %io_raddr: !firrtl.uint<8>, out %io_rdata: !firrtl.uint<32>) {
+  %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+  %mem_T_3, %mem_T_5 = firrtl.mem Undefined  {depth = 128 : i64, name = "mem", portNames = ["T_3", "T_5"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>, !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+  // CHECK: %mem_rw = firrtl.mem Undefined  {depth = 128 : i64, name = "mem", portNames = ["rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
+  %0 = firrtl.subfield %mem_T_3(0) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<7>
+  %1 = firrtl.subfield %mem_T_3(1) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<1>
+  %2 = firrtl.subfield %mem_T_3(2) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.clock
+  %3 = firrtl.subfield %mem_T_3(3) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<32>
+  %4 = firrtl.subfield %mem_T_5(0) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<7>
+  %5 = firrtl.subfield %mem_T_5(1) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
+  %6 = firrtl.subfield %mem_T_5(2) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.clock
+  %7 = firrtl.subfield %mem_T_5(3) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<32>
+  %8 = firrtl.subfield %mem_T_5(4) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
+  %9 = firrtl.not %io_wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
+  %10 = firrtl.and %io_en, %9 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  firrtl.connect %1, %10 : !firrtl.uint<1>, !firrtl.uint<1>
+  %11 = firrtl.bits %io_raddr 6 to 0 : (!firrtl.uint<8>) -> !firrtl.uint<7>
+  firrtl.connect %0, %11 : !firrtl.uint<7>, !firrtl.uint<7>
+  firrtl.connect %2, %clock : !firrtl.clock, !firrtl.clock
+  firrtl.connect %io_rdata, %3 : !firrtl.uint<32>, !firrtl.uint<32>
+  %12 = firrtl.and %io_en, %io_wen : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %13 = firrtl.bits %io_waddr 6 to 0 : (!firrtl.uint<8>) -> !firrtl.uint<7>
+  firrtl.connect %4, %13 : !firrtl.uint<7>, !firrtl.uint<7>
+  firrtl.connect %5, %12 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %6, %clock : !firrtl.clock, !firrtl.clock
+  firrtl.connect %8, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %7, %io_wdata : !firrtl.uint<32>, !firrtl.uint<32>
+}
+
+// Check for indirect connection to clock
+// CHECK-LABEL: firrtl.module @sram2t
+firrtl.module @sram2t(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_addr: !firrtl.uint<11>, in %io_ren: !firrtl.uint<1>, in %io_wen: !firrtl.uint<1>, in %io_dataIn: !firrtl.uint<32>, out %io_dataOut: !firrtl.uint<32>) {
+  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+  %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+  %mem__T_14, %mem__T_22 = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["_T_14", "_T_22"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>, !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
+  // CHECK:    %mem_rw = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
+  %0 = firrtl.subfield %mem__T_14(0) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<11>
+  %1 = firrtl.subfield %mem__T_14(1) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
+  %2 = firrtl.subfield %mem__T_14(2) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.clock
+  %3 = firrtl.subfield %mem__T_14(3) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<32>
+  %4 = firrtl.subfield %mem__T_14(4) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
+  %5 = firrtl.subfield %mem__T_22(0) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<11>
+  %6 = firrtl.subfield %mem__T_22(1) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<1>
+  %7 = firrtl.subfield %mem__T_22(2) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.clock
+  %8 = firrtl.subfield %mem__T_22(3) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<32>
+  firrtl.connect %0, %io_addr : !firrtl.uint<11>, !firrtl.uint<11>
+  firrtl.connect %1, %io_wen : !firrtl.uint<1>, !firrtl.uint<1>
+	%xc = firrtl.wire : !firrtl.clock
+  firrtl.connect %2, %xc : !firrtl.clock, !firrtl.clock
+  firrtl.connect %xc, %clock : !firrtl.clock, !firrtl.clock
+  firrtl.connect %4, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %3, %io_dataIn : !firrtl.uint<32>, !firrtl.uint<32>
+  %9 = firrtl.not %io_wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
+  %10 = firrtl.mux(%9, %io_ren, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  firrtl.connect %6, %10 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.connect %5, %io_addr : !firrtl.uint<11>, !firrtl.uint<11>
+  firrtl.connect %7, %clock : !firrtl.clock, !firrtl.clock
+  firrtl.connect %io_dataOut, %8 : !firrtl.uint<32>, !firrtl.uint<32>
+}
+}
+

--- a/test/Dialect/FIRRTL/inferRW.mlir
+++ b/test/Dialect/FIRRTL/inferRW.mlir
@@ -50,8 +50,8 @@ firrtl.circuit "TLRAM" {
     }
 
 // Test the pattern of enable  with Mux (sel, high, 0)
-// CHECK-LABEL: firrtl.module @sram4t
-  firrtl.module @sram4t(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_addr: !firrtl.uint<11>, in %io_ren: !firrtl.uint<1>, in %io_wen: !firrtl.uint<1>, in %io_dataIn: !firrtl.uint<32>, out %io_dataOut: !firrtl.uint<32>) {
+// CHECK-LABEL: firrtl.module @memTest4t
+  firrtl.module @memTest4t(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_addr: !firrtl.uint<11>, in %io_ren: !firrtl.uint<1>, in %io_wen: !firrtl.uint<1>, in %io_dataIn: !firrtl.uint<32>, out %io_dataOut: !firrtl.uint<32>) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %mem__T_14, %mem__T_22 = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["_T_14", "_T_22"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>, !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
@@ -79,8 +79,8 @@ firrtl.circuit "TLRAM" {
   }
 
 // Test the pattern of enable  with an And tree and Mux (sel, high, 0)
-// CHECK-LABEL: firrtl.module @sram6t
-  firrtl.module @sram6t(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_addr: !firrtl.uint<11>, in %io_valid: !firrtl.uint<1>, in %io_write: !firrtl.uint<1>, in %io_dataIn: !firrtl.uint<32>, out %io_dataOut: !firrtl.uint<32>) {
+// CHECK-LABEL: firrtl.module @memTest6t
+  firrtl.module @memTest6t(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_addr: !firrtl.uint<11>, in %io_valid: !firrtl.uint<1>, in %io_write: !firrtl.uint<1>, in %io_dataIn: !firrtl.uint<32>, out %io_dataOut: !firrtl.uint<32>) {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %mem__T_14, %mem__T_22 = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["_T_14", "_T_22"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>, !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
@@ -114,8 +114,8 @@ firrtl.circuit "TLRAM" {
   }
 
 // Cannot merge read and write, since the pattern is enable = Mux (sel, high, 1)
-// CHECK-LABEL: firrtl.module @sram7t
-  firrtl.module @sram7t(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_addr: !firrtl.uint<11>, in %io_valid: !firrtl.uint<1>, in %io_write: !firrtl.uint<1>, in %io_dataIn: !firrtl.uint<32>, out %io_dataOut: !firrtl.uint<32>) {
+// CHECK-LABEL: firrtl.module @memTest7t
+  firrtl.module @memTest7t(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_addr: !firrtl.uint<11>, in %io_valid: !firrtl.uint<1>, in %io_write: !firrtl.uint<1>, in %io_dataIn: !firrtl.uint<32>, out %io_dataOut: !firrtl.uint<32>) {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %mem__T_14, %mem__T_22 = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["_T_14", "_T_22"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>, !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
@@ -146,8 +146,8 @@ firrtl.circuit "TLRAM" {
   }
 
 // Cannot merge, since the clocks are different.
-// CHECK-LABEL: firrtl.module @sram5t
-  firrtl.module @sram5t(in %clk1: !firrtl.clock, in %clk2: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_en: !firrtl.uint<1>, in %io_wen: !firrtl.uint<1>, in %io_waddr: !firrtl.uint<8>, in %io_wdata: !firrtl.uint<32>, in %io_raddr: !firrtl.uint<8>, out %io_rdata: !firrtl.uint<32>) {
+// CHECK-LABEL: firrtl.module @memTest5t
+  firrtl.module @memTest5t(in %clk1: !firrtl.clock, in %clk2: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_en: !firrtl.uint<1>, in %io_wen: !firrtl.uint<1>, in %io_waddr: !firrtl.uint<8>, in %io_wdata: !firrtl.uint<32>, in %io_raddr: !firrtl.uint<8>, out %io_rdata: !firrtl.uint<32>) {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %mem_T_3, %mem_T_5 = firrtl.mem Undefined  {depth = 128 : i64, name = "mem", portNames = ["T_3", "T_5"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>, !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
     // CHECK:    %mem_T_3, %mem_T_5 = firrtl.mem Undefined  {depth = 128 : i64, name = "mem", portNames = ["T_3", "T_5"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>, !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
@@ -176,10 +176,9 @@ firrtl.circuit "TLRAM" {
     firrtl.connect %7, %io_wdata : !firrtl.uint<32>, !firrtl.uint<32>
   }
 
-
 // Check for a complement term in the And expression tree.
-// CHECK-LABEL: firrtl.module @sram3t
-  firrtl.module @sram3t(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_en: !firrtl.uint<1>, in %io_wen: !firrtl.uint<1>, in %io_waddr: !firrtl.uint<8>, in %io_wdata: !firrtl.uint<32>, in %io_raddr: !firrtl.uint<8>, out %io_rdata: !firrtl.uint<32>) {
+// CHECK-LABEL: firrtl.module @memTest3t
+  firrtl.module @memTest3t(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_en: !firrtl.uint<1>, in %io_wen: !firrtl.uint<1>, in %io_waddr: !firrtl.uint<8>, in %io_wdata: !firrtl.uint<32>, in %io_raddr: !firrtl.uint<8>, out %io_rdata: !firrtl.uint<32>) {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %mem_T_3, %mem_T_5 = firrtl.mem Undefined  {depth = 128 : i64, name = "mem", portNames = ["T_3", "T_5"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>, !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
 // CHECK: %mem_rw = firrtl.mem Undefined  {depth = 128 : i64, name = "mem", portNames = ["rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
@@ -209,8 +208,8 @@ firrtl.circuit "TLRAM" {
   }
 
 // Check for indirect connection to clock
-// CHECK-LABEL: firrtl.module @sram2t
-  firrtl.module @sram2t(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_addr: !firrtl.uint<11>, in %io_ren: !firrtl.uint<1>, in %io_wen: !firrtl.uint<1>, in %io_dataIn: !firrtl.uint<32>, out %io_dataOut: !firrtl.uint<32>) {
+// CHECK-LABEL: firrtl.module @memTest2t
+  firrtl.module @memTest2t(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_addr: !firrtl.uint<11>, in %io_ren: !firrtl.uint<1>, in %io_wen: !firrtl.uint<1>, in %io_dataIn: !firrtl.uint<32>, out %io_dataOut: !firrtl.uint<32>) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %mem__T_14, %mem__T_22 = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["_T_14", "_T_22"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>, !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>

--- a/test/Dialect/FIRRTL/inferRW.mlir
+++ b/test/Dialect/FIRRTL/inferRW.mlir
@@ -1,11 +1,12 @@
 // RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl.module(firrtl-infer-rw))' %s | FileCheck %s
 
 firrtl.circuit "TLRAM" {
+// Test the case when the enable is a simple not of write enable.
+// CHECK-LABEL: firrtl.module @TLRAM
     firrtl.module @TLRAM(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %index: !firrtl.uint<4>, in %index2: !firrtl.uint<4>, in %data_0: !firrtl.uint<8>, in %wen: !firrtl.uint<1>, in %_T_29: !firrtl.uint<1>, out %auto_0: !firrtl.uint<8>) {
       %mem_MPORT_en = firrtl.wire  : !firrtl.uint<1>
       %mem_MPORT_data_0 = firrtl.wire  : !firrtl.uint<8>
       %mem_0_MPORT, %mem_0_MPORT_1 = firrtl.mem Undefined  {depth = 16 : i64, name = "mem_0", portNames = ["MPORT", "MPORT_1"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-      // CHECK: %mem_0_rw = firrtl.mem Undefined  {depth = 16 : i64, name = "mem_0", portNames = ["rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, wdata: uint<8>, wmask: uint<1>>
       %0 = firrtl.subfield %mem_0_MPORT(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.uint<4>
       firrtl.connect %0, %index2 : !firrtl.uint<4>, !firrtl.uint<4>
       %1 = firrtl.subfield %mem_0_MPORT(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.uint<1>
@@ -34,31 +35,59 @@ firrtl.circuit "TLRAM" {
       %11 = firrtl.mux(%REG, %mem_MPORT_data_0, %r_0) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
       firrtl.connect %auto_0, %11 : !firrtl.uint<8>, !firrtl.uint<8>
 
-     // CHECK:  %[[v7:.+]] = firrtl.mux(%[[writeEnable:.+]], %[[writeAddr:.+]], %[[readAddr:.+]]) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-     // CHECK:  firrtl.connect %[[v0:.+]], %[[v7]] : !firrtl.uint<4>, !firrtl.uint<4>
-     // CHECK:  %[[v8:.+]] = firrtl.or %[[readEnable:.+]], %[[writeEnable]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-     // CHECK:  firrtl.connect %[[v1:.+]], %[[v8]] : !firrtl.uint<1>, !firrtl.uint<1>
-     // CHECK:  firrtl.connect %[[v4:.+]], %[[writeEnable]] : !firrtl.uint<1>, !firrtl.uint<1>
-     // CHECK:  %9 = firrtl.wire  : !firrtl.clock
-     // CHECK:  firrtl.connect %[[readAddr]], %[[index2:.+]] : !firrtl.uint<4>, !firrtl.uint<4>
-     // CHECK:  firrtl.connect %[[readEnable]], %mem_MPORT_en : !firrtl.uint<1>, !firrtl.uint<1>
-     // CHECK:  firrtl.connect %[[writeAddr]], %index : !firrtl.uint<4>, !firrtl.uint<4>
-     // CHECK:  firrtl.connect %[[writeEnable]], %wen : !firrtl.uint<1>, !firrtl.uint<1>
-     // CHECK:  %[[v10:.+]] = firrtl.not %wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
-     // CHECK:  firrtl.connect %mem_MPORT_en, %[[v10]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK: %mem_0_rw = firrtl.mem Undefined  {depth = 16 : i64, name = "mem_0", portNames = ["rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, wdata: uint<8>, wmask: uint<1>>
+// CHECK:  %[[v7:.+]] = firrtl.mux(%[[writeEnable:.+]], %[[writeAddr:.+]], %[[readAddr:.+]]) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+// CHECK:  firrtl.connect %[[v0:.+]], %[[v7]] : !firrtl.uint<4>, !firrtl.uint<4>
+// CHECK:  %[[v8:.+]] = firrtl.or %[[readEnable:.+]], %[[writeEnable]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:  firrtl.connect %[[v1:.+]], %[[v8]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:  firrtl.connect %[[v4:.+]], %[[writeEnable]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:  firrtl.connect %[[readAddr]], %[[index2:.+]] : !firrtl.uint<4>, !firrtl.uint<4>
+// CHECK:  firrtl.connect %[[readEnable]], %mem_MPORT_en : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:  firrtl.connect %[[writeAddr]], %index : !firrtl.uint<4>, !firrtl.uint<4>
+// CHECK:  firrtl.connect %[[writeEnable]], %wen : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:  %[[v10:.+]] = firrtl.not %wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:  firrtl.connect %mem_MPORT_en, %[[v10]] : !firrtl.uint<1>, !firrtl.uint<1>
     }
-}
 
-firrtl.circuit "sram6t"   {
+// Test the pattern of enable  with Mux (sel, high, 0)
+// CHECK-LABEL: firrtl.module @sram4t
+  firrtl.module @sram4t(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_addr: !firrtl.uint<11>, in %io_ren: !firrtl.uint<1>, in %io_wen: !firrtl.uint<1>, in %io_dataIn: !firrtl.uint<32>, out %io_dataOut: !firrtl.uint<32>) {
+    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    %mem__T_14, %mem__T_22 = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["_T_14", "_T_22"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>, !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
+// CHECK:    %mem_rw = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
+    %0 = firrtl.subfield %mem__T_14(0) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<11>
+    %1 = firrtl.subfield %mem__T_14(1) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
+    %2 = firrtl.subfield %mem__T_14(2) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.clock
+    %3 = firrtl.subfield %mem__T_14(3) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<32>
+    %4 = firrtl.subfield %mem__T_14(4) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
+    %5 = firrtl.subfield %mem__T_22(0) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<11>
+    %6 = firrtl.subfield %mem__T_22(1) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<1>
+    %7 = firrtl.subfield %mem__T_22(2) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.clock
+    %8 = firrtl.subfield %mem__T_22(3) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<32>
+    firrtl.connect %0, %io_addr : !firrtl.uint<11>, !firrtl.uint<11>
+    firrtl.connect %1, %io_wen : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %2, %clock : !firrtl.clock, !firrtl.clock
+    firrtl.connect %4, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %3, %io_dataIn : !firrtl.uint<32>, !firrtl.uint<32>
+    %9 = firrtl.not %io_wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %10 = firrtl.mux(%9, %io_ren, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    firrtl.connect %6, %10 : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %5, %io_addr : !firrtl.uint<11>, !firrtl.uint<11>
+    firrtl.connect %7, %clock : !firrtl.clock, !firrtl.clock
+    firrtl.connect %io_dataOut, %8 : !firrtl.uint<32>, !firrtl.uint<32>
+  }
+
+// Test the pattern of enable  with an And tree and Mux (sel, high, 0)
 // CHECK-LABEL: firrtl.module @sram6t
   firrtl.module @sram6t(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_addr: !firrtl.uint<11>, in %io_valid: !firrtl.uint<1>, in %io_write: !firrtl.uint<1>, in %io_dataIn: !firrtl.uint<32>, out %io_dataOut: !firrtl.uint<32>) {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %mem__T_14, %mem__T_22 = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["_T_14", "_T_22"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>, !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
-      // CHECK: %mem_rw = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
-   // CHECK:   %[[v7:.+]] = firrtl.mux(%writeEnable, %writeAddr, %readAddr) : (!firrtl.uint<1>, !firrtl.uint<11>, !firrtl.uint<11>) -> !firrtl.uint<11>
-   // CHECK:   firrtl.connect %[[v0:.+]], %[[v7]] : !firrtl.uint<11>, !firrtl.uint<11>
-   // CHECK:   %8 = firrtl.or %readEnable, %writeEnable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK: %mem_rw = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
+// CHECK:   %[[v7:.+]] = firrtl.mux(%writeEnable, %writeAddr, %readAddr) : (!firrtl.uint<1>, !firrtl.uint<11>, !firrtl.uint<11>) -> !firrtl.uint<11>
+// CHECK:   firrtl.connect %[[v0:.+]], %[[v7]] : !firrtl.uint<11>, !firrtl.uint<11>
+// CHECK:   %[[v8:.+]] = firrtl.or %readEnable, %writeEnable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     %0 = firrtl.subfield %mem__T_14(0) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<11>
     %1 = firrtl.subfield %mem__T_14(1) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
     %2 = firrtl.subfield %mem__T_14(2) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.clock
@@ -83,12 +112,14 @@ firrtl.circuit "sram6t"   {
     firrtl.connect %7, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %io_dataOut, %8 : !firrtl.uint<32>, !firrtl.uint<32>
   }
+
+// Cannot merge read and write, since the pattern is enable = Mux (sel, high, 1)
 // CHECK-LABEL: firrtl.module @sram7t
   firrtl.module @sram7t(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_addr: !firrtl.uint<11>, in %io_valid: !firrtl.uint<1>, in %io_write: !firrtl.uint<1>, in %io_dataIn: !firrtl.uint<32>, out %io_dataOut: !firrtl.uint<32>) {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %mem__T_14, %mem__T_22 = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["_T_14", "_T_22"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>, !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
-      // CHECK: %mem__T_14, %mem__T_22 = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["_T_14", "_T_22"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>, !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
+// CHECK: %mem__T_14, %mem__T_22 = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["_T_14", "_T_22"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>, !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
     %0 = firrtl.subfield %mem__T_14(0) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<11>
     %1 = firrtl.subfield %mem__T_14(1) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
     %2 = firrtl.subfield %mem__T_14(2) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.clock
@@ -113,123 +144,99 @@ firrtl.circuit "sram6t"   {
     firrtl.connect %7, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %io_dataOut, %8 : !firrtl.uint<32>, !firrtl.uint<32>
   }
-// Check for different clocks
-// CHECK-LABEL: firrtl.module @sram5t
-firrtl.module @sram5t(in %clk1: !firrtl.clock, in %clk2: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_en: !firrtl.uint<1>, in %io_wen: !firrtl.uint<1>, in %io_waddr: !firrtl.uint<8>, in %io_wdata: !firrtl.uint<32>, in %io_raddr: !firrtl.uint<8>, out %io_rdata: !firrtl.uint<32>) {
-  %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-  %mem_T_3, %mem_T_5 = firrtl.mem Undefined  {depth = 128 : i64, name = "mem", portNames = ["T_3", "T_5"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>, !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
-  // CHECK:    %mem_T_3, %mem_T_5 = firrtl.mem Undefined  {depth = 128 : i64, name = "mem", portNames = ["T_3", "T_5"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>, !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
-  %0 = firrtl.subfield %mem_T_3(0) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<7>
-  %1 = firrtl.subfield %mem_T_3(1) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<1>
-  %2 = firrtl.subfield %mem_T_3(2) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.clock
-  %3 = firrtl.subfield %mem_T_3(3) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<32>
-  %4 = firrtl.subfield %mem_T_5(0) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<7>
-  %5 = firrtl.subfield %mem_T_5(1) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
-  %6 = firrtl.subfield %mem_T_5(2) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.clock
-  %7 = firrtl.subfield %mem_T_5(3) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<32>
-  %8 = firrtl.subfield %mem_T_5(4) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
-  %9 = firrtl.not %io_wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
-  %10 = firrtl.and %io_en, %9 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-  firrtl.connect %1, %10 : !firrtl.uint<1>, !firrtl.uint<1>
-  %11 = firrtl.bits %io_raddr 6 to 0 : (!firrtl.uint<8>) -> !firrtl.uint<7>
-  firrtl.connect %0, %11 : !firrtl.uint<7>, !firrtl.uint<7>
-  firrtl.connect %2, %clk1 : !firrtl.clock, !firrtl.clock
-  firrtl.connect %io_rdata, %3 : !firrtl.uint<32>, !firrtl.uint<32>
-  %12 = firrtl.and %io_en, %io_wen : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-  %13 = firrtl.bits %io_waddr 6 to 0 : (!firrtl.uint<8>) -> !firrtl.uint<7>
-  firrtl.connect %4, %13 : !firrtl.uint<7>, !firrtl.uint<7>
-  firrtl.connect %5, %12 : !firrtl.uint<1>, !firrtl.uint<1>
-  firrtl.connect %6, %clk2 : !firrtl.clock, !firrtl.clock
-  firrtl.connect %8, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-  firrtl.connect %7, %io_wdata : !firrtl.uint<32>, !firrtl.uint<32>
-}
 
-// CHECK-LABEL: firrtl.module @sram4t
-firrtl.module @sram4t(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_addr: !firrtl.uint<11>, in %io_ren: !firrtl.uint<1>, in %io_wen: !firrtl.uint<1>, in %io_dataIn: !firrtl.uint<32>, out %io_dataOut: !firrtl.uint<32>) {
-  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-  %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-  %mem__T_14, %mem__T_22 = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["_T_14", "_T_22"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>, !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
-  // CHECK:    %mem_rw = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
-  %0 = firrtl.subfield %mem__T_14(0) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<11>
-  %1 = firrtl.subfield %mem__T_14(1) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
-  %2 = firrtl.subfield %mem__T_14(2) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.clock
-  %3 = firrtl.subfield %mem__T_14(3) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<32>
-  %4 = firrtl.subfield %mem__T_14(4) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
-  %5 = firrtl.subfield %mem__T_22(0) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<11>
-  %6 = firrtl.subfield %mem__T_22(1) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<1>
-  %7 = firrtl.subfield %mem__T_22(2) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.clock
-  %8 = firrtl.subfield %mem__T_22(3) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<32>
-  firrtl.connect %0, %io_addr : !firrtl.uint<11>, !firrtl.uint<11>
-  firrtl.connect %1, %io_wen : !firrtl.uint<1>, !firrtl.uint<1>
-  firrtl.connect %2, %clock : !firrtl.clock, !firrtl.clock
-  firrtl.connect %4, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-  firrtl.connect %3, %io_dataIn : !firrtl.uint<32>, !firrtl.uint<32>
-  %9 = firrtl.not %io_wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
-  %10 = firrtl.mux(%9, %io_ren, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-  firrtl.connect %6, %10 : !firrtl.uint<1>, !firrtl.uint<1>
-  firrtl.connect %5, %io_addr : !firrtl.uint<11>, !firrtl.uint<11>
-  firrtl.connect %7, %clock : !firrtl.clock, !firrtl.clock
-  firrtl.connect %io_dataOut, %8 : !firrtl.uint<32>, !firrtl.uint<32>
-}
+// Cannot merge, since the clocks are different.
+// CHECK-LABEL: firrtl.module @sram5t
+  firrtl.module @sram5t(in %clk1: !firrtl.clock, in %clk2: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_en: !firrtl.uint<1>, in %io_wen: !firrtl.uint<1>, in %io_waddr: !firrtl.uint<8>, in %io_wdata: !firrtl.uint<32>, in %io_raddr: !firrtl.uint<8>, out %io_rdata: !firrtl.uint<32>) {
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    %mem_T_3, %mem_T_5 = firrtl.mem Undefined  {depth = 128 : i64, name = "mem", portNames = ["T_3", "T_5"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>, !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    // CHECK:    %mem_T_3, %mem_T_5 = firrtl.mem Undefined  {depth = 128 : i64, name = "mem", portNames = ["T_3", "T_5"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>, !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+    %0 = firrtl.subfield %mem_T_3(0) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<7>
+    %1 = firrtl.subfield %mem_T_3(1) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<1>
+    %2 = firrtl.subfield %mem_T_3(2) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.clock
+    %3 = firrtl.subfield %mem_T_3(3) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<32>
+    %4 = firrtl.subfield %mem_T_5(0) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<7>
+    %5 = firrtl.subfield %mem_T_5(1) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
+    %6 = firrtl.subfield %mem_T_5(2) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.clock
+    %7 = firrtl.subfield %mem_T_5(3) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<32>
+    %8 = firrtl.subfield %mem_T_5(4) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
+    %9 = firrtl.not %io_wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %10 = firrtl.and %io_en, %9 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    firrtl.connect %1, %10 : !firrtl.uint<1>, !firrtl.uint<1>
+    %11 = firrtl.bits %io_raddr 6 to 0 : (!firrtl.uint<8>) -> !firrtl.uint<7>
+    firrtl.connect %0, %11 : !firrtl.uint<7>, !firrtl.uint<7>
+    firrtl.connect %2, %clk1 : !firrtl.clock, !firrtl.clock
+    firrtl.connect %io_rdata, %3 : !firrtl.uint<32>, !firrtl.uint<32>
+    %12 = firrtl.and %io_en, %io_wen : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %13 = firrtl.bits %io_waddr 6 to 0 : (!firrtl.uint<8>) -> !firrtl.uint<7>
+    firrtl.connect %4, %13 : !firrtl.uint<7>, !firrtl.uint<7>
+    firrtl.connect %5, %12 : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %6, %clk2 : !firrtl.clock, !firrtl.clock
+    firrtl.connect %8, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %7, %io_wdata : !firrtl.uint<32>, !firrtl.uint<32>
+  }
+
+
+// Check for a complement term in the And expression tree.
 // CHECK-LABEL: firrtl.module @sram3t
-firrtl.module @sram3t(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_en: !firrtl.uint<1>, in %io_wen: !firrtl.uint<1>, in %io_waddr: !firrtl.uint<8>, in %io_wdata: !firrtl.uint<32>, in %io_raddr: !firrtl.uint<8>, out %io_rdata: !firrtl.uint<32>) {
-  %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-  %mem_T_3, %mem_T_5 = firrtl.mem Undefined  {depth = 128 : i64, name = "mem", portNames = ["T_3", "T_5"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>, !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
-  // CHECK: %mem_rw = firrtl.mem Undefined  {depth = 128 : i64, name = "mem", portNames = ["rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
-  %0 = firrtl.subfield %mem_T_3(0) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<7>
-  %1 = firrtl.subfield %mem_T_3(1) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<1>
-  %2 = firrtl.subfield %mem_T_3(2) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.clock
-  %3 = firrtl.subfield %mem_T_3(3) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<32>
-  %4 = firrtl.subfield %mem_T_5(0) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<7>
-  %5 = firrtl.subfield %mem_T_5(1) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
-  %6 = firrtl.subfield %mem_T_5(2) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.clock
-  %7 = firrtl.subfield %mem_T_5(3) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<32>
-  %8 = firrtl.subfield %mem_T_5(4) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
-  %9 = firrtl.not %io_wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
-  %10 = firrtl.and %io_en, %9 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-  firrtl.connect %1, %10 : !firrtl.uint<1>, !firrtl.uint<1>
-  %11 = firrtl.bits %io_raddr 6 to 0 : (!firrtl.uint<8>) -> !firrtl.uint<7>
-  firrtl.connect %0, %11 : !firrtl.uint<7>, !firrtl.uint<7>
-  firrtl.connect %2, %clock : !firrtl.clock, !firrtl.clock
-  firrtl.connect %io_rdata, %3 : !firrtl.uint<32>, !firrtl.uint<32>
-  %12 = firrtl.and %io_en, %io_wen : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-  %13 = firrtl.bits %io_waddr 6 to 0 : (!firrtl.uint<8>) -> !firrtl.uint<7>
-  firrtl.connect %4, %13 : !firrtl.uint<7>, !firrtl.uint<7>
-  firrtl.connect %5, %12 : !firrtl.uint<1>, !firrtl.uint<1>
-  firrtl.connect %6, %clock : !firrtl.clock, !firrtl.clock
-  firrtl.connect %8, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-  firrtl.connect %7, %io_wdata : !firrtl.uint<32>, !firrtl.uint<32>
-}
+  firrtl.module @sram3t(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_en: !firrtl.uint<1>, in %io_wen: !firrtl.uint<1>, in %io_waddr: !firrtl.uint<8>, in %io_wdata: !firrtl.uint<32>, in %io_raddr: !firrtl.uint<8>, out %io_rdata: !firrtl.uint<32>) {
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    %mem_T_3, %mem_T_5 = firrtl.mem Undefined  {depth = 128 : i64, name = "mem", portNames = ["T_3", "T_5"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>, !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
+// CHECK: %mem_rw = firrtl.mem Undefined  {depth = 128 : i64, name = "mem", portNames = ["rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
+    %0 = firrtl.subfield %mem_T_3(0) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<7>
+    %1 = firrtl.subfield %mem_T_3(1) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<1>
+    %2 = firrtl.subfield %mem_T_3(2) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.clock
+    %3 = firrtl.subfield %mem_T_3(3) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<32>
+    %4 = firrtl.subfield %mem_T_5(0) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<7>
+    %5 = firrtl.subfield %mem_T_5(1) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
+    %6 = firrtl.subfield %mem_T_5(2) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.clock
+    %7 = firrtl.subfield %mem_T_5(3) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<32>
+    %8 = firrtl.subfield %mem_T_5(4) : (!firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
+    %9 = firrtl.not %io_wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %10 = firrtl.and %io_en, %9 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    firrtl.connect %1, %10 : !firrtl.uint<1>, !firrtl.uint<1>
+    %11 = firrtl.bits %io_raddr 6 to 0 : (!firrtl.uint<8>) -> !firrtl.uint<7>
+    firrtl.connect %0, %11 : !firrtl.uint<7>, !firrtl.uint<7>
+    firrtl.connect %2, %clock : !firrtl.clock, !firrtl.clock
+    firrtl.connect %io_rdata, %3 : !firrtl.uint<32>, !firrtl.uint<32>
+    %12 = firrtl.and %io_en, %io_wen : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %13 = firrtl.bits %io_waddr 6 to 0 : (!firrtl.uint<8>) -> !firrtl.uint<7>
+    firrtl.connect %4, %13 : !firrtl.uint<7>, !firrtl.uint<7>
+    firrtl.connect %5, %12 : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %6, %clock : !firrtl.clock, !firrtl.clock
+    firrtl.connect %8, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %7, %io_wdata : !firrtl.uint<32>, !firrtl.uint<32>
+  }
 
 // Check for indirect connection to clock
 // CHECK-LABEL: firrtl.module @sram2t
-firrtl.module @sram2t(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_addr: !firrtl.uint<11>, in %io_ren: !firrtl.uint<1>, in %io_wen: !firrtl.uint<1>, in %io_dataIn: !firrtl.uint<32>, out %io_dataOut: !firrtl.uint<32>) {
-  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-  %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-  %mem__T_14, %mem__T_22 = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["_T_14", "_T_22"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>, !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
-  // CHECK:    %mem_rw = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
-  %0 = firrtl.subfield %mem__T_14(0) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<11>
-  %1 = firrtl.subfield %mem__T_14(1) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
-  %2 = firrtl.subfield %mem__T_14(2) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.clock
-  %3 = firrtl.subfield %mem__T_14(3) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<32>
-  %4 = firrtl.subfield %mem__T_14(4) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
-  %5 = firrtl.subfield %mem__T_22(0) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<11>
-  %6 = firrtl.subfield %mem__T_22(1) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<1>
-  %7 = firrtl.subfield %mem__T_22(2) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.clock
-  %8 = firrtl.subfield %mem__T_22(3) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<32>
-  firrtl.connect %0, %io_addr : !firrtl.uint<11>, !firrtl.uint<11>
-  firrtl.connect %1, %io_wen : !firrtl.uint<1>, !firrtl.uint<1>
-	%xc = firrtl.wire : !firrtl.clock
-  firrtl.connect %2, %xc : !firrtl.clock, !firrtl.clock
-  firrtl.connect %xc, %clock : !firrtl.clock, !firrtl.clock
-  firrtl.connect %4, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-  firrtl.connect %3, %io_dataIn : !firrtl.uint<32>, !firrtl.uint<32>
-  %9 = firrtl.not %io_wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
-  %10 = firrtl.mux(%9, %io_ren, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-  firrtl.connect %6, %10 : !firrtl.uint<1>, !firrtl.uint<1>
-  firrtl.connect %5, %io_addr : !firrtl.uint<11>, !firrtl.uint<11>
-  firrtl.connect %7, %clock : !firrtl.clock, !firrtl.clock
-  firrtl.connect %io_dataOut, %8 : !firrtl.uint<32>, !firrtl.uint<32>
-}
+  firrtl.module @sram2t(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io_addr: !firrtl.uint<11>, in %io_ren: !firrtl.uint<1>, in %io_wen: !firrtl.uint<1>, in %io_dataIn: !firrtl.uint<32>, out %io_dataOut: !firrtl.uint<32>) {
+    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    %mem__T_14, %mem__T_22 = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["_T_14", "_T_22"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>, !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
+// CHECK:    %mem_rw = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
+    %0 = firrtl.subfield %mem__T_14(0) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<11>
+    %1 = firrtl.subfield %mem__T_14(1) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
+    %2 = firrtl.subfield %mem__T_14(2) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.clock
+    %3 = firrtl.subfield %mem__T_14(3) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<32>
+    %4 = firrtl.subfield %mem__T_14(4) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
+    %5 = firrtl.subfield %mem__T_22(0) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<11>
+    %6 = firrtl.subfield %mem__T_22(1) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<1>
+    %7 = firrtl.subfield %mem__T_22(2) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.clock
+    %8 = firrtl.subfield %mem__T_22(3) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.uint<32>
+    firrtl.connect %0, %io_addr : !firrtl.uint<11>, !firrtl.uint<11>
+    firrtl.connect %1, %io_wen : !firrtl.uint<1>, !firrtl.uint<1>
+    %xc = firrtl.wire : !firrtl.clock
+    firrtl.connect %2, %xc : !firrtl.clock, !firrtl.clock
+    firrtl.connect %xc, %clock : !firrtl.clock, !firrtl.clock
+    firrtl.connect %4, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %3, %io_dataIn : !firrtl.uint<32>, !firrtl.uint<32>
+    %9 = firrtl.not %io_wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %10 = firrtl.mux(%9, %io_ren, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    firrtl.connect %6, %10 : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %5, %io_addr : !firrtl.uint<11>, !firrtl.uint<11>
+    firrtl.connect %7, %clock : !firrtl.clock, !firrtl.clock
+    firrtl.connect %io_dataOut, %8 : !firrtl.uint<32>, !firrtl.uint<32>
+  }
 }
 


### PR DESCRIPTION
Add a `FIRRTL` pass to merge the read and write ports of a memory, if their enable condition is mutually exclusive.
This is an implementation of the Scala pass, `InferReadWrite` https://github.com/chipsalliance/firrtl/blob/v1.4.3/src/main/scala/firrtl/passes/memlib/InferReadWrite.scala
The heuristic used to infer mutually exclusive conditions, first constructs the `And` expression tree for 
both the read and write enable conditions. 
The conditions are mutually exclusive if any of the product terms is a complement of each other.
The pass also has to check if both the ports are connected to the same `clock`.
This pass only looks for `Seq` memories, that is memory with read and write latency of 1, and exactly two ports.