### PR TITLE
[FIRRTL][InstanceGraph] Add missing implementation of `addModule()`

### DIFF
--- a/include/circt/Dialect/FIRRTL/InstanceGraph.h
+++ b/include/circt/Dialect/FIRRTL/InstanceGraph.h
@@ -215,7 +215,7 @@ public:
   // on a CircuitOp.
 
   /// Add a newly created module to the instance graph.
-  InstanceGraphNode *addModule(Operation *op);
+  InstanceGraphNode *addModule(FModuleLike module);
 
   /// Remove this module from the instance graph. This will also remove all
   /// InstanceRecords in this module.  All instances of this module must have

--- a/lib/Dialect/FIRRTL/InstanceGraph.cpp
+++ b/lib/Dialect/FIRRTL/InstanceGraph.cpp
@@ -76,6 +76,13 @@ InstanceGraph::InstanceGraph(Operation *operation) {
   }
 }
 
+InstanceGraphNode *InstanceGraph::addModule(FModuleLike module) {
+  assert(!nodeMap.count(module.moduleNameAttr()) && "module already added");
+  auto *node = new InstanceGraphNode();
+  nodes.push_back(node);
+  return node;
+}
+
 void InstanceGraph::erase(InstanceGraphNode *node) {
   assert(node->noUses() &&
          "all instances of this module must have been erased.");


### PR DESCRIPTION
This adds a missing implementation of `addModule()` to the
InstanceGraph.  This is useful for users who want to keep the graph up
to date.  The signature has been changed to take a `FModuleLike` instead
of a `Operation *`.  This code is not tested by this commit.