### PR TITLE
[firtool] Add --ir-sv flag

### DIFF
--- a/test/firtool/memory.fir
+++ b/test/firtool/memory.fir
@@ -1,5 +1,5 @@
-; RUN: firtool %s --format=fir  --ir-hw | FileCheck %s 
-; RUN: firtool %s --format=fir  --ir-hw --ignore-read-enable-mem | FileCheck --check-prefix=READ %s 
+; RUN: firtool %s --format=fir  --ir-sv | FileCheck %s
+; RUN: firtool %s --format=fir  --ir-sv --ignore-read-enable-mem | FileCheck --check-prefix=READ %s
 
 circuit Qux:
   module Qux:


### PR DESCRIPTION
Added a separate flag to dump the IR with `sv` ops, replacing `--ir-hw`.
From this point onwards, `--ir-hw` will dump IR in HW form, while `--ir-sv`
will include constructs (such as registers) expanded into SytemVerilog form.