### PR TITLE
[FIRRTL] Do not dedup testharness memory irrespective of Prefix

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -69,7 +69,7 @@ void CreateSiFiveMetadataPass::renameMemory(CircuitOp circuitOp) {
   for (auto mod : circuitOp.getOps<FModuleOp>()) {
     bool isTestHarness = !dutModuleSet.contains(mod);
     for (auto memOp : mod.getBody()->getOps<MemOp>()) {
-      if (isTestHarness && !memOp.groupID().hasValue())
+      if (isTestHarness)
         memOp.groupIDAttr(
             IntegerAttr::get(IntegerType::get(ctxt, 32), --baseGroupID));
 

--- a/test/firtool/memoryMetadata.fir
+++ b/test/firtool/memoryMetadata.fir
@@ -1,5 +1,6 @@
 ; RUN: firtool %s -dedup=false --format=fir  --annotation-file %s.anno.json --repl-seq-mem --repl-seq-mem-file="metadata/dutModule.conf" --verilog |  FileCheck %s
 
+; CHECK-LABEL: external module tbMemoryKind1_ext_0
 
 ; CHECK-LABEL: external module tbMemoryKind1_ext
 
@@ -94,7 +95,7 @@ circuit test:
     tbMemoryKind1.w.data <= wData
 
 ; CHECK=LABEL: module hier1
-; CHECK:  tbMemoryKind1_ext tbMemoryKind1
+; CHECK:  tbMemoryKind1_ext_0 tbMemoryKind1
 
 
   module hier2: 
@@ -175,10 +176,12 @@ circuit test:
 ; CHECK: dutModule2 [[m:.+]] (
 
 ; CHECK-LABEL:      FILE "metadata/tb_seq_mems.json"
-; CHECK: [{"module_name":"tbMemoryKind1_ext","depth":16,"width":8,
-; CHECK:          "masked":false,"read":true,"write":true,"readwrite":false
-; CHECK:          "extra_ports":[],"hierarchy":
-; CHECK:          ["test.h2.m.tbMemoryKind1","test.h1.tbMemoryKind1"]}
+; CHECK: [{"module_name":"tbMemoryKind1_ext_0","depth":16,"width":8,
+; CHECK-SAME: "masked":false,"read":true,"write":true,"readwrite":false,
+; CHECK-SAME: "extra_ports":[],"hierarchy":["test.h1.tbMemoryKind1"]},
+; CHECK-SAME: {"module_name":"tbMemoryKind1_ext","depth":16,"width":8,"masked":false,
+; CHECK-SAME: "read":true,"write":true,"readwrite":false,"extra_ports":[],
+; CHECK-SAME: "hierarchy":["test.h2.m.tbMemoryKind1"]}]
 
 ; CHECK-LABEL:       FILE "metadata/seq_mems.json"
 ; CHECK:  [{"module_name":"dutMemory_ext","depth":32,"width":8,"masked":false,"read":true,
@@ -187,4 +190,5 @@ circuit test:
 
 ; CHECK-LABEL: FILE "metadata/dutModule.conf"
 ; CHECK: name dutMemory_ext depth 32 width 8 ports write,read
+; CHECK: name tbMemoryKind1_ext_0 depth 16 width 8 ports write,read
 ; CHECK: name tbMemoryKind1_ext depth 16 width 8 ports write,read

--- a/test/firtool/prefixMemory.fir
+++ b/test/firtool/prefixMemory.fir
@@ -114,9 +114,9 @@ circuit Foo : %[[
     readData <= _readData_T
 
 ; CHECK-LABEL:  firrtl.module private @prefix1_Bar
-; CHECK:        = firrtl.mem Undefined  {depth = 8 : i64, groupID = 2 : i32, modName = "prefix1_mem_ext", name = "prefix1_mem", portNames = ["MPORT", "readData_MPORT"], readLatency = 1 : i32, writeLatency = 1 : i32}
+; CHECK:        = firrtl.mem Undefined  {depth = 8 : i64, groupID = -2 : i32, modName = "prefix1_mem_ext", name = "prefix1_mem", portNames = ["MPORT", "readData_MPORT"], readLatency = 1 : i32, writeLatency = 1 : i32}
 ; CHECK-LABEL:  firrtl.module private @prefix2_Baz
-; CHECK:        = firrtl.mem Undefined  {depth = 8 : i64, groupID = 3 : i32, modName = "prefix2_mem_ext", name = "prefix2_mem", portNames = ["MPORT", "readData_MPORT"], readLatency = 1 : i32, writeLatency = 1 : i32}
+; CHECK:        = firrtl.mem Undefined  {depth = 8 : i64, groupID = -3 : i32, modName = "prefix2_mem_ext", name = "prefix2_mem", portNames = ["MPORT", "readData_MPORT"], readLatency = 1 : i32, writeLatency = 1 : i32}
 
-; HW-LABEL:  hw.module @prefix1_mem_ext(%R0_addr: i3, %R0_en: i1, %R0_clk: i1, %W0_addr: i3, %W0_en: i1, %W0_clk: i1, %W0_data: i1) -> (R0_data: i1)
 ; HW-LABEL:  hw.module @prefix2_mem_ext(%R0_addr: i3, %R0_en: i1, %R0_clk: i1, %W0_addr: i3, %W0_en: i1, %W0_clk: i1, %W0_data: i1) -> (R0_data: i1)
+; HW-LABEL:  hw.module @prefix1_mem_ext(%R0_addr: i3, %R0_en: i1, %R0_clk: i1, %W0_addr: i3, %W0_en: i1, %W0_clk: i1, %W0_data: i1) -> (R0_data: i1)


### PR DESCRIPTION
This change ensures the testharness memories are not deduped, irrespective of the `GroupID` assigned to them.
It ignores the `GroupID` assigned to a testharness memory by `PrefixModules` pass, which is currently the only pass that assigns the `GroupID`.