### PR TITLE
[FIRRTL] Add InjectDUTHierarchy Pass

### DIFF
--- a/docs/FIRRTLAnnotations.md
+++ b/docs/FIRRTLAnnotations.md
@@ -445,6 +445,30 @@ Example:
 }
 ```
 
+### InjectDUTHierarchyAnnotation
+
+| Property | Type   | Description                                             |
+|----------|--------|---------------------------------------------------------|
+| class    | string | `sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation` |
+| name     | string | The name of the module containing original DUT logic    |
+
+This annotation can be used to add an extra level of hierarchy in the design
+under the DUT (indicated with a `MarkDUTAnnotation`).  All logic in the original
+DUT will be moved into a module with the specified `name`.  This is typically
+used in combination with `ExtractBlackBoxAnnotation` (or with passes that add
+these annotations to extract components like clock gates or memories) to not
+intermix the original DUT contents with extracted module instantiations.
+
+This annotation should only appear zero or once.
+
+Example:
+``` json
+{
+  "class": "sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation",
+  "name": "Logic"
+}
+```
+
 ### [InlineAnnotation](https://www.chisel-lang.org/api/firrtl/latest/firrtl/passes/InlineAnnotation.html)
 
 | Property   | Type   | Description                      |

--- a/include/circt/Dialect/FIRRTL/AnnotationDetails.h
+++ b/include/circt/Dialect/FIRRTL/AnnotationDetails.h
@@ -53,6 +53,8 @@ constexpr const char *dutAnnoClass =
     "sifive.enterprise.firrtl.MarkDUTAnnotation";
 constexpr const char *testbenchDirAnnoClass =
     "sifive.enterprise.firrtl.TestBenchDirAnnotation";
+constexpr const char *injectDUTHierarchyAnnoClass =
+    "sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation";
 
 } // namespace firrtl
 } // namespace circt

--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -91,6 +91,9 @@ std::unique_ptr<mlir::Pass> createRemoveInvalidPass();
 
 std::unique_ptr<mlir::Pass>
 createMergeConnectionsPass(bool enableAggressiveMerging = false);
+
+std::unique_ptr<mlir::Pass> createInjectDUTHierarchyPass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/FIRRTL/Passes.h.inc"

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -418,4 +418,17 @@ def InferReadWrite : Pass<"firrtl-infer-rw", "firrtl::FModuleOp"> {
   let constructor = "circt::firrtl::createInferReadWritePass()";
 }
 
+def InjectDUTHierarchy : Pass<"firrtl-inject-dut-hier", "firrtl::CircuitOp"> {
+  let summary = "Add a level of hierarchy outside the DUT";
+  let description = [{
+    This pass takes the DUT (as indicated by the presence of a
+    MarkDUTAnnotation) and moves all the contents of it into a new module
+    insided the DUT named by an InjectDUTHierarchyAnnotation.  This pass is
+    intended to be used in conjunction with passes that pull things out of the
+    DUT, e.g., SRAM extraction, to give the extracted modules a new home that is
+    still inside the original DUT.
+  }];
+  let constructor = "circt::firrtl::createInjectDUTHierarchyPass()";
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_PASSES_TD

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -14,6 +14,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   InferResets.cpp
   InferReadWrite.cpp
   InferWidths.cpp
+  InjectDUTHierarchy.cpp
   LowerAnnotations.cpp
   LowerCHIRRTL.cpp
   LowerTypes.cpp

--- a/lib/Dialect/FIRRTL/Transforms/InjectDUTHierarchy.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InjectDUTHierarchy.cpp
@@ -1,0 +1,230 @@
+//===- InjectDUTHierarchy.cpp - Add hierarchy above the DUT ---------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Implementation of the SiFive transform InjectDUTHierarchy.  This moves all
+// the logic inside the DUT into a new module named using an annotation.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+
+#include "circt/Dialect/FIRRTL/AnnotationDetails.h"
+#include "circt/Dialect/FIRRTL/NLATable.h"
+#include "circt/Dialect/FIRRTL/Namespace.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "circt/Dialect/HW/HWAttributes.h"
+
+using namespace circt;
+using namespace firrtl;
+
+namespace {
+struct InjectDUTHierarchy : public InjectDUTHierarchyBase<InjectDUTHierarchy> {
+
+  /// The design-under-test (DUT).  This is kept up-to-date by the pass as the
+  /// DUT changes due to internal logic.
+  FModuleOp dut;
+
+  /// The wrapper module that is created inside the DUT to house all its logic.
+  FModuleOp wrapper;
+
+  /// The name of the new module to create under the DUT.
+  StringAttr wrapperName;
+
+  /// Mutable indicator that an error occurred for some reason.  If this is ever
+  /// true, then the pass can just signalPassFailure.
+  bool error = false;
+
+  void runOnOperation() override;
+};
+} // namespace
+
+void InjectDUTHierarchy::runOnOperation() {
+
+  CircuitOp circuit = getOperation();
+
+  AnnotationSet::removeAnnotations(circuit, [&](Annotation anno) {
+    if (!anno.isClass(injectDUTHierarchyAnnoClass))
+      return false;
+
+    auto name = anno.getMember<StringAttr>("name");
+    if (!name) {
+      emitError(circuit->getLoc())
+          << "contained a malformed "
+             "'sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation' "
+             "annotation that did not contain a 'name' field";
+      error = true;
+      return false;
+    }
+
+    if (wrapperName) {
+      emitError(circuit->getLoc())
+          << "contained multiple "
+             "'sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation' "
+             "annotations when at most one is allowed";
+      error = true;
+      return false;
+    }
+
+    wrapperName = name;
+    return true;
+  });
+
+  // TODO: Combine this logic with GrandCentral and other places that need to
+  // find the DUT.  Consider changing the MarkDUTAnnotation scattering to put
+  // this information on the Circuit so that we don't have to dig through all
+  // the modules to find the DUT.
+  for (auto mod : circuit.getOps<FModuleOp>()) {
+    if (!AnnotationSet(mod).hasAnnotation(dutAnnoClass))
+      continue;
+    if (dut) {
+      auto diag = emitError(mod.getLoc())
+                  << "is marked with a '" << dutAnnoClass << "', but '"
+                  << dut.moduleName()
+                  << "' also had such an annotation (this should "
+                     "be impossible!)";
+      diag.attachNote(dut.getLoc()) << "the first DUT was found here";
+      error = true;
+      break;
+    }
+    dut = mod;
+  }
+
+  // If a hierarchy annotation was provided, ensure that a DUT annotation also
+  // exists.  The pass could silently ignore this case and do nothing, but it is
+  // better to provide an error.
+  if (wrapperName && !dut) {
+    emitError(circuit->getLoc())
+        << "contained a '" << injectDUTHierarchyAnnoClass << "', but no '"
+        << dutAnnoClass << "' was provided";
+    error = true;
+  }
+
+  // The pass is in an error state due to invalid annotations.  Exit indicating
+  // failure.
+  if (error)
+    return signalPassFailure();
+
+  // The prerequisites for the pass to run were not met.  Indicate that no work
+  // was done and exit.
+  if (!dut || !wrapperName) {
+    markAllAnalysesPreserved();
+    return;
+  }
+
+  // Create a module that will become the new DUT.  The original DUT is renamed
+  // to become the wrapper.  This is done to save copying into the wrapper.
+  // While the logical movement is "copy the body of the DUT into a wrapper", it
+  // is mechanically more straigthforward to make the DUT the wrappper.  After
+  // this block finishes, the "dut" and "wrapper" variables are set correctly.
+  // This logic is intentionally put into a block to avoid confusion while the
+  // dut and wrapper do not match the logical definition.
+  OpBuilder b(circuit.getContext());
+  CircuitNamespace circuitNS(circuit);
+  {
+    b.setInsertionPointAfter(dut);
+    auto newDUT = b.create<FModuleOp>(dut.getLoc(), dut.getNameAttr(),
+                                      dut.getPorts(), dut.annotations());
+
+    SymbolTable::setSymbolVisibility(newDUT, dut.getVisibility());
+    dut->setAttr("sym_name",
+                 b.getStringAttr(circuitNS.newName(wrapperName.getValue())));
+
+    // The original DUT module is now the wrapper.  The new module we just
+    // created becomse the DUT.
+    wrapper = dut;
+    dut = newDUT;
+
+    // Finish setting up the wrapper.  It can have no annotations.
+    AnnotationSet::removePortAnnotations(wrapper,
+                                         [](auto, auto) { return true; });
+    AnnotationSet::removeAnnotations(wrapper, [](auto) { return true; });
+  }
+
+  // Instantiate the wrapper inside the DUT and wire it up.
+  b.setInsertionPointToStart(dut.getBody());
+  ModuleNamespace dutNS(dut);
+  auto wrapperInst = b.create<InstanceOp>(
+      b.getUnknownLoc(), wrapper, wrapper.moduleName(), ArrayRef<Attribute>{},
+      ArrayRef<Attribute>{}, false,
+      b.getStringAttr(dutNS.newName(wrapper.moduleName())));
+  for (auto pair : llvm::enumerate(wrapperInst.getResults())) {
+    Value lhs = dut.getArgument(pair.index());
+    Value rhs = pair.value();
+    if (dut.getPortDirection(pair.index()) == Direction::In)
+      std::swap(lhs, rhs);
+    b.create<ConnectOp>(b.getUnknownLoc(), lhs, rhs);
+  }
+
+  // Get ready to update non-local annotations (NLAs).  This requires both an
+  // NLA table and knowledge of what the DUT's port symbols are.
+  auto &nlaTable = getAnalysis<NLATable>();
+  DenseSet<Attribute> dutPortSyms;
+  for (auto port : dut.getPorts()) {
+    if (!port.sym)
+      continue;
+    dutPortSyms.insert(port.sym);
+  }
+
+  // Update NLAs invovle the DUT.  There are three cases to consider:
+  //   1. The DUT or a DUT port is a leaf ref.  Do nothing.
+  //   2. The DUT is the root.  Update the root module to be the wrapper.
+  //   3. The NLA passes through the DUT.  Remove the original InnerRef and
+  //      replace it with two InnerRefs: (1) on the DUT and (2) one the wrapper.
+  for (auto nla : llvm::make_early_inc_range(nlaTable.lookup(dut))) {
+    // The leaf ref is the DUT or a DUT port.
+    if (nla.leafMod() == dut.moduleName())
+      if (nla.isModule() || dutPortSyms.contains(nla.ref()))
+        continue;
+
+    // The DUT is the root module.
+    auto namepath = nla.namepath().getValue();
+    if (nla.root() == dut.getNameAttr()) {
+      auto tail = namepath.drop_front();
+      SmallVector<Attribute> newNamepath({hw::InnerRefAttr::get(
+          wrapper.getNameAttr(),
+          namepath.front().cast<hw::InnerRefAttr>().getName())});
+      newNamepath.append(tail.begin(), tail.end());
+      nla->setAttr("namepath", b.getArrayAttr(newNamepath));
+      continue;
+    }
+
+    // The NLA passes through the DUT.
+    size_t nlaIdx = 0;
+    for (auto attr : namepath) {
+      auto innerRef = attr.cast<hw::InnerRefAttr>();
+      if (innerRef.getModule() == dut.moduleName())
+        break;
+      nlaIdx++;
+    }
+    auto front = namepath.take_front(nlaIdx);
+    auto dutRef = namepath[nlaIdx].cast<hw::InnerRefAttr>();
+    auto back = namepath.drop_front(nlaIdx + 1);
+    SmallVector<Attribute> newNamepath(front.begin(), front.end());
+    newNamepath.push_back(hw::InnerRefAttr::get(dut.moduleNameAttr(),
+                                                wrapperInst.inner_symAttr()));
+    newNamepath.push_back(
+        hw::InnerRefAttr::get(wrapper.moduleNameAttr(), dutRef.getName()));
+    newNamepath.append(back.begin(), back.end());
+    nla->setAttr("namepath", b.getArrayAttr(newNamepath));
+
+    // Add the breadcrumb to the instance.
+    AnnotationSet annotations(wrapperInst);
+    NamedAttribute breadcrumb(b.getStringAttr("circt.nonlocal"),
+                              FlatSymbolRefAttr::get(nla.sym_nameAttr()));
+    annotations.addAnnotations(b.getDictionaryAttr({breadcrumb}));
+    annotations.applyToOperation(wrapperInst);
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Pass Creation
+//===----------------------------------------------------------------------===//
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createInjectDUTHierarchyPass() {
+  return std::make_unique<InjectDUTHierarchy>();
+}

--- a/test/Dialect/FIRRTL/inject-dut-hierarchy-errors.mlir
+++ b/test/Dialect/FIRRTL/inject-dut-hierarchy-errors.mlir
@@ -1,0 +1,28 @@
+// RUN: circt-opt -verify-diagnostics -pass-pipeline='firrtl.circuit(firrtl-inject-dut-hier)' --split-input-file %s
+
+// expected-error @+1 {{contained multiple 'sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation' annotations when at most one is allowed}}
+firrtl.circuit "MultipleHierarchyAnnotations" attributes {
+    annotations = [
+      {class = "sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation", name = "Foo"},
+      {class = "sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation", name = "Bar"}
+    ]
+  } {
+  firrtl.module private @DUT() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {}
+  firrtl.module @MultipleHierarchyAnnotations() {
+    firrtl.instance dut @DUT()
+  }
+}
+
+// -----
+
+// expected-error @+1 {{contained a 'sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation', but no 'sifive.enterprise.firrtl.MarkDUTAnnotation' was provided}}
+firrtl.circuit "HierarchyAnnotationWithoutMarkDUT" attributes {
+    annotations = [
+      {class = "sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation", name = "Foo"}
+    ]
+  } {
+  firrtl.module private @DUT() {}
+  firrtl.module @HierarchyAnnotationWithoutMarkDUT() {
+    firrtl.instance dut @DUT()
+  }
+}

--- a/test/Dialect/FIRRTL/inject-dut-hierarchy.mlir
+++ b/test/Dialect/FIRRTL/inject-dut-hierarchy.mlir
@@ -1,0 +1,81 @@
+// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-inject-dut-hier)' -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: firrtl.circuit "Top"
+firrtl.circuit "Top" attributes {
+    annotations = [{class = "sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation", name = "Foo"}]
+  } {
+  // CHECK:      firrtl.module private @Foo()
+  //
+  // CHECK:      firrtl.module private @DUT
+  // CHECK-SAME:   class = "sifive.enterprise.firrtl.MarkDUTAnnotation"
+  //
+  // CHECK-NEXT:   firrtl.instance Foo {{.+}} @Foo()
+  // CHECK-NEXT: }
+  firrtl.module private @DUT() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {}
+
+  // CHECK:      firrtl.module @Top
+  // CHECK-NEXT:   firrtl.instance dut @DUT
+  firrtl.module @Top() {
+    firrtl.instance dut @DUT()
+  }
+}
+
+// -----
+
+// CHECK-LABEL: firrtl.circuit "NLARenaming"
+firrtl.circuit "NLARenaming" attributes {
+    annotations = [{class = "sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation", name = "Foo"}]
+  } {
+  // An NLA that is rooted at the DUT moves to the wrapper.
+  //
+  // CHECK:      firrtl.nla @nla_DUTRoot [#hw.innerNameRef<@Foo::@sub>, #hw.innerNameRef<@Sub::@a>]
+  firrtl.nla @nla_DUTRoot [#hw.innerNameRef<@DUT::@sub>, #hw.innerNameRef<@Sub::@a>]
+
+  // NLAs that end at the DUT or a DUT port are unmodified.
+  //
+  // CHECK-NEXT: firrtl.nla @nla_DUTLeafModule [#hw.innerNameRef<@NLARenaming::@dut>, @DUT]
+  // CHECK-NEXT: firrtl.nla @nla_DUTLeafPort [#hw.innerNameRef<@NLARenaming::@dut>, #hw.innerNameRef<@DUT::@in>]
+  firrtl.nla @nla_DUTLeafModule [#hw.innerNameRef<@NLARenaming::@dut>, @DUT]
+  firrtl.nla @nla_DUTLeafPort [#hw.innerNameRef<@NLARenaming::@dut>, #hw.innerNameRef<@DUT::@in>]
+
+  // NLAs that end inside the DUT get an extra level of hierarchy.
+  //
+  // CHECK-NEXT: firrtl.nla @nla_DUTLeafWire [#hw.innerNameRef<@NLARenaming::@dut>, #hw.innerNameRef<@DUT::@[[inst_sym:.+]]>, #hw.innerNameRef<@Foo::@w>]
+  firrtl.nla @nla_DUTLeafWire [#hw.innerNameRef<@NLARenaming::@dut>, #hw.innerNameRef<@DUT::@w>]
+
+  // An NLA that passes through the DUT gets an extra level of hierarchy.
+  //
+  // CHECK-NEXT: firrtl.nla @nla_DUTPassthrough [#hw.innerNameRef<@NLARenaming::@dut>, #hw.innerNameRef<@DUT::@[[inst_sym:.+]]>, #hw.innerNameRef<@Foo::@sub>, @Sub]
+  firrtl.nla @nla_DUTPassthrough [#hw.innerNameRef<@NLARenaming::@dut>, #hw.innerNameRef<@DUT::@sub>, @Sub]
+  firrtl.module private @Sub() attributes {annotations = [{circt.nonlocal = @nla_DUTPassthrough, class = "nla_DUTPassthrough"}]} {
+    %a = firrtl.wire sym @a : !firrtl.uint<1>
+  }
+
+  // CHECK:     firrtl.module private @Foo
+  // CHECK:     firrtl.module private @DUT
+  // CHECK-NEXT   firrtl.instance Foo sym @[[inst_sym]]
+  firrtl.module private @DUT(
+    in %in: !firrtl.uint<1> sym @in [{circt.nonlocal = @nla_DUTLeafPort, class = "nla_DUTLeafPort"}]
+  ) attributes {
+    annotations = [
+      {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"},
+      {circt.nonlocal = @nla_DUTLeafModule, class = "nla_DUTLeafModule"}]}
+  {
+    %w = firrtl.wire sym @w {
+      annotations = [
+        {circt.nonlocal = @nla_DUTPassthrough, class = "nla_DUT_LeafWire"}]
+    } : !firrtl.uint<1>
+    firrtl.instance sub sym @sub {
+      annotations = [
+        {circt.nonlocal = @nla_DUTRoot, class = "circt.nonlocal"},
+        {circt.nonlocal = @nla_DUTPassthrough, class = "circt.nonlocal"}]} @Sub()
+  }
+  firrtl.module @NLARenaming() {
+    %dut_in = firrtl.instance dut sym @dut {
+      annotations = [
+        {circt.nonlocal = @nla_DUTLeafModule, class = "circt.nonlocal"},
+        {circt.nonlocal = @nla_DUTLeafPort, class = "circt.nonlocal"},
+        {circt.nonlocal = @nla_DUTLeafWire, class = "circt.nonlocal"},
+        {circt.nonlocal = @nla_DUTPassthrough, class = "circt.nonlocal"}]} @DUT(in in: !firrtl.uint<1>)
+  }
+}

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -193,6 +193,11 @@ static cl::opt<bool>
                 cl::init(true));
 
 static cl::opt<bool>
+    injectDUTHierarchy("inject-dut-hierarchy",
+                       cl::desc("add a level of hierarchy to the DUT"),
+                       cl::init(true));
+
+static cl::opt<bool>
     prefixModules("prefix-modules",
                   cl::desc("prefix modules with NestedPrefixAnnotation"),
                   cl::init(true));
@@ -442,6 +447,10 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
   if (!disableOptimization)
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
         createCSEPass());
+
+  if (injectDUTHierarchy)
+    pm.nest<firrtl::CircuitOp>().addPass(
+        firrtl::createInjectDUTHierarchyPass());
 
   if (lowerCHIRRTL)
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(


### PR DESCRIPTION
Add a pass that adds a level of hierarchy (indicated by an
InjectDUTHierarchyAnnotation) above the DUT (as indicated by a
MarkDUTAnnotation).

Add an option to enable the InjectDUTHierarchy pass from a command-line
option in firtool.