### PR TITLE
[SV][PrettifyVerilog] Lowered struct inject/array concat to `sv.passign` of individual fields/elements

### DIFF
--- a/test/Dialect/SV/prettify-verilog.mlir
+++ b/test/Dialect/SV/prettify-verilog.mlir
@@ -96,13 +96,14 @@ hw.module @sink_constants(%clock :i1) -> (out : i1){
 // CHECK-LABEL: @sinkReadInOut
 // VERILOG-LABEL: sinkReadInOut
 hw.module @sinkReadInOut(%clk: i1) {
-  %myreg = sv.reg  : !hw.inout<array<1xstruct<a:i48>>>
+  %myreg = sv.reg  : !hw.inout<array<1xstruct<a: i48, b: i48>>>
   %false = hw.constant false
-  %0 = sv.array_index_inout %myreg[%false]: !hw.inout<array<1xstruct<a: i48>>>, i1
-  %1 = sv.struct_field_inout %0["a"]: !hw.inout<struct<a: i48>>
-  %2 = sv.read_inout %1 : !hw.inout<i48>
+  %0 = sv.array_index_inout %myreg[%false]: !hw.inout<array<1xstruct<a: i48, b: i48>>>, i1
+  %a = sv.struct_field_inout %0["a"]: !hw.inout<struct<a: i48, b: i48>>
+  %b = sv.struct_field_inout %0["b"]: !hw.inout<struct<a: i48, b: i48>>
+  %2 = sv.read_inout %b : !hw.inout<i48>
   sv.alwaysff(posedge %clk)  {
-    sv.passign %1, %2 : i48
+    sv.passign %a, %2 : i48
   }
 }
 // CHECK:  %myreg = sv.reg
@@ -111,9 +112,9 @@ hw.module @sinkReadInOut(%clk: i1) {
 // CHECK:    sv.struct_field_inout
 // CHECK:    sv.read_inout
 
-// VERILOG:  struct packed {logic [47:0] a; }[0:0] myreg;
+// VERILOG:  struct packed {logic [47:0] a; logic [47:0] b; }[0:0] myreg;
 // VERILOG:  always_ff @(posedge clk)
-// VERILOG:    myreg[1'h0].a <= myreg[1'h0].a;
+// VERILOG:    myreg[1'h0].a <= myreg[1'h0].b;
 
 
 // CHECK-LABEL: @sink_expression
@@ -239,4 +240,326 @@ hw.module @unary_sink_no_duplicate(%arg0: i4) -> (result: i4) {
   // CHECK: hw.output
   %r = comb.concat %a, %b, %c : i1, i1, i2
   hw.output %r : i4
+}
+
+// CHECK-LABEL: hw.module private @ConnectToAllFields
+hw.module private @ConnectToAllFields(%clock: i1, %reset: i1, %value: i2, %base: !hw.inout<!hw.struct<a: i2>>) -> () {
+  %r = sv.reg : !hw.inout<!hw.struct<a: i2>>
+  %val = sv.read_inout %r : !hw.inout<!hw.struct<a: i2>>
+  sv.always posedge %clock {
+    sv.passign %r, %1 : !hw.struct<a: i2>
+  }
+
+  %0 = sv.read_inout %base : !hw.inout<!hw.struct<a: i2>>
+  %1 = hw.struct_inject %0["a"], %value : !hw.struct<a: i2>
+  // CHECK: sv.always posedge %clock {
+  // CHECK:   [[FIELD_A:%.+]] = sv.struct_field_inout %r["a"] : !hw.inout<struct<a: i2>>
+  // CHECK:   sv.passign [[FIELD_A]], %value : i2
+  // CHECK: }
+
+  // VERILOG:       always @(posedge clock)
+  // VERILOG-NEXT:    r.a <= value;
+}
+
+// CHECK-LABEL: hw.module private @ConnectSubfield
+hw.module private @ConnectSubfield(%clock: i1, %reset: i1, %value: i2) -> () {
+  %r = sv.reg : !hw.inout<!hw.struct<a: i2>>
+  %val = sv.read_inout %r : !hw.inout<!hw.struct<a: i2>>
+  sv.always posedge %clock {
+    sv.passign %r, %0 : !hw.struct<a: i2>
+  }
+
+  %0 = hw.struct_inject %val["a"], %value : !hw.struct<a: i2>
+  // CHECK: sv.always posedge %clock {
+  // CHECK:   [[FIELD_A:%.+]] = sv.struct_field_inout %r["a"] : !hw.inout<struct<a: i2>>
+  // CHECK:   sv.passign [[FIELD_A]], %value : i2
+  // CHECK: }
+
+  //VERILOG:      always @(posedge clock)
+  //VERILOG-NEXT:   r.a <= value;
+}
+
+// CHECK-LABEL: hw.module private @ConnectSubfields
+hw.module private @ConnectSubfields(%clock: i1, %reset: i1, %value2: i2, %value3: i3) -> () {
+  %r = sv.reg : !hw.inout<!hw.struct<a: i2, b: i3>>
+  %val = sv.read_inout %r : !hw.inout<!hw.struct<a: i2, b: i3>>
+  sv.always posedge %clock {
+    sv.passign %r, %1 : !hw.struct<a: i2, b: i3>
+  }
+
+  %0 = hw.struct_inject %val["a"], %value2 : !hw.struct<a: i2, b: i3>
+  %1 = hw.struct_inject %0["b"], %value3 : !hw.struct<a: i2, b: i3>
+  // CHECK: sv.always posedge %clock {
+  // CHECK:   [[FIELD_A:%.+]] = sv.struct_field_inout %r["a"] : !hw.inout<struct<a: i2, b: i3>>
+  // CHECK:   sv.passign [[FIELD_A]], %value2 : i2
+  // CHECK:   [[FIELD_B:%.+]] = sv.struct_field_inout %r["b"] : !hw.inout<struct<a: i2, b: i3>>
+  // CHECK:   sv.passign [[FIELD_B]], %value3 : i3
+  // CHECK: }
+
+  // VERILOG:      always @(posedge clock) begin
+  // VERILOG-NEXT:   r.a <= value2;
+  // VERILOG-NEXT:   r.b <= value3;
+  // VERILOG-NEXT: end
+}
+
+// CHECK-LABEL: hw.module private @ConnectSubfieldOverwrite
+hw.module private @ConnectSubfieldOverwrite(%clock: i1, %reset: i1, %value2: i2, %value3: i2) -> () {
+  %r = sv.reg : !hw.inout<!hw.struct<a: i2, b: i3>>
+  %val = sv.read_inout %r : !hw.inout<!hw.struct<a: i2, b: i3>>
+  sv.always posedge %clock {
+    sv.passign %r, %1 : !hw.struct<a: i2, b: i3>
+  }
+
+  %0 = hw.struct_inject %val["a"], %value2 : !hw.struct<a: i2, b: i3>
+  %1 = hw.struct_inject %0["a"], %value3 : !hw.struct<a: i2, b: i3>
+  // CHECK: sv.always posedge %clock {
+  // CHECK:   [[FIELD:%.+]] = sv.struct_field_inout %r["a"] : !hw.inout<struct<a: i2, b: i3>>
+  // CHECK:   sv.passign [[FIELD]], %value3 : i2
+  // CHECK: }
+
+  // VERILOG:      always @(posedge clock)
+  // VERILOG-NEXT:   r.a <= value3;
+}
+
+// CHECK-LABEL: hw.module private @ConnectNestedSubfield
+hw.module private @ConnectNestedSubfield(%clock: i1, %reset: i1, %value: i2) -> () {
+  %r = sv.reg : !hw.inout<!hw.struct<a: !hw.struct<b: i2>>>
+  %val = sv.read_inout %r : !hw.inout<!hw.struct<a: !hw.struct<b: i2>>>
+  sv.always posedge %clock {
+    sv.passign %r, %2 : !hw.struct<a: !hw.struct<b: i2>>
+  }
+  %0 = hw.struct_extract %val["a"] : !hw.struct<a: !hw.struct<b: i2>>
+  %1 = hw.struct_inject %0["b"], %value : !hw.struct<b: i2>
+  %2 = hw.struct_inject %val["a"], %1 : !hw.struct<a: !hw.struct<b: i2>>
+
+  // CHECK: sv.always posedge %clock {
+  // CHECK:   [[FIELD_A:%.+]] = sv.struct_field_inout %r["a"] : !hw.inout<struct<a: !hw.struct<b: i2>>>
+  // CHECK:   [[FIELD_B:%.+]] = sv.struct_field_inout [[FIELD_A]]["b"] : !hw.inout<struct<b: i2>>
+  // CHECK:   sv.passign [[FIELD_B]], %value : i2
+  // CHECK: }
+
+  // VERILOG:      always @(posedge clock)
+  // VERILOG-NEXT:   r.a.b <= value;
+}
+
+
+// CHECK-LABEL: hw.module private @ConnectSubindexMid
+hw.module private @ConnectSubindexMid(%clock: i1, %reset: i1, %value: i2) -> () {
+  %c0_i2 = hw.constant 0 : i2
+  %c-2_i2 = hw.constant -2 : i2
+  %r = sv.reg : !hw.inout<!hw.array<3xi2>>
+  %val = sv.read_inout %r : !hw.inout<!hw.array<3xi2>>
+  sv.always posedge %clock {
+    sv.passign %r, %3 : !hw.array<3xi2>
+  }
+
+  %0 = hw.array_slice %val[%c0_i2] : (!hw.array<3xi2>) -> !hw.array<1xi2>
+  %1 = hw.array_create %value : i2
+  %2 = hw.array_slice %val[%c-2_i2] : (!hw.array<3xi2>) -> !hw.array<1xi2>
+  %3 = hw.array_concat %0, %1, %2 : !hw.array<1xi2>, !hw.array<1xi2>, !hw.array<1xi2>
+  // CHECK: sv.always posedge %clock {
+  // CHECK:   [[FIELD:%.+]] = sv.array_index_inout %r[%c1_i2] : !hw.inout<array<3xi2>>, i2
+  // CHECK:   sv.passign [[FIELD]], %value : i2
+  // CHECK: }
+
+  // VERILOG:      always @(posedge clock)
+  // VERILOG-NEXT:   r[2'h1] <= value;
+}
+
+// CHECK-LABEL: hw.module private @ConnectSubindexSingleton
+hw.module private @ConnectSubindexSingleton(%clock: i1, %reset: i1, %value: i2) -> () {
+  %false = hw.constant false
+  %r = sv.reg : !hw.inout<!hw.array<1xi2>>
+  %val = sv.read_inout %r : !hw.inout<!hw.array<1xi2>>
+  sv.always posedge %clock {
+    sv.passign %r, %1 : !hw.array<1xi2>
+  }
+  %0 = hw.array_get %val[%false] : !hw.array<1xi2>
+  %1 = hw.array_create %value : i2
+
+  // VERILOG:      always @(posedge clock)
+  // VERILOG-NEXT:   r[1'h0] <= value;
+}
+
+// CHECK-LABEL: hw.module private @ConnectSubindexLeft
+hw.module private @ConnectSubindexLeft(%clock: i1, %reset: i1, %value: i2) -> () {
+  %c0_i2 = hw.constant 0 : i2
+
+  %r = sv.reg : !hw.inout<!hw.array<3xi2>>
+  %val = sv.read_inout %r : !hw.inout<!hw.array<3xi2>>
+  sv.always posedge %clock {
+    sv.passign %r, %2 : !hw.array<3xi2>
+  }
+
+  %0 = hw.array_slice %val[%c0_i2] : (!hw.array<3xi2>) -> !hw.array<2xi2>
+  %1 = hw.array_create %value : i2
+  %2 = hw.array_concat %0, %1 : !hw.array<2xi2>, !hw.array<1xi2>
+  // CHECK: sv.always posedge %clock {
+  // CHECK:   [[FIELD_1:%.+]] = sv.array_index_inout %r[%c-2_i2] : !hw.inout<array<3xi2>>, i2
+  // CHECK:   sv.passign [[FIELD_1]], %value : i2
+  // CHECK: }
+
+  // VERILOG:      always @(posedge clock)
+  // VERILOG-NEXT:   r[2'h2] <= value;
+}
+
+// CHECK-LABEL: hw.module private @ConnectSubindexRight
+hw.module private @ConnectSubindexRight(%clock: i1, %reset: i1, %value: i2) -> () {
+  %c1_i2 = hw.constant 1 : i2
+  %r = sv.reg : !hw.inout<!hw.array<3xi2>>
+  %val = sv.read_inout %r : !hw.inout<!hw.array<3xi2>>
+  sv.always posedge %clock {
+    sv.passign %r, %2 : !hw.array<3xi2>
+  }
+
+  %0 = hw.array_create %value : i2
+  %1 = hw.array_slice %val[%c1_i2] : (!hw.array<3xi2>) -> !hw.array<2xi2>
+  %2 = hw.array_concat %0, %1 : !hw.array<1xi2>, !hw.array<2xi2>
+  // CHECK: sv.always posedge %clock {
+  // CHECK:   [[FIELD_0:%.+]] = sv.array_index_inout %r[%c0_i2] : !hw.inout<array<3xi2>>, i2
+  // CHECK:   sv.passign [[FIELD_0]], %value : i2
+  // CHECK: }
+
+  // VERILOG:      always @(posedge clock)
+  // VERILOG-NEXT:     r[2'h0] <= value;
+}
+
+// CHECK-LABEL: hw.module private @ConnectSubindices
+hw.module private @ConnectSubindices(%clock: i1, %reset: i1, %value: i2) -> () {
+  %c0_i3 = hw.constant 0 : i3
+  %c2_i3 = hw.constant 2 : i3
+  %c3_i3 = hw.constant 3 : i3
+
+  %r = sv.reg : !hw.inout<!hw.array<5xi2>>
+  %val = sv.read_inout %r : !hw.inout<!hw.array<5xi2>>
+  sv.always posedge %clock {
+    sv.passign %r, %8 : !hw.array<5xi2>
+  }
+
+  %0 = hw.array_slice %val[%c0_i3] : (!hw.array<5xi2>) -> !hw.array<1xi2>
+  %1 = hw.array_create %value : i2
+  %2 = hw.array_slice %val[%c2_i3] : (!hw.array<5xi2>) -> !hw.array<3xi2>
+  %3 = hw.array_concat %0, %1, %2 : !hw.array<1xi2>, !hw.array<1xi2>, !hw.array<3xi2>
+  %4 = hw.array_slice %3[%c0_i3] : (!hw.array<5xi2>) -> !hw.array<2xi2>
+  %5 = hw.array_slice %3[%c3_i3] : (!hw.array<5xi2>) -> !hw.array<2xi2>
+  %6 = hw.array_concat %4, %1, %5 : !hw.array<2xi2>, !hw.array<1xi2>, !hw.array<2xi2>
+  %7 = hw.array_slice %6[%c0_i3] : (!hw.array<5xi2>) -> !hw.array<4xi2>
+  %8 = hw.array_concat %7, %1 : !hw.array<4xi2>, !hw.array<1xi2>
+  // CHECK: sv.always posedge %clock {
+  // CHECK:   [[IDX_1:%.+]] = sv.array_index_inout %r[%c1_i3] : !hw.inout<array<5xi2>>, i3
+  // CHECK:   sv.passign [[IDX_1]], %value : i2
+  // CHECK:   [[IDX_2:%.+]] = sv.array_index_inout %r[%c2_i3] : !hw.inout<array<5xi2>>, i3
+  // CHECK:   sv.passign [[IDX_2:%.+]], %value : i2
+  // CHECK:   [[IDX_4:%.+]] = sv.array_index_inout %r[%c-4_i3] : !hw.inout<array<5xi2>>, i3
+  // CHECK:   sv.passign [[IDX_4]], %value : i2
+  // CHECK: }
+
+  // VERILOG:      always @(posedge clock) begin
+  // VERILOG-NEXT:   r[3'h1] <= value;
+  // VERILOG-NEXT:   r[3'h2] <= value;
+  // VERILOG-NEXT:   r[3'h4] <= value;
+  // VERILOG-NEXT: end
+}
+
+// CHECK-LABEL: hw.module private @ConnectSubindicesOverwrite
+hw.module private @ConnectSubindicesOverwrite(%clock: i1, %reset: i1, %value: i2, %value2: i2) -> () {
+  %c0_i3 = hw.constant 0 : i3
+  %c2_i3 = hw.constant 2 : i3
+  %r = sv.reg : !hw.inout<!hw.array<5xi2>>
+  %val = sv.read_inout %r : !hw.inout<!hw.array<5xi2>>
+  sv.always posedge %clock {
+    sv.passign %r,  %10 : !hw.array<5xi2>
+  }
+
+  %0 = hw.array_slice %val[%c0_i3] : (!hw.array<5xi2>) -> !hw.array<1xi2>
+  %1 = hw.array_create %value : i2
+  %2 = hw.array_slice %val[%c2_i3] : (!hw.array<5xi2>) -> !hw.array<3xi2>
+  %3 = hw.array_concat %0, %1, %2 : !hw.array<1xi2>, !hw.array<1xi2>, !hw.array<3xi2>
+  %4 = hw.array_slice %3[%c0_i3] : (!hw.array<5xi2>) -> !hw.array<1xi2>
+  %5 = hw.array_slice %3[%c2_i3] : (!hw.array<5xi2>) -> !hw.array<3xi2>
+  %6 = hw.array_concat %4, %1, %5 : !hw.array<1xi2>, !hw.array<1xi2>, !hw.array<3xi2>
+  %7 = hw.array_slice %6[%c0_i3] : (!hw.array<5xi2>) -> !hw.array<1xi2>
+  %8 = hw.array_create %value2 : i2
+  %9 = hw.array_slice %6[%c2_i3] : (!hw.array<5xi2>) -> !hw.array<3xi2>
+  %10 = hw.array_concat %7, %8, %9 : !hw.array<1xi2>, !hw.array<1xi2>, !hw.array<3xi2>
+  // CHECK: sv.always posedge %clock {
+  // CHECK:   [[IDX:%.+]] = sv.array_index_inout %r[%c1_i3] : !hw.inout<array<5xi2>>, i3
+  // CHECK:   sv.passign [[IDX]], %value2 : i2
+  // CHECK: }
+
+
+  // VERILOG:      always @(posedge clock)
+  // VERILOG-NEXT:   r[3'h1] <= value2;
+}
+
+// CHECK-LABEL: hw.module private @ConnectNestedSubindex
+hw.module private @ConnectNestedSubindex(%clock: i1, %reset: i1, %value: i2) -> () {
+  %c1_i2 = hw.constant 1 : i2
+  %c0_i2 = hw.constant 0 : i2
+  %c-2_i2 = hw.constant -2 : i2
+
+  %r = sv.reg : !hw.inout<!hw.array<3xarray<3xi2>>>
+  %val = sv.read_inout %r : !hw.inout<!hw.array<3xarray<3xi2>>>
+  sv.always posedge %clock {
+    sv.passign %r, %8 : !hw.array<3xarray<3xi2>>
+  }
+  %0 = hw.array_get %val[%c1_i2] : !hw.array<3xarray<3xi2>>
+  %1 = hw.array_slice %val[%c0_i2] : (!hw.array<3xarray<3xi2>>) -> !hw.array<1xarray<3xi2>>
+  %2 = hw.array_slice %0[%c0_i2] : (!hw.array<3xi2>) -> !hw.array<1xi2>
+  %3 = hw.array_create %value : i2
+  %4 = hw.array_slice %0[%c-2_i2] : (!hw.array<3xi2>) -> !hw.array<1xi2>
+  %5 = hw.array_concat %2, %3, %4 : !hw.array<1xi2>, !hw.array<1xi2>, !hw.array<1xi2>
+  %6 = hw.array_create %5 : !hw.array<3xi2>
+  %7 = hw.array_slice %val[%c-2_i2] : (!hw.array<3xarray<3xi2>>) -> !hw.array<1xarray<3xi2>>
+  %8 = hw.array_concat %1, %6, %7 : !hw.array<1xarray<3xi2>>, !hw.array<1xarray<3xi2>>, !hw.array<1xarray<3xi2>>
+  // CHECK: sv.always posedge %clock {
+  // CHECK:   [[FIELD_INNER:%.+]] = sv.array_index_inout %r[%c1_i2] : !hw.inout<array<3xarray<3xi2>>>, i2
+  // CHECK:   [[FIELD_OUTER:%.+]] = sv.array_index_inout [[FIELD_INNER]][%c1_i2_0] : !hw.inout<array<3xi2>>, i2
+  // CHECK:   sv.passign [[FIELD_OUTER:%.+]], %value : i2
+  // CHECK: }
+
+  // VERILOG:      always @(posedge clock)
+  // VERILOG-NEXT:   r[2'h1][2'h1] <= value;
+}
+
+// CHECK-LABEL: hw.module private @ConnectNestedFieldsAndIndices
+hw.module private @ConnectNestedFieldsAndIndices(%clock: i1, %reset: i1, %value: i2) -> () {
+  %c2_i3 = hw.constant 2 : i3
+  %c0_i3 = hw.constant 0 : i3
+  %c-2_i2 = hw.constant -2 : i2
+  %c0_i2 = hw.constant 0 : i2
+  %c1_i2 = hw.constant 1 : i2
+  %c1_i3 = hw.constant 1 : i3
+
+  %r = sv.reg : !hw.inout<!hw.array<5xstruct<a: !hw.array<3xstruct<b: i2>>>>>
+  %val = sv.read_inout %r : !hw.inout<!hw.array<5xstruct<a: !hw.array<3xstruct<b: i2>>>>>
+  sv.always posedge %clock {
+    sv.passign %r,  %17 : !hw.array<5xstruct<a: !hw.array<3xstruct<b: i2>>>>
+  }
+
+  %c1_i3_0 = hw.constant 1 : i3
+  %5 = hw.array_get %val[%c1_i3_0] : !hw.array<5xstruct<a: !hw.array<3xstruct<b: i2>>>>
+  %6 = hw.struct_extract %5["a"] : !hw.struct<a: !hw.array<3xstruct<b: i2>>>
+  %c1_i2_1 = hw.constant 1 : i2
+  %7 = hw.array_get %6[%c1_i2_1] : !hw.array<3xstruct<b: i2>>
+  %8 = hw.struct_inject %7["b"], %value : !hw.struct<b: i2>
+  %9 = hw.array_slice %6[%c0_i2] : (!hw.array<3xstruct<b: i2>>) -> !hw.array<1xstruct<b: i2>>
+  %10 = hw.array_create %8 : !hw.struct<b: i2>
+  %11 = hw.array_slice %6[%c-2_i2] : (!hw.array<3xstruct<b: i2>>) -> !hw.array<1xstruct<b: i2>>
+  %12 = hw.array_concat %9, %10, %11 : !hw.array<1xstruct<b: i2>>, !hw.array<1xstruct<b: i2>>, !hw.array<1xstruct<b: i2>>
+  %13 = hw.struct_inject %5["a"], %12 : !hw.struct<a: !hw.array<3xstruct<b: i2>>>
+  %14 = hw.array_slice %val[%c0_i3] : (!hw.array<5xstruct<a: !hw.array<3xstruct<b: i2>>>>) -> !hw.array<1xstruct<a: !hw.array<3xstruct<b: i2>>>>
+  %15 = hw.array_create %13 : !hw.struct<a: !hw.array<3xstruct<b: i2>>>
+  %16 = hw.array_slice %val[%c2_i3] : (!hw.array<5xstruct<a: !hw.array<3xstruct<b: i2>>>>) -> !hw.array<3xstruct<a: !hw.array<3xstruct<b: i2>>>>
+  %17 = hw.array_concat %14, %15, %16 : !hw.array<1xstruct<a: !hw.array<3xstruct<b: i2>>>>, !hw.array<1xstruct<a: !hw.array<3xstruct<b: i2>>>>, !hw.array<3xstruct<a: !hw.array<3xstruct<b: i2>>>>
+  // CHECK: sv.always posedge %clock {
+  // CHECK:   [[ARR_1:%.+]] = sv.array_index_inout %r[%c1_i3] : !hw.inout<array<5xstruct<a: !hw.array<3xstruct<b: i2>>>>>, i3
+  // CHECK:   [[STRUCT_A:%.+]] = sv.struct_field_inout [[ARR_1]]["a"] : !hw.inout<struct<a: !hw.array<3xstruct<b: i2>>>>
+  // CHECK:   [[ARR_1:%.+]] = sv.array_index_inout [[STRUCT_A]][%c1_i2] : !hw.inout<array<3xstruct<b: i2>>>, i2
+  // CHECK:   [[STRUCT_B:%.+]] = sv.struct_field_inout [[ARR_1]]["b"] : !hw.inout<struct<b: i2>>
+  // CHECK:   sv.passign [[STRUCT_B]], %value : i2
+  // CHECK: }
+
+  // VERILOG:      always @(posedge clock)
+  // VERILOG-NEXT:   r[3'h1].a[2'h1].b <= value;
 }


### PR DESCRIPTION
If a register or a wire is updated with struct inject or array concat:

```
%reg = seq.firreg %clk, %b, ...
%a = hw.struct_inject %reg["a"], %valA
%b = hw.struct_inject %reg["b"], %valB
```

Instead of emitting structure constructs:

```
sv.bpassign %reg, hw.struct_inject ...
```

Which lower to:

```
reg <= { a: ..., b: ... }
```

This patch updates individual subfields:

```
%fieldA = sv.struct_field_inout %reg["a"]
%sv.passign %fieldA, %valA
%fieldB = sv.struct_field_inout %reg["B"]
%sv.passign %fieldB, %valB
```

Which lowers to:

```
reg.a <= valA;
reg.b <= valB;
```