### PR TITLE
[FIRRTL] Rename `LowerMemory` to `FlattenMemory`

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -45,7 +45,6 @@ std::unique_ptr<mlir::Pass> createInlinerPass();
 
 std::unique_ptr<mlir::Pass> createInferReadWritePass();
 
-std::unique_ptr<mlir::Pass> createLowerMemoryPass();
 
 std::unique_ptr<mlir::Pass> createBlackBoxMemoryPass();
 
@@ -61,6 +60,8 @@ std::unique_ptr<mlir::Pass> createDedupPass();
 std::unique_ptr<mlir::Pass> createEmitOMIRPass(StringRef outputFilename = "");
 
 std::unique_ptr<mlir::Pass> createExpandWhensPass();
+
+std::unique_ptr<mlir::Pass> createFlattenMemoryPass();
 
 std::unique_ptr<mlir::Pass> createInferWidthsPass();
 

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -134,6 +134,15 @@ def CreateSiFiveMetadata : Pass<"firrtl-emit-metadata", "firrtl::CircuitOp"> {
   let dependentDialects = ["hw::HWDialect"];
 }
 
+def FlattenMemory : Pass<"firrtl-flatten-memory", "firrtl::FModuleOp"> {
+  let summary = "Flatten aggregate memory data to a UInt";
+  let description = [{
+    This pass flattens the aggregate data of memory into a UInt, and inserts
+    appropriate bitcasts to access the data.
+  }];
+  let constructor = "circt::firrtl::createFlattenMemoryPass()";
+}
+
 def WireDFT : Pass<"firrtl-dft", "firrtl::CircuitOp"> {
   let summary = "Wires test enables to clock gates for DFT infrastructure";
   let description = [{
@@ -409,12 +418,4 @@ def InferReadWrite : Pass<"firrtl-infer-rw", "firrtl::FModuleOp"> {
   let constructor = "circt::firrtl::createInferReadWritePass()";
 }
 
-def LowerMemory : Pass<"firrtl-lower-memory", "firrtl::FModuleOp"> {
-  let summary = "Flatten aggregate memory data to a UInt";
-  let description = [{
-    This pass flattens aggregate memory data field into a UInt, and
-    inserts the appropriate logic to access the data.
-  }];
-  let constructor = "circt::firrtl::createLowerMemoryPass()";
-}
 #endif // CIRCT_DIALECT_FIRRTL_PASSES_TD

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -6,6 +6,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   Dedup.cpp
   EmitOMIR.cpp
   ExpandWhens.cpp
+  FlattenMemory.cpp
   GrandCentral.cpp
   GrandCentralTaps.cpp
   GrandCentralSignalMappings.cpp
@@ -15,7 +16,6 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   InferWidths.cpp
   LowerAnnotations.cpp
   LowerCHIRRTL.cpp
-  LowerMemory.cpp
   LowerTypes.cpp
   MergeConnections.cpp
   ModuleInliner.cpp

--- a/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
@@ -1,4 +1,4 @@
-//===- LowerMemory.cpp - Lower Memory Pass -----------------------===//
+//===- FlattenMemroy.cpp - Flatten Memory Pass ----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file defines the LowerMemory pass.
+// This file defines the FlattenMemory pass.
 //
 //===----------------------------------------------------------------------===//
 
@@ -26,7 +26,7 @@ using namespace circt;
 using namespace firrtl;
 
 namespace {
-struct LowerMemoryPass : public LowerMemoryBase<LowerMemoryPass> {
+struct FlattenMemoryPass : public FlattenMemoryBase<FlattenMemoryPass> {
   /// This pass flattens the aggregate data of memory into a UInt, and inserts
   /// appropriate bitcasts to access the data.
   void runOnOperation() override {
@@ -225,6 +225,6 @@ private:
 };
 } // end anonymous namespace
 
-std::unique_ptr<mlir::Pass> circt::firrtl::createLowerMemoryPass() {
-  return std::make_unique<LowerMemoryPass>();
+std::unique_ptr<mlir::Pass> circt::firrtl::createFlattenMemoryPass() {
+  return std::make_unique<FlattenMemoryPass>();
 }

--- a/test/Dialect/FIRRTL/flatten-memory.mlir
+++ b/test/Dialect/FIRRTL/flatten-memory.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl.module(firrtl-lower-memory))' %s | FileCheck  %s
+// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl.module(firrtl-flatten-memory))' %s | FileCheck  %s
 
 
 firrtl.circuit "Mem" {

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -468,7 +468,7 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
 
   if (replSeqMem)
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
-        firrtl::createLowerMemoryPass());
+        firrtl::createFlattenMemoryPass());
   // The input mlir file could be firrtl dialect so we might need to clean
   // things up.
   if (lowerTypes) {


### PR DESCRIPTION
The `LowerMemory` pass currently just flatten aggregate datatypes into a
single uint.  I want to separate the logic which lowers memories into
`hw.generatorModule`s out into a different pass, and I want to use the
name `LowerMemory` for that.
