### PR TITLE
[FIRRTL] Fix use-after-free in SFCCompat register handling.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/SFCCompat.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/SFCCompat.cpp
@@ -66,6 +66,7 @@ void SFCCompatPass::runOnOperation() {
       reg.replaceAllUsesWith(newReg.getResult());
       reg.erase();
       madeModifications = true;
+      continue;
     }
 
     // If the `RegResetOp` has an asynchronous reset and the reset value is not


### PR DESCRIPTION
When the a RegResetOp is driven by an invalid value, it is replaced
with a RegOp and the original op erased. This has been the case for a
while. However, recently, new code was added below this, which works
with a reference to the original op. This could lead to a
use-after-free, so in the case a replacement happened, skip over the
newly added code.

I wasn't able to quickly write a small reproducer of this behavior,
but it is quite evident when running the existing sfc-compat.mlir
tests that cover this codepath under valgrind.

Before:
==2456108== ERROR SUMMARY: 54 errors from 7 contexts (suppressed: 0 from 0)

After:
==2466205== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)