### PR TITLE
Add primitiveOp definition

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxStructure.td
+++ b/include/circt/Dialect/Calyx/CalyxStructure.td
@@ -56,6 +56,33 @@ def ProgramOp : CalyxContainer<"program", [
   let hasVerifier = 1;
 }
 
+def PrimitiveOp : CalyxOp<"primitive", [
+    HasParent<"ProgramOp">,
+    Symbol,
+    IsolatedFromAbove,
+    NoTerminator,
+    OpAsmOpInterface
+]> {
+
+  let summary = "Calyx Primitive";
+
+  let description = [{
+    The "calyx.primitive" operation represents an externally defined parameteric primitive
+    that a Calyx program can instantiate. It contains:
+    (1) Parameters for the widths of ports
+    (2) In- and output port definitions that define the interface.
+    ```
+  }];
+
+  let arguments = (ins
+    ArrayAttr:$portNames,
+    ArrayAttr:$portAttributes,
+    APIntAttr:$portDirections
+  );
+
+  let results = (outs);
+}
+
 def ComponentOp : CalyxOp<"component", [
     HasParent<"ProgramOp">,
     SymbolTable, /* contains Cell names. */


### PR DESCRIPTION
Hey folks, I wanted to start work on adding a primitiveOp to the Calyx dialect but I am still pretty new to the codebase and am looking for direction on how to add a new op and make sure it works as intended. As a reminder, Calyx primitives looks like:
```
primitive std_reg<"static"=1>[WIDTH](in: WIDTH, write_en: 1) -> (out: WIDTH, done: 1); // no body
```

I have a couple of questions:

1. How do I figure out which traits to attach to the Op? For example, it didn't make sense to me to make `PrimitiveOp` have `FunctionOpInterface` because primitives in Calyx cannot have a body. However, in most other ways, they are similar to components.
2. What is the right way to represent the parameters to a primitive? Should it just be an `ArrayAttr`?
3. I noticed we use `PortInfo` to get details of ports from components. However, a port attached to a primitive may have a parameteric width. Do I need to change `PortInfo` to support this or is `PortInfo` only generated from instances and not component definitions themselves.
4. What should I do after updating the `.td` file? Do I need to make changes to `CalyxOps.cpp`?

Appreciate y'all mentioning any other problems/changes you expect me to run into while doing this.

I'll also note this mostly follows the Rust compiler's representation of `primitive` and not quite what @mikeurbach suggested in https://github.com/llvm/circt/issues/2923. However, I'm hoping that this can act as a jumping off point for future directions.