### PR TITLE
[ExportVerilog] Change unnamed from "_T" to "_GEN"

### DIFF
--- a/lib/Dialect/SV/SVDialect.cpp
+++ b/lib/Dialect/SV/SVDialect.cpp
@@ -118,7 +118,7 @@ StringRef circt::sv::legalizeName(StringRef name,
                                   size_t &nextGeneratedNameID) {
   // Fastest path: empty name.
   if (name.empty())
-    return resolveKeywordConflict("_T", recordNames, nextGeneratedNameID);
+    return resolveKeywordConflict("_GEN", recordNames, nextGeneratedNameID);
 
   // Check that the name is valid as the semi-fast path.
   if (llvm::all_of(name, isValidVerilogCharacter) &&

--- a/test/Conversion/ExportVerilog/disallow-local-vars.mlir
+++ b/test/Conversion/ExportVerilog/disallow-local-vars.mlir
@@ -61,11 +61,11 @@ hw.module @hoist_expressions(%clock: i1, %x: i8, %y: i8, %z: i8) {
     %1 = comb.icmp eq %0, %z : i8
 
     // This shouldn't be touched.
-    // CHECK: if (_T == z) begin
-    // DISALLOW: if (_T == z) begin
+    // CHECK: if (_GEN == z) begin
+    // DISALLOW: if (_GEN == z) begin
     sv.if %1  {
-      // CHECK: $fwrite(32'h80000002, "Hi %x\n", _T * z);
-      // DISALLOW: $fwrite(32'h80000002, "Hi %x\n", _T * z);
+      // CHECK: $fwrite(32'h80000002, "Hi %x\n", _GEN * z);
+      // DISALLOW: $fwrite(32'h80000002, "Hi %x\n", _GEN * z);
       %2 = comb.mul %0, %z : i8
       sv.fwrite "Hi %x\0A"(%2) : i8
       sv.fatal 1
@@ -130,7 +130,7 @@ hw.module @EmittedDespiteDisallowed(%clock: i1, %reset: i1) {
   // DISALLOW: initial begin
   sv.initial {
     // CHECK: automatic logic [1:0] _magic = magic;
-    // DISALLOW: _T = magic;
+    // DISALLOW: _GEN = magic;
     %RANDOM = sv.verbatim.expr.se "magic" : () -> i2 {symbols = []}
 
     // CHECK: tick_value_2 = _magic[0];

--- a/test/Conversion/ExportVerilog/load-dialect.mlir
+++ b/test/Conversion/ExportVerilog/load-dialect.mlir
@@ -12,7 +12,7 @@ hw.module @cyclic(%a: i1) -> (b: i1) {
   // for holding the value of %0.  If this wire is not emitted then this test
   // should either be deleted or find a different way to force IR generation.
 
-  // CHECK: wire _T;
+  // CHECK: wire _GEN;
 
   %1 = comb.add %0, %0 : i1
   %0 = comb.shl %a, %a : i1

--- a/test/Conversion/ExportVerilog/name-legalize.mlir
+++ b/test/Conversion/ExportVerilog/name-legalize.mlir
@@ -109,9 +109,9 @@ hw.module @TestDupInstanceName(%a: i1) {
 
 // CHECK-LABEL: module TestEmptyInstanceName(
 hw.module @TestEmptyInstanceName(%a: i1) {
-  // CHECK: B _T (
+  // CHECK: B _GEN (
   hw.instance "" @B(a: %a: i1) -> ()
-  // CHECK: B _T_0 (
+  // CHECK: B _GEN_0 (
   hw.instance "" @B(a: %a: i1) -> ()
 }
 
@@ -130,7 +130,7 @@ hw.module @TestInstanceNameValueConflict(%a: i1) {
 // https://github.com/llvm/circt/issues/855
 // CHECK-LABEL: module nameless_reg(
 hw.module @nameless_reg(%a: i1) -> () {
-  // CHECK: reg [3:0] _T;
+  // CHECK: reg [3:0] _GEN;
   %661 = sv.reg : !hw.inout<i4>
 }
 

--- a/test/Conversion/ExportVerilog/sv-interfaces.mlir
+++ b/test/Conversion/ExportVerilog/sv-interfaces.mlir
@@ -115,7 +115,7 @@ module {
   }
   // CHECK-LABEL: module structs(
   // CHECK-NOT: wire [383:0] _tmp =
-  // CHECK: wire struct packed {logic [383:0] foo; } _T_2
+  // CHECK: wire struct packed {logic [383:0] foo; } _GEN_2
   // CHECK: endmodule
   hw.module @structs(%clk: i1, %rstn: i1) {
     %0 = sv.interface.instance {name = "iface"} : !sv.interface<@IValidReady_Struct>

--- a/test/Conversion/ExportVerilog/verilog-basic.mlir
+++ b/test/Conversion/ExportVerilog/verilog-basic.mlir
@@ -34,7 +34,7 @@ hw.module @Expressions(%in4: i4, %clock: i1) ->
   %c0_i6 = hw.constant 0 : i6
   %c0_i10 = hw.constant 0 : i10
 
-  // CHECK: wire [3:0] _T = in4 >> in4;
+  // CHECK: wire [3:0] _GEN = in4 >> in4;
   %7 = comb.extract %in4 from 2 : (i4) -> i1
 
   %10 = comb.shru %in4, %in4 : i4
@@ -53,7 +53,7 @@ hw.module @Expressions(%in4: i4, %clock: i1) ->
   %8 = comb.concat %7, %false : i1, i1
   %9 = comb.or %6, %8 : i2
 
-  // CHECK: assign w1 = _T;
+  // CHECK: assign w1 = _GEN;
   // CHECK: assign w1 = clock ? (clock ? 4'h1 : 4'h2) : 4'h3;
   // CHECK: assign w1 = clock ? 4'h1 : clock ? 4'h2 : 4'h3;
   %11 = comb.shrs %in4, %in4 : i4
@@ -138,23 +138,23 @@ hw.module @Precedence(%a: i4, %b: i4, %c: i4) -> (out1: i1, out: i10) {
   %_out1_output = sv.wire  : !hw.inout<i1>
   %_out_output = sv.wire  : !hw.inout<i10>
 
-  // CHECK: wire [4:0] _T = {1'h0, b};
-  // CHECK: wire [4:0] _T_0 = _T + {1'h0, c};
-  // CHECK: wire [5:0] _T_1 = {2'h0, a};
-  // CHECK: wire [5:0] _T_2 = {1'h0, _T_0};
-  // CHECK: assign _out_output = {4'h0, _T_1 + _T_2};
-  // CHECK: wire [4:0] _T_3 = {1'h0, a} + _T;
-  // CHECK: assign _out_output = {4'h0, {1'h0, _T_3} - {2'h0, c}};
-  // CHECK: assign _out_output = {4'h0, _T_1 - _T_2};
-  // CHECK: wire [7:0] _T_4 = {4'h0, b};
-  // CHECK: wire [8:0] _T_5 = {5'h0, a};
-  // CHECK: assign _out_output = {1'h0, _T_5 + {1'h0, _T_4 * {4'h0, c}}};
-  // CHECK: wire [8:0] _T_6 = {5'h0, c};
-  // CHECK: assign _out_output = {1'h0, {1'h0, {4'h0, a} * _T_4} + _T_6};
-  // CHECK: assign _out_output = {1'h0, {4'h0, _T_3} * _T_6};
-  // CHECK: assign _out_output = {1'h0, _T_5 * {4'h0, _T_0}};
-  // CHECK: assign _out_output = {5'h0, _T_3} * {5'h0, _T_0};
-  // CHECK: assign _out1_output = ^_T_0;
+  // CHECK: wire [4:0] _GEN = {1'h0, b};
+  // CHECK: wire [4:0] _GEN_0 = _GEN + {1'h0, c};
+  // CHECK: wire [5:0] _GEN_1 = {2'h0, a};
+  // CHECK: wire [5:0] _GEN_2 = {1'h0, _GEN_0};
+  // CHECK: assign _out_output = {4'h0, _GEN_1 + _GEN_2};
+  // CHECK: wire [4:0] _GEN_3 = {1'h0, a} + _GEN;
+  // CHECK: assign _out_output = {4'h0, {1'h0, _GEN_3} - {2'h0, c}};
+  // CHECK: assign _out_output = {4'h0, _GEN_1 - _GEN_2};
+  // CHECK: wire [7:0] _GEN_4 = {4'h0, b};
+  // CHECK: wire [8:0] _GEN_5 = {5'h0, a};
+  // CHECK: assign _out_output = {1'h0, _GEN_5 + {1'h0, _GEN_4 * {4'h0, c}}};
+  // CHECK: wire [8:0] _GEN_6 = {5'h0, c};
+  // CHECK: assign _out_output = {1'h0, {1'h0, {4'h0, a} * _GEN_4} + _GEN_6};
+  // CHECK: assign _out_output = {1'h0, {4'h0, _GEN_3} * _GEN_6};
+  // CHECK: assign _out_output = {1'h0, _GEN_5 * {4'h0, _GEN_0}};
+  // CHECK: assign _out_output = {5'h0, _GEN_3} * {5'h0, _GEN_0};
+  // CHECK: assign _out1_output = ^_GEN_0;
   // CHECK: assign _out1_output = b < c | b > c;
   // CHECK: assign _out_output = {6'h0, (b ^ c) & {3'h0, _out1_output}};
   // CHECK: assign _out_output = {2'h0, _out_output[9:2]};
@@ -273,18 +273,18 @@ hw.module @MultiUseExpr(%a: i4) -> (b0: i1, b1: i1, b2: i1, b3: i1, b4: i2) {
   %c-1_i5 = hw.constant -1 : i5
   %c-1_i4 = hw.constant -1 : i4
 
-  // CHECK: wire _T = ^a;
+  // CHECK: wire _GEN = ^a;
   %0 = comb.parity %a : i4
-  // CHECK-NEXT: wire [4:0] _T_0 = {1'h0, a} << 5'h1;
+  // CHECK-NEXT: wire [4:0] _GEN_0 = {1'h0, a} << 5'h1;
   %1 = comb.concat %false, %a : i1, i4
   %2 = comb.shl %1, %c1_i5 : i5
 
-  // CHECK-NEXT: wire [3:0] _T_1 = ~a;
-  // CHECK-NEXT: assign b0 = _T;
-  // CHECK-NEXT: assign b1 = ^_T;
-  // CHECK-NEXT: assign b2 = &_T_0;
-  // CHECK-NEXT: assign b3 = ^_T_0;
-  // CHECK-NEXT: assign b4 = _T_1[3:2];
+  // CHECK-NEXT: wire [3:0] _GEN_1 = ~a;
+  // CHECK-NEXT: assign b0 = _GEN;
+  // CHECK-NEXT: assign b1 = ^_GEN;
+  // CHECK-NEXT: assign b2 = &_GEN_0;
+  // CHECK-NEXT: assign b3 = ^_GEN_0;
+  // CHECK-NEXT: assign b4 = _GEN_1[3:2];
   %3 = comb.parity %0 : i1
   %4 = comb.icmp eq %2, %c-1_i5 : i5
   %5 = comb.parity %2 : i5

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -198,8 +198,8 @@ circuit test_mod : %[[{"a": "a"}]]
 ; VERILOG-NEXT:   input  [4:0] inp_2,
 ; VERILOG-NEXT:   output [2:0] out1, out2);
 ; VERILOG-EMPTY:
-; VERILOG-NEXT:   wire [5:0] _T = {inp_2[4], inp_2} << inp_1;
-; VERILOG-NEXT:   assign out1 = _T[2:0];
+; VERILOG-NEXT:   wire [5:0] _GEN = {inp_2[4], inp_2} << inp_1;
+; VERILOG-NEXT:   assign out1 = _GEN[2:0];
 ; VERILOG-NEXT:   assign out2 = inp_2[2:0];
 ; VERILOG-NEXT: endmodule
 


### PR DESCRIPTION
Change the name used when ExportVerilog generates a name for an unnamed
things from "_T" to "_GEN".  "_T" is currently used by Chisel for
temporaries it generates and "_GEN" is currently used by the Scala
FIRRTL Compiler for temporaries it generates.  This will benefit Chisel
users compiling with CIRCT as this will continue the clear delineation
between "Chisel generated a temporary" and "the FIRRTL compiler
generated a temporary".

Fixes #2571.