### PR TITLE
[FIRRTL] Add Dedup pass

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -54,6 +54,8 @@ createCreateSiFiveMetadataPass(bool replSeqMem = false,
 
 std::unique_ptr<mlir::Pass> createWireDFTPass();
 
+std::unique_ptr<mlir::Pass> createDedupPass();
+
 std::unique_ptr<mlir::Pass> createEmitOMIRPass(StringRef outputFilename = "");
 
 std::unique_ptr<mlir::Pass> createExpandWhensPass();

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -152,8 +152,11 @@ def Dedup : Pass<"firrtl-dedup", "firrtl::CircuitOp"> {
   let description = [{
     This pass detects modules which are structurally equivalent and removes the
     duplicate module by replacing all instances of one with the other.
-    Structural equivalence ignore the naming of operations and fields in
-    bundles, and any annotations.  Deduplicated modules will have their
+    Structural equivalence ignores the naming of operations and fields in
+    bundles, and any annotations. Deduplicating a module may cause the result
+    type of instances to change if the field names of a bundle type change.  To
+    handle this, the pass will update any bulk-connections so that the correct
+    fields are legally connected. Deduplicated modules will have their
     annotations merged, which tends to create many non-local annotations.
   }];
   let statistics = [

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -147,6 +147,22 @@ def WireDFT : Pass<"firrtl-dft", "firrtl::CircuitOp"> {
   let constructor = "circt::firrtl::createWireDFTPass()";
 }
 
+def Dedup : Pass<"firrtl-dedup", "firrtl::CircuitOp"> {
+  let summary = "Deduplicate modules which are structurally equivalent";
+  let description = [{
+    This pass detects modules which are structurally equivalent and removes the
+    duplicate module by replacing all instances of one with the other.
+    Structural equivalence ignore the naming of operations and fields in
+    bundles, and any annotations.  Deduplicated modules will have their
+    annotations merged, which tends to create many non-local annotations.
+  }];
+  let statistics = [
+    Statistic<"erasedModules", "num-erased-modules",
+      "Number of modules which were erased by deduplication">
+  ];
+  let constructor = "circt::firrtl::createDedupPass()";
+}
+
 def EmitOMIR : Pass<"firrtl-emit-omir", "firrtl::CircuitOp"> {
   let summary = "Emit OMIR annotations";
   let description = [{

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -3,6 +3,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   BlackBoxReader.cpp
   CheckCombCycles.cpp
   CreateSiFiveMetadata.cpp
+  Dedup.cpp
   EmitOMIR.cpp
   ExpandWhens.cpp
   GrandCentral.cpp

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -308,7 +308,7 @@ private:
   /// This fixes up a partial connect when the field names of a bundle type
   /// changes.  It finds all the fields which were previously connected and
   /// replaces them with new partial connects.
-  using LazyValue = llvm::function_ref<Value(ImplicitLocOpBuilder &)>;
+  using LazyValue = std::function<Value(ImplicitLocOpBuilder &)>;
   // NOLINTNEXTLINE(misc-no-recursion)
   void fixupPartialConnect(ImplicitLocOpBuilder &builder, LazyValue dst,
                            Type dstNewType, Type dstOldType, LazyValue src,
@@ -946,6 +946,7 @@ class DedupPass : public DedupBase<DedupPass> {
   void runOnOperation() override {
     auto *context = &getContext();
     auto circuit = getOperation();
+    circuit->dump();
     auto &instanceGraph = getAnalysis<InstanceGraph>();
     SymbolTable symbolTable(circuit);
     NLAMap nlaMap = createNLAMap(circuit);

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -937,7 +937,6 @@ class DedupPass : public DedupBase<DedupPass> {
   void runOnOperation() override {
     auto *context = &getContext();
     auto circuit = getOperation();
-    circuit->dump();
     auto &instanceGraph = getAnalysis<InstanceGraph>();
     SymbolTable symbolTable(circuit);
     NLAMap nlaMap = createNLAMap(circuit);

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -1,0 +1,1009 @@
+//===- Dedup.cpp - FIRRTL module deduping -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements FIRRTL module deduplication.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
+#include "circt/Dialect/FIRRTL/InstanceGraph.h"
+#include "circt/Dialect/FIRRTL/Namespace.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "circt/Dialect/HW/HWAttributes.h"
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "llvm/ADT/DepthFirstIterator.h"
+#include "llvm/ADT/PostOrderIterator.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Format.h"
+#include "llvm/Support/SHA256.h"
+
+using namespace circt;
+using namespace firrtl;
+using hw::InnerRefAttr;
+
+/// This stores a mapping from a module name to every NLA that it particiapates
+/// in.
+using NLAMap = DenseMap<Attribute, std::vector<NonLocalAnchor>>;
+
+NLAMap createNLAMap(CircuitOp circuit) {
+  DenseMap<Attribute, std::vector<NonLocalAnchor>> nlaMap;
+  for (auto nla : circuit.getBody()->getOps<NonLocalAnchor>()) {
+    for (auto element : nla.namepath()) {
+      if (auto moduleRef = element.dyn_cast<FlatSymbolRefAttr>())
+        nlaMap[moduleRef.getAttr()].push_back(nla);
+      else
+        nlaMap[element.cast<InnerRefAttr>().getModule()].push_back(nla);
+    }
+  }
+  return nlaMap;
+}
+
+//===----------------------------------------------------------------------===//
+// Hashing
+//===----------------------------------------------------------------------===//
+
+llvm::raw_ostream &printHex(llvm::raw_ostream &stream,
+                            ArrayRef<uint8_t> bytes) {
+  // Print the hash on a single line.
+  return stream << format_bytes(bytes, llvm::None, 32) << "\n";
+}
+
+llvm::raw_ostream &printHash(llvm::raw_ostream &stream, llvm::SHA256 &data) {
+  auto string = data.result();
+  ArrayRef bytes(reinterpret_cast<const uint8_t *>(string.begin()),
+                 string.size());
+  return printHex(stream, bytes);
+}
+
+llvm::raw_ostream &printHash(llvm::raw_ostream &stream, std::string data) {
+  ArrayRef bytes(reinterpret_cast<const uint8_t *>(data.c_str()),
+                 data.length());
+  return printHex(stream, bytes);
+}
+
+struct StructuralHasher {
+  explicit StructuralHasher(MLIRContext *context) {
+    nonessentialAttributes.insert(StringAttr::get(context, "annotations"));
+    nonessentialAttributes.insert(StringAttr::get(context, "name"));
+    nonessentialAttributes.insert(StringAttr::get(context, "portAnnotations"));
+    nonessentialAttributes.insert(StringAttr::get(context, "portNames"));
+    nonessentialAttributes.insert(StringAttr::get(context, "portSyms"));
+    nonessentialAttributes.insert(StringAttr::get(context, "portTypes"));
+    nonessentialAttributes.insert(StringAttr::get(context, "sym_name"));
+    nonessentialAttributes.insert(StringAttr::get(context, "inner_sym"));
+  };
+
+  std::string hash(FModuleLike module) {
+    update(&(*module));
+    auto hash = sha.final().str();
+    reset();
+    return hash;
+  }
+
+private:
+  void reset() {
+    currentIndex = 0;
+    indexes.clear();
+    sha.init();
+  }
+
+  void update(const void *pointer) {
+    auto *addr = reinterpret_cast<const uint8_t *>(&pointer);
+    sha.update(ArrayRef(addr, sizeof pointer));
+  }
+
+  void update(unsigned value) {
+    auto *addr = reinterpret_cast<const uint8_t *>(&value);
+    sha.update(ArrayRef(addr, sizeof value));
+  }
+
+  void update(TypeID typeID) { update(typeID.getAsOpaquePointer()); }
+
+  void update(BundleType type) {
+    update(type.getTypeID());
+    for (auto &element : type.getElements()) {
+      update(element.isFlip);
+      update(element.type);
+    }
+  }
+
+  void update(Type type) {
+    if (auto bundle = type.dyn_cast<BundleType>())
+      return update(bundle);
+    update(type.getAsOpaquePointer());
+  }
+
+  void update(BlockArgument arg) {
+    indexes[arg] = currentIndex++;
+    update(arg.getArgNumber());
+    update(arg.getType());
+  }
+
+  void update(OpResult result) {
+    indexes[result] = currentIndex++;
+    update(result.getType());
+  }
+
+  void update(OpOperand &operand) {
+    // We hash the value's index as it apears in the block.
+    auto it = indexes.find(operand.get());
+    assert(it != indexes.end() && "op should have been previously hashed");
+    update(it->second);
+  }
+
+  void update(DictionaryAttr dict) {
+    for (auto namedAttr : dict) {
+      auto name = namedAttr.getName();
+      // Skip names and annotations.
+      if (nonessentialAttributes.contains(name))
+        continue;
+      // Hash the interned pointer.
+      update(name.getAsOpaquePointer());
+      update(namedAttr.getValue().getAsOpaquePointer());
+    }
+  }
+
+  void update(Block &block) {
+    // Hash the block arguments.
+    for (auto arg : block.getArguments())
+      update(arg);
+    // Hash the operations in the block.
+    for (auto &op : block)
+      update(&op);
+  }
+
+  void update(mlir::OperationName name) {
+    // Operation names are interned.
+    update(name.getAsOpaquePointer());
+  }
+
+  // NOLINTNEXTLINE(misc-no-recursion)
+  void update(Operation *op) {
+    update(op->getName());
+    update(op->getAttrDictionary());
+    // Hash the operands.
+    for (auto &operand : op->getOpOperands())
+      update(operand);
+    // Hash the regions. We need to make sure an empty region doesn't hash the
+    // same as no region, so we include the number of regions.
+    update(op->getNumRegions());
+    for (auto &region : op->getRegions())
+      for (auto &block : region.getBlocks())
+        update(block);
+    // Record any op results.
+    for (auto result : op->getResults())
+      update(result);
+  }
+
+  // Every value is assigned a unique id based on their order of appearance.
+  unsigned currentIndex = 0;
+  DenseMap<Value, unsigned> indexes;
+
+  // This is a set of every attribute we should ignore.
+  DenseSet<Attribute> nonessentialAttributes;
+
+  // This is the actual running hash calculation. This is a stateful element
+  // that should be reinitialized after each hash is produced.
+  llvm::SHA256 sha;
+};
+
+//===----------------------------------------------------------------------===//
+// Deduplication
+//===----------------------------------------------------------------------===//
+
+struct Deduper {
+  Deduper(InstanceGraph &instanceGraph, SymbolTable &symbolTable,
+          NLAMap &nlaMap, CircuitOp circuit)
+      : context(circuit->getContext()), instanceGraph(instanceGraph),
+        symbolTable(symbolTable), nlaMap(nlaMap), nlaBlock(circuit.getBody()),
+        nonLocalString(StringAttr::get(context, "circt.nonlocal")),
+        classString(StringAttr::get(context, "class")) {}
+
+  /// Remove the "fromModule", and replace all references to it with the
+  /// "toModule".  Modules should be deduplicated in a bottom-up order.  Any
+  /// module which is not deduplicated needs to be recorded with the `record`
+  /// call.
+  void dedup(FModuleLike toModule, FModuleLike fromModule) {
+    // A map of operation (e.g. wires, nodes) names which are changed, which is
+    // used to update NLAs that reference the "fromModule".
+    DenseMap<StringAttr, StringAttr> renameMap;
+
+    // Merge the two modules.
+    mergeOps(renameMap, toModule, toModule, fromModule, fromModule);
+
+    // Rewrite NLAs pathing through these modules to refer to the to module.
+    if (auto to = dyn_cast<FModuleOp>(*toModule))
+      rewriteModuleNLAs(renameMap, to, cast<FModuleOp>(*fromModule));
+    else
+      rewriteExtModuleNLAs(toModule.moduleNameAttr(),
+                           fromModule.moduleNameAttr());
+
+    // Replace all instance of one module with the other.  If the module returns
+    // a different bundle type we have to fix up anything connecting to an
+    // instance of it.
+    fixupReferences(toModule, fromModule);
+  }
+
+  /// Record the usages of any NLA's in this module, so that we may update the
+  /// annotation if the parent module is deduped with another module.
+  void record(Operation *module) {
+    recordAnnotations(module);
+    module->walk([&](Operation *op) { recordAnnotations(op); });
+  }
+
+private:
+  /// Get a cached namespace for a module.
+  ModuleNamespace &getNamespace(Operation *module) {
+    auto [it, inserted] = moduleNamespaces.try_emplace(module, module);
+    return it->second;
+  }
+
+  /// Record all targets which use an NLA.
+  void recordAnnotations(Operation *op) {
+    for (auto anno : AnnotationSet(op)) {
+      if (auto nlaRef = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal")) {
+        // Don't record instance breadcrumbs.  We're only looking for the final
+        // target of an NLA.
+        if (anno.getClassAttr() == nonLocalString)
+          continue;
+        targetMap[nlaRef.getAttr()] = OpAnnoTarget(op);
+      }
+    }
+
+    auto portAnnotations = op->getAttrOfType<ArrayAttr>("portAnnotations");
+    if (!portAnnotations)
+      return;
+    auto module = dyn_cast<FModuleOp>(op);
+    auto mem = dyn_cast<MemOp>(op);
+    for (auto pair : llvm::enumerate(portAnnotations))
+      for (auto anno : AnnotationSet(pair.value().cast<ArrayAttr>()))
+        if (auto nlaRef = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal")) {
+          // Breadcrumbs don't appear on port annotations, so we can skip the
+          // class check that we have above.
+          if (module)
+            targetMap[nlaRef.getAttr()] = PortAnnoTarget(module, pair.index());
+          else if (mem)
+            targetMap[nlaRef.getAttr()] = PortAnnoTarget(mem, pair.index());
+          else
+            llvm_unreachable("unknown operaiton with ports");
+        }
+  }
+
+  /// This fixes up connects when the field names of a bundle type changes.  It
+  /// finds all fields which were previously bulk connected and legalizes it
+  /// into a connect for each field.
+  void fixupConnect(ImplicitLocOpBuilder &builder, Value dst, Type dstType,
+                    Value src, Type srcType) {
+    // If its not a bundle type, the types are guaranteed to be unchanged.  If
+    // it is a bundle type, we would rather bulk-connect the values instead of
+    // decomposing the connect if the type is unchanged.
+    if (dstType == dst.getType() && srcType == src.getType()) {
+      builder.create<ConnectOp>(dst, src);
+      return;
+    }
+    // It must be a bundle type and the field name has changed. We have to
+    // manually decompose the bulk connect into a connect for each field.
+    auto dstBundle = dstType.cast<BundleType>();
+    auto srcBundle = srcType.cast<BundleType>();
+    for (unsigned i = 0; i < dstBundle.getNumElements(); ++i) {
+      auto dstField = builder.create<SubfieldOp>(dst, i);
+      auto srcField = builder.create<SubfieldOp>(src, i);
+      if (!dstBundle.getElement(i).isFlip)
+        fixupConnect(builder, dstField, dstBundle.getElementType(i), srcField,
+                     srcBundle.getElementType(i));
+      else
+        fixupConnect(builder, srcField, srcBundle.getElementType(i), dstField,
+                     dstBundle.getElementType(i));
+    }
+  }
+
+  /// This fixes up a partial connect when the field names of a bundle type
+  /// changes.  It finds all the fields which were previously connected and
+  /// replaces them with new partial connects.
+  using LazyValue = llvm::function_ref<Value(ImplicitLocOpBuilder &)>;
+  // NOLINTNEXTLINE(misc-no-recursion)
+  void fixupPartialConnect(ImplicitLocOpBuilder &builder, LazyValue dst,
+                           Type dstNewType, Type dstOldType, LazyValue src,
+                           Type srcNewType, Type srcOldType) {
+    // If the types didn't change, just emit a partial connect.
+    if (dstOldType == dstNewType && srcOldType == srcNewType) {
+      auto dstField = dst(builder);
+      auto srcField = src(builder);
+      builder.create<PartialConnectOp>(dstField, srcField);
+      return;
+    }
+    // Check if they are bundle types.
+    if (auto dstOldBundle = dstOldType.dyn_cast<BundleType>()) {
+      auto dstNewBundle = dstOldType.cast<BundleType>();
+      auto srcNewBundle = dstNewType.cast<BundleType>();
+      auto srcOldBundle = srcOldType.cast<BundleType>();
+      for (auto &pair : llvm::enumerate(dstOldBundle)) {
+        // Find a matching field in the old type.
+        auto dstField = pair.value();
+        auto maybeIndex = srcOldBundle.getElementIndex(dstField.name);
+        if (!maybeIndex)
+          continue;
+        auto dstIndex = pair.index();
+        auto srcIndex = *maybeIndex;
+        // Recurse on the matching field. The code is complicated because we are
+        // trying to avoid creating subfield operations when no field ultimately
+        // matches.
+        Value dstValue;
+        auto dstLazy = [&](ImplicitLocOpBuilder &builder) {
+          if (!dstValue)
+            dstValue = builder.create<SubfieldOp>(dst(builder), dstIndex);
+          return dstValue;
+        };
+        auto dstNewElement = dstNewBundle.getElementType(dstIndex);
+        auto dstOldElement = dstOldBundle.getElementType(dstIndex);
+        Value srcValue;
+        auto srcLazy = [&](ImplicitLocOpBuilder &builder) {
+          if (!srcValue)
+            srcValue = builder.create<SubfieldOp>(src(builder), srcIndex);
+          return srcValue;
+        };
+        auto srcNewElement = srcNewBundle.getElementType(srcIndex);
+        auto srcOldElement = srcOldBundle.getElementType(srcIndex);
+        if (!dstField.isFlip)
+          fixupPartialConnect(builder, dstLazy, dstNewElement, dstOldElement,
+                              srcLazy, srcNewElement, srcOldElement);
+        else
+          fixupPartialConnect(builder, srcLazy, srcNewElement, srcOldElement,
+                              dstLazy, dstNewElement, dstOldElement);
+      }
+      return;
+    }
+    // If its not a bundle type, just replace it with a partial connect.
+    builder.create<PartialConnectOp>(dst(builder), src(builder));
+  }
+
+  /// When we replace a bundle type with a similar bundle with different field
+  /// names, we have to rewrite all the code to use the new field names. This
+  /// mostly affects subfield result types and any bulk connects.
+  // NOLINTNEXTLINE(misc-no-recursion)
+  void fixupReferences(Value newValue, Type oldType) {
+    SmallVector<std::pair<Value, Type>> workList;
+    workList.emplace_back(newValue, oldType);
+    while (!workList.empty()) {
+      auto [newValue, oldType] = workList.pop_back_val();
+      auto newType = newValue.getType();
+      for (auto *op : llvm::make_early_inc_range(newValue.getUsers())) {
+        // If the two types are identical, we don't need to do anything.
+        if (oldType == newType)
+          continue;
+        if (auto subfield = dyn_cast<SubfieldOp>(op)) {
+          // Rewrite a subfield op to return the correct type.
+          auto index = subfield.fieldIndex();
+          auto newResultType = newType.cast<BundleType>().getElementType(index);
+          auto result = subfield.getResult();
+          workList.emplace_back(result, result.getType());
+          subfield.getResult().setType(newResultType);
+        } else if (auto partial = dyn_cast<PartialConnectOp>(op)) {
+          // Rewrite the partial connect to connect the same elements.
+          auto dstOldType = partial.dest().getType();
+          auto dstNewType = dstOldType;
+          auto srcOldType = partial.src().getType();
+          auto srcNewType = srcOldType;
+          // Check which side of the partial connect was updated.
+          if (newValue == partial.dest())
+            dstOldType = oldType;
+          else
+            srcOldType = oldType;
+          ImplicitLocOpBuilder builder(partial.getLoc(), partial);
+          fixupPartialConnect(
+              builder, [&](auto) { return partial.dest(); }, dstNewType,
+              dstOldType, [&](auto) { return partial.src(); }, srcNewType,
+              srcOldType);
+          partial->erase();
+        } else if (auto connect = dyn_cast<ConnectOp>(op)) {
+          // Rewrite the connect to connect all values.
+          auto dst = connect.dest();
+          auto src = connect.src();
+          ImplicitLocOpBuilder builder(connect.getLoc(), connect);
+          // Check which side of the connect was updated.
+          if (newValue == dst)
+            fixupConnect(builder, dst, oldType, src, src.getType());
+          else
+            fixupConnect(builder, dst, dst.getType(), src, oldType);
+          connect->erase();
+        }
+      }
+    }
+  }
+
+  /// This is the root method to fixup module references when a module changes.
+  /// It matches all the results of "to" module with the results of the "from"
+  /// module.
+  void fixupReferences(FModuleLike toModule, Operation *fromModule) {
+    // Replace all instances of the other module.
+    auto *fromNode = instanceGraph[fromModule];
+    auto *toNode = instanceGraph[toModule];
+    for (auto *oldInstRec : llvm::make_early_inc_range(fromNode->uses())) {
+      auto oldInst = oldInstRec->getInstance();
+      // Create an instance to replace the old module.
+      auto newInst = OpBuilder(oldInst).create<InstanceOp>(
+          oldInst.getLoc(), toModule, oldInst.nameAttr());
+      newInst.annotationsAttr(oldInst.annotationsAttr());
+      auto oldInnerSym = oldInst.inner_symAttr();
+      if (oldInnerSym)
+        newInst.inner_symAttr(oldInnerSym);
+
+      // We have to replaceAll before fixing up references, we walk the new
+      // usages when fixing up any references.
+      oldInst.replaceAllUsesWith(newInst.getResults());
+      oldInstRec->getParent()->addInstance(newInst, toNode);
+      //  Update bulk connections and subfield operations.
+      for (auto results :
+           llvm::zip(newInst.getResults(), oldInst.getResultTypes()))
+        fixupReferences(std::get<0>(results), std::get<1>(results));
+      oldInstRec->erase();
+      oldInst->erase();
+    }
+    instanceGraph.erase(fromNode);
+    fromModule->erase();
+  }
+
+  /// Private NLA creation method.  This function requires an attribute array
+  /// with a placeholder in the first element, where the root refence of the NLA
+  /// will be inserted. This clones the NLA for each instantiation of the
+  /// "fromModule".
+  SmallVector<FlatSymbolRefAttr>
+  createNLAsImpl(StringAttr toModuleName, AnnoTarget to, Operation *fromModule,
+                 SmallVectorImpl<Attribute> &namepath) {
+    auto loc = fromModule->getLoc();
+    SmallVector<FlatSymbolRefAttr> nlas;
+    for (auto *instanceRecord : instanceGraph[fromModule]->uses()) {
+      auto parent = cast<FModuleOp>(instanceRecord->getParent()->getModule());
+      auto inst = instanceRecord->getInstance();
+      namepath[0] = OpAnnoTarget(inst).getNLAReference(getNamespace(parent));
+      auto arrayAttr = ArrayAttr::get(context, namepath);
+      auto nla = OpBuilder::atBlockBegin(nlaBlock).create<NonLocalAnchor>(
+          loc, "nla", arrayAttr);
+      // Insert it into the symbol table to get a unique name.
+      symbolTable.insert(nla);
+      auto nlaName = nla.getNameAttr();
+      auto nlaRef = FlatSymbolRefAttr::get(nlaName);
+      nlas.push_back(nlaRef);
+      // Make sure we update the NLAMap if the toModule gets deduped later.
+      nlaMap[toModuleName].push_back(nla);
+      nlaMap[parent.getNameAttr()].push_back(nla);
+      targetMap[nlaName] = to;
+      // Update the instance breadcrumbs.
+      auto nonLocalClass = NamedAttribute(classString, nonLocalString);
+      auto dict = DictionaryAttr::get(
+          context, {{nonLocalString, nlaRef}, nonLocalClass});
+      // Add the breadcrumb on the first instance.
+      AnnotationSet instAnnos(inst);
+      instAnnos.addAnnotations(dict);
+      instAnnos.applyToOperation(inst);
+
+      // Set the breadcrumb on following instances. Ignore the first element
+      // which was already handled above, and the last element which does not
+      // need to be breadcrumbed.
+      for (auto attr : nla.namepath().getValue().drop_front().drop_back()) {
+        auto innerRef = attr.cast<InnerRefAttr>();
+        auto *node = instanceGraph.lookup(innerRef.getModule());
+        // Find the instance referenced by the NLA.
+        auto targetInstanceName = innerRef.getName();
+        auto it = llvm::find_if(*node, [&](InstanceRecord *record) {
+          return record->getInstance().inner_symAttr() == targetInstanceName;
+        });
+        assert(it != node->end() &&
+               "Instance referenced by NLA does not exist in module");
+        // Commit the annotation update.
+        auto inst = (*it)->getInstance();
+        AnnotationSet instAnnos(inst);
+        instAnnos.addAnnotations(dict);
+        instAnnos.applyToOperation(inst);
+      }
+    }
+    return nlas;
+  }
+
+  /// Look up the instantiations of the this module and create an NLA for each
+  /// one, appending the baseNamepath to each NLA. This is used to add more
+  /// context to an already existing NLA.
+  SmallVector<FlatSymbolRefAttr> createNLAs(FModuleLike toModule, AnnoTarget to,
+                                            FModuleLike fromModule,
+                                            ArrayRef<Attribute> baseNamepath) {
+    SmallVector<Attribute> namepath;
+    // Push an empty placeholder.
+    namepath.push_back(nullptr);
+    namepath.append(baseNamepath.begin(), baseNamepath.end());
+    return createNLAsImpl(toModule.moduleNameAttr(), to, fromModule, namepath);
+  }
+
+  /// Look up the instantiations of this module and create an NLA for each one.
+  /// This returns an array of symbol references which can be used to reference
+  /// the NLAs.
+  SmallVector<FlatSymbolRefAttr> createNLAs(FModuleLike toModule,
+                                            StringAttr toModuleName,
+                                            AnnoTarget to,
+                                            FModuleLike fromModule) {
+    SmallVector<Attribute, 2> namepath;
+    // Push an empty placeholder.
+    namepath.push_back(nullptr);
+    namepath.push_back(to.getNLAReference(getNamespace(toModule)));
+    return createNLAsImpl(toModuleName, to, fromModule, namepath);
+  }
+
+  /// Clone the annotation for each NLA in a list.
+  void cloneAnnotation(SmallVector<FlatSymbolRefAttr> &nlas, Annotation anno,
+                       ArrayRef<NamedAttribute> attributes,
+                       unsigned nonLocalIndex,
+                       SmallVector<Annotation> &newAnnotations) {
+    SmallVector<NamedAttribute> mutableAttributes(attributes.begin(),
+                                                  attributes.end());
+    for (auto &nla : nlas) {
+      // Add the new annotation.
+      mutableAttributes[nonLocalIndex].setValue(nla);
+      auto dict = DictionaryAttr::getWithSorted(context, mutableAttributes);
+      anno.setDict(dict);
+      newAnnotations.push_back(anno);
+    }
+  }
+
+  /// This finds all NLAs which contain the "from" module, and renames any
+  /// reference to the "to" module.
+  void renameModuleInNLA(DenseMap<StringAttr, StringAttr> &renameMap,
+                         StringAttr toName, StringAttr fromName,
+                         NonLocalAnchor nla) {
+    auto fromRef = FlatSymbolRefAttr::get(fromName);
+    SmallVector<Attribute> namepath;
+    for (auto element : nla.namepath().getValue()) {
+      if (auto innerRef = element.dyn_cast<InnerRefAttr>()) {
+        if (innerRef.getModule() == fromName) {
+          auto to = renameMap[innerRef.getName()];
+          assert(to && "should have been renamed");
+          namepath.push_back(
+              InnerRefAttr::get(toName, renameMap[innerRef.getName()]));
+        } else
+          namepath.push_back(element);
+      } else if (element == fromRef) {
+        namepath.push_back(FlatSymbolRefAttr::get(toName));
+      } else {
+        namepath.push_back(element);
+      }
+    }
+    nla.namepathAttr(ArrayAttr::get(context, namepath));
+  }
+
+  /// This erases the NLA op, all breadcrumb trails, and removes the NLA from
+  /// every module's NLA map, but it does not delete it the NLA reference from
+  /// the target operation's annotations.
+  void eraseNLA(NonLocalAnchor nla) {
+    auto nlaRef = FlatSymbolRefAttr::get(nla.getNameAttr());
+    auto nonLocalClass = NamedAttribute(classString, nonLocalString);
+    auto dict =
+        DictionaryAttr::get(context, {{nonLocalString, nlaRef}, nonLocalClass});
+    auto namepath = nla.namepath().getValue();
+    for (auto attr : namepath.drop_back()) {
+      auto innerRef = attr.cast<InnerRefAttr>();
+      auto moduleName = innerRef.getModule();
+      llvm::erase_value(nlaMap[moduleName], nla);
+      // Find the instance referenced by the NLA.
+      auto *node = instanceGraph.lookup(moduleName);
+      auto targetInstanceName = innerRef.getName();
+      auto it = llvm::find_if(*node, [&](InstanceRecord *record) {
+        return record->getInstance().inner_symAttr() == targetInstanceName;
+      });
+      assert(it != node->end() &&
+             "Instance referenced by NLA does not exist in module");
+      // Commit the annotation update.
+      auto inst = (*it)->getInstance();
+      AnnotationSet instAnnos(inst);
+      instAnnos.removeAnnotation(dict);
+      instAnnos.applyToOperation(inst);
+    }
+    // Erase the NLA from the leaf module's nlaMap.
+    auto back = namepath.back();
+    if (auto ref = back.dyn_cast<InnerRefAttr>())
+      llvm::erase_value(nlaMap[ref.getModule()], nla);
+    else
+      llvm::erase_value(nlaMap[back.cast<FlatSymbolRefAttr>().getAttr()], nla);
+    targetMap.erase(nla.getNameAttr());
+    nla->erase();
+  }
+
+  /// Add additional context to a single annotation.
+  void addAnnotationContext(DenseMap<StringAttr, StringAttr> &renameMap,
+                            FModuleOp toModule, FModuleOp fromModule,
+                            SmallVectorImpl<Attribute> anno,
+                            ArrayRef<Attribute> baseNamepath) {}
+
+  /// Process all NLAs referencing the "from" module to point to the "to"
+  /// module. This is used after merging two modules together.
+  void addAnnotationContext(DenseMap<StringAttr, StringAttr> &renameMap,
+                            FModuleOp toModule, FModuleOp fromModule) {
+    auto toName = toModule.getNameAttr();
+    auto fromName = fromModule.getNameAttr();
+    // Create a copy of the current NLAs. We will be pushing and removing
+    // NLAs from this op as we go.
+    auto nlas = nlaMap[fromModule.getNameAttr()];
+    for (auto nla : nlas) {
+      // Change the NLA to target the toModule.
+      if (toModule != fromModule)
+        renameModuleInNLA(renameMap, toName, fromName, nla);
+      auto elements = nla.namepath().getValue();
+      // If we don't need to add more context, we're done here.
+      if (elements[0].cast<InnerRefAttr>().getModule() != toName)
+        continue;
+      // We need to clone the annotation for each new NLA.
+      auto target = targetMap[nla.sym_nameAttr()];
+      assert(target && "Target of NLA never encountered.  All modules should "
+                       "be reachable from the top module.");
+      SmallVector<Attribute> namepath(elements.begin(), elements.end());
+      SmallVector<Annotation> newAnnotations;
+      auto nlas = createNLAs(toModule, target, fromModule, namepath);
+      for (auto anno : target.getAnnotations()) {
+        // Find the non-local field of the annotation.
+        auto [it, found] = mlir::impl::findAttrSorted(anno.begin(), anno.end(),
+                                                      nonLocalString);
+        if (!found || it->getValue().cast<FlatSymbolRefAttr>().getAttr() !=
+                          nla.sym_nameAttr()) {
+          newAnnotations.push_back(anno);
+          continue;
+        }
+        auto nonLocalIndex = std::distance(anno.begin(), it);
+        // We have to clone all the annotations referencing this op
+        // SmallVector<NamedAttribute> attributes(anno.begin(), anno.end());
+        cloneAnnotation(nlas, anno, ArrayRef(anno.begin(), anno.end()),
+                        nonLocalIndex, newAnnotations);
+      }
+      AnnotationSet annotations(newAnnotations, context);
+      target.setAnnotations(annotations);
+
+      // Erase the old NLA and remove it from all breadcrumbs.
+      eraseNLA(nla);
+    }
+  }
+
+  /// Process all the NLAs that the two modules participate in, replacing
+  /// references to the "from" module with references to the "to" module, and
+  /// adding more context if necessary.
+  void rewriteModuleNLAs(DenseMap<StringAttr, StringAttr> &renameMap,
+                         FModuleOp toModule, FModuleOp fromModule) {
+    addAnnotationContext(renameMap, toModule, toModule);
+    addAnnotationContext(renameMap, toModule, fromModule);
+  }
+
+  // Update all NLAs which the "from" external module participates in to the
+  // "toName".
+  void rewriteExtModuleNLAs(StringAttr toName, StringAttr fromName) {
+    for (auto nla : nlaMap[fromName]) {
+      SmallVector<Attribute> namepath;
+      // External modules are guaranteed to be the final element of the NLA,
+      // since they do not have any bodies.
+      llvm::copy(nla.namepath().getValue().drop_back(),
+                 std::back_inserter(namepath));
+      namepath.push_back(FlatSymbolRefAttr::get(toName));
+      nla.namepathAttr(ArrayAttr::get(context, namepath));
+    }
+  }
+
+  /// Take an annotation, and update it to be a non-local annotation.  If the
+  /// annotation is already non-local and has enough context, it will be skipped
+  /// for now.
+  void makeAnnotationNonLocal(SmallVector<FlatSymbolRefAttr> &nlas,
+                              FModuleLike toModule, StringAttr toModuleName,
+                              AnnoTarget to, FModuleLike fromModule,
+                              AnnoTarget from, Annotation anno,
+                              SmallVector<Annotation> &newAnnotations) {
+    // Start constructing a new annotation, pushing a "circt.nonLocal" field
+    // into the correct spot if its not already a non-local annotation.
+    SmallVector<NamedAttribute> attributes;
+    int nonLocalIndex = -1;
+    for (auto val : llvm::enumerate(anno)) {
+      auto attr = val.value();
+      // Is this field "circt.nonlocal"?
+      auto compare = attr.getName().compare(nonLocalString);
+      if (compare == 0) {
+        // This annotation is already a non-local annotation. Record that this
+        // operation uses that NLA and stop processing this annotation.
+        auto nlaName = attr.getValue().cast<FlatSymbolRefAttr>().getAttr();
+        targetMap[nlaName] = from;
+        newAnnotations.push_back(anno);
+        return;
+      }
+      if (compare == 1) {
+        // Push an empty place holder for the non-local annotation.
+        nonLocalIndex = val.index();
+        attributes.push_back(NamedAttribute(nonLocalString, nonLocalString));
+        break;
+      }
+      attributes.push_back(attr);
+    }
+    if (nonLocalIndex == -1) {
+      // Push the "circt.nonlocal" to the last slot.
+      nonLocalIndex = attributes.size();
+      attributes.push_back(NamedAttribute(nonLocalString, nonLocalString));
+    } else {
+      // Copy the remaining annotation fields in.
+      attributes.append(anno.begin() + nonLocalIndex, anno.end());
+    }
+
+    // Construct the NLAs if we don't have any yet.
+    if (nlas.empty())
+      nlas = createNLAs(toModule, toModuleName, to, fromModule);
+
+    // Clone the annotation for each new NLA.
+    cloneAnnotation(nlas, anno, attributes, nonLocalIndex, newAnnotations);
+  }
+
+  /// Merge the annotations of a specific target, either a operation or a port
+  /// on an operation.
+  void mergeAnnotations(FModuleLike toModule, AnnoTarget to,
+                        AnnotationSet toAnnos, FModuleLike fromModule,
+                        AnnoTarget from, AnnotationSet fromAnnos) {
+    // We want to make sure all NLAs are put right above the first module.
+    SmallVector<Annotation> newAnnotations;
+    SmallVector<unsigned> alreadyHandled;
+    // This is a lazily constructed set of NLAs used to turn a local
+    // annotation into non-local annotations.
+    SmallVector<FlatSymbolRefAttr> fromNLAs;
+    for (auto anno : fromAnnos) {
+      // If this is a breadcrumb, copy it over with no changes.
+      if (anno.getClassAttr() == nonLocalString) {
+        newAnnotations.push_back(anno);
+        continue;
+      }
+
+      // If the ops have the same annotation, we don't have to turn it into a
+      // non-local annotation.
+      auto found = llvm::find(toAnnos, anno);
+      if (found != toAnnos.end()) {
+        alreadyHandled.push_back(std::distance(toAnnos.begin(), found));
+        newAnnotations.push_back(anno);
+        continue;
+      }
+      makeAnnotationNonLocal(fromNLAs, toModule, toModule.moduleNameAttr(), to,
+                             fromModule, from, anno, newAnnotations);
+    }
+
+    // This is a helper to skip already handled annotations.
+    auto *it = alreadyHandled.begin();
+    auto *end = alreadyHandled.end();
+    auto getNextHandledIndex = [&]() -> unsigned {
+      if (it == end)
+        return -1;
+      return *(it++);
+    };
+    auto index = getNextHandledIndex();
+
+    // Merge annotations from the other op, skipping the ones already handled.
+    SmallVector<FlatSymbolRefAttr> toNLAs;
+    for (auto pair : llvm::enumerate(toAnnos)) {
+      // If its already handled, skip it.
+      if (pair.index() == index) {
+        index = getNextHandledIndex();
+        continue;
+      }
+      // If this is a breadcrumb, copy it over with no changes.
+      auto anno = pair.value();
+      if (anno.getClassAttr() == nonLocalString) {
+        newAnnotations.push_back(anno);
+        continue;
+      }
+      makeAnnotationNonLocal(toNLAs, toModule, toModule.moduleNameAttr(), to,
+                             toModule, to, anno, newAnnotations);
+    }
+
+    // Copy over all the new annotations.
+    if (!newAnnotations.empty())
+      to.setAnnotations(AnnotationSet(newAnnotations, context));
+  }
+
+  /// Merge all annotations and port annotations on two operations.
+  void mergeAnnotations(FModuleLike toModule, Operation *to,
+                        FModuleLike fromModule, Operation *from) {
+    // Merge op annotations.
+    mergeAnnotations(toModule, OpAnnoTarget(to), AnnotationSet(to), fromModule,
+                     OpAnnoTarget(to), AnnotationSet(from));
+
+    // Merge port annotations.
+    if (toModule == to) {
+      // Merge module port annotations.
+      for (unsigned i = 0, e = toModule.getNumPorts(); i < e; ++i)
+        mergeAnnotations(toModule, PortAnnoTarget(toModule, i),
+                         AnnotationSet::forPort(toModule, i), fromModule,
+                         PortAnnoTarget(fromModule, i),
+                         AnnotationSet::forPort(fromModule, i));
+    } else if (auto toMem = dyn_cast<MemOp>(to)) {
+      // Merge memory port annotations.
+      auto fromMem = cast<MemOp>(from);
+      for (unsigned i = 0, e = toMem.getNumResults(); i < e; ++i)
+        mergeAnnotations(toModule, PortAnnoTarget(toMem, i),
+                         AnnotationSet::forPort(toMem, i), fromModule,
+                         PortAnnoTarget(fromMem, i),
+                         AnnotationSet::forPort(fromMem, i));
+    }
+  }
+
+  // Record the symbol name change of the operation or any of its ports when
+  // merging two operations.  The renamed symbols are used to update the
+  // target of any NLAs.  This will add symbols to the "to" operation if needed.
+  void recordSymRenames(DenseMap<StringAttr, StringAttr> &renameMap,
+                        FModuleLike toModule, Operation *to,
+                        FModuleLike fromModule, Operation *from) {
+    // If the "from" operation has an inner_sym, we need to make sure the
+    // "to" operation also has an `inner_sym` and then record the renaming.
+    if (auto fromSym = from->getAttrOfType<StringAttr>("inner_sym")) {
+      auto toSym = OpAnnoTarget(to).getInnerSym(getNamespace(toModule));
+      renameMap[fromSym] = toSym;
+    }
+
+    // If there are no port symbols on the "from" operation, we are done here.
+    auto fromPortSyms = from->getAttrOfType<ArrayAttr>("portSyms");
+    if (!fromPortSyms || fromPortSyms.empty())
+      return;
+    // We have to map each "fromPort" to each "toPort".
+    auto &moduleNamespace = getNamespace(toModule);
+    auto portCount = fromPortSyms.size();
+    auto portNames = to->getAttrOfType<ArrayAttr>("portNames");
+    auto toPortSyms = to->getAttrOfType<ArrayAttr>("portSyms");
+
+    // Create an array of new port symbols for the "to" operation, copy in the
+    // old symbols if it has any, create an empty symbol array if it doesn't.
+    SmallVector<Attribute> newPortSyms;
+    auto emptyString = StringAttr::get(context, "");
+    if (toPortSyms.empty())
+      newPortSyms.assign(portCount, emptyString);
+    else
+      newPortSyms.assign(toPortSyms.begin(), toPortSyms.end());
+
+    for (unsigned portNo = 0; portNo < portCount; ++portNo) {
+      // If this fromPort doesn't have a symbol, move on to the next one.
+      auto fromSym = fromPortSyms[portNo].cast<StringAttr>();
+      if (fromSym.getValue().empty())
+        continue;
+
+      // If this toPort doesn't have a symbol, assign one.
+      auto toSym = newPortSyms[portNo].cast<StringAttr>();
+      if (toSym == emptyString) {
+        // Get a reasonable base name for the port.
+        StringRef symName = "inner_sym";
+        if (portNames)
+          symName = portNames[portNo].cast<StringAttr>().getValue();
+        // Create the symbol and store it into the array.
+        toSym = StringAttr::get(context, moduleNamespace.newName(symName));
+        newPortSyms[portNo] = toSym;
+      }
+
+      // Record the renaming.
+      renameMap[fromSym] = toSym;
+    }
+
+    // Commit the new symbol attribute.
+    to->setAttr("portSyms", ArrayAttr::get(context, newPortSyms));
+  }
+
+  /// Recursively merge two operations.
+  // NOLINTNEXTLINE(misc-no-recursion)
+  void mergeOps(DenseMap<StringAttr, StringAttr> &renameMap,
+                FModuleLike toModule, Operation *to, FModuleLike fromModule,
+                Operation *from) {
+
+    // Recurse into any regions.
+    for (auto regions : llvm::zip(to->getRegions(), from->getRegions()))
+      mergeRegions(renameMap, toModule, std::get<0>(regions), fromModule,
+                   std::get<1>(regions));
+
+    // Record any inner_sym renamings that happened.
+    if (to != from)
+      recordSymRenames(renameMap, toModule, to, fromModule, from);
+
+    // Merge the annotations.
+    mergeAnnotations(toModule, to, fromModule, from);
+  }
+
+  /// Recursively merge two blocks.
+  void mergeBlocks(DenseMap<StringAttr, StringAttr> &renameMap,
+                   FModuleLike toModule, Block &toBlock, FModuleLike fromModule,
+                   Block &fromBlock) {
+    for (auto ops : llvm::zip(toBlock, fromBlock))
+      mergeOps(renameMap, toModule, &std::get<0>(ops), fromModule,
+               &std::get<1>(ops));
+  }
+
+  // Recursively merge two regions.
+  void mergeRegions(DenseMap<StringAttr, StringAttr> &renameMap,
+                    FModuleLike toModule, Region &toRegion,
+                    FModuleLike fromModule, Region &fromRegion) {
+    for (auto blocks : llvm::zip(toRegion, fromRegion))
+      mergeBlocks(renameMap, toModule, std::get<0>(blocks), fromModule,
+                  std::get<1>(blocks));
+  }
+
+  MLIRContext *context;
+  InstanceGraph &instanceGraph;
+  SymbolTable &symbolTable;
+
+  // This maps a module name to all NLAs it participates in. This is used to
+  // fixup any NLAs when a module is deduped.
+  NLAMap &nlaMap;
+
+  /// We insert all NLAs to the beginning of this block.
+  Block *nlaBlock;
+
+  // This maps an NLA to the operation or port that uses it. Since NLAs include
+  // the name of the leaf element, its only possible for the NLA to be used by a
+  // single op or port.
+  DenseMap<Attribute, AnnoTarget> targetMap;
+
+  // Cached attributes for faster comparisons and attribute building.
+  StringAttr nonLocalString;
+  StringAttr classString;
+
+  /// A module namespace cache.
+  DenseMap<Operation *, ModuleNamespace> moduleNamespaces;
+};
+
+//===----------------------------------------------------------------------===//
+// DedupPass
+//===----------------------------------------------------------------------===//
+
+namespace {
+class DedupPass : public DedupBase<DedupPass> {
+  void runOnOperation() override {
+    auto *context = &getContext();
+    auto circuit = getOperation();
+    auto &instanceGraph = getAnalysis<InstanceGraph>();
+    SymbolTable symbolTable(circuit);
+    NLAMap nlaMap = createNLAMap(circuit);
+    Deduper deduper(instanceGraph, symbolTable, nlaMap, circuit);
+    StructuralHasher hasher(&getContext());
+    auto anythingChanged = false;
+
+    // Modules annotated with this should not be considered for deduplication.
+    auto noDedupClass =
+        StringAttr::get(context, "firrtl.transforms.NoDedupAnnotation");
+
+    // A map of all the module hashes that we have calculated so far.
+    llvm::StringMap<Operation *> moduleHashes;
+
+    // We must iterate the modules from the bottom up so that we can properly
+    // deduplicate the modules. We have to store the visit order first so that
+    // we can safely delete nodes as we go from the instance graph.
+    for (auto *node : llvm::post_order(&instanceGraph)) {
+      auto module = cast<FModuleLike>(node->getModule());
+      // If the module is marked with NoDedup, just skip it.
+      if (AnnotationSet(module).hasAnnotation(noDedupClass))
+        continue;
+      // Calculate the hash of the module.
+      auto h = hasher.hash(module);
+      // Check if there a module with the same hash.
+      auto it = moduleHashes.find(h);
+      if (it != moduleHashes.end()) {
+        deduper.dedup(it->second, module);
+        erasedModules++;
+        anythingChanged = true;
+        continue;
+      }
+
+      // Any module not deduplicated must be recorded.
+      deduper.record(module);
+
+      // TODO: if the module is marked must dedup, error here.
+
+      // Record the module's hash if it has not been removed.
+      moduleHashes[h] = module;
+    }
+
+    if (!anythingChanged)
+      markAllAnalysesPreserved();
+  }
+};
+} // end anonymous namespace
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createDedupPass() {
+  return std::make_unique<DedupPass>();
+}

--- a/test/Dialect/FIRRTL/SFCTests/dedup-errors.fir
+++ b/test/Dialect/FIRRTL/SFCTests/dedup-errors.fir
@@ -38,33 +38,6 @@ circuit Top : %[[
 
 ; CHECK-NOT: firrtl.module @A_
 
-; // -----
-; "Modules with aggregate ports that are (partial)? connected should NOT dedup if
-; their port names differ".
-;
-; Note: it is reasonable for dedup to expand and update the connects/partial
-; connects that are changed by this process.  This needs to do this in a
-; flow-correct manner.
-;
-; CHECK-LABEL: firrtl.circuit "FooAndBarModule"
-circuit FooAndBarModule :
-  ; CHECK: firrtl.module @FooModule
-  module FooModule :
-    output io : {flip foo : UInt<1>, fuzz : UInt<1>}
-    io.fuzz <= io.foo
-  ; CHECK: firrtl.module @BarModule
-  module BarModule :
-    output io : {flip bar : UInt<1>, buzz : UInt<1>}
-    io.buzz <= io.bar
-  ; CHECK: firrtl.module @FooAndBarModule
-  module FooAndBarModule :
-    output io : {foo : {flip foo : UInt<1>, fuzz : UInt<1>}, bar : {flip bar : UInt<1>, buzz : UInt<1>}}
-    ; CHECK-NEXT: firrtl.instance foo @FooModule
-    ; CHECK-NEXT: firrtl.instance bar @BarModule
-    inst foo of FooModule
-    inst bar of BarModule
-    io.foo <- foo.io
-    io.bar <= bar.io
 
 ; // -----
 ; "The module A and A_ should dedup with different annotation targets."

--- a/test/Dialect/FIRRTL/SFCTests/dedup.fir
+++ b/test/Dialect/FIRRTL/SFCTests/dedup.fir
@@ -1,4 +1,4 @@
-; RUN: firtool -split-input-file -ir-fir -lower-types=0 -imconstprop=0 %s | FileCheck %s
+; RUN: firtool -dedup -split-input-file -ir-fir -lower-types=0 -imconstprop=0 %s | FileCheck %s
 ; Tests extracted from:
 ;   - test/scala/firrtlTests/transforms/DedupTests.scala
 ; The following tests are not included:

--- a/test/Dialect/FIRRTL/SFCTests/dedup.fir
+++ b/test/Dialect/FIRRTL/SFCTests/dedup.fir
@@ -1,5 +1,4 @@
 ; RUN: firtool -split-input-file -ir-fir -lower-types=0 -imconstprop=0 %s | FileCheck %s
-; XFAIL: *
 ; Tests extracted from:
 ;   - test/scala/firrtlTests/transforms/DedupTests.scala
 ; The following tests are not included:
@@ -210,6 +209,33 @@ circuit Top :
     parameter N = 1
 
 ; // -----
+; "Modules with aggregate ports that are (partial)? connected should NOT dedup if
+; their port names differ".
+;
+; Since the MFC support expanding connects and partial connects when the port
+; names differ, this now testing that the modules succesfully dedup.
+;
+; CHECK-LABEL: firrtl.circuit "FooAndBarModule"
+circuit FooAndBarModule :
+  ; CHECK: firrtl.module @FooModule
+  module FooModule :
+    output io : {flip foo : UInt<1>, fuzz : UInt<1>}
+    io.fuzz <= io.foo
+  ; CHECK-NOT: firrtl.module @BarModule
+  module BarModule :
+    output io : {flip bar : UInt<1>, buzz : UInt<1>}
+    io.buzz <= io.bar
+  ; CHECK: firrtl.module @FooAndBarModule
+  module FooAndBarModule :
+    output io : {foo : {flip foo : UInt<1>, fuzz : UInt<1>}, bar : {flip bar : UInt<1>, buzz : UInt<1>}}
+    ; CHECK: firrtl.instance foo @FooModule
+    ; CHECK: firrtl.instance bar @FooModule
+    inst foo of FooModule
+    inst bar of BarModule
+    io.foo <- foo.io
+    io.bar <= bar.io
+
+; // -----
 ; "Modules with aggregate ports that are (partial)? connected should dedup if
 ; their port names are the same".
 ;
@@ -293,13 +319,13 @@ circuit Top : %[[
     "target":"Top.A.b"
   }
 ]]
+  ; CHECK: firrtl.nla @[[nlaSym:[_a-zA-Z0-9]+]] [#hw.innerNameRef<@Top::@[[a1Sym:[_a-zA-Z0-9]+]]>, #hw.innerNameRef<@A::@[[bSym:[_a-zA-Z0-9]+]]>]
   ; CHECK: firrtl.module @Top
-  ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym:[_a-zA-Z0-9]+]] {annotations = [{circt.nonlocal = @[[nlaSym:[_a-zA-Z0-9]+]], class = "circt.nonlocal"}]} @A(
+  ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] {annotations = [{circt.nonlocal = @[[nlaSym]], class = "circt.nonlocal"}]} @A(
   ; CHECK-NEXT: firrtl.instance a2 @A(
   module Top :
     inst a1 of A
     inst a2 of A_
-  ; CHECK: firrtl.nla @[[nlaSym]] [#hw.innerNameRef<@Top::@[[a1Sym]]>, #hw.innerNameRef<@A::@[[bSym:[_a-zA-Z0-9]+]]>]
   module A :
     output x: UInt<1>
     ; CHECk-NEXT: firrtl.wire sym @[[bSym]] {annotations = [{circt.nonlocal = @[[nlaSym]], class = "hello"}]}
@@ -328,14 +354,14 @@ circuit Top : %[[
     "target":"~Top|A_>b"
   }
 ]]
+  ; CHECK: firrtl.nla @[[nlaSym1:[_a-zA-Z0-9]+]] [#hw.innerNameRef<@Top::@[[a1Sym:[_a-zA-Z0-9]+]]>, #hw.innerNameRef<@A::@[[bSym:[_a-zA-Z0-9]+]]>]
+  ; CHECK: firrtl.nla @[[nlaSym2:[_a-zA-Z0-9]+]] [#hw.innerNameRef<@Top::@[[a2Sym:[_a-zA-Z0-9]+]]>, #hw.innerNameRef<@A::@[[bSym]]>]
   ; CHECK: firrtl.module @Top
-  ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym:[_a-zA-Z0-9]+]] {annotations = [{circt.nonlocal = @[[nlaSym1:[_a-zA-Z0-9]+]], class = "circt.nonlocal"}]} @A(
-  ; CHECK-NEXT: firrtl.instance a2 sym @[[a2Sym:[_a-zA-Z0-9]+]] {annotations = [{circt.nonlocal = @[[nlaSym2:[_a-zA-Z0-9]+]], class = "circt.nonlocal"}]} @A(
+  ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] {annotations = [{circt.nonlocal = @[[nlaSym1]], class = "circt.nonlocal"}]} @A(
+  ; CHECK-NEXT: firrtl.instance a2 sym @[[a2Sym]] {annotations = [{circt.nonlocal = @[[nlaSym2]], class = "circt.nonlocal"}]} @A(
   module Top :
     inst a1 of A
     inst a2 of A_
-  ; CHECK: firrtl.nla @[[nlaSym2]] [#hw.innerNameRef<@Top::@[[a2Sym]]>, #hw.innerNameRef<@A::@[[bSym]]>]
-  ; CHECK: firrtl.nla @[[nlaSym1]] [#hw.innerNameRef<@Top::@[[a1Sym]]>, #hw.innerNameRef<@A::@[[bSym:[_a-zA-Z0-9]+]]>]
   module A :
     output x: UInt<1>
     ; CHECk-NEXT: firrtl.wire sym @[[bSym]] {annotations = [{circt.nonlocal = @[[nlaSym1]], class = "world"}, {circt.nonlocal = @[[nlaSym2]], class = "hello"}]}
@@ -591,11 +617,11 @@ circuit Top : %[[
   },
   {
     "class":"nla3",
-    "target":"~Top|Top/a1:A/b_:B"
+    "target":"~Top|Top/a1:A/b_:B_"
   },
   {
     "class":"nla4",
-    "target":"~Top|Top/a2:A/b_:B"
+    "target":"~Top|Top/a2:A/b_:B_"
   },
   {
     "class":"nla5",
@@ -611,15 +637,15 @@ circuit Top : %[[
   },
   {
     "class":"nla8",
-    "target":"~Top|Top/b_:B/c:C"
+    "target":"~Top|Top/b_:B_/c:C"
   },
   {
     "class":"nla9",
-    "target":"~Top|Top/a1:A/b_:B/c:C"
+    "target":"~Top|Top/a1:A/b_:B_/c:C"
   },
   {
     "class":"nla10",
-    "target":"~Top|Top/a2:A/b_:B/c:C"
+    "target":"~Top|Top/a2:A/b_:B_/c:C"
   },
   {
     "class":"nla11",
@@ -726,17 +752,17 @@ circuit Top : %[[
 
   ; CHECK:        firrtl.module @B()
   ; CHECK-SAME:     [{circt.nonlocal = @[[nla_2]], class = "nla2"},
-  ; CHECK-SAME:      {circt.nonlocal = @[[nla_1]], class = "nla1"},
   ; CHECK-SAME:      {circt.nonlocal = @[[nla_3]], class = "nla3"},
   ; CHECK-SAME:      {circt.nonlocal = @[[nla_4]], class = "nla4"},
+  ; CHECK-SAME:      {circt.nonlocal = @[[nla_1]], class = "nla1"},
   ; CHECK-SAME:      {circt.nonlocal = @[[nla_5]], class = "nla5"},
   ; CHECK-SAME:      {circt.nonlocal = @[[nla_6]], class = "nla6"}]
   module B :
     ; CHECK-NEXT:   firrtl.instance c sym @[[BcSym]]
-    ; CHECK-SAME:     [{circt.nonlocal = @[[nla_7]], class = "circt.nonlocal"},
-    ; CHECK-SAME:      {circt.nonlocal = @[[nla_8]], class = "circt.nonlocal"},
+    ; CHECK-SAME:     [{circt.nonlocal = @[[nla_8]], class = "circt.nonlocal"},
     ; CHECK-SAME:      {circt.nonlocal = @[[nla_9]], class = "circt.nonlocal"},
     ; CHECK-SAME:      {circt.nonlocal = @[[nla_10]], class = "circt.nonlocal"},
+    ; CHECK-SAME:      {circt.nonlocal = @[[nla_7]], class = "circt.nonlocal"},
     ; CHECK-SAME:      {circt.nonlocal = @[[nla_11]], class = "circt.nonlocal"},
     ; CHECK-SAME:      {circt.nonlocal = @[[nla_12]], class = "circt.nonlocal"}]
     ; CHECK-SAME:     @C()
@@ -775,33 +801,32 @@ circuit top : %[[
     "target":"~top|b>q.a"
   }
 ]]
+  ; CHECK:      firrtl.nla @[[nla_1:[_a-zA-Z0-9]+]]
+  ; CHECK-SAME:   [#hw.innerNameRef<@top::@[[topaSym:[_a-zA-Z0-9]+]]>,
+  ; CHECK-SAME:    #hw.innerNameRef<@a::@[[aiSym:[_a-zA-Z0-9]+]]>
+  ; CHECK:      firrtl.nla @[[nla_2:[_a-zA-Z0-9]+]]
+  ; CHECK-SAME:   [#hw.innerNameRef<@top::@[[topbSym:[_a-zA-Z0-9]+]]>,
+  ; CHECK-SAME:    #hw.innerNameRef<@a::@[[aiSym]]>
   ; CHECK: firrtl.module @top
   module top:
     input ia: {z: {y: {x: UInt<1>}}, a: UInt<1>}
     input ib: {a: {b: {c: UInt<1>}}, z: UInt<1>}
     output oa: {z: {y: {x: UInt<1>}}, a: UInt<1>}
     output ob: {a: {b: {c: UInt<1>}}, z: UInt<1>}
-    ; CHECK:      firrtl.instance a sym @[[topaSym:[_a-zA-Z0-9]+]]
-    ; CHECK-SAME:   [{circt.nonlocal = @[[nla_1:[_a-zA-Z0-9]+]], class = "circt.nonlocal"}]
+    ; CHECK:      firrtl.instance a sym @[[topaSym]]
+    ; CHECK-SAME:   [{circt.nonlocal = @[[nla_1]], class = "circt.nonlocal"}]
     inst a of a
     a.i.z.y.x <= ia.z.y.x
     a.i.a <= ia.a
     oa.z.y.x <= a.o.z.y.x
     oa.a <= a.o.a
-    ; CHECK:      firrtl.instance b sym @[[topbSym:[_a-zA-Z0-9]+]]
-    ; CHECK-SAME:   [{circt.nonlocal = @[[nla_2:[_a-zA-Z0-9]+]], class = "circt.nonlocal"}
+    ; CHECK:      firrtl.instance b sym @[[topbSym]]
+    ; CHECK-SAME:   [{circt.nonlocal = @[[nla_2]], class = "circt.nonlocal"}
     inst b of b
     b.q.a.b.c <= ib.a.b.c
     b.q.z <= ib.z
     ob.a.b.c <= b.r.a.b.c
     ob.z <= b.r.z
-
-  ; CHECK:      firrtl.nla @[[nla_2]]
-  ; CHECK-SAME:   [#hw.innerNameRef<@top::@[[topbSym]]>,
-  ; CHECK-SAME:    #hw.innerNameRef<@a::@[[aiSym:[_a-zA-Z0-9]+]]>
-  ; CHECK:      firrtl.nla @[[nla_1]]
-  ; CHECK-SAME:   [#hw.innerNameRef<@top::@[[topaSym]]>,
-  ; CHECK-SAME:    #hw.innerNameRef<@a::@[[aiSym]]>
 
   ; CHECK:      firrtl.module @a(
   ; CHECK-SAME:   in %i: {{.+}} sym @[[aiSym]]

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -1,0 +1,411 @@
+// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-dedup)' %s | FileCheck %s
+
+// CHECK-LABEL: firrtl.circuit "Empty"
+firrtl.circuit "Empty" {
+  // CHECK: firrtl.module @Empty0
+  firrtl.module @Empty0(in %i0: !firrtl.uint<1>) { }
+  // CHECK-NOT: firrtl.module @Empty1
+  firrtl.module @Empty1(in %i1: !firrtl.uint<1>) { }
+  // CHECK-NOT: firrtl.module @Empty2
+  firrtl.module @Empty2(in %i2: !firrtl.uint<1>) { }
+  firrtl.module @Empty() {
+    // CHECK: %e0_i0 = firrtl.instance e0  @Empty0
+    // CHECK: %e1_i0 = firrtl.instance e1  @Empty0
+    // CHECK: %e2_i0 = firrtl.instance e2  @Empty0
+    %e0_i0 = firrtl.instance e0 @Empty0(in i0: !firrtl.uint<1>)
+    %e1_i1 = firrtl.instance e1 @Empty1(in i1: !firrtl.uint<1>)
+    %e2_i2 = firrtl.instance e2 @Empty2(in i2: !firrtl.uint<1>)
+  }
+}
+
+
+// CHECK-LABEL: firrtl.circuit "Simple"
+firrtl.circuit "Simple" {
+  // CHECK: firrtl.module @Simple0
+  firrtl.module @Simple0() {
+    %a = firrtl.wire: !firrtl.bundle<a: uint<1>>
+  }
+  // CHECK-NOT: firrtl.module @Simple1
+  firrtl.module @Simple1() {
+    %b = firrtl.wire: !firrtl.bundle<b: uint<1>>
+  }
+  firrtl.module @Simple() {
+    // CHECK: firrtl.instance simple0 @Simple0
+    // CHECK: firrtl.instance simple1 @Simple0
+    firrtl.instance simple0 @Simple0()
+    firrtl.instance simple1 @Simple1()
+  }
+}
+
+
+// CHECK-LABEL: firrtl.circuit "PrimOps"
+firrtl.circuit "PrimOps" {
+  // CHECK: firrtl.module @PrimOps0
+  firrtl.module @PrimOps0(in %a: !firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>) {
+    %a_a = firrtl.subfield %a(0): (!firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>) -> !firrtl.uint<2>
+    %a_b = firrtl.subfield %a(1): (!firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>) -> !firrtl.uint<2>
+    %a_c = firrtl.subfield %a(2): (!firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>) -> !firrtl.uint<2>
+    %0 = firrtl.xor %a_a, %a_b: (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
+    firrtl.connect %a_c, %a_b: !firrtl.uint<2>, !firrtl.uint<2>
+  }
+  // CHECK-NOT: firrtl.module @PrimOps1
+  firrtl.module @PrimOps1(in %b: !firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>) {
+    %b_a = firrtl.subfield %b(0): (!firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>) -> !firrtl.uint<2>
+    %b_b = firrtl.subfield %b(1): (!firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>) -> !firrtl.uint<2>
+    %b_c = firrtl.subfield %b(2): (!firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>) -> !firrtl.uint<2>
+    %0 = firrtl.xor %b_a, %b_b: (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
+    firrtl.connect %b_c, %b_b: !firrtl.uint<2>, !firrtl.uint<2>
+  }
+  firrtl.module @PrimOps() {
+    // CHECK: firrtl.instance primops0 @PrimOps0
+    // CHECK: firrtl.instance primops1 @PrimOps0
+    %primops0 = firrtl.instance primops0 @PrimOps0(in a: !firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>)
+    %primops1 = firrtl.instance primops1 @PrimOps1(in b: !firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>)
+  }
+}
+
+// CHECK-LABEL: firrtl.circuit "Annotations"
+firrtl.circuit "Annotations" {
+  // CHECK: firrtl.nla [[NLA3:@nla.*]] [#hw.innerNameRef<@Annotations::@annotations1>, @Annotations0]
+  // CHECK: firrtl.nla [[NLA2:@nla.*]] [#hw.innerNameRef<@Annotations::@annotations0>, #hw.innerNameRef<@Annotations0::@e>]
+  // CHECK: firrtl.nla [[NLA1:@nla.*]] [#hw.innerNameRef<@Annotations::@annotations0>, #hw.innerNameRef<@Annotations0::@c>]
+  // CHECK: firrtl.nla [[NLA0:@nla.*]] [#hw.innerNameRef<@Annotations::@annotations1>, #hw.innerNameRef<@Annotations0::@b>]
+  // CHECK: firrtl.nla @annos_nla0 [#hw.innerNameRef<@Annotations::@annotations0>, #hw.innerNameRef<@Annotations0::@d>]
+  // CHECK: firrtl.nla @annos_nla1 [#hw.innerNameRef<@Annotations::@annotations1>, #hw.innerNameRef<@Annotations0::@d>]
+  firrtl.nla @annos_nla0 [#hw.innerNameRef<@Annotations::@annotations0>, #hw.innerNameRef<@Annotations0::@d>]
+  firrtl.nla @annos_nla1 [#hw.innerNameRef<@Annotations::@annotations1>, #hw.innerNameRef<@Annotations1::@i>]
+
+  // CHECK: firrtl.module @Annotations0() attributes {annotations = [{circt.nonlocal = [[NLA3]], class = "one"}]} 
+  firrtl.module @Annotations0() {
+    // Same annotation on both ops should stay local.
+    // CHECK: %a = firrtl.wire  {annotations = [{class = "both"}]}
+    %a = firrtl.wire {annotations = [{class = "both"}]} : !firrtl.uint<1>
+    
+    // Annotation from other module becomes non-local.
+    // CHECK: %b = firrtl.wire sym @b  {annotations = [{circt.nonlocal = [[NLA0]], class = "one"}]}
+    %b = firrtl.wire : !firrtl.uint<1>
+    
+    // Annotation from this module becomes non-local.
+    // CHECK: %c = firrtl.wire sym @c  {annotations = [{circt.nonlocal = [[NLA1]], class = "one"}]}
+    %c = firrtl.wire {annotations = [{class = "one"}]} : !firrtl.uint<1>
+    
+    // Two non-local annotations are unchanged, as they have enough context in the NLA already.
+    // CHECK: %d = firrtl.wire sym @d  {annotations = [{circt.nonlocal = @annos_nla1, class = "NonLocal"}, {circt.nonlocal = @annos_nla0, class = "NonLocal"}]}
+    %d = firrtl.wire sym @d {annotations = [{circt.nonlocal = @annos_nla0, class = "NonLocal"}]} : !firrtl.uint<1>
+    
+    // Subannotations should be handled correctly.
+    // CHECK: %e = firrtl.wire sym @e  {annotations = [#firrtl.subAnno<fieldID = 1, {circt.nonlocal = [[NLA2]], class = "subanno"}>]}
+    %e = firrtl.wire {annotations = [#firrtl.subAnno<fieldID = 1, {class = "subanno"}>]} : !firrtl.bundle<a: uint<1>>
+  }
+  // CHECK-NOT: firrtl.module @Annotations1
+  firrtl.module @Annotations1() attributes {annotations = [{class = "one"}]} {
+    %f = firrtl.wire {annotations = [{class = "both"}]} : !firrtl.uint<1>
+    %g = firrtl.wire {annotations = [{class = "one"}]} : !firrtl.uint<1>
+    %h = firrtl.wire : !firrtl.uint<1>
+    %i = firrtl.wire sym @i {annotations = [{circt.nonlocal = @annos_nla1, class = "NonLocal"}]} : !firrtl.uint<1>
+    %j = firrtl.wire : !firrtl.bundle<a: uint<1>>
+  }
+  firrtl.module @Annotations() {
+    // CHECK: firrtl.instance annotations0 sym @annotations0  {annotations = [{circt.nonlocal = @annos_nla0, class = "circt.nonlocal"}, {circt.nonlocal = [[NLA1]], class = "circt.nonlocal"}, {circt.nonlocal = [[NLA2]], class = "circt.nonlocal"}]} @Annotations0()
+    // CHECK: firrtl.instance annotations1 sym @annotations1  {annotations = [{circt.nonlocal = @annos_nla1, class = "circt.nonlocal"}, {circt.nonlocal = [[NLA0]], class = "circt.nonlocal"}, {circt.nonlocal = [[NLA3]], class = "circt.nonlocal"}]} @Annotations0()
+    firrtl.instance annotations0 sym @annotations0 {annotations = [{circt.nonlocal = @annos_nla0, class = "circt.nonlocal"}]} @Annotations0()
+    firrtl.instance annotations1 sym @annotations1 {annotations = [{circt.nonlocal = @annos_nla1, class = "circt.nonlocal"}]} @Annotations1()
+  }
+}
+
+// Check that module and memory port annotations are merged correctly.
+// CHECK-LABEL: firrtl.circuit "PortAnnotations"
+firrtl.circuit "PortAnnotations" {
+  // CHECK: firrtl.nla [[NLA3:@nla.*]] [#hw.innerNameRef<@PortAnnotations::@portannos0>, #hw.innerNameRef<@PortAnnotations0::@in>]
+  // CHECK: firrtl.nla [[NLA2:@nla.*]] [#hw.innerNameRef<@PortAnnotations::@portannos1>, #hw.innerNameRef<@PortAnnotations0::@in>]
+  // CHECK: firrtl.nla [[NLA1:@nla.*]] [#hw.innerNameRef<@PortAnnotations::@portannos0>, #hw.innerNameRef<@PortAnnotations0::@bar>]
+  // CHECK: firrtl.nla [[NLA0:@nla.*]] [#hw.innerNameRef<@PortAnnotations::@portannos1>, #hw.innerNameRef<@PortAnnotations0::@bar>]
+  // CHECK: firrtl.module @PortAnnotations0(in %in: !firrtl.uint<1> sym @in [
+  // CHECK-SAME: {circt.nonlocal = [[NLA2]], class = "port1"},
+  // CHECK-SAME: {circt.nonlocal = [[NLA3]], class = "port0"}]) {
+  firrtl.module @PortAnnotations0(in %in : !firrtl.uint<1> [{class = "port0"}]) {
+    // CHECK: %bar_r = firrtl.mem sym @bar
+    // CHECK-SAME: portAnnotations =
+    // CHECK-SAME:  {circt.nonlocal = [[NLA0]], class = "mem1"},
+    // CHECK-SAME:  {circt.nonlocal = [[NLA1]], class = "mem0"}
+    %bar_r = firrtl.mem Undefined  {depth = 16 : i64, name = "bar", portAnnotations = [[{class = "mem0"}]], portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
+  }
+  // CHECK-NOT: firrtl.module @PortAnnotations1
+  firrtl.module @PortAnnotations1(in %in : !firrtl.uint<1> [{class = "port1"}])  {
+    %bar_r = firrtl.mem Undefined  {depth = 16 : i64, name = "bar", portAnnotations = [[{class = "mem1"}]], portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
+  }
+  // CHECK: firrtl.module @PortAnnotations
+  firrtl.module @PortAnnotations() {
+    // CHECK: annotations = [{circt.nonlocal = [[NLA1]], class = "circt.nonlocal"}, {circt.nonlocal = [[NLA3]], class = "circt.nonlocal"}]
+    %portannos0_in = firrtl.instance portannos0 @PortAnnotations0(in in: !firrtl.uint<1>)
+    // CHECK: annotations = [{circt.nonlocal = [[NLA0]], class = "circt.nonlocal"}, {circt.nonlocal = [[NLA2]], class = "circt.nonlocal"}]
+    %portannos1_in = firrtl.instance portannos1 @PortAnnotations1(in in: !firrtl.uint<1>)
+  }
+}
+
+
+// Non-local annotations should have their path updated and bread crumbs should
+// not be turned into non-local annotations. Note that this should not create
+// totally new NLAs for the annotations, it should just update the existing
+// ones.
+// CHECK-LABEL: firrtl.circuit "Breadcrumb"
+firrtl.circuit "Breadcrumb" {
+  // CHECK:  @breadcrumb_nla0 [#hw.innerNameRef<@Breadcrumb::@breadcrumb0>, #hw.innerNameRef<@Breadcrumb0::@crumb0>, #hw.innerNameRef<@Crumb::@in>]
+  firrtl.nla @breadcrumb_nla0 [#hw.innerNameRef<@Breadcrumb::@breadcrumb0>, #hw.innerNameRef<@Breadcrumb0::@crumb0>, #hw.innerNameRef<@Crumb::@in>]
+  // CHECK:  @breadcrumb_nla1 [#hw.innerNameRef<@Breadcrumb::@breadcrumb1>, #hw.innerNameRef<@Breadcrumb0::@crumb0>, #hw.innerNameRef<@Crumb::@in>]
+  firrtl.nla @breadcrumb_nla1 [#hw.innerNameRef<@Breadcrumb::@breadcrumb1>, #hw.innerNameRef<@Breadcrumb1::@crumb1>, #hw.innerNameRef<@Crumb::@in>]
+  // CHECK:  @breadcrumb_nla2 [#hw.innerNameRef<@Breadcrumb::@breadcrumb0>, #hw.innerNameRef<@Breadcrumb0::@crumb0>, #hw.innerNameRef<@Crumb::@w>]
+  firrtl.nla @breadcrumb_nla2 [#hw.innerNameRef<@Breadcrumb::@breadcrumb0>, #hw.innerNameRef<@Breadcrumb0::@crumb0>, #hw.innerNameRef<@Crumb::@w>]
+  // CHECK:  @breadcrumb_nla3 [#hw.innerNameRef<@Breadcrumb::@breadcrumb1>, #hw.innerNameRef<@Breadcrumb0::@crumb0>, #hw.innerNameRef<@Crumb::@w>]
+  firrtl.nla @breadcrumb_nla3 [#hw.innerNameRef<@Breadcrumb::@breadcrumb1>, #hw.innerNameRef<@Breadcrumb1::@crumb1>, #hw.innerNameRef<@Crumb::@w>]
+  firrtl.module @Crumb(in %in: !firrtl.uint<1> sym @in [
+      {circt.nonlocal = @breadcrumb_nla0, class = "port0"}, 
+      {circt.nonlocal = @breadcrumb_nla1, class = "port1"}]) {
+    %w = firrtl.wire sym @w {annotations = [
+      {circt.nonlocal = @breadcrumb_nla2, class = "wire0"},
+      {circt.nonlocal = @breadcrumb_nla3, class = "wire1"}]}: !firrtl.uint<1>
+  }
+  // CHECK: firrtl.module @Breadcrumb0()
+  firrtl.module @Breadcrumb0() {
+    // CHECK: %crumb0_in = firrtl.instance crumb0 sym @crumb0  {annotations = [
+    // CHECK-SAME: {circt.nonlocal = @breadcrumb_nla1, class = "circt.nonlocal"},
+    // CHECK-SAME: {circt.nonlocal = @breadcrumb_nla3, class = "circt.nonlocal"},
+    // CHECK-SAME: {circt.nonlocal = @breadcrumb_nla0, class = "circt.nonlocal"},
+    // CHECK-SAME: {circt.nonlocal = @breadcrumb_nla2, class = "circt.nonlocal"}]}
+    %crumb_in = firrtl.instance crumb0 sym @crumb0 {annotations = [
+      {circt.nonlocal = @breadcrumb_nla0, class = "circt.nonlocal"},
+      {circt.nonlocal = @breadcrumb_nla2, class = "circt.nonlocal"}
+    ]} @Crumb(in in : !firrtl.uint<1>)
+  }
+  // CHECK-NOT: firrtl.module @Breadcrumb1()
+  firrtl.module @Breadcrumb1() {
+    %crumb_in = firrtl.instance crumb1 sym @crumb1 {annotations = [
+      {circt.nonlocal = @breadcrumb_nla1, class = "circt.nonlocal"},
+      {circt.nonlocal = @breadcrumb_nla3, class = "circt.nonlocal"}
+    ]} @Crumb(in in : !firrtl.uint<1>)
+  }
+  // CHECK: firrtl.module @Breadcrumb()
+  firrtl.module @Breadcrumb() {
+    // CHECK:     [{circt.nonlocal = @breadcrumb_nla0, class = "circt.nonlocal"},
+    // CHECK-SAME: {circt.nonlocal = @breadcrumb_nla2, class = "circt.nonlocal"}]}
+    firrtl.instance breadcrumb0 sym @breadcrumb0 {annotations = [
+      {circt.nonlocal = @breadcrumb_nla0, class = "circt.nonlocal"},
+      {circt.nonlocal = @breadcrumb_nla2, class = "circt.nonlocal"}
+    ]} @Breadcrumb0()
+    // CHECK:     [{circt.nonlocal = @breadcrumb_nla1, class = "circt.nonlocal"},
+    // CHECK-SAME: {circt.nonlocal = @breadcrumb_nla3, class = "circt.nonlocal"}]}
+    firrtl.instance breadcrumb1 sym @breadcrumb1 {annotations = [
+      {circt.nonlocal = @breadcrumb_nla1, class = "circt.nonlocal"},
+      {circt.nonlocal = @breadcrumb_nla3, class = "circt.nonlocal"}
+    ]} @Breadcrumb1()
+  }
+}
+
+// Non-local annotations should be updated with additional context if the module
+// at the root of the NLA is deduplicated.  The original NLA should be deleted,
+// and the annotation should be cloned for each parent of the root module.
+// CHECK-LABEL: firrtl.circuit "Context"
+firrtl.circuit "Context" {
+  // CHECK: firrtl.nla [[NLA3:@nla.*]] [#hw.innerNameRef<@Context::@context1>, #hw.innerNameRef<@Context0::@c0>, #hw.innerNameRef<@ContextLeaf::@w>]
+  // CHECK: firrtl.nla [[NLA1:@nla.*]] [#hw.innerNameRef<@Context::@context1>, #hw.innerNameRef<@Context0::@c0>, #hw.innerNameRef<@ContextLeaf::@in>]
+  // CHECK: firrtl.nla [[NLA2:@nla.*]] [#hw.innerNameRef<@Context::@context0>, #hw.innerNameRef<@Context0::@c0>, #hw.innerNameRef<@ContextLeaf::@w>]
+  // CHECK: firrtl.nla [[NLA0:@nla.*]] [#hw.innerNameRef<@Context::@context0>, #hw.innerNameRef<@Context0::@c0>, #hw.innerNameRef<@ContextLeaf::@in>]
+  // CHECK-NOT: @context_nla0
+  // CHECK-NOT: @context_nla1
+  // CHECK-NOT: @context_nla2
+  // CHECK-NOT: @context_nla3
+  firrtl.nla @context_nla0 [#hw.innerNameRef<@Context0::@c0>, #hw.innerNameRef<@ContextLeaf::@in>]
+  firrtl.nla @context_nla1 [#hw.innerNameRef<@Context0::@c0>, #hw.innerNameRef<@ContextLeaf::@w>]
+  firrtl.nla @context_nla2 [#hw.innerNameRef<@Context1::@c1>, #hw.innerNameRef<@ContextLeaf::@in>]
+  firrtl.nla @context_nla3 [#hw.innerNameRef<@Context1::@c1>, #hw.innerNameRef<@ContextLeaf::@w>]
+
+  // CHECK: firrtl.module @ContextLeaf(in %in: !firrtl.uint<1> sym @in [
+  // CHECK-SAME: {circt.nonlocal = [[NLA0]], class = "port0"},
+  // CHECK-SAME: {circt.nonlocal = [[NLA1]], class = "port1"}]
+  firrtl.module @ContextLeaf(in %in : !firrtl.uint<1> sym @in [
+      {circt.nonlocal = @context_nla0, class = "port0"},
+      {circt.nonlocal = @context_nla2, class = "port1"}
+    ]) {
+  
+    // CHECK: %w = firrtl.wire sym @w  {annotations = [
+    // CHECK-SAME: {circt.nonlocal = [[NLA2]], class = "fake0"}
+    // CHECK-SAME: {circt.nonlocal = [[NLA3]], class = "fake1"}
+    %w = firrtl.wire sym @w {annotations = [
+      {circt.nonlocal = @context_nla1, class = "fake0"},
+      {circt.nonlocal = @context_nla3, class = "fake1"}]}: !firrtl.uint<3>
+  }
+  firrtl.module @Context0() {
+    // CHECK: %leaf_in = firrtl.instance leaf sym @c0  {annotations = [
+    // CHECK-SAME: {circt.nonlocal = [[NLA0]], class = "circt.nonlocal"},
+    // CHECK-SAME: {circt.nonlocal = [[NLA2]], class = "circt.nonlocal"},
+    // CHECK-SAME: {circt.nonlocal = [[NLA1]], class = "circt.nonlocal"},
+    // CHECK-SAME: {circt.nonlocal = [[NLA3]], class = "circt.nonlocal"}]}
+    %leaf_in = firrtl.instance leaf sym @c0 {annotations = [
+      {circt.nonlocal = @context_nla0, class = "circt.nonlocal"},
+      {circt.nonlocal = @context_nla1, class = "circt.nonlocal"}
+    ]} @ContextLeaf(in in : !firrtl.uint<1>)
+  }
+  // CHECK-NOT: firrtl.module @Context1()
+  firrtl.module @Context1() {
+    %leaf_in = firrtl.instance leaf sym @c1 {annotations = [
+      {circt.nonlocal = @context_nla2, class = "circt.nonlocal"},
+      {circt.nonlocal = @context_nla3, class = "circt.nonlocal"}
+    ]} @ContextLeaf(in in : !firrtl.uint<1>)
+  }
+  firrtl.module @Context() {
+    // CHECK: firrtl.instance context0 sym @context0  {annotations = [
+    // CHECK-SAME: {circt.nonlocal = [[NLA0]], class = "circt.nonlocal"},
+    // CHECK-SAME: {circt.nonlocal = [[NLA2]], class = "circt.nonlocal"}]}
+    firrtl.instance context0 @Context0()
+    // CHECK: firrtl.instance context1 sym @context1  {annotations = [
+    // CHECK-SAME: {circt.nonlocal = [[NLA1]], class = "circt.nonlocal"},
+    // CHECK-SAME: {circt.nonlocal = [[NLA3]], class = "circt.nonlocal"}]}
+    firrtl.instance context1 @Context1()
+  }
+}
+
+
+// External modules should dedup and fixup any NLAs.
+// CHECK: firrtl.circuit "ExtModuleTest"
+firrtl.circuit "ExtModuleTest" {
+  // CHECK: firrtl.nla @ext_nla [#hw.innerNameRef<@ExtModuleTest::@e1>, @ExtMod0]
+  firrtl.nla @ext_nla [#hw.innerNameRef<@ExtModuleTest::@e1>, @ExtMod1]
+  // CHECK: firrtl.extmodule @ExtMod0() attributes {annotations = [{circt.nonlocal = @ext_nla}], defname = "a"}
+  firrtl.extmodule @ExtMod0() attributes {defname = "a"}
+  // CHECK-NOT: firrtl.extmodule @ExtMod1()
+  firrtl.extmodule @ExtMod1() attributes {annotations = [{circt.nonlocal = @ext_nla}], defname = "a"}
+  firrtl.module @ExtModuleTest() {
+    // CHECK: firrtl.instance e0  @ExtMod0()
+    firrtl.instance e0 @ExtMod0()
+    // CHECK: firrtl.instance e1 sym @e1  {annotations = [{circt.nonlocal = @ext_nla, class = "circt.nonlocal"}]} @ExtMod0()
+    firrtl.instance e1 sym @e1 {annotations = [{circt.nonlocal = @ext_nla, class = "circt.nonlocal"}]} @ExtMod1()
+  }
+}
+
+// As we dedup modules, the chain on NLAs should continuously grow.
+// CHECK-LABEL: firrtl.circuit "Chain"
+firrtl.circuit "Chain" {
+  // CHECK: firrtl.nla [[NLA0:@nla.*]] [#hw.innerNameRef<@Chain::@chainB1>, #hw.innerNameRef<@ChainB0::@chainA0>, #hw.innerNameRef<@ChainA0::@extchain0>, @ExtChain0]
+  // CHECK: firrtl.nla [[NLA1:@nla.*]] [#hw.innerNameRef<@Chain::@chainB0>, #hw.innerNameRef<@ChainB0::@chainA0>, #hw.innerNameRef<@ChainA0::@extchain0>, @ExtChain0]
+  // CHECK: firrtl.module @ChainB0()
+  firrtl.module @ChainB0() {
+    // CHECK: {annotations = [{circt.nonlocal = [[NLA1]], class = "circt.nonlocal"}, {circt.nonlocal = [[NLA0]], class = "circt.nonlocal"}]}
+    firrtl.instance chainA0 @ChainA0()
+  }
+  // CHECK: firrtl.extmodule @ExtChain0() attributes {annotations = [
+  // CHECK-SAME:  {circt.nonlocal = [[NLA0]], class = "1"},
+  // CHECK-SAME:  {circt.nonlocal = [[NLA1]], class = "0"}], defname = "ExtChain"}
+  firrtl.extmodule @ExtChain0() attributes {annotations = [{class = "0"}], defname = "ExtChain"}
+  // CHECK-NOT: firrtl.extmodule @ExtChain1()
+  firrtl.extmodule @ExtChain1() attributes {annotations = [{class = "1"}], defname = "ExtChain"}
+  // CHECK: firrtl.module @ChainA0()
+  firrtl.module @ChainA0()  {
+    // CHECK: {circt.nonlocal = [[NLA1]], class = "circt.nonlocal"}, {circt.nonlocal = [[NLA0]], class = "circt.nonlocal"}
+    firrtl.instance extchain0 @ExtChain0()
+  }
+  // CHECK-NOT: firrtl.module @ChainB1()
+  firrtl.module @ChainB1() {
+    firrtl.instance chainA1 @ChainA1()
+  }
+  // CHECK-NOT: firrtl.module @ChainA1()
+  firrtl.module @ChainA1()  {
+    firrtl.instance extchain1 @ExtChain1()
+  }
+  firrtl.module @Chain() {
+    // CHECK: firrtl.instance chainB0 sym @chainB0  {annotations = [{circt.nonlocal = [[NLA1]], class = "circt.nonlocal"}]} @ChainB0()
+    firrtl.instance chainB0 @ChainB0()
+    // CHECK: firrtl.instance chainB1 sym @chainB1  {annotations = [{circt.nonlocal = [[NLA0]], class = "circt.nonlocal"}]} @ChainB0()
+    firrtl.instance chainB1 @ChainB1()
+  }
+}
+
+
+// Check that we fixup subfields, partial connects, and connects, when an
+// instance op starts returning a different bundle type.
+// CHECK-LABEL: firrtl.circuit "Bundle"
+firrtl.circuit "Bundle" {
+  // CHECK: firrtl.module @Bundle0
+  firrtl.module @Bundle0(out %a: !firrtl.bundle<b: bundle<c flip: uint<1>, d: uint<1>>>) { }
+  // CHECK-NOT: firrtl.module @Bundle1
+  firrtl.module @Bundle1(out %e: !firrtl.bundle<f: bundle<g flip: uint<1>, h: uint<1>>>) { }
+  firrtl.module @Bundle() {
+    // CHECK: firrtl.instance bundle0  @Bundle0
+    %a = firrtl.instance bundle0 @Bundle0(out a: !firrtl.bundle<b: bundle<c flip: uint<1>, d: uint<1>>>)
+    // CHECK: firrtl.instance bundle1  @Bundle0
+    %e = firrtl.instance bundle1 @Bundle1(out e: !firrtl.bundle<f: bundle<g flip: uint<1>, h: uint<1>>>)
+    
+    // CHECK: [[B:%.+]] = firrtl.subfield %bundle0_a(0)
+    %b = firrtl.subfield %a(0) : (!firrtl.bundle<b: bundle<c flip: uint<1>, d: uint<1>>>) -> !firrtl.bundle<c flip: uint<1>, d: uint<1>>
+    // CHECK: [[F:%.+]] = firrtl.subfield %bundle1_a(0)
+    %f = firrtl.subfield %e(0) : (!firrtl.bundle<f: bundle<g flip: uint<1>, h: uint<1>>>) -> !firrtl.bundle<g flip: uint<1>, h: uint<1>>
+  
+    // Check that we properly fixup connects when the field names change.
+    %w0 = firrtl.wire : !firrtl.bundle<g flip: uint<1>, h: uint<1>>
+    // CHECK: [[W0_G:%.+]] = firrtl.subfield %w0(0)
+    // CHECK: [[F_G:%.+]] = firrtl.subfield [[F]](0)
+    // CHECK: firrtl.connect [[F_G]], [[W0_G]]
+    firrtl.connect %w0, %f : !firrtl.bundle<g flip: uint<1>, h: uint<1>>, !firrtl.bundle<g flip: uint<1>, h: uint<1>>
+    
+    // Check that we properly fixup partial connects when the field names change.
+    %w1 = firrtl.wire : !firrtl.bundle<g flip: uint<1>>
+    // CHECK: [[F_G:%.+]] = firrtl.subfield [[F]](0)
+    // CHECK: [[W1_G:%.+]] = firrtl.subfield %w1(0)
+    // CHECK: firrtl.partialconnect [[F_G]], [[W1_G]]
+    firrtl.partialconnect %w1, %f : !firrtl.bundle<g flip: uint<1>>, !firrtl.bundle<g flip: uint<1>, h: uint<1>>
+  }
+}
+
+
+// Make sure flipped fields are handled properly. This should pass flow
+// verification checking.
+// CHECK-LABEL: firrtl.circuit "Flip"
+firrtl.circuit "Flip" {
+  firrtl.module @Flip0(out %io: !firrtl.bundle<foo flip: uint<1>, fuzz: uint<1>>) {
+    %0 = firrtl.subfield %io(0) : (!firrtl.bundle<foo flip: uint<1>, fuzz: uint<1>>) -> !firrtl.uint<1>
+    %1 = firrtl.subfield %io(1) : (!firrtl.bundle<foo flip: uint<1>, fuzz: uint<1>>) -> !firrtl.uint<1>
+    firrtl.connect %1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+  firrtl.module @Flip1(out %io: !firrtl.bundle<bar flip: uint<1>, buzz: uint<1>>) {
+    %0 = firrtl.subfield %io(0) : (!firrtl.bundle<bar flip: uint<1>, buzz: uint<1>>) -> !firrtl.uint<1>
+    %1 = firrtl.subfield %io(1) : (!firrtl.bundle<bar flip: uint<1>, buzz: uint<1>>) -> !firrtl.uint<1>
+    firrtl.connect %1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+  firrtl.module @Flip(out %io: !firrtl.bundle<foo: bundle<foo flip: uint<1>, fuzz: uint<1>>, bar: bundle<bar flip: uint<1>, buzz: uint<1>>>) {
+    %0 = firrtl.subfield %io(1) : (!firrtl.bundle<foo: bundle<foo flip: uint<1>, fuzz: uint<1>>, bar: bundle<bar flip: uint<1>, buzz: uint<1>>>) -> !firrtl.bundle<bar flip: uint<1>, buzz: uint<1>>
+    %1 = firrtl.subfield %io(0) : (!firrtl.bundle<foo: bundle<foo flip: uint<1>, fuzz: uint<1>>, bar: bundle<bar flip: uint<1>, buzz: uint<1>>>) -> !firrtl.bundle<foo flip: uint<1>, fuzz: uint<1>>
+    %foo_io = firrtl.instance foo  @Flip0(out io: !firrtl.bundle<foo flip: uint<1>, fuzz: uint<1>>)
+    %bar_io = firrtl.instance bar  @Flip1(out io: !firrtl.bundle<bar flip: uint<1>, buzz: uint<1>>)
+    firrtl.partialconnect %1, %foo_io : !firrtl.bundle<foo flip: uint<1>, fuzz: uint<1>>, !firrtl.bundle<foo flip: uint<1>, fuzz: uint<1>>
+    firrtl.connect %0, %bar_io : !firrtl.bundle<bar flip: uint<1>, buzz: uint<1>>, !firrtl.bundle<bar flip: uint<1>, buzz: uint<1>>
+  }
+}
+
+
+// Don't attach empty annotations onto ops without annotations.
+// CHECK-LABEL: firrtl.circuit "NoEmptyAnnos"
+firrtl.circuit "NoEmptyAnnos" {
+  // CHECK-LABEL: @NoEmptyAnnos0()
+  firrtl.module @NoEmptyAnnos0() {
+    // CHECK: %w = firrtl.wire  : !firrtl.bundle<a: uint<1>>
+    // CHECK: %0 = firrtl.subfield %w(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+    %w = firrtl.wire : !firrtl.bundle<a: uint<1>>
+    %0 = firrtl.subfield %w(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+  }
+  firrtl.module @NoEmptyAnnos1() {
+    %w = firrtl.wire : !firrtl.bundle<a: uint<1>>
+    %0 = firrtl.subfield %w(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
+  }
+  firrtl.module @NoEmptyAnnos() {
+    firrtl.instance empty0 @NoEmptyAnnos0()
+    firrtl.instance empty1 @NoEmptyAnnos1()
+  }
+}
+
+
+// Don't deduplicate modules with NoDedup.
+// CHECK-LABEL: firrtl.circuit "NoDedup"
+firrtl.circuit "NoDedup" {
+  firrtl.module @Simple() { }
+  // CHECK: firrtl.module @NoDedup 
+  firrtl.module @NoDedup() attributes {annotations = [{class = "firrtl.transforms.NoDedupAnnotation"}]} { }
+}

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -405,7 +405,11 @@ firrtl.circuit "NoEmptyAnnos" {
 // Don't deduplicate modules with NoDedup.
 // CHECK-LABEL: firrtl.circuit "NoDedup"
 firrtl.circuit "NoDedup" {
-  firrtl.module @Simple() { }
+  firrtl.module @Simple0() { }
+  firrtl.module @Simple1() attributes {annotations = [{class = "firrtl.transforms.NoDedupAnnotation"}]} { }
   // CHECK: firrtl.module @NoDedup 
-  firrtl.module @NoDedup() attributes {annotations = [{class = "firrtl.transforms.NoDedupAnnotation"}]} { }
+  firrtl.module @NoDedup() {
+    firrtl.instance simple0 @Simple0()
+    firrtl.instance simple1 @Simple1()
+  }
 }

--- a/test/firtool/blackbox.mlir
+++ b/test/firtool/blackbox.mlir
@@ -55,26 +55,26 @@ firrtl.circuit "test_mod" attributes {annotations = [
       name = "blackbox-inline.svh",
       text = "`define SOME_MACRO\n"
     }
-  ]}
+  ], defname = "ExtInline"}
 
   // VERILOG-BAR-LABEL: module ExtResource(); endmodule
   // VERILOG-BAR-NOT:   module ExtResource(); endmodule
   firrtl.extmodule @ExtResource() attributes {annotations = [{
     class = "firrtl.transforms.BlackBoxResourceAnno",
     resourceId = "firtool/blackbox-resource.v"
-  }]}
+  }], defname = "ExtResource"}
 
   // Duplicate resources will not be copied.
   // VERILOG-BAR-NOT:   module ExtResource(); endmodule
   firrtl.extmodule @DuplicateExtResource() attributes {annotations = [{
     class = "firrtl.transforms.BlackBoxResourceAnno",
     resourceId = "firtool/blackbox-resource.v"
-  }]}
+  }], defname = "DuplicateExtResource"}
 
   // VERILOG-GIB-LABEL: module ExtPath(); endmodule
   // VERILOG-GIB-NOT:   module ExtPath(); endmodule
   firrtl.extmodule @ExtPath() attributes {annotations = [{
     class = "firrtl.transforms.BlackBoxPathAnno",
     path = "blackbox-path.v"
-  }]}
+  }], defname = "ExtPath"}
 }

--- a/test/firtool/memoryMetadata.fir
+++ b/test/firtool/memoryMetadata.fir
@@ -1,4 +1,4 @@
-; RUN: firtool %s --format=fir  --annotation-file %s.anno.json --repl-seq-mem --repl-seq-mem-file="metadata/dutModule.conf" --verilog |  FileCheck %s
+; RUN: firtool %s -dedup=false --format=fir  --annotation-file %s.anno.json --repl-seq-mem --repl-seq-mem-file="metadata/dutModule.conf" --verilog |  FileCheck %s
 
 
 ; CHECK-LABEL: external module tbMemoryKind1_ext

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -162,7 +162,7 @@ static cl::opt<bool>
 
 static cl::opt<bool>
     dedup("dedup", cl::desc("deduplicate structurally identical modules"),
-          cl::init(true));
+          cl::init(false));
 
 static cl::opt<bool>
     ignoreFIRLocations("ignore-fir-locators",

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -161,6 +161,10 @@ static cl::opt<bool>
                    cl::init(false));
 
 static cl::opt<bool>
+    dedup("dedup", cl::desc("deduplicate structurally identical modules"),
+          cl::init(true));
+
+static cl::opt<bool>
     ignoreFIRLocations("ignore-fir-locators",
                        cl::desc("ignore the @info locations in the .fir file"),
                        cl::init(false));
@@ -402,10 +406,9 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
         firrtl::createLowerFIRRTLAnnotationsPass(disableAnnotationsUnknown,
                                                  disableAnnotationsClassless));
 
-  if (!disableOptimization) {
+  if (!disableOptimization)
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
         createCSEPass());
-  }
 
   if (lowerCHIRRTL)
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
@@ -417,6 +420,9 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
 
   if (inferResets)
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInferResetsPass());
+
+  if (!disableOptimization && dedup)
+    pm.nest<firrtl::CircuitOp>().addPass(firrtl::createDedupPass());
 
   if (wireDFT)
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createWireDFTPass());


### PR DESCRIPTION
There is still a problem with memory port annotations and NLAs that I need to think through.

@seldridge  This is rebased off of `llvm/main` now that all prerequisites of this PR have been merged. This branch has a bug-fix that was not present earlier today.  It would be a good idea to work off this branch if anyone is working on porting the SFC dedup tests.