### PR TITLE
[HW][ExportModuleHierarchy] Allow multiple output files per module

### DIFF
--- a/docs/FIRRTLAnnotations.md
+++ b/docs/FIRRTLAnnotations.md
@@ -1289,7 +1289,8 @@ section describes well-defined attributes used by HW/SV passes.
 ### firrtl.moduleHierarchyFile
 
 Used by HWExportModuleHierarchy.  Signifies a root from which to dump the module
-hierarchy as a json file. This attribute has type OutputFileAttr.
+hierarchy as a json file. This attribute is a list of files to output to, and
+has type `ArraAttr<OutputFileAttr>`.
 
 The exported JSON file encodes a recursive tree of module instances as JSON
 objects, with each object containing the following members:
@@ -1303,32 +1304,32 @@ objects, with each object containing the following members:
 ### firrtl.extract.assert
 
 Used by SVExtractTestCode.  Specifies the output directory for extracted
-modules. This attribute has type OutputFileAttr.
+modules. This attribute has type `OutputFileAttr`.
 
 ### firrtl.extract.assume
 
 Used by SVExtractTestCode.  Specifies the output directory for extracted
-modules. This attribute has type OutputFileAttr.
+modules. This attribute has type `OutputFileAttr`.
 
 ### firrtl.extract.cover
 
 Used by SVExtractTestCode.  Specifies the output directory for extracted
-modules. This attribute has type OutputFileAttr.
+modules. This attribute has type `OutputFileAttr`.
 
 ### firrtl.extract.assert.bindfile
 
 Used by SVExtractTestCode.  Specifies the output file for extracted
-modules' bind file. This attribute has type OutputFileAttr.
+modules' bind file. This attribute has type `OutputFileAttr`.
 
 ### firrtl.extract.assume.bindfile
 
 Used by SVExtractTestCode.  Specifies the output file for extracted
-modules' bind file. This attribute has type OutputFileAttr.
+modules' bind file. This attribute has type `OutputFileAttr`.
 
 ### firrtl.extract.cover.bindfile
 
 Used by SVExtractTestCode.  Specifies the output file for extracted
-modules' bind file. This attribute has type OutputFileAttr.
+modules' bind file. This attribute has type `OutputFileAttr`.
 
 ### firrtl.extract.[cover|assume|assert].extra
 

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -524,24 +524,69 @@ void FIRRTLModuleLowering::runOnOperation() {
         });
   }
 
+  // Figure out which module it the DUT and TestHarness.  If there is no module
+  // marked as the DUT, the top module is the DUT. If the DUT and the test
+  // harness are the same, then there is no test harness.
+  Operation *testHarness = state.getInstanceGraph()->getTopLevelModule();
+  Operation *dut = state.getDut();
+  if (!dut) {
+    dut = testHarness;
+    testHarness = nullptr;
+  } else if (dut == testHarness) {
+    testHarness = nullptr;
+  }
+
   // Now update all the testbench modules' paths.  A module goes in the TB
   // directory if it isn't a child of the DUT and a DUT is marked.
-  if (tbdir) {
-    if (auto dut = state.getDut()) {
-      for (auto mod : state.oldToNewModuleMap) {
-        if (state.isInTestHarness(mod.first)) {
-          auto outputFile = hw::OutputFileAttr::getAsDirectory(
-              circuit.getContext(), tbdir.getValue(), false, true);
-          mod.second->setAttr("output_file", outputFile);
-        }
+  if (tbdir && testHarness) {
+    auto outputFile = hw::OutputFileAttr::getAsDirectory(
+        circuit.getContext(), tbdir.getValue(), false, true);
+    for (auto mod : state.oldToNewModuleMap) {
+      if (state.isInTestHarness(mod.first)) {
+        mod.second->setAttr("output_file", outputFile);
       }
     }
   }
 
-  // At this point, it is safe to the module hierarchy annotations, since they
-  // would have been used while lowering modules.
-  circuitAnno.removeAnnotationsWithClass(moduleHierAnnoClass,
-                                         testHarnessHierAnnoClass);
+  // Handle the creation of the module hierarchy metadata.
+
+  // Collect the two sets of hiearchy files from the circuit. Some of them will
+  // be rooted at the test harness, the others will be rooted at the DUT.
+  SmallVector<Attribute> dutHierarchyFiles;
+  SmallVector<Attribute> testHarnessHierarchyFiles;
+  circuitAnno.removeAnnotations([&](Annotation annotation) {
+    if (annotation.isClass(moduleHierAnnoClass)) {
+      auto file = hw::OutputFileAttr::getFromFilename(
+          &getContext(),
+          annotation.getMember<StringAttr>("filename").getValue(),
+          /*excludeFromFileList=*/true);
+      dutHierarchyFiles.push_back(file);
+      return true;
+    }
+    if (annotation.isClass(testHarnessHierAnnoClass)) {
+      auto file = hw::OutputFileAttr::getFromFilename(
+          &getContext(),
+          annotation.getMember<StringAttr>("filename").getValue(),
+          /*excludeFromFileList=*/true);
+      // If there is no testharness, we print the hiearchy for this file
+      // starting at the DUT.
+      if (testHarness)
+        testHarnessHierarchyFiles.push_back(file);
+      else
+        dutHierarchyFiles.push_back(file);
+      return true;
+    }
+    return false;
+  });
+  // Attach the lowered form of these annotations.
+  if (!dutHierarchyFiles.empty())
+    state.oldToNewModuleMap[dut]->setAttr(
+        moduleHierarchyFileAttrName,
+        ArrayAttr::get(&getContext(), dutHierarchyFiles));
+  if (!testHarnessHierarchyFiles.empty())
+    state.oldToNewModuleMap[testHarness]->setAttr(
+        moduleHierarchyFileAttrName,
+        ArrayAttr::get(&getContext(), testHarnessHierarchyFiles));
 
   SmallVector<FirMemory> memories;
   if (getContext().isMultithreadingEnabled()) {
@@ -933,24 +978,8 @@ FIRRTLModuleLowering::lowerModule(FModuleOp oldModule, Block *topLevelModule,
   // Transform module annotations
   AnnotationSet annos(oldModule);
 
-  // Grab output file from circuit-level annotation and lower to an attribute
-  // on the module.
-  auto setModuleHierarchyFileAttr = [&](const char hierAnnoClass[]) {
-    AnnotationSet circuitAnnos(loweringState.circuitOp);
-    if (auto hierAnno = circuitAnnos.getAnnotation(hierAnnoClass))
-      newModule->setAttr(
-          moduleHierarchyFileAttrName,
-          hw::OutputFileAttr::getFromFilename(
-              &getContext(),
-              hierAnno.getMember<StringAttr>("filename").getValue(),
-              /*excludeFromFileList=*/true));
-  };
-  if (annos.removeAnnotation(dutAnnoClass)) {
-    setModuleHierarchyFileAttr(moduleHierAnnoClass);
+  if (annos.removeAnnotation(dutAnnoClass))
     loweringState.setDut(oldModule);
-  }
-  if (loweringState.circuitOp.getMainModule() == oldModule)
-    setModuleHierarchyFileAttr(testHarnessHierAnnoClass);
 
   if (annos.removeAnnotation(verifBBClass))
     newModule->setAttr("firrtl.extract.cover.extra", builder.getUnitAttr());

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -524,7 +524,7 @@ void FIRRTLModuleLowering::runOnOperation() {
         });
   }
 
-  // Figure out which module it the DUT and TestHarness.  If there is no module
+  // Figure out which module is the DUT and TestHarness.  If there is no module
   // marked as the DUT, the top module is the DUT. If the DUT and the test
   // harness are the same, then there is no test harness.
   Operation *testHarness = state.getInstanceGraph()->getTopLevelModule();

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -550,7 +550,7 @@ void FIRRTLModuleLowering::runOnOperation() {
 
   // Handle the creation of the module hierarchy metadata.
 
-  // Collect the two sets of hiearchy files from the circuit. Some of them will
+  // Collect the two sets of hierarchy files from the circuit. Some of them will
   // be rooted at the test harness, the others will be rooted at the DUT.
   SmallVector<Attribute> dutHierarchyFiles;
   SmallVector<Attribute> testHarnessHierarchyFiles;

--- a/lib/Dialect/SV/Transforms/HWExportModuleHierarchy.cpp
+++ b/lib/Dialect/SV/Transforms/HWExportModuleHierarchy.cpp
@@ -86,7 +86,7 @@ void HWExportModuleHierarchyPass::runOnOperation() {
 
   llvm::errs() << "!starting\n";
   for (auto op : mlirModule.getOps<hw::HWModuleOp>()) {
-    auto attr =  op->getAttrOfType<ArrayAttr>("firrtl.moduleHierarchyFile");
+    auto attr = op->getAttrOfType<ArrayAttr>("firrtl.moduleHierarchyFile");
     if (!attr)
       continue;
     for (auto file : attr.getAsRange<hw::OutputFileAttr>()) {

--- a/lib/Dialect/SV/Transforms/HWExportModuleHierarchy.cpp
+++ b/lib/Dialect/SV/Transforms/HWExportModuleHierarchy.cpp
@@ -84,7 +84,6 @@ void HWExportModuleHierarchyPass::runOnOperation() {
   Optional<SymbolTable> symbolTable = None;
   bool directoryCreated = false;
 
-  llvm::errs() << "!starting\n";
   for (auto op : mlirModule.getOps<hw::HWModuleOp>()) {
     auto attr = op->getAttrOfType<ArrayAttr>("firrtl.moduleHierarchyFile");
     if (!attr)

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1118,13 +1118,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   }
 
   // CHECK-LABEL: hw.module @FooDUT
-  // firrtl.moduleHierarchyFile should only be present if both the
-  // MarkDUTAnnotation and the circuit-level ModuleHierarchyAnnotation are
-  // present.
-  // CHECK-NOT: firrtl.moduleHierarchyFile
   firrtl.module @FooDUT() attributes {annotations = [
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
-
     %chckcoverAnno_clock = firrtl.instance chkcoverAnno @chkcoverAnno(in clock: !firrtl.clock)
   }
 

--- a/test/Conversion/FIRRTLToHW/module-hierarchy-file.mlir
+++ b/test/Conversion/FIRRTLToHW/module-hierarchy-file.mlir
@@ -1,17 +1,56 @@
-// RUN: circt-opt -lower-firrtl-to-hw  %s | FileCheck %s
+// RUN: circt-opt -lower-firrtl-to-hw --split-input-file  %s | FileCheck %s
 
+// When there is no module marked as the DUT, the top level module should be
+// considered the DUT.
+firrtl.circuit "MyDUT" attributes {annotations = [
+  {class = "sifive.enterprise.firrtl.ModuleHierarchyAnnotation", filename = "./dir1/filename1.json" },
+  {class = "sifive.enterprise.firrtl.TestHarnessHierarchyAnnotation", filename = "./dir2/filename2.json" }]}
+{
+  // CHECK-LABEL: hw.module @MyDUT
+  // CHECK-SAME: attributes {firrtl.moduleHierarchyFile = [#hw.output_file<"./dir1/filename1.json", excludeFromFileList>, #hw.output_file<"./dir2/filename2.json", excludeFromFileList>]}
+  firrtl.module @MyDUT() {}
+}
+
+// -----
+
+// When the DUT is the top level module, there is no test harness either.
+firrtl.circuit "MyDUT" attributes {annotations = [
+  {class = "sifive.enterprise.firrtl.ModuleHierarchyAnnotation", filename = "./dir1/filename1.json" },
+  {class = "sifive.enterprise.firrtl.TestHarnessHierarchyAnnotation", filename = "./dir2/filename2.json" }]}
+{
+  // CHECK-LABEL: hw.module @MyDUT
+  // CHECK-SAME: attributes {firrtl.moduleHierarchyFile = [#hw.output_file<"./dir1/filename1.json", excludeFromFileList>, #hw.output_file<"./dir2/filename2.json", excludeFromFileList>]}
+  firrtl.module @MyDUT() attributes {annotations = [
+      {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {}
+}
+
+// -----
+
+// When the DUT is not the top-level module, the top-level module is the test
+// harness.
 firrtl.circuit "MyTestHarness" attributes {annotations = [
   {class = "sifive.enterprise.firrtl.ModuleHierarchyAnnotation", filename = "./dir1/filename1.json" },
   {class = "sifive.enterprise.firrtl.TestHarnessHierarchyAnnotation", filename = "./dir2/filename2.json" }]}
 {
   // CHECK-LABEL: hw.module @MyDUT
-  // CHECK: attributes {firrtl.moduleHierarchyFile = #hw.output_file<"./dir1/filename1.json", excludeFromFileList>}
+  // CHECK-SAME: attributes {firrtl.moduleHierarchyFile = [#hw.output_file<"./dir1/filename1.json", excludeFromFileList>]}
   firrtl.module @MyDUT() attributes {annotations = [
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {}
 
   // CHECK-LABEL: hw.module @MyTestHarness
-  // CHECK: attributes {firrtl.moduleHierarchyFile = #hw.output_file<"./dir2/filename2.json", excludeFromFileList>}
+  // CHECK-SAME: attributes {firrtl.moduleHierarchyFile = [#hw.output_file<"./dir2/filename2.json", excludeFromFileList>]}
   firrtl.module @MyTestHarness() {
     firrtl.instance myDUT @MyDUT()
   }
+}
+
+// -----
+
+// We should only export the module hierachy when the ModuleHiearchyAnnotation
+// is present.
+firrtl.circuit "MyDUT" {
+  // CHECK-LABEL: hw.module @MyDUT
+  // CHECK-NOT: firrtl.moduleHierarchyFile
+  firrtl.module @MyDUT() attributes {annotations = [
+      {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {}
 }

--- a/test/Dialect/SV/hw-export-module-hierarchy.mlir
+++ b/test/Dialect/SV/hw-export-module-hierarchy.mlir
@@ -13,7 +13,7 @@ hw.module @MainDesign(%in: i1) -> (out: i1) {
   hw.output %0 : i1
 }
 
-hw.module @TestHarness() attributes {firrtl.moduleHierarchyFile = #hw.output_file<"testharness_hier.json", excludeFromFileList>} {
+hw.module @TestHarness() attributes {firrtl.moduleHierarchyFile = [#hw.output_file<"testharness_hier.json", excludeFromFileList>]} {
   %0 = hw.constant 1 : i1
   hw.instance "main_design" @MainDesign(in: %0: i1) -> (out: i1)
 }


### PR DESCRIPTION
From the FIRRTL flow we need to be able to specify multiple output files
for the module hierarchy.  To do this, this change switches the
`firrtl.moduleHierarchyFile` to have an array of files instead of a
single file.

The FIRRTL flow needs to be able to output a module hierarchy file for
the testharness (top level module) and the DUT module. When these two
modules are the same, we would end up only outputing a single hierarchy
file.  Unfortunately, the SiFive build system is really hard coded to
expect both files (for now) so we had to add the ability to generate the
same file twice.