### PR TITLE
[Comb] Fix an edge case of the interval canonicalizer

### DIFF
--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -1182,7 +1182,11 @@ static bool tryMergeRanges(OrOp op, PatternRewriter &rewriter) {
   for (auto &&op : newOperands)
     newInputs.push_back(op);
 
-  if (newInputs.size() == 1)
+  if (newInputs.empty()) {
+    // If newInputs is empty, the result is true since the interval covers all
+    // and nothing is kept to newInputs.
+    rewriter.replaceOpWithNewOp<hw::ConstantOp>(op, rewriter.getI1Type(), true);
+  } else if (newInputs.size() == 1)
     rewriter.replaceOp(op, newInputs[0]);
   else
     rewriter.replaceOpWithNewOp<OrOp>(op, op.getType(), newInputs);

--- a/test/Dialect/HW/hw-ranges.mlir
+++ b/test/Dialect/HW/hw-ranges.mlir
@@ -190,3 +190,19 @@ hw.module @merge_with_upper_bound(%arg: i4) -> (cond: i1) {
 
   hw.output %in_range : i1
 }
+
+// CHECK-LABEL: @merge_range_covers_all
+// CHECK-NEXT: [[CST:%.+]] = hw.constant true
+// CHECK-NEXT: hw.output [[CST]] : i1
+hw.module @merge_range_covers_all(%0: i2) -> (a:i1) {
+  %c-1_i2 = hw.constant -1 : i2
+  %c0_i2 = hw.constant 0 : i2
+  %c-2_i2 = hw.constant -2 : i2
+  %c1_i2 = hw.constant 1 : i2
+  %1 = comb.icmp eq %0, %c-2_i2  : i2
+  %2 = comb.icmp eq %0, %c0_i2 : i2
+  %4 = comb.icmp eq %0, %c-1_i2 : i2
+  %5 = comb.icmp eq %0, %c1_i2 : i2
+  %6 = comb.or %1, %2, %4, %5 : i1
+  hw.output %6: i1
+}


### PR DESCRIPTION
This commit fixes a bug of the canonicalizer when
the interval is the same as the integer domain.
Fox example, let `a` be an i2 integer, then we can
canonicalize in the following way:
```
(a==0) or (a==1) or (a==2) or (a==3) ==> true
```