### PR TITLE
[cmake] Configure policy CMP0116

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,12 @@ if(POLICY CMP0077)
   cmake_policy(SET CMP0077 NEW)
 endif()
 
+# CMP0116: Ninja generators transform `DEPFILE`s from `add_custom_command()`
+# New in CMake 3.20. https://cmake.org/cmake/help/latest/policy/CMP0116.html
+if(POLICY CMP0116)
+  cmake_policy(SET CMP0116 OLD)
+endif()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
@@ -38,11 +44,11 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
 # Project setup and globals
 #-------------------------------------------------------------------------------
   project(circt LANGUAGES CXX C)
-  
+
 #-------------------------------------------------------------------------------
 # Options and settings
 #-------------------------------------------------------------------------------
-  
+
   option(LLVM_INCLUDE_TOOLS "Generate build targets for the LLVM tools." ON)
   option(LLVM_BUILD_TOOLS "Build the LLVM tools. If OFF, just generate build targets." ON)
 
@@ -51,22 +57,22 @@ if (MSVC)
 else ()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions -fno-rtti")
 endif ()
-  
+
 #-------------------------------------------------------------------------------
 # MLIR/LLVM Configuration
 #-------------------------------------------------------------------------------
-  
+
   find_package(MLIR REQUIRED CONFIG)
-  
+
   message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
   message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
-  
+
   set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
   set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
-  
+
   list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
   list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
-  
+
   include(TableGen)
   include(AddLLVM)
   include(AddMLIR)


### PR DESCRIPTION
  CMake 3.20 will result in many warnings on this policy.
  This commit silence it with the use of 'old' behaviour.
  And CMake 3.23 does warn it and simple use 'old' behaviour.
  Probably we can remove this when minimal cmake version up to 3.23.


-----

Currently the cmake I use is 3.20.3 and it raise many warnings follow

```
CMake Warning (dev) at llvm/llvm/cmake/modules/TableGen.cmake:94 (add_custom_command):
  Policy CMP0116 is not set: Ninja generators transform DEPFILEs from
  add_custom_command().  Run "cmake --help-policy CMP0116" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.
Call Stack (most recent call first):
  llvm/build/lib/cmake/mlir/AddMLIR.cmake:2 (tablegen)
  llvm/build/lib/cmake/mlir/AddMLIR.cmake:13 (mlir_tablegen)
  cmake/modules/AddCIRCT.cmake:4 (add_mlir_dialect)
  include/circt/Dialect/StaticLogic/CMakeLists.txt:1 (add_circt_dialect)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

also find the issue about CMP0116 [issue_link](https://github.com/llvm/circt/issues/849)
But CMP0115 wanring don't occur.
Solve it just like llvm does in [D101083](https://reviews.llvm.org/D101083)