### PR TITLE
[SV] use module name for instantation name of extracted module

### DIFF
--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -176,8 +176,7 @@ static hw::HWModuleOp createModuleForCut(hw::HWModuleOp op,
   // Add an instance in the old module for the extracted module
   b = OpBuilder::atBlockTerminator(op.getBodyBlock());
   auto inst = b.create<hw::InstanceOp>(
-      op.getLoc(), newMod, ("InvisibleBind" + suffix).str(),
-      inputs.getArrayRef(), ArrayAttr(),
+      op.getLoc(), newMod, newMod.getName(), inputs.getArrayRef(), ArrayAttr(),
       b.getStringAttr(
           ("__ETC_" + getVerilogModuleNameAttr(op).getValue() + suffix).str()));
   inst->setAttr("doNotPrint", b.getBoolAttr(true));

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -29,6 +29,9 @@
 // CHECK-NOT: foo_assert
 // CHECK-NOT: foo_assume
 // CHECK-NOT: foo_cover
+// CHECK: hw.instance "issue1246_assert"
+// CHECK: hw.instance "issue1246_assume"
+// CHECK: hw.instance "issue1246_cover"
 // CHECK: sv.bind <@issue1246::@__ETC_issue1246_assert>
 // CHECK: sv.bind <@issue1246::@__ETC_issue1246_assume> {output_file = #hw.output_file<"file4", excludeFromFileList>}
 // CHECK: sv.bind <@issue1246::@__ETC_issue1246_cover>


### PR DESCRIPTION
Use module name instead of "InvisibleBind".

Aligns with SFC behavior, here's a before/after for a test case:

```diff
58,60c58,60
<     hw.instance "InvisibleBind_assert" sym @__ETC_issue1246_assert @issue1246_assert(clock: %clock: i1) -> () {doNotPrint = true}
<     hw.instance "InvisibleBind_assume" sym @__ETC_issue1246_assume @issue1246_assume(clock: %clock: i1) -> () {doNotPrint = true}
<     hw.instance "InvisibleBind_cover" sym @__ETC_issue1246_cover @issue1246_cover(clock: %clock: i1) -> () {doNotPrint = true}
---
>     hw.instance "issue1246_assert" sym @__ETC_issue1246_assert @issue1246_assert(clock: %clock: i1) -> () {doNotPrint = true}
>     hw.instance "issue1246_assume" sym @__ETC_issue1246_assume @issue1246_assume(clock: %clock: i1) -> () {doNotPrint = true}
>     hw.instance "issue1246_cover" sym @__ETC_issue1246_cover @issue1246_cover(clock: %clock: i1) -> () {doNotPrint = true}
```