### PR TITLE
Fix website generation for pass documentation

### DIFF
--- a/docs/Passes.md
+++ b/docs/Passes.md
@@ -8,6 +8,10 @@ This document describes the available CIRCT passes and their contracts.
 
 [include "CIRCTConversionPasses.md"]
 
+## Calyx Dialect Passes
+
+[include "CalyxPasses.md"]
+
 ## ESI Dialect Passes
 
 [include "ESIPasses.md"]
@@ -16,9 +20,17 @@ This document describes the available CIRCT passes and their contracts.
 
 [include "FIRRTLPasses.md"]
 
+## FSM Dialect Passes
+
+[include "FSMPasses.md"]
+
 ## Handshake Dialect Passes
 
 [include "HandshakePasses.md"]
+
+## HW Dialect Passes
+
+[include "HWPasses.md"]
 
 ## LLHD Dialect Passes
 


### PR DESCRIPTION
When we generate a markdown file, and it is not included in any other
markdown file, the website generator will assume that the MD file should
be a top-level page.  Since the MD files generated for passes are
fragments, we end up with some bad top-level pages and untitled entries
in the sidebar.

see https://circt.llvm.org/docs/HWPasses/ for an example.