### PR TITLE
[FIRRTL] Set output directory for testbench BlackBox modules

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
@@ -146,7 +146,7 @@ void BlackBoxReaderPass::runOnOperation() {
         coverDir = dir.getValue();
         continue;
       }
-    
+
     if (annot.isClass(testbenchAnno))
       if (auto dir = annot.getMember<StringAttr>("dirname")) {
         testBenchDir = dir.getValue();

--- a/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
@@ -357,7 +357,7 @@ bool BlackBoxReaderPass::isDut(Operation *module) {
     dutModuleMap[module] = true;
     return true;
   }
-  auto node = instanceGraph->lookup(module);
+  auto *node = instanceGraph->lookup(module);
   if (node->noUses()) {
     dutModuleMap[module] = false;
     return false;

--- a/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
@@ -356,10 +356,10 @@ void BlackBoxReaderPass::setOutputFile(VerbatimOp op, StringAttr fileNameAttr,
   auto ext = llvm::sys::path::extension(fileName);
   bool exclude = (ext == ".h" || ext == ".vh" || ext == ".svh");
   auto outDir = targetDir;
-  if (isCover)
-    outDir = coverDir;
-  else if (!testBenchDir.empty() && targetDir.equals(".") && !isDut)
+  if (!testBenchDir.empty() && targetDir.equals(".") && !isDut)
     outDir = testBenchDir;
+  else if (isCover)
+    outDir = coverDir;
 
   // If targetDir is not set explicitly and this is a testbench module, then
   // update the targetDir to be the "../testbench".

--- a/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
@@ -347,7 +347,7 @@ bool BlackBoxReaderPass::loadFile(Operation *op, StringRef inputPath,
 ///  2. Record that the file has been generated to avoid duplicates.
 ///  3. Add each file name to the generated "file list" file.
 void BlackBoxReaderPass::setOutputFile(VerbatimOp op, StringAttr fileNameAttr,
-                                       bool dut, bool isCover) {
+                                       bool isDut, bool isCover) {
   auto *context = &getContext();
   auto fileName = fileNameAttr.getValue();
   // Exclude Verilog header files since we expect them to be included

--- a/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
@@ -141,12 +141,17 @@ void BlackBoxReaderPass::runOnOperation() {
     filteredAnnos.push_back(annot.getDict());
 
     // Get the testbench and cover directories.
-    if (annot.isClass(coverAnnoClass)) {
-      if (auto dir = annot.getMember<StringAttr>("directory"))
+    if (annot.isClass(coverAnnoClass))
+      if (auto dir = annot.getMember<StringAttr>("directory")) {
         coverDir = dir.getValue();
-    } else if (annot.isClass(testbenchAnno))
-      if (auto dir = annot.getMember<StringAttr>("dirname"))
+        continue;
+      }
+    
+    if (annot.isClass(testbenchAnno))
+      if (auto dir = annot.getMember<StringAttr>("dirname")) {
         testBenchDir = dir.getValue();
+        continue;
+      }
   }
   // Apply the filtered annotations to the circuit.  If we updated the circuit
   // and record that they changed.

--- a/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
@@ -46,7 +46,7 @@ struct BlackBoxReaderPass : public BlackBoxReaderBase<BlackBoxReaderPass> {
   bool runOnAnnotation(Operation *op, Annotation anno, OpBuilder &builder,
                        bool isCover);
   bool loadFile(Operation *op, StringRef inputPath, OpBuilder &builder);
-  void setOutputFile(VerbatimOp op, StringAttr fileNameAttr, bool dut = false,
+  void setOutputFile(VerbatimOp op, StringAttr fileNameAttr, bool isDut = false,
                      bool isCover = false);
   // Check if module or any of its parents in the InstanceGraph is a DUT.
   bool isDut(Operation *module);
@@ -357,7 +357,7 @@ void BlackBoxReaderPass::setOutputFile(VerbatimOp op, StringAttr fileNameAttr,
   auto outDir = targetDir;
   if (isCover)
     outDir = coverDir;
-  else if (!testBenchDir.empty() && targetDir.equals(".") && !dut)
+  else if (!testBenchDir.empty() && targetDir.equals(".") && !isDut)
     outDir = testBenchDir;
 
   // If targetDir is not set explicitly and this is a testbench module, then

--- a/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
@@ -392,7 +392,7 @@ bool BlackBoxReaderPass::isDut(Operation *module) {
   auto *node = instanceGraph->lookup(module);
   bool anyParentIsDut = false;
   if (node)
-    for (auto u : node->uses()) {
+    for (auto *u : node->uses()) {
       InstanceOp inst = u->getInstance();
       // Recursively check the parents.
       auto dut = isDut(inst->getParentOfType<FModuleOp>());

--- a/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
@@ -227,6 +227,7 @@ void BlackBoxReaderPass::runOnOperation() {
   // If nothing has changed we can preseve the analysis.
   if (!anythingChanged)
     markAllAnalysesPreserved();
+  markAnalysesPreserved<InstanceGraph>();
 
   // Clean up.
   emittedFiles.clear();

--- a/test/Dialect/FIRRTL/blackbox-reader.mlir
+++ b/test/Dialect/FIRRTL/blackbox-reader.mlir
@@ -1,19 +1,33 @@
 // RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-blackbox-reader)' %s | FileCheck %s
 
-firrtl.circuit "Foo" {
+firrtl.circuit "Foo" attributes {annotations = [
+{class = "sifive.enterprise.firrtl.TestBenchDirAnnotation", dirname = "../testbench"},
+{class = "sifive.enterprise.firrtl.ExtractCoverageAnnotation", directory = "cover"}
+]}
+{
   // CHECK-LABEL: firrtl.extmodule @ExtFoo()
   // CHECK-NOT: class = "firrtl.transforms.BlackBoxInlineAnno"
   // CHECK-SAME: class = "firrtl.transforms.BlackBox"
   firrtl.extmodule @ExtFoo() attributes {annotations = [{class = "firrtl.transforms.BlackBoxInlineAnno", name = "hello.v", text = "// world"}]}
+  // CHECK-LABEL: firrtl.extmodule @ExtFoo2()
+  // CHECK-NOT: class = "firrtl.transforms.BlackBoxInlineAnno"
+  firrtl.extmodule @ExtFoo2() attributes {annotations = [{class = "firrtl.transforms.BlackBoxInlineAnno", name = "hello2.v", text = "// world"}, {class = "freechips.rocketchip.annotations.InternalVerifBlackBoxAnnotation"}]}
+  // CHECK-LABEL: firrtl.extmodule @ExtFoo3()
+  // CHECK-NOT: class = "firrtl.transforms.BlackBoxInlineAnno"
+  firrtl.extmodule @ExtFoo3() attributes {annotations = [{class = "firrtl.transforms.BlackBoxInlineAnno", name = "hello3.v", text = "// world"}, {class = "freechips.rocketchip.annotations.InternalVerifBlackBoxAnnotation"}]}
   // CHECK-LABEL: firrtl.module @DUTBlackboxes
   // CHECK-NOT: class = "firrtl.transforms.BlackBoxInlineAnno"
   firrtl.module @DUTBlackboxes() attributes {annotations = [
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}, {class = "firrtl.transforms.BlackBoxInlineAnno", name = "hello_dut.v", text = "// world"}]} {
+      firrtl.instance foo2  @ExtFoo2()
   }
   firrtl.module @Foo() {
     firrtl.instance foo @ExtFoo()
+    firrtl.instance foo3 @ExtFoo3()
     firrtl.instance dut @DUTBlackboxes()
   }
   // CHECK: sv.verbatim "// world" {output_file = #hw.output_file<"../testbench/hello.v">, symbols = []}
+  // CHECK: sv.verbatim "// world" {output_file = #hw.output_file<"cover/hello2.v">, symbols = []}
+  // CHECK: sv.verbatim "// world" {output_file = #hw.output_file<"cover/hello3.v">, symbols = []}
   // CHECK: sv.verbatim "// world" {output_file = #hw.output_file<"./hello_dut.v">, symbols = []}
 }

--- a/test/Dialect/FIRRTL/blackbox-reader.mlir
+++ b/test/Dialect/FIRRTL/blackbox-reader.mlir
@@ -1,8 +1,19 @@
 // RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-blackbox-reader)' %s | FileCheck %s
 
 firrtl.circuit "Foo" {
-  // CHECK-LABEL: firrtl.extmodule @Foo()
+  // CHECK-LABEL: firrtl.extmodule @ExtFoo()
   // CHECK-NOT: class = "firrtl.transforms.BlackBoxInlineAnno"
   // CHECK-SAME: class = "firrtl.transforms.BlackBox"
-  firrtl.extmodule @Foo() attributes {annotations = [{class = "firrtl.transforms.BlackBoxInlineAnno", name = "hello.v", text = "// world"}]}
+  firrtl.extmodule @ExtFoo() attributes {annotations = [{class = "firrtl.transforms.BlackBoxInlineAnno", name = "hello.v", text = "// world"}]}
+  // CHECK-LABEL: firrtl.module @DUTBlackboxes
+  // CHECK-NOT: class = "firrtl.transforms.BlackBoxInlineAnno"
+  firrtl.module @DUTBlackboxes() attributes {annotations = [
+      {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}, {class = "firrtl.transforms.BlackBoxInlineAnno", name = "hello_dut.v", text = "// world"}]} {
+  }
+  firrtl.module @Foo() {
+    firrtl.instance foo @ExtFoo()
+    firrtl.instance dut @DUTBlackboxes()
+  }
+  // CHECK: sv.verbatim "// world" {output_file = #hw.output_file<"../testbench/hello.v">, symbols = []}
+  // CHECK: sv.verbatim "// world" {output_file = #hw.output_file<"./hello_dut.v">, symbols = []}
 }

--- a/test/Dialect/FIRRTL/blackbox-reader.mlir
+++ b/test/Dialect/FIRRTL/blackbox-reader.mlir
@@ -28,6 +28,6 @@ firrtl.circuit "Foo" attributes {annotations = [
   }
   // CHECK: sv.verbatim "// world" {output_file = #hw.output_file<"../testbench/hello.v">, symbols = []}
   // CHECK: sv.verbatim "// world" {output_file = #hw.output_file<"cover/hello2.v">, symbols = []}
-  // CHECK: sv.verbatim "// world" {output_file = #hw.output_file<"cover/hello3.v">, symbols = []}
+  // CHECK: sv.verbatim "// world" {output_file = #hw.output_file<"../testbench/hello3.v">, symbols = []}
   // CHECK: sv.verbatim "// world" {output_file = #hw.output_file<"./hello_dut.v">, symbols = []}
 }


### PR DESCRIPTION
In the `BlackBoxReader` pass, set the output directory for testbench modules to `../testbench`.
Runtime of pass on P550, before this commit: 
```
 6.7174 (  0.9%)    6.7174 (  2.2%)    BlackBoxReader
```
Runtime with this commit: 
```
  7.0718 (  0.9%)    7.0718 (  2.2%)    BlackBoxReader
  0.4767 (  0.1%)    0.4767 (  0.2%)      (A) circt::firrtl::InstanceGraph
```