### PR TITLE
[FIRRTL] Handle memTap on Memories excluded from MemToReg (#3102)

### DIFF
--- a/test/Dialect/FIRRTL/SFCTests/data-taps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps.fir
@@ -3,10 +3,7 @@
 ; - github.com/sifive/$internal:
 ;   - src/test/scala/grandcentral/DataTapsTest.scala
 
-circuit Top : %[[{
-    "class": "sifive.enterprise.firrtl.MarkDUTAnnotation",
-    "target": "~Top|Child"
-  }]]
+circuit Top :
   extmodule BlackBox :
     input in : UInt<1>
     output out : UInt<1>
@@ -88,6 +85,6 @@ circuit Top : %[[{
 ; CHECK: module MemTap_2_impl_0(
 ; CHECK:   output  _1,
 ; CHECK:           _0);
-; CHECK:   assign _1 = Top.unsigned_0.signed_0.always_1;
-; CHECK:   assign _0 = Top.unsigned_0.signed_0.always_0;
+; CHECK:   assign _1 = Top.unsigned_0.signed_0.always_ext.Memory[1];
+; CHECK:   assign _0 = Top.unsigned_0.signed_0.always_ext.Memory[0];
 ; CHECK: endmodule


### PR DESCRIPTION
Handle MemTap annotation on Memories that are excluded from `MemToRegOfVec` transformation.
This fixes an issue with the commit https://github.com/llvm/circt/commit/26276bfc85df9c0864730182f34ccf73e14c1f19 which updated this pass to only work on registers that were generated by `MemToRegOfVec` transformation. The assumption here was that every MemOp, should either be lowered to registers by `MemToRegOfVec` or to `FMemModuleOp` by `LowerMemory`. So, the GCT pass shouldn't expect to see a `MemOp`. 

But yesterday's commit https://github.com/llvm/circt/commit/b92396367a74d542a5ed51d745c4fbc27b6ad877, updated the `MemToRegOfVec` to exclude testbench memories and made the incorrect assumption that testbench memories wouldn't have memtap annotations. 

Finally this commit fixes that assumption and handles the Memtap annotation on `MemOp`s.