### PR TITLE
[FIRRTL] [CheckCombCycles] Improve error message by reconstructing a full cycle

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/CheckCombCycles.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckCombCycles.cpp
@@ -603,8 +603,7 @@ void dumpPathBetweenModulePorts(SmallString<16> &instancePath,
   std::queue<Node> que;
   que.push(start);
   while (!que.empty()) {
-    auto current = que.front();
-    que.pop();
+    Node current = que.front();
     if (current == end)
       break;
     for (auto child :
@@ -616,6 +615,8 @@ void dumpPathBetweenModulePorts(SmallString<16> &instancePath,
       previousNode.insert({child, current});
       que.push(child);
     }
+
+    que.pop();
   }
 
   SmallVector<Node> path;

--- a/lib/Dialect/FIRRTL/Transforms/CheckCombCycles.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckCombCycles.cpp
@@ -509,29 +509,32 @@ SmallVector<Node> sampleCycle(SCCIterator &scc) {
   llvm_unreachable("a cycle must be found in SCC");
 }
 
-void dumpSimpleCycle(SCCIterator &scc, FModuleOp module,
-                     mlir::InFlightDiagnostic &diag) {
-  // Sample a cycle to print.
-  SmallVector<Node> cycle = sampleCycle(scc);
-  unsigned cycleSize = cycle.size();
+// This function dumps a (shortest) path from `inputPort` to `outputPort` by
+// looking at a module referred by `instance`.
+void dumpPathBetweenModulePorts(SmallString<16> &instancePath,
+                                InstanceOp instance, unsigned inputPort,
+                                unsigned outputPort, NodeContext *context,
+                                mlir::InFlightDiagnostic &diag);
 
-  // NOTE: We visit the start element twice to explicitly indicate the path
-  // forms a cycle.
-  for (unsigned i = 0, e = cycleSize + 1; i < e; ++i) {
-    Node current = cycle[i % cycleSize];
-    bool lastNode = i == cycleSize;
+// Dump a path to a diagnostic.
+void dumpPath(SmallVector<Node> &path, SmallString<16> &instancePath,
+              FModuleOp module, bool isCycle, mlir::InFlightDiagnostic &diag) {
+  unsigned pathSize = isCycle ? path.size() + 1 : path.size();
+  for (unsigned i = 0, e = pathSize; i < e; ++i) {
+    Node current = path[i % path.size()];
+    Value currentValue = current.value;
+    bool isCycleEnd = i == path.size();
     auto attachInfo = [&]() -> mlir::Diagnostic & {
-      return diag.attachNote(current.value.getLoc())
-             << module.getName().str() << ".";
+      return diag.attachNote(currentValue.getLoc()) << instancePath << ".";
     };
 
-    // If the current value is port, emit its name.
-    if (auto arg = current.value.dyn_cast<BlockArgument>()) {
+    // If the currentValue is port, emit its name.
+    if (auto arg = currentValue.dyn_cast<BlockArgument>()) {
       attachInfo() << module.getPortName(arg.getArgNumber());
       continue;
     }
 
-    TypeSwitch<Operation *>(current.value.getDefiningOp())
+    TypeSwitch<Operation *>(currentValue.getDefiningOp())
         .Case<WireOp, RegOp, RegResetOp>(
             // For operations which declare signals, we simply print signal
             // names.
@@ -540,7 +543,7 @@ void dumpSimpleCycle(SCCIterator &scc, FModuleOp module,
           // If the op is InstanceOp or SubfieldOp, it is necessary to
           // investigate the next value since output values do not expilicty
           // appear in the cycle.
-          Node next = cycle[(i + 1) % cycleSize];
+          Node next = path[(i + 1) % path.size()];
           for (auto iter = GT::child_begin(current),
                     end = GT::child_end(current);
                iter != end; ++iter) {
@@ -550,24 +553,26 @@ void dumpSimpleCycle(SCCIterator &scc, FModuleOp module,
             auto iterImpl = iter.getIteratorImpl();
             if (std::holds_alternative<InstanceNodeIterator>(iterImpl)) {
               // Instance. Print names of input and output ports.
-              auto instance = current.value.getDefiningOp<InstanceOp>();
-              auto inputPort = current.value.cast<OpResult>().getResultNumber();
+              auto instance = currentValue.getDefiningOp<InstanceOp>();
+              auto inputPort = currentValue.cast<OpResult>().getResultNumber();
               auto outputPort =
                   std::get<InstanceNodeIterator>(iterImpl).getPortNumber();
-              attachInfo() << instance.name() << "."
-                           << instance.getPortName(inputPort).str();
-              if (!lastNode)
+              if (isCycleEnd)
                 attachInfo() << instance.name() << "."
-                             << instance.getPortName(outputPort).str();
+                             << instance.getPortName(inputPort).str();
+              else
+                dumpPathBetweenModulePorts(instancePath, instance, inputPort,
+                                           outputPort, current.context, diag);
+
             } else if (std::holds_alternative<SubfieldNodeIterator>(iterImpl)) {
               // SubfieldNodeIterator represents the connection between addr
               // port and data port.
-              auto subfieldAddr = current.value.getDefiningOp<SubfieldOp>();
+              auto subfieldAddr = currentValue.getDefiningOp<SubfieldOp>();
               auto subfieldData =
                   std::get<SubfieldNodeIterator>(iterImpl).getDataPort();
 
               attachInfo() << getFieldName(getFieldRefFromValue(subfieldAddr));
-              if (!lastNode)
+              if (!isCycleEnd)
                 diag.attachNote(subfieldData.getLoc())
                     << module.getName().str() << "."
                     << getFieldName(getFieldRefFromValue(subfieldData));
@@ -577,6 +582,66 @@ void dumpSimpleCycle(SCCIterator &scc, FModuleOp module,
         })
         .Default([&](auto op) {});
   }
+}
+
+// This function dumps a (shortest) path from `inputPort` to `outputPort` by
+// looking at a module referred by `instance`.
+void dumpPathBetweenModulePorts(SmallString<16> &instancePath,
+                                InstanceOp instance, unsigned inputPort,
+                                unsigned outputPort, NodeContext *context,
+                                mlir::InFlightDiagnostic &diag) {
+  auto module = dyn_cast<FModuleOp>(*instance.getReferencedModule());
+  if (!module)
+    return;
+  unsigned instancePathSize = instancePath.size();
+  instancePath += ".";
+  instancePath += instance.name();
+  auto start = Node(module.getArgument(inputPort), context);
+  auto end = Node(module.getArgument(outputPort), context);
+  llvm::DenseMap<Node, Node> previousNode;
+  // Find a shortest path from input port to output port by BFS.
+  std::queue<Node> que;
+  que.push(start);
+  while (!que.empty()) {
+    auto current = que.front();
+    que.pop();
+    if (current == end)
+      break;
+    for (auto child :
+         llvm::make_range(GT::child_begin(current), GT::child_end(current))) {
+      // If a child is marked before, skip it.
+      if (previousNode.count(child))
+        continue;
+      // Record a previous node.
+      previousNode.insert({child, current});
+      que.push(child);
+    }
+  }
+
+  SmallVector<Node> path;
+  Node current = end;
+  // Reconstruct a path backwardly.
+  while (current.value) {
+    path.push_back(current);
+    current = previousNode[current];
+  }
+  std::reverse(path.begin(), path.end());
+
+  diag.attachNote(instance.getLoc())
+      << "Instance " << instancePath << ": "
+      << instance.getPortName(inputPort).str() << " ---> "
+      << instance.getPortName(outputPort).str();
+  dumpPath(path, instancePath, module, /*isCycle=*/false, diag);
+  instancePath.resize(instancePathSize);
+}
+
+void dumpSimpleCycle(SCCIterator &scc, FModuleOp module,
+                     mlir::InFlightDiagnostic &diag) {
+  // Sample a cycle to print.
+  SmallVector<Node> cycle = sampleCycle(scc);
+  SmallString<16> instancePath;
+  instancePath += module.getName();
+  dumpPath(cycle, instancePath, module, /*isCycle=*/true, diag);
 }
 
 /// This pass constructs a local graph for each module to detect combinational

--- a/test/Dialect/FIRRTL/check-comb-cycles-short.mlir
+++ b/test/Dialect/FIRRTL/check-comb-cycles-short.mlir
@@ -55,8 +55,19 @@ module  {
   // Combination loop through an instance
   // CHECK-NOT: firrtl.circuit "hasloops"
   firrtl.circuit "hasloops"   {
-    firrtl.module @thru(in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
+    // expected-note @+2 {{hasloops.inner2.inner1.in}}
+    // expected-note @+1 {{hasloops.inner2.inner1.out}}
+    firrtl.module @thru1(in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
       firrtl.connect %out, %in : !firrtl.uint<1>, !firrtl.uint<1>
+    }
+
+    // expected-note @+2 {{hasloops.inner2.in}}
+    // expected-note @+1 {{hasloops.inner2.out}}
+    firrtl.module @thru2(in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
+      // expected-note @+1 {{Instance hasloops.inner2.inner1: in ---> out}}
+      %inner_in, %inner_out = firrtl.instance inner1 @thru1(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
+      firrtl.connect %inner_in, %in : !firrtl.uint<1>, !firrtl.uint<1>
+      firrtl.connect %out, %inner_out : !firrtl.uint<1>, !firrtl.uint<1>
     }
     // expected-error @+1 {{detected combinational cycle in a FIRRTL module}}
     firrtl.module @hasloops(in %clk: !firrtl.clock, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>, out %d: !firrtl.uint<1>) {
@@ -65,9 +76,9 @@ module  {
       // expected-note @+1 {{hasloops.z}}
       %z = firrtl.wire  : !firrtl.uint<1>
       firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
-      // expected-note @+2 {{hasloops.inner.in}}
-      // expected-note @+1 {{hasloops.inner.out}}
-      %inner_in, %inner_out = firrtl.instance inner @thru(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
+      // expected-note @+2 {{Instance hasloops.inner2: in ---> out}}
+      // expected-note @+1 {{hasloops.inner2.in}}
+      %inner_in, %inner_out = firrtl.instance inner2 @thru2(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
       firrtl.connect %inner_in, %y : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %z, %inner_out : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %y, %z : !firrtl.uint<1>, !firrtl.uint<1>


### PR DESCRIPTION
This is a follow-up onto https://github.com/llvm/circt/pull/2942

This commit tries improving an error message produced by recovering
a full cycle. Previously it didn't recurse into instance's internal so
the message is less verbose than SFC.

For example, the following IR contains a cycle through two instances 
`thru2` and `thru1`.

```scala
circuit hasloops :
 module thru2 :
   input in : UInt<1>  @[Bar.scala 33:38]
   output out : UInt<1> @[Bar.scala 33:38]
   out <= in @[Bar.scala 33:38]

 module thru1 :
   input in : UInt<1> @[Bar.scala 33:38]
   output out : UInt<1> @[Bar.scala 33:38]
   out <= in @[Bar.scala 33:38]
   inst inner of thru2 @[Bar.scala 33:38]
   inner.in <= in
   out <= inner.out

 module hasloops :
   input clk : Clock
   input a : UInt<1>
   input b : UInt<1>
   output c : UInt<1>
   output d : UInt<1>
   wire y : UInt<1> @[Bar.scala 33:38]
   wire z : UInt<1> @[Bar.scala 33:38]
   c <= b
   inst inner of thru1 @[Bar.scala 33:38]
   inner.in <= y
   z <= inner.out
   y <= z
   d <= z
```
New output:
```
foo.fir:15:9: error: detected combinational cycle in a FIRRTL module
 module hasloops :
        ^
Bar.scala:33:38: note: Instance hasloops.inner: in ---> out
Bar.scala:33:38: note: hasloops.inner.in
Bar.scala:33:38: note: Instance hasloops.inner.inner: in ---> out
Bar.scala:33:38: note: hasloops.inner.inner.in
Bar.scala:33:38: note: hasloops.inner.inner.out
Bar.scala:33:38: note: hasloops.inner.out
Bar.scala:33:38: note: hasloops._z
Bar.scala:33:38: note: hasloops._y
Bar.scala:33:38: note: hasloops.inner.in
```
Previous output:
```
foo.fir:15:9: error: detected combinational cycle in a FIRRTL module
 module hasloops :
        ^
Bar.scala:33:38: note: hasloops.inner.in
Bar.scala:33:38: note: hasloops.inner.out
Bar.scala:33:38: note: hasloops._z
Bar.scala:33:38: note: hasloops._y
Bar.scala:33:38: note: hasloops.inner.in
```
SFC output:
```
hasloops.y
hasloops.inner.in
hasloops.inner.inner.in
hasloops.inner.inner.out         @[Bar.scala 33:38]
hasloops.inner.out
hasloops.z
hasloops.y
```