### PR TITLE
[HW,Support] Make symbol cache generic and move it to Support

### DIFF
--- a/include/circt/Dialect/HW/HWSymCache.h
+++ b/include/circt/Dialect/HW/HWSymCache.h
@@ -40,8 +40,8 @@ public:
   };
 
   // Add inner names, which might be ports
-  void addInnerDefinition(mlir::StringAttr modSymbol, mlir::StringAttr name,
-                          mlir::Operation *op, size_t port = ~0ULL) {
+  void addDefinition(mlir::StringAttr modSymbol, mlir::StringAttr name,
+                     mlir::Operation *op, size_t port = ~0ULL) {
     auto key = InnerRefAttr::get(modSymbol, name);
     symbolCache.try_emplace(key, op, port);
   }

--- a/include/circt/Dialect/HW/HWSymCache.h
+++ b/include/circt/Dialect/HW/HWSymCache.h
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file declares a Symbol Cache.
+// This file declares a Symbol Cache specialized for HW instances.
 //
 //===----------------------------------------------------------------------===//
 
@@ -14,8 +14,7 @@
 #define CIRCT_DIALECT_HW_SYMCACHE_H
 
 #include "circt/Dialect/HW/HWAttributes.h"
-#include "mlir/IR/SymbolTable.h"
-#include "llvm/Support/Casting.h"
+#include "circt/Support/SymCache.h"
 
 namespace circt {
 namespace hw {
@@ -23,83 +22,55 @@ namespace hw {
 /// This stores lookup tables to make manipulating and working with the IR more
 /// efficient.  There are two phases to this object: the "building" phase in
 /// which it is "write only" and then the "using" phase which is read-only (and
-/// thus can be used by multiple threads).  The
-/// "freeze" method transitions between the two states.
-class HWSymbolCache {
+/// thus can be used by multiple threads).  The  "freeze" method transitions
+/// between the two states.
+class HWSymbolCache : public SymbolCacheBase {
 public:
   class Item {
   public:
     Item(mlir::Operation *op) : op(op), port(~0ULL) {}
     Item(mlir::Operation *op, size_t port) : op(op), port(port) {}
     bool hasPort() const { return port != ~0ULL; }
-    mlir::Operation *getOp() const { return op; }
     size_t getPort() const { return port; }
+    mlir::Operation *getOp() const { return op; }
 
   private:
     mlir::Operation *op;
     size_t port;
   };
 
-  /// In the building phase, add symbols.
-  void addDefinition(mlir::StringAttr symbol, mlir::Operation *op) {
-    assert(!isFrozen && "cannot mutate a frozen cache");
-    symbolCache.try_emplace(symbol, op, ~0ULL);
-  }
-
   // Add inner names, which might be ports
-  void addDefinition(mlir::StringAttr modSymbol, mlir::StringAttr name,
-                     mlir::Operation *op, size_t port = ~0ULL) {
-    assert(!isFrozen && "cannot mutate a frozen cache");
+  void addInnerDefinition(mlir::StringAttr modSymbol, mlir::StringAttr name,
+                          mlir::Operation *op, size_t port = ~0ULL) {
     auto key = InnerRefAttr::get(modSymbol, name);
     symbolCache.try_emplace(key, op, port);
   }
 
-  /// Populate the symbol cache with all symbol-defining operations within the
-  /// 'top' operation.
-  void addDefinitions(mlir::Operation *top) {
-    for (auto &region : top->getRegions())
-      for (auto &block : region.getBlocks())
-        for (mlir::Operation &op : block)
-          if (auto symOp = llvm::dyn_cast<mlir::SymbolOpInterface>(op))
-            if (auto name = symOp.getNameAttr())
-              addDefinition(name, symOp);
+  void addDefinition(mlir::Attribute key, mlir::Operation *op) override {
+    assert(!isFrozen && "cannot mutate a frozen cache");
+    symbolCache.try_emplace(key, op);
   }
 
-  // Add inner names, which might be ports
-  void addDefinition(InnerRefAttr name, mlir::Operation *op,
-                     size_t port = ~0ULL) {
-    assert(!isFrozen && "cannot mutate a frozen cache");
-    symbolCache.try_emplace(name, op, port);
+  HWSymbolCache::Item getInnerDefinition(mlir::StringAttr modSymbol,
+                                         mlir::StringAttr name) const {
+    return lookupInner(InnerRefAttr::get(modSymbol, name));
+  }
+
+  HWSymbolCache::Item getInnerDefinition(InnerRefAttr inner) const {
+    return lookupInner(inner);
   }
 
   /// Mark the cache as frozen, which allows it to be shared across threads.
   void freeze() { isFrozen = true; }
 
-  mlir::Operation *getDefinition(mlir::StringAttr symbol) const {
-    return lookup(symbol);
-  }
-
-  mlir::Operation *getDefinition(mlir::FlatSymbolRefAttr symbol) const {
-    return lookup(symbol.getAttr());
-  }
-
-  Item getDefinition(mlir::StringAttr modSymbol, mlir::StringAttr name) const {
-    return lookup(InnerRefAttr::get(modSymbol, name));
-  }
-
-  Item getDefinition(InnerRefAttr name) const { return lookup(name); }
-
-protected:
-  bool isFrozen = false;
-
 private:
-  Item lookup(InnerRefAttr attr) const {
+  Item lookupInner(InnerRefAttr attr) const {
     assert(isFrozen && "cannot read from this cache until it is frozen");
     auto it = symbolCache.find(attr);
     return it == symbolCache.end() ? Item{nullptr, ~0ULL} : it->second;
   }
 
-  mlir::Operation *lookup(mlir::StringAttr attr) const {
+  mlir::Operation *lookup(mlir::Attribute attr) const override {
     assert(isFrozen && "cannot read from this cache until it is frozen");
     auto it = symbolCache.find(attr);
     if (it == symbolCache.end())
@@ -108,23 +79,11 @@ private:
     return it->second.getOp();
   }
 
-  /// This stores a lookup table from symbol attribute to the operation
-  /// (hw.module, hw.instance, etc) that defines it.
-  /// TODO: It is super annoying that symbols are *defined* as StringAttr, but
-  /// are then referenced as FlatSymbolRefAttr.  Why can't we have nice
-  /// pointer uniqued things?? :-(
-  llvm::DenseMap<mlir::Attribute, Item> symbolCache;
-};
+  bool isFrozen = false;
 
-/// Like a SymbolCache, but allows for unfreezing to add new definitions.
-/// Unlike SymbolCache, the MutableSymbolCache is not thread safe, and the
-/// caller is expected to perform synchronization if used in a multithreaded
-/// context.
-class MutableSymbolCache : public HWSymbolCache {
-public:
-  /// Mark the cache as unfrozen, allowing for mutation. Caller should ensure
-  /// that the cache is no longer being read from after unfreezing occurs.
-  void unfreeze() { isFrozen = false; }
+  /// This stores a lookup table from symbol attribute to the item
+  /// that defines it.
+  llvm::DenseMap<mlir::Attribute, Item> symbolCache;
 };
 
 } // namespace hw

--- a/include/circt/Dialect/MSFT/ExportTcl.h
+++ b/include/circt/Dialect/MSFT/ExportTcl.h
@@ -13,15 +13,12 @@
 #ifndef CIRCT_DIALECT_MSFT_EXPORTTCL_H
 #define CIRCT_DIALECT_MSFT_EXPORTTCL_H
 
+#include "circt/Dialect/HW/HWSymCache.h"
 #include "circt/Dialect/MSFT/MSFTOpInterfaces.h"
 #include "circt/Support/LLVM.h"
 #include "llvm/ADT/StringRef.h"
 
 namespace circt {
-namespace hw {
-class HWSymbolCache;
-} // namespace hw
-
 namespace msft {
 class MSFTModuleOp;
 

--- a/include/circt/Support/SymCache.h
+++ b/include/circt/Support/SymCache.h
@@ -1,0 +1,86 @@
+//===- SymCache.h - Declare Symbol Cache ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares a Symbol Cache.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_SUPPORT_SYMCACHE_H
+#define CIRCT_SUPPORT_SYMCACHE_H
+
+#include "mlir/IR/SymbolTable.h"
+#include "llvm/Support/Casting.h"
+
+namespace circt {
+
+/// Base symbol cache class to allow for cache lookup through a pointer to some
+/// abstract cache. A symbol cache stores lookup tables to make manipulating and
+/// working with the IR more efficient.
+class SymbolCacheBase {
+public:
+  virtual ~SymbolCacheBase() {}
+
+  /// Defines 'op' as associated with the 'symbol' in the cache.
+  virtual void addDefinition(mlir::Attribute symbol, mlir::Operation *op) = 0;
+
+  /// Adds the symbol-defining 'op' to the cache.
+  void addSymbol(mlir::SymbolOpInterface op) {
+    addDefinition(op.getNameAttr(), op);
+  }
+
+  /// Populate the symbol cache with all symbol-defining operations within the
+  /// 'top' operation.
+  void addDefinitions(mlir::Operation *top) {
+    for (auto &region : top->getRegions())
+      for (auto &block : region.getBlocks())
+        for (auto symOp : block.getOps<mlir::SymbolOpInterface>())
+          addSymbol(symOp);
+  }
+
+  /// Lookup a definition for 'symbol' in the cache.
+  mlir::Operation *getDefinition(mlir::Attribute symbol) const {
+    return lookup(symbol);
+  }
+
+  /// Lookup a definition for 'symbol' in the cache.
+  mlir::Operation *getDefinition(mlir::FlatSymbolRefAttr symbol) const {
+    return lookup(symbol.getAttr());
+  }
+
+protected:
+  virtual mlir::Operation *lookup(mlir::Attribute attr) const = 0;
+};
+
+/// Default symbol cache implementation; stores associations between names
+/// (StringAttr's) to mlir::Operation's.
+/// Adding/getting definitions from the symbol cache is not
+/// thread safe. If this is required, synchronizing cache acccess should be
+/// ensured by the caller.
+class SymbolCache : public SymbolCacheBase {
+public:
+  /// In the building phase, add symbols.
+  void addDefinition(mlir::Attribute key, mlir::Operation *op) override {
+    symbolCache.try_emplace(key, op);
+  }
+
+protected:
+  mlir::Operation *lookup(mlir::Attribute attr) const override {
+    auto it = symbolCache.find(attr);
+    if (it == symbolCache.end())
+      return nullptr;
+    return it->second;
+  }
+
+  /// This stores a lookup table from symbol attribute to the operation
+  /// that defines it.
+  llvm::DenseMap<mlir::Attribute, mlir::Operation *> symbolCache;
+};
+
+} // namespace circt
+
+#endif // CIRCT_SUPPORT_SYMCACHE_H

--- a/include/circt/Support/SymCache.h
+++ b/include/circt/Support/SymCache.h
@@ -23,7 +23,7 @@ namespace circt {
 /// working with the IR more efficient.
 class SymbolCacheBase {
 public:
-  virtual ~SymbolCacheBase() {}
+  virtual ~SymbolCacheBase();
 
   /// Defines 'op' as associated with the 'symbol' in the cache.
   virtual void addDefinition(mlir::Attribute symbol, mlir::Operation *op) = 0;
@@ -35,12 +35,7 @@ public:
 
   /// Populate the symbol cache with all symbol-defining operations within the
   /// 'top' operation.
-  void addDefinitions(mlir::Operation *top) {
-    for (auto &region : top->getRegions())
-      for (auto &block : region.getBlocks())
-        for (auto symOp : block.getOps<mlir::SymbolOpInterface>())
-          addSymbol(symOp);
-  }
+  void addDefinitions(mlir::Operation *top);
 
   /// Lookup a definition for 'symbol' in the cache.
   virtual mlir::Operation *getDefinition(mlir::Attribute symbol) const = 0;

--- a/include/circt/Support/SymCache.h
+++ b/include/circt/Support/SymCache.h
@@ -43,17 +43,12 @@ public:
   }
 
   /// Lookup a definition for 'symbol' in the cache.
-  mlir::Operation *getDefinition(mlir::Attribute symbol) const {
-    return lookup(symbol);
-  }
+  virtual mlir::Operation *getDefinition(mlir::Attribute symbol) const = 0;
 
   /// Lookup a definition for 'symbol' in the cache.
   mlir::Operation *getDefinition(mlir::FlatSymbolRefAttr symbol) const {
-    return lookup(symbol.getAttr());
+    return getDefinition(symbol.getAttr());
   }
-
-protected:
-  virtual mlir::Operation *lookup(mlir::Attribute attr) const = 0;
 };
 
 /// Default symbol cache implementation; stores associations between names
@@ -68,13 +63,16 @@ public:
     symbolCache.try_emplace(key, op);
   }
 
-protected:
-  mlir::Operation *lookup(mlir::Attribute attr) const override {
+  // Pull in getDefinition(mlir::FlatSymbolRefAttr symbol)
+  using SymbolCacheBase::getDefinition;
+  mlir::Operation *getDefinition(mlir::Attribute attr) const override {
     auto it = symbolCache.find(attr);
     if (it == symbolCache.end())
       return nullptr;
     return it->second;
   }
+
+protected:
 
   /// This stores a lookup table from symbol attribute to the operation
   /// that defines it.

--- a/include/circt/Support/SymCache.h
+++ b/include/circt/Support/SymCache.h
@@ -68,7 +68,6 @@ public:
   }
 
 protected:
-
   /// This stores a lookup table from symbol attribute to the operation
   /// that defines it.
   llvm::DenseMap<mlir::Attribute, mlir::Operation *> symbolCache;

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -4150,12 +4150,12 @@ void SharedEmitterState::gatherFiles(bool separateModules) {
       for (NamedAttribute argAttr : moduleOp.getArgAttrs(p))
         if (auto sym = argAttr.getValue().dyn_cast<FlatSymbolRefAttr>())
           symbolCache.addDefinition(moduleOp.getNameAttr(), sym.getAttr(),
-                                         moduleOp, p);
+                                    moduleOp, p);
     for (size_t p = 0, e = moduleOp.getNumResults(); p != e; ++p)
       for (NamedAttribute resultAttr : moduleOp.getResultAttrs(p))
         if (auto sym = resultAttr.getValue().dyn_cast<FlatSymbolRefAttr>())
           symbolCache.addDefinition(moduleOp.getNameAttr(), sym.getAttr(),
-                                         moduleOp, p + numArgs);
+                                    moduleOp, p + numArgs);
   };
 
   SmallString<32> outputPath;

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -4138,7 +4138,7 @@ void SharedEmitterState::gatherFiles(bool separateModules) {
       // Populate the symbolCache with all operations that can define a symbol.
       if (auto name = op->getAttrOfType<StringAttr>(
               hw::InnerName::getInnerNameAttrName()))
-        symbolCache.addInnerDefinition(moduleOp.getNameAttr(), name, op);
+        symbolCache.addDefinition(moduleOp.getNameAttr(), name, op);
       if (isa<BindOp>(op))
         modulesContainingBinds.insert(moduleOp);
     });
@@ -4149,12 +4149,12 @@ void SharedEmitterState::gatherFiles(bool separateModules) {
     for (size_t p = 0; p != numArgs; ++p)
       for (NamedAttribute argAttr : moduleOp.getArgAttrs(p))
         if (auto sym = argAttr.getValue().dyn_cast<FlatSymbolRefAttr>())
-          symbolCache.addInnerDefinition(moduleOp.getNameAttr(), sym.getAttr(),
+          symbolCache.addDefinition(moduleOp.getNameAttr(), sym.getAttr(),
                                          moduleOp, p);
     for (size_t p = 0, e = moduleOp.getNumResults(); p != e; ++p)
       for (NamedAttribute resultAttr : moduleOp.getResultAttrs(p))
         if (auto sym = resultAttr.getValue().dyn_cast<FlatSymbolRefAttr>())
-          symbolCache.addInnerDefinition(moduleOp.getNameAttr(), sym.getAttr(),
+          symbolCache.addDefinition(moduleOp.getNameAttr(), sym.getAttr(),
                                          moduleOp, p + numArgs);
   };
 

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -905,8 +905,8 @@ void EmitterBase::emitTextWithSubstitutions(
           if (auto *symOp = state.symbolCache.getDefinition(fsym))
             symVerilogName = namify(sym, symOp);
         } else if (auto isym = sym.dyn_cast<InnerRefAttr>()) {
-          auto symOp =
-              state.symbolCache.getDefinition(isym.getModule(), isym.getName());
+          auto symOp = state.symbolCache.getInnerDefinition(isym.getModule(),
+                                                            isym.getName());
           symVerilogName = namify(sym, symOp);
         }
         os << symVerilogName;
@@ -4138,7 +4138,7 @@ void SharedEmitterState::gatherFiles(bool separateModules) {
       // Populate the symbolCache with all operations that can define a symbol.
       if (auto name = op->getAttrOfType<StringAttr>(
               hw::InnerName::getInnerNameAttrName()))
-        symbolCache.addDefinition(moduleOp.getNameAttr(), name, op);
+        symbolCache.addInnerDefinition(moduleOp.getNameAttr(), name, op);
       if (isa<BindOp>(op))
         modulesContainingBinds.insert(moduleOp);
     });
@@ -4149,13 +4149,13 @@ void SharedEmitterState::gatherFiles(bool separateModules) {
     for (size_t p = 0; p != numArgs; ++p)
       for (NamedAttribute argAttr : moduleOp.getArgAttrs(p))
         if (auto sym = argAttr.getValue().dyn_cast<FlatSymbolRefAttr>())
-          symbolCache.addDefinition(moduleOp.getNameAttr(), sym.getAttr(),
-                                    moduleOp, p);
+          symbolCache.addInnerDefinition(moduleOp.getNameAttr(), sym.getAttr(),
+                                         moduleOp, p);
     for (size_t p = 0, e = moduleOp.getNumResults(); p != e; ++p)
       for (NamedAttribute resultAttr : moduleOp.getResultAttrs(p))
         if (auto sym = resultAttr.getValue().dyn_cast<FlatSymbolRefAttr>())
-          symbolCache.addDefinition(moduleOp.getNameAttr(), sym.getAttr(),
-                                    moduleOp, p + numArgs);
+          symbolCache.addInnerDefinition(moduleOp.getNameAttr(), sym.getAttr(),
+                                         moduleOp, p + numArgs);
   };
 
   SmallString<32> outputPath;

--- a/lib/Dialect/HW/Transforms/HWSpecialize.cpp
+++ b/lib/Dialect/HW/Transforms/HWSpecialize.cpp
@@ -35,7 +35,7 @@ using InstanceParameters = llvm::DenseMap<hw::HWModuleOp, ArrayAttr>;
 
 // Generates a module name by composing the name of 'moduleOp' and the set of
 // provided 'parameters'.
-static std::string generateModuleName(HWSymbolCache &symbolCache,
+static std::string generateModuleName(SymbolCache &symbolCache,
                                       hw::HWModuleOp moduleOp,
                                       ArrayAttr parameters) {
   assert(parameters.size() != 0);
@@ -194,7 +194,7 @@ static void populateTypeConversion(Location loc, TypeConverter &typeConverter,
 // 4. Any references to module parameters have been replaced with the
 // parameter value.
 static LogicalResult specializeModule(OpBuilder builder, ArrayAttr parameters,
-                                      HWSymbolCache &sc, HWModuleOp source,
+                                      SymbolCache &sc, HWModuleOp source,
                                       HWModuleOp &target) {
   auto *ctx = builder.getContext();
   // Update the types of the source module ports based on evaluating any

--- a/lib/Dialect/HW/Transforms/HWSpecialize.cpp
+++ b/lib/Dialect/HW/Transforms/HWSpecialize.cpp
@@ -273,10 +273,9 @@ void HWSpecializePass::runOnOperation() {
                  llvm::DenseMap<ArrayAttr, llvm::SmallVector<hw::InstanceOp>>>
       parametersUsers;
 
-  // Maintain a symbol cache for fast looking during module specialization.
-  MutableSymbolCache sc;
+  // Maintain a symbol cache for fast lookup during module specialization.
+  SymbolCache sc;
   sc.addDefinitions(module);
-  sc.freeze();
 
   for (auto hwModule : module.getOps<hw::HWModuleOp>()) {
     for (auto instanceOp : hwModule.getOps<hw::InstanceOp>()) {
@@ -307,9 +306,7 @@ void HWSpecializePass::runOnOperation() {
       }
 
       // Extend the symbol cache with the newly created module.
-      sc.unfreeze();
       sc.addDefinition(specializedModule.getNameAttr(), specializedModule);
-      sc.freeze();
 
       // Rewrite instances of the specialized module to the specialized
       // module.

--- a/lib/Dialect/MSFT/CMakeLists.txt
+++ b/lib/Dialect/MSFT/CMakeLists.txt
@@ -33,6 +33,7 @@ add_circt_dialect_library(CIRCTMSFT
   CIRCTHW
   CIRCTSeq
   CIRCTSV
-   )
+  CIRCTSupport
+)
 
 add_dependencies(circt-headers MLIRMSFTIncGen)

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -1445,7 +1445,7 @@ static Op findInstanceSymbolInBlock(StringAttr name, Block *body) {
 hw::InstanceOp BindOp::getReferencedInstance(const hw::HWSymbolCache *cache) {
   // If we have a cache, directly look up the referenced instance.
   if (cache) {
-    auto result = cache->getDefinition(instance());
+    auto result = cache->getInnerDefinition(instance());
     return cast<hw::InstanceOp>(result.getOp());
   }
 
@@ -1497,7 +1497,7 @@ sv::InterfaceInstanceOp
 BindInterfaceOp::getReferencedInstance(const hw::HWSymbolCache *cache) {
   // If we have a cache, directly look up the referenced instance.
   if (cache) {
-    auto result = cache->getDefinition(instance());
+    auto result = cache->getInnerDefinition(instance());
     return cast<sv::InterfaceInstanceOp>(result.getOp());
   }
 

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -323,10 +323,7 @@ void SVExtractTestCodeImplPass::runOnOperation() {
       top->getAttrOfType<hw::OutputFileAttr>("firrtl.extract.cover.bindfile");
 
   hw::HWSymbolCache symCache;
-  for (auto &op : topLevelModule->getOperations())
-    if (auto symOp = dyn_cast<mlir::SymbolOpInterface>(op))
-      if (auto name = symOp.getNameAttr())
-        symCache.addDefinition(name, symOp);
+  symCache.addDefinitions(top);
   symCache.freeze();
 
   // Symbols not in the cache will only be fore instances added by an extract

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -10,6 +10,7 @@ add_circt_library(CIRCTSupport
   Path.cpp
   APInt.cpp
   ValueMapper.cpp
+  SymCache.cpp
 
   ADDITIONAL_HEADER_DIRS
 

--- a/lib/Support/SymCache.cpp
+++ b/lib/Support/SymCache.cpp
@@ -1,0 +1,29 @@
+//===- SymCache.cpp - Declare Symbol Cache ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines a Symbol Cache.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Support/SymCache.h"
+
+using namespace mlir;
+using namespace circt;
+
+namespace circt {
+
+/// Virtual method anchor.
+SymbolCacheBase::~SymbolCacheBase() {}
+
+void SymbolCacheBase::addDefinitions(mlir::Operation *top) {
+  for (auto &region : top->getRegions())
+    for (auto &block : region.getBlocks())
+      for (auto symOp : block.getOps<mlir::SymbolOpInterface>())
+        addSymbol(symOp);
+}
+} // namespace circt


### PR DESCRIPTION
To allow for using symbol caches for things other than that in `HW`, SymCache has been made generic.
Considering its current use/implementation (`HWSymCache`), `InnerRefAttr` getter/setters have been lifted to the `HWSymCache` specialization, while keeping the underlying `addDefinition/getDefinition/lookup` logic generic.

The cache class hierarchy starts with a `SymbolCacheBase`. The intention of having a non-templated type for read-only access to the cache is to be able to provide a symbol cache to other tools which might need to do efficient read-only lookup. In a follow-up commit, i intend to introduce a new class `SymUniquer` which, given a `SymbolCacheBase`, can generate unique names given an input base name - this will replace some custom logic in `SCFToCalyx` (and is probably useful other places in the codebase).