### PR TITLE
[FIRRTL] Add functions to look up bundle fields by StringAttr

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -300,18 +300,21 @@ public:
   size_t getNumElements() { return getElements().size(); }
 
   /// Look up an element's index by name.  This returns None on failure.
+  llvm::Optional<unsigned> getElementIndex(StringAttr name);
   llvm::Optional<unsigned> getElementIndex(StringRef name);
 
   /// Look up an element's name by index. This asserts if index is invalid.
   StringRef getElementName(size_t index);
 
   /// Look up an element by name.  This returns None on failure.
+  llvm::Optional<BundleElement> getElement(StringAttr name);
   llvm::Optional<BundleElement> getElement(StringRef name);
 
   /// Look up an element by index.  This asserts if index is invalid.
   BundleElement getElement(size_t index);
 
   /// Look up an element type by name.
+  FIRRTLType getElementType(StringAttr name);
   FIRRTLType getElementType(StringRef name);
 
   /// Look up an element type by index.

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -772,6 +772,16 @@ FIRRTLType BundleType::getPassiveType() {
   return passiveType;
 }
 
+llvm::Optional<unsigned> BundleType::getElementIndex(StringAttr name) {
+  for (auto it : llvm::enumerate(getElements())) {
+    auto element = it.value();
+    if (element.name == name) {
+      return unsigned(it.index());
+    }
+  }
+  return None;
+}
+
 llvm::Optional<unsigned> BundleType::getElementIndex(StringRef name) {
   for (auto it : llvm::enumerate(getElements())) {
     auto element = it.value();
@@ -788,8 +798,13 @@ StringRef BundleType::getElementName(size_t index) {
   return getElements()[index].name.getValue();
 }
 
-/// Look up an element by name.  This returns a BundleElement.
-auto BundleType::getElement(StringRef name) -> Optional<BundleElement> {
+Optional<BundleType::BundleElement> BundleType::getElement(StringAttr name) {
+  if (auto maybeIndex = getElementIndex(name))
+    return getElements()[*maybeIndex];
+  return None;
+}
+
+Optional<BundleType::BundleElement> BundleType::getElement(StringRef name) {
   if (auto maybeIndex = getElementIndex(name))
     return getElements()[*maybeIndex];
   return None;
@@ -800,6 +815,11 @@ BundleType::BundleElement BundleType::getElement(size_t index) {
   assert(index < getNumElements() &&
          "index must be less than number of fields in bundle");
   return getElements()[index];
+}
+
+FIRRTLType BundleType::getElementType(StringAttr name) {
+  auto element = getElement(name);
+  return element.hasValue() ? element.getValue().type : FIRRTLType();
 }
 
 FIRRTLType BundleType::getElementType(StringRef name) {

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -936,15 +936,14 @@ Optional<unsigned> FIRParser::getFieldIDFromTokens(ArrayAttr tokens, SMLoc loc,
       }
 
       // Token should point to valid sub-field.
-      auto subField = subFieldAttr.getValue();
-      auto index = bundleType.getElementIndex(subField);
+      auto index = bundleType.getElementIndex(subFieldAttr);
       if (!index) {
         emitError(loc, getMessage(tokenIdx) + " is not found in the bundle");
         return None;
       }
 
       id += bundleType.getFieldID(index.getValue());
-      currentType = bundleType.getElementType(subField);
+      currentType = bundleType.getElementType(index.getValue());
       continue;
     }
 

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -686,7 +686,7 @@ void InferResetsPass::traceResets(FIRRTLType dstType, Value dst, unsigned dstID,
     auto srcBundle = srcType.cast<BundleType>();
     for (unsigned dstIdx = 0, e = dstBundle.getNumElements(); dstIdx < e;
          ++dstIdx) {
-      auto dstField = dstBundle.getElements()[dstIdx].name.getValue();
+      auto dstField = dstBundle.getElements()[dstIdx].name;
       auto srcIdx = srcBundle.getElementIndex(dstField);
       if (!srcIdx)
         continue;

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1615,7 +1615,7 @@ void InferenceMapping::partiallyConstrainTypes(Value larger, Value smaller) {
           auto bBundle = bType.cast<BundleType>();
           for (unsigned aIndex = 0, e = aBundle.getNumElements(); aIndex < e;
                ++aIndex) {
-            auto aField = aBundle.getElements()[aIndex].name.getValue();
+            auto aField = aBundle.getElements()[aIndex].name;
             auto bIndex = bBundle.getElementIndex(aField);
             if (!bIndex)
               continue;


### PR DESCRIPTION
StringAttr comparisons are more efficient than regulare string
comparisons.  In the future we should look into using a binary search
when doing a string search.