### PR TITLE
[FIRRTL] Change Grand Central Views to Not Block Optimizations

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1471,7 +1471,13 @@ static LogicalResult canonicalizeSingleSetConnect(StrictConnectOp op,
     }
   }
 
-  if (isUselessName(connectedDecl)) {
+  // TODO: This is a hack to prevent removal if the operation is used by the
+  // Grand Central pass.  This should be changed later to use something less
+  // brittle.
+  auto gctTap =
+      AnnotationSet(connectedDecl)
+          .hasAnnotation("sifive.enterprise.grandcentral.AugmentedGroundType");
+  if (isUselessName(connectedDecl) && !gctTap) {
     // Replace all things *using* the decl with the constant/port, and
     // remove the declaration.
     rewriter.replaceOp(connectedDecl, replacement);

--- a/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
@@ -795,7 +795,7 @@ static Optional<DictionaryAttr> parseAugmentedType(
     auto localTarget = std::get<0>(expandNonLocal(target.first).back());
     auto subTargets = target.second;
 
-    NamedAttrList elementIface, elementScattered, dontTouch;
+    NamedAttrList elementIface, elementScattered;
 
     // Populate the annotation for the interface element.
     elementIface.append("class", classAttr);
@@ -806,20 +806,13 @@ static Optional<DictionaryAttr> parseAugmentedType(
     // Populate an annotation that will be scattered onto the element.
     elementScattered.append("class", classAttr);
     elementScattered.append("id", id);
-    // Populate a dont touch annotation for the scattered element.
-    dontTouch.append(
-        "class",
-        StringAttr::get(context, "firrtl.transforms.DontTouchAnnotation"));
     // If there are sub-targets, then add these.
     if (subTargets) {
       elementScattered.append("target", subTargets);
-      dontTouch.append("target", subTargets);
     }
 
     newAnnotations[localTarget].push_back(
         DictionaryAttr::getWithSorted(context, elementScattered));
-    newAnnotations[localTarget].push_back(
-        DictionaryAttr::getWithSorted(context, dontTouch));
 
     return DictionaryAttr::getWithSorted(context, elementIface);
   }

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -34,6 +34,12 @@ static bool isDeletableWireOrReg(Operation *op) {
   if (auto wire = dyn_cast<WireOp>(op))
     if (!isUselessName(wire.name()))
       return false;
+  // TODO: This is a dirty hack that is blocking wire removal if this is part of
+  // a Grand Central interface.  This should eventually be removed in favor of
+  // better annotation handling.
+  if (AnnotationSet(op).hasAnnotation(
+          "sifive.enterprise.grandcentral.AugmentedGroundType"))
+    return false;
   return isWireOrReg(op) && !hasDontTouch(op);
 }
 

--- a/test/Dialect/FIRRTL/annotations-errors.fir
+++ b/test/Dialect/FIRRTL/annotations-errors.fir
@@ -160,7 +160,7 @@ circuit Foo: %[[{"a":null,"target":"~Foo|Foo/baz:Bar"}]]
 ; nlas.
 
 ; expected-error @+2 {{unapplied annotations with target '~NLAParse|A_companion' and payload '[{class = "sifive.enterprise.grandcentral.ViewAnnotation", id = 0 : i64, name = "A", type = "companion"}]'}}
-; expected-error @+1 {{unapplied annotations with target '~NLAParse|FooBar>clock' and payload '[{class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 1 : i64, target = []}, {class = "firrtl.transforms.DontTouchAnnotation", target = []}]'}}
+; expected-error @+1 {{unapplied annotations with target '~NLAParse|FooBar>clock' and payload '[{class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 1 : i64, target = []}]'}}
 circuit NLAParse : %[[
   {
    "class": "sifive.enterprise.grandcentral.GrandCentralView$SerializedViewAnnotation",

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -928,7 +928,7 @@ circuit GCTInterface : %[
     ; members of the interface inside the parent.  Both port "a" and register
     ; "r" should be annotated.
     ; CHECK: firrtl.module @GCTInterface
-    ; CHECK-SAME: %a: !firrtl.uint<1> sym @a [
+    ; CHECK-SAME: %a: !firrtl.uint<1> [
     ; CHECK-SAME:   #firrtl.subAnno<fieldID = 0, {
     ; CHECK-SAME:     class = "sifive.enterprise.grandcentral.AugmentedGroundType",
     ; CHECK-SAME:     id = [[ID_port]] : i64}>


### PR DESCRIPTION
Change Grand Central (GCT) views feature to stop putting a don't
touch (optimization barrier) on signals that it is tapping.  Instead,
teach IMCP and canonicalization to not remove things which are part of a
GCT view.

Improve Grand Central (CGCT) views handling to use constants instead of
XMRs when the XMR is tapping a wire/node that is driven by a constant.
    
E.g., GCT will now generate an XMR like the following where previously
it would XMR to a wire driven by a constant:

```verilog    
assign Foo.bar.baz = 1'h1;
```

_Admittedly, this is a giant hack and we should rip this out in the
future in favor of a less special-cased approach.  E.g., this would be
better handled with access modifiers on symbols (public/private,
read/write) or dedicated operations (read tap, write tap)._