### PR TITLE
[FIRRTL] Use the new dutModuleName attribute for root of port target.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -625,7 +625,12 @@ void EmitOMIRPass::emitOptionalRTLPorts(DictionaryAttr node,
         jsonStream.object([&] {
           // Emit the `ref` field.
           buf.assign("OMDontTouchedReferenceTarget:~");
-          buf.append(getOperation().name());
+          if (module.moduleNameAttr() == dutModuleName) {
+            // If module is DUT, then root the target relative to the DUT.
+            buf.append(module.moduleName());
+          } else {
+            buf.append(getOperation().name());
+          }
           buf.push_back('|');
           buf.append(addSymbol(module));
           buf.push_back('>');

--- a/test/Dialect/FIRRTL/emit-omir.mlir
+++ b/test/Dialect/FIRRTL/emit-omir.mlir
@@ -509,6 +509,73 @@ firrtl.circuit "AddPorts" attributes {annotations = [{
 // CHECK-SAME:    #hw.innerNameRef<@AddPorts::[[SYMW]]>
 // CHECK-SAME:  ]
 
+firrtl.circuit "AddPortsRelative" attributes {annotations = [{
+  class = "freechips.rocketchip.objectmodel.OMIRAnnotation",
+  nodes = [
+    {
+      info = #loc,
+      id = "OMID:0",
+      fields = {
+        containingModule = {
+          info = #loc,
+          index = 0,
+          value = {
+            omir.tracker,
+            id = 0,
+            path = "~AddPortsRelative|DUT",
+            type = "OMInstanceTarget"
+          }
+        }
+      }
+    }
+  ]
+}]} {
+  firrtl.module @AddPortsRelative () {
+    %in = firrtl.wire : !firrtl.uint<1>
+    %out = firrtl.wire : !firrtl.uint<1>
+    %instance_x, %instance_y = firrtl.instance dut @DUT(in x: !firrtl.uint<1>, out y: !firrtl.uint<1>)
+    firrtl.connect %instance_x, %in : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %out, %instance_y : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+
+  firrtl.module @DUT(in %x: !firrtl.uint<1> sym @x, out %y: !firrtl.uint<1> sym @y) attributes {
+    annotations = [
+      {class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 0},
+      {class = "sifive.enterprise.firrtl.MarkDUTAnnotation", id = 1}
+    ]} {
+    firrtl.connect %y, %x : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+}
+
+// CHECK-LABEL: firrtl.circuit "AddPortsRelative"
+// CHECK:       firrtl.module @DUT
+// CHECK-SAME:    in %x: !firrtl.uint<1> sym [[SYMX:@[a-zA-Z0-9_]+]]
+// CHECK-SAME:    out %y: !firrtl.uint<1> sym [[SYMY:@[a-zA-Z0-9_]+]]
+
+// CHECK:       sv.verbatim
+// CHECK-SAME:  \22id\22: \22OMID:0\22
+// CHECK-SAME:    \22name\22: \22containingModule\22
+// CHECK-SAME:    \22value\22: \22OMInstanceTarget:~DUT|{{[{][{]0[}][}]}}\22
+// CHECK-SAME:    \22name\22: \22ports\22
+// CHECK-SAME:    \22value\22: [
+// CHECK-SAME:      {
+// CHECK-SAME:        \22ref\22: \22OMDontTouchedReferenceTarget:~DUT|{{[{][{]0[}][}]}}>{{[{][{]1[}][}]}}\22
+// CHECK-SAME:        \22direction\22: \22OMString:Input\22
+// CHECK-SAME:        \22width\22: \22OMBigInt:1\22
+// CHECK-SAME:      }
+// CHECK-SAME:      {
+// CHECK-SAME:        \22ref\22: \22OMDontTouchedReferenceTarget:~DUT|{{[{][{]0[}][}]}}>{{[{][{]2[}][}]}}\22
+// CHECK-SAME:        \22direction\22: \22OMString:Output\22
+// CHECK-SAME:        \22width\22: \22OMBigInt:1\22
+// CHECK-SAME:      }
+// CHECK-SAME:    ]
+
+// CHECK-SAME:  symbols = [
+// CHECK-SAME:    @DUT,
+// CHECK-SAME:    #hw.innerNameRef<@DUT::[[SYMX]]>,
+// CHECK-SAME:    #hw.innerNameRef<@DUT::[[SYMY]]>
+// CHECK-SAME:  ]
+
 
 // Check that the Target path is relative to the DUT, except for dutInstance
 


### PR DESCRIPTION
This previously just used the name of the circuit op, but this is not
always the desired root. When a DUT is marked, this should be pointing
to the DUT directly. Fortunately, we have a new attribute that tracks
the DUT module name we can just use.