### PR TITLE
[FIRParser] Fix bug extending an APInt to a smaller width

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3606,7 +3606,8 @@ ParseResult FIRCircuitParser::parseModule(CircuitOp circuit,
       // If the integer parameter is less than 32-bits, sign extend this to a
       // 32-bit value.  This needs to eventually emit as a 32-bit value in
       // Verilog and we want to get the size correct immediately.
-      result = result.sext(32);
+      if (result.getBitWidth() < 32)
+        result = result.sext(32);
 
       value = builder.getIntegerAttr(
           builder.getIntegerType(result.getBitWidth(), result.isSignBitSet()),

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -46,12 +46,12 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     parameter DEPTH = 32.42
     
   ; Check that integers are extended to 32 bits if they are smaller.
-  ; CHECK-LABEL: firrtl.extmodule private @IntegerParamsModul
+  ; CHECK-LABEL: firrtl.extmodule private @IntegerParamsModule
   extmodule IntegerParamsModule :
     ; CHECK-SAME: a: ui32 = 1
     parameter a = 1
-    ; CHECK-SAME: b: ui64 = 2251799813685248
-    parameter b = 2251799813685248
+    ; CHECK-SAME: b: ui40 = 4294967296
+    parameter b = 4294967296
 
   ; Module to test type parsing.
 

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -44,6 +44,14 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     parameter DEFAULT = 0
     parameter WIDTH = 32
     parameter DEPTH = 32.42
+    
+  ; Check that integers are extended to 32 bits if they are smaller.
+  ; CHECK-LABEL: firrtl.extmodule private @IntegerParamsModul
+  extmodule IntegerParamsModule :
+    ; CHECK-SAME: a: ui32 = 1
+    parameter a = 1
+    ; CHECK-SAME: b: ui64 = 2251799813685248
+    parameter b = 2251799813685248
 
   ; Module to test type parsing.
 


### PR DESCRIPTION
We recently removed usages of the deprecated function `sextOrSelf`.
This function allowed you to extend an APInt to a smaller width than it
currently is, becoming a noop.  The replacement function does not allow
doing this, and asserts.  During the cleanup I missed that we had to
guard this usage of `sext` to check the initial bitwidth before
attempting to sign-extend.

See: https://github.com/llvm/circt/pull/3202