### PR TITLE
[FIRRTL] Make all NLAs end in a Module

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -127,25 +127,29 @@ def GetWidthAsIntAttr : NativeCodeCall<
 def DropNameNode : Pat<
   (NodeOp $x, $name, $annotations, $inner_sym),
   (NodeOp $x, (GetEmptyString), $annotations, $inner_sym),
-  [(uselessNameAttr $name), (NonEmptyStringAttr $name), (NullAttr $inner_sym)]>;
+  [(uselessNameAttr $name), (NonEmptyStringAttr $name), (NullAttr $inner_sym),
+   (EmptyAttrDict $annotations)]>;
 
 // wire(name),!dnt -> wire("")
 def DropNameWire : Pat<
   (WireOp $name, $annotations, $inner_sym),
   (WireOp (GetEmptyString), $annotations, $inner_sym),
-  [(uselessNameAttr $name), (NonEmptyStringAttr $name), (NullAttr $inner_sym)]>;
+  [(uselessNameAttr $name), (NonEmptyStringAttr $name), (NullAttr $inner_sym),
+   (EmptyAttrDict $annotations)]>;
 
 // reg(clk, name),!dnt -> reg(clk, "")
 def DropNameReg : Pat<
   (RegOp $clk, $name, $annotations, $inner_sym),
   (RegOp $clk, (GetEmptyString), $annotations, $inner_sym),
-  [(uselessNameAttr $name), (NonEmptyStringAttr $name), (NullAttr $inner_sym)]>;
+  [(uselessNameAttr $name), (NonEmptyStringAttr $name), (NullAttr $inner_sym),
+   (EmptyAttrDict $annotations)]>;
 
 // regreset(clk, sig, val, name),!dnt -> regreset(clk, sig, val, "")
 def DropNameRegReset : Pat<
   (RegResetOp $clk, $sig, $val, $name, $annotations, $inner_sym),
   (RegResetOp $clk, $sig, $val, (GetEmptyString), $annotations, $inner_sym),
-  [(uselessNameAttr $name), (NonEmptyStringAttr $name), (NullAttr $inner_sym)]>;
+  [(uselessNameAttr $name), (NonEmptyStringAttr $name), (NullAttr $inner_sym),
+   (EmptyAttrDict $annotations)]>;
 
 // Mem(...,name),!dnt -> Mem(...x, "")
 def DropNameMem : Pat<

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -102,6 +102,9 @@ bool hasDontTouch(Value value);
 /// should prevent certain types of canonicalizations.
 bool hasDontTouch(Operation *op);
 
+/// Check whether an operation should not be removed.
+bool dontRemove(Operation *op);
+
 // Out-of-line implementation of various trait verification methods and
 // functions commonly used among operations.
 namespace impl {

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1405,7 +1405,8 @@ static LogicalResult canonicalizeSingleSetConnect(StrictConnectOp op,
   // Only support wire and reg for now.
   if (!isa<WireOp>(connectedDecl) && !isa<RegOp>(connectedDecl))
     return failure();
-  if (hasDontTouch(connectedDecl))
+  // Bail if the wire cannot be removed.
+  if (dontRemove(connectedDecl))
     return failure();
 
   // Only forward if the types exactly match and there is one connect.

--- a/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
@@ -137,15 +137,17 @@ buildNLA(CircuitOp circuit, size_t nlaSuffix,
   OpBuilder b(circuit.getBodyRegion());
   MLIRContext *ctxt = circuit.getContext();
   SmallVector<Attribute> insts;
-  for (auto &nla : nlas) {
+  for (size_t i = 0, e = nlas.size(); i < e; ++i) {
+    auto &nla = nlas[i];
     // Assumption: Symbol name = Operation name.
     auto module = std::get<1>(nla);
-    auto inst = std::get<2>(nla);
-    if (inst.empty())
+    if (i == e - 1)
       insts.push_back(FlatSymbolRefAttr::get(ctxt, module));
-    else
+    else {
+      auto inst = std::get<2>(nla);
       insts.push_back(hw::InnerRefAttr::get(StringAttr::get(ctxt, module),
                                             StringAttr::get(ctxt, inst)));
+    }
   }
   auto instAttr = ArrayAttr::get(ctxt, insts);
   auto nla = b.create<HierPathOp>(circuit.getLoc(),

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1516,8 +1516,6 @@ static bool needsSymbol(ArrayAttr &annotations) {
       // Ignore the annotation.
       continue;
     }
-    if (anno.getMember("circt.nonlocal"))
-      needsSymbol = true;
     filteredAnnos.push_back(attr);
   }
   if (needsSymbol)

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -675,7 +675,7 @@ private:
                                             AnnoTarget to,
                                             FModuleLike fromModule) {
     return createNLAs(toModuleName, to, fromModule,
-                      to.getNLAReference(getNamespace(toModule)));
+                      FlatSymbolRefAttr::get(to.getModule().moduleNameAttr()));
   }
 
   /// Clone the annotation for each NLA in a list.

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentralTaps.cpp
@@ -841,11 +841,19 @@ void GrandCentralTapsPass::runOnOperation() {
             addSymbol(getInnerRefTo(p));
           }
         }
-        for (auto inst : shortestPrefix.getValue())
+        for (auto inst : shortestPrefix.getValue()) {
           addSymbol(getInnerRefTo(inst));
+        }
+
         if (port.nla) {
-          for (auto sym : port.nla.namepath())
+          for (auto sym : port.nla.namepath().getValue().drop_back()) {
             addSymbol(sym);
+          }
+          if (port.target.hasPort())
+            addSymbol(
+                getInnerRefTo(port.target.getOp(), port.target.getPort()));
+          else
+            addSymbol(getInnerRefTo(port.target.getOp()));
         } else if (port.target.getOp()) {
           if (port.target.hasPort())
             addSymbol(

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -34,7 +34,7 @@ static bool isDeletableWireOrReg(Operation *op) {
   if (auto wire = dyn_cast<WireOp>(op))
     if (!isUselessName(wire.name()))
       return false;
-  return isWireOrReg(op) && !hasDontTouch(op);
+  return isWireOrReg(op) && !dontRemove(op);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -103,14 +103,13 @@ static void addAnnotation(AnnoTarget ref, unsigned fieldIdx,
 static FlatSymbolRefAttr buildNLA(AnnoPathValue target, ApplyState &state) {
   OpBuilder b(state.circuit.getBodyRegion());
   SmallVector<Attribute> insts;
-  for (auto inst : target.instances)
+  for (auto inst : target.instances) {
     insts.push_back(OpAnnoTarget(inst).getNLAReference(
         state.getNamespace(inst->getParentOfType<FModuleLike>())));
+  }
 
-  auto module = dyn_cast<FModuleLike>(target.ref.getOp());
-  if (!module)
-    module = target.ref.getOp()->getParentOfType<FModuleLike>();
-  insts.push_back(target.ref.getNLAReference(state.getNamespace(module)));
+  insts.push_back(
+      FlatSymbolRefAttr::get(target.ref.getModule().moduleNameAttr()));
   auto instAttr = ArrayAttr::get(state.circuit.getContext(), insts);
   auto nla = b.create<HierPathOp>(state.circuit.getLoc(), "nla", instAttr);
   state.symTbl.insert(nla);

--- a/test/Dialect/FIRRTL/SFCTests/dedup.fir
+++ b/test/Dialect/FIRRTL/SFCTests/dedup.fir
@@ -319,7 +319,7 @@ circuit Top : %[[
     "target":"Top.A.b"
   }
 ]]
-  ; CHECK: firrtl.hierpath @[[nlaSym:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]]]
+  ; CHECK: firrtl.hierpath @[[nlaSym:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A]
   ; CHECK: firrtl.module @Top
   ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] @A(
   ; CHECK-NEXT: firrtl.instance a2 @A(
@@ -328,7 +328,7 @@ circuit Top : %[[
     inst a2 of A_
   module A :
     output x: UInt<1>
-    ; CHECk-NEXT: firrtl.wire sym @[[bSym]] {annotations = [{circt.nonlocal = @[[nlaSym]], class = "hello"}]}
+    ; CHECk-NEXT: firrtl.wire {annotations = [{circt.nonlocal = @[[nlaSym]], class = "hello"}]}
     wire b: UInt<1>
     b is invalid
     x <= b
@@ -354,8 +354,8 @@ circuit Top : %[[
     "target":"~Top|A_>b"
   }
 ]]
-  ; CHECK: firrtl.hierpath @[[nlaSym1:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]]]
-  ; CHECK: firrtl.hierpath @[[nlaSym2:[_a-zA-Z0-9]+]] [@Top::@[[a2Sym:[_a-zA-Z0-9]+]], @A::@[[bSym]]]
+  ; CHECK: firrtl.hierpath @[[nlaSym1:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A]
+  ; CHECK: firrtl.hierpath @[[nlaSym2:[_a-zA-Z0-9]+]] [@Top::@[[a2Sym:[_a-zA-Z0-9]+]], @A]
   ; CHECK: firrtl.module @Top
   ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] @A(
   ; CHECK-NEXT: firrtl.instance a2 sym @[[a2Sym]] @A(
@@ -364,7 +364,7 @@ circuit Top : %[[
     inst a2 of A_
   module A :
     output x: UInt<1>
-    ; CHECk-NEXT: firrtl.wire sym @[[bSym]] {annotations = [{circt.nonlocal = @[[nlaSym1]], class = "world"}, {circt.nonlocal = @[[nlaSym2]], class = "hello"}]}
+    ; CHECk-NEXT: firrtl.wire {annotations = [{circt.nonlocal = @[[nlaSym1]], class = "world"}, {circt.nonlocal = @[[nlaSym2]], class = "hello"}]}
     wire b: UInt<1>
     b is invalid
     x <= b
@@ -450,9 +450,9 @@ circuit Top : %[[
     "target":"~Top|Top/a_:A_/b_:B_>bar"
   }
 ]]
-  ; CHECK: firrtl.hierpath @[[nla_4:[_a-zA-Z0-9]+]] [@Top::@[[a_Sym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]], @B::@[[fooSym:[_a-zA-Z0-9]+]]]
+  ; CHECK: firrtl.hierpath @[[nla_4:[_a-zA-Z0-9]+]] [@Top::@[[a_Sym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]], @B]
   ; CHECK: firrtl.hierpath @[[nla_3:[_a-zA-Z0-9]+]] [@Top::@[[a_Sym]], @A::@[[bSym]], @B]
-  ; CHECK: firrtl.hierpath @[[nla_2:[_a-zA-Z0-9]+]] [@Top::@[[aSym:[_a-zA-Z0-9]+]], @A::@[[bSym]], @B::@[[fooSym]]]
+  ; CHECK: firrtl.hierpath @[[nla_2:[_a-zA-Z0-9]+]] [@Top::@[[aSym:[_a-zA-Z0-9]+]], @A::@[[bSym]], @B]
   ; CHECK: firrtl.hierpath @[[nla_1:[_a-zA-Z0-9]+]] [@Top::@[[aSym]], @A::@[[bSym]], @B]
   ; CHECK: firrtl.module @Top
   module Top :
@@ -472,7 +472,8 @@ circuit Top : %[[
   ; CHECK-SAME: {circt.nonlocal = @[[nla_3]], class = "B_"}
   ; CHECK-SAME: {circt.nonlocal = @[[nla_1]], class = "B"}
   module B :
-    ; CHECK: firrtl.node sym @[[fooSym]]
+    ; CHECK: firrtl.node
+    ; CHECK-NOT: sym
     ; CHECK-SAME: {circt.nonlocal = @[[nla_4]], class = "B_.bar"}
     ; CHECK-SAME: {circt.nonlocal = @[[nla_2]], class = "B.foo"}
     node foo = UInt<1>(0)
@@ -512,7 +513,7 @@ circuit Top : %[[
   ; CHECK-SAME:      @A::@[[bSym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @B::@[[cSym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @C::@[[dSym:[_a-zA-Z0-9]+]],
-  ; CHECK-SAME:      @D::@[[fooSym:[_a-zA-Z0-9]+]]]
+  ; CHECK-SAME:      @D]
   ; CHECK-NEXT:   firrtl.hierpath @[[nla_3:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:     [@Top::@[[a_Sym]],
   ; CHECK-SAME:      @A::@[[bSym]],
@@ -524,7 +525,7 @@ circuit Top : %[[
   ; CHECK-SAME:      @A::@[[bSym]],
   ; CHECK-SAME:      @B::@[[cSym]],
   ; CHECK-SAME:      @C::@[[dSym]],
-  ; CHECK-SAME:      @D::@[[fooSym]]]
+  ; CHECK-SAME:      @D]
   ; CHECK-NEXT:   firrtl.hierpath @[[nla_1:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:     [@Top::@[[aSym]],
   ; CHECK-SAME:      @A::@[[bSym]],
@@ -561,6 +562,7 @@ circuit Top : %[[
   ; CHECK:        firrtl.module private @D
   module D :
     ; CHECK:        firrtl.node
+    ; CHECK-NOT:      sym
     node foo = UInt<1>(0)
 
   ; CHECK-NOT: firrtl.module private @A_
@@ -753,10 +755,10 @@ circuit top : %[[
 ]]
   ; CHECK:      firrtl.hierpath @[[nla_1:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:   [@top::@[[topaSym:[_a-zA-Z0-9]+]],
-  ; CHECK-SAME:    @a::@[[aiSym:[_a-zA-Z0-9]+]]
+  ; CHECK-SAME:    @a]
   ; CHECK:      firrtl.hierpath @[[nla_2:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:   [@top::@[[topbSym:[_a-zA-Z0-9]+]],
-  ; CHECK-SAME:    @a::@[[aiSym]]
+  ; CHECK-SAME:    @a]
   ; CHECK: firrtl.module @top
   module top:
     input ia: {z: {y: {x: UInt<1>}}, a: UInt<1>}
@@ -777,7 +779,7 @@ circuit top : %[[
     ob.z <= b.r.z
 
   ; CHECK:      firrtl.module private @a(
-  ; CHECK-SAME:   in %i: {{.+}} sym @[[aiSym]]
+  ; CHECK-SAME:   in %i:
   ; CHECK-NOT:    out
   ; CHECK-SAME:     [#firrtl.subAnno<fieldID = 1, {circt.nonlocal = @[[nla_2]], class = "nla2"}>,
   ; CHECK-SAME:      #firrtl.subAnno<fieldID = 4, {circt.nonlocal = @[[nla_1]], class = "nla1"}>]

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -106,11 +106,14 @@ circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar.a"},
     inst bar of Bar
 
     ; CHECK-LABEL: firrtl.circuit "Foo"
-    ; CHECK: firrtl.hierpath @nla_2 [@Foo::@bar, @Bar::@d]
-    ; CHECK: firrtl.hierpath @nla_1 [@Foo::@bar, @Bar::@b]
+    ; CHECK: firrtl.hierpath @nla_2 [@Foo::@bar, @Bar]
+    ; CHECK: firrtl.hierpath @nla_1 [@Foo::@bar, @Bar]
     ; CHECK: firrtl.module private @Bar
-    ; CHECK-SAME: sym @b [#firrtl.subAnno<fieldID = 2, {circt.nonlocal = @nla_1, three}>]
-    ; CHECK-NEXT:  %d = firrtl.wire sym @d
+    ; CHECK:      out %b
+    ; CHECK-NOT:  sym
+    ; CHECK-SAME: [#firrtl.subAnno<fieldID = 2, {circt.nonlocal = @nla_1, three}>]
+    ; CHECK-NEXT: %d = firrtl.wire
+    ; CHECK-NOT:  sym
     ; CHECK-SAME: {annotations = [#firrtl.subAnno<fieldID = 2, {circt.nonlocal = @nla_2, five}>]}
     ; CHECK-SAME: : !firrtl.bundle<baz: uint<1>, qux: uint<1>>
     ; CHECK: %bar_a, %bar_b, %bar_c = firrtl.instance bar
@@ -582,8 +585,8 @@ circuit memportAnno: %[[
       write-latency => 1
       read-under-write => undefined
 ; CHECK-LABEL: firrtl.circuit "memportAnno"  {
-; CHECK:        firrtl.hierpath @nla_1 [@memportAnno::@foo, @Foo::@memory]
-; CHECK:        %memory_w = firrtl.mem sym @memory Undefined  {depth = 16 : i64, name = "memory", portAnnotations
+; CHECK:        firrtl.hierpath @nla_1 [@memportAnno::@foo, @Foo]
+; CHECK:        %memory_w = firrtl.mem Undefined  {depth = 16 : i64, name = "memory", portAnnotations
 ; CHECK-SAME:   [{circt.nonlocal = @nla_1, class = "test"}]
 
 ; // -----

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -21,8 +21,8 @@ firrtl.circuit "Aggregates" attributes {rawAnnotations = [
 
 // CHECK-LABEL: firrtl.circuit "FooNL"
 // CHECK: firrtl.hierpath @nla_1 [@FooNL::@baz, @BazNL::@bar, @BarNL]
-// CHECK: firrtl.hierpath @nla_0 [@FooNL::@baz, @BazNL::@bar, @BarNL::@w]
-// CHECK: firrtl.hierpath @nla [@FooNL::@baz, @BazNL::@bar, @BarNL::@w2]
+// CHECK: firrtl.hierpath @nla_0 [@FooNL::@baz, @BazNL::@bar, @BarNL]
+// CHECK: firrtl.hierpath @nla [@FooNL::@baz, @BazNL::@bar, @BarNL]
 // CHECK: firrtl.module @BarNL
 // CHECK: %w = firrtl.wire sym @w {annotations = [{circt.nonlocal = @nla_0, class = "circt.test", nl = "nl"}]}
 // CHECK: %w2 = firrtl.wire sym @w2 {annotations = [{circt.fieldID = 5 : i32, circt.nonlocal = @nla, class = "circt.test", nl = "nl2"}]} : !firrtl.bundle<a: uint, b: vector<uint, 4>>
@@ -57,9 +57,10 @@ firrtl.circuit "FooNL"  attributes {rawAnnotations = [
 // Non-local annotations on memory ports should work.
 
 // CHECK-LABEL: firrtl.circuit "MemPortsNL"
-// CHECK: firrtl.hierpath @nla [@MemPortsNL::@child, @Child::@bar]
+// CHECK: firrtl.hierpath @nla [@MemPortsNL::@child, @Child]
 // CHECK: firrtl.module @Child()
-// CHECK:   %bar_r = firrtl.mem sym @bar
+// CHECK:   %bar_r = firrtl.mem
+// CHECK-NOT: sym
 // CHECK-SAME: portAnnotations = {{\[}}[{circt.nonlocal = @nla, class = "circt.test", nl = "nl"}]]
 // CHECK: firrtl.module @MemPortsNL()
 // CHECK:   firrtl.instance child sym @child
@@ -120,8 +121,8 @@ firrtl.circuit "Test" attributes {rawAnnotations = [
 firrtl.circuit "Test" attributes {rawAnnotations = [
   {class = "circt.test", target = "~Test|Test>exttest.in"}
   ]} {
-  // CHECK: firrtl.hierpath @nla [@Test::@exttest, @ExtTest::@in]
-  // CHECK: firrtl.extmodule @ExtTest(in in: !firrtl.uint<1> sym @in [{circt.nonlocal = @nla, class = "circt.test"}])
+  // CHECK: firrtl.hierpath @nla [@Test::@exttest, @ExtTest]
+  // CHECK: firrtl.extmodule @ExtTest(in in: !firrtl.uint<1> [{circt.nonlocal = @nla, class = "circt.test"}])
   firrtl.extmodule @ExtTest(in in: !firrtl.uint<1>)
 
   firrtl.module @Test() {
@@ -371,7 +372,7 @@ firrtl.circuit "GCTDataTap" attributes {rawAnnotations = [{
 }
 
 // CHECK-LABEL: firrtl.circuit "GCTDataTap"
-// CHECK:      firrtl.hierpath [[NLA:@.+]] [@GCTDataTap::@im, @InnerMod::@w]
+// CHECK:      firrtl.hierpath [[NLA:@.+]] [@GCTDataTap::@im, @InnerMod]
 
 // CHECK-LABEL: firrtl.extmodule private @DataTap
 

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -46,7 +46,7 @@ firrtl.circuit "Top"  {
     %a2_x = firrtl.instance a2  @A_(out x: !firrtl.uint<1>)
   }
   firrtl.module @A(out %x: !firrtl.uint<1>) {
-    // CHECK: %0 = firrtl.wire sym @inner_sym
+    // CHECK: %0 = firrtl.wire {
     %0 = firrtl.wire  {annotations = [{class = "hello"}]} : !firrtl.uint<1>
   }
   firrtl.module @A_(out %x: !firrtl.uint<1>) {
@@ -83,13 +83,13 @@ firrtl.circuit "PrimOps" {
 // CHECK-LABEL: firrtl.circuit "Annotations"
 firrtl.circuit "Annotations" {
   // CHECK: firrtl.hierpath [[NLA3:@nla.*]] [@Annotations::@annotations1, @Annotations0]
-  // CHECK: firrtl.hierpath [[NLA2:@nla.*]] [@Annotations::@annotations0, @Annotations0::@e]
-  // CHECK: firrtl.hierpath [[NLA1:@nla.*]] [@Annotations::@annotations0, @Annotations0::@c]
-  // CHECK: firrtl.hierpath [[NLA0:@nla.*]] [@Annotations::@annotations1, @Annotations0::@b]
-  // CHECK: firrtl.hierpath @annos_nla0 [@Annotations::@annotations0, @Annotations0::@d]
-  // CHECK: firrtl.hierpath @annos_nla1 [@Annotations::@annotations1, @Annotations0::@d]
-  firrtl.hierpath @annos_nla0 [@Annotations::@annotations0, @Annotations0::@d]
-  firrtl.hierpath @annos_nla1 [@Annotations::@annotations1, @Annotations1::@i]
+  // CHECK: firrtl.hierpath [[NLA2:@nla.*]] [@Annotations::@annotations0, @Annotations0]
+  // CHECK: firrtl.hierpath [[NLA1:@nla.*]] [@Annotations::@annotations0, @Annotations0]
+  // CHECK: firrtl.hierpath [[NLA0:@nla.*]] [@Annotations::@annotations1, @Annotations0]
+  // CHECK: firrtl.hierpath @annos_nla0 [@Annotations::@annotations0, @Annotations0]
+  // CHECK: firrtl.hierpath @annos_nla1 [@Annotations::@annotations1, @Annotations0]
+  firrtl.hierpath @annos_nla0 [@Annotations::@annotations0, @Annotations0]
+  firrtl.hierpath @annos_nla1 [@Annotations::@annotations1, @Annotations1]
 
   // CHECK: firrtl.module @Annotations0() attributes {annotations = [{circt.nonlocal = [[NLA3]], class = "one"}]}
   firrtl.module @Annotations0() {
@@ -98,11 +98,11 @@ firrtl.circuit "Annotations" {
     %a = firrtl.wire {annotations = [{class = "both"}]} : !firrtl.uint<1>
 
     // Annotation from other module becomes non-local.
-    // CHECK: %b = firrtl.wire sym @b  {annotations = [{circt.nonlocal = [[NLA0]], class = "one"}]}
+    // CHECK: %b = firrtl.wire {annotations = [{circt.nonlocal = [[NLA0]], class = "one"}]}
     %b = firrtl.wire : !firrtl.uint<1>
 
     // Annotation from this module becomes non-local.
-    // CHECK: %c = firrtl.wire sym @c  {annotations = [{circt.nonlocal = [[NLA1]], class = "one"}]}
+    // CHECK: %c = firrtl.wire {annotations = [{circt.nonlocal = [[NLA1]], class = "one"}]}
     %c = firrtl.wire {annotations = [{class = "one"}]} : !firrtl.uint<1>
 
     // Two non-local annotations are unchanged, as they have enough context in the NLA already.
@@ -110,7 +110,7 @@ firrtl.circuit "Annotations" {
     %d = firrtl.wire sym @d {annotations = [{circt.nonlocal = @annos_nla0, class = "NonLocal"}]} : !firrtl.uint<1>
 
     // Subannotations should be handled correctly.
-    // CHECK: %e = firrtl.wire sym @e  {annotations = [#firrtl.subAnno<fieldID = 1, {circt.nonlocal = [[NLA2]], class = "subanno"}>]}
+    // CHECK: %e = firrtl.wire {annotations = [#firrtl.subAnno<fieldID = 1, {circt.nonlocal = [[NLA2]], class = "subanno"}>]}
     %e = firrtl.wire {annotations = [#firrtl.subAnno<fieldID = 1, {class = "subanno"}>]} : !firrtl.bundle<a: uint<1>>
   }
   // CHECK-NOT: firrtl.module @Annotations1
@@ -132,15 +132,15 @@ firrtl.circuit "Annotations" {
 // Check that module and memory port annotations are merged correctly.
 // CHECK-LABEL: firrtl.circuit "PortAnnotations"
 firrtl.circuit "PortAnnotations" {
-  // CHECK: firrtl.hierpath [[NLA3:@nla.*]] [@PortAnnotations::@portannos0, @PortAnnotations0::@a]
-  // CHECK: firrtl.hierpath [[NLA2:@nla.*]] [@PortAnnotations::@portannos1, @PortAnnotations0::@a]
-  // CHECK: firrtl.hierpath [[NLA1:@nla.*]] [@PortAnnotations::@portannos0, @PortAnnotations0::@bar]
-  // CHECK: firrtl.hierpath [[NLA0:@nla.*]] [@PortAnnotations::@portannos1, @PortAnnotations0::@bar]
-  // CHECK: firrtl.module @PortAnnotations0(in %a: !firrtl.uint<1> sym @a [
+  // CHECK: firrtl.hierpath [[NLA3:@nla.*]] [@PortAnnotations::@portannos0, @PortAnnotations0]
+  // CHECK: firrtl.hierpath [[NLA2:@nla.*]] [@PortAnnotations::@portannos1, @PortAnnotations0]
+  // CHECK: firrtl.hierpath [[NLA1:@nla.*]] [@PortAnnotations::@portannos0, @PortAnnotations0]
+  // CHECK: firrtl.hierpath [[NLA0:@nla.*]] [@PortAnnotations::@portannos1, @PortAnnotations0]
+  // CHECK: firrtl.module @PortAnnotations0(in %a: !firrtl.uint<1> [
   // CHECK-SAME: {circt.nonlocal = [[NLA2]], class = "port1"},
   // CHECK-SAME: {circt.nonlocal = [[NLA3]], class = "port0"}]) {
   firrtl.module @PortAnnotations0(in %a : !firrtl.uint<1> [{class = "port0"}]) {
-    // CHECK: %bar_r = firrtl.mem sym @bar
+    // CHECK: %bar_r = firrtl.mem
     // CHECK-SAME: portAnnotations =
     // CHECK-SAME:  {circt.nonlocal = [[NLA0]], class = "mem1"},
     // CHECK-SAME:  {circt.nonlocal = [[NLA1]], class = "mem0"}
@@ -163,14 +163,14 @@ firrtl.circuit "PortAnnotations" {
 // ones.
 // CHECK-LABEL: firrtl.circuit "Breadcrumb"
 firrtl.circuit "Breadcrumb" {
-  // CHECK:  @breadcrumb_nla0 [@Breadcrumb::@breadcrumb0, @Breadcrumb0::@crumb0, @Crumb::@in]
-  firrtl.hierpath @breadcrumb_nla0 [@Breadcrumb::@breadcrumb0, @Breadcrumb0::@crumb0, @Crumb::@in]
-  // CHECK:  @breadcrumb_nla1 [@Breadcrumb::@breadcrumb1, @Breadcrumb0::@crumb0, @Crumb::@in]
-  firrtl.hierpath @breadcrumb_nla1 [@Breadcrumb::@breadcrumb1, @Breadcrumb1::@crumb1, @Crumb::@in]
-  // CHECK:  @breadcrumb_nla2 [@Breadcrumb::@breadcrumb0, @Breadcrumb0::@crumb0, @Crumb::@w]
-  firrtl.hierpath @breadcrumb_nla2 [@Breadcrumb::@breadcrumb0, @Breadcrumb0::@crumb0, @Crumb::@w]
-  // CHECK:  @breadcrumb_nla3 [@Breadcrumb::@breadcrumb1, @Breadcrumb0::@crumb0, @Crumb::@w]
-  firrtl.hierpath @breadcrumb_nla3 [@Breadcrumb::@breadcrumb1, @Breadcrumb1::@crumb1, @Crumb::@w]
+  // CHECK:  @breadcrumb_nla0 [@Breadcrumb::@breadcrumb0, @Breadcrumb0::@crumb0, @Crumb]
+  firrtl.hierpath @breadcrumb_nla0 [@Breadcrumb::@breadcrumb0, @Breadcrumb0::@crumb0, @Crumb]
+  // CHECK:  @breadcrumb_nla1 [@Breadcrumb::@breadcrumb1, @Breadcrumb0::@crumb0, @Crumb]
+  firrtl.hierpath @breadcrumb_nla1 [@Breadcrumb::@breadcrumb1, @Breadcrumb1::@crumb1, @Crumb]
+  // CHECK:  @breadcrumb_nla2 [@Breadcrumb::@breadcrumb0, @Breadcrumb0::@crumb0, @Crumb]
+  firrtl.hierpath @breadcrumb_nla2 [@Breadcrumb::@breadcrumb0, @Breadcrumb0::@crumb0, @Crumb]
+  // CHECK:  @breadcrumb_nla3 [@Breadcrumb::@breadcrumb1, @Breadcrumb0::@crumb0, @Crumb]
+  firrtl.hierpath @breadcrumb_nla3 [@Breadcrumb::@breadcrumb1, @Breadcrumb1::@crumb1, @Crumb]
   firrtl.module @Crumb(in %in: !firrtl.uint<1> sym @in [
       {circt.nonlocal = @breadcrumb_nla0, class = "port0"},
       {circt.nonlocal = @breadcrumb_nla1, class = "port1"}]) {
@@ -199,18 +199,18 @@ firrtl.circuit "Breadcrumb" {
 // and the annotation should be cloned for each parent of the root module.
 // CHECK-LABEL: firrtl.circuit "Context"
 firrtl.circuit "Context" {
-  // CHECK: firrtl.hierpath [[NLA3:@nla.*]] [@Context::@context1, @Context0::@c0, @ContextLeaf::@w]
-  // CHECK: firrtl.hierpath [[NLA1:@nla.*]] [@Context::@context1, @Context0::@c0, @ContextLeaf::@in]
-  // CHECK: firrtl.hierpath [[NLA2:@nla.*]] [@Context::@context0, @Context0::@c0, @ContextLeaf::@w]
-  // CHECK: firrtl.hierpath [[NLA0:@nla.*]] [@Context::@context0, @Context0::@c0, @ContextLeaf::@in]
+  // CHECK: firrtl.hierpath [[NLA3:@nla.*]] [@Context::@context1, @Context0::@c0, @ContextLeaf]
+  // CHECK: firrtl.hierpath [[NLA1:@nla.*]] [@Context::@context1, @Context0::@c0, @ContextLeaf]
+  // CHECK: firrtl.hierpath [[NLA2:@nla.*]] [@Context::@context0, @Context0::@c0, @ContextLeaf]
+  // CHECK: firrtl.hierpath [[NLA0:@nla.*]] [@Context::@context0, @Context0::@c0, @ContextLeaf]
   // CHECK-NOT: @context_nla0
   // CHECK-NOT: @context_nla1
   // CHECK-NOT: @context_nla2
   // CHECK-NOT: @context_nla3
-  firrtl.hierpath @context_nla0 [@Context0::@c0, @ContextLeaf::@in]
-  firrtl.hierpath @context_nla1 [@Context0::@c0, @ContextLeaf::@w]
-  firrtl.hierpath @context_nla2 [@Context1::@c1, @ContextLeaf::@in]
-  firrtl.hierpath @context_nla3 [@Context1::@c1, @ContextLeaf::@w]
+  firrtl.hierpath @context_nla0 [@Context0::@c0, @ContextLeaf]
+  firrtl.hierpath @context_nla1 [@Context0::@c0, @ContextLeaf]
+  firrtl.hierpath @context_nla2 [@Context1::@c1, @ContextLeaf]
+  firrtl.hierpath @context_nla3 [@Context1::@c1, @ContextLeaf]
 
   // CHECK: firrtl.module @ContextLeaf(in %in: !firrtl.uint<1> sym @in [
   // CHECK-SAME: {circt.nonlocal = [[NLA0]], class = "port0"},
@@ -265,8 +265,8 @@ firrtl.circuit "ExtModuleTest" {
 // https://github.com/llvm/circt/issues/2713
 // CHECK-LABEL: firrtl.circuit "Foo"
 firrtl.circuit "Foo"  {
-  // CHECK: firrtl.hierpath @nla_1 [@Foo::@b, @A::@a]
-  firrtl.hierpath @nla_1 [@Foo::@b, @B::@b]
+  // CHECK: firrtl.hierpath @nla_1 [@Foo::@b, @A]
+  firrtl.hierpath @nla_1 [@Foo::@b, @B]
   // CHECK: firrtl.extmodule @A(out a: !firrtl.clock sym @a [{circt.nonlocal = @nla_1}])
   firrtl.extmodule @A(out a: !firrtl.clock)
   firrtl.extmodule @B(out b: !firrtl.clock sym @b [{circt.nonlocal = @nla_1}])

--- a/test/Dialect/FIRRTL/emit-omir.mlir
+++ b/test/Dialect/FIRRTL/emit-omir.mlir
@@ -347,7 +347,7 @@ firrtl.circuit "SRAMPathsWithNLA" attributes {annotations = [{
     }
   ]
 }]} {
-  firrtl.hierpath @nla [@SRAMPathsWithNLA::@s1, @Submodule::@m1]
+  firrtl.hierpath @nla [@SRAMPathsWithNLA::@s1, @Submodule]
   firrtl.module @Submodule() {
     %mem2_port = firrtl.mem sym @m1 Undefined {annotations = [{circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 1}], depth = 8, name = "mem2", portNames = ["port"], readLatency = 0 : i32, writeLatency = 1 : i32 } : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: uint<42>>
   }
@@ -645,10 +645,10 @@ firrtl.circuit "AddPortsRelative" attributes {annotations = [{
 //   }
 // ]
 
-firrtl.circuit "FixPath"  attributes 
+firrtl.circuit "FixPath"  attributes
 {annotations = [{class = "freechips.rocketchip.objectmodel.OMIRAnnotation", nodes = [{fields = {d = {index = 3 : i64, info = loc(unknown), value = {id = 3 : i64, omir.tracker, path = "~FixPath|D", type = "OMMemberInstanceTarget"}}, dutInstance = {index = 0 : i64, info = loc(unknown), value = {id = 0 : i64, omir.tracker, path = "~FixPath|FixPath/c:C", type = "OMMemberInstanceTarget"}}, power = {index = 2 : i64, info = loc(unknown), value = {id = 2 : i64, omir.tracker, path = "~FixPath|FixPath/c:C/cd:D", type = "OMMemberInstanceTarget"}}, pwm = {index = 1 : i64, info = loc(unknown), value = {id = 1 : i64, omir.tracker, path = "~FixPath|FixPath/c:C>in", type = "OMMemberInstanceTarget"}}}, id = "OMID:0", info = loc(unknown)}]}]} {
   firrtl.hierpath @nla_3 [@FixPath::@c, @C::@cd, @D]
-  firrtl.hierpath @nla_2 [@FixPath::@c, @C::@in]
+  firrtl.hierpath @nla_2 [@FixPath::@c, @C]
   firrtl.hierpath @nla_1 [@FixPath::@c, @C]
   firrtl.module @C(in %in: !firrtl.uint<1> sym @in [{circt.nonlocal = @nla_2, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 1 : i64}]) attributes {annotations = [{circt.nonlocal = @nla_1, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 0 : i64}, {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
     firrtl.instance cd sym @cd  {annotations = [{circt.nonlocal = @nla_3, class = "circt.nonlocal"}]} @D()

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -730,7 +730,7 @@ firrtl.circuit "NLATop1" {
 // This should not error out. Note that there is no symbol on the %bundle. This handles a special case, when the nonlocal is applied to a subfield.
 firrtl.circuit "fallBackName" {
 
-  firrtl.hierpath @nla [@fallBackName::@test, @Aardvark::@test, @Zebra::@bundle]
+  firrtl.hierpath @nla [@fallBackName::@test, @Aardvark::@test, @Zebra]
   firrtl.hierpath @nla_1 [@fallBackName::@test,@Aardvark::@test_1, @Zebra]
   firrtl.module @fallBackName() {
     firrtl.instance test  sym @test {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}, {circt.nonlocal = @nla_1, class = "circt.nonlocal"} ]}@Aardvark()
@@ -749,23 +749,11 @@ firrtl.circuit "fallBackName" {
 
 // -----
 
-firrtl.circuit "Foo"   {
-  // expected-error @+1 {{operation with symbol: #hw.innerNameRef<@Bar::@b> was not found}}
-  firrtl.hierpath @nla_1 [@Foo::@bar, @Bar::@b]
-  firrtl.module @Bar(in %a: !firrtl.uint<1>, out %b: !firrtl.bundle<baz: uint<1>, qux: uint<1>> [#firrtl.subAnno<fieldID = 2, {circt.nonlocal = @nla_1, three}>], out %c: !firrtl.uint<1>) {
-  }
-  firrtl.module @Foo() {
-    %bar_a, %bar_b, %bar_c = firrtl.instance bar sym @bar  {annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}]} @Bar(in a: !firrtl.uint<1> [{one}], out b: !firrtl.bundle<baz: uint<1>, qux: uint<1>> [#firrtl.subAnno<fieldID = 1, {two}>], out c: !firrtl.uint<1> [{four}])
-  }
-}
-
-// -----
-
 firrtl.circuit "Top"   {
  // Legal nla would be:
-//firrtl.hierpath @nla [@Top::@mid, @Mid::@leaf, @Leaf::@w]
+//firrtl.hierpath @nla [@Top::@mid, @Mid::@leaf, @Leaf]
   // expected-error @+1 {{instance path is incorrect. Expected module: "Middle" instead found: "Leaf"}}
-  firrtl.hierpath @nla [@Top::@mid, @Leaf::@w]
+  firrtl.hierpath @nla [@Top::@mid, @Leaf]
   firrtl.module @Leaf() {
     %w = firrtl.wire sym @w  {annotations = [{circt.nonlocal = @nla, class = "fake1"}]} : !firrtl.uint<3>
   }

--- a/test/Dialect/FIRRTL/grand-central-taps.mlir
+++ b/test/Dialect/FIRRTL/grand-central-taps.mlir
@@ -333,9 +333,9 @@ firrtl.circuit "NLAGarbageCollection" {
   // CHECK-NOT: @nla_1
   // CHECK-NOT: @nla_2
   // CHECK-NOT: @nla_3
-  firrtl.hierpath @nla_1 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule::@foo]
-  firrtl.hierpath @nla_2 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule::@port]
-  firrtl.hierpath @nla_3 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule::@bar_0]
+  firrtl.hierpath @nla_1 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule]
+  firrtl.hierpath @nla_2 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule]
+  firrtl.hierpath @nla_3 [@NLAGarbageCollection::@dut, @DUT::@submodule, @Submodule]
   firrtl.module @Submodule(
     in %port: !firrtl.uint<1> sym @port [
       {circt.nonlocal = @nla_2,
@@ -419,8 +419,8 @@ firrtl.circuit "NLAGarbageCollection" {
 firrtl.circuit "NLAUsedInWiring"  {
   // CHECK-NOT: @nla_1
   // CHECK-NOT: @nla_2
-  firrtl.hierpath @nla_1 [@NLAUsedInWiring::@foo, @Foo::@f]
-  firrtl.hierpath @nla_2 [@NLAUsedInWiring::@foo, @Foo::@g]
+  firrtl.hierpath @nla_1 [@NLAUsedInWiring::@foo, @Foo]
+  firrtl.hierpath @nla_2 [@NLAUsedInWiring::@foo, @Foo]
 
   // CHECK-LABEL: firrtl.module @DataTap
   // CHECK-NEXT: [[TMP:%.+]] = firrtl.verbatim.expr
@@ -495,8 +495,8 @@ firrtl.circuit "NLAUsedInWiring"  {
 // See https://github.com/llvm/circt/issues/2767.
 
 firrtl.circuit "Top" {
-  firrtl.hierpath @nla_0 [@DUT::@submodule_1, @Submodule::@bar_0]
-  firrtl.hierpath @nla [@DUT::@submodule_2, @Submodule::@bar_0]
+  firrtl.hierpath @nla_0 [@DUT::@submodule_1, @Submodule]
+  firrtl.hierpath @nla [@DUT::@submodule_2, @Submodule]
   firrtl.module @Submodule(in %clock: !firrtl.clock, out %out: !firrtl.uint<1>) {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -958,8 +958,8 @@ firrtl.circuit "DedupedPath" attributes {
         id = 2 : i64}],
      id = 0 : i64,
      name = "View"}]} {
-  firrtl.hierpath @nla_0 [@DUT::@tile1, @Tile::@w]
-  firrtl.hierpath @nla [@DUT::@tile2, @Tile::@w]
+  firrtl.hierpath @nla_0 [@DUT::@tile1, @Tile]
+  firrtl.hierpath @nla [@DUT::@tile2, @Tile]
   firrtl.module @Tile() {
     %w = firrtl.wire sym @w {
       annotations = [

--- a/test/Dialect/FIRRTL/lower-memory.mlir
+++ b/test/Dialect/FIRRTL/lower-memory.mlir
@@ -228,8 +228,8 @@ firrtl.module @Annotations() attributes {annotations = [{class = "sifive.enterpr
 // Check that annotations are copied over to the instance.
 // CHECK-LABEL: firrtl.circuit "NonLocalAnnotation"
 firrtl.circuit "NonLocalAnnotation" {
-// CHECK:       [@NonLocalAnnotation::@dut, @DUT::@sym, @mem0::@mem0_ext]
-firrtl.hierpath @nla [@NonLocalAnnotation::@dut, @DUT::@sym]
+// CHECK:       @[[nla:.+]] [@NonLocalAnnotation::@dut, @DUT::@sym, @mem0]
+firrtl.hierpath @nla [@NonLocalAnnotation::@dut, @DUT]
 // CHECK: firrtl.module @NonLocalAnnotation()
 firrtl.module @NonLocalAnnotation()  {
   firrtl.instance dut sym @dut @DUT()
@@ -240,10 +240,10 @@ firrtl.module @DUT() {
   %mem0_write = firrtl.mem sym @sym Undefined {annotations = [{circt.nonlocal = @nla, class = "test0"}, {circt.nonlocal = @nla, class = "test2"}], depth = 12 : i64, name = "mem0", portNames = ["write"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
 // LowerMemory should ignore MemOps that are not seqmems. The following memory is a combmem with readLatency=1.
   %MRead_read = firrtl.mem Undefined {depth = 12 : i64, name = "MRead", portNames = ["read"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
-// CHECK:   %MRead_read = firrtl.mem Undefined 
+// CHECK:   %MRead_read = firrtl.mem Undefined
 }
 
 // CHECK: firrtl.module @mem0
-// CHECK:   firrtl.instance mem0_ext sym @mem0_ext  {annotations = [{circt.nonlocal = @nla, class = "test0"}, {circt.nonlocal = @nla, class = "test2"}]} @mem0_ext
+// CHECK:   firrtl.instance mem0_ext {annotations = [{circt.nonlocal = "[[nla]]", class = "test0"}, {circt.nonlocal = "[[nla]]", class = "test2"}]} @mem0_ext
 // CHECK: }
 }

--- a/test/Dialect/FIRRTL/prefix-modules.mlir
+++ b/test/Dialect/FIRRTL/prefix-modules.mlir
@@ -307,8 +307,8 @@ firrtl.circuit "GCTDataMemTapsPrefix" {
   firrtl.circuit "FixNLA"   {
     firrtl.hierpath @nla_1 [@FixNLA::@bar, @Bar::@baz, @Baz]
     // CHECK:   firrtl.hierpath @nla_1 [@FixNLA::@bar, @Bar::@baz, @Baz]
-    firrtl.hierpath @nla_2 [@FixNLA::@foo, @Foo::@bar, @Bar::@baz, @Baz::@s1]
-    // CHECK:   firrtl.hierpath @nla_2 [@FixNLA::@foo, @X_Foo::@bar, @X_Bar::@baz, @X_Baz::@s1]
+    firrtl.hierpath @nla_2 [@FixNLA::@foo, @Foo::@bar, @Bar::@baz, @Baz]
+    // CHECK:   firrtl.hierpath @nla_2 [@FixNLA::@foo, @X_Foo::@bar, @X_Bar::@baz, @X_Baz]
     firrtl.hierpath @nla_3 [@FixNLA::@bar, @Bar::@baz, @Baz]
     // CHECK:   firrtl.hierpath @nla_3 [@FixNLA::@bar, @Bar::@baz, @Baz]
     firrtl.hierpath @nla_4 [@Foo::@bar, @Bar::@baz, @Baz]

--- a/test/Dialect/FIRRTL/print-nla-table.mlir
+++ b/test/Dialect/FIRRTL/print-nla-table.mlir
@@ -1,14 +1,14 @@
 // RUN: circt-opt -firrtl-print-nla-table %s  2>&1 | FileCheck %s
 
-// CHECK: BarNL: nla_1, nla, 
-// CHECK: BazNL: nla_1, nla_0, nla, 
-// CHECK: FooNL: nla_1, nla_0, nla, 
-// CHECK: FooL: 
+// CHECK: BarNL: nla_1, nla,
+// CHECK: BazNL: nla_1, nla_0, nla,
+// CHECK: FooNL: nla_1, nla_0, nla,
+// CHECK: FooL:
 
 firrtl.circuit "FooNL"  {
   firrtl.hierpath @nla_1 [@FooNL::@baz, @BazNL::@bar, @BarNL]
-  firrtl.hierpath @nla_0 [@FooNL::@baz, @BazNL::@w]
-  firrtl.hierpath @nla [@FooNL::@baz, @BazNL::@bar, @BarNL::@w2]
+  firrtl.hierpath @nla_0 [@FooNL::@baz, @BazNL]
+  firrtl.hierpath @nla [@FooNL::@baz, @BazNL::@bar, @BarNL]
 
   firrtl.module @BarNL() attributes {annotations = [{circt.nonlocal = @nla_1, class = "circt.test", nl = "nl"}]} {
     %w2 = firrtl.wire sym @w2  {annotations = [{circt.fieldID = 5 : i32, circt.nonlocal = @nla, class = "circt.test", nl = "nl2"}]} : !firrtl.bundle<a: uint, b: vector<uint, 4>>

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -154,8 +154,8 @@ firrtl.module @TestInvalidAttr() {
 }
 
 // Basic test for NLA operations.
-// CHECK: firrtl.hierpath @nla [@Parent::@child, @Child::@w]
-firrtl.hierpath @nla [@Parent::@child, @Child::@w]
+// CHECK: firrtl.hierpath @nla [@Parent::@child, @Child]
+firrtl.hierpath @nla [@Parent::@child, @Child]
 firrtl.module @Child() {
   %w = firrtl.wire sym @w : !firrtl.uint<1>
 }


### PR DESCRIPTION
Change FIRRTL's NLA to require that it ends in a module.  This is a
semantic simplification that means an NLA only encodes a path and does
not encode what it points to.  This is done for two reasons:

First: this enables NLAs to exist without requiring a symbol on their
leaf target.  This avoids a problem where this symbol, which is an
optimization barrier equivalent to a DontTouchAnnotation, would block
optimizations unnecessarily.  Additionally, symbols apply to the whole
aggregate as opposed to individual fields which resulted in a loss of
optimization barrier specificity when using NLAs.

Second: this enables NLAs to be shared amongst multiple "circt.nonlocal"
annotations.  NLA verification is expensive and this has the potential
to speed up this verification by avoiding repeated work repeatedly
verifying the existence of the same symbols.

Note: this commit makes no changes to NLA generation in
parsing/scattering that works towards the second reason.  This will be
added in later commits.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>