### PR TITLE
[HandshakeToFIRRTL]: Add support for signed ops

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -212,7 +212,8 @@ struct InnerRefRecord {
 // insert-phase and lookup-phase based code.
 // TODO: Generalize this data structure.
 struct InnerRefList {
-  InnerRefList(MLIRContext* context) : InnerSymAttr(StringAttr::get(context, "inner_sym")) {}
+  InnerRefList(MLIRContext *context)
+      : InnerSymAttr(StringAttr::get(context, "inner_sym")) {}
 
   void sort() {
     llvm::sort(list);

--- a/include/circt/Dialect/Handshake/Visitor.h
+++ b/include/circt/Dialect/Handshake/Visitor.h
@@ -99,16 +99,15 @@ public:
   ResultType dispatchStdExprVisitor(Operation *op, ExtraArgs... args) {
     auto *thisCast = static_cast<ConcreteType *>(this);
     return TypeSwitch<Operation *, ResultType>(op)
-        .template Case<arith::IndexCastOp, arith::ExtUIOp, arith::TruncIOp,
-                       // Integer binary expressions.
-                       arith::CmpIOp, arith::AddIOp, arith::SubIOp,
-                       arith::MulIOp, arith::DivSIOp, arith::RemSIOp,
-                       arith::DivUIOp, arith::RemUIOp, arith::XOrIOp,
-                       arith::AndIOp, arith::OrIOp, arith::ShLIOp,
-                       arith::ShRSIOp, arith::ShRUIOp>(
-            [&](auto opNode) -> ResultType {
-              return thisCast->visitStdExpr(opNode, args...);
-            })
+        .template Case<
+            arith::IndexCastOp, arith::ExtUIOp, arith::ExtSIOp, arith::TruncIOp,
+            // Integer binary expressions.
+            arith::CmpIOp, arith::AddIOp, arith::SubIOp, arith::MulIOp,
+            arith::DivSIOp, arith::RemSIOp, arith::DivUIOp, arith::RemUIOp,
+            arith::XOrIOp, arith::AndIOp, arith::OrIOp, arith::ShLIOp,
+            arith::ShRSIOp, arith::ShRUIOp>([&](auto opNode) -> ResultType {
+          return thisCast->visitStdExpr(opNode, args...);
+        })
         .Default([&](auto opNode) -> ResultType {
           return thisCast->visitInvalidOp(op, args...);
         });
@@ -132,6 +131,7 @@ public:
   }
 
   HANDLE(arith::IndexCastOp);
+  HANDLE(arith::ExtSIOp);
   HANDLE(arith::ExtUIOp);
   HANDLE(arith::TruncIOp);
 

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -824,16 +824,14 @@ bool StdExprBuilder::buildSignExtendOp(unsigned dstWidth) {
   Value resultReady = resultSubfields[1];
   Value resultData = resultSubfields[2];
 
-  if (isSignedOp) {
+  if (isSignedOp)
     arg0Data = rewriter.create<AsSIntPrimOp>(insertLoc, arg0Data);
-  }
 
   Value resultDataOp =
       rewriter.create<PadPrimOp>(insertLoc, arg0Data, dstWidth);
 
-  if (isSignedOp) {
+  if (isSignedOp)
     resultDataOp = rewriter.create<AsUIntPrimOp>(insertLoc, resultDataOp);
-  }
 
   rewriter.create<ConnectOp>(insertLoc, resultData, resultDataOp);
 
@@ -914,13 +912,11 @@ void StdExprBuilder::buildBinaryLogic() {
   Value resultReady = resultSubfields[1];
   Value resultData = resultSubfields[2];
 
-  if (fstOpSigned) {
+  if (fstOpSigned)
     arg0Data = rewriter.create<AsSIntPrimOp>(insertLoc, arg0Data);
-  }
 
-  if (sndOpSigned) {
+  if (sndOpSigned)
     arg1Data = rewriter.create<AsSIntPrimOp>(insertLoc, arg1Data);
-  }
 
   // Carry out the binary operation.
   Value resultDataOp = rewriter.create<OpType>(insertLoc, arg0Data, arg1Data);

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -740,13 +740,14 @@ public:
       : portList(portList), insertLoc(insertLoc), rewriter(rewriter) {}
   using StdExprVisitor::visitStdExpr;
 
-  template <typename OpType>
+  template <typename OpType, bool fstOpSigned = false, bool sndOpSigned = false>
   void buildBinaryLogic();
 
   bool visitInvalidOp(Operation *op) { return false; }
 
   bool visitStdExpr(arith::CmpIOp op);
   bool visitStdExpr(arith::ExtUIOp op);
+  bool visitStdExpr(arith::ExtSIOp op);
   bool visitStdExpr(arith::TruncIOp op);
   bool visitStdExpr(arith::IndexCastOp op);
 
@@ -756,19 +757,26 @@ public:
   HANDLE(arith::AddIOp, AddPrimOp);
   HANDLE(arith::SubIOp, SubPrimOp);
   HANDLE(arith::MulIOp, MulPrimOp);
-  HANDLE(arith::DivSIOp, DivPrimOp);
-  HANDLE(arith::RemSIOp, RemPrimOp);
   HANDLE(arith::DivUIOp, DivPrimOp);
   HANDLE(arith::RemUIOp, RemPrimOp);
   HANDLE(arith::XOrIOp, XorPrimOp);
   HANDLE(arith::AndIOp, AndPrimOp);
   HANDLE(arith::OrIOp, OrPrimOp);
   HANDLE(arith::ShLIOp, DShlPrimOp);
-  HANDLE(arith::ShRSIOp, DShrPrimOp);
   HANDLE(arith::ShRUIOp, DShrPrimOp);
 #undef HANDLE
 
-  bool buildZeroExtendOp(unsigned dstWidth);
+#define HANDLE_SIGNED(OPTYPE, FIRRTLTYPE, sndOpSigned)                         \
+  bool visitStdExpr(OPTYPE op) {                                               \
+    return buildBinaryLogic<FIRRTLTYPE, true, sndOpSigned>(), true;            \
+  }
+  HANDLE_SIGNED(arith::DivSIOp, DivPrimOp, true);
+  HANDLE_SIGNED(arith::RemSIOp, RemPrimOp, true);
+  HANDLE_SIGNED(arith::ShRSIOp, DShrPrimOp, false);
+#undef HANDLE_SIGNED
+
+  template <bool isSignedOp = false>
+  bool buildSignExtendOp(unsigned dstWidth);
   bool buildTruncateOp(unsigned dstWidth);
 
 private:
@@ -785,22 +793,27 @@ bool StdExprBuilder::visitStdExpr(arith::CmpIOp op) {
   case arith::CmpIPredicate::ne:
     return buildBinaryLogic<NEQPrimOp>(), true;
   case arith::CmpIPredicate::slt:
+    return buildBinaryLogic<LTPrimOp, true, true>(), true;
   case arith::CmpIPredicate::ult:
     return buildBinaryLogic<LTPrimOp>(), true;
   case arith::CmpIPredicate::sle:
+    return buildBinaryLogic<LEQPrimOp, true, true>(), true;
   case arith::CmpIPredicate::ule:
     return buildBinaryLogic<LEQPrimOp>(), true;
   case arith::CmpIPredicate::sgt:
+    return buildBinaryLogic<GTPrimOp, true, true>(), true;
   case arith::CmpIPredicate::ugt:
     return buildBinaryLogic<GTPrimOp>(), true;
   case arith::CmpIPredicate::sge:
+    return buildBinaryLogic<GEQPrimOp, true, true>(), true;
   case arith::CmpIPredicate::uge:
     return buildBinaryLogic<GEQPrimOp>(), true;
   }
   llvm_unreachable("invalid CmpIOp");
 }
 
-bool StdExprBuilder::buildZeroExtendOp(unsigned dstWidth) {
+template <bool isSignedOp>
+bool StdExprBuilder::buildSignExtendOp(unsigned dstWidth) {
   ValueVector arg0Subfield = portList[0];
   ValueVector resultSubfields = portList[1];
 
@@ -811,8 +824,17 @@ bool StdExprBuilder::buildZeroExtendOp(unsigned dstWidth) {
   Value resultReady = resultSubfields[1];
   Value resultData = resultSubfields[2];
 
+  if (isSignedOp) {
+    arg0Data = rewriter.create<AsSIntPrimOp>(insertLoc, arg0Data);
+  }
+
   Value resultDataOp =
       rewriter.create<PadPrimOp>(insertLoc, arg0Data, dstWidth);
+
+  if (isSignedOp) {
+    resultDataOp = rewriter.create<AsUIntPrimOp>(insertLoc, resultDataOp);
+  }
+
   rewriter.create<ConnectOp>(insertLoc, resultData, resultDataOp);
 
   // Generate valid signal.
@@ -851,8 +873,14 @@ bool StdExprBuilder::buildTruncateOp(unsigned int dstWidth) {
 }
 
 bool StdExprBuilder::visitStdExpr(arith::ExtUIOp op) {
-  return buildZeroExtendOp(getFIRRTLType(getOperandDataType(op.getOperand()))
+  return buildSignExtendOp(getFIRRTLType(getOperandDataType(op.getOperand()))
                                .getBitWidthOrSentinel());
+}
+
+bool StdExprBuilder::visitStdExpr(arith::ExtSIOp op) {
+  return buildSignExtendOp<true>(
+      getFIRRTLType(getOperandDataType(op.getOperand()))
+          .getBitWidthOrSentinel());
 }
 
 bool StdExprBuilder::visitStdExpr(arith::TruncIOp op) {
@@ -866,11 +894,11 @@ bool StdExprBuilder::visitStdExpr(arith::IndexCastOp op) {
   unsigned targetBits = targetType.getBitWidthOrSentinel();
   unsigned sourceBits = sourceType.getBitWidthOrSentinel();
   return (targetBits < sourceBits ? buildTruncateOp(targetBits)
-                                  : buildZeroExtendOp(targetBits));
+                                  : buildSignExtendOp(targetBits));
 }
 
 /// Please refer to simple_addi.mlir test case.
-template <typename OpType>
+template <typename OpType, bool fstOpSigned, bool sndOpSigned>
 void StdExprBuilder::buildBinaryLogic() {
   ValueVector arg0Subfield = portList[0];
   ValueVector arg1Subfield = portList[1];
@@ -886,6 +914,14 @@ void StdExprBuilder::buildBinaryLogic() {
   Value resultReady = resultSubfields[1];
   Value resultData = resultSubfields[2];
 
+  if (fstOpSigned) {
+    arg0Data = rewriter.create<AsSIntPrimOp>(insertLoc, arg0Data);
+  }
+
+  if (sndOpSigned) {
+    arg1Data = rewriter.create<AsSIntPrimOp>(insertLoc, arg1Data);
+  }
+
   // Carry out the binary operation.
   Value resultDataOp = rewriter.create<OpType>(insertLoc, arg0Data, arg1Data);
   auto resultTy = resultDataOp.getType().cast<FIRRTLType>();
@@ -895,9 +931,14 @@ void StdExprBuilder::buildBinaryLogic() {
                          .cast<FIRRTLType>()
                          .getPassiveType()
                          .getBitWidthOrSentinel();
+
   if (resultWidth < resultTy.getBitWidthOrSentinel()) {
     resultDataOp = rewriter.create<BitsPrimOp>(insertLoc, resultDataOp,
                                                resultWidth - 1, 0);
+  } else if (fstOpSigned) {
+    // BitsPrimOp already casts to correct type, thus only do this when no
+    // BitsPrimOp was created
+    resultDataOp = rewriter.create<AsUIntPrimOp>(insertLoc, resultDataOp);
   }
 
   rewriter.create<ConnectOp>(insertLoc, resultData, resultDataOp);

--- a/test/Conversion/HandshakeToFIRRTL/test_signed_ops.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_signed_ops.mlir
@@ -1,0 +1,143 @@
+// RUN: circt-opt -split-input-file -lower-handshake-to-firrtl %s | FileCheck %s
+
+
+// CHECK:  firrtl.circuit "test_cmpi"  {
+// CHECK:    firrtl.module @arith_cmpi_in_ui32_ui32_out_ui1_sgt(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>) {
+// CHECK:      %[[VAL_3:.*]] = firrtl.subfield %[[VAL_0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
+// CHECK:      %[[VAL_6:.*]] = firrtl.subfield %[[VAL_1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_7:.*]] = firrtl.subfield %[[VAL_1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_8:.*]] = firrtl.subfield %[[VAL_1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
+// CHECK:      %[[VAL_9:.*]] = firrtl.subfield %[[VAL_2]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_10:.*]] = firrtl.subfield %[[VAL_2]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_11:.*]] = firrtl.subfield %[[VAL_2]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<1>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_12:.*]] = firrtl.asSInt %[[VAL_5]] : (!firrtl.uint<32>) -> !firrtl.sint<32>
+// CHECK:      %[[VAL_13:.*]] = firrtl.asSInt %[[VAL_8]] : (!firrtl.uint<32>) -> !firrtl.sint<32>
+// CHECK:      %[[VAL_14:.*]] = firrtl.gt %[[VAL_12]], %[[VAL_13]] : (!firrtl.sint<32>, !firrtl.sint<32>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_15:.*]] = firrtl.asUInt %[[VAL_14]] : (!firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:      firrtl.connect %[[VAL_11]], %[[VAL_15]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:      %[[VAL_16:.*]] = firrtl.and %[[VAL_3]], %[[VAL_6]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:      firrtl.connect %[[VAL_9]], %[[VAL_16]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:      %[[VAL_17:.*]] = firrtl.and %[[VAL_10]], %[[VAL_16]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:      firrtl.connect %[[VAL_4]], %[[VAL_17]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:      firrtl.connect %[[VAL_7]], %[[VAL_17]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:    }
+
+handshake.func @test_cmpi(%arg0: i32, %arg1: i32, %arg2: none, ...) -> (i1, none) {
+  %0 = arith.cmpi sgt, %arg0, %arg1 : i32
+  return %0, %arg2 : i1, none
+}
+
+// -----
+
+// CHECK:  firrtl.circuit "test_divsi"  {
+// CHECK:    firrtl.module @arith_divsi_in_ui32_ui32_out_ui32(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) {
+// CHECK:      %[[VAL_3:.*]] = firrtl.subfield %[[VAL_0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
+// CHECK:      %[[VAL_6:.*]] = firrtl.subfield %[[VAL_1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_7:.*]] = firrtl.subfield %[[VAL_1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_8:.*]] = firrtl.subfield %[[VAL_1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
+// CHECK:      %[[VAL_9:.*]] = firrtl.subfield %[[VAL_2]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_10:.*]] = firrtl.subfield %[[VAL_2]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_11:.*]] = firrtl.subfield %[[VAL_2]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
+// CHECK:      %[[VAL_12:.*]] = firrtl.asSInt %[[VAL_5]] : (!firrtl.uint<32>) -> !firrtl.sint<32>
+// CHECK:      %[[VAL_13:.*]] = firrtl.asSInt %[[VAL_8]] : (!firrtl.uint<32>) -> !firrtl.sint<32>
+// CHECK:      %[[VAL_14:.*]] = firrtl.div %[[VAL_12]], %[[VAL_13]] : (!firrtl.sint<32>, !firrtl.sint<32>) -> !firrtl.sint<33>
+// CHECK:      %[[VAL_15:.*]] = firrtl.bits %[[VAL_14]] 31 to 0 : (!firrtl.sint<33>) -> !firrtl.uint<32>
+// CHECK:      firrtl.connect %[[VAL_11]], %[[VAL_15]] : !firrtl.uint<32>, !firrtl.uint<32>
+// CHECK:      %[[VAL_16:.*]] = firrtl.and %[[VAL_3]], %[[VAL_6]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:      firrtl.connect %[[VAL_9]], %[[VAL_16]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:      %[[VAL_17:.*]] = firrtl.and %[[VAL_10]], %[[VAL_16]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:      firrtl.connect %[[VAL_4]], %[[VAL_17]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:      firrtl.connect %[[VAL_7]], %[[VAL_17]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:    }
+
+handshake.func @test_divsi(%arg0: i32, %arg1: i32, %arg2: none, ...) -> (i32, none) {
+  %0 = arith.divsi %arg0, %arg1 : i32
+  return %0, %arg2 : i32, none
+}
+
+// -----
+
+// CHECK:  firrtl.circuit "test_remsi"  {
+// CHECK:    firrtl.module @arith_remsi_in_ui32_ui32_out_ui32(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) {
+// CHECK:      %[[VAL_3:.*]] = firrtl.subfield %[[VAL_0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
+// CHECK:      %[[VAL_6:.*]] = firrtl.subfield %[[VAL_1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_7:.*]] = firrtl.subfield %[[VAL_1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_8:.*]] = firrtl.subfield %[[VAL_1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
+// CHECK:      %[[VAL_9:.*]] = firrtl.subfield %[[VAL_2]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_10:.*]] = firrtl.subfield %[[VAL_2]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_11:.*]] = firrtl.subfield %[[VAL_2]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
+// CHECK:      %[[VAL_12:.*]] = firrtl.asSInt %[[VAL_5]] : (!firrtl.uint<32>) -> !firrtl.sint<32>
+// CHECK:      %[[VAL_13:.*]] = firrtl.asSInt %[[VAL_8]] : (!firrtl.uint<32>) -> !firrtl.sint<32>
+// CHECK:      %[[VAL_14:.*]] = firrtl.rem %[[VAL_12]], %[[VAL_13]] : (!firrtl.sint<32>, !firrtl.sint<32>) -> !firrtl.sint<32>
+// CHECK:      %[[VAL_15:.*]] = firrtl.asUInt %[[VAL_14]] : (!firrtl.sint<32>) -> !firrtl.uint<32>
+// CHECK:      firrtl.connect %[[VAL_11]], %[[VAL_15]] : !firrtl.uint<32>, !firrtl.uint<32>
+// CHECK:      %[[VAL_16:.*]] = firrtl.and %[[VAL_3]], %[[VAL_6]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:      firrtl.connect %[[VAL_9]], %[[VAL_16]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:      %[[VAL_17:.*]] = firrtl.and %[[VAL_10]], %[[VAL_16]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:      firrtl.connect %[[VAL_4]], %[[VAL_17]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:      firrtl.connect %[[VAL_7]], %[[VAL_17]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:    }
+
+handshake.func @test_remsi(%arg0: i32, %arg1: i32, %arg2: none, ...) -> (i32, none) {
+  %0 = arith.remsi %arg0, %arg1 : i32
+  return %0, %arg2 : i32, none
+}
+
+// -----
+
+// CHECK:  firrtl.circuit "test_extsi"  {
+// CHECK:    firrtl.module @arith_extsi_in_ui16_out_ui32(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<16>>, out %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) {
+// CHECK:      %[[VAL_3:.*]] = firrtl.subfield %[[VAL_0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<16>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<16>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<16>>) -> !firrtl.uint<16>
+// CHECK:      %[[VAL_6:.*]] = firrtl.subfield %[[VAL_2]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_7:.*]] = firrtl.subfield %[[VAL_2]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_8:.*]] = firrtl.subfield %[[VAL_2]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
+// CHECK:      %[[VAL_9:.*]] = firrtl.asSInt %[[VAL_5]] : (!firrtl.uint<16>) -> !firrtl.sint<16>
+// CHECK:      %[[VAL_10:.*]] = firrtl.pad %[[VAL_9]], 16 : (!firrtl.sint<16>) -> !firrtl.sint<16>
+// CHECK:      %[[VAL_11:.*]] = firrtl.asUInt %[[VAL_10]] : (!firrtl.sint<16>) -> !firrtl.uint<16>
+// CHECK:      firrtl.connect %[[VAL_8]], %[[VAL_11]] : !firrtl.uint<32>, !firrtl.uint<16>
+// CHECK:      firrtl.connect %[[VAL_6]], %[[VAL_3]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:      %[[VAL_12:.*]] = firrtl.and %[[VAL_7]], %[[VAL_3]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:      firrtl.connect %[[VAL_4]], %[[VAL_12]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:    }
+
+handshake.func @test_extsi(%arg0: i16, %arg1: none, ...) -> (i32, none) {
+  %0 = arith.extsi %arg0 : i16 to i32
+  return %0, %arg1 : i32, none
+}
+
+// -----
+
+// CHECK:  firrtl.circuit "test_shrsi"  {
+// CHECK:    firrtl.module @arith_shrsi_in_ui32_ui32_out_ui32(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>, out %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) {
+// CHECK:      %[[VAL_3:.*]] = firrtl.subfield %[[VAL_0]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_4:.*]] = firrtl.subfield %[[VAL_0]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_5:.*]] = firrtl.subfield %[[VAL_0]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
+// CHECK:      %[[VAL_6:.*]] = firrtl.subfield %[[VAL_1]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_7:.*]] = firrtl.subfield %[[VAL_1]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_8:.*]] = firrtl.subfield %[[VAL_1]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
+// CHECK:      %[[VAL_9:.*]] = firrtl.subfield %[[VAL_2]](0) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_10:.*]] = firrtl.subfield %[[VAL_2]](1) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<1>
+// CHECK:      %[[VAL_11:.*]] = firrtl.subfield %[[VAL_2]](2) : (!firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<32>>) -> !firrtl.uint<32>
+// CHECK:      %[[VAL_12:.*]] = firrtl.asSInt %[[VAL_5]] : (!firrtl.uint<32>) -> !firrtl.sint<32>
+// CHECK:      %[[VAL_14:.*]] = firrtl.dshr %[[VAL_12]], %[[VAL_8]] : (!firrtl.sint<32>, !firrtl.uint<32>) -> !firrtl.sint<32>
+// CHECK:      %[[VAL_15:.*]] = firrtl.asUInt %[[VAL_14]] : (!firrtl.sint<32>) -> !firrtl.uint<32>
+// CHECK:      firrtl.connect %[[VAL_11]], %[[VAL_15]] : !firrtl.uint<32>, !firrtl.uint<32>
+// CHECK:      %[[VAL_16:.*]] = firrtl.and %[[VAL_3]], %[[VAL_6]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:      firrtl.connect %[[VAL_9]], %[[VAL_16]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:      %[[VAL_17:.*]] = firrtl.and %[[VAL_10]], %[[VAL_16]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:      firrtl.connect %[[VAL_4]], %[[VAL_17]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:      firrtl.connect %[[VAL_7]], %[[VAL_17]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:    }
+
+handshake.func @test_shrsi(%arg0: i32, %arg1: i32, %arg2: none, ...) -> (i32, none) {
+  %0 = arith.shrsi %arg0, %arg1 : i32
+  return %0, %arg2 : i32, none
+}


### PR DESCRIPTION
This PR adds support for signed operations by casting unsigned operands to signed ones, if needed. 
Closes #2728 as it solves the issues of all the existing operations.  

Note: I decided to template the parameter that indicate signedness of certain operands as this is statically known for each call to the helper functions.  