### PR TITLE
[FIRRTL] Fix IR printing assertion

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
@@ -167,12 +167,6 @@ struct FIRRTLOpAsmDialectInterface : public OpAsmDialectInterface {
       return;
     }
 
-    // Many firrtl dialect operations have an optional 'name' attribute.  If
-    // present, use it.
-    if (op->getNumResults() == 1)
-      if (auto nameAttr = op->getAttrOfType<StringAttr>("name"))
-        setNameFn(op->getResult(0), nameAttr.getValue());
-
     // For constants in particular, propagate the value into the result name to
     // make it easier to read the IR.
     if (auto constant = dyn_cast<ConstantOp>(op)) {
@@ -193,6 +187,7 @@ struct FIRRTLOpAsmDialectInterface : public OpAsmDialectInterface {
         constant.value().print(specialName, /*isSigned:*/ false);
       }
       setNameFn(constant.getResult(), specialName.str());
+      return;
     }
 
     if (auto specialConstant = dyn_cast<SpecialConstantOp>(op)) {
@@ -209,6 +204,7 @@ struct FIRRTLOpAsmDialectInterface : public OpAsmDialectInterface {
         specialName << "_asyncreset";
       }
       setNameFn(specialConstant.getResult(), specialName.str());
+      return;
     }
 
     // Set invalid values to have a distinct name.
@@ -237,7 +233,14 @@ struct FIRRTLOpAsmDialectInterface : public OpAsmDialectInterface {
         name = "invalid";
 
       setNameFn(invalid.getResult(), name);
+      return;
     }
+
+    // Many firrtl dialect operations have an optional 'name' attribute.  If
+    // present, use it.
+    if (op->getNumResults() == 1)
+      if (auto nameAttr = op->getAttrOfType<StringAttr>("name"))
+        setNameFn(op->getResult(0), nameAttr.getValue());
   }
 };
 

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -18,6 +18,8 @@ firrtl.module @Constants() {
   firrtl.specialconstant 1 : !firrtl.reset
   // CHECK: %c1_asyncreset = firrtl.specialconstant 1 : !firrtl.asyncreset
   firrtl.specialconstant 1 : !firrtl.asyncreset
+  // CHECK: firrtl.constant 4 : !firrtl.uint<8> {name = "test"}
+  firrtl.constant 4 : !firrtl.uint<8> {name = "test"}
 }
 
 //module MyModule :


### PR DESCRIPTION
The FIRRTL OpAsmDialectInterface should return right after it sets the
name of any operation, instead of falling through.  Since we are now
attaching "name" attributes on to expressions, its possible that we try
to set the name attribute twice on constant operations, which triggers
an assertion in MLIR.