### PR TITLE
[Scheduling] Add consistency check.

### DIFF
--- a/include/circt/Scheduling/Algorithms.h
+++ b/include/circt/Scheduling/Algorithms.h
@@ -27,47 +27,51 @@ LogicalResult scheduleASAP(Problem &prob);
 /// Solve the basic problem using linear programming and a handwritten
 /// implementation of the simplex algorithm. The objective is to minimize the
 /// start time of the given \p lastOp. Fails if the dependence graph contains
-/// cycles.
+/// cycles, or \p prob does not include \p lastOp.
 LogicalResult scheduleSimplex(Problem &prob, Operation *lastOp);
 
 /// Solve the resource-free cyclic problem using linear programming and a
 /// handwritten implementation of the simplex algorithm. The objectives are to
 /// determine the smallest feasible initiation interval, and to minimize the
 /// start time of the given \p lastOp. Fails if the dependence graph contains
-/// cycles that do not include at least one edge with a non-zero distance.
+/// cycles that do not include at least one edge with a non-zero distance, or
+/// \p prob does not include \p lastOp.
 LogicalResult scheduleSimplex(CyclicProblem &prob, Operation *lastOp);
 
 /// Solve the acyclic problem with shared operators using a linear
 /// programming-based heuristic. The approach tries to minimize the start time
 /// of the given \p lastOp, but optimality is not guaranteed. Fails if the
-/// dependence graph contains cycles.
+/// dependence graph contains cycles, or \p prob does not include \p lastOp.
 LogicalResult scheduleSimplex(SharedOperatorsProblem &prob, Operation *lastOp);
 
 /// Solve the modulo scheduling problem using a linear programming-based
 /// heuristic. The approach tries to determine the smallest feasible initiation
 /// interval, and to minimize the start time of the given \p lastOp, but
 /// optimality is not guaranteed. Fails if the dependence graph contains cycles
-/// that do not include at least one edge with a non-zero distance.
+/// that do not include at least one edge with a non-zero distance, or \p prob
+/// does not include \p lastOp.
 LogicalResult scheduleSimplex(ModuloProblem &prob, Operation *lastOp);
 
 /// Solve the acyclic, chaining-enabled problem using linear programming and a
 /// handwritten implementation of the simplex algorithm. This approach strictly
 /// adheres to the given maximum \p cycleTime. The objective is to minimize the
 /// start time of the given \p lastOp. Fails if the dependence graph contains
-/// cycles, or individual operator types have delays larger than \p cycleTime.
+/// cycles, or individual operator types have delays larger than \p cycleTime,
+/// or \p prob does not include \p lastOp.
 LogicalResult scheduleSimplex(ChainingProblem &prob, Operation *lastOp,
                               float cycleTime);
 
 /// Solve the basic problem using linear programming and an external LP solver.
 /// The objective is to minimize the start time of the given \p lastOp. Fails if
-/// the dependence graph contains cycles.
+/// the dependence graph contains cycles, or \p prob does not include \p lastOp.
 LogicalResult scheduleLP(Problem &prob, Operation *lastOp);
 
 /// Solve the resource-free cyclic problem using integer linear programming and
 /// an external ILP solver. The objectives are to determine the smallest
 /// feasible initiation interval, and to minimize the start time of the given \p
 /// lastOp. Fails if the dependence graph contains cycles that do not include at
-/// least one edge with a non-zero distance.
+/// least one edge with a non-zero distance, or \p prob does not include
+/// \p lastOp.
 LogicalResult scheduleLP(CyclicProblem &prob, Operation *lastOp);
 
 } // namespace scheduling

--- a/lib/Scheduling/LPSchedulers.cpp
+++ b/lib/Scheduling/LPSchedulers.cpp
@@ -23,11 +23,13 @@ using namespace operations_research;
 
 LogicalResult scheduling::scheduleLP(Problem &prob, Operation *lastOp) {
   Operation *containingOp = prob.getContainingOp();
+  if (!prob.hasOperation(lastOp))
+    return containingOp->emitError("problem does not include last operation");
 
   MPSolver::OptimizationProblemType problemType;
   if (!MPSolver::ParseSolverType("GLOP_LINEAR_PROGRAMMING", &problemType) ||
       !MPSolver::SupportsProblemType(problemType))
-    return containingOp->emitError("Solver is unvailable");
+    return containingOp->emitError("GLOP is unvailable");
 
   MPSolver solver("Problem", problemType);
   double infinity = solver.infinity();
@@ -78,11 +80,13 @@ LogicalResult scheduling::scheduleLP(Problem &prob, Operation *lastOp) {
 
 LogicalResult scheduling::scheduleLP(CyclicProblem &prob, Operation *lastOp) {
   Operation *containingOp = prob.getContainingOp();
+  if (!prob.hasOperation(lastOp))
+    return containingOp->emitError("problem does not include last operation");
 
   MPSolver::OptimizationProblemType probType;
   if (!MPSolver::ParseSolverType("CBC_MIXED_INTEGER_PROGRAMMING", &probType) ||
       !MPSolver::SupportsProblemType(probType))
-    return containingOp->emitError("Solver is unavailable");
+    return containingOp->emitError("Cbc is unavailable");
 
   MPSolver solver("CyclicProblem", probType);
   double infinity = solver.infinity();


### PR DESCRIPTION
The `lastOp` determines the algorithms' objective, so make sure it's actually registered in the given problem.