### PR TITLE
[HW] Remove InstanceOp's constaint on the symbol

### DIFF
--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -10,15 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Ensure symbol is one of the hw module.* types.  Passes on failed lookup, so
-/// more basic symbol validation can provide more useful error messages.
-def isModuleSymbol : AttrConstraint<
-    CPred<"!::mlir::SymbolTable::lookupNearestSymbolFrom("
-            "&$_op, $_self.cast<::mlir::FlatSymbolRefAttr>()) || "
-          "hw::isAnyModule(::mlir::SymbolTable::lookupNearestSymbolFrom("
-            "&$_op, $_self.cast<::mlir::FlatSymbolRefAttr>()))"
-    >, "is module like">;
-
 /// Base class factoring out some of the additional class declarations common to
 /// the module-like operations.
 class HWModuleOpBase<string mnemonic, list<Trait> traits = []> :
@@ -388,7 +379,7 @@ def InstanceOp : HWOp<"instance", [
   }];
 
   let arguments = (ins StrAttr:$instanceName,
-                       Confined<FlatSymbolRefAttr, [isModuleSymbol]>:$moduleName,
+                       FlatSymbolRefAttr:$moduleName,
                        Variadic<AnyType>:$inputs,
                        StrArrayAttr:$argNames, StrArrayAttr:$resultNames,
                        ParamDeclArrayAttr:$parameters,

--- a/test/Dialect/HW/errors.mlir
+++ b/test/Dialect/HW/errors.mlir
@@ -26,7 +26,7 @@ func private @notModule () {
 }
 
 hw.module @A(%arg0: i1) {
-  // expected-error @+1 {{'hw.instance' op attribute 'moduleName' failed to satisfy constraint: flat symbol reference attribute is module like}}
+  // expected-error @+1 {{symbol reference 'notModule' isn't a module}}
   hw.instance "foo" @notModule(a: %arg0: i1) -> ()
 }
 


### PR DESCRIPTION
The `HWInstanceOp` has a redundant check that the SymbolRef it has is a
valid HW module operation. This change keeps the more efficient of the
two methods, and removes the slower one.