### PR TITLE
[FIRRTL] Add FMemModule operation

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -159,7 +159,7 @@ def FMemModuleOp : FIRRTLOp<"memmodule",
   }];
   let arguments =
     (ins UI32Attr:$numReadPorts, UI32Attr:$numWritePorts,
-         UI32Attr:$numReadWritePorts, TypeAttr:$dataType, UI32Attr:$maskBits,
+         UI32Attr:$numReadWritePorts, UI32Attr:$dataWidth, UI32Attr:$maskBits,
          UI32Attr:$readLatency, UI32Attr:$writeLatency, UI64Attr:$depth,
          ArrayAttr:$extraPorts, AnnotationArrayAttr:$annotations);
   let results = (outs);
@@ -169,19 +169,13 @@ def FMemModuleOp : FIRRTLOp<"memmodule",
   let builders = [
     OpBuilder<(ins "StringAttr":$name, "ArrayRef<PortInfo>":$ports,
                    "uint32_t":$numReadPorts,  "uint32_t":$numWritePorts,
-                   "uint32_t":$numReadWritePorts, 
-                   "FIRRTLType":$dataType, "uint32_t":$maskBits,
-                   "uint32_t":$readLatency, "uint32_t":$writeLatency,
-                   "uint64_t":$depth,
+                   "uint32_t":$numReadWritePorts, "uint32_t":$dataWidth,
+                   "uint32_t":$maskBits, "uint32_t":$readLatency,
+                   "uint32_t":$writeLatency, "uint64_t":$depth,
                    CArg<"ArrayAttr", "ArrayAttr()">:$annotations)>
   ];
 
   let extraClassDeclaration = [{
-    /// Get the width of this memory's data type.
-    size_t dataWidth() {
-      return dataType().cast<FIRRTLType>().getBitWidthOrSentinel();
-    }
-
     /// Return true if this memory has a mask.
     bool isMasked() { return maskBits() > 1; }
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -155,7 +155,7 @@ def FMemModuleOp : FIRRTLOp<"memmodule",
     parameters.
     
     A "firrtl.mem" operation is typically lowered to this operation when they
-    are not directly lowered to an implementation by the compiler.
+    are not directly lowered to registers by the compiler.
   }];
   let arguments =
     (ins UI32Attr:$numReadPorts, UI32Attr:$numWritePorts,

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -144,6 +144,57 @@ def FExtModuleOp : FIRRTLOp<"extmodule",
   let hasVerifier = 1;
 }
 
+def FMemModuleOp : FIRRTLOp<"memmodule",
+      [IsolatedFromAbove, Symbol, HasParent<"CircuitOp">, OpAsmOpInterface,
+       DeclareOpInterfaceMethods<FModuleLike>,
+       DeclareOpInterfaceMethods<HWModuleLike>]> {
+  let summary = "FIRRTL Generated Module";
+  let description = [{
+    The "firrtl.memmodule" operation represents an external reference to a
+    memory module. See the "firrtl.mem" op for a deeper explantation of the
+    parameters.
+    
+    A "firrtl.mem" operation is typically lowered to this operation when they
+    are not directly lowered to an implementation by the compiler.
+  }];
+  let arguments =
+    (ins UI32Attr:$numReadPorts, UI32Attr:$numWritePorts,
+         UI32Attr:$numReadWritePorts, TypeAttr:$dataType, UI32Attr:$maskBits,
+         UI32Attr:$readLatency, UI32Attr:$writeLatency, UI64Attr:$depth,
+         ArrayAttr:$extraPorts, AnnotationArrayAttr:$annotations);
+  let results = (outs);
+  let regions = (region AnyRegion:$body);
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins "StringAttr":$name, "ArrayRef<PortInfo>":$ports,
+                   "uint32_t":$numReadPorts,  "uint32_t":$numWritePorts,
+                   "uint32_t":$numReadWritePorts, 
+                   "FIRRTLType":$dataType, "uint32_t":$maskBits,
+                   "uint32_t":$readLatency, "uint32_t":$writeLatency,
+                   "uint64_t":$depth,
+                   CArg<"ArrayAttr", "ArrayAttr()">:$annotations)>
+  ];
+
+  let extraClassDeclaration = [{
+    /// Get the width of this memory's data type.
+    size_t dataWidth() {
+      return dataType().cast<FIRRTLType>().getBitWidthOrSentinel();
+    }
+
+    /// Return true if this memory has a mask.
+    bool isMasked() { return maskBits() > 1; }
+
+    /// Inserts the given ports.
+    void insertPorts(ArrayRef<std::pair<unsigned, PortInfo>> ports);
+
+    void getAsmBlockArgumentNames(mlir::Region &region,
+                                  mlir::OpAsmSetValueNameFn setNameFn);
+  }];
+
+  let hasCustomAssemblyFormat = 1;
+}
+
 def NonLocalAnchor : FIRRTLOp<"nla",
       [IsolatedFromAbove, Symbol, 
        DeclareOpInterfaceMethods<SymbolUserOpInterface>,

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -748,7 +748,7 @@ void FMemModuleOp::build(OpBuilder &builder, OperationState &result,
                          uint32_t maskBits, uint32_t readLatency,
                          uint32_t writeLatency, uint64_t depth,
                          ArrayAttr annotations) {
-  auto context = builder.getContext();
+  auto *context = builder.getContext();
   buildModule(builder, result, name, ports, annotations);
   auto ui32Type = IntegerType::get(context, 32, IntegerType::Unsigned);
   auto ui64Type = IntegerType::get(context, 64, IntegerType::Unsigned);

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -442,25 +442,31 @@ SmallVector<PortInfo> FModuleOp::getPorts() {
 }
 
 /// This function can extract information about ports from a module and an
-/// extmodule.
-SmallVector<PortInfo> FExtModuleOp::getPorts() {
+/// extmodule or genmodule.
+static SmallVector<PortInfo> getPorts(FModuleLike module) {
   // FExtModuleOp's don't have block arguments or locations for their ports.
-  auto loc = getLoc();
-
+  auto loc = module->getLoc();
   SmallVector<PortInfo> results;
-  for (unsigned i = 0, e = getNumPorts(); i < e; ++i) {
-    results.push_back({getPortNameAttr(i), getPortType(i), getPortDirection(i),
-                       getPortSymbolAttr(i), loc,
-                       AnnotationSet::forPort(*this, i)});
+  for (unsigned i = 0, e = module.getNumPorts(); i < e; ++i) {
+    results.push_back({module.getPortNameAttr(i), module.getPortType(i),
+                       module.getPortDirection(i), module.getPortSymbolAttr(i),
+                       loc, AnnotationSet::forPort(module, i)});
   }
   return results;
+}
+
+SmallVector<PortInfo> FExtModuleOp::getPorts() {
+  return ::getPorts(cast<FModuleLike>((Operation *)*this));
+}
+
+SmallVector<PortInfo> FMemModuleOp::getPorts() {
+  return ::getPorts(cast<FModuleLike>((Operation *)*this));
 }
 
 // Return the port with the specified name.
 BlockArgument FModuleOp::getArgument(size_t portNumber) {
   return getBody()->getArgument(portNumber);
 }
-
 /// Inserts the given ports. The insertion indices are expected to be in order.
 /// Insertion occurs in-order, such that ports with the same insertion index
 /// appear in the module in the same order they appeared in the list.
@@ -515,6 +521,83 @@ void FModuleOp::insertPorts(ArrayRef<std::pair<unsigned, PortInfo>> ports) {
     newAnnos.push_back(annos ? annos : emptyArray);
     newSyms.push_back(port.second.sym ? port.second.sym : emptyString);
     body->insertArgument(port.first, port.second.type, port.second.loc);
+  }
+  migrateOldPorts(oldNumArgs);
+
+  // The lack of *any* port annotations is represented by an empty
+  // `portAnnotations` array as a shorthand.
+  if (llvm::all_of(newAnnos, [](Attribute attr) {
+        return attr.cast<ArrayAttr>().empty();
+      }))
+    newAnnos.clear();
+
+  // The lack of *any* port symbol is represented by an empty `portSyms` array
+  // as a shorthand.
+  if (llvm::all_of(newSyms, [](Attribute attr) {
+        return attr.cast<StringAttr>().getValue().empty();
+      }))
+    newSyms.clear();
+
+  // Apply these changed markers.
+  (*this)->setAttr("portDirections",
+                   direction::packAttribute(getContext(), newDirections));
+  (*this)->setAttr("portNames", ArrayAttr::get(getContext(), newNames));
+  (*this)->setAttr("portTypes", ArrayAttr::get(getContext(), newTypes));
+  (*this)->setAttr("portAnnotations", ArrayAttr::get(getContext(), newAnnos));
+  (*this)->setAttr("portSyms", ArrayAttr::get(getContext(), newSyms));
+}
+
+/// Inserts the given ports. The insertion indices are expected to be in order.
+/// Insertion occurs in-order, such that ports with the same insertion index
+/// appear in the module in the same order they appeared in the list.
+void FMemModuleOp::insertPorts(ArrayRef<std::pair<unsigned, PortInfo>> ports) {
+  if (ports.empty())
+    return;
+  unsigned oldNumArgs = getNumPorts();
+  unsigned newNumArgs = oldNumArgs + ports.size();
+
+  // Add direction markers and names for new ports.
+  SmallVector<Direction> existingDirections =
+      direction::unpackAttribute(this->getPortDirectionsAttr());
+  ArrayRef<Attribute> existingNames = this->getPortNames();
+  ArrayRef<Attribute> existingTypes = this->getPortTypes();
+  assert(existingDirections.size() == oldNumArgs);
+  assert(existingNames.size() == oldNumArgs);
+  assert(existingTypes.size() == oldNumArgs);
+
+  SmallVector<Direction> newDirections;
+  SmallVector<Attribute> newNames;
+  SmallVector<Attribute> newTypes;
+  SmallVector<Attribute> newAnnos;
+  SmallVector<Attribute> newSyms;
+  newDirections.reserve(newNumArgs);
+  newNames.reserve(newNumArgs);
+  newTypes.reserve(newNumArgs);
+  newAnnos.reserve(newNumArgs);
+  newSyms.reserve(newNumArgs);
+
+  auto emptyArray = ArrayAttr::get(getContext(), {});
+  auto emptyString = StringAttr::get(getContext(), "");
+
+  unsigned oldIdx = 0;
+  auto migrateOldPorts = [&](unsigned untilOldIdx) {
+    while (oldIdx < oldNumArgs && oldIdx < untilOldIdx) {
+      newDirections.push_back(existingDirections[oldIdx]);
+      newNames.push_back(existingNames[oldIdx]);
+      newTypes.push_back(existingTypes[oldIdx]);
+      newAnnos.push_back(getAnnotationsAttrForPort(oldIdx));
+      newSyms.push_back(getPortSymbolAttr(oldIdx));
+      ++oldIdx;
+    }
+  };
+  for (auto &port : ports) {
+    migrateOldPorts(port.first);
+    newDirections.push_back(port.second.direction);
+    newNames.push_back(port.second.name);
+    newTypes.push_back(TypeAttr::get(port.second.type));
+    auto annos = port.second.annotations.getArrayAttr();
+    newAnnos.push_back(annos ? annos : emptyArray);
+    newSyms.push_back(port.second.sym ? port.second.sym : emptyString);
   }
   migrateOldPorts(oldNumArgs);
 
@@ -656,6 +739,30 @@ void FExtModuleOp::build(OpBuilder &builder, OperationState &result,
     result.addAttribute("defname", builder.getStringAttr(defnameAttr));
   if (!parameters)
     result.addAttribute("parameters", builder.getArrayAttr({}));
+}
+
+void FMemModuleOp::build(OpBuilder &builder, OperationState &result,
+                         StringAttr name, ArrayRef<PortInfo> ports,
+                         uint32_t numReadPorts, uint32_t numWritePorts,
+                         uint32_t numReadWritePorts, FIRRTLType dataType,
+                         uint32_t maskBits, uint32_t readLatency,
+                         uint32_t writeLatency, uint64_t depth,
+                         ArrayAttr annotations) {
+  auto context = builder.getContext();
+  buildModule(builder, result, name, ports, annotations);
+  auto ui32Type = IntegerType::get(context, 32, IntegerType::Unsigned);
+  auto ui64Type = IntegerType::get(context, 64, IntegerType::Unsigned);
+  result.addAttribute("numReadPorts", IntegerAttr::get(ui32Type, numReadPorts));
+  result.addAttribute("numWritePorts",
+                      IntegerAttr::get(ui32Type, numWritePorts));
+  result.addAttribute("numReadWritePorts",
+                      IntegerAttr::get(ui32Type, numReadWritePorts));
+  result.addAttribute("dataType", TypeAttr::get(dataType));
+  result.addAttribute("maskBits", IntegerAttr::get(ui32Type, maskBits));
+  result.addAttribute("readLatency", IntegerAttr::get(ui32Type, readLatency));
+  result.addAttribute("writeLatency", IntegerAttr::get(ui32Type, writeLatency));
+  result.addAttribute("depth", IntegerAttr::get(ui64Type, depth));
+  result.addAttribute("extraPorts", ArrayAttr::get(context, {}));
 }
 
 /// Print a list of module ports in the following form:
@@ -871,6 +978,8 @@ static void printFModuleLikeOp(OpAsmPrinter &p, FModuleLike op) {
 
 void FExtModuleOp::print(OpAsmPrinter &p) { printFModuleLikeOp(p, *this); }
 
+void FMemModuleOp::print(OpAsmPrinter &p) { printFModuleLikeOp(p, *this); }
+
 void FModuleOp::print(OpAsmPrinter &p) {
   printFModuleLikeOp(p, *this);
 
@@ -1024,6 +1133,10 @@ ParseResult FExtModuleOp::parse(OpAsmParser &parser, OperationState &result) {
   return parseFModuleLikeOp(parser, result, /*hasSSAIdentifiers=*/false);
 }
 
+ParseResult FMemModuleOp::parse(OpAsmParser &parser, OperationState &result) {
+  return parseFModuleLikeOp(parser, result, /*hasSSAIdentifiers=*/false);
+}
+
 LogicalResult FExtModuleOp::verify() {
   auto params = parameters();
   if (params.empty())
@@ -1052,6 +1165,11 @@ void FModuleOp::getAsmBlockArgumentNames(mlir::Region &region,
 }
 
 void FExtModuleOp::getAsmBlockArgumentNames(
+    mlir::Region &region, mlir::OpAsmSetValueNameFn setNameFn) {
+  getAsmBlockArgumentNamesImpl(getOperation(), region, setNameFn);
+}
+
+void FMemModuleOp::getAsmBlockArgumentNames(
     mlir::Region &region, mlir::OpAsmSetValueNameFn setNameFn) {
   getAsmBlockArgumentNamesImpl(getOperation(), region, setNameFn);
 }

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -744,7 +744,7 @@ void FExtModuleOp::build(OpBuilder &builder, OperationState &result,
 void FMemModuleOp::build(OpBuilder &builder, OperationState &result,
                          StringAttr name, ArrayRef<PortInfo> ports,
                          uint32_t numReadPorts, uint32_t numWritePorts,
-                         uint32_t numReadWritePorts, FIRRTLType dataType,
+                         uint32_t numReadWritePorts, uint32_t dataWidth,
                          uint32_t maskBits, uint32_t readLatency,
                          uint32_t writeLatency, uint64_t depth,
                          ArrayAttr annotations) {
@@ -757,7 +757,7 @@ void FMemModuleOp::build(OpBuilder &builder, OperationState &result,
                       IntegerAttr::get(ui32Type, numWritePorts));
   result.addAttribute("numReadWritePorts",
                       IntegerAttr::get(ui32Type, numReadWritePorts));
-  result.addAttribute("dataType", TypeAttr::get(dataType));
+  result.addAttribute("dataWidth", IntegerAttr::get(ui32Type, dataWidth));
   result.addAttribute("maskBits", IntegerAttr::get(ui32Type, maskBits));
   result.addAttribute("readLatency", IntegerAttr::get(ui32Type, readLatency));
   result.addAttribute("writeLatency", IntegerAttr::get(ui32Type, writeLatency));

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -2,6 +2,14 @@
 
 firrtl.circuit "MyModule" {
 
+firrtl.module @mod() { }
+firrtl.extmodule @extmod()
+firrtl.memmodule @memmod () attributes {
+  depth = 16 : ui64, dataType = !firrtl.uint<1>, extraPorts = [], 
+  maskBits = 0 : ui32, numReadPorts = 0 : ui32, numWritePorts = 0 : ui32,
+  numReadWritePorts = 0 : ui32, readLatency = 0 : ui32,
+  writeLatency = 1 : ui32}
+
 // Constant op supports different return types.
 firrtl.module @Constants() {
   // CHECK: %c0_ui0 = firrtl.constant 0 : !firrtl.uint<0>

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -5,7 +5,7 @@ firrtl.circuit "MyModule" {
 firrtl.module @mod() { }
 firrtl.extmodule @extmod()
 firrtl.memmodule @memmod () attributes {
-  depth = 16 : ui64, dataType = !firrtl.uint<1>, extraPorts = [], 
+  depth = 16 : ui64, dataWidth = 1 : ui32, extraPorts = [], 
   maskBits = 0 : ui32, numReadPorts = 0 : ui32, numWritePorts = 0 : ui32,
   numReadWritePorts = 0 : ui32, readLatency = 0 : ui32,
   writeLatency = 1 : ui32}


### PR DESCRIPTION
This adds a FMemModule operation, which is an external module used for
FIRRTL SRAMs.  It is almost exactly the same, except it doesn't support
FExtModule's parameterization, does not have  a `defname`, and it
contains required attributes for memory metadata. It was convenient to
not use FExtModules with a bunch of extra attributes stored on it to
make sure that the attributes were properly checked.

The set of attributes stored on the memory are those needed to create all
the metadata files.  The types used for the attributes were generally
the same as those used by the memory generator schema. It might make
sense to revisit the types and use signless integer types in the future.