### PR TITLE
[Moore] Add concat expression

### DIFF
--- a/include/circt/Dialect/Moore/MIRExpressions.td
+++ b/include/circt/Dialect/Moore/MIRExpressions.td
@@ -20,3 +20,26 @@ def ConstantOp : MIROp<"constant", [NoSideEffect]> {
   let results = (outs MooreRValueType:$result);
   let assemblyFormat = "$value attr-dict `:` qualified(type($result))";
 }
+
+def ConcatOp : MIROp<"concat", [
+    NoSideEffect, DeclareOpInterfaceMethods<InferTypeOpInterface>
+]> {
+  let summary = "A concatenation of expressions";
+  let description = [{
+    This operation represents the SystemVerilog concatenation expression
+    `{x, y, z}`. See IEEE 1800-2017 §11.4.12 "Concatenation operators".
+
+    All operands must be simple bit vector types.
+
+    The concatenation result is a simple bit vector type. The result is unsigned
+    regardless of the sign of the operands (see concatenation-specific rules in
+    IEEE 1800-2017 §11.8.1 "Rules for expression types"). The size of the result
+    is the sum of the sizes of all operands. If any of the operands is
+    four-valued, the result is four-valued; otherwise it is two-valued.
+  }];
+  let arguments = (ins Variadic<SimpleBitVectorType>:$values);
+  let results = (outs SimpleBitVectorType:$result);
+  let assemblyFormat = [{
+    $values attr-dict `:` functional-type($values, $result)
+  }];
+}

--- a/include/circt/Dialect/Moore/MIROps.h
+++ b/include/circt/Dialect/Moore/MIROps.h
@@ -15,6 +15,7 @@
 
 #include "circt/Dialect/Moore/MooreDialect.h"
 #include "circt/Dialect/Moore/MooreTypes.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
 
 #define GET_OP_CLASSES
 #include "circt/Dialect/Moore/MooreEnums.h.inc"

--- a/include/circt/Dialect/Moore/MooreTypes.td
+++ b/include/circt/Dialect/Moore/MooreTypes.td
@@ -15,13 +15,27 @@
 
 include "circt/Dialect/Moore/MooreDialect.td"
 
+class MooreType<Pred condition, string description, string cppClassName>
+  : DialectType<MooreDialect, condition, description, cppClassName>;
+
+def PackedType : MooreType<CPred<"$_self.isa<moore::PackedType>()">,
+  "packed type", "moore::PackedType">;
+
+def UnpackedType : MooreType<CPred<"$_self.isa<moore::UnpackedType>()">,
+  "unpacked type", "moore::UnpackedType">;
+
+/// A simple bit vector type.
+def SimpleBitVectorType : MooreType<CPred<[{
+    $_self.isa<moore::UnpackedType>() &&
+    $_self.cast<moore::UnpackedType>().isSimpleBitVector()
+  }]>, "simple bit vector type", "moore::UnpackedType">;
+
 //===----------------------------------------------------------------------===//
 // Integer atom types
 //===----------------------------------------------------------------------===//
 
-def MooreIntType : DialectType<MooreDialect,
-  CPred<"$_self.isa<moore::IntType>()">,
-  "an SystemVerilog int", "::circt::moore::IntType">;
+def MooreIntType : MooreType<CPred<"$_self.isa<moore::IntType>()">,
+  "an SystemVerilog int", "moore::IntType">;
 
 //===----------------------------------------------------------------------===//
 // LValue / RValue predicates

--- a/include/circt/Dialect/Moore/MooreTypesImpl.td
+++ b/include/circt/Dialect/Moore/MooreTypesImpl.td
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-class MooreType<string name> : TypeDef<MooreDialect, name> { }
+class MooreTypeDef<string name> : TypeDef<MooreDialect, name> { }
 
-def LValueTypeImpl : MooreType<"LValue"> {
+def LValueTypeImpl : MooreTypeDef<"LValue"> {
   let mnemonic = "lvalue";
   let parameters = (ins "::mlir::Type":$nestedType);
   let assemblyFormat = "`<` $nestedType `>`";

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -184,6 +184,15 @@ static void populateTypeConversion(TypeConverter &typeConverter) {
     return llhd::SigType::get(inner);
   });
 
+  // Directly map simple bit vector types to a compact integer type. This needs
+  // to be added after all of the other conversions above, such that SBVs
+  // conversion gets tried first before any of the others.
+  typeConverter.addConversion([&](UnpackedType type) -> Optional<Type> {
+    if (auto sbv = type.getSimpleBitVectorOrNull())
+      return mlir::IntegerType::get(type.getContext(), sbv.size);
+    return llvm::None;
+  });
+
   // Valid target types.
   typeConverter.addConversion([](mlir::IntegerType type) { return type; });
 }

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -44,6 +44,16 @@ struct ConstantOpConv : public OpConversionPattern<ConstantOp> {
   }
 };
 
+struct ConcatOpConversion : public OpConversionPattern<ConcatOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(ConcatOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<comb::ConcatOp>(op, adaptor.values());
+    return success();
+  }
+};
+
 //===----------------------------------------------------------------------===//
 // Statement Conversion
 //===----------------------------------------------------------------------===//
@@ -228,6 +238,7 @@ static void populateOpConversion(RewritePatternSet &patterns,
   // clang-format off
   patterns.add<
     ConstantOpConv,
+    ConcatOpConversion,
     VariableDeclOpConv,
     AssignOpConv,
     ReturnOpConversion,

--- a/lib/Dialect/Moore/CMakeLists.txt
+++ b/lib/Dialect/Moore/CMakeLists.txt
@@ -17,6 +17,7 @@ add_circt_dialect_library(CIRCTMoore
 
   LINK_LIBS PUBLIC
   MLIRIR
+  MLIRInferTypeOpInterface
 )
 
 add_dependencies(circt-headers MLIRMooreIncGen)

--- a/lib/Dialect/Moore/MIROps.cpp
+++ b/lib/Dialect/Moore/MIROps.cpp
@@ -17,6 +17,29 @@ using namespace circt;
 using namespace circt::moore;
 
 //===----------------------------------------------------------------------===//
+// Type Inference
+//===----------------------------------------------------------------------===//
+
+LogicalResult ConcatOp::inferReturnTypes(MLIRContext *context,
+                                         Optional<Location> loc,
+                                         ValueRange operands,
+                                         DictionaryAttr attrs,
+                                         mlir::RegionRange regions,
+                                         SmallVectorImpl<Type> &results) {
+  Domain domain = Domain::TwoValued;
+  unsigned size = 0;
+  for (auto operand : operands) {
+    auto type = operand.getType().cast<UnpackedType>().getSimpleBitVector();
+    if (type.domain == Domain::FourValued)
+      domain = Domain::FourValued;
+    size += type.size;
+  }
+  results.push_back(
+      SimpleBitVectorType(domain, Sign::Unsigned, size).getType(context));
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // Custom LValue parser and printer
 //===----------------------------------------------------------------------===//
 

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -46,3 +46,13 @@ func @Calls(%arg0: !moore.byte, %arg1: !moore.int, %arg2: !moore.bit) -> !moore.
   %0 = call @FuncArgsAndReturns(%arg0, %arg1, %arg2) : (!moore.byte, !moore.int, !moore.bit) -> !moore.byte
   return %0 : !moore.byte
 }
+
+// CHECK-LABEL: func @UnrealizedConversionCast
+func @UnrealizedConversionCast(%arg0: !moore.byte) -> !moore.shortint {
+  // CHECK-NEXT: [[TMP:%.+]] = comb.concat %arg0, %arg0 : i8, i8
+  // CHECK-NEXT: return [[TMP]] : i16
+  %0 = builtin.unrealized_conversion_cast %arg0 : !moore.byte to i8
+  %1 = comb.concat %0, %0 : i8, i8
+  %2 = builtin.unrealized_conversion_cast %1 : i16 to !moore.shortint
+  return %2 : !moore.shortint
+}

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -56,3 +56,13 @@ func @UnrealizedConversionCast(%arg0: !moore.byte) -> !moore.shortint {
   %2 = builtin.unrealized_conversion_cast %1 : i16 to !moore.shortint
   return %2 : !moore.shortint
 }
+
+// CHECK-LABEL: func @Expressions
+func @Expressions(%arg0: !moore.bit, %arg1: !moore.logic) {
+  // CHECK-NEXT: %0 = comb.concat %arg0, %arg0 : i1, i1
+  // CHECK-NEXT: %1 = comb.concat %arg1, %arg1 : i1, i1
+  %0 = moore.mir.concat %arg0, %arg0 : (!moore.bit, !moore.bit) -> !moore.packed<range<bit, 1:0>>
+  %1 = moore.mir.concat %arg1, %arg1 : (!moore.logic, !moore.logic) -> !moore.packed<range<logic, 1:0>>
+  // CHECK-NEXT: return
+  return
+}

--- a/test/Dialect/Moore/basic.mlir
+++ b/test/Dialect/Moore/basic.mlir
@@ -9,3 +9,12 @@ llhd.entity @test1() -> () {
   %1 = moore.mir.vardecl "varname" = 3 : !moore.int
   moore.mir.assign %1, %0 : !moore.int
 }
+
+// CHECK-LABEL: func @Expressions
+func @Expressions(%a: !moore.bit, %b: !moore.logic) {
+  // CHECK: %0 = moore.mir.concat
+  // CHECK: %1 = moore.mir.concat
+  %0 = moore.mir.concat %a, %a : (!moore.bit, !moore.bit) -> !moore.packed<range<bit, 1:0>>
+  %1 = moore.mir.concat %b, %b : (!moore.logic, !moore.logic) -> !moore.packed<range<logic, 1:0>>
+  return
+}


### PR DESCRIPTION
As a first step towards bringing the Moore IRs into the CIRCT project, add a `ConcatOp` to the Moore dialect which represents a concatenation expression. The intention is to make this MLIR op precisely capture the semantics specified in the SystemVerilog standard. The documentation for the op points at the relevant pieces of the standard.

This op will allow Moore to start emitting `moore.mir.concat` instead of directly doing the lowering to LLHD/Comb, which is a great starting point to move the code generation logic from the Rust code into CIRCT.