### PR TITLE
[SV] Added `macro.ref` to reference macros.

### DIFF
--- a/include/circt/Dialect/SV/SVExpressions.td
+++ b/include/circt/Dialect/SV/SVExpressions.td
@@ -82,6 +82,29 @@ def VerbatimExprSEOp : SVOp<"verbatim.expr.se", [HasCustomSSAName]> {
   ];
 }
 
+def MacroRefExprOp : SVOp<"macro.ref", [NoSideEffect, HasCustomSSAName]> {
+  let summary = "Expression to refer to a SystemVerilog macro";
+  let description = [{
+    This operation produces a value by referencing a named macro.
+
+    Presently, it is assumed that the referenced macro is a constant with no
+    side effects.  This expression is subject to CSE.  It can be duplicated
+    and emitted inline by the Verilog emitter.
+    }];
+
+  let arguments = (ins MacroIdentAttr:$ident);
+  let results = (outs HWValueOrInOutType:$result);
+
+  let assemblyFormat = "`<` $ident `>` attr-dict `:` qualified(type($result))";
+
+  let builders = [
+    OpBuilder<(ins "Type":$resultType, "StringRef":$ident),
+               "build(odsBuilder, odsState, resultType, "
+                 "::circt::sv::MacroIdentAttr::get("
+                   "$_builder.getContext(), ident));">
+  ];
+}
+
 def ConstantXOp : SVOp<"constantX", [NoSideEffect, HasCustomSSAName]> {
   let summary = "A constant of value 'x'";
   let description = [{

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -94,6 +94,9 @@ def IfDefProceduralOp
   let builders = [
     OpBuilder<(ins "StringRef":$cond,
                       CArg<"std::function<void()>", "{}">:$thenCtor,
+                      CArg<"std::function<void()>", "{}">:$elseCtor)>,
+    OpBuilder<(ins "MacroIdentAttr":$cond,
+                      CArg<"std::function<void()>", "{}">:$thenCtor,
                       CArg<"std::function<void()>", "{}">:$elseCtor)>
   ];
 

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -30,7 +30,7 @@ public:
             // Expressions
             ReadInOutOp, ArrayIndexInOutOp, VerbatimExprOp, VerbatimExprSEOp,
             IndexedPartSelectInOutOp, IndexedPartSelectOp, StructFieldInOutOp,
-            ConstantXOp, ConstantZOp,
+            ConstantXOp, ConstantZOp, MacroRefExprOp,
             // Declarations.
             RegOp, WireOp, LocalParamOp, XMROp,
             // Control flow.
@@ -94,6 +94,7 @@ public:
   HANDLE(StructFieldInOutOp, Unhandled);
   HANDLE(ConstantXOp, Unhandled);
   HANDLE(ConstantZOp, Unhandled);
+  HANDLE(MacroRefExprOp, Unhandled);
 
   // Control flow.
   HANDLE(IfDefOp, Unhandled);

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -130,6 +130,10 @@ static bool isDuplicatableNullaryExpression(Operation *op) {
       return true;
   }
 
+  // If this is a macro reference without side effects, allow duplication.
+  if (isa<MacroRefExprOp>(op))
+    return true;
+
   return false;
 }
 
@@ -1538,6 +1542,7 @@ private:
   SubExprInfo visitSV(VerbatimExprSEOp op) {
     return visitVerbatimExprOp(op, op.symbols());
   }
+  SubExprInfo visitSV(MacroRefExprOp op);
   SubExprInfo visitSV(ConstantXOp op);
   SubExprInfo visitSV(ConstantZOp op);
 
@@ -1973,6 +1978,11 @@ SubExprInfo ExprEmitter::visitVerbatimExprOp(Operation *op, ArrayAttr symbols) {
       names);
 
   return {Unary, IsUnsigned};
+}
+
+SubExprInfo ExprEmitter::visitSV(MacroRefExprOp op) {
+  os << "`" << op.ident().getName();
+  return {LowestPrecedence, IsUnsigned};
 }
 
 SubExprInfo ExprEmitter::visitSV(ConstantXOp op) {

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -3608,7 +3608,7 @@ LogicalResult FIRRTLLowering::visitStmt(PrintFOp op) {
 
       // Emit an "sv.if '`PRINTF_COND_ & cond' into the #ifndef.
       Value ifCond =
-          builder.create<sv::VerbatimExprOp>(cond.getType(), "`PRINTF_COND_");
+          builder.create<sv::MacroRefExprOp>(cond.getType(), "PRINTF_COND_");
       ifCond = builder.createOrFold<comb::AndOp>(ifCond, cond);
 
       addIfProceduralBlock(ifCond, [&]() {
@@ -3638,7 +3638,7 @@ LogicalResult FIRRTLLowering::visitStmt(StopOp op) {
 
       // Emit an "sv.if '`STOP_COND_ & cond' into the #ifndef.
       Value ifCond =
-          builder.create<sv::VerbatimExprOp>(cond.getType(), "`STOP_COND_");
+          builder.create<sv::MacroRefExprOp>(cond.getType(), "STOP_COND_");
       ifCond = builder.createOrFold<comb::AndOp>(ifCond, cond);
       addIfProceduralBlock(ifCond, [&]() {
         // Emit the sv.fatal or sv.finish.
@@ -3771,11 +3771,11 @@ LogicalResult FIRRTLLowering::lowerVerificationStatement(
             circuitState.used_ASSERT_VERBOSE_COND = true;
             circuitState.used_STOP_COND = true;
             addIfProceduralBlock(
-                builder.create<sv::VerbatimExprOp>(boolType,
-                                                   "`ASSERT_VERBOSE_COND_"),
+                builder.create<sv::MacroRefExprOp>(boolType,
+                                                   "ASSERT_VERBOSE_COND_"),
                 [&]() { builder.create<sv::ErrorOp>(message, messageOps); });
             addIfProceduralBlock(
-                builder.create<sv::VerbatimExprOp>(boolType, "`STOP_COND_"),
+                builder.create<sv::MacroRefExprOp>(boolType, "STOP_COND_"),
                 [&]() { builder.create<sv::FatalOp>(); });
           });
         });

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -29,7 +29,8 @@ using namespace sv;
 /// Return true if the specified operation is an expression.
 bool sv::isExpression(Operation *op) {
   return isa<VerbatimExprOp, VerbatimExprSEOp, GetModportOp,
-             ReadInterfaceSignalOp, ConstantXOp, ConstantZOp>(op);
+             ReadInterfaceSignalOp, ConstantXOp, ConstantZOp, MacroRefExprOp>(
+      op);
 }
 
 LogicalResult sv::verifyInProceduralRegion(Operation *op) {
@@ -161,6 +162,15 @@ void VerbatimExprOp::getAsmResultNames(
 void VerbatimExprSEOp::getAsmResultNames(
     function_ref<void(Value, StringRef)> setNameFn) {
   getVerbatimExprAsmResultNames(getOperation(), std::move(setNameFn));
+}
+
+//===----------------------------------------------------------------------===//
+// MacroRefExprOp
+//===----------------------------------------------------------------------===//
+
+void MacroRefExprOp::getAsmResultNames(
+    function_ref<void(Value, StringRef)> setNameFn) {
+  setNameFn(getResult(), ident().getName());
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -23,8 +23,8 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
   // CHECK-NEXT:   `ifndef SYNTHESIS
     sv.ifdef.procedural "SYNTHESIS" {
     } else {
-  // CHECK-NEXT:     if (PRINTF_COND_ & 1'bx & 1'bz & 1'bz & cond & forceWire)
-      %tmp = sv.verbatim.expr "PRINTF_COND_" : () -> i1
+  // CHECK-NEXT:     if ((`PRINTF_COND_) & 1'bx & 1'bz & 1'bz & cond & forceWire)
+      %tmp = sv.macro.ref<"PRINTF_COND_"> : i1
       %verb_tmp = sv.verbatim.expr "{{0}}" : () -> i1 {symbols = [#hw.innerNameRef<@M1::@wire1>] }
       %tmp1 = sv.constantX : i1
       %tmp2 = sv.constantZ : i1

--- a/test/Conversion/ExportVerilog/verilog-basic.mlir
+++ b/test/Conversion/ExportVerilog/verilog-basic.mlir
@@ -367,13 +367,13 @@ hw.module @Print(%clock: i1, %reset: i1, %a: i4, %b: i4) {
   %c1_i5 = hw.constant 1 : i5
 
   // CHECK: always @(posedge clock) begin
-  // CHECK:   if (`PRINTF_COND_ & reset)
+  // CHECK:   if ((`PRINTF_COND_) & reset)
   // CHECK:     $fwrite(32'h80000002, "Hi %x %x\n", {1'h0, a} << 5'h1, b);
   // CHECK: end // always @(posedge)
   %0 = comb.concat %false, %a : i1, i4
   %1 = comb.shl %0, %c1_i5 : i5
   sv.always posedge %clock  {
-    %2 = sv.verbatim.expr "`PRINTF_COND_" : () -> i1
+    %2 = sv.macro.ref<"PRINTF_COND_"> : i1
     %3 = comb.and %2, %reset : i1
     sv.if %3  {
       sv.fwrite %fd, "Hi %x %x\0A"(%1, %b) : i5, i4

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -348,14 +348,14 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
     // CHECK:      sv.ifdef "SYNTHESIS" {
     // CHECK-NEXT: } else  {
-    // CHECK-NEXT: sv.always posedge %clock {
-    // CHECK-NEXT:     %PRINTF_COND_ = sv.verbatim.expr "`PRINTF_COND_" : () -> i1
+    // CHECK-NEXT:   sv.always posedge %clock {
+    // CHECK-NEXT:     %PRINTF_COND_ = sv.macro.ref< "PRINTF_COND_"> : i1
     // CHECK-NEXT:     [[AND:%.+]] = comb.and %PRINTF_COND_, %reset
     // CHECK-NEXT:     sv.if [[AND]] {
     // CHECK-NEXT:       [[FD:%.+]] = hw.constant -2147483646 : i32
     // CHECK-NEXT:       sv.fwrite [[FD]], "No operands!\0A"
     // CHECK-NEXT:     }
-    // CHECK-NEXT:     %PRINTF_COND__0 = sv.verbatim.expr "`PRINTF_COND_" : () -> i1
+    // CHECK-NEXT:     %PRINTF_COND__0 = sv.macro.ref< "PRINTF_COND_"> : i1
     // CHECK-NEXT:     [[AND:%.+]] = comb.and %PRINTF_COND__0, %reset : i1
     // CHECK-NEXT:     sv.if [[AND]] {
     // CHECK-NEXT:       [[FD:%.+]] = hw.constant -2147483646 : i32
@@ -389,7 +389,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: sv.ifdef "SYNTHESIS" {
     // CHECK-NEXT: } else {
     // CHECK-NEXT:   sv.always posedge %clock1 {
-    // CHECK-NEXT:     %STOP_COND_ = sv.verbatim.expr "`STOP_COND_" : () -> i1
+    // CHECK-NEXT:     %STOP_COND_ = sv.macro.ref< "STOP_COND_"> : i1
     // CHECK-NEXT:     %0 = comb.and %STOP_COND_, %reset : i1
     // CHECK-NEXT:     sv.if %0 {
     // CHECK-NEXT:       sv.fatal
@@ -398,7 +398,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.stop %clock1, %reset, 42
 
     // CHECK-NEXT:   sv.always posedge %clock2 {
-    // CHECK-NEXT:     %STOP_COND_ = sv.verbatim.expr "`STOP_COND_" : () -> i1
+    // CHECK-NEXT:     %STOP_COND_ = sv.macro.ref< "STOP_COND_"> : i1
     // CHECK-NEXT:     %0 = comb.and %STOP_COND_, %reset : i1
     // CHECK-NEXT:     sv.if %0 {
     // CHECK-NEXT:       sv.finish
@@ -575,11 +575,11 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: } else {
     // CHECK-NEXT:   sv.always posedge %clock {
     // CHECK-NEXT:     sv.if [[TMP2]] {
-    // CHECK-NEXT:       [[ASSERT_VERBOSE_COND:%.+]] = sv.verbatim.expr "`ASSERT_VERBOSE_COND_"
+    // CHECK-NEXT:       [[ASSERT_VERBOSE_COND:%.+]] = sv.macro.ref< "ASSERT_VERBOSE_COND_"> : i1
     // CHECK-NEXT:       sv.if [[ASSERT_VERBOSE_COND]] {
     // CHECK-NEXT:         sv.error "assert1"(%value) : i42
     // CHECK-NEXT:       }
-    // CHECK-NEXT:       [[STOP_COND:%.+]] = sv.verbatim.expr "`STOP_COND_"
+    // CHECK-NEXT:       [[STOP_COND:%.+]] = sv.macro.ref< "STOP_COND_"> : i1
     // CHECK-NEXT:       sv.if [[STOP_COND]] {
     // CHECK-NEXT:         sv.fatal
     // CHECK-NEXT:       }

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -20,7 +20,7 @@ hw.module @test1(%arg0: i1, %arg1: i1, %arg8: i8) {
   sv.always posedge  %arg0 {
     sv.ifdef.procedural "SYNTHESIS" {
     } else {
-      %tmp = sv.verbatim.expr "PRINTF_COND_" : () -> i1
+      %tmp = sv.macro.ref<"PRINTF_COND_">: i1
       %tmpx = sv.constantX : i1
       %tmpz = sv.constantZ : i1
       %tmp2 = comb.and %tmp, %tmpx, %tmpz, %arg1 : i1
@@ -39,7 +39,7 @@ hw.module @test1(%arg0: i1, %arg1: i1, %arg8: i8) {
   // CHECK-NEXT: sv.always posedge %arg0 {
   // CHECK-NEXT:   sv.ifdef.procedural "SYNTHESIS" {
   // CHECK-NEXT:   } else {
-  // CHECK-NEXT:     %PRINTF_COND_ = sv.verbatim.expr "PRINTF_COND_" : () -> i1
+  // CHECK-NEXT:     %PRINTF_COND_ = sv.macro.ref< "PRINTF_COND_"> : i1
   // CHECK-NEXT:     %x_i1 = sv.constantX : i1
   // CHECK-NEXT:     %z_i1 = sv.constantZ : i1
   // CHECK-NEXT:     [[COND:%.*]] = comb.and %PRINTF_COND_, %x_i1, %z_i1, %arg1 : i1

--- a/test/Dialect/SV/cse.mlir
+++ b/test/Dialect/SV/cse.mlir
@@ -1,0 +1,12 @@
+// RUN: circt-opt -cse %s | FileCheck %s
+
+// CHECK-LABEL: @cse_macro_ref()
+// CHECK: [[VAR:%.+]] = sv.macro.ref< "PRINTF_COND_"> : i1
+// CHECK: [[AND:%.+]] = comb.and [[VAR]], [[VAR]] : i1
+// CHECK: hw.output [[AND]] : i1
+hw.module @cse_macro_ref() -> (out: i1) {
+  %PRINTF_COND__0 = sv.macro.ref< "PRINTF_COND_"> : i1
+  %PRINTF_COND__1 = sv.macro.ref< "PRINTF_COND_"> : i1
+  %0 = comb.and %PRINTF_COND__0, %PRINTF_COND__1 : i1
+  hw.output %0 : i1
+}


### PR DESCRIPTION
Replaced verbatim expressions with an explicit `MacroRefExprOp` to refer to macros in `sv`.