### PR TITLE
[FIRRTL][WireDFT] Fix invalidated reference from growing DenseMap

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/WireDFT.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/WireDFT.cpp
@@ -327,9 +327,9 @@ void WireDFTPass::runOnOperation() {
     auto module = cast<FModuleOp>(node->getModule());
     unsigned portNo = module.getNumPorts();
     module.insertPorts({{portNo, portInfo}});
-
-    // Record the new signal and get a copy (reference will be invalidated).
     auto arg = module.getArgument(portNo);
+    
+    // Record the new signal.
     signal = arg;
 
     // Attach the input signal to each instance of this module.

--- a/lib/Dialect/FIRRTL/Transforms/WireDFT.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/WireDFT.cpp
@@ -328,7 +328,7 @@ void WireDFTPass::runOnOperation() {
     unsigned portNo = module.getNumPorts();
     module.insertPorts({{portNo, portInfo}});
     auto arg = module.getArgument(portNo);
-    
+
     // Record the new signal.
     signal = arg;
 

--- a/lib/Dialect/FIRRTL/Transforms/WireDFT.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/WireDFT.cpp
@@ -328,6 +328,10 @@ void WireDFTPass::runOnOperation() {
     unsigned portNo = module.getNumPorts();
     module.insertPorts({{portNo, portInfo}});
 
+    // Record the new signal and get a copy (reference will be invalidated).
+    auto arg = module.getArgument(portNo);
+    signal = arg;
+
     // Attach the input signal to each instance of this module.
     for (auto *instanceNode : node->uses()) {
       // Add an input signal to this instance op.
@@ -342,9 +346,7 @@ void WireDFTPass::runOnOperation() {
       builder.create<ConnectOp>(clone.getResult(portNo), signal);
     }
 
-    // Record and return the new signal.
-    signal = module.getArgument(portNo);
-    return signal;
+    return arg;
   };
 
   // Wire the signal to each clock gate using the helper above.
@@ -353,7 +355,7 @@ void WireDFTPass::runOnOperation() {
     auto module = cast<FModuleOp>(parent->getModule());
     auto builder =
         ImplicitLocOpBuilder::atBlockEnd(module->getLoc(), module.getBody());
-    // Hard coded port result number; the clock gate test_en port is 1
+    // Hard coded port result number; the clock gate test_en port is 1.
     auto testEnPortNo = 1;
     builder.create<ConnectOp>(instance->getInstance().getResult(testEnPortNo),
                               getSignal(parent));


### PR DESCRIPTION
`signal` is a mutable reference to an element in a `DenseMap`.  This
function can cause the DenseMap to grow in size and invalidate the
reference. We solve this problem by copying the pointer value into a
local.