### PR TITLE
[FIRRTL] Add `Annotation::begin()` and `end()`

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
@@ -71,6 +71,10 @@ public:
     return getDict().getAs<AttrClass>(name);
   }
 
+  using iterator = llvm::ArrayRef<NamedAttribute>::iterator;
+  iterator begin() const { return getDict().begin(); }
+  iterator end() const { return getDict().end(); }
+
   bool operator==(const Annotation &other) const { return attr == other.attr; }
   bool operator!=(const Annotation &other) const { return !(*this == other); }
   explicit operator bool() const { return bool(attr); }

--- a/lib/Dialect/FIRRTL/Transforms/PrefixModules.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/PrefixModules.cpp
@@ -239,7 +239,7 @@ void PrefixModulesPass::renameModule(FModuleOp module) {
     }
 
     NamedAttrList newAnno;
-    for (auto attr : anno.getDict()) {
+    for (auto attr : anno) {
       if (attr.getName() == "name") {
         newAnno.append(attr.getName(),
                        (Attribute)builder.getStringAttr(


### PR DESCRIPTION
This is a shorthand for `anno.getDict().begin()`.