### PR TITLE
[FIRRTL] Fix some passes to work with the new FMemModuleOp

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLInstanceGraph.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLInstanceGraph.cpp
@@ -26,7 +26,7 @@ InstanceGraph::InstanceGraph(Operation *operation)
 }
 
 ArrayRef<InstancePath> InstancePathCache::getAbsolutePaths(Operation *op) {
-  assert((isa<FModuleOp, FExtModuleOp>(op))); // extra parens makes parser smile
+  assert(isa<FModuleLike>(op));
 
   // If we have reached the circuit root, we're done.
   if (op == instanceGraph.getTopLevelNode()->getModule()) {

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
@@ -376,9 +376,9 @@ void GrandCentralSignalMappingsPass::runOnOperation() {
         continue;
       }
       extmodules.json.push_back(*extModule);
-      continue;
+    } else if (auto *module = dyn_cast<FModuleOp>(&op)) {
+      modules.push_back(*module);
     }
-    modules.push_back(cast<FModuleOp>(op));
   }
 
   auto reduce = [](const Result &acc, Result result) -> Result {

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -440,16 +440,17 @@ void IMConstPropPass::markInvalidValueOp(InvalidValueOp invalid) {
 /// enclosing block is marked live.  This sets up the def-use edges for ports.
 void IMConstPropPass::markInstanceOp(InstanceOp instance) {
   // Get the module being reference or a null pointer if this is an extmodule.
-  Operation *module = instanceGraph->getReferencedModule(instance);
+  Operation *op = instanceGraph->getReferencedModule(instance);
 
   // If this is an extmodule, just remember that any results and inouts are
   // overdefined.
-  if (auto extModule = dyn_cast<FExtModuleOp>(module)) {
+  if (!isa<FModuleOp>(op)) {
+    auto module = dyn_cast<FModuleLike>(op);
     for (size_t resultNo = 0, e = instance.getNumResults(); resultNo != e;
          ++resultNo) {
       auto portVal = instance.getResult(resultNo);
       // If this is an input to the extmodule, we can ignore it.
-      if (extModule.getPortDirection(resultNo) == Direction::In)
+      if (module.getPortDirection(resultNo) == Direction::In)
         continue;
 
       // Otherwise this is a result from it or an inout, mark it as overdefined.
@@ -459,7 +460,7 @@ void IMConstPropPass::markInstanceOp(InstanceOp instance) {
   }
 
   // Otherwise this is a defined module.
-  auto fModule = cast<FModuleOp>(module);
+  auto fModule = cast<FModuleOp>(op);
   markBlockExecutable(fModule.getBody());
 
   // Ok, it is a normal internal module reference.  Populate


### PR DESCRIPTION
This fixes a couple places that have the baked in assumption that there
are only 2 module types.  This can be merged before the new `FMemModuleOp`
is actually merged.