### PR TITLE
[FIRRTL] Fix bug when creating `AnnoSet` from `ArrayRef<Annotation>`

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
@@ -36,7 +36,7 @@ static ArrayAttr getAnnotationsFrom(ArrayRef<Annotation> annotations,
   SmallVector<Attribute> attrs;
   attrs.reserve(annotations.size());
   for (auto anno : annotations)
-    attrs.push_back(anno.getDict());
+    attrs.push_back(anno.getAttr());
   return ArrayAttr::get(context, attrs);
 }
 


### PR DESCRIPTION
When we create an `AnnotationSet` from an array of `Annotation`s, we
were accidentally creating the annotation using the only dictionary of
the annotation, instead of the underlying attribute.  This would have
the effect of taking `#firrtl.subAnnotation<>` and turning them into
regular annotations.  This was missed in
9e74f40f82fe372299a99b92f3474c6034a43229.