### PR TITLE
[FIRRTL][Dedup] Fix partial connect expansion

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -322,9 +322,9 @@ private:
     }
     // Check if they are bundle types.
     if (auto dstOldBundle = dstOldType.dyn_cast<BundleType>()) {
-      auto dstNewBundle = dstOldType.cast<BundleType>();
-      auto srcNewBundle = dstNewType.cast<BundleType>();
+      auto dstNewBundle = dstNewType.cast<BundleType>();
       auto srcOldBundle = srcOldType.cast<BundleType>();
+      auto srcNewBundle = srcNewType.cast<BundleType>();
       for (auto &pair : llvm::enumerate(dstOldBundle)) {
         // Find a matching field in the old type.
         auto dstField = pair.value();

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -355,6 +355,23 @@ firrtl.circuit "Bundle" {
   }
 }
 
+// This is testing an issue in partial connect fixup from a spelling mistake in
+// the pass.
+firrtl.circuit "PartialIssue" {
+  firrtl.module @A(out %a: !firrtl.bundle<member: bundle<a: bundle<clock: clock, reset: asyncreset>>>) { }
+  firrtl.module @B(out %b: !firrtl.bundle<member: bundle<b: bundle<clock: clock, reset: asyncreset>>>) { }
+  firrtl.module @PartialIssue() {
+    %a = firrtl.instance a @A(out a: !firrtl.bundle<member: bundle<a: bundle<clock: clock, reset: asyncreset>>>)
+    %b = firrtl.instance b @B(out b: !firrtl.bundle<member: bundle<b: bundle<clock: clock, reset: asyncreset>>>)
+    %wb = firrtl.wire : !firrtl.bundle<member: bundle<b: bundle<clock: clock, reset: asyncreset>>>
+    firrtl.partialconnect %wb, %b : !firrtl.bundle<member: bundle<b: bundle<clock: clock, reset: asyncreset>>>, !firrtl.bundle<member: bundle<b: bundle<clock: clock, reset: asyncreset>>>
+    // CHECK: %0 = firrtl.subfield %wb(0)
+    // CHECK: %1 = firrtl.subfield %0(0)
+    // CHECK: %2 = firrtl.subfield %b_a(0)
+    // CHECK: %3 = firrtl.subfield %2(0)
+    // CHECK: firrtl.partialconnect %1, %3
+  }
+}
 
 // Make sure flipped fields are handled properly. This should pass flow
 // verification checking.


### PR DESCRIPTION
When deduplicating two modules, the names of fields in bundle types may
change, which means we have to go and fix partial connect operations to
make sure that the proper fields remain connected.  There was a spelling
mistake in this piece of code which caused the expander to think that
the LHS and RHS types of the partial connect were unchanged, and not fix
up the partial connect.  This would typically cause fields which used to
be connected to become unconnected.