### PR TITLE
[HW] [ExportVerilog] Add parameter concat expression

### DIFF
--- a/include/circt/Dialect/HW/HWAttributes.td
+++ b/include/circt/Dialect/HW/HWAttributes.td
@@ -226,11 +226,14 @@ def PEO_ModS : I32EnumAttrCase<"ModS",11, "mods">;
 // Unary Expression Opcodes.
 def PEO_CLog2 : I32EnumAttrCase<"CLog2", 12, "clog2">;
 
+// String manipulation Opcodes.
+def PEO_Concat: I32EnumAttrCase<"Concat", 13, "concat">;
+
 def PEOAttr  : I32EnumAttr<"PEO", "Parameter Expression Opcode",
                            [PEO_Add, PEO_Mul, PEO_And, PEO_Or, PEO_Xor,
                             PEO_Shl, PEO_ShrU, PEO_ShrS,
                             PEO_DivU, PEO_DivS, PEO_ModU, PEO_ModS,
-                            PEO_CLog2]>;
+                            PEO_CLog2, PEO_Concat]>;
 }
 
 def ParamExprAttr : AttrDef<HWDialect, "ParamExpr"> {

--- a/include/circt/Dialect/HW/HWAttributes.td
+++ b/include/circt/Dialect/HW/HWAttributes.td
@@ -227,13 +227,13 @@ def PEO_ModS : I32EnumAttrCase<"ModS",11, "mods">;
 def PEO_CLog2 : I32EnumAttrCase<"CLog2", 12, "clog2">;
 
 // String manipulation Opcodes.
-def PEO_Concat: I32EnumAttrCase<"Concat", 13, "concat">;
+def PEO_StrConcat : I32EnumAttrCase<"StrConcat", 13, "str.concat">;
 
 def PEOAttr  : I32EnumAttr<"PEO", "Parameter Expression Opcode",
                            [PEO_Add, PEO_Mul, PEO_And, PEO_Or, PEO_Xor,
                             PEO_Shl, PEO_ShrU, PEO_ShrS,
                             PEO_DivU, PEO_DivS, PEO_ModU, PEO_ModS,
-                            PEO_CLog2, PEO_Concat]>;
+                            PEO_CLog2, PEO_StrConcat]>;
 }
 
 def ParamExprAttr : AttrDef<HWDialect, "ParamExpr"> {

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1453,6 +1453,11 @@ ModuleEmitter::printParamValue(Attribute value, raw_ostream &os,
     operandSign = IsUnsigned;
     isUnary = true;
     break;
+  case PEO::Concat:
+    operatorStr = ", ";
+    subprecedence = Symbol;
+    isUnary = false;
+    break;
   }
 
   // Emit the specified operand with a $signed() or $unsigned() wrapper around
@@ -1477,6 +1482,8 @@ ModuleEmitter::printParamValue(Attribute value, raw_ostream &os,
 
   if (subprecedence > parenthesizeIfLooserThan)
     os << '(';
+  if (expr.getOpcode() == PEO::Concat)
+    os << '{';
   bool allOperandsSigned = emitOperand(expr.getOperands()[0]);
   for (auto op : ArrayRef(expr.getOperands()).drop_front()) {
     // Handle the special case of (a + b + -42) as (a + b - 42).
@@ -1496,6 +1503,8 @@ ModuleEmitter::printParamValue(Attribute value, raw_ostream &os,
     os << operatorStr;
     allOperandsSigned &= emitOperand(op);
   }
+  if (expr.getOpcode() == PEO::Concat)
+    os << '}';
   if (subprecedence > parenthesizeIfLooserThan) {
     os << ')';
     subprecedence = Symbol;

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1453,7 +1453,7 @@ ModuleEmitter::printParamValue(Attribute value, raw_ostream &os,
     operandSign = IsUnsigned;
     isUnary = true;
     break;
-  case PEO::Concat:
+  case PEO::StrConcat:
     operatorStr = ", ";
     subprecedence = Symbol;
     isUnary = false;
@@ -1482,7 +1482,7 @@ ModuleEmitter::printParamValue(Attribute value, raw_ostream &os,
 
   if (subprecedence > parenthesizeIfLooserThan)
     os << '(';
-  if (expr.getOpcode() == PEO::Concat)
+  if (expr.getOpcode() == PEO::StrConcat)
     os << '{';
   bool allOperandsSigned = emitOperand(expr.getOperands()[0]);
   for (auto op : ArrayRef(expr.getOperands()).drop_front()) {
@@ -1503,7 +1503,7 @@ ModuleEmitter::printParamValue(Attribute value, raw_ostream &os,
     os << operatorStr;
     allOperandsSigned &= emitOperand(op);
   }
-  if (expr.getOpcode() == PEO::Concat)
+  if (expr.getOpcode() == PEO::StrConcat)
     os << '}';
   if (subprecedence > parenthesizeIfLooserThan) {
     os << ')';

--- a/lib/Dialect/HW/HWAttributes.cpp
+++ b/lib/Dialect/HW/HWAttributes.cpp
@@ -618,7 +618,7 @@ static Attribute simplifyCLog2(SmallVector<Attribute, 4> &operands) {
   });
 }
 
-static Attribute simplifyConcat(SmallVector<Attribute, 4> &operands) {
+static Attribute simplifyStrConcat(SmallVector<Attribute, 4> &operands) {
   // Combine all adjacent strings.
   SmallVector<Attribute> newOperands;
   SmallVector<StringAttr> stringsToCombine;
@@ -649,7 +649,7 @@ static Attribute simplifyConcat(SmallVector<Attribute, 4> &operands) {
   if (newOperands.size() == 1)
     return newOperands[0];
   if (newOperands.size() < operands.size())
-    return ParamExprAttr::get(PEO::Concat, newOperands);
+    return ParamExprAttr::get(PEO::StrConcat, newOperands);
   return {};
 }
 
@@ -706,8 +706,8 @@ Attribute ParamExprAttr::get(PEO opcode, ArrayRef<Attribute> operandsIn) {
   case PEO::CLog2:
     result = simplifyCLog2(operands);
     break;
-  case PEO::Concat:
-    result = simplifyConcat(operands);
+  case PEO::StrConcat:
+    result = simplifyStrConcat(operands);
     break;
   }
 

--- a/lib/Dialect/HW/HWAttributes.cpp
+++ b/lib/Dialect/HW/HWAttributes.cpp
@@ -625,15 +625,18 @@ static Attribute simplifyConcat(SmallVector<Attribute, 4> &operands) {
   auto combineAndPush = [&]() {
     if (stringsToCombine.empty())
       return;
+    // Concatenate buffered strings, push to ops.
     SmallString<32> newString;
     for (auto part : stringsToCombine)
       newString.append(part.getValue());
     newOperands.push_back(
         StringAttr::get(stringsToCombine[0].getContext(), newString));
+    stringsToCombine.clear();
   };
 
   for (Attribute op : operands) {
     if (auto strOp = op.dyn_cast<StringAttr>()) {
+      // Queue up adjacent strings.
       stringsToCombine.push_back(strOp);
     } else {
       newOperands.push_back(op);

--- a/lib/Dialect/HW/HWAttributes.cpp
+++ b/lib/Dialect/HW/HWAttributes.cpp
@@ -639,8 +639,8 @@ static Attribute simplifyConcat(SmallVector<Attribute, 4> &operands) {
       // Queue up adjacent strings.
       stringsToCombine.push_back(strOp);
     } else {
-      newOperands.push_back(op);
       combineAndPush();
+      newOperands.push_back(op);
     }
   }
   combineAndPush();

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -1201,9 +1201,9 @@ hw.module @NoneTypeParam<p1: none>() -> () {}
 // CHECK-LABEL: module ParamConcatInst
 // CHECK:         #(parameter name = "top") ();
 // CHECK:         NoneTypeParam #(
-// CHECK:           .p1({name, ".child"})
+// CHECK:           .p1({".", name, ".child"})
 // CHECK:         ) inst ();
 // CHECK:       endmodule
 hw.module @ParamConcatInst<name: none = "top">() -> () {
-  hw.instance "inst" @NoneTypeParam<p1: none = #hw.param.expr.concat<#hw.param.decl.ref<"name">, ".", "child">>() -> ()
+  hw.instance "inst" @NoneTypeParam<p1: none = #hw.param.expr.concat<".", #hw.param.decl.ref<"name">, ".", "child">>() -> ()
 }

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -1192,3 +1192,18 @@ hw.module @UseParameterizedArrays(%a: !hw.array<42xint<12>>, %b: !hw.array<24xin
   %c = hw.instance "inst" @parameterizedArrays<param: i32 = 12, N: i32 = 24>
     (a: %a : !hw.array<42xint<12>>, b: %b : !hw.array<24xint<12>>) -> (c: !hw.array<24xint<12>>) {}
 }
+
+// CHECK-LABEL: module NoneTypeParam
+// CHECK:         #(parameter p1) ();
+// CHECK:       endmodule
+hw.module @NoneTypeParam<p1: none>() -> () {}
+
+// CHECK-LABEL: module ParamConcatInst
+// CHECK:         #(parameter name = "top") ();
+// CHECK:         NoneTypeParam #(
+// CHECK:           .p1({name, ".child"})
+// CHECK:         ) inst ();
+// CHECK:       endmodule
+hw.module @ParamConcatInst<name: none = "top">() -> () {
+  hw.instance "inst" @NoneTypeParam<p1: none = #hw.param.expr.concat<#hw.param.decl.ref<"name">, ".", "child">>() -> ()
+}

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -1205,5 +1205,5 @@ hw.module @NoneTypeParam<p1: none>() -> () {}
 // CHECK:         ) inst ();
 // CHECK:       endmodule
 hw.module @ParamConcatInst<name: none = "top">() -> () {
-  hw.instance "inst" @NoneTypeParam<p1: none = #hw.param.expr.concat<".", #hw.param.decl.ref<"name">, ".", "child">>() -> ()
+  hw.instance "inst" @NoneTypeParam<p1: none = #hw.param.expr.str.concat<".", #hw.param.decl.ref<"name">, ".", "child">>() -> ()
 }

--- a/test/Dialect/HW/parameters.mlir
+++ b/test/Dialect/HW/parameters.mlir
@@ -229,3 +229,12 @@ hw.module @parameterizedArraysInstance
   %c = hw.instance "inst" @parameterizedArrays<param: i32 = 12, N: i32 = 24>
     (a: %a : !hw.array<42xint<12>>, b: %b : !hw.array<24xint<12>>) -> (c: !hw.array<24xint<12>>) {}
 }
+
+// CHECK-LABEL: hw.module @NoneTypeParam<p1: none>()
+hw.module @NoneTypeParam<p1: none>() -> () {}
+
+// CHECK-LABEL: hw.module @ParamConcatInst() {
+// CHECK:         hw.instance "inst" @NoneTypeParam<p1: none = "top.child">() -> ()
+hw.module @ParamConcatInst() -> () {
+  hw.instance "inst" @NoneTypeParam<p1: none = #hw.param.expr.concat<"top", ".", "child">>() -> ()
+}

--- a/test/Dialect/HW/parameters.mlir
+++ b/test/Dialect/HW/parameters.mlir
@@ -236,5 +236,5 @@ hw.module @NoneTypeParam<p1: none>() -> () {}
 // CHECK-LABEL: hw.module @ParamConcatInst() {
 // CHECK:         hw.instance "inst" @NoneTypeParam<p1: none = "top.child">() -> ()
 hw.module @ParamConcatInst() -> () {
-  hw.instance "inst" @NoneTypeParam<p1: none = #hw.param.expr.concat<"top", ".", "child">>() -> ()
+  hw.instance "inst" @NoneTypeParam<p1: none = #hw.param.expr.str.concat<"top", ".", "child">>() -> ()
 }


### PR DESCRIPTION
Adds a `ParamExprAttr` opcode for string concatenation. Has a
simplification which merges adjacent strings. Includes ExportVerilog
support.