### PR TITLE
[HW] Add HWRemoveUnusedPorts pass

### DIFF
--- a/include/circt/Dialect/SV/SVPasses.h
+++ b/include/circt/Dialect/SV/SVPasses.h
@@ -30,6 +30,7 @@ createHWMemSimImplPass(bool replSeqMem = false,
 std::unique_ptr<mlir::Pass> createSVExtractTestCodePass();
 std::unique_ptr<mlir::Pass>
 createHWExportModuleHierarchyPass(llvm::Optional<std::string> directory = {});
+std::unique_ptr<mlir::Pass> createHWRemoveUnusedPortsPass();
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/SV/SVPasses.h.inc"

--- a/include/circt/Dialect/SV/SVPasses.td
+++ b/include/circt/Dialect/SV/SVPasses.td
@@ -132,4 +132,12 @@ def HWExportModuleHierarchy : Pass<"hw-export-module-hierarchy",
    ];
 }
 
+def HWRemoveUnusedPorts : Pass<"hw-remove-unused-ports", "mlir::ModuleOp"> {
+  let summary = "Remove dead ports via intereprocedural dataflow analysis";
+  let constructor = "circt::sv::createHWRemoveUnusedPortsPass()";
+  let statistics = [
+    Statistic<"numRemovedPorts", "num-removed-ports", "Number of ports erased">,
+  ];
+}
+
 #endif // CIRCT_DIALECT_SV_SVPASSES

--- a/lib/Dialect/SV/Transforms/CMakeLists.txt
+++ b/lib/Dialect/SV/Transforms/CMakeLists.txt
@@ -4,6 +4,7 @@ add_circt_dialect_library(CIRCTSVTransforms
   HWStubExternalModules.cpp
   HWLegalizeModules.cpp
   HWMemSimImpl.cpp
+  HWRemoveUnusedPorts.cpp
   PrettifyVerilog.cpp
   SVExtractTestCode.cpp
   HWExportModuleHierarchy.cpp

--- a/lib/Dialect/SV/Transforms/HWRemoveUnusedPorts.cpp
+++ b/lib/Dialect/SV/Transforms/HWRemoveUnusedPorts.cpp
@@ -1,0 +1,418 @@
+//===- HWRemoveUnusedPorts.cpp - Remove Dead Ports --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements HWRemoveUnusedPorts pass which removes dead ports by
+// inspecting modules globally.
+//
+// 1. Input ports are dead if there is no user.
+// 2. Output ports are dead if output values are constant, or results are not
+//    used at any instance.
+// 3. Normal operations are deleted as well since erased ports can introduce
+//    extra dead code.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+#include "circt/Dialect/HW/HWAttributes.h"
+#include "circt/Dialect/HW/HWInstanceGraph.h"
+#include "circt/Dialect/SV/SVOps.h"
+#include "circt/Dialect/SV/SVPasses.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "llvm/ADT/APSInt.h"
+#include "llvm/ADT/PostOrderIterator.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "hw-remove-unused-ports"
+
+using namespace llvm;
+using namespace mlir;
+using namespace circt;
+using namespace hw;
+
+/// Return true if the port is deletable. Specifically, we cannot delete ports
+/// with symbols.
+static bool isDeletablePort(PortInfo port) {
+  return !port.sym || port.sym.getValue().empty();
+}
+
+/// Return true if the instance result is unused.
+static bool isOutputPortUnused(InstanceRecord *record, unsigned index) {
+  auto port = record->getInstance()->getResult(index);
+  return port.use_empty();
+}
+
+/// Return true if the output port is deletable. We can delete the port if the
+/// port doesn't have a symbol and its result value is not used at any instance.
+static bool isDeadOutputPort(HWModuleOp module, InstanceGraphNode *node,
+                             unsigned index) {
+  if (!isDeletablePort(module.getOutputPort(index)))
+    return false;
+
+  return llvm::all_of(node->uses(), [&](InstanceRecord *record) {
+    return isOutputPortUnused(record, index);
+  });
+}
+
+/// Return true if the input port is deletable. We can delete the port if
+/// there is no user and the port doesn't have a symbol.
+static bool isDeletableInputPort(HWModuleOp module, unsigned index) {
+  // If the port has use, we cannot delete the port.
+  if (!module.getArgument(index).use_empty())
+    return false;
+  if (!isDeletablePort(module.getInOrInoutPort(index)))
+    return false;
+
+  return true;
+}
+
+namespace {
+struct HWRemoveUnusedPortsPass
+    : public sv::HWRemoveUnusedPortsBase<HWRemoveUnusedPortsPass> {
+  void runOnOperation() override;
+
+  // A helper function to visit all private modules in the post-order of
+  // instance graph.
+  void visitPrivateModules(bool doFinalize);
+  void visitModule(HWModuleOp module, InstanceGraphNode *instanceGraphNode);
+
+  /// This function actually rewrites module definitions and their instances.
+  void finalize(HWModuleOp module, InstanceGraphNode *instanceGraphNode);
+
+  void visitValue(Value value);
+  void visitInputPort(StringAttr moduleName, unsigned index);
+  void visitOutputPort(StringAttr moduleName, unsigned index);
+
+  void addToWorklist(Value value) { worklist.insert(value); }
+
+  // Return a place holder for the given value. Values created by this function
+  // must be deleted at post-processing.
+  Value getDummyValue(Value value);
+
+  // Return a pair of module op and instance graph node if the module is a
+  // private module. If not, return a pair of nullptr.
+  std::pair<HWModuleOp, InstanceGraphNode *>
+  getModuleIfPrivate(StringAttr moduleName);
+
+  /// A worklist of values that might be dead. We have to use a set to avoid
+  /// double free. SetVector is used to make the pass deterministic.
+  llvm::SetVector<Value> worklist;
+
+  InstanceGraph *instanceGraph;
+  OpBuilder *builder;
+};
+} // namespace
+
+// Return a place holder for the given value. Values created by this function
+// must be deleted at post-processing.
+Value HWRemoveUnusedPortsPass::getDummyValue(Value value) {
+  builder->setInsertionPointAfterValue(value);
+  return builder
+      ->create<mlir::UnrealizedConversionCastOp>(
+          value.getLoc(), TypeRange{value.getType()}, ValueRange{})
+      .getResult(0);
+}
+
+// Return a pair of module op and instance graph node if the module is a
+// private module. If not, return a pair of nullptr.
+std::pair<HWModuleOp, InstanceGraphNode *>
+HWRemoveUnusedPortsPass::getModuleIfPrivate(StringAttr moduleName) {
+  auto *node = instanceGraph->lookup(moduleName);
+  if (!node || !node->getModule() || node->getModule().isPublic())
+    return {};
+
+  auto module = dyn_cast<HWModuleOp>(node->getModule());
+  return {module, node};
+}
+
+void HWRemoveUnusedPortsPass::visitOutputPort(StringAttr moduleName,
+                                              unsigned index) {
+  auto [module, node] = getModuleIfPrivate(moduleName);
+
+  if (!module || !isDeadOutputPort(module, node, index))
+    return;
+
+  // If the output port is dead, replace its corresponding operand of output op.
+  auto output = cast<OutputOp>(module.getBodyBlock()->getTerminator());
+  auto operand = output->getOperand(index);
+  output->setOperand(index, getDummyValue(operand));
+  addToWorklist(operand);
+}
+
+void HWRemoveUnusedPortsPass::visitInputPort(StringAttr moduleName,
+                                             unsigned index) {
+  auto [module, node] = getModuleIfPrivate(moduleName);
+
+  if (!module || !isDeletableInputPort(module, index))
+    return;
+
+  // If the input port is dead, traverse all uses and add their arguments
+  // to the worklist.
+  for (auto *use : node->uses()) {
+    if (!use->getInstance())
+      continue;
+    auto instance = dyn_cast<InstanceOp>(*use->getInstance());
+
+    if (!instance)
+      continue;
+    auto operand = instance.getOperand(index);
+    instance->setOperand(index, getDummyValue(operand));
+    addToWorklist(operand);
+  }
+}
+
+void HWRemoveUnusedPortsPass::visitValue(Value value) {
+  // If the value has an use, we cannot remove.
+  if (!value.use_empty())
+    return;
+
+  // If the value is a result of instance, the result may be dead in every
+  // instantiation.
+  if (auto instance = value.getDefiningOp<HWInstanceLike>())
+    return visitOutputPort(instance.referencedModuleNameAttr(),
+                           value.cast<mlir::OpResult>().getResultNumber());
+
+  if (auto inputPort = value.dyn_cast<BlockArgument>()) {
+    auto hwmodule =
+        dyn_cast<HWModuleLike>(inputPort.getParentBlock()->getParentOp());
+    if (!hwmodule)
+      return;
+    return visitInputPort(hwmodule.moduleNameAttr(), inputPort.getArgNumber());
+  }
+
+  // Otherwise, delete the value if its defining op is dead.
+  if (auto *op = value.getDefiningOp()) {
+    // If the op is dead, add its operands to the worklist.
+    if (isOpTriviallyDead(op)) {
+      for (auto operand : op->getOperands())
+        addToWorklist(operand);
+      op->erase();
+    }
+  }
+}
+
+void HWRemoveUnusedPortsPass::visitPrivateModules(bool doFinalize) {
+  for (auto *node : llvm::post_order(instanceGraph)) {
+    if (!node || !node->getModule() || node->getModule().isPublic())
+      continue;
+    auto module = dyn_cast<HWModuleOp>(node->getModule());
+    if (!module)
+      continue;
+
+    if (doFinalize)
+      finalize(module, node);
+    else
+      visitModule(module, node);
+  }
+}
+
+void HWRemoveUnusedPortsPass::runOnOperation() {
+  LLVM_DEBUG(llvm::dbgs() << "===----- Remove unused ports -----===\n");
+  instanceGraph = &getAnalysis<InstanceGraph>();
+  OpBuilder theBuilder(&getContext());
+  builder = &theBuilder;
+
+  visitPrivateModules(/*doFinalize=*/false);
+
+  while (!worklist.empty()) {
+    auto value = worklist.pop_back_val();
+    visitValue(value);
+  }
+
+  visitPrivateModules(/*doFinalize=*/true);
+}
+
+/// Remove elements at the specified indices from the input array, returning
+/// the elements not mentioned.  The indices array is expected to be sorted
+/// and unique.
+template <typename T, typename RandomAccessRange>
+static SmallVector<T>
+removeElementsAtIndices(RandomAccessRange input,
+                        ArrayRef<unsigned> indicesToDrop) {
+  // Copy over the live chunks.
+  size_t lastCopied = 0;
+  SmallVector<T> result;
+  result.reserve(input.size() - indicesToDrop.size());
+
+  for (unsigned indexToDrop : indicesToDrop) {
+    // If we skipped over some valid elements, copy them over.
+    if (indexToDrop > lastCopied) {
+      result.append(input.begin() + lastCopied, input.begin() + indexToDrop);
+      lastCopied = indexToDrop;
+    }
+    // Ignore this value so we don't copy it in the next iteration.
+    ++lastCopied;
+  }
+
+  // If there are live elements at the end, copy them over.
+  if (lastCopied < input.size())
+    result.append(input.begin() + lastCopied, input.end());
+
+  return result;
+}
+
+void HWRemoveUnusedPortsPass::finalize(HWModuleOp module,
+                                       InstanceGraphNode *instanceGraphNode) {
+  LLVM_DEBUG(llvm::dbgs() << "Prune ports of module: " << module.getName()
+                          << "\n");
+  SmallVector<unsigned> removalInputPortIndexes;
+  SmallVector<unsigned> removalOutputPortIndexes;
+
+  SmallDenseSet<Operation *, 4> deadOperations;
+  auto addMayDeadValue = [&](Value v) {
+    if (auto *op = v.getDefiningOp())
+      deadOperations.insert(op);
+  };
+
+  for (auto index : llvm::seq(0u, module.getNumResults()))
+    if (isDeadOutputPort(module, instanceGraphNode, index))
+      removalOutputPortIndexes.push_back(index);
+
+  auto output = cast<OutputOp>(module.getBodyBlock()->getTerminator());
+  builder->setInsertionPoint(output);
+  if (!removalOutputPortIndexes.empty()) {
+    auto newOutput = removeElementsAtIndices<Value>(output.operands(),
+                                                    removalOutputPortIndexes);
+    builder->create<hw::OutputOp>(output.getLoc(), newOutput);
+    for (auto index : removalOutputPortIndexes)
+      addMayDeadValue(output.getOperand(index));
+    output.erase();
+  }
+
+  // Traverse input ports.
+  for (auto index : llvm::seq(0u, module.getNumArguments()))
+    if (isDeletableInputPort(module, index))
+      removalInputPortIndexes.push_back(index);
+
+  // If there is nothing to remove, abort.
+  if (removalInputPortIndexes.empty() && removalOutputPortIndexes.empty())
+    return;
+
+  // Delete ports from the module.
+  module.erasePorts(removalInputPortIndexes, removalOutputPortIndexes);
+
+  // Delete arguments. It is necessary to remove the argument in the reverse
+  // order of `removalInputPortIndexes`.
+  for (auto arg : llvm::reverse(removalInputPortIndexes))
+    module.getBody().eraseArgument(arg);
+
+  // Rewrite all uses.
+  for (auto *use : instanceGraphNode->uses()) {
+    auto instance = dyn_cast<InstanceOp>(*use->getInstance());
+    if (!instance)
+      continue;
+    for (auto c : removalInputPortIndexes)
+      addMayDeadValue(instance.getOperand(c));
+
+    builder->setInsertionPoint(instance);
+    // Create a new instance op without unused ports.
+    auto newInstance = instance.erasePorts(*builder, removalInputPortIndexes,
+                                           removalOutputPortIndexes);
+
+    instanceGraph->replaceInstance(instance, newInstance);
+    // Remove old one.
+    instance.erase();
+  }
+
+  for (auto *op : deadOperations)
+    if (isOpTriviallyDead(op))
+      op->erase();
+
+  numRemovedPorts += removalInputPortIndexes.size();
+  numRemovedPorts += removalOutputPortIndexes.size();
+}
+
+void HWRemoveUnusedPortsPass::visitModule(
+    HWModuleOp module, InstanceGraphNode *instanceGraphNode) {
+  LLVM_DEBUG(llvm::dbgs() << "Preprocess module: " << module.getName() << "\n");
+  // These track port indexes that can be erased.
+  SmallVector<unsigned> removalInputPortIndexes;
+  SmallVector<unsigned> removalOutputPortIndexes;
+
+  // This tracks constant values of output ports.
+  SmallVector<llvm::Optional<APInt>> outputPortConstants;
+  auto ports = module.getPorts();
+
+  // Traverse output ports.
+  auto output = cast<OutputOp>(module.getBodyBlock()->getTerminator());
+  for (auto e : llvm::enumerate(ports.outputs)) {
+    unsigned index = e.index();
+    auto port = e.value();
+    if (!isDeletablePort(port))
+      continue;
+
+    // If the output port has no user at any instance, the port is dead.
+    if (llvm::all_of(instanceGraphNode->uses(), [&](auto record) {
+          return isOutputPortUnused(record, index);
+        })) {
+      outputPortConstants.push_back(None);
+      removalOutputPortIndexes.push_back(index);
+      auto result = output.getOperand(index);
+      // Replace a curresponding operand with a dummy value.
+      output.setOperand(index, getDummyValue(result));
+      addToWorklist(result);
+      continue;
+    }
+
+    // If the output value is constant, we can forward it into caller side.
+    auto *src = output.getOperand(index).getDefiningOp();
+    if (!isa_and_nonnull<hw::ConstantOp, sv::ConstantXOp>(src))
+      continue;
+
+    if (auto constant = dyn_cast<hw::ConstantOp>(src))
+      outputPortConstants.push_back(constant.value());
+    else
+      outputPortConstants.push_back(None);
+
+    removalOutputPortIndexes.push_back(index);
+    addToWorklist(output->getOperand(index));
+  }
+
+  for (auto index : llvm::seq(0u, module.getNumArguments()))
+    if (isDeletableInputPort(module, index))
+      removalInputPortIndexes.push_back(index);
+
+  // If there is nothing to remove, abort.
+  if (removalInputPortIndexes.empty() && removalOutputPortIndexes.empty())
+    return;
+
+  // Rewrite all uses.
+  for (auto *use : instanceGraphNode->uses()) {
+    auto instance = dyn_cast<InstanceOp>(*use->getInstance());
+    if (!instance)
+      continue;
+
+    for (auto [index, constant] :
+         llvm::zip(removalOutputPortIndexes, outputPortConstants)) {
+      auto result = instance.getResult(index);
+      if (result.use_empty())
+        continue;
+
+      builder->setInsertionPoint(instance);
+      Value value;
+      if (constant)
+        value = builder->create<hw::ConstantOp>(result.getLoc(), *constant);
+      else
+        value =
+            builder->create<sv::ConstantXOp>(result.getLoc(), result.getType());
+
+      result.replaceAllUsesWith(value);
+    }
+
+    // Replace instance arguments with dummy values.
+    for (auto inputPort : removalInputPortIndexes) {
+      auto operand = instance.getOperand(inputPort);
+      instance.setOperand(inputPort, getDummyValue(operand));
+      addToWorklist(operand);
+    }
+  }
+}
+
+std::unique_ptr<mlir::Pass> circt::sv::createHWRemoveUnusedPortsPass() {
+  return std::make_unique<HWRemoveUnusedPortsPass>();
+}

--- a/test/Dialect/SV/hw-remove-unused-ports.mlir
+++ b/test/Dialect/SV/hw-remove-unused-ports.mlir
@@ -1,0 +1,88 @@
+// RUN: circt-opt -hw-remove-unused-ports --split-input-file %s | FileCheck %s
+
+module {
+  // CHECK-LABEL: private @Child2() {
+  hw.module private @Child2(%in: i1) {
+    // CHECK-NEXT: hw.output
+    hw.output
+  }
+
+  // CHECK-LABEL: private @Child1() {
+  hw.module private @Child1(%in: i1) -> (out: i1) {
+    // CHECK-NEXT: hw.output
+    hw.output %in : i1
+  }
+
+  // CHECK-LABEL: hw.module @Parent(%in: i1)
+  hw.module @Parent(%in: i1) {
+    // CHECK-NEXT: hw.instance "child1" @Child1() -> ()
+    %child1.out = hw.instance "child1" @Child1(in: %in: i1) -> (out: i1)
+    // CHECK-NEXT: hw.instance "child2" @Child2() -> ()
+    hw.instance "child2" @Child2(in: %child1.out: i1) -> ()
+    // CHECK-NEXT: hw.output
+    hw.output
+  }
+}
+
+// -----
+module {
+  // CHECK-LABEL: hw.module @Top(%a: i1, %b: i1) -> (c: i1, d_unused: i1, d_invalid: i1, d_constant: i1)
+  hw.module @Top(%a: i1, %b: i1) -> (c: i1, d_unused: i1, d_invalid: i1, d_constant: i1) {
+    // Check that constants are forwarded to the caller.
+    // CHECK-NEXT: %x_i1 = sv.constantX
+    // CHECK-NEXT: %false = hw.constant false
+    // CHECK-NEXT: %A.c = hw.instance "A" @UseBar(b: %b: i1) -> (c: i1)
+    // CHECK-NEXT: hw.instance "B" @UseFoo(a: %a: i1)
+    // CHECK-NEXT: hw.output %A.c, %A.c, %x_i1, %false
+    %A.c, %A.d_unused, %A.d_invalid, %A.d_constant = hw.instance "A" @UseBar(a: %a: i1, b: %b: i1) -> (c: i1, d_unused: i1, d_invalid: i1, d_constant: i1)
+    %B.c = hw.instance "B" @UseFoo(a: %a: i1) -> (c: i1)
+    hw.output %A.c, %A.c, %A.d_invalid, %A.d_constant : i1, i1, i1, i1
+  }
+
+  // CHECK-LABEL: hw.module private @Bar(%b: i1) -> (c: i1)
+  hw.module private @Bar(%a: i1, %b: i1) -> (c: i1, d_unused: i1, d_invalid: i1, d_constant: i1) {
+    // CHECK-NEXT: hw.output %b : i1
+    %x = sv.constantX : i1
+    %false = hw.constant false
+    hw.output %b, %b, %x, %false : i1, i1, i1, i1
+  }
+
+  // CHECK-LABEL: hw.module private @UseBar(%b: i1) -> (c: i1)
+  hw.module private @UseBar(%a: i1, %b: i1) -> (c: i1, d_unused: i1, d_invalid: i1, d_constant: i1) {
+    // CHECK-NEXT: %A.c = hw.instance "A" @Bar(b: %b: i1) -> (c: i1)
+    // CHECK-NEXT: hw.output %A.c : i1
+    %A.c, %A.d_unused, %A.d_invalid, %A.d_constant = hw.instance "A" @Bar(a: %a: i1, b: %b: i1) -> (c: i1, d_unused: i1, d_invalid: i1, d_constant: i1)
+    hw.output %A.c, %A.d_unused, %A.d_invalid, %A.d_constant : i1, i1, i1, i1
+  }
+  // Check that %a and %c are not erased.
+  // CHECK-LABEL: hw.module private @Foo(%a: i1 {hw.exportPort = @dntSym}) -> (c: i1 {hw.exportPort = @dntSym})
+  hw.module private @Foo(%a: i1 {hw.exportPort = @dntSym}) -> (c: i1 {hw.exportPort = @dntSym}) {
+    %false = hw.constant false
+    // CHECK:  hw.output %false
+    hw.output %false : i1
+  }
+
+  // CHECK-LABEL: hw.module private @UseFoo(%a: i1) {
+  hw.module private @UseFoo(%a: i1) -> (c: i1) {
+    // CHECK-NEXT:  %A.c = hw.instance "A" @Foo(a: %a: i1) -> (c: i1)
+    // CHECK-NEXT:  hw.output
+    %A.c = hw.instance "A" @Foo(a: %a: i1) -> (c: i1)
+    hw.output %A.c : i1
+  }
+}
+
+// -----
+// Check that output_file attributes are preserved.
+module {
+  // CHECK-LABEL: @Sub() attributes {output_file = #hw.output_file<"hello">}
+  hw.module private @Sub(%a: i1) attributes {output_file = #hw.output_file<"hello">} {
+    hw.output
+  }
+  hw.module @PreserveOutputFile() {
+    %.a.wire = sv.wire  : !hw.inout<i1>
+    %0 = sv.read_inout %.a.wire : !hw.inout<i1>
+    // CHECK: hw.instance "sub" @Sub() -> () {output_file = #hw.output_file<"hello">}
+    hw.instance "sub" @Sub(a: %0: i1) -> () {output_file = #hw.output_file<"hello">}
+    hw.output
+  }
+}

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -561,6 +561,8 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
   if (!disableOptimization) {
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
         createSimpleCanonicalizerPass());
+    // TODO: Remove RemoveUnusedPortsPass at FIRRTL once it is confirmed that
+    //       HWRemoveUnusedPortsPass works well.
     if (removeUnusedPorts)
       pm.nest<firrtl::CircuitOp>().addPass(
           firrtl::createRemoveUnusedPortsPass());
@@ -598,6 +600,8 @@ processBuffer(MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
         modulePM.addPass(createCSEPass());
         modulePM.addPass(sv::createHWCleanupPass());
       }
+      if (removeUnusedPorts)
+        pm.addPass(circt::sv::createHWRemoveUnusedPortsPass());
     }
   }
 


### PR DESCRIPTION
This PR is based on https://github.com/llvm/circt/pull/3251.
This commit implements HWRemoveUnusedPorts which removes dead ports
of private modules by inspecting dataflow globally in a similar way to
llvm::DeadArgumentsElimination pass. We use worklist based algorithm to
get optimal results.

1. Input ports are dead if there is no user.
2. Output ports are dead if output values are constant, or results are not
   used at any instance.
3. It is necessary to delete normal operations as well since erased ports can
   introduce extra dead code.

Example:
`circt-opt hw-remove-unused-ports`
```mlir
  hw.module private @Child2(%in: i1) {
    hw.output
  }
  hw.module private @Child1(%in: i1) -> (out: i1) {
    hw.output %in : i1
  }
  hw.module @Parent(%in: i1) {
    %child1.out = hw.instance "child1" @Child1(in: %in: i1) -> (out: i1)
    hw.instance "child2" @Child2(in: %child1.out: i1) -> ()
    hw.output
  }
```
becomes
```mlir
hw.module private @Child2() {
    hw.output
 }
 hw.module private @Child1() {
    hw.output
 }
 hw.module @Parent(%in: i1) {
    hw.instance "child1" @Child1() -> ()
    hw.instance "child2" @Child2() -> ()
    hw.output
 }
```

Close https://github.com/llvm/circt/issues/3146