### PR TITLE
[FIRRTL] Use uint64_t for numElements in SeqMemOp

### DIFF
--- a/include/circt/Dialect/FIRRTL/CHIRRTL.td
+++ b/include/circt/Dialect/FIRRTL/CHIRRTL.td
@@ -59,11 +59,11 @@ def CMemoryType : TypeDef<CHIRRTLDialect, "CMemory"> {
   }];
 
   let parameters = (ins "firrtl::FIRRTLType":$elementType,
-                        "unsigned":$numElements);
+                        "firrtl::VectorIndexType":$numElements);
 
   let builders = [
     TypeBuilderWithInferredContext<(ins "firrtl::FIRRTLType":$elementType,
-                                        "unsigned":$numElements), [{
+                                        "firrtl::VectorIndexType":$numElements), [{
       return $_get(elementType.getContext(), elementType, numElements);
     }]>
   ];
@@ -126,7 +126,7 @@ def SeqMemOp : CHIRRTLOp<"seqmem", [HasCustomSSAName]> {
   let results = (outs CMemoryType:$result);
   let assemblyFormat = "(`sym` $inner_sym^)? $ruw custom<SeqMemOp>(attr-dict) `:` qualified(type($result))";
   let builders = [
-    OpBuilder<(ins "firrtl::FIRRTLType":$elementType, "unsigned":$numElements,
+    OpBuilder<(ins "firrtl::FIRRTLType":$elementType, "firrtl::VectorIndexType":$numElements,
                    "RUWAttr":$ruw, "mlir::StringRef":$name,
                    "ArrayAttr":$annotations,
                    CArg<"StringAttr", "StringAttr()">:$inner_sym)>

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -26,6 +26,8 @@ struct VectorTypeStorage;
 struct CMemoryTypeStorage;
 } // namespace detail.
 
+using VectorIndexType = uint64_t;
+
 class ClockType;
 class ResetType;
 class AsyncResetType;
@@ -371,10 +373,10 @@ class FVectorType : public FIRRTLType::TypeBase<FVectorType, FIRRTLType,
 public:
   using Base::Base;
 
-  static FIRRTLType get(FIRRTLType elementType, unsigned numElements);
+  static FIRRTLType get(FIRRTLType elementType, VectorIndexType numElements);
 
   FIRRTLType getElementType();
-  unsigned getNumElements();
+  VectorIndexType getNumElements();
 
   /// Return the recursive properties of the type.
   RecursiveTypeProperties getRecursiveTypeProperties();

--- a/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
@@ -195,7 +195,7 @@ static void printSeqMemOp(OpAsmPrinter &p, Operation *op, DictionaryAttr attr) {
 }
 
 void SeqMemOp::build(OpBuilder &builder, OperationState &result,
-                     FIRRTLType elementType, unsigned numElements, RUWAttr ruw,
+                     FIRRTLType elementType, VectorIndexType numElements, RUWAttr ruw,
                      StringRef name, ArrayAttr annotations,
                      StringAttr innerSym) {
   build(builder, result,
@@ -264,7 +264,7 @@ void CMemoryType::print(AsmPrinter &printer) const {
 
 Type CMemoryType::parse(AsmParser &parser) {
   FIRRTLType elementType;
-  unsigned numElements;
+  VectorIndexType numElements;
   if (parser.parseLess() || firrtl::parseNestedType(elementType, parser) ||
       parser.parseComma() || parser.parseInteger(numElements) ||
       parser.parseGreater())
@@ -274,7 +274,7 @@ Type CMemoryType::parse(AsmParser &parser) {
 
 LogicalResult CMemoryType::verify(function_ref<InFlightDiagnostic()> emitError,
                                   FIRRTLType elementType,
-                                  unsigned numElements) {
+                                  VectorIndexType numElements) {
   if (!elementType.isPassive()) {
     return emitError() << "behavioral memory element type must be passive";
   }

--- a/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
@@ -195,8 +195,8 @@ static void printSeqMemOp(OpAsmPrinter &p, Operation *op, DictionaryAttr attr) {
 }
 
 void SeqMemOp::build(OpBuilder &builder, OperationState &result,
-                     FIRRTLType elementType, VectorIndexType numElements, RUWAttr ruw,
-                     StringRef name, ArrayAttr annotations,
+                     FIRRTLType elementType, VectorIndexType numElements,
+                     RUWAttr ruw, StringRef name, ArrayAttr annotations,
                      StringAttr innerSym) {
   build(builder, result,
         CMemoryType::get(builder.getContext(), elementType, numElements), ruw,

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -885,7 +885,7 @@ namespace circt {
 namespace firrtl {
 namespace detail {
 struct VectorTypeStorage : mlir::TypeStorage {
-  using KeyTy = std::pair<FIRRTLType, unsigned>;
+  using KeyTy = std::pair<FIRRTLType, VectorIndexType>;
 
   VectorTypeStorage(KeyTy value) : value(value) {
     auto properties = value.first.getRecursiveTypeProperties();
@@ -911,14 +911,14 @@ struct VectorTypeStorage : mlir::TypeStorage {
 } // namespace firrtl
 } // namespace circt
 
-FIRRTLType FVectorType::get(FIRRTLType elementType, unsigned numElements) {
+FIRRTLType FVectorType::get(FIRRTLType elementType, VectorIndexType numElements) {
   return Base::get(elementType.getContext(),
                    std::make_pair(elementType, numElements));
 }
 
 FIRRTLType FVectorType::getElementType() { return getImpl()->value.first; }
 
-unsigned FVectorType::getNumElements() { return getImpl()->value.second; }
+VectorIndexType FVectorType::getNumElements() { return getImpl()->value.second; }
 
 /// Return the recursive properties of the type.
 RecursiveTypeProperties FVectorType::getRecursiveTypeProperties() {

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -911,14 +911,17 @@ struct VectorTypeStorage : mlir::TypeStorage {
 } // namespace firrtl
 } // namespace circt
 
-FIRRTLType FVectorType::get(FIRRTLType elementType, VectorIndexType numElements) {
+FIRRTLType FVectorType::get(FIRRTLType elementType,
+                            VectorIndexType numElements) {
   return Base::get(elementType.getContext(),
                    std::make_pair(elementType, numElements));
 }
 
 FIRRTLType FVectorType::getElementType() { return getImpl()->value.first; }
 
-VectorIndexType FVectorType::getNumElements() { return getImpl()->value.second; }
+VectorIndexType FVectorType::getNumElements() {
+  return getImpl()->value.second;
+}
 
 /// Return the recursive properties of the type.
 RecursiveTypeProperties FVectorType::getRecursiveTypeProperties() {

--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -221,7 +221,7 @@ public:
           }
         })
         .template Case<FVectorType>([&](FVectorType vector) {
-          for (auto i : llvm::seq(0u, vector.getNumElements())) {
+          for (auto i : llvm::seq(static_cast<VectorIndexType>(0), vector.getNumElements())) {
             auto subindex =
                 builder.create<SubindexOp>(value.getLoc(), value, i);
             foreachSubelement(builder, subindex, fn);

--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -221,7 +221,8 @@ public:
           }
         })
         .template Case<FVectorType>([&](FVectorType vector) {
-          for (auto i : llvm::seq(static_cast<VectorIndexType>(0), vector.getNumElements())) {
+          for (auto i : llvm::seq(static_cast<VectorIndexType>(0),
+                                  vector.getNumElements())) {
             auto subindex =
                 builder.create<SubindexOp>(value.getLoc(), value, i);
             foreachSubelement(builder, subindex, fn);

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1056,3 +1056,8 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: [[NOT_ENABLE:%.+]] = firrtl.not %enable
     ; CHECK-NEXT: [[NOT_COND:%.+]] = firrtl.not %cond
     ; CHECK-NEXT: firrtl.assert %clock, [[NOT_COND]], [[NOT_ENABLE]]
+
+  ; CHECK-LABEL: firrtl.module @LargeMemorySize
+  module LargeMemorySize :
+    ; CHECK: %{{[^!]*}} !chirrtl.cmemory<vector<uint<8>, 16>, 34359738368>
+    smem testharness : UInt<8>[16] [34359738368]


### PR DESCRIPTION
This should fix #2710.

unsigned int only has 32 bits on LLP64 and LP64, so its max value is 4,294,967,295.
If you want to express 34,359,738,368, you need a bigger space, i.e. 64 bits.

This commit modified `FVectorType` and `CMemory` because `SeqMemOp` use them to build.
I didn’t change Other codes that use unsigned as `VectorIndexType` (for example `SubindexOp`)
because I don’t know whether they need to express that large size.

Besides, I’m not sure whether I should use size_t or unsigned long long instead of uint64_t.