### PR TITLE
[FSM] Canonicalize away unreachable states

### DIFF
--- a/include/circt/Dialect/FSM/FSMOps.td
+++ b/include/circt/Dialect/FSM/FSMOps.td
@@ -67,6 +67,7 @@ def MachineOp : FSMOp<"machine", [HasParent<"mlir::ModuleOp">, FunctionOpInterfa
 
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
+  let hasCanonicalizeMethod = true;
 }
 
 def InstanceOp : FSMOp<"instance", [Symbol, HasCustomSSAName]> {
@@ -157,6 +158,11 @@ def StateOp : FSMOp<"state", [HasParent<"MachineOp">, Symbol,
 
   let assemblyFormat = [{
     $sym_name attr-dict `output` $output `transitions` $transitions
+  }];
+
+  let extraClassDeclaration = [{
+    /// Returns all possible next states from this state.
+    llvm::SetVector<StateOp> getNextStates();
   }];
 }
 

--- a/lib/Dialect/FSM/FSMOps.cpp
+++ b/lib/Dialect/FSM/FSMOps.cpp
@@ -22,6 +22,29 @@ using namespace fsm;
 // MachineOp
 //===----------------------------------------------------------------------===//
 
+// Returns all states that are unreachable from the initial state.
+static SmallVector<StateOp> unreachableStates(MachineOp machine) {
+  SetVector<StateOp> reachableStates;
+  SmallVector<StateOp, 4> queue;
+  queue.push_back(machine.getInitialStateOp());
+  while (!queue.empty()) {
+    auto state = queue.begin();
+    queue.erase(state);
+    if (reachableStates.contains(*state))
+      continue;
+    reachableStates.insert(*state);
+    llvm::copy(state->getNextStates(), std::back_inserter(queue));
+  }
+
+  // Get the difference between reachable states and all states in the machine.
+  auto allStates = machine.getOps<StateOp>();
+  SmallVector<StateOp> unreachableStates;
+  std::set_difference(allStates.begin(), allStates.end(),
+                      reachableStates.begin(), reachableStates.end(),
+                      std::back_inserter(unreachableStates));
+  return unreachableStates;
+}
+
 void MachineOp::build(OpBuilder &builder, OperationState &state, StringRef name,
                       StringRef initialStateName, Type stateType,
                       FunctionType type, ArrayRef<NamedAttribute> attrs,
@@ -127,6 +150,13 @@ LogicalResult MachineOp::verify() {
   return success();
 }
 
+LogicalResult MachineOp::canonicalize(MachineOp op, PatternRewriter &rewriter) {
+  // Remove any unreachable states.
+  for (auto unreachable : unreachableStates(op))
+    rewriter.eraseOp(unreachable);
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // InstanceOp
 //===----------------------------------------------------------------------===//
@@ -206,6 +236,15 @@ LogicalResult HWInstanceOp::verify() { return verifyCallerTypes(*this); }
 //===----------------------------------------------------------------------===//
 // StateOp
 //===----------------------------------------------------------------------===//
+
+SetVector<StateOp> StateOp::getNextStates() {
+  SmallVector<StateOp> nextStates;
+  llvm::transform(
+      transitions().getOps<TransitionOp>(),
+      std::inserter(nextStates, nextStates.begin()),
+      [](TransitionOp transition) { return transition.getNextState(); });
+  return SetVector<StateOp>(nextStates.begin(), nextStates.end());
+}
 
 LogicalResult StateOp::canonicalize(StateOp op, PatternRewriter &rewriter) {
   bool hasAlwaysTakenTransition = false;

--- a/lib/Dialect/FSM/FSMOps.cpp
+++ b/lib/Dialect/FSM/FSMOps.cpp
@@ -28,7 +28,7 @@ static SmallVector<StateOp> unreachableStates(MachineOp machine) {
   SmallVector<StateOp, 4> queue;
   queue.push_back(machine.getInitialStateOp());
   while (!queue.empty()) {
-    auto state = queue.begin();
+    auto *state = queue.begin();
     queue.erase(state);
     if (reachableStates.contains(*state))
       continue;

--- a/test/Dialect/FSM/canonicalize.mlir
+++ b/test/Dialect/FSM/canonicalize.mlir
@@ -1,0 +1,33 @@
+// RUN: circt-opt --canonicalize %s | FileCheck %s
+
+// Canonicalize unreachable states.
+
+fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE", stateType = i1} {
+  %cnt = fsm.variable "cnt" {initValue = 0 : i16} : i16
+
+  fsm.state "IDLE" output  {
+    fsm.output %arg0 : i1
+  } transitions  {
+    fsm.transition @B guard  {
+      %c0_i16 = arith.constant 0 : i16
+      %0 = arith.cmpi eq, %cnt, %c0_i16 : i16
+      fsm.return %0
+    } action  {
+    }
+  }
+
+  // CHECK-NOT: fsm.state "A"
+  fsm.state "A" output  {
+    fsm.output %arg0 : i1
+  } transitions  {}
+
+  // CHECK: fsm.state "B"
+  fsm.state "B" output  {
+    fsm.output %arg0 : i1
+  } transitions  {}
+
+  // CHECK-NOT: fsm.state "C"
+  fsm.state "C" output  {
+    fsm.output %arg0 : i1
+  } transitions  {}
+}


### PR DESCRIPTION
Since we currently only allow a single initial state for the state machine, it is a reasonable assumption that any unreasonable states may be pruned as part of canonicalization.

Depends on #3019 
