### PR TITLE
[HandshakeToFIRRTL] Add initial values to buffer module names

### DIFF
--- a/integration_test/Dialect/Handshake/buffer_initial_values.mlir
+++ b/integration_test/Dialect/Handshake/buffer_initial_values.mlir
@@ -1,0 +1,24 @@
+// REQUIRES: ieee-sim
+// UNSUPPORTED: ieee-sim-iverilog
+// RUN: circt-opt %s \
+// RUN:   --canonicalize='top-down=true region-simplify=true' \
+// RUN:   --handshake-materialize-forks-sinks --canonicalize \
+// RUN:   --handshake-insert-buffers=strategy=all --lower-handshake-to-firrtl | \
+// RUN: firtool --format=mlir --verilog > %buffer-export.sv
+// RUN: circt-rtl-sim.py %buffer-export.sv %S/driver.sv --sim %ieee-sim --no-default-driver --top driver | FileCheck %s
+// CHECK: Result={{.*}}10
+
+module {
+  handshake.func @top(%arg0: none) -> (i32, none) attributes {argNames = ["inCtrl"], resNames = ["out0", "outCtrl"]} {
+    %d = buffer [2] seq %dTrue {initValues = [20, 10]} : i32
+    %ctrl = merge %arg0, %cTrue : none
+
+    %6 = constant %ctrl {value = 10 : i32} : i32
+    %cond = arith.cmpi ne, %d, %6 : i32
+
+    %dTrue, %dFalse = cond_br %cond, %d : i32
+    %cTrue, %cFalse = cond_br %cond, %ctrl : none
+
+    return %dFalse, %cFalse : i32, none
+  }
+}

--- a/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
+++ b/lib/Conversion/HandshakeToFIRRTL/HandshakeToFIRRTL.cpp
@@ -443,6 +443,13 @@ static std::string getSubModuleName(Operation *oldOp) {
       subModuleName += "_seq";
     else
       subModuleName += "_fifo";
+
+    if (bufferOp.initValues().hasValue()) {
+      subModuleName += "_init";
+      for (auto e : *bufferOp.initValues())
+        subModuleName +=
+            "_" + std::to_string(e.dyn_cast<IntegerAttr>().getInt());
+    }
   }
 
   // Add control information.

--- a/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
+++ b/test/Conversion/HandshakeToFIRRTL/test_buffer.mlir
@@ -132,6 +132,7 @@ handshake.func @test_buffer_data(%arg0: index, %arg1: none, ...) -> (index, none
 
 // -----
 
+// CHECK-LABEL: firrtl.module @handshake_buffer_in_ui64_out_ui64_1slots_seq_init_42
 // CHECK: %validReg0 = firrtl.regreset %clock, %reset, %c1_ui1  : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK: %dataReg0 = firrtl.regreset %clock, %reset, %c42_ui64  : !firrtl.uint<1>, !firrtl.uint<64>, !firrtl.uint<64>
 
@@ -150,4 +151,13 @@ handshake.func @test_buffer_init(%arg0: index, %arg1: none, ...) -> (index, none
 handshake.func @test_buffer_tuple_seq(%t: tuple<i32, i32>, %arg0: none, ...) -> (tuple<i32, i32>, none) {
   %0 = buffer [2] seq %t : tuple<i32, i32>
   return %0, %arg0 : tuple<i32, i32>, none
+}
+
+// -----
+
+// CHECK-LABEL: firrtl.module @handshake_buffer_in_ui64_out_ui64_2slots_seq_init_42_24
+
+handshake.func @test_buffer_init(%arg0: index, %arg1: none, ...) -> (index, none) {
+  %0 = buffer [2] seq %arg0 {initValues=[42, 24]} : index
+  return %0, %arg1 : index, none
 }


### PR DESCRIPTION
This patch adds the initial values to the names of the buffer modules to create different modules for different initial values.

If added a new integration test as this bug mainly appears when the generated verilog is simulated.

Fixes #3180 