### PR TITLE
[FIRRTL] Add Utilities to NLA and NLATable. NFC.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -252,6 +252,9 @@ def NonLocalAnchor : FIRRTLOp<"nla",
     /// Returns true, if the NLA path contains the module.
     bool hasModule(StringAttr modName);
 
+    /// Returns true, if the NLA path contains the InnerSym {modName, symName}.
+    bool hasInnerSym(StringAttr modName, StringAttr symName) const;
+
     /// Returns true if this NLA targets a module or instance of a module (as
     /// opposed to an instance's port or something inside an instance).
     bool isModule();

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3562,6 +3562,16 @@ bool NonLocalAnchor::hasModule(StringAttr modName) {
   return false;
 }
 
+/// Return true if the NLA has the InnerSym .
+bool NonLocalAnchor::hasInnerSym(StringAttr modName, StringAttr symName) const {
+  for (auto nameRef : const_cast<NonLocalAnchor *>(this)->namepath())
+    if (auto ref = nameRef.dyn_cast<hw::InnerRefAttr>())
+      if (ref.getName() == symName && ref.getModule() == modName)
+        return true;
+
+  return false;
+}
+
 /// Return just the reference part of the namepath at a specific index.  This
 /// will return an empty attribute if this is the leaf and the leaf is a module.
 StringAttr NonLocalAnchor::refPart(unsigned i) {


### PR DESCRIPTION
This commit adds the following utilities
1. Check if an NLA contains an innerSym reference.
2. Get the NLAs that an InstanceOp participates in.
3. Add an NLA to a Module.