### PR TITLE
[PyCDE] Teach PlacementDB how to resolve to `Instance`s

### DIFF
--- a/frontends/PyCDE/src/pycde/instance.py
+++ b/frontends/PyCDE/src/pycde/instance.py
@@ -3,7 +3,7 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from __future__ import annotations
-from typing import List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 from .appid import AppID
 
@@ -78,12 +78,15 @@ class InstanceLike:
   def appid(self) -> AppID:
     return AppID(*[i.name for i in self.path])
 
-  def children(self) -> List[Instance]:
+  def children(self) -> Dict[str, Instance]:
     """Return a list of this instances children. Cache said list."""
     if self._child_cache is not None:
       return self._child_cache
     symbols_in_mod = self._get_sym_ops_in_module()
-    children = [self._create_instance(self, op) for op in symbols_in_mod]
+    children = {
+        op.attributes["sym_name"]: self._create_instance(self, op)
+        for op in symbols_in_mod
+    }
     # TODO: make these weak refs
     self._child_cache = children
     return children
@@ -91,7 +94,7 @@ class InstanceLike:
   def walk(self, callback):
     """Descend the instance hierarchy, calling back on each instance."""
     callback(self)
-    for child in self.children():
+    for child in self.children().values():
       child.walk(callback)
 
   def _attach_attribute(self, attr):

--- a/frontends/PyCDE/src/pycde/instance.py
+++ b/frontends/PyCDE/src/pycde/instance.py
@@ -32,7 +32,7 @@ class InstanceLike:
     self.inside_of = inside_of
     self.tgt_mod = tgt_mod
     self.root = root
-    self._child_cache: List[Instance] = None
+    self._child_cache: Dict[ir.StringAttr, Instance] = None
     self._op_cache = root.system._op_cache
 
   def _create_instance(self, parent: Instance,
@@ -84,8 +84,8 @@ class InstanceLike:
       return self._child_cache
     symbols_in_mod = self._get_sym_ops_in_module()
     children = {
-        op.attributes["sym_name"]: self._create_instance(self, op)
-        for op in symbols_in_mod
+        ir.StringAttr(op.attributes["sym_name"]):
+        self._create_instance(self, op) for op in symbols_in_mod
     }
     # TODO: make these weak refs
     self._child_cache = children

--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -2,6 +2,7 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from numpy import isin
 from pycde.devicedb import (EntityExtern, PlacementDB, PrimitiveDB,
                             PhysicalRegion)
 
@@ -201,7 +202,7 @@ class System:
 
   def createdb(self, primdb: PrimitiveDB = None):
     if self._placedb is None:
-      self._placedb = PlacementDB(self.mod, primdb)
+      self._placedb = PlacementDB(self, self.mod, primdb)
 
 
 class _OpCache:
@@ -209,7 +210,7 @@ class _OpCache:
 
   __slots__ = [
       "_module", "_symbols", "_module_symbols", "_symbol_modules",
-      "_instance_hier_cache", "_instance_cache"
+      "_instance_hier_cache", "_instance_hier_obj_cache", "_instance_cache"
   ]
 
   def __init__(self, module: ir.Module):
@@ -219,6 +220,7 @@ class _OpCache:
     self._symbol_modules: dict[str, _SpecializedModule] = {}
 
     self._instance_hier_cache: dict[str, msft.InstanceHierarchyOp] = None
+    self._instance_hier_obj_cache: dict[str, InstanceHierarchy] = {}
     self._instance_cache: dict[Instance, msft.DynamicInstanceOp] = {}
 
   def release_ops(self):
@@ -306,6 +308,7 @@ class _OpCache:
       with ir.InsertionPoint(self._module.body):
         hier_op = msft.InstanceHierarchyOp.create(root_mod_symbol)
         self._instance_hier_cache[root_mod_symbol] = hier_op
+        self._instance_hier_obj_cache[root_mod_symbol] = inst_hier
 
     return self._instance_hier_cache[root_mod_symbol]
 
@@ -318,3 +321,13 @@ class _OpCache:
       with inst.parent._get_ip():
         self._instance_cache[inst] = msft.DynamicInstanceOp.create(ref)
     return self._instance_cache[inst]
+
+  def get_or_create_inst_from_op(self, op: ir.OpView):
+    if isinstance(op, msft.InstanceHierarchyOp):
+      return self._instance_hier_obj_cache[op.top_module_ref]
+    if isinstance(op, msft.DynamicInstanceOp):
+      parent_inst = self.get_or_create_inst_from_op(op.operation.parent.opview)
+      instance_ref = hw.InnerRefAttr(op.instanceRef)
+      return parent_inst.children()[instance_ref.name]
+    raise TypeError(
+        "Can only resolve from InstanceHierarchyOp or DynamicInstanceOp")

--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -2,7 +2,6 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from numpy import isin
 from pycde.devicedb import (EntityExtern, PlacementDB, PrimitiveDB,
                             PhysicalRegion)
 

--- a/frontends/PyCDE/test/instances.py
+++ b/frontends/PyCDE/test/instances.py
@@ -120,7 +120,10 @@ test_inst.walk(lambda inst: print(inst, inst.locations))
 # reserved_loc = PhysLocation(PrimitiveType.M20K, 40, 40, 0)
 # entity_extern = t.create_entity_extern("tag")
 # test_inst.placedb.reserve_location(reserved_loc, entity_extern)
-assert t.placedb.get_instance_at(loc[1]) is not None
+
+# CHECK: PhysLocation<PrimitiveType.DSP, x:39, y:25, num:0> has (<instance: [UnParameterized, Nothing]>, None)
+print(f"{loc[1]} has {t.placedb.get_instance_at(loc[1])}")
+
 assert t.placedb.get_instance_at(PhysLocation(PrimitiveType.M20K, 0, 0,
                                               0)) is None
 # assert test_inst.placedb.get_instance_at(reserved_loc) is not None

--- a/lib/Bindings/Python/circt/dialects/_msft_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_msft_ops_ext.py
@@ -186,6 +186,10 @@ class DynamicInstanceOp:
     path.reverse()
     return _ir.ArrayAttr.get(path)
 
+  @property
+  def instanceRef(self):
+    return self.attributes["instanceRef"]
+
 
 class PDPhysLocationOp:
 

--- a/lib/Bindings/Python/circt/support.py
+++ b/lib/Bindings/Python/circt/support.py
@@ -118,6 +118,8 @@ def type_to_pytype(t):
 def attribute_to_var(attr):
   import mlir.ir as ir
 
+  if attr is None:
+    return None
   if not isinstance(attr, ir.Attribute):
     raise TypeError("attribute_to_var only accepts MLIR Attributes")
 


### PR DESCRIPTION
Previously, PlacementDB.get_instance_at would return a raw CIRCT op. It
now resolves it back to a Python Instance object. Also deletes the
coord-based instance lookup since it was untested and unused.