### PR TITLE
[FIRRTL][Parser] Use reference to namepsace, instead of copying it

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1526,7 +1526,7 @@ namespace {
 struct FIRStmtParser : public FIRParser {
   explicit FIRStmtParser(Block &blockToInsertInto,
                          FIRModuleContext &moduleContext,
-                         Namespace modNameSpace)
+                         Namespace &modNameSpace)
       : FIRParser(moduleContext.getConstants(), moduleContext.getLexer()),
         builder(mlir::ImplicitLocOpBuilder::atBlockEnd(
             UnknownLoc::get(getContext()), &blockToInsertInto)),
@@ -1619,7 +1619,7 @@ private:
   // Extra information maintained across a module.
   FIRModuleContext &moduleContext;
 
-  Namespace modNameSpace;
+  Namespace &modNameSpace;
 };
 
 } // end anonymous namespace


### PR DESCRIPTION
Use a reference to the namespace instead of invoking the copy constructor.
The entire module body is under a single namespace, so it makes sense to maintain a single copy of the namespace and pass reference to it. Instead of invoking the copy constructor for every statement block.

This is a fix to the performance regression, https://github.com/llvm/circt/issues/2440
