### PR TITLE
Pycde placement mutation

### DIFF
--- a/frontends/PyCDE/src/pycde/devicedb.py
+++ b/frontends/PyCDE/src/pycde/devicedb.py
@@ -129,12 +129,19 @@ class PlacementDB:
     self._db.add_placement(loc._loc, path, subpath, entity._entity_extern)
 
   def remove_placement(self, loc: PhysLocation):
-    # Remove the location from the PlacementDB.
     success = self._db.remove_placement(loc._loc)
     if not success:
       raise RuntimeError(f"Unable to remove placement at: {loc}")
 
     self._mutate_global_ref_placement(loc)
+
+  def move_placement(self, old_loc: PhysLocation, new_loc: PhysLocation):
+    success = self._db.move_placement(old_loc._loc, new_loc._loc)
+    if not success:
+      raise RuntimeError(
+          f"Unable to move placement from: {old_loc._loc}, to: {new_loc._loc}")
+
+    self._mutate_global_ref_placement(old_loc, new_loc)
 
   # Mutate the IR to reflect a placement that is being removed or moved. The old
   # location is used to scan for the relevant global ref. If the new location is

--- a/frontends/PyCDE/test/instances.py
+++ b/frontends/PyCDE/test/instances.py
@@ -47,6 +47,7 @@ primdb.add_coords(PrimitiveType.M20K, 15, 25)
 primdb.add_coords(PrimitiveType.M20K, 40, 40)
 primdb.add_coords("DSP", 0, 10)
 primdb.add_coords(PrimitiveType.DSP, 1, 12)
+primdb.add_coords(PrimitiveType.DSP, 1, 13)
 primdb.add(PhysLocation(PrimitiveType.DSP, 39, 25))
 
 print(PhysLocation(PrimitiveType.DSP, 39, 25))
@@ -127,10 +128,16 @@ assert (len(instance_attrs.find_unused()) == 1)
 
 test_inst.placedb.remove_placement(loc[1])
 
+old_loc = PhysLocation(PrimitiveType.DSP, 1, 12, sub_path="dsp_inst")
+new_loc = PhysLocation(PrimitiveType.DSP, 1, 13, sub_path="dsp_inst")
+test_inst.placedb.move_placement(old_loc, new_loc)
+
 print("=== After applying placements")
 t.print()
 # CHECK-LABEL: === After applying placements
 # CHECK-NOT: hw.globalRef {{.*}} #hw.innerNameRef<@UnParameterized::@Nothing> {{.*}} #msft.physloc<DSP, 39, 25, 0, "memory|bank">
+# CHECK-NOT: hw.globalRef {{.*}} #hw.innerNameRef<@UnParameterized::@Nothing>] {{.*}} #msft.physloc<DSP, 1, 12, 0, "dsp_inst">
+# CHECK: hw.globalRef {{.*}} #hw.innerNameRef<@UnParameterized::@Nothing>] {{.*}} #msft.physloc<DSP, 1, 13, 0, "dsp_inst">
 
 t.run_passes()
 
@@ -140,9 +147,10 @@ t.print()
 # OUTPUT-LABEL: proc Test_config { parent }
 # OUTPUT-NOT:  set_location_assignment M20K_X40_Y40
 # OUTPUT-NOT:  set_location_assignment MPDSP_X39_Y25_N0
+# OUTPUT-NOT:  set_location_assignment MPDSP_X1_Y13_N0
 # OUTPUT-DAG:  set_location_assignment MPDSP_X0_Y10_N0 -to $parent|UnParameterized|Nothing|dsp_inst
 # OUTPUT-DAG:  set_location_assignment M20K_X15_Y25_N0 -to $parent|UnParameterized|memory|bank
-# OUTPUT-DAG:  set_location_assignment MPDSP_X1_Y12_N0 -to $parent|UnParameterized_1|Nothing|dsp_inst
+# OUTPUT-DAG:  set_location_assignment MPDSP_X1_Y13_N0 -to $parent|UnParameterized_1|Nothing|dsp_inst
 # OUTPUT-DAG:  set_location_assignment M20K_X39_Y25_N0 -to $parent|UnParameterized_1|memory|bank
 # OUTPUT-DAG:  set_instance_assignment -name PLACE_REGION "X0 Y0 X10 Y10;X10 Y10 X20 Y20" -to $parent|UnParameterized|Nothing
 # OUTPUT-DAG:  set_instance_assignment -name RESERVE_PLACE_REGION OFF -to $parent|UnParameterized|Nothing

--- a/frontends/PyCDE/test/instances.py
+++ b/frontends/PyCDE/test/instances.py
@@ -125,6 +125,13 @@ assert instance_attrs.find_unused() is None
 instance_attrs.lookup(pycde.AppID("doesnotexist")).add_attribute(loc)
 assert (len(instance_attrs.find_unused()) == 1)
 
+test_inst.placedb.remove_placement(loc[1])
+
+print("=== After applying placements")
+t.print()
+# CHECK-LABEL: === After applying placements
+# CHECK-NOT: hw.globalRef {{.*}} #hw.innerNameRef<@UnParameterized::@Nothing> {{.*}} #msft.physloc<DSP, 39, 25, 0, "memory|bank">
+
 t.run_passes()
 
 print("=== Final mlir dump")
@@ -132,8 +139,8 @@ t.print()
 
 # OUTPUT-LABEL: proc Test_config { parent }
 # OUTPUT-NOT:  set_location_assignment M20K_X40_Y40
+# OUTPUT-NOT:  set_location_assignment MPDSP_X39_Y25_N0
 # OUTPUT-DAG:  set_location_assignment MPDSP_X0_Y10_N0 -to $parent|UnParameterized|Nothing|dsp_inst
-# OUTPUT-DAG:  set_location_assignment MPDSP_X39_Y25_N0 -to $parent|UnParameterized|Nothing|memory|bank
 # OUTPUT-DAG:  set_location_assignment M20K_X15_Y25_N0 -to $parent|UnParameterized|memory|bank
 # OUTPUT-DAG:  set_location_assignment MPDSP_X1_Y12_N0 -to $parent|UnParameterized_1|Nothing|dsp_inst
 # OUTPUT-DAG:  set_location_assignment M20K_X39_Y25_N0 -to $parent|UnParameterized_1|memory|bank


### PR DESCRIPTION
This adds an API to PyCDE to move and remove placements. This isn't ideal, but I've actually tried a few different things to do this more nicely, without any material benefit.

For one, we are passing the old location rather than an AppID or some other way of indicating what entity we are talking about. I think it would be a better API to specify the thing at the old location, rather than the old location itself, but this is the best I could come up with without significant changes. There isn't currently any way to find an entity given such a pointer, at least without walking the whole IR.

Second, given the old location, we should be able to look up the entity from the database itself, and use its global ref symbols to find the global ref. We could potentially use the symbol cache in the System instance to do this, but global refs created during placements currently do not reflect there. We would need to change this, and add some extra HW CAPIs to GlobalRefAttr, and then we could potentially look up symbols in constant time. Since we don't have that ability, I'm just scanning the top-level module for the global ref in question.

Finally, this leaves references to deleted global refs in the IR, for the reasons mentioned above.

On the plus side, this does let you move something in the database, and reflect that in the IR. I'm trying to figure out if this API is useful as-is, or if we need to implement some of the missing pieces above.