### PR TITLE
[FIRRTL][OMIR] Don't assume NLA's have an absolute path

### DIFF
--- a/lib/Dialect/FIRRTL/NLATable.cpp
+++ b/lib/Dialect/FIRRTL/NLATable.cpp
@@ -67,9 +67,9 @@ void NLATable::updateModuleInNLA(NonLocalAnchor nlaOp, StringAttr oldModule,
   auto *iter = std::find(nlas.begin(), nlas.end(), nlaOp);
   if (iter != nlas.end()) {
     nlas.erase(iter);
-    nodeMap[newModule].push_back(nlaOp);
     if (nlas.empty())
       nodeMap.erase(oldModule);
+    nodeMap[newModule].push_back(nlaOp);
   }
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -118,6 +118,7 @@ private:
   /// Analyses for the current operation; only valid within `runOnOperation`.
   SymbolTable *symtbl;
   CircuitNamespace *circuitNamespace;
+  InstanceGraph *instanceGraph;
   InstancePathCache *instancePaths;
   /// OMIR target trackers gathered in the current operation, by tracker ID.
   DenseMap<Attribute, Tracker> trackers;
@@ -178,6 +179,7 @@ void EmitOMIRPass::runOnOperation() {
   anyFailures = false;
   symtbl = nullptr;
   circuitNamespace = nullptr;
+  instanceGraph = nullptr;
   instancePaths = nullptr;
   trackers.clear();
   symbols.clear();
@@ -247,9 +249,11 @@ void EmitOMIRPass::runOnOperation() {
   // Establish some of the analyses we need throughout the pass.
   SymbolTable currentSymtbl(circuitOp);
   CircuitNamespace currentCircuitNamespace(circuitOp);
-  InstancePathCache currentInstancePaths(getAnalysis<InstanceGraph>());
+  InstanceGraph &currentInstanceGraph = getAnalysis<InstanceGraph>();
+  InstancePathCache currentInstancePaths(currentInstanceGraph);
   symtbl = &currentSymtbl;
   circuitNamespace = &currentCircuitNamespace;
+  instanceGraph = &currentInstanceGraph;
   instancePaths = &currentInstancePaths;
   dutModuleName = {};
 
@@ -286,7 +290,7 @@ void EmitOMIRPass::runOnOperation() {
             dyn_cast_or_null<NonLocalAnchor>(symtbl->lookup(nlaSym.getAttr()));
         removeTempNLAs.push_back(tracker.nla);
       }
-      if (sramIDs.erase(tracker.id) && !tracker.nla)
+      if (sramIDs.erase(tracker.id))
         makeTrackerAbsolute(tracker);
       trackers.insert({tracker.id, tracker});
       return true;
@@ -389,8 +393,16 @@ void EmitOMIRPass::makeTrackerAbsolute(Tracker &tracker) {
       builder.getNamedAttr("class", StringAttr::get(context, "circt.nonlocal")),
   });
 
+  // Get all the paths instantiating this module. If there is an NLA already
+  // attached to this tracker, we use it as a base to disambiguate the path to
+  // the memory.
+  Operation *mod;
+  if (tracker.nla)
+    mod = instanceGraph->lookup(tracker.nla.root())->getModule();
+  else
+    mod = tracker.op->getParentOfType<FModuleOp>();
+
   // Get all the paths instantiating this module.
-  auto mod = tracker.op->getParentOfType<FModuleOp>();
   auto paths = instancePaths->getAbsolutePaths(mod);
   if (paths.empty()) {
     tracker.op->emitError("OMIR node targets uninstantiated component `")
@@ -419,8 +431,25 @@ void EmitOMIRPass::makeTrackerAbsolute(Tracker &tracker) {
     namepath.push_back(hw::InnerRefAttr::getFromOperation(
         op, name, op->getParentOfType<FModuleOp>().getNameAttr()));
   };
+  // Add the path up to where the NLA starts.
   for (InstanceOp inst : paths[0])
     addToPath(inst, inst.nameAttr());
+  // Add the path from the NLA to the op.
+  if (tracker.nla) {
+    auto path = tracker.nla.namepath().getValue();
+    for (auto attr : path.drop_back()) {
+      auto ref = attr.cast<hw::InnerRefAttr>();
+      // Find the instance referenced by the NLA.
+      auto *node = instanceGraph->lookup(ref.getModule());
+      auto it = llvm::find_if(*node, [&](InstanceRecord *record) {
+        return record->getInstance().inner_symAttr() == ref.getName();
+      });
+      assert(it != node->end() &&
+             "Instance referenced by NLA does not exist in module");
+      addToPath((*it)->getInstance(), ref.getName());
+    }
+  }
+  // Add the op itself.
   addToPath(tracker.op, opName);
 
   // Add the NLA to the tracker and mark it to be deleted later.

--- a/lib/Dialect/FIRRTL/Transforms/WireDFT.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/WireDFT.cpp
@@ -327,6 +327,10 @@ void WireDFTPass::runOnOperation() {
     auto module = cast<FModuleOp>(node->getModule());
     unsigned portNo = module.getNumPorts();
     module.insertPorts({{portNo, portInfo}});
+    auto arg = module.getArgument(portNo);
+
+    // Record the new signal.
+    signal = arg;
 
     // Attach the input signal to each instance of this module.
     for (auto *instanceNode : node->uses()) {
@@ -342,9 +346,7 @@ void WireDFTPass::runOnOperation() {
       builder.create<ConnectOp>(clone.getResult(portNo), signal);
     }
 
-    // Record and return the new signal.
-    signal = module.getArgument(portNo);
-    return signal;
+    return arg;
   };
 
   // Wire the signal to each clock gate using the helper above.
@@ -353,7 +355,7 @@ void WireDFTPass::runOnOperation() {
     auto module = cast<FModuleOp>(parent->getModule());
     auto builder =
         ImplicitLocOpBuilder::atBlockEnd(module->getLoc(), module.getBody());
-    // Hard coded port result number; the clock gate test_en port is 1
+    // Hard coded port result number; the clock gate test_en port is 1.
     auto testEnPortNo = 1;
     builder.create<ConnectOp>(instance->getInstance().getResult(testEnPortNo),
                               getSignal(parent));


### PR DESCRIPTION
NLAs are used by EmitOMIR to print the instance path to memories and
modules. When an OMIR annotation does not have an NLA, a new absolute
NLA is created for it.  As a part of this, the pass assumes that NLAs
used by any OMIR node is rooted at the top module.  Dedup notably will
create NLAs for OMIR annotations which are not rooted at the root
module, and as a result the final OMIR JSON file will include only part
of the path to the memories or instances.

This changes the metadata emission to stop assuming that NLAs are rooted
at the top module, and instead use the existing NLA as a way to
disambiguate the path to the memory when creating a new absolute NLA.
The pass already will remove any "temporary" NLAs created for metadata
emission.