### PR TITLE
[FIRRTL] Use symbols for metadata emission

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -33,7 +33,7 @@ static const char metadataDirectoryAnnoClass[] =
 
 namespace {
 
-  // TODO: Move this to firrtl/utility
+// TODO: Move this to firrtl/utility
 StringAttr getOrAddInnerSym(Operation *op) {
   auto attr = op->getAttrOfType<StringAttr>("inner_sym");
   if (attr)

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -32,6 +32,19 @@ static const char metadataDirectoryAnnoClass[] =
     "sifive.enterprise.firrtl.MetadataDirAnnotation";
 
 namespace {
+
+  // TODO: Move this to firrtl/utility
+StringAttr getOrAddInnerSym(Operation *op) {
+  auto attr = op->getAttrOfType<StringAttr>("inner_sym");
+  if (attr)
+    return attr;
+  ModuleNamespace modNamespace(op->getParentOfType<FModuleOp>());
+  auto name = modNamespace.newName("s_");
+  attr = StringAttr::get(op->getContext(), name);
+  op->setAttr("inner_sym", attr);
+  return attr;
+}
+
 class CreateSiFiveMetadataPass
     : public CreateSiFiveMetadataBase<CreateSiFiveMetadataPass> {
   LogicalResult emitRetimeModulesMetadata();
@@ -71,7 +84,9 @@ LogicalResult CreateSiFiveMetadataPass::emitMemoryMetadata() {
   // memmory conf file.
   auto createMemMetadata = [&](FMemModuleOp mem,
                                llvm::json::OStream &jsonStream,
-                               std::string &seqMemConfStr) {
+                               std::string &seqMemConfStr,
+                               SmallVectorImpl<Attribute> &jsonSymbols,
+                               SmallVectorImpl<Attribute> &seqMemSymbols) {
     // Get the memory data width.
     auto width = mem.dataWidth();
     // Metadata needs to be printed for memories which are candidates for
@@ -85,6 +100,28 @@ LogicalResult CreateSiFiveMetadataPass::emitMemoryMetadata() {
           (mem.numReadPorts() <= 1) && width > 0))
       return;
 
+    SmallDenseMap<Attribute, unsigned> symbolIndices;
+    auto addSymbolToVerbatimOp = [&](Operation *op) -> SmallString<8> {
+      unsigned id;
+      Attribute symbol;
+      if (isa<FModuleLike>(op))
+        symbol = FlatSymbolRefAttr::get((SymbolTable::getSymbolName(op)));
+      else
+        symbol = hw::InnerRefAttr::get(
+            SymbolTable::getSymbolName(op->getParentOfType<FModuleOp>()),
+            getOrAddInnerSym(op));
+      auto it = symbolIndices.find(symbol);
+      if (it != symbolIndices.end()) {
+        id = it->second;
+      } else {
+        id = jsonSymbols.size();
+        jsonSymbols.push_back(symbol);
+        symbolIndices.insert({symbol, id});
+      }
+      SmallString<8> str;
+      ("{{" + Twine(id) + "}}").toVector(str);
+      return str;
+    };
     // Compute the mask granularity.
     auto isMasked = mem.isMasked();
     auto maskGran = width / mem.maskBits();
@@ -103,16 +140,19 @@ LogicalResult CreateSiFiveMetadataPass::emitMemoryMetadata() {
       portStr = "mrw";
     else if (mem.numReadWritePorts())
       portStr = "rw";
-    auto memExtName = mem.getName();
+    auto memExtSym = FlatSymbolRefAttr::get(SymbolTable::getSymbolName(mem));
+    auto symId = seqMemSymbols.size();
+    seqMemSymbols.push_back(memExtSym);
+
     auto maskGranStr =
         !isMasked ? "" : " mask_gran " + std::to_string(maskGran);
-    seqMemConfStr = (StringRef(seqMemConfStr) + "name " + memExtName +
-                     " depth " + Twine(mem.depth()) + " width " + Twine(width) +
-                     " ports " + portStr + maskGranStr + "\n")
+    seqMemConfStr = (StringRef(seqMemConfStr) + "name {{" + Twine(symId) +
+                     "}}" + " depth " + Twine(mem.depth()) + " width " +
+                     Twine(width) + " ports " + portStr + maskGranStr + "\n")
                         .str();
     // This adds a Json array element entry corresponding to this memory.
     jsonStream.object([&] {
-      jsonStream.attribute("module_name", memExtName);
+      jsonStream.attribute("module_name", addSymbolToVerbatimOp(mem));
       jsonStream.attribute("depth", (int64_t)mem.depth());
       jsonStream.attribute("width", (int64_t)width);
       jsonStream.attribute("masked", isMasked);
@@ -145,12 +185,12 @@ LogicalResult CreateSiFiveMetadataPass::emitMemoryMetadata() {
             continue;
           const InstanceOp &inst = p.front();
           std::string hierName =
-              inst->getParentOfType<FModuleOp>().getName().str();
+              addSymbolToVerbatimOp(inst->getParentOfType<FModuleOp>()).c_str();
           for (InstanceOp inst : p) {
             auto parentModule = inst->getParentOfType<FModuleOp>();
             if (dutMod == parentModule)
-              hierName = parentModule.getName().str();
-            hierName = hierName + "." + inst.name().str();
+              hierName = addSymbolToVerbatimOp(parentModule).c_str();
+            hierName = hierName + "." + addSymbolToVerbatimOp(inst).c_str();
           }
           hierNames.push_back(hierName);
           jsonStream.value(hierName);
@@ -176,15 +216,20 @@ LogicalResult CreateSiFiveMetadataPass::emitMemoryMetadata() {
   llvm::json::OStream dutJson(dutOs);
 
   std::string seqMemConfStr;
+  SmallVector<Attribute, 8> seqMemSymbols;
+  SmallVector<Attribute, 8> jsonSymbols;
   dutJson.array([&] {
     for (auto &dutM : dutMems)
-      createMemMetadata(dutM, dutJson, seqMemConfStr);
+      createMemMetadata(dutM, dutJson, seqMemConfStr, jsonSymbols,
+                        seqMemSymbols);
   });
+  SmallVector<Attribute, 8> jsonSymbolsTB;
   testBenchJson.array([&] {
     // The tbConfStr is populated here, but unused, it will not be printed to
     // file.
     for (auto &tbM : tbMems)
-      createMemMetadata(tbM, testBenchJson, seqMemConfStr);
+      createMemMetadata(tbM, testBenchJson, seqMemConfStr, jsonSymbolsTB,
+                        seqMemSymbols);
   });
 
   auto *context = &getContext();
@@ -199,17 +244,20 @@ LogicalResult CreateSiFiveMetadataPass::emitMemoryMetadata() {
   // Use unknown loc to avoid printing the location in the metadata files.
   auto tbVerbatimOp = builder.create<sv::VerbatimOp>(builder.getUnknownLoc(),
                                                      testBenchJsonBuffer);
+  tbVerbatimOp.symbolsAttr(ArrayAttr::get(context, jsonSymbolsTB));
   auto fileAttr = hw::OutputFileAttr::getFromDirectoryAndFilename(
       context, metadataDir, "tb_seq_mems.json", /*excludeFromFilelist=*/true);
   tbVerbatimOp->setAttr("output_file", fileAttr);
   auto dutVerbatimOp =
       builder.create<sv::VerbatimOp>(builder.getUnknownLoc(), dutJsonBuffer);
+  dutVerbatimOp.symbolsAttr(ArrayAttr::get(context, jsonSymbols));
   fileAttr = hw::OutputFileAttr::getFromDirectoryAndFilename(
       context, metadataDir, "seq_mems.json", /*excludeFromFilelist=*/true);
   dutVerbatimOp->setAttr("output_file", fileAttr);
 
   auto confVerbatimOp =
       builder.create<sv::VerbatimOp>(builder.getUnknownLoc(), seqMemConfStr);
+  confVerbatimOp.symbolsAttr(ArrayAttr::get(context, seqMemSymbols));
   if (replSeqMemFile.empty()) {
     circuitOp->emitError("metadata emission failed, the option "
                          "`-repl-seq-mem-file=<filename>` is mandatory for "

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -117,11 +117,12 @@ LogicalResult CreateSiFiveMetadataPass::emitMemoryMetadata() {
         symbol = hw::InnerRefAttr::get(
             op->getParentOfType<FModuleOp>().moduleNameAttr(),
             getOrAddInnerSym(op));
-      
-      auto [it, inserted] = symbolIndices.try_emplace(symbol, jsonSymbols.size());
+
+      auto [it, inserted] =
+          symbolIndices.try_emplace(symbol, jsonSymbols.size());
       if (inserted)
         jsonSymbols.push_back(symbol);
-      
+
       SmallString<8> str;
       ("{{" + Twine(it->second) + "}}").toVector(str);
       return str;

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -163,12 +163,12 @@ firrtl.circuit "top" {
     // CHECK-SAME: {\22module_name\22:\22{{[{][{]4[}][}]}}\22,\22depth\22:20,\22width\22:5,\22masked\22:false,\22read\22:false,\22write\22:true,\22readwrite\22:false,\22extra_ports\22:[]
     // CHECK-SAME: \22hierarchy\22:[\22{{[{][{]5[}][}]}}.{{[{][{]6[}][}]}}.{{[{][{]7[}][}]}}\22]}]" 
     // CHECK-SAME: {output_file = #hw.output_file<"metadata/tb_seq_mems.json", excludeFromFileList>
-    // CHECK-SAME: symbols = [@head_ext, @top, #hw.innerNameRef<@top::@s__0>, #hw.innerNameRef<@Mem1::@s_>, @head_0_ext, @top, #hw.innerNameRef<@top::@s__1>, #hw.innerNameRef<@Mem2::@s_>]}
+    // CHECK-SAME: symbols = [@head_ext, @top, #hw.innerNameRef<@top::@metadata_sym_0>, #hw.innerNameRef<@Mem1::@metadata_sym>, @head_0_ext, @top, #hw.innerNameRef<@top::@metadata_sym_1>, #hw.innerNameRef<@Mem2::@metadata_sym>]}
     // CHECK: sv.verbatim "[{\22module_name\22:\22{{[{][{]0[}][}]}}\22,\22depth\22:16,\22width\22:8,\22masked\22:false,\22read\22:true,\22write\22:false,\22readwrite\22:true,\22extra_ports\22:[]
     // CHECK-SAME: \22hierarchy\22:[\22{{[{][{]3[}][}]}}.{{[{][{]4[}][}]}}.{{[{][{]5[}][}]}}\22]},
     // CHECK-SAME: {\22module_name\22:\22{{[{][{]6[}][}]}}\22,\22depth\22:20,\22width\22:5,\22masked\22:false,\22read\22:true,\22write\22:true,\22readwrite\22:false,\22extra_ports\22:[],
     // CHECK-SAME: \22hierarchy\22:[\22{{[{][{]9[}][}]}}.{{[{][{]10[}][}]}}.{{[{][{]11[}][}]}}\22]}]"
-    // CHECK-SAME: output_file = #hw.output_file<"metadata/seq_mems.json", excludeFromFileList>, symbols = [@memory_ext, @top, #hw.innerNameRef<@top::@s_>, @DUT, #hw.innerNameRef<@DUT::@s_>, #hw.innerNameRef<@Mem::@s_>, @dumm_ext, @top, #hw.innerNameRef<@top::@s_>, @DUT, #hw.innerNameRef<@DUT::@s_>, #hw.innerNameRef<@Mem::@s__0>]}
+    // CHECK-SAME: output_file = #hw.output_file<"metadata/seq_mems.json", excludeFromFileList>, symbols = [@memory_ext, @top, #hw.innerNameRef<@top::@metadata_sym>, @DUT, #hw.innerNameRef<@DUT::@metadata_sym>, #hw.innerNameRef<@Mem::@metadata_sym>, @dumm_ext, @top, #hw.innerNameRef<@top::@metadata_sym>, @DUT, #hw.innerNameRef<@DUT::@metadata_sym>, #hw.innerNameRef<@Mem::@metadata_sym_0>]}
     // CHECK: sv.verbatim "name {{[{][{]0[}][}]}} depth 16 width 8 ports rw\0Aname {{[{][{]1[}][}]}} depth 20 width 5 ports write,read
     // CHECK-SAME: \0Aname {{[{][{]2[}][}]}} depth 20 width 5 ports write\0Aname {{[{][{]3[}][}]}} depth 20 width 5 ports write\0A"
     // CHECK-SAME: {output_file = #hw.output_file<"\22metadata/dut.conf\22", excludeFromFileList>, symbols = [@memory_ext, @dumm_ext, @head_ext, @head_0_ext]}

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -123,8 +123,14 @@ firrtl.circuit "OneMemory" {
     %0:5= firrtl.instance MWrite_ext sym @MWrite_ext_0  @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>, in user_input: !firrtl.uint<5>)
   }
   firrtl.memmodule @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>, in user_input: !firrtl.uint<5>) attributes {dataWidth = 42 : ui32, depth = 12 : ui64, extraPorts = [{direction = "input", name = "user_input", width = 5 : ui32}], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
-  // CHECK: sv.verbatim "[{\22module_name\22:\22MWrite_ext\22,\22depth\22:12,\22width\22:42,\22masked\22:false,\22read\22:false,\22write\22:true,\22readwrite\22:false,\22extra_ports\22:[{\22name\22:\22user_input\22,\22direction\22:\22input\22,\22width\22:5}],\22hierarchy\22:[\22OneMemory.MWrite_ext\22]}]"
-  // CHECK: sv.verbatim "name MWrite_ext depth 12 width 42 ports write\0A" {output_file = #hw.output_file<"\22metadata/dut.conf\22"
+    // CHECK: sv.verbatim "[{\22module_name\22:\22{{[{][{]0[}][}]}}
+    // CHECK-SAME: \22,\22depth\22:12,\22width\22:42,\22masked\22:false,\22read\22:false,\22write\22:true,\22readwrite\22:false,
+    // CHECK-SAME: \22extra_ports\22:[{\22name\22:\22user_input\22,\22direction\22:\22input\22,\22width\22:5}], 
+    // CHECK-SAME: \22hierarchy\22:[\22{{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}\22]}]"
+    // CHECK-SAME: {output_file = #hw.output_file<"metadata/tb_seq_mems.json", excludeFromFileList>, symbols = [@MWrite_ext, @OneMemory, #hw.innerNameRef<@OneMemory::@MWrite_ext_0>]}
+    // CHECK: sv.verbatim "[]" {output_file = #hw.output_file<"metadata/seq_mems.json", excludeFromFileList>, symbols = []}
+    // CHECK: sv.verbatim "name {{[{][{]0[}][}]}} depth 12 width 42 ports write\0A" {output_file = #hw.output_file<"\22metadata/dut.conf\22", excludeFromFileList>, symbols = [@MWrite_ext]}
+
 }
 
 // CHECK-LABEL: firrtl.circuit "top"
@@ -152,10 +158,18 @@ firrtl.circuit "top" {
     firrtl.memmodule @head_0_ext(in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>) attributes {dataWidth = 5 : ui32, depth = 20 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
     firrtl.memmodule @memory_ext(in R0_addr: !firrtl.uint<4>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<8>, in RW0_addr: !firrtl.uint<4>, in RW0_en: !firrtl.uint<1>, in RW0_clk: !firrtl.clock, in RW0_wmode: !firrtl.uint<1>, in RW0_wdata: !firrtl.uint<8>, out RW0_rdata: !firrtl.uint<8>) attributes {dataWidth = 8 : ui32, depth = 16 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 0 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
     firrtl.memmodule @dumm_ext(in R0_addr: !firrtl.uint<5>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<5>, in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>) attributes {dataWidth = 5 : ui32, depth = 20 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
-    // CHECK: sv.verbatim "[{\22module_name\22:\22head_ext\22,\22depth\22:20,\22width\22:5,\22masked\22:false,\22read\22:false,\22write\22:true,\22readwrite\22:false,\22extra_ports\22:[],\22hierarchy\22:[\22top.mem1.head_ext\22]},{\22module_name\22:\22head_0_ext\22,\22depth\22:20,\22width\22:5,\22masked\22:false,\22read\22:false,\22write\22:true,\22readwrite\22:false,\22extra_ports\22:[],\22hierarchy\22:[\22top.mem2.head_0_ext\22]}]"
-    // CHECK-SAME:  {output_file = #hw.output_file<"metadata/tb_seq_mems.json", excludeFromFileList>, symbols = []}
-    // CHECK: sv.verbatim "[{\22module_name\22:\22memory_ext\22,\22depth\22:16,\22width\22:8,\22masked\22:false,\22read\22:true,\22write\22:false,\22readwrite\22:true,\22extra_ports\22:[],\22hierarchy\22:[\22DUT.mem1.memory_ext\22]},{\22module_name\22:\22dumm_ext\22,\22depth\22:20,\22width\22:5,\22masked\22:false,\22read\22:true,\22write\22:true,\22readwrite\22:false,\22extra_ports\22:[],\22hierarchy\22:[\22DUT.mem1.dumm_ext\22]}]"
-    // CHECK-SAME: output_file = #hw.output_file<"metadata/seq_mems.json", excludeFromFileList>, symbols = []
-    // CHECK: sv.verbatim "name memory_ext depth 16 width 8 ports rw\0Aname dumm_ext depth 20 width 5 ports write,read\0Aname head_ext depth 20 width 5 ports write\0Aname head_0_ext depth 20 width 5 ports write\0A"
-    // CHECK-SAME: {output_file = #hw.output_file<"\22metadata/dut.conf\22", excludeFromFileList>, symbols = []}
+    // CHECK: sv.verbatim "[{\22module_name\22:\22{{[{][{]0[}][}]}}\22,\22depth\22:20,\22width\22:5,\22masked\22:false,\22read\22:false,\22write\22:true,\22readwrite\22:false,\22extra_ports\22:[]
+    // CHECK-SAME: \22hierarchy\22:[\22{{[{][{]1[}][}]}}.{{[{][{]2[}][}]}}.{{[{][{]3[}][}]}}\22]},
+    // CHECK-SAME: {\22module_name\22:\22{{[{][{]4[}][}]}}\22,\22depth\22:20,\22width\22:5,\22masked\22:false,\22read\22:false,\22write\22:true,\22readwrite\22:false,\22extra_ports\22:[]
+    // CHECK-SAME: \22hierarchy\22:[\22{{[{][{]5[}][}]}}.{{[{][{]6[}][}]}}.{{[{][{]7[}][}]}}\22]}]" 
+    // CHECK-SAME: {output_file = #hw.output_file<"metadata/tb_seq_mems.json", excludeFromFileList>
+    // CHECK-SAME: symbols = [@head_ext, @top, #hw.innerNameRef<@top::@s__0>, #hw.innerNameRef<@Mem1::@s_>, @head_0_ext, @top, #hw.innerNameRef<@top::@s__1>, #hw.innerNameRef<@Mem2::@s_>]}
+    // CHECK: sv.verbatim "[{\22module_name\22:\22{{[{][{]0[}][}]}}\22,\22depth\22:16,\22width\22:8,\22masked\22:false,\22read\22:true,\22write\22:false,\22readwrite\22:true,\22extra_ports\22:[]
+    // CHECK-SAME: \22hierarchy\22:[\22{{[{][{]3[}][}]}}.{{[{][{]4[}][}]}}.{{[{][{]5[}][}]}}\22]},
+    // CHECK-SAME: {\22module_name\22:\22{{[{][{]6[}][}]}}\22,\22depth\22:20,\22width\22:5,\22masked\22:false,\22read\22:true,\22write\22:true,\22readwrite\22:false,\22extra_ports\22:[],
+    // CHECK-SAME: \22hierarchy\22:[\22{{[{][{]9[}][}]}}.{{[{][{]10[}][}]}}.{{[{][{]11[}][}]}}\22]}]"
+    // CHECK-SAME: output_file = #hw.output_file<"metadata/seq_mems.json", excludeFromFileList>, symbols = [@memory_ext, @top, #hw.innerNameRef<@top::@s_>, @DUT, #hw.innerNameRef<@DUT::@s_>, #hw.innerNameRef<@Mem::@s_>, @dumm_ext, @top, #hw.innerNameRef<@top::@s_>, @DUT, #hw.innerNameRef<@DUT::@s_>, #hw.innerNameRef<@Mem::@s__0>]}
+    // CHECK: sv.verbatim "name {{[{][{]0[}][}]}} depth 16 width 8 ports rw\0Aname {{[{][{]1[}][}]}} depth 20 width 5 ports write,read
+    // CHECK-SAME: \0Aname {{[{][{]2[}][}]}} depth 20 width 5 ports write\0Aname {{[{][{]3[}][}]}} depth 20 width 5 ports write\0A"
+    // CHECK-SAME: {output_file = #hw.output_file<"\22metadata/dut.conf\22", excludeFromFileList>, symbols = [@memory_ext, @dumm_ext, @head_ext, @head_0_ext]}
 }

--- a/test/firtool/prefixMemory.fir
+++ b/test/firtool/prefixMemory.fir
@@ -112,9 +112,9 @@ circuit Foo : %[[
     readData <= _readData_T
 
 ; CHECK-LABEL:  firrtl.module private @prefix1_Bar
-; CHECK:          firrtl.instance mem @prefix1_mem
+; CHECK:          firrtl.instance mem sym @s_ @prefix1_mem
 ; CHECK-LABEL:  firrtl.module private @prefix2_Baz
-; CHECK:          firrtl.instance mem @prefix2_mem
+; CHECK:          firrtl.instance mem sym @s_ @prefix2_mem
 ; CHECK:        firrtl.memmodule @prefix1_mem
 ; CHECK:        firrtl.memmodule @prefix2_mem
 

--- a/test/firtool/prefixMemory.fir
+++ b/test/firtool/prefixMemory.fir
@@ -112,9 +112,9 @@ circuit Foo : %[[
     readData <= _readData_T
 
 ; CHECK-LABEL:  firrtl.module private @prefix1_Bar
-; CHECK:          firrtl.instance mem sym @s_ @prefix1_mem
+; CHECK:          firrtl.instance mem sym @metadata_sym @prefix1_mem
 ; CHECK-LABEL:  firrtl.module private @prefix2_Baz
-; CHECK:          firrtl.instance mem sym @s_ @prefix2_mem
+; CHECK:          firrtl.instance mem sym @metadata_sym @prefix2_mem
 ; CHECK:        firrtl.memmodule @prefix1_mem
 ; CHECK:        firrtl.memmodule @prefix2_mem
 


### PR DESCRIPTION
Update metadata emission to use symbols, instead of embedding the module names.