### PR TITLE
[LowerToHW] Wrap aynsc reset initiliazation by ifdef

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -2578,7 +2578,10 @@ void FIRRTLLowering::initializeRegister(
         // Merge if op if their reset values are same.
         auto &op = asyncRegPostRandomizationIfOp[{block, resetSignal}];
         if (!op)
-          op = builder.create<sv::IfOp>(resetSignal, [&]() {});
+          builder.create<sv::IfDefProceduralOp>("RANDOMIZE", [&] {
+            op = builder.create<sv::IfOp>(resetSignal, [&]() {});
+          });
+
         runWithInsertionPointAtEndOfBlock(
             [&]() { builder.create<sv::BPAssignOp>(reg, resetValue); },
             op.thenRegion());

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -787,9 +787,11 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT:       sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@InitReg1::@[[RANDOM_3_SYM]]>]}
     // CHECK-NEXT:       sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}};" {symbols = [#hw.innerNameRef<@InitReg1::@[[reg3_sym]]>, #hw.innerNameRef<@InitReg1::@[[RANDOM_3_SYM]]>]}
     // CHECK-NEXT:     }
-    // CHECK-NEXT:     sv.if %reset {
-    // CHECK-NEXT:       sv.bpassign %reg, %c0_i32 : i32
-    // CHECK-NEXT:       sv.bpassign %reg3, %c1_i32 : i32
+    // CHECK-NEXT:     sv.ifdef.procedural "RANDOMIZE"  {
+    // CHECK-NEXT:       sv.if %reset {
+    // CHECK-NEXT:         sv.bpassign %reg, %c0_i32 : i32
+    // CHECK-NEXT:         sv.bpassign %reg3, %c1_i32 : i32
+    // CHECK-NEXT:       }
     // CHECK-NEXT:     }
     // CHECK-NEXT:   }
     // CHECK-NEXT: }


### PR DESCRIPTION
This fixes the difference between SFC and MFC in async initializations.

MFC with the PR:
```
initial begin	// foo.fir:7:5
      `INIT_RANDOM_PROLOG_	// foo.fir:7:5
      `ifdef RANDOMIZE_REG_INIT	// foo.fir:7:5
        _RANDOM = {`RANDOM};	// foo.fir:7:5
        sync_0 = _RANDOM[0];	// foo.fir:7:5
      `endif
      `ifdef RANDOMIZE	// foo.fir:7:5
        if (reset)	// foo.fir:7:5
          sync_0 = 1'h0;	// foo.fir:7:5, :8:24
      `endif
    end // initial
```
SFC:
```
initial begin
  `ifdef RANDOMIZE
    `ifdef INIT_RANDOM
      `INIT_RANDOM
    `endif
    `ifndef VERILATOR
      `ifdef RANDOMIZE_DELAY
        #`RANDOMIZE_DELAY begin end
      `else
        #0.002 begin end
      `endif
    `endif
`ifdef RANDOMIZE_REG_INIT
  _RAND_0 = {1{`RANDOM}};
  sync_0 = _RAND_0[0:0];
`endif // RANDOMIZE_REG_INIT
  if (reset) begin
    sync_0 = 1'h0;
  end
  `endif // RANDOMIZE
end // initial
```