### PR TITLE
[Calyx] Canonicalize simple Par ops

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxControl.td
+++ b/include/circt/Dialect/Calyx/CalyxControl.td
@@ -177,7 +177,7 @@ def ParOp : CalyxContainer<"par", [
       region->push_back(new Block());
     }]>
   ];
-  let hasCanonicalizeMethod = true;
+  let hasCanonicalizer = true;
   let verifier = "return ::verify$cppClass(*this);";
 }
 

--- a/include/circt/Dialect/Calyx/CalyxControl.td
+++ b/include/circt/Dialect/Calyx/CalyxControl.td
@@ -148,8 +148,7 @@ def SeqOp : CalyxContainer<"seq", [
       region->push_back(new Block());
     }]>
   ];
-  let hasCanonicalizeMethod = true;
-
+  let hasCanonicalizer = true;
 }
 
 def ParOp : CalyxContainer<"par", [

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -64,10 +64,9 @@ struct CollapseUnaryControl : mlir::OpRewritePattern<CtrlOp> {
   LogicalResult matchAndRewrite(CtrlOp ctrlOp,
                                 PatternRewriter &rewriter) const override {
     auto &ops = ctrlOp.getBody()->getOperations();
-    if (ops.size() != 1 || !isa<EnableOp>(ops.front()))
-      return failure();
-
-    if (!isa<SeqOp, ParOp>(ctrlOp->getParentOp()))
+    bool isUnaryControl = (ops.size() == 1) && isa<EnableOp>(ops.front()) &&
+                          isa<SeqOp, ParOp>(ctrlOp->getParentOp());
+    if (!isUnaryControl)
       return failure();
 
     ops.front().moveBefore(ctrlOp);

--- a/test/Conversion/SCFToCalyx/convert_memory.mlir
+++ b/test/Conversion/SCFToCalyx/convert_memory.mlir
@@ -43,9 +43,7 @@
 // CHECK-NEXT:       }
 // CHECK-NEXT:       calyx.control  {
 // CHECK-NEXT:         calyx.seq  {
-// CHECK-NEXT:           calyx.par  {
-// CHECK-NEXT:             calyx.enable @assign_while_0_init_0
-// CHECK-NEXT:           }
+// CHECK-NEXT:           calyx.enable @assign_while_0_init_0
 // CHECK-NEXT:           calyx.while %std_lt_0.out with @bb0_0  {
 // CHECK-NEXT:             calyx.seq  {
 // CHECK-NEXT:               calyx.enable @bb0_2

--- a/test/Dialect/Calyx/canonicalization.mlir
+++ b/test/Dialect/Calyx/canonicalization.mlir
@@ -461,7 +461,7 @@ calyx.program "main" {
 
 // -----
 
-// Par ops with a single calyx.enable nested within a seq group is collapsed.
+// Unary control operations are collapsed.
 calyx.program "main" {
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
@@ -489,7 +489,9 @@ calyx.program "main" {
       calyx.seq {
         calyx.enable @B
         calyx.par {
-          calyx.enable @A
+          calyx.seq {
+            calyx.enable @A
+          }
         }
         calyx.enable @B
       }

--- a/test/Dialect/Calyx/canonicalization.mlir
+++ b/test/Dialect/Calyx/canonicalization.mlir
@@ -458,3 +458,41 @@ calyx.program "main" {
     }
   }
 }
+
+// -----
+
+// Par ops with a single calyx.enable nested within a seq group is collapsed.
+calyx.program "main" {
+  calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
+    %c1_1 = hw.constant 1 : i1
+    calyx.wires {
+      calyx.group @A {
+        calyx.assign %r.in = %c1_1 : i1
+        calyx.assign %r.write_en = %c1_1 : i1
+        calyx.group_done %r.done : i1
+      }
+      calyx.group @B {
+        calyx.assign %r.in = %c1_1 : i1
+        calyx.assign %r.write_en = %c1_1 : i1
+        calyx.group_done %r.done : i1
+      }
+    }
+    // CHECK-LABEL: calyx.control {
+    // CHECK-NEXT:    calyx.seq {
+    // CHECK-NEXT:      calyx.enable @B
+    // CHECK-NEXT:      calyx.enable @A
+    // CHECK-NEXT:      calyx.enable @B
+    // CHECK-NEXT:    }
+    // CHECK-NEXT:  }
+    calyx.control {
+      calyx.seq {
+        calyx.enable @B
+        calyx.par {
+          calyx.enable @A
+        }
+        calyx.enable @B
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pattern canonicalizes away a ParOp in cases where
1. it is nested within a seq structure
2. it enables only a single group.