### PR TITLE
[MSFT] Make dynamic instances hierarchical

### DIFF
--- a/include/circt/Dialect/HW/HWTypes.td
+++ b/include/circt/Dialect/HW/HWTypes.td
@@ -58,6 +58,15 @@ def UnionType : DialectType<HWDialect,
 // Type Definitions
 //===----------------------------------------------------------------------===//
 
+/// Points to a name within a module.
+def HWInnerRefAttr : Attr<
+  CPred<"$_self.isa<::circt::hw::InnerRefAttr>()">,
+        "name reference attribute"> {
+  let returnType = "::circt::hw::InnerRefAttr";
+  let storageType = "::circt::hw::InnerRefAttr";
+  let convertFromStorage = "$_self";
+}
+
 /// A flat symbol reference or a reference to a name within a module.
 def NameRefAttr : Attr<
   CPred<"$_self.isa<::mlir::FlatSymbolRefAttr, ::circt::hw::InnerRefAttr>()">,

--- a/include/circt/Dialect/MSFT/MSFT.td
+++ b/include/circt/Dialect/MSFT/MSFT.td
@@ -39,6 +39,8 @@ def MSFTDialect : Dialect {
     /// Register all MSFT attributes.
     void registerAttributes();
   }];
+
+  let dependentDialects = ["::circt::hw::HWDialect"];
 }
 // Base class for the operation in this dialect.
 class MSFTOp<string mnemonic, list<Trait> traits = []> :

--- a/include/circt/Dialect/MSFT/MSFTOps.h
+++ b/include/circt/Dialect/MSFT/MSFTOps.h
@@ -13,6 +13,7 @@
 #ifndef CIRCT_DIALECT_MSFT_MSFTOPS_H
 #define CIRCT_DIALECT_MSFT_MSFTOPS_H
 
+#include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Dialect/MSFT/MSFTAttributes.h"
 #include "circt/Dialect/MSFT/MSFTDialect.h"
 #include "circt/Dialect/MSFT/MSFTOpInterfaces.h"

--- a/include/circt/Dialect/MSFT/MSFTPDOps.td
+++ b/include/circt/Dialect/MSFT/MSFTPDOps.td
@@ -65,8 +65,22 @@ def PDPhysRegionOp : MSFTOp<"pd.physregion",
   }];
 }
 
+def InstanceHierarchyOp : MSFTOp<"instance.hierarchy",
+                                 [HasParent<"mlir::ModuleOp">, NoTerminator]> {
+  let summary = "The root of an instance hierarchy";
+
+  let arguments = (ins FlatSymbolRefAttr:$topModuleRef);
+  let regions = (region SizedRegion<1>:$instances);
+
+  let assemblyFormat = [{
+    $topModuleRef $instances attr-dict
+  }];
+}
+
 def DynamicInstanceOp : MSFTOp<"instance.dynamic",
-                               [HasParent<"mlir::ModuleOp">, NoTerminator]> {
+                               [ParentOneOf<["circt::msft::InstanceHierarchyOp",
+                                             "circt::msft::DynamicInstanceOp"]>,
+                                NoTerminator]> {
 
   let summary = "A module instance in the instance hierarchy";
   let description = [{
@@ -83,14 +97,14 @@ def DynamicInstanceOp : MSFTOp<"instance.dynamic",
     gives them the symbol of the globalref which was created to replace the
     dynamic instance.
   }];
-  let arguments = (ins NameRefArrayAttr:$appid);
+  let arguments = (ins HWInnerRefAttr:$instanceRef);
   let regions = (region SizedRegion<1>:$body);
 
   let assemblyFormat = [{
-    $appid $body attr-dict
+    custom<ImplicitInnerRef>($instanceRef) $body attr-dict
   }];
 
   let extraClassDeclaration = [{
-    bool isRootedIn(Operation *top);
+    ::mlir::ArrayAttr globalRefPath();
   }];
 }

--- a/lib/Bindings/Python/circt/dialects/_msft_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_msft_ops_ext.py
@@ -155,10 +155,29 @@ class EntityExternOp:
     return _msft.EntityExternOp(symbol_attr, metadata_attr)
 
 
+class InstanceHierarchyOp:
+
+  @staticmethod
+  def create(root_mod):
+    hier = _msft.InstanceHierarchyOp(root_mod)
+    hier.instances.blocks.append()
+    return hier
+
+
 class DynamicInstanceOp:
 
   @staticmethod
-  def create(appid):
-    inst = _msft.DynamicInstanceOp(appid)
+  def create(name_ref):
+    inst = _msft.DynamicInstanceOp(name_ref)
     inst.body.blocks.append()
     return inst
+
+  @property
+  def instance_path(self):
+    path = []
+    next = self
+    while isinstance(next, DynamicInstanceOp):
+      path.append(next.attributes["instanceRef"])
+      next = next.operation.parent.opview
+    path.reverse()
+    return _ir.ArrayAttr.get(path)

--- a/lib/Dialect/MSFT/DeviceDB.cpp
+++ b/lib/Dialect/MSFT/DeviceDB.cpp
@@ -107,7 +107,8 @@ LogicalResult PlacementDB::insertPlacement(PDPhysLocationOp locOp) {
   if (leaf->locOp != nullptr)
     return locOp->emitOpError("Could not apply placement ")
            << locOp.loc() << ". Position already occupied by "
-           << cast<DynamicInstanceOp>(leaf->locOp->getParentOp()).appid();
+           << cast<DynamicInstanceOp>(leaf->locOp->getParentOp())
+                  .globalRefPath();
 
   leaf->locOp = locOp;
   return success();
@@ -188,7 +189,8 @@ LogicalResult PlacementDB::movePlacement(PDPhysLocationOp locOp,
   if (newLeaf->locOp)
     return locOp.emitError(
                "cannot move to new location since location is occupied by ")
-           << cast<DynamicInstanceOp>(newLeaf->locOp->getParentOp()).appid();
+           << cast<DynamicInstanceOp>(newLeaf->locOp->getParentOp())
+                  .globalRefPath();
 
   locOp.locAttr(newLoc);
   newLeaf->locOp = locOp;

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -63,21 +63,44 @@ static void printPhysLoc(OpAsmPrinter &p, Operation *, PhysLocationAttr loc) {
 //===----------------------------------------------------------------------===//
 
 void PDPhysLocationOp::setGlobalRef(hw::GlobalRefOp ref) {
+  assert(ref);
   refAttr(FlatSymbolRefAttr::get(ref));
 }
 FlatSymbolRefAttr PDPhysLocationOp::getGlobalRefSym() { return refAttr(); }
 
 void PDPhysRegionOp::setGlobalRef(hw::GlobalRefOp ref) {
+  assert(ref);
   refAttr(FlatSymbolRefAttr::get(ref));
 }
 FlatSymbolRefAttr PDPhysRegionOp::getGlobalRefSym() { return refAttr(); }
 
-bool DynamicInstanceOp::isRootedIn(Operation *hwMod) {
-  if (appid().empty())
-    return false;
+ParseResult parseImplicitInnerRef(OpAsmParser &p, hw::InnerRefAttr &innerRef) {
+  SymbolRefAttr sym;
+  if (p.parseAttribute(sym))
+    return failure();
+  auto loc = p.getCurrentLocation();
+  if (sym.getNestedReferences().size() != 1)
+    return p.emitError(loc, "expected <module sym>::<inner name>");
+  innerRef = hw::InnerRefAttr::get(
+      sym.getRootReference(),
+      sym.getNestedReferences().front().getRootReference());
+  return success();
+}
+void printImplicitInnerRef(OpAsmPrinter &p, Operation *,
+                           hw::InnerRefAttr innerRef) {
+  p << SymbolRefAttr::get(innerRef.getModule(),
+                          {FlatSymbolRefAttr::get(innerRef.getName())});
+}
 
-  return SymbolTable::getSymbolName(hwMod) ==
-         appid()[0].cast<hw::InnerRefAttr>().getModule();
+ArrayAttr DynamicInstanceOp::globalRefPath() {
+  SmallVector<Attribute, 16> path;
+  DynamicInstanceOp next = *this;
+  do {
+    path.push_back(next.instanceRefAttr());
+    next = next->getParentOfType<DynamicInstanceOp>();
+  } while (next);
+  std::reverse(path.begin(), path.end());
+  return ArrayAttr::get(getContext(), path);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -63,13 +63,11 @@ static void printPhysLoc(OpAsmPrinter &p, Operation *, PhysLocationAttr loc) {
 //===----------------------------------------------------------------------===//
 
 void PDPhysLocationOp::setGlobalRef(hw::GlobalRefOp ref) {
-  assert(ref);
   refAttr(FlatSymbolRefAttr::get(ref));
 }
 FlatSymbolRefAttr PDPhysLocationOp::getGlobalRefSym() { return refAttr(); }
 
 void PDPhysRegionOp::setGlobalRef(hw::GlobalRefOp ref) {
-  assert(ref);
   refAttr(FlatSymbolRefAttr::get(ref));
 }
 FlatSymbolRefAttr PDPhysRegionOp::getGlobalRefSym() { return refAttr(); }

--- a/test/Dialect/MSFT/opt-errors.mlir
+++ b/test/Dialect/MSFT/opt-errors.mlir
@@ -23,9 +23,11 @@ hw.module @M() {
 
 // -----
 
-msft.instance.dynamic [#hw.innerNameRef<@reg::@reg>] {
-  // expected-error @+1 {{'msft.pd.location' op cannot both have a global ref symbol and be a child of a dynamic instance op}}
-  msft.pd.location @ref FF x: 0 y: 0 n: 0
+msft.instance.hierarchy @reg {
+  msft.instance.dynamic @reg::@reg {
+    // expected-error @+1 {{'msft.pd.location' op cannot both have a global ref symbol and be a child of a dynamic instance op}}
+    msft.pd.location @ref FF x: 0 y: 0 n: 0
+  }
 }
 
 // -----


### PR DESCRIPTION
Create an instance hierarchy root operation. Require dynamic instances
to nest inside of it and only represent a single level of the hierarchy.
Results in a tree which better models the instance hierarchy.
