### PR TITLE
[HW] Support parametric `hw.array`s

### DIFF
--- a/include/circt/Dialect/HW/HWTypes.h
+++ b/include/circt/Dialect/HW/HWTypes.h
@@ -17,6 +17,7 @@
 #include "circt/Dialect/HW/HWDialect.h"
 
 #include "circt/Support/LLVM.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Types.h"
 
 namespace circt {

--- a/include/circt/Dialect/HW/HWTypesImpl.td
+++ b/include/circt/Dialect/HW/HWTypesImpl.td
@@ -59,11 +59,11 @@ def ArrayTypeImpl : HWType<"Array"> {
   let extraClassDeclaration = [{
     static ArrayType get(Type elementType, size_t size) {
       auto *ctx = elementType.getContext();
-      auto intType = ::mlir::IntegerType::get(ctx, 32);
+      auto intType = ::mlir::IntegerType::get(ctx, 64);
       auto sizeAttr = ::mlir::IntegerAttr::get(intType, size);
       return ArrayType::get(ctx, elementType, sizeAttr);
     }
-    int64_t getSize() const;
+    size_t getSize() const;
   }];
 }
 
@@ -84,11 +84,11 @@ def UnpackedArrayType : HWType<"UnpackedArray"> {
   let extraClassDeclaration = [{
     static UnpackedArrayType get(Type elementType, size_t size) {
       auto *ctx = elementType.getContext();
-      auto intType = ::mlir::IntegerType::get(ctx, 32);
+      auto intType = ::mlir::IntegerType::get(ctx, 64);
       auto sizeAttr = ::mlir::IntegerAttr::get(intType, size);
       return UnpackedArrayType::get(ctx, elementType, sizeAttr);
     }
-    int64_t getSize() const;
+    size_t getSize() const;
   }];
 }
 

--- a/include/circt/Dialect/HW/HWTypesImpl.td
+++ b/include/circt/Dialect/HW/HWTypesImpl.td
@@ -51,15 +51,19 @@ def ArrayTypeImpl : HWType<"Array"> {
   }];
 
   let mnemonic = "array";
-  let parameters = (ins "::mlir::Type":$elementType, "size_t":$size);
+  let parameters = (ins "::mlir::Type":$elementType, "::mlir::Attribute":$sizeAttr);
   let genVerifyDecl = 1;
 
   let hasCustomAssemblyFormat = 1;
 
   let extraClassDeclaration = [{
     static ArrayType get(Type elementType, size_t size) {
-      return get(elementType.getContext(), elementType, size);
+      auto *ctx = elementType.getContext();
+      auto intType = ::mlir::IntegerType::get(ctx, 32);
+      auto sizeAttr = ::mlir::IntegerAttr::get(intType, size);
+      return ArrayType::get(ctx, elementType, sizeAttr);
     }
+    int64_t getSize() const;
   }];
 }
 
@@ -72,15 +76,19 @@ def UnpackedArrayType : HWType<"UnpackedArray"> {
   }];
 
   let mnemonic = "uarray";
-  let parameters = (ins "::mlir::Type":$elementType, "size_t":$size);
+  let parameters = (ins "::mlir::Type":$elementType, "::mlir::Attribute":$sizeAttr);
   let genVerifyDecl = 1;
 
   let hasCustomAssemblyFormat = 1;
 
   let extraClassDeclaration = [{
     static UnpackedArrayType get(Type elementType, size_t size) {
-      return get(elementType.getContext(), elementType, size);
+      auto *ctx = elementType.getContext();
+      auto intType = ::mlir::IntegerType::get(ctx, 32);
+      auto sizeAttr = ::mlir::IntegerAttr::get(intType, size);
+      return UnpackedArrayType::get(ctx, elementType, sizeAttr);
     }
+    int64_t getSize() const;
   }];
 }
 

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -104,6 +104,10 @@ static Attribute getInt32Attr(MLIRContext *ctx, uint32_t value) {
   return Builder(ctx).getI32IntegerAttr(value);
 }
 
+static Attribute getIntAttr(MLIRContext *ctx, Type t, const APInt &value) {
+  return Builder(ctx).getIntegerAttr(t, value);
+}
+
 /// Return true for nullary operations that are better emitted multiple
 /// times as inline expression (when they have multiple uses) rather than having
 /// a temporary wire.
@@ -1072,7 +1076,9 @@ static void emitDims(ArrayRef<Attribute> dims, raw_ostream &os, Location loc,
 
     // Otherwise it must be a parameterized dimension.  Shove the "-1" into the
     // attribute so it gets printed in canonical form.
-    auto negOne = getInt32Attr(loc.getContext(), -1);
+    auto negOne =
+        getIntAttr(loc.getContext(), width.getType(),
+                   APInt(width.getType().getIntOrFloatBitWidth(), -1L, true));
     width = ParamExprAttr::get(PEO::Add, width, negOne);
     os << '[';
     emitter.printParamValue(width, os, [loc]() {

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1120,8 +1120,7 @@ static bool printPackedTypeImpl(Type type, raw_ostream &os, Location loc,
         return true;
       })
       .Case<ArrayType>([&](ArrayType arrayType) {
-        dims.push_back(
-            getInt32Attr(arrayType.getContext(), arrayType.getSize()));
+        dims.push_back(arrayType.getSizeAttr());
         return printPackedTypeImpl(arrayType.getElementType(), os, loc, dims,
                                    implicitIntType, singleBitDefaultType,
                                    emitter);

--- a/lib/Dialect/HW/HWAttributes.cpp
+++ b/lib/Dialect/HW/HWAttributes.cpp
@@ -792,7 +792,7 @@ FailureOr<Type> hw::evaluateParametricType(Location loc, ArrayAttr parameters,
         return hw::ArrayType::get(
             arrayType.getContext(), elementType.getValue(),
             IntegerAttr::get(IntegerType::get(type.getContext(), 64),
-                             size.getValue()));
+                             size.getValue().getSExtValue()));
       })
       .Default([&](auto) { return type; });
 }

--- a/lib/Dialect/HW/HWAttributes.cpp
+++ b/lib/Dialect/HW/HWAttributes.cpp
@@ -780,5 +780,19 @@ FailureOr<Type> hw::evaluateParametricType(Location loc, ArrayAttr parameters,
         return {IntegerType::get(type.getContext(),
                                  attrValue.getValue().getSExtValue())};
       })
+      .Case<hw::ArrayType>([&](hw::ArrayType arrayType) -> FailureOr<Type> {
+        auto size =
+            evaluateParametricAttr(loc, parameters, arrayType.getSizeAttr());
+        if (failed(size))
+          return failure();
+        auto elementType =
+            evaluateParametricType(loc, parameters, arrayType.getElementType());
+        if (failed(elementType))
+          return failure();
+        return hw::ArrayType::get(
+            arrayType.getContext(), elementType.getValue(),
+            IntegerAttr::get(IntegerType::get(type.getContext(), 64),
+                             size.getValue()));
+      })
       .Default([&](auto) { return type; });
 }

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -1048,12 +1048,12 @@ hw.module @parameterizedTypes<param: i32 = 1, wire: i32 = 2>
 }
 
 // CHECK-LABEL: module parameterizedArrays
-// CHECK: #(parameter param = 1,
-// CHECK:   parameter N = 2) (
-hw.module @parameterizedArrays<param: i32 = 1, N: i32 = 2>
+// CHECK: #(parameter        param = 1,
+// CHECK:   parameter [11:0] N = 2) (
+hw.module @parameterizedArrays<param: i32 = 1, N: i12 = 2>
 // CHECK: input [41:0][param - 1:0]{{ *}}a,
   (%a: !hw.array<42x!hw.int<#hw.param.decl.ref<"param">>>,
-// CHECK:   input [N - 1:0][param - 1:0]{{ *}}b);
+// CHECK:   input [N - 64'd1:0][param - 1:0]{{ *}}b);
    %b: !hw.array<#hw.param.decl.ref<"N"> x !hw.int<#hw.param.decl.ref<"param">>>) {
 }
 

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -1047,6 +1047,16 @@ hw.module @parameterizedTypes<param: i32 = 1, wire: i32 = 2>
 
 }
 
+// CHECK-LABEL: module parameterizedArrays
+// CHECK: #(parameter param = 1,
+// CHECK:   parameter N = 2) (
+hw.module @parameterizedArrays<param: i32 = 1, N: i32 = 2>
+// CHECK: input [41:0][param - 1:0]{{ *}}a,
+  (%a: !hw.array<42x!hw.int<#hw.param.decl.ref<"param">>>,
+// CHECK:   input [N - 1:0][param - 1:0]{{ *}}b);
+   %b: !hw.array<#hw.param.decl.ref<"N"> x !hw.int<#hw.param.decl.ref<"param">>>) {
+}
+
 // CHECK-LABEL: // moduleWithComment has a comment
 // CHECK-NEXT:  // hello
 // CHECK-NEXT:  module moduleWithComment

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -1047,16 +1047,6 @@ hw.module @parameterizedTypes<param: i32 = 1, wire: i32 = 2>
 
 }
 
-// CHECK-LABEL: module parameterizedArrays
-// CHECK: #(parameter        param = 1,
-// CHECK:   parameter [11:0] N = 2) (
-hw.module @parameterizedArrays<param: i32 = 1, N: i12 = 2>
-// CHECK: input [41:0][param - 1:0]{{ *}}a,
-  (%a: !hw.array<42x!hw.int<#hw.param.decl.ref<"param">>>,
-// CHECK:   input [N - 64'd1:0][param - 1:0]{{ *}}b);
-   %b: !hw.array<#hw.param.decl.ref<"N"> x !hw.int<#hw.param.decl.ref<"param">>>) {
-}
-
 // CHECK-LABEL: // moduleWithComment has a comment
 // CHECK-NEXT:  // hello
 // CHECK-NEXT:  module moduleWithComment
@@ -1080,4 +1070,35 @@ hw.module @InlineArrayGet(%source: !hw.array<1xi1>) -> (r1:i1, r2:i1) {
   // CHECK:      assign r1 = source[1'h0];
   // CHECK-NEXT: assign r2 = source[1'h0];
   hw.output %0, %0 : i1, i1
+}
+
+// CHECK-LABEL: module parameterizedArrays
+// CHECK-NEXT:   #(parameter /*integer*/ param,
+// CHECK-NEXT:     parameter /*integer*/ N) (
+// CHECK-NEXT:   input  [41:0][param - 1:0]        a,
+// CHECK-NEXT:   input  [N - 64'd1:0][param - 1:0] b,
+// CHECK-NEXT:   output [N - 64'd1:0][param - 1:0] c);
+hw.module @parameterizedArrays<param: i32, N: i32>
+  (%a: !hw.array<42x!hw.int<#hw.param.decl.ref<"param">>>,
+   %b: !hw.array<#hw.param.decl.ref<"N"> x !hw.int<#hw.param.decl.ref<"param">>>) ->
+   (c: !hw.array<#hw.param.decl.ref<"N"> x !hw.int<#hw.param.decl.ref<"param">>>) {
+  hw.output %b : !hw.array<#hw.param.decl.ref<"N"> x !hw.int<#hw.param.decl.ref<"param">>>
+}
+
+// CHECK-LABEL: module UseParameterizedArrays(
+// CHECK-NEXT: input [41:0][11:0] a,
+// CHECK-NEXT: input [23:0][11:0] b);
+hw.module @UseParameterizedArrays(%a: !hw.array<42xint<12>>, %b: !hw.array<24xint<12>>) {
+// CHECK:  wire [23:0][11:0] _inst_c;
+// CHECK:  parameterizedArrays #(
+// CHECK-NEXT:    .param(12),
+// CHECK-NEXT:    .N(24)
+// CHECK-NEXT:  ) inst (
+// CHECK-NEXT:    .a (a),
+// CHECK-NEXT:    .b (b),
+// CHECK-NEXT:    .c (_inst_c)
+// CHECK-NEXT:  );
+// CHECK-NEXT: endmodule
+  %c = hw.instance "inst" @parameterizedArrays<param: i32 = 12, N: i32 = 24>
+    (a: %a : !hw.array<42xint<12>>, b: %b : !hw.array<24xint<12>>) -> (c: !hw.array<24xint<12>>) {}
 }

--- a/test/Dialect/HW/errors.mlir
+++ b/test/Dialect/HW/errors.mlir
@@ -44,7 +44,7 @@ hw.module @A() -> ("": i1) { }
 
 // -----
 
-// expected-error @+1 {{hw.array only supports one dimension}}
+// expected-error @+1 {{expected non-function type}}
 func private @arrayDims(%a: !hw.array<3 x 4 x i5>) { }
 
 // -----
@@ -311,3 +311,8 @@ module {
 // expected-note @+1 {{module declared here}}
   hw.module.extern @parameters<p1: i42>(%arg0: !hw.int<#hw.param.decl.ref<"p1">>) -> (out: !hw.int<#hw.param.decl.ref<"p1">>)
 }
+
+// -----
+
+// expected-error @+1 {{unsupported dimension kind in hw.array}}
+hw.module @bab<param: i32, N: i32> ( %array2d: !hw.array<i3 x i4>) {}

--- a/test/Dialect/HW/parameters.mlir
+++ b/test/Dialect/HW/parameters.mlir
@@ -194,6 +194,19 @@ hw.module @CLog2Expression<param: i32>() {
 hw.module @parameterizedArrays<param: i32, N: i32>
 // CHECK-SAME:%a: !hw.array<42xint<#hw.param.decl.ref<"param">>>,
   (%a: !hw.array<42x!hw.int<#hw.param.decl.ref<"param">>>,
-// CHECK-SAME: %b: !hw.array<#hw.param.decl.ref<"N">xint<#hw.param.decl.ref<"param">>>
-   %b: !hw.array<#hw.param.decl.ref<"N"> x !hw.int<#hw.param.decl.ref<"param">>>) {
+// CHECK-SAME: %b: !hw.array<#hw.param.decl.ref<"N">xint<#hw.param.decl.ref<"param">>>) ->
+   %b: !hw.array<#hw.param.decl.ref<"N"> x !hw.int<#hw.param.decl.ref<"param">>>) ->
+// CHECK-SAME: (c: !hw.array<#hw.param.decl.ref<"N">xint<#hw.param.decl.ref<"param">>>)
+   (c: !hw.array<#hw.param.decl.ref<"N"> x !hw.int<#hw.param.decl.ref<"param">>>) {
+  hw.output %b : !hw.array<#hw.param.decl.ref<"N"> x !hw.int<#hw.param.decl.ref<"param">>>
+}
+
+// CHECK-LABEL: @parameterizedArraysInstance(
+hw.module @parameterizedArraysInstance
+  (%a: !hw.array<42xint<12>>, %b: !hw.array<24xint<12>>) {
+
+// CHECK:      %inst.c = hw.instance "inst" @parameterizedArrays<param: i32 = 12, N: i32 = 24>
+// CHECK-SAME: (a: %a: !hw.array<42xi12>, b: %b: !hw.array<24xi12>) -> (c: !hw.array<24xi12>)
+  %c = hw.instance "inst" @parameterizedArrays<param: i32 = 12, N: i32 = 24>
+    (a: %a : !hw.array<42xint<12>>, b: %b : !hw.array<24xint<12>>) -> (c: !hw.array<24xint<12>>) {}
 }

--- a/test/Dialect/HW/parameters.mlir
+++ b/test/Dialect/HW/parameters.mlir
@@ -172,7 +172,6 @@ hw.module @parameterizedCombSeq<param: i32>
   %1 = seq.compreg %0, %clk: !hw.int<#hw.param.decl.ref<"param">>
 }
 
-<<<<<<< HEAD
 // CHECK-LABEL: hw.module @CLog2Expression<param: i32>() {
 hw.module @CLog2Expression<param: i32>() {
   // CHECK-NEXT: %0 = hw.param.value i32 = 0

--- a/test/Dialect/HW/parameters.mlir
+++ b/test/Dialect/HW/parameters.mlir
@@ -172,6 +172,7 @@ hw.module @parameterizedCombSeq<param: i32>
   %1 = seq.compreg %0, %clk: !hw.int<#hw.param.decl.ref<"param">>
 }
 
+<<<<<<< HEAD
 // CHECK-LABEL: hw.module @CLog2Expression<param: i32>() {
 hw.module @CLog2Expression<param: i32>() {
   // CHECK-NEXT: %0 = hw.param.value i32 = 0
@@ -188,4 +189,12 @@ hw.module @CLog2Expression<param: i32>() {
 
   // CHECK-NEXT: %4 = hw.param.value i32 = #hw.param.expr.clog2<#hw.param.decl.ref<"param">>
   %4 = hw.param.value i32 = #hw.param.expr.clog2<#hw.param.decl.ref<"param">>
+}
+
+// CHECK-LABEL: hw.module @parameterizedArrays<param: i32, N: i32>(
+hw.module @parameterizedArrays<param: i32, N: i32>
+// CHECK-SAME:%a: !hw.array<42xint<#hw.param.decl.ref<"param">>>,
+  (%a: !hw.array<42x!hw.int<#hw.param.decl.ref<"param">>>,
+// CHECK-SAME: %b: !hw.array<#hw.param.decl.ref<"N">xint<#hw.param.decl.ref<"param">>>
+   %b: !hw.array<#hw.param.decl.ref<"N"> x !hw.int<#hw.param.decl.ref<"param">>>) {
 }


### PR DESCRIPTION
This commit adds support for having parametric hw.array types. This is allowed for both the dimension as well as the inner type.

One small thing; i found it necessary to remove the "multidimensional array error message" (i.e. `hw.array<1x2xi3>`) due to difficulties with writing a parser for an n-ary, 'x' delimited list which also supports attributes as dimensions.
Since we nevertheless do not support multidimensional arrays in sv emission, i opted for a simpler parser that assumes a single dimension, an 'x', and a single inner type.