### PR TITLE
[SV] Avoid temporary wires when ReadInOutOp is after use

### DIFF
--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -614,21 +614,20 @@ hw.module @ArrayLHS(%clock: i1) {
   }
 }
 
-// CHECK-LABEL: module notEmitDuplicateWiresThatWereUnInlinedDueToLongNames
-hw.module @notEmitDuplicateWiresThatWereUnInlinedDueToLongNames(%clock: i1, %x: i1) {
-  // CHECK: wire _GEN;
+// CHECK-LABEL: module noTemporaryIfReadInOutIsAfterUse
+hw.module @noTemporaryIfReadInOutIsAfterUse(%clock: i1, %x: i1) {
   // CHECK: wire aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+
   %0 = comb.and %1, %x : i1
   // CHECK: always_ff @(posedge clock) begin
   sv.alwaysff(posedge %clock) {
-    // CHECK: if (_GEN & x) begin
+    // CHECK: if (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa & x) begin
     sv.if %0  {
       sv.verbatim "// hello"
     }
   }
 
   // CHECK: end // always_ff @(posedge)
-  // CHECK: assign _GEN = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
   %aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = sv.wire  : !hw.inout<i1>
   %1 = sv.read_inout %aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa : !hw.inout<i1>
 }


### PR DESCRIPTION
When the ReadInOutOp accessing a register or a wire was after the use of the read value, a temporary wire was emitted.  This patch instead moves both the definition of the read operation and the read itself to the top of the module, ensuring the order is correct and no temporaries are needed.

As a result, the verilog representation of a large design is 0.6% shorter, with thousands of temporaries eliminated.