### PR TITLE
Add an op to constrain output statements in graph regions

### DIFF
--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -24,6 +24,25 @@ def isModuleSymbol : AttrConstraint<
 // Control flow like-operations
 //===----------------------------------------------------------------------===//
 
+def OrderedOutputOp : SVOp<"ordered", [SingleBlock, NoTerminator, NoRegionArguments,
+                             NonProceduralOp]> {
+  let summary = "a sub-graph region which guarantees to output statements in-order";
+
+  let description = [{
+    This operation groups operations into a region whose purpose is to force
+    verilog emission to be statement-by-statement, in-order.  This allows
+    side-effecting operations, or macro expansions which applie to subsequent
+    operations to be properly sequenced.
+    This operation is for non-procedural regions and its body is non-procedural.
+  }];
+
+  let regions = (region SizedRegion<1>:$body);
+  let arguments = (ins);
+  let results = (outs);
+
+  let assemblyFormat = "$body attr-dict";
+}
+
 def IfDefOp : SVOp<"ifdef", [SingleBlock, NoTerminator, NoRegionArguments,
                              NonProceduralOp]> {
   let summary = "'ifdef MACRO' block";

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -34,8 +34,8 @@ public:
             // Declarations.
             RegOp, WireOp, LocalParamOp, XMROp,
             // Control flow.
-            IfDefOp, IfDefProceduralOp, IfOp, AlwaysOp, AlwaysCombOp,
-            AlwaysFFOp, InitialOp, CaseOp,
+            OrderedOutputOp, IfDefOp, IfDefProceduralOp, IfOp, AlwaysOp,
+            AlwaysCombOp, AlwaysFFOp, InitialOp, CaseOp,
             // Other Statements.
             AssignOp, BPAssignOp, PAssignOp, ForceOp, ReleaseOp, AliasOp,
             FWriteOp, VerbatimOp,
@@ -97,6 +97,7 @@ public:
   HANDLE(MacroRefExprOp, Unhandled);
 
   // Control flow.
+  HANDLE(OrderedOutputOp, Unhandled);
   HANDLE(IfDefOp, Unhandled);
   HANDLE(IfDefProceduralOp, Unhandled);
   HANDLE(IfOp, Unhandled);

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -2485,6 +2485,7 @@ private:
   LogicalResult visitStmt(TypedeclOp op);
 
   LogicalResult emitIfDef(Operation *op, MacroIdentAttr cond);
+  LogicalResult visitSV(OrderedOutputOp op);
   LogicalResult visitSV(IfDefOp op) { return emitIfDef(op, op.cond()); }
   LogicalResult visitSV(IfDefProceduralOp op) {
     return emitIfDef(op, op.cond());
@@ -3089,6 +3090,13 @@ void StmtEmitter::emitBlockAsStatement(Block *block,
   if (!multiLineComment.empty())
     os << " // " << multiLineComment;
   os << '\n';
+}
+
+LogicalResult StmtEmitter::visitSV(OrderedOutputOp ooop) {
+  // Emit the body.
+  for (auto &op : *ooop.getBody())
+    emitStatement(&op);
+  return success();
 }
 
 LogicalResult StmtEmitter::visitSV(IfOp op) {

--- a/test/Conversion/ExportVerilog/verilog-basic.mlir
+++ b/test/Conversion/ExportVerilog/verilog-basic.mlir
@@ -331,6 +331,34 @@ hw.module @SimpleConstPrintReset(%clock: i1, %reset: i1, %in4: i4) -> () {
 
 }
 
+
+// CHECK-LABEL: module ordered_region
+// CHECK-NEXT: input a
+// CHECK-EMPTY:
+hw.module @ordered_region(%a: i1) {
+  sv.ordered {
+    // CHECK-NEXT: `ifdef foo
+    sv.ifdef "foo" {
+      // CHECK-NEXT: wire
+      %wire = sv.wire : !hw.inout<i1>
+      // CHECK-EMPTY:
+      // CHECK-NEXT: assign
+      sv.assign %wire, %a : i1
+    }
+    // CHECK-NEXT: `endif
+    // CHECK-NEXT: `ifdef bar
+    sv.ifdef "bar" {
+      // CHECK-NEXT: wire
+      %wire = sv.wire : !hw.inout<i1>
+      // CHECK-EMPTY:
+      // CHECK-NEXT: assign
+      sv.assign %wire, %a : i1
+    }
+    // CHECK-NEXT: `endif
+  }
+}
+
+
 hw.module.extern @MyExtModule(%in: i8) -> (out: i1) attributes {verilogName = "FooExtModule"}
 hw.module.extern @AParameterizedExtModule<CFG: none>(%in: i8) -> (out: i1)
 

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -331,3 +331,24 @@ hw.module @nested_wire(%a: i1) {
     sv.assign %wire, %a : i1
   }
 }
+
+
+// CHECK-LABEL: hw.module @ordered_region
+hw.module @ordered_region(%a: i1) {
+  // CHECK: sv.ordered 
+  sv.ordered {
+    // CHECK: sv.ifdef "foo"
+    sv.ifdef "foo" {
+      // CHECK: sv.wire
+      %wire = sv.wire : !hw.inout<i1>
+      // CHECK: sv.assign
+      sv.assign %wire, %a : i1
+    }
+    sv.ifdef "bar" {
+      // CHECK: sv.wire
+      %wire = sv.wire : !hw.inout<i1>
+      // CHECK: sv.assign
+      sv.assign %wire, %a : i1
+    }
+  }
+}


### PR DESCRIPTION
Since graph regions don't have explicit output order, we add a region which outputs statements in order but is still a graph region.  This let's macros which might attach to subsequent operations on expansion or other side-effecting code to be properly sequenced.