### PR TITLE
[MSFT] Add verifier to DynInstData op interface

### DIFF
--- a/include/circt/Dialect/MSFT/MSFTOpInterfaces.h
+++ b/include/circt/Dialect/MSFT/MSFTOpInterfaces.h
@@ -14,7 +14,7 @@
 namespace circt {
 namespace msft {
 LogicalResult verifyDynInstData(Operation *);
-}
+} // namespace msft
 } // namespace circt
 #include "circt/Dialect/MSFT/MSFTOpInterfaces.h.inc"
 

--- a/include/circt/Dialect/MSFT/MSFTOpInterfaces.h
+++ b/include/circt/Dialect/MSFT/MSFTOpInterfaces.h
@@ -11,6 +11,11 @@
 
 #include "circt/Dialect/HW/HWOps.h"
 
+namespace circt {
+namespace msft {
+LogicalResult verifyDynInstData(Operation *);
+}
+} // namespace circt
 #include "circt/Dialect/MSFT/MSFTOpInterfaces.h.inc"
 
 #endif // CIRCT_DIALECT_MSFT_MSFTOPINTERFACES_H

--- a/include/circt/Dialect/MSFT/MSFTOpInterfaces.td
+++ b/include/circt/Dialect/MSFT/MSFTOpInterfaces.td
@@ -13,6 +13,9 @@ def DynInstDataOpInterface : OpInterface<"DynInstDataOpInterface"> {
     Interface for anything which needs to refer to a GlobalRefOp.
   }];
   let cppNamespace = "::circt::msft";
+  let verify = [{
+    return ::circt::msft::verifyDynInstData($_op);
+  }];
 
   let methods = [
     InterfaceMethod<
@@ -22,6 +25,13 @@ def DynInstDataOpInterface : OpInterface<"DynInstDataOpInterface"> {
       /*retTy=*/"void",
       /*methodName=*/"setGlobalRef",
       /*args=*/(ins "::circt::hw::GlobalRefOp":$ref)
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Get the symbol of the GlobalRefOp to which this op is referring.
+      }],
+      /*retTy=*/"FlatSymbolRefAttr",
+      /*methodName=*/"getGlobalRefSym"
     >
   ];
 }

--- a/lib/Dialect/MSFT/MSFTOpInterfaces.cpp
+++ b/lib/Dialect/MSFT/MSFTOpInterfaces.cpp
@@ -13,12 +13,9 @@ using namespace circt;
 using namespace msft;
 
 LogicalResult circt::msft::verifyDynInstData(Operation *op) {
-  auto didOp = dyn_cast<DynInstDataOpInterface>(op);
-  if (!didOp)
-    return op->emitOpError("does not have a DynInstData op interface");
-
   auto inst = dyn_cast<DynamicInstanceOp>(op->getParentOp());
-  FlatSymbolRefAttr globalRef = didOp.getGlobalRefSym();
+  FlatSymbolRefAttr globalRef =
+      cast<DynInstDataOpInterface>(op).getGlobalRefSym();
 
   if (inst && globalRef)
     return op->emitOpError("cannot both have a global ref symbol and be a "

--- a/lib/Dialect/MSFT/MSFTOpInterfaces.cpp
+++ b/lib/Dialect/MSFT/MSFTOpInterfaces.cpp
@@ -7,9 +7,27 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/MSFT/MSFTOpInterfaces.h"
+#include "circt/Dialect/MSFT/MSFTOps.h"
 
 using namespace circt;
 using namespace msft;
+
+LogicalResult circt::msft::verifyDynInstData(Operation *op) {
+  auto didOp = dyn_cast<DynInstDataOpInterface>(op);
+  if (!didOp)
+    return op->emitOpError("does not have a DynInstData op interface");
+
+  auto inst = dyn_cast<DynamicInstanceOp>(op->getParentOp());
+  FlatSymbolRefAttr globalRef = didOp.getGlobalRefSym();
+
+  if (inst && globalRef)
+    return op->emitOpError("cannot both have a global ref symbol and be a "
+                           "child of a dynamic instance op");
+  if (!inst && !globalRef)
+    return op->emitOpError("must have either a global ref symbol of belong to "
+                           "a dynamic instance op");
+  return success();
+}
 
 namespace circt {
 namespace msft {

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -58,6 +58,8 @@ static void printPhysLoc(OpAsmPrinter &p, Operation *, PhysLocationAttr loc) {
     << " x: " << loc.getX() << " y: " << loc.getY() << " n: " << loc.getNum();
 }
 
+FlatSymbolRefAttr PhysLocationOp::getGlobalRefSym() { return refAttr(); }
+
 void PhysLocationOp::setGlobalRef(hw::GlobalRefOp ref) {
   refAttr(FlatSymbolRefAttr::get(ref));
 }

--- a/test/Dialect/MSFT/dynamic_instance.mlir
+++ b/test/Dialect/MSFT/dynamic_instance.mlir
@@ -10,7 +10,7 @@ msft.instance.dynamic [#hw.innerNameRef<@shallow::@leaf>, #hw.innerNameRef<@leaf
 }
 
 msft.instance.dynamic [#hw.innerNameRef<@reg::@reg>] {
-  msft.pd.location @ref4 FF x: 0 y: 0 n: 0
+  msft.pd.location FF x: 0 y: 0 n: 0
 }
 
 hw.module.extern @Foo()

--- a/test/Dialect/MSFT/opt-errors.mlir
+++ b/test/Dialect/MSFT/opt-errors.mlir
@@ -20,3 +20,15 @@ hw.module @M() {
   // expected-error @+1 {{Cannot find module definition 'Bar'}}
   msft.instance @instance @Bar () : () -> ()
 }
+
+// -----
+
+msft.instance.dynamic [#hw.innerNameRef<@reg::@reg>] {
+  // expected-error @+1 {{'msft.pd.location' op cannot both have a global ref symbol and be a child of a dynamic instance op}}
+  msft.pd.location @ref FF x: 0 y: 0 n: 0
+}
+
+// -----
+
+// expected-error @+1 {{'msft.pd.location' op must have either a global ref symbol of belong to a dynamic instance op}}
+msft.pd.location FF x: 0 y: 0 n: 0


### PR DESCRIPTION
Ops using this interface must either be in a dynamic instance op block
XOR have a symbol pointing to a global ref.