### PR TITLE
[FIRRTL][InstanceGraph] Make instance graph mutable

### DIFF
--- a/include/circt/Dialect/FIRRTL/InstanceGraph.h
+++ b/include/circt/Dialect/FIRRTL/InstanceGraph.h
@@ -100,7 +100,7 @@ public:
   bool hasOneUse() { return llvm::hasSingleElement(uses()); }
 
   /// Get the number of direct instantiations of this module.
-  size_t getNumUses() { return std::distance(uses_begin(), uses_end()); }
+  size_t getNumUses() { return std::distance(usesBegin(), usesEnd()); }
 
   /// Iterator for module uses.
   struct UseIterator
@@ -125,10 +125,10 @@ public:
   };
 
   /// Iterate the instance records which instantiate this module.
-  UseIterator uses_begin() { return {this}; }
-  UseIterator uses_end() { return {}; }
+  UseIterator usesBegin() { return {this}; }
+  UseIterator usesEnd() { return {}; }
   llvm::iterator_range<UseIterator> uses() {
-    return llvm::make_range(uses_begin(), uses_end());
+    return llvm::make_range(usesBegin(), usesEnd());
   }
 
   /// Record a new instance op in the body of this module. Returns a newly
@@ -344,10 +344,10 @@ struct GraphTraits<Inverse<circt::firrtl::InstanceGraphNode *>> {
     return inverse.Graph;
   }
   static ChildIteratorType child_begin(NodeRef node) {
-    return {node->uses_begin(), &getParent};
+    return {node->usesBegin(), &getParent};
   }
   static ChildIteratorType child_end(NodeRef node) {
-    return {node->uses_end(), &getParent};
+    return {node->usesEnd(), &getParent};
   }
 };
 

--- a/include/circt/Dialect/FIRRTL/InstanceGraph.h
+++ b/include/circt/Dialect/FIRRTL/InstanceGraph.h
@@ -15,22 +15,33 @@
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Support/LLVM.h"
 #include "llvm/ADT/GraphTraits.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/iterator.h"
-#include <deque>
 
 namespace circt {
 namespace firrtl {
+
+namespace detail {
+/// This just maps a iterator of references to an iterator of addresses.
+template <typename I>
+struct AddressIterator
+    : public llvm::mapped_iterator<I, typename I::pointer (*)(
+                                          typename I::reference)> {
+  /* implicit */ AddressIterator(I iterator)
+      : llvm::mapped_iterator<I,
+                              typename I::pointer (*)(typename I::reference)>(
+            iterator, &std::addressof<typename I::value_type>) {}
+};
+
+} // namespace detail
 
 class InstanceGraphNode;
 
 /// This is an edge in the InstanceGraph. This tracks a specific instantiation
 /// of a module.
-class InstanceRecord {
+class InstanceRecord
+    : public llvm::ilist_node_with_parent<InstanceRecord, InstanceGraphNode> {
 public:
-  InstanceRecord(InstanceOp instance, InstanceGraphNode *parent,
-                 InstanceGraphNode *target)
-      : instance(instance), parent(parent), target(target) {}
-
   /// Get the InstanceOp that this is tracking.
   InstanceOp getInstance() const { return instance; }
 
@@ -40,68 +51,95 @@ public:
   /// Get the module which the InstanceOp is instantiating.
   InstanceGraphNode *getTarget() const { return target; }
 
+  /// Erase this instance record, removing it from the parent module and the
+  /// target's use-list.
+  void erase();
+
 private:
   friend class InstanceGraph;
+  friend class InstanceGraphNode;
 
-  /// The InstanceOp that this is tracking.
-  InstanceOp instance;
+  InstanceRecord(InstanceGraphNode *parent, InstanceOp instance,
+                 InstanceGraphNode *target)
+      : parent(parent), instance(instance), target(target) {}
+  InstanceRecord(const InstanceRecord &) = delete;
 
   /// This is the module where the InstanceOp lives.
   InstanceGraphNode *parent;
 
+  /// The InstanceOp that this is tracking.
+  InstanceOp instance;
+
   /// This is the module which the InstanceOp is instantiating.
   InstanceGraphNode *target;
+  /// Intrusive linked list for other uses.
+  InstanceRecord *nextUse = nullptr;
+  InstanceRecord *prevUse = nullptr;
 };
 
 /// This is a Node in the InstanceGraph.  Each node represents a Module in a
 /// Circuit.  Both external modules and regular modules can be represented by
 /// this class. It is possible to efficiently iterate all modules instantiated
 /// by this module, as well as all instantiations of this module.
-class InstanceGraphNode {
-  using EdgeVec = std::deque<InstanceRecord>;
-  using UseVec = std::vector<InstanceRecord *>;
-
-  static InstanceRecord *unwrap(EdgeVec::value_type &value) { return &value; }
-  class InstanceIterator final
-      : public llvm::mapped_iterator<EdgeVec::iterator, decltype(&unwrap)> {
-  public:
-    /// Initializes the result type iterator to the specified result iterator.
-    InstanceIterator(EdgeVec::iterator it)
-        : llvm::mapped_iterator<EdgeVec::iterator, decltype(&unwrap)>(it,
-                                                                      &unwrap) {
-    }
-  };
+class InstanceGraphNode : public llvm::ilist_node<InstanceGraphNode> {
+  using InstanceList = llvm::iplist<InstanceRecord>;
 
 public:
-  InstanceGraphNode() : module(nullptr) {}
-
   /// Get the module that this node is tracking.
   Operation *getModule() const { return module; }
 
   /// Iterate the instance records in this module.
-  using iterator = InstanceIterator;
-  iterator begin() { return iterator(moduleInstances.begin()); }
-  iterator end() { return iterator(moduleInstances.end()); }
-  llvm::iterator_range<iterator> instances() {
-    return llvm::make_range(begin(), end());
-  }
+  using iterator = detail::AddressIterator<InstanceList::iterator>;
+  iterator begin() { return instances.begin(); }
+  iterator end() { return instances.end(); }
+
+  /// Return true if there are no more instances of this module.
+  bool noUses() { return !firstUse; }
+
+  /// Return true if this module has exactly one use.
+  bool hasOneUse() { return llvm::hasSingleElement(uses()); }
 
   /// Get the number of direct instantiations of this module.
-  unsigned getNumUses() { return moduleUses.size(); }
+  size_t getNumUses() { return std::distance(uses_begin(), uses_end()); }
+
+  /// Iterator for module uses.
+  struct UseIterator
+      : public llvm::iterator_facade_base<
+            UseIterator, std::forward_iterator_tag, InstanceRecord *> {
+    UseIterator() : current(nullptr) {}
+    UseIterator(InstanceGraphNode *node) : current(node->firstUse) {}
+    InstanceRecord *operator*() const { return current; }
+    using llvm::iterator_facade_base<UseIterator, std::forward_iterator_tag,
+                                     InstanceRecord *>::operator++;
+    UseIterator &operator++() {
+      assert(current && "incrementing past end");
+      current = current->nextUse;
+      return *this;
+    }
+    bool operator==(const UseIterator &other) const {
+      return current == other.current;
+    }
+
+  private:
+    InstanceRecord *current;
+  };
 
   /// Iterate the instance records which instantiate this module.
-  using use_iterator = UseVec::iterator;
-  use_iterator uses_begin() { return moduleUses.begin(); }
-  use_iterator uses_end() { return moduleUses.end(); }
-  llvm::iterator_range<use_iterator> uses() {
+  UseIterator uses_begin() { return {this}; }
+  UseIterator uses_end() { return {}; }
+  llvm::iterator_range<UseIterator> uses() {
     return llvm::make_range(uses_begin(), uses_end());
   }
 
-private:
   /// Record a new instance op in the body of this module. Returns a newly
   /// allocated InstanceRecord which will be owned by this node.
-  InstanceRecord *recordInstance(InstanceOp instance,
-                                 InstanceGraphNode *target);
+  InstanceRecord *addInstance(InstanceOp instance, InstanceGraphNode *target);
+
+private:
+  friend class InstanceRecord;
+
+  InstanceGraphNode() : module(nullptr) {}
+  InstanceGraphNode(const InstanceGraphNode &) = delete;
 
   /// Record that a module instantiates this module.
   void recordUse(InstanceRecord *record);
@@ -112,10 +150,10 @@ private:
   /// List of instance operations in this module.  This member owns the
   /// InstanceRecords, which may be pointed to by other InstanceGraohNode's use
   /// lists.
-  EdgeVec moduleInstances;
+  InstanceList instances;
 
   /// List of instances which instantiate this module.
-  UseVec moduleUses;
+  InstanceRecord *firstUse = nullptr;
 
   // Provide access to the constructor.
   friend class InstanceGraph;
@@ -128,26 +166,12 @@ private:
 /// To use this class, retrieve a cached copy from the analysis manager:
 ///   auto &instanceGraph = getAnalysis<InstanceGraph>(getOperation());
 class InstanceGraph {
-
-  /// Storage for InstanceGraphNodes.
-  using NodeVec = std::deque<InstanceGraphNode>;
-
-  /// Iterator that unwraps a unique_ptr to return a regular pointer.
-  static InstanceGraphNode *unwrap(NodeVec::value_type &value) {
-    return &value;
-  }
-  struct NodeIterator final
-      : public llvm::mapped_iterator<NodeVec::iterator, decltype(&unwrap)> {
-    /// Initializes the result type iterator to the specified result iterator.
-    NodeIterator(NodeVec::iterator it)
-        : llvm::mapped_iterator<NodeVec::iterator, decltype(&unwrap)>(it,
-                                                                      &unwrap) {
-    }
-  };
+  /// This is the list of InstanceGraphNodes in the graph.
+  using NodeList = llvm::iplist<InstanceGraphNode>;
 
 public:
   /// Create a new module graph of a circuit.  This must be called on a FIRRTL
-  /// CircuitOp.
+  /// CircuitOp or MLIR ModuleOp.
   explicit InstanceGraph(Operation *operation);
 
   /// Get the node corresponding to the top-level module of a circuit.
@@ -176,7 +200,7 @@ public:
   bool isAncestor(FModuleLike child, FModuleOp parent);
 
   /// Iterate through all modules.
-  using iterator = NodeIterator;
+  using iterator = detail::AddressIterator<NodeList::iterator>;
   iterator begin() { return nodes.begin(); }
   iterator end() { return nodes.end(); }
 
@@ -188,20 +212,38 @@ public:
   // InstanceGraph is used as an analysis, this is only safe when the pass is
   // on a CircuitOp.
 
-  // Replaces an instance of a module with another instance. The target module
-  // of both InstanceOps must be the same.
+  /// Add a newly created module to the instance graph.
+  InstanceGraphNode *addModule(Operation *op);
+
+  /// Remove this module from the instance graph. This will also remove all
+  /// InstanceRecords in this module.  All instances of this module must have
+  /// been removed from the graph.
+  void erase(InstanceGraphNode *node);
+
+  /// Replaces an instance of a module with another instance. The target module
+  /// of both InstanceOps must be the same.
   void replaceInstance(InstanceOp inst, InstanceOp newInst);
 
+  /// Returns pointer to member of operation list.
+  static NodeList InstanceGraph::*
+  getSublistAccessgetSublistAccess(Operation *) {
+    return &InstanceGraph::nodes;
+  }
+
 private:
+  InstanceGraph(const InstanceGraph &) = delete;
+
+  InstanceGraphNode *topLevelNode;
+
   /// Get the node corresponding to the module.  If the node has does not exist
   /// yet, it will be created.
   InstanceGraphNode *getOrAddNode(StringAttr name);
 
   /// The storage for graph nodes, with deterministic iteration.
-  NodeVec nodes;
+  NodeList nodes;
 
   /// This maps each operation to its graph node.
-  llvm::DenseMap<Attribute, unsigned> nodeMap;
+  llvm::DenseMap<Attribute, InstanceGraphNode *> nodeMap;
 };
 
 /// An absolute instance path.
@@ -296,7 +338,7 @@ struct GraphTraits<Inverse<circt::firrtl::InstanceGraphNode *>> {
   }
 
   using ChildIteratorType =
-      llvm::mapped_iterator<NodeType::use_iterator, decltype(&getParent)>;
+      llvm::mapped_iterator<NodeType::UseIterator, decltype(&getParent)>;
 
   static NodeRef getEntryNode(Inverse<NodeRef> inverse) {
     return inverse.Graph;

--- a/lib/Dialect/FIRRTL/InstanceGraph.cpp
+++ b/lib/Dialect/FIRRTL/InstanceGraph.cpp
@@ -12,14 +12,42 @@
 using namespace circt;
 using namespace firrtl;
 
-InstanceRecord *InstanceGraphNode::recordInstance(InstanceOp instance,
-                                                  InstanceGraphNode *target) {
-  moduleInstances.emplace_back(instance, this, target);
-  return &moduleInstances.back();
+void InstanceRecord::erase() {
+  // Update the prev node to point to the next node.
+  if (prevUse)
+    prevUse->nextUse = nextUse;
+  else
+    target->firstUse = nextUse;
+  // Update the next node to point to the prev node.
+  if (nextUse)
+    nextUse->prevUse = prevUse;
+  getParent()->instances.erase(this);
+}
+
+InstanceRecord *InstanceGraphNode::addInstance(InstanceOp instance,
+                                               InstanceGraphNode *target) {
+  auto instanceRecord = new InstanceRecord(this, instance, target);
+  target->recordUse(instanceRecord);
+  instances.push_back(instanceRecord);
+  return instanceRecord;
 }
 
 void InstanceGraphNode::recordUse(InstanceRecord *record) {
-  moduleUses.push_back(record);
+  record->nextUse = firstUse;
+  if (firstUse)
+    firstUse->prevUse = record;
+  firstUse = record;
+}
+
+InstanceGraphNode *InstanceGraph::getOrAddNode(StringAttr name) {
+  // Try to insert an InstanceGraphNode. If its not inserted, it returns
+  // an iterator pointing to the node.
+  auto *&node = nodeMap[name];
+  if (!node) {
+    node = new InstanceGraphNode();
+    nodes.push_back(node);
+  }
+  return node;
 }
 
 InstanceGraph::InstanceGraph(Operation *operation) {
@@ -28,38 +56,37 @@ InstanceGraph::InstanceGraph(Operation *operation) {
       if ((operation = dyn_cast<CircuitOp>(&op)))
         break;
 
-  auto circuitOp = cast<CircuitOp>(operation);
-
-  // We insert the top level module first in to the node map.  Getting the node
-  // here is enough to ensure that it is the first one added.
-  getOrAddNode(circuitOp.nameAttr());
-
-  for (auto &op : *circuitOp.getBody()) {
-    if (auto extModule = dyn_cast<FExtModuleOp>(op)) {
-      auto *currentNode = getOrAddNode(extModule.getNameAttr());
-      currentNode->module = extModule;
-    }
-    if (auto module = dyn_cast<FModuleOp>(op)) {
-      auto *currentNode = getOrAddNode(module.getNameAttr());
-      currentNode->module = module;
-      // Find all instance operations in the module body.
-      module.body().walk([&](InstanceOp instanceOp) {
-        // Add an edge to indicate that this module instantiates the target.
-        auto *targetNode = getOrAddNode(instanceOp.moduleNameAttr().getAttr());
-        auto *instanceRecord =
-            currentNode->recordInstance(instanceOp, targetNode);
-        targetNode->recordUse(instanceRecord);
-      });
-    }
+  auto circuit = cast<CircuitOp>(operation);
+  auto topModuleName = circuit.nameAttr();
+  for (auto &op : *circuit.getBody()) {
+    auto module = dyn_cast<FModuleLike>(op);
+    if (!module)
+      continue;
+    auto name = module.moduleNameAttr();
+    auto currentNode = getOrAddNode(name);
+    currentNode->module = module;
+    if (name == topModuleName)
+      topLevelNode = currentNode;
+    // Find all instance operations in the module body.
+    module.walk([&](InstanceOp instanceOp) {
+      // Add an edge to indicate that this module instantiates the target.
+      auto *targetNode = getOrAddNode(instanceOp.moduleNameAttr().getAttr());
+      currentNode->addInstance(instanceOp, targetNode);
+    });
   }
 }
 
-InstanceGraphNode *InstanceGraph::getTopLevelNode() {
-  // The graph always puts the top level module in the array first.
-  if (!nodes.size())
-    return nullptr;
-  return &nodes[0];
+void InstanceGraph::erase(InstanceGraphNode *node) {
+  assert(node->noUses() &&
+         "all instances of this module must have been erased.");
+  // Erase all instances inside this module.
+  for (auto *instance : llvm::make_early_inc_range(*node))
+    instance->erase();
+  nodeMap.erase(cast<FModuleLike>(node->getModule()).moduleNameAttr());
+  nodes.erase(node);
 }
+
+InstanceGraphNode *InstanceGraph::getTopLevelNode() { return topLevelNode; }
 
 FModuleLike InstanceGraph::getTopLevelModule() {
   return getTopLevelNode()->getModule();
@@ -68,32 +95,11 @@ FModuleLike InstanceGraph::getTopLevelModule() {
 InstanceGraphNode *InstanceGraph::lookup(StringAttr name) {
   auto it = nodeMap.find(name);
   assert(it != nodeMap.end() && "Module not in InstanceGraph!");
-  return &nodes[it->second];
+  return it->second;
 }
 
 InstanceGraphNode *InstanceGraph::lookup(Operation *op) {
-  if (auto extModule = dyn_cast<FExtModuleOp>(op)) {
-    return lookup(extModule.getNameAttr());
-  }
-  if (auto module = dyn_cast<FModuleOp>(op)) {
-    return lookup(module.getNameAttr());
-  }
-  llvm_unreachable("Can only look up module operations.");
-}
-
-InstanceGraphNode *InstanceGraph::getOrAddNode(StringAttr name) {
-  // Try to insert an InstanceGraphNode. If its not inserted, it returns
-  // an iterator pointing to the node.
-  auto itAndInserted = nodeMap.try_emplace(name, 0);
-  auto &index = itAndInserted.first->second;
-  if (itAndInserted.second) {
-    // This is a new node, we have to add an element to the NodeVec.
-    nodes.emplace_back();
-    // Store the node storage index in to the map.
-    index = nodes.size() - 1;
-    return &nodes.back();
-  }
-  return &nodes[index];
+  return lookup(cast<FModuleLike>(op).moduleNameAttr());
 }
 
 Operation *InstanceGraph::getReferencedModule(InstanceOp op) {

--- a/lib/Dialect/FIRRTL/InstanceGraph.cpp
+++ b/lib/Dialect/FIRRTL/InstanceGraph.cpp
@@ -26,7 +26,7 @@ void InstanceRecord::erase() {
 
 InstanceRecord *InstanceGraphNode::addInstance(InstanceOp instance,
                                                InstanceGraphNode *target) {
-  auto instanceRecord = new InstanceRecord(this, instance, target);
+  auto *instanceRecord = new InstanceRecord(this, instance, target);
   target->recordUse(instanceRecord);
   instances.push_back(instanceRecord);
   return instanceRecord;
@@ -63,7 +63,7 @@ InstanceGraph::InstanceGraph(Operation *operation) {
     if (!module)
       continue;
     auto name = module.moduleNameAttr();
-    auto currentNode = getOrAddNode(name);
+    auto *currentNode = getOrAddNode(name);
     currentNode->module = module;
     if (name == topModuleName)
       topLevelNode = currentNode;
@@ -115,7 +115,7 @@ void InstanceGraph::replaceInstance(InstanceOp inst, InstanceOp newInst) {
   auto it = llvm::find_if(node->uses(), [&](InstanceRecord *record) {
     return record->getInstance() == inst;
   });
-  assert(it != node->uses_end() && "Instance of module not recorded in graph");
+  assert(it != node->usesEnd() && "Instance of module not recorded in graph");
 
   // We can just replace the instance op in the InstanceRecord without updating
   // any instance lists.

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -475,7 +475,7 @@ void CreateSiFiveMetadataPass::runOnOperation() {
   });
   if (it != body->end()) {
     dutMod = dyn_cast<FModuleOp>(*it);
-    auto instanceGraph = getAnalysis<InstanceGraph>();
+    auto &instanceGraph = getAnalysis<InstanceGraph>();
     auto *node = instanceGraph.lookup(&(*it));
     llvm::for_each(llvm::depth_first(node), [&](InstanceGraphNode *node) {
       dutModuleSet.insert(node->getModule());

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -1160,7 +1160,7 @@ LogicalResult InferResetsPass::buildDomains(CircuitOp circuit) {
       llvm::dbgs() << "\n===----- Build async reset domains -----===\n\n");
 
   // Gather the domains.
-  auto instGraph = getAnalysis<InstanceGraph>();
+  auto &instGraph = getAnalysis<InstanceGraph>();
   auto module = dyn_cast<FModuleOp>(instGraph.getTopLevelNode()->getModule());
   if (!module) {
     LLVM_DEBUG(llvm::dbgs()
@@ -1247,7 +1247,7 @@ void InferResetsPass::buildDomains(FModuleOp module,
 
   // Traverse the child instances.
   InstancePathVec childPath = instPath;
-  for (auto record : instGraph[module]->instances()) {
+  for (auto record : *instGraph[module]) {
     auto submodule = dyn_cast<FModuleOp>(record->getTarget()->getModule());
     if (!submodule)
       continue;

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -1247,7 +1247,7 @@ void InferResetsPass::buildDomains(FModuleOp module,
 
   // Traverse the child instances.
   InstancePathVec childPath = instPath;
-  for (auto record : *instGraph[module]) {
+  for (auto *record : *instGraph[module]) {
     auto submodule = dyn_cast<FModuleOp>(record->getTarget()->getModule());
     if (!submodule)
       continue;

--- a/lib/Dialect/FIRRTL/Transforms/RemoveUnusedPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/RemoveUnusedPorts.cpp
@@ -30,7 +30,7 @@ struct RemoveUnusedPortsPass
 } // namespace
 
 void RemoveUnusedPortsPass::runOnOperation() {
-  auto instanceGraph = getAnalysis<InstanceGraph>();
+  auto &instanceGraph = getAnalysis<InstanceGraph>();
   LLVM_DEBUG(llvm::dbgs() << "===----- Remove unused ports -----==="
                           << "\n");
   CircuitOp circuit = getOperation();

--- a/lib/Dialect/FIRRTL/Transforms/WireDFT.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/WireDFT.cpp
@@ -280,7 +280,7 @@ void WireDFTPass::runOnOperation() {
     if (!node->hasOneUse()) {
       auto diag = emitError(enableSignal.getLoc(),
                             "mutliple instantiations of the DFT enable signal");
-      auto it = node->uses_begin();
+      auto it = node->usesBegin();
       diag.attachNote((*it++)->getInstance()->getLoc())
           << "first instance here";
       diag.attachNote((*it)->getInstance()->getLoc()) << "second instance here";
@@ -299,7 +299,7 @@ void WireDFTPass::runOnOperation() {
     builder.create<ConnectOp>(module.getArgument(portNo), signal);
 
     // Add an output port to the instance of this module.
-    auto *instanceNode = (*node->uses_begin());
+    auto *instanceNode = (*node->usesBegin());
     auto clone = insertPortIntoInstance(instanceNode, {portNo, portInfo});
 
     // Set up for the next iteration.

--- a/lib/Dialect/FIRRTL/Transforms/WireDFT.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/WireDFT.cpp
@@ -277,7 +277,7 @@ void WireDFTPass::runOnOperation() {
   while (node != lca) {
     // If there is more than one parent the we are in trouble. We can't handle
     // more than one enable signal to wire everywhere else.
-    if (node->getNumUses() != 1) {
+    if (!node->hasOneUse()) {
       auto diag = emitError(enableSignal.getLoc(),
                             "mutliple instantiations of the DFT enable signal");
       auto it = node->uses_begin();

--- a/test/Dialect/FIRRTL/wire-dft-errors.mlir
+++ b/test/Dialect/FIRRTL/wire-dft-errors.mlir
@@ -38,9 +38,9 @@ firrtl.circuit "TwoEnables" {
   }
   
   firrtl.module @TwoEnables() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
-    // expected-note @+1 {{first instance here}}
-    firrtl.instance test_en0 @TestEn()
     // expected-note @+1 {{second instance here}}
+    firrtl.instance test_en0 @TestEn()
+    // expected-note @+1 {{first instance here}}
     firrtl.instance test_en1 @TestEn()
     %eicg_in, %eicg_test_en, %eicg_en, %eicg_out = firrtl.instance eicg @EICG_wrapper(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock)
   }


### PR DESCRIPTION
The instance graph was storing graph nodes in an array and handing out
pointers to the elements, which meant we could not properly delete nodes
from the graph without invalidating a bunch of node pointers.  To make
the instance graph more easily mutable, this changes the underlying
data structure of the graph to have stable pointers.

This change makes the instance graph follow the same model as
operations:  InstanceGraph holds a intrusive list of InstanceGraphNodes,
and InstanceGraphNodes hold an intrusive list of InstanceRecords.  The
uses are kept track of using a doubly linked list which is intrusive in
the InstanceRecord.  One benefit of using a representation similar to
MLIR operations is that we can closely match the API, which has slightly
less mental overhead when mutating the instance graph.