### PR TITLE
[ExportVerilog] Make `isExpressionUnableToInline` more liberal

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -2168,20 +2168,6 @@ SubExprInfo ExprEmitter::visitUnhandledExpr(Operation *op) {
 // NameCollector
 //===----------------------------------------------------------------------===//
 
-/// Checks whether the use block is nested in the definition block through a
-/// chain of ops that do not block the inlining of a definition.
-static bool allowsInlineUses(Block *def, Block *use) {
-  if (def == use)
-    return true;
-
-  // Presently, only `else if` chains allow inlining.
-  auto op = dyn_cast<IfOp>(use->getParentOp());
-  if (op && op.hasElse() && op.getElseBlock() == use && findNestedElseIf(use))
-    return allowsInlineUses(def, op->getBlock());
-
-  return false;
-}
-
 /// Return true if we are unable to ever inline the specified operation.  This
 /// happens because not all Verilog expressions are composable, notably you
 /// can only use bit selects like x[4:6] on simple expressions, you cannot use
@@ -2203,23 +2189,9 @@ static bool isExpressionUnableToInline(Operation *op) {
     if (verbatim.string().size() > 32)
       return true;
 
-  auto *opBlock = op->getBlock();
-
-  // If the parent op is not a module op, it is defined locally.
-  bool isLocalDefinition = !isa_and_nonnull<HWModuleOp>(op->getParentOp());
-
-  bool isDuplicatable = isDuplicatableExpression(op);
-
   // Scan the users of the operation to see if any of them need this to be
   // emitted out-of-line.
   for (auto user : op->getUsers()) {
-    // If the op is defined locally and the user is in a different block, then
-    // we emit this as an out-of-line declaration into its block and the user
-    // can refer to it unless the operation is duplicatable.
-    if (isLocalDefinition && !isDuplicatable &&
-        !allowsInlineUses(opBlock, user->getBlock()))
-      return true;
-
     // Verilog bit selection is required by the standard to be:
     // "a vector, packed array, packed structure, parameter or concatenation".
     //

--- a/test/Conversion/ExportVerilog/disallow-local-vars.mlir
+++ b/test/Conversion/ExportVerilog/disallow-local-vars.mlir
@@ -189,10 +189,16 @@ hw.module @DefinedInDifferentBlock(%a: i1, %b: i1) {
   hw.output
 }
 
+// CHECK-LABEL: module TemporaryWireAtDifferentBlock(
+// DISALLOW-LABEL: module TemporaryWireAtDifferentBlock(
 hw.module @TemporaryWireAtDifferentBlock(%a: i1) -> (b: i1) {
-  // CHECK: wire _GEN;
-  // DISALLOW: wire _GEN;
-
+  // Check that %0 and %1 are not inlined.
+  // CHECK:      wire [[GEN1:.+]];
+  // CHECK:      wire [[GEN2:.+]] = [[GEN1]] + [[GEN1]];
+  // CHECK:      if ([[GEN1]])
+  // DISALLOW:   wire [[GEN1:.+]];
+  // DISALLOW:   wire [[GEN2:.+]] = [[GEN1]] + [[GEN1]];
+  // DISALLOW:   if ([[GEN1]])
   %1 = comb.add %0, %0 : i1
   sv.initial {
     sv.if %0 {

--- a/test/Conversion/ExportVerilog/disallow-local-vars.mlir
+++ b/test/Conversion/ExportVerilog/disallow-local-vars.mlir
@@ -172,6 +172,11 @@ hw.module @ReadInoutAggregate(%clock: i1) {
 // CHECK-NEXT: initial begin
 // CHECK-NEXT:   if (a == b)
 // CHECK-NEXT:     $error("error")
+// DISALLOW: `ifdef DEF
+// DISALLOW-NEXT: initial begin
+// DISALLOW-NEXT:   if (a == b)
+// DISALLOW-NEXT:     $error("error")
+
 hw.module @DefinedInDifferentBlock(%a: i1, %b: i1) {
   sv.ifdef "DEF" {
     %0 = comb.icmp eq %a, %b : i1
@@ -181,5 +186,46 @@ hw.module @DefinedInDifferentBlock(%a: i1, %b: i1) {
       }
     }
   }
+  hw.output
+}
+
+hw.module @TemporaryWireAtDifferentBlock(%a: i1) -> (b: i1) {
+  // CHECK: wire _GEN;
+  // DISALLOW: wire _GEN;
+
+  %1 = comb.add %0, %0 : i1
+  sv.initial {
+    sv.if %0 {
+      sv.error "error"
+    }
+  }
+  %0 = comb.shl %a, %a : i1
+  %2 = comb.add %1, %1 : i1
+  hw.output %2 : i1
+}
+
+// CHECK-LABEL: module AggregateInline(
+// DISALLOW-LABEL: module AggregateInline(
+hw.module @AggregateInline(%clock: i1) {
+  %c0_i16 = hw.constant 0 : i16
+  %false = hw.constant false
+  // CHECK: wire [15:0]{{ *}}[[GEN:.+]];
+  // DISALLOW: wire [15:0]{{ *}}[[GEN:.+]];
+
+  %register = sv.reg  : !hw.inout<struct<a: i32>>
+  sv.always posedge %clock  {
+    // %4 can not be inlined because %3 uses %2.
+    %4 = comb.concat %c0_i16, %3 : i16, i16
+    // DISALLOW: register.a <= {16'h0, [[GEN]]};
+    // CHECK: register.a <= {16'h0, [[GEN]]};
+    sv.passign %1, %4 : i32
+  }
+  %1 = sv.struct_field_inout %register["a"] : !hw.inout<struct<a: i32>>
+  %2 = sv.read_inout %1 : !hw.inout<i32>
+  %3 = comb.extract %2 from 0 : (i32) -> i16
+  // DISALLOW: wire [31:0] [[GEN_2:.+]] = register.a;
+  // DISALLOW-NEXT: assign [[GEN]] = [[GEN_2]]
+  // CHECK: wire [31:0] [[GEN_2:.+]] = register.a;
+  // CHECK-NEXT: assign [[GEN]] = [[GEN_2]]
   hw.output
 }

--- a/test/Conversion/ExportVerilog/disallow-local-vars.mlir
+++ b/test/Conversion/ExportVerilog/disallow-local-vars.mlir
@@ -166,3 +166,20 @@ hw.module @ReadInoutAggregate(%clock: i1) {
   // DISALLOW-NEXT:  register[1'h0].a <= {16'h0, [[READ]][15:0]};
   hw.output
 }
+
+// CHECK-LABEL: DefinedInDifferentBlock
+// CHECK: `ifdef DEF
+// CHECK-NEXT: initial begin
+// CHECK-NEXT:   if (a == b)
+// CHECK-NEXT:     $error("error")
+hw.module @DefinedInDifferentBlock(%a: i1, %b: i1) {
+  sv.ifdef "DEF" {
+    %0 = comb.icmp eq %a, %b : i1
+    sv.initial {
+      sv.if %0 {
+        sv.error "error"
+      }
+    }
+  }
+  hw.output
+}

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1330,13 +1330,12 @@ hw.module @DoNotChainElseIf(%clock: i1, %flag1 : i1, %flag2: i1) {
 }
 
 // CHECK-LABEL: NestedElseIfHoist
-// CHECK: automatic logic        [[FLAG:.*]] = flag2 & flag4;
-// CHECK: automatic logic [31:0] [[ARG:.*]] = arg0 | arg1 | arg2;
+// CHECK: automatic logic [[FLAG:.*]] = flag2 & flag4;
 // CHECK: if (flag1)
 // CHECK: else if ([[FLAG]])
 // CHECK: else if (flag3 & [[FLAG]])
 // CHECK: else
-// CHECK: [[ARG]]
+// CHECK: arg0 | arg1 | arg2
 hw.module @NestedElseIfHoist(%clock: i1, %flag1 : i1, %flag2: i1, %flag3: i1, %flag4 : i1, %arg0: i32, %arg1: i32, %arg2: i32) {
   %fd = hw.constant 0x80000002 : i32
 


### PR DESCRIPTION
This commit removes conditions of `isExpressionUnableToInline` regarding
users in different blocks. As discussed in https://github.com/llvm/circt/issues/2962, it should be safe to 
remove the restriction today. 