### PR TITLE
[FIRRTL] check flip orientation in connect operations

### DIFF
--- a/docs/RationaleFIRRTL.md
+++ b/docs/RationaleFIRRTL.md
@@ -235,7 +235,7 @@ As an example of the second problem, consider the following circuit:
 ```scala
 module Bar:
   output a: { flip a: UInt<1> }
-  input b: { flip b: UInt<1> }
+  input b: { flip a: UInt<1> }
 
   b <= a
 ```
@@ -247,7 +247,7 @@ circuit:
 ``` scala
 module Bar:
   input a: { a: UInt<1> }
-  output b: { b: UInt<1> }
+  output b: { a: UInt<1> }
 
   b <= a
 ```

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -129,11 +129,10 @@ protected:
   using Type::Type;
 };
 
-/// Returns whether the two types are equivalent. See the FIRRTL spec for the
-/// full definition of type equivalence. This predicate differs from the spec in
-/// that it only compares passive types. Because of how the FIRRTL dialect uses
-/// flip types in module ports and aggregates, this definition, unlike the spec,
-/// ignores flips.
+/// Returns whether the two types are equivalent.  This implements the exact
+/// definition of type equivalence in the FIRRTL spec.  If the types being
+/// compared have any outer flips that encode FIRRTL module directions (input or
+/// output), these should be stripped before using this method.
 bool areTypesEquivalent(FIRRTLType destType, FIRRTLType srcType);
 
 /// Returns true if two types are weakly equivalent.  See the FIRRTL spec,

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -492,6 +492,8 @@ static bool areBundleElementsEquivalent(BundleType::BundleElement destElement,
                                         BundleType::BundleElement srcElement) {
   if (destElement.name != srcElement.name)
     return false;
+  if (destElement.isFlip != srcElement.isFlip)
+    return false;
 
   return areTypesEquivalent(destElement.type, srcElement.type);
 }

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2793,6 +2793,8 @@ ParseResult FIRStmtParser::parseLeadingExpStmt(Value lhs) {
 
   locationProcessor.setLoc(loc);
 
+  auto lhsType = lhs.getType().cast<FIRRTLType>();
+  auto rhsType = rhs.getType().cast<FIRRTLType>();
   auto lhsPType = lhs.getType().cast<FIRRTLType>().getPassiveType();
   auto rhsPType = rhs.getType().cast<FIRRTLType>().getPassiveType();
   if (lhsPType == rhsPType && false) {
@@ -2804,9 +2806,9 @@ ParseResult FIRStmtParser::parseLeadingExpStmt(Value lhs) {
   }
 
   if (kind == FIRToken::less_equal) {
-    if (!areTypesEquivalent(lhsPType, rhsPType))
+    if (!areTypesEquivalent(lhsType, rhsType))
       return emitError(loc, "cannot connect non-equivalent type ")
-             << rhsPType << " to " << lhsPType;
+             << rhsType << " to " << lhsType;
     emitConnect(builder, lhs, rhs);
   } else {
     assert(kind == FIRToken::less_minus && "unexpected kind");

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2798,8 +2798,8 @@ ParseResult FIRStmtParser::parseLeadingExpStmt(Value lhs) {
 
   auto lhsType = lhs.getType().cast<FIRRTLType>();
   auto rhsType = rhs.getType().cast<FIRRTLType>();
-  auto lhsPType = lhs.getType().cast<FIRRTLType>().getPassiveType();
-  auto rhsPType = rhs.getType().cast<FIRRTLType>().getPassiveType();
+  auto lhsPType = lhsType.getPassiveType();
+  auto rhsPType = rhsType.getPassiveType();
   if (lhsPType == rhsPType && false) {
     if (lhsPType.hasUninferredWidth())
       builder.create<ConnectOp>(lhs, rhs);

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1689,7 +1689,10 @@ void FIRStmtParser::emitInvalidate(Value val, Flow flow) {
 void FIRStmtParser::connectDebugValue(ImplicitLocOpBuilder &builder, Value dst,
                                       Value src) {
   auto type = dst.getType().cast<FIRRTLType>();
-  if (!type.containsAnalog()) {
+  auto stype = src.getType().cast<FIRRTLType>();
+  // If simple direct connect is possible, emit it.
+  // Non-passive source types require connect components individually
+  if (!type.containsAnalog() && stype.isPassive()) {
     builder.create<ConnectOp>(dst, src);
   } else if (type.isa<AnalogType>()) {
     builder.create<AttachOp>(SmallVector{dst, src});

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2798,15 +2798,6 @@ ParseResult FIRStmtParser::parseLeadingExpStmt(Value lhs) {
 
   auto lhsType = lhs.getType().cast<FIRRTLType>();
   auto rhsType = rhs.getType().cast<FIRRTLType>();
-  auto lhsPType = lhsType.getPassiveType();
-  auto rhsPType = rhsType.getPassiveType();
-  if (lhsPType == rhsPType && false) {
-    if (lhsPType.hasUninferredWidth())
-      builder.create<ConnectOp>(lhs, rhs);
-    else
-      builder.create<StrictConnectOp>(lhs, rhs);
-    return success();
-  }
 
   if (kind == FIRToken::less_equal) {
     if (!areTypesEquivalent(lhsType, rhsType))

--- a/test/Dialect/FIRRTL/connect-errors.fir
+++ b/test/Dialect/FIRRTL/connect-errors.fir
@@ -1,0 +1,20 @@
+; RUN: circt-translate -import-firrtl -verify-diagnostics --split-input-file %s
+
+circuit Foo:
+  module Foo:
+    output a: { flip a: UInt<1> }
+    output b: { a: UInt<1> }
+
+; expected-error @+1 {{cannot connect non-equivalent}}
+    b <= a
+
+;// -----
+
+circuit Bar:
+; expected-note @+1 {{left-hand-side}}
+  module Bar:
+    output a: { flip a: UInt<1> }
+    input b: { flip a: UInt<1> }
+
+; expected-error @+1 {{invalid flow}}
+    b <= a

--- a/test/Dialect/FIRRTL/parse-name-preservation.fir
+++ b/test/Dialect/FIRRTL/parse-name-preservation.fir
@@ -17,8 +17,10 @@ circuit Bar :
     ; type of the original wire.
     wire flip: {flip a: UInt<1>}
     ; CHECK: %_flip = firrtl.wire  : !firrtl.bundle<a flip: uint<1>>
+    ; CHECK-NEXT: [[_flip_0:%.+]] = firrtl.subfield %_flip(0)
     ; CHECK: %flip = firrtl.wire sym @flip  : !firrtl.bundle<a: uint<1>>
-    ; CHECK-NOT: firrtl.connect %flip, %_flip
+    ; CHECK-NEXT: [[flip_0:%.+]] = firrtl.subfield %flip(0)
+    ; CHECK-NEXT: firrtl.connect [[flip_0]], [[_flip_0]]
 
     ; Analog values should be tapped with a node.
     wire analog: Analog<1>

--- a/test/Dialect/FIRRTL/parse-name-preservation.fir
+++ b/test/Dialect/FIRRTL/parse-name-preservation.fir
@@ -18,7 +18,7 @@ circuit Bar :
     wire flip: {flip a: UInt<1>}
     ; CHECK: %_flip = firrtl.wire  : !firrtl.bundle<a flip: uint<1>>
     ; CHECK: %flip = firrtl.wire sym @flip  : !firrtl.bundle<a: uint<1>>
-    ; CHECK: firrtl.connect %flip, %_flip
+    ; CHECK-NOT: firrtl.connect %flip, %_flip
 
     ; Analog values should be tapped with a node.
     wire analog: Analog<1>


### PR DESCRIPTION
* Now we reject these invalid connect's in the parser (see test, from docs)
* verifier rejects `firrtl.connect`'s with these as well

This helps better match SFC behavior, and is useful for when `firrtl.partialconnect` is dropped.
In particular before this types could be "equivalent" but not "weakly equivalent", which is unexpected.

The name-preservation taps on non-passive types will be more verbose, connecting components individually.
This is because the name-preservation wire is made with a passive type, which this change makes illegal (to bulk connect to the original wire's non-passive type).