### PR TITLE
[FIRRTL] Change Grand Central Views to use Wire Taps and Sink Constants

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -28,6 +28,9 @@ IntegerAttr getIntAttr(Type type, const APInt &value);
 /// Utility for generating a constant zero attribute.
 IntegerAttr getIntZerosAttr(Type type);
 
+/// Return the module-scoped driver of a value only looking through one connect.
+Value getDriverFromConnect(Value val);
+
 /// Return the module-scoped driver of a value
 Value getModuleScopedDriver(Value val, bool lookThroughWires,
                             bool lookThroughNodes, bool lookThroughCasts);

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -130,6 +130,22 @@ IntegerAttr circt::firrtl::getIntZerosAttr(Type type) {
   return getIntAttr(type, APInt(width, 0));
 }
 
+/// Return the value that drives another FIRRTL value within module scope.  Only
+/// look backwards through one connection.  This is intended to be used in
+/// situations where you only need to look at the most recent connect, e.g., to
+/// know if a wire has been driven to a constant.  Return null if no driver via
+/// a connect was found.
+Value circt::firrtl::getDriverFromConnect(Value val) {
+  for (auto *user : val.getUsers()) {
+    if (auto connect = dyn_cast<FConnectLike>(user)) {
+      if (connect.dest() != val)
+        continue;
+      return connect.src();
+    }
+  }
+  return nullptr;
+}
+
 /// Return the value that drives another FIRRTL value within module scope.  This
 /// is parameterized by looking through or not through certain constructs.  This
 /// assumes a single driver and should only be run after `ExpandWhens`.

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/HWRename.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/HWRename.fir
@@ -27,7 +27,10 @@ circuit Top:
     b <= signed.b
 
     ; CHECK:      module DUT
-    ; CHECK:        wire [[wireName:.+]];
+    ; CHECK:        wire [[gctTap:.+]];
+    ; CHECK-NEXT:   wire [[wireName:.+]];
+    ; CHECK:        assign [[gctTap]] = [[driver:.+]];
+    ; CHECK-NEXT:   assign [[wireName]] = [[driver]];
     ; CHECK:      endmodule
 
     ; CHECK:      module Top
@@ -35,7 +38,7 @@ circuit Top:
     ; CHECK:      endmodule
 
     ; CHECK:      module MyView_mapping();
-    ; CHECK-NEXT:   assign MyView.[[elementName:.+]] = Top.[[dutName]].[[wireName]]
+    ; CHECK-NEXT:   assign MyView.[[elementName:.+]] = Top.[[dutName]].[[gctTap]]
     ; CHECK-NEXT: endmodule
 
     ; CHECK: interface MyInterface

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
@@ -230,28 +230,28 @@ circuit Top :
     ; EXTRACT:        FILE "Wire/firrtl/gct/MyView_mapping.sv"
     ; NOEXTRACT-NOT:  FILE {{.*}}/MyView_mapping.sv
     ; CHECK:          module MyView_mapping();
-    ; CHECK-NEXT:       assign MyView.uint = Top.dut.w_uint;
-    ; CHECK-NEXT:       assign MyView.vec[0] = Top.dut.w_vec_0;
-    ; CHECK-NEXT:       assign MyView.vec[1] = Top.dut.w_vec_1;
-    ; CHECK-NEXT:       assign MyView.multivec[0][0] = Top.dut.w_multivec_0_0;
-    ; CHECK-NEXT:       assign MyView.multivec[0][1] = Top.dut.w_multivec_0_1;
-    ; CHECK-NEXT:       assign MyView.multivec[0][2] = Top.dut.w_multivec_0_2;
-    ; CHECK-NEXT:       assign MyView.multivec[1][0] = Top.dut.w_multivec_1_0;
-    ; CHECK-NEXT:       assign MyView.multivec[1][1] = Top.dut.w_multivec_1_1;
-    ; CHECK-NEXT:       assign MyView.multivec[1][2] = Top.dut.w_multivec_1_2;
-    ; CHECK-NEXT:       assign MyView.vecOfBundle[0].sint = Top.dut.w_vecOfBundle_0_sint;
-    ; CHECK-NEXT:       assign MyView.vecOfBundle[0].uint = Top.dut.w_vecOfBundle_0_uint;
-    ; CHECK-NEXT:       assign MyView.vecOfBundle[1].sint = Top.dut.w_vecOfBundle_1_sint;
-    ; CHECK-NEXT:       assign MyView.vecOfBundle[1].uint = Top.dut.w_vecOfBundle_1_uint;
-    ; CHECK-NEXT:       assign MyView.otherOther.other.sint = Top.dut.w_otherOther_other_sint;
-    ; CHECK-NEXT:       assign MyView.otherOther.other.uint = Top.dut.w_otherOther_other_uint;
-    ; CHECK-NEXT:       assign MyView.sub_uint = Top.dut.submodule.w_uint;
-    ; CHECK-NEXT:       assign MyView.sub_vec[0] = Top.dut.submodule.w_vec_0;
-    ; CHECK-NEXT:       assign MyView.sub_vec[1] = Top.dut.submodule.w_vec_1;
-    ; CHECK-NEXT:       assign MyView.sub_vecOfBundle[0].sint = Top.dut.submodule.w_vecOfBundle_0_sint;
-    ; CHECK-NEXT:       assign MyView.sub_vecOfBundle[0].uint = Top.dut.submodule.w_vecOfBundle_0_uint;
-    ; CHECK-NEXT:       assign MyView.sub_vecOfBundle[1].sint = Top.dut.submodule.w_vecOfBundle_1_sint;
-    ; CHECK-NEXT:       assign MyView.sub_vecOfBundle[1].uint = Top.dut.submodule.w_vecOfBundle_1_uint;
+    ; CHECK-NEXT:       assign MyView.uint = Top.dut._gctTap;
+    ; CHECK-NEXT:       assign MyView.vec[0] = Top.dut._gctTap_0;
+    ; CHECK-NEXT:       assign MyView.vec[1] = Top.dut._gctTap_1;
+    ; CHECK-NEXT:       assign MyView.multivec[0][0] = Top.dut._gctTap_2;
+    ; CHECK-NEXT:       assign MyView.multivec[0][1] = Top.dut._gctTap_3;
+    ; CHECK-NEXT:       assign MyView.multivec[0][2] = Top.dut._gctTap_4;
+    ; CHECK-NEXT:       assign MyView.multivec[1][0] = Top.dut._gctTap_5;
+    ; CHECK-NEXT:       assign MyView.multivec[1][1] = Top.dut._gctTap_6;
+    ; CHECK-NEXT:       assign MyView.multivec[1][2] = Top.dut._gctTap_7;
+    ; CHECK-NEXT:       assign MyView.vecOfBundle[0].sint = Top.dut._gctTap_8;
+    ; CHECK-NEXT:       assign MyView.vecOfBundle[0].uint = Top.dut._gctTap_9;
+    ; CHECK-NEXT:       assign MyView.vecOfBundle[1].sint = Top.dut._gctTap_10;
+    ; CHECK-NEXT:       assign MyView.vecOfBundle[1].uint = Top.dut._gctTap_11;
+    ; CHECK-NEXT:       assign MyView.otherOther.other.sint = Top.dut._gctTap_12;
+    ; CHECK-NEXT:       assign MyView.otherOther.other.uint = Top.dut._gctTap_13;
+    ; CHECK-NEXT:       assign MyView.sub_uint = Top.dut.submodule._gctTap;
+    ; CHECK-NEXT:       assign MyView.sub_vec[0] = Top.dut.submodule._gctTap_0;
+    ; CHECK-NEXT:       assign MyView.sub_vec[1] = Top.dut.submodule._gctTap_1;
+    ; CHECK-NEXT:       assign MyView.sub_vecOfBundle[0].sint = Top.dut.submodule._gctTap_2;
+    ; CHECK-NEXT:       assign MyView.sub_vecOfBundle[0].uint = Top.dut.submodule._gctTap_3;
+    ; CHECK-NEXT:       assign MyView.sub_vecOfBundle[1].sint = Top.dut.submodule._gctTap_4;
+    ; CHECK-NEXT:       assign MyView.sub_vecOfBundle[1].uint = Top.dut.submodule._gctTap_5;
     ; CHECK:          endmodule
 
     ; EXTRACT:        FILE "Wire/firrtl/gct/MyInterface.sv"

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -175,12 +175,93 @@ firrtl.circuit "Foo"  attributes {
 
 // -----
 
-firrtl.circuit "GCTInterface"  attributes {annotations = [{unrelatedAnnotation}], rawAnnotations = [{class = "sifive.enterprise.grandcentral.GrandCentralView$SerializedViewAnnotation", companion = "~GCTInterface|view_companion", name = "view", parent = "~GCTInterface|GCTInterface", view = {class = "sifive.enterprise.grandcentral.AugmentedBundleType", defName = "ViewName", elements = [{description = "the register in GCTInterface", name = "register", tpe = {class = "sifive.enterprise.grandcentral.AugmentedBundleType", defName = "Register", elements = [{name = "_2", tpe = {class = "sifive.enterprise.grandcentral.AugmentedVectorType", elements = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", ref = {circuit = "GCTInterface", component = [{class = "firrtl.annotations.TargetToken$Field", value = "_2"}, {class = "firrtl.annotations.TargetToken$Index", value = 0 : i64}], module = "GCTInterface", path = [], ref = "r"}, tpe = {class = "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"}}, {class = "sifive.enterprise.grandcentral.AugmentedGroundType", ref = {circuit = "GCTInterface", component = [{class = "firrtl.annotations.TargetToken$Field", value = "_2"}, {class = "firrtl.annotations.TargetToken$Index", value = 1 : i64}], module = "GCTInterface", path = [], ref = "r"}, tpe = {class = "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"}}]}}, {name = "_0_inst", tpe = {class = "sifive.enterprise.grandcentral.AugmentedBundleType", defName = "_0_def", elements = [{name = "_1", tpe = {class = "sifive.enterprise.grandcentral.AugmentedGroundType", ref = {circuit = "GCTInterface", component = [{class = "firrtl.annotations.TargetToken$Field", value = "_0"}, {class = "firrtl.annotations.TargetToken$Field", value = "_1"}], module = "GCTInterface", path = [], ref = "r"}, tpe = {class = "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"}}}, {name = "_0", tpe = {class = "sifive.enterprise.grandcentral.AugmentedGroundType", ref = {circuit = "GCTInterface", component = [{class = "firrtl.annotations.TargetToken$Field", value = "_0"}, {class = "firrtl.annotations.TargetToken$Field", value = "_0"}], module = "GCTInterface", path = [], ref = "r"}, tpe = {class = "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"}}}]}}]}}, {description = "the port 'a' in GCTInterface", name = "port", tpe = {class = "sifive.enterprise.grandcentral.AugmentedGroundType", ref = {circuit = "GCTInterface", component = [], module = "GCTInterface", path = [], ref = "a"}, tpe = {class = "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"}}}]}}]} {
+firrtl.circuit "GCTInterface"  attributes {
+  annotations = [{unrelatedAnnotation}],
+  rawAnnotations = [
+    {class = "sifive.enterprise.grandcentral.GrandCentralView$SerializedViewAnnotation",
+     companion = "~GCTInterface|view_companion",
+     name = "view",
+     parent = "~GCTInterface|GCTInterface",
+     view = {
+       class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+       defName = "ViewName",
+       elements = [
+         {description = "the register in GCTInterface",
+          name = "register",
+          tpe = {
+            class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+            defName = "Register",
+            elements = [
+              {name = "_2",
+               tpe = {
+                 class = "sifive.enterprise.grandcentral.AugmentedVectorType",
+                 elements = [
+                   {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+                    ref = {
+                      circuit = "GCTInterface",
+                      component = [
+                        {class = "firrtl.annotations.TargetToken$Field", value = "_2"},
+                        {class = "firrtl.annotations.TargetToken$Index", value = 0 : i64}],
+                      module = "GCTInterface",
+                      path = [],
+                      ref = "r"},
+                    tpe = {
+                      class = "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"}},
+                  {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+                   ref = {
+                     circuit = "GCTInterface",
+                     component = [
+                       {class = "firrtl.annotations.TargetToken$Field", value = "_2"},
+                       {class = "firrtl.annotations.TargetToken$Index", value = 1 : i64}],
+                     module = "GCTInterface",
+                     path = [],
+                     ref = "r"},
+                   tpe = {class = "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"}}]}},
+              {name = "_0_inst",
+               tpe = {
+                 class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+                 defName = "_0_def",
+                 elements = [
+                   {name = "_1",
+                    tpe = {
+                      class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+                      ref = {
+                        circuit = "GCTInterface",
+                        component = [
+                          {class = "firrtl.annotations.TargetToken$Field", value = "_0"},
+                          {class = "firrtl.annotations.TargetToken$Field", value = "_1"}],
+                        module = "GCTInterface",
+                        path = [],
+                        ref = "r"},
+                      tpe = {class = "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"}}},
+                   {name = "_0",
+                    tpe = {
+                      class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+                      ref = {
+                        circuit = "GCTInterface",
+                        component = [
+                          {class = "firrtl.annotations.TargetToken$Field", value = "_0"},
+                          {class = "firrtl.annotations.TargetToken$Field", value = "_0"}],
+                        module = "GCTInterface",
+                        path = [],
+                        ref = "r"},
+                      tpe = {class = "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"}}}]}}]}},
+         {description = "the port 'a' in GCTInterface",
+          name = "port",
+          tpe = {
+            class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+            ref = {
+              circuit = "GCTInterface",
+              component = [],
+              module = "GCTInterface",
+              path = [],
+              ref = "a"},
+            tpe = {class = "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"}}}]}}]} {
   firrtl.module private @view_companion() {
     firrtl.skip
   }
   firrtl.module @GCTInterface(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %a: !firrtl.uint<1>) {
-    %r = firrtl.reg %clock  : !firrtl.bundle<_0: bundle<_0: uint<1>, _1: uint<1>>, _2: vector<uint<1>, 2>>
+    %r = firrtl.reg %clock  : !firrtl.bundle<_0: bundle<_0: uint<1>, _1: uint<2>>, _2: vector<uint<3>, 2>>
     firrtl.instance view_companion  @view_companion()
   }
 }
@@ -236,32 +317,58 @@ firrtl.circuit "GCTInterface"  attributes {annotations = [{unrelatedAnnotation}]
 // members of the interface inside the parent.  Both port "a" and register
 // "r" should be annotated.
 // CHECK: firrtl.module @GCTInterface
-// CHECK-SAME: %a: !firrtl.uint<1> sym @a [
+// CHECK-SAME: %a: !firrtl.uint<1>
+// CHECK-NEXT: %[[tap_a:.+]] = firrtl.wire sym
 // CHECK-SAME:   {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-// CHECK-SAME:    d = [[ID_port]] : i64}
-// CHECK-SAME: annotations = [
-// CHECK-SAME:   {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
-// CHECK-SAME:    id = [[ID_ViewName]] : i64,
-// CHECK-SAME:    name = "view",
-// CHECK-SAME:    type = "parent"}]
-// CHECK: firrtl.reg
-// CHECK-SAME: annotations
-// CHECK-SAME:   {circt.fieldID = 2 : i32,
-// CHECK-SAME:    class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-// CHECK-SAME:    id = [[ID_0]] : i64}
-// CHECK-SAME:   {circt.fieldID = 3 : i32,
-// CHECK-SAME:    class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-// CHECK-SAME:    id = [[ID_1]] : i64}
-// CHECK-SAME:   {circt.fieldID = 6 : i32,
-// CHECK-SAME:    class = "sifive.enterprise.grandcentral.AugmentedGroundType",
-// CHECK-SAME:    id = [[ID_2_1]] : i64}
-// CHECK-SAME:   {circt.fieldID = 5 : i32,
-// CHECK-SAME:    class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+// CHECK-SAME:    id = [[ID_port]] : i64}
+// CHECK-NEXT: firrtl.strictconnect %[[tap_a]], %a
+// CHECK:      %[[tap_r_2_0:.+]] = firrtl.wire sym
+// CHECK-SAME:   {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
 // CHECK-SAME:    id = [[ID_2_0]] : i64}
+// CHECK-NEXT: %[[tap_r_2_1:.+]] = firrtl.wire sym
+// CHECK-SAME:   {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+// CHECK-SAME:    id = [[ID_2_1]] : i64}
+// CHECK-NEXT: %[[tap_r_1:.+]] = firrtl.wire sym
+// CHECK-SAME:   {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+// CHECK-SAME:    id = [[ID_1]] : i64}
+// CHECK-NEXT: %[[tap_r_0:.+]] = firrtl.wire sym
+// CHECK-SAME:   {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+// CHECK-SAME:    id = [[ID_0]] : i64}
+// CHECK-NEXT: firrtl.reg
+// CHECK-NOT: annotations
 
 // -----
 
-firrtl.circuit "Foo"  attributes {rawAnnotations = [{class = "sifive.enterprise.grandcentral.ViewAnnotation", companion = "~Foo|Bar_companion", name = "Bar", parent = "~Foo|Foo", view = {class = "sifive.enterprise.grandcentral.AugmentedBundleType", defName = "View", elements = [{description = "a string", name = "string", tpe = {class = "sifive.enterprise.grandcentral.AugmentedStringType", value = "hello"}}, {description = "a boolean", name = "boolean", tpe = {class = "sifive.enterprise.grandcentral.AugmentedBooleanType", value = false}}, {description = "an integer", name = "integer", tpe = {class = "sifive.enterprise.grandcentral.AugmentedIntegerType", value = 42 : i64}}, {description = "a double", name = "double", tpe = {class = "sifive.enterprise.grandcentral.AugmentedDoubleType", value = 3.140000e+00 : f64}}]}}]} {
+firrtl.circuit "Foo"  attributes {
+  rawAnnotations = [
+    {class = "sifive.enterprise.grandcentral.ViewAnnotation",
+     companion = "~Foo|Bar_companion",
+     name = "Bar",
+     parent = "~Foo|Foo",
+     view = {
+       class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+       defName = "View",
+       elements = [
+         {description = "a string",
+          name = "string",
+          tpe = {
+            class = "sifive.enterprise.grandcentral.AugmentedStringType",
+            value = "hello"}},
+         {description = "a boolean",
+          name = "boolean",
+          tpe = {
+            class = "sifive.enterprise.grandcentral.AugmentedBooleanType",
+            value = false}},
+         {description = "an integer",
+          name = "integer",
+          tpe = {
+            class = "sifive.enterprise.grandcentral.AugmentedIntegerType",
+            value = 42 : i64}},
+         {description = "a double",
+          name = "double",
+          tpe = {
+            class = "sifive.enterprise.grandcentral.AugmentedDoubleType",
+            value = 3.140000e+00 : f64}}]}}]} {
   firrtl.extmodule private @Bar_companion()
   firrtl.module @Foo() {
      firrtl.instance Bar_companion @Bar_companion()

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -1144,6 +1144,66 @@ firrtl.circuit "InterfaceInTestHarness" attributes {
 
 // -----
 
+firrtl.circuit "ConstantsInMappingsModule" attributes {
+  annotations = [
+    {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+     defName = "Foo",
+     elements = [
+       {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+        name = "foo",
+        id = 1 : i64},
+       {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+        name = "bar",
+        id = 2 : i64},
+       {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+        name = "baz",
+        id = 3 : i64}],
+     id = 0 : i64,
+     name = "View"}]} {
+  firrtl.module @View_companion() attributes {
+    annotations = [
+      {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
+       defName = "Foo",
+       id = 0 : i64,
+       name = "View",
+       type = "companion"}]} {}
+  firrtl.module @DUT() attributes {
+    annotations = [
+      {class = "sifive.enterprise.grandcentral.ViewAnnotation.parent",
+       id = 0 : i64,
+       name = "view",
+       type = "parent"}
+    ]} {
+    %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
+    %a = firrtl.wire {annotations = [
+      {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+       id = 1 : i64}]} : !firrtl.uint<2>
+    firrtl.strictconnect %a, %c1_ui2 : !firrtl.uint<2>
+    %c0x8000_0000_0000_0000_ui64 = firrtl.constant 9223372036854775808 : !firrtl.uint<64>
+    %b = firrtl.wire {annotations = [
+      {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+       id = 2 : i64}]} : !firrtl.uint<64>
+    firrtl.strictconnect %b, %c0x8000_0000_0000_0000_ui64 : !firrtl.uint<64>
+    %c-1_si2 = firrtl.constant -1 : !firrtl.sint<2>
+    %c = firrtl.wire {annotations = [
+      {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+       id = 3 : i64}]} : !firrtl.sint<2>
+    firrtl.strictconnect %c, %c-1_si2 : !firrtl.sint<2>
+    firrtl.instance View_companion @View_companion()
+  }
+  firrtl.module @ConstantsInMappingsModule() {
+    firrtl.instance dut @DUT()
+  }
+}
+
+// CHECK-LABEL: "ConstantsInMappingsModule"
+// CHECK:       firrtl.module @View_mapping
+// CHECK-NEXT{LITERAL}: sv.verbatim "assign {{0}}.foo = 2'h1;"
+// CHECK-NEXT{LITERAL}: sv.verbatim "assign {{0}}.bar = 64'h8000000000000000;"
+// CHECK-NEXT{LITERAL}: sv.verbatim "assign {{0}}.baz = 2'h3;"
+
+// -----
+
 firrtl.circuit "YAMLOutputEmptyInterface" attributes {
   annotations = [
     {class = "sifive.enterprise.grandcentral.AugmentedBundleType",


### PR DESCRIPTION
Building on #3141, this changes Grand Central (GCT) Views to, during the `AnnotationLowering` pass, add don't touch wire taps on the anything that is marked as a Grand Central XMR.  This effectively unblocks optimizations around the actually tapped thing to enable things like port removal.

Additionally, this incorporates a commit from #3154 to sink constants into the GCT Views mappings file when possible. This PR adds a small change to also remove the symbol on tapped wire (which is now safe because the only possible user of the tap is GCT Views). This has the effect of removing the tap if it becomes unnecessary due to constant propagation.

This closes #3154 as this is a much better approach.

## Example

Starting from the following FIRRTL file where we want to tap `w` to an SV interface member called "named" and `_w` to an SV interface member called "unnamed":

```scala
circuit Top :
  module MyView_companion :

    wire _WIRE : UInt<1>
    _WIRE <= UInt<1>("h0")

  module DUT :
    input clock : Clock
    input reset : Reset
    output out : UInt<1>

    wire w : UInt<1>
    w <= UInt<1>("h1")
    wire _w : UInt<1>
    _w <= UInt<1>("h1")
    node _out_T = xor(w, _w)
    out <= _out_T
    inst MyView_companion of MyView_companion

  module Top :
    input clock : Clock
    input reset : UInt<1>
    output out : UInt<1>

    inst dut of DUT
    dut.clock <= clock
    dut.reset <= reset
    out <= dut.out
```

After `LowerAnnotations`, the IR looks like:
```mlir
    %w = firrtl.wire  : !firrtl.uint<1>
    %_gctTap = firrtl.wire sym @_gctTap  {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 1 : i64}]} : !firrtl.uint<1>
    firrtl.connect %gctTap, %w : !firrtl.uint<1>, !firrtl.uint<1>
    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
    firrtl.connect %w, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
    %_w = firrtl.wire  : !firrtl.uint<1>
    %_gctTap_0 = firrtl.wire sym @_gctTap_0  {annotations = [{class = "sifive.enterprise.grandcentral.AugmentedGroundType", id = 2 : i64}]} : !firrtl.uint<1>
    firrtl.connect %gctTap_0, %_w : !firrtl.uint<1>, !firrtl.uint<1>
    firrtl.connect %_w, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
```

Note that there are two new wires with symbols and GCT `AugmentedGroundType` indicators: `%_gctTap` tapping `%w` and `%_gctTap_0` tapping `%_w`.

The resulting Verilog for the DUT is then:

```verilog
module DUT();
  wire w = 1'h1;

  // This interface is elsewhere emitted as a bind statement.
  // MyInterface MyView();
  /* This instance is elsewhere emitted as a bind statement.
    MyView_companion MyView_companion ();
  */
endmodule
```

Notably, the port on `DUT` is removed and the mappings file is tapping the taps, not the original wires:
```verilog
module MyView_mapping();
  assign MyView.named = 1'h1;
  assign MyView.unnamed = 1'h1;
endmodule
```

## Notes

The wire tap is the same hack that I used for the name preservation experiment. This would be better modeled as a true `firrtl.tap` operation (possibly with `read` or `write` modifiers or as a disjoint operation called `firrtl.tap.read`). This can be an incremental improvement after this PR.

This only unblocks optimizations around GCT Views. GCT Views are frequently used together with GCT Taps. I.e., this PR alone is not expected to produce dramatic port removal. Both #3141 and this PR will need to be replicated for GCT Taps in order to see a dramatic port removal effect.