### PR TITLE
[ExportVerilog] Respect disallowLocalVariables when spilling temps.

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -2553,7 +2553,7 @@ bool isInProceduralRegion(SmallVector<Operation *> &ops) {
       continue;
     seen.insert(op);
     for (auto *user : op->getUsers()) {
-      if (user->hasTrait<ProceduralRegion>())
+      if (user->getParentOp()->hasTrait<ProceduralRegion>())
         return true;
       worklist.push_back(user);
     }


### PR DESCRIPTION
When spilling a large expression into a temporary, we need to respect
disallowLocalVariables inside procedural regions. There are actually a
few intertwined things that need to happen.

First, the logic checking if the spilled temp is inside a procedural
region needs to be enhanced to capture situations like the included
test case. Even if the large expression is originally defined within a
procedural region, we may hoist it to the top-level of the module in
PrepareForEmission. The check for being inside a procedural region has
to be extended to consider the users of the expression, not just where
it is defined.

Second, we need to be able to put the temps in the right
place. Before, they would get rearranged to the front of the current
block of statements being processed. This is not sufficient when
disallowLocalVariables is set, because the current block may be nested
inside other procedural regions. To be safe, we rearrange spilled
expressions to the top-level of the module body in this case. To
enable this, a second cursor and indent level are stored, which always
point to the end of the declaration block in the top-level.

Finally, in the case disallowLocalVariables is set and we spill into
the top-level, the call to emitDeclarationForTemporary may actually
emit the entire expression. This previously wouldn't happen, and the
declaration and assignment would always be separate. Now, we need to
keep track of which declarations were emitted with a complete
assignment, and use that information to avoid emitting duplicates.

With these three changes, the example in the test case is properly
spilled to the top-level of the module body when
disallowLocalVariables is set. This closes https://github.com/llvm/circt/issues/2772.