### PR TITLE
[MSFT] Add walk order option when walking placements.

### DIFF
--- a/include/circt-c/Dialect/MSFT.h
+++ b/include/circt-c/Dialect/MSFT.h
@@ -97,7 +97,6 @@ enum CirctMSFTDirection { NONE = 0, ASC = 1, DESC = 2 };
 typedef struct {
   CirctMSFTDirection columns;
   CirctMSFTDirection rows;
-  CirctMSFTDirection nums;
 } CirctMSFTWalkOrder;
 
 MLIR_CAPI_EXPORTED CirctMSFTPlacementDB

--- a/include/circt-c/Dialect/MSFT.h
+++ b/include/circt-c/Dialect/MSFT.h
@@ -93,6 +93,13 @@ typedef struct {
   MlirOperation op;
 } CirctMSFTPlacedInstance;
 
+enum CirctMSFTDirection { NONE = 0, ASC = 1, DESC = 2 };
+typedef struct {
+  CirctMSFTDirection columns;
+  CirctMSFTDirection rows;
+  CirctMSFTDirection nums;
+} CirctMSFTWalkOrder;
+
 MLIR_CAPI_EXPORTED CirctMSFTPlacementDB
 circtMSFTCreatePlacementDB(MlirOperation top, CirctMSFTPrimitiveDB seed);
 MLIR_CAPI_EXPORTED void circtMSFTDeletePlacementDB(CirctMSFTPlacementDB self);
@@ -114,7 +121,8 @@ typedef void (*CirctMSFTPlacementCallback)(MlirAttribute loc,
 /// on all sides), with -1 meaning unbounded.
 MLIR_CAPI_EXPORTED void circtMSFTPlacementDBWalkPlacements(
     CirctMSFTPlacementDB, CirctMSFTPlacementCallback, int64_t bounds[4],
-    CirctMSFTPrimitiveType primTypeFilter, void *userData);
+    CirctMSFTPrimitiveType primTypeFilter, CirctMSFTWalkOrder walkOrder,
+    void *userData);
 
 #ifdef __cplusplus
 }

--- a/include/circt/Dialect/MSFT/DeviceDB.h
+++ b/include/circt/Dialect/MSFT/DeviceDB.h
@@ -77,6 +77,14 @@ public:
     Operation *op;
   };
 
+  /// Contains the order to iterate in each dimension for walkPlacements.
+  enum Direction { NONE = 0, ASC = 1, DESC = 2 };
+  struct WalkOrder {
+    Direction columns;
+    Direction rows;
+    Direction nums;
+  };
+
   /// Assign an instance to a primitive. Return false if another instance is
   /// already placed at that location.
   LogicalResult addPlacement(PhysLocationAttr, PlacedInstance);
@@ -102,7 +110,8 @@ public:
   void walkPlacements(function_ref<void(PhysLocationAttr, PlacedInstance)>,
                       std::tuple<int64_t, int64_t, int64_t, int64_t> bounds =
                           std::make_tuple(-1, -1, -1, -1),
-                      Optional<PrimitiveType> primType = {});
+                      Optional<PrimitiveType> primType = {},
+                      Optional<WalkOrder> = {});
 
   /// Walk the region placement information.
   void walkRegionPlacements(

--- a/include/circt/Dialect/MSFT/DeviceDB.h
+++ b/include/circt/Dialect/MSFT/DeviceDB.h
@@ -77,7 +77,9 @@ public:
     Operation *op;
   };
 
-  /// Contains the order to iterate in each dimension for walkPlacements.
+  /// Contains the order to iterate in each dimension for walkPlacements. The
+  /// dimensions are visited with columns first, then rows, then numbers within
+  /// a cell.
   enum Direction { NONE = 0, ASC = 1, DESC = 2 };
   struct WalkOrder {
     Direction columns;

--- a/include/circt/Dialect/MSFT/DeviceDB.h
+++ b/include/circt/Dialect/MSFT/DeviceDB.h
@@ -84,7 +84,6 @@ public:
   struct WalkOrder {
     Direction columns;
     Direction rows;
-    Direction nums;
   };
 
   /// Assign an instance to a primitive. Return false if another instance is

--- a/integration_test/Bindings/Python/dialects/msft.py
+++ b/integration_test/Bindings/Python/dialects/msft.py
@@ -157,70 +157,60 @@ with ir.Context() as ctx, ir.Location.unknown():
   devdb.add_primitive(msft.PhysLocationAttr.get(msft.M20K, x=1, y=1, num=0))
   pdb = msft.PlacementDB(top.operation, devdb)
 
-  print("=== Placements ASC, ASC, ASC:")
-  walk_order = msft.WalkOrder(
-      columns=msft.Direction.ASC,
-      rows=msft.Direction.ASC,
-      nums=msft.Direction.ASC,
-  )
+  print("=== Placements ASC, ASC:")
+  walk_order = msft.WalkOrder(columns=msft.Direction.ASC,
+                              rows=msft.Direction.ASC)
   pdb.walk_placements(print_placement, walk_order=walk_order)
-  # CHECK-LABEL: === Placements ASC, ASC, ASC:
-  # CHECK: #msft.physloc<M20K, 0, 0, 0>
-  # CHECK: #msft.physloc<M20K, 0, 0, 1>
-  # CHECK: #msft.physloc<M20K, 0, 1, 0>
-  # CHECK: #msft.physloc<M20K, 0, 1, 1>
-  # CHECK: #msft.physloc<M20K, 1, 0, 0>
-  # CHECK: #msft.physloc<M20K, 1, 0, 1>
-  # CHECK: #msft.physloc<M20K, 1, 1, 0>
-  # CHECK: #msft.physloc<M20K, 1, 1, 1>
+  # CHECK-LABEL: === Placements ASC, ASC:
+  # CHECK: #msft.physloc<M20K, 0, 0
+  # CHECK: #msft.physloc<M20K, 0, 0
+  # CHECK: #msft.physloc<M20K, 0, 1
+  # CHECK: #msft.physloc<M20K, 0, 1
+  # CHECK: #msft.physloc<M20K, 1, 0
+  # CHECK: #msft.physloc<M20K, 1, 0
+  # CHECK: #msft.physloc<M20K, 1, 1
+  # CHECK: #msft.physloc<M20K, 1, 1
 
-  print("=== Placements DESC, DESC, DESC:")
-  walk_order = msft.WalkOrder(
-      columns=msft.Direction.DESC,
-      rows=msft.Direction.DESC,
-      nums=msft.Direction.DESC,
-  )
+  print("=== Placements DESC, DESC:")
+  walk_order = msft.WalkOrder(columns=msft.Direction.DESC,
+                              rows=msft.Direction.DESC)
   pdb.walk_placements(print_placement, walk_order=walk_order)
-  # CHECK-LABEL: === Placements DESC, DESC, DESC:
-  # CHECK: #msft.physloc<M20K, 1, 1, 1>
-  # CHECK: #msft.physloc<M20K, 1, 1, 0>
-  # CHECK: #msft.physloc<M20K, 1, 0, 1>
-  # CHECK: #msft.physloc<M20K, 1, 0, 0>
-  # CHECK: #msft.physloc<M20K, 0, 1, 1>
-  # CHECK: #msft.physloc<M20K, 0, 1, 0>
-  # CHECK: #msft.physloc<M20K, 0, 0, 1>
-  # CHECK: #msft.physloc<M20K, 0, 0, 0>
+  # CHECK-LABEL: === Placements DESC, DESC:
+  # CHECK: #msft.physloc<M20K, 1, 1
+  # CHECK: #msft.physloc<M20K, 1, 1
+  # CHECK: #msft.physloc<M20K, 1, 0
+  # CHECK: #msft.physloc<M20K, 1, 0
+  # CHECK: #msft.physloc<M20K, 0, 1
+  # CHECK: #msft.physloc<M20K, 0, 1
+  # CHECK: #msft.physloc<M20K, 0, 0
+  # CHECK: #msft.physloc<M20K, 0, 0
 
-  print("=== Placements ASC, DESC, ASC:")
-  walk_order = msft.WalkOrder(
-      columns=msft.Direction.ASC,
-      rows=msft.Direction.DESC,
-      nums=msft.Direction.ASC,
-  )
+  print("=== Placements ASC, DESC:")
+  walk_order = msft.WalkOrder(columns=msft.Direction.ASC,
+                              rows=msft.Direction.DESC)
   pdb.walk_placements(print_placement, walk_order=walk_order)
-  # CHECK-LABEL: === Placements ASC, DESC, ASC:
-  # CHECK: #msft.physloc<M20K, 0, 1, 0>
-  # CHECK: #msft.physloc<M20K, 0, 1, 1>
-  # CHECK: #msft.physloc<M20K, 0, 0, 0>
-  # CHECK: #msft.physloc<M20K, 0, 0, 1>
-  # CHECK: #msft.physloc<M20K, 1, 1, 0>
-  # CHECK: #msft.physloc<M20K, 1, 1, 1>
-  # CHECK: #msft.physloc<M20K, 1, 0, 0>
-  # CHECK: #msft.physloc<M20K, 1, 0, 1>
+  # CHECK-LABEL: === Placements ASC, DESC:
+  # CHECK: #msft.physloc<M20K, 0, 1
+  # CHECK: #msft.physloc<M20K, 0, 1
+  # CHECK: #msft.physloc<M20K, 0, 0
+  # CHECK: #msft.physloc<M20K, 0, 0
+  # CHECK: #msft.physloc<M20K, 1, 1
+  # CHECK: #msft.physloc<M20K, 1, 1
+  # CHECK: #msft.physloc<M20K, 1, 0
+  # CHECK: #msft.physloc<M20K, 1, 0
 
-  print("=== Placements None, Asc, None:")
-  walk_order = msft.WalkOrder(rows=msft.Direction.DESC,
-                              nums=msft.Direction.NONE)
+  print("=== Placements None, Asc:")
+  walk_order = msft.WalkOrder(rows=msft.Direction.DESC)
   pdb.walk_placements(print_placement, walk_order=walk_order)
-  # CHECK-LABEL: === Placements None, Asc, None:
-  # CHECK: #msft.physloc<M20K, {{.+}}, 1, {{.+}}>
-  # CHECK: #msft.physloc<M20K, {{.+}}, 1, {{.+}}>
-  # CHECK: #msft.physloc<M20K, {{.+}}, 0, {{.+}}>
-  # CHECK: #msft.physloc<M20K, {{.+}}, 0, {{.+}}>
-  # CHECK: #msft.physloc<M20K, {{.+}}, 1, {{.+}}>
-  # CHECK: #msft.physloc<M20K, {{.+}}, 1, {{.+}}>
-  # CHECK: #msft.physloc<M20K, {{.+}}, 0, {{.+}}>
-  # CHECK: #msft.physloc<M20K, {{.+}}, 0, {{.+}}>
+  # CHECK-LABEL: === Placements None, Asc:
+  # CHECK: #msft.physloc<M20K, {{.+}}, 1
+  # CHECK: #msft.physloc<M20K, {{.+}}, 1
+  # CHECK: #msft.physloc<M20K, {{.+}}, 0
+  # CHECK: #msft.physloc<M20K, {{.+}}, 0
+  # CHECK: #msft.physloc<M20K, {{.+}}, 1
+  # CHECK: #msft.physloc<M20K, {{.+}}, 1
+  # CHECK: #msft.physloc<M20K, {{.+}}, 0
+  # CHECK: #msft.physloc<M20K, {{.+}}, 0
 
   print("=== Errors:", file=sys.stderr)
   # TODO: Python's sys.stderr doesn't seem to be shared with C++ errors.

--- a/integration_test/Bindings/Python/dialects/msft.py
+++ b/integration_test/Bindings/Python/dialects/msft.py
@@ -146,6 +146,81 @@ with ir.Context() as ctx, ir.Location.unknown():
   seeded_pdb.walk_placements(print_placement, bounds=(6, 6, None, None))
   # CHECK-LABEL: === Placements (col 6):
 
+  devdb = msft.PrimitiveDB()
+  devdb.add_primitive(msft.PhysLocationAttr.get(msft.M20K, x=0, y=0, num=0))
+  devdb.add_primitive(msft.PhysLocationAttr.get(msft.M20K, x=1, y=0, num=1))
+  devdb.add_primitive(msft.PhysLocationAttr.get(msft.M20K, x=0, y=1, num=0))
+  devdb.add_primitive(msft.PhysLocationAttr.get(msft.M20K, x=0, y=0, num=1))
+  devdb.add_primitive(msft.PhysLocationAttr.get(msft.M20K, x=1, y=0, num=0))
+  devdb.add_primitive(msft.PhysLocationAttr.get(msft.M20K, x=1, y=1, num=1))
+  devdb.add_primitive(msft.PhysLocationAttr.get(msft.M20K, x=0, y=1, num=1))
+  devdb.add_primitive(msft.PhysLocationAttr.get(msft.M20K, x=1, y=1, num=0))
+  pdb = msft.PlacementDB(top.operation, devdb)
+
+  print("=== Placements ASC, ASC, ASC:")
+  walk_order = {
+      "columns": msft.Direction.ASC,
+      "rows": msft.Direction.ASC,
+      "nums": msft.Direction.ASC
+  }
+  pdb.walk_placements(print_placement, walk_order=walk_order)
+  # CHECK-LABEL: === Placements ASC, ASC, ASC:
+  # CHECK: #msft.physloc<M20K, 0, 0, 0>
+  # CHECK: #msft.physloc<M20K, 0, 0, 1>
+  # CHECK: #msft.physloc<M20K, 0, 1, 0>
+  # CHECK: #msft.physloc<M20K, 0, 1, 1>
+  # CHECK: #msft.physloc<M20K, 1, 0, 0>
+  # CHECK: #msft.physloc<M20K, 1, 0, 1>
+  # CHECK: #msft.physloc<M20K, 1, 1, 0>
+  # CHECK: #msft.physloc<M20K, 1, 1, 1>
+
+  print("=== Placements DESC, DESC, DESC:")
+  walk_order = {
+      "columns": msft.Direction.DESC,
+      "rows": msft.Direction.DESC,
+      "nums": msft.Direction.DESC
+  }
+  pdb.walk_placements(print_placement, walk_order=walk_order)
+  # CHECK-LABEL: === Placements DESC, DESC, DESC:
+  # CHECK: #msft.physloc<M20K, 1, 1, 1>
+  # CHECK: #msft.physloc<M20K, 1, 1, 0>
+  # CHECK: #msft.physloc<M20K, 1, 0, 1>
+  # CHECK: #msft.physloc<M20K, 1, 0, 0>
+  # CHECK: #msft.physloc<M20K, 0, 1, 1>
+  # CHECK: #msft.physloc<M20K, 0, 1, 0>
+  # CHECK: #msft.physloc<M20K, 0, 0, 1>
+  # CHECK: #msft.physloc<M20K, 0, 0, 0>
+
+  print("=== Placements ASC, DESC, ASC:")
+  walk_order = {
+      "columns": msft.Direction.ASC,
+      "rows": msft.Direction.DESC,
+      "nums": msft.Direction.ASC
+  }
+  pdb.walk_placements(print_placement, walk_order=walk_order)
+  # CHECK-LABEL: === Placements ASC, DESC, ASC:
+  # CHECK: #msft.physloc<M20K, 0, 1, 0>
+  # CHECK: #msft.physloc<M20K, 0, 1, 1>
+  # CHECK: #msft.physloc<M20K, 0, 0, 0>
+  # CHECK: #msft.physloc<M20K, 0, 0, 1>
+  # CHECK: #msft.physloc<M20K, 1, 1, 0>
+  # CHECK: #msft.physloc<M20K, 1, 1, 1>
+  # CHECK: #msft.physloc<M20K, 1, 0, 0>
+  # CHECK: #msft.physloc<M20K, 1, 0, 1>
+
+  print("=== Placements None, Asc, None:")
+  walk_order = {"rows": msft.Direction.DESC, "nums": msft.Direction.NONE}
+  pdb.walk_placements(print_placement, walk_order=walk_order)
+  # CHECK-LABEL: === Placements None, Asc, None:
+  # CHECK: #msft.physloc<M20K, {{.+}}, 1, {{.+}}>
+  # CHECK: #msft.physloc<M20K, {{.+}}, 1, {{.+}}>
+  # CHECK: #msft.physloc<M20K, {{.+}}, 0, {{.+}}>
+  # CHECK: #msft.physloc<M20K, {{.+}}, 0, {{.+}}>
+  # CHECK: #msft.physloc<M20K, {{.+}}, 1, {{.+}}>
+  # CHECK: #msft.physloc<M20K, {{.+}}, 1, {{.+}}>
+  # CHECK: #msft.physloc<M20K, {{.+}}, 0, {{.+}}>
+  # CHECK: #msft.physloc<M20K, {{.+}}, 0, {{.+}}>
+
   print("=== Errors:", file=sys.stderr)
   # TODO: Python's sys.stderr doesn't seem to be shared with C++ errors.
   # See https://github.com/llvm/circt/issues/1983 for more info.

--- a/integration_test/Bindings/Python/dialects/msft.py
+++ b/integration_test/Bindings/Python/dialects/msft.py
@@ -158,11 +158,11 @@ with ir.Context() as ctx, ir.Location.unknown():
   pdb = msft.PlacementDB(top.operation, devdb)
 
   print("=== Placements ASC, ASC, ASC:")
-  walk_order = {
-      "columns": msft.Direction.ASC,
-      "rows": msft.Direction.ASC,
-      "nums": msft.Direction.ASC
-  }
+  walk_order = msft.WalkOrder(
+      columns=msft.Direction.ASC,
+      rows=msft.Direction.ASC,
+      nums=msft.Direction.ASC,
+  )
   pdb.walk_placements(print_placement, walk_order=walk_order)
   # CHECK-LABEL: === Placements ASC, ASC, ASC:
   # CHECK: #msft.physloc<M20K, 0, 0, 0>
@@ -175,11 +175,11 @@ with ir.Context() as ctx, ir.Location.unknown():
   # CHECK: #msft.physloc<M20K, 1, 1, 1>
 
   print("=== Placements DESC, DESC, DESC:")
-  walk_order = {
-      "columns": msft.Direction.DESC,
-      "rows": msft.Direction.DESC,
-      "nums": msft.Direction.DESC
-  }
+  walk_order = msft.WalkOrder(
+      columns=msft.Direction.DESC,
+      rows=msft.Direction.DESC,
+      nums=msft.Direction.DESC,
+  )
   pdb.walk_placements(print_placement, walk_order=walk_order)
   # CHECK-LABEL: === Placements DESC, DESC, DESC:
   # CHECK: #msft.physloc<M20K, 1, 1, 1>
@@ -192,11 +192,11 @@ with ir.Context() as ctx, ir.Location.unknown():
   # CHECK: #msft.physloc<M20K, 0, 0, 0>
 
   print("=== Placements ASC, DESC, ASC:")
-  walk_order = {
-      "columns": msft.Direction.ASC,
-      "rows": msft.Direction.DESC,
-      "nums": msft.Direction.ASC
-  }
+  walk_order = msft.WalkOrder(
+      columns=msft.Direction.ASC,
+      rows=msft.Direction.DESC,
+      nums=msft.Direction.ASC,
+  )
   pdb.walk_placements(print_placement, walk_order=walk_order)
   # CHECK-LABEL: === Placements ASC, DESC, ASC:
   # CHECK: #msft.physloc<M20K, 0, 1, 0>
@@ -209,7 +209,8 @@ with ir.Context() as ctx, ir.Location.unknown():
   # CHECK: #msft.physloc<M20K, 1, 0, 1>
 
   print("=== Placements None, Asc, None:")
-  walk_order = {"rows": msft.Direction.DESC, "nums": msft.Direction.NONE}
+  walk_order = msft.WalkOrder(rows=msft.Direction.DESC,
+                              nums=msft.Direction.NONE)
   pdb.walk_placements(print_placement, walk_order=walk_order)
   # CHECK-LABEL: === Placements None, Asc, None:
   # CHECK: #msft.physloc<M20K, {{.+}}, 1, {{.+}}>

--- a/lib/Bindings/Python/MSFTModule.cpp
+++ b/lib/Bindings/Python/MSFTModule.cpp
@@ -99,9 +99,8 @@ public:
     if (!walkOrder.is_none())
       cWalkOrder = walkOrder.cast<CirctMSFTWalkOrder>();
     else
-      cWalkOrder =
-          CirctMSFTWalkOrder{CirctMSFTDirection::NONE, CirctMSFTDirection::NONE,
-                             CirctMSFTDirection::NONE};
+      cWalkOrder = CirctMSFTWalkOrder{CirctMSFTDirection::NONE,
+                                      CirctMSFTDirection::NONE};
 
     circtMSFTPlacementDBWalkPlacements(
         db,
@@ -233,9 +232,7 @@ void circt::python::populateDialectMSFTSubmodule(py::module &m) {
            py::arg("walk_order") = py::none());
 
   py::class_<CirctMSFTWalkOrder>(m, "WalkOrder")
-      .def(py::init<CirctMSFTDirection, CirctMSFTDirection,
-                    CirctMSFTDirection>(),
+      .def(py::init<CirctMSFTDirection, CirctMSFTDirection>(),
            py::arg("columns") = CirctMSFTDirection::NONE,
-           py::arg("rows") = CirctMSFTDirection::NONE,
-           py::arg("nums") = CirctMSFTDirection::NONE);
+           py::arg("rows") = CirctMSFTDirection::NONE);
 }

--- a/lib/Bindings/Python/MSFTModule.cpp
+++ b/lib/Bindings/Python/MSFTModule.cpp
@@ -95,18 +95,13 @@ public:
     else
       cPrim = prim.cast<CirctMSFTPrimitiveType>();
 
-    CirctMSFTWalkOrder cWalkOrder{CirctMSFTDirection::NONE,
-                                  CirctMSFTDirection::NONE,
-                                  CirctMSFTDirection::NONE};
-    if (!walkOrder.is_none()) {
-      py::dict pyWalkOrder = walkOrder.cast<py::dict>();
-      if (pyWalkOrder.contains("columns"))
-        cWalkOrder.columns = pyWalkOrder["columns"].cast<CirctMSFTDirection>();
-      if (pyWalkOrder.contains("rows"))
-        cWalkOrder.rows = pyWalkOrder["rows"].cast<CirctMSFTDirection>();
-      if (pyWalkOrder.contains("nums"))
-        cWalkOrder.nums = pyWalkOrder["nums"].cast<CirctMSFTDirection>();
-    }
+    CirctMSFTWalkOrder cWalkOrder;
+    if (!walkOrder.is_none())
+      cWalkOrder = walkOrder.cast<CirctMSFTWalkOrder>();
+    else
+      cWalkOrder =
+          CirctMSFTWalkOrder{CirctMSFTDirection::NONE, CirctMSFTDirection::NONE,
+                             CirctMSFTDirection::NONE};
 
     circtMSFTPlacementDBWalkPlacements(
         db,
@@ -236,4 +231,11 @@ void circt::python::populateDialectMSFTSubmodule(py::module &m) {
                std::make_tuple(py::none(), py::none(), py::none(), py::none()),
            py::arg("prim_type") = py::none(),
            py::arg("walk_order") = py::none());
+
+  py::class_<CirctMSFTWalkOrder>(m, "WalkOrder")
+      .def(py::init<CirctMSFTDirection, CirctMSFTDirection,
+                    CirctMSFTDirection>(),
+           py::arg("columns") = CirctMSFTDirection::NONE,
+           py::arg("rows") = CirctMSFTDirection::NONE,
+           py::arg("nums") = CirctMSFTDirection::NONE);
 }

--- a/lib/CAPI/Dialect/MSFT.cpp
+++ b/lib/CAPI/Dialect/MSFT.cpp
@@ -109,6 +109,7 @@ void circtMSFTPlacementDBWalkPlacements(CirctMSFTPlacementDB cdb,
                                         CirctMSFTPlacementCallback ccb,
                                         int64_t bounds[4],
                                         CirctMSFTPrimitiveType cPrimTypeFilter,
+                                        CirctMSFTWalkOrder cWalkOrder,
                                         void *userData) {
   PlacementDB *db = unwrap(cdb);
   auto cb = [ccb, userData](PhysLocationAttr loc,
@@ -120,9 +121,19 @@ void circtMSFTPlacementDBWalkPlacements(CirctMSFTPlacementDB cdb,
   Optional<PrimitiveType> primTypeFilter;
   if (cPrimTypeFilter >= 0)
     primTypeFilter = static_cast<PrimitiveType>(cPrimTypeFilter);
+
+  Optional<PlacementDB::WalkOrder> walkOrder;
+  if (cWalkOrder.columns != CirctMSFTDirection::NONE ||
+      cWalkOrder.rows != CirctMSFTDirection::NONE ||
+      cWalkOrder.nums != CirctMSFTDirection::NONE)
+    walkOrder = PlacementDB::WalkOrder{
+        static_cast<PlacementDB::Direction>(cWalkOrder.columns),
+        static_cast<PlacementDB::Direction>(cWalkOrder.rows),
+        static_cast<PlacementDB::Direction>(cWalkOrder.nums)};
+
   db->walkPlacements(
       cb, std::make_tuple(bounds[0], bounds[1], bounds[2], bounds[3]),
-      primTypeFilter);
+      primTypeFilter, walkOrder);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/CAPI/Dialect/MSFT.cpp
+++ b/lib/CAPI/Dialect/MSFT.cpp
@@ -124,12 +124,10 @@ void circtMSFTPlacementDBWalkPlacements(CirctMSFTPlacementDB cdb,
 
   Optional<PlacementDB::WalkOrder> walkOrder;
   if (cWalkOrder.columns != CirctMSFTDirection::NONE ||
-      cWalkOrder.rows != CirctMSFTDirection::NONE ||
-      cWalkOrder.nums != CirctMSFTDirection::NONE)
+      cWalkOrder.rows != CirctMSFTDirection::NONE)
     walkOrder = PlacementDB::WalkOrder{
         static_cast<PlacementDB::Direction>(cWalkOrder.columns),
-        static_cast<PlacementDB::Direction>(cWalkOrder.rows),
-        static_cast<PlacementDB::Direction>(cWalkOrder.nums)};
+        static_cast<PlacementDB::Direction>(cWalkOrder.rows)};
 
   db->walkPlacements(
       cb, std::make_tuple(bounds[0], bounds[1], bounds[2], bounds[3]),

--- a/lib/Dialect/MSFT/DeviceDB.cpp
+++ b/lib/Dialect/MSFT/DeviceDB.cpp
@@ -262,12 +262,10 @@ void PlacementDB::walkPlacements(
       DimNumMap numMap = rowF.second;
 
       // Num loop.
-      SmallVector<std::pair<size_t, DimDevType>> nums(numMap.begin(),
-                                                      numMap.end());
-      maybeSort(nums, walkOrder.map([](auto wo) { return wo.nums; }));
-      for (auto numF : nums) {
-        size_t num = numF.first;
-        DimDevType devMap = numF.second;
+      for (auto numF = numMap.begin(), numE = numMap.end(); numF != numE;
+           ++numF) {
+        size_t num = numF->getFirst();
+        DimDevType devMap = numF->getSecond();
 
         // DevType loop.
         for (auto devF = devMap.begin(), devE = devMap.end(); devF != devE;

--- a/lib/Dialect/MSFT/DeviceDB.cpp
+++ b/lib/Dialect/MSFT/DeviceDB.cpp
@@ -215,7 +215,7 @@ PlacementDB::getLeaf(PhysLocationAttr loc) {
 void PlacementDB::walkPlacements(
     function_ref<void(PhysLocationAttr, PlacedInstance)> callback,
     std::tuple<int64_t, int64_t, int64_t, int64_t> bounds,
-    Optional<PrimitiveType> primType) {
+    Optional<PrimitiveType> primType, Optional<WalkOrder> walkOrder) {
   uint64_t xmin = std::get<0>(bounds) < 0 ? 0 : std::get<0>(bounds);
   uint64_t xmax = std::get<1>(bounds) < 0 ? std::numeric_limits<uint64_t>::max()
                                           : (uint64_t)std::get<1>(bounds);
@@ -224,29 +224,50 @@ void PlacementDB::walkPlacements(
                                           : (uint64_t)std::get<3>(bounds);
 
   // TODO: Since the data structures we're using aren't sorted, the best we can
-  // do is iterate and filter. Once we get to performance, we'll figure out the
+  // do is iterate and filter. If a specific order is requested, we sort the
+  // keys by that as we go. Once we get to performance, we'll figure out the
   // right data structure.
 
+  auto maybeSort = [](auto &container, auto direction) {
+    if (!direction.hasValue())
+      return;
+    if (*direction == Direction::NONE)
+      return;
+
+    llvm::sort(container, [direction](auto colA, auto colB) {
+      if (*direction == Direction::ASC)
+        return colA.first < colB.first;
+
+      return colA.first > colB.first;
+    });
+  };
+
   // X loop.
-  for (auto colF = placements.begin(), colE = placements.end(); colF != colE;
-       ++colF) {
-    size_t x = colF->getFirst();
+  SmallVector<std::pair<size_t, DimYMap>> cols(placements.begin(),
+                                               placements.end());
+  maybeSort(cols, walkOrder.map([](auto wo) { return wo.columns; }));
+  for (auto colF : cols) {
+    size_t x = colF.first;
     if (x < xmin || x > xmax)
       continue;
-    DimYMap yMap = colF->getSecond();
+    DimYMap yMap = colF.second;
 
     // Y loop.
-    for (auto rowF = yMap.begin(), rowE = yMap.end(); rowF != rowE; ++rowF) {
-      size_t y = rowF->getFirst();
+    SmallVector<std::pair<size_t, DimNumMap>> rows(yMap.begin(), yMap.end());
+    maybeSort(rows, walkOrder.map([](auto wo) { return wo.rows; }));
+    for (auto rowF : rows) {
+      size_t y = rowF.first;
       if (y < ymin || y > ymax)
         continue;
-      DimNumMap numMap = rowF->getSecond();
+      DimNumMap numMap = rowF.second;
 
       // Num loop.
-      for (auto numF = numMap.begin(), numE = numMap.end(); numF != numE;
-           ++numF) {
-        size_t num = numF->getFirst();
-        DimDevType devMap = numF->getSecond();
+      SmallVector<std::pair<size_t, DimDevType>> nums(numMap.begin(),
+                                                      numMap.end());
+      maybeSort(nums, walkOrder.map([](auto wo) { return wo.nums; }));
+      for (auto numF : nums) {
+        size_t num = numF.first;
+        DimDevType devMap = numF.second;
 
         // DevType loop.
         for (auto devF = devMap.begin(), devE = devMap.end(); devF != devE;


### PR DESCRIPTION
This allows the user to specify a walk order through the placements'
columns, rows, and numbers at each location. If specified, the order
is used to sort the indices into the placements' maps. Otherwise, the
order is undefined as before.