### PR TITLE
[FIRRTL][NFC] Introduce FConnectLike interface  

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -265,3 +265,14 @@ def FModuleLike : OpInterface<"FModuleLike"> {
   }];
 }
 
+def FConnectLike : OpInterface<"FConnectLike"> {
+  let cppNamespace = "circt::firrtl";
+  let description = "Provide common connection information.";
+
+  let methods = [
+    InterfaceMethod<"Return a destination of connection.",
+    "Value", "dest", (ins)>,
+    InterfaceMethod<"Return a source of connection.",
+    "Value", "src", (ins)>,
+  ];
+}

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -21,7 +21,7 @@ def AttachOp : FIRRTLOp<"attach"> {
   let hasCanonicalizeMethod = true;
 }
 
-def ConnectOp : FIRRTLOp<"connect"> {
+def ConnectOp : FIRRTLOp<"connect", [FConnectLike]> {
   let summary = "Connect two signals";
   let description = [{
     Connect Operation:
@@ -59,7 +59,7 @@ def PartialConnectOp : FIRRTLOp<"partialconnect"> {
     "$dest `,` $src  attr-dict `:` qualified(type($dest)) `,` qualified(type($src))";
 }
 
-def StrictConnectOp : FIRRTLOp<"strictconnect", [SameTypeOperands]> {
+def StrictConnectOp : FIRRTLOp<"strictconnect", [SameTypeOperands, FConnectLike]> {
   let summary = "Connect two signals";
   let description =  [{
     Connect two values with strict constraints:

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1916,18 +1916,7 @@ FirMemory MemOp::getSummary() {
           continue;
         auto clockPort = a->getResult(0);
         for (auto *b : clockPort.getUsers()) {
-          if (auto connect = dyn_cast<ConnectOp>(b)) {
-            if (connect.dest() == clockPort) {
-              auto result =
-                  clockToLeader.insert({connect.src(), numWritePorts});
-              if (result.second) {
-                writeClockIDs.push_back(numWritePorts);
-              } else {
-                writeClockIDs.push_back(result.first->second);
-              }
-            }
-          }
-          if (auto connect = dyn_cast<StrictConnectOp>(b)) {
+          if (auto connect = dyn_cast<FConnectLike>(b)) {
             if (connect.dest() == clockPort) {
               auto result =
                   clockToLeader.insert({connect.src(), numWritePorts});

--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -126,17 +126,13 @@ public:
   /// Get the destination value from a connection.  This supports any operation
   /// which is capable of driving a value.
   static Value getDestinationValue(Operation *op) {
-    if (auto connect = dyn_cast<ConnectOp>(op))
-      return connect.dest();
-    return cast<StrictConnectOp>(op).dest();
+    return cast<FConnectLike>(op).dest();
   }
 
   /// Get the source value from a connection. This supports any operation which
   /// is capable of driving a value.
   static Value getConnectedValue(Operation *op) {
-    if (auto connect = dyn_cast<ConnectOp>(op))
-      return connect.src();
-    return cast<StrictConnectOp>(op).src();
+    return cast<FConnectLike>(op).src();
   }
 
   /// For every leaf field in the sink, record that it exists and should be

--- a/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
@@ -200,9 +200,9 @@ private:
   // Get the source value which is connected to the dst.
   Value getConnectSrc(Value dst) {
     for (auto *c : dst.getUsers())
-      if (isa<StrictConnectOp, ConnectOp>(c))
-        if (c->getOperand(0) == dst)
-          return c->getOperand(1);
+      if (auto connect = dyn_cast<FConnectLike>(c))
+        if (connect.dest() == dst)
+          return connect.src();
 
     return nullptr;
   }

--- a/lib/Dialect/FIRRTL/Transforms/RemoveResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/RemoveResets.cpp
@@ -37,13 +37,7 @@ static bool isInvalid(Value val) {
   // this pass runs after `ExpandWhens`.
   auto updateVal = [&](Value thisVal) {
     for (auto *user : thisVal.getUsers()) {
-      if (auto connect = dyn_cast<ConnectOp>(user)) {
-        if (connect.dest() != val)
-          continue;
-        val = connect.src();
-        return;
-      }
-      if (auto connect = dyn_cast<StrictConnectOp>(user)) {
+      if (auto connect = dyn_cast<FConnectLike>(user)) {
         if (connect.dest() != val)
           continue;
         val = connect.src();


### PR DESCRIPTION
This PR introduces `FConnectLike` interface to wrap ConnectOp and StrictConnectOp.
`FConnectLike` interface provides `src` and `dest` methods. This will reduce code duplication related to StrictConnectOp.   