### PR TITLE
FIRRTLFolds: don't crash on vector's connected to wire w/invalid

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1452,7 +1452,7 @@ static LogicalResult canonicalizeSingleSetConnect(StrictConnectOp op,
   if (srcValueOp) {
     // Replace with constant zero.
     if (isa<InvalidValueOp>(srcValueOp)) {
-      if (op.dest().getType().isa<BundleType>())
+      if (op.dest().getType().isa<BundleType, FVectorType>())
         return failure();
       if (op.dest().getType().isa<ClockType, AsyncResetType, ResetType>())
         replacement = rewriter.create<SpecialConstantOp>(

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2299,4 +2299,14 @@ firrtl.module @Issue2314(out %clock: !firrtl.clock, out %reset: !firrtl.reset, o
   // CHECK: firrtl.strictconnect %asyncReset, %[[zero_asyncReset]]
 }
 
+// Crasher from issue #3043
+// CHECK-LABEL: @Issue3043
+firrtl.module @Issue3043(out %a: !firrtl.vector<uint<5>, 3>) {
+  %_b = firrtl.wire  : !firrtl.vector<uint<5>, 3>
+  %b = firrtl.node sym @b %_b  : !firrtl.vector<uint<5>, 3>
+  %invalid = firrtl.invalidvalue : !firrtl.vector<uint<5>, 3>
+  firrtl.strictconnect %_b, %invalid : !firrtl.vector<uint<5>, 3>
+  firrtl.connect %a, %_b : !firrtl.vector<uint<5>, 3>, !firrtl.vector<uint<5>, 3>
+}
+
 }


### PR DESCRIPTION
Fixes #3043.
(see that issue for example/crasher details)