### PR TITLE
[PyCDE] Add SystolicArray construct

### DIFF
--- a/frontends/PyCDE/src/CMakeLists.txt
+++ b/frontends/PyCDE/src/CMakeLists.txt
@@ -8,7 +8,24 @@
 
 declare_mlir_python_sources(PyCDESources
   ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}"
-  SOURCES_GLOB pycde/*.py)
+  SOURCES
+    pycde/__init__.py
+    pycde/pycde_types.py
+    pycde/dialects/__init__.py
+    pycde/dialects/msft.py
+    pycde/dialects/seq.py
+    pycde/dialects/hw.py
+    pycde/dialects/comb.py
+    pycde/support.py
+    pycde/appid.py
+    pycde/module.py
+    pycde/attributes.py
+    pycde/constructs.py
+    pycde/system.py
+    pycde/devicedb.py
+    pycde/instance.py
+    pycde/value.py
+)
 
 add_mlir_python_modules(PyCDE
   ROOT_PREFIX "${CIRCT_PYTHON_PACKAGES_DIR}/pycde"

--- a/frontends/PyCDE/src/pycde/constructs.py
+++ b/frontends/PyCDE/src/pycde/constructs.py
@@ -1,0 +1,31 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+from .support import _obj_to_value
+from .pycde_types import dim as _dim
+from .value import Value as _Value
+from circt.support import get_value as _get_value
+from circt.dialects import msft as _msft, hw as _hw
+import mlir.ir as _ir
+
+
+def SystolicArray(pe_output_type, row_inputs, col_inputs, pe_builder):
+  """Build a systolic array."""
+
+  row_inputs_type = _hw.ArrayType(row_inputs.type)
+  col_inputs_type = _hw.ArrayType(col_inputs.type)
+  sa_result_type = _dim(pe_output_type, col_inputs_type.size,
+                        row_inputs_type.size)
+  array = _msft.SystolicArrayOp(sa_result_type, _get_value(row_inputs),
+                                _get_value(col_inputs))
+  pe = array.pe.blocks.append(row_inputs_type.element_type,
+                              col_inputs_type.element_type)
+  with _ir.InsertionPoint(pe):
+    result = pe_builder(_Value.get(pe.arguments[0]),
+                        _Value.get(pe.arguments[1]))
+    value = _obj_to_value(result, pe_output_type)
+    _msft.PEOutputOp(value.value)
+  return array.peOutputs

--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -40,7 +40,7 @@ class System:
   ]
 
   PASSES = """
-    msft-lower-instances, {partition}
+    msft-lower-constructs, msft-lower-instances, {partition}
     lower-msft-to-hw{{verilog-file={verilog_file}}},
     lower-seq-to-sv, hw.module(prettify-verilog), hw.module(hw-cleanup),
     msft-export-tcl{{tops={tops} tcl-file={tcl_file}}}

--- a/frontends/PyCDE/test/systolic_array.py
+++ b/frontends/PyCDE/test/systolic_array.py
@@ -1,0 +1,51 @@
+# RUN: rm -rf %t
+# RUN: %PYTHON% %s %t 2>&1 | FileCheck %s
+
+from pycde import dim, module, generator, types, Input, Output
+from pycde.constructs import SystolicArray
+import pycde
+
+import pycde.dialects.comb as comb
+
+import sys
+
+
+@module
+class Top:
+  clk = Input(types.i1)
+  row_data = Input(dim(8, 3))
+  col_data = Input(dim(8, 2))
+  out = Output(dim(8, 2, 3))
+
+  @generator
+  def build(mod):
+    # If we just feed constants, CIRCT pre-computes the outputs in the
+    # generated Verilog! Keep these for demo purposes.
+    # row_data = dim(8, 3)([1, 2, 3]).value
+    # col_data = dim(8, 2)([4, 5]).value
+
+    # CHECK-LABEL: %{{.+}} = msft.systolic.array [%{{.+}} : 3 x i8] [%{{.+}} : 2 x i8] pe (%arg0, %arg1) -> (i8) {
+    # CHECK:         [[SUM:%.+]] = comb.add %arg0, %arg1 : i8
+    # CHECK:         [[SUMR:%.+]] = seq.compreg [[SUM]], %clk : i8
+    # CHECK:         msft.pe.output [[SUMR]] : i8
+    def pe(r, c):
+      sum = comb.AddOp(r, c)
+      return sum.reg(mod.clk)
+
+    pe_outputs = SystolicArray(types.i8, mod.row_data, mod.col_data, pe)
+
+    mod.out = pe_outputs
+
+
+t = pycde.System([Top], name="SATest", output_directory=sys.argv[1])
+t.generate()
+print("=== Pre-pass mlir dump")
+t.print()
+
+print("=== Running passes")
+t.run_passes()
+
+print("=== Final mlir dump")
+t.print()
+
+t.emit_outputs()


### PR DESCRIPTION
Plumbs through the new `msft.systolic.array` to PyCDE. Specifying the PE result type could be inferred, but I think that would require upstream MLIR Python bindings modifications.