### PR TITLE
[Handshake] Add type equality checks to InstanceOp

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -114,7 +114,10 @@ def FuncOp : Op<Handshake_Dialect, "func", [
 }
 
 // InstanceOp
-def InstanceOp : Handshake_Op<"instance", [CallOpInterface]> {
+def InstanceOp : Handshake_Op<"instance", [
+    CallOpInterface,
+    DeclareOpInterfaceMethods<SymbolUserOpInterface>
+]> {
   let summary = "module instantiate operation";
   let description = [{
     The `instance` operation represents the instantiation of a module.  This

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -1435,6 +1435,42 @@ ParseResult JoinOp::parse(OpAsmParser &parser, OperationState &result) {
 
 void JoinOp::print(OpAsmPrinter &p) { sost::printOp(p, *this, false); }
 
+/// Based on mlir::func::CallOp::verifySymbolUses
+LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  // Check that the module attribute was specified.
+  auto fnAttr = this->moduleAttr();
+  assert(fnAttr && "requires a 'module' symbol reference attribute");
+
+  FuncOp fn = symbolTable.lookupNearestSymbolFrom<FuncOp>(*this, fnAttr);
+  if (!fn)
+    return emitOpError() << "'" << fnAttr.getValue()
+                         << "' does not reference a valid handshake function";
+
+  // Verify that the operand and result types match the callee.
+  auto fnType = fn.getFunctionType();
+  if (fnType.getNumInputs() != getNumOperands())
+    return emitOpError(
+        "incorrect number of operands for the referenced handshake function");
+
+  for (unsigned i = 0, e = fnType.getNumInputs(); i != e; ++i)
+    if (getOperand(i).getType() != fnType.getInput(i))
+      return emitOpError("operand type mismatch: expected operand type ")
+             << fnType.getInput(i) << ", but provided "
+             << getOperand(i).getType() << " for operand number " << i;
+
+  if (fnType.getNumResults() != getNumResults())
+    return emitOpError(
+        "incorrect number of results for the referenced handshake function");
+
+  for (unsigned i = 0, e = fnType.getNumResults(); i != e; ++i)
+    if (getResult(i).getType() != fnType.getResult(i))
+      return emitOpError("result type mismatch: expected result type ")
+             << fnType.getResult(i) << ", but provided "
+             << getResult(i).getType() << " for result number " << i;
+
+  return success();
+}
+
 LogicalResult InstanceOp::verify() {
   if ((*this)->getNumOperands() == 0)
     return emitOpError() << "must provide at least a control operand.";

--- a/test/Dialect/Handshake/errors.mlir
+++ b/test/Dialect/Handshake/errors.mlir
@@ -41,9 +41,71 @@ handshake.func @foo(%ctrl : none) -> none{
   return %ctrl : none
 }
 
+handshake.func @invalid_instance_op(%arg0 : i32, %ctrl : none) -> none {
+  // expected-error @+1 {{'handshake.instance' op incorrect number of operands for the referenced handshake function}}
+  instance @foo(%arg0, %ctrl) : (i32, none) -> ()
+  return %ctrl : none
+}
+
+// -----
+
+handshake.func @foo(%arg0 : i32, %ctrl : none) -> (none) {
+  return %ctrl : none
+}
+
+handshake.func @invalid_instance_op(%arg0 : i64, %ctrl : none) -> none {
+  // expected-error @+1 {{'handshake.instance' op operand type mismatch: expected operand type 'i32', but provided 'i64' for operand number 0}}
+  instance @foo(%arg0, %ctrl) : (i64, none) -> (none)
+  return %ctrl : none
+}
+
+// -----
+
+handshake.func @foo(%ctrl : none) -> (i32, none) {
+  %0 = constant %ctrl {value = 1 : i32} : i32
+  return %0, %ctrl : i32, none
+}
+
+handshake.func @invalid_instance_op(%arg0 : i32, %ctrl : none) -> none {
+  // expected-error @+1 {{'handshake.instance' op incorrect number of results for the referenced handshake function}}
+  instance @foo(%ctrl) : (none) -> (none)
+  return %ctrl : none
+}
+
+// -----
+
+handshake.func @foo(%ctrl : none) -> (i32, none) {
+  %0 = constant %ctrl {value = 1 : i32} : i32
+  return %0, %ctrl : i32, none
+}
+
+handshake.func @invalid_instance_op(%arg0 : i32, %ctrl : none) -> none {
+  // expected-error @+1 {{'handshake.instance' op result type mismatch: expected result type 'i32', but provided 'i64' for result number 0}}
+  %0, %outCtrl = instance @foo(%ctrl) : (none) -> (i64, none)
+  return %ctrl : none
+}
+
+// -----
+
+handshake.func @foo(%ctrl : none) -> none{
+  return %ctrl : none
+}
+
 handshake.func @invalid_instance_op(%ctrl : none) -> none {
   // expected-error @+1 {{'handshake.instance' op must provide at least a control operand.}}
   instance @foo() : () -> ()
+  return %ctrl : none
+}
+
+// -----
+
+func.func @foo() {
+  return
+}
+
+handshake.func @invalid_instance_op(%ctrl : none) -> none {
+  // expected-error @+1 {{'handshake.instance' op 'foo' does not reference a valid handshake function}}
+  instance @foo(%ctrl) : (none) -> (none)
   return %ctrl : none
 }
 


### PR DESCRIPTION
This patch adds the `SymbolUserOpInterface` to the `InstanceOp` which is used to enforce type equality of the operation and the `FuncOp` it calls.

The code is based on the same verifier for `mlir::func::CallOp`.