### PR TITLE
[CombFolds] Add a canonicalizer for andr, orr + replicate

### DIFF
--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -1042,10 +1042,9 @@ hw.module @combine_icmp_compare_concat0(%thing: i3) -> (a: i1) {
   %c0 = hw.constant 0 : i7
   %1 = comb.icmp ne %0, %c0 : i7
 
-  // CHECK: %c0_i6 = hw.constant 0 : i6
-  // CHECK: %0 = comb.replicate %thing : (i3) -> i6
-  // CHECK: %1 = comb.icmp ne %0, %c0_i6 : i6
-  // CHECK: hw.output %1 : i1
+  // CHECK: %c0_i3 = hw.constant 0 : i3
+  // CHECK: %0 = comb.icmp ne %thing, %c0_i3 : i3
+  // CHECK: hw.output %0 : i1
   hw.output %1 : i1
 }
 
@@ -1070,10 +1069,9 @@ hw.module @combine_icmp_compare_concat2(%thing: i3) -> (a: i1) {
   %1 = comb.icmp eq %0, %c0 : i8
   hw.output %1 : i1
 
-  // CHECK: %c0_i6 = hw.constant 0 : i6
-  // CHECK: %0 = comb.replicate %thing : (i3) -> i6
-  // CHECK: %1 = comb.icmp eq %0, %c0_i6 : i6
-  // CHECK: hw.output %1 : i1
+  // CHECK: %c0_i3 = hw.constant 0 : i3
+  // CHECK: %0 = comb.icmp eq %thing, %c0_i3 : i3
+  // CHECK: hw.output %0 : i1
 }
 
 // CHECK-LABEL: hw.module @combine_icmp_compare_known_bits0
@@ -1331,4 +1329,23 @@ hw.module @muxCommonOp(%cond: i1,
  
   // CHECK: hw.output [[O1]], [[O2]], [[O3]]
   hw.output %o1, %o2, %o3 : i128, i128, i128
+}
+
+// CHECK-LABEL: hw.module @ReductionReplicate(
+hw.module @ReductionReplicate(%r: i4) -> (a:i1, b:i1, c:i1, d:i1) {
+  %allones = hw.constant -1 : i32
+  %zero = hw.constant 0 : i32
+  %0 = comb.replicate %r : (i4) -> i32
+  // CHECK:      %c0_i4 = hw.constant 0 : i4
+  // CHECK-NEXT: %c-1_i4 = hw.constant -1 : i4
+  // CHECK-NEXT: [[A:%.+]] = comb.icmp eq %r, %c-1_i4
+  // CHECK-NEXT: [[B:%.+]] = comb.icmp eq %r, %c0_i4
+  // CHECK-NEXT: [[C:%.+]] = comb.icmp ne %r, %c-1_i4
+  // CHECK-NEXT: [[D:%.+]] = comb.icmp ne %r, %c0_i4
+  %a = comb.icmp eq %0, %allones : i32
+  %b = comb.icmp eq %0, %zero : i32
+  %c = comb.icmp ne %0, %allones : i32
+  %d = comb.icmp ne %0, %zero : i32
+  // CHECK-NEXT: hw.output [[A]], [[B]], [[C]], [[D]]
+  hw.output %a, %b, %c, %d: i1, i1, i1, i1
 }


### PR DESCRIPTION
This implements following canonicalizers which improve SiFive's internal designs. 
```
eq(replicate(v), 0) ==> v == 0
eq(replicate(v), -1) ===> v == -1
neq(replicate(v), 0) ==> v != 0
neq(replicate(v), -1) ===> v != -1
```
Close #3036