### PR TITLE
[FIRRTL] Make combmem clock analysis see through subfields

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1928,7 +1928,7 @@ FirMemory MemOp::getSummary() {
   size_t numReadPorts = 0;
   size_t numWritePorts = 0;
   size_t numReadWritePorts = 0;
-  llvm::SmallDenseMap<Value, unsigned> clockToLeader;
+  llvm::SmallDenseMap<FieldRef, unsigned> clockToLeader;
   SmallVector<int32_t> writeClockIDs;
 
   for (size_t i = 0, e = op.getNumResults(); i != e; ++i) {
@@ -1944,8 +1944,8 @@ FirMemory MemOp::getSummary() {
         for (auto *b : clockPort.getUsers()) {
           if (auto connect = dyn_cast<FConnectLike>(b)) {
             if (connect.dest() == clockPort) {
-              auto result =
-                  clockToLeader.insert({connect.src(), numWritePorts});
+              auto result = clockToLeader.insert(
+                  {getFieldRefFromValue(connect.src()), numWritePorts});
               if (result.second) {
                 writeClockIDs.push_back(numWritePorts);
               } else {


### PR DESCRIPTION
When lowering combinational memories, it is important to correctly
detect which ports are using the same clock.  Before this change, the
analysis would compare which value was connected to the clock.  This
could become a problem when the clock used is a subfield of a bundle,
and each port is using a different value. The SFC MemtoRefOfVec
transform compares the expression tree feeding into the clock, which
includes subfield, but not statements like nodes.

This is not an issue on most cores, as CSE and other optimizations make this
irrelevant.