### PR TITLE
[FIRRTL][Dedup] Merge location information

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -873,6 +873,8 @@ private:
   // NOLINTNEXTLINE(misc-no-recursion)
   void mergeOps(RenameMap &renameMap, FModuleLike toModule, Operation *to,
                 FModuleLike fromModule, Operation *from) {
+    // Merge the operation locations.
+    to->setLoc(FusedLoc::get(context, {to->getLoc(), from->getLoc()}));
 
     // Recurse into any regions.
     for (auto regions : llvm::zip(to->getRegions(), from->getRegions()))

--- a/test/Dialect/FIRRTL/dedup-locations.mlir
+++ b/test/Dialect/FIRRTL/dedup-locations.mlir
@@ -1,0 +1,18 @@
+// RUN: circt-opt -mlir-print-debuginfo -mlir-print-local-scope -pass-pipeline='firrtl.circuit(firrtl-dedup)' %s | FileCheck %s
+
+firrtl.circuit "Test" {
+// CHECK-LABEL: @Dedup0()
+firrtl.module @Dedup0() {
+  // CHECK: %w = firrtl.wire  : !firrtl.uint<1> loc(fused["foo", "bar"])
+  %w = firrtl.wire : !firrtl.uint<1> loc("foo")
+} loc("dedup0")
+// CHECK: loc(fused["dedup0", "dedup1"])
+// CHECK-NOT: @Dedup1()
+firrtl.module @Dedup1() {
+  %w = firrtl.wire : !firrtl.uint<1> loc("bar")
+} loc("dedup1")
+firrtl.module @Test() {
+  firrtl.instance dedup0 @Dedup0()
+  firrtl.instance dedup1 @Dedup1()
+}
+}


### PR DESCRIPTION
This adds support for fusing location information when two modules are
deduplicated with each other.