### PR TITLE
[FIRRTL] Properly parse printf assertions with no message

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParserAsserts.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParserAsserts.cpp
@@ -379,10 +379,13 @@ ParseResult circt::firrtl::foldWhenEncodedVerifOp(PrintFOp printOp) {
   case VerifFlavor::Cover:
   case VerifFlavor::AssertNotX: {
     // Extract label and message from the format string.
-    StringRef label, message;
-    std::tie(label, message) = fmt.split(':');
-    if (message.empty())
-      std::swap(label, message); // in case of no label
+    StringRef label;
+    StringRef message = fmt;
+    auto index = fmt.find(':');
+    if (index != StringRef::npos) {
+      label = fmt.slice(0, index);
+      message = fmt.slice(index + 1, StringRef::npos);
+    }
 
     // AssertNotX has the special format `assertNotX:%d:msg`, where the `%d`
     // would theoretically interpolate the value being check for X, but in

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -954,6 +954,20 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK-NEXT: firrtl.cover %clock, %cond, %enable, "foo 2" {eventControl = 0 : i32, isConcurrent = true}
 
     when cond:
+      printf(clock, enable, "assert:foo_0:", value)
+    ; CHECK: [[TMP:%.+]] = firrtl.not %cond
+    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "" {eventControl = 0 : i32, isConcurrent = true, name = "foo_0"}
+
+    when cond:
+      printf(clock, enable, "assume:foo_1:", value)
+    ; CHECK: [[TMP:%.+]] = firrtl.not %cond
+    ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "" {eventControl = 0 : i32, isConcurrent = true, name = "foo_1"}
+
+    when cond:
+      printf(clock, enable, "cover:foo_2:", value)
+    ; CHECK-NEXT: firrtl.cover %clock, %cond, %enable, "" {eventControl = 0 : i32, isConcurrent = true, name = "foo_2"}
+
+    when cond:
       printf(clock, enable, "assert:custom label 0:foo 3", value)
     ; CHECK: [[TMP:%.+]] = firrtl.not %cond
     ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "foo 3" {eventControl = 0 : i32, isConcurrent = true, name = "custom label 0"}


### PR DESCRIPTION
The assertion parsing framework would parse the label from
`cover:my-label:` as the message.  This was a mistake in part of the
logic to handle missing labels in such cases as `cover:my message`,
where it would always use label as a message if the message was empty.
Now, it uses the colon to disambiguate the two cases.

As a follow up we should check if it is actually legal to have a missing
label.
