### PR TITLE
[StandardToHandshake] Fix function type for external FuncOps

### DIFF
--- a/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
+++ b/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
@@ -1848,15 +1848,13 @@ static LogicalResult lowerFuncOp(func::FuncOp funcOp, MLIRContext *ctx,
 
   // Get function arguments
   llvm::SmallVector<mlir::Type, 8> argTypes;
-  for (auto &arg : funcOp.getArguments()) {
-    mlir::Type type = arg.getType();
-    argTypes.push_back(type);
-  }
+  for (auto &argType : funcOp.getArgumentTypes())
+    argTypes.push_back(argType);
 
   // Get function results
   llvm::SmallVector<mlir::Type, 8> resTypes;
-  for (auto arg : funcOp.getResultTypes())
-    resTypes.push_back(arg);
+  for (auto resType : funcOp.getResultTypes())
+    resTypes.push_back(resType);
 
   handshake::FuncOp newFuncOp;
 

--- a/test/Conversion/StandardToHandshake/test-simple-ops.mlir
+++ b/test/Conversion/StandardToHandshake/test-simple-ops.mlir
@@ -17,7 +17,7 @@ func @main(%c : i1, %a : i32, %b : i32) -> i32 {
 
 // Test function without body (external function).
 
-// CHECK-LABEL: handshake.func private @foo(none, ...) -> (i32, none)
+// CHECK-LABEL: handshake.func private @foo(i32, i32, none, ...) -> (i32, none)
 module {
   func private @foo(%a:i32, %b: i32) -> i32
 }


### PR DESCRIPTION
Missed in #2984. 
Previously, we relied on [funcOp.getArguments()](https://github.com/llvm/circt/blob/main/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp#L1851), which retrieves arguments from within the entry block, where `funcOp.getArgumentTypes()` would instead be the proper call.

Enables #2986.