### PR TITLE
[llvm] bump

### DIFF
--- a/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
@@ -62,7 +62,7 @@ class InstanceBuilder(support.NamedValueOpView):
     post_args = [
         ArrayAttr.get([StringAttr.get(x) for x in self.operand_names()]),
         ArrayAttr.get([StringAttr.get(x) for x in self.result_names()]),
-        ArrayAttr.get(inst_param_array), sym_name
+        ArrayAttr.get(inst_param_array)
     ]
     if results is None:
       results = module.type.results
@@ -86,6 +86,7 @@ class InstanceBuilder(support.NamedValueOpView):
                      pre_args,
                      post_args,
                      needs_result_type=True,
+                     inner_sym=sym_name,
                      loc=loc,
                      ip=ip)
 

--- a/lib/Bindings/Python/circt/dialects/_msft_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_msft_ops_ext.py
@@ -32,7 +32,7 @@ class InstanceBuilder(support.NamedValueOpView):
       parameters = _hw_ext.create_parameters(parameters, module)
     else:
       parameters = []
-    post_args = [_ir.ArrayAttr.get(parameters), target_design_partition]
+    post_args = []
     results = module.type.results
 
     super().__init__(
@@ -41,6 +41,8 @@ class InstanceBuilder(support.NamedValueOpView):
         input_port_mapping,
         pre_args,
         post_args,
+        parameters=_ir.ArrayAttr.get(parameters),
+        targetDesignPartition=target_design_partition,
         loc=loc,
         ip=ip,
     )

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -1679,7 +1679,7 @@ firrtl.module @add_cst_prop3(out %out_b: !firrtl.sint<4>) {
 // CHECK: %[[pad:.+]] = firrtl.pad %tmp_a, 5
 // CHECK-NEXT: firrtl.strictconnect %out_b, %[[pad]]
 // CHECK-NEXT: %[[pad:.+]] = firrtl.pad %tmp_a, 5
-// CHECK_NEXT: firrtl.strictconnect %out_b, %[[pad]]
+// CHECK-NEXT: firrtl.strictconnect %out_b, %[[pad]]
 firrtl.module @add_cst_prop4(out %out_b: !firrtl.uint<5>) {
   %tmp_a = firrtl.wire : !firrtl.uint<4>
   %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
@@ -1693,7 +1693,7 @@ firrtl.module @add_cst_prop4(out %out_b: !firrtl.uint<5>) {
 // CHECK: %[[pad:.+]] = firrtl.pad %tmp_a, 5
 // CHECK-NEXT: firrtl.strictconnect %out_b, %[[pad]]
 // CHECK-NEXT: %[[pad:.+]] = firrtl.pad %tmp_a, 5
-// CHECK_NEXT: firrtl.strictconnect %out_b, %[[pad]]
+// CHECK-NEXT: firrtl.strictconnect %out_b, %[[pad]]
 firrtl.module @add_cst_prop5(out %out_b: !firrtl.uint<5>) {
   %tmp_a = firrtl.wire : !firrtl.uint<4>
   %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -321,7 +321,7 @@ firrtl.circuit "InstanceOut2"   {
 // -----
 
 firrtl.circuit "invalidReg1"   {
-  // CHECK_LABEL: @invalidReg1
+  // CHECK-LABEL: @invalidReg1
   firrtl.module @invalidReg1(in %clock: !firrtl.clock, out %a: !firrtl.uint<1>) {
     %foobar = firrtl.reg %clock  : !firrtl.uint<1>
       //CHECK: %0 = firrtl.not %foobar : (!firrtl.uint<1>) -> !firrtl.uint<1>
@@ -336,7 +336,7 @@ firrtl.circuit "invalidReg1"   {
 // -----
 
 firrtl.circuit "invalidReg2"   {
-  // CHECK_LABEL: @invalidReg2
+  // CHECK-LABEL: @invalidReg2
   firrtl.module @invalidReg2(in %clock: !firrtl.clock, out %a: !firrtl.uint<1>) {
     %foobar = firrtl.reg %clock  : !firrtl.uint<1>
     firrtl.connect %foobar, %foobar : !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/prefix-modules.mlir
+++ b/test/Dialect/FIRRTL/prefix-modules.mlir
@@ -341,7 +341,7 @@ firrtl.circuit "GCTDataMemTapsPrefix" {
     // CHECK-SAME:  annotations = [{circt.nonlocal = @nla_4, class = "nla_4"}]
     // CHECK:       %mem_MPORT_en = firrtl.wire sym @s1  {annotations = [{circt.nonlocal = @nla_2, class = "nla_2"}]} : !firrtl.uint<1>
     // CHECK:       firrtl.module @Baz()
-    // CHECK_SAME:  annotations = [{circt.nonlocal = @nla_1, class = "nla_1"}, {circt.nonlocal = @nla_3, class = "nla_3"}]
+    // CHECK-SAME:  annotations = [{circt.nonlocal = @nla_1, class = "nla_1"}, {circt.nonlocal = @nla_3, class = "nla_3"}]
     // CHECK:       %mem_MPORT_en = firrtl.wire sym @s1  : !firrtl.uint<1>
     
   }


### PR DESCRIPTION
* https://reviews.llvm.org/D124717 changed optional attribute handling in the Python API
* https://reviews.llvm.org/D125604 catches misspelled FileCheck directives