### PR TITLE
[NFC] Fix deprecated warnings after bump llvm

### DIFF
--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -299,9 +299,7 @@ def CaseZOp : SVOp<"casez", [SingleBlock, NoTerminator, NoRegionArguments,
   let regions = (region VariadicRegion<SizedRegion<1>>:$caseRegions);
   let arguments = (ins HWIntegerType:$cond, ArrayAttr:$casePatterns);
   let results = (outs);
-
-  let parser = "return parseCaseZOp(parser, result);";
-  let printer = "printCaseZOp(p, *this);";
+  let hasCustomAssemblyFormat = 1;
   let verifier = "return ::verifyCaseZOp(*this);";
 
   let builders = [

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -634,7 +634,7 @@ auto CaseZOp::getCases() -> SmallVector<CaseZInfo, 4> {
   return result;
 }
 
-static ParseResult parseCaseZOp(OpAsmParser &parser, OperationState &result) {
+ParseResult CaseZOp::parse(OpAsmParser &parser, OperationState &result) {
   auto &builder = parser.getBuilder();
 
   OpAsmParser::OperandType condOperand;
@@ -716,11 +716,11 @@ static ParseResult parseCaseZOp(OpAsmParser &parser, OperationState &result) {
   return success();
 }
 
-static void printCaseZOp(OpAsmPrinter &p, CaseZOp op) {
-  p << ' ' << op.cond() << " : " << op.cond().getType();
-  p.printOptionalAttrDict(op->getAttrs(), /*elidedAttrs=*/{"casePatterns"});
+void CaseZOp::print(OpAsmPrinter &p) {
+  p << ' ' << cond() << " : " << cond().getType();
+  p.printOptionalAttrDict((*this)->getAttrs(), /*elidedAttrs=*/{"casePatterns"});
 
-  for (auto caseInfo : op.getCases()) {
+  for (auto caseInfo : getCases()) {
     p.printNewline();
     auto pattern = caseInfo.pattern;
     if (pattern.isDefault()) {

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -718,7 +718,8 @@ ParseResult CaseZOp::parse(OpAsmParser &parser, OperationState &result) {
 
 void CaseZOp::print(OpAsmPrinter &p) {
   p << ' ' << cond() << " : " << cond().getType();
-  p.printOptionalAttrDict((*this)->getAttrs(), /*elidedAttrs=*/{"casePatterns"});
+  p.printOptionalAttrDict((*this)->getAttrs(),
+                          /*elidedAttrs=*/{"casePatterns"});
 
   for (auto caseInfo : getCases()) {
     p.printNewline();


### PR DESCRIPTION
Thing is that:

note: `parser` and `printer` fields are deprecated and will be removed, please use the `hasCustomAssemblyFormat` field instead
def CaseZOp : SVOp<"casez", [SingleBlock, NoTerminator, NoRegionArguments,
  
------

Add CaseZOp::print, CaseZOp::parse function.