### PR TITLE
[FIRRTL][Dedup] Get a module's name before deleting it

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -975,9 +975,9 @@ class DedupPass : public DedupBase<DedupPass> {
       auto it = moduleHashes.find(h);
       if (it != moduleHashes.end()) {
         auto original = cast<FModuleLike>(it->second);
-        deduper.dedup(original, module);
         // Record the group ID of the other module.
         groupMap[module.moduleNameAttr()] = groupMap[original.moduleNameAttr()];
+        deduper.dedup(original, module);
         erasedModules++;
         anythingChanged = true;
         continue;


### PR DESCRIPTION
The dedup pass uses the module's name to implement the MustDedup
functionality. Unfortunately, it was grabbing the module name right after
deleting the module.