### PR TITLE
[FIRRTL] Remove unused NLAs from OMIR

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -276,9 +276,11 @@ void EmitOMIRPass::runOnOperation() {
         anyFailures = true;
         return true;
       }
-      if (auto nlaSym = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal"))
+      if (auto nlaSym = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal")) {
         tracker.nla =
             dyn_cast_or_null<NonLocalAnchor>(symtbl->lookup(nlaSym.getAttr()));
+        removeTempNLAs.push_back(tracker.nla);
+      }
       if (sramIDs.erase(tracker.id))
         makeTrackerAbsolute(tracker);
       trackers.insert({tracker.id, tracker});


### PR DESCRIPTION
`EmitOMIR.cpp` was removing `circt.nonlocal` annotations but not deleting the `NonLocalAnchor` operations.
This commit adds the removed NLA reference to the list of NLAs that need to be removed.
The assumption here is that NLAs are not reused, that is there is only one client for each NLA.
Not adding any lit test to check for this, since the NLA verifier should error out if we miss to remove the op.