### PR TITLE
[StaticLogicToCalyx] Pull out FuncOpConversion.

### DIFF
--- a/lib/Conversion/StaticLogicToCalyx/StaticLogicToCalyx.cpp
+++ b/lib/Conversion/StaticLogicToCalyx/StaticLogicToCalyx.cpp
@@ -716,115 +716,6 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
   return res;
 }
 
-/// Creates a new Calyx component for each FuncOp in the program.
-struct FuncOpConversion : public calyx::FuncOpPartialLoweringPattern {
-  using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
-
-  LogicalResult
-  partiallyLowerFuncToComp(FuncOp funcOp,
-                           PatternRewriter &rewriter) const override {
-    /// Maintain a mapping between funcOp input arguments and the port index
-    /// which the argument will eventually map to.
-    DenseMap<Value, unsigned> funcOpArgRewrites;
-
-    /// Maintain a mapping between funcOp output indexes and the component
-    /// output port index which the return value will eventually map to.
-    DenseMap<unsigned, unsigned> funcOpResultMapping;
-
-    /// Maintain a mapping between an external memory argument (identified by a
-    /// memref) and eventual component input- and output port indices that will
-    /// map to the memory ports. The pair denotes the start index of the memory
-    /// ports in the in- and output ports of the component. Ports are expected
-    /// to be ordered in the same manner as they are added by
-    /// calyx::appendPortsForExternalMemref.
-    DenseMap<Value, std::pair<unsigned, unsigned>> extMemoryCompPortIndices;
-
-    /// Create I/O ports. Maintain separate in/out port vectors to determine
-    /// which port index each function argument will eventually map to.
-    SmallVector<calyx::PortInfo> inPorts, outPorts;
-    FunctionType funcType = funcOp.getFunctionType();
-    unsigned extMemCounter = 0;
-    for (auto &arg : enumerate(funcOp.getArguments())) {
-      if (arg.value().getType().isa<MemRefType>()) {
-        /// External memories
-        auto memName =
-            "ext_mem" + std::to_string(extMemoryCompPortIndices.size());
-        extMemoryCompPortIndices[arg.value()] = {inPorts.size(),
-                                                 outPorts.size()};
-        calyx::appendPortsForExternalMemref(rewriter, memName, arg.value(),
-                                            extMemCounter++, inPorts, outPorts);
-      } else {
-        /// Single-port arguments
-        auto inName = "in" + std::to_string(arg.index());
-        funcOpArgRewrites[arg.value()] = inPorts.size();
-        inPorts.push_back(calyx::PortInfo{
-            rewriter.getStringAttr(inName),
-            calyx::convIndexType(rewriter, arg.value().getType()),
-            calyx::Direction::Input,
-            DictionaryAttr::get(rewriter.getContext(), {})});
-      }
-    }
-    for (auto &res : enumerate(funcType.getResults())) {
-      funcOpResultMapping[res.index()] = outPorts.size();
-      outPorts.push_back(calyx::PortInfo{
-          rewriter.getStringAttr("out" + std::to_string(res.index())),
-          calyx::convIndexType(rewriter, res.value()), calyx::Direction::Output,
-          DictionaryAttr::get(rewriter.getContext(), {})});
-    }
-
-    /// We've now recorded all necessary indices. Merge in- and output ports
-    /// and add the required mandatory component ports.
-    auto ports = inPorts;
-    llvm::append_range(ports, outPorts);
-    calyx::addMandatoryComponentPorts(rewriter, ports);
-
-    /// Create a calyx::ComponentOp corresponding to the to-be-lowered function.
-    auto compOp = rewriter.create<calyx::ComponentOp>(
-        funcOp.getLoc(), rewriter.getStringAttr(funcOp.getSymName()), ports);
-
-    /// Mark this component as the toplevel.
-    compOp->setAttr("toplevel", rewriter.getUnitAttr());
-
-    /// Store the function-to-component mapping.
-    functionMapping[funcOp] = compOp;
-    auto *compState = programState().getState<ComponentLoweringState>(compOp);
-    compState->setFuncOpResultMapping(funcOpResultMapping);
-
-    /// Rewrite funcOp SSA argument values to the CompOp arguments.
-    for (auto &mapping : funcOpArgRewrites)
-      mapping.getFirst().replaceAllUsesWith(
-          compOp.getArgument(mapping.getSecond()));
-
-    /// Register external memories
-    for (auto extMemPortIndices : extMemoryCompPortIndices) {
-      /// Create a mapping for the in- and output ports using the Calyx memory
-      /// port structure.
-      calyx::MemoryPortsImpl extMemPorts;
-      unsigned inPortsIt = extMemPortIndices.getSecond().first;
-      unsigned outPortsIt = extMemPortIndices.getSecond().second +
-                            compOp.getInputPortInfo().size();
-      extMemPorts.readData = compOp.getArgument(inPortsIt++);
-      extMemPorts.done = compOp.getArgument(inPortsIt);
-      extMemPorts.writeData = compOp.getArgument(outPortsIt++);
-      unsigned nAddresses = extMemPortIndices.getFirst()
-                                .getType()
-                                .cast<MemRefType>()
-                                .getShape()
-                                .size();
-      for (unsigned j = 0; j < nAddresses; ++j)
-        extMemPorts.addrPorts.push_back(compOp.getArgument(outPortsIt++));
-      extMemPorts.writeEn = compOp.getArgument(outPortsIt);
-
-      /// Register the external memory ports as a memory interface within the
-      /// component.
-      compState->registerMemoryInterface(extMemPortIndices.getFirst(),
-                                         calyx::MemoryInterface(extMemPorts));
-    }
-
-    return success();
-  }
-};
-
 /// In BuildWhileGroups, a register is created for each iteration argumenet of
 /// the while op. These registers are then written to on the while op
 /// terminating yield operation alongside before executing the whileOp in the
@@ -1523,7 +1414,8 @@ void StaticLogicToCalyxPass::runOnOperation() {
   SmallVector<LoweringPattern, 8> loweringPatterns;
 
   /// Creates a new Calyx component for each FuncOp in the inpurt module.
-  addOncePattern<FuncOpConversion>(loweringPatterns, funcMap, *loweringState);
+  addOncePattern<calyx::FuncOpConversion>(loweringPatterns, funcMap,
+                                          *loweringState);
 
   /// This pattern converts all index typed values to an i32 integer.
   addOncePattern<calyx::ConvertIndexTypes>(loweringPatterns, funcMap,


### PR DESCRIPTION
A clean copy and paste of `FuncOpConversion` from StaticLogicToCalyx to CalyxLoweringUtils leads to the following:

```bash
# Removed all tests besides the first / split-input-file, though the bug is the same in either case.
 ./bin/circt-opt ../test/Conversion/AffineToStaticLogic/loops.mlir -convert-affine-to-staticlogic -lower-static-logic-to-calyx=top-level-function=dot 
```

```mlir
PLEASE submit a bug report to https://bugs.llvm.org/ and include the crash backtrace.
Stack dump:
0.      Program arguments: ./bin/circt-opt ../test/Conversion/AffineToStaticLogic/loops.mlir -convert-affine-to-staticlogic -lower-static-logic-to-calyx=top-level-function=dot --mlir-print-stacktrace-on-diagnostic -mlir-disable-threading -mlir-print-ir-module-scope
Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
0  circt-opt                0x000000010be65ecd llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) + 61
1  circt-opt                0x000000010be6642b PrintStackTraceSignalHandler(void*) + 27
2  circt-opt                0x000000010be6419b llvm::sys::RunSignalHandlers() + 139
3  circt-opt                0x000000010be67f28 SignalHandler(int) + 232
4  libsystem_platform.dylib 0x00007fff20417d7d _sigtramp + 29
5  circt-opt                0x000000010d1b59fa llvm::PointerIntPair<mlir::Type, 3u, mlir::detail::ValueImpl::Kind, llvm::PointerLikeTypeTraits<mlir::Type>, llvm::PointerIntPairInfo<mlir::Type, 3u, llvm::PointerLikeTypeTraits<mlir::Type>>>::setPointerAndInt(mlir::Type, mlir::detail::ValueImpl::Kind) & + 74
6  circt-opt                0x000000010cc9d7c5 bool llvm::DenseMapBase<llvm::DenseMap<mlir::Operation*, llvm::DenseMap<unsigned int, circt::calyx::RegisterOp, llvm::DenseMapInfo<unsigned int, void>, llvm::detail::DenseMapPair<unsigned int, circt::calyx::RegisterOp>>, llvm::DenseMapInfo<mlir::Operation*, void>, llvm::detail::DenseMapPair<mlir::Operation*, llvm::DenseMap<unsigned int, circt::calyx::RegisterOp, llvm::DenseMapInfo<unsigned int, void>, llvm::detail::DenseMapPair<unsigned int, circt::calyx::RegisterOp>>>>, mlir::Operation*, llvm::DenseMap<unsigned int, circt::calyx::RegisterOp, llvm::DenseMapInfo<unsigned int, void>, llvm::detail::DenseMapPair<unsigned int, circt::calyx::RegisterOp>>, llvm::DenseMapInfo<mlir::Operation*, void>, llvm::detail::DenseMapPair<mlir::Operation*, llvm::DenseMap<unsigned int, circt::calyx::RegisterOp, llvm::DenseMapInfo<unsigned int, void>, llvm::detail::DenseMapPair<unsigned int, circt::calyx::RegisterOp>>>>::LookupBucketFor<mlir::Operation*>(mlir::Operation* const&, llvm::detail::DenseMapPair<mlir::Operation*, llvm::DenseMap<unsigned int, circt::calyx::RegisterOp, llvm::DenseMapInfo<unsigned int, void>, llvm::detail::DenseMapPair<unsigned int, circt::calyx::RegisterOp>>>*&) + 37
7  circt-opt                0x000000010cc9d738 llvm::DenseMapBase<llvm::DenseMap<mlir::Operation*, llvm::DenseMap<unsigned int, circt::calyx::RegisterOp, llvm::DenseMapInfo<unsigned int, void>, llvm::detail::DenseMapPair<unsigned int, circt::calyx::RegisterOp>>, llvm::DenseMapInfo<mlir::Operation*, void>, llvm::detail::DenseMapPair<mlir::Operation*, llvm::DenseMap<unsigned int, circt::calyx::RegisterOp, llvm::DenseMapInfo<unsigned int, void>, llvm::detail::DenseMapPair<unsigned int, circt::calyx::RegisterOp>>>>, mlir::Operation*, llvm::DenseMap<unsigned int, circt::calyx::RegisterOp, llvm::DenseMapInfo<unsigned int, void>, llvm::detail::DenseMapPair<unsigned int, circt::calyx::RegisterOp>>, llvm::DenseMapInfo<mlir::Operation*, void>, llvm::detail::DenseMapPair<mlir::Operation*, llvm::DenseMap<unsigned int, circt::calyx::RegisterOp, llvm::DenseMapInfo<unsigned int, void>, llvm::detail::DenseMapPair<unsigned int, circt::calyx::RegisterOp>>>>::FindAndConstruct(mlir::Operation*&&) + 40
8  circt-opt                0x000000010cc9d700 llvm::DenseMapBase<llvm::DenseMap<mlir::Operation*, llvm::DenseMap<unsigned int, circt::calyx::RegisterOp, llvm::DenseMapInfo<unsigned int, void>, llvm::detail::DenseMapPair<unsigned int, circt::calyx::RegisterOp>>, llvm::DenseMapInfo<mlir::Operation*, void>, llvm::detail::DenseMapPair<mlir::Operation*, llvm::DenseMap<unsigned int, circt::calyx::RegisterOp, llvm::DenseMapInfo<unsigned int, void>, llvm::detail::DenseMapPair<unsigned int, circt::calyx::RegisterOp>>>>, mlir::Operation*, llvm::DenseMap<unsigned int, circt::calyx::RegisterOp, llvm::DenseMapInfo<unsigned int, void>, llvm::detail::DenseMapPair<unsigned int, circt::calyx::RegisterOp>>, llvm::DenseMapInfo<mlir::Operation*, void>, llvm::detail::DenseMapPair<mlir::Operation*, llvm::DenseMap<unsigned int, circt::calyx::RegisterOp, llvm::DenseMapInfo<unsigned int, void>, llvm::detail::DenseMapPair<unsigned int, circt::calyx::RegisterOp>>>>::operator[](mlir::Operation*&&) + 48
9  circt-opt                0x000000010cde7742 circt::calyx::LoopLoweringStateInterface<circt::staticlogictocalyx::StaticLogicWhileOp>::addLoopIterReg(circt::staticlogictocalyx::StaticLogicWhileOp, circt::calyx::RegisterOp, unsigned int) + 82
10 circt-opt                0x000000010cde725b circt::staticlogictocalyx::BuildWhileGroups::partiallyLowerFuncToComp(mlir::func::FuncOp, mlir::PatternRewriter&) const::'lambda'(mlir::Operation*)::operator()(mlir::Operation*) const + 987
11 circt-opt                0x000000010cde6e70 mlir::WalkResult llvm::function_ref<mlir::WalkResult (mlir::Operation*)>::callback_fn<circt::staticlogictocalyx::BuildWhileGroups::partiallyLowerFuncToComp(mlir::func::FuncOp, mlir::PatternRewriter&) const::'lambda'(mlir::Operation*)>(long, mlir::Operation*) + 48
12 circt-opt                0x000000010d21182c llvm::function_ref<mlir::WalkResult (mlir::Operation*)>::operator()(mlir::Operation*) const + 60
13 circt-opt                0x000000010d2117c5 mlir::detail::walk(mlir::Operation*, llvm::function_ref<mlir::WalkResult (mlir::Operation*)>, mlir::WalkOrder) + 581
14 circt-opt                0x000000010d211741 mlir::detail::walk(mlir::Operation*, llvm::function_ref<mlir::WalkResult (mlir::Operation*)>, mlir::WalkOrder) + 449
15 circt-opt                0x000000010cde6db5 std::__1::enable_if<llvm::is_one_of<mlir::Operation*, mlir::Operation*, mlir::Region*, mlir::Block*>::value, mlir::WalkResult>::type mlir::detail::walk<(mlir::WalkOrder)1, circt::staticlogictocalyx::BuildWhileGroups::partiallyLowerFuncToComp(mlir::func::FuncOp, mlir::PatternRewriter&) const::'lambda'(mlir::Operation*), mlir::Operation*, mlir::WalkResult>(mlir::Operation*, circt::staticlogictocalyx::BuildWhileGroups::partiallyLowerFuncToComp(mlir::func::FuncOp, mlir::PatternRewriter&) const::'lambda'(mlir::Operation*)&&) + 69
16 circt-opt                0x000000010cde6d50 std::__1::enable_if<llvm::function_traits<std::__1::decay<circt::staticlogictocalyx::BuildWhileGroups::partiallyLowerFuncToComp(mlir::func::FuncOp, mlir::PatternRewriter&) const::'lambda'(mlir::Operation*)>::type>::num_args == 1, mlir::WalkResult>::type mlir::Operation::walk<(mlir::WalkOrder)1, circt::staticlogictocalyx::BuildWhileGroups::partiallyLowerFuncToComp(mlir::func::FuncOp, mlir::PatternRewriter&) const::'lambda'(mlir::Operation*), mlir::WalkResult>(circt::staticlogictocalyx::BuildWhileGroups::partiallyLowerFuncToComp(mlir::func::FuncOp, mlir::PatternRewriter&) const::'lambda'(mlir::Operation*)&&) + 48
17 circt-opt                0x000000010cde6d13 std::__1::enable_if<llvm::function_traits<std::__1::decay<circt::staticlogictocalyx::BuildWhileGroups::partiallyLowerFuncToComp(mlir::func::FuncOp, mlir::PatternRewriter&) const::'lambda'(mlir::Operation*)>::type>::num_args == 1, mlir::WalkResult>::type mlir::OpState::walk<(mlir::WalkOrder)1, circt::staticlogictocalyx::BuildWhileGroups::partiallyLowerFuncToComp(mlir::func::FuncOp, mlir::PatternRewriter&) const::'lambda'(mlir::Operation*), mlir::WalkResult>(circt::staticlogictocalyx::BuildWhileGroups::partiallyLowerFuncToComp(mlir::func::FuncOp, mlir::PatternRewriter&) const::'lambda'(mlir::Operation*)&&) + 51
18 circt-opt                0x000000010cde6ca9 circt::staticlogictocalyx::BuildWhileGroups::partiallyLowerFuncToComp(mlir::func::FuncOp, mlir::PatternRewriter&) const + 73
19 circt-opt                0x000000010c02b10b circt::calyx::FuncOpPartialLoweringPattern::partiallyLower(mlir::func::FuncOp, mlir::PatternRewriter&) const + 187
20 circt-opt                0x000000010ccb4643 circt::calyx::PartialLoweringPattern<mlir::func::FuncOp, mlir::OpRewritePattern>::matchAndRewrite(mlir::func::FuncOp, mlir::PatternRewriter&) const::'lambda'()::operator()() const + 51
21 circt-opt                0x000000010ccb45f2 void mlir::RewriterBase::updateRootInPlace<circt::calyx::PartialLoweringPattern<mlir::func::FuncOp, mlir::OpRewritePattern>::matchAndRewrite(mlir::func::FuncOp, mlir::PatternRewriter&) const::'lambda'()>(mlir::Operation*, circt::calyx::PartialLoweringPattern<mlir::func::FuncOp, mlir::OpRewritePattern>::matchAndRewrite(mlir::func::FuncOp, mlir::PatternRewriter&) const::'lambda'()&&) + 50
22 circt-opt                0x000000010ccb37a8 circt::calyx::PartialLoweringPattern<mlir::func::FuncOp, mlir::OpRewritePattern>::matchAndRewrite(mlir::func::FuncOp, mlir::PatternRewriter&) const + 88
23 circt-opt                0x000000010ccb36de mlir::detail::OpOrInterfaceRewritePatternBase<mlir::func::FuncOp>::matchAndRewrite(mlir::Operation*, mlir::PatternRewriter&) const + 62
24 circt-opt                0x000000010e256637 mlir::PatternApplicator::matchAndRewrite(mlir::Operation*, mlir::PatternRewriter&, llvm::function_ref<bool (mlir::Pattern const&)>, llvm::function_ref<void (mlir::Pattern const&)>, llvm::function_ref<mlir::LogicalResult (mlir::Pattern const&)>) + 1831
25 circt-opt                0x000000010e1dbf3e (anonymous namespace)::GreedyPatternRewriteDriver::simplify(llvm::MutableArrayRef<mlir::Region>) + 2286
26 circt-opt                0x000000010e1db4ef mlir::applyPatternsAndFoldGreedily(llvm::MutableArrayRef<mlir::Region>, mlir::FrozenRewritePatternSet const&, mlir::GreedyRewriteConfig) + 319
27 circt-opt                0x000000010d6ffcf2 mlir::applyPatternsAndFoldGreedily(mlir::Operation*, mlir::FrozenRewritePatternSet const&, mlir::GreedyRewriteConfig) + 82
28 circt-opt                0x000000010cdcc0c6 circt::staticlogictocalyx::StaticLogicToCalyxPass::runPartialPattern(mlir::RewritePatternSet&, bool) + 326
29 circt-opt                0x000000010cdca51b circt::staticlogictocalyx::StaticLogicToCalyxPass::runOnOperation() + 1531
30 circt-opt                0x000000010e3bf64c mlir::detail::OpToOpPassAdaptor::run(mlir::Pass*, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int) + 620
31 circt-opt                0x000000010e3bfd6c mlir::detail::OpToOpPassAdaptor::runPipeline(mlir::OpPassManager&, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int, mlir::PassInstrumentor*, mlir::PassInstrumentation::PipelineParentInfo const*) + 396
32 circt-opt                0x000000010e3c22c3 mlir::PassManager::runPasses(mlir::Operation*, mlir::AnalysisManager) + 115
33 circt-opt                0x000000010e3c209a mlir::PassManager::run(mlir::Operation*) + 922
34 circt-opt                0x000000010d61bf38 performActions(llvm::raw_ostream&, bool, bool, llvm::SourceMgr&, mlir::MLIRContext*, llvm::function_ref<mlir::LogicalResult (mlir::PassManager&)>) + 456
35 circt-opt                0x000000010d61a414 processBuffer(llvm::raw_ostream&, std::__1::unique_ptr<llvm::MemoryBuffer, std::__1::default_delete<llvm::MemoryBuffer>>, bool, bool, bool, bool, llvm::function_ref<mlir::LogicalResult (mlir::PassManager&)>, mlir::DialectRegistry&, llvm::ThreadPool*) + 484
36 circt-opt                0x000000010d61a159 mlir::MlirOptMain(llvm::raw_ostream&, std::__1::unique_ptr<llvm::MemoryBuffer, std::__1::default_delete<llvm::MemoryBuffer>>, llvm::function_ref<mlir::LogicalResult (mlir::PassManager&)>, mlir::DialectRegistry&, bool, bool, bool, bool, bool) + 521
37 circt-opt                0x000000010d61a5d8 mlir::MlirOptMain(llvm::raw_ostream&, std::__1::unique_ptr<llvm::MemoryBuffer, std::__1::default_delete<llvm::MemoryBuffer>>, mlir::PassPipelineCLParser const&, mlir::DialectRegistry&, bool, bool, bool, bool, bool) + 232
38 circt-opt                0x000000010d61b31b mlir::MlirOptMain(int, char**, llvm::StringRef, mlir::DialectRegistry&, bool) + 3291
39 circt-opt                0x000000010bbf80ce main + 206
40 libdyld.dylib            0x00007fff203edf3d start + 1
zsh: segmentation fault  ./bin/circt-opt ../test/Conversion/AffineToStaticLogic/loops.mlir  
```

Same thing occurs for SCFToCalyx. Currently unsure as to why.

Continued efforts on #2988.
