### PR TITLE
[FIR][ExportVerilog] Pass parsed strings unchanged to the output

### DIFF
--- a/include/circt/Support/String.h
+++ b/include/circt/Support/String.h
@@ -1,0 +1,28 @@
+//===- String.h - String Utilities ------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Utilities for working with strings.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_SUPPORT_STRING_H
+#define CIRCT_SUPPORT_STRING_H
+
+#include "circt/Support/LLVM.h"
+
+namespace circt {
+
+/// Converts escape sequences to characters.
+llvm::Optional<std::string> unescape(StringRef str);
+
+/// Escapes special characters in a string.
+std::string escape(StringRef str);
+
+} // namespace circt
+
+#endif // CIRCT_SUPPORT_STRING_H

--- a/integration_test/EmitVerilog/basic.mlir
+++ b/integration_test/EmitVerilog/basic.mlir
@@ -10,7 +10,7 @@ module {
     %c1Shl = hw.instance "shl" @shl (a: %c1: i1) -> (b: i1)
     sv.always posedge %clk {
       %fd = hw.constant 0x80000002 : i32
-      sv.fwrite %fd, "tick\n"
+      sv.fwrite %fd, "tick\\n"
     }
   }
 

--- a/integration_test/EmitVerilog/standards-verilator.mlir
+++ b/integration_test/EmitVerilog/standards-verilator.mlir
@@ -30,7 +30,7 @@ hw.module @top(%clock : i1, %reset: i1,
 
   sv.alwaysff(posedge %clock) {
     %fd = hw.constant 0x80000002 : i32
-    sv.fwrite %fd, "Yo\n"
+    sv.fwrite %fd, "Yo\\n"
   }
   
   hw.output %0, %1 : i4, i4

--- a/integration_test/EmitVerilog/sv-interfaces.mlir
+++ b/integration_test/EmitVerilog/sv-interfaces.mlir
@@ -33,7 +33,7 @@ module {
     sv.always posedge %clk {
       %validValue = sv.interface.signal.read %iface(@data_vr::@valid) : i1
       %fd = hw.constant 0x80000002 : i32
-      sv.fwrite %fd, "valid: %d\n" (%validValue) : i1
+      sv.fwrite %fd, "valid: %d\\n" (%validValue) : i1
     }
     // CHECK: valid: 1
     // CHECK: valid: 1

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -29,6 +29,7 @@
 #include "circt/Support/LLVM.h"
 #include "circt/Support/LoweringOptions.h"
 #include "circt/Support/Path.h"
+#include "circt/Support/String.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/IR/Threading.h"
@@ -2731,9 +2732,7 @@ LogicalResult StmtEmitter::visitSV(FWriteOp op) {
 
   emitExpression(op.fd(), ops);
 
-  os << ", \"";
-  os.write_escaped(op.string());
-  os << '"';
+  os << ", \"" << op.string() << '"';
 
   for (auto operand : op.operands()) {
     os << ", ";
@@ -2837,9 +2836,7 @@ LogicalResult StmtEmitter::emitSeverityMessageTask(Operation *op,
     if (message) {
       if (verbosity)
         os << ", ";
-      os << "\"";
-      os.write_escaped(message.getValue());
-      os << "\"";
+      os << "\"" << message.getValue() << '"';
       for (auto operand : operands) {
         os << ", ";
         emitExpression(operand, ops);
@@ -2894,9 +2891,7 @@ void StmtEmitter::emitAssertionMessage(StringAttr message, ValueRange args,
                                        bool isConcurrent = false) {
   if (!message)
     return;
-  os << " else $error(\"";
-  os.write_escaped(message.getValue());
-  os << "\"";
+  os << " else $error(\"" << message.getValue() << '"';
   for (auto arg : args) {
     os << ", ";
     emitExpression(arg, ops);

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -415,9 +415,7 @@ void Emitter::emitStatement(PrintFOp op) {
   emitExpression(op.clock());
   os << ", ";
   emitExpression(op.cond());
-  os << ", \"";
-  os.write_escaped(op.formatString());
-  os << "\"";
+  os << ", \"" << op.formatString() << '"';
   for (auto operand : op.operands()) {
     os << ", ";
     emitExpression(operand);
@@ -437,9 +435,7 @@ void Emitter::emitVerifStatement(T op, StringRef mnemonic) {
   emitExpression(op.predicate());
   os << ", ";
   emitExpression(op.enable());
-  os << ", \"";
-  os.write_escaped(op.message());
-  os << "\"";
+  os << ", \"" << op.message() << '"';
   os << ")";
   if (!op.name().empty()) {
     os << " : " << op.name();

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2524,6 +2524,13 @@ ParseResult FIRStmtParser::parseMemPort(MemDirAttr direction) {
   return moduleContext.addSymbolEntry(id, memoryData, startLoc, true);
 }
 
+/// Remove quotes from a string.
+static StringRef unquote(StringRef str) {
+  assert(str.size() >= 2 && "string too short");
+  assert(str.front() == '"' && str.back() == '"' && "not quoted");
+  return str.drop_front().drop_back();
+}
+
 /// printf ::= 'printf(' exp exp StringLit exp* ')' name? info?
 ParseResult FIRStmtParser::parsePrintf() {
   auto startTok = consumeToken(FIRToken::lp_printf);
@@ -2552,10 +2559,9 @@ ParseResult FIRStmtParser::parsePrintf() {
 
   locationProcessor.setLoc(startTok.getLoc());
 
-  auto formatStrUnescaped = FIRToken::getStringValue(formatString);
   builder.create<PrintFOp>(clock, condition,
-                           builder.getStringAttr(formatStrUnescaped), operands,
-                           name);
+                           builder.getStringAttr(unquote(formatString)),
+                           operands, name);
   return success();
 }
 
@@ -2613,8 +2619,7 @@ ParseResult FIRStmtParser::parseAssert() {
     return failure();
 
   locationProcessor.setLoc(startTok.getLoc());
-  auto messageUnescaped = FIRToken::getStringValue(message);
-  builder.create<AssertOp>(clock, predicate, enable, messageUnescaped,
+  builder.create<AssertOp>(clock, predicate, enable, unquote(message),
                            ValueRange{}, name.getValue());
   return success();
 }
@@ -2636,8 +2641,7 @@ ParseResult FIRStmtParser::parseAssume() {
     return failure();
 
   locationProcessor.setLoc(startTok.getLoc());
-  auto messageUnescaped = FIRToken::getStringValue(message);
-  builder.create<AssumeOp>(clock, predicate, enable, messageUnescaped,
+  builder.create<AssumeOp>(clock, predicate, enable, unquote(message),
                            ValueRange{}, name.getValue());
   return success();
 }
@@ -2659,8 +2663,7 @@ ParseResult FIRStmtParser::parseCover() {
     return failure();
 
   locationProcessor.setLoc(startTok.getLoc());
-  auto messageUnescaped = FIRToken::getStringValue(message);
-  builder.create<CoverOp>(clock, predicate, enable, messageUnescaped,
+  builder.create<CoverOp>(clock, predicate, enable, unquote(message),
                           ValueRange{}, name.getValue());
   return success();
 }

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -9,6 +9,7 @@ add_circt_library(CIRCTSupport
   LoweringOptions.cpp
   Path.cpp
   APInt.cpp
+  String.cpp
   ValueMapper.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/Support/String.cpp
+++ b/lib/Support/String.cpp
@@ -1,0 +1,108 @@
+//===- String.cpp - String Utilities ----------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Utilities for working with strings.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Support/String.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
+
+llvm::Optional<std::string> circt::unescape(StringRef str) {
+  std::string result;
+  result.reserve(str.size());
+  for (size_t i = 0, e = str.size(); i != e;) {
+    auto c = str[i++];
+    if (c != '\\') {
+      result.push_back(c);
+      continue;
+    }
+
+    if (i >= e)
+      return llvm::None;
+
+    char c1 = str[i++];
+    switch (c1) {
+    case '"':
+    case '\'':
+    case '\\':
+      result.push_back(c1);
+      continue;
+    case 'b':
+      result.push_back('\b');
+      continue;
+    case 'n':
+      result.push_back('\n');
+      continue;
+    case 't':
+      result.push_back('\t');
+      continue;
+    case 'f':
+      result.push_back('\f');
+      continue;
+    case 'r':
+      result.push_back('\r');
+      continue;
+    default:
+      break;
+    }
+
+    if (i >= e)
+      return llvm::None;
+
+    auto c2 = str[i++];
+    if (!llvm::isHexDigit(c1) || !llvm::isHexDigit(c2))
+      return llvm::None;
+
+    result.push_back((llvm::hexDigitValue(c1) << 4) | llvm::hexDigitValue(c2));
+  }
+  return result;
+}
+
+std::string circt::escape(StringRef str) {
+  std::string result;
+  llvm::raw_string_ostream os(result);
+
+  for (unsigned char c : str) {
+    switch (c) {
+    case '\\':
+      os << '\\' << '\\';
+      break;
+    case '\b':
+      os << '\\' << 'b';
+      break;
+    case '\n':
+      os << '\\' << 'n';
+      break;
+    case '\t':
+      os << '\\' << 't';
+      break;
+    case '\f':
+      os << '\\' << 'f';
+      break;
+    case '"':
+      os << '\\' << '"';
+      break;
+    case '\'':
+      os << '\\' << '\'';
+      break;
+    default:
+      if (llvm::isPrint(c)) {
+        os << c;
+      } else {
+        os << '\\';
+        os << llvm::hexdigit((c >> 4) & 0xF);
+        os << llvm::hexdigit((c >> 0) & 0xF);
+      }
+      break;
+    }
+  }
+  return result;
+}

--- a/test/Conversion/ExportVerilog/disallow-local-vars.mlir
+++ b/test/Conversion/ExportVerilog/disallow-local-vars.mlir
@@ -69,7 +69,7 @@ hw.module @hoist_expressions(%clock: i1, %x: i8, %y: i8, %z: i8) {
       // CHECK: $fwrite(32'h80000002, "Hi %x\n", _GEN * z);
       // DISALLOW: $fwrite(32'h80000002, "Hi %x\n", _GEN * z);
       %2 = comb.mul %0, %z : i8
-      sv.fwrite %fd, "Hi %x\0A"(%2) : i8
+      sv.fwrite %fd, "Hi %x\\n"(%2) : i8
       sv.fatal 1
     }
   }

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -31,7 +31,7 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
       %tmp3 = comb.and %tmp, %tmp1, %tmp2, %tmp2, %cond, %verb_tmp : i1
       sv.if %tmp3 {
   // CHECK-NEXT:       $fwrite(32'h80000002, "Hi\n");
-        sv.fwrite %fd, "Hi\n"
+        sv.fwrite %fd, "Hi\\n"
       }
 
   // CHECK-NEXT: release forceWire;
@@ -64,7 +64,7 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
   // CHECK-NEXT: always_ff @(posedge clock)
   // CHECK-NEXT:   $fwrite(32'h80000002, "Yo\n");
   sv.alwaysff(posedge %clock) {
-    sv.fwrite %fd, "Yo\n"
+    sv.fwrite %fd, "Yo\\n"
   }
 
   // CHECK-NEXT: always_ff @(posedge clock) begin
@@ -74,9 +74,9 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
   // CHECK-NEXT:     $fwrite(32'h80000002, "Sync Main Block\n");
   // CHECK-NEXT: end // always_ff @(posedge)
   sv.alwaysff(posedge %clock) {
-    sv.fwrite %fd, "Sync Main Block\n"
+    sv.fwrite %fd, "Sync Main Block\\n"
   } ( syncreset : posedge %cond) {
-    sv.fwrite %fd, "Sync Reset Block\n"
+    sv.fwrite %fd, "Sync Reset Block\\n"
   }
 
   // CHECK-NEXT: always_ff @(posedge clock or negedge cond) begin
@@ -86,9 +86,9 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
   // CHECK-NEXT:     $fwrite(32'h80000002, "Async Main Block\n");
   // CHECK-NEXT: end // always_ff @(posedge or negedge)
   sv.alwaysff(posedge %clock) {
-    sv.fwrite %fd, "Async Main Block\n"
+    sv.fwrite %fd, "Async Main Block\\n"
   } ( asyncreset : negedge %cond) {
-    sv.fwrite %fd, "Async Reset Block\n"
+    sv.fwrite %fd, "Async Reset Block\\n"
   }
 
   // CHECK-NEXT:  initial begin
@@ -119,7 +119,7 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
       %add = comb.add %val, %c42 : i8
 
       // CHECK-NEXT: $fwrite(32'h80000002, "Inlined! %x\n", 8'(val + 8'h2A));
-      sv.fwrite %fd, "Inlined! %x\n"(%add) : i8
+      sv.fwrite %fd, "Inlined! %x\\n"(%add) : i8
     }
 
     // begin/end required here to avoid else-confusion.
@@ -129,23 +129,23 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
       // CHECK-NEXT: if (clock)
       sv.if %clock {
         // CHECK-NEXT: $fwrite(32'h80000002, "Inside Block\n");
-        sv.fwrite %fd, "Inside Block\n"
+        sv.fwrite %fd, "Inside Block\\n"
       }
       // CHECK-NEXT: end
     } else { // CHECK-NEXT: else
       // CHECK-NOT: begin
       // CHECK-NEXT: $fwrite(32'h80000002, "Else Block\n");
-      sv.fwrite %fd, "Else Block\n"
+      sv.fwrite %fd, "Else Block\\n"
     }
 
     // CHECK-NEXT:   if (cond) begin
     sv.if %cond {
       // CHECK-NEXT:     $fwrite(32'h80000002, "Hi\n");
-      sv.fwrite %fd, "Hi\n"
+      sv.fwrite %fd, "Hi\\n"
 
       // CHECK-NEXT:     $fwrite(32'h80000002, "Bye %x\n", 8'(val + val));
       %tmp = comb.add %val, %val : i8
-      sv.fwrite %fd, "Bye %x\n"(%tmp) : i8
+      sv.fwrite %fd, "Bye %x\\n"(%tmp) : i8
 
       // CHECK-NEXT:     assert(cond);
       sv.assert %cond, immediate
@@ -235,7 +235,7 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
       %text = sv.verbatim.expr "`MACRO({{0}}, {{1}})" (%add, %xor): (i8,i8) -> i8
 
       // CHECK-NEXT: $fwrite(32'h80000002, "M: %x\n", `MACRO(8'(val + 8'h2A), val ^ 8'h2A));
-      sv.fwrite %fd, "M: %x\n"(%text) : i8
+      sv.fwrite %fd, "M: %x\\n"(%text) : i8
 
     }// CHECK-NEXT:   {{end$}}
   }

--- a/test/Conversion/ExportVerilog/sv-interfaces.mlir
+++ b/test/Conversion/ExportVerilog/sv-interfaces.mlir
@@ -73,7 +73,7 @@ module {
 
       %validValue = sv.interface.signal.read %iface(@data_vr::@valid) : i1
       // CHECK: $fwrite(32'h80000002, "valid: %d\n", iface.valid);
-      sv.fwrite %fd, "valid: %d\n" (%validValue) : i1
+      sv.fwrite %fd, "valid: %d\\n" (%validValue) : i1
       // CHECK: assert(iface.valid);
       sv.assert %validValue, immediate
 

--- a/test/Conversion/ExportVerilog/verilog-basic.mlir
+++ b/test/Conversion/ExportVerilog/verilog-basic.mlir
@@ -376,7 +376,7 @@ hw.module @Print(%clock: i1, %reset: i1, %a: i4, %b: i4) {
     %2 = sv.verbatim.expr "`PRINTF_COND_" : () -> i1
     %3 = comb.and %2, %reset : i1
     sv.if %3  {
-      sv.fwrite %fd, "Hi %x %x\0A"(%1, %b) : i5, i4
+      sv.fwrite %fd, "Hi %x %x\\n"(%1, %b) : i5, i4
     }
   }
   hw.output

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -83,7 +83,7 @@ firrtl.circuit "Foo" {
     // CHECK: skip
     firrtl.skip
     // CHECK: printf(someClock, ui1, "some\n magic\"stuff\"", ui1, someReset) : foo
-    firrtl.printf %someClock, %ui1, "some\n magic\"stuff\"" {name = "foo"} (%ui1, %someReset) : !firrtl.uint<1>, !firrtl.reset
+    firrtl.printf %someClock, %ui1, "some\\n magic\\\"stuff\\\"" {name = "foo"} (%ui1, %someReset) : !firrtl.uint<1>, !firrtl.reset
     // CHECK: assert(someClock, ui1, ui1, "msg") : foo
     // CHECK: assume(someClock, ui1, ui1, "msg") : foo
     // CHECK: cover(someClock, ui1, ui1, "msg") : foo

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -262,10 +262,10 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     else :
       _t <= _t_2
 
-    ; CHECK: firrtl.printf %clock, %reset, "Something interesting!\0A %x %x" (%_t, %_t_2) : !firrtl.vector<uint<1>, 12>, !firrtl.vector<uint<1>, 12>
+    ; CHECK: firrtl.printf %clock, %reset, "Something interesting!\\n %x %x" (%_t, %_t_2) : !firrtl.vector<uint<1>, 12>, !firrtl.vector<uint<1>, 12>
     printf(clock, reset, "Something interesting!\n %x %x", _t, _t_2)
 
-    ; CHECK: firrtl.printf %clock, %reset, "Something interesting!\0A %x %x" {name = "printf_0"}(%_t, %_t_2) : !firrtl.vector<uint<1>, 12>, !firrtl.vector<uint<1>, 12>
+    ; CHECK: firrtl.printf %clock, %reset, "Something interesting!\\n %x %x" {name = "printf_0"}(%_t, %_t_2) : !firrtl.vector<uint<1>, 12>, !firrtl.vector<uint<1>, 12>
     printf(clock, reset, "Something interesting!\n %x %x", _t, _t_2) : printf_0
 
     ; CHECK: firrtl.stop %clock, %reset, 42

--- a/test/firtool/escape.fir
+++ b/test/firtool/escape.fir
@@ -1,0 +1,15 @@
+; RUN: firtool %s -verilog | FileCheck %s
+
+
+circuit unicode_escape_in_string :
+  module unicode_escape_in_string :
+    input clock : Clock
+    input en : UInt<1>
+    ; CHECK: "PreservesUnicode \u2019s"
+    printf(clock, en, "PreservesUnicode \u2019s")
+
+    ; CHECK: "PreservesWhitespace \n \t \b"
+    printf(clock, en, "PreservesWhitespace \n \t \b")
+
+    ; CHECK: "PreservesQuotes \' \""
+    printf(clock, en, "PreservesQuotes \' \"")


### PR DESCRIPTION
Instead of un-escaping strings in the parser, they are passed through
the pipeline verbatim until they are printed. This is required in
order to support unicode escapes originating from Chisel.

String are unescaped/escaped where it is used in the JSON parser of the assertion generator.