### PR TITLE
[MSFT] Add PlacementDB APIs for removing and moving entities.

### DIFF
--- a/include/circt-c/Dialect/MSFT.h
+++ b/include/circt-c/Dialect/MSFT.h
@@ -106,6 +106,10 @@ MLIR_CAPI_EXPORTED
 size_t circtMSFTPlacementDBAddDesignPlacements(CirctMSFTPlacementDB);
 MLIR_CAPI_EXPORTED MlirLogicalResult circtMSFTPlacementDBAddPlacement(
     CirctMSFTPlacementDB, MlirAttribute loc, CirctMSFTPlacedInstance inst);
+MLIR_CAPI_EXPORTED MlirLogicalResult
+circtMSFTPlacementDBRemovePlacement(CirctMSFTPlacementDB, MlirAttribute loc);
+MLIR_CAPI_EXPORTED MlirLogicalResult circtMSFTPlacementDBMovePlacement(
+    CirctMSFTPlacementDB, MlirAttribute oldLoc, MlirAttribute newLoc);
 MLIR_CAPI_EXPORTED bool
 circtMSFTPlacementDBTryGetInstanceAt(CirctMSFTPlacementDB, MlirAttribute loc,
                                      CirctMSFTPlacedInstance *out);

--- a/include/circt/Dialect/MSFT/DeviceDB.h
+++ b/include/circt/Dialect/MSFT/DeviceDB.h
@@ -97,6 +97,14 @@ public:
   /// Walk the entire design adding placements root at the top module.
   size_t addDesignPlacements();
 
+  /// Remove the placement at a given location. Returns failure if nothing was
+  /// placed there.
+  LogicalResult removePlacement(PhysLocationAttr);
+  /// Move the placement at a given location to a new location. Returns failure
+  /// if nothing was placed at the previous location or something is already
+  /// placed at the new location.
+  LogicalResult movePlacement(PhysLocationAttr, PhysLocationAttr);
+
   /// Lookup the instance at a particular location.
   Optional<PlacedInstance> getInstanceAt(PhysLocationAttr);
 

--- a/integration_test/Bindings/Python/dialects/msft.py
+++ b/integration_test/Bindings/Python/dialects/msft.py
@@ -223,6 +223,30 @@ with ir.Context() as ctx, ir.Location.unknown():
   # CHECK: #msft.physloc<M20K, {{.+}}, 0
   # CHECK: #msft.physloc<M20K, {{.+}}, 0
 
+  print("=== Mutations:")
+  old_location = msft.PhysLocationAttr.get(msft.M20K, x=0, y=0, num=0)
+  new_location = msft.PhysLocationAttr.get(msft.M20K, x=1, y=1, num=1)
+
+  pdb.add_placement(old_location, path, "", resolved_inst)
+  assert pdb.get_instance_at(old_location)[2] == resolved_inst
+  rc = pdb.remove_placement(new_location)
+  assert rc == False
+  rc = pdb.remove_placement(old_location)
+  assert rc == True
+  assert pdb.get_instance_at(old_location) is None
+
+  rc = pdb.move_placement(old_location, new_location)
+  assert rc == False
+  pdb.add_placement(old_location, path, "", resolved_inst)
+  pdb.add_placement(new_location, path, "", resolved_inst)
+  rc = pdb.move_placement(old_location, new_location)
+  assert rc == False
+  pdb.remove_placement(new_location)
+  rc = pdb.move_placement(old_location, new_location)
+  assert rc == True
+  assert pdb.get_instance_at(old_location) is None
+  assert pdb.get_instance_at(new_location)[2] == resolved_inst
+
   print("=== Errors:", file=sys.stderr)
   # TODO: Python's sys.stderr doesn't seem to be shared with C++ errors.
   # See https://github.com/llvm/circt/issues/1983 for more info.

--- a/lib/Bindings/Python/MSFTModule.cpp
+++ b/lib/Bindings/Python/MSFTModule.cpp
@@ -63,6 +63,14 @@ public:
         db, loc,
         CirctMSFTPlacedInstance{path, subpath.c_str(), subpath.size(), op}));
   }
+  bool removePlacement(MlirAttribute loc) {
+    return mlirLogicalResultIsSuccess(
+        circtMSFTPlacementDBRemovePlacement(db, loc));
+  }
+  bool movePlacement(MlirAttribute oldLoc, MlirAttribute newLoc) {
+    return mlirLogicalResultIsSuccess(
+        circtMSFTPlacementDBMovePlacement(db, oldLoc, newLoc));
+  }
   py::object getInstanceAt(MlirAttribute loc) {
     CirctMSFTPlacedInstance inst;
     if (!circtMSFTPlacementDBTryGetInstanceAt(db, loc, &inst))
@@ -215,6 +223,11 @@ void circt::python::populateDialectMSFTSubmodule(py::module &m) {
       .def("add_placement", &PlacementDB::addPlacement,
            "Inform the DB about a new placement.", py::arg("location"),
            py::arg("path"), py::arg("subpath"), py::arg("op"))
+      .def("remove_placement", &PlacementDB::removePlacement,
+           "Remove a placment from the DB.", py::arg("location"))
+      .def("move_placement", &PlacementDB::movePlacement,
+           "Move a placement to another location in the DB.",
+           py::arg("old_location"), py::arg("new_location"))
       .def("get_nearest_free_in_column", &PlacementDB::getNearestFreeInColumn,
            "Find the nearest free primitive location in column.",
            py::arg("prim_type"), py::arg("column"), py::arg("nearest_to_y"))

--- a/lib/CAPI/Dialect/MSFT.cpp
+++ b/lib/CAPI/Dialect/MSFT.cpp
@@ -81,6 +81,18 @@ circtMSFTPlacementDBAddPlacement(CirctMSFTPlacementDB self, MlirAttribute cLoc,
 
   return wrap(failure());
 }
+MlirLogicalResult circtMSFTPlacementDBRemovePlacement(CirctMSFTPlacementDB db,
+                                                      MlirAttribute cLoc) {
+  auto loc = unwrap(cLoc).cast<PhysLocationAttr>();
+  return wrap(unwrap(db)->removePlacement(loc));
+}
+MlirLogicalResult circtMSFTPlacementDBMovePlacement(CirctMSFTPlacementDB db,
+                                                    MlirAttribute cOldLoc,
+                                                    MlirAttribute cNewLoc) {
+  auto oldLoc = unwrap(cOldLoc).cast<PhysLocationAttr>();
+  auto newLoc = unwrap(cNewLoc).cast<PhysLocationAttr>();
+  return wrap(unwrap(db)->movePlacement(oldLoc, newLoc));
+}
 bool circtMSFTPlacementDBTryGetInstanceAt(CirctMSFTPlacementDB self,
                                           MlirAttribute cLoc,
                                           CirctMSFTPlacedInstance *out) {


### PR DESCRIPTION
These complement the main add* APIs for putting entities into the
database and support moving entities around or removing entities
entirely after any initial placements.