### PR TITLE
[Calyx] Add sign extension support

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -223,3 +223,5 @@ def SliceLibOp : UnaryLibraryOp<"slice"> {
 def NotLibOp  : UnaryLibraryOp<"not"> {}
 
 def WireLibOp : UnaryLibraryOp<"wire", [SameTypeConstraint<"in", "out">]> {}
+
+def ExtSILibOp  : UnaryLibraryOp<"extsi"> {}

--- a/lib/Conversion/CalyxToHW/CalyxToHW.cpp
+++ b/lib/Conversion/CalyxToHW/CalyxToHW.cpp
@@ -310,6 +310,20 @@ private:
           auto wire = wireIn(op.in(), op.instanceName(), "", b);
           wires.append({wire.input(), wire});
         })
+        .Case([&](PadLibOp op) {
+          auto in = wireIn(op.in(), op.instanceName(), op.portName(op.in()), b);
+          auto srcWidth = in.getType().getIntOrFloatBitWidth();
+          auto destWidth = op.out().getType().getIntOrFloatBitWidth();
+          auto zero = b.create<hw::ConstantOp>(op.getLoc(),
+                                               APInt(destWidth - srcWidth, 0));
+          auto padded = b.createOrFold<comb::ConcatOp>(zero, in);
+          wires.append({in.input(), padded});
+        })
+        .Case([&](ExtSILibOp op) {
+          auto in = wireIn(op.in(), op.instanceName(), op.portName(op.in()), b);
+          auto extsi = createOrFoldSExt(op.getLoc(), in, op.out().getType(), b);
+          wires.append({in.input(), extsi});
+        })
         .Default([](Operation *) { return SmallVector<Value>(); });
   }
 

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -560,8 +560,8 @@ class BuildOpGroups : public FuncOpPartialLoweringPattern {
                              memref::StoreOp,
                              /// standard arithmetic
                              AddIOp, SubIOp, CmpIOp, ShLIOp, ShRUIOp, ShRSIOp,
-                             AndIOp, XOrIOp, OrIOp, ExtUIOp, TruncIOp, MulIOp,
-                             DivUIOp, RemUIOp, IndexCastOp>(
+                             AndIOp, XOrIOp, OrIOp, ExtUIOp, ExtSIOp, TruncIOp,
+                             MulIOp, DivUIOp, RemUIOp, IndexCastOp>(
                   [&](auto op) { return buildOp(rewriter, op).succeeded(); })
               .template Case<scf::WhileOp, FuncOp, scf::ConditionOp>([&](auto) {
                 /// Skip: these special cases will be handled separately.
@@ -600,6 +600,7 @@ private:
   LogicalResult buildOp(PatternRewriter &rewriter, CmpIOp op) const;
   LogicalResult buildOp(PatternRewriter &rewriter, TruncIOp op) const;
   LogicalResult buildOp(PatternRewriter &rewriter, ExtUIOp op) const;
+  LogicalResult buildOp(PatternRewriter &rewriter, ExtSIOp op) const;
   LogicalResult buildOp(PatternRewriter &rewriter, ReturnOp op) const;
   LogicalResult buildOp(PatternRewriter &rewriter, IndexCastOp op) const;
   LogicalResult buildOp(PatternRewriter &rewriter, memref::AllocOp op) const;
@@ -1008,6 +1009,12 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
 LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
                                      ExtUIOp op) const {
   return buildLibraryOp<calyx::CombGroupOp, calyx::PadLibOp>(
+      rewriter, op, {op.getOperand().getType()}, {op.getType()});
+}
+
+LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
+                                     ExtSIOp op) const {
+  return buildLibraryOp<calyx::CombGroupOp, calyx::ExtSILibOp>(
       rewriter, op, {op.getOperand().getType()}, {op.getType()});
 }
 
@@ -1983,7 +1990,7 @@ public:
     target.addLegalOp<AddIOp, SubIOp, CmpIOp, ShLIOp, ShRUIOp, ShRSIOp, AndIOp,
                       XOrIOp, OrIOp, ExtUIOp, TruncIOp, CondBranchOp, BranchOp,
                       MulIOp, DivUIOp, RemUIOp, ReturnOp, arith::ConstantOp,
-                      IndexCastOp, FuncOp>();
+                      IndexCastOp, FuncOp, ExtSIOp>();
 
     RewritePatternSet legalizePatterns(&getContext());
     legalizePatterns.add<DummyPattern>(&getContext());

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -1844,6 +1844,7 @@ ImplUnaryOpCellInterface(PadLibOp)
 ImplUnaryOpCellInterface(SliceLibOp)
 ImplUnaryOpCellInterface(NotLibOp)
 ImplUnaryOpCellInterface(WireLibOp)
+ImplUnaryOpCellInterface(ExtSILibOp)
 
 ImplBinOpCellInterface(LtLibOp)
 ImplBinOpCellInterface(GtLibOp)

--- a/test/Conversion/CalyxToHW/primitives.mlir
+++ b/test/Conversion/CalyxToHW/primitives.mlir
@@ -1,0 +1,44 @@
+// RUN: circt-opt --split-input-file -lower-calyx-to-hw --canonicalize %s | FileCheck %s
+
+// CHECK-LABEL:   hw.module @main(
+// CHECK-SAME:                    %[[IN0:.*]]: i4, %[[CLK:.*]]: i1, %[[RESET:.*]]: i1, %[[GO:.*]]: i1) -> (out0: i8, done: i1) {
+// CHECK:           %[[C0:.*]] = hw.constant 0 : i4
+// CHECK:           %[[C1:.*]] = hw.constant true
+// CHECK:           %[[PADDED:.*]] = comb.concat %[[C0]], %[[IN0]] : i4, i4
+// CHECK:           hw.output %[[PADDED]], %[[C1]] : i8, i1
+// CHECK:         }
+calyx.program "main" {
+  calyx.component @main(%in0: i4, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out0: i8, %done: i1 {done}) {
+    %true = hw.constant true
+    %std_pad.in, %std_pad.out = calyx.std_pad @std_pad : i4, i8
+    calyx.wires {
+      calyx.assign %std_pad.in = %in0 : i4
+      calyx.assign %out0 = %std_pad.out : i8
+      calyx.assign %done = %true : i1
+    }
+    calyx.control {}
+  }
+}
+
+// -----
+
+// CHECK-LABEL:   hw.module @main(
+// CHECK-SAME:                    %[[IN0:.*]]: i4, %[[CLK:.*]]: i1, %[[RESET:.*]]: i1, %[[GO:.*]]: i1) -> (out0: i8, done: i1) {
+// CHECK:           %[[C1:.*]] = hw.constant true
+// CHECK:           %[[SIGN:.*]] = comb.extract %[[IN0]] from 3 : (i4) -> i1
+// CHECK:           %[[SIGNVEC:.*]] = comb.replicate %[[SIGN]] : (i1) -> i4
+// CHECK:           %[[EXTENDED:.*]] = comb.concat %[[SIGNVEC]], %[[IN0]] : i4, i4
+// CHECK:           hw.output %[[EXTENDED]], %[[C1]] : i8, i1
+// CHECK:         }
+calyx.program "main" {
+  calyx.component @main(%in0: i4, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out0: i8, %done: i1 {done}) {
+    %true = hw.constant true
+    %std_extsi.in, %std_extsi.out = calyx.std_extsi @std_extsi : i4, i8
+    calyx.wires {
+      calyx.assign %std_extsi.in = %in0 : i4
+      calyx.assign %out0 = %std_extsi.out : i8
+      calyx.assign %done = %true : i1
+    }
+    calyx.control {}
+  }
+}

--- a/test/Conversion/SCFToCalyx/convert_simple.mlir
+++ b/test/Conversion/SCFToCalyx/convert_simple.mlir
@@ -147,3 +147,26 @@ module {
     return %a0, %a0, %a0, %a0, %a0 : i32, i32, i32, i32, i32
   }
 }
+
+// -----
+
+// Test sign extensions
+
+// CHECK:     calyx.group @ret_assign_0 {
+// CHECK-DAG:   calyx.assign %ret_arg0_reg.in = %std_pad_0.out : i8
+// CHECK-DAG:   calyx.assign %ret_arg0_reg.write_en = %true : i1
+// CHECK-DAG:   calyx.assign %ret_arg1_reg.in = %std_extsi_0.out : i8
+// CHECK-DAG:   calyx.assign %ret_arg1_reg.write_en = %true : i1
+// CHECK-DAG:   calyx.assign %std_pad_0.in = %in0 : i4
+// CHECK-DAG:   calyx.assign %std_extsi_0.in = %in0 : i4
+// CHECK-DAG:   %0 = comb.and %ret_arg0_reg.done, %ret_arg1_reg.done : i1
+// CHECK-DAG:   calyx.group_done %0 ? %true : i1
+// CHECK-DAG: }
+
+module {
+  func.func @main(%arg0 : i4) -> (i8, i8) {
+    %0 = arith.extui %arg0 : i4 to i8
+    %1 = arith.extsi %arg0 : i4 to i8
+    return %0, %1 : i8, i8
+  }
+}


### PR DESCRIPTION
This commit completes support for sign extension in SCFToCalyx, Calyx, and CalyxToHW. A new primitive, `std_extsi` is introduced to perform sign extension whereas `std_pad` implements zero extension.

As of now, the Calyx native compiler does not implement a sign extension primitive. However I do not see that as something which should block this commit - in my view, making the in-CIRCT flow more robust should take priority over immediate interchange compatibility with the rust compiler.