### PR TITLE
[ExportVerilog] Add $sampled use it in LowerToHW

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -3557,8 +3557,18 @@ LogicalResult FIRRTLLowering::lowerVerificationStatement(
   SmallVector<Value> messageOps;
   if (!isCover && opMessageAttr && !opMessageAttr.getValue().empty()) {
     message = opMessageAttr;
-    for (auto operand : opOperands)
-      messageOps.push_back(getLoweredValue(operand));
+    for (auto operand : opOperands) {
+      auto loweredValue = getLoweredValue(operand);
+      // Wrap any message ops in $sampled() to guarantee that these will print
+      // with the same value as when the assertion triggers.  (See SystemVerilog
+      // 2017 spec section 16.9.3 for more information.)  The custom
+      // "ifElseFatal" variant is special cased because this isn't actually a
+      // concurrent assertion.
+      auto format = op->getAttrOfType<StringAttr>("format");
+      if (isConcurrent && (!format || format.getValue() != "ifElseFatal"))
+        loweredValue = builder.create<sv::SampledOp>(loweredValue);
+      messageOps.push_back(loweredValue);
+    }
   }
 
   auto emit = [&]() {

--- a/lib/Dialect/FIRRTL/Import/FIRParserAsserts.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParserAsserts.cpp
@@ -586,6 +586,8 @@ ParseResult circt::firrtl::foldWhenEncodedVerifOp(PrintFOp printOp) {
     Operation *op;
     predicate = builder.create<NotPrimOp>(
         predicate); // assertion triggers when predicate fails
+    // TODO: The "ifElseFatal" variant isn't actually a concurrent assertion,
+    // but downstream logic assumes that isConcurrent is set.
     if (flavor == VerifFlavor::VerifLibAssert)
       op = builder.create<AssertOp>(printOp.clock(), predicate, printOp.cond(),
                                     message, printOp.operands(), label, true);

--- a/lib/Dialect/FIRRTL/Import/FIRParserAsserts.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParserAsserts.cpp
@@ -435,18 +435,12 @@ ParseResult circt::firrtl::foldWhenEncodedVerifOp(PrintFOp printOp) {
 
     // Handle the case of builtin Chisel assertions.
     //
-    // These are historically emitted as non-concurrent assertions and are
-    // expected to have format string arguments.  Parsing these as
-    // non-concurrent assertions works around two VCS lint warnings that arise
-    // if these are emitted as concurrent assertions:
-    //   1. VCS warns about non-sampled values used in the pass/fail statements
-    //      of concurrent assertions.
-    //   2. VCS warns if you sample the values ($sample) indicating that the
-    //      assertion has side effects.
+    // These are historically emitted as non-concurrent assertions but we choose
+    // to treat them as concurrent.
   case VerifFlavor::ChiselAssert: {
     builder.create<AssertOp>(
         printOp.clock(), builder.create<NotPrimOp>(whenStmt.condition()),
-        printOp.cond(), fmt, printOp.operands(), "chisel3_builtin", false);
+        printOp.cond(), fmt, printOp.operands(), "chisel3_builtin", true);
     printOp.erase();
     break;
   }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -438,10 +438,11 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: [[TMP3:%.+]] = comb.xor %aEn, [[TRUE]]
     // CHECK-NEXT: [[TMP4:%.+]] = comb.or [[TMP3]], %aCond
     // CHECK-NEXT: sv.assert.concurrent posedge %clock, [[TMP4]] label "assert__assert_0" message "assert0"
+    // CHECK-NEXT: [[SAMPLED:%.+]] =  sv.system.sampled %value : i42
     // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
     // CHECK-NEXT: [[TMP5:%.+]] = comb.xor %aEn, [[TRUE]]
     // CHECK-NEXT: [[TMP6:%.+]] = comb.or [[TMP5]], %aCond
-    // CHECK-NEXT: sv.assert.concurrent posedge %clock, [[TMP6]] message "assert0"(%value) : i42
+    // CHECK-NEXT: sv.assert.concurrent posedge %clock, [[TMP6]] message "assert0"([[SAMPLED]]) : i42
     // CHECK-NEXT: sv.ifdef "USE_PROPERTY_AS_CONSTRAINT" {
     // CHECK-NEXT:   sv.assume.concurrent posedge %clock, [[TMP2]]
     // CHECK-NEXT:   sv.assume.concurrent posedge %clock, [[TMP4]] label "assume__assert_0"
@@ -458,10 +459,11 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: [[TMP1:%.+]] = comb.xor %bEn, [[TRUE]]
     // CHECK-NEXT: [[TMP2:%.+]] = comb.or [[TMP1]], %bCond
     // CHECK-NEXT: sv.assume.concurrent posedge %clock, [[TMP2]] label "assume__assume_0" message "assume0"
+    // CHECK-NEXT: [[SAMPLED:%.+]] = sv.system.sampled %value
     // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
     // CHECK-NEXT: [[TMP1:%.+]] = comb.xor %bEn, [[TRUE]]
     // CHECK-NEXT: [[TMP2:%.+]] = comb.or [[TMP1]], %bCond
-    // CHECK-NEXT: sv.assume.concurrent posedge %clock, [[TMP2]] message "assume0"(%value) : i42
+    // CHECK-NEXT: sv.assume.concurrent posedge %clock, [[TMP2]] message "assume0"([[SAMPLED]]) : i42
     firrtl.cover %clock, %cCond, %cEn, "cover0" {isConcurrent = true}
     firrtl.cover %clock, %cCond, %cEn, "cover0" {isConcurrent = true, name = "cover_0"}
     firrtl.cover %clock, %cCond, %cEn, "cover0"(%value) : !firrtl.uint<42> {isConcurrent = true}

--- a/test/Dialect/FIRRTL/SFCTests/complex-asserts.fir
+++ b/test/Dialect/FIRRTL/SFCTests/complex-asserts.fir
@@ -75,9 +75,9 @@ circuit Foo:
     ; assert emitted as SVA
     ; CHECK-NEXT: wire [[TMP1:.+]] = ~enable | predicate5 | reset;
     ; CHECK-NEXT: assert__verif_library: assert property (@(posedge clock) [[TMP1]])
-    ; CHECK-SAME:   else $error("Assertion failed (verification library): SVA assert example");
+    ; CHECK-SAME:   else $error("Assertion failed (verification library): SVA assert example, sum was %d", $sampled(sum));
     when not(or(predicate5, asUInt(reset))) :
-      printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"format\":{\"type\":\"sva\"},\"baseMsg\":\"Assertion failed (verification library): SVA assert example\"}</extraction-summary> bar")
+      printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"format\":{\"type\":\"sva\"},\"baseMsg\":\"Assertion failed (verification library): SVA assert example, sum was %d\"}</extraction-summary> bar", sum)
       stop(clock, enable, 1)
 
     ; assert with custom label

--- a/test/Dialect/FIRRTL/SFCTests/complex-assumes.fir
+++ b/test/Dialect/FIRRTL/SFCTests/complex-assumes.fir
@@ -42,7 +42,7 @@ circuit Foo:
 
     ; assume with message with arguments
     ; CHECK-NEXT: {{assume__verif_library.*}}: assume property (@(posedge clock) ~enable | predicate4 | reset)
-    ; CHECK-SAME:   else $error("Assumption does not hold (verification library): expected sum === 2.U but got %d", sum);
+    ; CHECK-SAME:   else $error("Assumption does not hold (verification library): expected sum === 2.U but got %d", $sampled(sum));
     when not(or(predicate4, asUInt(reset))) :
       printf(clock, enable, "foo [verif-library-assume]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"baseMsg\":\"Assumption does not hold (verification library): expected sum === 2.U but got %d\"}</extraction-summary> bar", sum)
       stop(clock, enable, 1)

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -961,7 +961,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       stop(clock, enable, 1)
     ; CHECK: [[TMP:%.+]] = firrtl.not %cond
     ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Assertion failed with value %d"(%value) : !firrtl.uint<42>
-    ; CHECK-SAME: isConcurrent = false
+    ; CHECK-SAME: isConcurrent = true
     ; CHECK-SAME: name = "chisel3_builtin"
 
     when cond:
@@ -969,7 +969,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       stop(clock, enable, 1)
     ; CHECK: [[TMP:%.+]] = firrtl.not %cond
     ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Assertion failed: some message with value %d"(%value) : !firrtl.uint<42>
-    ; CHECK-SAME: isConcurrent = false
+    ; CHECK-SAME: isConcurrent = true
     ; CHECK-SAME: name = "chisel3_builtin"
 
     ; Verification Library Assertions


### PR DESCRIPTION
This adds a `sv.system.sampled` operation that emits as an always-inline `$sample(...)` system function.  This is then used as the lowering for concurrent asserts coming out of FIRRTL Dialect.

Fixes #2548.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>