### PR TITLE
[ExportVerilog] Remove max token limit and spilling in ExportVerilog.

### DIFF
--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -81,11 +81,6 @@ struct LoweringOptions {
   /// statements to be labeled.
   bool enforceVerifLabels = false;
 
-  /// This parameter limits the maximum number of tokes per one expression.
-  /// https://github.com/verilator/verilator/issues/2752
-  enum { DEFAULT_TOKEN_NUMBER = 40000 };
-  unsigned maximumNumberOfTokensPerExpression = DEFAULT_TOKEN_NUMBER;
-
   enum { DEFAULT_TERM_LIMIT = 256 };
   unsigned maximumNumberOfTermsPerExpression = DEFAULT_TERM_LIMIT;
 

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -57,12 +57,6 @@ void LoweringOptions::parse(StringRef text, ErrorHandlerT errorHandler) {
       }
     } else if (option == "explicitBitcastAddMul") {
       explicitBitcastAddMul = true;
-    } else if (option.startswith("maximumNumberOfTokensPerExpression=")) {
-      option = option.drop_front(strlen("maximumNumberOfTokensPerExpression="));
-      if (option.getAsInteger(10, maximumNumberOfTokensPerExpression)) {
-        errorHandler("expected integer source width");
-        maximumNumberOfTokensPerExpression = DEFAULT_TOKEN_NUMBER;
-      }
     } else if (option.startswith("maximumNumberOfTermsPerExpression=")) {
       option = option.drop_front(strlen("maximumNumberOfTermsPerExpression="));
       if (option.getAsInteger(10, maximumNumberOfTermsPerExpression)) {
@@ -74,9 +68,6 @@ void LoweringOptions::parse(StringRef text, ErrorHandlerT errorHandler) {
       // We continue parsing options after a failure.
     }
   }
-  if (maximumNumberOfTokensPerExpression < emittedLineLength)
-    errorHandler("maximumNumberOfTokensPerExpression must be equal or larger "
-                 "than emittedLineLength");
 }
 
 std::string LoweringOptions::toString() const {
@@ -97,9 +88,6 @@ std::string LoweringOptions::toString() const {
 
   if (emittedLineLength != DEFAULT_LINE_LENGTH)
     options += "emittedLineLength=" + std::to_string(emittedLineLength) + ',';
-  if (maximumNumberOfTokensPerExpression != DEFAULT_TOKEN_NUMBER)
-    options += "maximumNumberOfTokensPerExpression=" +
-               std::to_string(maximumNumberOfTokensPerExpression) + ',';
   if (maximumNumberOfTermsPerExpression != DEFAULT_TERM_LIMIT)
     options += "maximumNumberOfTermsPerExpression=" +
                std::to_string(maximumNumberOfTermsPerExpression) + ',';
@@ -155,7 +143,6 @@ struct LoweringCLOptions {
           "Style options.  Valid flags include: alwaysFF, "
           "noAlwaysComb, exprInEventControl, disallowPackedArrays, "
           "disallowLocalVariables, verifLabels, emittedLineLength=<n>, "
-          "maximumNumberOfTokensPerExpression=<n>, "
           "maximumNumberOfTermsPerExpression=<n>, explicitBitcastAddMul"),
       llvm::cl::value_desc("option")};
 };

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -635,11 +635,17 @@ hw.module @notEmitDuplicateWiresThatWereUnInlinedDueToLongNames(%clock: i1, %x: 
 
 // CHECK-LABEL: module largeConstant
 hw.module @largeConstant(%a: i100000, %b: i16) -> (x: i100000, y: i16) {
-  // Large constant is broken out to its own localparam to avoid long line problems.
+  // Large constant is inlined on multiple lines.
 
-  // CHECK: localparam [99999:0] _tmp = 100000'h2CD76FE086B93CE2F768A00B22A00000000000;
+  // CHECK: assign x = a + 100000'h2CD76FE086B93CE2F768A00B22A00000000000 +
+  // CHECK:               100000'h2CD76FE086B93CE2F768A00B22A00000000000 +
+  // CHECK:               100000'h2CD76FE086B93CE2F768A00B22A00000000000 +
+  // CHECK:               100000'h2CD76FE086B93CE2F768A00B22A00000000000 +
+  // CHECK:               100000'h2CD76FE086B93CE2F768A00B22A00000000000 +
+  // CHECK:               100000'h2CD76FE086B93CE2F768A00B22A00000000000 +
+  // CHECK:               100000'h2CD76FE086B93CE2F768A00B22A00000000000 +
+  // CHECK:               100000'h2CD76FE086B93CE2F768A00B22A00000000000;
   %c = hw.constant 1000000000000000000000000000000000000000000000 : i100000
-  // CHECK: assign x = a + _tmp + _tmp + _tmp + _tmp + _tmp + _tmp + _tmp + _tmp;
   %1 = comb.add %a, %c, %c, %c, %c, %c, %c, %c, %c : i100000
 
   // Small constants are emitted inline.

--- a/test/Conversion/ExportVerilog/line-length.mlir
+++ b/test/Conversion/ExportVerilog/line-length.mlir
@@ -1,8 +1,8 @@
 // RUN: circt-opt --lowering-options=emittedLineLength=40 --export-verilog %s | FileCheck %s --check-prefixes=CHECK,SHORT
 // RUN: circt-opt --export-verilog %s | FileCheck %s --check-prefixes=CHECK,DEFAULT
 // RUN: circt-opt --lowering-options=emittedLineLength=180 --export-verilog %s | FileCheck %s --check-prefixes=CHECK,LONG
-// RUN: circt-opt --lowering-options=emittedLineLength=40,maximumNumberOfTokensPerExpression=60 --export-verilog %s | FileCheck %s --check-prefixes=CHECK,LIMIT_SHORT
-// RUN: circt-opt --lowering-options=maximumNumberOfTokensPerExpression=120 --export-verilog %s | FileCheck %s --check-prefixes=CHECK,LIMIT_LONG
+// RUN: circt-opt --lowering-options=emittedLineLength=40,maximumNumberOfTermsPerExpression=16 --export-verilog %s | FileCheck %s --check-prefixes=CHECK,LIMIT_SHORT
+// RUN: circt-opt --lowering-options=maximumNumberOfTermsPerExpression=32 --export-verilog %s | FileCheck %s --check-prefixes=CHECK,LIMIT_LONG
 
 hw.module @longvariadic(%a: i8) -> (b: i8) {
   %1 = comb.add %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a, %a,
@@ -30,21 +30,21 @@ hw.module @longvariadic(%a: i8) -> (b: i8) {
 // LONG:       assign b = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a
 // LONG-NEXT:             + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
 
-// LIMIT_SHORT:       wire [7:0] _tmp = a + a + a + a + a + a + a + a + a + a + a
-// LIMIT_SHORT-NEXT:                    + a + a + a + a + a;
-// LIMIT_SHORT-NEXT:  wire [7:0] _tmp_0 = a + a + a + a + a + a + a + a + a + a + a
-// LIMIT_SHORT-NEXT:                      + a + a + a + a + a;
-// LIMIT_SHORT-NEXT:  wire [7:0] _tmp_1 = a + a + a + a + a + a + a + a + a + a + a
-// LIMIT_SHORT-NEXT:                      + a + a + a + a + a;
-// LIMIT_SHORT-NEXT:  wire [7:0] _tmp_2 = a + a + a + a + a + a + a + a + a + a + a
-// LIMIT_SHORT-NEXT:                      + a + a + a + a + a;
-// LIMIT_SHORT-NEXT:  assign b = _tmp + _tmp_0 + _tmp_1 + _tmp_2;
+// LIMIT_SHORT:       wire [7:0] _GEN;
+// LIMIT_SHORT:       assign _GEN = a + a + a + a + a + a + a + a + a + a + a
+// LIMIT_SHORT-NEXT:                + a + a + a + a + a + a + a + a + a + a +
+// LIMIT_SHORT-NEXT:                a + a + a + a + a + a + a + a + a + a + a
+// LIMIT_SHORT-NEXT:                + a + a + a + a + a + a + a + a + a + a +
+// LIMIT_SHORT-NEXT:                a + a + a + a + a + a + a + a + a + a + a
+// LIMIT_SHORT-NEXT:                + a + a + a + a + a + a + a + a + a + a +
+// LIMIT_SHORT-NEXT:                a;
+// LIMIT_SHORT:       assign b = _GEN;
 
-// LIMIT_LONG:        wire [7:0] _tmp = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
-// LIMIT_LONG-NEXT:                     a + a + a + a + a + a + a + a + a;
-// LIMIT_LONG-NEXT:   wire [7:0] _tmp_0 = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
-// LIMIT_LONG-NEXT:                       a + a + a + a + a + a + a + a + a;
-// LIMIT_LONG-NEXT:   assign b = _tmp + _tmp_0;
+// LIMIT_LONG:        wire [7:0] _GEN;
+// LIMIT_LONG:        assign _GEN = a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
+// LIMIT_LONG-NEXT:                 a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a +
+// LIMIT_LONG-NEXT:                 a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a + a;
+// LIMIT_LONG:        assign b = _GEN;
 
 hw.module @moduleWithComment()
   attributes {comment = "The quick brown fox jumps over the lazy dog.  The quick brown fox jumps over the lazy dog.\naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"} {}

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -917,15 +917,14 @@ hw.module @OutOfLineConstantsInAlwaysSensitivity() {
 // CHECK-LABEL: module TooLongConstExpr
 hw.module @TooLongConstExpr() {
   %myreg = sv.reg : !hw.inout<i4200>
-  // CHECK: always @* begin
+  // CHECK: always @*
   sv.always {
-    // CHECK-NEXT: localparam [4199:0] _tmp = 4200'h
-    // CHECK-NEXT: myreg <= 4200'(_tmp + _tmp);
+    // CHECK-NEXT: myreg <= 4200'(4200'h2323CB3A9903AD1D87D91023532E89D313E12BFCFCA2492A8561CADD94652CC4 +
+    // CHECK-NEXT:                             4200'h2323CB3A9903AD1D87D91023532E89D313E12BFCFCA2492A8561CADD94652CC4);
     %0 = hw.constant 15894191981981165163143546843135416146464164161464654561818646486465164684484 : i4200
     %1 = comb.add %0, %0 : i4200
     sv.passign %myreg, %1 : i4200
   }
-  // CHECK-NEXT: end
 }
 
 // Constants defined before use should be emitted in-place.


### PR DESCRIPTION
This is somewhat involved, and complicates ExportVerilog
significantly. Since we have developed a solution to handle this
problem in #2795, we can remove this code, and address this scenario
in PrepareForEmission.

It is also important to remove this code because it has bugs. I
believe they could have been resolved with #2773, but ultimately it is
better to do this in PrepareForEmission.

If the new logic doesn't cause a spill when the old logic would have,
the worst case is the expression remains inline. This might cause
Verilator to complain. But the previous logic could potentially drop
wires in illegal places, and it is best to remove that.