### PR TITLE
[PyCDE] Support reserving placements with EntityExternOp.

### DIFF
--- a/frontends/PyCDE/src/pycde/devicedb.py
+++ b/frontends/PyCDE/src/pycde/devicedb.py
@@ -120,8 +120,16 @@ class PlacementDB:
     # TODO: resolve instance and return it.
     return inst
 
-  def reserve_location(self, loc: PhysLocation, entity: msft.EntityExternOp):
-    ref = FlatSymbolRefAttr.get(entity.sym_name.value)
+  def reserve_location(self, loc: PhysLocation, entity: EntityExtern):
+    sym_name = entity._entity_extern.sym_name.value
+    ref = FlatSymbolRefAttr.get(sym_name)
     path = ArrayAttr.get([ref])
     subpath = ""
-    self._db.add_placement(loc._loc, path, subpath, entity)
+    self._db.add_placement(loc._loc, path, subpath, entity._entity_extern)
+
+
+class EntityExtern:
+  __slots__ = ["_entity_extern"]
+
+  def __init__(self, tag: str, metadata: typing.Any = ""):
+    self._entity_extern = msft.EntityExternOp.create(tag, metadata)

--- a/frontends/PyCDE/src/pycde/devicedb.py
+++ b/frontends/PyCDE/src/pycde/devicedb.py
@@ -7,7 +7,7 @@ import typing
 
 from circt.dialects import msft
 
-from mlir.ir import StringAttr, ArrayAttr
+from mlir.ir import StringAttr, ArrayAttr, FlatSymbolRefAttr
 
 PrimitiveType = msft.PrimitiveType
 
@@ -119,3 +119,9 @@ class PlacementDB:
       return None
     # TODO: resolve instance and return it.
     return inst
+
+  def reserve_location(self, loc: PhysLocation, entity: msft.EntityExternOp):
+    ref = FlatSymbolRefAttr.get(entity.sym_name.value)
+    path = ArrayAttr.get([ref])
+    subpath = ""
+    self._db.add_placement(loc._loc, path, subpath, entity)

--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -2,7 +2,7 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from pycde.devicedb import PrimitiveDB, PhysicalRegion
+from pycde.devicedb import EntityExtern, PrimitiveDB, PhysicalRegion
 
 from .module import _SpecializedModule
 from .pycde_types import types
@@ -103,7 +103,7 @@ class System:
 
   def create_entity_extern(self, tag: str, metadata=""):
     with self._get_ip():
-      entity_extern = circt.dialects.msft.EntityExternOp.create(tag, metadata)
+      entity_extern = EntityExtern(tag, metadata)
     return entity_extern
 
   def _create_circt_mod(self, spec_mod: _SpecializedModule, create_cb):

--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -101,6 +101,11 @@ class System:
       physical_region = PhysicalRegion(name)
     return physical_region
 
+  def create_entity_extern(self, tag: str, metadata=""):
+    with self._get_ip():
+      entity_extern = circt.dialects.msft.EntityExternOp.create(tag, metadata)
+    return entity_extern
+
   def _create_circt_mod(self, spec_mod: _SpecializedModule, create_cb):
     """Wrapper for a callback (which actually builds the CIRCT op) which
     controls all the bookkeeping around CIRCT module ops."""

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -218,3 +218,13 @@ def PhysicalRegionOp : MSFTOp<"physical_region",
     $sym_name `,` $bounds attr-dict
   }];
 }
+
+def EntityExternOp : MSFTOp<"entity.extern",
+    [Symbol, HasParent<"mlir::ModuleOp">]> {
+  let arguments = (ins
+    SymbolNameAttr:$sym_name,
+    AnyAttr:$metadata);
+  let assemblyFormat = [{
+    $sym_name $metadata attr-dict
+  }];
+}

--- a/integration_test/Bindings/Python/dialects/msft.py
+++ b/integration_test/Bindings/Python/dialects/msft.py
@@ -20,6 +20,8 @@ with ir.Context() as ctx, ir.Location.unknown():
                                      input_ports=[],
                                      output_ports=[])
 
+    entity_extern = msft.EntityExternOp.create("tag", "extra details")
+
     op = msft.MSFTModuleOp(name='MyWidget', input_ports=[], output_ports=[])
     with ir.InsertionPoint(op.add_entry_block()):
       msft.OutputOp([])
@@ -91,10 +93,12 @@ with ir.Context() as ctx, ir.Location.unknown():
   assert not place_rc
   # ERR: error: 'msft.instance' op Could not apply placement #msft.physloc<M20K, 2, 6, 1, "foo_subpath">. Position already occupied by msft.instance @ext1 @MyExternMod
 
+  physAttr2 = msft.PhysLocationAttr.get(msft.M20K, x=40, y=40, num=1)
   devdb = msft.PrimitiveDB()
   assert not devdb.is_valid_location(physAttr)
   devdb.add_primitive(physAttr)
   devdb.add_primitive(msft.PhysLocationAttr.get(msft.M20K, x=2, y=50, num=1))
+  devdb.add_primitive(physAttr2)
   assert devdb.is_valid_location(physAttr)
 
   seeded_pdb = msft.PlacementDB(top.operation, devdb)
@@ -106,9 +110,15 @@ with ir.Context() as ctx, ir.Location.unknown():
 
   rc = seeded_pdb.add_placement(physAttr, path, "foo_subpath", resolved_inst)
   assert rc
+  external_path = ir.ArrayAttr.get(
+      [ir.FlatSymbolRefAttr.get(entity_extern.sym_name.value)])
+  rc = seeded_pdb.add_placement(physAttr2, external_path, "", entity_extern)
+  assert rc
   with ir.InsertionPoint(m.body):
     global_ref = hw.GlobalRefOp(ir.StringAttr.get("foo"), path)
     global_ref.attributes["loc:foo_subpath"] = physAttr
+    global_ref = hw.GlobalRefOp(ir.StringAttr.get("bar"), external_path)
+    global_ref.attributes["loc"] = physAttr2
 
   nearest = seeded_pdb.get_nearest_free_in_column(msft.M20K, 2, 4)
   assert isinstance(nearest, msft.PhysLocationAttr)
@@ -128,6 +138,7 @@ with ir.Context() as ctx, ir.Location.unknown():
   print("=== Placements:")
   seeded_pdb.walk_placements(print_placement)
   # CHECK-LABEL: === Placements:
+  # CHECK: #msft.physloc<M20K, 40, 40, 1>, [@tag]
   # CHECK: #msft.physloc<M20K, 2, 6, 1, "foo_subpath">, [#hw.innerNameRef<@top::@inst1>, #hw.innerNameRef<@MyWidget::@ext1>]
   # CHECK: #msft.physloc<M20K, 2, 50, 1>
 

--- a/lib/Bindings/Python/circt/dialects/_msft_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_msft_ops_ext.py
@@ -137,3 +137,12 @@ class PhysicalRegionOp:
     existing_bounds.append(bounds)
     new_bounds = _ir.ArrayAttr.get(existing_bounds)
     self.attributes["bounds"] = new_bounds
+
+
+class EntityExternOp:
+
+  @staticmethod
+  def create(symbol, metadata=""):
+    symbol_attr = support.var_to_attribute(symbol)
+    metadata_attr = support.var_to_attribute(metadata)
+    return _msft.EntityExternOp(symbol_attr, metadata_attr)

--- a/lib/Dialect/MSFT/DeviceDB.cpp
+++ b/lib/Dialect/MSFT/DeviceDB.cpp
@@ -120,8 +120,8 @@ size_t PlacementDB::addPlacements(FlatSymbolRefAttr rootMod,
   ArrayAttr instPath = globalRef.namepath();
 
   // Filter out all paths which aren't related to this DB.
-  auto rootInnerRef = instPath.getValue()[0].cast<hw::InnerRefAttr>();
-  if (rootInnerRef.getModule().getValue() != rootMod.getValue())
+  auto rootInnerRef = instPath.getValue()[0].dyn_cast<hw::InnerRefAttr>();
+  if (rootInnerRef && rootInnerRef.getModule().getValue() != rootMod.getValue())
     return 0;
 
   size_t numFailed = 0;

--- a/lib/Dialect/MSFT/MSFTPasses.cpp
+++ b/lib/Dialect/MSFT/MSFTPasses.cpp
@@ -241,6 +241,7 @@ void LowerToHWPass::runOnOperation() {
   patterns.insert<ModuleExternOpLowering>(ctxt, verilogFile);
   patterns.insert<OutputOpLowering>(ctxt);
   patterns.insert<RemoveOpLowering<hw::GlobalRefOp>>(ctxt);
+  patterns.insert<RemoveOpLowering<EntityExternOp>>(ctxt);
 
   if (failed(applyPartialConversion(top, target, std::move(patterns))))
     signalPassFailure();

--- a/test/Dialect/MSFT/location.mlir
+++ b/test/Dialect/MSFT/location.mlir
@@ -20,6 +20,12 @@ hw.globalRef @ref4 [#hw.innerNameRef<@reg::@reg>] {
 
 hw.module.extern @Foo()
 
+// CHECK: msft.entity.extern @entity1 "some tag"
+msft.entity.extern @entity1 "some tag"
+
+// CHECK: msft.entity.extern @entity2 {name = "foo", number = 1 : i64}
+msft.entity.extern @entity2 {name = "foo", number = 1 : i64}
+
 // CHECK-LABEL: msft.module @leaf
 // LOWER-LABEL: hw.module @leaf
 msft.module @leaf {} () -> () {


### PR DESCRIPTION
This adds a new API to the PyCDE PlacementDB to reserve a placement by
adding an EntityExternOp with an appropriate path. This exists out of
band of the existing AppID mechanism to place internal entities.