### PR TITLE
[HW] Support hw.instance of modules with parametric in/out types

### DIFF
--- a/include/circt/Dialect/HW/HWAttributes.h
+++ b/include/circt/Dialect/HW/HWAttributes.h
@@ -25,6 +25,15 @@ struct InnerName {
 // Forward declaration.
 class GlobalRefOp;
 
+/// Returns a resolved version of 'type' wherein any parameter reference
+/// has been evaluated based on the set of provided 'parameters'.
+mlir::Type resolveParametricType(mlir::ArrayAttr parameters, mlir::Type type);
+
+/// Evaluates a parametric attribute (param.decl.ref/param.expr) based on a set
+/// of provided parameter values.
+mlir::APInt evaluateParamAttr(mlir::ArrayAttr parameters,
+                              mlir::Attribute paramAttr);
+
 } // namespace hw
 } // namespace circt
 

--- a/include/circt/Dialect/HW/HWAttributes.h
+++ b/include/circt/Dialect/HW/HWAttributes.h
@@ -27,12 +27,15 @@ class GlobalRefOp;
 
 /// Returns a resolved version of 'type' wherein any parameter reference
 /// has been evaluated based on the set of provided 'parameters'.
-mlir::Type resolveParametricType(mlir::ArrayAttr parameters, mlir::Type type);
+mlir::FailureOr<mlir::Type> evaluateParametricType(mlir::Location loc,
+                                                   mlir::ArrayAttr parameters,
+                                                   mlir::Type type);
 
 /// Evaluates a parametric attribute (param.decl.ref/param.expr) based on a set
 /// of provided parameter values.
-mlir::APInt evaluateParamAttr(mlir::ArrayAttr parameters,
-                              mlir::Attribute paramAttr);
+mlir::FailureOr<mlir::APInt> evaluateParametricAttr(mlir::Location loc,
+                                                    mlir::ArrayAttr parameters,
+                                                    mlir::Attribute paramAttr);
 
 } // namespace hw
 } // namespace circt

--- a/lib/Dialect/HW/HWAttributes.cpp
+++ b/lib/Dialect/HW/HWAttributes.cpp
@@ -707,7 +707,7 @@ replaceDeclRefInExpr(const std::map<std::string, IntegerAttr> &parameters,
                                      "parameters for the expression!");
     return it->second;
   } else if (auto paramExprAttr = paramAttr.dyn_cast<hw::ParamExprAttr>()) {
-    // Recurse into all of the operands of the expression.
+    // Recurse into all operands of the expression.
     llvm::SmallVector<Attribute, 4> replacedOperands;
     llvm::transform(paramExprAttr.getOperands(),
                     std::back_inserter(replacedOperands), [&](auto operand) {

--- a/lib/Dialect/HW/HWAttributes.cpp
+++ b/lib/Dialect/HW/HWAttributes.cpp
@@ -700,13 +700,15 @@ replaceDeclRefInExpr(const std::map<std::string, IntegerAttr> &parameters,
   if (paramAttr.dyn_cast<IntegerAttr>()) {
     // Nothing to do, constant value.
     return paramAttr;
-  } else if (auto paramRefAttr = paramAttr.dyn_cast<hw::ParamDeclRefAttr>()) {
+  }
+  if (auto paramRefAttr = paramAttr.dyn_cast<hw::ParamDeclRefAttr>()) {
     // Get the value from the provided parameters.
     auto it = parameters.find(paramRefAttr.getName().str());
     assert(it != parameters.end() && "Could not find parameter in the provided "
                                      "parameters for the expression!");
     return it->second;
-  } else if (auto paramExprAttr = paramAttr.dyn_cast<hw::ParamExprAttr>()) {
+  }
+  if (auto paramExprAttr = paramAttr.dyn_cast<hw::ParamExprAttr>()) {
     // Recurse into all operands of the expression.
     llvm::SmallVector<Attribute, 4> replacedOperands;
     llvm::transform(paramExprAttr.getOperands(),
@@ -736,7 +738,7 @@ APInt hw::evaluateParamAttr(ArrayAttr parameters, Attribute paramAttr) {
   // Then, evaluate the parametri attribute.
   if (auto intAttr = paramAttr.dyn_cast<IntegerAttr>())
     return intAttr.getValue();
-  else if (auto paramExprAttr = paramAttr.dyn_cast<hw::ParamExprAttr>()) {
+  if (auto paramExprAttr = paramAttr.dyn_cast<hw::ParamExprAttr>()) {
     // Since any ParamDeclRefAttr was replaced within the expression, the
     // expression should be able to be fully canonicalized to a constant. We do
     // this through the existing ParamExprAttr canonicalizer.
@@ -748,7 +750,8 @@ APInt hw::evaluateParamAttr(ArrayAttr parameters, Attribute paramAttr) {
            "canonicalize to a constant. Since not, this means that some parts "
            "of the expression did not resolve to a constant");
     return resIntAttr.getValue();
-  } else if (paramAttr.dyn_cast<hw::ParamDeclRefAttr>())
+  }
+  if (paramAttr.dyn_cast<hw::ParamDeclRefAttr>())
     assert(false && "Should have been replaced earlier!");
 
   assert(false && "Unhandled parametric attribute");

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1148,11 +1148,15 @@ LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 
   for (size_t i = 0; i != numOperands; ++i) {
     auto expectedType =
-        resolveParametricType(parameters(), expectedOperandTypes[i]);
-    auto operandType = getOperand(i).getType();
-    if (operandType != expectedType) {
+        evaluateParametricType(getLoc(), parameters(), expectedOperandTypes[i]);
+    if (failed(expectedType))
       return emitError([&](auto &diag) {
-        diag << "operand type #" << i << " must be " << expectedType
+        diag << "failed to resolve parametric input of instantiated module";
+      });
+    auto operandType = getOperand(i).getType();
+    if (operandType != expectedType.getValue()) {
+      return emitError([&](auto &diag) {
+        diag << "operand type #" << i << " must be " << expectedType.getValue()
              << ", but got " << operandType;
       });
     }
@@ -1183,11 +1187,15 @@ LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 
   for (size_t i = 0; i != numResults; ++i) {
     auto expectedType =
-        resolveParametricType(parameters(), expectedResultTypes[i]);
-    auto resultType = getResult(i).getType();
-    if (resultType != expectedType)
+        evaluateParametricType(getLoc(), parameters(), expectedResultTypes[i]);
+    if (failed(expectedType))
       return emitError([&](auto &diag) {
-        diag << "result type #" << i << " must be " << expectedType
+        diag << "failed to resolve parametric input of instantiated module";
+      });
+    auto resultType = getResult(i).getType();
+    if (resultType != expectedType.getValue())
+      return emitError([&](auto &diag) {
+        diag << "result type #" << i << " must be " << expectedType.getValue()
              << ", but got " << resultType;
       });
 

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1147,13 +1147,15 @@ LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
     });
 
   for (size_t i = 0; i != numOperands; ++i) {
-    auto expectedType = expectedOperandTypes[i];
+    auto expectedType =
+        resolveParametricType(parameters(), expectedOperandTypes[i]);
     auto operandType = getOperand(i).getType();
-    if (operandType != expectedType)
+    if (operandType != expectedType) {
       return emitError([&](auto &diag) {
         diag << "operand type #" << i << " must be " << expectedType
              << ", but got " << operandType;
       });
+    }
 
     if (argNames[i] != modArgNames[i])
       return emitError([&](auto &diag) {
@@ -1180,7 +1182,8 @@ LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
     });
 
   for (size_t i = 0; i != numResults; ++i) {
-    auto expectedType = expectedResultTypes[i];
+    auto expectedType =
+        resolveParametricType(parameters(), expectedResultTypes[i]);
     auto resultType = getResult(i).getType();
     if (resultType != expectedType)
       return emitError([&](auto &diag) {

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -926,8 +926,17 @@ hw.module @parameters<p1: i42 = 17, p2: i1>(%arg0: i8) -> (out: i8) {
 
 hw.module.extern @parameters2<p1: i42 = 17, p2: i1 = 0>(%arg0: i8) -> (out: i8)
 
+// CHECK-LABEL: module parameters3
+// CHECK-NEXT:   #(parameter [41:0] p1 = 42'd17) (
+// CHECK-NEXT:   input  [p1 - 1:0] arg0,
+// CHECK-NEXT:   output [p1 - 1:0] out);
+// CHECK:   assign out = arg0;
+hw.module @parameters3<p1: i42 = 17>(%arg0: !hw.int<#hw.param.decl.ref<"p1">>) -> (out: !hw.int<#hw.param.decl.ref<"p1">>) {
+  hw.output %arg0 : !hw.int<#hw.param.decl.ref<"p1">>
+}
+
 // CHECK-LABEL: module UseParameterized(
-hw.module @UseParameterized(%a: i8) -> (ww: i8, xx: i8, yy: i8, zz: i8) {
+hw.module @UseParameterized(%a: i8) -> (ww: i8, xx: i8, yy: i8, zz: i8, qq: i8) {
   // Two parameters.
   // CHECK:      parameters #(
   // CHECK-NEXT:   .p1(42'd4),
@@ -964,7 +973,16 @@ hw.module @UseParameterized(%a: i8) -> (ww: i8, xx: i8, yy: i8, zz: i8) {
   // CHECK-NEXT: );
   %r3 = hw.instance "inst4" @parameters2<p1: i42 = 17, p2: i1 = 0>(arg0: %a: i8) -> (out: i8)
 
-  hw.output %r0, %r1, %r2, %r3: i8, i8, i8, i8
+  // Parameterized I/O ports.
+  // CHECK: parameters3 #(
+  // CHECK-NEXT:   .p1(42'd8)
+  // CHECK-NEXT: ) inst5 (
+  // CHECK-NEXT:   .arg0 (a),
+  // CHECK-NEXT:   .out  (qq)
+  // CHECK-NEXT: );
+  %r4 = hw.instance "inst5" @parameters3<p1: i42 = 8>(arg0: %a: i8) -> (out: i8)
+
+  hw.output %r0, %r1, %r2, %r3, %r4: i8, i8, i8, i8, i8
 }
 
 // CHECK-LABEL: module UseParameterValue

--- a/test/Dialect/HW/errors.mlir
+++ b/test/Dialect/HW/errors.mlir
@@ -287,3 +287,27 @@ module  {
     hw.instance "h2" sym @inst_0 @C() -> () {circt.globalRef = [#hw.globalNameRef<@glbl_D_M1>]}
   }
 }
+
+// -----
+
+module {
+  hw.module @A(%a : !hw.int<41>) -> (out: !hw.int<42>) {
+// expected-error @+1 {{'hw.instance' op operand type #0 must be 'i42', but got 'i41'}}
+    %r0 = hw.instance "inst1" @parameters<p1: i42 = 42>(arg0: %a: !hw.int<41>) -> (out: !hw.int<42>)
+    hw.output %r0: !hw.int<42>
+  }
+// expected-note @+1 {{module declared here}}
+  hw.module.extern @parameters<p1: i42>(%arg0: !hw.int<#hw.param.decl.ref<"p1">>) -> (out: !hw.int<#hw.param.decl.ref<"p1">>)
+}
+
+// -----
+
+module {
+  hw.module @A(%a : !hw.int<42>) -> (out: !hw.int<41>) {
+// expected-error @+1 {{'hw.instance' op result type #0 must be 'i42', but got 'i41'}}
+    %r0 = hw.instance "inst1" @parameters<p1: i42 = 42>(arg0: %a: !hw.int<42>) -> (out: !hw.int<41>)
+    hw.output %r0: !hw.int<41>
+  }
+// expected-note @+1 {{module declared here}}
+  hw.module.extern @parameters<p1: i42>(%arg0: !hw.int<#hw.param.decl.ref<"p1">>) -> (out: !hw.int<#hw.param.decl.ref<"p1">>)
+}

--- a/test/Dialect/HW/parameters.mlir
+++ b/test/Dialect/HW/parameters.mlir
@@ -138,11 +138,26 @@ hw.module @associativeOrdering<p1: i4, p2: i4>()
 hw.module @parameterizedTypes<param: i32>
 // CHECK-SAME: %a: i17,
   (%a: !hw.int<17>,
-// CHECK-SAME: %b: !hw.int<#hw.param.decl.ref<"param">>
-   %b: !hw.int<#hw.param.decl.ref<"param">>) {
+// CHECK-SAME: %b: !hw.int<#hw.param.decl.ref<"param">>) ->
+   %b: !hw.int<#hw.param.decl.ref<"param">>) ->
+// CHECK-SAME: (c: !hw.int<#hw.param.decl.ref<"param">>)
+  (c: !hw.int<#hw.param.decl.ref<"param">>) {
 
   // CHECK: %paramWire = sv.wire : !hw.inout<int<#hw.param.decl.ref<"param">>>
   %paramWire = sv.wire : !hw.inout<!hw.int<#hw.param.decl.ref<"param">>>
+  // CHECK: %0 = sv.read_inout %paramWire : !hw.inout<int<#hw.param.decl.ref<"param">>>
+  %0 = sv.read_inout %paramWire : !hw.inout<!hw.int<#hw.param.decl.ref<"param">>>
+  // CHECK: hw.output %0 : !hw.int<#hw.param.decl.ref<"param">>
+  hw.output %0 : !hw.int<#hw.param.decl.ref<"param">>
+}
+
+// CHECK-LABEL: @parameterizedTypesInstance(
+hw.module @parameterizedTypesInstance
+  (%a: !hw.int<17>, %b: !hw.int<42>) {
+
+  // CHECK: hw.instance "inst" @parameterizedTypes<param: i32 = 42>(a: %a: i17, b: %b: i42) -> (c: i42)
+  %c = hw.instance "inst" @parameterizedTypes<param: i32 = 42>
+    (a: %a : !hw.int<17>, b: %b : !hw.int<42>) -> (c: !hw.int<42>) {}
 }
 
 // CHECK-LABEL: hw.module @parameterizedCombSeq<param: i32>(


### PR DESCRIPTION
To extend the capabilities of parametric modules, this commit introduces support for `hw.instance`'iating `hw.module`s with parametric input/output types. Upon instantiation (and `hw.instance` verification), module types are resolved based on the set of provided parameters to the `hw.instance` op.

The brunt of the work for supporting this is added through two new functions:
- resolveParametricType: Based on a set of parameters, a parametric type is resolved to its actual type. For now, only parametric `!hw.int` types are supported, but #2703 will add support for parametric array types.
- evaluateParamAttr: Based on a set of parameters, a parametric expression is evaluated through use of the existing ParamExprAttr canonicalizers.