### PR TITLE
[Seq] Moved pass definition to a separate header

### DIFF
--- a/include/circt/Dialect/Seq/CMakeLists.txt
+++ b/include/circt/Dialect/Seq/CMakeLists.txt
@@ -12,9 +12,7 @@
 add_circt_dialect(Seq seq)
 add_circt_doc(Seq -gen-dialect-doc Seq Dialects/)
 
-set(LLVM_TARGET_DEFINITIONS Seq.td)
+set(LLVM_TARGET_DEFINITIONS SeqPasses.td)
 mlir_tablegen(SeqPasses.h.inc -gen-pass-decls)
-
-add_circt_doc(Seq -gen-pass-doc SeqPasses ./)
-
-add_public_tablegen_target(MLIRSeqMiscIncGen)
+add_public_tablegen_target(CIRCTSeqTransformsIncGen)
+add_circt_doc(SeqPasses -gen-pass-doc SeqPasses ./)

--- a/include/circt/Dialect/Seq/Seq.td
+++ b/include/circt/Dialect/Seq/Seq.td
@@ -52,10 +52,4 @@ def CompRegOp : SeqOp<"compreg",
   let hasCustomAssemblyFormat = 1;
 }
 
-def LowerSeqToSV: Pass<"lower-seq-to-sv", "mlir::ModuleOp"> {
-  let summary = "Lower sequential ops to SV.";
-  let constructor = "circt::seq::createSeqLowerToSVPass()";
-  let dependentDialects = ["circt::sv::SVDialect"];
-}
-
 #endif // SEQ_TD

--- a/include/circt/Dialect/Seq/SeqDialect.h
+++ b/include/circt/Dialect/Seq/SeqDialect.h
@@ -16,14 +16,6 @@
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/Dialect.h"
 
-namespace circt {
-namespace seq {
-
-void registerSeqPasses();
-
-} // namespace seq
-} // namespace circt
-
 // Pull in the dialect definition.
 #include "circt/Dialect/Seq/SeqDialect.h.inc"
 

--- a/include/circt/Dialect/Seq/SeqPasses.h
+++ b/include/circt/Dialect/Seq/SeqPasses.h
@@ -1,0 +1,31 @@
+//===- SeqPasses.h - Seq pass entry points ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This header file defines prototypes that expose pass constructors.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_SEQ_SEQPASSES_H
+#define CIRCT_DIALECT_SEQ_SEQPASSES_H
+
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace circt {
+namespace seq {
+
+std::unique_ptr<mlir::Pass> createSeqLowerToSVPass();
+
+/// Generate the code for registering passes.
+#define GEN_PASS_REGISTRATION
+#include "circt/Dialect/Seq/SeqPasses.h.inc"
+
+} // namespace seq
+} // namespace circt
+
+#endif // CIRCT_DIALECT_SEQ_SEQPASSES_H

--- a/include/circt/Dialect/Seq/SeqPasses.td
+++ b/include/circt/Dialect/Seq/SeqPasses.td
@@ -1,0 +1,24 @@
+//===-- SeqPasses.td - Seq pass definition file ------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains definitions for passes that work on the Seq dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_SEQ_SEQPASSES
+#define CIRCT_DIALECT_SEQ_SEQPASSES
+
+include "mlir/Pass/PassBase.td"
+
+def LowerSeqToSV: Pass<"lower-seq-to-sv", "mlir::ModuleOp"> {
+  let summary = "Lower sequential ops to SV.";
+  let constructor = "circt::seq::createSeqLowerToSVPass()";
+  let dependentDialects = ["circt::sv::SVDialect"];
+}
+
+#endif // CIRCT_DIALECT_SEQ_SEQPASSES

--- a/include/circt/InitAllPasses.h
+++ b/include/circt/InitAllPasses.h
@@ -25,7 +25,7 @@
 #include "circt/Dialect/LLHD/Transforms/Passes.h"
 #include "circt/Dialect/MSFT/MSFTDialect.h"
 #include "circt/Dialect/SV/SVPasses.h"
-#include "circt/Dialect/Seq/SeqDialect.h"
+#include "circt/Dialect/Seq/SeqPasses.h"
 #include "circt/Transforms/Passes.h"
 
 namespace circt {
@@ -44,7 +44,7 @@ inline void registerAllPasses() {
   fsm::registerPasses();
   llhd::initLLHDTransformationPasses();
   msft::registerMSFTPasses();
-  seq::registerSeqPasses();
+  seq::registerPasses();
   sv::registerPasses();
   handshake::registerPasses();
   hw::registerPasses();

--- a/lib/CAPI/Dialect/CMakeLists.txt
+++ b/lib/CAPI/Dialect/CMakeLists.txt
@@ -68,6 +68,7 @@ add_mlir_public_c_api_library(CIRCTCAPISeq
   LINK_LIBS PUBLIC
   MLIRCAPIIR
   CIRCTSeq
+  CIRCTSeqTransforms
   )
 
 add_mlir_public_c_api_library(CIRCTCAPISV

--- a/lib/CAPI/Dialect/Seq.cpp
+++ b/lib/CAPI/Dialect/Seq.cpp
@@ -8,9 +8,10 @@
 
 #include "circt-c/Dialect/Seq.h"
 #include "circt/Dialect/Seq/SeqDialect.h"
+#include "circt/Dialect/Seq/SeqPasses.h"
 
 #include "mlir/CAPI/Registration.h"
 
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Sequential, seq, circt::seq::SeqDialect)
 
-void registerSeqPasses() { circt::seq::registerSeqPasses(); }
+void registerSeqPasses() { circt::seq::registerPasses(); }

--- a/lib/Dialect/Seq/CMakeLists.txt
+++ b/lib/Dialect/Seq/CMakeLists.txt
@@ -12,7 +12,6 @@
 add_circt_dialect_library(CIRCTSeq
   SeqDialect.cpp
   SeqOps.cpp
-  SeqPasses.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/Seq
@@ -21,7 +20,6 @@ add_circt_dialect_library(CIRCTSeq
   CIRCTHW
   CIRCTSV
   MLIRSeqIncGen
-  MLIRSeqMiscIncGen
   
   LINK_COMPONENTS
   Support
@@ -35,3 +33,5 @@ add_circt_dialect_library(CIRCTSeq
    )
 
 add_dependencies(circt-headers MLIRSeqIncGen)
+
+add_subdirectory(Transforms)

--- a/lib/Dialect/Seq/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Seq/Transforms/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_circt_dialect_library(CIRCTSeqTransforms
+  LowerSeqToSV.cpp
+
+  DEPENDS
+  CIRCTSeqTransformsIncGen
+
+  LINK_LIBS PUBLIC
+  CIRCTHW
+  CIRCTSeq
+  CIRCTSupport
+  CIRCTSV
+  MLIRIR
+  MLIRPass
+  MLIRTransformUtils
+)

--- a/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
@@ -1,28 +1,26 @@
-//===- SeqPasses.cpp - Implement Seq passes -------------------------------===//
+//===- LowerSeqToSV.cpp - Seq to SV lowering ------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+//
+// This transform translate Seq ops to SV.
+//
+//===----------------------------------------------------------------------===//
 
+#include "PassDetails.h"
 #include "circt/Dialect/SV/SVOps.h"
 #include "circt/Dialect/Seq/SeqOps.h"
+#include "circt/Dialect/Seq/SeqPasses.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 
-using namespace mlir;
 using namespace circt;
 using namespace seq;
-
-namespace circt {
-namespace seq {
-#define GEN_PASS_CLASSES
-#include "circt/Dialect/Seq/SeqPasses.h.inc"
-} // namespace seq
-} // namespace circt
 
 namespace {
 struct SeqToSVPass : public LowerSeqToSVBase<SeqToSVPass> {
@@ -70,8 +68,8 @@ public:
     return success();
   }
 };
-
 } // namespace
+
 void SeqToSVPass::runOnOperation() {
   ModuleOp top = getOperation();
   MLIRContext &ctxt = getContext();
@@ -86,17 +84,6 @@ void SeqToSVPass::runOnOperation() {
     signalPassFailure();
 }
 
-namespace circt {
-namespace seq {
-std::unique_ptr<OperationPass<ModuleOp>> createSeqLowerToSVPass() {
+std::unique_ptr<Pass> circt::seq::createSeqLowerToSVPass() {
   return std::make_unique<SeqToSVPass>();
 }
-} // namespace seq
-} // namespace circt
-
-namespace {
-#define GEN_PASS_REGISTRATION
-#include "circt/Dialect/Seq/SeqPasses.h.inc"
-} // namespace
-
-void circt::seq::registerSeqPasses() { registerPasses(); }

--- a/lib/Dialect/Seq/Transforms/PassDetails.h
+++ b/lib/Dialect/Seq/Transforms/PassDetails.h
@@ -1,0 +1,30 @@
+//===- PassDetails.h - Seq pass class details -----------===-----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Stuff shared between the different Seq passes.
+//
+//===----------------------------------------------------------------------===//
+
+// NOLINTNEXTLINE(llvm-header-guard)
+#ifndef DIALECT_SEQ_TRANSFORMS_PASSDETAILS_H
+#define DIALECT_SEQ_TRANSFORMS_PASSDETAILS_H
+
+#include "circt/Dialect/SV/SVDialect.h"
+#include "circt/Dialect/Seq/SeqOps.h"
+#include "mlir/Pass/Pass.h"
+
+namespace circt {
+namespace seq {
+
+#define GEN_PASS_CLASSES
+#include "circt/Dialect/Seq/SeqPasses.h.inc"
+
+} // namespace seq
+} // namespace circt
+
+#endif // DIALECT_SEQ_TRANSFORMS_PASSDETAILS_H

--- a/tools/circt-opt/CMakeLists.txt
+++ b/tools/circt-opt/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries(circt-opt
   CIRCTScheduling
   CIRCTSchedulingTestPasses
   CIRCTSeq
+  CIRCTSeqTransforms
   CIRCTStandardToHandshake
   CIRCTStandardToStaticLogic
   CIRCTStaticLogicOps


### PR DESCRIPTION
Moved the definiton of `Seq` passes to a separate `SeqPasses.h`, similarly to other dialects.
Exposed the `createSeqLowerToSV` function to be used by other clients.