### PR TITLE
[HWMemSimImpl] Fix randomization of wide memories

### DIFF
--- a/lib/Dialect/SV/Transforms/HWMemSimImpl.cpp
+++ b/lib/Dialect/SV/Transforms/HWMemSimImpl.cpp
@@ -363,18 +363,11 @@ void HWMemSimImpl::generateMemory(HWModuleOp op, FirMemory mem) {
           if (i > 0)
             rhs.append(", ");
           rhs.append("{`RANDOM}");
-          if (i == 0) {
-            auto rem = mem.dataWidth % randomWidth;
-            if (!rem)
-              continue;
-            if (rem == 1)
-              rhs.append("[0]");
-            else
-              rhs.append(("[" + Twine(rem - 1) + ":0]").str());
-          }
         }
         if (mem.dataWidth > randomWidth)
           rhs.append("}");
+        if (mem.dataWidth % randomWidth != 0)
+          ("[" + Twine(mem.dataWidth - 1) + ":0]").toVector(rhs);
         rhs.append(";");
 
         b.create<sv::VerbatimOp>(

--- a/test/Dialect/SV/hw-memsim.mlir
+++ b/test/Dialect/SV/hw-memsim.mlir
@@ -287,3 +287,9 @@ numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32,maskGran = 8 :ui32, numWri
 // CHECK-LABEL: hw.module @PR2769
 // CHECK-NOT: _GEN
 hw.module.generated @PR2769, @FIRRTLMem(%ro_addr_0: i4, %ro_en_0: i1, %ro_clock_0: i1,%rw_addr_0: i4, %rw_en_0: i1,  %rw_clock_0: i1, %rw_wmode_0: i1, %rw_wdata_0: i16,  %wo_addr_0: i4, %wo_en_0: i1, %wo_clock_0: i1, %wo_data_0: i16) -> (ro_data_0: i16, rw_rdata_0: i16) attributes {depth = 10 : i64, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : ui32, width = 16 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 0 : i32}
+
+// CHECK-LABEL: hw.module @RandomizeWeirdWidths
+// CHECK: sv.ifdef.procedural "RANDOMIZE_MEM_INIT"
+// CHECK-NEXT{LITERAL}: sv.verbatim "{{0}} = {{`RANDOM}, {`RANDOM}, {`RANDOM}, {`RANDOM}, {`RANDOM}}[144:0];"
+// CHECK-NEXT{LITERAL}: sv.verbatim "for (initvar = 0; initvar < 10; initvar = initvar + 1)\0A  Memory[initvar] = {{0}};"
+hw.module.generated @RandomizeWeirdWidths, @FIRRTLMem(%ro_addr_0: i4, %ro_en_0: i1, %ro_clock_0: i1,%rw_addr_0: i4, %rw_en_0: i1,  %rw_clock_0: i1, %rw_wmode_0: i1, %rw_wdata_0: i145, %wo_addr_0: i4, %wo_en_0: i1, %wo_clock_0: i1, %wo_data_0: i145) -> (ro_data_0: i145, rw_rdata_0: i145) attributes {depth = 10 : i64, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 1 : ui32, readLatency = 2 : ui32, readUnderWrite = 0 : ui32, width = 145 : ui32, writeClockIDs = [], writeLatency = 4 : ui32, writeUnderWrite = 0 : i32}


### PR DESCRIPTION
The `HWMemSimImpl` pass currently generates SystemVerilog that some tools cannot parse properly in cases where the memory data width is not a multiple of the random value bit width (32). In those cases the randomization produces:

    reg [33:0] _RANDOM;
    _RANDOM = {{`RANDOM}[1:0], {`RANDOM}};

Some tools do not recognize ``` {`RANDOM}[1:0] ``` as a primary expression and mistake it for being part of the concatenation, only to then complain that this isn't proper concatenation syntax.

This commit changes the randomization code to put the part-select after the overall concatenation, in the hope that most tools will have an easier time identifying `{...}[1:0]` as a primary expression if it appears as the right-hand side of an assignment. This now produces:

    reg [33:0] _RANDOM;
    _RANDOM = {{`RANDOM}, {`RANDOM}}[33:0];