### PR TITLE
[SCFToCalyx] Add special case for pipeline stages with side effects only.

### DIFF
--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -1802,12 +1802,14 @@ class BuildPipelineRegs : public FuncOpPartialLoweringPattern {
         for (auto &use : stageResult.getUses()) {
           unsigned operandNo = use.getOperandNumber();
           if (auto term =
-                  dyn_cast<staticlogic::PipelineTerminatorOp>(use.getOwner());
-              term && operandNo < term.iter_args().size()) {
-            WhileOpInterface whileOp(stage->getParentOp());
-            auto reg = getComponentState().getWhileIterReg(whileOp, operandNo);
-            getComponentState().addPipelineReg(stage, reg, i);
-            isIterArg = true;
+                  dyn_cast<staticlogic::PipelineTerminatorOp>(use.getOwner())) {
+            if (operandNo < term.iter_args().size()) {
+              WhileOpInterface whileOp(stage->getParentOp());
+              auto reg =
+                  getComponentState().getWhileIterReg(whileOp, operandNo);
+              getComponentState().addPipelineReg(stage, reg, i);
+              isIterArg = true;
+            }
           }
         }
         if (isIterArg)

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -1802,14 +1802,12 @@ class BuildPipelineRegs : public FuncOpPartialLoweringPattern {
         for (auto &use : stageResult.getUses()) {
           unsigned operandNo = use.getOperandNumber();
           if (auto term =
-                  dyn_cast<staticlogic::PipelineTerminatorOp>(use.getOwner())) {
-            if (operandNo < term.iter_args().size()) {
-              WhileOpInterface whileOp(stage->getParentOp());
-              auto reg =
-                  getComponentState().getWhileIterReg(whileOp, operandNo);
-              getComponentState().addPipelineReg(stage, reg, i);
-              isIterArg = true;
-            }
+                  dyn_cast<staticlogic::PipelineTerminatorOp>(use.getOwner());
+              term && operandNo < term.iter_args().size()) {
+            WhileOpInterface whileOp(stage->getParentOp());
+            auto reg = getComponentState().getWhileIterReg(whileOp, operandNo);
+            getComponentState().addPipelineReg(stage, reg, i);
+            isIterArg = true;
           }
         }
         if (isIterArg)

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -330,7 +330,7 @@ public:
     operationToGroup[op] = group;
   }
 
-  /// Returns the group registered for this non-pipelined value, and Optional
+  /// Returns the group registered for this non-pipelined value, and None
   /// otherwise.
   template <typename TGroupOp = calyx::GroupInterface>
   Optional<TGroupOp> getNonPipelinedGroupFrom(Operation *op) {
@@ -587,7 +587,9 @@ private:
   /// A mapping between SSA values and the groups which assign them.
   DenseMap<Value, calyx::GroupInterface> valueGroupAssigns;
 
-  /// A mapping between operations and the group to which it was assigned.
+  /// A mapping between operations and the group to which it was assigned. This
+  /// is used for specific corner cases, such as pipeline stages that may not
+  /// actually pipeline any values.
   DenseMap<Operation *, calyx::GroupInterface> operationToGroup;
 
   /// A mapping from return value indexes to return value registers.

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -958,7 +958,7 @@ private:
   template <typename TGroupOp>
   TGroupOp createGroupForOp(PatternRewriter &rewriter, Operation *op) const {
     Block *block = op->getBlock();
-    std::string groupName = getComponentState().getUniqueName(
+    auto groupName = getComponentState().getUniqueName(
         getComponentState().getProgramState().blockName(block));
     return createGroup<TGroupOp>(rewriter, getComponentState().getComponentOp(),
                                  op->getLoc(), groupName);
@@ -1800,13 +1800,12 @@ class BuildPipelineRegs : public FuncOpPartialLoweringPattern {
         Value stageResult = stage.getResult(i);
         bool isIterArg = false;
         for (auto &use : stageResult.getUses()) {
-          unsigned operandNo = use.getOperandNumber();
           if (auto term =
                   dyn_cast<staticlogic::PipelineTerminatorOp>(use.getOwner())) {
-            if (operandNo < term.iter_args().size()) {
+            if (use.getOperandNumber() < term.iter_args().size()) {
               WhileOpInterface whileOp(stage->getParentOp());
-              auto reg =
-                  getComponentState().getWhileIterReg(whileOp, operandNo);
+              auto reg = getComponentState().getWhileIterReg(
+                  whileOp, use.getOperandNumber());
               getComponentState().addPipelineReg(stage, reg, i);
               isIterArg = true;
             }

--- a/test/Conversion/SCFToCalyx/convert_pipeline.mlir
+++ b/test/Conversion/SCFToCalyx/convert_pipeline.mlir
@@ -238,4 +238,3 @@ module {
     return
   }
 }
-

--- a/test/Conversion/SCFToCalyx/convert_pipeline.mlir
+++ b/test/Conversion/SCFToCalyx/convert_pipeline.mlir
@@ -202,7 +202,8 @@ func.func @dot(%arg0: memref<64xi32>, %arg1: memref<64xi32>) -> i32 {
 // CHECK:       calyx.comb_group @[[COND_GROUP:.+]] {
 // CHECK:       calyx.group @[[LOAD_GROUP:.+]] {
 // CHECK:       calyx.group @[[INCR_GROUP:.+]] {
-// CHECK:       calyx.group @[[STORE_GROUP:.+]] {
+// CHECK:       calyx.group @[[STORE_GROUP1:.+]] {
+// CHECK:       calyx.group @[[STORE_GROUP2:.+]] {
 // CHECK-DAG:         calyx.assign %[[SLICE0_IN]] = %[[ITER_ARG0_OUT]]
 // CHECK-DAG:         calyx.assign %[[MEM1_WRITE_DATA]] = %[[S0_REG0_OUT]]
 // CHECK-DAG:         calyx.assign %[[MEM1_ADDR]] = %[[SLICE0_OUT]]
@@ -213,7 +214,8 @@ func.func @dot(%arg0: memref<64xi32>, %arg1: memref<64xi32>) -> i32 {
 // CHECK-NEXT: calyx.par {
 // CHECK-NEXT: calyx.enable @[[LOAD_GROUP]]
 // CHECK-NEXT: calyx.enable @[[INCR_GROUP]]
-// CHECK-NEXT: calyx.enable @[[STORE_GROUP]]
+// CHECK-NEXT: calyx.enable @[[STORE_GROUP1]]
+// CHECK-NEXT: calyx.enable @[[STORE_GROUP2]]
 // CHECK-NEXT: }
 module {
   func.func @store(%arg0: memref<4xi32>, %arg1: memref<4xi32>) {
@@ -230,6 +232,7 @@ module {
         staticlogic.pipeline.register %1, %2 : i32, index
       } : i32, index
       staticlogic.pipeline.stage start = 1 {
+        memref.store %0#0, %arg1[%arg2] : memref<4xi32>
         memref.store %0#0, %arg1[%arg2] : memref<4xi32>
         staticlogic.pipeline.register
       }

--- a/test/Conversion/SCFToCalyx/convert_pipeline.mlir
+++ b/test/Conversion/SCFToCalyx/convert_pipeline.mlir
@@ -193,9 +193,9 @@ func.func @dot(%arg0: memref<64xi32>, %arg1: memref<64xi32>) -> i32 {
 
 // CHECK:       calyx.component @store({{.+}}, {{.+}}, {{.+}}, %[[MEM1_DONE:.+]]: i1 {mem = {id = 1 : i32, tag = "done"}}, {{.+}}) -> ({{.+}}, %[[MEM1_WRITE_DATA:.+]]: i32 {mem = {id = 1 : i32, tag = "write_data"}}, %[[MEM1_ADDR0:.+]]: i2 {mem = {addr_idx = 0 : i32, id = 1 : i32, tag = "addr"}}, %[[MEM1_WRITE_EN:.+]]: i1 {mem = {id = 1 : i32, tag = "write_en"}}, {{.+}}) {
 // CHECK-DAG:     %[[SLICE0_IN:.+]], %[[SLICE0_OUT:.+]] = calyx.std_slice @std_slice_0
-// CHECK-DAG:     %[[S0_REG0_IN:.+]], %[[S0_REG0_EN:.+]], {{.+}}, {{.+}}, %[[S0_REG0_OUT:.+]], %[[S0_REG0_DONE:.+]] = calyx.register @stage_0_register_0_reg
-// CHECK-DAG:     %[[ITER_ARG0_IN:.+]], %[[ITER_ARG0_EN:.+]], {{.+}}, {{.+}}, %[[ITER_ARG0_OUT:.+]], %[[ITER_ARG0_DONE:.+]] = calyx.register @while_0_arg0_reg
-// CHECK-DAG:     %[[LT_LEFT:.+]], %[[LT_RIGHT:.+]], %[[LT_OUT:.+]] = calyx.std_lt
+// CHECK-DAG:     {{.+}}, {{.+}}, {{.+}}, {{.+}}, %[[S0_REG0_OUT:.+]], {{.+}} = calyx.register @stage_0_register_0_reg
+// CHECK-DAG:     {{.+}}, {{.+}}, {{.+}}, {{.+}}, %[[ITER_ARG0_OUT:.+]], {{.+}} = calyx.register @while_0_arg0_reg
+// CHECK-DAG:     {{.+}}, {{.+}}, %[[LT_OUT:.+]] = calyx.std_lt
 // CHECK-DAG:     %[[TRUE:.+]] = hw.constant true
 
 // CHECK:       calyx.group @[[INIT_GROUP:.+]] {

--- a/test/Conversion/SCFToCalyx/convert_pipeline.mlir
+++ b/test/Conversion/SCFToCalyx/convert_pipeline.mlir
@@ -137,7 +137,7 @@ func.func @minimal() {
 // CHECK-NEXT:            calyx.enable @[[S0_GROUP2]]
 // CHECK-NEXT:            calyx.enable @[[S1_GROUP0]]
 // CHECK-NEXT:          }
-// CHECK-NEXT:          calyx.while %std_lt_0.out with @bb0_0  {
+// CHECK-NEXT:          calyx.while %[[LT_OUT]] with @[[COND_GROUP]]  {
 // CHECK-NEXT:            calyx.par  {
 // CHECK-NEXT:              calyx.enable @[[S0_GROUP0]]
 // CHECK-NEXT:              calyx.enable @[[S0_GROUP1]]
@@ -185,3 +185,57 @@ func.func @dot(%arg0: memref<64xi32>, %arg1: memref<64xi32>) -> i32 {
   }
   return %0 : i32
 }
+
+// -----
+
+// Verify that independent store operations are still pipelined.
+// See: https://github.com/llvm/circt/issues/3112
+
+// CHECK:       calyx.component @store({{.+}}, {{.+}}, {{.+}}, %[[MEM1_DONE:.+]]: i1 {mem = {id = 1 : i32, tag = "done"}}, {{.+}}) -> ({{.+}}, %[[MEM1_WRITE_DATA:.+]]: i32 {mem = {id = 1 : i32, tag = "write_data"}}, %[[MEM1_ADDR0:.+]]: i2 {mem = {addr_idx = 0 : i32, id = 1 : i32, tag = "addr"}}, %[[MEM1_WRITE_EN:.+]]: i1 {mem = {id = 1 : i32, tag = "write_en"}}, {{.+}}) {
+// CHECK-DAG:     %[[SLICE0_IN:.+]], %[[SLICE0_OUT:.+]] = calyx.std_slice @std_slice_0
+// CHECK-DAG:     %[[S0_REG0_IN:.+]], %[[S0_REG0_EN:.+]], {{.+}}, {{.+}}, %[[S0_REG0_OUT:.+]], %[[S0_REG0_DONE:.+]] = calyx.register @stage_0_register_0_reg
+// CHECK-DAG:     %[[ITER_ARG0_IN:.+]], %[[ITER_ARG0_EN:.+]], {{.+}}, {{.+}}, %[[ITER_ARG0_OUT:.+]], %[[ITER_ARG0_DONE:.+]] = calyx.register @while_0_arg0_reg
+// CHECK-DAG:     %[[LT_LEFT:.+]], %[[LT_RIGHT:.+]], %[[LT_OUT:.+]] = calyx.std_lt
+// CHECK-DAG:     %[[TRUE:.+]] = hw.constant true
+
+// CHECK:       calyx.group @[[INIT_GROUP:.+]] {
+// CHECK:       calyx.comb_group @[[COND_GROUP:.+]] {
+// CHECK:       calyx.group @[[LOAD_GROUP:.+]] {
+// CHECK:       calyx.group @[[INCR_GROUP:.+]] {
+// CHECK:       calyx.group @[[STORE_GROUP:.+]] {
+// CHECK-DAG:         calyx.assign %[[SLICE0_IN]] = %[[ITER_ARG0_OUT]]
+// CHECK-DAG:         calyx.assign %[[MEM1_WRITE_DATA]] = %[[S0_REG0_OUT]]
+// CHECK-DAG:         calyx.assign %[[MEM1_ADDR]] = %[[SLICE0_OUT]]
+// CHECK-DAG:         calyx.assign %[[MEM1_WRITE_EN]] = %[[TRUE]]
+// CHECK-DAG:         calyx.group_done %[[MEM1_DONE]]
+
+// CHECK: calyx.while %[[LT_OUT]] with @[[COND_GROUP]] {
+// CHECK-NEXT: calyx.par {
+// CHECK-NEXT: calyx.enable @[[LOAD_GROUP]]
+// CHECK-NEXT: calyx.enable @[[INCR_GROUP]]
+// CHECK-NEXT: calyx.enable @[[STORE_GROUP]]
+// CHECK-NEXT: }
+module {
+  func.func @store(%arg0: memref<4xi32>, %arg1: memref<4xi32>) {
+    %c0 = arith.constant 0 : index
+    %c4 = arith.constant 4 : index
+    %c1 = arith.constant 1 : index
+    staticlogic.pipeline.while II =  1 trip_count =  4 iter_args(%arg2 = %c0) : (index) -> () {
+      %0 = arith.cmpi ult, %arg2, %c4 : index
+      staticlogic.pipeline.register %0 : i1
+    } do {
+      %0:2 = staticlogic.pipeline.stage start = 0 {
+        %1 = memref.load %arg0[%arg2] : memref<4xi32>
+        %2 = arith.addi %arg2, %c1 : index
+        staticlogic.pipeline.register %1, %2 : i32, index
+      } : i32, index
+      staticlogic.pipeline.stage start = 1 {
+        memref.store %0#0, %arg1[%arg2] : memref<4xi32>
+        staticlogic.pipeline.register
+      }
+      staticlogic.pipeline.terminator iter_args(%0#1), results() : (index) -> ()
+    }
+    return
+  }
+}
+


### PR DESCRIPTION
This is a hot fix for memref::StoreOps to be used unconditionally in a pipeline stage. I'm not really convinced this is the best approach, however I'm also hesitant to commit to any large-scale changes before we separate {SCF, StaticLogic}ToCalyx conversions.

Closes #3112, #3111. 