### PR TITLE
[Moore] Add shift expressions

### DIFF
--- a/include/circt/Dialect/Moore/MIRExpressions.td
+++ b/include/circt/Dialect/Moore/MIRExpressions.td
@@ -43,3 +43,53 @@ def ConcatOp : MIROp<"concat", [
     $values attr-dict `:` functional-type($values, $result)
   }];
 }
+
+//===----------------------------------------------------------------------===//
+// Shift operations
+//===----------------------------------------------------------------------===//
+
+class ShiftOp<string name> : MIROp<name, [
+    NoSideEffect, 
+    TypesMatchWith<"value and result types must match",
+                   "value", "result", "$_self">
+]> {
+  let arguments = (ins SimpleBitVectorType:$value,
+                       SimpleBitVectorType:$amount,
+                       UnitAttr:$arithmetic);
+  let results = (outs SimpleBitVectorType:$result);
+  let assemblyFormat = [{
+    ( `arithmetic` $arithmetic^ )? $value `,` $amount attr-dict
+    `:` type($value) `,` type($amount)
+  }];
+}
+
+def ShlOp : ShiftOp<"shl"> {
+  let summary = "A logical or arithmetic left-shift expression";
+  let description = [{
+    This operation represents the SystemVerilog logical and arithmetic
+    left-shift expressions `<<` and `<<<`.
+    See IEEE 1800-2017 §11.4.10 "Shift operators".
+
+    The value to be shifted and the amount must be simple bit vector types.
+    The shift result is of the same type as the input value.
+
+    The logical and arithmetic shift both insert zeros in place of the shifted
+    bits. 
+  }];
+}
+
+def ShrOp : ShiftOp<"shr"> {
+  let summary = "A logical or arithmetic right-shift expression";
+  let description = [{
+    This operation represents the SystemVerilog logical and arithmetic
+    right-shift expressions `>>` and `>>>`.
+    See IEEE 1800-2017 §11.4.10 "Shift operators".
+
+    The value to be shifted and the amount must be simple bit vector types.
+    The shift result is of the same type as the input value.
+
+    The logical shift always inserts zeros in place of the shifted bits.
+    The arithmetic shift inserts zeros if the result type is unsigned or the 
+    MSB (sign bit) if the result type is signed.
+  }];
+}

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -58,11 +58,37 @@ func @UnrealizedConversionCast(%arg0: !moore.byte) -> !moore.shortint {
 }
 
 // CHECK-LABEL: func @Expressions
-func @Expressions(%arg0: !moore.bit, %arg1: !moore.logic) {
+func @Expressions(%arg0: !moore.bit, %arg1: !moore.logic, %arg2: !moore.packed<range<bit, 5:0>>, %arg3: !moore.packed<range<bit<signed>, 4:0>>) {
   // CHECK-NEXT: %0 = comb.concat %arg0, %arg0 : i1, i1
   // CHECK-NEXT: %1 = comb.concat %arg1, %arg1 : i1, i1
   %0 = moore.mir.concat %arg0, %arg0 : (!moore.bit, !moore.bit) -> !moore.packed<range<bit, 1:0>>
   %1 = moore.mir.concat %arg1, %arg1 : (!moore.logic, !moore.logic) -> !moore.packed<range<logic, 1:0>>
+  // CHECK-NEXT: %[[V0:.+]] = hw.constant 0 : i5
+  // CHECK-NEXT: %[[V1:.+]] = comb.concat %[[V0]], %arg0 : i5, i1
+  // CHECK-NEXT: comb.shl %arg2, %[[V1]] : i6
+  // CHECK-NEXT: %[[V2:.+]] = comb.extract %arg2 from 5 : (i6) -> i1
+  // CHECK-NEXT: %[[V3:.+]] = hw.constant false
+  // CHECK-NEXT: %[[V4:.+]] = comb.icmp eq %[[V2]], %[[V3]] : i1
+  // CHECK-NEXT: %[[V5:.+]] = comb.extract %arg2 from 0 : (i6) -> i5
+  // CHECK-NEXT: %[[V6:.+]] = hw.constant -1 : i5
+  // CHECK-NEXT: %[[V7:.+]] = comb.mux %[[V4]], %[[V5]], %[[V6]] : i5
+  // CHECK-NEXT: comb.shl %arg3, %[[V7]] : i5
+  %2 = moore.mir.shl %arg2, %arg0 : !moore.packed<range<bit, 5:0>>, !moore.bit
+  %3 = moore.mir.shl arithmetic %arg3, %arg2 : !moore.packed<range<bit<signed>, 4:0>>, !moore.packed<range<bit, 5:0>>
+  // CHECK-NEXT: %[[V8:.+]] = hw.constant 0 : i5
+  // CHECK-NEXT: %[[V9:.+]] = comb.concat %[[V8]], %arg0 : i5, i1
+  // CHECK-NEXT: comb.shru %arg2, %[[V9]] : i6
+  // CHECK-NEXT: comb.shru %arg2, %arg2 : i6
+  // CHECK-NEXT: %[[V10:.+]] = comb.extract %arg2 from 5 : (i6) -> i1
+  // CHECK-NEXT: %[[V11:.+]] = hw.constant false
+  // CHECK-NEXT: %[[V12:.+]] = comb.icmp eq %[[V10]], %[[V11]] : i1
+  // CHECK-NEXT: %[[V13:.+]] = comb.extract %arg2 from 0 : (i6) -> i5
+  // CHECK-NEXT: %[[V14:.+]] = hw.constant -1 : i5
+  // CHECK-NEXT: %[[V15:.+]] = comb.mux %[[V12]], %[[V13]], %[[V14]] : i5
+  // CHECK-NEXT: comb.shrs %arg3, %[[V15]] : i5
+  %4 = moore.mir.shr %arg2, %arg0 : !moore.packed<range<bit, 5:0>>, !moore.bit
+  %5 = moore.mir.shr arithmetic %arg2, %arg2 : !moore.packed<range<bit, 5:0>>, !moore.packed<range<bit, 5:0>>
+  %6 = moore.mir.shr arithmetic %arg3, %arg2 : !moore.packed<range<bit<signed>, 4:0>>, !moore.packed<range<bit, 5:0>>
   // CHECK-NEXT: return
   return
 }

--- a/test/Dialect/Moore/basic.mlir
+++ b/test/Dialect/Moore/basic.mlir
@@ -11,10 +11,21 @@ llhd.entity @test1() -> () {
 }
 
 // CHECK-LABEL: func @Expressions
-func @Expressions(%a: !moore.bit, %b: !moore.logic) {
+func @Expressions(%a: !moore.bit, %b: !moore.logic, %c: !moore.packed<range<bit, 4:0>>) {
   // CHECK: %0 = moore.mir.concat
   // CHECK: %1 = moore.mir.concat
   %0 = moore.mir.concat %a, %a : (!moore.bit, !moore.bit) -> !moore.packed<range<bit, 1:0>>
   %1 = moore.mir.concat %b, %b : (!moore.logic, !moore.logic) -> !moore.packed<range<logic, 1:0>>
+
+  // CHECK: %2 = moore.mir.shl %
+  // CHECK: %3 = moore.mir.shl arithmetic %
+  %2 = moore.mir.shl %b, %a : !moore.logic, !moore.bit
+  %3 = moore.mir.shl arithmetic %c, %a : !moore.packed<range<bit, 4:0>>, !moore.bit
+
+  // CHECK: %4 = moore.mir.shr %
+  // CHECK: %5 = moore.mir.shr arithmetic %
+  %4 = moore.mir.shr %b, %a : !moore.logic, !moore.bit
+  %5 = moore.mir.shr arithmetic %c, %a : !moore.packed<range<bit, 4:0>>, !moore.bit
+
   return
 }


### PR DESCRIPTION
Add the logical and arithmetic left/right shift operations. `comb.shl` and the right-shift variants only support amount values with the same type as the value to be shifted. I'm not sure why this restriction was put in place and whether it could be lifted to reduce the number of operations we have to emit to adjust the integer bitwidth (also why isn't it the log2?).

## TODO

- [x] Land #2799 