### PR TITLE
Revert "[Handshake] Allow simple merges in canonical form (#2430)"

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakeCanonicalization.td
+++ b/include/circt/Dialect/Handshake/HandshakeCanonicalization.td
@@ -19,6 +19,9 @@ include "circt/Dialect/Handshake/Handshake.td"
 def HasOneOperand : Constraint<CPred<"$_self.size() == 1">, "has one operand">;
 def HasOneResult : Constraint<CPred<"$_self.size() == 1">, "has one result">;
 
+def EliminateSimpleMergesPattern : Pat<(MergeOp $dataType, $size, $arg), (replaceWithValue $arg),
+                                       [(HasOneOperand:$arg)]>;
+
 def EliminateSimpleBranchesPattern
     : Pat<(BranchOp $dataType, $a), (replaceWithValue $a)>;
 

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -339,6 +339,7 @@ def MergeOp : Handshake_Op<"merge", [
   let printer = "return ::print$cppClass(p, *this);";
   let parser = "return ::parse$cppClass(parser, result);";
 
+  let hasCanonicalizer = 1;
   let skipDefaultBuilders = 1;
   let builders = [OpBuilder<(ins "ValueRange":$operands)>];
 }

--- a/include/circt/Dialect/Handshake/HandshakePasses.h
+++ b/include/circt/Dialect/Handshake/HandshakePasses.h
@@ -32,7 +32,6 @@ std::unique_ptr<mlir::Pass> createHandshakeRemoveBuffersPass();
 std::unique_ptr<mlir::Pass> createHandshakeAddIDsPass();
 std::unique_ptr<mlir::OperationPass<handshake::FuncOp>>
 createHandshakeInsertBuffersPass();
-std::unique_ptr<mlir::Pass> createHandshakeRemoveSimpleMergesPass();
 
 /// Iterates over the handshake::FuncOp's in the program to build an instance
 /// graph. In doing so, we detect whether there are any cycles in this graph, as

--- a/include/circt/Dialect/Handshake/HandshakePasses.td
+++ b/include/circt/Dialect/Handshake/HandshakePasses.td
@@ -62,17 +62,6 @@ def HandshakeRemoveBuffers : Pass<"handshake-remove-buffers", "handshake::FuncOp
   let constructor = "circt::handshake::createHandshakeRemoveBuffersPass()";
 }
 
-def HandshakeRemoveSimpleMerges : Pass<"handshake-remove-simple-merges", "handshake::FuncOp"> {
-  let summary = "Remove simple merges from handshake functions.";
-  let description = [{
-    This pass analysis a handshake.func operation and removes any simple merges
-    - merge operation with a single input - from the function.
-    Simple merges are allowed in canonical Handshake IR due to their importance
-    in correct buffer placement.
-  }];
-  let constructor = "circt::handshake::createHandshakeRemoveSimpleMergesPass()";
-}
-
 def HandshakeAddIDs : Pass<"handshake-add-ids", "handshake::FuncOp"> {
   let summary = "Add an ID to each operation in a handshake function.";
   let description = [{

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -272,6 +272,11 @@ static ParseResult parseMergeOp(OpAsmParser &parser, OperationState &result) {
 
 void printMergeOp(OpAsmPrinter &p, MergeOp op) { sost::printOp(p, op, false); }
 
+void MergeOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                          MLIRContext *context) {
+  results.insert<circt::handshake::EliminateSimpleMergesPattern>(context);
+}
+
 /// Returns a dematerialized version of the value 'v', defined as the source of
 /// the value before passing through a buffer or fork operation.
 static Value getDematerialized(Value v) {

--- a/lib/Dialect/Handshake/Transforms/Materialization.cpp
+++ b/lib/Dialect/Handshake/Transforms/Materialization.cpp
@@ -22,7 +22,6 @@
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Support/IndentedOstream.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/ADT/TypeSwitch.h"
 
 using namespace circt;
@@ -150,30 +149,6 @@ struct HandshakeDematerializeForksSinksPass
   };
 };
 
-struct EliminateSimpleMergesPattern
-    : public OpRewritePattern<handshake::MergeOp> {
-  using OpRewritePattern::OpRewritePattern;
-  LogicalResult matchAndRewrite(handshake::MergeOp op,
-                                PatternRewriter &rewriter) const override {
-    if (op.getNumOperands() > 1)
-      return failure();
-    rewriter.replaceOp(op, op.getOperand(0));
-    return success();
-  };
-};
-
-struct HandshakeRemoveSimpleMergesPass
-    : public HandshakeRemoveSimpleMergesBase<HandshakeRemoveSimpleMergesPass> {
-  void runOnOperation() override {
-    handshake::FuncOp op = getOperation();
-    auto *ctx = op.getContext();
-    RewritePatternSet patterns(ctx);
-    patterns.add<EliminateSimpleMergesPattern>(ctx);
-    if (failed(applyPatternsAndFoldGreedily(op, std::move(patterns))))
-      signalPassFailure();
-  };
-};
-
 } // namespace
 
 std::unique_ptr<mlir::Pass>
@@ -184,9 +159,4 @@ circt::handshake::createHandshakeMaterializeForksSinksPass() {
 std::unique_ptr<mlir::Pass>
 circt::handshake::createHandshakeDematerializeForksSinksPass() {
   return std::make_unique<HandshakeDematerializeForksSinksPass>();
-}
-
-std::unique_ptr<mlir::Pass>
-circt::handshake::createHandshakeRemoveSimpleMergesPass() {
-  return std::make_unique<HandshakeRemoveSimpleMergesPass>();
 }

--- a/test/Conversion/StandardToHandshake/test_source_constants.mlir
+++ b/test/Conversion/StandardToHandshake/test_source_constants.mlir
@@ -3,11 +3,10 @@
 // CHECK-LABEL:   handshake.func @foo(
 // CHECK-SAME:                        %[[VAL_0:.*]]: i32,
 // CHECK-SAME:                        %[[VAL_1:.*]]: none, ...) -> (i32, none) attributes {argNames = ["in0", "inCtrl"], resNames = ["out0", "outCtrl"]} {
-// CHECK:           %[[VAL_2:.*]] = merge %[[VAL_0]] : i32
-// CHECK:           %[[VAL_3:.*]] = source
-// CHECK:           %[[VAL_4:.*]] = constant %[[VAL_3]] {value = 1 : i32} : i32
-// CHECK:           %[[VAL_5:.*]] = arith.addi %[[VAL_2]], %[[VAL_4]] : i32
-// CHECK:           return %[[VAL_5]], %[[VAL_1]] : i32, none
+// CHECK:           %[[VAL_2:.*]] = source
+// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_2]] {value = 1 : i32} : i32
+// CHECK:           %[[VAL_4:.*]] = arith.addi %[[VAL_0]], %[[VAL_3]] : i32
+// CHECK:           return %[[VAL_4]], %[[VAL_1]] : i32, none
 // CHECK:         }
 
 func @foo(%arg0 : i32) -> i32 {

--- a/test/Dialect/Handshake/canonicalization.mlir
+++ b/test/Dialect/Handshake/canonicalization.mlir
@@ -1,5 +1,27 @@
 // RUN: circt-opt -split-input-file -canonicalize='top-down=true region-simplify=true' %s | FileCheck %s
 
+// CHECK-LABEL:   handshake.func @simple(
+// CHECK-SAME:                           %[[VAL_0:.*]]: none, ...) -> none attributes {argNames = ["arg0"], resNames = ["outCtrl"]} {
+// CHECK:           %[[VAL_1:.*]] = constant %[[VAL_0]] {value = 1 : index} : index
+// CHECK:           %[[VAL_2:.*]]:2 = fork [2] %[[VAL_0]] : none
+// CHECK:           %[[VAL_3:.*]] = constant %[[VAL_2]]#0 {value = 42 : index} : index
+// CHECK:           %[[VAL_4:.*]] = arith.addi %[[VAL_1]], %[[VAL_3]] : index
+// CHECK:           sink %[[VAL_4]] : index
+// CHECK:           return %[[VAL_2]]#1 : none
+// CHECK:         }
+handshake.func @simple(%arg0: none, ...) -> none {
+  %0 = constant %arg0 {value = 1 : index} : index
+  %1 = br %arg0 : none
+  %2 = br %0 : index
+  %3 = merge %1 : none
+  %4 = merge %2 : index
+  %5:2 = fork [2] %3 : none
+  %6 = constant %5#0 {value = 42 : index} : index
+  %7 = arith.addi %4, %6 : index
+  sink %7 : index
+  handshake.return %5#1 : none
+}
+
 // -----
 
 // CHECK:   handshake.func @cmerge_with_control_used(%[[VAL_0:.*]]: none, %[[VAL_1:.*]]: none, %[[VAL_2:.*]]: none, ...) -> (none, index, none) attributes {argNames = ["arg0", "arg1", "arg2"], resNames = ["out0", "out1", "outCtrl"]} {


### PR DESCRIPTION
This reverts commit 8e4467132c364c86e81b92109e9def223c5847dd.

The problem which I thought this commit (partially) solved is actually solved by https://github.com/llvm/circt/pull/2444. In light of that, this commit is technically a regression and should be reverted.