### PR TITLE
[NFC] Rename dump method with toString method

### DIFF
--- a/lib/Dialect/LLHD/Simulator/Engine.cpp
+++ b/lib/Dialect/LLHD/Simulator/Engine.cpp
@@ -217,7 +217,7 @@ int Engine::simulate(int n, uint64_t maxTime) {
     trace.flush(/*force=*/true);
   }
 
-  llvm::errs() << "Finished at " << state->time.dump() << " (" << cycle
+  llvm::errs() << "Finished at " << state->time.toString() << " (" << cycle
                << " cycles)\n";
   return 0;
 }

--- a/lib/Dialect/LLHD/Simulator/State.cpp
+++ b/lib/Dialect/LLHD/Simulator/State.cpp
@@ -45,11 +45,9 @@ Time Time::operator+(const Time &rhs) const {
 
 bool Time::isZero() { return (time == 0 && delta == 0 && eps == 0); }
 
-std::string Time::dump() {
-  std::string ret;
-  raw_string_ostream ss(ret);
-  ss << time << "ps " << delta << "d " << eps << "e";
-  return ss.str();
+std::string Time::toString() const {
+  return std::to_string(time) + "ps " + std::to_string(delta) + "d " +
+         std::to_string(eps) + "e";
 }
 
 //===----------------------------------------------------------------------===//
@@ -77,17 +75,17 @@ bool Signal::operator<(const Signal &rhs) const {
   return false;
 }
 
-std::string Signal::dump() {
+std::string Signal::toHexString() const {
   std::string ret;
   raw_string_ostream ss(ret);
   ss << "0x";
   for (int i = size - 1; i >= 0; --i) {
     ss << format_hex_no_prefix(static_cast<int>(value.get()[i]), 2);
   }
-  return ss.str();
+  return ret;
 }
 
-std::string Signal::dump(unsigned elemIndex) {
+std::string Signal::toHexString(unsigned elemIndex) const {
   assert(elements.size() > 0 && "the signal type has to be tuple or array!");
   auto elemSize = elements[elemIndex].second;
   auto ptr = value.get() + elements[elemIndex].first;
@@ -307,8 +305,8 @@ void State::addSignalElement(unsigned index, unsigned offset, unsigned size) {
 void State::dumpSignal(llvm::raw_ostream &out, int index) {
   auto &sig = signals[index];
   for (auto inst : sig.triggers) {
-    out << time.dump() << "  " << instances[inst].path << "/" << sig.name
-        << "  " << sig.dump() << "\n";
+    out << time.toString() << "  " << instances[inst].path << "/" << sig.name
+        << "  " << sig.toHexString() << "\n";
   }
 }
 

--- a/lib/Dialect/LLHD/Simulator/State.h
+++ b/lib/Dialect/LLHD/Simulator/State.h
@@ -47,7 +47,7 @@ struct Time {
   bool isZero();
 
   /// Get the stored time in a printable format.
-  std::string dump();
+  std::string toString() const;
 
   uint64_t time;
   uint64_t delta;
@@ -87,11 +87,11 @@ struct Signal {
   bool operator<(const Signal &rhs) const;
 
   /// Return the value of the signal in hexadecimal string format.
-  std::string dump();
+  std::string toHexString() const;
 
   /// Return the value of the i-th element of the signal in hexadecimal string
   /// format.
-  std::string dump(unsigned);
+  std::string toHexString(unsigned) const;
 
   std::string name;
   std::string owner;

--- a/lib/Dialect/LLHD/Simulator/Trace.cpp
+++ b/lib/Dialect/LLHD/Simulator/Trace.cpp
@@ -51,10 +51,10 @@ void Trace::pushChange(unsigned inst, unsigned sigIndex, int elem = -1) {
     // Add element index to the hierarchical path.
     ss << '[' << elem << ']';
     // Get element value dump.
-    valueDump = sig.dump(elem);
+    valueDump = sig.toHexString(elem);
   } else {
     // Get signal value dump.
-    valueDump = sig.dump();
+    valueDump = sig.toHexString();
   }
 
   // Check wheter we have an actual change from last value.
@@ -101,12 +101,12 @@ void Trace::addChangeMerged(unsigned sigIndex) {
   if (sig.elements.size() > 0) {
     // Add a change for all sub-elements
     for (size_t i = 0, e = sig.elements.size(); i < e; ++i) {
-      auto valueDump = sig.dump(i);
+      auto valueDump = sig.toHexString(i);
       mergedChanges[std::make_pair(sigIndex, i)] = valueDump;
     }
   } else {
     // Add one change for the whole signal.
-    auto valueDump = sig.dump();
+    auto valueDump = sig.toHexString();
     mergedChanges[std::make_pair(sigIndex, -1)] = valueDump;
   }
 }
@@ -135,7 +135,7 @@ void Trace::flushFull() {
   if (changes.size() > 0) {
     sortChanges();
 
-    auto timeDump = currentTime.dump();
+    auto timeDump = currentTime.toString();
     for (auto change : changes) {
       out << timeDump << "  " << change.first << "  " << change.second << "\n";
     }


### PR DESCRIPTION
  Change the dump method in struct Time, Signal to
  toString, toHexString method.

follow the refactor link in [2673](https://github.com/llvm/circt/pull/2673)
will split into several patches.  

Since the dump() function in LLVM/MLIR will get an ostream output
and `void dump()` with return type `void` .
