### PR TITLE
[Support] Backedges: Use always registered `builtin.unrealized_conversion_cast`

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -207,8 +207,7 @@ def ConvertHWToLLHD : Pass<"convert-hw-to-llhd", "mlir::ModuleOp"> {
 def StandardToHandshake : Pass<"lower-std-to-handshake", "mlir::ModuleOp"> {
   let summary = "Lower Standard MLIR into Handshake IR";
   let constructor = "circt::createStandardToHandshakePass()";
-  let dependentDialects = ["handshake::HandshakeDialect",
-                           "circt::hw::HWDialect"];
+  let dependentDialects = ["handshake::HandshakeDialect"];
   let options =
     [Option<"sourceConstants", "source-constants", "bool", "false",
             "If true, will connect constants to source operations instead of "

--- a/include/circt/Dialect/HW/HWMiscOps.td
+++ b/include/circt/Dialect/HW/HWMiscOps.td
@@ -82,13 +82,3 @@ def ParamValueOp : HWOp<"param.value",
   let hasVerifier = 1;
   let hasFolder = true;
 }
-
-def BackedgeOp: HWOp<"backedge", [NoSideEffect, ConstantLike]> {
-  let summary = [{
-    This op is intended to be temporarily created during IR construction to
-    support backedges. Used by support/BackedgeBuilder.
-  }];
-
-  let results = (outs AnyType:$result);
-  let assemblyFormat = "type($result) attr-dict";
-}

--- a/include/circt/Support/BackedgeBuilder.h
+++ b/include/circt/Support/BackedgeBuilder.h
@@ -15,10 +15,7 @@
 #ifndef CIRCT_SUPPORT_BACKEDGEBUILDER_H
 #define CIRCT_SUPPORT_BACKEDGEBUILDER_H
 
-#include "circt/Dialect/HW/HWOps.h"
-
 #include "mlir/IR/Location.h"
-#include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Value.h"
 #include "llvm/ADT/SmallVector.h"
 
@@ -30,25 +27,7 @@ class Operation;
 
 namespace circt {
 
-/// `Backedge` is a wrapper class around a `Value`. When assigned another
-/// `Value`, it replaces all uses of itself with the new `Value` then become a
-/// wrapper around the new `Value`.
-class Backedge {
-public:
-  Backedge(mlir::Operation *op) : value(op->getResult(0)){};
-
-  operator mlir::Value() { return value; }
-  void setValue(mlir::Value newValue) {
-    assert(value.getType() == newValue.getType());
-    assert(!set && "backedge already set to a value!");
-    value.replaceAllUsesWith(newValue);
-    set = true;
-  }
-
-private:
-  mlir::Value value;
-  bool set = false;
-};
+class Backedge;
 
 /// Instantiate one of these and use it to build typed backedges. Backedges
 /// which get used as operands must be assigned to with the actual value before
@@ -64,46 +43,43 @@ private:
 ///   // When the actual value is available,
 ///   ready.set(anotherOp.getResult(0));
 /// ```
-///
-/// This template is to enable the use of an operation in any dialect which
-/// looks like a backedge op. Backedge ops have no arguments and return any
-/// type. There is a standard one in the 'HW' dialect, but presumably not every
-/// piece of code wants to load the 'HW' dialect. For the common case, an alias
-/// is provided below.
-template <typename BackedgeOp>
-class BackedgeBuilderImpl {
+class BackedgeBuilder {
+  friend class Backedge;
+
 public:
   /// To build a backedge op and manipulate it, we need a `PatternRewriter` and
   /// a `Location`. Store them during construct of this instance and use them
   /// when building.
-  BackedgeBuilderImpl(mlir::OpBuilder &builder, mlir::Location loc)
-      : builder(builder), rewriter(nullptr), loc(loc) {}
-  BackedgeBuilderImpl(mlir::PatternRewriter &rewriter, mlir::Location loc)
-      : builder(rewriter), rewriter(&rewriter), loc(loc) {}
-  ~BackedgeBuilderImpl() {
-    for (Operation *op : edges) {
-      assert(op->use_empty() && "Backedge still in use");
-      if (rewriter)
-        rewriter->eraseOp(op);
-      else
-        op->erase();
-    }
-  }
+  BackedgeBuilder(mlir::OpBuilder &builder, mlir::Location loc);
+  BackedgeBuilder(mlir::PatternRewriter &rewriter, mlir::Location loc);
+  ~BackedgeBuilder();
   /// Create a typed backedge.
-  Backedge get(mlir::Type resultType) {
-    auto be = builder.create<BackedgeOp>(loc, resultType);
-    edges.push_back(be);
-    return Backedge(be.getOperation());
-  }
+  Backedge get(mlir::Type resultType);
 
 private:
   mlir::OpBuilder &builder;
   mlir::PatternRewriter *rewriter;
   mlir::Location loc;
-  llvm::SmallVector<BackedgeOp, 16> edges;
+  llvm::SmallVector<mlir::Operation *, 16> edges;
 };
 
-using BackedgeBuilder = BackedgeBuilderImpl<hw::BackedgeOp>;
+/// `Backedge` is a wrapper class around a `Value`. When assigned another
+/// `Value`, it replaces all uses of itself with the new `Value` then become a
+/// wrapper around the new `Value`.
+class Backedge {
+  friend class BackedgeBuilder;
+
+  /// `Backedge` is constructed exclusively by `BackedgeBuilder`.
+  Backedge(mlir::Operation *op);
+
+public:
+  operator mlir::Value();
+  void setValue(mlir::Value);
+
+private:
+  mlir::Value value;
+  bool set = false;
+};
 
 } // namespace circt
 

--- a/lib/Support/BackedgeBuilder.cpp
+++ b/lib/Support/BackedgeBuilder.cpp
@@ -12,6 +12,8 @@
 
 #include "circt/Support/BackedgeBuilder.h"
 #include "circt/Support/LLVM.h"
+
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/PatternMatch.h"
 
 using namespace circt;
@@ -38,17 +40,12 @@ BackedgeBuilder::~BackedgeBuilder() {
 Backedge::operator mlir::Value() { return value; }
 
 BackedgeBuilder::BackedgeBuilder(OpBuilder &builder, Location loc)
-    : builder(builder), rewriter(nullptr), loc(loc) {
-  loc.getContext()->allowUnregisteredDialects();
-}
+    : builder(builder), rewriter(nullptr), loc(loc) {}
 BackedgeBuilder::BackedgeBuilder(PatternRewriter &rewriter, Location loc)
-    : builder(rewriter), rewriter(&rewriter), loc(loc) {
-  loc.getContext()->allowUnregisteredDialects();
-}
+    : builder(rewriter), rewriter(&rewriter), loc(loc) {}
 Backedge BackedgeBuilder::get(Type t) {
-  OperationState s(loc, "TemporaryBackedge");
-  s.addTypes(t);
-  auto *op = builder.create(s);
+  Operation *op =
+      builder.create<mlir::UnrealizedConversionCastOp>(loc, t, ValueRange{});
   edges.push_back(op);
   return Backedge(op);
 }

--- a/lib/Support/BackedgeBuilder.cpp
+++ b/lib/Support/BackedgeBuilder.cpp
@@ -1,0 +1,54 @@
+//===- BackedgeBuilder.cpp - Support for building backedges ---------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provide support for building backedges.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Support/BackedgeBuilder.h"
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/PatternMatch.h"
+
+using namespace circt;
+
+Backedge::Backedge(mlir::Operation *op) : value(op->getResult(0)) {}
+
+void Backedge::setValue(mlir::Value newValue) {
+  assert(value.getType() == newValue.getType());
+  assert(!set && "backedge already set to a value!");
+  value.replaceAllUsesWith(newValue);
+  set = true;
+}
+
+BackedgeBuilder::~BackedgeBuilder() {
+  for (Operation *op : edges) {
+    assert(op->use_empty() && "Backedge still in use");
+    if (rewriter)
+      rewriter->eraseOp(op);
+    else
+      op->erase();
+  }
+}
+
+Backedge::operator mlir::Value() { return value; }
+
+BackedgeBuilder::BackedgeBuilder(OpBuilder &builder, Location loc)
+    : builder(builder), rewriter(nullptr), loc(loc) {
+  loc.getContext()->allowUnregisteredDialects();
+}
+BackedgeBuilder::BackedgeBuilder(PatternRewriter &rewriter, Location loc)
+    : builder(rewriter), rewriter(&rewriter), loc(loc) {
+  loc.getContext()->allowUnregisteredDialects();
+}
+Backedge BackedgeBuilder::get(Type t) {
+  OperationState s(loc, "TemporaryBackedge");
+  s.addTypes(t);
+  auto *op = builder.create(s);
+  edges.push_back(op);
+  return Backedge(op);
+}

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 
 add_circt_library(CIRCTSupport
+  BackedgeBuilder.cpp
   FieldRef.cpp
   LoweringOptions.cpp
   Path.cpp
@@ -13,6 +14,5 @@ add_circt_library(CIRCTSupport
   ADDITIONAL_HEADER_DIRS
 
   LINK_LIBS PUBLIC
-  CIRCTHW
   MLIRIR
   )


### PR DESCRIPTION
Replace the registered op in `hw` with an always registered op. As suggested by @River707.

https://discourse.llvm.org/t/constructing-backedges/61941/2