### PR TITLE
[InferReadWrite] Identify StrictConnectOp patterns along with ConnectOp

### DIFF
--- a/test/Dialect/FIRRTL/inferRW.mlir
+++ b/test/Dialect/FIRRTL/inferRW.mlir
@@ -37,10 +37,10 @@ firrtl.circuit "TLRAM" {
 
 // CHECK: %mem_0_rw = firrtl.mem Undefined  {depth = 16 : i64, name = "mem_0", portNames = ["rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, wdata: uint<8>, wmask: uint<1>>
 // CHECK:  %[[v7:.+]] = firrtl.mux(%[[writeEnable:.+]], %[[writeAddr:.+]], %[[readAddr:.+]]) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-// CHECK:  firrtl.connect %[[v0:.+]], %[[v7]] : !firrtl.uint<4>, !firrtl.uint<4>
+// CHECK:  firrtl.strictconnect %[[v0:.+]], %[[v7]] : !firrtl.uint<4>
 // CHECK:  %[[v8:.+]] = firrtl.or %[[readEnable:.+]], %[[writeEnable]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:  firrtl.connect %[[v1:.+]], %[[v8]] : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:  firrtl.connect %[[v4:.+]], %[[writeEnable]] : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK:  firrtl.strictconnect %[[v1:.+]], %[[v8]] : !firrtl.uint<1>
+// CHECK:  firrtl.strictconnect %[[v4:.+]], %[[writeEnable]]
 // CHECK:  firrtl.connect %[[readAddr]], %[[index2:.+]] : !firrtl.uint<4>, !firrtl.uint<4>
 // CHECK:  firrtl.connect %[[readEnable]], %mem_MPORT_en : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:  firrtl.connect %[[writeAddr]], %index : !firrtl.uint<4>, !firrtl.uint<4>
@@ -86,7 +86,7 @@ firrtl.circuit "TLRAM" {
     %mem__T_14, %mem__T_22 = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["_T_14", "_T_22"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>, !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
 // CHECK: %mem_rw = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
 // CHECK:   %[[v7:.+]] = firrtl.mux(%writeEnable, %writeAddr, %readAddr) : (!firrtl.uint<1>, !firrtl.uint<11>, !firrtl.uint<11>) -> !firrtl.uint<11>
-// CHECK:   firrtl.connect %[[v0:.+]], %[[v7]] : !firrtl.uint<11>, !firrtl.uint<11>
+// CHECK:   firrtl.strictconnect %[[v0:.+]], %[[v7]]
 // CHECK:   %[[v8:.+]] = firrtl.or %readEnable, %writeEnable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     %0 = firrtl.subfield %mem__T_14(0) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<11>
     %1 = firrtl.subfield %mem__T_14(1) : (!firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>) -> !firrtl.uint<1>
@@ -246,7 +246,7 @@ firrtl.circuit "TLRAM" {
       // CHECK: %mem_0_rw = firrtl.mem Undefined  {depth = 16 : i64, name = "mem_0", portNames = ["rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, wdata: uint<8>, wmask: uint<1>>
       // CHECK: %[[v6:.+]] = firrtl.subfield %mem_0_rw(6) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, wdata: uint<8>, wmask: uint<1>>) -> !firrtl.uint<1>
       // CHECK: %[[c1_ui1:.+]] = firrtl.constant 1 : !firrtl.uint<1>
-      // CHECK: firrtl.connect %[[v6]], %[[c1_ui1]] : !firrtl.uint<1>, !firrtl.uint<1>
+      // CHECK: firrtl.strictconnect %[[v6]], %[[c1_ui1]]
       %0 = firrtl.subfield %mem_0_MPORT(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.uint<4>
       firrtl.connect %0, %index2 : !firrtl.uint<4>, !firrtl.uint<4>
       %1 = firrtl.subfield %mem_0_MPORT(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>) -> !firrtl.uint<1>


### PR DESCRIPTION
This commit fixes an issue with `InferReadWrite`, where it was not considering
 `StrictConnectOp` along with `ConnectOp`.
After #2615, `ConnectOp` patterns were replaced with `StrictConnectOp`, and
 the `InferReadWrite` pass was not identifying the mutually exclusive read
 and write enables anymore.
Also generate `StrictConnectOp` instead of the `ConnectOp` and fix the lit tests.