### PR TITLE
use `hasVerifier` instead of `verifier`

### DIFF
--- a/include/circt/Dialect/Calyx/Calyx.td
+++ b/include/circt/Dialect/Calyx/Calyx.td
@@ -83,7 +83,7 @@ class CalyxGroupPort<string mnemonic, list<Trait> traits = []> :
     I1:$src,
     Optional<I1>:$guard
   );
-  let verifier = "return ::verify$cppClass(*this);";
+  let hasVerifier = 1;
 }
 
 include "circt/Dialect/Calyx/CalyxStructure.td"

--- a/include/circt/Dialect/Calyx/CalyxControl.td
+++ b/include/circt/Dialect/Calyx/CalyxControl.td
@@ -31,7 +31,7 @@ def ControlOp : CalyxContainer<"control", [
       }
     ```
   }];
-  let verifier = "return ::verify$cppClass(*this);";
+  let hasVerifier = 1;
   let skipDefaultBuilders = true;
   let builders = [
     OpBuilder<(ins), [{
@@ -74,7 +74,7 @@ def IfOp : CalyxContainer<"if", [
   }];
 
   let assemblyFormat = "$cond (`with` $groupName^)? $thenRegion (`else` $elseRegion^)? attr-dict";
-  let verifier = "return ::verify$cppClass(*this);";
+  let hasVerifier = 1;
   let hasCanonicalizer = true;
   let extraClassDeclaration = [{
     /// Checks whether the `then` body exists.
@@ -177,7 +177,7 @@ def ParOp : CalyxContainer<"par", [
     }]>
   ];
   let hasCanonicalizer = true;
-  let verifier = "return ::verify$cppClass(*this);";
+  let hasVerifier = 1;
 }
 
 def EnableOp : CalyxOp<"enable", [
@@ -209,7 +209,7 @@ def EnableOp : CalyxOp<"enable", [
     }]>
   ];
   let assemblyFormat = "$groupName attr-dict";
-  let verifier = "return ::verify$cppClass(*this);";
+  let hasVerifier = 1;
 }
 
 def WhileOp : CalyxContainer<"while", [
@@ -242,7 +242,7 @@ def WhileOp : CalyxContainer<"while", [
   }];
   let hasCanonicalizeMethod = true;
   let assemblyFormat = "$cond (`with` $groupName^)? $body attr-dict";
-  let verifier = "return ::verify$cppClass(*this);";
+  let hasVerifier = 1;
   let skipDefaultBuilders = true;
   let builders = [
     OpBuilder<(ins

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -89,7 +89,7 @@ def MemoryOp : CalyxPrimitive<"memory", []> {
     $instanceName ` ` `<` $sizes `x` $width `>` $addrSizes attr-dict `:` qualified(type($results))
   }];
 
-  let verifier = "return ::verify$cppClass(*this);";
+  let hasVerifier = 1;
 
   let builders = [
     OpBuilder<(ins
@@ -214,24 +214,10 @@ class UnaryLibraryOp<string mnemonic> : CalyxLibraryOp<mnemonic, [Combinational]
 }
 
 def PadLibOp : UnaryLibraryOp<"pad"> {
-  let verifier = [{
-    unsigned inBits = getResult(0).getType().getIntOrFloatBitWidth();
-    unsigned outBits = getResult(1).getType().getIntOrFloatBitWidth();
-    if (inBits >= outBits)
-      return emitOpError("expected input bits (") << inBits << ')' <<
-                         " to be less than output bits (" << outBits << ')';
-    return success();
-  }];
+  let hasVerifier = 1;
 }
 
 def SliceLibOp : UnaryLibraryOp<"slice"> {
-  let verifier = [{
-    unsigned inBits = getResult(0).getType().getIntOrFloatBitWidth();
-    unsigned outBits = getResult(1).getType().getIntOrFloatBitWidth();
-    if (inBits <= outBits)
-      return emitOpError("expected input bits (") << inBits << ')' <<
-                         " to be greater than output bits (" << outBits << ')';
-    return success();
-  }];
+  let hasVerifier = 1;
 }
 def NotLibOp  : UnaryLibraryOp<"not"> {}

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -53,7 +53,7 @@ def ProgramOp : CalyxContainer<"program", [
     }
   }];
   let assemblyFormat = "$entryPointName $body attr-dict";
-  let verifier = "return ::verify$cppClass(*this);";
+  let hasVerifier = 1;
 }
 
 def ComponentOp : CalyxOp<"component", [
@@ -72,7 +72,7 @@ def ComponentOp : CalyxOp<"component", [
     (1) In- and output port definitions that define the interface.
     (2) The cells, wires, and control schedule.
 
-    A Calyx component requires attributes `clk`, `go`, and `reset` on separate input ports, 
+    A Calyx component requires attributes `clk`, `go`, and `reset` on separate input ports,
     and `done` on an output port.
 
     ```mlir
@@ -101,7 +101,7 @@ def ComponentOp : CalyxOp<"component", [
       using mlir::detail::FunctionOpInterfaceTrait<ComponentOp>::getBody;
 
       /// Returns the type of this function.
-      FunctionType getType() { 
+      FunctionType getType() {
         return getTypeAttr().getValue().cast<FunctionType>();
       }
 
@@ -155,7 +155,7 @@ def ComponentOp : CalyxOp<"component", [
                                     mlir::OpAsmSetValueNameFn setNameFn);
   }];
 
-  let verifier = "return ::verify$cppClass(*this);";
+  let hasVerifier = 1;
   let hasCustomAssemblyFormat = 1;
 }
 
@@ -183,7 +183,7 @@ def WiresOp : CalyxContainer<"wires", [
       region->push_back(new Block());
     }]>
   ];
-  let verifier = "return ::verify$cppClass(*this);";
+  let hasVerifier = 1;
 }
 
 def InstanceOp : CalyxCell<"instance", [
@@ -302,7 +302,7 @@ def CombGroupOp : CalyxOp<"comb_group", [
 
   let regions = (region SizedRegion<1>:$body);
   let assemblyFormat = "$sym_name $body attr-dict";
-  let verifier = "return ::verify$cppClass(*this);";
+  let hasVerifier = 1;
   let skipDefaultBuilders = true;
   let builders = [
     OpBuilder<(ins "StringRef":$sym_name), [{
@@ -348,7 +348,7 @@ def AssignOp : CalyxOp<"assign", [
       $_state.addOperands({dest, src});
     }]>
   ];
-  let verifier = "return ::verify$cppClass(*this);";
+  let hasVerifier = 1;
   let hasCustomAssemblyFormat = 1;
 }
 

--- a/include/circt/Dialect/Comb/Combinational.td
+++ b/include/circt/Dialect/Comb/Combinational.td
@@ -181,7 +181,7 @@ def ExtractOp : CombOp<"extract", [NoSideEffect]> {
     "$input `from` $lowBit attr-dict `:` functional-type($input, $result)";
 
   let hasFolder = true;
-  let verifier = "return ::verifyExtractOp(*this);";
+  let hasVerifier = 1;
   let hasCanonicalizeMethod = true;
 
   let builders = [
@@ -204,7 +204,7 @@ def ConcatOp : VariadicOp<"concat", [InferTypeOpInterface]> {
 
   let hasFolder = true;
   let hasCanonicalizeMethod = true;
-  let verifier = "return ::verifyConcatOp(*this);";
+  let hasVerifier = 1;
 
   let assemblyFormat = "$inputs attr-dict `:` qualified(type($inputs))";
 
@@ -237,7 +237,7 @@ def ReplicateOp : CombOp<"replicate", [NoSideEffect]> {
 
   let hasFolder = true;
   let hasCanonicalizeMethod = true;
-  let verifier = "return ::verifyReplicateOp(*this);";
+  let hasVerifier = 1;
 
   let builders = [
     OpBuilder<(ins "Value":$operand, "int32_t":$multiple), [{

--- a/include/circt/Dialect/Comb/Combinational.td
+++ b/include/circt/Dialect/Comb/Combinational.td
@@ -46,7 +46,7 @@ class UTVariadicOp<string mnemonic, list<Trait> traits = []> :
 
   let hasCanonicalizeMethod = true;
   let hasFolder = true;
-  let verifier =  "return ::verifyUTVariadicOp(*this);";
+  let hasVerifier = 1;
 
   let assemblyFormat = "$inputs attr-dict `:` qualified(type($result))";
 

--- a/include/circt/Dialect/ESI/ESIPorts.td
+++ b/include/circt/Dialect/ESI/ESIPorts.td
@@ -98,9 +98,7 @@ def WrapSVInterface: ESI_Op<"wrap.iface", [NoSideEffect]> {
     $interfaceSink attr-dict `:` qualified(type($interfaceSink)) `->` qualified(type($output))
   }];
 
-  let verifier = [{
-    return ::verify$cppClass(*this);
-  }];
+  let hasVerifier = 1;
 }
 
 def UnwrapSVInterface : ESI_Op<"unwrap.iface", []> {
@@ -117,7 +115,5 @@ def UnwrapSVInterface : ESI_Op<"unwrap.iface", []> {
     $chanInput `into` $interfaceSource attr-dict `:` `(` qualified(type($chanInput)) `,` qualified(type($interfaceSource)) `)`
   }];
 
-  let verifier = [{
-    return ::verify$cppClass(*this);
-  }];
+  let hasVerifier = 1;
 }

--- a/include/circt/Dialect/FIRRTL/CHIRRTL.td
+++ b/include/circt/Dialect/FIRRTL/CHIRRTL.td
@@ -140,7 +140,7 @@ def MemoryPortOp : CHIRRTLOp<"memoryport", [InferTypeOpInterface,
   let summary = "Defines a memory port on CHIRRTL memory";
   let description = [{
     This operation defines a new memory port on a `seqmem` or `combmem`CHISEL.
-    `data` is the data returned from the memory port.  
+    `data` is the data returned from the memory port.
 
     The memory port requires an access point, which sets the enable condition
     of the port, the clock, and the address.  This is done by passing the the
@@ -164,7 +164,7 @@ def MemoryPortOp : CHIRRTLOp<"memoryport", [InferTypeOpInterface,
                    CArg<"ArrayRef<Attribute>","{}">:$annotations)>
   ];
 
-  let verifier = "return ::verifyMemoryPortOp(*this);";
+  let hasVerifier = 1;
 
   let extraClassDeclaration = [{
     /// Get the assocated access op.

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -35,7 +35,7 @@ def InstanceOp : FIRRTLOp<"instance", [
 
   let results = (outs Variadic<FIRRTLType>:$results);
 
-  let verifier = "return ::verifyInstanceOp(*this);";
+  let hasVerifier = 1;
   let hasCustomAssemblyFormat = 1;
 
   let builders = [
@@ -121,7 +121,7 @@ def MemOp : FIRRTLOp<"mem", [HasCustomSSAName]> {
                    CArg<"StringAttr", "StringAttr()">:$inner_sym)>
   ];
 
-  let verifier = "return ::verifyMemOp(*this);";
+  let hasVerifier = 1;
 
   let hasCanonicalizeMethod = true;
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -98,7 +98,7 @@ def ConstantOp : FIRRTLOp<"constant",
     OpBuilder<(ins "const APSInt &":$value)>
   ];
   let hasFolder = 1;
-  let verifier = "return ::verifyConstantOp(*this);";
+  let hasVerifier = 1;
 }
 
 def SpecialConstantOp : FIRRTLOp<"specialconstant",
@@ -177,7 +177,7 @@ def SubfieldOp : FIRRTLExprOp<"subfield"> {
     }
   }];
 
-  let verifier = "return ::verifySubfieldOp(*this);";
+  let hasVerifier = 1;
 }
 
 class IndexConstraint<string value, string resultValue>
@@ -626,7 +626,7 @@ def HWStructCastOp : FIRRTLOp<"hwStructCast", [NoSideEffect]> {
   let assemblyFormat =
     "$input attr-dict `:` functional-type($input, $result)";
 
-  let verifier = "return ::verifyHWStructCastOp(*this);";
+  let hasVerifier = 1;
 }
 
 def BitCastOp: FIRRTLOp<"bitcast", [NoSideEffect]> {
@@ -637,7 +637,7 @@ def BitCastOp: FIRRTLOp<"bitcast", [NoSideEffect]> {
 
   let arguments = (ins FIRRTLType:$input);
   let results = (outs FIRRTLType:$result);
-  let verifier = "return ::verifyBitCastOp(*this);";
+  let hasVerifier = 1;
   let hasFolder = 1;
 
   let assemblyFormat = "$input attr-dict `:` functional-type($input, $result)";

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -36,7 +36,7 @@ def ConnectOp : FIRRTLOp<"connect"> {
   let assemblyFormat =
     "$dest `,` $src  attr-dict `:` qualified(type($dest)) `,` qualified(type($src))";
 
-  let verifier = "return ::verifyConnectOp(*this);";
+  let hasVerifier = 1;
   let hasCanonicalizeMethod = true;
 }
 
@@ -53,7 +53,7 @@ def PartialConnectOp : FIRRTLOp<"partialconnect"> {
   let results = (outs);
   let hasCanonicalizeMethod = true;
 
-  let verifier = "return ::verifyPartialConnectOp(*this);";
+  let hasVerifier = 1;
 
   let assemblyFormat =
     "$dest `,` $src  attr-dict `:` qualified(type($dest)) `,` qualified(type($src))";
@@ -72,7 +72,7 @@ def StrictConnectOp : FIRRTLOp<"strictconnect", [SameTypeOperands]> {
   let results = (outs);
   let hasCanonicalizeMethod = true;
 
-  let verifier = "return ::verifyStrictConnectOp(*this);";
+  let hasVerifier = 1;
 
   let assemblyFormat =
     "$dest `,` $src  attr-dict `:` qualified(type($dest))";

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -49,7 +49,7 @@ def CircuitOp : FIRRTLOp<"circuit",
   }];
 
   let assemblyFormat = "$name custom<CircuitOpAttrs>(attr-dict) $body";
-  let verifier = "return ::verifyCircuitOp(*this);";
+  let hasVerifier = 1;
 }
 
 def FModuleOp : FIRRTLOp<"module", [IsolatedFromAbove, Symbol, SingleBlock,
@@ -139,7 +139,7 @@ def FExtModuleOp : FIRRTLOp<"extmodule",
   }];
 
   let hasCustomAssemblyFormat = 1;
-  let verifier = "return ::verifyFExtModuleOp(*this);";
+  let hasVerifier = 1;
 }
 
 def NonLocalAnchor : FIRRTLOp<"nla",

--- a/include/circt/Dialect/FSM/FSMOps.td
+++ b/include/circt/Dialect/FSM/FSMOps.td
@@ -41,7 +41,7 @@ def MachineOp : FSMOp<"machine", [HasParent<"mlir::ModuleOp">, FunctionOpInterfa
     void getHWPortInfo(SmallVectorImpl<hw::PortInfo> &);
 
     /// Returns the type of this function.
-    FunctionType getType() { 
+    FunctionType getType() {
       return getTypeAttr().getValue().cast<FunctionType>();
     }
 
@@ -63,7 +63,7 @@ def MachineOp : FSMOp<"machine", [HasParent<"mlir::ModuleOp">, FunctionOpInterfa
   }];
 
   let hasCustomAssemblyFormat = 1;
-  let verifier = [{ return ::verify$cppClass(*this); }];
+  let hasVerifier = 1;
 }
 
 def InstanceOp : FSMOp<"instance", [Symbol, HasCustomSSAName]> {
@@ -83,7 +83,7 @@ def InstanceOp : FSMOp<"instance", [Symbol, HasCustomSSAName]> {
     MachineOp getMachine();
   }];
 
-  let verifier = [{ return ::verify$cppClass(*this); }];
+  let hasVerifier = 1;
 }
 
 def TriggerOp : FSMOp<"trigger", []> {
@@ -106,7 +106,7 @@ def TriggerOp : FSMOp<"trigger", []> {
     MachineOp getMachine();
   }];
 
-  let verifier = [{ return ::verify$cppClass(*this); }];
+  let hasVerifier = 1;
 }
 
 def HWInstanceOp : FSMOp<"hw_instance", [Symbol, AttrSizedOperandSegments]> {
@@ -134,7 +134,7 @@ def HWInstanceOp : FSMOp<"hw_instance", [Symbol, AttrSizedOperandSegments]> {
     MachineOp getMachine();
   }];
 
-  let verifier = [{ return ::verify$cppClass(*this); }];
+  let hasVerifier = 1;
 }
 
 def StateOp : FSMOp<"state", [HasParent<"MachineOp">, Symbol,
@@ -171,7 +171,7 @@ def OutputOp : FSMOp<"output", [HasParent<"StateOp">, ReturnLike, Terminator]> {
 
   let assemblyFormat = [{ attr-dict ($operands^ `:` qualified(type($operands)))? }];
 
-  let verifier = [{ return ::verify$cppClass(*this); }];
+  let hasVerifier = 1;
 }
 
 def TransitionOp : FSMOp<"transition", [HasParent<"StateOp">,
@@ -211,7 +211,7 @@ def TransitionOp : FSMOp<"transition", [HasParent<"StateOp">,
     bool isAlwaysTaken();
   }];
 
-  let verifier = [{ return ::verify$cppClass(*this); }];
+  let hasVerifier = 1;
 }
 
 def ReturnOp : FSMOp<"return", [HasParent<"TransitionOp">, ReturnLike,
@@ -260,7 +260,7 @@ def UpdateOp : FSMOp<"update", [HasParent<"TransitionOp">, SameTypeOperands]> {
     VariableOp getVariable();
   }];
 
-  let verifier = [{ return ::verify$cppClass(*this); }];
+  let hasVerifier = 1;
 }
 
 #endif // CIRCT_DIALECT_FSM_FSMOPS_TD

--- a/include/circt/Dialect/HW/HWAggregates.td
+++ b/include/circt/Dialect/HW/HWAggregates.td
@@ -32,12 +32,7 @@ def ArrayCreateOp : HWOp<"array_create", [NoSideEffect, SameTypeOperands]> {
   let arguments = (ins Variadic<HWNonInOutType>:$inputs);
   let results = (outs ArrayType:$result);
 
-  let verifier = [{
-    unsigned returnSize = getType().cast<ArrayType>().getSize();
-    if (inputs().size() != returnSize)
-      return failure();
-    return success();
-  }];
+  let hasVerifier = 1;
 
   let hasCustomAssemblyFormat = 1;
   let builders = [
@@ -102,14 +97,7 @@ def ArraySliceOp : HWOp<"array_slice", [NoSideEffect]> {
 
   let arguments = (ins ArrayType:$input, HWIntegerType:$lowIndex);
   let results = (outs ArrayType:$dst);
-  let verifier = [{
-    unsigned inputSize = type_cast<ArrayType>(input().getType()).getSize();
-    if (llvm::Log2_64_Ceil(inputSize) !=
-          lowIndex().getType().getIntOrFloatBitWidth())
-      return emitOpError(
-        "ArraySlice: index width must match clog2 of array size");
-    return success();
-  }];
+  let hasVerifier = 1;
 
   let assemblyFormat = [{
     $input`[`$lowIndex`]` attr-dict `:`

--- a/include/circt/Dialect/HW/HWMiscOps.td
+++ b/include/circt/Dialect/HW/HWMiscOps.td
@@ -46,7 +46,7 @@ def ConstantOp
     }
   }];
   let hasFolder = true;
-  let verifier = "return ::verifyConstantOp(*this);";
+  let hasVerifier = 1;
 }
 
 def KnownBitWidthType : Type<CPred<[{getBitWidth($_self) != -1}]>,
@@ -63,12 +63,7 @@ def BitcastOp: HWOp<"bitcast", [NoSideEffect]> {
   let results = (outs KnownBitWidthType:$result);
   let hasCanonicalizeMethod = true;
   let hasFolder = true;
-  let verifier = [{
-    if (getBitWidth(input().getType()) !=
-        getBitWidth(result().getType()))
-      return this->emitOpError("Bitwidth of input must match result");
-    return success();
-  }];
+  let hasVerifier = 1;
 
   let assemblyFormat = "$input attr-dict `:` functional-type($input, $result)";
 }
@@ -84,6 +79,6 @@ def ParamValueOp : HWOp<"param.value",
   let arguments = (ins AnyAttr:$value);
   let results = (outs HWValueType:$result);
   let assemblyFormat = "custom<ParamValue>($value, qualified(type($result))) attr-dict";
-  let verifier = "return ::verifyParamValueOp(*this);";
+  let hasVerifier = 1;
   let hasFolder = true;
 }

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -129,7 +129,7 @@ def HWModuleOp : HWModuleOpBase<"module",
                                   mlir::OpAsmSetValueNameFn setNameFn);
 
     /// Returns the type of this function.
-    FunctionType getType() { 
+    FunctionType getType() {
       return getTypeAttr().getValue().cast<FunctionType>();
     }
 
@@ -151,7 +151,7 @@ def HWModuleOp : HWModuleOpBase<"module",
   }];
 
   let hasCustomAssemblyFormat = 1;
-  let verifier = "return ::verify$cppClass(*this);";
+  let hasVerifier = 1;
 }
 
 def HWModuleExternOp : HWModuleOpBase<"module.extern",
@@ -233,7 +233,7 @@ def HWModuleExternOp : HWModuleOpBase<"module.extern",
                                   mlir::OpAsmSetValueNameFn setNameFn);
 
     /// Returns the type of this function.
-    FunctionType getType() { 
+    FunctionType getType() {
       return getTypeAttr().getValue().cast<FunctionType>();
     }
 
@@ -255,7 +255,7 @@ def HWModuleExternOp : HWModuleOpBase<"module.extern",
   }];
 
   let hasCustomAssemblyFormat = 1;
-  let verifier = "return ::verify$cppClass(*this);";
+  let hasVerifier = 1;
 }
 
 def HWGeneratorSchemaOp : HWOp<"generator.schema",
@@ -345,7 +345,7 @@ def HWModuleGeneratedOp : HWModuleOpBase<"module.generated",
                                   mlir::OpAsmSetValueNameFn setNameFn);
 
     /// Returns the type of this function.
-    FunctionType getType() { 
+    FunctionType getType() {
       return getTypeAttr().getValue().cast<FunctionType>();
     }
 
@@ -367,7 +367,7 @@ def HWModuleGeneratedOp : HWModuleOpBase<"module.generated",
   }];
 
   let hasCustomAssemblyFormat = 1;
-  let verifier = "return ::verify$cppClass(*this);";
+  let hasVerifier = 1;
 }
 
 def InstanceOp : HWOp<"instance", [
@@ -378,7 +378,7 @@ def InstanceOp : HWOp<"instance", [
     This represents an instance of a module. The inputs and results are
     the referenced module's inputs and outputs.  The `argNames` and
     `resultNames` attributes must match the referenced module.
-    
+
     Any parameters in the "old" format (slated to be removed) are stored in the
     `oldParameters` dictionary.
   }];
@@ -457,7 +457,7 @@ def InstanceOp : HWOp<"instance", [
   }];
 
   let hasCustomAssemblyFormat = 1;
-  let verifier = "return this->verifyCustom();";
+  let hasVerifier = 1;
 }
 
 def OutputOp : HWOp<"output", [Terminator, HasParent<"HWModuleOp">,
@@ -476,7 +476,7 @@ def OutputOp : HWOp<"output", [Terminator, HasParent<"HWModuleOp">,
 
   let assemblyFormat = "attr-dict ($operands^ `:` qualified(type($operands)))?";
 
-  let verifier = "return ::verifyOutputOp(this);";
+  let hasVerifier = 1;
 }
 
 def GlobalRefOp : HWOp<"globalRef", [IsolatedFromAbove, Symbol]> {
@@ -497,7 +497,7 @@ def GlobalRefOp : HWOp<"globalRef", [IsolatedFromAbove, Symbol]> {
 
   let assemblyFormat = [{ $sym_name $namepath attr-dict}];
 
-  let verifier = "return this->verifyGlobalRef();";
+  let hasVerifier = 1;
 }
 
 def ProbeOp : HWOp<"probe", []> {

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -107,7 +107,7 @@ def FuncOp : Op<Handshake_Dialect, "func", [
     }
   }];
 
-  let verifier = [{ return ::verify$cppClass(*this); }];
+  let hasVerifier = 1;
   let hasCustomAssemblyFormat = 1;
 }
 
@@ -179,7 +179,7 @@ def InstanceOp : Handshake_Op<"instance", [CallOpInterface]> {
     $module `(` $operands `)` attr-dict `:` functional-type($operands, results)
   }];
 
-  let verifier = [{ return ::verify$cppClass(*this); }];
+  let hasVerifier = 1;
 }
 
 // This is almost exactly like a standard FuncOp, except that it has some
@@ -200,7 +200,7 @@ def ReturnOp : Handshake_Op<"return", [Terminator]> {
   let skipDefaultBuilders = 1;
   let builders = [OpBuilder<(ins "ArrayRef<Value>":$operands)>];
 
-  let verifier = "return ::verify(*this);";
+  let hasVerifier = 1;
   let assemblyFormat = [{ operands attr-dict `:` qualified(type(operands)) }];
 }
 
@@ -259,7 +259,7 @@ def BufferOp : Handshake_Op<"buffer", [NoSideEffect, HasClock,
 
   }];
   let hasCustomAssemblyFormat = 1;
-  let verifier = "return ::verify$cppClass(*this);";
+  let hasVerifier = 1;
   let hasCanonicalizer = 1;
 }
 
@@ -381,7 +381,7 @@ def MuxOp : Handshake_Op<"mux", [
     // Use this builder for any other use case.
     OpBuilder<(ins "Value":$selectOperand, "ValueRange":$inputs)>];
   let hasCustomAssemblyFormat = 1;
-  let verifier = "return ::verify(*this);";
+  let hasVerifier = 1;
   let hasCanonicalizer = 1;
 }
 
@@ -598,7 +598,7 @@ def ConstantOp : Handshake_Op<"constant", [
     Attribute getValue() { return (*this)->getAttr("value"); }
   }];
   let assemblyFormat = [{ $ctrl attr-dict `:` qualified(type($result))}];
-  let verifier = "return ::verify$cppClass(*this);";
+  let hasVerifier = 1;
 }
 
 def EndOp
@@ -679,7 +679,7 @@ def MemoryOp : Handshake_Op<"memory", [
       "int":$id, "Value":$memref)>
   ];
   let assemblyFormat = "`[` `ld` `=` $ldCount `,` `st` `=`  $stCount `]` `(` $inputs `)` attr-dict `:` $memRefType `,` functional-type($inputs, $outputs)";
-  let verifier = "return ::verify$cppClass(*this);";
+  let hasVerifier = 1;
 }
 
 def ExternalMemoryOp : Handshake_Op<"extmemory", [
@@ -749,7 +749,7 @@ def LoadOp : Handshake_Op<"load", [
   let skipDefaultBuilders = 1;
   let builders = [OpBuilder<(ins "Value":$memref, "ArrayRef<Value>":$indices)>];
   let hasCustomAssemblyFormat = 1;
-  let verifier = "return ::verify$cppClass(*this);";
+  let hasVerifier = 1;
 }
 
 def StoreOp : Handshake_Op<"store", [
@@ -782,7 +782,7 @@ def StoreOp : Handshake_Op<"store", [
   let builders =
       [OpBuilder<(ins "Value":$valueToStore, "ArrayRef<Value>":$indices)>];
   let hasCustomAssemblyFormat = 1;
-  let verifier = "return ::verify$cppClass(*this);";
+  let hasVerifier = 1;
 }
 
 def JoinOp : Handshake_Op<"join", [

--- a/include/circt/Dialect/LLHD/IR/SignalOps.td
+++ b/include/circt/Dialect/LLHD/IR/SignalOps.td
@@ -299,5 +299,5 @@ def LLHD_RegOp : LLHD_Op<"reg", [
     }
   }];
 
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 }

--- a/include/circt/Dialect/LLHD/IR/StructureOps.td
+++ b/include/circt/Dialect/LLHD/IR/StructureOps.td
@@ -52,11 +52,11 @@ def LLHD_EntityOp : LLHD_Op<"entity", [
   let arguments = (ins I64Attr: $ins);
   let regions = (region SizedRegion<1>: $body);
 
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 
   let extraClassDeclaration = [{
     /// Returns the type of this function.
-    FunctionType getType() { 
+    FunctionType getType() {
       return getTypeAttr().getValue().cast<FunctionType>();
     }
 
@@ -129,7 +129,7 @@ def LLHD_ProcOp : LLHD_Op<"proc", [
 
   let extraClassDeclaration = [{
     /// Returns the type of this function.
-    FunctionType getType() { 
+    FunctionType getType() {
       return getTypeAttr().getValue().cast<FunctionType>();
     }
 
@@ -147,7 +147,7 @@ def LLHD_ProcOp : LLHD_Op<"proc", [
     LogicalResult verifyBody();
   }];
 
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//
@@ -211,7 +211,7 @@ def LLHD_InstOp : LLHD_Op<"inst", [
     }
   }];
 
-  let verifier = [{ return ::verify(*this); }];
+  let hasVerifier = 1;
 }
 
 def LLHD_ConnectOp : LLHD_Op<"con", [

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -127,7 +127,7 @@ def MSFTModuleOp : MSFTOp<"module",
                                   mlir::OpAsmSetValueNameFn setNameFn);
 
     /// Returns the type of this function.
-    FunctionType getType() { 
+    FunctionType getType() {
       return getTypeAttr().getValue().cast<FunctionType>();
     }
 
@@ -173,7 +173,7 @@ def MSFTModuleExternOp : MSFTOp<"module.extern",
   ];
 
   let hasCustomAssemblyFormat = 1;
-  let verifier = "return ::verify$cppClass(*this);";
+  let hasVerifier = 1;
 
   let extraClassDeclaration = [{
     /// Decode information about the input and output ports on this module.
@@ -250,7 +250,7 @@ def PDPhysLocationOp : MSFTOp<"pd.location",
   }];
 }
 
-def PDPhysRegionOp : MSFTOp<"pd.physregion", 
+def PDPhysRegionOp : MSFTOp<"pd.physregion",
       [DeclareOpInterfaceMethods<DynInstDataOpInterface>]> {
   let summary = "Specify a physical region for an instance";
   let description = [{

--- a/include/circt/Dialect/SV/SVExpressions.td
+++ b/include/circt/Dialect/SV/SVExpressions.td
@@ -92,7 +92,7 @@ def ConstantXOp : SVOp<"constantX", [NoSideEffect, HasCustomSSAName]> {
   let arguments = (ins);
   let results = (outs HWValueType:$result);
   let assemblyFormat = " attr-dict `:` qualified(type($result))";
-  let verifier = "return ::verify$cppClass(*this);";
+  let hasVerifier = 1;
   let extraClassDeclaration = [{
     int64_t getWidth() {
       return hw::getBitWidth(getType());
@@ -110,7 +110,7 @@ def ConstantZOp : SVOp<"constantZ", [NoSideEffect, HasCustomSSAName]> {
   let arguments = (ins);
   let results = (outs HWValueType:$result);
   let assemblyFormat = " attr-dict `:` qualified(type($result))";
-  let verifier = "return ::verify$cppClass(*this);";
+  let hasVerifier = 1;
   let extraClassDeclaration = [{
     int64_t getWidth() {
       return hw::getBitWidth(getType());
@@ -133,7 +133,7 @@ def LocalParamOp : SVOp<"localparam",
     `:` qualified(type($result)) custom<ImplicitSSAName>(attr-dict)
   }];
 
-  let verifier = "return ::verify$cppClass(*this);";
+  let hasVerifier = 1;
 }
 
 def IndexedPartSelectOp
@@ -155,7 +155,7 @@ def IndexedPartSelectOp
                                                 CArg<"bool", "false">:$decrement)>
   ];
 
-  let verifier = "return ::verifyIndexedPartSelectOp(*this);";
+  let hasVerifier = 1;
 
   let extraClassDeclaration = [{
     /// Infer the return types of this operation.

--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -15,7 +15,7 @@ include "circt/Types.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 
 // Note that net declarations like 'wire' should not appear in an always block.
-def WireOp : SVOp<"wire", [NonProceduralOp, 
+def WireOp : SVOp<"wire", [NonProceduralOp,
           DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
   let summary = "Define a new wire";
   let description = [{
@@ -46,7 +46,7 @@ def WireOp : SVOp<"wire", [NonProceduralOp,
       return result().getType().cast<InOutType>().getElementType();
     }
   }];
-  let verifier = [{ return ::verifyWireOp(*this); }];
+  let hasVerifier = 1;
 }
 
 def RegOp : SVOp<"reg", [
@@ -160,7 +160,7 @@ def IndexedPartSelectInOutOp : SVOp<"indexed_part_select_inout",
                                  CArg<"bool", "false">:$decrement)>
   ];
 
-  let verifier = "return ::verifyIndexedPartSelectOp(*this);";
+  let hasVerifier = 1;
 
   let extraClassDeclaration = [{
     /// Infer the return types of this operation.

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -189,7 +189,7 @@ def AlwaysOp : SVOp<"always", [SingleBlock, NoTerminator, NoRegionArguments,
   }];
 
   // Check that we have the same number of events and conditions.
-  let verifier = "return ::verifyAlwaysOp(*this);";
+  let hasVerifier = 1;
 }
 
 def AlwaysCombOp : SVOp<"alwayscomb", [SingleBlock, NoTerminator,
@@ -300,7 +300,7 @@ def CaseZOp : SVOp<"casez", [SingleBlock, NoTerminator, NoRegionArguments,
   let arguments = (ins HWIntegerType:$cond, ArrayAttr:$casePatterns);
   let results = (outs);
   let hasCustomAssemblyFormat = 1;
-  let verifier = "return ::verifyCaseZOp(*this);";
+  let hasVerifier = 1;
 
   let builders = [
     /// This ctor allows you to build a CaseZ with some number of cases, getting
@@ -343,7 +343,7 @@ def BPAssignOp : SVOp<"bpassign", [InOutTypeConstraint<"src", "dest">,
   let arguments = (ins InOutType:$dest, InOutElementType:$src);
   let results = (outs);
   let assemblyFormat = "$dest `,` $src  attr-dict `:` qualified(type($src))";
-  let verifier = "return ::verifyBPAssignOp(*this);";
+  let hasVerifier = 1;
 }
 
 def PAssignOp : SVOp<"passign", [InOutTypeConstraint<"src", "dest">,
@@ -358,7 +358,7 @@ def PAssignOp : SVOp<"passign", [InOutTypeConstraint<"src", "dest">,
   let arguments = (ins InOutType:$dest, InOutElementType:$src);
   let results = (outs);
   let assemblyFormat = "$dest `,` $src  attr-dict `:` qualified(type($src))";
-  let verifier = "return ::verifyPAssignOp(*this);";
+  let hasVerifier = 1;
 }
 
 
@@ -415,7 +415,7 @@ def AliasOp : SVOp<"alias"> {
   let assemblyFormat = "$operands attr-dict `:` qualified(type($operands))";
 
   // Verify that we have at least two operands.
-  let verifier = "return ::verifyAliasOp(*this);";
+  let hasVerifier = 1;
 }
 
 def FWriteOp : SVOp<"fwrite", [ProceduralOp]> {
@@ -470,7 +470,7 @@ def BindOp : SVOp<"bind", []> {
 
   let arguments = (ins InnerRefAttr:$instance);
   let results = (outs);
-  let verifier = "return ::verify$cppClass(*this);";
+  let hasVerifier = 1;
 
   let assemblyFormat = "$instance attr-dict";
   let builders = [
@@ -490,7 +490,7 @@ def BindInterfaceOp : SVOp<"bind.interface", []> {
   }];
   let arguments = (ins InnerRefAttr:$instance);
   let results = (outs);
-  let verifier = "return ::verify$cppClass(*this);";
+  let hasVerifier = 1;
 
   let assemblyFormat = "$instance attr-dict";
   let extraClassDeclaration = [{

--- a/include/circt/Dialect/SV/SVTypeDecl.td
+++ b/include/circt/Dialect/SV/SVTypeDecl.td
@@ -291,7 +291,7 @@ def AssignInterfaceSignalOp : SVOp<"interface.signal.assign", []> {
         `=` $rhs attr-dict `:` qualified(type($rhs))
   }];
 
-  let verifier = "return ::verifySignalExists(iface(), signalNameAttr());";
+  let hasVerifier = 1;
 }
 
 def ReadInterfaceSignalOp : SVOp<"interface.signal.read", [NoSideEffect]> {
@@ -329,5 +329,5 @@ def ReadInterfaceSignalOp : SVOp<"interface.signal.read", [NoSideEffect]> {
     InterfaceSignalOp getReferencedDecl(const hw::SymbolCache &cache);
   }];
 
-  let verifier = "return ::verifySignalExists(iface(), signalNameAttr());";
+  let hasVerifier = 1;
 }

--- a/include/circt/Dialect/SV/SVTypeDecl.td
+++ b/include/circt/Dialect/SV/SVTypeDecl.td
@@ -214,7 +214,7 @@ def InterfaceInstanceOp : SVOp<"interface.instance"> {
     }]>
   ];
 
-  let verifier = "return ::verifyInterfaceInstanceOp(*this);";
+  let hasVerifier = 1;
 
   let extraClassDeclaration = [{
     InterfaceType getInterfaceType() { return getType().cast<InterfaceType>(); }
@@ -223,14 +223,14 @@ def InterfaceInstanceOp : SVOp<"interface.instance"> {
     /// invalid IR.
     Operation *getReferencedInterface(const hw::SymbolCache *cache = nullptr);
 
-    
+
     //===------------------------------------------------------------------===//
     // SymbolOpInterface Methods
     //===------------------------------------------------------------------===//
 
     /// An InstanceOp may optionally define a symbol.
     bool isOptionalSymbol() { return true; }
-    
+
   }];
 }
 
@@ -253,7 +253,7 @@ def GetModportOp: SVOp<"modport.get", [NoSideEffect]> {
   let assemblyFormat =
     "$iface $field attr-dict `:` qualified(type($iface)) `->` qualified(type($result))";
 
-  let verifier = "return ::verifyGetModportOp(*this);";
+  let hasVerifier = 1;
 
   let builders = [
     OpBuilder<(ins "Value":$value, "::llvm::StringRef":$field)>

--- a/include/circt/Dialect/StaticLogic/StaticLogic.td
+++ b/include/circt/Dialect/StaticLogic/StaticLogic.td
@@ -132,9 +132,7 @@ def PipelineWhileOp : Op<StaticLogic_Dialect, "pipeline.while", []> {
 
   let hasCustomAssemblyFormat = 1;
 
-  let verifier = [{
-    return ::verify$cppClass(*this);
-  }];
+  let hasVerifier = 1;
 
   let skipDefaultBuilders = 1;
   let builders = [
@@ -194,9 +192,7 @@ def PipelineStageOp : Op<StaticLogic_Dialect, "pipeline.stage",
     `start` `=` $start (`when` $when^)? $body (`:` qualified(type($results))^)? attr-dict
   }];
 
-  let verifier = [{
-    return ::verify$cppClass(*this);
-  }];
+  let hasVerifier = 1;
 
   let skipDefaultBuilders = 1;
   let builders = [
@@ -226,9 +222,7 @@ def PipelineRegisterOp : Op<StaticLogic_Dialect, "pipeline.register",
     $operands (`:` qualified(type($operands))^)? attr-dict
   }];
 
-  let verifier = [{
-    return ::verify$cppClass(*this);
-  }];
+  let hasVerifier = 1;
 }
 
 def PipelineTerminatorOp : Op<StaticLogic_Dialect, "pipeline.terminator",
@@ -260,9 +254,7 @@ def PipelineTerminatorOp : Op<StaticLogic_Dialect, "pipeline.terminator",
     functional-type($iter_args, $results) attr-dict
   }];
 
-  let verifier = [{
-    return ::verify$cppClass(*this);
-  }];
+  let hasVerifier = 1;
 }
 
 #endif // STATICLOGIC_OPS

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -311,10 +311,10 @@ static void eraseControlWithGroupAndConditional(OpTy op,
 // ProgramOp
 //===----------------------------------------------------------------------===//
 
-static LogicalResult verifyProgramOp(ProgramOp program) {
-  if (program.getEntryPointComponent() == nullptr)
-    return program.emitOpError() << "has undefined entry-point component: \""
-                                 << program.entryPointName() << "\".";
+LogicalResult ProgramOp::verify() {
+  if (getEntryPointComponent() == nullptr)
+    return emitOpError() << "has undefined entry-point component: \""
+                         << entryPointName() << "\".";
 
   return success();
 }
@@ -575,26 +575,26 @@ static LogicalResult hasRequiredPorts(ComponentOp op) {
          << difference;
 }
 
-static LogicalResult verifyComponentOp(ComponentOp op) {
+LogicalResult ComponentOp::verify() {
   // Verify there is exactly one of each the wires and control operations.
-  auto wIt = op.getBody()->getOps<WiresOp>();
-  auto cIt = op.getBody()->getOps<ControlOp>();
+  auto wIt = getBody()->getOps<WiresOp>();
+  auto cIt = getBody()->getOps<ControlOp>();
   if (std::distance(wIt.begin(), wIt.end()) +
           std::distance(cIt.begin(), cIt.end()) !=
       2)
-    return op.emitOpError(
+    return emitOpError(
         "requires exactly one of each: 'calyx.wires', 'calyx.control'.");
 
-  if (failed(hasRequiredPorts(op)))
+  if (failed(hasRequiredPorts(*this)))
     return failure();
 
   // Verify the component actually does something: has a non-empty Control
   // region, or continuous assignments.
   bool hasNoControlConstructs =
-      op.getControlOp().getBody()->getOperations().empty();
-  bool hasNoAssignments = op.getWiresOp().getBody()->getOps<AssignOp>().empty();
+      getControlOp().getBody()->getOperations().empty();
+  bool hasNoAssignments = getWiresOp().getBody()->getOps<AssignOp>().empty();
   if (hasNoControlConstructs && hasNoAssignments)
-    return op->emitOpError(
+    return emitOpError(
         "The component currently does nothing. It needs to either have "
         "continuous assignments in the Wires region or control constructs in "
         "the Control region.");
@@ -678,9 +678,7 @@ void ComponentOp::getAsmBlockArgumentNames(
 //===----------------------------------------------------------------------===//
 // ControlOp
 //===----------------------------------------------------------------------===//
-static LogicalResult verifyControlOp(ControlOp control) {
-  return verifyControlBody(control);
-}
+LogicalResult ControlOp::verify() { return verifyControlBody(*this); }
 
 //===----------------------------------------------------------------------===//
 // SeqOp
@@ -697,16 +695,16 @@ void SeqOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
 // ParOp
 //===----------------------------------------------------------------------===//
 
-static LogicalResult verifyParOp(ParOp parOp) {
+LogicalResult ParOp::verify() {
   llvm::SmallSet<StringRef, 8> groupNames;
-  Block *body = parOp.getBody();
+  Block *body = getBody();
 
   // Add loose requirement that the body of a ParOp may not enable the same
   // Group more than once, e.g. calyx.par { calyx.enable @G calyx.enable @G }
   for (EnableOp op : body->getOps<EnableOp>()) {
     StringRef groupName = op.groupName();
     if (groupNames.count(groupName))
-      return parOp->emitOpError() << "cannot enable the same group: \""
+      return emitOpError() << "cannot enable the same group: \""
                                   << groupName << "\" more than once.";
     groupNames.insert(groupName);
   }
@@ -724,17 +722,17 @@ void ParOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
 //===----------------------------------------------------------------------===//
 // WiresOp
 //===----------------------------------------------------------------------===//
-static LogicalResult verifyWiresOp(WiresOp wires) {
-  auto component = wires->getParentOfType<ComponentOp>();
+LogicalResult WiresOp::verify() {
+  auto component = (*this)->getParentOfType<ComponentOp>();
   auto control = component.getControlOp();
 
   // Verify each group is referenced in the control section.
-  for (auto &&op : *wires.getBody()) {
+  for (auto &&op : *this->getBody()) {
     if (!isa<GroupInterface>(op))
       continue;
     auto group = cast<GroupInterface>(op);
     auto groupName = group.symName();
-    if (SymbolTable::symbolKnownUseEmpty(groupName, control))
+    if (::SymbolTable::symbolKnownUseEmpty(groupName, control))
       return op.emitOpError() << "with name: " << groupName
                               << " is unused in the control execution schedule";
   }
@@ -787,15 +785,15 @@ static LogicalResult isCombinational(Value value, GroupInterface group) {
 
 /// Verifies a combinational group may contain only combinational primitives or
 /// perform combinational logic.
-static LogicalResult verifyCombGroupOp(CombGroupOp group) {
+LogicalResult CombGroupOp::verify() {
 
-  for (auto &&op : *group.getBody()) {
+  for (auto &&op : *getBody()) {
     auto assign = dyn_cast<AssignOp>(op);
     if (assign == nullptr)
       continue;
     Value dst = assign.dest(), src = assign.src();
-    if (failed(isCombinational(dst, group)) ||
-        failed(isCombinational(src, group)))
+    if (failed(isCombinational(dst, *this)) ||
+        failed(isCombinational(src, *this)))
       return failure();
   }
   return success();
@@ -1082,11 +1080,11 @@ static LogicalResult verifyAssignOpValue(AssignOp op, bool isDestination) {
   return success();
 }
 
-static LogicalResult verifyAssignOp(AssignOp assign) {
+LogicalResult AssignOp::verify() {
   bool isDestination = true, isSource = false;
-  if (failed(verifyAssignOpValue(assign, isDestination)))
+  if (failed(verifyAssignOpValue(*this, isDestination)))
     return failure();
-  if (failed(verifyAssignOpValue(assign, isSource)))
+  if (failed(verifyAssignOpValue(*this, isSource)))
     return failure();
 
   return success();
@@ -1419,25 +1417,25 @@ void MemoryOp::build(OpBuilder &builder, OperationState &state,
   state.addTypes(types);
 }
 
-static LogicalResult verifyMemoryOp(MemoryOp memoryOp) {
-  ArrayRef<Attribute> sizes = memoryOp.sizes().getValue();
-  ArrayRef<Attribute> addrSizes = memoryOp.addrSizes().getValue();
-  size_t numDims = memoryOp.sizes().size();
-  size_t numAddrs = memoryOp.addrSizes().size();
+LogicalResult MemoryOp::verify() {
+  ArrayRef<Attribute> sizes = this->sizes().getValue();
+  ArrayRef<Attribute> addrSizes = this->addrSizes().getValue();
+  size_t numDims = this->sizes().size();
+  size_t numAddrs = this->addrSizes().size();
   if (numDims != numAddrs)
-    return memoryOp.emitOpError("mismatched number of dimensions (")
+    return emitOpError("mismatched number of dimensions (")
            << numDims << ") and address sizes (" << numAddrs << ")";
 
   size_t numExtraPorts = 5; // write data/enable, clk, and read data/done.
-  if (memoryOp.getNumResults() != numAddrs + numExtraPorts)
-    return memoryOp.emitOpError("incorrect number of address ports, expected ")
+  if (getNumResults() != numAddrs + numExtraPorts)
+    return emitOpError("incorrect number of address ports, expected ")
            << numAddrs;
 
   for (size_t i = 0; i < numDims; ++i) {
     int64_t size = sizes[i].cast<IntegerAttr>().getInt();
     int64_t addrSize = addrSizes[i].cast<IntegerAttr>().getInt();
     if (llvm::Log2_64_Ceil(size) > addrSize)
-      return memoryOp.emitOpError("address size (")
+      return emitOpError("address size (")
              << addrSize << ") for dimension " << i
              << " can't address the entire range (" << size << ")";
   }
@@ -1448,18 +1446,18 @@ static LogicalResult verifyMemoryOp(MemoryOp memoryOp) {
 //===----------------------------------------------------------------------===//
 // EnableOp
 //===----------------------------------------------------------------------===//
-static LogicalResult verifyEnableOp(EnableOp enableOp) {
-  auto component = enableOp->getParentOfType<ComponentOp>();
+LogicalResult EnableOp::verify() {
+  auto component = (*this)->getParentOfType<ComponentOp>();
   auto wiresOp = component.getWiresOp();
-  StringRef groupName = enableOp.groupName();
+  StringRef groupName = this->groupName();
 
   auto groupOp = wiresOp.lookupSymbol<GroupInterface>(groupName);
   if (!groupOp)
-    return enableOp.emitOpError()
+    return emitOpError()
            << "with group '" << groupName << "', which does not exist.";
 
   if (isa<CombGroupOp>(groupOp))
-    return enableOp.emitOpError() << "with group '" << groupName
+    return emitOpError() << "with group '" << groupName
                                   << "', which is a combinational group.";
 
   return success();
@@ -1469,14 +1467,14 @@ static LogicalResult verifyEnableOp(EnableOp enableOp) {
 // IfOp
 //===----------------------------------------------------------------------===//
 
-static LogicalResult verifyIfOp(IfOp ifOp) {
-  auto component = ifOp->getParentOfType<ComponentOp>();
+LogicalResult IfOp::verify() {
+  auto component = (*this)->getParentOfType<ComponentOp>();
   WiresOp wiresOp = component.getWiresOp();
 
-  if (ifOp.elseBodyExists() && ifOp.getElseBody()->empty())
-    return ifOp.emitError() << "empty 'else' region.";
+  if (elseBodyExists() && getElseBody()->empty())
+    return emitError() << "empty 'else' region.";
 
-  Optional<StringRef> optGroupName = ifOp.groupName();
+  Optional<StringRef> optGroupName = groupName();
   if (!optGroupName.hasValue()) {
     // No combinational group was provided.
     return success();
@@ -1484,16 +1482,16 @@ static LogicalResult verifyIfOp(IfOp ifOp) {
   StringRef groupName = optGroupName.getValue();
   auto groupOp = wiresOp.lookupSymbol<GroupInterface>(groupName);
   if (!groupOp)
-    return ifOp.emitOpError()
+    return emitOpError()
            << "with group '" << groupName << "', which does not exist.";
 
   if (isa<GroupOp>(groupOp))
-    return ifOp.emitOpError() << "with group '" << groupName
+    return emitOpError() << "with group '" << groupName
                               << "', which is not a combinational group.";
 
-  if (failed(groupOp.drivesPort(ifOp.cond())))
-    return ifOp.emitError()
-           << "with conditional op: '" << valueName(component, ifOp.cond())
+  if (failed(groupOp.drivesPort(cond())))
+    return emitError()
+           << "with conditional op: '" << valueName(component, cond())
            << "' expected to be driven from group: '" << groupName
            << "' but no driver was found.";
 
@@ -1674,11 +1672,11 @@ void IfOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
 //===----------------------------------------------------------------------===//
 // WhileOp
 //===----------------------------------------------------------------------===//
-static LogicalResult verifyWhileOp(WhileOp whileOp) {
-  auto component = whileOp->getParentOfType<ComponentOp>();
+LogicalResult WhileOp::verify() {
+  auto component = (*this)->getParentOfType<ComponentOp>();
   auto wiresOp = component.getWiresOp();
 
-  Optional<StringRef> optGroupName = whileOp.groupName();
+  Optional<StringRef> optGroupName = groupName();
   if (!optGroupName.hasValue()) {
     /// No combinational group was provided
     return success();
@@ -1686,16 +1684,16 @@ static LogicalResult verifyWhileOp(WhileOp whileOp) {
   StringRef groupName = optGroupName.getValue();
   auto groupOp = wiresOp.lookupSymbol<GroupInterface>(groupName);
   if (!groupOp)
-    return whileOp.emitOpError()
+    return emitOpError()
            << "with group '" << groupName << "', which does not exist.";
 
   if (isa<GroupOp>(groupOp))
-    return whileOp.emitOpError() << "with group '" << groupName
+    return emitOpError() << "with group '" << groupName
                                  << "', which is not a combinational group.";
 
-  if (failed(groupOp.drivesPort(whileOp.cond())))
-    return whileOp.emitError()
-           << "conditional op: '" << valueName(component, whileOp.cond())
+  if (failed(groupOp.drivesPort(cond())))
+    return emitError()
+           << "conditional op: '" << valueName(component, cond())
            << "' expected to be driven from group: '" << groupName
            << "' but no driver was found.";
 
@@ -1787,6 +1785,26 @@ SmallVector<DictionaryAttr> DivPipeLibOp::portAttributes() {
 //===----------------------------------------------------------------------===//
 // Calyx library ops
 //===----------------------------------------------------------------------===//
+
+LogicalResult PadLibOp::verify() {
+  unsigned inBits = getResult(0).getType().getIntOrFloatBitWidth();
+  unsigned outBits = getResult(1).getType().getIntOrFloatBitWidth();
+  if (inBits >= outBits)
+    return emitOpError("expected input bits (")
+           << inBits << ')' << " to be less than output bits (" << outBits
+           << ')';
+  return success();
+}
+
+LogicalResult SliceLibOp::verify() {
+  unsigned inBits = getResult(0).getType().getIntOrFloatBitWidth();
+  unsigned outBits = getResult(1).getType().getIntOrFloatBitWidth();
+  if (inBits <= outBits)
+    return emitOpError("expected input bits (")
+           << inBits << ')' << " to be greater than output bits (" << outBits
+           << ')';
+  return success();
+}
 
 #define ImplUnaryOpCellInterface(OpType)                                       \
   SmallVector<StringRef> OpType::portNames() { return {"in", "out"}; }         \

--- a/lib/Dialect/Comb/CombOps.cpp
+++ b/lib/Dialect/Comb/CombOps.cpp
@@ -188,6 +188,26 @@ static LogicalResult verifyUTVariadicOp(Operation *op) {
   return success();
 }
 
+LogicalResult AddOp::verify() {
+  return verifyUTVariadicOp(*this);
+}
+
+LogicalResult MulOp::verify() {
+  return verifyUTVariadicOp(*this);
+}
+
+LogicalResult AndOp::verify() {
+  return verifyUTVariadicOp(*this);
+}
+
+LogicalResult OrOp::verify() {
+  return verifyUTVariadicOp(*this);
+}
+
+LogicalResult XorOp::verify() {
+  return verifyUTVariadicOp(*this);
+}
+
 /// Return true if this is a two operand xor with an all ones constant as its
 /// RHS operand.
 bool XorOp::isBinaryNot() {
@@ -216,8 +236,8 @@ LogicalResult ConcatOp::verify() {
   unsigned operandsTotalWidth = getTotalWidth(inputs());
   if (tyWidth != operandsTotalWidth)
     return emitOpError("ConcatOp requires operands total width to "
-                                "match type width. operands "
-                                "totalWidth is")
+                       "match type width. operands "
+                       "totalWidth is")
            << operandsTotalWidth << ", but concatOp type width is " << tyWidth;
 
   return success();

--- a/lib/Dialect/Comb/CombOps.cpp
+++ b/lib/Dialect/Comb/CombOps.cpp
@@ -158,20 +158,20 @@ bool ICmpOp::isNotEqualZero() {
 // Unary Operations
 //===----------------------------------------------------------------------===//
 
-static LogicalResult verifyReplicateOp(ReplicateOp op) {
+LogicalResult ReplicateOp::verify() {
   // The source must be equal or smaller than the dest type, and an even
   // multiple of it.  Both are already known to be signless integers.
-  auto srcWidth = op.getOperand().getType().cast<IntegerType>().getWidth();
-  auto dstWidth = op.getType().getWidth();
+  auto srcWidth = getOperand().getType().cast<IntegerType>().getWidth();
+  auto dstWidth = getType().getWidth();
   if (srcWidth == 0)
-    return op.emitOpError("replicate does not take zero bit integer");
+    return emitOpError("replicate does not take zero bit integer");
 
   if (srcWidth > dstWidth)
-    return op.emitOpError("replicate cannot shrink bitwidth of operand"),
+    return emitOpError("replicate cannot shrink bitwidth of operand"),
            failure();
 
   if (dstWidth % srcWidth)
-    return op.emitOpError("replicate must produce integer multiple of operand"),
+    return emitOpError("replicate must produce integer multiple of operand"),
            failure();
 
   return success();
@@ -211,11 +211,11 @@ static unsigned getTotalWidth(ValueRange inputs) {
   return resultWidth;
 }
 
-static LogicalResult verifyConcatOp(ConcatOp concatOp) {
-  unsigned tyWidth = concatOp.getType().getWidth();
-  unsigned operandsTotalWidth = getTotalWidth(concatOp.inputs());
+LogicalResult ConcatOp::verify() {
+  unsigned tyWidth = getType().getWidth();
+  unsigned operandsTotalWidth = getTotalWidth(inputs());
   if (tyWidth != operandsTotalWidth)
-    return concatOp.emitOpError("ConcatOp requires operands total width to "
+    return emitOpError("ConcatOp requires operands total width to "
                                 "match type width. operands "
                                 "totalWidth is")
            << operandsTotalWidth << ", but concatOp type width is " << tyWidth;
@@ -246,11 +246,11 @@ LogicalResult ConcatOp::inferReturnTypes(MLIRContext *context,
 // Other Operations
 //===----------------------------------------------------------------------===//
 
-static LogicalResult verifyExtractOp(ExtractOp op) {
-  unsigned srcWidth = op.input().getType().cast<IntegerType>().getWidth();
-  unsigned dstWidth = op.getType().getWidth();
-  if (op.lowBit() >= srcWidth || srcWidth - op.lowBit() < dstWidth)
-    return op.emitOpError("from bit too large for input"), failure();
+LogicalResult ExtractOp::verify() {
+  unsigned srcWidth = input().getType().cast<IntegerType>().getWidth();
+  unsigned dstWidth = getType().getWidth();
+  if (lowBit() >= srcWidth || srcWidth - lowBit() < dstWidth)
+    return emitOpError("from bit too large for input"), failure();
 
   return success();
 }

--- a/lib/Dialect/Comb/CombOps.cpp
+++ b/lib/Dialect/Comb/CombOps.cpp
@@ -188,25 +188,15 @@ static LogicalResult verifyUTVariadicOp(Operation *op) {
   return success();
 }
 
-LogicalResult AddOp::verify() {
-  return verifyUTVariadicOp(*this);
-}
+LogicalResult AddOp::verify() { return verifyUTVariadicOp(*this); }
 
-LogicalResult MulOp::verify() {
-  return verifyUTVariadicOp(*this);
-}
+LogicalResult MulOp::verify() { return verifyUTVariadicOp(*this); }
 
-LogicalResult AndOp::verify() {
-  return verifyUTVariadicOp(*this);
-}
+LogicalResult AndOp::verify() { return verifyUTVariadicOp(*this); }
 
-LogicalResult OrOp::verify() {
-  return verifyUTVariadicOp(*this);
-}
+LogicalResult OrOp::verify() { return verifyUTVariadicOp(*this); }
 
-LogicalResult XorOp::verify() {
-  return verifyUTVariadicOp(*this);
-}
+LogicalResult XorOp::verify() { return verifyUTVariadicOp(*this); }
 
 /// Return true if this is a two operand xor with an all ones constant as its
 /// RHS operand.

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -200,15 +200,13 @@ static LogicalResult verifySVInterface(Operation *op,
 }
 
 LogicalResult WrapSVInterface::verify() {
-  auto modportType =
-      interfaceSink().getType().cast<circt::sv::ModportType>();
+  auto modportType = interfaceSink().getType().cast<circt::sv::ModportType>();
   auto chanType = output().getType().cast<ChannelPort>();
   return verifySVInterface(*this, modportType, chanType);
 }
 
 LogicalResult UnwrapSVInterface::verify() {
-  auto modportType =
-      interfaceSource().getType().cast<circt::sv::ModportType>();
+  auto modportType = interfaceSource().getType().cast<circt::sv::ModportType>();
   auto chanType = chanInput().getType().cast<ChannelPort>();
   return verifySVInterface(*this, modportType, chanType);
 }

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -199,18 +199,18 @@ static LogicalResult verifySVInterface(Operation *op,
   return success();
 }
 
-static LogicalResult verifyWrapSVInterface(WrapSVInterface &op) {
+LogicalResult WrapSVInterface::verify() {
   auto modportType =
-      op.interfaceSink().getType().cast<circt::sv::ModportType>();
-  auto chanType = op.output().getType().cast<ChannelPort>();
-  return verifySVInterface(op, modportType, chanType);
+      interfaceSink().getType().cast<circt::sv::ModportType>();
+  auto chanType = output().getType().cast<ChannelPort>();
+  return verifySVInterface(*this, modportType, chanType);
 }
 
-static LogicalResult verifyUnwrapSVInterface(UnwrapSVInterface &op) {
+LogicalResult UnwrapSVInterface::verify() {
   auto modportType =
-      op.interfaceSource().getType().cast<circt::sv::ModportType>();
-  auto chanType = op.chanInput().getType().cast<ChannelPort>();
-  return verifySVInterface(op, modportType, chanType);
+      interfaceSource().getType().cast<circt::sv::ModportType>();
+  auto chanType = chanInput().getType().cast<ChannelPort>();
+  return verifySVInterface(*this, modportType, chanType);
 }
 
 #define GET_OP_CLASSES

--- a/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
@@ -111,8 +111,7 @@ LogicalResult MemoryPortOp::verify() {
   // MemoryPorts require exactly 1 access. Right now there are no other
   // operations that could be using that value due to the types.
   if (!port().hasOneUse())
-    return emitOpError(
-        "port should be used by a chirrtl.memoryport.access");
+    return emitOpError("port should be used by a chirrtl.memoryport.access");
   return success();
 }
 

--- a/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
@@ -107,11 +107,11 @@ LogicalResult MemoryPortOp::inferReturnTypes(MLIRContext *context,
   return success();
 }
 
-static LogicalResult verifyMemoryPortOp(MemoryPortOp memoryPort) {
+LogicalResult MemoryPortOp::verify() {
   // MemoryPorts require exactly 1 access. Right now there are no other
   // operations that could be using that value due to the types.
-  if (!memoryPort.port().hasOneUse())
-    return memoryPort.emitOpError(
+  if (!port().hasOneUse())
+    return emitOpError(
         "port should be used by a chirrtl.memoryport.access");
   return success();
 }

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -278,7 +278,7 @@ LogicalResult CircuitOp::verify() {
 
     // Check that this extmodule's defname does not conflict with
     // the symbol name of any module.
-    auto collidingModule = lookupSymbol(defname.getValue());
+    auto *collidingModule = lookupSymbol(defname.getValue());
     if (isa_and_nonnull<FModuleOp>(collidingModule)) {
       auto diag =
           extModule.emitOpError()

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2278,8 +2278,7 @@ LogicalResult ConstantOp::verify() {
 
   // The sign of the attribute's integer type must match our integer type sign.
   auto attrType = valueAttr().getType().cast<IntegerType>();
-  if (attrType.isSignless() ||
-      attrType.isSigned() != getType().isSigned())
+  if (attrType.isSignless() || attrType.isSigned() != getType().isSigned())
     return emitError("firrtl.constant attribute has wrong sign");
 
   return success();
@@ -2384,10 +2383,9 @@ void SpecialConstantOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 }
 
 LogicalResult SubfieldOp::verify() {
-  if (fieldIndex() >=
-      input().getType().cast<BundleType>().getNumElements())
+  if (fieldIndex() >= input().getType().cast<BundleType>().getNumElements())
     return emitOpError("subfield element index is greater than the number "
-                          "of fields in the bundle type");
+                       "of fields in the bundle type");
   return success();
 }
 
@@ -3161,8 +3159,7 @@ LogicalResult BitCastOp::verify() {
            << resTypeBits.getValue() << ") don't match";
   }
   if (!inTypeBits.hasValue())
-    return emitError(
-               "bitwidth cannot be determined for input operand type ")
+    return emitError("bitwidth cannot be determined for input operand type ")
            << getOperand().getType();
   return emitError("bitwidth cannot be determined for result type ")
          << getType();

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -247,19 +247,19 @@ static void printCircuitOpAttrs(OpAsmPrinter &p, Operation *op,
   p.printOptionalAttrDictWithKeyword(op->getAttrs(), elidedAttrs);
 }
 
-static LogicalResult verifyCircuitOp(CircuitOp circuit) {
-  StringRef main = circuit.name();
+LogicalResult CircuitOp::verify() {
+  StringRef main = name();
 
   // Check that the circuit has a non-empty name.
   if (main.empty()) {
-    circuit.emitOpError("must have a non-empty name");
+    emitOpError("must have a non-empty name");
     return failure();
   }
 
   // Check that a module matching the "main" module exists in the circuit.
-  if (!circuit.getMainModule()) {
-    circuit.emitOpError("must contain one module that matches main name '" +
-                        main + "'");
+  if (!getMainModule()) {
+    emitOpError("must contain one module that matches main name '" + main +
+                "'");
     return failure();
   }
 
@@ -278,7 +278,7 @@ static LogicalResult verifyCircuitOp(CircuitOp circuit) {
 
     // Check that this extmodule's defname does not conflict with
     // the symbol name of any module.
-    auto collidingModule = circuit.lookupSymbol(defname.getValue());
+    auto collidingModule = lookupSymbol(defname.getValue());
     if (isa_and_nonnull<FModuleOp>(collidingModule)) {
       auto diag =
           extModule.emitOpError()
@@ -367,11 +367,11 @@ static LogicalResult verifyCircuitOp(CircuitOp circuit) {
     return success();
   };
 
-  InnerRefList instanceSyms(circuit.getContext());
-  InnerRefList leafInnerSyms(circuit.getContext());
+  InnerRefList instanceSyms(getContext());
+  InnerRefList leafInnerSyms(getContext());
   SmallVector<NonLocalAnchor> nlaList;
 
-  for (auto &op : *circuit.getBody()) {
+  for (auto &op : *getBody()) {
     // Record all the NLAs.
     if (auto nla = dyn_cast<NonLocalAnchor>(op))
       nlaList.push_back(nla);
@@ -1090,8 +1090,8 @@ ParseResult FExtModuleOp::parse(OpAsmParser &parser, OperationState &result) {
   return parseFModuleLikeOp(parser, result, /*hasSSAIdentifiers=*/false);
 }
 
-static LogicalResult verifyFExtModuleOp(FExtModuleOp op) {
-  auto params = op.parameters();
+LogicalResult FExtModuleOp::verify() {
+  auto params = parameters();
   if (params.empty())
     return success();
 
@@ -1101,8 +1101,8 @@ static LogicalResult verifyFExtModuleOp(FExtModuleOp op) {
     if (value.isa<IntegerAttr>() || value.isa<StringAttr>() ||
         value.isa<FloatAttr>())
       return true;
-    op.emitError() << "has unknown extmodule parameter value '"
-                   << param.getName().getValue() << "' = " << value;
+    emitError() << "has unknown extmodule parameter value '"
+                << param.getName().getValue() << "' = " << value;
     return false;
   };
 
@@ -1399,12 +1399,12 @@ LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 }
 
 /// Verify the correctness of an InstanceOp.
-static LogicalResult verifyInstanceOp(InstanceOp instance) {
+LogicalResult InstanceOp::verify() {
 
   // Check that this instance is inside a module.
-  auto module = instance->getParentOfType<FModuleOp>();
+  auto module = (*this)->getParentOfType<FModuleOp>();
   if (!module) {
-    instance.emitOpError("should be embedded in a 'firrtl.module'");
+    emitOpError("should be embedded in a 'firrtl.module'");
     return failure();
   }
 
@@ -1580,7 +1580,7 @@ void MemOp::getNumPorts(size_t &numReadPorts, size_t &numWritePorts,
 }
 
 /// Verify the correctness of a MemOp.
-static LogicalResult verifyMemOp(MemOp mem) {
+LogicalResult MemOp::verify() {
 
   // Store the port names as we find them. This lets us check quickly
   // for uniqueneess.
@@ -1590,26 +1590,26 @@ static LogicalResult verifyMemOp(MemOp mem) {
   // type is consistent across all ports.
   FIRRTLType oldDataType;
 
-  for (size_t i = 0, e = mem.getNumResults(); i != e; ++i) {
-    auto portName = mem.getPortName(i);
+  for (size_t i = 0, e = getNumResults(); i != e; ++i) {
+    auto portName = getPortName(i);
 
     // Get a bundle type representing this port, stripping an outer
     // flip if it exists.  If this is not a bundle<> or
     // flip<bundle<>>, then this is an error.
     BundleType portBundleType =
         TypeSwitch<FIRRTLType, BundleType>(
-            mem.getResult(i).getType().cast<FIRRTLType>())
+            getResult(i).getType().cast<FIRRTLType>())
             .Case<BundleType>([](BundleType a) { return a; })
             .Default([](auto) { return nullptr; });
     if (!portBundleType) {
-      mem.emitOpError() << "has an invalid type on port " << portName
-                        << " (expected '!firrtl.bundle<...>')";
+      emitOpError() << "has an invalid type on port " << portName
+                    << " (expected '!firrtl.bundle<...>')";
       return failure();
     }
 
     // Require that all port names are unique.
     if (!portNamesSet.insert(portName).second) {
-      mem.emitOpError() << "has non-unique port name " << portName;
+      emitOpError() << "has non-unique port name " << portName;
       return failure();
     }
 
@@ -1618,9 +1618,9 @@ static LogicalResult verifyMemOp(MemOp mem) {
     // in the type (but we don't know any more just yet).
     MemOp::PortKind portKind;
     {
-      auto elt = mem.getPortNamed(portName);
+      auto elt = getPortNamed(portName);
       if (!elt) {
-        mem.emitOpError() << "could not get port with name " << portName;
+        emitOpError() << "could not get port with name " << portName;
         return failure();
       }
       auto firrtlType = elt.getType().cast<FIRRTLType>();
@@ -1636,7 +1636,7 @@ static LogicalResult verifyMemOp(MemOp mem) {
         portKind = MemOp::PortKind::ReadWrite;
         break;
       default:
-        mem.emitOpError()
+        emitOpError()
             << "has an invalid number of fields on port " << portName
             << " (expected 4 for read, 5 for write, or 7 for read/write)";
         return failure();
@@ -1651,9 +1651,9 @@ static LogicalResult verifyMemOp(MemOp mem) {
       if (!dataTypeOption && portKind == MemOp::PortKind::ReadWrite)
         dataTypeOption = portBundleType.getElement("wdata");
       if (!dataTypeOption) {
-        mem.emitOpError() << "has no data field on port " << portName
-                          << " (expected to see \"data\" for a read or write "
-                             "port or \"rdata\" for a read/write port)";
+        emitOpError() << "has no data field on port " << portName
+                      << " (expected to see \"data\" for a read or write "
+                         "port or \"rdata\" for a read/write port)";
         return failure();
       }
       dataType = dataTypeOption.getValue().type;
@@ -1665,28 +1665,27 @@ static LogicalResult verifyMemOp(MemOp mem) {
 
     // Error if the data type isn't passive.
     if (!dataType.isPassive()) {
-      mem.emitOpError() << "has non-passive data type on port " << portName
-                        << " (memory types must be passive)";
+      emitOpError() << "has non-passive data type on port " << portName
+                    << " (memory types must be passive)";
       return failure();
     }
 
     // Error if the data type contains analog types.
     if (dataType.containsAnalog()) {
-      mem.emitOpError()
-          << "has a data type that contains an analog type on port " << portName
-          << " (memory types cannot contain analog types)";
+      emitOpError() << "has a data type that contains an analog type on port "
+                    << portName
+                    << " (memory types cannot contain analog types)";
       return failure();
     }
 
     // Check that the port type matches the kind that we determined
     // for this port.  This catches situations of extraneous port
     // fields beind included or the fields being named incorrectly.
-    FIRRTLType expectedType =
-        mem.getTypeForPort(mem.depth(), dataType, portKind,
-                           dataType.isGround() ? mem.getMaskBits() : 0);
+    FIRRTLType expectedType = getTypeForPort(
+        depth(), dataType, portKind, dataType.isGround() ? getMaskBits() : 0);
     // Compute the original port type as portBundleType may have
     // stripped outer flip information.
-    auto originalType = mem.getResult(i).getType();
+    auto originalType = getResult(i).getType();
     if (originalType != expectedType) {
       StringRef portKindName;
       switch (portKind) {
@@ -1700,36 +1699,36 @@ static LogicalResult verifyMemOp(MemOp mem) {
         portKindName = "readwrite";
         break;
       }
-      mem.emitOpError() << "has an invalid type for port " << portName
-                        << " of determined kind \"" << portKindName
-                        << "\" (expected " << expectedType << ", but got "
-                        << originalType << ")";
+      emitOpError() << "has an invalid type for port " << portName
+                    << " of determined kind \"" << portKindName
+                    << "\" (expected " << expectedType << ", but got "
+                    << originalType << ")";
       return failure();
     }
 
     // Error if the type of the current port was not the same as the
     // last port, but skip checking the first port.
     if (oldDataType && oldDataType != dataType) {
-      mem.emitOpError() << "port " << mem.getPortName(i)
-                        << " has a different type than port "
-                        << mem.getPortName(i - 1) << " (expected "
-                        << oldDataType << ", but got " << dataType << ")";
+      emitOpError() << "port " << getPortName(i)
+                    << " has a different type than port " << getPortName(i - 1)
+                    << " (expected " << oldDataType << ", but got " << dataType
+                    << ")";
       return failure();
     }
 
     oldDataType = dataType;
   }
 
-  auto maskWidth = mem.getMaskBits();
+  auto maskWidth = getMaskBits();
 
-  auto dataWidth = mem.getDataType().getBitWidthOrSentinel();
+  auto dataWidth = getDataType().getBitWidthOrSentinel();
   if (dataWidth > 0 && maskWidth > (size_t)dataWidth)
-    return mem.emitOpError("the mask width cannot be greater than "
-                           "data width");
+    return emitOpError("the mask width cannot be greater than "
+                       "data width");
 
-  if (mem.portAnnotations().size() != mem.getNumResults())
-    return mem.emitOpError("the number of result annotations should be "
-                           "equal to the number of results");
+  if (portAnnotations().size() != getNumResults())
+    return emitOpError("the number of result annotations should be "
+                       "equal to the number of results");
 
   return success();
 }
@@ -1992,126 +1991,126 @@ void WireOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 // Statements
 //===----------------------------------------------------------------------===//
 
-static LogicalResult verifyConnectOp(ConnectOp connect) {
-  FIRRTLType destType = connect.dest().getType().cast<FIRRTLType>();
-  FIRRTLType srcType = connect.src().getType().cast<FIRRTLType>();
+LogicalResult ConnectOp::verify() {
+  FIRRTLType destType = dest().getType().cast<FIRRTLType>();
+  FIRRTLType srcType = src().getType().cast<FIRRTLType>();
 
   // Analog types cannot be connected and must be attached.
   if (destType.isa<AnalogType>() || srcType.isa<AnalogType>())
-    return connect.emitError("analog types may not be connected");
+    return emitError("analog types may not be connected");
   if (auto destBundle = destType.dyn_cast<BundleType>())
     if (destBundle.containsAnalog())
-      return connect.emitError("analog types may not be connected");
+      return emitError("analog types may not be connected");
   if (auto srcBundle = srcType.dyn_cast<BundleType>())
     if (srcBundle.containsAnalog())
-      return connect.emitError("analog types may not be connected");
+      return emitError("analog types may not be connected");
 
   // Destination and source types must be equivalent.
   if (!areTypesEquivalent(destType, srcType))
-    return connect.emitError("type mismatch between destination ")
+    return emitError("type mismatch between destination ")
            << destType << " and source " << srcType;
 
   // Destination bitwidth must be greater than or equal to source bitwidth.
   int32_t destWidth = destType.getPassiveType().getBitWidthOrSentinel();
   int32_t srcWidth = srcType.getPassiveType().getBitWidthOrSentinel();
   if (destWidth > -1 && srcWidth > -1 && destWidth < srcWidth)
-    return connect.emitError("destination width ")
+    return emitError("destination width ")
            << destWidth << " is not greater than or equal to source width "
            << srcWidth;
 
   // TODO: Relax this to allow reads from output ports,
   // instance/memory input ports.
-  if (foldFlow(connect.src()) == Flow::Sink) {
+  if (foldFlow(src()) == Flow::Sink) {
     // A sink that is a port output or instance input used as a source is okay.
-    auto kind = getDeclarationKind(connect.src());
+    auto kind = getDeclarationKind(src());
     if (kind != DeclKind::Port && kind != DeclKind::Instance) {
       auto diag =
-          connect.emitOpError()
+          emitOpError()
           << "has invalid flow: the right-hand-side has sink flow and "
              "is not an output port or instance input (expected source "
              "flow, duplex flow, an output port, or an instance input).";
-      return diag.attachNote(connect.src().getLoc())
+      return diag.attachNote(src().getLoc())
              << "the right-hand-side was defined here.";
     }
   }
 
-  if (foldFlow(connect.dest()) == Flow::Source) {
-    auto diag = connect.emitOpError()
+  if (foldFlow(dest()) == Flow::Source) {
+    auto diag = emitOpError()
                 << "has invalid flow: the left-hand-side has source flow "
                    "(expected sink or duplex flow).";
-    return diag.attachNote(connect.dest().getLoc())
+    return diag.attachNote(dest().getLoc())
            << "the left-hand-side was defined here.";
   }
 
   return success();
 }
 
-static LogicalResult verifyPartialConnectOp(PartialConnectOp partialConnect) {
-  FIRRTLType destType = partialConnect.dest().getType().cast<FIRRTLType>();
-  FIRRTLType srcType = partialConnect.src().getType().cast<FIRRTLType>();
+LogicalResult PartialConnectOp::verify() {
+  FIRRTLType destType = dest().getType().cast<FIRRTLType>();
+  FIRRTLType srcType = src().getType().cast<FIRRTLType>();
 
   if (!areTypesWeaklyEquivalent(destType, srcType))
-    return partialConnect.emitError("type mismatch between destination ")
+    return emitError("type mismatch between destination ")
            << destType << " and source " << srcType
            << ". Types are not weakly equivalent.";
 
   // Check that the flows make sense.
-  if (foldFlow(partialConnect.src()) == Flow::Sink) {
+  if (foldFlow(src()) == Flow::Sink) {
     // A sink that is a port output or instance input used as a source is okay.
-    auto kind = getDeclarationKind(partialConnect.src());
+    auto kind = getDeclarationKind(src());
     if (kind != DeclKind::Port && kind != DeclKind::Instance) {
       auto diag =
-          partialConnect.emitOpError()
+          emitOpError()
           << "has invalid flow: the right-hand-side has sink flow and "
              "is not an output port or instance input (expected source "
              "flow, duplex flow, an output port, or an instance input).";
-      return diag.attachNote(partialConnect.src().getLoc())
+      return diag.attachNote(src().getLoc())
              << "the right-hand-side was defined here.";
     }
   }
 
-  if (foldFlow(partialConnect.dest()) == Flow::Source) {
-    auto diag = partialConnect.emitOpError()
+  if (foldFlow(dest()) == Flow::Source) {
+    auto diag = emitOpError()
                 << "has invalid flow: the left-hand-side has source flow "
                    "(expected sink or duplex flow).";
-    return diag.attachNote(partialConnect.dest().getLoc())
+    return diag.attachNote(dest().getLoc())
            << "the left-hand-side was defined here.";
   }
 
   return success();
 }
 
-static LogicalResult verifyStrictConnectOp(StrictConnectOp connect) {
-  FIRRTLType type = connect.dest().getType().cast<FIRRTLType>();
+LogicalResult StrictConnectOp::verify() {
+  FIRRTLType type = dest().getType().cast<FIRRTLType>();
 
   // Analog types cannot be connected and must be attached.
   if (type.isa<AnalogType>())
-    return connect.emitError("analog types may not be connected");
+    return emitError("analog types may not be connected");
   if (auto destBundle = type.dyn_cast<BundleType>())
     if (destBundle.containsAnalog())
-      return connect.emitError("analog types may not be connected");
+      return emitError("analog types may not be connected");
 
   // TODO: Relax this to allow reads from output ports,
   // instance/memory input ports.
-  if (foldFlow(connect.src()) == Flow::Sink) {
+  if (foldFlow(src()) == Flow::Sink) {
     // A sink that is a port output or instance input used as a source is okay.
-    auto kind = getDeclarationKind(connect.src());
+    auto kind = getDeclarationKind(src());
     if (kind != DeclKind::Port && kind != DeclKind::Instance) {
       auto diag =
-          connect.emitOpError()
+          emitOpError()
           << "has invalid flow: the right-hand-side has sink flow and "
              "is not an output port or instance input (expected source "
              "flow, duplex flow, an output port, or an instance input).";
-      return diag.attachNote(connect.src().getLoc())
+      return diag.attachNote(src().getLoc())
              << "the right-hand-side was defined here.";
     }
   }
 
-  if (foldFlow(connect.dest()) == Flow::Source) {
-    auto diag = connect.emitOpError()
+  if (foldFlow(dest()) == Flow::Source) {
+    auto diag = emitOpError()
                 << "has invalid flow: the left-hand-side has source flow "
                    "(expected sink or duplex flow).";
-    return diag.attachNote(connect.dest().getLoc())
+    return diag.attachNote(dest().getLoc())
            << "the left-hand-side was defined here.";
   }
 
@@ -2269,19 +2268,19 @@ ParseResult ConstantOp::parse(OpAsmParser &parser, OperationState &result) {
   return success();
 }
 
-static LogicalResult verifyConstantOp(ConstantOp constant) {
+LogicalResult ConstantOp::verify() {
   // If the result type has a bitwidth, then the attribute must match its width.
-  auto intType = constant.getType().cast<IntType>();
+  auto intType = getType().cast<IntType>();
   auto width = intType.getWidthOrSentinel();
-  if (width != -1 && (int)constant.value().getBitWidth() != width)
-    return constant.emitError(
+  if (width != -1 && (int)value().getBitWidth() != width)
+    return emitError(
         "firrtl.constant attribute bitwidth doesn't match return type");
 
   // The sign of the attribute's integer type must match our integer type sign.
-  auto attrType = constant.valueAttr().getType().cast<IntegerType>();
+  auto attrType = valueAttr().getType().cast<IntegerType>();
   if (attrType.isSignless() ||
-      attrType.isSigned() != constant.getType().isSigned())
-    return constant.emitError("firrtl.constant attribute has wrong sign");
+      attrType.isSigned() != getType().isSigned())
+    return emitError("firrtl.constant attribute has wrong sign");
 
   return success();
 }
@@ -2384,10 +2383,10 @@ void SpecialConstantOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   setNameFn(getResult(), specialName.str());
 }
 
-static LogicalResult verifySubfieldOp(SubfieldOp op) {
-  if (op.fieldIndex() >=
-      op.input().getType().cast<BundleType>().getNumElements())
-    return op.emitOpError("subfield element index is greater than the number "
+LogicalResult SubfieldOp::verify() {
+  if (fieldIndex() >=
+      input().getType().cast<BundleType>().getNumElements())
+    return emitOpError("subfield element index is greater than the number "
                           "of fields in the bundle type");
   return success();
 }
@@ -3111,37 +3110,37 @@ void VerbatimWireOp::getAsmResultNames(
 // Conversions to/from structs in the standard dialect.
 //===----------------------------------------------------------------------===//
 
-static LogicalResult verifyHWStructCastOp(HWStructCastOp cast) {
+LogicalResult HWStructCastOp::verify() {
   // We must have a bundle and a struct, with matching pairwise fields
   BundleType bundleType;
   hw::StructType structType;
-  if ((bundleType = cast.getOperand().getType().dyn_cast<BundleType>())) {
-    structType = cast.getType().dyn_cast<hw::StructType>();
+  if ((bundleType = getOperand().getType().dyn_cast<BundleType>())) {
+    structType = getType().dyn_cast<hw::StructType>();
     if (!structType)
-      return cast.emitError("result type must be a struct");
-  } else if ((bundleType = cast.getType().dyn_cast<BundleType>())) {
-    structType = cast.getOperand().getType().dyn_cast<hw::StructType>();
+      return emitError("result type must be a struct");
+  } else if ((bundleType = getType().dyn_cast<BundleType>())) {
+    structType = getOperand().getType().dyn_cast<hw::StructType>();
     if (!structType)
-      return cast.emitError("operand type must be a struct");
+      return emitError("operand type must be a struct");
   } else {
-    return cast.emitError("either source or result type must be a bundle type");
+    return emitError("either source or result type must be a bundle type");
   }
 
   auto firFields = bundleType.getElements();
   auto hwFields = structType.getElements();
   if (firFields.size() != hwFields.size())
-    return cast.emitError("bundle and struct have different number of fields");
+    return emitError("bundle and struct have different number of fields");
 
   for (size_t findex = 0, fend = firFields.size(); findex < fend; ++findex) {
     if (firFields[findex].name.getValue() != hwFields[findex].name)
-      return cast.emitError("field names don't match '")
+      return emitError("field names don't match '")
              << firFields[findex].name.getValue() << "', '"
              << hwFields[findex].name.getValue() << "'";
     int64_t firWidth =
         FIRRTLType(firFields[findex].type).getBitWidthOrSentinel();
     int64_t hwWidth = hw::getBitWidth(hwFields[findex].type);
     if (firWidth > 0 && hwWidth > 0 && firWidth != hwWidth)
-      return cast.emitError("size of field '")
+      return emitError("size of field '")
              << hwFields[findex].name.getValue() << "' don't match " << firWidth
              << ", " << hwWidth;
   }
@@ -3149,24 +3148,24 @@ static LogicalResult verifyHWStructCastOp(HWStructCastOp cast) {
   return success();
 }
 
-static LogicalResult verifyBitCastOp(BitCastOp cast) {
+LogicalResult BitCastOp::verify() {
 
-  auto inTypeBits = getBitWidth(cast.getOperand().getType().cast<FIRRTLType>());
-  auto resTypeBits = getBitWidth(cast.getType());
+  auto inTypeBits = getBitWidth(getOperand().getType().cast<FIRRTLType>());
+  auto resTypeBits = getBitWidth(getType());
   if (inTypeBits.hasValue() && resTypeBits.hasValue()) {
     // Bitwidths must match for valid bitcast.
     if (inTypeBits.getValue() == resTypeBits.getValue())
       return success();
-    return cast.emitError("the bitwidth of input (")
+    return emitError("the bitwidth of input (")
            << inTypeBits.getValue() << ") and result ("
            << resTypeBits.getValue() << ") don't match";
   }
   if (!inTypeBits.hasValue())
-    return cast.emitError(
+    return emitError(
                "bitwidth cannot be determined for input operand type ")
-           << cast.getOperand().getType();
-  return cast.emitError("bitwidth cannot be determined for result type ")
-         << cast.getType();
+           << getOperand().getType();
+  return emitError("bitwidth cannot be determined for result type ")
+         << getType();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -198,10 +198,10 @@ ParseResult ConstantOp::parse(OpAsmParser &parser, OperationState &result) {
   return success();
 }
 
-static LogicalResult verifyConstantOp(ConstantOp constant) {
+LogicalResult ConstantOp::verify() {
   // If the result type has a bitwidth, then the attribute must match its width.
-  if (constant.value().getBitWidth() != constant.getType().getWidth())
-    return constant.emitError(
+  if (value().getBitWidth() != getType().getWidth())
+    return emitError(
         "hw.constant attribute bitwidth doesn't match return type");
 
   return success();
@@ -273,10 +273,10 @@ static void printParamValue(OpAsmPrinter &p, Operation *, Attribute value,
   p.printAttributeWithoutType(value);
 }
 
-static LogicalResult verifyParamValueOp(ParamValueOp op) {
+LogicalResult ParamValueOp::verify() {
   // Check that the attribute expression is valid in this module.
-  return checkParameterInContext(op.value(),
-                                 op->getParentOfType<hw::HWModuleOp>(), op);
+  return checkParameterInContext(
+      value(), (*this)->getParentOfType<hw::HWModuleOp>(), (*this));
 }
 
 OpFoldResult ParamValueOp::fold(ArrayRef<Attribute> constants) {
@@ -1017,13 +1017,9 @@ static LogicalResult verifyModuleCommon(Operation *module) {
   return success();
 }
 
-static LogicalResult verifyHWModuleOp(HWModuleOp op) {
-  return verifyModuleCommon(op);
-}
+LogicalResult HWModuleOp::verify() { return verifyModuleCommon((*this)); }
 
-static LogicalResult verifyHWModuleExternOp(HWModuleExternOp op) {
-  return verifyModuleCommon(op);
-}
+LogicalResult HWModuleExternOp::verify() { return verifyModuleCommon((*this)); }
 
 void HWModuleOp::getAsmBlockArgumentNames(mlir::Region &region,
                                           mlir::OpAsmSetValueNameFn setNameFn) {
@@ -1042,29 +1038,29 @@ Operation *HWModuleGeneratedOp::getGeneratorKindOp() {
   return topLevelModuleOp.lookupSymbol(generatorKind());
 }
 
-static LogicalResult verifyHWModuleGeneratedOp(HWModuleGeneratedOp op) {
-  if (failed(verifyModuleCommon(op)))
+LogicalResult HWModuleGeneratedOp::verify() {
+  if (failed(verifyModuleCommon((*this))))
     return failure();
 
-  auto referencedKind = op.getGeneratorKindOp();
+  auto referencedKind = getGeneratorKindOp();
   if (referencedKind == nullptr)
-    return op.emitError("Cannot find generator definition '")
-           << op.generatorKind() << "'";
+    return emitError("Cannot find generator definition '")
+           << generatorKind() << "'";
 
   if (!isa<HWGeneratorSchemaOp>(referencedKind))
-    return op.emitError("Symbol resolved to '")
+    return emitError("Symbol resolved to '")
            << referencedKind->getName()
            << "' which is not a HWGeneratorSchemaOp";
 
   auto referencedKindOp = dyn_cast<HWGeneratorSchemaOp>(referencedKind);
   auto paramRef = referencedKindOp.requiredAttrs();
-  auto dict = op->getAttrDictionary();
+  auto dict = (*this)->getAttrDictionary();
   for (auto str : paramRef) {
     auto strAttr = str.dyn_cast<StringAttr>();
     if (!strAttr)
-      return op.emitError("Unknown attribute type, expected a string");
+      return emitError("Unknown attribute type, expected a string");
     if (!dict.get(strAttr.getValue()))
-      return op.emitError("Missing attribute '") << strAttr.getValue() << "'";
+      return emitError("Missing attribute '") << strAttr.getValue() << "'";
   }
 
   return success();
@@ -1364,6 +1360,8 @@ void InstanceOp::print(OpAsmPrinter &p) {
                        "moduleName", "argNames", "resultNames", "parameters"});
 }
 
+LogicalResult InstanceOp::verify() { return this->verifyCustom(); }
+
 /// Return the name of the specified input port or null if it cannot be
 /// determined.
 StringAttr InstanceOp::getArgumentName(size_t idx) {
@@ -1427,22 +1425,22 @@ void InstanceOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 //===----------------------------------------------------------------------===//
 
 /// Verify that the num of operands and types fit the declared results.
-static LogicalResult verifyOutputOp(OutputOp *op) {
+LogicalResult OutputOp::verify() {
   // Check that the we (hw.output) have the same number of operands as our
   // region has results.
-  auto opParent = (*op)->getParentOp();
+  auto opParent = (*this)->getParentOp();
   FunctionType modType = getModuleType(opParent);
   ArrayRef<Type> modResults = modType.getResults();
-  OperandRange outputValues = op->getOperands();
+  OperandRange outputValues = getOperands();
   if (modResults.size() != outputValues.size()) {
-    op->emitOpError("must have same number of operands as region results.");
+    emitOpError("must have same number of operands as region results.");
     return failure();
   }
 
   // Check that the types of our operands and the region's results match.
   for (size_t i = 0, e = modResults.size(); i < e; ++i) {
     if (modResults[i] != outputValues[i].getType()) {
-      op->emitOpError("output types must match module. In "
+      emitOpError("output types must match module. In "
                       "operand ")
           << i << ", expected " << modResults[i] << ", but got "
           << outputValues[i].getType() << ".";
@@ -1457,7 +1455,7 @@ static LogicalResult verifyOutputOp(OutputOp *op) {
 // Other Operations
 //===----------------------------------------------------------------------===//
 
-LogicalResult GlobalRefOp::verifyGlobalRef() {
+LogicalResult GlobalRefOp::verify() {
   Operation *parent = (*this)->getParentOp();
   StringAttr symNameAttr = (*this).sym_nameAttr();
   SymbolTable symTable(parent);
@@ -1588,6 +1586,22 @@ void ArrayCreateOp::build(OpBuilder &b, OperationState &state,
              [elemType](Value v) -> bool { return v.getType() == elemType; }) &&
          "All values must have same type.");
   build(b, state, ArrayType::get(elemType, values.size()), values);
+}
+
+LogicalResult ArrayCreateOp::verify() {
+  unsigned returnSize = getType().cast<ArrayType>().getSize();
+  if (inputs().size() != returnSize)
+    return failure();
+  return success();
+}
+
+LogicalResult ArraySliceOp::verify() {
+  unsigned inputSize = type_cast<ArrayType>(input().getType()).getSize();
+  if (llvm::Log2_64_Ceil(inputSize) !=
+      lowIndex().getType().getIntOrFloatBitWidth())
+    return emitOpError(
+        "ArraySlice: index width must match clog2 of array size");
+  return success();
 }
 
 static ParseResult parseArrayConcatTypes(OpAsmParser &p,
@@ -1951,6 +1965,12 @@ LogicalResult BitcastOp::canonicalize(BitcastOp op, PatternRewriter &rewriter) {
   auto bitcast = rewriter.createOrFold<BitcastOp>(op.getLoc(), op.getType(),
                                                   inputBitcast.input());
   rewriter.replaceOp(op, bitcast);
+  return success();
+}
+
+LogicalResult BitcastOp::verify() {
+  if (getBitWidth(input().getType()) != getBitWidth(result().getType()))
+    return this->emitOpError("Bitwidth of input must match result");
   return success();
 }
 

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1441,7 +1441,7 @@ LogicalResult OutputOp::verify() {
   for (size_t i = 0, e = modResults.size(); i < e; ++i) {
     if (modResults[i] != outputValues[i].getType()) {
       emitOpError("output types must match module. In "
-                      "operand ")
+                  "operand ")
           << i << ", expected " << modResults[i] << ", but got "
           << outputValues[i].getType() << ".";
       return failure();

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1042,7 +1042,7 @@ LogicalResult HWModuleGeneratedOp::verify() {
   if (failed(verifyModuleCommon((*this))))
     return failure();
 
-  auto referencedKind = getGeneratorKindOp();
+  auto *referencedKind = getGeneratorKindOp();
   if (referencedKind == nullptr)
     return emitError("Cannot find generator definition '")
            << generatorKind() << "'";
@@ -1428,7 +1428,7 @@ void InstanceOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 LogicalResult OutputOp::verify() {
   // Check that the we (hw.output) have the same number of operands as our
   // region has results.
-  auto opParent = (*this)->getParentOp();
+  auto *opParent = (*this)->getParentOp();
   FunctionType modType = getModuleType(opParent);
   ArrayRef<Type> modResults = modType.getResults();
   OperandRange outputValues = getOperands();

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -1472,15 +1472,15 @@ LogicalResult ReturnOp::verify() {
   const auto &results = function.getType().getResults();
   if (getNumOperands() != results.size())
     return emitOpError("has ")
-           << getNumOperands()
-           << " operands, but enclosing function returns " << results.size();
+           << getNumOperands() << " operands, but enclosing function returns "
+           << results.size();
 
   for (unsigned i = 0, e = results.size(); i != e; ++i)
     if (getOperand(i).getType() != results[i])
-      return emitError()
-             << "type of return operand " << i << " ("
-             << getOperand(i).getType()
-             << ") doesn't match function result type (" << results[i] << ")";
+      return emitError() << "type of return operand " << i << " ("
+                         << getOperand(i).getType()
+                         << ") doesn't match function result type ("
+                         << results[i] << ")";
 
   return success();
 }

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -397,9 +397,9 @@ void MuxOp::print(OpAsmPrinter &p) {
   p << " : " << selectType << ", " << dataType();
 }
 
-static LogicalResult verify(MuxOp op) {
-  unsigned numDataOperands = static_cast<int>(op.dataOperands().size());
-  auto selectType = op.selectOperand().getType();
+LogicalResult MuxOp::verify() {
+  unsigned numDataOperands = static_cast<int>(dataOperands().size());
+  auto selectType = selectOperand().getType();
 
   unsigned selectBits;
   if (auto integerType = selectType.dyn_cast<IntegerType>())
@@ -407,11 +407,11 @@ static LogicalResult verify(MuxOp op) {
   else if (selectType.isIndex())
     selectBits = IndexType::kInternalStorageBitWidth;
   else
-    return op.emitError("unsupported type for select operand: ") << selectType;
+    return emitError("unsupported type for select operand: ") << selectType;
 
   double maxDataOperands = std::pow(2, selectBits);
   if (numDataOperands > maxDataOperands)
-    return op.emitError("select bitwidth was ")
+    return emitError("select bitwidth was ")
            << selectBits << ", which can mux "
            << static_cast<int64_t>(maxDataOperands) << " operands, but found "
            << numDataOperands << " operands";
@@ -476,20 +476,20 @@ ParseResult ControlMergeOp::parse(OpAsmParser &parser, OperationState &result) {
 
 void ControlMergeOp::print(OpAsmPrinter &p) { sost::printOp(p, *this, false); }
 
-static ParseResult verifyFuncOp(handshake::FuncOp op) {
+LogicalResult FuncOp::verify() {
   // If this function is external there is nothing to do.
-  if (op.isExternal())
+  if (isExternal())
     return success();
 
   // Verify that the argument list of the function and the arg list of the
   // entry block line up.  The trait already verified that the number of
   // arguments is the same between the signature and the block.
-  auto fnInputTypes = op.getType().getInputs();
-  Block &entryBlock = op.front();
+  auto fnInputTypes = getType().getInputs();
+  Block &entryBlock = front();
 
   for (unsigned i = 0, e = entryBlock.getNumArguments(); i != e; ++i)
     if (fnInputTypes[i] != entryBlock.getArgument(i).getType())
-      return op.emitOpError("type of entry block argument #")
+      return emitOpError("type of entry block argument #")
              << i << '(' << entryBlock.getArgument(i).getType()
              << ") must match the type of the corresponding argument in "
              << "function signature(" << fnInputTypes[i] << ')';
@@ -497,27 +497,28 @@ static ParseResult verifyFuncOp(handshake::FuncOp op) {
   // Verify that we have a name for each argument and result of this function.
   auto verifyPortNameAttr = [&](StringRef attrName,
                                 unsigned numIOs) -> LogicalResult {
-    auto portNamesAttr = op->getAttrOfType<ArrayAttr>(attrName);
+    auto portNamesAttr = (*this)->getAttrOfType<ArrayAttr>(attrName);
 
     if (!portNamesAttr)
-      return op.emitOpError() << "expected attribute '" << attrName << "'.";
+      return emitOpError() << "expected attribute '" << attrName << "'.";
 
     auto portNames = portNamesAttr.getValue();
     if (portNames.size() != numIOs)
-      return op.emitOpError()
-             << "attribute '" << attrName << "' has " << portNames.size()
-             << " entries but is expected to have " << numIOs << ".";
+      return emitOpError() << "attribute '" << attrName << "' has "
+                           << portNames.size()
+                           << " entries but is expected to have " << numIOs
+                           << ".";
 
     if (llvm::any_of(portNames,
                      [&](Attribute attr) { return !attr.isa<StringAttr>(); }))
-      return op.emitOpError() << "expected all entries in attribute '"
-                              << attrName << "' to be strings.";
+      return emitOpError() << "expected all entries in attribute '" << attrName
+                           << "' to be strings.";
 
     return success();
   };
-  if (failed(verifyPortNameAttr("argNames", op.getNumArguments())))
+  if (failed(verifyPortNameAttr("argNames", getNumArguments())))
     return failure();
-  if (failed(verifyPortNameAttr("resNames", op.getNumResults())))
+  if (failed(verifyPortNameAttr("resNames", getNumResults())))
     return failure();
 
   return success();
@@ -959,10 +960,10 @@ void SourceOp::print(OpAsmPrinter &p) {
   p.printOptionalAttrDict((*this)->getAttrs(), {"size", "dataType", "control"});
 }
 
-static ParseResult verifyConstantOp(handshake::ConstantOp op) {
+LogicalResult ConstantOp::verify() {
   // Verify that the type of the provided value is equal to the result type.
-  if (op->getAttr("value").getType() != op.getResult().getType())
-    return op.emitOpError()
+  if ((*this)->getAttr("value").getType() != getResult().getType())
+    return emitOpError()
            << "constant value type differs from operation result type.";
 
   return success();
@@ -989,18 +990,18 @@ void handshake::TerminatorOp::build(OpBuilder &builder, OperationState &result,
   result.addSuccessors(successors);
 }
 
-static ParseResult verifyBufferOp(handshake::BufferOp op) {
+LogicalResult BufferOp::verify() {
   // Verify that exactly 'size' number of initial values have been provided, if
   // an initializer list have been provided.
-  if (op.initValues().hasValue()) {
-    if (!op.isSequential())
-      return op.emitOpError()
+  if (initValues().hasValue()) {
+    if (!isSequential())
+      return emitOpError()
              << "only bufferType buffers are allowed to have initial values.";
 
-    auto nInits = op.initValues().getValue().size();
-    if (nInits != op.size())
-      return op.emitOpError() << "expected " << op.size()
-                              << " init values but got " << nInits << ".";
+    auto nInits = initValues().getValue().size();
+    if (nInits != size())
+      return emitOpError() << "expected " << size() << " init values but got "
+                           << nInits << ".";
   }
 
   return success();
@@ -1108,33 +1109,33 @@ std::string handshake::MemoryOp::getResultName(unsigned int idx) {
   return getMemoryResultName(ldCount(), stCount(), idx);
 }
 
-static LogicalResult verifyMemoryOp(handshake::MemoryOp op) {
-  auto memrefType = op.memRefType();
+LogicalResult handshake::MemoryOp::verify() {
+  auto memrefType = memRefType();
 
   if (memrefType.getNumDynamicDims() != 0)
-    return op.emitOpError()
+    return emitOpError()
            << "memref dimensions for handshake.memory must be static.";
   if (memrefType.getShape().size() != 1)
-    return op.emitOpError() << "memref must have only a single dimension.";
+    return emitOpError() << "memref must have only a single dimension.";
 
-  unsigned stCount = op.stCount();
-  unsigned ldCount = op.ldCount();
+  unsigned stCount = this->stCount();
+  unsigned ldCount = this->ldCount();
   int addressCount = memrefType.getShape().size();
 
-  auto inputType = op.inputs().getType();
-  auto outputType = op.outputs().getType();
+  auto inputType = inputs().getType();
+  auto outputType = outputs().getType();
   Type dataType = memrefType.getElementType();
 
-  unsigned numOperands = static_cast<int>(op.inputs().size());
-  unsigned numResults = static_cast<int>(op.outputs().size());
+  unsigned numOperands = static_cast<int>(inputs().size());
+  unsigned numResults = static_cast<int>(outputs().size());
   if (numOperands != (1 + addressCount) * stCount + addressCount * ldCount)
-    return op.emitOpError("number of operands ")
+    return emitOpError("number of operands ")
            << numOperands << " does not match number expected of "
            << 2 * stCount + ldCount << " with " << addressCount
            << " address inputs per port";
 
   if (numResults != stCount + 2 * ldCount)
-    return op.emitOpError("number of results ")
+    return emitOpError("number of results ")
            << numResults << " does not match number expected of "
            << stCount + 2 * ldCount << " with " << addressCount
            << " address inputs per port";
@@ -1143,37 +1144,37 @@ static LogicalResult verifyMemoryOp(handshake::MemoryOp op) {
 
   for (unsigned i = 0; i < stCount; i++) {
     if (inputType[2 * i] != dataType)
-      return op.emitOpError("data type for store port ")
+      return emitOpError("data type for store port ")
              << i << ":" << inputType[2 * i] << " doesn't match memory type "
              << dataType;
     if (inputType[2 * i + 1] != addressType)
-      return op.emitOpError("address type for store port ")
+      return emitOpError("address type for store port ")
              << i << ":" << inputType[2 * i + 1]
              << " doesn't match address type " << addressType;
   }
   for (unsigned i = 0; i < ldCount; i++) {
     Type ldAddressType = inputType[2 * stCount + i];
     if (ldAddressType != addressType)
-      return op.emitOpError("address type for load port ")
+      return emitOpError("address type for load port ")
              << i << ":" << ldAddressType << " doesn't match address type "
              << addressType;
   }
   for (unsigned i = 0; i < ldCount; i++) {
     if (outputType[i] != dataType)
-      return op.emitOpError("data type for load port ")
+      return emitOpError("data type for load port ")
              << i << ":" << outputType[i] << " doesn't match memory type "
              << dataType;
   }
   for (unsigned i = 0; i < stCount; i++) {
     Type syncType = outputType[ldCount + i];
     if (!syncType.isa<NoneType>())
-      return op.emitOpError("data type for sync port for store port ")
+      return emitOpError("data type for sync port for store port ")
              << i << ":" << syncType << " is not 'none'";
   }
   for (unsigned i = 0; i < ldCount; i++) {
     Type syncType = outputType[ldCount + stCount + i];
     if (!syncType.isa<NoneType>())
-      return op.emitOpError("data type for sync port for load port ")
+      return emitOpError("data type for sync port for load port ")
              << i << ":" << syncType << " is not 'none'";
   }
 
@@ -1382,9 +1383,7 @@ static LogicalResult verifyMemoryAccessOp(TMemoryOp op) {
   return success();
 }
 
-static LogicalResult verifyLoadOp(handshake::LoadOp op) {
-  return verifyMemoryAccessOp(op);
-}
+LogicalResult LoadOp::verify() { return verifyMemoryAccessOp((*this)); }
 
 std::string handshake::StoreOp::getResultName(unsigned int idx) {
   std::string resName;
@@ -1411,9 +1410,7 @@ void handshake::StoreOp::build(OpBuilder &builder, OperationState &result,
   result.types.append(indices.size(), builder.getIndexType());
 }
 
-static LogicalResult verifyStoreOp(handshake::StoreOp op) {
-  return verifyMemoryAccessOp(op);
-}
+LogicalResult StoreOp::verify() { return verifyMemoryAccessOp((*this)); }
 
 ParseResult StoreOp::parse(OpAsmParser &parser, OperationState &result) {
   return parseMemoryAccessOp(parser, result);
@@ -1450,12 +1447,12 @@ ParseResult JoinOp::parse(OpAsmParser &parser, OperationState &result) {
 
 void JoinOp::print(OpAsmPrinter &p) { sost::printOp(p, *this, false); }
 
-static LogicalResult verifyInstanceOp(handshake::InstanceOp op) {
-  if (op->getNumOperands() == 0)
-    return op.emitOpError() << "must provide at least a control operand.";
+LogicalResult InstanceOp::verify() {
+  if ((*this)->getNumOperands() == 0)
+    return emitOpError() << "must provide at least a control operand.";
 
-  if (!op.getControl().getType().dyn_cast<NoneType>())
-    return op.emitOpError()
+  if (!getControl().getType().dyn_cast<NoneType>())
+    return emitOpError()
            << "last operand must be a control (none-typed) operand.";
 
   return success();
@@ -1465,24 +1462,24 @@ static LogicalResult verifyInstanceOp(handshake::InstanceOp op) {
 // TableGen'd op method definitions
 //===----------------------------------------------------------------------===//
 
-static LogicalResult verify(handshake::ReturnOp op) {
-  auto *parent = op->getParentOp();
+LogicalResult ReturnOp::verify() {
+  auto *parent = (*this)->getParentOp();
   auto function = dyn_cast<handshake::FuncOp>(parent);
   if (!function)
-    return op.emitOpError("must have a handshake.func parent");
+    return emitOpError("must have a handshake.func parent");
 
   // The operand number and types must match the function signature.
   const auto &results = function.getType().getResults();
-  if (op.getNumOperands() != results.size())
-    return op.emitOpError("has ")
-           << op.getNumOperands()
+  if (getNumOperands() != results.size())
+    return emitOpError("has ")
+           << getNumOperands()
            << " operands, but enclosing function returns " << results.size();
 
   for (unsigned i = 0, e = results.size(); i != e; ++i)
-    if (op.getOperand(i).getType() != results[i])
-      return op.emitError()
+    if (getOperand(i).getType() != results[i])
+      return emitError()
              << "type of return operand " << i << " ("
-             << op.getOperand(i).getType()
+             << getOperand(i).getType()
              << ") doesn't match function result type (" << results[i] << ")";
 
   return success();

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -732,27 +732,27 @@ void MSFTModuleExternOp::print(OpAsmPrinter &p) {
                           omittedAttrs);
 }
 
-static LogicalResult verifyMSFTModuleExternOp(MSFTModuleExternOp module) {
+LogicalResult MSFTModuleExternOp::verify() {
   using namespace mlir::function_interface_impl;
-  auto typeAttr = module->getAttrOfType<TypeAttr>(getTypeAttrName());
+  auto typeAttr = (*this)->getAttrOfType<TypeAttr>(getTypeAttrName());
   auto moduleType = typeAttr.getValue().cast<FunctionType>();
-  auto argNames = module->getAttrOfType<ArrayAttr>("argNames");
-  auto resultNames = module->getAttrOfType<ArrayAttr>("resultNames");
+  auto argNames = (*this)->getAttrOfType<ArrayAttr>("argNames");
+  auto resultNames = (*this)->getAttrOfType<ArrayAttr>("resultNames");
   if (argNames.size() != moduleType.getNumInputs())
-    return module->emitOpError("incorrect number of argument names");
+    return emitOpError("incorrect number of argument names");
   if (resultNames.size() != moduleType.getNumResults())
-    return module->emitOpError("incorrect number of result names");
+    return emitOpError("incorrect number of result names");
 
   SmallPtrSet<Attribute, 4> paramNames;
 
   // Check parameter default values are sensible.
-  for (auto param : module->getAttrOfType<ArrayAttr>("parameters")) {
+  for (auto param : (*this)->getAttrOfType<ArrayAttr>("parameters")) {
     auto paramAttr = param.cast<hw::ParamDeclAttr>();
 
     // Check that we don't have any redundant parameter names.  These are
     // resolved by string name: reuse of the same name would cause ambiguities.
     if (!paramNames.insert(paramAttr.getName()).second)
-      return module->emitOpError("parameter ")
+      return emitOpError("parameter ")
              << paramAttr << " has the same name as a previous parameter";
 
     // Default values are allowed to be missing, check them if present.
@@ -761,7 +761,7 @@ static LogicalResult verifyMSFTModuleExternOp(MSFTModuleExternOp module) {
       continue;
 
     if (value.getType() != paramAttr.getType().getValue())
-      return module->emitOpError("parameter ")
+      return emitOpError("parameter ")
              << paramAttr << " should have type "
              << paramAttr.getType().getValue() << "; has type "
              << value.getType();
@@ -769,7 +769,7 @@ static LogicalResult verifyMSFTModuleExternOp(MSFTModuleExternOp module) {
     // Verify that this is a valid parameter value, disallowing parameter
     // references.  We could allow parameters to refer to each other in the
     // future with lexical ordering if there is a need.
-    if (failed(checkParameterInContext(value, module, module,
+    if (failed(checkParameterInContext(value, *this, *this,
                                        /*disallowParamRefs=*/true)))
       return failure();
   }

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -761,10 +761,9 @@ LogicalResult MSFTModuleExternOp::verify() {
       continue;
 
     if (value.getType() != paramAttr.getType().getValue())
-      return emitOpError("parameter ")
-             << paramAttr << " should have type "
-             << paramAttr.getType().getValue() << "; has type "
-             << value.getType();
+      return emitOpError("parameter ") << paramAttr << " should have type "
+                                       << paramAttr.getType().getValue()
+                                       << "; has type " << value.getType();
 
     // Verify that this is a valid parameter value, disallowing parameter
     // references.  We could allow parameters to refer to each other in the

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -26,6 +26,7 @@
 using namespace circt;
 using namespace sv;
 
+static LogicalResult verifyIndexedPartSelectOp(Operation *op);
 /// Return true if the specified operation is an expression.
 bool sv::isExpression(Operation *op) {
   return isa<VerbatimExprOp, VerbatimExprSEOp, GetModportOp,
@@ -175,10 +176,10 @@ void ConstantXOp::getAsmResultNames(
   setNameFn(getResult(), specialName.str());
 }
 
-static LogicalResult verifyConstantXOp(ConstantXOp op) {
+LogicalResult ConstantXOp::verify() {
   // We don't allow zero width constant or unknown width.
-  if (op.getWidth() <= 0)
-    return op.emitError("unsupported type");
+  if (getWidth() <= 0)
+    return emitError("unsupported type");
   return success();
 }
 
@@ -190,10 +191,10 @@ void ConstantZOp::getAsmResultNames(
   setNameFn(getResult(), specialName.str());
 }
 
-static LogicalResult verifyConstantZOp(ConstantZOp op) {
+LogicalResult ConstantZOp::verify() {
   // We don't allow zero width constant or unknown type.
-  if (op.getWidth() <= 0)
-    return op.emitError("unsupported type");
+  if (getWidth() <= 0)
+    return emitError("unsupported type");
   return success();
 }
 
@@ -208,10 +209,10 @@ void LocalParamOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
     setNameFn(getResult(), nameAttr.getValue());
 }
 
-static LogicalResult verifyLocalParamOp(LocalParamOp op) {
+LogicalResult LocalParamOp::verify() {
   // Verify that this is a valid parameter value.
-  return hw::checkParameterInContext(op.value(),
-                                     op->getParentOfType<hw::HWModuleOp>(), op);
+  return hw::checkParameterInContext(
+      value(), (*this)->getParentOfType<hw::HWModuleOp>(), (*this));
 }
 
 //===----------------------------------------------------------------------===//
@@ -420,9 +421,9 @@ void AlwaysOp::build(OpBuilder &builder, OperationState &result,
 }
 
 /// Ensure that the symbol being instantiated exists and is an InterfaceOp.
-static LogicalResult verifyAlwaysOp(AlwaysOp op) {
-  if (op.events().size() != op.getNumOperands())
-    return op.emitError("different number of operands and events");
+LogicalResult AlwaysOp::verify() {
+  if (events().size() != getNumOperands())
+    return emitError("different number of operands and events");
   return success();
 }
 
@@ -736,10 +737,10 @@ void CaseZOp::print(OpAsmPrinter &p) {
   }
 }
 
-static LogicalResult verifyCaseZOp(CaseZOp op) {
+LogicalResult CaseZOp::verify() {
   // Ensure that the number of regions and number of case values match.
-  if (op.casePatterns().size() != op.getNumRegions())
-    return op.emitOpError("case pattern / region count mismatch");
+  if (casePatterns().size() != getNumRegions())
+    return emitOpError("case pattern / region count mismatch");
   return success();
 }
 
@@ -766,17 +767,17 @@ void CaseZOp::build(OpBuilder &builder, OperationState &result, Value cond,
 // Assignment statements
 //===----------------------------------------------------------------------===//
 
-static LogicalResult verifyBPAssignOp(BPAssignOp op) {
-  if (isa<sv::WireOp>(op.dest().getDefiningOp()))
-    return op.emitOpError(
+LogicalResult BPAssignOp::verify() {
+  if (isa<sv::WireOp>(dest().getDefiningOp()))
+    return emitOpError(
         "Verilog disallows procedural assignment to a net type (did you intend "
         "to use a variable type, e.g., sv.reg?)");
   return success();
 }
 
-static LogicalResult verifyPAssignOp(PAssignOp op) {
-  if (isa<sv::WireOp>(op.dest().getDefiningOp()))
-    return op.emitOpError(
+LogicalResult PAssignOp::verify() {
+  if (isa<sv::WireOp>(dest().getDefiningOp()))
+    return emitOpError(
         "Verilog disallows procedural assignment to a net type (did you intend "
         "to use a variable type, e.g., sv.reg?)");
   return success();
@@ -871,36 +872,36 @@ void InterfaceModportOp::build(OpBuilder &builder, OperationState &state,
 }
 
 /// Ensure that the symbol being instantiated exists and is an InterfaceOp.
-static LogicalResult verifyInterfaceInstanceOp(InterfaceInstanceOp op) {
-  auto symtable = SymbolTable::getNearestSymbolTable(op);
+LogicalResult InterfaceInstanceOp::verify() {
+  auto symtable = SymbolTable::getNearestSymbolTable((*this));
   if (!symtable)
-    return op.emitError("sv.interface.instance must exist within a region "
-                        "which has a symbol table.");
-  auto ifaceTy = op.getType();
+    return emitError("sv.interface.instance must exist within a region "
+                     "which has a symbol table.");
+  auto ifaceTy = getType();
   auto referencedOp =
       SymbolTable::lookupSymbolIn(symtable, ifaceTy.getInterface());
   if (!referencedOp)
-    return op.emitError("Symbol not found: ") << ifaceTy.getInterface() << ".";
+    return emitError("Symbol not found: ") << ifaceTy.getInterface() << ".";
   if (!isa<InterfaceOp>(referencedOp))
-    return op.emitError("Symbol ")
+    return emitError("Symbol ")
            << ifaceTy.getInterface() << " is not an InterfaceOp.";
   return success();
 }
 
 /// Ensure that the symbol being instantiated exists and is an
 /// InterfaceModportOp.
-static LogicalResult verifyGetModportOp(GetModportOp op) {
-  auto symtable = SymbolTable::getNearestSymbolTable(op);
+LogicalResult GetModportOp::verify() {
+  auto symtable = SymbolTable::getNearestSymbolTable((*this));
   if (!symtable)
-    return op.emitError("sv.interface.instance must exist within a region "
-                        "which has a symbol table.");
-  auto ifaceTy = op.getType();
+    return emitError("sv.interface.instance must exist within a region "
+                     "which has a symbol table.");
+  auto ifaceTy = getType();
   auto referencedOp =
       SymbolTable::lookupSymbolIn(symtable, ifaceTy.getModport());
   if (!referencedOp)
-    return op.emitError("Symbol not found: ") << ifaceTy.getModport() << ".";
+    return emitError("Symbol not found: ") << ifaceTy.getModport() << ".";
   if (!isa<InterfaceModportOp>(referencedOp))
-    return op.emitError("Symbol ")
+    return emitError("Symbol ")
            << ifaceTy.getModport() << " is not an InterfaceModportOp.";
   return success();
 }
@@ -1068,9 +1069,9 @@ LogicalResult WireOp::canonicalize(WireOp wire, PatternRewriter &rewriter) {
 }
 
 /// Ensure that the symbol being instantiated exists and is an InterfaceOp.
-static LogicalResult verifyWireOp(WireOp op) {
-  if (!isa<hw::HWModuleOp>(op->getParentOp()))
-    return op.emitError("sv.wire must not be in an always or initial block");
+LogicalResult WireOp::verify() {
+  if (!isa<hw::HWModuleOp>((*this)->getParentOp()))
+    return emitError("sv.wire must not be in an always or initial block");
   return success();
 }
 
@@ -1121,6 +1122,10 @@ LogicalResult IndexedPartSelectInOutOp::inferReturnTypes(
   return success();
 }
 
+LogicalResult IndexedPartSelectInOutOp::verify() {
+  return verifyIndexedPartSelectOp(*this);
+}
+
 OpFoldResult IndexedPartSelectInOutOp::fold(ArrayRef<Attribute> constants) {
   if (getType() == input().getType())
     return input();
@@ -1136,6 +1141,10 @@ void IndexedPartSelectOp::build(OpBuilder &builder, OperationState &result,
                                 bool decrement) {
   auto resultType = (IntegerType::get(builder.getContext(), width));
   build(builder, result, resultType, input, base, width, decrement);
+}
+
+LogicalResult IndexedPartSelectOp::verify() {
+  return verifyIndexedPartSelectOp(*this);
 }
 
 LogicalResult IndexedPartSelectOp::inferReturnTypes(
@@ -1215,10 +1224,10 @@ LogicalResult StructFieldInOutOp::inferReturnTypes(
 // Other ops.
 //===----------------------------------------------------------------------===//
 
-static LogicalResult verifyAliasOp(AliasOp op) {
+LogicalResult AliasOp::verify() {
   // Must have at least two operands.
-  if (op.operands().size() < 2)
-    return op.emitOpError("alias must have at least two operands");
+  if (operands().size() < 2)
+    return emitOpError("alias must have at least two operands");
 
   return success();
 }
@@ -1328,12 +1337,12 @@ hw::InstanceOp BindOp::getReferencedInstance(const hw::SymbolCache *cache) {
 }
 
 /// Ensure that the symbol being instantiated exists and is an InterfaceOp.
-static LogicalResult verifyBindOp(BindOp op) {
-  auto inst = op.getReferencedInstance();
+LogicalResult BindOp::verify() {
+  auto inst = getReferencedInstance();
   if (!inst)
-    return op.emitError("Referenced instance doesn't exist");
+    return emitError("Referenced instance doesn't exist");
   if (!inst->getAttr("doNotPrint"))
-    return op.emitError("Referenced instance isn't marked as doNotPrint");
+    return emitError("Referenced instance isn't marked as doNotPrint");
   return success();
 }
 
@@ -1370,12 +1379,12 @@ BindInterfaceOp::getReferencedInstance(const hw::SymbolCache *cache) {
 }
 
 /// Ensure that the symbol being instantiated exists and is an InterfaceOp.
-static LogicalResult verifyBindInterfaceOp(BindInterfaceOp op) {
-  auto inst = op.getReferencedInstance();
+LogicalResult BindInterfaceOp::verify() {
+  auto inst = getReferencedInstance();
   if (!inst)
-    return op.emitError("Referenced interface doesn't exist");
+    return emitError("Referenced interface doesn't exist");
   if (!inst->getAttr("doNotPrint"))
-    return op.emitError("Referenced interface isn't marked as doNotPrint");
+    return emitError("Referenced interface isn't marked as doNotPrint");
   return success();
 }
 

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -873,7 +873,7 @@ void InterfaceModportOp::build(OpBuilder &builder, OperationState &state,
 
 /// Ensure that the symbol being instantiated exists and is an InterfaceOp.
 LogicalResult InterfaceInstanceOp::verify() {
-  auto symtable = SymbolTable::getNearestSymbolTable((*this));
+  auto *symtable = SymbolTable::getNearestSymbolTable((*this));
   if (!symtable)
     return emitError("sv.interface.instance must exist within a region "
                      "which has a symbol table.");
@@ -891,7 +891,7 @@ LogicalResult InterfaceInstanceOp::verify() {
 /// Ensure that the symbol being instantiated exists and is an
 /// InterfaceModportOp.
 LogicalResult GetModportOp::verify() {
-  auto symtable = SymbolTable::getNearestSymbolTable((*this));
+  auto *symtable = SymbolTable::getNearestSymbolTable((*this));
   if (!symtable)
     return emitError("sv.interface.instance must exist within a region "
                      "which has a symbol table.");

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -994,6 +994,14 @@ InterfaceInstanceOp::getReferencedInterface(const hw::SymbolCache *cache) {
   return topLevelModuleOp.lookupSymbol(interface);
 }
 
+LogicalResult AssignInterfaceSignalOp::verify() {
+  return verifySignalExists(iface(), signalNameAttr());
+}
+
+LogicalResult ReadInterfaceSignalOp::verify() {
+  return verifySignalExists(iface(), signalNameAttr());
+}
+
 //===----------------------------------------------------------------------===//
 // WireOp
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/StaticLogic/StaticLogicOps.cpp
+++ b/lib/Dialect/StaticLogic/StaticLogicOps.cpp
@@ -105,15 +105,15 @@ void PipelineWhileOp::print(OpAsmPrinter &p) {
   p.printRegion(stages(), /*printEntryBlockArgs=*/false);
 }
 
-static LogicalResult verifyPipelineWhileOp(PipelineWhileOp op) {
+LogicalResult PipelineWhileOp::verify() {
   // Verify trip count is not negative.
-  if (op.tripCount() && *op.tripCount() < 0)
-    return op.emitOpError("trip count must not be negative, found ")
-           << *op.tripCount();
+  if (tripCount() && *tripCount() < 0)
+    return emitOpError("trip count must not be negative, found ")
+           << *tripCount();
 
   // Verify the condition block is "combinational" based on an allowlist of
   // Arithmetic ops.
-  Block &conditionBlock = op.condition().front();
+  Block &conditionBlock = condition().front();
   Operation *nonCombinational;
   WalkResult conditionWalk = conditionBlock.walk([&](Operation *op) {
     if (isa<StaticLogicDialect>(op->getDialect()))
@@ -134,32 +134,32 @@ static LogicalResult verifyPipelineWhileOp(PipelineWhileOp op) {
   });
 
   if (conditionWalk.wasInterrupted())
-    return op.emitOpError("condition must have a combinational body, found ")
+    return emitOpError("condition must have a combinational body, found ")
            << *nonCombinational;
 
   // Verify the condition block terminates with a value of type i1.
   TypeRange conditionResults =
       conditionBlock.getTerminator()->getOperandTypes();
   if (conditionResults.size() != 1)
-    return op.emitOpError(
+    return emitOpError(
                "condition must terminate with a single result, found ")
            << conditionResults;
 
-  if (conditionResults.front() != IntegerType::get(op.getContext(), 1))
-    return op.emitOpError("condition must terminate with an i1 result, found ")
+  if (conditionResults.front() != IntegerType::get(getContext(), 1))
+    return emitOpError("condition must terminate with an i1 result, found ")
            << conditionResults.front();
 
   // Verify the stages block contains at least one stage and a terminator.
-  Block &stagesBlock = op.stages().front();
+  Block &stagesBlock = stages().front();
   if (stagesBlock.getOperations().size() < 2)
-    return op.emitOpError("stages must contain at least one stage");
+    return emitOpError("stages must contain at least one stage");
 
   int64_t lastStartTime = -1;
   for (Operation &inner : stagesBlock) {
     // Verify the stages block contains only `staticlogic.pipeline.stage` and
     // `staticlogic.pipeline.terminator` ops.
     if (!isa<PipelineStageOp, PipelineTerminatorOp>(inner))
-      return op.emitOpError(
+      return emitOpError(
                  "stages may only contain 'staticlogic.pipeline.stage' or "
                  "'staticlogic.pipeline.terminator' ops, found ")
              << inner;
@@ -216,9 +216,9 @@ void PipelineWhileOp::build(OpBuilder &builder, OperationState &state,
 // PipelineStageOp
 //===----------------------------------------------------------------------===//
 
-static LogicalResult verifyPipelineStageOp(PipelineStageOp op) {
-  if (op.start() < 0)
-    return op.emitOpError("'start' must be non-negative");
+LogicalResult PipelineStageOp::verify() {
+  if (start() < 0)
+    return emitOpError("'start' must be non-negative");
 
   return success();
 }
@@ -240,18 +240,18 @@ void PipelineStageOp::build(OpBuilder &builder, OperationState &state,
 // PipelineRegisterOp
 //===----------------------------------------------------------------------===//
 
-static LogicalResult verifyPipelineRegisterOp(PipelineRegisterOp op) {
-  PipelineStageOp stage = op->getParentOfType<PipelineStageOp>();
+LogicalResult PipelineRegisterOp::verify() {
+  PipelineStageOp stage = (*this)->getParentOfType<PipelineStageOp>();
 
   // If this doesn't terminate a stage, it is terminating the condition.
   if (stage == nullptr)
     return success();
 
   // Verify stage terminates with the same types as the result types.
-  TypeRange registerTypes = op.getOperandTypes();
+  TypeRange registerTypes = getOperandTypes();
   TypeRange resultTypes = stage.getResultTypes();
   if (registerTypes != resultTypes)
-    return op.emitOpError("operand types (")
+    return emitOpError("operand types (")
            << registerTypes << ") must match result types (" << resultTypes
            << ")";
 
@@ -274,37 +274,37 @@ unsigned PipelineStageOp::getStageNumber() {
 // PipelineTerminatorOp
 //===----------------------------------------------------------------------===//
 
-static LogicalResult verifyPipelineTerminatorOp(PipelineTerminatorOp op) {
-  PipelineWhileOp pipeline = op->getParentOfType<PipelineWhileOp>();
+LogicalResult PipelineTerminatorOp::verify() {
+  PipelineWhileOp pipeline = (*this)->getParentOfType<PipelineWhileOp>();
 
   // Verify pipeline terminates with the same `iter_args` types as the pipeline.
-  auto iterArgs = op.iter_args();
+  auto iterArgs = iter_args();
   TypeRange terminatorArgTypes = iterArgs.getTypes();
   TypeRange pipelineArgTypes = pipeline.iterArgs().getTypes();
   if (terminatorArgTypes != pipelineArgTypes)
-    return op.emitOpError("'iter_args' types (")
+    return emitOpError("'iter_args' types (")
            << terminatorArgTypes << ") must match pipeline 'iter_args' types ("
            << pipelineArgTypes << ")";
 
   // Verify `iter_args` are defined by a pipeline stage.
   for (auto iterArg : iterArgs)
     if (iterArg.getDefiningOp<PipelineStageOp>() == nullptr)
-      return op.emitOpError(
+      return emitOpError(
           "'iter_args' must be defined by a 'staticlogic.pipeline.stage'");
 
   // Verify pipeline terminates with the same result types as the pipeline.
-  auto results = op.results();
+  auto results = (*this).results();
   TypeRange terminatorResultTypes = results.getTypes();
   TypeRange pipelineResultTypes = pipeline.getResultTypes();
   if (terminatorResultTypes != pipelineResultTypes)
-    return op.emitOpError("'results' types (")
+    return emitOpError("'results' types (")
            << terminatorResultTypes << ") must match pipeline result types ("
            << pipelineResultTypes << ")";
 
   // Verify `results` are defined by a pipeline stage.
   for (auto result : results)
     if (result.getDefiningOp<PipelineStageOp>() == nullptr)
-      return op.emitOpError(
+      return emitOpError(
           "'results' must be defined by a 'staticlogic.pipeline.stage'");
 
   return success();

--- a/lib/Dialect/StaticLogic/StaticLogicOps.cpp
+++ b/lib/Dialect/StaticLogic/StaticLogicOps.cpp
@@ -141,8 +141,7 @@ LogicalResult PipelineWhileOp::verify() {
   TypeRange conditionResults =
       conditionBlock.getTerminator()->getOperandTypes();
   if (conditionResults.size() != 1)
-    return emitOpError(
-               "condition must terminate with a single result, found ")
+    return emitOpError("condition must terminate with a single result, found ")
            << conditionResults;
 
   if (conditionResults.front() != IntegerType::get(getContext(), 1))


### PR DESCRIPTION
Issue is in [link](https://github.com/llvm/circt/issues/2774)
Fix most Operations in td files.
Left  `verifier` in some operation with `class` type not done, need some more work.
I don't know who to require for review because this patch covers a large part.