### PR TITLE
[FSM] Remove IsolatedFromAbove trait from `fsm.machine`

### DIFF
--- a/include/circt/Dialect/FSM/FSMOps.td
+++ b/include/circt/Dialect/FSM/FSMOps.td
@@ -15,8 +15,8 @@ include "mlir/Interfaces/ControlFlowInterfaces.td"
 
 def HasCustomSSAName : DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>;
 
-def MachineOp : FSMOp<"machine", [HasParent<"mlir::ModuleOp">, FunctionOpInterface,
-      Symbol, SymbolTable, IsolatedFromAbove, NoTerminator]> {
+def MachineOp : FSMOp<"machine", [FunctionOpInterface,
+      Symbol, SymbolTable, NoTerminator]> {
   let summary = "Define a finite-state machine";
   let description = [{
     `fsm.machine` represents a finite-state machine, including a machine name,

--- a/include/circt/Dialect/FSM/Passes.td
+++ b/include/circt/Dialect/FSM/Passes.td
@@ -15,7 +15,7 @@
 
 include "mlir/Pass/PassBase.td"
 
-def PrintFSMGraph : Pass<"fsm-print-graph", "circt::fsm::MachineOp"> {
+def PrintFSMGraph : Pass<"fsm-print-graph", "mlir::ModuleOp"> {
   let summary = "Print a DOT graph of the module hierarchy.";
   let constructor =  "circt::fsm::createPrintFSMGraphPass()";
 }

--- a/lib/Dialect/FSM/Transforms/PrintFSMGraph.cpp
+++ b/lib/Dialect/FSM/Transforms/PrintFSMGraph.cpp
@@ -24,9 +24,10 @@ namespace {
 struct PrintFSMGraphPass : public PrintFSMGraphBase<PrintFSMGraphPass> {
   PrintFSMGraphPass(raw_ostream &os) : os(os) {}
   void runOnOperation() override {
-    auto &fsmGraph = getAnalysis<fsm::FSMGraph>();
-    llvm::WriteGraph(os, &fsmGraph, /*ShortNames=*/false);
-    markAllAnalysesPreserved();
+    getOperation().walk([&](fsm::MachineOp machine) {
+      auto fsmGraph = fsm::FSMGraph(machine);
+      llvm::WriteGraph(os, &fsmGraph, /*ShortNames=*/false);
+    });
   }
   raw_ostream &os;
 };


### PR DESCRIPTION
As discussed in #3138, the IsolatedFromAbove trait is removed from the `fsm.machine` to allow it to be embedded within other operations, wherein it is possible to reference SSA values and symbols defined within an outer scope.

This change is fairly motivated by using `fsm.machine` inside a Calyx component. If it is, in the future, found that this change is prohibitive in writing generic/performant transformations on `fsm.machine`s, then FSM should take presendence, with the `IsolatedFromAbove` trait being re-introduced and the Calyx pass re-evaluated.