### PR TITLE
[FIRRTL] Do not dedup testharness memories

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -65,7 +65,7 @@ void CreateSiFiveMetadataPass::renameMemory(CircuitOp circuitOp) {
   // This is a random number to start the groupIDs at, large enough to not
   // conflict with existing IDs.
   // TODO: Move this logic out of this pass.
-  unsigned baseGroupID = -1;
+  unsigned baseGroupID = std::numeric_limits<unsigned>::max();
   for (auto mod : circuitOp.getOps<FModuleOp>()) {
     bool isTestHarness = !dutModuleSet.contains(mod);
     for (auto memOp : mod.getBody()->getOps<MemOp>()) {

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -62,8 +62,17 @@ void CreateSiFiveMetadataPass::renameMemory(CircuitOp circuitOp) {
   std::map<FirMemory, StringAttr> memNameMap;
   auto *ctxt = circuitOp.getContext();
   auto modNameAttr = StringAttr::get(ctxt, "modName");
-  for (auto mod : circuitOp.getOps<FModuleOp>())
+  // This is a random number to start the groupIDs at, large enough to not
+  // conflict with existing IDs.
+  // TODO: Move this logic out of this pass.
+  unsigned baseGroupID = 200;
+  for (auto mod : circuitOp.getOps<FModuleOp>()) {
+    bool isTestHarness = !dutModuleSet.contains(mod);
     for (auto memOp : mod.getBody()->getOps<MemOp>()) {
+      if (isTestHarness && !memOp.groupID().hasValue())
+        memOp.groupIDAttr(
+            IntegerAttr::get(IntegerType::get(ctxt, 32), ++baseGroupID));
+
       memOpList.push_back(memOp);
       auto firMem = memOp.getSummary();
       auto insert = memNameMap.find(firMem);
@@ -76,6 +85,7 @@ void CreateSiFiveMetadataPass::renameMemory(CircuitOp circuitOp) {
       } else
         memOp->setAttr(modNameAttr, insert->second);
     }
+  }
 }
 
 /// This function collects all the firrtl.mem ops and creates a verbatim op with
@@ -463,8 +473,6 @@ void CreateSiFiveMetadataPass::runOnOperation() {
   auto circuitOp = getOperation();
   auto *body = circuitOp.getBody();
 
-  renameMemory(circuitOp);
-
   // Find the device under test and create a set of all modules underneath it.
   auto it = llvm::find_if(*body, [&](Operation &op) -> bool {
     return AnnotationSet(&op).hasAnnotation(dutAnnoClass);
@@ -477,6 +485,8 @@ void CreateSiFiveMetadataPass::runOnOperation() {
       dutModuleSet.insert(node->getModule());
     });
   }
+  renameMemory(circuitOp);
+
   if (failed(emitRetimeModulesMetadata()) ||
       failed(emitSitestBlackboxMetadata()) || failed(emitMemoryMetadata()))
     return signalPassFailure();

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -65,13 +65,13 @@ void CreateSiFiveMetadataPass::renameMemory(CircuitOp circuitOp) {
   // This is a random number to start the groupIDs at, large enough to not
   // conflict with existing IDs.
   // TODO: Move this logic out of this pass.
-  unsigned baseGroupID = 200;
+  unsigned baseGroupID = -1;
   for (auto mod : circuitOp.getOps<FModuleOp>()) {
     bool isTestHarness = !dutModuleSet.contains(mod);
     for (auto memOp : mod.getBody()->getOps<MemOp>()) {
       if (isTestHarness && !memOp.groupID().hasValue())
         memOp.groupIDAttr(
-            IntegerAttr::get(IntegerType::get(ctxt, 32), ++baseGroupID));
+            IntegerAttr::get(IntegerType::get(ctxt, 32), --baseGroupID));
 
       memOpList.push_back(memOp);
       auto firMem = memOp.getSummary();
@@ -373,8 +373,7 @@ LogicalResult CreateSiFiveMetadataPass::emitSitestBlackboxMetadata() {
       "freechips.rocketchip.util.BlackBoxedROM", "chisel3.shim.CloneModule",
       "sifive.enterprise.grandcentral.MemTap"};
   std::array<StringRef, 6> blackListedAnnos = {
-      "firrtl.transforms.BlackBox",
-      "firrtl.transforms.BlackBoxInlineAnno",
+      "firrtl.transforms.BlackBox", "firrtl.transforms.BlackBoxInlineAnno",
       "sifive.enterprise.grandcentral.DataTapsAnnotation",
       "sifive.enterprise.grandcentral.MemTapAnnotation",
       "sifive.enterprise.grandcentral.transforms.SignalMappingAnnotation"};

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -124,9 +124,13 @@ firrtl.circuit "top"
     firrtl.module @top()  {
       firrtl.instance dut @dut()
       firrtl.instance mem1 @Mem1()
+      firrtl.instance mem2 @Mem2()
     }
     firrtl.module @Mem1() {
       %head_MPORT_2 = firrtl.mem Undefined  {depth = 20 : i64, name = "head", portNames = ["MPORT_2", "MPORT_6"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<5>, mask: uint<1>>
+    }
+    firrtl.module @Mem2() {
+      %head_MPORT_3 = firrtl.mem Undefined  {depth = 20 : i64, name = "head", portNames = ["MPORT_2", "MPORT_6"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<5>, mask: uint<1>>
     }
     firrtl.module @dut() attributes {annotations = [
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
@@ -136,9 +140,10 @@ firrtl.circuit "top"
       %memory_rw, %memory_rw_r = firrtl.mem Undefined  {annotations = [{class = "sifive.enterprise.firrtl.SeqMemInstanceMetadataAnnotation", data = {baseAddress = 2147483648 : i64, dataBits = 8 : i64, eccBits = 0 : i64, eccIndices = [], eccScheme = "none"}}], depth = 16 : i64, name = "memory", portNames = ["rw", "rw_r", "rw_w"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, wdata: uint<8>, wmask: uint<1>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
       %head_MPORT_2, %head_MPORT_6 = firrtl.mem Undefined  {depth = 20 : i64, name = "dumm", portNames = ["MPORT_2", "MPORT_6"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<5>, mask: uint<1>>, !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<5>, mask: uint<1>>
     }
-    // CHECK: sv.verbatim "[{\22module_name\22:\22head_ext\22,\22depth\22:20,\22width\22:5,\22masked\22:false,\22read\22:false,\22write\22:true,\22readwrite\22:false,\22extra_ports\22:[],\22hierarchy\22:[\22top.mem1.head\22]}]" {output_file = #hw.output_file<"metadata/tb_seq_mems.json", excludeFromFileList>, symbols = []}
+    // CHECK: sv.verbatim "[{\22module_name\22:\22head_ext_0\22,\22depth\22:20,\22width\22:5,\22masked\22:false,\22read\22:false,\22write\22:true,\22readwrite\22:false,\22extra_ports\22:[],\22hierarchy\22:[\22top.mem2.head\22]},{\22module_name\22:\22head_ext\22,\22depth\22:20,\22width\22:5,\22masked\22:false,\22read\22:false,\22write\22:true,\22readwrite\22:false,\22extra_ports\22:[],\22hierarchy\22:[\22top.mem1.head\22]}]"
+    // CHECK-SAME:  {output_file = #hw.output_file<"metadata/tb_seq_mems.json", excludeFromFileList>, symbols = []}
     // CHECK: sv.verbatim "[{\22module_name\22:\22memory_ext\22,\22depth\22:16,\22width\22:8,\22masked\22:false,\22read\22:true,\22write\22:false,\22readwrite\22:true,\22extra_ports\22:[],\22hierarchy\22:[\22top.dut.mem1.memory\22]
     // CHECK-SAME: output_file = #hw.output_file<"metadata/seq_mems.json", excludeFromFileList>, symbols = []
-    // CHECK: sv.verbatim "name memory_ext depth 16 width 8 ports rw\0Aname head_ext depth 20 width 5 ports write\0A"
+    // CHECK: sv.verbatim "name memory_ext depth 16 width 8 ports rw\0Aname head_ext_0 depth 20 width 5 ports write\0Aname head_ext depth 20 width 5 ports write\0A" 
     // CHECK-SAME: {output_file = #hw.output_file<"\22metadata/dut.conf\22", excludeFromFileList>, symbols = []}
 }


### PR DESCRIPTION
This commit adds a unique groupID to each Testharness memory to prevent their
 Dedup. This commit is a temporary fix to match SFC behavior. 
Currently, the memory dedup happens during the metadata emission, because that
 is the first pass that requires the name of the final memory module. The plan
 is to create a new Memory lowering pass, and move all the memory transformations to it.
