### PR TITLE
[Calyx] Add attributes for external memory interfaces

### DIFF
--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -1432,12 +1432,19 @@ appendPortsForExternalMemref(PatternRewriter &rewriter, StringRef memName,
                              SmallVectorImpl<calyx::PortInfo> &outPorts) {
   MemRefType memrefType = memref.getType().cast<MemRefType>();
 
+  /// Ports constituting a memory interface are added a set of attributes under
+  /// a "mem : {...}" dictionary. These attributes allows for deducing which
+  /// top-level I/O signals constitutes a unique memory interface.
   auto getMemoryInterfaceAttr = [&](StringRef tag,
                                     Optional<unsigned> addrIdx = {}) {
     auto attrs = SmallVector<NamedAttribute>{
+        /// "id" denotes a unique memory interface.
         rewriter.getNamedAttr("id", rewriter.getI32IntegerAttr(memoryID)),
+        /// "tag" denotes the function of this signal.
         rewriter.getNamedAttr("tag", rewriter.getStringAttr(tag))};
     if (addrIdx.hasValue())
+      /// "addr_idx" denotes the address index of this signal, for
+      /// multi-dimensional memory interfaces.
       attrs.push_back(rewriter.getNamedAttr(
           "addr_idx", rewriter.getI32IntegerAttr(addrIdx.getValue())));
 

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -1433,13 +1433,13 @@ appendPortsForExternalMemref(PatternRewriter &rewriter, StringRef memName,
   MemRefType memrefType = memref.getType().cast<MemRefType>();
 
   auto getMemoryInterfaceAttr = [&](StringRef tag,
-                                    Optional<unsigned> tagID = {}) {
+                                    Optional<unsigned> addrIdx = {}) {
     auto attrs = SmallVector<NamedAttribute>{
         rewriter.getNamedAttr("id", rewriter.getI32IntegerAttr(memoryID)),
         rewriter.getNamedAttr("tag", rewriter.getStringAttr(tag))};
-    if (tagID.hasValue())
+    if (addrIdx.hasValue())
       attrs.push_back(rewriter.getNamedAttr(
-          "tagID", rewriter.getI32IntegerAttr(tagID.getValue())));
+          "addr_idx", rewriter.getI32IntegerAttr(addrIdx.getValue())));
 
     return rewriter.getNamedAttr("mem", rewriter.getDictionaryAttr(attrs));
   };

--- a/test/Conversion/SCFToCalyx/convert_memory.mlir
+++ b/test/Conversion/SCFToCalyx/convert_memory.mlir
@@ -334,7 +334,7 @@ module {
 
 // CHECK:      module  {
 // CHECK-NEXT:   calyx.program "main"  {
-// CHECK:        calyx.component @main(%in0: i32, %ext_mem0_read_data: i32, %ext_mem0_done: i1, %in2: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%ext_mem0_write_data: i32, %ext_mem0_addr0: i3, %ext_mem0_write_en: i1, %done: i1 {done}) {
+// CHECK:        calyx.component @main(%in0: i32, %ext_mem0_read_data: i32 {mem = {id = 0 : i32, tag = "read_data"}}, %ext_mem0_done: i1 {mem = {id = 0 : i32, tag = "done"}}, %in2: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%ext_mem0_write_data: i32 {mem = {id = 0 : i32, tag = "write_data"}}, %ext_mem0_addr0: i3 {mem = {id = 0 : i32, tag = "addr", tagID = 0 : i32}}, %ext_mem0_write_en: i1 {mem = {id = 0 : i32, tag = "write_en"}}, %done: i1 {done}) {
 // CHECK-DAG:        %true = hw.constant true
 // CHECK-DAG:        %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i3
 // CHECK-NEXT:       calyx.wires  {
@@ -367,7 +367,7 @@ module {
 
 // CHECK:      module  {
 // CHECK-NEXT:   calyx.program "main"  {
-// CHECK:        calyx.component @main(%in0: i32, %ext_mem0_read_data: i32, %ext_mem0_done: i1, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%ext_mem0_write_data: i32, %ext_mem0_addr0: i3, %ext_mem0_write_en: i1, %out0: i32, %done: i1 {done}) {
+// CHECK:        calyx.component @main(%in0: i32, %ext_mem0_read_data: i32 {mem = {id = 0 : i32, tag = "read_data"}}, %ext_mem0_done: i1 {mem = {id = 0 : i32, tag = "done"}}, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%ext_mem0_write_data: i32 {mem = {id = 0 : i32, tag = "write_data"}}, %ext_mem0_addr0: i3 {mem = {id = 0 : i32, tag = "addr", tagID = 0 : i32}}, %ext_mem0_write_en: i1 {mem = {id = 0 : i32, tag = "write_en"}}, %out0: i32, %done: i1 {done}) {
 // CHECK:            %true = hw.constant true
 // CHECK:            %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i3
 // CHECK:            %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
@@ -402,7 +402,7 @@ module {
 
 // CHECK:      module  {
 // CHECK-NEXT:   calyx.program "main"  {
-// CHECK:        calyx.component @main(%in0: i32, %in1: i32, %ext_mem0_read_data: i32, %ext_mem0_done: i1, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%ext_mem0_write_data: i32, %ext_mem0_addr0: i3, %ext_mem0_write_en: i1, %out0: i32, %out1: i32, %done: i1 {done}) {
+// CHECK:        calyx.component @main(%in0: i32, %in1: i32, %ext_mem0_read_data: i32 {mem = {id = 0 : i32, tag = "read_data"}}, %ext_mem0_done: i1 {mem = {id = 0 : i32, tag = "done"}}, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%ext_mem0_write_data: i32 {mem = {id = 0 : i32, tag = "write_data"}}, %ext_mem0_addr0: i3 {mem = {id = 0 : i32, tag = "addr", tagID = 0 : i32}}, %ext_mem0_write_en: i1 {mem = {id = 0 : i32, tag = "write_en"}}, %out0: i32, %out1: i32, %done: i1 {done}) {
 // CHECK-DAG:        %true = hw.constant true
 // CHECK-DAG:        %std_slice_1.in, %std_slice_1.out = calyx.std_slice @std_slice_1 : i32, i3
 // CHECK-DAG:        %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i3

--- a/test/Conversion/SCFToCalyx/convert_memory.mlir
+++ b/test/Conversion/SCFToCalyx/convert_memory.mlir
@@ -334,7 +334,7 @@ module {
 
 // CHECK:      module  {
 // CHECK-NEXT:   calyx.program "main"  {
-// CHECK:        calyx.component @main(%in0: i32, %ext_mem0_read_data: i32 {mem = {id = 0 : i32, tag = "read_data"}}, %ext_mem0_done: i1 {mem = {id = 0 : i32, tag = "done"}}, %in2: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%ext_mem0_write_data: i32 {mem = {id = 0 : i32, tag = "write_data"}}, %ext_mem0_addr0: i3 {mem = {id = 0 : i32, tag = "addr", tagID = 0 : i32}}, %ext_mem0_write_en: i1 {mem = {id = 0 : i32, tag = "write_en"}}, %done: i1 {done}) {
+// CHECK:        calyx.component @main(%in0: i32, %ext_mem0_read_data: i32 {mem = {id = 0 : i32, tag = "read_data"}}, %ext_mem0_done: i1 {mem = {id = 0 : i32, tag = "done"}}, %in2: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%ext_mem0_write_data: i32 {mem = {id = 0 : i32, tag = "write_data"}}, %ext_mem0_addr0: i3 {mem = {addr_idx = 0 : i32, id = 0 : i32, tag = "addr"}}, %ext_mem0_write_en: i1 {mem = {id = 0 : i32, tag = "write_en"}}, %done: i1 {done}) {
 // CHECK-DAG:        %true = hw.constant true
 // CHECK-DAG:        %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i3
 // CHECK-NEXT:       calyx.wires  {
@@ -367,7 +367,7 @@ module {
 
 // CHECK:      module  {
 // CHECK-NEXT:   calyx.program "main"  {
-// CHECK:        calyx.component @main(%in0: i32, %ext_mem0_read_data: i32 {mem = {id = 0 : i32, tag = "read_data"}}, %ext_mem0_done: i1 {mem = {id = 0 : i32, tag = "done"}}, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%ext_mem0_write_data: i32 {mem = {id = 0 : i32, tag = "write_data"}}, %ext_mem0_addr0: i3 {mem = {id = 0 : i32, tag = "addr", tagID = 0 : i32}}, %ext_mem0_write_en: i1 {mem = {id = 0 : i32, tag = "write_en"}}, %out0: i32, %done: i1 {done}) {
+// CHECK:        calyx.component @main(%in0: i32, %ext_mem0_read_data: i32 {mem = {id = 0 : i32, tag = "read_data"}}, %ext_mem0_done: i1 {mem = {id = 0 : i32, tag = "done"}}, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%ext_mem0_write_data: i32 {mem = {id = 0 : i32, tag = "write_data"}}, %ext_mem0_addr0: i3 {mem = {addr_idx = 0 : i32, id = 0 : i32, tag = "addr"}}, %ext_mem0_write_en: i1 {mem = {id = 0 : i32, tag = "write_en"}}, %out0: i32, %done: i1 {done}) {
 // CHECK:            %true = hw.constant true
 // CHECK:            %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i3
 // CHECK:            %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
@@ -402,7 +402,7 @@ module {
 
 // CHECK:      module  {
 // CHECK-NEXT:   calyx.program "main"  {
-// CHECK:        calyx.component @main(%in0: i32, %in1: i32, %ext_mem0_read_data: i32 {mem = {id = 0 : i32, tag = "read_data"}}, %ext_mem0_done: i1 {mem = {id = 0 : i32, tag = "done"}}, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%ext_mem0_write_data: i32 {mem = {id = 0 : i32, tag = "write_data"}}, %ext_mem0_addr0: i3 {mem = {id = 0 : i32, tag = "addr", tagID = 0 : i32}}, %ext_mem0_write_en: i1 {mem = {id = 0 : i32, tag = "write_en"}}, %out0: i32, %out1: i32, %done: i1 {done}) {
+// CHECK:        calyx.component @main(%in0: i32, %in1: i32, %ext_mem0_read_data: i32 {mem = {id = 0 : i32, tag = "read_data"}}, %ext_mem0_done: i1 {mem = {id = 0 : i32, tag = "done"}}, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%ext_mem0_write_data: i32 {mem = {id = 0 : i32, tag = "write_data"}}, %ext_mem0_addr0: i3 {mem = {addr_idx = 0 : i32, id = 0 : i32, tag = "addr"}}, %ext_mem0_write_en: i1 {mem = {id = 0 : i32, tag = "write_en"}}, %out0: i32, %out1: i32, %done: i1 {done}) {
 // CHECK-DAG:        %true = hw.constant true
 // CHECK-DAG:        %std_slice_1.in, %std_slice_1.out = calyx.std_slice @std_slice_1 : i32, i3
 // CHECK-DAG:        %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i3

--- a/test/Conversion/SCFToCalyx/convert_pipeline.mlir
+++ b/test/Conversion/SCFToCalyx/convert_pipeline.mlir
@@ -54,7 +54,7 @@ func @minimal() {
 // -----
 
 // CHECK:     calyx.program "dot"
-// CHECK:       calyx.component @dot(%[[MEM0_READ:.+]]: i32, {{.+}}, %[[MEM1_READ:.+]]: i32, {{.+}}) -> ({{.+}} %[[MEM0_ADDR:.+]]: i6, {{.+}} %[[MEM1_ADDR:.+]]: i6, {{.+}} %[[OUT:.+]]: i32, {{.+}}) {
+// CHECK:       calyx.component @dot(%[[MEM0_READ:.+]]: i32 {mem = {id = 0 : i32, tag = "read_data"}}, {{.+}}, %[[MEM1_READ:.+]]: i32 {mem = {id = 1 : i32, tag = "read_data"}}, {{.+}}) -> ({{.+}} %[[MEM0_ADDR:.+]]: i6 {mem = {addr_idx = 0 : i32, id = 0 : i32, tag = "addr"}}, {{.+}} %[[MEM1_ADDR:.+]]: i6 {mem = {addr_idx = 0 : i32, id = 1 : i32, tag = "addr"}}, {{.+}} %[[OUT:.+]]: i32, {{.+}}) {
 // CHECK-DAG:     %[[TRUE:.+]] = hw.constant true
 // CHECK-DAG:     %[[C0:.+]] = hw.constant 0 : i32
 // CHECK-DAG:     %[[C64:.+]] = hw.constant 64 : i32


### PR DESCRIPTION
Currently doing some work on figuring out how to hook up Calyx with the cosimulation infrastructure in CIRCT-HLS. For this, i need to determine the set of ports which specifies an external memory connection. While this is possible via. a purely string-based approach, i'd like to be a bit safer and actually add some tagging information in SCFToCalyx to help resolve the ports that constitutes the interface.

This initial commit just adds the attributes to the component ports in SCFToCalyx, and does not intrude into the Calyx library itself.

If there's interest, i can follow up with a commit which integrates this notion of external memory interfaces into the Calyx ComponentOp
1. add a verifier that these memory interfaces are fully, and correctly, specified and
2. add ODS getters for the memory interfaces in the calyx.component operation.