### PR TITLE
[StandardToHandshake] Always emit `extmemory`, even when unused

### DIFF
--- a/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
+++ b/lib/Conversion/StandardToHandshake/StandardToHandshake.cpp
@@ -1293,6 +1293,13 @@ HandshakeLowering::replaceMemoryOps(ConversionPatternRewriter &rewriter,
 
   std::vector<Operation *> opsToErase;
 
+  // Enrich the memRefOps context with BlockArguments, in case they aren't used.
+  for (auto arg : r.getArguments()) {
+    if (!arg.getType().isa<MemRefType>())
+      continue;
+    memRefOps.insert(std::make_pair(arg, std::vector<Operation *>()));
+  }
+
   // Replace load and store ops with the corresponding handshake ops
   // Need to traverse ops in blocks to store them in memRefOps in program
   // order

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -525,6 +525,16 @@ LogicalResult FuncOp::verify() {
   if (failed(verifyPortNameAttr("resNames", getNumResults())))
     return failure();
 
+  // Verify that all memrefs have a corresponding extmemory operation
+  for (auto arg : entryBlock.getArguments()) {
+    if (!arg.getType().isa<MemRefType>())
+      continue;
+    if (arg.getUsers().empty() ||
+        !isa<ExternalMemoryOp>(*arg.getUsers().begin()))
+      return emitOpError("expected that block argument #")
+             << arg.getArgNumber() << " is used by an 'extmemory' operation";
+  }
+
   return success();
 }
 

--- a/test/Conversion/StandardToHandshake/test_extmemory.mlir
+++ b/test/Conversion/StandardToHandshake/test_extmemory.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -lower-std-to-handshake %s | FileCheck %s
+// RUN: circt-opt -lower-std-to-handshake %s --split-input-file | FileCheck %s
 
 // CHECK-LABEL:   handshake.func @main(
 // CHECK-SAME:                         %[[VAL_0:.*]]: memref<4xi32>,
@@ -15,4 +15,14 @@ func.func @main(%mem : memref<4xi32>) -> i32 {
   %idx = arith.constant 0 : index
   %0 = memref.load %mem[%idx] : memref<4xi32>
   return %0 : i32
+}
+
+// -----
+
+// CHECK-LABEL: handshake.func @no_use(%arg0: memref<4xi32>, %arg1: none, ...) -> none
+// CHECK:    extmemory[ld = 0, st = 0] (%arg0 : memref<4xi32>) () {id = 0 : i32} : () -> ()
+// CHECK:    return %arg1 : none
+// CHECK:  }
+func.func @no_use(%mem : memref<4xi32>) {
+  return
 }

--- a/test/Dialect/Handshake/errors.mlir
+++ b/test/Dialect/Handshake/errors.mlir
@@ -243,3 +243,10 @@ handshake.func @invalid_pack_wrong_types(%arg0 : i64, %arg1 : i32, %ctrl : none)
   %0 = handshake.pack %arg0, %arg1 : i64, i32
   return %0, %ctrl : tuple<i64, i32>, none
 }
+
+// -----
+
+handshake.func @invalid_memref_block_arg(%arg0 : memref<2xi64>, %ctrl : none) -> none {
+  // expected-error @-1 {{'handshake.func' op expected that block argument #0 is used by an 'extmemory' operation}}
+  return %ctrl : none
+}


### PR DESCRIPTION
This PR ensures that all memrefs are connected to memory by initializing the `memRefOps` map with an empty vector for all block arguments. The map is later on used to produce `ExternalMemrefOps`. 

Fixes #3256 