### PR TITLE
[FIRRTL][ModuleInliner] fix flatten+inline into multiple instance sites, annotation cleanup

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -434,9 +434,7 @@ private:
                                      const DenseSet<Attribute> &localSymbols,
                                      ModuleNamespace &moduleNamespace);
 
-  /// Returns true if the operation is annotated to be flattened.  This removes
-  /// the flattened annotation (hence, this should only be called once on a
-  /// module).
+  /// Returns true if the operation is annotated to be flattened.
   bool shouldFlatten(Operation *op);
 
   /// Returns true if the operation is annotated to be inlined.
@@ -655,9 +653,7 @@ void Inliner::cloneAndRename(
 }
 
 bool Inliner::shouldFlatten(Operation *op) {
-  return AnnotationSet::removeAnnotations(op, [](Annotation a) {
-    return a.isClass("firrtl.transforms.FlattenAnnotation");
-  });
+  return AnnotationSet(op).hasAnnotation("firrtl.transforms.FlattenAnnotation");
 }
 
 bool Inliner::shouldInline(Operation *op) {

--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -969,6 +969,17 @@ void Inliner::run() {
     mod.erase();
   }
 
+  // Remove leftover inline annotations, and check no flatten annotations
+  // remain as they should have been processed and removed.
+  for (auto mod : circuit.getBody()->getOps<FModuleLike>()) {
+    if (shouldInline(mod)) {
+      assert(cast<hw::HWModuleLike>(*mod).isPublic() &&
+             "non-public module with inline annotation still present");
+      AnnotationSet::removeAnnotations(mod, "firrtl.passes.InlineAnnotation");
+    }
+    assert(!shouldFlatten(mod) && "flatten annotation found on live module");
+  }
+
   LLVM_DEBUG({
     llvm::dbgs() << "NLA modifications:\n";
     for (auto nla : circuit.getBody()->getOps<NonLocalAnchor>()) {

--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -948,14 +948,14 @@ void Inliner::run() {
     auto module = worklist.pop_back_val();
     if (shouldFlatten(module)) {
       flattenInstances(module);
-      continue;
+      // Delete the flatten annotation, the transform was performed.
+      // Even if visited again in our walk (for inlining),
+      // we've just flattened it and so the annotation is no longer needed.
+      AnnotationSet::removeAnnotations(module,
+                                       "firrtl.transforms.FlattenAnnotation");
+    } else {
+      inlineInstances(module);
     }
-    inlineInstances(module);
-
-    // Delete the flatten annotations. Any module with the inline annotation
-    // will be deleted, as there won't be any remaining instances of it.
-    AnnotationSet(module).removeAnnotationsWithClass(
-        "firrtl.transforms.FlattenAnnotation");
   }
 
   // Delete all unreferenced modules.  Mark any NLAs that originate from dead

--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -513,6 +513,7 @@ bool Inliner::doesNLAMatchCurrentPath(NonLocalAnchor nla) {
 /// If this operation or any child operation has a name, add the prefix to that
 /// operation's name.  If the operation has any inner symbols, make sure that
 /// these are unique in the namespace.
+// NOLINTNEXTLINE(misc-no-recursion)
 void Inliner::rename(StringRef prefix, Operation *op,
                      ModuleNamespace &moduleNamespace) {
   // Add a prefix to things that has a "name" attribute.  We don't prefix
@@ -660,6 +661,7 @@ bool Inliner::shouldInline(Operation *op) {
   return AnnotationSet(op).hasAnnotation("firrtl.passes.InlineAnnotation");
 }
 
+// NOLINTNEXTLINE(misc-no-recursion)
 void Inliner::flattenInto(StringRef prefix, OpBuilder &b,
                           BlockAndValueMapping &mapper, FModuleOp parent,
                           DenseSet<Attribute> localSymbols,
@@ -759,6 +761,7 @@ void Inliner::flattenInstances(FModuleOp module) {
   }
 }
 
+// NOLINTNEXTLINE(misc-no-recursion)
 void Inliner::inlineInto(StringRef prefix, OpBuilder &b,
                          BlockAndValueMapping &mapper, FModuleOp parent,
                          DenseMap<Attribute, Attribute> &symbolRenames,

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -173,7 +173,6 @@ firrtl.module private @leaf() {
 // CHECK-NOT: annotation
 // This is preserved, public
 // CHECK:         firrtl.module @flatinline
-// But annotations should be removed?
 // CHECK-NOT: annotation
 // CHECK-NOT: @leaf
 

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -153,6 +153,30 @@ firrtl.module private @leaf() {
 // CHECK-NOT:   @flatinline
 // CHECK-NOT:   @leaf
 
+// Test behavior retaining public modules but not their annotations
+firrtl.circuit "TestPubAnno" {
+firrtl.module @TestPubAnno() {
+  firrtl.instance fi @flatinline()
+}
+firrtl.module @flatinline() attributes {annotations =
+        [{class = "firrtl.transforms.FlattenAnnotation"},
+         {class = "firrtl.passes.InlineAnnotation"}]} {
+  %test_wire = firrtl.wire : !firrtl.uint<2>
+  firrtl.instance leaf @leaf()
+}
+firrtl.module private @leaf() {
+  %test_wire = firrtl.wire : !firrtl.uint<2>
+}
+}
+// CHECK-LABEL: firrtl.circuit "TestPubAnno"
+// CHECK-NEXT:    firrtl.module @TestPubAnno
+// CHECK-NOT: annotation
+// This is preserved, public
+// CHECK:         firrtl.module @flatinline
+// But annotations should be removed?
+// CHECK-NOT: annotation
+// CHECK-NOT: @leaf
+
 // This is testing that connects are properly replaced when inlining. This is
 // also testing that the deep clone and remapping values is working correctly.
 firrtl.circuit "TestConnections" {

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -117,6 +117,41 @@ firrtl.module private @test3() {
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
+// Test behavior inlining a flattened module into multiple parents
+firrtl.circuit "TestInliningFlatten" {
+firrtl.module @TestInliningFlatten() {
+  firrtl.instance test1 @test1()
+  firrtl.instance test2 @test2()
+}
+firrtl.module private @test1() {
+  %test_wire = firrtl.wire : !firrtl.uint<2>
+  firrtl.instance fi @flatinline()
+}
+firrtl.module private @test2() {
+  %test_wire = firrtl.wire : !firrtl.uint<2>
+  firrtl.instance fi @flatinline()
+}
+firrtl.module private @flatinline() attributes {annotations =
+        [{class = "firrtl.transforms.FlattenAnnotation"},
+         {class = "firrtl.passes.InlineAnnotation"}]} {
+  %test_wire = firrtl.wire : !firrtl.uint<2>
+  firrtl.instance leaf @leaf()
+}
+firrtl.module private @leaf() {
+  %test_wire = firrtl.wire : !firrtl.uint<2>
+}
+}
+// CHECK-LABEL: firrtl.circuit "TestInliningFlatten"
+// CHECK-NEXT:    firrtl.module @TestInliningFlatten
+// inlining a flattened module should not contain 'instance's:
+// CHECK:       firrtl.module private @test1()
+// CHECK-NOT:     firrtl.instance
+// inlining a flattened module should not contain 'instance's:
+// CHECK:       firrtl.module private @test2()
+// CHECK-NOT:     firrtl.instance
+// These should be removed
+// CHECK-NOT:   @flatinline
+// CHECK-NOT:   @leaf
 
 // This is testing that connects are properly replaced when inlining. This is
 // also testing that the deep clone and remapping values is working correctly.


### PR DESCRIPTION
### Fix flatten+inline into multiple instances

Modules with both flatten+inline were only (inline+flatten)'d at first instantation site (not at all sites), and sometimes modules themselves were not flattened.
  * Code now behaves more as if we walked and flattened all annotated modules first, and then performed inlining.
  * Regression test added (non-exhaustive regarding the ways this could happen)
  * Circuits may now be larger in some cases when there are multiple instances of flatten+inline modules, but that appears the intended behavior and I can't say how common this is.
 
### Annotation cleanup

Fix lingering InlineAnnotation on modules (and rework how/when FlattenAnnotation is removed, as part of above task)
  * Module visibility changes some guarantees, as we assumed inline modules were dead (+removed) after inlining occurred.  Now that they can linger, be sure to cleanup their annotations.