### PR TITLE
[LowerToHW] Create type decl for bundle types

### DIFF
--- a/include/circt/Conversion/FIRRTLToHW.h
+++ b/include/circt/Conversion/FIRRTLToHW.h
@@ -25,7 +25,8 @@ namespace circt {
 
 std::unique_ptr<mlir::Pass>
 createLowerFIRRTLToHWPass(bool enableAnnotationWarning = false,
-                          bool nonConstAsyncResetValueIsError = false);
+                          bool nonConstAsyncResetValueIsError = false,
+                          bool createTypeDeclarations = false);
 
 } // namespace circt
 

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -123,7 +123,10 @@ def LowerFIRRTLToHW : Pass<"lower-firrtl-to-hw", "mlir::ModuleOp"> {
     "Emit warnings on unprocessed annotations during lower-to-hw pass">,
     Option<"nonConstAsyncResetValueIsError",
            "error-on-non-const-async-reset-values", "bool", "false",
-    "Emit errors instead of warnings on non-constant async reset values">
+    "Emit errors instead of warnings on non-constant async reset values">,
+    Option<"createTypeDeclarations", "create-type-declarations",
+           "bool", "false",
+    "Create type scope and type declarations for bundle types">
   ];
 }
 

--- a/include/circt/Dialect/HW/HWTypeDecls.td
+++ b/include/circt/Dialect/HW/HWTypeDecls.td
@@ -28,6 +28,10 @@ def TypeScopeOp : HWOp<"type_scope",
   let arguments = (ins SymbolNameAttr:$sym_name);
 
   let assemblyFormat = "$sym_name $body attr-dict";
+  let builders = [
+    OpBuilder<(ins "StringAttr":$sym_name,
+                   CArg<"std::function<void()>">:$bodyCtor)>
+  ];
 
   let extraClassDeclaration = [{
     Block *getBodyBlock() { return &body().front(); }

--- a/include/circt/Dialect/HW/HWTypes.h
+++ b/include/circt/Dialect/HW/HWTypes.h
@@ -75,6 +75,11 @@ bool type_isa(Type type) {
   return false;
 }
 
+template <typename First, typename Second, typename... Rest>
+bool type_isa(Type Val) { // NOLINT(readability-identifier-naming)
+  return type_isa<First>(Val) || type_isa<Second, Rest...>(Val);
+}
+
 // type_isa for a nullable argument.
 template <typename BaseTy>
 bool type_isa_and_nonnull(Type type) { // NOLINT(readability-identifier-naming)

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1762,6 +1762,19 @@ StringRef TypedeclOp::getPreferredName() {
 }
 
 //===----------------------------------------------------------------------===//
+// TypeScopeOP
+//===----------------------------------------------------------------------===//
+
+void TypeScopeOp::build(OpBuilder &builder, OperationState &result,
+                        StringAttr symName, std::function<void()> bodyCtor) {
+  result.addAttribute(sym_nameAttrName(result.name), symName);
+  OpBuilder::InsertionGuard guard(builder);
+  builder.createBlock(result.addRegion());
+  if (bodyCtor)
+    bodyCtor();
+}
+
+//===----------------------------------------------------------------------===//
 // BitcastOp
 //===----------------------------------------------------------------------===//
 

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-typedecl.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-typedecl.mlir
@@ -1,0 +1,44 @@
+// RUN: circt-opt -pass-pipeline='lower-firrtl-to-hw{create-type-declarations=true}' -verify-diagnostics %s | FileCheck %s
+firrtl.circuit "UseFoo" {
+  // Global type scope.
+  // CHECK-LABEL:   hw.type_scope
+  // CHECK-SAME:     @[[GLOBAL_TYPE_SCOPE:.+]] {
+  // CHECK-NEXT:      hw.typedecl @[[TYPE1:.+]], "Global_a" : !hw.struct<b: i1>
+  // CHECK-NEXT:      hw.typedecl @[[TYPE2:.+]] : !hw.struct<a: !hw.typealias<@[[GLOBAL_TYPE_SCOPE]]::@[[TYPE1]], !hw.struct<b: i1>>>
+  // CHECK-NEXT:      hw.typedecl @[[TYPE3:.+]] : !hw.struct<ext: i1>
+  // CHECK-NEXT:    }
+
+  // CHECK-LABEL:   hw.module @Foo
+  // CHECK-SAME:     (%in: i1) -> (sink: !hw.typealias<@[[GLOBAL_TYPE_SCOPE]]::@[[TYPE2]], !hw.struct<a: !hw.typealias<@[[GLOBAL_TYPE_SCOPE]]::@[[TYPE1]], !hw.struct<b: i1>>>>) {
+  firrtl.module @Foo(in %in: !firrtl.uint<1>, out %sink: !firrtl.bundle<a: bundle<b: uint<1>>>) {
+    // CHECK-NEXT:  sv.wire  : !hw.inout<typealias<@[[GLOBAL_TYPE_SCOPE]]::@[[TYPE2]], !hw.struct<a: !hw.typealias<@[[GLOBAL_TYPE_SCOPE]]::@[[TYPE1]], !hw.struct<b: i1>>>>>
+    // CHECK-NEXT:  sv.read_inout {{.+}} : !hw.inout<typealias<@[[GLOBAL_TYPE_SCOPE]]::@[[TYPE2]], !hw.struct<a: !hw.typealias<@[[GLOBAL_TYPE_SCOPE]]::@[[TYPE1]], !hw.struct<b: i1>>>>>
+    // CHECK-NEXT:  sv.struct_field_inout {{.+}}["a"] : !hw.inout<typealias<@[[GLOBAL_TYPE_SCOPE]]::@[[TYPE2]], !hw.struct<a: !hw.typealias<@[[GLOBAL_TYPE_SCOPE]]::@[[TYPE1]], !hw.struct<b: i1>>>>>
+    // CHECK-NEXT:  sv.struct_field_inout {{.+}}["b"] : !hw.inout<typealias<@[[GLOBAL_TYPE_SCOPE]]::@[[TYPE1]], !hw.struct<b: i1>>>
+    %0 = firrtl.subfield %sink(0) : (!firrtl.bundle<a: bundle<b: uint<1>>>) -> !firrtl.bundle<b: uint<1>>
+    %1 = firrtl.subfield %0(0) : (!firrtl.bundle<b: uint<1>>) -> !firrtl.uint<1>
+    firrtl.connect %1, %in : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+
+  // CHECK-LABEL:   hw.module @UseFoo() ->
+  // CHECK-SAME:      (sink: !hw.typealias<@[[GLOBAL_TYPE_SCOPE]]::@[[TYPE2]], !hw.struct<a: !hw.typealias<@[[GLOBAL_TYPE_SCOPE]]::@[[TYPE1]], !hw.struct<b: i1>>>>) {
+  firrtl.module @UseFoo(out %sink: !firrtl.bundle<a: bundle<b: uint<1>>>) {
+    // CHECK:           hw.instance "fetch" @Foo
+    // CHECK-SAME:         -> (sink: !hw.typealias<@[[GLOBAL_TYPE_SCOPE]]::@[[TYPE2]], !hw.struct<a: !hw.typealias<@[[GLOBAL_TYPE_SCOPE]]::@[[TYPE1]], !hw.struct<b: i1>>>>)
+    %a, %b = firrtl.instance fetch @Foo(in in: !firrtl.uint<1>, out sink: !firrtl.bundle<a: bundle<b: uint<1>>>)
+  }
+
+  // CHECK-LABEL:   hw.type_scope
+  // CHECK:         @[[MODULE_TYPE_SCOPE_BAR:.+]] {
+  // CHECK-NEXT:      hw.typedecl @[[TYPE1:.+]] : !hw.struct<a: i1>
+  // CHECK-NEXT:    }
+
+  // CHECK-LABEL:   hw.module @Bar() {
+  firrtl.module @Bar() {
+    // CHECK-NEXT:      sv.wire  : !hw.inout<typealias<@[[MODULE_TYPE_SCOPE_BAR]]::@[[TYPE1]], !hw.struct<a: i1>>>
+    %a = firrtl.wire : !firrtl.bundle<a: uint<1>>
+  }
+
+  // CHECK: hw.module.extern @Ext(%inA: !hw.typealias<@[[GLOBAL_TYPE_SCOPE]]::@[[TYPE3]], !hw.struct<ext: i1>>)
+  firrtl.extmodule @Ext(in inA: !firrtl.bundle<ext: uint<1>>)
+}

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -209,6 +209,11 @@ static cl::opt<bool> removeUnusedPorts("remove-unused-ports",
                                        cl::desc("enable unused ports pruning"),
                                        cl::init(true));
 
+static cl::opt<bool> createTypeDeclarations(
+    "create-type-declarations",
+    cl::desc("create type declarations for bundle types at LowerToHW"),
+    cl::init(false));
+
 /// Enable the pass to merge the read and write ports of a memory, if their
 /// enable conditions are mutually exclusive.
 static cl::opt<bool>
@@ -443,7 +448,8 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
   // Lower if we are going to verilog or if lowering was specifically requested.
   if (outputFormat != OutputIRFir) {
     pm.addPass(createLowerFIRRTLToHWPass(enableAnnotationWarning.getValue(),
-                                         nonConstAsyncResetValueIsError));
+                                         nonConstAsyncResetValueIsError,
+                                         createTypeDeclarations));
     pm.addPass(sv::createHWMemSimImplPass(replSeqMem, ignoreReadEnableMem));
 
     if (extractTestCode)


### PR DESCRIPTION
This commit modifies LowerToHW to cerate type decl ops for bundle types
since lowerd struct types are occasionally very long. Basically,
`lowerType` function is changed to create type decl ops when bundle
types are passed. This feature is opt-in. I added a flag `-create-type-declarations` to firtool. 

I added `TypeScope` class and `ModuleTypeScope` which inherits `TypeScope`.
They both return type alias type for bundle type.  Since we have to use consistent types for 
module instances globally, we first lower all port types  by `GlobalTypeScope` (which is an instance of `TypeScope`).



With this PR, for the following fir.
```scala
circuit Foo:
  module Foo:
    input source: {foo: UInt<1>, bar: {a: UInt<1>, b:UInt<1>}}
```
the output is
```sv
typedef struct packed {logic a; logic b; } Global_bar;
typedef struct packed {logic foo; Global_bar bar; } Global_BundleType2;
module Foo(     // foo.fir:2:10
  input Global_BundleType2 source);

endmodule
```

Will close https://github.com/llvm/circt/issues/2329