### PR TITLE
[ExportVerilog] Inline duplicatable unary op more even with multiuses

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -127,6 +127,24 @@ static bool isDuplicatableNullaryExpression(Operation *op) {
   return false;
 }
 
+// Return true if the expression can be inlined even when the op has multiple
+// uses. Be careful to add operations here since it might cause exponential
+// emission without proper restrictions.
+static bool isDuplicatableExpression(Operation *op) {
+  if (op->getNumOperands() == 0)
+    return isDuplicatableNullaryExpression(op);
+
+  // It is cheap to inline extract op.
+  if (isa<comb::ExtractOp>(op))
+    return true;
+
+  // We only inline array_get with a constant index.
+  if (auto array = dyn_cast<hw::ArrayGetOp>(op))
+    return array.index().getDefiningOp<ConstantOp>();
+
+  return false;
+}
+
 /// Return the verilog name of the operations that can define a symbol.
 /// Except for <WireOp, RegOp, LocalParamOp, InstanceOp>, check global state
 /// `getDeclarationVerilogName` for them.
@@ -2177,14 +2195,15 @@ static bool isExpressionUnableToInline(Operation *op) {
   // If the parent op is not a module op, it is defined locally.
   bool isLocalDefinition = !isa_and_nonnull<HWModuleOp>(op->getParentOp());
 
+  bool isDuplicatable = isDuplicatableExpression(op);
+
   // Scan the users of the operation to see if any of them need this to be
   // emitted out-of-line.
   for (auto user : op->getUsers()) {
     // If the op is defined locally and the user is in a different block, then
     // we emit this as an out-of-line declaration into its block and the user
-    // can refer to it unless the operation is nullary and duplicable.
-    if (isLocalDefinition && user->getBlock() != opBlock &&
-        !isDuplicatableNullaryExpression(op))
+    // can refer to it unless the operation is duplicatable.
+    if (isLocalDefinition && user->getBlock() != opBlock && !isDuplicatable)
       return true;
 
     // Verilog bit selection is required by the standard to be:
@@ -2220,12 +2239,10 @@ static bool isExpressionEmittedInline(Operation *op) {
   if (op->hasOneUse() && isa<hw::OutputOp>(*op->getUsers().begin()))
     return true;
 
-  // If this operation has multiple uses, we can't generally inline it.
-  if (!op->getResult(0).hasOneUse()) {
-    // ... unless it is nullary and duplicable, then we can emit it inline.
-    if (op->getNumOperands() != 0 || !isDuplicatableNullaryExpression(op))
-      return false;
-  }
+  // If this operation has multiple uses, we can't generally inline it unless
+  // the op is duplicatable.
+  if (!op->getResult(0).hasOneUse() && !isDuplicatableExpression(op))
+    return false;
 
   // If it isn't structurally possible to inline this expression, emit it out
   // of line.

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -988,8 +988,7 @@ hw.module @UseParameterValue<xx: i42>(%arg0: i8)
   %c = hw.instance "inst3" @parameters2<p1: i42 = #hw.param.expr.mul<#hw.param.expr.add<#hw.param.verbatim<"xx">, 17>, #hw.param.verbatim<"yy">>, p2: i1 = 0>(arg0: %arg0: i8) -> (out: i8)
 
   // CHECK: localparam [41:0] _T = xx + 42'd17;
-  // CHECK-NEXT: wire [7:0] _T_0 = _T[7:0];
-  // CHECK-NEXT: assign out3 = _T_0 + _T_0;
+  // CHECK-NEXT: assign out3 = _T[7:0] + _T[7:0];
   %d = hw.param.value i42 = #hw.param.expr.add<#hw.param.decl.ref<"xx">, 17>
   %e = comb.extract %d from 0 : (i42) -> i8
   %f = comb.add %e, %e : i8
@@ -1044,3 +1043,11 @@ hw.module @Foo(%a: i1, %b: i1) -> (r1: i1, r2: i1) {
   hw.output %0, %0 : i1, i1
 }
 
+// CHECK-LABEL: module InlineArrayGet(
+hw.module @InlineArrayGet(%source: !hw.array<1xi1>) -> (r1:i1, r2:i1) {
+  %false = hw.constant false
+  %0 = hw.array_get %source[%false] : !hw.array<1xi1>
+  // CHECK:      assign r1 = source[1'h0];
+  // CHECK-NEXT: assign r2 = source[1'h0];
+  hw.output %0, %0 : i1, i1
+}

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -502,12 +502,11 @@ hw.module @exprInlineTestIssue439(%clk: i1) {
   sv.always posedge %clk {
     %c = hw.constant 0 : i32
 
-    // CHECK: localparam      [31:0] _T = 32'h0;
-    // CHECK: automatic logic [15:0] _T_0 = _T[15:0];
+    // CHECK: localparam [31:0] _T = 32'h0;
     %e = comb.extract %c from 0 : (i32) -> i16
     %f = comb.add %e, %e : i16
     sv.fwrite "%d"(%f) : i16
-    // CHECK: $fwrite(32'h80000002, "%d", _T_0 + _T_0);
+    // CHECK: $fwrite(32'h80000002, "%d", _T[15:0] + _T[15:0]);
     // CHECK: end // always @(posedge)
   }
 }

--- a/test/Conversion/ExportVerilog/verilog-basic.mlir
+++ b/test/Conversion/ExportVerilog/verilog-basic.mlir
@@ -39,19 +39,16 @@ hw.module @Expressions(%in4: i4, %clock: i1) ->
 
   %10 = comb.shru %in4, %in4 : i4
 
-  // CHECK: wire [1:0] _in4_1to0 = in4[1:0];
-  // CHECK: wire [1:0] _in4_3to2 = in4[3:2];
-
   // CHECK: assign w1 = ~in4;
   %3 = comb.xor %in4, %c-1_i4 : i4
 
   // CHECK: assign w1 = in4 % 4'h1;
   %4 = comb.modu %in4, %c1_i4 : i4
 
-  // CHECK: assign w1 = {2'h0, _in4_1to0};
+  // CHECK: assign w1 = {2'h0, in4[1:0]};
   %5 = comb.extract %in4 from 0 : (i4) -> i2
 
-  // CHECK: assign w1 = {2'h0, _in4_3to2 | {in4[2], 1'h0}};
+  // CHECK: assign w1 = {2'h0, in4[3:2] | {in4[2], 1'h0}};
   %6 = comb.extract %in4 from 2 : (i4) -> i2
   %8 = comb.concat %7, %false : i1, i1
   %9 = comb.or %6, %8 : i2
@@ -66,7 +63,7 @@ hw.module @Expressions(%in4: i4, %clock: i1) ->
   %15 = comb.mux %clock, %c2_i4, %c3_i4 : i4
   %16 = comb.mux %clock, %c1_i4, %15 : i4
 
-  // CHECK: assign w1 = {2'h0, _in4_3to2 | _in4_1to0};
+  // CHECK: assign w1 = {2'h0, in4[3:2] | in4[1:0]};
   %17 = comb.or %6, %5 : i2
   %18 = comb.concat %c0_i2, %in4 : i2, i4
 

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -124,7 +124,6 @@ circuit test_mod : %[[{"a": "a"}]]
 ; VERILOG-NEXT:    wire [2:0] implicitTrunc_out2;
 ; VERILOG-NEXT:    wire [5:0] cat_d;
 ; VERILOG-EMPTY:
-; VERILOG-NEXT:    wire [4:0] _cat_d_4to0 = cat_d[4:0];
 ; VERILOG-NEXT:    Cat cat (
 ; VERILOG-NEXT:      .a (b),
 ; VERILOG-NEXT:      .b (b),
@@ -133,14 +132,14 @@ circuit test_mod : %[[{"a": "a"}]]
 ; VERILOG-NEXT:    );
 ; VERILOG-NEXT:    ImplicitTrunc implicitTrunc (
 ; VERILOG-NEXT:      .inp_1 (a),
-; VERILOG-NEXT:      .inp_2 (_cat_d_4to0),
+; VERILOG-NEXT:      .inp_2 (cat_d[4:0]),
 ; VERILOG-NEXT:      .out1  (implicitTrunc_out1),
 ; VERILOG-NEXT:      .out2  (implicitTrunc_out2)
 ; VERILOG-NEXT:    );
 ; VERILOG-NEXT:    PrettifyExample prettifyExample (
-; VERILOG-NEXT:      .inp_1 (_cat_d_4to0),
-; VERILOG-NEXT:      .inp_2 (_cat_d_4to0),
-; VERILOG-NEXT:      .inp_3 (_cat_d_4to0),
+; VERILOG-NEXT:      .inp_1 (cat_d[4:0]),
+; VERILOG-NEXT:      .inp_2 (cat_d[4:0]),
+; VERILOG-NEXT:      .inp_3 (cat_d[4:0]),
 ; VERILOG-NEXT:      .out1  (prettifyExample_out1),
 ; VERILOG-NEXT:      .out2  (prettifyExample_out2)
 ; VERILOG-NEXT:    );


### PR DESCRIPTION
This commit allows extract op and array_get op to be inlined even when
they have multiple uses. To prevent exponential emission, the index of
array_get must be constant.

Close #2576