### PR TITLE
[HW] Add port dir flip function, make `PortDirection` an enum class; NFC

### DIFF
--- a/include/circt/Dialect/HW/HWOps.h
+++ b/include/circt/Dialect/HW/HWOps.h
@@ -27,12 +27,15 @@
 namespace circt {
 namespace hw {
 
-/// A HW module ports direction.
-enum PortDirection {
+/// A module port direction.
+enum class PortDirection {
   INPUT = 1,
   OUTPUT = 2,
   INOUT = 3,
 };
+
+/// Flip a port direction.
+PortDirection flip(PortDirection direction);
 
 /// This holds the name, type, direction of a module's ports
 struct PortInfo {
@@ -49,7 +52,9 @@ struct PortInfo {
   StringAttr sym = {};
 
   StringRef getName() const { return name.getValue(); }
-  bool isOutput() const { return direction == OUTPUT; }
+  bool isInput() const { return direction == PortDirection::INPUT; }
+  bool isOutput() const { return direction == PortDirection::OUTPUT; }
+  bool isInOut() const { return direction == PortDirection::INOUT; }
 
   /// Return a unique numeric identifier for this port.
   ssize_t getId() const { return isOutput() ? argNum : (-1 - argNum); };

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -35,6 +35,7 @@
 using namespace circt;
 using namespace firrtl;
 using circt::comb::ICmpPredicate;
+using hw::PortDirection;
 
 static const char assertAnnoClass[] =
     "sifive.enterprise.firrtl.ExtractAssertionsAnnotation";
@@ -582,11 +583,11 @@ void FIRRTLModuleLowering::lowerMemoryDecls(ArrayRef<FirMemory> mems,
 
     auto makePortCommon = [&](StringRef prefix, size_t idx, Type bAddrType) {
       ports.push_back({b.getStringAttr(prefix + Twine(idx) + "_addr"),
-                       hw::INPUT, bAddrType, inputPin++});
-      ports.push_back({b.getStringAttr(prefix + Twine(idx) + "_en"), hw::INPUT,
-                       b1Type, inputPin++});
-      ports.push_back({b.getStringAttr(prefix + Twine(idx) + "_clk"), hw::INPUT,
-                       b1Type, inputPin++});
+                       PortDirection::INPUT, bAddrType, inputPin++});
+      ports.push_back({b.getStringAttr(prefix + Twine(idx) + "_en"),
+                       PortDirection::INPUT, b1Type, inputPin++});
+      ports.push_back({b.getStringAttr(prefix + Twine(idx) + "_clk"),
+                       PortDirection::INPUT, b1Type, inputPin++});
     };
 
     Type bDataType =
@@ -598,31 +599,31 @@ void FIRRTLModuleLowering::lowerMemoryDecls(ArrayRef<FirMemory> mems,
 
     for (size_t i = 0, e = mem.numReadPorts; i != e; ++i) {
       makePortCommon("R", i, bAddrType);
-      ports.push_back({b.getStringAttr("R" + Twine(i) + "_data"), hw::OUTPUT,
-                       bDataType, outputPin++});
+      ports.push_back({b.getStringAttr("R" + Twine(i) + "_data"),
+                       PortDirection::OUTPUT, bDataType, outputPin++});
     }
     for (size_t i = 0, e = mem.numReadWritePorts; i != e; ++i) {
       makePortCommon("RW", i, bAddrType);
-      ports.push_back({b.getStringAttr("RW" + Twine(i) + "_wmode"), hw::INPUT,
-                       b1Type, inputPin++});
-      ports.push_back({b.getStringAttr("RW" + Twine(i) + "_wdata"), hw::INPUT,
-                       bDataType, inputPin++});
-      ports.push_back({b.getStringAttr("RW" + Twine(i) + "_rdata"), hw::OUTPUT,
-                       bDataType, outputPin++});
+      ports.push_back({b.getStringAttr("RW" + Twine(i) + "_wmode"),
+                       PortDirection::INPUT, b1Type, inputPin++});
+      ports.push_back({b.getStringAttr("RW" + Twine(i) + "_wdata"),
+                       PortDirection::INPUT, bDataType, inputPin++});
+      ports.push_back({b.getStringAttr("RW" + Twine(i) + "_rdata"),
+                       PortDirection::OUTPUT, bDataType, outputPin++});
       // Ignore mask port, if maskBits =1
       if (mem.isMasked)
-        ports.push_back({b.getStringAttr("RW" + Twine(i) + "_wmask"), hw::INPUT,
-                         maskType, inputPin++});
+        ports.push_back({b.getStringAttr("RW" + Twine(i) + "_wmask"),
+                         PortDirection::INPUT, maskType, inputPin++});
     }
 
     for (size_t i = 0, e = mem.numWritePorts; i != e; ++i) {
       makePortCommon("W", i, bAddrType);
-      ports.push_back({b.getStringAttr("W" + Twine(i) + "_data"), hw::INPUT,
-                       bDataType, inputPin++});
+      ports.push_back({b.getStringAttr("W" + Twine(i) + "_data"),
+                       PortDirection::INPUT, bDataType, inputPin++});
       // Ignore mask port, if maskBits =1
       if (mem.isMasked)
-        ports.push_back({b.getStringAttr("W" + Twine(i) + "_mask"), hw::INPUT,
-                         maskType, inputPin++});
+        ports.push_back({b.getStringAttr("W" + Twine(i) + "_mask"),
+                         PortDirection::INPUT, maskType, inputPin++});
     }
 
     // Mask granularity is the number of data bits that each mask bit can

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -25,6 +25,19 @@
 using namespace circt;
 using namespace hw;
 
+/// Flip a port direction.
+PortDirection hw::flip(PortDirection direction) {
+  switch (direction) {
+  case PortDirection::INPUT:
+    return PortDirection::OUTPUT;
+  case PortDirection::OUTPUT:
+    return PortDirection::INPUT;
+  case PortDirection::INOUT:
+    return PortDirection::INOUT;
+  }
+  llvm_unreachable("unknown PortDirection");
+}
+
 /// Return true if the specified operation is a combinational logic op.
 bool hw::isCombinational(Operation *op) {
   struct IsCombClassifier : public TypeOpVisitor<IsCombClassifier, bool> {

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -154,8 +154,8 @@ static hw::HWModuleOp createModuleForCut(hw::HWModuleOp op,
     auto srcPorts = op.argNames();
     for (auto port : llvm::enumerate(inputs)) {
       auto name = getNameForPort(port.value(), srcPorts);
-      ports.push_back({b.getStringAttr(name), hw::INPUT, port.value().getType(),
-                       port.index()});
+      ports.push_back({b.getStringAttr(name), hw::PortDirection::INPUT,
+                       port.value().getType(), port.index()});
     }
   }
 


### PR DESCRIPTION
Add a `flip(PortDirection)` function which reverses a port direction. Also turn `PortDirection` into an `enum class` to avoid polluting the HW namespace. Most uses of the enum already have a `PortDirection::` prefix, so the change is fairly minimal and just enforces and already established practice.