### PR TITLE
[FIRRTL] Add error message to AnnotationArray type constraint

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
@@ -26,7 +26,7 @@ def AnnotationArrayAttr: ArrayAttrBase<
             "[&](::mlir::Attribute attr) { return attr.isa<"
             "::mlir::DictionaryAttr,"
             "::circt::firrtl::SubAnnotationAttr>();})">]>,
-    ""> {
+    "all elements must be DictionaryAttr or SubAnnotationAttr"> {
   let constBuilderCall = "$_builder.getArrayAttr($0)";
 }
 


### PR DESCRIPTION
This type constraint was missing an error message, causing the error
message to seem very cryptic.