### PR TITLE
[FIRRTL] Add isCompatibleReturnTypes to FIRRTLExprOp to allow MLIR parser accepting unknown width.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -78,7 +78,7 @@ class FIRRTLExprOp<string mnemonic, list<OpTrait> traits = []> :
     /// Returns when two result types are compatible for this op; method used
     /// by InferTypeOpInterface, this allows FIRRTL accept unknown width type.
     static bool isCompatibleReturnTypes(TypeRange l, TypeRange r) {
-      return areTypesEquivalent(l[0].cast<FIRRTLType>(), r[0].cast<FIRRTLType>());
+      return areTypesEquivalent(l[0].cast<FIRRTLType>(), r[0].cast<FIRRTLType>(), true);
     }
   }];
 }

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -74,6 +74,12 @@ class FIRRTLExprOp<string mnemonic, list<OpTrait> traits = []> :
         return {};
       return inferReturnType(operands, attrs, loc);
     }
+
+    /// Returns when two result types are compatible for this op; method used
+    /// by InferTypeOpInterface, this allows FIRRTL accept unknown width type.
+    static bool isCompatibleReturnTypes(TypeRange l, TypeRange r) {
+      return areTypesEquivalent(l[0].cast<FIRRTLType>(), r[0].cast<FIRRTLType>());
+    }
   }];
 }
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -131,7 +131,8 @@ protected:
 /// that it only compares passive types. Because of how the FIRRTL dialect uses
 /// flip types in module ports and aggregates, this definition, unlike the spec,
 /// ignores flips.
-bool areTypesEquivalent(FIRRTLType destType, FIRRTLType srcType);
+bool areTypesEquivalent(FIRRTLType destType, FIRRTLType srcType,
+                        bool checkWidth = false);
 
 /// Returns true if two types are weakly equivalent.  See the FIRRTL spec,
 /// Section 4.6, for a full definition of this.  Roughly, the oriented types

--- a/test/firtool/parse-unknown-width.mlir
+++ b/test/firtool/parse-unknown-width.mlir
@@ -1,0 +1,23 @@
+// RUN: firtool %s --format=mlir --ir-fir    | circt-opt | FileCheck %s --check-prefix=MLIR
+
+firrtl.circuit "Example" {
+  firrtl.module @Example(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %in: !firrtl.uint<2>, out %out: !firrtl.uint<2>) {
+    %_GEN_0 = firrtl.add %in, %in : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint
+    %_out_T = firrtl.node %_GEN_0 : !firrtl.uint
+    %_GEN_1 = firrtl.add %in, %in : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint
+    %_GEN_2 = firrtl.tail %_out_T, 1 : (!firrtl.uint) -> !firrtl.uint
+    %_out_T_1 = firrtl.node %_GEN_2 : !firrtl.uint
+    %_GEN_3 = firrtl.tail %_out_T, 1 : (!firrtl.uint) -> !firrtl.uint
+    firrtl.connect %out, %_out_T_1 : !firrtl.uint<2>, !firrtl.uint
+  }
+}
+
+// MLIR-LABEL: module  {
+// MLIR-NEXT :   firrtl.circuit "Example"   {
+// MLIR-NEXT :     firrtl.module @Example(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %in: !firrtl.uint<2>, out %out: !firrtl.uint<2>) {
+// MLIR-NEXT :       %_out_T = firrtl.add %in, %in {name = "_out_T"} : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<3>
+// MLIR-NEXT :       %_out_T_1 = firrtl.bits %_out_T 1 to 0 {name = "_out_T_1"} : (!firrtl.uint<3>) -> !firrtl.uint<2>
+// MLIR-NEXT :       firrtl.connect %out, %_out_T_1 : !firrtl.uint<2>, !firrtl.uint<2>
+// MLIR-NEXT :     }
+// MLIR-NEXT :   }
+// MLIR-NEXT : }


### PR DESCRIPTION
This PR fixes #2538
