### PR TITLE
[FSM] Make transition guard and action regions optional

### DIFF
--- a/include/circt/Dialect/FSM/FSMOps.td
+++ b/include/circt/Dialect/FSM/FSMOps.td
@@ -182,19 +182,19 @@ def TransitionOp : FSMOp<"transition", [HasParent<"StateOp">,
   let summary = "Define a transition of a state";
   let description = [{
     `fsm.transition` represents a transition of a state with a symbol reference
-    of the next state. This op includes a `$guard` region with an `fsm.return`
+    of the next state. This op includes an optional `$guard` region with an `fsm.return`
     as terminator that returns a Boolean value indicating the guard condition of
-    this transition. This op also includes an `$action` region that represents
+    this transition. This op also includes an optional `$action` region that represents
     the actions to be executed when this transition is taken.
   }];
 
   let arguments = (ins FlatSymbolRefAttr:$nextState);
-  let regions = (region SizedRegion<1>:$guard, SizedRegion<1>:$action);
+  let regions = (region AnyRegion:$guard, AnyRegion:$action);
 
   let hasCanonicalizeMethod = true;
 
   let assemblyFormat = [{
-    $nextState attr-dict `guard` $guard `action` $action
+    $nextState attr-dict (`guard` $guard^)? (`action` $action^)?
   }];
 
   let extraClassDeclaration = [{
@@ -208,9 +208,21 @@ def TransitionOp : FSMOp<"transition", [HasParent<"StateOp">,
 
     /// Get the return operation of the guard region, this should never fail.
     ReturnOp getGuardReturn() {
+      assert(!guard().empty() && "this transition has no guard");
       return cast<ReturnOp>(guard().front().getTerminator());
     }
 
+    /// Return whether this transition has a guard.
+    bool hasGuard() {
+      return !guard().empty();
+    }
+
+    /// Return whether this transition has an action.
+    bool hasAction() {
+      return !action().empty();
+    }
+
+    /// Returns true if this transition is always taken.
     bool isAlwaysTaken();
   }];
 

--- a/lib/Dialect/FSM/FSMOps.cpp
+++ b/lib/Dialect/FSM/FSMOps.cpp
@@ -259,6 +259,9 @@ StateOp TransitionOp::getNextState() {
 }
 
 bool TransitionOp::isAlwaysTaken() {
+  if (!hasGuard())
+    return true;
+
   auto guardReturn = getGuardReturn();
   if (guardReturn.getNumOperands() == 0)
     return true;
@@ -272,24 +275,26 @@ bool TransitionOp::isAlwaysTaken() {
 
 LogicalResult TransitionOp::canonicalize(TransitionOp op,
                                          PatternRewriter &rewriter) {
-  auto guardReturn = op.getGuardReturn();
-  if (guardReturn.getNumOperands() == 1)
-    if (auto constantOp = guardReturn.getOperand(0)
-                              .getDefiningOp<mlir::arith::ConstantOp>()) {
-      // Simplify when the guard region returns a constant value.
-      if (constantOp.getValue().cast<BoolAttr>().getValue()) {
-        // Replace the original return op with a new one without any operands
-        // if the constant is TRUE.
-        rewriter.setInsertionPoint(guardReturn);
-        rewriter.create<fsm::ReturnOp>(guardReturn.getLoc());
-        rewriter.eraseOp(guardReturn);
-      } else {
-        // Erase the whole transition op if the constant is FALSE, because the
-        // transition will never be taken.
-        rewriter.eraseOp(op);
+  if (op.hasGuard()) {
+    auto guardReturn = op.getGuardReturn();
+    if (guardReturn.getNumOperands() == 1)
+      if (auto constantOp = guardReturn.getOperand(0)
+                                .getDefiningOp<mlir::arith::ConstantOp>()) {
+        // Simplify when the guard region returns a constant value.
+        if (constantOp.getValue().cast<BoolAttr>().getValue()) {
+          // Replace the original return op with a new one without any operands
+          // if the constant is TRUE.
+          rewriter.setInsertionPoint(guardReturn);
+          rewriter.create<fsm::ReturnOp>(guardReturn.getLoc());
+          rewriter.eraseOp(guardReturn);
+        } else {
+          // Erase the whole transition op if the constant is FALSE, because the
+          // transition will never be taken.
+          rewriter.eraseOp(op);
+        }
+        return success();
       }
-      return success();
-    }
+  }
 
   return failure();
 }
@@ -300,7 +305,7 @@ LogicalResult TransitionOp::verify() {
            << nextState() << "`";
 
   // Verify the action region.
-  if (action().front().getTerminator()->getNumOperands() != 0)
+  if (hasAction() && action().front().getTerminator()->getNumOperands() != 0)
     return emitOpError("action region must not return any value");
 
   // Verify the transition is located in the correct region.

--- a/test/Dialect/FSM/basics.mlir
+++ b/test/Dialect/FSM/basics.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s | FileCheck %s
+// RUN: circt-opt --split-input-file %s | FileCheck %s
 
 // CHECK: fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE", stateType = i1} {
 // CHECK:   %cnt = fsm.variable "cnt" {initValue = 0 : i16} : i16
@@ -103,4 +103,51 @@ func @qux() {
   %in1 = arith.constant false
   %out1 = fsm.trigger %foo_inst(%in1) : (i1) -> i1
   return
+}
+
+// -----
+
+// Optional guard and action regions
+
+// CHECK:   fsm.machine @foo(%[[VAL_0:.*]]: i1) -> i1 attributes {initialState = "A", stateType = i1} {
+// CHECK:           %[[VAL_1:.*]] = fsm.variable "cnt" {initValue = 0 : i16} : i16
+// CHECK:           fsm.state "A" output {
+// CHECK:             fsm.output %[[VAL_0]] : i1
+// CHECK:           } transitions {
+// CHECK:             fsm.transition @A action {
+// CHECK:             }
+// CHECK:           }
+// CHECK:           fsm.state "B" output {
+// CHECK:             fsm.output %[[VAL_0]] : i1
+// CHECK:           } transitions {
+// CHECK:             fsm.transition @B guard {
+// CHECK:             }
+// CHECK:           }
+// CHECK:           fsm.state "C" output {
+// CHECK:             fsm.output %[[VAL_0]] : i1
+// CHECK:           } transitions {
+// CHECK:             fsm.transition @C
+// CHECK:           }
+// CHECK:         }
+fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "A", stateType = i1} {
+  %cnt = fsm.variable "cnt" {initValue = 0 : i16} : i16
+
+  fsm.state "A" output  {
+    fsm.output %arg0 : i1
+  } transitions {
+    fsm.transition @A action  {
+    }
+  }
+
+  fsm.state "B" output  {
+    fsm.output %arg0 : i1
+  } transitions {
+    fsm.transition @B guard {}
+  }
+
+  fsm.state "C" output  {
+    fsm.output %arg0 : i1
+  } transitions {
+    fsm.transition @C
+  }
 }


### PR DESCRIPTION
Guard and action regions are now optional. This is already stated in the dialect rationale, but was not implemented.