### PR TITLE
[firtool] Add --strip-debug-info to Emit Without Source Locator Comments

### DIFF
--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -293,6 +293,11 @@ static cl::opt<bool>
                           cl::desc("Log executions of toplevel module passes"),
                           cl::init(false));
 
+static cl::opt<bool> stripDebugInfo(
+    "strip-debug-info",
+    cl::desc("Disable source locator information in output Verilog"),
+    cl::init(false));
+
 /// Create a simple canonicalizer pass.
 static std::unique_ptr<Pass> createSimpleCanonicalizerPass() {
   mlir::GreedyRewriteConfig config;
@@ -539,6 +544,8 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
       modulePM.addPass(sv::createPrettifyVerilogPass());
     }
 
+    if (stripDebugInfo)
+      pm.addPass(mlir::createStripDebugInfoPass());
     // Emit a single file or multiple files depending on the output format.
     switch (outputFormat) {
     default:


### PR DESCRIPTION
This PR should resolve #2651.

Results:

```verilog
❯ .\cmake-build-debug\bin\firtool.exe .\test\firtool\firtool.fir | select -last 10

module MultibitMux(     // .\test\firtool\firtool.fir:242:10
  input        a_0, a_1, a_2,
  input  [1:0] sel,
  output       b);

  wire [2:0] _GEN = {{a_2}, {a_1}, {a_0}};      // .\test\firtool\firtool.fir:246:12
  assign b = _GEN[sel]; // .\test\firtool\firtool.fir:242:10, :246:12
endmodule


❯ .\cmake-build-debug\bin\firtool.exe .\test\firtool\firtool.fir --strip-debug-info | select -last 10

module MultibitMux(
  input        a_0, a_1, a_2,
  input  [1:0] sel,
  output       b);

  wire [2:0] _GEN = {{a_2}, {a_1}, {a_0}};
  assign b = _GEN[sel];
endmodule
```