### PR TITLE
[FIRRTL][CreateSiFiveMetadata] Base metadata on FMemModules

### DIFF
--- a/include/circt/Support/Namespace.h
+++ b/include/circt/Support/Namespace.h
@@ -92,12 +92,17 @@ public:
     // Try different suffixes until we get a collision-free one.
     tryName.clear();
     name.toVector(tryName); // toStringRef may leave tryName unfilled
-
-    // Indexes less than nextIndex[tryName] are lready used, so skip them.
-    // Indexes larger than nextIndex[tryName] may be used in another name.
-    size_t &i = nextIndex[tryName];
     tryName.push_back('_');
     size_t baseLength = tryName.size();
+
+    // Get the initial number to start from.  Since `:` is not a valid character
+    // in a verilog identifier, we use it separate the name and suffix.
+    tryName.push_back(':');
+    suffix.toVector(tryName);
+
+    // Indexes less than nextIndex[tryName] are already used, so skip them.
+    // Indexes larger than nextIndex[tryName] may be used in another name.
+    size_t &i = nextIndex[tryName];
     do {
       tryName.resize(baseLength);
       Twine(i++).toVector(tryName); // append integer to tryName

--- a/test/Dialect/FIRRTL/SFCTests/emit-omir.fir
+++ b/test/Dialect/FIRRTL/SFCTests/emit-omir.fir
@@ -80,9 +80,9 @@ circuit Foo : %[[
     mem shortint :
         data-type => UInt<42>
         depth => 8
-        read-latency => 0
+        read-latency => 1
         write-latency => 1
-        reader => port
+        writer => port
         read-under-write => undefined
     shortint.port is invalid
 
@@ -132,7 +132,7 @@ circuit Foo : %[[
 
 ; CHECK:       "id": "OMID:3"
 ; CHECK:       "name": "finalPath"
-; CHECK-NEXT:  "value": "OMMemberInstanceTarget:~Foo|Foo/parameter_2:Bar/shortint_ext:{{[^"]+}}"
+; CHECK-NEXT:  "value": "OMMemberInstanceTarget:~Foo|Foo/parameter_2:Bar/shortint_1:shortint_0/shortint_ext:{{[^"]+}}"
 
 ; CHECK:       "id": "OMID:4"
 ; CHECK:       "name": "containingModule"

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -117,32 +117,45 @@ firrtl.circuit "top"
   // CHECK: sv.verbatim "" {output_file = #hw.output_file<"\22metadata/dut.conf\22", excludeFromFileList>, symbols = []}
 }
 
+// CHECK-LABEL: firrtl.circuit "OneMemory"
+firrtl.circuit "OneMemory" {
+  firrtl.module @OneMemory() {
+    %0:5= firrtl.instance MWrite_ext sym @MWrite_ext_0  @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>, in user_input: !firrtl.uint<5>)
+  }
+  firrtl.memmodule @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>, in user_input: !firrtl.uint<5>) attributes {dataWidth = 42 : ui32, depth = 12 : ui64, extraPorts = [{direction = "input", name = "user_input", width = 5 : ui32}], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
+  // CHECK: sv.verbatim "[{\22module_name\22:\22MWrite_ext\22,\22depth\22:12,\22width\22:42,\22masked\22:false,\22read\22:false,\22write\22:true,\22readwrite\22:false,\22extra_ports\22:[{\22name\22:\22user_input\22,\22direction\22:\22input\22,\22width\22:5}],\22hierarchy\22:[\22OneMemory.MWrite_ext\22]}]"
+  // CHECK: sv.verbatim "name MWrite_ext depth 12 width 42 ports write\0A" {output_file = #hw.output_file<"\22metadata/dut.conf\22"
+}
+
 // CHECK-LABEL: firrtl.circuit "top"
-firrtl.circuit "top"
-{
+firrtl.circuit "top" {
     firrtl.module @top()  {
       firrtl.instance dut @DUT()
       firrtl.instance mem1 @Mem1()
       firrtl.instance mem2 @Mem2()
     }
     firrtl.module @Mem1() {
-      %head_MPORT_2 = firrtl.mem Undefined  {depth = 20 : i64, name = "head", portNames = ["MPORT_2", "MPORT_6"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<5>, mask: uint<1>>
+      %0:4 = firrtl.instance head_ext  @head_ext(in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>)
     }
     firrtl.module @Mem2() {
-      %head_MPORT_3 = firrtl.mem Undefined  {depth = 20 : i64, name = "head", portNames = ["MPORT_2", "MPORT_6"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<5>, mask: uint<1>>
+      %0:4 =  firrtl.instance head_0_ext  @head_0_ext(in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>)
     }
     firrtl.module @DUT() attributes {annotations = [
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
       firrtl.instance mem1 @Mem()
     }
     firrtl.module @Mem() {
-      %memory_rw, %memory_rw_r = firrtl.mem Undefined  {annotations = [{class = "sifive.enterprise.firrtl.SeqMemInstanceMetadataAnnotation", data = {baseAddress = 2147483648 : i64, dataBits = 8 : i64, eccBits = 0 : i64, eccIndices = [], eccScheme = "none"}}], depth = 16 : i64, name = "memory", portNames = ["rw", "rw_r", "rw_w"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, wdata: uint<8>, wmask: uint<1>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
-      %head_MPORT_2, %head_MPORT_6 = firrtl.mem Undefined  {depth = 20 : i64, name = "dumm", portNames = ["MPORT_2", "MPORT_6"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<5>, mask: uint<1>>, !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, data: uint<5>, mask: uint<1>>
+      %0:10 = firrtl.instance memory_ext {annotations = [{class = "sifive.enterprise.firrtl.SeqMemInstanceMetadataAnnotation", data = {baseAddress = 2147483648 : i64, dataBits = 8 : i64, eccBits = 0 : i64, eccIndices = [], eccScheme = "none"}}]} @memory_ext(in R0_addr: !firrtl.uint<4>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<8>, in RW0_addr: !firrtl.uint<4>, in RW0_en: !firrtl.uint<1>, in RW0_clk: !firrtl.clock, in RW0_wmode: !firrtl.uint<1>, in RW0_wdata: !firrtl.uint<8>, out RW0_rdata: !firrtl.uint<8>)
+      %1:8 = firrtl.instance dumm_ext @dumm_ext(in R0_addr: !firrtl.uint<5>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<5>, in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>)
     }
-    // CHECK: sv.verbatim "[{\22module_name\22:\22head_0_ext\22,\22depth\22:20,\22width\22:5,\22masked\22:false,\22read\22:false,\22write\22:true,\22readwrite\22:false,\22extra_ports\22:[],\22hierarchy\22:[\22top.mem2.head\22]},{\22module_name\22:\22head_ext\22,\22depth\22:20,\22width\22:5,\22masked\22:false,\22read\22:false,\22write\22:true,\22readwrite\22:false,\22extra_ports\22:[],\22hierarchy\22:[\22top.mem1.head\22]}]"
+    firrtl.memmodule @head_ext(in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>) attributes {dataWidth = 5 : ui32, depth = 20 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
+    firrtl.memmodule @head_0_ext(in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>) attributes {dataWidth = 5 : ui32, depth = 20 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
+    firrtl.memmodule @memory_ext(in R0_addr: !firrtl.uint<4>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<8>, in RW0_addr: !firrtl.uint<4>, in RW0_en: !firrtl.uint<1>, in RW0_clk: !firrtl.clock, in RW0_wmode: !firrtl.uint<1>, in RW0_wdata: !firrtl.uint<8>, out RW0_rdata: !firrtl.uint<8>) attributes {dataWidth = 8 : ui32, depth = 16 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 0 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
+    firrtl.memmodule @dumm_ext(in R0_addr: !firrtl.uint<5>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<5>, in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>) attributes {dataWidth = 5 : ui32, depth = 20 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
+    // CHECK: sv.verbatim "[{\22module_name\22:\22head_ext\22,\22depth\22:20,\22width\22:5,\22masked\22:false,\22read\22:false,\22write\22:true,\22readwrite\22:false,\22extra_ports\22:[],\22hierarchy\22:[\22top.mem1.head_ext\22]},{\22module_name\22:\22head_0_ext\22,\22depth\22:20,\22width\22:5,\22masked\22:false,\22read\22:false,\22write\22:true,\22readwrite\22:false,\22extra_ports\22:[],\22hierarchy\22:[\22top.mem2.head_0_ext\22]}]"
     // CHECK-SAME:  {output_file = #hw.output_file<"metadata/tb_seq_mems.json", excludeFromFileList>, symbols = []}
-    // CHECK: sv.verbatim "[{\22module_name\22:\22memory_ext\22,\22depth\22:16,\22width\22:8,\22masked\22:false,\22read\22:true,\22write\22:false,\22readwrite\22:true,\22extra_ports\22:[],\22hierarchy\22:[\22DUT.mem1.memory\22]
+    // CHECK: sv.verbatim "[{\22module_name\22:\22memory_ext\22,\22depth\22:16,\22width\22:8,\22masked\22:false,\22read\22:true,\22write\22:false,\22readwrite\22:true,\22extra_ports\22:[],\22hierarchy\22:[\22DUT.mem1.memory_ext\22]},{\22module_name\22:\22dumm_ext\22,\22depth\22:20,\22width\22:5,\22masked\22:false,\22read\22:true,\22write\22:true,\22readwrite\22:false,\22extra_ports\22:[],\22hierarchy\22:[\22DUT.mem1.dumm_ext\22]}]"
     // CHECK-SAME: output_file = #hw.output_file<"metadata/seq_mems.json", excludeFromFileList>, symbols = []
-    // CHECK: sv.verbatim "name memory_ext depth 16 width 8 ports rw\0Aname head_0_ext depth 20 width 5 ports write\0Aname head_ext depth 20 width 5 ports write\0A" 
+    // CHECK: sv.verbatim "name memory_ext depth 16 width 8 ports rw\0Aname dumm_ext depth 20 width 5 ports write,read\0Aname head_ext depth 20 width 5 ports write\0Aname head_0_ext depth 20 width 5 ports write\0A"
     // CHECK-SAME: {output_file = #hw.output_file<"\22metadata/dut.conf\22", excludeFromFileList>, symbols = []}
 }

--- a/test/firtool/memoryLowering.fir
+++ b/test/firtool/memoryLowering.fir
@@ -1,4 +1,4 @@
-; RUN: firtool %s --format=fir  --annotation-file %s.anno.json -emit-metadata -repl-seq-mem -repl-seq-mem-file="metadata/test.conf" --verilog |  FileCheck %s
+; RUN: firtool %s --format=fir --lower-memory --annotation-file %s.anno.json -emit-metadata -repl-seq-mem -repl-seq-mem-file="metadata/test.conf" --verilog |  FileCheck %s
 
 circuit test:
   module test:
@@ -35,7 +35,7 @@ circuit test:
 
 ; CHECK: metadata/seq_mems.json
 
-; CHECK: [{"module_name":"memory_ext","depth":16,"width":32,"masked":true,"read":true,"write":true,"readwrite":false,"mask_granularity":8,"extra_ports":[],"hierarchy":[]}]
+; CHECK: [{"module_name":"memory_ext","depth":16,"width":32,"masked":true,"read":true,"write":true,"readwrite":false,"mask_granularity":8,"extra_ports":[],"hierarchy":["test.memory.memory_ext"]}]
 
 ; CHECK: metadata/test.conf
 

--- a/test/firtool/memoryMetadata.fir
+++ b/test/firtool/memoryMetadata.fir
@@ -1,10 +1,5 @@
-; RUN: firtool %s -dedup=false --format=fir  --annotation-file %s.anno.json --repl-seq-mem --repl-seq-mem-file="metadata/dutModule.conf" --verilog |  FileCheck %s
+; RUN: firtool %s -dedup=false --lower-memory --format=fir --annotation-file %s.anno.json --repl-seq-mem --repl-seq-mem-file="metadata/dutModule.conf" --verilog |  FileCheck %s
 
-; CHECK-LABEL: external module tbMemoryKind1_0_ext
-
-; CHECK-LABEL: external module tbMemoryKind1_ext
-
-; CHECK-LABEL: external module dutMemory_ext
 
 circuit test:
   module tbMemModule1:
@@ -35,7 +30,8 @@ circuit test:
     tbMemoryKind1.w.data <= wData
 
 ; CHECK-LABEL: module tbMemModule1
-; CHECK:   tbMemoryKind1_ext tbMemoryKind1
+; CHECK:         tbMemoryKind1 tbMemoryKind1
+; CHECK:       endmodule
 
   module dutModule2:
     input clock: Clock
@@ -65,7 +61,7 @@ circuit test:
     dutMemory.w.data <= wData
 
 ; CHECK-LABEL: module dutModule2
-; CHECK:  dutMemory_ext dutMemory
+; CHECK:  dutMemory dutMemory
 
   module hier1: 
     input clock: Clock
@@ -95,7 +91,7 @@ circuit test:
     tbMemoryKind1.w.data <= wData
 
 ; CHECK=LABEL: module hier1
-; CHECK:  tbMemoryKind1_0_ext tbMemoryKind1
+; CHECK:  tbMemoryKind1_0 tbMemoryKind1
 
 
   module hier2: 
@@ -170,25 +166,31 @@ circuit test:
     m.wMask <= wMask
     m.wData <= wData
 
-
-
 ; CHECK-LABEL: module dutModule
 ; CHECK: dutModule2 [[m:.+]] (
 
-; CHECK-LABEL:      FILE "metadata/tb_seq_mems.json"
-; CHECK: [{"module_name":"tbMemoryKind1_0_ext","depth":16,"width":8,
-; CHECK-SAME: "masked":false,"read":true,"write":true,"readwrite":false,
-; CHECK-SAME: "extra_ports":[],"hierarchy":["test.h1.tbMemoryKind1"]},
-; CHECK-SAME: {"module_name":"tbMemoryKind1_ext","depth":16,"width":8,"masked":false,
-; CHECK-SAME: "read":true,"write":true,"readwrite":false,"extra_ports":[],
-; CHECK-SAME: "hierarchy":["test.h2.m.tbMemoryKind1"]}]
 
-; CHECK-LABEL:       FILE "metadata/seq_mems.json"
-; CHECK:  [{"module_name":"dutMemory_ext","depth":32,"width":8,"masked":false,"read":true,
-; CHECK:  "write":true,"readwrite":false,"extra_ports":[],
-; CHECK:  "hierarchy":["dutModule.m.dutMemory"]}]
+; CHECK-LABEL: external module tbMemoryKind1_ext
+; CHECK-LABEL: external module dutMemory_ext
+; CHECK-LABEL: external module tbMemoryKind1_0_ext
+
+
+; CHECK-LABEL: FILE "metadata/tb_seq_mems.json"
+; CHECK:      [{"module_name":"tbMemoryKind1_ext",
+; CHECK-SAME: "depth":16,"width":8,"masked":false,"read":true,"write":true,"readwrite":false,"extra_ports":[],
+; CHECK-SAME: "hierarchy":["test.h2.m.tbMemoryKind1.tbMemoryKind1_ext"]},
+; CHECK-SAME: {"module_name":"tbMemoryKind1_0_ext",
+; CHECK-SAME: "depth":16,"width":8,"masked":false,"read":true,"write":true,"readwrite":false,"extra_ports":[],
+; CHECK-SAME: "hierarchy":["test.h1.tbMemoryKind1.tbMemoryKind1_0_ext"]}]
+
+
+; CHECK-LABEL: FILE "metadata/seq_mems.json"
+; CHECK:      [{"module_name":"dutMemory_ext",
+; CHECK-SAME: "depth":32,"width":8,"masked":false,"read":true,"write":true,"readwrite":false,"extra_ports":[],
+; CHECK-SAME: "hierarchy":["dutModule.m.dutMemory.dutMemory_ext"]}]
+
 
 ; CHECK-LABEL: FILE "metadata/dutModule.conf"
 ; CHECK: name dutMemory_ext depth 32 width 8 ports write,read
-; CHECK: name tbMemoryKind1_0_ext depth 16 width 8 ports write,read
 ; CHECK: name tbMemoryKind1_ext depth 16 width 8 ports write,read
+; CHECK: name tbMemoryKind1_0_ext depth 16 width 8 ports write,read

--- a/test/firtool/prefixMemory.fir
+++ b/test/firtool/prefixMemory.fir
@@ -1,5 +1,5 @@
-; RUN: firtool %s --format=fir --repl-seq-mem --repl-seq-mem-file="dummy" --ir-fir | FileCheck %s 
-; RUN: firtool %s --format=fir  --repl-seq-mem --repl-seq-mem-file="dummy" --ir-sv | FileCheck --check-prefix=HW %s
+; RUN: firtool %s --repl-seq-mem --repl-seq-mem-file=test.txt --ir-fir | FileCheck %s 
+; RUN: firtool %s --repl-seq-mem --repl-seq-mem-file=test.txt --ir-sv | FileCheck --check-prefix=HW %s
 
 circuit Foo : %[[
   {
@@ -112,9 +112,11 @@ circuit Foo : %[[
     readData <= _readData_T
 
 ; CHECK-LABEL:  firrtl.module private @prefix1_Bar
-; CHECK:        = firrtl.mem Undefined  {depth = 8 : i64, groupID = 4294967294 : ui32, modName = "prefix1_mem_ext", name = "prefix1_mem", portNames = ["MPORT", "readData_MPORT"], readLatency = 1 : i32, writeLatency = 1 : i32}
+; CHECK:          firrtl.instance mem @prefix1_mem
 ; CHECK-LABEL:  firrtl.module private @prefix2_Baz
-; CHECK:        = firrtl.mem Undefined  {depth = 8 : i64, groupID = 4294967293 : ui32, modName = "prefix2_mem_ext", name = "prefix2_mem", portNames = ["MPORT", "readData_MPORT"], readLatency = 1 : i32, writeLatency = 1 : i32}
+; CHECK:          firrtl.instance mem @prefix2_mem
+; CHECK:        firrtl.memmodule @prefix1_mem
+; CHECK:        firrtl.memmodule @prefix2_mem
 
-; HW-LABEL:  hw.module.extern @prefix2_mem_ext(%R0_addr: i3, %R0_en: i1, %R0_clk: i1, %W0_addr: i3, %W0_en: i1, %W0_clk: i1, %W0_data: i1) -> (R0_data: i1)
-; HW-LABEL:  hw.module.extern @prefix1_mem_ext(%R0_addr: i3, %R0_en: i1, %R0_clk: i1, %W0_addr: i3, %W0_en: i1, %W0_clk: i1, %W0_data: i1) -> (R0_data: i1)
+; HW-LABEL: hw.module.extern @prefix1_mem
+; HW-LABEL: hw.module.extern @prefix2_mem

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -157,7 +157,7 @@ static cl::opt<bool> imconstprop(
 // new memory lowering pipeline.
 static cl::opt<bool> lowerMemory("lower-memory",
                                  cl::desc("run the lower-memory pass"),
-                                 cl::init(false), cl::cat(mainCategory));
+                                 cl::init(true), cl::cat(mainCategory));
 
 static cl::opt<bool>
     lowerTypes("lower-types",
@@ -504,9 +504,6 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
 
   if (wireDFT)
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createWireDFTPass());
-
-  if (prefixModules)
-    pm.nest<firrtl::CircuitOp>().addPass(firrtl::createPrefixModulesPass());
 
   if (blackBoxMemory)
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createBlackBoxMemoryPass());


### PR DESCRIPTION
This changes the memory-related metadata emitted by this pass to be
created from FMemModules instead of MemOps.  The memories will have
already been lowered into modules.  The pass can be simplified because
it no longer has to worry about deduplicating the memories itself.