### PR TITLE
[FIRRTL] Add ability to get the type ultimately targeted by a fieldID

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -107,9 +107,14 @@ public:
   /// nested under another type.
   unsigned getMaxFieldID();
 
-  /// Get the sub-type of a type for a field ID.  This is the identity function
-  /// for ground types.
-  FIRRTLType getSubTypeByFieldID(unsigned fieldID);
+  /// Get the sub-type of a type for a field ID, and the subfield's ID. Strip
+  /// off a single layer of this type and return the sub-type and a field ID
+  /// targeting the same field, but rebased on the sub-type.
+  std::pair<FIRRTLType, unsigned> getSubTypeByFieldID(unsigned fieldID);
+
+  /// Return the final type targeted by this field ID by recursively walking all
+  /// nested aggregate types. This is the identity function for ground types.
+  FIRRTLType getFinalTypeByFieldID(unsigned fieldID);
 
   /// Returns the effective field id when treating the index field as the
   /// root of the type.  Essentially maps a fieldID to a fieldID after a
@@ -335,7 +340,9 @@ public:
   /// index of the parent field.
   unsigned getIndexForFieldID(unsigned fieldID);
 
-  FIRRTLType getSubTypeByFieldID(unsigned fieldID);
+  /// Strip off a single layer of this type and return the sub-type and a field
+  /// ID targeting the same field, but rebased on the sub-type.
+  std::pair<FIRRTLType, unsigned> getSubTypeByFieldID(unsigned fieldID);
 
   /// Get the maximum field ID in this bundle.  This is helpful for constructing
   /// field IDs when this BundleType is nested in another aggregate type.
@@ -382,7 +389,9 @@ public:
   /// the index of the parent element.
   unsigned getIndexForFieldID(unsigned fieldID);
 
-  FIRRTLType getSubTypeByFieldID(unsigned fieldID);
+  /// Strip off a single layer of this type and return the sub-type and a field
+  /// ID targeting the same field, but rebased on the sub-type.
+  std::pair<FIRRTLType, unsigned> getSubTypeByFieldID(unsigned fieldID);
 
   /// Get the maximum field ID in this vector.  This is helpful for constructing
   /// field IDs when this VectorType is nested in another aggregate type.

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -831,7 +831,7 @@ unsigned BundleType::getFieldID(unsigned index) {
 unsigned BundleType::getIndexForFieldID(unsigned fieldID) {
   assert(getElements().size() && "Bundle must have >0 fields");
   auto fieldIDs = getImpl()->fieldIDs;
-  auto it = std::prev(llvm::upper_bound(fieldIDs, fieldID));
+  auto *it = std::prev(llvm::upper_bound(fieldIDs, fieldID));
   return std::distance(fieldIDs.begin(), it);
 }
 

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -447,16 +447,27 @@ unsigned FIRRTLType::getMaxFieldID() {
       });
 }
 
-FIRRTLType FIRRTLType::getSubTypeByFieldID(unsigned fieldID) {
-  return TypeSwitch<FIRRTLType, FIRRTLType>(*this)
+std::pair<FIRRTLType, unsigned>
+FIRRTLType::getSubTypeByFieldID(unsigned fieldID) {
+  return TypeSwitch<FIRRTLType, std::pair<FIRRTLType, unsigned>>(*this)
       .Case<AnalogType, ClockType, ResetType, AsyncResetType, SIntType,
-            UIntType>([](FIRRTLType t) { return t; })
+            UIntType>([&](FIRRTLType t) {
+        assert(!fieldID && "non-aggregate types must have a field id of 0");
+        return std::pair(t, 0);
+      })
       .Case<BundleType, FVectorType>(
-          [fieldID](auto type) { return type.getSubTypeByFieldID(fieldID); })
+          [&](auto type) { return type.getSubTypeByFieldID(fieldID); })
       .Default([](Type) {
         llvm_unreachable("unknown FIRRTL type");
-        return FIRRTLType();
+        return std::pair(FIRRTLType(), 0);
       });
+}
+
+FIRRTLType FIRRTLType::getFinalTypeByFieldID(unsigned fieldID) {
+  std::pair<FIRRTLType, unsigned> pair(*this, fieldID);
+  while (pair.second)
+    pair = pair.first.getSubTypeByFieldID(pair.second);
+  return pair.first;
 }
 
 std::pair<unsigned, bool> FIRRTLType::rootChildFieldID(unsigned fieldID,
@@ -820,18 +831,19 @@ unsigned BundleType::getFieldID(unsigned index) {
 unsigned BundleType::getIndexForFieldID(unsigned fieldID) {
   assert(getElements().size() && "Bundle must have >0 fields");
   auto fieldIDs = getImpl()->fieldIDs;
-  auto it =
-      std::prev(std::upper_bound(fieldIDs.begin(), fieldIDs.end(), fieldID));
+  auto it = std::prev(llvm::upper_bound(fieldIDs, fieldID));
   return std::distance(fieldIDs.begin(), it);
 }
 
-FIRRTLType BundleType::getSubTypeByFieldID(unsigned fieldID) {
+std::pair<FIRRTLType, unsigned>
+BundleType::getSubTypeByFieldID(unsigned fieldID) {
   if (fieldID == 0)
-    return *this;
+    return {*this, 0};
   auto fieldIDs = getImpl()->fieldIDs;
-  auto it =
-      std::prev(std::upper_bound(fieldIDs.begin(), fieldIDs.end(), fieldID));
-  return getElementType(std::distance(fieldIDs.begin(), it));
+  auto subfieldIndex = getIndexForFieldID(fieldID);
+  auto subfieldType = getElementType(subfieldIndex);
+  auto subfieldID = fieldID - getFieldID(subfieldIndex);
+  return {subfieldType, subfieldID};
 }
 
 unsigned BundleType::getMaxFieldID() { return getImpl()->maxFieldID; }
@@ -925,10 +937,12 @@ unsigned FVectorType::getIndexForFieldID(unsigned fieldID) {
   return (fieldID - 1) / (getElementType().getMaxFieldID() + 1);
 }
 
-FIRRTLType FVectorType::getSubTypeByFieldID(unsigned fieldID) {
+std::pair<FIRRTLType, unsigned>
+FVectorType::getSubTypeByFieldID(unsigned fieldID) {
   if (fieldID == 0)
-    return *this;
-  return getElementType();
+    return {*this, 0};
+  auto subfieldIndex = getIndexForFieldID(fieldID);
+  return {getElementType(), fieldID - getFieldID(subfieldIndex)};
 }
 
 unsigned FVectorType::getMaxFieldID() {

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -878,20 +878,8 @@ Optional<TypeSum> GrandCentralPass::computeField(Attribute field,
             auto fieldRef = leafMap.lookup(ground.getID());
             auto value = fieldRef.getValue();
             auto fieldID = fieldRef.getFieldID();
-            auto tpe = value.getType().cast<FIRRTLType>();
-
-            // Set type to ground type.
-            while (fieldID) {
-              TypeSwitch<FIRRTLType>(tpe)
-                  .Case<FVectorType, BundleType>([&](auto aggregate) {
-                    unsigned index = aggregate.getIndexForFieldID(fieldID);
-                    tpe = aggregate.getSubTypeByFieldID(fieldID);
-                    fieldID -= aggregate.getFieldID(index);
-                  })
-                  .Default([&](auto op) {
-                    llvm_unreachable("must be handled by traverseField");
-                  });
-            }
+            auto tpe = value.getType().cast<FIRRTLType>().getFinalTypeByFieldID(
+                fieldID);
             if (!tpe.isGround()) {
               value.getDefiningOp()->emitOpError()
                   << "cannot be added to interface with id '"


### PR DESCRIPTION
We have a function to return the type of a subfield using a fieldID.
The problem with this function is that it only strips a single layer at
a time from aggregate type, and it doesn't return the index of the
target element or its field ID.

This changes the functionality to return both the subtype, and the next
fieldID.  This makes it easier to iteratively follow subtypes all the
way to the final type.

This also adds a function to return the type targeted by the fieldID and
skip manually walking the data structures.