### PR TITLE
[ExportVerilog] Don't emit temporay wires for duplicatable operations even with a user in a different block

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -2174,8 +2174,8 @@ static bool isExpressionUnableToInline(Operation *op) {
   for (auto user : op->getUsers()) {
     // If the user is in a different block and the op shouldn't be inlined, then
     // we emit this as an out-of-line declaration into its block and the user
-    // can refer to it.
-    if (user->getBlock() != opBlock)
+    // can refer to it unless the operation is nullary and duplicable.
+    if (user->getBlock() != opBlock && !isDuplicatableNullaryExpression(op))
       return true;
 
     // Verilog bit selection is required by the standard to be:

--- a/test/Conversion/ExportVerilog/disallow-local-vars.mlir
+++ b/test/Conversion/ExportVerilog/disallow-local-vars.mlir
@@ -12,7 +12,6 @@ hw.module @side_effect_expr(%clock: i1) -> (a: i1, a2: i1) {
   // DISALLOW: `ifdef FOO_MACRO
   sv.ifdef "FOO_MACRO" {
     // DISALLOW: {{^    }}reg [[SE_REG:[_A-Za-z0-9]+]];
-    // DISALLOW: {{^    }}wire [[COND:[_A-Za-z0-9]+]] = INLINE_OK;
 
     // CHECK:    always @(posedge clock)
     // DISALLOW: always @(posedge clock)
@@ -21,7 +20,7 @@ hw.module @side_effect_expr(%clock: i1) -> (a: i1, a2: i1) {
 
       // This shouldn't be pushed into a reg.
       // CHECK: if (INLINE_OK)
-      // DISALLOW: if ([[COND]])
+      // DISALLOW: if (INLINE_OK)
       sv.if %0  {
         sv.fatal 1
       }
@@ -166,10 +165,9 @@ hw.module @ReadInoutAggregate(%clock: i1) {
     %4 = comb.concat %c0_i16, %3 : i16, i16
     sv.passign %1, %4 : i32
   }
-  // DISALLOW: localparam [[T:.+]] = 1'h0;
-  // DISALLOW-NEXT: wire [31:0] [[READ:.+]] = register{{\[}}[[T]]{{\]}}.a;
+  // DISALLOW:      wire [31:0] [[READ:.+]] = register[1'h0].a;
   // DISALLOW-NEXT: wire [31:0] [[CONCAT:.+]] = {16'h0, [[READ]][15:0]};
   // DISALLOW-NEXT: always @(
-  // DISALLOW-NEXT:  register{{\[}}[[T]]{{\]}}.a <= [[CONCAT]];
+  // DISALLOW-NEXT:  register[1'h0].a <= [[CONCAT]];
   hw.output
 }

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -562,11 +562,10 @@ hw.module @longvariadic(%a: i8) -> (b: i8) {
 // CHECK-EMPTY:
 // CHECK-NEXT:   reg memory_r_en_pipe[0:0];
 // CHECK-EMPTY:
-// CHECK-NEXT:   localparam _T = 1'h0;
 // CHECK-NEXT:   always_ff @(posedge clock)
-// CHECK-NEXT:     memory_r_en_pipe[_T] <= _T;
+// CHECK-NEXT:     memory_r_en_pipe[1'h0] <= 1'h0;
 // CHECK-NEXT:   initial
-// CHECK-NEXT:     memory_r_en_pipe[_T] = _T;
+// CHECK-NEXT:     memory_r_en_pipe[1'h0] = 1'h0;
 // CHECK-NEXT: endmodule
 hw.module @ArrayLHS(%clock: i1) {
   %false = hw.constant false


### PR DESCRIPTION
Currently we give up to emit inline if there exists an user in a different block. 
It is not the case if the operation is duplicable (Constant or nullary verbatim).

This fixes https://github.com/llvm/circt/issues/2483 for constant operations. 