### PR TITLE
[NFC] Fix warnings when build the release type.

### DIFF
--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -218,8 +218,8 @@ getPortInfoForOp(ConversionPatternRewriter &rewriter, Operation *op) {
 /// operator which references the memref input argument.
 static FIRRTLType getMemrefBundleType(ConversionPatternRewriter &rewriter,
                                       Value blockArg, bool flip) {
-  auto memrefType = blockArg.getType().dyn_cast<MemRefType>();
-  assert(memrefType && "expected blockArg to be a memref");
+  assert(blockArg.getType().dyn_cast<MemRefType>() &&
+         "expected blockArg to be a memref");
 
   auto extmemUsers = blockArg.getUsers();
   assert(std::distance(extmemUsers.begin(), extmemUsers.end()) == 1 &&

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -218,8 +218,8 @@ getPortInfoForOp(ConversionPatternRewriter &rewriter, Operation *op) {
 /// operator which references the memref input argument.
 static FIRRTLType getMemrefBundleType(ConversionPatternRewriter &rewriter,
                                       Value blockArg, bool flip) {
-  assert(blockArg.getType().dyn_cast<MemRefType>() &&
-         "expected blockArg to be a memref");
+  auto memrefType = blockArg.getType().dyn_cast<MemRefType>();
+  assert(memrefType && "expected blockArg to be a memref");
 
   auto extmemUsers = blockArg.getUsers();
   assert(std::distance(extmemUsers.begin(), extmemUsers.end()) == 1 &&

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -218,7 +218,7 @@ getPortInfoForOp(ConversionPatternRewriter &rewriter, Operation *op) {
 /// operator which references the memref input argument.
 static FIRRTLType getMemrefBundleType(ConversionPatternRewriter &rewriter,
                                       Value blockArg, bool flip) {
-  assert(blockArg.getType().dyn_cast<MemRefType>() &&
+  assert(blockArg.getType().isa<MemRefType>() &&
          "expected blockArg to be a memref");
 
   auto extmemUsers = blockArg.getUsers();

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -263,8 +263,8 @@ public:
 
   /// Registers a unique name for a given operation using a provided prefix.
   void setUniqueName(Operation *op, StringRef prefix) {
-    auto it = opNames.find(op);
-    assert(it == opNames.end() && "A unique name was already set for op");
+    assert(opNames.find(op) == opNames.end() &&
+           "A unique name was already set for op");
     opNames[op] = getUniqueName(prefix);
   }
 
@@ -2447,8 +2447,7 @@ public:
   }
 
   LogicalResult runPartialPattern(RewritePatternSet &pattern, bool runOnce) {
-    auto &nativePatternSet = pattern.getNativePatterns();
-    assert(nativePatternSet.size() == 1 &&
+    assert(pattern.getNativePatterns().size() == 1 &&
            "Should only apply 1 partial lowering pattern at once");
 
     // During component creation, the function body is inlined into the

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -263,8 +263,8 @@ public:
 
   /// Registers a unique name for a given operation using a provided prefix.
   void setUniqueName(Operation *op, StringRef prefix) {
-    assert(opNames.find(op) == opNames.end() &&
-           "A unique name was already set for op");
+    auto it = opNames.find(op);
+    assert(it == opNames.end() && "A unique name was already set for op");
     opNames[op] = getUniqueName(prefix);
   }
 
@@ -2447,7 +2447,8 @@ public:
   }
 
   LogicalResult runPartialPattern(RewritePatternSet &pattern, bool runOnce) {
-    assert(pattern.getNativePatterns().size() == 1 &&
+    auto &nativePatternSet = pattern.getNativePatterns();
+    assert(nativePatternSet.size() == 1 &&
            "Should only apply 1 partial lowering pattern at once");
 
     // During component creation, the function body is inlined into the

--- a/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
+++ b/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
@@ -965,7 +965,7 @@ void LoopNetworkRewriter::buildExitNetwork(Block *loopHeader,
     Operation *trueUser = *condBr.trueResult().getUsers().begin();
     Operation *falseUser = *condBr.falseResult().getUsers().begin();
     bool isTrueParity = trueUser->getBlock() == exitBlock;
-    [[maybe_unused]] bool isFalseParity = falseUser->getBlock() == exitBlock;
+    bool isFalseParity = falseUser->getBlock() == exitBlock;
     assert(isTrueParity ^ isFalseParity &&
            "The user of either the true or the false result should be in the "
            "exit block");

--- a/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
+++ b/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
@@ -965,7 +965,7 @@ void LoopNetworkRewriter::buildExitNetwork(Block *loopHeader,
     Operation *trueUser = *condBr.trueResult().getUsers().begin();
     Operation *falseUser = *condBr.falseResult().getUsers().begin();
     bool isTrueParity = trueUser->getBlock() == exitBlock;
-    bool isFalseParity = falseUser->getBlock() == exitBlock;
+    [[maybe_unused]] bool isFalseParity = falseUser->getBlock() == exitBlock;
     assert(isTrueParity ^ isFalseParity &&
            "The user of either the true or the false result should be in the "
            "exit block");

--- a/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
+++ b/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
@@ -963,10 +963,10 @@ void LoopNetworkRewriter::buildExitNetwork(Block *loopHeader,
         condBr &&
         "Expected a conditional control branch op in the loop condition block");
     Operation *trueUser = *condBr.trueResult().getUsers().begin();
-    Operation *falseUser = *condBr.falseResult().getUsers().begin();
     bool isTrueParity = trueUser->getBlock() == exitBlock;
-    bool isFalseParity = falseUser->getBlock() == exitBlock;
-    assert(isTrueParity ^ isFalseParity &&
+    assert(isTrueParity ^
+               ((*condBr.falseResult().getUsers().begin())->getBlock() ==
+                exitBlock) &&
            "The user of either the true or the false result should be in the "
            "exit block");
 

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -595,9 +595,7 @@ static bool narrowExtractWidth(ExtractOp outerExtractOp,
                                     /* narrowTrailingBits= */ true, rewriter);
       })
       .Case<MuxOp>([&](MuxOp innerOp) {
-        Type type = innerOp.getType();
-
-        assert(type.isa<IntegerType>() &&
+        assert(innerOp.getType().isa<IntegerType>() &&
                "extract() requires input to be of type IntegerType!");
 
         auto cond = innerOp.cond();

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -595,7 +595,9 @@ static bool narrowExtractWidth(ExtractOp outerExtractOp,
                                     /* narrowTrailingBits= */ true, rewriter);
       })
       .Case<MuxOp>([&](MuxOp innerOp) {
-        assert(innerOp.getType().isa<IntegerType>() &&
+        Type type = innerOp.getType();
+
+        assert(type.isa<IntegerType>() &&
                "extract() requires input to be of type IntegerType!");
 
         auto cond = innerOp.cond();

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
@@ -615,8 +615,7 @@ Attribute
 OpAnnoTarget::getNLAReference(ModuleNamespace &moduleNamespace) const {
   // If the op is a module, just return the module name.
   if (auto module = llvm::dyn_cast<FModuleLike>(getOp())) {
-    auto moduleName = module.moduleNameAttr();
-    assert(moduleName && "invalid NLA reference");
+    assert(module.moduleNameAttr() && "invalid NLA reference");
     return FlatSymbolRefAttr::get(module.moduleNameAttr());
   }
   // Return an inner-ref to the target.

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
@@ -615,7 +615,8 @@ Attribute
 OpAnnoTarget::getNLAReference(ModuleNamespace &moduleNamespace) const {
   // If the op is a module, just return the module name.
   if (auto module = llvm::dyn_cast<FModuleLike>(getOp())) {
-    assert(module.moduleNameAttr() && "invalid NLA reference");
+    auto moduleName = module.moduleNameAttr();
+    assert(moduleName && "invalid NLA reference");
     return FlatSymbolRefAttr::get(module.moduleNameAttr());
   }
   // Return an inner-ref to the target.

--- a/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
@@ -292,9 +292,9 @@ Operation *FIRRTLDialect::materializeConstant(OpBuilder &builder,
           loc, type,
           builder.getBoolAttr(attrValue.getValue().isAllOnesValue()));
 
-    auto intType = type.cast<IntType>();
-    assert((!intType.hasWidth() || (unsigned)intType.getWidthOrSentinel() ==
-                                       attrValue.getValue().getBitWidth()) &&
+    assert((!type.cast<IntType>().hasWidth() ||
+            (unsigned)type.cast<IntType>().getWidthOrSentinel() ==
+                attrValue.getValue().getBitWidth()) &&
            "type/value width mismatch materializing constant");
     return builder.create<ConstantOp>(loc, type, attrValue);
   }

--- a/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
@@ -292,7 +292,7 @@ Operation *FIRRTLDialect::materializeConstant(OpBuilder &builder,
           loc, type,
           builder.getBoolAttr(attrValue.getValue().isAllOnesValue()));
 
-    auto intType = type.cast<IntType>();
+    [[maybe_unused]] auto intType = type.cast<IntType>();
     assert((!intType.hasWidth() || (unsigned)intType.getWidthOrSentinel() ==
                                        attrValue.getValue().getBitWidth()) &&
            "type/value width mismatch materializing constant");

--- a/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
@@ -292,7 +292,7 @@ Operation *FIRRTLDialect::materializeConstant(OpBuilder &builder,
           loc, type,
           builder.getBoolAttr(attrValue.getValue().isAllOnesValue()));
 
-    [[maybe_unused]] auto intType = type.cast<IntType>();
+    auto intType = type.cast<IntType>();
     assert((!intType.hasWidth() || (unsigned)intType.getWidthOrSentinel() ==
                                        attrValue.getValue().getBitWidth()) &&
            "type/value width mismatch materializing constant");

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -621,7 +621,6 @@ void FModuleOp::insertPorts(ArrayRef<std::pair<unsigned, PortInfo>> ports) {
 void FModuleOp::erasePorts(ArrayRef<unsigned> portIndices) {
   if (portIndices.empty())
     return;
-  unsigned numPorts = getNumPorts();
 
   // Drop the direction markers for dead ports.
   SmallVector<Direction> portDirections =
@@ -630,11 +629,11 @@ void FModuleOp::erasePorts(ArrayRef<unsigned> portIndices) {
   ArrayRef<Attribute> portTypes = this->getPortTypes();
   ArrayRef<Attribute> portAnnos = this->getPortAnnotations();
   ArrayRef<Attribute> portSyms = this->getPortSymbols();
-  assert(portDirections.size() == numPorts);
-  assert(portNames.size() == numPorts);
-  assert(portAnnos.size() == numPorts || portAnnos.empty());
-  assert(portTypes.size() == numPorts);
-  assert(portSyms.size() == numPorts || portSyms.empty());
+  assert(portDirections.size() == getNumPorts());
+  assert(portNames.size() == getNumPorts());
+  assert(portAnnos.size() == getNumPorts() || portAnnos.empty());
+  assert(portTypes.size() == getNumPorts());
+  assert(portSyms.size() == getNumPorts() || portSyms.empty());
 
   SmallVector<Direction> newPortDirections =
       removeElementsAtIndices<Direction>(portDirections, portIndices);

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -621,7 +621,7 @@ void FModuleOp::insertPorts(ArrayRef<std::pair<unsigned, PortInfo>> ports) {
 void FModuleOp::erasePorts(ArrayRef<unsigned> portIndices) {
   if (portIndices.empty())
     return;
-  [[maybe_unused]] unsigned numPorts = getNumPorts();
+  unsigned numPorts = getNumPorts();
 
   // Drop the direction markers for dead ports.
   SmallVector<Direction> portDirections =

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -621,7 +621,7 @@ void FModuleOp::insertPorts(ArrayRef<std::pair<unsigned, PortInfo>> ports) {
 void FModuleOp::erasePorts(ArrayRef<unsigned> portIndices) {
   if (portIndices.empty())
     return;
-  unsigned numPorts = getNumPorts();
+  [[maybe_unused]] unsigned numPorts = getNumPorts();
 
   // Drop the direction markers for dead ports.
   SmallVector<Direction> portDirections =

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -557,8 +557,7 @@ private:
         if (innerRef.getModule() == fromName) {
           auto to = renameMap[innerRef.getName()];
           assert(to && "should have been renamed");
-          namepath.push_back(
-              InnerRefAttr::get(toName, renameMap[innerRef.getName()]));
+          namepath.push_back(InnerRefAttr::get(toName, to));
         } else
           namepath.push_back(element);
       } else if (element == fromRef) {

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -555,8 +555,7 @@ private:
     for (auto element : nla.namepath()) {
       if (auto innerRef = element.dyn_cast<InnerRefAttr>()) {
         if (innerRef.getModule() == fromName) {
-          auto to = renameMap[innerRef.getName()];
-          assert(to && "should have been renamed");
+          assert(renameMap[innerRef.getName()] && "should have been renamed");
           namepath.push_back(
               InnerRefAttr::get(toName, renameMap[innerRef.getName()]));
         } else

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -555,7 +555,8 @@ private:
     for (auto element : nla.namepath()) {
       if (auto innerRef = element.dyn_cast<InnerRefAttr>()) {
         if (innerRef.getModule() == fromName) {
-          assert(renameMap[innerRef.getName()] && "should have been renamed");
+          auto to = renameMap[innerRef.getName()];
+          assert(to && "should have been renamed");
           namepath.push_back(
               InnerRefAttr::get(toName, renameMap[innerRef.getName()]));
         } else

--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -781,15 +781,14 @@ void EmitOMIRPass::emitTrackedTarget(DictionaryAttr node,
       target.append(addSymbol(module));
 
       if (auto innerRef = nameRef.dyn_cast<hw::InnerRefAttr>()) {
-        auto nameAttr = innerRef.getName();
         // Find an instance with the given name in this module. Ensure it has a
         // symbol that we can refer to.
         auto instOp = instancesByName.lookup(innerRef);
         if (!instOp)
           continue;
-        LLVM_DEBUG(llvm::dbgs()
-                   << "Marking NLA-participating instance " << nameAttr
-                   << " in module " << modName << " as dont-touch\n");
+        LLVM_DEBUG(llvm::dbgs() << "Marking NLA-participating instance "
+                                << innerRef.getName() << " in module "
+                                << modName << " as dont-touch\n");
         instName = getInnerRefTo(instOp);
       }
     }

--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -781,14 +781,15 @@ void EmitOMIRPass::emitTrackedTarget(DictionaryAttr node,
       target.append(addSymbol(module));
 
       if (auto innerRef = nameRef.dyn_cast<hw::InnerRefAttr>()) {
+        auto nameAttr = innerRef.getName();
         // Find an instance with the given name in this module. Ensure it has a
         // symbol that we can refer to.
         auto instOp = instancesByName.lookup(innerRef);
         if (!instOp)
           continue;
-        LLVM_DEBUG(llvm::dbgs() << "Marking NLA-participating instance "
-                                << innerRef.getName() << " in module "
-                                << modName << " as dont-touch\n");
+        LLVM_DEBUG(llvm::dbgs()
+                   << "Marking NLA-participating instance " << nameAttr
+                   << " in module " << modName << " as dont-touch\n");
         instName = getInnerRefTo(instOp);
       }
     }

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -919,6 +919,7 @@ Optional<TypeSum> GrandCentralPass::computeField(Attribute field,
           [&](AugmentedBundleTypeAttr bundle) -> TypeSum {
             auto iface = traverseBundle(bundle, id, prefix, path);
             assert(iface && iface.getValue());
+            (void)iface;
             return VerbatimType({getInterfaceName(prefix, bundle), true});
           })
       .Case<AugmentedStringTypeAttr>([&](auto field) -> TypeSum {

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -917,8 +917,7 @@ Optional<TypeSum> GrandCentralPass::computeField(Attribute field,
           })
       .Case<AugmentedBundleTypeAttr>(
           [&](AugmentedBundleTypeAttr bundle) -> TypeSum {
-            [[maybe_unused]] auto iface =
-                traverseBundle(bundle, id, prefix, path);
+            auto iface = traverseBundle(bundle, id, prefix, path);
             assert(iface && iface.getValue());
             return VerbatimType({getInterfaceName(prefix, bundle), true});
           })

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -917,7 +917,8 @@ Optional<TypeSum> GrandCentralPass::computeField(Attribute field,
           })
       .Case<AugmentedBundleTypeAttr>(
           [&](AugmentedBundleTypeAttr bundle) -> TypeSum {
-            auto iface = traverseBundle(bundle, id, prefix, path);
+            [[maybe_unused]] auto iface =
+                traverseBundle(bundle, id, prefix, path);
             assert(iface && iface.getValue());
             return VerbatimType({getInterfaceName(prefix, bundle), true});
           })

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -298,16 +298,16 @@ class GrandCentralTapsPass : public GrandCentralTapsBase<GrandCentralTapsPass> {
   void gatherTap(Annotation anno, Port port) {
     auto key = getKey(anno);
     annos.insert({key, anno});
-    auto it = tappedPorts.insert({key, port});
-    assert(it.second && "ambiguous tap annotation");
+    tappedPorts.insert({key, port});
+    assert(tappedPorts.find(key)->second && "ambiguous tap annotation");
     if (auto sym = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal"))
       deadNLAs.insert(sym.getAttr());
   }
   void gatherTap(Annotation anno, Operation *op) {
     auto key = getKey(anno);
     annos.insert({key, anno});
-    auto it = tappedOps.insert({key, op});
-    assert(it.second && "ambiguous tap annotation");
+    tappedOps.insert({key, op});
+    assert(tappedOps.find(key)->second && "ambiguous tap annotation");
     if (auto sym = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal"))
       deadNLAs.insert(sym.getAttr());
   }

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -298,16 +298,15 @@ class GrandCentralTapsPass : public GrandCentralTapsBase<GrandCentralTapsPass> {
   void gatherTap(Annotation anno, Port port) {
     auto key = getKey(anno);
     annos.insert({key, anno});
-    auto it = tappedPorts.insert({key, port});
-    assert(it.second && "ambiguous tap annotation");
+    assert(tappedPorts.insert({key, port}).second &&
+           "ambiguous tap annotation");
     if (auto sym = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal"))
       deadNLAs.insert(sym.getAttr());
   }
   void gatherTap(Annotation anno, Operation *op) {
     auto key = getKey(anno);
     annos.insert({key, anno});
-    auto it = tappedOps.insert({key, op});
-    assert(it.second && "ambiguous tap annotation");
+    assert(tappedOps.insert({key, op}).second && "ambiguous tap annotation");
     if (auto sym = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal"))
       deadNLAs.insert(sym.getAttr());
   }

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -298,16 +298,16 @@ class GrandCentralTapsPass : public GrandCentralTapsBase<GrandCentralTapsPass> {
   void gatherTap(Annotation anno, Port port) {
     auto key = getKey(anno);
     annos.insert({key, anno});
+    assert(!tappedPorts.count(key) && "ambiguous tap annotation");
     tappedPorts.insert({key, port});
-    assert(tappedPorts.find(key)->second && "ambiguous tap annotation");
     if (auto sym = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal"))
       deadNLAs.insert(sym.getAttr());
   }
   void gatherTap(Annotation anno, Operation *op) {
     auto key = getKey(anno);
     annos.insert({key, anno});
+    assert(!tappedOps.count(key) && "ambiguous tap annotation");
     tappedOps.insert({key, op});
-    assert(tappedOps.find(key)->second && "ambiguous tap annotation");
     if (auto sym = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal"))
       deadNLAs.insert(sym.getAttr());
   }

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -298,15 +298,16 @@ class GrandCentralTapsPass : public GrandCentralTapsBase<GrandCentralTapsPass> {
   void gatherTap(Annotation anno, Port port) {
     auto key = getKey(anno);
     annos.insert({key, anno});
-    assert(tappedPorts.insert({key, port}).second &&
-           "ambiguous tap annotation");
+    auto it = tappedPorts.insert({key, port});
+    assert(it.second && "ambiguous tap annotation");
     if (auto sym = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal"))
       deadNLAs.insert(sym.getAttr());
   }
   void gatherTap(Annotation anno, Operation *op) {
     auto key = getKey(anno);
     annos.insert({key, anno});
-    assert(tappedOps.insert({key, op}).second && "ambiguous tap annotation");
+    auto it = tappedOps.insert({key, op});
+    assert(it.second && "ambiguous tap annotation");
     if (auto sym = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal"))
       deadNLAs.insert(sym.getAttr());
   }

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -53,12 +53,14 @@ static T &operator<<(T &os, InstancePathRef path) {
   return os;
 }
 
+#ifndef NDEBUG
 static StringRef getTail(InstancePathRef path) {
   if (path.empty())
     return "$root";
   auto last = path.back();
   return last.name();
 }
+#endif
 
 namespace {
 /// A reset domain.

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -53,7 +53,7 @@ static T &operator<<(T &os, InstancePathRef path) {
   return os;
 }
 
-static StringRef getTail(InstancePathRef path) {
+[[maybe_unused]] static StringRef getTail(InstancePathRef path) {
   if (path.empty())
     return "$root";
   auto last = path.back();

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -53,7 +53,7 @@ static T &operator<<(T &os, InstancePathRef path) {
   return os;
 }
 
-[[maybe_unused]] static StringRef getTail(InstancePathRef path) {
+static StringRef getTail(InstancePathRef path) {
   if (path.empty())
     return "$root";
   auto last = path.back();

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -678,10 +678,12 @@ void ConstraintSolver::dumpConstraints(llvm::raw_ostream &os) {
   }
 }
 
+#ifndef NDEBUG
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const LinIneq &l) {
   l.print(os);
   return os;
 }
+#endif
 
 /// Compute the canonicalized linear inequality expression starting at `expr`,
 /// for the `var` as the left hand side `x` of the inequality. `seenVars` is
@@ -811,10 +813,9 @@ computeBinary(ExprSolution lhs, ExprSolution rhs,
 static ExprSolution solveExpr(Expr *expr, SmallPtrSetImpl<Expr *> &seenVars,
                               unsigned indent = 1) {
   // See if we have a memoized result we can return.
-  bool isTrivial = isa<KnownExpr>(expr);
   if (expr->solution) {
     LLVM_DEBUG({
-      if (!isTrivial)
+      if (!isa<KnownExpr>(expr))
         llvm::dbgs().indent(indent * 2)
             << "- Cached " << *expr << " = " << *expr->solution << "\n";
     });
@@ -823,7 +824,7 @@ static ExprSolution solveExpr(Expr *expr, SmallPtrSetImpl<Expr *> &seenVars,
 
   // Otherwise compute the value of the expression.
   LLVM_DEBUG({
-    if (!isTrivial)
+    if (!isa<KnownExpr>(expr))
       llvm::dbgs().indent(indent * 2) << "- Solving " << *expr << "\n";
   });
   auto solution =
@@ -884,7 +885,7 @@ static ExprSolution solveExpr(Expr *expr, SmallPtrSetImpl<Expr *> &seenVars,
 
   // Produce some useful debug prints.
   LLVM_DEBUG({
-    if (!isTrivial) {
+    if (!isa<KnownExpr>(expr)) {
       if (solution.first)
         llvm::dbgs().indent(indent * 2)
             << "= Solved " << *expr << " = " << *solution.first;

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -678,7 +678,8 @@ void ConstraintSolver::dumpConstraints(llvm::raw_ostream &os) {
   }
 }
 
-inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const LinIneq &l) {
+[[maybe_unused]] inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                                      const LinIneq &l) {
   l.print(os);
   return os;
 }
@@ -811,7 +812,7 @@ computeBinary(ExprSolution lhs, ExprSolution rhs,
 static ExprSolution solveExpr(Expr *expr, SmallPtrSetImpl<Expr *> &seenVars,
                               unsigned indent = 1) {
   // See if we have a memoized result we can return.
-  bool isTrivial = isa<KnownExpr>(expr);
+  [[maybe_unused]] bool isTrivial = isa<KnownExpr>(expr);
   if (expr->solution) {
     LLVM_DEBUG({
       if (!isTrivial)

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -678,8 +678,7 @@ void ConstraintSolver::dumpConstraints(llvm::raw_ostream &os) {
   }
 }
 
-[[maybe_unused]] inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
-                                                      const LinIneq &l) {
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const LinIneq &l) {
   l.print(os);
   return os;
 }
@@ -812,7 +811,7 @@ computeBinary(ExprSolution lhs, ExprSolution rhs,
 static ExprSolution solveExpr(Expr *expr, SmallPtrSetImpl<Expr *> &seenVars,
                               unsigned indent = 1) {
   // See if we have a memoized result we can return.
-  [[maybe_unused]] bool isTrivial = isa<KnownExpr>(expr);
+  bool isTrivial = isa<KnownExpr>(expr);
   if (expr->solution) {
     LLVM_DEBUG({
       if (!isTrivial)

--- a/lib/Scheduling/TestPasses.cpp
+++ b/lib/Scheduling/TestPasses.cpp
@@ -83,13 +83,14 @@ static void constructProblem(Problem &prob, FuncOp func) {
   // of integer attributes
   if (auto attr = func->getAttrOfType<ArrayAttr>("auxdeps")) {
     auto &ops = prob.getOperations();
-    unsigned nOps = ops.size();
     for (auto &elemArr : parseArrayOfArrays(attr)) {
-      assert(elemArr.size() >= 2 && elemArr[0] < nOps && elemArr[1] < nOps);
+      assert(elemArr.size() >= 2 && elemArr[0] < ops.size() &&
+             elemArr[1] < ops.size());
       Operation *from = ops[elemArr[0]];
       Operation *to = ops[elemArr[1]];
       auto res = prob.insertDependence(std::make_pair(from, to));
       assert(succeeded(res));
+      (void)res;
     }
   }
 }

--- a/lib/Scheduling/TestPasses.cpp
+++ b/lib/Scheduling/TestPasses.cpp
@@ -83,13 +83,11 @@ static void constructProblem(Problem &prob, FuncOp func) {
   // of integer attributes
   if (auto attr = func->getAttrOfType<ArrayAttr>("auxdeps")) {
     auto &ops = prob.getOperations();
-    unsigned nOps = ops.size();
-    for (auto &elemArr : parseArrayOfArrays(attr)) {
+    [[maybe_unused]] unsigned nOps = ops.size();
+    for ([[maybe_unused]] auto &elemArr : parseArrayOfArrays(attr)) {
       assert(elemArr.size() >= 2 && elemArr[0] < nOps && elemArr[1] < nOps);
-      Operation *from = ops[elemArr[0]];
-      Operation *to = ops[elemArr[1]];
-      auto res = prob.insertDependence(std::make_pair(from, to));
-      assert(succeeded(res));
+      assert(succeeded(prob.insertDependence(
+          std::make_pair(ops[elemArr[0]], ops[elemArr[1]]))));
     }
   }
 }

--- a/lib/Scheduling/TestPasses.cpp
+++ b/lib/Scheduling/TestPasses.cpp
@@ -83,11 +83,13 @@ static void constructProblem(Problem &prob, FuncOp func) {
   // of integer attributes
   if (auto attr = func->getAttrOfType<ArrayAttr>("auxdeps")) {
     auto &ops = prob.getOperations();
-    [[maybe_unused]] unsigned nOps = ops.size();
-    for ([[maybe_unused]] auto &elemArr : parseArrayOfArrays(attr)) {
+    unsigned nOps = ops.size();
+    for (auto &elemArr : parseArrayOfArrays(attr)) {
       assert(elemArr.size() >= 2 && elemArr[0] < nOps && elemArr[1] < nOps);
-      assert(succeeded(prob.insertDependence(
-          std::make_pair(ops[elemArr[0]], ops[elemArr[1]]))));
+      Operation *from = ops[elemArr[0]];
+      Operation *to = ops[elemArr[1]];
+      auto res = prob.insertDependence(std::make_pair(from, to));
+      assert(succeeded(res));
     }
   }
 }

--- a/lib/Support/BackedgeBuilder.cpp
+++ b/lib/Support/BackedgeBuilder.cpp
@@ -27,8 +27,7 @@ void Backedge::setValue(mlir::Value newValue) {
 
 BackedgeBuilder::~BackedgeBuilder() {
   for (Operation *op : edges) {
-    auto users = op->getUsers();
-    assert(users.empty() && "Backedge still in use");
+    assert(op->getUsers().empty() && "Backedge still in use");
     if (rewriter)
       rewriter->eraseOp(op);
     else

--- a/lib/Support/BackedgeBuilder.cpp
+++ b/lib/Support/BackedgeBuilder.cpp
@@ -27,7 +27,7 @@ void Backedge::setValue(mlir::Value newValue) {
 
 BackedgeBuilder::~BackedgeBuilder() {
   for (Operation *op : edges) {
-    assert(op->getUsers().empty() && "Backedge still in use");
+    assert(op->use_empty() && "Backedge still in use");
     if (rewriter)
       rewriter->eraseOp(op);
     else

--- a/lib/Support/BackedgeBuilder.cpp
+++ b/lib/Support/BackedgeBuilder.cpp
@@ -27,7 +27,8 @@ void Backedge::setValue(mlir::Value newValue) {
 
 BackedgeBuilder::~BackedgeBuilder() {
   for (Operation *op : edges) {
-    assert(op->getUsers().empty() && "Backedge still in use");
+    auto users = op->getUsers();
+    assert(users.empty() && "Backedge still in use");
     if (rewriter)
       rewriter->eraseOp(op);
     else


### PR DESCRIPTION
   Fix the warnings build with release mode on circt.
   This can happen when you build llvm and circt with CMake option
   -DLLVM_ENABLE_ASSERTIONS=OFF 
   -DCMAKE_BUILD_TYPE=Release 
   fix it by placing the temporary variable in the assert function
   or with the attribute maybe_unused.


#### ----------------------
#### Build the Release mode

```shell
cd circt
mkdir llvm/build && cd llvm/build
cmake -G Ninja ../llvm \
-DLLVM_ENABLE_PROJECTS="mlir" \
-DLLVM_TARGETS_TO_BUILD="host" \
-DLLVM_ENABLE_ASSERTIONS=OFF \
-DCMAKE_BUILD_TYPE=Release \
-DCMAKE_EXPORT_COMPILE_COMMANDS=ON  \
-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLLVM_ENABLE_LLD=ON

ninja
ninja check-mlir

#### -----

cd circt
mkdir build && cd build
cmake -G Ninja .. \
    -DMLIR_DIR=$PWD/../llvm/build/lib/cmake/mlir \
    -DLLVM_DIR=$PWD/../llvm/build/lib/cmake/llvm \
    -DLLVM_ENABLE_ASSERTIONS=OFF \
    -DCMAKE_BUILD_TYPE=Release \
    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
    -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLLVM_ENABLE_LLD=ON

ninja
ninja check-circt
```


------

warnings are like:
[156/363] Building CXX object lib/Support/CMakeFiles/obj.CIRCTSupport.dir/BackedgeBuilder.cpp.o
../lib/Support/BackedgeBuilder.cpp:30:10: warning: unused variable 'users' [-Wunused-variable]
    auto users = op->getUsers();
         ^
1 warning generated.
[169/363] Building CXX object lib/Scheduling/CMakeFiles/obj.CIRCTSchedulingTestPasses.dir/TestPasses.cpp.o
../lib/Scheduling/TestPasses.cpp:91:12: warning: unused variable 'res' [-Wunused-variable]
      auto res = prob.insertDependence(std::make_pair(from, to));
           ^
../lib/Scheduling/TestPasses.cpp:86:14: warning: unused variable 'nOps' [-Wunused-variable]
    unsigned nOps = ops.size();
             ^
2 warnings generated.
[195/363] Building CXX object lib/Dialect/Comb/CMakeFiles/obj.CIRCTComb.dir/CombFolds.cpp.o
../lib/Dialect/Comb/CombFolds.cpp:598:14: warning: unused variable 'type' [-Wunused-variable]
        Type type = innerOp.getType();
             ^
1 warning generated.
[196/363] Building CXX object lib/Dialect/FIRRTL/CMakeFiles/obj.CIRCTFIRRTL.dir/FIRRTLAnnotations.cpp.o
../lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp:618:10: warning: unused variable 'moduleName' [-Wunused-variable]
    auto moduleName = module.moduleNameAttr();
...