### PR TITLE
[FIRRTL] Fix port symbol creation logic edge case in LowerTypes.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -687,7 +687,8 @@ TypeLoweringVisitor::addArg(Operation *module, unsigned insertPt,
 
   SmallString<16> symtmp;
   StringRef sym;
-  if (oldArg.sym) {
+  bool oldArgHadSym = oldArg.sym && !oldArg.sym.getValue().empty();
+  if (oldArgHadSym) {
     symtmp = (oldArg.sym.getValue() + field.suffix).str();
     sym = symtmp;
   } else
@@ -703,7 +704,7 @@ TypeLoweringVisitor::addArg(Operation *module, unsigned insertPt,
   auto direction = (Direction)((unsigned)oldArg.direction ^ field.isOutput);
 
   StringAttr newSym = {};
-  if ((needsSym || (oldArg.sym && !oldArg.sym.getValue().empty()))) {
+  if (needsSym || oldArgHadSym) {
     newSym = StringAttr::get(context, sym);
     opSymNames[newSym] = module;
   }

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1477,4 +1477,12 @@ firrtl.module @Issue2315(in %x: !firrtl.vector<uint<10>, 5>, in %source: !firrtl
   firrtl.module @testNLAbundle() {
     %testBundle_Bar_a, %testBundle_Bar_b, %testBundle_Bar_c = firrtl.instance testBundle_Bar sym @testBundle_Bar  {annotations = [{circt.nonlocal = @lowernla_1, class = "circt.nonlocal"}, {circt.nonlocal = @lowernla_2, class = "circt.nonlocal"}]} @testBundle_Bar(in a: !firrtl.uint<1> [{one}], out b: !firrtl.bundle<baz: uint<1>, qux: uint<1>, data: uint<2>> [#firrtl.subAnno<fieldID = 1, {two}>], out c: !firrtl.uint<1> [{four}])
   }
+
+  // CHECK-LABEL: firrtl.module @symNameCollision
+  // CHECK-SAME: in %a_foo: !firrtl.uint<1> sym @a_foo
+  // CHECK-SAME: in %b_foo: !firrtl.uint<1> sym @b_foo
+  firrtl.module @symNameCollision(
+    in %a: !firrtl.bundle<foo: uint<1>> [#firrtl.subAnno<fieldID=1, {circt.nonlocal = @foo}>],
+    in %b: !firrtl.bundle<foo: uint<1>> [#firrtl.subAnno<fieldID=1, {circt.nonlocal = @bar}>]) {
+  }
 } // CIRCUIT


### PR DESCRIPTION
It was previously possible for LowerTypes to generate duplicate
symbols for different ports inside addArg. The logic that decides to
create the 'newSym' attribute previously checked whether the old
symbol was null, and if not, if it was empty. But the logic for
setting the 'sym' string in the first place was missing the empty
check. Because we create empty symbols by default in some cases, this
was leading to incorrect behavior, where the suffix was concatenated
to an empty string. If multiple lowered bundle types had the same
suffix, this could create duplicates.

Fortunately the solution is simple, we just need to include the empty
check in both places. To make this more clear, the logic is pulled out
into a shared variable that can be checked in both places.