### PR TITLE
[FIRRTL] Stop double-generating attribute docs

### DIFF
--- a/include/circt/Dialect/FIRRTL/CMakeLists.txt
+++ b/include/circt/Dialect/FIRRTL/CMakeLists.txt
@@ -8,7 +8,6 @@ mlir_tablegen(FIRRTLEnums.cpp.inc -gen-enum-defs)
 mlir_tablegen(FIRRTLAttributes.h.inc -gen-attrdef-decls)
 mlir_tablegen(FIRRTLAttributes.cpp.inc -gen-attrdef-defs)
 add_public_tablegen_target(CIRCTFIRRTLEnumsIncGen)
-add_circt_doc(FIRRTL Dialects/FIRRTLAttributes -gen-attrdef-doc)
 
 set(LLVM_TARGET_DEFINITIONS Passes.td)
 mlir_tablegen(Passes.h.inc -gen-pass-decls)


### PR DESCRIPTION
The attribute defs documentation are generated by and included in the
FIRRTL dialect documentation.  This second  markdown file fragment
becomes a top-level page on the website, which has no title and an
empty box on the sidebar.

See https://circt.llvm.org/docs/Dialects/FIRRTLAttributes/ for the page this is creating.