### PR TITLE
[FIRRTL][LowerTypes] Fix std::lower_bound usage

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -202,6 +202,7 @@ struct InnerRefRecord {
   bool operator==(const InnerRefRecord &rhs) const {
     return (innerSym == rhs.innerSym && mod == rhs.mod);
   }
+  bool operator!=(const InnerRefRecord &rhs) const { return !(*this == rhs); }
 };
 
 // A data structure to record and lookup an InnerSym and the corresponding
@@ -212,7 +213,8 @@ struct InnerRefRecord {
 // insert-phase and lookup-phase based code.
 // TODO: Generalize this data structure.
 struct InnerRefList {
-  InnerRefList(MLIRContext* context) : InnerSymAttr(StringAttr::get(context, "inner_sym")) {}
+  InnerRefList(MLIRContext *context)
+      : InnerSymAttr(StringAttr::get(context, "inner_sym")) {}
 
   void sort() {
     llvm::sort(list);


### PR DESCRIPTION
`std::lower_bound` does not necessarily return `end()` when the searched for
element is not found: it can return an element `>` the searched for element.
For this reason it is necessary to check for equivalence after checking that an
element was found.

This was causing a crash in several SiFive cores although I have not been able
to reduce it to a simple test case yet.  The cause of the crash appears to be
that the `it->op` is an invalid op address. It is unclear to me how an invalid
op made it into the `opSymNames` list in the first place, but maybe someone
more familiar with the code can figure it out.
