### PR TITLE
[ExportVerilog] Removed redundant sv::IfOp inversion

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3188,16 +3188,7 @@ LogicalResult StmtEmitter::visitSV(IfOp op) {
   // it (either "if (" or "else if (") was printed already.
   IfOp ifOp = op;
   for (;;) {
-    // If we have an else and and empty then block, emit an inverted condition.
-    if (ifOp.hasElse() && ifOp.getThenBlock()->empty()) {
-      os << '!';
-      emitExpression(ifOp.cond(), ops, Unary);
-      os << ')';
-      emitBlockAsStatement(ifOp.getElseBlock(), ops);
-      break;
-    }
-
-    // Normal emission.
+    // Emit the condition and the then block.
     emitExpression(ifOp.cond(), ops);
     os << ')';
     emitBlockAsStatement(ifOp.getThenBlock(), ops);

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -34,13 +34,6 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
         sv.fwrite %fd, "Hi\n"
       }
 
-      // CHECK-NEXT: if (!(clock | cond))
-      // CHECK-NEXT:   $fwrite(32'h80000002, "Bye\n");
-      %tmp4 = comb.or %clock, %cond : i1
-      sv.if %tmp4 {
-      } else {
-        sv.fwrite %fd, "Bye\n"
-      }
   // CHECK-NEXT: release forceWire;
     sv.release %forceWire : !hw.inout<i1>
   // CHECK-NEXT:   `endif


### PR DESCRIPTION
Removed the `IfOp` inversion with empty then blocks in `EmitVerilog` since the canonicalizer performs the transformation already.