### PR TITLE
[Calyx] Add group-invariant code motion pass

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxPasses.h
+++ b/include/circt/Dialect/Calyx/CalyxPasses.h
@@ -26,6 +26,7 @@ std::unique_ptr<mlir::Pass> createGoInsertionPass();
 std::unique_ptr<mlir::Pass> createRemoveGroupsPass();
 std::unique_ptr<mlir::Pass> createClkInsertionPass();
 std::unique_ptr<mlir::Pass> createResetInsertionPass();
+std::unique_ptr<mlir::Pass> createGroupInvariantCodeMotionPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/Calyx/CalyxPasses.td
+++ b/include/circt/Dialect/Calyx/CalyxPasses.td
@@ -52,8 +52,16 @@ def GroupInvariantCodeMotion : Pass<"calyx-gicm", "calyx::ComponentOp"> {
     This pass performs GICM (group-invariant code motion) of operations which are
     deemed to be invariant of the group which they are placed in. In practice,
     this amounts to anything which is not a `calyx.group_done/assign/group_go`
-    operation.
-    GICM'd operations are lifted to wire-scope.
+    operation. GICM'd operations are lifted to wire-scope.
+
+    After GICM, a Calyx component has the following properties:
+    * No values are being defined within groups (excluding `calyx.group_go`).
+      As such, groups will only contain group-level assignments
+      (calyx.assign/group_done).
+    * Any value referenced by operations within the group may safely be
+      referenced by other groups, or operations in wire scope.
+    * A group does not define anything structural; it exclusively describes
+      wiring between existing structures.
   }];
   let dependentDialects = [];
   let constructor = "circt::calyx::createGroupInvariantCodeMotionPass()";

--- a/include/circt/Dialect/Calyx/CalyxPasses.td
+++ b/include/circt/Dialect/Calyx/CalyxPasses.td
@@ -46,6 +46,19 @@ def ResetInsertion : Pass<"calyx-reset-insertion", "calyx::ComponentOp"> {
   let constructor = "circt::calyx::createResetInsertionPass()";
 }
 
+def GroupInvariantCodeMotion : Pass<"calyx-gicm", "calyx::ComponentOp"> {
+  let summary = "Lift group-invariant operations to wire-scope.";
+  let description = [{
+    This pass performs GICM (group-invariant code motion) of operations which are
+    deemed to be invariant of the group which they are placed in. In practice,
+    this amounts to anything which is not a `calyx.group_done/assign/group_go`
+    operation.
+    GICM'd operations are lifted to wire-scope.
+  }];
+  let dependentDialects = [];
+  let constructor = "circt::calyx::createGroupInvariantCodeMotionPass()";
+}
+
 def CompileControl : Pass<"calyx-compile-control", "calyx::ComponentOp"> {
   let summary = "Generates latency-insensitive finite state machines to realize control.";
   let description = [{

--- a/include/circt/Dialect/Calyx/CalyxPasses.td
+++ b/include/circt/Dialect/Calyx/CalyxPasses.td
@@ -50,7 +50,7 @@ def GroupInvariantCodeMotion : Pass<"calyx-gicm", "calyx::ComponentOp"> {
   let summary = "Lift group-invariant operations to wire-scope.";
   let description = [{
     This pass performs GICM (group-invariant code motion) of operations which are
-    deemed to be invariant of the group which they are placed in. In practice,
+    deemed to be invariant of the group in which they are placed. In practice,
     this amounts to anything which is not a `calyx.group_done/assign/group_go`
     operation. GICM'd operations are lifted to wire-scope.
 

--- a/lib/Dialect/Calyx/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Calyx/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_circt_dialect_library(CIRCTCalyxTransforms
   CompileControl.cpp
+  GICM.cpp
   GoInsertion.cpp
   ClkResetInsertion.cpp
   RemoveGroups.cpp

--- a/lib/Dialect/Calyx/Transforms/GICM.cpp
+++ b/lib/Dialect/Calyx/Transforms/GICM.cpp
@@ -1,0 +1,49 @@
+//===- GICM.cpp - Group-invariant code motion pass --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass performs GICM (group-invariant code motion) of operations which are
+// deemed to be invariant of the group which they are placed in. In practice,
+// this amounts to anything which is not a `calyx.group_done/assign/group_go`
+// operation.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/Calyx/CalyxOps.h"
+#include "circt/Dialect/Calyx/CalyxPasses.h"
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OperationSupport.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+using namespace circt;
+using namespace calyx;
+using namespace mlir;
+
+namespace {
+
+struct GroupInvariantCodeMotionPass
+    : public GroupInvariantCodeMotionBase<GroupInvariantCodeMotionPass> {
+  void runOnOperation() override {
+    auto wires = getOperation().getWiresOp();
+    for (auto groupOp : wires.getOps<GroupOp>()) {
+      for (auto &op : llvm::make_early_inc_range(groupOp.getOps())) {
+        if (isa<GroupDoneOp, AssignOp, GroupGoOp>(op))
+          continue;
+        op.moveBefore(wires.getBody(), wires.getBody()->begin());
+      }
+    }
+  }
+};
+
+} // end anonymous namespace
+
+std::unique_ptr<mlir::Pass> circt::calyx::createGroupInvariantCodeMotionPass() {
+  return std::make_unique<GroupInvariantCodeMotionPass>();
+}

--- a/lib/Dialect/Calyx/Transforms/GICM.cpp
+++ b/lib/Dialect/Calyx/Transforms/GICM.cpp
@@ -7,9 +7,7 @@
 //===----------------------------------------------------------------------===//
 //
 // This pass performs GICM (group-invariant code motion) of operations which are
-// deemed to be invariant of the group which they are placed in. In practice,
-// this amounts to anything which is not a `calyx.group_done/assign/group_go`
-// operation.
+// deemed to be invariant of the group in which they are placed.
 //
 //===----------------------------------------------------------------------===//
 

--- a/test/Dialect/Calyx/gicm.mlir
+++ b/test/Dialect/Calyx/gicm.mlir
@@ -1,0 +1,48 @@
+// RUN: circt-opt -pass-pipeline='calyx.program(calyx.component(calyx-gicm))' %s | FileCheck %s
+
+calyx.program "main" {
+  calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
+    %add.left, %add.right, %add.out = calyx.std_add @add : i8, i8, i8
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i8, i1, i1, i1, i8, i1
+
+    %c9_i8 = hw.constant 9 : i8
+    %true = hw.constant 1 : i1
+    %c8_i6 = hw.constant 8 : i8
+
+    calyx.wires {
+      // CHECK: %[[ICMP2_GROUP2:.*]] = comb.icmp slt %r.out, %c8_i8 : i8
+      // CHECK: %[[ICMP1_GROUP2:.*]] = comb.icmp slt %[[ADD_GROUP2:.*]], %c8_i8 : i8
+      // CHECK: %[[ADD_GROUP2]] = comb.add %r.out, %c8_i8 : i8
+      // CHECK: %[[ICMP_GROUP1:.*]] = comb.icmp slt %r.out, %c8_i8 : i8
+      // CHECK-LABEL: calyx.group @Group1
+      calyx.group @Group1 {
+        // CHECK: calyx.assign %add.left = %[[ICMP_GROUP1]] ? %c8_i8 : i8
+        %0 = comb.icmp slt %r.out, %c8_i6 : i8
+        calyx.assign %add.left = %0 ? %c8_i6 : i8
+        calyx.assign %add.right = %r.out : i8
+        calyx.assign %r.in = %add.out : i8
+        calyx.assign %r.write_en = %true : i1
+        calyx.group_done %r.done : i1
+      }
+      // CHECK-LABEL: calyx.group @Group2 {
+      calyx.group @Group2 {
+        // CHECK: calyx.assign %add.left = %[[ICMP1_GROUP2]] ? %c8_i8 : i8
+        // CHECK: calyx.assign %add.right = %[[ICMP2_GROUP2]] ? %r.out : i8
+        %0 = comb.add %r.out, %c8_i6 : i8
+        %1 = comb.icmp slt %0, %c8_i6 : i8
+        %2 = comb.icmp slt %r.out, %c8_i6 : i8
+        calyx.assign %add.left = %1 ? %c8_i6 : i8
+        calyx.assign %add.right = %2 ? %r.out : i8
+        calyx.assign %r.in = %add.out : i8
+        calyx.assign %r.write_en = %true : i1
+        calyx.group_done %r.done : i1
+      }
+    }
+    calyx.control {
+      calyx.seq {
+        calyx.enable @Group1
+        calyx.enable @Group2
+      }
+    }
+  }
+}


### PR DESCRIPTION
The assumption here is that any operation which is not a special group operation (`calyx.group_done,calyx.group_go,calyx.assign`) is some form of combinational computation that can be lifted to the wire scope.

The pattern is added as a separate pass, but could be added as a canonicalization of `GroupOp`s.
I'd be in favor of adding this as a canonicalization of `GroupOp`s. GICM does not mean that we suddenly get unwanted sharing of `comb` operation results (e.g. as seen in the test, an identical `comb` operation is emitted twice in the wire scope - CSE is not part of `comb` canonicalizers, which i presume is due to fan-out reasons).
The downside to doing GICM during canonicalization is that it might obscure the IR a slight bit, since `comb` operations are no longer inside the groups where they were initially placed during either human IR writing, or when some other pass generated the IR... (but i guess that could also be said for other canonicalization patterns!).

Let me know what you think.