### PR TITLE
[FIRRTL] fix cover predicate inversion

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -3786,8 +3786,13 @@ LogicalResult FIRRTLLowering::lowerVerificationStatement(
     }
 
     // Formulate the `enable -> predicate` as `!enable | predicate`.
-    auto notEnable = comb::createOrFoldNot(enable, builder);
-    predicate = builder.createOrFold<comb::OrOp>(notEnable, predicate);
+    // Except for covers, combine them: enable & predicate
+    if (!isCover) {
+      auto notEnable = comb::createOrFoldNot(enable, builder);
+      predicate = builder.createOrFold<comb::OrOp>(notEnable, predicate);
+    } else {
+      predicate = builder.createOrFold<comb::AndOp>(enable, predicate);
+    }
 
     // Handle the regular SVA case.
     sv::EventControl event;

--- a/lib/Dialect/FIRRTL/Import/FIRParserAsserts.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParserAsserts.cpp
@@ -389,8 +389,9 @@ ParseResult circt::firrtl::foldWhenEncodedVerifOp(PrintFOp printOp) {
     // practice the Scala impl of ExtractTestCode just discards that `%d` label
     // and replaces it with `notX`. Also prepare the condition to be checked
     // here.
-    Value notCond = builder.create<NotPrimOp>(whenStmt.condition());
-    Value predicate = notCond;
+    Value predicate = whenStmt.condition();
+    if (flavor != VerifFlavor::Cover)
+      predicate = builder.create<NotPrimOp>(predicate);
     if (flavor == VerifFlavor::AssertNotX) {
       label = "notX";
       if (printOp.operands().size() != 1) {
@@ -398,6 +399,7 @@ ParseResult circt::firrtl::foldWhenEncodedVerifOp(PrintFOp printOp) {
         return failure();
       }
       // Construct a `!whenCond | (value !== 1'bx)` predicate.
+      Value notCond = predicate;
       predicate = builder.create<XorRPrimOp>(printOp.operands()[0]);
       predicate = builder.create<VerbatimExprOp>(UIntType::get(context, 1),
                                                  "{{0}} !== 1'bx", predicate);

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -431,18 +431,12 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.cover %clock, %cCond, %cEn, "cover0" {isConcurrent = true}
     firrtl.cover %clock, %cCond, %cEn, "cover0" {isConcurrent = true, name = "cover_0"}
     firrtl.cover %clock, %cCond, %cEn, "cover0"(%value) : !firrtl.uint<42> {isConcurrent = true}
-    // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
-    // CHECK-NEXT: [[TMP1:%.+]] = comb.xor %cEn, [[TRUE]]
-    // CHECK-NEXT: [[TMP2:%.+]] = comb.or [[TMP1]], %cCond
-    // CHECK-NEXT: sv.cover.concurrent posedge %clock, [[TMP2]]
-    // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
-    // CHECK-NEXT: [[TMP1:%.+]] = comb.xor %cEn, [[TRUE]]
-    // CHECK-NEXT: [[TMP2:%.+]] = comb.or [[TMP1]], %cCond
-    // CHECK-NEXT: sv.cover.concurrent posedge %clock, [[TMP2]] label "cover__cover_0"
-    // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
-    // CHECK-NEXT: [[TMP1:%.+]] = comb.xor %cEn, [[TRUE]]
-    // CHECK-NEXT: [[TMP2:%.+]] = comb.or [[TMP1]], %cCond
-    // CHECK-NEXT: sv.cover.concurrent posedge %clock, [[TMP2]]
+    // CHECK-NEXT: [[TMP:%.+]] = comb.and %cEn, %cCond
+    // CHECK-NEXT: sv.cover.concurrent posedge %clock, [[TMP]]
+    // CHECK-NEXT: [[TMP:%.+]] = comb.and %cEn, %cCond
+    // CHECK-NEXT: sv.cover.concurrent posedge %clock, [[TMP]] label "cover__cover_0"
+    // CHECK-NEXT: [[TMP:%.+]] = comb.and %cEn, %cCond
+    // CHECK-NEXT: sv.cover.concurrent posedge %clock, [[TMP]]
     firrtl.cover %clock, %cCond, %cEn, "cover1" {eventControl = 1 : i32, isConcurrent = true, name = "cover_1"}
     firrtl.cover %clock, %cCond, %cEn, "cover2" {eventControl = 2 : i32, isConcurrent = true, name = "cover_2"}
     // CHECK: sv.cover.concurrent negedge %clock, {{%.+}} label "cover__cover_1"
@@ -505,10 +499,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT:     [[TMP1:%.+]] = comb.xor %enable, [[TRUE]]
     // CHECK-NEXT:     [[TMP2:%.+]] = comb.or [[TMP1]], %cond
     // CHECK-NEXT:     sv.assume.concurrent posedge %clock, [[TMP2]] message "assume0"
-    // CHECK-NEXT:     [[TRUE:%.+]] = hw.constant true
-    // CHECK-NEXT:     [[TMP1:%.+]] = comb.xor %enable, [[TRUE]]
-    // CHECK-NEXT:     [[TMP2:%.+]] = comb.or [[TMP1]], %cond
-    // CHECK-NEXT:     sv.cover.concurrent posedge %clock, [[TMP2]]
+    // CHECK-NEXT:     [[TMP:%.+]] = comb.and %enable, %cond
+    // CHECK-NEXT:     sv.cover.concurrent posedge %clock, [[TMP]]
     // CHECK-NOT:      label
     // CHECK-NEXT:   }
     // CHECK-NEXT: }

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -943,8 +943,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     when cond:
       printf(clock, enable, "cover:foo 2", value)
-    ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.cover %clock, [[TMP]], %enable, "foo 2" {eventControl = 0 : i32, isConcurrent = true}
+    ; CHECK-NEXT: firrtl.cover %clock, %cond, %enable, "foo 2" {eventControl = 0 : i32, isConcurrent = true}
 
     when cond:
       printf(clock, enable, "assert:custom label 0:foo 3", value)
@@ -958,8 +957,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     when cond:
       printf(clock, enable, "cover:custom label 2:foo 5", value)
-    ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.cover %clock, [[TMP]], %enable, "foo 5" {eventControl = 0 : i32, isConcurrent = true, name = "custom label 2"}
+    ; CHECK-NEXT: firrtl.cover %clock, %cond, %enable, "foo 5" {eventControl = 0 : i32, isConcurrent = true, name = "custom label 2"}
 
     ; Optional `stop` with same clock and condition should be removed.
     when cond:

--- a/test/Dialect/SV/canonicalization.mlir
+++ b/test/Dialect/SV/canonicalization.mlir
@@ -140,13 +140,14 @@ func.func @mux_to_cond_assign_t(%clock: i1, %c: i1, %data: i2) {
 // CHECK-LABEL; @immediate_assert_canonicalization
 hw.module @assert_canonicalization(%clock: i1) {
   %true = hw.constant 1 : i1
+  %false = hw.constant 0 : i1
   sv.always posedge %clock {
     // CHECK-NOT: sv.assert
     sv.assert %true, immediate message "assert"
     // CHECK-NOT: sv.assume
     sv.assume %true, immediate message "assume"
     // CHECK-NOT: sv.cover
-    sv.cover %true, immediate
+    sv.cover %false, immediate
   }
 
   // CHECK-NOT: sv.assert.concurrent
@@ -154,7 +155,7 @@ hw.module @assert_canonicalization(%clock: i1) {
   // CHECK-NOT: sv.assume.concurrent
   sv.assume.concurrent posedge %clock, %true
   // CHECK-NOT: sv.cover.concurrent
-  sv.cover.concurrent posedge %clock, %true
+  sv.cover.concurrent posedge %clock, %false
 }
 
 // CHECK-LABEL: @case_stmt


### PR DESCRIPTION
Generally, don't invert guarding `when` conditions for Cover's.

This occurs in two places that this change addresses:

1) Guarding `when` for cover is not inverted when parsing printf-in-when into verification op:

```
when foo:
  printf("cover:*",...)
```

Means 'foo' is the predicate for the coverage,
don't invert it like with other verif ops.

2) For concurrent verif ops, we use `enable -> pred` as predicate (`assert(!enable | pred)`).  For CoverOp's, instead combine enable and pred (`enable & pred`).
---

These changes can be observed in the tests:

parse-basic.fir: Demonstrates (1)
lower-to-hw.mlir: Demonstrates (2)
