### PR TITLE
[FIRRTL] Add Inner Symbol DCE Pass

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -143,6 +143,9 @@ std::unique_ptr<mlir::Pass> createLowerXMRPass();
 
 std::unique_ptr<mlir::Pass>
 createResolveTracesPass(StringRef outputAnnotationFilename = "");
+
+std::unique_ptr<mlir::Pass> createInnerSymbolDCEPass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/FIRRTL/Passes.h.inc"

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -627,16 +627,17 @@ def ResolveTraces : Pass<"firrtl-resolve-traces", "firrtl::CircuitOp"> {
   let dependentDialects = ["sv::SVDialect"];
 }
 
-def InnerSymbolDCE : Pass<"inner-symbol-dce", "firrtl::CircuitOp"> {
+def InnerSymbolDCE : Pass<"firrtl-inner-symbol-dce", "mlir::ModuleOp"> {
   let summary = "Eliminate dead inner symbols";
   let description = [{
-    This pass deletes all private inner symbols which have no uses.  This is
-    necessary to unblock optimizations and removal of the operations which have
-    these unused inner symbols.
+    This pass deletes all inner symbols which have no uses. This is necessary to
+    unblock optimizations and removal of the operations which have these unused
+    inner symbols.
   }];
   let constructor = "circt::firrtl::createInnerSymbolDCEPass()";
   let statistics = [
-    Statistic<"numSymbolsRemoved", "num-sym-dce", "Number of symbols removed">
+    Statistic<"numSymbolsFound", "num-sym-found", "Number of symbols found">,
+    Statistic<"numSymbolsRemoved", "num-sym-removed", "Number of symbols removed">
   ];
 }
 

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -627,4 +627,17 @@ def ResolveTraces : Pass<"firrtl-resolve-traces", "firrtl::CircuitOp"> {
   let dependentDialects = ["sv::SVDialect"];
 }
 
+def InnerSymbolDCE : Pass<"inner-symbol-dce", "firrtl::CircuitOp"> {
+  let summary = "Eliminate dead inner symbols";
+  let description = [{
+    This pass deletes all private inner symbols which have no uses.  This is
+    necessary to unblock optimizations and removal of the operations which have
+    these unused inner symbols.
+  }];
+  let constructor = "circt::firrtl::createInnerSymbolDCEPass()";
+  let statistics = [
+    Statistic<"numSymbolsRemoved", "num-sym-dce", "Number of symbols removed">
+  ];
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_PASSES_TD

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -18,6 +18,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   InferReadWrite.cpp
   InferWidths.cpp
   InjectDUTHierarchy.cpp
+  InnerSymbolDCE.cpp
   LowerAnnotations.cpp
   LowerCHIRRTL.cpp
   LowerMemory.cpp

--- a/lib/Dialect/FIRRTL/Transforms/InnerSymbolDCE.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InnerSymbolDCE.cpp
@@ -1,0 +1,106 @@
+//===- InnerSymbolDCE.cpp - Delete Unused Inner Symbols----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//===----------------------------------------------------------------------===//
+//
+// This pass removes inner symbols which have no uses.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "llvm/ADT/APSInt.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace circt;
+using namespace firrtl;
+
+namespace {
+struct InnerRefInfo {
+  unsigned refcount = 0;
+  Operation *op;
+};
+} // namespace
+
+struct InnerSymbolDCEPass : public InnerSymbolDCEBase<InnerSymbolDCEPass> {
+  void runOnOperation() override;
+};
+
+void InnerSymbolDCEPass::runOnOperation() {
+  DenseMap<hw::InnerRefAttr, InnerRefInfo> innerRefMap;
+
+  CircuitOp circuit = getOperation();
+
+  auto examineAnnotation = [&](Annotation anno) -> void {
+    anno.getDict().walkSubAttrs([&](Attribute attr) {
+      auto innerRef = attr.dyn_cast<hw::InnerRefAttr>();
+      if (!innerRef)
+        return;
+      innerRefMap[innerRef].refcount++;
+    });
+  };
+
+  auto examineAnnotations = [&](Operation *op) -> void {
+    for (auto anno : AnnotationSet(op))
+      examineAnnotation(anno);
+  };
+
+  examineAnnotations(circuit);
+  for (Operation &op : circuit.getBody()->getOperations()) {
+    examineAnnotations(&op);
+
+    // Extract any hw::InnerRefAttrs from NLAs.
+    if (auto nla = dyn_cast<NonLocalAnchor>(op)) {
+      for (auto path : nla.namepath()) {
+        auto innerref = path.dyn_cast<hw::InnerRefAttr>();
+        if (!innerref || !innerRefMap.count(innerref))
+          continue;
+        innerRefMap[innerref].refcount++;
+      }
+      continue;
+    }
+
+    // Only walk inside modules.
+    auto mod = dyn_cast<FModuleOp>(op);
+    if (!mod)
+      continue;
+
+    auto modNameAttr = mod.moduleNameAttr();
+    mod.walk([&](Operation *op) {
+      examineAnnotations(op);
+      // If there is no symbol, then just continue.
+      auto symbol = op->getAttrOfType<StringAttr>("inner_sym");
+      if (!symbol)
+        return WalkResult::advance();
+
+      auto &info = innerRefMap[hw::InnerRefAttr::get(modNameAttr, symbol)];
+      assert(!info.op && "inner ref map should not have an op at this point");
+      info.op = op;
+
+      // If the visibility is public, blindly increment the reference count.
+      auto visibility = op->getAttrOfType<StringAttr>("inner_sym_visibility");
+      if (!visibility)
+        info.refcount++;
+      return WalkResult::advance();
+    });
+  }
+
+  for (auto keyValue : innerRefMap) {
+    auto info = keyValue.second;
+    // If the reference count is non-zero, then do nothing.  Otherwise, remove
+    // the inner symbol from the operation.
+    if (info.refcount)
+      continue;
+    info.op->removeAttr("inner_sym");
+    info.op->removeAttr("inner_sym_visibility");
+    ++numSymbolsRemoved;
+  }
+}
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createInnerSymbolDCEPass() {
+  return std::make_unique<InnerSymbolDCEPass>();
+}

--- a/lib/Dialect/FIRRTL/Transforms/InnerSymbolDCE.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InnerSymbolDCE.cpp
@@ -38,8 +38,10 @@ private:
 /// Find all InnerRefAttrs inside a given Attribute.
 void InnerSymbolDCEPass::findInnerRefs(Attribute attr) {
   // Check if this Attribute is an InnerRefAttr.
-  if (auto innerRef = dyn_cast<InnerRefAttr>(attr))
+  if (auto innerRef = dyn_cast<InnerRefAttr>(attr)) {
     insertInnerRef(innerRef);
+    return;
+  }
 
   // Check if any sub-Attributes are InnerRefAttrs.
   if (auto subElementAttr = dyn_cast<SubElementAttrInterface>(attr))

--- a/test/Dialect/FIRRTL/inner-symbol-dce.mlir
+++ b/test/Dialect/FIRRTL/inner-symbol-dce.mlir
@@ -1,0 +1,28 @@
+// RUN: circt-opt -pass-pipeline='firrtl.circuit(inner-symbol-dce)' %s | FileCheck %s
+
+// CHECK-LABEL: firrtl.circuit "Simple"
+firrtl.circuit "Simple" attributes {
+  annotations = [
+    {
+      class = "circuit",
+      key = #hw.innerNameRef<@Simple::@w0>,
+      dict = {key = #hw.innerNameRef<@Simple::@w1>},
+      array = [#hw.innerNameRef<@Simple::@w2>],
+      payload = "hello"
+    }
+  ]} {
+  // CHECK: firrtl.module @Simple
+  firrtl.module @Simple() {
+    // CHECK-NEXT: @w0
+    %w0 = firrtl.wire sym @w0 {inner_sym_visibility = "private"} : !firrtl.uint<1>
+    // CHECK-NEXT: @w1
+    %w1 = firrtl.wire sym @w1 {inner_sym_visibility = "private"} : !firrtl.uint<1>
+    // CHECK-NEXT: @w2
+    %w2 = firrtl.wire sym @w2 {inner_sym_visibility = "private"} : !firrtl.uint<1>
+    // CHECK-NEXT: %w3
+    // CHECK-NOT: @w3
+    %w3 = firrtl.wire sym @w3 {inner_sym_visibility = "private"} : !firrtl.uint<1>
+    // CHECK-NEXT: @w4
+    %w4 = firrtl.wire sym @w4 : !firrtl.uint<1>
+  }
+}

--- a/test/Dialect/FIRRTL/inner-symbol-dce.mlir
+++ b/test/Dialect/FIRRTL/inner-symbol-dce.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='firrtl.circuit(inner-symbol-dce)' %s | FileCheck %s
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl-inner-symbol-dce)' %s | FileCheck %s
 
 // CHECK-LABEL: firrtl.circuit "Simple"
 firrtl.circuit "Simple" attributes {
@@ -11,18 +11,31 @@ firrtl.circuit "Simple" attributes {
       payload = "hello"
     }
   ]} {
-  // CHECK: firrtl.module @Simple
+
+  // CHECK-LABEL: firrtl.module @Simple
   firrtl.module @Simple() {
     // CHECK-NEXT: @w0
-    %w0 = firrtl.wire sym @w0 {inner_sym_visibility = "private"} : !firrtl.uint<1>
+    %w0 = firrtl.wire sym @w0 : !firrtl.uint<1>
     // CHECK-NEXT: @w1
-    %w1 = firrtl.wire sym @w1 {inner_sym_visibility = "private"} : !firrtl.uint<1>
+    %w1 = firrtl.wire sym @w1 : !firrtl.uint<1>
     // CHECK-NEXT: @w2
-    %w2 = firrtl.wire sym @w2 {inner_sym_visibility = "private"} : !firrtl.uint<1>
-    // CHECK-NEXT: %w3
-    // CHECK-NOT: @w3
-    %w3 = firrtl.wire sym @w3 {inner_sym_visibility = "private"} : !firrtl.uint<1>
-    // CHECK-NEXT: @w4
+    %w2 = firrtl.wire sym @w2 : !firrtl.uint<1>
+    // CHECK-NEXT: @w3
+    %w3 = firrtl.wire sym @w3 : !firrtl.uint<1>
+    // CHECK-NEXT: %w4
+    // CHECK-NOT: @w4
     %w4 = firrtl.wire sym @w4 : !firrtl.uint<1>
+
+    firrtl.instance child sym @child @Child()
   }
+
+  // CHECK-LABEL: firrtl.module @Child
+  firrtl.module @Child() {
+    // CHECK-NEXT: @w5
+    %w5 = firrtl.wire sym @w5 : !firrtl.uint<1>
+  }
+
+  firrtl.hierpath private @nla [@Simple::@child, @Child::@w5]
 }
+
+sv.verbatim "{{0}}" {symbols = [#hw.innerNameRef<@Simple::@w3>]}

--- a/test/Dialect/FIRRTL/inner-symbol-dce.mlir
+++ b/test/Dialect/FIRRTL/inner-symbol-dce.mlir
@@ -23,7 +23,7 @@ firrtl.circuit "Simple" attributes {
     // CHECK-NEXT: @w3
     %w3 = firrtl.wire sym @w3 : !firrtl.uint<1>
     // CHECK-NEXT: %w4
-    // CHECK-NOT: @w4
+    // CHECK-NOT:  @w4
     %w4 = firrtl.wire sym @w4 : !firrtl.uint<1>
 
     firrtl.instance child sym @child @Child()

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -746,6 +746,9 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
   pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
       firrtl::createDropNamesPass(preserveMode));
 
+  // Run InnerSymbolDCE as late as possible, but before IMDCE.
+  pm.addPass(firrtl::createInnerSymbolDCEPass());
+
   // The above passes, IMConstProp in particular, introduce additional
   // canonicalization opportunities that we should pick up here before we
   // proceed to output-specific pipelines.


### PR DESCRIPTION
Add a new pass, InnerSymbolDCE, that can be used to remove unused inner
symbols from FIRRTL Dialect.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

This is the first patch in an incomplete series that will enable Grand Central views or taps to _not_ block constant propagation / dead wire removal.  This is the first piece in that.  Inner Symbol DCE is necessary because there needs to be a mechanism for a "soft" don't touch (private inner symbol) that can be referenced from an annotation.  Once the annotation is removed, then this pass can be used to DCE the symbols and enable removal of the operation.

This currently uses a non-standard attribute, `inner_sym_visibility`.  This will be added to the builder of ops that can have an inner symbol in the aforementioned incomplete patch series.