### PR TITLE
ExportVerilog: Add lowering option to always print port direction/type

### DIFF
--- a/docs/VerilogGeneration.md
+++ b/docs/VerilogGeneration.md
@@ -85,6 +85,10 @@ The current set of "style" Lowering Options is:
    information style.  The available styles are:
    * `plain`: `// perf/regress/AndNot.fir:3:10, :7:{10,17}`
    * `wrapInAtSquareBracket`: `// @[perf/regress/AndNot.fir:3:10, :7:{10,17}]`
+ * `disallowPortDeclSharing` (default=`false`).  If true, emit one port per
+   declaration.  Instead of `input a,\n b` this will produce
+   `input a,\n input b`.  When false, ports are emitted using the same
+   declaration when possible.
 
 ### Specifying `LoweringOptions` in a front-end HDL tool
 

--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -100,6 +100,11 @@ struct LoweringOptions {
     Plain,                // Default.
     WrapInAtSquareBracket // Wrap location info in @[..].
   } locationInfoStyle = Plain;
+
+  /// If true, every port is declared separately
+  /// (each includes direction and type (e.g., `input [3:0]`)).
+  /// When false (default), ports share declarations when possible.
+  bool disallowPortDeclSharing = false;
 };
 
 /// Register commandline options for the verilog emitter.

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -4024,16 +4024,19 @@ void ModuleEmitter::emitHWModule(HWModuleOp module) {
     ++portIdx;
 
     // If we have any more ports with the same types and the same direction,
-    // emit them in a list on the same line.
-    while (portIdx != e && portInfo[portIdx].direction == thisPortDirection &&
-           stripUnpackedTypes(portType) ==
-               stripUnpackedTypes(portInfo[portIdx].type)) {
-      StringRef name = getPortVerilogName(module, portInfo[portIdx]);
-      // Append this to the running port decl.
-      os << ",\n";
-      os.indent(startOfNamePos) << name;
-      printUnpackedTypePostfix(portInfo[portIdx].type, os);
-      ++portIdx;
+    // emit them in a list one per line.
+    // Optionally skip this behavior when requested by user.
+    if (!state.options.disallowPortDeclSharing) {
+      while (portIdx != e && portInfo[portIdx].direction == thisPortDirection &&
+             stripUnpackedTypes(portType) ==
+                 stripUnpackedTypes(portInfo[portIdx].type)) {
+        StringRef name = getPortVerilogName(module, portInfo[portIdx]);
+        // Append this to the running port decl.
+        os << ",\n";
+        os.indent(startOfNamePos) << name;
+        printUnpackedTypePostfix(portInfo[portIdx].type, os);
+        ++portIdx;
+      }
     }
 
     if (portIdx != e) {

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -78,6 +78,8 @@ void LoweringOptions::parse(StringRef text, ErrorHandlerT errorHandler) {
       } else {
         errorHandler("expected 'plain' or 'wrapInAtSquareBracket'");
       }
+    } else if (option == "disallowPortDeclSharing") {
+      disallowPortDeclSharing = true;
     } else {
       errorHandler(llvm::Twine("unknown style option \'") + option + "\'");
       // We continue parsing options after a failure.
@@ -104,6 +106,8 @@ std::string LoweringOptions::toString() const {
     options += "emitReplicatedOpsToHeader,";
   if (locationInfoStyle == LocationInfoStyle::WrapInAtSquareBracket)
     options += "locationInfoStyle=wrapInAtSquareBracket,";
+  if (disallowPortDeclSharing)
+    options += "disallowPortDeclSharing,";
 
   if (emittedLineLength != DEFAULT_LINE_LENGTH)
     options += "emittedLineLength=" + std::to_string(emittedLineLength) + ',';
@@ -164,7 +168,8 @@ struct LoweringCLOptions {
           "disallowLocalVariables, verifLabels, emittedLineLength=<n>, "
           "maximumNumberOfTermsPerExpression=<n>, explicitBitcastAddMul, "
           "emitReplicatedOpsToHeader, "
-          "locationInfoStyle={plain,wrapInAtSquareBracket}"),
+          "locationInfoStyle={plain,wrapInAtSquareBracket}, "
+          "disallowPortDeclSharing"),
       llvm::cl::value_desc("option")};
 };
 } // namespace

--- a/test/Conversion/ExportVerilog/port-decl-sharing.mlir
+++ b/test/Conversion/ExportVerilog/port-decl-sharing.mlir
@@ -1,0 +1,31 @@
+// RUN: circt-opt %s -export-verilog --split-input-file | FileCheck %s --match-full-lines
+
+module attributes {circt.loweringOptions = "disallowPortDeclSharing"}{
+// CHECK: module Foo( // dummy:1:1
+// CHECK-NEXT:  input        a,
+// CHECK-NEXT:  input        b,
+// CHECK-NEXT:  output [1:0] a_0,
+// CHECK-NEXT:  output [1:0] b_1);
+// CHECK: endmodule
+hw.module @Foo(%a: i1, %b: i1) -> (a: i2, b: i2) {
+  %ao = comb.concat %a, %b: i1, i1
+  %bo = comb.concat %a, %a: i1, i1
+  hw.output %ao, %bo : i2, i2
+} loc("dummy":1:1)
+}
+
+// -----
+
+module {
+// CHECK: module Foo( // dummy:1:1
+// CHECK-NEXT:  input        a,
+// CHECK-NEXT:               b,
+// CHECK-NEXT:  output [1:0] a_0,
+// CHECK-NEXT:               b_1);
+// CHECK: endmodule
+hw.module @Foo(%a: i1, %b: i1) -> (a: i2, b: i2) {
+  %ao = comb.concat %a, %b: i1, i1
+  %bo = comb.concat %a, %a: i1, i1
+  hw.output %ao, %bo : i2, i2
+} loc("dummy":1:1)
+}


### PR DESCRIPTION
## Summary
Currently we group ports by direction+type and only print that part (e.g., `input [3:0]`) once per group.

For compatibility reasons, it may be useful to always print this information for each port.

Add a new lowering option "noPortGrouping" to control this.


## Comparison
### Default/current:
```verilog
module Foo(     // dummy:1:1
  input        a,
               b,
  input  [4:0] c,
               d,
  output       a_0,
               b_1,
  output [4:0] c_2,
               d_3);
```

### With this option enabled:
```verilog
module Foo(     // dummy:1:1
  input        a,
  input        b,
  input  [4:0] c,
  input  [4:0] d,
  output       a_0,
  output       b_1,
  output [4:0] c_2,
  output [4:0] d_3);
```

## Option naming

Not sure "port grouping" is quite right, it's more about whether we have multiple ports per declaration :sweat_smile: .  Suggestions welcome, or I'll revisit tomorrow :).