### PR TITLE
[FIRRTL][Dedup] Add NoCircuitDedup annotation support

### DIFF
--- a/docs/FIRRTLAnnotations.md
+++ b/docs/FIRRTLAnnotations.md
@@ -517,6 +517,21 @@ Example:
 }
 ```
 
+### [NoCircuitDedupAnnotation](https://www.chisel-lang.org/api/firrtl/latest/firrtl/transforms/NoCircuitDedupAnnotation$.html)
+
+| Property   | Type   | Description                                  |
+| ---------- | ------ | -------------                                |
+| class      | string | `firrtl.transforms.NoCircuitDedupAnnotation` |
+
+This annotations will skip running the deduplication pass on the circuit.
+
+Example:
+```json
+{
+  "class": "firrtl.transforms.NoCircuitDedupAnnotation"
+}
+```
+
 ### OMIRFileAnnotation
 
 | Property   | Type   | Description                                           |

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -939,6 +939,12 @@ class DedupPass : public DedupBase<DedupPass> {
   void runOnOperation() override {
     auto *context = &getContext();
     auto circuit = getOperation();
+
+    // If this circuit is marked "NoDedup" skip this pass.
+    if (AnnotationSet::removeAnnotations(
+            circuit, "firrtl.transforms.NoCircuitDedupAnnotation"))
+      return markAllAnalysesPreserved();
+
     auto &instanceGraph = getAnalysis<InstanceGraph>();
     SymbolTable symbolTable(circuit);
     NLAMap nlaMap = createNLAMap(circuit);

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -413,3 +413,19 @@ firrtl.circuit "NoDedup" {
     firrtl.instance simple1 @Simple1()
   }
 }
+
+// Don't deduplicate modules with when the circuit is NoDedup.
+// CHECK-LABEL: firrtl.circuit "NoCircuitDedup"
+firrtl.circuit "NoCircuitDedup" attributes {annotations = [
+    // CHECK-NOT: "firrtl.transforms.NoCircuitDedupAnnotation"
+    {class = "firrtl.transforms.NoCircuitDedupAnnotation"}]} {
+  // CHECK: firrtl.module @Simple0
+  firrtl.module @Simple0() { }
+  // CHECK: firrtl.module @Simple1
+  firrtl.module @Simple1() { }
+  // CHECK: firrtl.module @NoCircuitDedup 
+  firrtl.module @NoCircuitDedup() {
+    firrtl.instance simple0 @Simple0()
+    firrtl.instance simple1 @Simple1()
+  }
+}


### PR DESCRIPTION
This annotation causes the deduplication pass to be skipped.