### PR TITLE
[LowerToHW] Don't extract TestHarness verif bboxes

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -888,7 +888,8 @@ FIRRTLModuleLowering::lowerExtModule(FExtModuleOp oldModule,
   bool hasOutputPort =
       llvm::any_of(firrtlPorts, [&](auto p) { return p.isOutput(); });
   if (!hasOutputPort &&
-      AnnotationSet::removeAnnotations(oldModule, verifBBClass))
+      AnnotationSet::removeAnnotations(oldModule, verifBBClass) &&
+      loweringState.isInDUT(oldModule))
     newModule->setAttr("firrtl.extract.cover.extra", builder.getUnitAttr());
 
   loweringState.processRemainingAnnotations(oldModule,

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -292,6 +292,19 @@ struct CircuitLoweringState {
   FModuleOp getDut() { return dut; }
   void setDut(FModuleOp mod) { dut = mod; }
 
+  // Return true if this module is instantiated by the DUT.  Returns false if
+  // the module is not instantiated by the DUT or if the DUT is not known.
+  bool isInDUT(FModuleLike mod) {
+    if (!dut)
+      return false;
+    return getInstanceGraph()->isAncestor(mod, dut);
+  }
+
+  // Return true if this module is instantiated by the Test Harness.  Returns
+  // false if the module is not instantiated by the Test Harness or if the Test
+  // Harness is not known.
+  bool isInTestHarness(FModuleLike mod) { return !isInDUT(mod); }
+
   InstanceGraph *getInstanceGraph() { return instanceGraph; }
 
 private:

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -520,7 +520,7 @@ void FIRRTLModuleLowering::runOnOperation() {
   if (tbdir) {
     if (auto dut = state.getDut()) {
       for (auto mod : state.oldToNewModuleMap) {
-        if (!state.getInstanceGraph()->isAncestor(mod.first, dut)) {
+        if (state.isInTestHarness(mod.first)) {
           auto outputFile = hw::OutputFileAttr::getAsDirectory(
               circuit.getContext(), tbdir.getValue(), false, true);
           mod.second->setAttr("output_file", outputFile);

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1121,7 +1121,10 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // present.
   // CHECK-NOT: firrtl.moduleHierarchyFile
   firrtl.module @FooDUT() attributes {annotations = [
-      {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {}
+      {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
+
+    %chckcoverAnno_clock = firrtl.instance chkcoverAnno @chkcoverAnno(in clock: !firrtl.clock)
+  }
 
   // CHECK-LABEL: hw.module @MemoryWritePortBehavior
   firrtl.module @MemoryWritePortBehavior(in %clock1: !firrtl.clock, in %clock2: !firrtl.clock) {
@@ -1230,8 +1233,15 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   }
 
   firrtl.extmodule @chkcoverAnno(in clock: !firrtl.clock) attributes {annotations = [{class = "freechips.rocketchip.annotations.InternalVerifBlackBoxAnnotation"}]}
+  // chckcoverAnno is extracted because it is instantiated inside the DUT.
   // CHECK-LABEL: hw.module.extern @chkcoverAnno(%clock: i1)
   // CHECK-SAME: attributes {firrtl.extract.cover.extra}
+
+  firrtl.extmodule @chkcoverAnno2(in clock: !firrtl.clock) attributes {annotations = [{class = "freechips.rocketchip.annotations.InternalVerifBlackBoxAnnotation"}]}
+  // checkcoverAnno2 is NOT extracted because it is not instantiated under the
+  // DUT.
+  // CHECK-LABEL: hw.module.extern @chkcoverAnno2(%clock: i1)
+  // CHECK-NOT: attributes {firrtl.extract.cover.extra}
 
   // CHECK-LABEL: hw.module.extern @InnerNamesExt
   // CHECK-SAME:  (


### PR DESCRIPTION
Change LowerToHW module extraction to not extract verification
blackboxes which are instantiated inside the test harness.

This also sneaks in some utilities for computing whether a module is in the DUT or the TestHarness and uses them to simplify existing logic.
    
Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>