### PR TITLE
[FIRRTL] [CheckCombCycle] Print a cycle while dumping signal names 

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -372,6 +372,10 @@ def CheckCombCycles : Pass<"firrtl-check-comb-cycles", "firrtl::CircuitOp"> {
   let description = [{
     This pass checks combinational cycles in the IR and emit errors.
   }];
+  let options = [
+    Option<"printSimpleCycle", "print-simple-cycle", "bool", "true",
+      "Print a simple cycle instead of printing all operations in SCC">
+  ];
   let constructor = "circt::firrtl::createCheckCombCyclesPass()";
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/CheckCombCycles.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckCombCycles.cpp
@@ -17,6 +17,7 @@
 #include "llvm/ADT/DepthFirstIterator.h"
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/ADT/SCCIterator.h"
+#include "llvm/ADT/SmallSet.h"
 #include <variant>
 
 using namespace circt;
@@ -206,6 +207,8 @@ public:
     return *this;
   }
 
+  unsigned getPortNumber() const { return *portIt; }
+
 private:
   InstanceOp instance;
   SmallVectorImpl<size_t>::iterator portEnd;
@@ -264,6 +267,7 @@ public:
           (portKind == MemOp::PortKind::ReadWrite &&
            index == (unsigned)ReadWritePortSubfield::rdata)) {
         child = ChildIterator(currentSubfield.result());
+        dataPort = currentSubfield.result();
         return;
       }
     }
@@ -276,6 +280,11 @@ public:
       child = ChildIterator();
     return *this;
   }
+
+  Value getDataPort() { return dataPort; }
+
+private:
+  Value dataPort;
 };
 } // namespace
 
@@ -372,6 +381,8 @@ public:
     }
   }
 
+  const variant_iterator &getIteratorImpl() const { return impl; }
+
   Node operator*() {
     switch (impl.index()) {
     case 0:
@@ -463,6 +474,105 @@ struct GraphTraits<Node> {
 //===----------------------------------------------------------------------===//
 
 namespace {
+
+using SCCIterator = llvm::scc_iterator<Node>;
+using GT = llvm::GraphTraits<Node>;
+
+// Sample a cycle from SCC.
+SmallVector<Node> sampleCycle(SCCIterator &scc) {
+  llvm::SmallDenseSet<Node, 4> sccNodes;
+  for (auto node : *scc)
+    sccNodes.insert(node);
+
+  auto current = *(*scc).begin();
+  SmallVector<Node> path;
+  SmallDenseMap<Node, unsigned> visitOrder;
+  while (true) {
+    for (auto child :
+         llvm::make_range(GT::child_begin(current), GT::child_end(current))) {
+      // If the child is out of SCC, we don't explore.
+      if (!sccNodes.contains(child))
+        continue;
+
+      auto it = visitOrder.find(child);
+      // If the child is visited before, path[visitedOrder[c]] ... path.end()
+      // forms a cycle.
+      if (it != visitOrder.end())
+        return SmallVector<Node>(path.begin() + it->second, path.end());
+
+      visitOrder.insert({child, path.size()});
+      path.push_back(child);
+      current = child;
+      break;
+    }
+  }
+  llvm_unreachable("a cycle must be found in SCC");
+}
+
+void dumpSimpleCycle(SCCIterator &scc, FModuleOp module,
+                     mlir::InFlightDiagnostic &diag) {
+  // Sample a cycle to print.
+  SmallVector<Node> cycle = sampleCycle(scc);
+  for (unsigned i = 0, e = cycle.size(); i < e; ++i) {
+    Node current = cycle[i];
+    auto attachInfo = [&]() -> mlir::Diagnostic & {
+      return diag.attachNote(current.value.getLoc())
+             << module.getName().str() << ".";
+    };
+
+    // If the current value is port, emit its name.
+    if (auto arg = current.value.dyn_cast<BlockArgument>()) {
+      attachInfo() << module.getPortName(arg.getArgNumber());
+      continue;
+    }
+
+    TypeSwitch<Operation *>(current.value.getDefiningOp())
+        .Case<WireOp, RegOp, RegResetOp>(
+            // For operations which declare signals, we simply print signal
+            // names.
+            [&](auto op) { attachInfo() << op.name(); })
+        .Case<InstanceOp, SubfieldOp>([&](auto op) {
+          // If the op is InstanceOp or SubfieldOp, it is necessary to
+          // investigate the next value since output values do not expilicty
+          // appear in the cycle.
+          Node next = cycle[(i + 1) % e];
+          for (auto iter = GT::child_begin(current),
+                    end = GT::child_end(current);
+               iter != end; ++iter) {
+            auto node = *iter;
+            if (node.value != next.value)
+              continue;
+
+            auto iterImpl = iter.getIteratorImpl();
+            if (std::holds_alternative<InstanceNodeIterator>(iterImpl)) {
+              // Instance. Print names of input and output ports.
+              auto instance = current.value.getDefiningOp<InstanceOp>();
+              auto inputPort = current.value.cast<OpResult>().getResultNumber();
+              auto outputPort =
+                  std::get<InstanceNodeIterator>(iterImpl).getPortNumber();
+              attachInfo() << instance.name() << "."
+                           << instance.getPortName(inputPort).str();
+              attachInfo() << instance.name() << "."
+                           << instance.getPortName(outputPort).str();
+            } else if (std::holds_alternative<SubfieldNodeIterator>(iterImpl)) {
+              // SubfieldNodeIterator represents the connection between addr
+              // port and data port.
+              auto subfieldAddr = current.value.getDefiningOp<SubfieldOp>();
+              auto subfieldData =
+                  std::get<SubfieldNodeIterator>(iterImpl).getDataPort();
+
+              attachInfo() << getFieldName(getFieldRefFromValue(subfieldAddr));
+              diag.attachNote(subfieldData.getLoc())
+                  << module.getName().str() << "."
+                  << getFieldName(getFieldRefFromValue(subfieldData));
+            }
+            break;
+          }
+        })
+        .Default([&](auto op) {});
+  }
+}
+
 /// This pass constructs a local graph for each module to detect combinational
 /// cycles. To capture the cross-module combinational cycles, this pass inlines
 /// the combinational paths between IOs of its subinstances into a subgraph and
@@ -485,7 +595,6 @@ class CheckCombCyclesPass : public CheckCombCyclesBase<CheckCombCyclesPass> {
         // FIRRTL module is an SSA region, all cycles must contain at least one
         // connect op. Thus we introduce a dummy source node to iterate on the
         // `dest`s of all connect ops in the module.
-        using SCCIterator = llvm::scc_iterator<Node>;
         for (auto combSCC = SCCIterator::begin(dummyNode); !combSCC.isAtEnd();
              ++combSCC) {
           if (combSCC.hasCycle()) {
@@ -493,9 +602,13 @@ class CheckCombCyclesPass : public CheckCombCyclesBase<CheckCombCyclesPass> {
             auto errorDiag = mlir::emitError(
                 module.getLoc(),
                 "detected combinational cycle in a FIRRTL module");
-            for (auto node : *combSCC) {
-              auto &noteDiag = errorDiag.attachNote(node.value.getLoc());
-              noteDiag << "this operation is part of the combinational cycle";
+            if (printSimpleCycle)
+              dumpSimpleCycle(combSCC, module, errorDiag);
+            else {
+              for (auto node : *combSCC) {
+                auto &noteDiag = errorDiag.attachNote(node.value.getLoc());
+                noteDiag << "this operation is part of the combinational cycle";
+              }
             }
           }
         }

--- a/test/Dialect/FIRRTL/check-comb-cycles-short.mlir
+++ b/test/Dialect/FIRRTL/check-comb-cycles-short.mlir
@@ -1,25 +1,4 @@
-// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-check-comb-cycles{print-simple-cycle=false})' --split-input-file --verify-diagnostics %s | FileCheck %s
-
-module  {
-  // Loop-free circuit
-  // CHECK: firrtl.circuit "hasnoloops"
-  firrtl.circuit "hasnoloops"   {
-    firrtl.module @thru(in %in1: !firrtl.uint<1>, in %in2: !firrtl.uint<1>, out %out1: !firrtl.uint<1>, out %out2: !firrtl.uint<1>) {
-      firrtl.connect %out1, %in1 : !firrtl.uint<1>, !firrtl.uint<1>
-      firrtl.connect %out2, %in2 : !firrtl.uint<1>, !firrtl.uint<1>
-    }
-    firrtl.module @hasnoloops(in %clk: !firrtl.clock, in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
-      %x = firrtl.wire  : !firrtl.uint<1>
-      %inner_in1, %inner_in2, %inner_out1, %inner_out2 = firrtl.instance inner @thru(in in1: !firrtl.uint<1>, in in2: !firrtl.uint<1>, out out1: !firrtl.uint<1>, out out2: !firrtl.uint<1>)
-      firrtl.connect %inner_in1, %a : !firrtl.uint<1>, !firrtl.uint<1>
-      firrtl.connect %x, %inner_out1 : !firrtl.uint<1>, !firrtl.uint<1>
-      firrtl.connect %inner_in2, %x : !firrtl.uint<1>, !firrtl.uint<1>
-      firrtl.connect %b, %inner_out2 : !firrtl.uint<1>, !firrtl.uint<1>
-    }
-  }
-}
-
-// -----
+// RUN: circt-opt --pass-pipeline='firrtl.circuit(firrtl-check-comb-cycles)' --split-input-file --verify-diagnostics %s | FileCheck %s
 
 module  {
   // Simple combinational loop
@@ -27,49 +6,12 @@ module  {
   firrtl.circuit "hasloops"   {
     // expected-error @+1 {{detected combinational cycle in a FIRRTL module}}
     firrtl.module @hasloops(in %clk: !firrtl.clock, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>, out %d: !firrtl.uint<1>) {
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
+      // expected-note @+1 {{y}}
       %y = firrtl.wire  : !firrtl.uint<1>
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
+      // expected-note @+1 {{z}}
       %z = firrtl.wire  : !firrtl.uint<1>
       firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %z, %y : !firrtl.uint<1>, !firrtl.uint<1>
-      firrtl.connect %y, %z : !firrtl.uint<1>, !firrtl.uint<1>
-      firrtl.connect %d, %z : !firrtl.uint<1>, !firrtl.uint<1>
-    }
-  }
-}
-
-// -----
-
-module  {
-  // Single-element combinational loop
-  // CHECK-NOT: firrtl.circuit "loop"
-  firrtl.circuit "loop"   {
-    // expected-error @+1 {{detected combinational cycle in a FIRRTL module}}
-    firrtl.module @loop(out %y: !firrtl.uint<8>) {
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
-      %w = firrtl.wire  : !firrtl.uint<8>
-      firrtl.connect %w, %w : !firrtl.uint<8>, !firrtl.uint<8>
-      firrtl.connect %y, %w : !firrtl.uint<8>, !firrtl.uint<8>
-    }
-  }
-}
-
-// -----
-
-module  {
-  // Node combinational loop
-  // CHECK-NOT: firrtl.circuit "hasloops"
-  firrtl.circuit "hasloops"   {
-    // expected-error @+1 {{detected combinational cycle in a FIRRTL module}}
-    firrtl.module @hasloops(in %clk: !firrtl.clock, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>, out %d: !firrtl.uint<1>) {
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
-      %y = firrtl.wire  : !firrtl.uint<1>
-      firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
-      %0 = firrtl.and %c, %y : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
-      %z = firrtl.node %0  : !firrtl.uint<1>
       firrtl.connect %y, %z : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %d, %z : !firrtl.uint<1>, !firrtl.uint<1>
     }
@@ -84,20 +26,21 @@ module  {
   firrtl.circuit "hasloops"   {
     // expected-error @+1 {{detected combinational cycle in a FIRRTL module}}
     firrtl.module @hasloops(in %clk: !firrtl.clock, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>, out %d: !firrtl.uint<1>) {
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
+      // expected-note @+1 {{hasloops.y}}
       %y = firrtl.wire  : !firrtl.uint<1>
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
+      // expected-note @+1 {{hasloops.z}}
       %z = firrtl.wire  : !firrtl.uint<1>
       firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
       %m_r = firrtl.mem Undefined  {depth = 2 : i64, name = "m", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>
       %0 = firrtl.subfield %m_r(2) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.clock
       firrtl.connect %0, %clk : !firrtl.clock, !firrtl.clock
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
+      // expected-note @+1 {{hasloops.m.r.addr}}
       %1 = firrtl.subfield %m_r(0) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.uint<1>
       firrtl.connect %1, %y : !firrtl.uint<1>, !firrtl.uint<1>
       %2 = firrtl.subfield %m_r(1) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.uint<1>
       %c1_ui = firrtl.constant 1 : !firrtl.uint
       firrtl.connect %2, %c1_ui : !firrtl.uint<1>, !firrtl.uint
+      // expected-note @+1 {{hasloops.m.r.data}}
       %3 = firrtl.subfield %m_r(3) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<1>>) -> !firrtl.uint<1>
       firrtl.connect %z, %3 : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %y, %z : !firrtl.uint<1>, !firrtl.uint<1>
@@ -117,12 +60,13 @@ module  {
     }
     // expected-error @+1 {{detected combinational cycle in a FIRRTL module}}
     firrtl.module @hasloops(in %clk: !firrtl.clock, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>, out %d: !firrtl.uint<1>) {
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
+      // expected-note @+1 {{hasloops.y}}
       %y = firrtl.wire  : !firrtl.uint<1>
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
+      // expected-note @+1 {{hasloops.z}}
       %z = firrtl.wire  : !firrtl.uint<1>
       firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
+      // expected-note @+2 {{hasloops.inner.in}}
+      // expected-note @+1 {{hasloops.inner.out}}
       %inner_in, %inner_out = firrtl.instance inner @thru(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
       firrtl.connect %inner_in, %y : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %z, %inner_out : !firrtl.uint<1>, !firrtl.uint<1>
@@ -140,39 +84,23 @@ module  {
   firrtl.circuit "hasloops"   {
     // expected-error @+1 {{detected combinational cycle in a FIRRTL module}}
     firrtl.module @hasloops(in %i: !firrtl.uint<1>, out %o: !firrtl.uint<1>) {
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
       %a = firrtl.wire  : !firrtl.uint<1>
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
+      // expected-note @+1 {{hasloops.b}}
       %b = firrtl.wire  : !firrtl.uint<1>
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
       %c = firrtl.wire  : !firrtl.uint<1>
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
+      // expected-note @+1 {{hasloops.d}}
       %d = firrtl.wire  : !firrtl.uint<1>
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
+      // expected-note @+1 {{hasloops.e}}
       %e = firrtl.wire  : !firrtl.uint<1>
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
       %0 = firrtl.and %c, %i : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
       firrtl.connect %a, %0 : !firrtl.uint<1>, !firrtl.uint<1>
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
       %1 = firrtl.and %a, %d : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
       firrtl.connect %b, %1 : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
-      // expected-note @+1 {{this operation is part of the combinational cycle}}
       %2 = firrtl.and %c, %e : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
       firrtl.connect %d, %2 : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %e, %b : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %o, %e : !firrtl.uint<1>, !firrtl.uint<1>
     }
-  }
-}
-
-// -----
-
-firrtl.circuit "strictConnectAndConnect" {
-  // expected-error @+2 {{detected combinational cycle in a FIRRTL module}}
-  // expected-note @+1 {{this operation is part of the combinational cycle}}
-  firrtl.module @strictConnectAndConnect(out %a: !firrtl.uint<11>, out %b: !firrtl.uint<11>) {
-    firrtl.connect %a, %b : !firrtl.uint<11>, !firrtl.uint<11>
-    firrtl.strictconnect %b, %a : !firrtl.uint<11>
   }
 }


### PR DESCRIPTION
This commit adds `print-simple-cycle` option to print a simple cycle (enabled by default).
With that option, CheckCombCycle pass prints signal names contained
in a cycle (in the order of a cycle path) instead of dumping all
operations in the scc. It is useful for chisel users to debug their
chisel code since the cycle is actually a counterexample. Previous
error message (i.e. dumping all operations in SCC) is intentionally
kept to test the cycle dectection algorithm.

Example:
```scala
; Location is random
circuit hasloops :
  module hasloops :
    input clk : Clock @[Bar.scala 33:38]
    input a : UInt<1> @[Bar.scala 33:38]
    input b : UInt<1> @[Bar.scala 33:38]
    output c : UInt<1> @[Bar.scala 33:38]
    output d : UInt<1> @[Bar.scala 33:38]
    wire y : UInt<1> @[Bar.scala 33:38]
    wire z : UInt<1> @[Bar.scala 33:38]
    c <= b @[Bar.scala 33:38]
    mem m : 
      data-type => UInt<1>
      depth => 2
      read-latency => 0
      write-latency => 1
      reader => r
      read-under-write => undefined
    m.r.clk <= clk @[Bar.scala 33:38]
    m.r.addr <= y @[Bar.scala 33:38]
    m.r.en <= UInt(1) @[Bar.scala 33:38]
    z <= m.r.data @[Bar.scala 33:38]
    y <= z @[Bar.scala 33:38]
    d <= z @[Bar.scala 33:38]
```
Previously, we didn't consider cases where locations come from chisel. The error message for the above IR was: 
```
foo.fir:2:10: error: detected combinational cycle in a FIRRTL module
  module hasloops :
         ^
Bar.scala:33:38: note: this operation is part of the combinational cycle
Bar.scala:33:38: note: this operation is part of the combinational cycle
Bar.scala:33:38: note: this operation is part of the combinational cycle
```
New error message:
```
foo.fir:2:10: error: detected combinational cycle in a FIRRTL module
  module hasloops :
         ^
Bar.scala:33:38: note: hasloops.m.r.addr
Bar.scala:33:38: note: hasloops.m.r.data
Bar.scala:33:38: note: hasloops._z
Bar.scala:33:38: note: hasloops._y
```

SFC: 
```
Exception in thread "main" firrtl.transforms.CheckCombLoops$CombLoopException: : [module hasloops] Combinational loop detected:
hasloops.y
hasloops.m.r.addr	 @[Bar.scala 33:38]
hasloops.m.r.data	
hasloops.z	 @[Bar.scala 33:38]
hasloops.y	 @[Bar.scala 33:38]
```
