### PR TITLE
[Handshake] Add optional visibility parsing for `FuncOp`

### DIFF
--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -23,6 +23,7 @@
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Transforms/InliningUtils.h"
 #include "llvm/ADT/SetVector.h"
@@ -631,6 +632,9 @@ ParseResult FuncOp::parse(OpAsmParser &parser, OperationState &result) {
   SmallVector<Type, 4> argTypes, resTypes;
   SmallVector<NamedAttrList, 4> argAttributes, resAttributes;
   SmallVector<Attribute> argNames;
+
+  // Parse visibility.
+  mlir::impl::parseOptionalVisibilityKeyword(parser, result.attributes);
 
   // Parse signature
   if (parser.parseSymbolName(nameAttr, SymbolTable::getSymbolAttrName(),

--- a/test/Dialect/Handshake/func.mlir
+++ b/test/Dialect/Handshake/func.mlir
@@ -1,0 +1,21 @@
+// RUN: circt-opt -split-input-file %s | circt-opt | FileCheck %s
+
+// CHECK-LABEL:   handshake.func private @private_func(
+// CHECK-SAME:                   %[[VAL_0:.*]]: i32,
+// CHECK-SAME:                   %[[VAL_1:.*]]: none, ...) -> (i32, none) attributes {argNames = ["arg0", "ctrl"], resNames = ["out0", "outCtrl"]} {
+// CHECK:           return %[[VAL_0]], %[[VAL_1]] : i32, none
+// CHECK:         }
+handshake.func private @private_func(%arg0 : i32, %ctrl: none) -> (i32, none) {
+  return %arg0, %ctrl : i32, none
+}
+
+// -----
+
+// CHECK-LABEL:   handshake.func public @public_func(
+// CHECK-SAME:                   %[[VAL_0:.*]]: i32,
+// CHECK-SAME:                   %[[VAL_1:.*]]: none, ...) -> (i32, none) attributes {argNames = ["arg0", "ctrl"], resNames = ["out0", "outCtrl"]} {
+// CHECK:           return %[[VAL_0]], %[[VAL_1]] : i32, none
+// CHECK:         }
+handshake.func public @public_func(%arg0 : i32, %ctrl: none) -> (i32, none) {
+  return %arg0, %ctrl : i32, none
+}


### PR DESCRIPTION
This PR introduces parsing for optional visibility information of `handshake::FuncOp`s.

I added a new test called `func.mlir` as there are no other tests that simply round-trip on operations in the `test/Dialect/Handshake` folder.