### PR TITLE
[ExportVerilog] ProbeOp namifier

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -769,7 +769,7 @@ static StringRef getProbedSymOpName(ProbeOp probe) {
         << "must have exactly one operand to use in verbatim substitution";
     return StringRef("");
   }
-  auto* wire = probe.getOperand(0).getDefiningOp();
+  auto *wire = probe.getOperand(0).getDefiningOp();
   assert(isa_and_nonnull<WireOp>(wire) &&
          "must be converted into a wire in the prepass");
   return getSymOpName(wire);
@@ -940,8 +940,6 @@ void EmitterBase::emitComment(StringAttr comment) {
     }
   }
 }
-
-
 
 //===----------------------------------------------------------------------===//
 // ModuleEmitter

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -693,10 +693,14 @@ private:
 };
 } // end anonymous namespace
 
-// Return probed value's name generated in prepareForEmission.
+// Return probed value's name associated with a wire generated in
+// prepareForEmission.
 static StringRef getProbedSymOpName(ProbeOp probe) {
-  if (probe.getNumOperands() != 1)
+  if (probe.getNumOperands() != 1) {
+    probe.emitError()
+        << "must have exactly one operand to use in verbatim substitution";
     return StringRef("");
+  }
   auto wire = probe.getOperand(0).getDefiningOp();
   assert(isa_and_nonnull<WireOp>(wire) &&
          "must be converted into a wire in the prepass");

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -769,7 +769,7 @@ static StringRef getProbedSymOpName(ProbeOp probe) {
         << "must have exactly one operand to use in verbatim substitution";
     return StringRef("");
   }
-  auto wire = probe.getOperand(0).getDefiningOp();
+  auto* wire = probe.getOperand(0).getDefiningOp();
   assert(isa_and_nonnull<WireOp>(wire) &&
          "must be converted into a wire in the prepass");
   return getSymOpName(wire);

--- a/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
+++ b/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
@@ -26,6 +26,11 @@ class GlobalNameResolver;
 /// for instances this is `instanceName`, etc.
 StringAttr getDeclarationName(Operation *op);
 
+/// Given an expression that is spilled into a temporary wire, try to
+/// synthesize a better name than "_T_42" based on the structure of the
+/// expression.
+StringAttr inferStructuralNameForTemporary(Value expr);
+
 /// This class keeps track of global names at the module/interface level.
 /// It is built in a global pass over the entire design and then frozen to allow
 /// concurrent accesses.

--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -383,10 +383,10 @@ static void replaceSingleOperandOfProbeOpWithWire(Block &block,
     operand = builder.create<ReadInOutOp>(operand);
 
   // Create a new wire to associate with ProbeOp.
-  // TODO: Add an useful name to wire.
   // TODO: Don't create a new wire if the operand can define symbols.
   builder.setInsertionPointToStart(wireBlock);
-  auto newWire = builder.create<WireOp>(operand.getType());
+  auto newWire = builder.create<WireOp>(
+      operand.getType(), inferStructuralNameForTemporary(operand));
 
   builder.setInsertionPoint(probeOp);
   if (isProceduralRegion) {

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1138,45 +1138,45 @@ hw.module @XMR_src(%a : i23) -> (aa: i3) {
 }
 
 // CHECK-LABEL: module SubstProbeInVerbatim1
-hw.module @SubstProbeInVerbatim1(%a: i1) -> (b: i1) {
-  // CHECK:      wire       [[PROBE_ADD:.+]];
+hw.module @SubstProbeInVerbatim1(%a: i4, %b: i1) -> (c: i1) {
+  // CHECK:      wire [1:0] [[PROBE_EXTRACT:_a_2to1]];
   // CHECK-NEXT: wire       [[PROBE_READ:.+]];
   // CHECK-NEXT: wire       [[PROBE_REG:.+]];
   // CHECK-NEXT: wire [0:0] [[WIRE:.+]];
   // CHECK-NEXT: reg  [0:0] [[REG:.+]];
 
-  // CHECK:      localparam _T_2 = 1'h0;
-  // CHECK-NEXT: assign [[PROBE_READ]] = wire_2[_T_2];
-  // CHECK-NEXT: assign [[PROBE_ADD]] = a + wire_2[_T_2];
+  // CHECK:      localparam _T_1 = 1'h0;
+  // CHECK-NEXT: assign [[PROBE_READ]] = [[WIRE]][_T_1];
+  // CHECK-NEXT: assign [[PROBE_EXTRACT]] = a[2:1];
   // CHECK-NEXT: initial begin
-  // CHECK-NEXT:   force [[PROBE_REG]] = [[REG]][_T_2];
+  // CHECK-NEXT:   force [[PROBE_REG]] = [[REG]][_T_1];
   %wire = sv.wire  : !hw.inout<array<1xi1>>
   %false = hw.constant false
   %0 = sv.array_index_inout %wire[%false] : !hw.inout<array<1xi1>>, i1
   %1 = sv.read_inout %0 : !hw.inout<i1>
-  hw.probe @read_wire, %1 : i1
-  %2 = comb.add %a, %1 : i1
-  hw.probe @read_add, %2 : i1
+  hw.probe @wire_sub, %1 : i1
+  %2 = comb.extract %a from 1 : (i4) -> i2
+  hw.probe @extract, %2 : i2
   %3 = sv.reg  : !hw.inout<array<1xi1>>
   sv.initial  {
     %4 = sv.array_index_inout %3[%false] : !hw.inout<array<1xi1>>, i1
-    hw.probe @read_reg_subfield, %4 : !hw.inout<i1>
+    hw.probe @reg_sub, %4 : !hw.inout<i1>
   }
-  sv.assign %0, %a : i1
+  sv.assign %0, %b : i1
   hw.output %1 : i1
 }
 
 // CHECK-LABEL: module SubstProbeInVerbatim2
 hw.module @SubstProbeInVerbatim2() -> (a: i1, b: i1, c: i1) {
   // CHECK:  assign a = SubstProbeInVerbatim1.[[PROBE_READ]];
-  // CHECK:  assign b = SubstProbeInVerbatim1.[[PROBE_ADD]];
+  // CHECK:  assign b = SubstProbeInVerbatim1.[[PROBE_EXTRACT]];
   // CHECK:  assign c = SubstProbeInVerbatim1.[[PROBE_REG]];
   %0 = sv.verbatim.expr "{{0}}.{{1}}" : () -> i1
-       {symbols = [@SubstProbeInVerbatim1, #hw.innerNameRef<@SubstProbeInVerbatim1::@read_wire>]}
+       {symbols = [@SubstProbeInVerbatim1, #hw.innerNameRef<@SubstProbeInVerbatim1::@wire_sub>]}
   %1 = sv.verbatim.expr "{{0}}.{{1}}" : () -> i1
-       {symbols = [@SubstProbeInVerbatim1, #hw.innerNameRef<@SubstProbeInVerbatim1::@read_add>]}
+       {symbols = [@SubstProbeInVerbatim1, #hw.innerNameRef<@SubstProbeInVerbatim1::@extract>]}
   %2 = sv.verbatim.expr "{{0}}.{{1}}" : () -> i1
-       {symbols = [@SubstProbeInVerbatim1, #hw.innerNameRef<@SubstProbeInVerbatim1::@read_reg_subfield>]}
+       {symbols = [@SubstProbeInVerbatim1, #hw.innerNameRef<@SubstProbeInVerbatim1::@reg_sub>]}
   hw.output %0, %1, %2 : i1, i1, i1
 }
 

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1137,6 +1137,49 @@ hw.module @XMR_src(%a : i23) -> (aa: i3) {
   hw.output %r : i3
 }
 
+// CHECK-LABEL: module SubstProbeInVerbatim1
+hw.module @SubstProbeInVerbatim1(%a: i1) -> (b: i1) {
+  // CHECK:      wire       [[PROBE_ADD:.+]];
+  // CHECK-NEXT: wire       [[PROBE_READ:.+]];
+  // CHECK-NEXT: wire       [[PROBE_REG:.+]];
+  // CHECK-NEXT: wire [0:0] [[WIRE:.+]];
+  // CHECK-NEXT: reg  [0:0] [[REG:.+]];
+
+  // CHECK:      localparam _T_2 = 1'h0;
+  // CHECK-NEXT: assign [[PROBE_READ]] = wire_2[_T_2];
+  // CHECK-NEXT: assign [[PROBE_ADD]] = a + wire_2[_T_2];
+  // CHECK-NEXT: initial begin
+  // CHECK-NEXT:   force [[PROBE_REG]] = [[REG]][_T_2];
+  %wire = sv.wire  : !hw.inout<array<1xi1>>
+  %false = hw.constant false
+  %0 = sv.array_index_inout %wire[%false] : !hw.inout<array<1xi1>>, i1
+  %1 = sv.read_inout %0 : !hw.inout<i1>
+  hw.probe @read_wire, %1 : i1
+  %2 = comb.add %a, %1 : i1
+  hw.probe @read_add, %2 : i1
+  %3 = sv.reg  : !hw.inout<array<1xi1>>
+  sv.initial  {
+    %4 = sv.array_index_inout %3[%false] : !hw.inout<array<1xi1>>, i1
+    hw.probe @read_reg_subfield, %4 : !hw.inout<i1>
+  }
+  sv.assign %0, %a : i1
+  hw.output %1 : i1
+}
+
+// CHECK-LABEL: module SubstProbeInVerbatim2
+hw.module @SubstProbeInVerbatim2() -> (a: i1, b: i1, c: i1) {
+  // CHECK:  assign a = SubstProbeInVerbatim1.[[PROBE_READ]];
+  // CHECK:  assign b = SubstProbeInVerbatim1.[[PROBE_ADD]];
+  // CHECK:  assign c = SubstProbeInVerbatim1.[[PROBE_REG]];
+  %0 = sv.verbatim.expr "{{0}}.{{1}}" : () -> i1
+       {symbols = [@SubstProbeInVerbatim1, #hw.innerNameRef<@SubstProbeInVerbatim1::@read_wire>]}
+  %1 = sv.verbatim.expr "{{0}}.{{1}}" : () -> i1
+       {symbols = [@SubstProbeInVerbatim1, #hw.innerNameRef<@SubstProbeInVerbatim1::@read_add>]}
+  %2 = sv.verbatim.expr "{{0}}.{{1}}" : () -> i1
+       {symbols = [@SubstProbeInVerbatim1, #hw.innerNameRef<@SubstProbeInVerbatim1::@read_reg_subfield>]}
+  hw.output %0, %1, %2 : i1, i1, i1
+}
+
 // CHECK-LABEL: module extInst
 hw.module.extern @extInst(%_h: i1, %_i: i1, %_j: i1, %_k: i1, %_z :i0) -> ()
 

--- a/test/Conversion/ExportVerilog/verilog-errors.mlir
+++ b/test/Conversion/ExportVerilog/verilog-errors.mlir
@@ -23,3 +23,16 @@ hw.module @B() {
 
 // expected-error @+1 {{name "parameter" is not allowed in Verilog output}}
 hw.module.extern @parameter ()
+
+// -----
+hw.module @invalid_probe_verbatim(%a: i1) {
+  // expected-error @+2 {{must have exactly one operand to use in verbatim substitution}}
+  // expected-error @+1 {{cannot get name for symbol #hw.innerNameRef<@invalid_probe_verbatim::@probe>}}
+  hw.probe @probe, %a, %a : i1, i1
+}
+
+hw.module @invalid() -> (a: i1) {
+  %0 = sv.verbatim.expr "{{0}}" : () -> i1
+       {symbols = [#hw.innerNameRef<@invalid_probe_verbatim::@probe>]}
+  hw.output %0 : i1
+}


### PR DESCRIPTION
This commit implements verbatim substitution of values
associated with probeop. Temporary wires are forced to be
created for associated values at prepareForEmission.
Currently, 
```mlir
hw.module @Foo(%a: i1) -> (b: i1) {
  %wire = sv.wire  : !hw.inout<struct<a: i1>>
  %0 = sv.struct_field_inout %wire["a"] : !hw.inout<struct<a: i1>>
  hw.probe @read_wire, %0 : !hw.inout<i1>
  %1 = sv.verbatim.expr "{{0}}.{{1}}" : () -> i1
       {symbols = [@Foo, #hw.innerNameRef<@Foo::@read_wire>]}
  sv.assign %0, %a : i1
  hw.output %1 : i1
}
``` 
will emit
```sv
module Foo(     // foo.mlir:1:1
  input  a,
  output b);

  wire                           _T;    // foo.mlir:4:3
  wire struct packed {logic a; } wire_0;        // foo.mlir:2:11

  assign _T = wire_0.a; // foo.mlir:3:8, :4:3
  assign wire_0.a = a;  // foo.mlir:3:8, :7:3
  assign b = Foo._T;    // foo.mlir:5:8, :8:3
endmodule
```

Depends on https://github.com/llvm/circt/pull/2443