### PR TITLE
[FIRRTL] Move AnnoTarget out of LowerAnnotations, fix bug

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
@@ -623,7 +623,7 @@ OpAnnoTarget::getNLAReference(ModuleNamespace &moduleNamespace) const {
 
 FIRRTLType OpAnnoTarget::getType() const {
   auto *op = getOp();
-  if (op->getNumResults() == 0)
+  if (op->getNumResults() != 1)
     return {};
   return op->getResult(0).getType().cast<FIRRTLType>();
 }

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
@@ -14,14 +14,23 @@
 #include "AnnotationDetails.h"
 #include "circt/Dialect/FIRRTL/FIRRTLAttributes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/Namespace.h"
+#include "circt/Dialect/HW/HWAttributes.h"
 #include "mlir/IR/FunctionImplementation.h"
 #include "mlir/IR/Operation.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 using mlir::function_like_impl::getArgAttrDict;
 using mlir::function_like_impl::setAllArgAttrDicts;
 
 using namespace circt;
 using namespace firrtl;
+
+static size_t getPortCount(Operation *op) {
+  if (auto module = dyn_cast<FModuleLike>(op))
+    return module.getNumPorts();
+  return op->getNumResults();
+}
 
 static ArrayAttr getAnnotationsFrom(Operation *op) {
   if (auto annots = op->getAttrOfType<ArrayAttr>(getAnnotationAttrName()))
@@ -532,6 +541,171 @@ void Annotation::removeMember(StringRef name) {
 
 Annotation AnnotationSetIterator::operator*() const {
   return Annotation(this->getBase().getArray()[this->getIndex()]);
+}
+
+//===----------------------------------------------------------------------===//
+// AnnoTarget
+//===----------------------------------------------------------------------===//
+
+FModuleLike AnnoTarget::getModule() const {
+  auto *op = getOp();
+  if (auto module = llvm::dyn_cast<FModuleLike>(op))
+    return module;
+  return op->getParentOfType<FModuleLike>();
+}
+
+AnnotationSet AnnoTarget::getAnnotations() const {
+  return TypeSwitch<AnnoTarget, AnnotationSet>(*this)
+      .Case<OpAnnoTarget, PortAnnoTarget>(
+          [&](auto target) { return target.getAnnotations(); })
+      .Default([&](auto target) { return AnnotationSet(getOp()); });
+}
+
+void AnnoTarget::setAnnotations(AnnotationSet annotations) const {
+  TypeSwitch<AnnoTarget>(*this).Case<OpAnnoTarget, PortAnnoTarget>(
+      [&](auto target) { target.setAnnotations(annotations); });
+}
+
+StringAttr AnnoTarget::getInnerSym(ModuleNamespace &moduleNamespace) const {
+  return TypeSwitch<AnnoTarget, StringAttr>(*this)
+      .Case<OpAnnoTarget, PortAnnoTarget>(
+          [&](auto target) { return target.getInnerSym(moduleNamespace); })
+      .Default([](auto target) { return StringAttr(); });
+}
+
+Attribute AnnoTarget::getNLAReference(ModuleNamespace &moduleNamespace) const {
+  return TypeSwitch<AnnoTarget, Attribute>(*this)
+      .Case<OpAnnoTarget, PortAnnoTarget>(
+          [&](auto target) { return target.getNLAReference(moduleNamespace); })
+      .Default([](auto target) { return Attribute(); });
+}
+
+FIRRTLType AnnoTarget::getType() const {
+  return TypeSwitch<AnnoTarget, FIRRTLType>(*this)
+      .Case<OpAnnoTarget, PortAnnoTarget>(
+          [](auto target) { return target.getType(); })
+      .Default([](auto target) { return FIRRTLType(); });
+}
+
+AnnotationSet OpAnnoTarget::getAnnotations() const {
+  return AnnotationSet(getOp());
+}
+
+void OpAnnoTarget::setAnnotations(AnnotationSet annotations) const {
+  annotations.applyToOperation(getOp());
+}
+
+StringAttr OpAnnoTarget::getInnerSym(ModuleNamespace &moduleNamespace) const {
+  auto *context = getOp()->getContext();
+  auto innerSym = getOp()->getAttrOfType<StringAttr>("inner_sym");
+  if (!innerSym) {
+    // Try to come up with a reasonable name.
+    StringRef name = "inner_sym";
+    auto nameAttr = getOp()->getAttrOfType<StringAttr>("name");
+    if (nameAttr)
+      name = nameAttr.getValue();
+    innerSym = StringAttr::get(context, moduleNamespace.newName(name));
+    getOp()->setAttr("inner_sym", innerSym);
+  }
+  return innerSym;
+}
+
+Attribute
+OpAnnoTarget::getNLAReference(ModuleNamespace &moduleNamespace) const {
+  // If the op is a module, just return the module name.
+  if (auto module = llvm::dyn_cast<FModuleLike>(getOp()))
+    return FlatSymbolRefAttr::get(module.moduleNameAttr());
+  // Return an inner-ref to the target.
+  auto module = getOp()->getParentOfType<FModuleLike>();
+  return hw::InnerRefAttr::get(module.moduleNameAttr(),
+                               getInnerSym(moduleNamespace));
+}
+
+FIRRTLType OpAnnoTarget::getType() const {
+  auto *op = getOp();
+  if (op->getNumResults() == 0)
+    return {};
+  return op->getResult(0).getType().cast<FIRRTLType>();
+}
+
+PortAnnoTarget::PortAnnoTarget(FModuleLike op, unsigned portNo)
+    : AnnoTarget({op, portNo}) {}
+
+PortAnnoTarget::PortAnnoTarget(MemOp op, unsigned portNo)
+    : AnnoTarget({op, portNo}) {}
+
+AnnotationSet PortAnnoTarget::getAnnotations() const {
+  if (auto memOp = llvm::dyn_cast<MemOp>(getOp()))
+    return AnnotationSet::forPort(memOp, getPortNo());
+  if (auto moduleOp = llvm::dyn_cast<FModuleLike>(getOp()))
+    return AnnotationSet::forPort(moduleOp, getPortNo());
+  llvm_unreachable("unknown port target");
+  return AnnotationSet(getOp()->getContext());
+}
+
+void PortAnnoTarget::setAnnotations(AnnotationSet annotations) const {
+  if (auto memOp = llvm::dyn_cast<MemOp>(getOp()))
+    annotations.applyToPort(memOp, getPortNo());
+  else if (auto moduleOp = llvm::dyn_cast<FModuleLike>(getOp()))
+    annotations.applyToPort(moduleOp, getPortNo());
+  else
+    llvm_unreachable("unknown port target");
+}
+
+StringAttr PortAnnoTarget::getInnerSym(ModuleNamespace &moduleNamespace) const {
+  auto *context = getOp()->getContext();
+
+  // If this is not a module, we just need to get an inner_sym on the operation
+  // itself.
+  if (!llvm::isa<FModuleLike>(getOp()))
+    return OpAnnoTarget(getOp()).getInnerSym(moduleNamespace);
+
+  auto portSyms = getOp()->getAttrOfType<ArrayAttr>("portSyms");
+  // If there is a valid sym, return it.
+  if (portSyms && !portSyms.empty())
+    if (auto innerSym = portSyms[getPortNo()].cast<StringAttr>())
+      if (!innerSym.strref().empty())
+        return innerSym;
+
+  // Create the new array.
+  SmallVector<Attribute> newSyms;
+  if (!portSyms || portSyms.empty())
+    newSyms.assign(getPortCount(getOp()), StringAttr::get(context, ""));
+  else
+    newSyms.assign(portSyms.begin(), portSyms.end());
+
+  // Try to come up with a reasonable name based on the port name.
+  StringRef name = "inner_sym";
+  if (auto portNames = getOp()->getAttrOfType<ArrayAttr>("portNames"))
+    name = portNames[getPortNo()].cast<StringAttr>().getValue();
+  else if (auto nameAttr = getOp()->getAttrOfType<StringAttr>("name"))
+    name = nameAttr.getValue();
+  auto innerSym = StringAttr::get(context, moduleNamespace.newName(name));
+
+  // Attach the inner sym.
+  newSyms[getPortNo()] = innerSym;
+  getOp()->setAttr("portSyms", ArrayAttr::get(context, newSyms));
+  return innerSym;
+}
+
+Attribute
+PortAnnoTarget::getNLAReference(ModuleNamespace &moduleNamespace) const {
+  auto module = llvm::dyn_cast<FModuleLike>(getOp());
+  if (!module)
+    module = getOp()->getParentOfType<FModuleLike>();
+  StringAttr moduleName = module.moduleNameAttr();
+  auto innerSym = getInnerSym(moduleNamespace);
+  return hw::InnerRefAttr::get(moduleName, innerSym);
+}
+
+FIRRTLType PortAnnoTarget::getType() const {
+  auto *op = getOp();
+  if (auto module = llvm::dyn_cast<FModuleLike>(op))
+    return module.getPortType(getPortNo());
+  if (llvm::isa<MemOp, InstanceOp>(op))
+    return op->getResult(getPortNo()).getType().cast<FIRRTLType>();
+  llvm_unreachable("unknow operation kind");
+  return {};
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -3,6 +3,19 @@
 // circt.test copies the annotation to the target
 // circt.testNT puts the targetless annotation on the circuit
 
+firrtl.circuit "Aggregates" attributes {annotations = [
+  {class = "circt.test", target = "~Aggregates|Aggregates>vector[1][1][1]"},
+  {class = "circt.test", target = "~Aggregates|Aggregates>bundle.a.b.c"}
+  ]} {
+  firrtl.module @Aggregates() {
+    // CHECK: {annotations = [{circt.fieldID = 14 : i32, class = "circt.test"}]}
+    %vector = firrtl.wire  : !firrtl.vector<vector<vector<uint<1>, 2>, 2>, 2>
+    // CHECK: {annotations = [{circt.fieldID = 3 : i32, class = "circt.test"}]}
+    %bundle = firrtl.wire  : !firrtl.bundle<a: bundle<b: bundle<c: uint<1>>>>
+  }
+}
+  
+// -----
 
 // A non-local annotation should work.
 
@@ -36,5 +49,3 @@ firrtl.circuit "FooNL"  attributes {annotations = [
     %w3 = firrtl.wire: !firrtl.uint
   }
 }
-
-


### PR DESCRIPTION
This moves the `AnnoTarget` class out of the `LowerAnnotations` pass.
This is so that it can be used in the `Dedup` pass.  The point of this
class is to track what an annotation is targeting, namely a certain op
or a port on an op.

The class was changed to use sub-types, representing ports with
`PortAnnoTarget`s or ops with `OpAnnoTarget`s.  The base class
`AnnoTarget` can be used with `TypeSwitch` to downcast to the derived
type.

The `FieldID` was moved out of the `AnnoTarget` class, since the
`Annotation` class already captures this information. `LowerAnnotations`
required some larger changes to work with this.

This also fixes a bug in `LowerAnnotations` where it would only resolve
1 field deep of nested aggregate types.