### PR TITLE
[FIRRTL] Add AddSeqMemPorts pass

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -54,6 +54,8 @@ createCreateSiFiveMetadataPass(bool replSeqMem = false,
 
 std::unique_ptr<mlir::Pass> createWireDFTPass();
 
+std::unique_ptr<mlir::Pass> createAddSeqMemPortsPass();
+
 std::unique_ptr<mlir::Pass> createDedupPass();
 
 std::unique_ptr<mlir::Pass> createEmitOMIRPass(StringRef outputFilename = "");

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -100,6 +100,20 @@ def Inliner : Pass<"firrtl-inliner", "firrtl::CircuitOp"> {
   let constructor = "circt::firrtl::createInlinerPass()";
 }
 
+def AddSeqMemPorts : Pass<"firrtl-add-seqmem-ports", "firrtl::CircuitOp"> {
+  let summary = "Add extra ports to memory modules";
+  let description = [{
+    This pass looks for `AddSeqMemPortAnnotation` annotations and adds extra
+    ports to memories.  It will emit metadata based if the
+    `AddSeqMemPortsFileAnnotation` annotation is specified.
+
+    This pass requires that FIRRTL MemOps have been lowered to modules to add
+    the extra ports.
+  }];
+  let constructor = "circt::firrtl::createAddSeqMemPortsPass()";
+  let dependentDialects = ["sv::SVDialect", "hw::HWDialect"];
+}
+
 def BlackBoxMemory : Pass<"firrtl-blackbox-memory", "firrtl::CircuitOp"> {
   let summary = "Replace all FIRRTL memories with an external module black box.";
   let description = [{

--- a/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
@@ -1,0 +1,442 @@
+//===- AddSeqMemPorts.cpp - Add extra ports to memories ---------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//===----------------------------------------------------------------------===//
+//
+// This file defines the AddSeqMemPorts pass.  This pass will add extra ports
+// to memory modules.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/AnnotationDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
+#include "circt/Dialect/FIRRTL/Namespace.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "circt/Dialect/SV/SVOps.h"
+#include "circt/Support/Namespace.h"
+#include "llvm/ADT/PostOrderIterator.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Parallel.h"
+
+using namespace circt;
+using namespace firrtl;
+
+namespace {
+struct AddSeqMemPortsPass : public AddSeqMemPortsBase<AddSeqMemPortsPass> {
+  void runOnOperation() override;
+  LogicalResult processAddPortAnno(Location loc, Annotation anno);
+  LogicalResult processFileAnno(Location loc, StringRef metadataDir,
+                                Annotation anno);
+  LogicalResult processAnnos(CircuitOp circuit);
+  void createOutputFile(hw::HWModuleLike module);
+  InstanceGraphNode *findDUT();
+  void processMemModule(FMemModuleOp mem);
+  LogicalResult processModule(FModuleOp module);
+
+  /// Get the cached namespace for a module.
+  ModuleNamespace &getModuleNamespace(FModuleLike module) {
+    return moduleNamespaces.try_emplace(module, module).first->second;
+  }
+
+  /// Returns an operation's `inner_sym`, adding one if necessary.
+  StringAttr getOrAddInnerSym(Operation *op) {
+    auto attr = op->getAttrOfType<StringAttr>("inner_sym");
+    if (attr)
+      return attr;
+    auto module = op->getParentOfType<FModuleOp>();
+    StringRef name = "sym";
+    if (auto nameAttr = op->getAttrOfType<StringAttr>("name"))
+      name = nameAttr.getValue();
+    name = getModuleNamespace(module).newName(name);
+    attr = StringAttr::get(op->getContext(), name);
+    op->setAttr("inner_sym", attr);
+    return attr;
+  }
+
+  /// Obtain an inner reference to an operation, possibly adding an `inner_sym`
+  /// to that operation.
+  hw::InnerRefAttr getInnerRefTo(Operation *op) {
+    return hw::InnerRefAttr::get(
+        SymbolTable::getSymbolName(op->getParentOfType<FModuleOp>()),
+        getOrAddInnerSym(op));
+  }
+
+  /// This represents the collected information of the memories in a module.
+  struct MemoryInfo {
+    /// The list of extra ports added to this module to support additional ports
+    /// on all memories underneath this module.
+    std::vector<std::pair<unsigned, PortInfo>> extraPorts;
+
+    /// This is an ordered list of instance paths to all memories underneath
+    /// this module. This will record each memory once for every port added,
+    /// which is for some reason the format of the metadata file.
+    std::vector<SmallVector<Attribute>> instancePaths;
+  };
+  /// This maps a module to information about the memories.
+  DenseMap<Operation *, MemoryInfo> memInfoMap;
+
+  InstanceGraph *instanceGraph;
+
+  /// If the metadata output file was specified in an annotation.
+  hw::OutputFileAttr outputFile;
+
+  /// This is the list of every port to be added to each sequential memory.
+  SmallVector<PortInfo> userPorts;
+  /// This is an attribute holding the metadata for extra ports.
+  ArrayAttr extraPortsAttr;
+
+  /// Cached module namespaces.
+  DenseMap<Operation *, ModuleNamespace> moduleNamespaces;
+
+  bool anythingChanged;
+};
+} // end anonymous namespace
+
+LogicalResult AddSeqMemPortsPass::processAddPortAnno(Location loc,
+                                                     Annotation anno) {
+  auto name = anno.getMember<StringAttr>("name");
+  if (!name)
+    return emitError(
+        loc, "AddSeqMemPortAnnotation requires field 'name' of string type");
+
+  auto input = anno.getMember<BoolAttr>("input");
+  if (!input)
+    return emitError(
+        loc, "AddSeqMemPortAnnotation requires field 'input' of boolean type");
+  auto direction = input.getValue() ? Direction::In : Direction::Out;
+
+  auto width = anno.getMember<IntegerAttr>("width");
+  if (!width)
+    return emitError(
+        loc, "AddSeqMemPortAnnotation requires field 'width' of integer type");
+  auto type = UIntType::get(&getContext(), width.getInt());
+
+  userPorts.push_back({name, type, direction});
+  return success();
+}
+
+LogicalResult AddSeqMemPortsPass::processFileAnno(Location loc,
+                                                  StringRef metadataDir,
+                                                  Annotation anno) {
+  if (outputFile)
+    return emitError(
+        loc, "circuit has two AddSeqMemPortsFileAnnotation annotations");
+
+  auto filename = anno.getMember<StringAttr>("filename");
+  if (!filename)
+    return emitError(loc,
+                     "AddSeqMemPortsFileAnnotation requires field 'filename' "
+                     "of string type");
+
+  outputFile = hw::OutputFileAttr::getFromDirectoryAndFilename(
+      &getContext(), metadataDir, filename.getValue(),
+      /*excludeFromFilelist=*/true);
+  return success();
+}
+
+LogicalResult AddSeqMemPortsPass::processAnnos(CircuitOp circuit) {
+  auto loc = circuit.getLoc();
+
+  // Find the metadata directory.
+  auto dirAnno = AnnotationSet(circuit).getAnnotation(
+      "sifive.enterprise.firrtl.MetadataDirAnnotation");
+  StringRef metadataDir = "metadata";
+  if (dirAnno) {
+    auto dir = dirAnno.getMember<StringAttr>("dirname");
+    if (!dir)
+      return emitError(loc, "MetadataDirAnnotation requires field 'dirname' of "
+                            "string type");
+    metadataDir = dir.getValue();
+  }
+
+  // Remove the annotations we care about.
+  bool error = false;
+  AnnotationSet::removeAnnotations(circuit, [&](Annotation anno) {
+    if (error)
+      return false;
+    if (anno.isClass("sifive.enterprise.firrtl.AddSeqMemPortAnnotation")) {
+      error = failed(processAddPortAnno(loc, anno));
+      return true;
+    }
+    if (anno.isClass("sifive.enterprise.firrtl.AddSeqMemPortsFileAnnotation")) {
+      error = failed(processFileAnno(loc, metadataDir, anno));
+      return true;
+    }
+    return false;
+  });
+  return failure(error);
+}
+
+InstanceGraphNode *AddSeqMemPortsPass::findDUT() {
+  // Find the DUT module.
+  for (auto *node : *instanceGraph) {
+    if (AnnotationSet(node->getModule()).hasAnnotation(dutAnnoClass))
+      return node;
+  }
+  return instanceGraph->getTopLevelNode();
+}
+
+void AddSeqMemPortsPass::processMemModule(FMemModuleOp mem) {
+  // We have to add the user ports to every mem module.
+  size_t portIndex = mem.getNumPorts();
+  auto &memInfo = memInfoMap[mem];
+  auto &extraPorts = memInfo.extraPorts;
+  for (auto &p : userPorts)
+    extraPorts.emplace_back(portIndex, p);
+  mem.insertPorts(extraPorts);
+  // Attach the extraPorts metadata.
+  mem.extraPortsAttr(extraPortsAttr);
+}
+
+LogicalResult AddSeqMemPortsPass::processModule(FModuleOp module) {
+  auto *context = &getContext();
+  // Insert the new port connections at the end of the module.
+  auto builder = OpBuilder::atBlockEnd(module.getBody());
+  auto &memInfo = memInfoMap[module];
+  auto &extraPorts = memInfo.extraPorts;
+  // List of ports added to submodules which must be connected to this module's
+  // ports.
+  SmallVector<Value> values;
+
+  // The base index to use when adding ports to the current module.
+  size_t firstPortIndex = module.getNumPorts();
+
+  for (auto &op : llvm::make_early_inc_range(*module.getBody())) {
+    // We cannot add extra ports to a regular memory op.
+    if (auto mem = dyn_cast<MemOp>(op))
+      return mem->emitError("memories should have been lowered to modules");
+
+    if (auto inst = dyn_cast<InstanceOp>(op)) {
+      auto submodule = instanceGraph->getReferencedModule(inst);
+      auto &subMemInfo = memInfoMap[submodule];
+      // Find out how many memory ports we have to add.
+      auto &subExtraPorts = subMemInfo.extraPorts;
+
+      // If there are no extra ports, we don't have to do anything.
+      if (subExtraPorts.size() == 0)
+        continue;
+
+      // Add the extra ports to the instance operation.
+      auto clone = inst.cloneAndInsertPorts(subExtraPorts);
+      inst.replaceAllUsesWith(
+          clone.getResults().drop_back(subExtraPorts.size()));
+      instanceGraph->replaceInstance(inst, clone);
+      inst->erase();
+      inst = clone;
+
+      // Connect each submodule port up to the parent module ports.
+      for (unsigned i = 0, e = subExtraPorts.size(); i < e; ++i) {
+        auto &[firstSubIndex, portInfo] = subExtraPorts[i];
+        // This is the index of the user port we are adding.
+        auto userIndex = i % userPorts.size();
+        auto &sramPort = userPorts[userIndex];
+        // Construct a port name, e.g. "sram_0_user_inputs".
+        auto sramIndex = extraPorts.size() / userPorts.size();
+        auto portName =
+            StringAttr::get(context, "sram_" + Twine(sramIndex) + "_" +
+                                         sramPort.name.getValue());
+        auto portDirection = sramPort.direction;
+        auto portType = sramPort.type;
+        // Record the extra port.
+        extraPorts.push_back(
+            {firstPortIndex, {portName, portType, portDirection}});
+        // Record the instance result for now, so that we can connect it to the
+        // parent module port after we actually add the ports.
+        values.push_back(inst.getResult(firstSubIndex + i));
+      }
+
+      // We don't want to collect the instance paths or attach inner_syms to
+      // the instance path if we aren't creating the output file.
+      if (outputFile) {
+        // We record any instance paths to memories which are rooted at the
+        // current module.
+        auto &instancePaths = memInfo.instancePaths;
+        auto ref = getInnerRefTo(inst);
+        // If its a mem module, this is the start of a path to the module.
+        if (isa<FMemModuleOp>(submodule))
+          instancePaths.push_back({ref});
+        // Copy any paths through the submodule to memories, adding the ref to
+        // the current instance.
+        for (auto subPath : subMemInfo.instancePaths) {
+          instancePaths.push_back(subPath);
+          instancePaths.back().push_back(ref);
+        }
+      }
+    }
+  }
+
+  // Add the extra ports to this module.
+  module.insertPorts(extraPorts);
+
+  // Connect the submodule ports to the parent module ports.
+  for (unsigned i = 0, e = values.size(); i < e; ++i) {
+    auto &[firstArg, port] = extraPorts[i];
+    Value modulePort = module.getArgument(firstArg + i);
+    Value instPort = values[i];
+    if (port.direction == Direction::In)
+      std::swap(modulePort, instPort);
+    builder.create<StrictConnectOp>(port.loc, modulePort, instPort);
+  }
+  return success();
+}
+
+void AddSeqMemPortsPass::createOutputFile(hw::HWModuleLike module) {
+  // Insert the verbatim at the bottom of the circuit.
+  auto circuit = getOperation();
+  auto builder = OpBuilder::atBlockEnd(circuit.getBody());
+
+  // Output buffer.
+  std::string buffer;
+  llvm::raw_string_ostream os(buffer);
+
+  // The current parameter to the verbatim op.
+  unsigned paramIndex = 0;
+  // Parameters to the verbatim op.
+  SmallVector<Attribute> params;
+  // Small cache to reduce the number of parameters passed to the verbatim.
+  DenseMap<Attribute, unsigned> usedParams;
+
+  // Helper to add a symbol to the verbatim, hitting the cache on the way.
+  auto addSymbol = [&](Attribute ref) {
+    auto it = usedParams.find(ref);
+    unsigned index;
+    if (it != usedParams.end()) {
+      index = it->second;
+    } else {
+      index = paramIndex;
+      usedParams[ref] = paramIndex++;
+      params.push_back(ref);
+    }
+    os << "{{" << index << "}}";
+  };
+
+  // The current sram we are processing.
+  unsigned sramIndex = 0;
+  auto dutSymbol = FlatSymbolRefAttr::get(module.moduleNameAttr());
+  auto &instancePaths = memInfoMap[module].instancePaths;
+  for (auto instancePath : instancePaths) {
+    os << sramIndex++ << " -> ";
+    addSymbol(dutSymbol);
+    // The instance path is reverse from the order we print it.
+    for (auto ref : llvm::reverse(instancePath)) {
+      os << ".";
+      addSymbol(ref);
+    }
+    os << "\n";
+  }
+
+  // Put the information in a verbatim operation.
+  auto verbatimOp = builder.create<sv::VerbatimOp>(
+      builder.getUnknownLoc(), buffer, ValueRange{},
+      builder.getArrayAttr(params));
+  verbatimOp->setAttr("output_file", outputFile);
+  anythingChanged = true;
+}
+
+void AddSeqMemPortsPass::runOnOperation() {
+  auto *context = &getContext();
+  auto circuit = getOperation();
+  instanceGraph = &getAnalysis<InstanceGraph>();
+  // Clear the state.
+  userPorts.clear();
+  memInfoMap.clear();
+  outputFile = {};
+  anythingChanged = false;
+
+  // Collect the annotations from the circuit.
+  if (failed(processAnnos(circuit)))
+    return signalPassFailure();
+
+  // SFC adds the ports in the opposite order they are attached, so we reverse
+  // the list here to match exactly.
+  std::reverse(userPorts.begin(), userPorts.end());
+
+  auto *dutNode = findDUT();
+
+  // Process the extra ports so we can attach it as metadata on to each memory.
+  SmallVector<Attribute> extraPorts;
+  auto ui32Type = IntegerType::get(context, 32, IntegerType::Unsigned);
+  for (auto &userPort : userPorts) {
+    SmallVector<NamedAttribute, 3> attrs;
+    attrs.emplace_back(StringAttr::get(context, "name"), userPort.name);
+    attrs.emplace_back(
+        StringAttr::get(context, "direction"),
+        StringAttr::get(
+            context, userPort.direction == Direction::In ? "input" : "output"));
+    attrs.emplace_back(
+        StringAttr::get(context, "width"),
+        IntegerAttr::get(ui32Type, userPort.type.getBitWidthOrSentinel()));
+    extraPorts.push_back(DictionaryAttr::get(context, attrs));
+  }
+  extraPortsAttr = ArrayAttr::get(context, extraPorts);
+
+  // If there are no user ports, don't do anything.
+  if (userPorts.size() > 0) {
+    // Visit the nodes in post-order.
+    for (auto *node : llvm::post_order(dutNode)) {
+      auto op = node->getModule();
+      if (auto module = dyn_cast<FModuleOp>(*op)) {
+        if (failed(processModule(module)))
+          return signalPassFailure();
+      } else if (auto mem = dyn_cast<FMemModuleOp>(*op)) {
+        processMemModule(mem);
+      }
+    }
+
+    // We handle the DUT differently than the rest of the modules.
+    if (auto dut = dyn_cast<FModuleOp>(*dutNode->getModule())) {
+      // For each instance of the dut, add the instance ports, but tie the port
+      // to 0 instead of wiring them to the parent.
+      for (auto *instRec : dutNode->uses()) {
+        auto inst = cast<InstanceOp>(*instRec->getInstance());
+        auto &dutMemInfo = memInfoMap[dut];
+        // Find out how many memory ports we have to add.
+        auto &subExtraPorts = dutMemInfo.extraPorts;
+        // If there are no extra ports, we don't have to do anything.
+        if (subExtraPorts.size() == 0)
+          continue;
+
+        // Add the extra ports to the instance operation.
+        auto clone = inst.cloneAndInsertPorts(subExtraPorts);
+        inst.replaceAllUsesWith(
+            clone.getResults().drop_back(subExtraPorts.size()));
+        instanceGraph->replaceInstance(inst, clone);
+        inst->erase();
+        inst = clone;
+
+        // Tie each port to 0.
+        OpBuilder builder(context);
+        builder.setInsertionPointAfter(inst);
+        for (unsigned i = 0, e = subExtraPorts.size(); i < e; ++i) {
+          auto &[firstResult, portInfo] = subExtraPorts[i];
+          if (portInfo.direction == Direction::Out)
+            continue;
+          auto value = inst.getResult(firstResult + i);
+          auto type = value.getType();
+          auto attr = getIntZerosAttr(type);
+          auto zero = builder.create<ConstantOp>(portInfo.loc, type, attr);
+          builder.create<StrictConnectOp>(portInfo.loc, value, zero);
+        }
+      }
+    }
+  }
+
+  // If there is an output file, create it.
+  if (outputFile)
+    createOutputFile(dutNode->getModule());
+
+  if (anythingChanged)
+    markAnalysesPreserved<InstanceGraph>();
+  else
+    markAllAnalysesPreserved();
+}
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createAddSeqMemPortsPass() {
+  return std::make_unique<AddSeqMemPortsPass>();
+}

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_circt_dialect_library(CIRCTFIRRTLTransforms
+  AddSeqMemPorts.cpp
   BlackBoxMemory.cpp
   BlackBoxReader.cpp
   CheckCombCycles.cpp

--- a/test/Dialect/FIRRTL/add-seqmem-ports-errors.mlir
+++ b/test/Dialect/FIRRTL/add-seqmem-ports-errors.mlir
@@ -1,0 +1,65 @@
+// RUN: circt-opt -firrtl-add-seqmem-ports -verify-diagnostics -split-input-file %s
+
+// expected-error@below {{MetadataDirAnnotation requires field 'dirname' of string type}}
+firrtl.circuit "Simple" attributes {annotations = [{
+    class = "sifive.enterprise.firrtl.MetadataDirAnnotation"
+  }]} {
+  firrtl.module @Simple() {}
+}
+
+// -----
+
+// expected-error@below {{AddSeqMemPortsFileAnnotation requires field 'filename' of string type}}
+firrtl.circuit "Simple" attributes {annotations = [{
+    class = "sifive.enterprise.firrtl.AddSeqMemPortsFileAnnotation"
+  }]} {
+  firrtl.module @Simple() {}
+}
+
+// -----
+
+// expected-error@below {{circuit has two AddSeqMemPortsFileAnnotation annotations}}
+firrtl.circuit "Simple" attributes {annotations = [
+  {
+    class = "sifive.enterprise.firrtl.AddSeqMemPortsFileAnnotation",
+    filename = "test"
+  },
+  {
+    class = "sifive.enterprise.firrtl.AddSeqMemPortsFileAnnotation",
+    filename = "test"
+  }]} {
+  firrtl.module @Simple() {}
+}
+
+// -----
+
+// expected-error@below {{AddSeqMemPortAnnotation requires field 'name' of string type}}
+firrtl.circuit "Simple" attributes {annotations = [{
+  class = "sifive.enterprise.firrtl.AddSeqMemPortAnnotation",
+  input = true,
+  width = 5
+ }]} {
+  firrtl.module @Simple() { }
+}
+
+// -----
+
+// expected-error@below {{AddSeqMemPortAnnotation requires field 'input' of boolean type}}
+firrtl.circuit "Simple" attributes {annotations = [{
+  class = "sifive.enterprise.firrtl.AddSeqMemPortAnnotation",
+  name = "user_input",
+  width = 5
+ }]} {
+  firrtl.module @Simple() { }
+}
+
+// -----
+
+// expected-error@below {{AddSeqMemPortAnnotation requires field 'width' of integer type}}
+firrtl.circuit "Simple" attributes {annotations = [{
+  class = "sifive.enterprise.firrtl.AddSeqMemPortAnnotation",
+  name = "user_input",
+  input = true
+ }]} {
+  firrtl.module @Simple() { }
+}

--- a/test/Dialect/FIRRTL/add-seqmem-ports.mlir
+++ b/test/Dialect/FIRRTL/add-seqmem-ports.mlir
@@ -1,0 +1,175 @@
+// RUN: circt-opt -firrtl-add-seqmem-ports %s | FileCheck %s
+
+// Should create the output file even if there are no seqmems.
+// CHECK-LABEL: firrtl.circuit "NoMems" {
+// CHECK-NOT: class = "sifive.enterprise.firrtl.AddSeqMemPortsFileAnnotation"
+firrtl.circuit "NoMems" attributes {annotations = [
+  {
+    class = "sifive.enterprise.firrtl.AddSeqMemPortsFileAnnotation",
+    filename = "sram.txt"
+  }]} {
+  firrtl.module @NoMems() {}
+  // CHECK: sv.verbatim "" {output_file = #hw.output_file<"metadata/sram.txt", excludeFromFileList>, symbols = []}
+}
+
+// Test for when there is a memory but no ports are added. The output file
+// should be empty.
+// CHECK-LABEL: firrtl.circuit "NoAddedPorts"  {
+firrtl.circuit "NoAddedPorts" attributes {annotations = [
+  {
+    class = "sifive.enterprise.firrtl.AddSeqMemPortsFileAnnotation",
+    filename = "sram.txt"
+  }]} {
+  // CHECK: firrtl.memmodule @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
+  firrtl.memmodule @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>) attributes {dataWidth = 42 : ui32, depth = 12 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
+  firrtl.module @NoAddedPorts() {
+    %0:4 = firrtl.instance MWrite_ext  @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
+  }
+  // CHECK: sv.verbatim "" {output_file = #hw.output_file<"metadata/sram.txt", excludeFromFileList>, symbols = []}
+}
+
+// Test for when there is no memory and we try to add ports. The output file
+// should be empty.
+// CHECK-LABEL: firrtl.circuit "NoMemory"  {
+// CHECK-NOT: class = "sifive.enterprise.firrtl.AddSeqMemPortAnnotation"
+firrtl.circuit "NoMemory" attributes {annotations = [
+  {
+    class = "sifive.enterprise.firrtl.AddSeqMemPortsFileAnnotation",
+    filename = "sram.txt"
+  },
+  {
+    class = "sifive.enterprise.firrtl.AddSeqMemPortAnnotation",
+    name = "user_input",
+    input = true,
+    width = 5
+  }]} {
+  firrtl.module @NoMemory() {
+  }
+  // CHECK: sv.verbatim "" {output_file = #hw.output_file<"metadata/sram.txt", excludeFromFileList>, symbols = []}
+}
+
+// Test for a single added port.
+// CHECK-LABEL: firrtl.circuit "Single"  {
+firrtl.circuit "Single" attributes {annotations = [
+  {
+    class = "sifive.enterprise.firrtl.AddSeqMemPortAnnotation",
+    name = "user_input",
+    input = true,
+    width = 3
+  }]} {
+  // CHECK:      firrtl.memmodule @MWrite_ext
+  // CHECK-SAME:    in user_input: !firrtl.uint<3>
+  // CHECK-SAME:    extraPorts = [{direction = "input", name = "user_input", width = 3 : ui32}]
+  firrtl.memmodule @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>) attributes {dataWidth = 42 : ui32, depth = 12 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
+  firrtl.module @Single() {
+    %0:4 = firrtl.instance MWrite_ext  @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
+  }
+}
+
+// Test for two ports added.
+// CHECK-LABEL: firrtl.circuit "Two"  {
+firrtl.circuit "Two" attributes {annotations = [
+  {
+    class = "sifive.enterprise.firrtl.AddSeqMemPortAnnotation",
+    name = "user_input",
+    input = true,
+    width = 3
+  },
+  {
+    class = "sifive.enterprise.firrtl.AddSeqMemPortAnnotation",
+    name = "user_output",
+    input = false,
+    width = 4
+  }]} {
+  firrtl.memmodule @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>) attributes {dataWidth = 42 : ui32, depth = 12 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
+  // The ports should be attached in the opposite order of the annotations.
+  // CHECK: firrtl.module @Child(out %sram_0_user_output: !firrtl.uint<4>, in %sram_0_user_input: !firrtl.uint<3>)
+  firrtl.module @Child() {
+    %0:4 = firrtl.instance MWrite_ext  @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
+    // CHECK: firrtl.strictconnect %sram_0_user_output, %MWrite_ext_user_output : !firrtl.uint<4>
+    // CHECK: firrtl.strictconnect %MWrite_ext_user_input, %sram_0_user_input : !firrtl.uint<3>
+  }
+  // CHECK: firrtl.module @Two(out %sram_0_user_output: !firrtl.uint<4>, in %sram_0_user_input: !firrtl.uint<3>, out %sram_1_user_output: !firrtl.uint<4>, in %sram_1_user_input: !firrtl.uint<3>)
+  firrtl.module @Two() {
+    firrtl.instance child0 @Child()
+    firrtl.instance child1 @Child()
+    // CHECK: %child0_sram_0_user_output, %child0_sram_0_user_input = firrtl.instance child0  @Child
+    // CHECK: %child1_sram_0_user_output, %child1_sram_0_user_input = firrtl.instance child1  @Child
+    // CHECK: firrtl.strictconnect %sram_0_user_output, %child0_sram_0_user_output : !firrtl.uint<4>
+    // CHECK: firrtl.strictconnect %child0_sram_0_user_input, %sram_0_user_input : !firrtl.uint<3>
+    // CHECK: firrtl.strictconnect %sram_1_user_output, %child1_sram_0_user_output : !firrtl.uint<4>
+    // CHECK: firrtl.strictconnect %child1_sram_0_user_input, %sram_1_user_input : !firrtl.uint<3>
+
+  }
+}
+
+// Test for a ports added port with a DUT. The input ports should be wired to
+// zero, and not wired up through the test harness.
+// CHECK-LABEL: firrtl.circuit "TestHarness"  {
+firrtl.circuit "TestHarness" attributes {annotations = [
+  {
+    class = "sifive.enterprise.firrtl.AddSeqMemPortAnnotation",
+    name = "user_input",
+    input = true,
+    width = 3
+  },
+  {
+    class = "sifive.enterprise.firrtl.AddSeqMemPortAnnotation",
+    name = "user_output",
+    input = false,
+    width = 4
+  }]} {
+  firrtl.memmodule @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>) attributes {dataWidth = 42 : ui32, depth = 12 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
+  // CHECK: firrtl.module @DUT(out %sram_0_user_output: !firrtl.uint<4>, in %sram_0_user_input: !firrtl.uint<3>)
+  firrtl.module @DUT() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
+    %0:4 = firrtl.instance MWrite_ext  @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
+  }
+  firrtl.module @TestHarness() {
+    firrtl.instance dut @DUT()
+    // CHECK: %dut_sram_0_user_output, %dut_sram_0_user_input = firrtl.instance dut @DUT(out sram_0_user_output: !firrtl.uint<4>, in sram_0_user_input: !firrtl.uint<3>)
+    // CHECK: %c0_ui3 = firrtl.constant 0 : !firrtl.uint<3>
+    // CHECK: firrtl.strictconnect %dut_sram_0_user_input, %c0_ui3 : !firrtl.uint<3>
+  }
+}
+
+// Slightly more complicated test.
+firrtl.circuit "Complex" attributes {annotations = [
+  {
+    class = "sifive.enterprise.firrtl.AddSeqMemPortsFileAnnotation",
+    filename = "sram.txt"
+  },
+  {
+    class = "sifive.enterprise.firrtl.AddSeqMemPortAnnotation",
+    name = "user_input",
+    input = true,
+    width = 3
+  },
+  {
+    class = "sifive.enterprise.firrtl.AddSeqMemPortAnnotation",
+    name = "user_output",
+    input = false,
+    width = 4
+  }]} {
+  firrtl.memmodule @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>) attributes {dataWidth = 42 : ui32, depth = 12 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
+  firrtl.module @Child() {
+    %0:4 = firrtl.instance MWrite_ext  @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
+  }
+  firrtl.module @DUT() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
+    // Double check that these instances now have symbols on them:
+    // CHECK: firrtl.instance MWrite_ext sym @MWrite_ext
+    %0:4 = firrtl.instance MWrite_ext  @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
+    // CHECK: firrtl.instance child sym @child  @Child
+    firrtl.instance child @Child()
+    // CHECK: firrtl.instance MWrite_ext sym @MWrite_ext_0  @MWrite_ext
+    %1:4 = firrtl.instance MWrite_ext  @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
+  }
+  firrtl.module @Complex() {
+    firrtl.instance dut @DUT()
+  }
+  // CHECK: sv.verbatim 
+  // CHECK-SAME{LITERAL}: 0 -> {{0}}.{{1}}
+  // CHECK-SAME{LITERAL}: 1 -> {{0}}.{{2}}.{{3}}
+  // CHECK-SAME{LITERAL}: 2 -> {{0}}.{{4}}
+  // CHECK-SAME: {output_file = #hw.output_file<"metadata/sram.txt", excludeFromFileList>,
+  // CHECK-SAME: symbols = [@DUT, #hw.innerNameRef<@DUT::@MWrite_ext>, #hw.innerNameRef<@DUT::@child>, #hw.innerNameRef<@Child::@MWrite_ext>, #hw.innerNameRef<@DUT::@MWrite_ext_0>]
+}

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -163,6 +163,11 @@ static cl::opt<bool> expandWhens("expand-whens",
                                  cl::init(true), cl::cat(mainCategory));
 
 static cl::opt<bool>
+    addSeqMemPorts("add-seqmem-ports",
+                   cl::desc("add user defined ports to sequential memories"),
+                   cl::init(true), cl::cat(mainCategory));
+
+static cl::opt<bool>
     blackBoxMemory("blackbox-memory",
                    cl::desc("Create a black box for all memory operations"),
                    cl::init(false), cl::cat(mainCategory));
@@ -551,6 +556,9 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
       pm.nest<firrtl::CircuitOp>().addPass(
           firrtl::createRemoveUnusedPortsPass());
   }
+
+  if (addSeqMemPorts)
+    pm.addNestedPass<firrtl::CircuitOp>(firrtl::createAddSeqMemPortsPass());
 
   if (emitMetadata)
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createCreateSiFiveMetadataPass(


### PR DESCRIPTION
This adds a new FIRRTL transformation which looks for
AddSeqMemPortsAnnotation and attaches the extra port specified to all
SRAMs under the DUT.  The extra ports are always of type `UInt<>` with a
user specified width.  The extra ports are wired up through the top of
the DUT and tied off to 0 in the testharness.

This pass requires that memories have been lowered to modules, and will
emit an error if it finds a regular mem op in the module.  This is
because it is not possible to add arbitrary ports to a memop that don't
match the schema of a memory r/w/rw port.