### PR TITLE
[Handshake] Allow simple merges in canonical form

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakeCanonicalization.td
+++ b/include/circt/Dialect/Handshake/HandshakeCanonicalization.td
@@ -19,9 +19,6 @@ include "circt/Dialect/Handshake/Handshake.td"
 def HasOneOperand : Constraint<CPred<"$_self.size() == 1">, "has one operand">;
 def HasOneResult : Constraint<CPred<"$_self.size() == 1">, "has one result">;
 
-def EliminateSimpleMergesPattern : Pat<(MergeOp $dataType, $size, $arg), (replaceWithValue $arg),
-                                       [(HasOneOperand:$arg)]>;
-
 def EliminateSimpleBranchesPattern
     : Pat<(BranchOp $dataType, $a), (replaceWithValue $a)>;
 

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -321,7 +321,6 @@ def MergeOp : Handshake_Op<"merge", [
   let printer = "return ::print$cppClass(p, *this);";
   let parser = "return ::parse$cppClass(parser, result);";
 
-  let hasCanonicalizer = 1;
   let skipDefaultBuilders = 1;
   let builders = [OpBuilder<(ins "ValueRange":$operands)>];
 }

--- a/include/circt/Dialect/Handshake/HandshakePasses.h
+++ b/include/circt/Dialect/Handshake/HandshakePasses.h
@@ -32,6 +32,7 @@ std::unique_ptr<mlir::Pass> createHandshakeRemoveBuffersPass();
 std::unique_ptr<mlir::Pass> createHandshakeAddIDsPass();
 std::unique_ptr<mlir::OperationPass<handshake::FuncOp>>
 createHandshakeInsertBuffersPass();
+std::unique_ptr<mlir::Pass> createHandshakeRemoveSimpleMergesPass();
 
 /// Iterates over the handshake::FuncOp's in the program to build an instance
 /// graph. In doing so, we detect whether there are any cycles in this graph, as

--- a/include/circt/Dialect/Handshake/HandshakePasses.td
+++ b/include/circt/Dialect/Handshake/HandshakePasses.td
@@ -62,6 +62,17 @@ def HandshakeRemoveBuffers : Pass<"handshake-remove-buffers", "handshake::FuncOp
   let constructor = "circt::handshake::createHandshakeRemoveBuffersPass()";
 }
 
+def HandshakeRemoveSimpleMerges : Pass<"handshake-remove-simple-merges", "handshake::FuncOp"> {
+  let summary = "Remove simple merges from handshake functions.";
+  let description = [{
+    This pass analysis a handshake.func operation and removes any simple merges
+    - merge operation with a single input - from the function.
+    Simple merges are allowed in canonical Handshake IR due to their importance
+    in correct buffer placement.
+  }];
+  let constructor = "circt::handshake::createHandshakeRemoveSimpleMergesPass()";
+}
+
 def HandshakeAddIDs : Pass<"handshake-add-ids", "handshake::FuncOp"> {
   let summary = "Add an ID to each operation in a handshake function.";
   let description = [{

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -272,11 +272,6 @@ static ParseResult parseMergeOp(OpAsmParser &parser, OperationState &result) {
 
 void printMergeOp(OpAsmPrinter &p, MergeOp op) { sost::printOp(p, op, false); }
 
-void MergeOp::getCanonicalizationPatterns(RewritePatternSet &results,
-                                          MLIRContext *context) {
-  results.insert<circt::handshake::EliminateSimpleMergesPattern>(context);
-}
-
 /// Returns a dematerialized version of the value 'v', defined as the source of
 /// the value before passing through a buffer or fork operation.
 static Value getDematerialized(Value v) {

--- a/lib/Dialect/Handshake/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Handshake/Transforms/CMakeLists.txt
@@ -5,7 +5,7 @@ add_circt_dialect_library(CIRCTHandshakeTransforms
   Buffers.cpp
 
   DEPENDS
-  MLIRHandshakeCanonicalizationIncGen
+  CIRCTHandshakeTransformsIncGen
 
   LINK_LIBS PUBLIC
   CIRCTHandshake

--- a/lib/Dialect/Handshake/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Handshake/Transforms/CMakeLists.txt
@@ -5,7 +5,7 @@ add_circt_dialect_library(CIRCTHandshakeTransforms
   Buffers.cpp
 
   DEPENDS
-  CIRCTHandshakeTransformsIncGen
+  MLIRHandshakeCanonicalizationIncGen
 
   LINK_LIBS PUBLIC
   CIRCTHandshake

--- a/lib/Dialect/Handshake/Transforms/Materialization.cpp
+++ b/lib/Dialect/Handshake/Transforms/Materialization.cpp
@@ -22,6 +22,7 @@
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Support/IndentedOstream.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/ADT/TypeSwitch.h"
 
 using namespace circt;
@@ -149,6 +150,30 @@ struct HandshakeDematerializeForksSinksPass
   };
 };
 
+struct EliminateSimpleMergesPattern
+    : public OpRewritePattern<handshake::MergeOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(handshake::MergeOp op,
+                                PatternRewriter &rewriter) const override {
+    if (op.getNumOperands() > 1)
+      return failure();
+    rewriter.replaceOp(op, op.getOperand(0));
+    return success();
+  };
+};
+
+struct HandshakeRemoveSimpleMergesPass
+    : public HandshakeRemoveSimpleMergesBase<HandshakeRemoveSimpleMergesPass> {
+  void runOnOperation() override {
+    handshake::FuncOp op = getOperation();
+    auto ctx = op.getContext();
+    RewritePatternSet patterns(ctx);
+    patterns.add<EliminateSimpleMergesPattern>(ctx);
+    if (failed(applyPatternsAndFoldGreedily(op, std::move(patterns))))
+      signalPassFailure();
+  };
+};
+
 } // namespace
 
 std::unique_ptr<mlir::Pass>
@@ -159,4 +184,9 @@ circt::handshake::createHandshakeMaterializeForksSinksPass() {
 std::unique_ptr<mlir::Pass>
 circt::handshake::createHandshakeDematerializeForksSinksPass() {
   return std::make_unique<HandshakeDematerializeForksSinksPass>();
+}
+
+std::unique_ptr<mlir::Pass>
+circt::handshake::createHandshakeRemoveSimpleMergesPass() {
+  return std::make_unique<HandshakeRemoveSimpleMergesPass>();
 }

--- a/lib/Dialect/Handshake/Transforms/Materialization.cpp
+++ b/lib/Dialect/Handshake/Transforms/Materialization.cpp
@@ -166,7 +166,7 @@ struct HandshakeRemoveSimpleMergesPass
     : public HandshakeRemoveSimpleMergesBase<HandshakeRemoveSimpleMergesPass> {
   void runOnOperation() override {
     handshake::FuncOp op = getOperation();
-    auto ctx = op.getContext();
+    auto *ctx = op.getContext();
     RewritePatternSet patterns(ctx);
     patterns.add<EliminateSimpleMergesPattern>(ctx);
     if (failed(applyPatternsAndFoldGreedily(op, std::move(patterns))))

--- a/test/Conversion/StandardToHandshake/test_source_constants.mlir
+++ b/test/Conversion/StandardToHandshake/test_source_constants.mlir
@@ -3,10 +3,11 @@
 // CHECK-LABEL:   handshake.func @foo(
 // CHECK-SAME:                        %[[VAL_0:.*]]: i32,
 // CHECK-SAME:                        %[[VAL_1:.*]]: none, ...) -> (i32, none) attributes {argNames = ["in0", "inCtrl"], resNames = ["out0", "outCtrl"]} {
-// CHECK:           %[[VAL_2:.*]] = source
-// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_2]] {value = 1 : i32} : i32
-// CHECK:           %[[VAL_4:.*]] = arith.addi %[[VAL_0]], %[[VAL_3]] : i32
-// CHECK:           return %[[VAL_4]], %[[VAL_1]] : i32, none
+// CHECK:           %[[VAL_2:.*]] = merge %[[VAL_0]] : i32
+// CHECK:           %[[VAL_3:.*]] = source
+// CHECK:           %[[VAL_4:.*]] = constant %[[VAL_3]] {value = 1 : i32} : i32
+// CHECK:           %[[VAL_5:.*]] = arith.addi %[[VAL_2]], %[[VAL_4]] : i32
+// CHECK:           return %[[VAL_5]], %[[VAL_1]] : i32, none
 // CHECK:         }
 
 func @foo(%arg0 : i32) -> i32 {

--- a/test/Dialect/Handshake/canonicalization.mlir
+++ b/test/Dialect/Handshake/canonicalization.mlir
@@ -1,27 +1,5 @@
 // RUN: circt-opt -split-input-file -canonicalize='top-down=true region-simplify=true' %s | FileCheck %s
 
-// CHECK-LABEL:   handshake.func @simple(
-// CHECK-SAME:                           %[[VAL_0:.*]]: none, ...) -> none attributes {argNames = ["arg0"], resNames = ["outCtrl"]} {
-// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = 1 : index} : index
-// CHECK:           %[[VAL_2:.*]]:2 = fork [2] %[[VAL_0]] : none
-// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_2]]#0 {value = 42 : index} : index
-// CHECK:           %[[VAL_4:.*]] = arith.addi %[[VAL_1]], %[[VAL_3]] : index
-// CHECK:           sink %[[VAL_4]] : index
-// CHECK:           return %[[VAL_2]]#1 : none
-// CHECK:         }
-handshake.func @simple(%arg0: none, ...) -> none {
-  %0 = constant %arg0 {value = 1 : index} : index
-  %1 = br %arg0 : none
-  %2 = br %0 : index
-  %3 = merge %1 : none
-  %4 = merge %2 : index
-  %5:2 = fork [2] %3 : none
-  %6 = constant %5#0 {value = 42 : index} : index
-  %7 = arith.addi %4, %6 : index
-  sink %7 : index
-  handshake.return %5#1 : none
-}
-
 // -----
 
 // CHECK:   handshake.func @cmerge_with_control_used(%[[VAL_0:.*]]: none, %[[VAL_1:.*]]: none, %[[VAL_2:.*]]: none, ...) -> (none, index, none) attributes {argNames = ["arg0", "arg1", "arg2"], resNames = ["out0", "out1", "outCtrl"]} {


### PR DESCRIPTION
In trying to get function pipelining to work, it finally seems like we've found the issue for why this hasn't been working. If we keep simple merges, and then add buffers to their outputs, function pipelining looks to be working.
This commit allows simple merges in canonical handshake IR, but keeps the option of removing them through a separate pass. After buffer insertion, the merges will be redundant, but we must keep them (at least for now) to guide buffer insertion.