### PR TITLE
Re-land "[CI] Use most recent integration test image. (#2474)"

### DIFF
--- a/.github/workflows/nightlyIntegrationTests.yml
+++ b/.github/workflows/nightlyIntegrationTests.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-18.04
     container:
-      image: ghcr.io/circt/images/circt-integration-test:v6-beta3
+      image: ghcr.io/circt/images/circt-integration-test:v10.1
     strategy:
       matrix:
         build-assert: [ON, OFF]

--- a/.github/workflows/shortIntegrationTests.yml
+++ b/.github/workflows/shortIntegrationTests.yml
@@ -23,7 +23,7 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-18.04
     container:
-      image: ghcr.io/circt/images/circt-integration-test:v6-beta3
+      image: ghcr.io/circt/images/circt-integration-test:v10.1
     strategy:
       # Keep the 'matrix' strategy with one data point to make it obvious that
       # this is one point in the overall matrix.


### PR DESCRIPTION
... to make OR-Tools available in integration tests.

The v10.1 image fixes the configuration problem in the nightly tests observed in #2479, so this should be good to go now.