### PR TITLE
[firtool] Rerun CSE after canonicalization in HW/SV pipeline

### DIFF
--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -555,6 +555,7 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
         auto &modulePM = pm.nest<hw::HWModuleOp>();
         modulePM.addPass(createCSEPass());
         modulePM.addPass(createSimpleCanonicalizerPass());
+        modulePM.addPass(createCSEPass());
         modulePM.addPass(sv::createHWCleanupPass());
       }
     }


### PR DESCRIPTION
This commit adds CSE after hw canonicalization to clean up values
created by canonicalization. Even though it will increase complie time slightly, 
I believe it is very beneficial to run CSE again in terms of verilog qualify. 
I have seen 20% simulation speed up for large designs. 

This also closes https://github.com/llvm/circt/issues/2449