### PR TITLE
[FIRRTL] Use tap wires for GCT data taps

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -1048,6 +1048,18 @@ void GrandCentralTapsPass::processAnnotation(AnnotatedPort &portAnno,
       if (!nla)
         wiring.prefices =
             instancePaths.getAbsolutePaths(op->getParentOfType<FModuleOp>());
+
+      // Set the literal member if this wire or node is driven by a constant.
+      auto driver = getDriverFromConnect(op->getResult(0));
+      if (driver)
+        if (auto constant =
+                dyn_cast_or_null<ConstantOp>(driver.getDefiningOp())) {
+          wiring.literal = {
+              IntegerAttr::get(constant.getContext(), constant.value()),
+              constant.getType()};
+          op->removeAttr("inner_sym");
+        }
+
       wiring.target = PortWiring::Target(op);
       portWiring.push_back(std::move(wiring));
       return;

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -357,6 +357,20 @@ LogicalResult circt::firrtl::applyGCTDataTaps(AnnoPathValue target,
         emitConnect(builder, tap, value);
         sourceTarget->name = tap.name();
         sourceTarget->component.clear(); // resolved in getValueByFieldID
+      } else if (!portSourceTarget) {
+        ImplicitLocOpBuilder builder(path.ref.getOp()->getLoc(),
+                                     path.ref.getOp());
+        builder.setInsertionPointAfter(path.ref.getOp());
+        Value value = path.ref.getOp()->getResult(0);
+        auto type = path.ref.getType()
+                        .getFinalTypeByFieldID(path.fieldIdx)
+                        .getPassiveType();
+        auto tap = builder.create<WireOp>(
+            type, state.getNamespace(path.ref.getModule()).newName("_gctTap"));
+        value = getValueByFieldID(builder, value, path.fieldIdx);
+        emitConnect(builder, tap, value);
+        sourceTarget->name = tap.name();
+        sourceTarget->component.clear(); // resolved in getValueByFieldID
       }
 
       sourceTargetPath = sourceTarget->str();

--- a/test/Dialect/FIRRTL/SFCTests/data-taps-nlas.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps-nlas.fir
@@ -21,12 +21,6 @@ circuit Top : %[[{
       "portName": "~Top|DataTap>d"
     }
 ]}]]
-  extmodule DataTap :
-    output b : UInt<1>
-    output c : UInt<1>
-    output d : UInt<1>
-    defname = DataTap
-
   module Foo :
     output g : UInt<1>
     wire f : UInt<1>
@@ -40,13 +34,24 @@ circuit Top : %[[{
     wire k : UInt<1>
     k is invalid
 
-; CHECK: module DataTap_impl_0(
-; CHECK:   output b, 
+  extmodule DataTap :
+    output b : UInt<1>
+    output c : UInt<1>
+    output d : UInt<1>
+    defname = DataTap
+
+; CHECK-LABEL: module Foo();
+; CHECK:   wire [[TAP:.+]] = 1'h0;
+; CHECK:   wire f = 1'h0;
+; CHECK: endmodule
+
+; CHECK-LABEL: module DataTap_impl_0(
+; CHECK:   output b,
 ; CHECK:          c,
 ; CHECK:          d
 ; CHECK: );
 ; CHECK:   assign b = Top.foo.f;
-; CHECK:   assign c = Top.foo.g;
+; CHECK:   assign c = Top.foo.[[TAP]];
 ; CHECK:   assign d = Top.k;
 ; CHECK: endmodule
 

--- a/test/Dialect/FIRRTL/SFCTests/data-taps-nlas.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps-nlas.fir
@@ -24,8 +24,8 @@ circuit Top : %[[{
   module Foo :
     output g : UInt<1>
     wire f : UInt<1>
-    g is invalid
-    f is invalid
+    g <= UInt<1>(0)
+    f <= UInt<1>(1)
 
   module Top:
     inst foo of Foo
@@ -41,18 +41,23 @@ circuit Top : %[[{
     defname = DataTap
 
 ; CHECK-LABEL: module Foo();
-; CHECK:   wire [[TAP:.+]] = 1'h0;
-; CHECK:   wire f = 1'h0;
-; CHECK: endmodule
+; CHECK-NEXT:    wire [[g_tap:.+]] = 1'h0;
+; CHECK-NEXT:    wire f = 1'h1;
+; CHECK-NEXT:    wire [[f_tap:.+]] = 1'h1;
+; CHECK:       endmodule
+
+; CHECK-LABEL: module Top();
+; CHECK:         wire k = 1'h0;
+; CHECK:         wire [[k_tap:.+]] = 1'h0;
 
 ; CHECK-LABEL: module DataTap_impl_0(
 ; CHECK:   output b,
 ; CHECK:          c,
 ; CHECK:          d
 ; CHECK: );
-; CHECK:   assign b = Top.foo.f;
-; CHECK:   assign c = Top.foo.[[TAP]];
-; CHECK:   assign d = Top.k;
+; CHECK:   assign b = Top.foo.[[f_tap]];
+; CHECK:   assign c = Top.foo.[[g_tap]];
+; CHECK:   assign d = Top.[[k_tap]];
 ; CHECK: endmodule
 
 ; // -----
@@ -86,4 +91,8 @@ circuit TestHarness : %[[
 
 ; CHECK:     module DataTap
 ; CHECK-NOT: endmodule
-; CHECK:       assign _0 = TestHarness.system.test.signal;
+; CHECK:       assign _0 = TestHarness.system.test.[[signal_tap:.+]];
+
+; CHECK:     module Test()
+; CHECK-NOT: endmodule
+; CHECK:       wire [7:0] [[signal_tap]] = 8'h0;

--- a/test/Dialect/FIRRTL/SFCTests/data-taps-nlas.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps-nlas.fir
@@ -1,6 +1,9 @@
 ; RUN: firtool --firrtl-grand-central --verilog --split-input-file %s | FileCheck %s
 ; See https://github.com/llvm/circt/issues/2691
 
+; Note: This includes DontTouchAnnotations to prevent these from getting
+; optimized away to constants as the purpose of this test is not to check
+; constant propagation behavior, but that NLAs work.
 circuit Top : %[[{
   "class": "sifive.enterprise.grandcentral.DataTapsAnnotation",
   "blackBox": "~Top|DataTap",
@@ -20,7 +23,20 @@ circuit Top : %[[{
       "source": "~Top|Top>k",
       "portName": "~Top|DataTap>d"
     }
-]}]]
+  ]
+},
+{
+  "class": "firrtl.transforms.DontTouchAnnotation",
+  "target": "~Top|Foo>g"
+},
+{
+  "class": "firrtl.transforms.DontTouchAnnotation",
+  "target": "~Top|Foo>f"
+},
+{
+  "class": "firrtl.transforms.DontTouchAnnotation",
+  "target": "~Top|Top>k"
+}]]
   module Foo :
     output g : UInt<1>
     wire f : UInt<1>
@@ -40,15 +56,13 @@ circuit Top : %[[{
     output d : UInt<1>
     defname = DataTap
 
-; CHECK-LABEL: module Foo();
-; CHECK-NEXT:    wire [[g_tap:.+]] = 1'h0;
-; CHECK-NEXT:    wire f = 1'h1;
-; CHECK-NEXT:    wire [[f_tap:.+]] = 1'h1;
+; CHECK-LABEL: module Foo(
+; CHECK:         assign [[g_tap:_gctTap.*]] = {{.*g.*}};
+; CHECK:         assign [[f_tap:_gctTap.*]] = f;
 ; CHECK:       endmodule
 
 ; CHECK-LABEL: module Top();
-; CHECK:         wire k = 1'h0;
-; CHECK:         wire [[k_tap:.+]] = 1'h0;
+; CHECK:         assign [[k_tap:.+]] = k;
 
 ; CHECK-LABEL: module DataTap_impl_0(
 ; CHECK:   output b,
@@ -62,6 +76,9 @@ circuit Top : %[[{
 
 ; // -----
 
+; Note: This includes DontTouchAnnotations to prevent these from getting
+; optimized away to constants as the purpose of this test is not to check
+; constant propagation behavior, but that NLAs work.
 circuit TestHarness : %[[
   {
     "class":"sifive.enterprise.grandcentral.DataTapsAnnotation",
@@ -73,6 +90,10 @@ circuit TestHarness : %[[
         "portName":"~TestHarness|DataTap>_0"
       }
     ]
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~TestHarness|TestHarness/system:Top/test:Test>signal"
   }
 ]]
   module TestHarness :
@@ -81,7 +102,7 @@ circuit TestHarness : %[[
     inst test of Test
     inst Companion of Companion
   extmodule DataTap :
-    output _0 : UInt<1>
+    output _0 : UInt<8>
     defname = DataTap
   module Companion :
     inst DataTap of DataTap
@@ -95,4 +116,4 @@ circuit TestHarness : %[[
 
 ; CHECK:     module Test()
 ; CHECK-NOT: endmodule
-; CHECK:       wire [7:0] [[signal_tap]] = 8'h0;
+; CHECK:       assign [[signal_tap]] = signal;

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -478,7 +478,7 @@ firrtl.circuit "GCTDataTap" attributes {rawAnnotations = [{
 }
 
 // CHECK-LABEL: firrtl.circuit "GCTDataTap"
-// CHECK:      firrtl.nla [[NLA:@.+]] [@GCTDataTap::@im, @InnerMod::@w]
+// CHECK:      firrtl.nla [[NLA:@.+]] [@GCTDataTap::@im, @InnerMod::@[[InnerMod_w_tap_sym:.+]]]
 
 // CHECK-LABEL: firrtl.extmodule private @DataTap
 
@@ -559,7 +559,9 @@ firrtl.circuit "GCTDataTap" attributes {rawAnnotations = [{
 // CHECK-SAME: ]
 
 // CHECK-LABEL: firrtl.module private @InnerMod
-// CHECK-NEXT: %w = firrtl.wire sym @w
+// CHECK-NEXT: %w = firrtl.wire
+// CHECK-NOT:    sym
+// CHECK-NEXT: %[[w_tap:.+]] = firrtl.wire sym @[[InnerMod_w_tap_sym]]
 // CHECK-SAME: annotations = [
 // CHECK-SAME:   {
 // CHECK-SAME:     circt.nonlocal = [[NLA]]
@@ -568,9 +570,21 @@ firrtl.circuit "GCTDataTap" attributes {rawAnnotations = [{
 // CHECK-SAME:     portID = [[PORT_ID_6]]
 // CHECK-SAME:   }
 // CHECK-SAME: ]
+// CHECK-NEXT: firrtl.strictconnect %[[w_tap]], %w
 
-// CHECK: firrtl.module @GCTDataTap
-// CHECK-LABEL: firrtl.reg sym @r
+// CHECK-LABEL: firrtl.module @GCTDataTap
+// CHECK-NEXT: %r = firrtl.reg
+// CHECK-NOT     sym
+// CHECK-NEXT: %[[r_tap_1:.+]] = firrtl.wire sym
+// CHECk-SAME: annotations = [
+// CHECK-SAME:   {
+// CHECK-SAME:     class = "sifive.enterprise.grandcentral.ReferenceDataTapKey.source"
+// CHECK-SAME:     id = [[ID]]
+// CHECK-SAME:     portID = [[PORT_ID_1]]
+// CHECK-SAME:   }
+// CHECK-SAME: ]
+// CHECK-NEXT: firrtl.strictconnect %[[r_tap_1]], %r
+// CHECK-NEXT: %[[r_tap_0:.+]] = firrtl.wire sym
 // CHECk-SAME: annotations = [
 // CHECK-SAME:   {
 // CHECK-SAME:     class = "sifive.enterprise.grandcentral.ReferenceDataTapKey.source"
@@ -578,25 +592,29 @@ firrtl.circuit "GCTDataTap" attributes {rawAnnotations = [{
 // CHECK-SAME:     portID = [[PORT_ID_0]]
 // CHECK-SAME:   }
 // CHECK-SAME: ]
+// CHECK-NEXT: firrtl.strictconnect %[[r_tap_0]], %r
 
-// CHECK-LABEL: firrtl.wire
+// CHECK:      %w = firrtl.wire
+// CHECK-NOT:    sym
+// CHECK-NEXT: %[[w_tap_3:.+]] = firrtl.wire sym
 // CHECK-SAME: annotations = [
 // CHECK-SAME:   {
-// CHECK-SAME:     circt.fieldID = 1
-// CHECK-SAME:     class = "firrtl.transforms.DontTouchAnnotation"
-// CHECK-SAME:   }
-// CHECK-SAME:   {
-// CHECK-SAME:     circt.fieldID = 1
 // CHECK-SAME:     class = "sifive.enterprise.grandcentral.ReferenceDataTapKey.source"
 // CHECK-SAME:     id = [[ID]]
 // CHECK-SAME:     portID = [[PORT_ID_3]]
 // CHECK-SAME:   }
+// CHECK-NEXT: %[[w_0:.+]] = firrtl.subfield %w(0)
+// CHECK-NEXT: firrtl.strictconnect %[[w_tap_3]], %[[w_0]]
+// CHECK:      %[[w_tap_2:.+]] = firrtl.wire sym
+// CHECK-SAME: annotations = [
 // CHECK-SAME:   {
 // CHECK-SAME:     class = "sifive.enterprise.grandcentral.ReferenceDataTapKey.source",
-// CHECK-SAME:      id = [[ID]]
-// CHECK-SAME:      portID = [[PORT_ID_2]]
+// CHECK-SAME:     id = [[ID]]
+// CHECK-SAME:     portID = [[PORT_ID_2]]
 // CHECK-SAME:   }
 // CHECK-SAME: ]
+// CHECK-NEXT: %[[w_0:.+]] = firrtl.subfield %w(0)
+// CHECK-NEXT: firrtl.strictconnect %[[w_tap_2]], %[[w_0]]
 
 // -----
 


### PR DESCRIPTION
Instead of directly referring to module ports or internal signals, this commit changes the GCT data taps pass to create an auxiliary "tap wire" inside the module. The wire is connected such that it "observes" the current value of the port (input or output) or internal signal, and all symbol references generated by GCT are with respect to this wire.

This has two distinct advantages:

1.  It removes a major source of symbols on module ports, which block port optimizations almost entirely.
2.  It offers a "receptacle" for IMConstProp to propagate constants into. This can lead to the tap wire being disconnected from the port if the port is only driven to a constant externally, which allows for the port to be removed.

### Todo
- [x] Land #3186 