### PR TITLE
[FIRRTL][Dedup] Fix creation of symbols with empty name

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
@@ -599,7 +599,7 @@ StringAttr OpAnnoTarget::getInnerSym(ModuleNamespace &moduleNamespace) const {
     // Try to come up with a reasonable name.
     StringRef name = "inner_sym";
     auto nameAttr = getOp()->getAttrOfType<StringAttr>("name");
-    if (nameAttr)
+    if (nameAttr && !nameAttr.getValue().empty())
       name = nameAttr.getValue();
     innerSym = StringAttr::get(context, moduleNamespace.newName(name));
     getOp()->setAttr("inner_sym", innerSym);

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -38,6 +38,22 @@ firrtl.circuit "Simple" {
 }
 
 
+// Should pick a valid symbol when a wire has no name.
+// CHECK-LABEL: firrtl.circuit "Top"
+firrtl.circuit "Top"  {
+  firrtl.module @Top() {
+    %a1_x = firrtl.instance a1  @A(out x: !firrtl.uint<1>)
+    %a2_x = firrtl.instance a2  @A_(out x: !firrtl.uint<1>)
+  }
+  firrtl.module @A(out %x: !firrtl.uint<1>) {
+    // CHECK: %0 = firrtl.wire sym @inner_sym
+    %0 = firrtl.wire  {annotations = [{class = "hello"}]} : !firrtl.uint<1>
+  }
+  firrtl.module @A_(out %x: !firrtl.uint<1>) {
+    %0 = firrtl.wire  : !firrtl.uint<1>
+  }
+}
+
 // CHECK-LABEL: firrtl.circuit "PrimOps"
 firrtl.circuit "PrimOps" {
   // CHECK: firrtl.module @PrimOps0


### PR DESCRIPTION
When creating an `inner_sym` for ops, Dedup was using the "name" attribute of
the op as a base.  For many ops, it is possible that the attribute is an empty
string, which should not be used to create a symbol.  This change makes Dedupe
use `inner_sym` as the symbol base when the name is empty.  This does not
change the behaviour for ports: they must have a non-empty name.
