### PR TITLE
[reduce] Add NodeSymbolRemover reduction

### DIFF
--- a/test/circt-reduce/node-symbol-remover.mlir
+++ b/test/circt-reduce/node-symbol-remover.mlir
@@ -1,0 +1,11 @@
+// RUN: circt-reduce %s --test %S/test.sh --test-arg cat --test-arg "%anotherWire = firrtl.node" --keep-best=0 --include node-symbol-remover | FileCheck %s
+
+firrtl.circuit "Foo" {
+  // CHECK: firrtl.module @Foo
+  // CHECK: %oneWire = firrtl.wire
+  // CHECK-NEXT: %anotherWire = firrtl.node %oneWire
+  firrtl.module @Foo() {
+    %oneWire = firrtl.wire : !firrtl.uint<1>
+    %anotherWire = firrtl.node sym @SYM %oneWire : !firrtl.uint<1>
+  }
+}


### PR DESCRIPTION
This commit adds a new reduction named NodeSymbolRemover to
remove symbols on node operations. This reduction is intended to
clean up symbols created by name preservation.

close #2963