### PR TITLE
[FIRRTL] Guard the MemToReg transformation with the annotation

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
@@ -39,8 +39,12 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
     auto circtOp = getOperation();
     static const char dutAnnoClass[] =
         "sifive.enterprise.firrtl.MarkDUTAnnotation";
+    static const char mem2regAnno[] =
+        "sifive.enterprise.firrtl.ConvertMemToRegOfVecAnnotation$";
     DenseSet<Operation *> dutModuleSet;
 
+    if (!AnnotationSet::removeAnnotations(circtOp, mem2regAnno))
+      return;
     auto *body = circtOp.getBody();
 
     // Find the device under test and create a set of all modules underneath it.

--- a/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
+++ b/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt -pass-pipeline='firrtl.circuit(mem-to-regofvec)' %s | FileCheck  %s
 
-firrtl.circuit "Mem" {
+firrtl.circuit "Mem" attributes {annotations = [{class = "sifive.enterprise.firrtl.ConvertMemToRegOfVecAnnotation$"}]}{
   firrtl.module public @Mem() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]}{
     %mem_read, %mem_write = firrtl.mem Undefined  {depth = 8 : i64, name = "mem", portNames = ["read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
   }
@@ -33,7 +33,7 @@ firrtl.circuit "Mem" {
 
 }
 
-firrtl.circuit  "GCTModule" {
+firrtl.circuit  "GCTModule" attributes {annotations = [{class = "sifive.enterprise.firrtl.ConvertMemToRegOfVecAnnotation$"}]}{
   firrtl.module public @GCTModule() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]}{
     %rf_read, %rf_write = firrtl.mem Undefined  {annotations = [#firrtl.subAnno<fieldID = 1, {class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = 1 : i64, type = "source"}>, #firrtl.subAnno<fieldID = 1, {class = "firrtl.transforms.DontTouchAnnotation"}>, #firrtl.subAnno<fieldID = 2, {class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = 2 : i64, type = "source"}>, #firrtl.subAnno<fieldID = 2, {class = "firrtl.transforms.DontTouchAnnotation"}>, #firrtl.subAnno<fieldID = 3, {class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = 3 : i64, type = "source"}>, #firrtl.subAnno<fieldID = 3, {class = "firrtl.transforms.DontTouchAnnotation"}>, #firrtl.subAnno<fieldID = 4, {class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = 4 : i64, type = "source"}>, #firrtl.subAnno<fieldID = 4, {class = "firrtl.transforms.DontTouchAnnotation"}>, #firrtl.subAnno<fieldID = 5, {class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = 5 : i64, type = "source"}>, #firrtl.subAnno<fieldID = 5, {class = "firrtl.transforms.DontTouchAnnotation"}>, #firrtl.subAnno<fieldID = 6, {class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = 6 : i64, type = "source"}>, #firrtl.subAnno<fieldID = 6, {class = "firrtl.transforms.DontTouchAnnotation"}>, #firrtl.subAnno<fieldID = 7, {class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = 7 : i64, type = "source"}>, #firrtl.subAnno<fieldID = 7, {class = "firrtl.transforms.DontTouchAnnotation"}>, #firrtl.subAnno<fieldID = 8, {class = "sifive.enterprise.grandcentral.ReferenceDataTapKey", id = 0 : i64, portID = 8 : i64, type = "source"}>, #firrtl.subAnno<fieldID = 8, {class = "firrtl.transforms.DontTouchAnnotation"}>, #firrtl.subAnno<fieldID = 1, {class = "firrtl.transforms.DontTouchAnnotation"}>, #firrtl.subAnno<fieldID = 2, {class = "firrtl.transforms.DontTouchAnnotation"}>, #firrtl.subAnno<fieldID = 3, {class = "firrtl.transforms.DontTouchAnnotation"}>, #firrtl.subAnno<fieldID = 4, {class = "firrtl.transforms.DontTouchAnnotation"}>, #firrtl.subAnno<fieldID = 5, {class = "firrtl.transforms.DontTouchAnnotation"}>, #firrtl.subAnno<fieldID = 6, {class = "firrtl.transforms.DontTouchAnnotation"}>, #firrtl.subAnno<fieldID = 7, {class = "firrtl.transforms.DontTouchAnnotation"}>, #firrtl.subAnno<fieldID = 8, {class = "firrtl.transforms.DontTouchAnnotation"}>, #firrtl.subAnno<fieldID = 1, {class = "firrtl.transforms.DontTouchAnnotation"}>, #firrtl.subAnno<fieldID = 2, {class = "firrtl.transforms.DontTouchAnnotation"}>, #firrtl.subAnno<fieldID = 3, {class = "firrtl.transforms.DontTouchAnnotation"}>, #firrtl.subAnno<fieldID = 4, {class = "firrtl.transforms.DontTouchAnnotation"}>, #firrtl.subAnno<fieldID = 5, {class = "firrtl.transforms.DontTouchAnnotation"}>, #firrtl.subAnno<fieldID = 6, {class = "firrtl.transforms.DontTouchAnnotation"}>, #firrtl.subAnno<fieldID = 7, {class = "firrtl.transforms.DontTouchAnnotation"}>, #firrtl.subAnno<fieldID = 8, {class = "firrtl.transforms.DontTouchAnnotation"}>], depth = 8 : i64, name = "rf", portNames = ["read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
       // CHECK-LABEL: firrtl.module public @GCTModule()
@@ -41,7 +41,7 @@ firrtl.circuit  "GCTModule" {
   }
 }
  
-firrtl.circuit "WriteMask" {
+firrtl.circuit "WriteMask" attributes {annotations = [{class = "sifive.enterprise.firrtl.ConvertMemToRegOfVecAnnotation$"}]}{
   firrtl.module public @WriteMask() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]}{
     %mem_read, %mem_write = firrtl.mem Undefined  {depth = 8 : i64, name = "mem", portNames = ["read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: vector<uint<8>, 2>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: vector<uint<8>, 2>, mask: vector<uint<1>, 2>>
     // CHECK-LABEL: firrtl.module public @WriteMask()
@@ -71,7 +71,7 @@ firrtl.circuit "WriteMask" {
   }
 }
 	
-firrtl.circuit "MemTap" {
+firrtl.circuit "MemTap" attributes {annotations = [{class = "sifive.enterprise.firrtl.ConvertMemToRegOfVecAnnotation$"}]}{
   firrtl.module public @MemTap() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]}{
 		%rf_MPORT, %rf_io_rdata_0_MPORT, %rf_io_rdata_1_MPORT = firrtl.mem sym @rf Undefined  {annotations = [{class = "sifive.enterprise.grandcentral.MemTapAnnotation", id = 11 : i64}], depth = 4 : i64, name = "rf", portNames = ["MPORT", "io_rdata_0_MPORT", "io_rdata_1_MPORT"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<2>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>, !firrtl.bundle<addr: uint<2>, en: uint<1>, clk: clock, data flip: uint<32>>, !firrtl.bundle<addr: uint<2>, en: uint<1>, clk: clock, data flip: uint<32>>
     // CHECK-LABEL: firrtl.module public @MemTap()

--- a/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
+++ b/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
@@ -4,7 +4,8 @@ firrtl.circuit "Mem" attributes {annotations = [{class = "sifive.enterprise.firr
   firrtl.module public @Mem() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]}{
     %mem_read, %mem_write = firrtl.mem Undefined  {depth = 8 : i64, name = "mem", portNames = ["read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
   }
-    // CHECK-LABEL: firrtl.module public @Mem(
+    // CHECK-LABEL: firrtl.circuit "Mem" {
+    // CHECK: firrtl.module public @Mem(
     // CHECK:         %mem_read = firrtl.wire  : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>
     // CHECK:         %[[v0:.+]] = firrtl.subfield %mem_read(0)
     // CHECK:         %[[v1:.+]] = firrtl.subfield %mem_read(1)
@@ -31,6 +32,13 @@ firrtl.circuit "Mem" attributes {annotations = [{class = "sifive.enterprise.firr
     // CHECK:         }
 
 
+}
+
+firrtl.circuit "Mem_Ignore" {
+  firrtl.module public @Mem_Ignore() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]}{
+    %mem_read, %mem_write = firrtl.mem Undefined  {depth = 8 : i64, name = "mem", portNames = ["read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+    // CHECK: %mem_read, %mem_write = firrtl.mem Undefined  {depth = 8 : i64, name = "mem", portNames = ["read", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
+  }
 }
 
 firrtl.circuit  "GCTModule" attributes {annotations = [{class = "sifive.enterprise.firrtl.ConvertMemToRegOfVecAnnotation$"}]}{

--- a/test/firtool/chirrtl.fir
+++ b/test/firtool/chirrtl.fir
@@ -8,6 +8,9 @@
 circuit test: %[[{
     "class": "sifive.enterprise.firrtl.MarkDUTAnnotation",
     "target":"~test|test"
+  }, 
+  {
+    "class": "sifive.enterprise.firrtl.ConvertMemToRegOfVecAnnotation$"
   }]]
   module test:
     input p: UInt<1>

--- a/test/firtool/memory.fir
+++ b/test/firtool/memory.fir
@@ -3,6 +3,9 @@
 circuit Qux: %[[{
     "class": "sifive.enterprise.firrtl.MarkDUTAnnotation",
     "target":"~Qux|Qux"
+  }, 
+  {
+    "class": "sifive.enterprise.firrtl.ConvertMemToRegOfVecAnnotation$"
   }]]
   module Qux: 
     input clock: Clock

--- a/test/firtool/phase-ordering.fir
+++ b/test/firtool/phase-ordering.fir
@@ -12,6 +12,9 @@
 circuit Issue794: %[[{
     "class": "sifive.enterprise.firrtl.MarkDUTAnnotation",
     "target":"~Issue794|Issue794"
+  }, 
+  {
+    "class": "sifive.enterprise.firrtl.ConvertMemToRegOfVecAnnotation$"
   }]]
   module Issue794:
     input clock: Clock


### PR DESCRIPTION
This commit makes sure that the `MemToRegOfVec` transformation must run only if the annotation
`"sifive.enterprise.firrtl.ConvertMemToRegOfVecAnnotation$"` is present on the `Circuit` op.
Earlier, the assumption was that the transformation can always run by default, but in order to match SFC behavior this check is necessary.
Add the check and update all the lit tests accordingly.