### PR TITLE
[Transform] [FIRTOOL] Add an pass to strip file locators with "fir" suffix

### DIFF
--- a/include/circt/Transforms/Passes.h
+++ b/include/circt/Transforms/Passes.h
@@ -25,8 +25,8 @@ namespace circt {
 
 std::unique_ptr<mlir::Pass> createFlattenMemRefPass();
 std::unique_ptr<mlir::Pass> createFlattenMemRefCallsPass();
-std::unique_ptr<mlir::Pass>
-createStripDebugInfoWithPredPass(const std::function<bool(mlir::Location)> &pred);
+std::unique_ptr<mlir::Pass> createStripDebugInfoWithPredPass(
+    const std::function<bool(mlir::Location)> &pred);
 
 //===----------------------------------------------------------------------===//
 // Registration

--- a/include/circt/Transforms/Passes.h
+++ b/include/circt/Transforms/Passes.h
@@ -25,6 +25,8 @@ namespace circt {
 
 std::unique_ptr<mlir::Pass> createFlattenMemRefPass();
 std::unique_ptr<mlir::Pass> createFlattenMemRefCallsPass();
+std::unique_ptr<mlir::Pass>
+createStripDebugInfoWithPredPass(std::function<bool(mlir::Location)> pred = {});
 
 //===----------------------------------------------------------------------===//
 // Registration

--- a/include/circt/Transforms/Passes.h
+++ b/include/circt/Transforms/Passes.h
@@ -26,7 +26,7 @@ namespace circt {
 std::unique_ptr<mlir::Pass> createFlattenMemRefPass();
 std::unique_ptr<mlir::Pass> createFlattenMemRefCallsPass();
 std::unique_ptr<mlir::Pass>
-createStripDebugInfoWithPredPass(std::function<bool(mlir::Location)> pred = {});
+createStripDebugInfoWithPredPass(const std::function<bool(mlir::Location)> &pred);
 
 //===----------------------------------------------------------------------===//
 // Registration

--- a/include/circt/Transforms/Passes.td
+++ b/include/circt/Transforms/Passes.td
@@ -45,7 +45,7 @@ def StripDebugInfoWithPred : Pass<"strip-debuginfo-with-pred", "::mlir::ModuleOp
     This pass extends mlir::StrinpDebugInfoPass to selectively strip locations with a
     given predicate.
   }];
-  let constructor = "circt::createStripDebugInfoWithPredPass()";
+  let constructor = "circt::createStripDebugInfoWithPredPass({})";
   let options = [
     Option<"dropSuffix", "drop-suffix", "std::string",
            /*default=*/"",

--- a/include/circt/Transforms/Passes.td
+++ b/include/circt/Transforms/Passes.td
@@ -38,4 +38,19 @@ def FlattenMemRefCalls : Pass<"flatten-memref-calls", "::mlir::ModuleOp"> {
   let dependentDialects = ["mlir::memref::MemRefDialect"];
 }
 
+def StripDebugInfoWithPred : Pass<"strip-debuginfo-with-pred", "::mlir::ModuleOp"> {
+  let summary = "Selectively strip debug info from all operations";
+
+  let description = [{
+    This pass extends mlir::StrinpDebugInfoPass to selectively strip locations with a
+    given predicate.
+  }];
+  let constructor = "circt::createStripDebugInfoWithPredPass()";
+  let options = [
+    Option<"dropSuffix", "drop-suffix", "std::string",
+           /*default=*/"",
+           "Drop file location info with the specified suffix. This option is"
+           "intended to be used for testing."> ];
+}
+
 #endif // CIRCT_TRANSFORMS_PASSES

--- a/lib/Transforms/CMakeLists.txt
+++ b/lib/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_circt_library(CIRCTTransforms
   FlattenMemRefs.cpp
+  StripDebugInfoWithPred.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Transforms

--- a/lib/Transforms/StripDebugInfoWithPred.cpp
+++ b/lib/Transforms/StripDebugInfoWithPred.cpp
@@ -25,7 +25,7 @@ static void updateLocIfChanged(OpOrBlockArgument *op, Location newLoc) {
 namespace {
 struct StripDebugInfoWithPred
     : public circt::StripDebugInfoWithPredBase<StripDebugInfoWithPred> {
-  StripDebugInfoWithPred(std::function<bool(mlir::Location)> pred)
+  StripDebugInfoWithPred(const std::function<bool(mlir::Location)>& pred)
       : pred(pred) {}
   void runOnOperation() override;
 

--- a/lib/Transforms/StripDebugInfoWithPred.cpp
+++ b/lib/Transforms/StripDebugInfoWithPred.cpp
@@ -10,10 +10,17 @@
 #include "circt/Transforms/Passes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Operation.h"
+#include "mlir/IR/Threading.h"
 #include "mlir/Pass/Pass.h"
 #include "llvm/ADT/SmallVector.h"
 
 using namespace mlir;
+
+template <typename OpOrBlockArgument>
+static void updateLocIfChanged(OpOrBlockArgument *op, Location newLoc) {
+  if (op->getLoc() != newLoc)
+    op->setLoc(newLoc);
+}
 
 namespace {
 struct StripDebugInfoWithPred

--- a/lib/Transforms/StripDebugInfoWithPred.cpp
+++ b/lib/Transforms/StripDebugInfoWithPred.cpp
@@ -25,7 +25,7 @@ static void updateLocIfChanged(OpOrBlockArgument *op, Location newLoc) {
 namespace {
 struct StripDebugInfoWithPred
     : public circt::StripDebugInfoWithPredBase<StripDebugInfoWithPred> {
-  StripDebugInfoWithPred(const std::function<bool(mlir::Location)>& pred)
+  StripDebugInfoWithPred(const std::function<bool(mlir::Location)> &pred)
       : pred(pred) {}
   void runOnOperation() override;
 

--- a/lib/Transforms/StripDebugInfoWithPred.cpp
+++ b/lib/Transforms/StripDebugInfoWithPred.cpp
@@ -1,0 +1,86 @@
+//===- StripDebugInfoWithPred.cpp - Strip debug information selectively ---===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+#include "circt/Transforms/Passes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/SmallVector.h"
+
+using namespace mlir;
+
+namespace {
+struct StripDebugInfoWithPred
+    : public circt::StripDebugInfoWithPredBase<StripDebugInfoWithPred> {
+  StripDebugInfoWithPred(std::function<bool(mlir::Location)> pred)
+      : pred(std::move(pred)) {}
+  void runOnOperation() override;
+
+  // Return stripped location for the given `loc`.
+  mlir::Location getStrippedLoc(Location loc) {
+    // If `pred` return true, strip the location.
+    if (pred(loc))
+      return UnknownLoc::get(loc.getContext());
+
+    if (auto fusedLoc = loc.dyn_cast<FusedLoc>()) {
+      SmallVector<mlir::Location> newLocations;
+      newLocations.reserve(fusedLoc.getLocations().size());
+      for (auto loc : fusedLoc.getLocations())
+        newLocations.push_back(getStrippedLoc(loc));
+      return FusedLoc::get(&getContext(), newLocations, fusedLoc.getMetadata());
+    }
+
+    // TODO: Handle other loc type.
+    return loc;
+  }
+
+private:
+  std::function<bool(mlir::Location)> pred = {};
+};
+} // namespace
+
+void StripDebugInfoWithPred::runOnOperation() {
+  // If pred is null and dropSuffix is non-empty, initialize the predicate to
+  // strip file info with that suffix.
+  if (!pred && !dropSuffix.empty()) {
+    pred = [&](mlir::Location loc) {
+      if (auto fileLoc = loc.dyn_cast<FileLineColLoc>())
+        return fileLoc.getFilename().getValue().endswith(dropSuffix);
+      return false;
+    };
+  }
+
+  if (!pred) {
+    getOperation().emitWarning()
+        << "predicate is uninitialized. No debug information is stripped.";
+    return;
+  }
+
+  // TODO: Consider parallelize this.
+  getOperation().walk([&](Operation *op) {
+    op->setLoc(getStrippedLoc(op->getLoc()));
+
+    // Strip block arguments debug info.
+    for (Region &region : op->getRegions()) {
+      for (Block &block : region.getBlocks()) {
+        for (BlockArgument &arg : block.getArguments()) {
+          arg.setLoc(getStrippedLoc(arg.getLoc()));
+        }
+      }
+    }
+  });
+}
+
+namespace circt {
+/// Creates a pass to strip debug information from a function.
+std::unique_ptr<Pass>
+createStripDebugInfoWithPredPass(std::function<bool(mlir::Location)> pred) {
+  return std::make_unique<StripDebugInfoWithPred>(std::move(pred));
+}
+} // namespace circt

--- a/test/Transforms/strip-debuginfo-pred.mlir
+++ b/test/Transforms/strip-debuginfo-pred.mlir
@@ -1,0 +1,13 @@
+// RUN: circt-opt -allow-unregistered-dialect %s -mlir-print-debuginfo -mlir-print-local-scope -pass-pipeline='strip-debuginfo-with-pred{drop-suffix=txt}' | FileCheck %s
+// This test verifies that debug locations are stripped.
+
+// CHECK-LABEL: func @inline_notation
+func.func @inline_notation() {
+  // CHECK: "foo"() : () -> i32 loc(unknown)
+  %1 = "foo"() : () -> i32 loc("foo.txt":0:0)
+
+// CHECK: loc(fused["foo", unknown]) 
+  affine.for %i0 = 0 to 8 {
+  } loc(fused["foo", "foo.txt":10:8]) 
+  return
+}

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -2,7 +2,7 @@
 ; RUN: firtool %s --format=fir --ir-fir --annotation-file %s.anno.json,%s.anno.1.json | circt-opt | FileCheck %s --check-prefix=ANNOTATIONS
 ; RUN: firtool %s --format=fir --ir-fir --annotation-file %s.anno.json --annotation-file %s.anno.1.json | circt-opt | FileCheck %s --check-prefix=ANNOTATIONS
 ; RUN: firtool %s --format=fir --ir-hw | circt-opt | FileCheck %s --check-prefix=MLIRLOWER
-; RUN: firtool %s --format=fir -verilog |             FileCheck %s --check-prefix=VERILOG
+; RUN: firtool %s --format=fir -verilog -strip-fir-debug-info  | FileCheck %s --check-prefix=VERILOG
 ; RUN: firtool %s --annotation-file %s.anno.json,%s.anno.1.json --parse-only | FileCheck %s --check-prefix=ANNOTATIONS
 ; RUN: firtool %s --omir-file %s.omir.anno.json --parse-only | FileCheck %s --check-prefix=OMIR
 ; RUN: firtool %s --omir-file %s.omir.anno.json --output-omir meta.omir.json --verilog | FileCheck %s --check-prefix=OMIROUT
@@ -125,6 +125,8 @@ circuit test_mod : %[[{"a": "a"}]]
 ; ANNOTATIONS-SAME: info = "a ModuleName Annotation"
 
 ; VERILOG-LABEL: module test_mod(
+; Check that a fir location is stripped.
+; VERILOG-NOT:   .fir
 ; VERILOG-NEXT:    input        clock,
 ; VERILOG-NEXT:                 a,
 ; VERILOG-NEXT:    input  [1:0] b,

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -2,7 +2,7 @@
 ; RUN: firtool %s --format=fir --ir-fir --annotation-file %s.anno.json,%s.anno.1.json | circt-opt | FileCheck %s --check-prefix=ANNOTATIONS
 ; RUN: firtool %s --format=fir --ir-fir --annotation-file %s.anno.json --annotation-file %s.anno.1.json | circt-opt | FileCheck %s --check-prefix=ANNOTATIONS
 ; RUN: firtool %s --format=fir --ir-hw | circt-opt | FileCheck %s --check-prefix=MLIRLOWER
-; RUN: firtool %s --format=fir -verilog -strip-fir-debug-info  | FileCheck %s --check-prefix=VERILOG
+; RUN: firtool %s --format=fir -verilog | FileCheck %s --check-prefix=VERILOG
 ; RUN: firtool %s --annotation-file %s.anno.json,%s.anno.1.json --parse-only | FileCheck %s --check-prefix=ANNOTATIONS
 ; RUN: firtool %s --omir-file %s.omir.anno.json --parse-only | FileCheck %s --check-prefix=OMIR
 ; RUN: firtool %s --omir-file %s.omir.anno.json --output-omir meta.omir.json --verilog | FileCheck %s --check-prefix=OMIROUT

--- a/tools/firtool/CMakeLists.txt
+++ b/tools/firtool/CMakeLists.txt
@@ -13,6 +13,7 @@ target_link_libraries(firtool PRIVATE
   CIRCTFIRRTLTransforms
   CIRCTHWTransforms
   CIRCTSVTransforms
+  CIRCTTransforms
 
   MLIRParser
   MLIRSupport

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -338,7 +338,7 @@ static cl::opt<bool>
 static cl::opt<bool> stripFirDebugInfo(
     "strip-fir-debug-info",
     cl::desc("Disable source fir locator information in output Verilog"),
-    cl::init(false), cl::cat(mainCategory));
+    cl::init(true), cl::cat(mainCategory));
 
 static cl::opt<bool> stripDebugInfo(
     "strip-debug-info",

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -25,6 +25,7 @@
 #include "circt/Dialect/SV/SVPasses.h"
 #include "circt/Support/LoweringOptions.h"
 #include "circt/Support/Version.h"
+#include "circt/Transforms/Passes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -334,6 +335,11 @@ static cl::opt<bool>
                           cl::desc("Log executions of toplevel module passes"),
                           cl::init(false), cl::cat(mainCategory));
 
+static cl::opt<bool> stripFirDebugInfo(
+    "strip-fir-debug-info",
+    cl::desc("Disable source fir locator information in output Verilog"),
+    cl::init(false), cl::cat(mainCategory));
+
 static cl::opt<bool> stripDebugInfo(
     "strip-debug-info",
     cl::desc("Disable source locator information in output Verilog"),
@@ -640,6 +646,14 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
       auto &modulePM = exportPm.nest<hw::HWModuleOp>();
       modulePM.addPass(sv::createPrettifyVerilogPass());
     }
+
+    if (stripFirDebugInfo)
+      exportPm.addPass(
+          circt::createStripDebugInfoWithPredPass([](mlir::Location loc) {
+            if (auto fileLoc = loc.dyn_cast<FileLineColLoc>())
+              return fileLoc.getFilename().getValue().endswith(".fir");
+            return false;
+          }));
 
     if (stripDebugInfo)
       exportPm.addPass(mlir::createStripDebugInfoPass());


### PR DESCRIPTION
This implements `-strip-fir-debug-info` option to drop source locators of fir files
just before ExportVerilog emission. The pass `StripDebugInfoWithPred` is similar to [StripDebugInfo
](https://github.com/llvm/llvm-project/blob/main/mlir/lib/Transforms/StripDebugInfo.cpp) pass, but `StripDebugInfoWithPred` selectively strips locations using given predicate.


