### PR TITLE
[FIRParser] Fix partial connect expansion with analog in bundles

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1734,7 +1734,9 @@ void FIRStmtParser::emitPartialConnect(ImplicitLocOpBuilder &builder, Value dst,
                                        Value src) {
   auto dstType = dst.getType().cast<FIRRTLType>();
   auto srcType = src.getType().cast<FIRRTLType>();
-  if (dstType == srcType) {
+  if (dstType.isa<AnalogType>()) {
+    builder.create<AttachOp>(SmallVector{dst, src});
+  } else if (dstType == srcType && !dstType.containsAnalog()) {
     emitConnect(builder, dst, src);
   } else if (auto dstBundle = dstType.dyn_cast<BundleType>()) {
     auto srcBundle = srcType.cast<BundleType>();

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -90,6 +90,12 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     ; CHECK: firrtl.connect %_t, %_t_2
     _t <- _t_2
+    
+    ; CHECK: [[a0:%.+]] = firrtl.subfield %bundleWithAnalog(0)
+    ; CHECK: [[a1:%.+]] = firrtl.subfield %bundleWithAnalog(0)
+    ; CHECK: firrtl.attach [[a1]], [[a0]]
+    wire bundleWithAnalog : {a: Analog<1>}
+    bundleWithAnalog <- bundleWithAnalog
 
     ; CHECK: [[INV:%.+]]  = firrtl.invalidvalue : !firrtl.uint<1>
     ; CHECK-NEXT: firrtl.strictconnect %auto, [[INV]] : !firrtl.uint<1>


### PR DESCRIPTION
When the LHS and RHS of a partial connect were the same types, we would
 emit a regular connect, but we forgot to check if there were any
analog types inside the bundle. When this is the case, we have to recurse
on the bundle elements and attach the analog fields together.