### PR TITLE
[FIRRTL] Fix LowerTypes for non-NLA hierpaths

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRAnnotations.cpp
@@ -137,16 +137,16 @@ buildNLA(CircuitOp circuit, size_t nlaSuffix,
   OpBuilder b(circuit.getBodyRegion());
   MLIRContext *ctxt = circuit.getContext();
   SmallVector<Attribute> insts;
-  for (auto &nla : nlas) {
+  for (size_t i = 0, e = nlas.size() - 1; i < e; ++i) {
+    auto &nla = nlas[i];
     // Assumption: Symbol name = Operation name.
     auto module = std::get<1>(nla);
     auto inst = std::get<2>(nla);
-    if (inst.empty())
-      insts.push_back(FlatSymbolRefAttr::get(ctxt, module));
-    else
-      insts.push_back(hw::InnerRefAttr::get(StringAttr::get(ctxt, module),
-                                            StringAttr::get(ctxt, inst)));
+    insts.push_back(hw::InnerRefAttr::get(StringAttr::get(ctxt, module),
+                                          StringAttr::get(ctxt, inst)));
   }
+  insts.push_back(FlatSymbolRefAttr::get(ctxt, std::get<1>(nlas.back())));
+
   auto instAttr = ArrayAttr::get(ctxt, insts);
   auto nla = b.create<HierPathOp>(circuit.getLoc(),
                                   "nla_" + std::to_string(nlaSuffix), instAttr);

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1521,8 +1521,6 @@ static bool needsSymbol(ArrayAttr &annotations) {
       // Ignore the annotation.
       continue;
     }
-    if (anno.getMember("circt.nonlocal"))
-      needsSymbol = true;
     filteredAnnos.push_back(attr);
   }
   if (needsSymbol)

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -103,14 +103,13 @@ static void addAnnotation(AnnoTarget ref, unsigned fieldIdx,
 static FlatSymbolRefAttr buildNLA(AnnoPathValue target, ApplyState &state) {
   OpBuilder b(state.circuit.getBodyRegion());
   SmallVector<Attribute> insts;
-  for (auto inst : target.instances)
+  for (auto inst : target.instances) {
     insts.push_back(OpAnnoTarget(inst).getNLAReference(
         state.getNamespace(inst->getParentOfType<FModuleLike>())));
+  }
 
-  auto module = dyn_cast<FModuleLike>(target.ref.getOp());
-  if (!module)
-    module = target.ref.getOp()->getParentOfType<FModuleLike>();
-  insts.push_back(target.ref.getNLAReference(state.getNamespace(module)));
+  insts.push_back(
+      FlatSymbolRefAttr::get(target.ref.getModule().moduleNameAttr()));
   auto instAttr = ArrayAttr::get(state.circuit.getContext(), insts);
   auto nla = b.create<HierPathOp>(state.circuit.getLoc(), "nla", instAttr);
   state.symTbl.insert(nla);

--- a/test/Dialect/FIRRTL/SFCTests/dedup.fir
+++ b/test/Dialect/FIRRTL/SFCTests/dedup.fir
@@ -319,7 +319,7 @@ circuit Top : %[[
     "target":"Top.A.b"
   }
 ]]
-  ; CHECK: firrtl.hierpath @[[nlaSym:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]]]
+  ; CHECK: firrtl.hierpath @[[nlaSym:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A]
   ; CHECK: firrtl.module @Top
   ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] {{.+}} @A(
   ; CHECK-NEXT: firrtl.instance a2 {{.+}} @A(
@@ -328,7 +328,7 @@ circuit Top : %[[
     inst a2 of A_
   module A :
     output x: UInt<1>
-    ; CHECk-NEXT: firrtl.wire sym @[[bSym]] {annotations = [{circt.nonlocal = @[[nlaSym]], class = "hello"}]}
+    ; CHECk-NEXT: firrtl.wire {annotations = [{circt.nonlocal = @[[nlaSym]], class = "hello"}]}
     wire b: UInt<1>
     b is invalid
     x <= b
@@ -354,8 +354,8 @@ circuit Top : %[[
     "target":"~Top|A_>b"
   }
 ]]
-  ; CHECK: firrtl.hierpath @[[nlaSym1:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]]]
-  ; CHECK: firrtl.hierpath @[[nlaSym2:[_a-zA-Z0-9]+]] [@Top::@[[a2Sym:[_a-zA-Z0-9]+]], @A::@[[bSym]]]
+  ; CHECK: firrtl.hierpath @[[nlaSym1:[_a-zA-Z0-9]+]] [@Top::@[[a1Sym:[_a-zA-Z0-9]+]], @A]
+  ; CHECK: firrtl.hierpath @[[nlaSym2:[_a-zA-Z0-9]+]] [@Top::@[[a2Sym:[_a-zA-Z0-9]+]], @A]
   ; CHECK: firrtl.module @Top
   ; CHECK-NEXT: firrtl.instance a1 sym @[[a1Sym]] {{.+}} @A(
   ; CHECK-NEXT: firrtl.instance a2 sym @[[a2Sym]] {{.+}} @A(
@@ -364,7 +364,7 @@ circuit Top : %[[
     inst a2 of A_
   module A :
     output x: UInt<1>
-    ; CHECk-NEXT: firrtl.wire sym @[[bSym]] {annotations = [{circt.nonlocal = @[[nlaSym1]], class = "world"}, {circt.nonlocal = @[[nlaSym2]], class = "hello"}]}
+    ; CHECk-NEXT: firrtl.wire {annotations = [{circt.nonlocal = @[[nlaSym1]], class = "world"}, {circt.nonlocal = @[[nlaSym2]], class = "hello"}]}
     wire b: UInt<1>
     b is invalid
     x <= b
@@ -450,9 +450,9 @@ circuit Top : %[[
     "target":"~Top|Top/a_:A_/b_:B_>bar"
   }
 ]]
-  ; CHECK: firrtl.hierpath @[[nla_4:[_a-zA-Z0-9]+]] [@Top::@[[a_Sym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]], @B::@[[fooSym:[_a-zA-Z0-9]+]]]
+  ; CHECK: firrtl.hierpath @[[nla_4:[_a-zA-Z0-9]+]] [@Top::@[[a_Sym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]], @B]
   ; CHECK: firrtl.hierpath @[[nla_3:[_a-zA-Z0-9]+]] [@Top::@[[a_Sym]], @A::@[[bSym]], @B]
-  ; CHECK: firrtl.hierpath @[[nla_2:[_a-zA-Z0-9]+]] [@Top::@[[aSym:[_a-zA-Z0-9]+]], @A::@[[bSym]], @B::@[[fooSym]]]
+  ; CHECK: firrtl.hierpath @[[nla_2:[_a-zA-Z0-9]+]] [@Top::@[[aSym:[_a-zA-Z0-9]+]], @A::@[[bSym]], @B]
   ; CHECK: firrtl.hierpath @[[nla_1:[_a-zA-Z0-9]+]] [@Top::@[[aSym]], @A::@[[bSym]], @B]
   ; CHECK: firrtl.module @Top
   module Top :
@@ -472,7 +472,7 @@ circuit Top : %[[
   ; CHECK-SAME: {circt.nonlocal = @[[nla_3]], class = "B_"}
   ; CHECK-SAME: {circt.nonlocal = @[[nla_1]], class = "B"}
   module B :
-    ; CHECK: firrtl.node sym @[[fooSym]]
+    ; CHECK: firrtl.node
     ; CHECK-SAME: {circt.nonlocal = @[[nla_4]], class = "B_.bar"}
     ; CHECK-SAME: {circt.nonlocal = @[[nla_2]], class = "B.foo"}
     node foo = UInt<1>(0)
@@ -512,7 +512,7 @@ circuit Top : %[[
   ; CHECK-SAME:      @A::@[[bSym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @B::@[[cSym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @C::@[[dSym:[_a-zA-Z0-9]+]],
-  ; CHECK-SAME:      @D::@[[fooSym:[_a-zA-Z0-9]+]]]
+  ; CHECK-SAME:      @D]
   ; CHECK-NEXT:   firrtl.hierpath @[[nla_3:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:     [@Top::@[[a_Sym]],
   ; CHECK-SAME:      @A::@[[bSym]],
@@ -524,7 +524,7 @@ circuit Top : %[[
   ; CHECK-SAME:      @A::@[[bSym]],
   ; CHECK-SAME:      @B::@[[cSym]],
   ; CHECK-SAME:      @C::@[[dSym]],
-  ; CHECK-SAME:      @D::@[[fooSym]]]
+  ; CHECK-SAME:      @D]
   ; CHECK-NEXT:   firrtl.hierpath @[[nla_1:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:     [@Top::@[[aSym]],
   ; CHECK-SAME:      @A::@[[bSym]],
@@ -752,11 +752,9 @@ circuit top : %[[
   }
 ]]
   ; CHECK:      firrtl.hierpath @[[nla_1:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:   [@top::@[[topaSym:[_a-zA-Z0-9]+]],
-  ; CHECK-SAME:    @a::@[[aiSym:[_a-zA-Z0-9]+]]
+  ; CHECK-SAME:   [@top::@[[topaSym:[_a-zA-Z0-9]+]], @a]
   ; CHECK:      firrtl.hierpath @[[nla_2:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:   [@top::@[[topbSym:[_a-zA-Z0-9]+]],
-  ; CHECK-SAME:    @a::@[[aiSym]]
+  ; CHECK-SAME:   [@top::@[[topbSym:[_a-zA-Z0-9]+]], @a]
   ; CHECK: firrtl.module @top
   module top:
     input ia: {z: {y: {x: UInt<1>}}, a: UInt<1>}
@@ -777,7 +775,7 @@ circuit top : %[[
     ob.z <= b.r.z
 
   ; CHECK:      firrtl.module private @a(
-  ; CHECK-SAME:   in %i: {{.+}} sym @[[aiSym]]
+  ; CHECK-SAME:   in %i:
   ; CHECK-NOT:    out
   ; CHECK-SAME:     [#firrtl.subAnno<fieldID = 1, {circt.nonlocal = @[[nla_2]], class = "nla2"}>,
   ; CHECK-SAME:      #firrtl.subAnno<fieldID = 4, {circt.nonlocal = @[[nla_1]], class = "nla1"}>]

--- a/test/Dialect/FIRRTL/annotations.fir
+++ b/test/Dialect/FIRRTL/annotations.fir
@@ -106,11 +106,14 @@ circuit Foo: %[[{"one":null,"target":"~Foo|Foo>bar.a"},
     inst bar of Bar
 
     ; CHECK-LABEL: firrtl.circuit "Foo"
-    ; CHECK: firrtl.hierpath @nla_2 [@Foo::@bar, @Bar::@d]
-    ; CHECK: firrtl.hierpath @nla_1 [@Foo::@bar, @Bar::@b]
+    ; CHECK: firrtl.hierpath @nla_2 [@Foo::@bar, @Bar]
+    ; CHECK: firrtl.hierpath @nla_1 [@Foo::@bar, @Bar]
     ; CHECK: firrtl.module private @Bar
-    ; CHECK-SAME: sym @b [#firrtl.subAnno<fieldID = 2, {circt.nonlocal = @nla_1, three}>]
-    ; CHECK-NEXT:  %d = firrtl.wire sym @d
+    ; CHECK:      out %b
+    ; CHECK-NOT:  sym
+    ; CHECK-SAME: [#firrtl.subAnno<fieldID = 2, {circt.nonlocal = @nla_1, three}>]
+    ; CHECK-NEXT: %d = firrtl.wire
+    ; CHECK-NOT:  sym
     ; CHECK-SAME: {annotations = [#firrtl.subAnno<fieldID = 2, {circt.nonlocal = @nla_2, five}>]}
     ; CHECK-SAME: : !firrtl.bundle<baz: uint<1>, qux: uint<1>>
     ; CHECK: %bar_a, %bar_b, %bar_c = firrtl.instance bar
@@ -582,8 +585,8 @@ circuit memportAnno: %[[
       write-latency => 1
       read-under-write => undefined
 ; CHECK-LABEL: firrtl.circuit "memportAnno"  {
-; CHECK:        firrtl.hierpath @nla_1 [@memportAnno::@foo, @Foo::@memory]
-; CHECK:        %memory_w = firrtl.mem sym @memory interesting_name Undefined  {depth = 16 : i64, name = "memory", portAnnotations
+; CHECK:        firrtl.hierpath @nla_1 [@memportAnno::@foo, @Foo]
+; CHECK:        %memory_w = firrtl.mem {{.+}} Undefined {depth = 16 : i64, name = "memory", portAnnotations
 ; CHECK-SAME:   [{circt.nonlocal = @nla_1, class = "test"}]
 
 ; // -----
@@ -629,5 +632,5 @@ circuit instportAnno: %[[
     inst bar of Bar
 
 ; CHECK-LABEL: firrtl.circuit "instportAnno"
-; CHECK:        firrtl.hierpath @[[HIER:[^ ]+]] [@instportAnno::@bar, @Bar::@baz]
-; CHECK:        %baz_a = firrtl.instance baz sym @baz interesting_name @Baz(out a: !firrtl.uint<1> [{circt.nonlocal = @[[HIER]], class = "hello"}])
+; CHECK:        firrtl.hierpath @[[HIER:[^ ]+]] [@instportAnno::@bar, @Bar]
+; CHECK:        %baz_a = firrtl.instance baz interesting_name @Baz(out a: !firrtl.uint<1> [{circt.nonlocal = @[[HIER]], class = "hello"}])

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -21,8 +21,8 @@ firrtl.circuit "Aggregates" attributes {rawAnnotations = [
 
 // CHECK-LABEL: firrtl.circuit "FooNL"
 // CHECK: firrtl.hierpath @nla_1 [@FooNL::@baz, @BazNL::@bar, @BarNL]
-// CHECK: firrtl.hierpath @nla_0 [@FooNL::@baz, @BazNL::@bar, @BarNL::@w]
-// CHECK: firrtl.hierpath @nla [@FooNL::@baz, @BazNL::@bar, @BarNL::@w2]
+// CHECK: firrtl.hierpath @nla_0 [@FooNL::@baz, @BazNL::@bar, @BarNL]
+// CHECK: firrtl.hierpath @nla [@FooNL::@baz, @BazNL::@bar, @BarNL]
 // CHECK: firrtl.module @BarNL
 // CHECK: %w = firrtl.wire sym @w {annotations = [{circt.nonlocal = @nla_0, class = "circt.test", nl = "nl"}]}
 // CHECK: %w2 = firrtl.wire sym @w2 {annotations = [{circt.fieldID = 5 : i32, circt.nonlocal = @nla, class = "circt.test", nl = "nl2"}]} : !firrtl.bundle<a: uint, b: vector<uint, 4>>
@@ -57,9 +57,10 @@ firrtl.circuit "FooNL"  attributes {rawAnnotations = [
 // Non-local annotations on memory ports should work.
 
 // CHECK-LABEL: firrtl.circuit "MemPortsNL"
-// CHECK: firrtl.hierpath @nla [@MemPortsNL::@child, @Child::@bar]
+// CHECK: firrtl.hierpath @nla [@MemPortsNL::@child, @Child]
 // CHECK: firrtl.module @Child()
-// CHECK:   %bar_r = firrtl.mem sym @bar
+// CHECK:   %bar_r = firrtl.mem
+// CHECK-NOT: sym
 // CHECK-SAME: portAnnotations = {{\[}}[{circt.nonlocal = @nla, class = "circt.test", nl = "nl"}]]
 // CHECK: firrtl.module @MemPortsNL()
 // CHECK:   firrtl.instance child sym @child
@@ -120,8 +121,8 @@ firrtl.circuit "Test" attributes {rawAnnotations = [
 firrtl.circuit "Test" attributes {rawAnnotations = [
   {class = "circt.test", target = "~Test|Test>exttest.in"}
   ]} {
-  // CHECK: firrtl.hierpath @nla [@Test::@exttest, @ExtTest::@in]
-  // CHECK: firrtl.extmodule @ExtTest(in in: !firrtl.uint<1> sym @in [{circt.nonlocal = @nla, class = "circt.test"}])
+  // CHECK: firrtl.hierpath @nla [@Test::@exttest, @ExtTest]
+  // CHECK: firrtl.extmodule @ExtTest(in in: !firrtl.uint<1> [{circt.nonlocal = @nla, class = "circt.test"}])
   firrtl.extmodule @ExtTest(in in: !firrtl.uint<1>)
 
   firrtl.module @Test() {
@@ -371,7 +372,7 @@ firrtl.circuit "GCTDataTap" attributes {rawAnnotations = [{
 }
 
 // CHECK-LABEL: firrtl.circuit "GCTDataTap"
-// CHECK:      firrtl.hierpath [[NLA:@.+]] [@GCTDataTap::@im, @InnerMod::@w]
+// CHECK:      firrtl.hierpath [[NLA:@.+]] [@GCTDataTap::@im, @InnerMod]
 
 // CHECK-LABEL: firrtl.extmodule private @DataTap
 

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1045,57 +1045,51 @@ firrtl.module private @is1436_FOO() {
 
 firrtl.circuit "NLALowering" {
   // Check if the NLA is updated with the new lowered symbol on a field element.
-  firrtl.hierpath @nla [@fallBackName::@test, @Aardvark::@test, @NLALowering::@b]
-  // CHECK: firrtl.hierpath @nla_0 [@fallBackName::@test, @Aardvark::@test, @NLALowering::@b_data]
-  // CHECK: firrtl.hierpath @nla [@fallBackName::@test, @Aardvark::@test, @NLALowering::@b_ready]
-  firrtl.hierpath @nla_1 [@fallBackName::@test, @Aardvark::@test_1, @NLALowering]
-  firrtl.hierpath @nla_2 [@fallBackName::@test, @Aardvark::@test, @NLALowering::@b2]
+  firrtl.hierpath @nla_b [@fallBackName::@test, @Aardvark::@test, @NLALowering::@b]
+  // CHECK:      firrtl.hierpath @nla_b [@fallBackName::@test, @Aardvark::@test, @NLALowering::@b_valid]
+  // CHECK-NEXT: firrtl.hierpath @nla_b_0 [@fallBackName::@test, @Aardvark::@test, @NLALowering::@b_ready]
+  // CHECK-NEXT: firrtl.hierpath @nla_b_1 [@fallBackName::@test, @Aardvark::@test, @NLALowering::@b_data]
+  firrtl.hierpath @nla [@fallBackName::@test, @Aardvark::@test_1, @NLALowering]
+  // CHECK-NEXT: firrtl.hierpath @nla [@fallBackName::@test, @Aardvark::@test_1, @NLALowering]
+  firrtl.hierpath @nla_b2 [@fallBackName::@test, @Aardvark::@test, @NLALowering::@b2]
+  // CHECK-NEXT: firrtl.hierpath @nla_b2 [@fallBackName::@test, @Aardvark::@test, @NLALowering::@b2_valid]
+  // CHECK-NEXT: firrtl.hierpath @nla_b2_0 [@fallBackName::@test, @Aardvark::@test, @NLALowering::@b2_ready]
+  // CHECK-NEXT: firrtl.hierpath @nla_b2_1 [@fallBackName::@test, @Aardvark::@test, @NLALowering::@b2_data]
   // CHECK-NOT: firrtl.hierpath @nla_2
   firrtl.module private @fallBackName() {
-    firrtl.instance test sym @test {
-      annotations = [
-        {circt.nonlocal = @nla, class = "circt.nonlocal"},
-        {circt.nonlocal = @nla_1, class = "circt.nonlocal"},
-        {circt.nonlocal = @nla_2, class = "circt.nonlocal"}
-      ]
-    } @Aardvark()
+    firrtl.instance test sym @test @Aardvark()
     firrtl.instance test2 @NLALowering()
   }
 
   firrtl.module private @Aardvark() {
-    firrtl.instance test sym @test {
-      annotations = [
-        {circt.nonlocal = @nla, class = "circt.nonlocal"},
-        {circt.nonlocal = @nla_2, class = "circt.nonlocal"}
-      ]
-    } @NLALowering()
-    firrtl.instance test1 sym @test_1 {annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}]}@NLALowering()
+    firrtl.instance test sym @test @NLALowering()
+    firrtl.instance test1 sym @test_1 @NLALowering()
   }
 
   // CHECK-LABEL: firrtl.module @NLALowering()
-  firrtl.module @NLALowering() attributes {annotations = [{circt.nonlocal = @nla_1, class = "circt.nonlocal"}]}{
+  firrtl.module @NLALowering() attributes {annotations = [{circt.nonlocal = @nla, class = "circt.nonlocal"}]}{
     // bundle has annotations reusing the same NLA, the DontTouch should get dropped.
     %bundle = firrtl.wire sym @b {
       annotations = [
-        #firrtl.subAnno<fieldID = 2, {circt.nonlocal = @nla, class = "test" }>,
-        #firrtl.subAnno<fieldID = 2, {circt.nonlocal = @nla, class = "firrtl.transforms.DontTouchAnnotation"}>,
-        #firrtl.subAnno<fieldID = 3, {circt.nonlocal = @nla, B}>,
-        #firrtl.subAnno<fieldID = 3, {circt.nonlocal = @nla, A}>,
-        #firrtl.subAnno<fieldID = 3, {circt.nonlocal = @nla, class = "firrtl.transforms.DontTouchAnnotation"}>
+        #firrtl.subAnno<fieldID = 2, {circt.nonlocal = @nla_b, class = "test" }>,
+        #firrtl.subAnno<fieldID = 2, {circt.nonlocal = @nla_b, class = "firrtl.transforms.DontTouchAnnotation"}>,
+        #firrtl.subAnno<fieldID = 3, {circt.nonlocal = @nla_b, B}>,
+        #firrtl.subAnno<fieldID = 3, {circt.nonlocal = @nla_b, A}>,
+        #firrtl.subAnno<fieldID = 3, {circt.nonlocal = @nla_b, class = "firrtl.transforms.DontTouchAnnotation"}>
       ]
     } : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
     %bundle2 = firrtl.wire sym @b2 {
       annotations = [
-        #firrtl.subAnno<fieldID = 3, {circt.nonlocal = @nla_2, class = "firrtl.transforms.DontTouchAnnotation"}>,
-        #firrtl.subAnno<fieldID = 2, {circt.nonlocal = @nla_2, class = "firrtl.transforms.DontTouchAnnotation"}>
+        #firrtl.subAnno<fieldID = 3, {circt.nonlocal = @nla_b2, class = "firrtl.transforms.DontTouchAnnotation"}>,
+        #firrtl.subAnno<fieldID = 2, {circt.nonlocal = @nla_b2, class = "firrtl.transforms.DontTouchAnnotation"}>
       ]
     } : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
     // CHECK:   %bundle_valid = firrtl.wire sym @b_valid : !firrtl.uint<1>
     // Note that same NLA is reused. But this depends on the order of the annotations, if DontTouch was earlier in the list, it would be dropped and a new NLA would be created.
-    // CHECK-NEXT:   %bundle_ready = firrtl.wire sym @b_ready {annotations = [{circt.nonlocal = @nla, class = "test"}]} : !firrtl.uint<1>
+    // CHECK-NEXT:   %bundle_ready = firrtl.wire sym @b_ready {annotations = [{circt.nonlocal = @nla_b_0, class = "test"}]} : !firrtl.uint<1>
     // Note the new NLA added here.
     // CHECK-NEXT:   %bundle_data = firrtl.wire sym @b_data
-    // CHECK-SAME: {annotations = [{B, circt.nonlocal = @nla_0}, {A, circt.nonlocal = @nla_0}]}
+    // CHECK-SAME: {annotations = [{B, circt.nonlocal = @nla_b_1}, {A, circt.nonlocal = @nla_b_1}]}
     // CHECK:   %bundle2_valid = firrtl.wire sym @b2_valid  : !firrtl.uint<1>
     // CHECK:   %bundle2_ready = firrtl.wire sym @b2_ready  : !firrtl.uint<1>
     // CHECK:   %bundle2_data = firrtl.wire sym @b2_data  : !firrtl.uint<64>
@@ -1105,15 +1099,15 @@ firrtl.circuit "NLALowering" {
 // Test the update of NLA when a new symbol is added after lowering of bundle fields.
 firrtl.circuit "NLALoweringNewSymbol" {
   firrtl.hierpath @lowernla_2 [@NLALoweringNewSymbol::@testBundle_Bar, @testBundle_Bar::@d]
-  // CHECK: firrtl.hierpath @lowernla_2_0 [@NLALoweringNewSymbol::@testBundle_Bar, @testBundle_Bar::@d_qux]
   // CHECK: firrtl.hierpath @lowernla_2 [@NLALoweringNewSymbol::@testBundle_Bar, @testBundle_Bar::@d_baz]
+  // CHECK: firrtl.hierpath @lowernla_2_0 [@NLALoweringNewSymbol::@testBundle_Bar, @testBundle_Bar::@d_qux]
   firrtl.hierpath @lowernla_1 [@NLALoweringNewSymbol::@testBundle_Bar, @testBundle_Bar::@b]
-  // CHECK: firrtl.hierpath @lowernla_1_0 [@NLALoweringNewSymbol::@testBundle_Bar, @testBundle_Bar::@b_qux]
   // CHECK: firrtl.hierpath @lowernla_1 [@NLALoweringNewSymbol::@testBundle_Bar, @testBundle_Bar::@b_baz]
+  // CHECK: firrtl.hierpath @lowernla_1_0 [@NLALoweringNewSymbol::@testBundle_Bar, @testBundle_Bar::@b_qux]
+  // CHECK: firrtl.hierpath @lowernla_1_1 [@NLALoweringNewSymbol::@testBundle_Bar, @testBundle_Bar::@b_data]
   firrtl.module private @testBundle_Bar(
     in %a: !firrtl.uint<1>,
-    out %b: !firrtl.bundle<baz: uint<1>, qux: uint<1>,
-    data: uint<2>> sym @b [
+    out %b: !firrtl.bundle<baz: uint<1>, qux: uint<1>, data: uint<2>> sym @b [
       #firrtl.subAnno<fieldID = 3, {circt.nonlocal = @lowernla_1, class = "firrtl.transforms.DontTouchAnnotation"}>,
       #firrtl.subAnno<fieldID = 1, {circt.nonlocal = @lowernla_1, A}>,
       #firrtl.subAnno<fieldID = 1, {circt.nonlocal = @lowernla_1, B}>,
@@ -1148,6 +1142,51 @@ firrtl.circuit "NLALoweringNewSymbol" {
       data: uint<2>> [#firrtl.subAnno<fieldID = 1, {two}>],
       out c: !firrtl.uint<1> [{four}]
     )
+  }
+}
+
+// Check that a hierarchical path that is not used by any annotation is still
+// updated.
+//
+// CHECK-LABEL: "PathsWithoutNLAsAreStillUpdated"
+firrtl.circuit "PathsWithoutNLAsAreStillUpdated" {
+  // CHECK-NEXT: firrtl.hierpath @{{[^ ]+}} [@PathsWithoutNLAsAreStillUpdated::@foo, @Foo::@[[a_a_sym:a_.+]]]
+  // CHECK-NEXT: firrtl.hierpath @{{[^ ]+}} [@PathsWithoutNLAsAreStillUpdated::@foo, @Foo::@[[a_b_c_sym:a_.+]]]
+  // CHECK-NEXT: firrtl.hierpath @{{[^ ]+}} [@PathsWithoutNLAsAreStillUpdated::@foo, @Foo::@[[b_a_sym:b_.+]]]
+  // CHECK-NEXT: firrtl.hierpath @{{[^ ]+}} [@PathsWithoutNLAsAreStillUpdated::@foo, @Foo::@[[b_b_c_sym:b_.+]]]
+  firrtl.hierpath @path_port [@PathsWithoutNLAsAreStillUpdated::@foo, @Foo::@a]
+  firrtl.hierpath @path_wire [@PathsWithoutNLAsAreStillUpdated::@foo, @Foo::@b]
+
+  // CHECK:        firrtl.module @Foo
+  // CHECK-SAME:     in %a_a: !firrtl.uint<1> sym @[[a_a_sym]]
+  // CHECK-SAME:     in %a_b_c: !firrtl.uint<2> sym @[[a_b_c_sym]]
+  firrtl.module @Foo(in %a : !firrtl.bundle<a : uint<1>, b : bundle<c : uint<2>>> sym @a) {
+    // CHECK-NEXT: firrtl.wire sym @[[b_a_sym]] : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.wire sym @[[b_b_c_sym]] : !firrtl.uint<2>
+    %b = firrtl.wire sym @b : !firrtl.bundle<a : uint<1>, b : bundle<c : uint<2>>>
+  }
+  firrtl.module @PathsWithoutNLAsAreStillUpdated() {
+    %foo_a = firrtl.instance foo sym @foo @Foo(in a : !firrtl.bundle<a : uint<1>, b : bundle<c : uint<2>>>)
+  }
+}
+
+// Check that only the correct symbols are updated.
+//
+// CHECK-LABEL: "CorrectSymbolsOnly"
+firrtl.circuit "CorrectSymbolsOnly" {
+  firrtl.hierpath @path_0 [@CorrectSymbolsOnly::@foo, @Foo::@a]
+  firrtl.hierpath @path_1 [@CorrectSymbolsOnly::@foo, @Foo::@a]
+  firrtl.module @Foo() {
+    // CHECK:      firrtl.wire
+    // CHECK-SAME:   {circt.nonlocal = @path_0, class = "path_0"}
+    // CHECK-SAME:   {circt.nonlocal = @path_1, class = "path_1"}
+    %a = firrtl.wire sym @a {annotations = [
+      {circt.nonlocal = @path_0, class = "path_0"},
+      {circt.nonlocal = @path_1, class = "path_1"}
+    ]} : !firrtl.bundle<a: uint<1>>
+  }
+  firrtl.module @CorrectSymbolsOnly() {
+    firrtl.instance foo sym @foo @Foo()
   }
 }
 

--- a/test/Dialect/FIRRTL/print-nla-table.mlir
+++ b/test/Dialect/FIRRTL/print-nla-table.mlir
@@ -1,14 +1,14 @@
 // RUN: circt-opt -firrtl-print-nla-table %s  2>&1 | FileCheck %s
 
-// CHECK: BarNL: nla_1, nla, 
-// CHECK: BazNL: nla_1, nla_0, nla, 
-// CHECK: FooNL: nla_1, nla_0, nla, 
-// CHECK: FooL: 
+// CHECK: BarNL: nla_1, nla,
+// CHECK: BazNL: nla_1, nla_0, nla,
+// CHECK: FooNL: nla_1, nla_0, nla,
+// CHECK: FooL:
 
 firrtl.circuit "FooNL"  {
   firrtl.hierpath @nla_1 [@FooNL::@baz, @BazNL::@bar, @BarNL]
-  firrtl.hierpath @nla_0 [@FooNL::@baz, @BazNL::@w]
-  firrtl.hierpath @nla [@FooNL::@baz, @BazNL::@bar, @BarNL::@w2]
+  firrtl.hierpath @nla_0 [@FooNL::@baz, @BazNL]
+  firrtl.hierpath @nla [@FooNL::@baz, @BazNL::@bar, @BarNL]
 
   firrtl.module @BarNL() attributes {annotations = [{circt.nonlocal = @nla_1, class = "circt.test", nl = "nl"}]} {
     %w2 = firrtl.wire sym @w2  {annotations = [{circt.fieldID = 5 : i32, circt.nonlocal = @nla, class = "circt.test", nl = "nl2"}]} : !firrtl.bundle<a: uint, b: vector<uint, 4>>

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -154,8 +154,8 @@ firrtl.module @TestInvalidAttr() {
 }
 
 // Basic test for NLA operations.
-// CHECK: firrtl.hierpath @nla [@Parent::@child, @Child::@w]
-firrtl.hierpath @nla [@Parent::@child, @Child::@w]
+// CHECK: firrtl.hierpath @nla [@Parent::@child, @Child]
+firrtl.hierpath @nla [@Parent::@child, @Child]
 firrtl.module @Child() {
   %w = firrtl.wire sym @w : !firrtl.uint<1>
 }


### PR DESCRIPTION
Fix a bug in LowerTypes where it would only update hierarchical paths
that are involved in a non-local annotation (NLAs).  This is done in
preparation for more widespread use of hierarchical paths (e.g., by
sv::VerbatimOp) and in preparation for enabling hierarchical paths to
end at the module and not on the final operation.

It follows that this changes the lowering for a hierarchical path
targeting a component/port to generate one new hierarchical path _for
every_ ground type regardless of whether or not the hierarchical path is
used by a non-local annotation.  Previously, new hierarchical paths
would only be generated when used by non-local annotations.

This works by simplifying the way that annotations are updated in
LowerTypes.  Previously, this would update hierarchical paths when
examining annotations and keeping track of an "old symbol" to "new
symbol" mapping.  This commit changes the tracking to track "old
hw::InnerRefAttr" to "new Vector<AnnoTarget>".  This more closely
matches the lowering procedure (as LowerTypes is fundamentally a mapping
of one aggregate type to one or more ground types and results in a nice
simplification of the existing logic.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

Example from the added test:

```mlir
firrtl.circuit "PathsWithoutNLAsAreStillUpdated" {
  firrtl.hierpath @path_port [@PathsWithoutNLAsAreStillUpdated::@foo, @Foo::@a]
  firrtl.hierpath @path_wire [@PathsWithoutNLAsAreStillUpdated::@foo, @Foo::@b]

  firrtl.module @Foo(in %a : !firrtl.bundle<a : uint<1>, b : bundle<c : uint<2>>> sym @a) {
    %b = firrtl.wire sym @b {annotations = [{class = "hello"}]} : !firrtl.bundle<a : uint<1>, b : bundle<c : uint<2>>>
  }
  firrtl.module @PathsWithoutNLAsAreStillUpdated() {
    %foo_a = firrtl.instance foo sym @foo @Foo(in a : !firrtl.bundle<a : uint<1>, b : bundle<c : uint<2>>>)
  }
}
```

Running this through `LowerTypes` produces the following debugging information:

```
===- Running LowerTypes Pass ------------------------------------------------===
Recording Inner Symbol Renames:
  - Module: @Foo
    - @b: [@b_a, @b_b_c]
    - @a: [@a_a, @a_b_c]
Updating hierarhical paths:
  - original: firrtl.hierpath @path_port [@PathsWithoutNLAsAreStillUpdated::@foo, @Foo::@a]
    replacements:
      - firrtl.hierpath @path_port [@PathsWithoutNLAsAreStillUpdated::@foo, @Foo::@a_a]
      - firrtl.hierpath @path_port_0 [@PathsWithoutNLAsAreStillUpdated::@foo, @Foo::@a_b_c]
  - original: firrtl.hierpath @path_wire [@PathsWithoutNLAsAreStillUpdated::@foo, @Foo::@b]
    replacements:
      - firrtl.hierpath @path_wire [@PathsWithoutNLAsAreStillUpdated::@foo, @Foo::@b_a]
      - firrtl.hierpath @path_wire_0 [@PathsWithoutNLAsAreStillUpdated::@foo, @Foo::@b_b_c]
```

And the MLIR output:

```mlir
firrtl.circuit "PathsWithoutNLAsAreStillUpdated"  {
  firrtl.hierpath @path_port [@PathsWithoutNLAsAreStillUpdated::@foo, @Foo::@a_a]
  firrtl.hierpath @path_port_0 [@PathsWithoutNLAsAreStillUpdated::@foo, @Foo::@a_b_c]
  firrtl.hierpath @path_wire [@PathsWithoutNLAsAreStillUpdated::@foo, @Foo::@b_a]
  firrtl.hierpath @path_wire_0 [@PathsWithoutNLAsAreStillUpdated::@foo, @Foo::@b_b_c]
  firrtl.module @Foo(in %a_a: !firrtl.uint<1> sym @a_a, in %a_b_c: !firrtl.uint<2> sym @a_b_c) {
    %b_a = firrtl.wire sym @b_a  {annotations = [{class = "hello"}]} : !firrtl.uint<1>
    %b_b_c = firrtl.wire sym @b_b_c  {annotations = [{class = "hello"}]} : !firrtl.uint<2>
  }
  firrtl.module @PathsWithoutNLAsAreStillUpdated() {
    %foo_a_a, %foo_a_b_c = firrtl.instance foo sym @foo  @Foo(in a_a: !firrtl.uint<1>, in a_b_c: !firrtl.uint<2>)
  }
}
```