### PR TITLE
[FIRRTL] add `BundleType::begin()` and `end()`

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -295,7 +295,7 @@ public:
 
   static FIRRTLType get(ArrayRef<BundleElement> elements, MLIRContext *context);
 
-  ArrayRef<BundleElement> getElements();
+  ArrayRef<BundleElement> getElements() const;
 
   size_t getNumElements() { return getElements().size(); }
 
@@ -345,6 +345,10 @@ public:
   /// of the type.  Essentially maps a fieldID to a fieldID after a subfield op.
   /// Returns the new id and whether the id is in the given child.
   std::pair<unsigned, bool> rootChildFieldID(unsigned fieldID, unsigned index);
+
+  using iterator = ArrayRef<BundleElement>::iterator;
+  iterator begin() const { return getElements().begin(); }
+  iterator end() const { return getElements().end(); }
 };
 
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -72,7 +72,7 @@ static Type lowerType(Type type) {
 
   if (BundleType bundle = firType.dyn_cast<BundleType>()) {
     mlir::SmallVector<hw::StructType::FieldInfo, 8> hwfields;
-    for (auto element : bundle.getElements()) {
+    for (auto element : bundle) {
       Type etype = lowerType(element.type);
       if (!etype)
         return {};
@@ -1693,7 +1693,7 @@ Value FIRRTLLowering::getExtOrTruncAggregateValue(Value array,
           if (destStructType.getNumElements() != srcStructType.getNumElements())
             return failure();
 
-          for (auto elem : enumerate(destStructType.getElements())) {
+          for (auto elem : llvm::enumerate(destStructType)) {
             auto structExtract =
                 builder.create<hw::StructExtractOp>(src, elem.value().name);
             if (failed(recurse(structExtract,

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1660,8 +1660,7 @@ size_t MemOp::getMaskBits() {
       continue;
 
     FIRRTLType mType;
-    for (auto t :
-         firstPortType.getPassiveType().cast<BundleType>().getElements()) {
+    for (auto t : firstPortType.getPassiveType().cast<BundleType>()) {
       if (t.name.getValue().contains("mask"))
         mType = t.type;
     }

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -63,7 +63,7 @@ static LogicalResult customTypePrinter(Type type, AsmPrinter &os) {
       })
       .Case<BundleType>([&](auto bundleType) {
         os << "bundle<";
-        llvm::interleaveComma(bundleType.getElements(), os,
+        llvm::interleaveComma(bundleType, os,
                               [&](BundleType::BundleElement element) {
                                 os << element.name.getValue();
                                 if (element.isFlip)
@@ -366,7 +366,7 @@ FIRRTLType FIRRTLType::getMaskType() {
       .Case<BundleType>([&](BundleType bundleType) {
         SmallVector<BundleType::BundleElement, 4> newElements;
         newElements.reserve(bundleType.getElements().size());
-        for (auto elt : bundleType.getElements())
+        for (auto elt : bundleType)
           newElements.push_back(
               {elt.name, false /* FIXME */, elt.type.getMaskType()});
         return BundleType::get(newElements, this->getContext());
@@ -391,7 +391,7 @@ FIRRTLType FIRRTLType::getWidthlessType() {
       .Case<BundleType>([&](auto a) {
         SmallVector<BundleType::BundleElement, 4> newElements;
         newElements.reserve(a.getElements().size());
-        for (auto elt : a.getElements())
+        for (auto elt : a)
           newElements.push_back(
               {elt.name, elt.isFlip, elt.type.getWidthlessType()});
         return BundleType::get(newElements, this->getContext());
@@ -559,7 +559,7 @@ bool firrtl::areTypesWeaklyEquivalent(FIRRTLType destType, FIRRTLType srcType,
   auto srcBundleType = srcType.dyn_cast<BundleType>();
   if (destBundleType && srcBundleType)
     return llvm::all_of(
-        destBundleType.getElements(), [&](auto destElt) -> bool {
+        destBundleType, [&](auto destElt) -> bool {
           auto destField = destElt.name.getValue();
           auto srcElt = srcBundleType.getElement(destField);
           // If the src doesn't contain the destination's field, that's okay.
@@ -736,7 +736,7 @@ FIRRTLType BundleType::get(ArrayRef<BundleElement> elements,
   return Base::get(context, elements);
 }
 
-auto BundleType::getElements() -> ArrayRef<BundleElement> {
+auto BundleType::getElements() const -> ArrayRef<BundleElement> {
   return getImpl()->elements;
 }
 
@@ -966,7 +966,7 @@ llvm::Optional<int32_t> firrtl::getBitWidth(FIRRTLType type) {
     return TypeSwitch<FIRRTLType, llvm::Optional<int32_t>>(type)
         .Case<BundleType>([&](BundleType bundle) {
           int32_t width = 0;
-          for (auto &elt : bundle.getElements()) {
+          for (auto &elt : bundle) {
             if (elt.isFlip)
               return llvm::Optional<int32_t>(None);
             auto w = getBitWidth(elt.type);

--- a/lib/Dialect/FIRRTL/Transforms/BlackBoxMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackBoxMemory.cpp
@@ -105,7 +105,7 @@ static void getBlackBoxPortsForMemOp(MemOp op,
     // every field in the bundle to the exter module's port list.  All memory
     // ports have an outer flip, so we just strip this.
     auto type = op.getResult(i).getType();
-    for (auto bundleElement : type.cast<BundleType>().getElements()) {
+    for (auto bundleElement : type.cast<BundleType>()) {
       auto name = (prefix + bundleElement.name.getValue()).str();
       auto type = bundleElement.type;
       auto direction = Direction::In;
@@ -208,8 +208,7 @@ static FModuleOp createWrapperModule(MemOp op,
   auto extResultIt = instanceOp.result_begin();
   for (auto memPort : moduleOp.getArguments()) {
     auto memPortType = memPort.getType().cast<FIRRTLType>();
-    for (auto field :
-         llvm::enumerate(memPortType.cast<BundleType>().getElements())) {
+    for (auto field : llvm::enumerate(memPortType.cast<BundleType>())) {
       auto fieldValue =
           builder.create<SubfieldOp>(op.getLoc(), memPort, field.index());
       // Create the connection between module arguments and the external module,
@@ -243,8 +242,7 @@ static void createWiresForMemoryPorts(OpBuilder builder, Location loc, MemOp op,
 
     // Connect each wire to the corresponding ports in the external module
     auto wireBundle = memPort.getType().cast<FIRRTLType>();
-    for (auto field :
-         llvm::enumerate(wireBundle.cast<BundleType>().getElements())) {
+    for (auto field : llvm::enumerate(wireBundle.cast<BundleType>())) {
       auto fieldValue =
           builder.create<SubfieldOp>(op.getLoc(), wireOp, field.index());
       // Create the connection between module arguments and the external module,

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -128,7 +128,7 @@ static Value createZeroValue(ImplicitLocOpBuilder &builder, FIRRTLType type,
           })
           .Case<BundleType>([&](auto type) {
             auto wireOp = builder.create<WireOp>(type);
-            for (auto &field : llvm::enumerate(type.getElements())) {
+            for (auto &field : llvm::enumerate(type)) {
               auto zero = createZeroValue(builder, field.value().type, cache);
               auto acc = builder.create<SubfieldOp>(field.value().type, wireOp,
                                                     field.index());
@@ -966,8 +966,8 @@ static FIRRTLType updateType(FIRRTLType oldType, unsigned fieldID,
   // If this is a bundle type, update the corresponding field.
   if (auto bundleType = oldType.dyn_cast<BundleType>()) {
     unsigned index = bundleType.getIndexForFieldID(fieldID);
-    SmallVector<BundleType::BundleElement> fields(
-        bundleType.getElements().begin(), bundleType.getElements().end());
+    SmallVector<BundleType::BundleElement> fields(bundleType.begin(),
+                                                  bundleType.end());
     fields[index].type = updateType(
         fields[index].type, fieldID - bundleType.getFieldID(index), fieldType);
     return BundleType::get(fields, oldType.getContext());

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1543,7 +1543,7 @@ void InferenceMapping::declareVars(Value value, Location loc) {
     } else if (auto bundleType = type.dyn_cast<BundleType>()) {
       // Bundle types recursively declare all bundle elements.
       fieldID++;
-      for (auto &element : bundleType.getElements()) {
+      for (auto &element : bundleType) {
         declare(element.type);
       }
     } else if (auto vecType = type.dyn_cast<FVectorType>()) {
@@ -1689,7 +1689,7 @@ void InferenceMapping::unifyTypes(FieldRef lhs, FieldRef rhs, FIRRTLType type) {
       fieldID++;
     } else if (auto bundleType = type.dyn_cast<BundleType>()) {
       fieldID++;
-      for (auto &element : bundleType.getElements()) {
+      for (auto &element : bundleType) {
         unify(element.type);
       }
     } else if (auto vecType = type.dyn_cast<FVectorType>()) {
@@ -1923,7 +1923,7 @@ bool InferenceTypeUpdate::updateValue(Value value) {
       // Bundle types recursively update all bundle elements.
       fieldID++;
       llvm::SmallVector<BundleType::BundleElement, 3> elements;
-      for (auto &element : bundleType.getElements()) {
+      for (auto &element : bundleType) {
         elements.emplace_back(element.name, element.isFlip,
                               update(element.type));
       }

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -749,7 +749,7 @@ static bool flattenType(FIRRTLType type, SmallVectorImpl<IntType> &results) {
   std::function<bool(FIRRTLType)> flatten = [&](FIRRTLType type) -> bool {
     return TypeSwitch<FIRRTLType, bool>(type)
         .Case<BundleType>([&](auto bundle) {
-          for (auto &elt : bundle.getElements())
+          for (auto &elt : bundle)
             if (!flatten(elt.type))
               return false;
           return true;


### PR DESCRIPTION
This adds `begin()` and `end()` functionality to `BundleType`.  These
functions are short hand for `bundleType.getElements().begin()`.