### PR TITLE
[LowerToHW] Guard out-of-bounds multi-bit mux

### DIFF
--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -326,7 +326,10 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK:      %[[ZEXT_INDEX:.+]] = comb.concat %false, {{.*}} : i1, i1
     // CHECK-NEXT: %[[ARRAY:.+]] = hw.array_create %false, %false, %false
     // CHECK-NEXT: %[[ARRAY_GET:.+]] = hw.array_get %[[ARRAY]][%[[ZEXT_INDEX]]]
-    // CHECK: hw.output %false, %[[ARRAY_GET]] : i1, i1
+    // CHECK-NEXT: %[[ARRAY_ZEROTH:.+]] = hw.array_get %[[ARRAY]][%c0_i2]
+    // CHECK-NEXT: %[[IS_OOB:.+]] = comb.icmp uge %[[ZEXT_INDEX]], %c-1_i2
+    // CHECK-NEXT: %[[GUARDED:.+]] = comb.mux %[[IS_OOB]], %[[ARRAY_ZEROTH]], %[[ARRAY_GET]]
+    // CHECK: hw.output %false, %[[GUARDED]] : i1, i1
     firrtl.connect %out2, %61 : !firrtl.sint<1>, !firrtl.sint<1>
   }
 
@@ -1617,9 +1620,12 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   firrtl.module @MutlibitMux(in %source_0: !firrtl.uint<1>, in %source_1: !firrtl.uint<1>, in %source_2: !firrtl.uint<1>, out %sink: !firrtl.uint<1>, in %index: !firrtl.uint<2>) {
     %0 = firrtl.multibit_mux %index, %source_2, %source_1, %source_0 : !firrtl.uint<2>, !firrtl.uint<1>
     firrtl.connect %sink, %0 : !firrtl.uint<1>, !firrtl.uint<1>
-    // CHECK-NEXT: %0 = hw.array_create %source_2, %source_1, %source_0 : i1
+    // CHECK:      %0 = hw.array_create %source_2, %source_1, %source_0 : i1
     // CHECK-NEXT: %1 = hw.array_get %0[%index] : !hw.array<3xi1>
-    // CHECK-NEXT: hw.output %1 : i1
+    // CHECK-NEXT: %2 = hw.array_get %0[%c0_i2]
+    // CHECK-NEXT: %3 = comb.icmp uge %index, %c-1_i2
+    // CHECK-NEXT: %4 = comb.mux %3, %2, %1
+    // CHECK-NEXT: hw.output %4 : i1
   }
 
   firrtl.module @inferUnmaskedMemory(in %clock: !firrtl.clock, in %rAddr: !firrtl.uint<4>, in %rEn: !firrtl.uint<1>, out %rData: !firrtl.uint<8>, in %wMask: !firrtl.uint<1>, in %wData: !firrtl.uint<8>) {


### PR DESCRIPTION
Change FIRRTL to HW lowering behavior for subaccess (which is
represented as a multi-bit mux) to return the zeroth element on an
out-of-bounds read.  Previously, this would return an X (the Verilog
out-of-bounds read behavior).  This change is made to align CIRCT with
SFC behavior around out-of-bounds subaccess lowering.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

This is done to fix situations like the following:

```scala
circuit Bar:
  module Bar:
    input index: UInt<4>
    input vec: UInt<8>[10]
    output out: UInt<8>

    out <= vec[index]
```

Without this patch, CIRCT produced:

```verilog
module Bar(
  input  [3:0] index,
  input  [7:0] vec_0, vec_1, vec_2, vec_3, vec_4, vec_5, vec_6, vec_7, vec_8, vec_9,
  output [7:0] out);

  wire [9:0][7:0] _GEN = {{vec_9}, {vec_8}, {vec_7}, {vec_6}, {vec_5}, {vec_4}, {vec_3}, {vec_2}, {vec_1}, {vec_0}};
  assign out = _GEN[index];
endmodule
```

With this patch, CIRCT produces:
```verilog
module Bar(
  input  [3:0] index,
  input  [7:0] vec_0, vec_1, vec_2, vec_3, vec_4, vec_5, vec_6, vec_7, vec_8, vec_9,
  output [7:0] out);

  wire [9:0][7:0] _GEN = {{vec_9}, {vec_8}, {vec_7}, {vec_6}, {vec_5}, {vec_4}, {vec_3}, {vec_2}, {vec_1}, {vec_0}};
  assign out = index > 4'h9 ? vec_0 : _GEN[index];
endmodule
```

The SFC produces:
```verilog
module Bar(
  input  [3:0] index,
  input  [7:0] vec_0,
  input  [7:0] vec_1,
  input  [7:0] vec_2,
  input  [7:0] vec_3,
  input  [7:0] vec_4,
  input  [7:0] vec_5,
  input  [7:0] vec_6,
  input  [7:0] vec_7,
  input  [7:0] vec_8,
  input  [7:0] vec_9,
  output [7:0] out
);
  wire [7:0] _GEN_1 = 4'h1 == index ? vec_1 : vec_0; 
  wire [7:0] _GEN_2 = 4'h2 == index ? vec_2 : _GEN_1; 
  wire [7:0] _GEN_3 = 4'h3 == index ? vec_3 : _GEN_2; 
  wire [7:0] _GEN_4 = 4'h4 == index ? vec_4 : _GEN_3; 
  wire [7:0] _GEN_5 = 4'h5 == index ? vec_5 : _GEN_4; 
  wire [7:0] _GEN_6 = 4'h6 == index ? vec_6 : _GEN_5; 
  wire [7:0] _GEN_7 = 4'h7 == index ? vec_7 : _GEN_6; 
  wire [7:0] _GEN_8 = 4'h8 == index ? vec_8 : _GEN_7; 
  assign out = 4'h9 == index ? vec_9 : _GEN_8; 
endmodule
```