### PR TITLE
[PrepareForEmission] Reuse wires for output ports

### DIFF
--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -687,6 +687,24 @@ hw.module @out_of_order_multi_result() -> (b: i1, c: i2) {
   hw.output %b, %c : i1, i2
 }
 
+hw.module.extern @single_result() -> (res: i3)
+// CHECK-LABEL: module instance_result_reuse_wires(
+hw.module @instance_result_reuse_wires() -> (b: i3) {
+  // CHECK:       wire {{.*}} some_wire;
+  // CHECK-EMPTY:
+  // CHECK-NEXT:  single_result b1 (
+  // CHECK-NEXT:  .res (some_wire)
+  // CHECK-NEXT:  );
+  // CHECK-NEXT:  assign b = some_wire;
+  %some_wire = sv.wire : !hw.inout<i3>
+  %read = sv.read_inout %some_wire : !hw.inout<i3>
+
+  %out1 = hw.instance "b1" @single_result() -> (res: i3)
+  sv.assign %some_wire, %out1 : i3
+
+  hw.output %read : i3
+}
+
 
 hw.module.extern @ExternDestMod(%a: i1, %b: i2) -> (c: i3, d: i4)
 hw.module @InternalDestMod(%a: i1, %b: i3) {}

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
@@ -185,7 +185,7 @@ circuit Top :
     ; NOEXTRACT:      module MyView_companion();
     ; NOEXTRACT:        Tap tap (
     ; NOEXTRACT-NEXT:     .b     (r),
-    ; NOEXTRACT-NEXT:     .clock (_tap_clock),
+    ; NOEXTRACT-NEXT:     .clock (clock),
     ; NOEXTRACT-NEXT:     .a     (_tap_a)
     ; NOEXTRACT-NEXT:   );
     ; NOEXTRACT-NEXT:   MyView_mapping MyView_mapping{{ *}}();
@@ -221,7 +221,7 @@ circuit Top :
     ; EXTRACT:        module MyView_companion();
     ; EXTRACT:          Tap tap (
     ; EXTRACT-NEXT:       .b     (r),
-    ; EXTRACT-NEXT:       .clock (_tap_clock),
+    ; EXTRACT-NEXT:       .clock (clock),
     ; EXTRACT-NEXT:       .a     (_tap_a)
     ; EXTRACT-NEXT:     );
     ; EXTRACT-NEXT:     MyView_mapping MyView_mapping{{ *}}();


### PR DESCRIPTION
This commit changes to reuse existing wires as placeholder of output ports 
when output ports are uniquely assigned to a wire.  

Example
```scala
circuit Foo:
  extmodule Bar:
    output sink: UInt<3>
  module Foo:
    output c: UInt<3>
    wire foo: UInt<3>
    inst bar of Bar
    foo <= bar.sink
    c <= foo
```
After:
```verilog
  wire [2:0] foo; 

  Bar bar ( 
    .sink (foo)
  );
  assign c = foo;  
```
Before:
```verilog
  wire [2:0] _bar_sink; // foo.fir:7:5
  wire [2:0] foo;       // foo.fir:6:5

  assign foo = _bar_sink;   
  Bar bar (     // foo.fir:7:5
    .sink (_bar_sink)
  );
  assign c = foo;  
``` 