### PR TITLE
[ExportVerilog] Allow non-local operations to be inlined even with users at different blocks

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -2174,13 +2174,17 @@ static bool isExpressionUnableToInline(Operation *op) {
 
   auto *opBlock = op->getBlock();
 
+  // If the parent op is not a module op, it is defined locally.
+  bool isLocalDefinition = !isa_and_nonnull<HWModuleOp>(op->getParentOp());
+
   // Scan the users of the operation to see if any of them need this to be
   // emitted out-of-line.
   for (auto user : op->getUsers()) {
-    // If the user is in a different block and the op shouldn't be inlined, then
+    // If the op is defined locally and the user is in a different block, then
     // we emit this as an out-of-line declaration into its block and the user
     // can refer to it unless the operation is nullary and duplicable.
-    if (user->getBlock() != opBlock && !isDuplicatableNullaryExpression(op))
+    if (isLocalDefinition && user->getBlock() != opBlock &&
+        !isDuplicatableNullaryExpression(op))
       return true;
 
     // Verilog bit selection is required by the standard to be:

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -584,10 +584,9 @@ hw.module @notEmitDuplicateWiresThatWereUnInlinedDueToLongNames(%clock: i1, %x: 
   // CHECK: wire _T;
   // CHECK: wire aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
   %0 = comb.and %1, %x : i1
-  // CHECK: wire _T_0 = _T & x;
   // CHECK: always_ff @(posedge clock) begin
   sv.alwaysff(posedge %clock) {
-    // CHECK: if (_T_0) begin
+    // CHECK: if (_T & x) begin
     sv.if %0  {
       sv.verbatim "// hello"
     }

--- a/test/Conversion/ExportVerilog/verilog-basic.mlir
+++ b/test/Conversion/ExportVerilog/verilog-basic.mlir
@@ -355,10 +355,9 @@ hw.module @Print(%clock: i1, %reset: i1, %a: i4, %b: i4) {
   %false = hw.constant false
   %c1_i5 = hw.constant 1 : i5
 
-  // CHECK: wire [4:0] _T = {1'h0, a} << 5'h1;
   // CHECK: always @(posedge clock) begin
   // CHECK:   if (`PRINTF_COND_ & reset)
-  // CHECK:     $fwrite(32'h80000002, "Hi %x %x\n", _T, b);
+  // CHECK:     $fwrite(32'h80000002, "Hi %x %x\n", {1'h0, a} << 5'h1, b);
   // CHECK: end // always @(posedge)
   %0 = comb.concat %false, %a : i1, i4
   %1 = comb.shl %0, %c1_i5 : i5
@@ -377,9 +376,8 @@ hw.module @UninitReg1(%clock: i1, %reset: i1, %cond: i1, %value: i2) {
   %c-1_i2 = hw.constant -1 : i2
   %count = sv.reg  : !hw.inout<i2>
 
-  // CHECK: wire [1:0] _T = ~{2{reset}} & (cond ? value : count);
-  // CHECK-NEXT: always_ff @(posedge clock)
-  // CHECK-NEXT:   count <= _T;
+  // CHECK: always_ff @(posedge clock)
+  // CHECK-NEXT:   count <= ~{2{reset}} & (cond ? value : count);
 
   %0 = sv.read_inout %count : !hw.inout<i2>
   %1 = comb.mux %cond, %value, %0 : i2


### PR DESCRIPTION
This commit allows operations to be inlined if they are defined at top-level because
every user can refer regardless of wherever they are.

Close https://github.com/llvm/circt/issues/2483