### PR TITLE
[HW] Relax parameter evaluation to allow resolution to passed in parameters

### DIFF
--- a/include/circt/Dialect/HW/HWAttributes.h
+++ b/include/circt/Dialect/HW/HWAttributes.h
@@ -33,9 +33,9 @@ mlir::FailureOr<mlir::Type> evaluateParametricType(mlir::Location loc,
 
 /// Evaluates a parametric attribute (param.decl.ref/param.expr) based on a set
 /// of provided parameter values.
-mlir::FailureOr<mlir::APInt> evaluateParametricAttr(mlir::Location loc,
-                                                    mlir::ArrayAttr parameters,
-                                                    mlir::Attribute paramAttr);
+mlir::FailureOr<mlir::Attribute>
+evaluateParametricAttr(mlir::Location loc, mlir::ArrayAttr parameters,
+                       mlir::Attribute paramAttr);
 
 /// Returns true if any part of t is parametric.
 bool isParametricType(mlir::Type t);


### PR DESCRIPTION
This removes the requirement that parameters passed to a module instance must evaluate to constants. This allows a parametric module to instantiate nested parametric modules using its own parameters.

This change required reworking the HWSpecialize pass, where parametric modules defer specialization of instantiated parametric modules until after the parent modules themselves are specialized.