### PR TITLE
[NFC,FIRRTL] Reorder worklist for IMConstProp

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -15,6 +15,7 @@
 #include "mlir/IR/Threading.h"
 #include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/TinyPtrVector.h"
+#include <stack>
 
 using namespace circt;
 using namespace firrtl;
@@ -270,7 +271,7 @@ private:
 
   /// A worklist of values whose LatticeValue recently changed, indicating the
   /// users need to be reprocessed.
-  std::queue<Value> changedLatticeValueWorklist;
+  std::stack<Value> changedLatticeValueWorklist;
 
   /// This keeps track of users the instance results that correspond to output
   /// ports.
@@ -304,7 +305,7 @@ void IMConstPropPass::runOnOperation() {
 
   // If a value changed lattice state then reprocess any of its users.
   while (!changedLatticeValueWorklist.empty()) {
-    Value changedVal = changedLatticeValueWorklist.front();
+    Value changedVal = changedLatticeValueWorklist.top();
     changedLatticeValueWorklist.pop();
     for (Operation *user : changedVal.getUsers()) {
       if (isBlockExecutable(user->getBlock()))

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -509,9 +509,8 @@ void IMConstPropPass::visitConnect(ConnectOp connect) {
   // Driving result ports propagates the value to each instance using the
   // module.
   if (auto blockArg = connect.dest().dyn_cast<BlockArgument>()) {
-    if (!AnnotationSet::get(blockArg).hasDontTouch())
-      for (auto userOfResultPort : resultPortToInstanceResultMapping[blockArg])
-        mergeLatticeValue(userOfResultPort, srcValue);
+    for (auto userOfResultPort : resultPortToInstanceResultMapping[blockArg])
+      mergeLatticeValue(userOfResultPort, srcValue);
     // Output ports are wire-like and may have users.
     mergeLatticeValue(connect.dest(), srcValue);
     return;


### PR DESCRIPTION
Use a stack rather than a queue for IMConstProp.  Improves locality.  Sees 20% performance improvement on large designs.  I don't see any dependence on worklist order for algorithmic complexity in the literature.

Minor change to not test don't touch when visiting connects.  markInstance already marks them overdefined and it's faster usually to do the merges than to test don't touch on a port.