### PR TITLE
Bump LLVM, Remove Duplicate Handshake Verification

### DIFF
--- a/test/Dialect/Handshake/errors.mlir
+++ b/test/Dialect/Handshake/errors.mlir
@@ -1,13 +1,5 @@
 // RUN: circt-opt %s --split-input-file --verify-diagnostics
 
-handshake.func @invalid_merge_like_no_data(%arg0: i1) {
-  // expected-error @+1 {{'handshake.mux' op must have at least one data operand}}
-  %0 = mux %arg0 [] : i1, i32 
-  return %0 : i32
-}
-
-// -----
-
 handshake.func @invalid_merge_like_wrong_type(%arg0: i1, %arg1: i32, %arg2: i64) { // expected-note {{prior use here}}
   // expected-error @+1 {{use of value '%arg2' expects different type than prior uses: 'i32' vs 'i64'}}
   %0 = mux %arg0 [%arg1, %arg2] : i1, i32 


### PR DESCRIPTION
Bump LLVM.

Remove a now uneeded verification of a Handshake interface where a
confined value was being manually verified.  This is now handled
automatically by LLVM/MLIR so the test was removed (to avoid duplicating
testing of LLVM/MLIR infrastructure).

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>