### PR TITLE
[PyCDE] Infer the result type of a SystolicArray PE

### DIFF
--- a/frontends/PyCDE/src/pycde/constructs.py
+++ b/frontends/PyCDE/src/pycde/constructs.py
@@ -12,20 +12,27 @@ from circt.dialects import msft as _msft, hw as _hw
 import mlir.ir as _ir
 
 
-def SystolicArray(pe_output_type, row_inputs, col_inputs, pe_builder):
+def SystolicArray(row_inputs, col_inputs, pe_builder):
   """Build a systolic array."""
 
   row_inputs_type = _hw.ArrayType(row_inputs.type)
   col_inputs_type = _hw.ArrayType(col_inputs.type)
+
+  dummy_op = _ir.Operation.create("dummy", regions=1)
+  pe_block = dummy_op.regions[0].blocks.append(row_inputs_type.element_type,
+                                               col_inputs_type.element_type)
+  with _ir.InsertionPoint(pe_block):
+    result = pe_builder(_Value.get(pe_block.arguments[0]),
+                        _Value.get(pe_block.arguments[1]))
+    value = _obj_to_value(result, result.type)
+    pe_output_type = value.type
+    _msft.PEOutputOp(value.value)
+
   sa_result_type = _dim(pe_output_type, col_inputs_type.size,
                         row_inputs_type.size)
   array = _msft.SystolicArrayOp(sa_result_type, _get_value(row_inputs),
                                 _get_value(col_inputs))
-  pe = array.pe.blocks.append(row_inputs_type.element_type,
-                              col_inputs_type.element_type)
-  with _ir.InsertionPoint(pe):
-    result = pe_builder(_Value.get(pe.arguments[0]),
-                        _Value.get(pe.arguments[1]))
-    value = _obj_to_value(result, pe_output_type)
-    _msft.PEOutputOp(value.value)
+  _msft.move_first_block(dummy_op, array)
+  dummy_op.operation.erase()
+
   return array.peOutputs

--- a/frontends/PyCDE/test/systolic_array.py
+++ b/frontends/PyCDE/test/systolic_array.py
@@ -32,7 +32,7 @@ class Top:
       sum = comb.AddOp(r, c)
       return sum.reg(mod.clk)
 
-    pe_outputs = SystolicArray(types.i8, mod.row_data, mod.col_data, pe)
+    pe_outputs = SystolicArray(mod.row_data, mod.col_data, pe)
 
     mod.out = pe_outputs
 

--- a/include/circt-c/Dialect/MSFT.h
+++ b/include/circt-c/Dialect/MSFT.h
@@ -27,6 +27,10 @@ MLIR_CAPI_EXPORTED void mlirMSFTRegisterPasses();
 // Values represented in `MSFT.td`.
 typedef int32_t CirctMSFTPrimitiveType;
 
+// Move the first block in `from` to the first region's last block in `to`.
+MLIR_CAPI_EXPORTED void circtMSFTMoveFirstBlock(MlirOperation from,
+                                                MlirOperation to);
+
 //===----------------------------------------------------------------------===//
 // MSFT Attributes.
 //===----------------------------------------------------------------------===//

--- a/lib/Bindings/Python/MSFTModule.cpp
+++ b/lib/Bindings/Python/MSFTModule.cpp
@@ -133,6 +133,11 @@ void circt::python::populateDialectMSFTSubmodule(py::module &m) {
       .value("DESC", CirctMSFTDirection::DESC)
       .export_values();
 
+  m.def("move_first_block", circtMSFTMoveFirstBlock, py::arg("from"),
+        py::arg("to"),
+        "Move the first block in `from` to the first region's last block in "
+        "`to`.");
+
   mlir_attribute_subclass(m, "PhysLocationAttr",
                           circtMSFTAttributeIsAPhysLocationAttribute)
       .def_classmethod(

--- a/lib/CAPI/Dialect/MSFT.cpp
+++ b/lib/CAPI/Dialect/MSFT.cpp
@@ -28,6 +28,11 @@ void mlirMSFTRegisterPasses() {
   mlir::registerCanonicalizerPass();
   circt::msft::registerMSFTPasses();
 }
+void circtMSFTMoveFirstBlock(MlirOperation from, MlirOperation to) {
+  Block &b = unwrap(from)->getRegion(0).getBlocks().front();
+  b.getParent()->getBlocks().remove(b);
+  unwrap(to)->getRegion(0).getBlocks().push_back(&b);
+}
 
 //===----------------------------------------------------------------------===//
 // PrimitiveDB.


### PR DESCRIPTION
To simplify the ownership model, MLIR core python bindings don't support
building a block before the operation. So we build a dummy operation
first, build the block, construct the array, move the block, then delete
the dummy op. The core MLIR C API doesn't have a region editing API, so
we need to add a specialized one in the MSFT C API.