### PR TITLE
[FIRRTL][InferResets] transfer inner sym when replacing registers

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -1543,7 +1543,7 @@ void InferResetsPass::implementAsyncReset(Operation *op, FModuleOp module,
     auto zero = createZeroValue(builder, regOp.getType());
     auto newRegOp = builder.create<RegResetOp>(
         regOp.getType(), regOp.clockVal(), actualReset, zero, regOp.nameAttr(),
-        regOp.annotations(), StringAttr{});
+        regOp.annotations(), regOp.inner_symAttr());
     regOp.getResult().replaceAllUsesWith(newRegOp);
     regOp->erase();
     return;

--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -361,8 +361,8 @@ firrtl.circuit "Top" {
   firrtl.module @Top(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %init: !firrtl.uint<1>, in %in: !firrtl.uint<8>, in %extraReset: !firrtl.asyncreset ) attributes {
     portAnnotations = [[],[],[],[],[{class = "firrtl.transforms.DontTouchAnnotation"}, {class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]]} {
     %c1_ui8 = firrtl.constant 1 : !firrtl.uint<8>
-    // CHECK: %reg1 = firrtl.regreset %clock, %extraReset, %c0_ui8
-    %reg1 = firrtl.reg %clock : !firrtl.uint<8>
+    // CHECK: %reg1 = firrtl.regreset sym @reg1 %clock, %extraReset, %c0_ui8
+    %reg1 = firrtl.reg sym @reg1 %clock : !firrtl.uint<8>
     firrtl.connect %reg1, %in : !firrtl.uint<8>, !firrtl.uint<8>
 
     // Existing async reset remains untouched.


### PR DESCRIPTION
When replacing RegOps with RegResetOps we need to make sure that we
transfer the inner_sym to the new operation.