### PR TITLE
[FIRRTL] Add utilities to NLATable analysis. NFC.

### DIFF
--- a/include/circt/Dialect/FIRRTL/NLATable.h
+++ b/include/circt/Dialect/FIRRTL/NLATable.h
@@ -65,6 +65,12 @@ public:
     llvm::set_intersect(common, set2);
   }
 
+  /// Get the instances that the InstanceOp participates in.
+  void getInstanceNLAs(InstanceOp inst, DenseSet<NonLocalAnchor> &nlas) {
+    commonNLAs(inst->getParentOfType<FModuleOp>().getNameAttr(),
+               inst.moduleNameAttr().getAttr(), nlas);
+  }
+
   //===-------------------------------------------------------------------------
   // Methods to keep an NLATable up to date.
   //
@@ -97,6 +103,13 @@ public:
   void renameModuleAndInnerRef(
       StringAttr newModName, StringAttr oldModName,
       const DenseMap<StringAttr, StringAttr> &innerSymRenameMap);
+
+  // Remove the NLA from the Module.
+  void removeNLAfromModule(NonLocalAnchor nla, StringAttr mod);
+
+  // Remove all the nlas in the set from the module.
+  void removeNLAsfromModule(const DenseSet<NonLocalAnchor> &nlas,
+                            StringAttr mod);
 
 private:
   NLATable(const NLATable &) = delete;

--- a/lib/Dialect/FIRRTL/NLATable.cpp
+++ b/lib/Dialect/FIRRTL/NLATable.cpp
@@ -88,6 +88,23 @@ void NLATable::renameModuleAndInnerRef(
   return;
 }
 
+void NLATable::removeNLAfromModule(NonLocalAnchor nla, StringAttr mod) {
+  auto nlaList = nodeMap[mod];
+  for (auto it = nlaList.begin(), e = nlaList.end(); it != e; ++it)
+    if ((*it) == nla) {
+      nlaList.erase(it);
+      break;
+    }
+}
+
+void NLATable::removeNLAsfromModule(const DenseSet<NonLocalAnchor> &nlas,
+                                    StringAttr mod) {
+  auto nlaList = nodeMap[mod];
+  for (auto it = nlaList.begin(), e = nlaList.end(); it != e; ++it)
+    if (nlas.count(*it))
+      nlaList.erase(it);
+}
+
 void NLATable::updateModuleInNLA(StringAttr name, StringAttr oldModule,
                                  StringAttr newModule) {
   auto nlaOp = getNLA(name);
@@ -118,11 +135,6 @@ FModuleLike NLATable::getModule(StringAttr name) {
   auto *n = symToOp.lookup(name);
   return dyn_cast_or_null<FModuleLike>(n);
 }
-
-// void NLATable::retargetInstance(InstanceOp inst, StringRef newModName) {
-//     inst.moduleNameAttr(FlatSymbolRefAttr::get(inst.getContext(),
-//     newModName));
-// }
 
 ArrayRef<NonLocalAnchor> NLATable::lookup(StringAttr name) {
   auto iter = nodeMap.find(name);


### PR DESCRIPTION
This commit adds utilities to NLATable analysis, 
 1. For getting the NLAs that an instance participates in.
 2. Remove an NLA from the Module.
 3. Remove a set of NLAs from the Module.