### PR TITLE
Update LLVM to 1aa4f0bb

### DIFF
--- a/include/circt/Conversion/ExportVerilog.h
+++ b/include/circt/Conversion/ExportVerilog.h
@@ -13,6 +13,7 @@
 #ifndef CIRCT_TRANSLATION_EXPORTVERILOG_H
 #define CIRCT_TRANSLATION_EXPORTVERILOG_H
 
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 
 namespace circt {

--- a/include/circt/Conversion/Passes.h
+++ b/include/circt/Conversion/Passes.h
@@ -25,6 +25,7 @@
 #include "circt/Conversion/SCFToCalyx.h"
 #include "circt/Conversion/StandardToHandshake.h"
 #include "circt/Conversion/StandardToStaticLogic.h"
+#include "mlir/IR/DialectRegistry.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassRegistry.h"
 

--- a/include/circt/Dialect/Handshake/CMakeLists.txt
+++ b/include/circt/Dialect/Handshake/CMakeLists.txt
@@ -9,6 +9,11 @@ mlir_tablegen(HandshakeEnums.cpp.inc -gen-enum-defs)
 add_public_tablegen_target(MLIRHandshakeEnumsIncGen)
 add_dependencies(circt-headers MLIRHandshakeEnumsIncGen)
 
+mlir_tablegen(HandshakeAttributes.h.inc -gen-attrdef-decls -attrdefs-dialect=handshake)
+mlir_tablegen(HandshakeAttributes.cpp.inc -gen-attrdef-defs -attrdefs-dialect=handshake)
+add_public_tablegen_target(MLIRHandshakeAttributesIncGen)
+add_dependencies(circt-headers MLIRHandshakeAttributesIncGen)
+
 mlir_tablegen(HandshakeAttrs.h.inc -gen-struct-attr-decls)
 mlir_tablegen(HandshakeAttrs.cpp.inc -gen-struct-attr-defs)
 add_public_tablegen_target(MLIRHandshakeAttrsIncGen)

--- a/include/circt/Dialect/Handshake/HandshakeOps.h
+++ b/include/circt/Dialect/Handshake/HandshakeOps.h
@@ -49,6 +49,9 @@ class HasClock : public TraitBase<ConcreteType, HasClock> {};
 } // namespace OpTrait
 } // namespace mlir
 
+#define GET_ATTRDEF_CLASSES
+#include "circt/Dialect/Handshake/HandshakeAttributes.h.inc"
+
 #define GET_OP_CLASSES
 #include "circt/Dialect/Handshake/Handshake.h.inc"
 

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+include "mlir/IR/EnumAttr.td"
 include "mlir/IR/OpAsmInterface.td"
 
 // This is almost exactly like a standard FuncOp, except that it has some
@@ -204,13 +205,16 @@ def ReturnOp : Handshake_Op<"return", [Terminator]> {
   let assemblyFormat = [{ operands attr-dict `:` qualified(type(operands)) }];
 }
 
-// Here use StrEnumAttr to better suit the BufferOp sequential
+// Here use I32EnumAttr to better suit the BufferOp sequential
 // attribute for it can only be seq or fifo.
-def BufferCaseSeq: StrEnumAttrCase<"seq">;
-def BufferCaseFIFO: StrEnumAttrCase<"fifo">;
+def BufferCaseSeq: I32EnumAttrCase<"seq", 0>;
+def BufferCaseFIFO: I32EnumAttrCase<"fifo", 1>;
 
-def BufferTypeEnum: StrEnumAttr<
-  "BufferTypeEnum", "BufferOp seq or fifo", [BufferCaseSeq, BufferCaseFIFO]>;
+def BufferTypeEnum: I32EnumAttr<
+  "BufferTypeEnum", "BufferOp seq or fifo", [BufferCaseSeq, BufferCaseFIFO]> {
+  let genSpecializedAttr = 0;
+}
+def BufferTypeEnumAttr: EnumAttr<Handshake_Dialect, BufferTypeEnum, "buffer_type_enum">;
 
 def BufferOp : Handshake_Op<"buffer", [NoSideEffect, HasClock,
   DeclareOpInterfaceMethods<ExecutableOpInterface>,
@@ -235,7 +239,7 @@ def BufferOp : Handshake_Op<"buffer", [NoSideEffect, HasClock,
     TypeAttr:$dataType,
     Confined<I32Attr, [IntMinValue<1>]>:$size,
     AnyType:$operand,
-    BufferTypeEnum:$bufferType,
+    BufferTypeEnumAttr:$bufferType,
     OptionalAttr<I64ArrayAttr>:$initValues);
   let results = (outs AnyType:$result);
   let skipDefaultBuilders = 1;
@@ -244,7 +248,7 @@ def BufferOp : Handshake_Op<"buffer", [NoSideEffect, HasClock,
 
   let extraClassDeclaration = [{
     bool isSequential() {
-      return symbolizeBufferTypeEnum(this->bufferType()) == BufferTypeEnum::seq;
+      return this->bufferType() == BufferTypeEnum::seq;
     }
     int getNumSlots() {
       return (*this)->getAttrOfType<IntegerAttr>("size").getValue().getZExtValue();

--- a/include/circt/Dialect/SV/CMakeLists.txt
+++ b/include/circt/Dialect/SV/CMakeLists.txt
@@ -8,6 +8,11 @@ mlir_tablegen(SVEnums.cpp.inc -gen-enum-defs)
 add_public_tablegen_target(MLIRSVEnumsIncGen)
 add_dependencies(circt-headers MLIRSVEnumsIncGen)
 
+mlir_tablegen(SVAttributes.h.inc -gen-attrdef-decls --attrdefs-dialect=sv)
+mlir_tablegen(SVAttributes.cpp.inc -gen-attrdef-defs --attrdefs-dialect=sv)
+add_public_tablegen_target(MLIRSVAttributesIncGen)
+add_dependencies(circt-headers MLIRSVAttributesIncGen)
+
 mlir_tablegen(SVStructs.h.inc -gen-struct-attr-decls)
 mlir_tablegen(SVStructs.cpp.inc -gen-struct-attr-defs)
 add_public_tablegen_target(MLIRSVStructsIncGen)

--- a/include/circt/Dialect/SV/SVOps.h
+++ b/include/circt/Dialect/SV/SVOps.h
@@ -128,6 +128,8 @@ public:
 
 #define GET_OP_CLASSES
 #include "circt/Dialect/SV/SVEnums.h.inc"
+#define GET_ATTRDEF_CLASSES
+#include "circt/Dialect/SV/SVAttributes.h.inc"
 // Clang format shouldn't reorder these headers.
 #include "circt/Dialect/SV/SV.h.inc"
 #include "circt/Dialect/SV/SVStructs.h.inc"

--- a/include/circt/Dialect/SV/SVTypeDecl.td
+++ b/include/circt/Dialect/SV/SVTypeDecl.td
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+include "mlir/IR/EnumAttr.td"
+
 //===----------------------------------------------------------------------===//
 // Interface operations
 //===----------------------------------------------------------------------===//
@@ -28,8 +30,8 @@ def InterfaceOp : SVOp<"interface",
     ```mlir
     sv.interface @myinterface {
       sv.interface.signal @data : i32
-      sv.interface.modport @input_port ("input" @data)
-      sv.interface.modport @output_port ("output" @data)
+      sv.interface.modport @input_port (input @data)
+      sv.interface.modport @output_port (output @data)
     }
     ```
   }];
@@ -106,13 +108,18 @@ def InterfaceSignalOp : SVOp<"interface.signal",
   ];
 }
 
-def ModportDirectionInput : StrEnumAttrCase<"input">;
-def ModportDirectionOutput : StrEnumAttrCase<"output">;
-def ModportDirectionInOut : StrEnumAttrCase<"inout">;
+def ModportDirectionInput : I32EnumAttrCase<"input", 0>;
+def ModportDirectionOutput : I32EnumAttrCase<"output", 1>;
+def ModportDirectionInOut : I32EnumAttrCase<"inout", 2>;
 
-def ModportDirectionAttr : StrEnumAttr<"ModportDirectionAttr",
+def ModportDirection : I32EnumAttr<"ModportDirection",
   "Defines direction in a modport",
-  [ModportDirectionInput, ModportDirectionOutput, ModportDirectionInOut]>;
+  [ModportDirectionInput, ModportDirectionOutput, ModportDirectionInOut]> {
+  let genSpecializedAttr = 0;
+}
+
+def ModportDirectionAttr : EnumAttr<SVDialect, ModportDirection,
+  "modport_direction">;
 
 def ModportDirectionField : StructFieldAttr<"direction", ModportDirectionAttr>;
 
@@ -137,8 +144,8 @@ def InterfaceModportOp : SVOp<"interface.modport",
     Example:
 
     ```mlir
-    sv.interface.modport @input_port ("input" @data)
-    sv.interface.modport @output_port ("output" @data)
+    sv.interface.modport @input_port (input @data)
+    sv.interface.modport @output_port (output @data)
     ```
   }];
 

--- a/include/circt/Transforms/Passes.h
+++ b/include/circt/Transforms/Passes.h
@@ -13,6 +13,7 @@
 #ifndef CIRCT_TRANSFORMS_PASSES_H
 #define CIRCT_TRANSFORMS_PASSES_H
 
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 #include <limits>
 

--- a/include/circt/Transforms/Passes.td
+++ b/include/circt/Transforms/Passes.td
@@ -16,7 +16,7 @@
 include "mlir/Pass/PassBase.td"
 include "mlir/Rewrite/PassUtil.td"
 
-def FlattenMemRef : Pass<"flatten-memref", "ModuleOp"> {
+def FlattenMemRef : Pass<"flatten-memref", "::mlir::ModuleOp"> {
   let summary = "Flatten memrefs";
   let description = [{
     Flattens multidimensional memories and accesses to them into
@@ -25,7 +25,7 @@ def FlattenMemRef : Pass<"flatten-memref", "ModuleOp"> {
   let dependentDialects = ["memref::MemRefDialect"];
 }
 
-def FlattenMemRefCalls : Pass<"flatten-memref-calls", "ModuleOp"> {
+def FlattenMemRefCalls : Pass<"flatten-memref-calls", "::mlir::ModuleOp"> {
   let summary = "Flatten memref calls";
   let description = [{
     Flattens calls to functions which have multidimensional memrefs as arguments.

--- a/integration_test/EmitVerilog/sv-interfaces.mlir
+++ b/integration_test/EmitVerilog/sv-interfaces.mlir
@@ -8,8 +8,8 @@ module {
     sv.interface.signal @data : i32
     sv.interface.signal @valid : i1
     sv.interface.signal @ready : i1
-    sv.interface.modport @data_in ("input" @data, "input" @valid, "output" @ready)
-    sv.interface.modport @data_out ("output" @data, "output" @valid, "input" @ready)
+    sv.interface.modport @data_in (input @data, input @valid, output @ready)
+    sv.interface.modport @data_out (output @data, output @valid, input @ready)
   }
 
   // TODO: This ugly bit is because we don't yet have ExportVerilog support

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -24,6 +24,7 @@
 #include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Dialect/HW/HWTypes.h"
 #include "circt/Dialect/HW/HWVisitors.h"
+#include "circt/Dialect/SV/SVOps.h"
 #include "circt/Dialect/SV/SVVisitors.h"
 #include "circt/Support/LLVM.h"
 #include "circt/Support/LoweringOptions.h"
@@ -3443,7 +3444,7 @@ LogicalResult StmtEmitter::visitSV(InterfaceModportOp op) {
 
   llvm::interleaveComma(op.ports(), os, [&](const Attribute &portAttr) {
     auto port = portAttr.cast<ModportStructAttr>();
-    os << port.direction().getValue() << ' ';
+    os << stringifyEnum(port.direction().getValue()) << ' ';
     auto signalDecl = state.symbolCache.getDefinition(port.signal());
     os << getSymOpName(signalDecl);
   });

--- a/lib/Conversion/PassDetail.h
+++ b/lib/Conversion/PassDetail.h
@@ -10,6 +10,8 @@
 #ifndef CONVERSION_PASSDETAIL_H
 #define CONVERSION_PASSDETAIL_H
 
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/DialectRegistry.h"
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {

--- a/lib/Dialect/Handshake/CMakeLists.txt
+++ b/lib/Dialect/Handshake/CMakeLists.txt
@@ -18,6 +18,7 @@ add_circt_dialect_library(CIRCTHandshake
   DEPENDS
   MLIRHandshakeInterfacesIncGen
   MLIRHandshakeCanonicalizationIncGen
+  MLIRHandshakeAttributesIncGen
   MLIRHandshakeEnumsIncGen
   MLIRHandshakeAttrsIncGen
   )

--- a/lib/Dialect/Handshake/HandshakeDialect.cpp
+++ b/lib/Dialect/Handshake/HandshakeDialect.cpp
@@ -12,10 +12,10 @@
 
 #include "circt/Dialect/Handshake/HandshakeDialect.h"
 #include "circt/Dialect/Handshake/HandshakeOps.h"
-#include "llvm/ADT/TypeSwitch.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/DialectImplementation.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 using namespace circt;
 using namespace circt::handshake;

--- a/lib/Dialect/Handshake/HandshakeDialect.cpp
+++ b/lib/Dialect/Handshake/HandshakeDialect.cpp
@@ -12,6 +12,7 @@
 
 #include "circt/Dialect/Handshake/HandshakeDialect.h"
 #include "circt/Dialect/Handshake/HandshakeOps.h"
+#include "llvm/ADT/TypeSwitch.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/DialectImplementation.h"
@@ -29,9 +30,15 @@ void HandshakeDialect::initialize() {
 #define GET_OP_LIST
 #include "circt/Dialect/Handshake/Handshake.cpp.inc"
       >();
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include "circt/Dialect/Handshake/HandshakeAttributes.cpp.inc"
+      >();
 }
 
 // Provide implementations for the enums, attributes and interfaces that we use.
+#define GET_ATTRDEF_CLASSES
+#include "circt/Dialect/Handshake/HandshakeAttributes.cpp.inc"
 #include "circt/Dialect/Handshake/HandshakeAttrs.cpp.inc"
 #include "circt/Dialect/Handshake/HandshakeDialect.cpp.inc"
 #include "circt/Dialect/Handshake/HandshakeEnums.cpp.inc"

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -1015,8 +1015,8 @@ void handshake::BufferOp::build(OpBuilder &builder, OperationState &result,
   result.addOperands(operand);
   sost::addAttributes(result, size, innerType);
   result.addTypes({innerType});
-  result.addAttribute(
-      "bufferType", builder.getStringAttr(stringifyBufferTypeEnum(bufferType)));
+  result.addAttribute("bufferType",
+                      BufferTypeEnumAttr::get(result.getContext(), bufferType));
 }
 
 ParseResult BufferOp::parse(OpAsmParser &parser, OperationState &result) {
@@ -1028,25 +1028,11 @@ ParseResult BufferOp::parse(OpAsmParser &parser, OperationState &result) {
   if (sost::parseIntInSquareBrackets(parser, size))
     return failure();
 
-  StringRef bufferTypeStr;
-  NamedAttrList attrStorage;
-  auto loc = parser.getCurrentLocation();
-  if (parser.parseOptionalKeyword(&bufferTypeStr, {"seq", "fifo"})) {
-    StringAttr attrVal;
-    mlir::OptionalParseResult parseResult = parser.parseOptionalAttribute(
-        attrVal, parser.getBuilder().getNoneType(), "bufferType", attrStorage);
-    if (parseResult.hasValue()) {
-      if (failed(*parseResult))
-        return failure();
-      bufferTypeStr = attrVal.getValue();
-    } else {
-      return parser.emitError(
-          loc, "expected string or keyword containing one of the following "
-               "enum values for attribute 'bufferType' [seq, fifo].");
-    }
-  }
-  result.addAttribute("bufferType",
-                      parser.getBuilder().getStringAttr(bufferTypeStr));
+  auto bufferTypeAttr = BufferTypeEnumAttr::parse(parser, {});
+  if (!bufferTypeAttr)
+    return failure();
+
+  result.addAttribute("bufferType", bufferTypeAttr);
 
   if (parser.parseOperandList(allOperands) ||
       parser.parseOptionalAttrDict(result.attributes) || parser.parseColon() ||
@@ -1065,7 +1051,7 @@ void BufferOp::print(OpAsmPrinter &p) {
   int size =
       (*this)->getAttrOfType<IntegerAttr>("size").getValue().getZExtValue();
   p << " [" << size << "]";
-  p << " " << (*this)->getAttrOfType<StringAttr>("bufferType").getValue();
+  bufferTypeAttr().print(p);
   Type type = (*this)->getAttrOfType<TypeAttr>("dataType").getValue();
   p << " " << (*this)->getOperands();
   p.printOptionalAttrDict((*this)->getAttrs(),

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -1051,7 +1051,7 @@ void BufferOp::print(OpAsmPrinter &p) {
   int size =
       (*this)->getAttrOfType<IntegerAttr>("size").getValue().getZExtValue();
   p << " [" << size << "]";
-  bufferTypeAttr().print(p);
+  p << " " << stringifyEnum(bufferType());
   Type type = (*this)->getAttrOfType<TypeAttr>("dataType").getValue();
   p << " " << (*this)->getOperands();
   p.printOptionalAttrDict((*this)->getAttrs(),

--- a/lib/Dialect/Handshake/Transforms/Analysis.cpp
+++ b/lib/Dialect/Handshake/Transforms/Analysis.cpp
@@ -213,7 +213,7 @@ static std::string dotPrintNode(mlir::raw_indented_ostream &outfile,
                      [&](auto) { return "cbranch"; })
                  .Case<handshake::BufferOp>([&](auto op) {
                    std::string n = "buffer ";
-                   n += op.bufferType();
+                   n += stringifyEnum(op.bufferType());
                    return n;
                  })
                  .Case<arith::AddIOp>([&](auto) { return "+"; })

--- a/lib/Dialect/SV/SVDialect.cpp
+++ b/lib/Dialect/SV/SVDialect.cpp
@@ -19,6 +19,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringSet.h"
+#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/ManagedStatic.h"
 
 using namespace circt;
@@ -37,8 +38,14 @@ void SVDialect::initialize() {
 #define GET_OP_LIST
 #include "circt/Dialect/SV/SV.cpp.inc"
       >();
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include "circt/Dialect/SV/SVAttributes.cpp.inc"
+      >();
 }
 
+#define GET_ATTRDEF_CLASSES
+#include "circt/Dialect/SV/SVAttributes.cpp.inc"
 #include "circt/Dialect/SV/SVDialect.cpp.inc"
 
 //===----------------------------------------------------------------------===//

--- a/lib/Transforms/PassDetail.h
+++ b/lib/Transforms/PassDetail.h
@@ -10,6 +10,8 @@
 #ifndef TRANSFORMS_PASSDETAIL_H
 #define TRANSFORMS_PASSDETAIL_H
 
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/DialectRegistry.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/Passes.h"
 

--- a/test/Conversion/ExportVerilog/name-legalize.mlir
+++ b/test/Conversion/ExportVerilog/name-legalize.mlir
@@ -168,7 +168,7 @@ sv.interface @output {
   // CHECK-NEXT: logic wire_1;
   sv.interface.signal @wire : i1
   // CHECK-NEXT: modport always_2(input input_0, output wire_1);
-  sv.interface.modport @always ("input" @input, "output" @wire)
+  sv.interface.modport @always (input @input, output @wire)
 }
 
 // Renaming the above interface declarations needs to rename their use in the

--- a/test/Conversion/ExportVerilog/sv-interfaces.mlir
+++ b/test/Conversion/ExportVerilog/sv-interfaces.mlir
@@ -18,8 +18,8 @@ module {
     sv.interface.signal @ready : i1
     sv.interface.signal @arrayData : !hw.array<4xi8>
     sv.interface.signal @uarrayData : !hw.uarray<4xi8>
-    sv.interface.modport @data_in ("input" @data, "input" @valid, "output" @ready)
-    sv.interface.modport @data_out ("output" @data, "output" @valid, "input" @ready)
+    sv.interface.modport @data_in (input @data, input @valid, output @ready)
+    sv.interface.modport @data_out (output @data, output @valid, input @ready)
     sv.verbatim  "//MACRO({{0}}, {{1}}, {{2}} -- {{3}})"
                     {symbols = [@data, @valid, @ready, @data_in]}
   }
@@ -36,8 +36,8 @@ module {
     sv.interface.signal @data : !hw.struct<foo: i7, bar: !hw.array<5 x i16>>
     sv.interface.signal @valid : i1
     sv.interface.signal @ready : i1
-    sv.interface.modport @data_in ("input" @data, "input" @valid, "output" @ready)
-    sv.interface.modport @data_out ("output" @data, "output" @valid, "input" @ready)
+    sv.interface.modport @data_in (input @data, input @valid, output @ready)
+    sv.interface.modport @data_out (output @data, output @valid, input @ready)
   }
 
   hw.module.extern @Rcvr (%m: !sv.modport<@data_vr::@data_in>)

--- a/test/Dialect/ESI/connectivity.mlir
+++ b/test/Dialect/ESI/connectivity.mlir
@@ -53,8 +53,8 @@ sv.interface @IData {
   sv.interface.signal @data : i32
   sv.interface.signal @valid : i1
   sv.interface.signal @ready : i1
-  sv.interface.modport @Source ("input" @data, "input" @valid, "output" @ready)
-  sv.interface.modport @Sink ("output" @data, "output" @valid, "input" @ready)
+  sv.interface.modport @Source (input @data, input @valid, output @ready)
+  sv.interface.modport @Sink (output @data, output @valid, input @ready)
 }
 hw.module @testIfaceWrap() {
   %ifaceOut = sv.interface.instance : !sv.interface<@IData>

--- a/test/Dialect/ESI/errors.mlir
+++ b/test/Dialect/ESI/errors.mlir
@@ -4,7 +4,7 @@ sv.interface @IData {
   sv.interface.signal @data : i32
   sv.interface.signal @valid : i1
   sv.interface.signal @stall : i1
-  sv.interface.modport @Sink ("output" @data, "output" @valid, "input" @ready)
+  sv.interface.modport @Sink (output @data, output @valid, input @ready)
 }
 
 hw.module @test() {
@@ -20,7 +20,7 @@ sv.interface @IData {
   sv.interface.signal @data : i2
   sv.interface.signal @valid : i1
   sv.interface.signal @ready : i1
-  sv.interface.modport @Sink ("output" @data, "output" @valid, "input" @ready)
+  sv.interface.modport @Sink (output @data, output @valid, input @ready)
 }
 
 hw.module @test() {
@@ -36,7 +36,7 @@ sv.interface @IData {
   sv.interface.signal @data : i2
   sv.interface.signal @valid : i1
   sv.interface.signal @ready : i1
-  sv.interface.modport @Sink ("output" @data, "output" @valid, "input" @ready)
+  sv.interface.modport @Sink (output @data, output @valid, input @ready)
 }
 
 hw.module @test(%m : !sv.modport<@IData::@Noexist>) {

--- a/test/Dialect/ESI/lowering.mlir
+++ b/test/Dialect/ESI/lowering.mlir
@@ -13,14 +13,14 @@ hw.module.extern @Reciever(%a: !esi.channel<i4>, %clk: i1)
 // IFACE-NEXT:    sv.interface.signal @valid : i1
 // IFACE-NEXT:    sv.interface.signal @ready : i1
 // IFACE-NEXT:    sv.interface.signal @data : i4
-// IFACE-NEXT:    sv.interface.modport @sink ("input" @ready, "output" @valid, "output" @data)
-// IFACE-NEXT:    sv.interface.modport @source ("input" @valid, "input" @data, "output" @ready)
+// IFACE-NEXT:    sv.interface.modport @sink (input @ready, output @valid, output @data)
+// IFACE-NEXT:    sv.interface.modport @source (input @valid, input @data, output @ready)
 // IFACE-LABEL: sv.interface @IValidReady_ArrayOf4xi64 {
 // IFACE-NEXT:    sv.interface.signal @valid : i1
 // IFACE-NEXT:    sv.interface.signal @ready : i1
 // IFACE-NEXT:    sv.interface.signal @data : !hw.array<4xi64>
-// IFACE-NEXT:    sv.interface.modport @sink  ("input" @ready, "output" @valid, "output" @data)
-// IFACE-NEXT:    sv.interface.modport @source  ("input" @valid, "input" @data, "output" @ready)
+// IFACE-NEXT:    sv.interface.modport @sink  (input @ready, output @valid, output @data)
+// IFACE-NEXT:    sv.interface.modport @source  (input @valid, input @data, output @ready)
 // IFACE-LABEL: hw.module.extern @Sender(%clk: i1, %x: !sv.modport<@IValidReady_i4::@sink>) -> (y: i8)
 // IFACE-LABEL: hw.module.extern @ArrSender(%x: !sv.modport<@IValidReady_ArrayOf4xi64::@sink>)
 // IFACE-LABEL: hw.module.extern @Reciever(%a: !sv.modport<@IValidReady_i4::@source>, %clk: i1)

--- a/test/Dialect/ESI/wrapif-lowering.mlir
+++ b/test/Dialect/ESI/wrapif-lowering.mlir
@@ -4,8 +4,8 @@ sv.interface @IValidReady_i4 {
   sv.interface.signal @valid : i1
   sv.interface.signal @ready : i1
   sv.interface.signal @data : i4
-  sv.interface.modport @source  ("input" @ready, "output" @valid, "output" @data)
-  sv.interface.modport @sink  ("input" @valid, "input" @data, "output" @ready)
+  sv.interface.modport @source  (input @ready, output @valid, output @data)
+  sv.interface.modport @sink  (input @valid, input @data, output @ready)
 }
 
 hw.module @test(%clk:i1, %rstn:i1) {

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -191,7 +191,7 @@ firrtl.circuit "Foo" {
 firrtl.circuit "Foo" {
   firrtl.module @Foo() {
   // expected-error @+1 {{'firrtl.mem' op attribute 'writeLatency' failed to satisfy constraint: 32-bit signless integer attribute whose minimum value is 1}}
-    %m = firrtl.mem Undefined {depth = 32 : i64, name = "m", readLatency = 0 : i32, writeLatency = 0 : i32} : !firrtl.bundle<>
+    %m = firrtl.mem Undefined {depth = 32 : i64, name = "m", portNames = ["rw"], readLatency = 0 : i32, writeLatency = 0 : i32} : !firrtl.bundle<>
   }
 }
 

--- a/test/Dialect/Handshake/errors.mlir
+++ b/test/Dialect/Handshake/errors.mlir
@@ -118,7 +118,8 @@ handshake.func @invalid_buffer_init2(%arg0 : i32, %ctrl : none) -> (i32, none) {
 // -----
 
 handshake.func @invalid_buffer_init3(%arg0 : i32, %ctrl : none) -> (i32, none) {
-  // expected-error @+1 {{'handshake.buffer' expected string or keyword containing one of the following enum values for attribute 'bufferType' [seq, fifo].}}
+  // expected-error @+2 {{'handshake.buffer' expected valid keyword}}
+  // expected-error @+1 {{'handshake.buffer' failed to parse BufferTypeEnumAttr parameter 'value' which is to be a `::BufferTypeEnum`}}
   %0 = buffer [1]  %arg0 {initValues = [1]} : i32
   return %0, %ctrl : i32, none
 }
@@ -126,7 +127,8 @@ handshake.func @invalid_buffer_init3(%arg0 : i32, %ctrl : none) -> (i32, none) {
 // -----
 
 handshake.func @invalid_buffer_init4(%arg0 : i32, %ctrl : none) -> (i32, none) {
-  // expected-error @+1 {{'handshake.buffer' expected string or keyword containing one of the following enum values for attribute 'bufferType' [seq, fifo].}}
+  // expected-error @+2 {{'handshake.buffer' expected ::BufferTypeEnum to be one of: seq, fifo}}
+  // expected-error @+1 {{'handshake.buffer' failed to parse BufferTypeEnumAttr parameter 'value' which is to be a `::BufferTypeEnum`}}
   %0 = buffer [1] SEQ %arg0 {initValues = [1]} : i32
   return %0, %ctrl : i32, none
 }

--- a/test/Dialect/SV/interfaces.mlir
+++ b/test/Dialect/SV/interfaces.mlir
@@ -14,14 +14,14 @@ module {
 
   sv.interface @myinterface {
     sv.interface.signal @data : i32
-    sv.interface.modport @input_port ("input" @data)
-    sv.interface.modport @output_port ("output" @data)
+    sv.interface.modport @input_port (input @data)
+    sv.interface.modport @output_port (output @data)
   }
 
   // CHECK-NEXT: sv.interface @myinterface {
   // CHECK-NEXT:   sv.interface.signal @data : i32
-  // CHECK-NEXT:   sv.interface.modport @input_port ("input" @data)
-  // CHECK-NEXT:   sv.interface.modport @output_port ("output" @data)
+  // CHECK-NEXT:   sv.interface.modport @input_port (input @data)
+  // CHECK-NEXT:   sv.interface.modport @output_port (output @data)
   // CHECK-NEXT: }
 
   // Handshake-like interface smoke test
@@ -30,16 +30,16 @@ module {
     sv.interface.signal @data : i32
     sv.interface.signal @valid : i1
     sv.interface.signal @ready : i1
-    sv.interface.modport @dataflow_in ("input" @data, "input" @valid, "output" @ready)
-    sv.interface.modport @dataflow_out ("output" @data, "output" @valid, "input" @ready)
+    sv.interface.modport @dataflow_in (input @data, input @valid, output @ready)
+    sv.interface.modport @dataflow_out (output @data, output @valid, input @ready)
   }
 
   // CHECK-NEXT: sv.interface @handshake_example {
   // CHECK-NEXT:   sv.interface.signal @data : i32
   // CHECK-NEXT:   sv.interface.signal @valid : i1
   // CHECK-NEXT:   sv.interface.signal @ready : i1
-  // CHECK-NEXT:   sv.interface.modport @dataflow_in ("input" @data, "input" @valid, "output" @ready)
-  // CHECK-NEXT:   sv.interface.modport @dataflow_out ("output" @data, "output" @valid, "input" @ready)
+  // CHECK-NEXT:   sv.interface.modport @dataflow_in (input @data, input @valid, output @ready)
+  // CHECK-NEXT:   sv.interface.modport @dataflow_out (output @data, output @valid, input @ready)
   // CHECK-NEXT: }
 
   hw.module.extern @Rcvr (%m: !sv.modport<@handshake_example::@dataflow_in>)


### PR DESCRIPTION
This fixes the remaining issues with the LLVM bump and gets us to the latest version of LLVM (as of a few hours ago). First of all, huge amount of thanks to @youngar, who helped me work through a lot of the changes here.

The first change is not too major and involved adding in some `#include`s, since https://github.com/llvm/llvm-project/commit/36d3efea15e6202edd64b05de38d8379e2baddb2 removed them from `mlir/Pass/Pass.h`.

The second change is a lot more substantial, and it affects the **SV** dialect's `ModportDirectionAttr` and the **Handshake** dialect's `BufferTypeEnum`. This includes changes to the assembly format parsers and printers such that you must not put quotes around `input`, `output`, or `inout` in `sv.interface.modport` ops.

#### Before

```mlir
sv.interface @myinterface {
  sv.interface.signal @data : i32
  sv.interface.modport @input_port ("input" @data)
  sv.interface.modport @output_port ("output" @data)
}
```

#### After

```mlir
sv.interface @myinterface {
  sv.interface.signal @data : i32
  sv.interface.modport @input_port (input @data)
  sv.interface.modport @output_port (output @data)
}
```

The reason for this is due to `StrEnumAttr` being removed in favor of `EnumAttr`. mogball first [announced this](https://discourse.llvm.org/t/psa-stop-using-strenumattr-do-use-enumattr/5710) on Discourse back in January, and actually removed it in the last week in https://github.com/llvm/llvm-project/commit/60e34f8dddb4a3ae5b82e8d55728c021126c4af8.

To summarize that post, we now have to use integers to back enum attributes, but the new `EnumAttr` comes with compiler/tablegen magic to give us most of the convenience of string enums without actually using strings as the backing representation. The actual implementation of this new code requires a bit more boilerplate, as mogball mentions in that Discourse post, which makes things a bit more verbose to work with internally for now.

We now have two layers of classes to work with now, one being closer to the "enum" side of things and the other being closer to the "attr" side of things, and you may need to convert back and forth between the two representations, at least until this boilerplate can be cleaned up. Using `ModportDirection` as the example, we now have a `ModportDirection`, which serves as the enum holding `input`, `output`, and `inout` as enum values, and `ModportDirectionAttr`, which is the attr associated with it.

The ops hold the Attr version, but you may need the Enum version to perform some operations. To go from Attr -> Enum, there's a `getValue()` method, and to go from Enum -> Attr, there's a `::get()` method on the Attr. Since the enums are now backed by integers, if you want the string, you'll need to use the `stringfyEnum()` function.


In case it's helpful, this [patch](https://reviews.llvm.org/D117514#change-b5JBmLmhK89W) in upstream LLVM migrated most of the core MLIR dialects from StrEnumAttr to EnumAttr, and I used that as my primary reference for what needed to be changed.


Since this is a larger change, I can preemptively kick off the longer tests, and I can also try running this on some of SiFive's cores internally.