### PR TITLE
[HW] Add clog2 parameter expression

### DIFF
--- a/docs/RationaleHW.md
+++ b/docs/RationaleHW.md
@@ -346,6 +346,13 @@ This set includes:
    represented as multiply by `-1`.  This allows it to trivially compose
    with affine expression canonicalizations.
 
+### clog2 Parameter Expression
+A `clog2` parameter expression opcode is provided, which calculates the ceiling
+of log base 2 of its argument. This is useful for calculating things like the
+minimum bitwidth needed to address memory of a parameterized size.
+
+Note that `clog2(0)` is `0`, which follows the Verilog spec.
+
 ### Using parameters in the body of a module
 
 Parameters are not [SSA values](https://en.wikipedia.org/wiki/Static_single_assignment_form), so they cannot directly be used within the body

--- a/include/circt/Dialect/HW/HWAttributes.td
+++ b/include/circt/Dialect/HW/HWAttributes.td
@@ -210,10 +210,15 @@ def PEO_DivU : I32EnumAttrCase<"DivU", 8, "divu">;
 def PEO_DivS : I32EnumAttrCase<"DivS", 9, "divs">;
 def PEO_ModU : I32EnumAttrCase<"ModU",10, "modu">;
 def PEO_ModS : I32EnumAttrCase<"ModS",11, "mods">;
+
+// Unary Expression Opcodes.
+def PEO_CLog2 : I32EnumAttrCase<"CLog2", 12, "clog2">;
+
 def PEOAttr  : I32EnumAttr<"PEO", "Parameter Expression Opcode",
                            [PEO_Add, PEO_Mul, PEO_And, PEO_Or, PEO_Xor,
                             PEO_Shl, PEO_ShrU, PEO_ShrS,
-                            PEO_DivU, PEO_DivS, PEO_ModU, PEO_ModS]>;
+                            PEO_DivU, PEO_DivS, PEO_ModU, PEO_ModS,
+                            PEO_CLog2]>;
 }
 
 def ParamExprAttr : AttrDef<HWDialect, "ParamExpr"> {

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1271,6 +1271,7 @@ ModuleEmitter::printParamValue(Attribute value, raw_ostream &os,
   StringRef operatorStr;
   VerilogPrecedence subprecedence = ForceEmitMultiUse;
   Optional<SubExprSignResult> operandSign;
+  bool isUnary = false;
 
   switch (expr.getOpcode()) {
   case PEO::Add:
@@ -1328,6 +1329,11 @@ ModuleEmitter::printParamValue(Attribute value, raw_ostream &os,
     subprecedence = Multiply;
     operandSign = IsSigned;
     break;
+  case PEO::CLog2:
+    operatorStr = "$clog2";
+    operandSign = IsUnsigned;
+    isUnary = true;
+    break;
   }
 
   // Emit the specified operand with a $signed() or $unsigned() wrapper around
@@ -1346,6 +1352,9 @@ ModuleEmitter::printParamValue(Attribute value, raw_ostream &os,
     }
     return signedness == IsSigned;
   };
+
+  if (isUnary)
+    os << operatorStr;
 
   if (subprecedence > parenthesizeIfLooserThan)
     os << '(';

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -1018,8 +1018,10 @@ hw.module @VerilogCompatParameters<p1: i42, p2: i32, p3: f64 = 1.5,
 hw.module @parameterizedTypes<param: i32 = 1, wire: i32 = 2>
   // CHECK: input [16:0]{{ *}}a,
   (%a: !hw.int<17>,
-  // CHECK: input [param - 1:0] b);
-   %b: !hw.int<#hw.param.decl.ref<"param">>) {
+  // CHECK: input [param - 1:0]{{ *}}b,
+   %b: !hw.int<#hw.param.decl.ref<"param">>,
+  // CHECK: input [$clog2($unsigned(param)) - 1:0]{{ *}}c);
+   %c: !hw.int<#hw.param.expr.clog2<#hw.param.decl.ref<"param">>>) {
 
   // Check that the parameter name renamification propagates.
   // CHECK: wire [wire_0 - 1:0] paramWire;

--- a/test/Dialect/HW/parameters.mlir
+++ b/test/Dialect/HW/parameters.mlir
@@ -156,3 +156,21 @@ hw.module @parameterizedCombSeq<param: i32>
   // CHECK: %1 = seq.compreg %0, %clk : !hw.int<#hw.param.decl.ref<"param">>
   %1 = seq.compreg %0, %clk: !hw.int<#hw.param.decl.ref<"param">>
 }
+
+// CHECK-LABEL: hw.module @CLog2Expression<param: i32>() {
+hw.module @CLog2Expression<param: i32>() {
+  // CHECK-NEXT: %0 = hw.param.value i32 = 0
+  %0 = hw.param.value i32 = #hw.param.expr.clog2<0>
+
+  // CHECK-NEXT: %1 = hw.param.value i32 = 0
+  %1 = hw.param.value i32 = #hw.param.expr.clog2<1>
+
+  // CHECK-NEXT: %2 = hw.param.value i32 = 1
+  %2 = hw.param.value i32 = #hw.param.expr.clog2<2>
+
+  // CHECK-NEXT: %3 = hw.param.value i32 = 2
+  %3 = hw.param.value i32 = #hw.param.expr.clog2<3>
+
+  // CHECK-NEXT: %4 = hw.param.value i32 = #hw.param.expr.clog2<#hw.param.decl.ref<"param">>
+  %4 = hw.param.value i32 = #hw.param.expr.clog2<#hw.param.decl.ref<"param">>
+}


### PR DESCRIPTION
This is a unary expression that calculates the ceiling of log base 2 of its
argument. Following the Verilog spec, clog2(0) is 0.

This is useful for calculating things such as the minimum bitwidth needed
to address a memory of a given size.