### PR TITLE
[FIRRTL][InferWidths] Support bundles in mux constraint

### DIFF
--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -354,6 +354,17 @@ firrtl.circuit "Foo" {
     firrtl.connect %1, %c2_ui3 : !firrtl.uint, !firrtl.uint<3>
   }
 
+  firrtl.module @MuxBundleOperands(in %a: !firrtl.bundle<a: uint<8>>, in %p: !firrtl.uint<1>, out %c: !firrtl.bundle<a: uint>) {
+    // CHECK: %w = firrtl.wire  : !firrtl.bundle<a: uint<8>>
+    %w = firrtl.wire  : !firrtl.bundle<a: uint>
+    %0 = firrtl.subfield %w(0) : (!firrtl.bundle<a: uint>) -> !firrtl.uint
+    %1 = firrtl.subfield %a(0) : (!firrtl.bundle<a: uint<8>>) -> !firrtl.uint<8>
+    firrtl.connect %0, %1 : !firrtl.uint, !firrtl.uint<8>
+    // CHECK: %2 = firrtl.mux(%p, %a, %w) : (!firrtl.uint<1>, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>) -> !firrtl.bundle<a: uint<8>>
+    %2 = firrtl.mux(%p, %a, %w) : (!firrtl.uint<1>, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint>) -> !firrtl.bundle<a: uint>
+    firrtl.connect %c, %2 : !firrtl.bundle<a: uint>, !firrtl.bundle<a: uint>
+  }
+
   // CHECK-LABEL: @ShlShrOp
   firrtl.module @ShlShrOp() {
     // CHECK: %0 = firrtl.shl {{.*}} -> !firrtl.uint<8>


### PR DESCRIPTION
The infer widths pass made the assumption that the arguments to a
MuxPrimOp were ground types, and would trigger an assertion trying to
create a `max(high, low)` constraint on the operands.  This changes the
mux constraint generation to recursively constrain the type of the
result to the maximum of the high and low signals.