### PR TITLE
[Calyx] Add WireLibOp to represent a wire in Calyx's core library.

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -209,7 +209,8 @@ def DivPipeLibOp : ArithBinaryLibraryOp<"div_pipe", [
   );
 }
 
-class UnaryLibraryOp<string mnemonic> : CalyxLibraryOp<mnemonic, [Combinational]> {
+class UnaryLibraryOp<string mnemonic, list<Trait> traits = []> :
+    CalyxLibraryOp<mnemonic, !listconcat(traits, [Combinational])> {
   let results = (outs AnyInteger:$in, AnyInteger:$out);
 }
 
@@ -222,3 +223,5 @@ def SliceLibOp : UnaryLibraryOp<"slice"> {
 }
 
 def NotLibOp  : UnaryLibraryOp<"not"> {}
+
+def WireLibOp : UnaryLibraryOp<"wire", [SameTypeConstraint<"in", "out">]> {}

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -1825,6 +1825,7 @@ LogicalResult SliceLibOp::verify() {
 ImplUnaryOpCellInterface(PadLibOp)
 ImplUnaryOpCellInterface(SliceLibOp)
 ImplUnaryOpCellInterface(NotLibOp)
+ImplUnaryOpCellInterface(WireLibOp)
 
 ImplBinOpCellInterface(LtLibOp)
 ImplBinOpCellInterface(GtLibOp)

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -97,7 +97,7 @@ private:
     TypeSwitch<Operation *>(op)
         .Case<MemoryOp, RegisterOp, NotLibOp, AndLibOp, OrLibOp, XorLibOp,
               AddLibOp, SubLibOp, GtLibOp, LtLibOp, EqLibOp, NeqLibOp, GeLibOp,
-              LeLibOp, LshLibOp, RshLibOp, SliceLibOp, PadLibOp>(
+              LeLibOp, LshLibOp, RshLibOp, SliceLibOp, PadLibOp, WireLibOp>(
             [&](auto op) { library = "core"; })
         .Case<SgtLibOp, SltLibOp, SeqLibOp, SneqLibOp, SgeLibOp, SleLibOp,
               SrshLibOp, MultPipeLibOp, DivPipeLibOp>(
@@ -487,7 +487,7 @@ void Emitter::emitComponent(ComponentOp op) {
           .Case<LtLibOp, GtLibOp, EqLibOp, NeqLibOp, GeLibOp, LeLibOp, SltLibOp,
                 SgtLibOp, SeqLibOp, SneqLibOp, SgeLibOp, SleLibOp, AddLibOp,
                 SubLibOp, ShruLibOp, RshLibOp, SrshLibOp, LshLibOp, AndLibOp,
-                NotLibOp, OrLibOp, XorLibOp>(
+                NotLibOp, OrLibOp, XorLibOp, WireLibOp>(
               [&](auto op) { emitLibraryPrimTypedByFirstInputPort(op); })
           .Case<MultPipeLibOp, DivPipeLibOp>(
               [&](auto op) { emitLibraryPrimTypedByFirstOutputPort(op); })

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -70,6 +70,7 @@ calyx.program "main" {
     // CHECK-NEXT:    m1 = std_mem_d2(8, 64, 64, 6, 6);
     // CHECK-NEXT:    @generated a0 = std_add(32);
     // CHECK-NEXT:    @generated s0 = std_slice(32, 8);
+    // CHECK-NEXT:    @generated wire = std_wire(8);
     %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 of @A : i32, i1, i1, i1, i32, i1
     %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance @c1 of @B {not_calyx_attr="foo", precious} : i1, i1, i1, i1, i1, i1
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i8, i1, i1, i1, i8, i1
@@ -77,6 +78,7 @@ calyx.program "main" {
     %m1.addr0, %m1.addr1, %m1.write_data, %m1.write_en, %m1.clk, %m1.read_data, %m1.done = calyx.memory @m1 <[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
     %a0.left, %a0.right, %a0.out = calyx.std_add @a0 {generated} : i32, i32, i32
     %s0.in, %s0.out = calyx.std_slice @s0 {generated} : i32, i8
+    %wire.in, %wire.out = calyx.std_wire @wire {generated} : i8, i8
     %c0 = hw.constant 0 : i1
     %c1 = hw.constant 1 : i1
     %c1_i32 = hw.constant 1 : i32

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -30,6 +30,7 @@ calyx.program "main" {
     // CHECK-NEXT: %pad.in, %pad.out = calyx.std_pad @pad : i8, i9
     // CHECK-NEXT: %slice.in, %slice.out = calyx.std_slice @slice : i8, i7
     // CHECK-NEXT: %not.in, %not.out = calyx.std_not @not : i8, i8
+    // CHECK-NEXT: %wire.in, %wire.out = calyx.std_wire @wire : i8, i8
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i8, i1, i1, i1, i8, i1
     %mu.clk, %mu.reset, %mu.go, %mu.lhs, %mu.rhs, %mu.out, %mu.done = calyx.std_mult_pipe @mu : i1, i1, i1, i32, i32, i32, i1
     %du.clk, %du.reset, %du.go, %du.left, %du.right, %du.out_quotient, %du.out_remainder, %du.done = calyx.std_div_pipe @du : i1, i1, i1, i32, i32, i32, i32, i1
@@ -42,6 +43,7 @@ calyx.program "main" {
     %pad.in, %pad.out = calyx.std_pad @pad : i8, i9
     %slice.in, %slice.out = calyx.std_slice @slice : i8, i7
     %not.in, %not.out = calyx.std_not @not : i8, i8
+    %wire.in, %wire.out = calyx.std_wire @wire : i8, i8
     %c1_i1 = hw.constant 1 : i1
     %c0_i6 = hw.constant 0 : i6
     %c0_i8 = hw.constant 0 : i8


### PR DESCRIPTION
This is a core Calyx primitive, and semantically is roughly the same
as sv.wire. Add support for it as a UnaryLibraryOp.