### PR TITLE
[SCFToCalyx] [StaticLogicToCalyx] Continue separation of the conversions.

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
+++ b/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
@@ -16,78 +16,13 @@
 
 #include "circt/Dialect/Calyx/CalyxOps.h"
 #include "circt/Support/LLVM.h"
+#include "mlir/IR/AsmState.h"
 #include "mlir/IR/PatternMatch.h"
 
 #include <variant>
 
 namespace circt {
 namespace calyx {
-
-// A structure representing a set of ports which act as a memory interface for
-// external memories.
-struct MemoryPortsImpl {
-  Value readData;
-  Value done;
-  Value writeData;
-  SmallVector<Value> addrPorts;
-  Value writeEn;
-};
-
-// Represents the interface of memory in Calyx. The various lowering passes
-// are agnostic wrt. whether working with a calyx::MemoryOp (internally
-// allocated memory) or MemoryPortsImpl (external memory).
-struct MemoryInterface {
-  MemoryInterface();
-  explicit MemoryInterface(const MemoryPortsImpl &ports);
-  explicit MemoryInterface(calyx::MemoryOp memOp);
-
-  // Getter methods for each memory interface port.
-  Value readData();
-  Value done();
-  Value writeData();
-  Value writeEn();
-  ValueRange addrPorts();
-
-private:
-  std::variant<calyx::MemoryOp, MemoryPortsImpl> impl;
-};
-
-// Provides an interface for the control flow `while` operation across different
-// dialects.
-template <typename T>
-class WhileOpInterface {
-  static_assert(std::is_convertible_v<T, Operation *>);
-
-public:
-  explicit WhileOpInterface(T op) : impl(op) {}
-  explicit WhileOpInterface(Operation *op) : impl(dyn_cast_or_null<T>(op)) {}
-
-  virtual ~WhileOpInterface() = default;
-
-  // Returns the arguments to this while operation.
-  virtual Block::BlockArgListType getBodyArgs() = 0;
-
-  // Returns body of this while operation.
-  virtual Block *getBodyBlock() = 0;
-
-  // Returns the Block in which the condition exists.
-  virtual Block *getConditionBlock() = 0;
-
-  // Returns the condition as a Value.
-  virtual Value getConditionValue() = 0;
-
-  // Returns the number of iterations the while loop will conduct if known.
-  virtual Optional<uint64_t> getBound() = 0;
-
-  // Returns the operation.
-  T getOperation() { return impl; }
-
-  // Returns the source location of the operation.
-  Location getLoc() { return impl->getLoc(); }
-
-private:
-  T impl;
-};
 
 // Walks the control of this component, and appends source information for leaf
 // nodes. It also appends a position attribute that connects the source location
@@ -124,6 +59,391 @@ TGroup createGroup(PatternRewriter &rewriter, calyx::ComponentOp compOp,
   rewriter.setInsertionPointToEnd(compOp.getWiresOp().getBody());
   return rewriter.create<TGroup>(loc, uniqueName.str());
 }
+
+// A structure representing a set of ports which act as a memory interface for
+// external memories.
+struct MemoryPortsImpl {
+  Value readData;
+  Value done;
+  Value writeData;
+  SmallVector<Value> addrPorts;
+  Value writeEn;
+};
+
+// Represents the interface of memory in Calyx. The various lowering passes
+// are agnostic wrt. whether working with a calyx::MemoryOp (internally
+// allocated memory) or MemoryPortsImpl (external memory).
+struct MemoryInterface {
+  MemoryInterface();
+  explicit MemoryInterface(const MemoryPortsImpl &ports);
+  explicit MemoryInterface(calyx::MemoryOp memOp);
+
+  // Getter methods for each memory interface port.
+  Value readData();
+  Value done();
+  Value writeData();
+  Value writeEn();
+  ValueRange addrPorts();
+
+private:
+  std::variant<calyx::MemoryOp, MemoryPortsImpl> impl;
+};
+
+// Provide a common interface for loop operations that need to be lowered to
+// Calyx.
+class LoopInterface {
+public:
+  virtual ~LoopInterface() = default;
+
+  // Returns the arguments to this while operation.
+  virtual Block::BlockArgListType getBodyArgs() = 0;
+
+  // Returns body of this while operation.
+  virtual Block *getBodyBlock() = 0;
+
+  // Returns the Block in which the condition exists.
+  virtual Block *getConditionBlock() = 0;
+
+  // Returns the condition as a Value.
+  virtual Value getConditionValue() = 0;
+
+  // Returns the number of iterations the while loop will conduct if known.
+  virtual Optional<uint64_t> getBound() = 0;
+};
+
+// Provides an interface for the control flow `while` operation across different
+// dialects.
+template <typename T>
+class WhileOpInterface : LoopInterface {
+  static_assert(std::is_convertible_v<T, Operation *>);
+
+public:
+  explicit WhileOpInterface(T op) : impl(op) {}
+  explicit WhileOpInterface(Operation *op) : impl(dyn_cast_or_null<T>(op)) {}
+
+  // Returns the operation.
+  T getOperation() { return impl; }
+
+  // Returns the source location of the operation.
+  Location getLoc() { return impl->getLoc(); }
+
+private:
+  T impl;
+};
+
+//===----------------------------------------------------------------------===//
+// Lowering state classes
+//===----------------------------------------------------------------------===//
+
+// An interface for the Calyx component lowering state.
+template <typename Loop>
+class ComponentLoweringStateInterface {
+  static_assert(std::is_base_of_v<LoopInterface, Loop>);
+
+public:
+  ComponentLoweringStateInterface(calyx::ComponentOp component)
+      : component(component) {}
+
+  virtual ~ComponentLoweringStateInterface() = default;
+
+  /// Register reg as being the idx'th iter_args register for 'op'.
+  virtual void addWhileIterReg(Loop op, calyx::RegisterOp reg,
+                               unsigned idx) = 0;
+
+  /// Return a mapping of block argument indices to block argument.
+  virtual calyx::RegisterOp getWhileIterReg(Loop op, unsigned idx) = 0;
+
+  /// Return a mapping of block argument indices to block argument.
+  virtual const DenseMap<unsigned, calyx::RegisterOp> &
+  getWhileIterRegs(Loop op) = 0;
+
+  /// Registers grp to be the while latch group of `op`.
+  virtual void setWhileLatchGroup(Loop op, calyx::GroupOp group) = 0;
+
+  /// Retrieve the while latch group registered for `op`.
+  virtual calyx::GroupOp getWhileLatchGroup(Loop op) = 0;
+
+  /// Returns the calyx::ComponentOp associated with this lowering state.
+  calyx::ComponentOp getComponentOp() { return component; }
+
+  /// Register reg as being the idx'th argument register for block. This is
+  /// necessary for the `BuildBBReg` pass.
+  void addBlockArgReg(Block *block, calyx::RegisterOp reg, unsigned idx) {
+    assert(blockArgRegs[block].count(idx) == 0);
+    assert(idx < block->getArguments().size());
+    blockArgRegs[block][idx] = reg;
+  }
+
+  /// Return a mapping of block argument indices to block argument registers.
+  /// This is necessary for the `BuildBBReg` pass.
+  const DenseMap<unsigned, calyx::RegisterOp> &getBlockArgRegs(Block *block) {
+    return blockArgRegs[block];
+  }
+
+  /// Register 'grp' as a group which performs block argument
+  /// register transfer when transitioning from basic block from to to.
+  void addBlockArgGroup(Block *from, Block *to, calyx::GroupOp grp) {
+    blockArgGroups[from][to].push_back(grp);
+  }
+
+  /// Returns a list of groups to be evaluated to perform the block argument
+  /// register assignments when transitioning from basic block 'from' to 'to'.
+  ArrayRef<calyx::GroupOp> getBlockArgGroups(Block *from, Block *to) {
+    return blockArgGroups[from][to];
+  }
+
+  /// Returns a unique name within compOp with the provided prefix.
+  std::string getUniqueName(StringRef prefix) {
+    std::string prefixStr = prefix.str();
+    unsigned idx = prefixIdMap[prefixStr];
+    ++prefixIdMap[prefixStr];
+    return (prefix + "_" + std::to_string(idx)).str();
+  }
+
+  /// Returns a unique name associated with a specific operation.
+  StringRef getUniqueName(Operation *op) {
+    auto it = opNames.find(op);
+    assert(it != opNames.end() && "A unique name should have been set for op");
+    return it->second;
+  }
+
+  /// Registers a unique name for a given operation using a provided prefix.
+  void setUniqueName(Operation *op, StringRef prefix) {
+    assert(opNames.find(op) == opNames.end() &&
+           "A unique name was already set for op");
+    opNames[op] = getUniqueName(prefix);
+  }
+
+  template <typename TLibraryOp>
+  TLibraryOp getNewLibraryOpInstance(PatternRewriter &rewriter, Location loc,
+                                     TypeRange resTypes) {
+    mlir::IRRewriter::InsertionGuard guard(rewriter);
+    Block *body = component.getBody();
+    rewriter.setInsertionPoint(body, body->begin());
+    auto name = TLibraryOp::getOperationName().split(".").second;
+    return rewriter.create<TLibraryOp>(loc, getUniqueName(name), resTypes);
+  }
+
+  /// Register value v as being evaluated when scheduling group.
+  void registerEvaluatingGroup(Value v, calyx::GroupInterface group) {
+    valueGroupAssigns[v] = group;
+  }
+
+  /// Return the group which evaluates the value v. Optionally, caller may
+  /// specify the expected type of the group.
+  template <typename TGroupOp = calyx::GroupInterface>
+  TGroupOp getEvaluatingGroup(Value v) {
+    auto it = valueGroupAssigns.find(v);
+    assert(it != valueGroupAssigns.end() && "No group evaluating value!");
+    if constexpr (std::is_same<TGroupOp, calyx::GroupInterface>::value)
+      return it->second;
+    else {
+      auto group = dyn_cast<TGroupOp>(it->second.getOperation());
+      assert(group && "Actual group type differed from expected group type");
+      return group;
+    }
+  }
+
+  /// Register reg as being the idx'th return value register.
+  void addReturnReg(calyx::RegisterOp reg, unsigned idx) {
+    assert(returnRegs.count(idx) == 0 &&
+           "A register was already registered for this index");
+    returnRegs[idx] = reg;
+  }
+
+  /// Returns the idx'th return value register.
+  calyx::RegisterOp getReturnReg(unsigned idx) {
+    assert(returnRegs.count(idx) && "No register registered for index!");
+    return returnRegs[idx];
+  }
+
+  /// Registers a memory interface as being associated with a memory identified
+  /// by 'memref'.
+  void registerMemoryInterface(Value memref,
+                               const calyx::MemoryInterface &memoryInterface) {
+    assert(memref.getType().isa<MemRefType>());
+    assert(memories.find(memref) == memories.end() &&
+           "Memory already registered for memref");
+    memories[memref] = memoryInterface;
+  }
+
+  /// Returns the memory interface registered for the given memref.
+  calyx::MemoryInterface getMemoryInterface(Value memref) {
+    assert(memref.getType().isa<MemRefType>());
+    auto it = memories.find(memref);
+    assert(it != memories.end() && "No memory registered for memref");
+    return it->second;
+  }
+
+  /// If v is an input to any memory registered within this component, returns
+  /// the memory. If not, returns null.
+  Optional<calyx::MemoryInterface> isInputPortOfMemory(Value v) {
+    for (auto &memIf : memories) {
+      auto &mem = memIf.getSecond();
+      if (mem.writeEn() == v || mem.writeData() == v ||
+          llvm::any_of(mem.addrPorts(), [=](Value port) { return port == v; }))
+        return {mem};
+    }
+    return {};
+  }
+
+  /// Creates register assignment operations within the provided groupOp.
+  void buildAssignmentsForRegisterWrite(PatternRewriter &rewriter,
+                                        calyx::GroupOp groupOp,
+                                        calyx::RegisterOp &reg,
+                                        Value inputValue) {
+    mlir::IRRewriter::InsertionGuard guard(rewriter);
+    auto loc = inputValue.getLoc();
+    rewriter.setInsertionPointToEnd(groupOp.getBody());
+    rewriter.create<calyx::AssignOp>(loc, reg.in(), inputValue);
+    rewriter.create<calyx::AssignOp>(
+        loc, reg.write_en(),
+        createConstant(loc, rewriter, getComponentOp(), 1, 1));
+    rewriter.create<calyx::GroupDoneOp>(loc, reg.done());
+  }
+
+  /// Creates a new group that assigns the 'ops' values to the iter arg
+  /// registers of the 'whileOp'.
+  calyx::GroupOp buildWhileIterArgAssignments(PatternRewriter &rewriter,
+                                              Loop op, Twine uniqueSuffix,
+                                              MutableArrayRef<OpOperand> ops) {
+    /// Pass iteration arguments through registers. This follows closely
+    /// to what is done for branch ops.
+    auto groupName = "assign_" + uniqueSuffix;
+    auto groupOp = calyx::createGroup<calyx::GroupOp>(
+        rewriter, getComponentOp(), op.getLoc(), groupName);
+    /// Create register assignment for each iter_arg. a calyx::GroupDone signal
+    /// is created for each register. These will be &'ed together in
+    /// MultipleGroupDonePattern.
+    for (auto &arg : ops) {
+      auto reg = getWhileIterReg(op, arg.getOperandNumber());
+      buildAssignmentsForRegisterWrite(rewriter, groupOp, reg, arg.get());
+    }
+    return groupOp;
+  }
+
+  /// Assign a mapping between the source funcOp result indices and the
+  /// corresponding output port indices of this componentOp.
+  void setFuncOpResultMapping(const DenseMap<unsigned, unsigned> &mapping) {
+    funcOpResultMapping = mapping;
+  }
+
+  /// Get the output port index of this component for which the funcReturnIdx of
+  /// the original function maps to.
+  unsigned getFuncOpResultMapping(unsigned funcReturnIdx) {
+    auto it = funcOpResultMapping.find(funcReturnIdx);
+    assert(it != funcOpResultMapping.end() &&
+           "No component return port index recorded for the requested function "
+           "return index");
+    return it->second;
+  }
+
+private:
+  /// The component which this lowering state is associated to.
+  calyx::ComponentOp component;
+
+  /// A mapping from blocks to block argument registers.
+  DenseMap<Block *, DenseMap<unsigned, calyx::RegisterOp>> blockArgRegs;
+
+  /// Block arg groups is a list of groups that should be sequentially
+  /// executed when passing control from the source to destination block.
+  /// Block arg groups are executed before blockScheduleables (akin to a
+  /// phi-node).
+  DenseMap<Block *, DenseMap<Block *, SmallVector<calyx::GroupOp>>>
+      blockArgGroups;
+
+  /// A mapping of string prefixes and the current uniqueness counter for that
+  /// prefix. Used to generate unique names.
+  std::map<std::string, unsigned> prefixIdMap;
+
+  /// A mapping from Operations and previously assigned unique name of the op.
+  std::map<Operation *, std::string> opNames;
+
+  /// A mapping between SSA values and the groups which assign them.
+  DenseMap<Value, calyx::GroupInterface> valueGroupAssigns;
+
+  /// A mapping from return value indexes to return value registers.
+  DenseMap<unsigned, calyx::RegisterOp> returnRegs;
+
+  /// A mapping from memref's to their corresponding Calyx memory interface.
+  DenseMap<Value, calyx::MemoryInterface> memories;
+
+  /// A mapping between the source funcOp result indices and the corresponding
+  /// output port indices of this componentOp.
+  DenseMap<unsigned, unsigned> funcOpResultMapping;
+};
+
+/// An interface for conversion passes that lower Calyx programs.
+class ProgramLoweringStateInterface {
+public:
+  explicit ProgramLoweringStateInterface(calyx::ProgramOp program,
+                                         StringRef topLevelFunction);
+
+  /// Returns a meaningful name for a value within the program scope.
+  template <typename ValueOrBlock>
+  std::string irName(ValueOrBlock &v) {
+    std::string s;
+    llvm::raw_string_ostream os(s);
+    mlir::AsmState asmState(program);
+    v.printAsOperand(os, asmState);
+    return s;
+  }
+
+  /// Returns a meaningful name for a block within the program scope (removes
+  /// the ^ prefix from block names).
+  std::string blockName(Block *b);
+
+  /// Returns the current program.
+  calyx::ProgramOp getProgram();
+
+  /// Returns the name of the top-level function in the source program.
+  StringRef getTopLevelFunction() const;
+
+private:
+  /// The name of this top-level function.
+  StringRef topLevelFunction;
+  /// The program associated with this state.
+  calyx::ProgramOp program;
+};
+
+/// Base class for partial lowering passes. A partial lowering pass
+/// modifies the root operation in place, but does not replace the root
+/// operation.
+/// The RewritePatternType template parameter allows for using both
+/// OpRewritePattern (default) or OpInterfaceRewritePattern.
+template <class OpType,
+          template <class> class RewritePatternType = OpRewritePattern>
+class PartialLoweringPattern : public RewritePatternType<OpType> {
+public:
+  using RewritePatternType<OpType>::RewritePatternType;
+  PartialLoweringPattern(MLIRContext *ctx, LogicalResult &resRef)
+      : RewritePatternType<OpType>(ctx), partialPatternRes(resRef) {}
+
+  LogicalResult matchAndRewrite(OpType op,
+                                PatternRewriter &rewriter) const override {
+    rewriter.updateRootInPlace(
+        op, [&] { partialPatternRes = partiallyLower(op, rewriter); });
+    return partialPatternRes;
+  }
+
+  virtual LogicalResult partiallyLower(OpType op,
+                                       PatternRewriter &rewriter) const = 0;
+
+private:
+  LogicalResult &partialPatternRes;
+};
+
+struct ModuleOpConversion : public OpRewritePattern<mlir::ModuleOp> {
+  ModuleOpConversion(MLIRContext *context, StringRef topLevelFunction,
+                     calyx::ProgramOp *programOpOutput);
+
+  LogicalResult matchAndRewrite(mlir::ModuleOp moduleOp,
+                                PatternRewriter &rewriter) const override;
+
+private:
+  calyx::ProgramOp *programOpOutput;
+  StringRef topLevelFunction;
+};
 
 } // namespace calyx
 } // namespace circt

--- a/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
+++ b/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
@@ -207,13 +207,13 @@ public:
                                              MutableArrayRef<OpOperand> ops) {
     /// Pass iteration arguments through registers. This follows closely
     /// to what is done for branch ops.
-    auto groupName = "assign_" + uniqueSuffix;
+    std::string groupName = "assign_" + uniqueSuffix.str();
     auto groupOp = calyx::createGroup<calyx::GroupOp>(rewriter, componentOp,
                                                       op.getLoc(), groupName);
     /// Create register assignment for each iter_arg. a calyx::GroupDone signal
     /// is created for each register. These will be &'ed together in
     /// MultipleGroupDonePattern.
-    for (auto &arg : ops) {
+    for (OpOperand &arg : ops) {
       auto reg = getLoopIterReg(op, arg.getOperandNumber());
       buildAssignmentsForRegisterWrite(rewriter, groupOp, componentOp, reg,
                                        arg.get());

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -86,7 +86,6 @@ using Scheduleable = std::variant<calyx::GroupOp, WhileScheduleable>;
 // Lowering state classes
 //===----------------------------------------------------------------------===//
 
-class ProgramLoweringState;
 /// Handles the current state of lowering of a Calyx component. It is mainly
 /// used as a key/value store for recording information during partial lowering,
 /// which is required at later lowering passes.
@@ -94,13 +93,8 @@ class ComponentLoweringState
     : public calyx::ComponentLoweringStateInterface,
       public calyx::LoopLoweringStateInterface<ScfWhileOp> {
 public:
-  ComponentLoweringState(ProgramLoweringState &state,
-                         calyx::ComponentOp component)
-      : calyx::ComponentLoweringStateInterface(component),
-        programLoweringState(state) {}
-
-  /// Returns the program state associated with this component.
-  ProgramLoweringState &getProgramState() { return programLoweringState; }
+  ComponentLoweringState(calyx::ComponentOp component)
+      : calyx::ComponentLoweringStateInterface(component) {}
 
   /// Register 'scheduleable' as being generated through lowering 'block'.
   ///
@@ -129,36 +123,9 @@ public:
   }
 
 private:
-  /// A reference to the parent program lowering state.
-  ProgramLoweringState &programLoweringState;
-
   /// BlockScheduleables is a list of scheduleables that should be
   /// sequentially executed when executing the associated basic block.
   DenseMap<mlir::Block *, SmallVector<Scheduleable>> blockScheduleables;
-};
-
-/// Handles the current state of lowering of a Calyx program. It is mainly used
-/// as a key/value store for recording information during partial lowering,
-/// which is required at later lowering passes.
-class ProgramLoweringState : public calyx::ProgramLoweringStateInterface {
-public:
-  explicit ProgramLoweringState(calyx::ProgramOp program,
-                                StringRef topLevelFunction)
-      : ProgramLoweringStateInterface(program, topLevelFunction) {}
-  /// Returns the component lowering state associated with compOp.
-  ComponentLoweringState &compLoweringState(calyx::ComponentOp compOp) {
-    auto it = compStates.find(compOp);
-    if (it != compStates.end())
-      return it->second;
-
-    /// Create a new ComponentLoweringState for the compOp.
-    auto newCompStateIt = compStates.try_emplace(compOp, *this, compOp);
-    return newCompStateIt.first->second;
-  }
-
-private:
-  /// Mapping from ComponentOp to component lowering state.
-  DenseMap<Operation *, ComponentLoweringState> compStates;
 };
 
 //===----------------------------------------------------------------------===//
@@ -172,8 +139,9 @@ private:
 class FuncOpPartialLoweringPattern
     : public calyx::PartialLoweringPattern<FuncOp> {
 public:
-  FuncOpPartialLoweringPattern(MLIRContext *context, LogicalResult &resRef,
-                               FuncMapping &_funcMap, ProgramLoweringState &pls)
+  FuncOpPartialLoweringPattern(
+      MLIRContext *context, LogicalResult &resRef, FuncMapping &_funcMap,
+      calyx::ProgramLoweringState<ComponentLoweringState> &pls)
       : PartialLoweringPattern(context, resRef), funcMap(_funcMap), pls(pls) {}
 
   LogicalResult partiallyLower(FuncOp funcOp,
@@ -207,7 +175,9 @@ public:
     return *compLoweringState;
   }
 
-  ProgramLoweringState &progState() const { return pls; }
+  calyx::ProgramLoweringState<ComponentLoweringState> &programState() const {
+    return pls;
+  }
 
   /// Partial lowering implementation.
   virtual LogicalResult
@@ -219,7 +189,7 @@ protected:
 private:
   mutable calyx::ComponentOp *compOp = nullptr;
   mutable ComponentLoweringState *compLoweringState = nullptr;
-  ProgramLoweringState &pls;
+  calyx::ProgramLoweringState<ComponentLoweringState> &pls;
 };
 
 //===----------------------------------------------------------------------===//
@@ -350,8 +320,7 @@ private:
   template <typename TGroupOp>
   TGroupOp createGroupForOp(PatternRewriter &rewriter, Operation *op) const {
     Block *block = op->getBlock();
-    auto groupName = getComponentState().getUniqueName(
-        getComponentState().getProgramState().blockName(block));
+    auto groupName = getComponentState().getUniqueName(programState().blockName(block));
     return calyx::createGroup<TGroupOp>(rewriter,
                                         getComponentState().getComponentOp(),
                                         op->getLoc(), groupName);
@@ -580,8 +549,8 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
     if (succOperands.empty())
       continue;
     // Create operand passing group
-    std::string groupName = progState().blockName(srcBlock) + "_to_" +
-                            progState().blockName(succBlock.value());
+    std::string groupName = programState().blockName(srcBlock) + "_to_" +
+        programState().blockName(succBlock.value());
     auto groupOp = calyx::createGroup<calyx::GroupOp>(rewriter, *getComponent(),
                                                       brOp.getLoc(), groupName);
     // Fetch block argument registers associated with the basic block
@@ -741,7 +710,7 @@ class RewriteMemoryAccesses
     : public calyx::PartialLoweringPattern<calyx::AssignOp> {
 public:
   RewriteMemoryAccesses(MLIRContext *context, LogicalResult &resRef,
-                        ProgramLoweringState &pls)
+                        calyx::ProgramLoweringState<ComponentLoweringState> &pls)
       : PartialLoweringPattern(context, resRef), pls(pls) {}
 
   LogicalResult partiallyLower(calyx::AssignOp assignOp,
@@ -779,7 +748,7 @@ public:
   }
 
 private:
-  ProgramLoweringState &pls;
+  calyx::ProgramLoweringState<ComponentLoweringState> &pls;
 };
 
 /// Connverts all index-typed operations and values to i32 values.
@@ -1001,7 +970,7 @@ struct FuncOpConversion : public FuncOpPartialLoweringPattern {
 
     /// Store the function-to-component mapping.
     funcMap[funcOp] = compOp;
-    auto &compState = progState().compLoweringState(compOp);
+    auto &compState = programState().compLoweringState(compOp);
     compState.setFuncOpResultMapping(funcOpResultMapping);
 
     /// Rewrite funcOp SSA argument values to the CompOp arguments.
@@ -1071,8 +1040,8 @@ class BuildWhileGroups : public FuncOpPartialLoweringPattern {
         auto condOp = scfWhileOp.getConditionOp().getArgs()[barg.index()];
         if (barg.value() != condOp) {
           res = whileOp.getOperation()->emitError()
-                << progState().irName(barg.value())
-                << " != " << progState().irName(condOp)
+                << programState().irName(barg.value())
+                << " != " << programState().irName(condOp)
                 << "do-while loops not supported; expected iter-args to "
                    "remain untransformed in the 'before' region of the "
                    "scf.while op.";
@@ -1139,7 +1108,7 @@ class BuildBBRegs : public FuncOpPartialLoweringPattern {
         assert(argType.isa<IntegerType>() && "unsupported block argument type");
         unsigned width = argType.getIntOrFloatBitWidth();
         std::string name =
-            progState().blockName(block) + "_arg" + std::to_string(arg.index());
+            programState().blockName(block) + "_arg" + std::to_string(arg.index());
         auto reg = createRegister(arg.value().getLoc(), rewriter,
                                   *getComponent(), width, name);
         getComponentState().addBlockArgReg(block, reg, arg.index());
@@ -1366,7 +1335,7 @@ class InlineCombGroups
                                            OpInterfaceRewritePattern> {
 public:
   InlineCombGroups(MLIRContext *context, LogicalResult &resRef,
-                   ProgramLoweringState &pls)
+                   calyx::ProgramLoweringState<ComponentLoweringState> &pls)
       : PartialLoweringPattern(context, resRef), pls(pls) {}
 
   LogicalResult partiallyLower(calyx::GroupInterface originGroup,
@@ -1438,7 +1407,7 @@ private:
     }
   }
 
-  ProgramLoweringState &pls;
+  calyx::ProgramLoweringState<ComponentLoweringState> &pls;
 };
 
 /// LateSSAReplacement contains various functions for replacing SSA values that
@@ -1703,7 +1672,8 @@ public:
 
 private:
   LogicalResult partialPatternRes;
-  std::shared_ptr<ProgramLoweringState> loweringState = nullptr;
+  std::shared_ptr<calyx::ProgramLoweringState<ComponentLoweringState>> loweringState =
+      nullptr;
 };
 
 void SCFToCalyxPass::runOnOperation() {
@@ -1723,7 +1693,8 @@ void SCFToCalyxPass::runOnOperation() {
          "programOp should have been set during module "
          "conversion, if module conversion succeeded.");
   loweringState =
-      std::make_shared<ProgramLoweringState>(programOp, topLevelFunction);
+      std::make_shared<calyx::ProgramLoweringState<ComponentLoweringState>>(
+          programOp, topLevelFunction);
 
   /// --------------------------------------------------------------------------
   /// If you are a developer, it may be helpful to add a

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -140,9 +140,9 @@ class FuncOpPartialLoweringPattern
     : public calyx::PartialLoweringPattern<FuncOp> {
 public:
   FuncOpPartialLoweringPattern(
-      MLIRContext *context, LogicalResult &resRef, FuncMapping &_funcMap,
+      MLIRContext *context, LogicalResult &resRef, FuncMapping &map,
       calyx::ProgramLoweringState<ComponentLoweringState> &pls)
-      : PartialLoweringPattern(context, resRef), funcMap(_funcMap), pls(pls) {}
+      : PartialLoweringPattern(context, resRef), funcMap(map), pls(pls) {}
 
   LogicalResult partiallyLower(FuncOp funcOp,
                                PatternRewriter &rewriter) const override final {

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -453,7 +453,7 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
     auto reg = createRegister(loadOp.getLoc(), rewriter, *getComponent(),
                               loadOp.getMemRefType().getElementTypeBitWidth(),
                               getComponentState().getUniqueName("load"));
-    getComponentState().buildAssignmentsForRegisterWrite(
+    calyx::buildAssignmentsForRegisterWrite(
         rewriter, group, getComponentState().getComponentOp(), reg,
         memoryInterface.readData());
     loadOp.getResult().replaceAllUsesWith(reg.out());
@@ -590,7 +590,7 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
     // Create register assignment for each block argument
     for (auto arg : enumerate(succOperands.getForwardedOperands())) {
       auto reg = dstBlockArgRegs[arg.index()];
-      getComponentState().buildAssignmentsForRegisterWrite(
+      calyx::buildAssignmentsForRegisterWrite(
           rewriter, groupOp, getComponentState().getComponentOp(), reg,
           arg.value());
     }
@@ -613,7 +613,7 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
                                                     retOp.getLoc(), groupName);
   for (auto op : enumerate(retOp.getOperands())) {
     auto reg = getComponentState().getReturnReg(op.index());
-    getComponentState().buildAssignmentsForRegisterWrite(
+    calyx::buildAssignmentsForRegisterWrite(
         rewriter, groupOp, getComponentState().getComponentOp(), reg,
         op.value());
   }

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -320,7 +320,8 @@ private:
   template <typename TGroupOp>
   TGroupOp createGroupForOp(PatternRewriter &rewriter, Operation *op) const {
     Block *block = op->getBlock();
-    auto groupName = getComponentState().getUniqueName(programState().blockName(block));
+    auto groupName =
+        getComponentState().getUniqueName(programState().blockName(block));
     return calyx::createGroup<TGroupOp>(rewriter,
                                         getComponentState().getComponentOp(),
                                         op->getLoc(), groupName);
@@ -550,7 +551,7 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
       continue;
     // Create operand passing group
     std::string groupName = programState().blockName(srcBlock) + "_to_" +
-        programState().blockName(succBlock.value());
+                            programState().blockName(succBlock.value());
     auto groupOp = calyx::createGroup<calyx::GroupOp>(rewriter, *getComponent(),
                                                       brOp.getLoc(), groupName);
     // Fetch block argument registers associated with the basic block
@@ -709,8 +710,9 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
 class RewriteMemoryAccesses
     : public calyx::PartialLoweringPattern<calyx::AssignOp> {
 public:
-  RewriteMemoryAccesses(MLIRContext *context, LogicalResult &resRef,
-                        calyx::ProgramLoweringState<ComponentLoweringState> &pls)
+  RewriteMemoryAccesses(
+      MLIRContext *context, LogicalResult &resRef,
+      calyx::ProgramLoweringState<ComponentLoweringState> &pls)
       : PartialLoweringPattern(context, resRef), pls(pls) {}
 
   LogicalResult partiallyLower(calyx::AssignOp assignOp,
@@ -1107,8 +1109,8 @@ class BuildBBRegs : public FuncOpPartialLoweringPattern {
         Type argType = arg.value().getType();
         assert(argType.isa<IntegerType>() && "unsupported block argument type");
         unsigned width = argType.getIntOrFloatBitWidth();
-        std::string name =
-            programState().blockName(block) + "_arg" + std::to_string(arg.index());
+        std::string name = programState().blockName(block) + "_arg" +
+                           std::to_string(arg.index());
         auto reg = createRegister(arg.value().getLoc(), rewriter,
                                   *getComponent(), width, name);
         getComponentState().addBlockArgReg(block, reg, arg.index());
@@ -1672,8 +1674,8 @@ public:
 
 private:
   LogicalResult partialPatternRes;
-  std::shared_ptr<calyx::ProgramLoweringState<ComponentLoweringState>> loweringState =
-      nullptr;
+  std::shared_ptr<calyx::ProgramLoweringState<ComponentLoweringState>>
+      loweringState = nullptr;
 };
 
 void SCFToCalyxPass::runOnOperation() {

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -168,7 +168,8 @@ private:
 /// and then perform their own walking of the IR. FuncOpPartialLoweringPatterns
 /// have direct access to the ComponentLoweringState for the corresponding
 /// component of the matched FuncOp.
-class FuncOpPartialLoweringPattern : public calyx::PartialLoweringPattern<FuncOp> {
+class FuncOpPartialLoweringPattern
+    : public calyx::PartialLoweringPattern<FuncOp> {
 public:
   FuncOpPartialLoweringPattern(MLIRContext *context, LogicalResult &resRef,
                                FuncMapping &_funcMap, ProgramLoweringState &pls)
@@ -732,7 +733,8 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
 /// This pass rewrites memory accesses that have a width mismatch. Such
 /// mismatches are due to index types being assumed 32-bit wide due to the lack
 /// of a width inference pass.
-class RewriteMemoryAccesses : public calyx::PartialLoweringPattern<calyx::AssignOp> {
+class RewriteMemoryAccesses
+    : public calyx::PartialLoweringPattern<calyx::AssignOp> {
 public:
   RewriteMemoryAccesses(MLIRContext *context, LogicalResult &resRef,
                         ProgramLoweringState &pls)
@@ -1357,7 +1359,7 @@ private:
 /// non-stateful groups) into groups referenced in the control schedule.
 class InlineCombGroups
     : public calyx::PartialLoweringPattern<calyx::GroupInterface,
-                                    OpInterfaceRewritePattern> {
+                                           OpInterfaceRewritePattern> {
 public:
   InlineCombGroups(MLIRContext *context, LogicalResult &resRef,
                    ProgramLoweringState &pls)
@@ -1647,8 +1649,8 @@ public:
 
     // Program conversion
     RewritePatternSet conversionPatterns(&getContext());
-    conversionPatterns.add<calyx::ModuleOpConversion>(&getContext(), topLevelFunction,
-                                               programOpOut);
+    conversionPatterns.add<calyx::ModuleOpConversion>(
+        &getContext(), topLevelFunction, programOpOut);
     return applyOpPatternsAndFold(getOperation(),
                                   std::move(conversionPatterns));
   }

--- a/lib/Conversion/StaticLogicToCalyx/StaticLogicToCalyx.cpp
+++ b/lib/Conversion/StaticLogicToCalyx/StaticLogicToCalyx.cpp
@@ -88,55 +88,19 @@ using Scheduleable =
 // Lowering state classes
 //===----------------------------------------------------------------------===//
 
-/// ComponentLoweringState handles the current state of lowering of a Calyx
-/// component. It is mainly used as a key/value store for recording information
-/// during partial lowering, which is required at later lowering passes.
 class ProgramLoweringState;
-class ComponentLoweringState {
+/// Handles the current state of lowering of a Calyx component. It is mainly
+/// used as a key/value store for recording information during partial lowering,
+/// which is required at later lowering passes.
+class ComponentLoweringState
+    : public calyx::ComponentLoweringStateInterface<StaticLogicWhileOp> {
 public:
-  ComponentLoweringState(ProgramLoweringState &pls, calyx::ComponentOp compOp)
-      : programLoweringState(pls), compOp(compOp) {}
+  ComponentLoweringState(ProgramLoweringState &state,
+                         calyx::ComponentOp component)
+      : calyx::ComponentLoweringStateInterface<StaticLogicWhileOp>(component),
+        programLoweringState(state) {}
 
   ProgramLoweringState &getProgramState() { return programLoweringState; }
-
-  /// Returns the calyx::ComponentOp associated with this lowering state.
-  calyx::ComponentOp getComponentOp() { return compOp; }
-
-  /// Returns a unique name within compOp with the provided prefix.
-  std::string getUniqueName(StringRef prefix) {
-    std::string prefixStr = prefix.str();
-    unsigned idx = prefixIdMap[prefixStr];
-    ++prefixIdMap[prefixStr];
-    return (prefix + "_" + std::to_string(idx)).str();
-  }
-
-  /// Returns a unique name associated with a specific operation.
-  StringRef getUniqueName(Operation *op) {
-    auto it = opNames.find(op);
-    assert(it != opNames.end() && "A unique name should have been set for op");
-    return it->second;
-  }
-
-  /// Registers a unique name for a given operation using a provided prefix.
-  void setUniqueName(Operation *op, StringRef prefix) {
-    assert(opNames.find(op) == opNames.end() &&
-           "A unique name was already set for op");
-    opNames[op] = getUniqueName(prefix);
-  }
-
-  template <typename TLibraryOp>
-  TLibraryOp getNewLibraryOpInstance(PatternRewriter &rewriter, Location loc,
-                                     TypeRange resTypes) {
-    IRRewriter::InsertionGuard guard(rewriter);
-    rewriter.setInsertionPoint(compOp.getBody(), compOp.getBody()->begin());
-    auto name = TLibraryOp::getOperationName().split(".").second;
-    return rewriter.create<TLibraryOp>(loc, getUniqueName(name), resTypes);
-  }
-
-  /// Register value v as being evaluated when scheduling group.
-  void registerEvaluatingGroup(Value v, calyx::GroupInterface group) {
-    valueGroupAssigns[v] = group;
-  }
 
   /// Registers operations that may be used in a pipeline, but does not produce
   /// a value to be used in a further stage.
@@ -160,34 +124,6 @@ public:
       assert(group && "Actual group type differed from expected group type");
       return group;
     }
-  }
-
-  /// Return the group which evaluates the value v. Optionally, caller may
-  /// specify the expected type of the group.
-  template <typename TGroupOp = calyx::GroupInterface>
-  TGroupOp getEvaluatingGroup(Value v) {
-    auto it = valueGroupAssigns.find(v);
-    assert(it != valueGroupAssigns.end() && "No group evaluating value!");
-    if constexpr (std::is_same<TGroupOp, calyx::GroupInterface>::value)
-      return it->second;
-    else {
-      auto group = dyn_cast<TGroupOp>(it->second.getOperation());
-      assert(group && "Actual group type differed from expected group type");
-      return group;
-    }
-  }
-
-  /// Register reg as being the idx'th return value register.
-  void addReturnReg(calyx::RegisterOp reg, unsigned idx) {
-    assert(returnRegs.count(idx) == 0 &&
-           "A register was already registered for this index");
-    returnRegs[idx] = reg;
-  }
-
-  /// Returns the idx'th return value register.
-  calyx::RegisterOp getReturnReg(unsigned idx) {
-    assert(returnRegs.count(idx) && "No register registered for index!");
-    return returnRegs[idx];
   }
 
   /// Register 'scheduleable' as being generated through lowering 'block'.
@@ -216,30 +152,6 @@ public:
     return {};
   }
 
-  /// Register 'grp' as a group which performs block argument
-  /// register transfer when transitioning from basic block from to to.
-  void addBlockArgGroup(Block *from, Block *to, calyx::GroupOp grp) {
-    blockArgGroups[from][to].push_back(grp);
-  }
-
-  /// Returns a list of groups to be evaluated to perform the block argument
-  /// register assignments when transitioning from basic block 'from' to 'to'.
-  ArrayRef<calyx::GroupOp> getBlockArgGroups(Block *from, Block *to) {
-    return blockArgGroups[from][to];
-  }
-
-  /// Register reg as being the idx'th argument register for block.
-  void addBlockArgReg(Block *block, calyx::RegisterOp reg, unsigned idx) {
-    assert(blockArgRegs[block].count(idx) == 0);
-    assert(idx < block->getArguments().size());
-    blockArgRegs[block][idx] = reg;
-  }
-
-  /// Return a mapping of block argument indices to block argument registers.
-  const DenseMap<unsigned, calyx::RegisterOp> &getBlockArgRegs(Block *block) {
-    return blockArgRegs[block];
-  }
-
   /// Register reg as being the idx'th pipeline register for the stage.
   void addPipelineReg(Operation *stage, calyx::RegisterOp reg, unsigned idx) {
     assert(pipelineRegs[stage].count(idx) == 0);
@@ -264,13 +176,8 @@ public:
   }
 
   /// Get the pipeline prologue.
-  SmallVector<SmallVector<StringAttr>> getPipelineProlouge(Operation *op) {
+  SmallVector<SmallVector<StringAttr>> getPipelinePrologue(Operation *op) {
     return pipelinePrologue[op];
-  }
-
-  /// Get the pipeline epilogue.
-  SmallVector<SmallVector<StringAttr>> getPipelineEpilouge(Operation *op) {
-    return pipelineEpilogue[op];
   }
 
   /// Create the pipeline prologue.
@@ -300,18 +207,19 @@ public:
   }
 
   /// Register reg as being the idx'th iter_args register for 'whileOp'.
-  void addWhileIterReg(StaticLogicWhileOp whileOp, calyx::RegisterOp reg,
-                       unsigned idx) {
-    assert(whileIterRegs[whileOp.getOperation()].count(idx) == 0 &&
+  void addWhileIterReg(StaticLogicWhileOp op, calyx::RegisterOp reg,
+                       unsigned idx) override {
+    assert(whileIterRegs[op.getOperation()].count(idx) == 0 &&
            "A register was already registered for the given while iter_arg "
            "index");
-    assert(idx < whileOp.getBodyArgs().size());
-    whileIterRegs[whileOp.getOperation()][idx] = reg;
+    assert(idx < op.getBodyArgs().size());
+    whileIterRegs[op.getOperation()][idx] = reg;
   }
 
   /// Return a mapping of block argument indices to block argument registers.
-  calyx::RegisterOp getWhileIterReg(StaticLogicWhileOp whileOp, unsigned idx) {
-    auto iterRegs = getWhileIterRegs(whileOp);
+  calyx::RegisterOp getWhileIterReg(StaticLogicWhileOp op,
+                                    unsigned idx) override {
+    auto iterRegs = getWhileIterRegs(op);
     auto it = iterRegs.find(idx);
     assert(it != iterRegs.end() &&
            "No iter arg register set for the provided index");
@@ -320,68 +228,23 @@ public:
 
   /// Return a mapping of block argument indices to block argument registers.
   const DenseMap<unsigned, calyx::RegisterOp> &
-  getWhileIterRegs(StaticLogicWhileOp whileOp) {
-    return whileIterRegs[whileOp.getOperation()];
+  getWhileIterRegs(StaticLogicWhileOp op) override {
+    return whileIterRegs[op.getOperation()];
   }
 
   /// Registers grp to be the while latch group of whileOp.
-  void setWhileLatchGroup(StaticLogicWhileOp whileOp, calyx::GroupOp grp) {
-    assert(whileLatchGroups.count(whileOp.getOperation()) == 0 &&
+  void setWhileLatchGroup(StaticLogicWhileOp op,
+                          calyx::GroupOp grp) override {
+    assert(whileLatchGroups.count(op.getOperation()) == 0 &&
            "A latch group was already set for this whileOp");
-    whileLatchGroups[whileOp.getOperation()] = grp;
+    whileLatchGroups[op.getOperation()] = grp;
   }
 
   /// Retrieve the while latch group registered for whileOp.
-  calyx::GroupOp getWhileLatchGroup(StaticLogicWhileOp whileOp) {
-    auto it = whileLatchGroups.find(whileOp.getOperation());
+  calyx::GroupOp getWhileLatchGroup(StaticLogicWhileOp op) override {
+    auto it = whileLatchGroups.find(op.getOperation());
     assert(it != whileLatchGroups.end() &&
            "No while latch group was set for this whileOp");
-    return it->second;
-  }
-
-  /// Registers a memory interface as being associated with a memory identified
-  /// by 'memref'.
-  void registerMemoryInterface(Value memref,
-                               const calyx::MemoryInterface &memoryInterface) {
-    assert(memref.getType().isa<MemRefType>());
-    assert(memories.find(memref) == memories.end() &&
-           "Memory already registered for memref");
-    memories[memref] = memoryInterface;
-  }
-
-  /// Returns the memory interface registered for the given memref.
-  calyx::MemoryInterface getMemoryInterface(Value memref) {
-    assert(memref.getType().isa<MemRefType>());
-    auto it = memories.find(memref);
-    assert(it != memories.end() && "No memory registered for memref");
-    return it->second;
-  }
-
-  /// If v is an input to any memory registered within this component, returns
-  /// the memory. If not, returns null.
-  Optional<calyx::MemoryInterface> isInputPortOfMemory(Value v) {
-    for (auto &memIf : memories) {
-      auto &mem = memIf.getSecond();
-      if (mem.writeEn() == v || mem.writeData() == v ||
-          llvm::any_of(mem.addrPorts(), [=](Value port) { return port == v; }))
-        return {mem};
-    }
-    return {};
-  }
-
-  /// Assign a mapping between the source funcOp result indices and the
-  /// corresponding output port indices of this componentOp.
-  void setFuncOpResultMapping(const DenseMap<unsigned, unsigned> &mapping) {
-    funcOpResultMapping = mapping;
-  }
-
-  /// Get the output port index of this component for which the funcReturnIdx of
-  /// the original function maps to.
-  unsigned getFuncOpResultMapping(unsigned funcReturnIdx) {
-    auto it = funcOpResultMapping.find(funcReturnIdx);
-    assert(it != funcOpResultMapping.end() &&
-           "No component return port index recorded for the requested function "
-           "return index");
     return it->second;
   }
 
@@ -389,33 +252,14 @@ private:
   /// A reference to the parent program lowering state.
   ProgramLoweringState &programLoweringState;
 
-  /// The component which this lowering state is associated to.
-  calyx::ComponentOp compOp;
-
-  /// A mapping of string prefixes and the current uniqueness counter for that
-  /// prefix. Used to generate unique names.
-  std::map<std::string, unsigned> prefixIdMap;
-
-  /// A mapping from Operations and previously assigned unique name of the op.
-  std::map<Operation *, std::string> opNames;
-
-  /// A mapping between SSA values and the groups which assign them.
-  DenseMap<Value, calyx::GroupInterface> valueGroupAssigns;
-
   /// A mapping between operations and the group to which it was assigned. This
   /// is used for specific corner cases, such as pipeline stages that may not
   /// actually pipeline any values.
   DenseMap<Operation *, calyx::GroupInterface> operationToGroup;
 
-  /// A mapping from return value indexes to return value registers.
-  DenseMap<unsigned, calyx::RegisterOp> returnRegs;
-
   /// BlockScheduleables is a list of scheduleables that should be
   /// sequentially executed when executing the associated basic block.
   DenseMap<mlir::Block *, SmallVector<Scheduleable>> blockScheduleables;
-
-  /// A mapping from blocks to block argument registers.
-  DenseMap<Block *, DenseMap<unsigned, calyx::RegisterOp>> blockArgRegs;
 
   /// A mapping from pipeline stages to their registers.
   DenseMap<Operation *, DenseMap<unsigned, calyx::RegisterOp>> pipelineRegs;
@@ -430,13 +274,6 @@ private:
   /// for one stage.
   DenseMap<Operation *, SmallVector<SmallVector<StringAttr>>> pipelineEpilogue;
 
-  /// Block arg groups is a list of groups that should be sequentially
-  /// executed when passing control from the source to destination block.
-  /// Block arg groups are executed before blockScheduleables (akin to a
-  /// phi-node).
-  DenseMap<Block *, DenseMap<Block *, SmallVector<calyx::GroupOp>>>
-      blockArgGroups;
-
   /// A while latch group is a group that should be sequentially executed when
   /// finishing a while loop body. The execution of this group will write the
   /// yield'ed loop body values to the iteration argument registers.
@@ -444,45 +281,16 @@ private:
 
   /// A mapping from while ops to iteration argument registers.
   DenseMap<Operation *, DenseMap<unsigned, calyx::RegisterOp>> whileIterRegs;
-
-  /// A mapping from memref's to their corresponding Calyx memory interface.
-  DenseMap<Value, calyx::MemoryInterface> memories;
-
-  /// A mapping between the source funcOp result indices and the corresponding
-  /// output port indices of this componentOp.
-  DenseMap<unsigned, unsigned> funcOpResultMapping;
 };
 
-/// ProgramLoweringState handles the current state of lowering of a Calyx
-/// program. It is mainly used as a key/value store for recording information
-/// during partial lowering, which is required at later lowering passes.
-class ProgramLoweringState {
+/// Handles the current state of lowering of a Calyx program. It is mainly used
+/// as a key/value store for recording information during partial lowering,
+/// which is required at later lowering passes.
+class ProgramLoweringState : public calyx::ProgramLoweringStateInterface {
 public:
   explicit ProgramLoweringState(calyx::ProgramOp program,
                                 StringRef topLevelFunction)
-      : topLevelFunction(topLevelFunction), program(program) {
-    getProgram();
-  }
-
-  /// Returns a meaningful name for a value within the program scope.
-  template <typename ValueOrBlock>
-  std::string irName(ValueOrBlock &v) {
-    std::string s;
-    llvm::raw_string_ostream os(s);
-    AsmState asmState(program);
-    v.printAsOperand(os, asmState);
-    return s;
-  }
-
-  /// Returns a meaningful name for a block within the program scope (removes
-  /// the ^ prefix from block names).
-  std::string blockName(Block *b) {
-    auto blockName = irName(*b);
-    blockName.erase(std::remove(blockName.begin(), blockName.end(), '^'),
-                    blockName.end());
-    return blockName;
-  }
-
+      : ProgramLoweringStateInterface(program, topLevelFunction) {}
   /// Returns the component lowering state associated with compOp.
   ComponentLoweringState &compLoweringState(calyx::ComponentOp compOp) {
     auto it = compStates.find(compOp);
@@ -494,89 +302,9 @@ public:
     return newCompStateIt.first->second;
   }
 
-  /// Returns the current program.
-  calyx::ProgramOp getProgram() {
-    assert(program.getOperation() != nullptr);
-    return program;
-  }
-
-  /// Returns the name of the top-level function in the source program.
-  StringRef getTopLevelFunction() const { return topLevelFunction; }
-
 private:
-  StringRef topLevelFunction;
-  calyx::ProgramOp program;
+  /// Mapping from ComponentOp to component lowering state.
   DenseMap<Operation *, ComponentLoweringState> compStates;
-};
-
-/// Creates register assignment operations within the provided groupOp.
-static void buildAssignmentsForRegisterWrite(ComponentLoweringState &state,
-                                             PatternRewriter &rewriter,
-                                             calyx::GroupOp groupOp,
-                                             calyx::RegisterOp &reg,
-                                             Value inputValue) {
-  IRRewriter::InsertionGuard guard(rewriter);
-  auto loc = inputValue.getLoc();
-  rewriter.setInsertionPointToEnd(groupOp.getBody());
-  rewriter.create<calyx::AssignOp>(loc, reg.in(), inputValue);
-  rewriter.create<calyx::AssignOp>(
-      loc, reg.write_en(),
-      createConstant(loc, rewriter, state.getComponentOp(), 1, 1));
-  rewriter.create<calyx::GroupDoneOp>(loc, reg.done());
-}
-
-/// Creates a new group that assigns the 'ops' values to the iter arg registers
-/// of the 'whileOp'.
-static calyx::GroupOp
-buildWhileIterArgAssignments(PatternRewriter &rewriter,
-                             ComponentLoweringState &state, Location loc,
-                             StaticLogicWhileOp whileOp, Twine uniqueSuffix,
-                             MutableArrayRef<OpOperand> ops) {
-  assert(whileOp.getOperation());
-  /// Pass iteration arguments through registers. This follows closely
-  /// to what is done for branch ops.
-  auto groupName = "assign_" + uniqueSuffix;
-  auto groupOp = calyx::createGroup<calyx::GroupOp>(
-      rewriter, state.getComponentOp(), loc, groupName);
-  /// Create register assignment for each iter_arg. a calyx::GroupDone signal
-  /// is created for each register. These will be &'ed together in
-  /// MultipleGroupDonePattern.
-  for (auto &arg : ops) {
-    auto reg = state.getWhileIterReg(whileOp, arg.getOperandNumber());
-    buildAssignmentsForRegisterWrite(state, rewriter, groupOp, reg, arg.get());
-  }
-  return groupOp;
-}
-
-//===----------------------------------------------------------------------===//
-// Partial lowering infrastructure
-//===----------------------------------------------------------------------===//
-
-/// Base class for partial lowering passes. A partial lowering pass
-/// modifies the root operation in place, but does not replace the root
-/// operation.
-/// The RewritePatternType template parameter allows for using both
-/// OpRewritePattern (default) or OpInterfaceRewritePattern.
-template <class OpType,
-          template <class> class RewritePatternType = OpRewritePattern>
-class PartialLoweringPattern : public RewritePatternType<OpType> {
-public:
-  using RewritePatternType<OpType>::RewritePatternType;
-  PartialLoweringPattern(MLIRContext *ctx, LogicalResult &resRef)
-      : RewritePatternType<OpType>(ctx), partialPatternRes(resRef) {}
-
-  LogicalResult matchAndRewrite(OpType op,
-                                PatternRewriter &rewriter) const override {
-    rewriter.updateRootInPlace(
-        op, [&] { partialPatternRes = partiallyLower(op, rewriter); });
-    return partialPatternRes;
-  }
-
-  virtual LogicalResult partiallyLower(OpType op,
-                                       PatternRewriter &rewriter) const = 0;
-
-private:
-  LogicalResult &partialPatternRes;
 };
 
 //===----------------------------------------------------------------------===//
@@ -587,7 +315,7 @@ private:
 /// and then perform their own walking of the IR. FuncOpPartialLoweringPatterns
 /// have direct access to the ComponentLoweringState for the corresponding
 /// component of the matched FuncOp.
-class FuncOpPartialLoweringPattern : public PartialLoweringPattern<FuncOp> {
+class FuncOpPartialLoweringPattern : public calyx::PartialLoweringPattern<FuncOp> {
 public:
   FuncOpPartialLoweringPattern(MLIRContext *context, LogicalResult &resRef,
                                FuncMapping &_funcMap, ProgramLoweringState &pls)
@@ -872,7 +600,7 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
     auto reg = createRegister(loadOp.getLoc(), rewriter, *getComponent(),
                               loadOp.getMemRefType().getElementTypeBitWidth(),
                               getComponentState().getUniqueName("load"));
-    buildAssignmentsForRegisterWrite(getComponentState(), rewriter, group, reg,
+    getComponentState().buildAssignmentsForRegisterWrite(rewriter, group, reg,
                                      memoryInterface.readData());
     loadOp.getResult().replaceAllUsesWith(reg.out());
     getComponentState().addBlockScheduleable(loadOp->getBlock(), group);
@@ -1008,7 +736,7 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
     // Create register assignment for each block argument
     for (auto arg : enumerate(succOperands.getForwardedOperands())) {
       auto reg = dstBlockArgRegs[arg.index()];
-      buildAssignmentsForRegisterWrite(getComponentState(), rewriter, groupOp,
+      getComponentState().buildAssignmentsForRegisterWrite(rewriter, groupOp,
                                        reg, arg.value());
     }
     /// Register the group as a block argument group, to be executed
@@ -1030,7 +758,7 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
                                                     retOp.getLoc(), groupName);
   for (auto op : enumerate(retOp.getOperands())) {
     auto reg = getComponentState().getReturnReg(op.index());
-    buildAssignmentsForRegisterWrite(getComponentState(), rewriter, groupOp,
+    getComponentState().buildAssignmentsForRegisterWrite( rewriter, groupOp,
                                      reg, op.value());
   }
   /// Schedule group for execution for when executing the return op block.
@@ -1147,7 +875,7 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
 /// This pass rewrites memory accesses that have a width mismatch. Such
 /// mismatches are due to index types being assumed 32-bit wide due to the lack
 /// of a width inference pass.
-class RewriteMemoryAccesses : public PartialLoweringPattern<calyx::AssignOp> {
+class RewriteMemoryAccesses : public calyx::PartialLoweringPattern<calyx::AssignOp> {
 public:
   RewriteMemoryAccesses(MLIRContext *context, LogicalResult &resRef,
                         ProgramLoweringState &pls)
@@ -1441,8 +1169,8 @@ class BuildWhileGroups : public FuncOpPartialLoweringPattern {
       SmallVector<calyx::GroupOp> initGroups;
       auto numOperands = whileOp.getOperation()->getNumOperands();
       for (size_t i = 0; i < numOperands; ++i) {
-        auto initGroupOp = buildWhileIterArgAssignments(
-            rewriter, getComponentState(), whileOp.getOperation()->getLoc(),
+        auto initGroupOp = getComponentState().buildWhileIterArgAssignments(
+            rewriter,
             whileOp,
             getComponentState().getUniqueName(whileOp.getOperation()) +
                 "_init_" + std::to_string(i),
@@ -1668,7 +1396,7 @@ class BuildPipelineGroups : public FuncOpPartialLoweringPattern {
     rewriter.eraseOp(combGroup);
 
     // Stitch evaluating group to register.
-    buildAssignmentsForRegisterWrite(getComponentState(), rewriter, group,
+    getComponentState().buildAssignmentsForRegisterWrite(rewriter, group,
                                      pipelineRegister, value);
 
     // Mark the new group as the evaluating group.
@@ -1734,46 +1462,6 @@ class BuildReturnRegs : public FuncOpPartialLoweringPattern {
     }
     return success();
   }
-};
-
-struct ModuleOpConversion : public OpRewritePattern<mlir::ModuleOp> {
-  ModuleOpConversion(MLIRContext *context, StringRef topLevelFunction,
-                     calyx::ProgramOp *programOpOutput)
-      : OpRewritePattern<mlir::ModuleOp>(context),
-        programOpOutput(programOpOutput), topLevelFunction(topLevelFunction) {
-    assert(programOpOutput->getOperation() == nullptr &&
-           "this function will set programOpOutput post module conversion");
-  }
-
-  LogicalResult matchAndRewrite(mlir::ModuleOp moduleOp,
-                                PatternRewriter &rewriter) const override {
-    if (!moduleOp.getOps<calyx::ProgramOp>().empty())
-      return failure();
-
-    rewriter.updateRootInPlace(moduleOp, [&] {
-      // Create ProgramOp
-      rewriter.setInsertionPointAfter(moduleOp);
-      auto programOp = rewriter.create<calyx::ProgramOp>(
-          moduleOp.getLoc(), StringAttr::get(getContext(), topLevelFunction));
-
-      // Inline the module body region
-      rewriter.inlineRegionBefore(moduleOp.getBodyRegion(),
-                                  programOp.getBodyRegion(),
-                                  programOp.getBodyRegion().end());
-
-      // Inlining the body region also removes ^bb0 from the module body
-      // region, so recreate that, before finally inserting the programOp
-      auto moduleBlock = rewriter.createBlock(&moduleOp.getBodyRegion());
-      rewriter.setInsertionPointToStart(moduleBlock);
-      rewriter.insert(programOp);
-      *programOpOutput = programOp;
-    });
-    return success();
-  }
-
-private:
-  calyx::ProgramOp *programOpOutput = nullptr;
-  StringRef topLevelFunction;
 };
 
 /// Builds a control schedule by traversing the CFG of the function and
@@ -1987,7 +1675,7 @@ private:
     if (auto bound = whileOp.getBound()) {
       // Subtract the number of iterations unrolled into the prologue.
       auto prologue =
-          getComponentState().getPipelineProlouge(whileOp.getOperation());
+          getComponentState().getPipelinePrologue(whileOp.getOperation());
       auto unrolledBound = *bound - prologue.size();
       whileCtrlOp->setAttr("bound", rewriter.getI64IntegerAttr(unrolledBound));
     }
@@ -1999,7 +1687,7 @@ private:
 /// This pass recursively inlines use-def chains of combinational logic (from
 /// non-stateful groups) into groups referenced in the control schedule.
 class InlineCombGroups
-    : public PartialLoweringPattern<calyx::GroupInterface,
+    : public calyx::PartialLoweringPattern<calyx::GroupInterface,
                                     OpInterfaceRewritePattern> {
 public:
   InlineCombGroups(MLIRContext *context, LogicalResult &resRef,
@@ -2274,7 +1962,7 @@ public:
 
     // Program conversion
     RewritePatternSet conversionPatterns(&getContext());
-    conversionPatterns.add<ModuleOpConversion>(&getContext(), topLevelFunction,
+    conversionPatterns.add<calyx::ModuleOpConversion>(&getContext(), topLevelFunction,
                                                programOpOut);
     return applyOpPatternsAndFold(getOperation(),
                                   std::move(conversionPatterns));
@@ -2285,7 +1973,7 @@ public:
   /// results are skipped for Once patterns).
   template <typename TPattern, typename... PatternArgs>
   void addOncePattern(SmallVectorImpl<LoweringPattern> &patterns,
-                      PatternArgs &&...args) {
+                      PatternArgs &&... args) {
     RewritePatternSet ps(&getContext());
     ps.add<TPattern>(&getContext(), partialPatternRes, args...);
     patterns.push_back(
@@ -2294,7 +1982,7 @@ public:
 
   template <typename TPattern, typename... PatternArgs>
   void addGreedyPattern(SmallVectorImpl<LoweringPattern> &patterns,
-                        PatternArgs &&...args) {
+                        PatternArgs &&... args) {
     RewritePatternSet ps(&getContext());
     ps.add<TPattern>(&getContext(), args...);
     patterns.push_back(

--- a/lib/Conversion/StaticLogicToCalyx/StaticLogicToCalyx.cpp
+++ b/lib/Conversion/StaticLogicToCalyx/StaticLogicToCalyx.cpp
@@ -80,8 +80,7 @@ struct LoopScheduleable {
 struct PipelineScheduleable : LoopScheduleable {};
 
 /// A variant of types representing scheduleable operations.
-using Scheduleable =
-    std::variant<calyx::GroupOp, PipelineScheduleable>;
+using Scheduleable = std::variant<calyx::GroupOp, PipelineScheduleable>;
 
 //===----------------------------------------------------------------------===//
 // Lowering state classes

--- a/lib/Conversion/StaticLogicToCalyx/StaticLogicToCalyx.cpp
+++ b/lib/Conversion/StaticLogicToCalyx/StaticLogicToCalyx.cpp
@@ -550,7 +550,7 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
     auto reg = createRegister(loadOp.getLoc(), rewriter, *getComponent(),
                               loadOp.getMemRefType().getElementTypeBitWidth(),
                               getComponentState().getUniqueName("load"));
-    getComponentState().buildAssignmentsForRegisterWrite(
+    calyx::buildAssignmentsForRegisterWrite(
         rewriter, group, getComponentState().getComponentOp(), reg,
         memoryInterface.readData());
     loadOp.getResult().replaceAllUsesWith(reg.out());
@@ -687,7 +687,7 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
     // Create register assignment for each block argument
     for (auto arg : enumerate(succOperands.getForwardedOperands())) {
       auto reg = dstBlockArgRegs[arg.index()];
-      getComponentState().buildAssignmentsForRegisterWrite(
+      calyx::buildAssignmentsForRegisterWrite(
           rewriter, groupOp, getComponentState().getComponentOp(), reg,
           arg.value());
     }
@@ -710,7 +710,7 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
                                                     retOp.getLoc(), groupName);
   for (auto op : enumerate(retOp.getOperands())) {
     auto reg = getComponentState().getReturnReg(op.index());
-    getComponentState().buildAssignmentsForRegisterWrite(
+    calyx::buildAssignmentsForRegisterWrite(
         rewriter, groupOp, getComponentState().getComponentOp(), reg,
         op.value());
   }
@@ -1349,7 +1349,7 @@ class BuildPipelineGroups : public FuncOpPartialLoweringPattern {
     rewriter.eraseOp(combGroup);
 
     // Stitch evaluating group to register.
-    getComponentState().buildAssignmentsForRegisterWrite(
+    calyx::buildAssignmentsForRegisterWrite(
         rewriter, group, getComponentState().getComponentOp(), pipelineRegister,
         value);
 

--- a/lib/Conversion/StaticLogicToCalyx/StaticLogicToCalyx.cpp
+++ b/lib/Conversion/StaticLogicToCalyx/StaticLogicToCalyx.cpp
@@ -236,9 +236,9 @@ class FuncOpPartialLoweringPattern
     : public calyx::PartialLoweringPattern<FuncOp> {
 public:
   FuncOpPartialLoweringPattern(
-      MLIRContext *context, LogicalResult &resRef, FuncMapping &_funcMap,
+      MLIRContext *context, LogicalResult &resRef, FuncMapping &map,
       calyx::ProgramLoweringState<ComponentLoweringState> &pls)
-      : PartialLoweringPattern(context, resRef), funcMap(_funcMap), pls(pls) {}
+      : PartialLoweringPattern(context, resRef), funcMap(map), pls(pls) {}
 
   LogicalResult partiallyLower(FuncOp funcOp,
                                PatternRewriter &rewriter) const override final {

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -291,7 +291,7 @@ ModuleOpConversion::matchAndRewrite(mlir::ModuleOp moduleOp,
 
     // Inlining the body region also removes ^bb0 from the module body
     // region, so recreate that, before finally inserting the programOp
-    auto moduleBlock = rewriter.createBlock(&moduleOp.getBodyRegion());
+    auto* moduleBlock = rewriter.createBlock(&moduleOp.getBodyRegion());
     rewriter.setInsertionPointToStart(moduleBlock);
     rewriter.insert(programOp);
     *programOpOutput = programOp;

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -65,24 +65,24 @@ Value getComponentOutput(calyx::ComponentOp compOp, unsigned outPortIdx) {
   return compOp.getArgument(index);
 }
 
-Type convIndexType(PatternRewriter &rewriter, Type type) {
+Type convIndexType(OpBuilder &builder, Type type) {
   if (type.isIndex())
-    return rewriter.getI32Type();
+    return builder.getI32Type();
   return type;
 }
 
-void buildAssignmentsForRegisterWrite(PatternRewriter &rewriter,
+void buildAssignmentsForRegisterWrite(OpBuilder &builder,
                                       calyx::GroupOp groupOp,
                                       calyx::ComponentOp componentOp,
                                       calyx::RegisterOp &reg,
                                       Value inputValue) {
-  mlir::IRRewriter::InsertionGuard guard(rewriter);
+  mlir::IRRewriter::InsertionGuard guard(builder);
   auto loc = inputValue.getLoc();
-  rewriter.setInsertionPointToEnd(groupOp.getBody());
-  rewriter.create<calyx::AssignOp>(loc, reg.in(), inputValue);
-  rewriter.create<calyx::AssignOp>(
-      loc, reg.write_en(), createConstant(loc, rewriter, componentOp, 1, 1));
-  rewriter.create<calyx::GroupDoneOp>(loc, reg.done());
+  builder.setInsertionPointToEnd(groupOp.getBody());
+  builder.create<calyx::AssignOp>(loc, reg.in(), inputValue);
+  builder.create<calyx::AssignOp>(
+      loc, reg.write_en(), createConstant(loc, builder, componentOp, 1, 1));
+  builder.create<calyx::GroupDoneOp>(loc, reg.done());
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -129,30 +129,6 @@ ValueRange MemoryInterface::addrPorts() {
 }
 
 //===----------------------------------------------------------------------===//
-// ProgramLoweringStateInterface
-//===----------------------------------------------------------------------===//
-
-ProgramLoweringStateInterface::ProgramLoweringStateInterface(
-    calyx::ProgramOp program, StringRef topLevelFunction)
-    : topLevelFunction(topLevelFunction), program(program) {}
-
-std::string ProgramLoweringStateInterface::blockName(Block *b) {
-  std::string blockName = irName(*b);
-  blockName.erase(std::remove(blockName.begin(), blockName.end(), '^'),
-                  blockName.end());
-  return blockName;
-}
-
-calyx::ProgramOp ProgramLoweringStateInterface::getProgram() {
-  assert(program.getOperation() != nullptr);
-  return program;
-}
-
-StringRef ProgramLoweringStateInterface::getTopLevelFunction() const {
-  return topLevelFunction;
-}
-
-//===----------------------------------------------------------------------===//
 // LoopInterface
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -291,7 +291,7 @@ ModuleOpConversion::matchAndRewrite(mlir::ModuleOp moduleOp,
 
     // Inlining the body region also removes ^bb0 from the module body
     // region, so recreate that, before finally inserting the programOp
-    auto* moduleBlock = rewriter.createBlock(&moduleOp.getBodyRegion());
+    auto *moduleBlock = rewriter.createBlock(&moduleOp.getBodyRegion());
     rewriter.setInsertionPointToStart(moduleBlock);
     rewriter.insert(programOp);
     *programOpOutput = programOp;

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -71,6 +71,20 @@ Type convIndexType(PatternRewriter &rewriter, Type type) {
   return type;
 }
 
+void buildAssignmentsForRegisterWrite(PatternRewriter &rewriter,
+                                      calyx::GroupOp groupOp,
+                                      calyx::ComponentOp componentOp,
+                                      calyx::RegisterOp &reg,
+                                      Value inputValue) {
+  mlir::IRRewriter::InsertionGuard guard(rewriter);
+  auto loc = inputValue.getLoc();
+  rewriter.setInsertionPointToEnd(groupOp.getBody());
+  rewriter.create<calyx::AssignOp>(loc, reg.in(), inputValue);
+  rewriter.create<calyx::AssignOp>(
+      loc, reg.write_en(), createConstant(loc, rewriter, componentOp, 1, 1));
+  rewriter.create<calyx::GroupDoneOp>(loc, reg.done());
+}
+
 //===----------------------------------------------------------------------===//
 // MemoryInterface
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This provides ProgramLoweringStateInterface and ComponentLoweringStateInterface to pull the heavy lifting. 

The (1) cyclic dependency between the component and program states and (2) generalized loop interface being used in `Scheduleable` has made this quite a cumbersome task.


Also pulls out PartialLoweringPattern, ModuleOpConversion classes.