### PR TITLE
[FIRRTL] Properly handle analog types w/ NamePreservation option

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1553,6 +1553,11 @@ private:
   // the representation simpler and more consistent.
   void emitInvalidate(Value val) { emitInvalidate(val, foldFlow(val)); }
 
+  /// Connect all elements of two values, emitting attaches or analog values and
+  /// connects for all others. This is useful since it is illegal to connect
+  /// analog values.
+  void emitConnect(ImplicitLocOpBuilder &builder, Value dst, Value src);
+
   /// Parse an @info marker if present and inform locationProcessor about it.
   ParseResult parseOptionalInfo() {
     LocationAttr loc;
@@ -1670,6 +1675,50 @@ void FIRStmtParser::emitInvalidate(Value val, Flow flow) {
         if (flow != Flow::Source)
           builder.create<ConnectOp>(val, builder.create<InvalidValueOp>(tpe));
       });
+}
+
+void FIRStmtParser::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
+                                Value src) {
+  auto type = dst.getType().cast<FIRRTLType>();
+  if (!type.containsAnalog()) {
+    builder.create<ConnectOp>(dst, src);
+  } else if (type.isa<AnalogType>()) {
+    builder.create<AttachOp>(SmallVector{dst, src});
+  } else if (auto bundle = type.dyn_cast<BundleType>()) {
+    for (size_t i = 0, e = bundle.getNumElements(); i < e; ++i) {
+      auto &dstField = moduleContext.getCachedSubaccess(dst, i);
+      if (!dstField) {
+        OpBuilder::InsertionGuard guard(builder);
+        builder.setInsertionPointAfterValue(dst);
+        dstField = builder.create<SubfieldOp>(dst, i);
+      }
+      auto &srcField = moduleContext.getCachedSubaccess(src, i);
+      if (!srcField) {
+        OpBuilder::InsertionGuard guard(builder);
+        builder.setInsertionPointAfterValue(src);
+        srcField = builder.create<SubfieldOp>(src, i);
+      }
+      emitConnect(builder, dstField, srcField);
+    }
+  } else if (auto vector = type.dyn_cast<FVectorType>()) {
+    for (size_t i = 0, e = vector.getNumElements(); i != e; ++i) {
+      auto &dstField = moduleContext.getCachedSubaccess(dst, i);
+      if (!dstField) {
+        OpBuilder::InsertionGuard guard(builder);
+        builder.setInsertionPointAfterValue(dst);
+        dstField = builder.create<SubindexOp>(dst, i);
+      }
+      auto &srcField = moduleContext.getCachedSubaccess(src, i);
+      if (!srcField) {
+        OpBuilder::InsertionGuard guard(builder);
+        builder.setInsertionPointAfterValue(src);
+        srcField = builder.create<SubindexOp>(src, i);
+      }
+      emitConnect(builder, dstField, srcField);
+    }
+  } else {
+    llvm_unreachable("unknown type");
+  }
 }
 
 //===-------------------------------
@@ -3100,7 +3149,7 @@ ParseResult FIRStmtParser::parseWire() {
       auto debug = builder.create<WireOp>(
           type.getPassiveType(), id, getConstants().emptyArrayAttr,
           StringAttr::get(annotations.getContext(), modNameSpace.newName(id)));
-      builder.create<ConnectOp>(debug, result);
+      emitConnect(builder, debug, result);
     }
   }
   return moduleContext.addSymbolEntry(id, result, startTok.getLoc());

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -530,6 +530,25 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     node f = UInt<4>(15)
     node g = UInt<4>(7)
 
+  ; NamePreservation should create attaches for analog typed elements.
+  ; https://github.com/llvm/circt/issues/2718
+  module Bar :
+    input a: {flip a: UInt<1>, b: Analog<1>}[1]
+    output b: {flip a: UInt<1>, b: Analog<1>}[1]
+
+    wire w: {flip a: UInt<1>, b: Analog<1>}[1]
+    a[0].a <= w[0].a
+    w[0].a <= b[0].a
+    
+    ; NAMES: [[B_0:%.+]] = firrtl.subindex %b[0]
+    ; NAMES: [[B_0_1:%.+]] = firrtl.subfield [[B_0]](1)
+    ; NAMES: [[A_0:%.+]] = firrtl.subindex %a[0]
+    ; NAMES: [[A_0_1]] = firrtl.subfield [[A_0]](1)
+    ; NAMES: [[W_0:%.+]] = firrtl.subindex %_w[0]
+    ; NAMES: [[W_0_1:%.+]] = firrtl.subfield [[W_0]](1)
+    ; NAMES: firrtl.attach [[A_0_1]], [[W_0_1]], [[B_0_1]]
+    attach(a[0].b, w[0].b, b[0].b)
+
   ; CHECK-LABEL: firrtl.module @subfield_implicit_cse
   module subfield_implicit_cse :
     input i: {x: UInt<1>}

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -530,25 +530,6 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     node f = UInt<4>(15)
     node g = UInt<4>(7)
 
-  ; NamePreservation should create attaches for analog typed elements.
-  ; https://github.com/llvm/circt/issues/2718
-  module Bar :
-    input a: {flip a: UInt<1>, b: Analog<1>}[1]
-    output b: {flip a: UInt<1>, b: Analog<1>}[1]
-
-    wire w: {flip a: UInt<1>, b: Analog<1>}[1]
-    a[0].a <= w[0].a
-    w[0].a <= b[0].a
-    
-    ; NAMES: [[B_0:%.+]] = firrtl.subindex %b[0]
-    ; NAMES: [[B_0_1:%.+]] = firrtl.subfield [[B_0]](1)
-    ; NAMES: [[A_0:%.+]] = firrtl.subindex %a[0]
-    ; NAMES: [[A_0_1]] = firrtl.subfield [[A_0]](1)
-    ; NAMES: [[W_0:%.+]] = firrtl.subindex %_w[0]
-    ; NAMES: [[W_0_1:%.+]] = firrtl.subfield [[W_0]](1)
-    ; NAMES: firrtl.attach [[A_0_1]], [[W_0_1]], [[B_0_1]]
-    attach(a[0].b, w[0].b, b[0].b)
-
   ; CHECK-LABEL: firrtl.module @subfield_implicit_cse
   module subfield_implicit_cse :
     input i: {x: UInt<1>}

--- a/test/Dialect/FIRRTL/parse-name-preservation.fir
+++ b/test/Dialect/FIRRTL/parse-name-preservation.fir
@@ -1,0 +1,22 @@
+; RUN: firtool --parse-only %s | FileCheck %s
+circuit Bar :
+  ; NamePreservation should create attaches for analog typed elements.
+  ; https://github.com/llvm/circt/issues/2718
+  module Bar :
+    input a: {flip a: UInt<1>, b: Analog<1>}[1]
+    output b: {flip a: UInt<1>, b: Analog<1>}[1]
+
+    wire w: {flip a: UInt<1>, b: Analog<1>}[1]
+    ; CHECK: %_w = firrtl.wire
+    ; CHECK: [[_W_0:%.+]] = firrtl.subindex %_w[0]
+    ; CHECK: [[_W_0_1:%.+]] = firrtl.subfield [[_W_0]](1)
+    ; CHECK: [[_W_0_0:%.+]] = firrtl.subfield [[_W_0]](0)
+    ; CHECK: %w = firrtl.wire sym @w
+    ; CHECK: [[W_0:%.+]] = firrtl.subindex %w[0]
+    ; CHECK: [[W_0_1:%.+]] = firrtl.subfield [[W_0]](1)
+    ; CHECK: [[W_0_0:%.+]] = firrtl.subfield [[W_0]](0)
+    ; CHECK: firrtl.connect [[W_0_0]], [[_W_0_0]]
+    ; CHECK: firrtl.attach [[W_0_1]], [[_W_0_1]]
+    a[0].a <= w[0].a
+    w[0].a <= b[0].a
+    attach(a[0].b, w[0].b, b[0].b)


### PR DESCRIPTION
This updates the FIRRTL parser to properly expand connects when an
aggregate contains an analog so that we emit an `attach` instead of a
`connect` for the analog element.  This issue happens only when the
`NamePreservation` flag is enabled.