### PR TITLE
[Windows] Switch build from msbuild to Ninja

### DIFF
--- a/.github/workflows/buildAndTestWindows.yml
+++ b/.github/workflows/buildAndTestWindows.yml
@@ -51,11 +51,12 @@ jobs:
         if: steps.cache-llvm.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
+          ./utils/find-vs.ps1
           mkdir llvm/build
           cd llvm/build
           cmake ..\llvm -GNinja `
             -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_BUILD_EXAMPLES=OFF `
-            -DLLVM_TARGETS_TO_BUILD="host" -DCMAKE_BUILD_TYPE=Release -Thost=x64 `
+            -DLLVM_TARGETS_TO_BUILD="host" `
             -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON `
             -DLLVM_INSTALL_UTILS=ON -DCMAKE_INSTALL_PREFIX="$(pwd)/../install"
           cmake --build . --target install --config Release
@@ -69,6 +70,7 @@ jobs:
       - name: Build and test CIRCT (release)
         shell: pwsh
         run: |
+          ./utils/find-vs.ps1
           mkdir build_release
           cd build_release
           cmake ../ -GNinja `
@@ -76,7 +78,7 @@ jobs:
             -DMLIR_DIR="$(pwd)/../llvm/build/lib/cmake/mlir/" `
             -DLLVM_DIR="$(pwd)/../llvm/build/lib/cmake/llvm/" `
             -DLLVM_EXTERNAL_LIT="$(pwd)/../llvm/build/Release/bin/llvm-lit.py" `
-            -DCMAKE_BUILD_TYPE=Release -Thost=x64 -DCMAKE_BUILD_TYPE=Release
+            -DCMAKE_BUILD_TYPE=Release
           cmake --build . --config Release
 
     # --- end of build-circt job.

--- a/.github/workflows/buildAndTestWindows.yml
+++ b/.github/workflows/buildAndTestWindows.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           mkdir llvm/build
           cd llvm/build
-          cmake ..\llvm -G "Visual Studio 16 2019" `
+          cmake ..\llvm -GNinja `
             -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_BUILD_EXAMPLES=OFF `
             -DLLVM_TARGETS_TO_BUILD="host" -DCMAKE_BUILD_TYPE=Release -Thost=x64 `
             -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON `
@@ -71,12 +71,11 @@ jobs:
         run: |
           mkdir build_release
           cd build_release
-          cmake ../ `
+          cmake ../ -GNinja `
             -DLLVM_ENABLE_ASSERTIONS=ON `
             -DMLIR_DIR="$(pwd)/../llvm/build/lib/cmake/mlir/" `
             -DLLVM_DIR="$(pwd)/../llvm/build/lib/cmake/llvm/" `
             -DLLVM_EXTERNAL_LIT="$(pwd)/../llvm/build/Release/bin/llvm-lit.py" `
-            -G "Visual Studio 16 2019" `
             -DCMAKE_BUILD_TYPE=Release -Thost=x64 -DCMAKE_BUILD_TYPE=Release
           cmake --build . --config Release
 

--- a/utils/find-vs.ps1
+++ b/utils/find-vs.ps1
@@ -1,0 +1,46 @@
+function Enter-VsDevEnv {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [switch]$Prerelease,
+        [Parameter()]
+        [string]$architecture = "x64"
+    )
+
+    $ErrorActionPreference = 'Stop'
+
+    if ($null -eq (Get-InstalledModule -name 'VSSetup' -ErrorAction SilentlyContinue)) {
+        Install-Module -Name 'VSSetup' -Scope CurrentUser -SkipPublisherCheck -Force
+    }
+    Import-Module -Name 'VSSetup'
+
+    Write-Verbose 'Searching for VC++ instances'
+    $vsinfo = `
+        Get-VSSetupInstance  -All -Prerelease:$Prerelease `
+    | Select-VSSetupInstance `
+        -Latest -Product * `
+        -Require 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64'
+
+    $vspath = $vsinfo.InstallationPath
+
+    switch ($env:PROCESSOR_ARCHITECTURE) {
+        "amd64" { $hostarch = "x64" }
+        "x86" { $hostarch = "x86" }
+        "arm64" { $hostarch = "arm64" }
+        default { throw "Unknown architecture: $switch" }
+    }
+
+    $devShellModule = "$vspath\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+
+    Import-Module -Global -Name $devShellModule
+
+    Write-Verbose 'Setting up environment variables'
+    Enter-VsDevShell -VsInstanceId $vsinfo.InstanceId  -SkipAutomaticLocation `
+        -devCmdArguments "-arch=$architecture -host_arch=$hostarch"
+
+    Set-Item -Force -path "Env:\Platform" -Value $architecture
+
+    remove-Module Microsoft.VisualStudio.DevShell, VSSetup
+}
+
+Enter-VsDevEnv

--- a/utils/find-vs.ps1
+++ b/utils/find-vs.ps1
@@ -1,3 +1,5 @@
+# Find and enter a Visual Studio development environment.
+# Required to use Ninja instead of msbuild on our build agents.
 function Enter-VsDevEnv {
     [CmdletBinding()]
     param(


### PR DESCRIPTION
MLIR/LLVM runs Windows builds with Ninja, so we should too. (Plus, it's waaayyyy faster on bigger boxes.)

Fixes #2647.