### PR TITLE
[FIRRTL] Remove NLAs dropped by DontTouch

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -1525,7 +1525,7 @@ void LowerTypesPass::runOnOperation() {
           failedToRemove = true;
           break;
         }
-        auto instOp = iter->op;
+        auto *instOp = iter->op;
         AnnotationSet::removeAnnotations(instOp, [&](Annotation anno) {
           if (auto nlaRef = anno.getMember("circt.nonlocal"))
             return (nlaName == nlaRef.cast<FlatSymbolRefAttr>().getAttr());

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -1491,7 +1491,10 @@ void LowerTypesPass::runOnOperation() {
   // element cannot be a module.
   for (auto nlaToSym : nlaToNewSymList) {
     auto nlaName = nlaToSym.nlaName;
-    // Get the nla with the corresponding name. This is guaranteed to exist.
+    // Get the nla with the corresponding name. It may not exist in the nlaMap,
+    // if we have already processed the NLA once. nlaToNewSymList can have
+    // duplicate entries for an NLA, since an NLA can be reused by multiple
+    // bundle subfields.
     auto iter = nlaMap.find(nlaName);
     if (iter == nlaMap.end())
       continue;

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -1485,7 +1485,7 @@ void LowerTypesPass::runOnOperation() {
   // have the "circt.nonlocal" annotation on the corresponding leaf, and delete
   // the NLA from the circuit.
 
-  struct validInstancesRecord {
+  struct ValidInstancesRecord {
     // NLA is invalid, if the "nonlocal" annotation is missing from the leaf.
     // Assumption: InstanceOp cannot be the leaf.
     bool isValid = false;
@@ -1493,7 +1493,7 @@ void LowerTypesPass::runOnOperation() {
   };
   // A record of each NLA, its instance path and if the NLA exists on some leaf
   // op.
-  DenseMap<StringAttr, validInstancesRecord> nlaToAnchorsMap;
+  DenseMap<StringAttr, ValidInstancesRecord> nlaToAnchorsMap;
 
   // For all ops in the circt, check its annotations.
   getOperation().walk([&](Operation *op) {
@@ -1526,7 +1526,7 @@ void LowerTypesPass::runOnOperation() {
           "cannot lower: NLA dropped but use exists in VerbatimOp");
       continue;
     }
-    for (auto instOp : nlaOps.getSecond().instances)
+    for (auto *instOp : nlaOps.getSecond().instances)
       AnnotationSet::removeAnnotations(instOp, [&](Annotation anno) {
         if (auto nlaRef = anno.getMember("circt.nonlocal"))
           if (nlaName == nlaRef.cast<FlatSymbolRefAttr>().getAttr())

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1417,22 +1417,28 @@ firrtl.module @Issue2315(in %x: !firrtl.vector<uint<10>, 5>, in %source: !firrtl
   firrtl.nla @nla [#hw.innerNameRef<@fallBackName::@test>, #hw.innerNameRef<@Aardvark::@test>, #hw.innerNameRef<@Zebra::@b>]
   // CHECK-SAME: [#hw.innerNameRef<@fallBackName::@test>, #hw.innerNameRef<@Aardvark::@test>, #hw.innerNameRef<@Zebra::@b_ready>]
   firrtl.nla @nla_1 [#hw.innerNameRef<@fallBackName::@test>,#hw.innerNameRef<@Aardvark::@test_1>, @Zebra]
+  firrtl.nla @nla_2 [#hw.innerNameRef<@fallBackName::@test>, #hw.innerNameRef<@Aardvark::@test>, #hw.innerNameRef<@Zebra::@b2>]
+  // CHECK-NOT: firrtl.nla @nla_2 
   firrtl.module @fallBackName() {
-    firrtl.instance test  sym @test {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}, {circt.nonlocal = @nla_1, class = "circt.nonlocal"} ]}@Aardvark()
+    firrtl.instance test  sym @test {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}, {circt.nonlocal = @nla_1, class = "circt.nonlocal"} , {circt.nonlocal = @nla_2, class = "circt.nonlocal"}]}@Aardvark()
     firrtl.instance test2 @Zebra()
   }
 
   firrtl.module @Aardvark() {
-    firrtl.instance test sym @test {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}]}@Zebra()
+    firrtl.instance test sym @test {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}, {circt.nonlocal = @nla_2, class = "circt.nonlocal"}]}@Zebra()
     firrtl.instance test1 sym @test_1 {annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}]}@Zebra()
   }
 
   // CHECK-LABEL: firrtl.module @Zebra()
-  firrtl.module @Zebra(){
+  firrtl.module @Zebra() attributes {annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}]}{
     %bundle = firrtl.wire sym @b {annotations = [#firrtl<"subAnno<fieldID = 2, {circt.nonlocal = @nla, class =\"test\" }>">]}: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
+    %bundle2 = firrtl.wire sym @b2 {annotations = [#firrtl<"subAnno<fieldID = 2, {circt.nonlocal = @nla_2, class =\"firrtl.transforms.DontTouchAnnotation\"}>">]}: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
    // CHECK:   %bundle_valid = firrtl.wire sym @b_valid : !firrtl.uint<1>
    // CHECK-NEXT:   %bundle_ready = firrtl.wire sym @b_ready {annotations = [{circt.nonlocal = @nla, class = "test"}]} : !firrtl.uint<1>
    // CHECK-NEXT:   %bundle_data = firrtl.wire sym @b_data : !firrtl.uint<64>
+   // CHECK:   %bundle2_valid = firrtl.wire sym @b2_valid  : !firrtl.uint<1>
+   // CHECK:   %bundle2_ready = firrtl.wire sym @b2_ready  : !firrtl.uint<1>
+   // CHECK:   %bundle2_data = firrtl.wire sym @b2_data  : !firrtl.uint<64>
   }
 
 // Test the update of NLA when a new symbol is added after lowering of bundle fields.

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1432,7 +1432,7 @@ firrtl.module @Issue2315(in %x: !firrtl.vector<uint<10>, 5>, in %source: !firrtl
   // CHECK-LABEL: firrtl.module @Zebra()
   firrtl.module @Zebra() attributes {annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}]}{
     %bundle = firrtl.wire sym @b {annotations = [#firrtl<"subAnno<fieldID = 2, {circt.nonlocal = @nla, class =\"test\" }>">]}: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
-    %bundle2 = firrtl.wire sym @b2 {annotations = [#firrtl<"subAnno<fieldID = 2, {circt.nonlocal = @nla_2, class =\"firrtl.transforms.DontTouchAnnotation\"}>">]}: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
+    %bundle2 = firrtl.wire sym @b2 {annotations = [#firrtl<"subAnno<fieldID = 3, {circt.nonlocal = @nla_2, class =\"firrtl.transforms.DontTouchAnnotation\"}>">, #firrtl<"subAnno<fieldID = 2, {circt.nonlocal = @nla_2, class =\"firrtl.transforms.DontTouchAnnotation\"}>">]}: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
    // CHECK:   %bundle_valid = firrtl.wire sym @b_valid : !firrtl.uint<1>
    // CHECK-NEXT:   %bundle_ready = firrtl.wire sym @b_ready {annotations = [{circt.nonlocal = @nla, class = "test"}]} : !firrtl.uint<1>
    // CHECK-NEXT:   %bundle_data = firrtl.wire sym @b_data : !firrtl.uint<64>


### PR DESCRIPTION
The `LowerTypes` pass should remove NLAs used for nonlocal `DontTouch` on Bundle fields.
1. `LowerTypes` will remove nonlocal `DontTouch` annotations and add symbol after lowering the bundle. For example, this annnotation would be dropped  , `#firrtl.subAnno<fieldID = 2, {circt.nonlocal = @nla_2, class ="firrtl.transforms.DontTouchAnnotation"}>` 
2. Dropping the `NLA` also handles the following case, when the fields of a bundle share the same `NLA`, since the symbol originally existed on the bundle, and all fields shared the symbol until `LowerTypes`.  
`%b = firrtl.wire sym @symB { annotations = {annotations = [#firrtl.subAnno<fieldID = 2, {circt.nonlocal = @nla_2, class ="firrtl.transforms.DontTouchAnnotation"}>, #firrtl.subAnno<fieldID = 4, {circt.nonlocal = @nla_2, class ="firrtl.transforms.DontTouchAnnotation"}> ">]}: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>`
3. `DontTouch` handling was already dropping the `NLA` annotation, but the original `NLA` was not being removed, and left dandling.
4. This commit, iterates over all the `NLA`s, and `circt.nonlocal` annotations, to find `NLA`s that don't have any leaf op, and exist only as bread crumbs on the `InstanceOp`s. Then remove such NLAs. 
5. Also added a check if the `NLA` is being used in `verbatim`, but this case cannot occur, because `verbatim` should not use `NLA` to print `bundle` subfields. So, we can decide to drop the `VerbatimOp` check here.