### PR TITLE
[Seq] Add a seq register to represent FIRRTL registers

### DIFF
--- a/include/circt/Dialect/Seq/Seq.td
+++ b/include/circt/Dialect/Seq/Seq.td
@@ -62,4 +62,69 @@ def CompRegOp : SeqOp<"compreg",
   ];
 }
 
+def FirRegOp : SeqOp<"firreg",
+    [NoSideEffect, AllTypesMatch<["next", "data"/*, "resetValue"*/]>,
+     SameVariadicOperandSize,
+     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
+      // AllTypesMatch doesn't work with Optional types yet.
+
+  let summary = "Register with preset and sync or async reset";
+  let description = [{
+    `firreg` represents registers originating from FIRRTL after the lowering
+    of the IR to HW.  The register is used as an intermediary in the process
+    of lowering to SystemVerilog to facilitate optimisation at the HW level,
+    compactly representing a register with a single operation instead of
+    composing it from register definitions, always blocks and if statements.
+
+    The `data` output of the register accesses the value it stores.  On the
+    rising edge of the `clk` input, the register takes a new value provided
+    by the `next` signal.  Optionally, the register can also be provided with
+    a synchronous or an asynchronous `reset` signal and `resetValue`, as shown
+    in the example below.
+
+    ```
+    %name = seq.firreg %next clock %clk [ sym @sym ]
+        [ reset (sync|async) %reset, %value ] : type
+    ```
+
+    Implicitly, all registers are pre-set to a randomized value.
+
+    A register implementing a counter starting at 0 from reset can be defined
+    as follows:
+
+    ```
+    %zero = hw.constant 0 : i32
+    %reg = seq.firreg %next clock %clk reset sync %reset, %zero : i32
+    %one = hw.constant 1 : i32
+    %next = comb.add %zero, %one : i32
+    ```
+  }];
+
+  let arguments = (ins AnyType:$next, I1:$clk, StrAttr:$name,
+                       OptionalAttr<SymbolNameAttr>:$inner_sym,
+                       Optional<I1>:$reset, Optional<AnyType>:$resetValue,
+                       UnitAttr:$isAsync);
+  let results = (outs AnyType:$data);
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins "Value":$next, "Value":$clk,
+                   "StringAttr":$name,
+                   CArg<"StringAttr", "{}">:$inner_sym)>,
+    OpBuilder<(ins "Value":$next, "Value":$clk,
+                   "StringAttr":$name,
+                   "Value":$reset, "Value":$resetValue,
+                   CArg<"StringAttr", "{}">:$inner_sym,
+                   CArg<"bool", "false">:$isAsync)>
+  ];
+
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    /// Check whether the register has a reset value.
+    bool hasReset() { return !!getReset(); }
+  }];
+}
+
 #endif // SEQ_TD

--- a/integration_test/Dialect/Seq/registers.mlir
+++ b/integration_test/Dialect/Seq/registers.mlir
@@ -1,0 +1,34 @@
+// REQUIRES: verilator
+// RUN: circt-opt %s -lower-seq-to-sv -export-verilog -verify-diagnostics -o %t2.mlir > %t1.sv
+// RUN: verilator --lint-only +1364-1995ext+v %t1.sv
+// RUN: verilator --lint-only +1364-2001ext+v %t1.sv
+// RUN: verilator --lint-only +1364-2005ext+v %t1.sv
+// RUN: verilator --lint-only +1800-2005ext+sv %t1.sv
+// RUN: verilator --lint-only +1800-2009ext+sv %t1.sv
+// RUN: verilator --lint-only +1800-2012ext+sv %t1.sv
+// RUN: verilator --lint-only +1800-2017ext+sv %t1.sv
+
+sv.verbatim "`define INIT_RANDOM_PROLOG_"
+
+hw.module @top(%clk: i1, %rstn: i1) {
+  %cst0 = hw.constant 0 : i32
+  %cst1 = hw.constant 1 : i32
+
+  %true = hw.constant 1 : i1
+  %rst = comb.xor %true, %rstn : i1
+
+  %rC = seq.firreg %nextC clock %clk sym @regC reset sync %rst, %cst0 : i32
+  %rB = seq.firreg %nextB clock %clk sym @regB reset sync %rst, %cst0 : i32
+  %rA = seq.firreg %nextA clock %clk sym @regA reset sync %rst, %cst0 : i32
+
+  %nextA = comb.add %rA, %cst1 : i32
+  %nextB = comb.add %rB, %rA : i32
+  %nextC = comb.add %rC, %rB : i32
+
+  sv.alwaysff(posedge %clk) {
+    %fd = hw.constant 0x80000002 : i32
+    sv.fwrite %fd, "%d %d %d\n"(%rA, %rB, %rC) : i32, i32, i32
+  }
+
+  hw.output
+}

--- a/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
@@ -11,14 +11,21 @@
 //===----------------------------------------------------------------------===//
 
 #include "PassDetails.h"
+#include "circt/Dialect/HW/HWAttributes.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/Namespace.h"
 #include "circt/Dialect/SV/SVAttributes.h"
 #include "circt/Dialect/SV/SVOps.h"
 #include "circt/Dialect/Seq/SeqOps.h"
 #include "circt/Dialect/Seq/SeqPasses.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/IntervalMap.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include <variant>
 
 using namespace circt;
 using namespace seq;
@@ -75,10 +82,378 @@ public:
 };
 } // namespace
 
+namespace {
+/// Lower FirRegOp to `sv.reg` and `sv.always`.
+class FirRegLower {
+public:
+  FirRegLower(hw::HWModuleOp module) : module(module), ns(module) {}
+
+  void lower();
+
+private:
+  /// Cache for constants.
+  DenseMap<APInt, Value> constants;
+
+  Value getConstant(const APInt &v) {
+    auto it = constants.try_emplace(v, Value{});
+    if (it.second) {
+      auto builder = ImplicitLocOpBuilder::atBlockBegin(module.getLoc(),
+                                                        module.getBodyBlock());
+      it.first->second = builder.create<hw::ConstantOp>(v);
+    }
+    return it.first->second;
+  }
+
+  using AsyncResetSignal = std::pair<Value, Value>;
+
+  std::pair<sv::RegOp, llvm::Optional<AsyncResetSignal>> lower(FirRegOp reg);
+
+  void initialise(OpBuilder &regBuilder, OpBuilder &initBuilder, sv::RegOp reg);
+
+  void addToAlwaysBlock(sv::EventControl clockEdge, Value clock,
+                        std::function<void(OpBuilder &)> body,
+                        ResetType resetStyle = {},
+                        sv::EventControl resetEdge = {}, Value reset = {},
+                        std::function<void(OpBuilder &)> resetBody = {});
+
+  using AlwaysKeyType = std::tuple<Block *, sv::EventControl, Value, ResetType,
+                                   sv::EventControl, Value>;
+  llvm::SmallDenseMap<AlwaysKeyType, std::pair<sv::AlwaysOp, sv::IfOp>>
+      alwaysBlocks;
+
+  hw::HWModuleOp module;
+  hw::ModuleNamespace ns;
+
+  /// This is a map from block to a pair of a random value and its unused
+  /// bits. It is used to reduce the number of random value.
+  std::pair<Value, unsigned> randomValueAndRemain;
+};
+} // namespace
+
+void FirRegLower::lower() {
+  // Find all registers to lower in the module.
+  auto regs = module.getOps<seq::FirRegOp>();
+  if (regs.empty())
+    return;
+
+  // Lower the regs to SV regs.
+  SmallVector<std::pair<sv::RegOp, llvm::Optional<AsyncResetSignal>>> toInit;
+  for (auto reg : llvm::make_early_inc_range(regs))
+    toInit.push_back(lower(reg));
+
+  // Create an initial block at the end of the module where random
+  // initialisation will be inserted.  Create two builders into the two
+  // `ifdef` ops where the registers will be placed.
+  //
+  // `ifdef SYNTHESIS
+  //   `ifdef RANDOMIZE_REG_INIT
+  //      ... regBuilder ...
+  //   `endif
+  //   initial
+  //     `INIT_RANDOM_PROLOG_
+  //     ... initBuilder ..
+  // `endif
+  if (!toInit.empty()) {
+    auto loc = module.getLoc();
+    MLIRContext *context = module.getContext();
+    auto randInitRef = sv::MacroIdentAttr::get(context, "RANDOMIZE_REG_INIT");
+
+    auto builder =
+        ImplicitLocOpBuilder::atBlockTerminator(loc, module.getBodyBlock());
+    builder.create<sv::IfDefOp>(
+        "SYNTHESIS", [] {},
+        [&] {
+          builder.create<sv::OrderedOutputOp>([&] {
+            auto ifInitOp = builder.create<sv::IfDefOp>(randInitRef);
+            auto regBuilder =
+                ImplicitLocOpBuilder::atBlockEnd(loc, ifInitOp.getThenBlock());
+
+            builder.create<sv::IfDefOp>("FIRRTL_BEFORE_INITIAL", [&] {
+              builder.create<sv::VerbatimOp>("`FIRRTL_BEFORE_INITIAL");
+            });
+
+            builder.create<sv::InitialOp>([&] {
+              builder.create<sv::VerbatimOp>("`INIT_RANDOM_PROLOG_");
+
+              llvm::DenseMap<Value, SmallVector<std::pair<sv::RegOp, Value>>>
+                  resets;
+              builder.create<sv::IfDefProceduralOp>(randInitRef, [&] {
+                // Create initialisers for all registers.
+                for (auto &[svReg, asyncReset] : toInit) {
+                  initialise(regBuilder, builder, svReg);
+                  if (asyncReset) {
+                    auto &[resetSignal, resetValue] = *asyncReset;
+                    resets[resetSignal].emplace_back(svReg, resetValue);
+                  }
+                }
+              });
+
+              if (!resets.empty()) {
+                builder.create<sv::IfDefProceduralOp>("RANDOMIZE", [&] {
+                  // If the register is async reset, we need to insert extra
+                  // initialization in post-randomization so that we can set the
+                  // reset value to register if the reset signal is enabled.
+                  for (auto &reset : resets) {
+                    // Create a block guarded by the RANDOMIZE macro and the
+                    // reset: `ifdef RANDOMIZE
+                    //   if (reset) begin
+                    //     ..
+                    //   end
+                    // `endif
+                    builder.create<sv::IfOp>(reset.first, [&] {
+                      for (auto &[reg, value] : reset.second)
+                        builder.create<sv::BPAssignOp>(reg.getLoc(), reg,
+                                                       value);
+                    });
+                  }
+                });
+              }
+            });
+
+            builder.create<sv::IfDefOp>("FIRRTL_AFTER_INITIAL", [&] {
+              builder.create<sv::VerbatimOp>("`FIRRTL_AFTER_INITIAL");
+            });
+          });
+        });
+  }
+}
+
+std::pair<sv::RegOp, llvm::Optional<FirRegLower::AsyncResetSignal>>
+FirRegLower::lower(FirRegOp reg) {
+  Location loc = reg.getLoc();
+
+  ImplicitLocOpBuilder builder(reg.getLoc(), reg);
+  auto svReg = builder.create<sv::RegOp>(loc, reg.getResult().getType(),
+                                         reg.getNameAttr());
+  svReg->setDialectAttrs(reg->getDialectAttrs());
+
+  if (auto innerSymAttr = reg.getInnerSymAttr())
+    svReg.setInnerSymAttr(innerSymAttr);
+  else
+    svReg.setInnerSymAttr(
+        builder.getStringAttr(ns.newName(Twine("__") + reg.getName() + "__")));
+
+  auto regVal = builder.create<sv::ReadInOutOp>(loc, svReg);
+
+  auto setInput = [&](OpBuilder &builder) {
+    if (reg.getNext() != reg)
+      builder.create<sv::PAssignOp>(loc, svReg, reg.getNext());
+  };
+
+  llvm::Optional<AsyncResetSignal> asyncReset;
+  if (reg.hasReset()) {
+    addToAlwaysBlock(
+        sv::EventControl::AtPosEdge, reg.getClk(), setInput,
+        reg.getIsAsync() ? ResetType::AsyncReset : ResetType::SyncReset,
+        sv::EventControl::AtPosEdge, reg.getReset(), [&](OpBuilder &builder) {
+          builder.create<sv::PAssignOp>(loc, svReg, reg.getResetValue());
+        });
+
+    if (reg.getIsAsync()) {
+      asyncReset = std::make_pair(reg.getReset(), reg.getResetValue());
+    }
+  } else {
+    addToAlwaysBlock(sv::EventControl::AtPosEdge, reg.getClk(), setInput);
+  }
+
+  reg.replaceAllUsesWith(regVal.getResult());
+  reg.erase();
+
+  return {svReg, asyncReset};
+}
+
+void FirRegLower::initialise(OpBuilder &regBuilder, OpBuilder &initBuilder,
+                             sv::RegOp reg) {
+  typedef std::pair<Attribute, std::pair<unsigned, unsigned>> SymbolAndRange;
+
+  auto regDefSym =
+      hw::InnerRefAttr::get(module.getNameAttr(), reg.getInnerSymAttr());
+
+  // Construct and return a new reference to `RANDOM.  It is always a 32-bit
+  // unsigned expression.  Calls to $random have side effects, so we use
+  // VerbatimExprSEOp.
+  constexpr unsigned randomWidth = 32;
+  auto getRandom32Val = [&](const char *suffix = "") -> Value {
+    sv::RegOp randReg = regBuilder.create<sv::RegOp>(
+        reg.getLoc(), regBuilder.getIntegerType(randomWidth),
+        /*name=*/regBuilder.getStringAttr("_RANDOM"),
+        /*inner_sym=*/
+        regBuilder.getStringAttr(ns.newName("_RANDOM")));
+
+    initBuilder.create<sv::VerbatimOp>(
+        reg.getLoc(), initBuilder.getStringAttr("{{0}} = {`RANDOM};"),
+        ValueRange{},
+        initBuilder.getArrayAttr({hw::InnerRefAttr::get(
+            module.getNameAttr(), randReg.getInnerSymAttr())}));
+
+    return randReg.getResult();
+  };
+
+  auto getRandomValues = [&](IntegerType type,
+                             SmallVector<SymbolAndRange> &values) {
+    auto width = type.getWidth();
+    assert(width != 0 && "zero bit width's not supported");
+    while (width > 0) {
+      // If there are no bits left, then generate a new random value.
+      if (!randomValueAndRemain.second)
+        randomValueAndRemain = {getRandom32Val("foo"), randomWidth};
+
+      auto reg = cast<sv::RegOp>(randomValueAndRemain.first.getDefiningOp());
+
+      auto symbol =
+          hw::InnerRefAttr::get(module.getNameAttr(), reg.getInnerSymAttr());
+      unsigned low = randomWidth - randomValueAndRemain.second;
+      unsigned high = randomWidth - 1;
+      if (width <= randomValueAndRemain.second)
+        high = width - 1 + low;
+      unsigned consumed = high - low + 1;
+      values.push_back({symbol, {high, low}});
+      randomValueAndRemain.second -= consumed;
+      width -= consumed;
+    }
+  };
+
+  // Get a random value with the specified width, combining or truncating
+  // 32-bit units as necessary.
+  auto emitRandomInit = [&](Value dest, Type type, const Twine &accessor) {
+    auto intType = type.cast<IntegerType>();
+    if (intType.getWidth() == 0)
+      return;
+
+    SmallVector<SymbolAndRange> values;
+    getRandomValues(intType, values);
+
+    SmallString<32> rhs(("{{0}}" + accessor + " = ").str());
+    unsigned i = 1;
+    SmallVector<Attribute, 4> symbols({regDefSym});
+    if (values.size() > 1)
+      rhs.append("{");
+    for (auto [value, range] : llvm::reverse(values)) {
+      symbols.push_back(value);
+      auto [high, low] = range;
+      if (i > 1)
+        rhs.append(", ");
+      rhs.append(("{{" + Twine(i++) + "}}").str());
+
+      // This uses all bits of the random value. Emit without part select.
+      if (high == randomWidth - 1 && low == 0)
+        continue;
+
+      // Emit a single bit part select, e.g., emit "[0]" and not "[0:0]".
+      if (high == low) {
+        rhs.append(("[" + Twine(high) + "]").str());
+        continue;
+      }
+
+      // Emit a part select, e.g., "[4:2]"
+      rhs.append(
+          ("[" + Twine(range.first) + ":" + Twine(range.second) + "]").str());
+    }
+    if (values.size() > 1)
+      rhs.append("}");
+    rhs.append(";");
+
+    initBuilder.create<sv::VerbatimOp>(reg.getLoc(), rhs, ValueRange{},
+                                       initBuilder.getArrayAttr(symbols));
+  };
+
+  // Randomly initialize everything in the register. If the register
+  // is an aggregate type, then assign random values to all its
+  // constituent ground types.
+  auto type = reg.getType().dyn_cast<hw::InOutType>().getElementType();
+  std::function<void(Type, const Twine &)> recurse = [&](Type type,
+                                                         const Twine &member) {
+    TypeSwitch<Type>(type)
+        .Case<hw::UnpackedArrayType, hw::ArrayType>([&](auto a) {
+          for (size_t i = 0, e = a.getSize(); i != e; ++i)
+            recurse(a.getElementType(), member + "[" + Twine(i) + "]");
+        })
+        .Case<hw::StructType>([&](hw::StructType s) {
+          for (auto elem : s.getElements())
+            recurse(elem.type, member + "." + elem.name.getValue());
+        })
+        .Default([&](auto type) { emitRandomInit(reg, type, member); });
+  };
+  recurse(type, "");
+}
+
+void FirRegLower::addToAlwaysBlock(sv::EventControl clockEdge, Value clock,
+                                   std::function<void(OpBuilder &)> body,
+                                   ::ResetType resetStyle,
+                                   sv::EventControl resetEdge, Value reset,
+                                   std::function<void(OpBuilder &)> resetBody) {
+  auto loc = module.getLoc();
+  auto builder =
+      ImplicitLocOpBuilder::atBlockTerminator(loc, module.getBodyBlock());
+
+  auto &op = alwaysBlocks[{builder.getBlock(), clockEdge, clock, resetStyle,
+                           resetEdge, reset}];
+  auto &alwaysOp = op.first;
+  auto &insideIfOp = op.second;
+
+  if (!alwaysOp) {
+    if (reset) {
+      assert(resetStyle != ::ResetType::NoReset);
+      // Here, we want to create the folloing structure with sv.always and
+      // sv.if. If `reset` is async, we need to add `reset` to a sensitivity
+      // list.
+      //
+      // sv.always @(clockEdge or reset) {
+      //   sv.if (reset) {
+      //     resetBody
+      //   } else {
+      //     body
+      //   }
+      // }
+
+      auto createIfOp = [&]() {
+        // It is weird but intended. Here we want to create an empty sv.if
+        // with an else block.
+        insideIfOp = builder.create<sv::IfOp>(
+            reset, []() {}, []() {});
+      };
+      if (resetStyle == ::ResetType::AsyncReset) {
+        sv::EventControl events[] = {clockEdge, resetEdge};
+        Value clocks[] = {clock, reset};
+
+        alwaysOp = builder.create<sv::AlwaysOp>(events, clocks, [&]() {
+          if (resetEdge == sv::EventControl::AtNegEdge)
+            llvm_unreachable("negative edge for reset is not expected");
+          createIfOp();
+        });
+      } else {
+        alwaysOp = builder.create<sv::AlwaysOp>(clockEdge, clock, createIfOp);
+      }
+    } else {
+      assert(!resetBody);
+      alwaysOp = builder.create<sv::AlwaysOp>(clockEdge, clock);
+      insideIfOp = nullptr;
+    }
+  }
+
+  if (reset) {
+    assert(insideIfOp && "reset body must be initialized before");
+    auto resetBuilder =
+        ImplicitLocOpBuilder::atBlockEnd(loc, insideIfOp.getThenBlock());
+    resetBody(resetBuilder);
+
+    auto bodyBuilder =
+        ImplicitLocOpBuilder::atBlockEnd(loc, insideIfOp.getElseBlock());
+    body(bodyBuilder);
+  } else {
+    auto bodyBuilder =
+        ImplicitLocOpBuilder::atBlockEnd(loc, alwaysOp.getBodyBlock());
+    body(bodyBuilder);
+  }
+}
+
 void SeqToSVPass::runOnOperation() {
   ModuleOp top = getOperation();
-  MLIRContext &ctxt = getContext();
 
+  for (auto module : top.getOps<hw::HWModuleOp>())
+    FirRegLower(module).lower();
+
+  MLIRContext &ctxt = getContext();
   ConversionTarget target(ctxt);
   target.addIllegalDialect<SeqDialect>();
   target.addLegalDialect<sv::SVDialect>();

--- a/test/Dialect/Seq/firreg-errors.mlir
+++ b/test/Dialect/Seq/firreg-errors.mlir
@@ -1,0 +1,6 @@
+// RUN: circt-opt %s -verify-diagnostics --split-input-file
+
+hw.module @NeedsBothResetAndResetValue(%input: i1, %clk: i1) {
+  // expected-error@+1 {{'seq.firreg' op must specify reset and reset value}}
+  "seq.firreg"(%input, %clk) { name = "reg", isAsync } : (i1, i1) -> i1
+}

--- a/test/Dialect/Seq/firreg.mlir
+++ b/test/Dialect/Seq/firreg.mlir
@@ -1,0 +1,450 @@
+// RUN: circt-opt %s -verify-diagnostics --lower-seq-to-sv | FileCheck %s
+
+// CHECK-LABEL: hw.module @lowering
+hw.module @lowering(%clk: i1, %rst: i1, %in: i32) -> (a: i32, b: i32, c: i32, d: i32, e: i32, f: i32) {
+  %cst0 = hw.constant 0 : i32
+
+  // CHECK: %rA = sv.reg sym @regA : !hw.inout<i32>
+  // CHECK: [[VAL_A:%.+]] = sv.read_inout %rA : !hw.inout<i32>
+  %rA = seq.firreg %in clock %clk sym @regA : i32
+
+  // CHECK: %rB = sv.reg sym @regB : !hw.inout<i32>
+  // CHECK: [[VAL_B:%.+]] = sv.read_inout %rB : !hw.inout<i32>
+  %rB = seq.firreg %in clock %clk sym @regB reset sync %rst, %cst0 : i32
+
+  // CHECK: %rC = sv.reg sym @regC : !hw.inout<i32>
+  // CHECK: [[VAL_C:%.+]] = sv.read_inout %rC : !hw.inout<i32>
+  %rC = seq.firreg %in clock %clk sym @regC reset async %rst, %cst0 : i32
+
+  // CHECK: %rD = sv.reg sym @regD : !hw.inout<i32>
+  // CHECK: [[VAL_D:%.+]] = sv.read_inout %rD : !hw.inout<i32>
+  %rD = seq.firreg %in clock %clk sym @regD : i32
+
+  // CHECK: %rE = sv.reg sym @regE : !hw.inout<i32>
+  // CHECK: [[VAL_E:%.+]] = sv.read_inout %rE : !hw.inout<i32>
+  %rE = seq.firreg %in clock %clk sym @regE reset sync %rst, %cst0 : i32
+
+  // CHECK: %rF = sv.reg sym @regF : !hw.inout<i32>
+  // CHECK: [[VAL_F:%.+]] = sv.read_inout %rF : !hw.inout<i32>
+  %rF = seq.firreg %in clock %clk sym @regF reset async %rst, %cst0 : i32
+
+  // CHECK: %rAnamed = sv.reg sym @regA : !hw.inout<i32>
+  %r = seq.firreg %in clock %clk sym @regA { "name" = "rAnamed" }: i32
+
+  // CHECK: %rNoSym = sv.reg sym @__rNoSym__ : !hw.inout<i32>
+  %rNoSym = seq.firreg %in clock %clk : i32
+
+  // CHECK:      sv.always posedge %clk {
+  // CHECK-NEXT:   sv.passign %rA, %in : i32
+  // CHECK-NEXT:   sv.passign %rD, %in : i32
+  // CHECK-NEXT:   sv.passign %rAnamed, %in : i32
+  // CHECK-NEXT:   sv.passign %rNoSym, %in : i32
+  // CHECK-NEXT: }
+  // CHECK-NEXT: sv.always posedge %clk {
+  // CHECK-NEXT:   sv.if %rst {
+  // CHECK-NEXT:     sv.passign %rB, %c0_i32 : i32
+  // CHECK-NEXT:     sv.passign %rE, %c0_i32 : i32
+  // CHECK-NEXT:   } else {
+  // CHECK-NEXT:     sv.passign %rB, %in : i32
+  // CHECK-NEXT:     sv.passign %rE, %in : i32
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
+  // CHECK-NEXT: sv.always posedge %clk, posedge %rst {
+  // CHECK-NEXT:   sv.if %rst {
+  // CHECK-NEXT:     sv.passign %rC, %c0_i32 : i32
+  // CHECK-NEXT:     sv.passign %rF, %c0_i32 : i32
+  // CHECK-NEXT:   } else {
+  // CHECK-NEXT:     sv.passign %rC, %in : i32
+  // CHECK-NEXT:     sv.passign %rF, %in : i32
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
+
+  // CHECK:      sv.ifdef  "SYNTHESIS" {
+  // CHECK-NEXT: } else {
+  // CHECK-NEXT:   sv.ordered {
+  // CHECK-NEXT:     sv.ifdef  "RANDOMIZE_REG_INIT" {
+  // CHECK-NEXT:       %_RANDOM = sv.reg sym @_RANDOM  : !hw.inout<i32>
+  // CHECK-NEXT:       %_RANDOM_0 = sv.reg sym @_RANDOM_0  {name = "_RANDOM"} : !hw.inout<i32>
+  // CHECK-NEXT:       %_RANDOM_1 = sv.reg sym @_RANDOM_1  {name = "_RANDOM"} : !hw.inout<i32>
+  // CHECK-NEXT:       %_RANDOM_2 = sv.reg sym @_RANDOM_2  {name = "_RANDOM"} : !hw.inout<i32>
+  // CHECK-NEXT:       %_RANDOM_3 = sv.reg sym @_RANDOM_3  {name = "_RANDOM"} : !hw.inout<i32>
+  // CHECK-NEXT:       %_RANDOM_4 = sv.reg sym @_RANDOM_4  {name = "_RANDOM"} : !hw.inout<i32>
+  // CHECK-NEXT:       %_RANDOM_5 = sv.reg sym @_RANDOM_5  {name = "_RANDOM"} : !hw.inout<i32>
+  // CHECK-NEXT:       %_RANDOM_6 = sv.reg sym @_RANDOM_6  {name = "_RANDOM"} : !hw.inout<i32>
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     sv.initial {
+  // CHECK-NEXT:       sv.verbatim "`INIT_RANDOM_PROLOG_" {symbols = []}
+  // CHECK-NEXT:       sv.ifdef.procedural  "RANDOMIZE_REG_INIT" {
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@lowering::@_RANDOM>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}};" {symbols = [#hw.innerNameRef<@lowering::@regA>, #hw.innerNameRef<@lowering::@_RANDOM>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@lowering::@_RANDOM_0>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}};" {symbols = [#hw.innerNameRef<@lowering::@regB>, #hw.innerNameRef<@lowering::@_RANDOM_0>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@lowering::@_RANDOM_1>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}};" {symbols = [#hw.innerNameRef<@lowering::@regC>, #hw.innerNameRef<@lowering::@_RANDOM_1>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@lowering::@_RANDOM_2>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}};" {symbols = [#hw.innerNameRef<@lowering::@regD>, #hw.innerNameRef<@lowering::@_RANDOM_2>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@lowering::@_RANDOM_3>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}};" {symbols = [#hw.innerNameRef<@lowering::@regE>, #hw.innerNameRef<@lowering::@_RANDOM_3>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@lowering::@_RANDOM_4>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}};" {symbols = [#hw.innerNameRef<@lowering::@regF>, #hw.innerNameRef<@lowering::@_RANDOM_4>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@lowering::@_RANDOM_5>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}};" {symbols = [#hw.innerNameRef<@lowering::@regA>, #hw.innerNameRef<@lowering::@_RANDOM_5>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@lowering::@_RANDOM_6>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}};" {symbols = [#hw.innerNameRef<@lowering::@__rNoSym__>, #hw.innerNameRef<@lowering::@_RANDOM_6>]}
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:       sv.ifdef.procedural  "RANDOMIZE" {
+  // CHECK-NEXT:         sv.if %rst {
+  // CHECK-NEXT:           sv.bpassign %rC, %c0_i32 : i32
+  // CHECK-NEXT:           sv.bpassign %rF, %c0_i32 : i32
+  // CHECK-NEXT:         }
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     sv.ifdef  "FIRRTL_AFTER_INITIAL" {
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL" {symbols = []}
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
+
+  // CHECK: hw.output [[VAL_A]], [[VAL_B]], [[VAL_C]], [[VAL_D]], [[VAL_E]], [[VAL_F]] : i32, i32, i32, i32, i32, i32
+  hw.output %rA, %rB, %rC, %rD, %rE, %rF : i32, i32, i32, i32, i32, i32
+}
+
+// CHECK-LABEL: hw.module private @UninitReg1(%clock: i1, %reset: i1, %cond: i1, %value: i2) {
+hw.module private @UninitReg1(%clock: i1, %reset: i1, %cond: i1, %value: i2) {
+  // CHECK: %c0_i2 = hw.constant 0 : i2
+  %c0_i2 = hw.constant 0 : i2
+  // CHECK-NEXT: %count = sv.reg sym @count : !hw.inout<i2>
+  // CHECK-NEXT: %0 = sv.read_inout %count : !hw.inout<i2>
+  // CHECK-NEXT: %1 = comb.mux %cond, %value, %0 : i2
+  // CHECK-NEXT: %2 = comb.mux %reset, %c0_i2, %1 : i2
+  // CHECK-NEXT: sv.always posedge %clock {
+  // CHECK-NEXT:   sv.passign %count, %2 : i2
+  // CHECK-NEXT: }
+
+  %count = seq.firreg %2 clock %clock sym @count : i2
+  %1 = comb.mux %cond, %value, %count : i2
+  %2 = comb.mux %reset, %c0_i2, %1 : i2
+
+  // CHECK-NEXT: sv.ifdef "SYNTHESIS"  {
+  // CHECK-NEXT: } else {
+  // CHECK-NEXT:   sv.ordered {
+  // CHECK-NEXT:     sv.ifdef "RANDOMIZE_REG_INIT" {
+  // CHECK-NEXT:       %[[RANDOM:.+]] = sv.reg sym @[[RANDOM_SYM:[_A-Za-z0-9]+]] {{.+}}
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     sv.ifdef "FIRRTL_BEFORE_INITIAL" {
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     sv.initial {
+  // CHECK-NEXT:     sv.verbatim "`INIT_RANDOM_PROLOG_"
+  // CHECK-NEXT:     sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
+  // CHECK-NEXT:        sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@UninitReg1::@[[RANDOM_SYM]]>]}
+  // CHECK-NEXT:        sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}}[1:0];" {symbols = [#hw.innerNameRef<@UninitReg1::@count>, #hw.innerNameRef<@UninitReg1::@[[RANDOM_SYM]]>]}
+  // CHECK-NEXT:      }
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     sv.ifdef "FIRRTL_AFTER_INITIAL" {
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL" {symbols = []}
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
+
+  // CHECK-NEXT: hw.output
+  hw.output
+}
+
+// module InitReg1 :
+//     input clock : Clock
+//     input reset : UInt<1>
+//     input io_d : UInt<32>
+//     output io_q : UInt<32>
+//     input io_en : UInt<1>
+//
+//     node _T = asAsyncReset(reset)
+//     reg reg : UInt<32>, clock with :
+//       reset => (_T, UInt<32>("h0"))
+//     io_q <= reg
+//     reg <= mux(io_en, io_d, reg)
+
+// CHECK-LABEL: hw.module private @InitReg1(
+hw.module private @InitReg1(%clock: i1, %reset: i1, %io_d: i32, %io_en: i1) -> (io_q: i32) {
+  %false = hw.constant false
+  %c1_i32 = hw.constant 1 : i32
+  %c0_i32 = hw.constant 0 : i32
+  %reg = seq.firreg %4 clock %clock sym @__reg__ reset async %reset, %c0_i32 : i32
+  %reg2 = seq.firreg %reg2 clock %clock sym @__reg2__ reset sync %reset, %c0_i32 : i32
+  %reg3 = seq.firreg %reg3 clock %clock sym @__reg3__ reset async %reset, %c1_i32 : i32
+  %0 = comb.concat %false, %reg : i1, i32
+  %1 = comb.concat %false, %reg2 : i1, i32
+  %2 = comb.add %0, %1 : i33
+  %3 = comb.extract %2 from 1 : (i33) -> i32
+  %4 = comb.mux %io_en, %io_d, %3 : i32
+
+  // CHECK:      %reg = sv.reg sym @[[reg_sym:.+]] : !hw.inout<i32>
+  // CHECK-NEXT: %0 = sv.read_inout %reg : !hw.inout<i32>
+  // CHECK-NEXT: %reg2 = sv.reg sym @[[reg2_sym:.+]] : !hw.inout<i32>
+  // CHECK-NEXT: %1 = sv.read_inout %reg2 : !hw.inout<i32>
+  // CHECK-NEXT: %reg3 = sv.reg sym @[[reg3_sym:.+]] : !hw.inout<i32
+  // CHECK-NEXT: %2 = sv.read_inout %reg3 : !hw.inout<i32>
+  // CHECK-NEXT: %3 = comb.concat %false, %0 : i1, i32
+  // CHECK-NEXT: %4 = comb.concat %false, %1 : i1, i32
+  // CHECK-NEXT: %5 = comb.add %3, %4 : i33
+  // CHECK-NEXT: %6 = comb.extract %5 from 1 : (i33) -> i32
+  // CHECK-NEXT: %7 = comb.mux %io_en, %io_d, %6 : i32
+  // CHECK-NEXT: sv.always posedge %clock, posedge %reset  {
+  // CHECK-NEXT:   sv.if %reset  {
+  // CHECK-NEXT:     sv.passign %reg, %c0_i32 : i32
+  // CHECK-NEXT:     sv.passign %reg3, %c1_i32 : i32
+  // CHECK-NEXT:   } else  {
+  // CHECK-NEXT:     sv.passign %reg, %7 : i32
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
+  // CHECK-NEXT: sv.always posedge %clock  {
+  // CHECK-NEXT:   sv.if %reset  {
+  // CHECK-NEXT:     sv.passign %reg2, %c0_i32 : i32
+  // CHECK-NEXT:   } else  {
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
+  // CHECK-NEXT: sv.ifdef "SYNTHESIS"  {
+  // CHECK-NEXT: } else {
+  // CHECK-NEXT:   sv.ordered {
+  // CHECK-NEXT:     sv.ifdef "RANDOMIZE_REG_INIT" {
+  // CHECK-NEXT:       %[[RANDOM:.+]] = sv.reg sym @[[RANDOM_SYM:[_A-Za-z0-9]+]] {{.+}}
+  // CHECK-NEXT:       %[[RANDOM_2:.+]] = sv.reg sym @[[RANDOM_2_SYM:[_A-Za-z0-9]+]] {{.+}}
+  // CHECK-NEXT:       %[[RANDOM_3:.+]] = sv.reg sym @[[RANDOM_3_SYM:[_A-Za-z0-9]+]] {{.+}}
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     sv.initial {
+  // CHECK-NEXT:       sv.verbatim "`INIT_RANDOM_PROLOG_"
+  // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@InitReg1::@[[RANDOM_SYM]]>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}};" {symbols = [#hw.innerNameRef<@InitReg1::@[[reg_sym]]>, #hw.innerNameRef<@InitReg1::@[[RANDOM_SYM]]>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@InitReg1::@[[RANDOM_2_SYM]]>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}};" {symbols = [#hw.innerNameRef<@InitReg1::@[[reg2_sym]]>, #hw.innerNameRef<@InitReg1::@[[RANDOM_2_SYM]]>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@InitReg1::@[[RANDOM_3_SYM]]>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}};" {symbols = [#hw.innerNameRef<@InitReg1::@[[reg3_sym]]>, #hw.innerNameRef<@InitReg1::@[[RANDOM_3_SYM]]>]}
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE"  {
+  // CHECK-NEXT:         sv.if %reset {
+  // CHECK-NEXT:           sv.bpassign %reg, %c0_i32 : i32
+  // CHECK-NEXT:           sv.bpassign %reg3, %c1_i32 : i32
+  // CHECK-NEXT:         }
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     sv.ifdef  "FIRRTL_AFTER_INITIAL" {
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL" {symbols = []}
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
+  // CHECK-NEXT: hw.output %0 : i32
+  hw.output %reg : i32
+}
+
+// CHECK-LABEL: hw.module private @UninitReg42(%clock: i1, %reset: i1, %cond: i1, %value: i42) {
+hw.module private @UninitReg42(%clock: i1, %reset: i1, %cond: i1, %value: i42) {
+  %c0_i42 = hw.constant 0 : i42
+  %count = seq.firreg %1 clock %clock sym @count : i42
+  %0 = comb.mux %cond, %value, %count : i42
+  %1 = comb.mux %reset, %c0_i42, %0 : i42
+
+  // CHECK:      %count = sv.reg sym @count : !hw.inout<i42>
+  // CHECK:      sv.ifdef "SYNTHESIS"  {
+  // CHECK-NEXT: } else {
+  // CHECK-NEXT:   sv.ordered {
+  // CHECK-NEXT:     sv.ifdef "RANDOMIZE_REG_INIT" {
+  // CHECK-NEXT:       %[[RANDOM_0:.+]] = sv.reg sym @[[RANDOM_0_SYM:[_A-Za-z0-9]+]] {{.+}}
+  // CHECK-NEXT:       %[[RANDOM_1:.+]] = sv.reg sym @[[RANDOM_1_SYM:[_A-Za-z0-9]+]] {{.+}}
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     sv.initial {
+  // CHECK-NEXT:       sv.verbatim "`INIT_RANDOM_PROLOG_"
+  // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@UninitReg42::@[[RANDOM_0_SYM]]>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@UninitReg42::@[[RANDOM_1_SYM]]>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{][{]1[}][}]}}[9:0], {{[{][{]2[}][}][}]}};" {symbols = [#hw.innerNameRef<@UninitReg42::@count>, #hw.innerNameRef<@UninitReg42::@[[RANDOM_1_SYM]]>, #hw.innerNameRef<@UninitReg42::@[[RANDOM_0_SYM]]>]}
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     sv.ifdef  "FIRRTL_AFTER_INITIAL" {
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL" {symbols = []}
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
+
+  hw.output
+}
+
+// CHECK-LABEL: hw.module private @regInitRandomReuse
+hw.module private @regInitRandomReuse(%clock: i1, %a: i1) -> (o1: i2, o2: i4, o3: i32, o4: i100) {
+  %c0_i99 = hw.constant 0 : i99
+  %c0_i31 = hw.constant 0 : i31
+  %c0_i3 = hw.constant 0 : i3
+  %false = hw.constant false
+  %r1 = seq.firreg %0 clock %clock sym @__r1__ : i2
+  %r2 = seq.firreg %1 clock %clock sym @__r2__ : i4
+  %r3 = seq.firreg %2 clock %clock sym @__r3__ : i32
+  %r4 = seq.firreg %3 clock %clock sym @__r4__ : i100
+  %0 = comb.concat %false, %a : i1, i1
+  %1 = comb.concat %c0_i3, %a : i3, i1
+  %2 = comb.concat %c0_i31, %a : i31, i1
+  %3 = comb.concat %c0_i99, %a : i99, i1
+  // CHECK:      %r1 = sv.reg sym @[[r1_sym:[_A-Za-z0-9]+]]
+  // CHECK:      %r2 = sv.reg sym @[[r2_sym:[_A-Za-z0-9]+]]
+  // CHECK:      %r3 = sv.reg sym @[[r3_sym:[_A-Za-z0-9]+]]
+  // CHECK:      %r4 = sv.reg sym @[[r4_sym:[_A-Za-z0-9]+]]
+  // CHECK:      sv.ifdef "SYNTHESIS" {
+  // CHECK-NEXT: } else {
+  // CHECK-NEXT:   sv.ordered {
+  // CHECK-NEXT:     sv.ifdef "RANDOMIZE_REG_INIT" {
+  // CHECK-NEXT:       %[[RANDOM_0:.+]] = sv.reg sym @[[RANDOM_0_SYM:[_A-Za-z0-9]+]]
+  // CHECK-NEXT:       %[[RANDOM_1:.+]] = sv.reg sym @[[RANDOM_1_SYM:[_A-Za-z0-9]+]]
+  // CHECK-NEXT:       %[[RANDOM_2:.+]] = sv.reg sym @[[RANDOM_2_SYM:[_A-Za-z0-9]+]]
+  // CHECK-NEXT:       %[[RANDOM_3:.+]] = sv.reg sym @[[RANDOM_3_SYM:[_A-Za-z0-9]+]]
+  // CHECK-NEXT:       %[[RANDOM_4:.+]] = sv.reg sym @[[RANDOM_4_SYM:[_A-Za-z0-9]+]]{{.+}}
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     sv.initial {
+  // CHECK-NEXT:       sv.verbatim "`INIT_RANDOM_PROLOG_"
+  // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_0_SYM]]>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}}[1:0];" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[r1_sym]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_0_SYM]]>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}}[5:2];" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[r2_sym]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_0_SYM]]>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_1_SYM]]>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{]}}{{[{][{]1[}][}]}}[5:0], {{[{][{]2[}][}]}}[31:6]{{[}]}};" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[r3_sym]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_1_SYM]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_0_SYM]]>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_2_SYM]]>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_3_SYM]]>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_4_SYM]]>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{]}}{{[{][{]1[}][}]}}[9:0], {{[{][{]2[}][}]}}, {{[{][{]3[}][}]}}, {{[{][{]4[}][}]}}[31:6]{{[}]}};" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[r4_sym]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_4_SYM]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_3_SYM]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_2_SYM]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_1_SYM]]>]}
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     sv.ifdef "FIRRTL_AFTER_INITIAL" {
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL" {symbols = []}
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
+  hw.output %r1, %r2, %r3, %r4 : i2, i4, i32, i100
+}
+
+// CHECK-LABEL: hw.module private @init1DVector
+hw.module private @init1DVector(%clock: i1, %a: !hw.array<2xi1>) -> (b: !hw.array<2xi1>) {
+  %r = seq.firreg %a clock %clock sym @__r__ : !hw.array<2xi1>
+
+  // CHECK:      %r = sv.reg sym @[[r_sym:[_A-Za-z0-9]+]]
+
+  // CHECK:      sv.always posedge %clock  {
+  // CHECK-NEXT:   sv.passign %r, %a : !hw.array<2xi1>
+  // CHECK-NEXT: }
+
+  // CHECK:      sv.ifdef "SYNTHESIS" {
+  // CHECK-NEXT: } else {
+  // CHECK-NEXT:   sv.ordered {
+  // CHECK-NEXT:     sv.ifdef "RANDOMIZE_REG_INIT" {
+  // CHECK-NEXT:       %[[RANDOM:.+]] = sv.reg sym @[[RANDOM_SYM:[_A-Za-z0-9]+]]{{.+}}
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     sv.initial {
+  // CHECK-NEXT:       sv.verbatim "`INIT_RANDOM_PROLOG_"
+  // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@init1DVector::@[[RANDOM_SYM]]>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}}[0] = {{[{][{]1[}][}]}}[0];" {symbols = [#hw.innerNameRef<@init1DVector::@[[r_sym]]>, #hw.innerNameRef<@init1DVector::@[[RANDOM_SYM]]>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}}[1] = {{[{][{]1[}][}]}}[1];" {symbols = [#hw.innerNameRef<@init1DVector::@[[r_sym]]>, #hw.innerNameRef<@init1DVector::@[[RANDOM_SYM]]>]}
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     sv.ifdef "FIRRTL_AFTER_INITIAL" {
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL" {symbols = []}
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
+  // CHECK-NEXT: hw.output %0 : !hw.array<2xi1>
+
+  hw.output %r : !hw.array<2xi1>
+}
+
+// CHECK-LABEL: hw.module private @init2DVector
+hw.module private @init2DVector(%clock: i1, %a: !hw.array<1xarray<1xi1>>) -> (b: !hw.array<1xarray<1xi1>>) {
+  %r = seq.firreg %a clock %clock sym @__r__ : !hw.array<1xarray<1xi1>>
+
+  // CHECK:      sv.always posedge %clock  {
+  // CHECK-NEXT:   sv.passign %r, %a : !hw.array<1xarray<1xi1>>
+  // CHECK-NEXT: }
+  // CHECK-NEXT: sv.ifdef  "SYNTHESIS" {
+  // CHECK-NEXT: } else {
+  // CHECK-NEXT:   sv.ordered {
+  // CHECK-NEXT:     sv.ifdef  "RANDOMIZE_REG_INIT" {
+  // CHECK-NEXT:       %_RANDOM = sv.reg sym @_RANDOM  : !hw.inout<i32>
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     sv.initial {
+  // CHECK-NEXT:       sv.verbatim "`INIT_RANDOM_PROLOG_" {symbols = []}
+  // CHECK-NEXT:       sv.ifdef.procedural  "RANDOMIZE_REG_INIT" {
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@init2DVector::@_RANDOM>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}}[0][0] = {{[{][{]1[}][}]}}[0];" {symbols = [#hw.innerNameRef<@init2DVector::@__r__>, #hw.innerNameRef<@init2DVector::@_RANDOM>]}
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     sv.ifdef "FIRRTL_AFTER_INITIAL" {
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL" {symbols = []}
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
+
+  hw.output %r : !hw.array<1xarray<1xi1>>
+  // CHECK: hw.output %0 : !hw.array<1xarray<1xi1>>
+}
+
+// CHECK-LABEL: hw.module private @initStruct
+hw.module private @initStruct(%clock: i1) {
+  %r = seq.firreg %r clock %clock sym @__r__ : !hw.struct<a: i1>
+
+  // CHECK:      %r = sv.reg sym @[[r_sym:[_A-Za-z0-9]+]]
+  // CHECK:      sv.ifdef "SYNTHESIS" {
+  // CHECK-NEXT: } else {
+  // CHECK-NEXT:   sv.ordered {
+  // CHECK-NEXT:     sv.ifdef "RANDOMIZE_REG_INIT" {
+  // CHECK-NEXT:       %[[RANDOM:.+]] = sv.reg sym @[[RANDOM_SYM:[_A-Za-z0-9]+]]{{.+}}
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     sv.initial {
+  // CHECK-NEXT:       sv.verbatim "`INIT_RANDOM_PROLOG_"
+  // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@initStruct::@[[RANDOM_SYM]]>]}
+  // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}}.a = {{[{][{]1[}][}]}}[0];" {symbols = [#hw.innerNameRef<@initStruct::@[[r_sym]]>, #hw.innerNameRef<@initStruct::@[[RANDOM_SYM]]>]}
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:     sv.ifdef "FIRRTL_AFTER_INITIAL" {
+  // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL" {symbols = []}
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
+
+  hw.output
+}
+
+// CHECK-LABEL: issue1594
+// Make sure LowerToHW's merging of always blocks kicks in for this example.
+hw.module @issue1594(%clock: i1, %reset: i1, %a: i1) -> (b: i1) {
+  %true = hw.constant true
+  %false = hw.constant false
+  %reset_n = sv.wire sym @__issue1594__reset_n  : !hw.inout<i1>
+  %0 = sv.read_inout %reset_n : !hw.inout<i1>
+  %1 = comb.xor %reset, %true : i1
+  sv.assign %reset_n, %1 : i1
+  %r = seq.firreg %a clock %clock sym @__r__ reset sync %0, %false : i1
+  // CHECK: sv.always posedge %clock
+  // CHECK-NOT: sv.always
+  // CHECK: hw.output
+  hw.output %r : i1
+}
+
+


### PR DESCRIPTION
The `seq.firreg` introduced in this PR captures all information required to represent FIRRTL registers and lower them in a separate pass to SV equivalently to the code emitted prior to this change. 

