### PR TITLE
[FIRRTL][RemoveUnusedPorts] Support strictconnect

### DIFF
--- a/test/Dialect/FIRRTL/remove-unused-ports.mlir
+++ b/test/Dialect/FIRRTL/remove-unused-ports.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-remove-unused-ports)' %s | FileCheck %s
+// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-remove-unused-ports)' %s -split-input-file | FileCheck %s
 firrtl.circuit "Top"   {
   // CHECK-LABEL: firrtl.module @Top(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>,
   // CHECK-SAME :                    out %d_unused: !firrtl.uint<1>, out %d_invalid: !firrtl.uint<1>, out %d_constant: !firrtl.uint<1>)
@@ -64,5 +64,76 @@ firrtl.circuit "Top"   {
     firrtl.connect %A_a, %a : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %A_b, %b : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %c, %A_c : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+}
+
+// -----
+
+// Strict connect version.
+firrtl.circuit "Top"   {
+  // CHECK-LABEL: firrtl.module @Top(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>,
+  // CHECK-SAME :                    out %d_unused: !firrtl.uint<1>, out %d_invalid: !firrtl.uint<1>, out %d_constant: !firrtl.uint<1>)
+  firrtl.module @Top(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>,
+                     out %d_unused: !firrtl.uint<1>, out %d_invalid: !firrtl.uint<1>, out %d_constant: !firrtl.uint<1>) {
+    %A_a, %A_b, %A_c, %A_d_unused, %A_d_invalid, %A_d_constant = firrtl.instance A  @UseBar(in a: !firrtl.uint<1>, in b: !firrtl.uint<1>, out c: !firrtl.uint<1>, out d_unused: !firrtl.uint<1>, out d_invalid: !firrtl.uint<1>, out d_constant: !firrtl.uint<1>)
+    // CHECK: %A_b, %A_c = firrtl.instance A @UseBar(in b: !firrtl.uint<1>, out c: !firrtl.uint<1>)
+    // CHECK-NEXT: firrtl.strictconnect %A_b, %b
+    // CHECK-NEXT: firrtl.strictconnect %c, %A_c
+    // CHECK-NEXT: firrtl.strictconnect %d_unused, %{{invalid_ui1.*}}
+    // CHECK-NEXT: firrtl.strictconnect %d_invalid, %{{invalid_ui1.*}}
+    // CHECK-NEXT: firrtl.strictconnect %d_constant, %{{c1_ui1.*}}
+    firrtl.strictconnect %A_a, %a : !firrtl.uint<1>
+    firrtl.strictconnect %A_b, %b : !firrtl.uint<1>
+    firrtl.strictconnect %c, %A_c : !firrtl.uint<1>
+    firrtl.strictconnect %d_unused, %A_d_unused : !firrtl.uint<1>
+    firrtl.strictconnect %d_invalid, %A_d_invalid : !firrtl.uint<1>
+    firrtl.strictconnect %d_constant, %A_d_constant : !firrtl.uint<1>
+  }
+
+  // Check that %a, %d_unused, %d_invalid and %d_constant are removed.
+  // CHECK-LABEL: firrtl.module @Bar(in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>)
+  // CHECK-NEXT:    firrtl.strictconnect %c, %b
+  // CHECK-NEXT:  }
+  firrtl.module @Bar(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>,
+                     out %d_unused: !firrtl.uint<1>, out %d_invalid: !firrtl.uint<1>, out %d_constant: !firrtl.uint<1>) {
+    firrtl.strictconnect %c, %b : !firrtl.uint<1>
+
+    %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
+    firrtl.strictconnect %d_invalid, %invalid_ui1 : !firrtl.uint<1>
+    %c1_i1 = firrtl.constant 1 : !firrtl.uint<1>
+    firrtl.strictconnect %d_constant, %c1_i1 : !firrtl.uint<1>
+  }
+
+  // Check that %a, %d_unused, %d_invalid and %d_constant are removed.
+  // CHECK-LABEL: firrtl.module @UseBar(in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) {
+  firrtl.module @UseBar(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>,
+                        out %d_unused: !firrtl.uint<1>, out %d_invalid: !firrtl.uint<1>, out %d_constant: !firrtl.uint<1>) {
+    %A_a, %A_b, %A_c, %A_d_unused, %A_d_invalid, %A_d_constant = firrtl.instance A  @Bar(in a: !firrtl.uint<1>, in b: !firrtl.uint<1>, out c: !firrtl.uint<1>, out d_unused: !firrtl.uint<1>, out d_invalid: !firrtl.uint<1>, out d_constant: !firrtl.uint<1>)
+    firrtl.strictconnect %A_a, %a : !firrtl.uint<1>
+    // CHECK: %A_b, %A_c = firrtl.instance A  @Bar(in b: !firrtl.uint<1>, out c: !firrtl.uint<1>)
+    firrtl.strictconnect %A_b, %b : !firrtl.uint<1>
+    firrtl.strictconnect %c, %A_c : !firrtl.uint<1>
+    firrtl.strictconnect %d_unused, %A_d_unused : !firrtl.uint<1>
+    firrtl.strictconnect %d_invalid, %A_d_invalid : !firrtl.uint<1>
+    firrtl.strictconnect %d_constant, %A_d_constant : !firrtl.uint<1>
+  }
+
+  // Make sure that %a, %b and %c are not erased because they have an annotation or a symbol.
+  // CHECK-LABEL: firrtl.module @Foo(in %a: !firrtl.uint<1> sym @dntSym, in %b: !firrtl.uint<1> [{a = "a"}], out %c: !firrtl.uint<1> sym @dntSym)
+  firrtl.module @Foo(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) attributes {
+    portAnnotations = [[], [{a = "a"}], []], portSyms = ["dntSym", "", "dntSym"]}
+  {
+    // CHECK: firrtl.strictconnect %c, %{{invalid_ui1.*}}
+    %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
+    firrtl.strictconnect %c, %invalid_ui1 : !firrtl.uint<1>
+  }
+
+  // CHECK-LABEL: firrtl.module @UseFoo(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>)
+  firrtl.module @UseFoo(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) {
+    %A_a, %A_b, %A_c = firrtl.instance A  @Foo(in a: !firrtl.uint<1>, in b: !firrtl.uint<1>, out c: !firrtl.uint<1>)
+    // CHECK: %A_a, %A_b, %A_c = firrtl.instance A @Foo(in a: !firrtl.uint<1>, in b: !firrtl.uint<1>, out c: !firrtl.uint<1>)
+    firrtl.strictconnect %A_a, %a : !firrtl.uint<1>
+    firrtl.strictconnect %A_b, %b : !firrtl.uint<1>
+    firrtl.strictconnect %c, %A_c : !firrtl.uint<1>
   }
 }

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -77,6 +77,8 @@ circuit test_mod : %[[{"a": "a"}]]
     multibitMux.a <= vec
     multibitMux.sel <= b
 
+    inst unusedPortsMod of UnusedPortsMod
+    unusedPortsMod.in <= a
 
 ; MLIR-LABEL: firrtl.module @test_mod(in %clock: !firrtl.clock, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<2>, out %c: !firrtl.uint<1>, in %vec_0: !firrtl.uint<1>, in %vec_1: !firrtl.uint<1>, in %vec_2: !firrtl.uint<1>) {
 ; MLIR-NEXT:    %cat_a, %cat_b, %cat_c, %cat_d = firrtl.instance cat @Cat(in a: !firrtl.uint<2>, in b: !firrtl.uint<2>, in c: !firrtl.uint<2>, out d: !firrtl.uint<6>)
@@ -105,6 +107,8 @@ circuit test_mod : %[[{"a": "a"}]]
 ; MLIR-NEXT:    firrtl.strictconnect %multibitMux_a_1, %vec_1 : !firrtl.uint<1>
 ; MLIR-NEXT:    firrtl.strictconnect %multibitMux_a_2, %vec_2 : !firrtl.uint<1>
 ; MLIR-NEXT:    firrtl.strictconnect %multibitMux_sel, %b : !firrtl.uint<2>
+; MLIR-NEXT:    %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
+; MLIR-NEXT:    firrtl.instance unusedPortsMod @UnusedPortsMod()
 ; MLIR-NEXT:  }
 
 ; ANNOTATIONS-LABEL: firrtl.module @test_mod
@@ -155,6 +159,7 @@ circuit test_mod : %[[{"a": "a"}]]
 ; VERILOG-NEXT:     .sel (b),
 ; VERILOG-NEXT:     .b   (multibitMux_b)
 ; VERILOG-NEXT:    );
+; VERILOG-NEXT:    UnusedPortsMod unusedPortsMod ();
 ; VERILOG-NEXT:  endmodule
 
 ; Check that we canonicalize the HW output of lowering.
@@ -247,3 +252,9 @@ circuit test_mod : %[[{"a": "a"}]]
 ; VERILOG-LABEL: module MultibitMux(
 ; VERILOG-CHECK: wire [2:0] [[T:.*]] = {{a_2}, {a_1}, {a_0}};
 ; VERILOG-CHECK-NEXT: assign b = [[T]][sel];
+
+  module UnusedPortsMod :
+    input in : UInt<1>
+    output out : UInt<1>
+    out is invalid
+; VERILOG-LABEL: module UnusedPortsMod();


### PR DESCRIPTION
This commit handles strictconnect in RemoveUnusedPorts pass.
Normal connect ops are probably canonicalized into strict connects
at the time of RemoveUnusedPorts so it is necessary to handle 
strictconnects. 

This also adds an e2e test for RemoveUnusedPorts pass.