### PR TITLE
[SVExtractTestCode][LowerToHW] Add coverage exclusion flag to testbench modules

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1059,6 +1059,7 @@ FIRRTLModuleLowering::lowerModule(FModuleOp oldModule, Block *topLevelModule,
       newModule->setAttr("output_file", testBenchDir);
       newModule->setAttr("firrtl.extract.do_not_extract",
                          builder.getUnitAttr());
+      newModule.commentAttr(builder.getStringAttr("VCS coverage exclude_file"));
     }
 
   bool failed = false;

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -166,6 +166,7 @@ static hw::HWModuleOp createModuleForCut(hw::HWModuleOp op,
       b.getStringAttr(getVerilogModuleNameAttr(op).getValue() + suffix), ports);
   if (path)
     newMod->setAttr("output_file", path);
+  newMod.commentAttr(b.getStringAttr("VCS coverage exclude_file"));
 
   // Update the mapping from old values to cloned values
   for (auto port : llvm::enumerate(inputs))

--- a/test/Conversion/FIRRTLToHW/module-hierarchy-file.mlir
+++ b/test/Conversion/FIRRTLToHW/module-hierarchy-file.mlir
@@ -65,10 +65,12 @@ firrtl.circuit "MyTestHarness" attributes {annotations = [ {class = "sifive.ente
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {}
 
   // CHECK-LABEL: hw.module private @Testbench
+  // CHECK-SAME:  comment = "VCS coverage exclude_file"
   // CHECK-SAME:  firrtl.extract.do_not_extract
   firrtl.module private @Testbench() {}
 
   // CHECK-LABEL: hw.module @MyTestHarness
+  // CHECK-SAME:  comment = "VCS coverage exclude_file"
   // CHECK-SAME:  firrtl.extract.do_not_extract
   firrtl.module @MyTestHarness() {
     firrtl.instance myDUT @MyDUT()

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -6,7 +6,7 @@
 // CHECK-NOT: attributes
 // CHECK-NEXT: hw.module.extern @foo_assert
 // CHECK-NOT: attributes
-// CHECK: hw.module @issue1246_assert(%clock: i1) attributes {output_file = #hw.output_file<"dir3/", excludeFromFileList, includeReplicatedOps>}
+// CHECK: hw.module @issue1246_assert(%clock: i1) attributes {comment = "VCS coverage exclude_file", output_file = #hw.output_file<"dir3/", excludeFromFileList, includeReplicatedOps>}
 // CHECK: sv.assert
 // CHECK: sv.error "Assertion failed"
 // CHECK: sv.error "assert:"
@@ -15,11 +15,11 @@
 // CHECK: sv.fatal 1
 // CHECK: foo_assert
 // CHECK: hw.module @issue1246_assume(%clock: i1)
-// CHECK-NOT: attributes
+// CHECK-SAME: attributes {comment = "VCS coverage exclude_file"}
 // CHECK: sv.assume
 // CHECK: foo_assume
 // CHECK: hw.module @issue1246_cover(%clock: i1)
-// CHECK-NOT: attributes
+// CHECK-SAME: attributes {comment = "VCS coverage exclude_file"}
 // CHECK: sv.cover
 // CHECK: foo_cover
 // CHECK: hw.module @issue1246


### PR DESCRIPTION
This adds "// VCS coverage exclude_file" comment to modules under testbench to
make coverage accurate. The comment is added to extracted modules at ETC and
modules under testbench (ref https://github.com/llvm/circt/pull/3058). 