### PR TITLE
[PrepareForEmission] Spill wires for largish expressions in concat.

### DIFF
--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -81,8 +81,15 @@ struct LoweringOptions {
   /// statements to be labeled.
   bool enforceVerifLabels = false;
 
+  /// This is the maximum number of terms in an expression before that
+  /// expression spills a wire.
   enum { DEFAULT_TERM_LIMIT = 256 };
   unsigned maximumNumberOfTermsPerExpression = DEFAULT_TERM_LIMIT;
+
+  /// This is the maximum number of terms in an expression used in a concat
+  /// before that expression spills a wire.
+  enum { DEFAULT_CONCAT_TERM_LIMIT = 10 };
+  unsigned maximumNumberOfTermsInConcat = DEFAULT_CONCAT_TERM_LIMIT;
 
   /// This is the target width of lines in an emitted Verilog source file in
   /// columns.

--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -51,13 +51,30 @@ static bool shouldSpillWire(Operation &op, const LoweringOptions &options) {
   auto isAssign = [](Operation *op) {
     return isa<AssignOp, PAssignOp, BPAssignOp, OutputOp>(op);
   };
+  auto isConcat = [](Operation *op) { return isa<ConcatOp>(op); };
+
+  if (!isVerilogExpression(&op))
+    return false;
 
   // If there are more than the maximum number of terms in this single result
   // expression, and it hasn't already been spilled, this should spill.
-  return isVerilogExpression(&op) &&
-         op.getNumOperands() > options.maximumNumberOfTermsPerExpression &&
-         op.getNumResults() == 1 &&
-         llvm::none_of(op.getResult(0).getUsers(), isAssign);
+  if (op.getNumOperands() > options.maximumNumberOfTermsPerExpression &&
+      op.getNumResults() == 1 &&
+      llvm::none_of(op.getResult(0).getUsers(), isAssign))
+    return true;
+
+  // Work around Verilator #3405. Large expressions inside a concat is worst
+  // case O(n^2) in a certain Verilator optimization, and can effectively hang
+  // Verilator on large designs. Verilator 4.224+ works around this by having a
+  // hard limit on its recursion. Here we break large expressions inside concats
+  // according to a configurable limit to work around the same issue.
+  // See https://github.com/verilator/verilator/issues/3405.
+  if (op.getNumOperands() > options.maximumNumberOfTermsInConcat &&
+      op.getNumResults() == 1 &&
+      llvm::any_of(op.getResult(0).getUsers(), isConcat))
+    return true;
+
+  return false;
 }
 
 // Given an invisible instance, make sure all inputs are driven from
@@ -93,7 +110,6 @@ static void lowerBoundInstance(InstanceOp op) {
     op.setOperand(nextOpNo - 1, newWireRead);
   }
 }
-
 
 // Ensure that each output of an instance are used only by a wire
 static void lowerInstanceResults(InstanceOp op) {

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -72,6 +72,11 @@ void LoweringOptions::parse(StringRef text, ErrorHandlerT errorHandler) {
         errorHandler("expected integer source width");
         maximumNumberOfTermsPerExpression = DEFAULT_TERM_LIMIT;
       }
+    } else if (option.consume_front("maximumNumberOfTermsInConcat=")) {
+      if (option.getAsInteger(10, maximumNumberOfTermsInConcat)) {
+        errorHandler("expected integer source width");
+        maximumNumberOfTermsInConcat = DEFAULT_CONCAT_TERM_LIMIT;
+      }
     } else if (option.consume_front("locationInfoStyle=")) {
       if (auto style = parseLocationInfoStyle(option)) {
         locationInfoStyle = *style;
@@ -114,6 +119,9 @@ std::string LoweringOptions::toString() const {
   if (maximumNumberOfTermsPerExpression != DEFAULT_TERM_LIMIT)
     options += "maximumNumberOfTermsPerExpression=" +
                std::to_string(maximumNumberOfTermsPerExpression) + ',';
+  if (maximumNumberOfTermsInConcat != DEFAULT_CONCAT_TERM_LIMIT)
+    options += "maximumNumberOfTermsInConcat=" +
+               std::to_string(maximumNumberOfTermsInConcat) + ',';
 
   // Remove a trailing comma if present.
   if (!options.empty()) {
@@ -166,7 +174,8 @@ struct LoweringCLOptions {
           "Style options.  Valid flags include: alwaysFF, "
           "noAlwaysComb, exprInEventControl, disallowPackedArrays, "
           "disallowLocalVariables, verifLabels, emittedLineLength=<n>, "
-          "maximumNumberOfTermsPerExpression=<n>, explicitBitcastAddMul, "
+          "maximumNumberOfTermsPerExpression=<n>, "
+          "maximumNumberOfTermsInConcat=<n>, explicitBitcastAddMul, "
           "emitReplicatedOpsToHeader, "
           "locationInfoStyle={plain,wrapInAtSquareBracket}, "
           "disallowPortDeclSharing"),

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1396,6 +1396,27 @@ hw.module @ReuseExistingInOut(%clock: i1, %a: i1) -> (out1: i1) {
   hw.output %0 : i1
 }
 
+// See https://github.com/verilator/verilator/issues/3405.
+// CHECK-LABEL: Verilator3405
+// CHECK-DAG: wire [[GEN0:.+]];
+// CHECK-DAG: wire [[GEN1:.+]];
+// CHECK-DAG: assign [[GEN0]] = {{.+}} | {{.+}} | {{.+}}
+// CHECK-DAG: assign [[GEN1]] = {{.+}} | {{.+}} | {{.+}}
+// CHECK: assign out = {[[GEN1]], [[GEN0]]}
+hw.module @Verilator3405(
+  %0: i1, %1: i1, %2: i1, %3: i1, %4: i1, %5: i1, %6: i1, %7: i1, %8: i1,
+  %9: i1, %10: i1, %11: i1, %12: i1, %13: i1, %14: i1, %15: i1, %16: i1,
+  %17: i1, %18: i1, %19: i1, %20: i1, %21: i1, %22: i1) -> (out: i2) {
+
+  %lhs = comb.or %0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10 : i1
+  %rhs = comb.or %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21 : i1
+
+  %out = comb.concat %lhs, %rhs : i1, i1
+
+  hw.output %out : i2
+}
+
+
 hw.module @bindInMod() {
   sv.bind #hw.innerNameRef<@remoteInstDut::@bindInst>
   sv.bind #hw.innerNameRef<@remoteInstDut::@bindInst3>


### PR DESCRIPTION
This adds another heuristic to shouldSpillWire, this time to check if
the number of operands in a single expression inside a concat. If this
exceeds a configurable limit, a wire is spilled. This is to work
around Verilator #3405.

Large expressions inside a concat is worst case O(n^2) in a certain
Verilator optimization, and can effectively hang Verilator on large
designs. Verilator 4.224+ works around this by having a hard limit on
its recursion. Here we break large expressions inside concats
according to a configurable limit to work around the same issue.
See https://github.com/verilator/verilator/issues/3405.