### PR TITLE
[FIRRTL] Donot add NLA for OMIR, if already exists.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -286,7 +286,7 @@ void EmitOMIRPass::runOnOperation() {
             dyn_cast_or_null<NonLocalAnchor>(symtbl->lookup(nlaSym.getAttr()));
         removeTempNLAs.push_back(tracker.nla);
       }
-      if (sramIDs.erase(tracker.id))
+      if (sramIDs.erase(tracker.id) && !tracker.nla)
         makeTrackerAbsolute(tracker);
       trackers.insert({tracker.id, tracker});
       return true;

--- a/test/Dialect/FIRRTL/emit-omir.mlir
+++ b/test/Dialect/FIRRTL/emit-omir.mlir
@@ -331,6 +331,50 @@ firrtl.circuit "SRAMPaths" attributes {annotations = [{
 // CHECK-SAME:  ]
 
 //===----------------------------------------------------------------------===//
+// Make SRAM Paths Absolute with existing NLAs (`SetOMIRSRAMPaths`)
+//===----------------------------------------------------------------------===//
+
+firrtl.circuit "SRAMPathsWithNLA" attributes {annotations = [{
+  class = "freechips.rocketchip.objectmodel.OMIRAnnotation",
+  nodes = [
+    {
+      info = #loc,
+      id = "OMID:1",
+      fields = {
+        omType = {info = #loc, index = 0, value = ["OMString:OMLazyModule", "OMString:OMSRAM"]},
+        finalPath = {info = #loc, index = 1, value = {omir.tracker, id = 1, type = "OMMemberReferenceTarget"}}
+      }
+    }
+  ]
+}]} {
+  firrtl.nla @nla [#hw.innerNameRef<@SRAMPathsWithNLA::@s1>, #hw.innerNameRef<@Submodule::@m1>]
+  firrtl.module @Submodule() {
+    %mem2_port = firrtl.mem sym @m1 Undefined {annotations = [{circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 1}], depth = 8, name = "mem2", portNames = ["port"], readLatency = 0 : i32, writeLatency = 1 : i32 } : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<42>>
+  }
+  firrtl.module @SRAMPathsWithNLA() {
+    firrtl.instance sub  sym @s1 {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}, {circt.nonlocal = @nla1, class = "circt.nonlocal"}]} @Submodule()
+    firrtl.instance sub1 sym @s2  @Submodule()
+  }
+}
+// CHECK-LABEL: firrtl.circuit "SRAMPathsWithNLA"
+// CHECK:  sv.verbatim
+// CHECK-SAME:  id\22: \22OMID:1\22
+// CHECK-SAME:    \22name\22: \22omType\22
+// CHECK-SAME:    \22value\22: [
+// CHECK-SAME:      \22OMString:OMLazyModule\22
+// CHECK-SAME:      \22OMString:OMSRAM\22
+// CHECK-SAME:    ]
+// CHECK-SAME:    \22name\22: \22finalPath\22
+// CHECK-SAME:    \22value\22: \22OMMemberInstanceTarget:~SRAMPathsWithNLA|{{[{][{]0[}][}]}}/{{[{][{]1[}][}]}}:{{[{][{]2[}][}]}}/{{[{][{]3[}][}]}}:{{[^\\]+}}\22
+
+// CHECK-SAME:  symbols = [
+// CHECK-SAME:    @SRAMPathsWithNLA,
+// CHECK-SAME:    #hw.innerNameRef<@SRAMPathsWithNLA::[[SYMSUB:@[a-zA-Z0-9_]+]]>,
+// CHECK-SAME:    @Submodule,
+// CHECK-SAME:    #hw.innerNameRef<@Submodule::[[SYMMEM1:@[a-zA-Z0-9_]+]]>
+// CHECK-SAME:  ]
+
+//===----------------------------------------------------------------------===//
 // Add module port information to the OMIR (`SetOMIRPorts`)
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
Skip adding a new NLA if it already exists for an `SRAM`.
This fixes a crash with `dedup` enabled.