### PR TITLE
[FIRRTL] Put Grand Central Black Boxes in Correct Directories

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,7 @@ configure_lit_site_cfg(
 
 set(CIRCT_TEST_DEPENDS
   FileCheck count not
+  split-file
   circt-capi-ir-test
   circt-opt
   circt-translate

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.anno.json
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.anno.json
@@ -686,5 +686,23 @@
         }
       ]
     }
+  },
+  {
+    "class": "firrtl.transforms.BlackBoxInlineAnno",
+    "target": "~Top|BlackBox_DUT",
+    "name": "BlackBox_DUT.v",
+    "text": "module BlackBox_DUT(input a);\nendmodule"
+  },
+  {
+    "class": "firrtl.transforms.BlackBoxInlineAnno",
+    "target": "~Top|BlackBox_GCT",
+    "name": "BlackBox_GCT.v",
+    "text": "module BlackBox_GCT(input a);\nendmodule"
+  },
+  {
+    "class": "firrtl.transforms.BlackBoxInlineAnno",
+    "target": "~Top|BlackBox_DUTAndGCT",
+    "name": "BlackBox_DUTAndGCT.v",
+    "text": "module BlackBox_DUTAndGCT(input a);\nendmodule"
   }
 ]

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
@@ -4,6 +4,15 @@
 ; RUN: firtool --firrtl-grand-central --disable-name-preservation --split-verilog --annotation-file %S/Wire.anno.json %s -o %t.folder > %t  && cat %t.folder/MyView_companion.sv | FileCheck %s --check-prefixes MYVIEW_COMPANION
 
 circuit Top :
+  extmodule BlackBox_DUT :
+    input a : UInt<1>
+
+  extmodule BlackBox_GCT :
+    input a : UInt<1>
+
+  extmodule BlackBox_DUTAndGCT :
+    input a : UInt<1>
+
   module Submodule :
     input clock : Clock
     input reset : Reset
@@ -55,10 +64,16 @@ circuit Top :
   module MyView_companion :
     output io : { }
 
-    inst tap of Tap
     wire clock: Clock
-    clock <= tap.clock
     reg r: UInt<1>, clock
+
+    inst bbox1 of BlackBox_GCT
+    bbox1.a <= r
+    inst bbox2 of BlackBox_DUTAndGCT
+    bbox2.a <= r
+
+    inst tap of Tap
+    clock <= tap.clock
     r <= tap.a
     tap.b <= r
 
@@ -122,6 +137,11 @@ circuit Top :
     out.uint <= submodule.out.uint
     inst MyView_companion of MyView_companion
 
+    inst bbox1 of BlackBox_DUT
+    bbox1.a <= in.uint
+    inst bbox2 of BlackBox_DUTAndGCT
+    bbox2.a <= in.uint
+
   module Top :
     input clock : Clock
     input reset : UInt<1>
@@ -179,6 +199,16 @@ circuit Top :
     ; EXTRACT-NEXT:        MyView_companion MyView_companion
     ; EXTRACT-NEXT:     */
     ; NOEXTRACT:        {{^ *}}MyView_companion MyView_companion
+
+    ; EXTRACT:        FILE "./BlackBox_DUT.v"
+    ; EXTRACT:        FILE "Wire/firrtl/gct/BlackBox_GCT.v"
+    ; EXTRACT:        FILE "Wire/firrtl/gct/BlackBox_DUTAndGCT.v"
+
+    ; EXTRACT:        FILE "firrtl_black_box_resource_files.f"
+    ; EXTRACT-NOT:    FILE
+    ; EXTRACT:          BlackBox_DUT.v
+    ; EXTRACT-NEXT:     Wire/firrtl/gct/BlackBox_DUTAndGCT.v
+    ; EXTRACT-NEXT:     Wire/firrtl/gct/BlackBox_GCT.v
 
     ; EXTRACT:        FILE "Wire/firrtl/bindings.sv"
     ; EXTRACT-NOT:    FILE

--- a/test/Dialect/FIRRTL/blackbox-reader.mlir
+++ b/test/Dialect/FIRRTL/blackbox-reader.mlir
@@ -1,5 +1,10 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-blackbox-reader)' %s | FileCheck %s
+// RUN: split-file %s %t
+// RUN: sed 's?@DIR@?%t?' %t/Foo.mlir.orig > %t/Foo.mlir
+// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-blackbox-reader)' %t/Foo.mlir | FileCheck %t/Foo.mlir
 
+//--- Baz.sv
+/* Baz */
+//--- Foo.mlir.orig
 firrtl.circuit "Foo" attributes {annotations = [
 {class = "sifive.enterprise.firrtl.TestBenchDirAnnotation", dirname = "../testbench"},
 {class = "sifive.enterprise.firrtl.ExtractCoverageAnnotation", directory = "cover"}
@@ -20,7 +25,12 @@ firrtl.circuit "Foo" attributes {annotations = [
   firrtl.module @DUTBlackboxes() attributes {annotations = [
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}, {class = "firrtl.transforms.BlackBoxInlineAnno", name = "hello_dut.v", text = "// world"}]} {
       firrtl.instance foo2  @ExtFoo2()
+      firrtl.instance bar @Bar()
+      firrtl.instance baz @Baz()
   }
+  firrtl.extmodule @Bar() attributes {annotations = [{class = "firrtl.transforms.BlackBoxInlineAnno", name = "Bar.v", text = "/* Bar */\0A"}], output_file = #hw.output_file<"bar/">}
+  firrtl.extmodule @Baz() attributes {annotations = [{class = "firrtl.transforms.BlackBoxPathAnno", path = "@DIR@/Baz.sv"}], output_file = #hw.output_file<"baz/">}
+  firrtl.extmodule @Qux() attributes {annotations = [{class = "firrtl.transforms.BlackBoxInlineAnno", name = "Qux.sv", text = "/* Qux */\0A"}], output_file = #hw.output_file<"qux/NotQux.jpeg">}
   firrtl.module @Foo() {
     firrtl.instance foo @ExtFoo()
     firrtl.instance foo3 @ExtFoo3()
@@ -30,9 +40,15 @@ firrtl.circuit "Foo" attributes {annotations = [
   // CHECK: sv.verbatim "// world" {output_file = #hw.output_file<"cover/hello2.v">, symbols = []}
   // CHECK: sv.verbatim "// world" {output_file = #hw.output_file<"../testbench/hello3.v">, symbols = []}
   // CHECK: sv.verbatim "// world" {output_file = #hw.output_file<"./hello_dut.v">, symbols = []}
+  // CHECK: sv.verbatim "/* Bar */\0A" {output_file = #hw.output_file<"bar/Bar.v">, symbols = []}
+  // CHECK: sv.verbatim "/* Baz */\0A" {output_file = #hw.output_file<"baz/Baz.sv">, symbols = []}
+  // CHECK: sv.verbatim "/* Qux */\0A" {output_file = #hw.output_file<"qux/NotQux.jpeg">, symbols = []}
   // CHECK: sv.verbatim "../testbench/hello.v\0A
   // CHECK-SAME:         ../testbench/hello3.v\0A
   // CHECK-SAME:         hello_dut.v\0A
-  // CHECK-SAME:         cover/hello2.v"
+  // CHECK-SAME:         bar/Bar.v\0A
+  // CHECK-SAME:         baz/Baz.sv\0A
+  // CHECK-SAME:         cover/hello2.v\0A
+  // CHECK-SAME:         qux/NotQux.jpeg"
   // CHECK-SAME: output_file = #hw.output_file<"firrtl_black_box_resource_files.f", excludeFromFileList>
 }


### PR DESCRIPTION
Change Grand Central Views to modify existing black boxes which are
instantiated in a companion so that they will be written to the Grand
Central extraction directory.  This is done to match SFC behavior around
where black boxes are written.

To implement this, I added the following functionality:

Add functionality to BlackBoxReader such that it will use the
"output_file" information on an external module when determining where
to put the black box.  The policy is as follows:

1. If the output file is a file (NOT a directory), then this file is
where the black will written.
2. If the output file is a directory, then this becomes a lowest
priority fallback for setting the directory.

This policy may require tweaking, but it gets CIRCT to match the Scala
FIRRTL Compiler (SFC) in tests and works for some SiFive designs which
are sensitive to the location of Grand Central black boxes.