### PR TITLE
[HW] Added a helper method to HWModuleOp to insert new outputs

### DIFF
--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -112,6 +112,16 @@ def HWModuleOp : HWModuleOpBase<"module",
       return getModuleOutputPort(*this, i);
     }
 
+    /// Inserts a list of output ports into the port list at a specific
+    /// location, shifting all subsequent ports.  Rewrites the output op
+    /// to return the associated values.
+    void insertOutputs(unsigned index,
+                       ArrayRef<std::pair<StringAttr, Value>> outputs);
+
+    /// Appends output ports to the module with the specified names and
+    /// rewrites the output op to return the associated values.
+    void appendOutputs(ArrayRef<std::pair<StringAttr, Value>> outputs);
+
     // TODO(mlir): FunctionLike shouldn't produce a getBody() helper, it is
     // squatting on the name.
     Block *getBodyBlock() { return &body().front(); }

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1029,6 +1029,32 @@ LogicalResult HWModuleOp::verify() { return verifyModuleCommon(*this); }
 
 LogicalResult HWModuleExternOp::verify() { return verifyModuleCommon(*this); }
 
+void HWModuleOp::insertOutputs(unsigned index,
+                               ArrayRef<std::pair<StringAttr, Value>> outputs) {
+
+  auto output = cast<OutputOp>(getBodyBlock()->getTerminator());
+  assert(index <= output->getNumOperands() && "invalid output index");
+
+  // Rewrite the port list of the module.
+  SmallVector<std::pair<unsigned, PortInfo>> indexedNewPorts;
+  for (auto &[name, value] : outputs) {
+    PortInfo port;
+    port.name = name;
+    port.direction = PortDirection::OUTPUT;
+    port.type = value.getType();
+    indexedNewPorts.emplace_back(index, port);
+  }
+  insertPorts({}, indexedNewPorts);
+
+  // Rewrite the output op.
+  for (auto &[name, value] : outputs)
+    output->insertOperands(index++, value);
+}
+
+void HWModuleOp::appendOutputs(ArrayRef<std::pair<StringAttr, Value>> outputs) {
+  return insertOutputs(getResultTypes().size(), outputs);
+}
+
 void HWModuleOp::getAsmBlockArgumentNames(mlir::Region &region,
                                           mlir::OpAsmSetValueNameFn setNameFn) {
   getAsmBlockArgumentNamesImpl(region, setNameFn);

--- a/unittests/Dialect/HW/CMakeLists.txt
+++ b/unittests/Dialect/HW/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_circt_unittest(CIRCTHWTests
+  HWModuleTest.cpp
   InstanceGraphTest.cpp
 )
 

--- a/unittests/Dialect/HW/HWModuleTest.cpp
+++ b/unittests/Dialect/HW/HWModuleTest.cpp
@@ -1,0 +1,78 @@
+//===- HWModuleTest.cpp - HW Module utility tests -------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/HW/HWDialect.h"
+#include "circt/Dialect/HW/HWInstanceGraph.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "llvm/ADT/PostOrderIterator.h"
+#include "gtest/gtest.h"
+
+using namespace mlir;
+using namespace circt;
+using namespace hw;
+
+namespace {
+
+TEST(HWModuleOpTest, AddOutputs) {
+  // Create a hw.module with no ports.
+  MLIRContext context;
+  context.loadDialect<HWDialect>();
+  LocationAttr loc = UnknownLoc::get(&context);
+  auto module = ModuleOp::create(loc);
+  auto builder = ImplicitLocOpBuilder::atBlockEnd(loc, module.getBody());
+  auto top = builder.create<HWModuleOp>(StringAttr::get(&context, "Top"),
+                                        ArrayRef<PortInfo>{});
+
+  builder.setInsertionPointToStart(top.getBodyBlock());
+  auto wireTy = builder.getIntegerType(2);
+
+  // Add two ports.
+  SmallVector<std::pair<StringAttr, Value>> appendPorts;
+  auto wireA = builder.create<ConstantOp>(wireTy, 0);
+  appendPorts.emplace_back(builder.getStringAttr("a"), wireA);
+  auto wireD = builder.create<ConstantOp>(wireTy, 1);
+  appendPorts.emplace_back(builder.getStringAttr("d"), wireD);
+  top.appendOutputs(appendPorts);
+
+  SmallVector<std::pair<StringAttr, Value>> insertPorts;
+  auto wireB = builder.create<ConstantOp>(wireTy, 2);
+  insertPorts.emplace_back(builder.getStringAttr("b"), wireB);
+  auto wireC = builder.create<ConstantOp>(wireTy, 3);
+  insertPorts.emplace_back(builder.getStringAttr("c"), wireC);
+  top.insertOutputs(1, insertPorts);
+
+  auto ports = top.getAllPorts();
+  ASSERT_EQ(ports.size(), 4);
+
+  EXPECT_EQ(ports[0].name, builder.getStringAttr("a"));
+  EXPECT_EQ(ports[0].direction, PortDirection::OUTPUT);
+  EXPECT_EQ(ports[0].type, wireTy);
+
+  EXPECT_EQ(ports[1].name, builder.getStringAttr("b"));
+  EXPECT_EQ(ports[1].direction, PortDirection::OUTPUT);
+  EXPECT_EQ(ports[1].type, wireTy);
+
+  EXPECT_EQ(ports[2].name, builder.getStringAttr("c"));
+  EXPECT_EQ(ports[2].direction, PortDirection::OUTPUT);
+  EXPECT_EQ(ports[2].type, wireTy);
+
+  EXPECT_EQ(ports[3].name, builder.getStringAttr("d"));
+  EXPECT_EQ(ports[3].direction, PortDirection::OUTPUT);
+  EXPECT_EQ(ports[3].type, wireTy);
+
+  auto output = cast<OutputOp>(top.getBodyBlock()->getTerminator());
+  ASSERT_EQ(output->getNumOperands(), 4);
+
+  EXPECT_EQ(output->getOperand(0), wireA.result());
+  EXPECT_EQ(output->getOperand(1), wireB.result());
+  EXPECT_EQ(output->getOperand(2), wireC.result());
+  EXPECT_EQ(output->getOperand(3), wireD.result());
+}
+
+} // namespace


### PR DESCRIPTION
Added `HWModuleOp::addOutputs` which takes a list of port name-value pairs and inserts the outputs into the port list and the output op.