### PR TITLE
[FIRRTL] Optimization Barrier

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -331,6 +331,7 @@ def DivPrimOp : IntBinaryPrimOp<"div", IntType> {
     optimized FIRRTL dialects that are separately converted to Verilog.
   }];
 }
+
 def RemPrimOp : IntBinaryPrimOp<"rem", IntType>;
 let inferType = "impl::inferBitwiseResult" in {
   def AndPrimOp : IntBinaryPrimOp<"and", UIntType, [Commutative]>;
@@ -355,6 +356,7 @@ let inferType = "impl::inferComparisonResult" in {
 def CatPrimOp : IntBinaryPrimOp<"cat", UIntType> {
   let hasCanonicalizeMethod = true;
 }
+
 def DShlPrimOp  : BinaryPrimOp<"dshl", IntType, UIntType, IntType>  {
   let description = [{
     A dynamic shift left operation. The width of `$result` is expanded to
@@ -362,12 +364,14 @@ def DShlPrimOp  : BinaryPrimOp<"dshl", IntType, UIntType, IntType>  {
   }];
   let hasCanonicalizeMethod = true;
 }
+
 def DShlwPrimOp : BinaryPrimOp<"dshlw", IntType, UIntType, IntType> {
   let description = [{
     A dynamic shift left operation same as 'dshl' but with different width rule.
     The width of `$result` is equal to `$lhs`.
   }];
 }
+
 def DShrPrimOp  : BinaryPrimOp<"dshr", IntType, UIntType, IntType> {
   let hasCanonicalizeMethod = true;
 }
@@ -437,6 +441,15 @@ let inferType = "impl::inferReductionResult" in {
       such, it returns 0 for zero-bit-wide operands.
     }];
   }
+}
+
+def OptimizationBarrierOp : UnaryPrimOp<"optbar", FIRRTLType, FIRRTLType> {
+  let description = [{
+    This operation serves to block optimizations through it.  It may not have
+    annotations.  It has no name.  It produces no output, though may cause 
+    changes in the output to preserve the dataflow (e.g. introduce an anonymous
+    wire).
+  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -306,6 +306,10 @@ OpFoldResult InvalidValueOp::fold(ArrayRef<Attribute> operands) {
   return InvalidValueAttr::get(getType());
 }
 
+OpFoldResult OptimizationBarrierOp::fold(ArrayRef<Attribute> operands) {
+  return {};
+}
+
 //===----------------------------------------------------------------------===//
 // Binary Operators
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2823,6 +2823,11 @@ FIRRTLType NotPrimOp::inferUnaryReturnType(FIRRTLType input,
   return UIntType::get(input.getContext(), inputi.getWidthOrSentinel());
 }
 
+FIRRTLType OptimizationBarrierOp::inferUnaryReturnType(FIRRTLType input,
+                                                       Optional<Location> loc) {
+  return input;
+}
+
 FIRRTLType impl::inferReductionResult(FIRRTLType input,
                                       Optional<Location> loc) {
   return UIntType::get(input.getContext(), 1);
@@ -3819,6 +3824,9 @@ void NegPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   genericAsmResultNames(*this, setNameFn);
 }
 void NotPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  genericAsmResultNames(*this, setNameFn);
+}
+void OptimizationBarrierOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   genericAsmResultNames(*this, setNameFn);
 }
 void OrPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -109,6 +109,17 @@ firrtl.module @ClockCast(in %clock: !firrtl.clock) {
   %1 = builtin.unrealized_conversion_cast %0 : i1 to !firrtl.clock
 }
 
+// optimization barriers
+// CHECK-LABEL: @OptBarrier
+firrtl.module @OptBarrier(in %a: !firrtl.uint<6>, out %b: !firrtl.uint<7>) {
+  // CHECK: %c0_ui6 = firrtl.constant 0
+  // CHECK-NEXT: %0 = firrtl.optbar %c0_ui6
+  // CHECK-NEXT: %1 = firrtl.add %a, %0 
+  %c0 = firrtl.constant 0 : !firrtl.uint<6>
+  %c = firrtl.optbar %c0 : (!firrtl.uint<6>) -> !firrtl.uint<6>
+  %1 = firrtl.add %a, %c : (!firrtl.uint<6>, !firrtl.uint<6>) -> !firrtl.uint<7>
+  firrtl.connect %b, %1 : !firrtl.uint<7>, !firrtl.uint<7>
+}
 
 // CHECK-LABEL: @TestDshRL
 firrtl.module @TestDshRL(in %in1 : !firrtl.uint<2>, in %in2: !firrtl.uint<3>) {


### PR DESCRIPTION
This operation breaks transformations to data-flow.  For example, it causes "Overdefined" state in IMCP.

Some work remains to prevent wire and node bypass optimization.