### PR TITLE
[CMake] Make version generation opt-in

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,13 @@ include_directories(${CIRCT_MAIN_INCLUDE_DIR})
 include_directories(${CIRCT_INCLUDE_DIR})
 
 # Set the release tag.
-option(CIRCT_RELEASE_TAG_ENABLED "Emit the release tag to output." ON)
+option(CIRCT_RELEASE_TAG_ENABLED "Emit the release tag to output." OFF)
+if (NOT CIRCT_RELEASE_TAG_ENABLED)
+  message(STATUS "Version generation is disabled. To enable the version "
+               "generation, please set CIRCT_RELEASE_TAG_ENABLED CMake "
+               "variable")
+endif()
+
 set(CIRCT_RELEASE_TAG "circtorg" CACHE STRING
     "Prefix of the release tag (e.g. circtorg, pycde and sifive).")
 

--- a/cmake/modules/GenVersionFile.cmake
+++ b/cmake/modules/GenVersionFile.cmake
@@ -7,7 +7,6 @@
 
 set(GIT_DESCRIBE_DEFAULT "unknown git version")
 if (DRY_RUN)
-  message(STATUS "Version generation is disabled.")
   set(GIT_DESCRIBE_OUTPUT "${GIT_DESCRIBE_DEFAULT}")
 else ()
   message(STATUS "Generating ${OUT_FILE} from ${IN_FILE} by `git describe --dirty --tags --match ${RELEASE_PATTERN}`")


### PR DESCRIPTION
This PR disables version generation by default since it creates unnecessary warnings in out-of-tree builds.  