### PR TITLE
[FIRRTL][Dedup] enhance error messages for dedup failures

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -105,6 +105,7 @@ private:
 
   void update(TypeID typeID) { update(typeID.getAsOpaquePointer()); }
 
+  // NOLINTNEXTLINE(misc-no-recursion)
   void update(BundleType type) {
     update(type.getTypeID());
     for (auto &element : type.getElements()) {
@@ -113,6 +114,7 @@ private:
     }
   }
 
+  // NOLINTNEXTLINE(misc-no-recursion)
   void update(Type type) {
     if (auto bundle = type.dyn_cast<BundleType>())
       return update(bundle);
@@ -219,6 +221,7 @@ struct Equivalence {
     nonessentialAttributes.insert(StringAttr::get(context, "inner_sym"));
   }
 
+  // NOLINTNEXTLINE(misc-no-recursion)
   LogicalResult check(InFlightDiagnostic &diag, const Twine &message,
                       Operation *a, BundleType aType, Operation *b,
                       BundleType bType) {
@@ -307,7 +310,8 @@ struct Equivalence {
       diag.attachNote(aIt->getLoc()) << "first block has more operations";
       diag.attachNote(b->getLoc()) << "second block here";
       return failure();
-    } else if (bIt != bEnd) {
+    }
+    if (bIt != bEnd) {
       diag.attachNote(bIt->getLoc()) << "second block has more operations";
       diag.attachNote(a->getLoc()) << "first block here";
       return failure();
@@ -417,6 +421,7 @@ struct Equivalence {
     return success();
   }
 
+  // NOLINTNEXTLINE(misc-no-recursion)
   LogicalResult check(InFlightDiagnostic &diag, InstanceOp a, InstanceOp b) {
     auto aName = a.moduleNameAttr().getAttr();
     auto bName = b.moduleNameAttr().getAttr();
@@ -440,6 +445,7 @@ struct Equivalence {
     return success();
   }
 
+  // NOLINTNEXTLINE(misc-no-recursion)
   LogicalResult check(InFlightDiagnostic &diag, BlockAndValueMapping &map,
                       Operation *a, Operation *b) {
     // Operation name.
@@ -517,6 +523,7 @@ struct Equivalence {
     return success();
   }
 
+  // NOLINTNEXTLINE(misc-no-recursion)
   void check(InFlightDiagnostic &diag, Operation *a, Operation *b) {
     BlockAndValueMapping map;
     if (failed(check(diag, map, a, b)))

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLAttributes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
@@ -18,7 +19,9 @@
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Support/LLVM.h"
+#include "mlir/IR/BlockAndValueMapping.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/Support/LogicalResult.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/DepthFirstIterator.h"
@@ -116,9 +119,7 @@ private:
     update(type.getAsOpaquePointer());
   }
 
-  void update(BlockArgument arg) {
-    indexes[arg] = currentIndex++;
-  }
+  void update(BlockArgument arg) { indexes[arg] = currentIndex++; }
 
   void update(OpResult result) {
     indexes[result] = currentIndex++;
@@ -196,6 +197,339 @@ private:
   // This is the actual running hash calculation. This is a stateful element
   // that should be reinitialized after each hash is produced.
   llvm::SHA256 sha;
+};
+
+//===----------------------------------------------------------------------===//
+// Equivalence
+//===----------------------------------------------------------------------===//
+
+/// This class is for reporting differences between two modules which should
+/// have been deduplicated.
+struct Equivalence {
+  Equivalence(MLIRContext *context, InstanceGraph &instanceGraph)
+      : instanceGraph(instanceGraph) {
+    portTypesAttr = StringAttr::get(context, "portTypes");
+    nonessentialAttributes.insert(StringAttr::get(context, "annotations"));
+    nonessentialAttributes.insert(StringAttr::get(context, "name"));
+    nonessentialAttributes.insert(StringAttr::get(context, "portAnnotations"));
+    nonessentialAttributes.insert(StringAttr::get(context, "portNames"));
+    nonessentialAttributes.insert(StringAttr::get(context, "portTypes"));
+    nonessentialAttributes.insert(StringAttr::get(context, "portSyms"));
+    nonessentialAttributes.insert(StringAttr::get(context, "sym_name"));
+    nonessentialAttributes.insert(StringAttr::get(context, "inner_sym"));
+  }
+
+  LogicalResult check(InFlightDiagnostic &diag, const Twine &message,
+                      Operation *a, BundleType aType, Operation *b,
+                      BundleType bType) {
+    if (aType.getNumElements() != bType.getNumElements()) {
+      diag.attachNote(a->getLoc())
+          << message << " bundle type has different number of elements";
+      diag.attachNote(b->getLoc()) << "second operation here";
+      return failure();
+    }
+
+    for (auto elementPair :
+         llvm::zip(aType.getElements(), bType.getElements())) {
+      auto aElement = std::get<0>(elementPair);
+      auto bElement = std::get<1>(elementPair);
+      if (aElement.isFlip != bElement.isFlip) {
+        diag.attachNote(a->getLoc()) << message << " bundle element "
+                                     << aElement.name << " flip does not match";
+        diag.attachNote(b->getLoc()) << "second operation here";
+        return failure();
+      }
+
+      if (failed(check(diag,
+                       "bundle element \'" + aElement.name.getValue() + "'", a,
+                       aElement.type, b, bElement.type)))
+        return failure();
+    }
+    return success();
+  }
+
+  LogicalResult check(InFlightDiagnostic &diag, const Twine &message,
+                      Operation *a, Type aType, Operation *b, Type bType) {
+    if (aType == bType)
+      return success();
+    if (aType.isa<BundleType>() && bType.isa<BundleType>())
+      return check(diag, message, a, aType.cast<BundleType>(), b,
+                   bType.cast<BundleType>());
+    diag.attachNote(a->getLoc())
+        << message << " types don't match, first type is " << aType;
+    diag.attachNote(b->getLoc()) << "second type is " << bType;
+    return failure();
+  }
+
+  LogicalResult check(InFlightDiagnostic &diag, BlockAndValueMapping &map,
+                      Operation *a, Block &aBlock, Operation *b,
+                      Block &bBlock) {
+
+    // Block Arguments.
+    if (aBlock.getNumArguments() != bBlock.getNumArguments()) {
+      diag.attachNote(a->getLoc())
+          << "modules have a different number of ports";
+      diag.attachNote(b->getLoc()) << "second module here";
+      return failure();
+    }
+
+    // Block argument types.
+    auto portNames = a->getAttrOfType<ArrayAttr>("portNames");
+    auto portNo = 0;
+    for (auto argPair :
+         llvm::zip(aBlock.getArguments(), bBlock.getArguments())) {
+      auto &aArg = std::get<0>(argPair);
+      auto &bArg = std::get<1>(argPair);
+      // TODO: we should print the port number if there are no port names, but
+      // there are always port names ;).
+      StringRef portName;
+      if (portNames) {
+        if (auto portNameAttr = portNames[portNo].dyn_cast<StringAttr>())
+          portName = portNameAttr.getValue();
+      }
+      // Assumption here that block arguments correspond to ports.
+      if (failed(check(diag, "module port '" + portName + "'", a,
+                       aArg.getType(), b, bArg.getType())))
+        return failure();
+      map.map(aArg, bArg);
+      portNo++;
+    }
+
+    // Blocks operations.
+    auto aIt = aBlock.begin();
+    auto aEnd = aBlock.end();
+    auto bIt = bBlock.begin();
+    auto bEnd = bBlock.end();
+    while (aIt != aEnd && bIt != bEnd)
+      if (failed(check(diag, map, &*aIt++, &*bIt++)))
+        return failure();
+    if (aIt != aEnd) {
+      diag.attachNote(aIt->getLoc()) << "first block has more operations";
+      diag.attachNote(b->getLoc()) << "second block here";
+      return failure();
+    } else if (bIt != bEnd) {
+      diag.attachNote(bIt->getLoc()) << "second block has more operations";
+      diag.attachNote(a->getLoc()) << "first block here";
+      return failure();
+    }
+    return success();
+  }
+
+  LogicalResult check(InFlightDiagnostic &diag, BlockAndValueMapping &map,
+                      Operation *a, Region &aRegion, Operation *b,
+                      Region &bRegion) {
+    auto aIt = aRegion.begin();
+    auto aEnd = aRegion.end();
+    auto bIt = bRegion.begin();
+    auto bEnd = bRegion.end();
+
+    // Region blocks.
+    while (aIt != aEnd && bIt != bEnd)
+      if (failed(check(diag, map, a, *aIt++, b, *bIt++)))
+        return failure();
+    if (aIt != aEnd || bIt != bEnd) {
+      diag.attachNote(a->getLoc())
+          << "operation regions have different number of blocks";
+      diag.attachNote(b->getLoc()) << "second operation here";
+      return failure();
+    }
+    return success();
+  }
+
+  LogicalResult check(InFlightDiagnostic &diag, Operation *a, IntegerAttr aAttr,
+                      Operation *b, IntegerAttr bAttr) {
+    if (aAttr == bAttr)
+      return success();
+    auto aDirections = direction::unpackAttribute(aAttr);
+    auto bDirections = direction::unpackAttribute(bAttr);
+    auto portNames = a->getAttrOfType<ArrayAttr>("portNames");
+    for (unsigned i = 0, e = aDirections.size(); i < e; ++i) {
+      auto aDirection = aDirections[i];
+      auto bDirection = bDirections[i];
+      if (aDirection != bDirection) {
+        auto &note = diag.attachNote(a->getLoc()) << "module port ";
+        if (portNames)
+          note << "'" << portNames[i].cast<StringAttr>().getValue() << "'";
+        else
+          note << i;
+        note << " directions don't match, first direction is '"
+             << direction::toString(aDirection) << "'";
+        diag.attachNote(b->getLoc()) << "second direction is '"
+                                     << direction::toString(bDirection) << "'";
+        return failure();
+      }
+    }
+    return success();
+  }
+
+  LogicalResult check(InFlightDiagnostic &diag, BlockAndValueMapping &map,
+                      Operation *a, DictionaryAttr aDict, Operation *b,
+                      DictionaryAttr bDict) {
+    // Fast path.
+    if (aDict == bDict)
+      return success();
+
+    DenseSet<Attribute> seenAttrs;
+    for (auto namedAttr : aDict) {
+      auto attrName = namedAttr.getName();
+      if (nonessentialAttributes.contains(attrName))
+        continue;
+
+      auto aAttr = namedAttr.getValue();
+      auto bAttr = bDict.get(attrName);
+      if (!bAttr) {
+        diag.attachNote(a->getLoc())
+            << "second operation is missing attribute " << attrName;
+        diag.attachNote(b->getLoc()) << "second operation here";
+        return diag;
+      }
+
+      if (attrName == "portDirections") {
+        // Special handling for the port directions attribute for better
+        // error messages.
+        if (failed(check(diag, a, aAttr.cast<IntegerAttr>(), b,
+                         bAttr.cast<IntegerAttr>())))
+          return failure();
+      } else if (aAttr != bAttr) {
+        diag.attachNote(a->getLoc())
+            << "first operation has attribute '" << attrName.getValue()
+            << "' with value " << aAttr;
+        diag.attachNote(b->getLoc()) << "second operation has value " << bAttr;
+        return failure();
+      }
+      seenAttrs.insert(attrName);
+    }
+    if (aDict.getValue().size() != bDict.getValue().size()) {
+      for (auto namedAttr : bDict) {
+        auto attrName = namedAttr.getName();
+        // Skip the attribute if we don't care about this particular one or it
+        // is one that is known to be in both dictionaries.
+        if (nonessentialAttributes.contains(attrName) ||
+            seenAttrs.contains(attrName))
+          continue;
+        // We have found an attribute that is only in the second operation.
+        diag.attachNote(a->getLoc())
+            << "first operation is missing attribute " << attrName;
+        diag.attachNote(b->getLoc()) << "second operation here";
+        return failure();
+      }
+    }
+    return success();
+  }
+
+  LogicalResult check(InFlightDiagnostic &diag, InstanceOp a, InstanceOp b) {
+    auto aName = a.moduleNameAttr().getAttr();
+    auto bName = b.moduleNameAttr().getAttr();
+    // If the modules instantiate are different we will want to know why the
+    // sub module did not dedupliate. This code recursively checks the child
+    // module.
+    if (aName != bName) {
+      diag.attachNote(a->getLoc()) << "first instance targets module " << aName;
+      diag.attachNote(b->getLoc())
+          << "second instance targets module " << bName;
+      diag.report();
+      auto aModule = instanceGraph.getReferencedModule(a);
+      auto bModule = instanceGraph.getReferencedModule(b);
+      // Create a new error for the submodule.
+      auto newDiag = emitError(aModule->getLoc())
+                     << "module " << aName << " not deduplicated with "
+                     << bName;
+      check(newDiag, aModule, bModule);
+      return failure();
+    }
+    return success();
+  }
+
+  LogicalResult check(InFlightDiagnostic &diag, BlockAndValueMapping &map,
+                      Operation *a, Operation *b) {
+    // Operation name.
+    if (a->getName() != b->getName()) {
+      diag.attachNote(a->getLoc()) << "first operation is a " << a->getName();
+      diag.attachNote(b->getLoc()) << "second operation is a " << b->getName();
+      return failure();
+    }
+
+    // If its an instance operaiton, perform some checking and possibly
+    // recurse.
+    if (auto aInst = dyn_cast<InstanceOp>(a)) {
+      auto bInst = cast<InstanceOp>(b);
+      if (failed(check(diag, aInst, bInst)))
+        return failure();
+    }
+
+    // Operation results.
+    if (a->getNumResults() != b->getNumResults()) {
+      diag.attachNote(a->getLoc())
+          << "operations have different number of results";
+      diag.attachNote(b->getLoc()) << "second operation here";
+      return failure();
+    }
+    for (auto resultPair : llvm::zip(a->getResults(), b->getResults())) {
+      auto &aValue = std::get<0>(resultPair);
+      auto &bValue = std::get<1>(resultPair);
+      if (failed(check(diag, "operation result", a, aValue.getType(), b,
+                       bValue.getType())))
+        return failure();
+      map.map(aValue, bValue);
+    }
+
+    // Operations operands.
+    if (a->getNumOperands() != b->getNumOperands()) {
+      diag.attachNote(a->getLoc())
+          << "operations have different number of operands";
+      diag.attachNote(b->getLoc()) << "second operation here";
+      return failure();
+    }
+    for (auto operandPair : llvm::zip(a->getOperands(), b->getOperands())) {
+      auto &aValue = std::get<0>(operandPair);
+      auto &bValue = std::get<1>(operandPair);
+      if (bValue != map.lookup(aValue)) {
+        diag.attachNote(a->getLoc())
+            << "operations use different operands, first operand is '"
+            << getFieldName(getFieldRefFromValue(aValue)) << "'";
+        diag.attachNote(b->getLoc())
+            << "second operand is '"
+            << getFieldName(getFieldRefFromValue(bValue))
+            << "', but should have been '"
+            << getFieldName(getFieldRefFromValue(map.lookup(aValue))) << "'";
+        return failure();
+      }
+    }
+
+    // Operation regions.
+    if (a->getNumRegions() != b->getNumRegions()) {
+      diag.attachNote(a->getLoc())
+          << "operations have different number of regions";
+      diag.attachNote(b->getLoc()) << "second operation here";
+      return failure();
+    }
+    for (auto regionPair : llvm::zip(a->getRegions(), b->getRegions())) {
+      auto &aRegion = std::get<0>(regionPair);
+      auto &bRegion = std::get<1>(regionPair);
+      if (failed(check(diag, map, a, aRegion, b, bRegion)))
+        return failure();
+    }
+
+    // Operation attributes.
+    if (failed(check(diag, map, a, a->getAttrDictionary(), b,
+                     b->getAttrDictionary())))
+      return failure();
+    return success();
+  }
+
+  void check(InFlightDiagnostic &diag, Operation *a, Operation *b) {
+    BlockAndValueMapping map;
+    if (failed(check(diag, map, a, b)))
+      return;
+    diag.attachNote(a->getLoc()) << "first module here";
+    diag.attachNote(b->getLoc()) << "second module here";
+  }
+
+  // This is a cached "portTypes" string attr.
+  StringAttr portTypesAttr;
+  // This is a set of every attribute we should ignore.
+  DenseSet<Attribute> nonessentialAttributes;
+  InstanceGraph &instanceGraph;
 };
 
 //===----------------------------------------------------------------------===//
@@ -897,6 +1231,7 @@ class DedupPass : public DedupBase<DedupPass> {
     NLAMap nlaMap = createNLAMap(circuit);
     Deduper deduper(instanceGraph, symbolTable, nlaMap, circuit);
     StructuralHasher hasher(&getContext());
+    Equivalence equiv(context, instanceGraph);
     auto anythingChanged = false;
 
     // Modules annotated with this should not be considered for deduplication.
@@ -951,11 +1286,13 @@ class DedupPass : public DedupBase<DedupPass> {
 
     // Get the group number from a module path.
     auto failed = false;
-    auto getGroup = [&](Attribute path) -> unsigned {
+    auto parseModule = [&](Attribute path) -> StringAttr {
       // Each module is listed as a target "~Circuit|Module" which we have to
       // parse.
       auto [_, rhs] = path.cast<StringAttr>().getValue().split('|');
-      auto module = StringAttr::get(context, rhs);
+      return StringAttr::get(context, rhs);
+    };
+    auto getGroup = [&](StringAttr module) -> unsigned {
       auto it = groupMap.find(module);
       if (it == groupMap.end()) {
         auto diag = emitError(circuit.getLoc(),
@@ -984,17 +1321,22 @@ class DedupPass : public DedupBase<DedupPass> {
       if (modules.size() == 0)
         return true;
       // Get the first element.
-      auto first = getGroup(modules[0]);
+      auto firstModule = parseModule(modules[0]);
+      auto first = getGroup(firstModule);
       if (failed)
         return false;
       // Verify that the remaining elements are all the same as the first.
       for (auto attr : modules.getValue().drop_front()) {
-        auto next = getGroup(attr);
+        auto nextModule = parseModule(attr);
+        auto next = getGroup(nextModule);
         if (failed)
           return false;
         if (first != next) {
-          emitError(circuit.getLoc(), "module ")
-              << attr << " not deduplicated with " << modules[0];
+          auto diag = emitError(circuit.getLoc(), "module ")
+                      << nextModule << " not deduplicated with " << firstModule;
+          auto a = instanceGraph.lookup(firstModule)->getModule();
+          auto b = instanceGraph.lookup(nextModule)->getModule();
+          equiv.check(diag, a, b);
           failed = true;
           return false;
         }

--- a/test/Dialect/FIRRTL/dedup-errors.mlir
+++ b/test/Dialect/FIRRTL/dedup-errors.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -verify-diagnostics -split-input-file -pass-pipeline='firrtl.circuit(firrtl-dedup)' %s
+// RUN: circt-opt --allow-unregistered-dialect -verify-diagnostics -split-input-file -pass-pipeline='firrtl.circuit(firrtl-dedup)' %s
 
 // expected-error@below {{MustDeduplicateAnnotation missing "modules" member}}
 firrtl.circuit "MustDedup" attributes {annotations = [{
@@ -19,15 +19,370 @@ firrtl.circuit "MustDedup" attributes {annotations = [{
 
 // -----
 
-// expected-error@below {{module "~MustDedup|Test1" not deduplicated with "~MustDedup|Test0"}}
+// expected-error@below {{module "Test1" not deduplicated with "Test0"}}
 firrtl.circuit "MustDedup" attributes {annotations = [{
       class = "firrtl.transforms.MustDeduplicateAnnotation",
       modules = ["~MustDedup|Test0", "~MustDedup|Test1"]
     }]} {
-  firrtl.module @Test0(in %i : !firrtl.uint<1>) { }
-  firrtl.module @Test1(in %i : !firrtl.uint<8>) { }
   firrtl.module @MustDedup() {
-    firrtl.instance test0 @Test0(in i : !firrtl.uint<1>)
-    firrtl.instance test1 @Test1(in i : !firrtl.uint<8>)
+    firrtl.instance test0 @Test0()
+    firrtl.instance test1 @Test1()
+  }
+  firrtl.module @Test0() {
+    // expected-note@below {{first operation is a firrtl.wire}}
+    %w = firrtl.wire : !firrtl.uint<8>
+  }
+  firrtl.module @Test1() {
+    // expected-note@below {{second operation is a firrtl.constant}}
+    %c1_ui8 = firrtl.constant 1 : !firrtl.uint<8>
+  }
+}
+
+// -----
+
+// expected-error@below {{module "Mid1" not deduplicated with "Mid0"}}
+firrtl.circuit "MustDedup" attributes {annotations = [{
+      class = "firrtl.transforms.MustDeduplicateAnnotation",
+      modules = ["~MustDedup|Mid0", "~MustDedup|Mid1"]
+    }]} {
+  firrtl.module @MustDedup() {
+    firrtl.instance mid0 @Mid0()
+    firrtl.instance mid1 @Mid1()
+  }
+  firrtl.module @Mid0() {
+    // expected-note@below {{first instance targets module "Test0"}}
+    firrtl.instance test0 @Test0()
+  }
+  firrtl.module @Mid1() {
+    // expected-note@below {{second instance targets module "Test1"}}
+    firrtl.instance test1 @Test1()
+  }
+  // expected-error@below {{module "Test0" not deduplicated with "Test1"}}
+  firrtl.module @Test0() {
+    // expected-note@below {{first operation is a firrtl.wire}}
+    %w = firrtl.wire : !firrtl.uint<8>
+  }
+  firrtl.module @Test1() {
+    // expected-note@below {{second operation is a firrtl.constant}}
+    %c1_ui8 = firrtl.constant 1 : !firrtl.uint<8>
+  }
+}
+
+// -----
+
+// expected-error@below {{module "Test1" not deduplicated with "Test0"}}
+firrtl.circuit "MustDedup" attributes {annotations = [{
+      class = "firrtl.transforms.MustDeduplicateAnnotation",
+      modules = ["~MustDedup|Test0", "~MustDedup|Test1"]
+    }]} {
+  firrtl.module @Test0() {
+    // expected-note@below {{operations have different number of results}}
+    "test"() : () -> ()
+  }
+  firrtl.module @Test1() {
+    // expected-note@below {{second operation here}}
+    %0 = "test"() : () -> (i32)
+  }
+  firrtl.module @MustDedup() {
+    firrtl.instance test0 @Test0()
+    firrtl.instance test1 @Test1()
+  }
+}
+
+// -----
+
+// expected-error@below {{module "Test1" not deduplicated with "Test0"}}
+firrtl.circuit "MustDedup" attributes {annotations = [{
+      class = "firrtl.transforms.MustDeduplicateAnnotation",
+      modules = ["~MustDedup|Test0", "~MustDedup|Test1"]
+    }]} {
+  firrtl.module @Test0() {
+    // expected-note@below {{operation result types don't match, first type is '!firrtl.uint<1>'}}
+    %w = firrtl.wire : !firrtl.uint<1>
+  }
+  firrtl.module @Test1() {
+    // expected-note@below {{second type is '!firrtl.uint<2>'}}
+    %w = firrtl.wire : !firrtl.uint<2>
+  }
+  firrtl.module @MustDedup() {
+    firrtl.instance test0 @Test0()
+    firrtl.instance test1 @Test1()
+  }
+}
+
+// -----
+
+// expected-error@below {{module "Test1" not deduplicated with "Test0"}}
+firrtl.circuit "MustDedup" attributes {annotations = [{
+      class = "firrtl.transforms.MustDeduplicateAnnotation",
+      modules = ["~MustDedup|Test0", "~MustDedup|Test1"]
+    }]} {
+  firrtl.module @Test0() {
+    // expected-note@below {{operation result bundle type has different number of elements}}
+    %w = firrtl.wire : !firrtl.bundle<a : uint<1>>
+  }
+  firrtl.module @Test1() {
+    // expected-note@below {{second operation here}}
+    %w = firrtl.wire : !firrtl.bundle<>
+  }
+  firrtl.module @MustDedup() {
+    firrtl.instance test0 @Test0()
+    firrtl.instance test1 @Test1()
+  }
+}
+
+// -----
+
+// expected-error@below {{module "Test1" not deduplicated with "Test0"}}
+firrtl.circuit "MustDedup" attributes {annotations = [{
+      class = "firrtl.transforms.MustDeduplicateAnnotation",
+      modules = ["~MustDedup|Test0", "~MustDedup|Test1"]
+    }]} {
+  firrtl.module @Test0() {
+    // expected-note@below {{operation result bundle element "a" flip does not match}}
+    %w = firrtl.wire : !firrtl.bundle<a : uint<1>>
+  }
+  firrtl.module @Test1() {
+    // expected-note@below {{second operation here}}
+    %w = firrtl.wire : !firrtl.bundle<a flip : uint<1>>
+  }
+  firrtl.module @MustDedup() {
+    firrtl.instance test0 @Test0()
+    firrtl.instance test1 @Test1()
+  }
+}
+// -----
+
+// expected-error@below {{module "Test1" not deduplicated with "Test0"}}
+firrtl.circuit "MustDedup" attributes {annotations = [{
+      class = "firrtl.transforms.MustDeduplicateAnnotation",
+      modules = ["~MustDedup|Test0", "~MustDedup|Test1"]
+    }]} {
+  firrtl.module @Test0() {
+    // expected-note@below {{bundle element 'a' types don't match, first type is '!firrtl.uint<1>'}}
+    %w = firrtl.wire : !firrtl.bundle<a : uint<1>>
+  }
+  firrtl.module @Test1() {
+    // expected-note@below {{second type is '!firrtl.uint<2>'}}
+    %w = firrtl.wire : !firrtl.bundle<b : uint<2>>
+  }
+  firrtl.module @MustDedup() {
+    firrtl.instance test0 @Test0()
+    firrtl.instance test1 @Test1()
+  }
+}
+
+// -----
+
+// expected-error@below {{module "Test1" not deduplicated with "Test0"}}
+firrtl.circuit "MustDedup" attributes {annotations = [{
+      class = "firrtl.transforms.MustDeduplicateAnnotation",
+      modules = ["~MustDedup|Test0", "~MustDedup|Test1"]
+    }]} {
+  firrtl.module @Test0(in %a : !firrtl.uint<1>) {
+    // expected-note@below {{operations have different number of operands}}
+    "test"(%a) : (!firrtl.uint<1>) -> ()
+  }
+  firrtl.module @Test1(in %a : !firrtl.uint<1>) {
+    // expected-note@below {{second operation here}}
+    "test"() : () -> ()
+  }
+  firrtl.module @MustDedup() {
+    firrtl.instance test0 @Test0(in a : !firrtl.uint<1>)
+    firrtl.instance test1 @Test1(in a : !firrtl.uint<1>)
+  }
+}
+
+// -----
+
+// expected-error@below {{module "Test1" not deduplicated with "Test0"}}
+firrtl.circuit "MustDedup" attributes {annotations = [{
+      class = "firrtl.transforms.MustDeduplicateAnnotation",
+      modules = ["~MustDedup|Test0", "~MustDedup|Test1"]
+    }]} {
+  firrtl.module @Test0(in %a : !firrtl.uint<1>, in %b : !firrtl.uint<1>) {
+    // expected-note@below {{operations use different operands, first operand is 'a'}}
+    %n = firrtl.node %a : !firrtl.uint<1>
+  }
+  firrtl.module @Test1(in %c : !firrtl.uint<1>, in %d : !firrtl.uint<1>) {
+    // expected-note@below {{second operand is 'd', but should have been 'c'}}
+    %n = firrtl.node %d : !firrtl.uint<1>
+  }
+  firrtl.module @MustDedup() {
+    firrtl.instance test0 @Test0(in a : !firrtl.uint<1>, in b : !firrtl.uint<1>)
+    firrtl.instance test1 @Test1(in c : !firrtl.uint<1>, in d : !firrtl.uint<1>)
+  }
+}
+
+// -----
+
+// expected-error@below {{module "Test1" not deduplicated with "Test0"}}
+firrtl.circuit "MustDedup" attributes {annotations = [{
+      class = "firrtl.transforms.MustDeduplicateAnnotation",
+      modules = ["~MustDedup|Test0", "~MustDedup|Test1"]
+    }]} {
+  firrtl.module @Test0(in %a : !firrtl.uint<1>) {
+    // expected-note@below {{operations have different number of regions}}
+    "test"()({}) : () -> ()
+  }
+  firrtl.module @Test1(in %a : !firrtl.uint<1>) {
+    // expected-note@below {{second operation here}}
+    "test"() : () -> ()
+  }
+  firrtl.module @MustDedup() {
+    firrtl.instance test0 @Test0(in a : !firrtl.uint<1>)
+    firrtl.instance test1 @Test1(in a : !firrtl.uint<1>)
+  }
+}
+
+// -----
+
+// expected-error@below {{module "Test1" not deduplicated with "Test0"}}
+firrtl.circuit "MustDedup" attributes {annotations = [{
+      class = "firrtl.transforms.MustDeduplicateAnnotation",
+      modules = ["~MustDedup|Test0", "~MustDedup|Test1"]
+    }]} {
+  firrtl.module @Test0(in %a : !firrtl.uint<1>) {
+    // expected-note@below {{operation regions have different number of blocks}}
+    "test"()({
+      ^bb0:
+        "return"() : () -> ()
+    }) : () -> ()
+  }
+  firrtl.module @Test1(in %a : !firrtl.uint<1>) {
+    // expected-note@below {{second operation here}}
+    "test"() ({
+      ^bb0:
+        "return"() : () -> ()
+      ^bb1:
+        "return"() : () -> ()
+    }): () -> ()
+  }
+  firrtl.module @MustDedup() {
+    firrtl.instance test0 @Test0(in a : !firrtl.uint<1>)
+    firrtl.instance test1 @Test1(in a : !firrtl.uint<1>)
+  }
+}
+
+// -----
+
+// expected-error@below {{module "Test1" not deduplicated with "Test0"}}
+firrtl.circuit "MustDedup" attributes {annotations = [{
+      class = "firrtl.transforms.MustDeduplicateAnnotation",
+      modules = ["~MustDedup|Test0", "~MustDedup|Test1"]
+    }]} {
+  // expected-note@below {{modules have a different number of ports}}
+  firrtl.module @Test0(in %a : !firrtl.uint<1>) { }
+  // expected-note@below {{second module here}}
+  firrtl.module @Test1() { }
+  firrtl.module @MustDedup() {
+    firrtl.instance test0 @Test0(in a : !firrtl.uint<1>)
+    firrtl.instance test1 @Test1()
+  }
+}
+
+// -----
+
+// expected-error@below {{module "Test1" not deduplicated with "Test0"}}
+firrtl.circuit "MustDedup" attributes {annotations = [{
+      class = "firrtl.transforms.MustDeduplicateAnnotation",
+      modules = ["~MustDedup|Test0", "~MustDedup|Test1"]
+    }]} {
+  // expected-note@below {{module port 'a' types don't match, first type is '!firrtl.uint<1>'}}
+  firrtl.module @Test0(in %a : !firrtl.uint<1>) { }
+  // expected-note@below {{second type is '!firrtl.uint<2>'}}
+  firrtl.module @Test1(in %a : !firrtl.uint<2>) { }
+  firrtl.module @MustDedup() {
+    firrtl.instance test0 @Test0(in a : !firrtl.uint<1>)
+    firrtl.instance test1 @Test1(in a : !firrtl.uint<2>)
+  }
+}
+
+// -----
+
+// expected-error@below {{module "Test1" not deduplicated with "Test0"}}
+firrtl.circuit "MustDedup" attributes {annotations = [{
+      class = "firrtl.transforms.MustDeduplicateAnnotation",
+      modules = ["~MustDedup|Test0", "~MustDedup|Test1"]
+    }]} {
+  // expected-note@below {{module port 'a' directions don't match, first direction is 'in'}}
+  firrtl.module @Test0(in %a : !firrtl.uint<1>) { }
+  // expected-note@below {{second direction is 'out'}}
+  firrtl.module @Test1(out %a : !firrtl.uint<1>) { }
+  firrtl.module @MustDedup() {
+    firrtl.instance test0 @Test0(in a : !firrtl.uint<1>)
+    firrtl.instance test1 @Test1(out a : !firrtl.uint<1>)
+  }
+}
+
+// -----
+
+// expected-error@below {{module "Test1" not deduplicated with "Test0"}}
+firrtl.circuit "MustDedup" attributes {annotations = [{
+      class = "firrtl.transforms.MustDeduplicateAnnotation",
+      modules = ["~MustDedup|Test0", "~MustDedup|Test1"]
+    }]} {
+  firrtl.module @Test0() {
+    // expected-note@below {{first block has more operations}}
+    %w = firrtl.wire : !firrtl.uint<8>
+  }
+  // expected-note@below {{second block here}}
+  firrtl.module @Test1() { }
+  firrtl.module @MustDedup() {
+    firrtl.instance test0 @Test0()
+    firrtl.instance test1 @Test1()
+  }
+}
+
+// -----
+
+// expected-error@below {{module "Test1" not deduplicated with "Test0"}}
+firrtl.circuit "MustDedup" attributes {annotations = [{
+      class = "firrtl.transforms.MustDeduplicateAnnotation",
+      modules = ["~MustDedup|Test0", "~MustDedup|Test1"]
+    }]} {
+  // expected-note@below {{first block here}}
+  firrtl.module @Test0() { }
+  firrtl.module @Test1() {
+    // expected-note@below {{second block has more operations}}
+    %w = firrtl.wire : !firrtl.uint<8>
+  }
+  firrtl.module @MustDedup() {
+    firrtl.instance test0 @Test0()
+    firrtl.instance test1 @Test1()
+  }
+}
+
+// -----
+
+// expected-error@below {{module "Test1" not deduplicated with "Test0"}}
+firrtl.circuit "MustDedup" attributes {annotations = [{
+      class = "firrtl.transforms.MustDeduplicateAnnotation",
+      modules = ["~MustDedup|Test0", "~MustDedup|Test1"]
+    }]} {
+  // expected-note@below {{second operation is missing attribute "test1"}}
+  firrtl.module @Test0() attributes {test1} { }
+  // expected-note@below {{second operation here}}
+  firrtl.module @Test1() attributes {} { }
+  firrtl.module @MustDedup() {
+    firrtl.instance test0 @Test0()
+    firrtl.instance test1 @Test1()
+  }
+}
+
+// -----
+
+// expected-error@below {{module "Test1" not deduplicated with "Test0"}}
+firrtl.circuit "MustDedup" attributes {annotations = [{
+      class = "firrtl.transforms.MustDeduplicateAnnotation",
+      modules = ["~MustDedup|Test0", "~MustDedup|Test1"]
+    }]} {
+  // expected-note@below {{first operation has attribute 'test' with value "a"}}
+  firrtl.module @Test0() attributes {test = "a"} { }
+  // expected-note@below {{second operation has value "b"}}
+  firrtl.module @Test1() attributes {test = "b"} { }
+  firrtl.module @MustDedup() {
+    firrtl.instance test0 @Test0()
+    firrtl.instance test1 @Test1()
   }
 }


### PR DESCRIPTION
A user can add an annotation "MustDedup" which lists modules which they expect to dedup, and emits an error message when that fails.  The error message produced by a dedup failure doesn't give any hint as to why deduplication failed.  This can be very annoying to debug, and usually involves `diff`ing the FIRRTL IR modules.

This change adds a diagnostic comparison of two modules, looking for the first difference between them which would have blocked deduplication.  This comparison ignores differences in port names and bundle element names the same way that the structural hasher does.