### PR TITLE
[LowerToHW] Lower node op with a symbol into read_inout op

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -2382,6 +2382,7 @@ LogicalResult FIRRTLLowering::visitDecl(NodeOp op) {
   if (symName) {
     auto wire = builder.create<sv::WireOp>(operand.getType(), name, symName);
     builder.create<sv::AssignOp>(wire, operand);
+    operand = builder.create<sv::ReadInOutOp>(wire);
   }
 
   return setLowering(op, operand);

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -208,10 +208,12 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // Nodes with names become wires.
     // CHECK-NEXT: %n1 = sv.wire
     // CHECK-NEXT: sv.assign %n1, %in2
+    // CHECK-NEXT: sv.read_inout %n1
     %n1 = firrtl.node %in2  {name = "n1"} : !firrtl.uint<2>
     
     // CHECK-NEXT: [[WIRE:%n2]] = sv.wire sym @__Simple__n2 : !hw.inout<i2>
     // CHECK-NEXT: sv.assign [[WIRE]], %in2 : i2
+    // CHECK-NEXT: sv.read_inout %n2
     %n2 = firrtl.node %in2  {name = "n2", annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<2>
 
     // Nodes with no names are just dropped.
@@ -219,6 +221,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
     // CHECK-NEXT: [[WIRE:%n3]] = sv.wire sym @nodeSym : !hw.inout<i2>
     // CHECK-NEXT: sv.assign [[WIRE]], %in2 : i2
+    // CHECK-NEXT: sv.read_inout [[WIRE]]
     %n3 = firrtl.node sym @nodeSym %in2 : !firrtl.uint<2>
 
     // CHECK-NEXT: [[CVT:%.+]] = comb.concat %false, %in2 : i1, i2


### PR DESCRIPTION
This PR changes to lower node ops with symbols into read_inout ops of wires.
Considering the concept of the current name preservation, "nodes become wires 
if they have names", it would be nice to use existing named wires as much as possible. 
This change basically disables optimizations across named nodes at comb levels, 
so we can prevent canonicalizers from duplicating expressions. 

This change reduces 30% temporary wires and 50% lint warnings related to dead wires 
in the large design while improving the simulation performance as well.

e2e example:
```scala
circuit Foo:
  module Foo:
    input data : UInt<1>[4]
    output z : UInt<4>
    node cat_lo = cat(data[1], data[0]);
    node cat_hi = cat(data[3], data[2]);
    node v = cat(cat_hi, cat_lo);
    z <= v
```

After:
```verilog
  assign cat_lo = {data_1, data_0};
  assign cat_hi = {data_3, data_2};
  assign v = {cat_hi, cat_lo};
  assign z = v;
```

Before:
```verilog
  assign cat_lo = {data_1, data_0};
  assign cat_hi = {data_3, data_2};
  assign v = {data_3, data_2, data_1, data_0};
  assign z = v;
```