### PR TITLE
[FIRRTL][AnnotationSet] Allow application to memory ports

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
@@ -23,6 +23,7 @@ namespace firrtl {
 
 class AnnotationSetIterator;
 class FModuleLike;
+class MemOp;
 
 /// Return the name of the attribute used for annotations on FIRRTL ops.
 inline StringRef getAnnotationAttrName() { return "annotations"; }
@@ -124,7 +125,8 @@ public:
   explicit AnnotationSet(Operation *op);
 
   /// Get an annotation set for the specified port.
-  static AnnotationSet forPort(Operation *op, size_t portNo);
+  static AnnotationSet forPort(FModuleLike op, size_t portNo);
+  static AnnotationSet forPort(MemOp op, size_t portNo);
 
   /// Get an annotation set for the specified value.
   static AnnotationSet get(Value v);
@@ -144,7 +146,8 @@ public:
   /// Store the annotations in this set in an operation's `portAnnotations`
   /// attribute, overwriting any existing annotations for this port. Returns
   /// true if the operation was modified, false otherwise.
-  bool applyToPort(Operation *op, size_t portNo) const;
+  bool applyToPort(FModuleLike op, size_t portNo) const;
+  bool applyToPort(MemOp op, size_t portNo) const;
 
   /// Store the annotations in this set in a `NamedAttrList` as an array
   /// attribute with the name `annotations`. Overwrites existing annotations.

--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
@@ -123,8 +123,8 @@ public:
   /// Get an annotation set for the specified operation.
   explicit AnnotationSet(Operation *op);
 
-  /// Get an annotation set for the specified module port.
-  static AnnotationSet forPort(FModuleLike module, size_t portNo);
+  /// Get an annotation set for the specified port.
+  static AnnotationSet forPort(Operation *op, size_t portNo);
 
   /// Get an annotation set for the specified value.
   static AnnotationSet get(Value v);
@@ -140,6 +140,11 @@ public:
   /// attribute if the set is empty. Returns true if the operation was modified,
   /// false otherwise.
   bool applyToOperation(Operation *op) const;
+
+  /// Store the annotations in this set in an operation's `portAnnotations`
+  /// attribute, overwriting any existing annotations for this port. Returns
+  /// true if the operation was modified, false otherwise.
+  bool applyToPort(Operation *op, size_t portNo) const;
 
   /// Store the annotations in this set in a `NamedAttrList` as an array
   /// attribute with the name `annotations`. Overwrites existing annotations.


### PR DESCRIPTION
Right now `AnnotationSet` assumes that only `FModuleOp`s have port
annotations, when they can actually be applied to both instance ops and
memory ops.  Since they all use the same `portAnnotations` attribute,
this can share a common code path.