### PR TITLE
[Handshake] Make builders more flexible by using ValueRange

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -137,7 +137,6 @@ def InstanceOp : Handshake_Op<"instance", [CallOpInterface]> {
       $_state.addOperands(operands);
       $_state.addAttribute("module", SymbolRefAttr::get(module));
       $_state.addTypes(module.getResultTypes());
-      $_state.addTypes({$_builder.getType<::mlir::NoneType>()});
   }]>, OpBuilder<
     (ins "SymbolRefAttr":$module, "TypeRange":$results,
      CArg<"ValueRange", "{}">:$operands), [{
@@ -199,7 +198,7 @@ def ReturnOp : Handshake_Op<"return", [Terminator]> {
   let arguments = (ins Variadic<AnyType> : $operands, NoneType : $control);
 
   let skipDefaultBuilders = 1;
-  let builders = [OpBuilder<(ins "ArrayRef<Value>":$operands)>];
+  let builders = [OpBuilder<(ins "ValueRange":$operands)>];
 
   let hasVerifier = 1;
   let assemblyFormat = [{ operands attr-dict `:` qualified(type(operands)) }];
@@ -679,7 +678,7 @@ def MemoryOp : Handshake_Op<"memory", [
 
   let skipDefaultBuilders = 1;
   let builders = [OpBuilder<(
-      ins "ArrayRef<Value>":$operands, "int":$outputs, "int":$control_outputs, "bool":$lsq,
+      ins "ValueRange":$operands, "int":$outputs, "int":$control_outputs, "bool":$lsq,
       "int":$id, "Value":$memref)>
   ];
   let assemblyFormat = "`[` `ld` `=` $ldCount `,` `st` `=`  $stCount `]` `(` $inputs `)` attr-dict `:` $memRefType `,` functional-type($inputs, $outputs)";
@@ -719,7 +718,7 @@ def ExternalMemoryOp : Handshake_Op<"extmemory", [
 
   let skipDefaultBuilders = 1;
   let builders = [OpBuilder<(
-      ins "Value":$memref, "ArrayRef<Value>":$inputs, "int":$ldCount, "int":$stCount,
+      ins "Value":$memref, "ValueRange":$inputs, "int":$ldCount, "int":$stCount,
       "int":$id)>
   ];
   let assemblyFormat = "`[` `ld` `=` $ldCount `,` `st` `=`  $stCount `]` `(` $memref `:` qualified(type($memref)) `)` `(` $inputs `)` attr-dict `:` functional-type($inputs, $outputs)";
@@ -751,7 +750,7 @@ def LoadOp : Handshake_Op<"load", [
   let arguments = (ins Variadic<AnyType>:$addresses, AnyType:$data, NoneType:$ctrl);
   let results = (outs AnyType:$dataResult, Variadic<AnyType>:$addressResults);
   let skipDefaultBuilders = 1;
-  let builders = [OpBuilder<(ins "Value":$memref, "ArrayRef<Value>":$indices)>];
+  let builders = [OpBuilder<(ins "Value":$memref, "ValueRange":$indices)>];
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
 }
@@ -784,7 +783,7 @@ def StoreOp : Handshake_Op<"store", [
   let results = (outs AnyType:$dataResult, Variadic<AnyType>:$addressResult);
 
   let builders =
-      [OpBuilder<(ins "Value":$valueToStore, "ArrayRef<Value>":$indices)>];
+      [OpBuilder<(ins "Value":$valueToStore, "ValueRange":$indices)>];
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
 }
@@ -807,7 +806,7 @@ def JoinOp : Handshake_Op<"join", [
   let results = (outs NoneType : $result);
 
   let skipDefaultBuilders = 1;
-  let builders = [OpBuilder<(ins "ArrayRef<Value>":$operands)>];
+  let builders = [OpBuilder<(ins "ValueRange":$operands)>];
   let hasCustomAssemblyFormat = 1;
 }
 

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -894,7 +894,7 @@ void EndOp::build(OpBuilder &builder, OperationState &result, Value operand) {
 }
 
 void handshake::ReturnOp::build(OpBuilder &builder, OperationState &result,
-                                ArrayRef<Value> operands) {
+                                ValueRange operands) {
   result.addOperands(operands);
 }
 
@@ -1173,7 +1173,7 @@ std::string handshake::ExternalMemoryOp::getResultName(unsigned int idx) {
 }
 
 void ExternalMemoryOp::build(OpBuilder &builder, OperationState &result,
-                             Value memref, ArrayRef<Value> inputs, int ldCount,
+                             Value memref, ValueRange inputs, int ldCount,
                              int stCount, int id) {
   SmallVector<Value> ops;
   ops.push_back(memref);
@@ -1196,7 +1196,7 @@ void ExternalMemoryOp::build(OpBuilder &builder, OperationState &result,
 }
 
 void MemoryOp::build(OpBuilder &builder, OperationState &result,
-                     ArrayRef<Value> operands, int outputs, int control_outputs,
+                     ValueRange operands, int outputs, int controlOutputs,
                      bool lsq, int id, Value memref) {
   result.addOperands(operands);
 
@@ -1206,7 +1206,7 @@ void MemoryOp::build(OpBuilder &builder, OperationState &result,
   result.types.append(outputs, memrefType.getElementType());
 
   // Control outputs
-  result.types.append(control_outputs, builder.getNoneType());
+  result.types.append(controlOutputs, builder.getNoneType());
   result.addAttribute("lsq", builder.getBoolAttr(lsq));
   result.addAttribute("memRefType", TypeAttr::get(memrefType));
 
@@ -1217,7 +1217,7 @@ void MemoryOp::build(OpBuilder &builder, OperationState &result,
   if (!lsq) {
     result.addAttribute("ldCount", builder.getIntegerAttr(i32Type, outputs));
     result.addAttribute(
-        "stCount", builder.getIntegerAttr(i32Type, control_outputs - outputs));
+        "stCount", builder.getIntegerAttr(i32Type, controlOutputs - outputs));
   }
 }
 
@@ -1285,7 +1285,7 @@ std::string handshake::LoadOp::getResultName(unsigned int idx) {
 }
 
 void handshake::LoadOp::build(OpBuilder &builder, OperationState &result,
-                              Value memref, ArrayRef<Value> indices) {
+                              Value memref, ValueRange indices) {
   // Address indices
   // result.addOperands(memref);
   result.addOperands(indices);
@@ -1375,7 +1375,7 @@ std::string handshake::StoreOp::getResultName(unsigned int idx) {
 }
 
 void handshake::StoreOp::build(OpBuilder &builder, OperationState &result,
-                               Value valueToStore, ArrayRef<Value> indices) {
+                               Value valueToStore, ValueRange indices) {
 
   // Address indices
   result.addOperands(indices);
@@ -1399,7 +1399,7 @@ ParseResult StoreOp::parse(OpAsmParser &parser, OperationState &result) {
 void StoreOp::print(OpAsmPrinter &p) { return printMemoryAccessOp(p, *this); }
 
 void JoinOp::build(OpBuilder &builder, OperationState &result,
-                   ArrayRef<Value> operands) {
+                   ValueRange operands) {
   auto type = builder.getNoneType();
   result.types.push_back(type);
 


### PR DESCRIPTION
The previously used `ArrayRef<Value>` can be implicity converted to `ValueRanges`, but the other way is not as simple.