### PR TITLE
[FIRRTL] print mem.conf even if there are no memories

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -240,20 +240,18 @@ LogicalResult CreateSiFiveMetadataPass::emitMemoryMetadata() {
       context, metadataDir, "seq_mems.json", /*excludeFromFilelist=*/true);
   dutVerbatimOp->setAttr("output_file", fileAttr);
 
-  if (!seqMemConfStr.empty()) {
-    auto confVerbatimOp =
-        builder.create<sv::VerbatimOp>(builder.getUnknownLoc(), seqMemConfStr);
-    if (replSeqMemFile.empty()) {
-      circuitOp->emitError("metadata emission failed, the option "
-                           "`-repl-seq-mem-file=<filename>` is mandatory for "
-                           "specifying a valid seq mem metadata file");
-      return failure();
-    }
-
-    auto fileAttr = hw::OutputFileAttr::getFromFilename(
-        context, replSeqMemFile, /*excludeFromFilelist=*/true);
-    confVerbatimOp->setAttr("output_file", fileAttr);
+  auto confVerbatimOp =
+      builder.create<sv::VerbatimOp>(builder.getUnknownLoc(), seqMemConfStr);
+  if (replSeqMemFile.empty()) {
+    circuitOp->emitError("metadata emission failed, the option "
+                         "`-repl-seq-mem-file=<filename>` is mandatory for "
+                         "specifying a valid seq mem metadata file");
+    return failure();
   }
+
+  fileAttr = hw::OutputFileAttr::getFromFilename(context, replSeqMemFile,
+                                                 /*excludeFromFilelist=*/true);
+  confVerbatimOp->setAttr("output_file", fileAttr);
 
   return success();
 }

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -111,11 +111,10 @@ firrtl.circuit "BasicBlackboxes" attributes { annotations = [{
 firrtl.circuit "top"
 {
   firrtl.module @top() { }
-  // When there are no memories, we still need to emit the seq_mems.json
-  // metadata, but not the memory.conf metadata.
+  // When there are no memories, we still need to emit the memory metadata.
   // CHECK: sv.verbatim "[]" {output_file = #hw.output_file<"metadata/tb_seq_mems.json", excludeFromFileList>, symbols = []}
   // CHECK: sv.verbatim "[]" {output_file = #hw.output_file<"metadata/seq_mems.json", excludeFromFileList>, symbols = []}
-  // CHECK-NOT: {output_file = #hw.output_file<"\22metadata/dut.conf\22", excludeFromFileList>, symbols = []}
+  // CHECK: sv.verbatim "" {output_file = #hw.output_file<"\22metadata/dut.conf\22", excludeFromFileList>, symbols = []}
 }
 
 // CHECK-LABEL: firrtl.circuit "top"


### PR DESCRIPTION
Currently, when passed `--repl-seq-mem-file=mem.conf` and there are no memories, we will not emit the `mem.conf` metadata. This changes that behaviour to create an empty file, which is the same as SFC behaviour.  Some tooling expects this file to be created even if it is empty.  We made a similar change for `seq_mems.json` and previously decided we didn't need to have the same behaviour for this file.

@richardxia please confirm this is actually needed :)