### PR TITLE
[FIRRTL] Add `FModuleLike::moduleNameAttr()`

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -21,10 +21,6 @@ def FModuleLike : OpInterface<"FModuleLike"> {
     // Module Name
     //===------------------------------------------------------------------===//
 
-    InterfaceMethod<"Get the module name attribute",
-    "StringAttr", "moduleNameAttr", (ins),
-    /*methodBody=*/[{ return $_op.getNameAttr(); }]>,
-
     InterfaceMethod<"Get the module name",
     "StringRef", "moduleName", (ins),
     /*methodBody=*/[{ return $_op.getName(); }]>,

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -21,6 +21,10 @@ def FModuleLike : OpInterface<"FModuleLike"> {
     // Module Name
     //===------------------------------------------------------------------===//
 
+    InterfaceMethod<"Get the module name attribute",
+    "StringAttr", "moduleNameAttr", (ins),
+    /*methodBody=*/[{ return $_op.getNameAttr(); }]>,
+
     InterfaceMethod<"Get the module name",
     "StringRef", "moduleName", (ins),
     /*methodBody=*/[{ return $_op.getName(); }]>,

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1038,11 +1038,12 @@ void InstanceOp::build(OpBuilder &builder, OperationState &result,
     portAnnotationsAttr = builder.getArrayAttr(portAnnotations);
   }
 
-  return build(builder, result, resultTypes,
-               SymbolRefAttr::get(builder.getContext(), module.moduleName()),
-               builder.getStringAttr(name), module.getPortDirectionsAttr(),
-               module.getPortNamesAttr(), builder.getArrayAttr(annotations),
-               portAnnotationsAttr, builder.getBoolAttr(lowerToBind), innerSym);
+  return build(
+      builder, result, resultTypes,
+      SymbolRefAttr::get(builder.getContext(), module.moduleNameAttr()),
+      builder.getStringAttr(name), module.getPortDirectionsAttr(),
+      module.getPortNamesAttr(), builder.getArrayAttr(annotations),
+      portAnnotationsAttr, builder.getBoolAttr(lowerToBind), innerSym);
 }
 
 /// Builds a new `InstanceOp` with the ports listed in `portIndices` erased, and

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -307,7 +307,7 @@ LogicalResult CreateSiFiveMetadataPass::emitRetimeModulesMetadata() {
       // We use symbol substitution to make sure we output the correct thing
       // when the module goes through renaming.
       j.value(("{{" + Twine(index++) + "}}").str());
-      symbols.push_back(SymbolRefAttr::get(context, module.moduleName()));
+      symbols.push_back(SymbolRefAttr::get(module.moduleNameAttr()));
     }
   });
 


### PR DESCRIPTION
This adds a function to get the module name as an attribute instead of a
string ref.