### PR TITLE
[FIRRTL][LowerToHW] Find the DUT in a prepass

### DIFF
--- a/include/circt/Support/LLVM.h
+++ b/include/circt/Support/LLVM.h
@@ -150,6 +150,7 @@ class TypeConverter;
 class TypeID;
 class TypeRange;
 class TypeStorage;
+class UnitAttr;
 class UnknownLoc;
 class Value;
 class ValueRange;
@@ -264,6 +265,7 @@ using mlir::TypeConverter;             // NOLINT(misc-unused-using-decls)
 using mlir::TypeID;                    // NOLINT(misc-unused-using-decls)
 using mlir::TypeRange;                 // NOLINT(misc-unused-using-decls)
 using mlir::TypeStorage;               // NOLINT(misc-unused-using-decls)
+using mlir::UnitAttr;                  // NOLINT(misc-unused-using-decls)
 using mlir::UnknownLoc;                // NOLINT(misc-unused-using-decls)
 using mlir::Value;                     // NOLINT(misc-unused-using-decls)
 using mlir::ValueRange;                // NOLINT(misc-unused-using-decls)

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1117,6 +1117,29 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.force %out, %in : !firrtl.uint<42>, !firrtl.uint<42>
   }
 
+  firrtl.extmodule @chkcoverAnno(in clock: !firrtl.clock) attributes {annotations = [{class = "freechips.rocketchip.annotations.InternalVerifBlackBoxAnnotation"}]}
+  // chckcoverAnno is extracted because it is instantiated inside the DUT.
+  // CHECK-LABEL: hw.module.extern @chkcoverAnno(%clock: i1)
+  // CHECK-SAME: attributes {firrtl.extract.cover.extra}
+
+  firrtl.extmodule @chkcoverAnno2(in clock: !firrtl.clock) attributes {annotations = [{class = "freechips.rocketchip.annotations.InternalVerifBlackBoxAnnotation"}]}
+  // checkcoverAnno2 is NOT extracted because it is not instantiated under the
+  // DUT.
+  // CHECK-LABEL: hw.module.extern @chkcoverAnno2(%clock: i1)
+  // CHECK-NOT: attributes {firrtl.extract.cover.extra}
+
+  // CHECK-LABEL: hw.module.extern @InnerNamesExt
+  // CHECK-SAME:  (
+  // CHECK-SAME:    clockIn: i1 {hw.exportPort = @extClockInSym}
+  // CHECK-SAME:  ) -> (
+  // CHECK-SAME:    clockOut: i1 {hw.exportPort = @extClockOutSym}
+  // CHECK-SAME:  )
+  firrtl.extmodule @InnerNamesExt(
+    in clockIn: !firrtl.clock sym @extClockInSym,
+    out clockOut: !firrtl.clock sym @extClockOutSym
+  )
+  attributes {annotations = [{class = "freechips.rocketchip.annotations.InternalVerifBlackBoxAnnotation"}]}
+
   // CHECK-LABEL: hw.module @FooDUT
   firrtl.module @FooDUT() attributes {annotations = [
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
@@ -1228,29 +1251,6 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %b = firrtl.bitcast %a : (!firrtl.bundle<valid: uint<2>, ready: uint<1>, data: uint<3>>) -> (!firrtl.vector<uint<2>, 3>)
     // CHECK: hw.bitcast %0 : (!hw.struct<valid: i2, ready: i1, data: i3>) -> !hw.array<3xi2>
   }
-
-  firrtl.extmodule @chkcoverAnno(in clock: !firrtl.clock) attributes {annotations = [{class = "freechips.rocketchip.annotations.InternalVerifBlackBoxAnnotation"}]}
-  // chckcoverAnno is extracted because it is instantiated inside the DUT.
-  // CHECK-LABEL: hw.module.extern @chkcoverAnno(%clock: i1)
-  // CHECK-SAME: attributes {firrtl.extract.cover.extra}
-
-  firrtl.extmodule @chkcoverAnno2(in clock: !firrtl.clock) attributes {annotations = [{class = "freechips.rocketchip.annotations.InternalVerifBlackBoxAnnotation"}]}
-  // checkcoverAnno2 is NOT extracted because it is not instantiated under the
-  // DUT.
-  // CHECK-LABEL: hw.module.extern @chkcoverAnno2(%clock: i1)
-  // CHECK-NOT: attributes {firrtl.extract.cover.extra}
-
-  // CHECK-LABEL: hw.module.extern @InnerNamesExt
-  // CHECK-SAME:  (
-  // CHECK-SAME:    clockIn: i1 {hw.exportPort = @extClockInSym}
-  // CHECK-SAME:  ) -> (
-  // CHECK-SAME:    clockOut: i1 {hw.exportPort = @extClockOutSym}
-  // CHECK-SAME:  )
-  firrtl.extmodule @InnerNamesExt(
-    in clockIn: !firrtl.clock sym @extClockInSym,
-    out clockOut: !firrtl.clock sym @extClockOutSym
-  )
-  attributes {annotations = [{class = "freechips.rocketchip.annotations.InternalVerifBlackBoxAnnotation"}]}
 
   // CHECK-LABEL: hw.module @InnerNames
   // CHECK-SAME:  (


### PR DESCRIPTION
There is an issue during module processing where we needed to know if
the module was instantiated underneath the DUT, and the answer to this
question depended on if we found the DUT module yet.

The typical way we have been handling this is to move this logic into a
post-pass, after we have found the DUT.  I don't think that this is the
first time this has burned us, so to make it safe we would need to
remove the DUT from the CircuitLoweringState to make sure no one used it
before it was populated.

Instead, this change finds the DUT in a pre-pass, so it is available
while processing each module.   We were already doing a pre-pass of the
circuit to look for NLAs, so I just stuck it in there. This let me
remove a post-pass to set the testbench directory.

This also changes the DUT to be a `FModuleLike` instead of a
`FModuleOp`, which should help if the DUT is ever an `FExtModule`.
This was not tested and there are probably other issues when that
happens.
