### PR TITLE
[FSM] Implement graph traits for `fsm.machine`

### DIFF
--- a/include/circt/Dialect/FSM/CMakeLists.txt
+++ b/include/circt/Dialect/FSM/CMakeLists.txt
@@ -1,2 +1,7 @@
 add_circt_dialect(FSM fsm)
 add_circt_doc(FSM -gen-dialect-doc FSM Dialects/)
+
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls)
+add_public_tablegen_target(CIRCTFSMTransformsIncGen)
+add_circt_doc(Passes -gen-pass-doc FSMPasses ./)

--- a/include/circt/Dialect/FSM/FSMGraph.h
+++ b/include/circt/Dialect/FSM/FSMGraph.h
@@ -200,9 +200,11 @@ struct llvm::GraphTraits<circt::fsm::FSMStateNode *> {
                             decltype(&getNextState)>;
 
   static NodeRef getEntryNode(NodeRef node) { return node; }
+  // NOLINTNEXTLINE(readability-identifier-naming)
   static ChildIteratorType child_begin(NodeRef node) {
     return {node->begin(), &getNextState};
   }
+  // NOLINTNEXTLINE(readability-identifier-naming)
   static ChildIteratorType child_end(NodeRef node) {
     return {node->end(), &getNextState};
   }

--- a/include/circt/Dialect/FSM/FSMGraph.h
+++ b/include/circt/Dialect/FSM/FSMGraph.h
@@ -1,0 +1,279 @@
+//===- FSMGraph.h - FSM graph -----------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the FSMGraph.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_FSM_FSMGraph_H
+#define CIRCT_DIALECT_FSM_FSMGraph_H
+
+#include "circt/Dialect/FSM/FSMOps.h"
+#include "circt/Support/LLVM.h"
+#include "llvm/ADT/GraphTraits.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/iterator.h"
+#include "llvm/Support/DOTGraphTraits.h"
+#include "llvm/Support/GraphWriter.h"
+
+#include <regex>
+
+namespace circt {
+namespace fsm {
+
+namespace detail {
+/// This just maps a iterator of references to an iterator of addresses.
+template <typename It>
+struct AddressIterator
+    : public llvm::mapped_iterator<It, typename It::pointer (*)(
+                                           typename It::reference)> {
+  // This using statement is to get around a bug in MSVC.  Without it, it
+  // tries to look up "It" as a member type of the parent class.
+  using Iterator = It;
+  /* implicit */ AddressIterator(Iterator iterator)
+      : llvm::mapped_iterator<It, typename Iterator::pointer (*)(
+                                      typename Iterator::reference)>(
+            iterator, &std::addressof<typename Iterator::value_type>) {}
+};
+
+// Escapes any occurance of (regex) characters 'c' in 'str'. If 'noEscape' is
+// set, does not prepend a '\' character to the replaced value.
+static void escape(std::string &str, const char *c, bool noEscape = false) {
+  std::string replacement = std::string(c);
+  if (!noEscape)
+    replacement = R"(\)" + replacement;
+  str = std::regex_replace(str, std::regex(c), replacement);
+};
+
+} // namespace detail
+
+class FSMStateNode;
+
+/// This is an edge in the FSMGraph. This tracks a transition between two
+/// states.
+class FSMTransitionEdge
+    : public llvm::ilist_node_with_parent<FSMTransitionEdge, FSMStateNode> {
+public:
+  /// Get the state where the transition originates from.
+  FSMStateNode *getCurrentState() const { return currentState; }
+
+  /// Get the module which the FSM-like is instantiating.
+  FSMStateNode *getNextState() const { return nextState; }
+
+  TransitionOp getTransition() const { return transition; }
+
+private:
+  friend class FSMGraphBase;
+  friend class FSMStateNode;
+
+  FSMTransitionEdge(FSMStateNode *currentState, TransitionOp transition,
+                    FSMStateNode *nextState)
+      : currentState(currentState), transition(transition),
+        nextState(nextState) {}
+  FSMTransitionEdge(const FSMTransitionEdge &) = delete;
+
+  /// The state where this transition originates from.
+  FSMStateNode *currentState;
+
+  /// The transition that this is tracking.
+  TransitionOp transition;
+
+  /// The next state of this transition.
+  FSMStateNode *nextState;
+};
+
+/// This is a Node in the FSMGraph.  Each node represents a state in the FSM.
+class FSMStateNode : public llvm::ilist_node<FSMStateNode> {
+  using FSMTransitionList = llvm::iplist<FSMTransitionEdge>;
+
+public:
+  FSMStateNode() : state(nullptr) {}
+
+  /// Get the state operation that this node is tracking.
+  StateOp getState() const { return state; }
+
+  /// Adds a new transition from this state.
+  FSMTransitionEdge *addTransition(FSMStateNode *nextState,
+                                   TransitionOp transition);
+
+  /// Iterate outgoing FSM transitions of this state.
+  using iterator = detail::AddressIterator<FSMTransitionList::iterator>;
+  iterator begin() { return transitions.begin(); }
+  iterator end() { return transitions.end(); }
+
+private:
+  FSMStateNode(StateOp state) : state(state) {}
+  FSMStateNode(const FSMStateNode &) = delete;
+
+  /// The state.
+  StateOp state;
+
+  /// List of outgoing transitions from this state.
+  FSMTransitionList transitions;
+
+  /// Provide access to the constructor.
+  friend class FSMGraph;
+};
+
+/// Graph representing FSM machines, their states and transitions between these.
+class FSMGraph {
+  /// This is the list of FSMStateNodes in the graph.
+  using NodeList = llvm::iplist<FSMStateNode>;
+
+public:
+  /// Create a new graph of an FSM machine operation.
+  explicit FSMGraph(Operation *operation);
+
+  /// Look up a FSMStateNode for a state.
+  FSMStateNode *lookup(StateOp op);
+
+  /// Lookup a FSMStateNode by name.
+  FSMStateNode *lookup(StringAttr name);
+
+  /// Lookup a FSMStateNode for a state.
+  FSMStateNode *operator[](StateOp op) { return lookup(op); }
+
+  /// Get the node corresponding to the entry state of the FSM.
+  FSMStateNode *getEntryNode();
+
+  /// Return the FSM machine operation which this graph tracks.
+  MachineOp getMachine() const { return machine; }
+
+  /// Iterate through all states.
+  using iterator = detail::AddressIterator<NodeList::iterator>;
+  iterator begin() { return nodes.begin(); }
+  iterator end() { return nodes.end(); }
+
+private:
+  FSMStateNode *getOrAddNode(StateOp state);
+
+  FSMGraph(const FSMGraph &) = delete;
+
+  /// The node under which all states are nested.
+  MachineOp machine;
+
+  /// The storage for graph nodes, with deterministic iteration.
+  NodeList nodes;
+
+  /// This maps each StateOp to its graph node.
+  llvm::DenseMap<Attribute, FSMStateNode *> nodeMap;
+};
+
+} // namespace fsm
+} // namespace circt
+
+// Provide graph traits for iterating the states.
+template <>
+struct llvm::GraphTraits<circt::fsm::FSMStateNode *> {
+  using NodeType = circt::fsm::FSMStateNode;
+  using NodeRef = NodeType *;
+
+  // Helper for getting the next state of a transition edge.
+  static NodeRef getNextState(const circt::fsm::FSMTransitionEdge *transition) {
+    return transition->getNextState();
+  }
+
+  using ChildIteratorType =
+      llvm::mapped_iterator<circt::fsm::FSMStateNode::iterator,
+                            decltype(&getNextState)>;
+
+  static NodeRef getEntryNode(NodeRef node) { return node; }
+  static ChildIteratorType child_begin(NodeRef node) {
+    return {node->begin(), &getNextState};
+  }
+  static ChildIteratorType child_end(NodeRef node) {
+    return {node->end(), &getNextState};
+  }
+};
+
+// Graph traits for the common FSM graph.
+template <>
+struct llvm::GraphTraits<circt::fsm::FSMGraph *>
+    : public llvm::GraphTraits<circt::fsm::FSMStateNode *> {
+  using nodes_iterator = circt::fsm::FSMGraph::iterator;
+
+  static NodeRef getEntryNode(circt::fsm::FSMGraph *graph) {
+    return graph->getEntryNode();
+  }
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  static nodes_iterator nodes_begin(circt::fsm::FSMGraph *graph) {
+    return graph->begin();
+  }
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  static nodes_iterator nodes_end(circt::fsm::FSMGraph *graph) {
+    return graph->end();
+  }
+};
+
+// Graph traits for DOT labelling.
+template <>
+struct llvm::DOTGraphTraits<circt::fsm::FSMGraph *>
+    : public llvm::DefaultDOTGraphTraits {
+  using DefaultDOTGraphTraits::DefaultDOTGraphTraits;
+
+  static std::string getNodeLabel(circt::fsm::FSMStateNode *node,
+                                  circt::fsm::FSMGraph *) {
+    // The name of the graph node is the state name.
+    return node->getState().sym_name().str();
+  }
+
+  static std::string getNodeDescription(circt::fsm::FSMStateNode *node,
+                                        circt::fsm::FSMGraph *) {
+    // The description of the node is the dump of its Output region.
+    std::string desc;
+    llvm::raw_string_ostream ss(desc);
+    llvm::interleave(
+        node->getState().output().getOps(), ss,
+        [&](mlir::Operation &op) { op.print(ss); }, "\\n");
+
+    return desc;
+  }
+
+  template <typename Iterator>
+  static std::string getEdgeAttributes(const circt::fsm::FSMStateNode *node,
+                                       Iterator it, circt::fsm::FSMGraph *) {
+    // Set an edge label that is the dump of the inner contents of the guard of
+    // the transition.
+    circt::fsm::FSMTransitionEdge *edge = *it.getCurrent();
+    circt::fsm::TransitionOp transition = edge->getTransition();
+    if (!transition.hasGuard())
+      return "";
+
+    std::string desc;
+    llvm::raw_string_ostream ss(desc);
+    llvm::interleave(
+        transition.guard().getOps(), ss,
+        [&](mlir::Operation &op) { op.print(ss); }, "\\n");
+    return ("label=\"" + desc + "\"");
+  }
+
+  static void addCustomGraphFeatures(const circt::fsm::FSMGraph *G,
+                                     GraphWriter<circt::fsm::FSMGraph *> &GW) {
+    // Print a separate node for global variables in the FSM.
+    llvm::raw_ostream &O = GW.getOStream();
+
+    O << "variables [shape=record,label=\"Variables|";
+
+    std::string desc;
+    llvm::raw_string_ostream ss(desc);
+    llvm::interleave(
+        llvm::make_filter_range(
+            G->getMachine().getOps(),
+            [](mlir::Operation &op) { return !isa<circt::fsm::StateOp>(&op); }),
+        ss, [&](mlir::Operation &op) { op.print(ss); }, "\\n");
+
+    // Ensure that special characters which may be present in the Op dumps are
+    // properly escaped.
+    circt::fsm::detail::escape(desc, R"(")");
+    circt::fsm::detail::escape(desc, R"(\{)", /*noEscape=*/true);
+    circt::fsm::detail::escape(desc, R"(\})", /*noEscape=*/true);
+    O << desc << "\"]";
+  }
+};
+
+#endif // CIRCT_DIALECT_FSM_FSMFSMGraph_H

--- a/include/circt/Dialect/FSM/FSMGraph.h
+++ b/include/circt/Dialect/FSM/FSMGraph.h
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef CIRCT_DIALECT_FSM_FSMGraph_H
-#define CIRCT_DIALECT_FSM_FSMGraph_H
+#ifndef CIRCT_DIALECT_FSM_FSMGRAPH_H
+#define CIRCT_DIALECT_FSM_FSMGRAPH_H
 
 #include "circt/Dialect/FSM/FSMOps.h"
 #include "circt/Support/LLVM.h"
@@ -252,18 +252,18 @@ struct llvm::DOTGraphTraits<circt::fsm::FSMGraph *>
     return ("label=\"" + desc + "\"");
   }
 
-  static void addCustomGraphFeatures(const circt::fsm::FSMGraph *G,
-                                     GraphWriter<circt::fsm::FSMGraph *> &GW) {
+  static void addCustomGraphFeatures(const circt::fsm::FSMGraph *graph,
+                                     GraphWriter<circt::fsm::FSMGraph *> &gw) {
     // Print a separate node for global variables in the FSM.
-    llvm::raw_ostream &O = GW.getOStream();
+    llvm::raw_ostream &os = gw.getOStream();
 
-    O << "variables [shape=record,label=\"Variables|";
+    os << "variables [shape=record,label=\"Variables|";
 
     std::string desc;
     llvm::raw_string_ostream ss(desc);
     llvm::interleave(
         llvm::make_filter_range(
-            G->getMachine().getOps(),
+            graph->getMachine().getOps(),
             [](mlir::Operation &op) { return !isa<circt::fsm::StateOp>(&op); }),
         ss, [&](mlir::Operation &op) { op.print(ss); }, "\\n");
 
@@ -272,8 +272,8 @@ struct llvm::DOTGraphTraits<circt::fsm::FSMGraph *>
     circt::fsm::detail::escape(desc, R"(")");
     circt::fsm::detail::escape(desc, R"(\{)", /*noEscape=*/true);
     circt::fsm::detail::escape(desc, R"(\})", /*noEscape=*/true);
-    O << desc << "\"]";
+    os << desc << "\"]";
   }
 };
 
-#endif // CIRCT_DIALECT_FSM_FSMFSMGraph_H
+#endif // CIRCT_DIALECT_FSM_FSMGRAPH_H

--- a/include/circt/Dialect/FSM/FSMPasses.h
+++ b/include/circt/Dialect/FSM/FSMPasses.h
@@ -1,0 +1,33 @@
+//===- Passes.h - FSM pass entry points -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This header file defines prototypes that expose pass constructors.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_FSM_FSMPASSES_H
+#define CIRCT_DIALECT_FSM_FSMPASSES_H
+
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassRegistry.h"
+#include "llvm/ADT/Optional.h"
+#include <memory>
+
+namespace circt {
+namespace fsm {
+
+std::unique_ptr<mlir::Pass> createPrintFSMGraphPass();
+
+/// Generate the code for registering passes.
+#define GEN_PASS_REGISTRATION
+#include "circt/Dialect/FSM/Passes.h.inc"
+
+} // namespace fsm
+} // namespace circt
+
+#endif // CIRCT_DIALECT_FSM_FSMPASSES_H

--- a/include/circt/Dialect/FSM/Passes.td
+++ b/include/circt/Dialect/FSM/Passes.td
@@ -1,0 +1,23 @@
+//===-- Passes.td - FSM pass definition file ---------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the passes that work on the FSM dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_FSM_PASSES_TD
+#define CIRCT_DIALECT_FSM_PASSES_TD
+
+include "mlir/Pass/PassBase.td"
+
+def PrintFSMGraph : Pass<"fsm-print-graph", "circt::fsm::MachineOp"> {
+  let summary = "Print a DOT graph of the module hierarchy.";
+  let constructor =  "circt::fsm::createPrintFSMGraphPass()";
+}
+
+#endif // CIRCT_DIALECT_FSM_PASSES_TD

--- a/include/circt/InitAllPasses.h
+++ b/include/circt/InitAllPasses.h
@@ -19,6 +19,7 @@
 #include "circt/Dialect/Calyx/CalyxPasses.h"
 #include "circt/Dialect/ESI/ESIDialect.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
+#include "circt/Dialect/FSM/FSMPasses.h"
 #include "circt/Dialect/HW/HWPasses.h"
 #include "circt/Dialect/Handshake/HandshakePasses.h"
 #include "circt/Dialect/LLHD/Transforms/Passes.h"
@@ -40,6 +41,7 @@ inline void registerAllPasses() {
   calyx::registerPasses();
   esi::registerESIPasses();
   firrtl::registerPasses();
+  fsm::registerPasses();
   llhd::initLLHDTransformationPasses();
   msft::registerMSFTPasses();
   seq::registerSeqPasses();

--- a/lib/Dialect/FSM/CMakeLists.txt
+++ b/lib/Dialect/FSM/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_circt_dialect_library(CIRCTFSM
   FSMDialect.cpp
+  FSMGraph.cpp
   FSMOps.cpp
   FSMTypes.cpp
 
@@ -11,3 +12,5 @@ add_circt_dialect_library(CIRCTFSM
   MLIRFunc
   MLIRArithmetic
   )
+
+add_subdirectory(Transforms)

--- a/lib/Dialect/FSM/FSMGraph.cpp
+++ b/lib/Dialect/FSM/FSMGraph.cpp
@@ -13,7 +13,7 @@ using namespace fsm;
 
 FSMTransitionEdge *FSMStateNode::addTransition(FSMStateNode *nextState,
                                                TransitionOp transition) {
-  auto transitionEdge = new FSMTransitionEdge(this, transition, nextState);
+  auto *transitionEdge = new FSMTransitionEdge(this, transition, nextState);
   transitions.push_back(transitionEdge);
   return transitionEdge;
 }

--- a/lib/Dialect/FSM/FSMGraph.cpp
+++ b/lib/Dialect/FSM/FSMGraph.cpp
@@ -1,0 +1,56 @@
+//===- FSMGraph.cpp - FSM Graph ---------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/FSM/FSMGraph.h"
+
+using namespace circt;
+using namespace fsm;
+
+FSMTransitionEdge *FSMStateNode::addTransition(FSMStateNode *nextState,
+                                               TransitionOp transition) {
+  auto transitionEdge = new FSMTransitionEdge(this, transition, nextState);
+  transitions.push_back(transitionEdge);
+  return transitionEdge;
+}
+
+FSMGraph::FSMGraph(Operation *op) {
+  machine = dyn_cast<MachineOp>(op);
+  assert(machine && "Expected a fsm::MachineOp");
+
+  // Find all states in the machine.
+  for (auto stateOp : machine.getOps<StateOp>()) {
+    // Add an edge to indicate that this state transitions to some other state.
+    auto *currentStateNode = getOrAddNode(stateOp);
+
+    for (auto transitionOp : stateOp.transitions().getOps<TransitionOp>()) {
+      auto *nextStateNode = getOrAddNode(transitionOp.getNextState());
+      currentStateNode->addTransition(nextStateNode, transitionOp);
+    }
+  }
+}
+
+FSMStateNode *FSMGraph::lookup(StringAttr name) {
+  auto it = nodeMap.find(name);
+  assert(it != nodeMap.end() && "Module not in InstanceGraph!");
+  return it->second;
+}
+
+FSMStateNode *FSMGraph::lookup(StateOp state) {
+  return lookup(state.getNameAttr());
+}
+
+FSMStateNode *FSMGraph::getOrAddNode(StateOp state) {
+  // Try to insert an FSMStateNode. If its not inserted, it returns
+  // an iterator pointing to the node.
+  auto *&node = nodeMap[state.getNameAttr()];
+  if (!node) {
+    node = new FSMStateNode(state);
+    nodes.push_back(node);
+  }
+  return node;
+}

--- a/lib/Dialect/FSM/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FSM/Transforms/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_circt_dialect_library(CIRCTFSMTransforms
+  PrintFSMGraph.cpp
+
+  DEPENDS
+  CIRCTFSMTransformsIncGen
+
+  LINK_LIBS PUBLIC
+  CIRCTFSM
+  CIRCTSupport
+  MLIRIR
+  MLIRPass
+  MLIRTransformUtils
+)

--- a/lib/Dialect/FSM/Transforms/PassDetails.h
+++ b/lib/Dialect/FSM/Transforms/PassDetails.h
@@ -1,0 +1,31 @@
+//===- PassDetails.h - FSM pass class details -------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Stuff shared between the different FSM passes.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-tidy seems to expect the absolute path in the header guard on some
+// systems, so just disable it.
+// NOLINTNEXTLINE(llvm-header-guard)
+#ifndef DIALECT_FSM_TRANSFORMS_PASSDETAILS_H
+#define DIALECT_FSM_TRANSFORMS_PASSDETAILS_H
+
+#include "circt/Dialect/FSM/FSMOps.h"
+#include "mlir/Pass/Pass.h"
+
+namespace circt {
+namespace fsm {
+
+#define GEN_PASS_CLASSES
+#include "circt/Dialect/FSM/Passes.h.inc"
+
+} // namespace fsm
+} // namespace circt
+
+#endif // DIALECT_FSM_TRANSFORMS_PASSDETAILS_H

--- a/lib/Dialect/FSM/Transforms/PrintFSMGraph.cpp
+++ b/lib/Dialect/FSM/Transforms/PrintFSMGraph.cpp
@@ -24,8 +24,8 @@ namespace {
 struct PrintFSMGraphPass : public PrintFSMGraphBase<PrintFSMGraphPass> {
   PrintFSMGraphPass(raw_ostream &os) : os(os) {}
   void runOnOperation() override {
-    auto &FSMGraph = getAnalysis<fsm::FSMGraph>();
-    llvm::WriteGraph(os, &FSMGraph, /*ShortNames=*/false);
+    auto &fsmGraph = getAnalysis<fsm::FSMGraph>();
+    llvm::WriteGraph(os, &fsmGraph, /*ShortNames=*/false);
     markAllAnalysesPreserved();
   }
   raw_ostream &os;

--- a/lib/Dialect/FSM/Transforms/PrintFSMGraph.cpp
+++ b/lib/Dialect/FSM/Transforms/PrintFSMGraph.cpp
@@ -1,0 +1,37 @@
+//===- FSMPrintFSMGraph.cpp - Print the instance graph ------*- C++
+//-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//===----------------------------------------------------------------------===//
+//
+// Print the module hierarchy.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FSM/FSMGraph.h"
+#include "circt/Dialect/FSM/FSMPasses.h"
+#include "circt/Dialect/HW/HWInstanceGraph.h"
+#include "llvm/Support/GraphWriter.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace circt;
+using namespace fsm;
+
+namespace {
+struct PrintFSMGraphPass : public PrintFSMGraphBase<PrintFSMGraphPass> {
+  PrintFSMGraphPass(raw_ostream &os) : os(os) {}
+  void runOnOperation() override {
+    auto &FSMGraph = getAnalysis<fsm::FSMGraph>();
+    llvm::WriteGraph(os, &FSMGraph, /*ShortNames=*/false);
+    markAllAnalysesPreserved();
+  }
+  raw_ostream &os;
+};
+} // end anonymous namespace
+
+std::unique_ptr<mlir::Pass> circt::fsm::createPrintFSMGraphPass() {
+  return std::make_unique<PrintFSMGraphPass>(llvm::errs());
+}

--- a/test/Dialect/FSM/print-graph.mlir
+++ b/test/Dialect/FSM/print-graph.mlir
@@ -1,0 +1,42 @@
+// RUN: circt-opt --fsm-print-graph %s -o %t 2>&1 | FileCheck %s
+
+// CHECK: [[IDLE:.*]] [shape=record,label="{IDLE|fsm.output %true : i1}"];
+// CHECK: [[IDLE]] -> [[BUSY:.*]][label="fsm.return %arg0"];
+// CHECK: [[BUSY]] [shape=record,label="{BUSY|fsm.output %false : i1}"];
+// CHECK: [[BUSY]] -> [[BUSY]][label="%0 = arith.cmpi ne, %cnt, %c0_i16 : i16\nfsm.return %0"];
+// FIX ME: FileCheck doesn't want to play nice with the following line (intended check: "[[BUSY]] -> [[IDLE]][label="%0 = arith.cmpi eq, %cnt, %c0_i16 : i16\nfsm.return %0"];")
+// CHECK: [[BUSY]] ->
+// CHECK: variables [shape=record,label="Variables|%c1_i16 = arith.constant 1 : i16\n%c0_i16 = arith.constant 0 : i16\n%false = arith.constant false\n%c256_i16 = arith.constant 256 : i16\n%true = arith.constant true\n%cnt = fsm.variable \"cnt\" \{initValue = 0 : i16\} : i16"]}
+
+fsm.machine @foo(%arg0: i1) -> i1 attributes {initialState = "IDLE", stateType = i1} {
+  %c1_i16 = arith.constant 1 : i16
+  %c0_i16 = arith.constant 0 : i16
+  %false = arith.constant false
+  %c256_i16 = arith.constant 256 : i16
+  %true = arith.constant true
+  %cnt = fsm.variable "cnt" {initValue = 0 : i16} : i16
+  fsm.state "IDLE" output {
+    fsm.output %true : i1
+  } transitions {
+    fsm.transition @BUSY guard {
+      fsm.return %arg0
+    } action {
+      fsm.update %cnt, %c256_i16 : i16
+    }
+  }
+  fsm.state "BUSY" output {
+    fsm.output %false : i1
+  } transitions {
+    fsm.transition @BUSY guard {
+      %0 = arith.cmpi ne, %cnt, %c0_i16 : i16
+      fsm.return %0
+    } action {
+      %0 = arith.subi %cnt, %c1_i16 : i16
+      fsm.update %cnt, %0 : i16
+    }
+    fsm.transition @IDLE guard {
+      %0 = arith.cmpi eq, %cnt, %c0_i16 : i16
+      fsm.return %0
+    }
+  }
+}

--- a/tools/circt-opt/CMakeLists.txt
+++ b/tools/circt-opt/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(circt-opt
   CIRCTFIRRTLToHW
   CIRCTFIRRTLTransforms
   CIRCTFSM
+  CIRCTFSMTransforms
   CIRCTHandshake
   CIRCTHandshakeToFIRRTL
   CIRCTHandshakeToHW


### PR DESCRIPTION
Initial implementation of LLVM graph traits for the `fsm.machine` operation. This will probably be a fairly critical piece of code for building further transformations, visualizations, ... upon.

Example `dot` output of the included `print-graph.mlir` test:
![out](https://user-images.githubusercontent.com/16338943/167316801-87ce6997-5694-433b-9179-2b690e92373d.png)

