### PR TITLE
[FIRRTL] Wire to Node canonicalization

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -129,7 +129,7 @@ def MemOp : ReferableDeclOp<"mem"> {
 
   let hasVerifier = 1;
 
-  let hasCanonicalizeMethod = true;
+  let hasCanonicalizeMethod = 1;
 
   let extraClassDeclaration = [{
     enum class PortKind { Read, Write, ReadWrite };
@@ -218,7 +218,8 @@ def NodeOp : ReferableDeclOp<"node",
     $input custom<ImplicitSSAName>(attr-dict) `:` qualified(type($input))
   }];
 
-  let hasCanonicalizer = true;
+  let hasCanonicalizer = 1;
+  let hasFolder = 1;
 }
 
 def RegOp : ReferableDeclOp<"reg"> {
@@ -251,7 +252,7 @@ def RegOp : ReferableDeclOp<"reg"> {
     (`sym` $inner_sym^)?
     operands custom<ImplicitSSAName>(attr-dict) `:` qualified(type($result))
   }];
-  let hasCanonicalizeMethod = true;
+  let hasCanonicalizeMethod = 1;
 }
 
 def RegResetOp : ReferableDeclOp<"regreset"> {
@@ -288,7 +289,7 @@ def RegResetOp : ReferableDeclOp<"regreset"> {
     `:` qualified(type($resetSignal)) `,` qualified(type($resetValue)) `,` qualified(type($result))
   }];
 
-  let hasCanonicalizer = true;
+  let hasCanonicalizer = 1;
   let hasVerifier = 1;
 }
 
@@ -320,5 +321,5 @@ def WireOp : ReferableDeclOp<"wire"> {
     (`sym` $inner_sym^)?
     custom<ImplicitSSAName>(attr-dict) `:` qualified(type($result))
   }];
-  let hasCanonicalizer = true;
+  let hasCanonicalizer = 1;
 }

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1639,16 +1639,11 @@ struct WireToNode : public mlir::RewritePattern {
       : RewritePattern(WireOp::getOperationName(), 0, context) {}
   LogicalResult matchAndRewrite(Operation *op,
                                 PatternRewriter &rewriter) const override {
-    //    llvm::errs() << "WireToNode\n";
-    //    op->dump();
     auto wire = cast<WireOp>(op);
-    //    wire.dump();
     auto strictcon = getSingleConnectUserOf(wire);
     if (!strictcon)
       return failure();
-    //    strictcon.dump();
     for (auto *user : wire->getUsers()) {
-      //        user->dump();
       if (user == strictcon)
         continue;
       if (user->isBeforeInBlock(strictcon))

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -1636,6 +1636,17 @@ firrtl.module @ComparisonOfConsts(
   // CHECK-NEXT: firrtl.strictconnect %y19, %c1_ui1
 }
 
+// CHECK-LABEL: @wire2node
+// CHECK-NEXT:   %tmp_a = firrtl.node %a  : !firrtl.uint<7>
+// CHECK-NEXT:   firrtl.strictconnect %b, %a : !firrtl.uint<7>
+// CHECK-NEXT:  }
+firrtl.module @wire2node(in %a: !firrtl.uint<7>, out %b: !firrtl.uint<7>) {
+  %tmp_a = firrtl.wire : !firrtl.uint<7>
+  firrtl.connect %tmp_a, %a : !firrtl.uint<7>, !firrtl.uint<7>
+  firrtl.connect %b, %tmp_a : !firrtl.uint<7>, !firrtl.uint<7>
+}
+
+
 // CHECK-LABEL: @add_cst_prop1
 // CHECK-NEXT:   %c11_ui9 = firrtl.constant 11 : !firrtl.uint<9>
 // CHECK-NEXT:   firrtl.strictconnect %out_b, %c11_ui9 : !firrtl.uint<9>

--- a/test/firtool/memory.fir
+++ b/test/firtool/memory.fir
@@ -61,8 +61,6 @@ circuit Qux: %[[{
 
 
 ;CHECK-LABEL: hw.module @Qux
-;CHECK:    %[[memory_r_data:.+]] = sv.wire sym @__Qux__memory_r_data  : !hw.inout<i8>
-;CHECK:    %[[v0:.+]] = sv.read_inout %[[memory_r_data]]
 ;CHECK:    %[[memory_0:.+]] = sv.reg
 ;CHECK:    %[[memory_1:.+]] = sv.reg
 ;CHECK:    %[[memory_2:.+]] = sv.reg
@@ -72,11 +70,13 @@ circuit Qux: %[[{
 ;CHECK:    %[[v5:.+]] = sv.read_inout %[[addr]]
 ;CHECK:    %[[v6:.+]] = hw.array_create
 ;CHECK:    %[[v7:.+]] = hw.array_get %[[v6]][%[[v5]]]
+;CHECK:    %[[memory_r_data:.+]] = sv.wire sym @__Qux__memory_r_data  : !hw.inout<i8>
 ;CHECK:    sv.assign %[[memory_r_data]], %[[v7]] : i8
-;CHECK:    %[[memory_rw_rdata:.+]] = sv.wire sym @__Qux__memory_rw_rdata  : !hw.inout<i8>
-;CHECK:    %[[v8:.+]] = sv.read_inout %memory_rw_rdata : !hw.inout<i8>
+;CHECK:    %[[v0:.+]] = sv.read_inout %[[memory_r_data]]
 ;CHECK:    %[[v9:.+]] = hw.array_get %[[v6]][%rwAddr] : !hw.array<4xi8>
+;CHECK:    %[[memory_rw_rdata:.+]] = sv.wire sym @__Qux__memory_rw_rdata  : !hw.inout<i8>
 ;CHECK:    sv.assign %[[memory_rw_rdata]], %[[v9]] : i8
+;CHECK:    %[[v8:.+]] = sv.read_inout %memory_rw_rdata : !hw.inout<i8>
 ;CHECK:    sv.always posedge %clock {
 ;CHECK-NEXT:      sv.passign %[[en]], %rEn : i1
 ;CHECK-NEXT:      sv.passign %[[addr]], %rAddr : i2

--- a/test/firtool/name-preservation.fir
+++ b/test/firtool/name-preservation.fir
@@ -14,8 +14,6 @@ circuit Foo:
     _x <= a
 
     ; Default behavior is to preserve named wires.
-    ; CHECK:        wire x_a;
-    ; CHECK:        wire x_b;
     wire x: {a: UInt<1>, flip b: UInt<1>}
     x <= _x
 
@@ -24,8 +22,11 @@ circuit Foo:
     node _y_a = x.a
 
     ; Default behavior is to preserve named nodes.
-    ; CHECK:        wire y;
     node y = _y_a
 
     b.a <= y
     x.b <= b.b
+
+    ; CHECK:        wire x_a;
+    ; CHECK:        wire y;
+    ; CHECK:        wire x_b;


### PR DESCRIPTION
Canonicalize wires with single writes which dominate their uses to nodes.

This is a draft copy of a reverted pr to keep it alive while we debug the slowdown.