### PR TITLE
[HMMemSimpImpl] Change an initialization to fix a syntax error

### DIFF
--- a/test/Dialect/SV/hw-memsim.mlir
+++ b/test/Dialect/SV/hw-memsim.mlir
@@ -104,15 +104,17 @@ hw.module.generated @FIRRTLMem_1_1_1_16_10_0_1_0_0, @FIRRTLMem(%ro_addr_0: i4, %
 //CHECK-NEXT:  sv.ifdef "SYNTHESIS" {
 //CHECK-NEXT:  } else {
 //CHECK-NEXT:    sv.ifdef "RANDOMIZE_MEM_INIT" {
-//CHECK-NEXT:      sv.verbatim "integer [[INITVAR:.+]];\0A" {{.+}}
+//CHECK-NEXT:      sv.verbatim "integer [[INITVAR1:.+]];\0A" {{.+}}
+//CHECK-NEXT:      sv.verbatim "integer [[INITVAR2:.+]];\0A" {{.+}}
 //CHECK-NEXT:    }
 //CHECK-NEXT:    sv.ifdef "RANDOMIZE_REG_INIT" {
 //CHECK-NEXT:    }
 //CHECK-NEXT:    sv.initial {
 //CHECK-NEXT:      sv.verbatim "`INIT_RANDOM_PROLOG_"
 //CHECK-NEXT:      sv.ifdef.procedural "RANDOMIZE_MEM_INIT" {
-//CHECK-NEXT:        sv.verbatim "for ([[INITVAR]] = 0; [[INITVAR]] < 10; [[INITVAR]] = [[INITVAR]] + 1)\0A  Memory[[[INITVAR]]]
-//CHECK-SAME{LITERAL}: = {`RANDOM}[15:0];"
+//CHECK-NEXT:        sv.reg sym @[[SYM:.*]] : !hw.inout<array<10xi32>>
+//CHECK-NEXT:        sv.verbatim "for ([[INITVAR1]] = 0; [[INITVAR1]] < 10; [[INITVAR1]] = [[INITVAR1]] + 1)\0A {{[{][{]0[}][}]}}[[[INITVAR1]]] = {{[{][{]}}`RANDOM{{[}][}]}};" {symbols = [#hw.innerNameRef<@FIRRTLMem_1_1_1_16_10_0_1_0_0::@[[SYM]]>]}
+//CHECK-NEXT:        sv.verbatim "for ([[INITVAR2]] = 0; [[INITVAR2]] < 10; [[INITVAR2]] = [[INITVAR2]] + 1)\0A  Memory[[[INITVAR2]]] = {{[{][{]0[}][}]}}[[[INITVAR2]]][15:0];" {symbols = [#hw.innerNameRef<@FIRRTLMem_1_1_1_16_10_0_1_0_0::@[[SYM]]>]}
 //CHECK-NEXT:      }
 //CHECK-NEXT:      sv.ifdef.procedural "RANDOMIZE_REG_INIT" {
 //CHECK-NEXT:      }
@@ -286,5 +288,9 @@ hw.module.generated @PR2769, @FIRRTLMem(%ro_addr_0: i4, %ro_en_0: i1, %ro_clock_
 
 // CHECK-LABEL: hw.module @RandomizeWeirdWidths
 // CHECK: sv.ifdef.procedural "RANDOMIZE_MEM_INIT"
-// CHECK-NEXT{LITERAL}: sv.verbatim "for (initvar = 0; initvar < 10; initvar = initvar + 1)\0A  Memory[initvar] = {{`RANDOM}, {`RANDOM}, {`RANDOM}, {`RANDOM}, {`RANDOM}}[144:0];"
+// CHECK-NEXT: %{{.*}} = sv.reg sym @[[SYM:.*]]  : !hw.inout<array<10xi160>>
+// CHECK-NEXT: sv.verbatim "for ([[INITVAR1:.*]] = 0; [[INITVAR1]] < 10; [[INITVAR1]] = [[INITVAR1]] + 1)\0A {{[{][{]0[}][}]}}[[[INITVAR1]]]
+// CHECK-SAME{LITERAL}: = {{`RANDOM}, {`RANDOM}, {`RANDOM}, {`RANDOM}, {`RANDOM}};"
+// CHECK-SAME: {symbols = [#hw.innerNameRef<@RandomizeWeirdWidths::@[[SYM]]>]}
+// CHECK-NEXT: sv.verbatim "for ([[INITVAR2:.*]] = 0; [[INITVAR2]] < 10; [[INITVAR2]] = [[INITVAR2]] + 1)\0A  Memory[[[INITVAR2]]] = {{[{][{]0[}][}]}}[[[INITVAR2]]][144:0];" {symbols = [#hw.innerNameRef<@RandomizeWeirdWidths::@[[SYM]]>]}
 hw.module.generated @RandomizeWeirdWidths, @FIRRTLMem(%ro_addr_0: i4, %ro_en_0: i1, %ro_clock_0: i1,%rw_addr_0: i4, %rw_en_0: i1,  %rw_clock_0: i1, %rw_wmode_0: i1, %rw_wdata_0: i145, %wo_addr_0: i4, %wo_en_0: i1, %wo_clock_0: i1, %wo_data_0: i145) -> (ro_data_0: i145, rw_rdata_0: i145) attributes {depth = 10 : i64, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 1 : ui32, readLatency = 2 : ui32, readUnderWrite = 0 : ui32, width = 145 : ui32, writeClockIDs = [], writeLatency = 4 : ui32, writeUnderWrite = 0 : i32}

--- a/test/firtool/memory.fir
+++ b/test/firtool/memory.fir
@@ -104,7 +104,8 @@ circuit Qux:
 ; CHECK-NEXT:    sv.ifdef "SYNTHESIS" {
 ; CHECK-NEXT:    } else {
 ; CHECK-NEXT:      sv.ifdef "RANDOMIZE_MEM_INIT" {
-; CHECK-NEXT:        sv.verbatim "integer [[INITVAR:.+]];\0A" {{.+}}
+; CHECK-NEXT:        sv.verbatim "integer [[INITVAR1:.+]];\0A" {{.+}}
+; CHECK-NEXT:        sv.verbatim "integer [[INITVAR2:.+]];\0A" {{.+}}
 ; CHECK-NEXT:      }
 ; CHECK-NEXT:      sv.ifdef "RANDOMIZE_REG_INIT" {
 ; CHECK-NEXT:        %[[RAND_1:.+]] = sv.reg sym @[[RAND_1_sym:[a-zA-Z0-9_]+]] : !hw.inout<i32>
@@ -112,8 +113,9 @@ circuit Qux:
 ; CHECK-NEXT:      sv.initial {
 ; CHECK-NEXT:        sv.verbatim "`INIT_RANDOM_PROLOG_"
 ; CHECK-NEXT:        sv.ifdef.procedural "RANDOMIZE_MEM_INIT" {
-; CHECK-NEXT:        sv.verbatim "for ([[INITVAR]] = 0; [[INITVAR]] < 16; [[INITVAR]] = [[INITVAR]] + 1)\0A  Memory[[[INITVAR]]]
-; CHECK-SAME{LITERAL}:  = {`RANDOM}[7:0];"
+; CHECK-NEXT:        sv.reg sym @[[SYM:.*]] : !hw.inout<array<16xi32>>
+; CHECK-NEXT:        sv.verbatim "for ([[INITVAR1]] = 0; [[INITVAR1]] < 16; [[INITVAR1]] = [[INITVAR1]] + 1)\0A {{[{][{]0[}][}]}}[[[INITVAR1]]] = {{[{][{]}}`RANDOM{{[}][}]}};" {symbols = [#hw.innerNameRef<@memory_ext::@[[SYM]]>]}
+; CHECK-NEXT:        sv.verbatim "for ([[INITVAR2]] = 0; [[INITVAR2]] < 16; [[INITVAR2]] = [[INITVAR2]] + 1)\0A  Memory[[[INITVAR2]]] = {{[{][{]0[}][}]}}[[[INITVAR2]]][7:0];" {symbols = [#hw.innerNameRef<@memory_ext::@[[SYM]]>]}
 ; CHECK-NEXT:        }
 ; CHECK-NEXT:        sv.ifdef.procedural "RANDOMIZE_REG_INIT" {
 ; CHECK-NEXT{LITERAL}:sv.verbatim "{{0}} = {`RANDOM};"


### PR DESCRIPTION
This is a follow-up to https://github.com/llvm/circt/pull/2860. Unfortunately, nc rejects`{{RANDOM}, {RANDOM}}[48:0];` as a syntax error. This PR fixes the syntax error by creating a register which contains all necessary randomized values and distribute values through the register.  e.g:
```verilog
reg [3:0][63:0] rand ;
reg [48:0] Memory [3:0] 

for(initvar1 = 0; initvar1 < 4; initvar1++)
rand[initvar1] = {{`RANDOM}, {`RANDOM}};
for(initvar2 = 0; initvar2 < 4; initvar2++)
Memory[initvar2] = rand[initvar2][48:0];
```