### PR TITLE
[FIRRTL] Add helper utilities for NLA. NFC.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -192,6 +192,12 @@ def NonLocalAnchor : FIRRTLOp<"nla",
     /// reference is a module.
     StringAttr ref();
 
+    /// Return the leaf Module.
+    StringAttr leafMod();
+
+    /// Returns true, if the NLA path contains the module.
+    bool hasModule(StringAttr modName);
+
     /// Returns true if this NLA targets a module or instance of a module (as
     /// opposed to an instance's port or something inside an instance).
     bool isModule();

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3309,6 +3309,21 @@ StringAttr NonLocalAnchor::root() {
   return modPart(0);
 }
 
+/// Return true if the NLA has the module in its path.
+bool NonLocalAnchor::hasModule(StringAttr modName) {
+  for (auto nameRef : namepath()) {
+    // nameRef is either an InnerRefAttr or a FlatSymbolRefAttr.
+    if (auto ref = nameRef.dyn_cast<hw::InnerRefAttr>()) {
+      if (ref.getModule() == modName)
+        return true;
+    } else {
+      if (nameRef.cast<FlatSymbolRefAttr>().getAttr() == modName)
+        return true;
+    }
+  }
+  return false;
+}
+
 /// Return just the reference part of the namepath at a specific index.  This
 /// will return an empty attribute if this is the leaf and the leaf is a module.
 StringAttr NonLocalAnchor::refPart(unsigned i) {
@@ -3322,6 +3337,12 @@ StringAttr NonLocalAnchor::refPart(unsigned i) {
 StringAttr NonLocalAnchor::ref() {
   assert(!namepath().empty());
   return refPart(namepath().size() - 1);
+}
+
+/// Return the leaf module.
+StringAttr NonLocalAnchor::leafMod() {
+  assert(!namepath().empty());
+  return modPart(namepath().size() - 1);
 }
 
 /// Returns true if this NLA targets an instance of a module (as opposed to


### PR DESCRIPTION
Add utilities for getting the leaf of a module and check if a module belongs to the NLA.