### PR TITLE
hw.probe for late binding to nameless values

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -211,6 +211,6 @@ def ProbeOp : FIRRTLOp<"probe"> {
   let arguments = (ins SymbolNameAttr:$inner_sym, Variadic<FIRRTLType>:$operands);
   let results = (outs);
 
-  let assemblyFormat = "$inner_sym `(` $operands `)` attr-dict `:` type($operands)";
+  let assemblyFormat = "$inner_sym attr-dict ( `,` $operands^  `:` type($operands))?";
 }
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -154,10 +154,10 @@ public:
     auto *thisCast = static_cast<ConcreteType *>(this);
     return TypeSwitch<Operation *, ResultType>(op)
         .template Case<AttachOp, ConnectOp, PartialConnectOp, ForceOp, PrintFOp,
-                       SkipOp, StopOp, WhenOp, AssertOp, AssumeOp, CoverOp>(
-            [&](auto opNode) -> ResultType {
-              return thisCast->visitStmt(opNode, args...);
-            })
+                       SkipOp, StopOp, WhenOp, AssertOp, AssumeOp, CoverOp,
+                       ProbeOp>([&](auto opNode) -> ResultType {
+          return thisCast->visitStmt(opNode, args...);
+        })
         .Default([&](auto expr) -> ResultType {
           return thisCast->visitInvalidStmt(op, args...);
         });
@@ -191,6 +191,8 @@ public:
   HANDLE(AssertOp);
   HANDLE(AssumeOp);
   HANDLE(CoverOp);
+  HANDLE(ProbeOp);
+
 #undef HANDLE
 };
 

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -458,3 +458,20 @@ def GlobalRefOp : HWOp<"globalRef", [IsolatedFromAbove, Symbol]> {
 
   let verifier = "return this->verifyGlobalRef();";
 }
+
+def ProbeOp : HWOp<"probe", []> {
+  let summary = "Probe values for use in remote references";
+  let description = [{
+    Captures values without binding to any accidental name.  This allows
+    capturing names holding values of interest while allowing the name to
+    resolved only at emission time.
+  }];
+
+  let arguments = (ins SymbolNameAttr:$inner_sym,
+                       Variadic<AnyType>:$operands);
+  let results = (outs);
+
+  let assemblyFormat = "$inner_sym attr-dict (`,` $operands^ `:` type($operands))?";
+
+}
+

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -581,6 +581,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   }
 
   firrtl.module @bar(in %io_cpu_flush: !firrtl.uint<1>) {
+    // CHECK: hw.probe @baz, %io_cpu_flush, %io_cpu_flush : i1, i1
+    firrtl.probe @baz, %io_cpu_flush, %io_cpu_flush  : !firrtl.uint<1>, !firrtl.uint<1>
   }
 
   // CHECK-LABEL: hw.module @foo

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -165,8 +165,8 @@ firrtl.module @ProbeTest(in %in1 : !firrtl.uint<2>, in %in2 : !firrtl.uint<3>, o
   firrtl.connect %w1, %w2 : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out3, %in2 : !firrtl.uint<3>, !firrtl.uint<3>
   %someNode = firrtl.node %in1 : !firrtl.uint<2>
-  // CHECK: firrtl.probe @foobar(%in1, %in2, %out3, %w1, %[[TMP3]], %someNode) : !firrtl.uint<2>, !firrtl.uint<3>, !firrtl.uint<3>, !firrtl.uint<4>, !firrtl.uint<4>, !firrtl.uint<2>
-  firrtl.probe @foobar (%in1, %in2, %out3, %w1, %w2, %someNode) : !firrtl.uint<2>, !firrtl.uint<3>, !firrtl.uint<3>, !firrtl.uint<4>, !firrtl.uint<4>, !firrtl.uint<2>
+  // CHECK: firrtl.probe @foobar, %in1, %in2, %out3, %w1, %[[TMP3]], %someNode : !firrtl.uint<2>, !firrtl.uint<3>, !firrtl.uint<3>, !firrtl.uint<4>, !firrtl.uint<4>, !firrtl.uint<2>
+  firrtl.probe @foobar, %in1, %in2, %out3, %w1, %w2, %someNode : !firrtl.uint<2>, !firrtl.uint<3>, !firrtl.uint<3>, !firrtl.uint<4>, !firrtl.uint<4>, !firrtl.uint<2>
 }
 
 }


### PR DESCRIPTION
This provides a way to refer to values without pre-binding a name.  Thus the implementation of the device holding a value is unspecified, simply constrained such that at emission time, a namable entity will exist with the value in it.  This will be used for bind and XMRs and in verbatim name-substitutions.