### PR TITLE
[FIRRTL] Add map existence check before lookup ModuleInliner

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -584,12 +584,13 @@ void Inliner::cloneAndRename(
         if (!isa<InstanceOp>(op) || symbolRenames.empty())
           return false;
         NamedAttrList newAnnotation;
-        if (auto newSym =
-                symbolRenames.lookup(sym.getAttr()).cast<StringAttr>()) {
-          anno.setMember("circt.nonlocal", FlatSymbolRefAttr::get(newSym));
-          newAnnotations.push_back(anno);
-          return true;
-        }
+        if (symbolRenames.count(sym.getAttr()))
+          if (auto newSym =
+                  symbolRenames.lookup(sym.getAttr()).cast<StringAttr>()) {
+            anno.setMember("circt.nonlocal", FlatSymbolRefAttr::get(newSym));
+            newAnnotations.push_back(anno);
+            return true;
+          }
       }
       return false;
     });


### PR DESCRIPTION
This commit fixes a bug in ModuleInliner, check if entry exists in map, before the lookup.