### PR TITLE
[FIRRTL] Donot dedup memories with unique Prefix

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -149,8 +149,10 @@ def DropNameRegReset : Pat<
 
 // Mem(...,name),!dnt -> Mem(...x, "")
 def DropNameMem : Pat<
-  (MemOp $rd, $rw, $depth, $ruw, $portNames, $name, $annotations, $portAnno, $inner_sym),
-  (MemOp $rd, $rw, $depth, $ruw, $portNames, (GetEmptyString), $annotations, $portAnno, $inner_sym),
+  (MemOp $rd, $rw, $depth, $ruw, $portNames, $name, $annotations, $portAnno,
+                                                      $inner_sym, $groupID),
+  (MemOp $rd, $rw, $depth, $ruw, $portNames, (GetEmptyString), $annotations,
+                                            $portAnno, $inner_sym, $groupID),
   [(uselessNameAttr $name), (NonEmptyStringAttr $name), (NullAttr $inner_sym)]>;
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLCANONICALIZATION_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -102,7 +102,8 @@ def MemOp : FIRRTLOp<"mem", [HasCustomSSAName]> {
          StrArrayAttr:$portNames, StrAttr:$name,
          AnnotationArrayAttr:$annotations,
          PortAnnotationsAttr:$portAnnotations,
-         OptionalAttr<SymbolNameAttr>:$inner_sym);
+         OptionalAttr<SymbolNameAttr>:$inner_sym,
+         OptionalAttr<I32Attr>:$groupID);
   let results = (outs Variadic<FIRRTLType>:$results);
 
   let assemblyFormat = [{

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -157,17 +157,17 @@ struct FirMemory {
   SmallVector<int32_t> writeClockIDs;
   StringAttr modName;
   bool isMasked;
-  StringRef prefix;
+  size_t groupID;
 
   // Location is carried along but not considered part of the identity of this.
   Location loc;
 
   std::tuple<size_t, size_t, size_t, size_t, size_t, size_t, size_t, size_t,
-             size_t, hw::WUW, SmallVector<int32_t>, StringRef>
+             size_t, hw::WUW, SmallVector<int32_t>, size_t>
   getTuple() const {
     return std::tie(numReadPorts, numWritePorts, numReadWritePorts, dataWidth,
                     depth, readLatency, writeLatency, maskBits, readUnderWrite,
-                    writeUnderWrite, writeClockIDs, prefix);
+                    writeUnderWrite, writeClockIDs, groupID);
   }
   bool operator<(const FirMemory &rhs) const {
     return getTuple() < rhs.getTuple();

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -157,16 +157,17 @@ struct FirMemory {
   SmallVector<int32_t> writeClockIDs;
   StringAttr modName;
   bool isMasked;
+  StringRef prefix;
 
   // Location is carried along but not considered part of the identity of this.
   Location loc;
 
   std::tuple<size_t, size_t, size_t, size_t, size_t, size_t, size_t, size_t,
-             size_t, hw::WUW, SmallVector<int32_t>>
+             size_t, hw::WUW, SmallVector<int32_t>, StringRef>
   getTuple() const {
     return std::tie(numReadPorts, numWritePorts, numReadWritePorts, dataWidth,
                     depth, readLatency, writeLatency, maskBits, readUnderWrite,
-                    writeUnderWrite, writeClockIDs);
+                    writeUnderWrite, writeClockIDs, prefix);
   }
   bool operator<(const FirMemory &rhs) const {
     return getTuple() < rhs.getTuple();

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1843,6 +1843,9 @@ FirMemory MemOp::getSummary() {
     op.emitError("'firrtl.mem' should have simple type and known width");
     width = 0;
   }
+  StringRef prefix;
+  if (op->hasAttr("prefix"))
+    prefix = op->getAttrOfType<StringAttr>("prefix").strref();
   StringAttr modName;
   if (op->hasAttr("modName"))
     modName = op->getAttrOfType<StringAttr>("modName");
@@ -1863,7 +1866,7 @@ FirMemory MemOp::getSummary() {
           (size_t)width,        op.depth(),       op.readLatency(),
           op.writeLatency(),    op.getMaskBits(), (size_t)op.ruw(),
           hw::WUW::PortOrder,   writeClockIDs,    modName,
-          op.getMaskBits() > 1, op.getLoc()};
+          op.getMaskBits() > 1, prefix,           op.getLoc()};
 }
 
 void MemOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1843,7 +1843,7 @@ FirMemory MemOp::getSummary() {
     op.emitError("'firrtl.mem' should have simple type and known width");
     width = 0;
   }
-  size_t groupID;
+  size_t groupID = 0;
   if (auto gID = op.groupIDAttr())
     groupID = gID.getInt();
   StringAttr modName;

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1843,9 +1843,9 @@ FirMemory MemOp::getSummary() {
     op.emitError("'firrtl.mem' should have simple type and known width");
     width = 0;
   }
-  StringRef prefix;
-  if (op->hasAttr("prefix"))
-    prefix = op->getAttrOfType<StringAttr>("prefix").strref();
+  size_t groupID;
+  if (auto gID = op.groupIDAttr())
+    groupID = gID.getInt();
   StringAttr modName;
   if (op->hasAttr("modName"))
     modName = op->getAttrOfType<StringAttr>("modName");
@@ -1866,7 +1866,7 @@ FirMemory MemOp::getSummary() {
           (size_t)width,        op.depth(),       op.readLatency(),
           op.writeLatency(),    op.getMaskBits(), (size_t)op.ruw(),
           hw::WUW::PortOrder,   writeClockIDs,    modName,
-          op.getMaskBits() > 1, prefix,           op.getLoc()};
+          op.getMaskBits() > 1, groupID,          op.getLoc()};
 }
 
 void MemOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3111,10 +3111,10 @@ ParseResult FIRStmtParser::parseMem(unsigned memIndent) {
         if (sym)
           break;
       }
-    result =
-        builder.create<MemOp>(resultTypes, readLatency, writeLatency, depth,
-                              ruw, builder.getArrayAttr(resultNames), id,
-                              annotations.first, annotations.second, sym);
+    result = builder.create<MemOp>(
+        resultTypes, readLatency, writeLatency, depth, ruw,
+        builder.getArrayAttr(resultNames), id, annotations.first,
+        annotations.second, sym, IntegerAttr());
   }
 
   UnbundledValueEntry unbundledValueEntry;

--- a/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
@@ -125,7 +125,8 @@ struct InferReadWritePass : public InferReadWriteBase<InferReadWritePass> {
           resultTypes, memOp.readLatency(), memOp.writeLatency(), memOp.depth(),
           RUWAttr::Undefined, builder.getArrayAttr(resultNames),
           memOp.nameAttr(), memOp.annotations(),
-          builder.getArrayAttr(portAnnotations), memOp.inner_symAttr());
+          builder.getArrayAttr(portAnnotations), memOp.inner_symAttr(),
+          IntegerAttr());
       auto rwPort = rwMem->getResult(0);
       // Create the subfield access to all fields of the port.
       // The addr should be connected to read/write address depending on the

--- a/lib/Dialect/FIRRTL/Transforms/LowerCHIRRTL.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerCHIRRTL.cpp
@@ -355,7 +355,7 @@ void LowerCHIRRTLPass::replaceMem(Operation *cmem, StringRef name,
   auto memory = memBuilder.create<MemOp>(
       resultTypes, readLatency, writeLatency, depth, ruw,
       memBuilder.getArrayAttr(resultNames), name, annotations,
-      memBuilder.getArrayAttr(portAnnotations), StringAttr{});
+      memBuilder.getArrayAttr(portAnnotations), StringAttr{}, IntegerAttr());
   if (auto innerSym = cmem->getAttr("inner_sym"))
     memory->setAttr("inner_sym", innerSym);
 

--- a/lib/Dialect/FIRRTL/Transforms/PrefixModules.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/PrefixModules.cpp
@@ -167,6 +167,7 @@ void PrefixModulesPass::renameModuleBody(std::string prefix, FModuleOp module) {
     if (auto memOp = dyn_cast<MemOp>(op)) {
       // Memories will be turned into modules and should be prefixed.
       memOp.nameAttr(StringAttr::get(context, prefix + memOp.name()));
+      memOp->setAttr("prefix", StringAttr::get(context, prefix));
     } else if (auto instanceOp = dyn_cast<InstanceOp>(op)) {
       auto target = dyn_cast<FModuleLike>(
           *instanceGraph->getReferencedModule(instanceOp));

--- a/lib/Dialect/FIRRTL/Transforms/PrefixModules.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/PrefixModules.cpp
@@ -105,6 +105,8 @@ class PrefixModulesPass : public PrefixModulesBase<PrefixModulesPass> {
   /// This is a map from a module name to new prefixes to be applied.
   PrefixMap prefixMap;
 
+  DenseMap<StringRef, size_t> prefixIdMap;
+
   /// A map of Grand Central interface ID to prefix.
   DenseMap<Attribute, std::string> interfacePrefixMap;
 
@@ -123,6 +125,13 @@ class PrefixModulesPass : public PrefixModulesBase<PrefixModulesPass> {
 /// any referenced module in the prefix map.
 void PrefixModulesPass::renameModuleBody(std::string prefix, FModuleOp module) {
   auto *context = module.getContext();
+  size_t groupID = 0;
+  auto iter = prefixIdMap.find(prefix);
+  if (iter == prefixIdMap.end()) {
+    groupID = prefixIdMap.size() + 1;
+    prefixIdMap[prefix] = groupID;
+  } else
+    groupID = iter->getSecond();
 
   // If we are renaming the body of this module, we need to mark that we have
   // changed the IR. If we are prefixing with the empty string, then nothing has
@@ -167,7 +176,8 @@ void PrefixModulesPass::renameModuleBody(std::string prefix, FModuleOp module) {
     if (auto memOp = dyn_cast<MemOp>(op)) {
       // Memories will be turned into modules and should be prefixed.
       memOp.nameAttr(StringAttr::get(context, prefix + memOp.name()));
-      memOp->setAttr("prefix", StringAttr::get(context, prefix));
+      memOp.groupIDAttr(
+          IntegerAttr::get(IntegerType::get(context, 32), groupID));
     } else if (auto instanceOp = dyn_cast<InstanceOp>(op)) {
       auto target = dyn_cast<FModuleLike>(
           *instanceGraph->getReferencedModule(instanceOp));

--- a/test/firtool/prefixMemory.fir
+++ b/test/firtool/prefixMemory.fir
@@ -1,0 +1,122 @@
+; RUN: firtool %s --format=fir  --ir-fir | FileCheck %s 
+; RUN: firtool %s --format=fir  --ir-hw | FileCheck --check-prefix=HW %s 
+
+circuit Foo : %[[
+  {
+    "class":"sifive.enterprise.firrtl.NestedPrefixModulesAnnotation",
+    "prefix":"prefix1_",
+    "inclusive":true,
+    "target":"~Foo|Bar"
+  },
+  {
+    "class":"sifive.enterprise.firrtl.NestedPrefixModulesAnnotation",
+    "prefix":"prefix2_",
+    "inclusive":true,
+    "target":"~Foo|Baz"
+  }
+]]
+  module Bar :
+    input clock : Clock
+    input reset : Reset
+    input readAddr : UInt<3>
+    output readData : UInt<32>
+    input writeEn : UInt<1>
+    input writeAddr : UInt<3>
+    input writeData : UInt<32>
+
+    mem mem :
+      data-type => UInt<1>
+      depth => 8
+      read-latency => 1
+      write-latency => 1
+      reader => readData_MPORT
+      writer => MPORT
+      read-under-write => undefined
+    mem.readData_MPORT.addr is invalid
+    mem.readData_MPORT.clk is invalid
+    mem.readData_MPORT.en <= UInt<1>("h0")
+    mem.MPORT.addr is invalid
+    mem.MPORT.clk is invalid
+    mem.MPORT.en <= UInt<1>("h0")
+    mem.MPORT.data is invalid
+    mem.MPORT.mask is invalid
+    mem.readData_MPORT.addr <= readAddr
+    mem.readData_MPORT.clk <= clock
+    readData <= mem.readData_MPORT.data
+    when writeEn :
+      mem.MPORT.addr <= writeAddr
+      mem.MPORT.clk <= clock
+      mem.MPORT.en <= UInt<1>("h1")
+      mem.MPORT.mask <= UInt<1>("h0")
+      mem.MPORT.data <= writeData
+      mem.MPORT.mask <= UInt<1>("h1")
+
+  module Baz :
+    input clock : Clock
+    input reset : Reset
+    input readAddr : UInt<3>
+    output readData : UInt<32>
+    input writeEn : UInt<1>
+    input writeAddr : UInt<3>
+    input writeData : UInt<32>
+
+    mem mem :
+      data-type => UInt<1>
+      depth => 8
+      read-latency => 1
+      write-latency => 1
+      reader => readData_MPORT
+      writer => MPORT
+      read-under-write => undefined
+    mem.readData_MPORT.addr is invalid
+    mem.readData_MPORT.clk is invalid
+    mem.readData_MPORT.en <= UInt<1>("h0")
+    mem.MPORT.addr is invalid
+    mem.MPORT.clk is invalid
+    mem.MPORT.en <= UInt<1>("h0")
+    mem.MPORT.data is invalid
+    mem.MPORT.mask is invalid
+    mem.readData_MPORT.addr <= readAddr
+    mem.readData_MPORT.clk <= clock
+    readData <= mem.readData_MPORT.data
+    when writeEn :
+      mem.MPORT.addr <= writeAddr
+      mem.MPORT.clk <= clock
+      mem.MPORT.en <= UInt<1>("h1")
+      mem.MPORT.mask <= UInt<1>("h0")
+      mem.MPORT.data <= writeData
+      mem.MPORT.mask <= UInt<1>("h1")
+
+  module Foo :
+    input clock : Clock
+    input reset : UInt<1>
+    input readAddr : UInt<3>
+    output readData : UInt<32>
+    input writeEn : UInt<1>
+    input writeAddr : UInt<3>
+    input writeData : UInt<32>
+
+    inst bar of Bar
+    bar.clock <= clock
+    bar.reset <= reset
+    bar.readAddr <= readAddr
+    bar.writeEn <= writeEn
+    bar.writeAddr <= writeAddr
+    bar.writeData <= writeData
+    inst baz of Baz
+    baz.clock <= clock
+    baz.reset <= reset
+    baz.readAddr <= readAddr
+    baz.writeEn <= writeEn
+    baz.writeAddr <= writeAddr
+    baz.writeData <= writeData
+    node _readData_T = xor(bar.readData, baz.readData)
+    readData <= _readData_T
+
+; CHECK-LABEL:  firrtl.module private @prefix1_Bar
+; CHECK:      %prefix1_mem_MPORT, %prefix1_mem_readData_MPORT = firrtl.mem Undefined  {depth = 8 : i64, modName = "prefix1_mem_ext", name = "prefix1_mem", portNames = ["MPORT", "readData_MPORT"], prefix = "prefix1_", readLatency = 1 : i32, writeLatency = 1 : i32}
+; CHECK-LABEL:    firrtl.module private @prefix2_Baz
+; CHECK:      %prefix2_mem_MPORT, %prefix2_mem_readData_MPORT = firrtl.mem Undefined  {depth = 8 : i64, modName = "prefix2_mem_ext", name = "prefix2_mem", portNames = ["MPORT", "readData_MPORT"], prefix = "prefix2_", readLatency = 1 : i32, writeLatency = 1 : i32}
+
+; HW-LABEL:  hw.module @prefix1_mem_ext(%R0_addr: i3, %R0_en: i1, %R0_clk: i1, %W0_addr: i3, %W0_en: i1, %W0_clk: i1, %W0_data: i1) -> (R0_data: i1)
+;HW-LABEL:  hw.module @prefix2_mem_ext(%R0_addr: i3, %R0_en: i1, %R0_clk: i1, %W0_addr: i3, %W0_en: i1, %W0_clk: i1, %W0_data: i1) -> (R0_data: i1)

--- a/test/firtool/prefixMemory.fir
+++ b/test/firtool/prefixMemory.fir
@@ -114,9 +114,9 @@ circuit Foo : %[[
     readData <= _readData_T
 
 ; CHECK-LABEL:  firrtl.module private @prefix1_Bar
-; CHECK:      %prefix1_mem_MPORT, %prefix1_mem_readData_MPORT = firrtl.mem Undefined  {depth = 8 : i64, modName = "prefix1_mem_ext", name = "prefix1_mem", portNames = ["MPORT", "readData_MPORT"], prefix = "prefix1_", readLatency = 1 : i32, writeLatency = 1 : i32}
-; CHECK-LABEL:    firrtl.module private @prefix2_Baz
-; CHECK:      %prefix2_mem_MPORT, %prefix2_mem_readData_MPORT = firrtl.mem Undefined  {depth = 8 : i64, modName = "prefix2_mem_ext", name = "prefix2_mem", portNames = ["MPORT", "readData_MPORT"], prefix = "prefix2_", readLatency = 1 : i32, writeLatency = 1 : i32}
+; CHECK:        = firrtl.mem Undefined  {depth = 8 : i64, groupID = 2 : i32, modName = "prefix1_mem_ext", name = "prefix1_mem", portNames = ["MPORT", "readData_MPORT"], readLatency = 1 : i32, writeLatency = 1 : i32}
+; CHECK-LABEL:  firrtl.module private @prefix2_Baz
+; CHECK:        = firrtl.mem Undefined  {depth = 8 : i64, groupID = 3 : i32, modName = "prefix2_mem_ext", name = "prefix2_mem", portNames = ["MPORT", "readData_MPORT"], readLatency = 1 : i32, writeLatency = 1 : i32}
 
 ; HW-LABEL:  hw.module @prefix1_mem_ext(%R0_addr: i3, %R0_en: i1, %R0_clk: i1, %W0_addr: i3, %W0_en: i1, %W0_clk: i1, %W0_data: i1) -> (R0_data: i1)
-;HW-LABEL:  hw.module @prefix2_mem_ext(%R0_addr: i3, %R0_en: i1, %R0_clk: i1, %W0_addr: i3, %W0_en: i1, %W0_clk: i1, %W0_data: i1) -> (R0_data: i1)
+; HW-LABEL:  hw.module @prefix2_mem_ext(%R0_addr: i3, %R0_en: i1, %R0_clk: i1, %W0_addr: i3, %W0_en: i1, %W0_clk: i1, %W0_data: i1) -> (R0_data: i1)


### PR DESCRIPTION
Add a `prefix` attribute to memory, to prevent memories with different prefix from getting deduped.
The `PrefixModules` pass can prefix the name for a `MemOp`. This prefix should not be ignored
when memories with same properties are deduped in `LowerToHW`.
This commit adds the `prefix` attribute to the `FirMemory`, such that it should also be considered
when merging all the memories.
In the absence of the prefix attribute it is ignored.
We can consider to make the attribute as a dedup domain id, instead of a prefix string.
