### PR TITLE
[FIRRTL] Use NLATable analysis to update modules in PrefixModules pass.

### DIFF
--- a/include/circt/Dialect/FIRRTL/NLATable.h
+++ b/include/circt/Dialect/FIRRTL/NLATable.h
@@ -88,6 +88,12 @@ public:
     }
   }
 
+  /// Get the NLAs that the module `modName` particiaptes in, and insert them into the DenseSet `nlas`.
+  void getNLAsInModule(StringAttr modName, DenseSet<NonLocalAnchor> &nlas) {
+    for (auto nla : lookup(modName))
+      nlas.insert(nla);
+  }
+
   //===-------------------------------------------------------------------------
   // Methods to keep an NLATable up to date.
   //
@@ -100,7 +106,7 @@ public:
   void addNLA(NonLocalAnchor nla);
 
   /// Record a new FModuleLike operation.
-  void addModule(Operation *mod);
+  void addModule(FModuleLike mod);
 
   /// Stop tracking a module.
   void eraseModule(StringAttr name);

--- a/include/circt/Dialect/FIRRTL/NLATable.h
+++ b/include/circt/Dialect/FIRRTL/NLATable.h
@@ -99,6 +99,9 @@ public:
   /// Record a new NLA operation.
   void addNLA(NonLocalAnchor nla);
 
+  /// Record a new FModuleLike operation.
+  void addModule(Operation *mod);
+
   /// Stop tracking a module.
   void eraseModule(StringAttr name);
 

--- a/include/circt/Dialect/FIRRTL/NLATable.h
+++ b/include/circt/Dialect/FIRRTL/NLATable.h
@@ -88,7 +88,8 @@ public:
     }
   }
 
-  /// Get the NLAs that the module `modName` particiaptes in, and insert them into the DenseSet `nlas`.
+  /// Get the NLAs that the module `modName` particiaptes in, and insert them
+  /// into the DenseSet `nlas`.
   void getNLAsInModule(StringAttr modName, DenseSet<NonLocalAnchor> &nlas) {
     for (auto nla : lookup(modName))
       nlas.insert(nla);

--- a/lib/Dialect/FIRRTL/NLATable.cpp
+++ b/lib/Dialect/FIRRTL/NLATable.cpp
@@ -147,3 +147,7 @@ void NLATable::eraseModule(StringAttr name) {
   symToOp.erase(name);
   nodeMap.erase(name);
 }
+
+void NLATable::addModule(Operation *op) {
+  symToOp[static_cast<FModuleLike>(op).moduleNameAttr()] = op;
+}

--- a/lib/Dialect/FIRRTL/NLATable.cpp
+++ b/lib/Dialect/FIRRTL/NLATable.cpp
@@ -148,6 +148,6 @@ void NLATable::eraseModule(StringAttr name) {
   nodeMap.erase(name);
 }
 
-void NLATable::addModule(Operation *op) {
-  symToOp[static_cast<FModuleLike>(op).moduleNameAttr()] = op;
+void NLATable::addModule(FModuleLike op) {
+  symToOp[op.moduleNameAttr()] = op;
 }

--- a/lib/Dialect/FIRRTL/NLATable.cpp
+++ b/lib/Dialect/FIRRTL/NLATable.cpp
@@ -148,6 +148,4 @@ void NLATable::eraseModule(StringAttr name) {
   nodeMap.erase(name);
 }
 
-void NLATable::addModule(FModuleLike op) {
-  symToOp[op.moduleNameAttr()] = op;
-}
+void NLATable::addModule(FModuleLike op) { symToOp[op.moduleNameAttr()] = op; }

--- a/lib/Dialect/FIRRTL/Transforms/PrefixModules.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/PrefixModules.cpp
@@ -226,6 +226,10 @@ void PrefixModulesPass::renameModuleBody(std::string prefix, FModuleOp module) {
           nlaTable->updateModuleInNLA(nlaName, oldModName, newTarget);
         }
       }
+      DenseSet<NonLocalAnchor> instNLAs;
+      nlaTable->getInstanceNLAs(instanceOp, instNLAs);
+      for (auto nla : instNLAs)
+        nlaTable->updateModuleInNLA(nla, oldModName, newTarget);
 
       instanceOp.moduleNameAttr(FlatSymbolRefAttr::get(context, newTarget));
     }
@@ -263,29 +267,32 @@ void PrefixModulesPass::renameModule(FModuleOp module) {
   auto fixNLAsRootedAt = [&](StringAttr oldModName, StringAttr newModuleName) {
     for (auto n : nlaTable->lookup(oldModName))
       if (n.root() == oldModName)
-        n.updateModule(oldModName, newModuleName);
+        nlaTable->updateModuleInNLA(n, oldModName, newModuleName);
   };
   // Rename the module for each required prefix. This will clone the module
   // once for each prefix but the first.
   OpBuilder builder(module);
   builder.setInsertionPointAfter(module);
+  auto oldModName = module.getNameAttr();
   for (auto &outerPrefix : llvm::drop_begin(prefixes)) {
     auto moduleClone = cast<FModuleOp>(builder.clone(*module));
     auto newModuleName = (outerPrefix + moduleName);
-    fixNLAsRootedAt(module.getNameAttr(),
-                    StringAttr::get(module.getContext(), newModuleName));
+    auto newModNameAttr = StringAttr::get(module.getContext(), newModuleName);
     moduleClone.setName(newModuleName);
+    nlaTable->addModule(moduleClone);
+    fixNLAsRootedAt(oldModName, newModNameAttr);
     // Each call to this function could invalidate the `prefixes` reference.
     renameModuleBody((outerPrefix + innerPrefix).str(), moduleClone);
   }
 
   auto prefixFull = (firstPrefix + innerPrefix).str();
   auto newModuleName = firstPrefix + moduleName;
-  fixNLAsRootedAt(module.getNameAttr(),
-                  StringAttr::get(module.getContext(), newModuleName));
   // The first prefix renames the module in place. There is always at least 1
   // prefix.
   module.setName(newModuleName);
+  nlaTable->addModule(module);
+  fixNLAsRootedAt(oldModName,
+                  StringAttr::get(module.getContext(), newModuleName));
   renameModuleBody(prefixFull, module);
 
   // If this module contains a Grand Central interface, then also apply renames
@@ -442,6 +449,7 @@ void PrefixModulesPass::runOnOperation() {
     circuitOp.nameAttr(newMainModuleName);
 
     // Now update all the NLAs that have the top level module symbol.
+    nlaTable->renameModule(oldModName, newMainModuleName);
     for (auto n : nlaTable->lookup(oldModName))
       if (n.root() == oldModName)
         nlaTable->updateModuleInNLA(n, oldModName, newMainModuleName);

--- a/lib/Dialect/FIRRTL/Transforms/PrefixModules.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/PrefixModules.cpp
@@ -267,7 +267,9 @@ void PrefixModulesPass::renameModule(FModuleOp module) {
   auto &firstPrefix = prefixes.front();
 
   auto fixNLAsRootedAt = [&](StringAttr oldModName, StringAttr newModuleName) {
-    for (auto n : nlaTable->lookup(oldModName))
+    DenseSet<NonLocalAnchor> nlas;
+    nlaTable->getNLAsInModule(oldModName, nlas);
+    for (auto n : nlas)
       if (n.root() == oldModName)
         nlaTable->updateModuleInNLA(n, oldModName, newModuleName);
   };


### PR DESCRIPTION
This commit fixes an issue with `PrefixModules` pass when it was not updating the `NLATable` with the new prefixed modules. 
It is critical to keep the `NLATable` analysis updated, when new Modules are added and NLAs are renamed. 