### PR TITLE
[MSFT] Add an op to place all the bits in a register

### DIFF
--- a/include/circt/Dialect/MSFT/MSFTAttributes.h
+++ b/include/circt/Dialect/MSFT/MSFTAttributes.h
@@ -21,4 +21,18 @@
 #define GET_ATTRDEF_CLASSES
 #include "circt/Dialect/MSFT/MSFTAttributes.h.inc"
 
+namespace circt {
+namespace msft {
+
+/// Parse and append a PhysLocAttr. Options are '*' for null location, <x, y,
+/// num> for a location which is implicitily a FF, or a full phys location
+/// attribute.
+LogicalResult parseOptionalRegLoc(SmallVectorImpl<PhysLocationAttr> &locs,
+                                  AsmParser &p);
+/// Print out the above.
+void printOptionalRegLoc(PhysLocationAttr loc, AsmPrinter &p);
+
+} // namespace msft
+} // namespace circt
+
 #endif // CIRCT_DIALECT_MSFT_MSFTATTRIBUTES_H

--- a/include/circt/Dialect/MSFT/MSFTAttributes.td
+++ b/include/circt/Dialect/MSFT/MSFTAttributes.td
@@ -63,3 +63,13 @@ def PhysicalBounds : MSFT_Attr<"PhysicalBounds"> {
 
 def PhysicalBoundsArray : TypedArrayAttrBase<PhysicalBounds,
   "array of PhysicalBounds">;
+
+def LocationVector : MSFT_Attr<"LocationVector"> {
+  let summary = "Vector of optional locations corresponding to bits in a type";
+  let mnemonic = "location_vec";
+  let parameters = (ins "::mlir::TypeAttr":$type,
+                        ArrayRefParameter<"::circt::msft::PhysLocationAttr">:$locs);
+
+  let hasCustomAssemblyFormat = 1;
+  let genVerifyDecl = 1;
+}

--- a/include/circt/Dialect/MSFT/MSFTPDOps.td
+++ b/include/circt/Dialect/MSFT/MSFTPDOps.td
@@ -49,6 +49,20 @@ def PDPhysLocationOp : MSFTOp<"pd.location",
   }];
 }
 
+def PDRegPhysLocationOp : MSFTOp<"pd.reg_location",
+      [DeclareOpInterfaceMethods<DynInstDataOpInterface>]> {
+  let summary = "Specify register locations";
+  let description = [{
+    A version of "PDPhysLocationOp" specialized for registers, which have one
+    location per bit.
+  }];
+  let arguments = (ins LocationVector:$locs,
+                       OptionalAttr<FlatSymbolRefAttr>:$ref);
+  let assemblyFormat = [{
+    (`ref` $ref^)? custom<ListOptionalRegLocList>($locs) attr-dict
+  }];
+}
+
 def PDPhysRegionOp : MSFTOp<"pd.physregion",
       [DeclareOpInterfaceMethods<DynInstDataOpInterface>]> {
   let summary = "Specify a physical region for an instance";

--- a/lib/Dialect/MSFT/MSFTAttributes.cpp
+++ b/lib/Dialect/MSFT/MSFTAttributes.cpp
@@ -87,7 +87,7 @@ LogicalResult LocationVectorAttr::verify(
 LogicalResult
 circt::msft::parseOptionalRegLoc(SmallVectorImpl<PhysLocationAttr> &locs,
                                  AsmParser &p) {
-  auto ctxt = p.getContext();
+  MLIRContext *ctxt = p.getContext();
   if (!p.parseOptionalStar()) {
     locs.push_back({});
     return success();

--- a/lib/Dialect/MSFT/MSFTAttributes.cpp
+++ b/lib/Dialect/MSFT/MSFTAttributes.cpp
@@ -73,6 +73,75 @@ void PhysicalBoundsAttr::print(AsmPrinter &p) const {
   p << '>';
 }
 
+LogicalResult LocationVectorAttr::verify(
+    llvm::function_ref<mlir::InFlightDiagnostic()> emitError, TypeAttr type,
+    ArrayRef<PhysLocationAttr> locs) {
+  uint64_t typeBitWidth = hw::getBitWidth(type.getValue());
+  if (typeBitWidth < 0)
+    return emitError() << "cannot compute bit width of type '" << type << "'";
+  if (typeBitWidth != locs.size())
+    return emitError() << "must specify " << typeBitWidth << " locations";
+  return success();
+}
+
+LogicalResult
+circt::msft::parseOptionalRegLoc(SmallVectorImpl<PhysLocationAttr> &locs,
+                                 AsmParser &p) {
+  auto ctxt = p.getContext();
+  if (!p.parseOptionalStar()) {
+    locs.push_back({});
+    return success();
+  }
+
+  PhysLocationAttr loc;
+  if (p.parseOptionalAttribute(loc).hasValue()) {
+    locs.push_back(loc);
+    return success();
+  }
+
+  uint64_t x, y, n;
+  if (p.parseLess() || p.parseInteger(x) || p.parseComma() ||
+      p.parseInteger(y) || p.parseComma() || p.parseInteger(n) ||
+      p.parseGreater())
+    return failure();
+  locs.push_back(PhysLocationAttr::get(
+      ctxt, PrimitiveTypeAttr::get(ctxt, PrimitiveType::FF), x, y, n));
+  return success();
+}
+
+void circt::msft::printOptionalRegLoc(PhysLocationAttr loc, AsmPrinter &p) {
+  if (loc && loc.getPrimitiveType().getValue() == PrimitiveType::FF)
+    p << '<' << loc.getX() << ", " << loc.getY() << ", " << loc.getNum() << '>';
+  else if (loc)
+    p << loc;
+  else
+    p << "*";
+}
+
+Attribute LocationVectorAttr::parse(AsmParser &p, Type) {
+  MLIRContext *ctxt = p.getContext();
+  TypeAttr type;
+  SmallVector<PhysLocationAttr, 32> locs;
+
+  if (p.parseLess() || p.parseAttribute(type) || p.parseComma() ||
+      p.parseLSquare() || p.parseCommaSeparatedList([&]() {
+        return parseOptionalRegLoc(locs, p);
+      }) ||
+      p.parseRSquare() || p.parseGreater())
+    return {};
+
+  return LocationVectorAttr::getChecked(p.getEncodedSourceLoc(p.getNameLoc()),
+                                        ctxt, type, locs);
+}
+
+void LocationVectorAttr::print(AsmPrinter &p) const {
+  p << '<' << getType() << ", [";
+  llvm::interleaveComma(getLocs(), p, [&p](PhysLocationAttr loc) {
+    printOptionalRegLoc(loc, p);
+  });
+  p << "]>";
+}
+
 void MSFTDialect::registerAttributes() {
   addAttributes<
 #define GET_ATTRDEF_LIST

--- a/lib/Dialect/MSFT/MSFTPasses.cpp
+++ b/lib/Dialect/MSFT/MSFTPasses.cpp
@@ -484,6 +484,7 @@ void ExportTclPass::runOnOperation() {
   RewritePatternSet patterns(ctxt);
   DenseSet<SymbolRefAttr> refsUsed;
   patterns.insert<RemovePhysOpLowering<PDPhysLocationOp>>(ctxt, refsUsed);
+  patterns.insert<RemovePhysOpLowering<PDRegPhysLocationOp>>(ctxt, refsUsed);
   patterns.insert<RemovePhysOpLowering<PDPhysRegionOp>>(ctxt, refsUsed);
   patterns.insert<RemovePhysOpLowering<DynamicInstanceVerbatimAttrOp>>(
       ctxt, refsUsed);

--- a/test/Dialect/MSFT/attributes.mlir
+++ b/test/Dialect/MSFT/attributes.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
+// RUN: circt-opt %s --allow-unregistered-dialect -verify-diagnostics | circt-opt --allow-unregistered-dialect -verify-diagnostics | FileCheck %s
 
 // CHECK-LABEL: msft.physical_region @region1
 msft.physical_region @region1, [
@@ -6,3 +6,6 @@ msft.physical_region @region1, [
   #msft.physical_bounds<x: [0, 10], y: [0, 10]>,
   // CHECK-SAME: #msft.physical_bounds<x: [20, 30], y: [20, 30]>
   #msft.physical_bounds<x: [20, 30], y: [20, 30]>]
+
+// CHECK: #msft.location_vec<i3, [*, <1, 2, 3>, #msft.physloc<DSP, 4, 5, 6>]>
+"dummy.op" () {"vec" = #msft.location_vec<i3, [*, <1, 2, 3>, #msft.physloc<DSP, 4, 5, 6>]>} : () -> ()

--- a/test/Dialect/MSFT/dynamic_instance.mlir
+++ b/test/Dialect/MSFT/dynamic_instance.mlir
@@ -27,11 +27,11 @@ msft.instance.hierarchy @shallow {
 
 msft.instance.hierarchy @reg {
   msft.instance.dynamic @reg::@reg {
-    msft.pd.location FF x: 0 y: 0 n: 0
+    msft.pd.reg_location i4 [*, <1,2,3>, <1,2,4>, <1,2,5>]
   }
 }
 // CHECK: hw.globalRef @instref_2 [#hw.innerNameRef<@reg::@reg>]
-// CHECK: msft.pd.location @instref_2 FF x: 0 y: 0 n: 0
+// CHECK: msft.pd.reg_location ref @instref_2 i4 [*, <1, 2, 3>, <1, 2, 4>, <1, 2, 5>]
 
 
 
@@ -72,8 +72,10 @@ msft.module @deeper {} () -> () {
 }
 
 // TCL-LABEL: proc reg_0_config
-msft.module @reg {} (%input : i8, %clk : i1) -> () {
-  %reg = seq.compreg sym @reg %input, %clk  : i8
-  // TCL: set_location_assignment FF_X0_Y0_N0 -to $parent|reg_1
+msft.module @reg {} (%input : i4, %clk : i1) -> () {
+  %reg = seq.compreg sym @reg %input, %clk  : i4
+  // TCL: set_location_assignment FF_X1_Y2_N3 -to $parent|reg_1[1]
+  // TCL: set_location_assignment FF_X1_Y2_N4 -to $parent|reg_1[2]
+  // TCL: set_location_assignment FF_X1_Y2_N5 -to $parent|reg_1[3]
   msft.output
 }


### PR DESCRIPTION
`PDRegPhysLocationOp` takes a type and a list of physical locations. The
list of physical locations must equal the bit width of the type. The
physical locations are each optional.