### PR TITLE
[HW] Add a mutable specialization of `SymbolCache`

### DIFF
--- a/include/circt/Dialect/HW/HWSymCache.h
+++ b/include/circt/Dialect/HW/HWSymCache.h
@@ -76,6 +76,9 @@ public:
 
   Item getDefinition(InnerRefAttr name) const { return lookup(name); }
 
+protected:
+  bool isFrozen = false;
+
 private:
   Item lookup(InnerRefAttr attr) const {
     assert(isFrozen && "cannot read from this cache until it is frozen");
@@ -92,14 +95,20 @@ private:
     return it->second.getOp();
   }
 
-  bool isFrozen = false;
-
   /// This stores a lookup table from symbol attribute to the operation
   /// (hw.module, hw.instance, etc) that defines it.
   /// TODO: It is super annoying that symbols are *defined* as StringAttr, but
   /// are then referenced as FlatSymbolRefAttr.  Why can't we have nice
   /// pointer uniqued things?? :-(
   llvm::DenseMap<mlir::Attribute, Item> symbolCache;
+};
+
+/// Like a SymbolCache, but allows for unfreezing to add new definitions.
+class MutableSymbolCache : public SymbolCache {
+public:
+  /// Mark the cache as unfrozen, allowing for mutation. Caller should ensure
+  /// that the cache is no longer being read from after unfreezing occurs.
+  void unfreeze() { isFrozen = false; }
 };
 
 } // namespace hw


### PR DESCRIPTION
As proposed in #2882, it would be nice to have a `SymbolCache` which does not have a strict two-phase ordering to allow for mutation. The general usecases can be described as those where we, in a loop:
1. Perform a symbol cache lookup
2. Create a new module based on the results of that lookup
3. Update the symbol cache to reflect the existance of the new module

Without the ability to mutate the symbol cache, we'd need to rebuild it upon every loop iteration (defeating the purpose of having the cache).