### PR TITLE
[FIRRTL] Use NLATable analysis in LowerTypes and GrandCentral

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -14,6 +14,7 @@
 #include "circt/Dialect/FIRRTL/AnnotationDetails.h"
 #include "circt/Dialect/FIRRTL/FIRRTLAttributes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
+#include "circt/Dialect/FIRRTL/NLATable.h"
 #include "circt/Dialect/FIRRTL/Namespace.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/HW/HWAttributes.h"
@@ -569,8 +570,7 @@ private:
   /// based on a PrefixInterfacesAnnotation.
   StringRef interfacePrefix;
 
-  /// Map of NLA symbol to NLA.
-  DenseMap<StringAttr, NonLocalAnchor> nlaMap;
+  NLATable *nlaTable;
 
   /// The set of NLAs that are dead after this pass.  These will be removed
   /// before the pass finishes.
@@ -795,7 +795,7 @@ bool GrandCentralPass::traverseField(Attribute field, IntegerAttr id,
         auto [fieldRef, sym] = leafMap.lookup(ground.getID());
         NonLocalAnchor nla;
         if (sym)
-          nla = nlaMap[sym.getAttr()];
+          nla = nlaTable->getNLA(sym.getAttr());
         Value leafValue = fieldRef.getValue();
         unsigned fieldID = fieldRef.getFieldID();
         assert(leafValue && "leafValue not found");
@@ -1322,9 +1322,7 @@ void GrandCentralPass::runOnOperation() {
     }
   };
 
-  /// Populate the NLA map with Symbol -> NLA.
-  for (NonLocalAnchor nla : circuitOp.getBody()->getOps<NonLocalAnchor>())
-    nlaMap.insert({nla.sym_nameAttr(), nla});
+  nlaTable = &getAnalysis<NLATable>();
 
   /// Walk the circuit and extract all information related to scattered
   /// Grand Central annotations.  This is used to populate: (1) the
@@ -1775,7 +1773,7 @@ void GrandCentralPass::runOnOperation() {
     // Remove NLA operations.
     if (auto nla = dyn_cast<NonLocalAnchor>(op)) {
       if (deadNLAs.count(nla.sym_nameAttr()))
-        nla.erase();
+        nlaTable->erase(nla);
       continue;
     }
 

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -1767,13 +1767,16 @@ void GrandCentralPass::runOnOperation() {
   }
 
   // Garbage collect dead NLAs.
+  auto symTable = getSymbolTable();
   for (auto &op :
        llvm::make_early_inc_range(circuitOp.getBody()->getOperations())) {
 
     // Remove NLA operations.
     if (auto nla = dyn_cast<NonLocalAnchor>(op)) {
-      if (deadNLAs.count(nla.sym_nameAttr()))
+      if (deadNLAs.count(nla.sym_nameAttr())) {
         nlaTable->erase(nla);
+        symTable.erase(nla);
+      }
       continue;
     }
 

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -1800,6 +1800,7 @@ void GrandCentralPass::runOnOperation() {
   // annotations.
   if (removalError)
     return signalPassFailure();
+  markAnalysesPreserved<NLATable>();
 }
 
 StringAttr GrandCentralPass::getOrAddInnerSym(Operation *op) {

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -33,6 +33,7 @@
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
 #include "circt/Dialect/FIRRTL/FIRRTLVisitors.h"
+#include "circt/Dialect/FIRRTL/NLATable.h"
 #include "circt/Dialect/FIRRTL/Namespace.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/HW/HWAttributes.h"
@@ -1301,7 +1302,7 @@ struct LowerTypesPass : public LowerFIRRTLTypesBase<LowerTypesPass> {
 void LowerTypesPass::runOnOperation() {
   std::vector<FModuleLike> ops;
   // Map of name of the NonLocalAnchor to the operation.
-  DenseMap<StringAttr, Operation *> nlaMap;
+  // DenseMap<StringAttr, Operation *> nlaMap;
   // Symbol Table
   SymbolTable symTbl(getOperation());
   // Cached attr
@@ -1312,10 +1313,8 @@ void LowerTypesPass::runOnOperation() {
     // Creating a map of all ops in the circt, but only modules are relevant.
     if (auto module = dyn_cast<FModuleLike>(op))
       ops.push_back(module);
-    // Record the NonLocalAnchor and its name.
-    if (auto nla = dyn_cast<NonLocalAnchor>(op))
-      nlaMap[nla.sym_nameAttr()] = nla;
   });
+  auto *nlaTable = &getAnalysis<NLATable>();
 
   // Lower each module and return a list of Nlas which need to be updated with
   // the new symbol names.
@@ -1432,10 +1431,9 @@ void LowerTypesPass::runOnOperation() {
     // if we have already processed the NLA once. nlaToNewSymList can have
     // duplicate entries for an NLA, since an NLA can be reused by multiple
     // bundle subfields.
-    auto iter = nlaMap.find(nlaName);
-    if (iter == nlaMap.end())
+    auto nla = nlaTable->getNLA(nlaName);
+    if (!nla)
       continue;
-    auto nla = cast<NonLocalAnchor>(iter->second);
     // Update the final element, which must be an InnerRefAttr.
     if (nlaToSym.newSym) {
       auto namepath = nla.namepath();
@@ -1451,6 +1449,7 @@ void LowerTypesPass::runOnOperation() {
         auto newNLAop = theBuilder.create<NonLocalAnchor>(
             circtNamespace.newName(nlaName.getValue()), newPath);
         updateNamepath(newNLAop, nlaName, false);
+        nlaTable->insert(newNLAop);
       } else
         nla.namepathAttr(newPath);
     } else if (nlaName != prevNLA)
@@ -1473,7 +1472,7 @@ void LowerTypesPass::runOnOperation() {
     // references to the nla from the InstanceOps and erase the NLA.
     auto nla = cast<NonLocalAnchor>(nlaOp);
     updateNamepath(nla, nla.getNameAttr(), true);
-    nla->erase();
+    nlaTable->erase(nla);
   }
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -1301,8 +1301,6 @@ struct LowerTypesPass : public LowerFIRRTLTypesBase<LowerTypesPass> {
 // This is the main entrypoint for the lowering pass.
 void LowerTypesPass::runOnOperation() {
   std::vector<FModuleLike> ops;
-  // Map of name of the NonLocalAnchor to the operation.
-  // DenseMap<StringAttr, Operation *> nlaMap;
   // Symbol Table
   SymbolTable symTbl(getOperation());
   // Cached attr
@@ -1473,6 +1471,7 @@ void LowerTypesPass::runOnOperation() {
     auto nla = cast<NonLocalAnchor>(nlaOp);
     updateNamepath(nla, nla.getNameAttr(), true);
     nlaTable->erase(nla);
+    symTbl.erase(nla);
   }
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -1473,6 +1473,7 @@ void LowerTypesPass::runOnOperation() {
     nlaTable->erase(nla);
     symTbl.erase(nla);
   }
+  markAnalysesPreserved<NLATable>();
 }
 
 /// This is the pass constructor.


### PR DESCRIPTION
Use NLATable analysis in LowerTypes and GrandCentral.
This is a continuation of https://github.com/llvm/circt/pull/2874, and shares the analysis commit with it.