### PR TITLE
[HW] InnerNameRef backed by a symbol

### DIFF
--- a/include/circt/Dialect/HW/HW.td
+++ b/include/circt/Dialect/HW/HW.td
@@ -19,6 +19,7 @@ include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/IR/RegionKindInterface.td"
 include "mlir/IR/FunctionInterfaces.td"
+include "mlir/IR/SubElementInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 

--- a/include/circt/Dialect/HW/HWAttributesNaming.td
+++ b/include/circt/Dialect/HW/HWAttributesNaming.td
@@ -10,17 +10,22 @@
 //
 //===----------------------------------------------------------------------===//
 
-def InnerRefAttr : AttrDef<HWDialect, "InnerRef"> {
+def InnerRefAttr : AttrDef<HWDialect, "InnerRef", [
+    DeclareAttrInterfaceMethods<SubElementAttrInterface>]> {
   let summary = "Refer to a name inside a module";
   let description = [{
     This works like a symbol reference, but to a name inside a module.
   }];
   let mnemonic = "innerNameRef";
-  let parameters = (ins "::mlir::StringAttr":$module, "::mlir::StringAttr":$name);
+  let parameters = (ins "::mlir::FlatSymbolRefAttr":$moduleRef,
+                        "::mlir::StringAttr":$name);
+
   let builders = [
-    AttrBuilderWithInferredContext<(ins "::mlir::StringAttr":$module, "::mlir::StringAttr":$name),[{
-      return get(module.getContext(), module, name);
-    }]>,
+    AttrBuilderWithInferredContext<(ins "::mlir::StringAttr":$module,
+                                        "::mlir::StringAttr":$name), [{
+      return $_get(
+          module.getContext(), mlir::FlatSymbolRefAttr::get(module), name);
+    }]>
   ];
 
   let hasCustomAssemblyFormat = 1;
@@ -28,7 +33,18 @@ def InnerRefAttr : AttrDef<HWDialect, "InnerRef"> {
   let extraClassDeclaration = [{
     /// Get the InnerRefAttr for an operation and add the sym on it.
     static InnerRefAttr getFromOperation(mlir::Operation *op,
-                  mlir::StringAttr symName, mlir::StringAttr moduleName) ;
+                                         mlir::StringAttr symName,
+                                         mlir::StringAttr moduleName);
+
+    /// Recursively traverse the sub-attribute.
+    void walkImmediateSubElements(
+        llvm::function_ref<void(mlir::Attribute)> walkAttrsFn,
+        llvm::function_ref<void(mlir::Type)> walkTypesFn) {
+      walkAttrsFn(getModule());
+    }
+
+    /// Return the name of the referenced module.
+    mlir::StringAttr getModule() const { return getModuleRef().getAttr(); }
   }];
 }
 

--- a/include/circt/Dialect/HW/HWSymCache.h
+++ b/include/circt/Dialect/HW/HWSymCache.h
@@ -48,7 +48,7 @@ public:
   void addDefinition(mlir::StringAttr modSymbol, mlir::StringAttr name,
                      mlir::Operation *op, size_t port = ~0ULL) {
     assert(!isFrozen && "cannot mutate a frozen cache");
-    auto key = InnerRefAttr::get(modSymbol.getContext(), modSymbol, name);
+    auto key = InnerRefAttr::get(modSymbol, name);
     symbolCache.try_emplace(key, op, port);
   }
 
@@ -71,7 +71,7 @@ public:
   }
 
   Item getDefinition(mlir::StringAttr modSymbol, mlir::StringAttr name) const {
-    return lookup(InnerRefAttr::get(modSymbol.getContext(), modSymbol, name));
+    return lookup(InnerRefAttr::get(modSymbol, name));
   }
 
   Item getDefinition(InnerRefAttr name) const { return lookup(name); }

--- a/include/circt/Dialect/SV/SV.td
+++ b/include/circt/Dialect/SV/SV.td
@@ -16,6 +16,7 @@
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/OpBase.td"
 include "mlir/IR/OpAsmInterface.td"
+include "mlir/IR/SubElementInterfaces.td"
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3435,7 +3435,7 @@ bool NonLocalAnchor::inlineModule(StringAttr moduleToDrop) {
         updateMade = true;
       } else if (!inlinedInstanceName.empty()) {
         newPath.push_back(hw::InnerRefAttr::get(
-            getContext(), ref.getModule(),
+            ref.getModule(),
             StringAttr::get(getContext(), inlinedInstanceName + "_" +
                                               ref.getName().getValue())));
         inlinedInstanceName = "";

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -1678,7 +1678,6 @@ void LowerTypesPass::runOnOperation() {
       SmallVector<Attribute> path(namepath.begin(), namepath.end());
       // Update the leaf element of the instance path to the new symbol.
       path[path.size() - 1] = hw::InnerRefAttr::get(
-          &getContext(),
           path[path.size() - 1].cast<hw::InnerRefAttr>().getModule(),
           nlaToSym.newSym);
       auto newPath = ArrayAttr::get(&getContext(), path);

--- a/lib/Dialect/HW/HWAttributes.cpp
+++ b/lib/Dialect/HW/HWAttributes.cpp
@@ -179,9 +179,7 @@ Attribute InnerRefAttr::parse(AsmParser &p, Type type) {
     return Attribute();
   if (attr.getNestedReferences().size() != 1)
     return Attribute();
-  auto *context = p.getContext();
-  return InnerRefAttr::get(context, attr.getRootReference(),
-                           attr.getLeafReference());
+  return InnerRefAttr::get(attr.getRootReference(), attr.getLeafReference());
 }
 
 void InnerRefAttr::print(AsmPrinter &p) const {


### PR DESCRIPTION
InnerNameRef now relies on a symbol constrained to a single nested reference.
It implements the SubElementAttrInterface trait so it can be scanned for references.
The constructor requiring a context argument was removed.