### PR TITLE
[firtool] verbose-pass-execution should print the final passes.

### DIFF
--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -562,6 +562,9 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
       outputFormat == OutputIRVerilog) {
     PassManager exportPm(&context);
     exportPm.enableTiming(ts);
+    if (verbosePassExecutions)
+      exportPm.addInstrumentation(
+          std::make_unique<FirtoolPassInstrumentation>());
     // Legalize unsupported operations within the modules.
     exportPm.nest<hw::HWModuleOp>().addPass(sv::createHWLegalizeModulesPass());
 


### PR DESCRIPTION
In a recent refactoring, firtool was split into two pass managers, so
we could stop before the "export" passes if any of the "lower" passes
failed. However, this neglected to include adding the
FirtoolPassInstrumentation to the "export" pass manager. This closes
https://github.com/llvm/circt/issues/2854.