### PR TITLE
[HandshakeToFIRRTL] Add flattening option

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -138,6 +138,11 @@ def HandshakeToFIRRTL : Pass<"lower-handshake-to-firrtl", "mlir::ModuleOp"> {
   }];
   let constructor = "circt::createHandshakeToFIRRTLPass()";
   let dependentDialects = ["firrtl::FIRRTLDialect"];
+  let options = [
+    Option<"enableFlattening", "flatten", "bool", "false",
+    "Flattens the generated FIRRTL component by inlining all dataflow component"
+    " instantiations into the top module.">,
+  ];
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
By playing around with inlining all handshake modules into the top-level, i've seen reduction in final LUT usage of ~10% in some cases. Given this, I think it's worthwhile to add a switch to enable this.