### PR TITLE
[MSFT] Merge input and output ports which are driven by the same signal

### DIFF
--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -206,6 +206,10 @@ SmallVector<unsigned> MSFTModuleOp::removePorts(llvm::BitVector inputs,
 
   // Erase the arguments after setting the new output op operands since the
   // arguments might be used by output op.
+  for (unsigned argNum = 0, e = body->getArguments().size(); argNum < e;
+       ++argNum)
+    if (inputs.test(argNum))
+      body->getArgument(argNum).dropAllUses();
   body->eraseArguments(inputs);
 
   return newToOldResultMap;

--- a/lib/Dialect/MSFT/MSFTPasses.cpp
+++ b/lib/Dialect/MSFT/MSFTPasses.cpp
@@ -1043,6 +1043,8 @@ void WireCleanupPass::dedupInputs(MSFTModuleOp mod) {
     return;
   InstanceOp inst = instantiations[0];
 
+  // Find all the arguments which are driven by the same signal. Remap them
+  // appropriately within the module, and mark that input port for deletion.
   Block *body = mod.getBodyBlock();
   DenseMap<Value, unsigned> valueToInput;
   llvm::BitVector argsToErase(body->getNumArguments());
@@ -1065,7 +1067,6 @@ void WireCleanupPass::dedupInputs(MSFTModuleOp mod) {
   // and update the instantiations.
   auto getOperands = [&](InstanceOp newInst, InstanceOp oldInst,
                          SmallVectorImpl<Value> &newOperands) {
-    // Use sort-merge-join to compute the new operands;
     for (unsigned argNum = 0, e = oldInst.getNumOperands(); argNum < e;
          ++argNum)
       if (!argsToErase.test(argNum))

--- a/lib/Dialect/MSFT/MSFTPasses.cpp
+++ b/lib/Dialect/MSFT/MSFTPasses.cpp
@@ -1047,16 +1047,16 @@ void WireCleanupPass::dedupInputs(MSFTModuleOp mod) {
   DenseMap<Value, unsigned> valueToInput;
   llvm::BitVector argsToErase(body->getNumArguments());
   for (OpOperand &oper : inst->getOpOperands()) {
-    // auto existingValue = valueToInput.find(oper.get());
-    // if (existingValue != valueToInput.end()) {
-    //   unsigned operNum = oper.getOperandNumber();
-    //   unsigned duplicateInputNum = existingValue->second;
-    //   body->getArgument(operNum).replaceAllUsesWith(
-    //       body->getArgument(duplicateInputNum));
-    //   argsToErase.set(operNum);
-    // } else {
-    //   valueToInput[oper.get()] = valueToInput.size();
-    // }
+    auto existingValue = valueToInput.find(oper.get());
+    if (existingValue != valueToInput.end()) {
+      unsigned operNum = oper.getOperandNumber();
+      unsigned duplicateInputNum = existingValue->second;
+      body->getArgument(operNum).replaceAllUsesWith(
+          body->getArgument(duplicateInputNum));
+      argsToErase.set(operNum);
+    } else {
+      valueToInput[oper.get()] = oper.getOperandNumber();
+    }
   }
 
   // Remove the ports.

--- a/lib/Dialect/MSFT/MSFTPasses.cpp
+++ b/lib/Dialect/MSFT/MSFTPasses.cpp
@@ -909,7 +909,9 @@ struct WireCleanupPass : public WireCleanupBase<WireCleanupPass>, PassCommon {
 
 private:
   void bubbleWiresUp(MSFTModuleOp mod);
+  void dedupOutputs(MSFTModuleOp mod);
   void sinkWiresDown(MSFTModuleOp mod);
+  void dedupInputs(MSFTModuleOp mod);
 };
 } // anonymous namespace
 
@@ -924,11 +926,47 @@ void WireCleanupPass::runOnOperation() {
   SmallVector<MSFTModuleOp> sortedMods;
   getAndSortModules(topMod, sortedMods);
 
-  for (auto mod : sortedMods)
+  for (auto mod : sortedMods) {
     bubbleWiresUp(mod);
+    dedupOutputs(mod);
+  }
 
-  for (auto mod : llvm::reverse(sortedMods))
+  for (auto mod : llvm::reverse(sortedMods)) {
     sinkWiresDown(mod);
+    dedupInputs(mod);
+  }
+}
+
+/// Remove outputs driven by the same value.
+void WireCleanupPass::dedupOutputs(MSFTModuleOp mod) {
+  Block *body = mod.getBodyBlock();
+  Operation *terminator = body->getTerminator();
+
+  DenseMap<Value, unsigned> valueToOutputIdx;
+  SmallVector<unsigned> outputMap;
+  llvm::BitVector outputPortsToRemove(terminator->getNumOperands());
+  for (OpOperand &outputVal : terminator->getOpOperands()) {
+    auto existing = valueToOutputIdx.find(outputVal.get());
+    if (existing != valueToOutputIdx.end()) {
+      outputMap.push_back(existing->second);
+      outputPortsToRemove.set(outputVal.getOperandNumber());
+    } else {
+      outputMap.push_back(valueToOutputIdx.size());
+      valueToOutputIdx[outputVal.get()] = valueToOutputIdx.size();
+    }
+  }
+
+  mod.removePorts(llvm::BitVector(mod.getNumArguments()), outputPortsToRemove);
+  updateInstances(mod, {},
+                  [&](InstanceOp newInst, InstanceOp oldInst,
+                      SmallVectorImpl<Value> &newOperands) {
+                    // Operands don't change.
+                    llvm::append_range(newOperands, oldInst.getOperands());
+                    // The results have to be remapped.
+                    for (OpResult res : oldInst.getResults())
+                      res.replaceAllUsesWith(
+                          newInst.getResult(outputMap[res.getResultNumber()]));
+                  });
 }
 
 /// Push up any wires which are simply passed-through.
@@ -997,6 +1035,45 @@ void WireCleanupPass::bubbleWiresUp(MSFTModuleOp mod) {
   updateInstances(mod, newToOldResult, setPassthroughsGetOperands);
 }
 
+void WireCleanupPass::dedupInputs(MSFTModuleOp mod) {
+  auto instantiations = moduleInstantiations[mod];
+  // TODO: remove this limitation. This would involve looking at the common
+  // loopbacks for all the instances.
+  if (instantiations.size() != 1)
+    return;
+  InstanceOp inst = instantiations[0];
+
+  Block *body = mod.getBodyBlock();
+  DenseMap<Value, unsigned> valueToInput;
+  llvm::BitVector argsToErase(body->getNumArguments());
+  for (OpOperand &oper : inst->getOpOperands()) {
+    // auto existingValue = valueToInput.find(oper.get());
+    // if (existingValue != valueToInput.end()) {
+    //   unsigned operNum = oper.getOperandNumber();
+    //   unsigned duplicateInputNum = existingValue->second;
+    //   body->getArgument(operNum).replaceAllUsesWith(
+    //       body->getArgument(duplicateInputNum));
+    //   argsToErase.set(operNum);
+    // } else {
+    //   valueToInput[oper.get()] = valueToInput.size();
+    // }
+  }
+
+  // Remove the ports.
+  auto remappedResults =
+      mod.removePorts(argsToErase, llvm::BitVector(inst.getNumResults()));
+  // and update the instantiations.
+  auto getOperands = [&](InstanceOp newInst, InstanceOp oldInst,
+                         SmallVectorImpl<Value> &newOperands) {
+    // Use sort-merge-join to compute the new operands;
+    for (unsigned argNum = 0, e = oldInst.getNumOperands(); argNum < e;
+         ++argNum)
+      if (!argsToErase.test(argNum))
+        newOperands.push_back(oldInst.getOperand(argNum));
+  };
+  updateInstances(mod, remappedResults, getOperands);
+}
+
 /// Sink all the instance connections which are loops.
 void WireCleanupPass::sinkWiresDown(MSFTModuleOp mod) {
   auto instantiations = moduleInstantiations[mod];
@@ -1033,21 +1110,6 @@ void WireCleanupPass::sinkWiresDown(MSFTModuleOp mod) {
     body->getArgument(resOper.first)
         .replaceAllUsesWith(terminator->getOperand(resOper.second));
     argsToErase.set(resOper.first);
-  }
-
-  // De-duplicate input signals.
-  DenseMap<Value, unsigned> valueToInput;
-  for (OpOperand &oper : inst->getOpOperands()) {
-    auto existingValue = valueToInput.find(oper.get());
-    if (existingValue != valueToInput.end()) {
-      unsigned operNum = oper.getOperandNumber();
-      unsigned duplicateInputNum = existingValue->second;
-      body->getArgument(operNum).replaceAllUsesWith(
-          body->getArgument(duplicateInputNum));
-      argsToErase.set(operNum);
-    } else {
-      valueToInput[oper.get()] = valueToInput.size();
-    }
   }
 
   // Remove the ports.

--- a/test/Dialect/MSFT/partition.mlir
+++ b/test/Dialect/MSFT/partition.mlir
@@ -99,7 +99,7 @@ msft.module @Array {} (%arr_in: !hw.array<4xi5>) -> (arr_out: !hw.array<4xi5>) {
 // CLEANUP:          msft.output
 
 // CLEANUP-LABEL:  msft.module @TopComplex {} (%arr_in: !hw.array<4xi5>) -> (out2: i5)
-// CLEANUP:          %part2.comb.add = msft.instance @part2 @dp_complex(%arr_in, %arr_in, %arr_in, %arr_in) {{.*}} : (!hw.array<4xi5>, !hw.array<4xi5>, !hw.array<4xi5>, !hw.array<4xi5>) -> i5
+// CLEANUP:          %part2.comb.add = msft.instance @part2 @dp_complex(%arr_in) {{.*}} : (!hw.array<4xi5>) -> i5
 // CLEANUP:          msft.instance @b @Array()  : () -> ()
 // CLEANUP:          msft.output %part2.comb.add : i5
 // CLEANUP-LABEL:  msft.module.extern @ExternI5(%foo_a: i5) -> (foo_x: i5)
@@ -117,27 +117,27 @@ msft.module @Array {} (%arr_in: !hw.array<4xi5>) -> (arr_out: !hw.array<4xi5>) {
 // CLEANUP:          %unit1.foo_x = msft.instance @unit1 @Extern(%c0_i2)  : (i2) -> i2
 // CLEANUP:          msft.output %b.unit2.foo_x, %unit1.foo_x : i2, i2
 
-// CLEANUP-LABEL:  msft.module @dp_complex {} (%hw.array_get.in0: !hw.array<4xi5>, %hw.array_get.in0_0: !hw.array<4xi5>, %hw.array_get.in0_1: !hw.array<4xi5>, %hw.array_get.in0_2: !hw.array<4xi5>) -> (comb.add: i5) attributes {argNames = ["hw.array_get.in0", "hw.array_get.in0", "hw.array_get.in0", "hw.array_get.in0"]} {
+// CLEANUP-LABEL:  msft.module @dp_complex {} (%hw.array_get.in0: !hw.array<4xi5>) -> (comb.add: i5) {
 // CLEANUP:          %c0_i2 = hw.constant 0 : i2
 // CLEANUP:          %0 = hw.array_get %hw.array_get.in0[%c0_i2] : !hw.array<4xi5>
-// CLEANUP:          %b.unit2.foo_x = msft.instance @b.unit2 @ExternI5(%0)  : (i5) -> i5
+// CLEANUP:          [[A0:%.+]] = msft.instance @b.unit2 @ExternI5(%0)  : (i5) -> i5
 // CLEANUP:          %c1_i2 = hw.constant 1 : i2
-// CLEANUP:          %1 = hw.array_get %hw.array_get.in0_0[%c1_i2] : !hw.array<4xi5>
-// CLEANUP:          %b.unit2.foo_x_3 = msft.instance @b.unit2 @ExternI5(%1)  : (i5) -> i5
+// CLEANUP:          %1 = hw.array_get %hw.array_get.in0[%c1_i2] : !hw.array<4xi5>
+// CLEANUP:          [[A1:%.+]] = msft.instance @b.unit2 @ExternI5(%1)  : (i5) -> i5
 // CLEANUP:          %c-2_i2 = hw.constant -2 : i2
-// CLEANUP:          %2 = hw.array_get %hw.array_get.in0_1[%c-2_i2] : !hw.array<4xi5>
-// CLEANUP:          %b.unit2.foo_x_4 = msft.instance @b.unit2 @ExternI5(%2)  : (i5) -> i5
+// CLEANUP:          %2 = hw.array_get %hw.array_get.in0[%c-2_i2] : !hw.array<4xi5>
+// CLEANUP:          [[A2:%.+]] = msft.instance @b.unit2 @ExternI5(%2)  : (i5) -> i5
 // CLEANUP:          %c-1_i2 = hw.constant -1 : i2
-// CLEANUP:          %3 = hw.array_get %hw.array_get.in0_2[%c-1_i2] : !hw.array<4xi5>
-// CLEANUP:          %b.unit2.foo_x_5 = msft.instance @b.unit2 @ExternI5(%3)  : (i5) -> i5
-// CLEANUP:          %4 = hw.array_create %b.unit2.foo_x, %b.unit2.foo_x_3, %b.unit2.foo_x_4, %b.unit2.foo_x_5 : i5
-// CLEANUP:          %c0_i2_6 = hw.constant 0 : i2
-// CLEANUP:          %5 = hw.array_get %4[%c0_i2_6] : !hw.array<4xi5>
-// CLEANUP:          %c1_i2_7 = hw.constant 1 : i2
-// CLEANUP:          %6 = hw.array_get %4[%c1_i2_7] : !hw.array<4xi5>
-// CLEANUP:          %c-2_i2_8 = hw.constant -2 : i2
-// CLEANUP:          %7 = hw.array_get %4[%c-2_i2_8] : !hw.array<4xi5>
-// CLEANUP:          %c-1_i2_9 = hw.constant -1 : i2
-// CLEANUP:          %8 = hw.array_get %4[%c-1_i2_9] : !hw.array<4xi5>
+// CLEANUP:          %3 = hw.array_get %hw.array_get.in0[%c-1_i2] : !hw.array<4xi5>
+// CLEANUP:          [[A3:%.+]] = msft.instance @b.unit2 @ExternI5(%3)  : (i5) -> i5
+// CLEANUP:          %4 = hw.array_create [[A0]], [[A1]], [[A2]], [[A3]] : i5
+// CLEANUP:          %c0_i2_3 = hw.constant 0 : i2
+// CLEANUP:          %5 = hw.array_get %4[%c0_i2_3] : !hw.array<4xi5>
+// CLEANUP:          %c1_i2_4 = hw.constant 1 : i2
+// CLEANUP:          %6 = hw.array_get %4[%c1_i2_4] : !hw.array<4xi5>
+// CLEANUP:          %c-2_i2_5 = hw.constant -2 : i2
+// CLEANUP:          %7 = hw.array_get %4[%c-2_i2_5] : !hw.array<4xi5>
+// CLEANUP:          %c-1_i2_6 = hw.constant -1 : i2
+// CLEANUP:          %8 = hw.array_get %4[%c-1_i2_6] : !hw.array<4xi5>
 // CLEANUP:          %9 = comb.add %5, %6, %7, %8 : i5
 // CLEANUP:          msft.output %9 : i5


### PR DESCRIPTION
For module outputs, if multiple `msft.output` operands are the same, eliminate toe duplicates and update the instantiations. For input ports, if the single instantiation drives multiple input ports with the same value, merge them.

One more step towards #2365.