### PR TITLE
[FIRRTL] create more strictconnect's (mkConnect -> emitConnect, enable strictconnect gen in emitConnect)

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -33,8 +33,7 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
   // If the types are the exact same we can just connect them.
   if (dstType == srcType) {
     // Strict connect does not allow uninferred widths.
-    // TODO: enable strict connect.
-    if (true || dstType.hasUninferredWidth())
+    if (dstType.hasUninferredWidth())
       builder.create<ConnectOp>(dst, src);
     else
       builder.create<StrictConnectOp>(dst, src);

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -106,7 +106,7 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
 
   // Strict connect requires the types to be completely equal, including
   // connecting uint<1> to abstract reset types.
-  if (dstType == srcType)
+  if (dstType == src.getType())
     builder.create<StrictConnectOp>(dst, src);
   else
     builder.create<ConnectOp>(dst, src);

--- a/lib/Dialect/FIRRTL/Transforms/LowerCHIRRTL.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerCHIRRTL.cpp
@@ -371,17 +371,8 @@ void LowerCHIRRTLPass::replaceMem(Operation *cmem, StringRef name,
     auto clock = memBuilder.create<SubfieldOp>(memoryPort, "clk");
     emitInvalid(memBuilder, clock);
 
-    // Initialization at the MemoryPortOp.  Use helper to connect if the
-    // address driver is larger than the port width.
-    auto addressLHS = address.getType().cast<FIRRTLType>().getPassiveType();
-    auto addressRHS =
-        cmemoryPortAccess.index().getType().cast<FIRRTLType>().getPassiveType();
-    if (addressLHS != addressRHS && addressLHS.getBitWidthOrSentinel() >= 0 &&
-        addressLHS.getBitWidthOrSentinel() < addressRHS.getBitWidthOrSentinel())
-      emitConnect(portBuilder, address, cmemoryPortAccess.index());
-    else
-      mkConnect(portBuilder, address, cmemoryPortAccess.index());
-
+    // Initialization at the MemoryPortOp.
+    emitConnect(portBuilder, address, cmemoryPortAccess.index());
     // Sequential+Read ports have a more complicated "enable inference".
     auto useEnableInference = isSequential && portKind == MemOp::PortKind::Read;
     auto *addressOp = cmemoryPortAccess.index().getDefiningOp();

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -800,10 +800,7 @@ bool TypeLoweringVisitor::visitStmt(StrictConnectOp op) {
     Value dest = getSubWhatever(op.dest(), field.index());
     if (field.value().isOutput)
       std::swap(src, dest);
-    if (src.getType().isa<AnalogType>())
-      builder->create<AttachOp>(ArrayRef<Value>{dest, src});
-    else
-      builder->create<StrictConnectOp>(dest, src);
+    builder->create<StrictConnectOp>(dest, src);
   }
   return true;
 }

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -79,16 +79,6 @@ struct NlaNameNewSym {
 };
 } // end anonymous namespace
 
-static void mkConnect(ImplicitLocOpBuilder *builder, Value dst, Value src) {
-  auto dstType = dst.getType().cast<FIRRTLType>();
-  auto srcType = src.getType().cast<FIRRTLType>();
-
-  if (srcType == dstType)
-    builder->create<StrictConnectOp>(dst, src);
-  else
-    builder->create<ConnectOp>(dst, src);
-}
-
 /// Return true if the type has more than zero bitwidth.
 static bool hasZeroBitWidth(FIRRTLType type) {
   return TypeSwitch<FIRRTLType, bool>(type)
@@ -786,7 +776,7 @@ bool TypeLoweringVisitor::visitStmt(ConnectOp op) {
     Value dest = getSubWhatever(op.dest(), field.index());
     if (field.value().isOutput)
       std::swap(src, dest);
-    mkConnect(builder, dest, src);
+    emitConnect(*builder, dest, src);
   }
   return true;
 }
@@ -879,13 +869,13 @@ bool TypeLoweringVisitor::visitDecl(MemOp op) {
               newMemories[field.index].getResult(index), fieldIndex);
           if (rType.getElement(fieldIndex).isFlip)
             std::swap(realOldField, newField);
-          mkConnect(builder, newField, realOldField);
+          emitConnect(*builder, newField, realOldField);
         }
       } else {
         for (auto mem : newMemories) {
           auto newField =
               builder->create<SubfieldOp>(mem.getResult(index), fieldIndex);
-          mkConnect(builder, newField, oldField);
+          emitConnect(*builder, newField, oldField);
         }
       }
     }

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -762,11 +762,7 @@ void TypeLoweringVisitor::lowerSAWritePath(Operation *op,
       for (int i = writePath.size() - 2; i >= 0; --i)
         leaf = cloneAccess(builder, writePath[i], leaf);
 
-      if (isa<ConnectOp, StrictConnectOp>(op) ||
-          leaf.getType() == op->getOperand(1).getType())
-        mkConnect(builder, leaf, op->getOperand(1));
-      else
-        emitConnect(*builder, leaf, op->getOperand(1));
+      emitConnect(*builder, leaf, op->getOperand(1));
     });
   }
 }

--- a/test/Dialect/FIRRTL/lower-chirrtl.mlir
+++ b/test/Dialect/FIRRTL/lower-chirrtl.mlir
@@ -285,7 +285,7 @@ firrtl.module @AddressLargerThanPort(in %clock: !firrtl.clock, in %addr: !firrtl
   // CHECK: [[ADDR:%.+]] = firrtl.subfield %mem_r(0)
   %addr_node = firrtl.node %addr  : !firrtl.uint<3>
   // CHECK: [[TRUNC:%.+]] = firrtl.tail %addr_node, 1
-  // CHECK: firrtl.connect [[ADDR]], [[TRUNC]]
+  // CHECK: firrtl.strictconnect [[ADDR]], [[TRUNC]]
   chirrtl.memoryport.access %r_port[%addr_node], %clock : !chirrtl.cmemoryport, !firrtl.uint<3>, !firrtl.clock
   // CHECK: firrtl.connect
   firrtl.connect %out, %r_data : !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -85,10 +85,10 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %_t_2 = firrtl.wire : !firrtl.vector<uint<1>, 12>
     wire _t_2 : UInt<1>[12]
 
-    ; CHECK: firrtl.connect %_t, %_t_2 : !firrtl.vector<uint<1>, 12>, !firrtl.vector<uint<1>, 12>
+    ; CHECK: firrtl.strictconnect %_t, %_t_2 : !firrtl.vector<uint<1>, 12>
     _t <= _t_2
 
-    ; CHECK: firrtl.connect %_t, %_t_2
+    ; CHECK: firrtl.strictconnect %_t, %_t_2
     _t <- _t_2
     
     ; CHECK: [[a0:%.+]] = firrtl.subfield %bundleWithAnalog(0)
@@ -115,6 +115,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     auto is invalid
 
     ; CHECK-NOT: firrtl.connect %reset
+    ; CHECK-NOT: firrtl.strictconnect %reset
     reset is invalid
 
     ; CHECK: %out_0 = firrtl.wire : !firrtl.bundle<member: bundle<0: bundle<clock: clock, reset: uint<1>>>>
@@ -123,14 +124,14 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: [[A:%.+]] = firrtl.subfield %out_0(0) : (!firrtl.bundle<member: bundle<0: bundle<clock: clock, reset: uint<1>>>>) -> !firrtl.bundle<0: bundle<clock: clock, reset: uint<1>>>
     ; CHECK: [[B:%.+]] = firrtl.subfield [[A]](0) : (!firrtl.bundle<0: bundle<clock: clock, reset: uint<1>>>) -> !firrtl.bundle<clock: clock, reset: uint<1>>
     ; CHECK: [[C:%.+]] = firrtl.subfield [[B]](1) : (!firrtl.bundle<clock: clock, reset: uint<1>>) -> !firrtl.uint<1>
-    ; CHECK: firrtl.connect %auto, [[C]] : !firrtl.uint<1>, !firrtl.uint<1>
+    ; CHECK: firrtl.strictconnect %auto, [[C]] : !firrtl.uint<1>
     auto <- out_0.member.0.reset @[Field 173:49]
 
     ; CHECK: %_t_3 = firrtl.wire : !firrtl.vector<uint<1>, 12>
     ; CHECK: [[A:%.+]] = firrtl.subindex %_t_3[0] : !firrtl.vector<uint<1>, 12>
     ; CHECK: %_t_4 = firrtl.wire : !firrtl.vector<uint<1>, 12>
     ; CHECK: [[B:%.+]] = firrtl.subindex %_t_4[0] : !firrtl.vector<uint<1>, 12>
-    ; CHECK: firrtl.connect [[A]], [[B]]
+    ; CHECK: firrtl.strictconnect [[A]], [[B]]
     wire _t_3 : UInt<1>[12] @[Nodes.scala 370:76]
     wire _t_4 : UInt<1>[12]
     _t_3[0] <= _t_4[0] @[Xbar.scala 21:44]
@@ -202,25 +203,25 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %c42_ui10 = firrtl.constant 42 : !firrtl.uint<10>
     ; CHECK: %c171_ui8 = firrtl.constant 171 : !firrtl.uint<8>
     ; CHECK: firrtl.add %c42_ui10, %c171_ui8
-    ; CHECK: firrtl.connect %auto
+    ; CHECK: firrtl.strictconnect %auto
     auto11 <= add(UInt<10>(42), UInt<8>("hAB"))
 
     ; CHECK: %c-85_si8 = firrtl.constant -85 : !firrtl.sint<8>
     sauto <= add(s8, SInt<8>(-85))
 
     ; CHECK: firrtl.when %reset {
-    ; CHECK:   firrtl.connect %_t, %_t_2
+    ; CHECK:   firrtl.strictconnect %_t, %_t_2
     ; CHECK: } else {
-    ; CHECK:   firrtl.connect %_t, %_t_2
+    ; CHECK:   firrtl.strictconnect %_t, %_t_2
     ; CHECK: }
     when reset : _t <= _t_2 else : _t <- _t_2
 
     ; CHECK: firrtl.when %reset {
     ; CHECK:   [[N4A:%.+]] = firrtl.node %_t_2
-    ; CHECK:   firrtl.connect %_t, [[N4A]]
+    ; CHECK:   firrtl.strictconnect %_t, [[N4A]]
     ; CHECK: } else {
     ; CHECK:   [[N4B:%.+]] = firrtl.node %_t_2
-    ; CHECK:   firrtl.connect %_t, [[N4B]]
+    ; CHECK:   firrtl.strictconnect %_t, [[N4B]]
     ; CHECK: }
     when reset :
       node n4 = _t_2
@@ -232,18 +233,18 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: [[TMP:%.+]] = firrtl.constant 4
     ; CHECK: [[COND:%.+]] = firrtl.lt %reset, [[TMP]]
     ; CHECK: firrtl.when [[COND]] {
-    ; CHECK:   firrtl.connect %_t, %_t_2
+    ; CHECK:   firrtl.strictconnect %_t, %_t_2
     ; CHECK: }
     ; CHECK-NOT: else
     when lt(reset, UInt(4)) :   ;; When with no else.
       _t <= _t_2
 
     ; CHECK: firrtl.when %reset  {
-    ; CHECK:   firrtl.connect %_t, %_t_2
+    ; CHECK:   firrtl.strictconnect %_t, %_t_2
     ; CHECK: } else  {
     ; CHECK:   [[COND:%.+]] = firrtl.not %reset
     ; CHECK:   firrtl.when [[COND]]  {
-    ; CHECK:     firrtl.connect %_t, %_t_2
+    ; CHECK:     firrtl.strictconnect %_t, %_t_2
     ; CHECK:   }
     ; CHECK: }
     when reset :
@@ -252,13 +253,13 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       _t <= _t_2
 
     ; CHECK: firrtl.when %reset  {
-    ; CHECK:   firrtl.connect %_t, %_t
+    ; CHECK:   firrtl.strictconnect %_t, %_t
     ; CHECK: } else  {
     ; CHECK:   [[COND:%.+]] = firrtl.not %reset
     ; CHECK:   firrtl.when [[COND]]  {
-    ; CHECK:     firrtl.connect %_t, %_t_2
+    ; CHECK:     firrtl.strictconnect %_t, %_t_2
     ; CHECK:   } else  {
-    ; CHECK:     firrtl.connect %_t, %_t_2
+    ; CHECK:     firrtl.strictconnect %_t, %_t_2
     ; CHECK:   }
     ; CHECK: }
     when reset:
@@ -327,7 +328,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %xyz_in = firrtl.instance xyz @circuit(in in: !firrtl.uint<80>)
     inst xyz of circuit
     ; CHECK: [[PAD:%.*]] = firrtl.pad %i8, 80 : (!firrtl.uint<8>) -> !firrtl.uint<80>
-    ; CHECK: firrtl.connect %xyz_in, [[PAD]] : !firrtl.uint<80>, !firrtl.uint<80>
+    ; CHECK: firrtl.strictconnect %xyz_in, [[PAD]] : !firrtl.uint<80>
     xyz.in <= i8
 
     ; CHECK: %myext_in, %myext_out = firrtl.instance myext @MyExtModule(in in: !firrtl.uint, out out: !firrtl.uint<8>)
@@ -611,7 +612,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     output tmp5: SInt<19>
     tmp5 <= SInt<19>(8)
      ; CHECK: %c8_si19 = firrtl.constant 8 : !firrtl.sint<19>
-     ; CHECK: firrtl.connect %tmp5, %c8_si19 : !firrtl.sint<19>, !firrtl.sint<19>
+     ; CHECK: firrtl.strictconnect %tmp5, %c8_si19 : !firrtl.sint<19>
 
    ; CHECK-LABEL: firrtl.module private @issue347
   module issue347 :
@@ -687,18 +688,20 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
   module TrickyIssue559:
     input input: UInt<1>
     output output: UInt<1>
-    ; CHECK: firrtl.connect %output, %input
+    ; CHECK: firrtl.strictconnect %output, %input
     output <= input
 
   ; CHECK-LABEL: firrtl.module private @CheckInvalids
   module CheckInvalids_in0 :
     input in0 : UInt<1>
     ; CHECK-NOT: firrtl.connect %in0
+    ; CHECK-NOT: firrtl.strictconnect %in0
     in0 is invalid
 
   module CheckInvalids_in1 :
     input in1 : { a : UInt<1>, b : UInt<1> }
     ; CHECK-NOT: firrtl.connect %in1
+    ; CHECK-NOT: firrtl.strictconnect %in1
     in1 is invalid
 
   module CheckInvalids_in2 :
@@ -796,7 +799,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
   module mutableSubIndex606 :
     output io : UInt<1>[8]
     ; CHECK:  %0 = firrtl.subindex %io[0] : !firrtl.vector<uint<1>, 8>
-    ; CHECK: firrtl.connect %0, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
+    ; CHECK: firrtl.strictconnect %0, %c0_ui1 : !firrtl.uint<1>
     io[0] <= UInt<1>("h00")
 
 
@@ -853,11 +856,11 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     cmem a: UInt<1>[8]
 
-    ; CHECK: firrtl.connect %rData, %r
+    ; CHECK: firrtl.strictconnect %rData, %r
     infer mport r = a[rAddr], clock
     rData <= r
 
-    ; CHECK: firrtl.connect %w_data, %wData
+    ; CHECK: firrtl.strictconnect %w_data, %wData
     infer mport w = a[wAddr], clock
     w <= wData
 

--- a/test/Dialect/FIRRTL/parse-locations.fir
+++ b/test/Dialect/FIRRTL/parse-locations.fir
@@ -42,7 +42,7 @@ circuit MyModule :  @[CIRCUIT.scala 127]
     ; CHECK: %1 = firrtl.subfield %out_0(0) {{.*}} loc("Field":173:49)
     ; CHECK: %2 = firrtl.subfield %1(0) {{.*}} loc("Field":173:49)
     ; CHECK: %3 = firrtl.subfield %2(0) : {{.*}} loc("Field":173:49)
-    ; CHECK: firrtl.connect %0, %3 : {{.*}} loc("Field":173:49)
+    ; CHECK: firrtl.strictconnect %0, %3 : {{.*}} loc("Field":173:49)
     auto.out_0 <- out_0.member.0.reset @[Field 173:49]
 
     ; Fused locators: https://github.com/llvm/circt/issues/224

--- a/test/Dialect/FIRRTL/parse-name-preservation.fir
+++ b/test/Dialect/FIRRTL/parse-name-preservation.fir
@@ -10,7 +10,7 @@ circuit Bar :
 
     ; Should use the non-tap wire in expressions.
     a <= in
-    ; CHECK: firrtl.connect %a, %in
+    ; CHECK: firrtl.strictconnect %a, %in
 
     ; When the type is not passive, the tap should be a wire with the passive
     ; type of the original wire.

--- a/test/firtool/connect.fir
+++ b/test/firtool/connect.fir
@@ -4,7 +4,7 @@
 
 ; CHECK-LABEL: @regularConnect
 ; CHECK: %0 = firrtl.pad %b, 5 : (!firrtl.uint<3>) -> !firrtl.uint<5>
-; CHECK: firrtl.connect %a, %0 : !firrtl.uint<5>, !firrtl.uint<5>
+; CHECK: firrtl.strictconnect %a, %0 : !firrtl.uint<5>
 circuit regularConnect :
  module regularConnect :
    output a: UInt<5>
@@ -13,7 +13,7 @@ circuit regularConnect :
 
 ; CHECK-LABEL: @truncatingIntegerConnect
 ; CHECK: %0 = firrtl.tail %b, 2 : (!firrtl.uint<5>) -> !firrtl.uint<3>
-; CHECK: firrtl.connect %a, %0 : !firrtl.uint<3>, !firrtl.uint<3>
+; CHECK: firrtl.strictconnect %a, %0 : !firrtl.uint<3>
 circuit truncatingIntegerConnect :
  module truncatingIntegerConnect :
    output a: UInt<3>
@@ -24,11 +24,11 @@ circuit truncatingIntegerConnect :
 ; CHECK: %0 = firrtl.subfield %a(0) : (!firrtl.bundle<a: uint<5>, b: uint<3>>) -> !firrtl.uint<5>
 ; CHECK: %1 = firrtl.subfield %b(0) : (!firrtl.bundle<a: uint<3>, b: uint<2>>) -> !firrtl.uint<3>
 ; CHECK: %2 = firrtl.pad %1, 5 : (!firrtl.uint<3>) -> !firrtl.uint<5>
-; CHECK: firrtl.connect %0, %2 : !firrtl.uint<5>, !firrtl.uint<5>
+; CHECK: firrtl.strictconnect %0, %2 : !firrtl.uint<5>
 ; CHECK: %3 = firrtl.subfield %a(1) : (!firrtl.bundle<a: uint<5>, b: uint<3>>) -> !firrtl.uint<3>
 ; CHECK: %4 = firrtl.subfield %b(1) : (!firrtl.bundle<a: uint<3>, b: uint<2>>) -> !firrtl.uint<2>
 ; CHECK: %5 = firrtl.pad %4, 3 : (!firrtl.uint<2>) -> !firrtl.uint<3>
-; CHECK: firrtl.connect %3, %5 : !firrtl.uint<3>, !firrtl.uint<3>
+; CHECK: firrtl.strictconnect %3, %5 : !firrtl.uint<3>
 circuit regularBundleConnect :
  module regularBundleConnect :
    output a: { a: UInt<5>, b: UInt<3> }
@@ -39,11 +39,11 @@ circuit regularBundleConnect :
 ; CHECK: %0 = firrtl.subfield %a(0) : (!firrtl.bundle<a: uint<5>, b: uint<3>>) -> !firrtl.uint<5>
 ; CHECK: %1 = firrtl.subfield %b(0) : (!firrtl.bundle<a: uint<6>, b: uint<1>>) -> !firrtl.uint<6>
 ; CHECK: %2 = firrtl.tail %1, 1 : (!firrtl.uint<6>) -> !firrtl.uint<5>
-; CHECK: firrtl.connect %0, %2 : !firrtl.uint<5>, !firrtl.uint<5>
+; CHECK: firrtl.strictconnect %0, %2 : !firrtl.uint<5>
 ; CHECK: %3 = firrtl.subfield %a(1) : (!firrtl.bundle<a: uint<5>, b: uint<3>>) -> !firrtl.uint<3>
 ; CHECK: %4 = firrtl.subfield %b(1) : (!firrtl.bundle<a: uint<6>, b: uint<1>>) -> !firrtl.uint<1>
 ; CHECK: %5 = firrtl.pad %4, 3 : (!firrtl.uint<1>) -> !firrtl.uint<3>
-; CHECK: firrtl.connect %3, %5 : !firrtl.uint<3>, !firrtl.uint<3>
+; CHECK: firrtl.strictconnect %3, %5 : !firrtl.uint<3>
 circuit truncatingBundleConnect :
  module truncatingBundleConnect :
    output a: { a: UInt<5>, b: UInt<3> }

--- a/test/firtool/optimizations.fir
+++ b/test/firtool/optimizations.fir
@@ -27,16 +27,16 @@ circuit test_cse :
 
 ; Both adds persist.
 ; NOOPT: %0 = firrtl.add %a, %a
-; NOOPT: firrtl.connect %b, %0
+; NOOPT: firrtl.strictconnect %b, %0
 ; NOOPT: %1 = firrtl.add %a, %a
-; NOOPT: firrtl.connect %c, %1
+; NOOPT: firrtl.strictconnect %c, %1
 
 ; Ands persist.
 ; NOOPT: %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
 ; NOOPT: firrtl.and %a, %c0_ui4
-; NOOPT: firrtl.connect %d,
+; NOOPT: firrtl.strictconnect %d,
 
 ; NOOPT-DAG: %c3_ui4 = firrtl.constant 3 : !firrtl.uint<4>
 ; NOOPT-DAG: %c1_ui4 = firrtl.constant 1 : !firrtl.uint<4>
 ; NOOPT: firrtl.and %c3_ui4, %c1_ui4
-; NOOPT: firrtl.connect %e,
+; NOOPT: firrtl.strictconnect %e,


### PR DESCRIPTION
### Summary

* Replace "mkConnect" helpers, moving to emitConnect
  * (mkConnect's aren't quite the same as emitConnect--they are happy to connect things of different types, where emitConnect will pad/etc as needed)
* Simplify code that conditionally called mkConnect vs emitConnect, let emitConnect handle things (LowerTypes, LowerCHIRRTL)
* Fix small bug in emitConnect preventing creation of strictconnect's after padding performed
  * (type equality check was done on types before the pad/etc) (first commit)
* Update tests
* Fix unnecessary check for analogtype nested within types strictconnect'd -- verifier rejects these

Follow-up to previous connect-related PR's.


