### PR TITLE
[FIRRTL] Dedup pass preserves the NLATable analysis. NFC.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -1336,6 +1336,7 @@ class DedupPass : public DedupBase<DedupPass> {
     // can block the deduplication of the parent modules.
     fixupAllModules(instanceGraph);
 
+    markAnalysesPreserved<NLATable>();
     if (!anythingChanged)
       markAllAnalysesPreserved();
   }


### PR DESCRIPTION
The `Dedup` pass keeps the `NLATable` in sync with any changes to Module names and NLA updates.
Hence the NLATable analysis is preserved by the pass.