### PR TITLE
[FIRRTL] Add output-mlir option to firtool.

### DIFF
--- a/test/firtool/firtool.mlir
+++ b/test/firtool/firtool.mlir
@@ -1,6 +1,6 @@
 // RUN: firtool %s --format=mlir --ir-fir    | circt-opt | FileCheck %s --check-prefix=MLIR
 // RUN: firtool %s --format=mlir -verilog |           FileCheck %s --check-prefix=VERILOG
-// RUN: firtool %s --format=mlir -verilog -output-mlir=%t | FileCheck %s --check-prefix=VERILOG-WITH-MLIR
+// RUN: firtool %s --format=mlir -verilog -output-final-mlir=%t | FileCheck %s --check-prefix=VERILOG-WITH-MLIR
 // RUN: FileCheck %s --input-file=%t --check-prefix=VERILOG-WITH-MLIR-OUT
 
 firrtl.circuit "Top" {

--- a/test/firtool/firtool.mlir
+++ b/test/firtool/firtool.mlir
@@ -1,5 +1,7 @@
 // RUN: firtool %s --format=mlir --ir-fir    | circt-opt | FileCheck %s --check-prefix=MLIR
 // RUN: firtool %s --format=mlir -verilog |           FileCheck %s --check-prefix=VERILOG
+// RUN: firtool %s --format=mlir -verilog -output-mlir=%t | FileCheck %s --check-prefix=VERILOG-WITH-MLIR
+// RUN: FileCheck %s --input-file=%t --check-prefix=VERILOG-WITH-MLIR-OUT
 
 firrtl.circuit "Top" {
   firrtl.module @Top(in %in : !firrtl.uint<8>,
@@ -17,3 +19,13 @@ firrtl.circuit "Top" {
 // VERILOG-NEXT :   output [7:0] out);
 // VERILOG-NEXT :   assign out = in;
 // VERILOG-NEXT : endmodule
+
+// VERILOG-WITH-MLIR-LABEL: module Top(
+// VERILOG-WITH-MLIR-NEXT :   input  [7:0] in,
+// VERILOG-WITH-MLIR-NEXT :   output [7:0] out);
+// VERILOG-WITH-MLIR-NEXT :   assign out = in;
+// VERILOG-WITH-MLIR-NEXT : endmodule
+
+// VERILOG-WITH-MLIR-OUT-LABEL: hw.module @Top(%in: i8) -> (out: i8) {
+// VERILOG-WITH-MLIR-OUT-NEXT:    hw.output %in : i8
+// VERILOG-WITH-MLIR-OUT-NEXT:  }

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -299,9 +299,12 @@ static cl::opt<std::string>
     omirOutFile("output-omir", cl::desc("file name for the output omir"),
                 cl::init(""), cl::cat(mainCategory));
 
-static cl::opt<std::string> mlirOutFile(
-    "output-mlir", cl::desc("Optional file name to output the final MLIR"),
-    cl::init(""), cl::value_desc("filename"), cl::cat(mainCategory));
+static cl::opt<std::string>
+    mlirOutFile("output-final-mlir",
+                cl::desc("Optional file name to output the final MLIR into, in "
+                         "addition to the output requested by -o"),
+                cl::init(""), cl::value_desc("filename"),
+                cl::cat(mainCategory));
 
 static cl::opt<std::string> blackBoxRootPath(
     "blackbox-path",

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -299,6 +299,10 @@ static cl::opt<std::string>
     omirOutFile("output-omir", cl::desc("file name for the output omir"),
                 cl::init(""), cl::cat(mainCategory));
 
+static cl::opt<std::string> mlirOutFile(
+    "output-mlir", cl::desc("Optional file name to output the final MLIR"),
+    cl::init(""), cl::value_desc("filename"), cl::cat(mainCategory));
+
 static cl::opt<std::string> blackBoxRootPath(
     "blackbox-path",
     cl::desc("Optional path to use as the root of black box annotations"),
@@ -650,6 +654,19 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
       outputFormat == OutputIRSV || outputFormat == OutputIRVerilog) {
     auto outputTimer = ts.nest("Print .mlir output");
     module->print(outputFile.getValue()->os());
+  }
+
+  // If requested, print the final MLIR into mlirOutFile.
+  if (!mlirOutFile.empty()) {
+    std::string mlirOutError;
+    auto mlirFile = openOutputFile(mlirOutFile, &mlirOutError);
+    if (!mlirFile) {
+      llvm::errs() << mlirOutError;
+      return failure();
+    }
+
+    module->print(mlirFile->os());
+    mlirFile->keep();
   }
 
   // We intentionally "leak" the Module into the MLIRContext instead of


### PR DESCRIPTION
This works similarly to output-omir: if specified, the final MLIR is
written into this file. This is useful to get the final MLIR output
alongside some other output, especially split-verilog.

This would close https://github.com/llvm/circt/issues/2946.