### PR TITLE
[ExportVerilog] Force to emit temporary wires for long verbatim

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -120,7 +120,7 @@ static bool isDuplicatableNullaryExpression(Operation *op) {
   // inline.
   if (isa<VerbatimExprOp>(op)) {
     if (op->getNumOperands() == 0 &&
-        op->getAttrOfType<StringAttr>("string").getValue().size() <= 16)
+        op->getAttrOfType<StringAttr>("string").getValue().size() <= 32)
       return true;
   }
 
@@ -2166,6 +2166,11 @@ static bool isExpressionUnableToInline(Operation *op) {
   // are inferred properly by verilog
   if (isa<StructCreateOp>(op))
     return true;
+
+  // Verbatim with a long string should be emitted as an out-of-line declration.
+  if (auto verbatim = dyn_cast<VerbatimExprOp>(op))
+    if (verbatim.string().size() > 32)
+      return true;
 
   auto *opBlock = op->getBlock();
 

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -275,6 +275,8 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
   // CHECK-NEXT: initial begin
   sv.initial {
     sv.verbatim "`define THING 1"
+    // CHECK-NEXT: automatic logic _T;
+    // CHECK-EMPTY:
     // CHECK-NEXT: `define THING
     %thing = sv.verbatim.expr "`THING" : () -> i42
     // CHECK-NEXT: wire42 = `THING;
@@ -287,6 +289,10 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
       // CHECK-NEXT: fwrite(32'h80000002, "%d", "THING");
       sv.fwrite "%d" (%c1) : i1
       // CHECK-NEXT: fwrite(32'h80000002, "%d", "THING");
+      %c2 = sv.verbatim.expr "\"VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE\"" : () -> i1
+      // CHECK-NEXT: _T = "VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE";
+      // CHECK-NEXT: fwrite(32'h80000002, "%d", _T);
+      sv.fwrite "%d" (%c2) : i1
       // CHECK-NEXT: `endif
     }
 


### PR DESCRIPTION
This PR comes from https://github.com/llvm/circt/pull/2512#discussion_r791199452.
This commit modifies ExportVerilog to force to emit temporary wires for verbatim with long string.
More specifically, if verbatim ops have string with >32 size, they are spilled.    
```mlir
%c2 = sv.verbatim.expr "VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG"
fwrite "%d" %c2
==>
wire _T  = "VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG_LINE_VERY_LONG";
fwrite "%d" _T
```

There are two arguable things:  
* Magic number (32 in this case, I picked so that it doesn't affect current outputs too much) 
* How we should handle verbatim ops with symbol substitution