### PR TITLE
[NFC] Change Canonicalization pattern to avoid exponential behavior

### DIFF
--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -737,9 +737,9 @@ hw.module @narrow_extract_from_and(%arg0: i32) -> (o1: i8, o2: i14, o3: i8, o4: 
   %2 = comb.extract %0 from 2 : (i32) -> i14
 
   // CHECK: %0 = comb.extract %arg0 from 4 : (i32) -> i4
-  // CHECK: %1 = comb.concat %c0_i8, %0, %c0_i2 : i8, i4, i2
+  // CHECK: %1 = comb.concat %c0_i3, %0, %false : i3, i4, i1
+  // CHECK: %2 = comb.concat %c0_i8, %0, %c0_i2 : i8, i4, i2
 
-  // CHECK: %2 = comb.concat %c0_i3, %0, %false : i3, i4, i1
   %c42_i32 = hw.constant 42 : i32  // 0b101010
   %3 = comb.and %arg0, %c42_i32 : i32
   %4 = comb.extract %3 from 1 : (i32) -> i8  
@@ -754,7 +754,7 @@ hw.module @narrow_extract_from_and(%arg0: i32) -> (o1: i8, o2: i14, o3: i8, o4: 
   // CHECK: %7 = comb.concat %c0_i4, %6, %c0_i2 : i4, i2, i2
  
   hw.output %1, %2, %4, %6 : i8, i14, i8, i8
-  // CHECK: hw.output %2, %1, %5, %7 : i8, i14, i8, i8
+  // CHECK: hw.output %1, %2, %5, %7 : i8, i14, i8, i8
 }
 
 // CHECK-LABEL: hw.module @fold_mux_tree1


### PR DESCRIPTION
If there were multiple extracts for a value, each one would be visited at least once, durring which it would scan all the others.