### PR TITLE
[FIRRTL] Remove NLA breadcrumbs from InstanceOps

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
@@ -286,14 +286,10 @@ static std::string addNLATargets(
   }
 
   for (int i = 0, e = nlaTargets.size() - 1; i < e; ++i) {
-    NamedAttrList pathmetadata, dontTouch;
-    pathmetadata.append("circt.nonlocal", nlaSym);
-    pathmetadata.append("class", StringAttr::get(context, "circt.nonlocal"));
+    NamedAttrList dontTouch;
     dontTouch.append(
         "class",
         StringAttr::get(context, "firrtl.transforms.DontTouchAnnotation"));
-    mutableAnnotationMap[std::get<0>(nlaTargets[i])].push_back(
-        DictionaryAttr::get(context, pathmetadata));
     // Every op with nonlocal anchor must have a symbol. Hence add the
     // dontTouch.
     mutableAnnotationMap[std::get<0>(nlaTargets[i])].push_back(
@@ -1097,11 +1093,7 @@ bool circt::firrtl::scatterCustomAnnotations(
 
           // Annotate instances along the NLA path.
           for (int i = 0, e = NLATargets.size() - 1; i < e; ++i) {
-            NamedAttrList fields;
-            fields.append("circt.nonlocal", nlaSym);
-            fields.append("class", StringAttr::get(context, "circt.nonlocal"));
             StringRef tgt = std::get<0>(NLATargets[i]);
-            newAnnotations[tgt].push_back(DictionaryAttr::get(context, fields));
             addDontTouch(tgt);
           }
         }
@@ -1217,11 +1209,6 @@ bool circt::firrtl::scatterCustomAnnotations(
 
         // Annotate instances along the NLA path.
         for (int i = 0, e = nlaTargets.size() - 1; i < e; ++i) {
-          NamedAttrList fields;
-          fields.append("circt.nonlocal", nlaSym);
-          fields.append("class", StringAttr::get(context, "circt.nonlocal"));
-          newAnnotations[std::get<0>(nlaTargets[i])].push_back(
-              DictionaryAttr::get(context, fields));
           addDontTouch(std::get<0>(nlaTargets[i]));
         }
       }

--- a/lib/Dialect/FIRRTL/Transforms/InjectDUTHierarchy.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InjectDUTHierarchy.cpp
@@ -209,13 +209,6 @@ void InjectDUTHierarchy::runOnOperation() {
         hw::InnerRefAttr::get(wrapper.moduleNameAttr(), dutRef.getName()));
     newNamepath.append(back.begin(), back.end());
     nla->setAttr("namepath", b.getArrayAttr(newNamepath));
-
-    // Add the breadcrumb to the instance.
-    AnnotationSet annotations(wrapperInst);
-    NamedAttribute breadcrumb(b.getStringAttr("circt.nonlocal"),
-                              FlatSymbolRefAttr::get(nla.sym_nameAttr()));
-    annotations.addAnnotations(b.getDictionaryAttr({breadcrumb}));
-    annotations.applyToOperation(wrapperInst);
   }
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -125,14 +125,6 @@ static FlatSymbolRefAttr scatterNonLocalPath(AnnoPathValue target,
                                              ApplyState &state) {
 
   FlatSymbolRefAttr sym = buildNLA(target, state);
-
-  NamedAttrList pathmetadata;
-  pathmetadata.append("circt.nonlocal", sym);
-  pathmetadata.append(
-      "class", StringAttr::get(state.circuit.getContext(), "circt.nonlocal"));
-  for (auto item : target.instances)
-    addAnnotation(OpAnnoTarget(item), 0, pathmetadata);
-
   return sym;
 }
 

--- a/test/Dialect/FIRRTL/SFCTests/dedup.fir
+++ b/test/Dialect/FIRRTL/SFCTests/dedup.fir
@@ -321,7 +321,7 @@ circuit Top : %[[
 ]]
   ; CHECK: firrtl.nla @[[nlaSym:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]]]
   ; CHECK: firrtl.module @Top
-  ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] {annotations = [{circt.nonlocal = @[[nlaSym]], class = "circt.nonlocal"}]} @A(
+  ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] @A(
   ; CHECK-NEXT: firrtl.instance a2 @A(
   module Top :
     inst a1 of A
@@ -357,8 +357,8 @@ circuit Top : %[[
   ; CHECK: firrtl.nla @[[nlaSym1:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]]]
   ; CHECK: firrtl.nla @[[nlaSym2:[_a-zA-Z0-9]+]] [@Top::@[[a2Sym:[_a-zA-Z0-9]+]], @A::@[[bSym]]]
   ; CHECK: firrtl.module @Top
-  ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] {annotations = [{circt.nonlocal = @[[nlaSym1]], class = "circt.nonlocal"}]} @A(
-  ; CHECK-NEXT: firrtl.instance a2 sym @[[a2Sym]] {annotations = [{circt.nonlocal = @[[nlaSym2]], class = "circt.nonlocal"}]} @A(
+  ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] @A(
+  ; CHECK-NEXT: firrtl.instance a2 sym @[[a2Sym]] @A(
   module Top :
     inst a1 of A
     inst a2 of A_

--- a/test/Dialect/FIRRTL/SFCTests/dedup.fir
+++ b/test/Dialect/FIRRTL/SFCTests/dedup.fir
@@ -456,17 +456,13 @@ circuit Top : %[[
   ; CHECK: firrtl.nla @[[nla_1:[_a-zA-Z0-9]+]] [@Top::@[[aSym]], @A::@[[bSym]], @B]
   ; CHECK: firrtl.module @Top
   module Top :
-    ; CHECK-NEXT: firrtl.instance a sym @[[aSym]] {{.+}} [{circt.nonlocal = @[[nla_1]], class = "circt.nonlocal"}, {circt.nonlocal = @[[nla_2]], class = "circt.nonlocal"}]} @A()
+    ; CHECK-NEXT: firrtl.instance a sym @[[aSym]] @A()
     inst a of A
-    ; CHECK-NEXT: firrtl.instance a_ sym @[[a_Sym]] {{.+}} [{circt.nonlocal = @[[nla_3]], class = "circt.nonlocal"}, {circt.nonlocal = @[[nla_4]], class = "circt.nonlocal"}]} @A()
+    ; CHECK-NEXT: firrtl.instance a_ sym @[[a_Sym]] @A()
     inst a_ of A_
   ; CHECK: firrtl.module private @A
   module A :
     ; CHECK-NEXT: firrtl.instance b sym @[[bSym]]
-    ; CHECK-SAME: {circt.nonlocal = @[[nla_3]], class = "circt.nonlocal"}
-    ; CHECK-SAME: {circt.nonlocal = @[[nla_4]], class = "circt.nonlocal"}
-    ; CHECK-SAME: {circt.nonlocal = @[[nla_1]], class = "circt.nonlocal"}
-    ; CHECK-SAME: {circt.nonlocal = @[[nla_2]], class = "circt.nonlocal"}
     ; CHECK-SAME: B()
     inst b of B
   ; CHECK-NOT: firrtl.module private @A_
@@ -538,53 +534,33 @@ circuit Top : %[[
   ; CHECK-NEXT:   firrtl.module @Top
   module Top :
     ; CHECK-NEXT:   firrtl.instance a sym @[[aSym]]
-    ; CHECK-SAME:     [{circt.nonlocal = @[[nla_1]], class = "circt.nonlocal"},
-    ; CHECK-SAME:      {circt.nonlocal = @[[nla_2]], class = "circt.nonlocal"}]}
     ; CHECK-SAME:     @A()
     inst a of A
     ; CHECK-NEXT:   firrtl.instance a_ sym @[[a_Sym]]
-    ; CHECK-SAME:     [{circt.nonlocal = @[[nla_3]], class = "circt.nonlocal"},
-    ; CHECK-SAME:      {circt.nonlocal = @[[nla_4]], class = "circt.nonlocal"}]}
     ; CHECK-SAME:     @A()
     inst a_ of A_
 
   ; CHECK:        firrtl.module private @A
   module A :
     ; CHECK-NEXT:   firrtl.instance b sym @[[bSym]]
-    ; CHECK-SAME:     [{circt.nonlocal = @[[nla_3]], class = "circt.nonlocal"},
-    ; CHECK-SAME:      {circt.nonlocal = @[[nla_4]], class = "circt.nonlocal"},
-    ; CHECK-SAME:      {circt.nonlocal = @[[nla_1]], class = "circt.nonlocal"},
-    ; CHECK-SAME:      {circt.nonlocal = @[[nla_2]], class = "circt.nonlocal"}]}
     ; CHECK-SAME:     @B()
     inst b of B
 
   ; CHECK:        firrtl.module private @B
   module B :
     ; CHECK-NEXT:   firrtl.instance c sym @[[cSym]]
-    ; CHECK-SAME:     [{circt.nonlocal = @[[nla_3]], class = "circt.nonlocal"},
-    ; CHECK-SAME:      {circt.nonlocal = @[[nla_4]], class = "circt.nonlocal"},
-    ; CHECK-SAME:      {circt.nonlocal = @[[nla_1]], class = "circt.nonlocal"},
-    ; CHECK-SAME:      {circt.nonlocal = @[[nla_2]], class = "circt.nonlocal"}]}
     ; CHECK-SAME:     @C()
     inst c of C
 
   ; CHECK:        firrtl.module private @C
   module C :
     ; CHECK-NEXT:   firrtl.instance d sym @[[dSym]]
-    ; CHECK-SAME:     [{circt.nonlocal = @[[nla_3]], class = "circt.nonlocal"},
-    ; CHECK-SAME:      {circt.nonlocal = @[[nla_4]], class = "circt.nonlocal"},
-    ; CHECK-SAME:      {circt.nonlocal = @[[nla_1]], class = "circt.nonlocal"},
-    ; CHECK-SAME:      {circt.nonlocal = @[[nla_2]], class = "circt.nonlocal"}]}
     ; CHECK-SAME:     @D()
     inst d of D
 
   ; CHECK:        firrtl.module private @D
-  ; CHECK-SAME:     [{circt.nonlocal = @[[nla_3]], class = "two"},
-  ; CHECK-SAME:      {circt.nonlocal = @[[nla_1]], class = "one"}]
   module D :
     ; CHECK:        firrtl.node
-    ; CHECK-SAME:     [{circt.nonlocal = @[[nla_4]], class = "two"},
-    ; CHECK-SAME:      {circt.nonlocal = @[[nla_2]], class = "one"}]
     node foo = UInt<1>(0)
 
   ; CHECK-NOT: firrtl.module private @A_
@@ -709,44 +685,24 @@ circuit Top : %[[
   ; CHECK-NEXT:   firrtl.module @Top
   module Top :
     ; CHECK-NEXT:   firrtl.instance b sym @[[TopbSym]]
-    ; CHECK-SAME:    [{circt.nonlocal = @[[nla_1]], class = "circt.nonlocal"},
-    ; CHECK-SAME:     {circt.nonlocal = @[[nla_7]], class = "circt.nonlocal"}]
     ; CHECK-SAME:     @B()
     inst b of B
     ; CHECK-NEXT:   firrtl.instance b_ sym @[[TopbSym]]
-    ; CHECK-SAME:    [{circt.nonlocal = @[[nla_2]], class = "circt.nonlocal"},
-    ; CHECK-SAME:     {circt.nonlocal = @[[nla_8]], class = "circt.nonlocal"}]
     ; CHECK-SAME:     @B()
     inst b_ of B_
     ; CHECK-NEXT:   firrtl.instance a1 sym @[[Topa1Sym]]
-    ; CHECK-SAME:    [{circt.nonlocal = @[[nla_3]], class = "circt.nonlocal"},
-    ; CHECK-SAME:     {circt.nonlocal = @[[nla_5]], class = "circt.nonlocal"},
-    ; CHECK-SAME:     {circt.nonlocal = @[[nla_9]], class = "circt.nonlocal"},
-    ; CHECK-SAME:     {circt.nonlocal = @[[nla_11]], class = "circt.nonlocal"}]
     ; CHECK-SAME:     @A()
     inst a1 of A
     ; CHECK-NEXT:   firrtl.instance a2 sym @[[Topa2Sym]]
-    ; CHECK-SAME:    [{circt.nonlocal = @[[nla_4]], class = "circt.nonlocal"},
-    ; CHECK-SAME:     {circt.nonlocal = @[[nla_6]], class = "circt.nonlocal"},
-    ; CHECK-SAME:     {circt.nonlocal = @[[nla_10]], class = "circt.nonlocal"},
-    ; CHECK-SAME:     {circt.nonlocal = @[[nla_12]], class = "circt.nonlocal"}]
     ; CHECK-SAME:     @A()
     inst a2 of A
 
   ; CHECK:        firrtl.module private @A()
   module A :
     ; CHECK-NEXT:   firrtl.instance b sym @[[AbSym]]
-    ; CHECK-SAME:     {circt.nonlocal = @[[nla_5]], class = "circt.nonlocal"},
-    ; CHECK-SAME:     {circt.nonlocal = @[[nla_6]], class = "circt.nonlocal"},
-    ; CHECK-SAME:     {circt.nonlocal = @[[nla_11]], class = "circt.nonlocal"},
-    ; CHECK-SAME:     {circt.nonlocal = @[[nla_12]], class = "circt.nonlocal"}]
     ; CHECK-SAME:     @B()
     inst b of B
     ; CHECK-NEXT:   firrtl.instance b_ sym @[[Ab_Sym]]
-    ; CHECK-SAME:     {circt.nonlocal = @[[nla_3]], class = "circt.nonlocal"},
-    ; CHECK-SAME:     {circt.nonlocal = @[[nla_4]], class = "circt.nonlocal"},
-    ; CHECK-SAME:     {circt.nonlocal = @[[nla_9]], class = "circt.nonlocal"},
-    ; CHECK-SAME:     {circt.nonlocal = @[[nla_10]], class = "circt.nonlocal"}]
     ; CHECK-SAME:     @B()
     inst b_ of B_
 
@@ -759,12 +715,6 @@ circuit Top : %[[
   ; CHECK-SAME:      {circt.nonlocal = @[[nla_6]], class = "nla6"}]
   module B :
     ; CHECK-NEXT:   firrtl.instance c sym @[[BcSym]]
-    ; CHECK-SAME:     [{circt.nonlocal = @[[nla_8]], class = "circt.nonlocal"},
-    ; CHECK-SAME:      {circt.nonlocal = @[[nla_9]], class = "circt.nonlocal"},
-    ; CHECK-SAME:      {circt.nonlocal = @[[nla_10]], class = "circt.nonlocal"},
-    ; CHECK-SAME:      {circt.nonlocal = @[[nla_7]], class = "circt.nonlocal"},
-    ; CHECK-SAME:      {circt.nonlocal = @[[nla_11]], class = "circt.nonlocal"},
-    ; CHECK-SAME:      {circt.nonlocal = @[[nla_12]], class = "circt.nonlocal"}]
     ; CHECK-SAME:     @C()
     inst c of C
 
@@ -814,14 +764,12 @@ circuit top : %[[
     output oa: {z: {y: {x: UInt<1>}}, a: UInt<1>}
     output ob: {a: {b: {c: UInt<1>}}, z: UInt<1>}
     ; CHECK:      firrtl.instance a sym @[[topaSym]]
-    ; CHECK-SAME:   [{circt.nonlocal = @[[nla_1]], class = "circt.nonlocal"}]
     inst a of a
     a.i.z.y.x <= ia.z.y.x
     a.i.a <= ia.a
     oa.z.y.x <= a.o.z.y.x
     oa.a <= a.o.a
     ; CHECK:      firrtl.instance b sym @[[topbSym]]
-    ; CHECK-SAME:   [{circt.nonlocal = @[[nla_2]], class = "circt.nonlocal"}
     inst b of b
     b.q.a.b.c <= ib.a.b.c
     b.q.z <= ib.z

--- a/test/Dialect/FIRRTL/annotations-errors.fir
+++ b/test/Dialect/FIRRTL/annotations-errors.fir
@@ -146,7 +146,7 @@ circuit Foo: %[[{"a":null,"target":"~Foo|Foo>x"}]]
 
 ; A target pointing at a non-existent instance should error.
 
-; expected-error @+1 {{unapplied annotations with target '~Foo|Foo>baz' and payload '[{circt.nonlocal = @nla_1, class = "circt.nonlocal"}, {class = "firrtl.transforms.DontTouchAnnotation"}]'}}
+; expected-error @+1 {{unapplied annotations with target '~Foo|Foo>baz' and payload '[{class = "firrtl.transforms.DontTouchAnnotation"}]'}}
 circuit Foo: %[[{"a":null,"target":"~Foo|Foo/baz:Bar"}]]
   module Bar:
     skip

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -82,7 +82,7 @@ circuit Foo: %[[
     ; CHECK-SAME annotations = [{c = "c"}]
     ; CHECK: firrtl.module @Foo
     ; CHECK: firrtl.instance bar
-    ; CHECK-SAME: annotations = [{a = "a"}, {b = "b"}, {circt.nonlocal = @nla_1, class = "circt.nonlocal"}]
+    ; CHECK-SAME: annotations = [{a = "a"}, {b = "b"}]
 
 ; // -----
 
@@ -412,8 +412,7 @@ circuit Test : %[[
 ; CHECK: firrtl.module private @Example() attributes {
 ; CHECK-SAME: annotations = [{circt.nonlocal = @nla_1, class = "fake"}]
 ; CHECK: firrtl.module @Test()
-; CHECK:   firrtl.instance Test sym @Test
-; CHECK-SAME: annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}]
+; CHECK:   firrtl.instance Test sym @Test @Example()
 
 ; // -----
 
@@ -432,11 +431,9 @@ circuit Foo: %[[{"a":"a","target":"~Foo|Foo/bar:Bar/baz:Baz"}, {"b":"b","target"
 ; CHECK: firrtl.module private @Baz
 ; CHECK-SAME: annotations = [{a = "a", circt.nonlocal = @nla_1}, {b = "b", circt.nonlocal = @nla_2}]
 ; CHECK: firrtl.module private @Bar()
-; CHECK: firrtl.instance baz
-; CHECK-SAME: [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}, {circt.nonlocal = @nla_2, class = "circt.nonlocal"}]
+; CHECK: firrtl.instance baz sym @baz @Baz()
 ; CHECK: firrtl.module @Foo()
-; CHECK: firrtl.instance bar
-; CHECK-SAME: [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}, {circt.nonlocal = @nla_2, class = "circt.nonlocal"}]
+; CHECK: firrtl.instance bar sym @bar @Bar()
 
 ; // -----
 
@@ -539,7 +536,6 @@ circuit Top : %[[{
 ; CHECK-SAME: {annotations = ["foo", "bar"], circuit = "", circuitPackage = "other", class = "sifive.enterprise.grandcentral.ModuleReplacementAnnotation", id = [[ID:.+]] : i64}
 
 ; CHECK: %child_in, %child_out = firrtl.instance child
-; CHECK-SAME: sym @child {annotations = [{circt.nonlocal = @nla_2, class = "circt.nonlocal"}]}
 
 ; CHECK: firrtl.extmodule private @Child(
 ; CHECK-SAME:   in in: !firrtl.uint<123> sym @in,

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -26,8 +26,8 @@ firrtl.circuit "Aggregates" attributes {rawAnnotations = [
 // CHECK: firrtl.module @BarNL
 // CHECK: %w = firrtl.wire sym @w {annotations = [{circt.nonlocal = @nla_0, class = "circt.test", nl = "nl"}]}
 // CHECK: %w2 = firrtl.wire sym @w2 {annotations = [{circt.fieldID = 5 : i32, circt.nonlocal = @nla, class = "circt.test", nl = "nl2"}]} : !firrtl.bundle<a: uint, b: vector<uint, 4>>
-// CHECK: firrtl.instance bar sym @bar {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}, {circt.nonlocal = @nla_0, class = "circt.nonlocal"}, {circt.nonlocal = @nla_1, class = "circt.nonlocal"}]} @BarNL()
-// CHECK: firrtl.instance baz sym @baz {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}, {circt.nonlocal = @nla_0, class = "circt.nonlocal"}, {circt.nonlocal = @nla_1, class = "circt.nonlocal"}]} @BazNL()
+// CHECK: firrtl.instance bar sym @bar @BarNL()
+// CHECK: firrtl.instance baz sym @baz @BazNL()
 // CHECK: firrtl.module @FooL
 // CHECK: %w3 = firrtl.wire {annotations = [{class = "circt.test", nl = "nl3"}]}
 firrtl.circuit "FooNL"  attributes {rawAnnotations = [
@@ -63,7 +63,6 @@ firrtl.circuit "FooNL"  attributes {rawAnnotations = [
 // CHECK-SAME: portAnnotations = {{\[}}[{circt.nonlocal = @nla, class = "circt.test", nl = "nl"}]]
 // CHECK: firrtl.module @MemPortsNL()
 // CHECK:   firrtl.instance child sym @child
-// CHECK-SAME: annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}]
 firrtl.circuit "MemPortsNL" attributes {rawAnnotations = [
   {class = "circt.test", nl = "nl", target = "~MemPortsNL|MemPortsNL/child:Child>bar.r"}
   ]}  {
@@ -110,7 +109,7 @@ firrtl.circuit "Test" attributes {rawAnnotations = [
   firrtl.extmodule @ExtTest()
 
   firrtl.module @Test() {
-    // CHECK: firrtl.instance exttest sym @exttest  {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}]} @ExtTest()
+    // CHECK: firrtl.instance exttest sym @exttest @ExtTest()
     firrtl.instance exttest @ExtTest()
   }
 }
@@ -126,7 +125,7 @@ firrtl.circuit "Test" attributes {rawAnnotations = [
   firrtl.extmodule @ExtTest(in in: !firrtl.uint<1>)
 
   firrtl.module @Test() {
-    // CHECK: %exttest_in = firrtl.instance exttest sym @exttest  {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}]} @ExtTest(in in: !firrtl.uint<1>)
+    // CHECK: %exttest_in = firrtl.instance exttest sym @exttest @ExtTest(in in: !firrtl.uint<1>)
     firrtl.instance exttest @ExtTest(in in : !firrtl.uint<1>)
   }
 }

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -122,10 +122,10 @@ firrtl.circuit "Annotations" {
     %j = firrtl.wire : !firrtl.bundle<a: uint<1>>
   }
   firrtl.module @Annotations() {
-    // CHECK: firrtl.instance annotations0 sym @annotations0  {annotations = [{circt.nonlocal = @annos_nla0, class = "circt.nonlocal"}, {circt.nonlocal = [[NLA1]], class = "circt.nonlocal"}, {circt.nonlocal = [[NLA2]], class = "circt.nonlocal"}]} @Annotations0()
-    // CHECK: firrtl.instance annotations1 sym @annotations1  {annotations = [{circt.nonlocal = @annos_nla1, class = "circt.nonlocal"}, {circt.nonlocal = [[NLA0]], class = "circt.nonlocal"}, {circt.nonlocal = [[NLA3]], class = "circt.nonlocal"}]} @Annotations0()
-    firrtl.instance annotations0 sym @annotations0 {annotations = [{circt.nonlocal = @annos_nla0, class = "circt.nonlocal"}]} @Annotations0()
-    firrtl.instance annotations1 sym @annotations1 {annotations = [{circt.nonlocal = @annos_nla1, class = "circt.nonlocal"}]} @Annotations1()
+    // CHECK: firrtl.instance annotations0 sym @annotations0  @Annotations0()
+    // CHECK: firrtl.instance annotations1 sym @annotations1  @Annotations0()
+    firrtl.instance annotations0 sym @annotations0 @Annotations0()
+    firrtl.instance annotations1 sym @annotations1 @Annotations1()
   }
 }
 
@@ -152,9 +152,7 @@ firrtl.circuit "PortAnnotations" {
   }
   // CHECK: firrtl.module @PortAnnotations
   firrtl.module @PortAnnotations() {
-    // CHECK: annotations = [{circt.nonlocal = [[NLA1]], class = "circt.nonlocal"}, {circt.nonlocal = [[NLA3]], class = "circt.nonlocal"}]
     %portannos0_in = firrtl.instance portannos0 @PortAnnotations0(in a: !firrtl.uint<1>)
-    // CHECK: annotations = [{circt.nonlocal = [[NLA0]], class = "circt.nonlocal"}, {circt.nonlocal = [[NLA2]], class = "circt.nonlocal"}]
     %portannos1_in = firrtl.instance portannos1 @PortAnnotations1(in b: !firrtl.uint<1>)
   }
 }
@@ -182,37 +180,17 @@ firrtl.circuit "Breadcrumb" {
   }
   // CHECK: firrtl.module @Breadcrumb0()
   firrtl.module @Breadcrumb0() {
-    // CHECK: %crumb0_in = firrtl.instance crumb0 sym @crumb0  {annotations = [
-    // CHECK-SAME: {circt.nonlocal = @breadcrumb_nla1, class = "circt.nonlocal"},
-    // CHECK-SAME: {circt.nonlocal = @breadcrumb_nla3, class = "circt.nonlocal"},
-    // CHECK-SAME: {circt.nonlocal = @breadcrumb_nla0, class = "circt.nonlocal"},
-    // CHECK-SAME: {circt.nonlocal = @breadcrumb_nla2, class = "circt.nonlocal"}]}
-    %crumb_in = firrtl.instance crumb0 sym @crumb0 {annotations = [
-      {circt.nonlocal = @breadcrumb_nla0, class = "circt.nonlocal"},
-      {circt.nonlocal = @breadcrumb_nla2, class = "circt.nonlocal"}
-    ]} @Crumb(in in : !firrtl.uint<1>)
+    // CHECK: %crumb0_in = firrtl.instance crumb0 sym @crumb0
+    %crumb_in = firrtl.instance crumb0 sym @crumb0 @Crumb(in in : !firrtl.uint<1>)
   }
   // CHECK-NOT: firrtl.module @Breadcrumb1()
   firrtl.module @Breadcrumb1() {
-    %crumb_in = firrtl.instance crumb1 sym @crumb1 {annotations = [
-      {circt.nonlocal = @breadcrumb_nla1, class = "circt.nonlocal"},
-      {circt.nonlocal = @breadcrumb_nla3, class = "circt.nonlocal"}
-    ]} @Crumb(in in : !firrtl.uint<1>)
+    %crumb_in = firrtl.instance crumb1 sym @crumb1 @Crumb(in in : !firrtl.uint<1>)
   }
   // CHECK: firrtl.module @Breadcrumb()
   firrtl.module @Breadcrumb() {
-    // CHECK:     [{circt.nonlocal = @breadcrumb_nla0, class = "circt.nonlocal"},
-    // CHECK-SAME: {circt.nonlocal = @breadcrumb_nla2, class = "circt.nonlocal"}]}
-    firrtl.instance breadcrumb0 sym @breadcrumb0 {annotations = [
-      {circt.nonlocal = @breadcrumb_nla0, class = "circt.nonlocal"},
-      {circt.nonlocal = @breadcrumb_nla2, class = "circt.nonlocal"}
-    ]} @Breadcrumb0()
-    // CHECK:     [{circt.nonlocal = @breadcrumb_nla1, class = "circt.nonlocal"},
-    // CHECK-SAME: {circt.nonlocal = @breadcrumb_nla3, class = "circt.nonlocal"}]}
-    firrtl.instance breadcrumb1 sym @breadcrumb1 {annotations = [
-      {circt.nonlocal = @breadcrumb_nla1, class = "circt.nonlocal"},
-      {circt.nonlocal = @breadcrumb_nla3, class = "circt.nonlocal"}
-    ]} @Breadcrumb1()
+    firrtl.instance breadcrumb0 sym @breadcrumb0 @Breadcrumb0()
+    firrtl.instance breadcrumb1 sym @breadcrumb1 @Breadcrumb1()
   }
 }
 
@@ -250,31 +228,17 @@ firrtl.circuit "Context" {
       {circt.nonlocal = @context_nla3, class = "fake1"}]}: !firrtl.uint<3>
   }
   firrtl.module @Context0() {
-    // CHECK: %leaf_in = firrtl.instance leaf sym @c0  {annotations = [
-    // CHECK-SAME: {circt.nonlocal = [[NLA0]], class = "circt.nonlocal"},
-    // CHECK-SAME: {circt.nonlocal = [[NLA2]], class = "circt.nonlocal"},
-    // CHECK-SAME: {circt.nonlocal = [[NLA1]], class = "circt.nonlocal"},
-    // CHECK-SAME: {circt.nonlocal = [[NLA3]], class = "circt.nonlocal"}]}
-    %leaf_in = firrtl.instance leaf sym @c0 {annotations = [
-      {circt.nonlocal = @context_nla0, class = "circt.nonlocal"},
-      {circt.nonlocal = @context_nla1, class = "circt.nonlocal"}
-    ]} @ContextLeaf(in in : !firrtl.uint<1>)
+    // CHECK: %leaf_in = firrtl.instance leaf sym @c0
+    %leaf_in = firrtl.instance leaf sym @c0 @ContextLeaf(in in : !firrtl.uint<1>)
   }
   // CHECK-NOT: firrtl.module @Context1()
   firrtl.module @Context1() {
-    %leaf_in = firrtl.instance leaf sym @c1 {annotations = [
-      {circt.nonlocal = @context_nla2, class = "circt.nonlocal"},
-      {circt.nonlocal = @context_nla3, class = "circt.nonlocal"}
-    ]} @ContextLeaf(in in : !firrtl.uint<1>)
+    %leaf_in = firrtl.instance leaf sym @c1 @ContextLeaf(in in : !firrtl.uint<1>)
   }
   firrtl.module @Context() {
-    // CHECK: firrtl.instance context0 sym @context0  {annotations = [
-    // CHECK-SAME: {circt.nonlocal = [[NLA0]], class = "circt.nonlocal"},
-    // CHECK-SAME: {circt.nonlocal = [[NLA2]], class = "circt.nonlocal"}]}
+    // CHECK: firrtl.instance context0 sym @context0
     firrtl.instance context0 @Context0()
-    // CHECK: firrtl.instance context1 sym @context1  {annotations = [
-    // CHECK-SAME: {circt.nonlocal = [[NLA1]], class = "circt.nonlocal"},
-    // CHECK-SAME: {circt.nonlocal = [[NLA3]], class = "circt.nonlocal"}]}
+    // CHECK: firrtl.instance context1 sym @context1
     firrtl.instance context1 @Context1()
   }
 }
@@ -292,8 +256,8 @@ firrtl.circuit "ExtModuleTest" {
   firrtl.module @ExtModuleTest() {
     // CHECK: firrtl.instance e0  @ExtMod0()
     firrtl.instance e0 @ExtMod0()
-    // CHECK: firrtl.instance e1 sym @e1  {annotations = [{circt.nonlocal = @ext_nla, class = "circt.nonlocal"}]} @ExtMod0()
-    firrtl.instance e1 sym @e1 {annotations = [{circt.nonlocal = @ext_nla, class = "circt.nonlocal"}]} @ExtMod1()
+    // CHECK: firrtl.instance e1 sym @e1 @ExtMod0()
+    firrtl.instance e1 sym @e1 @ExtMod1()
   }
 }
 
@@ -308,8 +272,8 @@ firrtl.circuit "Foo"  {
   firrtl.extmodule @B(out b: !firrtl.clock sym @b [{circt.nonlocal = @nla_1}])
   firrtl.module @Foo() {
     %b0_out = firrtl.instance a @A(out a: !firrtl.clock)
-    // CHECK: firrtl.instance b sym @b  {annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}]} @A(out a: !firrtl.clock)
-    %b1_out = firrtl.instance b sym @b {annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}]} @B(out b: !firrtl.clock)
+    // CHECK: firrtl.instance b sym @b  @A(out a: !firrtl.clock)
+    %b1_out = firrtl.instance b sym @b @B(out b: !firrtl.clock)
   }
 }
 
@@ -337,7 +301,6 @@ firrtl.circuit "Chain" {
   // CHECK: firrtl.nla [[NLA1:@nla.*]] [@Chain::@chainB0, @ChainB0::@chainA0, @ChainA0::@extchain0, @ExtChain0]
   // CHECK: firrtl.module @ChainB0()
   firrtl.module @ChainB0() {
-    // CHECK: {annotations = [{circt.nonlocal = [[NLA1]], class = "circt.nonlocal"}, {circt.nonlocal = [[NLA0]], class = "circt.nonlocal"}]}
     firrtl.instance chainA0 @ChainA0()
   }
   // CHECK: firrtl.extmodule @ExtChain0() attributes {annotations = [
@@ -348,7 +311,6 @@ firrtl.circuit "Chain" {
   firrtl.extmodule @ExtChain1() attributes {annotations = [{class = "1"}], defname = "ExtChain"}
   // CHECK: firrtl.module @ChainA0()
   firrtl.module @ChainA0()  {
-    // CHECK: {circt.nonlocal = [[NLA1]], class = "circt.nonlocal"}, {circt.nonlocal = [[NLA0]], class = "circt.nonlocal"}
     firrtl.instance extchain0 @ExtChain0()
   }
   // CHECK-NOT: firrtl.module @ChainB1()
@@ -360,9 +322,9 @@ firrtl.circuit "Chain" {
     firrtl.instance extchain1 @ExtChain1()
   }
   firrtl.module @Chain() {
-    // CHECK: firrtl.instance chainB0 sym @chainB0  {annotations = [{circt.nonlocal = [[NLA1]], class = "circt.nonlocal"}]} @ChainB0()
+    // CHECK: firrtl.instance chainB0 sym @chainB0 @ChainB0()
     firrtl.instance chainB0 @ChainB0()
-    // CHECK: firrtl.instance chainB1 sym @chainB1  {annotations = [{circt.nonlocal = [[NLA0]], class = "circt.nonlocal"}]} @ChainB0()
+    // CHECK: firrtl.instance chainB1 sym @chainB1 @ChainB0()
     firrtl.instance chainB1 @ChainB1()
   }
 }

--- a/test/Dialect/FIRRTL/lower-memory.mlir
+++ b/test/Dialect/FIRRTL/lower-memory.mlir
@@ -232,11 +232,11 @@ firrtl.circuit "NonLocalAnnotation" {
 firrtl.nla @nla [@NonLocalAnnotation::@dut, @DUT::@sym]
 // CHECK: firrtl.module @NonLocalAnnotation()
 firrtl.module @NonLocalAnnotation()  {
-  firrtl.instance dut sym @dut {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}]} @DUT()
+  firrtl.instance dut sym @dut @DUT()
 }
 // CHECK: firrtl.module @DUT()
 firrtl.module @DUT() {
-  // CHECK: firrtl.instance mem0 sym @sym {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}]} @mem0
+  // CHECK: firrtl.instance mem0 sym @sym @mem0
   %mem0_write = firrtl.mem sym @sym Undefined {annotations = [{circt.nonlocal = @nla, class = "test0"}, {circt.nonlocal = @nla, class = "test2"}], depth = 12 : i64, name = "mem0", portNames = ["write"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
 // LowerMemory should ignore MemOps that are not seqmems. The following memory is a combmem with readLatency=1.
   %MRead_read = firrtl.mem Undefined {depth = 12 : i64, name = "MRead", portNames = ["read"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>

--- a/test/Dialect/FIRRTL/prefix-modules.mlir
+++ b/test/Dialect/FIRRTL/prefix-modules.mlir
@@ -217,8 +217,8 @@ firrtl.circuit "NLATop" {
       inclusive = true
     }]} {
 
-    // CHECK:  firrtl.instance test sym @test {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}, {circt.nonlocal = @nla_1, class = "circt.nonlocal"}]} @T_Aardvark()
-    firrtl.instance test  sym @test {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}, {circt.nonlocal = @nla_1, class = "circt.nonlocal"} ]}@Aardvark()
+    // CHECK:  firrtl.instance test sym @test @T_Aardvark()
+    firrtl.instance test  sym @test @Aardvark()
 
     // CHECK: firrtl.instance test2 @T_Z_Zebra()
     firrtl.instance test2 @Zebra()
@@ -232,9 +232,9 @@ firrtl.circuit "NLATop" {
       inclusive = false
     }]} {
 
-    // CHECK:  firrtl.instance test sym @test {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}]} @T_A_Z_Zebra()
-    firrtl.instance test sym @test {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}]}@Zebra()
-    firrtl.instance test1 sym @test_1 {annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}]}@Zebra()
+    // CHECK:  firrtl.instance test sym @test @T_A_Z_Zebra()
+    firrtl.instance test sym @test @Zebra()
+    firrtl.instance test1 sym @test_1 @Zebra()
   }
 
   // CHECK: firrtl.module @T_Z_Zebra
@@ -315,24 +315,24 @@ firrtl.circuit "GCTDataMemTapsPrefix" {
     // CHECK:       firrtl.nla @nla_4 [@X_Foo::@bar, @X_Bar::@baz, @X_Baz]
     // CHECK-LABEL: firrtl.module @FixNLA()
     firrtl.module @FixNLA() {
-      firrtl.instance foo sym @foo  {annotations = [{circt.nonlocal = @nla_2, class = "circt.nonlocal"}]} @Foo()
-      firrtl.instance bar sym @bar  {annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}, {circt.nonlocal = @nla_3, class = "circt.nonlocal"}]} @Bar()
-      // CHECK:   firrtl.instance foo sym @foo  {annotations = [{circt.nonlocal = @nla_2, class = "circt.nonlocal"}]} @X_Foo()
-      // CHECK:   firrtl.instance bar sym @bar  {annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}, {circt.nonlocal = @nla_3, class = "circt.nonlocal"}]} @Bar()
+      firrtl.instance foo sym @foo  @Foo()
+      firrtl.instance bar sym @bar  @Bar()
+      // CHECK:   firrtl.instance foo sym @foo @X_Foo()
+      // CHECK:   firrtl.instance bar sym @bar @Bar()
     }
     firrtl.module @Foo() attributes {annotations = [{class = "sifive.enterprise.firrtl.NestedPrefixModulesAnnotation", inclusive = true, prefix = "X_"}]} {
-      firrtl.instance bar sym @bar  {annotations = [{circt.nonlocal = @nla_2, class = "circt.nonlocal"}, {circt.nonlocal = @nla_4, class = "circt.nonlocal"}]} @Bar()
+      firrtl.instance bar sym @bar  @Bar()
     }
     // CHECK-LABEL:   firrtl.module @X_Foo()
-    // CHECK:         firrtl.instance bar sym @bar  {annotations = [{circt.nonlocal = @nla_2, class = "circt.nonlocal"}, {circt.nonlocal = @nla_4, class = "circt.nonlocal"}]} @X_Bar()
+    // CHECK:         firrtl.instance bar sym @bar @X_Bar()
 
     // CHECK-LABEL:   firrtl.module @Bar()
     firrtl.module @Bar() {
-      firrtl.instance baz sym @baz  {annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}, {circt.nonlocal = @nla_2, class = "circt.nonlocal"}, {circt.nonlocal = @nla_3, class = "circt.nonlocal"}, {circt.nonlocal = @nla_4, class = "circt.nonlocal"}]} @Baz()
-      // CHECK:     firrtl.instance baz sym @baz  {annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}, {circt.nonlocal = @nla_3, class = "circt.nonlocal"}]} @Baz()
+      firrtl.instance baz sym @baz @Baz()
+      // CHECK:     firrtl.instance baz sym @baz @Baz()
     }
     // CHECK-LABEL: firrtl.module @X_Bar()
-    // CHECK:       firrtl.instance baz sym @baz  {annotations = [{circt.nonlocal = @nla_2, class = "circt.nonlocal"}, {circt.nonlocal = @nla_4, class = "circt.nonlocal"}]} @X_Baz()
+    // CHECK:       firrtl.instance baz sym @baz @X_Baz()
 
     firrtl.module @Baz() attributes {annotations = [{circt.nonlocal = @nla_1, class = "nla_1"}, {circt.nonlocal = @nla_3, class = "nla_3"}, {circt.nonlocal = @nla_4, class = "nla_4"}]} {
       %mem_MPORT_en = firrtl.wire sym @s1  {annotations = [{circt.nonlocal = @nla_2, class = "nla_2"}]} : !firrtl.uint<1>
@@ -354,16 +354,16 @@ firrtl.circuit "Test"   {
   firrtl.nla @nla_2 [@Test::@foo2, @Foo2::@bar, @Bar]
 
   firrtl.module @Test() {
-    firrtl.instance foo1 sym @foo1 {annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}]} @Foo1()
-    firrtl.instance foo2 sym @foo2 {annotations = [{circt.nonlocal = @nla_2, class = "circt.nonlocal"}]} @Foo2()
+    firrtl.instance foo1 sym @foo1 @Foo1()
+    firrtl.instance foo2 sym @foo2 @Foo2()
   }
 
   firrtl.module @Foo1() attributes {annotations = [{class = "sifive.enterprise.firrtl.NestedPrefixModulesAnnotation", inclusive = true, prefix = "A_"}]} {
-    firrtl.instance bar sym @bar {annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}]} @Bar()
+    firrtl.instance bar sym @bar @Bar()
   }
 
   firrtl.module @Foo2() attributes {annotations = [{class = "sifive.enterprise.firrtl.NestedPrefixModulesAnnotation", inclusive = true, prefix = "B_"}]} {
-    firrtl.instance bar sym @bar {annotations = [{circt.nonlocal = @nla_2, class = "circt.nonlocal"}]} @Bar()
+    firrtl.instance bar sym @bar @Bar()
   }
 
   // CHECK: firrtl.memmodule @A_Bar() attributes {annotations = [{circt.nonlocal = @nla_1, class = "test1"}]


### PR DESCRIPTION
This commit removes the NLA breadcrumbs from the InstanceOps. This is part of the changes to port the passes to use NLATable analysis instead of depending on the circt.nonlocal annotations on the InstanceOps.