### PR TITLE
[SV] Add a builder to CaseOp which takes a validation qualifier

### DIFF
--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -342,8 +342,16 @@ def CaseOp : SVOp<"case", [SingleBlock, NoTerminator, NoRegionArguments,
   let builders = [
     /// This ctor allows you to build a CaseZ with some number of cases, getting
     /// a callback for each case.
+    OpBuilder<(ins "CaseStmtType":$caseStyle,
+                   "ValidationQualifierTypeEnum":$validationQualifier,
+                   "Value":$cond, "size_t":$numCases,
+                   "std::function<CasePattern(size_t)>":$caseCtor)>,
     OpBuilder<(ins "CaseStmtType":$caseStyle, "Value":$cond, "size_t":$numCases,
-               "std::function<CasePattern(size_t)>":$caseCtor)>
+               "std::function<CasePattern(size_t)>":$caseCtor), [{
+      build($_builder, $_state, caseStyle,
+            ValidationQualifierTypeEnum::ValidationQualifierPlain, cond,  numCases,
+            caseCtor);
+    }]>
   ];
 
   let extraClassDeclaration = [{

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -819,11 +819,16 @@ LogicalResult CaseOp::verify() {
 /// This ctor allows you to build a CaseZ with some number of cases, getting
 /// a callback for each case.
 void CaseOp::build(OpBuilder &builder, OperationState &result,
-                   CaseStmtType caseStyle, Value cond, size_t numCases,
+                   CaseStmtType caseStyle,
+                   ValidationQualifierTypeEnum validationQualifier, Value cond,
+                   size_t numCases,
                    std::function<CasePattern(size_t)> caseCtor) {
   result.addOperands(cond);
   result.addAttribute("caseStyle",
                       CaseStmtTypeAttr::get(builder.getContext(), caseStyle));
+  result.addAttribute("validationQualifier",
+                      ValidationQualifierTypeEnumAttr::get(
+                          builder.getContext(), validationQualifier));
   SmallVector<Attribute> casePatterns;
 
   OpBuilder::InsertionGuard guard(builder);


### PR DESCRIPTION
This commit adds a builder to sv::CaseOp which takes a validation qualifier as
an argument. This is separated from https://github.com/llvm/circt/pull/3024.