### PR TITLE
[FIRRTL] Fix AnnotationSet iterator to work with `llvm::enumerate`

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
@@ -295,7 +295,8 @@ private:
 // Iteration over the annotation set.
 class AnnotationSetIterator
     : public llvm::indexed_accessor_iterator<AnnotationSetIterator,
-                                             AnnotationSet, Annotation> {
+                                             AnnotationSet, Annotation,
+                                             Annotation, Annotation> {
 public:
   // Index into this iterator.
   Annotation operator*() const;
@@ -303,9 +304,10 @@ public:
 private:
   AnnotationSetIterator(AnnotationSet owner, ptrdiff_t curIndex)
       : llvm::indexed_accessor_iterator<AnnotationSetIterator, AnnotationSet,
-                                        Annotation>(owner, curIndex) {}
+                                        Annotation, Annotation, Annotation>(
+            owner, curIndex) {}
   friend llvm::indexed_accessor_iterator<AnnotationSetIterator, AnnotationSet,
-                                         Annotation>;
+                                         Annotation, Annotation, Annotation>;
   friend class AnnotationSet;
 };
 


### PR DESCRIPTION
This sets the `AnnotationSetIterator`'s `PointerT` and `ReferenceT` all to
`Annotation`.  Without this, `llvm::enumerate` complains that `*it` does
not return a `Annotation &`, since it returns a `Annotation`.  This is
the same thing that `AttributeElementIterator` does.