### PR TITLE
[SV] Fix HWMemSimImpl Bad Randomization Verilog

### DIFF
--- a/test/Dialect/SV/hw-memsim.mlir
+++ b/test/Dialect/SV/hw-memsim.mlir
@@ -105,14 +105,19 @@ hw.module.generated @FIRRTLMem_1_1_1_16_10_0_1_0_0, @FIRRTLMem(%ro_addr_0: i4, %
 //CHECK-NEXT:  } else {
 //CHECK-NEXT:    sv.ifdef "RANDOMIZE_MEM_INIT" {
 //CHECK-NEXT:      sv.verbatim "integer [[INITVAR:.+]];\0A" {{.+}}
+//CHECK-NEXT:      %[[RANDOM_MEM:.+]] = sv.reg sym @[[_RANDOM_MEM:.+]] : !hw.inout<i32>
 //CHECK-NEXT:    }
 //CHECK-NEXT:    sv.ifdef "RANDOMIZE_REG_INIT" {
 //CHECK-NEXT:    }
 //CHECK-NEXT:    sv.initial {
 //CHECK-NEXT:      sv.verbatim "`INIT_RANDOM_PROLOG_"
 //CHECK-NEXT:      sv.ifdef.procedural "RANDOMIZE_MEM_INIT" {
-//CHECK-NEXT:        sv.verbatim "for ([[INITVAR]] = 0; [[INITVAR]] < 10; [[INITVAR]] = [[INITVAR]] + 1)\0A  Memory[[[INITVAR]]]
-//CHECK-SAME{LITERAL}: = {`RANDOM}[15:0];"
+//CHECK-NEXT:        sv.verbatim "for ([[INITVAR]] = 0; [[INITVAR]] < 10; [[INITVAR]] = [[INITVAR]] + 1) begin\0A
+//CHECK-SAME{LITERAL}: {{0}} = {`RANDOM};\0A
+//CHECK-SAME:          Memory[[[INITVAR]]] =
+//CHECK-SAME{LITERAL}:   {{0}}[15:0];\0A
+//CHECK-SAME:          end"
+//CHECK-SAME:          {symbols = [#hw.innerNameRef<@FIRRTLMem_1_1_1_16_10_0_1_0_0::@[[_RANDOM_MEM]]>]}
 //CHECK-NEXT:      }
 //CHECK-NEXT:      sv.ifdef.procedural "RANDOMIZE_REG_INIT" {
 //CHECK-NEXT:      }
@@ -286,5 +291,5 @@ hw.module.generated @PR2769, @FIRRTLMem(%ro_addr_0: i4, %ro_en_0: i1, %ro_clock_
 
 // CHECK-LABEL: hw.module @RandomizeWeirdWidths
 // CHECK: sv.ifdef.procedural "RANDOMIZE_MEM_INIT"
-// CHECK-NEXT{LITERAL}: sv.verbatim "for (initvar = 0; initvar < 10; initvar = initvar + 1)\0A  Memory[initvar] = {{`RANDOM}, {`RANDOM}, {`RANDOM}, {`RANDOM}, {`RANDOM}}[144:0];"
+// CHECK-NEXT{LITERAL}: sv.verbatim "for (initvar = 0; initvar < 10; initvar = initvar + 1) begin\0A  {{0}} = {{`RANDOM}, {`RANDOM}, {`RANDOM}, {`RANDOM}, {`RANDOM}};\0A  Memory[initvar] = {{0}}[144:0];\0Aend"
 hw.module.generated @RandomizeWeirdWidths, @FIRRTLMem(%ro_addr_0: i4, %ro_en_0: i1, %ro_clock_0: i1,%rw_addr_0: i4, %rw_en_0: i1,  %rw_clock_0: i1, %rw_wmode_0: i1, %rw_wdata_0: i145, %wo_addr_0: i4, %wo_en_0: i1, %wo_clock_0: i1, %wo_data_0: i145) -> (ro_data_0: i145, rw_rdata_0: i145) attributes {depth = 10 : i64, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 1 : ui32, readLatency = 2 : ui32, readUnderWrite = 0 : ui32, width = 145 : ui32, writeClockIDs = [], writeLatency = 4 : ui32, writeUnderWrite = 0 : i32}

--- a/test/firtool/memory.fir
+++ b/test/firtool/memory.fir
@@ -105,6 +105,7 @@ circuit Qux:
 ; CHECK-NEXT:    } else {
 ; CHECK-NEXT:      sv.ifdef "RANDOMIZE_MEM_INIT" {
 ; CHECK-NEXT:        sv.verbatim "integer [[INITVAR:.+]];\0A" {{.+}}
+; CHECK-NEXT:        %[[_RANDOM_MEM:.+]] = sv.reg sym @[[_RANDOM_MEM_SYM:.+]] : !hw.inout<i32>
 ; CHECK-NEXT:      }
 ; CHECK-NEXT:      sv.ifdef "RANDOMIZE_REG_INIT" {
 ; CHECK-NEXT:        %[[RAND_1:.+]] = sv.reg sym @[[RAND_1_sym:[a-zA-Z0-9_]+]] : !hw.inout<i32>
@@ -112,8 +113,11 @@ circuit Qux:
 ; CHECK-NEXT:      sv.initial {
 ; CHECK-NEXT:        sv.verbatim "`INIT_RANDOM_PROLOG_"
 ; CHECK-NEXT:        sv.ifdef.procedural "RANDOMIZE_MEM_INIT" {
-; CHECK-NEXT:        sv.verbatim "for ([[INITVAR]] = 0; [[INITVAR]] < 16; [[INITVAR]] = [[INITVAR]] + 1)\0A  Memory[[[INITVAR]]]
-; CHECK-SAME{LITERAL}:  = {`RANDOM}[7:0];"
+; CHECK-NEXT:        sv.verbatim "for ([[INITVAR]] = 0; [[INITVAR]] < 16; [[INITVAR]] = [[INITVAR]] + 1) begin\0A
+; CHECK-SAME{LITERAL}:   {{0}} = {`RANDOM};\0A
+; CHECK-SAME:            Memory[[[INITVAR]]] =
+; CHECK-SAME{LITERAL}:     {{0}}[7:0];\0Aend"
+; CHECK-SAME:          symbols = [#hw.innerNameRef<@memory_ext::@[[_RANDOM_MEM_SYM]]>]}
 ; CHECK-NEXT:        }
 ; CHECK-NEXT:        sv.ifdef.procedural "RANDOMIZE_REG_INIT" {
 ; CHECK-NEXT{LITERAL}:sv.verbatim "{{0}} = {`RANDOM};"


### PR DESCRIPTION
Fix a bug in the verbatim Verilog created by HWMemSimImpl for
randomizing memories.  This previously relied on an invalid Verilog
construct (bit select out of a concatenation).  This is changed to be
legal by using a temporary register.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

E.g., memory randomization now looks like:

```verilog
  `ifndef SYNTHESIS
    `ifdef RANDOMIZE_MEM_INIT
      reg [63:0] _RANDOM_MEM;

      integer initvar;
    `endif
    `ifdef RANDOMIZE_REG_INIT
      reg [31:0] _RANDOM;

    `endif
    initial begin
      `INIT_RANDOM_PROLOG_
      `ifdef RANDOMIZE_MEM_INIT
        for (initvar = 0; initvar < 16; initvar = initvar + 1) begin
          _RANDOM_MEM = {{`RANDOM}, {`RANDOM}};
          Memory[initvar] = _RANDOM_MEM[32:0];
        end
      `endif
      `ifdef RANDOMIZE_REG_INIT
        _RANDOM = {`RANDOM};
        _GEN = _RANDOM[0];
        _GEN_0 = _RANDOM[4:1];
      `endif
    end // initial
  `endif
```

This creates a `_RANDOM_MEM` reg of size large enough to fit one word of the memory. It then bit extracts out of this what it needs. The above example is a memory with a 33-bit word size.

Closes #2905 (as this is an alternative implementation).