### PR TITLE
[FIRRTL] FIx memory port NLAs + verifier

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -199,7 +199,7 @@ static LogicalResult updateExpandedPort(StringRef field, AnnoTarget &ref) {
   if (auto mem = dyn_cast<MemOp>(ref.getOp()))
     for (size_t p = 0, pe = mem.portNames().size(); p < pe; ++p)
       if (mem.getPortNameStr(p) == field) {
-        ref = PortAnnoTarget(ref.getOp(), p);
+        ref = PortAnnoTarget(mem, p);
         return success();
       }
   ref.getOp()->emitError("Cannot find port with name ") << field;
@@ -244,7 +244,7 @@ static FailureOr<unsigned> findVectorElement(Operation *op, Type type,
   return index;
 }
 
-static FailureOr<unsigned> findFieldID(AnnoTarget ref,
+static FailureOr<unsigned> findFieldID(AnnoTarget &ref,
                                        ArrayRef<TargetToken> tokens) {
   if (tokens.empty())
     return 0;
@@ -356,7 +356,8 @@ Optional<AnnoPathValue> resolveEntities(TokenAnnoTarget path,
     }
   }
 
-  // If we have aggregate specifiers, resolve those now.
+  // If we have aggregate specifiers, resolve those now. This call can update
+  // the ref to target a port of a memory.
   auto result = findFieldID(ref, component);
   if (failed(result))
     return {};

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -54,6 +54,29 @@ firrtl.circuit "FooNL"  attributes {annotations = [
 
 // -----
 
+// Non-local annotations on memory ports should work.
+
+// CHECK-LABEL: firrtl.circuit "MemPortsNL"
+// CHECK: firrtl.nla @nla [#hw.innerNameRef<@MemPortsNL::@child>, #hw.innerNameRef<@Child::@bar>]
+// CHECK: firrtl.module @Child()
+// CHECK:   %bar_r = firrtl.mem sym @bar
+// CHECK-SAME: portAnnotations = {{\[}}[{circt.nonlocal = @nla, class = "circt.test", nl = "nl"}]]
+// CHECK: firrtl.module @MemPortsNL()
+// CHECK:   firrtl.instance child sym @child
+// CHECK-SAME: annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}]
+firrtl.circuit "MemPortsNL" attributes {annotations = [
+  {class = "circt.test", nl = "nl", target = "~MemPortsNL|MemPortsNL/child:Child>bar.r"}
+  ]}  {
+  firrtl.module @Child() {
+    %bar_r = firrtl.mem Undefined  {depth = 16 : i64, name = "bar", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
+  }
+  firrtl.module @MemPortsNL() {
+    firrtl.instance child @Child()
+  }
+}
+
+// -----
+
 // Annotations on ports should work.
 firrtl.circuit "Test" attributes {annotations = [
   {class = "circt.test", target = "~Test|PortTest>in"}


### PR DESCRIPTION
When we attach non-local annotations to memory ports, since we do not
assign port symbols to the memory op, the leaf element of the anchor
should target a symbol on the memory.

The NLA verifier checks to see that there is an annotation which uses the NLA
attached to an operation.  When the annotation target is a memory port,
the NLA verifier also has to check the port annotations.  This same
logic would apply to InstanceOps, but we have decided that InstanceOp
annotations should be moved to the target module.

There was a small mistake in the LowerAnnotations pass where an `AnnoTarget`
should have been passed by reference, which resulted in memory port
annotation being attached directly to the memory instead.

The old/default annotation parsing framework is still broken: it creates
the NLA for the port annotation but does not attach a symbol to the
memory operation.