### PR TITLE
[HWCleanUp] Convert if operations to a case statement

### DIFF
--- a/include/circt/Dialect/SV/SVPasses.h
+++ b/include/circt/Dialect/SV/SVPasses.h
@@ -20,7 +20,8 @@ namespace circt {
 namespace sv {
 
 std::unique_ptr<mlir::Pass> createPrettifyVerilogPass();
-std::unique_ptr<mlir::Pass> createHWCleanupPass();
+std::unique_ptr<mlir::Pass>
+createHWCleanupPass(bool aggressiveIfOpMerge = false);
 std::unique_ptr<mlir::Pass> createHWStubExternalModulesPass();
 std::unique_ptr<mlir::Pass> createHWLegalizeModulesPass();
 std::unique_ptr<mlir::Pass> createHWGeneratorCalloutPass();

--- a/include/circt/Dialect/SV/SVPasses.h
+++ b/include/circt/Dialect/SV/SVPasses.h
@@ -20,8 +20,7 @@ namespace circt {
 namespace sv {
 
 std::unique_ptr<mlir::Pass> createPrettifyVerilogPass();
-std::unique_ptr<mlir::Pass>
-createHWCleanupPass(bool aggressiveIfOpMerge = false);
+std::unique_ptr<mlir::Pass> createHWCleanupPass(bool convertIfToCase = false);
 std::unique_ptr<mlir::Pass> createHWStubExternalModulesPass();
 std::unique_ptr<mlir::Pass> createHWLegalizeModulesPass();
 std::unique_ptr<mlir::Pass> createHWGeneratorCalloutPass();

--- a/include/circt/Dialect/SV/SVPasses.td
+++ b/include/circt/Dialect/SV/SVPasses.td
@@ -25,6 +25,10 @@ def HWCleanup : Pass<"hw-cleanup", "hw::HWModuleOp"> {
   }];
 
   let constructor = "circt::sv::createHWCleanupPass()";
+  let options = [
+    Option<"aggressiveIfOpMerge", "aggressive-if-op-merge",
+           "bool", "false", "Merge successive if ops by hoisting common conditions">
+   ];
 }
 
 def HWLegalizeModules : Pass<"hw-legalize-modules", "hw::HWModuleOp"> {

--- a/include/circt/Dialect/SV/SVPasses.td
+++ b/include/circt/Dialect/SV/SVPasses.td
@@ -26,8 +26,8 @@ def HWCleanup : Pass<"hw-cleanup", "hw::HWModuleOp"> {
 
   let constructor = "circt::sv::createHWCleanupPass()";
   let options = [
-    Option<"aggressiveIfOpMerge", "aggressive-if-op-merge",
-           "bool", "false", "Merge successive if ops by hoisting common conditions">
+    Option<"convertIfToCase", "convert-if-to-case",
+           "bool", "false", "Convert if ops to case op">
    ];
 }
 

--- a/lib/Dialect/SV/Transforms/HWCleanup.cpp
+++ b/lib/Dialect/SV/Transforms/HWCleanup.cpp
@@ -14,8 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "PassDetail.h"
+#include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVPasses.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/Support/Debug.h"
 
 using namespace circt;
 
@@ -63,6 +66,73 @@ struct AlwaysLikeOpInfo : public llvm::DenseMapInfo<Operation *> {
   }
 };
 
+// This struct analyses given two conditions. We decompose the atomic values
+// (i.e. non AndOp) in the two conditions into three sets `lhsAtoms`, `rhsAtoms`
+// and `commonAtoms` so that the following relation holds. This struct is used
+// to hoist values in commonAtoms outer if op.
+//
+// lhs = lhsAtoms /\ commonAtoms
+// rhs = rhsAtoms /\ commonAtoms
+struct ConditionPairInformation {
+  ConditionPairInformation(Value lhs, Value rhs) {
+    peelAtoms(lhs, lhsAtoms);
+    peelAtoms(rhs, rhsAtoms);
+
+    // Take an intersection.
+    for (auto atom : lhsAtoms)
+      if (rhsAtoms.contains(atom))
+        commonAtoms.push_back(atom);
+
+    if (commonAtoms.empty())
+      return;
+
+    // If lhsAtoms are equal to lhsAtoms, all conditions are the same.
+    if (commonAtoms.size() == lhsAtoms.size() &&
+        commonAtoms.size() == rhsAtoms.size()) {
+      lhsAtoms.clear();
+      rhsAtoms.clear();
+      return;
+    }
+
+    // Remove all common values from both sets.
+    for (auto atom : commonAtoms) {
+      lhsAtoms.remove(atom);
+      rhsAtoms.remove(atom);
+    }
+  }
+
+  // Remove ops.
+  void cleanUpOps() {
+    for (Operation *op : andOperations)
+      if (op->use_empty())
+        op->erase();
+  }
+
+  // Unique values in the condition lhs and rhs.
+  llvm::SmallSetVector<Value, 4> lhsAtoms, rhsAtoms;
+  // Common values in two conditions.
+  llvm::SmallVector<Value> commonAtoms;
+
+private:
+  // Track decomposed operations which might be dead after if-merging.
+  llvm::SmallSetVector<comb::AndOp, 4> andOperations;
+
+  // Helper function to accmulate atoms.
+  void peelAtoms(Value cond, llvm::SmallSetVector<Value, 4> &result) {
+    auto andOp = dyn_cast_or_null<comb::AndOp>(cond.getDefiningOp());
+    if (!andOp) {
+      result.insert(cond);
+      return;
+    }
+
+    // Insert op before recursing into operands to make `cleanUpOps` traverse
+    // operations from users.
+    andOperations.insert(andOp);
+    llvm::for_each(andOp.getOperands(),
+                   [&](Value cond) { peelAtoms(cond, result); });
+  }
+};
+
 } // end anonymous namespace
 
 // Merge two regions together. These regions must only have a one block.
@@ -93,6 +163,9 @@ static void mergeRegions(Region *region1, Region *region2) {
 
 namespace {
 struct HWCleanupPass : public sv::HWCleanupBase<HWCleanupPass> {
+  HWCleanupPass(bool aggressiveIfOpMergeFlag) {
+    aggressiveIfOpMerge = aggressiveIfOpMergeFlag;
+  }
   void runOnOperation() override;
 
   void runOnRegionsInOp(Operation &op);
@@ -109,6 +182,26 @@ private:
 
     op2->erase();
     anythingChanged = true;
+  }
+
+  // This function merge two if operations by hoisting common conditions.
+  sv::IfOp hoistIfOpConditions(sv::IfOp op1, sv::IfOp op2);
+
+  // This function tries merging two if operations.
+  sv::IfOp tryMergingIfOps(sv::IfOp ifOp, sv::IfOp prevIfOp) {
+    assert(ifOp != prevIfOp && "Cannot merge an op into itself");
+
+    // If conditions of op1 and op2 are equal, we can just merge them.
+    if (ifOp.cond() == prevIfOp.cond()) {
+      mergeOperationsIntoFrom(ifOp, prevIfOp);
+      return ifOp;
+    }
+
+    // If aggressiveIfOpMerge is not enabled, just return first if op.
+    if (!aggressiveIfOpMerge)
+      return ifOp;
+
+    return hoistIfOpConditions(ifOp, prevIfOp);
   }
 
   bool anythingChanged;
@@ -209,7 +302,8 @@ void HWCleanupPass::runOnProceduralRegion(Region &region) {
   Block &body = region.front();
 
   Operation *lastSideEffectingOp = nullptr;
-  for (Operation &op : llvm::make_early_inc_range(body)) {
+  for (auto it = body.begin(), end = body.end(); it != end; it++) {
+    Operation &op = *it;
     // Merge procedural ifdefs with neighbors in the procedural region.
     if (auto ifdef = dyn_cast<sv::IfDefProceduralOp>(op)) {
       if (auto prevIfDef =
@@ -222,13 +316,16 @@ void HWCleanupPass::runOnProceduralRegion(Region &region) {
       }
     }
 
-    // Merge 'if' operations with the same condition.
+    // Merge 'if' operations.
     if (auto ifop = dyn_cast<sv::IfOp>(op)) {
       if (auto prevIf = dyn_cast_or_null<sv::IfOp>(lastSideEffectingOp)) {
-        if (ifop.cond() == prevIf.cond()) {
-          // We know that there are no side effective operations between the
-          // two, so merge the first one into this one.
-          mergeOperationsIntoFrom(ifop, prevIf);
+        auto mergedIfOp = tryMergingIfOps(ifop, prevIf);
+        // If a new if op is returned, we have to update lastSideEffectingOp and
+        // the iterator because if ops are sunk.
+        if (mergedIfOp != ifop) {
+          lastSideEffectingOp = mergedIfOp;
+          it = mergedIfOp->getIterator();
+          continue;
         }
       }
     }
@@ -245,6 +342,97 @@ void HWCleanupPass::runOnProceduralRegion(Region &region) {
   }
 }
 
-std::unique_ptr<Pass> circt::sv::createHWCleanupPass() {
-  return std::make_unique<HWCleanupPass>();
+// This function merge two if operations when they have a common condition.
+// For example,
+// prevIfOp:
+//   if a1 & a2 &... & an & c1 & c2 .. & cn {e1}
+// ifOp:
+//   if b1 & b2 &... & bn & c1 & c2 .. & cn {e2}
+// ====>
+//   if c1 & c2 .. & cn {
+//     if a1 & a2 & ... & an {e1}
+//     if b1 & b2 & ... & bn {e2}
+//   }
+sv::IfOp HWCleanupPass::hoistIfOpConditions(sv::IfOp ifOp, sv::IfOp prevIfOp) {
+  // TOOD: Handle even when they have else blocks
+  if (ifOp.hasElse() || prevIfOp.hasElse())
+    return ifOp;
+
+  ConditionPairInformation condPairInfo(ifOp.cond(), prevIfOp.cond());
+
+  // If there is nothing in common, we cannot merge.
+  if (condPairInfo.commonAtoms.empty())
+    return ifOp;
+
+  // If both lhsAtoms and rhsAtoms are empty, it means the conditions
+  // are actually equivalent.
+  if (condPairInfo.lhsAtoms.empty() && condPairInfo.rhsAtoms.empty()) {
+    mergeOperationsIntoFrom(ifOp, prevIfOp);
+    return ifOp;
+  }
+
+  anythingChanged = true;
+
+  OpBuilder builder(ifOp.getContext());
+  auto i1Type = ifOp.cond().getType();
+
+  auto generateCondValue =
+      [&](Location loc, llvm::SmallSetVector<Value, 4> &conjunction) -> Value {
+    if (conjunction.empty())
+      return builder.create<hw::ConstantOp>(loc, i1Type, 1);
+
+    return builder.createOrFold<comb::AndOp>(loc, i1Type,
+                                             conjunction.takeVector());
+  };
+
+  auto merge = [&]() {
+    // If rhsAtoms is empty, it means we can move ifOp to the block of prevIfOp.
+    if (condPairInfo.rhsAtoms.empty()) {
+      // Move ifOp to the end of prevIfOp's then block.
+      builder.setInsertionPointToEnd(prevIfOp.getThenBlock());
+      auto newCond1 =
+          generateCondValue(ifOp.cond().getLoc(), condPairInfo.lhsAtoms);
+      ifOp.setOperand(newCond1);
+      // op1 might contain ops defined between op2 and op1, we have to move op2
+      // to the position of op1 to ensure that the dominance doesn't break.
+      prevIfOp->moveBefore(ifOp);
+      ifOp->moveBefore(prevIfOp.getThenBlock(), prevIfOp.getThenBlock()->end());
+      return prevIfOp;
+    }
+
+    // If lhsAtoms is empty, it means we can move prevIfOp to the block of ifOp.
+    if (condPairInfo.lhsAtoms.empty()) {
+      // Move prevIfOp to the start of ifOp's then block.
+      builder.setInsertionPointToStart(ifOp.getThenBlock());
+      auto newCond2 =
+          generateCondValue(prevIfOp.cond().getLoc(), condPairInfo.rhsAtoms);
+      prevIfOp.setOperand(newCond2);
+      prevIfOp->moveAfter(ifOp.getThenBlock(), ifOp.getThenBlock()->begin());
+      return ifOp;
+    }
+
+    // Ok, now we create a new if op to contain ifOp and prevIfOp.
+    builder.setInsertionPoint(ifOp);
+
+    // Create new conditions.
+    auto newCond1 = generateCondValue(ifOp.getLoc(), condPairInfo.lhsAtoms);
+    auto newCond2 = generateCondValue(prevIfOp.getLoc(), condPairInfo.rhsAtoms);
+    auto cond = builder.createOrFold<comb::AndOp>(ifOp.getLoc(),
+                                                  condPairInfo.commonAtoms);
+    auto newIf = builder.create<sv::IfOp>(prevIfOp.getLoc(), cond, [&]() {});
+
+    prevIfOp->moveBefore(newIf.getThenBlock(), newIf.getThenBlock()->begin());
+    ifOp->moveAfter(prevIfOp);
+    ifOp.setOperand(newCond1);
+    prevIfOp.setOperand(newCond2);
+    return newIf;
+  };
+
+  auto returnedIfOp = merge();
+  condPairInfo.cleanUpOps();
+  return returnedIfOp;
+}
+
+std::unique_ptr<Pass> circt::sv::createHWCleanupPass(bool aggressiveIfOpMerge) {
+  return std::make_unique<HWCleanupPass>(aggressiveIfOpMerge);
 }

--- a/test/Dialect/FIRRTL/SFCTests/complex-asserts.fir
+++ b/test/Dialect/FIRRTL/SFCTests/complex-asserts.fir
@@ -20,14 +20,9 @@ circuit Foo:
     input other : UInt<1>
     input sum : UInt<42>
 
-<<<<<<< HEAD
     ; CHECK: `ifndef SYNTHESIS
     ; CHECK-NEXT: always @(posedge clock) begin
-=======
-    ; CHECK: always @(posedge clock) begin
-    ; CHECK-NEXT: `ifndef SYNTHESIS
     ; CHECK-NEXT:   if (enable) begin
->>>>>>> 38bcfb149 ([HWCleanUp] Aggressive if conditions hoisting)
 
     ; assert with predicate only
     ; CHECK-NEXT: if (~(predicate1 | reset)) begin

--- a/test/Dialect/FIRRTL/SFCTests/complex-asserts.fir
+++ b/test/Dialect/FIRRTL/SFCTests/complex-asserts.fir
@@ -20,11 +20,17 @@ circuit Foo:
     input other : UInt<1>
     input sum : UInt<42>
 
+<<<<<<< HEAD
     ; CHECK: `ifndef SYNTHESIS
     ; CHECK-NEXT: always @(posedge clock) begin
+=======
+    ; CHECK: always @(posedge clock) begin
+    ; CHECK-NEXT: `ifndef SYNTHESIS
+    ; CHECK-NEXT:   if (enable) begin
+>>>>>>> 38bcfb149 ([HWCleanUp] Aggressive if conditions hoisting)
 
     ; assert with predicate only
-    ; CHECK-NEXT: if (enable & ~(predicate1 | reset)) begin
+    ; CHECK-NEXT: if (~(predicate1 | reset)) begin
     ; CHECK-NEXT:   if (`ASSERT_VERBOSE_COND_)
     ; CHECK-NEXT:     $error("Assertion failed (verification library): ");
     ; CHECK-NEXT:   if (`STOP_COND_)
@@ -35,7 +41,7 @@ circuit Foo:
       stop(clock, enable, 1)
 
     ; assert with message
-    ; CHECK-NEXT: if (enable & ~(predicate2 | reset)) begin
+    ; CHECK-NEXT: if (~(predicate2 | reset)) begin
     ; CHECK-NEXT:   if (`ASSERT_VERBOSE_COND_)
     ; CHECK-NEXT:     $error("Assertion failed (verification library): sum =/= 1.U");
     ; CHECK-NEXT:   if (`STOP_COND_)
@@ -46,7 +52,7 @@ circuit Foo:
       stop(clock, enable, 1)
 
     ; assert with when
-    ; CHECK-NEXT: if (other & enable & ~(predicate3 | reset)) begin
+    ; CHECK-NEXT: if (other & ~(predicate3 | reset)) begin
     ; CHECK-NEXT:   if (`ASSERT_VERBOSE_COND_)
     ; CHECK-NEXT:     $error("Assertion failed (verification library): Assert with when");
     ; CHECK-NEXT:   if (`STOP_COND_)
@@ -58,7 +64,7 @@ circuit Foo:
         stop(clock, enable, 1)
 
     ; assert with message with arguments
-    ; CHECK-NEXT: if (enable & ~(predicate4 | reset)) begin
+    ; CHECK-NEXT: if (~(predicate4 | reset)) begin
     ; CHECK-NEXT:   if (`ASSERT_VERBOSE_COND_)
     ; CHECK-NEXT:     $error("Assertion failed (verification library): expected sum === 2.U but got %d", sum);
     ; CHECK-NEXT:   if (`STOP_COND_)
@@ -68,6 +74,7 @@ circuit Foo:
       printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"format\":{\"type\":\"ifElseFatal\"},\"baseMsg\":\"Assertion failed (verification library): expected sum === 2.U but got %d\"}</extraction-summary> bar", sum)
       stop(clock, enable, 1)
 
+    ; CHECK-NEXT: end
     ; CHECK-NEXT: end
     ; CHECK-NEXT: `endif
 

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -557,7 +557,7 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
         modulePM.addPass(createCSEPass());
         modulePM.addPass(createSimpleCanonicalizerPass());
         modulePM.addPass(createCSEPass());
-        modulePM.addPass(sv::createHWCleanupPass());
+        modulePM.addPass(sv::createHWCleanupPass(/*convertIfToCase*/ true));
       }
     }
   }


### PR DESCRIPTION
This PR implements a folding which converts successive if statements into a case statement via a pattern matching.

The algorithm consists of two parts: if condition hoisting and case statement generation.   

#### If condition hoisting
As already implemented in HWCleanup, we compare two successive if ops and determine whether it is possible to merge them. 
Previously if ops are merged only if their conditions are equal but this PR enables to hoist common values from their conditions.  

Example:
```verilog
if a1 & a2 &... & an & c1 & c2 .. & cn {e1}
if b1 & b2 &... & bn & c1 & c2 .. & cn {e2}
 ====>
if c1 & c2 .. & cn {
  if a1 & a2 & ... & an {e1}
  if b1 & b2 & ... & bn {e2}
}
```

#### Case statement generation
After hoisting if conditions, we merge successive if ops when their conditions are IcmpOp whose lhs operand is shared and rhs is a constant.  
Example:
```verilog
if (a==0) {e0}
if (a==1) {e1}
if (a==2) {e2}
if (a==0) {e3}
===>
casez a:
  case 0:
    e0
    e3
  case 1:
    e1
  case 2:
    e2
```

Close https://github.com/llvm/circt/issues/2495