### PR TITLE
[SVTestExtractCode][LowerToHW] Add coverage exclusion flag to testbench

### DIFF
--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -60,7 +60,7 @@ def HWModuleOp : HWModuleOpBase<"module",
   }];
   let arguments = (ins StrArrayAttr:$argNames, StrArrayAttr:$resultNames,
                        ParamDeclArrayAttr:$parameters,
-                       StrAttr:$comment);
+                       StrAttr:$comment, StrAttr:$topOfFileComment);
   let results = (outs);
   let regions = (region SizedRegion<1>:$body);
 
@@ -69,11 +69,13 @@ def HWModuleOp : HWModuleOpBase<"module",
     OpBuilder<(ins "StringAttr":$name, "ArrayRef<PortInfo>":$ports,
                    CArg<"ArrayAttr", "{}">:$parameters,
                    CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes,
-                   CArg<"StringAttr", "{}">:$comment)>,
+                   CArg<"StringAttr", "{}">:$comment,
+                   CArg<"StringAttr", "{}">:$topOfFileComment)>,
     OpBuilder<(ins "StringAttr":$name, "const ModulePortInfo &":$ports,
                    CArg<"ArrayAttr", "{}">:$parameters,
                    CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes,
-                   CArg<"StringAttr", "{}">:$comment)>
+                   CArg<"StringAttr", "{}">:$comment,
+                   CArg<"StringAttr", "{}">:$topOfFileComment)>
   ];
 
   let extraModuleClassDeclaration = [{

--- a/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
+++ b/lib/Bindings/Python/circt/dialects/_hw_ops_ext.py
@@ -296,6 +296,8 @@ class HWModuleOp(ModuleLike):
   ):
     if "comment" not in attributes:
       attributes["comment"] = StringAttr.get("")
+    if "topOfFileComment" not in attributes:
+      attributes["topOfFileComment"] = StringAttr.get("")
     super().__init__(name,
                      input_ports,
                      output_ports,
@@ -359,6 +361,8 @@ class HWModuleExternOp(ModuleLike):
   ):
     if "comment" not in attributes:
       attributes["comment"] = StringAttr.get("")
+    if "topOfFileComment" not in attributes:
+      attributes["topOfFileComment"] = StringAttr.get("")
     super().__init__(name,
                      input_ports,
                      output_ports,

--- a/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
+++ b/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
@@ -136,6 +136,8 @@ struct FileInfo {
   /// replicated per-file operations the operation should be emitted.
   SmallVector<OpFileInfo, 1> ops;
 
+  StringAttr topOfFileComment;
+
   /// Whether to emit the replicated per-file operations.
   bool emitReplicatedOps = true;
 

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1059,6 +1059,8 @@ FIRRTLModuleLowering::lowerModule(FModuleOp oldModule, Block *topLevelModule,
       newModule->setAttr("output_file", testBenchDir);
       newModule->setAttr("firrtl.extract.do_not_extract",
                          builder.getUnitAttr());
+      newModule.topOfFileCommentAttr(
+          builder.getStringAttr("//VCS coverage exclude_file"));
     }
 
   bool failed = false;

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -166,6 +166,7 @@ static hw::HWModuleOp createModuleForCut(hw::HWModuleOp op,
       b.getStringAttr(getVerilogModuleNameAttr(op).getValue() + suffix), ports);
   if (path)
     newMod->setAttr("output_file", path);
+  newMod.topOfFileCommentAttr(b.getStringAttr("//VCS coverage exclude_file"));
 
   // Update the mapping from old values to cloned values
   for (auto port : llvm::enumerate(inputs))

--- a/test/Conversion/ExportVerilog/output-file.mlir
+++ b/test/Conversion/ExportVerilog/output-file.mlir
@@ -21,10 +21,12 @@ hw.module @foo2(%a: i1) -> (b: i1) attributes {output_file = #file2, output_file
 
 #file3 = #hw.output_file<"dir2/", includeReplicatedOps>
 #filelist3 = [#hw.output_filelist<"dir5/bar.f">]
-hw.module @foo3(%a: i1) -> (b: i1) attributes {output_file = #file3, output_filelist = #filelist3} {
+hw.module @foo3(%a: i1) -> (b: i1) attributes {output_file = #file3, output_filelist = #filelist3, topOfFileComment="TOP COMMENT"} {
   hw.output %a : i1
 }
 // CHECK-LABEL: FILE "dir2{{.}}foo3.sv"
+// CHECK-EMPTY:
+// CHECK-NEXT: TOP COMMENT
 // CHECK-LABEL: module foo3
 // CHECK-LABEL: module B
 

--- a/test/Conversion/FIRRTLToHW/module-hierarchy-file.mlir
+++ b/test/Conversion/FIRRTLToHW/module-hierarchy-file.mlir
@@ -66,10 +66,12 @@ firrtl.circuit "MyTestHarness" attributes {annotations = [ {class = "sifive.ente
 
   // CHECK-LABEL: hw.module private @Testbench
   // CHECK-SAME:  firrtl.extract.do_not_extract
+  // CHECK-SAME:  topOfFileComment = "//VCS coverage exclude_file"
   firrtl.module private @Testbench() {}
 
   // CHECK-LABEL: hw.module @MyTestHarness
   // CHECK-SAME:  firrtl.extract.do_not_extract
+  // CHECK-SAME:  topOfFileComment = "//VCS coverage exclude_file"
   firrtl.module @MyTestHarness() {
     firrtl.instance myDUT @MyDUT()
     firrtl.instance myTestBench @Testbench()

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -6,7 +6,7 @@
 // CHECK-NOT: attributes
 // CHECK-NEXT: hw.module.extern @foo_assert
 // CHECK-NOT: attributes
-// CHECK: hw.module @issue1246_assert(%clock: i1) attributes {output_file = #hw.output_file<"dir3/", excludeFromFileList, includeReplicatedOps>}
+// CHECK: hw.module @issue1246_assert(%clock: i1) attributes {output_file = #hw.output_file<"dir3/", excludeFromFileList, includeReplicatedOps>, topOfFileComment = "//VCS coverage exclude_file"}
 // CHECK: sv.assert
 // CHECK: sv.error "Assertion failed"
 // CHECK: sv.error "assert:"
@@ -15,11 +15,11 @@
 // CHECK: sv.fatal 1
 // CHECK: foo_assert
 // CHECK: hw.module @issue1246_assume(%clock: i1)
-// CHECK-NOT: attributes
+// CHECK-SAME: attributes {topOfFileComment = "//VCS coverage exclude_file"}
 // CHECK: sv.assume
 // CHECK: foo_assume
 // CHECK: hw.module @issue1246_cover(%clock: i1)
-// CHECK-NOT: attributes
+// CHECK-SAME: attributes {topOfFileComment = "//VCS coverage exclude_file"}
 // CHECK: sv.cover
 // CHECK: foo_cover
 // CHECK: hw.module @issue1246


### PR DESCRIPTION
This PR adds "// VCS coverage exclude_file" to extracted modules. This is alternative implementation 
of https://github.com/llvm/circt/pull/3183. This introduces "topOfFileComment" attribute to ExportVerilog so that we can inject comments top of files.

Honestly I think adding attribute to HWModule needs more discussion so I don't want to merge this at this time.  