### PR TITLE
[Calyx] Make cell operations symbol-defining

### DIFF
--- a/include/circt/Dialect/Calyx/Calyx.td
+++ b/include/circt/Dialect/Calyx/Calyx.td
@@ -50,6 +50,7 @@ class CalyxOp<string mnemonic, list<Trait> traits = []> :
 /// Base class for Calyx cells.
 class CalyxCell<string mnemonic, list<Trait> traits = []> :
   CalyxOp<mnemonic, !listconcat(traits, [
+    Symbol,
     DeclareOpInterfaceMethods<CellOpInterface>,
     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
   ])> {}

--- a/include/circt/Dialect/Calyx/CalyxInterfaces.td
+++ b/include/circt/Dialect/Calyx/CalyxInterfaces.td
@@ -92,8 +92,8 @@ def CellOpInterface : OpInterface<"CellInterface"> {
       (ins),
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
-        Operation* op = (*static_cast<ConcreteOp *>($_op));
-        return op->getAttrOfType<mlir::FlatSymbolRefAttr>("instanceName").getValue();
+        return $_op.getOperation()->template getAttrOfType<mlir::StringAttr>(
+          mlir::SymbolTable::getSymbolAttrName()).getValue();
       }]
     >,
     InterfaceMethod<

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -13,8 +13,8 @@
 /// Base class for Calyx primitives.
 class CalyxPrimitive<string mnemonic, list<Trait> traits = []> :
   CalyxCell<mnemonic, traits> {
-    let assemblyFormat = "$instanceName attr-dict `:` qualified(type(results))";
-    let arguments = (ins FlatSymbolRefAttr:$instanceName);
+    let assemblyFormat = "$sym_name attr-dict `:` qualified(type(results))";
+    let arguments = (ins SymbolNameAttr:$sym_name);
     let skipDefaultBuilders = 1;
 }
 
@@ -36,14 +36,14 @@ def RegisterOp : CalyxPrimitive<"register", [
   }];
   let results = (outs AnyType:$in, I1:$write_en, I1:$clk, I1:$reset, AnyType:$out, I1:$done);
   let builders = [
-    OpBuilder<(ins "StringRef":$instanceName, "size_t":$width), [{
-      $_state.addAttribute("instanceName", FlatSymbolRefAttr::get($_builder.getContext(), instanceName));
+    OpBuilder<(ins "StringRef":$sym_name, "size_t":$width), [{
+      $_state.addAttribute(mlir::SymbolTable::getSymbolAttrName(), $_builder.getStringAttr(sym_name));
       Type i1Type = $_builder.getI1Type();
       Type widthType = $_builder.getIntegerType(width);
       $_state.addTypes({widthType, i1Type, i1Type, i1Type, widthType, i1Type});
     }]>,
-    OpBuilder<(ins "StringRef":$instanceName, "Type":$type), [{
-      $_state.addAttribute("instanceName", FlatSymbolRefAttr::get($_builder.getContext(), instanceName));
+    OpBuilder<(ins "StringRef":$sym_name, "Type":$type), [{
+      $_state.addAttribute(mlir::SymbolTable::getSymbolAttrName(), $_builder.getStringAttr(sym_name));
       Type i1Type = $_builder.getI1Type();
       $_state.addTypes({type, i1Type, i1Type, i1Type, type, i1Type});
     }]>
@@ -75,7 +75,7 @@ def MemoryOp : CalyxPrimitive<"memory", []> {
   }];
 
   let arguments = (ins
-    FlatSymbolRefAttr:$instanceName,
+    SymbolNameAttr:$sym_name,
     I64Attr:$width,
     ArrayAttr:$sizes,
     ArrayAttr:$addrSizes
@@ -86,14 +86,14 @@ def MemoryOp : CalyxPrimitive<"memory", []> {
   );
 
   let assemblyFormat = [{
-    $instanceName ` ` `<` $sizes `x` $width `>` $addrSizes attr-dict `:` qualified(type($results))
+    $sym_name ` ` `<` $sizes `x` $width `>` $addrSizes attr-dict `:` qualified(type($results))
   }];
 
   let hasVerifier = 1;
 
   let builders = [
     OpBuilder<(ins
-      "StringRef":$instanceName,
+      "StringRef":$sym_name,
       "int64_t":$width,
       "ArrayRef<int64_t>":$sizes,
       "ArrayRef<int64_t>":$addrSizes
@@ -139,12 +139,10 @@ class CalyxLibraryOp<string mnemonic, list<Trait> traits = []> :
     ```
   }];
 
-  let arguments = (ins FlatSymbolRefAttr:$instanceName);
+  let arguments = (ins SymbolNameAttr:$sym_name);
   let builders = [
-    OpBuilder<(ins "StringRef":$instanceName, "::mlir::TypeRange":$resultTypes), [{
-      $_state.addAttribute("instanceName",
-        FlatSymbolRefAttr::get($_builder.getContext(), instanceName)
-      );
+    OpBuilder<(ins "StringRef":$sym_name, "::mlir::TypeRange":$resultTypes), [{
+      $_state.addAttribute(mlir::SymbolTable::getSymbolAttrName(), $_builder.getStringAttr(sym_name));
       $_state.addTypes(resultTypes);
     }]>
   ];

--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -219,13 +219,13 @@ def InstanceOp : CalyxCell<"instance", [
   }];
 
   let arguments = (ins
-    FlatSymbolRefAttr:$instanceName,
+    SymbolNameAttr:$sym_name,
     FlatSymbolRefAttr:$componentName
   );
   let results = (outs Variadic<AnyType>:$results);
 
   let assemblyFormat = [{
-    $instanceName `of` $componentName attr-dict (`:` qualified(type($results))^)?
+    $sym_name `of` $componentName attr-dict (`:` qualified(type($results))^)?
   }];
 }
 

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -41,8 +41,9 @@ calyx.program "main" {
   }
   calyx.component @main(%in: i16, %go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     %c1_1 = hw.constant 1 : i1
-    // expected-error @+1 {{'calyx.instance' op with instance symbol: 'c' is already a symbol for another instance.}}
+    // expected-note @+1 {{see existing symbol definition here}}
     calyx.instance @c of @foo : i1, i1, i1, i1
+    // expected-error @+1 {{redefinition of symbol named 'c'}}
     calyx.instance @c of @foo : i1, i1, i1, i1
     calyx.wires { calyx.assign %done = %c1_1 : i1 }
     calyx.control {}


### PR DESCRIPTION
Previously, cells were instantiated with `FlatSymbolRefAttr`s but didn't actually use these in a symbol table context.
This commit changes the `CellOpInterface` to expect implementing operations to be symbol-defining operations. A side-effect of this is that we now implicitly check for duplicate instance names (something which was possible beforehand).