### PR TITLE
[FIRRTL] Use NLATable analysis for Dedup Pass

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -218,6 +218,13 @@ def NonLocalAnchor : FIRRTLOp<"nla",
     /// Return true if any update is made.
     bool updateModule(StringAttr oldMod, StringAttr newMod);
 
+    /// Replace the oldMod module with newMod module in the namepath of the NLA.
+    /// Since the module is being updated, the symbols inside the module should
+    /// also be renamed. Use the rename Map to update the corresponding 
+    /// inner_sym names in the namepath. Return true if any update is made.
+    bool updateModuleAndInnerRef(StringAttr oldMod, StringAttr newMod,
+         const llvm::DenseMap<StringAttr, StringAttr> &innerSymRenameMap);
+
     /// Truncate the namepath for this NLA, at atMod module.
     /// If includeMod is false, drop atMod and beyond, else include it and drop
     /// everything after it.

--- a/include/circt/Dialect/FIRRTL/NLATable.h
+++ b/include/circt/Dialect/FIRRTL/NLATable.h
@@ -48,6 +48,7 @@ public:
 
   /// Remove the NLA from the analysis.
   void erase(NonLocalAnchor nlaOp);
+
   //===-------------------------------------------------------------------------
   // Methods to keep an NLATable up to date.
   //

--- a/include/circt/Dialect/FIRRTL/NLATable.h
+++ b/include/circt/Dialect/FIRRTL/NLATable.h
@@ -43,6 +43,11 @@ public:
   /// Resolve a symbol to a Module
   FModuleLike getModule(StringAttr name);
 
+  /// Insert a new NLA.
+  void insert(NonLocalAnchor nlaOp);
+
+  /// Remove the NLA from the analysis.
+  void erase(NonLocalAnchor nlaOp);
   //===-------------------------------------------------------------------------
   // Methods to keep an NLATable up to date.
   //
@@ -67,6 +72,14 @@ public:
   // Rename a module, this updates the name to module tracking and the name to
   // NLA tracking.
   void renameModule(StringAttr oldModName, StringAttr newModName);
+
+  // Replace the module oldModName with newModName in the namepath of any NLA.
+  // Since the module is being updated, the symbols inside the module should
+  // also be renamed. Use the rename map to update the inner_sym names in the
+  // namepath.
+  void renameModuleAndInnerRef(
+      StringAttr newModName, StringAttr oldModName,
+      const DenseMap<StringAttr, StringAttr> &innerSymRenameMap);
 
 private:
   NLATable(const NLATable &) = delete;

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3472,6 +3472,38 @@ bool NonLocalAnchor::updateModule(StringAttr oldMod, StringAttr newMod) {
   return updateMade;
 }
 
+bool NonLocalAnchor::updateModuleAndInnerRef(
+    StringAttr oldMod, StringAttr newMod,
+    const llvm::DenseMap<StringAttr, StringAttr> &innerSymRenameMap) {
+  auto fromRef = FlatSymbolRefAttr::get(oldMod);
+
+  auto namepathNew = namepath().getValue().vec();
+  bool updateMade = false;
+  // Break from the loop if the module is found, since it can occur only once.
+  for (auto &element : namepathNew) {
+    if (auto innerRef = element.dyn_cast<hw::InnerRefAttr>()) {
+      if (innerRef.getModule() != oldMod)
+        continue;
+      // Since the module got updated, the old innerRef symbol inside oldMod
+      // should also be updated to the new symbol inside the newMod.
+      auto to = innerSymRenameMap.find(innerRef.getName());
+      assert(to != innerSymRenameMap.end() && "should have been renamed");
+      updateMade = true;
+      element = hw::InnerRefAttr::get(newMod, to->second);
+      break;
+    }
+    if (element != fromRef)
+      continue;
+
+    updateMade = true;
+    element = FlatSymbolRefAttr::get(newMod);
+    break;
+  }
+  if (updateMade)
+    namepathAttr(ArrayAttr::get(getContext(), namepathNew));
+  return updateMade;
+}
+
 bool NonLocalAnchor::truncateAtModule(StringAttr atMod, bool includeMod) {
   SmallVector<Attribute, 4> newPath;
   bool updateMade = false;

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3484,12 +3484,14 @@ bool NonLocalAnchor::updateModuleAndInnerRef(
     if (auto innerRef = element.dyn_cast<hw::InnerRefAttr>()) {
       if (innerRef.getModule() != oldMod)
         continue;
+      auto symName = innerRef.getName();
       // Since the module got updated, the old innerRef symbol inside oldMod
       // should also be updated to the new symbol inside the newMod.
-      auto to = innerSymRenameMap.find(innerRef.getName());
-      assert(to != innerSymRenameMap.end() && "should have been renamed");
+      auto to = innerSymRenameMap.find(symName);
+      if (to != innerSymRenameMap.end())
+        symName = to->second;
       updateMade = true;
-      element = hw::InnerRefAttr::get(newMod, to->second);
+      element = hw::InnerRefAttr::get(newMod, symName);
       break;
     }
     if (element != fromRef)

--- a/lib/Dialect/FIRRTL/NLATable.cpp
+++ b/lib/Dialect/FIRRTL/NLATable.cpp
@@ -66,7 +66,6 @@ void NLATable::erase(NonLocalAnchor nla) {
     } else if (auto inr = ent.dyn_cast<hw::InnerRefAttr>())
       removeNLAfromList(nodeMap[inr.getModule()]);
   }
-  nla.erase();
 }
 
 void NLATable::renameModule(StringAttr oldModName, StringAttr newModName) {

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -15,6 +15,7 @@
 #include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
+#include "circt/Dialect/FIRRTL/NLATable.h"
 #include "circt/Dialect/FIRRTL/Namespace.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/HW/HWAttributes.h"
@@ -33,19 +34,6 @@
 using namespace circt;
 using namespace firrtl;
 using hw::InnerRefAttr;
-
-/// This stores a mapping from a module name to every NLA that it particiapates
-/// in.
-using NLAMap = DenseMap<Attribute, std::vector<NonLocalAnchor>>;
-
-NLAMap createNLAMap(CircuitOp circuit) {
-  NLAMap nlaMap;
-  for (auto nla : circuit.getBody()->getOps<NonLocalAnchor>()) {
-    for (size_t i = 0, e = nla.namepath().size(); i != e; ++i)
-      nlaMap[nla.modPart(i)].push_back(nla);
-  }
-  return nlaMap;
-}
 
 //===----------------------------------------------------------------------===//
 // Hashing
@@ -560,9 +548,10 @@ struct Deduper {
   using RenameMap = DenseMap<StringAttr, StringAttr>;
 
   Deduper(InstanceGraph &instanceGraph, SymbolTable &symbolTable,
-          NLAMap &nlaMap, CircuitOp circuit)
+          NLATable *nlaTable, CircuitOp circuit)
       : context(circuit->getContext()), instanceGraph(instanceGraph),
-        symbolTable(symbolTable), nlaMap(nlaMap), nlaBlock(circuit.getBody()),
+        symbolTable(symbolTable), nlaTable(nlaTable),
+        nlaBlock(circuit.getBody()),
         nonLocalString(StringAttr::get(context, "circt.nonlocal")),
         classString(StringAttr::get(context, "class")) {}
 
@@ -676,9 +665,7 @@ private:
       auto nlaName = nla.getNameAttr();
       auto nlaRef = FlatSymbolRefAttr::get(nlaName);
       nlas.push_back(nlaRef);
-      // Make sure we update the NLAMap if the toModule gets deduped later.
-      nlaMap[toModuleName].push_back(nla);
-      nlaMap[parent.getNameAttr()].push_back(nla);
+      nlaTable->insert(nla);
       targetMap[nlaName] = to;
       // Update the instance breadcrumbs.
       auto nonLocalClass = NamedAttribute(classString, nonLocalString);
@@ -740,30 +727,6 @@ private:
     }
   }
 
-  /// This finds all NLAs which contain the "from" module, and renames any
-  /// reference to the "to" module.
-  void renameModuleInNLA(DenseMap<StringAttr, StringAttr> &renameMap,
-                         StringAttr toName, StringAttr fromName,
-                         NonLocalAnchor nla) {
-    auto fromRef = FlatSymbolRefAttr::get(fromName);
-    SmallVector<Attribute> namepath;
-    for (auto element : nla.namepath()) {
-      if (auto innerRef = element.dyn_cast<InnerRefAttr>()) {
-        if (innerRef.getModule() == fromName) {
-          auto to = renameMap[innerRef.getName()];
-          assert(to && "should have been renamed");
-          namepath.push_back(InnerRefAttr::get(toName, to));
-        } else
-          namepath.push_back(element);
-      } else if (element == fromRef) {
-        namepath.push_back(FlatSymbolRefAttr::get(toName));
-      } else {
-        namepath.push_back(element);
-      }
-    }
-    nla.namepathAttr(ArrayAttr::get(context, namepath));
-  }
-
   /// This erases the NLA op, all breadcrumb trails, and removes the NLA from
   /// every module's NLA map, but it does not delete the NLA reference from
   /// the target operation's annotations.
@@ -776,7 +739,6 @@ private:
     for (auto attr : namepath.drop_back()) {
       auto innerRef = attr.cast<InnerRefAttr>();
       auto moduleName = innerRef.getModule();
-      llvm::erase_value(nlaMap[moduleName], nla);
       // Find the instance referenced by the NLA.
       auto *node = instanceGraph.lookup(moduleName);
       auto targetInstanceName = innerRef.getName();
@@ -793,9 +755,8 @@ private:
       instAnnos.applyToOperation(inst);
     }
     // Erase the NLA from the leaf module's nlaMap.
-    llvm::erase_value(nlaMap[nla.leafMod()], nla);
     targetMap.erase(nla.getNameAttr());
-    nla->erase();
+    nlaTable->erase(nla);
   }
 
   /// Process all NLAs referencing the "from" module to point to the "to"
@@ -806,11 +767,10 @@ private:
     auto fromName = fromModule.getNameAttr();
     // Create a copy of the current NLAs. We will be pushing and removing
     // NLAs from this op as we go.
-    auto nlas = nlaMap[fromModule.getNameAttr()];
+    auto nlas = nlaTable->lookup(fromModule.getNameAttr()).vec();
+    // Change the NLA to target the toModule.
+    nlaTable->renameModuleAndInnerRef(toName, fromName, renameMap);
     for (auto nla : nlas) {
-      // Change the NLA to target the toModule.
-      if (toModule != fromModule)
-        renameModuleInNLA(renameMap, toName, fromName, nla);
       auto elements = nla.namepath().getValue();
       // If we don't need to add more context, we're done here.
       if (nla.root() != toName)
@@ -858,8 +818,7 @@ private:
   // "toName".
   void rewriteExtModuleNLAs(RenameMap &renameMap, StringAttr toName,
                             StringAttr fromName) {
-    for (auto nla : nlaMap[fromName])
-      renameModuleInNLA(renameMap, toName, fromName, nla);
+    nlaTable->renameModuleAndInnerRef(toName, fromName, renameMap);
   }
 
   /// Take an annotation, and update it to be a non-local annotation.  If the
@@ -1099,9 +1058,8 @@ private:
   InstanceGraph &instanceGraph;
   SymbolTable &symbolTable;
 
-  // This maps a module name to all NLAs it participates in. This is used to
-  // fixup any NLAs when a module is deduped.
-  NLAMap &nlaMap;
+  /// Cached nla table analysis.
+  NLATable *nlaTable = nullptr;
 
   /// We insert all NLAs to the beginning of this block.
   Block *nlaBlock;
@@ -1246,9 +1204,9 @@ class DedupPass : public DedupBase<DedupPass> {
     auto *context = &getContext();
     auto circuit = getOperation();
     auto &instanceGraph = getAnalysis<InstanceGraph>();
+    auto *nlaTable = &getAnalysis<NLATable>();
     SymbolTable symbolTable(circuit);
-    NLAMap nlaMap = createNLAMap(circuit);
-    Deduper deduper(instanceGraph, symbolTable, nlaMap, circuit);
+    Deduper deduper(instanceGraph, symbolTable, nlaTable, circuit);
     StructuralHasher hasher(&getContext());
     Equivalence equiv(context, instanceGraph);
     auto anythingChanged = false;

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -757,6 +757,7 @@ private:
     // Erase the NLA from the leaf module's nlaMap.
     targetMap.erase(nla.getNameAttr());
     nlaTable->erase(nla);
+    symbolTable.erase(nla);
   }
 
   /// Process all NLAs referencing the "from" module to point to the "to"


### PR DESCRIPTION
Add a few utilities to the `NLATable` analysis, and use the analysis for `Dedup` pass, instead of using the `NLAMap`. 
This is a first step towards removing the NLA breadcrumbs on `InstanceOps`.