### PR TITLE
[FIRRTL][HW] Added module visibility attributes

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -30,6 +30,16 @@ def FModuleLike : OpInterface<"FModuleLike"> {
     /*methodBody=*/[{ return $_op.getNameAttr(); }]>,
 
     //===------------------------------------------------------------------===//
+    // Module visibility
+    //===------------------------------------------------------------------===//
+    InterfaceMethod<"Check whether the module is publicly visible",
+    "bool", "isPublic", (ins),
+    /*methodBody=*/[{
+      return SymbolTable::getSymbolVisibility($_op) ==
+             SymbolTable::Visibility::Public;
+    }]>,
+
+    //===------------------------------------------------------------------===//
     // Port Directions
     //===------------------------------------------------------------------===//
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -45,7 +45,7 @@ def CircuitOp : FIRRTLOp<"circuit",
 
     // Return the main module that is the entry point of the circuit.  This may
     // be either an FModuleOp or an FExtModuleOp.
-    Operation *getMainModule();
+    FModuleLike getMainModule();
   }];
 
   let assemblyFormat = "$name custom<CircuitOpAttrs>(attr-dict) $body";

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -982,6 +982,11 @@ FIRRTLModuleLowering::lowerModule(FModuleOp oldModule, Block *topLevelModule,
   if (auto outputFile = oldModule->getAttr("output_file"))
     newModule->setAttr("output_file", outputFile);
 
+  // If the circuit has an entry point, set all other modules private.
+  // Otherwise, mark all modules as public.
+  SymbolTable::setSymbolVisibility(newModule,
+                                   SymbolTable::getSymbolVisibility(oldModule));
+
   // Transform module annotations
   AnnotationSet annos(oldModule);
 

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3983,6 +3983,15 @@ DoneParsing:
   if (foundUnappliedAnnotations)
     return failure();
 
+  // If the module has an entry point that is not an external module, set the
+  // visibility of all non-main modules to private.
+  auto main = circuit.getMainModule();
+  if (isa<FModuleOp>(main)) {
+    for (auto mod : circuit.getOps<FModuleLike>()) {
+      if (mod != main)
+        SymbolTable::setSymbolVisibility(mod, SymbolTable::Visibility::Private);
+    }
+  }
   return success();
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -291,20 +291,12 @@ void IMConstPropPass::runOnOperation() {
 
   instanceGraph = &getAnalysis<InstanceGraph>();
 
-  // If the top level module is an external module, mark the input ports
-  // overdefined.
-  if (auto module = dyn_cast<FModuleOp>(circuit.getMainModule())) {
-    markBlockExecutable(module.getBody());
-    for (auto port : module.getBody()->getArguments())
-      markOverdefined(port);
-  } else {
-    // Otherwise, mark all module ports as being overdefined.
-    for (auto &circuitBodyOp : circuit.getBody()->getOperations()) {
-      if (auto module = dyn_cast<FModuleOp>(circuitBodyOp)) {
-        markBlockExecutable(module.getBody());
-        for (auto port : module.getBody()->getArguments())
-          markOverdefined(port);
-      }
+  // Mark the input ports of public modules as being overdefined.
+  for (auto module : circuit.getBody()->getOps<FModuleOp>()) {
+    if (module.isPublic()) {
+      markBlockExecutable(module.getBody());
+      for (auto port : module.getBody()->getArguments())
+        markOverdefined(port);
     }
   }
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -431,7 +431,7 @@ bool TypeLoweringVisitor::isModuleAllowedToPreserveAggregate(
 
   if (isa<FExtModuleOp>(module))
     return false;
-  return cast<CircuitOp>(module->getParentOp()).getMainModule() != module;
+  return !module.isPublic();
 }
 
 Value TypeLoweringVisitor::getSubWhatever(Value val, size_t index) {

--- a/lib/Dialect/FIRRTL/Transforms/RemoveUnusedPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/RemoveUnusedPorts.cpp
@@ -40,13 +40,12 @@ void RemoveUnusedPortsPass::runOnOperation() {
   auto &instanceGraph = getAnalysis<InstanceGraph>();
   LLVM_DEBUG(llvm::dbgs() << "===----- Remove unused ports -----==="
                           << "\n");
-  CircuitOp circuit = getOperation();
   // Iterate in the reverse order of instance graph iterator, i.e. from leaves
   // to top.
   for (auto *node : llvm::post_order(&instanceGraph))
     if (auto module = dyn_cast<FModuleOp>(node->getModule()))
       // Don't prune the main module.
-      if (circuit.getMainModule() != module)
+      if (!module.isPublic())
         removeUnusedModulePorts(module, node);
 }
 

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -801,6 +801,9 @@ static ParseResult parseHWModuleOp(OpAsmParser &parser, OperationState &result,
   SmallVector<Attribute> parameters;
   auto &builder = parser.getBuilder();
 
+  // Parse the visibility attribute.
+  mlir::impl::parseOptionalVisibilityKeyword(parser, result.attributes);
+
   // Parse the name as a symbol.
   StringAttr nameAttr;
   if (parser.parseSymbolName(nameAttr, SymbolTable::getSymbolAttrName(),
@@ -923,8 +926,14 @@ static void printModuleOp(OpAsmPrinter &p, Operation *op,
   auto argTypes = fnType.getInputs();
   auto resultTypes = fnType.getResults();
 
-  // Print the operation and the function name.
   p << ' ';
+
+  // Print the visibility of the module.
+  StringRef visibilityAttrName = SymbolTable::getVisibilityAttrName();
+  if (auto visibility = op->getAttrOfType<StringAttr>(visibilityAttrName))
+    p << visibility.getValue() << ' ';
+
+  // Print the operation and the function name.
   p.printSymbolName(SymbolTable::getSymbolName(op).getValue());
   if (modKind == GenMod) {
     p << ", ";
@@ -945,6 +954,7 @@ static void printModuleOp(OpAsmPrinter &p, Operation *op,
     omittedAttrs.push_back("argNames");
   omittedAttrs.push_back("resultNames");
   omittedAttrs.push_back("parameters");
+  omittedAttrs.push_back(visibilityAttrName);
   if (op->getAttrOfType<StringAttr>("comment").getValue().empty())
     omittedAttrs.push_back("comment");
 

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
@@ -13,7 +13,7 @@ firrtl.circuit "Simple" {
    // CHECK-SAME: <DEFAULT: i64, DEPTH: f64, FORMAT: none, WIDTH: i8>
    // CHECK-SAME: (%in: i1) -> (out: i8)
    // CHECK: attributes {verilogName = "name_thing"}
-   firrtl.extmodule @MyParameterizedExtModule
+   firrtl.extmodule private @MyParameterizedExtModule
      <DEFAULT: i64 = 0,
       DEPTH: f64 = 3.242000e+01,
       FORMAT: none = "xyz_timeout=%d\0A",
@@ -46,8 +46,8 @@ firrtl.circuit "Simple" {
     // CHECK-NEXT: hw.output [[RESULT]] : i4
   }
 
-  // CHECK-LABEL: hw.module @TestInstance(
-  firrtl.module @TestInstance(in %u2: !firrtl.uint<2>, in %s8: !firrtl.sint<8>,
+  // CHECK-LABEL: hw.module private @TestInstance(
+  firrtl.module private @TestInstance(in %u2: !firrtl.uint<2>, in %s8: !firrtl.sint<8>,
                               in %clock: !firrtl.clock,
                               in %reset: !firrtl.uint<1>) {
     // CHECK-NEXT: %c0_i2 = hw.constant
@@ -79,8 +79,8 @@ firrtl.circuit "Simple" {
     firrtl.printf %clock, %reset, "Something interesting! %x"(%myext#1) : !firrtl.uint<8>
   }
 
-  // CHECK-LABEL: hw.module @OutputFirst(%in1: i1, %in4: i4) -> (out4: i4) {
-  firrtl.module @OutputFirst(out %out4: !firrtl.uint<4>,
+  // CHECK-LABEL: hw.module private @OutputFirst(%in1: i1, %in4: i4) -> (out4: i4) {
+  firrtl.module private @OutputFirst(out %out4: !firrtl.uint<4>,
                              in %in1: !firrtl.uint<1>,
                              in %in4: !firrtl.uint<4>) {
     firrtl.connect %out4, %in4 : !firrtl.uint<4>, !firrtl.uint<4>
@@ -88,10 +88,10 @@ firrtl.circuit "Simple" {
     // CHECK-NEXT: hw.output %in4 : i4
   }
 
-  // CHECK-LABEL: hw.module @PortMadness(
+  // CHECK-LABEL: hw.module private @PortMadness(
   // CHECK: %inA: i4, %inB: i4, %inC: i4, %inE: i3)
   // CHECK: -> (outA: i4, outB: i4, outC: i4, outD: i4, outE: i4) {
-  firrtl.module @PortMadness(in %inA: !firrtl.uint<4>,
+  firrtl.module private @PortMadness(in %inA: !firrtl.uint<4>,
                              in %inB: !firrtl.uint<4>,
                              in %inC: !firrtl.uint<4>,
                              out %outA: !firrtl.uint<4>,
@@ -127,10 +127,10 @@ firrtl.circuit "Simple" {
     // CHECK: hw.output %inA, [[OUTBR]], [[OUTCR]], [[OUTDR]], [[OUTE]]
   }
 
-  // CHECK-LABEL: hw.module @Analog(%a1: !hw.inout<i1>) -> (outClock: i1) {
+  // CHECK-LABEL: hw.module private @Analog(%a1: !hw.inout<i1>) -> (outClock: i1) {
   // CHECK-NEXT:    %0 = sv.read_inout %a1 : !hw.inout<i1>
   // CHECK-NEXT:    hw.output %0 : i1
-  firrtl.module @Analog(in %a1: !firrtl.analog<1>,
+  firrtl.module private @Analog(in %a1: !firrtl.analog<1>,
                         out %outClock: !firrtl.clock) {
 
     %clock = firrtl.asClock %a1 : (!firrtl.analog<1>) -> !firrtl.clock
@@ -138,8 +138,8 @@ firrtl.circuit "Simple" {
   }
 
   // Issue #373: https://github.com/llvm/circt/issues/373
-  // CHECK-LABEL: hw.module @instance_ooo
-  firrtl.module @instance_ooo(in %arg0: !firrtl.uint<2>, in %arg1: !firrtl.uint<2>,
+  // CHECK-LABEL: hw.module private @instance_ooo
+  firrtl.module private @instance_ooo(in %arg0: !firrtl.uint<2>, in %arg1: !firrtl.uint<2>,
                               in %arg2: !firrtl.uint<3>,
                               out %out0: !firrtl.uint<8>) {
     // CHECK: %false = hw.constant false
@@ -163,8 +163,8 @@ firrtl.circuit "Simple" {
     // CHECK-NEXT: hw.output %myext.out
   }
 
-  // CHECK-LABEL: hw.module @instance_cyclic
-  firrtl.module @instance_cyclic(in %arg0: !firrtl.uint<2>, in %arg1: !firrtl.uint<2>) {
+  // CHECK-LABEL: hw.module private @instance_cyclic
+  firrtl.module private @instance_cyclic(in %arg0: !firrtl.uint<2>, in %arg1: !firrtl.uint<2>) {
     // CHECK: %myext.out = hw.instance "myext" @MyParameterizedExtModule<DEFAULT: i64 = 0, DEPTH: f64 = 3.242000e+01, FORMAT: none = "xyz_timeout=%d\0A", WIDTH: i8 = 32>(in: %0: i1)
     %myext:2 = firrtl.instance myext @MyParameterizedExtModule(in in: !firrtl.uint<1>, out out: !firrtl.uint<8>)
 
@@ -175,8 +175,8 @@ firrtl.circuit "Simple" {
     firrtl.connect %myext#0, %11 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 
-  // CHECK-LABEL: hw.module @ZeroWidthPorts(%inA: i4) -> (outa: i4) {
-  firrtl.module @ZeroWidthPorts(in %inA: !firrtl.uint<4>,
+  // CHECK-LABEL: hw.module private @ZeroWidthPorts(%inA: i4) -> (outa: i4) {
+  firrtl.module private @ZeroWidthPorts(in %inA: !firrtl.uint<4>,
                                 in %inB: !firrtl.uint<0>,
                                 in %inC: !firrtl.analog<0>,
                                 out %outa: !firrtl.uint<4>,
@@ -192,13 +192,13 @@ firrtl.circuit "Simple" {
     // CHECK: [[OUTAC:%.+]] = hw.constant 0 : i4
     // CHECK-NEXT: hw.output [[OUTAC]] : i4
   }
-  firrtl.extmodule @SameNamePorts(in inA: !firrtl.uint<4>,
+  firrtl.extmodule private @SameNamePorts(in inA: !firrtl.uint<4>,
                                 in inA: !firrtl.uint<1>,
                                 in inA: !firrtl.analog<1>,
                                 out outa: !firrtl.uint<4>,
                                 out outa: !firrtl.uint<1>)
-  // CHECK-LABEL: hw.module @ZeroWidthInstance
-  firrtl.module @ZeroWidthInstance(in %iA: !firrtl.uint<4>,
+  // CHECK-LABEL: hw.module private @ZeroWidthInstance
+  firrtl.module private @ZeroWidthInstance(in %iA: !firrtl.uint<4>,
                                    in %iB: !firrtl.uint<0>,
                                    in %iC: !firrtl.analog<0>,
                                    out %oA: !firrtl.uint<4>,
@@ -221,36 +221,36 @@ firrtl.circuit "Simple" {
     // CHECK: hw.output %myinst.outa
   }
 
-  // CHECK-LABEL: hw.module @SimpleStruct(%source: !hw.struct<valid: i1, ready: i1, data: i64>) -> (sink: !hw.struct<valid: i1, ready: i1, data: i64>) {
+  // CHECK-LABEL: hw.module private @SimpleStruct(%source: !hw.struct<valid: i1, ready: i1, data: i64>) -> (sink: !hw.struct<valid: i1, ready: i1, data: i64>) {
   // CHECK-NEXT:    hw.output %source : !hw.struct<valid: i1, ready: i1, data: i64>
-  firrtl.module @SimpleStruct(in %source: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>,
+  firrtl.module private @SimpleStruct(in %source: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>,
                               out %sink: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>) {
     firrtl.connect %sink, %source : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
   }
 
   // https://github.com/llvm/circt/issues/690
-  // CHECK-LABEL: hw.module @bar690(%led_0: !hw.inout<i1>) {
-  firrtl.module @bar690(in %led_0: !firrtl.analog<1>) {
+  // CHECK-LABEL: hw.module private @bar690(%led_0: !hw.inout<i1>) {
+  firrtl.module private @bar690(in %led_0: !firrtl.analog<1>) {
   }
-  // CHECK-LABEL: hw.module @foo690()
-  firrtl.module @foo690() {
+  // CHECK-LABEL: hw.module private @foo690()
+  firrtl.module private @foo690() {
     // CHECK: %.led_0.wire = sv.wire
     // CHECK: hw.instance "fpga" @bar690(led_0: %.led_0.wire: !hw.inout<i1>) -> ()
     %result = firrtl.instance fpga @bar690(in led_0: !firrtl.analog<1>)
   }
-  // CHECK-LABEL: hw.module @foo690a(%a: !hw.inout<i1>) {
-  firrtl.module @foo690a(in %a: !firrtl.analog<1>) {
+  // CHECK-LABEL: hw.module private @foo690a(%a: !hw.inout<i1>) {
+  firrtl.module private @foo690a(in %a: !firrtl.analog<1>) {
     %result = firrtl.instance fpga @bar690(in led_0: !firrtl.analog<1>)
     firrtl.attach %result, %a: !firrtl.analog<1>, !firrtl.analog<1>
   }
 
   // https://github.com/llvm/circt/issues/740
-  // CHECK-LABEL: hw.module @foo740(%led_0: !hw.inout<i1>) {
+  // CHECK-LABEL: hw.module private @foo740(%led_0: !hw.inout<i1>) {
   // CHECK:  %.led_0.wire = sv.wire
   // CHECK-NEXT: sv.read_inout %.led_0.wire
   // CHECK-NEXT:  hw.instance "fpga" @bar740(led_0: %.led_0.wire: !hw.inout<i1>) -> ()
-  firrtl.extmodule @bar740(in led_0: !firrtl.analog<1>)
-  firrtl.module @foo740(in %led_0: !firrtl.analog<1>) {
+  firrtl.extmodule private @bar740(in led_0: !firrtl.analog<1>)
+  firrtl.module private @foo740(in %led_0: !firrtl.analog<1>) {
     %result = firrtl.instance fpga @bar740(in led_0: !firrtl.analog<1>)
     firrtl.attach %result, %led_0 : !firrtl.analog<1>, !firrtl.analog<1>
   }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -341,8 +341,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 //    printf(clock, reset, "No operands!\n")
 //    printf(clock, reset, "Hi %x %x\n", add(a, a), b)
 
-  // CHECK-LABEL: hw.module @Print
-  firrtl.module @Print(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>,
+  // CHECK-LABEL: hw.module private @Print
+  firrtl.module private @Print(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>,
                        in %a: !firrtl.uint<4>, in %b: !firrtl.uint<4>) {
     // CHECK: [[ADD:%.+]] = comb.add
 
@@ -383,8 +383,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 //    stop(clock1, reset, 42)
 //    stop(clock2, reset, 0)
 
-  // CHECK-LABEL: hw.module @Stop
-  firrtl.module @Stop(in %clock1: !firrtl.clock, in %clock2: !firrtl.clock, in %reset: !firrtl.uint<1>) {
+  // CHECK-LABEL: hw.module private @Stop
+  firrtl.module private @Stop(in %clock1: !firrtl.clock, in %clock2: !firrtl.clock, in %reset: !firrtl.uint<1>) {
 
     // CHECK-NEXT: sv.always posedge %clock1 {
     // CHECK-NEXT:   sv.ifdef.procedural "SYNTHESIS" {
@@ -427,8 +427,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   //     cover(clock,  cCond, cEn, "cover0)"
   //     cover(clock,  cCond, cEn, "cover0)" : cover_0
 
-  // CHECK-LABEL: hw.module @Verification
-  firrtl.module @Verification(in %clock: !firrtl.clock, in %aCond: !firrtl.uint<1>,
+  // CHECK-LABEL: hw.module private @Verification
+  firrtl.module private @Verification(in %clock: !firrtl.clock, in %aCond: !firrtl.uint<1>,
     in %aEn: !firrtl.uint<1>, in %bCond: !firrtl.uint<1>, in %bEn: !firrtl.uint<1>,
     in %cCond: !firrtl.uint<1>, in %cEn: !firrtl.uint<1>, in %value: !firrtl.uint<42>) {
 
@@ -520,8 +520,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: hw.output
   }
 
-  // CHECK-LABEL: hw.module @VerificationGuards
-  firrtl.module @VerificationGuards(
+  // CHECK-LABEL: hw.module private @VerificationGuards
+  firrtl.module private @VerificationGuards(
     in %clock: !firrtl.clock,
     in %cond: !firrtl.uint<1>,
     in %enable: !firrtl.uint<1>
@@ -555,8 +555,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: }
   }
 
-  // CHECK-LABEL: hw.module @VerificationAssertFormat
-  firrtl.module @VerificationAssertFormat(
+  // CHECK-LABEL: hw.module private @VerificationAssertFormat
+  firrtl.module private @VerificationAssertFormat(
     in %clock: !firrtl.clock,
     in %cond: !firrtl.uint<1>,
     in %enable: !firrtl.uint<1>,
@@ -591,13 +591,13 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: }
   }
 
-  firrtl.module @bar(in %io_cpu_flush: !firrtl.uint<1>) {
+  firrtl.module private @bar(in %io_cpu_flush: !firrtl.uint<1>) {
     // CHECK: hw.probe @baz, %io_cpu_flush, %io_cpu_flush : i1, i1
     firrtl.probe @baz, %io_cpu_flush, %io_cpu_flush  : !firrtl.uint<1>, !firrtl.uint<1>
   }
 
-  // CHECK-LABEL: hw.module @foo
-  firrtl.module @foo() {
+  // CHECK-LABEL: hw.module private @foo
+  firrtl.module private @foo() {
     // CHECK-NEXT:  %io_cpu_flush.wire = sv.wire sym @__foo__io_cpu_flush.wire : !hw.inout<i1>
     // CHECK-NEXT:  [[IO:%[0-9]+]] = sv.read_inout %io_cpu_flush.wire
     %io_cpu_flush.wire = firrtl.wire {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<1>
@@ -615,8 +615,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-NOT: output_file
   // CHECK-NEXT: sv.bind <@bindTest::@[[quxSymbol:.+]]> {
   // CHECK-SAME: output_file = #hw.output_file<"outputDir/bindings.sv", excludeFromFileList>
-  // CHECK-NEXT: hw.module @bindTest()
-  firrtl.module @bindTest() {
+  // CHECK-NEXT: hw.module private @bindTest()
+  firrtl.module private @bindTest() {
     // CHECK: hw.instance "baz" sym @[[bazSymbol]] @bar
     %baz = firrtl.instance baz {lowerToBind = true} @bar(in io_cpu_flush: !firrtl.uint<1>)
     // CHECK: hw.instance "qux" sym @[[quxSymbol]] @bar
@@ -624,16 +624,16 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   }
 
 
-  // CHECK-LABEL: hw.module @output_fileTest
+  // CHECK-LABEL: hw.module private @output_fileTest
   // CHECK-SAME: output_file = #hw.output_file<"output_fileTest/dir/output_fileTest.sv", excludeFromFileList>
-  firrtl.module @output_fileTest() attributes {output_file = #hw.output_file<
+  firrtl.module private @output_fileTest() attributes {output_file = #hw.output_file<
     "output_fileTest/dir/output_fileTest.sv", excludeFromFileList
   >} {
   }
 
   // https://github.com/llvm/circt/issues/314
-  // CHECK-LABEL: hw.module @issue314
-  firrtl.module @issue314(in %inp_2: !firrtl.uint<27>, in %inpi: !firrtl.uint<65>) {
+  // CHECK-LABEL: hw.module private @issue314
+  firrtl.module private @issue314(in %inp_2: !firrtl.uint<27>, in %inpi: !firrtl.uint<65>) {
     // CHECK: %c0_i38 = hw.constant 0 : i38
     // CHECK: %tmp48 = sv.wire : !hw.inout<i27>
     %tmp48 = firrtl.wire : !firrtl.uint<27>
@@ -647,16 +647,16 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   }
 
   // https://github.com/llvm/circt/issues/318
-  // CHECK-LABEL: hw.module @test_rem
+  // CHECK-LABEL: hw.module private @test_rem
   // CHECK-NEXT:     %0 = comb.modu
   // CHECK-NEXT:     hw.output %0
-  firrtl.module @test_rem(in %tmp85: !firrtl.uint<1>, in %tmp79: !firrtl.uint<1>,
+  firrtl.module private @test_rem(in %tmp85: !firrtl.uint<1>, in %tmp79: !firrtl.uint<1>,
        out %out: !firrtl.uint<1>) {
     %2 = firrtl.rem %tmp79, %tmp85 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.connect %out, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 
-  // CHECK-LABEL: hw.module @Analog(%a1: !hw.inout<i1>, %b1: !hw.inout<i1>,
+  // CHECK-LABEL: hw.module private @Analog(%a1: !hw.inout<i1>, %b1: !hw.inout<i1>,
   // CHECK:                          %c1: !hw.inout<i1>) -> (outClock: i1) {
   // CHECK-NEXT:   %0 = sv.read_inout %c1 : !hw.inout<i1>
   // CHECK-NEXT:   %1 = sv.read_inout %b1 : !hw.inout<i1>
@@ -676,7 +676,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-NEXT:     }
   // CHECK-NEXT:    }
   // CHECK-NEXT:    hw.output %2 : i1
-  firrtl.module @Analog(in %a1: !firrtl.analog<1>, in %b1: !firrtl.analog<1>,
+  firrtl.module private @Analog(in %a1: !firrtl.analog<1>, in %b1: !firrtl.analog<1>,
                         in %c1: !firrtl.analog<1>, out %outClock: !firrtl.clock) {
     firrtl.attach %a1, %b1, %c1 : !firrtl.analog<1>, !firrtl.analog<1>, !firrtl.analog<1>
 
@@ -696,9 +696,9 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
  //   node _GEN_0 = mux(cond, value, count)
  //   count <= mux(reset, UInt<2>("h0"), _GEN_0)
 
-  // CHECK-LABEL: hw.module @UninitReg1(%clock: i1, %reset: i1, %cond: i1, %value: i2) {
+  // CHECK-LABEL: hw.module private @UninitReg1(%clock: i1, %reset: i1, %cond: i1, %value: i2) {
 
-  firrtl.module @UninitReg1(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>,
+  firrtl.module private @UninitReg1(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>,
                             in %cond: !firrtl.uint<1>, in %value: !firrtl.uint<2>) {
     // CHECK-NEXT: %c0_i2 = hw.constant 0 : i2
     %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
@@ -746,8 +746,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   //     io_q <= reg
   //     reg <= mux(io_en, io_d, reg)
 
-  // CHECK-LABEL: hw.module @InitReg1(
-  firrtl.module @InitReg1(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>,
+  // CHECK-LABEL: hw.module private @InitReg1(
+  firrtl.module private @InitReg1(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>,
                           in %io_d: !firrtl.uint<32>, in %io_en: !firrtl.uint<1>,
                           out %io_q: !firrtl.uint<32>) {
     // CHECK: %c0_i32 = hw.constant 0 : i32
@@ -841,8 +841,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   //     _M.write.data <= validif(inpred, indata)
   //     _M.write.mask <= validif(inpred, UInt<1>("h1"))
 
-  // CHECK-LABEL: hw.module @MemSimple(
-  firrtl.module @MemSimple(in %clock1: !firrtl.clock, in %clock2: !firrtl.clock,
+  // CHECK-LABEL: hw.module private @MemSimple(
+  firrtl.module private @MemSimple(in %clock1: !firrtl.clock, in %clock2: !firrtl.clock,
                            in %inpred: !firrtl.uint<1>, in %indata: !firrtl.sint<42>,
                            out %result: !firrtl.sint<42>,
                            out %result2: !firrtl.sint<42>) {
@@ -888,8 +888,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
       firrtl.connect %14, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 
-  // CHECK-LABEL: hw.module @MemSimple_mask(
-  firrtl.module @MemSimple_mask(in %clock1: !firrtl.clock, in %clock2: !firrtl.clock,
+  // CHECK-LABEL: hw.module private @MemSimple_mask(
+  firrtl.module private @MemSimple_mask(in %clock1: !firrtl.clock, in %clock2: !firrtl.clock,
                            in %inpred: !firrtl.uint<1>, in %indata: !firrtl.sint<40>,
                            out %result: !firrtl.sint<40>,
                            out %result2: !firrtl.sint<40>) {
@@ -937,9 +937,9 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
       %14 = firrtl.subfield %_M_write(4) : (!firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: sint<40>, mask: uint<4>>) -> !firrtl.uint<4>
       firrtl.connect %14, %c0_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
   }
-  // CHECK-LABEL: hw.module @IncompleteRead(
+  // CHECK-LABEL: hw.module private @IncompleteRead(
   // The read port has no use of the data field.
-  firrtl.module @IncompleteRead(in %clock1: !firrtl.clock) {
+  firrtl.module private @IncompleteRead(in %clock1: !firrtl.clock) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
 
@@ -954,12 +954,12 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.connect %8, %clock1 : !firrtl.clock, !firrtl.clock
   }
 
-  // CHECK-LABEL: hw.module @top_modx() -> (tmp27: i23) {
+  // CHECK-LABEL: hw.module private @top_modx() -> (tmp27: i23) {
   // CHECK-NEXT:    %c0_i23 = hw.constant 0 : i23
   // CHECK-NEXT:    %c42_i23 = hw.constant 42 : i23
   // CHECK-NEXT:    hw.output %c0_i23 : i23
   // CHECK-NEXT:  }
-  firrtl.module @top_modx(out %tmp27: !firrtl.uint<23>) {
+  firrtl.module private @top_modx(out %tmp27: !firrtl.uint<23>) {
     %0 = firrtl.wire : !firrtl.uint<0>
     %c42_ui23 = firrtl.constant 42 : !firrtl.uint<23>
     %1 = firrtl.tail %c42_ui23, 23 : (!firrtl.uint<23>) -> !firrtl.uint<0>
@@ -969,19 +969,19 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.connect %tmp27, %3 : !firrtl.uint<23>, !firrtl.uint<23>
   }
 
-  //CHECK-LABEL: hw.module @test_partialconnect(%clock: i1) {
+  //CHECK-LABEL: hw.module private @test_partialconnect(%clock: i1) {
   //CHECK: sv.always posedge %clock
-  firrtl.module @test_partialconnect(in %clock : !firrtl.clock) {
+  firrtl.module private @test_partialconnect(in %clock : !firrtl.clock) {
     %b = firrtl.reg %clock {name = "pcon"} : !firrtl.uint<1>
     %a = firrtl.constant 0 : !firrtl.uint<2>
     firrtl.partialconnect %b, %a : !firrtl.uint<1>, !firrtl.uint<2>
   }
 
-  // CHECK-LABEL: hw.module @SimpleStruct(%source: !hw.struct<valid: i1, ready: i1, data: i64>) -> (fldout: i64) {
+  // CHECK-LABEL: hw.module private @SimpleStruct(%source: !hw.struct<valid: i1, ready: i1, data: i64>) -> (fldout: i64) {
   // CHECK-NEXT:    %0 = hw.struct_extract %source["data"] : !hw.struct<valid: i1, ready: i1, data: i64>
   // CHECK-NEXT:    hw.output %0 : i64
   // CHECK-NEXT:  }
-  firrtl.module @SimpleStruct(in %source: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>,
+  firrtl.module private @SimpleStruct(in %source: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>,
                               out %fldout: !firrtl.uint<64>) {
     %2 = firrtl.subfield %source (2) : (!firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>) -> !firrtl.uint<64>
     firrtl.connect %fldout, %2 : !firrtl.uint<64>, !firrtl.uint<64>
@@ -989,7 +989,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
   // CHECK-LABEL: IsInvalidIssue572
   // https://github.com/llvm/circt/issues/572
-  firrtl.module @IsInvalidIssue572(in %a: !firrtl.analog<1>) {
+  firrtl.module private @IsInvalidIssue572(in %a: !firrtl.analog<1>) {
     // CHECK-NEXT: %0 = sv.read_inout %a : !hw.inout<i1>
 
     // CHECK-NEXT: %.invalid_analog = sv.wire : !hw.inout<i1>
@@ -1011,7 +1011,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
   // CHECK-LABEL: IsInvalidIssue654
   // https://github.com/llvm/circt/issues/654
-  firrtl.module @IsInvalidIssue654() {
+  firrtl.module private @IsInvalidIssue654() {
     %w = firrtl.wire : !firrtl.uint<0>
     %0 = firrtl.invalidvalue : !firrtl.uint<0>
     firrtl.connect %w, %0 : !firrtl.uint<0>, !firrtl.uint<0>
@@ -1019,20 +1019,20 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
   // CHECK-LABEL: ASQ
   // https://github.com/llvm/circt/issues/699
-  firrtl.module @ASQ(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset) {
+  firrtl.module private @ASQ(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %widx_widx_bin = firrtl.regreset %clock, %reset, %c0_ui1 {name = "widx_widx_bin"} : !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<4>
   }
 
-  // CHECK-LABEL: hw.module @Struct0bits(%source: !hw.struct<valid: i1, ready: i1, data: i0>) {
+  // CHECK-LABEL: hw.module private @Struct0bits(%source: !hw.struct<valid: i1, ready: i1, data: i0>) {
   // CHECK-NEXT:    hw.output
   // CHECK-NEXT:  }
-  firrtl.module @Struct0bits(in %source: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<0>>) {
+  firrtl.module private @Struct0bits(in %source: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<0>>) {
     %2 = firrtl.subfield %source (2) : (!firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<0>>) -> !firrtl.uint<0>
   }
 
-  // CHECK-LABEL: hw.module @MemDepth1
-  firrtl.module @MemDepth1(in %clock: !firrtl.clock, in %en: !firrtl.uint<1>,
+  // CHECK-LABEL: hw.module private @MemDepth1
+  firrtl.module private @MemDepth1(in %clock: !firrtl.clock, in %en: !firrtl.uint<1>,
                            in %addr: !firrtl.uint<1>, out %data: !firrtl.uint<32>) {
     // CHECK: %mem0.R0_data = hw.instance "mem0" @FIRRTLMem_1_0_0_32_1_0_1_0_1_1(R0_addr: %addr: i1, R0_en: %en: i1, R0_clk: %clock: i1) -> (R0_data: i32)
     // CHECK: hw.output %mem0.R0_data : i32
@@ -1048,15 +1048,15 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 }
 
   // https://github.com/llvm/circt/issues/1115
-  // CHECK-LABEL: hw.module @issue1115
-  firrtl.module @issue1115(in %a: !firrtl.sint<20>, out %tmp59: !firrtl.sint<2>) {
+  // CHECK-LABEL: hw.module private @issue1115
+  firrtl.module private @issue1115(in %a: !firrtl.sint<20>, out %tmp59: !firrtl.sint<2>) {
     %0 = firrtl.shr %a, 21 : (!firrtl.sint<20>) -> !firrtl.sint<1>
     firrtl.connect %tmp59, %0 : !firrtl.sint<2>, !firrtl.sint<1>
   }
 
-   // CHECK-LABEL: hw.module @UninitReg42(%clock: i1, %reset: i1, %cond: i1, %value: i42) {
+   // CHECK-LABEL: hw.module private @UninitReg42(%clock: i1, %reset: i1, %cond: i1, %value: i42) {
 
-  firrtl.module @UninitReg42(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>,
+  firrtl.module private @UninitReg42(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>,
                             in %cond: !firrtl.uint<1>, in %value: !firrtl.uint<42>) {
     %c0_ui42 = firrtl.constant 0 : !firrtl.uint<42>
     // CHECK: %count = sv.reg sym @count : !hw.inout<i42>
@@ -1085,7 +1085,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   }
 
   // CHECK-LABEL: issue1303
-  firrtl.module @issue1303(out %out: !firrtl.reset) {
+  firrtl.module private @issue1303(out %out: !firrtl.reset) {
     %c1_ui = firrtl.constant 1 : !firrtl.uint<1>
     firrtl.connect %out, %c1_ui : !firrtl.reset, !firrtl.uint<1>
     // CHECK-NEXT: %true = hw.constant true
@@ -1094,7 +1094,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
   // CHECK-LABEL: issue1594
   // Make sure LowerToHW's merging of always blocks kicks in for this example.
-  firrtl.module @issue1594(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
+  firrtl.module private @issue1594(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %reset_n = firrtl.wire  : !firrtl.uint<1>
     %0 = firrtl.not %reset : (!firrtl.uint<1>) -> !firrtl.uint<1>
@@ -1107,8 +1107,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK: hw.output
   }
 
-  // CHECK-LABEL: hw.module @Force
-  firrtl.module @Force(in %in: !firrtl.uint<42>) {
+  // CHECK-LABEL: hw.module private @Force
+  firrtl.module private @Force(in %in: !firrtl.uint<42>) {
     // CHECK: %out = sv.wire : !hw.inout<i42>
     // CHECK: sv.initial {
     // CHECK:   sv.force %out, %in : i42
@@ -1140,14 +1140,14 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   )
   attributes {annotations = [{class = "freechips.rocketchip.annotations.InternalVerifBlackBoxAnnotation"}]}
 
-  // CHECK-LABEL: hw.module @FooDUT
-  firrtl.module @FooDUT() attributes {annotations = [
+  // CHECK-LABEL: hw.module private @FooDUT
+  firrtl.module private @FooDUT() attributes {annotations = [
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
     %chckcoverAnno_clock = firrtl.instance chkcoverAnno @chkcoverAnno(in clock: !firrtl.clock)
   }
 
-  // CHECK-LABEL: hw.module @MemoryWritePortBehavior
-  firrtl.module @MemoryWritePortBehavior(in %clock1: !firrtl.clock, in %clock2: !firrtl.clock) {
+  // CHECK-LABEL: hw.module private @MemoryWritePortBehavior
+  firrtl.module private @MemoryWritePortBehavior(in %clock1: !firrtl.clock, in %clock2: !firrtl.clock) {
     // This memory has both write ports driven by the same clock.  It should be
     // lowered to an "aa" memory.
     //
@@ -1183,8 +1183,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.connect %clk_ab_node_w1, %tmp : !firrtl.clock, !firrtl.clock
   }
 
-  // CHECK-LABEL: hw.module @AsyncResetBasic(
-  firrtl.module @AsyncResetBasic(in %clock: !firrtl.clock, in %arst: !firrtl.asyncreset, in %srst: !firrtl.uint<1>) {
+  // CHECK-LABEL: hw.module private @AsyncResetBasic(
+  firrtl.module private @AsyncResetBasic(in %clock: !firrtl.clock, in %arst: !firrtl.asyncreset, in %srst: !firrtl.uint<1>) {
     %c9_ui42 = firrtl.constant 9 : !firrtl.uint<42>
     %c-9_si42 = firrtl.constant -9 : !firrtl.sint<42>
     // The following should not error because the reset values are constant.
@@ -1194,8 +1194,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %r3 = firrtl.regreset %clock, %srst, %c-9_si42 : !firrtl.uint<1>, !firrtl.sint<42>, !firrtl.sint<42>
   }
 
-  // CHECK-LABEL: hw.module @AsyncResetThroughWires(
-  firrtl.module @AsyncResetThroughWires(in %clock: !firrtl.clock, in %arst: !firrtl.asyncreset) {
+  // CHECK-LABEL: hw.module private @AsyncResetThroughWires(
+  firrtl.module private @AsyncResetThroughWires(in %clock: !firrtl.clock, in %arst: !firrtl.asyncreset) {
     %c9000_ui42 = firrtl.constant 9000 : !firrtl.uint<42>
     %c9001_ui42 = firrtl.constant 9001 : !firrtl.uint<42>
     // expected-note @+1 {{reset value defined here}}
@@ -1207,8 +1207,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %r0 = firrtl.regreset %clock, %arst, %constWire : !firrtl.asyncreset, !firrtl.uint<42>, !firrtl.uint<42>
   }
 
-  // CHECK-LABEL: hw.module @AsyncResetThroughNodes(
-  firrtl.module @AsyncResetThroughNodes(in %clock: !firrtl.clock, in %arst: !firrtl.asyncreset) {
+  // CHECK-LABEL: hw.module private @AsyncResetThroughNodes(
+  firrtl.module private @AsyncResetThroughNodes(in %clock: !firrtl.clock, in %arst: !firrtl.asyncreset) {
     %c1337_ui42 = firrtl.constant 1337 : !firrtl.uint<42>
     // expected-note @+1 {{reset value defined here}}
     %constNode = firrtl.node %c1337_ui42 : !firrtl.uint<42>
@@ -1217,42 +1217,42 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %r0 = firrtl.regreset %clock, %arst, %constNode : !firrtl.asyncreset, !firrtl.uint<42>, !firrtl.uint<42>
   }
 
-  // CHECK-LABEL: hw.module @BitCast1
-  firrtl.module @BitCast1() {
+  // CHECK-LABEL: hw.module private @BitCast1
+  firrtl.module private @BitCast1() {
     %a = firrtl.wire : !firrtl.vector<uint<2>, 13>
     %b = firrtl.bitcast %a : (!firrtl.vector<uint<2>, 13>) -> (!firrtl.uint<26>)
     // CHECK: hw.bitcast %0 : (!hw.array<13xi2>) -> i26
   }
 
-  // CHECK-LABEL: hw.module @BitCast2
-  firrtl.module @BitCast2() {
+  // CHECK-LABEL: hw.module private @BitCast2
+  firrtl.module private @BitCast2() {
     %a = firrtl.wire : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<1>>
     %b = firrtl.bitcast %a : (!firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<1>>) -> (!firrtl.uint<3>)
     // CHECK: hw.bitcast %0 : (!hw.struct<valid: i1, ready: i1, data: i1>) -> i3
 
   }
-  // CHECK-LABEL: hw.module @BitCast3
-  firrtl.module @BitCast3() {
+  // CHECK-LABEL: hw.module private @BitCast3
+  firrtl.module private @BitCast3() {
     %a = firrtl.wire : !firrtl.uint<26>
     %b = firrtl.bitcast %a : (!firrtl.uint<26>) -> (!firrtl.vector<uint<2>, 13>)
     // CHECK: hw.bitcast %0 : (i26) -> !hw.array<13xi2>
   }
 
-  // CHECK-LABEL: hw.module @BitCast4
-  firrtl.module @BitCast4() {
+  // CHECK-LABEL: hw.module private @BitCast4
+  firrtl.module private @BitCast4() {
     %a = firrtl.wire : !firrtl.uint<3>
     %b = firrtl.bitcast %a : (!firrtl.uint<3>) -> (!firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<1>>)
     // CHECK: hw.bitcast %0 : (i3) -> !hw.struct<valid: i1, ready: i1, data: i1>
 
   }
-  // CHECK-LABEL: hw.module @BitCast5
-  firrtl.module @BitCast5() {
+  // CHECK-LABEL: hw.module private @BitCast5
+  firrtl.module private @BitCast5() {
     %a = firrtl.wire : !firrtl.bundle<valid: uint<2>, ready: uint<1>, data: uint<3>>
     %b = firrtl.bitcast %a : (!firrtl.bundle<valid: uint<2>, ready: uint<1>, data: uint<3>>) -> (!firrtl.vector<uint<2>, 3>)
     // CHECK: hw.bitcast %0 : (!hw.struct<valid: i2, ready: i1, data: i3>) -> !hw.array<3xi2>
   }
 
-  // CHECK-LABEL: hw.module @InnerNames
+  // CHECK-LABEL: hw.module private @InnerNames
   // CHECK-SAME:  (
   // CHECK-SAME:    %value: i42 {hw.exportPort = @portValueSym}
   // CHECK-SAME:    %clock: i1 {hw.exportPort = @portClockSym}
@@ -1260,7 +1260,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-SAME:  ) -> (
   // CHECK-SAME:    out: i1 {hw.exportPort = @portOutSym}
   // CHECK-SAME:  )
-  firrtl.module @InnerNames(
+  firrtl.module private @InnerNames(
     in %value: !firrtl.uint<42> sym @portValueSym,
     in %clock: !firrtl.clock sym @portClockSym,
     in %reset: !firrtl.uint<1> sym @portResetSym,
@@ -1282,8 +1282,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.connect %out, %reset : !firrtl.uint<1>, !firrtl.uint<1>
   }
 
-  // CHECK-LABEL: hw.module @regInitRandomReuse
-  firrtl.module @regInitRandomReuse(in %clock: !firrtl.clock, in %a: !firrtl.uint<1>, out %o1: !firrtl.uint<2>, out %o2: !firrtl.uint<4>, out %o3: !firrtl.uint<32>, out %o4: !firrtl.uint<100>) {
+  // CHECK-LABEL: hw.module private @regInitRandomReuse
+  firrtl.module private @regInitRandomReuse(in %clock: !firrtl.clock, in %a: !firrtl.uint<1>, out %o1: !firrtl.uint<2>, out %o2: !firrtl.uint<4>, out %o3: !firrtl.uint<32>, out %o4: !firrtl.uint<100>) {
     %r1 = firrtl.reg %clock  : !firrtl.uint<2>
     %r2 = firrtl.reg %clock  : !firrtl.uint<4>
     %r3 = firrtl.reg %clock  : !firrtl.uint<32>
@@ -1326,8 +1326,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.connect %o4, %r4 : !firrtl.uint<100>, !firrtl.uint<100>
   }
 
-  // CHECK-LABEL: hw.module @init1DVector
-  firrtl.module @init1DVector(in %clock: !firrtl.clock, in %a: !firrtl.vector<uint<1>, 2>, out %b: !firrtl.vector<uint<1>, 2>) {
+  // CHECK-LABEL: hw.module private @init1DVector
+  firrtl.module private @init1DVector(in %clock: !firrtl.clock, in %a: !firrtl.vector<uint<1>, 2>, out %b: !firrtl.vector<uint<1>, 2>) {
     %r = firrtl.reg %clock  : !firrtl.vector<uint<1>, 2>
     // CHECK:      %r = sv.reg sym @[[r_sym:[_A-Za-z0-9]+]]
     // CHECK:      sv.ifdef "SYNTHESIS" {
@@ -1353,8 +1353,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: hw.output %0 : !hw.array<2xi1>
   }
 
-  // CHECK-LABEL: hw.module @init2DVector
-  firrtl.module @init2DVector(in %clock: !firrtl.clock, in %a: !firrtl.vector<vector<uint<1>, 1>, 1>, out %b: !firrtl.vector<vector<uint<1>, 1>, 1>) {
+  // CHECK-LABEL: hw.module private @init2DVector
+  firrtl.module private @init2DVector(in %clock: !firrtl.clock, in %a: !firrtl.vector<vector<uint<1>, 1>, 1>, out %b: !firrtl.vector<vector<uint<1>, 1>, 1>) {
     %r = firrtl.reg %clock  : !firrtl.vector<vector<uint<1>, 1>, 1>
     // CKECK-NEXT: sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
     // CKECK-NEXT:   %1 = sv.array_index_inout %r[%false] : !hw.inout<array<1xarray<1xi1>>>, i1
@@ -1373,8 +1373,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: hw.output %0 : !hw.array<1xarray<1xi1>>
   }
 
-  // CHECK-LABEL: hw.module @connectNarrowUIntVector
-  firrtl.module @connectNarrowUIntVector(in %clock: !firrtl.clock, in %a: !firrtl.vector<uint<1>, 1>, out %b: !firrtl.vector<uint<3>, 1>) {
+  // CHECK-LABEL: hw.module private @connectNarrowUIntVector
+  firrtl.module private @connectNarrowUIntVector(in %clock: !firrtl.clock, in %a: !firrtl.vector<uint<1>, 1>, out %b: !firrtl.vector<uint<3>, 1>) {
     %r1 = firrtl.reg %clock  : !firrtl.vector<uint<2>, 1>
     firrtl.connect %r1, %a : !firrtl.vector<uint<2>, 1>, !firrtl.vector<uint<1>, 1>
     firrtl.connect %b, %r1 : !firrtl.vector<uint<3>, 1>, !firrtl.vector<uint<2>, 1>
@@ -1391,8 +1391,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: hw.output %0 : !hw.array<1xi3>
   }
 
-  // CHECK-LABEL: hw.module @connectNarrowSIntVector
-  firrtl.module @connectNarrowSIntVector(in %clock: !firrtl.clock, in %a: !firrtl.vector<sint<1>, 1>, out %b: !firrtl.vector<sint<3>, 1>) {
+  // CHECK-LABEL: hw.module private @connectNarrowSIntVector
+  firrtl.module private @connectNarrowSIntVector(in %clock: !firrtl.clock, in %a: !firrtl.vector<sint<1>, 1>, out %b: !firrtl.vector<sint<3>, 1>) {
     %r1 = firrtl.reg %clock  : !firrtl.vector<sint<2>, 1>
     firrtl.connect %r1, %a : !firrtl.vector<sint<2>, 1>, !firrtl.vector<sint<1>, 1>
     firrtl.connect %b, %r1 : !firrtl.vector<sint<3>, 1>, !firrtl.vector<sint<2>, 1>
@@ -1410,8 +1410,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: hw.output %0 : !hw.array<1xi3>
   }
 
-  // CHECK-LABEL: hw.module @partialConnectVector
-  firrtl.module @partialConnectVector(in %clock: !firrtl.clock, in %a: !firrtl.vector<uint<3>, 1>, out %b: !firrtl.vector<uint<1>, 1>) {
+  // CHECK-LABEL: hw.module private @partialConnectVector
+  firrtl.module private @partialConnectVector(in %clock: !firrtl.clock, in %a: !firrtl.vector<uint<3>, 1>, out %b: !firrtl.vector<uint<1>, 1>) {
     %r = firrtl.reg %clock  : !firrtl.vector<uint<2>, 1>
     firrtl.partialconnect %r, %a : !firrtl.vector<uint<2>, 1>, !firrtl.vector<uint<3>, 1>
     firrtl.partialconnect %b, %r : !firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<2>, 1>
@@ -1430,8 +1430,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: hw.output %0 : !hw.array<1xi1>
   }
 
-  // CHECK-LABEL: hw.module @SubIndex
-  firrtl.module @SubIndex(in %a: !firrtl.vector<vector<uint<1>, 1>, 1>, in %clock: !firrtl.clock, out %o1: !firrtl.uint<1>, out %o2: !firrtl.vector<uint<1>, 1>) {
+  // CHECK-LABEL: hw.module private @SubIndex
+  firrtl.module private @SubIndex(in %a: !firrtl.vector<vector<uint<1>, 1>, 1>, in %clock: !firrtl.clock, out %o1: !firrtl.uint<1>, out %o2: !firrtl.vector<uint<1>, 1>) {
     %r1 = firrtl.reg %clock  : !firrtl.uint<1>
     %r2 = firrtl.reg %clock  : !firrtl.vector<uint<1>, 1>
     %0 = firrtl.subindex %a[0] : !firrtl.vector<vector<uint<1>, 1>, 1>
@@ -1449,8 +1449,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: hw.output %0, %1 : i1, !hw.array<1xi1>
   }
 
-  // CHECK-LABEL: hw.module @partialConnectDifferentVectorLength
-  firrtl.module @partialConnectDifferentVectorLength(in %clock: !firrtl.clock, in %a: !firrtl.vector<uint<1>, 2>, out %b: !firrtl.vector<uint<1>, 1>) {
+  // CHECK-LABEL: hw.module private @partialConnectDifferentVectorLength
+  firrtl.module private @partialConnectDifferentVectorLength(in %clock: !firrtl.clock, in %a: !firrtl.vector<uint<1>, 2>, out %b: !firrtl.vector<uint<1>, 1>) {
     %r1 = firrtl.reg %clock  : !firrtl.vector<uint<1>, 2>
     firrtl.connect %r1, %a : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
     firrtl.partialconnect %b, %r1 : !firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 2>
@@ -1465,8 +1465,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: hw.output %0 : !hw.array<1xi1>
   }
 
-  // CHECK-LABEL: hw.module @SubindexDestination
-  firrtl.module @SubindexDestination(in %clock: !firrtl.clock, in %a: !firrtl.vector<uint<1>, 3>, out %b: !firrtl.vector<uint<1>, 3>) {
+  // CHECK-LABEL: hw.module private @SubindexDestination
+  firrtl.module private @SubindexDestination(in %clock: !firrtl.clock, in %a: !firrtl.vector<uint<1>, 3>, out %b: !firrtl.vector<uint<1>, 3>) {
     %0 = firrtl.subindex %b[2] : !firrtl.vector<uint<1>, 3>
     %1 = firrtl.subindex %a[2] : !firrtl.vector<uint<1>, 3>
     firrtl.connect %0, %1 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -1479,16 +1479,16 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: hw.output %0 : !hw.array<3xi1>
   }
 
-  // CHECK-LABEL: hw.module @zero_width_constant()
+  // CHECK-LABEL: hw.module private @zero_width_constant()
   // https://github.com/llvm/circt/issues/2269
-  firrtl.module @zero_width_constant(out %a: !firrtl.uint<0>) {
+  firrtl.module private @zero_width_constant(out %a: !firrtl.uint<0>) {
     // CHECK-NEXT: hw.output
     %c0_ui0 = firrtl.constant 0 : !firrtl.uint<0>
     firrtl.connect %a, %c0_ui0 : !firrtl.uint<0>, !firrtl.uint<0>
   }
 
   // CHECK-LABEL: @subfield_write1(
-  firrtl.module @subfield_write1(out %a: !firrtl.bundle<a: uint<1>>) {
+  firrtl.module private @subfield_write1(out %a: !firrtl.bundle<a: uint<1>>) {
     %0 = firrtl.subfield %a(0) : (!firrtl.bundle<a: uint<1>>) -> !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     firrtl.connect %0, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -1501,7 +1501,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   }
 
   // CHECK-LABEL: @subfield_write2(
-  firrtl.module @subfield_write2(in %in: !firrtl.uint<1>, out %sink: !firrtl.bundle<a: bundle<b: bundle<c: uint<1>>>>) {
+  firrtl.module private @subfield_write2(in %in: !firrtl.uint<1>, out %sink: !firrtl.bundle<a: bundle<b: bundle<c: uint<1>>>>) {
     %0 = firrtl.subfield %sink(0) : (!firrtl.bundle<a: bundle<b: bundle<c: uint<1>>>>) -> !firrtl.bundle<b: bundle<c: uint<1>>>
     %1 = firrtl.subfield %0(0) : (!firrtl.bundle<b: bundle<c: uint<1>>>) -> !firrtl.bundle<c: uint<1>>
     %2 = firrtl.subfield %1(0) : (!firrtl.bundle<c: uint<1>>) -> !firrtl.uint<1>
@@ -1515,8 +1515,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: hw.output %0 : !hw.struct<a: !hw.struct<b: !hw.struct<c: i1>>>
   }
 
-  // CHECK-LABEL: hw.module @initStruct
-  firrtl.module @initStruct(in %clock: !firrtl.clock) {
+  // CHECK-LABEL: hw.module private @initStruct
+  firrtl.module private @initStruct(in %clock: !firrtl.clock) {
     %r = firrtl.reg %clock  : !firrtl.bundle<a: uint<1>>
     // CHECK:      %r = sv.reg sym @[[r_sym:[_A-Za-z0-9]+]]
     // CHECK:      sv.ifdef "SYNTHESIS" {
@@ -1534,8 +1534,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: }
   }
 
-  // CHECK-LABEL: hw.module @RegResetStructWiden
-  firrtl.module @RegResetStructWiden(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %init: !firrtl.bundle<a: uint<2>>) {
+  // CHECK-LABEL: hw.module private @RegResetStructWiden
+  firrtl.module private @RegResetStructWiden(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %init: !firrtl.bundle<a: uint<2>>) {
     // CHECK:      [[FALSE:%.*]] = hw.constant false
     // CHECK-NEXT: [[A:%.*]] = hw.struct_extract %init["a"] : !hw.struct<a: i2>
     // CHECK-NEXT: [[PADDED:%.*]] = comb.concat [[FALSE]], [[A]] : i1, i2
@@ -1550,8 +1550,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %reg = firrtl.regreset %clock, %reset, %init  : !firrtl.uint<1>, !firrtl.bundle<a: uint<2>>, !firrtl.bundle<a: uint<3>>
   }
 
-  // CHECK-LABEL: hw.module @BundleConnection
-  firrtl.module @BundleConnection(in %source: !firrtl.bundle<a: bundle<b: uint<1>>>, out %sink: !firrtl.bundle<a: bundle<b: uint<1>>>) {
+  // CHECK-LABEL: hw.module private @BundleConnection
+  firrtl.module private @BundleConnection(in %source: !firrtl.bundle<a: bundle<b: uint<1>>>, out %sink: !firrtl.bundle<a: bundle<b: uint<1>>>) {
     %0 = firrtl.subfield %sink(0) : (!firrtl.bundle<a: bundle<b: uint<1>>>) -> !firrtl.bundle<b: uint<1>>
     %1 = firrtl.subfield %source(0) : (!firrtl.bundle<a: bundle<b: uint<1>>>) -> !firrtl.bundle<b: uint<1>>
     firrtl.connect %0, %1 : !firrtl.bundle<b: uint<1>>, !firrtl.bundle<b: uint<1>>
@@ -1563,8 +1563,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: hw.output %0 : !hw.struct<a: !hw.struct<b: i1>>
   }
 
-  // CHECK-LABEL: hw.module @AggregateInvalidValue
-  firrtl.module @AggregateInvalidValue(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
+  // CHECK-LABEL: hw.module private @AggregateInvalidValue
+  firrtl.module private @AggregateInvalidValue(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
     %invalid = firrtl.invalidvalue : !firrtl.bundle<a: uint<1>, b: vector<uint<10>, 10>>
     %reg = firrtl.regreset %clock, %reset, %invalid : !firrtl.uint<1>, !firrtl.bundle<a: uint<1>, b: vector<uint<10>, 10>>, !firrtl.bundle<a: uint<1>, b: vector<uint<10>, 10>>
     // CHECK:      %c0_i101 = hw.constant 0 : i101
@@ -1578,8 +1578,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: }
   }
 
-  // CHECK-LABEL: hw.module @AggregateRegAssign
-  firrtl.module @AggregateRegAssign(in %clock: !firrtl.clock, in %value: !firrtl.uint<1>) {
+  // CHECK-LABEL: hw.module private @AggregateRegAssign
+  firrtl.module private @AggregateRegAssign(in %clock: !firrtl.clock, in %value: !firrtl.uint<1>) {
     %reg = firrtl.reg %clock : !firrtl.vector<uint<1>, 1>
     %reg_0 = firrtl.subindex %reg[0] : !firrtl.vector<uint<1>, 1>
     firrtl.connect %reg_0, %value : !firrtl.uint<1>, !firrtl.uint<1>
@@ -1587,8 +1587,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK:  sv.passign %0, %value : i1
   }
 
-  // CHECK-LABEL: hw.module @AggregateRegResetAssign
-  firrtl.module @AggregateRegResetAssign(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>,
+  // CHECK-LABEL: hw.module private @AggregateRegResetAssign
+  firrtl.module private @AggregateRegResetAssign(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>,
                                          in %init: !firrtl.vector<uint<1>, 1>, in %value: !firrtl.uint<1>) {
     %reg = firrtl.regreset %clock, %reset, %init  : !firrtl.uint<1>, !firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 1>
     %reg_0 = firrtl.subindex %reg[0] : !firrtl.vector<uint<1>, 1>
@@ -1597,16 +1597,16 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK:  sv.passign %0, %value : i1
   }
 
-  // CHECK-LABEL: hw.module @ForceNameSubmodule
+  // CHECK-LABEL: hw.module private @ForceNameSubmodule
   firrtl.nla @nla_1 [#hw.innerNameRef<@ForceNameTop::@sym_foo>,@ForceNameSubmodule]
   firrtl.nla @nla_2 [#hw.innerNameRef<@ForceNameTop::@sym_bar>,@ForceNameSubmodule]
-  firrtl.module @ForceNameSubmodule() attributes {annotations = [
+  firrtl.module private @ForceNameSubmodule() attributes {annotations = [
     {circt.nonlocal = @nla_2,
      class = "chisel3.util.experimental.ForceNameAnnotation", name = "Bar"},
     {circt.nonlocal = @nla_1,
      class = "chisel3.util.experimental.ForceNameAnnotation", name = "Foo"}]} {}
-  // CHECK: hw.module @ForceNameTop
-  firrtl.module @ForceNameTop() {
+  // CHECK: hw.module private @ForceNameTop
+  firrtl.module private @ForceNameTop() {
     firrtl.instance foo sym @sym_foo
       {annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}]}
       @ForceNameSubmodule()
@@ -1617,15 +1617,15 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: hw.instance "bar" sym @sym_bar {{.+}} {hw.verilogName = "Bar"}
   }
 
-  // CHECK-LABEL: hw.module @PreserveName
-  firrtl.module @PreserveName(in %a : !firrtl.uint<1>, in %b : !firrtl.uint<1>, out %c : !firrtl.uint<1>) {
+  // CHECK-LABEL: hw.module private @PreserveName
+  firrtl.module private @PreserveName(in %a : !firrtl.uint<1>, in %b : !firrtl.uint<1>, out %c : !firrtl.uint<1>) {
     //CHECK comb.or %a, %b {sv.namehint = "myname"}
     %foo = firrtl.or %a, %b {name = "myname"} : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.connect %c, %foo : !firrtl.uint<1>, !firrtl.uint<1>
   }
 
-  // CHECK-LABEL: hw.module @MutlibitMux(%source_0: i1, %source_1: i1, %source_2: i1, %index: i2) -> (sink: i1) {
-  firrtl.module @MutlibitMux(in %source_0: !firrtl.uint<1>, in %source_1: !firrtl.uint<1>, in %source_2: !firrtl.uint<1>, out %sink: !firrtl.uint<1>, in %index: !firrtl.uint<2>) {
+  // CHECK-LABEL: hw.module private @MutlibitMux(%source_0: i1, %source_1: i1, %source_2: i1, %index: i2) -> (sink: i1) {
+  firrtl.module private @MutlibitMux(in %source_0: !firrtl.uint<1>, in %source_1: !firrtl.uint<1>, in %source_2: !firrtl.uint<1>, out %sink: !firrtl.uint<1>, in %index: !firrtl.uint<2>) {
     %0 = firrtl.multibit_mux %index, %source_2, %source_1, %source_0 : !firrtl.uint<2>, !firrtl.uint<1>
     firrtl.connect %sink, %0 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK:      %0 = hw.array_create %source_2, %source_1, %source_0 : i1
@@ -1636,7 +1636,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: hw.output %4 : i1
   }
 
-  firrtl.module @inferUnmaskedMemory(in %clock: !firrtl.clock, in %rAddr: !firrtl.uint<4>, in %rEn: !firrtl.uint<1>, out %rData: !firrtl.uint<8>, in %wMask: !firrtl.uint<1>, in %wData: !firrtl.uint<8>) {
+  firrtl.module private @inferUnmaskedMemory(in %clock: !firrtl.clock, in %rAddr: !firrtl.uint<4>, in %rEn: !firrtl.uint<1>, out %rData: !firrtl.uint<8>, in %wMask: !firrtl.uint<1>, in %wData: !firrtl.uint<8>) {
     %tbMemoryKind1_r, %tbMemoryKind1_w = firrtl.mem Undefined  {depth = 16 : i64, modName = "tbMemoryKind1_ext", name = "tbMemoryKind1", portNames = ["r", "w"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
     %0 = firrtl.subfield %tbMemoryKind1_w(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.uint<8>
     %1 = firrtl.subfield %tbMemoryKind1_w(4) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.uint<1>
@@ -1657,15 +1657,15 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.connect %1, %wMask : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %0, %wData : !firrtl.uint<8>, !firrtl.uint<8>
   }
-  // CHECK-LABEL: hw.module @inferUnmaskedMemory
+  // CHECK-LABEL: hw.module private @inferUnmaskedMemory
   // CHECK-NEXT:   %[[v0:.+]] = comb.and %rEn, %wMask : i1
   // CHECK-NEXT:   %tbMemoryKind1.R0_data = hw.instance "tbMemoryKind1" @tbMemoryKind1_ext(R0_addr: %rAddr: i4, R0_en: %rEn: i1, R0_clk: %clock: i1, W0_addr: %rAddr: i4, W0_en: %[[v0]]: i1, W0_clk: %clock: i1, W0_data: %wData: i8) -> (R0_data: i8)
   // CHECK-NEXT:   hw.output %tbMemoryKind1.R0_data : i8
 
-  // CHECK-LABEL: hw.module @eliminateSingleOutputConnects
+  // CHECK-LABEL: hw.module private @eliminateSingleOutputConnects
   // CHECK-NOT:     [[WIRE:%.+]] = sv.wire
   // CHECK-NEXT:    hw.output %a : i1
-  firrtl.module @eliminateSingleOutputConnects(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
+  firrtl.module private @eliminateSingleOutputConnects(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
     firrtl.strictconnect %b, %a : !firrtl.uint<1>
   }
 }

--- a/test/Conversion/FIRRTLToHW/module-hierarchy-file.mlir
+++ b/test/Conversion/FIRRTLToHW/module-hierarchy-file.mlir
@@ -32,9 +32,9 @@ firrtl.circuit "MyTestHarness" attributes {annotations = [
   {class = "sifive.enterprise.firrtl.ModuleHierarchyAnnotation", filename = "./dir1/filename1.json" },
   {class = "sifive.enterprise.firrtl.TestHarnessHierarchyAnnotation", filename = "./dir2/filename2.json" }]}
 {
-  // CHECK-LABEL: hw.module @MyDUT
+  // CHECK-LABEL: hw.module private @MyDUT
   // CHECK-SAME: attributes {firrtl.moduleHierarchyFile = [#hw.output_file<"./dir1/filename1.json", excludeFromFileList>]}
-  firrtl.module @MyDUT() attributes {annotations = [
+  firrtl.module private @MyDUT() attributes {annotations = [
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {}
 
   // CHECK-LABEL: hw.module @MyTestHarness

--- a/test/Conversion/FIRRTLToHW/zero-width.mlir
+++ b/test/Conversion/FIRRTLToHW/zero-width.mlir
@@ -39,8 +39,8 @@ firrtl.circuit "Arithmetic" {
     // CHECK: hw.output %c0_i3, [[ADDRES]], %c0_i4, %true
   }
 
-  // CHECK-LABEL: hw.module @Exotic
-  firrtl.module @Exotic(in %uin3c: !firrtl.uint<3>,
+  // CHECK-LABEL: hw.module private @Exotic
+  firrtl.module private @Exotic(in %uin3c: !firrtl.uint<3>,
                         out %out0: !firrtl.uint<3>,
                         out %out1: !firrtl.uint<3>) {
     %uin0c = firrtl.wire : !firrtl.uint<0>
@@ -67,8 +67,8 @@ firrtl.circuit "Arithmetic" {
     // CHECK: hw.output %uin3c, %uin3c : i3, i3
   }
 
-  // CHECK-LABEL: hw.module @Decls
-  firrtl.module @Decls(in %uin3c: !firrtl.uint<3>) {
+  // CHECK-LABEL: hw.module private @Decls
+  firrtl.module private @Decls(in %uin3c: !firrtl.uint<3>) {
     %sin0c = firrtl.wire : !firrtl.sint<0>
     %uin0c = firrtl.wire : !firrtl.uint<0>
 

--- a/test/Dialect/FIRRTL/SFCTests/constantProp.mlir
+++ b/test/Dialect/FIRRTL/SFCTests/constantProp.mlir
@@ -10,8 +10,8 @@ firrtl.circuit "ConstInput"   {
     firrtl.connect %c_in1, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %z, %c_out : !firrtl.uint<1>, !firrtl.uint<1>
   }
-  // CHECK-LABEL: firrtl.module @Child
-  firrtl.module @Child(in %in0: !firrtl.uint<1>, in %in1: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
+  // CHECK-LABEL: firrtl.module private @Child
+  firrtl.module private @Child(in %in0: !firrtl.uint<1>, in %in1: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
     %0 = firrtl.and %in0, %in1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     // CHECK: firrtl.strictconnect %out, %in0 :
     firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -20,14 +20,14 @@ firrtl.circuit "ConstInput"   {
 
 //propagate constant inputs ONLY if ALL instance inputs get the same value
 firrtl.circuit "InstanceInput"   {
-  // CHECK-LABEL: firrtl.module @Bottom1
-  firrtl.module @Bottom1(in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
+  // CHECK-LABEL: firrtl.module private @Bottom1
+  firrtl.module private @Bottom1(in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
       // CHECK: %c1_ui1 = firrtl.constant 1
       // CHECK: firrtl.strictconnect %out, %c1_ui1
     firrtl.connect %out, %in : !firrtl.uint<1>, !firrtl.uint<1>
   }
-  // CHECK-LABEL: firrtl.module @Child1
-  firrtl.module @Child1(out %out: !firrtl.uint<1>) {
+  // CHECK-LABEL: firrtl.module private @Child1
+  firrtl.module private @Child1(out %out: !firrtl.uint<1>) {
     %c1_ui = firrtl.constant 1 : !firrtl.uint
     %b0_in, %b0_out = firrtl.instance b0 @Bottom1(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
     firrtl.connect %b0_in, %c1_ui : !firrtl.uint<1>, !firrtl.uint
@@ -53,13 +53,13 @@ firrtl.circuit "InstanceInput"   {
 
 //propagate constant inputs ONLY if ALL instance inputs get the same value
 firrtl.circuit "InstanceInput2"   {
-  // CHECK-LABEL: firrtl.module @Bottom2
-  firrtl.module @Bottom2(in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
+  // CHECK-LABEL: firrtl.module private @Bottom2
+  firrtl.module private @Bottom2(in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
     // CHECK: firrtl.strictconnect %out, %in 
     firrtl.connect %out, %in : !firrtl.uint<1>, !firrtl.uint<1>
   }
- // CHECK-LABEL:  firrtl.module @Child2
-  firrtl.module @Child2(out %out: !firrtl.uint<1>) {
+ // CHECK-LABEL:  firrtl.module private @Child2
+  firrtl.module private @Child2(out %out: !firrtl.uint<1>) {
     %c1_ui = firrtl.constant 1 : !firrtl.uint
     %b0_in, %b0_out = firrtl.instance b0 @Bottom2(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
     firrtl.connect %b0_in, %c1_ui : !firrtl.uint<1>, !firrtl.uint
@@ -97,7 +97,7 @@ firrtl.circuit "acrossWire"   {
 
 //"ConstProp" should "propagate constant outputs"
 firrtl.circuit "constOutput"   {
-  firrtl.module @constOutChild(out %out: !firrtl.uint<1>) {
+  firrtl.module private @constOutChild(out %out: !firrtl.uint<1>) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     firrtl.connect %out, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   }
@@ -188,7 +188,7 @@ firrtl.circuit "padZeroReg"   {
 
 // should "pad constant connections to outputs when propagating"
 firrtl.circuit "padConstOut"   {
-  firrtl.module @padConstOutChild(out %x: !firrtl.uint<8>) {
+  firrtl.module private @padConstOutChild(out %x: !firrtl.uint<8>) {
     %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
     firrtl.connect %x, %c3_ui2 : !firrtl.uint<8>, !firrtl.uint<2>
   }
@@ -205,8 +205,8 @@ firrtl.circuit "padConstOut"   {
 
 // "pad constant connections to submodule inputs when propagating"
 firrtl.circuit "padConstIn"   {
-  // CHECK-LABEL: firrtl.module @padConstInChild
-  firrtl.module @padConstInChild(in %x: !firrtl.uint<8>, out %y: !firrtl.uint<16>) {
+  // CHECK-LABEL: firrtl.module private @padConstInChild
+  firrtl.module private @padConstInChild(in %x: !firrtl.uint<8>, out %y: !firrtl.uint<16>) {
     %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
     %0 = firrtl.cat %c3_ui2, %x : (!firrtl.uint<2>, !firrtl.uint<8>) -> !firrtl.uint<10>
     // CHECK: %[[C9:.+]] = firrtl.constant 771 : !firrtl.uint<16>

--- a/test/Dialect/FIRRTL/SFCTests/dedup.fir
+++ b/test/Dialect/FIRRTL/SFCTests/dedup.fir
@@ -28,7 +28,7 @@ circuit Top :
     output x: UInt<1>
     x <= UInt(1)
 
-; CHECK-NOT: firrtl.module @A_
+; CHECK-NOT: firrtl.module private @A_
 
 ; // -----
 ; "The module A and B should be deduped"
@@ -40,7 +40,7 @@ circuit Top :
     ; CHECK-NEXT-COUNT-2: firrtl.instance {{a(1|2)}} @A(
     inst a1 of A
     inst a2 of A_
-  ; CHECK: firrtl.module @A
+  ; CHECK: firrtl.module private @A
   module A :
     output x: UInt<1>
     ; CHECK: firrtl.instance b @B(
@@ -57,8 +57,8 @@ circuit Top :
     output x: UInt<1>
     x <= UInt(1)
 
-; CHECK-NOT: firrtl.module @A_
-; CHECK-NOT: firrtl.module @B_
+; CHECK-NOT: firrtl.module private @A_
+; CHECK-NOT: firrtl.module private @B_
 
 ; // -----
 ; "The module A and B with comments should be deduped"
@@ -86,8 +86,8 @@ circuit Top :
     output x: UInt<1>
     x <= UInt(1)
 
-; CHECK-NOT: firrtl.module @A_
-; CHECK-NOT: firrtl.module @B_
+; CHECK-NOT: firrtl.module private @A_
+; CHECK-NOT: firrtl.module private @B_
 
 ; // -----
 ; "A_ but not A should be deduped if not annotated"
@@ -106,7 +106,7 @@ circuit Top :
     output x: UInt<1> @[xx 1:1]
     x <= UInt(1)
 
-; CHECK-NOT: firrtl.module @A_
+; CHECK-NOT: firrtl.module private @A_
 
 ; // -----
 ; "Extmodules with the same defname and parameters should dedup"
@@ -120,7 +120,7 @@ circuit Top :
     inst a1 of A
     inst a2 of A_
     out <= and(a1.x, a2.y)
-  ; CHECK: firrtl.module @A
+  ; CHECK: firrtl.module private @A
   module A : @[yy 2:2]
     output x: UInt<1> @[yy 2:2]
     ; CHECK-NEXT: firrtl.instance b @B(
@@ -139,8 +139,8 @@ circuit Top :
     defname = BB
     parameter N = 0
 
-; CHECK-NOT: firrtl.module @A_
-; CHECK-NOT: firrtl.extmodule @C
+; CHECK-NOT: firrtl.module private @A_
+; CHECK-NOT: firrtl.extmodule private @C
 
 ; // -----
 ; "Extmodules with different defname should NOT dedup"
@@ -159,17 +159,17 @@ circuit Top :
     output x: UInt<1> @[yy 2:2]
     inst b of B
     x <= b.u
-  ; CHECK: firrtl.module @A_
+  ; CHECK: firrtl.module private @A_
   module A_ : @[xx 1:1]
     output y: UInt<1> @[xx 1:1]
     inst c of C
     y <= c.u
-  ; CHECK: firrtl.extmodule @B
+  ; CHECK: firrtl.extmodule private @B
   extmodule B : @[aa 3:3]
     output u : UInt<1> @[aa 4:4]
     defname = BB
     parameter N = 0
-  ; CHECK: firrtl.extmodule @C
+  ; CHECK: firrtl.extmodule private @C
   extmodule C : @[bb 5:5]
     output u : UInt<1> @[bb 6:6]
     defname = CD
@@ -192,17 +192,17 @@ circuit Top :
     output x: UInt<1> @[yy 2:2]
     inst b of B
     x <= b.u
-  ; CHECK: firrtl.module @A_
+  ; CHECK: firrtl.module private @A_
   module A_ : @[xx 1:1]
     output y: UInt<1> @[xx 1:1]
     inst c of C
     y <= c.u
-  ; CHECK: firrtl.extmodule @B
+  ; CHECK: firrtl.extmodule private @B
   extmodule B : @[aa 3:3]
     output u : UInt<1> @[aa 4:4]
     defname = BB
     parameter N = 0
-  ; CHECK: firrtl.extmodule @C
+  ; CHECK: firrtl.extmodule private @C
   extmodule C : @[bb 5:5]
     output u : UInt<1> @[bb 6:6]
     defname = BB
@@ -217,11 +217,11 @@ circuit Top :
 ;
 ; CHECK-LABEL: firrtl.circuit "FooAndBarModule"
 circuit FooAndBarModule :
-  ; CHECK: firrtl.module @FooModule
+  ; CHECK: firrtl.module private @FooModule
   module FooModule :
     output io : {flip foo : UInt<1>, fuzz : UInt<1>}
     io.fuzz <= io.foo
-  ; CHECK-NOT: firrtl.module @BarModule
+  ; CHECK-NOT: firrtl.module private @BarModule
   module BarModule :
     output io : {flip bar : UInt<1>, buzz : UInt<1>}
     io.buzz <= io.bar
@@ -241,11 +241,11 @@ circuit FooAndBarModule :
 ;
 ; CHECK-LABEL: firrtl.circuit "FooAndBarModule"
 circuit FooAndBarModule :
-  ; CHECK: firrtl.module @FooModule
+  ; CHECK: firrtl.module private @FooModule
   module FooModule :
     output io : {flip foo : UInt<1>, fuzz : UInt<1>}
     io.fuzz <= io.foo
-  ; CHECK-NOT: firrtl.module @BarModule
+  ; CHECK-NOT: firrtl.module private @BarModule
   module BarModule :
     output io : {flip foo : UInt<1>, fuzz : UInt<1>}
     io.fuzz <= io.foo
@@ -283,8 +283,8 @@ circuit Top :
     output x: UInt<1>
     x <= UInt(1)
 
-; CHECK-NOT: firrtl.module @A_
-; CHECK-NOT: firrtl.module @B_
+; CHECK-NOT: firrtl.module private @A_
+; CHECK-NOT: firrtl.module private @B_
 
 ; // -----
 ; "The module A and A_ should be deduped with fields that sort of match".
@@ -307,7 +307,7 @@ circuit Top :
     b is invalid
     x <= b.b
 
-; CHECK-NOT: firrtl.module @A_
+; CHECK-NOT: firrtl.module private @A_
 
 ; // -----
 ; "The module A and A_ should dedup with different annotation targets".
@@ -338,7 +338,7 @@ circuit Top : %[[
     b is invalid
     x <= b
 
-; CHECK-NOT: firrtl.module @A_
+; CHECK-NOT: firrtl.module private @A_
 
 ; // -----
 ; "The module A and A_ should dedup with the same annotation targets".
@@ -374,7 +374,7 @@ circuit Top : %[[
     b is invalid
     x <= b
 
-; CHECK-NOT: firrtl.module @A_
+; CHECK-NOT: firrtl.module private @A_
 
 ; // -----
 ; "The deduping module A and A_ should rename internal signals that have
@@ -398,7 +398,7 @@ circuit Top : %[[
     a1 is invalid
     inst a2 of A_
     a2 is invalid
-  ; CHECK: firrtl.module @A(
+  ; CHECK: firrtl.module private @A(
   module A :
     input x: UInt<1>
     output y: UInt<1>
@@ -411,7 +411,7 @@ circuit Top : %[[
     node b = add(x, UInt(1))
     y <= add(b, b)
 
-; CHECK-NOT: firrtl.module @A_(
+; CHECK-NOT: firrtl.module private @A_(
 
 ; // -----
 ; "main should not be deduped even if it's the last module"
@@ -460,7 +460,7 @@ circuit Top : %[[
     inst a of A
     ; CHECK-NEXT: firrtl.instance a_ sym @[[a_Sym]] {{.+}} [{circt.nonlocal = @[[nla_3]], class = "circt.nonlocal"}, {circt.nonlocal = @[[nla_4]], class = "circt.nonlocal"}]} @A()
     inst a_ of A_
-  ; CHECK: firrtl.module @A
+  ; CHECK: firrtl.module private @A
   module A :
     ; CHECK-NEXT: firrtl.instance b sym @[[bSym]]
     ; CHECK-SAME: {circt.nonlocal = @[[nla_3]], class = "circt.nonlocal"}
@@ -469,10 +469,10 @@ circuit Top : %[[
     ; CHECK-SAME: {circt.nonlocal = @[[nla_2]], class = "circt.nonlocal"}
     ; CHECK-SAME: B()
     inst b of B
-  ; CHECK-NOT: firrtl.module @A_
+  ; CHECK-NOT: firrtl.module private @A_
   module A_ :
     inst b_ of B_
-  ; CHECK: firrtl.module @B
+  ; CHECK: firrtl.module private @B
   ; CHECK-SAME: {circt.nonlocal = @[[nla_3]], class = "B_"}
   ; CHECK-SAME: {circt.nonlocal = @[[nla_1]], class = "B"}
   module B :
@@ -480,7 +480,7 @@ circuit Top : %[[
     ; CHECK-SAME: {circt.nonlocal = @[[nla_4]], class = "B_.bar"}
     ; CHECK-SAME: {circt.nonlocal = @[[nla_2]], class = "B.foo"}
     node foo = UInt<1>(0)
-  ; CHECK-NOT: firrtl.module @B_
+  ; CHECK-NOT: firrtl.module private @B_
   module B_ :
     node bar = UInt<1>(0)
 
@@ -548,7 +548,7 @@ circuit Top : %[[
     ; CHECK-SAME:     @A()
     inst a_ of A_
 
-  ; CHECK:        firrtl.module @A
+  ; CHECK:        firrtl.module private @A
   module A :
     ; CHECK-NEXT:   firrtl.instance b sym @[[bSym]]
     ; CHECK-SAME:     [{circt.nonlocal = @[[nla_3]], class = "circt.nonlocal"},
@@ -558,7 +558,7 @@ circuit Top : %[[
     ; CHECK-SAME:     @B()
     inst b of B
 
-  ; CHECK:        firrtl.module @B
+  ; CHECK:        firrtl.module private @B
   module B :
     ; CHECK-NEXT:   firrtl.instance c sym @[[cSym]]
     ; CHECK-SAME:     [{circt.nonlocal = @[[nla_3]], class = "circt.nonlocal"},
@@ -568,7 +568,7 @@ circuit Top : %[[
     ; CHECK-SAME:     @C()
     inst c of C
 
-  ; CHECK:        firrtl.module @C
+  ; CHECK:        firrtl.module private @C
   module C :
     ; CHECK-NEXT:   firrtl.instance d sym @[[dSym]]
     ; CHECK-SAME:     [{circt.nonlocal = @[[nla_3]], class = "circt.nonlocal"},
@@ -578,7 +578,7 @@ circuit Top : %[[
     ; CHECK-SAME:     @D()
     inst d of D
 
-  ; CHECK:        firrtl.module @D
+  ; CHECK:        firrtl.module private @D
   ; CHECK-SAME:     [{circt.nonlocal = @[[nla_3]], class = "two"},
   ; CHECK-SAME:      {circt.nonlocal = @[[nla_1]], class = "one"}]
   module D :
@@ -587,10 +587,10 @@ circuit Top : %[[
     ; CHECK-SAME:      {circt.nonlocal = @[[nla_2]], class = "one"}]
     node foo = UInt<1>(0)
 
-  ; CHECK-NOT: firrtl.module @A_
-  ; CHECK-NOT: firrtl.module @B_
-  ; CHECK-NOT: firrtl.module @C_
-  ; CHECK-NOT: firrtl.module @D_
+  ; CHECK-NOT: firrtl.module private @A_
+  ; CHECK-NOT: firrtl.module private @B_
+  ; CHECK-NOT: firrtl.module private @C_
+  ; CHECK-NOT: firrtl.module private @D_
   module A_ :
     inst b_ of B_
   module B_ :
@@ -733,7 +733,7 @@ circuit Top : %[[
     ; CHECK-SAME:     @A()
     inst a2 of A
 
-  ; CHECK:        firrtl.module @A()
+  ; CHECK:        firrtl.module private @A()
   module A :
     ; CHECK-NEXT:   firrtl.instance b sym @[[AbSym]]
     ; CHECK-SAME:     {circt.nonlocal = @[[nla_5]], class = "circt.nonlocal"},
@@ -750,7 +750,7 @@ circuit Top : %[[
     ; CHECK-SAME:     @B()
     inst b_ of B_
 
-  ; CHECK:        firrtl.module @B()
+  ; CHECK:        firrtl.module private @B()
   ; CHECK-SAME:     [{circt.nonlocal = @[[nla_2]], class = "nla2"},
   ; CHECK-SAME:      {circt.nonlocal = @[[nla_3]], class = "nla3"},
   ; CHECK-SAME:      {circt.nonlocal = @[[nla_4]], class = "nla4"},
@@ -768,7 +768,7 @@ circuit Top : %[[
     ; CHECK-SAME:     @C()
     inst c of C
 
-  ; CHECK:        firrtl.module @C()
+  ; CHECK:        firrtl.module private @C()
   ; CHECK-SAME:     [{circt.nonlocal = @[[nla_7]], class = "nla7"},
   ; CHECK-SAME:      {circt.nonlocal = @[[nla_8]], class = "nla8"},
   ; CHECK-SAME:      {circt.nonlocal = @[[nla_9]], class = "nla9"},
@@ -778,7 +778,7 @@ circuit Top : %[[
   module C :
     skip
 
-  ; CHECK-NOT: firrtl.module @B_()
+  ; CHECK-NOT: firrtl.module private @B_()
   module B_ :
     inst c of C
 
@@ -828,7 +828,7 @@ circuit top : %[[
     ob.a.b.c <= b.r.a.b.c
     ob.z <= b.r.z
 
-  ; CHECK:      firrtl.module @a(
+  ; CHECK:      firrtl.module private @a(
   ; CHECK-SAME:   in %i: {{.+}} sym @[[aiSym]]
   ; CHECK-NOT:    out
   ; CHECK-SAME:     [#firrtl.subAnno<fieldID = 1, {circt.nonlocal = @[[nla_2]], class = "nla2"}>,
@@ -838,7 +838,7 @@ circuit top : %[[
     output o: {z: {y: {x: UInt<1>}}, a: UInt<1>}
     o <= i
 
-  ; CHECK-NOT:  firrtl.module @b(
+  ; CHECK-NOT:  firrtl.module private @b(
   module b:
     input q: {a: {b: {c: UInt<1>}}, z: UInt<1>}
     output r: {a: {b: {c: UInt<1>}}, z: UInt<1>}

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -60,7 +60,7 @@ circuit Foo: %[[{"a":"a","target":"~Foo|Bar"}]]
     bar.a <= a
 
     ; CHECK-LABEL: firrtl.circuit "Foo" {
-    ; CHECK: firrtl.extmodule @Bar
+    ; CHECK: firrtl.extmodule private @Bar
     ; CHECK-SAME: attributes {annotations = [{a = "a"}]}
 
 ; // -----
@@ -78,7 +78,7 @@ circuit Foo: %[[
     inst bar of Bar
     ; CHECK-LABEL: firrtl.circuit "Foo"
     ; CHECK: firrtl.nla  @nla_1 [#hw.innerNameRef<@Foo::@bar>, @Bar]
-    ; CHECK: firrtl.module @Bar
+    ; CHECK: firrtl.module private @Bar
     ; CHECK-SAME annotations = [{c = "c"}]
     ; CHECK: firrtl.module @Foo
     ; CHECK: firrtl.instance bar
@@ -108,7 +108,7 @@ circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar.a"},
     ; CHECK-LABEL: firrtl.circuit "Foo"
     ; CHECK: firrtl.nla @nla_2 [#hw.innerNameRef<@Foo::@bar>, #hw.innerNameRef<@Bar::@d>] 
     ; CHECK: firrtl.nla @nla_1 [#hw.innerNameRef<@Foo::@bar>, #hw.innerNameRef<@Bar::@b>]
-    ; CHECK: firrtl.module @Bar
+    ; CHECK: firrtl.module private @Bar
     ; CHECK-SAME: sym @b [#firrtl.subAnno<fieldID = 2, {circt.nonlocal = @nla_1, three}>]
     ; CHECK-NEXT:  %d = firrtl.wire sym @d  
     ; CHECK-SAME: {annotations = [#firrtl.subAnno<fieldID = 2, {circt.nonlocal = @nla_2, five}>]}
@@ -238,7 +238,7 @@ circuit Foo: %[[{"a":"a","target":"~Foo|Bar>bar"},{"b":"b","target":"Foo.Foo.foo
     bar.bar <= foo
 
     ; CHECK-LABEL: module {
-    ; CHECK: firrtl.extmodule @Bar
+    ; CHECK: firrtl.extmodule private @Bar
     ; CHECK-SAME: [[_:.+]] [{a = "a"}]
     ; CHECK: firrtl.module @Foo
     ; CHECK-SAME: %foo: [[_:.+]] [{b = "b"}]
@@ -557,7 +557,7 @@ circuit GCTDataTap : %[
     ; CHECK-LABEL: firrtl.circuit "GCTDataTap"
     ; CHECK-SAME: annotations = [{unrelatedAnnotation}]
     ; CHECK:      firrtl.nla @nla_1 [#hw.innerNameRef<@GCTDataTap::@im>, #hw.innerNameRef<@InnerMod::@w>]
-    ; CHECK: firrtl.extmodule @DataTap
+    ; CHECK: firrtl.extmodule private @DataTap
     ; CHECK-SAME: _0: !firrtl.uint<1> sym @_0 [
     ; CHECK-SAME:   {class = "sifive.enterprise.grandcentral.ReferenceDataTapKey",
     ; CHECK-SAME:    id = [[ID:[0-9]+]] : i64,
@@ -618,7 +618,7 @@ circuit GCTDataTap : %[
     ; CHECK-SAME:   {class = "sifive.enterprise.grandcentral.DataTapsAnnotation"},
     ; CHECK-SAME:   {class = "firrtl.transforms.DontTouchAnnotation"}]
 
-    ; CHECK: firrtl.extmodule @BlackBox
+    ; CHECK: firrtl.extmodule private @BlackBox
     ; CHECK-SAME: annotations = [
     ; CHECK-SAME:   {class = "sifive.enterprise.grandcentral.DataTapModuleSignalKey",
     ; CHECK-SAME:    id = [[ID]] : i64,
@@ -630,7 +630,7 @@ circuit GCTDataTap : %[
     ; CHECK-SAME:    internalPath = "baz.quz",
     ; CHECK-SAME:    portID = [[PORT_ID_5]] : i64}
 
-    ; CHECK: firrtl.module @InnerMod
+    ; CHECK: firrtl.module private @InnerMod
     ; CHECK-NEXT: %w = firrtl.wire sym @w
     ; CHECK-SAME: {circt.nonlocal = @nla_1, class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = 7 : i64, type = "source"}
 
@@ -692,7 +692,7 @@ circuit GCTMemTap : %[
 
     ; CHECK-LABEL: firrtl.circuit "GCTMemTap"
     ; CHECK-SAME: annotations = [{unrelatedAnnotation}]
-    ; CHECK: firrtl.extmodule @MemTap
+    ; CHECK: firrtl.extmodule private @MemTap
     ; CHECK-SAME: mem: [[A:.+]] [
     ; CHECK-SAME:   #firrtl.subAnno<fieldID = 1,
     ; CHECK-SAME:     {class = "sifive.enterprise.grandcentral.MemTapAnnotation",
@@ -918,7 +918,7 @@ circuit GCTInterface : %[
     ; CHECK-SAME: {unrelatedAnnotation}
 
     ; The companion should be marked.
-    ; CHECK: firrtl.module @view_companion
+    ; CHECK: firrtl.module private @view_companion
     ; CHECK-SAME: annotations
     ; CHECK-SAME: {class = "sifive.enterprise.grandcentral.ViewAnnotation",
     ; CHECK-SAME:  id = [[ID_ViewName]] : i64,
@@ -1033,7 +1033,7 @@ circuit Test : %[[
 
 ; CHECK-LABEL:  firrtl.circuit "Test"
 ; CHECK: firrtl.nla @nla_1 [#hw.innerNameRef<@Test::@Test>, @Example]
-; CHECK: firrtl.module @Example() attributes {
+; CHECK: firrtl.module private @Example() attributes {
 ; CHECK-SAME: annotations = [{circt.nonlocal = @nla_1, class = "fake"}]
 ; CHECK: firrtl.module @Test()
 ; CHECK:   firrtl.instance Test sym @Test
@@ -1053,9 +1053,9 @@ circuit Foo: %[[{"a":"a","target":"~Foo|Foo/bar:Bar/baz:Baz"}, {"b":"b","target"
 ; CHECK-LABEL: firrtl.circuit "Foo"
 ; CHECK: firrtl.nla @nla_2 [#hw.innerNameRef<@Foo::@bar>, #hw.innerNameRef<@Bar::@baz>, @Baz]
 ; CHECK: firrtl.nla @nla_1 [#hw.innerNameRef<@Foo::@bar>, #hw.innerNameRef<@Bar::@baz>, @Baz]
-; CHECK: firrtl.module @Baz
+; CHECK: firrtl.module private @Baz
 ; CHECK-SAME: annotations = [{a = "a", circt.nonlocal = @nla_1}, {b = "b", circt.nonlocal = @nla_2}]
-; CHECK: firrtl.module @Bar()
+; CHECK: firrtl.module private @Bar()
 ; CHECK: firrtl.instance baz
 ; CHECK-SAME: [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}, {circt.nonlocal = @nla_2, class = "circt.nonlocal"}]
 ; CHECK: firrtl.module @Foo()
@@ -1165,7 +1165,7 @@ circuit Top : %[[{
 ; CHECK: %child_in, %child_out = firrtl.instance child
 ; CHECK-SAME: sym @child {annotations = [{circt.nonlocal = @nla_2, class = "circt.nonlocal"}]}
 
-; CHECK: firrtl.extmodule @Child(
+; CHECK: firrtl.extmodule private @Child(
 ; CHECK-SAME:   in in: !firrtl.uint<123> sym @in,
 ; CHECK-SAME:   out out: !firrtl.uint<456> sym @out
 ; CHECK-SAME: )

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -807,3 +807,10 @@ firrtl.circuit "MismatchedRegister" {
     firrtl.connect %z, %r : !firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 1>
   }
 }
+
+// -----
+
+// expected-error @+1 {{'firrtl.circuit' op main module 'private_main' must be public}}
+firrtl.circuit "private_main" {
+  firrtl.module private @private_main() {}
+}

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -4,7 +4,7 @@ firrtl.circuit "Test" {
 
   // CHECK-LABEL: @PassThrough
   // CHECK: (in %source: !firrtl.uint<1>, out %dest: !firrtl.uint<1>)
-  firrtl.module @PassThrough(in %source: !firrtl.uint<1>, out %dest: !firrtl.uint<1>) {
+  firrtl.module private @PassThrough(in %source: !firrtl.uint<1>, out %dest: !firrtl.uint<1>) {
     // CHECK-NEXT: %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
 
     %dontTouchWire = firrtl.wire sym @a1 : !firrtl.uint<1>
@@ -118,7 +118,7 @@ firrtl.circuit "Test" {
   // https://github.com/llvm/circt/issues/1236
 
   // CHECK-LABEL: @UnusedModule(in %source: !firrtl.uint<1>, out %dest: !firrtl.uint<1>)
-  firrtl.module @UnusedModule(in %source: !firrtl.uint<1>, out %dest: !firrtl.uint<1>) {
+  firrtl.module private @UnusedModule(in %source: !firrtl.uint<1>, out %dest: !firrtl.uint<1>) {
     // CHECK-NEXT: firrtl.connect %dest, %source
     firrtl.connect %dest, %source : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK-NEXT: }
@@ -126,7 +126,7 @@ firrtl.circuit "Test" {
 
 
   // CHECK-LABEL: ReadMem
-  firrtl.module @ReadMem() {
+  firrtl.module private @ReadMem() {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
 
@@ -171,8 +171,8 @@ firrtl.circuit "Issue1188"  {
 
 // DontTouch annotation should block constant propagation.
 firrtl.circuit "testDontTouch"  {
-  // CHECK-LABEL: firrtl.module @blockProp
-  firrtl.module @blockProp1(in %clock: !firrtl.clock, in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) attributes {
+  // CHECK-LABEL: firrtl.module private @blockProp
+  firrtl.module private @blockProp1(in %clock: !firrtl.clock, in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) attributes {
     portAnnotations = [[], [],[]],
     portSyms = ["", "dntSym", ""]
   }{
@@ -181,16 +181,16 @@ firrtl.circuit "testDontTouch"  {
     firrtl.connect %c, %a : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %b, %c : !firrtl.uint<1>, !firrtl.uint<1>
   }
-  // CHECK-LABEL: firrtl.module @allowProp
-  firrtl.module @allowProp(in %clock: !firrtl.clock, in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
+  // CHECK-LABEL: firrtl.module private @allowProp
+  firrtl.module private @allowProp(in %clock: !firrtl.clock, in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
     // CHECK: [[CONST:%.+]] = firrtl.constant 1 : !firrtl.uint<1>
     %c = firrtl.reg %clock  : !firrtl.uint<1>
     firrtl.connect %c, %a : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: firrtl.connect %b, [[CONST]]
     firrtl.connect %b, %c : !firrtl.uint<1>, !firrtl.uint<1>
   }
-  // CHECK-LABEL: firrtl.module @blockProp3
-  firrtl.module @blockProp3(in %clock: !firrtl.clock, in %a: !firrtl.uint<1> , out %b: !firrtl.uint<1>) {
+  // CHECK-LABEL: firrtl.module private @blockProp3
+  firrtl.module private @blockProp3(in %clock: !firrtl.clock, in %a: !firrtl.uint<1> , out %b: !firrtl.uint<1>) {
     //CHECK: %c = firrtl.reg
     %c = firrtl.reg sym @s2 %clock : !firrtl.uint<1>
     firrtl.connect %c, %a : !firrtl.uint<1>, !firrtl.uint<1>
@@ -215,8 +215,8 @@ firrtl.circuit "testDontTouch"  {
     // CHECK: firrtl.connect %a2, %blockProp3_b
     firrtl.connect %a2, %blockProp3_b : !firrtl.uint<1>, !firrtl.uint<1>
   }
-  // CHECK-LABEL: firrtl.module @CheckNode
-  firrtl.module @CheckNode(in %x: !firrtl.uint<1>, out %y: !firrtl.uint<1>) {
+  // CHECK-LABEL: firrtl.module private @CheckNode
+  firrtl.module private @CheckNode(in %x: !firrtl.uint<1>, out %y: !firrtl.uint<1>) {
     %z = firrtl.node   sym @s2 %x: !firrtl.uint<1>
     // CHECK: firrtl.connect %y, %z
     firrtl.connect %y, %z : !firrtl.uint<1>, !firrtl.uint<1>
@@ -227,11 +227,11 @@ firrtl.circuit "testDontTouch"  {
 // -----
 
 firrtl.circuit "OutPortTop" {
-    firrtl.module @OutPortChild1(out %out: !firrtl.uint<1>)  attributes {portSyms = ["dntSym"]}{
+    firrtl.module private @OutPortChild1(out %out: !firrtl.uint<1>)  attributes {portSyms = ["dntSym"]}{
       %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
       firrtl.connect %out, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     } 
-    firrtl.module @OutPortChild2(out %out: !firrtl.uint<1>) {
+    firrtl.module private @OutPortChild2(out %out: !firrtl.uint<1>) {
       %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
       firrtl.connect %out, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     }
@@ -254,14 +254,14 @@ firrtl.circuit "OutPortTop" {
 // -----
 
 firrtl.circuit "InputPortTop"   {
-  // CHECK-LABEL: firrtl.module @InputPortChild2
-  firrtl.module @InputPortChild2(in %in0: !firrtl.uint<1>, in %in1: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
+  // CHECK-LABEL: firrtl.module private @InputPortChild2
+  firrtl.module private @InputPortChild2(in %in0: !firrtl.uint<1>, in %in1: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
     // CHECK: = firrtl.constant 1
     %0 = firrtl.and %in0, %in1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   }
-  // CHECK-LABEL: firrtl.module @InputPortChild
-  firrtl.module @InputPortChild(in %in0: !firrtl.uint<1>, in %in1: !firrtl.uint<1>, out %out: !firrtl.uint<1>) attributes {
+  // CHECK-LABEL: firrtl.module private @InputPortChild
+  firrtl.module private @InputPortChild(in %in0: !firrtl.uint<1>, in %in1: !firrtl.uint<1>, out %out: !firrtl.uint<1>) attributes {
     portAnnotations = [[], [], []], portSyms = ["", "dntSym", ""]
   } {
     // CHECK: %0 = firrtl.and %in0, %in1
@@ -284,7 +284,7 @@ firrtl.circuit "InputPortTop"   {
 // -----
 
 firrtl.circuit "InstanceOut"   {
-  firrtl.extmodule @Ext(in a: !firrtl.uint<1>)
+  firrtl.extmodule private @Ext(in a: !firrtl.uint<1>)
 
   // CHECK-LABEL: firrtl.module @InstanceOut
   firrtl.module @InstanceOut(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
@@ -301,7 +301,7 @@ firrtl.circuit "InstanceOut"   {
 // -----
 
 firrtl.circuit "InstanceOut2"   {
-  firrtl.module @Ext(in %a: !firrtl.uint<1>) {
+  firrtl.module private @Ext(in %a: !firrtl.uint<1>) {
   }
 
   // CHECK-LABEL: firrtl.module @InstanceOut2
@@ -384,8 +384,8 @@ firrtl.circuit "RegResetInvalidReset"  {
 //
 // CHECK-LABEL: "Oscillators"
 firrtl.circuit "Oscillators"   {
-  // CHECK: firrtl.module @Foo
-  firrtl.module @Foo(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, out %a: !firrtl.uint<1>) {
+  // CHECK: firrtl.module private @Foo
+  firrtl.module private @Foo(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, out %a: !firrtl.uint<1>) {
     // CHECK: firrtl.reg
     %r = firrtl.reg %clock : !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
@@ -398,8 +398,8 @@ firrtl.circuit "Oscillators"   {
     %2 = firrtl.or %r, %s : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.connect %a, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   }
-  // CHECK: firrtl.module @Bar
-  firrtl.module @Bar(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, out %a: !firrtl.uint<1>) {
+  // CHECK: firrtl.module private @Bar
+  firrtl.module private @Bar(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, out %a: !firrtl.uint<1>) {
     // CHECK: firrtl.reg
     %r = firrtl.reg %clock  : !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
@@ -413,8 +413,8 @@ firrtl.circuit "Oscillators"   {
     %2 = firrtl.or %r, %s : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.connect %a, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   }
-  // CHECK: firrtl.module @Baz
-  firrtl.module @Baz(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, out %a: !firrtl.uint<1>) {
+  // CHECK: firrtl.module private @Baz
+  firrtl.module private @Baz(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, out %a: !firrtl.uint<1>) {
     // CHECK: firrtl.reg
     %r = firrtl.reg %clock  : !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
@@ -428,8 +428,8 @@ firrtl.circuit "Oscillators"   {
     firrtl.connect %a, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   }
   firrtl.extmodule @Ext(in a: !firrtl.uint<1>)
-  // CHECK: firrtl.module @Qux
-  firrtl.module @Qux(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, out %a: !firrtl.uint<1>) {
+  // CHECK: firrtl.module private @Qux
+  firrtl.module private @Qux(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, out %a: !firrtl.uint<1>) {
     %ext_a = firrtl.instance ext @Ext(in a: !firrtl.uint<1>)
     // CHECK: firrtl.reg
     %r = firrtl.reg %clock  : !firrtl.uint<1>
@@ -473,8 +473,8 @@ firrtl.circuit "Oscillators"   {
 //
 // CHECK-LABK: firrtl.circuit "rhs_sink_output_used_as_wire"
 firrtl.circuit "rhs_sink_output_used_as_wire" {
-  // CHECK: firrtl.module @Bar
-  firrtl.module @Bar(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>, out %d: !firrtl.uint<1>) {
+  // CHECK: firrtl.module private @Bar
+  firrtl.module private @Bar(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>, out %d: !firrtl.uint<1>) {
     firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
     %_c = firrtl.wire  : !firrtl.uint<1>
     // CHECK: firrtl.xor %a, %c
@@ -566,7 +566,7 @@ firrtl.circuit "dntOutput" {
     %m = firrtl.mux(%c, %int_b, %const) : (!firrtl.uint<1>, !firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
     firrtl.connect %b, %m : !firrtl.uint<3>, !firrtl.uint<3>
   }
-  firrtl.module @foo(out %b: !firrtl.uint<3> ) attributes {portSyms = ["dntSym1"] } {
+  firrtl.module private @foo(out %b: !firrtl.uint<3> ) attributes {portSyms = ["dntSym1"] } {
     %const = firrtl.constant 1 : !firrtl.uint<3>
     firrtl.connect %b, %const : !firrtl.uint<3>, !firrtl.uint<3>
   }

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -3,7 +3,7 @@
 // Test that an external module as the main module works.
 firrtl.circuit "main_extmodule" {
   firrtl.extmodule @main_extmodule()
-  firrtl.module @unused () { }
+  firrtl.module private @unused () { }
 }
 // CHECK-LABEL: firrtl.circuit "main_extmodule" {
 // CHECK-NEXT:   firrtl.extmodule @main_extmodule()
@@ -15,19 +15,19 @@ firrtl.module @delete_dead_modules () {
   firrtl.instance used @used()
   firrtl.instance used @used_ext()
 }
-firrtl.module @unused () { }
-firrtl.module @used () { }
-firrtl.extmodule @unused_ext ()
-firrtl.extmodule @used_ext ()
+firrtl.module private @unused () { }
+firrtl.module private @used () { }
+firrtl.extmodule private @unused_ext ()
+firrtl.extmodule private @used_ext ()
 }
 // CHECK-LABEL: firrtl.circuit "delete_dead_modules" {
 // CHECK-NEXT:   firrtl.module @delete_dead_modules() {
 // CHECK-NEXT:     firrtl.instance used @used()
 // CHECK-NEXT:     firrtl.instance used @used_ext
 // CHECK-NEXT:   }
-// CHECK-NEXT:   firrtl.module @used() {
+// CHECK-NEXT:   firrtl.module private @used() {
 // CHECK-NEXT:   }
-// CHECK-NEXT:   firrtl.extmodule @used_ext()
+// CHECK-NEXT:   firrtl.extmodule private @used_ext()
 // CHECK-NEXT: }
 
 
@@ -36,12 +36,12 @@ firrtl.circuit "inlining" {
 firrtl.module @inlining() {
   firrtl.instance test1 @test1()
 }
-firrtl.module @test1()
+firrtl.module private @test1()
   attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
   %test_wire = firrtl.wire : !firrtl.uint<2>
   firrtl.instance test2 @test2()
 }
-firrtl.module @test2()
+firrtl.module private @test2()
   attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
   %test_wire = firrtl.wire : !firrtl.uint<2>
 }
@@ -62,11 +62,11 @@ firrtl.module @flattening()
   attributes {annotations = [{class = "firrtl.transforms.FlattenAnnotation"}]} {
   firrtl.instance test1 @test1()
 }
-firrtl.module @test1() {
+firrtl.module private @test1() {
   %test_wire = firrtl.wire : !firrtl.uint<2>
   firrtl.instance test2 @test2()
 }
-firrtl.module @test2() {
+firrtl.module private @test2() {
   %test_wire = firrtl.wire : !firrtl.uint<2>
 }
 }
@@ -75,8 +75,8 @@ firrtl.module @test2() {
 // CHECK-NOT:      annotations
 // CHECK-NEXT:     %test1_test_wire = firrtl.wire : !firrtl.uint<2>
 // CHECK-NEXT:     %test1_test2_test_wire = firrtl.wire : !firrtl.uint<2>
-// CHECK-NOT:    firrtl.module @test1
-// CHECK-NOT:    firrtl.module @test2
+// CHECK-NOT:    firrtl.module private @test1
+// CHECK-NOT:    firrtl.module private @test2
 
 
 // Test that inlining and flattening compose well.
@@ -86,19 +86,19 @@ firrtl.module @compose() {
   firrtl.instance test2 @test2()
   firrtl.instance test3 @test3()
 }
-firrtl.module @test1() attributes {annotations =
+firrtl.module private @test1() attributes {annotations =
         [{class = "firrtl.transforms.FlattenAnnotation"},
          {class = "firrtl.passes.InlineAnnotation"}]} {
   %test_wire = firrtl.wire : !firrtl.uint<2>
   firrtl.instance test2 @test2()
   firrtl.instance test3 @test3()
 }
-firrtl.module @test2() attributes {annotations =
+firrtl.module private @test2() attributes {annotations =
         [{class = "firrtl.passes.InlineAnnotation"}]} {
   %test_wire = firrtl.wire : !firrtl.uint<2>
   firrtl.instance test3 @test3()
 }
-firrtl.module @test3() {
+firrtl.module private @test3() {
   %test_wire = firrtl.wire : !firrtl.uint<2>
 }
 }
@@ -112,7 +112,7 @@ firrtl.module @test3() {
 // CHECK-NEXT:     firrtl.instance test2_test3 @test3()
 // CHECK-NEXT:     firrtl.instance test3 @test3()
 // CHECK-NEXT:   }
-// CHECK-NEXT:   firrtl.module @test3() {
+// CHECK-NEXT:   firrtl.module private @test3() {
 // CHECK-NEXT:     %test_wire = firrtl.wire  : !firrtl.uint<2>
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
@@ -253,15 +253,15 @@ firrtl.circuit "NLAInlining" {
   firrtl.nla @nla4 [#hw.innerNameRef<@NLAInlining::@foo>, @Foo]
   firrtl.nla @nla5 [#hw.innerNameRef<@NLAInlining::@foo>, #hw.innerNameRef<@Foo::@b>]
   firrtl.nla @nla6 [#hw.innerNameRef<@NLAInlining::@foo>, #hw.innerNameRef<@Foo::@port>]
-  // CHECK-NEXT: firrtl.module @Bar
+  // CHECK-NEXT: firrtl.module private @Bar
   // CHECK-SAME: %port: {{.+}} sym @port [{circt.nonlocal = @nla3, class = "nla3"}]
   // CHECK-SAME: [{circt.nonlocal = @nla1, class = "nla1"}]
-  firrtl.module @Bar(
+  firrtl.module private @Bar(
     in %port: !firrtl.uint<1> sym @port [{circt.nonlocal = @nla3, class = "nla3"}]
   ) attributes {annotations = [{circt.nonlocal = @nla1, class = "nla1"}]} {
     %a = firrtl.wire sym @a {annotations = [{circt.nonlocal = @nla2, class = "nla2"}]} : !firrtl.uint<1>
   }
-  firrtl.module @Foo(in %port: !firrtl.uint<1> sym @port [{circt.nonlocal = @nla6, class = "nla6"}]) attributes {annotations = [
+  firrtl.module private @Foo(in %port: !firrtl.uint<1> sym @port [{circt.nonlocal = @nla6, class = "nla6"}]) attributes {annotations = [
   {class = "firrtl.passes.InlineAnnotation"}, {circt.nonlocal = @nla4, class = "nla4"}]} {
     %bar_port = firrtl.instance bar sym @bar {annotations = [
       {circt.nonlocal = @nla1, class = "circt.nonlocal"},
@@ -302,22 +302,22 @@ firrtl.circuit "NLAInliningNotMainRoot" {
   // CHECK-NEXT: firrtl.nla @nla2_0 [#hw.innerNameRef<@Foo::@baz>, #hw.innerNameRef<@Baz::@port>]
   firrtl.nla @nla1 [#hw.innerNameRef<@Bar::@baz>, #hw.innerNameRef<@Baz::@a>]
   firrtl.nla @nla2 [#hw.innerNameRef<@Bar::@baz>, #hw.innerNameRef<@Baz::@port>]
-  // CHECK: firrtl.module @Baz
+  // CHECK: firrtl.module private @Baz
   // CHECK-SAME: %port: {{.+}} [{circt.nonlocal = @nla2, class = "nla2"}, {circt.nonlocal = @nla2_0, class = "nla2"}]
-  firrtl.module @Baz(
+  firrtl.module private @Baz(
     in %port: !firrtl.uint<1> sym @port [{circt.nonlocal = @nla2, class = "nla2"}]
   ) {
     // CHECK-NEXT: firrtl.wire {{.+}} [{circt.nonlocal = @nla1, class = "hello"}, {circt.nonlocal = @nla1_0, class = "hello"}]
     %a = firrtl.wire sym @a {annotations = [{circt.nonlocal = @nla1, class = "hello"}]} : !firrtl.uint<1>
   }
-  firrtl.module @Bar() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
+  firrtl.module private @Bar() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
     %baz_port = firrtl.instance baz sym @baz {annotations = [
       {circt.nonlocal = @nla1, class = "circt.nonlocal"},
       {circt.nonlocal = @nla2, class = "circt.nonlocal"}
     ]} @Baz(in port: !firrtl.uint<1>)
   }
-  // CHECK: firrtl.module @Foo
-  firrtl.module @Foo() {
+  // CHECK: firrtl.module private @Foo
+  firrtl.module private @Foo() {
     // CHECK-NEXT: firrtl.instance bar_baz {{.+}} [{circt.nonlocal = @nla1_0, class = "circt.nonlocal"}, {circt.nonlocal = @nla2_0, class = "circt.nonlocal"}]
     firrtl.instance bar @Bar()
   }
@@ -403,35 +403,35 @@ firrtl.circuit "NLAFlatteningChildRoot" {
   firrtl.nla @nla2 [#hw.innerNameRef<@Bar::@qux>, #hw.innerNameRef<@Qux::@Qux_port>]
   firrtl.nla @nla3 [#hw.innerNameRef<@Baz::@quz>, #hw.innerNameRef<@Quz::@b>]
   firrtl.nla @nla4 [#hw.innerNameRef<@Baz::@quz>, #hw.innerNameRef<@Quz::@Quz_port>]
-  // CHECK: firrtl.module @Quz
+  // CHECK: firrtl.module private @Quz
   // CHECK-SAME: in %port: {{.+}} [{circt.nonlocal = @nla4, class = "nla4"}]
-  firrtl.module @Quz(
+  firrtl.module private @Quz(
     in %port: !firrtl.uint<1> sym @Quz_port [{circt.nonlocal = @nla4, class = "nla4"}]
   ) {
     // CHECK-NEXT: firrtl.wire {{.+}} [{circt.nonlocal = @nla3, class = "nla3"}]
     %b = firrtl.wire sym @b {annotations = [{circt.nonlocal = @nla3, class = "nla3"}]} : !firrtl.uint<1>
   }
-  firrtl.module @Qux(
+  firrtl.module private @Qux(
     in %port: !firrtl.uint<1> sym @Qux_port [{circt.nonlocal = @nla2, class = "nla2"}]
   ) {
     %a = firrtl.wire sym @a {annotations = [{circt.nonlocal = @nla1, class = "nla1"}]} : !firrtl.uint<1>
   }
-  // CHECK: firrtl.module @Baz
-  firrtl.module @Baz() {
+  // CHECK: firrtl.module private @Baz
+  firrtl.module private @Baz() {
     // CHECK-NEXT: firrtl.instance {{.+}} [{circt.nonlocal = @nla3, class = "circt.nonlocal"}, {circt.nonlocal = @nla4, class = "circt.nonlocal"}]
     firrtl.instance quz sym @quz {annotations = [
       {circt.nonlocal = @nla3, class = "circt.nonlocal"},
       {circt.nonlocal = @nla4, class = "circt.nonlocal"}
     ]} @Quz(in port: !firrtl.uint<1>)
   }
-  firrtl.module @Bar() {
+  firrtl.module private @Bar() {
     firrtl.instance qux sym @qux {annotations = [
       {circt.nonlocal = @nla1, class = "circt.nonlocal"},
       {circt.nonlocal = @nla2, class = "circt.nonlocal"}
     ]} @Qux(in port: !firrtl.uint<1>)
   }
-  // CHECK: firrtl.module @Foo
-  firrtl.module @Foo() attributes {annotations = [{class = "firrtl.transforms.FlattenAnnotation"}]} {
+  // CHECK: firrtl.module private @Foo
+  firrtl.module private @Foo() attributes {annotations = [{class = "firrtl.transforms.FlattenAnnotation"}]} {
     // CHECK-NEXT: %bar_qux_port = firrtl.wire sym @Qux_port {{.+}} [{class = "nla2"}]
     // CHECK-NEXT: %bar_qux_a = firrtl.wire {{.+}} [{class = "nla1"}]
     // CHECK-NEXT: %baz_quz_port = firrtl.wire sym @Quz_port {{.+}} [{class = "nla4"}]
@@ -484,14 +484,14 @@ firrtl.circuit "CollidingSymbols" {
 firrtl.circuit "CollidingSymbolsPort" {
   // CHECK-NEXT: firrtl.nla @nla1 [#hw.innerNameRef<@CollidingSymbolsPort::@foo>, #hw.innerNameRef<@Foo::@[[BarbSym:[_a-zA-Z0-9]+]]>]
   firrtl.nla @nla1 [#hw.innerNameRef<@CollidingSymbolsPort::@foo>, #hw.innerNameRef<@Foo::@bar>, #hw.innerNameRef<@Bar::@b>]
-  // CHECK-NOT: firrtl.module @Bar
-  firrtl.module @Bar(
+  // CHECK-NOT: firrtl.module private @Bar
+  firrtl.module private @Bar(
     in %b: !firrtl.uint<1> sym @b [{circt.nonlocal = @nla1, class = "nla1"}]
   ) attributes {annotations = [
     {class = "firrtl.passes.InlineAnnotation"}
   ]} {}
-  // CHECK-NEXT: firrtl.module @Foo
-  firrtl.module @Foo() {
+  // CHECK-NEXT: firrtl.module private @Foo
+  firrtl.module private @Foo() {
     // CHECK-NEXT: firrtl.wire sym @[[BarbSym]] {annotations = [{circt.nonlocal = @nla1, class = "nla1"}]}
     firrtl.instance bar sym @bar {annotations = [
       {circt.nonlocal = @nla1, class = "circt.nonlocal"}
@@ -555,7 +555,7 @@ firrtl.circuit "CollidingSymbolsNLAFixup" {
   firrtl.nla @nla0 [#hw.innerNameRef<@Foo::@bar>,
                     #hw.innerNameRef<@Bar::@baz0>,
                     #hw.innerNameRef<@Baz::@io>]
-  
+
   // CHECK: firrtl.nla @nla1 [#hw.innerNameRef<@Foo::@bar>, #hw.innerNameRef<@Bar::@w>]
   firrtl.nla @nla1 [#hw.innerNameRef<@Foo::@bar>,
                     #hw.innerNameRef<@Bar::@baz0>,
@@ -584,7 +584,7 @@ firrtl.circuit "CollidingSymbolsNLAFixup" {
       {circt.nonlocal = @nla0, class = "circt.nonlocal"},
       {circt.nonlocal = @nla1, class = "circt.nonlocal"}]} @Bar()
   }
-  
+
   firrtl.module @CollidingSymbolsNLAFixup() {
     firrtl.instance system sym @system @Foo()
   }
@@ -595,7 +595,7 @@ firrtl.circuit "CollidingSymbolsNLAFixup" {
 //
 // CHECK-LABEL: firrtl.circuit "RenameAnything"
 firrtl.circuit "RenameAnything" {
-  firrtl.module @Foo() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
+  firrtl.module private @Foo() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
     "some_unknown_dialect.op"() { name = "world" } : () -> ()
   }
   // CHECK-NEXT: firrtl.module @RenameAnything

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -5,14 +5,14 @@
 
 firrtl.circuit "TopLevel" {
 
-  // COMMON-LABEL: firrtl.module @Simple
+  // COMMON-LABEL: firrtl.module private @Simple
   // COMMON-SAME: in %[[SOURCE_VALID_NAME:source_valid]]: [[SOURCE_VALID_TYPE:!firrtl.uint<1>]]
   // COMMON-SAME: out %[[SOURCE_READY_NAME:source_ready]]: [[SOURCE_READY_TYPE:!firrtl.uint<1>]]
   // COMMON-SAME: in %[[SOURCE_DATA_NAME:source_data]]: [[SOURCE_DATA_TYPE:!firrtl.uint<64>]]
   // COMMON-SAME: out %[[SINK_VALID_NAME:sink_valid]]: [[SINK_VALID_TYPE:!firrtl.uint<1>]]
   // COMMON-SAME: in %[[SINK_READY_NAME:sink_ready]]: [[SINK_READY_TYPE:!firrtl.uint<1>]]
   // COMMON-SAME: out %[[SINK_DATA_NAME:sink_data]]: [[SINK_DATA_TYPE:!firrtl.uint<64>]]
-  firrtl.module @Simple(in %source: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>,
+  firrtl.module private @Simple(in %source: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>,
                         out %sink: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) {
 
     // COMMON-NEXT: firrtl.when %[[SOURCE_VALID_NAME]]
@@ -60,7 +60,7 @@ firrtl.circuit "TopLevel" {
     firrtl.connect %sink, %sinkV : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
   }
 
-  // COMMON-LABEL: firrtl.module @Recursive
+  // COMMON-LABEL: firrtl.module private @Recursive
   // CHECK-SAME: in %[[FLAT_ARG_1_NAME:arg_foo_bar_baz]]: [[FLAT_ARG_1_TYPE:!firrtl.uint<1>]]
   // CHECK-SAME: in %[[FLAT_ARG_2_NAME:arg_foo_qux]]: [[FLAT_ARG_2_TYPE:!firrtl.sint<64>]]
   // CHECK-SAME: out %[[OUT_1_NAME:out1]]: [[OUT_1_TYPE:!firrtl.uint<1>]]
@@ -68,7 +68,7 @@ firrtl.circuit "TopLevel" {
   // AGGREGATE-SAME: in %[[ARG_NAME:arg]]: [[ARG_TYPE:!firrtl.bundle<foo: bundle<bar: bundle<baz: uint<1>>, qux: sint<64>>>]]
   // AGGREGATE-SAME: out %[[OUT_1_NAME:out1]]: [[OUT_1_TYPE:!firrtl.uint<1>]]
   // AGGREGATE-SAME: out %[[OUT_2_NAME:out2]]: [[OUT_2_TYPE:!firrtl.sint<64>]]
-  firrtl.module @Recursive(in %arg: !firrtl.bundle<foo: bundle<bar: bundle<baz: uint<1>>, qux: sint<64>>>,
+  firrtl.module private @Recursive(in %arg: !firrtl.bundle<foo: bundle<bar: bundle<baz: uint<1>>, qux: sint<64>>>,
                            out %out1: !firrtl.uint<1>, out %out2: !firrtl.sint<64>) {
 
     // CHECK-NEXT: firrtl.connect %[[OUT_1_NAME]], %[[FLAT_ARG_1_NAME]] : [[OUT_1_TYPE]], [[FLAT_ARG_1_TYPE]]
@@ -88,26 +88,26 @@ firrtl.circuit "TopLevel" {
     firrtl.connect %out2, %3 : !firrtl.sint<64>, !firrtl.sint<64>
   }
 
-  // CHECK-LABEL: firrtl.module @Uniquification
+  // CHECK-LABEL: firrtl.module private @Uniquification
   // CHECK-SAME: in %[[FLATTENED_ARG:a_b]]: [[FLATTENED_TYPE:!firrtl.uint<1>]],
   // CHECK-NOT: %[[FLATTENED_ARG]]
   // CHECK-SAME: in %[[RENAMED_ARG:a_b.+]]: [[RENAMED_TYPE:!firrtl.uint<1>]]
   // CHECK-SAME: {portNames = ["a_b", "a_b"]}
-  firrtl.module @Uniquification(in %a: !firrtl.bundle<b: uint<1>>, in %a_b: !firrtl.uint<1>) {
+  firrtl.module private @Uniquification(in %a: !firrtl.bundle<b: uint<1>>, in %a_b: !firrtl.uint<1>) {
   }
 
-  // CHECK-LABEL: firrtl.module @Top
-  firrtl.module @Top(in %in : !firrtl.bundle<a: uint<1>, b: uint<1>>,
+  // CHECK-LABEL: firrtl.module private @Top
+  firrtl.module private @Top(in %in : !firrtl.bundle<a: uint<1>, b: uint<1>>,
                      out %out : !firrtl.bundle<a: uint<1>, b: uint<1>>) {
     // CHECK: firrtl.strictconnect %out_a, %in_a : !firrtl.uint<1>
     // CHECK: firrtl.strictconnect %out_b, %in_b : !firrtl.uint<1>
     firrtl.connect %out, %in : !firrtl.bundle<a: uint<1>, b: uint<1>>, !firrtl.bundle<a: uint<1>, b: uint<1>>
   }
 
-  // CHECK-LABEL: firrtl.module @Foo
+  // CHECK-LABEL: firrtl.module private @Foo
   // CHECK-SAME: in %[[FLAT_ARG_INPUT_NAME:a_b_c]]: [[FLAT_ARG_INPUT_TYPE:!firrtl.uint<1>]]
   // CHECK-SAME: out %[[FLAT_ARG_OUTPUT_NAME:b_b_c]]: [[FLAT_ARG_OUTPUT_TYPE:!firrtl.uint<1>]]
-  firrtl.module @Foo(in %a: !firrtl.bundle<b: bundle<c: uint<1>>>, out %b: !firrtl.bundle<b: bundle<c: uint<1>>>) {
+  firrtl.module private @Foo(in %a: !firrtl.bundle<b: bundle<c: uint<1>>>, out %b: !firrtl.bundle<b: bundle<c: uint<1>>>) {
     // CHECK: firrtl.strictconnect %[[FLAT_ARG_OUTPUT_NAME]], %[[FLAT_ARG_INPUT_NAME]] : [[FLAT_ARG_OUTPUT_TYPE]]
     firrtl.connect %b, %a : !firrtl.bundle<b: bundle<c: uint<1>>>, !firrtl.bundle<b: bundle<c: uint<1>>>
   }
@@ -145,9 +145,9 @@ firrtl.circuit "TopLevel" {
 //     memory.w.mask <= wMask
 //     memory.w.data <= wData
 
-  // CHECK-LABEL: firrtl.module @Mem2
-  // FLATTEN-LABEL: firrtl.module @Mem2
-  firrtl.module @Mem2(in %clock: !firrtl.clock, in %rAddr: !firrtl.uint<4>, in %rEn: !firrtl.uint<1>, out %rData: !firrtl.bundle<a: uint<8>, b: uint<8>>, in %wAddr: !firrtl.uint<4>, in %wEn: !firrtl.uint<1>, in %wMask: !firrtl.bundle<a: uint<1>, b: uint<1>>, in %wData: !firrtl.bundle<a: uint<8>, b: uint<8>>) {
+  // CHECK-LABEL: firrtl.module private @Mem2
+  // FLATTEN-LABEL: firrtl.module private @Mem2
+  firrtl.module private @Mem2(in %clock: !firrtl.clock, in %rAddr: !firrtl.uint<4>, in %rEn: !firrtl.uint<1>, out %rData: !firrtl.bundle<a: uint<8>, b: uint<8>>, in %wAddr: !firrtl.uint<4>, in %wEn: !firrtl.uint<1>, in %wMask: !firrtl.bundle<a: uint<1>, b: uint<1>>, in %wData: !firrtl.bundle<a: uint<8>, b: uint<8>>) {
     %memory_r, %memory_w = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r", "w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
     %0 = firrtl.subfield %memory_r(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>) -> !firrtl.clock
     firrtl.connect %0, %clock : !firrtl.clock, !firrtl.clock
@@ -272,7 +272,7 @@ firrtl.circuit "TopLevel" {
   }
 
   // FLATTEN-LABEL @Mem2_flatten
-  firrtl.module @Mem2_flatten(in %clock: !firrtl.clock, in %rAddr: !firrtl.uint<4>, in %rEn: !firrtl.uint<1>, out
+  firrtl.module private @Mem2_flatten(in %clock: !firrtl.clock, in %rAddr: !firrtl.uint<4>, in %rEn: !firrtl.uint<1>, out
   %rData: !firrtl.bundle<a: uint<8>, b: uint<16>>, in %wAddr: !firrtl.uint<4>, in %wEn: !firrtl.uint<1>, in %wMask:
   !firrtl.bundle<a: uint<1>, b: uint<1>>, in %wData: !firrtl.bundle<a: uint<8>, b: uint<16>>) {
     %memory_r, %memory_w = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r", "w"], readLatency
@@ -340,7 +340,7 @@ firrtl.circuit "TopLevel" {
 //    rwDataOut <= memory.rw.rdata
 
   // FLATTEN-LABEL @MemoryRWSplit
-  firrtl.module @MemoryRWSplit(in %clock: !firrtl.clock, in %rwEn: !firrtl.uint<1>, in %rwMode: !firrtl.uint<1>, in %rwAddr: !firrtl.uint<4>, in %rwMask: !firrtl.uint<1>, in %rwDataIn: !firrtl.uint<8>, out %rwDataOut: !firrtl.uint<8>) {
+  firrtl.module private @MemoryRWSplit(in %clock: !firrtl.clock, in %rwEn: !firrtl.uint<1>, in %rwMode: !firrtl.uint<1>, in %rwAddr: !firrtl.uint<4>, in %rwMask: !firrtl.uint<1>, in %rwDataIn: !firrtl.uint<8>, out %rwDataOut: !firrtl.uint<8>) {
     %memory_rw = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["rw"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, wdata: uint<8>, wmask: uint<1>>
     %0 = firrtl.subfield %memory_rw(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, wdata: uint<8>, wmask: uint<1>>) -> !firrtl.clock
     firrtl.connect %0, %clock : !firrtl.clock, !firrtl.clock
@@ -361,16 +361,16 @@ firrtl.circuit "TopLevel" {
 
 
  // FLATTEN-LABEL @MemoryRWSplitUnique
-  firrtl.module @MemoryRWSplitUnique() {
+  firrtl.module private @MemoryRWSplitUnique() {
     %memory_rw, %memory_rw_r, %memory_rw_w = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["rw", "rw_r", "rw_w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, wdata: uint<8>, wmask: uint<1>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
   }
 
 
 // https://github.com/llvm/circt/issues/593
 
-    firrtl.module @mod_2(in %clock: !firrtl.clock, in %inp_a: !firrtl.bundle<inp_d: uint<14>>) {
+    firrtl.module private @mod_2(in %clock: !firrtl.clock, in %inp_a: !firrtl.bundle<inp_d: uint<14>>) {
     }
-    firrtl.module @top_mod(in %clock: !firrtl.clock) {
+    firrtl.module private @top_mod(in %clock: !firrtl.clock) {
       %U0_clock, %U0_inp_a = firrtl.instance U0 @mod_2(in clock: !firrtl.clock, in inp_a: !firrtl.bundle<inp_d: uint<14>>)
       %0 = firrtl.invalidvalue : !firrtl.clock
       firrtl.connect %U0_clock, %0 : !firrtl.clock, !firrtl.clock
@@ -380,16 +380,16 @@ firrtl.circuit "TopLevel" {
 
 
 
-//CHECK-LABEL:     firrtl.module @mod_2(in %clock: !firrtl.clock, in %inp_a_inp_d: !firrtl.uint<14>)
-//CHECK:    firrtl.module @top_mod(in %clock: !firrtl.clock)
+//CHECK-LABEL:     firrtl.module private @mod_2(in %clock: !firrtl.clock, in %inp_a_inp_d: !firrtl.uint<14>)
+//CHECK:    firrtl.module private @top_mod(in %clock: !firrtl.clock)
 //CHECK-NEXT:      %U0_clock, %U0_inp_a_inp_d = firrtl.instance U0 @mod_2(in clock: !firrtl.clock, in inp_a_inp_d: !firrtl.uint<14>)
 //CHECK-NEXT:      %invalid_clock = firrtl.invalidvalue : !firrtl.clock
 //CHECK-NEXT:      firrtl.connect %U0_clock, %invalid_clock : !firrtl.clock, !firrtl.clock
 //CHECK-NEXT:      %invalid_ui14 = firrtl.invalidvalue : !firrtl.uint<14>
 //CHECK-NEXT:      firrtl.strictconnect %U0_inp_a_inp_d, %invalid_ui14 : !firrtl.uint<14>
 
-//AGGREGATE-LABEL: firrtl.module @mod_2(in %clock: !firrtl.clock, in %inp_a: !firrtl.bundle<inp_d: uint<14>>)
-//AGGREGATE:    firrtl.module @top_mod(in %clock: !firrtl.clock)
+//AGGREGATE-LABEL: firrtl.module private @mod_2(in %clock: !firrtl.clock, in %inp_a: !firrtl.bundle<inp_d: uint<14>>)
+//AGGREGATE:    firrtl.module private @top_mod(in %clock: !firrtl.clock)
 //AGGREGATE-NEXT:  %U0_clock, %U0_inp_a = firrtl.instance U0  @mod_2(in clock: !firrtl.clock, in inp_a: !firrtl.bundle<inp_d: uint<14>>)
 //AGGREGATE-NEXT:  %invalid_clock = firrtl.invalidvalue : !firrtl.clock
 //AGGREGATE-NEXT:  firrtl.connect %U0_clock, %invalid_clock : !firrtl.clock, !firrtl.clock
@@ -400,8 +400,8 @@ firrtl.circuit "TopLevel" {
 // https://github.com/llvm/circt/issues/661
 
 // This test is just checking that the following doesn't error.
-    // COMMON-LABEL: firrtl.module @Issue661
-    firrtl.module @Issue661(in %clock: !firrtl.clock) {
+    // COMMON-LABEL: firrtl.module private @Issue661
+    firrtl.module private @Issue661(in %clock: !firrtl.clock) {
       %head_MPORT_2, %head_MPORT_6 = firrtl.mem Undefined {depth = 20 : i64, name = "head", portNames = ["MPORT_2", "MPORT_6"], readLatency = 0 : i32, writeLatency = 1 : i32}
       : !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<5>, mask: uint<1>>,
         !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<5>, mask: uint<1>>
@@ -409,23 +409,23 @@ firrtl.circuit "TopLevel" {
     }
 
 // Check that a non-bundled mux ops are untouched.
-    // CHECK-LABEL: firrtl.module @Mux
-    firrtl.module @Mux(in %p: !firrtl.uint<1>, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) {
+    // CHECK-LABEL: firrtl.module private @Mux
+    firrtl.module private @Mux(in %p: !firrtl.uint<1>, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) {
       // CHECK-NEXT: %0 = firrtl.mux(%p, %a, %b) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
       // CHECK-NEXT: firrtl.connect %c, %0 : !firrtl.uint<1>, !firrtl.uint<1>
       %0 = firrtl.mux(%p, %a, %b) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
       firrtl.connect %c, %0 : !firrtl.uint<1>, !firrtl.uint<1>
     }
-    // CHECK-LABEL: firrtl.module @MuxBundle
-    firrtl.module @MuxBundle(in %p: !firrtl.uint<1>, in %a: !firrtl.bundle<a: uint<1>>, in %b: !firrtl.bundle<a: uint<1>>, out %c: !firrtl.bundle<a: uint<1>>) {
+    // CHECK-LABEL: firrtl.module private @MuxBundle
+    firrtl.module private @MuxBundle(in %p: !firrtl.uint<1>, in %a: !firrtl.bundle<a: uint<1>>, in %b: !firrtl.bundle<a: uint<1>>, out %c: !firrtl.bundle<a: uint<1>>) {
       // CHECK-NEXT: %0 = firrtl.mux(%p, %a_a, %b_a) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
       // CHECK-NEXT: firrtl.strictconnect %c_a, %0 : !firrtl.uint<1>
       %0 = firrtl.mux(%p, %a, %b) : (!firrtl.uint<1>, !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>) -> !firrtl.bundle<a: uint<1>>
       firrtl.connect %c, %0 : !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>
     }
 
-    // CHECK-LABEL: firrtl.module @NodeBundle
-    firrtl.module @NodeBundle(in %a: !firrtl.bundle<a: uint<1>>, out %b: !firrtl.uint<1>) {
+    // CHECK-LABEL: firrtl.module private @NodeBundle
+    firrtl.module private @NodeBundle(in %a: !firrtl.bundle<a: uint<1>>, out %b: !firrtl.uint<1>) {
       // CHECK-NEXT: %n_a = firrtl.node %a_a  : !firrtl.uint<1>
       // CHECK-NEXT: firrtl.connect %b, %n_a : !firrtl.uint<1>, !firrtl.uint<1>
       %n = firrtl.node %a : !firrtl.bundle<a: uint<1>>
@@ -433,8 +433,8 @@ firrtl.circuit "TopLevel" {
       firrtl.connect %b, %n_a : !firrtl.uint<1>, !firrtl.uint<1>
     }
 
-    // CHECK-LABEL: firrtl.module @RegBundle(in %a_a: !firrtl.uint<1>, in %clk: !firrtl.clock, out %b_a: !firrtl.uint<1>)
-    firrtl.module @RegBundle(in %a: !firrtl.bundle<a: uint<1>>, in %clk: !firrtl.clock, out %b: !firrtl.bundle<a: uint<1>>) {
+    // CHECK-LABEL: firrtl.module private @RegBundle(in %a_a: !firrtl.uint<1>, in %clk: !firrtl.clock, out %b_a: !firrtl.uint<1>)
+    firrtl.module private @RegBundle(in %a: !firrtl.bundle<a: uint<1>>, in %clk: !firrtl.clock, out %b: !firrtl.bundle<a: uint<1>>) {
       // CHECK-NEXT: %x_a = firrtl.reg %clk : !firrtl.uint<1>
       // CHECK-NEXT: firrtl.connect %x_a, %a_a : !firrtl.uint<1>, !firrtl.uint<1>
       // CHECK-NEXT: firrtl.connect %b_a, %x_a : !firrtl.uint<1>, !firrtl.uint<1>
@@ -447,8 +447,8 @@ firrtl.circuit "TopLevel" {
       firrtl.connect %2, %3 : !firrtl.uint<1>, !firrtl.uint<1>
     }
 
-    // CHECK-LABEL: firrtl.module @RegBundleWithBulkConnect(in %a_a: !firrtl.uint<1>, in %clk: !firrtl.clock, out %b_a: !firrtl.uint<1>)
-    firrtl.module @RegBundleWithBulkConnect(in %a: !firrtl.bundle<a: uint<1>>, in %clk: !firrtl.clock, out %b: !firrtl.bundle<a: uint<1>>) {
+    // CHECK-LABEL: firrtl.module private @RegBundleWithBulkConnect(in %a_a: !firrtl.uint<1>, in %clk: !firrtl.clock, out %b_a: !firrtl.uint<1>)
+    firrtl.module private @RegBundleWithBulkConnect(in %a: !firrtl.bundle<a: uint<1>>, in %clk: !firrtl.clock, out %b: !firrtl.bundle<a: uint<1>>) {
       // CHECK-NEXT: %x_a = firrtl.reg %clk : !firrtl.uint<1>
       // CHECK-NEXT: firrtl.strictconnect %x_a, %a_a : !firrtl.uint<1>
       // CHECK-NEXT: firrtl.strictconnect %b_a, %x_a : !firrtl.uint<1>
@@ -457,8 +457,8 @@ firrtl.circuit "TopLevel" {
       firrtl.connect %b, %x : !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>
     }
 
-    // CHECK-LABEL: firrtl.module @WireBundle(in %a_a: !firrtl.uint<1>,  out %b_a: !firrtl.uint<1>)
-    firrtl.module @WireBundle(in %a: !firrtl.bundle<a: uint<1>>,  out %b: !firrtl.bundle<a: uint<1>>) {
+    // CHECK-LABEL: firrtl.module private @WireBundle(in %a_a: !firrtl.uint<1>,  out %b_a: !firrtl.uint<1>)
+    firrtl.module private @WireBundle(in %a: !firrtl.bundle<a: uint<1>>,  out %b: !firrtl.bundle<a: uint<1>>) {
       // CHECK-NEXT: %x_a = firrtl.wire  : !firrtl.uint<1>
       // CHECK-NEXT: firrtl.connect %x_a, %a_a : !firrtl.uint<1>, !firrtl.uint<1>
       // CHECK-NEXT: firrtl.connect %b_a, %x_a : !firrtl.uint<1>, !firrtl.uint<1>
@@ -471,8 +471,8 @@ firrtl.circuit "TopLevel" {
       firrtl.connect %2, %3 : !firrtl.uint<1>, !firrtl.uint<1>
     }
 
-  // CHECK-LABEL: firrtl.module @WireBundlesWithBulkConnect
-  firrtl.module @WireBundlesWithBulkConnect(in %source: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>,
+  // CHECK-LABEL: firrtl.module private @WireBundlesWithBulkConnect
+  firrtl.module private @WireBundlesWithBulkConnect(in %source: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>,
                              out %sink: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) {
     // CHECK: %w_valid = firrtl.wire  : !firrtl.uint<1>
     // CHECK: %w_ready = firrtl.wire  : !firrtl.uint<1>
@@ -489,13 +489,13 @@ firrtl.circuit "TopLevel" {
   }
 
 // Test vector lowering
-  firrtl.module @LowerVectors(in %a: !firrtl.vector<uint<1>, 2>, out %b: !firrtl.vector<uint<1>, 2>) {
+  firrtl.module private @LowerVectors(in %a: !firrtl.vector<uint<1>, 2>, out %b: !firrtl.vector<uint<1>, 2>) {
     firrtl.connect %b, %a: !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
   }
-  // CHECK-LABEL: firrtl.module @LowerVectors(in %a_0: !firrtl.uint<1>, in %a_1: !firrtl.uint<1>, out %b_0: !firrtl.uint<1>, out %b_1: !firrtl.uint<1>)
+  // CHECK-LABEL: firrtl.module private @LowerVectors(in %a_0: !firrtl.uint<1>, in %a_1: !firrtl.uint<1>, out %b_0: !firrtl.uint<1>, out %b_1: !firrtl.uint<1>)
   // CHECK: firrtl.strictconnect %b_0, %a_0
   // CHECK: firrtl.strictconnect %b_1, %a_1
-  // AGGREGATE-LABEL: firrtl.module @LowerVectors(in %a: !firrtl.vector<uint<1>, 2>, out %b: !firrtl.vector<uint<1>, 2>)
+  // AGGREGATE-LABEL: firrtl.module private @LowerVectors(in %a: !firrtl.vector<uint<1>, 2>, out %b: !firrtl.vector<uint<1>, 2>)
   // AGGREGATE-NEXT: %0 = firrtl.subindex %a[0] : !firrtl.vector<uint<1>, 2>
   // AGGREGATE-NEXT: %1 = firrtl.subindex %b[0] : !firrtl.vector<uint<1>, 2>
   // AGGREGATE-NEXT: firrtl.strictconnect %1, %0 : !firrtl.uint<1>
@@ -504,8 +504,8 @@ firrtl.circuit "TopLevel" {
   // AGGREGATE-NEXT: firrtl.strictconnect %3, %2 : !firrtl.uint<1>
 
 // Test vector of bundles lowering
-  // COMMON-LABEL: firrtl.module @LowerVectorsOfBundles(in %in_0_a: !firrtl.uint<1>, out %in_0_b: !firrtl.uint<1>, in %in_1_a: !firrtl.uint<1>, out %in_1_b: !firrtl.uint<1>, out %out_0_a: !firrtl.uint<1>, in %out_0_b: !firrtl.uint<1>, out %out_1_a: !firrtl.uint<1>, in %out_1_b: !firrtl.uint<1>)
-  firrtl.module @LowerVectorsOfBundles(in %in: !firrtl.vector<bundle<a : uint<1>, b  flip: uint<1>>, 2>,
+  // COMMON-LABEL: firrtl.module private @LowerVectorsOfBundles(in %in_0_a: !firrtl.uint<1>, out %in_0_b: !firrtl.uint<1>, in %in_1_a: !firrtl.uint<1>, out %in_1_b: !firrtl.uint<1>, out %out_0_a: !firrtl.uint<1>, in %out_0_b: !firrtl.uint<1>, out %out_1_a: !firrtl.uint<1>, in %out_1_b: !firrtl.uint<1>)
+  firrtl.module private @LowerVectorsOfBundles(in %in: !firrtl.vector<bundle<a : uint<1>, b  flip: uint<1>>, 2>,
                                        out %out: !firrtl.vector<bundle<a : uint<1>, b  flip: uint<1>>, 2>) {
     // COMMON:      firrtl.strictconnect %out_0_a, %in_0_a : !firrtl.uint<1>
     // COMMON-NEXT: firrtl.strictconnect %in_0_b, %out_0_b : !firrtl.uint<1>
@@ -516,14 +516,14 @@ firrtl.circuit "TopLevel" {
 
   // COMMON-LABEL: firrtl.extmodule @ExternalModule(in source_valid: !firrtl.uint<1>, out source_ready: !firrtl.uint<1>, in source_data: !firrtl.uint<64>)
   firrtl.extmodule @ExternalModule(in source: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>)
-  firrtl.module @Test() {
+  firrtl.module private @Test() {
     // COMMON: %inst_source_valid, %inst_source_ready, %inst_source_data = firrtl.instance "" @ExternalModule(in source_valid: !firrtl.uint<1>, out source_ready: !firrtl.uint<1>, in source_data: !firrtl.uint<64>)
     %inst_source = firrtl.instance "" @ExternalModule(in source: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>)
   }
 
 // Test RegResetOp lowering
-  // CHECK-LABEL: firrtl.module @LowerRegResetOp
-  firrtl.module @LowerRegResetOp(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %a_d: !firrtl.vector<uint<1>, 2>, out %a_q: !firrtl.vector<uint<1>, 2>) {
+  // CHECK-LABEL: firrtl.module private @LowerRegResetOp
+  firrtl.module private @LowerRegResetOp(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %a_d: !firrtl.vector<uint<1>, 2>, out %a_q: !firrtl.vector<uint<1>, 2>) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %init = firrtl.wire  : !firrtl.vector<uint<1>, 2>
     %0 = firrtl.subindex %init[0] : !firrtl.vector<uint<1>, 2>
@@ -567,8 +567,8 @@ firrtl.circuit "TopLevel" {
 
 // Test RegResetOp lowering without name attribute
 // https://github.com/llvm/circt/issues/795
-  // CHECK-LABEL: firrtl.module @LowerRegResetOpNoName
-  firrtl.module @LowerRegResetOpNoName(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %a_d: !firrtl.vector<uint<1>, 2>, out %a_q: !firrtl.vector<uint<1>, 2>) {
+  // CHECK-LABEL: firrtl.module private @LowerRegResetOpNoName
+  firrtl.module private @LowerRegResetOpNoName(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %a_d: !firrtl.vector<uint<1>, 2>, out %a_q: !firrtl.vector<uint<1>, 2>) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %init = firrtl.wire  : !firrtl.vector<uint<1>, 2>
     %0 = firrtl.subindex %init[0] : !firrtl.vector<uint<1>, 2>
@@ -593,8 +593,8 @@ firrtl.circuit "TopLevel" {
 
 // Test RegOp lowering without name attribute
 // https://github.com/llvm/circt/issues/795
-  // CHECK-LABEL: firrtl.module @lowerRegOpNoName
-  firrtl.module @lowerRegOpNoName(in %clock: !firrtl.clock, in %a_d: !firrtl.vector<uint<1>, 2>, out %a_q: !firrtl.vector<uint<1>, 2>) {
+  // CHECK-LABEL: firrtl.module private @lowerRegOpNoName
+  firrtl.module private @lowerRegOpNoName(in %clock: !firrtl.clock, in %a_d: !firrtl.vector<uint<1>, 2>, out %a_q: !firrtl.vector<uint<1>, 2>) {
     %r = firrtl.reg %clock {name = ""} : !firrtl.vector<uint<1>, 2>
       firrtl.connect %r, %a_d : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
       firrtl.connect %a_q, %r : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
@@ -607,19 +607,19 @@ firrtl.circuit "TopLevel" {
  // CHECK:    firrtl.strictconnect %a_q_1, %1 : !firrtl.uint<1>
 
 // Test that InstanceOp Annotations are copied to the new instance.
-  firrtl.module @Bar(out %a: !firrtl.vector<uint<1>, 2>) {
+  firrtl.module private @Bar(out %a: !firrtl.vector<uint<1>, 2>) {
     %0 = firrtl.invalidvalue : !firrtl.vector<uint<1>, 2>
     firrtl.connect %a, %0 : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
   }
-  firrtl.module @AnnotationsInstanceOp() {
+  firrtl.module private @AnnotationsInstanceOp() {
     %bar_a = firrtl.instance bar {annotations = [{a = "a"}]} @Bar(out a: !firrtl.vector<uint<1>, 2>)
   }
   // CHECK: firrtl.instance
   // CHECK-SAME: annotations = [{a = "a"}]
 
 // Test that MemOp Annotations are copied to lowered MemOps.
-  // COMMON-LABEL: firrtl.module @AnnotationsMemOp
-  firrtl.module @AnnotationsMemOp() {
+  // COMMON-LABEL: firrtl.module private @AnnotationsMemOp
+  firrtl.module private @AnnotationsMemOp() {
     %bar_r, %bar_w = firrtl.mem Undefined  {annotations = [{a = "a"}], depth = 16 : i64, name = "bar", portNames = ["r", "w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: vector<uint<8>, 2>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: vector<uint<8>, 2>, mask: vector<uint<1>, 2>>
   }
   // COMMON: firrtl.mem
@@ -628,8 +628,8 @@ firrtl.circuit "TopLevel" {
   // COMMON-SAME: annotations = [{a = "a"}]
 
 // Test that WireOp Annotations are copied to lowered WireOps.
-  // CHECK-LABEL: firrtl.module @AnnotationsWireOp
-  firrtl.module @AnnotationsWireOp() {
+  // CHECK-LABEL: firrtl.module private @AnnotationsWireOp
+  firrtl.module private @AnnotationsWireOp() {
     %bar = firrtl.wire  {annotations = [{a = "a"}]} : !firrtl.vector<uint<1>, 2>
   }
   // CHECK: firrtl.wire
@@ -639,8 +639,8 @@ firrtl.circuit "TopLevel" {
 
 // Test that WireOp annotations which are sensitive to field IDs are annotated
 // with the lowered field IDs.
-  // COMMON-LABEL: firrtl.module @AnnotationsWithFieldIdWireOp
-  firrtl.module @AnnotationsWithFieldIdWireOp() {
+  // COMMON-LABEL: firrtl.module private @AnnotationsWithFieldIdWireOp
+  firrtl.module private @AnnotationsWithFieldIdWireOp() {
     %foo = firrtl.wire {annotations = [{class = "sifive.enterprise.grandcentral.SignalDriverAnnotation"}]} : !firrtl.uint<1>
     %bar = firrtl.wire {annotations = [{class = "sifive.enterprise.grandcentral.SignalDriverAnnotation"}]} : !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<1>>
     %baz = firrtl.wire {annotations = [#firrtl<"subAnno<fieldID = 2, {class = \"sifive.enterprise.grandcentral.SignalDriverAnnotation\"}>">]} : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
@@ -663,8 +663,8 @@ firrtl.circuit "TopLevel" {
   // AGGREGATE-SAME: {annotations = [#firrtl.subAnno<fieldID = 2, {class = "sifive.enterprise.grandcentral.SignalDriverAnnotation"}>]}
 
 // Test that Reg/RegResetOp Annotations are copied to lowered registers.
-  // CHECK-LABEL: firrtl.module @AnnotationsRegOp
-  firrtl.module @AnnotationsRegOp(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
+  // CHECK-LABEL: firrtl.module private @AnnotationsRegOp
+  firrtl.module private @AnnotationsRegOp(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
     %bazInit = firrtl.wire  : !firrtl.vector<uint<1>, 2>
     %0 = firrtl.subindex %bazInit[0] : !firrtl.vector<uint<1>, 2>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
@@ -684,8 +684,8 @@ firrtl.circuit "TopLevel" {
   // CHECK-SAME: annotations = [{b = "b"}]
 
 // Test that WhenOp with regions has its regions lowered.
-// CHECK-LABEL: firrtl.module @WhenOp
-  firrtl.module @WhenOp (in %p: !firrtl.uint<1>,
+// CHECK-LABEL: firrtl.module private @WhenOp
+  firrtl.module private @WhenOp (in %p: !firrtl.uint<1>,
                          in %in : !firrtl.bundle<a: uint<1>, b: uint<1>>,
                          out %out : !firrtl.bundle<a: uint<1>, b: uint<1>>) {
     // No else region.
@@ -708,8 +708,8 @@ firrtl.circuit "TopLevel" {
   }
 
 // Test that subfield annotations on wire are lowred to appropriate instance based on fieldID.
-  // CHECK-LABEL: firrtl.module @AnnotationsBundle
-  firrtl.module @AnnotationsBundle() {
+  // CHECK-LABEL: firrtl.module private @AnnotationsBundle
+  firrtl.module private @AnnotationsBundle() {
     %bar = firrtl.wire  {annotations = [#firrtl.subAnno<fieldID = 3, {one}>, #firrtl.subAnno<fieldID = 5, {two}>]} : !firrtl.vector<bundle<baz: uint<1>, qux: uint<1>>, 2>
 
       // TODO: Enable this
@@ -726,8 +726,8 @@ firrtl.circuit "TopLevel" {
   }
 
 // Test that subfield annotations on reg are lowred to appropriate instance based on fieldID.
- // CHECK-LABEL: firrtl.module @AnnotationsBundle2
-  firrtl.module @AnnotationsBundle2(in %clock: !firrtl.clock) {
+ // CHECK-LABEL: firrtl.module private @AnnotationsBundle2
+  firrtl.module private @AnnotationsBundle2(in %clock: !firrtl.clock) {
     %bar = firrtl.reg %clock  {annotations = [#firrtl.subAnno<fieldID = 3, {one}>, #firrtl.subAnno<fieldID = 5, {two}>]} : !firrtl.vector<bundle<baz: uint<1>, qux: uint<1>>, 2>
 
     // TODO: Enable this
@@ -740,8 +740,8 @@ firrtl.circuit "TopLevel" {
 // Test that subfield annotations on reg are lowred to appropriate instance based on fieldID. Ignore un-flattened array targets
 // circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar[0].qux[0]"},{"two":null,"target":"~Foo|Foo>bar[1].baz"},{"three":null,"target":"~Foo|Foo>bar[0].yes"} ]]
 
- // CHECK-LABEL: firrtl.module @AnnotationsBundle3
-  firrtl.module @AnnotationsBundle3(in %clock: !firrtl.clock) {
+ // CHECK-LABEL: firrtl.module private @AnnotationsBundle3
+  firrtl.module private @AnnotationsBundle3(in %clock: !firrtl.clock) {
     %bar = firrtl.reg %clock  {annotations = [#firrtl.subAnno<fieldID = 6, {one}>, #firrtl.subAnno<fieldID = 12, {two}>, #firrtl.subAnno<fieldID = 8, {three}>]} : !firrtl.vector<bundle<baz: vector<uint<1>, 2>, qux: vector<uint<1>, 2>, yes: bundle<a: uint<1>, b: uint<1>>>, 2>
 
     // TODO: Enable this
@@ -761,8 +761,8 @@ firrtl.circuit "TopLevel" {
 
 // Test wire connection semantics.  Based on the flippedness of the destination
 // type, the connection may be reversed.
-// CHECK-LABEL firrtl.module @WireSemantics
-  firrtl.module @WireSemantics() {
+// CHECK-LABEL firrtl.module private @WireSemantics
+  firrtl.module private @WireSemantics() {
     %a = firrtl.wire  : !firrtl.bundle<a: bundle<a: uint<1>>>
     %ax = firrtl.wire  : !firrtl.bundle<a: bundle<a: uint<1>>>
     // CHECK:  %a_a_a = firrtl.wire
@@ -878,8 +878,8 @@ firrtl.circuit "TopLevel" {
   }
 
 // Test corner cases of partial connect semantics.
- // CHECK-LABEL: firrtl.module @PartialConnectEdgeCases
-  firrtl.module @PartialConnectEdgeCases() {
+ // CHECK-LABEL: firrtl.module private @PartialConnectEdgeCases
+  firrtl.module private @PartialConnectEdgeCases() {
     // Only matching fields are connected.
     %a = firrtl.wire : !firrtl.bundle<a: uint<1>, b: uint<1>, c: uint<1>>
     %b = firrtl.wire : !firrtl.bundle<a: uint<1>, b: uint<1>>
@@ -913,8 +913,8 @@ firrtl.circuit "TopLevel" {
 
 
 // Test partial connect truncation.
- // CHECK-LABEL: firrtl.module @PartialConnectTruncation
-  firrtl.module @PartialConnectTruncation() {
+ // CHECK-LABEL: firrtl.module private @PartialConnectTruncation
+  firrtl.module private @PartialConnectTruncation() {
     // It should not truncate when they are the same
     %a = firrtl.wire : !firrtl.uint<0>
     %b = firrtl.wire : !firrtl.uint<0>
@@ -938,10 +938,10 @@ firrtl.circuit "TopLevel" {
   }
 
 // Bug: must strip the flip type from the LHS of a value.
- // CHECK-LABEL: firrtl.module @PartialConnectLHSFlip
-  firrtl.module @PartialConnectLHSFlip(in %a: !firrtl.bundle<b: bundle<c flip: uint<2>>>) { }
-   // CHECK-LABEL: firrtl.module @FooFlipType
-  firrtl.module @FooFlipType(in %a: !firrtl.bundle<b: bundle<c flip: uint<2>>>) {
+ // CHECK-LABEL: firrtl.module private @PartialConnectLHSFlip
+  firrtl.module private @PartialConnectLHSFlip(in %a: !firrtl.bundle<b: bundle<c flip: uint<2>>>) { }
+   // CHECK-LABEL: firrtl.module private @FooFlipType
+  firrtl.module private @FooFlipType(in %a: !firrtl.bundle<b: bundle<c flip: uint<2>>>) {
     %mgmt_a = firrtl.instance mgmt @PartialConnectLHSFlip(in a: !firrtl.bundle<b: bundle<c flip: uint<2>>>)
     %0 = firrtl.subfield %mgmt_a(0) : (!firrtl.bundle<b: bundle<c flip: uint<2>>>) -> !firrtl.bundle<c flip: uint<2>>
     %1 = firrtl.subfield %0(0) : (!firrtl.bundle<c flip: uint<2>>) -> !firrtl.uint<2>
@@ -950,7 +950,7 @@ firrtl.circuit "TopLevel" {
   }
 
 // Test partial connect with analogs are transformed to attaches.
-  firrtl.module @PartialConnectAnalogs() {
+  firrtl.module private @PartialConnectAnalogs() {
     // CHECK-LABEL: @PartialConnectAnalogs
     %a = firrtl.wire : !firrtl.bundle<a: analog<1>>
     %b = firrtl.wire : !firrtl.bundle<a: analog<1>>
@@ -959,8 +959,8 @@ firrtl.circuit "TopLevel" {
   }
 
 // Test that a vector of bundles with a write works.
- // CHECK-LABEL: firrtl.module @aofs
-    firrtl.module @aofs(in %a: !firrtl.uint<1>, in %sel: !firrtl.uint<2>, out %b: !firrtl.vector<bundle<wo: uint<1>>, 4>) {
+ // CHECK-LABEL: firrtl.module private @aofs
+    firrtl.module private @aofs(in %a: !firrtl.uint<1>, in %sel: !firrtl.uint<2>, out %b: !firrtl.vector<bundle<wo: uint<1>>, 4>) {
       %0 = firrtl.subindex %b[0] : !firrtl.vector<bundle<wo: uint<1>>, 4>
       %1 = firrtl.subfield %0(0) : (!firrtl.bundle<wo: uint<1>>) -> !firrtl.uint<1>
       %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
@@ -988,7 +988,7 @@ firrtl.circuit "TopLevel" {
   // CHECK-LABEL: firrtl.extmodule @Sub1
   // CHECK-COUNT-2: [{b}]
   // CHECK-NOT: [{a}]
-  firrtl.module @Port(in %a: !firrtl.vector<uint<1>, 2> [{b}]) {
+  firrtl.module private @Port(in %a: !firrtl.vector<uint<1>, 2> [{b}]) {
     %sub_a = firrtl.instance sub @Sub1(in a: !firrtl.vector<uint<1>, 2>)
     firrtl.connect %sub_a, %a : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
   }
@@ -997,8 +997,8 @@ firrtl.circuit "TopLevel" {
 // matching fieldIDs.
     // The annotation should be copied to just a.a.  The firrtl.hello arg
     // attribute should be copied to each new port.
-    firrtl.module @PortBundle(in %a: !firrtl.bundle<a: uint<1>, b flip: uint<1>> [#firrtl.subAnno<fieldID = 1, {a}>]) {}
-    // CHECK-LABEL: firrtl.module @PortBundle
+    firrtl.module private @PortBundle(in %a: !firrtl.bundle<a: uint<1>, b flip: uint<1>> [#firrtl.subAnno<fieldID = 1, {a}>]) {}
+    // CHECK-LABEL: firrtl.module private @PortBundle
     // CHECK-COUNT-1: [{a}]
 
 // Test that a truncating connect emitted during lower types correctly adds an
@@ -1007,8 +1007,8 @@ firrtl.circuit "TopLevel" {
 // See: https://github.com/llvm/circt/issues/1276
 
   firrtl.extmodule @Bar2(in a: !firrtl.uint<2>)
-// CHECK-LABEL: firrtl.module @TruncatingConnectWithFlip
-  firrtl.module @TruncatingConnectWithFlip() {
+// CHECK-LABEL: firrtl.module private @TruncatingConnectWithFlip
+  firrtl.module private @TruncatingConnectWithFlip() {
     // CHECK: %[[a_b:.+]] = firrtl.wire
     %a = firrtl.wire  : !firrtl.bundle<b: uint<1>>
     // CHECK-NEXT: %bar_a = firrtl.instance bar @Bar
@@ -1032,13 +1032,13 @@ firrtl.circuit "TopLevel" {
 //
 //     b <= a[sel][sel]
 
-  firrtl.module @multidimRead(in %a: !firrtl.vector<vector<uint<2>, 2>, 2>, in %sel: !firrtl.uint<2>, out %b: !firrtl.uint<2>) {
+  firrtl.module private @multidimRead(in %a: !firrtl.vector<vector<uint<2>, 2>, 2>, in %sel: !firrtl.uint<2>, out %b: !firrtl.uint<2>) {
     %0 = firrtl.subaccess %a[%sel] : !firrtl.vector<vector<uint<2>, 2>, 2>, !firrtl.uint<2>
     %1 = firrtl.subaccess %0[%sel] : !firrtl.vector<uint<2>, 2>, !firrtl.uint<2>
     firrtl.connect %b, %1 : !firrtl.uint<2>, !firrtl.uint<2>
   }
 
-// CHECK-LABEL: firrtl.module @multidimRead(in %a_0_0: !firrtl.uint<2>, in %a_0_1: !firrtl.uint<2>, in %a_1_0: !firrtl.uint<2>, in %a_1_1: !firrtl.uint<2>, in %sel: !firrtl.uint<2>, out %b: !firrtl.uint<2>) {
+// CHECK-LABEL: firrtl.module private @multidimRead(in %a_0_0: !firrtl.uint<2>, in %a_0_1: !firrtl.uint<2>, in %a_1_0: !firrtl.uint<2>, in %a_1_1: !firrtl.uint<2>, in %sel: !firrtl.uint<2>, out %b: !firrtl.uint<2>) {
 // CHECK-NEXT:      %0 = firrtl.multibit_mux %sel, %a_1_0, %a_0_0 : !firrtl.uint<2>, !firrtl.uint<2>
 // CHECK-NEXT:      %1 = firrtl.multibit_mux %sel, %a_1_1, %a_0_1 : !firrtl.uint<2>, !firrtl.uint<2>
 // CHECK-NEXT:      %2 = firrtl.multibit_mux %sel, %1, %0 : !firrtl.uint<2>, !firrtl.uint<2>
@@ -1054,12 +1054,12 @@ firrtl.circuit "TopLevel" {
 //     a <= default
 //     a[sel] <= b
 
-  firrtl.module @write1D(in %b: !firrtl.uint<1>, in %sel: !firrtl.uint<2>, in %default: !firrtl.vector<uint<1>, 2>, out %a: !firrtl.vector<uint<1>, 2>) {
+  firrtl.module private @write1D(in %b: !firrtl.uint<1>, in %sel: !firrtl.uint<2>, in %default: !firrtl.vector<uint<1>, 2>, out %a: !firrtl.vector<uint<1>, 2>) {
     firrtl.connect %a, %default : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
     %0 = firrtl.subaccess %a[%sel] : !firrtl.vector<uint<1>, 2>, !firrtl.uint<2>
     firrtl.connect %0, %b : !firrtl.uint<1>, !firrtl.uint<1>
   }
-// CHECK-LABEL:    firrtl.module @write1D(in %b: !firrtl.uint<1>, in %sel: !firrtl.uint<2>, in %default_0: !firrtl.uint<1>, in %default_1: !firrtl.uint<1>, out %a_0: !firrtl.uint<1>, out %a_1: !firrtl.uint<1>) {
+// CHECK-LABEL:    firrtl.module private @write1D(in %b: !firrtl.uint<1>, in %sel: !firrtl.uint<2>, in %default_0: !firrtl.uint<1>, in %default_1: !firrtl.uint<1>, out %a_0: !firrtl.uint<1>, out %a_1: !firrtl.uint<1>) {
 // CHECK-NEXT:      firrtl.strictconnect %a_0, %default_0 : !firrtl.uint<1>
 // CHECK-NEXT:      firrtl.strictconnect %a_1, %default_1 : !firrtl.uint<1>
 // CHECK-NEXT:      %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
@@ -1083,12 +1083,12 @@ firrtl.circuit "TopLevel" {
 //
 //     a[sel][sel] <= b
 
-  firrtl.module @multidimWrite(in %sel: !firrtl.uint<1>, in %b: !firrtl.uint<2>, out %a: !firrtl.vector<vector<uint<2>, 2>, 2>) {
+  firrtl.module private @multidimWrite(in %sel: !firrtl.uint<1>, in %b: !firrtl.uint<2>, out %a: !firrtl.vector<vector<uint<2>, 2>, 2>) {
     %0 = firrtl.subaccess %a[%sel] : !firrtl.vector<vector<uint<2>, 2>, 2>, !firrtl.uint<1>
     %1 = firrtl.subaccess %0[%sel] : !firrtl.vector<uint<2>, 2>, !firrtl.uint<1>
     firrtl.connect %1, %b : !firrtl.uint<2>, !firrtl.uint<2>
   }
-// CHECK-LABEL:    firrtl.module @multidimWrite(in %sel: !firrtl.uint<1>, in %b: !firrtl.uint<2>, out %a_0_0: !firrtl.uint<2>, out %a_0_1: !firrtl.uint<2>, out %a_1_0: !firrtl.uint<2>, out %a_1_1: !firrtl.uint<2>) {
+// CHECK-LABEL:    firrtl.module private @multidimWrite(in %sel: !firrtl.uint<1>, in %b: !firrtl.uint<2>, out %a_0_0: !firrtl.uint<2>, out %a_0_1: !firrtl.uint<2>, out %a_1_0: !firrtl.uint<2>, out %a_1_1: !firrtl.uint<2>) {
 // CHECK-NEXT:      %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
 // CHECK-NEXT:      %0 = firrtl.eq %sel, %c0_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:      firrtl.when %0  {
@@ -1128,7 +1128,7 @@ firrtl.circuit "TopLevel" {
 //
 //     b <= def
 //     b[sel].wo <= a.wo
-  firrtl.module @writeVectorOfBundle1D(in %a: !firrtl.bundle<wo: uint<1>, valid: uint<2>>, in %def: !firrtl.vector<bundle<wo: uint<1>, valid: uint<2>>, 2>, in %sel: !firrtl.uint<2>, out %b: !firrtl.vector<bundle<wo: uint<1>, valid: uint<2>>, 2>) {
+  firrtl.module private @writeVectorOfBundle1D(in %a: !firrtl.bundle<wo: uint<1>, valid: uint<2>>, in %def: !firrtl.vector<bundle<wo: uint<1>, valid: uint<2>>, 2>, in %sel: !firrtl.uint<2>, out %b: !firrtl.vector<bundle<wo: uint<1>, valid: uint<2>>, 2>) {
     firrtl.connect %b, %def : !firrtl.vector<bundle<wo: uint<1>, valid: uint<2>>, 2>, !firrtl.vector<bundle<wo: uint<1>, valid: uint<2>>, 2>
     %0 = firrtl.subaccess %b[%sel] : !firrtl.vector<bundle<wo: uint<1>, valid: uint<2>>, 2>, !firrtl.uint<2>
     %1 = firrtl.subfield %0(0) : (!firrtl.bundle<wo: uint<1>, valid: uint<2>>) -> !firrtl.uint<1>
@@ -1136,7 +1136,7 @@ firrtl.circuit "TopLevel" {
     firrtl.connect %1, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 
-// CHECK-LABEL:    firrtl.module @writeVectorOfBundle1D(in %a_wo: !firrtl.uint<1>, in %a_valid: !firrtl.uint<2>, in %def_0_wo: !firrtl.uint<1>, in %def_0_valid: !firrtl.uint<2>, in %def_1_wo: !firrtl.uint<1>, in %def_1_valid: !firrtl.uint<2>, in %sel: !firrtl.uint<2>, out %b_0_wo: !firrtl.uint<1>, out %b_0_valid: !firrtl.uint<2>, out %b_1_wo: !firrtl.uint<1>, out %b_1_valid: !firrtl.uint<2>) {
+// CHECK-LABEL:    firrtl.module private @writeVectorOfBundle1D(in %a_wo: !firrtl.uint<1>, in %a_valid: !firrtl.uint<2>, in %def_0_wo: !firrtl.uint<1>, in %def_0_valid: !firrtl.uint<2>, in %def_1_wo: !firrtl.uint<1>, in %def_1_valid: !firrtl.uint<2>, in %sel: !firrtl.uint<2>, out %b_0_wo: !firrtl.uint<1>, out %b_0_valid: !firrtl.uint<2>, out %b_1_wo: !firrtl.uint<1>, out %b_1_valid: !firrtl.uint<2>) {
 // CHECK-NEXT:      firrtl.strictconnect %b_0_wo, %def_0_wo : !firrtl.uint<1>
 // CHECK-NEXT:      firrtl.strictconnect %b_0_valid, %def_0_valid : !firrtl.uint<2>
 // CHECK-NEXT:      firrtl.strictconnect %b_1_wo, %def_1_wo : !firrtl.uint<1>
@@ -1163,7 +1163,7 @@ firrtl.circuit "TopLevel" {
 //
 //     b <= a[sel1][sel1]
 //     c <= a[sel1][sel2]
-  firrtl.module @multiSubaccess(in %a: !firrtl.vector<vector<uint<2>, 2>, 2>, in %sel1: !firrtl.uint<1>, in %sel2: !firrtl.uint<1>, out %b: !firrtl.uint<2>, out %c: !firrtl.uint<2>) {
+  firrtl.module private @multiSubaccess(in %a: !firrtl.vector<vector<uint<2>, 2>, 2>, in %sel1: !firrtl.uint<1>, in %sel2: !firrtl.uint<1>, out %b: !firrtl.uint<2>, out %c: !firrtl.uint<2>) {
     %0 = firrtl.subaccess %a[%sel1] : !firrtl.vector<vector<uint<2>, 2>, 2>, !firrtl.uint<1>
     %1 = firrtl.subaccess %0[%sel1] : !firrtl.vector<uint<2>, 2>, !firrtl.uint<1>
     firrtl.connect %b, %1 : !firrtl.uint<2>, !firrtl.uint<2>
@@ -1172,7 +1172,7 @@ firrtl.circuit "TopLevel" {
     firrtl.connect %c, %3 : !firrtl.uint<2>, !firrtl.uint<2>
   }
 
-// CHECK-LABEL:    firrtl.module @multiSubaccess(in %a_0_0: !firrtl.uint<2>, in %a_0_1: !firrtl.uint<2>, in %a_1_0: !firrtl.uint<2>, in %a_1_1: !firrtl.uint<2>, in %sel1: !firrtl.uint<1>, in %sel2: !firrtl.uint<1>, out %b: !firrtl.uint<2>, out %c: !firrtl.uint<2>) {
+// CHECK-LABEL:    firrtl.module private @multiSubaccess(in %a_0_0: !firrtl.uint<2>, in %a_0_1: !firrtl.uint<2>, in %a_1_0: !firrtl.uint<2>, in %a_1_1: !firrtl.uint<2>, in %sel1: !firrtl.uint<1>, in %sel2: !firrtl.uint<1>, out %b: !firrtl.uint<2>, out %c: !firrtl.uint<2>) {
 // CHECK-NEXT:      %0 = firrtl.multibit_mux %sel1, %a_1_0, %a_0_0 : !firrtl.uint<1>, !firrtl.uint<2>
 // CHECK-NEXT:      %1 = firrtl.multibit_mux %sel1, %a_1_1, %a_0_1 : !firrtl.uint<1>, !firrtl.uint<2>
 // CHECK-NEXT:      %2 = firrtl.multibit_mux %sel1, %1, %0 : !firrtl.uint<1>, !firrtl.uint<2>
@@ -1186,7 +1186,7 @@ firrtl.circuit "TopLevel" {
 
 // Handle zero-length vector subaccess
   // CHECK-LABEL: zvec
-  firrtl.module @zvec(in %i: !firrtl.vector<bundle<a: uint<8>, b: uint<4>>, 0>, in %sel: !firrtl.uint<1>, out %foo: !firrtl.vector<uint<1>, 0>, out %o: !firrtl.uint<8>) {
+  firrtl.module private @zvec(in %i: !firrtl.vector<bundle<a: uint<8>, b: uint<4>>, 0>, in %sel: !firrtl.uint<1>, out %foo: !firrtl.vector<uint<1>, 0>, out %o: !firrtl.uint<8>) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %0 = firrtl.subaccess %foo[%c0_ui1] : !firrtl.vector<uint<1>, 0>, !firrtl.uint<1>
     firrtl.connect %0, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -1197,11 +1197,11 @@ firrtl.circuit "TopLevel" {
   }
 
 // Test InstanceOp with port annotations.
-// CHECK-LABEL firrtl.module @Bar3
-  firrtl.module @Bar3(in %a: !firrtl.uint<1>, out %b: !firrtl.bundle<baz: uint<1>, qux: uint<1>>) {
+// CHECK-LABEL firrtl.module private @Bar3
+  firrtl.module private @Bar3(in %a: !firrtl.uint<1>, out %b: !firrtl.bundle<baz: uint<1>, qux: uint<1>>) {
   }
-  // CHECK-LABEL firrtl.module @Foo3
-  firrtl.module @Foo3() {
+  // CHECK-LABEL firrtl.module private @Foo3
+  firrtl.module private @Foo3() {
     // CHECK: in a: !firrtl.uint<1> [{one}], out b_baz: !firrtl.uint<1> [{two}], out b_qux: !firrtl.uint<1>
     %bar_a, %bar_b = firrtl.instance bar @Bar3(in a: !firrtl.uint<1> [{one}], out b: !firrtl.bundle<baz: uint<1>, qux: uint<1>> [#firrtl.subAnno<fieldID = 1, {two}>])
   }
@@ -1215,9 +1215,9 @@ firrtl.circuit "TopLevel" {
 //                 {"e":null,"target":"~Foo|Foo>bar.rw.wmode"}
 //                 {"f":null,"target":"~Foo|Foo>bar.rw.wmask.baz"}]]
 
-// CHECK-LABEL: firrtl.module @Foo4
-// FLATTEN-LABEL: firrtl.module @Foo4
-  firrtl.module @Foo4() {
+// CHECK-LABEL: firrtl.module private @Foo4
+// FLATTEN-LABEL: firrtl.module private @Foo4
+  firrtl.module private @Foo4() {
     // CHECK: firrtl.mem
     // CHECK-SAME: portAnnotations = [
     // CHECK-SAME: [{a}, #firrtl.subAnno<fieldID = 4, {b}>],
@@ -1254,8 +1254,8 @@ firrtl.circuit "TopLevel" {
   }
 
 // Test that partial connects can extend
-// CHECK-LABEL: firrtl.module @TLBBB
-firrtl.module @TLBBB() {
+// CHECK-LABEL: firrtl.module private @TLBBB
+firrtl.module private @TLBBB() {
   %invalid_ui9 = firrtl.invalidvalue : !firrtl.uint<9>
   %in_bits = firrtl.wire  : !firrtl.uint<9>
   firrtl.connect %in_bits, %invalid_ui9 : !firrtl.uint<9>, !firrtl.uint<9>
@@ -1265,14 +1265,14 @@ firrtl.module @TLBBB() {
 }
 
 // This simply has to not crash
-// CHECK-LABEL: firrtl.module @vecmem
-// FLATTEN-LABEL: firrtl.module @vecmem
-firrtl.module @vecmem(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
+// CHECK-LABEL: firrtl.module private @vecmem
+// FLATTEN-LABEL: firrtl.module private @vecmem
+firrtl.module private @vecmem(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
   %vmem_MPORT, %vmem_rdwrPort = firrtl.mem Undefined  {depth = 32 : i64, name = "vmem", portNames = ["MPORT", "rdwrPort"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, data flip: vector<uint<17>, 8>>, !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, rdata flip: vector<uint<17>, 8>, wmode: uint<1>, wdata: vector<uint<17>, 8>, wmask: vector<uint<1>, 8>>
 }
 
-// CHECK-LABEL: firrtl.module @bofa
-firrtl.module @bofa(out %auto: !firrtl.bundle<io_out: bundle<foo: bundle<bar: analog<1>>>>) {
+// CHECK-LABEL: firrtl.module private @bofa
+firrtl.module private @bofa(out %auto: !firrtl.bundle<io_out: bundle<foo: bundle<bar: analog<1>>>>) {
   %0 = firrtl.subfield %auto(0) : (!firrtl.bundle<io_out: bundle<foo: bundle<bar: analog<1>>>>) -> !firrtl.bundle<foo: bundle<bar: analog<1>>>
   %io = firrtl.wire  : !firrtl.bundle<foo: bundle<bar: analog<1>>>
   firrtl.partialconnect %0, %io : !firrtl.bundle<foo: bundle<bar: analog<1>>>, !firrtl.bundle<foo: bundle<bar: analog<1>>>
@@ -1281,8 +1281,8 @@ firrtl.module @bofa(out %auto: !firrtl.bundle<io_out: bundle<foo: bundle<bar: an
 
 // Issue 1436
 firrtl.extmodule @is1436_BAR(out io: !firrtl.bundle<llWakeup flip: vector<uint<1>, 1>>)
-// CHECK-LABEL: firrtl.module @is1436_FOO
-firrtl.module @is1436_FOO() {
+// CHECK-LABEL: firrtl.module private @is1436_FOO
+firrtl.module private @is1436_FOO() {
   %thing_io = firrtl.instance thing @is1436_BAR(out io: !firrtl.bundle<llWakeup flip: vector<uint<1>, 1>>)
   %0 = firrtl.subfield %thing_io(0) : (!firrtl.bundle<llWakeup flip: vector<uint<1>, 1>>) -> !firrtl.vector<uint<1>, 1>
   %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
@@ -1290,8 +1290,8 @@ firrtl.module @is1436_FOO() {
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   firrtl.connect %1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   }
-  // CHECK-LABEL: firrtl.module @BitCast1
-  firrtl.module @BitCast1(out %o_0: !firrtl.uint<1>, out %o_1: !firrtl.uint<1>) {
+  // CHECK-LABEL: firrtl.module private @BitCast1
+  firrtl.module private @BitCast1(out %o_0: !firrtl.uint<1>, out %o_1: !firrtl.uint<1>) {
     %a1 = firrtl.wire : !firrtl.uint<4>
     %b = firrtl.bitcast %a1 : (!firrtl.uint<4>) -> (!firrtl.vector<uint<2>, 2>)
     // CHECK:  %[[v0:.+]] = firrtl.bits %a1 1 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<2>
@@ -1338,7 +1338,7 @@ firrtl.module @is1436_FOO() {
 
   }
 
-  firrtl.module @VecMemFlatten(in %clock: !firrtl.clock, in %rAddr: !firrtl.uint<4>, in %rEn: !firrtl.uint<1>, out %rData: !firrtl.vector<uint<8>, 4>, in %wAddr: !firrtl.uint<4>, in %wEn: !firrtl.uint<1>, in %wMask: !firrtl.vector<uint<1>, 4>, in %wData: !firrtl.vector<uint<8>, 4>) {
+  firrtl.module private @VecMemFlatten(in %clock: !firrtl.clock, in %rAddr: !firrtl.uint<4>, in %rEn: !firrtl.uint<1>, out %rData: !firrtl.vector<uint<8>, 4>, in %wAddr: !firrtl.uint<4>, in %wEn: !firrtl.uint<1>, in %wMask: !firrtl.vector<uint<1>, 4>, in %wData: !firrtl.vector<uint<8>, 4>) {
     %memory_r, %memory_w = firrtl.mem Undefined  {depth = 16 : i64, name = "memory", portNames = ["r", "w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: vector<uint<8>, 4>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: vector<uint<8>, 4>, mask: vector<uint<1>, 4>>
     %0 = firrtl.subfield %memory_r(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: vector<uint<8>, 4>>) -> !firrtl.clock
     firrtl.connect %0, %clock : !firrtl.clock, !firrtl.clock
@@ -1359,7 +1359,7 @@ firrtl.module @is1436_FOO() {
     %8 = firrtl.subfield %memory_w(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: vector<uint<8>, 4>, mask: vector<uint<1>, 4>>) -> !firrtl.vector<uint<8>, 4>
     firrtl.connect %8, %wData : !firrtl.vector<uint<8>, 4>, !firrtl.vector<uint<8>, 4>
   }
-  // FLATTEN-LABEL:  firrtl.module @VecMemFlatten
+  // FLATTEN-LABEL:  firrtl.module private @VecMemFlatten
   // FLATTEN:    %[[memory_r:.+]], %[[memory_w:.+]] = firrtl.mem Undefined  {depth = 16 : i64, name = "memory", portNames = ["r", "w"], readLatency = 0 : i32, writeLatency = 1 : i32}
   // FLATTEN-SAME:    !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<32>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<4>>
   // FLATTEN:    %[[v3:.+]] = firrtl.subfield %[[memory_r]](3)
@@ -1397,8 +1397,8 @@ firrtl.module @is1436_FOO() {
 
 
 // Test that empty bundles can be lowered.
-  // FLATTEN-LABEL: firrtl.module @SiFive_Queue_8()
-  firrtl.module @SiFive_Queue_8()  {
+  // FLATTEN-LABEL: firrtl.module private @SiFive_Queue_8()
+  firrtl.module private @SiFive_Queue_8()  {
     %SiFive_ram_MPORT, %SiFive_ram_io_deq_bits_MPORT = firrtl.mem Undefined  {depth = 2 : i64, name = "SiFive_ram", portNames = ["MPORT", "io_deq_bits_MPORT"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<id: uint<4>, addr: uint<31>, len: uint<8>, size: uint<3>, burst: uint<2>, lock: uint<1>, cache: uint<4>, prot: uint<3>, qos: uint<4>, user: bundle<>, echo: bundle<>>, mask: bundle<id: uint<1>, addr: uint<1>, len: uint<1>, size: uint<1>, burst: uint<1>, lock: uint<1>, cache: uint<1>, prot: uint<1>, qos: uint<1>, user: bundle<>, echo: bundle<>>>, !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: bundle<id: uint<4>, addr: uint<31>, len: uint<8>, size: uint<3>, burst: uint<2>, lock: uint<1>, cache: uint<4>, prot: uint<3>, qos: uint<4>, user: bundle<>, echo: bundle<>>>
     // FLATTEN: %SiFive_ram_MPORT, %SiFive_ram_io_deq_bits_MPORT = firrtl.mem Undefined  {depth = 2 : i64, name = "SiFive_ram", portNames = ["MPORT", "io_deq_bits_MPORT"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<60>, mask: uint<60>>, !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<60>>
    // FLATTEN:   %[[v3:.+]] = firrtl.subfield %SiFive_ram_MPORT(3) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<60>, mask: uint<60>>) -> !firrtl.uint<60>
@@ -1415,8 +1415,8 @@ firrtl.module @is1436_FOO() {
 
 // Issue #2315: Narrow index constants overflow when subaccessing long vectors.
 // https://github.com/llvm/circt/issues/2315
-// CHECK-LABEL: firrtl.module @Issue2315
-firrtl.module @Issue2315(in %x: !firrtl.vector<uint<10>, 5>, in %source: !firrtl.uint<2>, out %z: !firrtl.uint<10>) {
+// CHECK-LABEL: firrtl.module private @Issue2315
+firrtl.module private @Issue2315(in %x: !firrtl.vector<uint<10>, 5>, in %source: !firrtl.uint<2>, out %z: !firrtl.uint<10>) {
   %0 = firrtl.subaccess %x[%source] : !firrtl.vector<uint<10>, 5>, !firrtl.uint<2>
   firrtl.connect %z, %0 : !firrtl.uint<10>, !firrtl.uint<10>
   // The width of multibit mux index will be converted at LowerToHW,
@@ -1432,18 +1432,18 @@ firrtl.module @Issue2315(in %x: !firrtl.vector<uint<10>, 5>, in %source: !firrtl
   firrtl.nla @nla_1 [#hw.innerNameRef<@fallBackName::@test>,#hw.innerNameRef<@Aardvark::@test_1>, @Zebra]
   firrtl.nla @nla_2 [#hw.innerNameRef<@fallBackName::@test>, #hw.innerNameRef<@Aardvark::@test>, #hw.innerNameRef<@Zebra::@b2>]
   // CHECK-NOT: firrtl.nla @nla_2 
-  firrtl.module @fallBackName() {
+  firrtl.module private @fallBackName() {
     firrtl.instance test  sym @test {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}, {circt.nonlocal = @nla_1, class = "circt.nonlocal"} , {circt.nonlocal = @nla_2, class = "circt.nonlocal"}]}@Aardvark()
     firrtl.instance test2 @Zebra()
   }
 
-  firrtl.module @Aardvark() {
+  firrtl.module private @Aardvark() {
     firrtl.instance test sym @test {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}, {circt.nonlocal = @nla_2, class = "circt.nonlocal"}]}@Zebra()
     firrtl.instance test1 sym @test_1 {annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}]}@Zebra()
   }
 
-  // CHECK-LABEL: firrtl.module @Zebra()
-  firrtl.module @Zebra() attributes {annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}]}{
+  // CHECK-LABEL: firrtl.module private @Zebra()
+  firrtl.module private @Zebra() attributes {annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}]}{
     // bundle has annotations reusing the same NLA, the DontTouch should get dropped.
     %bundle = firrtl.wire sym @b {annotations = [#firrtl<"subAnno<fieldID = 2, {circt.nonlocal = @nla, class =\"test\" }>">,#firrtl<"subAnno<fieldID = 2, {circt.nonlocal = @nla, class =\"firrtl.transforms.DontTouchAnnotation\" }>">, #firrtl<"subAnno<fieldID = 3, {circt.nonlocal = @nla, B}>">, #firrtl<"subAnno<fieldID = 3, {circt.nonlocal = @nla, A}>">, #firrtl<"subAnno<fieldID = 3, {circt.nonlocal = @nla, class =\"firrtl.transforms.DontTouchAnnotation\" }>">]}: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
     %bundle2 = firrtl.wire sym @b2 {annotations = [#firrtl<"subAnno<fieldID = 3, {circt.nonlocal = @nla_2, class =\"firrtl.transforms.DontTouchAnnotation\"}>">, #firrtl<"subAnno<fieldID = 2, {circt.nonlocal = @nla_2, class =\"firrtl.transforms.DontTouchAnnotation\"}>">]}: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
@@ -1465,8 +1465,8 @@ firrtl.module @Issue2315(in %x: !firrtl.vector<uint<10>, 5>, in %source: !firrtl
   firrtl.nla @lowernla_1 [#hw.innerNameRef<@testNLAbundle::@testBundle_Bar>, #hw.innerNameRef<@testBundle_Bar::@b>]
   // CHECK: firrtl.nla @lowernla_1_0 [#hw.innerNameRef<@testNLAbundle::@testBundle_Bar>, #hw.innerNameRef<@testBundle_Bar::@b_qux>]
   // CHECK: firrtl.nla @lowernla_1 [#hw.innerNameRef<@testNLAbundle::@testBundle_Bar>, #hw.innerNameRef<@testBundle_Bar::@b_baz>]
-  firrtl.module @testBundle_Bar(in %a: !firrtl.uint<1>, out %b: !firrtl.bundle<baz: uint<1>, qux: uint<1>, data: uint<2>> sym @b [#firrtl<"subAnno<fieldID = 3, {circt.nonlocal = @lowernla_1, class =\"firrtl.transforms.DontTouchAnnotation\" }>">, #firrtl.subAnno<fieldID = 1, {circt.nonlocal = @lowernla_1, A}>, #firrtl.subAnno<fieldID = 1, {circt.nonlocal = @lowernla_1, B}>, #firrtl.subAnno<fieldID = 2, {circt.nonlocal = @lowernla_1, C}>], out %c: !firrtl.uint<1>) {
-  // CHECK-LABEL: firrtl.module @testBundle_Bar
+  firrtl.module private @testBundle_Bar(in %a: !firrtl.uint<1>, out %b: !firrtl.bundle<baz: uint<1>, qux: uint<1>, data: uint<2>> sym @b [#firrtl<"subAnno<fieldID = 3, {circt.nonlocal = @lowernla_1, class =\"firrtl.transforms.DontTouchAnnotation\" }>">, #firrtl.subAnno<fieldID = 1, {circt.nonlocal = @lowernla_1, A}>, #firrtl.subAnno<fieldID = 1, {circt.nonlocal = @lowernla_1, B}>, #firrtl.subAnno<fieldID = 2, {circt.nonlocal = @lowernla_1, C}>], out %c: !firrtl.uint<1>) {
+  // CHECK-LABEL: firrtl.module private @testBundle_Bar
   // CHECK-SAME: out %b_baz: !firrtl.uint<1> sym @b_baz [{A, circt.nonlocal = @lowernla_1}, {B, circt.nonlocal = @lowernla_1}]
   // CHECK-SAME: out %b_qux: !firrtl.uint<1> sym @b_qux [{C, circt.nonlocal = @lowernla_1_0}]
   // CHECK-SAME: out %b_data: !firrtl.uint<2> sym @b_data,
@@ -1474,7 +1474,7 @@ firrtl.module @Issue2315(in %x: !firrtl.vector<uint<10>, 5>, in %source: !firrtl
     // CHECK: %d_baz = firrtl.wire sym @d_baz  {annotations = [{A, circt.nonlocal = @lowernla_2}, {C, circt.nonlocal = @lowernla_2}, {D, circt.nonlocal = @lowernla_2}]}
     // CHECK: %d_qux = firrtl.wire sym @d_qux  {annotations = [{A, circt.nonlocal = @lowernla_2_0}, {B, circt.nonlocal = @lowernla_2_0}, {C, circt.nonlocal = @lowernla_2_0}, {D, circt.nonlocal = @lowernla_2_0}]} : !firrtl.uint<1>
   }
-  firrtl.module @testNLAbundle() {
+  firrtl.module private @testNLAbundle() {
     %testBundle_Bar_a, %testBundle_Bar_b, %testBundle_Bar_c = firrtl.instance testBundle_Bar sym @testBundle_Bar  {annotations = [{circt.nonlocal = @lowernla_1, class = "circt.nonlocal"}, {circt.nonlocal = @lowernla_2, class = "circt.nonlocal"}]} @testBundle_Bar(in a: !firrtl.uint<1> [{one}], out b: !firrtl.bundle<baz: uint<1>, qux: uint<1>, data: uint<2>> [#firrtl.subAnno<fieldID = 1, {two}>], out c: !firrtl.uint<1> [{four}])
   }
 } // CIRCUIT

--- a/test/Dialect/FIRRTL/omir.fir
+++ b/test/Dialect/FIRRTL/omir.fir
@@ -271,13 +271,13 @@ circuit Foo: %[[
     ; CHECK-SAME:    g = {{{[^{}]+}} value = {id = [[gID:[0-9]+]] : i64, omir.tracker, path = {{"[a-zA-Z~|:/>]+"}}, type = {{"OM[a-zA-Z]+"}}
     ; CHECK-DAG:   firrtl.nla @[[Foo_eE_E:nla_[0-9]+]]
     ; CHECK-DAG:   firrtl.nla @[[Foo_cC_C:nla_[0-9]+]]
-    ; CHECK:       firrtl.module @C
+    ; CHECK:       firrtl.module private @C
     ; CHECK-SAME:    {circt.nonlocal = @[[Foo_cC_C]], class = "freechips.rocketchip.objectmodel.OMIRTracker", id = [[cID]] : i64}
-    ; CHECK:       firrtl.module @D
+    ; CHECK:       firrtl.module private @D
     ; CHECK-SAME:    {class = "freechips.rocketchip.objectmodel.OMIRTracker", id = [[dID]] : i64}
-    ; CHECK:       firrtl.module @E
+    ; CHECK:       firrtl.module private @E
     ; CHECK-SAME:    {circt.nonlocal = @[[Foo_eE_E]], class = "freechips.rocketchip.objectmodel.OMIRTracker", id = [[eID]] : i64}
-    ; CHECK:       firrtl.module @F
+    ; CHECK:       firrtl.module private @F
     ; CHECK-SAME:    {class = "freechips.rocketchip.objectmodel.OMIRTracker", id = [[fID]] : i64}
     ; CHECK:       firrtl.module @Foo
     ; CHECK-NEXT:  %a = firrtl.wire

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -13,13 +13,13 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
   ; CHECK: }
 
 
-  ; CHECK-LABEL: firrtl.module @circuit(in %in: !firrtl.uint<80>) {
+  ; CHECK-LABEL: firrtl.module private @circuit(in %in: !firrtl.uint<80>) {
   module circuit :    ; Module with a keyword id.
     input in: UInt<80>
 
   ; CHECK: }
 
-  ; CHECK-LABEL: firrtl.extmodule @MyExtModule(in in: !firrtl.uint, out out: !firrtl.uint<8>)
+  ; CHECK-LABEL: firrtl.extmodule private @MyExtModule(in in: !firrtl.uint, out out: !firrtl.uint<8>)
   ; CHECK: attributes {defname = "myextmodule"}
   ; CHECK-NOT: {
   extmodule MyExtModule :
@@ -27,7 +27,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     output ,,, out ,,: ,, UInt,<,8,>  ; Commas are whitespace
     defname = myextmodule
 
-  ; CHECK-LABEL: firrtl.extmodule @MyParameterizedExtModule
+  ; CHECK-LABEL: firrtl.extmodule private @MyParameterizedExtModule
   ; CHECK-SAME:    <FORMAT: none = "xyz_timeout=%d\0A",
   ; CHECK-SAME:     DEFAULT: ui32 = 0,
   ; CHECK-SAME:     WIDTH: ui32 = 32,
@@ -47,7 +47,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
   ; Module to test type parsing.
 
-  ; CHECK-LABEL: firrtl.module @types(
+  ; CHECK-LABEL: firrtl.module private @types(
   module types :
     input c: Clock         ; CHECK: %c: !firrtl.clock,
     input r: Reset         ; CHECK: %r: !firrtl.reset,
@@ -63,7 +63,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input vec: UInt<1>[4] ; CHECK: %vec: !firrtl.vector<uint<1>, 4>) {
 
 
-  ; CHECK-LABEL: firrtl.module @stmts(
+  ; CHECK-LABEL: firrtl.module private @stmts(
   module stmts :
     input reset : UInt<1>         ; CHECK: in %reset: !firrtl.uint<1>,
     input reset_async: AsyncReset ; CHECK: in %reset_async: !firrtl.asyncreset,
@@ -415,7 +415,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.cover %clock, %pred, %en, "X equals Y when Z is valid" {eventControl = 0 : i32, isConcurrent = false, name = "cover_0"}
     cover(clock, pred, en, "X equals Y when Z is valid") : cover_0
 
-  ; CHECK-LABEL: firrtl.module @type_handling(
+  ; CHECK-LABEL: firrtl.module private @type_handling(
   module type_handling :
     wire _t_6 : { flip b : { bits : { source : UInt<7> } } }
     node _t_8 = bits(_t_6.b.bits.source, 5, 0)
@@ -430,7 +430,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     wire flip4 : { flip x : { flip a : UInt }[4] }
 
 
-  ; CHECK-LABEL: firrtl.module @expr_stmt_ambiguity(
+  ; CHECK-LABEL: firrtl.module private @expr_stmt_ambiguity(
   module expr_stmt_ambiguity :
     ; CHECK: %reg = firrtl.wire : !firrtl.uint
     wire reg : UInt
@@ -443,20 +443,20 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.subfield %write(0)
     write.id <= UInt(1)
 
-  ; CHECK-LABEL: firrtl.module @expr_stmt_ambiguity2(
+  ; CHECK-LABEL: firrtl.module private @expr_stmt_ambiguity2(
   module expr_stmt_ambiguity2 :
     ; CHECK: firrtl.instance write @circuit
     inst write of circuit
     ; CHECK: firrtl.connect %write_in
     write.in <= UInt(1)
 
-  ; CHECK-LABEL: firrtl.module @oversize_shift(
+  ; CHECK-LABEL: firrtl.module private @oversize_shift(
   module oversize_shift :
     wire value : UInt<2>
     ; CHECK: firrtl.shr %value, 5 : (!firrtl.uint<2>) -> !firrtl.uint<1>
     node n = shr(value, 5)
 
-  ; CHECK-LABEL: firrtl.module @when_else_ambiguity(
+  ; CHECK-LABEL: firrtl.module private @when_else_ambiguity(
   module when_else_ambiguity :
     output out : UInt
     input in : UInt
@@ -477,7 +477,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: }
 
 
-  ; CHECK-LABEL: firrtl.module @chisel_when_mport_bug(
+  ; CHECK-LABEL: firrtl.module private @chisel_when_mport_bug(
   module chisel_when_mport_bug :
     input cond : UInt<1>
     input addr : UInt
@@ -506,7 +506,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     node n1 = xyz0
 
 
-  ; CHECK-LABEL: firrtl.module @constant_implicit_cse(
+  ; CHECK-LABEL: firrtl.module private @constant_implicit_cse(
   module constant_implicit_cse :
     input cond : UInt<1>
 
@@ -535,7 +535,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     node f = UInt<4>(15)
     node g = UInt<4>(7)
 
-  ; CHECK-LABEL: firrtl.module @subfield_implicit_cse
+  ; CHECK-LABEL: firrtl.module private @subfield_implicit_cse
   module subfield_implicit_cse :
     input i: {x: UInt<1>}
     input cond: UInt<1>
@@ -562,7 +562,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.strictconnect %w, %invalid_0
     w is invalid
 
-  ; CHECK-LABEL: firrtl.module @flip_one
+  ; CHECK-LABEL: firrtl.module private @flip_one
   module flip_one :
     input bf: { flip int_1 : UInt<1>, int_out : UInt<2>}
     ; CHECK: %0 = firrtl.subfield %bf(0)
@@ -572,7 +572,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     when _T :
       skip
 
-  ; CHECK-LABEL: firrtl.module @mem_depth_1
+  ; CHECK-LABEL: firrtl.module private @mem_depth_1
   module mem_depth_1 :
     input clock : Clock
     input reset : UInt<1>
@@ -589,7 +589,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       ; CHECK: !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<3>, mask: uint<1>>,
       ; CHECK: !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<3>>
 
-  ; CHECK-LABEL: firrtl.module @mem_no_ports() {
+  ; CHECK-LABEL: firrtl.module private @mem_no_ports() {
   ; CHECK-NEXT: }
   ; https://github.com/llvm/circt/issues/531
   module mem_no_ports :
@@ -600,33 +600,33 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       write-latency => 1
       read-under-write => undefined
 
-  ; CHECK-LABEL: firrtl.module @issue354(out %tmp5: !firrtl.sint<19>) {
+  ; CHECK-LABEL: firrtl.module private @issue354(out %tmp5: !firrtl.sint<19>) {
   module issue354 :
     output tmp5: SInt<19>
     tmp5 <= SInt<19>(8)
      ; CHECK: %c8_si19 = firrtl.constant 8 : !firrtl.sint<19>
      ; CHECK: firrtl.connect %tmp5, %c8_si19 : !firrtl.sint<19>, !firrtl.sint<19>
 
-   ; CHECK-LABEL: firrtl.module @issue347
+   ; CHECK-LABEL: firrtl.module private @issue347
   module issue347 :
     output tmp12: SInt<4>
     tmp12 <= SInt<4>(-4)
     ; CHECK: %c-4_si4 = firrtl.constant -4 : !firrtl.sint<4>
 
-  ; CHECK-LABEL: firrtl.extmodule @issue183<A: si32 = -1>()
+  ; CHECK-LABEL: firrtl.extmodule private @issue183<A: si32 = -1>()
   extmodule issue183:
      parameter A = -1
 
   ; The Scala FIRRTL Compiler allows this for an aggregate node with an internal
   ; analog.
-  ; CHECK-LABEL: firrtl.module @analog_in_aggregate_node
+  ; CHECK-LABEL: firrtl.module private @analog_in_aggregate_node
   module analog_in_aggregate_node:
     input a: { a: UInt<1>, b: Analog<1>}
     ; CHECK: %b = firrtl.node %a : !firrtl.bundle<a: uint<1>, b: analog<1>>
     node b = a
 
   ; Check that a register clock sink is converted to passive
-  ; CHECK-LABEL: firrtl.module @register_clock_passive
+  ; CHECK-LABEL: firrtl.module private @register_clock_passive
   module register_clock_passive:
     input clkIn: Clock
     output clkOut: Clock
@@ -635,7 +635,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     reg r: UInt<1>, clkOut
 
   ; Check that a register reset sink is converted to passive
-  ; CHECK-LABEL: firrtl.module @register_reset_passive
+  ; CHECK-LABEL: firrtl.module private @register_reset_passive
   module register_reset_passive:
     input clk: Clock
     output rst: UInt<1>
@@ -644,7 +644,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     reg r: UInt<1>, clk with : (reset => (rst, UInt<1>(0)))
 
   ; Check that a register init sink is converted to passive
-  ; CHECK-LABEL: firrtl.module @register_init_passive
+  ; CHECK-LABEL: firrtl.module private @register_init_passive
   module register_init_passive:
     input clk: Clock
     input rst: UInt<1>
@@ -654,7 +654,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     reg r: UInt<1>, clk with : (reset => (rst, init))
 
   ; https://github.com/llvm/circt/issues/492
-  ; CHECK-LABEL: firrtl.module @WriteOnlyMemIssue492
+  ; CHECK-LABEL: firrtl.module private @WriteOnlyMemIssue492
   module WriteOnlyMemIssue492 :
     input clock: Clock
     input wAddr: UInt<4>
@@ -677,14 +677,14 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     memory.w.data <= wData
 
   ; https://github.com/llvm/circt/issues/559
-  ; CHECK-LABEL: firrtl.module @TrickyIssue559
+  ; CHECK-LABEL: firrtl.module private @TrickyIssue559
   module TrickyIssue559:
     input input: UInt<1>
     output output: UInt<1>
     ; CHECK: firrtl.connect %output, %input
     output <= input
 
-  ; CHECK-LABEL: firrtl.module @CheckInvalids
+  ; CHECK-LABEL: firrtl.module private @CheckInvalids
   module CheckInvalids_in0 :
     input in0 : UInt<1>
     ; CHECK-NOT: firrtl.connect %in0
@@ -786,7 +786,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     out1 <= in1
 
   ; https://github.com/llvm/circt/issues/606
-  ; CHECK-LABEL: firrtl.module @mutableSubIndex606
+  ; CHECK-LABEL: firrtl.module private @mutableSubIndex606
   module mutableSubIndex606 :
     output io : UInt<1>[8]
     ; CHECK:  %0 = firrtl.subindex %io[0] : !firrtl.vector<uint<1>, 8>
@@ -837,7 +837,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
   ; Test that behavioral memory reads and writes both work and that flow checks
   ; don't fail here.  (A memory port should have duplex flow.)
   ; See: https://github.com/llvm/circt/issues/1058
-  ; CHECK-LABEL: firrtl.module @BehavioralMemory
+  ; CHECK-LABEL: firrtl.module private @BehavioralMemory
   module BehavioralMemory:
     input clock: Clock
     input rAddr: UInt<3>
@@ -857,7 +857,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
   ; Test that a mux with an unknown width select line parses.  This is a check
   ; of the predicate enforced on UInt1Type.
-  ; CHECK-LABEL: firrtl.module @MuxUnknownWidthSelect_Issue1108
+  ; CHECK-LABEL: firrtl.module private @MuxUnknownWidthSelect_Issue1108
   module MuxUnknownWidthSelect_Issue1108:
     input a: UInt<1>
     input b: UInt<1>
@@ -867,7 +867,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
   ; Test that a mux with aggregate type is still compatible even if the leaf
   ; types disagree in their width.
-  ; CHECK-LABEL: firrtl.module @MuxAggregateWidthMismatch_Issue2806
+  ; CHECK-LABEL: firrtl.module private @MuxAggregateWidthMismatch_Issue2806
   module MuxAggregateWidthMismatch_Issue2806:
     input a: UInt<1>[1]
     input b: UInt<32>[1]
@@ -883,7 +883,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     c <= mux(sel, a, b)
     z <= mux(sel, x, y)
 
-  ; CHECK-LABEL: firrtl.extmodule @RawStringParam
+  ; CHECK-LABEL: firrtl.extmodule private @RawStringParam
   ; CHECK-SAME:    <TYPE: none = "bit",
   ; CHECK-SAME:     FORMAT: none = "xyz_timeout=%d\\n",
   ; CHECK-SAME:     MIXED_QUOTES: none = "\22'\\\22">
@@ -893,7 +893,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     parameter MIXED_QUOTES = '"\'\"'
   ; "
 
-  ; CHECK-LABEL: firrtl.module @issue1303
+  ; CHECK-LABEL: firrtl.module private @issue1303
   module issue1303:
     output out: Reset
     out <= UInt(1)

--- a/test/Dialect/FIRRTL/parse-locations.fir
+++ b/test/Dialect/FIRRTL/parse-locations.fir
@@ -19,18 +19,18 @@ circuit MyModule :  @[CIRCUIT.scala 127]
   ; MODULE: CHECK: } loc("FooBar.scala":369:27)
 
 
-  ; CHECK-LABEL: firrtl.module @M2
+  ; CHECK-LABEL: firrtl.module private @M2
   module M2 :   @[Filename With Space.scala 1:2]
     input in: UInt
   ; CHECK: } loc("Filename With Space.scala":1:2)
 
-  ; CHECK-LABEL: firrtl.module @M3
+  ; CHECK-LABEL: firrtl.module private @M3
   module M3 :   @[NoSpaceInLocator]   ; expected-warning {{ignoring unknown @ info record format}}
     input in: UInt
   ; CHECK: } loc({{.*}}test{{.*}}Dialect{{.*}}FIRRTL{{.*}}parse-locations.fir"
 
 
-  ; CHECK-LABEL: firrtl.module @Subexpressions
+  ; CHECK-LABEL: firrtl.module private @Subexpressions
   module Subexpressions :
     input in: UInt
     output auto : { out_0 : UInt<1> }
@@ -53,7 +53,7 @@ circuit MyModule :  @[CIRCUIT.scala 127]
     ; CHECK: %other_thing = firrtl.wire{{.*}} loc("File with space.perl":1:23)
     wire other_thing : SInt<4> @[File with space.perl 1:23]
 
-  ; CHECK-LABEL: firrtl.module @issue1140
+  ; CHECK-LABEL: firrtl.module private @issue1140
   ; https://github.com/llvm/circt/issues/1140
   module issue1140:
     input mask_bit_2 : UInt<1>

--- a/test/Dialect/FIRRTL/remove-unused-ports.mlir
+++ b/test/Dialect/FIRRTL/remove-unused-ports.mlir
@@ -20,10 +20,10 @@ firrtl.circuit "Top"   {
   }
 
   // Check that %a, %d_unused, %d_invalid and %d_constant are removed.
-  // CHECK-LABEL: firrtl.module @Bar(in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>)
+  // CHECK-LABEL: firrtl.module private @Bar(in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>)
   // CHECK-NEXT:    firrtl.connect %c, %b
   // CHECK-NEXT:  }
-  firrtl.module @Bar(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>,
+  firrtl.module private @Bar(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>,
                      out %d_unused: !firrtl.uint<1>, out %d_invalid: !firrtl.uint<1>, out %d_constant: !firrtl.uint<1>) {
     firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
 
@@ -34,8 +34,8 @@ firrtl.circuit "Top"   {
   }
 
   // Check that %a, %d_unused, %d_invalid and %d_constant are removed.
-  // CHECK-LABEL: firrtl.module @UseBar(in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) {
-  firrtl.module @UseBar(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>,
+  // CHECK-LABEL: firrtl.module private @UseBar(in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) {
+  firrtl.module private @UseBar(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>,
                         out %d_unused: !firrtl.uint<1>, out %d_invalid: !firrtl.uint<1>, out %d_constant: !firrtl.uint<1>) {
     %A_a, %A_b, %A_c, %A_d_unused, %A_d_invalid, %A_d_constant = firrtl.instance A  @Bar(in a: !firrtl.uint<1>, in b: !firrtl.uint<1>, out c: !firrtl.uint<1>, out d_unused: !firrtl.uint<1>, out d_invalid: !firrtl.uint<1>, out d_constant: !firrtl.uint<1>)
     firrtl.connect %A_a, %a : !firrtl.uint<1>, !firrtl.uint<1>
@@ -48,8 +48,8 @@ firrtl.circuit "Top"   {
   }
 
   // Make sure that %a, %b and %c are not erased because they have an annotation or a symbol.
-  // CHECK-LABEL: firrtl.module @Foo(in %a: !firrtl.uint<1> sym @dntSym, in %b: !firrtl.uint<1> [{a = "a"}], out %c: !firrtl.uint<1> sym @dntSym)
-  firrtl.module @Foo(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) attributes {
+  // CHECK-LABEL: firrtl.module private @Foo(in %a: !firrtl.uint<1> sym @dntSym, in %b: !firrtl.uint<1> [{a = "a"}], out %c: !firrtl.uint<1> sym @dntSym)
+  firrtl.module private @Foo(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) attributes {
     portAnnotations = [[], [{a = "a"}], []], portSyms = ["dntSym", "", "dntSym"]}
   {
     // CHECK: firrtl.connect %c, %{{invalid_ui1.*}}
@@ -57,8 +57,8 @@ firrtl.circuit "Top"   {
     firrtl.connect %c, %invalid_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 
-  // CHECK-LABEL: firrtl.module @UseFoo(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>)
-  firrtl.module @UseFoo(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) {
+  // CHECK-LABEL: firrtl.module private @UseFoo(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>)
+  firrtl.module private @UseFoo(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) {
     %A_a, %A_b, %A_c = firrtl.instance A  @Foo(in a: !firrtl.uint<1>, in b: !firrtl.uint<1>, out c: !firrtl.uint<1>)
     // CHECK: %A_a, %A_b, %A_c = firrtl.instance A @Foo(in a: !firrtl.uint<1>, in b: !firrtl.uint<1>, out c: !firrtl.uint<1>)
     firrtl.connect %A_a, %a : !firrtl.uint<1>, !firrtl.uint<1>
@@ -91,10 +91,10 @@ firrtl.circuit "Top"   {
   }
 
   // Check that %a, %d_unused, %d_invalid and %d_constant are removed.
-  // CHECK-LABEL: firrtl.module @Bar(in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>)
+  // CHECK-LABEL: firrtl.module private @Bar(in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>)
   // CHECK-NEXT:    firrtl.strictconnect %c, %b
   // CHECK-NEXT:  }
-  firrtl.module @Bar(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>,
+  firrtl.module private @Bar(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>,
                      out %d_unused: !firrtl.uint<1>, out %d_invalid: !firrtl.uint<1>, out %d_constant: !firrtl.uint<1>) {
     firrtl.strictconnect %c, %b : !firrtl.uint<1>
 
@@ -105,8 +105,8 @@ firrtl.circuit "Top"   {
   }
 
   // Check that %a, %d_unused, %d_invalid and %d_constant are removed.
-  // CHECK-LABEL: firrtl.module @UseBar(in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) {
-  firrtl.module @UseBar(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>,
+  // CHECK-LABEL: firrtl.module private @UseBar(in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) {
+  firrtl.module private @UseBar(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>,
                         out %d_unused: !firrtl.uint<1>, out %d_invalid: !firrtl.uint<1>, out %d_constant: !firrtl.uint<1>) {
     %A_a, %A_b, %A_c, %A_d_unused, %A_d_invalid, %A_d_constant = firrtl.instance A  @Bar(in a: !firrtl.uint<1>, in b: !firrtl.uint<1>, out c: !firrtl.uint<1>, out d_unused: !firrtl.uint<1>, out d_invalid: !firrtl.uint<1>, out d_constant: !firrtl.uint<1>)
     firrtl.strictconnect %A_a, %a : !firrtl.uint<1>
@@ -119,8 +119,8 @@ firrtl.circuit "Top"   {
   }
 
   // Make sure that %a, %b and %c are not erased because they have an annotation or a symbol.
-  // CHECK-LABEL: firrtl.module @Foo(in %a: !firrtl.uint<1> sym @dntSym, in %b: !firrtl.uint<1> [{a = "a"}], out %c: !firrtl.uint<1> sym @dntSym)
-  firrtl.module @Foo(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) attributes {
+  // CHECK-LABEL: firrtl.module private @Foo(in %a: !firrtl.uint<1> sym @dntSym, in %b: !firrtl.uint<1> [{a = "a"}], out %c: !firrtl.uint<1> sym @dntSym)
+  firrtl.module private @Foo(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) attributes {
     portAnnotations = [[], [{a = "a"}], []], portSyms = ["dntSym", "", "dntSym"]}
   {
     // CHECK: firrtl.strictconnect %c, %{{invalid_ui1.*}}
@@ -128,8 +128,8 @@ firrtl.circuit "Top"   {
     firrtl.strictconnect %c, %invalid_ui1 : !firrtl.uint<1>
   }
 
-  // CHECK-LABEL: firrtl.module @UseFoo(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>)
-  firrtl.module @UseFoo(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) {
+  // CHECK-LABEL: firrtl.module private @UseFoo(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>)
+  firrtl.module private @UseFoo(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) {
     %A_a, %A_b, %A_c = firrtl.instance A  @Foo(in a: !firrtl.uint<1>, in b: !firrtl.uint<1>, out c: !firrtl.uint<1>)
     // CHECK: %A_a, %A_b, %A_c = firrtl.instance A @Foo(in a: !firrtl.uint<1>, in b: !firrtl.uint<1>, out c: !firrtl.uint<1>)
     firrtl.strictconnect %A_a, %a : !firrtl.uint<1>

--- a/test/circt-reduce/port-pruner.mlir
+++ b/test/circt-reduce/port-pruner.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-reduce %s --test %S/test.sh --test-arg cat --test-arg "firrtl.module @Bar" --keep-best=0 --include firrtl-remove-unused-ports | FileCheck %s
+// RUN: circt-reduce %s --test %S/test.sh --test-arg cat --test-arg "firrtl.module private @Bar" --keep-best=0 --include firrtl-remove-unused-ports | FileCheck %s
 
 firrtl.circuit "Foo" {
   // CHECK-LABEL: firrtl.module @Foo
@@ -16,13 +16,13 @@ firrtl.circuit "Foo" {
   }
 
   // We're only ever using ports %b and %d -- the rest should be stripped.
-  // CHECK-LABEL: firrtl.module @Bar
+  // CHECK-LABEL: firrtl.module private @Bar
   // CHECK-NOT: in %a
   // CHECK-SAME: in %b
   // CHECK-NOT: out %c
   // CHECK-SAME: out %d
   // CHECK-NOT: out %e
-  firrtl.module @Bar(
+  firrtl.module private @Bar(
     in %a: !firrtl.uint<1>,
     in %b: !firrtl.uint<1>,
     out %c: !firrtl.uint<1>,

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -169,7 +169,7 @@ circuit test_mod : %[[{"a": "a"}]]
     output d: UInt<6>
     d <= cat(cat(a, b), c)
 
-; MLIRLOWER-LABEL: hw.module @Cat(%a: i2, %b: i2, %c: i2) -> (d: i6) {
+; MLIRLOWER-LABEL: hw.module private @Cat(%a: i2, %b: i2, %c: i2) -> (d: i6) {
 ; MLIRLOWER-NEXT:    %0 = comb.concat %a, %b, %c : i2, i2, i2
 ; MLIRLOWER-NEXT:    hw.output %0 : i6
 ; MLIRLOWER-NEXT:  }
@@ -185,7 +185,7 @@ circuit test_mod : %[[{"a": "a"}]]
     out1 <= dshl(inp_2, inp_1)
     out2 <= inp_2
 
-; MLIRLOWER-LABEL: hw.module @ImplicitTrunc(%inp_1: i1, %inp_2: i5) -> (out1: i3, out2: i3) {
+; MLIRLOWER-LABEL: hw.module private @ImplicitTrunc(%inp_1: i1, %inp_2: i5) -> (out1: i3, out2: i3) {
 ; MLIRLOWER-NEXT:    %c0_i5 = hw.constant 0 : i5
 ; MLIRLOWER-NEXT:    %0 = comb.extract %inp_2 from 4 : (i5) -> i1
 ; MLIRLOWER-NEXT:    %1 = comb.concat %0, %inp_2 : i1, i5


### PR DESCRIPTION
`firrtl` and `hw` modules can now be annotated with MLIR visibility attributes.

The FIR parser sets the visibility of all non-main modules to private if the
main module is defined, otherwise all modules remain public.

Transformations were altered to inspect the visibility attribute instead of
checking whether a module matches the main of a circuit.