### PR TITLE
[FIRRTL][NLATable] Fix invalidated reference after growing a DenseMap

### DIFF
--- a/lib/Dialect/FIRRTL/NLATable.cpp
+++ b/lib/Dialect/FIRRTL/NLATable.cpp
@@ -67,9 +67,9 @@ void NLATable::updateModuleInNLA(NonLocalAnchor nlaOp, StringAttr oldModule,
   auto *iter = std::find(nlas.begin(), nlas.end(), nlaOp);
   if (iter != nlas.end()) {
     nlas.erase(iter);
-    nodeMap[newModule].push_back(nlaOp);
     if (nlas.empty())
       nodeMap.erase(oldModule);
+    nodeMap[newModule].push_back(nlaOp);
   }
 }
 


### PR DESCRIPTION
In `updateModuleInNLA`, the NLATable was using a reference `nlas`
into a DenseMap after inserting a new element `newModule`. This change
just slightly reorders the code to remove this issue.