### PR TITLE
[ExportVerilog] Inline StructExtract

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -138,7 +138,7 @@ static bool isDuplicatableExpression(Operation *op) {
     return isDuplicatableNullaryExpression(op);
 
   // It is cheap to inline extract op.
-  if (isa<comb::ExtractOp>(op))
+  if (isa<comb::ExtractOp, hw::StructExtractOp>(op))
     return true;
 
   // We only inline array_get with a constant index.

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -658,6 +658,14 @@ hw.module @StructExtractExtract(%a: !hw.struct<b: i4>) -> (r: i2) {
   hw.output %1 : i2
 }
 
+// CHECK-LABEL: StrurctExtractInline
+hw.module @StrurctExtractInline(%a: !hw.struct<v: i1>) -> (b: i1, c: i1) {
+  %0 = hw.struct_extract %a["v"] : !hw.struct<v: i1>
+  // CHECK:      assign b = a.v;
+  // CHECK-NEXT: assign c = a.v;
+  hw.output %0, %0 : i1, i1
+}
+
 hw.module.extern @DifferentResultMod() -> (out1: i1, out2: i2)
 
 // CHECK-LABEL: module out_of_order_multi_result(


### PR DESCRIPTION
This is cherry-picked from https://github.com/llvm/circt/pull/2611

This commit allows struct_extract ops to be inlined even when they have multiple uses. It will make the output more readable.

For the following IR:
```mlir
hw.module @Foo(%a: !hw.struct<v: i1>) -> (b: i1, c: i1) {
  %0 = hw.struct_extract %a["v"] : !hw.struct<v: i1>
  hw.output %0, %0 : i1, i1
}
```

Before:
```verilog
  wire _GEN = a.v;      // bar.fir:7:12
  assign b = _GEN;      // bar.fir:2:10
  assign c = _GEN;      // bar.fir:2:10
```
After:
```verilog
  assign b = a.v;       // bar.fir:2:10, :7:12
  assign c = a.v;       // bar.fir:2:10, :7:12
```
