### PR TITLE
[CalyxToFSM] Initial Calyx-to-FSM control schedule lowering

### DIFF
--- a/include/circt/Conversion/CalyxToFSM.h
+++ b/include/circt/Conversion/CalyxToFSM.h
@@ -1,0 +1,32 @@
+//===- CalyxToFSM.h - Calyx to FSM conversion pass --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares passes which lowers a Calyx control schedule to an FSM
+// representation.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_CONVERSION_CALYXTOFSM_CALYXTOFSM_H
+#define CIRCT_CONVERSION_CALYXTOFSM_CALYXTOFSM_H
+
+#include "circt/Dialect/Calyx/CalyxOps.h"
+#include "circt/Dialect/FSM/FSMOps.h"
+#include "circt/Support/LLVM.h"
+#include <memory>
+
+namespace mlir {
+class Pass;
+} // namespace mlir
+
+namespace circt {
+
+std::unique_ptr<mlir::Pass> createCalyxToFSMPass();
+
+} // namespace circt
+
+#endif // CIRCT_CONVERSION_CALYXTOFSM_CALYXTOFSM_H

--- a/include/circt/Conversion/Passes.h
+++ b/include/circt/Conversion/Passes.h
@@ -14,6 +14,7 @@
 #define CIRCT_CONVERSION_PASSES_H
 
 #include "circt/Conversion/AffineToStaticLogic.h"
+#include "circt/Conversion/CalyxToFSM.h"
 #include "circt/Conversion/CalyxToHW.h"
 #include "circt/Conversion/ExportVerilog.h"
 #include "circt/Conversion/FIRRTLToHW.h"

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -133,6 +133,19 @@ def CalyxToHW : Pass<"lower-calyx-to-hw", "mlir::ModuleOp"> {
 }
 
 //===----------------------------------------------------------------------===//
+// CalyxToFSM
+//===----------------------------------------------------------------------===//
+
+def CalyxToFSM : Pass<"lower-calyx-to-fsm", "calyx::ComponentOp"> {
+  let summary = "Lower Calyx to FSM";
+  let description = [{
+    This pass lowers a Calyx control schedule to an FSM representation.
+  }];
+  let constructor = "circt::createCalyxToFSMPass()";
+  let dependentDialects = ["fsm::FSMDialect", "comb::CombDialect"];
+}
+
+//===----------------------------------------------------------------------===//
 // FIRRTLToHW
 //===----------------------------------------------------------------------===//
 

--- a/include/circt/Dialect/Calyx/CalyxPasses.h
+++ b/include/circt/Dialect/Calyx/CalyxPasses.h
@@ -27,6 +27,7 @@ std::unique_ptr<mlir::Pass> createRemoveGroupsPass();
 std::unique_ptr<mlir::Pass> createClkInsertionPass();
 std::unique_ptr<mlir::Pass> createResetInsertionPass();
 std::unique_ptr<mlir::Pass> createGroupInvariantCodeMotionPass();
+std::unique_ptr<mlir::Pass> createMaterializeFSMPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/Calyx/CalyxPasses.td
+++ b/include/circt/Dialect/Calyx/CalyxPasses.td
@@ -116,4 +116,19 @@ def GoInsertion : Pass<"calyx-go-insertion", "calyx::ComponentOp"> {
   let constructor = "circt::calyx::createGoInsertionPass()";
 }
 
+def MaterializeFSM : Pass<"calyx-materialize-fsm", "calyx::ComponentOp"> {
+  let summary = "Materializes an FSM embedded inside the control of this Calyx component.";
+  let description = [{
+    Materializes the FSM in the control of the component. This materializes the
+    top-level I/O of the FSM to receive `group_done` signals as input and
+    `group_go` signals as output, based on the `calyx.enable` operations
+    used within the states of the FSM.
+    Each transition of the FSM is predicated on the enabled groups within a
+    state being done, or, for static groups, a separate sub-FSM is instantiated
+    to await the group finishing.
+  }];
+  let dependentDialects = ["comb::CombDialect", "hw::HWDialect", "fsm::FSMDialect"];
+  let constructor = "circt::calyx::createMaterializeFSMPass()";
+}
+
 #endif // CIRCT_DIALECT_CALYX_CALYXPASSES_TD

--- a/include/circt/Dialect/FSM/FSMOps.td
+++ b/include/circt/Dialect/FSM/FSMOps.td
@@ -15,8 +15,8 @@ include "mlir/Interfaces/ControlFlowInterfaces.td"
 
 def HasCustomSSAName : DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>;
 
-def MachineOp : FSMOp<"machine", [HasParent<"mlir::ModuleOp">, FunctionOpInterface,
-      Symbol, SymbolTable, IsolatedFromAbove, NoTerminator]> {
+def MachineOp : FSMOp<"machine", [FunctionOpInterface,
+      Symbol, SymbolTable, NoTerminator]> {
   let summary = "Define a finite-state machine";
   let description = [{
     `fsm.machine` represents a finite-state machine, including a machine name,
@@ -65,6 +65,7 @@ def MachineOp : FSMOp<"machine", [HasParent<"mlir::ModuleOp">, FunctionOpInterfa
     }
   }];
 
+  let skipDefaultBuilders = 1;
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
 }
@@ -158,6 +159,17 @@ def StateOp : FSMOp<"state", [HasParent<"MachineOp">, Symbol,
   let assemblyFormat = [{
     $sym_name attr-dict `output` $output `transitions` $transitions
   }];
+
+  let extraClassDeclaration = [{
+    /// Returns all possible next states from this state.
+    llvm::SetVector<StateOp> getNextStates();
+  }];
+
+  let builders = [
+    OpBuilder<(ins "StringRef":$stateName)>
+  ];
+
+  let skipDefaultBuilders = 1;
 }
 
 def OutputOp : FSMOp<"output", [HasParent<"StateOp">, ReturnLike, Terminator]> {
@@ -226,6 +238,12 @@ def TransitionOp : FSMOp<"transition", [HasParent<"StateOp">,
     bool isAlwaysTaken();
   }];
 
+  let builders = [
+    OpBuilder<(ins "StringRef":$nextState)>,
+    OpBuilder<(ins "fsm::StateOp":$nextState)>
+  ];
+
+  let skipDefaultBuilders = 1;
   let hasVerifier = 1;
 }
 
@@ -237,10 +255,13 @@ def ReturnOp : FSMOp<"return", [HasParent<"TransitionOp">, ReturnLike,
     values if the parent region is a `$guard` region.
   }];
 
+  let extraClassDeclaration = [{
+    // Assigns the guard operand to the provided value.
+    void setOperand(Value operand);
+  }];
+
   let arguments = (ins Optional<I1>:$operand);
-
   let builders = [ OpBuilder<(ins), "build($_builder, $_state, Value());"> ];
-
   let assemblyFormat = [{ attr-dict ($operand^)? }];
 }
 

--- a/include/circt/Dialect/FSM/Passes.td
+++ b/include/circt/Dialect/FSM/Passes.td
@@ -15,7 +15,7 @@
 
 include "mlir/Pass/PassBase.td"
 
-def PrintFSMGraph : Pass<"fsm-print-graph", "circt::fsm::MachineOp"> {
+def PrintFSMGraph : Pass<"fsm-print-graph", "mlir::ModuleOp"> {
   let summary = "Print a DOT graph of the module hierarchy.";
   let constructor =  "circt::fsm::createPrintFSMGraphPass()";
 }

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(AffineToStaticLogic)
+add_subdirectory(CalyxToFSM)
 add_subdirectory(CalyxToHW)
 add_subdirectory(ExportVerilog)
 add_subdirectory(FIRRTLToHW)

--- a/lib/Conversion/CalyxToFSM/CMakeLists.txt
+++ b/lib/Conversion/CalyxToFSM/CMakeLists.txt
@@ -1,0 +1,21 @@
+add_circt_library(CIRCTCalyxToFSM
+  CalyxToFSM.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/CalyxToFSM
+
+  DEPENDS
+  CIRCTConversionPassIncGen
+
+  LINK_COMPONENTS
+  Core
+
+  LINK_LIBS PUBLIC
+  CIRCTCalyx
+  CIRCTFSM
+  MLIRIR
+  MLIRPass
+  MLIRFunc
+  MLIRSupport
+  MLIRTransforms
+  )

--- a/lib/Conversion/CalyxToFSM/CalyxToFSM.cpp
+++ b/lib/Conversion/CalyxToFSM/CalyxToFSM.cpp
@@ -1,0 +1,325 @@
+//===- CalyxToFSM.cpp - Calyx to FSM conversion pass ----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===----------------------------------------------------------------------===//
+//
+// This is the main Calyx control to FSM Conversion Pass Implementation.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Conversion/CalyxToFSM.h"
+#include "../PassDetail.h"
+#include "circt/Dialect/Calyx/CalyxOps.h"
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/FSM/FSMDialect.h"
+#include "circt/Dialect/FSM/FSMGraph.h"
+#include "circt/Dialect/FSM/FSMOps.h"
+#include "circt/Support/Namespace.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace mlir;
+using namespace circt;
+using namespace calyx;
+using namespace fsm;
+using namespace sv;
+
+namespace {
+
+class CompileFSMVisitor {
+public:
+  CompileFSMVisitor(SymbolCache &sc, FSMGraph &graph)
+      : graph(graph), sc(sc), ctx(graph.getMachine().getContext()),
+        builder(graph.getMachine().getContext()) {
+    ns.add(sc);
+  }
+
+  /// Lowers the provided 'op' into a new FSM StateOp.
+  LogicalResult dispatch(StateOp currentState, Operation *op,
+                         StateOp nextState) {
+    return TypeSwitch<Operation *, LogicalResult>(op)
+        .template Case<SeqOp, EnableOp, IfOp, WhileOp>(
+            [&](auto opNode) { return visit(currentState, opNode, nextState); })
+        .Default([&](auto) {
+          return op->emitError() << "Operation '" << op->getName()
+                                 << "' not supported for FSM compilation";
+        });
+  }
+
+  ArrayRef<Attribute> getCompiledGroups() { return compiledGroups; }
+
+private:
+  /// Operation visitors;
+  /// Apart from the visited operation, a visitor is provided with two extra
+  /// arguments:
+  /// currentState:
+  ///   This represents a state which the callee has allocated to this visitor;
+  ///   the visitor is free to use this state to its liking.
+  /// nextState:
+  ///   This represent the next state which this visitor eventually must
+  ///   transition to.
+  LogicalResult visit(StateOp currentState, SeqOp, StateOp nextState);
+  LogicalResult visit(StateOp currentState, EnableOp, StateOp nextState);
+  LogicalResult visit(StateOp currentState, IfOp, StateOp nextState);
+  LogicalResult visit(StateOp currentState, WhileOp, StateOp nextState);
+
+  /// StateScopeGuards represent unique state name scopes generated from pushing
+  /// states onto the state stack. The guard carries a unique name as well as
+  /// managing the lifetime of suffixes on the state stack.
+  struct StateScopeGuard {
+  public:
+    StateScopeGuard(CompileFSMVisitor &visitor, StringRef name,
+                    StringRef suffix)
+        : visitor(visitor), name(name) {
+      visitor.stateStack.push_back(suffix.str());
+    }
+    ~StateScopeGuard() {
+      assert(!visitor.stateStack.empty());
+      visitor.stateStack.pop_back();
+    }
+
+    StringRef getName() { return name; }
+
+  private:
+    CompileFSMVisitor &visitor;
+    std::string name;
+  };
+
+  /// Generates a new state name based on the current state stack and the
+  /// provided suffix. The new suffix is pushed onto the state stack. Returns a
+  /// guard object which pops the new suffix upon destruction.
+  StateScopeGuard pushStateScope(StringRef suffix) {
+    std::string name;
+    llvm::raw_string_ostream ss(name);
+    llvm::interleave(
+        stateStack, ss, [&](const auto &it) { ss << it; }, "_");
+    name += +"_" + suffix.str();
+    return StateScopeGuard(*this, ns.newName(name), suffix);
+  }
+
+  FSMGraph &graph;
+  SymbolCache &sc;
+  MLIRContext *ctx;
+  OpBuilder builder;
+  Namespace ns;
+  SmallVector<std::string, 4> stateStack;
+
+  /// Maintain the set of compiled groups within this FSM, to pass Calyx
+  /// verifiers.
+  SmallVector<Attribute, 8> compiledGroups;
+};
+
+LogicalResult CompileFSMVisitor::visit(StateOp currentState, IfOp ifOp,
+                                       StateOp nextState) {
+  auto stateGuard = pushStateScope("if");
+  auto loc = ifOp.getLoc();
+
+  // Rename the current state now that we know it's an if header.
+  graph.renameState(currentState, stateGuard.getName());
+
+  auto lowerBranch = [&](Value cond, StringRef nextStateSuffix, bool invert,
+                         Operation *innerBranchOp) {
+    auto branchStateGuard = pushStateScope(nextStateSuffix);
+    auto branchStateOp =
+        graph.createState(builder, ifOp.getLoc(), branchStateGuard.getName())
+            ->getState();
+
+    auto transitionOp = graph
+                            .createTransition(builder, ifOp.getLoc(),
+                                              currentState, branchStateOp)
+                            ->getTransition();
+    auto guardReturnOp = transitionOp.getGuardReturn();
+    builder.setInsertionPoint(guardReturnOp);
+    Value branchTaken = cond;
+    if (invert) {
+      OpBuilder::InsertionGuard g(builder);
+      branchTaken = comb::createOrFoldNot(loc, branchTaken, builder);
+    }
+
+    guardReturnOp.setOperand(branchTaken);
+
+    // Recurse into the body of the branch, with an exit state targeting
+    // 'nextState'.
+    if (failed(dispatch(branchStateOp, innerBranchOp, nextState)))
+      return failure();
+    return success();
+  };
+
+  // Then branch.
+  if (failed(lowerBranch(ifOp.cond(), "then", false,
+                         &ifOp.getThenBody()->front())))
+    return failure();
+
+  // Else branch.
+  FailureOr<Value> elseRes;
+  if (ifOp.elseBodyExists()) {
+    if (failed(lowerBranch(ifOp.cond(), "else", true,
+                           &ifOp.getElseBody()->front())))
+      return failure();
+  }
+
+  return success();
+}
+
+LogicalResult CompileFSMVisitor::visit(StateOp currentState, SeqOp seqOp,
+                                       StateOp nextState) {
+  Location loc = seqOp.getLoc();
+  auto seqStateGuard = pushStateScope("seq");
+
+  // Create a new state for each nested operation within this seqOp.
+  auto &seqOps = seqOp.getBody()->getOperations();
+  llvm::SmallVector<std::pair<Operation *, StateOp>> seqStates;
+
+  // Iterate over the operations within the sequence. We do this in reverse
+  // order to ensure that we always know the next state.
+  // Note: not using llvm::enumerate here since it isnt a bidirectional
+  // iterator.
+  StateOp currentOpNextState = nextState;
+  int n = seqOps.size() - 1;
+  for (auto &op : llvm::reverse(*seqOp.getBody())) {
+    auto subStateGuard = pushStateScope(std::to_string(n--));
+    auto thisStateOp =
+        graph.createState(builder, op.getLoc(), subStateGuard.getName())
+            ->getState();
+    seqStates.insert(seqStates.begin(), {&op, thisStateOp});
+    sc.addSymbol(thisStateOp);
+
+    // Recurse into the current operation.
+    if (failed(dispatch(thisStateOp, &op, currentOpNextState)))
+      return failure();
+
+    // This state is now the next state for the following operation.
+    currentOpNextState = thisStateOp;
+  }
+
+  // Make 'currentState' transition directly the first state in the sequence.
+  graph.createTransition(builder, loc, currentState, seqStates.front().second);
+
+  return success();
+}
+
+LogicalResult CompileFSMVisitor::visit(StateOp currentState, WhileOp whileOp,
+                                       StateOp nextState) {
+  OpBuilder::InsertionGuard g(builder);
+  auto whileStateGuard = pushStateScope("while");
+  auto loc = whileOp.getLoc();
+
+  // The current state is the while header (branch to whileOp or nextState).
+  // Rename the current state now that we know it's a while header state.
+  StateOp whileHeaderState = currentState;
+  graph.renameState(whileHeaderState,
+                    (whileStateGuard.getName() + "_header").str());
+  sc.addSymbol(whileHeaderState);
+
+  // Dispatch into the while body. The while body will always return to the
+  // header.
+  auto whileBodyEntryState =
+      graph
+          .createState(builder, loc,
+                       (whileStateGuard.getName() + "_entry").str())
+          ->getState();
+  sc.addSymbol(whileBodyEntryState);
+  Operation *whileBodyOp = &whileOp.getBody()->front();
+  if (failed(dispatch(whileBodyEntryState, whileBodyOp, whileHeaderState)))
+    return failure();
+
+  // Create transitions to either the while body or the next state based on the
+  // while condition.
+  auto bodyTransition =
+      graph
+          .createTransition(builder, loc, whileHeaderState, whileBodyEntryState)
+          ->getTransition();
+  auto nextStateTransition =
+      graph.createTransition(builder, loc, whileHeaderState, nextState)
+          ->getTransition();
+
+  bodyTransition.getGuardReturn().setOperand(whileOp.cond());
+  builder.setInsertionPoint(nextStateTransition.getGuardReturn());
+  nextStateTransition.getGuardReturn().setOperand(
+      comb::createOrFoldNot(loc, whileOp.cond(), builder));
+  return success();
+}
+
+LogicalResult CompileFSMVisitor::visit(StateOp currentState, EnableOp enableOp,
+                                       StateOp nextState) {
+  assert(currentState &&
+         "Expected this enableOp to be nested into some provided state");
+
+  // Rename the current state now that we know it's an enable state.
+  auto enableStateGuard = pushStateScope(enableOp.groupName());
+  graph.renameState(currentState, enableStateGuard.getName());
+
+  // Create a new calyx.enable in the output state referencing the enabled
+  // group. We create a new op here as opposed to moving the existing, to make
+  // callers iterating over nested ops safer.
+  OpBuilder::InsertionGuard g(builder);
+  builder.setInsertionPointToStart(&currentState.output().front());
+  builder.create<calyx::EnableOp>(enableOp.getLoc(), enableOp.groupName());
+
+  if (nextState)
+    graph.createTransition(builder, enableOp.getLoc(), currentState, nextState);
+
+  // Append this group to the set of compiled groups.
+  compiledGroups.push_back(
+      SymbolRefAttr::get(builder.getContext(), enableOp.groupName()));
+
+  return success();
+}
+
+class CalyxToFSMPass : public CalyxToFSMBase<CalyxToFSMPass> {
+public:
+  void runOnOperation() override;
+}; // end anonymous namespace
+
+void CalyxToFSMPass::runOnOperation() {
+  ComponentOp component = getOperation();
+  OpBuilder builder(&getContext());
+  auto ctrlOp = component.getControlOp();
+  assert(ctrlOp.getBody()->getOperations().size() == 1 &&
+         "Expected a single top-level operation in the schedule");
+  Operation &topLevelCtrlOp = ctrlOp.getBody()->front();
+  builder.setInsertionPoint(&topLevelCtrlOp);
+
+  // Create a side-effect-only FSM (no inputs, no outputs) which will strictly
+  // refer to the symbols and SSA values defined in the regions of the
+  // ComponentOp. This makes for an intermediate step, which allows for
+  // outlining the FSM (materializing FSM I/O) at a later point.
+  auto funcType = FunctionType::get(&getContext(), {}, {});
+  auto machine = builder.create<MachineOp>(
+      ctrlOp.getLoc(), "control", "fsm_entry", builder.getI1Type(), funcType);
+  auto graph = FSMGraph(machine);
+
+  SymbolCache sc;
+  sc.addDefinitions(machine);
+
+  // Create entry and exit states
+  auto entryState =
+      graph.createState(builder, ctrlOp.getLoc(), "fsm_entry")->getState();
+  auto exitState =
+      graph.createState(builder, ctrlOp.getLoc(), "fsm_exit")->getState();
+
+  auto visitor = CompileFSMVisitor(sc, graph);
+  auto res = visitor.dispatch(entryState, &topLevelCtrlOp, exitState);
+
+  if (failed(res)) {
+    signalPassFailure();
+    return;
+  }
+
+  // Remove the top-level calyx control operation that we've now converted to an
+  // FSM.
+  topLevelCtrlOp.erase();
+
+  // Add the set of compiled groups as an attribute to the fsm.
+  machine->setAttr(
+      "compiledGroups",
+      ArrayAttr::get(builder.getContext(), visitor.getCompiledGroups()));
+}
+
+} // namespace
+
+std::unique_ptr<mlir::Pass> circt::createCalyxToFSMPass() {
+  return std::make_unique<CalyxToFSMPass>();
+}

--- a/lib/Conversion/PassDetail.h
+++ b/lib/Conversion/PassDetail.h
@@ -43,8 +43,13 @@ class FuncOp;
 
 namespace circt {
 
+namespace fsm {
+class FSMDialect;
+} // namespace fsm
+
 namespace calyx {
 class CalyxDialect;
+class ComponentOp;
 } // namespace calyx
 
 namespace firrtl {

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -179,6 +179,13 @@ LogicalResult calyx::verifyCell(Operation *op) {
 
 LogicalResult calyx::verifyControlLikeOp(Operation *op) {
   auto parent = op->getParentOp();
+
+  if (isa<calyx::EnableOp>(op) &&
+      !isa<calyx::CalyxDialect>(parent->getDialect())) {
+    // calyx.enable mixed with other dialects; anything goes.
+    return success();
+  }
+
   if (!hasControlRegion(parent))
     return op->emitOpError()
            << "has parent: " << parent

--- a/lib/Dialect/Calyx/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Calyx/Transforms/CMakeLists.txt
@@ -6,6 +6,7 @@ add_circt_dialect_library(CIRCTCalyxTransforms
   RemoveGroups.cpp
   CalyxHelpers.cpp
   CalyxLoweringUtils.cpp
+  MaterializeFSM.cpp
 
   DEPENDS
   CIRCTCalyxTransformsIncGen

--- a/lib/Dialect/Calyx/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Calyx/Transforms/CMakeLists.txt
@@ -16,6 +16,7 @@ add_circt_dialect_library(CIRCTCalyxTransforms
   CIRCTComb
   CIRCTHW
   CIRCTSupport
+  CIRCTFSM
   MLIRIR
   MLIRPass
   MLIRTransformUtils

--- a/lib/Dialect/Calyx/Transforms/MaterializeFSM.cpp
+++ b/lib/Dialect/Calyx/Transforms/MaterializeFSM.cpp
@@ -1,0 +1,131 @@
+//===- MaterializeFSM.cpp - FSM Outlining Pass ------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Contains the definitions of the FSM materialization pass.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/Calyx/CalyxOps.h"
+#include "circt/Dialect/Calyx/CalyxPasses.h"
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OperationSupport.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/Debug.h"
+
+using namespace circt;
+using namespace calyx;
+using namespace mlir;
+
+namespace {
+
+struct MaterializeFSMPass : public MaterializeFSMBase<MaterializeFSMPass> {
+  void runOnOperation() override;
+};
+
+} // end anonymous namespace
+
+void MaterializeFSMPass::runOnOperation() {
+  ComponentOp component = getOperation();
+  auto *ctx = &getContext();
+  auto controlOp = component.getControlOp();
+  auto machineOp =
+      dyn_cast_or_null<fsm::MachineOp>(controlOp.getBody()->front());
+  if (!machineOp) {
+    controlOp.emitOpError()
+        << "expected an `fsm.machine` operation as the top-level operation "
+           "within the control region of this component";
+    signalPassFailure();
+    return;
+  }
+
+  OpBuilder builder(ctx);
+
+  // Commonly used constants.
+  builder.setInsertionPointToStart(&machineOp.getBody().front());
+  auto c1 = builder.create<hw::ConstantOp>(machineOp.getLoc(),
+                                           builder.getI1Type(), 1);
+  auto c0 = builder.create<hw::ConstantOp>(machineOp.getLoc(),
+                                           builder.getI1Type(), 0);
+
+  // Walk the states of the machine and gather the relation between states and
+  // the groups which they enable as well as the set of all enabled states.
+  DenseMap<fsm::StateOp, DenseSet<Attribute>> stateEnables;
+  DenseSet<StringAttr> allEnabledGroups;
+
+  for (auto stateOp : machineOp.getOps<fsm::StateOp>()) {
+    for (auto enableOp : llvm::make_early_inc_range(
+             stateOp.output().getOps<calyx::EnableOp>())) {
+      stateEnables[stateOp].insert(enableOp.groupNameAttr().getAttr());
+      allEnabledGroups.insert(enableOp.groupNameAttr().getAttr());
+      // Erase the enable op now that we've recorded the information.
+      enableOp.erase();
+    }
+  }
+
+  // Create a new fsm.machine to include the materialized I/O ports. We must
+  // create a new operation, since an fsm.machine with type () -> () does _not_
+  // have an operand storage, and an operand storage can only be allocated on
+  // construction.
+  SmallVector<Type> IOTypes =
+      SmallVector<Type>(allEnabledGroups.size(), builder.getI1Type());
+  machineOp.setType(builder.getFunctionType(IOTypes, IOTypes));
+  assert(machineOp.getBody().getNumArguments() == 0 &&
+         "expected no inputs to the FSM");
+  machineOp.getBody().addArguments(
+      IOTypes,
+      SmallVector<Location, 4>(IOTypes.size(), builder.getUnknownLoc()));
+
+  // Build output assignments and transition guards in every state. We here
+  // assume that the ordering of states in allEnabledGroups is fixed, since it
+  // is used as an analogue for port I/O ordering.
+  for (auto stateOp : machineOp.getOps<fsm::StateOp>()) {
+    llvm::SmallVector<Value> operands;
+    llvm::SmallVector<Value> doneGuards;
+    auto &enabledGroups = stateEnables[stateOp];
+    // Note: llvm::enumerate does not play nicely with DenseSet
+    size_t portIndex = 0;
+    for (auto group : allEnabledGroups) {
+      if (enabledGroups.contains(group)) {
+        operands.push_back(c1);
+        doneGuards.push_back(machineOp.getArgument(portIndex));
+      } else {
+        operands.push_back(c0);
+      }
+      ++portIndex;
+    }
+
+    // Assign the output op.
+    auto outputOp = stateOp.output().getOps<fsm::OutputOp>();
+    assert(!outputOp.empty() &&
+           "Expected an fsm.output op inside the state output region");
+    (*outputOp.begin()).getOperation()->setOperands(operands);
+
+    // Assign the transition guards.
+    for (auto transition : stateOp.transitions().getOps<fsm::TransitionOp>()) {
+      auto guardOp = transition.getGuardReturn();
+      llvm::SmallVector<Value> guards;
+      llvm::append_range(guards, doneGuards);
+      if (guardOp.operand())
+        guards.push_back(guardOp.operand());
+
+      if (guards.empty())
+        continue;
+
+      builder.setInsertionPoint(guardOp);
+      Value guardConjunction =
+          builder.create<comb::AndOp>(transition.getLoc(), guards);
+      guardOp.setOperand(guardConjunction);
+    }
+  }
+}
+
+std::unique_ptr<mlir::Pass> circt::calyx::createMaterializeFSMPass() {
+  return std::make_unique<MaterializeFSMPass>();
+}

--- a/lib/Dialect/Calyx/Transforms/PassDetails.h
+++ b/lib/Dialect/Calyx/Transforms/PassDetails.h
@@ -18,6 +18,7 @@
 
 #include "circt/Dialect/Calyx/CalyxOps.h"
 #include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/FSM/FSMOps.h"
 #include "mlir/Pass/Pass.h"
 
 namespace circt {

--- a/lib/Dialect/FSM/Transforms/PrintFSMGraph.cpp
+++ b/lib/Dialect/FSM/Transforms/PrintFSMGraph.cpp
@@ -24,9 +24,10 @@ namespace {
 struct PrintFSMGraphPass : public PrintFSMGraphBase<PrintFSMGraphPass> {
   PrintFSMGraphPass(raw_ostream &os) : os(os) {}
   void runOnOperation() override {
-    auto &fsmGraph = getAnalysis<fsm::FSMGraph>();
-    llvm::WriteGraph(os, &fsmGraph, /*ShortNames=*/false);
-    markAllAnalysesPreserved();
+    getOperation().walk([&](fsm::MachineOp machine) {
+      auto fsmGraph = fsm::FSMGraph(machine);
+      llvm::WriteGraph(os, &fsmGraph, /*ShortNames=*/false);
+    });
   }
   raw_ostream &os;
 };

--- a/test/Conversion/CalyxToFSM/lower-if.mlir
+++ b/test/Conversion/CalyxToFSM/lower-if.mlir
@@ -1,0 +1,107 @@
+// RUN: circt-opt --split-input-file -pass-pipeline='calyx.program(calyx.component(lower-calyx-to-fsm))' %s | FileCheck %s
+
+// CHECK:      fsm.machine @control() attributes {compiledGroups = [@true, @false, @cond], initialState = "fsm_entry", stateType = i1} {
+// CHECK-NEXT:   fsm.state "fsm_entry" output {
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @seq_0_cond guard {
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state "fsm_exit" output {
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state "seq_1_if" output {
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @seq_1_if_then guard {
+// CHECK-NEXT:       fsm.return %lt_reg.out
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:     fsm.transition @seq_1_if_else guard {
+// CHECK-NEXT:       %true_0 = hw.constant true
+// CHECK-NEXT:       %0 = comb.xor %lt_reg.out, %true_0 : i1
+// CHECK-NEXT:       fsm.return %0
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state "seq_1_if_then" output {
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @seq_1_if_then_seq_0_true guard {
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state "seq_1_if_then_seq_0_true" output {
+// CHECK-NEXT:     calyx.enable @true
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @fsm_exit guard {
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state "seq_1_if_else" output {
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @seq_1_if_else_seq_0_false guard {
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state "seq_1_if_else_seq_0_false" output {
+// CHECK-NEXT:     calyx.enable @false
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @fsm_exit guard {
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state "seq_0_cond" output {
+// CHECK-NEXT:     calyx.enable @cond
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @seq_1_if guard {
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+calyx.program "main" {
+  calyx.component @main(%go: i1 {go}, %reset: i1 {reset}, %clk: i1 {clk}) -> (%done: i1 {done}) {
+    %false = hw.constant false
+    %true = hw.constant true
+    %lt_reg.in, %lt_reg.write_en, %lt_reg.clk, %lt_reg.reset, %lt_reg.out, %lt_reg.done = calyx.register @lt_reg : i1, i1, i1, i1, i1, i1
+    %t.in, %t.write_en, %t.clk, %t.reset, %t.out, %t.done = calyx.register @t : i1, i1, i1, i1, i1, i1
+    %f.in, %f.write_en, %f.clk, %f.reset, %f.out, %f.done = calyx.register @f : i1, i1, i1, i1, i1, i1
+    %lt.left, %lt.right, %lt.out = calyx.std_lt @lt : i1, i1, i1
+    calyx.wires {
+      %0 = calyx.undef : i1
+      calyx.group @true {
+        %true.go = calyx.group_go %0 : i1
+        calyx.assign %t.in = %true.go ? %true : i1
+        calyx.assign %t.write_en = %true.go ? %true : i1
+        calyx.group_done %t.done : i1
+      }
+      calyx.group @false {
+        %false.go = calyx.group_go %0 : i1
+        calyx.assign %f.in = %false.go ? %true : i1
+        calyx.assign %f.write_en = %false.go ? %true : i1
+        calyx.group_done %f.done : i1
+      }
+      calyx.group @cond {
+        %cond.go = calyx.group_go %0 : i1
+        calyx.assign %lt_reg.in = %cond.go ? %lt.out : i1
+        calyx.assign %lt_reg.write_en = %cond.go ? %true : i1
+        calyx.assign %lt.left = %cond.go ? %true : i1
+        calyx.assign %lt.right = %cond.go ? %false : i1
+        calyx.group_done %lt_reg.done ? %true : i1
+      }
+    }
+    calyx.control {
+      calyx.seq {
+        calyx.enable @cond
+        calyx.if %lt_reg.out {
+          calyx.seq {
+            calyx.enable @true
+          }
+        } else {
+          calyx.seq {
+            calyx.enable @false
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/Conversion/CalyxToFSM/lower-seq.mlir
+++ b/test/Conversion/CalyxToFSM/lower-seq.mlir
@@ -1,0 +1,74 @@
+// RUN: circt-opt --split-input-file -pass-pipeline='calyx.program(calyx.component(lower-calyx-to-fsm))' %s | FileCheck %s
+
+// CHECK:       fsm.machine @control() attributes {compiledGroups = [@C, @B, @A], initialState = "fsm_entry", stateType = i1} {
+// CHECK-NEXT:   fsm.state "fsm_entry" output {
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @seq_0_A guard {
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state "fsm_exit" output {
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state "seq_2_C" output {
+// CHECK-NEXT:     calyx.enable @C
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @fsm_exit guard {
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state "seq_1_B" output {
+// CHECK-NEXT:     calyx.enable @B
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @seq_2_C guard {
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state "seq_0_A" output {
+// CHECK-NEXT:     calyx.enable @A
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @seq_1_B guard {
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+calyx.program "main" {
+  calyx.component @main(%go: i1 {go}, %reset: i1 {reset}, %clk: i1 {clk}) -> (%done: i1 {done}) {
+    %c2_i8 = hw.constant 2 : i8
+    %c1_i8 = hw.constant 1 : i8
+    %c0_i8 = hw.constant 0 : i8
+    %true = hw.constant true
+    %a.in, %a.write_en, %a.clk, %a.reset, %a.out, %a.done = calyx.register @a : i8, i1, i1, i1, i8, i1
+    %b.in, %b.write_en, %b.clk, %b.reset, %b.out, %b.done = calyx.register @b : i8, i1, i1, i1, i8, i1
+    %c.in, %c.write_en, %c.clk, %c.reset, %c.out, %c.done = calyx.register @c : i8, i1, i1, i1, i8, i1
+    calyx.wires {
+      %0 = calyx.undef : i1
+      calyx.group @A {
+        %A.go = calyx.group_go %0 : i1
+        calyx.assign %a.in = %A.go ? %c0_i8 : i8
+        calyx.assign %a.write_en = %A.go ? %true : i1
+        calyx.group_done %a.done : i1
+      }
+      calyx.group @B {
+        %B.go = calyx.group_go %0 : i1
+        calyx.assign %b.in = %B.go ? %c1_i8 : i8
+        calyx.assign %b.write_en = %B.go ? %true : i1
+        calyx.group_done %b.done : i1
+      }
+      calyx.group @C {
+        %C.go = calyx.group_go %0 : i1
+        calyx.assign %c.in = %C.go ? %c2_i8 : i8
+        calyx.assign %c.write_en = %C.go ? %true : i1
+        calyx.group_done %c.done : i1
+      }
+    }
+    calyx.control {
+      calyx.seq {
+        calyx.enable @A
+        calyx.enable @B
+        calyx.enable @C
+      }
+    }
+  }
+}

--- a/test/Conversion/CalyxToFSM/lower-while.mlir
+++ b/test/Conversion/CalyxToFSM/lower-while.mlir
@@ -1,0 +1,128 @@
+// RUN: circt-opt --split-input-file -pass-pipeline='calyx.program(calyx.component(lower-calyx-to-fsm))' %s | FileCheck %s
+
+// CHECK:      fsm.machine @control() attributes {compiledGroups = [@do_add, @do_add, @do_add, @cond], initialState = "fsm_entry", stateType = i1} {
+// CHECK-NEXT:   fsm.state "fsm_entry" output {
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @seq_0_cond guard {
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state "fsm_exit" output {
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state "seq_1_while_header" output {
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @seq_1_while_if guard {
+// CHECK-NEXT:       fsm.return %lt_reg.out
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:     fsm.transition @fsm_exit guard {
+// CHECK-NEXT:       %true_0 = hw.constant true
+// CHECK-NEXT:       %0 = comb.xor %lt_reg.out, %true_0 : i1
+// CHECK-NEXT:       fsm.return %0
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state "seq_1_while_if" output {
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @seq_1_while_if_then guard {
+// CHECK-NEXT:       fsm.return %lt_reg.out
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:     fsm.transition @seq_1_while_if_else guard {
+// CHECK-NEXT:       %true_0 = hw.constant true
+// CHECK-NEXT:       %0 = comb.xor %lt_reg.out, %true_0 : i1
+// CHECK-NEXT:       fsm.return %0
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state "seq_1_while_if_then" output {
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @seq_1_while_if_then_seq_0_do_add guard {
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state "seq_1_while_if_then_seq_1_do_add" output {
+// CHECK-NEXT:     calyx.enable @do_add
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @seq_1_while_header guard {
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state "seq_1_while_if_then_seq_0_do_add" output {
+// CHECK-NEXT:     calyx.enable @do_add
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @seq_1_while_if_then_seq_1_do_add guard {
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state "seq_1_while_if_else" output {
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @seq_1_while_if_else_seq_0_do_add guard {
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state "seq_1_while_if_else_seq_0_do_add" output {
+// CHECK-NEXT:     calyx.enable @do_add
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @seq_1_while_header guard {
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state "seq_0_cond" output {
+// CHECK-NEXT:     calyx.enable @cond
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @seq_1_while_header guard {
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+calyx.program "main" {
+  calyx.component @main(%go: i1 {go}, %reset: i1 {reset}, %clk: i1 {clk}) -> (%done: i1 {done}) {
+    %true = hw.constant true
+    %c1_i32 = hw.constant 1 : i32
+    %c5_i32 = hw.constant 5 : i32
+    %c4_i32 = hw.constant 4 : i32
+    %lt_reg.in, %lt_reg.write_en, %lt_reg.clk, %lt_reg.reset, %lt_reg.out, %lt_reg.done = calyx.register @lt_reg : i1, i1, i1, i1, i1, i1
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i32, i1, i1, i1, i32, i1
+    %add.left, %add.right, %add.out = calyx.std_add @add : i32, i32, i32
+    %lt.left, %lt.right, %lt.out = calyx.std_lt @lt : i32, i32, i1
+    calyx.wires {
+      %0 = calyx.undef : i1
+      calyx.group @do_add {
+        %do_add.go = calyx.group_go %0 : i1
+        calyx.assign %add.right = %do_add.go ? %c4_i32 : i32
+        calyx.assign %add.left = %do_add.go ? %c4_i32 : i32
+        calyx.assign %r.in = %do_add.go ? %add.out : i32
+        calyx.assign %r.write_en = %do_add.go ? %true : i1
+        calyx.group_done %r.done : i1
+      }
+      calyx.group @cond {
+        %cond.go = calyx.group_go %0 : i1
+        calyx.assign %lt_reg.in = %cond.go ? %lt.out : i1
+        calyx.assign %lt_reg.write_en = %cond.go ? %true : i1
+        calyx.assign %lt.right = %cond.go ? %c5_i32 : i32
+        calyx.assign %lt.left = %cond.go ? %c1_i32 : i32
+        calyx.group_done %lt_reg.done ? %true : i1
+      }
+    }
+    calyx.control {
+      calyx.seq {
+        calyx.enable @cond
+        calyx.while %lt_reg.out {
+          calyx.if %lt_reg.out {
+            calyx.seq {
+              calyx.enable @do_add
+              calyx.enable @do_add
+            }
+          } else {
+            calyx.seq {
+              calyx.enable @do_add
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/Dialect/Calyx/materialize-fsm.mlir
+++ b/test/Dialect/Calyx/materialize-fsm.mlir
@@ -1,0 +1,124 @@
+// RUN: circt-opt -pass-pipeline='calyx.program(calyx.component(lower-calyx-to-fsm,calyx-materialize-fsm))' %s | FileCheck %s
+
+// todo: non-deterministically fails due to state reordering.
+
+// CHECK: fsm.machine @control(%arg0: i1, %arg1: i1, %arg2: i1) -> (i1, i1, i1) attributes {compiledGroups = [@true, @false, @cond], initialState = "fsm_entry", stateType = i1} {
+// CHECK-NEXT:   %true_0 = hw.constant true
+// CHECK-NEXT:   %false_1 = hw.constant false
+// CHECK-NEXT:   fsm.state "fsm_entry" output {
+// CHECK-NEXT:     fsm.output %false_1, %false_1, %false_1 : i1, i1, i1
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @seq_0_cond guard {
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state "fsm_exit" output {
+// CHECK-NEXT:     fsm.output %false_1, %false_1, %false_1 : i1, i1, i1
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state "seq_1_if" output {
+// CHECK-NEXT:     fsm.output %false_1, %false_1, %false_1 : i1, i1, i1
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @seq_1_if_then guard {
+// CHECK-NEXT:       %0 = comb.and %lt_reg.out : i1
+// CHECK-NEXT:       fsm.return %0
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:     fsm.transition @seq_1_if_else guard {
+// CHECK-NEXT:       %true_2 = hw.constant true
+// CHECK-NEXT:       %0 = comb.xor %lt_reg.out, %true_2 : i1
+// CHECK-NEXT:       %1 = comb.and %0 : i1
+// CHECK-NEXT:       fsm.return %1
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state "seq_1_if_then" output {
+// CHECK-NEXT:     fsm.output %false_1, %false_1, %false_1 : i1, i1, i1
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @seq_1_if_then_seq_0_true guard {
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state "seq_1_if_then_seq_0_true" output {
+// CHECK-NEXT:     fsm.output %false_1, %true_0, %false_1 : i1, i1, i1
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @fsm_exit guard {
+// CHECK-NEXT:       %0 = comb.and %arg1 : i1
+// CHECK-NEXT:       fsm.return %0
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state "seq_1_if_else" output {
+// CHECK-NEXT:     fsm.output %false_1, %false_1, %false_1 : i1, i1, i1
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @seq_1_if_else_seq_0_false guard {
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state "seq_1_if_else_seq_0_false" output {
+// CHECK-NEXT:     fsm.output %true_0, %false_1, %false_1 : i1, i1, i1
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @fsm_exit guard {
+// CHECK-NEXT:       %0 = comb.and %arg0 : i1
+// CHECK-NEXT:       fsm.return %0
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   fsm.state "seq_0_cond" output {
+// CHECK-NEXT:     fsm.output %false_1, %false_1, %true_0 : i1, i1, i1
+// CHECK-NEXT:   } transitions {
+// CHECK-NEXT:     fsm.transition @seq_1_if guard {
+// CHECK-NEXT:       %0 = comb.and %arg2 : i1
+// CHECK-NEXT:       fsm.return %0
+// CHECK-NEXT:     } action {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+calyx.program "main" {
+  calyx.component @main(%go: i1 {go}, %reset: i1 {reset}, %clk: i1 {clk}) -> (%done: i1 {done}) {
+    %false = hw.constant false
+    %true = hw.constant true
+    %lt_reg.in, %lt_reg.write_en, %lt_reg.clk, %lt_reg.reset, %lt_reg.out, %lt_reg.done = calyx.register @lt_reg : i1, i1, i1, i1, i1, i1
+    %t.in, %t.write_en, %t.clk, %t.reset, %t.out, %t.done = calyx.register @t : i1, i1, i1, i1, i1, i1
+    %f.in, %f.write_en, %f.clk, %f.reset, %f.out, %f.done = calyx.register @f : i1, i1, i1, i1, i1, i1
+    %lt.left, %lt.right, %lt.out = calyx.std_lt @lt : i1, i1, i1
+    calyx.wires {
+      %0 = calyx.undef : i1
+      calyx.group @true {
+        %true.go = calyx.group_go %0 : i1
+        calyx.assign %t.in = %true.go ? %true : i1
+        calyx.assign %t.write_en = %true.go ? %true : i1
+        calyx.group_done %t.done : i1
+      }
+      calyx.group @false {
+        %false.go = calyx.group_go %0 : i1
+        calyx.assign %f.in = %false.go ? %true : i1
+        calyx.assign %f.write_en = %false.go ? %true : i1
+        calyx.group_done %f.done : i1
+      }
+      calyx.group @cond {
+        %cond.go = calyx.group_go %0 : i1
+        calyx.assign %lt_reg.in = %cond.go ? %lt.out : i1
+        calyx.assign %lt_reg.write_en = %cond.go ? %true : i1
+        calyx.assign %lt.left = %cond.go ? %true : i1
+        calyx.assign %lt.right = %cond.go ? %false : i1
+        calyx.group_done %lt_reg.done ? %true : i1
+      }
+    }
+    calyx.control {
+      calyx.seq {
+        calyx.enable @cond
+        calyx.if %lt_reg.out {
+          calyx.seq {
+            calyx.enable @true
+          }
+        } else {
+          calyx.seq {
+            calyx.enable @false
+          }
+        }
+      }
+    }
+  }
+}

--- a/tools/circt-opt/CMakeLists.txt
+++ b/tools/circt-opt/CMakeLists.txt
@@ -12,6 +12,7 @@ target_link_libraries(circt-opt
   CIRCTAnalysisTestPasses
   CIRCTCalyx
   CIRCTCalyxToHW
+  CIRCTCalyxToFSM
   CIRCTCalyxTransforms
   CIRCTESI
   CIRCTExportVerilog


### PR DESCRIPTION
This commit represents a lowering pass for converting a Calyx control schedule (seq/if/while/enable) into an FSM representation. The FSM is embedded within the Calyx component, and references both the group symbols and cell SSA values.

The lowering method is a fairly straight forward conversion, which leaves plenty of canonicalization opportunities to remove redundant states in the generated FSM. However, doing it as presented in this PR lends itself to some clean code (which I prefer, rather than prematurely optimizing during lowering) as well as meaningful naming of states (which i think is fairly important).

Marked as draft due to mixing in changes to the FSM dialect which needs to be discussed. Once things are settled, FSM dialect and FSMGraph changes will be factored out into a separate PR.

Things to be discussed:
- MachineOp is **no more** `IsolatedFromAbove`; this is a requirement for the FSM to be able to reference the symbols and SSA values defined within the component. If we find that the presented style of lowering is compelling, but we still want an `IsolatedFromAbove` FSM machine, one option could be to introduced a new `EmbeddedMachineOp` to allow for this kind of behaviour.
- ~~I added a `fsm.ref` (not sure about the name) to represent _a reference to some symbol_. The semantics of a reference is implementation defined, and merely serves to convey the semantics of associating a symbol reference with a given state. `fsm.ref` is call-like and can provide arguments to references, as well as return values.~~
  - Edit: Removed in favor of relaxing `calyx.enable` verifier.

Graph print of the `lower-while.mlir` test:
<img src="https://user-images.githubusercontent.com/16338943/168989336-c9a59b75-c62f-432c-8529-f77617121a57.png" alt="image" width="500" class="center"/>
