### PR TITLE
[MSFT] Make PhysLocation operation and use it instead of an attribute on GlobalRef

### DIFF
--- a/include/circt/Dialect/MSFT/DeviceDB.h
+++ b/include/circt/Dialect/MSFT/DeviceDB.h
@@ -73,7 +73,7 @@ public:
   /// necessary as most often the instance is an extern module.
   struct PlacedInstance {
     ArrayAttr path;
-    llvm::StringRef subpath;
+    StringAttr subpath;
     Operation *op;
   };
 
@@ -93,7 +93,8 @@ public:
   LogicalResult addPlacement(PhysicalRegionRefAttr, PlacedInstance);
   /// Using the operation attributes, add the proper placements to the database.
   /// Return the number of placements which weren't added due to conflicts.
-  size_t addPlacements(FlatSymbolRefAttr rootMod, mlir::Operation *);
+  size_t addPlacements(const hw::SymbolCache &globalRefs,
+                       FlatSymbolRefAttr rootMod, mlir::Operation *);
   /// Walk the entire design adding placements root at the top module.
   size_t addDesignPlacements();
 

--- a/include/circt/Dialect/MSFT/MSFTAttributes.td
+++ b/include/circt/Dialect/MSFT/MSFTAttributes.td
@@ -37,8 +37,7 @@ def PhysLocation : MSFT_Attr<"PhysLocation"> {
   let mnemonic = "physloc";
   let parameters = (ins
     "PrimitiveTypeAttr":$primitiveType,
-    "uint64_t":$x, "uint64_t":$y, "uint64_t":$num,
-    StringRefParameter<"subPath">:$subPath);
+    "uint64_t":$x, "uint64_t":$y, "uint64_t":$num);
 }
 
 def PhysicalBounds : MSFT_Attr<"PhysicalBounds"> {

--- a/include/circt/Dialect/MSFT/MSFTOps.h
+++ b/include/circt/Dialect/MSFT/MSFTOps.h
@@ -13,6 +13,7 @@
 #ifndef CIRCT_DIALECT_MSFT_MSFTOPS_H
 #define CIRCT_DIALECT_MSFT_MSFTOPS_H
 
+#include "circt/Dialect/MSFT/MSFTAttributes.h"
 #include "circt/Dialect/MSFT/MSFTDialect.h"
 #include "circt/Support/LLVM.h"
 

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -231,3 +231,12 @@ def EntityExternOp : MSFTOp<"entity.extern",
     $sym_name $metadata attr-dict
   }];
 }
+
+def PhysLocationOp : MSFTOp<"pd.location"> {
+  let arguments = (ins PhysLocation:$loc,
+                       OptionalAttr<StrAttr>:$subPath,
+                       OptionalAttr<FlatSymbolRefAttr>:$ref);
+  let assemblyFormat = [{
+    ($ref^)? $loc (`path` `:` $subPath^)? attr-dict
+  }];
+}

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1296,6 +1296,8 @@ LogicalResult GlobalRefOp::verifyGlobalRef() {
   static const char globalRefStr[] = "circt.globalRef";
   SymbolTable symTable(parent);
   auto hasGlobalRef = [&](Attribute attr) -> bool {
+    if (!attr)
+      return false;
     for (auto ref : attr.cast<ArrayAttr>().getAsRange<GlobalRefAttr>())
       if (ref.getGlblSym().getAttr() == symNameAttr)
         return true;

--- a/lib/Dialect/MSFT/ExportQuartusTcl.cpp
+++ b/lib/Dialect/MSFT/ExportQuartusTcl.cpp
@@ -68,9 +68,9 @@ void emitPath(TclOutputState &s, PlacementDB::PlacedInstance inst) {
   }
 
   // Some placements don't require subpaths.
-  if (!inst.subpath.empty()) {
+  if (inst.subpath) {
     s.os << '|';
-    s.os << inst.subpath;
+    s.os << inst.subpath.getValue();
   }
 
   s.os << '\n';

--- a/lib/Dialect/MSFT/MSFTAttributes.cpp
+++ b/lib/Dialect/MSFT/MSFTAttributes.cpp
@@ -31,15 +31,7 @@ Attribute PhysLocationAttr::parse(AsmParser &p, Type type) {
 
   if (p.parseLess() || p.parseKeyword(&devTypeStr) || p.parseComma() ||
       p.parseInteger(x) || p.parseComma() || p.parseInteger(y) ||
-      p.parseComma() || p.parseInteger(num))
-    return Attribute();
-
-  // Parse an optional subPath.
-  if (succeeded(p.parseOptionalComma()))
-    if (p.parseString(&subPath))
-      return Attribute();
-
-  if (p.parseGreater())
+      p.parseComma() || p.parseInteger(num) || p.parseGreater())
     return Attribute();
 
   Optional<PrimitiveType> devType = symbolizePrimitiveType(devTypeStr);
@@ -49,20 +41,13 @@ Attribute PhysLocationAttr::parse(AsmParser &p, Type type) {
   }
   PrimitiveTypeAttr devTypeAttr =
       PrimitiveTypeAttr::get(p.getContext(), *devType);
-  auto phy =
-      PhysLocationAttr::get(p.getContext(), devTypeAttr, x, y, num, subPath);
+  auto phy = PhysLocationAttr::get(p.getContext(), devTypeAttr, x, y, num);
   return phy;
 }
 
 void PhysLocationAttr::print(AsmPrinter &p) const {
   p << "<" << stringifyPrimitiveType(getPrimitiveType().getValue()) << ", "
-    << getX() << ", " << getY() << ", " << getNum();
-
-  // Print an optional subPath.
-  if (!getSubPath().empty())
-    p << ", \"" << getSubPath() << '"';
-
-  p << '>';
+    << getX() << ", " << getY() << ", " << getNum() << '>';
 }
 
 Attribute PhysicalRegionRefAttr::parse(AsmParser &p, Type type) {

--- a/lib/Dialect/MSFT/MSFTPasses.cpp
+++ b/lib/Dialect/MSFT/MSFTPasses.cpp
@@ -232,20 +232,16 @@ void LowerToHWPass::runOnOperation() {
   // Convert everything except instance ops first.
 
   ConversionTarget target(*ctxt);
-  target.addIllegalOp<MSFTModuleOp, MSFTModuleExternOp, OutputOp>();
+  target.addIllegalOp<MSFTModuleOp, MSFTModuleExternOp, OutputOp,
+                      hw::GlobalRefOp>();
   target.addLegalDialect<hw::HWDialect>();
   target.addLegalDialect<sv::SVDialect>();
-  target.addDynamicallyLegalOp<hw::GlobalRefOp>([](hw::GlobalRefOp op) {
-    for (auto attr : op->getAttrs())
-      if (isa<MSFTDialect>(attr.getValue().getDialect()))
-        return false;
-    return true;
-  });
 
   RewritePatternSet patterns(ctxt);
   patterns.insert<ModuleOpLowering>(ctxt, verilogFile);
   patterns.insert<ModuleExternOpLowering>(ctxt, verilogFile);
   patterns.insert<OutputOpLowering>(ctxt);
+  patterns.insert<RemoveOpLowering<msft::PhysLocationOp>>(ctxt);
   patterns.insert<RemoveOpLowering<hw::GlobalRefOp>>(ctxt);
   patterns.insert<RemoveOpLowering<EntityExternOp>>(ctxt);
   patterns.insert<RemoveOpLowering<DesignPartitionOp>>(ctxt);

--- a/test/Dialect/MSFT/location.mlir
+++ b/test/Dialect/MSFT/location.mlir
@@ -2,21 +2,18 @@
 // RUN: circt-opt %s --lower-msft-to-hw=tops=shallow,deeper,regions,reg --lower-seq-to-sv | FileCheck %s --check-prefix=LOWER
 // RUN: circt-opt %s --lower-msft-to-hw=tops=shallow,deeper,regions,reg --lower-seq-to-sv --export-verilog | FileCheck %s --check-prefix=TCL
 
-hw.globalRef @ref1 [#hw.innerNameRef<@deeper::@branch>, #hw.innerNameRef<@shallow::@leaf>, #hw.innerNameRef<@leaf::@module>] {
-  "foo" = #msft.physloc<M20K, 15, 9, 3, "memBank2">
-}
+hw.globalRef @ref1 [#hw.innerNameRef<@deeper::@branch>, #hw.innerNameRef<@shallow::@leaf>, #hw.innerNameRef<@leaf::@module>]
+msft.pd.location @ref1 <M20K, 15, 9, 3> path: "memBank2"
 
-hw.globalRef @ref2 [#hw.innerNameRef<@shallow::@leaf>, #hw.innerNameRef<@leaf::@module>] {
-  "bar" = #msft.physloc<M20K, 8, 19, 1, "memBank2">
-}
+hw.globalRef @ref2 [#hw.innerNameRef<@shallow::@leaf>, #hw.innerNameRef<@leaf::@module>]
+msft.pd.location @ref2 <M20K, 8, 19, 1> path: "memBank2"
 
 hw.globalRef @ref3 [#hw.innerNameRef<@regions::@module>] {
   "baz" = #msft.physical_region_ref<@region1>
 }
 
-hw.globalRef @ref4 [#hw.innerNameRef<@reg::@reg>] {
-  "qux" = #msft.physloc<FF, 0, 0, 0>
-}
+hw.globalRef @ref4 [#hw.innerNameRef<@reg::@reg>]
+msft.pd.location @ref4 <FF, 0, 0, 0>
 
 hw.module.extern @Foo()
 


### PR DESCRIPTION
Keep the PhysLocation attribute for the actual physical location. Create
an op to refer to a global ref with the location attribute and the
subpath. Incremental change towards a new approach to dynamic instances.

This PR breaks tcl placement output in the way the integration test and pycde
enters the placements. Will be fixed shortly with the dynamic instance PR.