### PR TITLE
[Handshake] Support buffer initialization

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakeCanonicalization.td
+++ b/include/circt/Dialect/Handshake/HandshakeCanonicalization.td
@@ -32,7 +32,7 @@ def EliminateSunkConstantsPattern
           (replaceWithValue $sink)>;
 
 def EliminateSunkBuffersPattern
-    : Pat<(SinkOp:$sink (BufferOp $dataType, $size, $value, $sequential)),
+    : Pat<(SinkOp:$sink (BufferOp $dataType, $size, $value, $sequential, $initValues)),
           (SinkOp $value)>;
 
 #endif // CIRCT_DIALECT_HANDSHAKE_HANDSHAKECANONICALIZATION_TD

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -218,13 +218,21 @@ def BufferOp : Handshake_Op<"buffer", [NoSideEffect, HasClock,
     must be an unsigned integer larger than 0. $sequantial=True indicates a
     nontransparent buffer, while $sequantial=False indicates a transparent
     buffer.
+
+    An 'initValues' attribute containing a list of integer values may be provided.
+    The list must be of the same length as the number of slots. This will
+    initialize the buffer with the given values upon reset.
+    For now, only sequential buffers are allowed to have initial values.
+    @todo: How to support different init types? these have to be stored (and
+    retrieved) as attributes, hence they must be of a known type.
   }];
 
   let arguments = (ins
     TypeAttr:$dataType,
     Confined<I32Attr, [IntMinValue<1>]>:$size,
     AnyType:$operand,
-    BoolAttr:$sequential);
+    BoolAttr:$sequential,
+    OptionalAttr<I64ArrayAttr>:$initValues);
   let results = (outs AnyType:$result);
   let skipDefaultBuilders = 1;
   let builders = [OpBuilder<(ins "Type":$dataType, "int":$size,
@@ -237,9 +245,18 @@ def BufferOp : Handshake_Op<"buffer", [NoSideEffect, HasClock,
     int getNumSlots() {
       return (*this)->getAttrOfType<IntegerAttr>("size").getValue().getZExtValue();
     }
+    SmallVector<int64_t> getInitValues() {
+      assert(initValues() && "initValues attribute not set");
+      SmallVector<int64_t> values;
+      for (auto value : (*this)->getAttrOfType<ArrayAttr>("initValues"))
+        values.push_back(value.cast<IntegerAttr>().getValue().getSExtValue());
+      return values;
+    }
+
   }];
   let printer = "return ::print$cppClass(p, *this);";
   let parser = "return ::parse$cppClass(parser, result);";
+  let verifier = "return ::verify$cppClass(*this);";
   let hasCanonicalizer = 1;
 }
 

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -2301,9 +2301,10 @@ bool HandshakeBuilder::visitHandshake(BufferOp op) {
       initValues = op.getInitValues();
     return buildSeqBufferLogic(op.getNumSlots(), &input, &output, clock, reset,
                                op.isControl(), initValues);
-  } else
-    return buildFIFOBufferLogic(op.getNumSlots(), &input, &output, clock, reset,
-                                op.isControl());
+  }
+
+  return buildFIFOBufferLogic(op.getNumSlots(), &input, &output, clock, reset,
+                              op.isControl());
 }
 
 bool HandshakeBuilder::visitHandshake(ExternalMemoryOp op) {

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -962,7 +962,7 @@ public:
                             Value succReady, Value predData, Value dataReg);
   bool buildSeqBufferLogic(int64_t numStage, ValueVector *input,
                            ValueVector *output, Value clock, Value reset,
-                           bool isControl);
+                           bool isControl, ArrayRef<int64_t> initValues = {});
   bool buildFIFOBufferLogic(int64_t numStage, ValueVector *input,
                             ValueVector *output, Value clock, Value reset,
                             bool isControl);
@@ -2186,7 +2186,8 @@ bool HandshakeBuilder::buildFIFOBufferLogic(int64_t numStage,
 
 bool HandshakeBuilder::buildSeqBufferLogic(int64_t numStage, ValueVector *input,
                                            ValueVector *output, Value clock,
-                                           Value reset, bool isControl) {
+                                           Value reset, bool isControl,
+                                           ArrayRef<int64_t> initValues) {
   if (input == nullptr || output == nullptr)
     return false;
 
@@ -2201,6 +2202,7 @@ bool HandshakeBuilder::buildSeqBufferLogic(int64_t numStage, ValueVector *input,
   // Create useful value and type for valid/ready signal.
   auto bitType = UIntType::get(rewriter.getContext(), 1);
   auto falseConst = createConstantOp(bitType, APInt(1, 0), insertLoc, rewriter);
+  auto trueConst = createConstantOp(bitType, APInt(1, 1), insertLoc, rewriter);
 
   // Create useful value and type for data signal.
   FIRRTLType dataType = nullptr;
@@ -2225,21 +2227,28 @@ bool HandshakeBuilder::buildSeqBufferLogic(int64_t numStage, ValueVector *input,
 
   // Create multiple stages buffer logic.
   for (unsigned i = 0; i < numStage; ++i) {
+    bool isInitialized = initValues.size() > i;
+
     // Create wires for ready signal from the success buffer stage.
     auto readyWire = rewriter.create<WireOp>(insertLoc, bitType,
                                              "readyWire" + std::to_string(i));
 
     // Create a register for valid signal.
-    auto validReg =
-        rewriter.create<RegResetOp>(insertLoc, bitType, clock, reset,
-                                    falseConst, "validReg" + std::to_string(i));
+    auto validReg = rewriter.create<RegResetOp>(
+        insertLoc, bitType, clock, reset,
+        isInitialized ? trueConst : falseConst, "validReg" + std::to_string(i));
 
     // Create registers for data signal.
     Value dataReg = nullptr;
+    Value initValue = zeroDataConst;
+    if (isInitialized)
+      initValue = createConstantOp(
+          dataType, APInt(dataType.getBitWidthOrSentinel(), initValues[i]),
+          insertLoc, rewriter);
     if (!isControl)
-      dataReg = rewriter.create<RegResetOp>(insertLoc, dataType, clock, reset,
-                                            zeroDataConst,
-                                            "dataReg" + std::to_string(i));
+      dataReg =
+          rewriter.create<RegResetOp>(insertLoc, dataType, clock, reset,
+                                      initValue, "dataReg" + std::to_string(i));
 
     // Create wires for valid, ready and data signal coming from the control
     // buffer stage.
@@ -2286,10 +2295,13 @@ bool HandshakeBuilder::visitHandshake(BufferOp op) {
   Value reset = portList[3][0];
 
   // For now, we only support sequential buffers.
-  if (op.sequential())
+  if (op.sequential()) {
+    SmallVector<int64_t> initValues = {};
+    if (op.initValues())
+      initValues = op.getInitValues();
     return buildSeqBufferLogic(op.getNumSlots(), &input, &output, clock, reset,
-                               op.isControl());
-  else
+                               op.isControl(), initValues);
+  } else
     return buildFIFOBufferLogic(op.getNumSlots(), &input, &output, clock, reset,
                                 op.isControl());
 }

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -968,6 +968,23 @@ void handshake::TerminatorOp::build(OpBuilder &builder, OperationState &result,
   result.addSuccessors(successors);
 }
 
+static ParseResult verifyBufferOp(handshake::BufferOp op) {
+  // Verify that exactly 'size' number of initial values have been provided, if
+  // an initializer list have been provided.
+  if (op.initValues().hasValue()) {
+    if (!op.isSequential())
+      return op.emitOpError()
+             << "only sequential buffers are allowed to have initial values.";
+
+    auto nInits = op.initValues().getValue().size();
+    if (nInits != op.size())
+      return op.emitOpError() << "expected " << op.size()
+                              << " init values but got " << nInits << ".";
+  }
+
+  return success();
+}
+
 void handshake::BufferOp::getCanonicalizationPatterns(
     RewritePatternSet &results, MLIRContext *context) {
   results.insert<circt::handshake::EliminateSunkBuffersPattern>(context);

--- a/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
@@ -129,3 +129,13 @@ handshake.func @test_buffer_data(%arg0: index, %arg1: none, ...) -> (index, none
   %0 = buffer [2] %arg0 {sequential = true} : index
   return %0, %arg1 : index, none
 }
+
+// -----
+
+// CHECK: %validReg0 = firrtl.regreset %clock, %reset, %c1_ui1  : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK: %dataReg0 = firrtl.regreset %clock, %reset, %c42_ui64  : !firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>
+
+handshake.func @test_buffer_init(%arg0: index, %arg1: none, ...) -> (index, none) {
+  %0 = buffer [1] %arg0 {sequential = true, initValues=[42]} : index
+  return %0, %arg1 : index, none
+}

--- a/test/Dialect/Handshake/errors.mlir
+++ b/test/Dialect/Handshake/errors.mlir
@@ -113,3 +113,19 @@ handshake.func @invalid_constant_value(%ctrl : none) -> none {
   %0 = constant %ctrl {value = 1 : i31} : i32
   return %ctrl : none
 }
+
+// -----
+
+handshake.func @invalid_buffer_init1(%arg0 : i32, %ctrl : none) -> (i32, none) {
+  // expected-error @+1 {{'handshake.buffer' op expected 2 init values but got 1.}}
+  %0 = buffer [2] %arg0 {initValues = [1], sequential=true} : i32
+  return %0, %ctrl : i32, none
+}
+
+// -----
+
+handshake.func @invalid_buffer_init2(%arg0 : i32, %ctrl : none) -> (i32, none) {
+  // expected-error @+1 {{'handshake.buffer' op only sequential buffers are allowed to have initial values.}}
+  %0 = buffer [1] %arg0 {initValues = [1], sequential=false} : i32
+  return %0, %ctrl : i32, none
+}


### PR DESCRIPTION
This commit adds support for buffer initialization. A list of integer values may be provided to sequential buffers, which will be made the reset values of the buffer registers when lowering to hardware.