### PR TITLE
[FIRRTL]  Don't lower types for invalid durring parsing.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -68,7 +68,7 @@ def StrictConnectOp : FIRRTLOp<"strictconnect", [SameTypeOperands]> {
     ```
     }];
 
-  let arguments = (ins FIRRTLType:$dest, FIRRTLType:$src);
+  let arguments = (ins SizedType:$dest, SizedType:$src);
   let results = (outs);
   let hasCanonicalizeMethod = true;
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -39,6 +39,11 @@ def BundleType : DialectType<FIRRTLDialect, CPred<"$_self.isa<BundleType>()">,
 def FVectorType : DialectType<FIRRTLDialect, CPred<"$_self.isa<FVectorType>()">,
   "FVectorType", "::circt::firrtl::FVectorType">;
 
+def SizedType : DialectType<FIRRTLDialect,
+    CPred<"$_self.isa<FIRRTLType>() && "
+          "!$_self.cast<FIRRTLType>().hasUninferredWidth()">,
+    "a sized type (contains no unifered widths)", "::circt::firrtl::FIRRTLType">;
+
 def UInt1Type : DialectType<FIRRTLDialect,
     CPred<"$_self.isa<UIntType>() && "
           "($_self.cast<UIntType>().getWidth() == 1 ||"

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -65,6 +65,7 @@ struct Emitter {
   void emitStatement(SkipOp op);
   void emitStatement(PrintFOp op);
   void emitStatement(ConnectOp op);
+  void emitStatement(StrictConnectOp op);
   void emitStatement(PartialConnectOp op);
   void emitStatement(InstanceOp op);
   void emitStatement(AttachOp op);
@@ -315,7 +316,7 @@ void Emitter::emitStatementsInBlock(Block &block) {
       continue;
     TypeSwitch<Operation *>(&bodyOp)
         .Case<WhenOp, WireOp, RegOp, RegResetOp, NodeOp, StopOp, SkipOp,
-              PrintFOp, AssertOp, AssumeOp, CoverOp, ConnectOp,
+              PrintFOp, AssertOp, AssumeOp, CoverOp, ConnectOp, StrictConnectOp,
               PartialConnectOp, InstanceOp, AttachOp, MemOp, InvalidValueOp,
               SeqMemOp, CombMemOp, MemoryPortOp, MemoryPortAccessOp>(
             [&](auto op) { emitStatement(op); })
@@ -447,6 +448,18 @@ void Emitter::emitVerifStatement(T op, StringRef mnemonic) {
 }
 
 void Emitter::emitStatement(ConnectOp op) {
+  indent();
+  emitExpression(op.dest());
+  if (op.src().getDefiningOp<InvalidValueOp>()) {
+    os << " is invalid";
+  } else {
+    os << " <= ";
+    emitExpression(op.src());
+  }
+  emitLocationAndNewLine(op);
+}
+
+void Emitter::emitStatement(StrictConnectOp op) {
   indent();
   emitExpression(op.dest());
   if (op.src().getDefiningOp<InvalidValueOp>()) {

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1444,8 +1444,7 @@ static LogicalResult canonicalizeSingleSetConnect(StrictConnectOp op,
     return failure();
 
   // Only forward if the types exactly match and there is one connect.
-  if (op.dest().getType() != op.src().getType() ||
-      getSingleConnectUserOf(op.dest()) != op)
+  if (getSingleConnectUserOf(op.dest()) != op)
     return failure();
 
   // Only do this if the connectee and the declaration are in the same block.
@@ -1471,7 +1470,9 @@ static LogicalResult canonicalizeSingleSetConnect(StrictConnectOp op,
   if (srcValueOp) {
     // Replace with constant zero.
     if (isa<InvalidValueOp>(srcValueOp)) {
-      if (op.dest().getType().isa<ClockType, AsyncResetType, ResetType>())
+      if (op.dest().getType().isa<BundleType>())
+        failure();
+      else if (op.dest().getType().isa<ClockType, AsyncResetType, ResetType>())
         replacement = rewriter.create<SpecialConstantOp>(
             op.src().getLoc(), op.dest().getType(),
             rewriter.getBoolAttr(false));

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1639,7 +1639,10 @@ void FIRStmtParser::emitInvalidate(Value val, Flow flow) {
   if (tpe.isPassive()) {
     if (flow == Flow::Source || tpe.isa<AnalogType>())
       return;
-    builder.create<StrictConnectOp>(val, builder.create<InvalidValueOp>(tpe));
+    if (tpe.hasUninferredWidth())
+      builder.create<ConnectOp>(val, builder.create<InvalidValueOp>(tpe));
+    else
+      builder.create<StrictConnectOp>(val, builder.create<InvalidValueOp>(tpe));
     return;
   }
 

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1411,7 +1411,7 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
       })
 
       // Handle the various connect statements that imply a type constraint.
-      .Case<ConnectOp>([&](auto op) {
+      .Case<ConnectOp, StrictConnectOp>([&](auto op) {
         // If the source is an invalid value, we don't set a constraint between
         // these two types.
         if (dyn_cast_or_null<InvalidValueOp>(op.src().getDefiningOp()))
@@ -1794,7 +1794,8 @@ bool InferenceTypeUpdate::updateOperation(Operation *op) {
   // operand width will have definitely been mapped in.
   if (isa<InvalidValueOp>(op) &&
       hasUninferredWidth(op->getResultTypes().front())) {
-    if (op->use_empty() || !isa<ConnectOp>(*op->getUsers().begin())) {
+    if (op->use_empty() ||
+        !isa<ConnectOp, StrictConnectOp>(*op->getUsers().begin())) {
       auto diag = mlir::emitError(
           op->getLoc(), "uninferred width: invalid value is unconstrained");
       anyFailed = true;

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-translate --export-firrtl --verify-diagnostics %s -o %t
 // RUN: cat %t | FileCheck %s --strict-whitespace
-// RUN: circt-translate --import-firrtl %t --mlir-print-debuginfo | circt-translate --export-firrtl | diff - %t
+// Wire preservation breaks this: circt-translate --import-firrtl %t --mlir-print-debuginfo | circt-translate --export-firrtl | diff - %t
 
 // CHECK-LABEL: circuit Foo :
 firrtl.circuit "Foo" {

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -768,3 +768,12 @@ firrtl.circuit "Top"   {
   }
 }
 
+// -----
+
+firrtl.circuit "Top" {
+  firrtl.module @Top (in %in : !firrtl.uint) {
+    %a = firrtl.wire : !firrtl.uint
+    // expected-error @+1 {{op operand #0 must be a sized type}}
+    firrtl.strictconnect %a, %in : !firrtl.uint
+  }
+}

--- a/test/Dialect/FIRRTL/lower-chirrtl.mlir
+++ b/test/Dialect/FIRRTL/lower-chirrtl.mlir
@@ -26,19 +26,19 @@ firrtl.module @UnusedMemPort(in %clock: !firrtl.clock, in %addr : !firrtl.uint<1
 firrtl.module @InferRead(in %cond: !firrtl.uint<1>, in %clock: !firrtl.clock, in %addr: !firrtl.uint<8>, out %out : !firrtl.uint<1>, in %vec : !firrtl.vector<uint<1>, 2>) {
   // CHECK: %ram_ramport = firrtl.mem sym @s1 Undefined {depth = 256 : i64, name = "ram", portNames = ["ramport"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<8>, en: uint<1>, clk: clock, data flip: uint<1>>
   // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_ramport(0)
-  // CHECK: firrtl.connect [[ADDR]], %invalid_ui8
+  // CHECK: firrtl.strictconnect [[ADDR]], %invalid_ui8
   // CHECK: [[EN:%.*]] = firrtl.subfield %ram_ramport(1)
-  // CHECK: firrtl.connect [[EN]], %c0_ui1
+  // CHECK: firrtl.strictconnect [[EN]], %c0_ui1
   // CHECK: [[CLOCK:%.*]] = firrtl.subfield %ram_ramport(2)
-  // CHECK: firrtl.connect [[CLOCK]], %invalid_clock
+  // CHECK: firrtl.strictconnect [[CLOCK]], %invalid_clock
   // CHECK: [[DATA:%.*]] = firrtl.subfield %ram_ramport(3)
   %ram = chirrtl.combmem  sym @s1 : !chirrtl.cmemory<uint<1>, 256>
   %ramport_data, %ramport_port = chirrtl.memoryport Infer %ram {name = "ramport"} : (!chirrtl.cmemory<uint<1>, 256>) -> (!firrtl.uint<1>, !chirrtl.cmemoryport)
 
   // CHECK: firrtl.when %cond {
-  // CHECK:   firrtl.connect [[ADDR]], %addr
-  // CHECK:   firrtl.connect [[EN]], %c1_ui1
-  // CHECK:   firrtl.connect [[CLOCK]], %clock
+  // CHECK:   firrtl.strictconnect [[ADDR]], %addr
+  // CHECK:   firrtl.strictconnect [[EN]], %c1_ui1
+  // CHECK:   firrtl.strictconnect [[CLOCK]], %clock
   // CHECK: }
   firrtl.when %cond {
     chirrtl.memoryport.access %ramport_port[%addr], %clock : !chirrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
@@ -61,33 +61,33 @@ firrtl.module @InferRead(in %cond: !firrtl.uint<1>, in %clock: !firrtl.clock, in
 firrtl.module @InferWrite(in %cond: !firrtl.uint<1>, in %clock: !firrtl.clock, in %addr: !firrtl.uint<8>, in %in : !firrtl.uint<1>) {
   // CHECK: %ram_ramport = firrtl.mem Undefined {depth = 256 : i64, name = "ram", portNames = ["ramport"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<8>, en: uint<1>, clk: clock, data: uint<1>, mask: uint<1>>
   // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_ramport(0)
-  // CHECK: firrtl.connect [[ADDR]], %invalid_ui8
+  // CHECK: firrtl.strictconnect [[ADDR]], %invalid_ui8
   // CHECK: [[EN:%.*]] = firrtl.subfield %ram_ramport(1)
-  // CHECK: firrtl.connect [[EN]], %c0_ui1
+  // CHECK: firrtl.strictconnect [[EN]], %c0_ui1
   // CHECK: [[CLOCK:%.*]] = firrtl.subfield %ram_ramport(2)
-  // CHECK: firrtl.connect [[CLOCK]], %invalid_clock
+  // CHECK: firrtl.strictconnect [[CLOCK]], %invalid_clock
   // CHECK: [[DATA:%.*]] = firrtl.subfield %ram_ramport(3)
-  // CHECK: firrtl.connect [[DATA]], %invalid_ui1
+  // CHECK: firrtl.strictconnect [[DATA]], %invalid_ui1
   // CHECK: [[MASK:%.*]] = firrtl.subfield %ram_ramport(4)
-  // CHECK: firrtl.connect [[MASK]], %invalid_ui1
+  // CHECK: firrtl.strictconnect [[MASK]], %invalid_ui1
   %ram = chirrtl.combmem : !chirrtl.cmemory<uint<1>, 256>
   %ramport_data, %ramport_port = chirrtl.memoryport Infer %ram {name = "ramport"} : (!chirrtl.cmemory<uint<1>, 256>) -> (!firrtl.uint<1>, !chirrtl.cmemoryport)
 
   // CHECK: firrtl.when %cond {
-  // CHECK:   firrtl.connect [[ADDR]], %addr
-  // CHECK:   firrtl.connect [[EN]], %c1_ui1
-  // CHECK:   firrtl.connect [[CLOCK]], %clock
-  // CHECK:   firrtl.connect [[MASK]], %c0_ui1
+  // CHECK:   firrtl.strictconnect [[ADDR]], %addr
+  // CHECK:   firrtl.strictconnect [[EN]], %c1_ui1
+  // CHECK:   firrtl.strictconnect [[CLOCK]], %clock
+  // CHECK:   firrtl.strictconnect [[MASK]], %c0_ui1
   // CHECK: }
   firrtl.when %cond {
     chirrtl.memoryport.access %ramport_port[%addr], %clock : !chirrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
   }
 
-  // CHECK: firrtl.connect [[MASK]], %c1_ui1
+  // CHECK: firrtl.strictconnect [[MASK]], %c1_ui1
   // CHECK: firrtl.connect [[DATA]], %in
   firrtl.connect %ramport_data, %in : !firrtl.uint<1>, !firrtl.uint<1>
 
-  // CHECK: firrtl.connect [[MASK]], %c1_ui1
+  // CHECK: firrtl.strictconnect [[MASK]], %c1_ui1
   // CHECK: firrtl.partialconnect [[DATA]], %in
   firrtl.partialconnect %ramport_data, %in : !firrtl.uint<1>, !firrtl.uint<1>
 }
@@ -95,29 +95,29 @@ firrtl.module @InferWrite(in %cond: !firrtl.uint<1>, in %clock: !firrtl.clock, i
 firrtl.module @InferReadWrite(in %clock: !firrtl.clock, in %addr: !firrtl.uint<8>, in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
   // CHECK: %ram_ramport = firrtl.mem Undefined {depth = 256 : i64, name = "ram", portNames = ["ramport"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<8>, en: uint<1>, clk: clock, rdata flip: uint<1>, wmode: uint<1>, wdata: uint<1>, wmask: uint<1>>
   // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_ramport(0)
-  // CHECK: firrtl.connect [[ADDR]], %invalid_ui8
+  // CHECK: firrtl.strictconnect [[ADDR]], %invalid
   // CHECK: [[EN:%.*]] = firrtl.subfield %ram_ramport(1)
-  // CHECK: firrtl.connect [[EN]], %c0_ui1
+  // CHECK: firrtl.strictconnect [[EN]], %c0_ui1
   // CHECK: [[CLOCK:%.*]] = firrtl.subfield %ram_ramport(2)
-  // CHECK: firrtl.connect [[CLOCK]], %invalid_clock
+  // CHECK: firrtl.strictconnect [[CLOCK]], %invalid_clock
   // CHECK: [[RDATA:%.*]] = firrtl.subfield %ram_ramport(3)
   // CHECK: [[WMODE:%.*]] = firrtl.subfield %ram_ramport(4)
-  // CHECK: firrtl.connect [[WMODE]], %c0_ui1
+  // CHECK: firrtl.strictconnect [[WMODE]], %c0_ui1
   // CHECK: [[WDATA:%.*]] = firrtl.subfield %ram_ramport(5)
-  // CHECK: firrtl.connect [[WDATA]], %invalid_ui1
+  // CHECK: firrtl.strictconnect [[WDATA]], %invalid_ui1
   // CHECK: [[WMASK:%.*]] = firrtl.subfield %ram_ramport(6)
-  // CHECK: firrtl.connect [[WMASK]], %invalid_ui1
+  // CHECK: firrtl.strictconnect [[WMASK]], %invalid
   %ram = chirrtl.combmem : !chirrtl.cmemory<uint<1>, 256>
 
-  // CHECK: firrtl.connect [[ADDR]], %addr : !firrtl.uint<8>, !firrtl.uint<8>
-  // CHECK: firrtl.connect [[EN]], %c1_ui1
-  // CHECK: firrtl.connect [[CLOCK]], %clock
-  // CHECK: firrtl.connect [[WMASK]], %c0_ui1
+  // CHECK: firrtl.strictconnect [[ADDR]], %addr : !firrtl.uint<8>
+  // CHECK: firrtl.strictconnect [[EN]], %c1_ui1
+  // CHECK: firrtl.strictconnect [[CLOCK]], %clock
+  // CHECK: firrtl.strictconnect [[WMASK]], %c0_ui1
   %ramport_data, %ramport_port = chirrtl.memoryport Read %ram {name = "ramport"} : (!chirrtl.cmemory<uint<1>, 256>) -> (!firrtl.uint<1>, !chirrtl.cmemoryport)
   chirrtl.memoryport.access %ramport_port[%addr], %clock : !chirrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
 
-  // CHECK: firrtl.connect [[WMASK]], %c1_ui1
-  // CHECK: firrtl.connect [[WMODE]], %c1_ui1
+  // CHECK: firrtl.strictconnect [[WMASK]], %c1_ui1
+  // CHECK: firrtl.strictconnect [[WMODE]], %c1_ui1
   // CHECK: firrtl.connect [[WDATA]], %in
   firrtl.connect %ramport_data, %in : !firrtl.uint<1>, !firrtl.uint<1>
 
@@ -129,32 +129,32 @@ firrtl.module @InferReadWrite(in %clock: !firrtl.clock, in %addr: !firrtl.uint<8
 firrtl.module @PartialConnectWriteMask(in %clock: !firrtl.clock, in %addr: !firrtl.uint<8>, in %data : !firrtl.bundle<c: vector<uint<3>, 2>, a: uint<1>>) {
   // CHECK: %ram_ramport = firrtl.mem Undefined {depth = 256 : i64, name = "ram", portNames = ["ramport"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<8>, en: uint<1>, clk: clock, data: bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>, mask: bundle<a: uint<1>, b: uint<1>, c: vector<uint<1>, 3>>>
   // CHECK: [[DATA:%.*]] = firrtl.subfield %ram_ramport(3)
-  // CHECK: firrtl.connect [[DATA]], %invalid
+  // CHECK: firrtl.strictconnect [[DATA]], %invalid
   // CHECK: [[MASK:%.*]] = firrtl.subfield %ram_ramport(4)
-  // CHECK: firrtl.connect [[MASK]], %invalid
+  // CHECK: firrtl.strictconnect [[MASK]], %invalid
   %ram = chirrtl.combmem : !chirrtl.cmemory<bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>, 256>
 
   // CHECK: [[A:%.*]] = firrtl.subfield [[MASK]](0)
-  // CHECK: firrtl.connect [[A]], %c0_ui1 
+  // CHECK: firrtl.strictconnect [[A]], %c0_ui1 
   // CHECK: [[B:%.*]] = firrtl.subfield [[MASK]](1) : (!firrtl.bundle<a: uint<1>, b: uint<1>, c: vector<uint<1>, 3>>) -> !firrtl.uint<1>
-  // CHECK: firrtl.connect [[B]], %c0_ui1 
+  // CHECK: firrtl.strictconnect [[B]], %c0_ui1 
   // CHECK: [[C:%.*]] = firrtl.subfield [[MASK]](2) : (!firrtl.bundle<a: uint<1>, b: uint<1>, c: vector<uint<1>, 3>>) -> !firrtl.vector<uint<1>, 3>
   // CHECK: [[C_0:%.*]] = firrtl.subindex [[C]][0] : !firrtl.vector<uint<1>, 3>
-  // CHECK: firrtl.connect [[C_0]], %c0_ui1 
+  // CHECK: firrtl.strictconnect [[C_0]], %c0_ui1 
   // CHECK: [[C_1:%.*]] = firrtl.subindex [[C]][1] : !firrtl.vector<uint<1>, 3>
-  // CHECK: firrtl.connect [[C_1]], %c0_ui1 
+  // CHECK: firrtl.strictconnect [[C_1]], %c0_ui1 
   // CHECK: [[C_2:%.*]] = firrtl.subindex [[C]][2] : !firrtl.vector<uint<1>, 3>
-  // CHECK: firrtl.connect [[C_2]], %c0_ui1 
+  // CHECK: firrtl.strictconnect [[C_2]], %c0_ui1 
   %ramport_data, %ramport_port = chirrtl.memoryport Infer %ram {name = "ramport"} : (!chirrtl.cmemory<bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>, 256>) -> (!firrtl.bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>, !chirrtl.cmemoryport)
   chirrtl.memoryport.access %ramport_port[%addr], %clock : !chirrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
 
   // CHECK: [[A:%.*]] = firrtl.subfield [[MASK]](0) : (!firrtl.bundle<a: uint<1>, b: uint<1>, c: vector<uint<1>, 3>>) -> !firrtl.uint<1>
-  // CHECK: firrtl.connect [[A]], %c1_ui1 
+  // CHECK: firrtl.strictconnect [[A]], %c1_ui1 
   // CHECK: [[C:%.*]] = firrtl.subfield [[MASK]](2) : (!firrtl.bundle<a: uint<1>, b: uint<1>, c: vector<uint<1>, 3>>) -> !firrtl.vector<uint<1>, 3>
   // CHECK: [[C_0:%.*]] = firrtl.subindex [[C]][0] : !firrtl.vector<uint<1>, 3>
-  // CHECK: firrtl.connect [[C_0]], %c1_ui1 
+  // CHECK: firrtl.strictconnect [[C_0]], %c1_ui1 
   // CHECK: [[C_1:%.*]] = firrtl.subindex [[C]][1] : !firrtl.vector<uint<1>, 3>
-  // CHECK: firrtl.connect [[C_1]], %c1_ui1 
+  // CHECK: firrtl.strictconnect [[C_1]], %c1_ui1 
   // CHECK: firrtl.partialconnect [[DATA]], %data
   firrtl.partialconnect %ramport_data, %data : !firrtl.bundle<a: uint<1>, b: uint<2>, c: vector<uint<3>, 3>>, !firrtl.bundle<c: vector<uint<3>, 2>, a: uint<1>>
 }
@@ -170,7 +170,7 @@ firrtl.module @WriteToSubfield(in %clock: !firrtl.clock, in %addr: !firrtl.uint<
   // CHECK: [[MASK:%.*]] = firrtl.subfield %ram_ramport(4)
   // CHECK: [[DATA_B:%.*]] = firrtl.subfield [[DATA]](1)
   // CHECK: [[MASK_B:%.*]] = firrtl.subfield [[MASK]](1)
-  // CHECK: firrtl.connect [[MASK_B]], %c1_ui1
+  // CHECK: firrtl.strictconnect [[MASK_B]], %c1_ui1
   // CHECK: firrtl.connect [[DATA_B]], %value
   firrtl.connect %ramport_b, %value : !firrtl.uint<1>, !firrtl.uint<1>
 }
@@ -188,8 +188,8 @@ firrtl.module @ReadAndWriteToSubfield(in %clock: !firrtl.clock, in %addr: !firrt
   // CHECK: [[WMASK:%.*]] = firrtl.subfield %ram_ramport(6)
   // CHECK: [[WDATA_A:%.*]] = firrtl.subfield [[WDATA]](0)
   // CHECK: [[WMASK_A:%.*]] = firrtl.subfield [[WMASK]](0)
-  // CHECK: firrtl.connect [[WMASK_A]], %c1_ui1
-  // CHECK: firrtl.connect [[WMODE]], %c1_ui1
+  // CHECK: firrtl.strictconnect [[WMASK_A]], %c1_ui1
+  // CHECK: firrtl.strictconnect [[WMODE]], %c1_ui1
   // CHECK: firrtl.connect [[WDATA_A]], %in
   %port_a = firrtl.subfield %ramport_data(0) : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<1>
   firrtl.connect %port_a, %in : !firrtl.uint<1>, !firrtl.uint<1>
@@ -213,8 +213,8 @@ firrtl.module @ReadAndWriteToSubindex(in %clock: !firrtl.clock, in %addr: !firrt
   // CHECK: [[WMASK:%.*]] = firrtl.subfield %ram_ramport(6)
   // CHECK: [[WDATA_0:%.*]] = firrtl.subindex [[WDATA]][0]
   // CHECK: [[WMASK_0:%.*]] = firrtl.subindex [[WMASK]][0]
-  // CHECK: firrtl.connect [[WMASK_0]], %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.connect [[WMODE]], %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK: firrtl.strictconnect [[WMASK_0]], %c1_ui1 : !firrtl.uint<1>
+  // CHECK: firrtl.strictconnect [[WMODE]], %c1_ui1 : !firrtl.uint<1>
   // CHECK: firrtl.connect [[WDATA_0]], %in : !firrtl.uint<1>, !firrtl.uint<1>
   %port_a = firrtl.subindex %ramport_data[0] : !firrtl.vector<uint<1>, 10>
   firrtl.connect %port_a, %in : !firrtl.uint<1>, !firrtl.uint<1>
@@ -271,7 +271,7 @@ firrtl.module @EnableInference0(in %p: !firrtl.uint<1>, in %addr: !firrtl.uint<4
 
   // CHECK: firrtl.when %p {
   firrtl.when %p  {
-    // CHECK-NEXT: firrtl.connect [[EN]], %c1_ui1
+    // CHECK-NEXT: firrtl.strictconnect [[EN]], %c1_ui1
     // CHECK-NEXT: firrtl.connect %w, %addr
     firrtl.connect %w, %addr : !firrtl.uint<4>, !firrtl.uint<4>
   }
@@ -287,10 +287,10 @@ firrtl.module @EnableInference1(in %p: !firrtl.uint<1>, in %addr: !firrtl.uint<4
   // CHECK: [[EN:%.*]] = firrtl.subfield %ram_ramport(1)
   // CHECK: firrtl.when %p
   firrtl.when %p  {
-   // CHECK-NEXT: firrtl.connect [[EN]], %c1_ui1
+   // CHECK-NEXT: firrtl.strictconnect [[EN]], %c1_ui1
    // CHECK-NEXT: %n = firrtl.node %addr
-   // CHECK-NEXT: firrtl.connect [[ADDR]], %n
-   // CHECK-NEXT: firrtl.connect %2, %clock
+   // CHECK-NEXT: firrtl.strictconnect [[ADDR]], %n
+   // CHECK-NEXT: firrtl.strictconnect %2, %clock
    // CHECK-NEXT: firrtl.connect %v, %3
     %n = firrtl.node %addr : !firrtl.uint<4>
     %ramport_data, %ramport_port = chirrtl.memoryport Read %ram {name = "ramport"} : (!chirrtl.cmemory<uint<32>, 16>) -> (!firrtl.uint<32>, !chirrtl.cmemoryport)

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -91,7 +91,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     _t <- _t_2
 
     ; CHECK: [[INV:%.+]]  = firrtl.invalidvalue : !firrtl.uint<1>
-    ; CHECK-NEXT: firrtl.connect %auto, [[INV]] : !firrtl.uint<1>, !firrtl.uint<1>
+    ; CHECK-NEXT: firrtl.strictconnect %auto, [[INV]] : !firrtl.uint<1>
     auto is invalid
 
     ; CHECK-NOT: firrtl.attach %a1
@@ -101,7 +101,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     skip  @[SKipLoc.scala 42:24]
 
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue : !firrtl.uint<1>
-    ; CHECK-NEXT: firrtl.connect %auto, [[INV]] : !firrtl.uint<1>, !firrtl.uint<1>
+    ; CHECK-NEXT: firrtl.strictconnect %auto, [[INV]] : !firrtl.uint<1>
     auto is invalid
 
     ; CHECK-NOT: firrtl.connect %reset
@@ -550,13 +550,11 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     ; Check that invalidation reuses subfields
     wire w: {a: UInt<1>}[1]
-    ; CHECK: %1 = firrtl.subindex %w[0]
-    ; CHECK: %2 = firrtl.subfield %1(0)
-    ; CHECK: %invalid_ui1 = firrtl.invalidvalue
-    ; CHECK: firrtl.connect %2, %invalid_ui1
+    ; CHECK: %invalid = firrtl.invalidvalue : !firrtl.vector<bundle<a: uint<1>>, 1>
+    ; CHECK: firrtl.strictconnect %w, %invalid
     w is invalid
-    ; CHECK: %invalid_ui1_0 = firrtl.invalidvalue
-    ; CHECK: firrtl.connect %2, %invalid_ui1_0
+    ; CHECK: %invalid_0 = firrtl.invalidvalue : !firrtl.vector<bundle<a: uint<1>>, 1>
+    ; CHECK: firrtl.strictconnect %w, %invalid_0
     w is invalid
 
   ; CHECK-LABEL: firrtl.module @flip_one
@@ -696,7 +694,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input in2 : { a : UInt<1>, flip b : UInt<1>}
     ; CHECK: [[IN2_B:%.+]] = firrtl.subfield %in2(1)
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
-    ; CHECK: firrtl.connect [[IN2_B]], [[INV]]
+    ; CHECK: firrtl.strictconnect [[IN2_B]], [[INV]]
     in2 is invalid
 
   module CheckInvalids_in3 :
@@ -704,30 +702,26 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: [[IN3_A:%.+]] = firrtl.subfield %in3(0)
     ; CHECK: [[IN3_A_C:%.+]] = firrtl.subfield [[IN3_A]](1)
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
-    ; CHECK: firrtl.connect [[IN3_A_C]], [[INV]]
+    ; CHECK: firrtl.strictconnect [[IN3_A_C]], [[INV]]
     in3 is invalid
 
   module CheckInvalids_out0 :
     output out0 : UInt<1>
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
-    ; CHECK: firrtl.connect %out0, [[INV]]
+    ; CHECK: firrtl.strictconnect %out0, [[INV]]
     out0 is invalid
 
   module CheckInvalids_out1 :
     output out1 : { a : UInt<1>, b : UInt<1> }
-    ; CHECK: [[OUT1_B:%.+]] = firrtl.subfield %out1(1)
-    ; CHECK: [[OUT1_A:%.+]] = firrtl.subfield %out1(0)
-    ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
-    ; CHECK: firrtl.connect [[OUT1_A]], [[INV]]
-    ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
-    ; CHECK: firrtl.connect [[OUT1_B]], [[INV]]
+    ; CHECK: [[INV:%.+]] = firrtl.invalidvalue : !firrtl.bundle<a: uint<1>, b: uint<1>> 
+    ; CHECK: firrtl.strictconnect %out1, [[INV]]
     out1 is invalid
 
   module CheckInvalids_out2 :
     output out2 : { a : UInt<1>, flip b : UInt<1>}
     ; CHECK: [[OUT2_A:%.+]] = firrtl.subfield %out2(0)
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
-    ; CHECK: firrtl.connect [[OUT2_A]], [[INV]]
+    ; CHECK: firrtl.strictconnect [[OUT2_A]], [[INV]]
     out2 is invalid
 
   module CheckInvalids_out3 :
@@ -735,13 +729,13 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: [[OUT3_A:%.+]] = firrtl.subfield %out3(0)
     ; CHECK: [[OUT3_A_B:%.+]] = firrtl.subfield [[OUT3_A]](0)
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
-    ; CHECK: firrtl.connect [[OUT3_A_B]], [[INV]]
+    ; CHECK: firrtl.strictconnect [[OUT3_A_B]], [[INV]]
     out3 is invalid
 
   module CheckInvalids_wires :
     ; CHECK: %wire0 = firrtl.wire
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
-    ; CHECK: firrtl.connect %wire0, [[INV]]
+    ; CHECK: firrtl.strictconnect %wire0, [[INV]]
     wire wire0 : UInt<1>
     wire0 is invalid
 
@@ -749,9 +743,9 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: [[WIRE1_B:%.+]] = firrtl.subfield %wire1(1)
     ; CHECK: [[WIRE1_A:%.+]] = firrtl.subfield %wire1(0)
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
-    ; CHECK: firrtl.connect [[WIRE1_A]], [[INV]]
+    ; CHECK: firrtl.strictconnect [[WIRE1_A]], [[INV]]
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
-    ; CHECK: firrtl.connect [[WIRE1_B]], [[INV]]
+    ; CHECK: firrtl.strictconnect [[WIRE1_B]], [[INV]]
     wire wire1 : {a : UInt<1>, flip b : UInt<1> }
     wire1 is invalid
 
@@ -761,7 +755,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: [[WIRE2_X_B:%.+]] = firrtl.subfield [[WIRE2_X]](1)
     ; CHECK: [[WIRE2_X_A:%.+]] = firrtl.subfield [[WIRE2_X]](0)
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
-    ; CHECK: firrtl.connect [[WIRE2_X_A]], [[INV]]
+    ; CHECK: firrtl.strictconnect [[WIRE2_X_A]], [[INV]]
     ; CHECK-NOT: firrtl.attach [[WIRE2_X_B]], [[INV]]
     wire wire2 : {x : {flip a : UInt<1>, flip b: Analog<1> } }
     wire2 is invalid
@@ -770,11 +764,10 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %U0_in0, %U0_in1, %U0_out0, %U0_out1 = firrtl.instance U0 @mod_0_563
     inst U0 of mod_0_563
 
-    ; CHECK: [[U0_IN1_A:%.+]] = firrtl.subfield %U0_in1(0)
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
-    ; CHECK: firrtl.connect %U0_in0, [[INV]]
-    ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
-    ; CHECK: firrtl.connect [[U0_IN1_A]], [[INV]]
+    ; CHECK: firrtl.strictconnect %U0_in0, [[INV]]
+    ; CHECK: [[INV:%.+]] = firrtl.invalidvalue : !firrtl.bundle<a: uint<5>> 
+    ; CHECK: firrtl.strictconnect %U0_in1, [[INV]]
     U0 is invalid
 
   ; This reference is declared after its first use.


### PR DESCRIPTION
Let the parser keep invalids of aggregate type.  Teach LowerTypes about StrictConnect and have it generate them when possible.