### PR TITLE
[FIRRTL] Omnibus fixes for Grand Central Signal Mappings

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -78,7 +78,8 @@ std::unique_ptr<mlir::Pass> createGrandCentralPass();
 
 std::unique_ptr<mlir::Pass> createGrandCentralTapsPass();
 
-std::unique_ptr<mlir::Pass> createGrandCentralSignalMappingsPass();
+std::unique_ptr<mlir::Pass>
+createGrandCentralSignalMappingsPass(StringRef outputFilename = "");
 
 std::unique_ptr<mlir::Pass> createCheckCombCyclesPass();
 

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -365,6 +365,8 @@ def GrandCentralSignalMappings : Pass<"firrtl-grand-central-signal-mappings",
                                       "firrtl::CircuitOp"> {
   let summary = "Generate signal mappings that force/probe remote signals";
   let constructor = "circt::firrtl::createGrandCentralSignalMappingsPass()";
+  let options = [Option<"outputFilename", "file", "std::string", "",
+      "Output file for the JSON-serialized OMIR data">];
 }
 
 def CheckCombCycles : Pass<"firrtl-check-comb-cycles", "firrtl::CircuitOp"> {

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -367,6 +367,7 @@ def GrandCentralSignalMappings : Pass<"firrtl-grand-central-signal-mappings",
   let constructor = "circt::firrtl::createGrandCentralSignalMappingsPass()";
   let options = [Option<"outputFilename", "file", "std::string", "",
       "Output file for the JSON-serialized OMIR data">];
+  let dependentDialects = ["sv::SVDialect", "circt::hw::HWDialect"];
 }
 
 def CheckCombCycles : Pass<"firrtl-check-comb-cycles", "firrtl::CircuitOp"> {

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -2323,8 +2323,8 @@ LogicalResult FIRRTLLowering::visitDecl(VerbatimWireOp op) {
   if (!symbols)
     symbols = ArrayAttr::get(op.getContext(), {});
 
-  return setLoweringTo<sv::VerbatimExprOp>(op, resultTy, op.textAttr(),
-                                           operands, symbols);
+  return setLoweringTo<sv::VerbatimExprSEOp>(op, resultTy, op.textAttr(),
+                                             operands, symbols);
 }
 
 LogicalResult FIRRTLLowering::visitDecl(NodeOp op) {

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
@@ -258,6 +258,9 @@ void ModuleSignalMappings::instantiateMappingsModule(FModuleOp mappingsModule) {
 class GrandCentralSignalMappingsPass
     : public GrandCentralSignalMappingsBase<GrandCentralSignalMappingsPass> {
   void runOnOperation() override;
+
+public:
+  std::string outputFilename;
 };
 
 void GrandCentralSignalMappingsPass::runOnOperation() {
@@ -282,6 +285,9 @@ void GrandCentralSignalMappingsPass::runOnOperation() {
 }
 
 std::unique_ptr<mlir::Pass>
-circt::firrtl::createGrandCentralSignalMappingsPass() {
-  return std::make_unique<GrandCentralSignalMappingsPass>();
+circt::firrtl::createGrandCentralSignalMappingsPass(StringRef outputFilename) {
+  auto pass = std::make_unique<GrandCentralSignalMappingsPass>();
+  if (!outputFilename.empty())
+    pass->outputFilename = outputFilename;
+  return pass;
 }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -283,7 +283,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
     // CHECK: [[VERB1:%.+]] = sv.verbatim.expr "MAGIC_CONSTANT" : () -> i42
     // CHECK: [[VERB2:%.+]] = sv.verbatim.expr "$bits({{[{][{]0[}][}]}}, {{[{][{]1[}][}]}})"([[VERB1]]) : (i42) -> i32 {symbols = [@Simple]}
-    // CHECK: [[VERB3:%.+]] = sv.verbatim.expr "$size({{[{][{]0[}][}]}}, {{[{][{]1[}][}]}})"([[VERB1]]) : (i42) -> !hw.inout<i32> {symbols = [@Simple]}
+    // CHECK: [[VERB3:%.+]] = sv.verbatim.expr.se "$size({{[{][{]0[}][}]}}, {{[{][{]1[}][}]}})"([[VERB1]]) : (i42) -> !hw.inout<i32> {symbols = [@Simple]}
     // CHECK: [[VERB3READ:%.+]] = sv.read_inout [[VERB3]]
     // CHECK: [[VERB1EXT:%.+]] = comb.concat {{%.+}}, [[VERB1]] : i1, i42
     // CHECK: [[VERB2EXT:%.+]] = comb.concat {{%.+}}, [[VERB2]] : i11, i32

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -1104,7 +1104,7 @@ circuit Sub : %[[{
     dataSink <= ext.someOutput
 
 ; CHECK-LABEL: firrtl.circuit "Sub"
-; CHECK-SAME: {annotations = [], circuit = "", circuitPackage = "other", class = "sifive.enterprise.grandcentral.SignalDriverAnnotation", id = [[ID:.+]] : i64}
+; CHECK-SAME: {annotations = [], circuit = "", circuitPackage = "other", class = "sifive.enterprise.grandcentral.SignalDriverAnnotation", emitJSON, id = [[ID:.+]] : i64}
 
 ; CHECK-LABEL: firrtl.module @Sub
 ; CHECK-SAME: {class = "sifive.enterprise.grandcentral.SignalDriverAnnotation", id = [[ID]] : i64}

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -500,7 +500,8 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
     auto &circuitPM = pm.nest<firrtl::CircuitOp>();
     circuitPM.addPass(firrtl::createGrandCentralPass());
     circuitPM.addPass(firrtl::createGrandCentralTapsPass());
-    circuitPM.addPass(firrtl::createGrandCentralSignalMappingsPass());
+    circuitPM.addPass(
+        firrtl::createGrandCentralSignalMappingsPass(outputFilename));
   }
 
   // Read black box source files into the IR.


### PR DESCRIPTION
Update the Grand Central (GCT) Signal Mappings pass to emit SiFive JSON configuration information necessary for downstream tests to work.  Concretely, this produces a filelist and some extra information about external modules in the design.

An example of output would be:

```json
{
  "vendor": {
    "vcs": {
      "vsrcs": [
        "/Users/schuylere/repos/github.com/llvm/circt/build/grandcentral/signaldriving/Simple/mfc/driving/signal_driver_signal_mappings.sv",
        "/Users/schuylere/repos/github.com/llvm/circt/build/grandcentral/signaldriving/Simple/mfc/driving/signal_driver.sv"
      ]
    },
    "verilator": {
      "error": [
        "force statement is not supported in verilator"
      ]
    }
  },
  "remove_vsrcs": [],
  "vsrcs": [],
  "load_jsons": [
    "ExternalModule.json"
  ]
}
```