### PR TITLE
[reduce] Make reducer NLA aware

### DIFF
--- a/tools/circt-reduce/Reduction.cpp
+++ b/tools/circt-reduce/Reduction.cpp
@@ -768,6 +768,8 @@ void circt::createAllReductions(
   add(std::make_unique<PassReduction>(context, firrtl::createInlinerPass()));
   add(std::make_unique<PassReduction>(context,
                                       createSimpleCanonicalizerPass()));
+  add(std::make_unique<PassReduction>(context,
+                                      firrtl::createIMConstPropPass()));
   add(std::make_unique<PassReduction>(
       context, firrtl::createRemoveUnusedPortsPass(/*ignoreDontTouch=*/true)));
   add(std::make_unique<InstanceStubber>());


### PR DESCRIPTION
Extend `circt-reducer` with some additional mechanism to appropriately remove `firrtl.nla` ops when instances, modules, or ports are modified or removed. Currently this is very FIRRTL-specific, but I hope to make this more general-purpose in the future. With this fix the reducer becomes more useful on FIRRTL inputs that make heavy use of non-local annotations and non-local anchors, which is very likely if they use some form of deduplication or proper multiple instantiation.