### PR TITLE
[Calyx] Relax `calyx.enable` verifier

### DIFF
--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -179,6 +179,13 @@ LogicalResult calyx::verifyCell(Operation *op) {
 
 LogicalResult calyx::verifyControlLikeOp(Operation *op) {
   auto parent = op->getParentOp();
+
+  if (isa<calyx::EnableOp>(op) &&
+      !isa<calyx::CalyxDialect>(parent->getDialect())) {
+    // calyx.enable mixed with other dialects; anything goes.
+    return success();
+  }
+
   if (!hasControlRegion(parent))
     return op->emitOpError()
            << "has parent: " << parent


### PR DESCRIPTION
This allows embedding `calyx.enable` operations into regions defined by operations not in the Calyx dialect.

Discussion in https://github.com/llvm/circt/pull/3138.