### PR TITLE
[FIRRTL] Simplify NonLocalAnchor namepath printing

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -201,7 +201,7 @@ def NonLocalAnchor : FIRRTLOp<"nla",
   }];
   let arguments = (ins SymbolNameAttr:$sym_name, NameRefArrayAttr:$namepath);
   let results = (outs);
-  let assemblyFormat = [{ $sym_name $namepath attr-dict}];
+  let hasCustomAssemblyFormat = 1;
   let extraClassDeclaration = [{
     /// Drop the module from the namepath. If its a InnerNameRef, then drop
     /// the Module-Instance pair, else drop the final module from the namepath.

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
@@ -110,7 +110,7 @@ firrtl.circuit "Foo" attributes {annotations = [
         {class = "firrtl.transforms.BlackBox", circt.nonlocal = @nla_1}
     ]} {}
     // Non-local annotations should not produce errors either.
-    firrtl.nla  @nla_1 [#hw.innerNameRef<@Bar::@s1>, @Foo]
+    firrtl.nla  @nla_1 [@Bar::@s1, @Foo]
     firrtl.module @Bar() {
       firrtl.instance foo sym @s1 {annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}]} @Foo()
     }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1540,8 +1540,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   }
 
   // CHECK-LABEL: hw.module private @ForceNameSubmodule
-  firrtl.nla @nla_1 [#hw.innerNameRef<@ForceNameTop::@sym_foo>,@ForceNameSubmodule]
-  firrtl.nla @nla_2 [#hw.innerNameRef<@ForceNameTop::@sym_bar>,@ForceNameSubmodule]
+  firrtl.nla @nla_1 [@ForceNameTop::@sym_foo, @ForceNameSubmodule]
+  firrtl.nla @nla_2 [@ForceNameTop::@sym_bar, @ForceNameSubmodule]
   firrtl.module private @ForceNameSubmodule() attributes {annotations = [
     {circt.nonlocal = @nla_2,
      class = "chisel3.util.experimental.ForceNameAnnotation", name = "Bar"},

--- a/test/Dialect/FIRRTL/SFCTests/dedup-errors.fir
+++ b/test/Dialect/FIRRTL/SFCTests/dedup-errors.fir
@@ -61,7 +61,7 @@ circuit Top : %[[
   module Top :
     inst a1 of A
     inst a2 of A_
-  ; CHECK: firrtl.nla @[[nlaSym]] [#hw.innerNameRef<@Top::@[[a1Sym]]>, #hw.innerNameRef<@A::@[[bSym:[_a-zA-Z0-9]+]]>]
+  ; CHECK: firrtl.nla @[[nlaSym]] [@Top::@[[a1Sym]], @A::@[[bSym:[_a-zA-Z0-9]+]]]
   module A :
     output x: UInt<1>
     ; CHECk-NEXT: firrtl.wire sym @[[bSym]] {annotations = [{circt.nonlocal = @[[nlaSym]], class = "firrtl.transforms.DontTouchAnnotation"}]}
@@ -101,8 +101,8 @@ circuit Top : %[[
   module Top :
     inst a1 of A
     inst a2 of A_
-  ; CHECK: firrtl.nla @[[nlaSym1]] [#hw.innerNameRef<@Top::@[[a1Sym1]]>, #hw.innerNameRef<@A::@[[bSym:[_a-zA-Z0-9]+]]>]
-  ; CHECK: firrtl.nla @[[nlaSym2]] [#hw.innerNameRef<@Top::@[[a1Sym2]]>, #hw.innerNameRef<@A::@[[bSym]]>]
+  ; CHECK: firrtl.nla @[[nlaSym1]] [@Top::@[[a1Sym1]], @A::@[[bSym:[_a-zA-Z0-9]+]]]
+  ; CHECK: firrtl.nla @[[nlaSym2]] [@Top::@[[a1Sym2]], @A::@[[bSym]]]
   module A :
     output x: UInt<1>
     ; CHECk-NEXT: firrtl.wire sym @[[bSym]]

--- a/test/Dialect/FIRRTL/SFCTests/dedup.fir
+++ b/test/Dialect/FIRRTL/SFCTests/dedup.fir
@@ -319,7 +319,7 @@ circuit Top : %[[
     "target":"Top.A.b"
   }
 ]]
-  ; CHECK: firrtl.nla @[[nlaSym:[_a-zA-Z0-9]+]] [#hw.innerNameRef<@Top::@[[a1Sym:[_a-zA-Z0-9]+]]>, #hw.innerNameRef<@A::@[[bSym:[_a-zA-Z0-9]+]]>]
+  ; CHECK: firrtl.nla @[[nlaSym:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]]]
   ; CHECK: firrtl.module @Top
   ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] {annotations = [{circt.nonlocal = @[[nlaSym]], class = "circt.nonlocal"}]} @A(
   ; CHECK-NEXT: firrtl.instance a2 @A(
@@ -354,8 +354,8 @@ circuit Top : %[[
     "target":"~Top|A_>b"
   }
 ]]
-  ; CHECK: firrtl.nla @[[nlaSym1:[_a-zA-Z0-9]+]] [#hw.innerNameRef<@Top::@[[a1Sym:[_a-zA-Z0-9]+]]>, #hw.innerNameRef<@A::@[[bSym:[_a-zA-Z0-9]+]]>]
-  ; CHECK: firrtl.nla @[[nlaSym2:[_a-zA-Z0-9]+]] [#hw.innerNameRef<@Top::@[[a2Sym:[_a-zA-Z0-9]+]]>, #hw.innerNameRef<@A::@[[bSym]]>]
+  ; CHECK: firrtl.nla @[[nlaSym1:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]]]
+  ; CHECK: firrtl.nla @[[nlaSym2:[_a-zA-Z0-9]+]] [@Top::@[[a2Sym:[_a-zA-Z0-9]+]], @A::@[[bSym]]]
   ; CHECK: firrtl.module @Top
   ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] {annotations = [{circt.nonlocal = @[[nlaSym1]], class = "circt.nonlocal"}]} @A(
   ; CHECK-NEXT: firrtl.instance a2 sym @[[a2Sym]] {annotations = [{circt.nonlocal = @[[nlaSym2]], class = "circt.nonlocal"}]} @A(
@@ -450,10 +450,10 @@ circuit Top : %[[
     "target":"~Top|Top/a_:A_/b_:B_>bar"
   }
 ]]
-  ; CHECK: firrtl.nla @[[nla_4:[_a-zA-Z0-9]+]] [#hw.innerNameRef<@Top::@[[a_Sym:[_a-zA-Z0-9]+]]>, #hw.innerNameRef<@A::@[[bSym:[_a-zA-Z0-9]+]]>, #hw.innerNameRef<@B::@[[fooSym:[_a-zA-Z0-9]+]]>]
-  ; CHECK: firrtl.nla @[[nla_3:[_a-zA-Z0-9]+]] [#hw.innerNameRef<@Top::@[[a_Sym]]>, #hw.innerNameRef<@A::@[[bSym]]>, @B]
-  ; CHECK: firrtl.nla @[[nla_2:[_a-zA-Z0-9]+]] [#hw.innerNameRef<@Top::@[[aSym:[_a-zA-Z0-9]+]]>, #hw.innerNameRef<@A::@[[bSym]]>, #hw.innerNameRef<@B::@[[fooSym]]>]
-  ; CHECK: firrtl.nla @[[nla_1:[_a-zA-Z0-9]+]] [#hw.innerNameRef<@Top::@[[aSym]]>, #hw.innerNameRef<@A::@[[bSym]]>, @B]
+  ; CHECK: firrtl.nla @[[nla_4:[_a-zA-Z0-9]+]] [@Top::@[[a_Sym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]], @B::@[[fooSym:[_a-zA-Z0-9]+]]]
+  ; CHECK: firrtl.nla @[[nla_3:[_a-zA-Z0-9]+]] [@Top::@[[a_Sym]], @A::@[[bSym]], @B]
+  ; CHECK: firrtl.nla @[[nla_2:[_a-zA-Z0-9]+]] [@Top::@[[aSym:[_a-zA-Z0-9]+]], @A::@[[bSym]], @B::@[[fooSym]]]
+  ; CHECK: firrtl.nla @[[nla_1:[_a-zA-Z0-9]+]] [@Top::@[[aSym]], @A::@[[bSym]], @B]
   ; CHECK: firrtl.module @Top
   module Top :
     ; CHECK-NEXT: firrtl.instance a sym @[[aSym]] {{.+}} [{circt.nonlocal = @[[nla_1]], class = "circt.nonlocal"}, {circt.nonlocal = @[[nla_2]], class = "circt.nonlocal"}]} @A()
@@ -512,28 +512,28 @@ circuit Top : %[[
   }
 ]]
   ; CHECK:        firrtl.nla @[[nla_4:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:     [#hw.innerNameRef<@Top::@[[a_Sym:[_a-zA-Z0-9]+]]>,
-  ; CHECK-SAME:      #hw.innerNameRef<@A::@[[bSym:[_a-zA-Z0-9]+]]>,
-  ; CHECK-SAME:      #hw.innerNameRef<@B::@[[cSym:[_a-zA-Z0-9]+]]>,
-  ; CHECK-SAME:      #hw.innerNameRef<@C::@[[dSym:[_a-zA-Z0-9]+]]>,
-  ; CHECK-SAME:      #hw.innerNameRef<@D::@[[fooSym:[_a-zA-Z0-9]+]]>]
+  ; CHECK-SAME:     [@Top::@[[a_Sym:[_a-zA-Z0-9]+]],
+  ; CHECK-SAME:      @A::@[[bSym:[_a-zA-Z0-9]+]],
+  ; CHECK-SAME:      @B::@[[cSym:[_a-zA-Z0-9]+]],
+  ; CHECK-SAME:      @C::@[[dSym:[_a-zA-Z0-9]+]],
+  ; CHECK-SAME:      @D::@[[fooSym:[_a-zA-Z0-9]+]]]
   ; CHECK-NEXT:   firrtl.nla @[[nla_3:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:     [#hw.innerNameRef<@Top::@[[a_Sym]]>,
-  ; CHECK-SAME:      #hw.innerNameRef<@A::@[[bSym]]>,
-  ; CHECK-SAME:      #hw.innerNameRef<@B::@[[cSym]]>,
-  ; CHECK-SAME:      #hw.innerNameRef<@C::@[[dSym]]>,
+  ; CHECK-SAME:     [@Top::@[[a_Sym]],
+  ; CHECK-SAME:      @A::@[[bSym]],
+  ; CHECK-SAME:      @B::@[[cSym]],
+  ; CHECK-SAME:      @C::@[[dSym]],
   ; CHECK-SAME:      @D]
   ; CHECK-NEXT:   firrtl.nla @[[nla_2:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:     [#hw.innerNameRef<@Top::@[[aSym:[_a-zA-Z0-9]+]]>,
-  ; CHECK-SAME:      #hw.innerNameRef<@A::@[[bSym]]>,
-  ; CHECK-SAME:      #hw.innerNameRef<@B::@[[cSym]]>,
-  ; CHECK-SAME:      #hw.innerNameRef<@C::@[[dSym]]>,
-  ; CHECK-SAME:      #hw.innerNameRef<@D::@[[fooSym]]>]
+  ; CHECK-SAME:     [@Top::@[[aSym:[_a-zA-Z0-9]+]],
+  ; CHECK-SAME:      @A::@[[bSym]],
+  ; CHECK-SAME:      @B::@[[cSym]],
+  ; CHECK-SAME:      @C::@[[dSym]],
+  ; CHECK-SAME:      @D::@[[fooSym]]]
   ; CHECK-NEXT:   firrtl.nla @[[nla_1:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:     [#hw.innerNameRef<@Top::@[[aSym]]>,
-  ; CHECK-SAME:      #hw.innerNameRef<@A::@[[bSym]]>,
-  ; CHECK-SAME:      #hw.innerNameRef<@B::@[[cSym]]>,
-  ; CHECK-SAME:      #hw.innerNameRef<@C::@[[dSym]]>,
+  ; CHECK-SAME:     [@Top::@[[aSym]],
+  ; CHECK-SAME:      @A::@[[bSym]],
+  ; CHECK-SAME:      @B::@[[cSym]],
+  ; CHECK-SAME:      @C::@[[dSym]],
   ; CHECK-SAME:      @D]
   ; CHECK-NEXT:   firrtl.module @Top
   module Top :
@@ -657,54 +657,54 @@ circuit Top : %[[
   }
 ]]
   ; CHECK:        firrtl.nla @[[nla_12:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:     [#hw.innerNameRef<@Top::@[[Topa2Sym:[_a-zA-Z0-9]+]]>,
-  ; CHECK-SAME:      #hw.innerNameRef<@A::@[[AbSym:[_a-zA-Z0-9]+]]>,
-  ; CHECK-SAME:      #hw.innerNameRef<@B::@[[BcSym:[_a-zA-Z0-9]+]]>,
+  ; CHECK-SAME:     [@Top::@[[Topa2Sym:[_a-zA-Z0-9]+]],
+  ; CHECK-SAME:      @A::@[[AbSym:[_a-zA-Z0-9]+]],
+  ; CHECK-SAME:      @B::@[[BcSym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @C]
   ; CHECK:        firrtl.nla @[[nla_11:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:     [#hw.innerNameRef<@Top::@[[Topa1Sym:[_a-zA-Z0-9]+]]>,
-  ; CHECK-SAME:      #hw.innerNameRef<@A::@[[AbSym]]>,
-  ; CHECK-SAME:      #hw.innerNameRef<@B::@[[BcSym]]>,
+  ; CHECK-SAME:     [@Top::@[[Topa1Sym:[_a-zA-Z0-9]+]],
+  ; CHECK-SAME:      @A::@[[AbSym]],
+  ; CHECK-SAME:      @B::@[[BcSym]],
   ; CHECK-SAME:      @C]
   ; CHECK:        firrtl.nla @[[nla_10:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:     [#hw.innerNameRef<@Top::@[[Topa2Sym]]>,
-  ; CHECK-SAME:      #hw.innerNameRef<@A::@[[Ab_Sym:[_a-zA-Z0-9]+]]>,
-  ; CHECK-SAME:      #hw.innerNameRef<@B::@[[BcSym]]>,
+  ; CHECK-SAME:     [@Top::@[[Topa2Sym]],
+  ; CHECK-SAME:      @A::@[[Ab_Sym:[_a-zA-Z0-9]+]],
+  ; CHECK-SAME:      @B::@[[BcSym]],
   ; CHECK-SAME:      @C]
   ; CHECK:        firrtl.nla @[[nla_9:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:     [#hw.innerNameRef<@Top::@[[Topa1Sym]]>,
-  ; CHECK-SAME:      #hw.innerNameRef<@A::@[[Ab_Sym]]>,
-  ; CHECK-SAME:      #hw.innerNameRef<@B::@[[BcSym]]>,
+  ; CHECK-SAME:     [@Top::@[[Topa1Sym]],
+  ; CHECK-SAME:      @A::@[[Ab_Sym]],
+  ; CHECK-SAME:      @B::@[[BcSym]],
   ; CHECK-SAME:      @C]
   ; CHECK:        firrtl.nla @[[nla_8:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:     [#hw.innerNameRef<@Top::@[[Topb_Sym:[_a-zA-Z0-9]+]]>,
-  ; CHECK-SAME:      #hw.innerNameRef<@B::@[[BcSym]]>,
+  ; CHECK-SAME:     [@Top::@[[Topb_Sym:[_a-zA-Z0-9]+]],
+  ; CHECK-SAME:      @B::@[[BcSym]],
   ; CHECK-SAME:      @C]
   ; CHECK:        firrtl.nla @[[nla_7:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:     [#hw.innerNameRef<@Top::@[[TopbSym:[_a-zA-Z0-9]+]]>,
-  ; CHECK-SAME:      #hw.innerNameRef<@B::@[[BcSym]]>,
+  ; CHECK-SAME:     [@Top::@[[TopbSym:[_a-zA-Z0-9]+]],
+  ; CHECK-SAME:      @B::@[[BcSym]],
   ; CHECK-SAME:      @C]
   ; CHECK:        firrtl.nla @[[nla_6:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:     [#hw.innerNameRef<@Top::@[[Topa2Sym]]>,
-  ; CHECK-SAME:      #hw.innerNameRef<@A::@[[AbSym]]>,
+  ; CHECK-SAME:     [@Top::@[[Topa2Sym]],
+  ; CHECK-SAME:      @A::@[[AbSym]],
   ; CHECK-SAME:      @B]
   ; CHECK:        firrtl.nla @[[nla_5:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:     [#hw.innerNameRef<@Top::@[[Topa1Sym]]>,
-  ; CHECK-SAME:      #hw.innerNameRef<@A::@[[AbSym]]>,
+  ; CHECK-SAME:     [@Top::@[[Topa1Sym]],
+  ; CHECK-SAME:      @A::@[[AbSym]],
   ; CHECK-SAME:      @B]
   ; CHECK:        firrtl.nla @[[nla_4:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:     [#hw.innerNameRef<@Top::@[[Topa2Sym]]>,
-  ; CHECK-SAME:      #hw.innerNameRef<@A::@[[Ab_Sym]]>,
+  ; CHECK-SAME:     [@Top::@[[Topa2Sym]],
+  ; CHECK-SAME:      @A::@[[Ab_Sym]],
   ; CHECK-SAME:      @B]
   ; CHECK:        firrtl.nla @[[nla_3:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:     [#hw.innerNameRef<@Top::@[[Topa1Sym]]>,
-  ; CHECK-SAME:      #hw.innerNameRef<@A::@[[Ab_Sym]]>,
+  ; CHECK-SAME:     [@Top::@[[Topa1Sym]],
+  ; CHECK-SAME:      @A::@[[Ab_Sym]],
   ; CHECK-SAME:      @B]
   ; CHECK:        firrtl.nla @[[nla_2:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:     [#hw.innerNameRef<@Top::@[[Topb_Sym]]>,
+  ; CHECK-SAME:     [@Top::@[[Topb_Sym]],
   ; CHECK-SAME:      @B]
   ; CHECK:        firrtl.nla @[[nla_1:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:     [#hw.innerNameRef<@Top::@[[TopbSym]]>,
+  ; CHECK-SAME:     [@Top::@[[TopbSym]],
   ; CHECK-SAME:      @B]
   ; CHECK-NEXT:   firrtl.module @Top
   module Top :
@@ -802,11 +802,11 @@ circuit top : %[[
   }
 ]]
   ; CHECK:      firrtl.nla @[[nla_1:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:   [#hw.innerNameRef<@top::@[[topaSym:[_a-zA-Z0-9]+]]>,
-  ; CHECK-SAME:    #hw.innerNameRef<@a::@[[aiSym:[_a-zA-Z0-9]+]]>
+  ; CHECK-SAME:   [@top::@[[topaSym:[_a-zA-Z0-9]+]],
+  ; CHECK-SAME:    @a::@[[aiSym:[_a-zA-Z0-9]+]]
   ; CHECK:      firrtl.nla @[[nla_2:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:   [#hw.innerNameRef<@top::@[[topbSym:[_a-zA-Z0-9]+]]>,
-  ; CHECK-SAME:    #hw.innerNameRef<@a::@[[aiSym]]>
+  ; CHECK-SAME:   [@top::@[[topbSym:[_a-zA-Z0-9]+]],
+  ; CHECK-SAME:    @a::@[[aiSym]]
   ; CHECK: firrtl.module @top
   module top:
     input ia: {z: {y: {x: UInt<1>}}, a: UInt<1>}

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -77,7 +77,7 @@ circuit Foo: %[[
   module Foo:
     inst bar of Bar
     ; CHECK-LABEL: firrtl.circuit "Foo"
-    ; CHECK: firrtl.nla  @nla_1 [#hw.innerNameRef<@Foo::@bar>, @Bar]
+    ; CHECK: firrtl.nla  @nla_1 [@Foo::@bar, @Bar]
     ; CHECK: firrtl.module private @Bar
     ; CHECK-SAME annotations = [{c = "c"}]
     ; CHECK: firrtl.module @Foo
@@ -106,8 +106,8 @@ circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar.a"},
     inst bar of Bar
 
     ; CHECK-LABEL: firrtl.circuit "Foo"
-    ; CHECK: firrtl.nla @nla_2 [#hw.innerNameRef<@Foo::@bar>, #hw.innerNameRef<@Bar::@d>]
-    ; CHECK: firrtl.nla @nla_1 [#hw.innerNameRef<@Foo::@bar>, #hw.innerNameRef<@Bar::@b>]
+    ; CHECK: firrtl.nla @nla_2 [@Foo::@bar, @Bar::@d]
+    ; CHECK: firrtl.nla @nla_1 [@Foo::@bar, @Bar::@b]
     ; CHECK: firrtl.module private @Bar
     ; CHECK-SAME: sym @b [#firrtl.subAnno<fieldID = 2, {circt.nonlocal = @nla_1, three}>]
     ; CHECK-NEXT:  %d = firrtl.wire sym @d
@@ -408,7 +408,7 @@ circuit Test : %[[
     inst Test of Example
 
 ; CHECK-LABEL:  firrtl.circuit "Test"
-; CHECK: firrtl.nla @nla_1 [#hw.innerNameRef<@Test::@Test>, @Example]
+; CHECK: firrtl.nla @nla_1 [@Test::@Test, @Example]
 ; CHECK: firrtl.module private @Example() attributes {
 ; CHECK-SAME: annotations = [{circt.nonlocal = @nla_1, class = "fake"}]
 ; CHECK: firrtl.module @Test()
@@ -427,8 +427,8 @@ circuit Foo: %[[{"a":"a","target":"~Foo|Foo/bar:Bar/baz:Baz"}, {"b":"b","target"
   module Foo :
     inst bar of Bar
 ; CHECK-LABEL: firrtl.circuit "Foo"
-; CHECK: firrtl.nla @nla_2 [#hw.innerNameRef<@Foo::@bar>, #hw.innerNameRef<@Bar::@baz>, @Baz]
-; CHECK: firrtl.nla @nla_1 [#hw.innerNameRef<@Foo::@bar>, #hw.innerNameRef<@Bar::@baz>, @Baz]
+; CHECK: firrtl.nla @nla_2 [@Foo::@bar, @Bar::@baz, @Baz]
+; CHECK: firrtl.nla @nla_1 [@Foo::@bar, @Bar::@baz, @Baz]
 ; CHECK: firrtl.module private @Baz
 ; CHECK-SAME: annotations = [{a = "a", circt.nonlocal = @nla_1}, {b = "b", circt.nonlocal = @nla_2}]
 ; CHECK: firrtl.module private @Bar()
@@ -586,7 +586,7 @@ circuit memportAnno: %[[
       write-latency => 1
       read-under-write => undefined
 ; CHECK-LABEL: firrtl.circuit "memportAnno"  {
-; CHECK:        firrtl.nla @nla_1 [#hw.innerNameRef<@memportAnno::@foo>, #hw.innerNameRef<@Foo::@memory>]
+; CHECK:        firrtl.nla @nla_1 [@memportAnno::@foo, @Foo::@memory]
 ; CHECK:        %memory_w = firrtl.mem sym @memory Undefined  {depth = 16 : i64, name = "memory", portAnnotations
 ; CHECK-SAME:   [{circt.nonlocal = @nla_1, class = "test"}]
 

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -20,9 +20,9 @@ firrtl.circuit "Aggregates" attributes {rawAnnotations = [
 // A non-local annotation should work.
 
 // CHECK-LABEL: firrtl.circuit "FooNL"
-// CHECK: firrtl.nla @nla_1 [#hw.innerNameRef<@FooNL::@baz>, #hw.innerNameRef<@BazNL::@bar>, @BarNL]
-// CHECK: firrtl.nla @nla_0 [#hw.innerNameRef<@FooNL::@baz>, #hw.innerNameRef<@BazNL::@bar>, #hw.innerNameRef<@BarNL::@w>]
-// CHECK: firrtl.nla @nla [#hw.innerNameRef<@FooNL::@baz>, #hw.innerNameRef<@BazNL::@bar>, #hw.innerNameRef<@BarNL::@w2>]
+// CHECK: firrtl.nla @nla_1 [@FooNL::@baz, @BazNL::@bar, @BarNL]
+// CHECK: firrtl.nla @nla_0 [@FooNL::@baz, @BazNL::@bar, @BarNL::@w]
+// CHECK: firrtl.nla @nla [@FooNL::@baz, @BazNL::@bar, @BarNL::@w2]
 // CHECK: firrtl.module @BarNL
 // CHECK: %w = firrtl.wire sym @w {annotations = [{circt.nonlocal = @nla_0, class = "circt.test", nl = "nl"}]}
 // CHECK: %w2 = firrtl.wire sym @w2 {annotations = [{circt.fieldID = 5 : i32, circt.nonlocal = @nla, class = "circt.test", nl = "nl2"}]} : !firrtl.bundle<a: uint, b: vector<uint, 4>>
@@ -57,7 +57,7 @@ firrtl.circuit "FooNL"  attributes {rawAnnotations = [
 // Non-local annotations on memory ports should work.
 
 // CHECK-LABEL: firrtl.circuit "MemPortsNL"
-// CHECK: firrtl.nla @nla [#hw.innerNameRef<@MemPortsNL::@child>, #hw.innerNameRef<@Child::@bar>]
+// CHECK: firrtl.nla @nla [@MemPortsNL::@child, @Child::@bar]
 // CHECK: firrtl.module @Child()
 // CHECK:   %bar_r = firrtl.mem sym @bar
 // CHECK-SAME: portAnnotations = {{\[}}[{circt.nonlocal = @nla, class = "circt.test", nl = "nl"}]]
@@ -105,7 +105,7 @@ firrtl.circuit "Test" attributes {rawAnnotations = [
 firrtl.circuit "Test" attributes {rawAnnotations = [
   {class = "circt.test", target = "~Test|Test>exttest"}
   ]} {
-  // CHECK: firrtl.nla @nla [#hw.innerNameRef<@Test::@exttest>, @ExtTest]
+  // CHECK: firrtl.nla @nla [@Test::@exttest, @ExtTest]
   // CHECK: firrtl.extmodule @ExtTest() attributes {annotations = [{circt.nonlocal = @nla, class = "circt.test"}]}
   firrtl.extmodule @ExtTest()
 
@@ -121,7 +121,7 @@ firrtl.circuit "Test" attributes {rawAnnotations = [
 firrtl.circuit "Test" attributes {rawAnnotations = [
   {class = "circt.test", target = "~Test|Test>exttest.in"}
   ]} {
-  // CHECK: firrtl.nla @nla [#hw.innerNameRef<@Test::@exttest>, #hw.innerNameRef<@ExtTest::@in>]
+  // CHECK: firrtl.nla @nla [@Test::@exttest, @ExtTest::@in]
   // CHECK: firrtl.extmodule @ExtTest(in in: !firrtl.uint<1> sym @in [{circt.nonlocal = @nla, class = "circt.test"}])
   firrtl.extmodule @ExtTest(in in: !firrtl.uint<1>)
 
@@ -372,7 +372,7 @@ firrtl.circuit "GCTDataTap" attributes {rawAnnotations = [{
 }
 
 // CHECK-LABEL: firrtl.circuit "GCTDataTap"
-// CHECK:      firrtl.nla [[NLA:@.+]] [#hw.innerNameRef<@GCTDataTap::@im>, #hw.innerNameRef<@InnerMod::@w>]
+// CHECK:      firrtl.nla [[NLA:@.+]] [@GCTDataTap::@im, @InnerMod::@w]
 
 // CHECK-LABEL: firrtl.extmodule private @DataTap
 

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -82,14 +82,14 @@ firrtl.circuit "PrimOps" {
 
 // CHECK-LABEL: firrtl.circuit "Annotations"
 firrtl.circuit "Annotations" {
-  // CHECK: firrtl.nla [[NLA3:@nla.*]] [#hw.innerNameRef<@Annotations::@annotations1>, @Annotations0]
-  // CHECK: firrtl.nla [[NLA2:@nla.*]] [#hw.innerNameRef<@Annotations::@annotations0>, #hw.innerNameRef<@Annotations0::@e>]
-  // CHECK: firrtl.nla [[NLA1:@nla.*]] [#hw.innerNameRef<@Annotations::@annotations0>, #hw.innerNameRef<@Annotations0::@c>]
-  // CHECK: firrtl.nla [[NLA0:@nla.*]] [#hw.innerNameRef<@Annotations::@annotations1>, #hw.innerNameRef<@Annotations0::@b>]
-  // CHECK: firrtl.nla @annos_nla0 [#hw.innerNameRef<@Annotations::@annotations0>, #hw.innerNameRef<@Annotations0::@d>]
-  // CHECK: firrtl.nla @annos_nla1 [#hw.innerNameRef<@Annotations::@annotations1>, #hw.innerNameRef<@Annotations0::@d>]
-  firrtl.nla @annos_nla0 [#hw.innerNameRef<@Annotations::@annotations0>, #hw.innerNameRef<@Annotations0::@d>]
-  firrtl.nla @annos_nla1 [#hw.innerNameRef<@Annotations::@annotations1>, #hw.innerNameRef<@Annotations1::@i>]
+  // CHECK: firrtl.nla [[NLA3:@nla.*]] [@Annotations::@annotations1, @Annotations0]
+  // CHECK: firrtl.nla [[NLA2:@nla.*]] [@Annotations::@annotations0, @Annotations0::@e]
+  // CHECK: firrtl.nla [[NLA1:@nla.*]] [@Annotations::@annotations0, @Annotations0::@c]
+  // CHECK: firrtl.nla [[NLA0:@nla.*]] [@Annotations::@annotations1, @Annotations0::@b]
+  // CHECK: firrtl.nla @annos_nla0 [@Annotations::@annotations0, @Annotations0::@d]
+  // CHECK: firrtl.nla @annos_nla1 [@Annotations::@annotations1, @Annotations0::@d]
+  firrtl.nla @annos_nla0 [@Annotations::@annotations0, @Annotations0::@d]
+  firrtl.nla @annos_nla1 [@Annotations::@annotations1, @Annotations1::@i]
 
   // CHECK: firrtl.module @Annotations0() attributes {annotations = [{circt.nonlocal = [[NLA3]], class = "one"}]}
   firrtl.module @Annotations0() {
@@ -132,10 +132,10 @@ firrtl.circuit "Annotations" {
 // Check that module and memory port annotations are merged correctly.
 // CHECK-LABEL: firrtl.circuit "PortAnnotations"
 firrtl.circuit "PortAnnotations" {
-  // CHECK: firrtl.nla [[NLA3:@nla.*]] [#hw.innerNameRef<@PortAnnotations::@portannos0>, #hw.innerNameRef<@PortAnnotations0::@a>]
-  // CHECK: firrtl.nla [[NLA2:@nla.*]] [#hw.innerNameRef<@PortAnnotations::@portannos1>, #hw.innerNameRef<@PortAnnotations0::@a>]
-  // CHECK: firrtl.nla [[NLA1:@nla.*]] [#hw.innerNameRef<@PortAnnotations::@portannos0>, #hw.innerNameRef<@PortAnnotations0::@bar>]
-  // CHECK: firrtl.nla [[NLA0:@nla.*]] [#hw.innerNameRef<@PortAnnotations::@portannos1>, #hw.innerNameRef<@PortAnnotations0::@bar>]
+  // CHECK: firrtl.nla [[NLA3:@nla.*]] [@PortAnnotations::@portannos0, @PortAnnotations0::@a]
+  // CHECK: firrtl.nla [[NLA2:@nla.*]] [@PortAnnotations::@portannos1, @PortAnnotations0::@a]
+  // CHECK: firrtl.nla [[NLA1:@nla.*]] [@PortAnnotations::@portannos0, @PortAnnotations0::@bar]
+  // CHECK: firrtl.nla [[NLA0:@nla.*]] [@PortAnnotations::@portannos1, @PortAnnotations0::@bar]
   // CHECK: firrtl.module @PortAnnotations0(in %a: !firrtl.uint<1> sym @a [
   // CHECK-SAME: {circt.nonlocal = [[NLA2]], class = "port1"},
   // CHECK-SAME: {circt.nonlocal = [[NLA3]], class = "port0"}]) {
@@ -165,14 +165,14 @@ firrtl.circuit "PortAnnotations" {
 // ones.
 // CHECK-LABEL: firrtl.circuit "Breadcrumb"
 firrtl.circuit "Breadcrumb" {
-  // CHECK:  @breadcrumb_nla0 [#hw.innerNameRef<@Breadcrumb::@breadcrumb0>, #hw.innerNameRef<@Breadcrumb0::@crumb0>, #hw.innerNameRef<@Crumb::@in>]
-  firrtl.nla @breadcrumb_nla0 [#hw.innerNameRef<@Breadcrumb::@breadcrumb0>, #hw.innerNameRef<@Breadcrumb0::@crumb0>, #hw.innerNameRef<@Crumb::@in>]
-  // CHECK:  @breadcrumb_nla1 [#hw.innerNameRef<@Breadcrumb::@breadcrumb1>, #hw.innerNameRef<@Breadcrumb0::@crumb0>, #hw.innerNameRef<@Crumb::@in>]
-  firrtl.nla @breadcrumb_nla1 [#hw.innerNameRef<@Breadcrumb::@breadcrumb1>, #hw.innerNameRef<@Breadcrumb1::@crumb1>, #hw.innerNameRef<@Crumb::@in>]
-  // CHECK:  @breadcrumb_nla2 [#hw.innerNameRef<@Breadcrumb::@breadcrumb0>, #hw.innerNameRef<@Breadcrumb0::@crumb0>, #hw.innerNameRef<@Crumb::@w>]
-  firrtl.nla @breadcrumb_nla2 [#hw.innerNameRef<@Breadcrumb::@breadcrumb0>, #hw.innerNameRef<@Breadcrumb0::@crumb0>, #hw.innerNameRef<@Crumb::@w>]
-  // CHECK:  @breadcrumb_nla3 [#hw.innerNameRef<@Breadcrumb::@breadcrumb1>, #hw.innerNameRef<@Breadcrumb0::@crumb0>, #hw.innerNameRef<@Crumb::@w>]
-  firrtl.nla @breadcrumb_nla3 [#hw.innerNameRef<@Breadcrumb::@breadcrumb1>, #hw.innerNameRef<@Breadcrumb1::@crumb1>, #hw.innerNameRef<@Crumb::@w>]
+  // CHECK:  @breadcrumb_nla0 [@Breadcrumb::@breadcrumb0, @Breadcrumb0::@crumb0, @Crumb::@in]
+  firrtl.nla @breadcrumb_nla0 [@Breadcrumb::@breadcrumb0, @Breadcrumb0::@crumb0, @Crumb::@in]
+  // CHECK:  @breadcrumb_nla1 [@Breadcrumb::@breadcrumb1, @Breadcrumb0::@crumb0, @Crumb::@in]
+  firrtl.nla @breadcrumb_nla1 [@Breadcrumb::@breadcrumb1, @Breadcrumb1::@crumb1, @Crumb::@in]
+  // CHECK:  @breadcrumb_nla2 [@Breadcrumb::@breadcrumb0, @Breadcrumb0::@crumb0, @Crumb::@w]
+  firrtl.nla @breadcrumb_nla2 [@Breadcrumb::@breadcrumb0, @Breadcrumb0::@crumb0, @Crumb::@w]
+  // CHECK:  @breadcrumb_nla3 [@Breadcrumb::@breadcrumb1, @Breadcrumb0::@crumb0, @Crumb::@w]
+  firrtl.nla @breadcrumb_nla3 [@Breadcrumb::@breadcrumb1, @Breadcrumb1::@crumb1, @Crumb::@w]
   firrtl.module @Crumb(in %in: !firrtl.uint<1> sym @in [
       {circt.nonlocal = @breadcrumb_nla0, class = "port0"},
       {circt.nonlocal = @breadcrumb_nla1, class = "port1"}]) {
@@ -221,18 +221,18 @@ firrtl.circuit "Breadcrumb" {
 // and the annotation should be cloned for each parent of the root module.
 // CHECK-LABEL: firrtl.circuit "Context"
 firrtl.circuit "Context" {
-  // CHECK: firrtl.nla [[NLA3:@nla.*]] [#hw.innerNameRef<@Context::@context1>, #hw.innerNameRef<@Context0::@c0>, #hw.innerNameRef<@ContextLeaf::@w>]
-  // CHECK: firrtl.nla [[NLA1:@nla.*]] [#hw.innerNameRef<@Context::@context1>, #hw.innerNameRef<@Context0::@c0>, #hw.innerNameRef<@ContextLeaf::@in>]
-  // CHECK: firrtl.nla [[NLA2:@nla.*]] [#hw.innerNameRef<@Context::@context0>, #hw.innerNameRef<@Context0::@c0>, #hw.innerNameRef<@ContextLeaf::@w>]
-  // CHECK: firrtl.nla [[NLA0:@nla.*]] [#hw.innerNameRef<@Context::@context0>, #hw.innerNameRef<@Context0::@c0>, #hw.innerNameRef<@ContextLeaf::@in>]
+  // CHECK: firrtl.nla [[NLA3:@nla.*]] [@Context::@context1, @Context0::@c0, @ContextLeaf::@w]
+  // CHECK: firrtl.nla [[NLA1:@nla.*]] [@Context::@context1, @Context0::@c0, @ContextLeaf::@in]
+  // CHECK: firrtl.nla [[NLA2:@nla.*]] [@Context::@context0, @Context0::@c0, @ContextLeaf::@w]
+  // CHECK: firrtl.nla [[NLA0:@nla.*]] [@Context::@context0, @Context0::@c0, @ContextLeaf::@in]
   // CHECK-NOT: @context_nla0
   // CHECK-NOT: @context_nla1
   // CHECK-NOT: @context_nla2
   // CHECK-NOT: @context_nla3
-  firrtl.nla @context_nla0 [#hw.innerNameRef<@Context0::@c0>, #hw.innerNameRef<@ContextLeaf::@in>]
-  firrtl.nla @context_nla1 [#hw.innerNameRef<@Context0::@c0>, #hw.innerNameRef<@ContextLeaf::@w>]
-  firrtl.nla @context_nla2 [#hw.innerNameRef<@Context1::@c1>, #hw.innerNameRef<@ContextLeaf::@in>]
-  firrtl.nla @context_nla3 [#hw.innerNameRef<@Context1::@c1>, #hw.innerNameRef<@ContextLeaf::@w>]
+  firrtl.nla @context_nla0 [@Context0::@c0, @ContextLeaf::@in]
+  firrtl.nla @context_nla1 [@Context0::@c0, @ContextLeaf::@w]
+  firrtl.nla @context_nla2 [@Context1::@c1, @ContextLeaf::@in]
+  firrtl.nla @context_nla3 [@Context1::@c1, @ContextLeaf::@w]
 
   // CHECK: firrtl.module @ContextLeaf(in %in: !firrtl.uint<1> sym @in [
   // CHECK-SAME: {circt.nonlocal = [[NLA0]], class = "port0"},
@@ -283,8 +283,8 @@ firrtl.circuit "Context" {
 // External modules should dedup and fixup any NLAs.
 // CHECK: firrtl.circuit "ExtModuleTest"
 firrtl.circuit "ExtModuleTest" {
-  // CHECK: firrtl.nla @ext_nla [#hw.innerNameRef<@ExtModuleTest::@e1>, @ExtMod0]
-  firrtl.nla @ext_nla [#hw.innerNameRef<@ExtModuleTest::@e1>, @ExtMod1]
+  // CHECK: firrtl.nla @ext_nla [@ExtModuleTest::@e1, @ExtMod0]
+  firrtl.nla @ext_nla [@ExtModuleTest::@e1, @ExtMod1]
   // CHECK: firrtl.extmodule @ExtMod0() attributes {annotations = [{circt.nonlocal = @ext_nla}], defname = "a"}
   firrtl.extmodule @ExtMod0() attributes {defname = "a"}
   // CHECK-NOT: firrtl.extmodule @ExtMod1()
@@ -301,8 +301,8 @@ firrtl.circuit "ExtModuleTest" {
 // https://github.com/llvm/circt/issues/2713
 // CHECK-LABEL: firrtl.circuit "Foo"
 firrtl.circuit "Foo"  {
-  // CHECK: firrtl.nla @nla_1 [#hw.innerNameRef<@Foo::@b>, #hw.innerNameRef<@A::@a>]
-  firrtl.nla @nla_1 [#hw.innerNameRef<@Foo::@b>, #hw.innerNameRef<@B::@b>]
+  // CHECK: firrtl.nla @nla_1 [@Foo::@b, @A::@a]
+  firrtl.nla @nla_1 [@Foo::@b, @B::@b]
   // CHECK: firrtl.extmodule @A(out a: !firrtl.clock sym @a [{circt.nonlocal = @nla_1}])
   firrtl.extmodule @A(out a: !firrtl.clock)
   firrtl.extmodule @B(out b: !firrtl.clock sym @b [{circt.nonlocal = @nla_1}])
@@ -333,8 +333,8 @@ firrtl.circuit "Foo"  {
 // As we dedup modules, the chain on NLAs should continuously grow.
 // CHECK-LABEL: firrtl.circuit "Chain"
 firrtl.circuit "Chain" {
-  // CHECK: firrtl.nla [[NLA0:@nla.*]] [#hw.innerNameRef<@Chain::@chainB1>, #hw.innerNameRef<@ChainB0::@chainA0>, #hw.innerNameRef<@ChainA0::@extchain0>, @ExtChain0]
-  // CHECK: firrtl.nla [[NLA1:@nla.*]] [#hw.innerNameRef<@Chain::@chainB0>, #hw.innerNameRef<@ChainB0::@chainA0>, #hw.innerNameRef<@ChainA0::@extchain0>, @ExtChain0]
+  // CHECK: firrtl.nla [[NLA0:@nla.*]] [@Chain::@chainB1, @ChainB0::@chainA0, @ChainA0::@extchain0, @ExtChain0]
+  // CHECK: firrtl.nla [[NLA1:@nla.*]] [@Chain::@chainB0, @ChainB0::@chainA0, @ChainA0::@extchain0, @ExtChain0]
   // CHECK: firrtl.module @ChainB0()
   firrtl.module @ChainB0() {
     // CHECK: {annotations = [{circt.nonlocal = [[NLA1]], class = "circt.nonlocal"}, {circt.nonlocal = [[NLA0]], class = "circt.nonlocal"}]}

--- a/test/Dialect/FIRRTL/emit-omir.mlir
+++ b/test/Dialect/FIRRTL/emit-omir.mlir
@@ -202,7 +202,7 @@ firrtl.circuit "NonLocalTrackers" attributes {annotations = [{
     OMReferenceTarget1 = {info = #loc, index = 1, id = "OMID:1", value = {omir.tracker, id = 0, type = "OMReferenceTarget"}}
   }}]
 }]} {
-  firrtl.nla @nla_0 [#hw.innerNameRef<@NonLocalTrackers::@b>, #hw.innerNameRef<@B::@a>, @A]
+  firrtl.nla @nla_0 [@NonLocalTrackers::@b, @B::@a, @A]
   firrtl.module @A() attributes {annotations = [{circt.nonlocal = @nla_0, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 0}]} {}
   firrtl.module @B() {
     firrtl.instance a sym @a {annotations = [{circt.nonlocal = @nla_0, class = "circt.nonlocal"}]} @A()
@@ -347,7 +347,7 @@ firrtl.circuit "SRAMPathsWithNLA" attributes {annotations = [{
     }
   ]
 }]} {
-  firrtl.nla @nla [#hw.innerNameRef<@SRAMPathsWithNLA::@s1>, #hw.innerNameRef<@Submodule::@m1>]
+  firrtl.nla @nla [@SRAMPathsWithNLA::@s1, @Submodule::@m1]
   firrtl.module @Submodule() {
     %mem2_port = firrtl.mem sym @m1 Undefined {annotations = [{circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 1}], depth = 8, name = "mem2", portNames = ["port"], readLatency = 0 : i32, writeLatency = 1 : i32 } : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<42>>
   }
@@ -391,7 +391,7 @@ firrtl.circuit "SRAMPathsWithNLA" attributes {annotations = [{
     }
   ]
 }]} {
-  firrtl.nla @nla [#hw.innerNameRef<@SRAMPaths::@sub>, @Submodule]
+  firrtl.nla @nla [@SRAMPaths::@sub, @Submodule]
   firrtl.extmodule @MySRAM()
   firrtl.module @Submodule() {
     firrtl.instance mem1 {annotations = [{circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 0}]} @MySRAM()
@@ -647,9 +647,9 @@ firrtl.circuit "AddPortsRelative" attributes {annotations = [{
 
 firrtl.circuit "FixPath"  attributes 
 {annotations = [{class = "freechips.rocketchip.objectmodel.OMIRAnnotation", nodes = [{fields = {d = {index = 3 : i64, info = loc(unknown), value = {id = 3 : i64, omir.tracker, path = "~FixPath|D", type = "OMMemberInstanceTarget"}}, dutInstance = {index = 0 : i64, info = loc(unknown), value = {id = 0 : i64, omir.tracker, path = "~FixPath|FixPath/c:C", type = "OMMemberInstanceTarget"}}, power = {index = 2 : i64, info = loc(unknown), value = {id = 2 : i64, omir.tracker, path = "~FixPath|FixPath/c:C/cd:D", type = "OMMemberInstanceTarget"}}, pwm = {index = 1 : i64, info = loc(unknown), value = {id = 1 : i64, omir.tracker, path = "~FixPath|FixPath/c:C>in", type = "OMMemberInstanceTarget"}}}, id = "OMID:0", info = loc(unknown)}]}]} {
-  firrtl.nla @nla_3 [#hw.innerNameRef<@FixPath::@c>, #hw.innerNameRef<@C::@cd>, @D]
-  firrtl.nla @nla_2 [#hw.innerNameRef<@FixPath::@c>, #hw.innerNameRef<@C::@in>]
-  firrtl.nla @nla_1 [#hw.innerNameRef<@FixPath::@c>, @C]
+  firrtl.nla @nla_3 [@FixPath::@c, @C::@cd, @D]
+  firrtl.nla @nla_2 [@FixPath::@c, @C::@in]
+  firrtl.nla @nla_1 [@FixPath::@c, @C]
   firrtl.module @C(in %in: !firrtl.uint<1> sym @in [{circt.nonlocal = @nla_2, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 1 : i64}]) attributes {annotations = [{circt.nonlocal = @nla_1, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 0 : i64}, {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
     firrtl.instance cd sym @cd  {annotations = [{circt.nonlocal = @nla_3, class = "circt.nonlocal"}]} @D()
   }

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -660,11 +660,19 @@ firrtl.circuit "BitCast4" {
 
 // -----
 
+firrtl.circuit "NLAWithNestedReference" {
+firrtl.module @NLAWithNestedReference() { }
+// expected-error @below {{only one nested reference is allowed}}
+firrtl.nla @nla [@A::@B::@C]
+}
+
+// -----
+
 
 firrtl.circuit "LowerToBind" {
  // expected-error @+1 {{the instance path cannot be empty/single element}}
 firrtl.nla @NLA1 []
-firrtl.nla @NLA2 [#hw.innerNameRef<@LowerToBind::@s1>]
+firrtl.nla @NLA2 [@LowerToBind::@s1]
 firrtl.module @InstanceLowerToBind() {}
 firrtl.module @LowerToBind() {
   firrtl.instance foo sym @s1 {lowerToBind = true, annotations = [{circt.nonlocal = @NLA2, class = "circt.test", nl = "nl"}]} @InstanceLowerToBind() 
@@ -676,8 +684,8 @@ firrtl.module @LowerToBind() {
 firrtl.circuit "NLATop" {
 
  // expected-error @+1 {{the instance path can only contain inner sym reference, only the leaf can refer to a module symbol}}
-  firrtl.nla @nla [#hw.innerNameRef<@NLATop::@test>, @Aardvark, @Zebra]
-  firrtl.nla @nla_1 [#hw.innerNameRef<@NLATop::@test>,#hw.innerNameRef<@Aardvark::@test_1>, @Zebra]
+  firrtl.nla @nla [@NLATop::@test, @Aardvark, @Zebra]
+  firrtl.nla @nla_1 [@NLATop::@test,@Aardvark::@test_1, @Zebra]
   firrtl.module @NLATop() {
     firrtl.instance test  sym @test {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}, {circt.nonlocal = @nla_1, class = "circt.nonlocal"} ]}@Aardvark()
     firrtl.instance test2 @Zebra()
@@ -696,8 +704,8 @@ firrtl.circuit "NLATop" {
 
 firrtl.circuit "NLATop1" {
   // expected-error @+1 {{instance path is incorrect. Expected module: "Aardvark" instead found: "Zebra"}}
-  firrtl.nla @nla [#hw.innerNameRef<@NLATop1::@test>, #hw.innerNameRef<@Zebra::@test>,#hw.innerNameRef<@Aardvark::@test>]
-  firrtl.nla @nla_1 [#hw.innerNameRef<@NLATop1::@test>,#hw.innerNameRef<@Aardvark::@test_1>, @Zebra]
+  firrtl.nla @nla [@NLATop1::@test, @Zebra::@test,@Aardvark::@test]
+  firrtl.nla @nla_1 [@NLATop1::@test,@Aardvark::@test_1, @Zebra]
   firrtl.module @NLATop1() {
     firrtl.instance test  sym @test {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}, {circt.nonlocal = @nla_1, class = "circt.nonlocal"} ]}@Aardvark()
     firrtl.instance test2 @Zebra()
@@ -722,8 +730,8 @@ firrtl.circuit "NLATop1" {
 // This should not error out. Note that there is no symbol on the %bundle. This handles a special case, when the nonlocal is applied to a subfield.
 firrtl.circuit "fallBackName" {
 
-  firrtl.nla @nla [#hw.innerNameRef<@fallBackName::@test>, #hw.innerNameRef<@Aardvark::@test>, #hw.innerNameRef<@Zebra::@bundle>]
-  firrtl.nla @nla_1 [#hw.innerNameRef<@fallBackName::@test>,#hw.innerNameRef<@Aardvark::@test_1>, @Zebra]
+  firrtl.nla @nla [@fallBackName::@test, @Aardvark::@test, @Zebra::@bundle]
+  firrtl.nla @nla_1 [@fallBackName::@test,@Aardvark::@test_1, @Zebra]
   firrtl.module @fallBackName() {
     firrtl.instance test  sym @test {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}, {circt.nonlocal = @nla_1, class = "circt.nonlocal"} ]}@Aardvark()
     firrtl.instance test2 @Zebra()
@@ -743,7 +751,7 @@ firrtl.circuit "fallBackName" {
 
 firrtl.circuit "Foo"   {
   // expected-error @+1 {{operation with symbol: #hw.innerNameRef<@Bar::@b> was not found}}
-  firrtl.nla @nla_1 [#hw.innerNameRef<@Foo::@bar>, #hw.innerNameRef<@Bar::@b>]
+  firrtl.nla @nla_1 [@Foo::@bar, @Bar::@b]
   firrtl.module @Bar(in %a: !firrtl.uint<1>, out %b: !firrtl.bundle<baz: uint<1>, qux: uint<1>> [#firrtl.subAnno<fieldID = 2, {circt.nonlocal = @nla_1, three}>], out %c: !firrtl.uint<1>) {
   }
   firrtl.module @Foo() {
@@ -755,9 +763,9 @@ firrtl.circuit "Foo"   {
 
 firrtl.circuit "Top"   {
  // Legal nla would be:
-//firrtl.nla @nla [#hw.innerNameRef<@Top::@mid>, #hw.innerNameRef<@Mid::@leaf>, #hw.innerNameRef<@Leaf::@w>]
+//firrtl.nla @nla [@Top::@mid, @Mid::@leaf, @Leaf::@w]
   // expected-error @+1 {{instance path is incorrect. Expected module: "Middle" instead found: "Leaf"}}
-  firrtl.nla @nla [#hw.innerNameRef<@Top::@mid>, #hw.innerNameRef<@Leaf::@w>]
+  firrtl.nla @nla [@Top::@mid, @Leaf::@w]
   firrtl.module @Leaf() {
     %w = firrtl.wire sym @w  {annotations = [{circt.nonlocal = @nla, class = "fake1"}]} : !firrtl.uint<3>
   }

--- a/test/Dialect/FIRRTL/extract-instances.mlir
+++ b/test/Dialect/FIRRTL/extract-instances.mlir
@@ -65,22 +65,12 @@ firrtl.circuit "ExtractBlackBoxesSimple" attributes {annotations = [{class = "fi
 
 // CHECK: firrtl.circuit "ExtractBlackBoxesSimple2"
 firrtl.circuit "ExtractBlackBoxesSimple2" attributes {annotations = [{class = "firrtl.transforms.BlackBoxTargetDirAnno", targetDir = "BlackBoxes"}]} {
-  // CHECK: firrtl.nla @nla_1 [#hw.innerNameRef<@ExtractBlackBoxesSimple2::@bb>, @MyBlackBox]
+  // CHECK: firrtl.nla @nla_1 [@ExtractBlackBoxesSimple2::@bb, @MyBlackBox]
   // CHECK-NOT: firrtl.nla @nla_2
   // CHECK-NOT: firrtl.nla @nla_3
-  firrtl.nla @nla_1 [
-    #hw.innerNameRef<@BBWrapper::@bb>,
-    @MyBlackBox
-  ]
-  firrtl.nla @nla_2 [
-    #hw.innerNameRef<@DUTModule::@mod>,
-    #hw.innerNameRef<@BBWrapper::@bb>
-  ]
-  firrtl.nla @nla_3 [
-    #hw.innerNameRef<@ExtractBlackBoxesSimple2::@dut>,
-    #hw.innerNameRef<@DUTModule::@mod>,
-    #hw.innerNameRef<@BBWrapper::@bb>
-  ]
+  firrtl.nla @nla_1 [@BBWrapper::@bb, @MyBlackBox]
+  firrtl.nla @nla_2 [@DUTModule::@mod, @BBWrapper::@bb]
+  firrtl.nla @nla_3 [@ExtractBlackBoxesSimple2::@dut, @DUTModule::@mod, @BBWrapper::@bb]
   // Annotation on the extmodule itself
   // CHECK-LABEL: firrtl.extmodule private @MyBlackBox
   firrtl.extmodule private @MyBlackBox(in in: !firrtl.uint<8>, out out: !firrtl.uint<8>) attributes {annotations = [
@@ -157,9 +147,9 @@ firrtl.circuit "ExtractBlackBoxesSimple2" attributes {annotations = [{class = "f
   // CHECK-SAME: output_file = #hw.output_file<"BlackBoxes.txt", excludeFromFileList>
   // CHECK-SAME: symbols = [
   // CHECK-SAME: @DUTModule
-  // CHECK-SAME: #hw.innerNameRef<@DUTModule::[[WRAPPER_SYM]]>
-  // CHECK-SAME: #hw.innerNameRef<@ExtractBlackBoxesSimple2::[[BB2_SYM]]>
-  // CHECK-SAME: #hw.innerNameRef<@ExtractBlackBoxesSimple2::[[BB_SYM]]>
+  // CHECK-SAME: @DUTModule::[[WRAPPER_SYM]]
+  // CHECK-SAME: @ExtractBlackBoxesSimple2::[[BB2_SYM]]
+  // CHECK-SAME: @ExtractBlackBoxesSimple2::[[BB_SYM]]
   // CHECK-SAME: ]
 }
 
@@ -170,28 +160,28 @@ firrtl.circuit "ExtractBlackBoxesSimple2" attributes {annotations = [{class = "f
 // CHECK: firrtl.circuit "ExtractBlackBoxesIntoDUTSubmodule"
 firrtl.circuit "ExtractBlackBoxesIntoDUTSubmodule"  {
   // CHECK-LABEL: firrtl.nla @nla_1 [
-  // CHECK-SAME:    #hw.innerNameRef<@ExtractBlackBoxesIntoDUTSubmodule::@tb>
-  // CHECK-SAME:    #hw.innerNameRef<@TestHarness::@dut>
-  // CHECK-SAME:    #hw.innerNameRef<@DUTModule::@BlackBoxes>
-  // CHECK-SAME:    #hw.innerNameRef<@BlackBoxes::@bb1>
+  // CHECK-SAME:    @ExtractBlackBoxesIntoDUTSubmodule::@tb
+  // CHECK-SAME:    @TestHarness::@dut
+  // CHECK-SAME:    @DUTModule::@BlackBoxes
+  // CHECK-SAME:    @BlackBoxes::@bb1
   // CHECK-SAME:  ]
   firrtl.nla @nla_1 [
-    #hw.innerNameRef<@ExtractBlackBoxesIntoDUTSubmodule::@tb>,
-    #hw.innerNameRef<@TestHarness::@dut>,
-    #hw.innerNameRef<@DUTModule::@mod>,
-    #hw.innerNameRef<@BBWrapper::@bb1>
+    @ExtractBlackBoxesIntoDUTSubmodule::@tb,
+    @TestHarness::@dut,
+    @DUTModule::@mod,
+    @BBWrapper::@bb1
   ]
   // CHECK-LABEL: firrtl.nla @nla_2 [
-  // CHECK-SAME:    #hw.innerNameRef<@ExtractBlackBoxesIntoDUTSubmodule::@tb>
-  // CHECK-SAME:    #hw.innerNameRef<@TestHarness::@dut>
-  // CHECK-SAME:    #hw.innerNameRef<@DUTModule::@BlackBoxes>
-  // CHECK-SAME:    #hw.innerNameRef<@BlackBoxes::@bb2>
+  // CHECK-SAME:    @ExtractBlackBoxesIntoDUTSubmodule::@tb
+  // CHECK-SAME:    @TestHarness::@dut
+  // CHECK-SAME:    @DUTModule::@BlackBoxes
+  // CHECK-SAME:    @BlackBoxes::@bb2
   // CHECK-SAME:  ]
   firrtl.nla @nla_2 [
-    #hw.innerNameRef<@ExtractBlackBoxesIntoDUTSubmodule::@tb>,
-    #hw.innerNameRef<@TestHarness::@dut>,
-    #hw.innerNameRef<@DUTModule::@mod>,
-    #hw.innerNameRef<@BBWrapper::@bb2>
+    @ExtractBlackBoxesIntoDUTSubmodule::@tb,
+    @TestHarness::@dut,
+    @DUTModule::@mod,
+    @BBWrapper::@bb2
   ]
   firrtl.extmodule private @MyBlackBox(in in: !firrtl.uint<8>, out out: !firrtl.uint<8>) attributes {annotations = [{class = "sifive.enterprise.firrtl.ExtractBlackBoxAnnotation", dest = "BlackBoxes", filename = "BlackBoxes.txt", prefix = "bb"}], defname = "MyBlackBox"}
   firrtl.module private @BBWrapper(in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>) {
@@ -247,9 +237,9 @@ firrtl.circuit "ExtractBlackBoxesIntoDUTSubmodule"  {
   // CHECK-SAME: output_file = #hw.output_file<"BlackBoxes.txt", excludeFromFileList>
   // CHECK-SAME: symbols = [
   // CHECK-SAME: @DUTModule
-  // CHECK-SAME: #hw.innerNameRef<@DUTModule::[[WRAPPER_SYM]]>
-  // CHECK-SAME: #hw.innerNameRef<@BlackBoxes::[[BB2_SYM]]>
-  // CHECK-SAME: #hw.innerNameRef<@BlackBoxes::[[BB1_SYM]]>
+  // CHECK-SAME: @DUTModule::[[WRAPPER_SYM]]
+  // CHECK-SAME: @BlackBoxes::[[BB2_SYM]]
+  // CHECK-SAME: @BlackBoxes::[[BB1_SYM]]
   // CHECK-SAME: ]
 }
 
@@ -277,7 +267,7 @@ firrtl.circuit "ExtractClockGatesSimple" attributes {annotations = [{class = "si
   // CHECK-SAME: output_file = #hw.output_file<"ClockGates.txt", excludeFromFileList>
   // CHECK-SAME: symbols = [
   // CHECK-SAME: @DUTModule
-  // CHECK-SAME: #hw.innerNameRef<@ExtractClockGatesSimple::[[CKG_SYM]]>
+  // CHECK-SAME: @ExtractClockGatesSimple::[[CKG_SYM]]
   // CHECK-SAME: ]
 }
 
@@ -356,9 +346,9 @@ firrtl.circuit "ExtractClockGatesMixed" attributes {annotations = [{class = "sif
   // CHECK-SAME: output_file = #hw.output_file<"ClockGates.txt", excludeFromFileList>
   // CHECK-SAME: symbols = [
   // CHECK-SAME: @DUTModule
-  // CHECK-SAME: #hw.innerNameRef<@DUTModule::@inst>
-  // CHECK-SAME: #hw.innerNameRef<@ExtractClockGatesMixed::@ckg1>
-  // CHECK-SAME: #hw.innerNameRef<@ExtractClockGatesMixed::@ckg2>
+  // CHECK-SAME: @DUTModule::@inst
+  // CHECK-SAME: @ExtractClockGatesMixed::@ckg1
+  // CHECK-SAME: @ExtractClockGatesMixed::@ckg2
   // CHECK-SAME: ]
 }
 
@@ -392,14 +382,14 @@ firrtl.circuit "ExtractClockGatesComposed" attributes {annotations = [
   // CHECK-SAME: output_file = #hw.output_file<"ClockGates.txt", excludeFromFileList>
   // CHECK-SAME: symbols = [
   // CHECK-SAME: @DUTModule
-  // CHECK-SAME: #hw.innerNameRef<@ExtractClockGatesComposed::[[CKG_SYM]]>
+  // CHECK-SAME: @ExtractClockGatesComposed::[[CKG_SYM]]
   // CHECK-SAME: ]
   // CHECK: sv.verbatim "
   // CHECK-SAME{LITERAL}: mem_wiring_0 -> {{0}}.{{1}}\0A
   // CHECK-SAME: output_file = #hw.output_file<"SeqMems.txt", excludeFromFileList>
   // CHECK-SAME: symbols = [
   // CHECK-SAME: @DUTModule
-  // CHECK-SAME: #hw.innerNameRef<@ExtractClockGatesComposed::[[MEM_SYM]]>
+  // CHECK-SAME: @ExtractClockGatesComposed::[[MEM_SYM]]
   // CHECK-SAME: ]
 }
 
@@ -431,8 +421,8 @@ firrtl.circuit "ExtractSeqMemsSimple2" attributes {annotations = [{class = "sifi
   // CHECK-SAME: output_file = #hw.output_file<"SeqMems.txt", excludeFromFileList>
   // CHECK-SAME: symbols = [
   // CHECK-SAME: @DUTModule
-  // CHECK-SAME: #hw.innerNameRef<@DUTModule::[[MEM_SYM]]>
-  // CHECK-SAME: #hw.innerNameRef<@ExtractSeqMemsSimple2::[[MEM_EXT_SYM]]>
+  // CHECK-SAME: @DUTModule::[[MEM_SYM]]
+  // CHECK-SAME: @ExtractSeqMemsSimple2::[[MEM_EXT_SYM]]
   // CHECK-SAME: ]
 }
 
@@ -446,14 +436,14 @@ firrtl.circuit "InstSymConflict" {
   // CHECK-NOT: firrtl.nla @nla_1
   // CHECK-NOT: firrtl.nla @nla_2
   firrtl.nla @nla_1 [
-    #hw.innerNameRef<@InstSymConflict::@dut>,
-    #hw.innerNameRef<@DUTModule::@mod1>,
-    #hw.innerNameRef<@BBWrapper::@bb>
+    @InstSymConflict::@dut,
+    @DUTModule::@mod1,
+    @BBWrapper::@bb
   ]
   firrtl.nla @nla_2 [
-    #hw.innerNameRef<@InstSymConflict::@dut>,
-    #hw.innerNameRef<@DUTModule::@mod2>,
-    #hw.innerNameRef<@BBWrapper::@bb>
+    @InstSymConflict::@dut,
+    @DUTModule::@mod2,
+    @BBWrapper::@bb
   ]
   firrtl.extmodule private @MyBlackBox(in in: !firrtl.uint<8>, out out: !firrtl.uint<8>) attributes {defname = "MyBlackBox"}
   firrtl.module private @BBWrapper(in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>) {

--- a/test/Dialect/FIRRTL/grand-central-taps.mlir
+++ b/test/Dialect/FIRRTL/grand-central-taps.mlir
@@ -333,9 +333,9 @@ firrtl.circuit "NLAGarbageCollection" {
   // CHECK-NOT: @nla_1
   // CHECK-NOT: @nla_2
   // CHECK-NOT: @nla_3
-  firrtl.nla @nla_1 [#hw.innerNameRef<@NLAGarbageCollection::@dut>, #hw.innerNameRef<@DUT::@submodule>, #hw.innerNameRef<@Submodule::@foo>]
-  firrtl.nla @nla_2 [#hw.innerNameRef<@NLAGarbageCollection::@dut>, #hw.innerNameRef<@DUT::@submodule>, #hw.innerNameRef<@Submodule::@port>]
-  firrtl.nla @nla_3 [#hw.innerNameRef<@NLAGarbageCollection::@dut>, #hw.innerNameRef<@DUT::@submodule>, #hw.innerNameRef<@Submodule::@bar_0>]
+  firrtl.nla @nla_1 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule::@foo]
+  firrtl.nla @nla_2 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule::@port]
+  firrtl.nla @nla_3 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule::@bar_0]
   firrtl.module @Submodule(
     in %port: !firrtl.uint<1> sym @port [
       {circt.nonlocal = @nla_2,
@@ -419,8 +419,8 @@ firrtl.circuit "NLAGarbageCollection" {
 firrtl.circuit "NLAUsedInWiring"  {
   // CHECK-NOT: @nla_1
   // CHECK-NOT: @nla_2
-  firrtl.nla @nla_1 [#hw.innerNameRef<@NLAUsedInWiring::@foo>, #hw.innerNameRef<@Foo::@f>]
-  firrtl.nla @nla_2 [#hw.innerNameRef<@NLAUsedInWiring::@foo>, #hw.innerNameRef<@Foo::@g>]
+  firrtl.nla @nla_1 [@NLAUsedInWiring::@foo, @Foo::@f]
+  firrtl.nla @nla_2 [@NLAUsedInWiring::@foo, @Foo::@g]
 
   // CHECK-LABEL: firrtl.module @DataTap
   // CHECK-NEXT: [[TMP:%.+]] = firrtl.verbatim.expr
@@ -495,8 +495,8 @@ firrtl.circuit "NLAUsedInWiring"  {
 // See https://github.com/llvm/circt/issues/2767.
 
 firrtl.circuit "Top" {
-  firrtl.nla @nla_0 [#hw.innerNameRef<@DUT::@submodule_1>, #hw.innerNameRef<@Submodule::@bar_0>]
-  firrtl.nla @nla [#hw.innerNameRef<@DUT::@submodule_2>, #hw.innerNameRef<@Submodule::@bar_0>]
+  firrtl.nla @nla_0 [@DUT::@submodule_1, @Submodule::@bar_0]
+  firrtl.nla @nla [@DUT::@submodule_2, @Submodule::@bar_0]
   firrtl.module @Submodule(in %clock: !firrtl.clock, out %out: !firrtl.uint<1>) {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -958,8 +958,8 @@ firrtl.circuit "DedupedPath" attributes {
         id = 2 : i64}],
      id = 0 : i64,
      name = "View"}]} {
-  firrtl.nla @nla_0 [#hw.innerNameRef<@DUT::@tile1>, #hw.innerNameRef<@Tile::@w>]
-  firrtl.nla @nla [#hw.innerNameRef<@DUT::@tile2>, #hw.innerNameRef<@Tile::@w>]
+  firrtl.nla @nla_0 [@DUT::@tile1, @Tile::@w]
+  firrtl.nla @nla [@DUT::@tile2, @Tile::@w]
   firrtl.module @Tile() {
     %w = firrtl.wire sym @w {
       annotations = [

--- a/test/Dialect/FIRRTL/inject-dut-hierarchy.mlir
+++ b/test/Dialect/FIRRTL/inject-dut-hierarchy.mlir
@@ -28,25 +28,25 @@ firrtl.circuit "NLARenaming" attributes {
   } {
   // An NLA that is rooted at the DUT moves to the wrapper.
   //
-  // CHECK:      firrtl.nla @nla_DUTRoot [#hw.innerNameRef<@Foo::@sub>, #hw.innerNameRef<@Sub::@a>]
-  firrtl.nla @nla_DUTRoot [#hw.innerNameRef<@DUT::@sub>, #hw.innerNameRef<@Sub::@a>]
+  // CHECK:      firrtl.nla @nla_DUTRoot [@Foo::@sub, @Sub::@a]
+  firrtl.nla @nla_DUTRoot [@DUT::@sub, @Sub::@a]
 
   // NLAs that end at the DUT or a DUT port are unmodified.
   //
-  // CHECK-NEXT: firrtl.nla @nla_DUTLeafModule [#hw.innerNameRef<@NLARenaming::@dut>, @DUT]
-  // CHECK-NEXT: firrtl.nla @nla_DUTLeafPort [#hw.innerNameRef<@NLARenaming::@dut>, #hw.innerNameRef<@DUT::@in>]
-  firrtl.nla @nla_DUTLeafModule [#hw.innerNameRef<@NLARenaming::@dut>, @DUT]
-  firrtl.nla @nla_DUTLeafPort [#hw.innerNameRef<@NLARenaming::@dut>, #hw.innerNameRef<@DUT::@in>]
+  // CHECK-NEXT: firrtl.nla @nla_DUTLeafModule [@NLARenaming::@dut, @DUT]
+  // CHECK-NEXT: firrtl.nla @nla_DUTLeafPort [@NLARenaming::@dut, @DUT::@in]
+  firrtl.nla @nla_DUTLeafModule [@NLARenaming::@dut, @DUT]
+  firrtl.nla @nla_DUTLeafPort [@NLARenaming::@dut, @DUT::@in]
 
   // NLAs that end inside the DUT get an extra level of hierarchy.
   //
-  // CHECK-NEXT: firrtl.nla @nla_DUTLeafWire [#hw.innerNameRef<@NLARenaming::@dut>, #hw.innerNameRef<@DUT::@[[inst_sym:.+]]>, #hw.innerNameRef<@Foo::@w>]
-  firrtl.nla @nla_DUTLeafWire [#hw.innerNameRef<@NLARenaming::@dut>, #hw.innerNameRef<@DUT::@w>]
+  // CHECK-NEXT: firrtl.nla @nla_DUTLeafWire [@NLARenaming::@dut, @DUT::@[[inst_sym:.+]], @Foo::@w]
+  firrtl.nla @nla_DUTLeafWire [@NLARenaming::@dut, @DUT::@w]
 
   // An NLA that passes through the DUT gets an extra level of hierarchy.
   //
-  // CHECK-NEXT: firrtl.nla @nla_DUTPassthrough [#hw.innerNameRef<@NLARenaming::@dut>, #hw.innerNameRef<@DUT::@[[inst_sym:.+]]>, #hw.innerNameRef<@Foo::@sub>, @Sub]
-  firrtl.nla @nla_DUTPassthrough [#hw.innerNameRef<@NLARenaming::@dut>, #hw.innerNameRef<@DUT::@sub>, @Sub]
+  // CHECK-NEXT: firrtl.nla @nla_DUTPassthrough [@NLARenaming::@dut, @DUT::@[[inst_sym:.+]], @Foo::@sub, @Sub]
+  firrtl.nla @nla_DUTPassthrough [@NLARenaming::@dut, @DUT::@sub, @Sub]
   firrtl.module private @Sub() attributes {annotations = [{circt.nonlocal = @nla_DUTPassthrough, class = "nla_DUTPassthrough"}]} {
     %a = firrtl.wire sym @a : !firrtl.uint<1>
   }

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -300,17 +300,17 @@ sv.verbatim "hello"
 //
 // CHECK-LABEL: firrtl.circuit "NLAInlining"
 firrtl.circuit "NLAInlining" {
-  // CHECK-NEXT: firrtl.nla @nla1 [#hw.innerNameRef<@NLAInlining::@bar>, @Bar]
-  // CHECK-NEXT: firrtl.nla @nla2 [#hw.innerNameRef<@NLAInlining::@bar>, #hw.innerNameRef<@Bar::@a>]
-  // CHECK-NEXT: firrtl.nla @nla3 [#hw.innerNameRef<@NLAInlining::@bar>, #hw.innerNameRef<@Bar::@port>]
+  // CHECK-NEXT: firrtl.nla @nla1 [@NLAInlining::@bar, @Bar]
+  // CHECK-NEXT: firrtl.nla @nla2 [@NLAInlining::@bar, @Bar::@a]
+  // CHECK-NEXT: firrtl.nla @nla3 [@NLAInlining::@bar, @Bar::@port]
   // CHECK-NOT:  firrtl.nla @nla4
   // CHECK-NOT:  firrtl.nla @nla5
-  firrtl.nla @nla1 [#hw.innerNameRef<@NLAInlining::@foo>, #hw.innerNameRef<@Foo::@bar>, @Bar]
-  firrtl.nla @nla2 [#hw.innerNameRef<@NLAInlining::@foo>, #hw.innerNameRef<@Foo::@bar>, #hw.innerNameRef<@Bar::@a>]
-  firrtl.nla @nla3 [#hw.innerNameRef<@NLAInlining::@foo>, #hw.innerNameRef<@Foo::@bar>, #hw.innerNameRef<@Bar::@port>]
-  firrtl.nla @nla4 [#hw.innerNameRef<@NLAInlining::@foo>, @Foo]
-  firrtl.nla @nla5 [#hw.innerNameRef<@NLAInlining::@foo>, #hw.innerNameRef<@Foo::@b>]
-  firrtl.nla @nla6 [#hw.innerNameRef<@NLAInlining::@foo>, #hw.innerNameRef<@Foo::@port>]
+  firrtl.nla @nla1 [@NLAInlining::@foo, @Foo::@bar, @Bar]
+  firrtl.nla @nla2 [@NLAInlining::@foo, @Foo::@bar, @Bar::@a]
+  firrtl.nla @nla3 [@NLAInlining::@foo, @Foo::@bar, @Bar::@port]
+  firrtl.nla @nla4 [@NLAInlining::@foo, @Foo]
+  firrtl.nla @nla5 [@NLAInlining::@foo, @Foo::@b]
+  firrtl.nla @nla6 [@NLAInlining::@foo, @Foo::@port]
   // CHECK-NEXT: firrtl.module private @Bar
   // CHECK-SAME: %port: {{.+}} sym @port [{circt.nonlocal = @nla3, class = "nla3"}]
   // CHECK-SAME: [{circt.nonlocal = @nla1, class = "nla1"}]
@@ -354,12 +354,12 @@ firrtl.circuit "NLAInlining" {
 //
 // CHECK-LABEL: firrtl.circuit "NLAInliningNotMainRoot"
 firrtl.circuit "NLAInliningNotMainRoot" {
-  // CHECK-NEXT: firrtl.nla @nla1 [#hw.innerNameRef<@NLAInliningNotMainRoot::@baz>, #hw.innerNameRef<@Baz::@a>]
-  // CHECK-NEXT: firrtl.nla @nla1_0 [#hw.innerNameRef<@Foo::@baz>, #hw.innerNameRef<@Baz::@a>]
-  // CHECK-NEXT: firrtl.nla @nla2 [#hw.innerNameRef<@NLAInliningNotMainRoot::@baz>, #hw.innerNameRef<@Baz::@port>]
-  // CHECK-NEXT: firrtl.nla @nla2_0 [#hw.innerNameRef<@Foo::@baz>, #hw.innerNameRef<@Baz::@port>]
-  firrtl.nla @nla1 [#hw.innerNameRef<@Bar::@baz>, #hw.innerNameRef<@Baz::@a>]
-  firrtl.nla @nla2 [#hw.innerNameRef<@Bar::@baz>, #hw.innerNameRef<@Baz::@port>]
+  // CHECK-NEXT: firrtl.nla @nla1 [@NLAInliningNotMainRoot::@baz, @Baz::@a]
+  // CHECK-NEXT: firrtl.nla @nla1_0 [@Foo::@baz, @Baz::@a]
+  // CHECK-NEXT: firrtl.nla @nla2 [@NLAInliningNotMainRoot::@baz, @Baz::@port]
+  // CHECK-NEXT: firrtl.nla @nla2_0 [@Foo::@baz, @Baz::@port]
+  firrtl.nla @nla1 [@Bar::@baz, @Baz::@a]
+  firrtl.nla @nla2 [@Bar::@baz, @Baz::@port]
   // CHECK: firrtl.module private @Baz
   // CHECK-SAME: %port: {{.+}} [{circt.nonlocal = @nla2, class = "nla2"}, {circt.nonlocal = @nla2_0, class = "nla2"}]
   firrtl.module private @Baz(
@@ -399,14 +399,14 @@ firrtl.circuit "NLAInliningNotMainRoot" {
 //
 // CHECK-LABEL: firrtl.circuit "NLAFlattening"
 firrtl.circuit "NLAFlattening" {
-  // CHECK-NEXT: firrtl.nla @nla1 [#hw.innerNameRef<@NLAFlattening::@foo>, #hw.innerNameRef<@Foo::@a>]
-  // CHECK-NEXT: firrtl.nla @nla2 [#hw.innerNameRef<@NLAFlattening::@foo>, #hw.innerNameRef<@Foo::@port>]
+  // CHECK-NEXT: firrtl.nla @nla1 [@NLAFlattening::@foo, @Foo::@a]
+  // CHECK-NEXT: firrtl.nla @nla2 [@NLAFlattening::@foo, @Foo::@port]
   // CHECK-NOT:  firrtl.nla @nla3
   // CHECK-NOT:  firrtl.nla @nla4
-  firrtl.nla @nla1 [#hw.innerNameRef<@NLAFlattening::@foo>, #hw.innerNameRef<@Foo::@bar>, #hw.innerNameRef<@Bar::@baz>, #hw.innerNameRef<@Baz::@a>]
-  firrtl.nla @nla2 [#hw.innerNameRef<@NLAFlattening::@foo>, #hw.innerNameRef<@Foo::@bar>, #hw.innerNameRef<@Bar::@baz>, #hw.innerNameRef<@Baz::@port>]
-  firrtl.nla @nla3 [#hw.innerNameRef<@NLAFlattening::@foo>, #hw.innerNameRef<@Foo::@bar>, #hw.innerNameRef<@Bar::@baz>, @Baz]
-  firrtl.nla @nla4 [#hw.innerNameRef<@Foo::@bar>, #hw.innerNameRef<@Bar::@b>]
+  firrtl.nla @nla1 [@NLAFlattening::@foo, @Foo::@bar, @Bar::@baz, @Baz::@a]
+  firrtl.nla @nla2 [@NLAFlattening::@foo, @Foo::@bar, @Bar::@baz, @Baz::@port]
+  firrtl.nla @nla3 [@NLAFlattening::@foo, @Foo::@bar, @Bar::@baz, @Baz]
+  firrtl.nla @nla4 [@Foo::@bar, @Bar::@b]
   firrtl.module @Baz(
     in %port: !firrtl.uint<1> sym @port [{circt.nonlocal = @nla2, class = "nla2"}]
   ) attributes {annotations = [{circt.nonlocal = @nla3, class = "nla3"}]} {
@@ -455,12 +455,12 @@ firrtl.circuit "NLAFlattening" {
 firrtl.circuit "NLAFlatteningChildRoot" {
   // CHECK-NOT:  firrtl.nla @nla1
   // CHECK-NOT:  firrtl.nla @nla2
-  // CHECK-NEXT: firrtl.nla @nla3 [#hw.innerNameRef<@Baz::@quz>, #hw.innerNameRef<@Quz::@b>]
-  // CHECK-NEXT: firrtl.nla @nla4 [#hw.innerNameRef<@Baz::@quz>, #hw.innerNameRef<@Quz::@Quz_port>]
-  firrtl.nla @nla1 [#hw.innerNameRef<@Bar::@qux>, #hw.innerNameRef<@Qux::@a>]
-  firrtl.nla @nla2 [#hw.innerNameRef<@Bar::@qux>, #hw.innerNameRef<@Qux::@Qux_port>]
-  firrtl.nla @nla3 [#hw.innerNameRef<@Baz::@quz>, #hw.innerNameRef<@Quz::@b>]
-  firrtl.nla @nla4 [#hw.innerNameRef<@Baz::@quz>, #hw.innerNameRef<@Quz::@Quz_port>]
+  // CHECK-NEXT: firrtl.nla @nla3 [@Baz::@quz, @Quz::@b]
+  // CHECK-NEXT: firrtl.nla @nla4 [@Baz::@quz, @Quz::@Quz_port]
+  firrtl.nla @nla1 [@Bar::@qux, @Qux::@a]
+  firrtl.nla @nla2 [@Bar::@qux, @Qux::@Qux_port]
+  firrtl.nla @nla3 [@Baz::@quz, @Quz::@b]
+  firrtl.nla @nla4 [@Baz::@quz, @Quz::@Quz_port]
   // CHECK: firrtl.module private @Quz
   // CHECK-SAME: in %port: {{.+}} [{circt.nonlocal = @nla4, class = "nla4"}]
   firrtl.module private @Quz(
@@ -510,8 +510,8 @@ firrtl.circuit "NLAFlatteningChildRoot" {
 //
 // CHECK-LABEL: CollidingSymbols
 firrtl.circuit "CollidingSymbols" {
-  // CHECK-NEXT: firrtl.nla @nla1 [#hw.innerNameRef<@CollidingSymbols::@[[FoobarSym:[_a-zA-Z0-9]+]]>, @Bar]
-  firrtl.nla @nla1 [#hw.innerNameRef<@CollidingSymbols::@foo>, #hw.innerNameRef<@Foo::@bar>, @Bar]
+  // CHECK-NEXT: firrtl.nla @nla1 [@CollidingSymbols::@[[FoobarSym:[_a-zA-Z0-9]+]], @Bar]
+  firrtl.nla @nla1 [@CollidingSymbols::@foo, @Foo::@bar, @Bar]
   firrtl.module @Bar() attributes {annotations = [{circt.nonlocal = @nla1, class = "nla1"}]} {}
   firrtl.module @Foo() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
     %b = firrtl.wire sym @b : !firrtl.uint<1>
@@ -540,8 +540,8 @@ firrtl.circuit "CollidingSymbols" {
 //
 // CHECK-LABEL: CollidingSymbolsPort
 firrtl.circuit "CollidingSymbolsPort" {
-  // CHECK-NEXT: firrtl.nla @nla1 [#hw.innerNameRef<@CollidingSymbolsPort::@foo>, #hw.innerNameRef<@Foo::@[[BarbSym:[_a-zA-Z0-9]+]]>]
-  firrtl.nla @nla1 [#hw.innerNameRef<@CollidingSymbolsPort::@foo>, #hw.innerNameRef<@Foo::@bar>, #hw.innerNameRef<@Bar::@b>]
+  // CHECK-NEXT: firrtl.nla @nla1 [@CollidingSymbolsPort::@foo, @Foo::@[[BarbSym:[_a-zA-Z0-9]+]]]
+  firrtl.nla @nla1 [@CollidingSymbolsPort::@foo, @Foo::@bar, @Bar::@b]
   // CHECK-NOT: firrtl.module private @Bar
   firrtl.module private @Bar(
     in %b: !firrtl.uint<1> sym @b [{circt.nonlocal = @nla1, class = "nla1"}]
@@ -574,9 +574,9 @@ firrtl.circuit "CollidingSymbolsPort" {
 firrtl.circuit "CollidingSymbolsReTop" {
   // CHECK-NOT:  #hw.innerNameRef<@CollidingSymbolsReTop::@baz>
   // CHECK-NOT:  #hw.innerNameRef<@Foo::@baz>
-  // CHECK-NEXT: firrtl.nla @nla1 [#hw.innerNameRef<@CollidingSymbolsReTop::@[[TopbazSym:[_a-zA-Z0-9]+]]>, #hw.innerNameRef<@Baz::@a>]
-  // CHECK-NEXT: firrtl.nla @nla1_0 [#hw.innerNameRef<@Foo::@[[FoobazSym:[_a-zA-Z0-9]+]]>, #hw.innerNameRef<@Baz::@a>]
-  firrtl.nla @nla1 [#hw.innerNameRef<@Bar::@baz>, #hw.innerNameRef<@Baz::@a>]
+  // CHECK-NEXT: firrtl.nla @nla1 [@CollidingSymbolsReTop::@[[TopbazSym:[_a-zA-Z0-9]+]], @Baz::@a]
+  // CHECK-NEXT: firrtl.nla @nla1_0 [@Foo::@[[FoobazSym:[_a-zA-Z0-9]+]], @Baz::@a]
+  firrtl.nla @nla1 [@Bar::@baz, @Baz::@a]
   // CHECK: firrtl.module @Baz
   firrtl.module @Baz() {
     // CHECK-NEXT: firrtl.wire {{.+}} [{circt.nonlocal = @nla1, class = "hello"}, {circt.nonlocal = @nla1_0, class = "hello"}]
@@ -609,15 +609,11 @@ firrtl.circuit "CollidingSymbolsReTop" {
 // instance inlined should be renamed, and it should *not* update the NLA.
 // CHECK-LABEL: firrtl.circuit "CollidingSymbolsNLAFixup"
 firrtl.circuit "CollidingSymbolsNLAFixup" {
-  // CHECK: firrtl.nla @nla0 [#hw.innerNameRef<@Foo::@bar>, #hw.innerNameRef<@Bar::@io>]
-  firrtl.nla @nla0 [#hw.innerNameRef<@Foo::@bar>,
-                    #hw.innerNameRef<@Bar::@baz0>,
-                    #hw.innerNameRef<@Baz::@io>]
+  // CHECK: firrtl.nla @nla0 [@Foo::@bar, @Bar::@io]
+  firrtl.nla @nla0 [@Foo::@bar, @Bar::@baz0, @Baz::@io]
 
-  // CHECK: firrtl.nla @nla1 [#hw.innerNameRef<@Foo::@bar>, #hw.innerNameRef<@Bar::@w>]
-  firrtl.nla @nla1 [#hw.innerNameRef<@Foo::@bar>,
-                    #hw.innerNameRef<@Bar::@baz0>,
-                    #hw.innerNameRef<@Baz::@w>]
+  // CHECK: firrtl.nla @nla1 [@Foo::@bar, @Bar::@w]
+  firrtl.nla @nla1 [@Foo::@bar, @Bar::@baz0, @Baz::@w]
 
   firrtl.module @Baz(out %io: !firrtl.uint<1> sym @io [{circt.nonlocal = @nla0, class = "test"}])
        attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
@@ -668,8 +664,8 @@ firrtl.circuit "RenameAnything" {
 // corresponds to the original NLA path.
 // CHECK-LABEL: firrtl.circuit "AnnotationSplit0"
 firrtl.circuit "AnnotationSplit0" {
-firrtl.nla @nla_5560 [#hw.innerNameRef<@Bar0::@leaf>, #hw.innerNameRef<@Leaf::@w>]
-firrtl.nla @nla_5561 [#hw.innerNameRef<@Bar1::@leaf>, #hw.innerNameRef<@Leaf::@w>]
+firrtl.nla @nla_5560 [@Bar0::@leaf, @Leaf::@w]
+firrtl.nla @nla_5561 [@Bar1::@leaf, @Leaf::@w]
 firrtl.module @Leaf() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
   %w = firrtl.wire sym @w {annotations = [
     {circt.nonlocal = @nla_5560, class = "test0"},
@@ -696,8 +692,8 @@ firrtl.module @AnnotationSplit0() {
 // above in that the annotation does not become a regular local annotation.
 // CHECK-LABEL: firrtl.circuit "AnnotationSplit1"
 firrtl.circuit "AnnotationSplit1" {
-firrtl.nla @nla_5560 [#hw.innerNameRef<@AnnotationSplit1::@bar0>, #hw.innerNameRef<@Bar0::@leaf>, #hw.innerNameRef<@Leaf::@w>]
-firrtl.nla @nla_5561 [#hw.innerNameRef<@AnnotationSplit1::@bar1>, #hw.innerNameRef<@Bar1::@leaf>, #hw.innerNameRef<@Leaf::@w>]
+firrtl.nla @nla_5560 [@AnnotationSplit1::@bar0, @Bar0::@leaf, @Leaf::@w]
+firrtl.nla @nla_5561 [@AnnotationSplit1::@bar1, @Bar1::@leaf, @Leaf::@w]
 firrtl.module @Leaf() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
   %w = firrtl.wire sym @w {annotations = [
     {circt.nonlocal = @nla_5560, class = "test0"},

--- a/test/Dialect/FIRRTL/lower-memory.mlir
+++ b/test/Dialect/FIRRTL/lower-memory.mlir
@@ -228,8 +228,8 @@ firrtl.module @Annotations() attributes {annotations = [{class = "sifive.enterpr
 // Check that annotations are copied over to the instance.
 // CHECK-LABEL: firrtl.circuit "NonLocalAnnotation"
 firrtl.circuit "NonLocalAnnotation" {
-// CHECK:       [#hw.innerNameRef<@NonLocalAnnotation::@dut>, #hw.innerNameRef<@DUT::@sym>, #hw.innerNameRef<@mem0::@mem0_ext>]
-firrtl.nla @nla [#hw.innerNameRef<@NonLocalAnnotation::@dut>, #hw.innerNameRef<@DUT::@sym>]
+// CHECK:       [@NonLocalAnnotation::@dut, @DUT::@sym, @mem0::@mem0_ext]
+firrtl.nla @nla [@NonLocalAnnotation::@dut, @DUT::@sym]
 // CHECK: firrtl.module @NonLocalAnnotation()
 firrtl.module @NonLocalAnnotation()  {
   firrtl.instance dut sym @dut {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}]} @DUT()

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1266,11 +1266,11 @@ firrtl.module private @Issue2315(in %x: !firrtl.vector<uint<10>, 5>, in %source:
 }
 
   // Check if the NLA is updated with the new lowered symbol on a field element.
-  firrtl.nla @nla [#hw.innerNameRef<@fallBackName::@test>, #hw.innerNameRef<@Aardvark::@test>, #hw.innerNameRef<@Zebra::@b>]
-  // CHECK:  firrtl.nla @nla_0 [#hw.innerNameRef<@fallBackName::@test>, #hw.innerNameRef<@Aardvark::@test>, #hw.innerNameRef<@Zebra::@b_data>]
-  // CHECK: firrtl.nla @nla [#hw.innerNameRef<@fallBackName::@test>, #hw.innerNameRef<@Aardvark::@test>, #hw.innerNameRef<@Zebra::@b_ready>]
-  firrtl.nla @nla_1 [#hw.innerNameRef<@fallBackName::@test>,#hw.innerNameRef<@Aardvark::@test_1>, @Zebra]
-  firrtl.nla @nla_2 [#hw.innerNameRef<@fallBackName::@test>, #hw.innerNameRef<@Aardvark::@test>, #hw.innerNameRef<@Zebra::@b2>]
+  firrtl.nla @nla [@fallBackName::@test, @Aardvark::@test, @Zebra::@b]
+  // CHECK:  firrtl.nla @nla_0 [@fallBackName::@test, @Aardvark::@test, @Zebra::@b_data]
+  // CHECK: firrtl.nla @nla [@fallBackName::@test, @Aardvark::@test, @Zebra::@b_ready]
+  firrtl.nla @nla_1 [@fallBackName::@test,@Aardvark::@test_1, @Zebra]
+  firrtl.nla @nla_2 [@fallBackName::@test, @Aardvark::@test, @Zebra::@b2]
   // CHECK-NOT: firrtl.nla @nla_2
   firrtl.module private @fallBackName() {
     firrtl.instance test  sym @test {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}, {circt.nonlocal = @nla_1, class = "circt.nonlocal"} , {circt.nonlocal = @nla_2, class = "circt.nonlocal"}]}@Aardvark()
@@ -1299,12 +1299,12 @@ firrtl.module private @Issue2315(in %x: !firrtl.vector<uint<10>, 5>, in %source:
   }
 
 // Test the update of NLA when a new symbol is added after lowering of bundle fields.
-  firrtl.nla @lowernla_2 [#hw.innerNameRef<@testNLAbundle::@testBundle_Bar>, #hw.innerNameRef<@testBundle_Bar::@d>]
-  // CHECK: firrtl.nla @lowernla_2_0 [#hw.innerNameRef<@testNLAbundle::@testBundle_Bar>, #hw.innerNameRef<@testBundle_Bar::@d_qux>]
-  // CHECK: firrtl.nla @lowernla_2 [#hw.innerNameRef<@testNLAbundle::@testBundle_Bar>, #hw.innerNameRef<@testBundle_Bar::@d_baz>]
-  firrtl.nla @lowernla_1 [#hw.innerNameRef<@testNLAbundle::@testBundle_Bar>, #hw.innerNameRef<@testBundle_Bar::@b>]
-  // CHECK: firrtl.nla @lowernla_1_0 [#hw.innerNameRef<@testNLAbundle::@testBundle_Bar>, #hw.innerNameRef<@testBundle_Bar::@b_qux>]
-  // CHECK: firrtl.nla @lowernla_1 [#hw.innerNameRef<@testNLAbundle::@testBundle_Bar>, #hw.innerNameRef<@testBundle_Bar::@b_baz>]
+  firrtl.nla @lowernla_2 [@testNLAbundle::@testBundle_Bar, @testBundle_Bar::@d]
+  // CHECK: firrtl.nla @lowernla_2_0 [@testNLAbundle::@testBundle_Bar, @testBundle_Bar::@d_qux]
+  // CHECK: firrtl.nla @lowernla_2 [@testNLAbundle::@testBundle_Bar, @testBundle_Bar::@d_baz]
+  firrtl.nla @lowernla_1 [@testNLAbundle::@testBundle_Bar, @testBundle_Bar::@b]
+  // CHECK: firrtl.nla @lowernla_1_0 [@testNLAbundle::@testBundle_Bar, @testBundle_Bar::@b_qux]
+  // CHECK: firrtl.nla @lowernla_1 [@testNLAbundle::@testBundle_Bar, @testBundle_Bar::@b_baz]
   firrtl.module private @testBundle_Bar(in %a: !firrtl.uint<1>, out %b: !firrtl.bundle<baz: uint<1>, qux: uint<1>, data: uint<2>> sym @b [#firrtl<"subAnno<fieldID = 3, {circt.nonlocal = @lowernla_1, class =\"firrtl.transforms.DontTouchAnnotation\" }>">, #firrtl.subAnno<fieldID = 1, {circt.nonlocal = @lowernla_1, A}>, #firrtl.subAnno<fieldID = 1, {circt.nonlocal = @lowernla_1, B}>, #firrtl.subAnno<fieldID = 2, {circt.nonlocal = @lowernla_1, C}>], out %c: !firrtl.uint<1>) {
   // CHECK-LABEL: firrtl.module private @testBundle_Bar
   // CHECK-SAME: out %b_baz: !firrtl.uint<1> sym @b_baz [{A, circt.nonlocal = @lowernla_1}, {B, circt.nonlocal = @lowernla_1}]

--- a/test/Dialect/FIRRTL/prefix-modules.mlir
+++ b/test/Dialect/FIRRTL/prefix-modules.mlir
@@ -205,10 +205,10 @@ firrtl.circuit "GCTInterfacePrefix"
 // CHECK: firrtl.circuit "T_NLATop"
 firrtl.circuit "NLATop" {
 
-  firrtl.nla @nla [#hw.innerNameRef<@NLATop::@test>, #hw.innerNameRef<@Aardvark::@test>, @Zebra]
-  firrtl.nla @nla_1 [#hw.innerNameRef<@NLATop::@test>,#hw.innerNameRef<@Aardvark::@test_1>, @Zebra]
-  // CHECK: firrtl.nla @nla [#hw.innerNameRef<@T_NLATop::@test>, #hw.innerNameRef<@T_Aardvark::@test>, @T_A_Z_Zebra]
-  // CHECK: firrtl.nla @nla_1 [#hw.innerNameRef<@T_NLATop::@test>, #hw.innerNameRef<@T_Aardvark::@test_1>, @T_A_Z_Zebra]
+  firrtl.nla @nla [@NLATop::@test, @Aardvark::@test, @Zebra]
+  firrtl.nla @nla_1 [@NLATop::@test,@Aardvark::@test_1, @Zebra]
+  // CHECK: firrtl.nla @nla [@T_NLATop::@test, @T_Aardvark::@test, @T_A_Z_Zebra]
+  // CHECK: firrtl.nla @nla_1 [@T_NLATop::@test, @T_Aardvark::@test_1, @T_A_Z_Zebra]
   // CHECK: firrtl.module @T_NLATop
   firrtl.module @NLATop()
     attributes {annotations = [{
@@ -305,14 +305,14 @@ firrtl.circuit "GCTDataMemTapsPrefix" {
 // Test the the NonLocalAnchor is properly updated.
 // CHECK-LABEL: firrtl.circuit "FixNLA" {
   firrtl.circuit "FixNLA"   {
-    firrtl.nla @nla_1 [#hw.innerNameRef<@FixNLA::@bar>, #hw.innerNameRef<@Bar::@baz>, @Baz]
-    // CHECK:   firrtl.nla @nla_1 [#hw.innerNameRef<@FixNLA::@bar>, #hw.innerNameRef<@Bar::@baz>, @Baz]
-    firrtl.nla @nla_2 [#hw.innerNameRef<@FixNLA::@foo>, #hw.innerNameRef<@Foo::@bar>, #hw.innerNameRef<@Bar::@baz>, #hw.innerNameRef<@Baz::@s1>]
-    // CHECK:   firrtl.nla @nla_2 [#hw.innerNameRef<@FixNLA::@foo>, #hw.innerNameRef<@X_Foo::@bar>, #hw.innerNameRef<@X_Bar::@baz>, #hw.innerNameRef<@X_Baz::@s1>]
-    firrtl.nla @nla_3 [#hw.innerNameRef<@FixNLA::@bar>, #hw.innerNameRef<@Bar::@baz>, @Baz]
-    // CHECK:   firrtl.nla @nla_3 [#hw.innerNameRef<@FixNLA::@bar>, #hw.innerNameRef<@Bar::@baz>, @Baz]
-    firrtl.nla @nla_4 [#hw.innerNameRef<@Foo::@bar>, #hw.innerNameRef<@Bar::@baz>, @Baz]
-    // CHECK:       firrtl.nla @nla_4 [#hw.innerNameRef<@X_Foo::@bar>, #hw.innerNameRef<@X_Bar::@baz>, @X_Baz]
+    firrtl.nla @nla_1 [@FixNLA::@bar, @Bar::@baz, @Baz]
+    // CHECK:   firrtl.nla @nla_1 [@FixNLA::@bar, @Bar::@baz, @Baz]
+    firrtl.nla @nla_2 [@FixNLA::@foo, @Foo::@bar, @Bar::@baz, @Baz::@s1]
+    // CHECK:   firrtl.nla @nla_2 [@FixNLA::@foo, @X_Foo::@bar, @X_Bar::@baz, @X_Baz::@s1]
+    firrtl.nla @nla_3 [@FixNLA::@bar, @Bar::@baz, @Baz]
+    // CHECK:   firrtl.nla @nla_3 [@FixNLA::@bar, @Bar::@baz, @Baz]
+    firrtl.nla @nla_4 [@Foo::@bar, @Bar::@baz, @Baz]
+    // CHECK:       firrtl.nla @nla_4 [@X_Foo::@bar, @X_Bar::@baz, @X_Baz]
     // CHECK-LABEL: firrtl.module @FixNLA()
     firrtl.module @FixNLA() {
       firrtl.instance foo sym @foo  {annotations = [{circt.nonlocal = @nla_2, class = "circt.nonlocal"}]} @Foo()
@@ -348,10 +348,10 @@ firrtl.circuit "GCTDataMemTapsPrefix" {
 
 // Test that NonLocalAnchors are properly updated with memmodules.
 firrtl.circuit "Test"   {
-  // CHECK: firrtl.nla @nla_1 [#hw.innerNameRef<@Test::@foo1>, #hw.innerNameRef<@A_Foo1::@bar>, @A_Bar]
-  firrtl.nla @nla_1 [#hw.innerNameRef<@Test::@foo1>, #hw.innerNameRef<@Foo1::@bar>, @Bar]
-  // CHECK: firrtl.nla @nla_2 [#hw.innerNameRef<@Test::@foo2>, #hw.innerNameRef<@B_Foo2::@bar>, @B_Bar]
-  firrtl.nla @nla_2 [#hw.innerNameRef<@Test::@foo2>, #hw.innerNameRef<@Foo2::@bar>, @Bar]
+  // CHECK: firrtl.nla @nla_1 [@Test::@foo1, @A_Foo1::@bar, @A_Bar]
+  firrtl.nla @nla_1 [@Test::@foo1, @Foo1::@bar, @Bar]
+  // CHECK: firrtl.nla @nla_2 [@Test::@foo2, @B_Foo2::@bar, @B_Bar]
+  firrtl.nla @nla_2 [@Test::@foo2, @Foo2::@bar, @Bar]
 
   firrtl.module @Test() {
     firrtl.instance foo1 sym @foo1 {annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}]} @Foo1()

--- a/test/Dialect/FIRRTL/print-nla-table.mlir
+++ b/test/Dialect/FIRRTL/print-nla-table.mlir
@@ -6,9 +6,9 @@
 // CHECK: FooL: 
 
 firrtl.circuit "FooNL"  {
-  firrtl.nla @nla_1 [#hw.innerNameRef<@FooNL::@baz>, #hw.innerNameRef<@BazNL::@bar>, @BarNL]
-  firrtl.nla @nla_0 [#hw.innerNameRef<@FooNL::@baz>, #hw.innerNameRef<@BazNL::@w>]
-  firrtl.nla @nla [#hw.innerNameRef<@FooNL::@baz>, #hw.innerNameRef<@BazNL::@bar>, #hw.innerNameRef<@BarNL::@w2>]
+  firrtl.nla @nla_1 [@FooNL::@baz, @BazNL::@bar, @BarNL]
+  firrtl.nla @nla_0 [@FooNL::@baz, @BazNL::@w]
+  firrtl.nla @nla [@FooNL::@baz, @BazNL::@bar, @BarNL::@w2]
 
   firrtl.module @BarNL() attributes {annotations = [{circt.nonlocal = @nla_1, class = "circt.test", nl = "nl"}]} {
     %w2 = firrtl.wire sym @w2  {annotations = [{circt.fieldID = 5 : i32, circt.nonlocal = @nla, class = "circt.test", nl = "nl2"}]} : !firrtl.bundle<a: uint, b: vector<uint, 4>>

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -153,6 +153,16 @@ firrtl.module @TestInvalidAttr() {
   }
 }
 
+// Basic test for NLA operations.
+// CHECK: firrtl.nla @nla [@Parent::@child, @Child::@w]
+firrtl.nla @nla [@Parent::@child, @Child::@w]
+firrtl.module @Child() {
+  %w = firrtl.wire sym @w : !firrtl.uint<1>
+}
+firrtl.module @Parent() {
+  firrtl.instance child sym @child {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}]} @Child()
+}
+
 // CHECK-LABEL: @VerbatimExpr
 firrtl.module @VerbatimExpr() {
   // CHECK: %[[TMP:.+]] = firrtl.verbatim.expr "FOO" : () -> !firrtl.uint<42>


### PR DESCRIPTION
Printing the namepath array as a regular attribute means we have a lot
of  overhead to write out all the `hw.innerRefAttr`s.  This changes the
NLA operation printer to print the namepath array without the name of
the of the attributes.

```mlir
// Before:
firrtl.nla @nla_1 [#hw.innerNameRef<@Foo::@bar>, #hw.innerNameRef<@Bar::@b>]
// After:
firrtl.nla @nla_1 [@Foo::@bar, @Bar::@b]
```

If anyone has any other suggestions for the printed format, I would love to bike-shed on this. We could choose something similar to the annotation target strings: `Foo/bar:Bar/b`