### PR TITLE
[Moore] Add types to C API

### DIFF
--- a/include/circt-c/Dialect/Moore.h
+++ b/include/circt-c/Dialect/Moore.h
@@ -28,43 +28,43 @@ MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Moore, moore);
 enum MooreIntKind {
   // The integer vector types. These are the builtin single-bit integer types.
   /// A `bit`.
-  Bit,
+  MooreBit,
   /// A `logic`.
-  Logic,
+  MooreLogic,
   /// A `reg`.
-  Reg,
+  MooreReg,
 
   // The integer atom types. These are the builtin multi-bit integer types.
   /// A `byte`.
-  Byte,
+  MooreByte,
   /// A `shortint`.
-  ShortInt,
+  MooreShortInt,
   /// An `int`.
-  Int,
+  MooreInt,
   /// A `longint`.
-  LongInt,
+  MooreLongInt,
   /// An `integer`.
-  Integer,
+  MooreInteger,
   /// A `time`.
-  Time,
+  MooreTime,
 };
 
 enum MooreRealKind {
   /// A `shortreal`.
-  ShortReal,
+  MooreShortReal,
   /// A `real`.
-  Real,
+  MooreReal,
   /// A `realtime`.
-  RealTime,
+  MooreRealTime,
 };
 
 enum MooreSign {
   /// No sign is explicitly given.
-  None,
+  MooreNone,
   /// Explicitly marked to be unsigned.
-  Unsigned,
+  MooreUnsigned,
   /// Explicitly marked to be signed.
-  Signed,
+  MooreSigned,
 };
 
 /// Create a void type.

--- a/include/circt-c/Dialect/Moore.h
+++ b/include/circt-c/Dialect/Moore.h
@@ -21,6 +21,120 @@ extern "C" {
 
 MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Moore, moore);
 
+//===----------------------------------------------------------------------===//
+// Types
+//===----------------------------------------------------------------------===//
+
+enum MooreIntKind {
+  // The integer vector types. These are the builtin single-bit integer types.
+  /// A `bit`.
+  Bit,
+  /// A `logic`.
+  Logic,
+  /// A `reg`.
+  Reg,
+
+  // The integer atom types. These are the builtin multi-bit integer types.
+  /// A `byte`.
+  Byte,
+  /// A `shortint`.
+  ShortInt,
+  /// An `int`.
+  Int,
+  /// A `longint`.
+  LongInt,
+  /// An `integer`.
+  Integer,
+  /// A `time`.
+  Time,
+};
+
+enum MooreRealKind {
+  /// A `shortreal`.
+  ShortReal,
+  /// A `real`.
+  Real,
+  /// A `realtime`.
+  RealTime,
+};
+
+enum MooreSign {
+  /// No sign is explicitly given.
+  None,
+  /// Explicitly marked to be unsigned.
+  Unsigned,
+  /// Explicitly marked to be signed.
+  Signed,
+};
+
+/// Create a void type.
+MLIR_CAPI_EXPORTED MlirType mooreVoidTypeGet(MlirContext ctx);
+/// Create a string type.
+MLIR_CAPI_EXPORTED MlirType mooreStringTypeGet(MlirContext ctx);
+/// Create a chandle type.
+MLIR_CAPI_EXPORTED MlirType mooreChandleTypeGet(MlirContext ctx);
+/// Create an event type.
+MLIR_CAPI_EXPORTED MlirType mooreEventTypeGet(MlirContext ctx);
+/// Create an int type.
+MLIR_CAPI_EXPORTED MlirType mooreIntTypeGet(MlirContext ctx,
+                                            enum MooreIntKind kind,
+                                            enum MooreSign sign);
+/// Create a `logic` type.
+MLIR_CAPI_EXPORTED MlirType mooreIntTypeGetLogic(MlirContext ctx);
+/// Create an `int` type.
+MLIR_CAPI_EXPORTED MlirType mooreIntTypeGetInt(MlirContext ctx);
+/// Create a `time` type.
+MLIR_CAPI_EXPORTED MlirType mooreIntTypeGetTime(MlirContext ctx);
+/// Create a real type.
+MLIR_CAPI_EXPORTED MlirType mooreRealTypeGet(MlirContext ctx,
+                                             enum MooreRealKind kind);
+/// Create a packed unsized dimension type.
+MLIR_CAPI_EXPORTED MlirType moorePackedUnsizedDimTypeGet(MlirType inner);
+/// Create a packed range dimension type.
+MLIR_CAPI_EXPORTED MlirType moorePackedRangeDimTypeGet(MlirType inner,
+                                                       unsigned size,
+                                                       bool upDir, int offset);
+/// Create a unpacked unsized dimension type.
+MLIR_CAPI_EXPORTED MlirType mooreUnpackedUnsizedDimTypeGet(MlirType inner);
+/// Create a unpacked array dimension type.
+MLIR_CAPI_EXPORTED MlirType mooreUnpackedArrayDimTypeGet(MlirType inner,
+                                                         unsigned size);
+/// Create a unpacked range dimension type.
+MLIR_CAPI_EXPORTED MlirType mooreUnpackedRangeDimTypeGet(MlirType inner,
+                                                         unsigned size,
+                                                         bool upDir,
+                                                         int offset);
+/// Create a unpacked assoc dimension type without index.
+MLIR_CAPI_EXPORTED MlirType mooreUnpackedAssocDimTypeGet(MlirType inner);
+/// Create a unpacked assoc dimension type width index.
+MLIR_CAPI_EXPORTED MlirType
+mooreUnpackedAssocDimTypeGetWithIndex(MlirType inner, MlirType indexType);
+/// Create a unpacked queue dimension type without bound.
+MLIR_CAPI_EXPORTED MlirType mooreUnpackedQueueDimTypeGet(MlirType inner);
+/// Create a unpacked queue dimension type with bound.
+MLIR_CAPI_EXPORTED MlirType
+mooreUnpackedQueueDimTypeGetWithBound(MlirType inner, unsigned bound);
+/// Create a enum type without base.
+MLIR_CAPI_EXPORTED MlirType mooreEnumTypeGet(MlirAttribute name,
+                                             MlirLocation loc);
+/// Create a enum type with base.
+MLIR_CAPI_EXPORTED MlirType mooreEnumTypeGetWithBase(MlirAttribute name,
+                                                     MlirLocation loc,
+                                                     MlirType base);
+// TODO: PackedStructType
+// TODO: UnpackedStructType
+/// Create a simple bit-vector type.
+MLIR_CAPI_EXPORTED MlirType mooreSimpleBitVectorTypeGet(MlirContext ctx,
+                                                        bool isFourValued,
+                                                        bool isSigned,
+                                                        unsigned size);
+/// Checks whether the passed UnpackedType is a four-valued type.
+MLIR_CAPI_EXPORTED bool mooreIsFourValuedType(MlirType type);
+/// Checks whether the passed type is a simple bit-vector.
+MLIR_CAPI_EXPORTED bool mooreIsSimpleBitVectorType(MlirType type);
+/// Returns the size of a simple bit-vector type in bits.
+MLIR_CAPI_EXPORTED unsigned mooreGetSimpleBitVectorSize(MlirType type);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/CAPI/Dialect/Moore.cpp
+++ b/lib/CAPI/Dialect/Moore.cpp
@@ -28,11 +28,11 @@ MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Moore, moore, MooreDialect)
 
 static Optional<Sign> convertMooreSign(enum MooreSign sign) {
   switch (sign) {
-  case MooreSign::Signed:
+  case MooreSign::MooreSigned:
     return Sign::Signed;
-  case MooreSign::Unsigned:
+  case MooreSign::MooreUnsigned:
     return Sign::Unsigned;
-  case MooreSign::None:
+  case MooreSign::MooreNone:
     return {};
   }
   llvm_unreachable("All cases should be covered.");
@@ -40,24 +40,24 @@ static Optional<Sign> convertMooreSign(enum MooreSign sign) {
 
 static IntType::Kind convertMooreIntKind(enum MooreIntKind kind) {
   switch (kind) {
-  case MooreIntKind::Bit:
+  case MooreIntKind::MooreBit:
     return IntType::Kind::Bit;
-  case MooreIntKind::Logic:
+  case MooreIntKind::MooreLogic:
     return IntType::Kind::Logic;
-  case MooreIntKind::Reg:
+  case MooreIntKind::MooreReg:
     return IntType::Kind::Reg;
 
-  case MooreIntKind::Byte:
+  case MooreIntKind::MooreByte:
     return IntType::Kind::Byte;
-  case MooreIntKind::ShortInt:
+  case MooreIntKind::MooreShortInt:
     return IntType::Kind::ShortInt;
-  case MooreIntKind::Int:
+  case MooreIntKind::MooreInt:
     return IntType::Kind::Int;
-  case MooreIntKind::LongInt:
+  case MooreIntKind::MooreLongInt:
     return IntType::Kind::LongInt;
-  case MooreIntKind::Integer:
+  case MooreIntKind::MooreInteger:
     return IntType::Kind::Integer;
-  case MooreIntKind::Time:
+  case MooreIntKind::MooreTime:
     return IntType::Kind::Time;
   }
   llvm_unreachable("All cases should be covered.");
@@ -65,11 +65,11 @@ static IntType::Kind convertMooreIntKind(enum MooreIntKind kind) {
 
 static RealType::Kind convertMooreRealKind(enum MooreRealKind kind) {
   switch (kind) {
-  case MooreRealKind::ShortReal:
+  case MooreRealKind::MooreShortReal:
     return circt::moore::RealType::ShortReal;
-  case MooreRealKind::Real:
+  case MooreRealKind::MooreReal:
     return circt::moore::RealType::Real;
-  case MooreRealKind::RealTime:
+  case MooreRealKind::MooreRealTime:
     return circt::moore::RealType::RealTime;
   }
   llvm_unreachable("All cases should be covered.");

--- a/lib/CAPI/Dialect/Moore.cpp
+++ b/lib/CAPI/Dialect/Moore.cpp
@@ -21,3 +21,191 @@ using namespace circt::moore;
 //===----------------------------------------------------------------------===//
 
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Moore, moore, MooreDialect)
+
+//===----------------------------------------------------------------------===//
+// Types
+//===----------------------------------------------------------------------===//
+
+static Optional<Sign> convertMooreSign(enum MooreSign sign) {
+  switch (sign) {
+  case MooreSign::Signed:
+    return Sign::Signed;
+  case MooreSign::Unsigned:
+    return Sign::Unsigned;
+  case MooreSign::None:
+    return {};
+  }
+  llvm_unreachable("All cases should be covered.");
+}
+
+static IntType::Kind convertMooreIntKind(enum MooreIntKind kind) {
+  switch (kind) {
+  case MooreIntKind::Bit:
+    return IntType::Kind::Bit;
+  case MooreIntKind::Logic:
+    return IntType::Kind::Logic;
+  case MooreIntKind::Reg:
+    return IntType::Kind::Reg;
+
+  case MooreIntKind::Byte:
+    return IntType::Kind::Byte;
+  case MooreIntKind::ShortInt:
+    return IntType::Kind::ShortInt;
+  case MooreIntKind::Int:
+    return IntType::Kind::Int;
+  case MooreIntKind::LongInt:
+    return IntType::Kind::LongInt;
+  case MooreIntKind::Integer:
+    return IntType::Kind::Integer;
+  case MooreIntKind::Time:
+    return IntType::Kind::Time;
+  }
+  llvm_unreachable("All cases should be covered.");
+}
+
+static RealType::Kind convertMooreRealKind(enum MooreRealKind kind) {
+  switch (kind) {
+  case MooreRealKind::ShortReal:
+    return circt::moore::RealType::ShortReal;
+  case MooreRealKind::Real:
+    return circt::moore::RealType::Real;
+  case MooreRealKind::RealTime:
+    return circt::moore::RealType::RealTime;
+  }
+  llvm_unreachable("All cases should be covered.");
+}
+
+/// Create a void type.
+MlirType mooreVoidTypeGet(MlirContext ctx) {
+  return wrap(VoidType::get(unwrap(ctx)));
+}
+
+/// Create a string type.
+MlirType mooreStringTypeGet(MlirContext ctx) {
+  return wrap(StringType::get(unwrap(ctx)));
+}
+
+/// Create a chandle type.
+MlirType mooreChandleTypeGet(MlirContext ctx) {
+  return wrap(ChandleType::get(unwrap(ctx)));
+}
+
+/// Create a event type.
+MlirType mooreEventTypeGet(MlirContext ctx) {
+  return wrap(EventType::get(unwrap(ctx)));
+}
+
+/// Create an int type.
+MlirType mooreIntTypeGet(MlirContext ctx, enum MooreIntKind kind,
+                         enum MooreSign sign) {
+  return wrap(IntType::get(unwrap(ctx), convertMooreIntKind(kind),
+                           convertMooreSign(sign)));
+}
+
+/// Create a `logic` type.
+MlirType mooreIntTypeGetLogic(MlirContext ctx) {
+  return wrap(IntType::getLogic(unwrap(ctx)));
+}
+
+/// Create an `int` type.
+MlirType mooreIntTypeGetInt(MlirContext ctx) {
+  return wrap(IntType::getInt(unwrap(ctx)));
+}
+
+/// Create a `time` type.
+MlirType mooreIntTypeGetTime(MlirContext ctx) {
+  return wrap(IntType::getTime(unwrap(ctx)));
+}
+
+/// Create a real type.
+MlirType mooreRealTypeGet(MlirContext ctx, enum MooreRealKind kind) {
+  return wrap(RealType::get(unwrap(ctx), convertMooreRealKind(kind)));
+}
+
+/// Create a packed unsized dimension type.
+MlirType moorePackedUnsizedDimTypeGet(MlirType inner) {
+  return wrap(PackedUnsizedDim::get(unwrap(inner).cast<PackedType>()));
+}
+
+/// Create a packed range dimension type.
+MlirType moorePackedRangeDimTypeGet(MlirType inner, unsigned size, bool upDir,
+                                    int offset) {
+  RangeDir dir = upDir ? RangeDir::Up : RangeDir::Down;
+  return wrap(
+      PackedRangeDim::get(unwrap(inner).cast<PackedType>(), size, dir, offset));
+}
+
+/// Create a unpacked unsized dimension type.
+MlirType mooreUnpackedUnsizedDimTypeGet(MlirType inner) {
+  return wrap(UnpackedUnsizedDim::get(unwrap(inner).cast<UnpackedType>()));
+}
+
+/// Create a unpacked array dimension type.
+MlirType mooreUnpackedArrayDimTypeGet(MlirType inner, unsigned size) {
+  return wrap(UnpackedArrayDim::get(unwrap(inner).cast<UnpackedType>(), size));
+}
+
+/// Create a unpacked range dimension type.
+MlirType mooreUnpackedRangeDimTypeGet(MlirType inner, unsigned size, bool upDir,
+                                      int offset) {
+  RangeDir dir = upDir ? RangeDir::Up : RangeDir::Down;
+  return wrap(UnpackedRangeDim::get(unwrap(inner).cast<UnpackedType>(), size,
+                                    dir, offset));
+}
+
+/// Create a unpacked assoc dimension type without index.
+MlirType mooreUnpackedAssocDimTypeGet(MlirType inner) {
+  return wrap(UnpackedAssocDim::get(unwrap(inner).cast<UnpackedType>()));
+}
+
+/// Create a unpacked assoc dimension type with index.
+MlirType mooreUnpackedAssocDimTypeGetWithIndex(MlirType inner,
+                                               MlirType indexType) {
+  return wrap(UnpackedAssocDim::get(unwrap(inner).cast<UnpackedType>(),
+                                    unwrap(indexType).cast<UnpackedType>()));
+}
+
+/// Create a unpacked queue dimension type without bound.
+MlirType mooreUnpackedQueueDimTypeGet(MlirType inner) {
+  return wrap(UnpackedQueueDim::get(unwrap(inner).cast<UnpackedType>()));
+}
+
+/// Create a unpacked queue dimension type with bound.
+MlirType mooreUnpackedQueueDimTypeGetWithBound(MlirType inner, unsigned bound) {
+  return wrap(UnpackedQueueDim::get(unwrap(inner).cast<UnpackedType>(), bound));
+}
+
+/// Create a enum type without base.
+MlirType mooreEnumTypeGet(MlirAttribute name, MlirLocation loc) {
+  return wrap(EnumType::get(unwrap(name).cast<StringAttr>(), unwrap(loc)));
+}
+
+/// Create a enum type width base.
+MlirType mooreEnumTypeGetWithBase(MlirAttribute name, MlirLocation loc,
+                                  MlirType base) {
+  return wrap(EnumType::get(unwrap(name).cast<StringAttr>(), unwrap(loc),
+                            unwrap(base).cast<PackedType>()));
+}
+
+/// Create a simple bit-vector type.
+MlirType mooreSimpleBitVectorTypeGet(MlirContext ctx, bool isFourValued,
+                                     bool isSigned, unsigned size) {
+  Domain domain = isFourValued ? Domain::FourValued : Domain::TwoValued;
+  Sign sign = isSigned ? Sign::Signed : Sign::Unsigned;
+  return wrap(SimpleBitVectorType(domain, sign, size).getType(unwrap(ctx)));
+}
+
+/// Checks whether the passed UnpackedType is a four-valued type.
+bool mooreIsFourValuedType(MlirType type) {
+  return unwrap(type).cast<UnpackedType>().getDomain() == Domain::FourValued;
+}
+
+/// Checks whether the passed type is a simple bit-vector.
+bool mooreIsSimpleBitVectorType(MlirType type) {
+  return unwrap(type).cast<UnpackedType>().isSimpleBitVector();
+}
+
+/// Returns the size of a simple bit-vector type in bits.
+unsigned mooreGetSimpleBitVectorSize(MlirType type) {
+  return unwrap(type).cast<UnpackedType>().getSimpleBitVector().size;
+}


### PR DESCRIPTION
A first step to have proper support of the Moore types in the C API. This focusses on the functions to create types and some SBV type functions needed to support the already existing moore operations in the external moore frontend compiler.