### PR TITLE
[SV] Add custom parser for case op for validation qualifier

### DIFF
--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -304,11 +304,14 @@ def CaseZStmt: I32EnumAttrCase<"CaseZStmt", 2, "casez">;
 def CaseStmtTypeAttr : I32EnumAttr<"CaseStmtType", "case type",
                                    [CaseStmt, CaseXStmt, CaseZStmt]>;
 
-def ValidationQualifierUnique: I32EnumAttrCase<"ValidationQualifierUnique", 0, "unique">;
-def ValidationQualifierUnique0: I32EnumAttrCase<"ValidationQualifierUnique0", 1, "unique0">;
-def ValidationQualifierPriority: I32EnumAttrCase<"ValidationQualifierPriority", 2, "priority">;
-def ValidationQualifierTypeEnum: I32EnumAttr<"ValidationQualifierTypeEnumAttr", "validation qualifier type",
-              [ValidationQualifierUnique, ValidationQualifierUnique0, ValidationQualifierPriority]> {
+def ValidationQualifierPlain: I32EnumAttrCase<"ValidationQualifierPlain", 0, "plain">;
+def ValidationQualifierUnique: I32EnumAttrCase<"ValidationQualifierUnique", 1, "unique">;
+def ValidationQualifierUnique0: I32EnumAttrCase<"ValidationQualifierUnique0", 2, "unique0">;
+def ValidationQualifierPriority: I32EnumAttrCase<"ValidationQualifierPriority", 3, "priority">;
+
+def ValidationQualifierTypeEnum: I32EnumAttr<"ValidationQualifierTypeEnum", "validation qualifier type",
+              [ValidationQualifierPlain, ValidationQualifierUnique,
+               ValidationQualifierUnique0, ValidationQualifierPriority]> {
   let genSpecializedAttr = 0;
   let cppNamespace = "::circt::sv";
 }
@@ -324,7 +327,9 @@ def CaseOp : SVOp<"case", [SingleBlock, NoTerminator, NoRegionArguments,
   let arguments = (ins DefaultValuedAttr<CaseStmtTypeAttr,
                                          "CaseStmtType::CaseStmt">:$caseStyle,
                        HWIntegerType:$cond, ArrayAttr:$casePatterns,
-                       OptionalAttr<ValidationQualifierTypeAttr>: $validationQualifier);
+                       DefaultValuedAttr<ValidationQualifierTypeAttr,
+                       "ValidationQualifierTypeEnum::ValidationQualifierPlain">:
+                       $validationQualifier);
   let results = (outs);
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3215,9 +3215,10 @@ LogicalResult StmtEmitter::visitSV(CaseOp op) {
   SmallPtrSet<Operation *, 8> ops, emptyOps;
   ops.insert(op);
   indent();
-  if (op.validationQualifier().hasValue())
-    os << stringifyValidationQualifierTypeEnumAttr(
-              op.validationQualifier().getValue())
+  if (op.validationQualifier() !=
+      ValidationQualifierTypeEnum::ValidationQualifierPlain)
+    os << circt::sv::stringifyValidationQualifierTypeEnum(
+              op.validationQualifier())
        << " ";
   const char *opname = nullptr;
   switch (op.caseStyle()) {

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -395,7 +395,7 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
      } // CHECK-NEXT: endcase
 
     // CHECK-NEXT: priority case (cond)
-    sv.case %cond : i1 {validationQualifier = #sv<"validation_qualifier priority">}
+    sv.case priority %cond : i1
     // CHECK-NEXT: default:
     default: {
       // CHECK-NEXT: $fwrite(32'h80000002, "zero");
@@ -403,7 +403,7 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
     } // CHECK-NEXT: endcase
 
     // CHECK-NEXT: unique casez (cond)
-    sv.case casez %cond : i1 {validationQualifier = #sv<"validation_qualifier unique">}
+    sv.case casez unique %cond : i1
     // CHECK-NEXT: default:
     default: {
       // CHECK-NEXT: $fwrite(32'h80000002, "zero");


### PR DESCRIPTION
This is a follow-up to https://github.com/llvm/circt/pull/2913 to implement custom parser for case op. Also DefaultValuedAttr is used instead of OptionalValuedAttr. 