### PR TITLE
ask vscode compiling via clang by default.

### DIFF
--- a/.vscode/Unified.code-workspace.example.jsonc
+++ b/.vscode/Unified.code-workspace.example.jsonc
@@ -31,6 +31,8 @@
     "cmake.generator": "Ninja",
     "cmake.configureArgs": [
       // LLVM
+      "-DCMAKE_C_COMPILER=clang",
+      "-DCMAKE_CXX_COMPILER=clang++",
       "-DLLVM_ENABLE_PROJECTS=mlir",
       "-DLLVM_TARGETS_TO_BUILD=X86;RISCV",
       "-DLLVM_ENABLE_ASSERTIONS=ON",


### PR DESCRIPTION
Some system will by default use gnu toolchain, while gcc doesn't provide option `-Werror=unguarded-availability-new`, which leads to a failing build.