### PR TITLE
[FIRRTL] Strict Connect op and starting to canonicalize all connects to it

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -59,6 +59,25 @@ def PartialConnectOp : FIRRTLOp<"partialconnect"> {
     "$dest `,` $src  attr-dict `:` qualified(type($dest)) `,` qualified(type($src))";
 }
 
+def StrictConnectOp : FIRRTLOp<"strictconnect", [SameTypeOperands]> {
+  let summary = "Connect two signals";
+  let description =  [{
+    Connect two values with strict constraints:
+    ```
+      firrtl.strictconnect %dest, %src : t1
+    ```
+    }];
+
+  let arguments = (ins FIRRTLType:$dest, FIRRTLType:$src);
+  let results = (outs);
+  let hasCanonicalizeMethod = true;
+
+  let verifier = "return ::verifyStrictConnectOp(*this);";
+
+  let assemblyFormat =
+    "$dest `,` $src  attr-dict `:` qualified(type($dest))";
+}
+
 def PrintFOp : FIRRTLOp<"printf"> {
   let summary = "Formatted Print Statement";
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -153,11 +153,12 @@ public:
   ResultType dispatchStmtVisitor(Operation *op, ExtraArgs... args) {
     auto *thisCast = static_cast<ConcreteType *>(this);
     return TypeSwitch<Operation *, ResultType>(op)
-        .template Case<AttachOp, ConnectOp, PartialConnectOp, ForceOp, PrintFOp,
-                       SkipOp, StopOp, WhenOp, AssertOp, AssumeOp, CoverOp,
-                       ProbeOp>([&](auto opNode) -> ResultType {
-          return thisCast->visitStmt(opNode, args...);
-        })
+        .template Case<AttachOp, ConnectOp, PartialConnectOp, StrictConnectOp,
+                       ForceOp, PrintFOp, SkipOp, StopOp, WhenOp, AssertOp,
+                       AssumeOp, CoverOp, ProbeOp>(
+            [&](auto opNode) -> ResultType {
+              return thisCast->visitStmt(opNode, args...);
+            })
         .Default([&](auto expr) -> ResultType {
           return thisCast->visitInvalidStmt(op, args...);
         });
@@ -183,6 +184,7 @@ public:
   HANDLE(AttachOp);
   HANDLE(ConnectOp);
   HANDLE(PartialConnectOp);
+  HANDLE(StrictConnectOp);
   HANDLE(ForceOp);
   HANDLE(PrintFOp);
   HANDLE(SkipOp);

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1425,6 +1425,7 @@ struct FIRRTLLowering : public FIRRTLVisitor<FIRRTLLowering, LogicalResult> {
   LogicalResult visitStmt(SkipOp op);
   LogicalResult visitStmt(ConnectOp op);
   LogicalResult visitStmt(PartialConnectOp op);
+  LogicalResult visitStmt(StrictConnectOp op);
   LogicalResult visitStmt(ForceOp op);
   LogicalResult visitStmt(PrintFOp op);
   LogicalResult visitStmt(StopOp op);
@@ -3387,6 +3388,54 @@ LogicalResult FIRRTLLowering::visitStmt(PartialConnectOp op) {
     };
     recurse(destVal, srcVal, destType, op.src().getType());
 
+    return success();
+  }
+
+  builder.create<sv::AssignOp>(destVal, srcVal);
+  return success();
+}
+
+LogicalResult FIRRTLLowering::visitStmt(StrictConnectOp op) {
+  auto dest = op.dest();
+  auto srcVal = getLoweredValue(op.src());
+  if (!srcVal)
+    return handleZeroBit(op.src(), []() { return success(); });
+
+  auto destVal = getPossiblyInoutLoweredValue(dest);
+  if (!destVal)
+    return failure();
+
+  if (!destVal.getType().isa<hw::InOutType>())
+    return op.emitError("destination isn't an inout type");
+
+  auto *definingOp = getFieldRefFromValue(dest).getValue().getDefiningOp();
+
+  // If this is an assignment to a register, then the connect implicitly
+  // happens under the clock that gates the register.
+  if (auto regOp = dyn_cast_or_null<RegOp>(definingOp)) {
+    Value clockVal = getLoweredValue(regOp.clockVal());
+    if (!clockVal)
+      return failure();
+
+    addToAlwaysBlock(clockVal,
+                     [&]() { builder.create<sv::PAssignOp>(destVal, srcVal); });
+    return success();
+  }
+
+  // If this is an assignment to a RegReset, then the connect implicitly
+  // happens under the clock and reset that gate the register.
+  if (auto regResetOp = dyn_cast_or_null<RegResetOp>(definingOp)) {
+    Value clockVal = getLoweredValue(regResetOp.clockVal());
+    Value resetSignal = getLoweredValue(regResetOp.resetSignal());
+    if (!clockVal || !resetSignal)
+      return failure();
+
+    addToAlwaysBlock(sv::EventControl::AtPosEdge, clockVal,
+                     regResetOp.resetSignal().getType().isa<AsyncResetType>()
+                         ? ::ResetType::AsyncReset
+                         : ::ResetType::SyncReset,
+                     sv::EventControl::AtPosEdge, resetSignal,
+                     [&]() { builder.create<sv::PAssignOp>(destVal, srcVal); });
     return success();
   }
 

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -179,7 +179,7 @@ static bool insertResetMux(ImplicitLocOpBuilder &builder, Value target,
     TypeSwitch<Operation *>(useOp)
         // Insert a mux on the value connected to the target:
         // connect(dst, src) -> connect(dst, mux(reset, resetValue, src))
-        .Case<ConnectOp, PartialConnectOp>([&](auto op) {
+        .Case<ConnectOp, PartialConnectOp, StrictConnectOp>([&](auto op) {
           if (op.dest() != target)
             return;
           LLVM_DEBUG(llvm::dbgs() << "  - Insert mux into " << op << "\n");
@@ -590,7 +590,7 @@ void InferResetsPass::traceResets(CircuitOp circuit) {
       llvm::dbgs() << "\n===----- Tracing uninferred resets -----===\n\n");
   circuit.walk([&](Operation *op) {
     TypeSwitch<Operation *>(op)
-        .Case<ConnectOp, PartialConnectOp>(
+        .Case<ConnectOp, PartialConnectOp, StrictConnectOp>(
             [&](auto op) { traceResets(op.dest(), op.src(), op.getLoc()); })
 
         .Case<InstanceOp>([&](auto op) { traceResets(op); })

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1211,7 +1211,8 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
     else
       allWidthsKnown = false;
   }
-  if (allWidthsKnown && !isa<ConnectOp, PartialConnectOp, AttachOp>(op))
+  if (allWidthsKnown &&
+      !isa<ConnectOp, PartialConnectOp, StrictConnectOp, AttachOp>(op))
     return success();
 
   // Actually generate the necessary constraint expressions.

--- a/lib/Dialect/FIRRTL/Transforms/RemoveResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/RemoveResets.cpp
@@ -42,6 +42,11 @@ static bool isInvalid(Value val) {
           continue;
         val = connect.src();
         return;
+      } else if (auto connect = dyn_cast<StrictConnectOp>(user)) {
+        if (connect.dest() != val)
+          continue;
+        val = connect.src();
+        return;
       }
     }
     val = nullptr;

--- a/test/Dialect/FIRRTL/SFCTests/async-reset.fir
+++ b/test/Dialect/FIRRTL/SFCTests/async-reset.fir
@@ -113,10 +113,10 @@ circuit Foo:
     complex_literal[3] <= UInt<1>("h00")
     reg r : UInt<1>[4], clock with : (reset => (reset, complex_literal))
     z <= r
-    ; CHECK: firrtl.connect %z_0, %c1_ui1
-    ; CHECK: firrtl.connect %z_1, %c1_ui1
-    ; CHECK: firrtl.connect %z_2, %c0_ui1
-    ; CHECK: firrtl.connect %z_3, %c0_ui1
+    ; CHECK: firrtl.strictconnect %z_0, %c1_ui1
+    ; CHECK: firrtl.strictconnect %z_1, %c1_ui1
+    ; CHECK: firrtl.strictconnect %z_2, %c0_ui1
+    ; CHECK: firrtl.strictconnect %z_3, %c0_ui1
 
 // -----
 
@@ -130,7 +130,7 @@ circuit Foo:
     reg r : UInt<1>, clock with : (reset => (reset, r))
     r <= UInt(0)
     z <= r
-    ; CHECK: firrtl.connect %z, %c0_ui1
+    ; CHECK: firrtl.strictconnect %z, %c0_ui1
 
 // -----
 
@@ -144,4 +144,4 @@ circuit Foo:
     reg r : UInt<1>, clock with : (reset => (reset, UInt(0)))
     r <= UInt(0)
     z <= r
-    ; CHECK: firrtl.connect %z, %c0_ui1
+    ; CHECK: firrtl.strictconnect %z, %c0_ui1

--- a/test/Dialect/FIRRTL/SFCTests/constantProp.mlir
+++ b/test/Dialect/FIRRTL/SFCTests/constantProp.mlir
@@ -13,7 +13,7 @@ firrtl.circuit "ConstInput"   {
   // CHECK-LABEL: firrtl.module @Child
   firrtl.module @Child(in %in0: !firrtl.uint<1>, in %in1: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
     %0 = firrtl.and %in0, %in1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    // CHECK: firrtl.connect %out, %in0 :
+    // CHECK: firrtl.strictconnect %out, %in0 :
     firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
@@ -23,7 +23,7 @@ firrtl.circuit "InstanceInput"   {
   // CHECK-LABEL: firrtl.module @Bottom1
   firrtl.module @Bottom1(in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
       // CHECK: %c1_ui1 = firrtl.constant 1
-      // CHECK: firrtl.connect %out, %c1_ui1
+      // CHECK: firrtl.strictconnect %out, %c1_ui1
     firrtl.connect %out, %in : !firrtl.uint<1>, !firrtl.uint<1>
   }
   // CHECK-LABEL: firrtl.module @Child1
@@ -32,7 +32,7 @@ firrtl.circuit "InstanceInput"   {
     %b0_in, %b0_out = firrtl.instance b0 @Bottom1(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
     firrtl.connect %b0_in, %c1_ui : !firrtl.uint<1>, !firrtl.uint
     // CHECK: %[[C1:.+]] = firrtl.constant 1 :
-    // CHECK: firrtl.connect %out, %[[C1]]
+    // CHECK: firrtl.strictconnect %out, %[[C1]]
     firrtl.connect %out, %b0_out : !firrtl.uint<1>, !firrtl.uint<1>
   }
   // CHECK-LABEL:  firrtl.module @InstanceInput
@@ -46,7 +46,7 @@ firrtl.circuit "InstanceInput"   {
     %0 = firrtl.and %b0_out, %b1_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     %1 = firrtl.and %0, %c_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     // CHECK: %[[C0:.+]] = firrtl.constant 1 : !firrtl.uint<1>
-    // CHECK: firrtl.connect %z, %[[C0]] : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK: firrtl.strictconnect %z, %[[C0]] : !firrtl.uint<1>
     firrtl.connect %z, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
@@ -55,7 +55,7 @@ firrtl.circuit "InstanceInput"   {
 firrtl.circuit "InstanceInput2"   {
   // CHECK-LABEL: firrtl.module @Bottom2
   firrtl.module @Bottom2(in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
-    // CHECK: firrtl.connect %out, %in 
+    // CHECK: firrtl.strictconnect %out, %in 
     firrtl.connect %out, %in : !firrtl.uint<1>, !firrtl.uint<1>
   }
  // CHECK-LABEL:  firrtl.module @Child2
@@ -63,7 +63,7 @@ firrtl.circuit "InstanceInput2"   {
     %c1_ui = firrtl.constant 1 : !firrtl.uint
     %b0_in, %b0_out = firrtl.instance b0 @Bottom2(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
     firrtl.connect %b0_in, %c1_ui : !firrtl.uint<1>, !firrtl.uint
-    // CHECK: firrtl.connect %out, %b0_out
+    // CHECK: firrtl.strictconnect %out, %b0_out
     firrtl.connect %out, %b0_out : !firrtl.uint<1>, !firrtl.uint<1>
   }
  // CHECK-LABEL:  firrtl.module @InstanceInput2
@@ -76,7 +76,7 @@ firrtl.circuit "InstanceInput2"   {
     firrtl.connect %b1_in, %c1_ui : !firrtl.uint<1>, !firrtl.uint
     %0 = firrtl.and %b0_out, %b1_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     %1 = firrtl.and %0, %c_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-   // CHECK:  firrtl.connect %z, %1
+   // CHECK:  firrtl.strictconnect %z, %1
     firrtl.connect %z, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
@@ -91,7 +91,7 @@ firrtl.circuit "acrossWire"   {
     %0 = firrtl.mux(%x, %c0_ui1, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.connect %z, %0 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: %[[C2:.+]] = firrtl.constant 0 : !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.connect %y, %[[C2]] : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.strictconnect %y, %[[C2]] : !firrtl.uint<1>
   }
 }
 
@@ -107,7 +107,7 @@ firrtl.circuit "constOutput"   {
     firrtl.connect %z, %0 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: %[[C3_0:.+]] = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK: %[[C3:.+]] = firrtl.constant 0 : !firrtl.uint<1>
-    // CHECK: firrtl.connect %z, %[[C3:.+]] : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK: firrtl.strictconnect %z, %[[C3:.+]] : !firrtl.uint<1>
   }
 }
 
@@ -122,7 +122,7 @@ firrtl.circuit "optiMux"   {
     %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
     %0 = firrtl.mux(%c1_ui, %c0_ui2, %c0_ui4) : (!firrtl.uint, !firrtl.uint<2>, !firrtl.uint<4>) -> !firrtl.uint<4>
     // CHECK: %[[C4:.+]] = firrtl.constant 0 :
-    // CHECK: firrtl.connect %z, %[[C4]]
+    // CHECK: firrtl.strictconnect %z, %[[C4]]
     firrtl.connect %z, %0 : !firrtl.uint<4>, !firrtl.uint<4>
   }
 }
@@ -133,7 +133,7 @@ firrtl.circuit "divFold"   {
     %0 = firrtl.div %a, %a : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
     firrtl.connect %b, %0 : !firrtl.uint<8>, !firrtl.uint<8>
     // CHECK: %[[C5:.+]] = firrtl.constant 1 : !firrtl.uint<8>
-    // CHECK: firrtl.connect %b, %[[C5]] : !firrtl.uint<8>, !firrtl.uint<8>
+    // CHECK: firrtl.strictconnect %b, %[[C5]] : !firrtl.uint<8>
   }
 }
 
@@ -149,7 +149,7 @@ firrtl.circuit "padConstWire"   {
     %0 = firrtl.cat %w_a, %w_b : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<16>
     firrtl.connect %z, %0 : !firrtl.uint<16>, !firrtl.uint<16>
     // CHECK: %[[C6:.+]] = firrtl.constant 771 : !firrtl.uint<16>
-    // CHECK-NEXT: firrtl.connect %z, %[[C6]] : !firrtl.uint<16>, !firrtl.uint<16>
+    // CHECK-NEXT: firrtl.strictconnect %z, %[[C6]] : !firrtl.uint<16>
   }
 }
 
@@ -165,7 +165,7 @@ firrtl.circuit "padConstReg"   {
     %0 = firrtl.cat %r_a, %r_b : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<16>
     firrtl.connect %z, %0 : !firrtl.uint<16>, !firrtl.uint<16>
     // CHECK: %[[C6:.+]] = firrtl.constant 771 : !firrtl.uint<16>
-    // CHECK-NEXT: firrtl.connect %z, %[[C6]] : !firrtl.uint<16>, !firrtl.uint<16>
+    // CHECK-NEXT: firrtl.strictconnect %z, %[[C6]] : !firrtl.uint<16>
   }
 }
 
@@ -182,7 +182,7 @@ firrtl.circuit "padZeroReg"   {
       %1 = firrtl.cat %n, %r : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<16>
       firrtl.connect %z, %1 : !firrtl.uint<16>, !firrtl.uint<16>
     // CHECK: %[[TMP:.+]] = firrtl.constant 43776 : !firrtl.uint<16>
-    // CHECK-NEXT: firrtl.connect %z, %[[TMP]] : !firrtl.uint<16>, !firrtl.uint<16>
+    // CHECK-NEXT: firrtl.strictconnect %z, %[[TMP]] : !firrtl.uint<16>
   }
 }
 
@@ -197,8 +197,8 @@ firrtl.circuit "padConstOut"   {
     %c_x = firrtl.instance c @padConstOutChild(out x: !firrtl.uint<8>)
     %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
     %0 = firrtl.cat %c3_ui2, %c_x : (!firrtl.uint<2>, !firrtl.uint<8>) -> !firrtl.uint<10>
-    // CHECK: %[[C8:.+]] = firrtl.constant 771 : !firrtl.uint<10>
-    // CHECK: firrtl.connect %z, %[[C8]] : !firrtl.uint<16>, !firrtl.uint<10>
+    // CHECK: %[[C8:.+]] = firrtl.constant 771 : !firrtl.uint<16>
+    // CHECK: firrtl.strictconnect %z, %[[C8]] : !firrtl.uint<16>
     firrtl.connect %z, %0 : !firrtl.uint<16>, !firrtl.uint<10>
   }
 }
@@ -209,8 +209,8 @@ firrtl.circuit "padConstIn"   {
   firrtl.module @padConstInChild(in %x: !firrtl.uint<8>, out %y: !firrtl.uint<16>) {
     %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
     %0 = firrtl.cat %c3_ui2, %x : (!firrtl.uint<2>, !firrtl.uint<8>) -> !firrtl.uint<10>
-    // CHECK: %[[C9:.+]] = firrtl.constant 771 : !firrtl.uint<10>
-    // CHECK: firrtl.connect %y, %[[C9]] : !firrtl.uint<16>, !firrtl.uint<10>
+    // CHECK: %[[C9:.+]] = firrtl.constant 771 : !firrtl.uint<16>
+    // CHECK: firrtl.strictconnect %y, %[[C9]] : !firrtl.uint<16>
     firrtl.connect %y, %0 : !firrtl.uint<16>, !firrtl.uint<10>
   }
   // CHECK-LABEL: firrtl.module @padConstIn
@@ -220,7 +220,7 @@ firrtl.circuit "padConstIn"   {
     firrtl.connect %c_x, %c3_ui2 : !firrtl.uint<8>, !firrtl.uint<2>
     firrtl.connect %z, %c_y : !firrtl.uint<16>, !firrtl.uint<16>
     // CHECK: %[[C10:.+]] = firrtl.constant 771 : !firrtl.uint<16>
-    // CHECK: firrtl.connect %z, %[[C10]] : !firrtl.uint<16>, !firrtl.uint<16>
+    // CHECK: firrtl.strictconnect %z, %[[C10]] : !firrtl.uint<16>
   }
 }
 
@@ -229,7 +229,7 @@ firrtl.circuit "removePad"   {
   // CHECK-LABEL: firrtl.module @removePad
   firrtl.module @removePad(in %x: !firrtl.uint<8>, out %z: !firrtl.uint<8>) {
     %0 = firrtl.pad %x, 6 : (!firrtl.uint<8>) -> !firrtl.uint<8>
-    // CHECK: firrtl.connect %z, %x : !firrtl.uint<8>, !firrtl.uint<8>
+    // CHECK: firrtl.strictconnect %z, %x : !firrtl.uint<8>
     firrtl.connect %z, %0 : !firrtl.uint<8>, !firrtl.uint<8>
   }
 }
@@ -242,7 +242,7 @@ firrtl.circuit "uninitSelfReg"   {
     firrtl.connect %r, %r : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
     // CHECK: %invalid_ui8 = firrtl.invalidvalue : !firrtl.uint<8>
-    // CHECK: firrtl.connect %z, %invalid_ui8 : !firrtl.uint<8>, !firrtl.uint<8>
+    // CHECK: firrtl.strictconnect %z, %invalid_ui8 : !firrtl.uint<8>
   }
 }
 
@@ -255,7 +255,7 @@ firrtl.circuit "constResetReg"   {
     firrtl.connect %r, %r : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
     // CHECK: %[[C11:.+]] = firrtl.constant 11 : !firrtl.uint<8>
-    // CHECK: firrtl.connect %z, %[[C11]] : !firrtl.uint<8>, !firrtl.uint<8>
+    // CHECK: firrtl.strictconnect %z, %[[C11]] : !firrtl.uint<8>
   }
 }
 
@@ -269,8 +269,8 @@ firrtl.circuit "asyncReset"   {
     %0 = firrtl.mux(%en, %c0_ui4, %r) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<8>) -> !firrtl.uint<8>
     firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
-    // CHECK: firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
-    // CHECK: firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
+    // CHECK: firrtl.strictconnect %r, %0 : !firrtl.uint<8>
+    // CHECK: firrtl.strictconnect %z, %r : !firrtl.uint<8>
   }
 }
 
@@ -283,7 +283,7 @@ firrtl.circuit "constReg2"   {
     firrtl.connect %r, %c-5_si4 : !firrtl.sint<8>, !firrtl.sint<4>
     firrtl.connect %z, %r : !firrtl.sint<8>, !firrtl.sint<8>
     // CHECK: %[[C12:.+]] = firrtl.constant -5 : !firrtl.sint<8>
-    // CHECK: firrtl.connect %z, %[[C12]] : !firrtl.sint<8>, !firrtl.sint<8>
+    // CHECK: firrtl.strictconnect %z, %[[C12]] : !firrtl.sint<8>
   }
 }
 
@@ -296,7 +296,7 @@ firrtl.circuit "regSameConstReset"   {
     firrtl.connect %r, %c11_ui4 : !firrtl.uint<8>, !firrtl.uint<4>
     firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
     // CHECK: %[[C13:.+]] = firrtl.constant 11 : !firrtl.uint<8>
-    // CHECK: firrtl.connect %z, %[[C13]] : !firrtl.uint<8>, !firrtl.uint<8>
+    // CHECK: firrtl.strictconnect %z, %[[C13]] : !firrtl.uint<8>
   }
 }
 
@@ -311,7 +311,7 @@ firrtl.circuit "SignTester"   {
     %1 = firrtl.mux(%c0_ui1, %c0_si3, %0) : (!firrtl.uint<1>, !firrtl.sint<3>, !firrtl.sint<3>) -> !firrtl.sint<3>
     firrtl.connect %ref, %1 : !firrtl.sint<3>, !firrtl.sint<3>
     // CHECK:  %[[C14:.+]] = firrtl.constant -3 : !firrtl.sint<3>
-    // CHECK:  firrtl.connect %ref, %[[C14]] : !firrtl.sint<3>, !firrtl.sint<3>
+    // CHECK:  firrtl.strictconnect %ref, %[[C14]] : !firrtl.sint<3>
   }
 }
 
@@ -323,7 +323,7 @@ firrtl.circuit "AddTester"   {
     %0 = firrtl.add %c-1_si1, %c-1_si1 : (!firrtl.sint<1>, !firrtl.sint<1>) -> !firrtl.sint<2>
     firrtl.connect %ref, %0 : !firrtl.sint<2>, !firrtl.sint<2>
     // CHECK:  %[[C15:.+]] = firrtl.constant -2 : !firrtl.sint<2>
-    // CHECK:  firrtl.connect %ref, %[[C15]]
+    // CHECK:  firrtl.strictconnect %ref, %[[C15]]
   }
 }
 
@@ -340,9 +340,9 @@ firrtl.circuit "ConstPropReductionTester"   {
     firrtl.connect %out3, %2 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK:  %[[C16:.+]] = firrtl.constant 1
     // CHECK:  %[[C17:.+]] = firrtl.constant 0
-    // CHECK:  firrtl.connect %out1, %[[C17]]
-    // CHECK:  firrtl.connect %out2, %[[C16]]
-    // CHECK:  firrtl.connect %out3, %[[C16]]
+    // CHECK:  firrtl.strictconnect %out1, %[[C17]]
+    // CHECK:  firrtl.strictconnect %out2, %[[C16]]
+    // CHECK:  firrtl.strictconnect %out3, %[[C16]]
   }
 }
 
@@ -358,7 +358,7 @@ firrtl.circuit "TailTester"   {
     %2 = firrtl.tail %head_temp, 2 : (!firrtl.uint<3>) -> !firrtl.uint<1>
     firrtl.connect %out, %2 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK:  %[[C18:.+]] = firrtl.constant 0
-    // CHECK:  firrtl.connect %out, %[[C18]]
+    // CHECK:  firrtl.strictconnect %out, %[[C18]]
   }
 }
 
@@ -375,7 +375,7 @@ firrtl.circuit "TailTester2"   {
     %2 = firrtl.tail %tail_temp, 4 : (!firrtl.uint<5>) -> !firrtl.uint<1>
     firrtl.connect %out, %2 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK:  %[[C21:.+]] = firrtl.constant 1
-    // CHECK:  firrtl.connect %out, %[[C21]]
+    // CHECK:  firrtl.strictconnect %out, %[[C21]]
   }
 }
 
@@ -390,7 +390,7 @@ firrtl.circuit "ZeroWidthAdd"   {
     %2 = firrtl.tail %1, 13 : (!firrtl.uint<20>) -> !firrtl.uint<7>
     firrtl.connect %y, %2 : !firrtl.uint<7>, !firrtl.uint<7>
     // CHECK:  %[[C20:.+]] = firrtl.constant 0
-    // CHECK:  firrtl.connect %y, %[[C20]]
+    // CHECK:  firrtl.strictconnect %y, %[[C20]]
   }
 }
 
@@ -404,7 +404,7 @@ firrtl.circuit "regConstReset"   {
     firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
     // CHECK: %[[C22:.+]] = firrtl.constant 11 
-    // CHECK: firrtl.connect %z, %[[C22]]
+    // CHECK: firrtl.strictconnect %z, %[[C22]]
   }
 }
 
@@ -423,6 +423,6 @@ firrtl.circuit "constPropRegMux"   {
   %2 = firrtl.xor %r1, %r2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out, %2 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: %[[C23:.+]] = firrtl.constant 1
-    // CHECK: firrtl.connect %out, %[[C23]]
+    // CHECK: firrtl.strictconnect %out, %[[C23]]
   }
 }

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -16,44 +16,44 @@ firrtl.module @Casts(in %ui1 : !firrtl.uint<1>, in %si1 : !firrtl.sint<1>,
   %invalid_asyncreset = firrtl.invalidvalue : !firrtl.asyncreset
 
   // No effect
-  // CHECK: firrtl.connect %out_ui1, %ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK: firrtl.strictconnect %out_ui1, %ui1 : !firrtl.uint<1>
   %0 = firrtl.asUInt %ui1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out_ui1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.connect %out_si1, %si1 : !firrtl.sint<1>, !firrtl.sint<1>
+  // CHECK: firrtl.strictconnect %out_si1, %si1 : !firrtl.sint<1>
   %1 = firrtl.asSInt %si1 : (!firrtl.sint<1>) -> !firrtl.sint<1>
   firrtl.connect %out_si1, %1 : !firrtl.sint<1>, !firrtl.sint<1>
-  // CHECK: firrtl.connect %out_clock, %clock : !firrtl.clock, !firrtl.clock
+  // CHECK: firrtl.strictconnect %out_clock, %clock : !firrtl.clock
   %2 = firrtl.asClock %clock : (!firrtl.clock) -> !firrtl.clock
   firrtl.connect %out_clock, %2 : !firrtl.clock, !firrtl.clock
-  // CHECK: firrtl.connect %out_asyncreset, %asyncreset : !firrtl.asyncreset, !firrtl.asyncreset
+  // CHECK: firrtl.strictconnect %out_asyncreset, %asyncreset : !firrtl.asyncreset
   %3 = firrtl.asAsyncReset %asyncreset : (!firrtl.asyncreset) -> !firrtl.asyncreset
   firrtl.connect %out_asyncreset, %3 : !firrtl.asyncreset, !firrtl.asyncreset
 
   // Constant fold.
-  // CHECK: firrtl.connect %out_ui1, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK: firrtl.strictconnect %out_ui1, %c1_ui1 : !firrtl.uint<1>
   %4 = firrtl.asUInt %c1_si1 : (!firrtl.sint<1>) -> !firrtl.uint<1>
   firrtl.connect %out_ui1, %4 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.connect %out_si1, %c-1_si1 : !firrtl.sint<1>, !firrtl.sint<1>
+  // CHECK: firrtl.strictconnect %out_si1, %c-1_si1 : !firrtl.sint<1>
   %5 = firrtl.asSInt %c1_ui1 : (!firrtl.uint<1>) -> !firrtl.sint<1>
   firrtl.connect %out_si1, %5 : !firrtl.sint<1>, !firrtl.sint<1>
-  // CHECK: firrtl.connect %out_clock, %c1_clock : !firrtl.clock, !firrtl.clock
+  // CHECK: firrtl.strictconnect %out_clock, %c1_clock : !firrtl.clock
   %6 = firrtl.asClock %c1_ui1 : (!firrtl.uint<1>) -> !firrtl.clock
   firrtl.connect %out_clock, %6 : !firrtl.clock, !firrtl.clock
-  // CHECK: firrtl.connect %out_asyncreset, %c1_asyncreset : !firrtl.asyncreset, !firrtl.asyncreset
+  // CHECK: firrtl.strictconnect %out_asyncreset, %c1_asyncreset : !firrtl.asyncreset
   %7 = firrtl.asAsyncReset %c1_ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset
   firrtl.connect %out_asyncreset, %7 : !firrtl.asyncreset, !firrtl.asyncreset
 
   // Invalid values
-  // CHECK: firrtl.connect %out_ui1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK: firrtl.strictconnect %out_ui1, %c0_ui1 : !firrtl.uint<1>
   %8 = firrtl.asUInt %invalid_si1 : (!firrtl.sint<1>) -> !firrtl.uint<1>
   firrtl.connect %out_ui1, %8 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.connect %out_si1, %c0_si1 : !firrtl.sint<1>, !firrtl.sint<1>
+  // CHECK: firrtl.strictconnect %out_si1, %c0_si1 : !firrtl.sint<1>
   %9 = firrtl.asSInt %invalid_ui1 : (!firrtl.uint<1>) -> !firrtl.sint<1>
   firrtl.connect %out_si1, %9 : !firrtl.sint<1>, !firrtl.sint<1>
-  // CHECK: firrtl.connect %out_clock, %c0_clock : !firrtl.clock, !firrtl.clock
+  // CHECK: firrtl.strictconnect %out_clock, %c0_clock : !firrtl.clock
   %10 = firrtl.asClock %invalid_ui1 : (!firrtl.uint<1>) -> !firrtl.clock
   firrtl.connect %out_clock, %10 : !firrtl.clock, !firrtl.clock
-  // CHECK: firrtl.connect %out_asyncreset, %c0_asyncreset : !firrtl.asyncreset, !firrtl.asyncreset
+  // CHECK: firrtl.strictconnect %out_asyncreset, %c0_asyncreset : !firrtl.asyncreset
   %11 = firrtl.asAsyncReset %invalid_ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset
   firrtl.connect %out_asyncreset, %11 : !firrtl.asyncreset, !firrtl.asyncreset
 }
@@ -76,12 +76,12 @@ firrtl.module @Div(in %a: !firrtl.uint<4>,
   // CHECK-DAG: [[ZERO_i4:%.+]] = firrtl.constant 0 : !firrtl.uint<4>
 
   // Check that 'div(a, a) -> 1' works for known UInt widths.
-  // CHECK: firrtl.connect %b, [[ONE_i4]]
+  // CHECK: firrtl.strictconnect %b, [[ONE_i4]]
   %0 = firrtl.div %a, %a : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %b, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // Check that 'div(c, c) -> 1' works for known SInt widths.
-  // CHECK: firrtl.connect %d, [[ONE_s5]] : !firrtl.sint<5>, !firrtl.sint<5>
+  // CHECK: firrtl.strictconnect %d, [[ONE_s5]] : !firrtl.sint<5>
   %1 = firrtl.div %c, %c : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.sint<5>
   firrtl.connect %d, %1 : !firrtl.sint<5>, !firrtl.sint<5>
 
@@ -96,18 +96,18 @@ firrtl.module @Div(in %a: !firrtl.uint<4>,
   firrtl.connect %h, %3 : !firrtl.sint, !firrtl.sint
 
   // Check that 'div(a, 1) -> a' for known UInt widths.
-  // CHECK: firrtl.connect %b, %a
+  // CHECK: firrtl.strictconnect %b, %a
   %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
   %4 = firrtl.div %a, %c1_ui2 : (!firrtl.uint<4>, !firrtl.uint<2>) -> !firrtl.uint<4>
   firrtl.connect %b, %4 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.connect %i, %c5_ui4
+  // CHECK: firrtl.strictconnect %i, %c5_ui4
   %c1_ui4 = firrtl.constant 15 : !firrtl.uint<4>
   %c3_ui4 = firrtl.constant 3 : !firrtl.uint<4>
   %5 = firrtl.div %c1_ui4, %c3_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %i, %5 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.connect %i, [[ZERO_i4]]
+  // CHECK: firrtl.strictconnect %i, [[ZERO_i4]]
   %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
   %6 = firrtl.div %invalid_ui4, %a : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %i, %6 : !firrtl.uint<4>, !firrtl.uint<4>
@@ -119,7 +119,7 @@ firrtl.module @Rem(in %a: !firrtl.uint<4>, out %b: !firrtl.uint<4>) {
 
   %invalid_i4 = firrtl.invalidvalue : !firrtl.uint<4>
 
-  // CHECK: firrtl.connect %b, %[[ZERO_i4]]
+  // CHECK: firrtl.strictconnect %b, %[[ZERO_i4]]
   %rem = firrtl.rem %invalid_i4, %a : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %b, %rem : !firrtl.uint<4>, !firrtl.uint<4>
 }
@@ -128,23 +128,23 @@ firrtl.module @Rem(in %a: !firrtl.uint<4>, out %b: !firrtl.uint<4>) {
 firrtl.module @And(in %in: !firrtl.uint<4>,
                    in %sin: !firrtl.sint<4>,
                    out %out: !firrtl.uint<4>) {
-  // CHECK: firrtl.connect %out, %c1_ui4
+  // CHECK: firrtl.strictconnect %out, %c1_ui4
   %c1_ui4 = firrtl.constant 1 : !firrtl.uint<4>
   %c3_ui4 = firrtl.constant 3 : !firrtl.uint<4>
   %0 = firrtl.and %c3_ui4, %c1_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.connect %out, %in
+  // CHECK: firrtl.strictconnect %out, %in
   %c15_ui4 = firrtl.constant 15 : !firrtl.uint<4>
   %1 = firrtl.and %in, %c15_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.connect %out, %c0_ui4
+  // CHECK: firrtl.strictconnect %out, %c0_ui4
   %c1_ui0 = firrtl.constant 0 : !firrtl.uint<4>
   %2 = firrtl.and %in, %c1_ui0 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %2 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.connect %out, %in
+  // CHECK: firrtl.strictconnect %out, %in
   %3 = firrtl.and %in, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %3 : !firrtl.uint<4>, !firrtl.uint<4>
 
@@ -152,29 +152,29 @@ firrtl.module @And(in %in: !firrtl.uint<4>,
   // cannot be folded!
 
   // CHECK: firrtl.and %in, %c3_ui2
-  // CHECK-NEXT: firrtl.connect %out,
+  // CHECK-NEXT: firrtl.strictconnect %out,
   %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
   %4 = firrtl.and %in, %c3_ui2 : (!firrtl.uint<4>, !firrtl.uint<2>) -> !firrtl.uint<4>
   firrtl.connect %out, %4 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // Mixed type input and outputs.
 
-  // CHECK: firrtl.connect %out, %c1_ui4
+  // CHECK: firrtl.strictconnect %out, %c1_ui4
   %c1_si4 = firrtl.constant 1 : !firrtl.sint<4>
   %5 = firrtl.and %c1_si4, %c1_si4 : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %5 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: [[AND:%.+]] = firrtl.and %sin, %sin
-  // CHECK-NEXT: firrtl.connect %out, [[AND]]
+  // CHECK-NEXT: firrtl.strictconnect %out, [[AND]]
   %6 = firrtl.and %sin, %sin : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %6 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.connect %out, %c0_ui4
+  // CHECK: firrtl.strictconnect %out, %c0_ui4
   %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
   %7 = firrtl.and %in, %invalid_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %7 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.connect %out, %c0_ui4
+  // CHECK: firrtl.strictconnect %out, %c0_ui4
   %8 = firrtl.and %invalid_ui4, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %8 : !firrtl.uint<4>, !firrtl.uint<4>
 }
@@ -183,44 +183,44 @@ firrtl.module @And(in %in: !firrtl.uint<4>,
 firrtl.module @Or(in %in: !firrtl.uint<4>,
                   in %sin: !firrtl.sint<4>,
                   out %out: !firrtl.uint<4>) {
-  // CHECK: firrtl.connect %out, %c7_ui4
+  // CHECK: firrtl.strictconnect %out, %c7_ui4
   %c4_ui4 = firrtl.constant 4 : !firrtl.uint<4>
   %c3_ui4 = firrtl.constant 3 : !firrtl.uint<4>
   %0 = firrtl.or %c3_ui4, %c4_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.connect %out, %c15_ui4
+  // CHECK: firrtl.strictconnect %out, %c15_ui4
   %c1_ui15 = firrtl.constant 15 : !firrtl.uint<4>
   %1 = firrtl.or %in, %c1_ui15 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.connect %out, %in
+  // CHECK: firrtl.strictconnect %out, %in
   %c1_ui0 = firrtl.constant 0 : !firrtl.uint<4>
   %2 = firrtl.or %in, %c1_ui0 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %2 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.connect %out, %in
+  // CHECK: firrtl.strictconnect %out, %in
   %3 = firrtl.or %in, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %3 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // Mixed type input and outputs.
 
-  // CHECK: firrtl.connect %out, %c1_ui4
+  // CHECK: firrtl.strictconnect %out, %c1_ui4
   %c1_si4 = firrtl.constant 1 : !firrtl.sint<4>
   %5 = firrtl.or %c1_si4, %c1_si4 : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %5 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: [[OR:%.+]] = firrtl.or %sin, %sin
-  // CHECK-NEXT: firrtl.connect %out, [[OR]]
+  // CHECK-NEXT: firrtl.strictconnect %out, [[OR]]
   %6 = firrtl.or %sin, %sin : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %6 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.connect %out, %in
+  // CHECK: firrtl.strictconnect %out, %in
   %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
   %7 = firrtl.or %in, %invalid_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %7 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.connect %out, %in
+  // CHECK: firrtl.strictconnect %out, %in
   %8 = firrtl.or %invalid_ui4, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %8 : !firrtl.uint<4>, !firrtl.uint<4>
 
@@ -234,33 +234,33 @@ firrtl.module @Or(in %in: !firrtl.uint<4>,
 firrtl.module @Xor(in %in: !firrtl.uint<4>,
                    in %sin: !firrtl.sint<4>,
                    out %out: !firrtl.uint<4>) {
-  // CHECK: firrtl.connect %out, %c2_ui4
+  // CHECK: firrtl.strictconnect %out, %c2_ui4
   %c1_ui4 = firrtl.constant 1 : !firrtl.uint<4>
   %c3_ui4 = firrtl.constant 3 : !firrtl.uint<4>
   %0 = firrtl.xor %c3_ui4, %c1_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.connect %out, %in
+  // CHECK: firrtl.strictconnect %out, %in
   %c1_ui0 = firrtl.constant 0 : !firrtl.uint<4>
   %2 = firrtl.xor %in, %c1_ui0 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %2 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.connect %out, %c0_ui4
+  // CHECK: firrtl.strictconnect %out, %c0_ui4
   %3 = firrtl.xor %in, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %3 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // Mixed type input and outputs.
 
-  // CHECK: firrtl.connect %out, %c0_ui4
+  // CHECK: firrtl.strictconnect %out, %c0_ui4
   %6 = firrtl.xor %sin, %sin : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %6 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.connect %out, %in
+  // CHECK: firrtl.strictconnect %out, %in
   %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
   %7 = firrtl.xor %in, %invalid_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %7 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.connect %out, %in
+  // CHECK: firrtl.strictconnect %out, %in
   %8 = firrtl.xor %invalid_ui4, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %8 : !firrtl.uint<4>, !firrtl.uint<4>
 
@@ -274,7 +274,7 @@ firrtl.module @Xor(in %in: !firrtl.uint<4>,
 firrtl.module @EQ(in %in1: !firrtl.uint<1>,
                   in %in4: !firrtl.uint<4>,
                   out %out: !firrtl.uint<1>) {
-  // CHECK: firrtl.connect %out, %in1
+  // CHECK: firrtl.strictconnect %out, %in1
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   %0 = firrtl.eq %in1, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -284,45 +284,45 @@ firrtl.module @EQ(in %in1: !firrtl.uint<1>,
   %1 = firrtl.eq %in1, %c3_ui2 : (!firrtl.uint<1>, !firrtl.uint<2>) -> !firrtl.uint<1>
   firrtl.connect %out, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: firrtl.eq %in1, %c3_ui2
-  // CHECK-NEXT: firrtl.connect
+  // CHECK-NEXT: firrtl.strictconnect
 
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   %2 = firrtl.eq %in1, %c0_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.not %in1
-  // CHECK-NEXT: firrtl.connect
+  // CHECK-NEXT: firrtl.strictconnect
 
   %c15_ui4 = firrtl.constant 15 : !firrtl.uint<4>
   %3 = firrtl.eq %in4, %c15_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
   firrtl.connect %out, %3 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: firrtl.andr %in4
-  // CHECK-NEXT: firrtl.connect
+  // CHECK-NEXT: firrtl.strictconnect
 
   %4 = firrtl.eq %in4, %c0_ui1 : (!firrtl.uint<4>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out, %4 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: [[ORR:%.+]] = firrtl.orr %in4
   // CHECK-NEXT: firrtl.not [[ORR]]
-  // CHECK-NEXT: firrtl.connect
+  // CHECK-NEXT: firrtl.strictconnect
 
   %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
   %5 = firrtl.eq %in1, %invalid_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out, %5 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.not %in1
-  // CHECK-NEXT: firrtl.connect
+  // CHECK-NEXT: firrtl.strictconnect
 
   %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
   %6 = firrtl.eq %in4, %invalid_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
   firrtl.connect %out, %6 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: [[ORR:%.+]] = firrtl.orr %in4
   // CHECK-NEXT: firrtl.not [[ORR]]
-  // CHECK-NEXT: firrtl.connect
+  // CHECK-NEXT: firrtl.strictconnect
 }
 
 // CHECK-LABEL: firrtl.module @NEQ
 firrtl.module @NEQ(in %in1: !firrtl.uint<1>,
                    in %in4: !firrtl.uint<4>,
                    out %out: !firrtl.uint<1>) {
-  // CHECK: firrtl.connect %out, %in
+  // CHECK: firrtl.strictconnect %out, %in
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   %0 = firrtl.neq %in1, %c0_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -331,25 +331,25 @@ firrtl.module @NEQ(in %in1: !firrtl.uint<1>,
   %1 = firrtl.neq %in1, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.not %in1
-  // CHECK-NEXT: firrtl.connect
+  // CHECK-NEXT: firrtl.strictconnect
 
   %2 = firrtl.neq %in4, %c0_ui1 : (!firrtl.uint<4>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: firrtl.orr %in4
-  // CHECK-NEXT: firrtl.connect
+  // CHECK-NEXT: firrtl.strictconnect
 
   %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
   %3 = firrtl.neq %in4, %invalid_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
   firrtl.connect %out, %3 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: firrtl.orr %in4
-  // CHECK-NEXT: firrtl.connect
+  // CHECK-NEXT: firrtl.strictconnect
 
   %c15_ui4 = firrtl.constant 15 : !firrtl.uint<4>
   %4 = firrtl.neq %in4, %c15_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
   firrtl.connect %out, %4 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: [[ANDR:%.+]] = firrtl.andr %in4
   // CHECK-NEXT: firrtl.not [[ANDR]]
-  // CHECK-NEXT: firrtl.connect
+  // CHECK-NEXT: firrtl.strictconnect
 }
 
 // CHECK-LABEL: firrtl.module @Cat
@@ -358,19 +358,19 @@ firrtl.module @Cat(in %in4: !firrtl.uint<4>,
                    out %outcst: !firrtl.uint<8>,
                    out %outcst2: !firrtl.uint<8>) {
 
-  // CHECK: firrtl.connect %out4, %in4
+  // CHECK: firrtl.strictconnect %out4, %in4
   %0 = firrtl.bits %in4 3 to 2 : (!firrtl.uint<4>) -> !firrtl.uint<2>
   %1 = firrtl.bits %in4 1 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<2>
   %2 = firrtl.cat %0, %1 : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<4>
   firrtl.connect %out4, %2 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.connect %outcst, %c243_ui8
+  // CHECK: firrtl.strictconnect %outcst, %c243_ui8
   %c15_ui4 = firrtl.constant 15 : !firrtl.uint<4>
   %c3_ui4 = firrtl.constant 3 : !firrtl.uint<4>
   %3 = firrtl.cat %c15_ui4, %c3_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<8>
   firrtl.connect %outcst, %3 : !firrtl.uint<8>, !firrtl.uint<8>
 
-  // CHECK: firrtl.connect %outcst2, %c0_ui8
+  // CHECK: firrtl.strictconnect %outcst2, %c0_ui8
   %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
   %4 = firrtl.cat %invalid_ui4, %invalid_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<8>
   firrtl.connect %outcst2, %4 : !firrtl.uint<8>, !firrtl.uint<8>
@@ -382,31 +382,31 @@ firrtl.module @Bits(in %in1: !firrtl.uint<1>,
                     out %out1: !firrtl.uint<1>,
                     out %out2: !firrtl.uint<2>,
                     out %out4: !firrtl.uint<4>) {
-  // CHECK: firrtl.connect %out1, %in1
+  // CHECK: firrtl.strictconnect %out1, %in1
   %0 = firrtl.bits %in1 0 to 0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 
-  // CHECK: firrtl.connect %out4, %in4
+  // CHECK: firrtl.strictconnect %out4, %in4
   %1 = firrtl.bits %in4 3 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out4, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.connect %out2, %c1_ui2
+  // CHECK: firrtl.strictconnect %out2, %c1_ui2
   %c10_ui4 = firrtl.constant 10 : !firrtl.uint<4>
   %2 = firrtl.bits %c10_ui4 2 to 1 : (!firrtl.uint<4>) -> !firrtl.uint<2>
   firrtl.connect %out2, %2 : !firrtl.uint<2>, !firrtl.uint<2>
 
 
   // CHECK: firrtl.bits %in4 2 to 2 : (!firrtl.uint<4>) -> !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.connect %out1, %
+  // CHECK-NEXT: firrtl.strictconnect %out1, %
   %3 = firrtl.bits %in4 3 to 1 : (!firrtl.uint<4>) -> !firrtl.uint<3>
   %4 = firrtl.bits %3 1 to 1 : (!firrtl.uint<3>) -> !firrtl.uint<1>
   firrtl.connect %out1, %4 : !firrtl.uint<1>, !firrtl.uint<1>
 
-  // CHECK: firrtl.connect %out1, %in1
+  // CHECK: firrtl.strictconnect %out1, %in1
   %5 = firrtl.bits %in1 0 to 0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out1, %5 : !firrtl.uint<1>, !firrtl.uint<1>
 
-  // CHECK: firrtl.connect %out2, %c0_ui2
+  // CHECK: firrtl.strictconnect %out2, %c0_ui2
   %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
   %6 = firrtl.bits %invalid_ui4 2 to 1 : (!firrtl.uint<4>) -> !firrtl.uint<2>
   firrtl.connect %out2, %6 : !firrtl.uint<2>, !firrtl.uint<2>
@@ -417,21 +417,21 @@ firrtl.module @Head(in %in4u: !firrtl.uint<4>,
                     out %out1u: !firrtl.uint<1>,
                     out %out3u: !firrtl.uint<3>) {
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4u 3 to 3
-  // CHECK-NEXT: firrtl.connect %out1u, [[BITS]]
+  // CHECK-NEXT: firrtl.strictconnect %out1u, [[BITS]]
   %0 = firrtl.head %in4u, 1 : (!firrtl.uint<4>) -> !firrtl.uint<1>
   firrtl.connect %out1u, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4u 3 to 1
-  // CHECK-NEXT: firrtl.connect %out3u, [[BITS]]
+  // CHECK-NEXT: firrtl.strictconnect %out3u, [[BITS]]
   %1 = firrtl.head %in4u, 3 : (!firrtl.uint<4>) -> !firrtl.uint<3>
   firrtl.connect %out3u, %1 : !firrtl.uint<3>, !firrtl.uint<3>
 
-  // CHECK: firrtl.connect %out3u, %c5_ui3
+  // CHECK: firrtl.strictconnect %out3u, %c5_ui3
   %c10_ui4 = firrtl.constant 10 : !firrtl.uint<4>
   %2 = firrtl.head %c10_ui4, 3 : (!firrtl.uint<4>) -> !firrtl.uint<3>
   firrtl.connect %out3u, %2 : !firrtl.uint<3>, !firrtl.uint<3>
 
-  // CHECK: firrtl.connect %out3u, %c0_ui3
+  // CHECK: firrtl.strictconnect %out3u, %c0_ui3
   %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
   %3 = firrtl.head %invalid_ui4, 3 : (!firrtl.uint<4>) -> !firrtl.uint<3>
   firrtl.connect %out3u, %3 : !firrtl.uint<3>, !firrtl.uint<3>
@@ -444,42 +444,42 @@ firrtl.module @Mux(in %in: !firrtl.uint<4>,
                    in %val2: !firrtl.uint<1>,
                    out %out: !firrtl.uint<4>,
                    out %out1: !firrtl.uint<1>) {
-  // CHECK: firrtl.connect %out, %in
+  // CHECK: firrtl.strictconnect %out, %in
   %0 = firrtl.mux (%cond, %in, %in) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.connect %out, %c7_ui4
+  // CHECK: firrtl.strictconnect %out, %c7_ui4
   %c7_ui4 = firrtl.constant 7 : !firrtl.uint<4>
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   %2 = firrtl.mux (%c0_ui1, %in, %c7_ui4) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %2 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.connect %out1, %cond
+  // CHECK: firrtl.strictconnect %out1, %cond
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   %3 = firrtl.mux (%cond, %c1_ui1, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out1, %3 : !firrtl.uint<1>, !firrtl.uint<1>
 
-  // CHECK: firrtl.connect %out, %invalid_ui4
+  // CHECK: firrtl.strictconnect %out, %invalid_ui4
   %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
   %7 = firrtl.mux (%cond, %invalid_ui4, %invalid_ui4) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %7 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.connect %out, %c7_ui4
+  // CHECK: firrtl.strictconnect %out, %c7_ui4
   %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
   %8 = firrtl.mux (%invalid_ui1, %in, %c7_ui4) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %8 : !firrtl.uint<4>, !firrtl.uint<4>
 
   %9 = firrtl.multibit_mux %c1_ui1, %c0_ui1, %cond : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.connect %out1, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %out1, %c0_ui1
   firrtl.connect %out1, %9 : !firrtl.uint<1>, !firrtl.uint<1>
 
   %10 = firrtl.multibit_mux %cond, %val1, %val2 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: %[[MUX:.+]] = firrtl.mux(%cond, %val1, %val2)
-  // CHECK-NEXT: firrtl.connect %out1, %[[MUX]]
+  // CHECK-NEXT: firrtl.strictconnect %out1, %[[MUX]]
   firrtl.connect %out1, %10 : !firrtl.uint<1>, !firrtl.uint<1>
 
   %11 = firrtl.multibit_mux %cond, %val1, %val1, %val1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.connect %out1, %val1
+  // CHECK-NEXT: firrtl.strictconnect %out1, %val1
   firrtl.connect %out1, %11 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
@@ -488,16 +488,16 @@ firrtl.module @Pad(in %in1u: !firrtl.uint<1>,
                    out %out1u: !firrtl.uint<1>,
                    out %outu: !firrtl.uint<4>,
                    out %outs: !firrtl.sint<4>) {
-  // CHECK: firrtl.connect %out1u, %in1u
+  // CHECK: firrtl.strictconnect %out1u, %in1u
   %0 = firrtl.pad %in1u, 1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out1u, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 
-  // CHECK: firrtl.connect %outu, %c1_ui4
+  // CHECK: firrtl.strictconnect %outu, %c1_ui4
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   %1 = firrtl.pad %c1_ui1, 4 : (!firrtl.uint<1>) -> !firrtl.uint<4>
   firrtl.connect %outu, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.connect %outs, %c-1_si4
+  // CHECK: firrtl.strictconnect %outs, %c-1_si4
   %c1_si1 = firrtl.constant -1 : !firrtl.sint<1>
   %2 = firrtl.pad %c1_si1, 4 : (!firrtl.sint<1>) -> !firrtl.sint<4>
   firrtl.connect %outs, %2 : !firrtl.sint<4>, !firrtl.sint<4>
@@ -507,16 +507,16 @@ firrtl.module @Pad(in %in1u: !firrtl.uint<1>,
 firrtl.module @Shl(in %in1u: !firrtl.uint<1>,
                    out %out1u: !firrtl.uint<1>,
                    out %outu: !firrtl.uint<4>) {
-  // CHECK: firrtl.connect %out1u, %in1u
+  // CHECK: firrtl.strictconnect %out1u, %in1u
   %0 = firrtl.shl %in1u, 0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out1u, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 
-  // CHECK: firrtl.connect %outu, %c8_ui4
+  // CHECK: firrtl.strictconnect %outu, %c8_ui4
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   %1 = firrtl.shl %c1_ui1, 3 : (!firrtl.uint<1>) -> !firrtl.uint<4>
   firrtl.connect %outu, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.connect %outu, %c0_ui4
+  // CHECK: firrtl.strictconnect %outu, %c0_ui4
   %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
   %2 = firrtl.shl %invalid_ui1, 3 : (!firrtl.uint<1>) -> !firrtl.uint<4>
   firrtl.connect %outu, %2 : !firrtl.uint<4>, !firrtl.uint<4>
@@ -531,58 +531,58 @@ firrtl.module @Shr(in %in1u: !firrtl.uint<1>,
                    out %out1s: !firrtl.sint<1>,
                    out %out1u: !firrtl.uint<1>,
                    out %outu: !firrtl.uint<4>) {
-  // CHECK: firrtl.connect %out1u, %in1u
+  // CHECK: firrtl.strictconnect %out1u, %in1u
   %0 = firrtl.shr %in1u, 0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out1u, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 
-  // CHECK: firrtl.connect %out1u, %c0_ui1
+  // CHECK: firrtl.strictconnect %out1u, %c0_ui1
   %1 = firrtl.shr %in4u, 4 : (!firrtl.uint<4>) -> !firrtl.uint<1>
   firrtl.connect %out1u, %1 : !firrtl.uint<1>, !firrtl.uint<1>
 
-  // CHECK: firrtl.connect %out1u, %c0_ui1
+  // CHECK: firrtl.strictconnect %out1u, %c0_ui1
   %2 = firrtl.shr %in4u, 5 : (!firrtl.uint<4>) -> !firrtl.uint<1>
   firrtl.connect %out1u, %2 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4s 3 to 3
   // CHECK-NEXT: [[CAST:%.+]] = firrtl.asSInt [[BITS]]
-  // CHECK-NEXT: firrtl.connect %out1s, [[CAST]]
+  // CHECK-NEXT: firrtl.strictconnect %out1s, [[CAST]]
   %3 = firrtl.shr %in4s, 3 : (!firrtl.sint<4>) -> !firrtl.sint<1>
   firrtl.connect %out1s, %3 : !firrtl.sint<1>, !firrtl.sint<1>
 
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4s 3 to 3
   // CHECK-NEXT: [[CAST:%.+]] = firrtl.asSInt [[BITS]]
-  // CHECK-NEXT: firrtl.connect %out1s, [[CAST]]
+  // CHECK-NEXT: firrtl.strictconnect %out1s, [[CAST]]
   %4 = firrtl.shr %in4s, 4 : (!firrtl.sint<4>) -> !firrtl.sint<1>
   firrtl.connect %out1s, %4 : !firrtl.sint<1>, !firrtl.sint<1>
 
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4s 3 to 3
   // CHECK-NEXT: [[CAST:%.+]] = firrtl.asSInt [[BITS]]
-  // CHECK-NEXT: firrtl.connect %out1s, [[CAST]]
+  // CHECK-NEXT: firrtl.strictconnect %out1s, [[CAST]]
   %5 = firrtl.shr %in4s, 5 : (!firrtl.sint<4>) -> !firrtl.sint<1>
   firrtl.connect %out1s, %5 : !firrtl.sint<1>, !firrtl.sint<1>
 
-  // CHECK: firrtl.connect %out1u, %c1_ui1
+  // CHECK: firrtl.strictconnect %out1u, %c1_ui1
   %c12_ui4 = firrtl.constant 12 : !firrtl.uint<4>
   %6 = firrtl.shr %c12_ui4, 3 : (!firrtl.uint<4>) -> !firrtl.uint<1>
   firrtl.connect %out1u, %6 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4u 3 to 3
-  // CHECK-NEXT: firrtl.connect %out1u, [[BITS]]
+  // CHECK-NEXT: firrtl.strictconnect %out1u, [[BITS]]
   %7 = firrtl.shr %in4u, 3 : (!firrtl.uint<4>) -> !firrtl.uint<1>
   firrtl.connect %out1u, %7 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // Issue #313: https://github.com/llvm/circt/issues/313
-  // CHECK: firrtl.connect %out1s, %in1s : !firrtl.sint<1>, !firrtl.sint<1>
+  // CHECK: firrtl.strictconnect %out1s, %in1s : !firrtl.sint<1>
   %8 = firrtl.shr %in1s, 42 : (!firrtl.sint<1>) -> !firrtl.sint<1>
   firrtl.connect %out1s, %8 : !firrtl.sint<1>, !firrtl.sint<1>
 
   // Issue #1064: https://github.com/llvm/circt/issues/1064
-  // CHECK: firrtl.connect %out1u, %c0_ui0
+  // CHECK: firrtl.strictconnect %out1u, %c0_ui1
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   %9 = firrtl.dshr %in0u, %c1_ui1 : (!firrtl.uint<0>, !firrtl.uint<1>) -> !firrtl.uint<0>
   firrtl.connect %out1u, %9 : !firrtl.uint<1>, !firrtl.uint<0>
 
-  // CHECK: firrtl.connect %out1u, %c0_ui1
+  // CHECK: firrtl.strictconnect %out1u, %c0_ui1
   %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
   %10 = firrtl.shr %invalid_ui4, 3 : (!firrtl.uint<4>) -> !firrtl.uint<1>
   firrtl.connect %out1u, %10 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -593,21 +593,21 @@ firrtl.module @Tail(in %in4u: !firrtl.uint<4>,
                     out %out1u: !firrtl.uint<1>,
                     out %out3u: !firrtl.uint<3>) {
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4u 0 to 0
-  // CHECK-NEXT: firrtl.connect %out1u, [[BITS]]
+  // CHECK-NEXT: firrtl.strictconnect %out1u, [[BITS]]
   %0 = firrtl.tail %in4u, 3 : (!firrtl.uint<4>) -> !firrtl.uint<1>
   firrtl.connect %out1u, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4u 2 to 0
-  // CHECK-NEXT: firrtl.connect %out3u, [[BITS]]
+  // CHECK-NEXT: firrtl.strictconnect %out3u, [[BITS]]
   %1 = firrtl.tail %in4u, 1 : (!firrtl.uint<4>) -> !firrtl.uint<3>
   firrtl.connect %out3u, %1 : !firrtl.uint<3>, !firrtl.uint<3>
 
-  // CHECK: firrtl.connect %out3u, %c2_ui3
+  // CHECK: firrtl.strictconnect %out3u, %c2_ui3
   %c10_ui4 = firrtl.constant 10 : !firrtl.uint<4>
   %2 = firrtl.tail %c10_ui4, 1 : (!firrtl.uint<4>) -> !firrtl.uint<3>
   firrtl.connect %out3u, %2 : !firrtl.uint<3>, !firrtl.uint<3>
 
-  // CHECK: firrtl.connect %out3u, %c0_ui3
+  // CHECK: firrtl.strictconnect %out3u, %c0_ui3
   %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
   %3 = firrtl.tail %invalid_ui4, 1 : (!firrtl.uint<4>) -> !firrtl.uint<3>
   firrtl.connect %out3u, %3 : !firrtl.uint<3>, !firrtl.uint<3>
@@ -629,15 +629,15 @@ firrtl.module @Andr(out %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>,
   %4 = firrtl.andr %invalid_ui2 : (!firrtl.uint<2>) -> !firrtl.uint<1>
   // CHECK: %[[ZERO:.+]] = firrtl.constant 0 : !firrtl.uint<1>
   // CHECK: %[[ONE:.+]] = firrtl.constant 1 : !firrtl.uint<1>
-  // CHECK: firrtl.connect %a, %[[ZERO]]
+  // CHECK: firrtl.strictconnect %a, %[[ZERO]]
   firrtl.connect %a, %0 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.connect %b, %[[ONE]]
+  // CHECK: firrtl.strictconnect %b, %[[ONE]]
   firrtl.connect %b, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.connect %c, %[[ZERO]]
+  // CHECK: firrtl.strictconnect %c, %[[ZERO]]
   firrtl.connect %c, %2 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.connect %d, %[[ONE]]
+  // CHECK: firrtl.strictconnect %d, %[[ONE]]
   firrtl.connect %d, %3 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.connect %e, %[[ZERO]]
+  // CHECK: firrtl.strictconnect %e, %[[ZERO]]
   firrtl.connect %e, %4 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
@@ -657,15 +657,15 @@ firrtl.module @Orr(out %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>,
   %4 = firrtl.orr %invalid_ui2 : (!firrtl.uint<2>) -> !firrtl.uint<1>
   // CHECK: %[[ZERO:.+]] = firrtl.constant 0 : !firrtl.uint<1>
   // CHECK: %[[ONE:.+]] = firrtl.constant 1 : !firrtl.uint<1>
-  // CHECK: firrtl.connect %a, %[[ZERO]]
+  // CHECK: firrtl.strictconnect %a, %[[ZERO]]
   firrtl.connect %a, %0 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.connect %b, %[[ONE]]
+  // CHECK: firrtl.strictconnect %b, %[[ONE]]
   firrtl.connect %b, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.connect %c, %[[ZERO]]
+  // CHECK: firrtl.strictconnect %c, %[[ZERO]]
   firrtl.connect %c, %2 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.connect %d, %[[ONE]]
+  // CHECK: firrtl.strictconnect %d, %[[ONE]]
   firrtl.connect %d, %3 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.connect %e, %[[ZERO]]
+  // CHECK: firrtl.strictconnect %e, %[[ZERO]]
   firrtl.connect %e, %4 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
@@ -685,15 +685,15 @@ firrtl.module @Xorr(out %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>,
   %4 = firrtl.xorr %invalid_ui2 : (!firrtl.uint<2>) -> !firrtl.uint<1>
   // CHECK: %[[ZERO:.+]] = firrtl.constant 0 : !firrtl.uint<1>
   // CHECK: %[[ONE:.+]] = firrtl.constant 1 : !firrtl.uint<1>
-  // CHECK: firrtl.connect %a, %[[ZERO]]
+  // CHECK: firrtl.strictconnect %a, %[[ZERO]]
   firrtl.connect %a, %0 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.connect %b, %[[ONE]]
+  // CHECK: firrtl.strictconnect %b, %[[ONE]]
   firrtl.connect %b, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.connect %c, %[[ZERO]]
+  // CHECK: firrtl.strictconnect %c, %[[ZERO]]
   firrtl.connect %c, %2 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.connect %d, %[[ONE]]
+  // CHECK: firrtl.strictconnect %d, %[[ONE]]
   firrtl.connect %d, %3 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.connect %e, %[[ZERO]]
+  // CHECK: firrtl.strictconnect %e, %[[ZERO]]
   firrtl.connect %e, %4 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
@@ -704,24 +704,24 @@ firrtl.module @Reduce(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>,
   %1 = firrtl.orr %a : (!firrtl.uint<1>) -> !firrtl.uint<1>
   %2 = firrtl.xorr %a : (!firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %b, %0 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.connect %b, %a
+  // CHECK: firrtl.strictconnect %b, %a
   firrtl.connect %c, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.connect %c, %a
+  // CHECK: firrtl.strictconnect %c, %a
   firrtl.connect %d, %2 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.connect %d, %a
+  // CHECK: firrtl.strictconnect %d, %a
 }
 
 
 // CHECK-LABEL: firrtl.module @subaccess
 firrtl.module @subaccess(out %result: !firrtl.uint<8>, in %vec0: !firrtl.vector<uint<8>, 16>) {
   // CHECK: [[TMP:%.+]] = firrtl.subindex %vec0[11]
-  // CHECK-NEXT: firrtl.connect %result, [[TMP]]
+  // CHECK-NEXT: firrtl.strictconnect %result, [[TMP]]
   %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
   %0 = firrtl.subaccess %vec0[%c11_ui8] : !firrtl.vector<uint<8>, 16>, !firrtl.uint<8>
   firrtl.connect %result, %0 :!firrtl.uint<8>, !firrtl.uint<8>
 
   // CHECK: [[TMP:%.+]] = firrtl.subindex %vec0[0]
-  // CHECK-NEXT: firrtl.connect %result, [[TMP]]
+  // CHECK-NEXT: firrtl.strictconnect %result, [[TMP]]
   %invalid_ui8 = firrtl.invalidvalue : !firrtl.uint<8>
   %1 = firrtl.subaccess %vec0[%invalid_ui8] : !firrtl.vector<uint<8>, 16>, !firrtl.uint<8>
   firrtl.connect %result, %1 :!firrtl.uint<8>, !firrtl.uint<8>
@@ -749,7 +749,7 @@ firrtl.module @issue432(out %tmp8: !firrtl.uint<10>) {
   %0 = firrtl.tail %c130_si10, 0 : (!firrtl.sint<10>) -> !firrtl.uint<10>
   firrtl.connect %tmp8, %0 : !firrtl.uint<10>, !firrtl.uint<10>
   // CHECK-NEXT: %c130_ui10 = firrtl.constant 130 : !firrtl.uint<10>
-  // CHECK-NEXT: firrtl.connect %tmp8, %c130_ui10
+  // CHECK-NEXT: firrtl.strictconnect %tmp8, %c130_ui10
 }
 
 // CHECK-LABEL: firrtl.module @issue437
@@ -761,8 +761,8 @@ firrtl.module @issue437(out %tmp19: !firrtl.uint<1>) {
 }
 
 // CHECK-LABEL: firrtl.module @issue446
-// CHECK-NEXT: [[TMP:%.+]] = firrtl.constant 0 : !firrtl.uint<0>
-// CHECK-NEXT: firrtl.connect %tmp10, [[TMP]] : !firrtl.uint<1>, !firrtl.uint<0>
+// CHECK-NEXT: [[TMP:%.+]] = firrtl.constant 0 : !firrtl.uint<1>
+// CHECK-NEXT: firrtl.strictconnect %tmp10, [[TMP]] : !firrtl.uint<1>
 firrtl.module @issue446(in %inp_1: !firrtl.sint<0>, out %tmp10: !firrtl.uint<1>) {
   %0 = firrtl.xor %inp_1, %inp_1 : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.uint<0>
   firrtl.connect %tmp10, %0 : !firrtl.uint<1>, !firrtl.uint<0>
@@ -778,7 +778,7 @@ firrtl.module @xorUnsized(in %inp_1: !firrtl.sint, out %tmp10: !firrtl.uint) {
 // https://github.com/llvm/circt/issues/516
 // CHECK-LABEL: @issue516
 // CHECK-NEXT: [[TMP:%.+]] = firrtl.constant 0 : !firrtl.uint<0>
-// CHECK-NEXT: firrtl.connect %tmp3, [[TMP]] : !firrtl.uint<0>, !firrtl.uint<0>
+// CHECK-NEXT: firrtl.strictconnect %tmp3, [[TMP]] : !firrtl.uint<0>
 firrtl.module @issue516(in %inp_0: !firrtl.uint<0>, out %tmp3: !firrtl.uint<0>) {
   %0 = firrtl.div %inp_0, %inp_0 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
   firrtl.connect %tmp3, %0 : !firrtl.uint<0>, !firrtl.uint<0>
@@ -787,7 +787,7 @@ firrtl.module @issue516(in %inp_0: !firrtl.uint<0>, out %tmp3: !firrtl.uint<0>) 
 // https://github.com/llvm/circt/issues/591
 // CHECK-LABEL: @reg_cst_prop1
 // CHECK-NEXT:   %c5_ui8 = firrtl.constant 5 : !firrtl.uint<8>
-// CHECK-NEXT:   firrtl.connect %out_b, %c5_ui8 : !firrtl.uint<8>, !firrtl.uint<8>
+// CHECK-NEXT:   firrtl.strictconnect %out_b, %c5_ui8 : !firrtl.uint<8>
 // CHECK-NEXT:  }
 firrtl.module @reg_cst_prop1(in %clock: !firrtl.clock, out %out_b: !firrtl.uint<8>) {
   %c5_ui8 = firrtl.constant 5 : !firrtl.uint<8>
@@ -803,9 +803,9 @@ firrtl.module @reg_cst_prop1(in %clock: !firrtl.clock, out %out_b: !firrtl.uint<
 // CHECK-NEXT:      %c5_ui8 = firrtl.constant 5 : !firrtl.uint<8>
 // CHECK-NEXT:      %tmp_a = firrtl.reg sym @reg1 %clock : !firrtl.uint<8>
 // CHECK-NEXT:      %tmp_b = firrtl.reg %clock  : !firrtl.uint<8>
-// CHECK-NEXT:      firrtl.connect %tmp_a, %c5_ui8 : !firrtl.uint<8>, !firrtl.uint<8>
-// CHECK-NEXT:      firrtl.connect %tmp_b, %tmp_a : !firrtl.uint<8>, !firrtl.uint<8>
-// CHECK-NEXT:      firrtl.connect %out_b, %tmp_b : !firrtl.uint<8>, !firrtl.uint<8>
+// CHECK-NEXT:      firrtl.strictconnect %tmp_a, %c5_ui8 : !firrtl.uint<8>
+// CHECK-NEXT:      firrtl.strictconnect %tmp_b, %tmp_a : !firrtl.uint<8>
+// CHECK-NEXT:      firrtl.strictconnect %out_b, %tmp_b : !firrtl.uint<8>
 
 firrtl.module @reg_cst_prop1_DontTouch(in %clock: !firrtl.clock, out %out_b: !firrtl.uint<8>) {
   %c5_ui8 = firrtl.constant 5 : !firrtl.uint<8>
@@ -817,7 +817,7 @@ firrtl.module @reg_cst_prop1_DontTouch(in %clock: !firrtl.clock, out %out_b: !fi
 }
 // CHECK-LABEL: @reg_cst_prop2
 // CHECK-NEXT:   %c5_ui8 = firrtl.constant 5 : !firrtl.uint<8>
-// CHECK-NEXT:   firrtl.connect %out_b, %c5_ui8 : !firrtl.uint<8>, !firrtl.uint<8>
+// CHECK-NEXT:   firrtl.strictconnect %out_b, %c5_ui8 : !firrtl.uint<8>
 // CHECK-NEXT:  }
 firrtl.module @reg_cst_prop2(in %clock: !firrtl.clock, out %out_b: !firrtl.uint<8>) {
   %tmp_b = firrtl.reg %clock {name = "tmp_b"} : !firrtl.uint<8>
@@ -831,7 +831,7 @@ firrtl.module @reg_cst_prop2(in %clock: !firrtl.clock, out %out_b: !firrtl.uint<
 
 // CHECK-LABEL: @reg_cst_prop3
 // CHECK-NEXT:   %c0_ui8 = firrtl.constant 0 : !firrtl.uint<8>
-// CHECK-NEXT:   firrtl.connect %out_b, %c0_ui8 : !firrtl.uint<8>, !firrtl.uint<8>
+// CHECK-NEXT:   firrtl.strictconnect %out_b, %c0_ui8 : !firrtl.uint<8>
 // CHECK-NEXT:  }
 firrtl.module @reg_cst_prop3(in %clock: !firrtl.clock, out %out_b: !firrtl.uint<8>) {
   %tmp_a = firrtl.reg %clock {name = "tmp_a"} : !firrtl.uint<8>
@@ -844,7 +844,7 @@ firrtl.module @reg_cst_prop3(in %clock: !firrtl.clock, out %out_b: !firrtl.uint<
 
 // CHECK-LABEL: @pcon
 // CHECK-NEXT:   %0 = firrtl.bits %in 4 to 0 : (!firrtl.uint<9>) -> !firrtl.uint<5>
-// CHECK-NEXT:   firrtl.connect %out, %0 : !firrtl.uint<5>, !firrtl.uint<5>
+// CHECK-NEXT:   firrtl.strictconnect %out, %0 : !firrtl.uint<5>
 // CHECK-NEXT:  }
 firrtl.module @pcon(in %in: !firrtl.uint<9>, out %out: !firrtl.uint<5>) {
   firrtl.partialconnect %out, %in : !firrtl.uint<5>, !firrtl.uint<9>
@@ -887,7 +887,7 @@ firrtl.module @AttachDeadWireDontTouch(in %a: !firrtl.analog<1>, in %b: !firrtl.
 
 // CHECK-LABEL: @wire_cst_prop1
 // CHECK-NEXT:   %c10_ui9 = firrtl.constant 10 : !firrtl.uint<9>
-// CHECK-NEXT:   firrtl.connect %out_b, %c10_ui9 : !firrtl.uint<9>, !firrtl.uint<9>
+// CHECK-NEXT:   firrtl.strictconnect %out_b, %c10_ui9 : !firrtl.uint<9>
 // CHECK-NEXT:  }
 firrtl.module @wire_cst_prop1(out %out_b: !firrtl.uint<9>) {
   %tmp_a = firrtl.wire : !firrtl.uint<8>
@@ -899,7 +899,7 @@ firrtl.module @wire_cst_prop1(out %out_b: !firrtl.uint<9>) {
 }
 
 // CHECK-LABEL: @wire_port_prop1
-// CHECK-NEXT:   firrtl.connect %out_b, %in_a : !firrtl.uint<9>, !firrtl.uint<9>
+// CHECK-NEXT:   firrtl.strictconnect %out_b, %in_a : !firrtl.uint<9>
 // CHECK-NEXT:  }
 firrtl.module @wire_port_prop1(in %in_a: !firrtl.uint<9>, out %out_b: !firrtl.uint<9>) {
   %tmp = firrtl.wire : !firrtl.uint<9>
@@ -959,27 +959,27 @@ firrtl.module @CompareWithSelf(
 
   %0 = firrtl.leq %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
   firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.connect %y0, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y0, %c1_ui1
 
   %1 = firrtl.lt %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
   firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.connect %y1, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y1, %c0_ui1
 
   %2 = firrtl.geq %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
   firrtl.connect %y2, %2 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.connect %y2, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y2, %c1_ui1
 
   %3 = firrtl.gt %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
   firrtl.connect %y3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.connect %y3, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y3, %c0_ui1
 
   %4 = firrtl.eq %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
   firrtl.connect %y4, %4 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.connect %y4, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y4, %c1_ui1
 
   %5 = firrtl.neq %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
   firrtl.connect %y5, %5 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.connect %y5, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y5, %c0_ui1
 }
 
 // CHECK-LABEL: @LEQOutsideBounds
@@ -1008,8 +1008,8 @@ firrtl.module @LEQOutsideBounds(
   %1 = firrtl.leq %a, %c8_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
   firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.connect %y0, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y1, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y0, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y1, %c1_ui1
 
   // b <= 3 -> 1
   // b <= 4 -> 1
@@ -1017,8 +1017,8 @@ firrtl.module @LEQOutsideBounds(
   %3 = firrtl.leq %b, %c4_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
   firrtl.connect %y2, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.connect %y2, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y3, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y2, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y3, %c1_ui1
 
   // b <= -5 -> 0
   // b <= -6 -> 0
@@ -1026,8 +1026,8 @@ firrtl.module @LEQOutsideBounds(
   %5 = firrtl.leq %b, %cm6_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
   firrtl.connect %y4, %4 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y5, %5 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.connect %y4, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y5, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y4, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y5, %c0_ui1
 }
 
 // CHECK-LABEL: @LTOutsideBounds
@@ -1056,8 +1056,8 @@ firrtl.module @LTOutsideBounds(
   %1 = firrtl.lt %a, %c9_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
   firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.connect %y0, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y1, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y0, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y1, %c1_ui1
 
   // b < 4 -> 1
   // b < 5 -> 1
@@ -1065,8 +1065,8 @@ firrtl.module @LTOutsideBounds(
   %3 = firrtl.lt %b, %c5_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
   firrtl.connect %y2, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.connect %y2, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y3, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y2, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y3, %c1_ui1
 
   // b < -4 -> 0
   // b < -5 -> 0
@@ -1074,8 +1074,8 @@ firrtl.module @LTOutsideBounds(
   %5 = firrtl.lt %b, %cm5_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
   firrtl.connect %y4, %4 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y5, %5 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.connect %y4, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y5, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y4, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y5, %c0_ui1
 }
 
 // CHECK-LABEL: @GEQOutsideBounds
@@ -1104,8 +1104,8 @@ firrtl.module @GEQOutsideBounds(
   %1 = firrtl.geq %a, %c9_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
   firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.connect %y0, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y1, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y0, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y1, %c0_ui1
 
   // b >= 4 -> 0
   // b >= 5 -> 0
@@ -1113,8 +1113,8 @@ firrtl.module @GEQOutsideBounds(
   %3 = firrtl.geq %b, %c5_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
   firrtl.connect %y2, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.connect %y2, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y3, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y2, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y3, %c0_ui1
 
   // b >= -4 -> 1
   // b >= -5 -> 1
@@ -1122,8 +1122,8 @@ firrtl.module @GEQOutsideBounds(
   %5 = firrtl.geq %b, %cm5_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
   firrtl.connect %y4, %4 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y5, %5 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.connect %y4, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y5, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y4, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y5, %c1_ui1
 }
 
 // CHECK-LABEL: @GTOutsideBounds
@@ -1152,8 +1152,8 @@ firrtl.module @GTOutsideBounds(
   %1 = firrtl.gt %a, %c8_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
   firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.connect %y0, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y1, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y0, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y1, %c0_ui1
 
   // b > 3 -> 0
   // b > 4 -> 0
@@ -1161,8 +1161,8 @@ firrtl.module @GTOutsideBounds(
   %3 = firrtl.gt %b, %c4_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
   firrtl.connect %y2, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.connect %y2, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y3, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y2, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y3, %c0_ui1
 
   // b > -5 -> 1
   // b > -6 -> 1
@@ -1170,8 +1170,8 @@ firrtl.module @GTOutsideBounds(
   %5 = firrtl.gt %b, %cm6_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
   firrtl.connect %y4, %4 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y5, %5 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.connect %y4, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y5, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y4, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y5, %c1_ui1
 }
 
 // CHECK-LABEL: @ComparisonOfDifferentWidths
@@ -1221,18 +1221,18 @@ firrtl.module @ComparisonOfDifferentWidths(
   firrtl.connect %y9, %9 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y10, %10 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y11, %11 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.connect %y0, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y1, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y2, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y3, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y4, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y5, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y6, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y7, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y8, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y9, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y10, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y11, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y0, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y1, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y2, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y3, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y4, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y5, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y6, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y7, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y8, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y9, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y10, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y11, %c1_ui1
 }
 
 // CHECK-LABEL: @ComparisonOfUnsizedAndSized
@@ -1282,18 +1282,18 @@ firrtl.module @ComparisonOfUnsizedAndSized(
   firrtl.connect %y9, %9 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y10, %10 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y11, %11 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.connect %y0, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y1, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y2, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y3, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y4, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y5, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y6, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y7, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y8, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y9, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y10, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y11, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y0, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y1, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y2, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y3, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y4, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y5, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y6, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y7, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y8, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y9, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y10, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y11, %c1_ui1
 }
 
 // CHECK-LABEL: @ComparisonOfUnsized
@@ -1343,18 +1343,18 @@ firrtl.module @ComparisonOfUnsized(
   firrtl.connect %y9, %9 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y10, %10 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y11, %11 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.connect %y0, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y1, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y2, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y3, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y4, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y5, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y6, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y7, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y8, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y9, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y10, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y11, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y0, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y1, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y2, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y3, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y4, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y5, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y6, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y7, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y8, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y9, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y10, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y11, %c1_ui1
 }
 
 // CHECK-LABEL: @ComparisonOfZeroAndNonzeroWidths
@@ -1440,30 +1440,30 @@ firrtl.module @ComparisonOfZeroAndNonzeroWidths(
   firrtl.connect %y21, %21 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y22, %22 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y23, %23 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.connect %y0, %c1_ui1
-  // CHECK: firrtl.connect %y1, %c1_ui1
-  // CHECK: firrtl.connect %y2, %c1_ui1
-  // CHECK: firrtl.connect %y3, %c1_ui1
-  // CHECK: firrtl.connect %y4, %c0_ui1
-  // CHECK: firrtl.connect %y5, %c1_ui1
-  // CHECK: firrtl.connect %y6, %c0_ui1
-  // CHECK: firrtl.connect %y7, %c1_ui1
-  // CHECK: firrtl.connect %y8, %c1_ui1
-  // CHECK: firrtl.connect %y9, %c0_ui1
-  // CHECK: firrtl.connect %y10, %c1_ui1
-  // CHECK: firrtl.connect %y11, %c0_ui1
-  // CHECK: firrtl.connect %y12, %c0_ui1
-  // CHECK: firrtl.connect %y13, %c0_ui1
-  // CHECK: firrtl.connect %y14, %c0_ui1
-  // CHECK: firrtl.connect %y15, %c0_ui1
-  // CHECK: firrtl.connect %y16, %c1_ui1
-  // CHECK: firrtl.connect %y17, %c0_ui1
-  // CHECK: firrtl.connect %y18, %c1_ui1
-  // CHECK: firrtl.connect %y19, %c0_ui1
-  // CHECK: firrtl.connect %y20, %c0_ui1
-  // CHECK: firrtl.connect %y21, %c1_ui1
-  // CHECK: firrtl.connect %y22, %c0_ui1
-  // CHECK: firrtl.connect %y23, %c1_ui1
+  // CHECK: firrtl.strictconnect %y0, %c1_ui1
+  // CHECK: firrtl.strictconnect %y1, %c1_ui1
+  // CHECK: firrtl.strictconnect %y2, %c1_ui1
+  // CHECK: firrtl.strictconnect %y3, %c1_ui1
+  // CHECK: firrtl.strictconnect %y4, %c0_ui1
+  // CHECK: firrtl.strictconnect %y5, %c1_ui1
+  // CHECK: firrtl.strictconnect %y6, %c0_ui1
+  // CHECK: firrtl.strictconnect %y7, %c1_ui1
+  // CHECK: firrtl.strictconnect %y8, %c1_ui1
+  // CHECK: firrtl.strictconnect %y9, %c0_ui1
+  // CHECK: firrtl.strictconnect %y10, %c1_ui1
+  // CHECK: firrtl.strictconnect %y11, %c0_ui1
+  // CHECK: firrtl.strictconnect %y12, %c0_ui1
+  // CHECK: firrtl.strictconnect %y13, %c0_ui1
+  // CHECK: firrtl.strictconnect %y14, %c0_ui1
+  // CHECK: firrtl.strictconnect %y15, %c0_ui1
+  // CHECK: firrtl.strictconnect %y16, %c1_ui1
+  // CHECK: firrtl.strictconnect %y17, %c0_ui1
+  // CHECK: firrtl.strictconnect %y18, %c1_ui1
+  // CHECK: firrtl.strictconnect %y19, %c0_ui1
+  // CHECK: firrtl.strictconnect %y20, %c0_ui1
+  // CHECK: firrtl.strictconnect %y21, %c1_ui1
+  // CHECK: firrtl.strictconnect %y22, %c0_ui1
+  // CHECK: firrtl.strictconnect %y23, %c1_ui1
 }
 
 // CHECK-LABEL: @ComparisonOfZeroWidths
@@ -1522,18 +1522,18 @@ firrtl.module @ComparisonOfZeroWidths(
   firrtl.connect %y9, %9 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y10, %10 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y11, %11 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.connect %y0, %c1_ui1
-  // CHECK: firrtl.connect %y1, %c1_ui1
-  // CHECK: firrtl.connect %y2, %c0_ui1
-  // CHECK: firrtl.connect %y3, %c0_ui1
-  // CHECK: firrtl.connect %y4, %c1_ui1
-  // CHECK: firrtl.connect %y5, %c1_ui1
-  // CHECK: firrtl.connect %y6, %c0_ui1
-  // CHECK: firrtl.connect %y7, %c0_ui1
-  // CHECK: firrtl.connect %y8, %c1_ui1
-  // CHECK: firrtl.connect %y9, %c1_ui1
-  // CHECK: firrtl.connect %y10, %c0_ui1
-  // CHECK: firrtl.connect %y11, %c0_ui1
+  // CHECK: firrtl.strictconnect %y0, %c1_ui1
+  // CHECK: firrtl.strictconnect %y1, %c1_ui1
+  // CHECK: firrtl.strictconnect %y2, %c0_ui1
+  // CHECK: firrtl.strictconnect %y3, %c0_ui1
+  // CHECK: firrtl.strictconnect %y4, %c1_ui1
+  // CHECK: firrtl.strictconnect %y5, %c1_ui1
+  // CHECK: firrtl.strictconnect %y6, %c0_ui1
+  // CHECK: firrtl.strictconnect %y7, %c0_ui1
+  // CHECK: firrtl.strictconnect %y8, %c1_ui1
+  // CHECK: firrtl.strictconnect %y9, %c1_ui1
+  // CHECK: firrtl.strictconnect %y10, %c0_ui1
+  // CHECK: firrtl.strictconnect %y11, %c0_ui1
 }
 
 // CHECK-LABEL: @ComparisonOfConsts
@@ -1619,34 +1619,34 @@ firrtl.module @ComparisonOfConsts(
   firrtl.connect %y17, %17 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y18, %18 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y19, %19 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.connect %y0, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y1, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y2, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y3, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y4, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y0, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y1, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y2, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y3, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y4, %c0_ui1
 
-  // CHECK-NEXT: firrtl.connect %y5, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y6, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y7, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y8, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y9, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y5, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y6, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y7, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y8, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y9, %c0_ui1
 
-  // CHECK-NEXT: firrtl.connect %y10, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y11, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y12, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y13, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y14, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y10, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y11, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y12, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y13, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y14, %c1_ui1
 
-  // CHECK-NEXT: firrtl.connect %y15, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y16, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y17, %c0_ui1
-  // CHECK-NEXT: firrtl.connect %y18, %c1_ui1
-  // CHECK-NEXT: firrtl.connect %y19, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y15, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y16, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y17, %c0_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y18, %c1_ui1
+  // CHECK-NEXT: firrtl.strictconnect %y19, %c1_ui1
 }
 
 // CHECK-LABEL: @add_cst_prop1
 // CHECK-NEXT:   %c11_ui9 = firrtl.constant 11 : !firrtl.uint<9>
-// CHECK-NEXT:   firrtl.connect %out_b, %c11_ui9 : !firrtl.uint<9>, !firrtl.uint<9>
+// CHECK-NEXT:   firrtl.strictconnect %out_b, %c11_ui9 : !firrtl.uint<9>
 // CHECK-NEXT:  }
 firrtl.module @add_cst_prop1(out %out_b: !firrtl.uint<9>) {
   %c6_ui7 = firrtl.constant 6 : !firrtl.uint<7>
@@ -1659,7 +1659,7 @@ firrtl.module @add_cst_prop1(out %out_b: !firrtl.uint<9>) {
 
 // CHECK-LABEL: @add_cst_prop2
 // CHECK-NEXT:   %c-1_si9 = firrtl.constant -1 : !firrtl.sint<9>
-// CHECK-NEXT:   firrtl.connect %out_b, %c-1_si9 : !firrtl.sint<9>, !firrtl.sint<9>
+// CHECK-NEXT:   firrtl.strictconnect %out_b, %c-1_si9 : !firrtl.sint<9>
 // CHECK-NEXT:  }
 firrtl.module @add_cst_prop2(out %out_b: !firrtl.sint<9>) {
   %c6_ui7 = firrtl.constant -6 : !firrtl.sint<7>
@@ -1672,7 +1672,7 @@ firrtl.module @add_cst_prop2(out %out_b: !firrtl.sint<9>) {
 
 // CHECK-LABEL: @add_cst_prop3
 // CHECK-NEXT:   %c-2_si4 = firrtl.constant -2 : !firrtl.sint<4>
-// CHECK-NEXT:   firrtl.connect %out_b, %c-2_si4 : !firrtl.sint<4>, !firrtl.sint<4>
+// CHECK-NEXT:   firrtl.strictconnect %out_b, %c-2_si4 : !firrtl.sint<4>
 // CHECK-NEXT:  }
 firrtl.module @add_cst_prop3(out %out_b: !firrtl.sint<4>) {
   %c1_si2 = firrtl.constant -1 : !firrtl.sint<2>
@@ -1685,9 +1685,9 @@ firrtl.module @add_cst_prop3(out %out_b: !firrtl.sint<4>) {
 
 // CHECK-LABEL: @add_cst_prop4
 // CHECK: %[[pad:.+]] = firrtl.pad %tmp_a, 5
-// CHECK-NEXT: firrtl.connect %out_b, %[[pad]]
+// CHECK-NEXT: firrtl.strictconnect %out_b, %[[pad]]
 // CHECK-NEXT: %[[pad:.+]] = firrtl.pad %tmp_a, 5
-// CHECK_NEXT: firrtl.connect %out_b, %[[pad]]
+// CHECK_NEXT: firrtl.strictconnect %out_b, %[[pad]]
 firrtl.module @add_cst_prop4(out %out_b: !firrtl.uint<5>) {
   %tmp_a = firrtl.wire : !firrtl.uint<4>
   %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
@@ -1699,9 +1699,9 @@ firrtl.module @add_cst_prop4(out %out_b: !firrtl.uint<5>) {
 
 // CHECK-LABEL: @add_cst_prop5
 // CHECK: %[[pad:.+]] = firrtl.pad %tmp_a, 5
-// CHECK-NEXT: firrtl.connect %out_b, %[[pad]]
+// CHECK-NEXT: firrtl.strictconnect %out_b, %[[pad]]
 // CHECK-NEXT: %[[pad:.+]] = firrtl.pad %tmp_a, 5
-// CHECK_NEXT: firrtl.connect %out_b, %[[pad]]
+// CHECK_NEXT: firrtl.strictconnect %out_b, %[[pad]]
 firrtl.module @add_cst_prop5(out %out_b: !firrtl.uint<5>) {
   %tmp_a = firrtl.wire : !firrtl.uint<4>
   %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
@@ -1713,7 +1713,7 @@ firrtl.module @add_cst_prop5(out %out_b: !firrtl.uint<5>) {
 
 // CHECK-LABEL: @sub_cst_prop1
 // CHECK-NEXT:      %c1_ui9 = firrtl.constant 1 : !firrtl.uint<9>
-// CHECK-NEXT:      firrtl.connect %out_b, %c1_ui9 : !firrtl.uint<9>, !firrtl.uint<9>
+// CHECK-NEXT:      firrtl.strictconnect %out_b, %c1_ui9 : !firrtl.uint<9>
 // CHECK-NEXT:  }
 firrtl.module @sub_cst_prop1(out %out_b: !firrtl.uint<9>) {
   %c6_ui7 = firrtl.constant 6 : !firrtl.uint<7>
@@ -1726,7 +1726,7 @@ firrtl.module @sub_cst_prop1(out %out_b: !firrtl.uint<9>) {
 
 // CHECK-LABEL: @sub_cst_prop2
 // CHECK-NEXT:      %c-11_si9 = firrtl.constant -11 : !firrtl.sint<9>
-// CHECK-NEXT:      firrtl.connect %out_b, %c-11_si9 : !firrtl.sint<9>, !firrtl.sint<9>
+// CHECK-NEXT:      firrtl.strictconnect %out_b, %c-11_si9 : !firrtl.sint<9>
 // CHECK-NEXT:  }
 firrtl.module @sub_cst_prop2(out %out_b: !firrtl.sint<9>) {
   %c6_ui7 = firrtl.constant -6 : !firrtl.sint<7>
@@ -1739,10 +1739,10 @@ firrtl.module @sub_cst_prop2(out %out_b: !firrtl.sint<9>) {
 
 // CHECK-LABEL: @sub_cst_prop3
 // CHECK: %[[pad:.+]] = firrtl.pad %tmp_a, 5
-// CHECK-NEXT: firrtl.connect %out_b, %[[pad]]
+// CHECK-NEXT: firrtl.strictconnect %out_b, %[[pad]]
 // CHECK: %[[neg:.+]] = firrtl.neg %tmp_a
 // CHECK: %[[cast:.+]] = firrtl.asUInt %[[neg]]
-// CHECK-NEXT: firrtl.connect %out_b, %[[cast]]
+// CHECK-NEXT: firrtl.strictconnect %out_b, %[[cast]]
 firrtl.module @sub_cst_prop3(out %out_b: !firrtl.uint<5>) {
   %tmp_a = firrtl.wire : !firrtl.uint<4>
   %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
@@ -1754,7 +1754,7 @@ firrtl.module @sub_cst_prop3(out %out_b: !firrtl.uint<5>) {
 
 // CHECK-LABEL: @mul_cst_prop1
 // CHECK-NEXT:      %c30_ui15 = firrtl.constant 30 : !firrtl.uint<15>
-// CHECK-NEXT:      firrtl.connect %out_b, %c30_ui15 : !firrtl.uint<15>, !firrtl.uint<15>
+// CHECK-NEXT:      firrtl.strictconnect %out_b, %c30_ui15 : !firrtl.uint<15>
 // CHECK-NEXT:  }
 firrtl.module @mul_cst_prop1(out %out_b: !firrtl.uint<15>) {
   %c6_ui7 = firrtl.constant 6 : !firrtl.uint<7>
@@ -1767,7 +1767,7 @@ firrtl.module @mul_cst_prop1(out %out_b: !firrtl.uint<15>) {
 
 // CHECK-LABEL: @mul_cst_prop2
 // CHECK-NEXT:      %c-30_si15 = firrtl.constant -30 : !firrtl.sint<15>
-// CHECK-NEXT:      firrtl.connect %out_b, %c-30_si15 : !firrtl.sint<15>, !firrtl.sint<15>
+// CHECK-NEXT:      firrtl.strictconnect %out_b, %c-30_si15 : !firrtl.sint<15>
 // CHECK-NEXT:  }
 firrtl.module @mul_cst_prop2(out %out_b: !firrtl.sint<15>) {
   %c6_ui7 = firrtl.constant -6 : !firrtl.sint<7>
@@ -1780,7 +1780,7 @@ firrtl.module @mul_cst_prop2(out %out_b: !firrtl.sint<15>) {
 
 // CHECK-LABEL: @mul_cst_prop3
 // CHECK-NEXT:      %c30_si15 = firrtl.constant 30 : !firrtl.sint<15>
-// CHECK-NEXT:      firrtl.connect %out_b, %c30_si15 : !firrtl.sint<15>, !firrtl.sint<15>
+// CHECK-NEXT:      firrtl.strictconnect %out_b, %c30_si15 : !firrtl.sint<15>
 // CHECK-NEXT:  }
 firrtl.module @mul_cst_prop3(out %out_b: !firrtl.sint<15>) {
   %c6_ui7 = firrtl.constant -6 : !firrtl.sint<7>
@@ -1793,8 +1793,8 @@ firrtl.module @mul_cst_prop3(out %out_b: !firrtl.sint<15>) {
 
 // CHECK-LABEL: @mul_cst_prop4
 // CHECK: %[[zero:.+]] = firrtl.constant 0 : !firrtl.uint<15>
-// CHECK: firrtl.connect %out_b, %[[zero]]
-// CHECK: firrtl.connect %out_b, %[[zero]]
+// CHECK: firrtl.strictconnect %out_b, %[[zero]]
+// CHECK: firrtl.strictconnect %out_b, %[[zero]]
 firrtl.module @mul_cst_prop4(out %out_b: !firrtl.uint<15>) {
   %tmp_a = firrtl.wire : !firrtl.uint<7>
   %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<8>
@@ -1839,11 +1839,11 @@ firrtl.module @EmptyNode(in %d1: !firrtl.uint<5>,
   // CHECK-NEXT: %bar3 = firrtl.node %d1  {annotations = [{extrastuff = "n1"}]} : !firrtl.uint<5>
   %bar3 = firrtl.node %d1 {annotations = [{extrastuff = "n1"}]} : !firrtl.uint<5>
   %_T_4 = firrtl.node %tmp : !firrtl.uint<6>
-  // CHECK-NEXT: firrtl.connect %foo0, %bar0 : !firrtl.uint<5>, !firrtl.uint<5>
-  // CHECK-NEXT: firrtl.connect %foo1, %d1 : !firrtl.uint<5>, !firrtl.uint<5>
-  // CHECK-NEXT: firrtl.connect %foo2, %bar2 : !firrtl.uint<5>, !firrtl.uint<5>
-  // CHECK-NEXT: firrtl.connect %foo3, %bar3 : !firrtl.uint<5>, !firrtl.uint<5>
-  // CHECK-NEXT: firrtl.connect %foo4, %0 : !firrtl.uint<6>, !firrtl.uint<6>
+  // CHECK-NEXT: firrtl.strictconnect %foo0, %bar0 : !firrtl.uint<5>
+  // CHECK-NEXT: firrtl.strictconnect %foo1, %d1 : !firrtl.uint<5>
+  // CHECK-NEXT: firrtl.strictconnect %foo2, %bar2 : !firrtl.uint<5>
+  // CHECK-NEXT: firrtl.strictconnect %foo3, %bar3 : !firrtl.uint<5>
+  // CHECK-NEXT: firrtl.strictconnect %foo4, %0 : !firrtl.uint<6>
   firrtl.connect %foo0, %bar0 : !firrtl.uint<5>, !firrtl.uint<5>
   firrtl.connect %foo1, %bar1 : !firrtl.uint<5>, !firrtl.uint<5>
   firrtl.connect %foo2, %bar2 : !firrtl.uint<5>, !firrtl.uint<5>
@@ -1884,7 +1884,7 @@ firrtl.module @MuxInvalidTypeOpt(in %in : !firrtl.uint<1>, out %out : !firrtl.ui
 // CHECK: firrtl.mux(%in, %c1_ui4, %c7_ui4) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
 
 // CHECK-LABEL: firrtl.module @issue1100
-// CHECK: firrtl.connect %tmp62, %c1_ui1
+// CHECK: firrtl.strictconnect %tmp62, %c1_ui1
   firrtl.module @issue1100(out %tmp62: !firrtl.uint<1>) {
     %c-1_si2 = firrtl.constant -1 : !firrtl.sint<2>
     %0 = firrtl.orr %c-1_si2 : (!firrtl.sint<2>) -> !firrtl.uint<1>
@@ -1892,7 +1892,7 @@ firrtl.module @MuxInvalidTypeOpt(in %in : !firrtl.uint<1>, out %out : !firrtl.ui
   }
 
   // CHECK-LABEL: firrtl.module @issue1101
-  // CHECK: firrtl.connect %y, %c-7_si4
+  // CHECK: firrtl.strictconnect %y, %c-7_si4
   firrtl.module @issue1101(out %y: !firrtl.sint<4>) {
     %c9_si10 = firrtl.constant 9 : !firrtl.sint<10>
     firrtl.partialconnect %y, %c9_si10 : !firrtl.sint<4>, !firrtl.sint<10>
@@ -1909,7 +1909,7 @@ firrtl.module @issue1116(out %z: !firrtl.uint<1>) {
   %c844336_ui = firrtl.constant 844336 : !firrtl.uint
   %c161_ui8 = firrtl.constant 161 : !firrtl.uint<8>
   %0 = firrtl.leq %c844336_ui, %c161_ui8 : (!firrtl.uint, !firrtl.uint<8>) -> !firrtl.uint<1>
-  // CHECK: firrtl.connect %z, %c0_ui1
+  // CHECK: firrtl.strictconnect %z, %c0_ui1
   firrtl.connect %z, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
@@ -1931,7 +1931,7 @@ firrtl.module @issue1118(out %z0: !firrtl.uint, out %z1: !firrtl.sint) {
 // CHECK-LABEL: firrtl.module @issue1139
 firrtl.module @issue1139(out %z: !firrtl.uint<4>) {
   // CHECK-NEXT: %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
-  // CHECK-NEXT: firrtl.connect %z, %c0_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
+  // CHECK-NEXT: firrtl.strictconnect %z, %c0_ui4 : !firrtl.uint<4>
   %c4_ui4 = firrtl.constant 4 : !firrtl.uint<4>
   %c674_ui = firrtl.constant 674 : !firrtl.uint
   %0 = firrtl.dshr %c4_ui4, %c674_ui : (!firrtl.uint<4>, !firrtl.uint) -> !firrtl.uint<4>
@@ -2016,8 +2016,8 @@ firrtl.module @PadMuxOperands(
 firrtl.module @regsyncreset(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %foo : !firrtl.uint<2>, out %bar: !firrtl.uint<2>) {
   // CHECK: %[[const:.*]] = firrtl.constant 1
   // CHECK-NEXT: firrtl.regreset %clock, %reset, %[[const]]
-  // CHECK-NEXT:  firrtl.connect %bar, %d : !firrtl.uint<2>, !firrtl.uint<2>
-  // CHECK-NEXT:  firrtl.connect %d, %foo : !firrtl.uint<2>, !firrtl.uint<2>
+  // CHECK-NEXT:  firrtl.strictconnect %bar, %d : !firrtl.uint<2>
+  // CHECK-NEXT:  firrtl.strictconnect %d, %foo : !firrtl.uint<2>
   // CHECK-NEXT: }
   %d = firrtl.reg %clock  : !firrtl.uint<2>
   firrtl.connect %bar, %d : !firrtl.uint<2>, !firrtl.uint<2>
@@ -2052,14 +2052,14 @@ firrtl.module @dshifts_to_ishifts(in %a_in: !firrtl.sint<58>,
   // CHECK: %0 = firrtl.bits %a_in 57 to 4 : (!firrtl.sint<58>) -> !firrtl.uint<54>
   // CHECK: %1 = firrtl.asSInt %0 : (!firrtl.uint<54>) -> !firrtl.sint<54>
   // CHECK: %2 = firrtl.pad %1, 58 : (!firrtl.sint<54>) -> !firrtl.sint<58>
-  // CHECK: firrtl.connect %a_out, %2 : !firrtl.sint<58>, !firrtl.sint<58>
+  // CHECK: firrtl.strictconnect %a_out, %2 : !firrtl.sint<58>
   %c4_ui10 = firrtl.constant 4 : !firrtl.uint<10>
   %0 = firrtl.dshr %a_in, %c4_ui10 : (!firrtl.sint<58>, !firrtl.uint<10>) -> !firrtl.sint<58>
   firrtl.connect %a_out, %0 : !firrtl.sint<58>, !firrtl.sint<58>
 
   // CHECK: %3 = firrtl.shl %b_in, 4 : (!firrtl.uint<8>) -> !firrtl.uint<12>
   // CHECK: %4 = firrtl.pad %3, 23 : (!firrtl.uint<12>) -> !firrtl.uint<23>
-  // CHECK: firrtl.connect %b_out, %4 : !firrtl.uint<23>, !firrtl.uint<23>
+  // CHECK: firrtl.strictconnect %b_out, %4 : !firrtl.uint<23>
   %c4_ui4 = firrtl.constant 4 : !firrtl.uint<4>
   %1 = firrtl.dshl %b_in, %c4_ui4 : (!firrtl.uint<8>, !firrtl.uint<4>) -> !firrtl.uint<23>
   firrtl.connect %b_out, %1 : !firrtl.uint<23>, !firrtl.uint<23>
@@ -2067,18 +2067,18 @@ firrtl.module @dshifts_to_ishifts(in %a_in: !firrtl.sint<58>,
   // CHECK: %5 = firrtl.bits %c_in 57 to 57 : (!firrtl.sint<58>) -> !firrtl.uint<1>
   // CHECK: %6 = firrtl.asSInt %5 : (!firrtl.uint<1>) -> !firrtl.sint<1>
   // CHECK: %7 = firrtl.pad %6, 58 : (!firrtl.sint<1>) -> !firrtl.sint<58>
-  // CHECK: firrtl.connect %c_out, %7 : !firrtl.sint<58>, !firrtl.sint<58>
+  // CHECK: firrtl.strictconnect %c_out, %7 : !firrtl.sint<58>
   %c438_ui10 = firrtl.constant 438 : !firrtl.uint<10>
   %2 = firrtl.dshr %c_in, %c438_ui10 : (!firrtl.sint<58>, !firrtl.uint<10>) -> !firrtl.sint<58>
   firrtl.connect %c_out, %2 : !firrtl.sint<58>, !firrtl.sint<58>
 
-  // CHECK: firrtl.connect %a_out, %a_in : !firrtl.sint<58>, !firrtl.sint<58>
+  // CHECK: firrtl.strictconnect %a_out, %a_in : !firrtl.sint<58>
   %invalid_ui10 = firrtl.invalidvalue : !firrtl.uint<10>
   %3 = firrtl.dshr %a_in, %invalid_ui10 : (!firrtl.sint<58>, !firrtl.uint<10>) -> !firrtl.sint<58>
   firrtl.connect %a_out, %3 : !firrtl.sint<58>, !firrtl.sint<58>
 
   // CHECK: [[TMP:%.+]] = firrtl.pad %b_in, 23 : (!firrtl.uint<8>) -> !firrtl.uint<23>
-  // CHECK: firrtl.connect %b_out, [[TMP]] : !firrtl.uint<23>, !firrtl.uint<23>
+  // CHECK: firrtl.strictconnect %b_out, [[TMP]] : !firrtl.uint<23>
   %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
   %4 = firrtl.dshl %b_in, %invalid_ui4 : (!firrtl.uint<8>, !firrtl.uint<4>) -> !firrtl.uint<23>
   firrtl.connect %b_out, %4 : !firrtl.uint<23>, !firrtl.uint<23>
@@ -2093,7 +2093,7 @@ firrtl.module @constReg(in %clock: !firrtl.clock,
   firrtl.connect %r1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %out, %r1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:  %[[C11:.+]] = firrtl.constant 1 : !firrtl.uint<1>
-  // CHECK:  firrtl.connect %out, %[[C11]]
+  // CHECK:  firrtl.strictconnect %out, %[[C11]]
 }
 
 // CHECK-LABEL: firrtl.module @constReg
@@ -2110,7 +2110,7 @@ firrtl.module @constReg2(in %clock: !firrtl.clock,
   %2 = firrtl.xor %r1, %r2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:  %[[C12:.+]] = firrtl.constant 1 : !firrtl.uint<1>
-  // CHECK:  firrtl.connect %out, %[[C12]]
+  // CHECK:  firrtl.strictconnect %out, %[[C12]]
 }
 
 // CHECK-LABEL: firrtl.module @constReg3
@@ -2120,7 +2120,7 @@ firrtl.module @constReg3(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, i
   %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
   firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
   // CHECK:  %[[C14:.+]] = firrtl.constant 11
-  // CHECK: firrtl.connect %z, %[[C14]]
+  // CHECK: firrtl.strictconnect %z, %[[C14]]
   firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
 }
 
@@ -2132,7 +2132,7 @@ firrtl.module @constReg4(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, i
   %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
   firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
   // CHECK:  %[[C13:.+]] = firrtl.constant 11
-  // CHECK: firrtl.connect %z, %[[C13]]
+  // CHECK: firrtl.strictconnect %z, %[[C13]]
   firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
 }
 
@@ -2145,7 +2145,7 @@ firrtl.module @constReg6(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, i
   %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
   firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
   // CHECK:  %[[C13:.+]] = firrtl.constant 11
-  // CHECK: firrtl.connect %z, %[[C13]]
+  // CHECK: firrtl.strictconnect %z, %[[C13]]
   firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
 }
 
@@ -2157,7 +2157,7 @@ firrtl.module @constReg5(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, i
   %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<8>
   // CHECK: %0 = firrtl.mux(%cond, %c11_ui8, %r)
   %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
-  // CHECK: firrtl.connect %r, %0
+  // CHECK: firrtl.strictconnect %r, %0
   firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
   firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
 }
@@ -2189,7 +2189,7 @@ firrtl.module @namedrop(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in
   %_T_3 = firrtl.regreset %clock, %reset, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
   %a = firrtl.mem Undefined {depth = 8 : i64, name = "_T_5", portNames = ["a"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<1>>
   firrtl.connect %out, %in : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.connect %out, %in
+  // CHECK: firrtl.strictconnect %out, %in
 }
   firrtl.module @BitCast(out %o:!firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<1>> ) {
     %a = firrtl.wire : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<1>>
@@ -2197,14 +2197,14 @@ firrtl.module @namedrop(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in
     %b2 = firrtl.bitcast %b : (!firrtl.uint<3>) -> (!firrtl.uint<3>)
     %c = firrtl.bitcast %b2 :  (!firrtl.uint<3>)-> (!firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<1>>)
     firrtl.connect %o, %c : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<1>>, !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<1>>
-    // CHECK: firrtl.connect %o, %a : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<1>>, !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<1>>
+    // CHECK: firrtl.strictconnect %o, %a : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<1>>
   }
 
 // Issue #2197
 // CHECK-LABEL: @Issue2197
 firrtl.module @Issue2197(in %clock: !firrtl.clock, out %x: !firrtl.uint<2>) {
   // CHECK: [[ZERO:%.+]] = firrtl.constant 0 : !firrtl.uint<2>
-  // CHECK-NEXT: firrtl.connect %x, [[ZERO]] : !firrtl.uint<2>, !firrtl.uint<2>
+  // CHECK-NEXT: firrtl.strictconnect %x, [[ZERO]] : !firrtl.uint<2>
   %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
   %reg = firrtl.reg %clock : !firrtl.uint<2>
   %0 = firrtl.pad %invalid_ui1, 2 : (!firrtl.uint<1>) -> !firrtl.uint<2>
@@ -2221,7 +2221,7 @@ firrtl.module @ZeroWidthAdd(out %a: !firrtl.sint<1>) {
   %1 = firrtl.add %0, %zw : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.sint<1>
   firrtl.connect %a, %1 : !firrtl.sint<1>, !firrtl.sint<1>
   // CHECK:      %[[zero:.+]] = firrtl.constant 0 : !firrtl.sint<1>
-  // CHECK-NEXT: firrtl.connect %a, %[[zero]]
+  // CHECK-NEXT: firrtl.strictconnect %a, %[[zero]]
 }
 
 // CHECK-LABEL: @ZeroWidthDshr
@@ -2230,7 +2230,7 @@ firrtl.module @ZeroWidthDshr(in %a: !firrtl.sint<0>, out %b: !firrtl.sint<0>) {
   %0 = firrtl.dshr %a, %zw : (!firrtl.sint<0>, !firrtl.uint<0>) -> !firrtl.sint<0>
   firrtl.connect %b, %0 : !firrtl.sint<0>, !firrtl.sint<0>
   // CHECK:      %[[zero:.+]] = firrtl.constant 0 : !firrtl.sint<0>
-  // CHECK-NEXT: firrtl.connect %b, %[[zero]]
+  // CHECK-NEXT: firrtl.strictconnect %b, %[[zero]]
 }
 
 // CHECK-LABEL: @ZeroWidthPad
@@ -2239,7 +2239,7 @@ firrtl.module @ZeroWidthPad(out %b: !firrtl.sint<1>) {
   %0 = firrtl.pad %zw, 1 : (!firrtl.sint<0>) -> !firrtl.sint<1>
   firrtl.connect %b, %0 : !firrtl.sint<1>, !firrtl.sint<1>
   // CHECK:      %[[zero:.+]] = firrtl.constant 0 : !firrtl.sint<1>
-  // CHECK-NEXT: firrtl.connect %b, %[[zero]]
+  // CHECK-NEXT: firrtl.strictconnect %b, %[[zero]]
 }
 
 // CHECK-LABEL: @ZeroWidthCat
@@ -2249,7 +2249,7 @@ firrtl.module @ZeroWidthCat(out %a: !firrtl.uint<1>) {
   %0 = firrtl.cat %one, %zw : (!firrtl.uint<1>, !firrtl.uint<0>) -> !firrtl.uint<1>
   firrtl.connect %a, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:      %[[one:.+]] = firrtl.constant 1 : !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.connect %a, %[[one]]
+  // CHECK-NEXT: firrtl.strictconnect %a, %[[one]]
 }
 
 // Issue mentioned in PR #2251
@@ -2260,7 +2260,7 @@ firrtl.module @Issue2251(out %o: !firrtl.sint<15>) {
   %0 = firrtl.pad %invalid_si1, 15 : (!firrtl.sint<1>) -> !firrtl.sint<15>
   firrtl.connect %o, %0 : !firrtl.sint<15>, !firrtl.sint<15>
   // CHECK:      %[[zero:.+]] = firrtl.constant 0 : !firrtl.sint<15>
-  // CHECK-NEXT: firrtl.connect %o, %[[zero]]
+  // CHECK-NEXT: firrtl.strictconnect %o, %[[zero]]
 }
 
 // Issue mentioned in #2289
@@ -2277,7 +2277,7 @@ firrtl.module @Issue2289(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, o
   // CHECK-NEXT: %[[neg:.+]] = firrtl.neg %[[dshl]]
   // CHECK-NEXT: %[[pad:.+]] = firrtl.pad %[[neg]], 5
   // CHECK-NEXT: %[[cast:.+]] = firrtl.asUInt %[[pad]]
-  // CHECK-NEXT: firrtl.connect %out, %[[cast]]
+  // CHECK-NEXT: firrtl.strictconnect %out, %[[cast]]
 }
 
 // Issue mentioned in #2291
@@ -2301,17 +2301,17 @@ firrtl.module @Issue2314(out %clock: !firrtl.clock, out %reset: !firrtl.reset, o
   %invalid_clock = firrtl.invalidvalue : !firrtl.clock
   firrtl.connect %inv_clock, %invalid_clock : !firrtl.clock, !firrtl.clock
   firrtl.connect %clock, %inv_clock : !firrtl.clock, !firrtl.clock
-  // CHECK: firrtl.connect %clock, %[[zero_clock]]
+  // CHECK: firrtl.strictconnect %clock, %[[zero_clock]]
   %inv_reset = firrtl.wire  : !firrtl.reset
   %invalid_reset = firrtl.invalidvalue : !firrtl.reset
   firrtl.connect %inv_reset, %invalid_reset : !firrtl.reset, !firrtl.reset
   firrtl.connect %reset, %inv_reset : !firrtl.reset, !firrtl.reset
-  // CHECK: firrtl.connect %reset, %[[zero_reset]]
+  // CHECK: firrtl.strictconnect %reset, %[[zero_reset]]
   %inv_asyncReset = firrtl.wire  : !firrtl.asyncreset
   %invalid_asyncreset = firrtl.invalidvalue : !firrtl.asyncreset
   firrtl.connect %inv_asyncReset, %invalid_asyncreset : !firrtl.asyncreset, !firrtl.asyncreset
   firrtl.connect %asyncReset, %inv_asyncReset : !firrtl.asyncreset, !firrtl.asyncreset
-  // CHECK: firrtl.connect %asyncReset, %[[zero_asyncReset]]
+  // CHECK: firrtl.strictconnect %asyncReset, %[[zero_asyncReset]]
 }
 
 }

--- a/test/Dialect/FIRRTL/const-prop-single-module.mlir
+++ b/test/Dialect/FIRRTL/const-prop-single-module.mlir
@@ -17,7 +17,7 @@ firrtl.module @Top01(in %x: !firrtl.uint<5>, out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top01
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 1
-// CHECK-NEXT: firrtl.connect %y, %[[K]]
+// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
 
 
 // The rule x < 0 should never be true if x is a UInt
@@ -28,7 +28,7 @@ firrtl.module @Top02(in %x: !firrtl.uint<5>, out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top02
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 0
-// CHECK-NEXT: firrtl.connect %y, %[[K]]
+// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
 
 
 // The rule 0 <= x should always be true if x is a UInt
@@ -39,7 +39,7 @@ firrtl.module @Top03(in %x: !firrtl.uint<5>, out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top03
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 1
-// CHECK-NEXT: firrtl.connect %y, %[[K]]
+// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
 
 
 // The rule 0 > x should never be true if x is a UInt
@@ -50,7 +50,7 @@ firrtl.module @Top04(in %x: !firrtl.uint<5>, out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top04
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 0
-// CHECK-NEXT: firrtl.connect %y, %[[K]]
+// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
 
 
 // The rule 1 < 3 should always be true
@@ -62,7 +62,7 @@ firrtl.module @Top05(out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top05
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 1
-// CHECK-NEXT: firrtl.connect %y, %[[K]]
+// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
 
 
 // The rule x < 8 should always be true if x only has 3 bits
@@ -73,7 +73,7 @@ firrtl.module @Top06(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top06
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 1
-// CHECK-NEXT: firrtl.connect %y, %[[K]]
+// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
 
 
 // The rule x <= 7 should always be true if x only has 3 bits
@@ -84,7 +84,7 @@ firrtl.module @Top07(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top07
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 1
-// CHECK-NEXT: firrtl.connect %y, %[[K]]
+// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
 
 
 // The rule 8 > x should always be true if x only has 3 bits
@@ -95,7 +95,7 @@ firrtl.module @Top08(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top08
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 1
-// CHECK-NEXT: firrtl.connect %y, %[[K]]
+// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
 
 
 // The rule 7 >= x should always be true if x only has 3 bits
@@ -106,7 +106,7 @@ firrtl.module @Top09(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top09
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 1
-// CHECK-NEXT: firrtl.connect %y, %[[K]]
+// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
 
 
 // The rule 10 == 10 should always be true
@@ -117,7 +117,7 @@ firrtl.module @Top10(out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top10
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 1
-// CHECK-NEXT: firrtl.connect %y, %[[K]]
+// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
 
 
 // The rule x == z should not be true even if they have the same number of bits
@@ -127,7 +127,7 @@ firrtl.module @Top11(in %x: !firrtl.uint<3>, in %z: !firrtl.uint<3>, out %y: !fi
 }
 // CHECK-LABEL: firrtl.module @Top11
 // CHECK-NEXT: %[[K:.+]] = firrtl.eq %x, %z
-// CHECK-NEXT: firrtl.connect %y, %[[K]]
+// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
 
 
 // The rule 10 != 10 should always be false
@@ -138,7 +138,7 @@ firrtl.module @Top12(out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top12
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 0
-// CHECK-NEXT: firrtl.connect %y, %[[K]]
+// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
 
 
 // The rule 1 >= 3 should always be false
@@ -150,7 +150,7 @@ firrtl.module @Top13(out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top13
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 0
-// CHECK-NEXT: firrtl.connect %y, %[[K]]
+// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
 
 
 // The rule x >= 8 should never be true if x only has 3 bits
@@ -161,7 +161,7 @@ firrtl.module @Top14(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top14
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 0
-// CHECK-NEXT: firrtl.connect %y, %[[K]]
+// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
 
 
 // The rule x > 7 should never be true if x only has 3 bits
@@ -172,7 +172,7 @@ firrtl.module @Top15(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top15
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 0
-// CHECK-NEXT: firrtl.connect %y, %[[K]]
+// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
 
 
 // The rule 8 <= x should never be true if x only has 3 bits
@@ -183,7 +183,7 @@ firrtl.module @Top16(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top16
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 0
-// CHECK-NEXT: firrtl.connect %y, %[[K]]
+// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
 
 
 // The rule 7 < x should never be true if x only has 3 bits
@@ -194,6 +194,6 @@ firrtl.module @Top17(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top17
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 0
-// CHECK-NEXT: firrtl.connect %y, %[[K]]
+// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
 
 }

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -80,31 +80,31 @@ circuit test_mod : %[[{"a": "a"}]]
 
 ; MLIR-LABEL: firrtl.module @test_mod(in %clock: !firrtl.clock, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<2>, out %c: !firrtl.uint<1>, in %vec_0: !firrtl.uint<1>, in %vec_1: !firrtl.uint<1>, in %vec_2: !firrtl.uint<1>) {
 ; MLIR-NEXT:    %cat_a, %cat_b, %cat_c, %cat_d = firrtl.instance cat @Cat(in a: !firrtl.uint<2>, in b: !firrtl.uint<2>, in c: !firrtl.uint<2>, out d: !firrtl.uint<6>)
-; MLIR-NEXT:    firrtl.connect %cat_a, %b : !firrtl.uint<2>, !firrtl.uint<2>
-; MLIR-NEXT:    firrtl.connect %cat_b, %b : !firrtl.uint<2>, !firrtl.uint<2>
-; MLIR-NEXT:    firrtl.connect %cat_c, %b : !firrtl.uint<2>, !firrtl.uint<2>
+; MLIR-NEXT:    firrtl.strictconnect %cat_a, %b : !firrtl.uint<2>
+; MLIR-NEXT:    firrtl.strictconnect %cat_b, %b : !firrtl.uint<2>
+; MLIR-NEXT:    firrtl.strictconnect %cat_c, %b : !firrtl.uint<2>
 ; MLIR-NEXT:    %implicitTrunc_inp_1, %implicitTrunc_inp_2, %implicitTrunc_out1, %implicitTrunc_out2 = firrtl.instance implicitTrunc @ImplicitTrunc(in inp_1: !firrtl.uint<1>, in inp_2: !firrtl.sint<5>, out out1: !firrtl.sint<3>, out out2: !firrtl.sint<3>)
-; MLIR-NEXT:    firrtl.connect %implicitTrunc_inp_1, %a : !firrtl.uint<1>, !firrtl.uint<1>
+; MLIR-NEXT:    firrtl.strictconnect %implicitTrunc_inp_1, %a : !firrtl.uint<1>
 ; MLIR-NEXT:    %0 = firrtl.asSInt %cat_d : (!firrtl.uint<6>) -> !firrtl.sint<6>
 ; MLIR-NEXT:    %1 = firrtl.bits %0 4 to 0 : (!firrtl.sint<6>) -> !firrtl.uint<5>
 ; MLIR-NEXT:    %2 = firrtl.asSInt %1 : (!firrtl.uint<5>) -> !firrtl.sint<5>
-; MLIR-NEXT:    firrtl.connect %implicitTrunc_inp_2, %2 : !firrtl.sint<5>, !firrtl.sint<5>
+; MLIR-NEXT:    firrtl.strictconnect %implicitTrunc_inp_2, %2 : !firrtl.sint<5>
 ; MLIR-NEXT:    %prettifyExample_inp_1, %prettifyExample_inp_2, %prettifyExample_inp_3, %prettifyExample_out1, %prettifyExample_out2 = firrtl.instance prettifyExample @PrettifyExample(in inp_1: !firrtl.uint<5>, in inp_2: !firrtl.uint<5>, in inp_3: !firrtl.uint<5>, out out1: !firrtl.uint<10>, out out2: !firrtl.uint<10>)
 ; MLIR-NEXT:    %3 = firrtl.bits %cat_d 4 to 0 : (!firrtl.uint<6>) -> !firrtl.uint<5>
-; MLIR-NEXT:    firrtl.connect %prettifyExample_inp_1, %3 : !firrtl.uint<5>, !firrtl.uint<5>
+; MLIR-NEXT:    firrtl.strictconnect %prettifyExample_inp_1, %3 : !firrtl.uint<5>
 ; MLIR-NEXT:    %4 = firrtl.bits %cat_d 4 to 0 : (!firrtl.uint<6>) -> !firrtl.uint<5>
-; MLIR-NEXT:    firrtl.connect %prettifyExample_inp_2, %4 : !firrtl.uint<5>, !firrtl.uint<5>
+; MLIR-NEXT:    firrtl.strictconnect %prettifyExample_inp_2, %4 : !firrtl.uint<5>
 ; MLIR-NEXT:    %5 = firrtl.bits %cat_d 4 to 0 : (!firrtl.uint<6>) -> !firrtl.uint<5>
-; MLIR-NEXT:    firrtl.connect %prettifyExample_inp_3, %5 : !firrtl.uint<5>, !firrtl.uint<5>
+; MLIR-NEXT:    firrtl.strictconnect %prettifyExample_inp_3, %5 : !firrtl.uint<5>
 ; MLIR-NEXT:    %flipFlop_clock, %flipFlop_a_d, %flipFlop_a_q = firrtl.instance flipFlop @FlipFlop(in clock: !firrtl.clock, in a_d: !firrtl.uint<1>, out a_q: !firrtl.uint<1>)
-; MLIR-NEXT:    firrtl.connect %flipFlop_clock, %clock : !firrtl.clock, !firrtl.clock
-; MLIR-NEXT:    firrtl.connect %flipFlop_a_d, %a : !firrtl.uint<1>, !firrtl.uint<1>
-; MLIR-NEXT:    firrtl.connect %c, %flipFlop_a_q : !firrtl.uint<1>, !firrtl.uint<1>
+; MLIR-NEXT:    firrtl.strictconnect %flipFlop_clock, %clock : !firrtl.clock
+; MLIR-NEXT:    firrtl.strictconnect %flipFlop_a_d, %a : !firrtl.uint<1>
+; MLIR-NEXT:    firrtl.strictconnect %c, %flipFlop_a_q : !firrtl.uint<1>
 ; MLIR-NEXT:    %multibitMux_a_0, %multibitMux_a_1, %multibitMux_a_2, %multibitMux_sel, %multibitMux_b = firrtl.instance multibitMux @MultibitMux(in a_0: !firrtl.uint<1>, in a_1: !firrtl.uint<1>, in a_2: !firrtl.uint<1>, in sel: !firrtl.uint<2>, out b: !firrtl.uint<1>)
-; MLIR-NEXT:    firrtl.connect %multibitMux_a_0, %vec_0 : !firrtl.uint<1>, !firrtl.uint<1>
-; MLIR-NEXT:    firrtl.connect %multibitMux_a_1, %vec_1 : !firrtl.uint<1>, !firrtl.uint<1>
-; MLIR-NEXT:    firrtl.connect %multibitMux_a_2, %vec_2 : !firrtl.uint<1>, !firrtl.uint<1>
-; MLIR-NEXT:    firrtl.connect %multibitMux_sel, %b : !firrtl.uint<2>, !firrtl.uint<2>
+; MLIR-NEXT:    firrtl.strictconnect %multibitMux_a_0, %vec_0 : !firrtl.uint<1>
+; MLIR-NEXT:    firrtl.strictconnect %multibitMux_a_1, %vec_1 : !firrtl.uint<1>
+; MLIR-NEXT:    firrtl.strictconnect %multibitMux_a_2, %vec_2 : !firrtl.uint<1>
+; MLIR-NEXT:    firrtl.strictconnect %multibitMux_sel, %b : !firrtl.uint<2>
 ; MLIR-NEXT:  }
 
 ; ANNOTATIONS-LABEL: firrtl.module @test_mod

--- a/test/firtool/firtool.mlir
+++ b/test/firtool/firtool.mlir
@@ -9,7 +9,7 @@ firrtl.circuit "Top" {
 }
 
 // MLIR-LABEL: firrtl.module @Top(in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>) {
-// MLIR-NEXT:    firrtl.connect %out, %in : !firrtl.uint<8>, !firrtl.uint<8>
+// MLIR-NEXT:    firrtl.strictconnect %out, %in : !firrtl.uint<8>
 // MLIR-NEXT:  }
 
 // VERILOG-LABEL: module Top(

--- a/test/firtool/optimizations.fir
+++ b/test/firtool/optimizations.fir
@@ -13,17 +13,17 @@ circuit test_cse :
     d <= and(a, UInt<4>(0))
     e <= and(UInt<4>(3), UInt<4>(1))
 
-; OPT-DAG: %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
-; OPT-DAG: %c1_ui4 = firrtl.constant 1 : !firrtl.uint<4>
+; OPT-DAG: %c0_ui5 = firrtl.constant 0 : !firrtl.uint<5>
+; OPT-DAG: %c1_ui5 = firrtl.constant 1 : !firrtl.uint<5>
 
 ; Only one add.
 ; OPT: %0 = firrtl.add %a, %a
-; OPT: firrtl.connect %b, %0
-; OPT: firrtl.connect %c, %0
+; OPT: firrtl.strictconnect %b, %0
+; OPT: firrtl.strictconnect %c, %0
 
 ; Connect with zero and one directly.
-; OPT: firrtl.connect %d, %c0_ui4
-; OPT: firrtl.connect %e, %c1_ui4
+; OPT: firrtl.strictconnect %d, %c0_ui5
+; OPT: firrtl.strictconnect %e, %c1_ui5
 
 ; Both adds persist.
 ; NOOPT: %0 = firrtl.add %a, %a


### PR DESCRIPTION
Strict connect ops have matching types with no implicit behavior.  The goal is to canonicalize ALL connects into this form so that most passes have strong guarantees when processing connects.