### PR TITLE
[FIRRTLToHW] Consider strictconnect for elimination

### DIFF
--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1647,4 +1647,11 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-NEXT:   %[[v0:.+]] = comb.and %rEn, %wMask : i1
   // CHECK-NEXT:   %tbMemoryKind1.R0_data = hw.instance "tbMemoryKind1" @tbMemoryKind1_ext(R0_addr: %rAddr: i4, R0_en: %rEn: i1, R0_clk: %clock: i1, W0_addr: %rAddr: i4, W0_en: %[[v0]]: i1, W0_clk: %clock: i1, W0_data: %wData: i8) -> (R0_data: i8)
   // CHECK-NEXT:   hw.output %tbMemoryKind1.R0_data : i8
+
+  // CHECK-LABEL: hw.module @eliminateSingleOutputConnects
+  // CHECK-NOT:     [[WIRE:%.+]] = sv.wire
+  // CHECK-NEXT:    hw.output %a : i1
+  firrtl.module @eliminateSingleOutputConnects(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
+    firrtl.strictconnect %b, %a : !firrtl.uint<1>
+  }
 }


### PR DESCRIPTION
The `LowerToHW` conversion uses the `tryEliminatingConnectsToValue` function to try and eliminate unnecessary connects to a value and replace all value uses with the connected value instead. This is used to avoid unnecessary `*.output` temporary wires when generating the `hw.output` lowering. That function only considers `ConnectOp` though, and any `StrictConnectOp` are left untouched. This commit extends the elimination to also consider `StrictConnectOp`, such that the lowered HW design contains fewer temporary wires.