### PR TITLE
[Tests] Added Icarus Verilog test harness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,6 +311,24 @@ else()
 endif()
 
 #-------------------------------------------------------------------------------
+# Icarus Verilog Configuration
+#-------------------------------------------------------------------------------
+
+# If Icarus Verilog hasn't been explicitly disabled, find it.
+option(IVERILOG_DISABLE "Disable the Icarus Verilog tests.")
+if (IVERILOG_DISABLE)
+  message(STATUS "Disabling Icarus Verilog tests.")
+else()
+  find_program(IVERILOG_PATH "iverilog")
+  if(EXISTS ${IVERILOG_PATH})
+    message(STATUS "Found iverilog at ${IVERILOG_PATH}.")
+  else()
+    set(IVERILOG_PATH "")
+    message(STATUS "Did not find iverilog.")
+  endif()
+endif()
+
+#-------------------------------------------------------------------------------
 # capnp Configuration
 #-------------------------------------------------------------------------------
 

--- a/integration_test/Dialect/Handshake/dot.mlir
+++ b/integration_test/Dialect/Handshake/dot.mlir
@@ -1,4 +1,5 @@
 // REQUIRES: ieee-sim
+// UNSUPPORTED: iverilog
 // RUN: circt-opt %s --lower-std-to-handshake \ 
 // RUN:   --canonicalize='top-down=true region-simplify=true' \
 // RUN:   --handshake-materialize-forks-sinks --canonicalize \

--- a/integration_test/Dialect/Handshake/dot.mlir
+++ b/integration_test/Dialect/Handshake/dot.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: ieee-sim
-// UNSUPPORTED: iverilog
+// UNSUPPORTED: ieee-sim-iverilog
 // RUN: circt-opt %s --lower-std-to-handshake \ 
 // RUN:   --canonicalize='top-down=true region-simplify=true' \
 // RUN:   --handshake-materialize-forks-sinks --canonicalize \

--- a/integration_test/Dialect/Handshake/matmul.mlir
+++ b/integration_test/Dialect/Handshake/matmul.mlir
@@ -1,4 +1,5 @@
 // REQUIRES: ieee-sim
+// UNSUPPORTED: iverilog
 // RUN: circt-opt %s --lower-std-to-handshake \ 
 // RUN:   --canonicalize='top-down=true region-simplify=true' \
 // RUN:   --handshake-materialize-forks-sinks --canonicalize \

--- a/integration_test/Dialect/Handshake/matmul.mlir
+++ b/integration_test/Dialect/Handshake/matmul.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: ieee-sim
-// UNSUPPORTED: iverilog
+// UNSUPPORTED: ieee-sim-iverilog
 // RUN: circt-opt %s --lower-std-to-handshake \ 
 // RUN:   --canonicalize='top-down=true region-simplify=true' \
 // RUN:   --handshake-materialize-forks-sinks --canonicalize \

--- a/integration_test/ESI/primitives/primitive_tb.sv
+++ b/integration_test/ESI/primitives/primitive_tb.sv
@@ -1,4 +1,5 @@
 // REQUIRES: ieee-sim
+// UNSUPPORTED: iverilog
 // RUN: circt-rtl-sim.py --sim %ieee-sim %INC%/circt/Dialect/ESI/ESIPrimitives.sv %s
 
 //===- primitive_tb.sv - tests for ESI primitives -----------*- verilog -*-===//

--- a/integration_test/ESI/primitives/primitive_tb.sv
+++ b/integration_test/ESI/primitives/primitive_tb.sv
@@ -1,5 +1,5 @@
 // REQUIRES: ieee-sim
-// UNSUPPORTED: iverilog
+// UNSUPPORTED: ieee-sim-iverilog
 // RUN: circt-rtl-sim.py --sim %ieee-sim %INC%/circt/Dialect/ESI/ESIPrimitives.sv %s
 
 //===- primitive_tb.sv - tests for ESI primitives -----------*- verilog -*-===//

--- a/integration_test/circt-rtl-sim/circt-rtl-sim-iverilog.sv
+++ b/integration_test/circt-rtl-sim/circt-rtl-sim-iverilog.sv
@@ -1,0 +1,15 @@
+// REQUIRES: iverilog
+// RUN: circt-rtl-sim.py --sim %iverilog --cycles 2 %s | FileCheck %s
+
+module top(
+  input clk,
+  input rstn
+);
+
+  always@(posedge clk)
+    if (rstn)
+      $display("tock");
+  // CHECK:      tock
+  // CHECK-NEXT: tock
+
+endmodule

--- a/integration_test/lit.cfg.py
+++ b/integration_test/lit.cfg.py
@@ -88,6 +88,17 @@ if config.yosys_path != "":
   tools.append('yosys')
   config.available_features.add('yosys')
 
+# Enable Icarus Verilog as a fallback if no other ieee-sim was detected.
+if config.iverilog_path != "":
+  tool_dirs.append(os.path.dirname(config.iverilog_path))
+  tools.append('iverilog')
+  tools.append('vvp')
+  config.available_features.add('iverilog')
+  config.available_features.add('ieee-sim')
+  config.available_features.add('rtl-sim')
+  config.substitutions.append(('%iverilog', config.iverilog_path))
+  config.substitutions.append(('%ieee-sim', config.iverilog_path))
+
 # Enable Verilator if it has been detected.
 if config.verilator_path != "":
   tool_dirs.append(os.path.dirname(config.verilator_path))
@@ -133,23 +144,14 @@ if config.questa_path != "":
   config.substitutions.append(
       ('%ieee-sim', os.path.join(config.questa_path, "vsim")))
 
-# Enable Icarus Verilog as a fallback if no other ieee-sim was detected.
-if config.iverilog_path != "":
-  tool_dirs.append(os.path.dirname(config.iverilog_path))
-  tools.append('iverilog')
-  tools.append('vvp')
-  config.available_features.add('iverilog')
-  config.substitutions.append(('%iverilog', config.iverilog_path))
-  if 'ieee-sim' not in config.available_features:
-    config.available_features.add('ieee-sim')
-    config.available_features.add('rtl-sim')
-    config.substitutions.append(('%ieee-sim', config.iverilog_path))
-
 ieee_sims = list(filter(lambda x: x[0] == '%ieee-sim', config.substitutions))
 if len(ieee_sims) > 1:
   warnings.warn(
       f"You have multiple ieee-sim simulators configured, choosing: {ieee_sims[-1][1]}"
   )
+
+if ieee_sims and ieee_sims[-1][1] == config.iverilog_path:
+  config.available_features.add('ieee-sim-iverilog')
 
 # Enable ESI cosim tests if they have been built.
 if config.esi_cosim_path != "":

--- a/integration_test/lit.cfg.py
+++ b/integration_test/lit.cfg.py
@@ -134,15 +134,16 @@ if config.questa_path != "":
       ('%ieee-sim', os.path.join(config.questa_path, "vsim")))
 
 # Enable Icarus Verilog as a fallback if no other ieee-sim was detected.
-if config.iverilog_path != "" and 'ieee-sim' not in config.available_features:
+if config.iverilog_path != "":
   tool_dirs.append(os.path.dirname(config.iverilog_path))
   tools.append('iverilog')
   tools.append('vvp')
   config.available_features.add('iverilog')
-  config.available_features.add('ieee-sim')
-  config.available_features.add('rtl-sim')
   config.substitutions.append(('%iverilog', config.iverilog_path))
-  config.substitutions.append(('%ieee-sim', config.iverilog_path))
+  if 'ieee-sim' not in config.available_features:
+    config.available_features.add('ieee-sim')
+    config.available_features.add('rtl-sim')
+    config.substitutions.append(('%ieee-sim', config.iverilog_path))
 
 ieee_sims = list(filter(lambda x: x[0] == '%ieee-sim', config.substitutions))
 if len(ieee_sims) > 1:

--- a/integration_test/lit.cfg.py
+++ b/integration_test/lit.cfg.py
@@ -150,6 +150,9 @@ if len(ieee_sims) > 1:
       f"You have multiple ieee-sim simulators configured, choosing: {ieee_sims[-1][1]}"
   )
 
+# If the ieee-sim was selected to be iverilog in case no other simulators are
+# available, define a feature flag to allow tests which cannot be simulated
+# with iverilog to be disabled.
 if ieee_sims and ieee_sims[-1][1] == config.iverilog_path:
   config.available_features.add('ieee-sim-iverilog')
 

--- a/integration_test/lit.cfg.py
+++ b/integration_test/lit.cfg.py
@@ -133,6 +133,17 @@ if config.questa_path != "":
   config.substitutions.append(
       ('%ieee-sim', os.path.join(config.questa_path, "vsim")))
 
+# Enable Icarus Verilog as a fallback if no other ieee-sim was detected.
+if config.iverilog_path != "" and 'ieee-sim' not in config.available_features:
+  tool_dirs.append(os.path.dirname(config.iverilog_path))
+  tools.append('iverilog')
+  tools.append('vvp')
+  config.available_features.add('iverilog')
+  config.available_features.add('ieee-sim')
+  config.available_features.add('rtl-sim')
+  config.substitutions.append(('%iverilog', config.iverilog_path))
+  config.substitutions.append(('%ieee-sim', config.iverilog_path))
+
 ieee_sims = list(filter(lambda x: x[0] == '%ieee-sim', config.substitutions))
 if len(ieee_sims) > 1:
   warnings.warn(

--- a/integration_test/lit.site.cfg.py.in
+++ b/integration_test/lit.site.cfg.py.in
@@ -45,6 +45,7 @@ config.yosys_path = "@YOSYS_PATH@"
 config.quartus_path = "@QUARTUS_PATH@"
 config.vivado_path = "@VIVADO_PATH@"
 config.questa_path = "@QUESTA_PATH@"
+config.iverilog_path = "@IVERILOG_PATH@"
 config.esi_capnp = "@ESI_CAPNP@"
 config.bindings_python_enabled = @CIRCT_BINDINGS_PYTHON_ENABLED@
 config.bindings_tcl_enabled = @CIRCT_BINDINGS_TCL_ENABLED@

--- a/tools/circt-rtl-sim/circt-rtl-sim.py.in
+++ b/tools/circt-rtl-sim/circt-rtl-sim.py.in
@@ -21,13 +21,25 @@ ThisFileDir = os.path.dirname(__file__)
 DebugBuild = "@CMAKE_BUILD_TYPE@" == "Debug"
 
 
-class Questa:
-  """Run and compile funcs for Questasim."""
+class IEEEDriver:
+  """Common driver for event-based simulators."""
 
   DefaultDriver = "driver.sv"
 
   def __init__(self, path, args):
     self.args = args
+
+    if args.no_default_driver:
+      self.top = args.top
+    else:
+      self.top = "driver"
+
+
+class Questa(IEEEDriver):
+  """Run and compile funcs for Questasim."""
+
+  def __init__(self, path, args):
+    super().__init__(path, args)
 
     # Find Questa
     if os.path.exists(path):
@@ -54,18 +66,13 @@ class Questa:
     return subprocess.run(args)
 
   def run(self, cycles, simargs):
-    if self.args.no_default_driver:
-      top = self.args.top
-    else:
-      top = "driver"
-
     vsim = os.path.join(self.path, "vsim")
     # Note: vsim exit codes say nothing about the test run's pass/fail even
     # if $fatal is encountered in the simulation.
     if self.args.gui:
-      cmd = [vsim, top, "-gui", "-voptargs=\"+acc\""]
+      cmd = [vsim, self.top, "-gui", "-voptargs=\"+acc\""]
     else:
-      cmd = [vsim, top, "-batch", "-do", "run -all"]
+      cmd = [vsim, self.top, "-batch", "-do", "run -all"]
     if cycles >= 0:
       cmd.append(f"+cycles={cycles}")
     for lib in self.dpiLibs:
@@ -78,14 +85,12 @@ class Questa:
     return subprocess.run(cmd + simargs.split())
 
 
-class Vivado:
+class Vivado(IEEEDriver):
   """Run and compile funcs for Vivado."""
 
-  DefaultDriver = "driver.sv"
-
   def __init__(self, path, args):
+    super().__init__(path, args)
     self.path = path
-    self.args = args
 
   def compile(self, sources):
     sources = filter(lambda fn: not (fn.endswith(".so") or fn.endswith(".dll")),
@@ -98,22 +103,14 @@ class Vivado:
       return rc
 
     elab = os.path.join(self.path, "xelab")
-    if self.args.no_default_driver:
-      top = self.args.top
-    else:
-      top = "driver"
-    top = self.libname + "." + top
+    top = self.libname + "." + self.top
     args = [elab, top, "-lib", work, "-debug", "typical"]
     return subprocess.run(args)
 
   def run(self, cycles, simargs):
     xsim = os.path.join(self.path, "xsim")
 
-    if self.args.no_default_driver:
-      top = self.args.top
-    else:
-      top = "driver"
-    top = self.libname + "." + top
+    top = self.libname + "." + self.top
     args = [xsim, top]
 
     script = "script.tcl"
@@ -138,6 +135,36 @@ class Vivado:
     if not name:
       name = "work"
     return name
+
+
+class Iverilog(IEEEDriver):
+  """Run and compile funcs for Verilator."""
+
+  def __init__(self, path, args):
+    super().__init__(path, args)
+
+    # Find the compiler & simulator.
+    self.iverilog = args.sim
+    self.vvp = os.path.join(os.path.dirname(self.iverilog), "vvp")
+
+  def compile(self, sources):
+    return subprocess.run([
+        self.iverilog, "-s", self.top, "-g2005-sv", "-o", "obj.vvp"
+    ] + sources)
+
+  def run(self, cycles, args):
+    print(self.top)
+
+    cmd = [self.vvp, "obj.vvp"]
+
+    if cycles >= 0:
+      cmd.append(f"+cycles={cycles}")
+
+    cmd += args.split()
+    print(f"Running: {cmd}")
+    sys.stdout.flush()
+
+    return subprocess.run(cmd)
 
 
 class Verilator:
@@ -261,13 +288,15 @@ def __main__(args):
     sim = Questa(simParts[0], args)
   elif simName == "xsim":
     sim = Vivado(simParts[0], args)
+  elif simName == "iverilog":
+    sim = Iverilog(simParts[0], args)
   elif simName == "verilator":
     sim = Verilator(args)
   else:
     print(f"Could not determine simulator from '{args.sim}'", file=sys.stderr)
     return 1
 
-  if not args.no_default_driver:
+  if not args.no_default_driver and sim.DefaultDriver:
     args.sources.append(os.path.join(ThisFileDir, sim.DefaultDriver))
 
   if not args.no_compile:

--- a/tools/circt-rtl-sim/circt-rtl-sim.py.in
+++ b/tools/circt-rtl-sim/circt-rtl-sim.py.in
@@ -138,7 +138,7 @@ class Vivado(IEEEDriver):
 
 
 class Iverilog(IEEEDriver):
-  """Run and compile funcs for Verilator."""
+  """Run and compile funcs for Iverilog."""
 
   def __init__(self, path, args):
     super().__init__(path, args)

--- a/tools/circt-rtl-sim/circt-rtl-sim.py.in
+++ b/tools/circt-rtl-sim/circt-rtl-sim.py.in
@@ -296,7 +296,7 @@ def __main__(args):
     print(f"Could not determine simulator from '{args.sim}'", file=sys.stderr)
     return 1
 
-  if not args.no_default_driver and sim.DefaultDriver:
+  if not args.no_default_driver:
     args.sources.append(os.path.join(ThisFileDir, sim.DefaultDriver))
 
   if not args.no_compile:


### PR DESCRIPTION
If questa or vivado are not found, `iverilog` is used to run
supported tests. Tests which cannot be executed using this simulator
can be disabled by adding `// DISABLED: iverilog`.

Icarus verilog tests can be disabled altogether by passing
`-DIVERILOG_DISABLE=ON` to cmake, similarly to other simulators.

resolves llvm/circt#879