### PR TITLE
[FIRParser] Flip assert predicate before applying modifiers

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParserAsserts.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParserAsserts.cpp
@@ -505,6 +505,8 @@ ParseResult circt::firrtl::foldWhenEncodedVerifOp(PrintFOp printOp) {
       return failure();
 
     Value predicate = whenStmt.condition();
+    predicate = builder.create<NotPrimOp>(
+        predicate); // assertion triggers when predicate fails
     switch (predMod) {
     case PredicateModifier::NoMod:
       // Leave the predicate unmodified.
@@ -578,8 +580,6 @@ ParseResult circt::firrtl::foldWhenEncodedVerifOp(PrintFOp printOp) {
 
     // Build the verification op itself.
     Operation *op;
-    predicate = builder.create<NotPrimOp>(
-        predicate); // assertion triggers when predicate fails
     // TODO: The "ifElseFatal" variant isn't actually a concurrent assertion,
     // but downstream logic assumes that isConcurrent is set.
     if (flavor == VerifFlavor::VerifLibAssert)

--- a/test/Dialect/FIRRTL/SFCTests/complex-asserts.fir
+++ b/test/Dialect/FIRRTL/SFCTests/complex-asserts.fir
@@ -89,7 +89,7 @@ circuit Foo:
       stop(clock, enable, 1)
 
     ; assert with predicate option for X-passing
-    ; CHECK-NEXT: wire [[TMP3:.+]] = ~enable | ~(~predicate7 | ~predicate7 === 1'bx);
+    ; CHECK-NEXT: wire [[TMP3:.+]] = ~enable | predicate7 | predicate7 === 1'bx;
     ; CHECK-NEXT: assert__verif_library_2: assert property (@(posedge clock) [[TMP3]])
     ; CHECK-SAME:   else $error("Assertion failed (verification library): X-passing assert example");
     when not(predicate7) :

--- a/test/Dialect/FIRRTL/SFCTests/complex-assumes.fir
+++ b/test/Dialect/FIRRTL/SFCTests/complex-assumes.fir
@@ -55,7 +55,7 @@ circuit Foo:
       stop(clock, enable, 1)
 
     ; assume with predicate option for X-passing
-    ; CHECK-NEXT: {{assume__verif_library.*}}: assume property (@(posedge clock) ~enable | ~(~predicate6 | ~predicate6 === 1'bx))
+    ; CHECK-NEXT: {{assume__verif_library.*}}: assume property (@(posedge clock) ~enable | predicate6 | predicate6 === 1'bx)
     ; CHECK-SAME:   else $error("Assumption does not hold (verification library): X-passing assume example");
     when not(predicate6) :
       printf(clock, enable, "foo [verif-library-assume]<extraction-summary>{\"predicateModifier\":{\"type\":\"trueOrIsX\"},\"baseMsg\":\"Assumption does not hold (verification library): X-passing assume example\"}</extraction-summary> bar")

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -988,10 +988,10 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     when cond:
       printf(clock, enable, "Assertion failed: [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"trueOrIsX\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"},{\"type\":\"formalOnly\"}],\"labelExts\":[\"label\",\"magic\"],\"format\":{\"type\":\"sva\"},\"baseMsg\":\"Hello Assert\"}", value)
       stop(clock, enable, 1)
-    ; CHECK: [[TMP1:%.+]] = firrtl.xorr %cond
+    ; CHECK: [[CONDINV:%.+]] = firrtl.not %cond
+    ; CHECK: [[TMP1:%.+]] = firrtl.xorr [[CONDINV]]
     ; CHECK-NEXT: [[TMP2:%.+]] = firrtl.verbatim.expr "{{[{][{]0[}][}]}} === 1'bx"([[TMP1]])
-    ; CHECK-NEXT: [[TMP3:%.+]] = firrtl.or %cond, [[TMP2]]
-    ; CHECK-NEXT: [[TMP:%.+]] = firrtl.not [[TMP3]]
+    ; CHECK-NEXT: [[TMP:%.+]] = firrtl.or [[CONDINV]], [[TMP2]]
     ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Hello Assert"(%value) : !firrtl.uint<42>
     ; CHECK-SAME: format = "sva"
     ; CHECK-SAME: guards = ["USE_UNR_ONLY_CONSTRAINTS", "USE_FORMAL_ONLY_CONSTRAINTS"]
@@ -1012,10 +1012,10 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     when cond:
       printf(clock, enable, "Assumption failed: [verif-library-assume]<extraction-summary>{\"predicateModifier\":{\"type\":\"trueOrIsX\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"},{\"type\":\"formalOnly\"}],\"labelExts\":[\"label\",\"voodoo\"],\"baseMsg\":\"Hello Assume\"}", value)
       stop(clock, enable, 1)
-    ; CHECK: [[TMP1:%.+]] = firrtl.xorr %cond
+    ; CHECK: [[CONDINV:%.+]] = firrtl.not %cond
+    ; CHECK: [[TMP1:%.+]] = firrtl.xorr [[CONDINV]]
     ; CHECK-NEXT: [[TMP2:%.+]] = firrtl.verbatim.expr "{{[{][{]0[}][}]}} === 1'bx"([[TMP1]])
-    ; CHECK-NEXT: [[TMP3:%.+]] = firrtl.or %cond, [[TMP2]]
-    ; CHECK-NEXT: [[TMP:%.+]] = firrtl.not [[TMP3]]
+    ; CHECK-NEXT: [[TMP:%.+]] = firrtl.or [[CONDINV]], [[TMP2]]
     ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "Hello Assume"(%value) : !firrtl.uint<42>
     ; CHECK-SAME: guards = ["USE_UNR_ONLY_CONSTRAINTS", "USE_FORMAL_ONLY_CONSTRAINTS"]
     ; CHECK-SAME: name = "verif_library_label_voodoo"


### PR DESCRIPTION
When parsing printf-encoded assertions, the condition of the surrounding `when` has to be inverted in order to go from the fail-when-true polarity of the printf to the fail-when-false polarity of the assert. Predicate modifiers (currently just `trueOrIsX`) are formulated with respect to the assertion predicate, i.e., on the fail-when-false polarity. So a `trueOrIsX` modifier is supposed to add an additional pass case to the assertion if the condition is `X`. The parser currently applies predicate modifiers on the fail-when-true polarity, which is wrong. Move the predicate inversion upwards so it occurs before modifiers are applied.

Fixes #2653.