### PR TITLE
[FIRRTL] Relax reg reset width checking

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2010,11 +2010,6 @@ LogicalResult RegResetOp::verify() {
     return emitError("type mismatch between register ")
            << regType << " and reset value " << resetType;
 
-  // Truncation on initialisation is banned.
-  if (!isTypeLarger(regType, resetType))
-    return emitError("register ")
-           << regType << " is not as wide as initialiser  " << resetType;
-
   return success();
 }
 

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -114,6 +114,13 @@ firrtl.module @TestDshRL(in %in1 : !firrtl.uint<2>, in %in2: !firrtl.uint<3>) {
   %2 = firrtl.dshlw %in1, %in2 : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<2>
 }
 
+// We allow implicit truncation of a register's reset value.
+// CHECK-LABEL: @RegResetTruncation
+firrtl.module @RegResetTruncation(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %value: !firrtl.bundle<a: uint<2>>, out %out: !firrtl.bundle<a: uint<1>>) {
+  %r2 = firrtl.regreset %clock, %reset, %value  : !firrtl.uint<1>, !firrtl.bundle<a: uint<2>>, !firrtl.bundle<a: uint<1>>
+  firrtl.connect %out, %r2 : !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>
+}
+
 // CHECK-LABEL: @TestNodeName
 firrtl.module @TestNodeName(in %in1 : !firrtl.uint<8>) {
   // CHECK: %n1 = firrtl.node %in1 : !firrtl.uint<8>


### PR DESCRIPTION
The FIRRTL spec specifies that reset value of a register must be the
same width or smaller than the register.  We recently increased the
strictness of this check in https://github.com/llvm/circt/pull/2741.  It turns out that SFC does not implement
this kind of error checking, and by not allowing implicit truncation we
are failing to build some cores which build fine on SFC.  This reverts
the strict width checking.