### PR TITLE
[SV] Support inout operations with aggregate type alias

### DIFF
--- a/include/circt/Dialect/HW/HWTypes.h
+++ b/include/circt/Dialect/HW/HWTypes.h
@@ -77,7 +77,7 @@ bool type_isa(Type type) {
 
 // type_isa for a nullable argument.
 template <typename BaseTy>
-bool type_isa_and_nonnull(Type type) {
+bool type_isa_and_nonnull(Type type) { // NOLINT(readability-identifier-naming)
   if (!type)
     return false;
   return type_isa<BaseTy>(type);

--- a/include/circt/Dialect/HW/HWTypes.h
+++ b/include/circt/Dialect/HW/HWTypes.h
@@ -75,6 +75,14 @@ bool type_isa(Type type) {
   return false;
 }
 
+// type_isa for a nullable argument.
+template <typename BaseTy>
+bool type_isa_and_nonnull(Type type) {
+  if (!type)
+    return false;
+  return type_isa<BaseTy>(type);
+}
+
 template <typename BaseTy>
 BaseTy type_cast(Type type) {
   assert(type_isa<BaseTy>(type) && "type must convert to requested type");

--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -178,7 +178,7 @@ def IndexedPartSelectInOutOp : SVOp<"indexed_part_select_inout",
 }
 
 def InOutStructType
-  : Type<CPred<"getInOutElementType($_self).isa<hw::StructType>()">,
+  : Type<CPred<"hw::type_isa_and_nonnull<hw::StructType>(getInOutElementType($_self))">,
          "an inout type with struct field", "::circt::hw::InOutType">;
 
 def StructFieldInOutOp : SVOp<"struct_field_inout",

--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -178,7 +178,7 @@ def IndexedPartSelectInOutOp : SVOp<"indexed_part_select_inout",
 }
 
 def InOutStructType
-  : Type<CPred<"hw::type_isa_and_nonnull<hw::StructType>(getInOutElementType($_self))">,
+  : Type<CPred<"circt::hw::type_isa_and_nonnull<hw::StructType>(getInOutElementType($_self))">,
          "an inout type with struct field", "::circt::hw::InOutType">;
 
 def StructFieldInOutOp : SVOp<"struct_field_inout",

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1606,7 +1606,7 @@ void StructExtractOp::build(OpBuilder &builder, OperationState &odsState,
 
 void StructExtractOp::build(OpBuilder &builder, OperationState &odsState,
                             Value input, StringAttr fieldAttr) {
-  auto structType = input.getType().cast<StructType>();
+  auto structType = type_cast<StructType>(input.getType());
   auto resultType = structType.getFieldType(fieldAttr);
   build(builder, odsState, resultType, input, fieldAttr);
 }

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -1204,7 +1204,7 @@ LogicalResult StructFieldInOutOp::inferReturnTypes(
   if (!field)
     return failure();
   auto structType =
-      getInOutElementType(operands[0].getType()).cast<hw::StructType>();
+      hw::type_cast<hw::StructType>(getInOutElementType(operands[0].getType()));
   auto resultType = structType.getFieldType(field.cast<StringAttr>());
   if (!resultType)
     return failure();

--- a/lib/Dialect/SV/SVTypes.cpp
+++ b/lib/Dialect/SV/SVTypes.cpp
@@ -25,10 +25,11 @@ using namespace circt::sv;
 Type circt::sv::getAnyHWArrayElementType(Type type) {
   if (!type)
     return {};
-  if (auto array = type.dyn_cast<hw::ArrayType>())
+  if (auto array = hw::type_dyn_cast<hw::ArrayType>(type))
     return array.getElementType();
-  if (auto array = type.dyn_cast<hw::UnpackedArrayType>())
+  if (auto array = hw::type_dyn_cast<hw::UnpackedArrayType>(type))
     return array.getElementType();
+
   return {};
 }
 

--- a/test/Conversion/ExportVerilog/hw-typedecls.mlir
+++ b/test/Conversion/ExportVerilog/hw-typedecls.mlir
@@ -70,3 +70,20 @@ hw.module @testAggregateCreate(%i: i1) -> (out1: i1, out2: i1) {
   %2 = hw.struct_extract %0["b"] : !hw.typealias<@__hw_typedecls::@bar,!hw.struct<a: i1, b: i1>>
   hw.output %1, %2 : i1, i1
 }
+
+// CHECK-LABEL: module testAggregateInout
+hw.module @testAggregateInout(%i: i1) -> (out1: i8, out2: i1) {
+  // CHECK:      wire arr array;
+  // CHECK-NEXT: wire bar str;
+  // CHECK-EMPTY:
+  // CHECK-NEXT: assign out1 = array[4'h0];
+  // CHECk-NEXT: assign out2 = str.a;
+  %array = sv.wire : !hw.inout<!hw.typealias<@__hw_typedecls::@arr, !hw.array<16xi8>>>
+  %str = sv.wire : !hw.inout<!hw.typealias<@__hw_typedecls::@bar, !hw.struct<a: i1, b: i1>>>
+  %c0_i4 = hw.constant 0 : i4
+  %0 = sv.array_index_inout %array[%c0_i4] : !hw.inout<!hw.typealias<@__hw_typedecls::@arr, !hw.array<16xi8>>>, i4
+  %1 = sv.struct_field_inout %str["a"] : !hw.inout<!hw.typealias<@__hw_typedecls::@bar, !hw.struct<a: i1, b: i1>>>
+  %2 = sv.read_inout %0 : !hw.inout<i8>
+  %3 = sv.read_inout %1 : !hw.inout<i1>
+  hw.output %2, %3 : i8, i1
+}


### PR DESCRIPTION
This commit modifies SV inout operations to use `hw::type_cast` to
cast types so that they can be used with type alias.

Close https://github.com/llvm/circt/issues/2529