### PR TITLE
[HW] StructExtractOp folder

### DIFF
--- a/include/circt/Dialect/HW/HWAggregates.td
+++ b/include/circt/Dialect/HW/HWAggregates.td
@@ -147,6 +147,8 @@ def ArrayGetOp : HWOp<"array_get",
   let builders = [
     OpBuilder<(ins "Value":$input, "Value":$index)>
   ];
+
+  let hasFolder = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/HW/HWAggregates.td
+++ b/include/circt/Dialect/HW/HWAggregates.td
@@ -178,6 +178,8 @@ def StructExtractOp : HWOp<"struct_extract", [NoSideEffect]> {
     OpBuilder<(ins "Value":$input, "StructType::FieldInfo":$field)>,
     OpBuilder<(ins "Value":$input, "StringAttr":$field)>
   ];
+
+  let hasFolder = 1;
 }
 
 // Extract a range of bits from the specified input.

--- a/include/circt/Dialect/HW/HWTypesImpl.td
+++ b/include/circt/Dialect/HW/HWTypesImpl.td
@@ -115,6 +115,7 @@ def StructTypeImpl : HWType<"Struct"> {
     using FieldInfo = ::circt::hw::detail::FieldInfo;
     mlir::Type getFieldType(mlir::StringRef fieldName);
     void getInnerTypes(mlir::SmallVectorImpl<mlir::Type>&);
+    llvm::Optional<unsigned> getFieldIndex(mlir::StringRef fieldName);
   }];
 }
 

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1617,15 +1617,13 @@ void StructExtractOp::build(OpBuilder &builder, OperationState &odsState,
 OpFoldResult StructExtractOp::fold(ArrayRef<Attribute> operands) {
   auto structCreate = dyn_cast_or_null<StructCreateOp>(input().getDefiningOp());
   if (!structCreate)
-    return nullptr;
-  StructType ty = input().getType().cast<StructType>();
-  ArrayRef<hw::StructType::FieldInfo> elems = ty.getElements();
-  unsigned idx = 0, numElems = elems.size();
-  for (; idx < numElems; ++idx)
-    if (elems[idx].name == fieldAttr())
-      break;
-  assert(idx < numElems);
-  return structCreate.getOperand(idx);
+    return {};
+  StructType ty = input().getType().dyn_cast<StructType>();
+  if (!ty)
+    return {};
+  if (auto idx = ty.getFieldIndex(field()))
+    return structCreate.getOperand(*idx);
+  return {};
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1727,15 +1727,16 @@ void ArrayGetOp::build(OpBuilder &builder, OperationState &result, Value input,
 OpFoldResult ArrayGetOp::fold(ArrayRef<Attribute> operands) {
   auto inputCreate = dyn_cast_or_null<ArrayCreateOp>(input().getDefiningOp());
   if (!inputCreate)
-    return nullptr;
+    return {};
 
-  auto constIdx = dyn_cast_or_null<ConstantOp>(index().getDefiningOp());
-  if (!constIdx || constIdx.value().getBitWidth() > 64)
-    return nullptr;
+  IntegerAttr constIdx = operands[1].dyn_cast_or_null<IntegerAttr>();
+  if (!constIdx || constIdx.getValue().getBitWidth() > 64)
+    return {};
 
-  uint64_t idx = constIdx.value().getLimitedValue();
+  uint64_t idx = constIdx.getValue().getLimitedValue();
   auto createInputs = inputCreate.inputs();
-  assert(idx < createInputs.size());
+  if (idx >= createInputs.size())
+    return {};
   return createInputs[createInputs.size() - idx - 1];
 }
 

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1613,6 +1613,21 @@ void StructExtractOp::build(OpBuilder &builder, OperationState &odsState,
   build(builder, odsState, resultType, input, fieldAttr);
 }
 
+// A struct extract of a struct create -> corresponding struct create operand.
+OpFoldResult StructExtractOp::fold(ArrayRef<Attribute> operands) {
+  auto structCreate = dyn_cast_or_null<StructCreateOp>(input().getDefiningOp());
+  if (!structCreate)
+    return nullptr;
+  StructType ty = input().getType().cast<StructType>();
+  ArrayRef<hw::StructType::FieldInfo> elems = ty.getElements();
+  unsigned idx = 0, numElems = elems.size();
+  for (; idx < numElems; ++idx)
+    if (elems[idx].name == fieldAttr())
+      break;
+  assert(idx < numElems);
+  return structCreate.getOperand(idx);
+}
+
 //===----------------------------------------------------------------------===//
 // StructInjectOp
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1722,6 +1722,21 @@ void ArrayGetOp::build(OpBuilder &builder, OperationState &result, Value input,
   build(builder, result, resultType, input, index);
 }
 
+// An array_get of an array_create with a constant index can just be the
+// array_create operand at the constant index.
+OpFoldResult ArrayGetOp::fold(ArrayRef<Attribute> operands) {
+  auto inputCreate = dyn_cast_or_null<ArrayCreateOp>(input().getDefiningOp());
+  if (!inputCreate)
+    return nullptr;
+
+  auto constIdx = dyn_cast_or_null<ConstantOp>(index().getDefiningOp());
+  if (!constIdx || constIdx.value().getBitWidth() > 64)
+    return nullptr;
+
+  uint64_t idx = constIdx.value().getLimitedValue();
+  return inputCreate.inputs()[idx];
+}
+
 //===----------------------------------------------------------------------===//
 // TypedeclOp
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1734,7 +1734,9 @@ OpFoldResult ArrayGetOp::fold(ArrayRef<Attribute> operands) {
     return nullptr;
 
   uint64_t idx = constIdx.value().getLimitedValue();
-  return inputCreate.inputs()[idx];
+  auto createInputs = inputCreate.inputs();
+  assert(idx < createInputs.size());
+  return createInputs[createInputs.size() - idx - 1];
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1618,7 +1618,7 @@ OpFoldResult StructExtractOp::fold(ArrayRef<Attribute> operands) {
   auto structCreate = dyn_cast_or_null<StructCreateOp>(input().getDefiningOp());
   if (!structCreate)
     return {};
-  auto ty = type_dyn_cast<StructType>(input().getType());
+  auto ty = type_cast<StructType>(input().getType());
   if (!ty)
     return {};
   if (auto idx = ty.getFieldIndex(field()))

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1618,7 +1618,7 @@ OpFoldResult StructExtractOp::fold(ArrayRef<Attribute> operands) {
   auto structCreate = dyn_cast_or_null<StructCreateOp>(input().getDefiningOp());
   if (!structCreate)
     return {};
-  StructType ty = input().getType().dyn_cast<StructType>();
+  auto ty = type_dyn_cast<StructType>(input().getType());
   if (!ty)
     return {};
   if (auto idx = ty.getFieldIndex(field()))

--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -261,6 +261,17 @@ Type StructType::getFieldType(mlir::StringRef fieldName) {
   return Type();
 }
 
+Optional<unsigned> StructType::getFieldIndex(mlir::StringRef fieldName) {
+  ArrayRef<hw::StructType::FieldInfo> elems = getElements();
+  unsigned idx = 0, numElems = elems.size();
+  for (; idx < numElems; ++idx)
+    if (elems[idx].name == fieldName)
+      break;
+  if (idx >= numElems)
+    return {};
+  return idx;
+}
+
 void StructType::getInnerTypes(SmallVectorImpl<Type> &types) {
   for (const auto &field : getElements())
     types.push_back(field.type);

--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -266,10 +266,8 @@ Optional<unsigned> StructType::getFieldIndex(mlir::StringRef fieldName) {
   unsigned idx = 0, numElems = elems.size();
   for (; idx < numElems; ++idx)
     if (elems[idx].name == fieldName)
-      break;
-  if (idx >= numElems)
-    return {};
-  return idx;
+      return idx;
+  return {};
 }
 
 void StructType::getInnerTypes(SmallVectorImpl<Type> &types) {

--- a/test/Dialect/HW/canonicalization.mlir
+++ b/test/Dialect/HW/canonicalization.mlir
@@ -1063,6 +1063,14 @@ hw.module @array_get1(%a0: i3, %a1: i3, %a2: i3) -> (r0: i3) {
   hw.output %r0 : i3
 }
 
+// CHECK-LABEL: hw.module @struct_extract1(%a0: i3, %a1: i5) -> (r0: i3)
+// CHECK-NEXT:    hw.output %a0 : i3
+hw.module @struct_extract1(%a0: i3, %a1: i5) -> (r0: i3) {
+  %s = hw.struct_create (%a0, %a1) : !hw.struct<foo: i3, bar: i5>
+  %r0 = hw.struct_extract %s["foo"] : !hw.struct<foo: i3, bar: i5>
+  hw.output %r0 : i3
+}
+
 // == Begin: test cases from LowerToHW ==
 
 // CHECK-LABEL:  hw.module @instance_ooo(%arg0: i2, %arg1: i2, %arg2: i3) -> (out0: i8) {

--- a/test/Dialect/HW/canonicalization.mlir
+++ b/test/Dialect/HW/canonicalization.mlir
@@ -1054,12 +1054,12 @@ hw.module @bitcast_canonicalization(%arg0: i4) -> (r1: i4, r2: !hw.array<2xi2>) 
   hw.output %id, %b : i4, !hw.array<2xi2>
 }
 
-// CHECK-LABEL: hw.module @array_get1(%a0: i3, %a1: i3) -> (r0: i3)
+// CHECK-LABEL: hw.module @array_get1(%a0: i3, %a1: i3, %a2: i3) -> (r0: i3)
 // CHECK-NEXT:    hw.output %a0 : i3
-hw.module @array_get1(%a0: i3, %a1: i3) -> (r0: i3) {
-  %c0 = hw.constant 0 : i1
-  %arr = hw.array_create %a0, %a1 : i3
-  %r0 = hw.array_get %arr[%c0] : !hw.array<2xi3>
+hw.module @array_get1(%a0: i3, %a1: i3, %a2: i3) -> (r0: i3) {
+  %c0 = hw.constant 0 : i2
+  %arr = hw.array_create %a2, %a1, %a0 : i3
+  %r0 = hw.array_get %arr[%c0] : !hw.array<3xi3>
   hw.output %r0 : i3
 }
 

--- a/test/Dialect/HW/canonicalization.mlir
+++ b/test/Dialect/HW/canonicalization.mlir
@@ -1053,6 +1053,16 @@ hw.module @bitcast_canonicalization(%arg0: i4) -> (r1: i4, r2: !hw.array<2xi2>) 
   // CHECK-NEXT: hw.output %arg0, %0
   hw.output %id, %b : i4, !hw.array<2xi2>
 }
+
+// CHECK-LABEL: hw.module @array_get1(%a0: i3, %a1: i3) -> (r0: i3)
+// CHECK-NEXT:    hw.output %a0 : i3
+hw.module @array_get1(%a0: i3, %a1: i3) -> (r0: i3) {
+  %c0 = hw.constant 0 : i1
+  %arr = hw.array_create %a0, %a1 : i3
+  %r0 = hw.array_get %arr[%c0] : !hw.array<2xi3>
+  hw.output %r0 : i3
+}
+
 // == Begin: test cases from LowerToHW ==
 
 // CHECK-LABEL:  hw.module @instance_ooo(%arg0: i2, %arg1: i2, %arg2: i3) -> (out0: i8) {
@@ -1291,4 +1301,3 @@ hw.module @MemDepth1(%clock: i1, %en: i1, %addr: i1) -> (data: i32) {
 }
 
 // == End: test cases from LowerToHW ==
-


### PR DESCRIPTION
```
%st = hw.struct_create (%0, ...) : !hw.struct<foo: ...>
%field = hw.struct_extract %st["foo"] : ...
```
can just be `%0`.