### PR TITLE
[FIRRTL] Fix uses of deprecated APInt functions

### DIFF
--- a/include/circt/Support/APInt.h
+++ b/include/circt/Support/APInt.h
@@ -17,9 +17,9 @@
 
 namespace circt {
 
-/// A safe version of APInt::sextOrSelf that will NOT assert on zero-width
+/// A safe version of APInt::sext that will NOT assert on zero-width
 /// signed APSInts.  Instead of asserting, this will zero extend.
-APInt sextOrSelfZeroWidth(APInt value, unsigned width);
+APInt sextZeroWidth(APInt value, unsigned width);
 
 /// A safe version of APSInt::extOrTrunc that will NOT assert on zero-width
 /// signed APSInts.  Instead of asserting, this will zero extend.

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -200,7 +200,7 @@ constFoldFIRRTLBinaryOp(Operation *op, ArrayRef<Attribute> operands,
   // If the result type is smaller than the computation then we need to
   // narrow the constant after the calculation.
   if (opKind == BinOpKind::DivideOrShift)
-    resultValue = resultValue.truncOrSelf(resultType.getWidthOrSentinel());
+    resultValue = resultValue.trunc(resultType.getWidthOrSentinel());
 
   assert((unsigned)resultType.getWidthOrSentinel() ==
          resultValue.getBitWidth());
@@ -540,21 +540,21 @@ OpFoldResult LEQPrimOp::fold(ArrayRef<Attribute> operands) {
 
       // leq(x, const) -> 0 where const < minValue of the signed type of x
       if (!isUnsigned &&
-          sextOrSelfZeroWidth(rhsCst.getValue(), commonWidth)
-              .slt(getMinSignedValue(*width).sextOrSelf(commonWidth)))
+          sextZeroWidth(rhsCst.getValue(), commonWidth)
+              .slt(getMinSignedValue(*width).sext(commonWidth)))
         return getIntAttr(getType(), APInt(1, 0));
 
       // leq(x, const) -> 1 where const >= maxValue of the unsigned type of x
       if (isUnsigned &&
           rhsCst.getValue()
-              .zextOrSelf(commonWidth)
-              .uge(getMaxUnsignedValue(*width).zextOrSelf(commonWidth)))
+              .zext(commonWidth)
+              .uge(getMaxUnsignedValue(*width).zext(commonWidth)))
         return getIntAttr(getType(), APInt(1, 1));
 
       // leq(x, const) -> 1 where const >= maxValue of the signed type of x
       if (!isUnsigned &&
-          sextOrSelfZeroWidth(rhsCst.getValue(), commonWidth)
-              .sge(getMaxSignedValue(*width).sextOrSelf(commonWidth)))
+          sextZeroWidth(rhsCst.getValue(), commonWidth)
+              .sge(getMaxSignedValue(*width).sext(commonWidth)))
         return getIntAttr(getType(), APInt(1, 1));
     }
   }
@@ -593,21 +593,21 @@ OpFoldResult LTPrimOp::fold(ArrayRef<Attribute> operands) {
       // Handled explicitly above.
 
       if (!isUnsigned &&
-          sextOrSelfZeroWidth(rhsCst.getValue(), commonWidth)
-              .sle(getMinSignedValue(*width).sextOrSelf(commonWidth)))
+          sextZeroWidth(rhsCst.getValue(), commonWidth)
+              .sle(getMinSignedValue(*width).sext(commonWidth)))
         return getIntAttr(getType(), APInt(1, 0));
 
       // lt(x, const) -> 1 where const > maxValue of the unsigned type of x
       if (isUnsigned &&
           rhsCst.getValue()
-              .zextOrSelf(commonWidth)
-              .ugt(getMaxUnsignedValue(*width).zextOrSelf(commonWidth)))
+              .zext(commonWidth)
+              .ugt(getMaxUnsignedValue(*width).zext(commonWidth)))
         return getIntAttr(getType(), APInt(1, 1));
 
       // lt(x, const) -> 1 where const > maxValue of the signed type of x
       if (!isUnsigned &&
-          sextOrSelfZeroWidth(rhsCst.getValue(), commonWidth)
-              .sgt(getMaxSignedValue(*width).sextOrSelf(commonWidth)))
+          sextZeroWidth(rhsCst.getValue(), commonWidth)
+              .sgt(getMaxSignedValue(*width).sext(commonWidth)))
         return getIntAttr(getType(), APInt(1, 1));
     }
   }
@@ -645,14 +645,14 @@ OpFoldResult GEQPrimOp::fold(ArrayRef<Attribute> operands) {
       // geq(x, const) -> 0 where const > maxValue of the unsigned type of x
       if (isUnsigned &&
           rhsCst.getValue()
-              .zextOrSelf(commonWidth)
-              .ugt(getMaxUnsignedValue(*width).zextOrSelf(commonWidth)))
+              .zext(commonWidth)
+              .ugt(getMaxUnsignedValue(*width).zext(commonWidth)))
         return getIntAttr(getType(), APInt(1, 0));
 
       // geq(x, const) -> 0 where const > maxValue of the signed type of x
       if (!isUnsigned &&
-          sextOrSelfZeroWidth(rhsCst.getValue(), commonWidth)
-              .sgt(getMaxSignedValue(*width).sextOrSelf(commonWidth)))
+          sextZeroWidth(rhsCst.getValue(), commonWidth)
+              .sgt(getMaxSignedValue(*width).sext(commonWidth)))
         return getIntAttr(getType(), APInt(1, 0));
 
       // geq(x, const) -> 1 where const <= minValue of the unsigned type of x
@@ -660,8 +660,8 @@ OpFoldResult GEQPrimOp::fold(ArrayRef<Attribute> operands) {
 
       // geq(x, const) -> 1 where const <= minValue of the signed type of x
       if (!isUnsigned &&
-          sextOrSelfZeroWidth(rhsCst.getValue(), commonWidth)
-              .sle(getMinSignedValue(*width).sextOrSelf(commonWidth)))
+          sextZeroWidth(rhsCst.getValue(), commonWidth)
+              .sle(getMinSignedValue(*width).sext(commonWidth)))
         return getIntAttr(getType(), APInt(1, 1));
     }
   }
@@ -693,14 +693,14 @@ OpFoldResult GTPrimOp::fold(ArrayRef<Attribute> operands) {
       // gt(x, const) -> 0 where const >= maxValue of the unsigned type of x
       if (isUnsigned &&
           rhsCst.getValue()
-              .zextOrSelf(commonWidth)
-              .uge(getMaxUnsignedValue(*width).zextOrSelf(commonWidth)))
+              .zext(commonWidth)
+              .uge(getMaxUnsignedValue(*width).zext(commonWidth)))
         return getIntAttr(getType(), APInt(1, 0));
 
       // gt(x, const) -> 0 where const >= maxValue of the signed type of x
       if (!isUnsigned &&
-          sextOrSelfZeroWidth(rhsCst.getValue(), commonWidth)
-              .sge(getMaxSignedValue(*width).sextOrSelf(commonWidth)))
+          sextZeroWidth(rhsCst.getValue(), commonWidth)
+              .sge(getMaxSignedValue(*width).sext(commonWidth)))
         return getIntAttr(getType(), APInt(1, 0));
 
       // gt(x, const) -> 1 where const < minValue of the unsigned type of x
@@ -708,8 +708,8 @@ OpFoldResult GTPrimOp::fold(ArrayRef<Attribute> operands) {
 
       // gt(x, const) -> 1 where const < minValue of the signed type of x
       if (!isUnsigned &&
-          sextOrSelfZeroWidth(rhsCst.getValue(), commonWidth)
-              .slt(getMinSignedValue(*width).sextOrSelf(commonWidth)))
+          sextZeroWidth(rhsCst.getValue(), commonWidth)
+              .slt(getMinSignedValue(*width).sext(commonWidth)))
         return getIntAttr(getType(), APInt(1, 1));
     }
   }
@@ -973,8 +973,8 @@ OpFoldResult CatPrimOp::fold(ArrayRef<Attribute> operands) {
   if (auto lhs = getConstant(operands[0]))
     if (auto rhs = getConstant(operands[1])) {
       auto destWidth = getType().getWidthOrSentinel();
-      APInt tmp1 = lhs->zextOrSelf(destWidth) << rhs->getBitWidth();
-      APInt tmp2 = rhs->zextOrSelf(destWidth);
+      APInt tmp1 = lhs->zext(destWidth) << rhs->getBitWidth();
+      APInt tmp2 = rhs->zext(destWidth);
       return getIntAttr(getType(), tmp1 | tmp2);
     }
 
@@ -1062,7 +1062,7 @@ OpFoldResult BitsPrimOp::fold(ArrayRef<Attribute> operands) {
   if (hasKnownWidthIntTypes(*this))
     if (auto cst = getConstant(operands[0]))
       return getIntAttr(getType(),
-                        cst->lshr(lo()).truncOrSelf(hi() - lo() + 1));
+                        cst->lshr(lo()).trunc(hi() - lo() + 1));
 
   return {};
 }
@@ -1251,7 +1251,7 @@ OpFoldResult ShrPrimOp::fold(ArrayRef<Attribute> operands) {
     else
       value = cst->lshr(std::min(shiftAmount, inputWidth));
     auto resultWidth = std::max(inputWidth - shiftAmount, 1);
-    return getIntAttr(getType(), value.truncOrSelf(resultWidth));
+    return getIntAttr(getType(), value.trunc(resultWidth));
   }
   return {};
 }
@@ -1298,7 +1298,7 @@ OpFoldResult HeadPrimOp::fold(ArrayRef<Attribute> operands) {
       int shiftAmount =
           input().getType().cast<IntType>().getWidthOrSentinel() - amount();
       return getIntAttr(getType(),
-                        cst->lshr(shiftAmount).truncOrSelf(amount()));
+                        cst->lshr(shiftAmount).trunc(amount()));
     }
 
   return {};
@@ -1308,7 +1308,7 @@ OpFoldResult TailPrimOp::fold(ArrayRef<Attribute> operands) {
   if (hasKnownWidthIntTypes(*this))
     if (auto cst = getConstant(operands[0]))
       return getIntAttr(getType(),
-                        cst->truncOrSelf(getType().getWidthOrSentinel()));
+                        cst->trunc(getType().getWidthOrSentinel()));
   return {};
 }
 

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -539,22 +539,19 @@ OpFoldResult LEQPrimOp::fold(ArrayRef<Attribute> operands) {
       // This can never occur since const is unsigned and cannot be less than 0.
 
       // leq(x, const) -> 0 where const < minValue of the signed type of x
-      if (!isUnsigned &&
-          sextZeroWidth(rhsCst.getValue(), commonWidth)
-              .slt(getMinSignedValue(*width).sext(commonWidth)))
+      if (!isUnsigned && sextZeroWidth(rhsCst.getValue(), commonWidth)
+                             .slt(getMinSignedValue(*width).sext(commonWidth)))
         return getIntAttr(getType(), APInt(1, 0));
 
       // leq(x, const) -> 1 where const >= maxValue of the unsigned type of x
-      if (isUnsigned &&
-          rhsCst.getValue()
-              .zext(commonWidth)
-              .uge(getMaxUnsignedValue(*width).zext(commonWidth)))
+      if (isUnsigned && rhsCst.getValue()
+                            .zext(commonWidth)
+                            .uge(getMaxUnsignedValue(*width).zext(commonWidth)))
         return getIntAttr(getType(), APInt(1, 1));
 
       // leq(x, const) -> 1 where const >= maxValue of the signed type of x
-      if (!isUnsigned &&
-          sextZeroWidth(rhsCst.getValue(), commonWidth)
-              .sge(getMaxSignedValue(*width).sext(commonWidth)))
+      if (!isUnsigned && sextZeroWidth(rhsCst.getValue(), commonWidth)
+                             .sge(getMaxSignedValue(*width).sext(commonWidth)))
         return getIntAttr(getType(), APInt(1, 1));
     }
   }
@@ -592,22 +589,19 @@ OpFoldResult LTPrimOp::fold(ArrayRef<Attribute> operands) {
       // lt(x, const) -> 0 where const <= minValue of the unsigned type of x
       // Handled explicitly above.
 
-      if (!isUnsigned &&
-          sextZeroWidth(rhsCst.getValue(), commonWidth)
-              .sle(getMinSignedValue(*width).sext(commonWidth)))
+      if (!isUnsigned && sextZeroWidth(rhsCst.getValue(), commonWidth)
+                             .sle(getMinSignedValue(*width).sext(commonWidth)))
         return getIntAttr(getType(), APInt(1, 0));
 
       // lt(x, const) -> 1 where const > maxValue of the unsigned type of x
-      if (isUnsigned &&
-          rhsCst.getValue()
-              .zext(commonWidth)
-              .ugt(getMaxUnsignedValue(*width).zext(commonWidth)))
+      if (isUnsigned && rhsCst.getValue()
+                            .zext(commonWidth)
+                            .ugt(getMaxUnsignedValue(*width).zext(commonWidth)))
         return getIntAttr(getType(), APInt(1, 1));
 
       // lt(x, const) -> 1 where const > maxValue of the signed type of x
-      if (!isUnsigned &&
-          sextZeroWidth(rhsCst.getValue(), commonWidth)
-              .sgt(getMaxSignedValue(*width).sext(commonWidth)))
+      if (!isUnsigned && sextZeroWidth(rhsCst.getValue(), commonWidth)
+                             .sgt(getMaxSignedValue(*width).sext(commonWidth)))
         return getIntAttr(getType(), APInt(1, 1));
     }
   }
@@ -643,25 +637,22 @@ OpFoldResult GEQPrimOp::fold(ArrayRef<Attribute> operands) {
       commonWidth = std::max(commonWidth, 0);
 
       // geq(x, const) -> 0 where const > maxValue of the unsigned type of x
-      if (isUnsigned &&
-          rhsCst.getValue()
-              .zext(commonWidth)
-              .ugt(getMaxUnsignedValue(*width).zext(commonWidth)))
+      if (isUnsigned && rhsCst.getValue()
+                            .zext(commonWidth)
+                            .ugt(getMaxUnsignedValue(*width).zext(commonWidth)))
         return getIntAttr(getType(), APInt(1, 0));
 
       // geq(x, const) -> 0 where const > maxValue of the signed type of x
-      if (!isUnsigned &&
-          sextZeroWidth(rhsCst.getValue(), commonWidth)
-              .sgt(getMaxSignedValue(*width).sext(commonWidth)))
+      if (!isUnsigned && sextZeroWidth(rhsCst.getValue(), commonWidth)
+                             .sgt(getMaxSignedValue(*width).sext(commonWidth)))
         return getIntAttr(getType(), APInt(1, 0));
 
       // geq(x, const) -> 1 where const <= minValue of the unsigned type of x
       // Handled explicitly above.
 
       // geq(x, const) -> 1 where const <= minValue of the signed type of x
-      if (!isUnsigned &&
-          sextZeroWidth(rhsCst.getValue(), commonWidth)
-              .sle(getMinSignedValue(*width).sext(commonWidth)))
+      if (!isUnsigned && sextZeroWidth(rhsCst.getValue(), commonWidth)
+                             .sle(getMinSignedValue(*width).sext(commonWidth)))
         return getIntAttr(getType(), APInt(1, 1));
     }
   }
@@ -691,25 +682,22 @@ OpFoldResult GTPrimOp::fold(ArrayRef<Attribute> operands) {
       commonWidth = std::max(commonWidth, 0);
 
       // gt(x, const) -> 0 where const >= maxValue of the unsigned type of x
-      if (isUnsigned &&
-          rhsCst.getValue()
-              .zext(commonWidth)
-              .uge(getMaxUnsignedValue(*width).zext(commonWidth)))
+      if (isUnsigned && rhsCst.getValue()
+                            .zext(commonWidth)
+                            .uge(getMaxUnsignedValue(*width).zext(commonWidth)))
         return getIntAttr(getType(), APInt(1, 0));
 
       // gt(x, const) -> 0 where const >= maxValue of the signed type of x
-      if (!isUnsigned &&
-          sextZeroWidth(rhsCst.getValue(), commonWidth)
-              .sge(getMaxSignedValue(*width).sext(commonWidth)))
+      if (!isUnsigned && sextZeroWidth(rhsCst.getValue(), commonWidth)
+                             .sge(getMaxSignedValue(*width).sext(commonWidth)))
         return getIntAttr(getType(), APInt(1, 0));
 
       // gt(x, const) -> 1 where const < minValue of the unsigned type of x
       // This can never occur since const is unsigned and cannot be less than 0.
 
       // gt(x, const) -> 1 where const < minValue of the signed type of x
-      if (!isUnsigned &&
-          sextZeroWidth(rhsCst.getValue(), commonWidth)
-              .slt(getMinSignedValue(*width).sext(commonWidth)))
+      if (!isUnsigned && sextZeroWidth(rhsCst.getValue(), commonWidth)
+                             .slt(getMinSignedValue(*width).sext(commonWidth)))
         return getIntAttr(getType(), APInt(1, 1));
     }
   }
@@ -1061,8 +1049,7 @@ OpFoldResult BitsPrimOp::fold(ArrayRef<Attribute> operands) {
   // Constant fold.
   if (hasKnownWidthIntTypes(*this))
     if (auto cst = getConstant(operands[0]))
-      return getIntAttr(getType(),
-                        cst->lshr(lo()).trunc(hi() - lo() + 1));
+      return getIntAttr(getType(), cst->lshr(lo()).trunc(hi() - lo() + 1));
 
   return {};
 }
@@ -1297,8 +1284,7 @@ OpFoldResult HeadPrimOp::fold(ArrayRef<Attribute> operands) {
     if (auto cst = getConstant(operands[0])) {
       int shiftAmount =
           input().getType().cast<IntType>().getWidthOrSentinel() - amount();
-      return getIntAttr(getType(),
-                        cst->lshr(shiftAmount).trunc(amount()));
+      return getIntAttr(getType(), cst->lshr(shiftAmount).trunc(amount()));
     }
 
   return {};
@@ -1307,8 +1293,7 @@ OpFoldResult HeadPrimOp::fold(ArrayRef<Attribute> operands) {
 OpFoldResult TailPrimOp::fold(ArrayRef<Attribute> operands) {
   if (hasKnownWidthIntTypes(*this))
     if (auto cst = getConstant(operands[0]))
-      return getIntAttr(getType(),
-                        cst->trunc(getType().getWidthOrSentinel()));
+      return getIntAttr(getType(), cst->trunc(getType().getWidthOrSentinel()));
   return {};
 }
 

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -589,6 +589,7 @@ OpFoldResult LTPrimOp::fold(ArrayRef<Attribute> operands) {
       // lt(x, const) -> 0 where const <= minValue of the unsigned type of x
       // Handled explicitly above.
 
+      // lt(x, const) -> 0 where const <= minValue of the signed type of x
       if (!isUnsigned && sextZeroWidth(rhsCst.getValue(), commonWidth)
                              .sle(getMinSignedValue(*width).sext(commonWidth)))
         return getIntAttr(getType(), APInt(1, 0));

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3606,7 +3606,7 @@ ParseResult FIRCircuitParser::parseModule(CircuitOp circuit,
       // If the integer parameter is less than 32-bits, sign extend this to a
       // 32-bit value.  This needs to eventually emit as a 32-bit value in
       // Verilog and we want to get the size correct immediately.
-      result = result.sextOrSelf(32);
+      result = result.sext(32);
 
       value = builder.getIntegerAttr(
           builder.getIntegerType(result.getBitWidth(), result.isSignBitSet()),

--- a/lib/Support/APInt.cpp
+++ b/lib/Support/APInt.cpp
@@ -16,8 +16,7 @@
 using namespace circt;
 
 APInt circt::sextZeroWidth(APInt value, unsigned width) {
-  return value.getBitWidth() ? value.sext(width)
-                             : value.zext(width);
+  return value.getBitWidth() ? value.sext(width) : value.zext(width);
 }
 
 APSInt circt::extOrTruncZeroWidth(APSInt value, unsigned width) {

--- a/lib/Support/APInt.cpp
+++ b/lib/Support/APInt.cpp
@@ -15,9 +15,9 @@
 
 using namespace circt;
 
-APInt circt::sextOrSelfZeroWidth(APInt value, unsigned width) {
-  return value.getBitWidth() ? value.sextOrSelf(width)
-                             : value.zextOrSelf(width);
+APInt circt::sextZeroWidth(APInt value, unsigned width) {
+  return value.getBitWidth() ? value.sext(width)
+                             : value.zext(width);
 }
 
 APSInt circt::extOrTruncZeroWidth(APSInt value, unsigned width) {


### PR DESCRIPTION
APInt's extending and truncating functions have been relaxed to allow
the desired width to be the same as the input width.  Since this change
the following functions have been deprecated and can be replaced with
their simpler counterparts:

```
truncOrSelf -> trunc
zextOrSelf -> zext
sextOrSelf -> sext
```

See https://reviews.llvm.org/D125556 for relaxing the restrictions.
See https://reviews.llvm.org/D125558 for the deprecation.
Fixes #3201.