### PR TITLE
[LowerToHW][SVExtractTestCode] Don't extract assertions from testbench

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -981,8 +981,11 @@ FIRRTLModuleLowering::lowerModule(FModuleOp oldModule, Block *topLevelModule,
 
   // If this is in the test harness, make sure it goes to the test directory.
   if (auto testBenchDir = loweringState.getTestBenchDirectory())
-    if (loweringState.isInTestHarness(oldModule))
+    if (loweringState.isInTestHarness(oldModule)) {
       newModule->setAttr("output_file", testBenchDir);
+      newModule->setAttr("firrtl.extract.do_not_extract",
+                         builder.getUnitAttr());
+    }
 
   bool failed = false;
   // Remove ForceNameAnnotations by generating verilogNames on instances.

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -387,6 +387,13 @@ void SVExtractTestCodeImplPass::runOnOperation() {
       // modules.
       if (isBound(rtlmod))
         continue;
+
+      // In the module is in test harness, we don't have to extract from it.
+      if (rtlmod->hasAttr("firrtl.extract.do_not_extract")) {
+        rtlmod->removeAttr("firrtl.extract.do_not_extract");
+        continue;
+      }
+
       doModule(rtlmod, isAssert, "_assert", assertDir, assertBindFile);
       doModule(rtlmod, isAssume, "_assume", assumeDir, assumeBindFile);
       doModule(rtlmod, isCover, "_cover", coverDir, coverBindFile);

--- a/test/Conversion/FIRRTLToHW/module-hierarchy-file.mlir
+++ b/test/Conversion/FIRRTLToHW/module-hierarchy-file.mlir
@@ -54,3 +54,24 @@ firrtl.circuit "MyDUT" {
   firrtl.module @MyDUT() attributes {annotations = [
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {}
 }
+
+// -----
+
+// Check that "firrtl.extract.do_not_extract" is added to modules in test harness.
+firrtl.circuit "MyTestHarness" attributes {annotations = [ {class = "sifive.enterprise.firrtl.TestBenchDirAnnotation", dirname = "tb"}]}
+{
+  // CHECK-LABEL: hw.module private @MyDUT() {
+  firrtl.module private @MyDUT() attributes {annotations = [
+      {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {}
+
+  // CHECK-LABEL: hw.module private @Testbench
+  // CHECK-SAME:  firrtl.extract.do_not_extract
+  firrtl.module private @Testbench() {}
+
+  // CHECK-LABEL: hw.module @MyTestHarness
+  // CHECK-SAME:  firrtl.extract.do_not_extract
+  firrtl.module @MyTestHarness() {
+    firrtl.instance myDUT @MyDUT()
+    firrtl.instance myTestBench @Testbench()
+  }
+}

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -80,3 +80,17 @@ module attributes {firrtl.extract.assert =  #hw.output_file<"dir3/", excludeFrom
     hw.instance "submodule" @AlreadyExtracted(clock: %clock: i1) -> () {doNotPrint = true}
   }
 }
+
+// -----
+
+// Check that we don't extract assertions from a module with "firrtl.extract.do_not_extract" attribute.
+//
+// CHECK-NOT:  hw.module @ModuleInTestHarness_assert
+// CHECK-NOT:  firrtl.extract.do_not_extract
+module attributes {firrtl.extract.assert =  #hw.output_file<"dir3/", excludeFromFileList, includeReplicatedOps>} {
+  hw.module @ModuleInTestHarness(%clock: i1) -> () attributes {"firrtl.extract.do_not_extract"} {
+    sv.always posedge %clock  {
+      sv.assert %clock, immediate
+    }
+  }
+}


### PR DESCRIPTION
We don't have to extract assertions from  modules in testbench since
it already separated from DUT. This commit adds`firrtl.extract.do_not_extract` 
attribue to modules on LowerToHW if they are located in testbench. 
And in SVExtractTestCode, we skip extractions if that attribute appears.

This change will hopefully improve simulation performance by reducing overheads 
of module instantiation. 