### PR TITLE
[FIRRTL] Preserve All Wires

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRParser.h
+++ b/include/circt/Dialect/FIRRTL/FIRParser.h
@@ -38,6 +38,11 @@ struct FIRParserOptions {
   /// This, along with numOMIRFiles provides structure to the buffers in the
   /// source manager.
   unsigned numAnnotationFiles;
+  /// If true, then the parser will NOT generate debug taps for "named" wires
+  /// and nodes.  A "named" wire/node is one whose name does NOT beging with a
+  /// leading "_".  If false, debug-ability is greatly increased.  If true, much
+  /// more compact Verilog will be generated.
+  bool disableNamePreservation = true;
 };
 
 mlir::OwningOpRef<mlir::ModuleOp> importFIRFile(llvm::SourceMgr &sourceMgr,

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
@@ -1,7 +1,7 @@
-; RUN: firtool --firrtl-grand-central --verilog --annotation-file %S/Wire.anno.json --annotation-file %S/Extract.anno.json %s | FileCheck %s --check-prefixes CHECK,EXTRACT
-; RUN: firtool --firrtl-grand-central --verilog --annotation-file %S/Wire.anno.json %s | FileCheck %s --check-prefixes CHECK,NOEXTRACT
-; RUN: firtool --firrtl-grand-central --verilog --annotation-file %S/Wire.anno.json --annotation-file %S/Extract.anno.json %s --annotation-file %S/YAML.anno.json | FileCheck %s --check-prefixes YAML
-; RUN: firtool --firrtl-grand-central --split-verilog --annotation-file %S/Wire.anno.json %s -o %t.folder > %t  && cat %t.folder/MyView_companion.sv | FileCheck %s --check-prefixes MYVIEW_COMPANION
+; RUN: firtool --firrtl-grand-central --disable-name-preservation --verilog --annotation-file %S/Wire.anno.json --annotation-file %S/Extract.anno.json %s | FileCheck %s --check-prefixes CHECK,EXTRACT
+; RUN: firtool --firrtl-grand-central --disable-name-preservation --verilog --annotation-file %S/Wire.anno.json %s | FileCheck %s --check-prefixes CHECK,NOEXTRACT
+; RUN: firtool --firrtl-grand-central --disable-name-preservation --verilog --annotation-file %S/Wire.anno.json --annotation-file %S/Extract.anno.json %s --annotation-file %S/YAML.anno.json | FileCheck %s --check-prefixes YAML
+; RUN: firtool --firrtl-grand-central --disable-name-preservation --split-verilog --annotation-file %S/Wire.anno.json %s -o %t.folder > %t  && cat %t.folder/MyView_companion.sv | FileCheck %s --check-prefixes MYVIEW_COMPANION
 
 circuit Top :
   module Submodule :

--- a/test/Dialect/FIRRTL/SFCTests/data-taps-nlas.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps-nlas.fir
@@ -1,4 +1,4 @@
-; RUN: firtool --firrtl-grand-central --verilog %s | FileCheck %s
+; RUN: firtool --firrtl-grand-central --disable-name-preservation --verilog %s | FileCheck %s
 ; See https://github.com/llvm/circt/issues/2691
 
 circuit Top : %[[{

--- a/test/Dialect/FIRRTL/SFCTests/signal-mappings.fir
+++ b/test/Dialect/FIRRTL/SFCTests/signal-mappings.fir
@@ -1,4 +1,4 @@
-; RUN: firtool %s --annotation-file %S/signal-mappings-subCircuit.json --firrtl-grand-central --verilog | FileCheck %s
+; RUN: firtool %s --annotation-file %S/signal-mappings-subCircuit.json --disable-name-preservation --firrtl-grand-central --verilog | FileCheck %s
 
 ; Subcircuit:
 

--- a/test/Dialect/FIRRTL/SFCTests/width-spec-errors.fir
+++ b/test/Dialect/FIRRTL/SFCTests/width-spec-errors.fir
@@ -1,4 +1,4 @@
-; RUN: firtool --split-input-file --verify-diagnostics %s
+; RUN: firtool --disable-name-preservation --split-input-file --verify-diagnostics %s
 ; Tests extracted from:
 ; - test/scala/firrtlTests/WidthSpec.scala
 

--- a/test/firtool/name-preservation.fir
+++ b/test/firtool/name-preservation.fir
@@ -1,0 +1,37 @@
+; RUN: firtool %s | FileCheck %s --check-prefixes=CHECK,NAMES
+; RUN: firtool %s -disable-name-preservation | FileCheck %s --check-prefixes=CHECK,NO_NAMES
+
+circuit Foo:
+  ; CHECK-LABEL: module Foo
+  module Foo:
+    input a: {a: UInt<1>, flip b: UInt<1>}
+    output b: {a: UInt<1>, flip b: UInt<1>}
+
+    ; Unnamed wires are always removed.
+    ; CHECK-NOT: wire _x_a;
+    ; CHECK-NOT: wire _x_b;
+
+    wire _x: {a: UInt<1>, flip b: UInt<1>}
+    _x <= a
+
+    ; Default behavior is to preserve named wires.
+    ; NAMES:        wire x_a;
+    ; NAMES:        wire x_b;
+    ; With -disable-name-preservation, named wires are removed.
+    ; NO_NAMES-NOT: wire x_b;
+    ; NO_NAMES-NOT: wire x_a;
+    wire x: {a: UInt<1>, flip b: UInt<1>}
+    x <= _x
+
+    ; Unnamed nodes are always removed.
+    ; CHECK-NOT: wire _y_a;
+    node _y_a = x.a
+
+    ; Default behavior is to preserve named nodes.
+    ; NAMES:        wire y;
+    ; With -disable-name-preservation, named nodes are removed.
+    ; NO-NAMES-NOT: wire y;
+    node y = _y_a
+
+    b.a <= y
+    x.b <= b.b

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -102,6 +102,11 @@ static cl::opt<bool> disableAnnotationsUnknown(
     "disable-annotation-unknown",
     cl::desc("Ignore unknown annotations when parsing"), cl::init(false));
 
+static cl::opt<bool> disableNamePreservation(
+    "disable-name-preservation",
+    cl::desc("Don't generate debug taps for named FIRRTL wires and nodes"),
+    cl::init(false));
+
 static cl::opt<bool>
     emitMetadata("emit-metadata",
                  cl::desc("emit metadata for metadata annotations"),
@@ -381,6 +386,7 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
     options.ignoreInfoLocators = ignoreFIRLocations;
     options.rawAnnotations = newAnno;
     options.numAnnotationFiles = numAnnotationFiles;
+    options.disableNamePreservation = disableNamePreservation;
     module = importFIRFile(sourceMgr, &context, options);
   } else {
     auto parserTimer = ts.nest("MLIR Parser");


### PR DESCRIPTION
Change end-to-end FIRRTL compilation behavior to preserve all wires that
exist in CHIRRTL.  This is accomplished by creating a "shadow wire" that
is assigned the value of the actual wire and marked "don't touch".

This is done to enable better debug-ability of Chisel designs by, with a
future change to Chisel to convert any named Scala val to a wire,
enabling users to always have references to named things they define in
Chisel.

This has the effect of changing the compilation of the following:

```scala
circuit Foo:
  module Foo:
    input a: UInt<1>
    output b: UInt<1>

    wire x: UInt<1>
    x <= a

    b <= x
```

To produce:
```verilog
module Foo(	
  input  a,
  output b);

  wire x;	

  assign x = a;
  assign b = a;
endmodule
```

With the change that @jackkoenig shows in [this Chisel branch](https://github.com/chipsalliance/chisel3/compare/emit-named-nodes-as-wires), this will preserve _almost_ every Chisel-defined `val`.

Note: this is the absolute simplest possible way to implement this change.  There are cleaner ways like building out more support for FIRRTL probe ops and enabling named probes.  Users should also likely have a way of opting out of preserve all wires behavior.

h/t: @jsmithsf