### PR TITLE
[FIRRTL][Dedup] Improve error when module is both NoDedup and MustDedup

### DIFF
--- a/test/Dialect/FIRRTL/dedup-errors.mlir
+++ b/test/Dialect/FIRRTL/dedup-errors.mlir
@@ -24,6 +24,22 @@ firrtl.circuit "MustDedup" attributes {annotations = [{
       class = "firrtl.transforms.MustDeduplicateAnnotation",
       modules = ["~MustDedup|Test0", "~MustDedup|Test1"]
     }]} {
+  // expected-note@below {{module marked NoDedup}}
+  firrtl.module @Test0() attributes {annotations = [{class = "firrtl.transforms.NoDedupAnnotation"}]} { }
+  firrtl.module @Test1() { }
+  firrtl.module @MustDedup() {
+    firrtl.instance test0 @Test0()
+    firrtl.instance test1 @Test1()
+  }
+}
+
+// -----
+
+// expected-error@below {{module "Test1" not deduplicated with "Test0"}}
+firrtl.circuit "MustDedup" attributes {annotations = [{
+      class = "firrtl.transforms.MustDeduplicateAnnotation",
+      modules = ["~MustDedup|Test0", "~MustDedup|Test1"]
+    }]} {
   firrtl.module @MustDedup() {
     firrtl.instance test0 @Test0()
     firrtl.instance test1 @Test1()


### PR DESCRIPTION
When a module is not deduplicated due to a NoDedup annotation, the
equivalence checker would compare the module bodies, missing the fact
that the annotation was what blocked deduplication.

This also fixes a bug when the NoDedup and MustDedup annotation pointed
at the same module.  We didn't record the presence of the module when it
was marked NoDedup which caused the MustDedup annotation to claim that
the referenced module did not exist.