### PR TITLE
[LLHD] Process Lowering: support muxed signals

### DIFF
--- a/test/Dialect/LLHD/Transforms/processLowering.mlir
+++ b/test/Dialect/LLHD/Transforms/processLowering.mlir
@@ -44,3 +44,45 @@ llhd.proc @prbAndWaitMoreObserved(%arg0 : !llhd.sig<i64>, %arg1 : !llhd.sig<i64>
   %0 = llhd.prb %arg0 : !llhd.sig<i64>
   llhd.wait (%arg0, %arg1 : !llhd.sig<i64>, !llhd.sig<i64>), ^bb1
 }
+
+// CHECK-NEXT: llhd.entity @muxedSignal
+llhd.proc @muxedSignal(%arg0 : !llhd.sig<i64>, %arg1 : !llhd.sig<i64>) -> () {
+  cf.br ^bb1
+^bb1:
+  // CHECK-NEXT: %{{.*}} = hw.constant
+  // CHECK-NEXT: %{{.*}} = comb.mux
+  // CHECK-NEXT: %{{.*}} = llhd.prb
+  // CHECK-NEXT: }
+  %cond = hw.constant true
+  %sig = comb.mux %cond, %arg0, %arg1 : !llhd.sig<i64>
+  %0 = llhd.prb %sig : !llhd.sig<i64>
+  llhd.wait (%arg0, %arg1 : !llhd.sig<i64>, !llhd.sig<i64>), ^bb1
+}
+
+// CHECK-NEXT: llhd.entity @muxedSignal2
+llhd.proc @muxedSignal2(%arg0 : !llhd.sig<i64>, %arg1 : !llhd.sig<i64>) -> () {
+  cf.br ^bb1
+^bb1:
+  // CHECK-NEXT: %{{.*}} = hw.constant
+  // CHECK-NEXT: %{{.*}} = comb.mux
+  // CHECK-NEXT: %{{.*}} = llhd.prb
+  // CHECK-NEXT: }
+  %cond = hw.constant true
+  %sig = comb.mux %cond, %arg0, %arg1 : !llhd.sig<i64>
+  %0 = llhd.prb %sig : !llhd.sig<i64>
+  llhd.wait (%sig : !llhd.sig<i64>), ^bb1
+}
+
+// CHECK-NEXT: llhd.entity @partialSignal
+llhd.proc @partialSignal(%arg0 : !llhd.sig<i64>) -> () {
+  cf.br ^bb1
+^bb1:
+  // CHECK-NEXT: %{{.*}} = hw.constant
+  // CHECK-NEXT: %{{.*}} = llhd.sig.extract
+  // CHECK-NEXT: %{{.*}} = llhd.prb
+  // CHECK-NEXT: }
+  %c = hw.constant 16 : i6
+  %sig = llhd.sig.extract %arg0 from %c : (!llhd.sig<i64>) -> !llhd.sig<i32>
+  %0 = llhd.prb %sig : !llhd.sig<i32>
+  llhd.wait (%arg0 : !llhd.sig<i64>), ^bb1
+}

--- a/test/Dialect/LLHD/Transforms/processLoweringErrors.mlir
+++ b/test/Dialect/LLHD/Transforms/processLoweringErrors.mlir
@@ -61,3 +61,15 @@ llhd.proc @moreThanTwoBlocksNotAllowed() -> () {
 ^bb2:
   llhd.wait ^bb1
 }
+
+// -----
+
+llhd.proc @muxedSignal(%arg0 : !llhd.sig<i64>, %arg1 : !llhd.sig<i64>, %arg2 : !llhd.sig<i1>) -> () {
+  cf.br ^bb1
+^bb1:
+  %cond = llhd.prb %arg2 : !llhd.sig<i1>
+  %sig = comb.mux %cond, %arg0, %arg1 : !llhd.sig<i64>
+  %0 = llhd.prb %sig : !llhd.sig<i64>
+  // expected-error @+1 {{Process-lowering: The wait terminator is required to have all probed signals as arguments!}}
+  llhd.wait (%arg0, %arg2 : !llhd.sig<i64>, !llhd.sig<i1>), ^bb1
+}


### PR DESCRIPTION
Canonicalization merges similar basic blocks and selects differing values via block arguments. This also includes values of LLHD signal type. The block-argument-to-mux pass then transforms them to muxes that need to be considered in process lowering.