### PR TITLE
[FIRRTL] Add `HWDialect` to the `dependentDialects`

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDialect.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDialect.h
@@ -13,6 +13,7 @@
 #ifndef CIRCT_DIALECT_FIRRTL_DIALECT_H
 #define CIRCT_DIALECT_FIRRTL_DIALECT_H
 
+#include "circt/Dialect/HW/HWDialect.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Dialect.h"

--- a/include/circt/Dialect/FIRRTL/FIRRTLDialect.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDialect.td
@@ -21,6 +21,9 @@ def FIRRTLDialect : Dialect {
   }];
 
   let hasConstantMaterializer = 1;
+  let dependentDialects = [
+    "circt::hw::HWDialect"
+  ];
   let cppNamespace = "::circt::firrtl";
   let extraClassDeclaration = [{
     /// Register all FIRRTL types.


### PR DESCRIPTION
FIRRTL heavily uses some attributes defined in the HW dialect, and it is
causing a crash when a pass creates these attributes without the dialect
being loaded first.