### PR TITLE
[SCFToCalyx, Calyx, CalyxToHW] Add support for signed div and rem

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -191,21 +191,17 @@ def AndLibOp  : CombinationalArithBinaryLibraryOp<"and"> {}
 def OrLibOp   : CombinationalArithBinaryLibraryOp<"or"> {}
 def XorLibOp  : CombinationalArithBinaryLibraryOp<"xor"> {}
 
-def MultPipeLibOp : ArithBinaryLibraryOp<"mult_pipe", [
+class ArithBinaryPipeLibraryOp<string mnemonic> : ArithBinaryLibraryOp<mnemonic # "_pipe", [
     SameTypeConstraint<"left", "out">
   ]> {
   let results = (outs I1:$clk, I1:$reset, I1:$go, AnyType:$left, AnyType:$right, AnyType:$out, I1:$done);
 }
 
-def DivPipeLibOp : ArithBinaryLibraryOp<"div_pipe", [
-    SameTypeConstraint<"left", "out_quotient">,
-    SameTypeConstraint<"right", "out_remainder">
-  ]> {
-  let results = (outs
-    I1:$clk, I1:$reset, I1:$go, AnyType:$left, AnyType:$right,
-    AnyType:$out_quotient, AnyType:$out_remainder, I1:$done
-  );
-}
+def MultPipeLibOp : ArithBinaryPipeLibraryOp<"mult"> {}
+def DivSPipeLibOp : ArithBinaryPipeLibraryOp<"divs"> {}
+def DivUPipeLibOp : ArithBinaryPipeLibraryOp<"divu"> {}
+def RemUPipeLibOp : ArithBinaryPipeLibraryOp<"remu"> {}
+def RemSPipeLibOp : ArithBinaryPipeLibraryOp<"rems"> {}
 
 class UnaryLibraryOp<string mnemonic, list<Trait> traits = []> :
     CalyxLibraryOp<mnemonic, !listconcat(traits, [Combinational])> {

--- a/lib/Conversion/StaticLogicToCalyx/StaticLogicToCalyx.cpp
+++ b/lib/Conversion/StaticLogicToCalyx/StaticLogicToCalyx.cpp
@@ -920,11 +920,10 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
   Location loc = div.getLoc();
   Type width = div.getResult().getType(), one = rewriter.getI1Type();
   auto divPipe =
-      getComponentState().getNewLibraryOpInstance<calyx::DivPipeLibOp>(
+      getComponentState().getNewLibraryOpInstance<calyx::DivUPipeLibOp>(
           rewriter, loc, {one, one, one, width, width, width, width, one});
-  return buildLibraryBinaryPipeOp<calyx::DivPipeLibOp>(
-      rewriter, div, divPipe,
-      /*out=*/divPipe.out_quotient());
+  return buildLibraryBinaryPipeOp<calyx::DivUPipeLibOp>(rewriter, div, divPipe,
+                                                        /*out=*/divPipe.out());
 }
 
 LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
@@ -932,11 +931,10 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
   Location loc = rem.getLoc();
   Type width = rem.getResult().getType(), one = rewriter.getI1Type();
   auto remPipe =
-      getComponentState().getNewLibraryOpInstance<calyx::DivPipeLibOp>(
+      getComponentState().getNewLibraryOpInstance<calyx::DivUPipeLibOp>(
           rewriter, loc, {one, one, one, width, width, width, width, one});
-  return buildLibraryBinaryPipeOp<calyx::DivPipeLibOp>(
-      rewriter, rem, remPipe,
-      /*out=*/remPipe.out_remainder());
+  return buildLibraryBinaryPipeOp<calyx::DivUPipeLibOp>(rewriter, rem, remPipe,
+                                                        /*out=*/remPipe.out());
 }
 
 template <typename TAllocOp>
@@ -2059,7 +2057,7 @@ private:
       ///   LateSSAReplacement)
       if (src.isa<BlockArgument>() ||
           isa<calyx::RegisterOp, calyx::MemoryOp, hw::ConstantOp,
-              arith::ConstantOp, calyx::MultPipeLibOp, calyx::DivPipeLibOp>(
+              arith::ConstantOp, calyx::MultPipeLibOp, calyx::DivUPipeLibOp>(
               src.getDefiningOp()))
         continue;
 

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -1720,9 +1720,9 @@ LogicalResult WhileOp::canonicalize(WhileOp whileOp,
 // Calyx library ops
 //===----------------------------------------------------------------------===//
 
-#define ImplBinPipeOpCellInterface(OpType)                                     \
+#define ImplBinPipeOpCellInterface(OpType, outName)                            \
   SmallVector<StringRef> OpType::portNames() {                                 \
-    return {"clk", "reset", "go", "left", "right", "out", "done"};             \
+    return {"clk", "reset", "go", "left", "right", outName, "done"};           \
   }                                                                            \
                                                                                \
   SmallVector<Direction> OpType::portDirections() {                            \
@@ -1752,11 +1752,11 @@ LogicalResult WhileOp::canonicalize(WhileOp whileOp,
     };                                                                         \
   }
 
-ImplBinPipeOpCellInterface(MultPipeLibOp);
-ImplBinPipeOpCellInterface(DivUPipeLibOp);
-ImplBinPipeOpCellInterface(DivSPipeLibOp);
-ImplBinPipeOpCellInterface(RemUPipeLibOp);
-ImplBinPipeOpCellInterface(RemSPipeLibOp);
+ImplBinPipeOpCellInterface(MultPipeLibOp, "out");
+ImplBinPipeOpCellInterface(DivUPipeLibOp, "out_quotient");
+ImplBinPipeOpCellInterface(DivSPipeLibOp, "out_quotient");
+ImplBinPipeOpCellInterface(RemUPipeLibOp, "out_remainder");
+ImplBinPipeOpCellInterface(RemSPipeLibOp, "out_remainder");
 
 LogicalResult PadLibOp::verify() {
   unsigned inBits = getResult(0).getType().getIntOrFloatBitWidth();

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -1717,80 +1717,46 @@ LogicalResult WhileOp::canonicalize(WhileOp whileOp,
 }
 
 //===----------------------------------------------------------------------===//
-// MultPipe
-//===----------------------------------------------------------------------===//
-
-SmallVector<StringRef> MultPipeLibOp::portNames() {
-  return {"clk", "reset", "go", "left", "right", "out", "done"};
-}
-
-SmallVector<Direction> MultPipeLibOp::portDirections() {
-  return {Input, Input, Input, Input, Input, Output, Output};
-}
-
-void MultPipeLibOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
-  getCellAsmResultNames(setNameFn, *this, this->portNames());
-}
-
-SmallVector<DictionaryAttr> MultPipeLibOp::portAttributes() {
-  MLIRContext *context = getContext();
-  IntegerAttr isSet = IntegerAttr::get(IntegerType::get(context, 1), 1);
-  NamedAttrList go, clk, reset, done;
-  go.append("go", isSet);
-  clk.append("clk", isSet);
-  reset.append("reset", isSet);
-  done.append("done", isSet);
-  return {
-      clk.getDictionary(context),   /* Clk    */
-      reset.getDictionary(context), /* Reset  */
-      go.getDictionary(context),    /* Go     */
-      DictionaryAttr::get(context), /* Lhs    */
-      DictionaryAttr::get(context), /* Rhs    */
-      DictionaryAttr::get(context), /* Out    */
-      done.getDictionary(context)   /* Done   */
-  };
-}
-
-//===----------------------------------------------------------------------===//
-// DivPipe
-//===----------------------------------------------------------------------===//
-
-SmallVector<StringRef> DivPipeLibOp::portNames() {
-  return {"clk",          "reset",         "go",  "left", "right",
-          "out_quotient", "out_remainder", "done"};
-}
-
-SmallVector<Direction> DivPipeLibOp::portDirections() {
-  return {Input, Input, Input, Input, Input, Output, Output, Output};
-}
-
-void DivPipeLibOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
-  getCellAsmResultNames(setNameFn, *this, this->portNames());
-}
-
-SmallVector<DictionaryAttr> DivPipeLibOp::portAttributes() {
-  MLIRContext *context = getContext();
-  IntegerAttr isSet = IntegerAttr::get(IntegerType::get(context, 1), 1);
-  NamedAttrList go, clk, reset, done;
-  go.append("go", isSet);
-  clk.append("clk", isSet);
-  reset.append("reset", isSet);
-  done.append("done", isSet);
-  return {
-      clk.getDictionary(context),   /* Clk       */
-      reset.getDictionary(context), /* Reset     */
-      go.getDictionary(context),    /* Go        */
-      DictionaryAttr::get(context), /* Lhs       */
-      DictionaryAttr::get(context), /* Rhs       */
-      DictionaryAttr::get(context), /* Quotient  */
-      DictionaryAttr::get(context), /* Remainder */
-      done.getDictionary(context)   /* Done      */
-  };
-}
-
-//===----------------------------------------------------------------------===//
 // Calyx library ops
 //===----------------------------------------------------------------------===//
+
+#define ImplBinPipeOpCellInterface(OpType)                                     \
+  SmallVector<StringRef> OpType::portNames() {                                 \
+    return {"clk", "reset", "go", "left", "right", "out", "done"};             \
+  }                                                                            \
+                                                                               \
+  SmallVector<Direction> OpType::portDirections() {                            \
+    return {Input, Input, Input, Input, Input, Output, Output};                \
+  }                                                                            \
+                                                                               \
+  void OpType::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {              \
+    getCellAsmResultNames(setNameFn, *this, this->portNames());                \
+  }                                                                            \
+                                                                               \
+  SmallVector<DictionaryAttr> OpType::portAttributes() {                       \
+    MLIRContext *context = getContext();                                       \
+    IntegerAttr isSet = IntegerAttr::get(IntegerType::get(context, 1), 1);     \
+    NamedAttrList go, clk, reset, done;                                        \
+    go.append("go", isSet);                                                    \
+    clk.append("clk", isSet);                                                  \
+    reset.append("reset", isSet);                                              \
+    done.append("done", isSet);                                                \
+    return {                                                                   \
+        clk.getDictionary(context),   /* Clk    */                             \
+        reset.getDictionary(context), /* Reset  */                             \
+        go.getDictionary(context),    /* Go     */                             \
+        DictionaryAttr::get(context), /* Lhs    */                             \
+        DictionaryAttr::get(context), /* Rhs    */                             \
+        DictionaryAttr::get(context), /* Out    */                             \
+        done.getDictionary(context)   /* Done   */                             \
+    };                                                                         \
+  }
+
+ImplBinPipeOpCellInterface(MultPipeLibOp);
+ImplBinPipeOpCellInterface(DivUPipeLibOp);
+ImplBinPipeOpCellInterface(DivSPipeLibOp);
+ImplBinPipeOpCellInterface(RemUPipeLibOp);
+ImplBinPipeOpCellInterface(RemSPipeLibOp);
 
 LogicalResult PadLibOp::verify() {
   unsigned inBits = getResult(0).getType().getIntOrFloatBitWidth();

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -543,10 +543,14 @@ void Emitter::emitComponent(ComponentOp op) {
               [&](auto op) { emitLibraryPrimTypedByFirstInputPort(op); })
           .Case<MultPipeLibOp>(
               [&](auto op) { emitLibraryPrimTypedByFirstOutputPort(op); })
-          .Case<RemUPipeLibOp, RemSPipeLibOp, DivUPipeLibOp, DivSPipeLibOp>(
-              [&](auto op) {
-                emitLibraryPrimTypedByFirstOutputPort(op, {"std_div_pipe"});
-              })
+          .Case<RemUPipeLibOp, DivUPipeLibOp>([&](auto op) {
+            emitLibraryPrimTypedByFirstOutputPort(
+                op, /*calyxLibName=*/{"std_div_pipe"});
+          })
+          .Case<RemSPipeLibOp, DivSPipeLibOp>([&](auto op) {
+            emitLibraryPrimTypedByFirstOutputPort(
+                op, /*calyxLibName=*/{"std_sdiv_pipe"});
+          })
           .Default([&](auto op) {
             emitOpError(op, "not supported for emission inside component");
           });

--- a/test/Conversion/SCFToCalyx/convert_simple.mlir
+++ b/test/Conversion/SCFToCalyx/convert_simple.mlir
@@ -99,7 +99,7 @@ module {
 // CHECK:       calyx.group @bb0_0  {
 // CHECK-DAG:    calyx.assign %std_divu_pipe_0.left = %in0 : i32
 // CHECK-DAG:    calyx.assign %std_divu_pipe_0.right = %in1 : i32
-// CHECK-DAG:    calyx.assign %divui_0_reg.in = %std_divu_pipe_0.out : i32
+// CHECK-DAG:    calyx.assign %divui_0_reg.in = %std_divu_pipe_0.out_quotient : i32
 // CHECK-DAG:    calyx.assign %divui_0_reg.write_en = %std_divu_pipe_0.done : i1
 // CHECK-DAG:    calyx.assign %std_divu_pipe_0.go = %true : i1
 // CHECK-DAG:    calyx.group_done %divui_0_reg.done : i1
@@ -116,7 +116,7 @@ module {
 // CHECK:       calyx.group @bb0_0  {
 // CHECK-DAG:    calyx.assign %std_remu_pipe_0.left = %in0 : i32
 // CHECK-DAG:    calyx.assign %std_remu_pipe_0.right = %in1 : i32
-// CHECK-DAG:    calyx.assign %remui_0_reg.in = %std_remu_pipe_0.out : i32
+// CHECK-DAG:    calyx.assign %remui_0_reg.in = %std_remu_pipe_0.out_remainder : i32
 // CHECK-DAG:    calyx.assign %remui_0_reg.write_en = %std_remu_pipe_0.done : i1
 // CHECK-DAG:    calyx.assign %std_remu_pipe_0.go = %true : i1
 // CHECK-DAG:    calyx.group_done %remui_0_reg.done : i1
@@ -133,7 +133,7 @@ module {
 // CHECK:       calyx.group @bb0_0  {
 // CHECK-DAG:    calyx.assign %std_divs_pipe_0.left = %in0 : i32
 // CHECK-DAG:    calyx.assign %std_divs_pipe_0.right = %in1 : i32
-// CHECK-DAG:    calyx.assign %divsi_0_reg.in = %std_divs_pipe_0.out : i32
+// CHECK-DAG:    calyx.assign %divsi_0_reg.in = %std_divs_pipe_0.out_quotient : i32
 // CHECK-DAG:    calyx.assign %divsi_0_reg.write_en = %std_divs_pipe_0.done : i1
 // CHECK-DAG:    calyx.assign %std_divs_pipe_0.go = %true : i1
 // CHECK-DAG:    calyx.group_done %divsi_0_reg.done : i1
@@ -150,7 +150,7 @@ module {
 // CHECK:       calyx.group @bb0_0  {
 // CHECK-DAG:    calyx.assign %std_rems_pipe_0.left = %in0 : i32
 // CHECK-DAG:    calyx.assign %std_rems_pipe_0.right = %in1 : i32
-// CHECK-DAG:    calyx.assign %remsi_0_reg.in = %std_rems_pipe_0.out : i32
+// CHECK-DAG:    calyx.assign %remsi_0_reg.in = %std_rems_pipe_0.out_remainder : i32
 // CHECK-DAG:    calyx.assign %remsi_0_reg.write_en = %std_rems_pipe_0.done : i1
 // CHECK-DAG:    calyx.assign %std_rems_pipe_0.go = %true : i1
 // CHECK-DAG:    calyx.group_done %remsi_0_reg.done : i1

--- a/test/Conversion/SCFToCalyx/convert_simple.mlir
+++ b/test/Conversion/SCFToCalyx/convert_simple.mlir
@@ -97,11 +97,11 @@ module {
 module {
   func.func @main(%a0 : i32, %a1 : i32) -> i32 {
 // CHECK:       calyx.group @bb0_0  {
-// CHECK-DAG:    calyx.assign %std_div_pipe_0.left = %in0 : i32
-// CHECK-DAG:    calyx.assign %std_div_pipe_0.right = %in1 : i32
-// CHECK-DAG:    calyx.assign %divui_0_reg.in = %std_div_pipe_0.out_quotient : i32
-// CHECK-DAG:    calyx.assign %divui_0_reg.write_en = %std_div_pipe_0.done : i1
-// CHECK-DAG:    calyx.assign %std_div_pipe_0.go = %true : i1
+// CHECK-DAG:    calyx.assign %std_divu_pipe_0.left = %in0 : i32
+// CHECK-DAG:    calyx.assign %std_divu_pipe_0.right = %in1 : i32
+// CHECK-DAG:    calyx.assign %divui_0_reg.in = %std_divu_pipe_0.out : i32
+// CHECK-DAG:    calyx.assign %divui_0_reg.write_en = %std_divu_pipe_0.done : i1
+// CHECK-DAG:    calyx.assign %std_divu_pipe_0.go = %true : i1
 // CHECK-DAG:    calyx.group_done %divui_0_reg.done : i1
 // CHECK-NEXT:  }
     %0 = arith.divui %a0, %a1 : i32
@@ -114,14 +114,48 @@ module {
 module {
   func.func @main(%a0 : i32, %a1 : i32) -> i32 {
 // CHECK:       calyx.group @bb0_0  {
-// CHECK-DAG:    calyx.assign %std_div_pipe_0.left = %in0 : i32
-// CHECK-DAG:    calyx.assign %std_div_pipe_0.right = %in1 : i32
-// CHECK-DAG:    calyx.assign %remui_0_reg.in = %std_div_pipe_0.out_remainder : i32
-// CHECK-DAG:    calyx.assign %remui_0_reg.write_en = %std_div_pipe_0.done : i1
-// CHECK-DAG:    calyx.assign %std_div_pipe_0.go = %true : i1
+// CHECK-DAG:    calyx.assign %std_remu_pipe_0.left = %in0 : i32
+// CHECK-DAG:    calyx.assign %std_remu_pipe_0.right = %in1 : i32
+// CHECK-DAG:    calyx.assign %remui_0_reg.in = %std_remu_pipe_0.out : i32
+// CHECK-DAG:    calyx.assign %remui_0_reg.write_en = %std_remu_pipe_0.done : i1
+// CHECK-DAG:    calyx.assign %std_remu_pipe_0.go = %true : i1
 // CHECK-DAG:    calyx.group_done %remui_0_reg.done : i1
 // CHECK-NEXT:  }
     %0 = arith.remui %a0, %a1 : i32
+    return %0 : i32
+  }
+}
+
+// -----
+
+module {
+  func.func @main(%a0 : i32, %a1 : i32) -> i32 {
+// CHECK:       calyx.group @bb0_0  {
+// CHECK-DAG:    calyx.assign %std_divs_pipe_0.left = %in0 : i32
+// CHECK-DAG:    calyx.assign %std_divs_pipe_0.right = %in1 : i32
+// CHECK-DAG:    calyx.assign %divsi_0_reg.in = %std_divs_pipe_0.out : i32
+// CHECK-DAG:    calyx.assign %divsi_0_reg.write_en = %std_divs_pipe_0.done : i1
+// CHECK-DAG:    calyx.assign %std_divs_pipe_0.go = %true : i1
+// CHECK-DAG:    calyx.group_done %divsi_0_reg.done : i1
+// CHECK-NEXT:  }
+    %0 = arith.divsi %a0, %a1 : i32
+    return %0 : i32
+  }
+}
+
+// -----
+
+module {
+  func.func @main(%a0 : i32, %a1 : i32) -> i32 {
+// CHECK:       calyx.group @bb0_0  {
+// CHECK-DAG:    calyx.assign %std_rems_pipe_0.left = %in0 : i32
+// CHECK-DAG:    calyx.assign %std_rems_pipe_0.right = %in1 : i32
+// CHECK-DAG:    calyx.assign %remsi_0_reg.in = %std_rems_pipe_0.out : i32
+// CHECK-DAG:    calyx.assign %remsi_0_reg.write_en = %std_rems_pipe_0.done : i1
+// CHECK-DAG:    calyx.assign %std_rems_pipe_0.go = %true : i1
+// CHECK-DAG:    calyx.group_done %remsi_0_reg.done : i1
+// CHECK-NEXT:  }
+    %0 = arith.remsi %a0, %a1 : i32
     return %0 : i32
   }
 }

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -22,7 +22,7 @@ calyx.program "main" {
     %s2.in, %s2.write_en, %s2.clk, %s2.reset, %s2.out, %s2.done = calyx.register @s2 : i32, i1, i1, i1, i32, i1
     // CHECK: mu = std_mult_pipe(32);
     %mu.clk, %mu.reset, %mu.go, %mu.left, %mu.right, %mu.out, %mu.done = calyx.std_mult_pipe @mu : i1, i1, i1, i32, i32, i32, i1
-    // CHECK: divs = std_div_pipe(32);
+    // CHECK: divs = std_sdiv_pipe(32);
     // CHECK: remu = std_div_pipe(32);
     %divs.clk, %divs.reset, %divs.go, %divs.left, %divs.right, %divs.out, %divs.done = calyx.std_divs_pipe @divs : i1, i1, i1, i32, i32, i32, i1
     %remu.clk, %remu.reset, %remu.go, %remu.left, %remu.right, %remu.out, %remu.done = calyx.std_remu_pipe @remu : i1, i1, i1, i32, i32, i32, i1

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -18,12 +18,34 @@ calyx.program "main" {
   // CHECK-LABEL: component B<"toplevel"=1>(in: 1, @go go: 1, @clk clk: 1, @reset reset: 1) -> (out: 1, @done done: 1) {
   calyx.component @B(%in: i1, %go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%out: i1, %done: i1 {done}) {
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
-    %s.in, %s.write_en, %s.clk, %s.reset, %s.out, %s.done = calyx.register @s : i32, i1, i1, i1, i32, i1
+    %s1.in, %s1.write_en, %s1.clk, %s1.reset, %s1.out, %s1.done = calyx.register @s1 : i32, i1, i1, i1, i32, i1
+    %s2.in, %s2.write_en, %s2.clk, %s2.reset, %s2.out, %s2.done = calyx.register @s2 : i32, i1, i1, i1, i32, i1
     // CHECK: mu = std_mult_pipe(32);
     %mu.clk, %mu.reset, %mu.go, %mu.left, %mu.right, %mu.out, %mu.done = calyx.std_mult_pipe @mu : i1, i1, i1, i32, i32, i32, i1
+    // CHECK: divs = std_div_pipe(32);
+    // CHECK: remu = std_div_pipe(32);
+    %divs.clk, %divs.reset, %divs.go, %divs.left, %divs.right, %divs.out, %divs.done = calyx.std_divs_pipe @divs : i1, i1, i1, i32, i32, i32, i1
+    %remu.clk, %remu.reset, %remu.go, %remu.left, %remu.right, %remu.out, %remu.done = calyx.std_remu_pipe @remu : i1, i1, i1, i32, i32, i32, i1
+
     %c1_1 = hw.constant 1 : i1
     %c4_32 = hw.constant 4 : i32
     calyx.wires {
+
+    // CHECK-LABEL: group DivRemWrite {
+    // CHECK-NEXT:   s1.in = divs.out_quotient;
+    // CHECK-NEXT:   s2.in = remu.out_remainder;
+    // CHECK-NEXT:   s1.write_en = 1'd1;
+    // CHECK-NEXT:   s2.write_en = 1'd1;
+    // CHECK-NEXT:   DivRemWrite[done] = s1.done;
+    // CHECK-NEXT: }
+      calyx.group @DivRemWrite {
+        calyx.assign %s1.in = %divs.out : i32
+        calyx.assign %s2.in = %remu.out : i32
+        calyx.assign %s1.write_en = %c1_1 : i1
+        calyx.assign %s2.write_en = %c1_1 : i1
+        calyx.group_done %s1.done : i1
+      }
+
       calyx.group @RegisterWrite {
         calyx.assign %r.in = %c1_1 : i1
         calyx.assign %r.write_en = %c1_1 : i1
@@ -33,16 +55,16 @@ calyx.program "main" {
       // CHECK-NEXT: mu.left = 32'd4;
       // CHECK-NEXT: mu.right = 32'd4;
       // CHECK-NEXT: mu.go = 1'd1;
-      // CHECK-NEXT: s.write_en = mu.done;
-      // CHECK-NEXT: s.in = mu.out;
-      // CHECK-NEXT: MultWrite[done] = s.done;
+      // CHECK-NEXT: s1.write_en = mu.done;
+      // CHECK-NEXT: s1.in = mu.out;
+      // CHECK-NEXT: MultWrite[done] = s1.done;
       calyx.group @MultWrite {
         calyx.assign %mu.left = %c4_32 : i32
         calyx.assign %mu.right = %c4_32 : i32
         calyx.assign %mu.go = %c1_1 : i1
-        calyx.assign %s.write_en = %mu.done : i1
-        calyx.assign %s.in = %mu.out : i32
-        calyx.group_done %s.done : i1
+        calyx.assign %s1.write_en = %mu.done : i1
+        calyx.assign %s1.in = %mu.out : i32
+        calyx.group_done %s1.done : i1
       }
     }
 
@@ -58,6 +80,7 @@ calyx.program "main" {
         } else {
           calyx.enable @MultWrite
         }
+        calyx.enable @DivRemWrite
       }
     }
   } {toplevel}

--- a/test/Dialect/Calyx/export-errors.mlir
+++ b/test/Dialect/Calyx/export-errors.mlir
@@ -15,17 +15,3 @@ calyx.program "main" {
   }
 }
 
-// -----
-
-calyx.program "main" {
-  calyx.component @main(%in0: i4, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out0: i8, %done: i1 {done}) {
-    %true = hw.constant true
-    // expected-error @+2 {{'calyx.std_divu_pipe' op not supported for emission}}
-    // expected-note @+1 {{The Calyx CIRCT implementation implements distinct operations for divu/divs/remu/rems operations, which is incompatible with the native Rust compiler (see https://github.com/llvm/circt/pull/3238)}}
-    %0:7 = calyx.std_divu_pipe @std_divu_pipe : i1, i1, i1, i32, i32, i32, i1
-    calyx.wires {
-      calyx.assign %done = %true : i1
-    }
-    calyx.control {}
-  }
-}

--- a/test/Dialect/Calyx/export-errors.mlir
+++ b/test/Dialect/Calyx/export-errors.mlir
@@ -14,3 +14,18 @@ calyx.program "main" {
     calyx.control {}
   }
 }
+
+// -----
+
+calyx.program "main" {
+  calyx.component @main(%in0: i4, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out0: i8, %done: i1 {done}) {
+    %true = hw.constant true
+    // expected-error @+2 {{'calyx.std_divu_pipe' op not supported for emission}}
+    // expected-note @+1 {{The Calyx CIRCT implementation implements distinct operations for divu/divs/remu/rems operations, which is incompatible with the native Rust compiler (see https://github.com/llvm/circt/pull/3238)}}
+    %0:7 = calyx.std_divu_pipe @std_divu_pipe : i1, i1, i1, i32, i32, i32, i1
+    calyx.wires {
+      calyx.assign %done = %true : i1
+    }
+    calyx.control {}
+  }
+}

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -21,7 +21,7 @@ calyx.program "main" {
     // CHECK:      %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i8, i1, i1, i1, i8, i1
     // CHECK-NEXT: %r2.in, %r2.write_en, %r2.clk, %r2.reset, %r2.out, %r2.done = calyx.register @r2 : i1, i1, i1, i1, i1, i1
     // CHECK-NEXT: %mu.clk, %mu.reset, %mu.go, %mu.left, %mu.right, %mu.out, %mu.done = calyx.std_mult_pipe @mu : i1, i1, i1, i32, i32, i32, i1
-    // CHECK-NEXT: %du.clk, %du.reset, %du.go, %du.left, %du.right, %du.out_quotient, %du.out_remainder, %du.done = calyx.std_div_pipe @du : i1, i1, i1, i32, i32, i32, i32, i1
+    // CHECK-NEXT: %du.clk, %du.reset, %du.go, %du.left, %du.right, %du.out, %du.done = calyx.std_divu_pipe @du : i1, i1, i1, i32, i32, i32, i1
     // CHECK-NEXT: %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory @m <[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
     // CHECK-NEXT: %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 of @A : i8, i1, i1, i1, i8, i1
     // CHECK-NEXT: %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance @c1 of @A : i8, i1, i1, i1, i8, i1
@@ -35,7 +35,7 @@ calyx.program "main" {
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i8, i1, i1, i1, i8, i1
     %r2.in, %r2.write_en, %r2.clk, %r2.reset, %r2.out, %r2.done = calyx.register @r2 : i1, i1, i1, i1, i1, i1
     %mu.clk, %mu.reset, %mu.go, %mu.lhs, %mu.rhs, %mu.out, %mu.done = calyx.std_mult_pipe @mu : i1, i1, i1, i32, i32, i32, i1
-    %du.clk, %du.reset, %du.go, %du.left, %du.right, %du.out_quotient, %du.out_remainder, %du.done = calyx.std_div_pipe @du : i1, i1, i1, i32, i32, i32, i32, i1
+    %du.clk, %du.reset, %du.go, %du.left, %du.right, %du.out, %du.done = calyx.std_divu_pipe @du : i1, i1, i1, i32, i32, i32, i1
     %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory @m <[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
     %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 of @A : i8, i1, i1, i1, i8, i1
     %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance @c1 of @A : i8, i1, i1, i1, i8, i1

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -21,7 +21,7 @@ calyx.program "main" {
     // CHECK:      %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i8, i1, i1, i1, i8, i1
     // CHECK-NEXT: %r2.in, %r2.write_en, %r2.clk, %r2.reset, %r2.out, %r2.done = calyx.register @r2 : i1, i1, i1, i1, i1, i1
     // CHECK-NEXT: %mu.clk, %mu.reset, %mu.go, %mu.left, %mu.right, %mu.out, %mu.done = calyx.std_mult_pipe @mu : i1, i1, i1, i32, i32, i32, i1
-    // CHECK-NEXT: %du.clk, %du.reset, %du.go, %du.left, %du.right, %du.out, %du.done = calyx.std_divu_pipe @du : i1, i1, i1, i32, i32, i32, i1
+    // CHECK-NEXT: %du.clk, %du.reset, %du.go, %du.left, %du.right, %du.out_quotient, %du.done = calyx.std_divu_pipe @du : i1, i1, i1, i32, i32, i32, i1
     // CHECK-NEXT: %m.addr0, %m.addr1, %m.write_data, %m.write_en, %m.clk, %m.read_data, %m.done = calyx.memory @m <[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
     // CHECK-NEXT: %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 of @A : i8, i1, i1, i1, i8, i1
     // CHECK-NEXT: %c1.in, %c1.go, %c1.clk, %c1.reset, %c1.out, %c1.done = calyx.instance @c1 of @A : i8, i1, i1, i1, i8, i1


### PR DESCRIPTION
Adds support both at the front- and back-end level to ensure that all signed `arith` division/modulo operators work end-to-end.

Notably, this also changes the semantics of the `DivLibPipe` operator in that it no longer provides both a quotient and remainder result. This change aligns the Calyx operators to better fit within an MLIR/CIRCT up/downstream context (`arith` and `comb` operators), but breaks compatibility with the div primitive in the native calyx compiler. A note has been added in the Calyx emitter to indicate of this.

Opted not to add support in StaticLogicToCalyx for the new operations since i assume the existing code duplication will be cleaned up in the near future, with `SCFToCalyx` taking precedence for the shared logic.
