### PR TITLE
[HW] Change HW.array_slice syntax

### DIFF
--- a/include/circt/Dialect/HW/HWAggregates.td
+++ b/include/circt/Dialect/HW/HWAggregates.td
@@ -113,7 +113,7 @@ def ArraySliceOp : HWOp<"array_slice", [NoSideEffect]> {
   }];
 
   let assemblyFormat = [{
-    $input `at` $lowIndex attr-dict `:`
+    $input`[`$lowIndex`]` attr-dict `:`
       `(` custom<SliceTypes>(type($input), qualified(type($lowIndex))) `)` `->` qualified(type($dst))
   }];
 }

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -65,8 +65,8 @@ hw.module @TESTSIMPLE(%a: i4, %b: i4, %c: i2, %cond: i1,
   %34 = comb.xor %a, %allone : i4
 
   %arrCreated = hw.array_create %allone, %allone, %allone, %allone, %allone, %allone, %allone, %allone, %allone : i4
-  %slice1 = hw.array_slice %arrCreated at %a : (!hw.array<9xi4>) -> !hw.array<3xi4>
-  %slice2 = hw.array_slice %arrCreated at %b : (!hw.array<9xi4>) -> !hw.array<3xi4>
+  %slice1 = hw.array_slice %arrCreated[%a] : (!hw.array<9xi4>) -> !hw.array<3xi4>
+  %slice2 = hw.array_slice %arrCreated[%b] : (!hw.array<9xi4>) -> !hw.array<3xi4>
   %35 = comb.mux %cond, %slice1, %slice2 : !hw.array<3xi4>
 
   %ab = comb.add %a, %b : i4


### PR DESCRIPTION
This may fix #2176:
> These are logically equivalent operations. array_slice should use the same syntax (but have the additional return type).

I think this issue is proposing changing `array_slice` syntax to use square bracket?
I did some small change to `td` file, but not so sure if this is the syntax that @lattner originally want.

Additionally, I also have a question about the type assembly format for `hw.array_slice` and `hw.array_get`:
`hw.array_slice` serialize the input parameter type, while `hw.array_get` doesn't. I thought types of ODS format should always be explicit, while this seems to be a counter example. Just curious the originally design purpose here.