### PR TITLE
[Seq] Emit a single always block for registers defined in the same block

### DIFF
--- a/include/circt/Dialect/Seq/Seq.td
+++ b/include/circt/Dialect/Seq/Seq.td
@@ -52,7 +52,7 @@ def CompRegOp : SeqOp<"compreg",
   let hasCustomAssemblyFormat = 1;
 }
 
-def LowerSeqToSV: Pass<"lower-seq-to-sv", "mlir::ModuleOp"> {
+def LowerSeqToSV: Pass<"lower-seq-to-sv"> {
   let summary = "Lower sequential ops to SV.";
   let constructor = "circt::seq::createSeqLowerToSVPass()";
   let dependentDialects = ["circt::sv::SVDialect"];

--- a/test/Dialect/Seq/basic.mlir
+++ b/test/Dialect/Seq/basic.mlir
@@ -7,17 +7,6 @@ hw.module @top(%clk: i1, %rst: i1, %i: i32, %s: !hw.struct<foo: i32>) {
   seq.compreg %i, %clk : i32
   // CHECK: %{{.+}} = seq.compreg %i, %clk, %rst, %c0_i32  : i32
   // CHECK: %{{.+}} = seq.compreg %i, %clk : i32
-  // SV: [[REG0:%.+]] = sv.reg  : !hw.inout<i32>
-  // SV: [[REG5:%.+]] = sv.read_inout [[REG0]] : !hw.inout<i32>
-  // SV: sv.alwaysff(posedge %clk)  {
-  // SV:   sv.passign [[REG0]], %i : i32
-  // SV: }(syncreset : posedge %rst)  {
-  // SV:   sv.passign [[REG0]], %c0_i32 : i32
-  // SV: }
-  // SV: [[REG1:%.+]] = sv.reg  : !hw.inout<i32>
-  // SV: sv.alwaysff(posedge %clk)  {
-  // SV:   sv.passign [[REG1]], %i : i32
-  // SV: }
 
   %sv = hw.struct_create (%r0) : !hw.struct<foo: i32>
 
@@ -26,15 +15,29 @@ hw.module @top(%clk: i1, %rst: i1, %i: i32, %s: !hw.struct<foo: i32>) {
   // CHECK: %foo = seq.compreg %s, %clk, %rst, %{{.+}} : !hw.struct<foo: i32>
   // CHECK: %{{.+}} = seq.compreg %s, %clk : !hw.struct<foo: i32>
 
+  // SV: [[REG0:%.+]] = sv.reg  : !hw.inout<i32>
+  // SV: [[REG5:%.+]] = sv.read_inout [[REG0]] : !hw.inout<i32>
+  // SV: [[REG1:%.+]] = sv.reg  : !hw.inout<i32>
   // SV: [[REGST:%.+]] = hw.struct_create ([[REG5]]) : !hw.struct<foo: i32>
   // SV: %foo = sv.reg  : !hw.inout<struct<foo: i32>>
+
+
+
+
   // SV: sv.alwaysff(posedge %clk)  {
+  // SV:   sv.passign [[REG0]], %i : i32
   // SV:   sv.passign %foo, %s : !hw.struct<foo: i32>
   // SV: }(syncreset : posedge %rst)  {
+  // SV:   sv.passign [[REG0]], %c0_i32 : i32
   // SV:   sv.passign %foo, [[REGST]] : !hw.struct<foo: i32>
   // SV: }
+
   // SV: [[REG4:%.+]] = sv.reg : !hw.inout<struct<foo: i32>>
+  // SV: %bar = sv.reg sym @reg1
+  // SV: sv.reg sym @reg2
+
   // SV: sv.alwaysff(posedge %clk)  {
+  // SV:   sv.passign [[REG1]], %i : i32
   // SV:   sv.passign [[REG4]], %s : !hw.struct<foo: i32>
   // SV: }
 
@@ -42,7 +45,5 @@ hw.module @top(%clk: i1, %rst: i1, %i: i32, %s: !hw.struct<foo: i32>) {
   seq.compreg sym @reg2 %i, %clk : i32
   // CHECK: %bar = seq.compreg sym @reg1
   // CHECK: seq.compreg sym @reg2
-
-  // SV: %bar = sv.reg sym @reg1
-  // SV: sv.reg sym @reg2
 }
+


### PR DESCRIPTION
Combined `always_ff` blocks emitted for `seq.compreg` registers in the same basic block in order to reduce the number of ops generated by the `seq` to `sv` lowering.