### PR TITLE
LLVM bump (as we know it)

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -181,6 +181,7 @@ jobs:
           mkdir configure_unified
           cd configure_unified
           cmake ../llvm/llvm \
+            -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_SHARED_LIBS=ON \
             -DLLVM_ENABLE_PROJECTS=mlir \
             -DLLVM_TARGETS_TO_BUILD=host \

--- a/.github/workflows/trackLLVMChanges.yml
+++ b/.github/workflows/trackLLVMChanges.yml
@@ -5,7 +5,7 @@ on:
     # 10:00 AM UTC is 3AM Pacific Time
     - cron: '0 10 * * *'
   # Run this workflow on pull requests which change this workflow
-  pull_request: 
+  pull_request:
     paths:
       - .github/workflows/trackLLVMChanges.yml
   workflow_dispatch:
@@ -50,7 +50,7 @@ jobs:
           cd llvm
           echo "::set-output name=sha::$(git rev-parse HEAD)"
           cmake --build ../build --config Debug --target check-circt -- -j$(nproc)
-      
+
       - name: Build latest LLVM commit
         id: build-latest-llvm-commit
         continue-on-error: true
@@ -60,7 +60,7 @@ jobs:
           git checkout --detach origin/main
           echo "::set-output name=sha::$(git rev-parse HEAD)"
           cmake --build ../build --config Debug --target check-circt -- -j$(nproc)
-      
+
       - name: Bisect commits
         if: steps.build-latest-llvm-commit.outcome != 'success'
         run: |

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -214,16 +214,6 @@ def NodeOp : FIRRTLOp<"node",
   }];
 
   let hasCanonicalizer = true;
-
-  let extraClassDeclaration = [{
-    /// Infer the return types of this operation.
-    static LogicalResult inferReturnTypes(MLIRContext *context,
-                                          Optional<Location> loc,
-                                          ValueRange operands,
-                                          DictionaryAttr attrs,
-                                          mlir::RegionRange regions,
-                                          SmallVectorImpl<Type> &results);
-  }];
 }
 
 def RegOp : FIRRTLOp<"reg", [HasCustomSSAName/*MemAlloc*/]> {

--- a/include/circt/Dialect/HW/ModuleImplementation.h
+++ b/include/circt/Dialect/HW/ModuleImplementation.h
@@ -31,16 +31,15 @@ StringAttr getPortNameAttr(MLIRContext *context, StringRef name);
 /// result arguments.
 ParseResult parseModuleFunctionSignature(
     OpAsmParser &parser,
-    SmallVectorImpl<OpAsmParser::UnresolvedOperand> &argNames,
-    SmallVectorImpl<Type> &argTypes, SmallVectorImpl<NamedAttrList> &argAttrs,
+    SmallVectorImpl<OpAsmParser::Argument> &args,
     bool &isVariadic, SmallVectorImpl<Type> &resultTypes,
-    SmallVectorImpl<NamedAttrList> &resultAttrs,
+    SmallVectorImpl<DictionaryAttr> &resultAttrs,
     SmallVectorImpl<Attribute> &resultNames);
 
 /// Parse a function result list with named results.
 ParseResult parseFunctionResultList(OpAsmParser &parser,
                                     SmallVectorImpl<Type> &resultTypes,
-                                    SmallVectorImpl<NamedAttrList> &resultAttrs,
+                                    SmallVectorImpl<DictionaryAttr> &resultAttrs,
                                     SmallVectorImpl<Attribute> &resultNames);
 
 /// Print a module signature with named results.

--- a/include/circt/Dialect/HW/ModuleImplementation.h
+++ b/include/circt/Dialect/HW/ModuleImplementation.h
@@ -30,17 +30,16 @@ StringAttr getPortNameAttr(MLIRContext *context, StringRef name);
 /// This is a variant of mlor::parseFunctionSignature that allows names on
 /// result arguments.
 ParseResult parseModuleFunctionSignature(
-    OpAsmParser &parser,
-    SmallVectorImpl<OpAsmParser::Argument> &args,
+    OpAsmParser &parser, SmallVectorImpl<OpAsmParser::Argument> &args,
     bool &isVariadic, SmallVectorImpl<Type> &resultTypes,
     SmallVectorImpl<DictionaryAttr> &resultAttrs,
     SmallVectorImpl<Attribute> &resultNames);
 
 /// Parse a function result list with named results.
-ParseResult parseFunctionResultList(OpAsmParser &parser,
-                                    SmallVectorImpl<Type> &resultTypes,
-                                    SmallVectorImpl<DictionaryAttr> &resultAttrs,
-                                    SmallVectorImpl<Attribute> &resultNames);
+ParseResult
+parseFunctionResultList(OpAsmParser &parser, SmallVectorImpl<Type> &resultTypes,
+                        SmallVectorImpl<DictionaryAttr> &resultAttrs,
+                        SmallVectorImpl<Attribute> &resultNames);
 
 /// Print a module signature with named results.
 void printModuleSignature(OpAsmPrinter &p, Operation *op,

--- a/integration_test/Dialect/Handshake/dot.mlir
+++ b/integration_test/Dialect/Handshake/dot.mlir
@@ -1,6 +1,6 @@
 // REQUIRES: ieee-sim
 // UNSUPPORTED: ieee-sim-iverilog
-// RUN: circt-opt %s --lower-std-to-handshake \ 
+// RUN: circt-opt %s --lower-std-to-handshake \
 // RUN:   --canonicalize='top-down=true region-simplify=true' \
 // RUN:   --handshake-materialize-forks-sinks --canonicalize \
 // RUN:   --handshake-insert-buffers=strategy=all --lower-handshake-to-firrtl | \
@@ -9,7 +9,7 @@
 // CHECK: Result={{.*}}3589632
 
 module {
-  func @top() -> i32 {
+  func.func @top() -> i32 {
     %c123_i32 = arith.constant 123 : i32
     %c456_i32 = arith.constant 456 : i32
     %c0_i32 = arith.constant 0 : i32

--- a/integration_test/Dialect/Handshake/matmul.mlir
+++ b/integration_test/Dialect/Handshake/matmul.mlir
@@ -1,6 +1,6 @@
 // REQUIRES: ieee-sim
 // UNSUPPORTED: ieee-sim-iverilog
-// RUN: circt-opt %s --lower-std-to-handshake \ 
+// RUN: circt-opt %s --lower-std-to-handshake \
 // RUN:   --canonicalize='top-down=true region-simplify=true' \
 // RUN:   --handshake-materialize-forks-sinks --canonicalize \
 // RUN:   --handshake-insert-buffers=strategy=all --lower-handshake-to-firrtl | \
@@ -9,7 +9,7 @@
 // CHECK: Result={{.*}}448704
 
 module {
-  func @top() -> i32 {
+  func.func @top() -> i32 {
     %c123_i32 = arith.constant 123 : i32
     %c456_i32 = arith.constant 456 : i32
     %c0_i32 = arith.constant 0 : i32

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -445,16 +445,17 @@ void ComponentOp::print(OpAsmPrinter &p) {
 /// port names to `attrName`.
 static ParseResult
 parsePortDefList(OpAsmParser &parser, OperationState &result,
-                 SmallVectorImpl<OpAsmParser::UnresolvedOperand> &ports,
+                 SmallVectorImpl<OpAsmParser::Argument> &ports,
                  SmallVectorImpl<Type> &portTypes,
                  SmallVectorImpl<NamedAttrList> &portAttrs) {
   auto parsePort = [&]() -> ParseResult {
-    OpAsmParser::UnresolvedOperand port;
+    OpAsmParser::Argument port;
     Type portType;
     // Expect each port to have the form `%<ssa-name> : <type>`.
-    if (parser.parseRegionArgument(port) || parser.parseColon() ||
+    if (parser.parseArgument(port) || parser.parseColon() ||
         parser.parseType(portType))
       return failure();
+    port.type = portType;
     ports.push_back(port);
     portTypes.push_back(portType);
 
@@ -472,9 +473,9 @@ parsePortDefList(OpAsmParser &parser, OperationState &result,
 /// Parses the signature of a Calyx component.
 static ParseResult
 parseComponentSignature(OpAsmParser &parser, OperationState &result,
-                        SmallVectorImpl<OpAsmParser::UnresolvedOperand> &ports,
+                        SmallVectorImpl<OpAsmParser::Argument> &ports,
                         SmallVectorImpl<Type> &portTypes) {
-  SmallVector<OpAsmParser::UnresolvedOperand> inPorts, outPorts;
+  SmallVector<OpAsmParser::Argument> inPorts, outPorts;
   SmallVector<Type> inPortTypes, outPortTypes;
   SmallVector<NamedAttrList> portAttributes;
 
@@ -490,7 +491,7 @@ parseComponentSignature(OpAsmParser &parser, OperationState &result,
   // just inferred from the SSA names of the component.
   SmallVector<Attribute> portNames;
   auto getPortName = [context](const auto &port) -> StringAttr {
-    StringRef name = port.name;
+    StringRef name = port.ssaName.name;
     if (name.startswith("%"))
       name = name.drop_front();
     return StringAttr::get(context, name);
@@ -525,7 +526,9 @@ ParseResult ComponentOp::parse(OpAsmParser &parser, OperationState &result) {
                              result.attributes))
     return failure();
 
-  SmallVector<OpAsmParser::UnresolvedOperand> ports;
+  // SmallVector<OpAsmParser::UnresolvedOperand> ports;
+  SmallVector<mlir::OpAsmParser::Argument> ports;
+
   SmallVector<Type> portTypes;
   if (parseComponentSignature(parser, result, ports, portTypes))
     return failure();
@@ -537,7 +540,7 @@ ParseResult ComponentOp::parse(OpAsmParser &parser, OperationState &result) {
   result.addAttribute(ComponentOp::getTypeAttrName(), TypeAttr::get(type));
 
   auto *body = result.addRegion();
-  if (parser.parseRegion(*body, ports, portTypes))
+  if (parser.parseRegion(*body, ports))
     return failure();
 
   if (body->empty())

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -526,7 +526,6 @@ ParseResult ComponentOp::parse(OpAsmParser &parser, OperationState &result) {
                              result.attributes))
     return failure();
 
-  // SmallVector<OpAsmParser::UnresolvedOperand> ports;
   SmallVector<mlir::OpAsmParser::Argument> ports;
 
   SmallVector<Type> portTypes;

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -851,7 +851,7 @@ static bool printModulePorts(OpAsmPrinter &p, Block *block,
 /// will populate `entryArgs`.
 static ParseResult
 parseModulePorts(OpAsmParser &parser, bool hasSSAIdentifiers,
-                 SmallVectorImpl<OpAsmParser::UnresolvedOperand> &entryArgs,
+                 SmallVectorImpl<OpAsmParser::Argument> &entryArgs,
                  SmallVectorImpl<Direction> &portDirections,
                  SmallVectorImpl<Attribute> &portNames,
                  SmallVectorImpl<Attribute> &portTypes,
@@ -870,17 +870,19 @@ parseModulePorts(OpAsmParser &parser, bool hasSSAIdentifiers,
 
     // Parse the port name.
     if (hasSSAIdentifiers) {
-      OpAsmParser::UnresolvedOperand arg;
-      if (parser.parseRegionArgument(arg))
+      OpAsmParser::Argument arg;
+      if (parser.parseArgument(arg))
         return failure();
       entryArgs.push_back(arg);
       // The name of an argument is of the form "%42" or "%id", and since
       // parsing succeeded, we know it always has one character.
-      assert(arg.name.size() > 1 && arg.name[0] == '%' && "Unknown MLIR name");
-      if (isdigit(arg.name[1]))
+      assert(arg.ssaName.name.size() > 1 && arg.ssaName.name[0] == '%' &&
+             "Unknown MLIR name");
+      if (isdigit(arg.ssaName.name[1]))
         portNames.push_back(StringAttr::get(context, ""));
       else
-        portNames.push_back(StringAttr::get(context, arg.name.drop_front()));
+        portNames.push_back(
+            StringAttr::get(context, arg.ssaName.name.drop_front()));
     } else {
       std::string portName;
       if (parser.parseKeywordOrString(&portName))
@@ -893,6 +895,10 @@ parseModulePorts(OpAsmParser &parser, bool hasSSAIdentifiers,
     if (parser.parseColonType(portType))
       return failure();
     portTypes.push_back(TypeAttr::get(portType));
+
+    if (hasSSAIdentifiers) {
+      entryArgs.back().type = portType;
+    }
 
     // Parse the optional port symbol.
     StringAttr portSym;
@@ -1053,7 +1059,7 @@ static ParseResult parseFModuleLikeOp(OpAsmParser &parser,
   result.addAttribute("parameters", builder.getArrayAttr(parameters));
 
   // Parse the module ports.
-  SmallVector<OpAsmParser::UnresolvedOperand> entryArgs;
+  SmallVector<OpAsmParser::Argument> entryArgs;
   SmallVector<Direction, 4> portDirections;
   SmallVector<Attribute, 4> portNames;
   SmallVector<Attribute, 4> portTypes;
@@ -1114,15 +1120,7 @@ static ParseResult parseFModuleLikeOp(OpAsmParser &parser,
   auto *body = result.addRegion();
 
   if (hasSSAIdentifiers) {
-    // Collect block argument types.
-    SmallVector<Type, 4> argTypes;
-    if (!entryArgs.empty())
-      llvm::transform(portTypes, std::back_inserter(argTypes),
-                      [](Attribute typeAttr) -> Type {
-                        return typeAttr.cast<TypeAttr>().getValue();
-                      });
-
-    if (parser.parseRegion(*body, entryArgs, argTypes))
+    if (parser.parseRegion(*body, entryArgs))
       return failure();
     if (body->empty())
       body->push_back(new Block());
@@ -1505,7 +1503,7 @@ ParseResult InstanceOp::parse(OpAsmParser &parser, OperationState &result) {
   std::string name;
   StringAttr innerSymAttr;
   FlatSymbolRefAttr moduleName;
-  SmallVector<OpAsmParser::UnresolvedOperand> entryArgs;
+  SmallVector<OpAsmParser::Argument> entryArgs;
   SmallVector<Direction, 4> portDirections;
   SmallVector<Attribute, 4> portNames;
   SmallVector<Attribute, 4> portTypes;
@@ -2005,17 +2003,6 @@ void MemOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 // Construct name of the module which will be used for the memory definition.
 StringAttr FirMemory::getFirMemoryName() const { return modName; }
 
-/// Infer the return types of this operation.
-LogicalResult NodeOp::inferReturnTypes(MLIRContext *context,
-                                       Optional<Location> loc,
-                                       ValueRange operands,
-                                       DictionaryAttr attrs,
-                                       mlir::RegionRange regions,
-                                       SmallVectorImpl<Type> &results) {
-  results.push_back(operands[0].getType());
-  return success();
-}
-
 void NodeOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   setNameFn(getResult(), name());
 }
@@ -2502,7 +2489,7 @@ FIRRTLType SubaccessOp::inferReturnType(ValueRange operands,
 
 ParseResult MultibitMuxOp::parse(OpAsmParser &parser, OperationState &result) {
   OpAsmParser::UnresolvedOperand index;
-  llvm::SmallVector<OpAsmParser::UnresolvedOperand, 16> inputs;
+  SmallVector<OpAsmParser::UnresolvedOperand, 16> inputs;
   Type indexType, elemType;
 
   if (parser.parseOperand(index) || parser.parseComma() ||

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -896,9 +896,8 @@ parseModulePorts(OpAsmParser &parser, bool hasSSAIdentifiers,
       return failure();
     portTypes.push_back(TypeAttr::get(portType));
 
-    if (hasSSAIdentifiers) {
+    if (hasSSAIdentifiers)
       entryArgs.back().type = portType;
-    }
 
     // Parse the optional port symbol.
     StringAttr portSym;

--- a/lib/Dialect/HW/ModuleImplementation.cpp
+++ b/lib/Dialect/HW/ModuleImplementation.cpp
@@ -42,7 +42,7 @@ StringAttr module_like_impl::getPortNameAttr(MLIRContext *context,
 ///
 ParseResult module_like_impl::parseFunctionResultList(
     OpAsmParser &parser, SmallVectorImpl<Type> &resultTypes,
-    SmallVectorImpl<NamedAttrList> &resultAttrs,
+    SmallVectorImpl<DictionaryAttr> &resultAttrs,
     SmallVectorImpl<Attribute> &resultNames) {
 
   auto parseElt = [&]() -> ParseResult {
@@ -53,9 +53,14 @@ ParseResult module_like_impl::parseFunctionResultList(
 
     resultTypes.emplace_back();
     resultAttrs.emplace_back();
+
+    NamedAttrList attrs;
     if (parser.parseColonType(resultTypes.back()) ||
-        parser.parseOptionalAttrDict(resultAttrs.back()))
+        parser.parseOptionalAttrDict(attrs))
       return failure();
+
+    resultAttrs.back() = attrs.getDictionary(parser.getContext());
+
     return success();
   };
 
@@ -66,18 +71,14 @@ ParseResult module_like_impl::parseFunctionResultList(
 /// This is a variant of mlor::parseFunctionSignature that allows names on
 /// result arguments.
 ParseResult module_like_impl::parseModuleFunctionSignature(
-    OpAsmParser &parser,
-    SmallVectorImpl<OpAsmParser::UnresolvedOperand> &argNames,
-    SmallVectorImpl<Type> &argTypes, SmallVectorImpl<NamedAttrList> &argAttrs,
+    OpAsmParser &parser, SmallVectorImpl<OpAsmParser::Argument> &args,
     bool &isVariadic, SmallVectorImpl<Type> &resultTypes,
-    SmallVectorImpl<NamedAttrList> &resultAttrs,
+    SmallVectorImpl<DictionaryAttr> &resultAttrs,
     SmallVectorImpl<Attribute> &resultNames) {
 
   using namespace mlir::function_interface_impl;
-  bool allowArgAttrs = true;
-  bool allowVariadic = false;
-  if (parseFunctionArgumentList(parser, allowArgAttrs, allowVariadic, argNames,
-                                argTypes, argAttrs, isVariadic))
+  if (parser.parseArgumentList(args, OpAsmParser::Delimiter::Paren,
+                               /*allowTypes=*/true, /*allowAttrs=*/true))
     return failure();
 
   if (succeeded(parser.parseOptionalArrow()))

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -431,7 +431,6 @@ ParseResult MSFTModuleOp::parse(OpAsmParser &parser, OperationState &result) {
   SmallVector<Type> argTypes;
   for (auto arg : entryArgs)
     argTypes.push_back(arg.type);
-
   auto type = builder.getFunctionType(argTypes, resultTypes);
   result.addAttribute(getTypeAttrName(), TypeAttr::get(type));
 

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -402,10 +402,8 @@ ParseResult MSFTModuleOp::parse(OpAsmParser &parser, OperationState &result) {
 
   auto loc = parser.getCurrentLocation();
 
-  SmallVector<OpAsmParser::UnresolvedOperand, 4> entryArgs;
-  SmallVector<NamedAttrList, 4> argAttrs;
-  SmallVector<NamedAttrList, 4> resultAttrs;
-  SmallVector<Type, 4> argTypes;
+  SmallVector<OpAsmParser::Argument, 4> entryArgs;
+  SmallVector<DictionaryAttr, 4> resultAttrs;
   SmallVector<Type, 4> resultTypes;
   auto &builder = parser.getBuilder();
 
@@ -425,12 +423,15 @@ ParseResult MSFTModuleOp::parse(OpAsmParser &parser, OperationState &result) {
   bool isVariadic = false;
   SmallVector<Attribute> resultNames;
   if (hw::module_like_impl::parseModuleFunctionSignature(
-          parser, entryArgs, argTypes, argAttrs, isVariadic, resultTypes,
-          resultAttrs, resultNames))
+          parser, entryArgs, isVariadic, resultTypes, resultAttrs, resultNames))
     return failure();
 
   // Record the argument and result types as an attribute.  This is necessary
   // for external modules.
+  SmallVector<Type> argTypes;
+  for (auto arg : entryArgs)
+    argTypes.push_back(arg.type);
+
   auto type = builder.getFunctionType(argTypes, resultTypes);
   result.addAttribute(getTypeAttrName(), TypeAttr::get(type));
 
@@ -452,25 +453,20 @@ ParseResult MSFTModuleOp::parse(OpAsmParser &parser, OperationState &result) {
   if (!entryArgs.empty()) {
     for (auto &arg : entryArgs)
       argNames.push_back(
-          hw::module_like_impl::getPortNameAttr(context, arg.name));
-  } else if (!argTypes.empty()) {
-    // The parser returns empty names in a special way.
-    argNames.assign(argTypes.size(), StringAttr::get(context, ""));
+          hw::module_like_impl::getPortNameAttr(context, arg.ssaName.name));
   }
 
   result.addAttribute("argNames", ArrayAttr::get(context, argNames));
   result.addAttribute("resultNames", ArrayAttr::get(context, resultNames));
 
-  assert(argAttrs.size() == argTypes.size());
   assert(resultAttrs.size() == resultTypes.size());
 
   // Add the attributes to the module arguments.
-  addArgAndResultAttrs(builder, result, argAttrs, resultAttrs);
+  addArgAndResultAttrs(builder, result, entryArgs, resultAttrs);
 
   // Parse the optional module body.
-  auto regionSuccess = parser.parseOptionalRegion(
-      *result.addRegion(), entryArgs,
-      entryArgs.empty() ? ArrayRef<Type>() : argTypes);
+  auto regionSuccess =
+      parser.parseOptionalRegion(*result.addRegion(), entryArgs);
   if (regionSuccess.hasValue() && failed(*regionSuccess))
     return failure();
 
@@ -650,10 +646,8 @@ ParseResult MSFTModuleExternOp::parse(OpAsmParser &parser,
 
   auto loc = parser.getCurrentLocation();
 
-  SmallVector<OpAsmParser::UnresolvedOperand, 4> entryArgs;
-  SmallVector<NamedAttrList, 4> argAttrs;
-  SmallVector<NamedAttrList, 4> resultAttrs;
-  SmallVector<Type, 4> argTypes;
+  SmallVector<OpAsmParser::Argument, 4> entryArgs;
+  SmallVector<DictionaryAttr, 4> resultAttrs;
   SmallVector<Type, 4> resultTypes;
   SmallVector<Attribute> parameters;
   auto &builder = parser.getBuilder();
@@ -669,14 +663,18 @@ ParseResult MSFTModuleExternOp::parse(OpAsmParser &parser,
   SmallVector<Attribute> resultNames;
   if (parseParameterList(parser, parameters) ||
       hw::module_like_impl::parseModuleFunctionSignature(
-          parser, entryArgs, argTypes, argAttrs, isVariadic, resultTypes,
-          resultAttrs, resultNames) ||
+          parser, entryArgs, isVariadic, resultTypes, resultAttrs,
+          resultNames) ||
       // If function attributes are present, parse them.
       parser.parseOptionalAttrDictWithKeyword(result.attributes))
     return failure();
 
   // Record the argument and result types as an attribute.  This is necessary
   // for external modules.
+  SmallVector<Type> argTypes;
+  for (auto arg : entryArgs)
+    argTypes.push_back(arg.type);
+
   auto type = builder.getFunctionType(argTypes, resultTypes);
   result.addAttribute(getTypeAttrName(), TypeAttr::get(type));
 
@@ -694,10 +692,7 @@ ParseResult MSFTModuleExternOp::parse(OpAsmParser &parser,
   if (!entryArgs.empty()) {
     for (auto &arg : entryArgs)
       argNames.push_back(
-          hw::module_like_impl::getPortNameAttr(context, arg.name));
-  } else if (!argTypes.empty()) {
-    // The parser returns empty names in a special way.
-    argNames.assign(argTypes.size(), StringAttr::get(context, ""));
+          hw::module_like_impl::getPortNameAttr(context, arg.ssaName.name));
   }
 
   // An explicit `argNames` attribute overrides the MLIR names.  This is how
@@ -709,11 +704,10 @@ ParseResult MSFTModuleExternOp::parse(OpAsmParser &parser,
   result.addAttribute("resultNames", ArrayAttr::get(context, resultNames));
   result.addAttribute("parameters", ArrayAttr::get(context, parameters));
 
-  assert(argAttrs.size() == argTypes.size());
   assert(resultAttrs.size() == resultTypes.size());
 
   // Add the attributes to the function arguments.
-  addArgAndResultAttrs(builder, result, argAttrs, resultAttrs);
+  addArgAndResultAttrs(builder, result, entryArgs, resultAttrs);
 
   // Extern modules carry an empty region to work with HWModuleImplementation.h.
   result.addRegion();
@@ -857,10 +851,22 @@ ParseResult SystolicArrayOp::parse(OpAsmParser &parser,
   result.addOperands(operands);
 
   Type peOutputType;
-  SmallVector<OpAsmParser::UnresolvedOperand> peArgs;
-  if (parser.parseKeyword("pe") ||
-      parser.parseOperandList(peArgs, 2, AsmParser::Delimiter::Paren) ||
-      parser.parseArrow() || parser.parseLParen() ||
+  SmallVector<OpAsmParser::Argument> peArgs;
+  if (parser.parseKeyword("pe")) {
+    return failure();
+  }
+  llvm::SMLoc peLoc = parser.getCurrentLocation();
+  if (parser.parseArgumentList(peArgs, AsmParser::Delimiter::Paren)) {
+    return failure();
+  }
+  if (peArgs.size() != 2) {
+    return parser.emitError(peLoc, "expected two operands");
+  }
+
+  peArgs[0].type = rowType;
+  peArgs[1].type = columnType;
+
+  if (parser.parseArrow() || parser.parseLParen() ||
       parser.parseType(peOutputType) || parser.parseRParen())
     return failure();
 
@@ -868,9 +874,12 @@ ParseResult SystolicArrayOp::parse(OpAsmParser &parser,
       hw::ArrayType::get(peOutputType, numColumns), numRows)});
 
   Region *pe = result.addRegion();
-  llvm::SMLoc peLoc = parser.getCurrentLocation();
-  if (parser.parseRegion(*pe, peArgs, {rowType, columnType}))
+
+  peLoc = parser.getCurrentLocation();
+
+  if (parser.parseRegion(*pe, peArgs))
     return failure();
+
   if (pe->getBlocks().size() != 1)
     return parser.emitError(peLoc, "expected one block for the PE");
   Operation *peTerm = pe->getBlocks().front().getTerminator();

--- a/test/Analysis/dependence-analysis.mlir
+++ b/test/Analysis/dependence-analysis.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt %s -test-dependence-analysis | FileCheck %s
 
 // CHECK-LABEL: func @test1
-func @test1(%arg0: memref<?xi32>) -> i32 {
+func.func @test1(%arg0: memref<?xi32>) -> i32 {
   %c0_i32 = arith.constant 0 : i32
   %0:2 = affine.for %arg1 = 0 to 10 iter_args(%arg2 = %c0_i32, %arg3 = %c0_i32) -> (i32, i32) {
     // CHECK: affine.load %arg0[%arg1] {dependences = []}
@@ -14,7 +14,7 @@ func @test1(%arg0: memref<?xi32>) -> i32 {
 
 // CHECK-LABEL: func @test2
 #set = affine_set<(d0) : (d0 - 3 >= 0)>
-func @test2(%arg0: memref<?xi32>, %arg1: memref<?xi32>) {
+func.func @test2(%arg0: memref<?xi32>, %arg1: memref<?xi32>) {
   affine.for %arg2 = 0 to 10 {
     // CHECK: affine.load %arg0[%arg2] {dependences = []}
     %0 = affine.load %arg0[%arg2] : memref<?xi32>
@@ -30,7 +30,7 @@ func @test2(%arg0: memref<?xi32>, %arg1: memref<?xi32>) {
 }
 
 // CHECK-LABEL: func @test3
-func @test3(%arg0: memref<?xi32>) {
+func.func @test3(%arg0: memref<?xi32>) {
   %0 = memref.alloca() : memref<1xi32>
   %1 = memref.alloca() : memref<1xi32>
   %2 = memref.alloca() : memref<1xi32>
@@ -55,7 +55,7 @@ func @test3(%arg0: memref<?xi32>) {
 }
 
 // CHECK-LABEL: func @test4
-func @test4(%arg0: memref<?xi32>, %arg1: memref<?xi32>) {
+func.func @test4(%arg0: memref<?xi32>, %arg1: memref<?xi32>) {
   %c1_i32 = arith.constant 1 : i32
   affine.for %arg2 = 0 to 10 {
     // CHECK: affine.load %arg1[%arg2] {dependences = []}
@@ -69,7 +69,7 @@ func @test4(%arg0: memref<?xi32>, %arg1: memref<?xi32>) {
 }
 
 // CHECK-LABEL: func @test5
-func @test5(%arg0: memref<?xi32>) {
+func.func @test5(%arg0: memref<?xi32>) {
   affine.for %arg1 = 2 to 10 {
     // CHECK{LITERAL}: affine.load %arg0[%arg1 - 2] {dependences = [[[1, 1]], [[2, 2]]]}
     %0 = affine.load %arg0[%arg1 - 2] : memref<?xi32>
@@ -84,7 +84,7 @@ func @test5(%arg0: memref<?xi32>) {
 
 // CHECK-LABEL: func @test6
 #set1 = affine_set<(d0) : (d0 - 5 >= 0)>
-func @test6(%arg0: memref<?xi32>) {
+func.func @test6(%arg0: memref<?xi32>) {
   affine.for %arg1 = 0 to 10 {
     %0 = affine.if #set1(%arg1) -> i32 {
       // CHECK: affine.load %arg0[%arg1] {dependences = []}
@@ -103,7 +103,7 @@ func @test6(%arg0: memref<?xi32>) {
 // CHECK-LABEL: func @test7
 #set2 = affine_set<(d0) : (d0 - 2 >= 0)>
 #set3 = affine_set<(d0) : (d0 - 6 >= 0)>
-func @test7(%arg0: memref<?xi32>) {
+func.func @test7(%arg0: memref<?xi32>) {
   affine.for %arg1 = 0 to 10 {
     affine.if #set2(%arg1) {
       %0 = affine.if #set3(%arg1) -> i32 {
@@ -119,7 +119,7 @@ func @test7(%arg0: memref<?xi32>) {
 }
 
 // CHECK-LABEL: func @test8
-func @test8(%arg0: memref<?xi32>) {
+func.func @test8(%arg0: memref<?xi32>) {
   affine.for %arg1 = 0 to 10 {
     affine.if #set2(%arg1) {
       %0 = affine.if #set3(%arg1) -> i32 {

--- a/test/Analysis/scheduling-analysis.mlir
+++ b/test/Analysis/scheduling-analysis.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt %s -test-scheduling-analysis | FileCheck %s
 
 // CHECK-LABEL: func @test1
-func @test1(%arg0: memref<?xi32>) -> i32 {
+func.func @test1(%arg0: memref<?xi32>) -> i32 {
   %c0_i32 = arith.constant 0 : i32
   %0:2 = affine.for %arg1 = 0 to 10 iter_args(%arg2 = %c0_i32, %arg3 = %c0_i32) -> (i32, i32) {
     %1 = affine.load %arg0[%arg1] : memref<?xi32>
@@ -13,7 +13,7 @@ func @test1(%arg0: memref<?xi32>) -> i32 {
 }
 // CHECK-LABEL: func @test2
 #set = affine_set<(d0) : (d0 - 3 >= 0)>
-func @test2(%arg0: memref<?xi32>, %arg1: memref<?xi32>) {
+func.func @test2(%arg0: memref<?xi32>, %arg1: memref<?xi32>) {
   affine.for %arg2 = 0 to 10 {
     %0 = affine.load %arg0[%arg2] : memref<?xi32>
     affine.if #set(%arg2) {
@@ -27,7 +27,7 @@ func @test2(%arg0: memref<?xi32>, %arg1: memref<?xi32>) {
 }
 
 // CHECK-LABEL: func @test3
-func @test3(%arg0: memref<?xi32>) {
+func.func @test3(%arg0: memref<?xi32>) {
   %0 = memref.alloca() : memref<1xi32>
   %1 = memref.alloca() : memref<1xi32>
   %2 = memref.alloca() : memref<1xi32>
@@ -52,7 +52,7 @@ func @test3(%arg0: memref<?xi32>) {
 
 // CHECK-LABEL: func @test4
 // CHECK-NOT: dependence
-func @test4(%arg0: memref<?xi32>, %arg1: memref<?xi32>) {
+func.func @test4(%arg0: memref<?xi32>, %arg1: memref<?xi32>) {
   %c1_i32 = arith.constant 1 : i32
   affine.for %arg2 = 0 to 10 {
     %0 = affine.load %arg1[%arg2] : memref<?xi32>
@@ -65,7 +65,7 @@ func @test4(%arg0: memref<?xi32>, %arg1: memref<?xi32>) {
 }
 
 // CHECK-LABEL: func @test5
-func @test5(%arg0: memref<?xi32>) {
+func.func @test5(%arg0: memref<?xi32>) {
   affine.for %arg1 = 2 to 10 {
     // CHECK: affine.load %arg0[%arg1 - 2] {dependence}
     %0 = affine.load %arg0[%arg1 - 2] : memref<?xi32>
@@ -79,7 +79,7 @@ func @test5(%arg0: memref<?xi32>) {
 
 // CHECK-LABEL: func @test6
 #set1 = affine_set<(d0) : (d0 - 5 >= 0)>
-func @test6(%arg0: memref<?xi32>) {
+func.func @test6(%arg0: memref<?xi32>) {
   affine.for %arg1 = 0 to 10 {
     %0 = affine.if #set1(%arg1) -> i32 {
       %1 = affine.load %arg0[%arg1] : memref<?xi32>
@@ -98,7 +98,7 @@ func @test6(%arg0: memref<?xi32>) {
 // CHECK-LABEL: func @test7
 #set2 = affine_set<(d0) : (d0 - 2 >= 0)>
 #set3 = affine_set<(d0) : (d0 - 6 >= 0)>
-func @test7(%arg0: memref<?xi32>) {
+func.func @test7(%arg0: memref<?xi32>) {
   affine.for %arg1 = 0 to 10 {
     affine.if #set2(%arg1) {
       %0 = affine.if #set3(%arg1) -> i32 {
@@ -114,7 +114,7 @@ func @test7(%arg0: memref<?xi32>) {
 }
 
 // CHECK-LABEL: func @test8
-func @test8(%arg0: memref<?xi32>) {
+func.func @test8(%arg0: memref<?xi32>) {
   affine.for %arg1 = 0 to 10 {
     affine.if #set2(%arg1) {
       %0 = affine.if #set3(%arg1) -> i32 {
@@ -133,7 +133,7 @@ func @test8(%arg0: memref<?xi32>) {
 }
 
 // CHECK-LABEL: func @test9
-func @test9(%arg0: memref<4x4xi32>, %arg1: memref<4x4xi32>, %arg2: memref<4x4xi32>) {
+func.func @test9(%arg0: memref<4x4xi32>, %arg1: memref<4x4xi32>, %arg2: memref<4x4xi32>) {
   affine.for %arg3 = 0 to 4 {
     affine.for %arg4 = 0 to 4 {
       affine.for %arg5 = 0 to 4 {
@@ -152,7 +152,7 @@ func @test9(%arg0: memref<4x4xi32>, %arg1: memref<4x4xi32>, %arg2: memref<4x4xi3
 }
 
 // CHECK-LABEL: func @test10
-func @test10(%arg0: memref<5xi32>) {
+func.func @test10(%arg0: memref<5xi32>) {
   %true = arith.constant 1 : i1
   %c0_i32 = arith.constant 0 : i32
   affine.for %arg1 = 0 to 5 {

--- a/test/Conversion/AffineToStaticLogic/loops.mlir
+++ b/test/Conversion/AffineToStaticLogic/loops.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt -convert-affine-to-staticlogic %s | FileCheck %s
 
 // CHECK-LABEL: func @minimal
-func @minimal(%arg0 : memref<10xindex>) {
+func.func @minimal(%arg0 : memref<10xindex>) {
   // Setup constants.
   // CHECK: %[[LB:.+]] = arith.constant 0 : [[ITER_TYPE:.+]]
   // CHECK: %[[UB:.+]] = arith.constant [[TRIP_COUNT:.+]] : [[ITER_TYPE]]
@@ -30,7 +30,7 @@ func @minimal(%arg0 : memref<10xindex>) {
 }
 
 // CHECK-LABEL: func @dot
-func @dot(%arg0: memref<64xi32>, %arg1: memref<64xi32>) -> i32 {
+func.func @dot(%arg0: memref<64xi32>, %arg1: memref<64xi32>) -> i32 {
   // Pipeline boilerplate checked above, just check the stages computations.
 
   // First stage.

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
@@ -10,7 +10,7 @@
 
 firrtl.circuit "OperandTypeIsFIRRTL" {
   firrtl.module @OperandTypeIsFIRRTL() { }
-  func.func @Test() {
+    func.func @Test() {
     // expected-error @+1 {{Found unhandled FIRRTL operation 'firrtl.constant'}}
     %a = firrtl.constant 0 : !firrtl.uint<1>
     return

--- a/test/Conversion/LLHDToLLVM/convert_aggregates.mlir
+++ b/test/Conversion/LLHDToLLVM/convert_aggregates.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt %s --convert-llhd-to-llvm | FileCheck %s
 
 // CHECK-LABEL: llvm.func @convertBitcast
-func @convertBitcast(%arg0 : i32, %arg1: !hw.array<2xi32>, %arg2: !hw.struct<foo: i32, bar: i32>) {
+func.func @convertBitcast(%arg0 : i32, %arg1: !hw.array<2xi32>, %arg2: !hw.struct<foo: i32, bar: i32>) {
 
   // CHECK-NEXT: %[[ONE1:.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK-NEXT: %[[A1:.*]] = llvm.alloca %[[ONE1]] x i32 {alignment = 4 : i64} : (i32) -> !llvm.ptr<i32>
@@ -28,7 +28,7 @@ func @convertBitcast(%arg0 : i32, %arg1: !hw.array<2xi32>, %arg2: !hw.struct<foo
 }
 
 // CHECK-LABEL: llvm.func @convertArray
-func @convertArray(%arg0 : i1, %arg1: !hw.array<2xi32>) {
+func.func @convertArray(%arg0 : i1, %arg1: !hw.array<2xi32>) {
 
   // CHECK-NEXT: %[[ZERO:.*]] = llvm.mlir.constant(0 : i32) : i32
   // CHECK-NEXT: %[[ONE:.*]] = llvm.mlir.constant(1 : i32) : i32
@@ -59,12 +59,12 @@ func @convertArray(%arg0 : i1, %arg1: !hw.array<2xi32>) {
   // CHECK-NEXT: %[[E4:.*]] = llvm.extractvalue %arg1[1 : i32] : !llvm.array<2 x i32>
   // CHECK-NEXT: llvm.insertvalue %[[E4]], %[[I3]][3 : i32] : !llvm.array<4 x i32>
   %2 = hw.array_concat %arg1, %arg1 : !hw.array<2xi32>, !hw.array<2xi32>
-  
+
   return
 }
 
 // CHECK-LABEL: llvm.func @convertStruct
-func @convertStruct(%arg0 : i32, %arg1: !hw.struct<foo: i32, bar: i8>) {
+func.func @convertStruct(%arg0 : i32, %arg1: !hw.struct<foo: i32, bar: i8>) {
   // CHECK-NEXT: llvm.extractvalue %arg1[1 : i32] : !llvm.struct<(i8, i32)>
   %0 = hw.struct_extract %arg1["foo"] : !hw.struct<foo: i32, bar: i8>
 

--- a/test/Conversion/LLHDToLLVM/convert_arithmetic.mlir
+++ b/test/Conversion/LLHDToLLVM/convert_arithmetic.mlir
@@ -2,7 +2,7 @@
 // RUN: circt-opt %s --convert-llhd-to-llvm | FileCheck %s
 
 // CHECK-LABEL:   llvm.func @convertArithmetic
-func @convertArithmetic(%arg0: i32, %arg1: i32, %arg2: i32) -> i32 {
+func.func @convertArithmetic(%arg0: i32, %arg1: i32, %arg2: i32) -> i32 {
     // CHECK: %[[R0:.*]] = llvm.add %arg0, %arg1 : i32
     // CHECK: %[[R1:.*]] = llvm.add %[[R0]], %arg2 : i32
     %0 = comb.add %arg0, %arg1, %arg2 : i32
@@ -28,7 +28,7 @@ func @convertArithmetic(%arg0: i32, %arg1: i32, %arg2: i32) -> i32 {
 }
 
 // CHECK-LABEL:   llvm.func @convertRelational
-func @convertRelational(%arg0: i32, %arg1: i32) {
+func.func @convertRelational(%arg0: i32, %arg1: i32) {
     // CHECK: llvm.icmp "eq" %arg0, %arg1 : i32
     %0 = comb.icmp eq %arg0, %arg1 : i32
     // CHECK: llvm.icmp "ne" %arg0, %arg1 : i32

--- a/test/Conversion/LLHDToLLVM/convert_bitwise.mlir
+++ b/test/Conversion/LLHDToLLVM/convert_bitwise.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: convert_bitwise_i1
 // CHECK-SAME: %[[LHS:.*]]: i1,
 // CHECK-SAME: %[[RHS:.*]]: i1
-func @convert_bitwise_i1(%lhs : i1, %rhs : i1) {
+func.func @convert_bitwise_i1(%lhs : i1, %rhs : i1) {
   // CHECK-NEXT: %{{.*}} = llvm.and %[[LHS]], %[[RHS]] : i1
   %1 = comb.and %lhs, %rhs : i1
   // CHECK-NEXT: %{{.*}} = llvm.or %[[LHS]], %[[RHS]] : i1
@@ -17,7 +17,7 @@ func @convert_bitwise_i1(%lhs : i1, %rhs : i1) {
 // CHECK-LABEL: convert_bitwise_i32
 // CHECK-SAME: %[[LHS:.*]]: i32,
 // CHECK-SAME: %[[RHS:.*]]: i32
-func @convert_bitwise_i32(%lhs : i32, %rhs : i32) {
+func.func @convert_bitwise_i32(%lhs : i32, %rhs : i32) {
   // CHECK-NEXT: %{{.*}} = llvm.and %[[LHS]], %[[RHS]] : i32
   comb.and %lhs, %rhs : i32
   // CHECK-NEXT: %{{.*}} = llvm.or %[[LHS]], %[[RHS]] : i32
@@ -29,7 +29,7 @@ func @convert_bitwise_i32(%lhs : i32, %rhs : i32) {
 }
 
 // CHECK-LABEL: convert_bitwise_i32_variadic
-func @convert_bitwise_i32_variadic(%arg0 : i32, %arg1 : i32, %arg2 : i32) {
+func.func @convert_bitwise_i32_variadic(%arg0 : i32, %arg1 : i32, %arg2 : i32) {
   %a = comb.and %arg0 : i32
   %b = comb.or %arg1 : i32
   %c = comb.xor %arg2 : i32
@@ -51,7 +51,7 @@ func @convert_bitwise_i32_variadic(%arg0 : i32, %arg1 : i32, %arg2 : i32) {
 // CHECK-SAME: %[[BASE:.*]]: i5,
 // CHECK-SAME: %[[HIDDEN:.*]]: i2,
 // CHECK-SAME: %[[AMOUNT:.*]]: i2
-func @convert_shl_i5_i2_i2(%base : i5, %hidden : i2, %amount : i2) {
+func.func @convert_shl_i5_i2_i2(%base : i5, %hidden : i2, %amount : i2) {
   // CHECK-NEXT: %[[ZEXTB:.*]] = llvm.zext %[[BASE]] : i5 to i7
   // CHECK-NEXT: %[[ZEXTH:.*]] = llvm.zext %[[HIDDEN]] : i2 to i7
   // CHECK-NEXT: %[[ZEXTA:.*]] = llvm.zext %[[AMOUNT]] : i2 to i7
@@ -70,7 +70,7 @@ func @convert_shl_i5_i2_i2(%base : i5, %hidden : i2, %amount : i2) {
 // CHECK-SAME: %[[BASE:.*]]: i5,
 // CHECK-SAME: %[[HIDDEN:.*]]: i2,
 // CHECK-SAME: %[[AMOUNT:.*]]: i2
-func @convert_shr_i5_i2_i2(%base : i5, %hidden : i2, %amount : i2) {
+func.func @convert_shr_i5_i2_i2(%base : i5, %hidden : i2, %amount : i2) {
   // CHECK-NEXT: %[[ZEXTB:.*]] = llvm.zext %[[BASE]] : i5 to i7
   // CHECK-NEXT: %[[ZEXTH:.*]] = llvm.zext %[[HIDDEN]] : i2 to i7
   // CHECK-NEXT: %[[ZEXTA:.*]] = llvm.zext %[[AMOUNT]] : i2 to i7
@@ -85,7 +85,7 @@ func @convert_shr_i5_i2_i2(%base : i5, %hidden : i2, %amount : i2) {
 }
 
 // CHECK-LABEL: llvm.func @convert_comb_shift
-func @convert_comb_shift(%arg0: i32, %arg1: i32, %arg2: i1) -> i32 {
+func.func @convert_comb_shift(%arg0: i32, %arg1: i32, %arg2: i1) -> i32 {
 
   // CHECK: %[[R0:.*]] = llvm.shl %arg0, %arg1 : i32
   %0 = comb.shl %arg0, %arg1 : i32

--- a/test/Conversion/LLHDToLLVM/convert_extract.mlir
+++ b/test/Conversion/LLHDToLLVM/convert_extract.mlir
@@ -34,7 +34,7 @@
 // CHECK:           llvm.store %[[VAL_26]], %[[VAL_28]] : !llvm.ptr<struct<(ptr<i8>, i64, i64, i64)>>
 // CHECK:           llvm.return
 // CHECK:         }
-func @convertSigExtract (%c : i5, %sI32 : !llhd.sig<i32>) {
+func.func @convertSigExtract (%c : i5, %sI32 : !llhd.sig<i32>) {
   %0 = llhd.sig.extract %sI32 from %c : (!llhd.sig<i32>) -> !llhd.sig<i10>
 
   return
@@ -70,7 +70,7 @@ func @convertSigExtract (%c : i5, %sI32 : !llhd.sig<i32>) {
 // CHECK:           llvm.store %[[VAL_23]], %[[VAL_25]] : !llvm.ptr<struct<(ptr<i8>, i64, i64, i64)>>
 // CHECK:           llvm.return
 // CHECK:         }
-func @convertSigArraySlice (%c : i2, %sArr : !llhd.sig<!hw.array<4xi4>>) {
+func.func @convertSigArraySlice (%c : i2, %sArr : !llhd.sig<!hw.array<4xi4>>) {
   %1 = llhd.sig.array_slice %sArr at %c : (!llhd.sig<!hw.array<4xi4>>) -> !llhd.sig<!hw.array<2xi4>>
 
   return
@@ -105,7 +105,7 @@ func @convertSigArraySlice (%c : i2, %sArr : !llhd.sig<!hw.array<4xi4>>) {
 // CHECK:           llvm.store %[[VAL_22]], %[[VAL_24]] : !llvm.ptr<struct<(ptr<i8>, i64, i64, i64)>>
 // CHECK:           llvm.return
 // CHECK:         }
-func @convertSigStructExtract (%sTup : !llhd.sig<!hw.struct<foo: i1, bar: i2, baz: i3>>) {
+func.func @convertSigStructExtract (%sTup : !llhd.sig<!hw.struct<foo: i1, bar: i2, baz: i3>>) {
   %1 = llhd.sig.struct_extract %sTup["bar"] : !llhd.sig<!hw.struct<foo: i1, bar: i2, baz: i3>>
 
   return
@@ -141,7 +141,7 @@ func @convertSigStructExtract (%sTup : !llhd.sig<!hw.struct<foo: i1, bar: i2, ba
 // CHECK:           llvm.store %[[VAL_23]], %[[VAL_25]] : !llvm.ptr<struct<(ptr<i8>, i64, i64, i64)>>
 // CHECK:           llvm.return
 // CHECK:         }
-func @convertSigArrayGet(%sArr : !llhd.sig<!hw.array<4xi4>>, %c : i2) {
+func.func @convertSigArrayGet(%sArr : !llhd.sig<!hw.array<4xi4>>, %c : i2) {
   %1 = llhd.sig.array_get %sArr[%c] : !llhd.sig<!hw.array<4xi4>>
 
   return

--- a/test/Conversion/LLHDToLLVM/convert_memory.mlir
+++ b/test/Conversion/LLHDToLLVM/convert_memory.mlir
@@ -12,7 +12,7 @@
 // CHECK:           llvm.store %[[VAL_1]], %[[VAL_5]] : !llvm.ptr<i32>
 // CHECK:           llvm.return
 // CHECK:         }
-func @lower_var(%i1 : i1, %i32 : i32) {
+func.func @lower_var(%i1 : i1, %i32 : i32) {
   %0 = llhd.var %i1 : i1
   %1 = llhd.var %i32 : i32
   return
@@ -25,7 +25,7 @@ func @lower_var(%i1 : i1, %i32 : i32) {
 // CHECK:           %[[VAL_3:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<i32>
 // CHECK:           llvm.return
 // CHECK:         }
-func @lower_load(%i1 : !llhd.ptr<i1>, %i32 : !llhd.ptr<i32>) {
+func.func @lower_load(%i1 : !llhd.ptr<i1>, %i32 : !llhd.ptr<i32>) {
   %0 = llhd.load %i1 : !llhd.ptr<i1>
   %1 = llhd.load %i32 : !llhd.ptr<i32>
   return
@@ -40,7 +40,7 @@ func @lower_load(%i1 : !llhd.ptr<i1>, %i32 : !llhd.ptr<i32>) {
 // CHECK:           llvm.store %[[VAL_2]], %[[VAL_3]] : !llvm.ptr<i32>
 // CHECK:           llvm.return
 // CHECK:         }
-func @lower_store(%i1 : i1, %i1Ptr : !llhd.ptr<i1>, %i32 : i32, %i32Ptr : !llhd.ptr<i32>) {
+func.func @lower_store(%i1 : i1, %i1Ptr : !llhd.ptr<i1>, %i32 : i32, %i32Ptr : !llhd.ptr<i32>) {
   llhd.store %i1Ptr, %i1 : !llhd.ptr<i1>
   llhd.store %i32Ptr, %i32 : !llhd.ptr<i32>
   return

--- a/test/Conversion/LLHDToLLVM/convert_process_persistence.mlir
+++ b/test/Conversion/LLHDToLLVM/convert_process_persistence.mlir
@@ -2,27 +2,27 @@
 // RUN: circt-opt %s --convert-llhd-to-llvm | FileCheck %s
 
 // CHECK-LABEL: @dummy_i1
-func @dummy_i1 (%0 : i1) {
+func.func @dummy_i1 (%0 : i1) {
   return
 }
 
 // CHECK-LABEL: @dummy_i32
-func @dummy_i32 (%0 : i32)  {
+func.func @dummy_i32 (%0 : i32)  {
   return
 }
 
 // CHECK-LABEL: @dummy_time
-func @dummy_time (%0 : !llhd.time) {
+func.func @dummy_time (%0 : !llhd.time) {
   return
 }
 
 // CHECK-LABEL: @dummy_ptr
-func @dummy_ptr(%0 : !llhd.ptr<i32>) {
+func.func @dummy_ptr(%0 : !llhd.ptr<i32>) {
   return
 }
 
 // CHECK-LABEL: @dummy_subsig
-func @dummy_subsig(%0 : !llhd.sig<i10>) {
+func.func @dummy_subsig(%0 : !llhd.sig<i10>) {
   return
 }
 
@@ -62,7 +62,7 @@ llhd.proc @convert_persistent_i1 () -> () {
   %0 = hw.constant 0 : i1
   cf.br ^resume
 ^resume:
-  call @dummy_i1(%0) : (i1) -> ()
+  func.call @dummy_i1(%0) : (i1) -> ()
   cf.br ^resume
 }
 
@@ -103,7 +103,7 @@ llhd.proc @convert_persistent_i32 () -> () {
   %0 = hw.constant 0 : i32
   cf.br ^resume
 ^resume:
-  call @dummy_i32(%0) : (i32) -> ()
+  func.call @dummy_i32(%0) : (i32) -> ()
   cf.br ^resume
 }
 
@@ -143,7 +143,7 @@ llhd.proc @convert_persistent_time () -> () {
   %0 = llhd.constant_time #llhd.time<0ns, 0d, 1e>
   cf.br ^resume
 ^resume:
-  call @dummy_time(%0) : (!llhd.time) -> ()
+  func.call @dummy_time(%0) : (!llhd.time) -> ()
   cf.br ^resume
 }
 
@@ -187,7 +187,7 @@ llhd.proc @convert_persistent_ptr () -> () {
   %1 = llhd.var %0 : i32
   cf.br ^resume
 ^resume:
-  call @dummy_ptr(%1) : (!llhd.ptr<i32>) -> ()
+  func.call @dummy_ptr(%1) : (!llhd.ptr<i32>) -> ()
   cf.br ^resume
 }
 
@@ -258,7 +258,7 @@ llhd.proc @convert_persistent_subsig () -> (%out : !llhd.sig<i32>) {
   %0 = llhd.sig.extract %out from %zero : (!llhd.sig<i32>) -> !llhd.sig<i10>
   cf.br ^resume
 ^resume:
-  call @dummy_subsig(%0) : (!llhd.sig<i10>) -> ()
+  func.call @dummy_subsig(%0) : (!llhd.sig<i10>) -> ()
   cf.br ^resume
 }
 
@@ -306,7 +306,7 @@ llhd.proc @convert_persistent_block_argument () -> () {
 ^argBB(%i : i32):
     cf.br ^end
 ^end:
-    call @dummy_i32(%i) : (i32) -> ()
+    func.call @dummy_i32(%i) : (i32) -> ()
     llhd.halt
 }
 

--- a/test/Conversion/LLHDToLLVM/convert_value_creation.mlir
+++ b/test/Conversion/LLHDToLLVM/convert_value_creation.mlir
@@ -32,7 +32,7 @@ llvm.func @convert_const() {
 // CHECK:           %[[VAL_10:.*]] = llvm.insertvalue %[[VAL_1]], %[[VAL_9]][3 : i32] : !llvm.array<4 x i32>
 // CHECK:           llvm.return
 // CHECK:         }
-func @convert_array(%ci1 : i1, %ci32 : i32) {
+func.func @convert_array(%ci1 : i1, %ci32 : i32) {
   %0 = hw.array_create %ci1, %ci1, %ci1 : i1
   %1 = hw.array_create %ci32, %ci32, %ci32, %ci32 : i32
 
@@ -49,7 +49,7 @@ func @convert_array(%ci1 : i1, %ci32 : i32) {
 // CHECK:           %[[VAL_6:.*]] = llvm.insertvalue %[[VAL_0]], %[[VAL_5]][2 : i32] : !llvm.struct<(i3, i2, i1)>
 // CHECK:           llvm.return
 // CHECK:         }
-func @convert_tuple(%ci1 : i1, %ci2 : i2, %ci3 : i3) {
+func.func @convert_tuple(%ci1 : i1, %ci2 : i2, %ci3 : i3) {
   %0 = hw.struct_create (%ci1, %ci2, %ci3) : !hw.struct<foo: i1, bar: i2, baz: i3>
 
   return

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -14,14 +14,14 @@ llhd.entity @test1() -> () {
 
 // CHECK-LABEL: func @FuncArgsAndReturns
 // CHECK-SAME: (%arg0: i8, %arg1: i32, %arg2: i1) -> i8
-func @FuncArgsAndReturns(%arg0: !moore.byte, %arg1: !moore.int, %arg2: !moore.bit) -> !moore.byte {
+func.func @FuncArgsAndReturns(%arg0: !moore.byte, %arg1: !moore.int, %arg2: !moore.bit) -> !moore.byte {
   // CHECK-NEXT: return %arg0 : i8
   return %arg0 : !moore.byte
 }
 
 // CHECK-LABEL: func @ControlFlow
 // CHECK-SAME: (%arg0: i32, %arg1: i1)
-func @ControlFlow(%arg0: !moore.int, %arg1: i1) {
+func.func @ControlFlow(%arg0: !moore.int, %arg1: i1) {
   // CHECK-NEXT:   cf.br ^bb1(%arg0 : i32)
   // CHECK-NEXT: ^bb1(%0: i32):
   // CHECK-NEXT:   cf.cond_br %arg1, ^bb1(%0 : i32), ^bb2(%arg0 : i32)
@@ -36,7 +36,7 @@ func @ControlFlow(%arg0: !moore.int, %arg1: i1) {
 
 // CHECK-LABEL: func @Calls
 // CHECK-SAME: (%arg0: i8, %arg1: i32, %arg2: i1) -> i8
-func @Calls(%arg0: !moore.byte, %arg1: !moore.int, %arg2: !moore.bit) -> !moore.byte {
+func.func @Calls(%arg0: !moore.byte, %arg1: !moore.int, %arg2: !moore.bit) -> !moore.byte {
   // CHECK-NEXT: %true =
   // CHECK-NEXT: call @ControlFlow(%arg1, %true) : (i32, i1) -> ()
   // CHECK-NEXT: [[TMP:%.+]] = call @FuncArgsAndReturns(%arg0, %arg1, %arg2) : (i8, i32, i1) -> i8
@@ -48,7 +48,7 @@ func @Calls(%arg0: !moore.byte, %arg1: !moore.int, %arg2: !moore.bit) -> !moore.
 }
 
 // CHECK-LABEL: func @UnrealizedConversionCast
-func @UnrealizedConversionCast(%arg0: !moore.byte) -> !moore.shortint {
+func.func @UnrealizedConversionCast(%arg0: !moore.byte) -> !moore.shortint {
   // CHECK-NEXT: [[TMP:%.+]] = comb.concat %arg0, %arg0 : i8, i8
   // CHECK-NEXT: return [[TMP]] : i16
   %0 = builtin.unrealized_conversion_cast %arg0 : !moore.byte to i8
@@ -58,7 +58,7 @@ func @UnrealizedConversionCast(%arg0: !moore.byte) -> !moore.shortint {
 }
 
 // CHECK-LABEL: func @Expressions
-func @Expressions(%arg0: !moore.bit, %arg1: !moore.logic, %arg2: !moore.packed<range<bit, 5:0>>, %arg3: !moore.packed<range<bit<signed>, 4:0>>) {
+func.func @Expressions(%arg0: !moore.bit, %arg1: !moore.logic, %arg2: !moore.packed<range<bit, 5:0>>, %arg3: !moore.packed<range<bit<signed>, 4:0>>) {
   // CHECK-NEXT: %0 = comb.concat %arg0, %arg0 : i1, i1
   // CHECK-NEXT: %1 = comb.concat %arg1, %arg1 : i1, i1
   %0 = moore.mir.concat %arg0, %arg0 : (!moore.bit, !moore.bit) -> !moore.packed<range<bit, 1:0>>

--- a/test/Conversion/SCFToCalyx/cider_source_location.mlir
+++ b/test/Conversion/SCFToCalyx/cider_source_location.mlir
@@ -2,7 +2,7 @@
 
 module {
 // CHECK: module attributes {calyx.metadata = ["loc({{.*}}11:5)", "loc({{.*}}13:5)"]}
-  func @main(%a0 : i32, %a1 : i32, %a2 : i32) -> i32 {
+  func.func @main(%a0 : i32, %a1 : i32, %a2 : i32) -> i32 {
     %0 = arith.addi %a0, %a1 : i32
     %1 = arith.addi %0, %a1 : i32
     %b = arith.cmpi uge, %1, %a2 : i32

--- a/test/Conversion/SCFToCalyx/convert_controlflow.mlir
+++ b/test/Conversion/SCFToCalyx/convert_controlflow.mlir
@@ -47,7 +47,7 @@
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 module {
-  func @main(%arg0 : i32, %arg1 : i32) -> i32 {
+  func.func @main(%arg0 : i32, %arg1 : i32) -> i32 {
     %0 = arith.cmpi slt, %arg0, %arg1 : i32
     cf.cond_br %0, ^bb1, ^bb2
   ^bb1:
@@ -170,7 +170,7 @@ module {
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 module {
-  func @main(%arg0: i32, %arg1: i32, %arg2: i32) -> i32 {
+  func.func @main(%arg0: i32, %arg1: i32, %arg2: i32) -> i32 {
     %cst = arith.constant 0 : i32
     %0:3 = scf.while (%arg3 = %arg0, %arg4 = %cst, %arg5 = %cst) : (i32, i32, i32) -> (i32, i32, i32) {
       %1 = arith.cmpi slt, %arg3, %arg1 : i32
@@ -305,7 +305,7 @@ module {
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 module {
-  func @main(%arg0: i32, %arg1: i32, %arg2: i32) -> i32 {
+  func.func @main(%arg0: i32, %arg1: i32, %arg2: i32) -> i32 {
     %cst = arith.constant 0 : i32
     %0:3 = scf.while (%arg3 = %arg0, %arg4 = %cst, %arg5 = %cst) : (i32, i32, i32) -> (i32, i32, i32) {
       %1 = arith.cmpi slt, %arg3, %arg1 : i32
@@ -381,7 +381,7 @@ module {
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 module {
-  func @main(%a0 : i32, %a1 : i32, %a2 : i32) -> i32 {
+  func.func @main(%a0 : i32, %a1 : i32, %a2 : i32) -> i32 {
     %0 = arith.addi %a0, %a1 : i32
     %1 = arith.addi %0, %a1 : i32
     %b = arith.cmpi uge, %1, %a2 : i32

--- a/test/Conversion/SCFToCalyx/convert_memory.mlir
+++ b/test/Conversion/SCFToCalyx/convert_memory.mlir
@@ -56,7 +56,7 @@
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 module {
-  func @main() {
+  func.func @main() {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %c64 = arith.constant 64 : index
@@ -124,7 +124,7 @@ module {
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 module {
-  func @main(%arg0 : i32) -> i32 {
+  func.func @main(%arg0 : i32) -> i32 {
     %0 = memref.alloc() : memref<64xi32>
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : i32
@@ -182,7 +182,7 @@ module {
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 module {
-  func @main(%arg0 : i32) -> i32 {
+  func.func @main(%arg0 : i32) -> i32 {
     %0 = memref.alloc() : memref<64xi32>
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : i32
@@ -246,7 +246,7 @@ module {
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 module {
-  func @main(%arg0 : i6) -> i32 {
+  func.func @main(%arg0 : i6) -> i32 {
     %0 = memref.alloc() : memref<64xi32>
     %c1 = arith.constant 1 : index
     %arg0_idx =  arith.index_cast %arg0 : i6 to index
@@ -287,7 +287,7 @@ module {
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 module {
-  func @main(%i : index) -> i32 {
+  func.func @main(%i : index) -> i32 {
     %0 = memref.alloc() : memref<64xi32>
     %1 = memref.load %0[%i] : memref<64xi32>
     return %1 : i32
@@ -322,7 +322,7 @@ module {
 // CHECH-NEXT:   }
 // CHECH-NEXT: }
 module {
-  func @main(%i : i8) -> index {
+  func.func @main(%i : i8) -> index {
     %0 = arith.index_cast %i : i8 to index
     return %0 : index
   }
@@ -355,7 +355,7 @@ module {
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 module {
-  func @main(%arg0 : i32, %mem0 : memref<8xi32>, %i : index) {
+  func.func @main(%arg0 : i32, %mem0 : memref<8xi32>, %i : index) {
     memref.store %arg0, %mem0[%i] : memref<8xi32>
     return
   }
@@ -390,7 +390,7 @@ module {
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 module {
-  func @main(%i : index, %mem0 : memref<8xi32>) -> i32 {
+  func.func @main(%i : index, %mem0 : memref<8xi32>) -> i32 {
     %0 = memref.load %mem0[%i] : memref<8xi32>
     return %0 : i32
   }
@@ -447,7 +447,7 @@ module {
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 module {
-  func @main(%i0 : index, %i1 : index, %mem0 : memref<8xi32>) -> (i32, i32) {
+  func.func @main(%i0 : index, %i1 : index, %mem0 : memref<8xi32>) -> (i32, i32) {
     %0 = memref.load %mem0[%i0] : memref<8xi32>
     %1 = memref.load %mem0[%i1] : memref<8xi32>
     return %0, %1 : i32, i32
@@ -473,7 +473,7 @@ module {
 // CHECK-NEXT:        calyx.group_done %mem_0.done : i1
 // CHECK-NEXT:      }
 module {
-  func @main(%i : index) -> i32 {
+  func.func @main(%i : index) -> i32 {
     %c1_32 = arith.constant 1 : i32
     %0 = memref.alloc() : memref<1xi32>
     %1 = memref.load %0[%i] : memref<1xi32>
@@ -488,7 +488,7 @@ module {
 
 // CHECK: calyx.std_slice {{.*}} i32, i6
 module {
-  func @main(%mem : memref<33xi32>) -> i32 {
+  func.func @main(%mem : memref<33xi32>) -> i32 {
     %c0 = arith.constant 0 : index
     %0 = memref.load %mem[%c0] : memref<33xi32>
     return %0 : i32
@@ -505,7 +505,7 @@ module {
 // CHECK-DAG:           calyx.assign %mem_0.addr0 = %std_slice_3.out : i1
 // CHECK-DAG:           calyx.assign %mem_0.addr1 = %std_slice_2.out : i1
 module {
-  func @main() {
+  func.func @main() {
     %c1_32 = arith.constant 1 : i32
     %i = arith.constant 0 : index
     %0 = memref.alloc() : memref<1x1x1x1xi32>

--- a/test/Conversion/SCFToCalyx/convert_pipeline.mlir
+++ b/test/Conversion/SCFToCalyx/convert_pipeline.mlir
@@ -34,7 +34,7 @@
 // CHECK-NEXT:        } {bound = 10 : i64}
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
-func @minimal() {
+func.func @minimal() {
   %c0_i64 = arith.constant 0 : i64
   %c10_i64 = arith.constant 10 : i64
   %c1_i64 = arith.constant 1 : i64
@@ -158,7 +158,7 @@ func @minimal() {
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
-func @dot(%arg0: memref<64xi32>, %arg1: memref<64xi32>) -> i32 {
+func.func @dot(%arg0: memref<64xi32>, %arg1: memref<64xi32>) -> i32 {
   %c0_i32 = arith.constant 0 : i32
   %c0 = arith.constant 0 : index
   %c64 = arith.constant 64 : index

--- a/test/Conversion/SCFToCalyx/convert_simple.mlir
+++ b/test/Conversion/SCFToCalyx/convert_simple.mlir
@@ -31,7 +31,7 @@
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 module {
-  func @main(%a0 : i32, %a1 : i32) -> i32 {
+  func.func @main(%a0 : i32, %a1 : i32) -> i32 {
     %0 = arith.addi %a0, %a1 : i32
     %1 = arith.shli %0, %a0 : i32
     %2 = arith.subi %1, %0 : i32
@@ -70,7 +70,7 @@ module {
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 module {
-  func @main(%a0 : i32, %a1 : i32) -> (i32, i32) {
+  func.func @main(%a0 : i32, %a1 : i32) -> (i32, i32) {
     return %a0, %a1 : i32, i32
   }
 }
@@ -78,7 +78,7 @@ module {
 // -----
 
 module {
-  func @main(%a0 : i32, %a1 : i32) -> i32 {
+  func.func @main(%a0 : i32, %a1 : i32) -> i32 {
 // CHECK:       calyx.group @bb0_0  {
 // CHECK-DAG:    calyx.assign %std_mult_pipe_0.left = %in0 : i32
 // CHECK-DAG:    calyx.assign %std_mult_pipe_0.right = %in1 : i32
@@ -95,7 +95,7 @@ module {
 // -----
 
 module {
-  func @main(%a0 : i32, %a1 : i32) -> i32 {
+  func.func @main(%a0 : i32, %a1 : i32) -> i32 {
 // CHECK:       calyx.group @bb0_0  {
 // CHECK-DAG:    calyx.assign %std_div_pipe_0.left = %in0 : i32
 // CHECK-DAG:    calyx.assign %std_div_pipe_0.right = %in1 : i32
@@ -112,7 +112,7 @@ module {
 // -----
 
 module {
-  func @main(%a0 : i32, %a1 : i32) -> i32 {
+  func.func @main(%a0 : i32, %a1 : i32) -> i32 {
 // CHECK:       calyx.group @bb0_0  {
 // CHECK-DAG:    calyx.assign %std_div_pipe_0.left = %in0 : i32
 // CHECK-DAG:    calyx.assign %std_div_pipe_0.right = %in1 : i32
@@ -143,7 +143,7 @@ module {
 // CHECK-DAG:      calyx.group_done %0 ? %true : i1
 // CHECK-NEXT: }
 module {
-  func @main(%a0 : i32) -> (i32, i32, i32, i32, i32) {
+  func.func @main(%a0 : i32) -> (i32, i32, i32, i32, i32) {
     return %a0, %a0, %a0, %a0, %a0 : i32, i32, i32, i32, i32
   }
 }

--- a/test/Conversion/SCFToCalyx/errors.mlir
+++ b/test/Conversion/SCFToCalyx/errors.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt --lower-scf-to-calyx %s -split-input-file -verify-diagnostics
 
 module {
-  func @f(%arg0 : f32, %arg1 : f32) -> f32 {
+  func.func @f(%arg0 : f32, %arg1 : f32) -> f32 {
     // expected-error @+1 {{failed to legalize operation 'arith.addf' that was explicitly marked illegal}}
     %2 = arith.addf %arg0, %arg1 : f32
     return %2 : f32
@@ -12,17 +12,17 @@ module {
 
 // expected-error @+1 {{Module contains multiple functions, but no top level function was set. Please see --top-level-function}}
 module {
-  func @f1() {
+  func.func @f1() {
     return
   }
-  func @f2() {
+  func.func @f2() {
     return
   }
 }
 
 // -----
 
-func @main() {
+func.func @main() {
   cf.br ^bb1
 ^bb1:
   cf.br ^bb2

--- a/test/Conversion/StandardToHandshake/errors.mlir
+++ b/test/Conversion/StandardToHandshake/errors.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt -lower-std-to-handshake %s -split-input-file -verify-diagnostics
 
-func @multidim() -> i32 {
+func.func @multidim() -> i32 {
   // expected-error @+1 {{memref's must be both statically sized and unidimensional.}}
   %0 = memref.alloc() : memref<2x2xi32>
   %idx = arith.constant 0 : index
@@ -10,7 +10,7 @@ func @multidim() -> i32 {
 
 // -----
 
-func @dynsize(%dyn : index) -> i32{
+func.func @dynsize(%dyn : index) -> i32{
   // expected-error @+1 {{memref's must be both statically sized and unidimensional.}}
   %0 = memref.alloc(%dyn) : memref<?xi32>
   %idx = arith.constant 0 : index
@@ -23,7 +23,7 @@ func @dynsize(%dyn : index) -> i32{
 // Test non-canonical loops that have multiple entry points (irreducible cfg).
 
 // expected-error @+1 {{Non-canonical loop structures detected; a potential loop header has backedges not dominated by the loop header. This indicates that the loop has multiple entry points. Handshake lowering does not yet support this form of control flow, exiting.}}
-func @non_canon_loop(%arg0 : memref<100xi32>, %arg1 : i32) -> i32 {
+func.func @non_canon_loop(%arg0 : memref<100xi32>, %arg1 : i32) -> i32 {
     %c0_i32 = arith.constant 0 : i32
     %c100 = arith.constant 100 : index
     %c0 = arith.constant 0 : index

--- a/test/Conversion/StandardToHandshake/task_pipelining_errors.mlir
+++ b/test/Conversion/StandardToHandshake/task_pipelining_errors.mlir
@@ -5,7 +5,7 @@
 // an exit block.
 
 // expected-error @+1 {{Multiple exits detected within a loop. Loop task pipelining is only supported for loops with unified loop exit blocks.}}
-func @main(%cond : i1) -> index {
+func.func @main(%cond : i1) -> index {
   %c1 = arith.constant 1 : index
   %c42 = arith.constant 42 : index
   %c1_0 = arith.constant 1 : index
@@ -13,10 +13,10 @@ func @main(%cond : i1) -> index {
 ^bb1(%0: index):	// 2 preds: ^bb0, ^bb2
   %1 = arith.cmpi slt, %0, %c42 : index
   cf.cond_br %1, ^bb2, ^bb3
-^bb2:	
+^bb2:
   %2 = arith.addi %0, %c1_0 : index
   cf.cond_br %cond, ^bb1(%2 : index), ^bb3
-^bb3:	
+^bb3:
   return %0 : index
 }
 
@@ -27,7 +27,7 @@ func @main(%cond : i1) -> index {
 // exit blocks). Like the above, but the loop header is not an exit point.
 
 // expected-error @+1 {{Multiple exits detected within a loop. Loop task pipelining is only supported for loops with unified loop exit blocks.}}
-func @main(%cond : i1) -> index {
+func.func @main(%cond : i1) -> index {
   %c1 = arith.constant 1 : index
   %c42 = arith.constant 42 : index
   %c1_0 = arith.constant 1 : index
@@ -35,13 +35,13 @@ func @main(%cond : i1) -> index {
 ^bb1(%0: index):
   %1 = arith.cmpi slt, %0, %c42 : index
   cf.br ^bb2
-^bb2:	
+^bb2:
   %2 = arith.addi %0, %c1_0 : index
   cf.cond_br %cond, ^bb3, ^bb4
 ^bb3:
   %3 = arith.addi %0, %c1_0 : index
   cf.cond_br %cond, ^bb1(%2 : index), ^bb4
-^bb4:	
+^bb4:
   return %0 : index
 }
 
@@ -51,7 +51,7 @@ func @main(%cond : i1) -> index {
 // A loop with a single exit point but with multiple loop latches.
 
 // expected-error @+1 {{Multiple loop latches detected (backedges from within the loop to the loop header). Loop task pipelining is only supported for loops with unified loop latches.}}
-func @main(%cond : i1) -> index {
+func.func @main(%cond : i1) -> index {
   %c1 = arith.constant 1 : index
   %c42 = arith.constant 42 : index
   %c1_0 = arith.constant 1 : index
@@ -59,12 +59,12 @@ func @main(%cond : i1) -> index {
 ^bb1(%0: index):
   %1 = arith.cmpi slt, %0, %c42 : index
   cf.br ^bb2
-^bb2:	
+^bb2:
   %2 = arith.addi %0, %c1_0 : index
   cf.cond_br %cond, ^bb1(%2 : index), ^bb3
 ^bb3:
   %3 = arith.addi %0, %c1_0 : index
   cf.cond_br %cond, ^bb1(%2 : index), ^bb4
-^bb4:	
+^bb4:
   return %0 : index
 }

--- a/test/Conversion/StandardToHandshake/test-simple-ops.mlir
+++ b/test/Conversion/StandardToHandshake/test-simple-ops.mlir
@@ -8,7 +8,7 @@
 // CHECK:           %[[VAL_7:.*]] = select %[[VAL_4]], %[[VAL_6]], %[[VAL_5]] : i32
 // CHECK:           return %[[VAL_7]], %[[VAL_3]] : i32, none
 // CHECK:         }
-func @main(%c : i1, %a : i32, %b : i32) -> i32 {
+func.func @main(%c : i1, %a : i32, %b : i32) -> i32 {
   %0 = arith.select %c, %a, %b : i32
   return %0 : i32
 }
@@ -19,5 +19,5 @@ func @main(%c : i1, %a : i32, %b : i32) -> i32 {
 
 // CHECK-LABEL: handshake.func private @foo(i32, i32, none, ...) -> (i32, none)
 module {
-  func private @foo(%a:i32, %b: i32) -> i32
+  func.func private @foo(%a:i32, %b: i32) -> i32
 }

--- a/test/Conversion/StandardToHandshake/test1.mlir
+++ b/test/Conversion/StandardToHandshake/test1.mlir
@@ -44,7 +44,7 @@
 // CHECK:           sink %[[VAL_42]] : index
 // CHECK:           return %[[VAL_41]] : none
 // CHECK:         }
-func @simple_loop() {
+func.func @simple_loop() {
 ^bb0:
   cf.br ^bb1
 ^bb1:	// pred: ^bb0

--- a/test/Conversion/StandardToHandshake/test10.mlir
+++ b/test/Conversion/StandardToHandshake/test10.mlir
@@ -110,7 +110,7 @@
 // CHECK:           sink %[[VAL_107]] : index
 // CHECK:           return %[[VAL_106]] : none
 // CHECK:         }
-func @affine_dma_start(%arg0: index) {
+func.func @affine_dma_start(%arg0: index) {
   %0 = memref.alloc() : memref<100xf32>
   %1 = memref.alloc() : memref<100xf32, 2>
   %2 = memref.alloc() : memref<1xi32>

--- a/test/Conversion/StandardToHandshake/test11.mlir
+++ b/test/Conversion/StandardToHandshake/test11.mlir
@@ -103,7 +103,7 @@
 // CHECK:           sink %[[VAL_106]] : index
 // CHECK:           return %[[VAL_105]] : none
 // CHECK:         }
-func @imperfectly_nested_loops() {
+func.func @imperfectly_nested_loops() {
   %c0 = arith.constant 0 : index
   %c42 = arith.constant 42 : index
   %c1 = arith.constant 1 : index

--- a/test/Conversion/StandardToHandshake/test12.mlir
+++ b/test/Conversion/StandardToHandshake/test12.mlir
@@ -158,7 +158,7 @@
 // CHECK:           sink %[[VAL_166]] : index
 // CHECK:           return %[[VAL_165]] : none
 // CHECK:         }
-func @more_imperfectly_nested_loops() {
+func.func @more_imperfectly_nested_loops() {
   %c0 = arith.constant 0 : index
   %c42 = arith.constant 42 : index
   %c1 = arith.constant 1 : index

--- a/test/Conversion/StandardToHandshake/test13.mlir
+++ b/test/Conversion/StandardToHandshake/test13.mlir
@@ -104,7 +104,7 @@
 // CHECK:           sink %[[VAL_107]] : index
 // CHECK:           return %[[VAL_106]] : none
 // CHECK:         }
-func @affine_apply_loops_shorthand(%arg0: index) {
+func.func @affine_apply_loops_shorthand(%arg0: index) {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   cf.br ^bb1(%c0 : index)

--- a/test/Conversion/StandardToHandshake/test14.mlir
+++ b/test/Conversion/StandardToHandshake/test14.mlir
@@ -78,7 +78,7 @@
 // CHECK:           sink %[[VAL_77]] : index
 // CHECK:           return %[[VAL_76]] : none
 // CHECK:         }
-func @affine_store(%arg0: index) {
+func.func @affine_store(%arg0: index) {
   %0 = memref.alloc() : memref<10xf32>
   %cst = arith.constant 1.100000e+01 : f32
   %c0 = arith.constant 0 : index

--- a/test/Conversion/StandardToHandshake/test15.mlir
+++ b/test/Conversion/StandardToHandshake/test15.mlir
@@ -68,7 +68,7 @@
 // CHECK:           sink %[[VAL_66]] : index
 // CHECK:           return %[[VAL_65]] : none
 // CHECK:         }
-func @affine_load(%arg0: index) {
+func.func @affine_load(%arg0: index) {
   %0 = memref.alloc() : memref<10xf32>
   %c0 = arith.constant 0 : index
   %c10 = arith.constant 10 : index

--- a/test/Conversion/StandardToHandshake/test16.mlir
+++ b/test/Conversion/StandardToHandshake/test16.mlir
@@ -23,7 +23,7 @@
 // CHECK:           %[[VAL_19:.*]] = select %[[VAL_11]]#0, %[[VAL_18]], %[[VAL_17]] : index
 // CHECK:           return %[[VAL_19]], %[[VAL_4]]#3 : index, none
 // CHECK:         }
-func @affine_apply_ceildiv(%arg0: index) -> index {
+func.func @affine_apply_ceildiv(%arg0: index) -> index {
     %c42 = arith.constant 42 : index
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index

--- a/test/Conversion/StandardToHandshake/test17.mlir
+++ b/test/Conversion/StandardToHandshake/test17.mlir
@@ -20,7 +20,7 @@
 // CHECK:           %[[VAL_16:.*]] = select %[[VAL_10]]#0, %[[VAL_14]]#0, %[[VAL_15]] : index
 // CHECK:           return %[[VAL_16]], %[[VAL_4]]#3 : index, none
 // CHECK:         }
-func @affine_apply_floordiv(%arg0: index) -> index {
+func.func @affine_apply_floordiv(%arg0: index) -> index {
     %c42 = arith.constant 42 : index
     %c0 = arith.constant 0 : index
     %c-1 = arith.constant -1 : index

--- a/test/Conversion/StandardToHandshake/test18.mlir
+++ b/test/Conversion/StandardToHandshake/test18.mlir
@@ -15,7 +15,7 @@
 // CHECK:           %[[VAL_11:.*]] = select %[[VAL_9]], %[[VAL_7]]#0, %[[VAL_10]] : index
 // CHECK:           return %[[VAL_11]], %[[VAL_3]]#2 : index, none
 // CHECK:         }
-func @affine_apply_mod(%arg0: index) -> index {
+func.func @affine_apply_mod(%arg0: index) -> index {
     %c42 = arith.constant 42 : index
     %0 = arith.remsi %arg0, %c42 : index
     %c0 = arith.constant 0 : index

--- a/test/Conversion/StandardToHandshake/test19.mlir
+++ b/test/Conversion/StandardToHandshake/test19.mlir
@@ -41,7 +41,7 @@
 // CHECK:           sink %[[VAL_33]] : index
 // CHECK:           return %[[VAL_1]]#17 : none
 // CHECK:         }
-func @affine_applies() {
+func.func @affine_applies() {
     %c0 = arith.constant 0 : index
     %c101 = arith.constant 101 : index
     %c102 = arith.constant 102 : index

--- a/test/Conversion/StandardToHandshake/test2.mlir
+++ b/test/Conversion/StandardToHandshake/test2.mlir
@@ -94,7 +94,7 @@
 // CHECK:           sink %[[VAL_96]] : index
 // CHECK:           return %[[VAL_95]] : none
 // CHECK:         }
-func @imperfectly_nested_loops() {
+func.func @imperfectly_nested_loops() {
 ^bb0:
   cf.br ^bb1
 ^bb1:	// pred: ^bb0

--- a/test/Conversion/StandardToHandshake/test20.mlir
+++ b/test/Conversion/StandardToHandshake/test20.mlir
@@ -67,7 +67,7 @@
 // CHECK:           sink %[[VAL_65]] : index
 // CHECK:           return %[[VAL_64]] : none
 // CHECK:         }
-func @min_reduction_tree(%arg0: index) {
+func.func @min_reduction_tree(%arg0: index) {
   %c0 = arith.constant 0 : index
   %0 = arith.cmpi slt, %arg0, %arg0 : index
   %1 = arith.select %0, %arg0, %arg0 : index

--- a/test/Conversion/StandardToHandshake/test21.mlir
+++ b/test/Conversion/StandardToHandshake/test21.mlir
@@ -129,7 +129,7 @@
 // CHECK:           sink %[[VAL_133]] : index
 // CHECK:           return %[[VAL_132]] : none
 // CHECK:         }
-func @loop_min_max(%arg0: index) {
+func.func @loop_min_max(%arg0: index) {
   %c0 = arith.constant 0 : index
   %c42 = arith.constant 42 : index
   %c1 = arith.constant 1 : index

--- a/test/Conversion/StandardToHandshake/test22.mlir
+++ b/test/Conversion/StandardToHandshake/test22.mlir
@@ -204,7 +204,7 @@
 // CHECK:           sink %[[VAL_220]] : index
 // CHECK:           return %[[VAL_219]] : none
 // CHECK:         }
-func @if_for() {
+func.func @if_for() {
   %c0 = arith.constant 0 : index
   %c-1 = arith.constant -1 : index
   %1 = arith.muli %c-1, %c-1 : index

--- a/test/Conversion/StandardToHandshake/test23.mlir
+++ b/test/Conversion/StandardToHandshake/test23.mlir
@@ -43,7 +43,7 @@
 // CHECK:           sink %[[VAL_44]] : index
 // CHECK:           return %[[VAL_43]] : none
 // CHECK:         }
-func @multi_cond(%arg0: index, %arg1: index, %arg2: index, %arg3: index) {
+func.func @multi_cond(%arg0: index, %arg1: index, %arg2: index, %arg3: index) {
     %c0 = arith.constant 0 : index
     %c-1 = arith.constant -1 : index
     %1 = arith.muli %c0, %c-1 : index

--- a/test/Conversion/StandardToHandshake/test24.mlir
+++ b/test/Conversion/StandardToHandshake/test24.mlir
@@ -48,7 +48,7 @@
 // CHECK:           sink %[[VAL_48]] : index
 // CHECK:           return %[[VAL_47]] : none
 // CHECK:         }
-  func @nested_ifs() {
+  func.func @nested_ifs() {
     %c0 = arith.constant 0 : index
     %c-1 = arith.constant -1 : index
     %1 = arith.muli %c0, %c-1 : index

--- a/test/Conversion/StandardToHandshake/test25.mlir
+++ b/test/Conversion/StandardToHandshake/test25.mlir
@@ -21,7 +21,7 @@
 // CHECK:           sink %[[VAL_18]] : index
 // CHECK:           return %[[VAL_17]] : none
 // CHECK:         }
-  func @if_else() {
+  func.func @if_else() {
     %c0 = arith.constant 0 : index
     %c-1 = arith.constant -1 : index
     %1 = arith.muli %c0, %c-1 : index

--- a/test/Conversion/StandardToHandshake/test26.mlir
+++ b/test/Conversion/StandardToHandshake/test26.mlir
@@ -18,7 +18,7 @@
 // CHECK:           sink %[[VAL_15]] : index
 // CHECK:           return %[[VAL_14]] : none
 // CHECK:         }
-  func @if_only() {
+  func.func @if_only() {
     %c0 = arith.constant 0 : index
     %c-1 = arith.constant -1 : index
     %1 = arith.muli %c0, %c-1 : index

--- a/test/Conversion/StandardToHandshake/test27.mlir
+++ b/test/Conversion/StandardToHandshake/test27.mlir
@@ -44,7 +44,7 @@
 // CHECK:           sink %[[VAL_42]] : index
 // CHECK:           return %[[VAL_41]] : none
 // CHECK:         }
-func @simple_loop() {
+func.func @simple_loop() {
 ^bb0:
   cf.br ^bb1
 ^bb1:	// pred: ^bb0

--- a/test/Conversion/StandardToHandshake/test28.mlir
+++ b/test/Conversion/StandardToHandshake/test28.mlir
@@ -74,7 +74,7 @@
 // CHECK:           sink %[[VAL_75]] : index
 // CHECK:           return %[[VAL_74]] : none
 // CHECK:         }
-func @affine_load(%arg0: index) {
+func.func @affine_load(%arg0: index) {
   %0 = memref.alloc() : memref<10xf32>
   %10 = memref.alloc() : memref<10xf32>
   %c0 = arith.constant 0 : index

--- a/test/Conversion/StandardToHandshake/test29.mlir
+++ b/test/Conversion/StandardToHandshake/test29.mlir
@@ -19,7 +19,7 @@
 // CHECK:           sink %[[VAL_15]] : i32
 // CHECK:           return %[[VAL_12]] : none
 // CHECK:         }
-func @load_store(%0 : memref<4xi32>, %1 : index) {
+func.func @load_store(%0 : memref<4xi32>, %1 : index) {
   %c1 = arith.constant 11 : i32
   memref.store %c1, %0[%1] : memref<4xi32>
   %3 = memref.load %0[%1] : memref<4xi32>

--- a/test/Conversion/StandardToHandshake/test3.mlir
+++ b/test/Conversion/StandardToHandshake/test3.mlir
@@ -144,7 +144,7 @@
 // CHECK:           sink %[[VAL_150]] : index
 // CHECK:           return %[[VAL_149]] : none
 // CHECK:         }
-func @more_imperfectly_nested_loops() {
+func.func @more_imperfectly_nested_loops() {
 ^bb0:
   cf.br ^bb1
 ^bb1:	// pred: ^bb0

--- a/test/Conversion/StandardToHandshake/test30.mlir
+++ b/test/Conversion/StandardToHandshake/test30.mlir
@@ -88,7 +88,7 @@
 // CHECK:           sink %[[VAL_89]] : index
 // CHECK:           return %[[VAL_88]] : none
 // CHECK:         }
-func @affine_load(%arg0: index) {
+func.func @affine_load(%arg0: index) {
   %0 = memref.alloc() : memref<10xf32>
   %c0 = arith.constant 0 : index
   %c10 = arith.constant 10 : index

--- a/test/Conversion/StandardToHandshake/test31.mlir
+++ b/test/Conversion/StandardToHandshake/test31.mlir
@@ -88,7 +88,7 @@
 // CHECK:           sink %[[VAL_89]] : index
 // CHECK:           return %[[VAL_88]] : none
 // CHECK:         }
-func @affine_load(%arg0: index) {
+func.func @affine_load(%arg0: index) {
   %0 = memref.alloc() : memref<10xf32>
   %10 = memref.alloc() : memref<10xf32>
   %c0 = arith.constant 0 : index

--- a/test/Conversion/StandardToHandshake/test32.mlir
+++ b/test/Conversion/StandardToHandshake/test32.mlir
@@ -62,7 +62,7 @@
 // CHECK:           sink %[[VAL_63]] : index
 // CHECK:           return %[[VAL_62]] : none
 // CHECK:         }
-func @test() {
+func.func @test() {
   %10 = memref.alloc() : memref<10xf32>
   %c0 = arith.constant 0 : index
   %c10 = arith.constant 10 : index

--- a/test/Conversion/StandardToHandshake/test33.mlir
+++ b/test/Conversion/StandardToHandshake/test33.mlir
@@ -53,7 +53,7 @@
 // CHECK:           sink %[[VAL_54]] : index
 // CHECK:           return %[[VAL_53]] : none
 // CHECK:         }
-func @test() {
+func.func @test() {
   %10 = memref.alloc() : memref<10xf32>
   %c0 = arith.constant 0 : index
   %c10 = arith.constant 10 : index

--- a/test/Conversion/StandardToHandshake/test34.mlir
+++ b/test/Conversion/StandardToHandshake/test34.mlir
@@ -56,7 +56,7 @@
 // CHECK:           sink %[[VAL_56]] : index
 // CHECK:           return %[[VAL_55]] : none
 // CHECK:         }
-func @test() {
+func.func @test() {
   %10 = memref.alloc() : memref<10xf32>
   %c0 = arith.constant 0 : index
   %c10 = arith.constant 10 : index

--- a/test/Conversion/StandardToHandshake/test35.mlir
+++ b/test/Conversion/StandardToHandshake/test35.mlir
@@ -63,7 +63,7 @@
 // CHECK:           sink %[[VAL_65]] : index
 // CHECK:           return %[[VAL_64]] : none
 // CHECK:         }
-func @test() {
+func.func @test() {
   %10 = memref.alloc() : memref<10xf32>
   %11 = memref.alloca() : memref<10xf32>
   %c0 = arith.constant 0 : index

--- a/test/Conversion/StandardToHandshake/test4.mlir
+++ b/test/Conversion/StandardToHandshake/test4.mlir
@@ -34,7 +34,7 @@
 // CHECK:           sink %[[VAL_25]] : i32
 // CHECK:           return %[[VAL_13]], %[[VAL_16]], %[[VAL_4]] : f32, i32, none
 // CHECK:         }
-func @ops(f32, f32, i32, i32) -> (f32, i32) {
+func.func @ops(f32, f32, i32, i32) -> (f32, i32) {
 ^bb0(%arg0: f32, %arg1: f32, %arg2: i32, %arg3: i32):
   %0 = arith.subf %arg0, %arg1: f32
   %1 = arith.subi %arg2, %arg3: i32

--- a/test/Conversion/StandardToHandshake/test5.mlir
+++ b/test/Conversion/StandardToHandshake/test5.mlir
@@ -21,7 +21,7 @@
 // CHECK:           %[[VAL_8]] = br %[[VAL_17]] : i32
 // CHECK:           return %[[VAL_12]], %[[VAL_9]] : i32, none
 // CHECK:         }
-func @dfs_block_order() -> (i32) {
+func.func @dfs_block_order() -> (i32) {
   %0 = arith.constant 42 : i32
   cf.br ^bb2
 ^bb1:

--- a/test/Conversion/StandardToHandshake/test6.mlir
+++ b/test/Conversion/StandardToHandshake/test6.mlir
@@ -36,7 +36,7 @@
 // CHECK:           sink %[[VAL_27]] : i32
 // CHECK:           return %[[VAL_13]]#0, %[[VAL_18]]#0, %[[VAL_4]] : f32, i32, none
 // CHECK:         }
-func @ops(f32, f32, i32, i32) -> (f32, i32) {
+func.func @ops(f32, f32, i32, i32) -> (f32, i32) {
 ^bb0(%arg0: f32, %arg1: f32, %arg2: i32, %arg3: i32):
   %0 = arith.subf %arg0, %arg1: f32
   %1 = arith.subi %arg2, %arg3: i32

--- a/test/Conversion/StandardToHandshake/test7.mlir
+++ b/test/Conversion/StandardToHandshake/test7.mlir
@@ -36,7 +36,7 @@
 // CHECK:           sink %[[VAL_34]] : index
 // CHECK:           return %[[VAL_33]] : none
 // CHECK:         }
-func @simple_loop() {
+func.func @simple_loop() {
 ^bb0:
   cf.br ^bb1
 ^bb1:	// pred: ^bb0

--- a/test/Conversion/StandardToHandshake/test8.mlir
+++ b/test/Conversion/StandardToHandshake/test8.mlir
@@ -36,7 +36,7 @@
 // CHECK:           sink %[[VAL_32]] : index
 // CHECK:           return %[[VAL_31]] : none
 // CHECK:         }
-func @simple_loop() {
+func.func @simple_loop() {
 ^bb0:
   cf.br ^bb1
 ^bb1:	// pred: ^bb0

--- a/test/Conversion/StandardToHandshake/test9.mlir
+++ b/test/Conversion/StandardToHandshake/test9.mlir
@@ -82,7 +82,7 @@
 // CHECK:           sink %[[VAL_79]] : index
 // CHECK:           return %[[VAL_78]] : none
 // CHECK:         }
-func @affine_dma_wait(%arg0: index) {
+func.func @affine_dma_wait(%arg0: index) {
   %0 = memref.alloc() : memref<1xi32>
   %c64 = arith.constant 64 : index
   %c0 = arith.constant 0 : index

--- a/test/Conversion/StandardToHandshake/test_call.mlir
+++ b/test/Conversion/StandardToHandshake/test_call.mlir
@@ -6,7 +6,7 @@
 // CHECK:           %[[VAL_2:.*]] = merge %[[VAL_0]] : i32
 // CHECK:           return %[[VAL_2]], %[[VAL_1]] : i32, none
 // CHECK:         }
-func @bar(%0 : i32) -> i32 {
+func.func @bar(%0 : i32) -> i32 {
   return %0 : i32
 }
 
@@ -19,7 +19,7 @@ func @bar(%0 : i32) -> i32 {
 // CHECK:           sink %[[VAL_4]]#1 : none
 // CHECK:           return %[[VAL_4]]#0, %[[VAL_3]]#1 : i32, none
 // CHECK:         }
-func @foo(%0 : i32) -> i32 {
+func.func @foo(%0 : i32) -> i32 {
   %a1 = call @bar(%0) : (i32) -> i32
   return %a1 : i32
 }
@@ -29,13 +29,13 @@ func @foo(%0 : i32) -> i32 {
 // Branching control flow with calls in each branch.
 
 // CHECK-LABEL:   handshake.func @add(
-func @add(%arg0 : i32, %arg1: i32) -> i32 {
+func.func @add(%arg0 : i32, %arg1: i32) -> i32 {
   %0 = arith.addi %arg0, %arg1 : i32
   return %0 : i32
 }
 
 // CHECK-LABEL:   handshake.func @sub(
-func @sub(%arg0 : i32, %arg1: i32) -> i32 {
+func.func @sub(%arg0 : i32, %arg1: i32) -> i32 {
   %0 = arith.subi %arg0, %arg1 : i32
   return %0 : i32
 }
@@ -70,7 +70,7 @@ func @sub(%arg0 : i32, %arg1: i32) -> i32 {
 // CHECK:           %[[VAL_32:.*]] = mux %[[VAL_31]] {{\[}}%[[VAL_29]], %[[VAL_21]]] : index, i32
 // CHECK:           return %[[VAL_32]], %[[VAL_30]] : i32, none
 // CHECK:         }
-func @main(%arg0 : i32, %arg1 : i32, %cond : i1) -> i32 {
+func.func @main(%arg0 : i32, %arg1 : i32, %cond : i1) -> i32 {
   cf.cond_br %cond, ^bb1, ^bb2
 ^bb1:
   %0 = call @add(%arg0, %arg1) : (i32, i32) -> i32

--- a/test/Conversion/StandardToHandshake/test_disable_task_pipelining.mlir
+++ b/test/Conversion/StandardToHandshake/test_disable_task_pipelining.mlir
@@ -39,7 +39,7 @@
 // CHECK:           sink %[[VAL_36]] : index
 // CHECK:           return %[[VAL_35]] : none
 // CHECK:         }
-func @simple_loop() {
+func.func @simple_loop() {
 ^bb0:
   cf.br ^bb1
 ^bb1:	// pred: ^bb0

--- a/test/Conversion/StandardToHandshake/test_extmemory.mlir
+++ b/test/Conversion/StandardToHandshake/test_extmemory.mlir
@@ -11,7 +11,7 @@
 // CHECK:           %[[VAL_8:.*]], %[[VAL_3]] = load {{\[}}%[[VAL_7]]] %[[VAL_2]]#0, %[[VAL_4]]#0 : index, i32
 // CHECK:           return %[[VAL_8]], %[[VAL_6]] : i32, none
 // CHECK:         }
-func @main(%mem : memref<4xi32>) -> i32 {
+func.func @main(%mem : memref<4xi32>) -> i32 {
   %idx = arith.constant 0 : index
   %0 = memref.load %mem[%idx] : memref<4xi32>
   return %0 : i32

--- a/test/Conversion/StandardToHandshake/test_naming.mlir
+++ b/test/Conversion/StandardToHandshake/test_naming.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt -lower-std-to-handshake %s | FileCheck %s
 
 // CHECK-LABEL: handshake.func @main(%arg0: i32, %arg1: i32, %arg2: i32, %arg3: none, ...) -> (i32, none) attributes {argNames = ["a", "b", "c", "inCtrl"], resNames = ["res", "outCtrl"]} {
-func @main(%arg0 : i32, %b : i32, %c: i32) -> i32 attributes {argNames = ["a", "b", "c"], resNames = ["res"]} {
+func.func @main(%arg0 : i32, %b : i32, %c: i32) -> i32 attributes {argNames = ["a", "b", "c"], resNames = ["res"]} {
   return %arg0 : i32
 }

--- a/test/Conversion/StandardToHandshake/test_source_constants.mlir
+++ b/test/Conversion/StandardToHandshake/test_source_constants.mlir
@@ -9,7 +9,7 @@
 // CHECK:           return %[[VAL_4]], %[[VAL_1]] : i32, none
 // CHECK:         }
 
-func @foo(%arg0 : i32) -> i32 {
+func.func @foo(%arg0 : i32) -> i32 {
   %c1_i32 = arith.constant 1 : i32
   %0 = arith.addi %arg0, %c1_i32 : i32
   return %0 : i32

--- a/test/Conversion/StandardToStaticLogic/test_pipeline.mlir
+++ b/test/Conversion/StandardToStaticLogic/test_pipeline.mlir
@@ -30,7 +30,7 @@
 // CHECK:         }
 // CHECK:       }
 
-func @simple_loop() {
+func.func @simple_loop() {
 ^bb0:
   cf.br ^bb1
 ^bb1:	// pred: ^bb0

--- a/test/Dialect/ESI/connectivity.mlir
+++ b/test/Dialect/ESI/connectivity.mlir
@@ -47,8 +47,8 @@ hw.module @test(%clk: i1, %rstn: i1) {
   // CHECK-NEXT:  hw.instance "nullRcvr" @Reciever(a: [[NULLI1]]: !esi.channel<i1>) -> ()
 }
 
-hw.module.extern @IFaceSender(!sv.modport<@IData::@Source>) -> ()
-hw.module.extern @IFaceRcvr(!sv.modport<@IData::@Sink>) -> ()
+hw.module.extern @IFaceSender(%x: !sv.modport<@IData::@Source>) -> ()
+hw.module.extern @IFaceRcvr(%x: !sv.modport<@IData::@Sink>) -> ()
 sv.interface @IData {
   sv.interface.signal @data : i32
   sv.interface.signal @valid : i1
@@ -59,26 +59,26 @@ sv.interface @IData {
 hw.module @testIfaceWrap() {
   %ifaceOut = sv.interface.instance : !sv.interface<@IData>
   %ifaceOutSource = sv.modport.get %ifaceOut @Source : !sv.interface<@IData> -> !sv.modport<@IData::@Source>
-  hw.instance "ifaceSender" @IFaceSender ("": %ifaceOutSource: !sv.modport<@IData::@Source>) -> ()
+  hw.instance "ifaceSender" @IFaceSender (x: %ifaceOutSource: !sv.modport<@IData::@Source>) -> ()
   %ifaceOutSink = sv.modport.get %ifaceOut @Sink: !sv.interface<@IData> -> !sv.modport<@IData::@Sink>
   %idataChanOut = esi.wrap.iface %ifaceOutSink: !sv.modport<@IData::@Sink> -> !esi.channel<i32>
 
   // CHECK-LABEL:  hw.module @testIfaceWrap() {
   // CHECK-NEXT:     %0 = sv.interface.instance {name = "ifaceOut"} : !sv.interface<@IData>
   // CHECK-NEXT:     %1 = sv.modport.get %0 @Source : !sv.interface<@IData> -> !sv.modport<@IData::@Source>
-  // CHECK-NEXT:     hw.instance "ifaceSender" @IFaceSender("": %1: !sv.modport<@IData::@Source>) -> ()
+  // CHECK-NEXT:     hw.instance "ifaceSender" @IFaceSender(x: %1: !sv.modport<@IData::@Source>) -> ()
   // CHECK-NEXT:     %2 = sv.modport.get %0 @Sink : !sv.interface<@IData> -> !sv.modport<@IData::@Sink>
   // CHECK-NEXT:     %3 = esi.wrap.iface %2 : !sv.modport<@IData::@Sink> -> !esi.channel<i32>
 
   %ifaceIn = sv.interface.instance : !sv.interface<@IData>
   %ifaceInSink = sv.modport.get %ifaceIn @Sink : !sv.interface<@IData> -> !sv.modport<@IData::@Sink>
-  hw.instance "ifaceRcvr" @IFaceRcvr ("": %ifaceInSink: !sv.modport<@IData::@Sink>) -> ()
+  hw.instance "ifaceRcvr" @IFaceRcvr (x: %ifaceInSink: !sv.modport<@IData::@Sink>) -> ()
   %ifaceInSource = sv.modport.get %ifaceIn @Sink : !sv.interface<@IData> -> !sv.modport<@IData::@Source>
   esi.unwrap.iface %idataChanOut into %ifaceInSource : (!esi.channel<i32>, !sv.modport<@IData::@Source>)
 
   // CHECK-NEXT:     %4 = sv.interface.instance {name = "ifaceIn"} : !sv.interface<@IData>
   // CHECK-NEXT:     %5 = sv.modport.get %4 @Sink : !sv.interface<@IData> -> !sv.modport<@IData::@Sink>
-  // CHECK-NEXT:     hw.instance "ifaceRcvr" @IFaceRcvr("": %5: !sv.modport<@IData::@Sink>) -> ()
+  // CHECK-NEXT:     hw.instance "ifaceRcvr" @IFaceRcvr(x: %5: !sv.modport<@IData::@Sink>) -> ()
   // CHECK-NEXT:     %6 = sv.modport.get %4 @Sink : !sv.interface<@IData> -> !sv.modport<@IData::@Source>
   // CHECK-NEXT:     esi.unwrap.iface %3 into %6 : (!esi.channel<i32>, !sv.modport<@IData::@Source>)
 }

--- a/test/Dialect/FSM/basics.mlir
+++ b/test/Dialect/FSM/basics.mlir
@@ -96,7 +96,7 @@ hw.module @bar(%clk: i1, %rst_n: i1) {
 }
 
 // Software-style instantiation and triggering.
-func @qux() {
+func.func @qux() {
   %foo_inst = fsm.instance "foo_inst" @foo
   %in0 = arith.constant true
   %out0 = fsm.trigger %foo_inst(%in0) : (i1) -> i1

--- a/test/Dialect/HW/canonicalization.mlir
+++ b/test/Dialect/HW/canonicalization.mlir
@@ -535,7 +535,7 @@ hw.module @concat_fold_3(%arg0: i1) -> (result: i8) {
 
 // CHECK-LABEL: hw.module @concat_fold_4
 hw.module @concat_fold_4(%arg0: i3) -> (result: i5) {
-  // CHECK-NEXT: %0 = comb.extract %arg0 from 2 : (i3) -> i1 
+  // CHECK-NEXT: %0 = comb.extract %arg0 from 2 : (i3) -> i1
   %0 = comb.extract %arg0 from 2 : (i3) -> (i1)
   // CHECK-NEXT: %1 = comb.replicate %0 : (i1) -> i2
   %1 = comb.concat %0, %0, %arg0 : i1, i1, i3
@@ -578,7 +578,7 @@ hw.module @concat_fold7(%arg0: i5) -> (result: i20) {
 hw.module @concat_fold8(%arg0: i5, %arg1: i3) -> (r0: i28, r1: i28, r2: i13) {
   %0 = comb.replicate %arg0 : (i5) -> i20
 
-  // CHECK-NEXT: %0 = comb.replicate %arg0 : (i5) -> i25 
+  // CHECK-NEXT: %0 = comb.replicate %arg0 : (i5) -> i25
   // CHECK-NEXT: %1 = comb.concat %arg1, %0 : i3, i25
   %1 = comb.concat %arg1, %arg0, %0 : i3, i5, i20
 
@@ -840,7 +840,7 @@ hw.module @shru_shift_to_extract_and_concat0(%arg0: i12) -> (result: i12) {
 
 // CHECK-LABEL: hw.module @shru_shift_to_extract_and_concat1(%arg0: i12) -> (result: i12) {
 // CHECK-NEXT:   %0 = comb.extract %arg0 from 11 : (i12) -> i1
-// CHECK-NEXT:   %1 = comb.replicate %0 : (i1) -> i2 
+// CHECK-NEXT:   %1 = comb.replicate %0 : (i1) -> i2
 // CHECK-NEXT:   %2 = comb.extract %arg0 from 2 : (i12) -> i10
 // CHECK-NEXT:   %3 = comb.concat %1, %2 : i2, i10
 // CHECK-NEXT:   hw.output %3
@@ -1036,8 +1036,8 @@ hw.module @wire5() -> () {
 hw.module @replicate(%arg0: i7) -> (r1: i9, r2: i7) {
   %c2 = hw.constant 2 : i3
   %r1 = comb.replicate %c2 : (i3) -> i9
-  
-// CHECK-NEXT: %c146_i9 = hw.constant 146 : i9 
+
+// CHECK-NEXT: %c146_i9 = hw.constant 146 : i9
   %r2 = comb.replicate %arg0 : (i7) -> i7
 
 // CHECK-NEXT:  hw.output %c146_i9, %arg0
@@ -1287,10 +1287,10 @@ hw.module @foo() {
 }
 
 // CHECK-LABEL:  hw.module @MemDepth1(%clock: i1, %en: i1, %addr: i1) -> (data: i32) {
-// CHECK-NEXT:    %mem0.0 = hw.instance "mem0" @FIRRTLMem_1_0_0_32_1_0_1_1("": %clock: i1, "": %en: i1, "": %addr: i1) -> ("": i32)
+// CHECK-NEXT:    %mem0.0 = hw.instance "mem0" @FIRRTLMem_1_0_0_32_1_0_1_1(x: %clock: i1, y: %en: i1, z: %addr: i1) -> ("": i32)
 // CHECK-NEXT:    hw.output %mem0.0 : i32
 // CHECK-NEXT:  }
-hw.module.extern @FIRRTLMem_1_0_0_32_1_0_1_1(i1, i1, i1) -> ("": i32)
+hw.module.extern @FIRRTLMem_1_0_0_32_1_0_1_1(%x: i1, %y: i1, %z: i1) -> ("": i32)
 hw.module @MemDepth1(%clock: i1, %en: i1, %addr: i1) -> (data: i32) {
   %.load0.clk.wire = sv.wire  : !hw.inout<i1>
   %0 = sv.read_inout %.load0.clk.wire : !hw.inout<i1>
@@ -1298,7 +1298,7 @@ hw.module @MemDepth1(%clock: i1, %en: i1, %addr: i1) -> (data: i32) {
   %1 = sv.read_inout %.load0.en.wire : !hw.inout<i1>
   %.load0.addr.wire = sv.wire  : !hw.inout<i1>
   %2 = sv.read_inout %.load0.addr.wire : !hw.inout<i1>
-  %mem0.ro_data_0 = hw.instance "mem0" @FIRRTLMem_1_0_0_32_1_0_1_1("": %0: i1, "": %1: i1, "": %2: i1) -> ("": i32)
+  %mem0.ro_data_0 = hw.instance "mem0" @FIRRTLMem_1_0_0_32_1_0_1_1("x": %0: i1, "y": %1: i1, "z": %2: i1) -> ("": i32)
   %3 = sv.read_inout %.load0.clk.wire : !hw.inout<i1>
   sv.assign %.load0.clk.wire, %clock : i1
   %4 = sv.read_inout %.load0.addr.wire : !hw.inout<i1>

--- a/test/Dialect/HW/errors.mlir
+++ b/test/Dialect/HW/errors.mlir
@@ -1,27 +1,27 @@
 // RUN: circt-opt %s -split-input-file -verify-diagnostics
 
-func private @test_extract(%arg0: i4) {
+func.func private @test_extract(%arg0: i4) {
   // expected-error @+1 {{'comb.extract' op from bit too large for input}}
   %a = comb.extract %arg0 from 6 : (i4) -> i3
 }
 
 // -----
 
-func private @test_extract(%arg0: i4) {
+func.func private @test_extract(%arg0: i4) {
   // expected-error @+1 {{'comb.extract' op from bit too large for input}}
   %b = comb.extract %arg0 from 2 : (i4) -> i3
 }
 
 // -----
 
-func private @test_and() {
+func.func private @test_and() {
   // expected-error @+1 {{'comb.and' op expected 1 or more operands}}
   %b = comb.and : i111
 }
 
 // -----
 
-func private @notModule () {
+func.func private @notModule () {
   return
 }
 
@@ -58,12 +58,12 @@ hw.module @A() -> ("": i1) { }
 // -----
 
 // expected-error @+1 {{expected non-function type}}
-func private @arrayDims(%a: !hw.array<3 x 4 x i5>) { }
+func.func private @arrayDims(%a: !hw.array<3 x 4 x i5>) { }
 
 // -----
 
 // expected-error @+1 {{invalid element for hw.inout type}}
-func private @invalidInout(%arg0: !hw.inout<tensor<*xf32>>) { }
+func.func private @invalidInout(%arg0: !hw.inout<tensor<*xf32>>) { }
 
 // -----
 

--- a/test/Dialect/HW/modules.mlir
+++ b/test/Dialect/HW/modules.mlir
@@ -54,5 +54,5 @@ hw.module.generated @genmod1, @MEMORY() -> (FOOBAR: i1) attributes {write_latenc
 // CHECK-LABEL: hw.generator.schema @MEMORY, "Simple-Memory", ["ports", "write_latency", "read_latency"]
 // CHECK-NEXT: hw.module.generated @genmod1, @MEMORY() -> (FOOBAR: i1) attributes {ports = ["read", "write"], read_latency = 1 : i64, write_latency = 1 : i64}
 
-// CHECK-LABEL: hw.module.extern @AnonArg(i42)
-hw.module.extern @AnonArg(i42)
+//// C*ECK-LABEL: hw.module.extern @AnonArg(i42)
+//// hw.module.extern @AnonArg(i42)

--- a/test/Dialect/HW/modules.mlir
+++ b/test/Dialect/HW/modules.mlir
@@ -53,6 +53,3 @@ hw.generator.schema @MEMORY, "Simple-Memory", ["ports", "write_latency", "read_l
 hw.module.generated @genmod1, @MEMORY() -> (FOOBAR: i1) attributes {write_latency=1, read_latency=1, ports=["read","write"]}
 // CHECK-LABEL: hw.generator.schema @MEMORY, "Simple-Memory", ["ports", "write_latency", "read_latency"]
 // CHECK-NEXT: hw.module.generated @genmod1, @MEMORY() -> (FOOBAR: i1) attributes {ports = ["read", "write"], read_latency = 1 : i64, write_latency = 1 : i64}
-
-//// C*ECK-LABEL: hw.module.extern @AnonArg(i42)
-//// hw.module.extern @AnonArg(i42)

--- a/test/Dialect/HW/types.mlir
+++ b/test/Dialect/HW/types.mlir
@@ -3,32 +3,32 @@
 // CHECK-LABEL: module
 module {
   // CHECK-LABEL: func @i20x5array(%{{.*}}: !hw.array<5xi20>)
-  func @i20x5array(%A: !hw.array<5 x i20>) {
+  func.func @i20x5array(%A: !hw.array<5 x i20>) {
     return
   }
 
   // CHECK-LABEL: func @si20x5array(%{{.*}}: !hw.array<5xsi20>)
-  func @si20x5array(%A: !hw.array<5 x si20>) {
+  func.func @si20x5array(%A: !hw.array<5 x si20>) {
     return
   }
 
   // CHECK-LABEL: func @inoutType(%arg0: !hw.inout<i42>) {
-  func @inoutType(%arg0: !hw.inout<i42>) {
+  func.func @inoutType(%arg0: !hw.inout<i42>) {
     return
   }
 
   // CHECK-LABEL: func @structType(%arg0: !hw.struct<>, %arg1: !hw.struct<foo: i32, bar: i4, baz: !hw.struct<foo: i7>>) {
-  func @structType(%SE: !hw.struct<>, %SF: !hw.struct<foo: i32, bar: i4, baz: !hw.struct<foo: i7>>) {
+  func.func @structType(%SE: !hw.struct<>, %SF: !hw.struct<foo: i32, bar: i4, baz: !hw.struct<foo: i7>>) {
     return
   }
 
   // CHECK-LABEL: func @unionType(%arg0: !hw.union<foo: i32, bar: i4, baz: !hw.struct<foo: i7>>) {
-  func @unionType(%SF: !hw.union<foo: i32, bar: i4, baz: !hw.struct<foo: i7>>) {
+  func.func @unionType(%SF: !hw.union<foo: i32, bar: i4, baz: !hw.struct<foo: i7>>) {
     return
   }
 
   // CHECK-LABEL: nestedType
-  func @nestedType(
+  func.func @nestedType(
     // CHECK: %arg0: !hw.inout<array<42xi8>>,
     %arg0: !hw.inout<!hw.array<42xi8>>,
      // CHECK: %arg1: !hw.inout<array<42xi8>>,
@@ -44,7 +44,7 @@ module {
   }
 
   // CHECK-LABEL: aliasedAggregates
-  func @aliasedAggregates(%i: i1) {
+  func.func @aliasedAggregates(%i: i1) {
     // CHECK: !hw.typealias<@ns::@bar, !hw.struct<a: i1, b: i1>>
     %0 = hw.struct_create(%i, %i) : !hw.typealias<@ns::@bar, !hw.struct<a: i1, b: i1>>
     // CHECK: !hw.typealias<@ns::@bar, !hw.union<a: i1, b: i1>>

--- a/test/Dialect/LLHD/Canonicalization/bitwise.mlir
+++ b/test/Dialect/LLHD/Canonicalization/bitwise.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: @check_shl_folding
 // CHECK-SAME: %[[BASE:.*]]: i4
 // CHECK-SAME: %[[HIDDEN:.*]]: i8
-func @check_shl_folding(%base : i4, %hidden : i8) -> (i4, i4) {
+func.func @check_shl_folding(%base : i4, %hidden : i8) -> (i4, i4) {
   // CHECK-NEXT: %[[NEGSEVEN:.*]] = hw.constant -7 : i4
   %0 = hw.constant 2 : i4
   %1 = hw.constant 4 : i4
@@ -18,7 +18,7 @@ func @check_shl_folding(%base : i4, %hidden : i8) -> (i4, i4) {
 // CHECK-LABEL: @check_shr_folding
 // CHECK-SAME: %[[BASE:.*]]: i4
 // CHECK-SAME: %[[HIDDEN:.*]]: i8
-func @check_shr_folding(%base : i4, %hidden : i8) -> (i4, i4) {
+func.func @check_shr_folding(%base : i4, %hidden : i8) -> (i4, i4) {
   // CHECK-NEXT: %[[NEGSEVEN:.*]] = hw.constant -7 : i4
   %0 = hw.constant 2 : i4
   %1 = hw.constant 4 : i4

--- a/test/Dialect/LLHD/Canonicalization/constant.mlir
+++ b/test/Dialect/LLHD/Canonicalization/constant.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: @const_hoisting
 // CHECK-SAME: %[[SIG:.*]]: !llhd.sig<i32>
-func @const_hoisting(%sig : !llhd.sig<i32>) {
+func.func @const_hoisting(%sig : !llhd.sig<i32>) {
   // CHECK-DAG: %[[C0:.*]] = hw.constant -1 : i32
   // CHECK-DAG: %[[TIME:.*]] = llhd.constant_time <1ns, 0d, 0e>
   // CHECK-NEXT: cf.br ^[[BB:.*]]

--- a/test/Dialect/LLHD/Canonicalization/extract.mlir
+++ b/test/Dialect/LLHD/Canonicalization/extract.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt %s -canonicalize='top-down=true region-simplify=true' | FileCheck %s
 
 // CHECK-LABEL: @sigExtractOp
-func @sigExtractOp(%arg0 : !llhd.sig<i32>, %arg1: i5) -> (!llhd.sig<i32>, !llhd.sig<i32>) {
+func.func @sigExtractOp(%arg0 : !llhd.sig<i32>, %arg1: i5) -> (!llhd.sig<i32>, !llhd.sig<i32>) {
   %zero = hw.constant 0 : i5
 
   // CHECK: %[[EXT:.*]] = llhd.sig.extract %arg0 from %arg1 : (!llhd.sig<i32>) -> !llhd.sig<i32>
@@ -14,7 +14,7 @@ func @sigExtractOp(%arg0 : !llhd.sig<i32>, %arg1: i5) -> (!llhd.sig<i32>, !llhd.
 }
 
 // CHECK-LABEL: @sigArraySlice
-func @sigArraySliceOp(%arg0: !llhd.sig<!hw.array<30xi32>>, %arg1: !llhd.sig<!hw.array<30xi32>>, %arg2: i5)
+func.func @sigArraySliceOp(%arg0: !llhd.sig<!hw.array<30xi32>>, %arg1: !llhd.sig<!hw.array<30xi32>>, %arg2: i5)
     -> (!llhd.sig<!hw.array<30xi32>>, !llhd.sig<!hw.array<30xi32>>, !llhd.sig<!hw.array<20xi32>>, !llhd.sig<!hw.array<3xi32>>) {
   %zero = hw.constant 0 : i5
 
@@ -40,8 +40,8 @@ func @sigArraySliceOp(%arg0: !llhd.sig<!hw.array<30xi32>>, %arg1: !llhd.sig<!hw.
 }
 
 // CHECK-LABEL: @sigArrayGetOp
-func @sigArrayGetOp(%arg0: !llhd.sig<!hw.array<30xi32>>, %arg1: !llhd.sig<!hw.array<30xi32>>) -> (!llhd.sig<i32>, !llhd.sig<i32>) {
-  
+func.func @sigArrayGetOp(%arg0: !llhd.sig<!hw.array<30xi32>>, %arg1: !llhd.sig<!hw.array<30xi32>>) -> (!llhd.sig<i32>, !llhd.sig<i32>) {
+
   // CHECK-NEXT: %c4_i5 = hw.constant 4 : i5
   // CHECK-NEXT: %c6_i5 = hw.constant 6 : i5
   %a = hw.constant 3 : i5

--- a/test/Dialect/LLHD/Canonicalization/memory.mlir
+++ b/test/Dialect/LLHD/Canonicalization/memory.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: @check_mem_dce
 // CHECK-SAME: %[[INT:.*]]: i32,
 // CHECK-SAME: %[[INT2:.*]]: i32
-func @check_mem_dce(%int : i32, %int2 : i32) -> i32 {
+func.func @check_mem_dce(%int : i32, %int2 : i32) -> i32 {
   // CHECK-NEXT: %[[VAR:.*]] = llhd.var %[[INT]] : i32
   %0 = llhd.var %int : i32
   %1 = llhd.var %int2 : i32
@@ -23,7 +23,7 @@ func @check_mem_dce(%int : i32, %int2 : i32) -> i32 {
 // CHECK-LABEL: @check_mem_cse
 // CHECK-SAME: %[[INT:.*]]: i32,
 // CHECK-SAME: %[[INT2:.*]]: i32
-func @check_mem_cse(%int : i32, %int2 : i32) {
+func.func @check_mem_cse(%int : i32, %int2 : i32) {
   // CHECK-NEXT: %[[VAR1:.*]] = llhd.var %[[INT]] : i32
   %0 = llhd.var %int : i32
   // CHECK-NEXT: %[[VAR2:.*]] = llhd.var %[[INT2]] : i32

--- a/test/Dialect/LLHD/Canonicalization/probeCSE.mlir
+++ b/test/Dialect/LLHD/Canonicalization/probeCSE.mlir
@@ -3,7 +3,7 @@
 
 // CHECK-LABEL: @check_dce_prb_but_not_cse
 // CHECK-SAME: %[[SIG:.*]]: !llhd.sig<i32>
-func @check_dce_prb_but_not_cse(%sig : !llhd.sig<i32>) -> (i32, i32) {
+func.func @check_dce_prb_but_not_cse(%sig : !llhd.sig<i32>) -> (i32, i32) {
   // CHECK-NEXT: %[[P1:.*]] = llhd.prb %[[SIG]] : !llhd.sig<i32>
   %1 = llhd.prb %sig : !llhd.sig<i32>
   // CHECK-NEXT: %[[P2:.*]] = llhd.prb %[[SIG]] : !llhd.sig<i32>

--- a/test/Dialect/LLHD/Canonicalization/signalOps.mlir
+++ b/test/Dialect/LLHD/Canonicalization/signalOps.mlir
@@ -5,7 +5,7 @@
 // CHECK-SAME: %[[VAL:.*]]: i32
 // CHECK-SAME: %[[TIME:.*]]: !llhd.time
 // CHECK-SAME: %[[COND:.*]]: i1
-func @drv_folding(%sig: !llhd.sig<i32>, %val: i32, %time: !llhd.time, %cond: i1) {
+func.func @drv_folding(%sig: !llhd.sig<i32>, %val: i32, %time: !llhd.time, %cond: i1) {
   %true = hw.constant 1 : i1
   %false = hw.constant 0 : i1
 

--- a/test/Dialect/LLHD/IR/bitwise.mlir
+++ b/test/Dialect/LLHD/IR/bitwise.mlir
@@ -9,7 +9,7 @@
 // CHECK-SAME: %[[SIGARRAY2:.*]]: !llhd.sig<!hw.array<2xi8>>
 // CHECK-SAME: %[[ARRAY4:.*]]: !hw.array<4xi8>
 // CHECK-SAME: %[[ARRAY2:.*]]: !hw.array<2xi8>
-func @check_bitwise(%a : i64, %c : i8,
+func.func @check_bitwise(%a : i64, %c : i8,
     %sig1 : !llhd.sig<i32>, %sig2 : !llhd.sig<i4>,
     %sigarray4: !llhd.sig<!hw.array<4xi8>>, %sigarray2: !llhd.sig<!hw.array<2xi8>>,
     %array4: !hw.array<4xi8>, %array2: !hw.array<2xi8>) {

--- a/test/Dialect/LLHD/IR/extract-errors.mlir
+++ b/test/Dialect/LLHD/IR/extract-errors.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt %s -mlir-print-op-generic -split-input-file -verify-diagnostics
 
-func @illegal_signal_to_array(%sig : !llhd.sig<!hw.array<3xi32>>, %ind: i2) {
+func.func @illegal_signal_to_array(%sig : !llhd.sig<!hw.array<3xi32>>, %ind: i2) {
   // expected-error @+1 {{'llhd.sig.array_slice' op result #0 must be LLHD sig type of an ArrayType values, but got '!hw.array<3xi32>'}}
   %0 = llhd.sig.array_slice %sig at %ind : (!llhd.sig<!hw.array<3xi32>>) -> !hw.array<3xi32>
 
@@ -9,7 +9,7 @@ func @illegal_signal_to_array(%sig : !llhd.sig<!hw.array<3xi32>>, %ind: i2) {
 
 // -----
 
-func @illegal_array_element_type_mismatch(%sig : !llhd.sig<!hw.array<3xi32>>, %ind: i2) {
+func.func @illegal_array_element_type_mismatch(%sig : !llhd.sig<!hw.array<3xi32>>, %ind: i2) {
   // expected-error @+1 {{arrays element type must match}}
   %0 = llhd.sig.array_slice %sig at %ind : (!llhd.sig<!hw.array<3xi32>>) -> !llhd.sig<!hw.array<2xi1>>
 
@@ -18,7 +18,7 @@ func @illegal_array_element_type_mismatch(%sig : !llhd.sig<!hw.array<3xi32>>, %i
 
 // -----
 
-func @illegal_result_array_too_big(%sig : !llhd.sig<!hw.array<3xi32>>, %ind: i2) {
+func.func @illegal_result_array_too_big(%sig : !llhd.sig<!hw.array<3xi32>>, %ind: i2) {
   // expected-error @+1 {{width of result type has to be smaller than or equal to the input type}}
   %0 = llhd.sig.array_slice %sig at %ind : (!llhd.sig<!hw.array<3xi32>>) -> !llhd.sig<!hw.array<4xi32>>
 
@@ -27,7 +27,7 @@ func @illegal_result_array_too_big(%sig : !llhd.sig<!hw.array<3xi32>>, %ind: i2)
 
 // -----
 
-func @illegal_sig_to_int(%s : !llhd.sig<i32>, %ind: i5) {
+func.func @illegal_sig_to_int(%s : !llhd.sig<i32>, %ind: i5) {
   // expected-error @+1 {{'llhd.sig.extract' op result #0 must be LLHD sig type of an integer bitvector of one or more bits values, but got 'i10'}}
   %0 = llhd.sig.extract %s from %ind : (!llhd.sig<i32>) -> i10
 
@@ -36,7 +36,7 @@ func @illegal_sig_to_int(%s : !llhd.sig<i32>, %ind: i5) {
 
 // -----
 
-func @illegal_sig_to_int_to_wide(%s : !llhd.sig<i32>, %ind: i5) {
+func.func @illegal_sig_to_int_to_wide(%s : !llhd.sig<i32>, %ind: i5) {
   // expected-error @+1 {{width of result type has to be smaller than or equal to the input type}}
   %0 = llhd.sig.extract %s from %ind : (!llhd.sig<i32>) -> !llhd.sig<i64>
 
@@ -45,7 +45,7 @@ func @illegal_sig_to_int_to_wide(%s : !llhd.sig<i32>, %ind: i5) {
 
 // -----
 
-func @extract_element_tuple_index_out_of_bounds(%tup : !llhd.sig<!hw.struct<foo: i1, bar: i2, baz: i3>>) {
+func.func @extract_element_tuple_index_out_of_bounds(%tup : !llhd.sig<!hw.struct<foo: i1, bar: i2, baz: i3>>) {
   // expected-error @+1 {{invalid field name specified}}
   %0 = llhd.sig.struct_extract %tup["foobar"] : !llhd.sig<!hw.struct<foo: i1, bar: i2, baz: i3>>
 

--- a/test/Dialect/LLHD/IR/extract.mlir
+++ b/test/Dialect/LLHD/IR/extract.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt %s -mlir-print-op-generic -split-input-file -verify-diagnostics | circt-opt | circt-opt | FileCheck %s
 
 // CHECK-LABEL: @sigExtract
-func @sigExtract (%arg0 : !llhd.sig<i32>, %arg1: i5) -> () {
+func.func @sigExtract (%arg0 : !llhd.sig<i32>, %arg1: i5) -> () {
   // CHECK-NEXT: %{{.*}} = llhd.sig.extract %arg0 from %arg1 : (!llhd.sig<i32>) -> !llhd.sig<i5>
   %1 = llhd.sig.extract %arg0 from %arg1 : (!llhd.sig<i32>) -> !llhd.sig<i5>
 
@@ -9,7 +9,7 @@ func @sigExtract (%arg0 : !llhd.sig<i32>, %arg1: i5) -> () {
 }
 
 // CHECK-LABEL: @sigArray
-func @sigArray (%arg0 : !llhd.sig<!hw.array<5xi1>>, %arg1: i3) -> () {
+func.func @sigArray (%arg0 : !llhd.sig<!hw.array<5xi1>>, %arg1: i3) -> () {
   // CHECK-NEXT: %{{.*}} = llhd.sig.array_slice %arg0 at %arg1 : (!llhd.sig<!hw.array<5xi1>>) -> !llhd.sig<!hw.array<3xi1>>
   %0 = llhd.sig.array_slice %arg0 at %arg1 : (!llhd.sig<!hw.array<5xi1>>) -> !llhd.sig<!hw.array<3xi1>>
   // CHECK-NEXT: %{{.*}} = llhd.sig.array_get %arg0[%arg1] : !llhd.sig<!hw.array<5xi1>>
@@ -19,7 +19,7 @@ func @sigArray (%arg0 : !llhd.sig<!hw.array<5xi1>>, %arg1: i3) -> () {
 }
 
 // CHECK-LABEL: @sigStructExtract
-func @sigStructExtract(%arg0 : !llhd.sig<!hw.struct<foo: i1, bar: i2, baz: i3>>) {
+func.func @sigStructExtract(%arg0 : !llhd.sig<!hw.struct<foo: i1, bar: i2, baz: i3>>) {
   // CHECK-NEXT: %{{.*}} = llhd.sig.struct_extract %arg0["foo"] : !llhd.sig<!hw.struct<foo: i1, bar: i2, baz: i3>>
   %0 = llhd.sig.struct_extract %arg0["foo"] : !llhd.sig<!hw.struct<foo: i1, bar: i2, baz: i3>>
   // CHECK-NEXT: %{{.*}} = llhd.sig.struct_extract %arg0["baz"] : !llhd.sig<!hw.struct<foo: i1, bar: i2, baz: i3>>

--- a/test/Dialect/LLHD/IR/memory-errors.mlir
+++ b/test/Dialect/LLHD/IR/memory-errors.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt %s -mlir-print-op-generic -split-input-file -verify-diagnostics
 
 // expected-note @+1 {{prior use here}}
-func @check_illegal_store(%i1Ptr : !llhd.ptr<i1>, %i32Const : i32) {
+func.func @check_illegal_store(%i1Ptr : !llhd.ptr<i1>, %i32Const : i32) {
   // expected-error @+1 {{use of value '%i32Const' expects different type than prior uses: 'i1' vs 'i32'}}
   llhd.store %i1Ptr, %i32Const : !llhd.ptr<i1>
 

--- a/test/Dialect/LLHD/IR/memory.mlir
+++ b/test/Dialect/LLHD/IR/memory.mlir
@@ -4,7 +4,7 @@
 // CHECK-SAME: %[[INT:.*]]: i32
 // CHECK-SAME: %[[ARRAY:.*]]: !hw.array<3xi1>
 // CHECK-SAME: %[[TUP:.*]]: !hw.struct<foo: i1, bar: i2, baz: i3>
-func @check_var(%int : i32, %array : !hw.array<3xi1>, %tup : !hw.struct<foo: i1, bar: i2, baz: i3>) {
+func.func @check_var(%int : i32, %array : !hw.array<3xi1>, %tup : !hw.struct<foo: i1, bar: i2, baz: i3>) {
   // CHECK-NEXT: %{{.*}} = llhd.var %[[INT]] : i32
   %0 = llhd.var %int : i32
   // CHECK-NEXT: %{{.*}} = llhd.var %[[ARRAY]] : !hw.array<3xi1>
@@ -19,7 +19,7 @@ func @check_var(%int : i32, %array : !hw.array<3xi1>, %tup : !hw.struct<foo: i1,
 // CHECK-SAME: %[[INT:.*]]: !llhd.ptr<i32>
 // CHECK-SAME: %[[ARRAY:.*]]: !llhd.ptr<!hw.array<3xi1>>
 // CHECK-SAME: %[[TUP:.*]]: !llhd.ptr<!hw.struct<foo: i1, bar: i2, baz: i3>>
-func @check_load(%int : !llhd.ptr<i32>, %array : !llhd.ptr<!hw.array<3xi1>>, %tup : !llhd.ptr<!hw.struct<foo: i1, bar: i2, baz: i3>>) {
+func.func @check_load(%int : !llhd.ptr<i32>, %array : !llhd.ptr<!hw.array<3xi1>>, %tup : !llhd.ptr<!hw.struct<foo: i1, bar: i2, baz: i3>>) {
   // CHECK-NEXT: %{{.*}} = llhd.load %[[INT]] : !llhd.ptr<i32>
   %0 = llhd.load %int : !llhd.ptr<i32>
   // CHECK-NEXT: %{{.*}} = llhd.load %[[ARRAY]] : !llhd.ptr<!hw.array<3xi1>>
@@ -37,7 +37,7 @@ func @check_load(%int : !llhd.ptr<i32>, %array : !llhd.ptr<!hw.array<3xi1>>, %tu
 // CHECK-SAME: %[[ARRAYC:.*]]: !hw.array<3xi1>
 // CHECK-SAME: %[[TUP:.*]]: !llhd.ptr<!hw.struct<foo: i1, bar: i2, baz: i3>>
 // CHECK-SAME: %[[TUPC:.*]]: !hw.struct<foo: i1, bar: i2, baz: i3>
-func @check_store(%int : !llhd.ptr<i32>, %intC : i32 , %array : !llhd.ptr<!hw.array<3xi1>>, %arrayC : !hw.array<3xi1>, %tup : !llhd.ptr<!hw.struct<foo: i1, bar: i2, baz: i3>>, %tupC : !hw.struct<foo: i1, bar: i2, baz: i3>) {
+func.func @check_store(%int : !llhd.ptr<i32>, %intC : i32 , %array : !llhd.ptr<!hw.array<3xi1>>, %arrayC : !hw.array<3xi1>, %tup : !llhd.ptr<!hw.struct<foo: i1, bar: i2, baz: i3>>, %tupC : !hw.struct<foo: i1, bar: i2, baz: i3>) {
   // CHECK-NEXT: llhd.store %[[INT]], %[[INTC]] : !llhd.ptr<i32>
   llhd.store %int, %intC : !llhd.ptr<i32>
   // CHECK-NEXT: llhd.store %[[ARRAY]], %[[ARRAYC]] : !llhd.ptr<!hw.array<3xi1>>

--- a/test/Dialect/LLHD/IR/signal.mlir
+++ b/test/Dialect/LLHD/IR/signal.mlir
@@ -23,7 +23,7 @@ llhd.entity @checkSigInst () -> () {
 }
 
 // CHECK-LABEL: checkPrb
-func @checkPrb(%arg0 : !llhd.sig<i1>, %arg1 : !llhd.sig<i64>, %arg2 : !llhd.sig<!hw.array<3xi8>>, %arg3 : !llhd.sig<!hw.struct<foo: i1, bar: i2, baz: i4>>) {
+func.func @checkPrb(%arg0 : !llhd.sig<i1>, %arg1 : !llhd.sig<i64>, %arg2 : !llhd.sig<!hw.array<3xi8>>, %arg3 : !llhd.sig<!hw.struct<foo: i1, bar: i2, baz: i4>>) {
   // CHECK: %{{.*}} = llhd.prb %arg0 : !llhd.sig<i1>
   %0 = llhd.prb %arg0 : !llhd.sig<i1>
   // CHECK-NEXT: %{{.*}} = llhd.prb %arg1 : !llhd.sig<i64>
@@ -37,7 +37,7 @@ func @checkPrb(%arg0 : !llhd.sig<i1>, %arg1 : !llhd.sig<i64>, %arg2 : !llhd.sig<
 }
 
 // CHECK-LABEL: checkOutput
-func @checkOutput(%arg0: i32, %arg1: !llhd.time) {
+func.func @checkOutput(%arg0: i32, %arg1: !llhd.time) {
   // CHECK-NEXT: %{{.+}} = llhd.output %arg0 after %arg1 : i32
   %0 = llhd.output %arg0 after %arg1 : i32
   // CHECK-NEXT: %{{.+}} = llhd.output "sigName" %arg0 after %arg1 : i32
@@ -47,11 +47,11 @@ func @checkOutput(%arg0: i32, %arg1: !llhd.time) {
 }
 
 // CHECK-LABEL: checkDrv
-func @checkDrv(%arg0 : !llhd.sig<i1>, %arg1 : !llhd.sig<i64>, %arg2 : i1,
+func.func @checkDrv(%arg0 : !llhd.sig<i1>, %arg1 : !llhd.sig<i64>, %arg2 : i1,
     %arg3 : i64, %arg4 : !llhd.time, %arg5 : !llhd.sig<!hw.array<3xi8>>,
     %arg6 : !llhd.sig<!hw.struct<foo: i1, bar: i2, baz: i4>>,
     %arg7 : !hw.array<3xi8>, %arg8 : !hw.struct<foo: i1, bar: i2, baz: i4>) {
-      
+
   // CHECK-NEXT: llhd.drv %arg0, %arg2 after %arg4 : !llhd.sig<i1>
   llhd.drv %arg0, %arg2 after %arg4 : !llhd.sig<i1>
   // CHECK-NEXT: llhd.drv %arg1, %arg3 after %arg4 : !llhd.sig<i64>

--- a/test/Dialect/LLHD/IR/time.mlir
+++ b/test/Dialect/LLHD/IR/time.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt %s -allow-unregistered-dialect | FileCheck %s
 
-func @test_time_type() {
+func.func @test_time_type() {
   // CHECK: %[[CONST:.*]] = "time_result"() : () -> !llhd.time
   %0 = "time_result"() : () -> !llhd.time
   // CHECK-NEXT: "time_const_arg"(%[[CONST]]) : (!llhd.time) -> ()
@@ -8,7 +8,7 @@ func @test_time_type() {
   return
 }
 
-func @test_time_attr() {
+func.func @test_time_attr() {
   "time_attr"() {
     // CHECK: time0 = #llhd.time<1ns, 0d, 0e>
     time0 = #llhd.time<1ns, 0d, 0e> : !llhd.time,

--- a/test/Dialect/LLHD/IR/type-and-attribute-parsing.mlir
+++ b/test/Dialect/LLHD/IR/type-and-attribute-parsing.mlir
@@ -1,14 +1,14 @@
 // RUN: circt-opt %s --split-input-file --verify-diagnostics
 
 // expected-error @+1 {{unknown  type `illegaltype` in dialect `llhd`}}
-func @illegaltype(%arg0: !llhd.illegaltype) {
+func.func @illegaltype(%arg0: !llhd.illegaltype) {
     return
 }
 
 // -----
 
 // expected-error @+2 {{unknown attribute `illegalattr` in dialect `llhd`}}
-func @illegalattr() {
+func.func @illegalattr() {
     %0 = llhd.constant_time #llhd.illegalattr : i1
     return
 }

--- a/test/Dialect/LLHD/Transforms/memoryToBlockArgument.mlir
+++ b/test/Dialect/LLHD/Transforms/memoryToBlockArgument.mlir
@@ -41,7 +41,7 @@ llhd.proc @check_simple() -> () {
 // CHECK:           %[[VAL_1:.*]] = llhd.var %[[VAL_0]] : i32
 // CHECK:           return %[[VAL_1]] : !llhd.ptr<i32>
 // CHECK:         }
-func @allocate_mem() -> !llhd.ptr<i32> {
+func.func @allocate_mem() -> !llhd.ptr<i32> {
   %c = hw.constant 0 : i32
   %ptr = llhd.var %c : i32
   return %ptr : !llhd.ptr<i32>
@@ -50,7 +50,7 @@ func @allocate_mem() -> !llhd.ptr<i32> {
 // CHECK-LABEL:   llhd.proc @pointer_returned_from_call() -> () {
 // CHECK:           %[[ALLSET:.*]] = hw.constant -1 : i32
 // CHECK:           %[[VAL_0:.*]] = hw.constant true
-// CHECK:           %[[VAL_1:.*]] = call @allocate_mem() : () -> !llhd.ptr<i32>
+// CHECK:           %[[VAL_1:.*]] = func.call @allocate_mem() : () -> !llhd.ptr<i32>
 // CHECK:           cf.cond_br %[[VAL_0]], ^bb1, ^bb2
 // CHECK:         ^bb1:
 // CHECK:           %[[VAL_2:.*]] = hw.constant 6 : i32
@@ -68,7 +68,7 @@ func @allocate_mem() -> !llhd.ptr<i32> {
 llhd.proc @pointer_returned_from_call() -> () {
   %allset = hw.constant -1 : i32
   %cond = hw.constant 1 : i1
-  %ptr = call @allocate_mem() : () -> !llhd.ptr<i32>
+  %ptr = func.call @allocate_mem() : () -> !llhd.ptr<i32>
   cf.cond_br %cond, ^bb1, ^bb2
 ^bb1:
   %c6 = hw.constant 6 : i32
@@ -90,7 +90,7 @@ llhd.proc @pointer_returned_from_call() -> () {
 // CHECK:           llhd.store %[[VAL_0]], %[[VAL_1]] : !llhd.ptr<i32>
 // CHECK:           return
 // CHECK:         }
-func @store_something(%ptr : !llhd.ptr<i32>) {
+func.func @store_something(%ptr : !llhd.ptr<i32>) {
   %c = hw.constant 0 : i32
   llhd.store %ptr, %c : !llhd.ptr<i32>
   return
@@ -121,7 +121,7 @@ llhd.proc @pointer_passed_to_function() -> () {
   %ptr = llhd.var %c5 : i32
   cf.cond_br %cond, ^bb1, ^bb2
 ^bb1:
-  call @store_something(%ptr) : (!llhd.ptr<i32>) -> ()
+  func.call @store_something(%ptr) : (!llhd.ptr<i32>) -> ()
   cf.br ^bb3
 ^bb2:
   %c7 = hw.constant 7 : i32

--- a/test/Dialect/LLHD/Transforms/totalFunctionInlining.mlir
+++ b/test/Dialect/LLHD/Transforms/totalFunctionInlining.mlir
@@ -7,13 +7,13 @@
 // into entities.
 
 // CHECK-NOT: func
-func @simple() -> i32 {
+func.func @simple() -> i32 {
   %0 = hw.constant 5 : i32
   return %0 : i32
 }
 
 // CHECK-NOT: func
-func @complex(%flag : i1) -> i32 {
+func.func @complex(%flag : i1) -> i32 {
   cf.cond_br %flag, ^bb1, ^bb2
 ^bb1:
   %0 = hw.constant 5 : i32
@@ -29,7 +29,7 @@ llhd.entity @check_entity_inline() -> (%out : !llhd.sig<i32>) {
   // CHECK-NEXT: %{{.*}} = llhd.constant_time
   // CHECK-NEXT: llhd.drv
   // CHECK-NEXT: }
-  %1 = call @simple() : () -> i32
+  %1 = func.call @simple() : () -> i32
   %time = llhd.constant_time #llhd.time<1ns, 0d, 0e>
   llhd.drv %out, %1 after %time : !llhd.sig<i32>
 }
@@ -50,7 +50,7 @@ llhd.proc @check_proc_inline(%arg : !llhd.sig<i1>) -> (%out : !llhd.sig<i32>) {
   // CHECK-NEXT: llhd.halt
   // CHECK-NEXT: }
   %0 = llhd.prb %arg : !llhd.sig<i1>
-  %1 = call @complex(%0) : (i1) -> i32
+  %1 = func.call @complex(%0) : (i1) -> i32
   %time = llhd.constant_time #llhd.time<1ns, 0d, 0e>
   llhd.drv %out, %1 after %time : !llhd.sig<i32>
   llhd.halt

--- a/test/Dialect/Moore/basic.mlir
+++ b/test/Dialect/Moore/basic.mlir
@@ -11,7 +11,7 @@ llhd.entity @test1() -> () {
 }
 
 // CHECK-LABEL: func @Expressions
-func @Expressions(%a: !moore.bit, %b: !moore.logic, %c: !moore.packed<range<bit, 4:0>>) {
+func.func @Expressions(%a: !moore.bit, %b: !moore.logic, %c: !moore.packed<range<bit, 4:0>>) {
   // CHECK: %0 = moore.mir.concat
   // CHECK: %1 = moore.mir.concat
   %0 = moore.mir.concat %a, %a : (!moore.bit, !moore.bit) -> !moore.packed<range<bit, 1:0>>

--- a/test/Dialect/Moore/types-errors.mlir
+++ b/test/Dialect/Moore/types-errors.mlir
@@ -1,33 +1,33 @@
 // RUN: circt-opt --verify-diagnostics --split-input-file %s
 
 // expected-error @+1 {{ambiguous packing; wrap `named` in `packed<...>` or `unpacked<...>` to disambiguate}}
-func @Foo(%arg0: !moore.named<"foo", bit, loc(unknown)>) { return }
+func.func @Foo(%arg0: !moore.named<"foo", bit, loc(unknown)>) { return }
 
 // -----
 // expected-error @+1 {{ambiguous packing; wrap `ref` in `packed<...>` or `unpacked<...>` to disambiguate}}
-func @Foo(%arg0: !moore.ref<bit, loc(unknown)>) { return }
+func.func @Foo(%arg0: !moore.ref<bit, loc(unknown)>) { return }
 
 // -----
 // expected-error @+1 {{ambiguous packing; wrap `unsized` in `packed<...>` or `unpacked<...>` to disambiguate}}
-func @Foo(%arg0: !moore.unsized<bit>) { return }
+func.func @Foo(%arg0: !moore.unsized<bit>) { return }
 
 // -----
 // expected-error @+1 {{ambiguous packing; wrap `range` in `packed<...>` or `unpacked<...>` to disambiguate}}
-func @Foo(%arg0: !moore.range<bit, 3:0>) { return }
+func.func @Foo(%arg0: !moore.range<bit, 3:0>) { return }
 
 // -----
 // expected-error @+1 {{ambiguous packing; wrap `struct` in `packed<...>` or `unpacked<...>` to disambiguate}}
-func @Foo(%arg0: !moore.struct<{}, loc(unknown)>) { return }
+func.func @Foo(%arg0: !moore.struct<{}, loc(unknown)>) { return }
 
 // -----
 // expected-error @+1 {{unpacked struct cannot have a sign}}
-func @Foo(%arg0: !moore.unpacked<struct<unsigned, {}, loc(unknown)>>) { return }
-func @Bar(%arg0: !moore.packed<struct<unsigned, {}, loc(unknown)>>) { return }
+func.func @Foo(%arg0: !moore.unpacked<struct<unsigned, {}, loc(unknown)>>) { return }
+func.func @Bar(%arg0: !moore.packed<struct<unsigned, {}, loc(unknown)>>) { return }
 
 // -----
 // expected-error @+1 {{unpacked type '!moore.string' where only packed types are allowed}}
-func @Foo(%arg0: !moore.packed<struct<{a: string}, loc(unknown)>>) { return }
+func.func @Foo(%arg0: !moore.packed<struct<{a: string}, loc(unknown)>>) { return }
 
 // -----
 // expected-error @+1 {{unpacked type '!moore.string' where only packed types are allowed}}
-func @Foo(%arg0: !moore.packed<unsized<string>>) { return }
+func.func @Foo(%arg0: !moore.packed<unsized<string>>) { return }

--- a/test/Dialect/Moore/types.mlir
+++ b/test/Dialect/Moore/types.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt %s | circt-opt | FileCheck %s
 
 // CHECK-LABEL: func @UnitTypes(
-func @UnitTypes(
+func.func @UnitTypes(
   // CHECK-SAME: %arg0: !moore.void
   // CHECK-SAME: %arg1: !moore.string
   // CHECK-SAME: %arg2: !moore.chandle
@@ -13,7 +13,7 @@ func @UnitTypes(
 ) { return }
 
 // CHECK-LABEL: func @IntTypes(
-func @IntTypes(
+func.func @IntTypes(
   // CHECK-SAME: %arg0: !moore.bit
   // CHECK-SAME: %arg1: !moore.logic
   // CHECK-SAME: %arg2: !moore.reg
@@ -71,7 +71,7 @@ func @IntTypes(
 ) { return }
 
 // CHECK-LABEL: func @RealTypes(
-func @RealTypes(
+func.func @RealTypes(
   // CHECK-SAME: %arg0: !moore.shortreal
   // CHECK-SAME: %arg1: !moore.real
   // CHECK-SAME: %arg2: !moore.realtime
@@ -81,7 +81,7 @@ func @RealTypes(
 ) { return }
 
 // CHECK-LABEL: func @EnumType(
-func @EnumType(
+func.func @EnumType(
   // CHECK-SAME: %arg0: !moore.enum<loc("foo.sv":42:9001)>
   // CHECK-SAME: %arg1: !moore.enum<int, loc("foo.sv":42:9001)>
   // CHECK-SAME: %arg2: !moore.enum<"Foo", loc("foo.sv":42:9001)>
@@ -93,7 +93,7 @@ func @EnumType(
 ) { return }
 
 // CHECK-LABEL: func @IndirectTypes(
-func @IndirectTypes(
+func.func @IndirectTypes(
   // CHECK-SAME: %arg0: !moore.packed<named<"Foo", bit, loc("foo.sv":42:9001)>>
   // CHECK-SAME: %arg1: !moore.packed<ref<bit, loc("foo.sv":42:9001)>>
   %arg0: !moore.packed<named<"Foo", bit, loc("foo.sv":42:9001)>>,
@@ -109,7 +109,7 @@ func @IndirectTypes(
 ) { return }
 
 // CHECK-LABEL: func @DimTypes(
-func @DimTypes(
+func.func @DimTypes(
   // CHECK-SAME: %arg0: !moore.packed<unsized<bit>>,
   // CHECK-SAME: %arg1: !moore.packed<range<bit, 4:-5>>,
   %arg0: !moore.packed<unsized<bit>>,
@@ -133,7 +133,7 @@ func @DimTypes(
 }
 
 // CHECK-LABEL: func @StructTypes(
-func @StructTypes(
+func.func @StructTypes(
   // CHECK-SAME: %arg0: !moore.packed<struct<{}, loc("foo.sv":42:9001)>>
   // CHECK-SAME: %arg1: !moore.packed<struct<"Foo", {}, loc("foo.sv":42:9001)>>
   // CHECK-SAME: %arg2: !moore.packed<struct<unsigned, {}, loc("foo.sv":42:9001)>>

--- a/test/Dialect/SV/canonicalization.mlir
+++ b/test/Dialect/SV/canonicalization.mlir
@@ -11,7 +11,7 @@
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
 
-func @if_dead_condition(%arg0: i1) {
+func.func @if_dead_condition(%arg0: i1) {
   %fd = hw.constant 0x80000002 : i32
 
   sv.always posedge %arg0 {
@@ -58,7 +58,7 @@ func @if_dead_condition(%arg0: i1) {
 // CHECK-NOT:     sv.initial
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
-func @empy_op(%arg0: i1) {
+func.func @empy_op(%arg0: i1) {
   sv.initial {
     sv.if %arg0 {}
     sv.if %arg0 {} else {}
@@ -83,7 +83,7 @@ func @empy_op(%arg0: i1) {
 // CHECK-NEXT:    }
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
-func @invert_if(%arg0: i1) {
+func.func @invert_if(%arg0: i1) {
   sv.initial {
     sv.if %arg0 {
     } else {
@@ -103,7 +103,7 @@ func @invert_if(%arg0: i1) {
 // CHECK-NEXT:    }
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
-func @mux_to_cond_assign_f(%clock: i1, %c: i1, %data: i2) {
+func.func @mux_to_cond_assign_f(%clock: i1, %c: i1, %data: i2) {
   %r = sv.reg  : !hw.inout<i2>
   %1 = sv.read_inout %r : !hw.inout<i2>
   %0 = comb.mux %c, %data, %1 : i2
@@ -125,7 +125,7 @@ func @mux_to_cond_assign_f(%clock: i1, %c: i1, %data: i2) {
 // CHECK-NEXT:    }
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
-func @mux_to_cond_assign_t(%clock: i1, %c: i1, %data: i2) {
+func.func @mux_to_cond_assign_t(%clock: i1, %c: i1, %data: i2) {
   %r = sv.reg  : !hw.inout<i2>
   %r2 = sv.reg  : !hw.inout<i2>
   %r3 = sv.reg sym @r3 : !hw.inout<i2>

--- a/test/Dialect/StaticLogic/errors.mlir
+++ b/test/Dialect/StaticLogic/errors.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt %s -split-input-file -verify-diagnostics
 
-func @combinational_condition() {
+func.func @combinational_condition() {
   %c0_i32 = arith.constant 0 : i32
   %0 = memref.alloc() : memref<8xi32>
   // expected-error @+1 {{'staticlogic.pipeline.while' op condition must have a combinational body, found %3 = "memref.load"(%1, %2) : (memref<8xi32>, index) -> i32}}
@@ -20,7 +20,7 @@ func @combinational_condition() {
 
 // -----
 
-func @single_condition() {
+func.func @single_condition() {
   %false = arith.constant 0 : i1
   // expected-error @+1 {{'staticlogic.pipeline.while' op condition must terminate with a single result, found 'i1', 'i1'}}
   staticlogic.pipeline.while II = 1 iter_args(%arg0 = %false) : (i1) -> () {
@@ -36,7 +36,7 @@ func @single_condition() {
 
 // -----
 
-func @boolean_condition() {
+func.func @boolean_condition() {
   %c0_i32 = arith.constant 0 : i32
   // expected-error @+1 {{'staticlogic.pipeline.while' op condition must terminate with an i1 result, found 'i32'}}
   staticlogic.pipeline.while II = 1 iter_args(%arg0 = %c0_i32) : (i32) -> () {
@@ -52,7 +52,7 @@ func @boolean_condition() {
 
 // -----
 
-func @only_stages() {
+func.func @only_stages() {
   %false = arith.constant 0 : i1
   // expected-error @+1 {{'staticlogic.pipeline.while' op stages must contain at least one stage}}
   staticlogic.pipeline.while II = 1 iter_args(%arg0 = %false) : (i1) -> () {
@@ -65,7 +65,7 @@ func @only_stages() {
 
 // -----
 
-func @only_stages() {
+func.func @only_stages() {
   %false = arith.constant 0 : i1
   // expected-error @+1 {{'staticlogic.pipeline.while' op stages may only contain 'staticlogic.pipeline.stage' or 'staticlogic.pipeline.terminator' ops, found %1 = "arith.addi"(%arg0, %arg0) : (i1, i1) -> i1}}
   staticlogic.pipeline.while II = 1 iter_args(%arg0 = %false) : (i1) -> () {
@@ -79,7 +79,7 @@ func @only_stages() {
 
 // -----
 
-func @mismatched_register_types() {
+func.func @mismatched_register_types() {
   %false = arith.constant 0 : i1
   staticlogic.pipeline.while II = 1 iter_args(%arg0 = %false) : (i1) -> () {
     staticlogic.pipeline.register %arg0 : i1
@@ -95,7 +95,7 @@ func @mismatched_register_types() {
 
 // -----
 
-func @mismatched_iter_args_types() {
+func.func @mismatched_iter_args_types() {
   %false = arith.constant 0 : i1
   staticlogic.pipeline.while II = 1 iter_args(%arg0 = %false) : (i1) -> () {
     staticlogic.pipeline.register %arg0 : i1
@@ -111,7 +111,7 @@ func @mismatched_iter_args_types() {
 
 // -----
 
-func @invalid_iter_args() {
+func.func @invalid_iter_args() {
   %false = arith.constant 0 : i1
   staticlogic.pipeline.while II = 1 iter_args(%arg0 = %false) : (i1) -> (i1) {
     staticlogic.pipeline.register %arg0 : i1
@@ -127,7 +127,7 @@ func @invalid_iter_args() {
 
 // -----
 
-func @mismatched_result_types() {
+func.func @mismatched_result_types() {
   %false = arith.constant 0 : i1
   staticlogic.pipeline.while II = 1 iter_args(%arg0 = %false) : (i1) -> (i1) {
     staticlogic.pipeline.register %arg0 : i1
@@ -143,7 +143,7 @@ func @mismatched_result_types() {
 
 // -----
 
-func @invalid_results() {
+func.func @invalid_results() {
   %false = arith.constant 0 : i1
   staticlogic.pipeline.while II = 1 iter_args(%arg0 = %false) : (i1) -> (i1) {
     staticlogic.pipeline.register %arg0 : i1
@@ -159,7 +159,7 @@ func @invalid_results() {
 
 // -----
 
-func @negative_start() {
+func.func @negative_start() {
   %false = arith.constant 0 : i1
   staticlogic.pipeline.while II = 1 iter_args(%arg0 = %false) : (i1) -> () {
     staticlogic.pipeline.register %arg0 : i1
@@ -175,7 +175,7 @@ func @negative_start() {
 
 // -----
 
-func @non_monotonic_start0() {
+func.func @non_monotonic_start0() {
   %false = arith.constant 0 : i1
   staticlogic.pipeline.while II = 1 iter_args(%arg0 = %false) : (i1) -> () {
     staticlogic.pipeline.register %arg0 : i1
@@ -194,7 +194,7 @@ func @non_monotonic_start0() {
 
 // -----
 
-func @non_monotonic_start1() {
+func.func @non_monotonic_start1() {
   %false = arith.constant 0 : i1
   staticlogic.pipeline.while II = 1 iter_args(%arg0 = %false) : (i1) -> () {
     staticlogic.pipeline.register %arg0 : i1

--- a/test/Dialect/StaticLogic/round-trip.mlir
+++ b/test/Dialect/StaticLogic/round-trip.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt %s -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
 
-func @test1(%arg0: memref<?xi32>) -> i32 {
+func.func @test1(%arg0: memref<?xi32>) -> i32 {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c10 = arith.constant 10 : index
@@ -33,7 +33,7 @@ func @test1(%arg0: memref<?xi32>) -> i32 {
   return %0 : i32
 }
 
-func @test2(%arg0: memref<?xi32>, %arg1: memref<?xi32>) {
+func.func @test2(%arg0: memref<?xi32>, %arg1: memref<?xi32>) {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c3 = arith.constant 3 : index
@@ -67,14 +67,14 @@ func @test2(%arg0: memref<?xi32>, %arg1: memref<?xi32>) {
     } : i1, index, i32
     staticlogic.pipeline.stage start = 5 when %3#0  {
       memref.store %3#2, %arg1[%3#1] : memref<?xi32>
-      staticlogic.pipeline.register 
+      staticlogic.pipeline.register
     }
     staticlogic.pipeline.terminator iter_args(%0#0), results() : (index) -> ()
   }
   return
 }
 
-func @test3(%arg0: memref<?xi32>) {
+func.func @test3(%arg0: memref<?xi32>) {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c10 = arith.constant 10 : index
@@ -105,14 +105,14 @@ func @test3(%arg0: memref<?xi32>) {
     } : i32
     staticlogic.pipeline.stage start = 2 {
       memref.store %4, %0[%c0] : memref<1xi32>
-      staticlogic.pipeline.register 
+      staticlogic.pipeline.register
     }
     staticlogic.pipeline.terminator iter_args(%3#0), results() : (index) -> ()
   }
   return
 }
 
-func @test4(%arg0: memref<?xi32>, %arg1: memref<?xi32>) {
+func.func @test4(%arg0: memref<?xi32>, %arg1: memref<?xi32>) {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c10 = arith.constant 10 : index
@@ -141,14 +141,14 @@ func @test4(%arg0: memref<?xi32>, %arg1: memref<?xi32>) {
     } : index, i32
     staticlogic.pipeline.stage start = 4 {
       memref.store %2#1, %arg0[%2#0] : memref<?xi32>
-      staticlogic.pipeline.register 
+      staticlogic.pipeline.register
     }
     staticlogic.pipeline.terminator iter_args(%0#0), results() : (index) -> ()
   }
   return
 }
 
-func @test5(%arg0: memref<?xi32>) {
+func.func @test5(%arg0: memref<?xi32>) {
   %c1 = arith.constant 1 : index
   %c2 = arith.constant 2 : index
   %c10 = arith.constant 10 : index
@@ -174,14 +174,14 @@ func @test5(%arg0: memref<?xi32>) {
     staticlogic.pipeline.stage start = 2 {
       %2 = arith.addi %0, %1#0 : i32
       memref.store %2, %arg0[%arg1] : memref<?xi32>
-      staticlogic.pipeline.register 
+      staticlogic.pipeline.register
     }
     staticlogic.pipeline.terminator iter_args(%1#1), results() : (index) -> ()
   }
   return
 }
 
-func @trip_count_attr() {
+func.func @trip_count_attr() {
   %false = arith.constant 0 : i1
   // CHECK: staticlogic.pipeline.while II = 1 trip_count = 3
   staticlogic.pipeline.while II = 1 trip_count = 3 iter_args(%arg0 = %false) : (i1) -> () {

--- a/test/Scheduling/asap-errors.mlir
+++ b/test/Scheduling/asap-errors.mlir
@@ -2,7 +2,7 @@
 
 // expected-error@+2 {{dependence cycle detected}}
 // expected-error@+1 {{scheduling failed}}
-func @cyclic_graph() attributes {
+func.func @cyclic_graph() attributes {
   auxdeps = [ [0,1], [1,2], [2,3], [3,1] ]
   } {
   %0 = arith.constant 0 : i32

--- a/test/Scheduling/chaining-problem-errors.mlir
+++ b/test/Scheduling/chaining-problem-errors.mlir
@@ -2,7 +2,7 @@
 
 // expected-error@+2 {{Missing delays}}
 // expected-error@+1 {{problem check failed}}
-func @missing_delay() attributes {
+func.func @missing_delay() attributes {
   operatortypes = [
     { name = "foo", latency = 0}
   ]} {
@@ -13,7 +13,7 @@ func @missing_delay() attributes {
 
 // expected-error@+2 {{Negative delays}}
 // expected-error@+1 {{problem check failed}}
-func @negative_delay() attributes {
+func.func @negative_delay() attributes {
   operatortypes = [
     { name = "foo", latency = 0, incdelay = -1.0, outdelay = -1.0}
   ]} {
@@ -24,7 +24,7 @@ func @negative_delay() attributes {
 
 // expected-error@+2 {{Incoming & outgoing delay must be equal for zero-latency operator type}}
 // expected-error@+1 {{problem check failed}}
-func @inc_out_mismatch() attributes {
+func.func @inc_out_mismatch() attributes {
   cycletime = 10.0, operatortypes = [
     { name = "foo", latency = 0, incdelay = 1.0, outdelay = 2.0}
   ]} {
@@ -34,7 +34,7 @@ func @inc_out_mismatch() attributes {
 // -----
 
 // expected-error@+1 {{problem verification failed}}
-func @no_stic() {
+func.func @no_stic() {
   // expected-error@+1 {{Operation has no non-negative start time in cycle}}
   return { problemStartTime = 0 }
 }
@@ -43,7 +43,7 @@ func @no_stic() {
 
 // expected-error@+2 {{Precedence violated in cycle 0}}
 // expected-error@+1 {{problem verification failed}}
-func @precedence1(%arg0 : i32, %arg1 : i32) attributes {
+func.func @precedence1(%arg0 : i32, %arg1 : i32) attributes {
   operatortypes = [
     { name = "add", latency = 0, incdelay = 1.0, outdelay = 1.0}
   ] } {
@@ -56,7 +56,7 @@ func @precedence1(%arg0 : i32, %arg1 : i32) attributes {
 
 // expected-error@+2 {{Precedence violated in cycle 3}}
 // expected-error@+1 {{problem verification failed}}
-func @precedence2(%arg0 : i32, %arg1 : i32) attributes {
+func.func @precedence2(%arg0 : i32, %arg1 : i32) attributes {
   operatortypes = [
    { name = "add", latency = 0, incdelay = 1.0, outdelay = 1.0},
    { name = "mul", latency = 3, incdelay = 2.5, outdelay = 3.75}

--- a/test/Scheduling/chaining-problems.mlir
+++ b/test/Scheduling/chaining-problems.mlir
@@ -2,7 +2,7 @@
 // RUN: circt-opt %s -test-simplex-scheduler=with=ChainingProblem -allow-unregistered-dialect | FileCheck %s -check-prefix=SIMPLEX
 
 // SIMPLEX-LABEL: adder_chain
-func @adder_chain(%arg0 : i32, %arg1 : i32) -> i32 attributes {
+func.func @adder_chain(%arg0 : i32, %arg1 : i32) -> i32 attributes {
   cycletime = 5.0, // only evaluated for scheduler test; ignored by the problem test!
   operatortypes = [
    { name = "add", latency = 0, incdelay = 2.34, outdelay = 2.34}
@@ -18,7 +18,7 @@ func @adder_chain(%arg0 : i32, %arg1 : i32) -> i32 attributes {
 }
 
 // SIMPLEX-LABEL: multi_cycle
-func @multi_cycle(%arg0 : i32, %arg1 : i32) -> i32 attributes {
+func.func @multi_cycle(%arg0 : i32, %arg1 : i32) -> i32 attributes {
   cycletime = 5.0, // only evaluated for scheduler test; ignored by the problem test!
   operatortypes = [
    { name = "add", latency = 0, incdelay = 2.34, outdelay = 2.34},

--- a/test/Scheduling/chaining-simplex-errors.mlir
+++ b/test/Scheduling/chaining-simplex-errors.mlir
@@ -2,7 +2,7 @@
 
 // expected-error@+2 {{Delays of operator type 'inv' exceed maximum cycle time}}
 // expected-error@+1 {{scheduling failed}}
-func @invalid_delay() attributes {
+func.func @invalid_delay() attributes {
   cycletime = 2.0,  operatortypes = [{ name = "inv", latency = 0, incdelay = 2.34, outdelay = 2.34}] } {
   return { opr = "inv" }
 }

--- a/test/Scheduling/cyclic-problem-errors.mlir
+++ b/test/Scheduling/cyclic-problem-errors.mlir
@@ -2,7 +2,7 @@
 
 // expected-error@+2 {{Invalid initiation interval}}
 // expected-error@+1 {{problem verification failed}}
-func @no_II() {
+func.func @no_II() {
   return { problemStartTime = 0 }
 }
 
@@ -10,7 +10,7 @@ func @no_II() {
 
 // expected-error@+2 {{Precedence violated for dependence}}
 // expected-error@+1 {{problem verification failed}}
-func @backedge_violated(%a1 : i32, %a2 : i32) -> i32 attributes {
+func.func @backedge_violated(%a1 : i32, %a2 : i32) -> i32 attributes {
   problemInitiationInterval = 2,
   auxdeps = [ [2,0,1] ]
   } {

--- a/test/Scheduling/cyclic-problems.mlir
+++ b/test/Scheduling/cyclic-problems.mlir
@@ -3,7 +3,7 @@
 
 // SIMPLEX-LABEL: cyclic
 // SIMPLEX-SAME: simplexInitiationInterval = 2
-func @cyclic(%a1 : i32, %a2 : i32) -> i32 attributes {
+func.func @cyclic(%a1 : i32, %a2 : i32) -> i32 attributes {
   problemInitiationInterval = 2,
   auxdeps = [ [4,1,1], [4,2,2] ],
   operatortypes = [ { name = "_0", latency = 0 }, { name = "_2", latency = 2 } ]
@@ -24,7 +24,7 @@ func @cyclic(%a1 : i32, %a2 : i32) -> i32 attributes {
 
 // SIMPLEX-LABEL: mobility
 // SIMPLEX-SAME: simplexInitiationInterval = 3
-func @mobility() attributes {
+func.func @mobility() attributes {
   problemInitiationInterval = 3,
   auxdeps = [
     [0,1], [0,2], [1,3], [2,3],
@@ -51,7 +51,7 @@ func @mobility() attributes {
 
 // SIMPLEX-LABEL: interleaved_cycles
 // SIMPLEX-SAME: simplexInitiationInterval = 4
-func @interleaved_cycles() attributes {
+func.func @interleaved_cycles() attributes {
   problemInitiationInterval = 4,
   auxdeps = [
     [0,1], [0,2], [1,3], [2,3],
@@ -87,7 +87,7 @@ func @interleaved_cycles() attributes {
 
 // SIMPLEX-LABEL: self_arc
 // SIMPLEX-SAME: simplexInitiationInterval = 3
-func @self_arc() -> i32 attributes {
+func.func @self_arc() -> i32 attributes {
   problemInitiationInterval = 3,
   auxdeps = [ [1,1,1] ],
   operatortypes = [ { name = "_3", latency = 3 } ]

--- a/test/Scheduling/cyclic-simplex-errors.mlir
+++ b/test/Scheduling/cyclic-simplex-errors.mlir
@@ -2,7 +2,7 @@
 
 // expected-error@+2 {{problem is infeasible}}
 // expected-error@+1 {{scheduling failed}}
-func @cyclic_graph() attributes {
+func.func @cyclic_graph() attributes {
   auxdeps = [ [0,1], [1,2], [2,3], [3,1] ]
   } {
   %0 = arith.constant 0 : i32

--- a/test/Scheduling/modulo-problem-errors.mlir
+++ b/test/Scheduling/modulo-problem-errors.mlir
@@ -2,7 +2,7 @@
 
 // expected-error@+2 {{Operator type 'limited' is oversubscribed}}
 // expected-error@+1 {{problem verification failed}}
-func @oversubscribed(%a0 : i32, %a1 : i32, %a2 : i32) -> i32 attributes {
+func.func @oversubscribed(%a0 : i32, %a1 : i32, %a2 : i32) -> i32 attributes {
   problemInitiationInterval = 2,
   operatortypes = [ { name = "limited", latency = 1, limit = 2} ]
   } {

--- a/test/Scheduling/modulo-problems.mlir
+++ b/test/Scheduling/modulo-problems.mlir
@@ -3,7 +3,7 @@
 
 // SIMPLEX-LABEL: canis14_fig2
 // SIMPLEX-SAME: simplexInitiationInterval = 4
-func @canis14_fig2() attributes {
+func.func @canis14_fig2() attributes {
   problemInitiationInterval = 3,
   auxdeps = [ [3,0,1], [3,4] ],
   operatortypes = [
@@ -21,7 +21,7 @@ func @canis14_fig2() attributes {
 
 // SIMPLEX-LABEL: minII_feasible
 // SIMPLEX-SAME: simplexInitiationInterval = 4
-func @minII_feasible() attributes {
+func.func @minII_feasible() attributes {
   problemInitiationInterval = 3,
   auxdeps = [ [6,1,5], [5,2,3], [6,7] ],
   operatortypes = [
@@ -44,7 +44,7 @@ func @minII_feasible() attributes {
 
 // SIMPLEX-LABEL: minII_infeasible
 // SIMPLEX-SAME: simplexInitiationInterval = 4
-func @minII_infeasible() -> i32 attributes {
+func.func @minII_infeasible() -> i32 attributes {
   problemInitiationInterval = 4,
   auxdeps = [ [0,1], [5,1,1] ],
   operatortypes = [

--- a/test/Scheduling/or-tools/cyclic-problems.mlir
+++ b/test/Scheduling/or-tools/cyclic-problems.mlir
@@ -3,7 +3,7 @@
 
 // LP-LABEL: cyclic
 // LP-SAME: lpInitiationInterval = 2
-func @cyclic(%a1 : i32, %a2 : i32) -> i32 attributes {
+func.func @cyclic(%a1 : i32, %a2 : i32) -> i32 attributes {
   auxdeps = [ [4,1,1], [4,2,2] ],
   operatortypes = [ { name = "_0", latency = 0 }, { name = "_2", latency = 2 } ]
   } {
@@ -19,7 +19,7 @@ func @cyclic(%a1 : i32, %a2 : i32) -> i32 attributes {
 
 // LP-LABEL: mobility
 // LP-SAME: lpInitiationInterval = 3
-func @mobility() attributes {
+func.func @mobility() attributes {
   auxdeps = [
     [0,1], [0,2], [1,3], [2,3],
     [3,4], [3,5], [4,6], [5,6],
@@ -40,7 +40,7 @@ func @mobility() attributes {
 
 // LP-LABEL: interleaved_cycles
 // LP-SAME: lpInitiationInterval = 4
-func @interleaved_cycles() attributes {
+func.func @interleaved_cycles() attributes {
   auxdeps = [
     [0,1], [0,2], [1,3], [2,3],
     [3,4], [4,7], [3,5], [5,6], [6,7],
@@ -66,7 +66,7 @@ func @interleaved_cycles() attributes {
 
 // LP-LABEL: self_arc
 // LP-SAME: lpInitiationInterval = 3
-func @self_arc() -> i32 attributes {
+func.func @self_arc() -> i32 attributes {
   auxdeps = [ [1,1,1] ],
   operatortypes = [ { name = "_3", latency = 3 } ]
   } {

--- a/test/Scheduling/or-tools/problems.mlir
+++ b/test/Scheduling/or-tools/problems.mlir
@@ -2,7 +2,7 @@
 // RUN: circt-opt %s -test-lp-scheduler=with=Problem -allow-unregistered-dialect | FileCheck %s -check-prefix=LP
 
 // LP-LABEL: unit_latencies
-func @unit_latencies(%a1 : i32, %a2 : i32, %a3 : i32, %a4 : i32) -> i32 {
+func.func @unit_latencies(%a1 : i32, %a2 : i32, %a3 : i32, %a4 : i32) -> i32 {
   %0 = arith.addi %a1, %a2 : i32
   %1 = arith.addi %0, %a3 : i32
   %2:3 = "more.results"(%0, %1) : (i32, i32) -> (i32, i32, i32)
@@ -16,7 +16,7 @@ func @unit_latencies(%a1 : i32, %a2 : i32, %a3 : i32, %a4 : i32) -> i32 {
 }
 
 // LP-LABEL: arbitrary_latencies
-func @arbitrary_latencies(%v : complex<f32>) -> f32 attributes {
+func.func @arbitrary_latencies(%v : complex<f32>) -> f32 attributes {
   operatortypes = [
     { name = "extr", latency = 0 },
     { name = "add", latency = 3 },
@@ -35,7 +35,7 @@ func @arbitrary_latencies(%v : complex<f32>) -> f32 attributes {
 }
 
 // LP-LABEL: auxiliary_dependences
-func @auxiliary_dependences() attributes { auxdeps = [
+func.func @auxiliary_dependences() attributes { auxdeps = [
     [0,1], [0,2], [2,3], [3,4], [3,6], [4,5], [5,6]
   ] } {
   %0 = arith.constant 0 : i32

--- a/test/Scheduling/problem-errors.mlir
+++ b/test/Scheduling/problem-errors.mlir
@@ -2,7 +2,7 @@
 
 // expected-error@+2 {{Operator type 'foo' has no latency}}
 // expected-error@+1 {{problem check failed}}
-func @no_latency() {
+func.func @no_latency() {
   %0 = arith.constant 0 : i32
   %1 = arith.constant { problemStartTime = 0, opr = "foo" } 1 : i32
   return
@@ -11,7 +11,7 @@ func @no_latency() {
 // -----
 
 // expected-error@+1 {{problem verification failed}}
-func @no_starttime() {
+func.func @no_starttime() {
   %0 = arith.constant { problemStartTime = 0 } 0 : i32
   %1 = arith.constant 1 : i32 // expected-error {{Operation has no start time}}
   return { problemStartTime = 0 }
@@ -21,7 +21,7 @@ func @no_starttime() {
 
 // expected-error@+2 {{Precedence violated for dependence}}
 // expected-error@+1 {{problem verification failed}}
-func @ssa_dep_violated(%a0 : i32, %a1 : i32, %a2 : i32) -> i32 attributes {
+func.func @ssa_dep_violated(%a0 : i32, %a1 : i32, %a2 : i32) -> i32 attributes {
   operatortypes = [
     { name = "_0", latency = 0 },
     { name = "_1", latency = 1 },
@@ -37,7 +37,7 @@ func @ssa_dep_violated(%a0 : i32, %a1 : i32, %a2 : i32) -> i32 attributes {
 
 // expected-error@+2 {{Precedence violated for dependence}}
 // expected-error@+1 {{problem verification failed}}
-func @aux_dep_violated() attributes {
+func.func @aux_dep_violated() attributes {
   auxdeps = [ [0,1], [1,2], [2,3] ]
   } {
   %0 = arith.constant { problemStartTime = 123 } 0 : i32

--- a/test/Scheduling/problems.mlir
+++ b/test/Scheduling/problems.mlir
@@ -4,7 +4,7 @@
 
 // ASAP-LABEL: unit_latencies
 // SIMPLEX-LABEL: unit_latencies
-func @unit_latencies(%a1 : i32, %a2 : i32, %a3 : i32, %a4 : i32) -> i32 {
+func.func @unit_latencies(%a1 : i32, %a2 : i32, %a3 : i32, %a4 : i32) -> i32 {
   // ASAP-NEXT: asapStartTime = 0
   %0 = arith.addi %a1, %a2 { problemStartTime = 0 } : i32
   // ASAP-NEXT: asapStartTime = 1
@@ -27,7 +27,7 @@ func @unit_latencies(%a1 : i32, %a2 : i32, %a3 : i32, %a4 : i32) -> i32 {
 
 // ASAP-LABEL: arbitrary_latencies
 // SIMPLEX-LABEL: arbitrary_latencies
-func @arbitrary_latencies(%v : complex<f32>) -> f32 attributes {
+func.func @arbitrary_latencies(%v : complex<f32>) -> f32 attributes {
   operatortypes = [
     { name = "extr", latency = 0 },
     { name = "add", latency = 3 },
@@ -54,7 +54,7 @@ func @arbitrary_latencies(%v : complex<f32>) -> f32 attributes {
 
 // ASAP-LABEL: auxiliary_dependences
 // SIMPLEX-LABEL: auxiliary_dependences
-func @auxiliary_dependences() attributes { auxdeps = [
+func.func @auxiliary_dependences() attributes { auxdeps = [
     [0,1], [0,2], [2,3], [3,4], [3,6], [4,5], [5,6]
   ] } {
   // ASAP-NEXT: asapStartTime = 0

--- a/test/Scheduling/shared-operators-problem-errors.mlir
+++ b/test/Scheduling/shared-operators-problem-errors.mlir
@@ -2,7 +2,7 @@
 
 // expected-error@+2 {{Limited operator type '_0' has zero latency}}
 // expected-error@+1 {{problem check failed}}
-func @limited_but_zero_latency() attributes {
+func.func @limited_but_zero_latency() attributes {
   operatortypes = [ { name = "_0", latency = 0, limit = 1} ]
   } {
   return { opr = "_0" }
@@ -12,7 +12,7 @@ func @limited_but_zero_latency() attributes {
 
 // expected-error@+2 {{Operator type 'limited' is oversubscribed}}
 // expected-error@+1 {{problem verification failed}}
-func @oversubscribed(%a0 : i32, %a1 : i32, %a2 : i32) -> i32 attributes {
+func.func @oversubscribed(%a0 : i32, %a1 : i32, %a2 : i32) -> i32 attributes {
   operatortypes = [ { name = "limited", latency = 1, limit = 2} ]
   } {
   %0 = arith.addi %a0, %a0 { problemStartTime = 0 } : i32

--- a/test/Scheduling/shared-operators-problems.mlir
+++ b/test/Scheduling/shared-operators-problems.mlir
@@ -2,7 +2,7 @@
 // RUN: circt-opt %s -test-simplex-scheduler=with=SharedOperatorsProblem -allow-unregistered-dialect | FileCheck %s -check-prefix=SIMPLEX
 
 // SIMPLEX-LABEL: full_load
-func @full_load(%a0 : i32, %a1 : i32, %a2 : i32, %a3 : i32, %a4 : i32, %a5 : i32) -> i32 attributes {
+func.func @full_load(%a0 : i32, %a1 : i32, %a2 : i32, %a3 : i32, %a4 : i32, %a5 : i32) -> i32 attributes {
   operatortypes = [
     { name = "add", latency = 3, limit = 1 },
     { name = "_0", latency = 0 }
@@ -19,7 +19,7 @@ func @full_load(%a0 : i32, %a1 : i32, %a2 : i32, %a3 : i32, %a4 : i32, %a5 : i32
 }
 
 // SIMPLEX-LABEL: partial_load
-func @partial_load(%a0 : i32, %a1 : i32, %a2 : i32, %a3 : i32, %a4 : i32, %a5 : i32) -> i32 attributes {
+func.func @partial_load(%a0 : i32, %a1 : i32, %a2 : i32, %a3 : i32, %a4 : i32, %a5 : i32) -> i32 attributes {
   operatortypes = [
     { name = "add", latency = 3, limit = 3},
     { name = "_0", latency = 0 }
@@ -36,7 +36,7 @@ func @partial_load(%a0 : i32, %a1 : i32, %a2 : i32, %a3 : i32, %a4 : i32, %a5 : 
 }
 
 // SIMPLEX-LABEL: multiple
-func @multiple(%a0 : i32, %a1 : i32, %a2 : i32, %a3 : i32, %a4 : i32, %a5 : i32) -> i32 attributes {
+func.func @multiple(%a0 : i32, %a1 : i32, %a2 : i32, %a3 : i32, %a4 : i32, %a5 : i32) -> i32 attributes {
   operatortypes = [
     { name = "slowAdd", latency = 3, limit = 2},
     { name = "fastAdd", latency = 1, limit = 1},

--- a/test/Transforms/flatten_memref.mlir
+++ b/test/Transforms/flatten_memref.mlir
@@ -13,7 +13,7 @@
 // CHECK:           memref.store %[[VAL_5]], %[[VAL_0]]{{\[}}%[[VAL_8]]] : memref<16xi32>
 // CHECK:           return %[[VAL_5]] : i32
 // CHECK:         }
-func @as_func_arg(%a : memref<4x4xi32>, %i : index) -> i32 {
+func.func @as_func_arg(%a : memref<4x4xi32>, %i : index) -> i32 {
   %0 = memref.load %a[%i, %i] : memref<4x4xi32>
   memref.store %0, %a[%i, %i] : memref<4x4xi32>
   return %0 : i32
@@ -32,7 +32,7 @@ func @as_func_arg(%a : memref<4x4xi32>, %i : index) -> i32 {
 // CHECK:           %[[VAL_10:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_9]]] : memref<210xi32>
 // CHECK:           return %[[VAL_10]] : i32
 // CHECK:         }
-func @multidim3(%a : memref<5x6x7xi32>, %i1 : index, %i2 : index, %i3 : index) -> i32 {
+func.func @multidim3(%a : memref<5x6x7xi32>, %i1 : index, %i2 : index, %i3 : index) -> i32 {
   %0 = memref.load %a[%i1, %i2, %i3] : memref<5x6x7xi32>
   return %0 : i32
 }
@@ -57,7 +57,7 @@ func @multidim3(%a : memref<5x6x7xi32>, %i1 : index, %i2 : index, %i3 : index) -
 // CHECK:           %[[VAL_14:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_13]]] : memref<18900xi32>
 // CHECK:           return %[[VAL_14]] : i32
 // CHECK:         }
-func @multidim5(%a : memref<5x6x7x9x10xi32>, %i : index) -> i32 {
+func.func @multidim5(%a : memref<5x6x7x9x10xi32>, %i : index) -> i32 {
   %0 = memref.load %a[%i, %i, %i, %i, %i] : memref<5x6x7x9x10xi32>
   return %0 : i32
 }
@@ -82,7 +82,7 @@ func @multidim5(%a : memref<5x6x7x9x10xi32>, %i : index) -> i32 {
 // CHECK:           %[[VAL_14:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_13]]] : memref<512xi32>
 // CHECK:           return %[[VAL_14]] : i32
 // CHECK:         }
-func @multidim5_p2(%a : memref<2x4x8x2x4xi32>, %i : index) -> i32 {
+func.func @multidim5_p2(%a : memref<2x4x8x2x4xi32>, %i : index) -> i32 {
   %0 = memref.load %a[%i, %i, %i, %i, %i] : memref<2x4x8x2x4xi32>
   return %0 : i32
 }
@@ -93,7 +93,7 @@ func @multidim5_p2(%a : memref<2x4x8x2x4xi32>, %i : index) -> i32 {
 // CHECK:                      %[[VAL_0:.*]]: memref<16xi32>) -> memref<16xi32> {
 // CHECK:           return %[[VAL_0]] : memref<16xi32>
 // CHECK:         }
-func @as_func_ret(%a : memref<4x4xi32>) -> memref<4x4xi32> {
+func.func @as_func_ret(%a : memref<4x4xi32>) -> memref<4x4xi32> {
   return %a : memref<4x4xi32>
 }
 
@@ -103,7 +103,7 @@ func @as_func_ret(%a : memref<4x4xi32>) -> memref<4x4xi32> {
 // CHECK:           %[[VAL_0:.*]] = memref.alloc() : memref<16xi32>
 // CHECK:           return %[[VAL_0]] : memref<16xi32>
 // CHECK:         }
-func @allocs() -> memref<4x4xi32> {
+func.func @allocs() -> memref<4x4xi32> {
   %0 = memref.alloc() : memref<4x4xi32>
   return %0 : memref<4x4xi32>
 }
@@ -126,7 +126,7 @@ func @allocs() -> memref<4x4xi32> {
 // CHECK:           memref.store %[[VAL_10]], %[[VAL_6]]{{\[}}%[[VAL_13]]] : memref<16xi32>
 // CHECK:           return
 // CHECK:         }
-func @across_bbs(%i1 : index, %i2 : index, %c : i1) {
+func.func @across_bbs(%i1 : index, %i2 : index, %c : i1) {
   %0 = memref.alloc() : memref<4x4xi32>
   %1 = memref.alloc() : memref<4x4xi32>
   cf.cond_br %c,
@@ -140,7 +140,7 @@ func @across_bbs(%i1 : index, %i2 : index, %c : i1) {
 
 // -----
 
-func @foo(%0 : memref<4x4xi32>) -> memref<4x4xi32> {
+func.func @foo(%0 : memref<4x4xi32>) -> memref<4x4xi32> {
   return %0 : memref<4x4xi32>
 }
 
@@ -149,7 +149,7 @@ func @foo(%0 : memref<4x4xi32>) -> memref<4x4xi32> {
 // CHECK:           %[[VAL_1:.*]] = call @foo(%[[VAL_0]]) : (memref<16xi32>) -> memref<16xi32>
 // CHECK:           return
 // CHECK:         }
-func @calls() {
+func.func @calls() {
   %0 = memref.alloc() : memref<4x4xi32>
   %1 = call @foo(%0) : (memref<4x4xi32>) -> (memref<4x4xi32>)
   return

--- a/test/Transforms/flatten_memref_calls.mlir
+++ b/test/Transforms/flatten_memref_calls.mlir
@@ -10,8 +10,8 @@
 // CHECK:           return
 // CHECK:         }
 module  {
-  func private @foo(memref<30x30xi32>) -> i32
-  func @main() {
+  func.func private @foo(memref<30x30xi32>) -> i32
+  func.func @main() {
     %c0 = arith.constant 0 : index
     %0 = memref.alloca() : memref<30x30xi32>
     %1 = call @foo(%0) : (memref<30x30xi32>) -> i32

--- a/test/circt-opt/trivial.mlir
+++ b/test/circt-opt/trivial.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt %s -allow-unregistered-dialect | FileCheck %s
 
 // CHECK-LABEL: func @simpleCFG(%{{.*}}: i32, %{{.*}}: f32) -> i1 {
-func @simpleCFG(%arg0: i32, %f: f32) -> i1 {
+func.func @simpleCFG(%arg0: i32, %f: f32) -> i1 {
   // CHECK: %{{.*}} = "foo"() : () -> i64
   %1 = "foo"() : ()->i64
   // CHECK: "bar"(%{{.*}}) : (i64) -> (i1, i1, i1)

--- a/test/handshake-runner/call_bb.mlir
+++ b/test/handshake-runner/call_bb.mlir
@@ -2,13 +2,13 @@
 // RUN: circt-opt -lower-std-to-handshake %s | handshake-runner | FileCheck %s
 // CHECK: 763 2996
 module {
-  func @muladd(%1:index, %2:index, %3:index) -> (index) {
+  func.func @muladd(%1:index, %2:index, %3:index) -> (index) {
     %i2 = arith.muli %1, %2 : index
     %i3 = arith.addi %3, %i2 : index
 	 return %i3 : index
   }
 
-  func @main() -> (index, index) {
+  func.func @main() -> (index, index) {
     %c0 = arith.constant 0 : index
     %c101 = arith.constant 101 : index
     %c102 = arith.constant 102 : index

--- a/test/handshake-runner/call_controlflow.mlir
+++ b/test/handshake-runner/call_controlflow.mlir
@@ -3,17 +3,17 @@
 // RUN  handshake-runner handshake.mlir 3 2 1 | FileCheck %s
 // CHECK: 5
 
-func @add(%arg0 : i32, %arg1: i32) -> i32 {
+func.func @add(%arg0 : i32, %arg1: i32) -> i32 {
   %0 = arith.addi %arg0, %arg1 : i32
   return %0 : i32
 }
 
-func @sub(%arg0 : i32, %arg1: i32) -> i32 {
+func.func @sub(%arg0 : i32, %arg1: i32) -> i32 {
   %0 = arith.subi %arg0, %arg1 : i32
   return %0 : i32
 }
 
-func @main(%arg0 : i32, %arg1 : i32, %cond : i1) -> i32 {
+func.func @main(%arg0 : i32, %arg1 : i32, %cond : i1) -> i32 {
   cf.cond_br %cond, ^bb1, ^bb2
 ^bb1:
   %0 = call @add(%arg0, %arg1) : (i32, i32) -> i32

--- a/test/handshake-runner/cdiv-old-std.mlir
+++ b/test/handshake-runner/cdiv-old-std.mlir
@@ -3,7 +3,7 @@
 // CHECK: 0 2,3,4,5 2,3,4,5 1,1431655763,3,858993455 3,4,5,6 2,3,4,5 2,3,4,5 2,3,4,5 2,3,4,5 0,-1,0,-1
 
 module {
-  func @main(%0: memref<4xi32>,
+  func.func @main(%0: memref<4xi32>,
 			    %2: memref<4xi32>,
 				 %4: memref<4xi32>,
 				 %5: memref<4xi32>,

--- a/test/handshake-runner/cdiv-std.mlir
+++ b/test/handshake-runner/cdiv-std.mlir
@@ -3,7 +3,7 @@
 // CHECK: 0
 
 module {
-  func @main() -> index {
+  func.func @main() -> index {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %c10 = arith.constant 10 : index

--- a/test/handshake-runner/complex_bb.mlir
+++ b/test/handshake-runner/complex_bb.mlir
@@ -2,7 +2,7 @@
 // RUN: circt-opt -lower-std-to-handshake %s | handshake-runner | FileCheck %s
 // CHECK: 763 2996
 module {
-  func @main() -> (index, index) {
+  func.func @main() -> (index, index) {
     %c0 = arith.constant 0 : index
     %c101 = arith.constant 101 : index
     %c102 = arith.constant 102 : index

--- a/test/handshake-runner/floydwarshall-std.mlir
+++ b/test/handshake-runner/floydwarshall-std.mlir
@@ -3,7 +3,7 @@
 // CHECK: 0
 
 module {
-  func @main() -> index {
+  func.func @main() -> index {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %c4 = arith.constant 4 : index

--- a/test/handshake-runner/histogram-std.mlir
+++ b/test/handshake-runner/histogram-std.mlir
@@ -3,7 +3,7 @@
 // CHECK: 0
 
 module {
-  func @main() -> index {
+  func.func @main() -> index {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %c10 = arith.constant 10 : index

--- a/test/handshake-runner/loadstore.mlir
+++ b/test/handshake-runner/loadstore.mlir
@@ -3,7 +3,7 @@
 // CHECK: 1
 
 module {
-  func @main(%arg0: index) -> (i8) {
+  func.func @main(%arg0: index) -> (i8) {
     %0 = memref.alloc() : memref<10xi8>
     %c1 = arith.constant 1 : i8
 	 memref.store %c1, %0[%arg0] : memref<10xi8>

--- a/test/handshake-runner/loop-check-1-std.mlir
+++ b/test/handshake-runner/loop-check-1-std.mlir
@@ -3,7 +3,7 @@
 // CHECK: 10
 
 module {
-  func @main() -> i32 {
+  func.func @main() -> i32 {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %c4 = arith.constant 4 : index

--- a/test/handshake-runner/loop-check-2-std.mlir
+++ b/test/handshake-runner/loop-check-2-std.mlir
@@ -3,7 +3,7 @@
 // CHECK: 10
 
 module {
-  func @main() -> i32 {
+  func.func @main() -> i32 {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %c3 = arith.constant 3 : index

--- a/test/handshake-runner/matmul-check-std.mlir
+++ b/test/handshake-runner/matmul-check-std.mlir
@@ -5,7 +5,7 @@
 
 
 module {
-  func @main() -> i32 {
+  func.func @main() -> i32 {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %c8 = arith.constant 8 : index

--- a/test/handshake-runner/matmul-std.mlir
+++ b/test/handshake-runner/matmul-std.mlir
@@ -3,7 +3,7 @@
 // CHECK: 0
 
 module {
-  func @main() -> index {
+  func.func @main() -> index {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %c4 = arith.constant 4 : index

--- a/test/handshake-runner/memory_simple_2_std.mlir
+++ b/test/handshake-runner/memory_simple_2_std.mlir
@@ -3,7 +3,7 @@
 // CHECK: 5 5,3,4,5
 
 module {
-  func @main(%0: memref<4xi32>) -> i32{
+  func.func @main(%0: memref<4xi32>) -> i32{
     %c0 = arith.constant 0 : index
     %c5 = arith.constant 5 : i32
     memref.store %c5, %0[%c0] : memref<4xi32>

--- a/test/handshake-runner/memory_simple_std.mlir
+++ b/test/handshake-runner/memory_simple_std.mlir
@@ -3,7 +3,7 @@
 // CHECK: 2 2,3,4,5
 
 module {
-  func @main(%0 : memref<4xi32>) -> i32{
+  func.func @main(%0 : memref<4xi32>) -> i32{
     %c0 = arith.constant 0 : index
     %1 = memref.load %0[%c0] : memref<4xi32>
     return %1 : i32

--- a/test/handshake-runner/simple_loop.mlir
+++ b/test/handshake-runner/simple_loop.mlir
@@ -3,7 +3,7 @@
 // RUN: handshake-runner %s | FileCheck %s
 // CHECK: 42
 module {
-  func @main() -> index {
+  func.func @main() -> index {
     %c1 = arith.constant 1 : index
     %c42 = arith.constant 42 : index
     %c1_0 = arith.constant 1 : index

--- a/test/handshake-runner/simple_loop_buffered.mlir
+++ b/test/handshake-runner/simple_loop_buffered.mlir
@@ -3,7 +3,7 @@
 // RUN: | handshake-runner | FileCheck %s
 // CHECK: 42
 module {
-  func @main() -> index {
+  func.func @main() -> index {
     %c1 = arith.constant 1 : index
     %c42 = arith.constant 42 : index
     %c1_0 = arith.constant 1 : index


### PR DESCRIPTION
It was hard.
80% of credit goes to @youngar

- `func` and `call` op parsing requires the dialect specifier: https://discourse.llvm.org/t/psa-special-case-parsing-of-func-operations-is-being-removed/61953
- Region argument parsing overhaul: https://reviews.llvm.org/D124649
- LLVM requires a cmake build type to be specified: https://reviews.llvm.org/D124153