### PR TITLE
[FIRRTL] Make dedup respect declaration order

### DIFF
--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -501,3 +501,17 @@ firrtl.circuit "MustDedup" attributes {annotations = [{
     firrtl.instance simple1 @Simple1()
   }
 }
+
+// Check that the declaration order of modules determines deduplication order,
+// not instantiation order.
+//
+// CHECK-LABEL: firrtl.circuit "DeclarationOrderNotInstantiationOrder"
+firrtl.circuit "DeclarationOrderNotInstantiationOrder" {
+  // CHECK-NEXT: firrtl.module private @X
+  firrtl.module private @X(in %a: !firrtl.uint<1>) {}
+  firrtl.module private @Y(in %a: !firrtl.uint<1>) {}
+  firrtl.module @DeclarationOrderNotInstantiationOrder() {
+    %y_a = firrtl.instance y @Y(in a: !firrtl.uint<1>)
+    %x_a = firrtl.instance x @X(in a: !firrtl.uint<1>)
+  }
+}


### PR DESCRIPTION
Change FIRRTL's deduplication pass to use module declaration order when
determining whether module A should deduplicate into module B or vice
versa.

Fixes #3033.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>