### PR TITLE
[StandardToHandshake] enable reuse by exposing region lowering

### DIFF
--- a/include/circt/Conversion/StandardToHandshake.h
+++ b/include/circt/Conversion/StandardToHandshake.h
@@ -14,6 +14,9 @@
 #ifndef CIRCT_CONVERSION_STANDARDTOHANDSHAKE_H_
 #define CIRCT_CONVERSION_STANDARDTOHANDSHAKE_H_
 
+#include "circt/Dialect/Handshake/HandshakeOps.h"
+#include "circt/Dialect/Handshake/HandshakePasses.h"
+#include "mlir/Transforms/DialectConversion.h"
 #include <memory>
 
 namespace mlir {
@@ -25,7 +28,180 @@ class OperationPass;
 namespace circt {
 
 namespace handshake {
-class FuncOp;
+
+// ============================================================================
+// Partial lowering infrastructure
+// ============================================================================
+
+using RegionLoweringFunc =
+    llvm::function_ref<LogicalResult(Region &, ConversionPatternRewriter &)>;
+// Convenience function for executing a PartialLowerRegion with a provided
+// partial lowering function.
+LogicalResult partiallyLowerRegion(const RegionLoweringFunc &loweringFunc,
+                                   MLIRContext *ctx, Region &r);
+
+// Holds the shared state of the different transformations required to transform
+// Standard to Handshake operations. The transformations are expressed as member
+// functions to simplify access to the state.
+//
+// This class' member functions expect a rewriter that matched on the parent
+// operation of the encapsulated region.
+class HandshakeLowering {
+public:
+  using BlockValues = DenseMap<Block *, std::vector<Value>>;
+  using BlockOps = DenseMap<Block *, std::vector<Operation *>>;
+  using blockArgPairs = DenseMap<Value, Operation *>;
+  using MemRefToMemoryAccessOp =
+      llvm::MapVector<Value, std::vector<Operation *>>;
+
+  explicit HandshakeLowering(Region &r) : r(r) {}
+  LogicalResult addMergeOps(ConversionPatternRewriter &rewriter);
+  LogicalResult addBranchOps(ConversionPatternRewriter &rewriter);
+  LogicalResult replaceCallOps(ConversionPatternRewriter &rewriter);
+
+  template <typename TTerm>
+  LogicalResult setControlOnlyPath(ConversionPatternRewriter &rewriter) {
+    // Creates start and end points of the control-only path
+
+    // Temporary start node (removed in later steps) in entry block
+    Block *entryBlock = &r.front();
+    rewriter.setInsertionPointToStart(entryBlock);
+    Operation *startOp = rewriter.create<StartOp>(entryBlock->front().getLoc());
+    setBlockEntryControl(entryBlock, startOp->getResult(0));
+
+    // Replace original return ops with new returns with additional control
+    // input
+    for (auto retOp : llvm::make_early_inc_range(r.getOps<TTerm>())) {
+      rewriter.setInsertionPoint(retOp);
+      SmallVector<Value, 8> operands(retOp->getOperands());
+      operands.push_back(startOp->getResult(0));
+      rewriter.replaceOpWithNewOp<handshake::ReturnOp>(retOp, operands);
+    }
+    return success();
+  }
+  LogicalResult connectConstantsToControl(ConversionPatternRewriter &rewriter,
+                                          bool sourceConstants);
+
+  LogicalResult loopNetworkRewriting(ConversionPatternRewriter &rewriter);
+
+  BlockOps insertMergeOps(BlockValues blockLiveIns, blockArgPairs &mergePairs,
+                          ConversionPatternRewriter &rewriter);
+
+  // Insert appropriate type of Merge CMerge for control-only path,
+  // Merge for single-successor blocks, Mux otherwise
+  Operation *insertMerge(Block *block, Value val,
+                         ConversionPatternRewriter &rewriter);
+
+  // Replaces standard memory ops with their handshake version (i.e.,
+  // ops which connect to memory/LSQ). Returns a map with an ordered
+  // list of new ops corresponding to each memref. Later, we instantiate
+  // a memory node for each memref and connect it to its load/store ops
+  LogicalResult replaceMemoryOps(ConversionPatternRewriter &rewriter,
+                                 MemRefToMemoryAccessOp &memRefOps);
+
+  LogicalResult connectToMemory(ConversionPatternRewriter &rewriter,
+                                MemRefToMemoryAccessOp memRefOps, bool lsq);
+  void setMemOpControlInputs(ConversionPatternRewriter &rewriter,
+                             ArrayRef<Operation *> memOps, Operation *memOp,
+                             int offset, ArrayRef<int> cntrlInd);
+
+  LogicalResult finalize(ConversionPatternRewriter &rewriter);
+
+  // Returns the entry control value for operations contained within this
+  // block.
+  Value getBlockEntryControl(Block *block) const;
+
+  void setBlockEntryControl(Block *block, Value v);
+
+  Region &getRegion() { return r; }
+  MLIRContext *getContext() { return r.getContext(); }
+
+protected:
+  Region &r;
+
+private:
+  DenseMap<Block *, Value> blockEntryControlMap;
+};
+
+// Driver for the HandshakeLowering class.
+// Note: using two different vararg template names due to potantial references
+// that would cause a type mismatch
+template <typename T, typename... TArgs, typename... TArgs2>
+LogicalResult runPartialLowering(
+    T &instance,
+    LogicalResult (T::*memberFunc)(ConversionPatternRewriter &, TArgs2...),
+    TArgs &...args) {
+  return partiallyLowerRegion(
+      [&](Region &, ConversionPatternRewriter &rewriter) -> LogicalResult {
+        return (instance.*memberFunc)(rewriter, args...);
+      },
+      instance.getContext(), instance.getRegion());
+}
+
+// Helper to check the validity of the dataflow conversion
+LogicalResult checkDataflowConversion(Region &r, bool disableTaskPipelining);
+
+// Driver that applies the partial lowerings expressed in HandshakeLowering to
+// the region encapsulated in it. The region is assumed to have a terminator of
+// type TTerm. See HandshakeLowering for the different lowering steps.
+template <typename TTerm>
+LogicalResult lowerRegion(HandshakeLowering &hl, bool sourceConstants,
+                          bool disableTaskPipelining) {
+  //  Perform initial dataflow conversion. This process allows for the use of
+  //  non-deterministic merge-like operations.
+  HandshakeLowering::MemRefToMemoryAccessOp memOps;
+
+  if (failed(
+          runPartialLowering(hl, &HandshakeLowering::replaceMemoryOps, memOps)))
+    return failure();
+  if (failed(runPartialLowering(hl,
+                                &HandshakeLowering::setControlOnlyPath<TTerm>)))
+    return failure();
+  if (failed(runPartialLowering(hl, &HandshakeLowering::addMergeOps)))
+    return failure();
+  if (failed(runPartialLowering(hl, &HandshakeLowering::replaceCallOps)))
+    return failure();
+  if (failed(runPartialLowering(hl, &HandshakeLowering::addBranchOps)))
+    return failure();
+
+  // The following passes modifies the dataflow graph to being safe for task
+  // pipelining. In doing so, non-deterministic merge structures are replaced
+  // for deterministic structures.
+  if (!disableTaskPipelining) {
+    if (failed(
+            runPartialLowering(hl, &HandshakeLowering::loopNetworkRewriting)))
+      return failure();
+  }
+
+  // Fork/sink materialization. @todo: this should be removed and
+  // materialization should be run as a separate pass afterward initial dataflow
+  // conversion! However, connectToMemory has some hard-coded assumptions on the
+  // existence of fork/sink operations...
+  if (failed(partiallyLowerRegion(addSinkOps, hl.getContext(), hl.getRegion())))
+    return failure();
+
+  if (failed(runPartialLowering(
+          hl, &HandshakeLowering::connectConstantsToControl, sourceConstants)))
+    return failure();
+
+  if (failed(partiallyLowerRegion(addForkOps, hl.getContext(), hl.getRegion())))
+    return failure();
+  if (failed(checkDataflowConversion(hl.getRegion(), disableTaskPipelining)))
+    return failure();
+
+  bool lsq = false;
+  if (failed(runPartialLowering(hl, &HandshakeLowering::connectToMemory, memOps,
+                                lsq)))
+    return failure();
+
+  // Add  control argument to entry block, replace references to the
+  // temporary handshake::StartOp operation, and finally remove the start
+  // op.
+  if (failed(runPartialLowering(hl, &HandshakeLowering::finalize)))
+    return failure();
+  return success();
+}
+
 } // namespace handshake
 
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
@@ -40,7 +216,6 @@ createHandshakeCanonicalizePass();
 std::unique_ptr<mlir::OperationPass<handshake::FuncOp>>
 createHandshakeRemoveBlockPass();
 
-
 } // namespace circt
 
-#endif // MLIR_CONVERSION_STANDARDTOHANDSHAKE_H_
+#endif // CIRCT_CONVERSION_STANDARDTOHANDSHAKE_H_

--- a/include/circt/Dialect/Handshake/HandshakePasses.h
+++ b/include/circt/Dialect/Handshake/HandshakePasses.h
@@ -48,10 +48,10 @@ LogicalResult resolveInstanceGraph(ModuleOp moduleOp,
 LogicalResult verifyAllValuesHasOneUse(handshake::FuncOp op);
 
 // Adds sink operations to any unused value in f.
-LogicalResult addSinkOps(handshake::FuncOp f, OpBuilder &rewriter);
+LogicalResult addSinkOps(Region &r, OpBuilder &rewriter);
 
 // Adds fork operations to any value with multiple uses in f.
-LogicalResult addForkOps(handshake::FuncOp f, OpBuilder &rewriter);
+LogicalResult addForkOps(Region &r, OpBuilder &rewriter);
 void insertFork(Value result, bool isLazy, OpBuilder &rewriter);
 
 /// Generate the code for registering passes.


### PR DESCRIPTION
This change makes the lowering infrastructure used to lower `func::FuncOp` bodies available for other usages. As discussed in #2951 the lowering of the region is not dependent on the operation holding it. 

The newly added `lowerRegion` function expects a sub-type of `HandshakeLowering` which might have overridden member functions. The members are declared `virtual` to allow for such overriding without re-implementing the `lowerRegion` function. 

**Limitation**: Using this in a rewrite that changes the types of the entry block's `BlockArgument`s might cause problems due to `lowerRegion` not having access to the changed `Value`s and types. 

I'm sorry that this PR got this large, but there was a lot to restructure for this "simple" change.

Fixes #2951 