### PR TITLE
[FIRRTL] Fix bug in unmasked RW memory lowering

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
@@ -408,7 +408,7 @@ InstanceOp LowerMemoryPass::emitMemoryInstance(MemOp op, FModuleOp module,
         if (summary.isMasked)
           addPort(Direction::In, "wmask", getType(summary.maskBits));
         else
-          removeMask("en", "wmask");
+          removeMask("wmode", "wmask");
       } else {
         addPort(Direction::In, "addr", addressType);
         addPort(Direction::In, "en", ui1Type);

--- a/test/Dialect/FIRRTL/lower-memory.mlir
+++ b/test/Dialect/FIRRTL/lower-memory.mlir
@@ -188,7 +188,7 @@ firrtl.circuit "MemDepth1" {
 
 // CHECK-LABEL: firrtl.circuit "inferUnmaskedMemory"
 firrtl.circuit "inferUnmaskedMemory" {
-  firrtl.module @inferUnmaskedMemory(in %clock: !firrtl.clock, in %rAddr: !firrtl.uint<4>, in %rEn: !firrtl.uint<1>, out %rData: !firrtl.uint<8>, in %wMask: !firrtl.uint<1>, in %wData: !firrtl.uint<8>) {
+  firrtl.module @inferUnmaskedMemory(in %clock: !firrtl.clock, in %rAddr: !firrtl.uint<4>, in %rEn: !firrtl.uint<1>, out %rData: !firrtl.uint<8>, in %wMode: !firrtl.uint<1>, in %wMask: !firrtl.uint<1>, in %wData: !firrtl.uint<8>) {
     %tbMemoryKind1_r, %tbMemoryKind1_w = firrtl.mem Undefined  {depth = 16 : i64, modName = "tbMemoryKind1_ext", name = "tbMemoryKind1", portNames = ["r", "w"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
     %0 = firrtl.subfield %tbMemoryKind1_w(3) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.uint<8>
     %1 = firrtl.subfield %tbMemoryKind1_w(4) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>) -> !firrtl.uint<1>
@@ -210,6 +210,17 @@ firrtl.circuit "inferUnmaskedMemory" {
     firrtl.connect %0, %wData : !firrtl.uint<8>, !firrtl.uint<8>
     // CHECK: [[AND:%.+]] = firrtl.and %wMask, %rEn
     // CHECK: firrtl.connect %tbMemoryKind1_W0_en, %0
+    %MReadWrite_readwrite = firrtl.mem Undefined {depth = 12 : i64, name = "MReadWrite", portNames = ["readwrite"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
+    %rw_en = firrtl.subfield %MReadWrite_readwrite(1) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<1>
+    %rw_wmode = firrtl.subfield %MReadWrite_readwrite(4) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<1>
+    %rw_mask = firrtl.subfield %MReadWrite_readwrite(6) : (!firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>) -> !firrtl.uint<1>
+    firrtl.connect %rw_en, %rEn : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %rw_wmode, %wMode : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.connect %rw_mask, %wMask : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK:  %[[MReadWrite_RW0_addr:.+]], %[[MReadWrite_RW0_en:.+]], %[[MReadWrite_RW0_clk:.+]], %[[MReadWrite_RW0_wmode:.+]], %[[MReadWrite_RW0_wdata:.+]], %[[MReadWrite_RW0_rdata:.+]] = firrtl.instance MReadWrite  @MReadWrite
+    // CHECK:   firrtl.connect %[[MReadWrite_RW0_en]], %rEn : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK:   %1 = firrtl.and %wMask, %wMode : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK:   firrtl.connect %[[MReadWrite_RW0_wmode]], %1 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
 


### PR DESCRIPTION
This commit fixes an issue with lowering unmasked RW memories.
If a memory has a single bit mask, then the mask bit can be removed and combined with the write enable.
But if the memory is a ReadWrite memory, then the enable port is used for both read and write enable. For such a ReadWrite memory we cannot combine the write mask with the enable, it has to be combined with the Write Mode.
Such that if the mask bit is disabled, then the write should be disabled.