### PR TITLE
[PyCDE] Adds support for rebuilding the instance cache

### DIFF
--- a/include/circt/Dialect/MSFT/MSFTPDOps.td
+++ b/include/circt/Dialect/MSFT/MSFTPDOps.td
@@ -70,10 +70,10 @@ def InstanceHierarchyOp : MSFTOp<"instance.hierarchy",
   let summary = "The root of an instance hierarchy";
 
   let arguments = (ins FlatSymbolRefAttr:$topModuleRef);
-  let regions = (region SizedRegion<1>:$instances);
+  let regions = (region SizedRegion<1>:$body);
 
   let assemblyFormat = [{
-    $topModuleRef $instances attr-dict
+    $topModuleRef $body attr-dict
   }];
 }
 

--- a/integration_test/Bindings/Python/dialects/msft.py
+++ b/integration_test/Bindings/Python/dialects/msft.py
@@ -70,7 +70,7 @@ with ir.Context() as ctx, ir.Location.unknown():
 
   with ir.InsertionPoint(mod.body):
     hier = msft.InstanceHierarchyOp.create(ir.FlatSymbolRefAttr.get("top"))
-    with ir.InsertionPoint(hier.instances.blocks[0]):
+    with ir.InsertionPoint(hier.body.blocks[0]):
       dyn_inst = msft.DynamicInstanceOp.create(path[0])
       with ir.InsertionPoint(dyn_inst.body.blocks[0]):
         dyn_inst = msft.DynamicInstanceOp.create(path[1])

--- a/lib/Bindings/Python/circt/dialects/_msft_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_msft_ops_ext.py
@@ -160,7 +160,7 @@ class InstanceHierarchyOp:
   @staticmethod
   def create(root_mod):
     hier = _msft.InstanceHierarchyOp(root_mod)
-    hier.instances.blocks.append()
+    hier.body.blocks.append()
     return hier
 
   @property


### PR DESCRIPTION
If the instance caches got cleared, lazily rebuild them on queries. Thus
far, we've gotten away with this since we were in a "fire and forget"
type situation, but lowering the high-level constructs won't be.