### PR TITLE
[SCFToCalyx] Support parallel loop iter arg register initialization.

### DIFF
--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -1708,13 +1708,9 @@ private:
                  whileSchedPtr) {
         auto &whileOp = whileSchedPtr->whileOp;
 
-        /// Insert while iter arg initialization group. For a single iter arg
-        /// initialization, just emit an enable, but for multiple, emit a
-        /// parallel group to assign them all at once.
-        if (whileSchedPtr->initGroups.size() == 1) {
-          rewriter.create<calyx::EnableOp>(
-              loc, whileSchedPtr->initGroups[0].getName());
-        } else {
+        /// Insert while iter arg initialization group(s). Emit a
+        /// parallel group to assign one or more registers all at once.
+        {
           PatternRewriter::InsertionGuard g(rewriter);
           auto parOp = rewriter.create<calyx::ParOp>(loc);
           rewriter.setInsertionPointToStart(parOp.getBody());

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -97,9 +97,9 @@ private:
 struct WhileScheduleable {
   /// While operation to schedule.
   WhileOpInterface whileOp;
-  /// The group to schedule before the while operation This group should set the
-  /// initial values of the loop init_args registers.
-  calyx::GroupOp initGroup;
+  /// The group(s) to schedule before the while operation These groups should
+  /// set the initial value(s) of the loop init_args register(s).
+  SmallVector<calyx::GroupOp> initGroups;
 };
 
 /// A variant of types representing scheduleable operations.
@@ -580,9 +580,11 @@ static void buildAssignmentsForRegisterWrite(ComponentLoweringState &state,
 
 /// Creates a new group that assigns the 'ops' values to the iter arg registers
 /// of the 'whileOp'.
-static calyx::GroupOp buildWhileIterArgAssignments(
-    PatternRewriter &rewriter, ComponentLoweringState &state, Location loc,
-    WhileOpInterface whileOp, Twine uniqueSuffix, ValueRange ops) {
+static calyx::GroupOp
+buildWhileIterArgAssignments(PatternRewriter &rewriter,
+                             ComponentLoweringState &state, Location loc,
+                             WhileOpInterface whileOp, Twine uniqueSuffix,
+                             MutableArrayRef<OpOperand> ops) {
   assert(whileOp.getOperation());
   /// Pass iteration arguments through registers. This follows closely
   /// to what is done for branch ops.
@@ -592,10 +594,9 @@ static calyx::GroupOp buildWhileIterArgAssignments(
   /// Create register assignment for each iter_arg. a calyx::GroupDone signal
   /// is created for each register. These will be &'ed together in
   /// MultipleGroupDonePattern.
-  for (auto arg : enumerate(ops)) {
-    auto reg = state.getWhileIterReg(whileOp, arg.index());
-    buildAssignmentsForRegisterWrite(state, rewriter, groupOp, reg,
-                                     arg.value());
+  for (auto &arg : ops) {
+    auto reg = state.getWhileIterReg(whileOp, arg.getOperandNumber());
+    buildAssignmentsForRegisterWrite(state, rewriter, groupOp, reg, arg.get());
   }
   return groupOp;
 }
@@ -1011,7 +1012,7 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
   auto assignGroup = buildWhileIterArgAssignments(
       rewriter, getComponentState(), yieldOp.getLoc(), whileOpInterface,
       getComponentState().getUniqueName(whileOp) + "_latch",
-      yieldOp.getOperands());
+      yieldOp->getOpOperands());
   getComponentState().setWhileLatchGroup(whileOpInterface, assignGroup);
   return success();
 }
@@ -1026,7 +1027,7 @@ BuildOpGroups::buildOp(PatternRewriter &rewriter,
   auto assignGroup = buildWhileIterArgAssignments(
       rewriter, getComponentState(), term.getLoc(), whileOpInterface,
       getComponentState().getUniqueName(whileOp) + "_latch",
-      term.getOperands());
+      term->getOpOperands());
   getComponentState().setWhileLatchGroup(whileOpInterface, assignGroup);
   return success();
 }
@@ -1542,18 +1543,24 @@ class BuildWhileGroups : public FuncOpPartialLoweringPattern {
             .replaceAllUsesWith(reg.out());
       }
 
-      /// Create iter args initial value assignment group
-      auto initGroupOp = buildWhileIterArgAssignments(
-          rewriter, getComponentState(), whileOp.getOperation()->getLoc(),
-          whileOp,
-          getComponentState().getUniqueName(whileOp.getOperation()) + "_init",
-          whileOp.getOperation()->getOperands());
+      /// Create iter args initial value assignment group(s), one per register.
+      SmallVector<calyx::GroupOp> initGroups;
+      auto numOperands = whileOp.getOperation()->getNumOperands();
+      for (size_t i = 0; i < numOperands; ++i) {
+        auto initGroupOp = buildWhileIterArgAssignments(
+            rewriter, getComponentState(), whileOp.getOperation()->getLoc(),
+            whileOp,
+            getComponentState().getUniqueName(whileOp.getOperation()) +
+                "_init_" + std::to_string(i),
+            whileOp.getOperation()->getOpOperand(i));
+        initGroups.push_back(initGroupOp);
+      }
 
       /// Add the while op to the list of scheduleable things in the current
       /// block.
       getComponentState().addBlockScheduleable(
           whileOp.getOperation()->getBlock(),
-          WhileScheduleable{whileOp, initGroupOp});
+          WhileScheduleable{whileOp, initGroups});
       return WalkResult::advance();
     });
     return res;
@@ -1701,9 +1708,19 @@ private:
                  whileSchedPtr) {
         auto &whileOp = whileSchedPtr->whileOp;
 
-        /// Insert while iter arg initialization group.
-        rewriter.create<calyx::EnableOp>(loc,
-                                         whileSchedPtr->initGroup.getName());
+        /// Insert while iter arg initialization group. For a single iter arg
+        /// initialization, just emit an enable, but for multiple, emit a
+        /// parallel group to assign them all at once.
+        if (whileSchedPtr->initGroups.size() == 1) {
+          rewriter.create<calyx::EnableOp>(
+              loc, whileSchedPtr->initGroups[0].getName());
+        } else {
+          PatternRewriter::InsertionGuard g(rewriter);
+          auto parOp = rewriter.create<calyx::ParOp>(loc);
+          rewriter.setInsertionPointToStart(parOp.getBody());
+          for (auto group : whileSchedPtr->initGroups)
+            rewriter.create<calyx::EnableOp>(loc, group.getName());
+        }
 
         auto cond = whileOp.getConditionValue();
         auto condGroup =

--- a/test/Conversion/SCFToCalyx/convert_controlflow.mlir
+++ b/test/Conversion/SCFToCalyx/convert_controlflow.mlir
@@ -81,15 +81,20 @@ module {
 // CHECK-DAG:        %bb3_arg0_reg.in, %bb3_arg0_reg.write_en, %bb3_arg0_reg.clk, %bb3_arg0_reg.reset, %bb3_arg0_reg.out, %bb3_arg0_reg.done = calyx.register @bb3_arg0_reg : i32, i1, i1, i1, i32, i1
 // CHECK-NEXT:       calyx.wires  {
 // CHECK-NEXT:         calyx.assign %out0 = %ret_arg0_reg.out : i32
-// CHECK-NEXT:         calyx.group @assign_while_0_init  {
+// CHECK-NEXT:         calyx.group @assign_while_0_init_0  {
 // CHECK-NEXT:           calyx.assign %while_0_arg0_reg.in = %in0 : i32
 // CHECK-NEXT:           calyx.assign %while_0_arg0_reg.write_en = %true : i1
+// CHECK-NEXT:           calyx.group_done %while_0_arg0_reg.done : i1
+// CHECK-NEXT:         }
+// CHECK-NEXT:         calyx.group @assign_while_0_init_1  {
 // CHECK-NEXT:           calyx.assign %while_0_arg1_reg.in = %c0_i32 : i32
 // CHECK-NEXT:           calyx.assign %while_0_arg1_reg.write_en = %true : i1
+// CHECK-NEXT:           calyx.group_done %while_0_arg1_reg.done : i1
+// CHECK-NEXT:         }
+// CHECK-NEXT:         calyx.group @assign_while_0_init_2  {
 // CHECK-NEXT:           calyx.assign %while_0_arg2_reg.in = %c0_i32 : i32
 // CHECK-NEXT:           calyx.assign %while_0_arg2_reg.write_en = %true : i1
-// CHECK-NEXT:           %0 = comb.and %while_0_arg0_reg.done, %while_0_arg1_reg.done, %while_0_arg2_reg.done : i1
-// CHECK-NEXT:           calyx.group_done %0 ? %true : i1
+// CHECK-NEXT:           calyx.group_done %while_0_arg2_reg.done : i1
 // CHECK-NEXT:         }
 // CHECK-NEXT:         calyx.comb_group @bb0_0  {
 // CHECK-NEXT:           calyx.assign %std_slt_0.left = %while_0_arg0_reg.out : i32
@@ -139,7 +144,11 @@ module {
 // CHECK-NEXT:       }
 // CHECK-NEXT:       calyx.control  {
 // CHECK-NEXT:         calyx.seq  {
-// CHECK-NEXT:           calyx.enable @assign_while_0_init
+// CHECK-NEXT:           calyx.par {
+// CHECK-NEXT:             calyx.enable @assign_while_0_init_0
+// CHECK-NEXT:             calyx.enable @assign_while_0_init_1
+// CHECK-NEXT:             calyx.enable @assign_while_0_init_2
+// CHECK-NEXT:           }
 // CHECK-NEXT:           calyx.while %std_slt_0.out with @bb0_0  {
 // CHECK-NEXT:             calyx.seq  {
 // CHECK-NEXT:               calyx.if %std_slt_1.out with @bb0_1  {
@@ -207,15 +216,20 @@ module {
 // CHECK-DAG:        %bb3_arg0_reg.in, %bb3_arg0_reg.write_en, %bb3_arg0_reg.clk, %bb3_arg0_reg.reset, %bb3_arg0_reg.out, %bb3_arg0_reg.done = calyx.register @bb3_arg0_reg : i32, i1, i1, i1, i32, i1
 // CHECK-NEXT:       calyx.wires  {
 // CHECK-NEXT:         calyx.assign %out0 = %ret_arg0_reg.out : i32
-// CHECK-NEXT:         calyx.group @assign_while_0_init  {
+// CHECK-NEXT:         calyx.group @assign_while_0_init_0  {
 // CHECK-NEXT:           calyx.assign %while_0_arg0_reg.in = %in0 : i32
 // CHECK-NEXT:           calyx.assign %while_0_arg0_reg.write_en = %true : i1
+// CHECK-NEXT:           calyx.group_done %while_0_arg0_reg.done : i1
+// CHECK-NEXT:         }
+// CHECK-NEXT:         calyx.group @assign_while_0_init_1  {
 // CHECK-NEXT:           calyx.assign %while_0_arg1_reg.in = %c0_i32 : i32
 // CHECK-NEXT:           calyx.assign %while_0_arg1_reg.write_en = %true : i1
+// CHECK-NEXT:           calyx.group_done %while_0_arg1_reg.done : i1
+// CHECK-NEXT:         }
+// CHECK-NEXT:         calyx.group @assign_while_0_init_2  {
 // CHECK-NEXT:           calyx.assign %while_0_arg2_reg.in = %c0_i32 : i32
 // CHECK-NEXT:           calyx.assign %while_0_arg2_reg.write_en = %true : i1
-// CHECK-NEXT:           %0 = comb.and %while_0_arg0_reg.done, %while_0_arg1_reg.done, %while_0_arg2_reg.done : i1
-// CHECK-NEXT:           calyx.group_done %0 ? %true : i1
+// CHECK-NEXT:           calyx.group_done %while_0_arg2_reg.done : i1
 // CHECK-NEXT:         }
 // CHECK-NEXT:         calyx.comb_group @bb0_0  {
 // CHECK-NEXT:           calyx.assign %std_slt_0.left = %while_0_arg0_reg.out : i32
@@ -265,7 +279,11 @@ module {
 // CHECK-NEXT:       }
 // CHECK-NEXT:       calyx.control  {
 // CHECK-NEXT:         calyx.seq  {
-// CHECK-NEXT:           calyx.enable @assign_while_0_init
+// CHECK-NEXT:           calyx.par  {
+// CHECK-NEXT:             calyx.enable @assign_while_0_init_0
+// CHECK-NEXT:             calyx.enable @assign_while_0_init_1
+// CHECK-NEXT:             calyx.enable @assign_while_0_init_2
+// CHECK-NEXT:           }
 // CHECK-NEXT:           calyx.while %std_slt_0.out with @bb0_0  {
 // CHECK-NEXT:             calyx.seq  {
 // CHECK-NEXT:               calyx.if %std_slt_1.out with @bb0_1  {

--- a/test/Conversion/SCFToCalyx/convert_memory.mlir
+++ b/test/Conversion/SCFToCalyx/convert_memory.mlir
@@ -43,7 +43,9 @@
 // CHECK-NEXT:       }
 // CHECK-NEXT:       calyx.control  {
 // CHECK-NEXT:         calyx.seq  {
-// CHECK-NEXT:           calyx.enable @assign_while_0_init_0
+// CHECK-NEXT:           calyx.par  {
+// CHECK-NEXT:             calyx.enable @assign_while_0_init_0
+// CHECK-NEXT:           }
 // CHECK-NEXT:           calyx.while %std_lt_0.out with @bb0_0  {
 // CHECK-NEXT:             calyx.seq  {
 // CHECK-NEXT:               calyx.enable @bb0_2

--- a/test/Conversion/SCFToCalyx/convert_memory.mlir
+++ b/test/Conversion/SCFToCalyx/convert_memory.mlir
@@ -15,7 +15,7 @@
 // CHECK-DAG:        %mem_0.addr0, %mem_0.write_data, %mem_0.write_en, %mem_0.clk, %mem_0.read_data, %mem_0.done = calyx.memory @mem_0 <[64] x 32> [6] {external = true} : i6, i32, i1, i1, i32, i1
 // CHECK-DAG:        %while_0_arg0_reg.in, %while_0_arg0_reg.write_en, %while_0_arg0_reg.clk, %while_0_arg0_reg.reset, %while_0_arg0_reg.out, %while_0_arg0_reg.done = calyx.register @while_0_arg0_reg : i32, i1, i1, i1, i32, i1
 // CHECK-NEXT:       calyx.wires  {
-// CHECK-NEXT:         calyx.group @assign_while_0_init  {
+// CHECK-NEXT:         calyx.group @assign_while_0_init_0  {
 // CHECK-NEXT:           calyx.assign %while_0_arg0_reg.in = %c0_i32 : i32
 // CHECK-NEXT:           calyx.assign %while_0_arg0_reg.write_en = %true : i1
 // CHECK-NEXT:           calyx.group_done %while_0_arg0_reg.done : i1
@@ -43,7 +43,7 @@
 // CHECK-NEXT:       }
 // CHECK-NEXT:       calyx.control  {
 // CHECK-NEXT:         calyx.seq  {
-// CHECK-NEXT:           calyx.enable @assign_while_0_init
+// CHECK-NEXT:           calyx.enable @assign_while_0_init_0
 // CHECK-NEXT:           calyx.while %std_lt_0.out with @bb0_0  {
 // CHECK-NEXT:             calyx.seq  {
 // CHECK-NEXT:               calyx.enable @bb0_2

--- a/test/Conversion/SCFToCalyx/convert_pipeline.mlir
+++ b/test/Conversion/SCFToCalyx/convert_pipeline.mlir
@@ -9,14 +9,14 @@
 // CHECK-DAG:     %[[LT_LEFT:.+]], %[[LT_RIGHT:.+]], %[[LT_OUT:.+]] = calyx.std_lt
 // CHECK-DAG:     %[[ITER_ARG_IN:.+]], %[[ITER_ARG_EN:.+]], %while_0_arg0_reg.clk, %while_0_arg0_reg.reset, %[[ITER_ARG_OUT:.+]], %[[ITER_ARG_DONE:.+]] = calyx.register
 // CHECK:         calyx.wires
-// CHECK-DAG:       calyx.group @assign_while_0_init
+// CHECK-DAG:       calyx.group @[[INIT_GROUP:.+]] {
 // CHECK-DAG:         calyx.assign %[[ITER_ARG_IN]] = %[[C0]] : i64
 // CHECK-DAG:         calyx.assign %[[ITER_ARG_EN]] = %[[TRUE]] : i1
 // CHECK-DAG:         calyx.group_done %[[ITER_ARG_DONE]] : i1
-// CHECK-DAG:       calyx.comb_group @bb0_0
+// CHECK-DAG:       calyx.comb_group @[[COND_GROUP:.+]] {
 // CHECK-DAG:         calyx.assign %[[LT_LEFT]] = %[[ITER_ARG_OUT]] : i64
 // CHECK-DAG:         calyx.assign %[[LT_RIGHT]] = %[[C10]] : i64
-// CHECK-DAG:       calyx.group @assign_while_0_latch
+// CHECK-DAG:       calyx.group @[[COMPUTE_GROUP:.+]] {
 // CHECK-DAG:         calyx.assign %[[ITER_ARG_IN]] = %[[ADD_OUT]] : i64
 // CHECK-DAG:         calyx.assign %[[ITER_ARG_EN]] = %[[TRUE]] : i1
 // CHECK-DAG:         calyx.assign %[[ADD_LEFT]] = %[[ITER_ARG_OUT]] : i64
@@ -24,10 +24,10 @@
 // CHECK-DAG:         calyx.group_done %[[ITER_ARG_DONE]] : i1
 // CHECK:         calyx.control
 // CHECK-NEXT:      calyx.seq
-// CHECK-NEXT:        calyx.enable @assign_while_0_init
-// CHECK-NEXT:        calyx.while %[[LT_OUT]] with @bb0_0
+// CHECK-NEXT:        calyx.enable @[[INIT_GROUP]]
+// CHECK-NEXT:        calyx.while %[[LT_OUT]] with @[[COND_GROUP]]
 // CHECK-NEXT:          calyx.par
-// CHECK-NEXT:            calyx.enable @assign_while_0_latch
+// CHECK-NEXT:            calyx.enable @[[COMPUTE_GROUP]]
 // CHECK-NEXT:          }
 // CHECK-NEXT:        }
 // CHECK-NEXT:      }

--- a/test/Conversion/SCFToCalyx/convert_pipeline.mlir
+++ b/test/Conversion/SCFToCalyx/convert_pipeline.mlir
@@ -24,7 +24,9 @@
 // CHECK-DAG:         calyx.group_done %[[ITER_ARG_DONE]] : i1
 // CHECK:         calyx.control
 // CHECK-NEXT:      calyx.seq
-// CHECK-NEXT:        calyx.enable @[[INIT_GROUP]]
+// CHECK-NEXT:        calyx.par
+// CHECK-NEXT:          calyx.enable @[[INIT_GROUP]]
+// CHECK-NEXT:        }
 // CHECK-NEXT:        calyx.while %[[LT_OUT]] with @[[COND_GROUP]]
 // CHECK-NEXT:          calyx.par
 // CHECK-NEXT:            calyx.enable @[[COMPUTE_GROUP]]


### PR DESCRIPTION
Previously, all iter arg registers were assigned in a single
group. This prevents Calyx from being able to infer static timing for
this group. While we could enhance the downstream analysis, this patch
makes the potential parallelism explicit in the IR when multiple
registers are initialized. With this, Calyx is able to infer static
timing for the initialization group.