### PR TITLE
[SV] Allow sv.wire in any non-procedural region.

### DIFF
--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -46,7 +46,6 @@ def WireOp : SVOp<"wire", [NonProceduralOp,
       return result().getType().cast<InOutType>().getElementType();
     }
   }];
-  let hasVerifier = 1;
 }
 
 def RegOp : SVOp<"reg", [

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -1189,11 +1189,7 @@ LogicalResult WireOp::canonicalize(WireOp wire, PatternRewriter &rewriter) {
 }
 
 /// Ensure that the symbol being instantiated exists and is an InterfaceOp.
-LogicalResult WireOp::verify() {
-  if ((*this)->getParentOp()->hasTrait<ProceduralRegion>())
-    return emitError("sv.wire must not be in a procedural region");
-  return success();
-}
+LogicalResult WireOp::verify() { return verifyInNonProceduralRegion(*this); }
 
 //===----------------------------------------------------------------------===//
 // ReadInOutOp

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -1190,8 +1190,8 @@ LogicalResult WireOp::canonicalize(WireOp wire, PatternRewriter &rewriter) {
 
 /// Ensure that the symbol being instantiated exists and is an InterfaceOp.
 LogicalResult WireOp::verify() {
-  if (!isa<hw::HWModuleOp>((*this)->getParentOp()))
-    return emitError("sv.wire must not be in an always or initial block");
+  if ((*this)->getParentOp()->hasTrait<ProceduralRegion>())
+    return emitError("sv.wire must not be in a procedural region");
   return success();
 }
 

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -1188,9 +1188,6 @@ LogicalResult WireOp::canonicalize(WireOp wire, PatternRewriter &rewriter) {
   return success();
 }
 
-/// Ensure that the symbol being instantiated exists and is an InterfaceOp.
-LogicalResult WireOp::verify() { return verifyInNonProceduralRegion(*this); }
-
 //===----------------------------------------------------------------------===//
 // ReadInOutOp
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -320,3 +320,14 @@ hw.module @XMR_src(%a : i23) {
     // CHECK: = sv.indexed_part_select %[[v4]][%[[in4:.+]]  decrement : 5] : i18, i4
     hw.output %c, %d : i3, i5
 }
+
+// CHECK-LABEL: hw.module @nested_wire
+hw.module @nested_wire(%a: i1) {
+  // CHECK: sv.ifdef "foo"
+  sv.ifdef "foo" {
+    // CHECK: sv.wire
+    %wire = sv.wire : !hw.inout<i1>
+    // CHECK: sv.assign
+    sv.assign %wire, %a : i1
+  }
+}


### PR DESCRIPTION
The previous verifier required sv.wire to exist in the top-level body
of a hw.module. This relaxes the verifier to allow wires in any
non-procedural region.