### PR TITLE
[FIRParser] Default chisel3 asserts to `ifElseFatal`

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParserAsserts.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParserAsserts.cpp
@@ -434,13 +434,11 @@ ParseResult circt::firrtl::foldWhenEncodedVerifOp(PrintFOp printOp) {
   }
 
     // Handle the case of builtin Chisel assertions.
-    //
-    // These are historically emitted as non-concurrent assertions but we choose
-    // to treat them as concurrent.
   case VerifFlavor::ChiselAssert: {
-    builder.create<AssertOp>(
+    auto op = builder.create<AssertOp>(
         printOp.clock(), builder.create<NotPrimOp>(whenStmt.condition()),
         printOp.cond(), fmt, printOp.operands(), "chisel3_builtin", true);
+    op->setAttr("format", StringAttr::get(context, "ifElseFatal"));
     printOp.erase();
     break;
   }

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -981,6 +981,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       stop(clock, enable, 1)
     ; CHECK: [[TMP:%.+]] = firrtl.not %cond
     ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Assertion failed with value %d"(%value) : !firrtl.uint<42>
+    ; CHECK-SAME: format = "ifElseFatal"
     ; CHECK-SAME: isConcurrent = true
     ; CHECK-SAME: name = "chisel3_builtin"
 
@@ -989,6 +990,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       stop(clock, enable, 1)
     ; CHECK: [[TMP:%.+]] = firrtl.not %cond
     ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Assertion failed: some message with value %d"(%value) : !firrtl.uint<42>
+    ; CHECK-SAME: format = "ifElseFatal"
     ; CHECK-SAME: isConcurrent = true
     ; CHECK-SAME: name = "chisel3_builtin"
 
@@ -1048,6 +1050,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK-NOT: firrtl.assert %clock, %cond, %enable, "hello"
     ; CHECK: [[TMP:%.+]] = firrtl.not %not_cond
     ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Assertion failed: hello"
+    ; CHECK-SAME: format = "ifElseFatal"
     ; CHECK-SAME: name = "chisel3_builtin"
 
     when not_reset:
@@ -1059,6 +1062,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK-NOT: firrtl.assert %clock, %cond, %enable, "hello outside reset"
     ; CHECK: [[TMP:%.+]] = firrtl.not %not_cond2
     ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Assertion failed: hello outside reset"
+    ; CHECK-SAME: format = "ifElseFatal"
     ; CHECK-SAME: name = "chisel3_builtin"
     ; CHECK: }
 


### PR DESCRIPTION
In SFC, these `chisel3_builtin` asserts default to the `ifElseFatal`
format.  We previously thought that we could emit these in a simpler
format, but it is missing the wrapper which checks `ASSERT_VERBOSE_CONDITION`.
This macro is used to prevent assertions from triggering when the test
bench is reseting.  Without guarding the assertion on this value, we are
getting some spurious failures when the first reset has run.