### PR TITLE
[firtool] Only blackbox SRAMs when `-repl-seq-mem` is specified

### DIFF
--- a/test/Dialect/FIRRTL/SFCTests/emit-omir.fir
+++ b/test/Dialect/FIRRTL/SFCTests/emit-omir.fir
@@ -1,4 +1,4 @@
-; RUN: firtool --mem-to-regofvec=0 --verify-diagnostics --verilog --emit-omir %s | FileCheck %s
+; RUN: firtool --repl-seq-mem --repl-seq-mem-file="dummy" --mem-to-regofvec=0 --verify-diagnostics --verilog --emit-omir %s | FileCheck %s
 
 circuit Foo : %[[
   {

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -538,7 +538,7 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
         firrtl::createInferReadWritePass());
 
-  if (lowerMemory)
+  if (replSeqMem && lowerMemory)
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerMemoryPass());
 
   if (prefixModules)


### PR DESCRIPTION
Due some hasty changes when we realized that `MemToRegOfVec` transform
should not lower all memories, we started blackboxing seq mems which
we shouldn't be.  We need to make sure that the `LowerMemory` pass is
gated on the `repl-seq-mem` flag in firtool, which will allow SRAMs to
be lowered to generated memory modules instead of blackboxes.