### PR TITLE
[FIRParser] Expand and remove partial connects at parse time

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -1,0 +1,28 @@
+//===- FIRRTLUtils.h - FIRRTL IR Utilities ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines various utilties to help generate and process FIRRTL IR.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_FIRRTL_FIRRTLUTILS_H
+#define CIRCT_DIALECT_FIRRTL_FIRRTLUTILS_H
+
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "mlir/IR/BuiltinOps.h"
+
+namespace circt {
+namespace firrtl {
+/// Emit a connect between two values.
+void emitConnect(OpBuilder &builder, Location loc, Value lhs, Value rhs);
+void emitConnect(ImplicitLocOpBuilder &builder, Value lhs, Value rhs);
+
+} // namespace firrtl
+} // namespace circt
+
+#endif // CIRCT_DIALECT_FIRRTL_FIRRTLUTILS_H

--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -19,11 +19,8 @@
 namespace circt {
 namespace firrtl {
 /// Emit a connect between two values.
-void emitConnect(OpBuilder &builder, Location loc, Value lhs, Value rhs,
-                 bool shouldPad = true);
-void emitConnect(ImplicitLocOpBuilder &builder, Value lhs, Value rhs,
-                 bool shouldPad = true);
-
+void emitConnect(OpBuilder &builder, Location loc, Value lhs, Value rhs);
+void emitConnect(ImplicitLocOpBuilder &builder, Value lhs, Value rhs);
 } // namespace firrtl
 } // namespace circt
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -19,8 +19,10 @@
 namespace circt {
 namespace firrtl {
 /// Emit a connect between two values.
-void emitConnect(OpBuilder &builder, Location loc, Value lhs, Value rhs);
-void emitConnect(ImplicitLocOpBuilder &builder, Value lhs, Value rhs);
+void emitConnect(OpBuilder &builder, Location loc, Value lhs, Value rhs,
+                 bool shouldPad = true);
+void emitConnect(ImplicitLocOpBuilder &builder, Value lhs, Value rhs,
+                 bool shouldPad = true);
 
 } // namespace firrtl
 } // namespace circt

--- a/lib/Dialect/FIRRTL/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/CMakeLists.txt
@@ -8,6 +8,7 @@ add_circt_dialect_library(CIRCTFIRRTL
   FIRRTLOpInterfaces.cpp
   FIRRTLOps.cpp
   FIRRTLTypes.cpp
+  FIRRTLUtils.cpp
   InstanceGraph.cpp
   NLATable.cpp
 

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -17,16 +17,16 @@ using namespace circt;
 using namespace firrtl;
 
 void circt::firrtl::emitConnect(OpBuilder &builder, Location loc, Value dst,
-                                Value src) {
+                                Value src, bool shouldPad) {
   ImplicitLocOpBuilder locBuilder(loc, builder.getInsertionBlock(),
                                   builder.getInsertionPoint());
-  emitConnect(locBuilder, dst, src);
+  emitConnect(locBuilder, dst, src, shouldPad);
   builder.restoreInsertionPoint(locBuilder.saveInsertionPoint());
 }
 
 /// Emit a connect between two values.
 void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
-                                Value src) {
+                                Value src, bool shouldPad) {
   auto dstType = dst.getType().cast<FIRRTLType>();
   auto srcType = src.getType().cast<FIRRTLType>();
 
@@ -56,7 +56,7 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
       auto srcField = builder.create<SubfieldOp>(src, i);
       if (dstBundle.getElement(i).isFlip)
         std::swap(dstField, srcField);
-      emitConnect(builder, dstField, srcField);
+      emitConnect(builder, dstField, srcField, shouldPad);
     }
     return;
   }
@@ -74,7 +74,7 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
     for (size_t i = 0; i < numElements; ++i) {
       auto dstField = builder.create<SubindexOp>(dst, i);
       auto srcField = builder.create<SubindexOp>(src, i);
-      emitConnect(builder, dstField, srcField);
+      emitConnect(builder, dstField, srcField, shouldPad);
     }
     return;
   }
@@ -99,7 +99,7 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
     // Insert the cast back to signed if needed.
     if (tmpType != dstType)
       src = builder.create<AsSIntPrimOp>(dstType, src);
-  } else if (srcWidth < dstWidth) {
+  } else if (shouldPad && srcWidth < dstWidth) {
     // Need to extend arg.
     src = builder.create<PadPrimOp>(src, dstWidth);
   }

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -17,16 +17,16 @@ using namespace circt;
 using namespace firrtl;
 
 void circt::firrtl::emitConnect(OpBuilder &builder, Location loc, Value dst,
-                                Value src, bool shouldPad) {
+                                Value src) {
   ImplicitLocOpBuilder locBuilder(loc, builder.getInsertionBlock(),
                                   builder.getInsertionPoint());
-  emitConnect(locBuilder, dst, src, shouldPad);
+  emitConnect(locBuilder, dst, src);
   builder.restoreInsertionPoint(locBuilder.saveInsertionPoint());
 }
 
 /// Emit a connect between two values.
 void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
-                                Value src, bool shouldPad) {
+                                Value src) {
   auto dstType = dst.getType().cast<FIRRTLType>();
   auto srcType = src.getType().cast<FIRRTLType>();
 
@@ -56,7 +56,7 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
       auto srcField = builder.create<SubfieldOp>(src, i);
       if (dstBundle.getElement(i).isFlip)
         std::swap(dstField, srcField);
-      emitConnect(builder, dstField, srcField, shouldPad);
+      emitConnect(builder, dstField, srcField);
     }
     return;
   }
@@ -74,7 +74,7 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
     for (size_t i = 0; i < numElements; ++i) {
       auto dstField = builder.create<SubindexOp>(dst, i);
       auto srcField = builder.create<SubindexOp>(src, i);
-      emitConnect(builder, dstField, srcField, shouldPad);
+      emitConnect(builder, dstField, srcField);
     }
     return;
   }
@@ -99,7 +99,7 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
     // Insert the cast back to signed if needed.
     if (tmpType != dstType)
       src = builder.create<AsSIntPrimOp>(dstType, src);
-  } else if (shouldPad && srcWidth < dstWidth) {
+  } else if (srcWidth < dstWidth) {
     // Need to extend arg.
     src = builder.create<PadPrimOp>(src, dstWidth);
   }

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -106,8 +106,7 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
 
   // Strict connect requires the types to be completely equal, including
   // connecting uint<1> to abstract reset types.
-  // TODO: enable strict connect.
-  if (false && dstType == srcType)
+  if (dstType == srcType)
     builder.create<StrictConnectOp>(dst, src);
   else
     builder.create<ConnectOp>(dst, src);

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -33,7 +33,7 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
   // If the types are the exact same we can just connect them.
   if (dstType == srcType) {
     // Strict connect does not allow uninferred widths.
-    // TODO: enable strict connect, same thing below.
+    // TODO: enable strict connect.
     if (true || dstType.hasUninferredWidth())
       builder.create<ConnectOp>(dst, src);
     else

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -1,0 +1,114 @@
+//===- FIRRTLUtils.cpp - FIRRTL IR Utilities --------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines various utilties to help generate and process FIRRTL IR.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+
+using namespace circt;
+using namespace firrtl;
+
+void circt::firrtl::emitConnect(OpBuilder &builder, Location loc, Value dst,
+                                Value src) {
+  ImplicitLocOpBuilder locBuilder(loc, builder.getInsertionBlock(),
+                                  builder.getInsertionPoint());
+  emitConnect(locBuilder, dst, src);
+  builder.restoreInsertionPoint(locBuilder.saveInsertionPoint());
+}
+
+/// Emit a connect between two values.
+void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
+                                Value src) {
+  auto dstType = dst.getType().cast<FIRRTLType>();
+  auto srcType = src.getType().cast<FIRRTLType>();
+
+  // If the types are the exact same we can just connect them.
+  if (dstType == srcType) {
+    // Strict connect does not allow uninferred widths.
+    // TODO: enable strict connect, same thing below.
+    if (true || dstType.hasUninferredWidth())
+      builder.create<ConnectOp>(dst, src);
+    else
+      builder.create<StrictConnectOp>(dst, src);
+    return;
+  }
+
+  if (auto dstBundle = dstType.dyn_cast<BundleType>()) {
+    // Connect all the bundle elements pairwise.
+    auto numElements = dstBundle.getNumElements();
+    // Check if we are trying to create an illegal connect - just create the
+    // connect and let the verifier catch it.
+    auto srcBundle = srcType.dyn_cast<BundleType>();
+    if (!srcBundle || numElements != srcBundle.getNumElements()) {
+      builder.create<ConnectOp>(dst, src);
+      return;
+    }
+    for (size_t i = 0; i < numElements; ++i) {
+      auto dstField = builder.create<SubfieldOp>(dst, i);
+      auto srcField = builder.create<SubfieldOp>(src, i);
+      if (dstBundle.getElement(i).isFlip)
+        std::swap(dstField, srcField);
+      emitConnect(builder, dstField, srcField);
+    }
+    return;
+  }
+
+  if (auto dstVector = dstType.dyn_cast<FVectorType>()) {
+    // Connect all the vector elements pairwise.
+    auto numElements = dstVector.getNumElements();
+    // Check if we are trying to create an illegal connect - just create the
+    // connect and let the verifier catch it.
+    auto srcVector = srcType.dyn_cast<FVectorType>();
+    if (!srcVector || numElements != srcVector.getNumElements()) {
+      builder.create<ConnectOp>(dst, src);
+      return;
+    }
+    for (size_t i = 0; i < numElements; ++i) {
+      auto dstField = builder.create<SubindexOp>(dst, i);
+      auto srcField = builder.create<SubindexOp>(src, i);
+      emitConnect(builder, dstField, srcField);
+    }
+    return;
+  }
+
+  // Handle ground types with possibly uninferred widths.
+  auto dstWidth = dstType.getBitWidthOrSentinel();
+  auto srcWidth = srcType.getBitWidthOrSentinel();
+  if (dstWidth < 0 || srcWidth < 0) {
+    // If one of these types has an uninferred width, we connect them with a
+    // regular connect operation.
+    builder.create<ConnectOp>(dst, src);
+    return;
+  }
+
+  // The source must be extended or truncated.
+  if (dstWidth < srcWidth) {
+    // firrtl.tail always returns uint even for sint operands.
+    IntType tmpType = dstType.cast<IntType>();
+    if (tmpType.isSigned())
+      tmpType = UIntType::get(dstType.getContext(), dstWidth);
+    src = builder.create<TailPrimOp>(tmpType, src, srcWidth - dstWidth);
+    // Insert the cast back to signed if needed.
+    if (tmpType != dstType)
+      src = builder.create<AsSIntPrimOp>(dstType, src);
+  } else if (srcWidth < dstWidth) {
+    // Need to extend arg.
+    src = builder.create<PadPrimOp>(src, dstWidth);
+  }
+
+  // Strict connect requires the types to be completely equal, including
+  // connecting uint<1> to abstract reset types.
+  // TODO: enable strict connect.
+  if (false && dstType == srcType)
+    builder.create<StrictConnectOp>(dst, src);
+  else
+    builder.create<ConnectOp>(dst, src);
+}

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2801,14 +2801,6 @@ ParseResult FIRStmtParser::parseLeadingExpStmt(Value lhs) {
   }
 
   if (kind == FIRToken::less_equal) {
-    // Some operations, dshl for example, have implicit truncations, even in lo
-    // firrtl.  Chisel will also use connects as partial connects to do
-    // truncation.  Handle truncations as partial connects, which allow
-    // truncation.
-    if (lhsPType.getBitWidthOrSentinel() >= 0 &&
-        lhsPType.getBitWidthOrSentinel() < rhsPType.getBitWidthOrSentinel())
-      emitConnect(builder, lhs, rhs);
-    else
       emitConnect(builder, lhs, rhs);
   } else {
     assert(kind == FIRToken::less_minus && "unexpected kind");

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2801,9 +2801,10 @@ ParseResult FIRStmtParser::parseLeadingExpStmt(Value lhs) {
   }
 
   if (kind == FIRToken::less_equal) {
-    // We don't want the connect to automatically pad values and hide width
-    // errors, so we instruct the connection to not pad the source value.
-    emitConnect(builder, lhs, rhs, /*shouldPad=*/false);
+    if (!areTypesEquivalent(lhsPType, rhsPType))
+      return emitError(loc, "cannot connect non-equivalent type ")
+             << rhsPType << " to " << lhsPType;
+    emitConnect(builder, lhs, rhs);
   } else {
     assert(kind == FIRToken::less_minus && "unexpected kind");
     emitPartialConnect(builder, lhs, rhs);

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2801,7 +2801,9 @@ ParseResult FIRStmtParser::parseLeadingExpStmt(Value lhs) {
   }
 
   if (kind == FIRToken::less_equal) {
-    emitConnect(builder, lhs, rhs);
+    // We don't want the connect to automatically pad values and hide width
+    // errors, so we instruct the connection to not pad the source value.
+    emitConnect(builder, lhs, rhs, /*shouldPad=*/false);
   } else {
     assert(kind == FIRToken::less_minus && "unexpected kind");
     emitPartialConnect(builder, lhs, rhs);

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -320,7 +320,8 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     ; CHECK: %xyz_in = firrtl.instance xyz @circuit(in in: !firrtl.uint<80>)
     inst xyz of circuit
-    ; CHECK: firrtl.connect %xyz_in, %i8 : !firrtl.uint<80>, !firrtl.uint<8>
+    ; CHECK: [[PAD:%.*]] = firrtl.pad %i8, 80 : (!firrtl.uint<8>) -> !firrtl.uint<80>
+    ; CHECK: firrtl.connect %xyz_in, [[PAD]] : !firrtl.uint<80>, !firrtl.uint<80>
     xyz.in <= i8
 
     ; CHECK: %myext_in, %myext_out = firrtl.instance myext @MyExtModule(in in: !firrtl.uint, out out: !firrtl.uint<8>)
@@ -888,7 +889,11 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     output b: {a: Reset, b: Reset}
 
     b <= a
-    ; CHECK: firrtl.connect %b, %a : !firrtl.bundle<a: reset, b: reset>, !firrtl.bundle<a: uint<1>, b: asyncreset>
+    ; CHECK: %1 = firrtl.subfield %a(0) : (!firrtl.bundle<a: uint<1>, b: asyncreset>) -> !firrtl.uint<1>
+    ; CHECK: firrtl.connect %0, %1 : !firrtl.reset, !firrtl.uint<1>
+    ; CHECK: %2 = firrtl.subfield %b(1) : (!firrtl.bundle<a: reset, b: reset>) -> !firrtl.reset
+    ; CHECK: %3 = firrtl.subfield %a(1) : (!firrtl.bundle<a: uint<1>, b: asyncreset>) -> !firrtl.asyncreset
+    ; CHECK: firrtl.connect %2, %3 : !firrtl.reset, !firrtl.asyncreset
 
   ; CHECK-LABEL: @WhenEncodedVerification
   module WhenEncodedVerification:

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -320,8 +320,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     ; CHECK: %xyz_in = firrtl.instance xyz @circuit(in in: !firrtl.uint<80>)
     inst xyz of circuit
-    ; CHECK: [[PAD:%.*]] = firrtl.pad %i8, 80 : (!firrtl.uint<8>) -> !firrtl.uint<80>
-    ; CHECK: firrtl.connect %xyz_in, [[PAD]] : !firrtl.uint<80>, !firrtl.uint<80>
+    ; CHECK: firrtl.connect %xyz_in, %i8 : !firrtl.uint<80>, !firrtl.uint<8>
     xyz.in <= i8
 
     ; CHECK: %myext_in, %myext_out = firrtl.instance myext @MyExtModule(in in: !firrtl.uint, out out: !firrtl.uint<8>)

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -88,7 +88,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.connect %_t, %_t_2 : !firrtl.vector<uint<1>, 12>, !firrtl.vector<uint<1>, 12>
     _t <= _t_2
 
-    ; CHECK: firrtl.partialconnect %_t, %_t_2
+    ; CHECK: firrtl.connect %_t, %_t_2
     _t <- _t_2
 
     ; CHECK: [[INV:%.+]]  = firrtl.invalidvalue : !firrtl.uint<1>
@@ -117,7 +117,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: [[A:%.+]] = firrtl.subfield %out_0(0) : (!firrtl.bundle<member: bundle<0: bundle<clock: clock, reset: uint<1>>>>) -> !firrtl.bundle<0: bundle<clock: clock, reset: uint<1>>>
     ; CHECK: [[B:%.+]] = firrtl.subfield [[A]](0) : (!firrtl.bundle<0: bundle<clock: clock, reset: uint<1>>>) -> !firrtl.bundle<clock: clock, reset: uint<1>>
     ; CHECK: [[C:%.+]] = firrtl.subfield [[B]](1) : (!firrtl.bundle<clock: clock, reset: uint<1>>) -> !firrtl.uint<1>
-    ; CHECK: firrtl.partialconnect %auto, [[C]] : !firrtl.uint<1>, !firrtl.uint<1>
+    ; CHECK: firrtl.connect %auto, [[C]] : !firrtl.uint<1>, !firrtl.uint<1>
     auto <- out_0.member.0.reset @[Field 173:49]
 
     ; CHECK: %_t_3 = firrtl.wire : !firrtl.vector<uint<1>, 12>
@@ -205,7 +205,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.when %reset {
     ; CHECK:   firrtl.connect %_t, %_t_2
     ; CHECK: } else {
-    ; CHECK:   firrtl.partialconnect %_t, %_t_2
+    ; CHECK:   firrtl.connect %_t, %_t_2
     ; CHECK: }
     when reset : _t <= _t_2 else : _t <- _t_2
 
@@ -214,7 +214,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK:   firrtl.connect %_t, [[N4A]]
     ; CHECK: } else {
     ; CHECK:   [[N4B:%.+]] = firrtl.node %_t_2
-    ; CHECK:   firrtl.partialconnect %_t, [[N4B]]
+    ; CHECK:   firrtl.connect %_t, [[N4B]]
     ; CHECK: }
     when reset :
       node n4 = _t_2

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -320,7 +320,8 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     ; CHECK: %xyz_in = firrtl.instance xyz @circuit(in in: !firrtl.uint<80>)
     inst xyz of circuit
-    ; CHECK: firrtl.connect %xyz_in, %i8 : !firrtl.uint<80>, !firrtl.uint<8>
+    ; CHECK: [[PAD:%.*]] = firrtl.pad %i8, 80 : (!firrtl.uint<8>) -> !firrtl.uint<80>
+    ; CHECK: firrtl.connect %xyz_in, [[PAD]] : !firrtl.uint<80>, !firrtl.uint<80>
     xyz.in <= i8
 
     ; CHECK: %myext_in, %myext_out = firrtl.instance myext @MyExtModule(in in: !firrtl.uint, out out: !firrtl.uint<8>)

--- a/test/Dialect/FIRRTL/parse-locations.fir
+++ b/test/Dialect/FIRRTL/parse-locations.fir
@@ -42,7 +42,7 @@ circuit MyModule :  @[CIRCUIT.scala 127]
     ; CHECK: %1 = firrtl.subfield %out_0(0) {{.*}} loc("Field":173:49)
     ; CHECK: %2 = firrtl.subfield %1(0) {{.*}} loc("Field":173:49)
     ; CHECK: %3 = firrtl.subfield %2(0) : {{.*}} loc("Field":173:49)
-    ; CHECK: firrtl.partialconnect %0, %3 : {{.*}} loc("Field":173:49)
+    ; CHECK: firrtl.connect %0, %3 : {{.*}} loc("Field":173:49)
     auto.out_0 <- out_0.member.0.reset @[Field 173:49]
 
     ; Fused locators: https://github.com/llvm/circt/issues/224

--- a/test/firtool/connect.fir
+++ b/test/firtool/connect.fir
@@ -3,7 +3,8 @@
 ; Ensure connect is demoted to partial connect in the presence of implicit truncation.
 
 ; CHECK-LABEL: @regularConnect
-; CHECK: firrtl.connect %a, %b : !firrtl.uint<5>, !firrtl.uint<3>
+; CHECK: %0 = firrtl.pad %b, 5 : (!firrtl.uint<3>) -> !firrtl.uint<5>
+; CHECK: firrtl.connect %a, %0 : !firrtl.uint<5>, !firrtl.uint<5>
 circuit regularConnect :
  module regularConnect :
    output a: UInt<5>
@@ -11,7 +12,8 @@ circuit regularConnect :
    a <= b
 
 ; CHECK-LABEL: @truncatingIntegerConnect
-; CHECK: firrtl.partialconnect %a, %b : !firrtl.uint<3>, !firrtl.uint<5>
+; CHECK: %0 = firrtl.tail %b, 2 : (!firrtl.uint<5>) -> !firrtl.uint<3>
+; CHECK: firrtl.connect %a, %0 : !firrtl.uint<3>, !firrtl.uint<3>
 circuit truncatingIntegerConnect :
  module truncatingIntegerConnect :
    output a: UInt<3>
@@ -19,7 +21,14 @@ circuit truncatingIntegerConnect :
    a <= b
 
 ; CHECK-LABEL: @regularBundleConnect
-; CHECK: firrtl.connect %a, %b : !firrtl.bundle<a: uint<5>, b: uint<3>>, !firrtl.bundle<a: uint<3>, b: uint<2>>
+; CHECK: %0 = firrtl.subfield %a(0) : (!firrtl.bundle<a: uint<5>, b: uint<3>>) -> !firrtl.uint<5>
+; CHECK: %1 = firrtl.subfield %b(0) : (!firrtl.bundle<a: uint<3>, b: uint<2>>) -> !firrtl.uint<3>
+; CHECK: %2 = firrtl.pad %1, 5 : (!firrtl.uint<3>) -> !firrtl.uint<5>
+; CHECK: firrtl.connect %0, %2 : !firrtl.uint<5>, !firrtl.uint<5>
+; CHECK: %3 = firrtl.subfield %a(1) : (!firrtl.bundle<a: uint<5>, b: uint<3>>) -> !firrtl.uint<3>
+; CHECK: %4 = firrtl.subfield %b(1) : (!firrtl.bundle<a: uint<3>, b: uint<2>>) -> !firrtl.uint<2>
+; CHECK: %5 = firrtl.pad %4, 3 : (!firrtl.uint<2>) -> !firrtl.uint<3>
+; CHECK: firrtl.connect %3, %5 : !firrtl.uint<3>, !firrtl.uint<3>
 circuit regularBundleConnect :
  module regularBundleConnect :
    output a: { a: UInt<5>, b: UInt<3> }
@@ -27,7 +36,14 @@ circuit regularBundleConnect :
    a <= b
 
 ; CHECK-LABEL: @truncatingBundleConnect
-; CHECK: firrtl.partialconnect %a, %b : !firrtl.bundle<a: uint<5>, b: uint<3>>, !firrtl.bundle<a: uint<6>, b: uint<1>>
+; CHECK: %0 = firrtl.subfield %a(0) : (!firrtl.bundle<a: uint<5>, b: uint<3>>) -> !firrtl.uint<5>
+; CHECK: %1 = firrtl.subfield %b(0) : (!firrtl.bundle<a: uint<6>, b: uint<1>>) -> !firrtl.uint<6>
+; CHECK: %2 = firrtl.tail %1, 1 : (!firrtl.uint<6>) -> !firrtl.uint<5>
+; CHECK: firrtl.connect %0, %2 : !firrtl.uint<5>, !firrtl.uint<5>
+; CHECK: %3 = firrtl.subfield %a(1) : (!firrtl.bundle<a: uint<5>, b: uint<3>>) -> !firrtl.uint<3>
+; CHECK: %4 = firrtl.subfield %b(1) : (!firrtl.bundle<a: uint<6>, b: uint<1>>) -> !firrtl.uint<1>
+; CHECK: %5 = firrtl.pad %4, 3 : (!firrtl.uint<1>) -> !firrtl.uint<3>
+; CHECK: firrtl.connect %3, %5 : !firrtl.uint<3>, !firrtl.uint<3>
 circuit truncatingBundleConnect :
  module truncatingBundleConnect :
    output a: { a: UInt<5>, b: UInt<3> }

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -94,10 +94,8 @@ circuit test_mod : %[[{"a": "a"}]]
 ; MLIR-NEXT:    %prettifyExample_inp_1, %prettifyExample_inp_2, %prettifyExample_inp_3, %prettifyExample_out1, %prettifyExample_out2 = firrtl.instance prettifyExample @PrettifyExample(in inp_1: !firrtl.uint<5>, in inp_2: !firrtl.uint<5>, in inp_3: !firrtl.uint<5>, out out1: !firrtl.uint<10>, out out2: !firrtl.uint<10>)
 ; MLIR-NEXT:    %3 = firrtl.bits %cat_d 4 to 0 : (!firrtl.uint<6>) -> !firrtl.uint<5>
 ; MLIR-NEXT:    firrtl.strictconnect %prettifyExample_inp_1, %3 : !firrtl.uint<5>
-; MLIR-NEXT:    %4 = firrtl.bits %cat_d 4 to 0 : (!firrtl.uint<6>) -> !firrtl.uint<5>
-; MLIR-NEXT:    firrtl.strictconnect %prettifyExample_inp_2, %4 : !firrtl.uint<5>
-; MLIR-NEXT:    %5 = firrtl.bits %cat_d 4 to 0 : (!firrtl.uint<6>) -> !firrtl.uint<5>
-; MLIR-NEXT:    firrtl.strictconnect %prettifyExample_inp_3, %5 : !firrtl.uint<5>
+; MLIR-NEXT:    firrtl.strictconnect %prettifyExample_inp_2, %3 : !firrtl.uint<5>
+; MLIR-NEXT:    firrtl.strictconnect %prettifyExample_inp_3, %3 : !firrtl.uint<5>
 ; MLIR-NEXT:    %flipFlop_clock, %flipFlop_a_d, %flipFlop_a_q = firrtl.instance flipFlop @FlipFlop(in clock: !firrtl.clock, in a_d: !firrtl.uint<1>, out a_q: !firrtl.uint<1>)
 ; MLIR-NEXT:    firrtl.strictconnect %flipFlop_clock, %clock : !firrtl.clock
 ; MLIR-NEXT:    firrtl.strictconnect %flipFlop_a_d, %a : !firrtl.uint<1>


### PR DESCRIPTION
(This probably needs to be aligned with some other PRs currently opened, and hasn't really been tested fully)

This change starts resolving partial connects at firrtl parse time to
remove them from the IR, with the eventual goal of removing partial
connects entirely.

There are places in the code where partial connects were used to as a
way to truncate sources in a connect.  A helper was added to
automatically insert pads or truncates where needed so that the sizes of
operands match for connect ops.  Most of these places could generate a
strict connect instead of a regular connect, but I decided to save the
test churn for a follow up commit.

The way this code is written has an eye towards eventually making strict
connect ops the *only* connect operations in the IR.  When potentially
creating a bulk connect, if two connected fields have different sizes,
the connect will be expanded and the source field will be truncated or
extended.  If regular connects are staying in the IR then we can satisfy
this with a single bulk connect.

The current issues with adopting strict connects are:
- Should we be able to strict-connect an uninferred-width value to an known-width one? Or do we need a `resize` operation we can insert to "cast" the uninferred width to a known size? (we already have zext and trunc but we might need one op that can do both).
- Should we be able to strict-connect a `Reset` typed value to a `UInt<1>` or do we need to insert a `AsUIntPrimOp` to cast it?
- Do we want some bulk-casting operation that can work on Bundle types? This one is less pressing - we can split the connects for now.