### PR TITLE
[StaticLogic] Add start time attribute to PipelineStageOp.

### DIFF
--- a/include/circt/Dialect/StaticLogic/StaticLogic.td
+++ b/include/circt/Dialect/StaticLogic/StaticLogic.td
@@ -157,6 +157,8 @@ def PipelineStageOp : Op<StaticLogic_Dialect, "pipeline.stage",
     This operation has a single-block region which dictates the operations that
     may occur concurrently.
 
+    It has a `start` attribute, which indicates the start cycle for this stage.
+
     It may have an optional `when` predicate, which supports conditional
     execution for each stage. This is in addition to the `condition` region that
     controls the execution of the whole pipeline. A stage with a `when`
@@ -177,6 +179,7 @@ def PipelineStageOp : Op<StaticLogic_Dialect, "pipeline.stage",
   }];
 
   let arguments = (ins
+    I64Attr:$start,
     Optional<I1>:$when
   );
 
@@ -189,12 +192,12 @@ def PipelineStageOp : Op<StaticLogic_Dialect, "pipeline.stage",
   );
 
   let assemblyFormat = [{
-    (`when` $when^)? $body (`:` qualified(type($results))^)? attr-dict
+    `start` `=` $start (`when` $when^)? $body (`:` qualified(type($results))^)? attr-dict
   }];
 
   let skipDefaultBuilders = 1;
   let builders = [
-    OpBuilder<(ins "mlir::TypeRange":$resultTypes)>
+    OpBuilder<(ins "mlir::TypeRange":$resultTypes, "mlir::IntegerAttr":$start)>
   ];
 
   let extraClassDeclaration = [{

--- a/include/circt/Dialect/StaticLogic/StaticLogic.td
+++ b/include/circt/Dialect/StaticLogic/StaticLogic.td
@@ -179,7 +179,7 @@ def PipelineStageOp : Op<StaticLogic_Dialect, "pipeline.stage",
   }];
 
   let arguments = (ins
-    I64Attr:$start,
+    SI64Attr:$start,
     Optional<I1>:$when
   );
 
@@ -193,6 +193,10 @@ def PipelineStageOp : Op<StaticLogic_Dialect, "pipeline.stage",
 
   let assemblyFormat = [{
     `start` `=` $start (`when` $when^)? $body (`:` qualified(type($results))^)? attr-dict
+  }];
+
+  let verifier = [{
+    return ::verify$cppClass(*this);
   }];
 
   let skipDefaultBuilders = 1;

--- a/lib/Conversion/AffineToStaticLogic/AffineToStaticLogic.cpp
+++ b/lib/Conversion/AffineToStaticLogic/AffineToStaticLogic.cpp
@@ -435,7 +435,9 @@ LogicalResult AffineToStaticLogic::createStaticLogicPipeline(
       stageTypes.push_back(lowerBound.getType());
 
     // Create the stage itself.
-    auto stage = builder.create<PipelineStageOp>(stageTypes);
+    auto startTimeAttr =
+        builder.getIntegerAttr(builder.getI64Type(), startTime);
+    auto stage = builder.create<PipelineStageOp>(stageTypes, startTimeAttr);
     auto &stageBlock = stage.getBodyBlock();
     auto *stageTerminator = stageBlock.getTerminator();
     builder.setInsertionPointToStart(&stageBlock);

--- a/lib/Conversion/AffineToStaticLogic/AffineToStaticLogic.cpp
+++ b/lib/Conversion/AffineToStaticLogic/AffineToStaticLogic.cpp
@@ -435,8 +435,8 @@ LogicalResult AffineToStaticLogic::createStaticLogicPipeline(
       stageTypes.push_back(lowerBound.getType());
 
     // Create the stage itself.
-    auto startTimeAttr =
-        builder.getIntegerAttr(builder.getI64Type(), startTime);
+    auto startTimeAttr = builder.getIntegerAttr(
+        builder.getIntegerType(64, /*isSigned=*/true), startTime);
     auto stage = builder.create<PipelineStageOp>(stageTypes, startTimeAttr);
     auto &stageBlock = stage.getBodyBlock();
     auto *stageTerminator = stageBlock.getTerminator();

--- a/lib/Dialect/StaticLogic/StaticLogicOps.cpp
+++ b/lib/Dialect/StaticLogic/StaticLogicOps.cpp
@@ -175,10 +175,11 @@ void PipelineWhileOp::build(OpBuilder &builder, OperationState &state,
 //===----------------------------------------------------------------------===//
 
 void PipelineStageOp::build(OpBuilder &builder, OperationState &state,
-                            TypeRange resultTypes) {
+                            TypeRange resultTypes, IntegerAttr start) {
   OpBuilder::InsertionGuard g(builder);
 
   state.addTypes(resultTypes);
+  state.addAttribute("start", start);
 
   Region *region = state.addRegion();
   Block &block = region->emplaceBlock();

--- a/lib/Dialect/StaticLogic/StaticLogicOps.cpp
+++ b/lib/Dialect/StaticLogic/StaticLogicOps.cpp
@@ -135,14 +135,30 @@ static LogicalResult verifyPipelineWhileOp(PipelineWhileOp op) {
   if (stagesBlock.getOperations().size() < 2)
     return op.emitOpError("stages must contain at least one stage");
 
-  // Verify the stages block contains only `staticlogic.pipeline.stage` and
-  // `staticlogic.pipeline.terminator` ops.
-  for (Operation &inner : stagesBlock)
+  int64_t lastStartTime = -1;
+  for (Operation &inner : stagesBlock) {
+    // Verify the stages block contains only `staticlogic.pipeline.stage` and
+    // `staticlogic.pipeline.terminator` ops.
     if (!isa<PipelineStageOp, PipelineTerminatorOp>(inner))
       return op.emitOpError(
                  "stages may only contain 'staticlogic.pipeline.stage' or "
                  "'staticlogic.pipeline.terminator' ops, found ")
              << inner;
+
+    // Verify the stage start times are monotonically increasing.
+    if (auto stage = dyn_cast<PipelineStageOp>(inner)) {
+      if (lastStartTime == -1) {
+        lastStartTime = stage.start();
+        continue;
+      }
+
+      if (lastStartTime >= stage.start())
+        return stage.emitOpError("'start' must be after previous 'start' (")
+               << lastStartTime << ')';
+
+      lastStartTime = stage.start();
+    }
+  }
 
   return success();
 }
@@ -173,6 +189,13 @@ void PipelineWhileOp::build(OpBuilder &builder, OperationState &state,
 //===----------------------------------------------------------------------===//
 // PipelineStageOp
 //===----------------------------------------------------------------------===//
+
+static LogicalResult verifyPipelineStageOp(PipelineStageOp op) {
+  if (op.start() < 0)
+    return op.emitOpError("'start' must be non-negative");
+
+  return success();
+}
 
 void PipelineStageOp::build(OpBuilder &builder, OperationState &state,
                             TypeRange resultTypes, IntegerAttr start) {

--- a/test/Conversion/SCFToCalyx/convert_pipeline.mlir
+++ b/test/Conversion/SCFToCalyx/convert_pipeline.mlir
@@ -42,7 +42,7 @@ func @minimal() {
     %0 = arith.cmpi ult, %arg0, %c10_i64 : i64
     staticlogic.pipeline.register %0 : i1
   } do {
-    %0 = staticlogic.pipeline.stage  {
+    %0 = staticlogic.pipeline.stage start = 0 {
       %1 = arith.addi %arg0, %c1_i64 : i64
       staticlogic.pipeline.register %1 : i64
     } : i64

--- a/test/Dialect/StaticLogic/errors.mlir
+++ b/test/Dialect/StaticLogic/errors.mlir
@@ -10,7 +10,7 @@ func @combinational_condition() {
     %2 = arith.cmpi ult, %1, %arg0 : i32
     staticlogic.pipeline.register %2 : i1
   } do {
-    staticlogic.pipeline.stage {
+    staticlogic.pipeline.stage start = 0 {
       staticlogic.pipeline.register
     }
     staticlogic.pipeline.terminator iter_args(), results() : () -> ()
@@ -26,7 +26,7 @@ func @single_condition() {
   staticlogic.pipeline.while II = 1 iter_args(%arg0 = %false) : (i1) -> () {
     staticlogic.pipeline.register %arg0, %arg0 : i1, i1
   } do {
-    staticlogic.pipeline.stage {
+    staticlogic.pipeline.stage start = 0 {
       staticlogic.pipeline.register
     }
     staticlogic.pipeline.terminator iter_args(), results() : () -> ()
@@ -42,7 +42,7 @@ func @boolean_condition() {
   staticlogic.pipeline.while II = 1 iter_args(%arg0 = %c0_i32) : (i32) -> () {
     staticlogic.pipeline.register %arg0 : i32
   } do {
-    staticlogic.pipeline.stage {
+    staticlogic.pipeline.stage start = 0 {
       staticlogic.pipeline.register
     }
     staticlogic.pipeline.terminator iter_args(), results() : () -> ()
@@ -84,7 +84,7 @@ func @mismatched_register_types() {
   staticlogic.pipeline.while II = 1 iter_args(%arg0 = %false) : (i1) -> () {
     staticlogic.pipeline.register %arg0 : i1
   } do {
-    %0 = staticlogic.pipeline.stage {
+    %0 = staticlogic.pipeline.stage start = 0 {
       // expected-error @+1 {{'staticlogic.pipeline.register' op operand types ('i1') must match result types ('i2')}}
       staticlogic.pipeline.register %arg0 : i1
     } : i2
@@ -100,7 +100,7 @@ func @mismatched_iter_args_types() {
   staticlogic.pipeline.while II = 1 iter_args(%arg0 = %false) : (i1) -> () {
     staticlogic.pipeline.register %arg0 : i1
   } do {
-    staticlogic.pipeline.stage {
+    staticlogic.pipeline.stage start = 0 {
       staticlogic.pipeline.register
     }
     // expected-error @+1 {{'staticlogic.pipeline.terminator' op 'iter_args' types () must match pipeline 'iter_args' types ('i1')}}
@@ -116,7 +116,7 @@ func @invalid_iter_args() {
   staticlogic.pipeline.while II = 1 iter_args(%arg0 = %false) : (i1) -> (i1) {
     staticlogic.pipeline.register %arg0 : i1
   } do {
-    staticlogic.pipeline.stage {
+    staticlogic.pipeline.stage start = 0 {
       staticlogic.pipeline.register
     }
     // expected-error @+1 {{'staticlogic.pipeline.terminator' op 'iter_args' must be defined by a 'staticlogic.pipeline.stage'}}
@@ -132,7 +132,7 @@ func @mismatched_result_types() {
   staticlogic.pipeline.while II = 1 iter_args(%arg0 = %false) : (i1) -> (i1) {
     staticlogic.pipeline.register %arg0 : i1
   } do {
-    %0 = staticlogic.pipeline.stage {
+    %0 = staticlogic.pipeline.stage start = 0 {
       staticlogic.pipeline.register %arg0 : i1
     } : i1
     // expected-error @+1 {{'staticlogic.pipeline.terminator' op 'results' types () must match pipeline result types ('i1')}}
@@ -148,7 +148,7 @@ func @invalid_results() {
   staticlogic.pipeline.while II = 1 iter_args(%arg0 = %false) : (i1) -> (i1) {
     staticlogic.pipeline.register %arg0 : i1
   } do {
-    %0 = staticlogic.pipeline.stage {
+    %0 = staticlogic.pipeline.stage start = 0 {
       staticlogic.pipeline.register %arg0 : i1
     } : i1
     // expected-error @+1 {{'staticlogic.pipeline.terminator' op 'results' must be defined by a 'staticlogic.pipeline.stage'}}


### PR DESCRIPTION
This is an essential result of scheduling, and should be captured in
this IR. It is a property of the pipeline stage, not the operations or
operator types they might map to. This information, with the pipeline
II, is needed by lowering passes to generate the appropriate
cycle-level timings. Specifically, it will be used to determine which
stages need to be considered in the pipeline prologue and epilogue.