### PR TITLE
[MSFT] [ExportTcl] Ween off of DeviceDB

### DIFF
--- a/include/circt/Dialect/MSFT/ExportTcl.h
+++ b/include/circt/Dialect/MSFT/ExportTcl.h
@@ -13,6 +13,7 @@
 #ifndef CIRCT_DIALECT_MSFT_EXPORTTCL_H
 #define CIRCT_DIALECT_MSFT_EXPORTTCL_H
 
+#include "circt/Dialect/MSFT/MSFTOpInterfaces.h"
 #include "circt/Support/LLVM.h"
 #include "llvm/ADT/StringRef.h"
 
@@ -24,9 +25,24 @@ class SymbolCache;
 namespace msft {
 class MSFTModuleOp;
 
-/// Export TCL for a specific hw module.
-mlir::LogicalResult exportQuartusTcl(Operation *module,
-                                     StringRef outputFile = "");
+/// Instantiate for all Tcl emissions. We want to cache the symbols and binned
+/// ops -- this helper class provides that caching.
+class TclEmitter {
+public:
+  TclEmitter(mlir::ModuleOp topLevel);
+  LogicalResult emit(Operation *forMod, StringRef outputFile);
+
+  Operation *getDefinition(FlatSymbolRefAttr);
+
+private:
+  mlir::ModuleOp topLevel;
+
+  bool populated;
+  hw::SymbolCache topLevelSymbols;
+  DenseMap<Operation *, SmallVector<DynInstDataOpInterface, 0>> tclOpsForMod;
+
+  LogicalResult populate();
+};
 
 } // namespace msft
 } // namespace circt

--- a/lib/Dialect/MSFT/ExportQuartusTcl.cpp
+++ b/lib/Dialect/MSFT/ExportQuartusTcl.cpp
@@ -30,13 +30,55 @@ using namespace circt;
 using namespace hw;
 using namespace msft;
 
-// TODO: Currently assumes Stratix 10 and QuartusPro. Make more general.
+TclEmitter::TclEmitter(mlir::ModuleOp topLevel)
+    : topLevel(topLevel), populated(false) {}
 
+LogicalResult TclEmitter::populate() {
+  if (populated)
+    return success();
+
+  // Populated the symbol cache.
+  for (auto symOp : topLevel.getOps<mlir::SymbolOpInterface>())
+    if (auto name = symOp.getNameAttr())
+      topLevelSymbols.addDefinition(name, symOp);
+  topLevelSymbols.freeze();
+  populated = true;
+
+  // Bin any operations we may need to emit based on the root module in the
+  // instance hierarchy path.
+  for (auto tclOp : topLevel.getOps<DynInstDataOpInterface>()) {
+    FlatSymbolRefAttr refSym = tclOp.getGlobalRefSym();
+    if (!refSym)
+      return tclOp->emitOpError("must run dynamic instance lowering first");
+    auto ref = dyn_cast_or_null<hw::GlobalRefOp>(
+        topLevelSymbols.getDefinition(refSym));
+    if (!ref)
+      return tclOp->emitOpError("could not find hw.globalRef ") << refSym;
+    if (ref.namepath().empty())
+      continue;
+    auto modSym = FlatSymbolRefAttr::get(
+        ref.namepath()[0].cast<hw::InnerRefAttr>().getModule());
+    Operation *mod = topLevelSymbols.getDefinition(modSym);
+    assert(mod &&
+           "Invalid IR -- should have been caught by GlobalRef verifier");
+    tclOpsForMod[mod].push_back(tclOp);
+  }
+  return success();
+}
+
+Operation *TclEmitter::getDefinition(FlatSymbolRefAttr sym) {
+  if (failed(populate()))
+    return nullptr;
+  return topLevelSymbols.getDefinition(sym);
+}
+
+// TODO: Currently assumes Stratix 10 and QuartusPro. Make more general.
 namespace {
 /// Utility struct to assist in output and track other relevent state which are
 /// not specific to the entity hierarchy (global WRT to the entity hierarchy).
 struct TclOutputState {
-  TclOutputState(llvm::raw_ostream &os) : os(os) {}
+  TclOutputState(TclEmitter &emitter, llvm::raw_ostream &os)
+      : os(os), emitter(emitter) {}
 
   llvm::raw_ostream &os;
   llvm::raw_ostream &indent() {
@@ -44,44 +86,55 @@ struct TclOutputState {
     return os;
   };
 
+  TclEmitter &emitter;
   SmallVector<Attribute> symbolRefs;
+
+  LogicalResult emit(PDPhysRegionOp region);
+  LogicalResult emit(PDPhysLocationOp loc);
+
+  void emitPath(hw::GlobalRefOp ref, Optional<StringRef> subpath);
+  void emitInnerRefPart(hw::InnerRefAttr innerRef);
 };
 } // anonymous namespace
 
-void emitInnerRefPart(TclOutputState &s, hw::InnerRefAttr innerRef) {
+void TclOutputState::emitInnerRefPart(hw::InnerRefAttr innerRef) {
   // We append new symbolRefs to the state, so s.symbolRefs.size() is the
   // index of the InnerRefAttr we are about to add.
-  s.os << "{{" << s.symbolRefs.size() << "}}";
+  os << "{{" << symbolRefs.size() << "}}";
 
   // Append a new inner reference for the template above.
-  s.symbolRefs.push_back(innerRef);
+  symbolRefs.push_back(innerRef);
 }
 
-void emitPath(TclOutputState &s, PlacementDB::PlacedInstance inst) {
+void TclOutputState::emitPath(hw::GlobalRefOp ref,
+                              Optional<StringRef> subpath) {
   // Traverse each part of the path.
-  auto parts = inst.path.getAsRange<hw::InnerRefAttr>();
+  auto parts = ref.namepathAttr().getAsRange<hw::InnerRefAttr>();
   auto lastPart = std::prev(parts.end());
   for (auto part : parts) {
-    emitInnerRefPart(s, part);
+    emitInnerRefPart(part);
     if (part != *lastPart)
-      s.os << '|';
+      os << '|';
   }
 
   // Some placements don't require subpaths.
-  if (inst.subpath) {
-    s.os << '|';
-    s.os << inst.subpath.getValue();
-  }
+  if (subpath)
+    os << '|' << subpath;
 
-  s.os << '\n';
+  os << '\n';
 }
 
 /// Emit tcl in the form of:
 /// "set_location_assignment MPDSP_X34_Y285_N0 -to $parent|fooInst|entityName"
-static void emit(TclOutputState &s, PlacementDB::PlacedInstance inst,
-                 PhysLocationAttr pla) {
+LogicalResult TclOutputState::emit(PDPhysLocationOp loc) {
 
-  s.indent() << "set_location_assignment ";
+  auto ref =
+      dyn_cast_or_null<hw::GlobalRefOp>(emitter.getDefinition(loc.refAttr()));
+  if (!ref)
+    return loc.emitOpError("could not find hw.globalRef named ")
+           << loc.refAttr();
+  PhysLocationAttr pla = loc.loc();
+  indent() << "set_location_assignment ";
 
   // Different devices have different 'number' letters (the 'N' in 'N0'). M20Ks
   // and DSPs happen to have the same one, probably because they never co-exist
@@ -89,26 +142,27 @@ static void emit(TclOutputState &s, PlacementDB::PlacedInstance inst,
   char numCharacter;
   switch (pla.getPrimitiveType().getValue()) {
   case PrimitiveType::M20K:
-    s.os << "M20K";
+    os << "M20K";
     numCharacter = 'N';
     break;
   case PrimitiveType::DSP:
-    s.os << "MPDSP";
+    os << "MPDSP";
     numCharacter = 'N';
     break;
   case PrimitiveType::FF:
-    s.os << "FF";
+    os << "FF";
     numCharacter = 'N';
     break;
   }
 
   // Write out the rest of the location info.
-  s.os << "_X" << pla.getX() << "_Y" << pla.getY() << "_" << numCharacter
-       << pla.getNum();
+  os << "_X" << pla.getX() << "_Y" << pla.getY() << "_" << numCharacter
+     << pla.getNum();
 
   // To which entity does this apply?
-  s.os << " -to $parent|";
-  emitPath(s, inst);
+  os << " -to $parent|";
+  emitPath(ref, loc.subPath());
+  return success();
 }
 
 /// Emit tcl in the form of:
@@ -116,92 +170,83 @@ static void emit(TclOutputState &s, PlacementDB::PlacedInstance inst,
 /// set_instance_assignment -name RESERVE_PLACE_REGION OFF -to $parent|a|b|c
 /// set_instance_assignment -name CORE_ONLY_PLACE_REGION ON -to $parent|a|b|c
 /// set_instance_assignment -name REGION_NAME test_region -to $parent|a|b|c
-static void emit(TclOutputState &s, PlacementDB::PlacedInstance inst,
-                 PDPhysRegionOp regionRef) {
-  auto topModule = inst.op->getParentOfType<mlir::ModuleOp>();
-  auto physicalRegion = topModule.lookupSymbol<DeclPhysicalRegionOp>(
-      regionRef.physRegionRefAttr());
-  assert(physicalRegion && "must reference an existant physical region");
+LogicalResult TclOutputState::emit(PDPhysRegionOp region) {
+  auto ref = dyn_cast_or_null<hw::GlobalRefOp>(
+      emitter.getDefinition(region.refAttr()));
+  if (!ref)
+    return region.emitOpError("could not find hw.globalRef named ")
+           << region.refAttr();
+
+  auto physicalRegion = dyn_cast_or_null<DeclPhysicalRegionOp>(
+      emitter.getDefinition(region.physRegionRefAttr()));
+  if (!physicalRegion)
+    return region.emitOpError(
+               "could not find physical region declaration named ")
+           << region.physRegionRefAttr();
 
   // PLACE_REGION directive.
-  s.indent() << "set_instance_assignment -name PLACE_REGION \"";
+  indent() << "set_instance_assignment -name PLACE_REGION \"";
   auto physicalBounds =
       physicalRegion.bounds().getAsRange<PhysicalBoundsAttr>();
   llvm::interleave(
-      physicalBounds, s.os,
-      [&s](PhysicalBoundsAttr bounds) {
-        s.os << 'X' << bounds.getXMin() << ' ';
-        s.os << 'Y' << bounds.getYMin() << ' ';
-        s.os << 'X' << bounds.getXMax() << ' ';
-        s.os << 'Y' << bounds.getYMax();
+      physicalBounds, os,
+      [&](PhysicalBoundsAttr bounds) {
+        os << 'X' << bounds.getXMin() << ' ';
+        os << 'Y' << bounds.getYMin() << ' ';
+        os << 'X' << bounds.getXMax() << ' ';
+        os << 'Y' << bounds.getYMax();
       },
       ";");
-  s.os << '"';
-  s.os << " -to $parent|";
-  emitPath(s, inst);
+  os << '"';
+
+  os << " -to $parent|";
+  emitPath(ref, region.subPath());
 
   // RESERVE_PLACE_REGION directive.
-  s.indent() << "set_instance_assignment -name RESERVE_PLACE_REGION OFF";
-  s.os << " -to $parent|";
-  emitPath(s, inst);
+  indent() << "set_instance_assignment -name RESERVE_PLACE_REGION OFF";
+  os << " -to $parent|";
+  emitPath(ref, region.subPath());
 
   // CORE_ONLY_PLACE_REGION directive.
-  s.indent() << "set_instance_assignment -name CORE_ONLY_PLACE_REGION ON";
-  s.os << " -to $parent|";
-  emitPath(s, inst);
+  indent() << "set_instance_assignment -name CORE_ONLY_PLACE_REGION ON";
+  os << " -to $parent|";
+  emitPath(ref, region.subPath());
 
   // REGION_NAME directive.
-  s.indent() << "set_instance_assignment -name REGION_NAME ";
-  s.os << physicalRegion.getName();
-  s.os << " -to $parent|";
-  emitPath(s, inst);
-}
-
-static bool isEntityExtern(Operation *op) {
-  auto globalRef = cast<hw::GlobalRefOp>(op);
-  auto path = globalRef.namepath().getValue();
-  auto leafRef = path.back().dyn_cast<FlatSymbolRefAttr>();
-  if (!leafRef)
-    return false;
-
-  auto rootMod = op->getParentOfType<mlir::ModuleOp>();
-  auto *leafRefOp = rootMod.lookupSymbol(leafRef);
-  return isa<EntityExternOp>(leafRefOp);
+  indent() << "set_instance_assignment -name REGION_NAME ";
+  os << physicalRegion.getName();
+  os << " -to $parent|";
+  emitPath(ref, region.subPath());
+  return success();
 }
 
 /// Write out all the relevant tcl commands. Create one 'proc' per module which
 /// takes the parent entity name since we don't assume that the created module
 /// is the top level for the entire design.
-LogicalResult circt::msft::exportQuartusTcl(Operation *hwMod,
-                                            StringRef outputFile) {
+LogicalResult TclEmitter::emit(Operation *hwMod, StringRef outputFile) {
+  if (failed(populate()))
+    return failure();
+
   // Build up the output Tcl, tracking symbol references in state.
   std::string s;
   llvm::raw_string_ostream os(s);
-  TclOutputState state(os);
-  PlacementDB db(hwMod);
-  size_t failures = db.addDesignPlacements();
-  if (failures != 0)
-    return hwMod->emitError("Could not place ") << failures << " instances";
-
+  TclOutputState state(*this, os);
   os << "proc {{" << state.symbolRefs.size() << "}}_config { parent } {\n";
   state.symbolRefs.push_back(SymbolRefAttr::get(hwMod));
 
-  db.walkPlacements(
-      [&state](PhysLocationAttr loc, PlacementDB::PlacedInstance inst) {
-        // Skip entities which we don't need to emit placements for.
-        if (isEntityExtern(inst.op))
-          return;
-        emit(state, inst, loc);
-      });
-
-  db.walkRegionPlacements(
-      [&state](PDPhysRegionOp regionRef, PlacementDB::PlacedInstance inst) {
-        // Skip entities which we don't need to emit placements for.
-        if (isEntityExtern(inst.op))
-          return;
-        emit(state, inst, regionRef);
-      });
-
+  // Loop through the ops relevant to the specified root module.
+  LogicalResult ret = success();
+  for (Operation *tclOp : tclOpsForMod[hwMod]) {
+    LogicalResult rc =
+        TypeSwitch<Operation *, LogicalResult>(tclOp)
+            .Case([&](PDPhysLocationOp op) { return state.emit(op); })
+            .Case([&](PDPhysRegionOp op) { return state.emit(op); })
+            .Default([](Operation *op) {
+              return op->emitOpError("could not determine how to output tcl");
+            });
+    if (failed(rc))
+      ret = failure();
+  }
   os << "}\n\n";
 
   // Create a verbatim op containing the Tcl and symbol references.

--- a/lib/Dialect/MSFT/MSFTPasses.cpp
+++ b/lib/Dialect/MSFT/MSFTPasses.cpp
@@ -470,14 +470,14 @@ struct ExportTclPass : public ExportTclBase<ExportTclPass> {
 void ExportTclPass::runOnOperation() {
   auto top = getOperation();
   auto *ctxt = &getContext();
+  TclEmitter emitter(top);
 
   // Traverse MSFT location attributes and export the required Tcl into
   // templated `sv::VerbatimOp`s with symbolic references to the instance paths.
   for (auto moduleName : tops) {
-    Operation *hwmod = top.lookupSymbol(moduleName);
-    if (!hwmod)
-      continue;
-    if (failed(exportQuartusTcl(hwmod, tclFile)))
+    Operation *hwmod =
+        emitter.getDefinition(FlatSymbolRefAttr::get(ctxt, moduleName));
+    if (!hwmod || failed(emitter.emit(hwmod, tclFile)))
       return signalPassFailure();
   }
 

--- a/test/Dialect/MSFT/translate-errors.mlir
+++ b/test/Dialect/MSFT/translate-errors.mlir
@@ -2,12 +2,10 @@
 
 hw.module.extern @Foo()
 
-// expected-error @+1 {{'hw.globalRef' op referenced non-existant PhysicalRegion named @region1}}
 hw.globalRef @ref [#hw.innerNameRef<@top::@foo1>]
+// expected-error @+1 {{'msft.pd.physregion' op could not find physical region declaration named @region1}}
 msft.pd.physregion @ref @region1
 
-
-// expected-error @+1 {{Could not place 1 instances}}
 msft.module @top {} () -> () {
   msft.instance @foo1 @Foo() {circt.globalRef = [#hw.globalNameRef<@ref>], inner_sym = "foo1"} : () -> ()
   msft.output


### PR DESCRIPTION
Since DeviceDB will be re-oriented around the new dynamic instance op
and export tcl is run after lowering away the dynamic instance ops, we
can't use the DeviceDB.