### PR TITLE
[FIRRTL][CheckCombCycles] Use FConnectLike

### DIFF
--- a/test/Dialect/FIRRTL/check-comb-cycles.mlir
+++ b/test/Dialect/FIRRTL/check-comb-cycles.mlir
@@ -165,3 +165,14 @@ module  {
     }
   }
 }
+
+// -----
+
+firrtl.circuit "strictConnectAndConnect" {
+  // expected-error @+2 {{detected combinational cycle in a FIRRTL module}}
+  // expected-note @+1 {{this operation is part of the combinational cycle}}
+  firrtl.module @strictConnectAndConnect(out %a: !firrtl.uint<11>, out %b: !firrtl.uint<11>) {
+    firrtl.connect %a, %b : !firrtl.uint<11>, !firrtl.uint<11>
+    firrtl.strictconnect %b, %a : !firrtl.uint<11>
+  }
+}


### PR DESCRIPTION
This is a follow-up of c4917d7, which replaces ConnectOp with FConnectLike with CheckCombCycles.