### PR TITLE
[FIRRTL][InstanceGraph] look up using StringAttr instead of StringRef

### DIFF
--- a/include/circt/Dialect/FIRRTL/InstanceGraph.h
+++ b/include/circt/Dialect/FIRRTL/InstanceGraph.h
@@ -157,6 +157,9 @@ public:
   /// or an FExtModuleOp.
   InstanceGraphNode *lookup(Operation *op);
 
+  /// Lookup an module by name.
+  InstanceGraphNode *lookup(StringAttr name);
+
   /// Lookup an InstanceGraphNode for a module. Operation must be an FModuleOp
   /// or an FExtModuleOp.
   InstanceGraphNode *operator[](Operation *op) { return lookup(op); }
@@ -189,16 +192,13 @@ public:
 private:
   /// Get the node corresponding to the module.  If the node has does not exist
   /// yet, it will be created.
-  InstanceGraphNode *getOrAddNode(StringRef name);
-
-  /// Lookup an module by name.
-  InstanceGraphNode *lookup(StringRef name);
+  InstanceGraphNode *getOrAddNode(StringAttr name);
 
   /// The storage for graph nodes, with deterministic iteration.
   NodeVec nodes;
 
   /// This maps each operation to its graph node.
-  llvm::StringMap<unsigned> nodeMap;
+  llvm::DenseMap<Attribute, unsigned> nodeMap;
 };
 
 /// An absolute instance path.


### PR DESCRIPTION
Using `StringAttr`s instead of `StringRef`s is a pointer comparison
instead of a string comparison.