### PR TITLE
[FIRRTL] Move ExtractInstances pass before GCT

### DIFF
--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -526,6 +526,9 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
   if (imconstprop && !disableOptimization)
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createIMConstPropPass());
 
+  if (extractInstances)
+    pm.addNestedPass<firrtl::CircuitOp>(firrtl::createExtractInstancesPass());
+
   // Run passes to resolve Grand Central features.  This should run before
   // BlackBoxReader because Grand Central needs to inform BlackBoxReader where
   // certain black boxes should be placed.
@@ -554,9 +557,6 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
       pm.nest<firrtl::CircuitOp>().addPass(
           firrtl::createRemoveUnusedPortsPass());
   }
-
-  if (extractInstances)
-    pm.addNestedPass<firrtl::CircuitOp>(firrtl::createExtractInstancesPass());
 
   if (emitMetadata)
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createCreateSiFiveMetadataPass(


### PR DESCRIPTION
This commit moves the `ExtractInstances` pass before the `GCT` passes.
`GCT` passes can embed the instance paths into `Verbatim` ops, which can later be updated 
by the `ExtractInstances` pass, causing incorrect instance paths being generated into the verilog.