### PR TITLE
[Support] Add iterator interface to SymbolCache

### DIFF
--- a/include/circt/Support/Namespace.h
+++ b/include/circt/Support/Namespace.h
@@ -35,10 +35,9 @@ public:
   /// SymbolCache initializer; initialize from every key that is convertible to
   /// a StringAttr in the SymbolCache.
   Namespace(SymbolCache &symCache) {
-    for (auto &&[attr, _] : symCache) {
+    for (auto &&[attr, _] : symCache)
       if (auto strAttr = attr.dyn_cast<StringAttr>())
         nextIndex.insert({strAttr.getValue(), 0});
-    }
   }
 
   Namespace &operator=(const Namespace &other) = default;

--- a/include/circt/Support/Namespace.h
+++ b/include/circt/Support/Namespace.h
@@ -15,6 +15,7 @@
 #define CIRCT_SUPPORT_NAMESPACE_H
 
 #include "circt/Support/LLVM.h"
+#include "circt/Support/SymCache.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/Twine.h"
@@ -30,6 +31,15 @@ public:
   Namespace() {}
   Namespace(const Namespace &other) = default;
   Namespace(Namespace &&other) : nextIndex(std::move(other.nextIndex)) {}
+
+  /// SymbolCache initializer; initialize from every key that is convertible to
+  /// a StringAttr in the SymbolCache.
+  Namespace(SymbolCache &symCache) {
+    for (auto &&[attr, _] : symCache) {
+      if (auto strAttr = attr.dyn_cast<StringAttr>())
+        nextIndex.insert({strAttr.getValue(), 0});
+    }
+  }
 
   Namespace &operator=(const Namespace &other) = default;
   Namespace &operator=(Namespace &&other) {

--- a/include/circt/Support/Namespace.h
+++ b/include/circt/Support/Namespace.h
@@ -32,18 +32,18 @@ public:
   Namespace(const Namespace &other) = default;
   Namespace(Namespace &&other) : nextIndex(std::move(other.nextIndex)) {}
 
-  /// SymbolCache initializer; initialize from every key that is convertible to
-  /// a StringAttr in the SymbolCache.
-  Namespace(SymbolCache &symCache) {
-    for (auto &&[attr, _] : symCache)
-      if (auto strAttr = attr.dyn_cast<StringAttr>())
-        nextIndex.insert({strAttr.getValue(), 0});
-  }
-
   Namespace &operator=(const Namespace &other) = default;
   Namespace &operator=(Namespace &&other) {
     nextIndex = std::move(other.nextIndex);
     return *this;
+  }
+
+  /// SymbolCache initializer; initialize from every key that is convertible to
+  /// a StringAttr in the SymbolCache.
+  void add(SymbolCache &symCache) {
+    for (auto &&[attr, _] : symCache)
+      if (auto strAttr = attr.dyn_cast<StringAttr>())
+        nextIndex.insert({strAttr.getValue(), 0});
   }
 
   /// Empty the namespace.

--- a/lib/Dialect/HW/Transforms/HWSpecialize.cpp
+++ b/lib/Dialect/HW/Transforms/HWSpecialize.cpp
@@ -356,7 +356,8 @@ void HWSpecializePass::runOnOperation() {
   // Maintain a symbol cache for fast lookup during module specialization.
   SymbolCache sc;
   sc.addDefinitions(module);
-  Namespace ns(sc);
+  Namespace ns;
+  ns.add(sc);
 
   for (auto hwModule : module.getOps<hw::HWModuleOp>()) {
     // If this module is parametric, defer registering its parametric


### PR DESCRIPTION
Continuing from the work in #3137, instead of introducing a new class for generating unique names, it might be better to simply have a way to initialize a namespace from a `SymbolCache`.

To do so, this PR introduces an iterator interface to the base `SymbolCache` class which iterates over pairs of `{mlir::Attribute, mlir::Operation*}`.

Given this interface, it's now possible to range-loop over any given cache and use the values for namespace initialization.