### PR TITLE
[ExportVerilog] Don't add underscores for user specified names

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -878,6 +878,7 @@ void EmitterBase::emitComment(StringAttr comment) {
 /// a better name than "_T_42" based on the structure of the expression.
 StringAttr EmitterBase::inferStructuralNameForTemporary(Value expr) {
   StringAttr result;
+  bool addPrefixUnderScore = true;
 
   // Look through read_inout.
   if (auto read = expr.getDefiningOp<ReadInOutOp>())
@@ -900,6 +901,8 @@ StringAttr EmitterBase::inferStructuralNameForTemporary(Value expr) {
       // doesn't explicitly specify it. Do this last
       result = nameHint;
 
+      // If there is a namehint, don't add underscores to the name.
+      addPrefixUnderScore = false;
     } else {
       TypeSwitch<Operation *>(op)
           // Generate a pretty name for VerbatimExpr's that look macro-like
@@ -941,7 +944,7 @@ StringAttr EmitterBase::inferStructuralNameForTemporary(Value expr) {
     return {};
 
   // Make sure that all temporary names start with an underscore.
-  if (result.strref().front() != '_')
+  if (addPrefixUnderScore && result.strref().front() != '_')
     result = StringAttr::get(expr.getContext(), "_" + result.strref());
 
   return result;

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -123,7 +123,7 @@ hw.module @TESTSIMPLE(%a: i4, %b: i4, %c: i2, %cond: i1,
 // CHECK-EMPTY:
 // CHECK-NEXT:   wire [8:0][3:0] [[WIRE0:.+]] = {{[{}][{}]}}4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}, {4'hF}};
 // CHECK-NEXT:   wire [2:0][3:0] [[WIRE1:.+]] = {{[{}][{}]}}4'hF}, {a + b}, {4'hF}};
-// CHECK-NEXT:   wire [9:0][3:0] [[WIRE2:_array2d_idx_0_name]] = array2d[a];
+// CHECK-NEXT:   wire [9:0][3:0] [[WIRE2:array2d_idx_0_name]] = array2d[a];
 // CHECK-NEXT:   wire struct packed {logic [1:0] foo; logic [3:0] bar; } [[WIRE3:.+]] = '{foo: c, bar: a};
 // CHECK-NEXT:   assign r0 = a + b;
 // CHECK-NEXT:   assign r2 = a - b;


### PR DESCRIPTION
This commit modifies name inference of temporary wires not to
add underscores to namehints.

Close #2572