### PR TITLE
[HW] Allow hw::IntType in hw::isHWIntegerType

### DIFF
--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -37,13 +37,17 @@ using namespace circt::hw::detail;
 //===----------------------------------------------------------------------===/
 
 /// Return true if the specified type is a value HW Integer type.  This checks
-/// that it is a signless standard dialect type, that it isn't zero bits.
+/// that it is a signless standard dialect type, that it isn't zero bits, or a
+/// hw::IntType.
 bool circt::hw::isHWIntegerType(mlir::Type type) {
   Type canonicalType;
   if (auto typeAlias = type.dyn_cast<TypeAliasType>())
     canonicalType = typeAlias.getCanonicalType();
   else
     canonicalType = type;
+
+  if (canonicalType.isa<hw::IntType>())
+    return true;
 
   auto intType = canonicalType.dyn_cast<IntegerType>();
   if (!intType || !intType.isSignless())

--- a/test/Dialect/HW/parameters.mlir
+++ b/test/Dialect/HW/parameters.mlir
@@ -143,5 +143,16 @@ hw.module @parameterizedTypes<param: i32>
 
   // CHECK: %paramWire = sv.wire : !hw.inout<int<#hw.param.decl.ref<"param">>>
   %paramWire = sv.wire : !hw.inout<!hw.int<#hw.param.decl.ref<"param">>>
+}
 
+// CHECK-LABEL: hw.module @parameterizedCombSeq<param: i32>(
+hw.module @parameterizedCombSeq<param: i32>
+// CHECK-SAME: %a: !hw.int<#hw.param.decl.ref<"param">>
+  (%a: !hw.int<#hw.param.decl.ref<"param">>,
+    %clk : i1) {
+
+  // CHECK: %0 = comb.add %a, %a : !hw.int<#hw.param.decl.ref<"param">>
+  %0 = comb.add %a, %a : !hw.int<#hw.param.decl.ref<"param">>
+  // CHECK: %1 = seq.compreg %0, %clk : !hw.int<#hw.param.decl.ref<"param">>
+  %1 = seq.compreg %0, %clk: !hw.int<#hw.param.decl.ref<"param">>
 }


### PR DESCRIPTION
#1928 related. Small change, but fairly impactful in allowing us to build generic hardware modules. Without this, `comb` and `seq` operations cannot accept `hw.int` types.

Verilog emission seems to work out-of-the box for both `comb` and `seq` operations.