### PR TITLE
[FIRRTL] Delete GCT taps that have no ports

### DIFF
--- a/test/Dialect/FIRRTL/grand-central-taps.mlir
+++ b/test/Dialect/FIRRTL/grand-central-taps.mlir
@@ -522,3 +522,20 @@ firrtl.circuit "Top" {
   // CHECK-SAME: symbols = [@Top, #hw.innerNameRef<@Top::@dut>, #hw.innerNameRef<@DUT::@submodule_2>, #hw.innerNameRef<@Submodule::@bar>]
   firrtl.extmodule @MemTap_2(out mem_0: !firrtl.uint<1> [{class = "sifive.enterprise.grandcentral.MemTapAnnotation", id = 1 : i64, word = 0 : i64}]) attributes {defname = "MemTap"}
 }
+
+// -----
+
+// Check that an empty data tap module and its instantiations is deleted.
+
+// CHECK-LABEL: "Top"
+// CHECK-NOT: firrtl.extmodule {{.+}}@DataTap
+// CHECK-NOT: firrtl.instance DataTap @DataTap()
+firrtl.circuit "Top" {
+  firrtl.extmodule @DataTap() attributes {annotations = [{class = "sifive.enterprise.grandcentral.DataTapsAnnotation"}]}
+  firrtl.module @DUT() {
+    firrtl.instance DataTap @DataTap()
+  }
+  firrtl.module @Top() {
+    firrtl.instance dut @DUT()
+  }
+}


### PR DESCRIPTION
Fix a bug in the GrandCentralTaps pass where data or mem taps that had
no ports would result in external module instantiations in the final
design that had no corresponding implementation.  Change the
GrandCentralTaps pass to delete these modules and their instantiations.
This can arise more frequently due to a recent change to the Grand
Central Chisel API where zero-width taps are now allowed in the API,
generate a tap module, but generate no actual taps.

An alternative implementation would be to generate empty modules which
are cleaned up later.  This seemed wasteful.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>