### PR TITLE
[FIRRTL] s/RemoveResets/RemoveInvalid/ and Make All Invalids Zero

### DIFF
--- a/test/Dialect/FIRRTL/SFCTests/invalid-interpretations.fir
+++ b/test/Dialect/FIRRTL/SFCTests/invalid-interpretations.fir
@@ -42,3 +42,34 @@ circuit InvalidInterpretations:
     ; Interpretation 4: Invalid is zero otherwise.
     ; CHECK:       assign out_mux = cond ? a : 8'h0;
     ; CHECK-NEXT:  assign out_add = {1'h0, a};
+
+; // -----
+
+; This is checking that an invalid value in another module is not propagated,
+; but is interpreted as "zero".  The end result of this is that the main module
+; should have a register that will be reset to a non-zero value, but is
+; constantly driven to zero by default.
+;
+; See: https://github.com/llvm/circt/issues/2782
+
+; CHECK-LABEL: module InvalidInOtherModule
+circuit InvalidInOtherModule :
+  module InvalidInOtherModule :
+    input clock: Clock
+    input reset: UInt<1>
+    output b: SInt<8>
+
+    inst other of OtherModule
+
+    ; CHECK:      always @(posedge clock)
+    ; CHECK-NEXT:   if (reset)
+    ; CHECK-NEXT:     r <= 8'h4;
+    ; CHECK-NEXT:   else
+    ; CHECK-NEXT:     r <= 8'h0;
+    reg r : SInt<8>, clock with: (reset => (reset, SInt<8>(4)))
+    r <= other.b
+    b <= r
+
+  module OtherModule :
+    output b: SInt<8>
+    b is invalid

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -105,7 +105,7 @@ circuit test_mod : %[[{"a": "a"}]]
 ; MLIR-NEXT:    firrtl.strictconnect %multibitMux_a_1, %vec_1 : !firrtl.uint<1>
 ; MLIR-NEXT:    firrtl.strictconnect %multibitMux_a_2, %vec_2 : !firrtl.uint<1>
 ; MLIR-NEXT:    firrtl.strictconnect %multibitMux_sel, %b : !firrtl.uint<2>
-; MLIR-NEXT:    %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
+; MLIR-NEXT:    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
 ; MLIR-NEXT:    firrtl.instance unusedPortsMod @UnusedPortsMod()
 ; MLIR-NEXT:  }
 


### PR DESCRIPTION
This changes the `RemoveResets` pass to be called `RemoveInvalid`.  It then extends this pass to, after invalid reset initializers are converted to reset-less registers, re-walks each module to convert invalids to constant zero ops.  (Invalid bundles are ignored.)  This is done to incorrectly spotty application of the "invalid is zero" interpretation that was applied during canonicalization.

This is done for SFC-exactness, e.g., to fix #2782.