### PR TITLE
Track LLVM commits

### DIFF
--- a/.github/workflows/trackLLVMChanges.yml
+++ b/.github/workflows/trackLLVMChanges.yml
@@ -68,12 +68,11 @@ jobs:
           git bisect start ${{ steps.build-latest-llvm-commit.outputs.sha }} ${{ steps.build-current-llvm-commit.outputs.sha }} -- mlir llvm
           git bisect run cmake --build ../build --config Debug --target check-circt -- -j$(nproc)
 
-      - name: Log broken commit
+      - name: Git Bisect Log
         if: steps.build-latest-llvm-commit.outcome != 'success'
         run: |
           cd llvm
           git bisect log
-          git log
 
       - name: Fail if incompatible commits exist
         if: steps.build-latest-llvm-commit.outcome != 'success'

--- a/.github/workflows/trackLLVMChanges.yml
+++ b/.github/workflows/trackLLVMChanges.yml
@@ -25,6 +25,11 @@ jobs:
           mkdir build
           cd build
           cmake ../llvm/llvm \
+            -DLLVM_USE_LINKER=lld \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_RULE_MESSAGES=OFF \
+            -DCMAKE_BUILD_TYPE=Debug \
             -DBUILD_SHARED_LIBS=ON \
             -DLLVM_ENABLE_PROJECTS=mlir \
             -DLLVM_TARGETS_TO_BUILD=host \
@@ -40,8 +45,8 @@ jobs:
         id: build-current-llvm-commit
         run: |
           cd llvm
-          cmake --build ../build --config Debug --target check-circt --
           echo "::set-output name=sha::$(git rev-parse HEAD)"
+          cmake --build ../build --config Debug --target check-circt --
       
       - name: Build latest LLVM commit
         id: build-latest-llvm-commit
@@ -50,14 +55,14 @@ jobs:
           cd llvm
           git fetch origin main
           git checkout --detach origin/main
-          cmake --build ../build --config Debug --target check-circt --
           echo "::set-output name=sha::$(git rev-parse HEAD)"
+          cmake --build ../build --config Debug --target check-circt -- -j($nproc)
       
       - name: Bisect commits
         if: steps.build-latest-llvm-commit.outcome != 'success'
         run: |
           cd llvm
-          git bisect start ${{ steps.build-latest-llvm-commit.outputs.sha }} ${{ steps.build-current-llvm-commits.outputs.sha }} -- mlir llvm
+          git bisect start ${{ steps.build-latest-llvm-commit.outputs.sha }} ${{ steps.build-current-llvm-commit.outputs.sha }} -- mlir llvm
           git bisect run cmake --build ../build --config Debug --target check-circt --
 
       - name: Log broken commit

--- a/.github/workflows/trackLLVMChanges.yml
+++ b/.github/workflows/trackLLVMChanges.yml
@@ -56,6 +56,7 @@ jobs:
         if: steps.build-latest-llvm-commit.outcome != 'success'
         run: |
           cd llvm
+          git bisect bad
           git bisect run cmake --build ../build --config Debug --target check-circt --
 
       - name: Log broken commit

--- a/.github/workflows/trackLLVMChanges.yml
+++ b/.github/workflows/trackLLVMChanges.yml
@@ -4,7 +4,10 @@ on:
   schedule:
     # 10:00 AM UTC is 3AM Pacific Time
     - cron: '0 10 * * *'
-  pull_request: {}
+  # Run this workflow on pull requests which change this workflow
+  pull_request: 
+    paths:
+      - .github/workflows/trackLLVMChanges.yml
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/trackLLVMChanges.yml
+++ b/.github/workflows/trackLLVMChanges.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           cd llvm
           echo "::set-output name=sha::$(git rev-parse HEAD)"
-          cmake --build ../build --config Debug --target check-circt -- -j($nproc)
+          cmake --build ../build --config Debug --target check-circt -- -j$(nproc)
       
       - name: Build latest LLVM commit
         id: build-latest-llvm-commit
@@ -59,14 +59,14 @@ jobs:
           git fetch origin main
           git checkout --detach origin/main
           echo "::set-output name=sha::$(git rev-parse HEAD)"
-          cmake --build ../build --config Debug --target check-circt -- -j($nproc)
+          cmake --build ../build --config Debug --target check-circt -- -j$(nproc)
       
       - name: Bisect commits
         if: steps.build-latest-llvm-commit.outcome != 'success'
         run: |
           cd llvm
           git bisect start ${{ steps.build-latest-llvm-commit.outputs.sha }} ${{ steps.build-current-llvm-commit.outputs.sha }} -- mlir llvm
-          git bisect run cmake --build ../build --config Debug --target check-circt -- -j($nproc)
+          git bisect run cmake --build ../build --config Debug --target check-circt -- -j$(nproc)
 
       - name: Log broken commit
         if: steps.build-latest-llvm-commit.outcome != 'success'

--- a/.github/workflows/trackLLVMChanges.yml
+++ b/.github/workflows/trackLLVMChanges.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           cd llvm
           echo "::set-output name=sha::$(git rev-parse HEAD)"
-          cmake --build ../build --config Debug --target check-circt --
+          cmake --build ../build --config Debug --target check-circt -- -j($nproc)
       
       - name: Build latest LLVM commit
         id: build-latest-llvm-commit
@@ -63,7 +63,7 @@ jobs:
         run: |
           cd llvm
           git bisect start ${{ steps.build-latest-llvm-commit.outputs.sha }} ${{ steps.build-current-llvm-commit.outputs.sha }} -- mlir llvm
-          git bisect run cmake --build ../build --config Debug --target check-circt --
+          git bisect run cmake --build ../build --config Debug --target check-circt -- -j($nproc)
 
       - name: Log broken commit
         if: steps.build-latest-llvm-commit.outcome != 'success'

--- a/.github/workflows/trackLLVMChanges.yml
+++ b/.github/workflows/trackLLVMChanges.yml
@@ -1,0 +1,67 @@
+name: Track LLVM Changes
+
+on:
+  schedule:
+    # 13:00 (1PM) UTC is 5AM Pacific Time
+    - cron: '0 13 * * *'
+  pull_request: {}
+  workflow_dispatch:
+
+jobs:
+  track-llvm-changes:
+    name: Configure Unified Build
+    runs-on: ubuntu-18.04
+    steps:
+      # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
+      # time.
+      - name: Get CIRCT
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+          submodules: "true"
+
+      - name: Configure Unified Build
+        run: |
+          mkdir build
+          cd build
+          cmake ../llvm/llvm \
+            -DBUILD_SHARED_LIBS=ON \
+            -DLLVM_ENABLE_PROJECTS=mlir \
+            -DLLVM_TARGETS_TO_BUILD=host \
+            -DLLVM_ENABLE_ASSERTIONS=ON \
+            -DLLVM_EXTERNAL_PROJECTS=circt \
+            -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=$PWD/..
+
+      - name: Build current LLVM commit
+        run: |
+          cd llvm
+          cmake --build ../build --config Debug --target check-circt --
+          git bisect start
+          git bisect good
+      
+      - name: Build latest LLVM commit
+        id: build-latest-llvm-commit
+        continue-on-error: true
+        run: |
+          cd llvm
+          git pull origin main
+          git checkout -d origin/main
+          cmake --build ../build --config Debug --target check-circt --
+      
+      - name: Bisect commits
+        if: steps.build-latest-llvm-commit.outcome != 'success'
+        run: |
+          cd llvm
+          git bisect run cmake --build ../build --config Debug --target check-circt --
+
+      - name: Log broken commit
+        if: steps.build-latest-llvm-commit.outcome != 'success'
+        run: |
+          cd llvm
+          git log
+
+      - name: Fail if incompatible commits exist
+        if: steps.build-latest-llvm-commit.outcome != 'success'
+        run: exit 1
+
+  # --- end of track-llvm-changes job.

--- a/.github/workflows/trackLLVMChanges.yml
+++ b/.github/workflows/trackLLVMChanges.yml
@@ -2,15 +2,15 @@ name: Track LLVM Changes
 
 on:
   schedule:
-    # 13:00 (1PM) UTC is 5AM Pacific Time
-    - cron: '0 13 * * *'
+    # 10:00 AM UTC is 3AM Pacific Time
+    - cron: '0 10 * * *'
   pull_request: {}
   workflow_dispatch:
 
 jobs:
   track-llvm-changes:
     name: Track LLVM Changes
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
       # time.
@@ -28,6 +28,10 @@ jobs:
             -DBUILD_SHARED_LIBS=ON \
             -DLLVM_ENABLE_PROJECTS=mlir \
             -DLLVM_TARGETS_TO_BUILD=host \
+            -DLLVM_BUILD_EXAMPLES=OFF \
+            -DLLVM_INSTALL_UTILS=OFF \
+            -DLLVM_ENABLE_OCAMLDOC=OFF \
+            -DLLVM_ENABLE_BINDINGS=OFF \
             -DLLVM_ENABLE_ASSERTIONS=ON \
             -DLLVM_EXTERNAL_PROJECTS=circt \
             -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=$PWD/..

--- a/.github/workflows/trackLLVMChanges.yml
+++ b/.github/workflows/trackLLVMChanges.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   track-llvm-changes:
-    name: Configure Unified Build
+    name: Track LLVM Changes
     runs-on: ubuntu-18.04
     steps:
       # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 2
           submodules: "true"
 
-      - name: Configure Unified Build
+      - name: Configure Project
         run: |
           mkdir build
           cd build

--- a/.github/workflows/trackLLVMChanges.yml
+++ b/.github/workflows/trackLLVMChanges.yml
@@ -37,32 +37,34 @@ jobs:
             -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=$PWD/..
 
       - name: Build current LLVM commit
+        id: build-current-llvm-commit
         run: |
           cd llvm
           cmake --build ../build --config Debug --target check-circt --
-          git bisect start
-          git bisect good
+          echo "::set-output name=sha::$(git rev-parse HEAD)"
       
       - name: Build latest LLVM commit
         id: build-latest-llvm-commit
         continue-on-error: true
         run: |
           cd llvm
-          git pull origin main
-          git checkout -d origin/main
+          git fetch origin main
+          git checkout --detach origin/main
           cmake --build ../build --config Debug --target check-circt --
+          echo "::set-output name=sha::$(git rev-parse HEAD)"
       
       - name: Bisect commits
         if: steps.build-latest-llvm-commit.outcome != 'success'
         run: |
           cd llvm
-          git bisect bad
+          git bisect start ${{ steps.build-latest-llvm-commit.outputs.sha }} ${{ steps.build-current-llvm-commits.outputs.sha }} -- mlir llvm
           git bisect run cmake --build ../build --config Debug --target check-circt --
 
       - name: Log broken commit
         if: steps.build-latest-llvm-commit.outcome != 'success'
         run: |
           cd llvm
+          git bisect log
           git log
 
       - name: Fail if incompatible commits exist

--- a/.github/workflows/trackLLVMChanges.yml
+++ b/.github/workflows/trackLLVMChanges.yml
@@ -68,14 +68,14 @@ jobs:
           git bisect start ${{ steps.build-latest-llvm-commit.outputs.sha }} ${{ steps.build-current-llvm-commit.outputs.sha }} -- mlir llvm
           git bisect run cmake --build ../build --config Debug --target check-circt -- -j$(nproc)
 
-      - name: Git Bisect Log
+      # Summarize Results (re-run tests to make the log easier to parse)
+      - name: Summarize Results
         if: steps.build-latest-llvm-commit.outcome != 'success'
         run: |
           cd llvm
           git bisect log
-
-      - name: Fail if incompatible commits exist
-        if: steps.build-latest-llvm-commit.outcome != 'success'
-        run: exit 1
+          FIRST_BAD_COMMIT=$(git bisect log | sed -n 's/# first bad commit: \[\([0-9a-f]*\)\].*/\1/p')
+          git checkout $FIRST_BAD_COMMIT
+          cmake --build ../build --config Debug --target check-circt -- -j$(nproc)
 
   # --- end of track-llvm-changes job.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![](https://github.com/llvm/circt/workflows/Build%20and%20Test/badge.svg?event=push)](https://github.com/llvm/circt/actions?query=workflow%3A%22Build+and+Test%22)
 [![Nightly integration tests](https://github.com/llvm/circt/workflows/Nightly%20integration%20tests/badge.svg)](https://github.com/llvm/circt/actions?query=workflow%3A%22Nightly+integration+tests%22)
 
+[![Track LLVM Changes](https://github.com/llvm/circt/actions/workflows/trackLLVMChanges.yml/badge.svg)](https://github.com/llvm/circt/actions/workflows/trackLLVMChanges.yml) <-- This workflow is failing if there exists an MLIR commit which breaks CIRCT. If it is failing, please update MLIR and fix the issue, as multiple failures make it harder to bump MLIR.
+
 # ⚡️ "CIRCT" / Circuit IR Compilers and Tools
 
 "CIRCT" stands for "Circuit IR Compilers and Tools".  One might also interpret

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![](https://github.com/llvm/circt/workflows/Build%20and%20Test/badge.svg?event=push)](https://github.com/llvm/circt/actions?query=workflow%3A%22Build+and+Test%22)
 [![Nightly integration tests](https://github.com/llvm/circt/workflows/Nightly%20integration%20tests/badge.svg)](https://github.com/llvm/circt/actions?query=workflow%3A%22Nightly+integration+tests%22)
 
-[![Track LLVM Changes](https://github.com/llvm/circt/actions/workflows/trackLLVMChanges.yml/badge.svg)](https://github.com/llvm/circt/actions/workflows/trackLLVMChanges.yml) <-- This workflow is failing if there exists an MLIR commit which breaks CIRCT. If it is failing, please update MLIR and fix the issue, as multiple failures make it harder to bump MLIR.
+[![Track LLVM Changes](https://github.com/llvm/circt/actions/workflows/trackLLVMChanges.yml/badge.svg)](https://github.com/llvm/circt/actions/workflows/trackLLVMChanges.yml) <br>↳ If failing, there exists an upstream LLVM commit which breaks CIRCT.
 
 # ⚡️ "CIRCT" / Circuit IR Compilers and Tools
 


### PR DESCRIPTION
This PR adds a workflow which runs around 3AM Pacific Time and bisects the LLVM repo, starting at the current commit in the CIRCT submodule through the most recent commit on `main`. The workflow fails if _any_ MLIR commits break CIRCT. The workflow has a step that clearly displays [the error encountered](https://github.com/llvm/circt/runs/5699113248?check_suite_focus=true#step:7:263) and [the first breaking commit](https://github.com/llvm/circt/runs/5699113248?check_suite_focus=true#step:7:13). Note, this means that having the workflow "fail" on this PR is **correct** (it will only run on PRs which change this workflow). Hopefully this will make it easier to stay on top of updating LLVM.

Currently, I just provide a badge in the Readme but we can incrementally improve this by adding better notification support.

