### PR TITLE
[ExportVerilog] Add extra bitcast to toplevel sub op

### DIFF
--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -90,6 +90,7 @@ struct LoweringOptions {
   unsigned emittedLineLength = DEFAULT_LINE_LENGTH;
 
   /// Add an explicit bitcast for avoiding bitwidth mismatch LINT errors.
+  /// TODO: Change the name of option since it is not limit to add/mul anymore.
   bool explicitBitcastAddMul = false;
 
   /// If true, replicated ops are emitted to a header file.

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -117,9 +117,11 @@ hw.module @M1<param1: i42>(%clock : i1, %cond : i1, %val : i8) {
     sv.if %cond {
       %c42 = hw.constant 42 : i8
       %add = comb.add %val, %c42 : i8
+      %sub_inner = comb.sub %val, %c42 : i8
+      %sub = comb.sub %sub_inner, %c42 : i8
 
-      // CHECK-NEXT: $fwrite(32'h80000002, "Inlined! %x\n", 8'(val + 8'h2A));
-      sv.fwrite %fd, "Inlined! %x\n"(%add) : i8
+      // CHECK-NEXT: $fwrite(32'h80000002, "Inlined! %x %x\n", 8'(val + 8'h2A), 8'(val - 8'h2A - 8'h2A));
+      sv.fwrite %fd, "Inlined! %x %x\n"(%add, %sub) : i8, i8
     }
 
     // begin/end required here to avoid else-confusion.


### PR DESCRIPTION
This commit changes ExportVerilog to emit extra bitcast to toplevel sub op 
to surpass (false-positive) lint warning when `explicitBitcastAddMul` option is enabled.