### PR TITLE
[SV][ExportVerilog] Add sv.case op

### DIFF
--- a/include/circt/Dialect/SV/SV.td
+++ b/include/circt/Dialect/SV/SV.td
@@ -36,6 +36,10 @@ def NonProceduralOp : NativeOpTrait<"NonProceduralOp"> {
   let cppNamespace = "::circt::sv";
 }
 
+def CaseLikeOp : NativeOpTrait<"CaseLikeOp"> {
+  let cppNamespace = "::circt::sv";
+}
+
 include "circt/Dialect/HW/HWTypes.td"
 include "circt/Dialect/HW/HWAttributesNaming.td"
 include "circt/Dialect/SV/SVTypes.td"

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -292,7 +292,7 @@ def InitialOp : SVOp<"initial", [SingleBlock, NoTerminator, NoRegionArguments,
 }
 
 def CaseZOp : SVOp<"casez", [SingleBlock, NoTerminator, NoRegionArguments,
-                             ProceduralRegion, ProceduralOp]> {
+                             ProceduralRegion, ProceduralOp, CaseLikeOp]> {
   let summary = "'casez (cond)' block";
   let description = "See SystemVerilog 2017 12.5.1.";
 
@@ -300,9 +300,7 @@ def CaseZOp : SVOp<"casez", [SingleBlock, NoTerminator, NoRegionArguments,
   let arguments = (ins HWIntegerType:$cond, ArrayAttr:$casePatterns);
   let results = (outs);
 
-  let parser = "return parseCaseZOp(parser, result);";
-  let printer = "printCaseZOp(p, *this);";
-  let verifier = "return ::verifyCaseZOp(*this);";
+  let hasCustomAssemblyFormat = 1;
 
   let builders = [
     /// This ctor allows you to build a CaseZ with some number of cases, getting
@@ -310,12 +308,24 @@ def CaseZOp : SVOp<"casez", [SingleBlock, NoTerminator, NoRegionArguments,
     OpBuilder<(ins "Value":$cond, "size_t":$numCases,
                "std::function<CaseZPattern(size_t)>":$caseCtor)>
   ];
+}
 
-  let extraClassDeclaration = [{
-    SmallVector<CaseZInfo, 4> getCases();
+def CaseOp : SVOp<"case", [SingleBlock, NoTerminator, NoRegionArguments,
+                             ProceduralRegion, ProceduralOp, CaseLikeOp]> {
+  let summary = "'case (cond)' block";
+  let description = "See SystemVerilog 2017 12.5.2.";
 
-    // void addCase(...)
-  }];
+  let regions = (region VariadicRegion<SizedRegion<1>>:$caseRegions);
+  let arguments = (ins HWIntegerType:$cond, ArrayAttr:$casePatterns);
+  let results = (outs);
+
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+
+  let builders = [
+    /// This ctor allows you to build a Case with CaseZ
+    OpBuilder<(ins "CaseZOp":$caseZOp)>
+  ];
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -35,7 +35,7 @@ public:
             RegOp, WireOp, LocalParamOp, XMROp,
             // Control flow.
             IfDefOp, IfDefProceduralOp, IfOp, AlwaysOp, AlwaysCombOp,
-            AlwaysFFOp, InitialOp, CaseZOp,
+            AlwaysFFOp, InitialOp, CaseZOp, CaseOp,
             // Other Statements.
             AssignOp, BPAssignOp, PAssignOp, ForceOp, ReleaseOp, AliasOp,
             FWriteOp, VerbatimOp,
@@ -104,6 +104,7 @@ public:
   HANDLE(AlwaysFFOp, Unhandled);
   HANDLE(InitialOp, Unhandled);
   HANDLE(CaseZOp, Unhandled);
+  HANDLE(CaseOp, Unhandled);
 
   // Other Statements.
   HANDLE(AssignOp, Unhandled);

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -2456,6 +2456,9 @@ private:
   LogicalResult visitSV(AlwaysFFOp op);
   LogicalResult visitSV(InitialOp op);
   LogicalResult visitSV(CaseZOp op);
+  LogicalResult visitSV(CaseOp op);
+  template <typename CaseLike>
+  LogicalResult visitSV(CaseLike op, StringRef name);
   LogicalResult visitSV(FWriteOp op);
   LogicalResult visitSV(VerbatimOp op);
 
@@ -3261,10 +3264,21 @@ LogicalResult StmtEmitter::visitSV(InitialOp op) {
 }
 
 LogicalResult StmtEmitter::visitSV(CaseZOp op) {
+  return visitSV<decltype(op)>(op, "casez");
+}
+
+LogicalResult StmtEmitter::visitSV(CaseOp op) {
+  return visitSV<decltype(op)>(op, "case");
+}
+
+template <typename CaseLike>
+LogicalResult StmtEmitter::visitSV(CaseLike op, StringRef name) {
+  static_assert(std::is_base_of<CaseLike, CaseOp>::value ||
+                std::is_base_of<CaseLike, CaseZOp>::value);
   SmallPtrSet<Operation *, 8> ops, emptyOps;
   ops.insert(op);
 
-  indent() << "casez (";
+  indent() << name << " (";
   emitExpression(op.cond(), ops);
   os << ')';
   emitLocationInfoAndNewLine(ops);


### PR DESCRIPTION
This PR [adds a `sv.case`](https://github.com/llvm/circt/pull/2607#issuecomment-1039345071) for #2528 

I also added a `CaseLikeOp` trait to eliminate duplicate code between `CaseZOp` and `CaseOp`. I'm not sure whether that's a good way.

Cons:
1. I can't name `CaseLikeOp::print` because it will cause conflict on the generated code `using Op::print`:
     ```cpp
    class CaseZOp : public ::mlir::Op<CaseZOp, ::mlir::OpTrait::VariadicRegions, ::mlir::OpTrait::ZeroResult, 
    ::mlir::OpTrait::ZeroSuccessor, ::mlir::OpTrait::OneOperand, ::mlir::OpTrait::SingleBlock, ::mlir::OpTrait::NoTerminator, 
    ::mlir::OpTrait::NoRegionArguments, ::circt::sv::ProceduralRegion, ::circt::sv::ProceduralOp, ::circt::sv::CaseLikeOp> {
    public:
      using Op::Op;
      using Op::print;
    ...
    ```
2. I can't use `CaseLikeOp` as a base class for `CaseZOp` and `CaseOp` in `StmtEmitter::visitSV`. Now I'm using a template method + static_assert + is_base_of to avoid duplicate code, which is awkward.

Pros:
1. It works.