### PR TITLE
 [SV][Seq][FIRRTL] Lowered FIRRTL registers to `seq.firreg` 

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -257,7 +257,7 @@ def LowerFIRRTLToHW : Pass<"lower-firrtl-to-hw", "mlir::ModuleOp"> {
   }];
   let constructor = "circt::createLowerFIRRTLToHWPass()";
   let dependentDialects = ["comb::CombDialect", "hw::HWDialect",
-                           "sv::SVDialect"];
+                           "seq::SeqDialect", "sv::SVDialect"];
   let options = [
     Option<"enableAnnotationWarning", "warn-on-unprocessed-annotations",
            "bool", "false",

--- a/lib/Conversion/FIRRTLToHW/CMakeLists.txt
+++ b/lib/Conversion/FIRRTLToHW/CMakeLists.txt
@@ -11,6 +11,7 @@ add_circt_conversion_library(CIRCTFIRRTLToHW
   CIRCTComb
   CIRCTFIRRTL
   CIRCTHW
+  CIRCTSeq
   CIRCTSV
   MLIRTransforms
 )

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -26,6 +26,7 @@
 #include "circt/Dialect/HW/HWTypes.h"
 #include "circt/Dialect/HW/Namespace.h"
 #include "circt/Dialect/SV/SVOps.h"
+#include "circt/Dialect/Seq/SeqOps.h"
 #include "circt/Support/BackedgeBuilder.h"
 #include "circt/Support/Namespace.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -1403,9 +1404,6 @@ struct FIRRTLLowering : public FIRRTLVisitor<FIRRTLLowering, LogicalResult> {
   LogicalResult setLoweringTo(Operation *orig, CtorArgTypes... args);
   Backedge createBackedge(Value orig, Type type);
   bool updateIfBackedge(Value dest, Value src);
-  void emitRandomizePrologIfNeeded();
-  void initializeRegister(Value reg, llvm::Optional<std::pair<Value, Value>>
-                                         asyncRegResetInitPair = llvm::None);
 
   void runWithInsertionPointAtEndOfBlock(std::function<void(void)> fn,
                                          Region &region);
@@ -1431,7 +1429,6 @@ struct FIRRTLLowering : public FIRRTLVisitor<FIRRTLLowering, LogicalResult> {
                                  std::function<void(void)> elseCtor = {});
   void addIfProceduralBlock(Value cond, std::function<void(void)> thenCtor,
                             std::function<void(void)> elseCtor = {});
-  void addToOrderedBlock(std::function<void(void)> body);
   Value getExtOrTruncAggregateValue(Value array, FIRRTLType sourceType,
                                     FIRRTLType destType, bool allowTruncate);
 
@@ -1569,6 +1566,8 @@ struct FIRRTLLowering : public FIRRTLVisitor<FIRRTLLowering, LogicalResult> {
       StringAttr nameAttr, bool isConcurrent, EventControl eventControl);
 
   LogicalResult visitStmt(SkipOp op);
+
+  void lowerRegConnect(const FieldRef &fieldRef, Value dest, Value srcVal);
   LogicalResult visitStmt(ConnectOp op);
   LogicalResult visitStmt(StrictConnectOp op);
   LogicalResult visitStmt(ForceOp op);
@@ -1614,27 +1613,10 @@ private:
   llvm::SmallDenseMap<std::pair<Block *, Attribute>, sv::IfDefOp> ifdefBlocks;
   llvm::SmallDenseMap<Block *, sv::InitialOp> initialBlocks;
 
-  llvm::SmallDenseMap<Block *, sv::IfDefProceduralOp> randomizeRegInitIfOp;
-  llvm::SmallDenseMap<std::pair<Block *, Value>, sv::IfOp>
-      asyncRegPostRandomizationIfOp;
-  llvm::SmallDenseMap<Block *, sv::OrderedOutputOp> orderedOutputOp;
-
   /// This is a set of wires that get inserted as an artifact of the
   /// lowering process.  LowerToHW should attempt to clean these up after
   /// lowering.
   SmallVector<sv::WireOp> tmpWiresToOptimize;
-
-  /// This is true if we've emitted `INIT_RANDOM_PROLOG_ into an initial
-  /// block in this module already.
-  bool randomizePrologEmitted;
-
-  /// This is true if we've emitted `FIRRTL_BEFORE_INITIAL and
-  /// `FIRRTL_AFTER_INITIAL into an initial block in this module already.
-  bool areFIRRTLBeforeAndAfterInitialEmitted;
-
-  /// This is a map from block to a pair of a random value and its unused
-  /// bits. It is used to reduce the number of random value.
-  DenseMap<Block *, std::pair<Value, unsigned>> blockRandomValueAndRemain;
 
   /// A namespace that can be used to generte new symbol names that are unique
   /// within this module.
@@ -1648,6 +1630,11 @@ private:
   /// so that a combinational cycles of backedges, the one backedge that gets
   /// replaced with an undriven wire is consistent.
   llvm::MapVector<Value, Value> backedges;
+
+  /// Back-edges for register.  A mapping from the operation defining the
+  /// FIRRTL register to the backedge which represents the next value, along
+  /// with the value to which the register was lowered.
+  DenseMap<Operation *, seq::FirRegOp> regMapping;
 };
 } // end anonymous namespace
 
@@ -1662,8 +1649,6 @@ LogicalResult FIRRTLLowering::run() {
   // through each operation, lowering each in turn if we can, introducing
   // casts if we cannot.
   auto &body = theModule.getBody();
-  randomizePrologEmitted = false;
-  areFIRRTLBeforeAndAfterInitialEmitted = false;
 
   SmallVector<Operation *, 16> opsToRemove;
 
@@ -2281,22 +2266,6 @@ void FIRRTLLowering::addToIfDefBlock(StringRef cond,
   }
 }
 
-void FIRRTLLowering::addToOrderedBlock(std::function<void(void)> body) {
-  auto op = orderedOutputOp.lookup(builder.getBlock());
-  if (op) {
-    runWithInsertionPointAtEndOfBlock(body, op.getRegion());
-
-    // Move the earlier sv.ordered block(s) down to where the last would have
-    // been inserted.  This ensures that any values used by the sv.ordered
-    // blocks are defined ahead of the uses, which leads to better generated
-    // Verilog.
-    op->moveBefore(builder.getInsertionBlock(), builder.getInsertionPoint());
-  } else {
-    orderedOutputOp[builder.getBlock()] =
-        builder.create<sv::OrderedOutputOp>(body);
-  }
-}
-
 void FIRRTLLowering::addToInitialBlock(std::function<void(void)> body) {
   auto op = initialBlocks.lookup(builder.getBlock());
   if (op) {
@@ -2566,210 +2535,6 @@ LogicalResult FIRRTLLowering::visitDecl(NodeOp op) {
   return setLowering(op, operand);
 }
 
-/// Emit a `INIT_RANDOM_PROLOG_ statement into the current block.  This should
-/// already be within an `ifndef SYNTHESIS + initial block.
-void FIRRTLLowering::emitRandomizePrologIfNeeded() {
-  if (randomizePrologEmitted)
-    return;
-
-  builder.create<sv::VerbatimOp>("`INIT_RANDOM_PROLOG_");
-  randomizePrologEmitted = true;
-}
-
-void FIRRTLLowering::initializeRegister(
-    Value reg, llvm::Optional<std::pair<Value, Value>> asyncRegResetInitPair) {
-  typedef std::pair<Attribute, std::pair<unsigned, unsigned>> SymbolAndRange;
-
-  // The point in the design where we should add randomization register
-  // definitions.  This is at the top of the "`ifndef SYNTHESIS" block.
-  mlir::OpBuilder::InsertPoint regInsertionPoint;
-
-  auto regDef = cast<sv::RegOp>(reg.getDefiningOp());
-  if (!regDef->hasAttrOfType<StringAttr>("inner_sym"))
-    regDef->setAttr("inner_sym", builder.getStringAttr(moduleNamespace.newName(
-                                     Twine("__") + regDef.getName() + "__")));
-  auto regDefSym =
-      hw::InnerRefAttr::get(theModule.getNameAttr(), regDef.getInnerSymAttr());
-
-  // Construct and return a new reference to `RANDOM.  It is always a 32-bit
-  // unsigned expression.  Calls to $random have side effects, so we use
-  // VerbatimExprSEOp.
-  constexpr unsigned randomWidth = 32;
-  auto getRandom32Val = [&](Twine suffix = "") -> Value {
-    sv::RegOp randReg;
-    {
-      OpBuilder::InsertionGuard topBuilder(builder);
-      builder.restoreInsertionPoint(regInsertionPoint);
-      randReg = builder.create<sv::RegOp>(
-          reg.getLoc(), builder.getIntegerType(randomWidth),
-          /*name=*/builder.getStringAttr("_RANDOM"),
-          /*inner_sym=*/
-          builder.getStringAttr(moduleNamespace.newName(Twine("_RANDOM"))));
-    }
-
-    builder.create<sv::VerbatimOp>(
-        builder.getStringAttr(Twine("{{0}} = {`RANDOM};")), ValueRange{},
-        builder.getArrayAttr({hw::InnerRefAttr::get(
-            theModule.getNameAttr(), randReg.getInnerSymAttr())}));
-
-    return randReg.getResult();
-  };
-
-  auto getRandomValues = [&](IntegerType type,
-                             SmallVector<SymbolAndRange> &values) {
-    auto width = type.getWidth();
-    assert(width != 0 && "zero bit width's not supported");
-    while (width > 0) {
-      auto &randomValueAndRemain =
-          blockRandomValueAndRemain[builder.getBlock()];
-
-      // If there are no bits left, then generate a new random value.
-      if (!randomValueAndRemain.second)
-        randomValueAndRemain = {getRandom32Val("foo"), randomWidth};
-
-      auto reg = cast<sv::RegOp>(randomValueAndRemain.first.getDefiningOp());
-
-      auto symbol =
-          hw::InnerRefAttr::get(theModule.getNameAttr(), reg.getInnerSymAttr());
-      unsigned low = randomWidth - randomValueAndRemain.second;
-      unsigned high = randomWidth - 1;
-      if (width <= randomValueAndRemain.second)
-        high = width - 1 + low;
-      unsigned consumed = high - low + 1;
-      values.push_back({symbol, {high, low}});
-      randomValueAndRemain.second -= consumed;
-      width -= consumed;
-    }
-  };
-
-  // Get a random value with the specified width, combining or truncating
-  // 32-bit units as necessary.
-  auto emitRandomInit = [&](Value dest, Type type, Twine accessor) {
-    auto intType = type.cast<IntegerType>();
-    if (intType.getWidth() == 0)
-      return;
-
-    SmallVector<SymbolAndRange> values;
-    getRandomValues(intType, values);
-
-    SmallString<32> rhs(("{{0}}" + accessor + " = ").str());
-    unsigned i = 1;
-    SmallVector<Attribute, 4> symbols({regDefSym});
-    if (values.size() > 1)
-      rhs.append("{");
-    for (auto [value, range] : llvm::reverse(values)) {
-      symbols.push_back(value);
-      auto [high, low] = range;
-      if (i > 1)
-        rhs.append(", ");
-      rhs.append(("{{" + Twine(i++) + "}}").str());
-
-      // This uses all bits of the random value. Emit without part select.
-      if (high == randomWidth - 1 && low == 0)
-        continue;
-
-      // Emit a single bit part select, e.g., emit "[0]" and not "[0:0]".
-      if (high == low) {
-        rhs.append(("[" + Twine(high) + "]").str());
-        continue;
-      }
-
-      // Emit a part select, e.g., "[4:2]"
-      rhs.append(
-          ("[" + Twine(range.first) + ":" + Twine(range.second) + "]").str());
-    }
-    if (values.size() > 1)
-      rhs.append("}");
-    rhs.append(";");
-
-    builder.create<sv::VerbatimOp>(rhs, ValueRange{},
-                                   builder.getArrayAttr(symbols));
-  };
-
-  // Randomly initialize everything in the register. If the register
-  // is an aggregate type, then assign random values to all its
-  // constituent ground types.
-  auto randomInit = [&]() {
-    auto type = reg.getType().dyn_cast<hw::InOutType>().getElementType();
-    std::function<void(Value, Type, Twine)> recurse = [&](Value reg, Type type,
-                                                          Twine accessor) {
-      TypeSwitch<Type>(type)
-          .Case<hw::UnpackedArrayType, hw::ArrayType>([&](auto a) {
-            for (size_t i = 0, e = a.getSize(); i != e; ++i)
-              recurse(reg, a.getElementType(), accessor + "[" + Twine(i) + "]");
-          })
-          .Case<hw::StructType>([&](hw::StructType s) {
-            for (auto elem : s.getElements())
-              recurse(reg, elem.type, accessor + "." + elem.name.getValue());
-          })
-          .Default([&](auto type) { emitRandomInit(reg, type, accessor); });
-    };
-    recurse(reg, type, "");
-  };
-
-  // Emit the initializer expression for simulation that fills it with random
-  // value.
-
-  addToIfDefBlock("SYNTHESIS", std::function<void()>(), [&]() {
-    addToOrderedBlock([&]() {
-      addToIfDefBlock(
-          "RANDOMIZE_REG_INIT",
-          [&]() { regInsertionPoint = builder.saveInsertionPoint(); },
-          std::function<void()>());
-
-      addToIfDefBlock(
-          "FIRRTL_BEFORE_INITIAL",
-          [&] {
-            if (!areFIRRTLBeforeAndAfterInitialEmitted)
-              builder.create<sv::VerbatimOp>("`FIRRTL_BEFORE_INITIAL");
-          },
-          std::function<void()>());
-
-      addToInitialBlock([&]() {
-        emitRandomizePrologIfNeeded();
-        circuitState.used_RANDOMIZE_REG_INIT = 1;
-        auto *block = builder.getBlock();
-
-        // Randomized values are assigned to registers in `ifdef
-        // RANDOMIZE_REG_INIT block.
-        auto &op = randomizeRegInitIfOp[block];
-        if (!op)
-          op = builder.create<sv::IfDefProceduralOp>("RANDOMIZE_REG_INIT",
-                                                     [&]() {});
-        runWithInsertionPointAtEndOfBlock(randomInit, op.getThenRegion());
-
-        // If the register is async reset, we need to insert extra
-        // initialization in post-randomization so that we can set the reset
-        // value to register if the reset signal is enabled.
-        if (asyncRegResetInitPair.hasValue()) {
-          Value resetSignal, resetValue;
-          std::tie(resetSignal, resetValue) = *asyncRegResetInitPair;
-          // Merge if op if their reset values are same.
-          auto &op = asyncRegPostRandomizationIfOp[{block, resetSignal}];
-          if (!op)
-            builder.create<sv::IfDefProceduralOp>("RANDOMIZE", [&] {
-              op = builder.create<sv::IfOp>(resetSignal, [&]() {});
-            });
-
-          runWithInsertionPointAtEndOfBlock(
-              [&]() { builder.create<sv::BPAssignOp>(reg, resetValue); },
-              op.getThenRegion());
-        }
-      });
-
-      addToIfDefBlock(
-          "FIRRTL_AFTER_INITIAL",
-          [&] {
-            if (!areFIRRTLBeforeAndAfterInitialEmitted) {
-              builder.create<sv::VerbatimOp>("`FIRRTL_AFTER_INITIAL");
-              areFIRRTLBeforeAndAfterInitialEmitted = true;
-            }
-          },
-          std::function<void()>());
-    });
-  });
-}
-
 LogicalResult FIRRTLLowering::visitDecl(RegOp op) {
   auto resultType = lowerType(op.getResult().getType());
   if (!resultType)
@@ -2777,16 +2542,23 @@ LogicalResult FIRRTLLowering::visitDecl(RegOp op) {
   if (resultType.isInteger(0))
     return setLowering(op, Value());
 
+  Value clockVal = getLoweredValue(op.getClockVal());
+  if (!clockVal)
+    return failure();
+
   // Add symbol if DontTouch annotation present.
   auto symName = getInnerSymName(op);
   if (AnnotationSet::removeAnnotations(op, dontTouchAnnoClass) && !symName)
     symName = op.getNameAttr();
-  auto regResult =
-      builder.create<sv::RegOp>(resultType, op.getNameAttr(), symName);
-  (void)setLowering(op, regResult);
 
-  initializeRegister(regResult);
-
+  // Create a reg op, wiring itself to its input.
+  Backedge inputEdge = backedgeBuilder.get(resultType);
+  auto reg = builder.create<seq::FirRegOp>(inputEdge, clockVal,
+                                           op.getNameAttr(), symName);
+  inputEdge.setValue(reg);
+  circuitState.used_RANDOMIZE_REG_INIT = 1;
+  regMapping.try_emplace(op, reg);
+  (void)setLowering(op, reg);
   return success();
 }
 
@@ -2809,27 +2581,18 @@ LogicalResult FIRRTLLowering::visitDecl(RegResetOp op) {
   auto symName = getInnerSymName(op);
   if (AnnotationSet::removeAnnotations(op, dontTouchAnnoClass) && !symName)
     symName = op.getNameAttr();
-  auto regResult =
-      builder.create<sv::RegOp>(resultType, op.getNameAttr(), symName);
-  (void)setLowering(op, regResult);
 
-  auto resetFn = [&]() {
-    builder.create<sv::PAssignOp>(regResult, resetValue);
-  };
+  // Create a reg op, wiring itself to its input.
+  bool isAsync = op.getResetSignal().getType().isa<AsyncResetType>();
+  Backedge inputEdge = backedgeBuilder.get(resultType);
+  auto reg =
+      builder.create<seq::FirRegOp>(inputEdge, clockVal, op.getNameAttr(),
+                                    resetSignal, resetValue, symName, isAsync);
+  inputEdge.setValue(reg);
+  circuitState.used_RANDOMIZE_REG_INIT = 1;
+  regMapping.try_emplace(op, reg);
+  (void)setLowering(op, reg);
 
-  if (op.getResetSignal().getType().isa<AsyncResetType>()) {
-    addToAlwaysBlock(sv::EventControl::AtPosEdge, clockVal,
-                     ::ResetType::AsyncReset, sv::EventControl::AtPosEdge,
-                     resetSignal, std::function<void()>(), resetFn);
-  } else { // sync reset
-    addToAlwaysBlock(sv::EventControl::AtPosEdge, clockVal,
-                     ::ResetType::SyncReset, sv::EventControl::AtPosEdge,
-                     resetSignal, std::function<void()>(), resetFn);
-  }
-  llvm::Optional<std::pair<Value, Value>> asyncRegResetInitPair;
-  if (op.getResetSignal().getType().isa<AsyncResetType>())
-    asyncRegResetInitPair = {resetSignal, resetValue};
-  initializeRegister(regResult, asyncRegResetInitPair);
   return success();
 }
 
@@ -3636,6 +3399,95 @@ LogicalResult FIRRTLLowering::visitStmt(SkipOp op) {
   return success();
 }
 
+void FIRRTLLowering::lowerRegConnect(const FieldRef &fieldRef, Value dest,
+                                     Value srcVal) {
+  auto *regOp = fieldRef.getValue().getDefiningOp();
+  // Construct the updated value.  For each access, starting with the
+  // outermost ones, the new value is computed by updating one of its
+  // fields. The value of the field itself is determined by updating the
+  // previous value according to the subsequent access operation.
+  std::function<Value(Value, Type, unsigned)> inject = [&](Value base,
+                                                           Type type,
+                                                           unsigned fieldID) {
+    if (auto bundle = type.dyn_cast<BundleType>()) {
+      auto index = bundle.getIndexForFieldID(fieldID);
+      fieldID -= bundle.getFieldID(index);
+
+      auto ty = hw::type_cast<hw::StructType>(base.getType());
+      auto field = ty.getElements()[index];
+      auto name = field.name;
+
+      // Determine the value of the new field.
+      Value value;
+      if (fieldID == 0) {
+        value = srcVal;
+      } else {
+        auto oldField =
+            builder.create<hw::StructExtractOp>(field.type, base, field.name);
+        value = inject(oldField, bundle.getElementType(index), fieldID);
+      }
+
+      return builder.create<hw::StructInjectOp>(ty, base, name, value)
+          .getResult();
+
+    } else {
+      auto vector = type.cast<FVectorType>();
+      auto index = vector.getIndexForFieldID(fieldID);
+      fieldID -= vector.getFieldID(index);
+
+      auto ty = hw::type_cast<hw::ArrayType>(base.getType());
+      auto elemTy = ty.getElementType();
+
+      auto size = ty.getSize();
+      auto indexWidth = getBitWidthFromVectorSize(size);
+
+      // Determine the value of the new field.
+      Value value;
+      if (fieldID == 0) {
+        value = srcVal;
+      } else {
+        auto oldField = builder.create<hw::ArrayGetOp>(
+            elemTy, base,
+            builder.create<hw::ConstantOp>(APInt(indexWidth, index)));
+        value = inject(oldField, vector.getElementType(), fieldID);
+      }
+
+      // Build a new array by concatenating predecessors, the new
+      // value and any successors from the old array.
+      if (index == 0 && size == 1)
+        return builder.create<hw::ArrayCreateOp>(value).getResult();
+
+      SmallVector<Value> elements;
+      if (index != 0) {
+        elements.push_back(builder.create<hw::ArraySliceOp>(
+            hw::ArrayType::get(elemTy, index), base,
+            getOrCreateIntConstant(indexWidth, 0)));
+      }
+      elements.push_back(builder.create<hw::ArrayCreateOp>(value));
+      if (index + 1 != size) {
+        elements.push_back(builder.create<hw::ArraySliceOp>(
+            hw::ArrayType::get(elemTy, size - index - 1), base,
+            getOrCreateIntConstant(indexWidth, index + 1)));
+      }
+
+      return builder.create<hw::ArrayConcatOp>(elements).getResult();
+    }
+  };
+
+  // Update the last value mapped for the register.
+  auto it = regMapping.find(regOp);
+  assert(it != regMapping.end() && "register not defined");
+  auto seqReg = it->second;
+
+  auto fieldID = fieldRef.getFieldID();
+  Value nextValue = srcVal;
+  if (fieldID != 0) {
+    nextValue =
+        inject(seqReg.getNext(), regOp->getResult(0).getType(), fieldID);
+  }
+  seqReg.getNextMutable().assign(nextValue);
+}
+
 LogicalResult FIRRTLLowering::visitStmt(ConnectOp op) {
   auto dest = op.getDest();
   // The source can be a smaller integer, extend it as appropriate if so.
@@ -3648,39 +3500,15 @@ LogicalResult FIRRTLLowering::visitStmt(ConnectOp op) {
   if (!destVal)
     return failure();
 
+  auto fieldRef = getFieldRefFromValue(dest);
+  auto definingOp = fieldRef.getValue().getDefiningOp();
+  if (isa<RegOp>(definingOp) || isa<RegResetOp>(definingOp)) {
+    lowerRegConnect(fieldRef, dest, srcVal);
+    return success();
+  }
+
   if (!destVal.getType().isa<hw::InOutType>())
     return op.emitError("destination isn't an inout type");
-
-  auto *definingOp = getFieldRefFromValue(dest).getValue().getDefiningOp();
-
-  // If this is an assignment to a register, then the connect implicitly
-  // happens under the clock that gates the register.
-  if (auto regOp = dyn_cast_or_null<RegOp>(definingOp)) {
-    Value clockVal = getLoweredValue(regOp.getClockVal());
-    if (!clockVal)
-      return failure();
-
-    addToAlwaysBlock(clockVal,
-                     [&]() { builder.create<sv::PAssignOp>(destVal, srcVal); });
-    return success();
-  }
-
-  // If this is an assignment to a RegReset, then the connect implicitly
-  // happens under the clock and reset that gate the register.
-  if (auto regResetOp = dyn_cast_or_null<RegResetOp>(definingOp)) {
-    Value clockVal = getLoweredValue(regResetOp.getClockVal());
-    Value resetSignal = getLoweredValue(regResetOp.getResetSignal());
-    if (!clockVal || !resetSignal)
-      return failure();
-
-    addToAlwaysBlock(sv::EventControl::AtPosEdge, clockVal,
-                     regResetOp.getResetSignal().getType().isa<AsyncResetType>()
-                         ? ::ResetType::AsyncReset
-                         : ::ResetType::SyncReset,
-                     sv::EventControl::AtPosEdge, resetSignal,
-                     [&]() { builder.create<sv::PAssignOp>(destVal, srcVal); });
-    return success();
-  }
 
   builder.create<sv::AssignOp>(destVal, srcVal);
   return success();
@@ -3696,6 +3524,13 @@ LogicalResult FIRRTLLowering::visitStmt(StrictConnectOp op) {
   if (!destVal)
     return failure();
 
+  auto fieldRef = getFieldRefFromValue(dest);
+  auto definingOp = fieldRef.getValue().getDefiningOp();
+  if (isa<RegOp>(definingOp) || isa<RegResetOp>(definingOp)) {
+    lowerRegConnect(fieldRef, dest, srcVal);
+    return success();
+  }
+
   // If this connect is driving a value that is currently a backedge, record
   // that the source is the value of the backedge.
   if (updateIfBackedge(destVal, srcVal))
@@ -3703,37 +3538,6 @@ LogicalResult FIRRTLLowering::visitStmt(StrictConnectOp op) {
 
   if (!destVal.getType().isa<hw::InOutType>())
     return op.emitError("destination isn't an inout type");
-
-  auto *definingOp = getFieldRefFromValue(dest).getValue().getDefiningOp();
-
-  // If this is an assignment to a register, then the connect implicitly
-  // happens under the clock that gates the register.
-  if (auto regOp = dyn_cast_or_null<RegOp>(definingOp)) {
-    Value clockVal = getLoweredValue(regOp.getClockVal());
-    if (!clockVal)
-      return failure();
-
-    addToAlwaysBlock(clockVal,
-                     [&]() { builder.create<sv::PAssignOp>(destVal, srcVal); });
-    return success();
-  }
-
-  // If this is an assignment to a RegReset, then the connect implicitly
-  // happens under the clock and reset that gate the register.
-  if (auto regResetOp = dyn_cast_or_null<RegResetOp>(definingOp)) {
-    Value clockVal = getLoweredValue(regResetOp.getClockVal());
-    Value resetSignal = getLoweredValue(regResetOp.getResetSignal());
-    if (!clockVal || !resetSignal)
-      return failure();
-
-    addToAlwaysBlock(sv::EventControl::AtPosEdge, clockVal,
-                     regResetOp.getResetSignal().getType().isa<AsyncResetType>()
-                         ? ::ResetType::AsyncReset
-                         : ::ResetType::SyncReset,
-                     sv::EventControl::AtPosEdge, resetSignal,
-                     [&]() { builder.create<sv::PAssignOp>(destVal, srcVal); });
-    return success();
-  }
 
   builder.create<sv::AssignOp>(destVal, srcVal);
   return success();

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -636,158 +636,6 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.connect %outClock, %1 : !firrtl.clock, !firrtl.clock
   }
 
-
- // module UninitReg1 :
- //   input clock: Clock
- //   input reset : UInt<1>
- //   input cond: UInt<1>
- //   input value: UInt<2>
- //   reg count : UInt<2>, clock with :
- //     reset => (UInt<1>("h0"), count)
- //   node x = count
- //   node _GEN_0 = mux(cond, value, count)
- //   count <= mux(reset, UInt<2>("h0"), _GEN_0)
-
-  // CHECK-LABEL: hw.module private @UninitReg1(%clock: i1, %reset: i1, %cond: i1, %value: i2) {
-
-  firrtl.module private @UninitReg1(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>,
-                            in %cond: !firrtl.uint<1>, in %value: !firrtl.uint<2>) {
-    // CHECK-NEXT: %c0_i2 = hw.constant 0 : i2
-    %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
-    // CHECK-NEXT: %count = sv.reg sym @count : !hw.inout<i2>
-    // CHECK-NEXT: %0 = sv.read_inout %count : !hw.inout<i2>
-    %count = firrtl.reg %clock {name = "count", annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<2>
-
-    // CHECK-NEXT: sv.ifdef "SYNTHESIS"  {
-    // CHECK-NEXT:   } else {
-    // CHECK-NEXT:     sv.ordered {
-    // CHECK-NEXT:       sv.ifdef "RANDOMIZE_REG_INIT" {
-    // CHECK-NEXT:         %[[RANDOM:.+]] = sv.reg sym @[[RANDOM_SYM:[_A-Za-z0-9]+]] {{.+}}
-    // CHECK-NEXT:       }
-    // CHECK-NEXT:       sv.ifdef "FIRRTL_BEFORE_INITIAL" {
-    // CHECK-NEXT:         sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
-    // CHECK-NEXT:       }
-    // CHECK-NEXT:       sv.initial {
-    // CHECK-NEXT:       sv.verbatim "`INIT_RANDOM_PROLOG_"
-    // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
-    // CHECK-NEXT:          sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@UninitReg1::@[[RANDOM_SYM]]>]}
-    // CHECK-NEXT:          sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}}[1:0];" {symbols = [#hw.innerNameRef<@UninitReg1::@count>, #hw.innerNameRef<@UninitReg1::@[[RANDOM_SYM]]>]}
-    // CHECK-NEXT:        }
-    // CHECK-NEXT:       }
-    // CHECK-NEXT:       sv.ifdef "FIRRTL_AFTER_INITIAL" {
-    // CHECK-NEXT:         sv.verbatim "`FIRRTL_AFTER_INITIAL" {symbols = []}
-    // CHECK-NEXT:       }
-    // CHECK-NEXT:    }
-    // CHECK-NEXT:  }
-
-    // CHECK-NEXT: %1 = comb.mux %cond, %value, %0 : i2
-    // CHECK-NEXT: %2 = comb.mux %reset, %c0_i2, %1 : i2
-    %4 = firrtl.mux(%cond, %value, %count) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
-    %5 = firrtl.mux(%reset, %c0_ui2, %4) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
-
-    // CHECK-NEXT: sv.always posedge %clock {
-    // CHECK-NEXT:   sv.passign %count, %2 : i2
-    // CHECK-NEXT: }
-    firrtl.connect %count, %5 : !firrtl.uint<2>, !firrtl.uint<2>
-
-    // CHECK-NEXT: hw.output
-  }
-
-  // module InitReg1 :
-  //     input clock : Clock
-  //     input reset : UInt<1>
-  //     input io_d : UInt<32>
-  //     output io_q : UInt<32>
-  //     input io_en : UInt<1>
-  //
-  //     node _T = asAsyncReset(reset)
-  //     reg reg : UInt<32>, clock with :
-  //       reset => (_T, UInt<32>("h0"))
-  //     io_q <= reg
-  //     reg <= mux(io_en, io_d, reg)
-
-  // CHECK-LABEL: hw.module private @InitReg1(
-  firrtl.module private @InitReg1(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>,
-                          in %io_d: !firrtl.uint<32>, in %io_en: !firrtl.uint<1>,
-                          out %io_q: !firrtl.uint<32>) {
-    // CHECK:      %c1_i32 = hw.constant 1 : i32
-    // CHECK-NEXT: %c0_i32 = hw.constant 0 : i32
-    %c0_ui32 = firrtl.constant 0 : !firrtl.uint<32>
-    %c1_ui32 = firrtl.constant 1 : !firrtl.uint<32>
-
-    %4 = firrtl.asAsyncReset %reset : (!firrtl.uint<1>) -> !firrtl.asyncreset
-
-    // CHECK-NEXT: %reg = sv.reg sym @[[reg_sym:.+]] : !hw.inout<i32>
-    // CHECK-NEXT: %0 = sv.read_inout %reg : !hw.inout<i32>
-    // CHECK-NEXT: %reg2 = sv.reg sym @[[reg2_sym:.+]] : !hw.inout<i32>
-    // CHECK-NEXT: %1 = sv.read_inout %reg2 : !hw.inout<i32>
-    // CHECK-NEXT: sv.always posedge %clock  {
-    // CHECK-NEXT:   sv.if %reset  {
-    // CHECK-NEXT:     sv.passign %reg2, %c0_i32 : i32
-    // CHECK-NEXT:   } else  {
-    // CHECK-NEXT:   }
-    // CHECK-NEXT: }
-    // CHECK-NEXT: %reg3 = sv.reg sym @[[reg3_sym:.+]] : !hw.inout<i32
-    // CHECK-NEXT: sv.ifdef "SYNTHESIS"  {
-    // CHECK-NEXT: } else {
-    // CHECK-NEXT:   sv.ordered {
-    // CHECK-NEXT:     sv.ifdef "RANDOMIZE_REG_INIT" {
-    // CHECK-NEXT:       %[[RANDOM:.+]] = sv.reg sym @[[RANDOM_SYM:[_A-Za-z0-9]+]] {{.+}}
-    // CHECK-NEXT:       %[[RANDOM_2:.+]] = sv.reg sym @[[RANDOM_2_SYM:[_A-Za-z0-9]+]] {{.+}}
-    // CHECK-NEXT:       %[[RANDOM_3:.+]] = sv.reg sym @[[RANDOM_3_SYM:[_A-Za-z0-9]+]] {{.+}}
-    // CHECK-NEXT:     }
-    // CHECK-NEXT:     sv.ifdef "FIRRTL_BEFORE_INITIAL" {
-    // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
-    // CHECK-NEXT:     }
-    // CHECK-NEXT:     sv.initial {
-    // CHECK-NEXT:       sv.verbatim "`INIT_RANDOM_PROLOG_"
-    // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
-    // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@InitReg1::@[[RANDOM_SYM]]>]}
-    // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}};" {symbols = [#hw.innerNameRef<@InitReg1::@[[reg_sym]]>, #hw.innerNameRef<@InitReg1::@[[RANDOM_SYM]]>]}
-    // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@InitReg1::@[[RANDOM_2_SYM]]>]}
-    // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}};" {symbols = [#hw.innerNameRef<@InitReg1::@[[reg2_sym]]>, #hw.innerNameRef<@InitReg1::@[[RANDOM_2_SYM]]>]}
-    // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@InitReg1::@[[RANDOM_3_SYM]]>]}
-    // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}};" {symbols = [#hw.innerNameRef<@InitReg1::@[[reg3_sym]]>, #hw.innerNameRef<@InitReg1::@[[RANDOM_3_SYM]]>]}
-    // CHECK-NEXT:       }
-    // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE"  {
-    // CHECK-NEXT:         sv.if %reset {
-    // CHECK-NEXT:           sv.bpassign %reg, %c0_i32 : i32
-    // CHECK-NEXT:           sv.bpassign %reg3, %c1_i32 : i32
-    // CHECK-NEXT:         }
-    // CHECK-NEXT:       }
-    // CHECK-NEXT:     }
-    // CHECK-NEXT:     sv.ifdef "FIRRTL_AFTER_INITIAL" {
-    // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL" {symbols = []}
-    // CHECK-NEXT:     }
-    // CHECK-NEXT:   }
-    // CHECK-NEXT: }
-    // CHECK-NEXT: %2 = comb.concat %false, %0 : i1, i32
-    // CHECK-NEXT: %3 = comb.concat %false, %1 : i1, i32
-    // CHECK-NEXT: %4 = comb.add %2, %3 : i33
-    // CHECK-NEXT: %5 = comb.extract %4 from 1 : (i33) -> i32
-    // CHECK-NEXT: %6 = comb.mux %io_en, %io_d, %5 : i32
-    // CHECK-NEXT: sv.always posedge %clock, posedge %reset  {
-    // CHECK-NEXT:   sv.if %reset  {
-    // CHECK-NEXT:     sv.passign %reg, %c0_i32 : i32
-    // CHECK-NEXT:     sv.passign %reg3, %c1_i32 : i32
-    // CHECK-NEXT:   } else  {
-    // CHECK-NEXT:     sv.passign %reg, %6 : i32
-    // CHECK-NEXT:   }
-    // CHECK-NEXT: }
-    %reg = firrtl.regreset %clock, %4, %c0_ui32 {name = "reg"} : !firrtl.asyncreset, !firrtl.uint<32>, !firrtl.uint<32>
-    %reg2 = firrtl.regreset %clock, %reset, %c0_ui32 {name = "reg2"} : !firrtl.uint<1>, !firrtl.uint<32>, !firrtl.uint<32>
-    %reg3 = firrtl.regreset %clock, %4, %c1_ui32 {name = "reg3"} : !firrtl.asyncreset, !firrtl.uint<32>, !firrtl.uint<32>
-
-    %sum = firrtl.add %reg, %reg2 : (!firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<33>
-    %shorten = firrtl.head %sum, 32 : (!firrtl.uint<33>) -> !firrtl.uint<32>
-    %5 = firrtl.mux(%io_en, %io_d, %shorten) : (!firrtl.uint<1>, !firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>
-
-    firrtl.connect %reg, %5 : !firrtl.uint<32>, !firrtl.uint<32>
-    firrtl.connect %io_q, %reg: !firrtl.uint<32>, !firrtl.uint<32>
-
-    // CHECK-NEXT: hw.output %0 : i32
-  }
-
   //  module MemSimple :
   //     input clock1  : Clock
   //     input clock2  : Clock
@@ -1029,65 +877,12 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.connect %tmp59, %0 : !firrtl.sint<2>, !firrtl.sint<1>
   }
 
-   // CHECK-LABEL: hw.module private @UninitReg42(%clock: i1, %reset: i1, %cond: i1, %value: i42) {
-
-  firrtl.module private @UninitReg42(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>,
-                            in %cond: !firrtl.uint<1>, in %value: !firrtl.uint<42>) {
-    %c0_ui42 = firrtl.constant 0 : !firrtl.uint<42>
-    // CHECK: %count = sv.reg sym @count : !hw.inout<i42>
-    %count = firrtl.reg %clock {name = "count", annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<42>
-
-    // CHECK: sv.ifdef "SYNTHESIS"  {
-    // CHECK-NEXT:   } else {
-    // CHECK-NEXT:    sv.ordered {
-    // CHECK-NEXT:      sv.ifdef "RANDOMIZE_REG_INIT" {
-    // CHECK-NEXT:        %[[RANDOM_0:.+]] = sv.reg sym @[[RANDOM_0_SYM:[_A-Za-z0-9]+]] {{.+}}
-    // CHECK-NEXT:        %[[RANDOM_1:.+]] = sv.reg sym @[[RANDOM_1_SYM:[_A-Za-z0-9]+]] {{.+}}
-    // CHECK-NEXT:      }
-    // CHECK-NEXT:      sv.ifdef "FIRRTL_BEFORE_INITIAL" {
-    // CHECK-NEXT:        sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
-    // CHECK-NEXT:      }
-    // CHECK-NEXT:      sv.initial {
-    // CHECK-NEXT:      sv.verbatim "`INIT_RANDOM_PROLOG_"
-    // CHECK-NEXT:      sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
-    // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@UninitReg42::@[[RANDOM_0_SYM]]>]}
-    // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@UninitReg42::@[[RANDOM_1_SYM]]>]}
-    // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{][{]1[}][}]}}[9:0], {{[{][{]2[}][}][}]}};" {symbols = [#hw.innerNameRef<@UninitReg42::@count>, #hw.innerNameRef<@UninitReg42::@[[RANDOM_1_SYM]]>, #hw.innerNameRef<@UninitReg42::@[[RANDOM_0_SYM]]>]}
-    // CHECK-NEXT:       }
-    // CHECK-NEXT:      }
-    // CHECK-NEXT:      sv.ifdef "FIRRTL_AFTER_INITIAL" {
-    // CHECK-NEXT:        sv.verbatim "`FIRRTL_AFTER_INITIAL" {symbols = []}
-    // CHECK-NEXT:      }
-    // CHECK-NEXT:    }
-    // CHECK-NEXT:  }
-
-    %4 = firrtl.mux(%cond, %value, %count) : (!firrtl.uint<1>, !firrtl.uint<42>, !firrtl.uint<42>) -> !firrtl.uint<42>
-    %5 = firrtl.mux(%reset, %c0_ui42, %4) : (!firrtl.uint<1>, !firrtl.uint<42>, !firrtl.uint<42>) -> !firrtl.uint<42>
-
-    firrtl.connect %count, %5 : !firrtl.uint<42>, !firrtl.uint<42>
-  }
-
   // CHECK-LABEL: issue1303
   firrtl.module private @issue1303(out %out: !firrtl.reset) {
     %c1_ui = firrtl.constant 1 : !firrtl.uint<1>
     firrtl.connect %out, %c1_ui : !firrtl.reset, !firrtl.uint<1>
     // CHECK-NEXT: %true = hw.constant true
     // CHECK-NEXT: hw.output %true
-  }
-
-  // CHECK-LABEL: issue1594
-  // Make sure LowerToHW's merging of always blocks kicks in for this example.
-  firrtl.module private @issue1594(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
-    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    %reset_n = firrtl.wire  : !firrtl.uint<1>
-    %0 = firrtl.not %reset : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.connect %reset_n, %0 : !firrtl.uint<1>, !firrtl.uint<1>
-    %r = firrtl.regreset %clock, %reset_n, %c0_ui1  : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
-    firrtl.connect %r, %a : !firrtl.uint<1>, !firrtl.uint<1>
-    firrtl.connect %b, %r : !firrtl.uint<1>, !firrtl.uint<1>
-    // CHECK: sv.always posedge %clock
-    // CHECK-NOT: sv.always
-    // CHECK: hw.output
   }
 
   // CHECK-LABEL: hw.module private @Force
@@ -1238,119 +1033,12 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %wireName = firrtl.wire sym @wireSym : !firrtl.uint<42>
     // CHECK: %wireName = sv.wire sym @wireSym : !hw.inout<i42>
     %regName = firrtl.reg sym @regSym %clock : !firrtl.uint<42>
-    // CHECK: %regName = sv.reg sym @regSym : !hw.inout<i42>
+    // CHECK: %regName = seq.firreg %regName clock %clock sym @regSym : i42
     %regResetName = firrtl.regreset sym @regResetSym %clock, %reset, %value : !firrtl.uint<1>, !firrtl.uint<42>, !firrtl.uint<42>
-    // CHECK: %regResetName = sv.reg sym @regResetSym : !hw.inout<i42>
+    // CHECK: %regResetName = seq.firreg %regResetName clock %clock sym @regResetSym reset sync %reset, %value : i42
     %memName_port = firrtl.mem sym @memSym Undefined {depth = 12 : i64, name = "memName", portNames = ["port"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     // CHECK: {{%.+}} = hw.instance "memName_ext" sym @memSym
     firrtl.connect %out, %reset : !firrtl.uint<1>, !firrtl.uint<1>
-  }
-
-  // CHECK-LABEL: hw.module private @regInitRandomReuse
-  firrtl.module private @regInitRandomReuse(in %clock: !firrtl.clock, in %a: !firrtl.uint<1>, out %o1: !firrtl.uint<2>, out %o2: !firrtl.uint<4>, out %o3: !firrtl.uint<32>, out %o4: !firrtl.uint<100>) {
-    %r1 = firrtl.reg %clock  : !firrtl.uint<2>
-    %r2 = firrtl.reg %clock  : !firrtl.uint<4>
-    %r3 = firrtl.reg %clock  : !firrtl.uint<32>
-    %r4 = firrtl.reg %clock  : !firrtl.uint<100>
-    // CHECK:      %r1 = sv.reg sym @[[r1_sym:[_A-Za-z0-9]+]]
-    // CHECK:      %r2 = sv.reg sym @[[r2_sym:[_A-Za-z0-9]+]]
-    // CHECK:      %r3 = sv.reg sym @[[r3_sym:[_A-Za-z0-9]+]]
-    // CHECK:      %r4 = sv.reg sym @[[r4_sym:[_A-Za-z0-9]+]]
-    // CHECK:      sv.ifdef "SYNTHESIS" {
-    // CHECK-NEXT: } else {
-    // CHECK-NEXT:   sv.ordered {
-    // CHECK-NEXT:     sv.ifdef "RANDOMIZE_REG_INIT" {
-    // CHECK-NEXT:       %[[RANDOM_0:.+]] = sv.reg sym @[[RANDOM_0_SYM:[_A-Za-z0-9]+]]
-    // CHECK-NEXT:       %[[RANDOM_1:.+]] = sv.reg sym @[[RANDOM_1_SYM:[_A-Za-z0-9]+]]
-    // CHECK-NEXT:       %[[RANDOM_2:.+]] = sv.reg sym @[[RANDOM_2_SYM:[_A-Za-z0-9]+]]
-    // CHECK-NEXT:       %[[RANDOM_3:.+]] = sv.reg sym @[[RANDOM_3_SYM:[_A-Za-z0-9]+]]
-    // CHECK-NEXT:       %[[RANDOM_4:.+]] = sv.reg sym @[[RANDOM_4_SYM:[_A-Za-z0-9]+]]{{.+}}
-    // CHECK-NEXT:     }
-    // CHECK-NEXT:     sv.ifdef "FIRRTL_BEFORE_INITIAL" {
-    // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
-    // CHECK-NEXT:     }
-    // CHECK-NEXT:     sv.initial {
-    // CHECK-NEXT:       sv.verbatim "`INIT_RANDOM_PROLOG_"
-    // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
-    // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_0_SYM]]>]}
-    // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}}[1:0];" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[r1_sym]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_0_SYM]]>]}
-    // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{][{]1[}][}]}}[5:2];" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[r2_sym]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_0_SYM]]>]}
-    // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_1_SYM]]>]}
-    // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{]}}{{[{][{]1[}][}]}}[5:0], {{[{][{]2[}][}]}}[31:6]{{[}]}};" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[r3_sym]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_1_SYM]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_0_SYM]]>]}
-    // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_2_SYM]]>]}
-    // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_3_SYM]]>]}
-    // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_4_SYM]]>]}
-    // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {{[{]}}{{[{][{]1[}][}]}}[9:0], {{[{][{]2[}][}]}}, {{[{][{]3[}][}]}}, {{[{][{]4[}][}]}}[31:6]{{[}]}};" {symbols = [#hw.innerNameRef<@regInitRandomReuse::@[[r4_sym]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_4_SYM]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_3_SYM]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_2_SYM]]>, #hw.innerNameRef<@regInitRandomReuse::@[[RANDOM_1_SYM]]>]}
-    // CHECK-NEXT:       }
-    // CHECK-NEXT:     }
-    // CHECK-NEXT:     sv.ifdef "FIRRTL_AFTER_INITIAL" {
-    // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL" {symbols = []}
-    // CHECK-NEXT:     }
-    // CHECK-NEXT:   }
-    // CHECK-NEXT: }
-    firrtl.connect %r1, %a : !firrtl.uint<2>, !firrtl.uint<1>
-    firrtl.connect %r2, %a : !firrtl.uint<4>, !firrtl.uint<1>
-    firrtl.connect %r3, %a : !firrtl.uint<32>, !firrtl.uint<1>
-    firrtl.connect %r4, %a : !firrtl.uint<100>, !firrtl.uint<1>
-    firrtl.connect %o1, %r1 : !firrtl.uint<2>, !firrtl.uint<2>
-    firrtl.connect %o2, %r2 : !firrtl.uint<4>, !firrtl.uint<4>
-    firrtl.connect %o3, %r3 : !firrtl.uint<32>, !firrtl.uint<32>
-    firrtl.connect %o4, %r4 : !firrtl.uint<100>, !firrtl.uint<100>
-  }
-
-  // CHECK-LABEL: hw.module private @init1DVector
-  firrtl.module private @init1DVector(in %clock: !firrtl.clock, in %a: !firrtl.vector<uint<1>, 2>, out %b: !firrtl.vector<uint<1>, 2>) {
-    %r = firrtl.reg %clock  : !firrtl.vector<uint<1>, 2>
-    // CHECK:      %r = sv.reg sym @[[r_sym:[_A-Za-z0-9]+]]
-    // CHECK:      sv.ifdef "SYNTHESIS" {
-    // CHECK-NEXT: } else {
-    // CHECK-NEXT:   sv.ordered {
-    // CHECK-NEXT:     sv.ifdef "RANDOMIZE_REG_INIT" {
-    // CHECK-NEXT:       %[[RANDOM:.+]] = sv.reg sym @[[RANDOM_SYM:[_A-Za-z0-9]+]]{{.+}}
-    // CHECK-NEXT:     }
-    // CHECK-NEXT:     sv.ifdef "FIRRTL_BEFORE_INITIAL" {
-    // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
-    // CHECK-NEXT:     }
-    // CHECK-NEXT:     sv.initial {
-    // CHECK-NEXT:       sv.verbatim "`INIT_RANDOM_PROLOG_"
-    // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
-    // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@init1DVector::@[[RANDOM_SYM]]>]}
-    // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}}[0] = {{[{][{]1[}][}]}}[0];" {symbols = [#hw.innerNameRef<@init1DVector::@[[r_sym]]>, #hw.innerNameRef<@init1DVector::@[[RANDOM_SYM]]>]}
-    // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}}[1] = {{[{][{]1[}][}]}}[1];" {symbols = [#hw.innerNameRef<@init1DVector::@[[r_sym]]>, #hw.innerNameRef<@init1DVector::@[[RANDOM_SYM]]>]}
-    // CHECK-NEXT:       }
-    // CHECK-NEXT:     }
-    // CHECK-NEXT:     sv.ifdef "FIRRTL_AFTER_INITIAL" {
-    // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL" {symbols = []}
-    // CHECK-NEXT:     }
-    // CHECK-NEXT:   }
-    // CHECK-NEXT: }
-
-    firrtl.connect %r, %a : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
-    firrtl.connect %b, %r : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
-    // CHECK:      sv.always posedge %clock  {
-    // CHECK-NEXT:   sv.passign %r, %a : !hw.array<2xi1>
-    // CHECK-NEXT: }
-    // CHECK-NEXT: hw.output %0 : !hw.array<2xi1>
-  }
-
-  // CHECK-LABEL: hw.module private @init2DVector
-  firrtl.module private @init2DVector(in %clock: !firrtl.clock, in %a: !firrtl.vector<vector<uint<1>, 1>, 1>, out %b: !firrtl.vector<vector<uint<1>, 1>, 1>) {
-    %r = firrtl.reg %clock  : !firrtl.vector<vector<uint<1>, 1>, 1>
-    // CKECK-NEXT: sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
-    // CKECK-NEXT:   %1 = sv.array_index_inout %r[%false] : !hw.inout<array<1xarray<1xi1>>>, i1
-    // CKECK-NEXT:   %2 = sv.array_index_inout %1[%false] : !hw.inout<array<1xi1>>, i1
-    // CKECK-NEXT:   %RANDOM = sv.verbatim.expr.se "`RANDOM" : () -> i32 {symbols = []}
-    // CKECK-NEXT:   %3 = comb.extract %RANDOM from 0 : (i32) -> i1
-    // CKECK-NEXT:   sv.bpassign %2, %3 : i1
-    // CKECK-NEXT: }
-
-    firrtl.connect %r, %a : !firrtl.vector<vector<uint<1>, 1>, 1>, !firrtl.vector<vector<uint<1>, 1>, 1>
-    firrtl.connect %b, %r : !firrtl.vector<vector<uint<1>, 1>, 1>, !firrtl.vector<vector<uint<1>, 1>, 1>
-
-    // CHECK:      sv.always posedge %clock  {
-    // CHECK-NEXT:   sv.passign %r, %a : !hw.array<1xarray<1xi1>>
-    // CHECK-NEXT: }
-    // CHECK-NEXT: hw.output %0 : !hw.array<1xarray<1xi1>>
   }
 
   // CHECK-LABEL: hw.module private @connectNarrowUIntVector
@@ -1358,16 +1046,14 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %r1 = firrtl.reg %clock  : !firrtl.vector<uint<2>, 1>
     firrtl.connect %r1, %a : !firrtl.vector<uint<2>, 1>, !firrtl.vector<uint<1>, 1>
     firrtl.connect %b, %r1 : !firrtl.vector<uint<3>, 1>, !firrtl.vector<uint<2>, 1>
-    // CHECK:      %2 = hw.array_get %a[%false] : !hw.array<1xi1>
-    // CHECK-NEXT: %3 = comb.concat %false, %2 : i1, i1
-    // CHECK-NEXT: %4 = hw.array_create %3 : i2
-    // CHECK-NEXT: sv.always posedge %clock  {
-    // CHECK-NEXT:   sv.passign %r1, %4 : !hw.array<1xi2>
-    // CHECK-NEXT: }
-    // CHECK-NEXT: %5 = hw.array_get %1[%false] : !hw.array<1xi2>
-    // CHECK-NEXT: %6 = comb.concat %false, %5 : i1, i2
-    // CHECK-NEXT: %7 = hw.array_create %6 : i3
-    // CHECK-NEXT: sv.assign %.b.output, %7 : !hw.array<1xi3>
+    // CHECK:      %r1 = seq.firreg %3 clock %clock : !hw.array<1xi2>
+    // CHECK-NEXT: %1 = hw.array_get %a[%false] : !hw.array<1xi1>
+    // CHECK-NEXT: %2 = comb.concat %false, %1 : i1, i1
+    // CHECK-NEXT: %3 = hw.array_create %2 : i2
+    // CHECK-NEXT: %4 = hw.array_get %r1[%false] : !hw.array<1xi2>
+    // CHECK-NEXT: %5 = comb.concat %false, %4 : i1, i2
+    // CHECK-NEXT: %6 = hw.array_create %5 : i3
+    // CHECK-NEXT: sv.assign %.b.output, %6 : !hw.array<1xi3>
     // CHECK-NEXT: hw.output %0 : !hw.array<1xi3>
   }
 
@@ -1376,17 +1062,15 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %r1 = firrtl.reg %clock  : !firrtl.vector<sint<2>, 1>
     firrtl.connect %r1, %a : !firrtl.vector<sint<2>, 1>, !firrtl.vector<sint<1>, 1>
     firrtl.connect %b, %r1 : !firrtl.vector<sint<3>, 1>, !firrtl.vector<sint<2>, 1>
-    // CHECK:      %2 = hw.array_get %a[%false] : !hw.array<1xi1>
-    // CHECK-NEXT: %3 = comb.concat %2, %2 : i1, i1
-    // CHECK-NEXT: %4 = hw.array_create %3 : i2
-    // CHECK-NEXT: sv.always posedge %clock  {
-    // CHECK-NEXT:   sv.passign %r1, %4 : !hw.array<1xi2>
-    // CHECK-NEXT: }
-    // CHECK-NEXT: %5 = hw.array_get %1[%false] : !hw.array<1xi2>
-    // CHECK-NEXT: %6 = comb.extract %5 from 1 : (i2) -> i1
-    // CHECK-NEXT: %7 = comb.concat %6, %5 : i1, i2
-    // CHECK-NEXT: %8 = hw.array_create %7 : i3
-    // CHECK-NEXT: sv.assign %.b.output, %8 : !hw.array<1xi3>
+    // CHECK:      %r1 = seq.firreg %3 clock %clock : !hw.array<1xi2>
+    // CHECK-NEXT: %1 = hw.array_get %a[%false] : !hw.array<1xi1>
+    // CHECK-NEXT: %2 = comb.concat %1, %1 : i1, i1
+    // CHECK-NEXT: %3 = hw.array_create %2 : i2
+    // CHECK-NEXT: %4 = hw.array_get %r1[%false] : !hw.array<1xi2>
+    // CHECK-NEXT: %5 = comb.extract %4 from 1 : (i2) -> i1
+    // CHECK-NEXT: %6 = comb.concat %5, %4 : i1, i2
+    // CHECK-NEXT: %7 = hw.array_create %6 : i3
+    // CHECK-NEXT: sv.assign %.b.output, %7 : !hw.array<1xi3>
     // CHECK-NEXT: hw.output %0 : !hw.array<1xi3>
   }
 
@@ -1400,13 +1084,11 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.connect %r2, %0 : !firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 1>
     firrtl.connect %o1, %r1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %o2, %r2 : !firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 1>
-    // CHECK:      %2 = hw.array_get %a[%false] : !hw.array<1xarray<1xi1>>
-    // CHECK-NEXT: %3 = hw.array_get %2[%false] : !hw.array<1xi1>
-    // CHECK-NEXT: sv.always posedge %clock  {
-    // CHECK-NEXT:   sv.passign %r1, %3 : i1
-    // CHECK-NEXT:   sv.passign %r2, %2 : !hw.array<1xi1>
-    // CHECK-NEXT: }
-    // CHECK-NEXT: hw.output %0, %1 : i1, !hw.array<1xi1>
+    // CHECK:      %r1 = seq.firreg %1 clock %clock : i1
+    // CHECK-NEXT: %r2 = seq.firreg %0 clock %clock : !hw.array<1xi1>
+    // CHECK-NEXT: %0 = hw.array_get %a[%false] : !hw.array<1xarray<1xi1>>
+    // CHECK-NEXT: %1 = hw.array_get %0[%false] : !hw.array<1xi1>
+    // CHECK-NEXT: hw.output %r1, %r2 : i1, !hw.array<1xi1>
   }
 
   // CHECK-LABEL: hw.module private @SubAccess
@@ -1419,13 +1101,11 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.connect %r2, %0 : !firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 1>
     firrtl.connect %o1, %r1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %o2, %r2 : !firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 1>
-    // CHECK:      %2 = hw.array_get %a[%x] : !hw.array<1xarray<1xi1>>
-    // CHECK-NEXT: %3 = hw.array_get %2[%y] : !hw.array<1xi1>
-    // CHECK-NEXT: sv.always posedge %clock  {
-    // CHECK-NEXT:   sv.passign %r1, %3 : i1
-    // CHECK-NEXT:   sv.passign %r2, %2 : !hw.array<1xi1>
-    // CHECK-NEXT: }
-    // CHECK-NEXT: hw.output %0, %1 : i1, !hw.array<1xi1>
+    // CHECK:      %r1 = seq.firreg %1 clock %clock : i1
+    // CHECK-NEXT: %r2 = seq.firreg %0 clock %clock : !hw.array<1xi1>
+    // CHECK-NEXT: %0 = hw.array_get %a[%x] : !hw.array<1xarray<1xi1>>
+    // CHECK-NEXT: %1 = hw.array_get %0[%y] : !hw.array<1xi1>
+    // CHECK-NEXT: hw.output %r1, %r2 : i1, !hw.array<1xi1>
   }
 
   // CHECK-LABEL: hw.module private @SubindexDestination
@@ -1491,46 +1171,13 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: hw.output %0 : !hw.struct<a: !hw.struct<b: !hw.struct<c: i1>>>
   }
 
-  // CHECK-LABEL: hw.module private @initStruct
-  firrtl.module private @initStruct(in %clock: !firrtl.clock) {
-    %r = firrtl.reg %clock  : !firrtl.bundle<a: uint<1>>
-    // CHECK:      %r = sv.reg sym @[[r_sym:[_A-Za-z0-9]+]]
-    // CHECK:      sv.ifdef "SYNTHESIS" {
-    // CHECK-NEXT: } else {
-    // CHECK-NEXT:   sv.ordered {
-    // CHECK-NEXT:     sv.ifdef "RANDOMIZE_REG_INIT" {
-    // CHECK-NEXT:       %[[RANDOM:.+]] = sv.reg sym @[[RANDOM_SYM:[_A-Za-z0-9]+]]{{.+}}
-    // CHECK-NEXT:     }
-    // CHECK-NEXT:     sv.ifdef "FIRRTL_BEFORE_INITIAL" {
-    // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL" {symbols = []}
-    // CHECK-NEXT:     }
-    // CHECK-NEXT:     sv.initial {
-    // CHECK-NEXT:       sv.verbatim "`INIT_RANDOM_PROLOG_"
-    // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
-    // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}} = {`RANDOM};" {symbols = [#hw.innerNameRef<@initStruct::@[[RANDOM_SYM]]>]}
-    // CHECK-NEXT:         sv.verbatim "{{[{][{]0[}][}]}}.a = {{[{][{]1[}][}]}}[0];" {symbols = [#hw.innerNameRef<@initStruct::@[[r_sym]]>, #hw.innerNameRef<@initStruct::@[[RANDOM_SYM]]>]}
-    // CHECK-NEXT:       }
-    // CHECK-NEXT:     }
-    // CHECK-NEXT:     sv.ifdef "FIRRTL_AFTER_INITIAL" {
-    // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL" {symbols = []}
-    // CHECK-NEXT:     }
-    // CHECK-NEXT:   }
-    // CHECK-NEXT: }
-  }
-
   // CHECK-LABEL: hw.module private @RegResetStructWiden
   firrtl.module private @RegResetStructWiden(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %init: !firrtl.bundle<a: uint<2>>) {
     // CHECK:      [[FALSE:%.*]] = hw.constant false
     // CHECK-NEXT: [[A:%.*]] = hw.struct_extract %init["a"] : !hw.struct<a: i2>
     // CHECK-NEXT: [[PADDED:%.*]] = comb.concat [[FALSE]], [[A]] : i1, i2
     // CHECK-NEXT: [[STRUCT:%.*]] = hw.struct_create ([[PADDED]]) : !hw.struct<a: i3>
-    // CHECK-NEXT: %reg = sv.reg {{.+}}  : !hw.inout<struct<a: i3>>
-    // CHECK-NEXT: sv.always posedge %clock  {
-    // CHECK-NEXT:   sv.if %reset  {
-    // CHECK-NEXT:     sv.passign %reg, [[STRUCT]] : !hw.struct<a: i3>
-    // CHECK-NEXT:   } else  {
-    // CHECK-NEXT:   }
-    // CHECK-NEXT: }
+    // CHECK-NEXT: %reg = seq.firreg %reg clock %clock reset sync %reset, %2 : !hw.struct<a: i3>
     %reg = firrtl.regreset %clock, %reset, %init  : !firrtl.uint<1>, !firrtl.bundle<a: uint<2>>, !firrtl.bundle<a: uint<3>>
   }
 
@@ -1553,13 +1200,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %reg = firrtl.regreset %clock, %reset, %invalid : !firrtl.uint<1>, !firrtl.bundle<a: uint<1>, b: vector<uint<10>, 10>>, !firrtl.bundle<a: uint<1>, b: vector<uint<10>, 10>>
     // CHECK:      %c0_i101 = hw.constant 0 : i101
     // CHECK-NEXT: %0 = hw.bitcast %c0_i101 : (i101) -> !hw.struct<a: i1, b: !hw.array<10xi10>>
-    // CHECK-NEXT: %reg = sv.reg {{.+}} : !hw.inout<struct<a: i1, b: !hw.array<10xi10>>>
-    // CHECK-NEXT: sv.always posedge %clock  {
-    // CHECK-NEXT:   sv.if %reset  {
-    // CHECK-NEXT:     sv.passign %reg, %0 : !hw.struct<a: i1, b: !hw.array<10xi10>>
-    // CHECK-NEXT:   } else  {
-    // CHECK-NEXT:   }
-    // CHECK-NEXT: }
+    // CHECK-NEXT: %reg = seq.firreg %reg clock %clock reset sync %reset, %0 : !hw.struct<a: i1, b: !hw.array<10xi10>>
   }
 
   // CHECK-LABEL: hw.module private @AggregateRegAssign
@@ -1567,8 +1208,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %reg = firrtl.reg %clock : !firrtl.vector<uint<1>, 1>
     %reg_0 = firrtl.subindex %reg[0] : !firrtl.vector<uint<1>, 1>
     firrtl.connect %reg_0, %value : !firrtl.uint<1>, !firrtl.uint<1>
-    // CHECK:  %0 = sv.array_index_inout %reg[%false] : !hw.inout<array<1xi1>>, i1
-    // CHECK:  sv.passign %0, %value : i1
+    // CHECK: %reg = seq.firreg [[INPUT:%.+]] clock %clock : !hw.array<1xi1>
+    // CHECK: [[INPUT]] = hw.array_create %value : i1
   }
 
   // CHECK-LABEL: hw.module private @AggregateRegResetAssign
@@ -1577,8 +1218,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %reg = firrtl.regreset %clock, %reset, %init  : !firrtl.uint<1>, !firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 1>
     %reg_0 = firrtl.subindex %reg[0] : !firrtl.vector<uint<1>, 1>
     firrtl.connect %reg_0, %value : !firrtl.uint<1>, !firrtl.uint<1>
-    // CHECK:  %0 = sv.array_index_inout %reg[%false] : !hw.inout<array<1xi1>>, i1
-    // CHECK:  sv.passign %0, %value : i1
+    // CHECK: %reg = seq.firreg [[INPUT:%.+]] clock %clock reset sync %reset, %init : !hw.array<1xi1>
+    // CHECK: [[INPUT]] = hw.array_create %value : i1
   }
 
   // CHECK-LABEL: hw.module private @ForceNameSubmodule
@@ -1694,7 +1335,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // %cast accidentally still points to the back edge in the lowering table.
     firrtl.strictconnect %out, %cast : !firrtl.clock
   }
-  
+
   // Check that when inputs are connected to other inputs, the backedges are
   // properly resolved to the final real value.
   // CHECK-LABEL: hw.module @ChainedBackedges
@@ -1721,5 +1362,284 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %1 = firrtl.instance blackbox @Blackbox(in inst : !firrtl.uint<1>)
     firrtl.strictconnect %0, %1 : !firrtl.uint<1>
     firrtl.strictconnect %1, %0 : !firrtl.uint<1>
+  }
+
+  // CHECK-LABEL: hw.module @LowerToFirReg(%clock: i1, %reset: i1, %value: i2) -> (result: i2)
+  firrtl.module @LowerToFirReg(in %clock: !firrtl.clock,
+                     in %reset: !firrtl.uint<1>,
+                     in %value: !firrtl.uint<2>,
+                     out %result: !firrtl.uint<2>) {
+    %count = firrtl.reg %clock: !firrtl.uint<2>
+    // CHECK: %count = seq.firreg %value clock %clock : i2
+
+    firrtl.strictconnect %result, %count : !firrtl.uint<2>
+    firrtl.strictconnect %count, %value : !firrtl.uint<2>
+
+    // CHECK: hw.output %count : i2
+  }
+
+  // CHECK-LABEL: hw.module @ConnectSubfield(%clock: i1, %reset: i1, %value: i2) -> (result: !hw.struct<a: i2>)
+  firrtl.module @ConnectSubfield(in %clock: !firrtl.clock,
+                                 in %reset: !firrtl.uint<1>,
+                                 in %value: !firrtl.uint<2>,
+                                 out %result: !firrtl.bundle<a: uint<2>>) {
+    %count = firrtl.reg %clock: !firrtl.bundle<a: uint<2>>
+    // CHECK: %count = seq.firreg %1 clock %clock : !hw.struct<a: i2>
+
+    firrtl.strictconnect %result, %count : !firrtl.bundle<a: uint<2>>
+    %field = firrtl.subfield %count(0) : (!firrtl.bundle<a: uint<2>>) -> !firrtl.uint<2>
+    firrtl.strictconnect %field, %value : !firrtl.uint<2>
+
+    // CHECK: %1 = hw.struct_inject %count["a"], %value : !hw.struct<a: i2>
+
+    // CHECK: hw.output %count : !hw.struct<a: i2>
+  }
+
+  // CHECK-LABEL: hw.module @ConnectSubfields(%clock: i1, %reset: i1, %value2: i2, %value3: i3) -> (result: !hw.struct<a: i2, b: i3>)
+  firrtl.module @ConnectSubfields(in %clock: !firrtl.clock,
+                                 in %reset: !firrtl.uint<1>,
+                                 in %value2: !firrtl.uint<2>,
+                                 in %value3: !firrtl.uint<3>,
+                                 out %result: !firrtl.bundle<a: uint<2>, b: uint<3>>) {
+    %count = firrtl.reg %clock: !firrtl.bundle<a: uint<2>, b: uint<3>>
+    // CHECK: %count = seq.firreg [[AFTER_B:%.+]] clock %clock : !hw.struct<a: i2, b: i3>
+
+    firrtl.strictconnect %result, %count : !firrtl.bundle<a: uint<2>, b: uint<3>>
+
+    %fieldA = firrtl.subfield %count(0) : (!firrtl.bundle<a: uint<2>, b: uint<3>>) -> !firrtl.uint<2>
+    firrtl.strictconnect %fieldA, %value2 : !firrtl.uint<2>
+    %fieldB = firrtl.subfield %count(1) : (!firrtl.bundle<a: uint<2>, b: uint<3>>) -> !firrtl.uint<3>
+    firrtl.strictconnect %fieldB, %value3 : !firrtl.uint<3>
+
+    // CHECK: [[AFTER_A:%.+]] = hw.struct_inject %count["a"], %value2 : !hw.struct<a: i2, b: i3>
+    // CHECK: [[AFTER_B]] = hw.struct_inject [[AFTER_A]]["b"], %value3 : !hw.struct<a: i2, b: i3>
+
+    // CHECK: hw.output %count : !hw.struct<a: i2, b: i3>
+  }
+
+  // CHECK-LABEL: hw.module @ConnectNestedSubfield(%clock: i1, %reset: i1, %value: i2) -> (result: !hw.struct<a: !hw.struct<b: i2>>)
+  firrtl.module @ConnectNestedSubfield(in %clock: !firrtl.clock,
+                                       in %reset: !firrtl.uint<1>,
+                                       in %value: !firrtl.uint<2>,
+                                       out %result: !firrtl.bundle<a: bundle<b: uint<2>>>) {
+    %count = firrtl.reg %clock: !firrtl.bundle<a: bundle<b: uint<2>>>
+    // CHECK: %count = seq.firreg %4 clock %clock : !hw.struct<a: !hw.struct<b: i2>>
+
+    firrtl.strictconnect %result, %count : !firrtl.bundle<a: bundle<b: uint<2>>>
+    %field0 = firrtl.subfield %count(0) : (!firrtl.bundle<a: bundle<b: uint<2>>>) -> !firrtl.bundle<b: uint<2>>
+    %field1 = firrtl.subfield %field0(0) : (!firrtl.bundle<b: uint<2>>) -> !firrtl.uint<2>
+    firrtl.strictconnect %field1, %value : !firrtl.uint<2>
+
+    // CHECK: %2 = hw.struct_extract %count["a"] : !hw.struct<a: !hw.struct<b: i2>>
+    // CHECK: %3 = hw.struct_inject %2["b"], %value : !hw.struct<b: i2>
+    // CHECK: %4 = hw.struct_inject %count["a"], %3 : !hw.struct<a: !hw.struct<b: i2>>
+
+    // CHECK: hw.output %count : !hw.struct<a: !hw.struct<b: i2>>
+  }
+
+  // CHECK-LABEL: hw.module @ConnectNestedFieldsAndIndices(%clock: i1, %reset: i1, %value: i2) -> (result: !hw.array<5xstruct<a: !hw.array<3xstruct<b: i2>>>>)
+  firrtl.module @ConnectNestedFieldsAndIndices(in %clock: !firrtl.clock,
+                                 in %reset: !firrtl.uint<1>,
+                                 in %value: !firrtl.uint<2>,
+                                 out %result: !firrtl.vector<bundle<a: vector<bundle<b: uint<2>>, 3>>, 5>) {
+    %count = firrtl.reg %clock: !firrtl.vector<bundle<a: vector<bundle<b: uint<2>>, 3>>, 5>
+    %field1 = firrtl.subindex %count[1] : !firrtl.vector<bundle<a: vector<bundle<b: uint<2>>, 3>>, 5>
+    %field2 = firrtl.subfield %field1(0) : (!firrtl.bundle<a: vector<bundle<b: uint<2>>, 3>>) -> !firrtl.vector<bundle<b: uint<2>>, 3>
+    %field3 = firrtl.subindex %field2[1] : !firrtl.vector<bundle<b: uint<2>>, 3>
+    %field4 = firrtl.subfield %field3(0) : (!firrtl.bundle<b: uint<2>>) -> !firrtl.uint<2>
+    firrtl.strictconnect %field4, %value : !firrtl.uint<2>
+
+    // CHECK: %count = seq.firreg %17 clock %clock : !hw.array<5xstruct<a: !hw.array<3xstruct<b: i2>>>>
+    // CHECK-DAG: %1 = hw.array_get %count[%c1_i3] : !hw.array<5xstruct<a: !hw.array<3xstruct<b: i2>>>>
+    // CHECK-DAG: %2 = hw.struct_extract %1["a"] : !hw.struct<a: !hw.array<3xstruct<b: i2>>>
+    // CHECK-DAG: %3 = hw.array_get %2[%c1_i2] : !hw.array<3xstruct<b: i2>>
+    // CHECK-DAG: %4 = hw.struct_extract %3["b"] : !hw.struct<b: i2>
+    // CHECK-DAG: %5 = hw.array_get %count[%c1_i3_0] : !hw.array<5xstruct<a: !hw.array<3xstruct<b: i2>>>>
+    // CHECK-DAG: %6 = hw.struct_extract %5["a"] : !hw.struct<a: !hw.array<3xstruct<b: i2>>>
+    // CHECK-DAG: %7 = hw.array_get %6[%c1_i2_1] : !hw.array<3xstruct<b: i2>>
+    // CHECK-DAG: %8 = hw.struct_inject %7["b"], %value : !hw.struct<b: i2>
+    // CHECK-DAG: %9 = hw.array_slice %6[%c0_i2] : (!hw.array<3xstruct<b: i2>>) -> !hw.array<1xstruct<b: i2>>
+    // CHECK-DAG: %10 = hw.array_create %8 : !hw.struct<b: i2>
+    // CHECK-DAG: %11 = hw.array_slice %6[%c-2_i2] : (!hw.array<3xstruct<b: i2>>) -> !hw.array<1xstruct<b: i2>>
+    // CHECK-DAG: %12 = hw.array_concat %9, %10, %11 : !hw.array<1xstruct<b: i2>>, !hw.array<1xstruct<b: i2>>, !hw.array<1xstruct<b: i2>>
+    // CHECK-DAG: %13 = hw.struct_inject %5["a"], %12 : !hw.struct<a: !hw.array<3xstruct<b: i2>>>
+    // CHECK-DAG: %14 = hw.array_slice %count[%c0_i3] : (!hw.array<5xstruct<a: !hw.array<3xstruct<b: i2>>>>) -> !hw.array<1xstruct<a: !hw.array<3xstruct<b: i2>>>>
+    // CHECK-DAG: %15 = hw.array_create %13 : !hw.struct<a: !hw.array<3xstruct<b: i2>>>
+    // CHECK-DAG: %16 = hw.array_slice %count[%c2_i3] : (!hw.array<5xstruct<a: !hw.array<3xstruct<b: i2>>>>) -> !hw.array<3xstruct<a: !hw.array<3xstruct<b: i2>>>>
+    // CHECK-DAG: %17 = hw.array_concat %14, %15, %16 : !hw.array<1xstruct<a: !hw.array<3xstruct<b: i2>>>>, !hw.array<1xstruct<a: !hw.array<3xstruct<b: i2>>>>, !hw.array<3xstruct<a: !hw.array<3xstruct<b: i2>>>>
+  }
+
+  // CHECK-LABEL: hw.module @ConnectSubindex(%clock: i1, %reset: i1, %value: i2) -> (result: !hw.array<3xi2>)
+  firrtl.module @ConnectSubindex(in %clock: !firrtl.clock,
+                                 in %reset: !firrtl.uint<1>,
+                                 in %value: !firrtl.uint<2>,
+                                 out %result: !firrtl.vector<uint<2>, 3>) {
+    %count = firrtl.reg %clock: !firrtl.vector<uint<2>, 3>
+    // CHECK: %count = seq.firreg %4 clock %clock : !hw.array<3xi2>
+
+    firrtl.strictconnect %result, %count : !firrtl.vector<uint<2>, 3>
+    %field = firrtl.subindex %count[1] : !firrtl.vector<uint<2>, 3>
+    firrtl.strictconnect %field, %value : !firrtl.uint<2>
+
+    // CHECK: %0 = hw.array_get %count[%c1_i2] : !hw.array<3xi2>
+    // CHECK: %1 = hw.array_slice %count[%c0_i2] : (!hw.array<3xi2>) -> !hw.array<1xi2>
+    // CHECK: %2 = hw.array_create %value : i2
+    // CHECK: %3 = hw.array_slice %count[%c-2_i2] : (!hw.array<3xi2>) -> !hw.array<1xi2>
+    // CHECK: %4 = hw.array_concat %1, %2, %3 : !hw.array<1xi2>, !hw.array<1xi2>, !hw.array<1xi2>
+
+    // CHECK: hw.output %count : !hw.array<3xi2>
+  }
+
+  // CHECK-LABEL: hw.module @ConnectSubindexSingleton(%clock: i1, %reset: i1, %value: i2) -> (result: !hw.array<1xi2>)
+  firrtl.module @ConnectSubindexSingleton(in %clock: !firrtl.clock,
+                                 in %reset: !firrtl.uint<1>,
+                                 in %value: !firrtl.uint<2>,
+                                 out %result: !firrtl.vector<uint<2>, 1>) {
+    %count = firrtl.reg %clock: !firrtl.vector<uint<2>, 1>
+    // CHECK: %count = seq.firreg [[INPUT:%.+]] clock %clock : !hw.array<1xi2>
+
+    firrtl.strictconnect %result, %count : !firrtl.vector<uint<2>, 1>
+    %field = firrtl.subindex %count[0] : !firrtl.vector<uint<2>, 1>
+    firrtl.strictconnect %field, %value : !firrtl.uint<2>
+
+    // CHECK: [[INPUT]] = hw.array_create %value : i2
+    // CHECK: hw.output %count : !hw.array<1xi2>
+  }
+
+  // CHECK-LABEL: hw.module @ConnectSubindexLHS(%clock: i1, %reset: i1, %value: i2) -> (result: !hw.array<3xi2>)
+  firrtl.module @ConnectSubindexLHS(in %clock: !firrtl.clock,
+                                 in %reset: !firrtl.uint<1>,
+                                 in %value: !firrtl.uint<2>,
+                                 out %result: !firrtl.vector<uint<2>, 3>) {
+    %count = firrtl.reg %clock: !firrtl.vector<uint<2>, 3>
+    // CHECK: %count = seq.firreg [[INPUT:%.+]] clock %clock : !hw.array<3xi2>
+
+    firrtl.strictconnect %result, %count : !firrtl.vector<uint<2>, 3>
+    %field = firrtl.subindex %count[0] : !firrtl.vector<uint<2>, 3>
+    firrtl.strictconnect %field, %value : !firrtl.uint<2>
+
+    // CHECK: [[ELEM:%.+]] = hw.array_create %value : i2
+    // CHECK: [[REST:%.+]] = hw.array_slice %count[%c1_i2] : (!hw.array<3xi2>) -> !hw.array<2xi2>
+    // CHECK: [[INPUT]] = hw.array_concat [[ELEM]], [[REST]] : !hw.array<1xi2>, !hw.array<2xi2>
+
+    // CHECK: hw.output %count : !hw.array<3xi2>
+  }
+
+  // CHECK-LABEL: hw.module @ConnectSubindexRHS(%clock: i1, %reset: i1, %value: i2) -> (result: !hw.array<3xi2>)
+  firrtl.module @ConnectSubindexRHS(in %clock: !firrtl.clock,
+                                 in %reset: !firrtl.uint<1>,
+                                 in %value: !firrtl.uint<2>,
+                                 out %result: !firrtl.vector<uint<2>, 3>) {
+    %count = firrtl.reg %clock: !firrtl.vector<uint<2>, 3>
+    // CHECK: %count = seq.firreg [[INPUT:%.+]] clock %clock : !hw.array<3xi2>
+
+    firrtl.strictconnect %result, %count : !firrtl.vector<uint<2>, 3>
+    %field = firrtl.subindex %count[2] : !firrtl.vector<uint<2>, 3>
+    firrtl.strictconnect %field, %value : !firrtl.uint<2>
+
+    // CHECK: [[REST:%.+]] = hw.array_slice %count[%c0_i2] : (!hw.array<3xi2>) -> !hw.array<2xi2>
+    // CHECK: [[ELEM:%.+]] = hw.array_create %value : i2
+    // CHECK: [[INPUT]] = hw.array_concat [[REST]], [[ELEM]] : !hw.array<2xi2>, !hw.array<1xi2>
+
+    // CHECK: hw.output %count : !hw.array<3xi2>
+  }
+
+  // CHECK-LABEL: hw.module @ConnectSubindices(%clock: i1, %reset: i1, %value: i2) -> (result: !hw.array<5xi2>)
+  firrtl.module @ConnectSubindices(in %clock: !firrtl.clock,
+                                 in %reset: !firrtl.uint<1>,
+                                 in %value: !firrtl.uint<2>,
+                                 out %result: !firrtl.vector<uint<2>, 5>) {
+    %count = firrtl.reg %clock: !firrtl.vector<uint<2>, 5>
+    // CHECK: %count = seq.firreg %13 clock %clock : !hw.array<5xi2>
+
+    firrtl.strictconnect %result, %count : !firrtl.vector<uint<2>, 5>
+
+    %field1 = firrtl.subindex %count[1] : !firrtl.vector<uint<2>, 5>
+    firrtl.strictconnect %field1, %value : !firrtl.uint<2>
+    %field2 = firrtl.subindex %count[2] : !firrtl.vector<uint<2>, 5>
+    firrtl.strictconnect %field2, %value : !firrtl.uint<2>
+    %field5 = firrtl.subindex %count[4] : !firrtl.vector<uint<2>, 5>
+    firrtl.strictconnect %field5, %value : !firrtl.uint<2>
+
+    // CHECK-DAG: %1 = hw.array_slice %count[%c0_i3] : (!hw.array<5xi2>) -> !hw.array<1xi2>
+    // CHECK-DAG: %2 = hw.array_create %value : i2
+    // CHECK-DAG: %3 = hw.array_slice %count[%c2_i3] : (!hw.array<5xi2>) -> !hw.array<3xi2>
+    // CHECK-DAG: %4 = hw.array_concat %1, %2, %3 : !hw.array<1xi2>, !hw.array<1xi2>, !hw.array<3xi2>
+    // CHECK-DAG: %6 = hw.array_slice %4[%c0_i3] : (!hw.array<5xi2>) -> !hw.array<2xi2>
+    // CHECK-DAG: %7 = hw.array_create %value : i2
+    // CHECK-DAG: %8 = hw.array_slice %4[%c3_i3] : (!hw.array<5xi2>) -> !hw.array<2xi2>
+    // CHECK-DAG: %9 = hw.array_concat %6, %7, %8 : !hw.array<2xi2>, !hw.array<1xi2>, !hw.array<2xi2>
+    // CHECK-DAG: %11 = hw.array_slice %9[%c0_i3] : (!hw.array<5xi2>) -> !hw.array<4xi2>
+    // CHECK-DAG: %12 = hw.array_create %value : i2
+    // CHECK-DAG: %13 = hw.array_concat %11, %12 : !hw.array<4xi2>, !hw.array<1xi2>
+
+    // CHECK: hw.output %count : !hw.array<5xi2>
+  }
+
+  // CHECK-LABEL: hw.module @ConnectNestedSubindex(%clock: i1, %reset: i1, %value: i2) -> (result: !hw.array<3xarray<3xi2>>)
+  firrtl.module @ConnectNestedSubindex(in %clock: !firrtl.clock,
+                                       in %reset: !firrtl.uint<1>,
+                                       in %value: !firrtl.uint<2>,
+                                       out %result: !firrtl.vector<vector<uint<2>, 3>, 3>) {
+    %count = firrtl.reg %clock: !firrtl.vector<vector<uint<2>, 3>, 3>
+    // CHECK: %count = seq.firreg %10 clock %clock : !hw.array<3xarray<3xi2>>
+
+    firrtl.strictconnect %result, %count : !firrtl.vector<vector<uint<2>, 3>, 3>
+    %field0 = firrtl.subindex %count[1] : !firrtl.vector<vector<uint<2>, 3>, 3>
+    %field1 = firrtl.subindex %field0[1] : !firrtl.vector<uint<2>, 3>
+    firrtl.strictconnect %field1, %value : !firrtl.uint<2>
+
+    // CHECK-DAG: %0 = hw.array_get %count[%c1_i2] : !hw.array<3xarray<3xi2>>
+    // CHECK-DAG: %1 = hw.array_get %0[%c1_i2] : !hw.array<3xi2>
+    // CHECK-DAG: %2 = hw.array_get %count[%c1_i2_0] : !hw.array<3xarray<3xi2>>
+    // CHECK-DAG: %3 = hw.array_slice %2[%c0_i2] : (!hw.array<3xi2>) -> !hw.array<1xi2>
+    // CHECK-DAG: %4 = hw.array_create %value : i2
+    // CHECK-DAG: %5 = hw.array_slice %2[%c-2_i2] : (!hw.array<3xi2>) -> !hw.array<1xi2>
+    // CHECK-DAG: %6 = hw.array_concat %3, %4, %5 : !hw.array<1xi2>, !hw.array<1xi2>, !hw.array<1xi2>
+    // CHECK-DAG: %7 = hw.array_slice %count[%c0_i2] : (!hw.array<3xarray<3xi2>>) -> !hw.array<1xarray<3xi2>>
+    // CHECK-DAG: %8 = hw.array_create %6 : !hw.array<3xi2>
+    // CHECK-DAG: %9 = hw.array_slice %count[%c-2_i2] : (!hw.array<3xarray<3xi2>>) -> !hw.array<1xarray<3xi2>>
+    // CHECK-DAG: %10 = hw.array_concat %7, %8, %9 : !hw.array<1xarray<3xi2>>, !hw.array<1xarray<3xi2>>, !hw.array<1xarray<3xi2>>
+
+    // CHECK: hw.output %count : !hw.array<3xarray<3xi2>>
+  }
+
+  // CHECK-LABEL: hw.module @SyncReset(%clock: i1, %reset: i1, %value: i2) -> (result: i2)
+  firrtl.module @SyncReset(in %clock: !firrtl.clock,
+                           in %reset: !firrtl.uint<1>,
+                           in %value: !firrtl.uint<2>,
+                           out %result: !firrtl.uint<2>) {
+    %count = firrtl.regreset %clock, %reset, %value : !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
+
+    // CHECK: %count = seq.firreg %count clock %clock reset sync %reset, %value : i2
+    // CHECK: hw.output %count : i2
+
+    firrtl.strictconnect %result, %count : !firrtl.uint<2>
+  }
+
+  // CHECK-LABEL: hw.module @AsyncReset(%clock: i1, %reset: i1, %value: i2) -> (result: i2)
+  firrtl.module @AsyncReset(in %clock: !firrtl.clock,
+                           in %reset: !firrtl.asyncreset,
+                           in %value: !firrtl.uint<2>,
+                           out %result: !firrtl.uint<2>) {
+    %count = firrtl.regreset %clock, %reset, %value : !firrtl.asyncreset, !firrtl.uint<2>, !firrtl.uint<2>
+
+    // CHECK: %count = seq.firreg %value clock %clock reset async %reset, %value : i2
+    // CHECK: hw.output %count : i2
+
+    firrtl.strictconnect %count, %value : !firrtl.uint<2>
+    firrtl.strictconnect %result, %count : !firrtl.uint<2>
+  }
+
+  // CHECK-LABEL: hw.module @NoConnect(%clock: i1, %reset: i1) -> (result: i2)
+  firrtl.module @NoConnect(in %clock: !firrtl.clock,
+                     in %reset: !firrtl.uint<1>,
+                     out %result: !firrtl.uint<2>) {
+    %count = firrtl.reg %clock: !firrtl.uint<2>
+    // CHECK: %count = seq.firreg %count clock %clock : i2
+
+    firrtl.strictconnect %result, %count : !firrtl.uint<2>
+
+    // CHECK: hw.output %count : i2
   }
 }

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -266,7 +266,7 @@ circuit test_mod : %[[{"class": "circt.testNT", "data": "a"}]]
 ; VERILOG-NEXT:    output a_q);
 ; VERILOG:         always @(posedge clock)
 ; VERILOG-NEXT:      r <= a_d;
-; VERILOG-NEXT:    assign a_q = r;
+; VERILOG:         assign a_q = r;
 
   module MultibitMux :
     input a : UInt<1>[3]

--- a/test/firtool/memory.fir
+++ b/test/firtool/memory.fir
@@ -79,10 +79,10 @@ circuit Qux: %[[{
 ;CHECK-SAME:        (%[[multbit_mux_wire]], %[[array_get]])
 ;CHECK:    %[[v7:.+]] = sv.read_inout %[[multbit_mux_wire]] : !hw.inout<i8>
 ;CHECK:    sv.always posedge %clock {
-;CHECK-NEXT:      sv.passign %[[addr]], %rAddr : i2
 ;CHECK-NEXT:      sv.passign %[[memory_0]]
 ;CHECK-NEXT:      sv.passign %[[memory_1]]
 ;CHECK-NEXT:      sv.passign %[[memory_2]]
 ;CHECK-NEXT:      sv.passign %[[memory_3]]
+;CHECK-NEXT:      sv.passign %[[addr]], %rAddr : i2
 ;CHECK-NEXT:    }
 ;CHECK:    hw.output %[[v6]], %[[v7]]

--- a/tools/firtool/CMakeLists.txt
+++ b/tools/firtool/CMakeLists.txt
@@ -12,6 +12,8 @@ target_link_libraries(firtool PRIVATE
   CIRCTFIRRTLToHW
   CIRCTFIRRTLTransforms
   CIRCTHWTransforms
+  CIRCTSeq
+  CIRCTSeqTransforms
   CIRCTSVTransforms
   CIRCTTransforms
 

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -23,6 +23,8 @@
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVDialect.h"
 #include "circt/Dialect/SV/SVPasses.h"
+#include "circt/Dialect/Seq/SeqDialect.h"
+#include "circt/Dialect/Seq/SeqPasses.h"
 #include "circt/Support/LoweringOptions.h"
 #include "circt/Support/Version.h"
 #include "circt/Transforms/Passes.h"
@@ -643,6 +645,7 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
         modulePM.addPass(createSimpleCanonicalizerPass());
       }
     } else {
+      pm.addPass(seq::createSeqLowerToSVPass());
       pm.addPass(sv::createHWMemSimImplPass(replSeqMem, ignoreReadEnableMem));
 
       if (extractTestCode)
@@ -855,7 +858,8 @@ static LogicalResult executeFirtool(MLIRContext &context) {
 
   // Register our dialects.
   context.loadDialect<chirrtl::CHIRRTLDialect, firrtl::FIRRTLDialect,
-                      hw::HWDialect, comb::CombDialect, sv::SVDialect>();
+                      hw::HWDialect, comb::CombDialect, seq::SeqDialect,
+                      sv::SVDialect>();
 
   // Process the input.
   if (failed(processInput(context, ts, std::move(input), outputFile)))


### PR DESCRIPTION
In `LowerToHW`, FIRRTL registers are lowered to the Seq register.

Complete connects to the registers are mapped to the `next` value. Partial updates, for either bundles or arrays, use functional-style `hw.struct_inject` or `hw.array_concat` operations to update individual fields. Registers with no connects or no connects to some of their fields or indices set their next value to themselves. The self-parallel-assignment is then eliminated in `PrettifyVerilog`. Partial updates are also simplified before Verilog emission.

Random initialisation is now delegated to the lowering of the FIR registers in the `Seq` dialect.