### PR TITLE
[SCFToCalyx] [StaticLogicToCalyx] Reduce templating in interfaces.

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
+++ b/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
@@ -228,7 +228,7 @@ class ComponentLoweringStateInterface {
 public:
   ComponentLoweringStateInterface(calyx::ComponentOp component);
 
-  virtual ~ComponentLoweringStateInterface();
+  ~ComponentLoweringStateInterface();
 
   /// Returns the calyx::ComponentOp associated with this lowering state.
   calyx::ComponentOp getComponentOp();

--- a/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
+++ b/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
@@ -490,7 +490,7 @@ public:
 
   /// Partial lowering implementation.
   virtual LogicalResult
-  PartiallyLowerFuncToComp(mlir::func::FuncOp funcOp,
+  partiallyLowerFuncToComp(mlir::func::FuncOp funcOp,
                            PatternRewriter &rewriter) const = 0;
 
 protected:
@@ -508,7 +508,7 @@ class ConvertIndexTypes : public calyx::FuncOpPartialLoweringPattern {
   using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
 
   LogicalResult
-  PartiallyLowerFuncToComp(mlir::func::FuncOp funcOp,
+  partiallyLowerFuncToComp(mlir::func::FuncOp funcOp,
                            PatternRewriter &rewriter) const override;
 };
 

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -139,7 +139,7 @@ class BuildOpGroups : public calyx::FuncOpPartialLoweringPattern {
   using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
 
   LogicalResult
-  PartiallyLowerFuncToComp(FuncOp funcOp,
+  partiallyLowerFuncToComp(FuncOp funcOp,
                            PatternRewriter &rewriter) const override {
     /// We walk the operations of the funcOp to ensure that all def's have
     /// been visited before their uses.
@@ -790,7 +790,7 @@ struct FuncOpConversion : public calyx::FuncOpPartialLoweringPattern {
   using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
 
   LogicalResult
-  PartiallyLowerFuncToComp(FuncOp funcOp,
+  partiallyLowerFuncToComp(FuncOp funcOp,
                            PatternRewriter &rewriter) const override {
     /// Maintain a mapping between funcOp input arguments and the port index
     /// which the argument will eventually map to.
@@ -902,7 +902,7 @@ class BuildWhileGroups : public calyx::FuncOpPartialLoweringPattern {
   using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
 
   LogicalResult
-  PartiallyLowerFuncToComp(FuncOp funcOp,
+  partiallyLowerFuncToComp(FuncOp funcOp,
                            PatternRewriter &rewriter) const override {
     LogicalResult res = success();
     funcOp.walk([&](Operation *op) {
@@ -988,7 +988,7 @@ class BuildBBRegs : public calyx::FuncOpPartialLoweringPattern {
   using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
 
   LogicalResult
-  PartiallyLowerFuncToComp(FuncOp funcOp,
+  partiallyLowerFuncToComp(FuncOp funcOp,
                            PatternRewriter &rewriter) const override {
     funcOp.walk([&](Block *block) {
       /// Do not register component input values.
@@ -1018,7 +1018,7 @@ class BuildReturnRegs : public calyx::FuncOpPartialLoweringPattern {
   using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
 
   LogicalResult
-  PartiallyLowerFuncToComp(FuncOp funcOp,
+  partiallyLowerFuncToComp(FuncOp funcOp,
                            PatternRewriter &rewriter) const override {
 
     for (auto argType : enumerate(funcOp.getResultTypes())) {
@@ -1052,7 +1052,7 @@ class BuildControl : public calyx::FuncOpPartialLoweringPattern {
   using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
 
   LogicalResult
-  PartiallyLowerFuncToComp(FuncOp funcOp,
+  partiallyLowerFuncToComp(FuncOp funcOp,
                            PatternRewriter &rewriter) const override {
     auto *entryBlock = &funcOp.getBlocks().front();
     rewriter.setInsertionPointToStart(getComponent()->getControlOp().getBody());
@@ -1311,7 +1311,7 @@ private:
 class LateSSAReplacement : public calyx::FuncOpPartialLoweringPattern {
   using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
 
-  LogicalResult PartiallyLowerFuncToComp(FuncOp funcOp,
+  LogicalResult partiallyLowerFuncToComp(FuncOp funcOp,
                                          PatternRewriter &) const override {
     funcOp.walk([&](scf::WhileOp op) {
       /// The yielded values returned from the while op will be present in the
@@ -1349,7 +1349,7 @@ class CleanupFuncOps : public calyx::FuncOpPartialLoweringPattern {
   using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
 
   LogicalResult
-  PartiallyLowerFuncToComp(FuncOp funcOp,
+  partiallyLowerFuncToComp(FuncOp funcOp,
                            PatternRewriter &rewriter) const override {
     rewriter.eraseOp(funcOp);
     return success();

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -130,76 +130,12 @@ private:
 };
 
 //===----------------------------------------------------------------------===//
-// Partial lowering patterns
-//===----------------------------------------------------------------------===//
-
-/// FuncOpPartialLoweringPatterns are patterns which intend to match on FuncOps
-/// and then perform their own walking of the IR. FuncOpPartialLoweringPatterns
-/// have direct access to the ComponentLoweringState for the corresponding
-/// component of the matched FuncOp.
-class FuncOpPartialLoweringPattern
-    : public calyx::PartialLoweringPattern<FuncOp> {
-public:
-  FuncOpPartialLoweringPattern(MLIRContext *context, LogicalResult &resRef,
-                               FuncMapping &map,
-                               calyx::ProgramLoweringState &pls)
-      : PartialLoweringPattern(context, resRef), funcMap(map), pls(pls) {}
-
-  LogicalResult partiallyLower(FuncOp funcOp,
-                               PatternRewriter &rewriter) const override final {
-    // Initialize the component op references if a calyx::ComponentOp has been
-    // created for the matched funcOp.
-    if (auto it = funcMap.find(funcOp); it != funcMap.end()) {
-      componentOp = &it->second;
-      compLoweringState = pls.getState<ComponentLoweringState>(*getComponent());
-    }
-
-    return PartiallyLowerFuncToComp(funcOp, rewriter);
-  }
-
-  // Returns the component operation associated with the currently executing
-  // partial lowering.
-  calyx::ComponentOp *getComponent() const {
-    assert(
-        componentOp != nullptr &&
-        "Expected component op to have been set during pattern construction");
-    return componentOp;
-  }
-
-  // Returns the component state associated with the currently executing
-  // partial lowering.
-  template <typename T>
-  T &getState() const {
-    static_assert(
-        std::is_convertible_v<T, calyx::ComponentLoweringStateInterface>);
-    assert(compLoweringState != nullptr &&
-           "Expected component lowering state to have been set during pattern "
-           "construction");
-    return *static_cast<T *>(compLoweringState);
-  }
-
-  calyx::ProgramLoweringState &programState() const { return pls; }
-
-  /// Partial lowering implementation.
-  virtual LogicalResult
-  PartiallyLowerFuncToComp(FuncOp funcOp, PatternRewriter &rewriter) const = 0;
-
-protected:
-  FuncMapping &funcMap;
-
-private:
-  mutable calyx::ComponentOp *componentOp = nullptr;
-  mutable calyx::ComponentLoweringStateInterface *compLoweringState = nullptr;
-  calyx::ProgramLoweringState &pls;
-};
-
-//===----------------------------------------------------------------------===//
 // Conversion patterns
 //===----------------------------------------------------------------------===//
 
 /// Iterate through the operations of a source function and instantiate
 /// components or primitives based on the type of the operations.
-class BuildOpGroups : public FuncOpPartialLoweringPattern {
+class BuildOpGroups : public calyx::FuncOpPartialLoweringPattern {
   using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
 
   LogicalResult
@@ -798,38 +734,6 @@ private:
   calyx::ProgramLoweringState &pls;
 };
 
-/// Connverts all index-typed operations and values to i32 values.
-class ConvertIndexTypes : public FuncOpPartialLoweringPattern {
-  using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
-
-  LogicalResult
-  PartiallyLowerFuncToComp(FuncOp funcOp,
-                           PatternRewriter &rewriter) const override {
-    funcOp.walk([&](Block *block) {
-      for (auto arg : block->getArguments())
-        arg.setType(calyx::convIndexType(rewriter, arg.getType()));
-    });
-
-    funcOp.walk([&](Operation *op) {
-      for (auto res : op->getResults()) {
-        auto resType = res.getType();
-        if (!resType.isIndex())
-          continue;
-
-        res.setType(calyx::convIndexType(rewriter, resType));
-        if (auto constOp = dyn_cast<arith::ConstantOp>(op)) {
-          APInt value;
-          calyx::matchConstantOp(constOp, value);
-          rewriter.setInsertionPoint(constOp);
-          rewriter.replaceOpWithNewOp<arith::ConstantOp>(
-              constOp, rewriter.getI32IntegerAttr(value.getSExtValue()));
-        }
-      }
-    });
-    return success();
-  }
-};
-
 /// Inlines Calyx ExecuteRegionOp operations within their parent blocks.
 /// An execution region op (ERO) is inlined by:
 ///  i  : add a sink basic block for all yield operations inside the
@@ -881,73 +785,8 @@ class InlineExecuteRegionOpPattern
   }
 };
 
-static void
-appendPortsForExternalMemref(PatternRewriter &rewriter, StringRef memName,
-                             Value memref, unsigned memoryID,
-                             SmallVectorImpl<calyx::PortInfo> &inPorts,
-                             SmallVectorImpl<calyx::PortInfo> &outPorts) {
-  MemRefType memrefType = memref.getType().cast<MemRefType>();
-
-  /// Ports constituting a memory interface are added a set of attributes under
-  /// a "mem : {...}" dictionary. These attributes allows for deducing which
-  /// top-level I/O signals constitutes a unique memory interface.
-  auto getMemoryInterfaceAttr = [&](StringRef tag,
-                                    Optional<unsigned> addrIdx = {}) {
-    auto attrs = SmallVector<NamedAttribute>{
-        /// "id" denotes a unique memory interface.
-        rewriter.getNamedAttr("id", rewriter.getI32IntegerAttr(memoryID)),
-        /// "tag" denotes the function of this signal.
-        rewriter.getNamedAttr("tag", rewriter.getStringAttr(tag))};
-    if (addrIdx.hasValue())
-      /// "addr_idx" denotes the address index of this signal, for
-      /// multi-dimensional memory interfaces.
-      attrs.push_back(rewriter.getNamedAttr(
-          "addr_idx", rewriter.getI32IntegerAttr(addrIdx.getValue())));
-
-    return rewriter.getNamedAttr("mem", rewriter.getDictionaryAttr(attrs));
-  };
-
-  /// Read data
-  inPorts.push_back(calyx::PortInfo{
-      rewriter.getStringAttr(memName + "_read_data"),
-      memrefType.getElementType(), calyx::Direction::Input,
-      DictionaryAttr::get(rewriter.getContext(),
-                          {getMemoryInterfaceAttr("read_data")})});
-
-  /// Done
-  inPorts.push_back(
-      calyx::PortInfo{rewriter.getStringAttr(memName + "_done"),
-                      rewriter.getI1Type(), calyx::Direction::Input,
-                      DictionaryAttr::get(rewriter.getContext(),
-                                          {getMemoryInterfaceAttr("done")})});
-
-  /// Write data
-  outPorts.push_back(calyx::PortInfo{
-      rewriter.getStringAttr(memName + "_write_data"),
-      memrefType.getElementType(), calyx::Direction::Output,
-      DictionaryAttr::get(rewriter.getContext(),
-                          {getMemoryInterfaceAttr("write_data")})});
-
-  /// Memory address outputs
-  for (auto dim : enumerate(memrefType.getShape())) {
-    outPorts.push_back(calyx::PortInfo{
-        rewriter.getStringAttr(memName + "_addr" + std::to_string(dim.index())),
-        rewriter.getIntegerType(calyx::handleZeroWidth(dim.value())),
-        calyx::Direction::Output,
-        DictionaryAttr::get(rewriter.getContext(),
-                            {getMemoryInterfaceAttr("addr", dim.index())})});
-  }
-
-  /// Write enable
-  outPorts.push_back(calyx::PortInfo{
-      rewriter.getStringAttr(memName + "_write_en"), rewriter.getI1Type(),
-      calyx::Direction::Output,
-      DictionaryAttr::get(rewriter.getContext(),
-                          {getMemoryInterfaceAttr("write_en")})});
-}
-
 /// Creates a new Calyx component for each FuncOp in the program.
-struct FuncOpConversion : public FuncOpPartialLoweringPattern {
+struct FuncOpConversion : public calyx::FuncOpPartialLoweringPattern {
   using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
 
   LogicalResult
@@ -966,7 +805,7 @@ struct FuncOpConversion : public FuncOpPartialLoweringPattern {
     /// map to the memory ports. The pair denotes the start index of the memory
     /// ports in the in- and output ports of the component. Ports are expected
     /// to be ordered in the same manner as they are added by
-    /// appendPortsForExternalMemref.
+    /// calyx::appendPortsForExternalMemref.
     DenseMap<Value, std::pair<unsigned, unsigned>> extMemoryCompPortIndices;
 
     /// Create I/O ports. Maintain separate in/out port vectors to determine
@@ -981,8 +820,8 @@ struct FuncOpConversion : public FuncOpPartialLoweringPattern {
             "ext_mem" + std::to_string(extMemoryCompPortIndices.size());
         extMemoryCompPortIndices[arg.value()] = {inPorts.size(),
                                                  outPorts.size()};
-        appendPortsForExternalMemref(rewriter, memName, arg.value(),
-                                     extMemCounter++, inPorts, outPorts);
+        calyx::appendPortsForExternalMemref(rewriter, memName, arg.value(),
+                                            extMemCounter++, inPorts, outPorts);
       } else {
         /// Single-port arguments
         auto inName = "in" + std::to_string(arg.index());
@@ -1016,7 +855,7 @@ struct FuncOpConversion : public FuncOpPartialLoweringPattern {
     compOp->setAttr("toplevel", rewriter.getUnitAttr());
 
     /// Store the function-to-component mapping.
-    funcMap[funcOp] = compOp;
+    functionMapping[funcOp] = compOp;
     auto *compState = programState().getState<ComponentLoweringState>(compOp);
     compState->setFuncOpResultMapping(funcOpResultMapping);
 
@@ -1059,7 +898,7 @@ struct FuncOpConversion : public FuncOpPartialLoweringPattern {
 /// the while op. These registers are then written to on the while op
 /// terminating yield operation alongside before executing the whileOp in the
 /// schedule, to set the initial values of the argument registers.
-class BuildWhileGroups : public FuncOpPartialLoweringPattern {
+class BuildWhileGroups : public calyx::FuncOpPartialLoweringPattern {
   using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
 
   LogicalResult
@@ -1145,7 +984,7 @@ class BuildWhileGroups : public FuncOpPartialLoweringPattern {
 };
 
 /// Builds registers for each block argument in the program.
-class BuildBBRegs : public FuncOpPartialLoweringPattern {
+class BuildBBRegs : public calyx::FuncOpPartialLoweringPattern {
   using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
 
   LogicalResult
@@ -1175,7 +1014,7 @@ class BuildBBRegs : public FuncOpPartialLoweringPattern {
 
 /// Builds registers for the return statement of the program and constant
 /// assignments to the component return value.
-class BuildReturnRegs : public FuncOpPartialLoweringPattern {
+class BuildReturnRegs : public calyx::FuncOpPartialLoweringPattern {
   using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
 
   LogicalResult
@@ -1209,7 +1048,7 @@ class BuildReturnRegs : public FuncOpPartialLoweringPattern {
 /// For simplicity, the generated control flow is expanded for all possible
 /// paths in the input DAG. This elaborated control flow is later reduced in
 /// the runControlFlowSimplification passes.
-class BuildControl : public FuncOpPartialLoweringPattern {
+class BuildControl : public calyx::FuncOpPartialLoweringPattern {
   using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
 
   LogicalResult
@@ -1469,7 +1308,7 @@ private:
 
 /// LateSSAReplacement contains various functions for replacing SSA values that
 /// were not replaced during op construction.
-class LateSSAReplacement : public FuncOpPartialLoweringPattern {
+class LateSSAReplacement : public calyx::FuncOpPartialLoweringPattern {
   using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
 
   LogicalResult PartiallyLowerFuncToComp(FuncOp funcOp,
@@ -1506,7 +1345,7 @@ class LateSSAReplacement : public FuncOpPartialLoweringPattern {
 };
 
 /// Erases FuncOp operations.
-class CleanupFuncOps : public FuncOpPartialLoweringPattern {
+class CleanupFuncOps : public calyx::FuncOpPartialLoweringPattern {
   using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
 
   LogicalResult
@@ -1769,7 +1608,8 @@ void SCFToCalyxPass::runOnOperation() {
   addGreedyPattern<InlineExecuteRegionOpPattern>(loweringPatterns);
 
   /// This pattern converts all index typed values to an i32 integer.
-  addOncePattern<ConvertIndexTypes>(loweringPatterns, funcMap, *loweringState);
+  addOncePattern<calyx::ConvertIndexTypes>(loweringPatterns, funcMap,
+                                           *loweringState);
 
   /// This pattern creates registers for all basic-block arguments.
   addOncePattern<BuildBBRegs>(loweringPatterns, funcMap, *loweringState);

--- a/lib/Conversion/StaticLogicToCalyx/StaticLogicToCalyx.cpp
+++ b/lib/Conversion/StaticLogicToCalyx/StaticLogicToCalyx.cpp
@@ -234,7 +234,7 @@ class BuildOpGroups : public calyx::FuncOpPartialLoweringPattern {
   using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
 
   LogicalResult
-  PartiallyLowerFuncToComp(FuncOp funcOp,
+  partiallyLowerFuncToComp(FuncOp funcOp,
                            PatternRewriter &rewriter) const override {
     /// We walk the operations of the funcOp to ensure that all def's have
     /// been visited before their uses.
@@ -801,7 +801,7 @@ struct FuncOpConversion : public calyx::FuncOpPartialLoweringPattern {
   using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
 
   LogicalResult
-  PartiallyLowerFuncToComp(FuncOp funcOp,
+  partiallyLowerFuncToComp(FuncOp funcOp,
                            PatternRewriter &rewriter) const override {
     /// Maintain a mapping between funcOp input arguments and the port index
     /// which the argument will eventually map to.
@@ -913,7 +913,7 @@ class BuildWhileGroups : public calyx::FuncOpPartialLoweringPattern {
   using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
 
   LogicalResult
-  PartiallyLowerFuncToComp(FuncOp funcOp,
+  partiallyLowerFuncToComp(FuncOp funcOp,
                            PatternRewriter &rewriter) const override {
     LogicalResult res = success();
     funcOp.walk([&](Operation *op) {
@@ -979,7 +979,7 @@ class BuildBBRegs : public calyx::FuncOpPartialLoweringPattern {
   using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
 
   LogicalResult
-  PartiallyLowerFuncToComp(FuncOp funcOp,
+  partiallyLowerFuncToComp(FuncOp funcOp,
                            PatternRewriter &rewriter) const override {
     funcOp.walk([&](Block *block) {
       /// Do not register component input values.
@@ -1008,7 +1008,7 @@ class BuildPipelineRegs : public calyx::FuncOpPartialLoweringPattern {
   using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
 
   LogicalResult
-  PartiallyLowerFuncToComp(FuncOp funcOp,
+  partiallyLowerFuncToComp(FuncOp funcOp,
                            PatternRewriter &rewriter) const override {
     funcOp.walk([&](staticlogic::PipelineRegisterOp op) {
       // Condition registers are handled in BuildWhileGroups.
@@ -1069,7 +1069,7 @@ class BuildPipelineGroups : public calyx::FuncOpPartialLoweringPattern {
   using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
 
   LogicalResult
-  PartiallyLowerFuncToComp(FuncOp funcOp,
+  partiallyLowerFuncToComp(FuncOp funcOp,
                            PatternRewriter &rewriter) const override {
     for (auto pipeline : funcOp.getOps<staticlogic::PipelineWhileOp>())
       for (auto stage :
@@ -1233,7 +1233,7 @@ class BuildReturnRegs : public calyx::FuncOpPartialLoweringPattern {
   using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
 
   LogicalResult
-  PartiallyLowerFuncToComp(FuncOp funcOp,
+  partiallyLowerFuncToComp(FuncOp funcOp,
                            PatternRewriter &rewriter) const override {
 
     for (auto argType : enumerate(funcOp.getResultTypes())) {
@@ -1267,7 +1267,7 @@ class BuildControl : public calyx::FuncOpPartialLoweringPattern {
   using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
 
   LogicalResult
-  PartiallyLowerFuncToComp(FuncOp funcOp,
+  partiallyLowerFuncToComp(FuncOp funcOp,
                            PatternRewriter &rewriter) const override {
     auto *entryBlock = &funcOp.getBlocks().front();
     rewriter.setInsertionPointToStart(getComponent()->getControlOp().getBody());
@@ -1542,7 +1542,7 @@ private:
 class LateSSAReplacement : public calyx::FuncOpPartialLoweringPattern {
   using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
 
-  LogicalResult PartiallyLowerFuncToComp(FuncOp funcOp,
+  LogicalResult partiallyLowerFuncToComp(FuncOp funcOp,
                                          PatternRewriter &) const override {
     funcOp.walk([&](memref::LoadOp loadOp) {
       if (calyx::singleLoadFromMemory(loadOp)) {
@@ -1566,7 +1566,7 @@ class CleanupFuncOps : public calyx::FuncOpPartialLoweringPattern {
   using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
 
   LogicalResult
-  PartiallyLowerFuncToComp(FuncOp funcOp,
+  partiallyLowerFuncToComp(FuncOp funcOp,
                            PatternRewriter &rewriter) const override {
     rewriter.eraseOp(funcOp);
     return success();

--- a/lib/Conversion/StaticLogicToCalyx/StaticLogicToCalyx.cpp
+++ b/lib/Conversion/StaticLogicToCalyx/StaticLogicToCalyx.cpp
@@ -247,8 +247,7 @@ public:
     auto it = funcMap.find(funcOp);
     if (it != funcMap.end()) {
       compOp = &it->second;
-      compLoweringState =
-          pls.getState<ComponentLoweringState>(*getComponent());
+      compLoweringState = pls.getState<ComponentLoweringState>(*getComponent());
     }
 
     return PartiallyLowerFuncToComp(funcOp, rewriter);
@@ -1030,8 +1029,7 @@ struct FuncOpConversion : public FuncOpPartialLoweringPattern {
 
     /// Store the function-to-component mapping.
     funcMap[funcOp] = compOp;
-    auto *compState =
-        programState().getState<ComponentLoweringState>(compOp);
+    auto *compState = programState().getState<ComponentLoweringState>(compOp);
     compState->setFuncOpResultMapping(funcOpResultMapping);
 
     /// Rewrite funcOp SSA argument values to the CompOp arguments.

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -14,13 +14,82 @@
 #include "circt/Dialect/Calyx/CalyxHelpers.h"
 #include "circt/Dialect/Calyx/CalyxOps.h"
 #include "circt/Support/LLVM.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/Matchers.h"
 
 #include <variant>
 
+using namespace llvm;
+using namespace mlir;
+using namespace mlir::arith;
+
 namespace circt {
 namespace calyx {
+
+void appendPortsForExternalMemref(PatternRewriter &rewriter, StringRef memName,
+                                  Value memref, unsigned memoryID,
+                                  SmallVectorImpl<calyx::PortInfo> &inPorts,
+                                  SmallVectorImpl<calyx::PortInfo> &outPorts) {
+  MemRefType memrefType = memref.getType().cast<MemRefType>();
+
+  // Ports constituting a memory interface are added a set of attributes under
+  // a "mem : {...}" dictionary. These attributes allows for deducing which
+  // top-level I/O signals constitutes a unique memory interface.
+  auto getMemoryInterfaceAttr = [&](StringRef tag,
+                                    Optional<unsigned> addrIdx = {}) {
+    auto attrs = SmallVector<NamedAttribute>{
+        // "id" denotes a unique memory interface.
+        rewriter.getNamedAttr("id", rewriter.getI32IntegerAttr(memoryID)),
+        // "tag" denotes the function of this signal.
+        rewriter.getNamedAttr("tag", rewriter.getStringAttr(tag))};
+    if (addrIdx.hasValue())
+      // "addr_idx" denotes the address index of this signal, for
+      // multi-dimensional memory interfaces.
+      attrs.push_back(rewriter.getNamedAttr(
+          "addr_idx", rewriter.getI32IntegerAttr(addrIdx.getValue())));
+
+    return rewriter.getNamedAttr("mem", rewriter.getDictionaryAttr(attrs));
+  };
+
+  // Read data
+  inPorts.push_back(calyx::PortInfo{
+      rewriter.getStringAttr(memName + "_read_data"),
+      memrefType.getElementType(), calyx::Direction::Input,
+      DictionaryAttr::get(rewriter.getContext(),
+                          {getMemoryInterfaceAttr("read_data")})});
+
+  // Done
+  inPorts.push_back(
+      calyx::PortInfo{rewriter.getStringAttr(memName + "_done"),
+                      rewriter.getI1Type(), calyx::Direction::Input,
+                      DictionaryAttr::get(rewriter.getContext(),
+                                          {getMemoryInterfaceAttr("done")})});
+
+  // Write data
+  outPorts.push_back(calyx::PortInfo{
+      rewriter.getStringAttr(memName + "_write_data"),
+      memrefType.getElementType(), calyx::Direction::Output,
+      DictionaryAttr::get(rewriter.getContext(),
+                          {getMemoryInterfaceAttr("write_data")})});
+
+  // Memory address outputs
+  for (auto dim : enumerate(memrefType.getShape())) {
+    outPorts.push_back(calyx::PortInfo{
+        rewriter.getStringAttr(memName + "_addr" + std::to_string(dim.index())),
+        rewriter.getIntegerType(calyx::handleZeroWidth(dim.value())),
+        calyx::Direction::Output,
+        DictionaryAttr::get(rewriter.getContext(),
+                            {getMemoryInterfaceAttr("addr", dim.index())})});
+  }
+
+  // Write enable
+  outPorts.push_back(calyx::PortInfo{
+      rewriter.getStringAttr(memName + "_write_en"), rewriter.getI1Type(),
+      calyx::Direction::Output,
+      DictionaryAttr::get(rewriter.getContext(),
+                          {getMemoryInterfaceAttr("write_en")})});
+}
 
 WalkResult
 getCiderSourceLocationMetadata(calyx::ComponentOp component,
@@ -309,6 +378,75 @@ ModuleOpConversion::matchAndRewrite(mlir::ModuleOp moduleOp,
     rewriter.setInsertionPointToStart(moduleBlock);
     rewriter.insert(programOp);
     *programOpOutput = programOp;
+  });
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// Partial lowering patterns
+//===----------------------------------------------------------------------===//
+
+FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern(
+    MLIRContext *context, LogicalResult &resRef,
+    DenseMap<mlir::func::FuncOp, calyx::ComponentOp> &map,
+    calyx::ProgramLoweringState &state)
+    : PartialLoweringPattern(context, resRef), functionMapping(map),
+      programLoweringState(state) {}
+
+LogicalResult
+FuncOpPartialLoweringPattern::partiallyLower(mlir::func::FuncOp funcOp,
+                                             PatternRewriter &rewriter) const {
+  // Initialize the component op references if a calyx::ComponentOp has been
+  // created for the matched funcOp.
+  if (auto it = functionMapping.find(funcOp); it != functionMapping.end()) {
+    calyx::ComponentOp op = it->second;
+    componentOp = &op;
+    componentLoweringState =
+        programLoweringState.getState<ComponentLoweringStateInterface>(op);
+  }
+
+  return PartiallyLowerFuncToComp(funcOp, rewriter);
+}
+
+calyx::ComponentOp *FuncOpPartialLoweringPattern::getComponent() const {
+  assert(componentOp != nullptr &&
+         "Component operation should be set during pattern construction");
+  return componentOp;
+}
+
+ProgramLoweringState &FuncOpPartialLoweringPattern::programState() const {
+  return programLoweringState;
+}
+
+//===----------------------------------------------------------------------===//
+// ConvertIndexTypes
+//===----------------------------------------------------------------------===//
+
+LogicalResult
+ConvertIndexTypes::PartiallyLowerFuncToComp(mlir::func::FuncOp funcOp,
+                                            PatternRewriter &rewriter) const {
+  funcOp.walk([&](Block *block) {
+    for (Value arg : block->getArguments())
+      arg.setType(calyx::convIndexType(rewriter, arg.getType()));
+  });
+
+  funcOp.walk([&](Operation *op) {
+    for (Value result : op->getResults()) {
+      Type resType = result.getType();
+      if (!resType.isIndex())
+        continue;
+
+      result.setType(calyx::convIndexType(rewriter, resType));
+      auto constant = dyn_cast<mlir::arith::ConstantOp>(op);
+      if (!constant)
+        continue;
+
+      APInt value;
+      calyx::matchConstantOp(constant, value);
+      rewriter.setInsertionPoint(constant);
+      rewriter.replaceOpWithNewOp<mlir::arith::ConstantOp>(
+          constant, rewriter.getI32IntegerAttr(value.getSExtValue()));
+    }
   });
   return success();
 }

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -250,6 +250,30 @@ unsigned ComponentLoweringStateInterface::getFuncOpResultMapping(
 }
 
 //===----------------------------------------------------------------------===//
+// ProgramLoweringState
+//===----------------------------------------------------------------------===//
+
+ProgramLoweringState::ProgramLoweringState(calyx::ProgramOp program,
+                                           StringRef topLevelFunction)
+    : topLevelFunction(topLevelFunction), program(program) {}
+
+calyx::ProgramOp ProgramLoweringState::getProgram() {
+  assert(program.getOperation() != nullptr);
+  return program;
+}
+
+StringRef ProgramLoweringState::getTopLevelFunction() const {
+  return topLevelFunction;
+}
+
+std::string ProgramLoweringState::blockName(Block *b) {
+  std::string blockName = irName(*b);
+  blockName.erase(std::remove(blockName.begin(), blockName.end(), '^'),
+                  blockName.end());
+  return blockName;
+}
+
+//===----------------------------------------------------------------------===//
 // ModuleOpConversion
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -405,7 +405,7 @@ FuncOpPartialLoweringPattern::partiallyLower(mlir::func::FuncOp funcOp,
         programLoweringState.getState<ComponentLoweringStateInterface>(op);
   }
 
-  return PartiallyLowerFuncToComp(funcOp, rewriter);
+  return partiallyLowerFuncToComp(funcOp, rewriter);
 }
 
 calyx::ComponentOp *FuncOpPartialLoweringPattern::getComponent() const {
@@ -423,7 +423,7 @@ ProgramLoweringState &FuncOpPartialLoweringPattern::programState() const {
 //===----------------------------------------------------------------------===//
 
 LogicalResult
-ConvertIndexTypes::PartiallyLowerFuncToComp(mlir::func::FuncOp funcOp,
+ConvertIndexTypes::partiallyLowerFuncToComp(mlir::func::FuncOp funcOp,
                                             PatternRewriter &rewriter) const {
   funcOp.walk([&](Block *block) {
     for (Value arg : block->getArguments())


### PR DESCRIPTION
As pointed out by @mortbopet [here](https://github.com/llvm/circt/pull/3263#issuecomment-1145625237), we can place the heavy loading on a function rather than the entire class. This reduces some template bloating.

Continued work in #2988.

