### PR TITLE
[InferResets] Fix inference for zero-length vectors

### DIFF
--- a/test/Dialect/FIRRTL/infer-resets-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-resets-errors.mlir
@@ -118,7 +118,7 @@ firrtl.circuit "top" {
 // -----
 // Should not allow Vecs to infer different Reset Types
 firrtl.circuit "top" {
-  // expected-error @+2 {{reset network "out[0]" simultaneously connected to async and sync resets}}
+  // expected-error @+2 {{reset network "out[]" simultaneously connected to async and sync resets}}
   // expected-note @+1 {{majority of connections to this reset are async}}
   firrtl.module @top(in %reset0: !firrtl.asyncreset, in %reset1: !firrtl.uint<1>, out %out: !firrtl.vector<reset, 2>) {
     %0 = firrtl.subindex %out[0] : !firrtl.vector<reset, 2>


### PR DESCRIPTION
When tracing resets through the design, the `InferResets` pass always uses the ID of the first vector element if it encounters a vector type. This is done to ensure that connections to an element of a vector affects the type inference of all the other elements too, since the pass can only pick a single reset type for the entire vector instead of individual types for each vector element.

This is problematic since it assumes that all vectors have at least one element, which may not be the case in practice. If such a vector is encountered, the field IDs get out of sync in weird ways if the vector is embedded in a bundle: when the bundle is asked to resolve a field ID to one of its fields, it treats the zero-length vector as actually having zero elements, such that forcibly asking for the first, non-existent element of that vector spills over into the next bundle field.

This commit changes the handling of vectors by always using the vector's self-referential field ID (i.e., the ID 0) to capture connections during reset tracing. Later in type updating, vectors correspondingly assume that a field ID 0 means that the vector element type is to be updated. This is not generally how field refs are supposed to work, but since the ID abuse is limited to this file we should be fine.

Fixes #2857.