### PR TITLE
[FIRRTL] Allow foreign types in module/instance ports

### DIFF
--- a/docs/Dialects/FIRRTL/RationaleFIRRTL.md
+++ b/docs/Dialects/FIRRTL/RationaleFIRRTL.md
@@ -556,6 +556,19 @@ Flow is _not_ represented as a first-class type in CIRCT.  We instead provide
 utilities for computing flow when needed, e.g., for connect statement
 verification.
 
+### Non-FIRRTL Types
+
+The FIRRTL dialect has limited support for foreign types, i.e., types that are defined outside the FIRRTL dialect. Almost all operations expect to be dealing with FIRRTL types, especially those that are sensitive to the type they operate on, like `firrtl.add` or `firrtl.connect`. However, a restricted set of operations allows for simple pass-through semantics of foreign types. These include the following:
+
+- Ports on a `firrtl.module`, where the foreign types are treated as opaque values moving in and out of the module
+- Ports on a `firrtl.instance`
+- `firrtl.wire` to allow for def-after-use cases; the wire must have a single strict connect that uniquely defines the wire's value
+- `firrtl.strictconnect` to module outputs, instance inputs, and wires
+
+The expected lowering for strict connects is for the connect to be eliminated and the right-hand-side source value of the connect being instead materialized in all places where the left hand side is used. Basically we want wires and connects to disappear, and all places where the wire is "read" should instead read the value that was driven onto the wire.
+
+The reason we provide this foreign type support is to allow for partial lowering of FIRRTL to HW and other dialects. Passes might lower a subset of types and operations to the target dialect and we need a mechanism to have the lowered values be passed around the FIRRTL module hierarchy untouched alongside the FIRRTL ops that are yet to be lowered.
+
 ## Operations
 
 ### Multiple result `firrtl.instance` operation

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -40,7 +40,7 @@ def InstanceOp : ReferableDeclOp<"instance", [HasParent<"firrtl::FModuleOp, firr
                        UnitAttr:$lowerToBind,
                        OptionalAttr<InnerSymAttr>:$inner_sym);
 
-  let results = (outs Variadic<FIRRTLType>:$results);
+  let results = (outs Variadic<AnyType>:$results);
 
   let hasCustomAssemblyFormat = 1;
 
@@ -354,7 +354,7 @@ def WireOp : ReferableDeclOp<"wire"> {
   let arguments = (ins StrAttr:$name, NameKindAttr:$nameKind,
                        AnnotationArrayAttr:$annotations,
                        OptionalAttr<InnerSymAttr>:$inner_sym);
-  let results = (outs FIRRTLBaseType:$result);
+  let results = (outs AnyType:$result);
 
   let builders = [
     OpBuilder<(ins "::mlir::Type":$elementType,

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -105,10 +105,10 @@ def FModuleLike : OpInterface<"FModuleLike"> {
     }]>,
 
     InterfaceMethod<"Get a port type",
-    "FIRRTLType", "getPortType", (ins "size_t":$portIndex), [{}],
+    "Type", "getPortType", (ins "size_t":$portIndex), [{}],
     /*defaultImplementation=*/[{
       auto typeAttr = $_op.getPortTypeAttr(portIndex);
-      return typeAttr.getValue().template cast<FIRRTLType>();
+      return typeAttr.getValue();
     }]>,
 
     //===------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -49,7 +49,8 @@ def StrictConnectOp : FIRRTLOp<"strictconnect", [SameTypeOperands, FConnectLike]
     ```
     }];
 
-  let arguments = (ins SizedBaseOrRefType:$dest, SizedBaseOrRefType:$src);
+  let arguments = (ins SizedBaseOrRefTypeOrForeignType:$dest,
+                       SizedBaseOrRefTypeOrForeignType:$src);
   let results = (outs);
   let hasCanonicalizeMethod = true;
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -38,6 +38,9 @@ def FIRRTLBaseType : FIRRTLDialectType<
     All base types are FIRRTLType's, and inherit from FIRRTLBaseType.
   }]>;
 
+def ForeignType : FIRRTLDialectType<CPred<"!$_self.isa<FIRRTLType>()">,
+                                    "foreign type", "::mlir::Type">;
+
 def ClockType : FIRRTLDialectType<CPred<"$_self.isa<ClockType>()">,
     "clock", "::circt::firrtl::ClockType">,
   BuildableType<"ClockType::get($_builder.getContext())">;
@@ -78,6 +81,12 @@ def SizedBaseOrRefType : FIRRTLDialectType<
           "!$_self.cast<RefType>().getType().hasUninferredWidth()">,
     ]>,
   "a sized base or ref type (contains no uninferred widths)", "::circt::firrtl::FIRRTLType">;
+
+def SizedType : FIRRTLDialectType<CPred<"$_self.isa<FIRRTLBaseType>() && "
+    "!$_self.cast<FIRRTLBaseType>().hasUninferredWidth()">,
+    "a sized type (contains no unifered widths)", "::circt::firrtl::FIRRTLType">;
+def SizedOrForeignType : AnyTypeOf<[SizedType, ForeignType]>;
+def SizedBaseOrRefTypeOrForeignType : AnyTypeOf<[SizedBaseOrRefType, ForeignType]>;
 
 def UInt1Type : FIRRTLDialectType<
     CPred<"$_self.isa<UIntType>() && "

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -48,12 +48,13 @@ using hw::PortDirection;
 /// annotated module should be dumped to a file.
 static const char moduleHierarchyFileAttrName[] = "firrtl.moduleHierarchyFile";
 
-/// Given a FIRRTL type, return the corresponding type for the HW dialect.
-/// This returns a null type if it cannot be lowered.
+/// Given a type, return the corresponding lowered type for the HW dialect.
+/// Non-FIRRTL types are simply passed through. This returns a null type if it
+/// cannot be lowered.
 static Type lowerType(Type type) {
   auto firType = type.dyn_cast<FIRRTLBaseType>();
   if (!firType)
-    return {};
+    return type;
 
   // Ignore flip types.
   firType = firType.getPassiveType();
@@ -82,11 +83,11 @@ static Type lowerType(Type type) {
   return {};
 }
 
-/// Return true if the specified FIRRTL type is a sized type (Int or Analog)
+/// Return true if the specified type is a sized FIRRTL type (Int or Analog)
 /// with zero bits.
 static bool isZeroBitFIRRTLType(Type type) {
-  return type.cast<FIRRTLBaseType>().getPassiveType().getBitWidthOrSentinel() ==
-         0;
+  auto ftype = type.dyn_cast<FIRRTLBaseType>();
+  return ftype && ftype.getPassiveType().getBitWidthOrSentinel() == 0;
 }
 
 // Return a single source value in the operands of the given attach op if
@@ -151,18 +152,17 @@ static IntType getWidestIntType(Type t1, Type t2) {
   return t2c.getWidth() > t1c.getWidth() ? t2c : t1c;
 }
 
-/// Cast from a standard type to a FIRRTL type, potentially with a flip.
+/// Cast a value to a desired target type. This will insert struct casts and
+/// unrealized conversion casts as necessary.
 static Value castToFIRRTLType(Value val, Type type,
                               ImplicitLocOpBuilder &builder) {
-  auto firType = type.cast<FIRRTLType>();
-
   // Use HWStructCastOp for a bundle type.
   if (BundleType bundle = type.dyn_cast<BundleType>())
     val = builder.createOrFold<HWStructCastOp>(bundle.getPassiveType(), val);
 
   if (type != val.getType())
-    val = builder.create<mlir::UnrealizedConversionCastOp>(firType, val)
-              .getResult(0);
+    val = builder.create<mlir::UnrealizedConversionCastOp>(type, val).getResult(
+        0);
 
   return val;
 }
@@ -1200,7 +1200,6 @@ static Value tryEliminatingAttachesToAnalogValue(Value value,
 /// location is where a 'hw.merge' operation should be inserted if needed.
 static Value tryEliminatingConnectsToValue(Value flipValue,
                                            Operation *insertPoint) {
-  assert(flipValue.getType().isa<FIRRTLBaseType>());
   // Handle analog's separately.
   if (flipValue.getType().isa<AnalogType>())
     return tryEliminatingAttachesToAnalogValue(flipValue, insertPoint);
@@ -1235,6 +1234,12 @@ static Value tryEliminatingConnectsToValue(Value flipValue,
   ImplicitLocOpBuilder builder(insertPoint->getLoc(), insertPoint);
 
   auto connectSrc = connectOp->getOperand(1);
+
+  // Directly forward foreign types.
+  if (!connectSrc.getType().isa<FIRRTLType>()) {
+    connectOp->erase();
+    return connectSrc;
+  }
 
   // Convert fliped sources to passive sources.
   if (!connectSrc.getType().cast<FIRRTLBaseType>().isPassive())
@@ -1812,8 +1817,7 @@ Value FIRRTLLowering::getOrCreateIntConstant(const APInt &value) {
 /// zero bit, or returns failure() if it was some other kind of failure.
 static LogicalResult handleZeroBit(Value failedOperand,
                                    std::function<LogicalResult()> fn) {
-  assert(failedOperand && failedOperand.getType().isa<FIRRTLType>() &&
-         "Should be called on the failed FIRRTL operand");
+  assert(failedOperand && "Should be called on the failed operand");
   if (!isZeroBitFIRRTLType(failedOperand.getType()))
     return failure();
   return fn();
@@ -2484,6 +2488,13 @@ LogicalResult FIRRTLLowering::visitExpr(SubfieldOp op) {
 //===----------------------------------------------------------------------===//
 
 LogicalResult FIRRTLLowering::visitDecl(WireOp op) {
+  // Foreign types lower to a backedge that needs to be resolved by a later
+  // connect op.
+  if (!op.getType().isa<FIRRTLType>()) {
+    createBackedge(op, op.getType());
+    return success();
+  }
+
   auto resultType = lowerType(op.getResult().getType());
   if (!resultType)
     return failure();
@@ -2896,6 +2907,12 @@ LogicalResult FIRRTLLowering::visitDecl(InstanceOp oldInstance) {
           continue;
         }
       }
+    }
+
+    // Directly materialize foreign types.
+    if (!port.type.isa<FIRRTLType>()) {
+      operands.push_back(createBackedge(portResult, portType));
+      continue;
     }
 
     // Create a wire for each input/inout operand, so there is

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
@@ -666,7 +666,7 @@ PortAnnoTarget::getNLAReference(ModuleNamespace &moduleNamespace) const {
 FIRRTLType PortAnnoTarget::getType() const {
   auto *op = getOp();
   if (auto module = llvm::dyn_cast<FModuleLike>(op))
-    return module.getPortType(getPortNo());
+    return module.getPortType(getPortNo()).cast<FIRRTLType>();
   if (llvm::isa<MemOp, InstanceOp>(op))
     return op->getResult(getPortNo()).getType().cast<FIRRTLType>();
   llvm_unreachable("unknow operation kind");

--- a/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
@@ -25,13 +25,10 @@ LogicalResult circt::firrtl::verifyModuleLikeOpInterface(FModuleLike module) {
   // Verify port types first.  This is used as the basis for the number of
   // ports required everywhere else.
   auto portTypes = module.getPortTypesAttr();
-  if (!portTypes)
-    return module.emitOpError("requires valid port types");
-  if (llvm::any_of(portTypes.getValue(), [](Attribute attr) {
-        auto typeAttr = attr.dyn_cast<TypeAttr>();
-        return !typeAttr || !typeAttr.getValue().isa<FIRRTLType>();
+  if (!portTypes || llvm::any_of(portTypes.getValue(), [](Attribute attr) {
+        return !attr.isa<TypeAttr>();
       }))
-    return module.emitOpError("ports should all be FIRRTL types");
+    return module.emitOpError("requires valid port types");
 
   auto numPorts = portTypes.size();
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -382,7 +382,7 @@ LogicalResult CircuitOp::verify() {
     // has zero false positives.
     for (auto p : llvm::zip(ports, collidingPorts)) {
       StringAttr aName = std::get<0>(p).name, bName = std::get<1>(p).name;
-      FIRRTLType aType = std::get<0>(p).type, bType = std::get<1>(p).type;
+      Type aType = std::get<0>(p).type, bType = std::get<1>(p).type;
 
       if (aName != bName)
         return extModule.emitOpError()
@@ -2154,12 +2154,13 @@ LogicalResult ConnectOp::verify() {
 }
 
 LogicalResult StrictConnectOp::verify() {
-  auto type = getDest().getType().cast<FIRRTLType>();
-  auto baseType = type.dyn_cast<FIRRTLBaseType>();
+  if (auto type = getDest().getType().dyn_cast<FIRRTLType>()) {
+    auto baseType = type.dyn_cast<FIRRTLBaseType>();
 
-  // Analog types cannot be connected and must be attached.
-  if (baseType && baseType.containsAnalog())
-    return emitError("analog types may not be connected");
+    // Analog types cannot be connected and must be attached.
+    if (baseType && baseType.containsAnalog())
+      return emitError("analog types may not be connected");
+  }
 
   // Check that the flows make sense.
   if (failed(checkConnectFlow(*this)))

--- a/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
@@ -226,7 +226,8 @@ LogicalResult AddSeqMemPortsPass::processModule(FModuleOp module) {
         auto portType = sramPort.type;
         // Record the extra port.
         extraPorts.push_back(
-            {firstPortIndex, {portName, portType, portDirection}});
+            {firstPortIndex,
+             {portName, portType.cast<FIRRTLType>(), portDirection}});
         // Record the instance result for now, so that we can connect it to the
         // parent module port after we actually add the ports.
         values.push_back(inst.getResult(firstSubIndex + i));

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -844,10 +844,16 @@ class GrandCentralTapsPass : public GrandCentralTapsBase<GrandCentralTapsPass> {
     auto key = getKey(anno);
     annos.insert({key, anno});
     assert(!tappedPorts.count(key) && "ambiguous tap annotation");
-    auto portWidth = cast<FModuleLike>(port.first)
-                         .getPortType(port.second)
-                         .cast<FIRRTLBaseType>()
-                         .getBitWidthOrSentinel();
+    auto portType = cast<FModuleLike>(port.first).getPortType(port.second);
+    auto firrtlPortType = portType.dyn_cast<FIRRTLType>();
+    if (!firrtlPortType) {
+      port.first->emitError("data tap cannot target port with non-FIRRTL type ")
+          << portType;
+      return signalPassFailure();
+    }
+
+    auto portWidth =
+        firrtlPortType.cast<FIRRTLBaseType>().getBitWidthOrSentinel();
     // If the port width is non-zero, process it normally.  Otherwise, record it
     // as being zero-width.
     if (portWidth)

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -1762,10 +1762,12 @@ LogicalResult InferResetsPass::verifyNoAbstractReset() {
   for (FModuleLike module :
        getOperation().getBodyBlock()->getOps<FModuleLike>()) {
     for (PortInfo port : module.getPorts()) {
-      if (getBaseType(port.type).isa<ResetType>()) {
-        module->emitOpError()
-            << "contains an abstract reset type after InferResets";
-        hasAbstractResetPorts = true;
+      if (auto portType = port.type.dyn_cast<FIRRTLType>()) {
+        if (getBaseType(portType).isa<ResetType>()) {
+          module->emitOpError()
+              << "contains an abstract reset type after InferResets";
+          hasAbstractResetPorts = true;
+        }
       }
     }
   }

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -53,13 +53,6 @@ firrtl.circuit "" {
 // -----
 
 firrtl.circuit "foo" {
-// expected-error @+1 {{ports should all be FIRRTL types}}
-firrtl.module @foo(in %a: i1) {}
-}
-
-// -----
-
-firrtl.circuit "foo" {
 // expected-error @+1 {{requires 1 port directions}}
 firrtl.module @foo(in %a : !firrtl.uint<1>) attributes {portDirections = 3 : i2} {}
 }
@@ -922,17 +915,6 @@ firrtl.circuit "NonRefRegister" {
   firrtl.module @NonRefRegister(in %clock: !firrtl.clock) {
     // expected-error @+1 {{'firrtl.reg' op result #0 must be a passive base type that does not contain analog}}
     %r = firrtl.reg %clock : !firrtl.ref<uint<8>>
-  }
-}
-
-// -----
-// Wire ops cannot have reference type
-
-firrtl.circuit "MyView" {
-  firrtl.module @MyView() {
-  // expected-error @+1 {{'firrtl.wire' op result #0 must be a base type, but got '!firrtl.ref<uint<1>>'}}
-    %ref_in1 = firrtl.wire : !firrtl.ref<uint<1>>
-    %in1 = firrtl.wire : !firrtl.uint<1>
   }
 }
 


### PR DESCRIPTION
In order to support partial lowerings involving the FIRRTL dialect, and to mix in foreign operations and types, we need a way to pass foreign types through FIRRTL modules, instances, and trivial connects.

This commit extends `FModuleLike`, `InstanceOp`, and `StrictConnectOp` to also accept foreign, non-FIRRTL types for ports and connections to those ports. It also adapts the `LowerToHW` pass to simply pass through foreign-typed values when they appear in module and instance ports. This requires adding special case handling in a few places since we cannot create an `InOutType` and therefore `WireOp` around arbitrary foreign types, so we generally have to immediately materialize foreign values.

This lowering can be quite usefully combined with the builtin `unrealized_conversion_cast` to wrap and unwrap values of foreign types and establish a path for FIRRTL values to cross dialect boundaries in a controlled fashion.

Allows foreign types in the following ops:
- `FModuleLike`
- `InstanceOp`
- `StrictConnectOp`
- `WireOp`

During lowering to HW, values are materialized directly through a backedge (wires and instance ports) since we cannot create temporary SV wires to hold these values.

### Todo
- [x] Land #2693 
- [x] Land #3323 
- [x] Land #3362 