### PR TITLE
[FIRRTL] Add RemoveUnusedPortsPass

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -39,6 +39,8 @@ std::unique_ptr<mlir::Pass> createLowerCHIRRTLPass();
 
 std::unique_ptr<mlir::Pass> createIMConstPropPass();
 
+std::unique_ptr<mlir::Pass> createRemoveUnusedPortsPass();
+
 std::unique_ptr<mlir::Pass> createInlinerPass();
 
 std::unique_ptr<mlir::Pass> createInferReadWritePass();

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -68,6 +68,19 @@ def IMConstProp : Pass<"firrtl-imconstprop", "firrtl::CircuitOp"> {
   ];
 }
 
+def RemoveUnusedPorts : Pass<"firrtl-remove-unused-ports", "firrtl::CircuitOp"> {
+  let summary = "Remove unused ports";
+  let description = [{
+    This pass removes unused ports without annotations or symbols. Implementation
+    wise, this pass iterates over the instance graph in a topological order from
+    leaves to the top so that we can remove unused ports optimally.
+  }];
+  let constructor = "circt::firrtl::createRemoveUnusedPortsPass()";
+  let statistics = [
+    Statistic<"numRemovedPorts", "num-removed-ports", "Number of ports erased">,
+  ];
+}
+
 def Inliner : Pass<"firrtl-inliner", "firrtl::CircuitOp"> {
   let summary = "Performs inlining, flattening, and dead module elimination";
   let description = [{

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -19,6 +19,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   PrefixModules.cpp
   PrintInstanceGraph.cpp
   RemoveResets.cpp
+  RemoveUnusedPorts.cpp
   WireDFT.cpp
 
   DEPENDS

--- a/lib/Dialect/FIRRTL/Transforms/RemoveUnusedPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/RemoveUnusedPorts.cpp
@@ -1,0 +1,172 @@
+//===- RemoveUnusedPorts.cpp - Remove Dead Ports ----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLAnnotations.h"
+#include "circt/Dialect/FIRRTL/FIRRTLAttributes.h"
+#include "circt/Dialect/FIRRTL/InstanceGraph.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "llvm/ADT/APSInt.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "firrtl-remove-unused-ports"
+
+using namespace circt;
+using namespace firrtl;
+
+namespace {
+struct RemoveUnusedPortsPass
+    : public RemoveUnusedPortsBase<RemoveUnusedPortsPass> {
+  void runOnOperation() override;
+  void removeUnusedModulePorts(FModuleOp module,
+                               InstanceGraphNode *instanceGraphNode);
+};
+} // namespace
+
+void RemoveUnusedPortsPass::runOnOperation() {
+  auto instanceGraph = getAnalysis<InstanceGraph>();
+  LLVM_DEBUG(llvm::dbgs() << "===----- Remove unused ports -----==="
+                          << "\n");
+  CircuitOp circuit = getOperation();
+  // Iterate in the reverse order of instance graph iterator, i.e. from leaves
+  // to top.
+  for (auto *node : llvm::reverse(instanceGraph))
+    if (auto module = dyn_cast<FModuleOp>(node->getModule()))
+      // Don't prune the main module.
+      if (circuit.getMainModule() != module)
+        removeUnusedModulePorts(module, node);
+}
+
+void RemoveUnusedPortsPass::removeUnusedModulePorts(
+    FModuleOp module, InstanceGraphNode *instanceGraphNode) {
+  LLVM_DEBUG(llvm::dbgs() << "Prune ports of module: " << module.getName()
+                          << "\n");
+  // This tracks port indexes that can be erased.
+  SmallVector<unsigned> removalPortIndexes;
+  // This tracks constant values of output ports. None indicates an invalid
+  // value.
+  SmallVector<llvm::Optional<APSInt>> outputPortConstants;
+  auto ports = module.getPorts();
+
+  for (auto e : llvm::enumerate(ports)) {
+    unsigned index = e.index();
+    auto port = e.value();
+    auto arg = module.getArgument(index);
+
+    // If the port is don't touch or has unprocessed annotations, we cannot
+    // remove the port. Maybe we can allow annotations though.
+    if (hasDontTouch(arg) || !port.annotations.empty())
+      continue;
+
+    // TODO: Handle inout ports.
+    if (port.isInOut())
+      continue;
+
+    // If the port is input and has an user, we cannot remove the
+    // port.
+    if (port.isInput() && !arg.use_empty())
+      continue;
+
+    // If the port is output, then check that the port is only connected to
+    // invalid or constant.
+    if (port.isOutput()) {
+      if (arg.use_empty()) {
+        outputPortConstants.push_back(None);
+      } else if (arg.hasOneUse()) {
+        auto connect = dyn_cast<ConnectOp>(*arg.user_begin());
+        if (!connect || !isa_and_nonnull<InvalidValueOp, ConstantOp>(
+                            connect.src().getDefiningOp()))
+          continue;
+
+        Operation *srcOp;
+        if (auto constant =
+                dyn_cast<ConstantOp>(connect.src().getDefiningOp())) {
+          outputPortConstants.push_back(constant.value());
+          srcOp = constant;
+        } else {
+          assert(isa<InvalidValueOp>(connect.src().getDefiningOp()) &&
+                 "only expect invalid");
+          srcOp = connect.src().getDefiningOp();
+          outputPortConstants.push_back(None);
+        }
+        // Erase connect op because we are going to remove this output ports.
+        connect.erase();
+        if (srcOp->use_empty())
+          srcOp->erase();
+
+      } else {
+        continue;
+      }
+    }
+
+    removalPortIndexes.push_back(index);
+  }
+
+  // If there is nothing to remove, abort.
+  if (removalPortIndexes.empty())
+    return;
+
+  module.erasePorts(removalPortIndexes);
+
+  LLVM_DEBUG(llvm::for_each(removalPortIndexes, [&](unsigned index) {
+               llvm::dbgs() << "Delete port: " << ports[index].name << "\n";
+             }););
+
+  // Rewrite all uses.
+  for (auto *use : instanceGraphNode->uses()) {
+    auto instance = use->getInstance();
+    OpBuilder builder(instance);
+    unsigned outputPortIndex = 0;
+    for (auto index : removalPortIndexes) {
+      auto result = instance.getResult(index);
+      assert(!ports[index].isInOut() && "don't expect inout ports");
+
+      // If the port is input, replace the port with an unwritten wire
+      // so that we can remove use-chains in SV dialect canonicalization.
+      if (ports[index].isInput()) {
+        WireOp wire =
+            builder.create<WireOp>(instance.getLoc(), result.getType());
+        result.replaceUsesWithIf(wire, [&](OpOperand &op) -> bool {
+          // Connects can be deleted directly.
+          if (isa<ConnectOp>(op.getOwner())) {
+            op.getOwner()->erase();
+            return false;
+          }
+          return true;
+        });
+
+        // If the wire doesn't have an user, just erase it.
+        if (wire.use_empty())
+          wire.erase();
+        continue;
+      }
+      auto portConstant = outputPortConstants[outputPortIndex++];
+      // Output case. Replace with the output port with an invalid or constant
+      // value.
+      Value value;
+      if (portConstant)
+        value = builder.create<ConstantOp>(instance.getLoc(), *portConstant);
+      else
+        value =
+            builder.create<InvalidValueOp>(instance.getLoc(), result.getType());
+
+      result.replaceAllUsesWith(value);
+    }
+
+    // Create a new instance op without unused ports.
+    instance.erasePorts(builder, removalPortIndexes);
+    // Remove old one.
+    instance.erase();
+  }
+
+  numRemovedPorts += removalPortIndexes.size();
+}
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createRemoveUnusedPortsPass() {
+  return std::make_unique<RemoveUnusedPortsPass>();
+}

--- a/test/Dialect/FIRRTL/remove-unused-ports.mlir
+++ b/test/Dialect/FIRRTL/remove-unused-ports.mlir
@@ -1,0 +1,68 @@
+// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-remove-unused-ports)' %s | FileCheck %s
+firrtl.circuit "Top"   {
+  // CHECK-LABEL: firrtl.module @Top(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>,
+  // CHECK-SAME :                    out %d_unused: !firrtl.uint<1>, out %d_invalid: !firrtl.uint<1>, out %d_constant: !firrtl.uint<1>)
+  firrtl.module @Top(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>,
+                     out %d_unused: !firrtl.uint<1>, out %d_invalid: !firrtl.uint<1>, out %d_constant: !firrtl.uint<1>) {
+    %A_a, %A_b, %A_c, %A_d_unused, %A_d_invalid, %A_d_constant = firrtl.instance A  @UseBar(in a: !firrtl.uint<1>, in b: !firrtl.uint<1>, out c: !firrtl.uint<1>, out d_unused: !firrtl.uint<1>, out d_invalid: !firrtl.uint<1>, out d_constant: !firrtl.uint<1>)
+    // CHECK: %A_b, %A_c = firrtl.instance A @UseBar(in b: !firrtl.uint<1>, out c: !firrtl.uint<1>)
+    // CHECK-NEXT: firrtl.connect %A_b, %b
+    // CHECK-NEXT: firrtl.connect %c, %A_c
+    // CHECK-NEXT: firrtl.connect %d_unused, %{{invalid_ui1.*}}
+    // CHECK-NEXT: firrtl.connect %d_invalid, %{{invalid_ui1.*}}
+    // CHECK-NEXT: firrtl.connect %d_constant, %{{c1_ui1.*}}
+    firrtl.connect %A_a, %a : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %A_b, %b : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %c, %A_c : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %d_unused, %A_d_unused : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %d_invalid, %A_d_invalid : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %d_constant, %A_d_constant : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+
+  // Check that %a, %d_unused, %d_invalid and %d_constant are removed.
+  // CHECK-LABEL: firrtl.module @Bar(in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>)
+  // CHECK-NEXT:    firrtl.connect %c, %b
+  // CHECK-NEXT:  }
+  firrtl.module @Bar(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>,
+                     out %d_unused: !firrtl.uint<1>, out %d_invalid: !firrtl.uint<1>, out %d_constant: !firrtl.uint<1>) {
+    firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
+
+    %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
+    firrtl.connect %d_invalid, %invalid_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    %c1_i1 = firrtl.constant 1 : !firrtl.uint<1>
+    firrtl.connect %d_constant, %c1_i1 : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+
+  // Check that %a, %d_unused, %d_invalid and %d_constant are removed.
+  // CHECK-LABEL: firrtl.module @UseBar(in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) {
+  firrtl.module @UseBar(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>,
+                        out %d_unused: !firrtl.uint<1>, out %d_invalid: !firrtl.uint<1>, out %d_constant: !firrtl.uint<1>) {
+    %A_a, %A_b, %A_c, %A_d_unused, %A_d_invalid, %A_d_constant = firrtl.instance A  @Bar(in a: !firrtl.uint<1>, in b: !firrtl.uint<1>, out c: !firrtl.uint<1>, out d_unused: !firrtl.uint<1>, out d_invalid: !firrtl.uint<1>, out d_constant: !firrtl.uint<1>)
+    firrtl.connect %A_a, %a : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK: %A_b, %A_c = firrtl.instance A  @Bar(in b: !firrtl.uint<1>, out c: !firrtl.uint<1>)
+    firrtl.connect %A_b, %b : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %c, %A_c : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %d_unused, %A_d_unused : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %d_invalid, %A_d_invalid : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %d_constant, %A_d_constant : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+
+  // Make sure that %a, %b and %c are not erased because they have an annotation or a symbol.
+  // CHECK-LABEL: firrtl.module @Foo(in %a: !firrtl.uint<1> sym @dntSym, in %b: !firrtl.uint<1> [{a = "a"}], out %c: !firrtl.uint<1> sym @dntSym)
+  firrtl.module @Foo(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) attributes {
+    portAnnotations = [[], [{a = "a"}], []], portSyms = ["dntSym", "", "dntSym"]}
+  {
+    // CHECK: firrtl.connect %c, %{{invalid_ui1.*}}
+    %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
+    firrtl.connect %c, %invalid_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+
+  // CHECK-LABEL: firrtl.module @UseFoo(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>)
+  firrtl.module @UseFoo(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) {
+    %A_a, %A_b, %A_c = firrtl.instance A  @Foo(in a: !firrtl.uint<1>, in b: !firrtl.uint<1>, out c: !firrtl.uint<1>)
+    // CHECK: %A_a, %A_b, %A_c = firrtl.instance A @Foo(in a: !firrtl.uint<1>, in b: !firrtl.uint<1>, out c: !firrtl.uint<1>)
+    firrtl.connect %A_a, %a : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %A_b, %b : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %c, %A_c : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+}

--- a/test/firtool/chirrtl.fir
+++ b/test/firtool/chirrtl.fir
@@ -1,4 +1,4 @@
-; RUN: firtool -blackbox-memory -verilog %s | FileCheck %s
+; RUN: firtool -blackbox-memory -remove-unused-ports=false -verilog %s | FileCheck %s
 
 ; This is testing that CHIRRTL enable inference is working as intended.  If the
 ; no-op wires and nodes are not optimized away, then both ports should always


### PR DESCRIPTION
This commit adds RemoveUnusedPortsPass to prune unused ports.
RemoveUnusedPortsPass removes unused ports from the bottom of the
instance graph so that we can remove ports optimally. Ports are
not removed if they have annotations or inner sym.

Close https://github.com/llvm/circt/issues/2420