### PR TITLE
[FIRRTL] basic support for subcircuit signal driving flows

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -87,9 +87,7 @@ std::unique_ptr<mlir::Pass> createGrandCentralPass();
 std::unique_ptr<mlir::Pass> createGrandCentralTapsPass();
 
 std::unique_ptr<mlir::Pass>
-createGrandCentralSignalMappingsPass(StringRef outputFilename = "",
-                                     StringRef markDut = "",
-                                     StringRef Prefix = "");
+createGrandCentralSignalMappingsPass(StringRef outputFilename = "");
 
 std::unique_ptr<mlir::Pass> createCheckCombCyclesPass();
 

--- a/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
@@ -1563,7 +1563,7 @@ bool circt::firrtl::scatterCustomAnnotations(
 
       // A callback that will scatter every source and sink target pair to the
       // corresponding two ends of the connection.
-      bool emitJSON = false;
+      bool isSubCircuit = false;
       llvm::StringSet annotatedModules;
       auto handleTarget = [&](Attribute attr, unsigned i, bool isSource) {
         auto targetId = newID();
@@ -1610,7 +1610,7 @@ bool circt::firrtl::scatterCustomAnnotations(
           // Indicate that this requires JSON emission (whereas the main circuit
           // does not).
           if (pair.second)
-            emitJSON = true;
+            isSubCircuit = true;
 
           // Assemble the annotation on this side of the connection.
           NamedAttrList fields;
@@ -1674,10 +1674,9 @@ bool circt::firrtl::scatterCustomAnnotations(
         if (!handleTarget(attr, i++, false))
           return false;
 
-      // Add the emitJSON attribute as we now have enough information to know if
-      // we are in the subcircuit or the main circuit.
-      if (emitJSON)
-        fields.append("emitJSON", UnitAttr::get(context));
+      // Add field indicating if we're the subcircuit or not.
+      fields.append("isSubCircuit", BoolAttr::get(context, isSubCircuit));
+
       newAnnotations["~"].push_back(DictionaryAttr::get(context, fields));
 
       // Indicate which modules have embedded `SignalDriverAnnotation`s.

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
@@ -11,11 +11,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/AnnotationDetails.h"
 #include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
 #include "circt/Dialect/FIRRTL/Namespace.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/SV/SVOps.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/Threading.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/JSON.h"
@@ -29,8 +31,29 @@ namespace json = llvm::json;
 using namespace circt;
 using namespace firrtl;
 
-static constexpr const char *signalDriverAnnoClass =
-    "sifive.enterprise.grandcentral.SignalDriverAnnotation";
+//===- Terminology and useful information ---------------------------------===//
+//
+// For SignalDriver annotations, "local" refers to the subcircuit that
+// drives/probes values in the main "remote" circuit.
+//
+// Driven values ("sinks"), are set via 'force XMR = input_port;' statements.
+// Probes ("sources"), are read via 'assign output_port = XMR;' statements.
+//
+// The end goal is a mappings module that is generated and instantiated in the
+// subcircuit which interacts with targeted values in the main circuit.
+//
+//===- Flow ---------------------------------------------------------------===//
+//
+// Signal driver annotations are needed when processing both circuits:
+//
+// First the original annotations are used with the main circuit, in order to
+// emit extra wires around forced inputs and to emit updated annotations
+// pointing to the values across naming or hierarchy changes performed.
+//
+// Second these updated annotations are used when processing the subcircuit
+// which is when the mappings module is created and instantiated.
+//
+//===----------------------------------------------------------------------===//
 
 //===----------------------------------------------------------------------===//
 // Per-Module Signal Mappings
@@ -39,10 +62,10 @@ static constexpr const char *signalDriverAnnoClass =
 namespace {
 enum class MappingDirection {
   /// The local signal forces the remote signal.
-  DriveRemote,
+  DriveRemote, // Sink
   /// The local signal is driven to the value of the remote signal through a
   /// connect.
-  ProbeRemote,
+  ProbeRemote, // Source
 };
 
 /// The information necessary to connect a local signal in a module to a remote
@@ -60,6 +83,10 @@ struct SignalMapping {
   /// The name of the local value, for reuse in the generated signal mappings
   /// module.
   StringAttr localName;
+  /// Which "side" we're on
+  bool isLocal;
+  /// NLA, if present
+  FlatSymbolRefAttr nlaSym;
 };
 
 /// A helper structure that collects the data necessary to generate the signal
@@ -73,13 +100,12 @@ struct ModuleSignalMappings {
   void instantiateMappingsModule(FModuleOp mappingsModule);
 
   FModuleOp module;
-  bool allAnalysesPreserved = false;
+  bool allAnalysesPreserved = true;
   SmallVector<SignalMapping> mappings;
   SmallString<64> mappingsModuleName;
 
   StringRef markDut;
   StringRef prefix;
-  DenseSet<unsigned> forcedInputPorts;
 };
 } // namespace
 
@@ -98,6 +124,8 @@ static T &operator<<(T &os, const SignalMapping &mapping) {
 /// references and `ForceOp`s to probe and drive remote signals. This is
 /// dictated by the presence of `SignalDriverAnnotation` on the module and
 /// individual operations inside it.
+/// If the module is the "remote" (main) circuit, gather those mappings
+/// for use handling forced input ports and creating updated mappings.
 void ModuleSignalMappings::run() {
   // Check whether this module has any `SignalDriverAnnotation`s. These indicate
   // whether the module contains any operations with such annotations and
@@ -105,7 +133,6 @@ void ModuleSignalMappings::run() {
   if (!AnnotationSet::removeAnnotations(module, signalDriverAnnoClass)) {
     LLVM_DEBUG(llvm::dbgs() << "Skipping `" << module.getName()
                             << "` (has no annotations)\n");
-    allAnalysesPreserved = true;
     return;
   }
   LLVM_DEBUG(llvm::dbgs() << "Running on module `" << module.getName()
@@ -133,22 +160,35 @@ void ModuleSignalMappings::run() {
     });
   });
 
-  // Remove connections to sources.  This is done to cleanup invalidations that
-  // occur from the Chisel API of Grand Central.
-  for (auto mapping : mappings)
+  auto localMappings =
+      llvm::make_filter_range(mappings, [](auto &m) { return m.isLocal; });
+
+  // Remove connections to sources in the subcircuit.  This is done to cleanup
+  // invalidations that occur from the Chisel API of Grand Central.
+  // Only the remote value "source" should be connected to local source values.
+  for (auto mapping : localMappings)
     if (mapping.dir == MappingDirection::ProbeRemote) {
       for (auto &use : llvm::make_early_inc_range(mapping.localValue.getUses()))
         if (auto connect = dyn_cast<FConnectLike>(use.getOwner()))
-          if (connect.dest() == mapping.localValue)
+          if (connect.dest() == mapping.localValue) {
             connect.erase();
+            allAnalysesPreserved = false;
+          };
     }
 
-  // If this module either
-  if (mappings.empty()) {
+  // If there aren't any local-side (subcircuit-side) mappings, we're done.
+  if (localMappings.empty()) {
     LLVM_DEBUG(llvm::dbgs() << "Skipping `" << module.getName()
                             << "` (has no non-zero sources or sinks)\n");
-    allAnalysesPreserved = true;
     return;
+  }
+
+  // Changes are coming, mark analyses not preserved
+  allAnalysesPreserved = false;
+
+  if (!llvm::all_of(mappings, [](auto &m) { return m.isLocal; })) {
+    emitWarning(module->getLoc(),
+                "both remote and local SignalDriverAnnotation mappings found");
   }
 
   // Pick a name for the module that implements the signal mappings.
@@ -179,31 +219,14 @@ void ModuleSignalMappings::addTarget(Value value, Annotation anno) {
   mapping.remoteTarget = anno.getMember<StringAttr>("peer");
   mapping.localValue = value;
   mapping.type = value.getType().cast<FIRRTLType>();
-
-  // Only continue to emit signal driving code for the "local" side of these
-  // annotations, which sits in the sub-circuit and interacts with the main
-  // circuit on the "remote" side.  If we are in the "remote" side of the
-  // annotation, which sits in the main circuit, then record if we ever see any
-  // forces of module inputs.  These require special fixups due to the fact that
-  // SV force will force the entire net connected to the port as well.
-  if (anno.getMember<StringAttr>("side").getValue() != "local") {
-    if (mapping.dir != MappingDirection::DriveRemote)
-      return;
-    auto blockArg = value.dyn_cast<BlockArgument>();
-    if (!blockArg)
-      return;
-    auto portIdx = blockArg.getArgNumber();
-    if (module.getPortDirection(portIdx) == Direction::Out)
-      return;
-    forcedInputPorts.insert(portIdx);
-    return;
-  }
+  mapping.isLocal = anno.getMember<StringAttr>("side").getValue() == "local";
+  mapping.nlaSym = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal");
 
   // Guess a name for the local value. This is only for readability's sake,
   // giving the pass a hint for picking the names of the generated module ports.
   if (auto blockArg = value.dyn_cast<BlockArgument>()) {
     mapping.localName = module.getPortNameAttr(blockArg.getArgNumber());
-  } else if (auto op = value.getDefiningOp()) {
+  } else if (auto *op = value.getDefiningOp()) {
     mapping.localName = op->getAttrOfType<StringAttr>("name");
   }
 
@@ -219,7 +242,9 @@ FModuleOp ModuleSignalMappings::emitMappingsModule() {
   // Determine what ports this module will have, given the signal mappings we
   // are supposed to emit.
   SmallVector<PortInfo> ports;
-  for (auto &mapping : mappings) {
+  auto localMappings =
+      llvm::make_filter_range(mappings, [](auto &m) { return m.isLocal; });
+  for (auto &mapping : localMappings) {
     ports.push_back(PortInfo{mapping.localName,
                              mapping.type,
                              mapping.dir == MappingDirection::DriveRemote
@@ -238,7 +263,7 @@ FModuleOp ModuleSignalMappings::emitMappingsModule() {
   // Generate the connect and force statements inside the module.
   builder.setInsertionPointToStart(mappingsModule.getBody());
   unsigned portIdx = 0;
-  for (auto &mapping : mappings) {
+  for (auto &mapping : localMappings) {
     // TODO: Actually generate a proper XMR here. For now just do some textual
     // replacements. Generating a real IR node (like a proper XMR op) would be
     // much better, but the modules that `EmitSignalMappings` interacts with
@@ -249,11 +274,13 @@ FModuleOp ModuleSignalMappings::emitMappingsModule() {
     // llvm::errs() << "Rewriting " << circuitName << " " << pathName <<
     // "\nWith: " << markDut << " " << Prefix << "\n";
     bool seenRoot = false;
+    auto [modulePath, varPath] = pathName.split('>');
     if (markDut.empty()) {
-      remoteXmrName += circuitName.drop_front();
+      // If no DUT, top-level is first module in modulePath
+      // ("~Top|Foo/b:B" -> "Foo.b")
+      remoteXmrName += modulePath.split('/').first;
       seenRoot = true;
     }
-    auto [modulePath, varPath] = pathName.split('>');
     do {
       auto [item, tail] = modulePath.split(':');
       modulePath = tail;
@@ -303,7 +330,9 @@ void ModuleSignalMappings::instantiateMappingsModule(FModuleOp mappingsModule) {
 
   // Generate the connections to and from the instance.
   unsigned portIdx = 0;
-  for (auto &mapping : mappings) {
+  auto localMappings =
+      llvm::make_filter_range(mappings, [](auto &m) { return m.isLocal; });
+  for (auto &mapping : localMappings) {
     Value dst = inst.getResult(portIdx++);
     Value src = mapping.localValue;
     if (mapping.dir == MappingDirection::ProbeRemote)
@@ -316,8 +345,40 @@ void ModuleSignalMappings::instantiateMappingsModule(FModuleOp mappingsModule) {
 // Pass Infrastructure
 //===----------------------------------------------------------------------===//
 
+/// External modules, for emitting when processing subcircuit
+struct ExtModules {
+  /// External modules put in the vsrcs field of the JSON.
+  SmallVector<FExtModuleOp> vsrc;
+  /// External modules put in the "load_jsons" field of the JSON.
+  SmallVector<FExtModuleOp> json;
+};
+
+/// Information gathered about mappings, used for identifying forced input ports
+/// and generating updated mappings for the remote side (main circuit).
+struct ModuleMappingResult {
+  /// Were changes made that invalidate analyses?
+  bool allAnalysesPreserved;
+  /// Module scanned
+  FModuleOp module;
+  /// Signal mappings whose remote targets are in this circuit
+  SmallVector<SignalMapping> remoteMappings;
+};
+
 class GrandCentralSignalMappingsPass
     : public GrandCentralSignalMappingsBase<GrandCentralSignalMappingsPass> {
+
+  /// Generate operation to output list of external modules
+  /// Used when processing the sub- (local) circuit.
+  void emitSubCircuitJSON(CircuitOp circuit, StringAttr circuitPackage,
+                          StringRef outputFilename,
+                          const ExtModules &extmodules);
+
+  /// Fixup forced input ports and emit updated mappings
+  /// Used when processing the main (remote) circuit.
+  FailureOr<bool>
+  emitUpdatedMappings(CircuitOp circuit, StringAttr circuitPackage,
+                      MutableArrayRef<ModuleMappingResult> result);
+
   void runOnOperation() override;
 
 public:
@@ -329,44 +390,41 @@ public:
 void GrandCentralSignalMappingsPass::runOnOperation() {
   CircuitOp circuit = getOperation();
 
-  bool emitJSON = false;
   StringAttr circuitPackage;
-  AnnotationSet::removeAnnotations(circuit, [&](Annotation anno) {
-    if (!anno.isClass("sifive.enterprise.grandcentral.SignalDriverAnnotation"))
-      return false;
+  BoolAttr isSubCircuitAttr;
+  bool circuitHasAnno =
+      AnnotationSet::removeAnnotations(circuit, [&](Annotation anno) {
+        if (!anno.isClass(signalDriverAnnoClass))
+          return false;
 
-    emitJSON = anno.getDict().contains("emitJSON");
-    circuitPackage = anno.getMember<StringAttr>("circuitPackage");
-    return true;
-  });
+        isSubCircuitAttr = anno.getMember<BoolAttr>("isSubCircuit");
+        circuitPackage = anno.getMember<StringAttr>("circuitPackage");
+        return true;
+      });
 
-  if (emitJSON && !circuitPackage) {
+  if (!circuitHasAnno) {
+    // Nothing to do here
+    markAllAnalysesPreserved();
+    return;
+  }
+
+  if (!isSubCircuitAttr) {
+    emitError(
+        circuit->getLoc(),
+        "has invalid SignalDriverAnnotation (missing 'isSubCircuit' field')");
+    return signalPassFailure();
+  }
+  bool isSubCircuit = isSubCircuitAttr.getValue();
+
+  if (isSubCircuit && !circuitPackage) {
     emitError(circuit->getLoc())
-        << "has invalid SignalDriverAnnotation (JSON emission is enabled, but "
-           "no circuitPacakge was provided";
+        << "has invalid SignalDriverAnnotation (subcircuit JSON emission is "
+           "enabled, but no circuitPackage was provided)";
     return signalPassFailure();
   }
 
-  typedef struct {
-    bool allAnalysesPreserved;
-    DenseMap<FModuleOp, DenseSet<unsigned>> forcedInputPorts;
-  } Result;
-
-  auto processModule = [this](FModuleOp module) -> Result {
-    ModuleSignalMappings mapper(module, markDut, prefix);
-    mapper.run();
-    return {mapper.allAnalysesPreserved,
-            DenseMap<FModuleOp, DenseSet<unsigned>>(
-                {{module, mapper.forcedInputPorts}})};
-  };
-
   SmallVector<FModuleOp> modules;
-  struct {
-    // External modules put in the vsrcs field of the JSON.
-    SmallVector<FExtModuleOp> vsrc;
-    // External modules put in the "load_jsons" field of the JSON.
-    SmallVector<FExtModuleOp> json;
-  } extmodules;
+  ExtModules extmodules;
 
   for (auto op : circuit.body().getOps<FModuleLike>()) {
     if (auto *extModule = dyn_cast<FExtModuleOp>(&op)) {
@@ -381,46 +439,42 @@ void GrandCentralSignalMappingsPass::runOnOperation() {
     }
   }
 
-  auto reduce = [](const Result &acc, Result result) -> Result {
-    DenseMap<FModuleOp, DenseSet<unsigned>> foo = acc.forcedInputPorts;
-    foo.insert(result.forcedInputPorts.begin(), result.forcedInputPorts.end());
-    return {acc.allAnalysesPreserved && result.allAnalysesPreserved, foo};
-  };
-  // Note: this uses (unsigned)true instead of (bool)true for the reduction
-  // because llvm::parallelTransformReduce uses the "data" method of std::vector
-  // which is NOT provided for bool for optimization reasons.
-  Result result = llvm::parallelTransformReduce(
-      modules.begin(), modules.end(), Result(), reduce, processModule);
+  // Pre-allocate result vector
+  SmallVector<ModuleMappingResult> results;
+  results.resize(modules.size());
 
-  auto *instanceGraph = &getAnalysis<InstanceGraph>();
-  DenseMap<FModuleOp, ModuleNamespace> moduleNamespaces;
-  for (auto fixup : result.forcedInputPorts) {
-    for (auto portIdx : fixup.second) {
-      for (auto *use : instanceGraph->lookup(fixup.first)->uses()) {
-        auto inst = use->getInstance();
-        auto port = inst->getResult(portIdx);
-        OpBuilder builder(inst.getContext());
-        builder.setInsertionPointAfter(inst);
-        auto parentModule = inst->getParentOfType<FModuleOp>();
-        ModuleNamespace &moduleNamespace = moduleNamespaces[parentModule];
-        auto wire = builder.create<WireOp>(
-            builder.getUnknownLoc(), port.getType(), builder.getStringAttr({}),
-            builder.getArrayAttr({}),
-            builder.getStringAttr(moduleNamespace.newName("_GEN")));
-        port.replaceAllUsesWith(wire);
-        builder.create<StrictConnectOp>(builder.getUnknownLoc(), port, wire);
-      }
-    }
+  mlir::parallelForEachN(
+      circuit.getContext(), 0, modules.size(),
+      [this, &modules, &results](size_t index) {
+        ModuleSignalMappings mapper(modules[index], markDut, prefix);
+        mapper.run();
+        results[index] = {
+            mapper.allAnalysesPreserved, modules[index],
+            SmallVector<SignalMapping>{llvm::make_filter_range(
+                mapper.mappings, [](auto &m) { return !m.isLocal; })}};
+      });
+  bool allAnalysesPreserved =
+      llvm::all_of(results, [](auto &r) { return r.allAnalysesPreserved; });
+
+  // If this is a subcircuit, then emit JSON information necessary to drive
+  // SiFive tools.
+  // Otherwise handle any forced input ports and emit updated mappings.
+  if (isSubCircuit) {
+    emitSubCircuitJSON(circuit, circuitPackage, outputFilename, extmodules);
+  } else {
+    auto result = emitUpdatedMappings(circuit, circuitPackage, results);
+    if (failed(result))
+      return signalPassFailure();
+    allAnalysesPreserved &= *result;
   }
 
-  if (result.allAnalysesPreserved)
+  if (allAnalysesPreserved)
     markAllAnalysesPreserved();
+}
 
-  // If this is a subcircuit, then continue on and emit JSON information
-  // necessary to drive SiFive tools.
-  if (!emitJSON)
-    return;
-
+void GrandCentralSignalMappingsPass::emitSubCircuitJSON(
+    CircuitOp circuit, StringAttr circuitPackage, StringRef outputFilename,
+    const ExtModules &extmodules) {
   std::string jsonString;
   llvm::raw_string_ostream jsonStream(jsonString);
   json::OStream j(jsonStream, 2);
@@ -463,6 +517,211 @@ void GrandCentralSignalMappingsPass::runOnOperation() {
       "output_file",
       hw::OutputFileAttr::getFromFilename(
           b.getContext(), Twine(circuitPackage) + ".subcircuit.json", true));
+}
+
+FailureOr<bool> GrandCentralSignalMappingsPass::emitUpdatedMappings(
+    CircuitOp circuit, StringAttr circuitPackage,
+    MutableArrayRef<ModuleMappingResult> results) {
+  bool allAnalysesPreserved = true;
+
+  // 1) Sanity checking
+  // 2) Fixup ports that are driven from subcircuit
+  // 3) Generate new remote references
+  //    For now, just drive/probe using `module.name` XMR's,
+  //    it's much simpler than emitting hierarchical paths
+  //    from the top module/DUT, and works for now.
+  // 4) Emit updated mappings as SignalDriverAnnotations
+  //    for consumption when processing the subcircuit
+  //    (as replacements for the original annotations)
+
+  // Helper to instantiate module namespaces as-needed
+  DenseMap<FModuleOp, ModuleNamespace> moduleNamespaces;
+  auto getModuleNamespace =
+      [&moduleNamespaces](FModuleOp module) -> ModuleNamespace & {
+    return moduleNamespaces.try_emplace(module, module).first->second;
+  };
+
+  // (1) Scan mappings for unexpected or unsupported values
+  for (auto const &[_, mod, mappings] : results) {
+    for (auto &mapping : mappings) {
+      // This isn't handled yet, error out instead of doing wrong thing
+      if (mapping.nlaSym) {
+        emitError(mapping.localValue.getLoc())
+            << "non-local value targeted by SignalDriverAnnotation, "
+               "unsupported (NLA found)";
+        return failure();
+      }
+      // No local-side mappings on main circuit side
+      if (mapping.isLocal) {
+        emitError(mapping.localValue.getLoc())
+            << "local-side SignalDriverAnnotation found in main circuit, "
+               "mixing not supported";
+        return failure();
+      }
+    }
+  }
+
+  // (2) Find input ports that are sinks, insert wires at instantiation points
+  auto *instanceGraph = &getAnalysis<InstanceGraph>();
+  DenseSet<unsigned> forcedInputPorts;
+  for (auto &[_, mod, mappings] : results) {
+    // Walk mappings looking for module ports that are being driven,
+    // and gather their indices for fixing up.
+    forcedInputPorts.clear();
+    for (auto &mapping : mappings) {
+      if (mapping.dir == MappingDirection::DriveRemote /* Sink */) {
+        if (auto blockArg = mapping.localValue.dyn_cast<BlockArgument>()) {
+          auto portIdx = blockArg.getArgNumber();
+          if (mod.getPortDirection(portIdx) == Direction::In) {
+            if (!forcedInputPorts.insert(portIdx).second) {
+              emitError(blockArg.getLoc())
+                  << "module port driven more than once, unsupported "
+                     "SignalDriverAnnotation";
+              return failure();
+            }
+          }
+        }
+      }
+    }
+
+    // Find all instantiations of this module, and replace uses of each driven
+    // port with a wire that's connected to a wire that is connected to the
+    // port. This is done to cause an 'assign' to be created, disconnecting
+    // the forced input port's net from its uses.
+    if (forcedInputPorts.empty())
+      continue;
+
+    unsigned useCount = 0;
+    for (auto *use : instanceGraph->lookup(mod)->uses()) {
+      // Ensure just the one use for now, this matters if we want
+      // to be able to emit a unique path from the top module.
+      if (++useCount != 1) {
+        emitError(mod.getLoc())
+            << "module with input port driven instantiated more than once, "
+               "unsupported SignalDriverAnnotation";
+
+        return failure();
+      }
+      allAnalysesPreserved = false;
+
+      auto inst = use->getInstance();
+      OpBuilder builder(inst.getContext());
+      builder.setInsertionPointAfter(inst);
+      auto parentModule = inst->getParentOfType<FModuleOp>();
+      ModuleNamespace &moduleNamespace = getModuleNamespace(parentModule);
+
+      for (auto portIdx : forcedInputPorts) {
+        auto port = inst->getResult(portIdx);
+
+        // Create chain like:
+        // port_result <= foo_dataIn_x_buffer
+        // foo_dataIn_x_buffer <= foo_dataIn_x
+        auto replacementWireName =
+            builder.getStringAttr(moduleNamespace.newName(
+                mod.moduleName() + "_" + mod.getPortName(portIdx)));
+        auto bufferWireName = builder.getStringAttr(moduleNamespace.newName(
+            replacementWireName.getValue() + "_buffer"));
+        auto bufferWire = builder.create<WireOp>(
+            builder.getUnknownLoc(), port.getType(), bufferWireName,
+            builder.getArrayAttr({}), bufferWireName);
+        auto replacementWire = builder.create<WireOp>(
+            builder.getUnknownLoc(), port.getType(), replacementWireName,
+            builder.getArrayAttr({}), replacementWireName);
+        port.replaceAllUsesWith(replacementWire);
+        builder.create<StrictConnectOp>(builder.getUnknownLoc(), port,
+                                        bufferWire);
+        builder.create<StrictConnectOp>(builder.getUnknownLoc(), bufferWire,
+                                        replacementWire);
+      }
+    }
+  }
+
+  // (3) Generate updated remote references
+  // Helpers to emit basic 'module.name' XMR's for the mappings.
+  // Use inner_sym for non-ports
+  SmallVector<Attribute> symbols;
+  auto getOrAddInnerSym = [&](Operation *op) -> StringAttr {
+    auto attr = op->getAttrOfType<StringAttr>("inner_sym");
+    if (attr)
+      return attr;
+    StringRef name = "sym";
+    if (auto nameAttr = op->getAttrOfType<StringAttr>("name"))
+      name = nameAttr.getValue();
+    auto module = op->getParentOfType<FModuleOp>();
+    name = getModuleNamespace(module).newName(name);
+    attr = StringAttr::get(op->getContext(), name);
+    op->setAttr("inner_sym", attr);
+    return attr;
+  };
+  auto mkRef = [&](FModuleOp module,
+                   const SignalMapping &mapping) -> std::string {
+    if (mapping.localValue.isa<BlockArgument>()) {
+      return llvm::formatv("~{0}|{1}>{2}", circuit.name(), module.getName(),
+                           mapping.localName);
+    }
+    auto idx = symbols.size();
+    symbols.push_back(hw::InnerRefAttr::get(
+        SymbolTable::getSymbolName(module),
+        getOrAddInnerSym(mapping.localValue.getDefiningOp())));
+    return llvm::formatv("~{0}|{1}>{2}", circuit.name(), module.getName(),
+                         "{{" + Twine(idx) + "}}");
+  };
+
+  // Generate and sort new mappings for (better) output stability
+  SmallVector<std::pair<std::string, StringRef>, 32> sinks, sources;
+  auto addUpdatedMappings = [&](MappingDirection filterDir, auto &vec) {
+    for (auto const &[_, mod, mappings] : results)
+      for (auto &mapping : mappings)
+        if (mapping.dir == filterDir)
+          vec.emplace_back(mkRef(mod, mapping),
+                           mapping.remoteTarget.getValue());
+  };
+  addUpdatedMappings(MappingDirection::DriveRemote, sinks);
+  addUpdatedMappings(MappingDirection::ProbeRemote, sources);
+  // Sort on local targets only, remote may contain substitution placeholders
+  llvm::sort(sinks, llvm::less_second());
+  llvm::sort(sources, llvm::less_second());
+
+  // (4) Emit updated mappings for consumption by subcircuit
+  std::string jsonString;
+  llvm::raw_string_ostream jsonStream(jsonString);
+  json::OStream j(jsonStream, 2);
+
+  j.array([&] {
+    j.object([&] {
+      j.attribute("class", signalDriverAnnoClass);
+      j.attributeArray("sinkTargets", [&]() {
+        for (auto &[remote, local] : sinks) {
+          j.objectBegin();
+          j.attribute("_1", remote);
+          j.attribute("_2", local);
+          j.objectEnd();
+        };
+      });
+      j.attributeArray("sourceTargets", [&]() {
+        for (auto &[remote, local] : sources) {
+          j.objectBegin();
+          j.attribute("_1", remote);
+          j.attribute("_2", local);
+          j.objectEnd();
+        };
+      });
+      // Emit these but don't attempt to plumb through their original values
+      j.attribute("circuit", "circuit empty :\n  module empty :\n\n    skip\n");
+      j.attributeArray("annotations", [&]() {});
+      if (circuitPackage)
+        j.attribute("circuitPackage", circuitPackage.getValue());
+    });
+  });
+  auto b = OpBuilder::atBlockEnd(circuit.getBody());
+  auto jsonOp = b.create<sv::VerbatimOp>(b.getUnknownLoc(), jsonString,
+                                         ValueRange{}, b.getArrayAttr(symbols));
+  // TODO: plumb option to specify path/name?
+  constexpr char jsonOutFile[] = "sigdrive.json";
+  jsonOp->setAttr("output_file", hw::OutputFileAttr::getFromFilename(
+                                     b.getContext(), jsonOutFile, true));
+
+  return allAnalysesPreserved;
 }
 
 std::unique_ptr<mlir::Pass> circt::firrtl::createGrandCentralSignalMappingsPass(

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
@@ -261,7 +261,6 @@ FModuleOp ModuleSignalMappings::emitMappingsModule() {
   builder.setInsertionPointToStart(mappingsModule.getBody());
   unsigned portIdx = 0;
   for (auto &mapping : localMappings) {
-    SmallString<32> remoteXmrName;
     // TODO: Actually generate a proper XMR here. For now just do some textual
     // replacements. Generating a real IR node (like a proper XMR op) would be
     // much better, but the modules that `EmitSignalMappings` interacts with
@@ -276,6 +275,7 @@ FModuleOp ModuleSignalMappings::emitMappingsModule() {
       continue;
     }
 
+    SmallString<32> remoteXmrName;
     if (tokenized->instances.empty()) {
       // If no instance path, just use module directly
       remoteXmrName = tokenized->module;

--- a/test/Dialect/FIRRTL/SFCTests/signal-mappings.fir
+++ b/test/Dialect/FIRRTL/SFCTests/signal-mappings.fir
@@ -36,18 +36,18 @@ circuit Sub :
 ; CHECK:                   data_source_w_1);
 ; CHECK:   `ifndef VERILATOR
 ; CHECK:   initial begin
-; CHECK:     force Top.clock = clock_sink;
-; CHECK:     force Top.dataIn_a_b_c = data_sink_u;
-; CHECK:     force Top.dataIn_d = data_sink_v;
-; CHECK:     force Top.dataIn_e = data_sink_w_0;
-; CHECK:     force Top.dataIn_e = data_sink_w_1;
+; CHECK:     force Foo.clock = clock_sink;
+; CHECK:     force Foo.dataIn_a_b_c = data_sink_u;
+; CHECK:     force Foo.dataIn_d = data_sink_v;
+; CHECK:     force Foo.dataIn_e = data_sink_w_0;
+; CHECK:     force Foo.dataIn_e = data_sink_w_1;
 ; CHECK:   end
 ; CHECK:   `endif
 ; CHECK:   assign clock_source = Top.clock;
-; CHECK:   assign data_source_u = Top.dataOut_x_y_z;
-; CHECK:   assign data_source_v = Top.dataOut_w;
-; CHECK:   assign data_source_w_0 = Top.dataOut_p;
-; CHECK:   assign data_source_w_1 = Top.dataOut_p;
+; CHECK:   assign data_source_u = Foo.dataOut_x_y_z;
+; CHECK:   assign data_source_v = Foo.dataOut_w;
+; CHECK:   assign data_source_w_0 = Foo.dataOut_p;
+; CHECK:   assign data_source_w_1 = Foo.dataOut_p;
 ; CHECK: endmodule
 
 

--- a/test/Dialect/FIRRTL/SFCTests/subcircuit-flow/flow.test
+++ b/test/Dialect/FIRRTL/SFCTests/subcircuit-flow/flow.test
@@ -1,0 +1,109 @@
+; Check main circuit + subcircuit mappings flow
+
+; Execute flow both normally and with altering hierarchy (via inline)
+
+; Create some directories for output, cleanup if present
+; RUN: rm -rf %t && mkdir -p %t/default %t/inline
+
+; 1) Run on main circuit, with signal mapping annotations
+; RUN: firtool %S/main.fir --annotation-file %S/subCircuit.json --firrtl-grand-central --split-verilog -o %t/default
+; RUN: firtool %S/main.fir --annotation-file %S/subCircuit.json --annotation-file %S/inline.json --firrtl-grand-central --split-verilog -o %t/inline
+
+; Check the generated file
+; RUN: FileCheck %s --input-file=%t/default/sigdrive.json --check-prefix=JSONDEFAULT
+; RUN: FileCheck %s --input-file=%t/inline/sigdrive.json --check-prefix=JSONINLINE
+
+; JSONDEFAULT:        SignalDriverAnnotation
+; JSONDEFAULT-LABEL:    "sinkTargets"
+; JSONDEFAULT{LITERAL}:   "_1": "~Top|Foo>clock",
+; JSONDEFAULT{LITERAL}:   "_1": "~Top|Foo>dataIn_a_b_c",
+; JSONDEFAULT{LITERAL}:   "_1": "~Top|Foo>dataIn_d",
+; JSONDEFAULT{LITERAL}:   "_1": "~Top|Bar>b",
+; JSONDEFAULT-LABEL:    "sourceTargets"
+; JSONDEFAULT{LITERAL}:   "_1": "~Top|Top>clock",
+; JSONDEFAULT{LITERAL}:   "_1": "~Top|Foo>dataOut_x_y_z",
+; JSONDEFAULT{LITERAL}:   "_1": "~Top|Foo>dataOut_w",
+; JSONDEFAULT:          "circuit"
+; JSONDEFAULT:          "annotations": []
+; JSONDEFAULT:          "circuitPackage": "flowtest"
+
+; JSONINLINE:         SignalDriverAnnotation
+; JSONINLINE-LABEL:     "sinkTargets"
+; JSONINLINE{LITERAL}:    "_1": "~Top|Top>foo_clock",
+; JSONINLINE{LITERAL}:    "_1": "~Top|Top>foo_dataIn_a_b_c",
+; JSONINLINE{LITERAL}:    "_1": "~Top|Top>foo_dataIn_d",
+; JSONINLINE{LITERAL}:    "_1": "~Top|Bar>b",
+; JSONINLINE-LABEL:     "sourceTargets"
+; JSONINLINE{LITERAL}:    "_1": "~Top|Top>clock",
+; JSONINLINE{LITERAL}:    "_1": "~Top|Top>foo_dataOut_x_y_z",
+; JSONINLINE{LITERAL}:    "_1": "~Top|Top>foo_dataOut_w",
+; JSONINLINE:           "circuit"
+; JSONINLINE:           "annotations": []
+; JSONINLINE:           "circuitPackage": "flowtest"
+
+
+; 2) Run on sub circuit, with updated annotation file (sigdrive.json) from (1):
+; RUN: firtool %S/subcircuit.fir --annotation-file %t/default/sigdrive.json --firrtl-grand-central | FileCheck %s --check-prefix=MAPPINGDEFAULT
+; RUN: firtool %S/subcircuit.fir --annotation-file %t/inline/sigdrive.json --firrtl-grand-central | FileCheck %s --check-prefix=MAPPINGINLINE
+
+; MAPPINGDEFAULT-LABEL: module Sub_signal_mappings(
+; MAPPINGDEFAULT-NEXT:   input           clock_sink,
+; MAPPINGDEFAULT-NEXT:   input  [41:0]   data_sink_u,
+; MAPPINGDEFAULT-NEXT:   input  [9000:0] data_sink_v,
+; MAPPINGDEFAULT-NEXT:   input           data_sink_w_0,
+; MAPPINGDEFAULT-NEXT:                   data_sink_w_1,
+; MAPPINGDEFAULT-NEXT:   output          clock_source,
+; MAPPINGDEFAULT-NEXT:   output [41:0]   data_source_u,
+; MAPPINGDEFAULT-NEXT:   output [9000:0] data_source_v);
+; (Don't preserve mappings to values that don't exist)
+; MAPPINGDEFAULT-NOT:                    data_source_w_0
+; MAPPINGDEFAULT-NOT:                    data_source_w_1
+; MAPPINGDEFAULT:       `ifndef VERILATOR
+; MAPPINGDEFAULT-NEXT:   initial begin
+; MAPPINGDEFAULT-NEXT:     force Foo.clock = clock_sink;
+; MAPPINGDEFAULT-NEXT:     force Foo.dataIn_a_b_c = data_sink_u;
+; MAPPINGDEFAULT-NEXT:     force Foo.dataIn_d = data_sink_v;
+; TODO: This is wrong but expected for now
+; MAPPINGDEFAULT-NEXT:     force Bar.b = data_sink_w_0;
+; MAPPINGDEFAULT-NEXT:     force Bar.b = data_sink_w_1;
+; (cont)
+; MAPPINGDEFAULT-NEXT:   end
+; MAPPINGDEFAULT-NEXT:   `endif
+; MAPPINGDEFAULT-NEXT:   assign clock_source = Top.clock;
+; MAPPINGDEFAULT-NEXT:   assign data_source_u = Foo.dataOut_x_y_z;
+; MAPPINGDEFAULT-NEXT:   assign data_source_v = Foo.dataOut_w;
+; MAPPINGDEFAULT-NOT:           data_source_w_0
+; MAPPINGDEFAULT-NOT:           data_source_w_1
+; MAPPINGDEFAULT-NEXT: endmodule
+
+; MAPPINGINLINE-LABEL: module Sub_signal_mappings(
+; MAPPINGINLINE-NEXT:   input           clock_sink,
+; MAPPINGINLINE-NEXT:   input  [41:0]   data_sink_u,
+; MAPPINGINLINE-NEXT:   input  [9000:0] data_sink_v,
+; MAPPINGINLINE-NEXT:   input           data_sink_w_0,
+; MAPPINGINLINE-NEXT:                   data_sink_w_1,
+; MAPPINGINLINE-NEXT:   output          clock_source,
+; MAPPINGINLINE-NEXT:   output [41:0]   data_source_u,
+; MAPPINGINLINE-NEXT:   output [9000:0] data_source_v);
+; (Don't preserve mappings to values that don't exist)
+; MAPPINGINLINE-NOT:                    data_source_w_0
+; MAPPINGINLINE-NOT:                    data_source_w_1
+; MAPPINGINLINE:       `ifndef VERILATOR
+; MAPPINGINLINE-NEXT:   initial begin
+; MAPPINGINLINE-NEXT:     force Top.foo_clock = clock_sink;
+; MAPPINGINLINE-NEXT:     force Top.foo_dataIn_a_b_c = data_sink_u;
+; MAPPINGINLINE-NEXT:     force Top.foo_dataIn_d = data_sink_v;
+; TODO: This is wrong but expected for now
+; MAPPINGINLINE-NEXT:     force Bar.b = data_sink_w_0;
+; MAPPINGINLINE-NEXT:     force Bar.b = data_sink_w_1;
+; (cont)
+; MAPPINGINLINE-NEXT:   end
+; MAPPINGINLINE-NEXT:   `endif
+; MAPPINGINLINE-NEXT:   assign clock_source = Top.clock;
+; MAPPINGINLINE-NEXT:   assign data_source_u = Top.foo_dataOut_x_y_z;
+; MAPPINGINLINE-NEXT:   assign data_source_v = Top.foo_dataOut_w;
+; MAPPINGINLINE-NOT:           data_source_w_0
+; MAPPINGINLINE-NOT:           data_source_w_1
+; MAPPINGINLINE-NEXT: endmodule
+
+

--- a/test/Dialect/FIRRTL/SFCTests/subcircuit-flow/inline.json
+++ b/test/Dialect/FIRRTL/SFCTests/subcircuit-flow/inline.json
@@ -1,0 +1,6 @@
+[
+  {
+    "class": "firrtl.passes.InlineAnnotation",
+    "target": "~Top|Foo"
+  }
+]

--- a/test/Dialect/FIRRTL/SFCTests/subcircuit-flow/lit.local.cfg
+++ b/test/Dialect/FIRRTL/SFCTests/subcircuit-flow/lit.local.cfg
@@ -1,0 +1,2 @@
+# Only treat *.test as test files:
+config.suffixes = [ '.test' ]

--- a/test/Dialect/FIRRTL/SFCTests/subcircuit-flow/main.fir
+++ b/test/Dialect/FIRRTL/SFCTests/subcircuit-flow/main.fir
@@ -1,0 +1,38 @@
+; Main circuit ("remote")
+
+circuit Top :
+  module Bar :
+    input a: UInt
+    input b: UInt
+    output o: UInt
+    o <= add(a, not(b))
+
+  module Foo :
+    input clock : Clock
+    input reset : Reset
+    input dataIn : {a: {b: {c: UInt<42>}}, d: UInt<9001>, e: UInt<42>}
+    output dataOut : {x: {y: {z: UInt<42>}}, w: UInt<9001>, u: UInt<42>}
+    reg stuff : UInt<42>, clock
+    reg stuff2 : UInt<9001>, clock
+
+    stuff <= dataIn.a.b.c
+    stuff2 <= dataIn.d
+    dataOut.x.y.z <= stuff
+    dataOut.w <= stuff2
+
+    inst bar of Bar
+    bar.a <= dataIn.a.b.c
+    bar.b <= dataIn.e
+    dataOut.u <= bar.o
+
+  module Top :
+    input clock : Clock
+    input reset : UInt<1>
+    input dataIn : {a: {b: {c: UInt<42>}}, d: UInt<9001>, e: UInt<42>}
+    output zu: UInt
+
+    inst foo of Foo
+    foo.clock <= asClock(UInt<1>(0))
+    foo.reset <= reset
+    foo.dataIn <- dataIn
+    zu <= and(foo.dataOut.x.y.z, foo.dataOut.u)

--- a/test/Dialect/FIRRTL/SFCTests/subcircuit-flow/subCircuit.json
+++ b/test/Dialect/FIRRTL/SFCTests/subcircuit-flow/subCircuit.json
@@ -1,0 +1,44 @@
+[
+  {
+    "class": "sifive.enterprise.grandcentral.SignalDriverAnnotation",
+    "sinkTargets": [
+      {
+        "_1": "~Top|Foo>clock",
+        "_2": "~Sub|Sub>clock_sink"
+      },
+      {
+        "_1": "~Top|Foo>dataIn.a.b.c",
+        "_2": "~Sub|Sub>data_sink.u"
+      },
+      {
+        "_1": "~Top|Foo>dataIn.d",
+        "_2": "~Sub|Sub>data_sink.v"
+      },
+      {
+        "_1": "~Top|Bar>b",
+        "_2": "~Sub|Sub>data_sink.w"
+      }
+    ],
+    "sourceTargets": [
+      {
+        "_1": "~Top|Top>clock",
+        "_2": "~Sub|Sub>clock_source"
+      },
+      {
+        "_1": "~Top|Foo>dataOut.x.y.z",
+        "_2": "~Sub|Sub>data_source.u"
+      },
+      {
+        "_1": "~Top|Foo>dataOut.w",
+        "_2": "~Sub|Sub>data_source.v"
+      },
+      {
+        "_1": "~Top|Foo>dataOut.p",
+        "_2": "~Sub|Sub>data_source.w"
+      }
+    ],
+    "circuit": "circuit empty :\n  module empty :\n\n    skip\n",
+    "annotations": [],
+    "circuitPackage": "flowtest"
+  }
+]

--- a/test/Dialect/FIRRTL/SFCTests/subcircuit-flow/subcircuit.fir
+++ b/test/Dialect/FIRRTL/SFCTests/subcircuit-flow/subcircuit.fir
@@ -1,0 +1,22 @@
+; Subcircuit ("local")
+
+circuit Sub :
+  extmodule SubExtern :
+    input clockIn : Clock
+    output clockOut : Clock
+    input someInput : { u: UInt<42>, v: UInt<9001>, w: UInt<1>[2] }
+    output someOutput : { u: UInt<42>, v: UInt<9001>, w: UInt<1>[2] }
+
+  module Sub :
+    wire clock_source : Clock
+    wire clock_sink : Clock
+    wire data_source : { u: UInt<42>, v: UInt<9001>, w: UInt<1>[2] }
+    wire data_sink : { u: UInt<42>, v: UInt<9001>, w: UInt<1>[2] }
+    clock_source is invalid
+    data_source is invalid
+
+    inst ext of SubExtern
+    ext.clockIn <= clock_source
+    ext.someInput <= data_source
+    clock_sink <= ext.clockOut
+    data_sink <= ext.someOutput

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -1104,7 +1104,7 @@ circuit Sub : %[[{
     dataSink <= ext.someOutput
 
 ; CHECK-LABEL: firrtl.circuit "Sub"
-; CHECK-SAME: {annotations = [], circuit = "", circuitPackage = "other", class = "sifive.enterprise.grandcentral.SignalDriverAnnotation", emitJSON, id = [[ID:.+]] : i64}
+; CHECK-SAME: {annotations = [], circuit = "", circuitPackage = "other", class = "sifive.enterprise.grandcentral.SignalDriverAnnotation", id = [[ID:[0-9]+]] : i64, isSubCircuit = true}
 
 ; CHECK-LABEL: firrtl.module @Sub
 ; CHECK-SAME: {class = "sifive.enterprise.grandcentral.SignalDriverAnnotation", id = [[ID]] : i64}

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -338,15 +338,6 @@ static cl::opt<bool> stripDebugInfo(
     cl::desc("Disable source locator information in output Verilog"),
     cl::init(false), cl::cat(mainCategory));
 
-static cl::opt<std::string>
-    sigmapPrefix("sigmap-prefix",
-                 cl::desc("prefix for signal mapping module dut path"),
-                 cl::init(""), cl::cat(mainCategory));
-static cl::opt<std::string>
-    sigmapDut("sigmap-dut",
-              cl::desc("dut for signal mapping target correction"),
-              cl::init(""), cl::cat(mainCategory));
-
 /// Create a simple canonicalizer pass.
 static std::unique_ptr<Pass> createSimpleCanonicalizerPass() {
   mlir::GreedyRewriteConfig config;
@@ -567,8 +558,8 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
     auto &circuitPM = pm.nest<firrtl::CircuitOp>();
     circuitPM.addPass(firrtl::createGrandCentralPass());
     circuitPM.addPass(firrtl::createGrandCentralTapsPass());
-    circuitPM.addPass(firrtl::createGrandCentralSignalMappingsPass(
-        outputFilename, sigmapDut, sigmapPrefix));
+    circuitPM.addPass(
+        firrtl::createGrandCentralSignalMappingsPass(outputFilename));
   }
 
   // Read black box source files into the IR.


### PR DESCRIPTION
This is handled with a two-step flow:

* main.fir + subCircuit.json --(firtool)--> (normal output) + sigdrive.json (new)
* subcircuit.fir + sigdrive.json --(firtool)--> (normal output)

The new test in 'subcircuit-flow' demonstrates this in action.

There are many limitations, this is meant to just be enough to
support some specific existing use cases only.

----

Notes:

* Forced input ports now have an additional wire added to distance
  the driven value from its uses (at instantiation points).
  The goal is to ensure an 'assign' is created between the wire
  used elsewhere and the wire bound to the driven port.
  The single wire previously created was apparently insufficient.
  These wires are now given names and symbols, which may be unneeded.

* Mappings are generated using `module.name` XMR's, which may not be
  supported everywhere.  SFC emits hierarchical paths from the DUT,
  which is more complicated to support and not yet found to be needed.

* SignalDriver annotations are only acted on in GCSM if the CircuitOp
  has the modified annotation which must contain a "isSubCircuit" field.
  This annotation was already created during parsing, but used an
  optional 'emitJSON' field to indicate if this is the subcircuit.
  This is now required for simplicity.
  * For users of firtool, the change is handled already in
    FIRAnnotations, but some test cases relied on the previous behavior.
  * `emitJSON` is deprecated, in practice this was interpreted and set
    as indicator of processing a subcircuit.
  * The pass will always emit something if the annotations are found.

* Sources/Sinks that target aggregates like vectors or bundles are not
  supported and may misbehave (existing bug).

* Sources/Sinks targeting ports of extmodules are not yet supported,
  but these seem to be ignored in SFC as well.

* Remote targets must be local, if they walk an instantiation path
  (and generate NLA's), these are not currently supported.

* Remote targets must have unique instance path.
  This is true in practice, and allows the simple `module.name` XMR's.

* Flow assumes only two circuits: remote (main) and local (subcircuit)