### PR TITLE
[LLHD] Add output operation

### DIFF
--- a/include/circt/Dialect/LLHD/IR/SignalOps.td
+++ b/include/circt/Dialect/LLHD/IR/SignalOps.td
@@ -83,6 +83,46 @@ def LLHD_PrbOp : LLHD_Op<"prb", [
   let assemblyFormat = "$signal attr-dict `:` qualified(type($signal))";
 }
 
+def LLHD_OutputOp : LLHD_Op<"output", [
+    TypesMatchWith<
+      "type of 'value' and underlying type of 'result' have to match.",
+      "value", "result", "SigType::get($_self)">
+  ]> {
+  let summary = "Introduce a new signal and drive a value onto it.";
+  let description = [{
+    The `llhd.output` operation introduces a new signal and continuously
+    drives a the given value onto it after a given time-delay. The same
+    value is used to initialize the signal in the same way as the 'init'
+    value in `llhd.sig`. An optional name can be given to the created signal.
+    This shows up, e.g., in the simulation trace.
+
+    Example:
+
+    ```mlir
+    %value = llhd.const 1 : i1
+    %time = llhd.const #llhd.time<1ns, 0d, 0e> : !llhd.time
+    %sig = llhd.output "sigName" %value after %time : i1
+
+    // is equivalent to
+
+    %value = llhd.const 1 : i1
+    %time = llhd.const #llhd.time<1ns, 0d, 0e> : !llhd.time
+    %sig = llhd.sig "sigName" %value : i1
+    llhd.drv %sig, %value after %time : !llhd.sig<i1>
+    ```
+  }];
+
+  let arguments = (ins OptionalAttr<StrAttr>: $name,
+                       LLHD_AnyUnderlyingType: $value,
+                       LLHD_TimeType: $time);
+
+  let results = (outs LLHD_AnySigType: $result);
+
+  let assemblyFormat = [{
+    ( $name^ )? $value `after` $time attr-dict `:` qualified(type($value))
+  }];
+}
+
 def LLHD_DrvOp : LLHD_Op<"drv", [
     TypesMatchWith<
       "type of 'value' and underlying type of 'signal' have to match.",

--- a/test/Dialect/LLHD/IR/inst-errors.mlir
+++ b/test/Dialect/LLHD/IR/inst-errors.mlir
@@ -38,7 +38,7 @@ llhd.entity @empty() -> () {}
 
 llhd.entity @test_uniqueness() -> () {
   llhd.inst "inst" @empty() -> () : () -> ()
-  // expected-error @+1 {{Redefinition of instance named 'inst'!}}
+  // expected-error @+1 {{redefinition of instance named 'inst'!}}
   llhd.inst "inst" @empty() -> () : () -> ()
 }
 

--- a/test/Dialect/LLHD/IR/signal-errors.mlir
+++ b/test/Dialect/LLHD/IR/signal-errors.mlir
@@ -24,9 +24,19 @@ llhd.entity @check_illegal_drv (%sig : !llhd.sig<i1>) -> () {
 
 // -----
 
-// expected-error @+4 {{Redefinition of signal named 'sigI1'!}}
+// expected-error @+4 {{redefinition of signal named 'sigI1'!}}
 llhd.entity @check_unique_sig_names () -> () {
   %cI1 = hw.constant 0 : i1
   %sig1 = llhd.sig "sigI1" %cI1 : i1
   %sig2 = llhd.sig "sigI1" %cI1 : i1
+}
+
+// -----
+
+// expected-error @+5 {{redefinition of signal named 'sigI1'!}}
+llhd.entity @check_unique_sig_names2 () -> () {
+  %cI1 = hw.constant 0 : i1
+  %time = llhd.constant_time <0ns, 1d, 0e>
+  %sig1 = llhd.sig "sigI1" %cI1 : i1
+  %sig2 = llhd.output "sigI1" %cI1 after %time : i1
 }

--- a/test/Dialect/LLHD/IR/signal.mlir
+++ b/test/Dialect/LLHD/IR/signal.mlir
@@ -36,6 +36,16 @@ func @checkPrb(%arg0 : !llhd.sig<i1>, %arg1 : !llhd.sig<i64>, %arg2 : !llhd.sig<
   return
 }
 
+// CHECK-LABEL: checkOutput
+func @checkOutput(%arg0: i32, %arg1: !llhd.time) {
+  // CHECK-NEXT: %{{.+}} = llhd.output %arg0 after %arg1 : i32
+  %0 = llhd.output %arg0 after %arg1 : i32
+  // CHECK-NEXT: %{{.+}} = llhd.output "sigName" %arg0 after %arg1 : i32
+  %1 = llhd.output "sigName" %arg0 after %arg1 : i32
+
+  return
+}
+
 // CHECK-LABEL: checkDrv
 func @checkDrv(%arg0 : !llhd.sig<i1>, %arg1 : !llhd.sig<i64>, %arg2 : i1,
     %arg3 : i64, %arg4 : !llhd.time, %arg5 : !llhd.sig<!hw.array<3xi8>>,


### PR DESCRIPTION
The output operation allows a more SSA friendly way to create signals with a single driver. This is especially useful when converting between HW and LLHD as it simplifies canonicalization patterns and analyses.

See issue #1009

For example, in the already existing HW to LLHD pass and a LLHD to HW promotion pass I'm currently experimenting with it allows to bridge between the dialects by using this `llhd.output` for the HW -> LLHD direction and `llhd.prb` for the LLHD -> HW direction. After the conversion is complete they can be folded as such:

```mlir
%sig = llhd.output %arg0 after <0ns, 0d, 0e>
%0 = llhd.prb %sig  // can then be folded to %arg0
```

```mlir
%0 = llhd.prb %arg0
%sig = llhd.output %0 after <0ns, 0d, 0e>
```
In the second pattern,  `%sig` cannot be set equivalent to `%arg0` by replacing the value because the prb-output chain implies a one-way connect and replacing the value would be a bidirectional connect, but it could be simplified to a `llhd.oneway_connect` operation as proposed in #1011.

This PR implies that we use zero-delay drives as connects such as `llhd.con`, but in only one direction. Alternatively, we could introduce another operation that does not have a time argument to represent a connection between LLHD signals and HW SSA values.

Related discussions: #1010, #988

Follow-up work:
- [ ] Use this op in HWToLLHD
- [ ] Implement canonicalization patterns
- [ ] Support it in behavioral to structural LLHD lowering
- [ ] Support it in llhd-sim