### PR TITLE
[FSM] Make initial state explicit

### DIFF
--- a/include/circt/Dialect/FSM/FSMOps.td
+++ b/include/circt/Dialect/FSM/FSMOps.td
@@ -25,19 +25,20 @@ def MachineOp : FSMOp<"machine", [HasParent<"mlir::ModuleOp">, FunctionOpInterfa
   }];
 
   let arguments = (ins StrAttr:$sym_name, TypeAttr:$stateType,
+                       StrAttr:$initialState,
                        TypeAttrOf<FunctionType>:$function_type);
   let regions = (region SizedRegion<1>:$body);
 
   let builders = [
-    OpBuilder<(ins "StringRef":$name, "Type":$stateType,
-      "FunctionType":$function_type,
+    OpBuilder<(ins "StringRef":$name, "StringRef":$initialState,
+      "Type":$stateType, "FunctionType":$function_type,
       CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs,
       CArg<"ArrayRef<DictionaryAttr>", "{}">:$argAttrs)>
   ];
 
   let extraClassDeclaration = [{
-    /// Get the default state of the machine.
-    StateOp getDefaultState();
+    /// Get the initial state of the machine.
+    StateOp getInitialStateOp();
 
     /// Get the port information of the machine.
     void getHWPortInfo(SmallVectorImpl<hw::PortInfo> &);

--- a/test/Dialect/FSM/basics.mlir
+++ b/test/Dialect/FSM/basics.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt %s | FileCheck %s
 
-// CHECK: fsm.machine @foo(%arg0: i1) -> i1 attributes {stateType = i1} {
+// CHECK: fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE", stateType = i1} {
 // CHECK:   %cnt = fsm.variable "cnt" {initValue = 0 : i16} : i16
 // CHECK:   fsm.state "IDLE" output  {
 // CHECK:     %true = arith.constant true
@@ -48,7 +48,7 @@
 // CHECK:   return
 // CHECK: }
 
-fsm.machine @foo(%arg0: i1) -> i1 attributes {stateType = i1} {
+fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE", stateType = i1} {
   %cnt = fsm.variable "cnt" {initValue = 0 : i16} : i16
 
   fsm.state "IDLE" output  {

--- a/test/Dialect/FSM/errors.mlir
+++ b/test/Dialect/FSM/errors.mlir
@@ -1,0 +1,6 @@
+// RUN: circt-opt %s -split-input-file -verify-diagnostics
+
+// Test missing initial state.
+
+// expected-error @+1 {{'fsm.machine' op initial state 'IDLE' was not defined in the machine}}
+fsm.machine @foo(%arg0: i1) -> i1 attributes {stateType = i1, initialState = "IDLE"} {}


### PR DESCRIPTION
Previously, the first state in the machine was assumed to be the initial state - I believe being explicit here is important to ensure the machine behaves as intended. Also modified "default" state to "initial" state (seems to be more consistent with literature). It should be mentioned that I'm doing this to detach some of the "hardware-like" assumptions of the FSM dialect (another example is the implicit priority encoding of the list of transitions). I'd like to see it be more broadly applicable so that we can do interesting things such as DFA/NFA optimizations, equivalence, etc..