### PR TITLE
locationStyleInfo: add doc blurb, add to cl::opt help

### DIFF
--- a/docs/VerilogGeneration.md
+++ b/docs/VerilogGeneration.md
@@ -81,6 +81,10 @@ The current set of "style" Lowering Options is:
 
  * `emittedLineLength` (default=`90`).  This is the target width of lines in an
    emitted Verilog source file in columns.
+ * `locationInfoStyle` (default=`plain`).  This option controls emitted location
+   information style.  The available styles are:
+   * `plain`: `// perf/regress/AndNot.fir:3:10, :7:{10,17}`
+   * `wrapInAtSquareBracket`: `// @[perf/regress/AndNot.fir:3:10, :7:{10,17}]`
 
 ### Specifying `LoweringOptions` in a front-end HDL tool
 

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -163,7 +163,8 @@ struct LoweringCLOptions {
           "noAlwaysComb, exprInEventControl, disallowPackedArrays, "
           "disallowLocalVariables, verifLabels, emittedLineLength=<n>, "
           "maximumNumberOfTermsPerExpression=<n>, explicitBitcastAddMul, "
-          "emitReplicatedOpsToHeader"),
+          "emitReplicatedOpsToHeader, "
+          "locationInfoStyle={plain,wrapInAtSquareBracket}"),
       llvm::cl::value_desc("option")};
 };
 } // namespace


### PR DESCRIPTION
Assuming we want to advertise the option for use, add it to docs and the `--help` output to aid discoverability.

Will conflict with #3046, where I just now included similar additions for that option as well :).

Writing it up, it does seem like a `None` option would make sense (or at least a person reading docs might ask "but what if I don't want location information" is my thinking)? I think that is what `--strip-debug-info` does.  Anyway that can wait :).  For now lets document what's available now! :+1: 