### PR TITLE
[HandshakeToFIRRTL] Add support for tuple types

### DIFF
--- a/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
@@ -139,3 +139,15 @@ handshake.func @test_buffer_init(%arg0: index, %arg1: none, ...) -> (index, none
   %0 = buffer [1] seq %arg0 {initValues=[42]} : index
   return %0, %arg1 : index, none
 }
+
+// -----
+
+// CHECK-LABEL: firrtl.module @handshake_buffer_in_tuple_ui32_ui32_out_tuple_ui32_ui32_2slots_seq(
+// CHECK: %[[VALUE:.*]] = firrtl.constant 0 : !firrtl.sint<64>
+// CHECK: %[[ZERO_BUNDLE:.*]] = firrtl.bitcast %[[VALUE]] : (!firrtl.sint<64>) -> !firrtl.bundle<field0: uint<32>, field1: uint<32>>
+// CHECK: %dataReg0 = firrtl.regreset %{{.*}}, %{{.*}}, %[[ZERO_BUNDLE]]  : !firrtl.uint<1>, !firrtl.bundle<field0: uint<32>, field1: uint<32>>, !firrtl.bundle<field0: uint<32>, field1: uint<32>>
+
+handshake.func @test_buffer_tuple_seq(%t: tuple<i32, i32>, %arg0: none, ...) -> (tuple<i32, i32>, none) {
+  %0 = buffer [2] seq %t : tuple<i32, i32>
+  return %0, %arg0 : tuple<i32, i32>, none
+}

--- a/test/Conversion/HandshakeToFIRRTL/test_buffer_fifo.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_buffer_fifo.mlir
@@ -24,3 +24,11 @@ handshake.func @test_fifo_nonetype(%arg0: none, %arg1: none, ...) -> (none, none
   %0 = buffer [3] fifo %arg0 : none
   return %0, %arg1 : none, none
 }
+
+// -----
+// CHECK: firrtl.module @innerFIFO_1_tuple_ui32_ui32
+// CHECK: firrtl.module @handshake_buffer_in_tuple_ui32_ui32_out_tuple_ui32_ui32_1slots_fifo
+handshake.func @test_buffer_tuple_fifo(%t: tuple<i32, i32>, %arg0: none, ...) -> (tuple<i32, i32>, none) attributes {argNames = ["t", "inCtrl"], resNames = ["out0", "outCtrl"]} {
+  %0 = buffer [1] fifo %t : tuple<i32, i32>
+  return %0, %arg0 : tuple<i32, i32>, none
+}

--- a/test/Conversion/HandshakeToFIRRTL/test_tuple_type.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_tuple_type.mlir
@@ -1,0 +1,12 @@
+// RUN: circt-opt -lower-handshake-to-firrtl --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: firrtl.circuit "test_tuple"  {
+// CHECK:  firrtl.module @test_tuple(in %[[VAL_0:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: bundle<field0: uint<64>, field1: uint<32>>>, in %[[VAL_1:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, out %[[VAL_2:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: bundle<field0: uint<64>, field1: uint<32>>>, out %[[VAL_3:.*]]: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, in %[[VAL_4:.*]]: !firrtl.clock, in %[[VAL_5:.*]]: !firrtl.uint<1>) {
+// CHECK:    firrtl.connect %[[VAL_2]], %[[VAL_0]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: bundle<field0: uint<64>, field1: uint<32>>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: bundle<field0: uint<64>, field1: uint<32>>>
+// CHECK:    firrtl.connect %[[VAL_3]], %[[VAL_1]] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>>
+// CHECK:  }
+// CHECK:}
+
+handshake.func @test_tuple(%arg0: tuple<i64, i32>, %ctrl: none, ...) -> (tuple<i64, i32>, none) {
+  return %arg0, %ctrl : tuple<i64, i32>, none
+}


### PR DESCRIPTION
This commit introduces lowering for tuple types by transforming them to BundleTypes.

Some of this work was part of #3054 but as this grew bigger than expected, I decided to split this into separate PRs.