### PR TITLE
[FIRRTL][AddSeqMemPorts] Don't error if there are still MemOps

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
@@ -208,10 +208,6 @@ LogicalResult AddSeqMemPortsPass::processModule(FModuleOp module) {
   unsigned firstPortIndex = module.getNumPorts();
 
   for (auto &op : llvm::make_early_inc_range(*module.getBody())) {
-    // We cannot add extra ports to a regular memory op.
-    if (auto mem = dyn_cast<MemOp>(op))
-      return mem->emitError("memories should have been lowered to modules");
-
     if (auto inst = dyn_cast<InstanceOp>(op)) {
       auto submodule = instanceGraph->getReferencedModule(inst);
       auto &subMemInfo = memInfoMap[submodule];


### PR DESCRIPTION
The `AddSeqMemPorts` pass has a check during execution that it doesn't
see any MemOps, since they should have been converted to behavioural
implementations or blackboxed.  This was a very simple check added just
to catch any phase-ordering problems in the FIRRTL pipeline.  We have
since revised the lowering of memories to let some memories to be
handled by the HW memory generator, and so some mem ops can still be
around and it isn't an error. There was no test to update when removing
this check.