### PR TITLE
[FIRRTL] Set name and file location for Comb memory wrapper module

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -167,7 +167,10 @@ struct FirMemory {
 
   // Location is carried along but not considered part of the identity of this.
   Location loc;
+  // Flag to indicate if the memory was under the DUT hierarchy, only used in
+  // LowerToHW. Not part of the identity.
   bool isInDut = false;
+  // The original MemOp, only used in LowerToHW.  Also not part of the identity.
   Operation *op = nullptr;
 
   std::tuple<size_t, size_t, size_t, size_t, size_t, size_t, size_t, size_t,

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -167,6 +167,8 @@ struct FirMemory {
 
   // Location is carried along but not considered part of the identity of this.
   Location loc;
+  bool isInDut = false;
+  Operation *op = nullptr;
 
   std::tuple<size_t, size_t, size_t, size_t, size_t, size_t, size_t, size_t,
              size_t, hw::WUW, SmallVector<int32_t>, uint32_t>

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -325,7 +325,9 @@ struct CircuitLoweringState {
 
   InstanceGraph *getInstanceGraph() { return instanceGraph; }
 
-  StringAttr getNewMemName(StringAttr oldName) const {
+  // Given the FirMemory name, return the generated op module name. This map
+  // maintains the appropriate names for the deduped memories.
+  StringAttr getGenOpMemName(StringAttr oldName) const {
     auto iter = memoryNameMap.find(oldName);
     assert(iter != memoryNameMap.end() && "Memory name map not found");
     return iter->getSecond();
@@ -371,6 +373,10 @@ private:
   /// applicable).
   DenseMap<std::pair<Attribute, Attribute>, Attribute> instanceForceNames;
 
+  /// Map of original FirMemory name to the Generated Op name. All the deduped
+  /// memories have the same FirMemory name (because it is derived from the
+  /// memory parameters), but the generated op name depends on the MemOp name,
+  /// which is selected after dedup.
   DenseMap<StringAttr, StringAttr> memoryNameMap;
 
   /// Cached nla table analysis.
@@ -590,9 +596,12 @@ void FIRRTLModuleLowering::runOnOperation() {
         moduleHierarchyFileAttrName,
         ArrayAttr::get(&getContext(), testHarnessHierarchyFiles));
 
+  // Collect all the memories in the module. Construct the FirMemory, set the
+  // DUT flag and also record the Memop.
   auto collectFIRRTLMemories =
       [&state](FModuleOp module) -> SmallVector<FirMemory> {
     SmallVector<FirMemory> retval;
+    // Check if this module is in the DUT hierarchy.
     bool isInDut = state.isInDUT(module);
     for (auto op : module.getBody()->getOps<MemOp>()) {
       auto sum = op.getSummary();
@@ -603,10 +612,17 @@ void FIRRTLModuleLowering::runOnOperation() {
     return retval;
   };
 
+  // 1. First collect the memories as FirMemory, set the DUT flag and also
+  // record the MemOp.
+  // 2. Then Dedup the memories using the mergeFIRRTLMemories routine. This uses
+  // the memory parameters to merge memories with the exactly same parameters.
+  // 3. Then For each of the deduped memories, create the HWModuleGeneratedOp,
+  // and assign a unique name to the wrapper module based on the MemOp name. It
+  // is important to use the MemOp name because appropriate prefixes have to be
+  // respected, also the correct output directory needs to be set based on the
+  // DUT or testbench hierarchy.
   SmallVector<FirMemory> memories;
   if (getContext().isMultithreadingEnabled()) {
-    // TODO: Update this to use a mlir::parallelTransformReduce once it
-    // exists.
     memories = llvm::parallelTransformReduce(
         modulesToProcess.begin(), modulesToProcess.end(),
         SmallVector<FirMemory>(), mergeFIRRTLMemories, collectFIRRTLMemories);
@@ -736,12 +752,20 @@ void FIRRTLModuleLowering::lowerMemoryDecls(ArrayRef<FirMemory> mems,
         b.getNamedAttr("writeClockIDs", b.getI32ArrayAttr(mem.writeClockIDs))};
 
     // Make the global module for the memory
+    // Set a name for the memory wrapper module, the combMem is an arbitrary
+    // suffix. It is important to derive the name from the original MemOp name,
+    // to respect the corresponding prefixes..
     auto memoryName = b.getStringAttr(
         namesp.newName(static_cast<MemOp>(mem.op).name() + "_combMem"));
+    // Now record this generated name for the corresponding FirMemory name,
+    // because all the memories that have the same FirMemory name, will now use
+    // this new generated name at the Instance Op. Basically this is the name
+    // used for all the deduped memories.
     state.memoryNameMap[mem.getFirMemoryName()] = memoryName;
     auto genOp = b.create<hw::HWModuleGeneratedOp>(
         mem.loc, memorySchema, memoryName, ports, StringRef(), ArrayAttr(),
         genAttrs);
+    // Also set the appropriate directory.
     if (!mem.isInDut)
       if (auto testBenchDir = state.getTestBenchDirectory())
         genOp->setAttr("output_file", testBenchDir);
@@ -2839,7 +2863,7 @@ LogicalResult FIRRTLLowering::visitDecl(MemOp op) {
   }
 
   auto memModuleAttr =
-      circuitState.getNewMemName(memSummary.getFirMemoryName());
+      circuitState.getGenOpMemName(memSummary.getFirMemoryName());
 
   // Create the instance to replace the memop.
   auto inst = builder.create<hw::InstanceOp>(

--- a/lib/Dialect/SV/Transforms/HWMemSimImpl.cpp
+++ b/lib/Dialect/SV/Transforms/HWMemSimImpl.cpp
@@ -487,6 +487,8 @@ void HWMemSimImplPass::runOnOperation() {
       } else {
         auto newModule = builder.create<HWModuleOp>(
             oldModule.getLoc(), nameAttr, oldModule.getPorts());
+        if (auto outdir = oldModule->getAttr("output_file"))
+          newModule->setAttr("output_file", outdir);
         HWMemSimImpl(getContext(), replSeqMem, ignoreReadEnableMem)
             .generateMemory(newModule, mem);
       }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -8,56 +8,13 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
   //These come from MemSimple, IncompleteRead, and MemDepth1
   // CHECK-LABEL: hw.generator.schema @FIRRTLMem, "FIRRTL_Memory", ["depth", "numReadPorts", "numWritePorts", "numReadWritePorts", "readLatency", "writeLatency", "width", "maskGran", "readUnderWrite", "writeUnderWrite", "writeClockIDs"]
-  //
-  // This memory has two write ports where both write ports are driven by the
-  // same clock.
-  //
-  // CHECK-NEXT:  hw.module.generated @FIRRTLMem_0_2_0_8_16_1_1_1_0_1_0_aa,
-  // CHECK-SAME: @FIRRTLMem(%W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i8, %W1_addr: i4, %W1_en: i1, %W1_clk: i1, %W1_data: i8)
-  // CHECK-SAME: attributes {depth = 16 : i64, maskGran = 8 : ui32, numReadPorts = 0 : ui32,
-  // CHECK-SAME: numReadWritePorts = 0 : ui32, numWritePorts = 2 : ui32,
-  // CHECK-SAME: readLatency = 1 : ui32, readUnderWrite = 0 : ui32,
-  // CHECK-SAME: width = 8 : ui32, writeClockIDs = [0 : i32, 0 : i32],
-  // CHECK-SAME: writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
-  //
-  // This memory is the same as the above memory, but each write port is driven
-  // by a different clock.
-  //
-  // CHECK-NEXT:  hw.module.generated @FIRRTLMem_0_2_0_8_16_1_1_1_0_1_0_ab,
-  // CHECK-SAME: @FIRRTLMem(%W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i8, %W1_addr: i4, %W1_en: i1, %W1_clk: i1, %W1_data: i8)
-  // CHECK-SAME: attributes {depth = 16 : i64, maskGran = 8 : ui32, numReadPorts = 0 : ui32,
-  // CHECK-SAME: numReadWritePorts = 0 : ui32, numWritePorts = 2 : ui32,
-  // CHECK-SAME: readLatency = 1 : ui32, readUnderWrite = 0 : ui32,
-  // CHECK-SAME: width = 8 : ui32, writeClockIDs = [0 : i32, 1 : i32],
-  // CHECK-SAME: writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
-  //
-  // CHECK-NEXT:  hw.module.generated @FIRRTLMem_1_0_0_32_1_0_1_0_1_1_0,
-  // CHECK-SAME: @FIRRTLMem(%R0_addr: i1, %R0_en: i1, %R0_clk: i1) -> (R0_data: i32)
-  // CHECK-SAME: attributes {depth = 1 : i64, maskGran = 32 : ui32, numReadPorts = 1 : ui32,
-  // CHECK-SAME: numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32,
-  // CHECK-SAME: readLatency = 0 : ui32, readUnderWrite = 1 : ui32,
-  // CHECK-SAME: width = 32 : ui32, writeClockIDs = [],
-  // CHECK-SAME: writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
-  // CHECK-NEXT:  hw.module.generated @FIRRTLMem_1_0_0_42_12_0_1_0_0_1_0,
-  // CHECK-SAME: @FIRRTLMem(%R0_addr: i4, %R0_en: i1, %R0_clk: i1) -> (R0_data: i42)
-  // CHECK-SAME: attributes {depth = 12 : i64, maskGran = 42 : ui32, numReadPorts = 1 : ui32,
-  // CHECK-SAME: numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32,
-  // CHECK-SAME: readLatency = 0 : ui32, readUnderWrite = 0 : ui32,
-  // CHECK-SAME: width = 42 : ui32, writeClockIDs = [],
-  // CHECK-SAME: writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
-
-  // CHECK:    hw.module.generated @tbMemoryKind1_ext, @FIRRTLMem
-  // CHECK-SAME: (%R0_addr: i4, %R0_en: i1, %R0_clk: i1, %W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i8)
-
-  // CHECK-NEXT: hw.module.generated @FIRRTLMem_1_1_1_40_1022_1_1_4_0_1_0_a,
-  // CHECK-SAME:  @FIRRTLMem(%R0_addr: i10, %R0_en: i1, %R0_clk: i1, %RW0_addr: i10, %RW0_en: i1, %RW0_clk: i1, %RW0_wmode: i1, %RW0_wdata: i40, %RW0_wmask: i4, %W0_addr: i10, %W0_en: i1, %W0_clk: i1, %W0_data: i40, %W0_mask: i4) -> (R0_data: i40, RW0_rdata: i40)
-  // CHECK-NEXT:  hw.module.generated @FIRRTLMem_1_1_1_42_12_0_1_1_0_1_0_a,
-  // CHECK-SAME: @FIRRTLMem(%R0_addr: i4, %R0_en: i1, %R0_clk: i1, %RW0_addr: i4, %RW0_en: i1, %RW0_clk: i1, %RW0_wmode: i1, %RW0_wdata: i42, %W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i42) -> (R0_data: i42, RW0_rdata: i42)
-  // CHECK-SAME: attributes {depth = 12 : i64, maskGran = 42 : ui32, numReadPorts = 1 : ui32,
-  // CHECK-SAME: numReadWritePorts = 1 : ui32, numWritePorts = 1 : ui32,
-  // CHECK-SAME: readLatency = 0 : ui32, readUnderWrite = 0 : ui32,
-  // CHECK-SAME: width = 42 : ui32, writeClockIDs = [0 : i32],
-  // CHECK-SAME: writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+  // CHECK: hw.module.generated @aa_combMem, @FIRRTLMem(%W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i8, %W1_addr: i4, %W1_en: i1, %W1_clk: i1, %W1_data: i8) attributes {depth = 16 : i64, maskGran = 8 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 2 : ui32, readLatency = 1 : ui32, readUnderWrite = 0 : ui32, width = 8 : ui32, writeClockIDs = [0 : i32, 0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+  // CHECK: hw.module.generated @ab_combMem, @FIRRTLMem(%W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i8, %W1_addr: i4, %W1_en: i1, %W1_clk: i1, %W1_data: i8) attributes {depth = 16 : i64, maskGran = 8 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 2 : ui32, readLatency = 1 : ui32, readUnderWrite = 0 : ui32, width = 8 : ui32, writeClockIDs = [0 : i32, 1 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+  // CHECK: hw.module.generated @mem0_combMem, @FIRRTLMem(%R0_addr: i1, %R0_en: i1, %R0_clk: i1) -> (R0_data: i32) attributes {depth = 1 : i64, maskGran = 32 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 1 : ui32, width = 32 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+  // CHECK: hw.module.generated @_M_combMem, @FIRRTLMem(%R0_addr: i4, %R0_en: i1, %R0_clk: i1) -> (R0_data: i42) attributes {depth = 12 : i64, maskGran = 42 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : ui32, width = 42 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+  // CHECK: hw.module.generated @tbMemoryKind1_combMem, @FIRRTLMem(%R0_addr: i4, %R0_en: i1, %R0_clk: i1, %W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i8) -> (R0_data: i8) attributes {depth = 16 : i64, maskGran = 8 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, readUnderWrite = 0 : ui32, width = 8 : ui32, writeClockIDs = [0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+  // CHECK: hw.module.generated @_M_mask_combMem, @FIRRTLMem(%R0_addr: i10, %R0_en: i1, %R0_clk: i1, %RW0_addr: i10, %RW0_en: i1, %RW0_clk: i1, %RW0_wmode: i1, %RW0_wdata: i40, %RW0_wmask: i4, %W0_addr: i10, %W0_en: i1, %W0_clk: i1, %W0_data: i40, %W0_mask: i4) -> (R0_data: i40, RW0_rdata: i40) attributes {depth = 1022 : i64, maskGran = 10 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, readUnderWrite = 0 : ui32, width = 40 : ui32, writeClockIDs = [0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+  // CHECK: hw.module.generated @_M_combMem_0, @FIRRTLMem(%R0_addr: i4, %R0_en: i1, %R0_clk: i1, %RW0_addr: i4, %RW0_en: i1, %RW0_clk: i1, %RW0_wmode: i1, %RW0_wdata: i42, %W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i42) -> (R0_data: i42, RW0_rdata: i42) attributes {depth = 12 : i64, maskGran = 42 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : ui32, width = 42 : ui32, writeClockIDs = [0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
 
   // CHECK-LABEL: hw.module @Simple
   firrtl.module @Simple(in %in1: !firrtl.uint<4>,
@@ -867,7 +824,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %c0_ui3 = firrtl.constant 0 : !firrtl.uint<3>
     %_M_read, %_M_rw, %_M_write = firrtl.mem Undefined {depth = 12 : i64, name = "_M", portNames = ["read", "rw", "write"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: sint<42>, wmode: uint<1>, wdata: sint<42>, wmask: uint<1>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: sint<42>, mask: uint<1>>
   // CHECK: %[[v2:.+]] = comb.and %inpred, %true : i1
-  // CHECK: %_M_ext.R0_data, %_M_ext.RW0_rdata = hw.instance "_M_ext" @FIRRTLMem_1_1_1_42_12_0_1_1_0_1_0_a(R0_addr: %c0_i4: i4, R0_en: %true: i1, R0_clk: %clock1: i1, RW0_addr: %c0_i4_0: i4, RW0_en: %0: i1, RW0_clk: %clock1: i1, RW0_wmode: %true: i1, RW0_wdata: %1: i42, W0_addr: %c0_i4_1: i4, W0_en: %[[v2]]: i1, W0_clk: %clock2: i1, W0_data: %indata: i42) -> (R0_data: i42, RW0_rdata: i42)
+  // CHECK: %_M_ext.R0_data, %_M_ext.RW0_rdata = hw.instance "_M_ext" @_M_combMem_0(R0_addr: %c0_i4: i4, R0_en: %true: i1, R0_clk: %clock1: i1, RW0_addr: %c0_i4_0: i4, RW0_en: %0: i1, RW0_clk: %clock1: i1, RW0_wmode: %true: i1, RW0_wdata: %1: i42, W0_addr: %c0_i4_1: i4, W0_en: %[[v2]]: i1, W0_clk: %clock2: i1, W0_data: %indata: i42) -> (R0_data: i42, RW0_rdata: i42)
   // CHECK: hw.output %_M_ext.R0_data, %_M_ext.RW0_rdata : i42, i42
 
       %0 = firrtl.subfield %_M_read(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>) -> !firrtl.sint<42>
@@ -916,7 +873,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
     %c1_ui5 = firrtl.constant 1 : !firrtl.uint<5>
     %_M_read, %_M_rw, %_M_write = firrtl.mem Undefined {depth = 1022 : i64, name = "_M_mask", portNames = ["read", "rw", "write"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data flip: sint<40>>, !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, rdata flip: sint<40>, wmode: uint<1>, wdata: sint<40>, wmask: uint<4>>, !firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data: sint<40>, mask: uint<4>>
-    // CHECK: %_M_mask_ext.R0_data, %_M_mask_ext.RW0_rdata = hw.instance "_M_mask_ext" @FIRRTLMem_1_1_1_40_1022_1_1_4_0_1_0_a(R0_addr: %c0_i10: i10, R0_en: %true: i1, R0_clk: %clock1: i1, RW0_addr: %c0_i10: i10, RW0_en: %true: i1, RW0_clk: %clock1: i1, RW0_wmode: %true: i1, RW0_wdata: %0: i40, RW0_wmask: %c0_i4: i4, W0_addr: %c0_i10: i10, W0_en: %inpred: i1, W0_clk: %clock2: i1, W0_data: %indata: i40, W0_mask: %c0_i4: i4) -> (R0_data: i40, RW0_rdata: i40)
+    // CHECK: %_M_mask_ext.R0_data, %_M_mask_ext.RW0_rdata = hw.instance "_M_mask_ext" @_M_mask_combMem(R0_addr: %c0_i10: i10, R0_en: %true: i1, R0_clk: %clock1: i1, RW0_addr: %c0_i10: i10, RW0_en: %true: i1, RW0_clk: %clock1: i1, RW0_wmode: %true: i1, RW0_wdata: %0: i40, RW0_wmask: %c0_i4: i4, W0_addr: %c0_i10: i10, W0_en: %inpred: i1, W0_clk: %clock2: i1, W0_data: %indata: i40, W0_mask: %c0_i4: i4) -> (R0_data: i40, RW0_rdata: i40)
     // CHECK: hw.output %_M_mask_ext.R0_data, %_M_mask_ext.RW0_rdata : i40, i40
 
       %0 = firrtl.subfield %_M_read(3) : (!firrtl.bundle<addr: uint<10>, en: uint<1>, clk: clock, data flip: sint<40>>) -> !firrtl.sint<40>
@@ -959,7 +916,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
 
-    // CHECK:  %_M_ext.R0_data = hw.instance "_M_ext" @FIRRTLMem_1_0_0_42_12_0_1_0_0_1_0(R0_addr: %c0_i4: i4, R0_en: %true: i1, R0_clk: %clock1: i1) -> (R0_data: i42)
+    // CHECK:  %_M_ext.R0_data = hw.instance "_M_ext" @_M_combMem(R0_addr: %c0_i4: i4, R0_en: %true: i1, R0_clk: %clock1: i1) -> (R0_data: i42)
     %_M_read = firrtl.mem Undefined {depth = 12 : i64, name = "_M", portNames = ["read"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>
     // Read port.
     %6 = firrtl.subfield %_M_read(0) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>) -> !firrtl.uint<4>
@@ -1042,7 +999,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-LABEL: hw.module private @MemDepth1
   firrtl.module private @MemDepth1(in %clock: !firrtl.clock, in %en: !firrtl.uint<1>,
                            in %addr: !firrtl.uint<1>, out %data: !firrtl.uint<32>) {
-    // CHECK: %mem0_ext.R0_data = hw.instance "mem0_ext" @FIRRTLMem_1_0_0_32_1_0_1_0_1_1_0(R0_addr: %addr: i1, R0_en: %en: i1, R0_clk: %clock: i1) -> (R0_data: i32)
+    // CHECK: %mem0_ext.R0_data = hw.instance "mem0_ext" @mem0_combMem(R0_addr: %addr: i1, R0_en: %en: i1, R0_clk: %clock: i1) -> (R0_data: i32)
     // CHECK: hw.output %mem0_ext.R0_data : i32
     %mem0_load0 = firrtl.mem Old {depth = 1 : i64, name = "mem0", portNames = ["load0"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
     %0 = firrtl.subfield %mem0_load0(2) : (!firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>) -> !firrtl.clock
@@ -1160,7 +1117,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // lowered to an "aa" memory. Even if the clock is passed via different wires,
     // we should identify the clocks to be same.
     //
-    // CHECK: hw.instance "aa_ext" @FIRRTLMem_0_2_0_8_16_1_1_1_0_1_0_aa
+    // CHECK: hw.instance "aa_ext" @aa_combMem
     %memory_aa_w0, %memory_aa_w1 = firrtl.mem Undefined {depth = 16 : i64, name = "aa", portNames = ["w0", "w1"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
     %clk_aa_w0 = firrtl.subfield %memory_aa_w0(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.clock
     %clk_aa_w1 = firrtl.subfield %memory_aa_w1(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.clock
@@ -1174,7 +1131,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // This memory has different clocks for each write port.  It should be
     // lowered to an "ab" memory.
     //
-    // CHECK: hw.instance "ab_ext" @FIRRTLMem_0_2_0_8_16_1_1_1_0_1_0_ab
+    // CHECK: hw.instance "ab_ext" @ab_combMem
     %memory_ab_w0, %memory_ab_w1 = firrtl.mem Undefined {depth = 16 : i64, name = "ab", portNames = ["w0", "w1"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
     %clk_ab_w0 = firrtl.subfield %memory_ab_w0(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.clock
     %clk_ab_w1 = firrtl.subfield %memory_ab_w1(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.clock
@@ -1186,7 +1143,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // annotation blocking this from being optimized away).  This should be
     // lowered to an "aa" since they are identical.
     //
-    // CHECK: hw.instance "ab_node_ext" @FIRRTLMem_0_2_0_8_16_1_1_1_0_1_0_aa
+    // CHECK: hw.instance "ab_node_ext" @aa_combMem
     %memory_ab_node_w0, %memory_ab_node_w1 = firrtl.mem Undefined {depth = 16 : i64, name = "ab_node", portNames = ["w0", "w1"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
     %clk_ab_node_w0 = firrtl.subfield %memory_ab_node_w0(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.clock
     %clk_ab_node_w1 = firrtl.subfield %memory_ab_node_w1(2) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.clock
@@ -1644,7 +1601,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   }
   // CHECK-LABEL: hw.module private @inferUnmaskedMemory
   // CHECK-NEXT:   %[[v0:.+]] = comb.and %rEn, %wMask : i1
-  // CHECK-NEXT:   %tbMemoryKind1_ext.R0_data = hw.instance "tbMemoryKind1_ext" @tbMemoryKind1_ext(R0_addr: %rAddr: i4, R0_en: %rEn: i1, R0_clk: %clock: i1, W0_addr: %rAddr: i4, W0_en: %[[v0]]: i1, W0_clk: %clock: i1, W0_data: %wData: i8) -> (R0_data: i8)
+  // CHECK-NEXT:   %tbMemoryKind1_ext.R0_data = hw.instance "tbMemoryKind1_ext" @tbMemoryKind1_combMem(R0_addr: %rAddr: i4, R0_en: %rEn: i1, R0_clk: %clock: i1, W0_addr: %rAddr: i4, W0_en: %[[v0]]: i1, W0_clk: %clock: i1, W0_data: %wData: i8) -> (R0_data: i8)
   // CHECK-NEXT:   hw.output %tbMemoryKind1_ext.R0_data : i8
 
   // CHECK-LABEL: hw.module private @eliminateSingleOutputConnects


### PR DESCRIPTION
This commit sets the Combinational memory wrapper module name and file location, instead of the generic `FIRRTLMem_0_2_0_8_16_1_1_1_0_1_0_aa` formatted name and default file location.
Use the name associated with `firrtl.mem` to derive the wrapper module name, after appending it with `_combMem`.
This ensures the correct module prefix is used for the wrapper module. (For example `SiFive` prefix for DUT modules and not otherwise).
For memories outside the DUT, set the output file directory to the TestBench directory if available. 
This change requires to add the `MemOp` to the `FirMemory`, such that the memory dedup can be done in `LowerToHW`.
Use a map `memoryNameMap` to get the correct `HWModuleGeneratedOp`  names for deduped memories.