### PR TITLE
[FIRRTL] rename `mem-to-regOfVec` to `firrtl-mem-to-reg-of-vec`

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -451,7 +451,7 @@ def ExtractInstances : Pass<"firrtl-extract-instances", "firrtl::CircuitOp"> {
   let dependentDialects = ["sv::SVDialect", "circt::hw::HWDialect"];
 }
 
-def MemToRegOfVec : Pass<"mem-to-regofvec", "firrtl::CircuitOp"> {
+def MemToRegOfVec : Pass<"firrtl-mem-to-reg-of-vec", "firrtl::CircuitOp"> {
   let summary = "Convert the memory to a Register vector";
   let description = [{
     This pass generates the logic to implement a memory using Registers.

--- a/test/Dialect/FIRRTL/SFCTests/emit-omir.fir
+++ b/test/Dialect/FIRRTL/SFCTests/emit-omir.fir
@@ -1,4 +1,4 @@
-; RUN: firtool --repl-seq-mem --repl-seq-mem-file="dummy" --mem-to-regofvec=0 --verify-diagnostics --verilog --emit-omir %s | FileCheck %s
+; RUN: firtool --repl-seq-mem --repl-seq-mem-file="dummy" --mem-to-reg-of-vec=0 --verify-diagnostics --verilog --emit-omir %s | FileCheck %s
 
 circuit Foo : %[[
   {

--- a/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
+++ b/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='firrtl.circuit(mem-to-regofvec)' %s | FileCheck  %s
+// RUN: circt-opt -pass-pipeline='firrtl.circuit(firrtl-mem-to-reg-of-vec)' %s | FileCheck  %s
 
 firrtl.circuit "Mem" attributes {annotations = [{class = "sifive.enterprise.firrtl.ConvertMemToRegOfVecAnnotation$"}]}{
   firrtl.module public @Mem() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]}{

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -212,8 +212,8 @@ static cl::opt<bool>
                      cl::init(true), cl::cat(mainCategory));
 
 static cl::opt<bool>
-    memToRegOfVec("mem-to-regofvec",
-                  cl::desc("run the memToRegOfVec transform pass on firrtl"),
+    memToRegOfVec("mem-to-reg-of-vec",
+                  cl::desc("convert combinational memories to registers"),
                   cl::init(true));
 
 static cl::opt<bool>


### PR DESCRIPTION
This adds the `firrtl-` prefix to the beginning of the command line
option for this pass, so that we keep our dialect passes namespaced.

I found the use of capital letters in the command line option to be a
unconventional, so I spread it out to the significantly longer
`firrtl-mem-to-reg-of-vec`.  In the future maybe we can think about
renaming this pass.