### PR TITLE
[SV] Use Better Named Wires When Possible

### DIFF
--- a/test/Dialect/FIRRTL/SFCTests/invalid-interpretations.fir
+++ b/test/Dialect/FIRRTL/SFCTests/invalid-interpretations.fir
@@ -16,10 +16,10 @@ circuit InvalidInterpretations:
     output out_mux: UInt<8>
     output out_add: UInt<9>
 
-    wire inv: UInt<8>
-    inv is invalid
+    wire _inv: UInt<8>
+    _inv is invalid
 
-    reg r: UInt<8>, clock with : (reset => (reset, inv))
+    reg r: UInt<8>, clock with : (reset => (reset, _inv))
     r <= a
     out_reg <= r
     ; Interpretation 1: Invalid is undefined if used as the initialization value
@@ -37,8 +37,8 @@ circuit InvalidInterpretations:
     ; Interpretation 3: Invalid is undefined as the false leg of a validif.
     ; CHECK:       assign out_validif = a;
 
-    out_mux <= mux(cond, a, inv)
-    out_add <= add(a, inv)
+    out_mux <= mux(cond, a, _inv)
+    out_add <= add(a, _inv)
     ; Interpretation 4: Invalid is zero otherwise.
     ; CHECK:       assign out_mux = cond ? a : 8'h0;
     ; CHECK-NEXT:  assign out_add = {1'h0, a};


### PR DESCRIPTION
Change PrettifyVerilog to choose wires with good names over SSA values
without names or with less good names.  This is done specifically to
cause Verilog emitted to use Chisel "val names" (which are represented
as dead wires at this point in the compiler) instead of their
underscore-named counterparts.

Fixes #2808.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

FYI: @jackkoenig

## Example 1

Consider the following circuit where `node x` was a `val x = a | b` in Chisel:

```scala
circuit Foo:
  module Foo:
    input a: UInt<1>
    input b: UInt<1>
    output out: UInt<1>

    node x = or(a, b)
    out <= x
```

Without this PR, CIRCT produces:

```verilog
module Foo(
  input  a, b,
  output out);

  wire x;

  wire _x = a | b;
  assign x = _x;
  assign out = _x;
endmodule
```

With this PR:

```verilog
module Foo(
  input  a, b,
  output out);

  wire x;

  assign x = a | b;
  assign out = x;
endmodule
```

## Example 2

Consider Rocket's ALU (which was the example shown here: https://github.com/llvm/circt/pull/2676#issuecomment-1050476319

Without this PR, CIRCT produces:

```verilog
module ALU(
  input         clock, reset,
  input  [3:0]  io_dw, io_fn,
  input  [63:0] io_in2, io_in1,
  output [63:0] io_out, io_adder_out,
  output        io_cmp_out);

  wire [63:0] in2_inv;
  wire [63:0] in1_xor_in2;
  wire        slt;
  wire [5:0]  shamt;
  wire [63:0] shin_r;
  wire [63:0] shin;
  wire [63:0] shout_r;
  wire [63:0] shout_l;
  wire [63:0] shout;
  wire [63:0] logic_0;
  wire [63:0] shift_logic;
  wire [63:0] out;

  wire [63:0] _GEN = {64{io_fn[3]}} ^ io_in2;
  assign in2_inv = _GEN;
  wire [63:0] _in1_xor_in2 = io_in1 ^ _GEN;
  assign in1_xor_in2 = _in1_xor_in2;
  wire [63:0] _GEN_0 = io_in1 + _GEN + {63'h0, io_fn[3]};
  wire _slt = io_in1[63] == io_in2[63] ? _GEN_0[63] : io_fn[1] ? io_in2[63] : io_in1[63];
  assign slt = _slt;
  wire _GEN_1 = io_dw == 4'h4;
  wire [31:0] _GEN_2 = _GEN_1 ? io_in1[63:32] : {32{io_fn[3] & io_in1[31]}};
  wire _GEN_3 = io_in2[5] & _GEN_1;
  assign shamt = {_GEN_3, io_in2[4:0]};
  wire [63:0] _shin_r = {_GEN_2, io_in1[31:0]};
  assign shin_r = _shin_r;
  wire _shin_T = io_fn == 4'h5;
  wire _shin_T_1 = io_fn == 4'hB;
  wire [63:0] _shin = _shin_T | _shin_T_1 ? _shin_r : {io_in1[0], io_in1[1], io_in1[2], io_in1[3], io_in1[4],
                io_in1[5], io_in1[6], io_in1[7], io_in1[8], io_in1[9], io_in1[10], io_in1[11], io_in1[12],
                io_in1[13], io_in1[14], io_in1[15], io_in1[16], io_in1[17], io_in1[18], io_in1[19],
                io_in1[20], io_in1[21], io_in1[22], io_in1[23], io_in1[24], io_in1[25], io_in1[26],
                io_in1[27], io_in1[28], io_in1[29], io_in1[30], io_in1[31], _GEN_2[0], _GEN_2[1],
                _GEN_2[2], _GEN_2[3], _GEN_2[4], _GEN_2[5], _GEN_2[6], _GEN_2[7], _GEN_2[8], _GEN_2[9],
                _GEN_2[10], _GEN_2[11], _GEN_2[12], _GEN_2[13], _GEN_2[14], _GEN_2[15], _GEN_2[16],
                _GEN_2[17], _GEN_2[18], _GEN_2[19], _GEN_2[20], _GEN_2[21], _GEN_2[22], _GEN_2[23],
                _GEN_2[24], _GEN_2[25], _GEN_2[26], _GEN_2[27], _GEN_2[28], _GEN_2[29], _GEN_2[30],
                _GEN_2[31]};
  assign shin = _shin;
  wire [64:0] _GEN_4 = $signed($signed({io_fn[3] & _shin[63], _shin}) >>> {59'h0, _GEN_3, io_in2[4:0]});
  assign shout_r = _GEN_4[63:0];
  wire [63:0] _GEN_5 = {_GEN_4[0], _GEN_4[1], _GEN_4[2], _GEN_4[3], _GEN_4[4], _GEN_4[5], _GEN_4[6], _GEN_4[7],
                _GEN_4[8], _GEN_4[9], _GEN_4[10], _GEN_4[11], _GEN_4[12], _GEN_4[13], _GEN_4[14],
                _GEN_4[15], _GEN_4[16], _GEN_4[17], _GEN_4[18], _GEN_4[19], _GEN_4[20], _GEN_4[21],
                _GEN_4[22], _GEN_4[23], _GEN_4[24], _GEN_4[25], _GEN_4[26], _GEN_4[27], _GEN_4[28],
                _GEN_4[29], _GEN_4[30], _GEN_4[31], _GEN_4[32], _GEN_4[33], _GEN_4[34], _GEN_4[35],
                _GEN_4[36], _GEN_4[37], _GEN_4[38], _GEN_4[39], _GEN_4[40], _GEN_4[41], _GEN_4[42],
                _GEN_4[43], _GEN_4[44], _GEN_4[45], _GEN_4[46], _GEN_4[47], _GEN_4[48], _GEN_4[49],
                _GEN_4[50], _GEN_4[51], _GEN_4[52], _GEN_4[53], _GEN_4[54], _GEN_4[55], _GEN_4[56],
                _GEN_4[57], _GEN_4[58], _GEN_4[59], _GEN_4[60], _GEN_4[61], _GEN_4[62], _GEN_4[63]};
  assign shout_l = _GEN_5;
  wire [63:0] _shout = (_shin_T | _shin_T_1 ? _GEN_4[63:0] : 64'h0) | (io_fn == 4'h1 ? _GEN_5 : 64'h0);
  assign shout = _shout;
  wire _logic_T_1 = io_fn == 4'h6;
  wire [63:0] _logic = (io_fn == 4'h4 | _logic_T_1 ? _in1_xor_in2 : 64'h0) | (_logic_T_1 | io_fn == 4'h7 ? io_in1
                & io_in2 : 64'h0);
  assign logic_0 = _logic;
  wire [63:0] _shift_logic = {63'h0, io_fn > 4'hB & _slt} | _logic | _shout;
  assign shift_logic = _shift_logic;
  wire [63:0] _out = io_fn == 4'h0 | io_fn == 4'hA ? _GEN_0 : _shift_logic;
  assign out = _out;
  assign io_out = io_dw == 4'h2 ? {{32{_out[31]}}, _out[31:0]} : _out;
  assign io_adder_out = _GEN_0;
  assign io_cmp_out = io_fn[0] ^ (io_fn[3] ? _slt : _in1_xor_in2 == 64'h0);
endmodule
```

With this PR:

```verilog
module ALU(
  input         clock, reset,
  input  [3:0]  io_dw, io_fn,
  input  [63:0] io_in2, io_in1,
  output [63:0] io_out, io_adder_out,
  output        io_cmp_out);

  wire [63:0] in2_inv;
  wire [63:0] in1_xor_in2;
  wire        slt;
  wire [5:0]  shamt;
  wire [63:0] shin_r;
  wire [63:0] shin;
  wire [63:0] shout_r;
  wire [63:0] shout_l;
  wire [63:0] shout;
  wire [63:0] logic_0;
  wire [63:0] shift_logic;
  wire [63:0] out;

  assign in2_inv = {64{io_fn[3]}} ^ io_in2;
  assign in1_xor_in2 = io_in1 ^ in2_inv;
  wire [63:0] _GEN = io_in1 + in2_inv + {63'h0, io_fn[3]};
  assign slt = io_in1[63] == io_in2[63] ? _GEN[63] : io_fn[1] ? io_in2[63] : io_in1[63];
  wire _GEN_0 = io_dw == 4'h4;
  wire [31:0] _GEN_1 = _GEN_0 ? io_in1[63:32] : {32{io_fn[3] & io_in1[31]}};
  wire _GEN_2 = io_in2[5] & _GEN_0;
  assign shamt = {_GEN_2, io_in2[4:0]};
  assign shin_r = {_GEN_1, io_in1[31:0]};
  wire _shin_T = io_fn == 4'h5;
  wire _shin_T_1 = io_fn == 4'hB;
  assign shin = _shin_T | _shin_T_1 ? shin_r : {io_in1[0], io_in1[1], io_in1[2], io_in1[3], io_in1[4],
                io_in1[5], io_in1[6], io_in1[7], io_in1[8], io_in1[9], io_in1[10], io_in1[11], io_in1[12],
                io_in1[13], io_in1[14], io_in1[15], io_in1[16], io_in1[17], io_in1[18], io_in1[19],
                io_in1[20], io_in1[21], io_in1[22], io_in1[23], io_in1[24], io_in1[25], io_in1[26],
                io_in1[27], io_in1[28], io_in1[29], io_in1[30], io_in1[31], _GEN_1[0], _GEN_1[1],
                _GEN_1[2], _GEN_1[3], _GEN_1[4], _GEN_1[5], _GEN_1[6], _GEN_1[7], _GEN_1[8], _GEN_1[9],
                _GEN_1[10], _GEN_1[11], _GEN_1[12], _GEN_1[13], _GEN_1[14], _GEN_1[15], _GEN_1[16],
                _GEN_1[17], _GEN_1[18], _GEN_1[19], _GEN_1[20], _GEN_1[21], _GEN_1[22], _GEN_1[23],
                _GEN_1[24], _GEN_1[25], _GEN_1[26], _GEN_1[27], _GEN_1[28], _GEN_1[29], _GEN_1[30],
                _GEN_1[31]};
  wire [64:0] _GEN_3 = $signed($signed({io_fn[3] & shin[63], shin}) >>> {59'h0, _GEN_2, io_in2[4:0]});
  assign shout_r = _GEN_3[63:0];
  assign shout_l = {_GEN_3[0], _GEN_3[1], _GEN_3[2], _GEN_3[3], _GEN_3[4], _GEN_3[5], _GEN_3[6], _GEN_3[7],
                _GEN_3[8], _GEN_3[9], _GEN_3[10], _GEN_3[11], _GEN_3[12], _GEN_3[13], _GEN_3[14],
                _GEN_3[15], _GEN_3[16], _GEN_3[17], _GEN_3[18], _GEN_3[19], _GEN_3[20], _GEN_3[21],
                _GEN_3[22], _GEN_3[23], _GEN_3[24], _GEN_3[25], _GEN_3[26], _GEN_3[27], _GEN_3[28],
                _GEN_3[29], _GEN_3[30], _GEN_3[31], _GEN_3[32], _GEN_3[33], _GEN_3[34], _GEN_3[35],
                _GEN_3[36], _GEN_3[37], _GEN_3[38], _GEN_3[39], _GEN_3[40], _GEN_3[41], _GEN_3[42],
                _GEN_3[43], _GEN_3[44], _GEN_3[45], _GEN_3[46], _GEN_3[47], _GEN_3[48], _GEN_3[49],
                _GEN_3[50], _GEN_3[51], _GEN_3[52], _GEN_3[53], _GEN_3[54], _GEN_3[55], _GEN_3[56],
                _GEN_3[57], _GEN_3[58], _GEN_3[59], _GEN_3[60], _GEN_3[61], _GEN_3[62], _GEN_3[63]};
  assign shout = (_shin_T | _shin_T_1 ? shout_r : 64'h0) | (io_fn == 4'h1 ? shout_l : 64'h0);
  wire _logic_T_1 = io_fn == 4'h6;
  assign logic_0 = (io_fn == 4'h4 | _logic_T_1 ? in1_xor_in2 : 64'h0) | (_logic_T_1 | io_fn == 4'h7 ? io_in1 &
                io_in2 : 64'h0);
  assign shift_logic = {63'h0, io_fn > 4'hB & slt} | logic_0 | shout;
  assign out = io_fn == 4'h0 | io_fn == 4'hA ? _GEN : shift_logic;
  assign io_out = io_dw == 4'h2 ? {{32{out[31]}}, out[31:0]} : out;
  assign io_adder_out = _GEN;
  assign io_cmp_out = io_fn[0] ^ (io_fn[3] ? slt : in1_xor_in2 == 64'h0);
endmodule
```

Diff:
```diff
diff --git a/val-foo/orig/ALU.sv b/val-foo/new/ALU.sv
index 1826ea25..b7729a3d 100644
--- a/val-foo/orig/ALU.sv
+++ b/val-foo/new/ALU.sv
@@ -18,56 +18,46 @@ module ALU(
   wire [63:0] shift_logic;
   wire [63:0] out;
 
-  wire [63:0] _GEN = {64{io_fn[3]}} ^ io_in2;
-  assign in2_inv = _GEN;
-  wire [63:0] _in1_xor_in2 = io_in1 ^ _GEN;
-  assign in1_xor_in2 = _in1_xor_in2;
-  wire [63:0] _GEN_0 = io_in1 + _GEN + {63'h0, io_fn[3]};
-  wire _slt = io_in1[63] == io_in2[63] ? _GEN_0[63] : io_fn[1] ? io_in2[63] : io_in1[63];
-  assign slt = _slt;
-  wire _GEN_1 = io_dw == 4'h4;
-  wire [31:0] _GEN_2 = _GEN_1 ? io_in1[63:32] : {32{io_fn[3] & io_in1[31]}};
-  wire _GEN_3 = io_in2[5] & _GEN_1;
-  assign shamt = {_GEN_3, io_in2[4:0]};
-  wire [63:0] _shin_r = {_GEN_2, io_in1[31:0]};
-  assign shin_r = _shin_r;
+  assign in2_inv = {64{io_fn[3]}} ^ io_in2;
+  assign in1_xor_in2 = io_in1 ^ in2_inv;
+  wire [63:0] _GEN = io_in1 + in2_inv + {63'h0, io_fn[3]};
+  assign slt = io_in1[63] == io_in2[63] ? _GEN[63] : io_fn[1] ? io_in2[63] : io_in1[63];
+  wire _GEN_0 = io_dw == 4'h4;
+  wire [31:0] _GEN_1 = _GEN_0 ? io_in1[63:32] : {32{io_fn[3] & io_in1[31]}};
+  wire _GEN_2 = io_in2[5] & _GEN_0;
+  assign shamt = {_GEN_2, io_in2[4:0]};
+  assign shin_r = {_GEN_1, io_in1[31:0]};
   wire _shin_T = io_fn == 4'h5;
   wire _shin_T_1 = io_fn == 4'hB;
-  wire [63:0] _shin = _shin_T | _shin_T_1 ? _shin_r : {io_in1[0], io_in1[1], io_in1[2], io_in1[3], io_in1[4],
+  assign shin = _shin_T | _shin_T_1 ? shin_r : {io_in1[0], io_in1[1], io_in1[2], io_in1[3], io_in1[4],
                 io_in1[5], io_in1[6], io_in1[7], io_in1[8], io_in1[9], io_in1[10], io_in1[11], io_in1[12],
                 io_in1[13], io_in1[14], io_in1[15], io_in1[16], io_in1[17], io_in1[18], io_in1[19],
                 io_in1[20], io_in1[21], io_in1[22], io_in1[23], io_in1[24], io_in1[25], io_in1[26],
-                io_in1[27], io_in1[28], io_in1[29], io_in1[30], io_in1[31], _GEN_2[0], _GEN_2[1],
-                _GEN_2[2], _GEN_2[3], _GEN_2[4], _GEN_2[5], _GEN_2[6], _GEN_2[7], _GEN_2[8], _GEN_2[9],
-                _GEN_2[10], _GEN_2[11], _GEN_2[12], _GEN_2[13], _GEN_2[14], _GEN_2[15], _GEN_2[16],
-                _GEN_2[17], _GEN_2[18], _GEN_2[19], _GEN_2[20], _GEN_2[21], _GEN_2[22], _GEN_2[23],
-                _GEN_2[24], _GEN_2[25], _GEN_2[26], _GEN_2[27], _GEN_2[28], _GEN_2[29], _GEN_2[30],
-                _GEN_2[31]};
-  assign shin = _shin;
-  wire [64:0] _GEN_4 = $signed($signed({io_fn[3] & _shin[63], _shin}) >>> {59'h0, _GEN_3, io_in2[4:0]});
-  assign shout_r = _GEN_4[63:0];
-  wire [63:0] _GEN_5 = {_GEN_4[0], _GEN_4[1], _GEN_4[2], _GEN_4[3], _GEN_4[4], _GEN_4[5], _GEN_4[6], _GEN_4[7],
-                _GEN_4[8], _GEN_4[9], _GEN_4[10], _GEN_4[11], _GEN_4[12], _GEN_4[13], _GEN_4[14],
-                _GEN_4[15], _GEN_4[16], _GEN_4[17], _GEN_4[18], _GEN_4[19], _GEN_4[20], _GEN_4[21],
-                _GEN_4[22], _GEN_4[23], _GEN_4[24], _GEN_4[25], _GEN_4[26], _GEN_4[27], _GEN_4[28],
-                _GEN_4[29], _GEN_4[30], _GEN_4[31], _GEN_4[32], _GEN_4[33], _GEN_4[34], _GEN_4[35],
-                _GEN_4[36], _GEN_4[37], _GEN_4[38], _GEN_4[39], _GEN_4[40], _GEN_4[41], _GEN_4[42],
-                _GEN_4[43], _GEN_4[44], _GEN_4[45], _GEN_4[46], _GEN_4[47], _GEN_4[48], _GEN_4[49],
-                _GEN_4[50], _GEN_4[51], _GEN_4[52], _GEN_4[53], _GEN_4[54], _GEN_4[55], _GEN_4[56],
-                _GEN_4[57], _GEN_4[58], _GEN_4[59], _GEN_4[60], _GEN_4[61], _GEN_4[62], _GEN_4[63]};
-  assign shout_l = _GEN_5;
-  wire [63:0] _shout = (_shin_T | _shin_T_1 ? _GEN_4[63:0] : 64'h0) | (io_fn == 4'h1 ? _GEN_5 : 64'h0);
-  assign shout = _shout;
+                io_in1[27], io_in1[28], io_in1[29], io_in1[30], io_in1[31], _GEN_1[0], _GEN_1[1],
+                _GEN_1[2], _GEN_1[3], _GEN_1[4], _GEN_1[5], _GEN_1[6], _GEN_1[7], _GEN_1[8], _GEN_1[9],
+                _GEN_1[10], _GEN_1[11], _GEN_1[12], _GEN_1[13], _GEN_1[14], _GEN_1[15], _GEN_1[16],
+                _GEN_1[17], _GEN_1[18], _GEN_1[19], _GEN_1[20], _GEN_1[21], _GEN_1[22], _GEN_1[23],
+                _GEN_1[24], _GEN_1[25], _GEN_1[26], _GEN_1[27], _GEN_1[28], _GEN_1[29], _GEN_1[30],
+                _GEN_1[31]};
+  wire [64:0] _GEN_3 = $signed($signed({io_fn[3] & shin[63], shin}) >>> {59'h0, _GEN_2, io_in2[4:0]});
+  assign shout_r = _GEN_3[63:0];
+  assign shout_l = {_GEN_3[0], _GEN_3[1], _GEN_3[2], _GEN_3[3], _GEN_3[4], _GEN_3[5], _GEN_3[6], _GEN_3[7],
+                _GEN_3[8], _GEN_3[9], _GEN_3[10], _GEN_3[11], _GEN_3[12], _GEN_3[13], _GEN_3[14],
+                _GEN_3[15], _GEN_3[16], _GEN_3[17], _GEN_3[18], _GEN_3[19], _GEN_3[20], _GEN_3[21],
+                _GEN_3[22], _GEN_3[23], _GEN_3[24], _GEN_3[25], _GEN_3[26], _GEN_3[27], _GEN_3[28],
+                _GEN_3[29], _GEN_3[30], _GEN_3[31], _GEN_3[32], _GEN_3[33], _GEN_3[34], _GEN_3[35],
+                _GEN_3[36], _GEN_3[37], _GEN_3[38], _GEN_3[39], _GEN_3[40], _GEN_3[41], _GEN_3[42],
+                _GEN_3[43], _GEN_3[44], _GEN_3[45], _GEN_3[46], _GEN_3[47], _GEN_3[48], _GEN_3[49],
+                _GEN_3[50], _GEN_3[51], _GEN_3[52], _GEN_3[53], _GEN_3[54], _GEN_3[55], _GEN_3[56],
+                _GEN_3[57], _GEN_3[58], _GEN_3[59], _GEN_3[60], _GEN_3[61], _GEN_3[62], _GEN_3[63]};
+  assign shout = (_shin_T | _shin_T_1 ? shout_r : 64'h0) | (io_fn == 4'h1 ? shout_l : 64'h0);
   wire _logic_T_1 = io_fn == 4'h6;
-  wire [63:0] _logic = (io_fn == 4'h4 | _logic_T_1 ? _in1_xor_in2 : 64'h0) | (_logic_T_1 | io_fn == 4'h7 ? io_in1
-                & io_in2 : 64'h0);
-  assign logic_0 = _logic;
-  wire [63:0] _shift_logic = {63'h0, io_fn > 4'hB & _slt} | _logic | _shout;
-  assign shift_logic = _shift_logic;
-  wire [63:0] _out = io_fn == 4'h0 | io_fn == 4'hA ? _GEN_0 : _shift_logic;
-  assign out = _out;
-  assign io_out = io_dw == 4'h2 ? {{32{_out[31]}}, _out[31:0]} : _out;
-  assign io_adder_out = _GEN_0;
-  assign io_cmp_out = io_fn[0] ^ (io_fn[3] ? _slt : _in1_xor_in2 == 64'h0);
+  assign logic_0 = (io_fn == 4'h4 | _logic_T_1 ? in1_xor_in2 : 64'h0) | (_logic_T_1 | io_fn == 4'h7 ? io_in1 &
+                io_in2 : 64'h0);
+  assign shift_logic = {63'h0, io_fn > 4'hB & slt} | logic_0 | shout;
+  assign out = io_fn == 4'h0 | io_fn == 4'hA ? _GEN : shift_logic;
+  assign io_out = io_dw == 4'h2 ? {{32{out[31]}}, out[31:0]} : out;
+  assign io_adder_out = _GEN;
+  assign io_cmp_out = io_fn[0] ^ (io_fn[3] ? slt : in1_xor_in2 == 64'h0);
 endmodule
```

## Example 3

There are some weird situations where you can get code like the following (either explicitly written or because of how canonicalization surprisingly works):

```scala
circuit Foo:
  module Foo:
    input a: UInt<1>
    output out: UInt<1>

    node w_0 = a
    node w_1 = a
    node w_2 = a
    node w_3 = a
    out <= a
```

Without this PR, CIRCT will produce what you expect:

```verilog
module Foo(
  input  a,
  output out);

  wire w_0;
  wire w_1;
  wire w_2;
  wire w_3;

  assign w_0 = a;
  assign w_1 = a;
  assign w_2 = a;
  assign w_3 = a;
  assign out = a;
endmodule
```

With this PR, CIRCT will turn this into a pipeline of assigns (which guarantees that every dead wire is used):

```verilog
module Foo(
  input  a,
  output out);

  wire w_0;
  wire w_1;
  wire w_2;
  wire w_3;

  assign w_0 = a;
  assign w_1 = w_0;
  assign w_2 = w_1;
  assign w_3 = w_2;
  assign out = w_3;
endmodule
```

This may not be the best idea, but it is a legal transformation that guarantees dead wires are used and avoids lint errors.  I noticed this because CIRCT is being too aggressive with node canonicalization in FIRRTL Dialect.  The following:

```scala
circuit Foo:
  module Foo:
    input a: UInt<1>
    output out: UInt<1>

    node w_0 = a
    node w_1 = w_0
    node w_2 = w_1
    node w_3 = w_2
    out <= w_3
```

Is canonicalized to direct assigns creating dead nodes after FIRRTL Dialect canonicalization:

```mlir
firrtl.module @Foo(in %a: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
  %w_0 = firrtl.node sym @w_0 %a  : !firrtl.uint<1>
  %w_1 = firrtl.node sym @w_1 %a  : !firrtl.uint<1>
  %w_2 = firrtl.node sym @w_2 %a  : !firrtl.uint<1>
  %w_3 = firrtl.node sym @w_3 %a  : !firrtl.uint<1>
  firrtl.strictconnect %out, %a : !firrtl.uint<1>
}
```