### PR TITLE
[HW][StructType] Add a getFieldIndex(StringAttr) method

### DIFF
--- a/include/circt/Dialect/HW/HWTypesImpl.td
+++ b/include/circt/Dialect/HW/HWTypesImpl.td
@@ -116,6 +116,7 @@ def StructTypeImpl : HWType<"Struct"> {
     mlir::Type getFieldType(mlir::StringRef fieldName);
     void getInnerTypes(mlir::SmallVectorImpl<mlir::Type>&);
     llvm::Optional<unsigned> getFieldIndex(mlir::StringRef fieldName);
+    llvm::Optional<unsigned> getFieldIndex(mlir::StringAttr fieldName);
   }];
 }
 

--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -263,8 +263,7 @@ Type StructType::getFieldType(mlir::StringRef fieldName) {
 
 Optional<unsigned> StructType::getFieldIndex(mlir::StringRef fieldName) {
   ArrayRef<hw::StructType::FieldInfo> elems = getElements();
-  unsigned idx = 0, numElems = elems.size();
-  for (; idx < numElems; ++idx)
+  for (size_t idx = 0, numElems = elems.size(); idx < numElems; ++idx)
     if (elems[idx].name == fieldName)
       return idx;
   return {};
@@ -272,7 +271,7 @@ Optional<unsigned> StructType::getFieldIndex(mlir::StringRef fieldName) {
 
 Optional<unsigned> StructType::getFieldIndex(mlir::StringAttr fieldName) {
   ArrayRef<hw::StructType::FieldInfo> elems = getElements();
-  for (unsigned idx = 0, numElems = elems.size(); idx < numElems; ++idx)
+  for (size_t idx = 0, numElems = elems.size(); idx < numElems; ++idx)
     if (elems[idx].name == fieldName)
       return idx;
   return {};

--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -270,6 +270,14 @@ Optional<unsigned> StructType::getFieldIndex(mlir::StringRef fieldName) {
   return {};
 }
 
+Optional<unsigned> StructType::getFieldIndex(mlir::StringAttr fieldName) {
+  ArrayRef<hw::StructType::FieldInfo> elems = getElements();
+  for (unsigned idx = 0, numElems = elems.size(); idx < numElems; ++idx)
+    if (elems[idx].name == fieldName)
+      return idx;
+  return {};
+}
+
 void StructType::getInnerTypes(SmallVectorImpl<Type> &types) {
   for (const auto &field : getElements())
     types.push_back(field.type);


### PR DESCRIPTION
This PR follows #2580 to add a `getFieldIndex(StringAttr)` method, as requested in #2585. I put `idx` and `numElems` declaration in for loop because they are only used in that scope; I hope this doesn't conflict with any coding style rules.

I am a total newbie in LLVM, MLIR and CIRCT. I'm curious why using `StringAttr` is faster than `StringRef`. Bellow is my analytics, but I'm not sure if they are the actual cause:

- Comparing `StringAttr` with `StringRef` will be comparing two `StringRef`, which is [comparing two memory sequences](https://github.com/llvm/llvm-project/blob/b0cd3abf032e01e6a8f742952e8427ad2e350a5b/llvm/include/llvm/ADT/StringRef.h#L76).
- Comparing two `StringAttr` compares two pointers because [the `Attribute` class is just a wrapper to a unique storage pointer](https://github.com/llvm/llvm-project/blob/b0cd3abf032e01e6a8f742952e8427ad2e350a5b/mlir/include/mlir/IR/Attributes.h#L20-L23). (Can I think `Attribute` as Java's `String`? Two `Attribute`/`String` with the same value are the same block in memory.)
- The speed difference is caused by comparing memory blocks vs comparing pointers, right?