### PR TITLE
[LowerToHW] Support ForceNameAnnotation instances

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -49,6 +49,8 @@ static const char testHarnessHierAnnoClass[] =
     "sifive.enterprise.firrtl.TestHarnessHierarchyAnnotation";
 static const char verifBBClass[] =
     "freechips.rocketchip.annotations.InternalVerifBlackBoxAnnotation";
+static const char forceNameClass[] =
+    "chisel3.util.experimental.ForceNameAnnotation";
 
 /// Attribute that indicates that the module hierarchy starting at the
 /// annotated module should be dumped to a file.
@@ -253,7 +255,12 @@ struct CircuitLoweringState {
                        InstanceGraph *instanceGraph)
       : circuitOp(circuitOp), instanceGraph(instanceGraph),
         enableAnnotationWarning(enableAnnotationWarning),
-        nonConstAsyncResetValueIsError(nonConstAsyncResetValueIsError) {}
+        nonConstAsyncResetValueIsError(nonConstAsyncResetValueIsError) {
+    // Populate the NLA map with any discovered NonLocalAnchors.
+    NonLocalAnchor foo;
+    for (auto nla : circuitOp.getBody()->getOps<NonLocalAnchor>())
+      nlaMap[nla.sym_nameAttr()] = nla;
+  }
 
   Operation *getNewModule(Operation *oldModule) {
     auto it = oldToNewModuleMap.find(oldModule);
@@ -277,6 +284,14 @@ struct CircuitLoweringState {
   void setDut(FModuleOp mod) { dut = mod; }
 
   InstanceGraph *getInstanceGraph() { return instanceGraph; }
+
+  NonLocalAnchor lookupNLA(FlatSymbolRefAttr sym) {
+    return nlaMap[sym.getAttr()];
+  }
+
+  /// A mapping of instances to their forced instantiation names (if
+  /// applicable).
+  DenseMap<std::pair<Attribute, Attribute>, Attribute> instanceForceNames;
 
 private:
   friend struct FIRRTLModuleLowering;
@@ -310,6 +325,9 @@ private:
   // The design-under-test (DUT), if it is found.  This will be set if a
   // "sifive.enterprise.firrtl.MarkDUTAnnotation" exists.
   FModuleOp dut;
+
+  /// Map of symbol name to NonLocalAnchor op.
+  llvm::DenseMap<Attribute, NonLocalAnchor> nlaMap;
 };
 
 void CircuitLoweringState::processRemainingAnnotations(
@@ -891,6 +909,74 @@ FIRRTLModuleLowering::lowerModule(FModuleOp oldModule, Block *topLevelModule,
 
   if (annos.removeAnnotation(verifBBClass))
     newModule->setAttr("firrtl.extract.cover.extra", builder.getUnitAttr());
+
+  bool failed = false;
+  // Remove ForceNameAnnotations by generating verilogNames on instances.
+  annos.removeAnnotations([&](Annotation anno) {
+    if (!anno.isClass(forceNameClass))
+      return false;
+
+    auto sym = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal");
+    // This must be a non-local annotation due to how the Chisel API is
+    // implemented.
+    //
+    // TODO: handle this in some sensible way based on what the SFC does with
+    // a local annotation.
+    if (!sym) {
+      auto diag = oldModule.emitOpError()
+                  << "contains a '" << forceNameClass
+                  << "' that is not a non-local annotation";
+      diag.attachNote() << "the erroneous annotation is '" << anno.getDict()
+                        << "'\n";
+      failed = true;
+      return false;
+    }
+
+    auto nla = loweringState.lookupNLA(sym);
+    // The non-local anchor must exist.
+    //
+    // TODO: handle this with annotation verification.
+    if (!nla) {
+      auto diag = oldModule.emitOpError()
+                  << "contains a '" << forceNameClass
+                  << "' whose non-local symbol, '" << sym
+                  << "' does not exist in the circuit";
+      diag.attachNote() << "the erroneous annotation is '" << anno.getDict();
+      failed = true;
+      return false;
+    }
+
+    // Add the forced name to global state (keyed by a pseudo-inner name ref).
+    // Error out if this key is alredy in use.
+    //
+    // TODO: this error behavior can be relaxed to always overwrite with the
+    // new forced name (the bug-compatible behavior of the Chisel
+    // implementation) or fixed to duplicate modules such that the naming can
+    // be applied.
+    auto mod = nla.modpath()
+                   .getValue()
+                   .take_back(2)[0]
+                   .cast<FlatSymbolRefAttr>()
+                   .getAttr();
+    auto inst = nla.namepath().getValue().take_back(2)[0];
+    auto inserted = loweringState.instanceForceNames.insert(
+        {{mod, inst}, anno.getMember("name")});
+    if (!inserted.second &&
+        (anno.getMember("name") != (inserted.first->second))) {
+      auto diag = oldModule.emitError()
+                  << "contained multiple '" << forceNameClass
+                  << "' with different names: " << inserted.first->second
+                  << " was not " << anno.getMember("name");
+      diag.attachNote() << "the erroneous annotation is '" << anno.getDict()
+                        << "'";
+      failed = true;
+      return false;
+    }
+    return true;
+  });
+
+  if (failed)
+    return {};
 
   loweringState.processRemainingAnnotations(oldModule, annos);
   return newModule;
@@ -2654,6 +2740,11 @@ LogicalResult FIRRTLLowering::visitDecl(InstanceOp oldInstance) {
 
   if (oldInstance.lowerToBind())
     newInstance->setAttr("doNotPrint", builder.getBoolAttr(true));
+
+  if (auto forceName = circuitState.instanceForceNames[{
+          cast<hw::HWModuleOp>(newInstance->getParentOp()).getNameAttr(),
+          newInstance.getName()}])
+    newInstance->setAttr("hw.verilogName", forceName);
 
   // Now that we have the new hw.instance, we need to remap all of the users
   // of the outputs/results to the values returned by the instance.

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -285,14 +285,6 @@ struct CircuitLoweringState {
 
   InstanceGraph *getInstanceGraph() { return instanceGraph; }
 
-  NonLocalAnchor lookupNLA(FlatSymbolRefAttr sym) {
-    return nlaMap[sym.getAttr()];
-  }
-
-  Attribute lookupInstanceForceName(std::pair<Attribute, Attribute> instance) {
-    return instanceForceNames.lookup(instance);
-  }
-
 private:
   friend struct FIRRTLModuleLowering;
   friend struct FIRRTLLowering;
@@ -936,7 +928,7 @@ FIRRTLModuleLowering::lowerModule(FModuleOp oldModule, Block *topLevelModule,
       return false;
     }
 
-    auto nla = loweringState.lookupNLA(sym);
+    auto nla = loweringState.nlaMap.lookup(sym.getAttr());
     // The non-local anchor must exist.
     //
     // TODO: handle this with annotation verification.
@@ -2745,7 +2737,7 @@ LogicalResult FIRRTLLowering::visitDecl(InstanceOp oldInstance) {
   if (oldInstance.lowerToBind())
     newInstance->setAttr("doNotPrint", builder.getBoolAttr(true));
 
-  if (auto forceName = circuitState.lookupInstanceForceName(
+  if (auto forceName = circuitState.instanceForceNames.lookup(
           {cast<hw::HWModuleOp>(newInstance->getParentOp()).getNameAttr(),
            newInstance.getName()}))
     newInstance->setAttr("hw.verilogName", forceName);

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -289,9 +289,9 @@ struct CircuitLoweringState {
     return nlaMap[sym.getAttr()];
   }
 
-  /// A mapping of instances to their forced instantiation names (if
-  /// applicable).
-  DenseMap<std::pair<Attribute, Attribute>, Attribute> instanceForceNames;
+  Attribute lookupInstanceForceName(std::pair<Attribute, Attribute> instance) {
+    return instanceForceNames.lookup(instance);
+  }
 
 private:
   friend struct FIRRTLModuleLowering;
@@ -325,6 +325,10 @@ private:
   // The design-under-test (DUT), if it is found.  This will be set if a
   // "sifive.enterprise.firrtl.MarkDUTAnnotation" exists.
   FModuleOp dut;
+
+  /// A mapping of instances to their forced instantiation names (if
+  /// applicable).
+  DenseMap<std::pair<Attribute, Attribute>, Attribute> instanceForceNames;
 
   /// Map of symbol name to NonLocalAnchor op.
   llvm::DenseMap<Attribute, NonLocalAnchor> nlaMap;

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -2745,9 +2745,9 @@ LogicalResult FIRRTLLowering::visitDecl(InstanceOp oldInstance) {
   if (oldInstance.lowerToBind())
     newInstance->setAttr("doNotPrint", builder.getBoolAttr(true));
 
-  if (auto forceName = circuitState.instanceForceNames[{
-          cast<hw::HWModuleOp>(newInstance->getParentOp()).getNameAttr(),
-          newInstance.getName()}])
+  if (auto forceName = circuitState.lookupInstanceForceName(
+          {cast<hw::HWModuleOp>(newInstance->getParentOp()).getNameAttr(),
+           newInstance.getName()}))
     newInstance->setAttr("hw.verilogName", forceName);
 
   // Now that we have the new hw.instance, we need to remap all of the users

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1573,4 +1573,24 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK:  %0 = sv.array_index_inout %reg[%false] : !hw.inout<array<1xi1>>, i1
     // CHECK:  sv.passign %0, %value : i1
   }
+
+  // CHECK-LABEL: hw.module @ForceNameSubmodule
+  firrtl.nla @nla_1 [@ForceNameTop, @ForceNameSubmodule] ["foo", "ForceNameSubmodule"]
+  firrtl.nla @nla_2 [@ForceNameTop, @ForceNameSubmodule] ["bar", "ForceNameSubmodule"]
+  firrtl.module @ForceNameSubmodule() attributes {annotations = [
+    {circt.nonlocal = @nla_2,
+     class = "chisel3.util.experimental.ForceNameAnnotation", name = "Bar"},
+    {circt.nonlocal = @nla_1,
+     class = "chisel3.util.experimental.ForceNameAnnotation", name = "Foo"}]} {}
+  // CHECK: hw.module @ForceNameTop
+  firrtl.module @ForceNameTop() {
+    firrtl.instance foo
+      {annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}]}
+      @ForceNameSubmodule()
+    firrtl.instance bar
+      {annotations = [{circt.nonlocal = @nla_2, class = "circt.nonlocal"}]}
+      @ForceNameSubmodule()
+    // CHECK:      hw.instance "foo" {{.+}} {hw.verilogName = "Foo"}
+    // CHECK-NEXT: hw.instance "bar" {{.+}} {hw.verilogName = "Bar"}
+  }
 }


### PR DESCRIPTION
Add handling of Chisel's "forceName" API during FIRRTL Dialect to HW
Dialect conversion.  This can be used to guarantee that an instance has
a specific name.  The full Chisel API can be used to also force the
names of signals, but this is not supported.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

Note: this patch is _not_ enough to handle our uses of ForceNameAnnotation.  Currently, we use this to correct names after inlining.  There is a separate issue where non-local annotations (NLAs) are not properly updated by FIRRTL's module inliner.  I'm working on fixing this.