### PR TITLE
[Calyx] Update MultPipeOp and DivPipeOp format to round-trip.

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -196,7 +196,7 @@ def XorLibOp  : CombinationalArithBinaryLibraryOp<"xor"> {}
 def MultPipeLibOp : ArithBinaryLibraryOp<"mult_pipe", [
     SameTypeConstraint<"left", "out">
   ]> {
-  let results = (outs AnyType:$left, AnyType:$right, I1:$go, I1:$clk, I1:$reset, AnyType:$out, I1:$done);
+  let results = (outs I1:$clk, I1:$reset, I1:$go, AnyType:$left, AnyType:$right, AnyType:$out, I1:$done);
 }
 
 def DivPipeLibOp : ArithBinaryLibraryOp<"div_pipe", [
@@ -204,7 +204,7 @@ def DivPipeLibOp : ArithBinaryLibraryOp<"div_pipe", [
     SameTypeConstraint<"right", "out_remainder">
   ]> {
   let results = (outs
-    AnyType:$left, AnyType:$right, I1:$go, I1:$clk, I1:$reset,
+    I1:$clk, I1:$reset, I1:$go, AnyType:$left, AnyType:$right,
     AnyType:$out_quotient, AnyType:$out_remainder, I1:$done
   );
 }

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -1060,7 +1060,7 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
   Type width = mul.getResult().getType(), one = rewriter.getI1Type();
   auto mulPipe =
       getComponentState().getNewLibraryOpInstance<calyx::MultPipeLibOp>(
-          rewriter, loc, {width, width, one, one, one, width, one});
+          rewriter, loc, {one, one, one, width, width, width, one});
   return buildLibraryBinaryPipeOp<calyx::MultPipeLibOp>(rewriter, mul, mulPipe,
                                                         /*out=*/mulPipe.out());
 }
@@ -1071,7 +1071,7 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
   Type width = div.getResult().getType(), one = rewriter.getI1Type();
   auto divPipe =
       getComponentState().getNewLibraryOpInstance<calyx::DivPipeLibOp>(
-          rewriter, loc, {width, width, one, one, one, width, width, one});
+          rewriter, loc, {one, one, one, width, width, width, width, one});
   return buildLibraryBinaryPipeOp<calyx::DivPipeLibOp>(
       rewriter, div, divPipe,
       /*out=*/divPipe.out_quotient());
@@ -1083,7 +1083,7 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
   Type width = rem.getResult().getType(), one = rewriter.getI1Type();
   auto remPipe =
       getComponentState().getNewLibraryOpInstance<calyx::DivPipeLibOp>(
-          rewriter, loc, {width, width, one, one, one, width, width, one});
+          rewriter, loc, {one, one, one, width, width, width, width, one});
   return buildLibraryBinaryPipeOp<calyx::DivPipeLibOp>(
       rewriter, rem, remPipe,
       /*out=*/remPipe.out_remainder());

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -1706,7 +1706,7 @@ LogicalResult WhileOp::canonicalize(WhileOp whileOp,
 //===----------------------------------------------------------------------===//
 
 SmallVector<StringRef> MultPipeLibOp::portNames() {
-  return {"left", "right", "go", "clk", "reset", "out", "done"};
+  return {"clk", "reset", "go", "left", "right", "out", "done"};
 }
 
 SmallVector<Direction> MultPipeLibOp::portDirections() {
@@ -1726,11 +1726,11 @@ SmallVector<DictionaryAttr> MultPipeLibOp::portAttributes() {
   reset.append("reset", isSet);
   done.append("done", isSet);
   return {
-      DictionaryAttr(),             /* Lhs    */
-      DictionaryAttr(),             /* Rhs    */
-      go.getDictionary(context),    /* Go     */
       clk.getDictionary(context),   /* Clk    */
       reset.getDictionary(context), /* Reset  */
+      go.getDictionary(context),    /* Go     */
+      DictionaryAttr(),             /* Lhs    */
+      DictionaryAttr(),             /* Rhs    */
       DictionaryAttr(),             /* Out    */
       done.getDictionary(context)   /* Done   */
   };
@@ -1741,7 +1741,7 @@ SmallVector<DictionaryAttr> MultPipeLibOp::portAttributes() {
 //===----------------------------------------------------------------------===//
 
 SmallVector<StringRef> DivPipeLibOp::portNames() {
-  return {"left",         "right",         "go",  "clk", "reset",
+  return {"clk",          "reset",         "go",  "left", "right",
           "out_quotient", "out_remainder", "done"};
 }
 
@@ -1762,11 +1762,11 @@ SmallVector<DictionaryAttr> DivPipeLibOp::portAttributes() {
   reset.append("reset", isSet);
   done.append("done", isSet);
   return {
-      DictionaryAttr(),             /* Lhs       */
-      DictionaryAttr(),             /* Rhs       */
-      go.getDictionary(context),    /* Go        */
       clk.getDictionary(context),   /* Clk       */
       reset.getDictionary(context), /* Reset     */
+      go.getDictionary(context),    /* Go        */
+      DictionaryAttr(),             /* Lhs       */
+      DictionaryAttr(),             /* Rhs       */
       DictionaryAttr(),             /* Quotient  */
       DictionaryAttr(),             /* Remainder */
       done.getDictionary(context)   /* Done      */

--- a/test/Conversion/SCFToCalyx/convert_pipeline.mlir
+++ b/test/Conversion/SCFToCalyx/convert_pipeline.mlir
@@ -63,7 +63,7 @@ func @minimal() {
 // CHECK-DAG:     %[[SLICE1_IN:.+]], %[[SLICE1_OUT:.+]] = calyx.std_slice @std_slice_1
 // CHECK-DAG:     %[[ADD0_LEFT:.+]], %[[ADD0_RIGHT:.+]], %[[ADD0_OUT:.+]] = calyx.std_add @std_add_0
 // CHECK-DAG:     %[[ADD1_LEFT:.+]], %[[ADD1_RIGHT:.+]], %[[ADD1_OUT:.+]] = calyx.std_add @std_add_1
-// CHECK-DAG:     %[[MUL_LEFT:.+]], %[[MUL_RIGHT:.+]], %[[MUL_GO:.+]], {{.+}}, {{.+}}, %[[MUL_OUT:.+]], %[[MUL_DONE:.+]] = calyx.std_mult_pipe
+// CHECK-DAG:     {{.+}}, {{.+}}, %[[MUL_GO:.+]], %[[MUL_LEFT:.+]], %[[MUL_RIGHT:.+]], %[[MUL_OUT:.+]], %[[MUL_DONE:.+]] = calyx.std_mult_pipe
 // CHECK-DAG:     %[[LT_LEFT:.+]], %[[LT_RIGHT:.+]], %[[LT_OUT:.+]] = calyx.std_lt
 // CHECK-DAG:     %[[ITER_ARG0_IN:.+]], %[[ITER_ARG0_EN:.+]], {{.+}}, {{.+}}, %[[ITER_ARG0_OUT:.+]], %[[ITER_ARG0_DONE:.+]] = calyx.register @while_0_arg0_reg
 // CHECK-DAG:     %[[ITER_ARG1_IN:.+]], %[[ITER_ARG1_EN:.+]], {{.+}}, {{.+}}, %[[ITER_ARG1_OUT:.+]], %[[ITER_ARG1_DONE:.+]] = calyx.register @while_0_arg1_reg

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -18,7 +18,7 @@ calyx.program "main" {
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     %s.in, %s.write_en, %s.clk, %s.reset, %s.out, %s.done = calyx.register @s : i32, i1, i1, i1, i32, i1
     // CHECK: mu = std_mult_pipe(32);
-    %mu.left, %mu.right, %mu.go, %mu.clk, %mu.reset, %mu.out, %mu.done = calyx.std_mult_pipe @mu : i32, i32, i1, i1, i1, i32, i1
+    %mu.clk, %mu.reset, %mu.go, %mu.left, %mu.right, %mu.out, %mu.done = calyx.std_mult_pipe @mu : i1, i1, i1, i32, i32, i32, i1
     %c1_1 = hw.constant 1 : i1
     %c4_32 = hw.constant 4 : i32
     calyx.wires {

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -19,8 +19,8 @@ calyx.program "main" {
   // CHECK-LABEL:   calyx.component @main(%clk: i1 {clk}, %go: i1 {go}, %reset: i1 {reset}) -> (%done: i1 {done}) {
   calyx.component @main(%clk: i1 {clk}, %go: i1 {go}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     // CHECK:      %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i8, i1, i1, i1, i8, i1
-    // CHECK-NEXT: %mu.left, %mu.right, %mu.go, %mu.clk, %mu.reset, %mu.out, %mu.done = calyx.std_mult_pipe @mu : i32, i32, i1, i1, i1, i32, i1
-    // CHECK-NEXT: %du.left, %du.right, %du.go, %du.clk, %du.reset, %du.out_quotient, %du.out_remainder, %du.done = calyx.std_div_pipe @du : i32, i32, i1, i1, i1, i32, i32, i1
+    // CHECK-NEXT: %mu.clk, %mu.reset, %mu.go, %mu.left, %mu.right, %mu.out, %mu.done = calyx.std_mult_pipe @mu : i1, i1, i1, i32, i32, i32, i1
+    // CHECK-NEXT: %du.clk, %du.reset, %du.go, %du.left, %du.right, %du.out_quotient, %du.out_remainder, %du.done = calyx.std_div_pipe @du : i1, i1, i1, i32, i32, i32, i32, i1
     // CHECK-NEXT: %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory @m <[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
     // CHECK-NEXT: %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 of @A : i8, i1, i1, i1, i8, i1
     // CHECK-NEXT: %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance @c1 of @A : i8, i1, i1, i1, i8, i1
@@ -31,8 +31,8 @@ calyx.program "main" {
     // CHECK-NEXT: %slice.in, %slice.out = calyx.std_slice @slice : i8, i7
     // CHECK-NEXT: %not.in, %not.out = calyx.std_not @not : i8, i8
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i8, i1, i1, i1, i8, i1
-    %mu.lhs, %mu.rhs, %mu.go, %mu.clk, %mu.reset, %mu.out, %mu.done = calyx.std_mult_pipe @mu : i32, i32, i1, i1, i1, i32, i1
-    %du.left, %du.right, %du.go, %du.clk, %du.reset, %du.out_quotient, %du.out_remainder, %du.done = calyx.std_div_pipe @du : i32, i32, i1, i1, i1, i32, i32, i1
+    %mu.clk, %mu.reset, %mu.go, %mu.lhs, %mu.rhs, %mu.out, %mu.done = calyx.std_mult_pipe @mu : i1, i1, i1, i32, i32, i32, i1
+    %du.clk, %du.reset, %du.go, %du.left, %du.right, %du.out_quotient, %du.out_remainder, %du.done = calyx.std_div_pipe @du : i1, i1, i1, i32, i32, i32, i32, i1
     %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory @m <[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
     %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 of @A : i8, i1, i1, i1, i8, i1
     %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance @c1 of @A : i8, i1, i1, i1, i8, i1


### PR DESCRIPTION
This aligns the textual IR format, the emitter, and any locations
these ops were constructed in code to the result order defined by the
native  Calyx compiler. This is required for these ops to be able to
round-trip through the native compiler.