### PR TITLE
[FIRRTL] Add signalPassFailure to LowerToHW and exit early.

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -259,8 +259,6 @@ struct CircuitLoweringState {
       used_RANDOMIZE_MEM_INIT{false};
   std::atomic<bool> used_RANDOMIZE_GARBAGE_ASSIGN{false};
 
-  std::atomic<bool> moduleLoweringFailed{false};
-
   CircuitLoweringState(CircuitOp circuitOp, bool enableAnnotationWarning,
                        bool nonConstAsyncResetValueIsError,
                        InstanceGraph *instanceGraph)
@@ -426,10 +424,10 @@ private:
                                       Block *topLevelModule,
                                       CircuitLoweringState &loweringState);
 
-  void lowerModuleBody(FModuleOp oldModule,
-                       CircuitLoweringState &loweringState);
-  void lowerModuleOperations(hw::HWModuleOp module,
-                             CircuitLoweringState &loweringState);
+  LogicalResult lowerModuleBody(FModuleOp oldModule,
+                                CircuitLoweringState &loweringState);
+  LogicalResult lowerModuleOperations(hw::HWModuleOp module,
+                                      CircuitLoweringState &loweringState);
 
   void lowerMemoryDecls(ArrayRef<FirMemory> mems,
                         CircuitLoweringState &loweringState);
@@ -560,12 +558,13 @@ void FIRRTLModuleLowering::runOnOperation() {
 
   // Now that we've lowered all of the modules, move the bodies over and
   // update any instances that refer to the old modules.
-  mlir::parallelForEachN(
-      &getContext(), 0, modulesToProcess.size(),
-      [&](auto index) { lowerModuleBody(modulesToProcess[index], state); });
+  auto result = mlir::failableParallelForEachN(
+      &getContext(), 0, modulesToProcess.size(), [&](auto index) {
+        return lowerModuleBody(modulesToProcess[index], state);
+      });
 
   // If any module bodies failed to lower, return early.
-  if (state.moduleLoweringFailed)
+  if (failed(result))
     return signalPassFailure();
 
   // Move binds from inside modules to outside modules.
@@ -1152,13 +1151,14 @@ static SmallVector<SubfieldOp> getAllFieldAccesses(Value structValue,
 /// Now that we have the operations for the hw.module's corresponding to the
 /// firrtl.module's, we can go through and move the bodies over, updating the
 /// ports and instances.
-void FIRRTLModuleLowering::lowerModuleBody(
-    FModuleOp oldModule, CircuitLoweringState &loweringState) {
+LogicalResult
+FIRRTLModuleLowering::lowerModuleBody(FModuleOp oldModule,
+                                      CircuitLoweringState &loweringState) {
   auto newModule =
       dyn_cast_or_null<hw::HWModuleOp>(loweringState.getNewModule(oldModule));
   // Don't touch modules if we failed to lower ports.
   if (!newModule)
-    return;
+    return success();
 
   ImplicitLocOpBuilder bodyBuilder(oldModule.getLoc(), newModule.body());
 
@@ -1247,7 +1247,7 @@ void FIRRTLModuleLowering::lowerModuleBody(
   cursor.erase();
 
   // Lower all of the other operations.
-  lowerModuleOperations(newModule, loweringState);
+  return lowerModuleOperations(newModule, loweringState);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1281,7 +1281,7 @@ struct FIRRTLLowering : public FIRRTLVisitor<FIRRTLLowering, LogicalResult> {
         builder(module.getLoc(), module.getContext()),
         moduleNamespace(MixedModuleNamespace(module)) {}
 
-  void run();
+  LogicalResult run();
 
   void optimizeTemporaryWire(sv::WireOp wire);
 
@@ -1527,13 +1527,13 @@ private:
 };
 } // end anonymous namespace
 
-void FIRRTLModuleLowering::lowerModuleOperations(
+LogicalResult FIRRTLModuleLowering::lowerModuleOperations(
     hw::HWModuleOp module, CircuitLoweringState &loweringState) {
-  FIRRTLLowering(module, loweringState).run();
+  return FIRRTLLowering(module, loweringState).run();
 }
 
 // This is the main entrypoint for the lowering pass.
-void FIRRTLLowering::run() {
+LogicalResult FIRRTLLowering::run() {
   // FIRRTL FModule is a single block because FIRRTL ops are a DAG.  Walk
   // through each operation, lowering each in turn if we can, introducing
   // casts if we cannot.
@@ -1559,11 +1559,7 @@ void FIRRTLLowering::run() {
         opsToRemove.push_back(&op);
         break;
       case LoweringFailure:
-        // If lowering failed, don't remove *anything* we've lowered so far,
-        // there may be uses, and the pass will fail anyway. Mark the failure in
-        // state.
-        opsToRemove.clear();
-        circuitState.moduleLoweringFailed = true;
+        return failure();
       }
     }
   }
@@ -1582,6 +1578,8 @@ void FIRRTLLowering::run() {
   // inserted by MemOp insertions.
   for (auto wire : tmpWiresToOptimize)
     optimizeTemporaryWire(wire);
+
+  return success();
 }
 
 // Try to optimize out temporary wires introduced during lowering.

--- a/test/firtool/firtool-errors.mlir
+++ b/test/firtool/firtool-errors.mlir
@@ -1,0 +1,12 @@
+// RUN: firtool %s -format=mlir -verilog -verify-diagnostics | FileCheck --allow-empty %s
+
+firrtl.circuit "top" {
+  // expected-error @+2 {{'firrtl.module' op contains a 'chisel3.util.experimental.ForceNameAnnotation' that is not a non-local annotation}}
+  // expected-note @+1 {{the erroneous annotation is '{class = "chisel3.util.experimental.ForceNameAnnotation"}'}}
+  firrtl.module @top() attributes {annotations = [{class = "chisel3.util.experimental.ForceNameAnnotation"}]} {
+  }
+}
+
+// Ensure circuits that error out don't make it to ExportVerilog.
+
+// CHECK-NOT: module top


### PR DESCRIPTION
This adds early returns with signalPassFailure when failure bubbles up
in the LowerToHW pass. In order to catch such failures and exit before
the ExportVerilog passes, the firtool pass manager is split into two
pipelines. The first pipeline handles the main lowering passes, and
only if those succeed, the second pipeline handles ExportVerilog.