### PR TITLE
[FIRRTL] Set the cover attribute for extern modules

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -870,7 +870,14 @@ FIRRTLModuleLowering::lowerExtModule(FExtModuleOp oldModule,
   auto parameters = getHWParameters(oldModule, /*ignoreValues=*/true);
   auto newModule = builder.create<hw::HWModuleExternOp>(
       oldModule.getLoc(), nameAttr, ports, verilogName, parameters);
-  if (AnnotationSet::removeAnnotations(oldModule, verifBBClass))
+  auto hasOutputPort = [&]() {
+    for (auto p : firrtlPorts)
+      if (p.isOutput())
+        return true;
+    return false;
+  };
+  if (!hasOutputPort() &&
+      AnnotationSet::removeAnnotations(oldModule, verifBBClass))
     newModule->setAttr("firrtl.extract.cover.extra", builder.getUnitAttr());
 
   loweringState.processRemainingAnnotations(oldModule,

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -870,13 +870,10 @@ FIRRTLModuleLowering::lowerExtModule(FExtModuleOp oldModule,
   auto parameters = getHWParameters(oldModule, /*ignoreValues=*/true);
   auto newModule = builder.create<hw::HWModuleExternOp>(
       oldModule.getLoc(), nameAttr, ports, verilogName, parameters);
-  auto hasOutputPort = [&]() {
-    for (auto p : firrtlPorts)
-      if (p.isOutput())
-        return true;
-    return false;
-  };
-  if (!hasOutputPort() &&
+
+  bool hasOutputPort =
+      llvm::any_of(firrtlPorts, [&](auto p) { return p.isOutput(); });
+  if (!hasOutputPort &&
       AnnotationSet::removeAnnotations(oldModule, verifBBClass))
     newModule->setAttr("firrtl.extract.cover.extra", builder.getUnitAttr());
 

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -870,6 +870,9 @@ FIRRTLModuleLowering::lowerExtModule(FExtModuleOp oldModule,
   auto parameters = getHWParameters(oldModule, /*ignoreValues=*/true);
   auto newModule = builder.create<hw::HWModuleExternOp>(
       oldModule.getLoc(), nameAttr, ports, verilogName, parameters);
+  if (AnnotationSet::removeAnnotations(oldModule, verifBBClass))
+    newModule->setAttr("firrtl.extract.cover.extra", builder.getUnitAttr());
+
   loweringState.processRemainingAnnotations(oldModule,
                                             AnnotationSet(oldModule));
   return newModule;

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1225,6 +1225,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   }
 
   firrtl.extmodule @chkcoverAnno(in clock: !firrtl.clock) attributes {annotations = [{class = "freechips.rocketchip.annotations.InternalVerifBlackBoxAnnotation"}]}
+  // CHECK-LABEL: hw.module.extern @chkcoverAnno(%clock: i1)
+  // CHECK-SAME: attributes {firrtl.extract.cover.extra}
 
   // CHECK-LABEL: hw.module.extern @InnerNamesExt
   // CHECK-SAME:  (

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1238,6 +1238,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     in clockIn: !firrtl.clock sym @extClockInSym,
     out clockOut: !firrtl.clock sym @extClockOutSym
   )
+  attributes {annotations = [{class = "freechips.rocketchip.annotations.InternalVerifBlackBoxAnnotation"}]}
 
   // CHECK-LABEL: hw.module @InnerNames
   // CHECK-SAME:  (


### PR DESCRIPTION
This commit sets the `firrtl.extract.cover.extra` attribute, for `FExtModuleOp` with the `InternalVerifBlackBoxAnnotation`.
It is already being set for `FModuleOp`.
