### PR TITLE
[Handshake] Rename handshake.instance to handshake.call

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -110,20 +110,20 @@ def FuncOp : Op<Handshake_Dialect, "func", [
   let hasCustomAssemblyFormat = 1;
 }
 
-// InstanceOp
-def InstanceOp : Handshake_Op<"instance", [CallOpInterface]> {
-  let summary = "module instantiate operation";
+// CallOp
+def CallOp : Handshake_Op<"call", [CallOpInterface]> {
+  let summary = "Handshake function instantiation operation";
   let description = [{
-    The `instance` operation represents the instantiation of a module.  This
-	  is similar to a function call, except that different instances of the
-	  same module are guaranteed to have their own distinct state.
-    The instantiated module is encoded as a symbol reference attribute named
-    "module". An instance operation takes a control input as its last argument
+    The `call` operation represents the instantiation of a handshake function.
+    This is similar to a function call, except that different calls of the
+	  same function are guaranteed to have their own distinct state.
+    The called function is encoded as a symbol reference attribute named
+    "module". A call operation takes a control input as its last argument
     and returns a control output as its last result.
 
     Example:
     ```mlir
-    %2:2 = handshake.instance @my_add(%0, %1, %ctrl) : (f32, f32, none) -> (f32, none)
+    %2:2 = call @my_add(%0, %1, %ctrl) : (f32, f32, none) -> (f32, none)
     ```
   }];
 
@@ -168,7 +168,7 @@ def InstanceOp : Handshake_Op<"instance", [CallOpInterface]> {
       return (*this)->getAttrOfType<SymbolRefAttr>("module");
     }
 
-    /// Get the control operand of this instance op
+    /// Get the control operand of this call op
     Value getControl() {
       return getOperands().back();
     }

--- a/include/circt/Dialect/Handshake/Visitor.h
+++ b/include/circt/Dialect/Handshake/Visitor.h
@@ -31,7 +31,7 @@ public:
         .template Case<
             // Handshake nodes.
             BranchOp, BufferOp, ConditionalBranchOp, ConstantOp, ControlMergeOp,
-            EndOp, ForkOp, FuncOp, InstanceOp, JoinOp, LazyForkOp, LoadOp,
+            EndOp, ForkOp, FuncOp, CallOp, JoinOp, LazyForkOp, LoadOp,
             MemoryOp, ExternalMemoryOp, MergeOp, MuxOp, ReturnOp, SinkOp,
             handshake::SelectOp, SourceOp, StartOp, StoreOp, TerminatorOp>(
             [&](auto opNode) -> ResultType {
@@ -68,7 +68,7 @@ public:
   HANDLE(EndOp);
   HANDLE(ForkOp);
   HANDLE(FuncOp);
-  HANDLE(InstanceOp);
+  HANDLE(CallOp);
   HANDLE(JoinOp);
   HANDLE(LazyForkOp);
   HANDLE(LoadOp);

--- a/include/circt/Dialect/Handshake/Visitor.h
+++ b/include/circt/Dialect/Handshake/Visitor.h
@@ -31,8 +31,8 @@ public:
         .template Case<
             // Handshake nodes.
             BranchOp, BufferOp, ConditionalBranchOp, ConstantOp, ControlMergeOp,
-            EndOp, ForkOp, FuncOp, CallOp, JoinOp, LazyForkOp, LoadOp,
-            MemoryOp, ExternalMemoryOp, MergeOp, MuxOp, ReturnOp, SinkOp,
+            EndOp, ForkOp, FuncOp, CallOp, JoinOp, LazyForkOp, LoadOp, MemoryOp,
+            ExternalMemoryOp, MergeOp, MuxOp, ReturnOp, SinkOp,
             handshake::SelectOp, SourceOp, StartOp, StoreOp, TerminatorOp>(
             [&](auto opNode) -> ResultType {
               return thisCast->visitHandshake(opNode, args...);

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -1414,7 +1414,7 @@ ParseResult JoinOp::parse(OpAsmParser &parser, OperationState &result) {
 
 void JoinOp::print(OpAsmPrinter &p) { sost::printOp(p, *this, false); }
 
-static LogicalResult verifyInstanceOp(handshake::InstanceOp op) {
+static LogicalResult verifyCallOp(handshake::CallOp op) {
   if (op->getNumOperands() == 0)
     return op.emitOpError() << "must provide at least a control operand.";
 

--- a/lib/Dialect/Handshake/Transforms/Analysis.cpp
+++ b/lib/Dialect/Handshake/Transforms/Analysis.cpp
@@ -484,12 +484,12 @@ std::string HandshakeDotPrintPass::dotPrint(mlir::raw_indented_ostream &os,
   os << "label=\"\"\n";
   os << "peripheries=0\n";
   for (Operation &op : *bodyBlock) {
-    if (!isa<handshake::InstanceOp, handshake::ReturnOp>(op)) {
+    if (!isa<handshake::CallOp, handshake::ReturnOp>(op)) {
       // Regular node in the diagram.
       opNameMap[&op] = dotPrintNode(os, instanceName, &op, opIDs);
       continue;
     }
-    auto instOp = dyn_cast<handshake::InstanceOp>(op);
+    auto instOp = dyn_cast<handshake::CallOp>(op);
     if (instOp) {
       // Recurse into instantiated submodule.
       auto calledFuncOp =

--- a/lib/Dialect/Handshake/Transforms/PassHelpers.cpp
+++ b/lib/Dialect/Handshake/Transforms/PassHelpers.cpp
@@ -39,7 +39,7 @@ LogicalResult resolveInstanceGraph(ModuleOp moduleOp,
   // Create use graph
   auto walkFuncOps = [&](handshake::FuncOp funcOp) {
     auto &funcUses = instanceGraph[funcOp.getName().str()];
-    funcOp.walk([&](handshake::InstanceOp instanceOp) {
+    funcOp.walk([&](handshake::CallOp instanceOp) {
       funcUses.insert(instanceOp.getModule().str());
     });
   };

--- a/test/Conversion/HandshakeToFIRRTL/errors.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/errors.mlir
@@ -4,17 +4,17 @@
 // expected-error @+1 {{'builtin.module' op cannot deduce top level function - cycle detected in instance graph (bar->baz->foo->bar).}}
 module {
   handshake.func @bar(%ctrl : none) -> (none) {
-    %0 = handshake.instance @baz(%ctrl) : (none) -> (none)
+    %0 = call @baz(%ctrl) : (none) -> (none)
     return %0: none
   }
 
   handshake.func @foo(%ctrl : none) -> (none) {
-    %0 = handshake.instance @bar(%ctrl) : (none) -> (none)
+    %0 = call @bar(%ctrl) : (none) -> (none)
     return %0: none  
   }
   
   handshake.func @baz(%ctrl : none) -> (none) {
-    %0 = handshake.instance @foo(%ctrl) : (none) -> (none)
+    %0 = call @foo(%ctrl) : (none) -> (none)
     return %0: none  
   }
 }
@@ -25,12 +25,12 @@ module {
 // expected-error @+1 {{'builtin.module' op multiple candidate top-level modules detected (bar, foo). Please remove one of these from the source program.}}
 module {
   handshake.func @bar(%ctrl : none) -> (none) {
-    %0 = handshake.instance @baz(%ctrl) : (none) -> (none)
+    %0 = call @baz(%ctrl) : (none) -> (none)
     return %0: none
   }
 
   handshake.func @foo(%ctrl : none) -> (none) {
-    %0 = handshake.instance @baz(%ctrl) : (none) -> (none)
+    %0 = call @baz(%ctrl) : (none) -> (none)
     return %0: none  
   }
   

--- a/test/Conversion/HandshakeToFIRRTL/test_instance.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_instance.mlir
@@ -18,12 +18,12 @@ module {
   }
 
   handshake.func @bar(%a: i32, %ctrl : none) -> (i32, none) {
-    %c, %ctrlOut = handshake.instance @baz(%a, %ctrl) : (i32, none) -> (i32, none)
+    %c, %ctrlOut = call @baz(%a, %ctrl) : (i32, none) -> (i32, none)
     return %c, %ctrlOut : i32, none
   }
 
   handshake.func @foo(%a: i32, %ctrl : none) -> (i32, none) {
-    %b:2 = handshake.instance @bar(%a, %ctrl) : (i32, none) -> (i32, none)
+    %b:2 = call @bar(%a, %ctrl) : (i32, none) -> (i32, none)
     return %b#0, %b#1 : i32, none
   }
 }

--- a/test/Conversion/StandardToHandshake/test_call.mlir
+++ b/test/Conversion/StandardToHandshake/test_call.mlir
@@ -15,7 +15,7 @@ func @bar(%0 : i32) -> i32 {
 // CHECK-SAME:                        %[[VAL_1:.*]]: none, ...) -> (i32, none) attributes {argNames = ["in0", "inCtrl"], resNames = ["out0", "outCtrl"]} {
 // CHECK:           %[[VAL_2:.*]] = merge %[[VAL_0]] : i32
 // CHECK:           %[[VAL_3:.*]]:2 = fork [2] %[[VAL_1]] : none
-// CHECK:           %[[VAL_4:.*]]:2 = instance @bar(%[[VAL_2]], %[[VAL_3]]#0) : (i32, none) -> (i32, none)
+// CHECK:           %[[VAL_4:.*]]:2 = call @bar(%[[VAL_2]], %[[VAL_3]]#0) : (i32, none) -> (i32, none)
 // CHECK:           sink %[[VAL_4]]#1 : none
 // CHECK:           return %[[VAL_4]]#0, %[[VAL_3]]#1 : i32, none
 // CHECK:         }
@@ -53,7 +53,7 @@ func @sub(%arg0 : i32, %arg1: i32) -> i32 {
 // CHECK:           %[[VAL_16:.*]], %[[VAL_17:.*]] = control_merge %[[VAL_12]] : none
 // CHECK:           %[[VAL_18:.*]]:2 = fork [2] %[[VAL_16]] : none
 // CHECK:           sink %[[VAL_17]] : index
-// CHECK:           %[[VAL_19:.*]]:2 = instance @add(%[[VAL_14]], %[[VAL_15]], %[[VAL_18]]#1) : (i32, i32, none) -> (i32, none)
+// CHECK:           %[[VAL_19:.*]]:2 = call @add(%[[VAL_14]], %[[VAL_15]], %[[VAL_18]]#1) : (i32, i32, none) -> (i32, none)
 // CHECK:           sink %[[VAL_19]]#1 : none
 // CHECK:           %[[VAL_20:.*]] = br %[[VAL_18]]#0 : none
 // CHECK:           %[[VAL_21:.*]] = br %[[VAL_19]]#0 : i32
@@ -62,7 +62,7 @@ func @sub(%arg0 : i32, %arg1: i32) -> i32 {
 // CHECK:           %[[VAL_24:.*]], %[[VAL_25:.*]] = control_merge %[[VAL_13]] : none
 // CHECK:           %[[VAL_26:.*]]:2 = fork [2] %[[VAL_24]] : none
 // CHECK:           sink %[[VAL_25]] : index
-// CHECK:           %[[VAL_27:.*]]:2 = instance @sub(%[[VAL_22]], %[[VAL_23]], %[[VAL_26]]#1) : (i32, i32, none) -> (i32, none)
+// CHECK:           %[[VAL_27:.*]]:2 = call @sub(%[[VAL_22]], %[[VAL_23]], %[[VAL_26]]#1) : (i32, i32, none) -> (i32, none)
 // CHECK:           sink %[[VAL_27]]#1 : none
 // CHECK:           %[[VAL_28:.*]] = br %[[VAL_26]]#0 : none
 // CHECK:           %[[VAL_29:.*]] = br %[[VAL_27]]#0 : i32

--- a/test/Dialect/Handshake/errors.mlir
+++ b/test/Dialect/Handshake/errors.mlir
@@ -36,9 +36,9 @@ handshake.func @foo(%ctrl : none) -> none{
   return %ctrl : none
 }
 
-handshake.func @invalid_instance_op(%arg0 : i32, %ctrl : none) -> none {
-  // expected-error @+1 {{'handshake.instance' op last operand must be a control (none-typed) operand.}}
-  instance @foo(%ctrl, %arg0) : (none, i32) -> ()
+handshake.func @invalid_call_op(%arg0 : i32, %ctrl : none) -> none {
+  // expected-error @+1 {{'handshake.call' op last operand must be a control (none-typed) operand.}}
+  call @foo(%ctrl, %arg0) : (none, i32) -> ()
   return %ctrl : none
 }
 
@@ -48,9 +48,9 @@ handshake.func @foo(%ctrl : none) -> none{
   return %ctrl : none
 }
 
-handshake.func @invalid_instance_op(%ctrl : none) -> none {
-  // expected-error @+1 {{'handshake.instance' op must provide at least a control operand.}}
-  instance @foo() : () -> ()
+handshake.func @invalid_call_op(%ctrl : none) -> none {
+  // expected-error @+1 {{'handshake.call' op must provide at least a control operand.}}
+  call @foo() : () -> ()
   return %ctrl : none
 }
 


### PR DESCRIPTION
As discussed in #2118, renaming handshake.instance to handshake.call paves the path for handshake.instance to implement the semantics of instantiating a hardware module, as compared to a handshake function.