### PR TITLE
[FIRRTL] Parse nonlocal annotations on ports correctly

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3040,7 +3040,10 @@ ParseResult FIRStmtParser::parseMem(unsigned memIndent) {
 
     auto sym = getSymbolIfRequired(annotations.first, id);
     if (!sym)
-      sym = getSymbolIfRequired(annotations.second, id);
+      for (auto portAnno : annotations.second.getAsRange<ArrayAttr>())
+        if ((sym = getSymbolIfRequired(portAnno, id)))
+          break;
+
     result =
         builder.create<MemOp>(resultTypes, readLatency, writeLatency, depth,
                               ruw, builder.getArrayAttr(resultNames), id,

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -1189,3 +1189,29 @@ circuit Top : %[[
     a is invalid
 
 ; CHECK-LABEL: firrtl.circuit
+
+
+; // -----
+;
+circuit memportAnno: %[[
+{
+ "class":"test",
+ "target":"~memportAnno|memportAnno/foo:Foo>memory.w"
+}
+]]
+  module memportAnno:
+    inst foo of Foo
+  module Foo:
+    mem memory:
+      data-type => UInt<8>
+      depth => 16
+      reader => r
+      writer => w
+      readwriter => rw
+      read-latency => 1
+      write-latency => 1
+      read-under-write => undefined
+; CHECK-LABEL: firrtl.circuit "memportAnno"  {
+; CHECK:        firrtl.nla @nla_1 [#hw.innerNameRef<@memportAnno::@foo>, #hw.innerNameRef<@Foo::@memory>]
+; CHECK:        %memory_r, %memory_rw, %memory_w = firrtl.mem sym @memory Undefined  {depth = 16 : i64, name = "memory", portAnnotations
+; CHECK-SAME:   [{circt.nonlocal = @nla_1, class = "test"}]


### PR DESCRIPTION
This commit fixes a bug in annotation parsing for ports in `FIRParser`.
The pass was not adding the appropriate symbol if one of the ports has a nonlocal annotation.
Fixes: https://github.com/llvm/circt/issues/2746