### PR TITLE
Re-land "[Calyx] Support toplevel attribute on ComponentOp in emitter."

### DIFF
--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -1436,6 +1436,9 @@ struct FuncOpConversion : public FuncOpPartialLoweringPattern {
     auto compOp = rewriter.create<calyx::ComponentOp>(
         funcOp.getLoc(), rewriter.getStringAttr(funcOp.sym_name()), ports);
 
+    /// Mark this component as the toplevel.
+    compOp->setAttr("toplevel", rewriter.getUnitAttr());
+
     /// Store the function-to-component mapping.
     funcMap[funcOp] = compOp;
     auto &compState = progState().compLoweringState(compOp);

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -397,6 +397,10 @@ static void printComponentOp(OpAsmPrinter &p, ComponentOp op) {
   p.printRegion(op.body(), /*printEntryBlockArgs=*/false,
                 /*printBlockTerminators=*/false,
                 /*printEmptyBlock=*/false);
+
+  SmallVector<StringRef> elidedAttrs = {"portAttributes", "portNames",
+                                        "portDirections", "sym_name", "type"};
+  p.printOptionalAttrDict(op->getAttrs(), elidedAttrs);
 }
 
 /// Parses the ports of a Calyx component signature, and adds the corresponding

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -56,8 +56,8 @@ constexpr std::array<StringRef, 6> CalyxIntegerAttributes{
 };
 
 /// A list of boolean attributes supported by the native Calyx compiler.
-constexpr std::array<StringRef, 6> CalyxBooleanAttributes{
-  "clk", "done", "go", "reset", "generated", "precious"
+constexpr std::array<StringRef, 7> CalyxBooleanAttributes{
+  "clk", "done", "go", "reset", "generated", "precious", "toplevel"
 };
 // clang-format on
 
@@ -229,7 +229,12 @@ private:
     if (attr.isa<UnitAttr>()) {
       assert(isBooleanAttribute &&
              "Non-boolean attributes must provide an integer value.");
-      buffer << addressSymbol() << identifier << space();
+      if (isGroupOrComponentAttr) {
+        buffer << LAngleBracket() << delimiter() << identifier << delimiter()
+               << equals() << "1" << RAngleBracket();
+      } else {
+        buffer << addressSymbol() << identifier << space();
+      }
     } else if (auto intAttr = attr.dyn_cast<IntegerAttr>()) {
       APInt value = intAttr.getValue();
       if (isGroupOrComponentAttr) {

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -51,11 +51,13 @@ static constexpr std::string_view addressSymbol() { return "@"; }
 
 // clang-format off
 /// A list of integer attributes supported by the native Calyx compiler.
+// NOLINTNEXTLINE(readability-identifier-naming)
 constexpr std::array<StringRef, 6> CalyxIntegerAttributes{
   "external", "static", "share", "bound", "write_together", "read_together"
 };
 
 /// A list of boolean attributes supported by the native Calyx compiler.
+// NOLINTNEXTLINE(readability-identifier-naming)
 constexpr std::array<StringRef, 7> CalyxBooleanAttributes{
   "clk", "done", "go", "reset", "generated", "precious", "toplevel"
 };

--- a/test/Conversion/SCFToCalyx/convert_controlflow.mlir
+++ b/test/Conversion/SCFToCalyx/convert_controlflow.mlir
@@ -43,7 +43,7 @@
 // CHECK-NEXT:           calyx.enable @ret_assign_0
 // CHECK-NEXT:         }
 // CHECK-NEXT:       }
-// CHECK-NEXT:     }
+// CHECK-NEXT:     } {toplevel}
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 module {
@@ -157,7 +157,7 @@ module {
 // CHECK-NEXT:           calyx.enable @ret_assign_0
 // CHECK-NEXT:         }
 // CHECK-NEXT:       }
-// CHECK-NEXT:     }
+// CHECK-NEXT:     } {toplevel}
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 module {
@@ -283,7 +283,7 @@ module {
 // CHECK-NEXT:           calyx.enable @ret_assign_0
 // CHECK-NEXT:         }
 // CHECK-NEXT:       }
-// CHECK-NEXT:     }
+// CHECK-NEXT:     } {toplevel}
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 module {
@@ -359,7 +359,7 @@ module {
 // CHECK-NEXT:           }
 // CHECK-NEXT:         }
 // CHECK-NEXT:       }
-// CHECK-NEXT:     }
+// CHECK-NEXT:     } {toplevel}
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 module {

--- a/test/Conversion/SCFToCalyx/convert_memory.mlir
+++ b/test/Conversion/SCFToCalyx/convert_memory.mlir
@@ -52,7 +52,7 @@
 // CHECK-NEXT:           }
 // CHECK-NEXT:         }
 // CHECK-NEXT:       }
-// CHECK-NEXT:     }
+// CHECK-NEXT:     } {toplevel}
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 module {
@@ -120,7 +120,7 @@ module {
 // CHECK-NEXT:           calyx.enable @ret_assign_0
 // CHECK-NEXT:         }
 // CHECK-NEXT:       }
-// CHECK-NEXT:     }
+// CHECK-NEXT:     } {toplevel}
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 module {
@@ -178,7 +178,7 @@ module {
 // CHECK-NEXT:           calyx.enable @ret_assign_0
 // CHECK-NEXT:         }
 // CHECK-NEXT:       }
-// CHECK-NEXT:     }
+// CHECK-NEXT:     } {toplevel}
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 module {
@@ -242,7 +242,7 @@ module {
 // CHECK-NEXT:           calyx.enable @ret_assign_0
 // CHECK-NEXT:         }
 // CHECK-NEXT:       }
-// CHECK-NEXT:     }
+// CHECK-NEXT:     } {toplevel}
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 module {
@@ -283,7 +283,7 @@ module {
 // CHECK-NEXT:           calyx.enable @ret_assign_0
 // CHECK-NEXT:         }
 // CHECK-NEXT:       }
-// CHECK-NEXT:     }
+// CHECK-NEXT:     } {toplevel}
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 module {
@@ -318,7 +318,7 @@ module {
 // CHECH-NEXT:           calyx.enable @ret_assign_0
 // CHECH-NEXT:         }
 // CHECH-NEXT:       }
-// CHECH-NEXT:     }
+// CHECH-NEXT:     } {toplevel}
 // CHECH-NEXT:   }
 // CHECH-NEXT: }
 module {
@@ -351,7 +351,7 @@ module {
 // CHECK-NEXT:           calyx.enable @bb0_0
 // CHECK-NEXT:         }
 // CHECK-NEXT:       }
-// CHECK-NEXT:     }
+// CHECK-NEXT:     } {toplevel}
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 module {
@@ -386,7 +386,7 @@ module {
 // CHECK-NEXT:           calyx.enable @ret_assign_0
 // CHECK-NEXT:         }
 // CHECK-NEXT:       }
-// CHECK-NEXT:     }
+// CHECK-NEXT:     } {toplevel}
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 module {
@@ -443,7 +443,7 @@ module {
 // CHECK-NEXT:           calyx.enable @ret_assign_0
 // CHECK-NEXT:         }
 // CHECK-NEXT:       }
-// CHECK-NEXT:     }
+// CHECK-NEXT:     } {toplevel}
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 module {

--- a/test/Conversion/SCFToCalyx/convert_simple.mlir
+++ b/test/Conversion/SCFToCalyx/convert_simple.mlir
@@ -27,7 +27,7 @@
 // CHECK-NEXT:           calyx.enable @ret_assign_0
 // CHECK-NEXT:         }
 // CHECK-NEXT:       }
-// CHECK-NEXT:     }
+// CHECK-NEXT:     } {toplevel}
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 module {
@@ -66,7 +66,7 @@ module {
 // CHECK-NEXT:           calyx.enable @ret_assign_0
 // CHECK-NEXT:         }
 // CHECK-NEXT:       }
-// CHECK-NEXT:     }
+// CHECK-NEXT:     } {toplevel}
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 module {

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -13,7 +13,7 @@ calyx.program "main" {
     calyx.control {}
   } {static = 1}
 
-  // CHECK-LABEL: component B(in: 1, @go go: 1, @clk clk: 1, @reset reset: 1) -> (out: 1, @done done: 1) {
+  // CHECK-LABEL: component B<"toplevel"=1>(in: 1, @go go: 1, @clk clk: 1, @reset reset: 1) -> (out: 1, @done done: 1) {
   calyx.component @B(%in: i1, %go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%out: i1, %done: i1 {done}) {
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     %s.in, %s.write_en, %s.clk, %s.reset, %s.out, %s.done = calyx.register @s : i32, i1, i1, i1, i32, i1
@@ -58,7 +58,7 @@ calyx.program "main" {
         }
       }
     }
-  }
+  } {toplevel}
 
   // CHECK-LABEL: component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   calyx.component @main(%go: i1 {go = 1}, %clk: i1 {clk = 1}, %reset: i1 {reset = 1}) -> (%done: i1 {done = 1}) {


### PR DESCRIPTION
This adds back the functionality, but uses a SmallVector<StringRef>
for the ComponentOp's elided attrs.