### PR TITLE
[Support] Extract ValueMapper to separate support file

### DIFF
--- a/include/circt/Support/ValueMapper.h
+++ b/include/circt/Support/ValueMapper.h
@@ -48,10 +48,10 @@ public:
       TypeTransformer typeTransformer = ValueMapper::identity);
 
   // Set the mapped value of 'from' to 'to'. If 'from' is already mapped to a
-  // backedge, replaces that backedge with 'to'. If 'override' is not set, and a
+  // backedge, replaces that backedge with 'to'. If 'replace' is not set, and a
   // (non-backedge) mapping already exists, an assert is thrown.
-  void set(mlir::Value from, mlir::Value to, bool override = false);
-  void set(mlir::ValueRange from, mlir::ValueRange to, bool override = false);
+  void set(mlir::Value from, mlir::Value to, bool replace = false);
+  void set(mlir::ValueRange from, mlir::ValueRange to, bool replace = false);
 
 private:
   BackedgeBuilder *bb = nullptr;

--- a/include/circt/Support/ValueMapper.h
+++ b/include/circt/Support/ValueMapper.h
@@ -48,9 +48,10 @@ public:
       TypeTransformer typeTransformer = ValueMapper::identity);
 
   // Set the mapped value of 'from' to 'to'. If 'from' is already mapped to a
-  // backedge, replaces that backedge with 'to'.
-  void set(mlir::Value from, mlir::Value to);
-  void set(mlir::ValueRange from, mlir::ValueRange to);
+  // backedge, replaces that backedge with 'to'. If 'override' is not set, and a
+  // (non-backedge) mapping already exists, an assert is thrown.
+  void set(mlir::Value from, mlir::Value to, bool override = false);
+  void set(mlir::ValueRange from, mlir::ValueRange to, bool override = false);
 
 private:
   BackedgeBuilder *bb = nullptr;

--- a/include/circt/Support/ValueMapper.h
+++ b/include/circt/Support/ValueMapper.h
@@ -1,0 +1,62 @@
+//===- ValueMapper.h - Support for mapping SSA values -----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides support for mapping SSA values between two domains.
+// Provided a BackedgeBuilder, the ValueMapper supports mappings between
+// GraphRegions, creating Backedges in cases of 'get'ing mapped values which are
+// yet to be 'set'.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_SUPPORT_VALUEMAPPER_H
+#define CIRCT_SUPPORT_VALUEMAPPER_H
+
+#include "circt/Support/BackedgeBuilder.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/OperationSupport.h"
+#include "mlir/IR/Value.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <functional>
+#include <variant>
+
+namespace circt {
+
+/// The ValueMapper class facilitates the definition and connection of SSA
+/// def-use chains between two location - a 'from' location (defining
+/// use-def chains) and a 'to' location (where new operations are created based
+/// on the 'from' location).´
+class ValueMapper {
+public:
+  using TypeTransformer = llvm::function_ref<mlir::Type(mlir::Type)>;
+  static mlir::Type identity(mlir::Type t) { return t; };
+  explicit ValueMapper(BackedgeBuilder *bb = nullptr) : bb(bb) {}
+
+  // Get the mapped value of value 'from'. If no mapping has been registered, a
+  // new backedge is created. The type of the mapped value may optionally be
+  // modified through the 'typeTransformer'.
+  mlir::Value get(mlir::Value from,
+                  TypeTransformer typeTransformer = ValueMapper::identity);
+  llvm::SmallVector<mlir::Value>
+  get(mlir::ValueRange from,
+      TypeTransformer typeTransformer = ValueMapper::identity);
+
+  // Set the mapped value of 'from' to 'to'. If 'from' is already mapped to a
+  // backedge, replaces that backedge with 'to'.
+  void set(mlir::Value from, mlir::Value to);
+  void set(mlir::ValueRange from, mlir::ValueRange to);
+
+private:
+  BackedgeBuilder *bb = nullptr;
+  llvm::DenseMap<mlir::Value, std::variant<mlir::Value, Backedge>> mapping;
+};
+
+} // namespace circt
+
+#endif // CIRCT_SUPPORT_VALUEMAPPER_H

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -9,6 +9,7 @@ add_circt_library(CIRCTSupport
   LoweringOptions.cpp
   Path.cpp
   APInt.cpp
+  ValueMapper.cpp
 
   ADDITIONAL_HEADER_DIRS
 

--- a/lib/Support/ValueMapper.cpp
+++ b/lib/Support/ValueMapper.cpp
@@ -60,5 +60,5 @@ void ValueMapper::set(ValueRange from, ValueRange to, bool replace) {
   assert(from.size() == to.size() && !replace &&
          "Expected # of 'from' values and # of 'to' values to be identical.");
   for (auto [f, t] : llvm::zip(from, to))
-    set(f, t);
+    set(f, t, replace);
 }

--- a/lib/Support/ValueMapper.cpp
+++ b/lib/Support/ValueMapper.cpp
@@ -1,0 +1,66 @@
+//===- ValueMapper.cpp - Support for mapping SSA values ---------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides support for mapping SSA values between two domains.
+// Provided a BackedgeBuilder, the ValueMapper supports mappings between
+// GraphRegions, creating Backedges in cases of 'get'ing mapped values which are
+// yet to be 'set'.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Support/ValueMapper.h"
+
+using namespace mlir;
+using namespace circt;
+mlir::Value ValueMapper::get(Value from, TypeTransformer typeTransformer) {
+  if (mapping.count(from) == 0) {
+    assert(bb && "Trying to 'get' a mapped value without any value set. No "
+                 "BackedgeBuilder was provided, so cannot provide any mapped "
+                 "SSA value!");
+    // Create a backedge which will be resolved at a later time once all
+    // operands are created.
+    mapping[from] = bb->get(typeTransformer(from.getType()));
+  }
+  auto operandMapping = mapping[from];
+  Value mappedOperand;
+  if (auto *v = std::get_if<Value>(&operandMapping))
+    mappedOperand = *v;
+  else
+    mappedOperand = std::get<Backedge>(operandMapping);
+  return mappedOperand;
+}
+
+llvm::SmallVector<Value> ValueMapper::get(ValueRange from,
+                                          TypeTransformer typeTransformer) {
+  llvm::SmallVector<Value> to;
+  for (auto f : from)
+    to.push_back(get(f, typeTransformer));
+  return to;
+}
+
+// Set the mapped value of 'from' to 'to'. If 'from' is already mapped to a
+// backedge, replaces that backedge with 'to'.
+void ValueMapper::set(Value from, Value to) {
+  auto it = mapping.find(from);
+  if (it != mapping.end()) {
+    if (auto *backedge = std::get_if<Backedge>(&it->second)) {
+      backedge->setValue(to);
+    } else {
+      assert(false && "'from' was already mapped to a final value!");
+    }
+  }
+  // Register the new mapping
+  mapping[from] = to;
+}
+
+void ValueMapper::set(ValueRange from, ValueRange to) {
+  assert(from.size() == to.size() &&
+         "Expected # of 'from' values and # of 'to' values to be identical.");
+  for (auto [f, t] : llvm::zip(from, to))
+    set(f, t);
+}

--- a/lib/Support/ValueMapper.cpp
+++ b/lib/Support/ValueMapper.cpp
@@ -45,7 +45,7 @@ llvm::SmallVector<Value> ValueMapper::get(ValueRange from,
 
 // Set the mapped value of 'from' to 'to'. If 'from' is already mapped to a
 // backedge, replaces that backedge with 'to'.
-void ValueMapper::set(Value from, Value to) {
+void ValueMapper::set(Value from, Value to, bool override) {
   auto it = mapping.find(from);
   if (it != mapping.end()) {
     if (auto *backedge = std::get_if<Backedge>(&it->second)) {
@@ -58,8 +58,8 @@ void ValueMapper::set(Value from, Value to) {
   mapping[from] = to;
 }
 
-void ValueMapper::set(ValueRange from, ValueRange to) {
-  assert(from.size() == to.size() &&
+void ValueMapper::set(ValueRange from, ValueRange to, bool override) {
+  assert(from.size() == to.size() && !override &&
          "Expected # of 'from' values and # of 'to' values to be identical.");
   for (auto [f, t] : llvm::zip(from, to))
     set(f, t);

--- a/lib/Support/ValueMapper.cpp
+++ b/lib/Support/ValueMapper.cpp
@@ -43,9 +43,7 @@ llvm::SmallVector<Value> ValueMapper::get(ValueRange from,
   return to;
 }
 
-// Set the mapped value of 'from' to 'to'. If 'from' is already mapped to a
-// backedge, replaces that backedge with 'to'.
-void ValueMapper::set(Value from, Value to, bool override) {
+void ValueMapper::set(Value from, Value to, bool replace) {
   auto it = mapping.find(from);
   if (it != mapping.end()) {
     if (auto *backedge = std::get_if<Backedge>(&it->second)) {
@@ -58,8 +56,8 @@ void ValueMapper::set(Value from, Value to, bool override) {
   mapping[from] = to;
 }
 
-void ValueMapper::set(ValueRange from, ValueRange to, bool override) {
-  assert(from.size() == to.size() && !override &&
+void ValueMapper::set(ValueRange from, ValueRange to, bool replace) {
+  assert(from.size() == to.size() && !replace &&
          "Expected # of 'from' values and # of 'to' values to be identical.");
   for (auto [f, t] : llvm::zip(from, to))
     set(f, t);


### PR DESCRIPTION
This commit extracts the ValueMapper class from HandshakeToHW to a separate support file.

The ValueMapper facilitates the definition and connection of SSA def-use chains between two location - a 'from' location (defining use-def chains) and a 'to' location (where new operations are created based on the 'from' location). An optional type transformation function may be provided to transform output types.
The mapper works for both SSACFG and GraphRegions, with the latter implemented through leveraging a BackedgeBuilder.