### PR TITLE
[LLHD] Fix SigArrayGetOp canonicalization

### DIFF
--- a/lib/Dialect/LLHD/IR/LLHDOps.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDOps.cpp
@@ -348,15 +348,18 @@ static LogicalResult canonicalizeSigPtrArrayGetOp(Op op,
       matchPattern(op.input(),
                    m_Op<llhd::ShrOp>(matchers::m_Any(), matchers::m_Any(),
                                      m_Constant(&amountAttr)))) {
+    // Use APInt for index to keep the original bitwidth, zero-extend amount to
+    // add it to index without requiring the same bitwidth and using the width
+    // of index
     APInt index = indexAttr.getValue();
-    APInt amount = amountAttr.getValue();
+    uint64_t amount = amountAttr.getValue().getZExtValue();
     auto shrOp = op.input().template getDefiningOp<llhd::ShrOp>();
     unsigned baseWidth = shrOp.getBaseWidth();
     unsigned hiddenWidth = shrOp.getHiddenWidth();
 
     // with amt + index < baseWidth
     //   => llhd.sig.array_get(base, amt + index)
-    if (amount.getZExtValue() + index.getZExtValue() < baseWidth) {
+    if (amount + index.getZExtValue() < baseWidth) {
       op.inputMutable().assign(shrOp.base());
       Value newIndex =
           rewriter.create<hw::ConstantOp>(op->getLoc(), amount + index);
@@ -367,8 +370,7 @@ static LogicalResult canonicalizeSigPtrArrayGetOp(Op op,
 
     // with amt + index >= baseWidth && amt + index < baseWidth + hiddenWidth
     //   => llhd.sig.array_get(hidden, amt + index - baseWidth)
-    if (amount.getZExtValue() + index.getZExtValue() <
-        baseWidth + hiddenWidth) {
+    if (amount + index.getZExtValue() < baseWidth + hiddenWidth) {
       op.inputMutable().assign(shrOp.hidden());
       Value newIndex = rewriter.create<hw::ConstantOp>(
           op->getLoc(), amount + index - baseWidth);

--- a/test/Dialect/LLHD/Canonicalization/extract.mlir
+++ b/test/Dialect/LLHD/Canonicalization/extract.mlir
@@ -46,13 +46,15 @@ func @sigArrayGetOp(%arg0: !llhd.sig<!hw.array<30xi32>>, %arg1: !llhd.sig<!hw.ar
   // CHECK-NEXT: %c6_i5 = hw.constant 6 : i5
   %a = hw.constant 3 : i5
   %b = hw.constant 17 : i5
+  %c = hw.constant 3 : i32
+  %d = hw.constant 17 : i32
 
   // CHECK-NEXT: %[[RES1:.*]] = llhd.sig.array_get %arg0[%c6_i5] : !llhd.sig<!hw.array<30xi32>>
-  %0 = llhd.shr %arg0, %arg1, %a : (!llhd.sig<!hw.array<30xi32>>, !llhd.sig<!hw.array<30xi32>>, i5) -> !llhd.sig<!hw.array<30xi32>>
+  %0 = llhd.shr %arg0, %arg1, %c : (!llhd.sig<!hw.array<30xi32>>, !llhd.sig<!hw.array<30xi32>>, i32) -> !llhd.sig<!hw.array<30xi32>>
   %1 = llhd.sig.array_get %0[%a] : !llhd.sig<!hw.array<30xi32>>
 
   // CHECK-NEXT: %[[RES2:.*]] = llhd.sig.array_get %arg1[%c4_i5] : !llhd.sig<!hw.array<30xi32>>
-  %2 = llhd.shr %arg0, %arg1, %b : (!llhd.sig<!hw.array<30xi32>>, !llhd.sig<!hw.array<30xi32>>, i5) -> !llhd.sig<!hw.array<30xi32>>
+  %2 = llhd.shr %arg0, %arg1, %d : (!llhd.sig<!hw.array<30xi32>>, !llhd.sig<!hw.array<30xi32>>, i32) -> !llhd.sig<!hw.array<30xi32>>
   %3 = llhd.sig.array_get %2[%b] : !llhd.sig<!hw.array<30xi32>>
 
   // CHECK-NEXT: return %[[RES1]], %[[RES2]] : !llhd.sig<i32>, !llhd.sig<i32>


### PR DESCRIPTION
When indexing a signal-array with SigArrayGetOp that was created by a shrOp, an assertion is thrown when the bitwidth of the shift amount type and the index type do not match. We can also allow this canonicalization when the bitwidths do not match.