### PR TITLE
[FIRParser] Don't bulk connect bundles with analog in them

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1636,10 +1636,11 @@ private:
 void FIRStmtParser::emitInvalidate(Value val, Flow flow) {
   auto tpe = val.getType().cast<FIRRTLType>();
 
-  if (tpe.isPassive()) {
-    if (flow == Flow::Source || tpe.isa<AnalogType>())
+  auto props = tpe.getRecursiveTypeProperties();
+  if (props.isPassive && !props.containsAnalog) {
+    if (flow == Flow::Source)
       return;
-    if (tpe.hasUninferredWidth())
+    if (props.hasUninferredWidth)
       builder.create<ConnectOp>(val, builder.create<InvalidValueOp>(tpe));
     else
       builder.create<StrictConnectOp>(val, builder.create<InvalidValueOp>(tpe));

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -76,7 +76,8 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input s1 : SInt<1>            ; CHECK: in %s1: !firrtl.sint<1>,
     input s8 : SInt<8>            ; CHECK: in %s8: !firrtl.sint<8>,
     input a1 : Analog<1>          ; CHECK: in %a1: !firrtl.analog<1>,
-    input a8 : Analog<8>          ; CHECK: in %a8: !firrtl.analog<8>)
+    input a8 : Analog<8>          ; CHECK: in %a8: !firrtl.analog<8>,
+    input ab : {x : Analog<1>}    ; CHECK: in %ab: !firrtl.bundle<x: analog<1>>)
 
     ; CHECK: %_t = firrtl.wire : !firrtl.vector<uint<1>, 12>
     wire _t : UInt<1>[12] @[Nodes.scala 370:76]
@@ -96,6 +97,9 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     ; CHECK-NOT: firrtl.attach %a1
     a1 is invalid
+    
+    ; CHECK-NOT: firrtl.attach %ab
+    ab is invalid
 
     ; CHECK: firrtl.skip
     skip  @[SKipLoc.scala 42:24]


### PR DESCRIPTION
This is a small regression from dd873d9824f6. When an analog is inside a
bundle which is `is invalid`ated, we need to ensure that we don't
connect the analog value.