### PR TITLE
[CI] Prevent yapf from linting .py.in files.

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -85,7 +85,7 @@ jobs:
         if: ${{ always() }}
         shell: bash
         run: |
-          files=$(git diff --name-only $DIFF_COMMIT | grep -e '\.py' || echo -n)
+          files=$(git diff --name-only $DIFF_COMMIT | grep -e '\.py$' || echo -n)
           if [[ ! -z $files ]]; then
             yapf --diff $files
           fi


### PR DESCRIPTION
Stumbled across this [here](https://github.com/llvm/circt/runs/4826212347): The changes to `test/lit.site.cfg.py.in` trigger the linting check, but `yapf` complains that the file is not syntactically correct (due to the `@REPLACEMENT_TAGS@`).