### PR TITLE
FIREmitter: give strictconnect same invalid treatment, add test

### DIFF
--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -608,7 +608,8 @@ void Emitter::emitStatement(InvalidValueOp op) {
   // a connect.
   if (llvm::all_of(op->getUses(), [&](OpOperand &use) {
         return use.getOperandNumber() == 1 &&
-               isa<ConnectOp, PartialConnectOp>(use.getOwner());
+               isa<ConnectOp, PartialConnectOp, StrictConnectOp>(
+                   use.getOwner());
       }))
     return;
 

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -100,9 +100,14 @@ firrtl.circuit "Foo" {
     %someInst_someIn, %someInst_someOut = firrtl.instance someInst @Simple(in someIn: !firrtl.uint<1>, out someOut: !firrtl.uint<1>)
     firrtl.connect %someInst_someIn, %ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %someOut, %someInst_someOut : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK-NOT: _invalid
     // CHECK: someOut is invalid
     %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
     firrtl.connect %someOut, %invalid_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK-NOT: _invalid
+    // CHECK: someOut is invalid
+    %invalid_ui2 = firrtl.invalidvalue : !firrtl.uint<1>
+    firrtl.strictconnect %someOut, %invalid_ui2 : !firrtl.uint<1>
     // CHECK: attach(an0, an1)
     %an0 = firrtl.wire : !firrtl.analog<1>
     %an1 = firrtl.wire : !firrtl.analog<1>


### PR DESCRIPTION
Noticed while working on #3027.

This has conflicts/ordering problems with that PR, I'll update/resolve as needed.