### PR TITLE
[FIRRTL][Metadata] Print empty seq_mems.json files

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -218,21 +218,18 @@ LogicalResult CreateSiFiveMetadataPass::emitMemoryMetadata() {
     if (auto dir = dirAnno.getMember<StringAttr>("dirname"))
       metadataDir = dir.getValue();
 
-  if (testBenchJsonBuffer != "[]") {
-    // Use unknown loc to avoid printing the location in the metadata files.
-    auto tbVerbatimOp = builder.create<sv::VerbatimOp>(builder.getUnknownLoc(),
-                                                       testBenchJsonBuffer);
-    auto fileAttr = hw::OutputFileAttr::getFromDirectoryAndFilename(
-        context, metadataDir, "tb_seq_mems.json", /*excludeFromFilelist=*/true);
-    tbVerbatimOp->setAttr("output_file", fileAttr);
-  }
-  if (dutJsonBuffer != "[]") {
-    auto dutVerbatimOp =
-        builder.create<sv::VerbatimOp>(builder.getUnknownLoc(), dutJsonBuffer);
-    auto fileAttr = hw::OutputFileAttr::getFromDirectoryAndFilename(
-        context, metadataDir, "seq_mems.json", /*excludeFromFilelist=*/true);
-    dutVerbatimOp->setAttr("output_file", fileAttr);
-  }
+  // Use unknown loc to avoid printing the location in the metadata files.
+  auto tbVerbatimOp = builder.create<sv::VerbatimOp>(builder.getUnknownLoc(),
+                                                     testBenchJsonBuffer);
+  auto fileAttr = hw::OutputFileAttr::getFromDirectoryAndFilename(
+      context, metadataDir, "tb_seq_mems.json", /*excludeFromFilelist=*/true);
+  tbVerbatimOp->setAttr("output_file", fileAttr);
+  auto dutVerbatimOp =
+      builder.create<sv::VerbatimOp>(builder.getUnknownLoc(), dutJsonBuffer);
+  fileAttr = hw::OutputFileAttr::getFromDirectoryAndFilename(
+      context, metadataDir, "seq_mems.json", /*excludeFromFilelist=*/true);
+  dutVerbatimOp->setAttr("output_file", fileAttr);
+
   if (!seqMemConfStr.empty()) {
     auto confVerbatimOp =
         builder.create<sv::VerbatimOp>(builder.getUnknownLoc(), seqMemConfStr);

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -104,6 +104,21 @@ firrtl.circuit "BasicBlackboxes" attributes { annotations = [{
   // CHECK: sv.verbatim "[\22DUTBlackbox1\22,\22DUTBlackbox2\22]" {output_file = #hw.output_file<"dut_blackboxes.json", excludeFromFileList>, symbols = []}
 }
 
+//===----------------------------------------------------------------------===//
+// MemoryMetadata
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: firrtl.circuit "top"
+firrtl.circuit "top" 
+{
+  firrtl.module @top() { }
+  // When there are no memories, we still need to emit the seq_mems.json
+  // metadata, but not the memory.conf metadata.
+  // CHECK: sv.verbatim "[]" {output_file = #hw.output_file<"metadata/tb_seq_mems.json", excludeFromFileList>, symbols = []}
+  // CHECK: sv.verbatim "[]" {output_file = #hw.output_file<"metadata/seq_mems.json", excludeFromFileList>, symbols = []}
+  // CHECK-NOT: {output_file = #hw.output_file<"\22metadata/dut.conf\22", excludeFromFileList>, symbols = []}
+}
+
 // CHECK-LABEL: firrtl.circuit "top"
 firrtl.circuit "top" 
 {


### PR DESCRIPTION
When there are no memories, we are not emitting the metadata file
describing them.  This changes the firtool to always emit the metadata
when instructed, printing just an empty array `[]` when there are no
memories.