### PR TITLE
[FIRRTL][Dedup] Fix incorrect string cast in printHash().

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -54,10 +54,7 @@ llvm::raw_ostream &printHex(llvm::raw_ostream &stream,
 }
 
 llvm::raw_ostream &printHash(llvm::raw_ostream &stream, llvm::SHA256 &data) {
-  auto string = data.result();
-  ArrayRef bytes(reinterpret_cast<const uint8_t *>(string.begin()),
-                 string.size());
-  return printHex(stream, bytes);
+  return printHex(stream, data.result());
 }
 
 llvm::raw_ostream &printHash(llvm::raw_ostream &stream, std::string data) {


### PR DESCRIPTION
This should actually fix the Windows build error, unlike https://github.com/llvm/circt/pull/2894.

In a recent commit, 654d5e96c84c80274f04ddd1a5984adc547b5cec, that
bumped the LLVM submodule, LLVM changed the SHA256 hasher to return
std::array<uint8_t, 32> instead of StringRefs. This causes MSVC to
report an error when compiling the printHash() debugging function, where
we now have an invalid reinterpret_cast.

This commit fixes the issue by performing the correct type conversions
from std::array to ArrayRef, which is now done without an explicit cast.


I manually ran a Windows build at https://github.com/llvm/circt/runs/6018882415?check_suite_focus=true, and it passed.