### PR TITLE
[FIRRTL][FullAsyncResetTransform] Preseve synchronous reset value

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -1677,13 +1677,19 @@ void InferResetsPass::implementAsyncReset(Operation *op, FModuleOp module,
     }
     LLVM_DEBUG(llvm::dbgs() << "- Updating reset of " << regOp << "\n");
 
+    auto reset = regOp.resetSignal();
+    auto value = regOp.resetValue();
+
     // If we arrive here, the register has a sync reset. In order to add an
     // async reset, we have to move the sync reset into a mux in front of the
     // register.
-    insertResetMux(builder, regOp, regOp.resetSignal(), regOp.resetValue());
-    builder.setInsertionPoint(regOp);
+    insertResetMux(builder, regOp, reset, value);
+    builder.setInsertionPointAfterValue(regOp);
+    auto mux = builder.create<MuxPrimOp>(reset, value, regOp);
+    builder.create<ConnectOp>(regOp, mux);
 
     // Replace the existing reset with the async reset.
+    builder.setInsertionPoint(regOp);
     auto zero = createZeroValue(builder, regOp.getType());
     regOp.resetSignalMutable().assign(actualReset);
     regOp.resetValueMutable().assign(zero);

--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -369,39 +369,45 @@ firrtl.circuit "Top" {
 
     // Existing sync reset is moved to mux.
     // CHECK: %reg3 = firrtl.regreset %clock, %extraReset, %c0_ui8
-    // CHECK: %0 = firrtl.mux(%init, %c1_ui8, %in)
-    // CHECK: firrtl.connect %reg3, %0
+    // CHECK: %0 = firrtl.mux(%init, %c1_ui8, %reg3)
+    // CHECK: %1 = firrtl.mux(%init, %c1_ui8, %in)
+    // CHECK: firrtl.connect %reg3, %1
     %reg3 = firrtl.regreset %clock, %init, %c1_ui8 : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %reg3, %in : !firrtl.uint<8>, !firrtl.uint<8>
 
     // Factoring of sync reset into mux works through subfield op.
-    // CHECK: %reg4 = firrtl.regreset %clock, %extraReset, %1
-    // CHECK: %3 = firrtl.subfield %reset4(0)
-    // CHECK: %4 = firrtl.subfield %reg4(0)
-    // CHECK: %5 = firrtl.mux(%init, %3, %in)
-    // CHECK: firrtl.connect %4, %5
+    // CHECK: %reg4 = firrtl.regreset %clock, %extraReset, %2
+    // CHECK: %4 = firrtl.mux(%init, %reset4, %reg4)
+    // CHECK: %5 = firrtl.subfield %reset4(0)
+    // CHECK: %6 = firrtl.subfield %reg4(0)
+    // CHECK: %7 = firrtl.mux(%init, %5, %in)
+    // CHECK: firrtl.connect %6, %7
     %reset4 = firrtl.wire : !firrtl.bundle<a: uint<8>>
     %reg4 = firrtl.regreset %clock, %init, %reset4 : !firrtl.uint<1>, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>
     %0 = firrtl.subfield %reg4(0) : (!firrtl.bundle<a: uint<8>>) -> !firrtl.uint<8>
     firrtl.connect %0, %in : !firrtl.uint<8>, !firrtl.uint<8>
 
     // Factoring of sync reset into mux works through subindex op.
-    // CHECK: %reg5 = firrtl.regreset %clock, %extraReset, %6
-    // CHECK: %8 = firrtl.subindex %reset5[0]
-    // CHECK: %9 = firrtl.subindex %reg5[0]
-    // CHECK: %10 = firrtl.mux(%init, %8, %in)
-    // CHECK: firrtl.connect %9, %10
+    // CHECK: %reg5 = firrtl.regreset %clock, %extraReset, %8
+    // CHECK: %10 = firrtl.mux(%init, %reset5, %reg5)
+    // CHECK: firrtl.connect %reg5, %10
+    // CHECK: %11 = firrtl.subindex %reset5[0]
+    // CHECK: %12 = firrtl.subindex %reg5[0]
+    // CHECK: %13 = firrtl.mux(%init, %11, %in)
+    // CHECK: firrtl.connect %12, %13
     %reset5 = firrtl.wire : !firrtl.vector<uint<8>, 1>
     %reg5 = firrtl.regreset %clock, %init, %reset5 : !firrtl.uint<1>, !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
     %1 = firrtl.subindex %reg5[0] : !firrtl.vector<uint<8>, 1>
     firrtl.connect %1, %in : !firrtl.uint<8>, !firrtl.uint<8>
 
     // Factoring of sync reset into mux works through subaccess op.
-    // CHECK: %reg6 = firrtl.regreset %clock, %extraReset, %11
-    // CHECK: %13 = firrtl.subaccess %reset6[%in]
-    // CHECK: %14 = firrtl.subaccess %reg6[%in]
-    // CHECK: %15 = firrtl.mux(%init, %13, %in)
-    // CHECK: firrtl.connect %14, %15
+    // CHECK: %reg6 = firrtl.regreset %clock, %extraReset, %14 
+    // CHECK: %16 = firrtl.mux(%init, %reset6, %reg6)
+    // CHECK: firrtl.connect %reg6, %16
+    // CHECK: %17 = firrtl.subaccess %reset6[%in]
+    // CHECK: %18 = firrtl.subaccess %reg6[%in]
+    // CHECK: %19 = firrtl.mux(%init, %17, %in)
+    // CHECK: firrtl.connect %18, %19
     %reset6 = firrtl.wire : !firrtl.vector<uint<8>, 1>
     %reg6 = firrtl.regreset %clock, %init, %reset6 : !firrtl.uint<1>, !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
     %2 = firrtl.subaccess %reg6[%in] : !firrtl.vector<uint<8>, 1>, !firrtl.uint<8>
@@ -409,8 +415,8 @@ firrtl.circuit "Top" {
 
     // Subfields that are never assigned to should not leave unused reset
     // subfields behind.
-    // CHECK-NOT: %16 = firrtl.subfield %reset4(0)
-    // CHECK: %16 = firrtl.subfield %reg4(0)
+    // CHECK-NOT: firrtl.subfield %reset4(0)
+    // CHECK: %20 = firrtl.subfield %reg4(0)
     %3 = firrtl.subfield %reg4(0) : (!firrtl.bundle<a: uint<8>>) -> !firrtl.uint<8>
   }
 }
@@ -699,6 +705,8 @@ firrtl.circuit "SubAccess" {
     %2 = firrtl.subaccess %arr[%reg6] : !firrtl.vector<uint<8>, 1>, !firrtl.uint<2>
     firrtl.strictconnect %2, %in : !firrtl.uint<8>
     // CHECK:  %reg6 = firrtl.regreset %clock, %extraReset, %c0_ui2  : !firrtl.asyncreset, !firrtl.uint<2>, !firrtl.uint<2>
+    // CHECK-NEXT: %0 = firrtl.mux(%init, %c1_ui2, %reg6)
+    // CHECK: firrtl.connect %reg6, %0
     // CHECK-NEXT:  %[[v0:.+]] = firrtl.subaccess %arr[%reg6] : !firrtl.vector<uint<8>, 1>, !firrtl.uint<2>
     // CHECK-NEXT:  firrtl.strictconnect %[[v0]], %in : !firrtl.uint<8>
 


### PR DESCRIPTION
When the FullAsyncResetTransform replaces the reset of a register it
replaces all other connections to the register with a `mux(reset,
resetValue, originalValue)`.  The transform did not properly take into
account the implicit self connection of every register, `r <= r`.  This
caused problems when the value was connected inside of a When block, and
the old reset value would become gated on the When op's condition.  The
original reset value needed to have higher priority than the original
conditions. This change adds an explicit self-connect to the register
which is properly muxed with the reset.

An alternative way of handling this is to move the
`FullAsyncResetTransform` after ExpandWhens, or to make the implicit
self connect of registers explicit in the parser.



Input:
```firrtl
reg r : UInt<8>, clock with :
  (reset => (reset, UInt<8>(1)))

when cond:
  r <= x
```

Original output:
```firrtl
reg r : UInt<8>, clock with :
  (reset => (async, UInt<8>(0)))

when cond:
  r = mux (reset, UInt<8>(1), x)
```

New output:
```firrtl
reg r : UInt<8>, clock with :
  (reset => (async, UInt<8>(0)))

r <= mux(reset, UInt<8>(1), r)

when cond:
  r = mux (reset, UInt<8>(1), x)
```