### PR TITLE
[SV] Improve register canonicalization

### DIFF
--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 include "mlir/IR/EnumAttr.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
 
 /// Ensure symbol is one of the hw module.* types
 def isModuleSymbol : AttrConstraint<
@@ -388,7 +389,7 @@ def CaseOp : SVOp<"case", [SingleBlock, NoTerminator, NoRegionArguments,
 //===----------------------------------------------------------------------===//
 
 def AssignOp : SVOp<"assign", [InOutTypeConstraint<"src", "dest">,
-                                 NonProceduralOp]> {
+                                 NonProceduralOp, MemoryEffects<[MemWrite]>]> {
   let summary = "Continuous assignment";
   let description = [{
     A SystemVerilog assignment statement 'x = y;'.
@@ -400,7 +401,7 @@ def AssignOp : SVOp<"assign", [InOutTypeConstraint<"src", "dest">,
 }
 
 def BPAssignOp : SVOp<"bpassign", [InOutTypeConstraint<"src", "dest">,
-                                   ProceduralOp]> {
+                                   ProceduralOp, MemoryEffects<[MemWrite]>]> {
   let summary = "Blocking procedural assignment";
   let description = [{
     A SystemVerilog blocking procedural assignment statement 'x = y;'.  These
@@ -414,7 +415,7 @@ def BPAssignOp : SVOp<"bpassign", [InOutTypeConstraint<"src", "dest">,
 }
 
 def PAssignOp : SVOp<"passign", [InOutTypeConstraint<"src", "dest">,
-                                 ProceduralOp]> {
+                                 ProceduralOp, MemoryEffects<[MemWrite]>]> {
   let summary = "Nonblocking procedural assignment";
   let description = [{
     A SystemVerilog nonblocking procedural assignment statement 'x <= y;'.
@@ -435,7 +436,7 @@ def PAssignOp : SVOp<"passign", [InOutTypeConstraint<"src", "dest">,
 //===----------------------------------------------------------------------===//
 
 def ForceOp : SVOp<"force", [InOutTypeConstraint<"src", "dest">,
-                                   ProceduralOp]> {
+                                   ProceduralOp, MemoryEffects<[MemWrite]>]> {
   let summary = "Force procedural statement";
   let description = [{
     A SystemVerilog force procedural statement 'force x = y;'.  These
@@ -452,7 +453,7 @@ def ForceOp : SVOp<"force", [InOutTypeConstraint<"src", "dest">,
   let assemblyFormat = "$dest `,` $src  attr-dict `:` qualified(type($src))";
 }
 
-def ReleaseOp : SVOp<"release", [ProceduralOp]> {
+def ReleaseOp : SVOp<"release", [ProceduralOp, MemoryEffects<[MemWrite]>]> {
   let summary = "Release procedural statement";
   let description = [{
     Release is used in conjunction with force. When released,
@@ -699,7 +700,8 @@ def InfoOp : NonfatalMessageOp<"info"> {
 }
 
 def DepositOp : SVOp<"nonstandard.deposit", 
-    [ProceduralOp, VendorExtension, InOutTypeConstraint<"src", "dest">]> {
+    [ProceduralOp, VendorExtension, InOutTypeConstraint<"src", "dest">,
+     MemoryEffects<[MemWrite]>]> {
   let summary = "`$deposit` system task";
   let description = [{
     This system task sets the value of a net or variable, but doesn't hold it.

--- a/lib/Dialect/SV/CMakeLists.txt
+++ b/lib/Dialect/SV/CMakeLists.txt
@@ -15,6 +15,7 @@ add_circt_dialect_library(CIRCTSV
 
   LINK_LIBS PUBLIC
   MLIRIR
+  MLIRSideEffectInterfaces
   CIRCTHW
   CIRCTComb
    )

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -255,7 +255,7 @@ LogicalResult RegOp::canonicalize(RegOp op, PatternRewriter &rewriter) {
   // Check that all operations on the wire are sv.assigns. All other wire
   // operations will have been handled by other canonicalization.
   for (auto &use : op.getResult().getUses())
-    if (!isa<AssignOp>(use.getOwner()))
+    if (!isa<PAssignOp, BPAssignOp>(use.getOwner()))
       return failure();
 
   // Remove all uses of the wire.

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -256,8 +256,7 @@ static bool isWriteOnly(Operation *op) {
     auto memEffectOpInterface =
         dyn_cast<mlir::MemoryEffectOpInterface>(use.getOwner());
     if (!memEffectOpInterface ||
-        !memEffectOpInterface
-             .template onlyHasEffect<mlir::MemoryEffects::Write>())
+        !memEffectOpInterface.onlyHasEffect<mlir::MemoryEffects::Write>())
       return false;
   }
   return true;

--- a/test/Dialect/SV/canonicalization.mlir
+++ b/test/Dialect/SV/canonicalization.mlir
@@ -287,15 +287,22 @@ hw.module @case_stmt(%arg: i3) {
 
   }
 
-// Remove read-only registers.
-// CHECK-LABEL: hw.module @remove_reg
-// CHECK-NEXT:  %r2 = sv.reg sym @r3 : !hw.inout<i2>
-// CHECK-NEXT:  hw.output
-hw.module @remove_reg(%input: i2){
+// Remove write-only registers.
+// CHECK-LABEL:  hw.module @remove_write_only(%input: i2) -> (a: i2) {
+// CHECK-NEXT:     %r2 = sv.reg  : !hw.inout<i2>
+// CHECK-NEXT:     %r3 = sv.reg sym @r3  : !hw.inout<i2>
+// CHECK-NEXT:     %0 = sv.read_inout %r2 : !hw.inout<i2>
+// CHECK-NEXT:     hw.output %0 : i2
+// CHECK-NEXT:   }
+hw.module @remove_write_only(%input: i2) -> (a: i2) {
   %r1 = sv.reg  : !hw.inout<i2>
-  %r2 = sv.reg sym @r3 : !hw.inout<i2>
+  %r2 = sv.reg : !hw.inout<i2>
+  %r3 = sv.reg sym @r3 : !hw.inout<i2>
   sv.initial {
     sv.passign %r1, %input : i2
     sv.bpassign %r1, %input : i2
   }
+  sv.assign %r1, %input : i2
+  %res = sv.read_inout %r2: !hw.inout<i2>
+  hw.output %res : i2
 }

--- a/test/firtool/optimizations.mlir
+++ b/test/firtool/optimizations.mlir
@@ -1,7 +1,7 @@
 // RUN: firtool %s -verilog | FileCheck %s
 // Issue 2393: Check that if statements created by canonicalizer are merged.
 // CHECK-LABEL: module Issue2393(
-hw.module @Issue2393(%clock: i1, %c: i1, %data: i2) {
+hw.module @Issue2393(%clock: i1, %c: i1, %data: i2) -> (a: i2, b: i2) {
   %r1 = sv.reg : !hw.inout<i2>
   %1 = sv.read_inout %r1 : !hw.inout<i2>
   %r2 = sv.reg : !hw.inout<i2>
@@ -18,4 +18,5 @@ hw.module @Issue2393(%clock: i1, %c: i1, %data: i2) {
   // CHECK-NEXT:     r2 <= data;
   // CHECK-NEXT:   end
   // CHECK-NEXT: end
+  hw.output %1, %2 : i2, i2
 }


### PR DESCRIPTION
This PR adds a register canonicalization to remove write-only registers tha checks only `sv.assign` for  `sv.reg`. 
It would be necessary to check `sv.passign` and `sv.bpassign` as well for registers.