### PR TITLE
[HW] GlobalRefOp performance enhancement

### DIFF
--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -482,7 +482,9 @@ def OutputOp : HWOp<"output", [Terminator, HasParent<"HWModuleOp">,
   let hasVerifier = 1;
 }
 
-def GlobalRefOp : HWOp<"globalRef", [IsolatedFromAbove, Symbol]> {
+def GlobalRefOp : HWOp<"globalRef", [
+    DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+    IsolatedFromAbove, Symbol]> {
   let summary = "A global reference to uniquely identify each"
                                     "instance of an operation";
   let description = [{
@@ -495,8 +497,6 @@ def GlobalRefOp : HWOp<"globalRef", [IsolatedFromAbove, Symbol]> {
   let arguments = (ins SymbolNameAttr:$sym_name, NameRefArrayAttr:$namepath);
 
   let assemblyFormat = [{ $sym_name $namepath attr-dict }];
-
-  let hasVerifier = 1;
 }
 
 def ProbeOp : HWOp<"probe", []> {
@@ -514,4 +514,3 @@ def ProbeOp : HWOp<"probe", []> {
   let assemblyFormat = "$inner_sym attr-dict (`,` $operands^ `:` qualified(type($operands)))?";
 
 }
-

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1454,10 +1454,11 @@ LogicalResult OutputOp::verify() {
 // Other Operations
 //===----------------------------------------------------------------------===//
 
-LogicalResult GlobalRefOp::verify() {
+LogicalResult
+GlobalRefOp::verifySymbolUses(mlir::SymbolTableCollection &symTables) {
   Operation *parent = (*this)->getParentOp();
+  SymbolTable &symTable = symTables.getSymbolTable(parent);
   StringAttr symNameAttr = (*this).sym_nameAttr();
-  SymbolTable symTable(parent);
   auto hasGlobalRef = [&](Attribute attr) -> bool {
     if (!attr)
       return false;


### PR DESCRIPTION
Instead of building a `SymbolTable` for each verify call, use
`SymbolUserOpInterface` to be fed the symbol table. Fixes #2794.