### PR TITLE
[HW] Allow OutputOp outside of modules

### DIFF
--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -428,8 +428,7 @@ def InstanceOp : HWOp<"instance", [
   let verifier = "return this->verifyCustom();";
 }
 
-def OutputOp : HWOp<"output", [Terminator, HasParent<"HWModuleOp">,
-                                NoSideEffect, ReturnLike]> {
+def OutputOp : HWOp<"output", [Terminator, NoSideEffect, ReturnLike]> {
   let summary = "HW termination operation";
   let description = [{
     "hw.output" marks the end of a region in the HW dialect and the values

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -295,10 +295,9 @@ FunctionType hw::getModuleType(Operation *moduleOrInstance) {
     return FunctionType::get(instance->getContext(), inputs, results);
   }
 
-  assert(isAnyModule(moduleOrInstance) &&
-         "must be called on instance or module");
   auto typeAttr =
       moduleOrInstance->getAttrOfType<TypeAttr>(HWModuleOp::getTypeAttrName());
+  assert(typeAttr && "must be called on instance or module");
   return typeAttr.getValue().cast<FunctionType>();
 }
 

--- a/test/Dialect/HW/modules.mlir
+++ b/test/Dialect/HW/modules.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
+// RUN: circt-opt %s -verify-diagnostics -allow-unregistered-dialect | circt-opt -verify-diagnostics -allow-unregistered-dialect | FileCheck %s
 
 hw.module @B(%a: i1) -> (nameOfPortInSV: i1, "": i1) {
   %0 = comb.or %a, %a : i1
@@ -56,3 +56,15 @@ hw.module.generated @genmod1, @MEMORY() -> (FOOBAR: i1) attributes {write_latenc
 
 // CHECK-LABEL: hw.module.extern @AnonArg(i42)
 hw.module.extern @AnonArg(i42)
+
+// CHECK-LABEL: hw.module @OutputUsableOutsideModule()
+hw.module @OutputUsableOutsideModule() {
+  // CHECK-NEXT: "imaginary_nested_region_op"() ({
+  // CHECK-NEXT:   [[TMP:%.+]] = hw.constant 0
+  // CHECK-NEXT:   hw.output [[TMP]], [[TMP]]
+  // CHECK-NEXT: })
+  "imaginary_nested_region_op"() ({
+    %c0_i42 = hw.constant 0 : i42
+    hw.output %c0_i42, %c0_i42 : i42, i42
+  }) {type = () -> (i42, i42)} : () -> (i42, i42)
+}


### PR DESCRIPTION
Remove the constraint on `OutputOp` that its parent has to be a `HWModuleOp` specifically. This makes the operation reusable in contexts of other dialects which introduce their own module-like operations with similar semantics to the HW modules. An example is an operation introducing a nested region into the module for some reason, where using the already existing `OutputOp` would be highly desirable. For example:

```mlir
hw.module @Foo() {
  %0 = generator.if %someCond : i42 {
    // ...
    hw.output %x : i42
  } else {
    // ...
    hw.output %y : i42
  }
}
```

As a result, the operation containing the `OutputOp` must merely provide a `FunctionType` attribute named `type`, pretty much like any other builtin-style function in MLIR. In the long term, we might want to add an interface for ops that can act as parent to an `OutputOp`, which we can use to query the required output type signature.