### PR TITLE
[FIRRTL] Add some more functionality to `InnerSymbol`

### DIFF
--- a/include/circt/Dialect/FIRRTL/CHIRRTL.td
+++ b/include/circt/Dialect/FIRRTL/CHIRRTL.td
@@ -19,6 +19,7 @@ include "mlir/IR/OpAsmInterface.td"
 include "circt/Dialect/FIRRTL/FIRRTLDialect.td"
 include "circt/Dialect/FIRRTL/FIRRTLAttributes.td"
 include "circt/Dialect/FIRRTL/FIRRTLTypes.td"
+include "circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/IR/SymbolInterfaces.td"
 
@@ -102,7 +103,7 @@ def HasCustomSSAName : DeclareOpInterfaceMethods<OpAsmOpInterface,
 class CHIRRTLOp<string mnemonic, list<Trait> traits = []> :
     Op<CHIRRTLDialect, mnemonic, traits>;
 
-def CombMemOp : CHIRRTLOp<"combmem", [HasCustomSSAName]> {
+def CombMemOp : CHIRRTLOp<"combmem", [HasCustomSSAName, InnerSymbol]> {
   let summary = "Define a new combinational memory";
   let description = [{
     Define a new behavioral combinational memory. Combinational memories have a
@@ -119,7 +120,7 @@ def CombMemOp : CHIRRTLOp<"combmem", [HasCustomSSAName]> {
   ];
 }
 
-def SeqMemOp : CHIRRTLOp<"seqmem", [HasCustomSSAName]> {
+def SeqMemOp : CHIRRTLOp<"seqmem", [HasCustomSSAName, InnerSymbol]> {
   let summary = "Define a new sequential memory";
   let description = [{
     Define a new behavioral sequential memory.  Sequential memories have a

--- a/include/circt/Dialect/FIRRTL/CHIRRTLDialect.h
+++ b/include/circt/Dialect/FIRRTL/CHIRRTLDialect.h
@@ -14,6 +14,7 @@
 #define CIRCT_DIALECT_FIRRTL_CHIRRTLDIALECT_H
 
 #include "circt/Dialect/FIRRTL/FIRRTLDialect.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h"
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/BuiltinAttributes.h"

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -93,7 +93,7 @@ def InstanceOp : FIRRTLOp<"instance", [HasParent<"firrtl::FModuleOp, firrtl::Whe
   }];
 }
 
-def MemOp : FIRRTLOp<"mem", [HasCustomSSAName]> {
+def MemOp : FIRRTLOp<"mem", [HasCustomSSAName, InnerSymbol]> {
   let summary = "Define a new mem";
   let arguments =
     (ins Confined<I32Attr, [IntMinValue<0>]>:$readLatency,
@@ -287,7 +287,7 @@ def RegResetOp : FIRRTLOp<"regreset", [HasCustomSSAName, InnerSymbol]> {
   let hasVerifier = 1;
 }
 
-def WireOp : FIRRTLOp<"wire", [HasCustomSSAName]> {
+def WireOp : FIRRTLOp<"wire", [HasCustomSSAName, InnerSymbol]> {
   let summary = "Define a new wire";
   let description = [{
     Declare a new wire:

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -11,6 +11,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef CIRCT_DIALECT_FIRRTL_FIRRTLOPINTERFACES_H
+#define CIRCT_DIALECT_FIRRTL_FIRRTLOPINTERFACES_H
+
 #include "circt/Dialect/FIRRTL/FIRRTLAnnotations.h"
 #include "circt/Dialect/FIRRTL/FIRRTLAttributes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
@@ -75,3 +78,5 @@ public:
 } // namespace mlir
 
 #include "circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h.inc"
+
+#endif // CIRCT_DIALECT_FIRRTL_FIRRTLOPINTERFACES_H

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -10,6 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef FIRRTLOPINTERFACES_TD
+#define FIRRTLOPINTERFACES_TD
+
 include "mlir/IR/OpBase.td"
 
 def FModuleLike : OpInterface<"FModuleLike"> {
@@ -279,34 +282,70 @@ def FConnectLike : OpInterface<"FConnectLike"> {
 
 def InnerSymbol : OpInterface<"InnerSymbolOpInterface"> {
   let description = [{
-    This interface describes an operation that may define an
-    `inner_sym`.  An `inner_sym` operation resides 
-    in arbitrarily-nested regions of a region that defines a
-    `InnerSymbolTable`.
-    Inner Symbols are different from normal symbols due to 
-    MLIR symbol table resolution rules.  Specifically normal
-    symbols are resolved by first going up to the closest
-    parent symbol table and resolving from there (recursing
-    down for complex symbol paths).  In FIRRTL and SV, modules
-    define a symbol in a circuit or std.module symbol table.
-    For instances to be able to resolve the modules they
-    instantiate, the symbol use in an instance must resolve 
-    in the top-level symbol table.  If a module were a
-    symbol table, instances resolving a symbol would start from 
-    their own module, never seeing other modules (since 
-    resolution would start in the parent module of the 
-    instance and be unable to go to the global scope).
-    The second problem arises from nesting.  Symbols defining 
-    ops must be immediate children of a symbol table.  FIRRTL
-    and SV operations which define a inner_sym are grandchildren,
-    at least, of a symbol table and may be much further nested.
-    Lastly, ports need to define inner_sym, something not allowed
-    by normal symbols.
+    This interface describes an operation that may define an `inner_sym`.  An
+    `inner_sym` operation resides in arbitrarily-nested regions of a region
+    that defines a `InnerSymbolTable`.
+
+    Inner Symbols are different from normal symbols due to MLIR symbol table
+    resolution rules.  Specifically normal symbols are resolved by first going
+    up to the closest parent symbol table and resolving from there (recursing
+    down for complex symbol paths).  In FIRRTL and SV, modules define a symbol
+    in a circuit or std.module symbol table. For instances to be able to
+    resolve the modules they instantiate, the symbol use in an instance must
+    resolve in the top-level symbol table.  If a module were a symbol table,
+    instances resolving a symbol would start from their own module, never
+    seeing other modules (since resolution would start in the parent module of
+    the instance and be unable to go to the global scope).
+
+    The second problem arises from nesting.  Symbols defining ops must be
+    immediate children of a symbol table.  FIRRTL and SV operations which
+    define a inner_sym are grandchildren, at least, of a symbol table and may
+    be much further nested. Lastly, ports need to define inner_sym, something
+    not allowed by normal symbols.
   }];
 
   let cppNamespace = "::circt::firrtl";
-  let methods = [];
-
+  let methods = [
+    InterfaceMethod<"Returns the name attribute of this inner symbol.",
+      "StringAttr", "getNameAttr", (ins), [{}],
+      /*defaultImplementation=*/[{
+        return $_op->template getAttrOfType<StringAttr>(
+          InnerSymbolOpInterface::getInnerSymAttrName());
+      }]
+    >,
+    InterfaceMethod<"Returns the name of this inner symbol.",
+      "StringRef", "getName", (ins), [{}],
+      /*defaultImplementation=*/[{
+        return $_op.getNameAttr().getValue();
+      }]
+    >,
+    InterfaceMethod<"Sets the name of this inner symbol.",
+      "void", "setNameAttr", (ins "StringAttr":$name), [{}],
+      /*defaultImplementation=*/[{
+        $_op->setAttr(InnerSymbolOpInterface::getInnerSymAttrName(), name);
+      }]
+    >,
+    InterfaceMethod<"Sets the name of this inner symbol.",
+      "void", "setName", (ins "StringRef":$name), [{}],
+      /*defaultImplementation=*/[{
+        $_op.setNameAttr(StringAttr::get($_op->getContext(), name));
+      }]
+    >,
+    InterfaceMethod<"Remove the name of this inner symbol.",
+      "void", "removeNameAttr", (ins), [{}],
+      /*defaultImplementation=*/[{
+        $_op->removeAttr(InnerSymbolOpInterface::getInnerSymAttrName());
+      }]
+    >
+  ];
+  let extraClassDeclaration = [{
+    /// Get the attribute name for inner symbol.
+    static StringRef getInnerSymAttrName() {
+      return "inner_sym";
+    }
+  }];
 }
 
 def InnerSymbolTable : NativeOpTrait<"InnerSymbolTable">;
+
+#endif // FIRRTLOPINTERFACES_TD

--- a/include/circt/Dialect/FIRRTL/Namespace.h
+++ b/include/circt/Dialect/FIRRTL/Namespace.h
@@ -14,6 +14,7 @@
 #ifndef CIRCT_DIALECT_FIRRTL_NAMESPACE_H
 #define CIRCT_DIALECT_FIRRTL_NAMESPACE_H
 
+#include "circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Support/Namespace.h"
 
@@ -64,8 +65,8 @@ struct ModuleNamespace : public Namespace {
 
   /// Populate the namespace with the body of a module-like operation.
   void addBody(FModuleLike module) {
-    module.walk([&](Operation *op) {
-      auto attr = op->getAttrOfType<StringAttr>("inner_sym");
+    module.walk([&](InnerSymbolOpInterface op) {
+      auto attr = op.getNameAttr();
       if (attr)
         nextIndex.insert({attr.getValue(), 0});
     });

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
@@ -13,6 +13,7 @@
 #include "circt/Dialect/FIRRTL/FIRRTLAnnotations.h"
 #include "circt/Dialect/FIRRTL/AnnotationDetails.h"
 #include "circt/Dialect/FIRRTL/FIRRTLAttributes.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Dialect/FIRRTL/Namespace.h"
 #include "circt/Dialect/HW/HWAttributes.h"
@@ -595,18 +596,18 @@ void OpAnnoTarget::setAnnotations(AnnotationSet annotations) const {
 }
 
 StringAttr OpAnnoTarget::getInnerSym(ModuleNamespace &moduleNamespace) const {
-  auto *context = getOp()->getContext();
-  auto innerSym = getOp()->getAttrOfType<StringAttr>("inner_sym");
+  auto innerSymOp = mlir::cast<InnerSymbolOpInterface>(getOp());
+  auto innerSym = innerSymOp.getNameAttr();
   if (!innerSym) {
     // Try to come up with a reasonable name.
     StringRef name = "inner_sym";
     auto nameAttr = getOp()->getAttrOfType<StringAttr>("name");
     if (nameAttr && !nameAttr.getValue().empty())
       name = nameAttr.getValue();
+    auto *context = getOp()->getContext();
     innerSym = StringAttr::get(context, moduleNamespace.newName(name));
-    getOp()->setAttr("inner_sym", innerSym);
+    innerSymOp.setNameAttr(innerSym);
   }
-  assert(innerSym && "invalid inner_sym");
   return innerSym;
 }
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -227,17 +227,12 @@ static bool hasPortNamed(FModuleLike op, StringAttr name) {
 }
 
 static bool hasValNamed(FModuleLike op, StringAttr name) {
-  bool retval = false;
-  op.walk([name, &retval](Operation *op) {
-    auto attr = op->getAttrOfType<StringAttr>("inner_sym");
-    if (attr == name) {
-      retval = true;
+  auto result = op.walk([name](InnerSymbolOpInterface op) {
+    if (op.getNameAttr() == name)
       return WalkResult::interrupt();
-    }
     return WalkResult::advance();
-    ;
   });
-  return retval;
+  return result.wasInterrupted();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
@@ -13,6 +13,7 @@
 #include "PassDetails.h"
 #include "circt/Dialect/FIRRTL/AnnotationDetails.h"
 #include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
 #include "circt/Dialect/FIRRTL/Namespace.h"
@@ -46,16 +47,16 @@ struct AddSeqMemPortsPass : public AddSeqMemPortsBase<AddSeqMemPortsPass> {
 
   /// Returns an operation's `inner_sym`, adding one if necessary.
   StringAttr getOrAddInnerSym(Operation *op) {
-    auto attr = op->getAttrOfType<StringAttr>("inner_sym");
-    if (attr)
+    auto innerSymOp = cast<InnerSymbolOpInterface>(op);
+    if (auto attr = innerSymOp.getNameAttr())
       return attr;
     auto module = op->getParentOfType<FModuleOp>();
     StringRef name = "sym";
     if (auto nameAttr = op->getAttrOfType<StringAttr>("name"))
       name = nameAttr.getValue();
     name = getModuleNamespace(module).newName(name);
-    attr = StringAttr::get(op->getContext(), name);
-    op->setAttr("inner_sym", attr);
+    auto attr = StringAttr::get(op->getContext(), name);
+    innerSymOp.setNameAttr(attr);
     return attr;
   }
 

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -13,6 +13,7 @@
 #include "PassDetails.h"
 #include "circt/Dialect/FIRRTL/FIRRTLAttributes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
 #include "circt/Dialect/FIRRTL/NLATable.h"
@@ -901,9 +902,11 @@ private:
                         Operation *from) {
     // If the "from" operation has an inner_sym, we need to make sure the
     // "to" operation also has an `inner_sym` and then record the renaming.
-    if (auto fromSym = from->getAttrOfType<StringAttr>("inner_sym")) {
-      auto toSym = OpAnnoTarget(to).getInnerSym(getNamespace(toModule));
-      renameMap[fromSym] = toSym;
+    if (auto fromSymOp = dyn_cast<InnerSymbolOpInterface>(from)) {
+      if (auto fromSym = fromSymOp.getNameAttr()) {
+        auto toSym = OpAnnoTarget(to).getInnerSym(getNamespace(toModule));
+        renameMap[fromSym] = toSym;
+      }
     }
 
     // If there are no port symbols on the "from" operation, we are done here.

--- a/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
@@ -75,13 +75,14 @@ struct ExtractInstancesPass
 
   /// Returns an operation's `inner_sym`, adding one if necessary.
   StringAttr getOrAddInnerSym(Operation *op) {
-    auto attr = op->getAttrOfType<StringAttr>("inner_sym");
+    auto innerSymOp = cast<InnerSymbolOpInterface>(op);
+    auto attr = innerSymOp.getNameAttr();
     if (attr)
       return attr;
     auto module = op->getParentOfType<FModuleOp>();
     auto name = getModuleNamespace(module).newName("extraction_sym");
     attr = StringAttr::get(op->getContext(), name);
-    op->setAttr("inner_sym", attr);
+    innerSymOp.setNameAttr(attr);
     return attr;
   }
 

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -1267,7 +1267,8 @@ bool GrandCentralPass::traverseField(Attribute field, IntegerAttr id,
                 StringAttr::get(&getContext(),
                                 "assign " + path.getString() + ";"),
                 ValueRange{}, ArrayAttr::get(&getContext(), path.getSymbols()));
-            leafValue.getDefiningOp()->removeAttr("inner_sym");
+            cast<InnerSymbolOpInterface>(leafValue.getDefiningOp())
+                .removeNameAttr();
             return true;
           }
         }
@@ -2260,7 +2261,8 @@ void GrandCentralPass::runOnOperation() {
 }
 
 StringAttr GrandCentralPass::getOrAddInnerSym(Operation *op) {
-  auto attr = op->getAttrOfType<StringAttr>("inner_sym");
+  auto innerSymOp = cast<InnerSymbolOpInterface>(op);
+  auto attr = innerSymOp.getNameAttr();
   if (attr)
     return attr;
   auto module = op->getParentOfType<FModuleOp>();
@@ -2269,7 +2271,7 @@ StringAttr GrandCentralPass::getOrAddInnerSym(Operation *op) {
     nameHint = attr.getValue();
   auto name = getModuleNamespace(module).newName(nameHint);
   attr = StringAttr::get(op->getContext(), name);
-  op->setAttr("inner_sym", attr);
+  innerSymOp.setNameAttr(attr);
   return attr;
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralSignalMappings.cpp
@@ -14,6 +14,7 @@
 #include "circt/Dialect/FIRRTL/AnnotationDetails.h"
 #include "circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h"
 #include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h"
 #include "circt/Dialect/FIRRTL/Namespace.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/SV/SVOps.h"
@@ -633,7 +634,8 @@ FailureOr<bool> GrandCentralSignalMappingsPass::emitUpdatedMappings(
   // Use inner_sym for non-ports
   SmallVector<Attribute> symbols;
   auto getOrAddInnerSym = [&](Operation *op) -> StringAttr {
-    auto attr = op->getAttrOfType<StringAttr>("inner_sym");
+    auto innerSymOp = cast<InnerSymbolOpInterface>(op);
+    auto attr = innerSymOp.getNameAttr();
     if (attr)
       return attr;
     StringRef name = "sym";
@@ -642,7 +644,7 @@ FailureOr<bool> GrandCentralSignalMappingsPass::emitUpdatedMappings(
     auto module = op->getParentOfType<FModuleOp>();
     name = getModuleNamespace(module).newName(name);
     attr = StringAttr::get(op->getContext(), name);
-    op->setAttr("inner_sym", attr);
+    innerSymOp.setNameAttr(attr);
     return attr;
   };
   auto mkRef = [&](FModuleOp module,

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -1076,7 +1076,7 @@ void GrandCentralTapsPass::processAnnotation(AnnotatedPort &portAnno,
           wiring.literal = {
               IntegerAttr::get(constant.getContext(), constant.value()),
               constant.getType()};
-          op->removeAttr("inner_sym");
+          cast<InnerSymbolOpInterface>(op).removeNameAttr();
         }
 
       wiring.target = PortWiring::Target(op);
@@ -1216,13 +1216,14 @@ void GrandCentralTapsPass::processAnnotation(AnnotatedPort &portAnno,
 }
 
 StringAttr GrandCentralTapsPass::getOrAddInnerSym(Operation *op) {
-  auto attr = op->getAttrOfType<StringAttr>("inner_sym");
+  auto innerSymOp = cast<InnerSymbolOpInterface>(op);
+  auto attr = innerSymOp.getNameAttr();
   if (attr)
     return attr;
   auto module = op->getParentOfType<FModuleOp>();
   auto name = getModuleNamespace(module).newName("gct_sym");
   attr = StringAttr::get(op->getContext(), name);
-  op->setAttr("inner_sym", attr);
+  innerSymOp.setNameAttr(attr);
   return attr;
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerCHIRRTL.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerCHIRRTL.cpp
@@ -12,6 +12,7 @@
 
 #include "PassDetails.h"
 #include "circt/Dialect/FIRRTL/CHIRRTLVisitors.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
@@ -338,8 +339,8 @@ void LowerCHIRRTLPass::replaceMem(Operation *cmem, StringRef name,
       resultTypes, readLatency, writeLatency, depth, ruw,
       memBuilder.getArrayAttr(resultNames), name, annotations,
       memBuilder.getArrayAttr(portAnnotations), StringAttr{}, IntegerAttr());
-  if (auto innerSym = cmem->getAttr("inner_sym"))
-    memory->setAttr("inner_sym", innerSym);
+  if (auto innerSym = cast<InnerSymbolOpInterface>(cmem).getNameAttr())
+    memory.inner_symAttr(innerSym);
 
   // Process each memory port, initializing the memory port and inferring when
   // to set the enable signal high.


### PR DESCRIPTION
This adds a getter, setter, and remover for the `inner_sym` attribute to
the `InnerSymbolOpInterface`.  This folows the same conention as
`Symbol` and names the functions `getName()` and `setName()`.  This is
pretty confusing since most things using this interface have another
attribute actually called `name`.

This fixes up most places in the FIRRTL passes that used to manually
look for the `inner_sym` attribute.  We still have a few places that
deal with symbols on ports.